### PR TITLE
Avoid use of run-as

### DIFF
--- a/packages/flutter_tools/lib/src/device.dart
+++ b/packages/flutter_tools/lib/src/device.dart
@@ -688,16 +688,8 @@ class AndroidDevice extends Device {
     return false;
   }
 
-  String _getDeviceDataPath(ApplicationPackage app) {
-    return '/data/data/${app.id}';
-  }
-
   String _getDeviceSha1Path(ApplicationPackage app) {
-    return '${_getDeviceDataPath(app)}/${app.name}.sha1';
-  }
-
-  String _getDeviceBundlePath(ApplicationPackage app) {
-    return '${_getDeviceDataPath(app)}/dev.flx';
+    return '/data/local/tmp/sky.${app.id}.sha1';
   }
 
   String _getDeviceApkSha1(ApplicationPackage app) {
@@ -743,7 +735,6 @@ class AndroidDevice extends Device {
 
     print('Installing ${app.name} on device.');
     runCheckedSync(adbCommandForDevice(['install', '-r', app.localPath]));
-    runCheckedSync(adbCommandForDevice(['shell', 'run-as', app.id, 'chmod', '777', _getDeviceDataPath(app)]));
     runCheckedSync(adbCommandForDevice(['shell', 'echo', '-n', _getSourceSha1(app), '>', _getDeviceSha1Path(app)]));
     return true;
   }
@@ -764,13 +755,11 @@ class AndroidDevice extends Device {
       _forwardObservatoryPort();
 
     String deviceTmpPath = '/data/local/tmp/dev.flx';
-    String deviceBundlePath = _getDeviceBundlePath(apk);
     runCheckedSync(adbCommandForDevice(['push', bundlePath, deviceTmpPath]));
-    runCheckedSync(adbCommandForDevice(['shell', 'mv', deviceTmpPath, deviceBundlePath]));
     List<String> cmd = adbCommandForDevice([
       'shell', 'am', 'start',
       '-a', 'android.intent.action.RUN',
-      '-d', deviceBundlePath,
+      '-d', deviceTmpPath,
     ]);
     if (checked)
       cmd.addAll(['--ez', 'enable-checked-mode', 'true']);


### PR DESCRIPTION
Issue #1988 results from run-as not working on some phones,
because of Android issue 58373.

This change removes the need for run-as for running
"flutter start". It is still needed for tracing.
