### PR TITLE
Snackbar Refactor

### DIFF
--- a/examples/fitness/lib/feed.dart
+++ b/examples/fitness/lib/feed.dart
@@ -54,7 +54,6 @@ class FeedFragment extends StatefulComponent {
 }
 
 class FeedFragmentState extends State<FeedFragment> {
-  final GlobalKey<PlaceholderState> _snackBarPlaceholderKey = new GlobalKey<PlaceholderState>();
   FitnessMode _fitnessMode = FitnessMode.feed;
 
   void _handleFitnessModeChange(FitnessMode value) {
@@ -115,15 +114,14 @@ class FeedFragmentState extends State<FeedFragment> {
 
   void _handleItemDismissed(FitnessItem item) {
     config.onItemDeleted(item);
-    showSnackBar(
-      context: context,
-      placeholderKey: _snackBarPlaceholderKey,
+    Scaffold.of(context).showSnackBar(new SnackBar(
       content: new Text("Item deleted."),
-      actions: <SnackBarAction>[new SnackBarAction(label: "UNDO", onPressed: () {
-        config.onItemCreated(item);
-        Navigator.of(context).pop();
-      })]
-    );
+      actions: <SnackBarAction>[
+        new SnackBarAction(label: "UNDO", onPressed: () {
+          config.onItemCreated(item);
+        }),
+      ]
+    ));
   }
 
   Widget buildChart() {
@@ -212,7 +210,6 @@ class FeedFragmentState extends State<FeedFragment> {
     return new Scaffold(
       toolBar: buildToolBar(),
       body: buildBody(),
-      snackBar: new Placeholder(key: _snackBarPlaceholderKey),
       floatingActionButton: buildFloatingActionButton()
     );
   }

--- a/examples/fitness/lib/measurement.dart
+++ b/examples/fitness/lib/measurement.dart
@@ -112,8 +112,6 @@ class MeasurementFragment extends StatefulComponent {
 }
 
 class MeasurementFragmentState extends State<MeasurementFragment> {
-  final GlobalKey<PlaceholderState> _snackBarPlaceholderKey = new GlobalKey<PlaceholderState>();
-
   String _weight = "";
   DateTime _when = new DateTime.now();
 
@@ -123,11 +121,9 @@ class MeasurementFragmentState extends State<MeasurementFragment> {
       parsedWeight = double.parse(_weight);
     } on FormatException catch(e) {
       print("Exception $e");
-      showSnackBar(
-        context: context,
-        placeholderKey: _snackBarPlaceholderKey,
+      Scaffold.of(context).showSnackBar(new SnackBar(
         content: new Text('Save failed')
-      );
+      ));
     }
     config.onCreated(new Measurement(when: _when, weight: parsedWeight));
     Navigator.of(context).pop();
@@ -198,8 +194,7 @@ class MeasurementFragmentState extends State<MeasurementFragment> {
   Widget build(BuildContext context) {
     return new Scaffold(
       toolBar: buildToolBar(),
-      body: buildBody(context),
-      snackBar: new Placeholder(key: _snackBarPlaceholderKey)
+      body: buildBody(context)
     );
   }
 }

--- a/packages/flutter/lib/src/material/constants.dart
+++ b/packages/flutter/lib/src/material/constants.dart
@@ -15,7 +15,6 @@ const double kStatusBarHeight = 50.0;
 // Tablet/Desktop: 64dp
 const double kToolBarHeight = 56.0;
 const double kExtendedToolBarHeight = 128.0;
-const double kSnackBarHeight = 52.0;
 
 // https://www.google.com/design/spec/layout/metrics-keylines.html#metrics-keylines-keylines-spacing
 const double kListTitleHeight = 72.0;

--- a/packages/flutter/lib/src/material/scaffold.dart
+++ b/packages/flutter/lib/src/material/scaffold.dart
@@ -2,15 +2,18 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:async';
+import 'dart:collection';
 import 'dart:math' as math;
 import 'dart:ui' as ui;
 
+import 'package:flutter/animation.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 
-import 'constants.dart';
 import 'material.dart';
 import 'tool_bar.dart';
+import 'snack_bar.dart';
 
 const double _kFloatingActionButtonMargin = 16.0; // TODO(hmuller): should be device dependent
 
@@ -77,46 +80,103 @@ class _ScaffoldLayout extends MultiChildLayoutDelegate {
 
 final _ScaffoldLayout _scaffoldLayout = new _ScaffoldLayout();
 
-void _addIfNonNull(List<LayoutId> children, Widget child, Object childId) {
-  if (child != null)
-    children.add(new LayoutId(child: child, id: childId));
-}
-
-class Scaffold extends StatelessComponent {
+class Scaffold extends StatefulComponent {
   Scaffold({
     Key key,
-    this.body,
     this.toolBar,
-    this.snackBar,
-    this.floatingActionButton,
-    this.bottomSheet
+    this.body,
+    this.bottomSheet,
+    this.floatingActionButton
   }) : super(key: key);
 
-  final Widget body;
   final ToolBar toolBar;
-  final Widget snackBar;
+  final Widget body;
+  final Widget bottomSheet; // this is for non-modal bottom sheets
   final Widget floatingActionButton;
-  final Widget bottomSheet;
+
+  static ScaffoldState of(BuildContext context) => context.ancestorStateOfType(ScaffoldState);
+
+  ScaffoldState createState() => new ScaffoldState();
+}
+
+class ScaffoldState extends State<Scaffold> {
+
+  Queue<SnackBar> _snackBars = new Queue<SnackBar>();
+  Performance _snackBarPerformance;
+  Timer _snackBarTimer;
+
+  void showSnackBar(SnackBar snackbar) {
+    _snackBarPerformance ??= SnackBar.createPerformance()
+      ..addStatusListener(_handleSnackBarStatusChange);
+    setState(() {
+      _snackBars.addLast(snackbar.withPerformance(_snackBarPerformance));
+    });
+  }
+
+  void _handleSnackBarStatusChange(PerformanceStatus status) {
+    switch (status) {
+      case PerformanceStatus.dismissed:
+        assert(_snackBars.isNotEmpty);
+        setState(() {
+          _snackBars.removeFirst();
+        });
+        break;
+      case PerformanceStatus.completed:
+        setState(() {
+          assert(_snackBarTimer == null);
+          // build will create a new timer if necessary to dismiss the snack bar
+        });
+        break;
+      case PerformanceStatus.forward:
+      case PerformanceStatus.reverse:
+        break;
+    }
+  }
+
+  void _hideSnackBar() {
+    _snackBarPerformance.reverse();
+    _snackBarTimer = null;
+  }
+
+  void dispose() {
+    _snackBarPerformance?.stop();
+    _snackBarPerformance = null;
+    _snackBarTimer?.cancel();
+    _snackBarTimer = null;
+    super.dispose();
+  }
+
+  void _addIfNonNull(List<LayoutId> children, Widget child, Object childId) {
+    if (child != null)
+      children.add(new LayoutId(child: child, id: childId));
+  }
 
   Widget build(BuildContext context) {
-    final Widget paddedToolBar = toolBar?.withPadding(new EdgeDims.only(top: ui.window.padding.top));
-    final Widget materialBody = body != null ? new Material(child: body) : null;
-    Widget constrainedSnackBar;
-    if (snackBar != null) {
-      // TODO(jackson): On tablet/desktop, minWidth = 288, maxWidth = 568
-      constrainedSnackBar = new ConstrainedBox(
-        constraints: const BoxConstraints(maxHeight: kSnackBarHeight),
-        child: snackBar
-      );
+    final Widget paddedToolBar = config.toolBar?.withPadding(new EdgeDims.only(top: ui.window.padding.top));
+    final Widget materialBody = config.body != null ? new Material(child: config.body) : null;
+
+    if (_snackBars.length > 0) {
+      if (_snackBarPerformance.isDismissed)
+        _snackBarPerformance.forward();
+      ModalRoute route = ModalRoute.of(context);
+      if (route == null || route.isCurrent) {
+        if (_snackBarPerformance.isCompleted && _snackBarTimer == null)
+          _snackBarTimer = new Timer(_snackBars.first.duration, _hideSnackBar);
+      } else {
+        _snackBarTimer?.cancel();
+        _snackBarTimer = null;
+      }
     }
 
     final List<LayoutId>children = new List<LayoutId>();
     _addIfNonNull(children, materialBody, _Child.body);
     _addIfNonNull(children, paddedToolBar, _Child.toolBar);
-    _addIfNonNull(children, bottomSheet, _Child.bottomSheet);
-    _addIfNonNull(children, constrainedSnackBar, _Child.snackBar);
-    _addIfNonNull(children, floatingActionButton, _Child.floatingActionButton);
+    _addIfNonNull(children, config.bottomSheet, _Child.bottomSheet);
+    if (_snackBars.isNotEmpty)
+      _addIfNonNull(children, _snackBars.first, _Child.snackBar);
+    _addIfNonNull(children, config.floatingActionButton, _Child.floatingActionButton);
 
     return new CustomMultiChildLayout(children, delegate: _scaffoldLayout);
   }
+
 }

--- a/packages/flutter/lib/src/material/snack_bar.dart
+++ b/packages/flutter/lib/src/material/snack_bar.dart
@@ -2,19 +2,29 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:async';
-
 import 'package:flutter/animation.dart';
 import 'package:flutter/widgets.dart';
 
-import 'constants.dart';
 import 'material.dart';
 import 'theme.dart';
 import 'typography.dart';
 
+// https://www.google.com/design/spec/components/snackbars-toasts.html#snackbars-toasts-specs
 const double _kSideMargins = 24.0;
-const double _kVerticalPadding = 14.0;
+const double _kSingleLineVerticalPadding = 14.0;
+const double _kMultiLineVerticalPadding = 24.0;
 const Color _kSnackBackground = const Color(0xFF323232);
+
+// TODO(ianh): We should check if the given text and actions are going to fit on
+// one line or not, and if they are, use the single-line layout, and if not, use
+// the multiline layout. See link above.
+
+// TODO(ianh): Implement the Tablet version of snackbar if we're "on a tablet".
+
+const Duration kSnackBarTransitionDuration = const Duration(milliseconds: 250);
+const Duration kSnackBarShortDisplayDuration = const Duration(milliseconds: 1500);
+const Duration kSnackBarMediumDisplayDuration = const Duration(milliseconds: 2750);
+const Curve snackBarFadeCurve = const Interval(0.72, 1.0, curve: Curves.fastOutSlowIn);
 
 class SnackBarAction extends StatelessComponent {
   SnackBarAction({Key key, this.label, this.onPressed }) : super(key: key) {
@@ -29,32 +39,35 @@ class SnackBarAction extends StatelessComponent {
       onTap: onPressed,
       child: new Container(
         margin: const EdgeDims.only(left: _kSideMargins),
-        padding: const EdgeDims.symmetric(vertical: _kVerticalPadding),
+        padding: const EdgeDims.symmetric(vertical: _kSingleLineVerticalPadding),
         child: new Text(label)
       )
     );
   }
 }
 
-class _SnackBar extends StatelessComponent {
-  _SnackBar({
+class SnackBar extends StatelessComponent {
+  SnackBar({
     Key key,
     this.content,
     this.actions,
-    this.route
+    this.duration: kSnackBarShortDisplayDuration,
+    this.performance
   }) : super(key: key) {
     assert(content != null);
   }
 
   final Widget content;
   final List<SnackBarAction> actions;
-  final _SnackBarRoute route;
+  final Duration duration;
+  final PerformanceView performance;
 
   Widget build(BuildContext context) {
+    assert(performance != null);
     List<Widget> children = <Widget>[
       new Flexible(
         child: new Container(
-          margin: const EdgeDims.symmetric(vertical: _kVerticalPadding),
+          margin: const EdgeDims.symmetric(vertical: _kSingleLineVerticalPadding),
           child: new DefaultTextStyle(
             style: Typography.white.subhead,
             child: content
@@ -64,25 +77,21 @@ class _SnackBar extends StatelessComponent {
     ];
     if (actions != null)
       children.addAll(actions);
-    return new SquashTransition(
-      performance: route.performance,
-      height: new AnimatedValue<double>(
-        0.0,
-        end: kSnackBarHeight,
-        curve: Curves.easeIn,
-        reverseCurve: Curves.easeOut
-      ),
-      child: new ClipRect(
-        child: new OverflowBox(
-          minHeight: kSnackBarHeight,
-          maxHeight: kSnackBarHeight,
-          child: new Material(
-            elevation: 6,
-            color: _kSnackBackground,
-            child: new Container(
-              margin: const EdgeDims.symmetric(horizontal: _kSideMargins),
-              child: new DefaultTextStyle(
-                style: new TextStyle(color: Theme.of(context).accentColor),
+    return new ClipRect(
+      child: new AlignTransition(
+        performance: performance,
+        alignment: new AnimatedValue<FractionalOffset>(const FractionalOffset(0.0, 0.0)),
+        heightFactor: new AnimatedValue<double>(0.0, end: 1.0, curve: Curves.fastOutSlowIn),
+        child: new Material(
+          elevation: 6,
+          color: _kSnackBackground,
+          child: new Container(
+            margin: const EdgeDims.symmetric(horizontal: _kSideMargins),
+            child: new DefaultTextStyle(
+              style: new TextStyle(color: Theme.of(context).accentColor),
+              child: new FadeTransition(
+                performance: performance,
+                opacity: new AnimatedValue<double>(0.0, end: 1.0, curve: snackBarFadeCurve),
                 child: new Row(children)
               )
             )
@@ -91,33 +100,23 @@ class _SnackBar extends StatelessComponent {
       )
     );
   }
-}
 
-class _SnackBarRoute extends TransitionRoute {
-  _SnackBarRoute({ Completer completer }) : super(completer: completer);
+  // API for Scaffold.addSnackBar():
 
-  bool get opaque => false;
-  Duration get transitionDuration => const Duration(milliseconds: 200);
-}
+  static Performance createPerformance() {
+    return new Performance(
+      duration: kSnackBarTransitionDuration,
+      debugLabel: 'SnackBar'
+    );
+  }
 
-Future showSnackBar({ BuildContext context, GlobalKey<PlaceholderState> placeholderKey, Widget content, List<SnackBarAction> actions }) {
-  final Completer completer = new Completer();
-  _SnackBarRoute route = new _SnackBarRoute(completer: completer);
-  _SnackBar snackBar = new _SnackBar(
-    route: route,
-    content: content,
-    actions: actions
-  );
-
-  // TODO(hansmuller): https://github.com/flutter/flutter/issues/374
-  assert(placeholderKey.currentState.child == null);
-
-  placeholderKey.currentState.child = snackBar;
-  Navigator.of(context).pushEphemeral(route);
-  return completer.future.then((_) {
-    // If our overlay has been obscured by an opaque OverlayEntry currentState
-    // will have been cleared already.
-    if (placeholderKey.currentState != null)
-      placeholderKey.currentState.child = null;
-  });
+  SnackBar withPerformance(Performance newPerformance) {
+    return new SnackBar(
+      key: key,
+      content: content,
+      actions: actions,
+      duration: duration,
+      performance: newPerformance
+    );
+  }
 }


### PR DESCRIPTION
"showSnackBar()" is now a feature of a Scaffold. To get to a Scaffold
you either use a global key (`scaffoldKey.currentState.showSnackBar(...)`),
or you use `Scaffold.of(context)`.

Snack bars no longer have a route. They are entirely managed by the
Scaffold. Fixes #432.

Snack bars now queue up when you have several of them. Fixes #374.

Snack bars now auto-size themselves around their contents. This is step
one towards implementing multiline snack bars.

Snack bars now self-dismiss after some per-snackbar configurable period.

The self-dismissing pauses while a dialog is up above the snackbar (or
anything that uses ModalRoute). To enable this, there's now a
`ModalRoute.of(context)` API that returns the current ModalRoute, and
you will be rebuilt if you asked for this and the route's "current"
status changes. To implement this, the Navigator now rebuilds
unconditionally any time it pushes or pops a route.

Snack bars now use the curves that Android uses for snack bars.

Snack bar contents now fade in.
