### PR TITLE
OverlayRoute.finished()

### DIFF
--- a/packages/flutter/lib/src/material/bottom_sheet.dart
+++ b/packages/flutter/lib/src/material/bottom_sheet.dart
@@ -153,16 +153,12 @@ class _ModalBottomSheetRoute extends OverlayRoute {
     super.didPush(overlay, insertionPoint);
   }
 
-  void _finish(dynamic result) {
-    super.didPop(result); // clear the overlay entries
-    completer.complete(result);
-  }
-
   void didPop(dynamic result) {
+    completer.complete(result);
     if (performance.isDismissed)
-      _finish(result);
+      finished();
     else
-      performance.reverse().then((_) { _finish(result); });
+      performance.reverse().then((_) { finished(); });
   }
 
   Widget _buildModalBarrier(BuildContext context) {

--- a/packages/flutter/lib/src/material/drawer.dart
+++ b/packages/flutter/lib/src/material/drawer.dart
@@ -74,7 +74,7 @@ class _DrawerRoute extends OverlayRoute {
               Navigator.of(context).pop();
               break;
             case _DrawerState.popped:
-              super.didPop(null);
+              finished();
               break;
             case _DrawerState.closed:
               assert(false);
@@ -87,6 +87,8 @@ class _DrawerRoute extends OverlayRoute {
   }
 
   void didPop(dynamic result) {
+    // we don't call the superclass because we want to control the timing of the
+    // call to finished().
     switch (_state) {
       case _DrawerState.showing:
         _drawerKey.currentState?._close();
@@ -96,7 +98,7 @@ class _DrawerRoute extends OverlayRoute {
         assert(false);
         break;
       case _DrawerState.closed:
-        super.didPop(null);
+        finished();
         break;
     }
   }

--- a/packages/flutter/lib/src/widgets/routes.dart
+++ b/packages/flutter/lib/src/widgets/routes.dart
@@ -45,7 +45,19 @@ abstract class OverlayRoute extends Route {
     }
   }
 
+  // Subclasses shouldn't call this if they want to delay the finished() call.
   void didPop(dynamic result) {
+    finished();
+  }
+
+  /// Clears out the overlay entries.
+  ///
+  /// This method is intended to be used by subclasses who don't call
+  /// super.didPop() because they want to have control over the timing of the
+  /// overlay removal.
+  ///
+  /// Do not call this method outside of this context.
+  void finished() {
     for (OverlayEntry entry in _overlayEntries)
       entry.remove();
     _overlayEntries.clear();
@@ -84,7 +96,7 @@ abstract class TransitionRoute extends OverlayRoute {
           overlayEntries.first.opaque = false;
         break;
       case PerformanceStatus.dismissed:
-        super.didPop(_result); // clear the overlays
+        super.finished(); // clear the overlays
         completer?.complete(_result);
         break;
     }

--- a/packages/unit/test/widget/bottom_sheet_test.dart
+++ b/packages/unit/test/widget/bottom_sheet_test.dart
@@ -36,13 +36,14 @@ void main() {
       tester.pump(); // bottom sheet show animation starts
       tester.pump(new Duration(seconds: 1)); // animation done
       expect(tester.findText('BottomSheet'), isNotNull);
+      expect(showBottomSheetThenCalled, isFalse);
 
       // Tap on the the bottom sheet itself to dismiss it
       tester.tap(tester.findText('BottomSheet'));
       tester.pump(); // bottom sheet dismiss animation starts
+      expect(showBottomSheetThenCalled, isTrue);
       tester.pump(new Duration(seconds: 1)); // last frame of animation (sheet is entirely off-screen, but still present)
       tester.pump(new Duration(seconds: 1)); // frame after the animation (sheet has been removed)
-      expect(showBottomSheetThenCalled, isTrue);
       expect(tester.findText('BottomSheet'), isNull);
 
       showModalBottomSheet(context: context, builder: (BuildContext context) => new Text('BottomSheet'));


### PR DESCRIPTION
Rather than have delayed calls to super.didPop(), which raises my
eyebrow every time I see it, this provides a separate finished()
function to call, and uses the convention that if you want to call it
yourself, you just don't call super.didPop().
