### PR TITLE
Search all the build configurations for sky_snapshot

### DIFF
--- a/packages/flutter_tools/lib/src/commands/flutter_command_runner.dart
+++ b/packages/flutter_tools/lib/src/commands/flutter_command_runner.dart
@@ -195,19 +195,19 @@ class FlutterCommandRunner extends CommandRunner {
         configs.add(new BuildConfiguration.local(
           type: BuildType.debug,
           hostPlatform: hostPlatform,
-          targetPlatform: hostPlatformAsTarget,
+          targetPlatform: TargetPlatform.android,
           enginePath: enginePath,
-          buildPath: globalResults['host-debug-build-path'],
-          testable: true
+          buildPath: globalResults['android-debug-build-path'],
+          deviceId: globalResults['android-device-id']
         ));
 
         configs.add(new BuildConfiguration.local(
           type: BuildType.debug,
           hostPlatform: hostPlatform,
-          targetPlatform: TargetPlatform.android,
+          targetPlatform: hostPlatformAsTarget,
           enginePath: enginePath,
-          buildPath: globalResults['android-debug-build-path'],
-          deviceId: globalResults['android-device-id']
+          buildPath: globalResults['host-debug-build-path'],
+          testable: true
         ));
 
         if (Platform.isMacOS) {
@@ -233,19 +233,19 @@ class FlutterCommandRunner extends CommandRunner {
         configs.add(new BuildConfiguration.local(
           type: BuildType.release,
           hostPlatform: hostPlatform,
-          targetPlatform: hostPlatformAsTarget,
+          targetPlatform: TargetPlatform.android,
           enginePath: enginePath,
-          buildPath: globalResults['host-release-build-path'],
-          testable: true
+          buildPath: globalResults['android-release-build-path'],
+          deviceId: globalResults['android-device-id']
         ));
 
         configs.add(new BuildConfiguration.local(
           type: BuildType.release,
           hostPlatform: hostPlatform,
-          targetPlatform: TargetPlatform.android,
+          targetPlatform: hostPlatformAsTarget,
           enginePath: enginePath,
-          buildPath: globalResults['android-release-build-path'],
-          deviceId: globalResults['android-device-id']
+          buildPath: globalResults['host-release-build-path'],
+          testable: true
         ));
 
         if (Platform.isMacOS) {


### PR DESCRIPTION
Previously, we assumed the first build configuration would have one. Now we
keep looking until we find one. Also, re-ordered the configurations so that
you'll get the Android one if you have both, which is probably what you would
expect.

Fixes #100
