### PR TITLE
Give loose contraints to text inside input widget

### DIFF
--- a/packages/flutter/lib/src/material/input.dart
+++ b/packages/flutter/lib/src/material/input.dart
@@ -167,7 +167,7 @@ class InputState extends ScrollableState<Input> {
     scrollTo(scrollBehavior.updateExtents(
       contentExtent: _contentWidth,
       containerExtent: _containerWidth,
-      scrollOffset: _contentWidth)
-    );
+      scrollOffset: _contentWidth
+    ));
   }
 }

--- a/packages/flutter/lib/src/painting/text_painter.dart
+++ b/packages/flutter/lib/src/painting/text_painter.dart
@@ -177,10 +177,18 @@ class TextPainter {
     return _applyFloatingPointHack(_paragraph.maxIntrinsicWidth);
   }
 
+  double get width {
+    assert(!_needsLayout);
+    return _applyFloatingPointHack(_paragraph.width);
+  }
+
+  double get height {
+    assert(!_needsLayout);
+    return _applyFloatingPointHack(_paragraph.height);
+  }
+
   Size get size {
     assert(!_needsLayout);
-    double height = _applyFloatingPointHack(_paragraph.height);
-    double width = _applyFloatingPointHack(_paragraph.width);
     return new Size(width, height);
   }
 

--- a/packages/flutter/lib/src/rendering/paragraph.dart
+++ b/packages/flutter/lib/src/rendering/paragraph.dart
@@ -47,14 +47,11 @@ class RenderParagraph extends RenderBox {
     markNeedsLayout();
   }
 
-  // Whether the text should be allowed to wrap to multiple lines.
-  bool get allowLineWrap => true;
-
   void layoutText(BoxConstraints constraints) {
     assert(constraints != null);
     if (_constraintsForCurrentLayout == constraints)
       return; // already cached this layout
-    textPainter.maxWidth = allowLineWrap ? constraints.maxWidth : double.INFINITY;
+    textPainter.maxWidth = constraints.maxWidth;
     textPainter.minWidth = constraints.minWidth;
     textPainter.minHeight = constraints.minHeight;
     textPainter.maxHeight = constraints.maxHeight;


### PR DESCRIPTION
The input widget scrolls, so it should give its text loose constraints.  That
way the text ends up being its intrinsic size even if put in a context with
tight constraints.

Fixes #298
