### PR TITLE
Popup menu in Stocks throws exception

### DIFF
--- a/packages/flutter/lib/src/material/drawer.dart
+++ b/packages/flutter/lib/src/material/drawer.dart
@@ -62,25 +62,27 @@ class _DrawerRoute extends OverlayRoute {
   _DrawerState _state = _DrawerState.showing;
 
   Widget _build(BuildContext context) {
-    return new _DrawerController(
-      key: _drawerKey,
-      settleDuration: _kBaseSettleDuration,
-      onClosed: () {
-        _DrawerState previousState = _state;
-        _state = _DrawerState.closed;
-        switch (previousState) {
-          case _DrawerState.showing:
-            Navigator.of(context).pop();
-            break;
-          case _DrawerState.popped:
-            super.didPop(null);
-            break;
-          case _DrawerState.closed:
-            assert(false);
-            break;
-        }
-      },
-      child: new _Drawer(route: this)
+    return new RepaintBoundary(
+      child: new _DrawerController(
+        key: _drawerKey,
+        settleDuration: _kBaseSettleDuration,
+        onClosed: () {
+          _DrawerState previousState = _state;
+          _state = _DrawerState.closed;
+          switch (previousState) {
+            case _DrawerState.showing:
+              Navigator.of(context).pop();
+              break;
+            case _DrawerState.popped:
+              super.didPop(null);
+              break;
+            case _DrawerState.closed:
+              assert(false);
+              break;
+          }
+        },
+        child: new _Drawer(route: this)
+      )
     );
   }
 
@@ -202,7 +204,7 @@ class _DrawerControllerState extends State<_DrawerController> {
               widthFactor: _performance.progress,
               child: new SizeObserver(
                 onSizeChanged: _handleSizeChanged,
-                child: new ForcedLayer(
+                child: new RepaintBoundary(
                   child: config.child
                 )
               )

--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -1061,7 +1061,7 @@ class RenderPointerListener extends RenderProxyBox {
 /// previously. Similarly, when the child repaints but the surround tree does
 /// not, we can re-record its display list without re-recording the display list
 /// for the surround tree.
-class RenderForcedLayer extends RenderProxyBox {
+class RenderRepaintBoundary extends RenderProxyBox {
   bool get hasLayer => true;
 }
 

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -1321,9 +1321,9 @@ class Listener extends OneChildRenderObjectWidget {
   }
 }
 
-class ForcedLayer extends OneChildRenderObjectWidget {
-  ForcedLayer({ Key key, Widget child }) : super(key: key, child: child);
-  RenderForcedLayer createRenderObject() => new RenderForcedLayer();
+class RepaintBoundary extends OneChildRenderObjectWidget {
+  RepaintBoundary({ Key key, Widget child }) : super(key: key, child: child);
+  RenderRepaintBoundary createRenderObject() => new RenderRepaintBoundary();
 }
 
 class IgnorePointer extends OneChildRenderObjectWidget {

--- a/packages/flutter/lib/src/widgets/routes.dart
+++ b/packages/flutter/lib/src/widgets/routes.dart
@@ -39,9 +39,7 @@ abstract class OverlayRoute extends Route {
 
   void didPush(OverlayState overlay, OverlayEntry insertionPoint) {
     for (WidgetBuilder builder in builders) {
-      _overlayEntries.add(new OverlayEntry(builder: (BuildContext context) {
-        return new ForcedLayer(child: builder(context));
-      }));
+      _overlayEntries.add(new OverlayEntry(builder: builder));
       overlay?.insert(_overlayEntries.last, above: insertionPoint);
       insertionPoint = _overlayEntries.last;
     }
@@ -170,6 +168,7 @@ class _ModalScope extends StatusTransitionComponent {
         )
       );
     }
+    contents = new RepaintBoundary(child: contents);
     ModalPosition position = route.position;
     if (position == null)
       return contents;


### PR DESCRIPTION
Previously, we were putting a ForcedLayer just below the overlay, but that
causes trouble for routes like the popup menu that want to position themselves
inside the overlay. Instead, I've moved the ForcedLayer down into ModalRoute.

Also, rename ForcedLayer to RepaintBoundary, which is more descriptive of what
this widget does.

Fixes #485
