### PR TITLE
support older android devices (>= 17)

### DIFF
--- a/packages/flutter/lib/src/http/mojo_client.dart
+++ b/packages/flutter/lib/src/http/mojo_client.dart
@@ -58,7 +58,7 @@ class MojoClient {
   }
 
   Future<Uint8List> readBytes(url, {Map<String, String> headers}) {
-    return get(url, headers: headers).then((response) {
+    return get(url, headers: headers).then((Response response) {
       _checkResponseSuccess(url, response);
       return response.bodyBytes;
     });


### PR DESCRIPTION
- fix regex `adb devices -l` parsing for older android devices
- move the version check back to android 17 (4.2.x of Jelly Bean) - I loaded up a few flutter sample apps on a v17 device
- re-word the error message for older devices, so that it identifies the device version as the issue, instead of the android sdk version

Flutter didn't load successfully on the v15 device I have (ICS). I didn't test on the first version of Jelly Bean (v16, 4.1.0). So:
- v15: crash
- v16: ??
- v17: success
