### PR TITLE
Don't run these benchmarks forever by default

### DIFF
--- a/packages/unit/benchmark/stocks/animation_bench.dart
+++ b/packages/unit/benchmark/stocks/animation_bench.dart
@@ -7,7 +7,7 @@ import 'package:stocks/stock_data.dart' as stock_data;
 import '../../test/widget/widget_tester.dart';
 
 const int _kNumberOfIterations = 50000;
-const bool _kRunForever = true;
+const bool _kRunForever = false;
 
 void main() {
   assert(false); // Don't run in checked mode

--- a/packages/unit/benchmark/stocks/build_bench.dart
+++ b/packages/unit/benchmark/stocks/build_bench.dart
@@ -7,7 +7,7 @@ import 'package:stocks/stock_data.dart' as stock_data;
 import '../../test/widget/widget_tester.dart';
 
 const int _kNumberOfIterations = 100000;
-const bool _kRunForever = true;
+const bool _kRunForever = false;
 
 void _doNothing() { }
 


### PR DESCRIPTION
Running forever is useful for profiling but makes these scripts less useful for
measurement.  :)
