### PR TITLE
Add a way to register listeners for app shutdown

### DIFF
--- a/packages/flutter/lib/services.dart
+++ b/packages/flutter/lib/services.dart
@@ -18,5 +18,6 @@ export 'src/services/image_cache.dart';
 export 'src/services/image_decoder.dart';
 export 'src/services/image_resource.dart';
 export 'src/services/keyboard.dart';
+export 'src/services/lifecycle.dart';
 export 'src/services/service_registry.dart';
 export 'src/services/shell.dart';

--- a/packages/flutter/lib/src/services/activity.dart
+++ b/packages/flutter/lib/src/services/activity.dart
@@ -7,6 +7,7 @@ import 'dart:async';
 
 import 'package:sky_services/activity/activity.mojom.dart';
 
+import 'lifecycle.dart';
 import 'shell.dart';
 
 export 'package:sky_services/activity/activity.mojom.dart';
@@ -23,6 +24,7 @@ const int MULTIPLE_TASK = 0x08000000;
 ActivityProxy _initActivityProxy() {
   ActivityProxy activity = new ActivityProxy.unbound();
   shell.connectToService(null, activity);
+  lifecycle.addShutdownListener(() => activity.close());
   return activity;
 }
 

--- a/packages/flutter/lib/src/services/asset_bundle.dart
+++ b/packages/flutter/lib/src/services/asset_bundle.dart
@@ -14,6 +14,7 @@ import 'fetch.dart';
 import 'image_cache.dart';
 import 'image_decoder.dart';
 import 'image_resource.dart';
+import 'lifecycle.dart';
 import 'shell.dart';
 
 abstract class AssetBundle {
@@ -95,9 +96,11 @@ class MojoAssetBundle extends AssetBundle {
 
 AssetBundle _initRootBundle() {
   try {
-    AssetBundleProxy bundle = new AssetBundleProxy.fromHandle(
+    AssetBundleProxy proxy = new AssetBundleProxy.fromHandle(
         new core.MojoHandle(internals.takeRootBundleHandle()));
-    return new MojoAssetBundle(bundle);
+    AssetBundle bundle = new MojoAssetBundle(proxy);
+    lifecycle.addShutdownListener(() => bundle.close());
+    return bundle;
   } catch (e) {
     return null;
   }

--- a/packages/flutter/lib/src/services/lifecycle.dart
+++ b/packages/flutter/lib/src/services/lifecycle.dart
@@ -1,0 +1,32 @@
+// Copyright 2015 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:ui' as ui;
+
+typedef void ShutdownListener();
+
+class _Lifecycle {
+  _Lifecycle() {
+    ui.lifecycleHooks.onShutdown = _handleShutdown;
+  }
+
+  final List<ShutdownListener> _shutdownListeners = new List<ShutdownListener>();
+
+  void _handleShutdown() {
+    for (ShutdownListener listener in _shutdownListeners)
+      listener();
+  }
+
+  /// Calls listener before app shutdown.
+  void addShutdownListener(ShutdownListener listener) {
+    _shutdownListeners.add(listener);
+  }
+
+  /// Stops calling listener before app shutdown.
+  bool removeShutdownListener(ShutdownListener listener) {
+    _shutdownListeners.remove(listener);
+  }
+}
+
+final _Lifecycle lifecycle = new _Lifecycle();

--- a/packages/flutter/lib/src/services/shell.dart
+++ b/packages/flutter/lib/src/services/shell.dart
@@ -10,6 +10,8 @@ import 'package:mojo/core.dart' as core;
 import 'package:mojo/mojo/service_provider.mojom.dart';
 import 'package:mojo/mojo/shell.mojom.dart';
 
+import 'lifecycle.dart';
+
 // A replacement for shell.connectToService.  Implementations should return true
 // if they handled the request, or false if the request should fall through
 // to the default requestService.
@@ -33,6 +35,7 @@ ApplicationConnection _initEmbedderConnection() {
     return null;
   ServiceProviderProxy services = new ServiceProviderProxy.fromHandle(servicesHandle);
   ServiceProviderStub exposedServices = new ServiceProviderStub.fromHandle(exposedServicesHandle);
+  lifecycle.addShutdownListener(() => services.close());
   return new ApplicationConnection(exposedServices, services);
 }
 


### PR DESCRIPTION
Also add shutdown handlers that close Mojo handlers that were opened on behalf
of various services
