### PR TITLE
Safely clear SnackBack and BottomSheet placeholders

### DIFF
--- a/packages/flutter/lib/src/material/bottom_sheet.dart
+++ b/packages/flutter/lib/src/material/bottom_sheet.dart
@@ -221,6 +221,9 @@ Future showBottomSheet({ BuildContext context, GlobalKey<PlaceholderState> place
   placeholderKey.currentState.child = new _PersistentBottomSheet(route: route);
   Navigator.of(context).pushEphemeral(route);
   return completer.future.then((_) {
-    placeholderKey.currentState.child = null;
+    // If our overlay has been obscured by an opaque OverlayEntry then currentState
+    // will have been cleared already.
+    if (placeholderKey.currentState != null)
+      placeholderKey.currentState.child = null;
   });
 }

--- a/packages/flutter/lib/src/material/snack_bar.dart
+++ b/packages/flutter/lib/src/material/snack_bar.dart
@@ -108,9 +108,16 @@ Future showSnackBar({ BuildContext context, GlobalKey<PlaceholderState> placehol
     content: content,
     actions: actions
   );
+
+  // TODO(hansmuller): https://github.com/flutter/flutter/issues/374
+  assert(placeholderKey.currentState.child == null);
+
   placeholderKey.currentState.child = snackBar;
   Navigator.of(context).pushEphemeral(route);
   return completer.future.then((_) {
-    placeholderKey.currentState.child = null;
+    // If our overlay has been obscured by an opaque OverlayEntry currentState
+    // will have been cleared already.
+    if (placeholderKey.currentState != null)
+      placeholderKey.currentState.child = null;
   });
 }


### PR DESCRIPTION
Correct one stocks demo bug: displaying the stock symbol viewer (single tap on a row) while a BottomSheet or SnackBar was up, would assert.

Thep SnackBack and BottomSheet placeholder keys are cleared when they're obscured by a route with an opaque OverlayEntry.  So in that case there's no need to try and clear the placeholder's  child again.
