### PR TITLE
Download build artifacts from a zip file

### DIFF
--- a/packages/flutter/pubspec.yaml
+++ b/packages/flutter/pubspec.yaml
@@ -7,8 +7,8 @@ dependencies:
   collection: '>=1.1.3 <2.0.0'
   intl: '>=0.12.4+2 <0.13.0'
   material_design_icons: '>=0.0.3 <0.1.0'
-  sky_engine: 0.0.57
-  sky_services: 0.0.57
+  sky_engine: 0.0.58
+  sky_services: 0.0.58
   vector_math: '>=1.4.3 <2.0.0'
 
   cassowary:

--- a/packages/flutter_tools/lib/src/commands/run_mojo.dart
+++ b/packages/flutter_tools/lib/src/commands/run_mojo.dart
@@ -89,7 +89,7 @@ class RunMojoCommand extends FlutterCommand {
 
     if (argResults['android']) {
       args.add('--android');
-      final String cloudStorageBaseUrl = ArtifactStore.getCloudStorageBaseUrl('shell', 'android-arm');
+      final String cloudStorageBaseUrl = ArtifactStore.getCloudStorageBaseUrl('android-arm');
       final String appPath = _makePathAbsolute(bundlePath);
       final String appName = path.basename(appPath);
       final String appDir = path.dirname(appPath);

--- a/travis/download_tester.py
+++ b/travis/download_tester.py
@@ -7,6 +7,7 @@ import argparse
 import os
 import subprocess
 import sys
+import zipfile
 
 def download(base_url, out_dir, name):
     url = '%s/%s' % (base_url, name)
@@ -28,10 +29,12 @@ def main():
     with open(args.revision_file, 'r') as f:
         revision = f.read()
 
-    base_url = 'https://storage.googleapis.com/mojo/sky/shell/linux-x64/%s' % revision
-    download(base_url, out_dir, 'sky_shell')
-    download(base_url, out_dir, 'icudtl.dat')
-    download(base_url, out_dir, 'sky_snapshot')
+    base_url = 'https://storage.googleapis.com/mojo/flutter/%s/linux-x64' % revision
+    download(base_url, out_dir, 'artifacts.zip')
+
+    artifacts_zip = zipfile.ZipFile(os.path.join(out_dir, 'artifacts.zip'))
+    artifacts_zip.extractall(out_dir)
+    artifacts_zip.close()
 
     subprocess.call([ 'chmod', 'a+x', os.path.join(out_dir, 'sky_shell' )])
     subprocess.call([ 'chmod', 'a+x', os.path.join(out_dir, 'sky_snapshot' )])


### PR DESCRIPTION
This updates the Flutter tools to match the proposed new packaging of artifacts
in the engine release script.
- The GCS URL for artifacts is now gs://mojo/flutter/$revision/$platform
- Categories have been removed from the Artifact class
- All artifacts for a given platform now live in a zip file.  If an artifact
  is not present in the local cache, then the zip will be downloaded and
  extracted.

Note that darwin-x64 artifacts go through a different process that (for now)
continues to use the old format.
