### PR TITLE
Add a repaint rainbow to help debug repaint issues

### DIFF
--- a/packages/flutter/lib/painting.dart
+++ b/packages/flutter/lib/painting.dart
@@ -14,6 +14,7 @@ library painting;
 
 export 'src/painting/basic_types.dart';
 export 'src/painting/box_painter.dart';
+export 'src/painting/colors.dart';
 export 'src/painting/shadows.dart';
 export 'src/painting/text_painter.dart';
 export 'src/painting/text_style.dart';

--- a/packages/flutter/lib/src/painting/colors.dart
+++ b/packages/flutter/lib/src/painting/colors.dart
@@ -1,0 +1,80 @@
+// Copyright 2015 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:ui' show Color;
+
+class HSVColor {
+  const HSVColor.fromAHSV(this.a, this.h, this.s, this.v);
+
+  /// Alpha, from 0.0 to 1.0.
+  final double a;
+
+  /// Hue, from 0.0 to 360.0.
+  final double h;
+
+  /// Saturation, from 0.0 to 1.0.
+  final double s;
+
+  /// Value, from 0.0 to 1.0.
+  final double v;
+
+  HSVColor withAlpha(double a) {
+    return new HSVColor.fromAHSV(a, h, s, v);
+  }
+
+  HSVColor withHue(double h) {
+    return new HSVColor.fromAHSV(a, h, s, v);
+  }
+
+  HSVColor withSaturation(double s) {
+    return new HSVColor.fromAHSV(a, h, s, v);
+  }
+
+  HSVColor withValue(double v) {
+    return new HSVColor.fromAHSV(a, h, s, v);
+  }
+
+  /// Returns this color in RGB.
+  Color toColor() {
+    final double h = this.h % 360;
+    final double c = s * v;
+    final double x = c * (1 - (((h / 60.0) % 2) - 1).abs());
+    final double m = v - c;
+
+    double r;
+    double g;
+    double b;
+    if (h < 60.0) {
+      r = c;
+      g = x;
+      b = 0.0;
+    } else if (h < 120.0) {
+      r = x;
+      g = c;
+      b = 0.0;
+    } else if (h < 180.0) {
+      r = 0.0;
+      g = c;
+      b = x;
+    } else if (h < 240.0) {
+      r = 0.0;
+      g = x;
+      b = c;
+    } else if (h < 300.0) {
+      r = x;
+      g = 0.0;
+      b = c;
+    } else {
+      r = c;
+      g = 0.0;
+      b = x;
+    }
+    return new Color.fromARGB(
+      ( a      * 0xFF).round(),
+      ((r + m) * 0xFF).round(),
+      ((g + m) * 0xFF).round(),
+      ((b + m) * 0xFF).round()
+    );
+  }
+}

--- a/packages/flutter/lib/src/rendering/debug.dart
+++ b/packages/flutter/lib/src/rendering/debug.dart
@@ -6,6 +6,7 @@ import 'dart:ui' as ui;
 import 'dart:async';
 import 'dart:collection';
 
+import 'package:flutter/painting.dart';
 import 'package:vector_math/vector_math_64.dart';
 
 /// Causes each RenderBox to paint a box around its bounds.
@@ -37,6 +38,15 @@ int debugPaintPointersColorValue = 0x00BBBB;
 
 /// The color to use when painting RenderError boxes in checked mode.
 ui.Color debugErrorBoxColor = const ui.Color(0xFFFF0000);
+
+/// Overlay a rotating set of colors when repainting layers in checked mode.
+bool debugEnableRepaintRainbox = false;
+
+/// The current color to overlay when repainting a layer.
+HSVColor debugCurrentRepaintColor = const HSVColor.fromAHSV(0.4, 60.0, 1.0, 1.0);
+
+/// The amount to increment the hue of the current repaint color.
+double debugRepaintRainboxHueIncrement = 2.0;
 
 List<String> debugDescribeTransform(Matrix4 transform) {
   List<String> matrix = transform.toString().split('\n').map((String s) => '  $s').toList();

--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -167,6 +167,8 @@ class PaintingContext {
     if (!_isRecording)
       return;
     assert(() {
+      if (debugEnableRepaintRainbox)
+        canvas.drawRect(_paintBounds, new Paint()..color = debugCurrentRepaintColor.toColor());
       if (debugPaintLayerBordersEnabled) {
         Paint paint = new Paint()
           ..style = ui.PaintingStyle.stroke

--- a/packages/flutter/lib/src/rendering/view.dart
+++ b/packages/flutter/lib/src/rendering/view.dart
@@ -6,9 +6,11 @@ import 'dart:developer';
 import 'dart:ui' as ui;
 
 import 'package:flutter/animation.dart';
+import 'package:flutter/painting.dart';
 import 'package:vector_math/vector_math_64.dart';
 
 import 'box.dart';
+import 'debug.dart';
 import 'layer.dart';
 import 'object.dart';
 
@@ -126,6 +128,11 @@ class RenderView extends RenderObject with RenderObjectWithChildMixin<RenderBox>
       ui.Scene scene = builder.build();
       ui.window.render(scene);
       scene.dispose();
+      assert(() {
+        if (debugEnableRepaintRainbox)
+          debugCurrentRepaintColor = debugCurrentRepaintColor.withHue(debugCurrentRepaintColor.h + debugRepaintRainboxHueIncrement);
+        return true;
+      });
     } finally {
       Timeline.finishSync();
     }


### PR DESCRIPTION
The repaint raindbow tints each recording with a rotating set of colors so you
can see which pixels are repainting each frame.
