### PR TITLE
Cursor is tiny when there's no text in an input

### DIFF
--- a/packages/flutter/lib/src/rendering/editable_paragraph.dart
+++ b/packages/flutter/lib/src/rendering/editable_paragraph.dart
@@ -29,14 +29,11 @@ class RenderEditableParagraph extends RenderParagraph {
        _scrollOffset = scrollOffset,
        super(text);
 
-  Color _cursorColor;
-  bool _showCursor;
   SizeChangedCallback onContentSizeChanged;
-  Offset _scrollOffset;
-
   Size _contentSize;
 
   Color get cursorColor => _cursorColor;
+  Color _cursorColor;
   void set cursorColor(Color value) {
     if (_cursorColor == value)
       return;
@@ -45,6 +42,7 @@ class RenderEditableParagraph extends RenderParagraph {
   }
 
   bool get showCursor => _showCursor;
+  bool _showCursor;
   void set showCursor(bool value) {
     if (_showCursor == value)
       return;
@@ -53,6 +51,7 @@ class RenderEditableParagraph extends RenderParagraph {
   }
 
   Offset get scrollOffset => _scrollOffset;
+  Offset _scrollOffset;
   void set scrollOffset(Offset value) {
     if (_scrollOffset == value)
       return;

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -222,6 +222,8 @@ class EditableTextState extends State<EditableText> {
   }
 }
 
+final String _kZeroWidthSpace = new String.fromCharCode(0x200B);
+
 class _EditableTextWidget extends LeafRenderObjectWidget {
   _EditableTextWidget({
     Key key,
@@ -275,8 +277,9 @@ class _EditableTextWidget extends LeafRenderObjectWidget {
       ]);
     }
 
+    String text = value.text;
     return new StyledTextSpan(style, <TextSpan>[
-      new PlainTextSpan(value.text)
+      new PlainTextSpan(text.isEmpty ? _kZeroWidthSpace : text)
     ]);
   }
 }


### PR DESCRIPTION
Now we use a zero-width space to force the engine to resolve the font and tell
us how large the text is likely to be once there's text in the widget.

Fixes #302
