### PR TITLE
Rename LabeledGlobalKey's argument to debugLabel

### DIFF
--- a/examples/address_book/lib/main.dart
+++ b/examples/address_book/lib/main.dart
@@ -48,12 +48,12 @@ class AddressBookHome extends StatelessComponent {
     );
   }
 
-  static final GlobalKey nameKey = new GlobalKey(label: 'name field');
-  static final GlobalKey phoneKey = new GlobalKey(label: 'phone field');
-  static final GlobalKey emailKey = new GlobalKey(label: 'email field');
-  static final GlobalKey addressKey = new GlobalKey(label: 'address field');
-  static final GlobalKey ringtoneKey = new GlobalKey(label: 'ringtone field');
-  static final GlobalKey noteKey = new GlobalKey(label: 'note field');
+  static final GlobalKey nameKey = new GlobalKey(debugLabel: 'name field');
+  static final GlobalKey phoneKey = new GlobalKey(debugLabel: 'phone field');
+  static final GlobalKey emailKey = new GlobalKey(debugLabel: 'email field');
+  static final GlobalKey addressKey = new GlobalKey(debugLabel: 'address field');
+  static final GlobalKey ringtoneKey = new GlobalKey(debugLabel: 'ringtone field');
+  static final GlobalKey noteKey = new GlobalKey(debugLabel: 'note field');
 
   Widget buildBody(BuildContext context) {
     return new Block(<Widget>[

--- a/packages/flutter/lib/src/material/dropdown.dart
+++ b/packages/flutter/lib/src/material/dropdown.dart
@@ -239,7 +239,7 @@ class DropdownButton<T> extends StatelessComponent {
   }
 
   Widget build(BuildContext context) {
-    GlobalKey indexedStackKey = new GlobalKey(label: 'DropdownButton.IndexedStack');
+    GlobalKey indexedStackKey = new GlobalKey(debugLabel: 'DropdownButton.IndexedStack');
     int selectedIndex = 0;
     for (int itemIndex = 0; itemIndex < items.length; itemIndex++) {
       if (items[itemIndex].value == value) {

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -75,7 +75,7 @@ abstract class GlobalKey<T extends State<StatefulComponent>> extends Key {
 
   /// Constructs a LabeledGlobalKey, which is a GlobalKey with a label used for debugging.
   /// The label is not used for comparing the identity of the key.
-  factory GlobalKey({ String label }) => new LabeledGlobalKey<T>(label); // the label is purely for debugging purposes and is otherwise ignored
+  factory GlobalKey({ String debugLabel }) => new LabeledGlobalKey<T>(debugLabel); // the label is purely for debugging purposes and is otherwise ignored
 
   static final Map<GlobalKey, Element> _registry = new Map<GlobalKey, Element>();
   static final Map<GlobalKey, int> _debugDuplicates = new Map<GlobalKey, int>();
@@ -175,9 +175,9 @@ abstract class GlobalKey<T extends State<StatefulComponent>> extends Key {
 /// The optional label can be used for documentary purposes. It does not affect
 /// the key's identity.
 class LabeledGlobalKey<T extends State<StatefulComponent>> extends GlobalKey<T> {
-  const LabeledGlobalKey(this._label) : super.constructor();
-  final String _label;
-  String toString() => '[GlobalKey ${_label != null ? _label : hashCode}]';
+  const LabeledGlobalKey(this._debugLabel) : super.constructor();
+  final String _debugLabel;
+  String toString() => '[GlobalKey ${_debugLabel != null ? _debugLabel : hashCode}]';
 }
 
 /// A kind of [GlobalKey] that takes its identity from the object used as its value.


### PR DESCRIPTION
The old name was confusing.

Fixes #462
