### PR TITLE
Clean up the Navigator API again.

### DIFF
--- a/packages/flutter/lib/src/widgets/overlay.dart
+++ b/packages/flutter/lib/src/widgets/overlay.dart
@@ -52,8 +52,7 @@ class OverlayState extends State<Overlay> {
 
   void initState() {
     super.initState();
-    for (OverlayEntry entry in config.initialEntries)
-      insert(entry);
+    insertAll(config.initialEntries);
   }
 
   void insert(OverlayEntry entry, { OverlayEntry above }) {


### PR DESCRIPTION
- Split didPush() into didPush() and install(), so that we can install
  the overlays without triggering the push logic. This will be used in a
  subsequent patch to implement route replacement.
- Split didPop() into didPop() and dispose(), so that we can remove
  overlays without triggering the pop logic. Also for a subsequent patch
  that implements replacement.
- Clean up _navigator on the routes when the Navigator itself is
  disposed.
- Drop the forwarding logic on willPushNext() -- now didPushNext() --
  and didPopNext(), since we no longer have StateRoutes to get in the
  way.
- Implement isCurrent more broadly and without having to keep track of
  state.
- Provide some toString()s on NamedRouteSettings and ModalRoutes.
- Make OverlayState.initState() use the insertAl functionality.
- Make OverlayRoute.builders abstract since that way you'll catch when
  you forget to do it. If you don't want overlays, don't inherit from
  this class.
- Made handleStatusChanged() on TransitionRoute public so that it can be
  overridden by subclasses.
