### PR TITLE
Make dev/update-packages.dart more aggressive

### DIFF
--- a/dev/update_packages.dart
+++ b/dev/update_packages.dart
@@ -10,7 +10,7 @@ update(Directory directory) {
   for (FileSystemEntity dir in directory.listSync()) {
     if (dir is Directory) {
       print("Updating ${dir.path}...");
-      ProcessResult result = Process.runSync(binaryName, ['get'], workingDirectory: dir.path);
+      ProcessResult result = Process.runSync(binaryName, ['upgrade'], workingDirectory: dir.path);
       if (result.exitCode != 0) {
         print("... failed with exit code ${result.exitCode}.");
         print(result.stdout);


### PR DESCRIPTION
Now it uses `pub upgrade` rather than `pub get`.

This is good because if some of your packages are at one version and
some are at another, `flutter analyze` gets annoyed (it tries to test
everything with one set of packages). This way you move every package to
the latest versions all at once.
