### PR TITLE
Fix issue with forward-delete in editable text widget

### DIFF
--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -52,7 +52,7 @@ class EditableString implements KeyboardClient {
   }
 
   String textAfter(TextRange range) {
-    return text.substring(range.end);
+    return text.substring(range.end, text.length);
   }
 
   String textInside(TextRange range) {
@@ -105,8 +105,9 @@ class EditableString implements KeyboardClient {
   void deleteSurroundingText(int beforeLength, int afterLength) {
     TextRange beforeRange = new TextRange(
         start: selection.start - beforeLength, end: selection.start);
+    int afterRangeEnd = math.min(selection.end + afterLength, text.length);
     TextRange afterRange =
-        new TextRange(start: selection.end, end: selection.end + afterLength);
+        new TextRange(start: selection.end, end: afterRangeEnd);
     _delete(afterRange);
     _delete(beforeRange);
     selection = new TextRange(

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -52,7 +52,7 @@ class EditableString implements KeyboardClient {
   }
 
   String textAfter(TextRange range) {
-    return text.substring(range.end, text.length);
+    return text.substring(range.end);
   }
 
   String textInside(TextRange range) {


### PR DESCRIPTION
Fixes index issues when a forward delete is attempted at the end of the text range. Logic now mirrors similar checks done at the beginning of the text range.
