### PR TITLE
Fix tapcancel on slop.

### DIFF
--- a/packages/flutter/lib/src/gestures/arena.dart
+++ b/packages/flutter/lib/src/gestures/arena.dart
@@ -146,8 +146,7 @@ class GestureArena {
     } else {
       assert(disposition == GestureDisposition.accepted);
       if (state.isOpen) {
-        if (state.eagerWinner == null)
-          state.eagerWinner = member;
+        state.eagerWinner ??= member;
       } else {
         _resolveInFavorOf(key, state, member);
       }

--- a/packages/flutter/lib/src/gestures/recognizer.dart
+++ b/packages/flutter/lib/src/gestures/recognizer.dart
@@ -112,7 +112,7 @@ abstract class PrimaryPointerGestureRecognizer extends OneSequenceGestureRecogni
       // TODO(abarth): Maybe factor the slop handling out into a separate class?
       if (event.type == 'pointermove' && _getDistance(event) > kTouchSlop) {
         resolve(GestureDisposition.rejected);
-        stopTrackingPointer(event.pointer);
+        stopTrackingPointer(primaryPointer);
       } else {
         handlePrimaryPointer(event);
       }

--- a/packages/flutter/lib/src/gestures/tap.dart
+++ b/packages/flutter/lib/src/gestures/tap.dart
@@ -43,6 +43,15 @@ class TapGestureRecognizer extends PrimaryPointerGestureRecognizer {
     }
   }
 
+  void resolve(GestureDisposition disposition) {
+    if (_wonArena && disposition == GestureDisposition.rejected) {
+      if (onTapCancel != null)
+        onTapCancel();
+      _reset();
+    }      
+    super.resolve(disposition);
+  }
+
   void didExceedDeadline() {
     _checkDown();
   }

--- a/packages/unit/test/gestures/tap_test.dart
+++ b/packages/unit/test/gestures/tap_test.dart
@@ -161,19 +161,28 @@ void main() {
     tap.onTap = () {
       tapRecognized = true;
     };
+    bool tapCanceled = false;
+    tap.onTapCancel = () {
+      tapCanceled = true;
+    };
 
     tap.addPointer(down3);
     GestureArena.instance.close(3);
     expect(tapRecognized, isFalse);
+    expect(tapCanceled, isFalse);
     router.route(down3);
     expect(tapRecognized, isFalse);
+    expect(tapCanceled, isFalse);
 
     router.route(move3);
     expect(tapRecognized, isFalse);
+    expect(tapCanceled, isTrue);
     router.route(up3);
     expect(tapRecognized, isFalse);
+    expect(tapCanceled, isTrue);
     GestureArena.instance.sweep(3);
     expect(tapRecognized, isFalse);
+    expect(tapCanceled, isTrue);
 
     tap.dispose();
   });


### PR DESCRIPTION
Make sure to send tapcancel when the primary pointer fails because of
slop, even if the gesture won by default.

Also, minor cleanup and clarification of an invariant.
