### PR TITLE
Parent data not updated when reparenting using global keys

### DIFF
--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -1275,9 +1275,6 @@ abstract class RenderObjectElement<T extends RenderObjectWidget> extends Buildab
     super.mount(parent, newSlot);
     assert(_slot == newSlot);
     attachRenderObject(newSlot);
-    ParentDataElement parentDataElement = _findAncestorParentDataElement();
-    if (parentDataElement != null)
-      updateParentData(parentDataElement.widget);
     _dirty = false;
   }
 
@@ -1491,6 +1488,9 @@ abstract class RenderObjectElement<T extends RenderObjectWidget> extends Buildab
     _slot = newSlot;
     _ancestorRenderObjectElement = _findAncestorRenderObjectElement();
     _ancestorRenderObjectElement?.insertChildRenderObject(renderObject, newSlot);
+    ParentDataElement parentDataElement = _findAncestorParentDataElement();
+    if (parentDataElement != null)
+      updateParentData(parentDataElement.widget);
   }
 
   void detachRenderObject() {

--- a/packages/unit/test/widget/parent_data_test.dart
+++ b/packages/unit/test/widget/parent_data_test.dart
@@ -284,4 +284,55 @@ void main() {
       checkTree(tester, <TestParentData>[]);
     });
   });
+
+  test('ParentDataWidget interacts with global keys', () {
+    testWidgets((WidgetTester tester) {
+      GlobalKey key = new GlobalKey();
+
+      tester.pumpWidget(
+        new Stack(<Widget>[
+          new Positioned(
+            top: 10.0,
+            left: 10.0,
+            child: new DecoratedBox(key: key, decoration: kBoxDecorationA)
+          )
+        ])
+      );
+
+      checkTree(tester, <TestParentData>[
+        new TestParentData(top: 10.0, left: 10.0),
+      ]);
+
+      tester.pumpWidget(
+        new Stack(<Widget>[
+          new Positioned(
+            top: 10.0,
+            left: 10.0,
+            child: new DecoratedBox(
+              decoration: kBoxDecorationB,
+              child: new DecoratedBox(key: key, decoration: kBoxDecorationA)
+            )
+          )
+        ])
+      );
+
+      checkTree(tester, <TestParentData>[
+        new TestParentData(top: 10.0, left: 10.0),
+      ]);
+
+      tester.pumpWidget(
+        new Stack(<Widget>[
+          new Positioned(
+            top: 10.0,
+            left: 10.0,
+            child: new DecoratedBox(key: key, decoration: kBoxDecorationA)
+          )
+        ])
+      );
+
+      checkTree(tester, <TestParentData>[
+        new TestParentData(top: 10.0, left: 10.0),
+      ]);
+    });
+  });
 }


### PR DESCRIPTION
When we reactivate a subtree that had a global key, we weren't updating the
parent data because:

1) The child wasn't in the tree when we updated the parent data element.
2) The activated child didn't go through mount (just through update).

This patch moves the parent data update work to when we attach the render
object, which we do both during mount and when reactivating a child.

Fixes #345
