### PR TITLE
Assert: don't push a PageRoute over a PopupRoute.

### DIFF
--- a/packages/flutter/lib/src/widgets/routes.dart
+++ b/packages/flutter/lib/src/widgets/routes.dart
@@ -350,6 +350,10 @@ abstract class ModalRoute<T> extends TransitionRoute<T> {
 abstract class PopupRoute<T> extends ModalRoute<T> {
   PopupRoute({ Completer<T> completer }) : super(completer: completer);
   bool get opaque => false;
+  bool willPushNext(Route nextRoute) {
+    assert(nextRoute is! PageRoute);
+    return super.willPushNext(nextRoute);
+  }
 }
 
 /// A modal route that replaces the entire screen.


### PR DESCRIPTION
"Fixes" #389.
