### PR TITLE
Refactor bottom sheet support, add one to the stocks demo

### DIFF
--- a/examples/stocks/lib/main.dart
+++ b/examples/stocks/lib/main.dart
@@ -81,7 +81,7 @@ class StocksAppState extends State<StocksApp> {
       if (path.length != 3)
         return null;
       if (_stocks.containsKey(path[2]))
-        return (RouteArguments args) => new StockSymbolViewer(_stocks[path[2]]);
+        return (RouteArguments args) => new StockSymbolViewer(stock: _stocks[path[2]]);
       return null;
     }
     return null;

--- a/examples/stocks/lib/stock_home.dart
+++ b/examples/stocks/lib/stock_home.dart
@@ -186,6 +186,10 @@ class StockHomeState extends State<StockHome> {
           stock.percentChange = 100.0 * (1.0 / stock.lastSale);
           stock.lastSale += 1.0;
         });
+        showModalBottomSheet(
+          context: context,
+          child: new StockSymbolViewer(stock: stock, showToolBar: false)
+        );
       },
       onOpen: (Stock stock, Key arrowKey) {
         Set<Key> mostValuableKeys = new Set<Key>();

--- a/examples/stocks/lib/stock_symbol_viewer.dart
+++ b/examples/stocks/lib/stock_symbol_viewer.dart
@@ -5,16 +5,54 @@
 part of stocks;
 
 class StockSymbolViewer extends StatelessComponent {
-  StockSymbolViewer(this.stock);
+  StockSymbolViewer({ this.stock, this.showToolBar: true });
 
   final Stock stock;
+  final bool showToolBar;
 
   Widget build(BuildContext context) {
     String lastSale = "\$${stock.lastSale.toStringAsFixed(2)}";
     String changeInPrice = "${stock.percentChange.toStringAsFixed(2)}%";
     if (stock.percentChange > 0)
       changeInPrice = "+" + changeInPrice;
+
     TextStyle headings = Theme.of(context).text.body2;
+    Widget body = new Block(<Widget>[
+      new Container(
+        margin: new EdgeDims.all(20.0),
+        child: new Card(
+          child: new Container(
+            padding: new EdgeDims.all(20.0),
+            child: new Column(<Widget>[
+                new Row(<Widget>[
+                  new Text(
+                    '${stock.symbol}',
+                    style: Theme.of(context).text.display2
+                  ),
+                  new Hero(
+                    tag: StockRowPartKind.arrow,
+                    turns: 2,
+                    child: new StockArrow(percentChange: stock.percentChange)
+                  ),
+                ],
+                justifyContent: FlexJustifyContent.spaceBetween
+              ),
+              new Text('Last Sale', style: headings),
+              new Text('$lastSale ($changeInPrice)'),
+              new Container(
+                height: 8.0
+              ),
+              new Text('Market Cap', style: headings),
+              new Text('${stock.marketCap}'),
+            ])
+          )
+        )
+      )
+    ]);
+
+    if (!showToolBar)
+      return body;
+
     return new Scaffold(
       toolBar: new ToolBar(
         left: new IconButton(
@@ -25,39 +63,7 @@ class StockSymbolViewer extends StatelessComponent {
         ),
         center: new Text(stock.name)
       ),
-      body: new Block(<Widget>[
-          new Container(
-            margin: new EdgeDims.all(20.0),
-            child: new Card(
-              child: new Container(
-                padding: new EdgeDims.all(20.0),
-                child: new Column(<Widget>[
-                    new Row(<Widget>[
-                      new Text(
-                        '${stock.symbol}',
-                        style: Theme.of(context).text.display2
-                      ),
-                      new Hero(
-                        tag: StockRowPartKind.arrow,
-                        turns: 2,
-                        child: new StockArrow(percentChange: stock.percentChange)
-                      ),
-                    ],
-                    justifyContent: FlexJustifyContent.spaceBetween
-                  ),
-                  new Text('Last Sale', style: headings),
-                  new Text('$lastSale ($changeInPrice)'),
-                  new Container(
-                    height: 8.0
-                  ),
-                  new Text('Market Cap', style: headings),
-                  new Text('${stock.marketCap}'),
-                ])
-              )
-            )
-          )
-        ]
-      )
+      body: body
     );
   }
 

--- a/packages/flutter/lib/src/widgets/modal_barrier.dart
+++ b/packages/flutter/lib/src/widgets/modal_barrier.dart
@@ -39,8 +39,8 @@ class ModalBarrier extends StatelessComponent {
   }
 }
 
-class _AnimatedModalBarrier extends StatelessComponent {
-  _AnimatedModalBarrier({
+class AnimatedModalBarrier extends StatelessComponent {
+  AnimatedModalBarrier({
     Key key,
     this.color,
     this.performance
@@ -108,7 +108,7 @@ abstract class ModalRoute extends TransitionRoute {
   Widget buildModalWidget(BuildContext context);
 
   Widget _buildModalBarrier(BuildContext context) {
-    return new _AnimatedModalBarrier(
+    return new AnimatedModalBarrier(
       color: new AnimatedColorValue(_kTransparent, end: barrierColor, curve: Curves.ease),
       performance: performance
     );

--- a/packages/unit/test/widget/bottom_sheet_test.dart
+++ b/packages/unit/test/widget/bottom_sheet_test.dart
@@ -29,6 +29,7 @@ void main() {
       tester.tap(tester.findText('BottomSheet'));
       tester.pump(); // bottom sheet dismiss animation starts
       tester.pump(new Duration(seconds: 1)); // animation done
+      tester.pump(new Duration(seconds: 2)); // rebuild frame
       expect(tester.findText('BottomSheet'), isNull);
 
       showModalBottomSheet(context: context, child: new Text('BottomSheet'));
@@ -40,6 +41,7 @@ void main() {
       tester.tapAt(new Point(20.0, 20.0));
       tester.pump(); // bottom sheet dismiss animation starts
       tester.pump(new Duration(seconds: 1)); // animation done
+      tester.pump(new Duration(seconds: 2)); // rebuild frame
       expect(tester.findText('BottomSheet'), isNull);
     });
   });


### PR DESCRIPTION
Factored OverlayRoute out of the modal and persistent bottom sheet classes, since the bottom sheet classes need to drive the performance.

Added a bottom sheet to the stocks demo: long-press on a stock shows a modal bottom sheet.

Made AnimatedModalBarrier public.
