### PR TITLE
Remove StateRoutes

### DIFF
--- a/examples/stocks/lib/stock_home.dart
+++ b/examples/stocks/lib/stock_home.dart
@@ -24,8 +24,8 @@ class StockHomeState extends State<StockHome> {
   String _searchQuery;
 
   void _handleSearchBegin() {
-    Navigator.of(context).push(new StateRoute(
-      onPop: () {
+    ModalRoute.of(context).addLocalHistoryEntry(new LocalHistoryEntry(
+      onRemove: () {
         setState(() {
           _isSearching = false;
           _searchQuery = null;

--- a/packages/flutter/lib/src/material/drawer.dart
+++ b/packages/flutter/lib/src/material/drawer.dart
@@ -86,7 +86,7 @@ class _DrawerRoute extends OverlayRoute {
     );
   }
 
-  void didPop(dynamic result) {
+  bool didPop(dynamic result) {
     // we don't call the superclass because we want to control the timing of the
     // call to finished().
     switch (_state) {
@@ -101,6 +101,7 @@ class _DrawerRoute extends OverlayRoute {
         finished();
         break;
     }
+    return true;
   }
 }
 

--- a/packages/flutter/lib/src/material/material_app.dart
+++ b/packages/flutter/lib/src/material/material_app.dart
@@ -84,9 +84,7 @@ class _MaterialAppState extends State<MaterialApp> {
     if (event.type == 'back') {
       NavigatorState navigator = _navigator.currentState;
       assert(navigator != null);
-      if (navigator.hasPreviousRoute)
-        navigator.pop();
-      else
+      if (!navigator.pop())
         activity.finishCurrentActivity();
     }
   }

--- a/packages/flutter/lib/src/material/scaffold.dart
+++ b/packages/flutter/lib/src/material/scaffold.dart
@@ -175,8 +175,8 @@ class ScaffoldState extends State<Scaffold> {
     Performance performance = BottomSheet.createPerformance()
       ..forward();
     _PersistentBottomSheet bottomSheet;
-    Route route = new StateRoute(
-      onPop: () {
+    LocalHistoryEntry entry = new LocalHistoryEntry(
+      onRemove: () {
         assert(_currentBottomSheet._widget == bottomSheet);
         assert(bottomSheetKey.currentState != null);
         bottomSheetKey.currentState.close();
@@ -191,7 +191,7 @@ class ScaffoldState extends State<Scaffold> {
       performance: performance,
       onClosing: () {
         assert(_currentBottomSheet._widget == bottomSheet);
-        Navigator.of(context).remove(route);
+        entry.remove();
       },
       onDismissed: () {
         assert(_dismissedBottomSheets != null);
@@ -201,12 +201,12 @@ class ScaffoldState extends State<Scaffold> {
       },
       builder: builder
     );
-    Navigator.of(context).push(route);
+    ModalRoute.of(context).addLocalHistoryEntry(entry);
     setState(() {
       _currentBottomSheet = new ScaffoldFeatureController._(
         bottomSheet,
         completer,
-        () => Navigator.of(context).remove(route),
+        () => entry.remove(),
         setState
       );
     });

--- a/packages/flutter/lib/src/widgets/hero_controller.dart
+++ b/packages/flutter/lib/src/widgets/hero_controller.dart
@@ -27,9 +27,9 @@ class HeroController extends NavigatorObserver {
   void didPush(Route route, Route previousRoute) {
     assert(navigator != null);
     assert(route != null);
-    if (route is ModalRoute) { // as opposed to StateRoute, say
+    if (route is PageRoute) {
       assert(route.performance != null);
-      if (previousRoute is ModalRoute) // as opposed to the many other types of routes, or null
+      if (previousRoute is PageRoute) // could be null
         _from = previousRoute;
       _to = route;
       _performance = route.performance;
@@ -40,9 +40,9 @@ class HeroController extends NavigatorObserver {
   void didPop(Route route, Route previousRoute) {
     assert(navigator != null);
     assert(route != null);
-    if (route is ModalRoute) { // as opposed to StateRoute, say
+    if (route is PageRoute) {
       assert(route.performance != null);
-      if (previousRoute is ModalRoute) { // as opposed to the many other types of routes
+      if (previousRoute is PageRoute) {
         _to = previousRoute;
         _from = route;
         _performance = route.performance;

--- a/packages/unit/test/widget/heroes_test.dart
+++ b/packages/unit/test/widget/heroes_test.dart
@@ -15,7 +15,6 @@ final Map<String, RouteBuilder> routes = <String, RouteBuilder>{
     new Container(height: 100.0, width: 100.0),
     new Card(child: new Hero(tag: 'a', child: new Container(height: 100.0, width: 100.0, key: firstKey))),
     new Container(height: 100.0, width: 100.0),
-    new FlatButton(child: new Text('state route please'), onPressed: () => Navigator.of(args.context).push(new StateRoute())),
     new FlatButton(child: new Text('button'), onPressed: () => Navigator.of(args.context).pushNamed('/two')),
   ]),
   '/two': (RouteArguments args) => new Block([
@@ -33,76 +32,6 @@ void main() {
       tester.pumpWidget(new MaterialApp(routes: routes));
 
       // the initial setup.
-
-      expect(tester.findElementByKey(firstKey), isOnStage);
-      expect(tester.findElementByKey(firstKey), isInCard);
-      expect(tester.findElementByKey(secondKey), isNull);
-
-      tester.tap(tester.findText('button'));
-      tester.pump(); // begin navigation
-
-      // at this stage, the second route is off-stage, so that we can form the
-      // hero party.
-
-      expect(tester.findElementByKey(firstKey), isOnStage);
-      expect(tester.findElementByKey(firstKey), isInCard);
-      expect(tester.findElementByKey(secondKey), isOffStage);
-      expect(tester.findElementByKey(secondKey), isInCard);
-
-      tester.pump();
-
-      // at this stage, the heroes have just gone on their journey, we are
-      // seeing them at t=16ms. The original page no longer contains the hero.
-
-      expect(tester.findElementByKey(firstKey), isNull);
-      expect(tester.findElementByKey(secondKey), isOnStage);
-      expect(tester.findElementByKey(secondKey), isNotInCard);
-
-      tester.pump();
-
-      // t=32ms for the journey. Surely they are still at it.
-
-      expect(tester.findElementByKey(firstKey), isNull);
-      expect(tester.findElementByKey(secondKey), isOnStage);
-      expect(tester.findElementByKey(secondKey), isNotInCard);
-
-      tester.pump(new Duration(seconds: 1));
-
-      // t=1.032s for the journey. The journey has ended (it ends this frame, in
-      // fact). The hero should now be in the new page, on-stage.
-
-      expect(tester.findElementByKey(firstKey), isNull);
-      expect(tester.findElementByKey(secondKey), isOnStage);
-      expect(tester.findElementByKey(secondKey), isInCard);
-
-      tester.pump();
-
-      // Should not change anything.
-
-      expect(tester.findElementByKey(firstKey), isNull);
-      expect(tester.findElementByKey(secondKey), isOnStage);
-      expect(tester.findElementByKey(secondKey), isInCard);
-
-    });
-  });
-
-  test('Heroes animate even with intervening state routes', () {
-    testWidgets((WidgetTester tester) {
-
-      tester.pumpWidget(new Container()); // clear our memory
-
-      tester.pumpWidget(new MaterialApp(routes: routes));
-
-      // the initial setup.
-
-      expect(tester.findElementByKey(firstKey), isOnStage);
-      expect(tester.findElementByKey(firstKey), isInCard);
-      expect(tester.findElementByKey(secondKey), isNull);
-
-      // insert a state route
-
-      tester.tap(tester.findText('state route please'));
-      tester.pump();
 
       expect(tester.findElementByKey(firstKey), isOnStage);
       expect(tester.findElementByKey(firstKey), isInCard);


### PR DESCRIPTION
`Navigator.of(context).push(new StateRoute())`
...is now:
`ModalRoute.of(context).addLocalHistoryEntry(new LocalHistoryEntry())`
`StateRoute` and `LocalHistoryEntry` are similar, except `onPop` is now `onRemove` and `LocalHistoryEntry` has a `remove()` method that causes the local history entry to be removed.

`Route.didPop()` and `NavigatorState.pop()` now return a boolean saying whether or not the route or navigator (respectively) handled the pop itself.

Other changes:
- Heroes now trigger on `PageRoutes`, not `ModalRoutes`.
- `hasPreviousRoute` is gone.
- `NavigatorState.remove()` is gone.

A subsequent patch will simplify the `isCurrent` stuff which is now overengineered.

Fixes #553.
