### PR TITLE
Moar shebang.

### DIFF
--- a/dev/update_packages.dart
+++ b/dev/update_packages.dart
@@ -1,3 +1,4 @@
+#!/usr/bin/env dart
 // Copyright 2015 The Chromium Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.


### PR DESCRIPTION
Make it possible to run dev/update_packages.dart directly from the shell.

@abarth
