### PR TITLE
Route refactor

### DIFF
--- a/examples/widgets/dropdown.dart
+++ b/examples/widgets/dropdown.dart
@@ -4,24 +4,22 @@
 
 import 'package:flutter/material.dart';
 
-class DropdownDemo extends StatefulComponent {
-  DropdownDemo();
-
-  DropdownDemoState createState() => new DropdownDemoState();
+class DropDownDemo extends StatefulComponent {
+  DropDownDemoState createState() => new DropDownDemoState();
 }
 
-class DropdownDemoState extends State<DropdownDemo> {
+class DropDownDemoState extends State<DropDownDemo> {
   String _value = "Free";
 
-  List<DropdownMenuItem> _buildItems() {
+  List<DropDownMenuItem<String>> _buildItems() {
     return ["One", "Two", "Free", "Four"].map((String value) {
-      return new DropdownMenuItem<String>(value: value, child: new Text(value));
+      return new DropDownMenuItem<String>(value: value, child: new Text(value));
     })
     .toList();
   }
 
   Widget build(BuildContext context) {
-    Widget dropdown = new DropdownButton<String>(
+    Widget dropdown = new DropDownButton<String>(
       items: _buildItems(),
       value: _value,
       onChanged: (String newValue) {
@@ -33,7 +31,7 @@ class DropdownDemoState extends State<DropdownDemo> {
     );
 
     return new Scaffold(
-      toolBar: new ToolBar(center: new Text('DropdownDemo Demo')),
+      toolBar: new ToolBar(center: new Text('DropDownDemo Demo')),
       body: new Container(
         decoration: new BoxDecoration(backgroundColor: Theme.of(context).primarySwatch[50]),
         child: new Center(child: dropdown)
@@ -44,14 +42,14 @@ class DropdownDemoState extends State<DropdownDemo> {
 
 void main() {
   runApp(new MaterialApp(
-    title: 'DropdownDemo',
+    title: 'DropDownDemo',
     theme: new ThemeData(
       brightness: ThemeBrightness.light,
       primarySwatch: Colors.blue,
       accentColor: Colors.redAccent[200]
     ),
     routes: <String, RouteBuilder>{
-      '/': (RouteArguments args) => new DropdownDemo(),
+      '/': (RouteArguments args) => new DropDownDemo(),
     }
   ));
 }

--- a/packages/flutter/lib/src/material/bottom_sheet.dart
+++ b/packages/flutter/lib/src/material/bottom_sheet.dart
@@ -140,55 +140,32 @@ class _ModalBottomSheetState extends State<_ModalBottomSheet> {
   }
 }
 
-class _ModalBottomSheetRoute extends OverlayRoute {
-  _ModalBottomSheetRoute({ this.completer, this.builder });
+class _ModalBottomSheetRoute<T> extends PopupRoute<T> {
+  _ModalBottomSheetRoute({
+    Completer<T> completer,
+    this.builder
+  }) : super(completer: completer);
 
-  final Completer completer;
   final WidgetBuilder builder;
-  Performance performance;
 
-  void didPush(OverlayState overlay, OverlayEntry insertionPoint) {
-    performance = BottomSheet.createPerformance()
-      ..forward();
-    super.didPush(overlay, insertionPoint);
+  Duration get transitionDuration => _kBottomSheetDuration;
+  bool get barrierDismissable => true;
+  Color get barrierColor => Colors.black54;
+
+  Performance createPerformance() {
+    return BottomSheet.createPerformance();
   }
 
-  void didPop(dynamic result) {
-    completer.complete(result);
-    if (performance.isDismissed)
-      finished();
-    else
-      performance.reverse().then((_) { finished(); });
+  Widget buildPage(BuildContext context) {
+    return new _ModalBottomSheet(route: this);
   }
-
-  Widget _buildModalBarrier(BuildContext context) {
-    return new AnimatedModalBarrier(
-      color: new AnimatedColorValue(_kTransparent, end: _kBarrierColor, curve: Curves.ease),
-      performance: performance
-    );
-  }
-
-  Widget _buildBottomSheet(BuildContext context) {
-    return new Focus(
-      key: new GlobalObjectKey(this),
-      child: new _ModalBottomSheet(route: this)
-    );
-  }
-
-  List<WidgetBuilder> get builders => <WidgetBuilder>[
-    _buildModalBarrier,
-    _buildBottomSheet,
-  ];
-
-  String get debugLabel => '$runtimeType';
-  String toString() => '$runtimeType(performance: $performance)';
 }
 
 Future showModalBottomSheet({ BuildContext context, WidgetBuilder builder }) {
   assert(context != null);
   assert(builder != null);
   final Completer completer = new Completer();
-  Navigator.of(context).pushEphemeral(new _ModalBottomSheetRoute(
+  Navigator.of(context).push(new _ModalBottomSheetRoute(
     completer: completer,
     builder: builder
   ));

--- a/packages/flutter/lib/src/material/dialog.dart
+++ b/packages/flutter/lib/src/material/dialog.dart
@@ -115,13 +115,16 @@ class Dialog extends StatelessComponent {
   }
 }
 
-class _DialogRoute<T> extends ModalRoute<T> {
-  _DialogRoute({ Completer<T> completer, this.child }) : super(completer: completer);
+class _DialogRoute<T> extends PopupRoute<T> {
+  _DialogRoute({
+    Completer<T> completer,
+    this.child
+  }) : super(completer: completer);
 
   final Widget child;
 
-  bool get opaque => false;
   Duration get transitionDuration => const Duration(milliseconds: 150);
+  bool get barrierDismissable => true;
   Color get barrierColor => Colors.black54;
 
   Widget buildPage(BuildContext context) => child;

--- a/packages/flutter/lib/src/material/page.dart
+++ b/packages/flutter/lib/src/material/page.dart
@@ -5,6 +5,8 @@
 import 'package:flutter/animation.dart';
 import 'package:flutter/widgets.dart';
 
+import 'colors.dart';
+
 class _MaterialPageTransition extends TransitionWithChild {
   _MaterialPageTransition({
     Key key,
@@ -36,7 +38,7 @@ class _MaterialPageTransition extends TransitionWithChild {
   }
 }
 
-class MaterialPageRoute<T> extends ModalRoute<T> {
+class MaterialPageRoute<T> extends PageRoute<T> {
   MaterialPageRoute({
     this.builder,
     NamedRouteSettings settings: const NamedRouteSettings()
@@ -48,8 +50,8 @@ class MaterialPageRoute<T> extends ModalRoute<T> {
   final WidgetBuilder builder;
 
   Duration get transitionDuration => const Duration(milliseconds: 150);
-
-  bool get opaque => true;
+  bool get barrierDismissable => false;
+  Color get barrierColor => Colors.black54;
 
   Widget buildPage(BuildContext context) {
     Widget result = builder(context);

--- a/packages/flutter/lib/src/material/popup_menu.dart
+++ b/packages/flutter/lib/src/material/popup_menu.dart
@@ -53,13 +53,13 @@ class _PopupMenuPainter extends CustomPainter {
   }
 }
 
-class _PopupMenu extends StatelessComponent {
+class _PopupMenu<T> extends StatelessComponent {
   _PopupMenu({
     Key key,
     this.route
   }) : super(key: key);
 
-  final _MenuRoute route;
+  final _PopupMenuRoute<T> route;
 
   Widget build(BuildContext context) {
     double unit = 1.0 / (route.items.length + 1.5); // 1.0 for the width and 0.5 for the last item's fade.
@@ -118,11 +118,16 @@ class _PopupMenu extends StatelessComponent {
   }
 }
 
-class _MenuRoute extends ModalRoute {
-  _MenuRoute({ Completer completer, this.position, this.items, this.elevation }) : super(completer: completer);
+class _PopupMenuRoute<T> extends PopupRoute<T> {
+  _PopupMenuRoute({
+    Completer<T> completer,
+    this.position,
+    this.items,
+    this.elevation
+  }) : super(completer: completer);
 
   final ModalPosition position;
-  final List<PopupMenuItem> items;
+  final List<PopupMenuItem<T>> items;
   final int elevation;
 
   Performance createPerformance() {
@@ -133,15 +138,16 @@ class _MenuRoute extends ModalRoute {
     return result;
   }
 
-  bool get opaque => false;
   Duration get transitionDuration => _kMenuDuration;
+  bool get barrierDismissable => true;
+  Color get barrierColor => null;
 
   Widget buildPage(BuildContext context) => new _PopupMenu(route: this);
 }
 
 Future showMenu({ BuildContext context, ModalPosition position, List<PopupMenuItem> items, int elevation: 8 }) {
   Completer completer = new Completer();
-  Navigator.of(context).pushEphemeral(new _MenuRoute(
+  Navigator.of(context).push(new _PopupMenuRoute(
     completer: completer,
     position: position,
     items: items,

--- a/packages/flutter/lib/src/material/popup_menu_item.dart
+++ b/packages/flutter/lib/src/material/popup_menu_item.dart
@@ -9,7 +9,7 @@ import 'theme.dart';
 const double _kMenuItemHeight = 48.0;
 const double _kBaselineOffsetFromBottom = 20.0;
 
-class PopupMenuItem extends StatelessComponent {
+class PopupMenuItem<T> extends StatelessComponent {
   PopupMenuItem({
     Key key,
     this.value,
@@ -17,7 +17,7 @@ class PopupMenuItem extends StatelessComponent {
   }) : super(key: key);
 
   final Widget child;
-  final dynamic value;
+  final T value;
 
   Widget build(BuildContext context) {
     return new Container(

--- a/packages/flutter/lib/src/widgets/heroes.dart
+++ b/packages/flutter/lib/src/widgets/heroes.dart
@@ -12,7 +12,7 @@ import 'transitions.dart';
 // Heroes are the parts of an application's screen-to-screen transitions where a
 // component from one screen shifts to a position on the other. For example,
 // album art from a list of albums growing to become the centerpiece of the
-// album's details view. In this context, a screen is a navigator Route.
+// album's details view. In this context, a screen is a navigator ModalRoute.
 
 // To get this effect, all you have to do is wrap each hero on each route with a
 // Hero widget, and give each hero a tag. Tag must either be unique within the
@@ -50,7 +50,7 @@ import 'transitions.dart';
 // TODO(ianh): If the widgets use Inherited properties, they are taken from the
 // Navigator's position in the widget hierarchy, not the source or target. We
 // should interpolate the inherited properties from their value at the source to
-// their value at the target. See: https://github.com/flutter/engine/issues/1698
+// their value at the target. See: https://github.com/flutter/flutter/issues/213
 
 final Object centerOfAttentionHeroTag = new Object();
 

--- a/packages/flutter/lib/src/widgets/modal_barrier.dart
+++ b/packages/flutter/lib/src/widgets/modal_barrier.dart
@@ -9,12 +9,10 @@ import 'framework.dart';
 import 'navigator.dart';
 import 'transitions.dart';
 
-const Color kTransparent = const Color(0x00000000);
-
 class ModalBarrier extends StatelessComponent {
   ModalBarrier({
     Key key,
-    this.color: kTransparent,
+    this.color,
     this.dismissable: true
   }) : super(key: key);
 
@@ -27,9 +25,10 @@ class ModalBarrier extends StatelessComponent {
         if (dismissable)
           Navigator.of(context).pop();
       },
+      behavior: HitTestBehavior.opaque,
       child: new ConstrainedBox(
         constraints: const BoxConstraints.expand(),
-        child: new DecoratedBox(
+        child: color == null ? null : new DecoratedBox(
           decoration: new BoxDecoration(
             backgroundColor: color
           )


### PR DESCRIPTION
- Removed the concept of ephemeral routes.
- Renamed the two _MenuRoutes to _PopupMenuRoute and _DropDownRoute.
- Added type arguments in various places:
  - DropDownMenu
  - _DropDownRoute
  - _ModalBottomSheetRoute
  - PopupMenuItem
  - _PopupMenu
  - _PopupMenuRoute
- Made _ModalBottomSheetRoute, the two ex _MenuRoutes, and _DialogRoute
  all inherit from ModalRoute, via PopupRoute.
- Change "Dropdown" and "DropDown" to "DropDown" consistently.
- Made MaterialPageRoute inherit from PageRoute.
- Made ModalBarrier not create a box if it's always transparent.
- Exposed the Futures on TransitionRoutes.
- Fixed that menus were no longer dismissable by tapping the modal
  barrier.
