### PR TITLE
Give the StockSymbolView's Hero a Key

### DIFF
--- a/examples/stocks/lib/stock_symbol_viewer.dart
+++ b/examples/stocks/lib/stock_symbol_viewer.dart
@@ -25,6 +25,7 @@ class StockSymbolView extends StatelessComponent {
               style: Theme.of(context).text.display2
             ),
             new Hero(
+              key: new ObjectKey(stock),
               tag: StockRowPartKind.arrow,
               turns: 2,
               child: new StockArrow(percentChange: stock.percentChange)


### PR DESCRIPTION
The StockSymbolBottomSheet includes a Hero, as does the StockSymbolPage and the StockRow. When two or more heroes with the same tag are gathered together Heros.of() expects them to have distinguishing non-null keys. Now they do.

Fixes https://github.com/flutter/flutter/issues/382
