### PR TITLE
Adds needed semicolon in example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Currently the Sky Engine assumes the entry point for your application is a
 ```
 <sky>
 <script>
-import 'package:your_app_name/main.dart'
+import 'package:your_app_name/main.dart';
 
 void main() {
   new HelloWorldApp();


### PR DESCRIPTION
The missing semicolon was noted during the Sky demo presented by Eric Seidel (www.youtube.com/watch?v=PnIWl33YMwA).
