### PR TITLE
Pin `package:test` to an exact revision

### DIFF
--- a/packages/cassowary/pubspec.yaml
+++ b/packages/cassowary/pubspec.yaml
@@ -6,6 +6,6 @@ homepage: https://github.com/flutter/flutter/tree/master/packages/cassowary
 environment:
   sdk: '>=1.0.0 <2.0.0'
 dev_dependencies:
-  test: '>=0.12.0 <0.13.0'
+  test: 0.12.5+2
   test_runner: '<=0.2.16'
   dart_coveralls: '<=0.3.0'

--- a/packages/flutter/pubspec.yaml
+++ b/packages/flutter/pubspec.yaml
@@ -11,6 +11,9 @@ dependencies:
   sky_services: 0.0.62
   vector_math: '>=1.4.3 <2.0.0'
 
+  # To pin the transitive dependency through mojo_sdk.
+  test: 0.12.5+2
+
   cassowary:
     path: ../cassowary
   newton:

--- a/packages/flutter_test/pubspec.yaml
+++ b/packages/flutter_test/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_test
 dependencies:
-  test: ^0.12.5
+  test: 0.12.5+2
   quiver: ^0.21.4
   flutter:
     path: ../flutter

--- a/packages/flutter_tools/pubspec.yaml
+++ b/packages/flutter_tools/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
   mustache4dart: ^1.0.0
   path: ^1.3.0
   stack_trace: ^1.4.0
-  test: ^0.12.5
+  test: 0.12.5+2
   yaml: ^2.1.3
 
   flx:

--- a/packages/flx/pubspec.yaml
+++ b/packages/flx/pubspec.yaml
@@ -13,4 +13,4 @@ environment:
   sdk: '>=1.12.0 <2.0.0'
 
 dev_dependencies:
-  test: ^0.12.5
+  test: 0.12.5+2

--- a/packages/newton/pubspec.yaml
+++ b/packages/newton/pubspec.yaml
@@ -6,6 +6,6 @@ homepage: https://github.com/flutter/flutter/tree/master/packages/newton
 environment:
   sdk: '>=1.0.0 <2.0.0'
 dev_dependencies:
-  test: '>=0.12.0 <0.13.0'
+  test: 0.12.5+2
   test_runner: '<=0.2.16'
   dart_coveralls: '<=0.3.0'

--- a/packages/playfair/pubspec.yaml
+++ b/packages/playfair/pubspec.yaml
@@ -9,7 +9,7 @@ dependencies:
     path: ../flutter
 
 dev_dependencies:
-  test: '>=0.12.0 <0.13.0'
+  test: 0.12.5+2
 
 environment:
   sdk: '>=1.12.0 <2.0.0'


### PR DESCRIPTION
We use a number of non-public APIs in the test package, which makes our
dependency quite fragile. This patch pins a specific, known-good version. We
should update to the lastest version in a follow-up patch.
