### PR TITLE
Refactor PaintingContext

### DIFF
--- a/examples/rendering/lib/sector_layout.dart
+++ b/examples/rendering/lib/sector_layout.dart
@@ -282,7 +282,7 @@ class RenderSectorRing extends RenderSectorWithChildren {
     super.paint(context, offset);
     RenderSector child = firstChild;
     while (child != null) {
-      context.paintChild(child, offset.toPoint());
+      context.paintChild(child, offset);
       final SectorChildListParentData childParentData = child.parentData;
       child = childParentData.nextSibling;
     }
@@ -388,7 +388,7 @@ class RenderSectorSlice extends RenderSectorWithChildren {
     RenderSector child = firstChild;
     while (child != null) {
       assert(child.parentData is SectorChildListParentData);
-      context.paintChild(child, offset.toPoint());
+      context.paintChild(child, offset);
       final SectorChildListParentData childParentData = child.parentData;
       child = childParentData.nextSibling;
     }
@@ -470,7 +470,7 @@ class RenderBoxToRenderSectorAdapter extends RenderBox with RenderObjectWithChil
     if (child != null) {
       Rect bounds = offset & size;
       // we move the offset to the center of the circle for the RenderSectors
-      context.paintChild(child, bounds.center);
+      context.paintChild(child, bounds.center.toOffset());
     }
   }
 

--- a/packages/flutter/lib/src/material/tabs.dart
+++ b/packages/flutter/lib/src/material/tabs.dart
@@ -232,7 +232,7 @@ class _RenderTabBar extends RenderBox with
     RenderBox child = firstChild;
     while (child != null) {
       final _TabBarParentData childParentData = child.parentData;
-      context.paintChild(child, childParentData.position + offset);
+      context.paintChild(child, childParentData.offset + offset);
       if (index++ == selectedIndex)
         _paintIndicator(context.canvas, child, offset);
       child = childParentData.nextSibling;

--- a/packages/flutter/lib/src/rendering/box.dart
+++ b/packages/flutter/lib/src/rendering/box.dart
@@ -287,6 +287,8 @@ class BoxHitTestEntry extends HitTestEntry {
 
 /// Parent data used by [RenderBox] and its subclasses
 class BoxParentData extends ParentData {
+  // TODO(abarth): Switch to using an Offset rather than a Point here. This
+  //               value is really the offset from the parent.
   Point _position = Point.origin;
   /// The point at which to paint the child in the parent's coordinate system
   Point get position => _position;
@@ -294,6 +296,7 @@ class BoxParentData extends ParentData {
     assert(RenderObject.debugDoingLayout);
     _position = value;
   }
+  Offset get offset => _position.toOffset();
   String toString() => 'position=$position';
 }
 
@@ -771,7 +774,7 @@ abstract class RenderBoxContainerDefaultsMixin<ChildType extends RenderBox, Pare
     RenderBox child = firstChild;
     while (child != null) {
       final ParentDataType childParentData = child.parentData;
-      context.paintChild(child, childParentData.position + offset);
+      context.paintChild(child, childParentData.offset + offset);
       child = childParentData.nextSibling;
     }
   }

--- a/packages/flutter/lib/src/rendering/overflow.dart
+++ b/packages/flutter/lib/src/rendering/overflow.dart
@@ -131,7 +131,7 @@ class RenderOverflowBox extends RenderBox with RenderObjectWithChildMixin<Render
 
   void paint(PaintingContext context, Offset offset) {
     if (child != null)
-      context.paintChild(child, offset.toPoint());
+      context.paintChild(child, offset);
   }
 
   void debugDescribeSettings(List<String> settings) {
@@ -198,7 +198,7 @@ class RenderSizedOverflowBox extends RenderBox with RenderObjectWithChildMixin<R
 
   void paint(PaintingContext context, Offset offset) {
     if (child != null)
-      context.paintChild(child, offset.toPoint());
+      context.paintChild(child, offset);
   }
 }
 

--- a/packages/flutter/lib/src/rendering/shifted_box.dart
+++ b/packages/flutter/lib/src/rendering/shifted_box.dart
@@ -56,7 +56,7 @@ abstract class RenderShiftedBox extends RenderBox with RenderObjectWithChildMixi
   void paint(PaintingContext context, Offset offset) {
     if (child != null) {
       final BoxParentData childParentData = child.parentData;
-      context.paintChild(child, childParentData.position + offset);
+      context.paintChild(child, childParentData.offset + offset);
     }
   }
 

--- a/packages/flutter/lib/src/rendering/stack.dart
+++ b/packages/flutter/lib/src/rendering/stack.dart
@@ -489,6 +489,6 @@ class RenderIndexedStack extends RenderStackBase {
       return;
     RenderBox child = _childAtIndex();
     final StackParentData childParentData = child.parentData;
-    context.paintChild(child, childParentData.position + offset);
+    context.paintChild(child, childParentData.offset + offset);
   }
 }

--- a/packages/flutter/lib/src/rendering/statistics_box.dart
+++ b/packages/flutter/lib/src/rendering/statistics_box.dart
@@ -54,6 +54,6 @@ class RenderStatisticsBox extends RenderBox {
   }
 
   void paint(PaintingContext context, Offset offset) {
-    context.paintStatistics(optionsMask, rasterizerThreshold, offset, size);
+    context.pushStatistics(offset, optionsMask, rasterizerThreshold, size);
   }
 }

--- a/packages/flutter/lib/src/rendering/view.dart
+++ b/packages/flutter/lib/src/rendering/view.dart
@@ -110,7 +110,7 @@ class RenderView extends RenderObject with RenderObjectWithChildMixin<RenderBox>
 
   void paint(PaintingContext context, Offset offset) {
     if (child != null)
-      context.paintChild(child, offset.toPoint());
+      context.paintChild(child, offset);
   }
 
   /// Uploads the composited layer tree to the engine

--- a/packages/flutter/lib/src/rendering/viewport.dart
+++ b/packages/flutter/lib/src/rendering/viewport.dart
@@ -146,12 +146,15 @@ class RenderViewport extends RenderBox with RenderObjectWithChildMixin<RenderBox
   void paint(PaintingContext context, Offset offset) {
     if (child != null) {
       Offset roundedScrollOffset = _scrollOffsetRoundedToIntegerDevicePixels;
-      bool _needsClip = offset < Offset.zero ||
-                        !(offset & size).contains(((offset - roundedScrollOffset) & child.size).bottomRight);
-      if (_needsClip)
-        context.paintChildWithClipRect(child, (offset - roundedScrollOffset).toPoint(), offset & size);
-      else
-        context.paintChild(child, (offset - roundedScrollOffset).toPoint());
+      bool _needsClip = offset < Offset.zero
+          || !(offset & size).contains(((offset - roundedScrollOffset) & child.size).bottomRight);
+      if (_needsClip) {
+        context.pushClipRect(needsCompositing, offset, Point.origin & size, (PaintingContext context, Offset offset) {
+          context.paintChild(child, offset - roundedScrollOffset);
+        });
+      } else {
+        context.paintChild(child, offset - roundedScrollOffset);
+      }
     }
   }
 


### PR DESCRIPTION
This patch simplifies PaintingContext with several goals:

1) We now call a callback instead of assuming the caller has a single child to
   paint. This change will let us handle render objects that wish to paint more
   than one child.
2) We now avoid creating lots of empty picture layers because we don't eagerly
   start recording pictures. Instead, we wait for the first caller to touch the
   canvas before creating the picture recorder.
3) We now are more consistent about which values have incorporated the painting
   offset.
