### PR TITLE
flutter start should give better errors when it can't find main

### DIFF
--- a/packages/flutter_tools/lib/src/commands/start.dart
+++ b/packages/flutter_tools/lib/src/commands/start.dart
@@ -30,7 +30,7 @@ class StartCommand extends FlutterCommand {
         defaultsTo: true,
         help: 'Toggle Dart\'s checked mode.');
     argParser.addOption('target',
-        defaultsTo: '.',
+        defaultsTo: '',
         abbr: 't',
         help: 'Target app path or filename to start.');
     argParser.addFlag('boot',
@@ -67,6 +67,14 @@ class StartCommand extends FlutterCommand {
         String mainPath = target;
         if (FileSystemEntity.isDirectorySync(target))
           mainPath = path.join(target, 'lib', 'main.dart');
+        if (!FileSystemEntity.isFileSync(mainPath)) {
+          String message = 'Tried to run ${mainPath}, but that file does not exist.';
+          if (!argResults.wasParsed('target'))
+            message += '\nConsider using the -t option to specify that Dart file to start.';
+          stderr.writeln(message);
+          continue;
+        }
+
         BuildCommand builder = new BuildCommand();
         builder.inheritFromParent(this);
         await builder.buildInTempDir(

--- a/packages/flutter_tools/test/start_test.dart
+++ b/packages/flutter_tools/test/start_test.dart
@@ -38,7 +38,7 @@ defineTests() {
 
       CommandRunner runner = new CommandRunner('test_flutter', '')
         ..addCommand(command);
-      runner.run(['start']).then((int code) => expect(code, equals(0)));
+      runner.run(['start', '-t', 'test/start_test.dart']).then((int code) => expect(code, equals(0)));
     });
 
     test('returns 0 when iOS is connected and ready to be started', () {


### PR DESCRIPTION
Now we suggest using -t to specify the main Dart file.

Fixes #53
