### PR TITLE
Clean up the term "modal" in the navigator

### DIFF
--- a/packages/flutter/lib/src/widgets/hero_controller.dart
+++ b/packages/flutter/lib/src/widgets/hero_controller.dart
@@ -24,7 +24,7 @@ class HeroController extends NavigatorObserver {
 
   final List<OverlayEntry> _overlayEntries = new List<OverlayEntry>();
 
-  void didPushModal(Route route, Route previousRoute) {
+  void didPush(Route route, Route previousRoute) {
     assert(navigator != null);
     assert(route != null);
     if (route is ModalRoute) { // as opposed to StateRoute, say
@@ -37,7 +37,7 @@ class HeroController extends NavigatorObserver {
     }
   }
 
-  void didPopModal(Route route, Route previousRoute) {
+  void didPop(Route route, Route previousRoute) {
     assert(navigator != null);
     assert(route != null);
     if (route is ModalRoute) { // as opposed to StateRoute, say


### PR DESCRIPTION
Now we only use it for things related to ModalRoute and ModalBarrier.

(This is easy now that ephemeral routes are gone, so there's no other
kind of route to distinguish against.)

Fixes #388.
