### PR TITLE
print logging timestamps to profile app launch

### DIFF
--- a/packages/flutter_tools/lib/executable.dart
+++ b/packages/flutter_tools/lib/executable.dart
@@ -32,14 +32,21 @@ import 'src/process.dart';
 ///
 /// This function is intended to be used from the [flutter] command line tool.
 Future main(List<String> args) async {
+  DateTime startTime = new DateTime.now();
+
   // This level can be adjusted by users through the `--verbose` option.
   Logger.root.level = Level.WARNING;
   Logger.root.onRecord.listen((LogRecord record) {
+    String prefix = '';
+    if (Logger.root.level <= Level.FINE) {
+      Duration elapsed = record.time.difference(startTime);
+      prefix = '[${elapsed.inMilliseconds.toString().padLeft(4)} ms] ';
+    }
     String level = record.level.name.toLowerCase();
     if (record.level >= Level.WARNING) {
-      stderr.writeln('$level: ${record.message}');
+      stderr.writeln('$prefix$level: ${record.message}');
     } else {
-      print('$level: ${record.message}');
+      print('$prefix$level: ${record.message}');
     }
     if (record.error != null)
       stderr.writeln(record.error);

--- a/packages/flutter_tools/lib/src/commands/build.dart
+++ b/packages/flutter_tools/lib/src/commands/build.dart
@@ -9,6 +9,7 @@ import 'dart:typed_data';
 import 'package:archive/archive.dart';
 import 'package:flx/bundle.dart';
 import 'package:flx/signing.dart';
+import 'package:logging/logging.dart';
 import 'package:path/path.dart' as path;
 import 'package:yaml/yaml.dart';
 
@@ -20,6 +21,8 @@ const String _kSnapshotKey = 'snapshot_blob.bin';
 const List<String> _kDensities = const ['drawable-xxhdpi'];
 const List<String> _kThemes = const ['white', 'black'];
 const List<int> _kSizes = const [18, 24, 36, 48];
+
+final Logger _logging = new Logger('flutter_tools.build');
 
 class _Asset {
   final String base;
@@ -179,6 +182,8 @@ class BuildCommand extends FlutterCommand {
     String privateKeyPath: _kDefaultPrivateKeyPath,
     bool precompiledSnapshot: false
   }) async {
+    _logging.fine('Building $outputPath');
+
     Map manifestDescriptor = _loadManifest(manifestPath);
 
     Iterable<_Asset> assets = _parseAssets(manifestDescriptor, manifestPath);

--- a/packages/flutter_tools/lib/src/commands/daemon.dart
+++ b/packages/flutter_tools/lib/src/commands/daemon.dart
@@ -25,8 +25,6 @@ final Logger _logging = new Logger('flutter_tools.daemon');
 // TODO: Create a `device` domain in order to list devices and fire events when
 // devices are added or removed.
 
-// TODO: Is this the best name? Server? Daemon?
-
 /// A server process command. This command will start up a long-lived server.
 /// It reads JSON-RPC based commands from stdin, executes them, and returns
 /// JSON-RPC based responses and events to stdout.

--- a/packages/flutter_tools/lib/src/device.dart
+++ b/packages/flutter_tools/lib/src/device.dart
@@ -43,6 +43,8 @@ abstract class Device {
 
   /// Stop an app package on the current device
   Future<bool> stopApp(ApplicationPackage app);
+
+  String toString() => '$runtimeType $id';
 }
 
 class IOSDevice extends Device {
@@ -773,6 +775,8 @@ class AndroidDevice extends Device {
     bool checked,
     String route
   }) {
+    _logging.fine('$this startBundle');
+
     if (!FileSystemEntity.isFileSync(bundlePath)) {
       _logging.severe('Cannot find $bundlePath');
       return false;

--- a/packages/flutter_tools/lib/src/process.dart
+++ b/packages/flutter_tools/lib/src/process.dart
@@ -87,16 +87,14 @@ String _runWithLoggingSync(List<String> cmd, {
   if (results.exitCode != 0) {
     String errorDescription = 'Error code ${results.exitCode} '
         'returned when attempting to run command: ${cmd.join(' ')}';
-    _logging.fine(errorDescription);
-    if (results.stderr.length > 0) {
+    _logging.info(errorDescription);
+    if (results.stderr.length > 0)
       _logging.info('Errors logged: ${results.stderr.trim()}');
-    }
-
-    if (checked) {
+    if (checked)
       throw errorDescription;
-    }
   }
-  _logging.fine(results.stdout.trim());
+  if (results.stdout.trim().isNotEmpty)
+    _logging.fine(results.stdout.trim());
   return results.stdout;
 }
 


### PR DESCRIPTION
- print logging timestamps to profile app launch

`flutter start` takes 3 seconds now - this PR will help us determine where the time is going. Even after the flutter start process finishes it still takes ~2 seconds for the app to finish coming up on the device. Some sample output:

```
[  36 ms] fine: downloading toolchain
[  58 ms] info: /Users/devoncarew/tools/android-sdk-macosx/platform-tools/adb version
[  88 ms] fine: Android Debug Bridge version 1.0.32
Revision eac51f2bb6a8-android
[  88 ms] info: /Users/devoncarew/tools/android-sdk-macosx/platform-tools/adb devices -l
[ 107 ms] fine: List of devices attached
TA95000FQA             device usb:336592896X product:peregrine_retus model:XT1045 device:peregrine
[ 123 ms] info: /Users/devoncarew/tools/android-sdk-macosx/platform-tools/adb version
[ 142 ms] fine: Android Debug Bridge version 1.0.32
Revision eac51f2bb6a8-android
[ 144 ms] info: /Users/devoncarew/tools/android-sdk-macosx/platform-tools/adb -s TA95000FQA start-server
[ 165 ms] info: /Users/devoncarew/tools/android-sdk-macosx/platform-tools/adb -s TA95000FQA shell echo ready
[ 245 ms] fine: ready
[ 245 ms] info: /Users/devoncarew/tools/android-sdk-macosx/platform-tools/adb -s TA95000FQA shell getprop ro.build.version.sdk
[ 295 ms] fine: 22
[ 296 ms] fine: running stop command
[ 297 ms] fine: running install command
[ 299 ms] info: /Users/devoncarew/tools/android-sdk-macosx/platform-tools/adb -s TA95000FQA shell pm path org.domokit.sky.shell
[ 849 ms] fine: package:/data/app/org.domokit.sky.shell-1/base.apk
[ 849 ms] info: /Users/devoncarew/tools/android-sdk-macosx/platform-tools/adb -s TA95000FQA shell cat /data/local/tmp/sky.org.domokit.sky.shell.sha1
[ 890 ms] fine: 6fb28f1667ab7117cfb36f85084f60c46b21a449
[1073 ms] fine: running build command for AndroidDevice TA95000FQA
[1075 ms] info: /Users/devoncarew/tools/android-sdk-macosx/platform-tools/adb -s TA95000FQA shell am force-stop org.domokit.sky.shell
[1802 ms] fine: Building /var/folders/00/0w978000h01000cxqpysvccm003j4x/T/flutter_toolsZuwAC7/app.flx
[1854 ms] info: /Users/devoncarew/projects/flutter/flutter/bin/cache/artifacts/sky_engine/b792ca37fa59b75ec00657c33be86288de060d65/Release/darwin-x64/sky_snapshot /Users/devoncarew/projects/flutter/flutter/examples/material_gallery/lib/main.dart --package-root=packages --snapshot=/var/folders/00/0w978000h01000cxqpysvccm003j4x/T/flutter_toolsZuwAC7/snapshot_blob.bin
[2455 ms] fine: running start bundle for AndroidDevice TA95000FQA
[2455 ms] fine: AndroidDevice TA95000FQA startBundle
[2455 ms] info: /Users/devoncarew/tools/android-sdk-macosx/platform-tools/adb -s TA95000FQA forward tcp:8181 tcp:8181
[2478 ms] info: /Users/devoncarew/tools/android-sdk-macosx/platform-tools/adb -s TA95000FQA push /var/folders/00/0w978000h01000cxqpysvccm003j4x/T/flutter_toolsZuwAC7/app.flx /data/local/tmp/dev.flx
[2575 ms] info: /Users/devoncarew/tools/android-sdk-macosx/platform-tools/adb -s TA95000FQA shell am start -a android.intent.action.RUN -d /data/local/tmp/dev.flx --ez enable-checked-mode true org.domokit.sky.shell/org.domokit.sky.shell.SkyActivity
[3218 ms] fine: Starting: Intent { act=android.intent.action.RUN dat=/data/local/tmp/dev.flx cmp=org.domokit.sky.shell/.SkyActivity (has extras) }
[3219 ms] fine: finished start command
```
