### PR TITLE
add a flutter.yaml file to the init template

### DIFF
--- a/packages/flutter_tools/lib/executable.dart
+++ b/packages/flutter_tools/lib/executable.dart
@@ -32,10 +32,11 @@ Future main(List<String> args) async {
   // This level can be adjusted by users through the `--verbose` option.
   Logger.root.level = Level.WARNING;
   Logger.root.onRecord.listen((LogRecord record) {
+    String level = record.level.name.toLowerCase();
     if (record.level >= Level.WARNING) {
-      stderr.writeln(record.message);
+      stderr.writeln('$level: ${record.message}');
     } else {
-      print(record.message);
+      print('$level: ${record.message}');
     }
     if (record.error != null)
       stderr.writeln(record.error);

--- a/packages/flutter_tools/lib/src/commands/flutter_command_runner.dart
+++ b/packages/flutter_tools/lib/src/commands/flutter_command_runner.dart
@@ -49,7 +49,7 @@ class FlutterCommandRunner extends CommandRunner {
     argParser.addFlag('local-build',
         negatable: false,
         help:
-            'Automatically detect your engine src directory from an overridden Flutter package.'
+            'Automatically detect your engine src directory from an overridden Flutter package. '
             'Useful if you are building Flutter locally and are using a dependency_override for'
             'the Flutter package that points to your engine src directory.');
     argParser.addOption('engine-src-path', hide: true,

--- a/packages/flutter_tools/lib/src/commands/init.dart
+++ b/packages/flutter_tools/lib/src/commands/init.dart
@@ -89,6 +89,7 @@ abstract class Template {
 class FlutterSimpleTemplate extends Template {
   FlutterSimpleTemplate() : super('flutter-simple', 'A minimal Flutter project.') {
     files['.gitignore'] = _gitignore;
+    files['flutter.yaml'] = _flutterYaml;
     files['pubspec.yaml'] = _pubspec;
     files['README.md'] = _readme;
     files['lib/main.dart'] = _libMain;
@@ -98,9 +99,8 @@ class FlutterSimpleTemplate extends Template {
 String _normalizeProjectName(String name) {
   name = name.replaceAll('-', '_').replaceAll(' ', '_');
   // Strip any extension (like .dart).
-  if (name.contains('.')) {
+  if (name.contains('.'))
     name = name.substring(0, name.indexOf('.'));
-  }
   return name;
 }
 
@@ -132,6 +132,12 @@ dependencies:
   flutter: ">=0.0.2 <0.1.0"
 dev_dependencies:
   sky_tools: any
+''';
+
+const String _flutterYaml = r'''
+name: {{projectName}}
+material-design-icons:
+  - name: content/add
 ''';
 
 const String _libMain = r'''

--- a/packages/flutter_tools/pubspec.yaml
+++ b/packages/flutter_tools/pubspec.yaml
@@ -28,7 +28,7 @@ dependencies:
 # See also https://github.com/dart-lang/pub/issues/1356
 
 dev_dependencies:
-  mockito: "^0.10.1"
+  mockito: ^0.10.1
 
 # Add the bin/sky_tools.dart script to the scripts pub installs.
 executables:


### PR DESCRIPTION
Add a flutter.yaml file to the init template. @abarth, are these now required for apps? Possibly became a requirement w/ the move to not using an http server.
