### PR TITLE
Make stocks list scrolling 2x faster on the main thread

### DIFF
--- a/packages/flutter/lib/src/rendering/block.dart
+++ b/packages/flutter/lib/src/rendering/block.dart
@@ -255,6 +255,7 @@ class RenderBlockViewport extends RenderBlockBase {
        super(children: children, direction: direction, itemExtent: itemExtent, minExtent: minExtent);
 
   bool _inCallback = false;
+  bool get hasLayer => true;
 
   /// Called during [layout] to determine the blocks children
   ///

--- a/packages/flutter/lib/src/widgets/homogeneous_viewport.dart
+++ b/packages/flutter/lib/src/widgets/homogeneous_viewport.dart
@@ -148,7 +148,9 @@ class _HomogeneousViewportElement extends RenderObjectElement<HomogeneousViewpor
     assert(_layoutItemCount != null);
     List<Widget> newWidgets;
     if (_layoutItemCount > 0)
-      newWidgets = widget.builder(this, _layoutFirstIndex, _layoutItemCount);
+      newWidgets = widget.builder(this, _layoutFirstIndex, _layoutItemCount).map((Widget widget) {
+        return new RepaintBoundary(key: new ValueKey<Key>(widget.key), child: widget);
+      }).toList();
     else
       newWidgets = <Widget>[];
     _children = updateChildren(_children, newWidgets);


### PR DESCRIPTION
This patch improves the repaint strategy for HomogeneousViewport so that the
list itself and every entry in the list has a repaint boundary. That means that
we only record list items as they enter the view.
