### PR TITLE
Give type arguments to routes.

### DIFF
--- a/packages/flutter/lib/src/material/dialog.dart
+++ b/packages/flutter/lib/src/material/dialog.dart
@@ -115,8 +115,8 @@ class Dialog extends StatelessComponent {
   }
 }
 
-class _DialogRoute extends ModalRoute {
-  _DialogRoute({ Completer completer, this.child }) : super(completer: completer);
+class _DialogRoute<T> extends ModalRoute<T> {
+  _DialogRoute({ Completer<T> completer, this.child }) : super(completer: completer);
 
   final Widget child;
 

--- a/packages/flutter/lib/src/material/page.dart
+++ b/packages/flutter/lib/src/material/page.dart
@@ -36,7 +36,7 @@ class _MaterialPageTransition extends TransitionWithChild {
   }
 }
 
-class MaterialPageRoute extends ModalRoute {
+class MaterialPageRoute<T> extends ModalRoute<T> {
   MaterialPageRoute({
     this.builder,
     NamedRouteSettings settings: const NamedRouteSettings()

--- a/packages/flutter/lib/src/widgets/navigator.dart
+++ b/packages/flutter/lib/src/widgets/navigator.dart
@@ -5,10 +5,10 @@
 import 'framework.dart';
 import 'overlay.dart';
 
-abstract class Route {
+abstract class Route<T> {
   List<OverlayEntry> get overlayEntries;
   void didPush(OverlayState overlay, OverlayEntry insertionPoint) { }
-  void didPop(dynamic result) { }
+  void didPop(T result) { }
 
   /// The given route has been pushed onto the navigator after this route.
   /// Return true if the route before this one should be notified also. The
@@ -140,6 +140,9 @@ class NavigatorState extends State<Navigator> {
   /// Do not use this for ModalRoutes, or indeed anything other than
   /// StateRoutes. Doing so would cause very odd results, e.g. ModalRoutes would
   /// get confused about who is current.
+  ///
+  /// The type of the result argument, if provided, must match the type argument
+  /// of the class of the given route. (In practice, this is usually "dynamic".)
   void remove(Route route, [dynamic result]) {
     assert(_modal.contains(route));
     assert(route.overlayEntries.isEmpty);
@@ -155,6 +158,10 @@ class NavigatorState extends State<Navigator> {
 
   /// Removes the current route, notifying the observer (if any), and the
   /// previous routes (using [Route.didPopNext]).
+  ///
+  /// The type of the result argument, if provided, must match the type argument
+  /// of the class of the current route. (In practice, this is usually
+  /// "dynamic".)
   void pop([dynamic result]) {
     setState(() {
       // We use setState to guarantee that we'll rebuild, since the routes can't


### PR DESCRIPTION
These end up not actually being used, currently, because we don't have generic methods, which you'd need for showDialog() and friends, and we don't have any way to parameterise a class type at runtime, which you'd need for MaterialApp routes, but it's a step in the right direction.

This also makes TransitionRoute support two completers, one for when you pop and one for the end of the dismiss transition.
