### PR TITLE
Hit Testing Cleanup

### DIFF
--- a/packages/flutter/lib/src/rendering/binding.dart
+++ b/packages/flutter/lib/src/rendering/binding.dart
@@ -31,14 +31,6 @@ int _hammingWeight(int value) {
   return weight;
 }
 
-/// A hit test entry used by [FlutterBinding]
-class BindingHitTestEntry extends HitTestEntry {
-  const BindingHitTestEntry(HitTestTarget target, this.result) : super(target);
-
-  /// The result of the hit test
-  final HitTestResult result;
-}
-
 /// State used in converting PointerPackets to PointerInputEvents
 class _PointerState {
   _PointerState({ this.pointer, this.lastPosition });
@@ -269,7 +261,7 @@ class FlutterBinding extends HitTestTarget {
   HitTestResult hitTest(Point position) {
     HitTestResult result = new HitTestResult();
     _renderView.hitTest(result, position: position);
-    result.add(new BindingHitTestEntry(this, result));
+    result.add(new HitTestEntry(this));
     return result;
   }
 
@@ -280,7 +272,7 @@ class FlutterBinding extends HitTestTarget {
       entry.target.handleEvent(event, entry);
   }
 
-  void handleEvent(InputEvent e, BindingHitTestEntry entry) {
+  void handleEvent(InputEvent e, HitTestEntry entry) {
     if (e is PointerInputEvent) {
       PointerInputEvent event = e;
       pointerRouter.route(event);

--- a/packages/flutter/lib/src/rendering/box.dart
+++ b/packages/flutter/lib/src/rendering/box.dart
@@ -275,10 +275,14 @@ class BoxConstraints extends Constraints {
 
 /// A hit test entry used by [RenderBox]
 class BoxHitTestEntry extends HitTestEntry {
-  const BoxHitTestEntry(HitTestTarget target, this.localPosition) : super(target);
+  const BoxHitTestEntry(RenderBox target, this.localPosition) : super(target);
+
+  RenderBox get target => super.target;
 
   /// The position of the hit test in the local coordinates of [target]
   final Point localPosition;
+
+  String toString() => '${target.runtimeType}@$localPosition';
 }
 
 /// Parent data used by [RenderBox] and its subclasses

--- a/packages/flutter/lib/src/rendering/hit_test.dart
+++ b/packages/flutter/lib/src/rendering/hit_test.dart
@@ -19,12 +19,14 @@ class HitTestEntry {
 
   /// The [HitTestTarget] encountered during the hit test.
   final HitTestTarget target;
+
+  String toString() => '$target';
 }
 
 /// The result of performing a hit test.
 class HitTestResult {
   HitTestResult({ List<HitTestEntry> path })
-    : path = path != null ? path : new List<HitTestEntry>();
+    : path = path ?? <HitTestEntry>[];
 
   /// The list of [HitTestEntry] objects recorded during the hit test.
   ///
@@ -36,9 +38,11 @@ class HitTestResult {
   /// Add a [HitTestEntry] to the path.
   ///
   /// The new entry is added at the end of the path, which means entries should
-  /// be added in order from most specific to least specific, typically during a
-  /// upward walk in the tree being hit tested.
+  /// be added in order from most specific to least specific, typically during an
+  /// upward walk of the tree being hit tested.
   void add(HitTestEntry entry) {
     path.add(entry);
   }
+
+  String toString() => 'HitTestResult(${path.isEmpty ? "<empty path>" : path.join(", ")})';
 }


### PR DESCRIPTION
- Drop the unused BindingHitTestEntry class. (Well, it was
  constructed, but its member was never used, so it wasn't doing
  anything a boring old HitTestEntry couldn't already do.)
- Add toString()s to HitTestEntry and HitTestResult, to aid in
  debugging hit-test related code.
