### PR TITLE
You should be able to nest Scaffolds

### DIFF
--- a/packages/flutter/lib/src/rendering/custom_layout.dart
+++ b/packages/flutter/lib/src/rendering/custom_layout.dart
@@ -10,7 +10,7 @@ class MultiChildLayoutParentData extends ContainerBoxParentDataMixin<RenderBox> 
 }
 
 abstract class MultiChildLayoutDelegate {
-  final Map<Object, RenderBox> _idToChild = new Map<Object, RenderBox>();
+  Map<Object, RenderBox> _idToChild;
 
   /// Returns the size of this object given the incomming constraints.
   /// The size cannot reflect the instrinsic sizes of the children.
@@ -39,15 +39,20 @@ abstract class MultiChildLayoutDelegate {
   }
 
   void _callPerformLayout(Size size, BoxConstraints constraints, RenderBox firstChild) {
-    RenderBox child = firstChild;
-    while (child != null) {
-      final MultiChildLayoutParentData childParentData = child.parentData;
-      assert(childParentData.id != null);
-      _idToChild[childParentData.id] = child;
-      child = childParentData.nextSibling;
+    final Map<Object, RenderBox> previousIdToChild = _idToChild;
+    try {
+      _idToChild = new Map<Object, RenderBox>();
+      RenderBox child = firstChild;
+      while (child != null) {
+        final MultiChildLayoutParentData childParentData = child.parentData;
+        assert(childParentData.id != null);
+        _idToChild[childParentData.id] = child;
+        child = childParentData.nextSibling;
+      }
+      performLayout(size, constraints);
+    } finally {
+      _idToChild = previousIdToChild;
     }
-    performLayout(size, constraints);
-    _idToChild.clear();
   }
 
   /// Layout and position all children given this widget's size and the specified

--- a/packages/unit/test/widget/custom_multi_child_layout_test.dart
+++ b/packages/unit/test/widget/custom_multi_child_layout_test.dart
@@ -19,11 +19,13 @@ class TestMultiChildLayoutDelegate extends MultiChildLayoutDelegate {
   bool performLayoutIsChild;
 
   void performLayout(Size size, BoxConstraints constraints) {
-    performLayoutSize = size;
-    performLayoutConstraints = constraints;
-    performLayoutSize0 = layoutChild(0, constraints);
-    performLayoutSize1 = layoutChild(1, constraints);
-    performLayoutIsChild = isChild('fred');
+    expect(() {
+      performLayoutSize = size;
+      performLayoutConstraints = constraints;
+      performLayoutSize0 = layoutChild(0, constraints);
+      performLayoutSize1 = layoutChild(1, constraints);
+      performLayoutIsChild = isChild('fred');
+    }, returnsNormally);
   }
 }
 
@@ -34,7 +36,7 @@ void main() {
       tester.pumpWidget(new Center(
         child: new CustomMultiChildLayout([
           new LayoutId(id: 0, child: new Container(width: 150.0, height: 100.0)),
-          new LayoutId(id: 1, child: new Container(width: 100.0, height: 200.0))
+          new LayoutId(id: 1, child: new Container(width: 100.0, height: 200.0)),
         ],
           delegate: delegate
         )
@@ -56,6 +58,25 @@ void main() {
       expect(delegate.performLayoutSize1.width, 100.0);
       expect(delegate.performLayoutSize1.height, 200.0);
       expect(delegate.performLayoutIsChild, false);
+    });
+  });
+
+  test('Nested CustomMultiChildLayouts', () {
+    testWidgets((WidgetTester tester) {
+      TestMultiChildLayoutDelegate delegate = new TestMultiChildLayoutDelegate();
+      tester.pumpWidget(new Center(
+        child: new CustomMultiChildLayout([
+          new LayoutId(
+            id: 0,
+            child: new CustomMultiChildLayout([
+              new LayoutId(id: 0, child: new Container(width: 150.0, height: 100.0)),
+              new LayoutId(id: 1, child: new Container(width: 100.0, height: 200.0)),
+            ], delegate: delegate)
+          ),
+          new LayoutId(id: 1, child: new Container(width: 100.0, height: 200.0)),
+        ], delegate: delegate)
+      ));
+
     });
   });
 }


### PR DESCRIPTION
Prior to this patch, MultiChildLayoutDelegate couldn't be re-entered because it
cleared _idToChild when unwinding its stack. Now we restore the previous value
of _idToChild when we unwind.
