### PR TITLE
Operators needed to lerp a FractionalOffset.

### DIFF
--- a/packages/flutter/lib/src/painting/box_painter.dart
+++ b/packages/flutter/lib/src/painting/box_painter.dart
@@ -1110,6 +1110,15 @@ class FractionalOffset {
   const FractionalOffset(this.x, this.y);
   final double x;
   final double y;
+  FractionalOffset operator -(FractionalOffset other) {
+    return new FractionalOffset(x - other.x, y - other.y);
+  }
+  FractionalOffset operator +(FractionalOffset other) {
+    return new FractionalOffset(x + other.x, y + other.y);
+  }
+  FractionalOffset operator *(double other) {
+    return new FractionalOffset(x * other, y * other);
+  }
   bool operator ==(dynamic other) {
     if (other is! FractionalOffset)
       return false;


### PR DESCRIPTION
Without this, you can't use AnimatedValue<FractionalOffset>, because its
lerp() function uses the operators.
