### PR TITLE
Make Drawer stateful again

### DIFF
--- a/examples/fitness/lib/feed.dart
+++ b/examples/fitness/lib/feed.dart
@@ -63,31 +63,28 @@ class FeedFragmentState extends State<FeedFragment> {
     Navigator.of(context).pop();
   }
 
-  void _showDrawer() {
-    showDrawer(
-      context: context,
-      child: new Block(<Widget>[
-        new DrawerHeader(child: new Text('Fitness')),
-        new DrawerItem(
-          icon: 'action/view_list',
-          onPressed: () => _handleFitnessModeChange(FitnessMode.feed),
-          selected: _fitnessMode == FitnessMode.feed,
-          child: new Text('Feed')),
-        new DrawerItem(
-          icon: 'action/assessment',
-          onPressed: () => _handleFitnessModeChange(FitnessMode.chart),
-          selected: _fitnessMode == FitnessMode.chart,
-          child: new Text('Chart')),
-        new DrawerDivider(),
-        new DrawerItem(
-          icon: 'action/settings',
-          onPressed: _handleShowSettings,
-          child: new Text('Settings')),
-        new DrawerItem(
-          icon: 'action/help',
-          child: new Text('Help & Feedback'))
-      ])
-    );
+  Widget _buildDrawer(BuildContext context) {
+    return new Block(<Widget>[
+      new DrawerHeader(child: new Text('Fitness')),
+      new DrawerItem(
+        icon: 'action/view_list',
+        onPressed: () => _handleFitnessModeChange(FitnessMode.feed),
+        selected: _fitnessMode == FitnessMode.feed,
+        child: new Text('Feed')),
+      new DrawerItem(
+        icon: 'action/assessment',
+        onPressed: () => _handleFitnessModeChange(FitnessMode.chart),
+        selected: _fitnessMode == FitnessMode.chart,
+        child: new Text('Chart')),
+      new DrawerDivider(),
+      new DrawerItem(
+        icon: 'action/settings',
+        onPressed: _handleShowSettings,
+        child: new Text('Settings')),
+      new DrawerItem(
+        icon: 'action/help',
+        child: new Text('Help & Feedback'))
+    ]);
   }
 
   void _handleShowSettings() {
@@ -107,7 +104,8 @@ class FeedFragmentState extends State<FeedFragment> {
     return new ToolBar(
       left: new IconButton(
         icon: "navigation/menu",
-        onPressed: _showDrawer),
+        onPressed: () { showDrawer(context: context, builder: _buildDrawer ); }
+      ),
       center: new Text(fitnessModeTitle)
     );
   }

--- a/examples/material_gallery/lib/gallery_page.dart
+++ b/examples/material_gallery/lib/gallery_page.dart
@@ -13,7 +13,7 @@ class GalleryPage extends StatelessComponent {
   final WidgetDemo active;
   final ValueChanged<ThemeData> onThemeChanged;
 
-  void _showDrawer(BuildContext context) {
+  Widget _buildDrawer(BuildContext context) {
     List<Widget> items = <Widget>[
       new DrawerHeader(child: new Text('Material demos')),
     ];
@@ -27,7 +27,7 @@ class GalleryPage extends StatelessComponent {
       ));
     }
 
-    showDrawer(context: context, child: new Block(items));
+    return new Block(items);
   }
 
   Widget _body(BuildContext context) {
@@ -45,7 +45,7 @@ class GalleryPage extends StatelessComponent {
       toolBar: new ToolBar(
         left: new IconButton(
           icon: 'navigation/menu',
-          onPressed: () { _showDrawer(context); }
+          onPressed: () { showDrawer(context: context, builder: _buildDrawer); }
         ),
         center: new Text(active?.title ?? 'Material gallery')
       ),

--- a/examples/stocks/lib/global_settings.dart
+++ b/examples/stocks/lib/global_settings.dart
@@ -1,0 +1,38 @@
+// Copyright 2015 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+part of stocks;
+
+enum OptimismMode { optimistic, pessimistic }
+enum BackupMode { enabled, disabled }
+
+class GlobalSettings {
+  GlobalSettings({
+    OptimismMode optimism: OptimismMode.optimistic,
+    BackupMode backup: BackupMode.disabled,
+    VoidCallback onChanged
+  }) : _optimism = optimism,
+       _backup = backup,
+       _onChanged = onChanged;
+
+  OptimismMode get optimism => _optimism;
+  OptimismMode _optimism;
+  void set optimism(OptimismMode value) {
+    if (_optimism == value)
+      return;
+    _optimism = value;
+    _onChanged();
+  }
+
+  BackupMode get backup => _backup;
+  BackupMode _backup;
+  void set backup(BackupMode value) {
+    if (_backup == value)
+      return;
+    _backup = value;
+    _onChanged();
+  }
+
+  VoidCallback _onChanged;
+}

--- a/examples/stocks/lib/main.dart
+++ b/examples/stocks/lib/main.dart
@@ -15,6 +15,7 @@ import 'package:flutter/rendering.dart';
 
 import 'stock_data.dart';
 
+part 'global_settings.dart';
 part 'stock_arrow.dart';
 part 'stock_home.dart';
 part 'stock_list.dart';
@@ -22,7 +23,6 @@ part 'stock_menu.dart';
 part 'stock_row.dart';
 part 'stock_settings.dart';
 part 'stock_symbol_viewer.dart';
-part 'stock_types.dart';
 
 class StocksApp extends StatefulComponent {
   StocksAppState createState() => new StocksAppState();
@@ -35,6 +35,7 @@ class StocksAppState extends State<StocksApp> {
 
   void initState() {
     super.initState();
+    _settings = new GlobalSettings(onChanged: _handleSettingsChanged);
     new StockDataFetcher((StockData data) {
       setState(() {
         data.appendTo(_stocks, _symbols);
@@ -42,30 +43,19 @@ class StocksAppState extends State<StocksApp> {
     });
   }
 
-  StockMode _optimismSetting = StockMode.optimistic;
-  BackupMode _backupSetting = BackupMode.disabled;
-  void modeUpdater(StockMode optimism) {
-    setState(() {
-      _optimismSetting = optimism;
-    });
-  }
-  void settingsUpdater({ StockMode optimism, BackupMode backup }) {
-    setState(() {
-      if (optimism != null)
-        _optimismSetting = optimism;
-      if (backup != null)
-        _backupSetting = backup;
-    });
+  GlobalSettings _settings;
+  void _handleSettingsChanged() {
+    setState(() { });
   }
 
   ThemeData get theme {
-    switch (_optimismSetting) {
-      case StockMode.optimistic:
+    switch (_settings.optimism) {
+      case OptimismMode.optimistic:
         return new ThemeData(
           brightness: ThemeBrightness.light,
           primarySwatch: Colors.purple
         );
-      case StockMode.pessimistic:
+      case OptimismMode.pessimistic:
         return new ThemeData(
           brightness: ThemeBrightness.dark,
           accentColor: Colors.redAccent[200]
@@ -92,8 +82,8 @@ class StocksAppState extends State<StocksApp> {
       title: 'Stocks',
       theme: theme,
       routes: <String, RouteBuilder>{
-         '/':         (RouteArguments args) => new StockHome(_stocks, _symbols, _optimismSetting, modeUpdater),
-         '/settings': (RouteArguments args) => new StockSettings(_optimismSetting, _backupSetting, settingsUpdater)
+         '/':         (_) => new StockHome(_stocks, _symbols, _settings),
+         '/settings': (_) => new StockSettings(_settings)
       },
       onGenerateRoute: _getRoute
     );

--- a/examples/stocks/lib/stock_home.dart
+++ b/examples/stocks/lib/stock_home.dart
@@ -4,20 +4,17 @@
 
 part of stocks;
 
-typedef void ModeUpdater(StockMode mode);
-
 class StockHome extends StatefulComponent {
-  StockHome(this.stocks, this.symbols, this.stockMode, this.modeUpdater);
+  StockHome(this.stocks, this.symbols, this.settings);
 
   final Map<String, Stock> stocks;
   final List<String> symbols;
-  final StockMode stockMode;
-  final ModeUpdater modeUpdater;
+  final GlobalSettings settings;
 
-  StockHomeState createState() => new StockHomeState();
+  _StockHomeState createState() => new _StockHomeState();
 }
 
-class StockHomeState extends State<StockHome> {
+class _StockHomeState extends State<StockHome> {
 
   final GlobalKey scaffoldKey = new GlobalKey();
   bool _isSearching = false;
@@ -54,9 +51,8 @@ class StockHomeState extends State<StockHome> {
     });
   }
 
-  void _handleStockModeChange(StockMode value) {
-    if (config.modeUpdater != null)
-      config.modeUpdater(value);
+  void _handleOptimismChanged(OptimismMode optimism) {
+    config.settings.optimism = optimism;
   }
 
   void _handleMenuShow() {
@@ -67,75 +63,72 @@ class StockHomeState extends State<StockHome> {
     );
   }
 
-  void _showDrawer() {
-    showDrawer(
-      context: context,
-      child: new Block(<Widget>[
-        new DrawerHeader(child: new Text('Stocks')),
-        new DrawerItem(
-          icon: 'action/assessment',
-          selected: true,
-          child: new Text('Stock List')
-        ),
-        new DrawerItem(
-          icon: 'action/account_balance',
-          onPressed: () {
-            showDialog(
-              context: context,
-              child: new Dialog(
-                title: new Text('Not Implemented'),
-                content: new Text('This feature has not yet been implemented.'),
-                actions: <Widget>[
-                  new FlatButton(
-                    child: new Text('USE IT'),
-                    onPressed: () {
-                      Navigator.of(context).pop(false);
-                    }
-                  ),
-                  new FlatButton(
-                    child: new Text('OH WELL'),
-                    onPressed: () {
-                      Navigator.of(context).pop(false);
-                    }
-                  ),
-                ]
-              )
-            );
-          },
-          child: new Text('Account Balance')
-        ),
-        new DrawerItem(
-          icon: 'device/dvr',
-          onPressed: () { debugDumpApp(); debugDumpRenderTree(); debugDumpLayerTree(); },
-          child: new Text('Dump App to Console')
-        ),
-        new DrawerDivider(),
-        new DrawerItem(
-          icon: 'action/thumb_up',
-          onPressed: () => _handleStockModeChange(StockMode.optimistic),
-          child: new Row(<Widget>[
-            new Flexible(child: new Text('Optimistic')),
-            new Radio<StockMode>(value: StockMode.optimistic, groupValue: config.stockMode, onChanged: _handleStockModeChange)
-          ])
-        ),
-        new DrawerItem(
-          icon: 'action/thumb_down',
-          onPressed: () => _handleStockModeChange(StockMode.pessimistic),
-          child: new Row(<Widget>[
-            new Flexible(child: new Text('Pessimistic')),
-            new Radio<StockMode>(value: StockMode.pessimistic, groupValue: config.stockMode, onChanged: _handleStockModeChange)
-          ])
-        ),
-        new DrawerDivider(),
-        new DrawerItem(
-          icon: 'action/settings',
-          onPressed: _handleShowSettings,
-          child: new Text('Settings')),
-        new DrawerItem(
-          icon: 'action/help',
-          child: new Text('Help & Feedback'))
-      ])
-    );
+  Widget _buildDrawer(BuildContext context) {
+    return new Block(<Widget>[
+      new DrawerHeader(child: new Text('Stocks')),
+      new DrawerItem(
+        icon: 'action/assessment',
+        selected: true,
+        child: new Text('Stock List')
+      ),
+      new DrawerItem(
+        icon: 'action/account_balance',
+        onPressed: () {
+          showDialog(
+            context: context,
+            child: new Dialog(
+              title: new Text('Not Implemented'),
+              content: new Text('This feature has not yet been implemented.'),
+              actions: <Widget>[
+                new FlatButton(
+                  child: new Text('USE IT'),
+                  onPressed: () {
+                    Navigator.of(context).pop(false);
+                  }
+                ),
+                new FlatButton(
+                  child: new Text('OH WELL'),
+                  onPressed: () {
+                    Navigator.of(context).pop(false);
+                  }
+                ),
+              ]
+            )
+          );
+        },
+        child: new Text('Account Balance')
+      ),
+      new DrawerItem(
+        icon: 'device/dvr',
+        onPressed: () { debugDumpApp(); debugDumpRenderTree(); debugDumpLayerTree(); },
+        child: new Text('Dump App to Console')
+      ),
+      new DrawerDivider(),
+      new DrawerItem(
+        icon: 'action/thumb_up',
+        onPressed: () => _handleOptimismChanged(OptimismMode.optimistic),
+        child: new Row(<Widget>[
+          new Flexible(child: new Text('Optimistic')),
+          new Radio<OptimismMode>(value: OptimismMode.optimistic, groupValue: config.settings.optimism, onChanged: _handleOptimismChanged)
+        ])
+      ),
+      new DrawerItem(
+        icon: 'action/thumb_down',
+        onPressed: () => _handleOptimismChanged(OptimismMode.pessimistic),
+        child: new Row(<Widget>[
+          new Flexible(child: new Text('Pessimistic')),
+          new Radio<OptimismMode>(value: OptimismMode.pessimistic, groupValue: config.settings.optimism, onChanged: _handleOptimismChanged)
+        ])
+      ),
+      new DrawerDivider(),
+      new DrawerItem(
+        icon: 'action/settings',
+        onPressed: _handleShowSettings,
+        child: new Text('Settings')),
+      new DrawerItem(
+        icon: 'action/help',
+        child: new Text('Help & Feedback'))
+    ]);
   }
 
   void _handleShowSettings() {
@@ -148,7 +141,7 @@ class StockHomeState extends State<StockHome> {
       elevation: 0,
       left: new IconButton(
         icon: "navigation/menu",
-        onPressed: _showDrawer
+        onPressed: () { showDrawer(context: context, builder: _buildDrawer ); }
       ),
       center: new Text('Stocks'),
       right: <Widget>[

--- a/examples/stocks/lib/stock_settings.dart
+++ b/examples/stocks/lib/stock_settings.dart
@@ -4,37 +4,31 @@
 
 part of stocks;
 
-typedef void SettingsUpdater({
-  StockMode optimism,
-  BackupMode backup
-});
-
 class StockSettings extends StatefulComponent {
-  const StockSettings(this.optimism, this.backup, this.updater);
+  const StockSettings(this.settings);
 
-  final StockMode optimism;
-  final BackupMode backup;
-  final SettingsUpdater updater;
+  final GlobalSettings settings;
 
-  StockSettingsState createState() => new StockSettingsState();
+  _StockSettingsState createState() => new _StockSettingsState();
 }
 
-class StockSettingsState extends State<StockSettings> {
+class _StockSettingsState extends State<StockSettings> {
   void _handleOptimismChanged(bool value) {
     value ??= false;
-    sendUpdates(value ? StockMode.optimistic : StockMode.pessimistic, config.backup);
+    config.settings.optimism = value ? OptimismMode.optimistic : OptimismMode.pessimistic;
   }
 
   void _handleBackupChanged(bool value) {
-    sendUpdates(config.optimism, value ? BackupMode.enabled : BackupMode.disabled);
+    value ??= false;
+    config.settings.backup = value ? BackupMode.enabled : BackupMode.disabled;
   }
 
   void _confirmOptimismChange() {
     switch (config.optimism) {
-      case StockMode.optimistic:
+      case OptimismMode.optimistic:
         _handleOptimismChanged(false);
         break;
-      case StockMode.pessimistic:
+      case OptimismMode.pessimistic:
         showDialog(
           context: context,
           child: new Dialog(
@@ -60,14 +54,6 @@ class StockSettingsState extends State<StockSettings> {
     }
   }
 
-  void sendUpdates(StockMode optimism, BackupMode backup) {
-    if (config.updater != null)
-      config.updater(
-        optimism: optimism,
-        backup: backup
-      );
-  }
-
   Widget buildToolBar(BuildContext context) {
     return new ToolBar(
       left: new IconButton(
@@ -88,7 +74,7 @@ class StockSettingsState extends State<StockSettings> {
           child: new Row(<Widget>[
             new Flexible(child: new Text('Everything is awesome')),
             new Checkbox(
-              value: config.optimism == StockMode.optimistic,
+              value: config.optimism == OptimismMode.optimistic,
               onChanged: (bool value) => _confirmOptimismChange()
             ),
           ])

--- a/examples/stocks/lib/stock_types.dart
+++ b/examples/stocks/lib/stock_types.dart
@@ -1,8 +1,0 @@
-// Copyright 2015 The Chromium Authors. All rights reserved.
-// Use of this source code is governed by a BSD-style license that can be
-// found in the LICENSE file.
-
-part of stocks;
-
-enum StockMode { optimistic, pessimistic }
-enum BackupMode { enabled, disabled }

--- a/examples/widgets/card_collection.dart
+++ b/examples/widgets/card_collection.dart
@@ -117,39 +117,36 @@ class CardCollectionState extends State<CardCollection> {
     }
   }
 
-  void _showDrawer() {
-    showDrawer(
-      context: context,
-      child: new IconTheme(
-        data: const IconThemeData(color: IconThemeColor.black),
-        child: new Block(<Widget>[
-          new DrawerHeader(child: new Text('Options')),
-          buildDrawerCheckbox("Make card labels editable", _editable, _toggleEditable),
-          buildDrawerCheckbox("Snap fling scrolls to center", _snapToCenter, _toggleSnapToCenter),
-          buildDrawerCheckbox("Fixed size cards", _fixedSizeCards, _toggleFixedSizeCards),
-          buildDrawerCheckbox("Let the sun shine", _sunshine, _toggleSunshine),
-          buildDrawerCheckbox("Vary font sizes", _varyFontSizes, _toggleVaryFontSizes, enabled: !_editable),
-          new DrawerDivider(),
-          buildDrawerColorRadioItem("Deep Purple", Colors.deepPurple, _primaryColor, _selectColor),
-          buildDrawerColorRadioItem("Green", Colors.green, _primaryColor, _selectColor),
-          buildDrawerColorRadioItem("Amber", Colors.amber, _primaryColor, _selectColor),
-          buildDrawerColorRadioItem("Teal", Colors.teal, _primaryColor, _selectColor),
-          new DrawerDivider(),
-          buildDrawerDirectionRadioItem("Dismiss horizontally", DismissDirection.horizontal, _dismissDirection, _changeDismissDirection, icon: 'action/code'),
-          buildDrawerDirectionRadioItem("Dismiss left", DismissDirection.left, _dismissDirection, _changeDismissDirection, icon: 'navigation/arrow_back'),
-          buildDrawerDirectionRadioItem("Dismiss right", DismissDirection.right, _dismissDirection, _changeDismissDirection, icon: 'navigation/arrow_forward'),
-          new DrawerDivider(),
-          buildFontRadioItem("Left-align text", new TextStyle(textAlign: TextAlign.left), _textStyle, _changeTextStyle, icon: 'editor/format_align_left', enabled: !_editable),
-          buildFontRadioItem("Center-align text", new TextStyle(textAlign: TextAlign.center), _textStyle, _changeTextStyle, icon: 'editor/format_align_center', enabled: !_editable),
-          buildFontRadioItem("Right-align text", new TextStyle(textAlign: TextAlign.right), _textStyle, _changeTextStyle, icon: 'editor/format_align_right', enabled: !_editable),
-          new DrawerDivider(),
-          new DrawerItem(
-            icon: 'device/dvr',
-            onPressed: () { debugDumpApp(); debugDumpRenderTree(); },
-            child: new Text('Dump App to Console')
-          ),
-        ])
-      )
+  Widget _buildDrawer(BuildContext context) {
+    return new IconTheme(
+      data: const IconThemeData(color: IconThemeColor.black),
+      child: new Block(<Widget>[
+        new DrawerHeader(child: new Text('Options')),
+        buildDrawerCheckbox("Make card labels editable", _editable, _toggleEditable),
+        buildDrawerCheckbox("Snap fling scrolls to center", _snapToCenter, _toggleSnapToCenter),
+        buildDrawerCheckbox("Fixed size cards", _fixedSizeCards, _toggleFixedSizeCards),
+        buildDrawerCheckbox("Let the sun shine", _sunshine, _toggleSunshine),
+        buildDrawerCheckbox("Vary font sizes", _varyFontSizes, _toggleVaryFontSizes, enabled: !_editable),
+        new DrawerDivider(),
+        buildDrawerColorRadioItem("Deep Purple", Colors.deepPurple, _primaryColor, _selectColor),
+        buildDrawerColorRadioItem("Green", Colors.green, _primaryColor, _selectColor),
+        buildDrawerColorRadioItem("Amber", Colors.amber, _primaryColor, _selectColor),
+        buildDrawerColorRadioItem("Teal", Colors.teal, _primaryColor, _selectColor),
+        new DrawerDivider(),
+        buildDrawerDirectionRadioItem("Dismiss horizontally", DismissDirection.horizontal, _dismissDirection, _changeDismissDirection, icon: 'action/code'),
+        buildDrawerDirectionRadioItem("Dismiss left", DismissDirection.left, _dismissDirection, _changeDismissDirection, icon: 'navigation/arrow_back'),
+        buildDrawerDirectionRadioItem("Dismiss right", DismissDirection.right, _dismissDirection, _changeDismissDirection, icon: 'navigation/arrow_forward'),
+        new DrawerDivider(),
+        buildFontRadioItem("Left-align text", new TextStyle(textAlign: TextAlign.left), _textStyle, _changeTextStyle, icon: 'editor/format_align_left', enabled: !_editable),
+        buildFontRadioItem("Center-align text", new TextStyle(textAlign: TextAlign.center), _textStyle, _changeTextStyle, icon: 'editor/format_align_center', enabled: !_editable),
+        buildFontRadioItem("Right-align text", new TextStyle(textAlign: TextAlign.right), _textStyle, _changeTextStyle, icon: 'editor/format_align_right', enabled: !_editable),
+        new DrawerDivider(),
+        new DrawerItem(
+          icon: 'device/dvr',
+          onPressed: () { debugDumpApp(); debugDumpRenderTree(); },
+          child: new Text('Dump App to Console')
+        ),
+      ])
     );
   }
 
@@ -267,7 +264,10 @@ class CardCollectionState extends State<CardCollection> {
 
   Widget buildToolBar() {
     return new ToolBar(
-      left: new IconButton(icon: "navigation/menu", onPressed: _showDrawer),
+      left: new IconButton(
+        icon: "navigation/menu",
+        onPressed: () { showDrawer(context: context, builder: _buildDrawer); }
+      ),
       right: <Widget>[
         new Text(_dismissDirectionText(_dismissDirection))
       ],

--- a/examples/widgets/pageable_list.dart
+++ b/examples/widgets/pageable_list.dart
@@ -83,37 +83,37 @@ class PageableListAppState extends State<PageableListApp> {
     });
   }
 
-  void _showDrawer() {
-    showDrawer(
-      context: context,
-      child: new Block(<Widget>[
-        new DrawerHeader(child: new Text('Options')),
-        new DrawerItem(
-          icon: 'navigation/more_horiz',
-          selected: scrollDirection == ScrollDirection.horizontal,
-          child: new Text('Horizontal Layout'),
-          onPressed: switchScrollDirection
-        ),
-        new DrawerItem(
-          icon: 'navigation/more_vert',
-          selected: scrollDirection == ScrollDirection.vertical,
-          child: new Text('Vertical Layout'),
-          onPressed: switchScrollDirection
-        ),
-        new DrawerItem(
-          onPressed: toggleItemsWrap,
-          child: new Row(<Widget>[
-            new Flexible(child: new Text('Scrolling wraps around')),
-            new Checkbox(value: itemsWrap)
-          ])
-        )
-      ])
-    );
+  Widget _buildDrawer(BuildContext context) {
+    return new Block(<Widget>[
+      new DrawerHeader(child: new Text('Options')),
+      new DrawerItem(
+        icon: 'navigation/more_horiz',
+        selected: scrollDirection == ScrollDirection.horizontal,
+        child: new Text('Horizontal Layout'),
+        onPressed: switchScrollDirection
+      ),
+      new DrawerItem(
+        icon: 'navigation/more_vert',
+        selected: scrollDirection == ScrollDirection.vertical,
+        child: new Text('Vertical Layout'),
+        onPressed: switchScrollDirection
+      ),
+      new DrawerItem(
+        onPressed: toggleItemsWrap,
+        child: new Row(<Widget>[
+          new Flexible(child: new Text('Scrolling wraps around')),
+          new Checkbox(value: itemsWrap)
+        ])
+      )
+    ]);
   }
 
   Widget buildToolBar() {
     return new ToolBar(
-      left: new IconButton(icon: "navigation/menu", onPressed: _showDrawer),
+      left: new IconButton(
+        icon: "navigation/menu",
+        onPressed: () { showDrawer(context: context, builder: _buildDrawer); }
+      ),
       center: new Text('PageableList'),
       right: <Widget>[
         new Text(scrollDirection == ScrollDirection.horizontal ? "horizontal" : "vertical")

--- a/packages/flutter/lib/src/material/drawer.dart
+++ b/packages/flutter/lib/src/material/drawer.dart
@@ -37,7 +37,7 @@ class _Drawer extends StatelessComponent {
         constraints: const BoxConstraints.expand(width: _kWidth),
         child: new Material(
           elevation: route.elevation,
-          child: route.child
+          child: route.builder(context)
         )
       )
     );
@@ -51,9 +51,9 @@ enum _DrawerState {
 }
 
 class _DrawerRoute extends OverlayRoute {
-  _DrawerRoute({ this.child, this.elevation });
+  _DrawerRoute({ this.builder, this.elevation });
 
-  final Widget child;
+  final WidgetBuilder builder;
   final int elevation;
 
   List<WidgetBuilder> get builders => <WidgetBuilder>[ _build ];
@@ -219,6 +219,6 @@ class _DrawerControllerState extends State<_DrawerController> {
   }
 }
 
-void showDrawer({ BuildContext context, Widget child, int elevation: 16 }) {
-  Navigator.of(context).push(new _DrawerRoute(child: child, elevation: elevation));
+void showDrawer({ BuildContext context, WidgetBuilder builder, int elevation: 16 }) {
+  Navigator.of(context).push(new _DrawerRoute(builder: builder, elevation: elevation));
 }

--- a/packages/unit/test/widget/drawer_test.dart
+++ b/packages/unit/test/widget/drawer_test.dart
@@ -24,7 +24,7 @@ void main() {
       );
       tester.pump(); // no effect
       expect(tester.findText('drawer'), isNull);
-      showDrawer(context: context, child: new Text('drawer'));
+      showDrawer(context: context, builder: (_) => new Text('drawer'));
       tester.pump(); // drawer should be starting to animate in
       expect(tester.findText('drawer'), isNotNull);
       tester.pump(new Duration(seconds: 1)); // animation done
@@ -53,7 +53,7 @@ void main() {
       );
       tester.pump(); // no effect
       expect(tester.findText('drawer'), isNull);
-      showDrawer(context: context, child: new Text('drawer'));
+      showDrawer(context: context, builder: (_) => new Text('drawer'));
       tester.pump(); // drawer should be starting to animate in
       expect(tester.findText('drawer'), isNotNull);
       tester.pump(new Duration(seconds: 1)); // animation done


### PR DESCRIPTION
We need to pass a WidgetBuilder instead of a Widget to showDrawer so that
app-level setStates will trigger a rebuild of the drawer. This patch pulled a
refactoring of the global settings in the stocks app so that they were cleanly
owned by the StocksApp and referenced by pointer instead of from copies.

Fixes #604
Fixes #187
