### PR TITLE
ignore .atom directories

### DIFF
--- a/examples/.gitignore
+++ b/examples/.gitignore
@@ -1,3 +1,4 @@
+.atom
 .DS_Store
 .buildlog
 .idea


### PR DESCRIPTION
Opening our repo, or our examples, with Atom, and then running an example, will generate this file.
