### PR TITLE
More resilient Widget tests

### DIFF
--- a/packages/unit/test/widget/align_test.dart
+++ b/packages/unit/test/widget/align_test.dart
@@ -1,3 +1,7 @@
+// Copyright 2015 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 import 'package:test/test.dart';

--- a/packages/unit/test/widget/animated_container_test.dart
+++ b/packages/unit/test/widget/animated_container_test.dart
@@ -1,3 +1,7 @@
+// Copyright 2015 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 import 'package:flutter/animation.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';

--- a/packages/unit/test/widget/block_test.dart
+++ b/packages/unit/test/widget/block_test.dart
@@ -1,3 +1,7 @@
+// Copyright 2015 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 import 'package:flutter/widgets.dart';
 import 'package:test/test.dart';
 

--- a/packages/unit/test/widget/bottom_sheet_test.dart
+++ b/packages/unit/test/widget/bottom_sheet_test.dart
@@ -1,3 +1,7 @@
+// Copyright 2015 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:test/test.dart';

--- a/packages/unit/test/widget/box_decoration_test.dart
+++ b/packages/unit/test/widget/box_decoration_test.dart
@@ -1,3 +1,7 @@
+// Copyright 2015 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:test/test.dart';

--- a/packages/unit/test/widget/build_scope_test.dart
+++ b/packages/unit/test/widget/build_scope_test.dart
@@ -1,3 +1,7 @@
+// Copyright 2015 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 import 'package:flutter/animation.dart';
 import 'package:flutter/widgets.dart';
 import 'package:test/test.dart';

--- a/packages/unit/test/widget/center_test.dart
+++ b/packages/unit/test/widget/center_test.dart
@@ -1,3 +1,7 @@
+// Copyright 2015 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 import 'package:flutter/widgets.dart';
 import 'package:test/test.dart';
 

--- a/packages/unit/test/widget/coordinates_test.dart
+++ b/packages/unit/test/widget/coordinates_test.dart
@@ -1,3 +1,7 @@
+// Copyright 2015 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 import 'package:test/test.dart';

--- a/packages/unit/test/widget/custom_multi_child_layout_test.dart
+++ b/packages/unit/test/widget/custom_multi_child_layout_test.dart
@@ -1,3 +1,7 @@
+// Copyright 2015 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 import 'package:test/test.dart';

--- a/packages/unit/test/widget/custom_one_child_layout_test.dart
+++ b/packages/unit/test/widget/custom_one_child_layout_test.dart
@@ -1,3 +1,7 @@
+// Copyright 2015 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 import 'package:flutter/widgets.dart';
 import 'package:test/test.dart';
 

--- a/packages/unit/test/widget/date_picker_test.dart
+++ b/packages/unit/test/widget/date_picker_test.dart
@@ -1,3 +1,7 @@
+// Copyright 2015 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 import 'package:flutter/material.dart';
 import 'package:test/test.dart';
 

--- a/packages/unit/test/widget/dismissable_test.dart
+++ b/packages/unit/test/widget/dismissable_test.dart
@@ -1,3 +1,7 @@
+// Copyright 2015 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 import 'package:test/test.dart';
@@ -280,3 +284,4 @@ void main() {
     });
   });
 }
+

--- a/packages/unit/test/widget/draggable_test.dart
+++ b/packages/unit/test/widget/draggable_test.dart
@@ -1,3 +1,7 @@
+// Copyright 2015 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 import 'package:flutter/material.dart';
 import 'package:test/test.dart';
 

--- a/packages/unit/test/widget/drawer_test.dart
+++ b/packages/unit/test/widget/drawer_test.dart
@@ -1,3 +1,7 @@
+// Copyright 2015 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:test/test.dart';

--- a/packages/unit/test/widget/duplicate_key_test.dart
+++ b/packages/unit/test/widget/duplicate_key_test.dart
@@ -1,3 +1,7 @@
+// Copyright 2015 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 import 'package:flutter/widgets.dart';
 import 'package:test/test.dart';
 

--- a/packages/unit/test/widget/flex_test.dart
+++ b/packages/unit/test/widget/flex_test.dart
@@ -1,3 +1,7 @@
+// Copyright 2015 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 import 'package:test/test.dart';

--- a/packages/unit/test/widget/focus_test.dart
+++ b/packages/unit/test/widget/focus_test.dart
@@ -1,3 +1,7 @@
+// Copyright 2015 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 import 'package:flutter/widgets.dart';
 import 'package:test/test.dart';
 

--- a/packages/unit/test/widget/fractionally_sized_box_test.dart
+++ b/packages/unit/test/widget/fractionally_sized_box_test.dart
@@ -1,3 +1,7 @@
+// Copyright 2015 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 import 'package:test/test.dart';

--- a/packages/unit/test/widget/gesture_detector_test.dart
+++ b/packages/unit/test/widget/gesture_detector_test.dart
@@ -1,3 +1,7 @@
+// Copyright 2015 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 import 'package:flutter/widgets.dart';
 import 'package:test/test.dart';
 

--- a/packages/unit/test/widget/heroes_test.dart
+++ b/packages/unit/test/widget/heroes_test.dart
@@ -1,3 +1,7 @@
+// Copyright 2015 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 import 'package:flutter/material.dart';
 import 'package:test/test.dart';
 

--- a/packages/unit/test/widget/homogeneous_viewport_test.dart
+++ b/packages/unit/test/widget/homogeneous_viewport_test.dart
@@ -1,3 +1,7 @@
+// Copyright 2015 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 import 'package:flutter/widgets.dart';
 import 'package:test/test.dart';
 

--- a/packages/unit/test/widget/input_test.dart
+++ b/packages/unit/test/widget/input_test.dart
@@ -1,3 +1,7 @@
+// Copyright 2015 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 import 'package:mojo_services/keyboard/keyboard.mojom.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';

--- a/packages/unit/test/widget/listener_test.dart
+++ b/packages/unit/test/widget/listener_test.dart
@@ -1,3 +1,7 @@
+// Copyright 2015 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 import 'package:flutter/widgets.dart';
 import 'package:test/test.dart';
 

--- a/packages/unit/test/widget/mixed_viewport_test.dart
+++ b/packages/unit/test/widget/mixed_viewport_test.dart
@@ -1,3 +1,7 @@
+// Copyright 2015 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 import 'package:flutter/widgets.dart';
 import 'package:test/test.dart';
 

--- a/packages/unit/test/widget/multichild_test.dart
+++ b/packages/unit/test/widget/multichild_test.dart
@@ -1,3 +1,7 @@
+// Copyright 2015 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 import 'package:test/test.dart';

--- a/packages/unit/test/widget/navigator_test.dart
+++ b/packages/unit/test/widget/navigator_test.dart
@@ -1,3 +1,7 @@
+// Copyright 2015 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 import 'package:flutter/material.dart';
 import 'package:test/test.dart';
 

--- a/packages/unit/test/widget/pageable_list_test.dart
+++ b/packages/unit/test/widget/pageable_list_test.dart
@@ -1,3 +1,7 @@
+// Copyright 2015 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 import 'package:flutter/widgets.dart';
 import 'package:test/test.dart';
 

--- a/packages/unit/test/widget/parent_data_test.dart
+++ b/packages/unit/test/widget/parent_data_test.dart
@@ -1,3 +1,7 @@
+// Copyright 2015 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 import 'package:test/test.dart';

--- a/packages/unit/test/widget/positioned_test.dart
+++ b/packages/unit/test/widget/positioned_test.dart
@@ -1,3 +1,7 @@
+// Copyright 2015 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 import 'package:flutter/animation.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';

--- a/packages/unit/test/widget/progress_indicator_test.dart
+++ b/packages/unit/test/widget/progress_indicator_test.dart
@@ -1,3 +1,7 @@
+// Copyright 2015 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 
 import 'package:flutter/rendering.dart';
 import 'package:flutter/material.dart';

--- a/packages/unit/test/widget/render_object_widget_test.dart
+++ b/packages/unit/test/widget/render_object_widget_test.dart
@@ -1,3 +1,7 @@
+// Copyright 2015 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 import 'package:test/test.dart';

--- a/packages/unit/test/widget/scrollable_list_hit_testing_test.dart
+++ b/packages/unit/test/widget/scrollable_list_hit_testing_test.dart
@@ -1,3 +1,7 @@
+// Copyright 2015 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 import 'package:test/test.dart';

--- a/packages/unit/test/widget/scrollable_list_horizontal_test.dart
+++ b/packages/unit/test/widget/scrollable_list_horizontal_test.dart
@@ -1,3 +1,7 @@
+// Copyright 2015 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 import 'package:test/test.dart';

--- a/packages/unit/test/widget/scrollable_list_vertical_test.dart
+++ b/packages/unit/test/widget/scrollable_list_vertical_test.dart
@@ -1,3 +1,7 @@
+// Copyright 2015 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 import 'package:flutter/widgets.dart';
 import 'package:test/test.dart';
 

--- a/packages/unit/test/widget/scrollable_list_with_inherited_test.dart
+++ b/packages/unit/test/widget/scrollable_list_with_inherited_test.dart
@@ -1,3 +1,7 @@
+// Copyright 2015 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 import 'package:flutter/widgets.dart';
 import 'package:test/test.dart';
 

--- a/packages/unit/test/widget/set_state_test.dart
+++ b/packages/unit/test/widget/set_state_test.dart
@@ -1,3 +1,7 @@
+// Copyright 2015 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 import 'package:flutter/widgets.dart';
 import 'package:test/test.dart';
 

--- a/packages/unit/test/widget/shader_mask_test.dart
+++ b/packages/unit/test/widget/shader_mask_test.dart
@@ -1,3 +1,7 @@
+// Copyright 2015 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 import 'dart:ui' as ui;
 
 import 'package:flutter/painting.dart';

--- a/packages/unit/test/widget/size_observer_test.dart
+++ b/packages/unit/test/widget/size_observer_test.dart
@@ -1,3 +1,7 @@
+// Copyright 2015 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';

--- a/packages/unit/test/widget/snack_bar_test.dart
+++ b/packages/unit/test/widget/snack_bar_test.dart
@@ -1,3 +1,7 @@
+// Copyright 2015 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 import 'package:flutter/material.dart';
 import 'package:test/test.dart';
 

--- a/packages/unit/test/widget/stack_test.dart
+++ b/packages/unit/test/widget/stack_test.dart
@@ -1,3 +1,7 @@
+// Copyright 2015 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 import 'package:test/test.dart';

--- a/packages/unit/test/widget/stateful_component_test.dart
+++ b/packages/unit/test/widget/stateful_component_test.dart
@@ -1,3 +1,7 @@
+// Copyright 2015 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 import 'package:test/test.dart';

--- a/packages/unit/test/widget/stateful_components_test.dart
+++ b/packages/unit/test/widget/stateful_components_test.dart
@@ -1,3 +1,7 @@
+// Copyright 2015 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 import 'package:flutter/widgets.dart';
 import 'package:test/test.dart';
 

--- a/packages/unit/test/widget/syncing_test.dart
+++ b/packages/unit/test/widget/syncing_test.dart
@@ -1,3 +1,7 @@
+// Copyright 2015 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 import 'package:flutter/widgets.dart';
 import 'package:test/test.dart';
 

--- a/packages/unit/test/widget/tabs_test.dart
+++ b/packages/unit/test/widget/tabs_test.dart
@@ -1,3 +1,7 @@
+// Copyright 2015 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:test/test.dart';

--- a/packages/unit/test/widget/test_widgets.dart
+++ b/packages/unit/test/widget/test_widgets.dart
@@ -1,3 +1,7 @@
+// Copyright 2015 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 import 'package:flutter/widgets.dart';
 import 'package:test/test.dart';
 

--- a/packages/unit/test/widget/transform_test.dart
+++ b/packages/unit/test/widget/transform_test.dart
@@ -1,3 +1,7 @@
+// Copyright 2015 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 import 'package:flutter/widgets.dart';
 import 'package:test/test.dart';
 

--- a/packages/unit/test/widget/widget_tester.dart
+++ b/packages/unit/test/widget/widget_tester.dart
@@ -1,3 +1,9 @@
+// Copyright 2015 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:ui' as ui;
+
 import 'package:flutter/animation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/rendering.dart';
@@ -29,7 +35,10 @@ typedef Point SizeToPointFunction(Size size);
 class WidgetTester {
   WidgetTester._(FakeAsync async)
     : async = async,
-      clock = async.getClock(new DateTime.utc(2015, 1, 1));
+      clock = async.getClock(new DateTime.utc(2015, 1, 1)) {
+    timeDilation = 1.0;
+    ui.window.onBeginFrame = null;
+  }
 
   final FakeAsync async;
   final Clock clock;


### PR DESCRIPTION
- force the time dilation to 1.0 for the Widget tests, so that a local
  change doesn't break all the tests during development.
- add missing license block to all the files.
- set ui.window.onBeginFrame to null when you use WidgetTester, so that
  the engine doesn't trigger any confusing frames after our fake frames.
