### PR TITLE
Fix focus bug that was breaking nested navigators

### DIFF
--- a/packages/flutter/lib/src/widgets/focus.dart
+++ b/packages/flutter/lib/src/widgets/focus.dart
@@ -192,6 +192,7 @@ class FocusState extends State<Focus> {
 
   void _scopeRemoved(GlobalKey key) {
     assert(_focusedScope == key);
+    GlobalKey.unregisterRemoveListener(_currentlyRegisteredScopeRemovalListenerKey, _scopeRemoved);
     _currentlyRegisteredScopeRemovalListenerKey = null;
     setState(() {
       _focusedScope = null;


### PR DESCRIPTION
Turns out we were assuming that once the global key is gone, our
listener is unregistered. It isn't.

I'm planning on adding a test as part of my nested navigator work.
