### PR TITLE
Reduce paint time for Stocks drawer animation by 88%

### DIFF
--- a/packages/flutter/lib/src/material/drawer.dart
+++ b/packages/flutter/lib/src/material/drawer.dart
@@ -202,7 +202,9 @@ class _DrawerControllerState extends State<_DrawerController> {
               widthFactor: _performance.progress,
               child: new SizeObserver(
                 onSizeChanged: _handleSizeChanged,
-                child: config.child
+                child: new ForcedLayer(
+                  child: config.child
+                )
               )
             )
           )


### PR DESCRIPTION
Now we use a forced layer around the reprojected content of the drawer, which
means we don't have to re-record it during the slide animation. This saves 2ms
per frame.

The total main-thread time for the drawer animation is now 2.0ms.
