### PR TITLE
Add all the icon sizes to the FLX

### DIFF
--- a/packages/flutter_tools/lib/src/commands/build.dart
+++ b/packages/flutter_tools/lib/src/commands/build.dart
@@ -18,7 +18,7 @@ import 'flutter_command.dart';
 const String _kSnapshotKey = 'snapshot_blob.bin';
 const List<String> _kDensities = const ['drawable-xxhdpi'];
 const List<String> _kThemes = const ['white', 'black'];
-const List<int> _kSizes = const [24];
+const List<int> _kSizes = const [18, 24, 36, 48];
 
 class _Asset {
   final String base;


### PR DESCRIPTION
Adding all the sizes of all the icons adds about 50 KB to the stocks FLX.
That's probably the right trade-off until we get better at pruning the set of
assets.

Fixes #235
