### PR TITLE
dev/update_packages.dart --upgrade

### DIFF
--- a/dev/update_packages.dart
+++ b/dev/update_packages.dart
@@ -6,11 +6,15 @@
 import 'dart:io';
 
 final String binaryName = Platform.isWindows ? 'pub.bat' : 'pub';
-update(Directory directory) {
+void update(Directory directory, bool upgrade) {
   for (FileSystemEntity dir in directory.listSync()) {
     if (dir is Directory) {
       print("Updating ${dir.path}...");
-      ProcessResult result = Process.runSync(binaryName, ['get'], workingDirectory: dir.path);
+      ProcessResult result = Process.runSync(
+        binaryName,
+        [ upgrade ? 'upgrade' : 'get' ],
+        workingDirectory: dir.path
+      );
       if (result.exitCode != 0) {
         print("... failed with exit code ${result.exitCode}.");
         print(result.stdout);
@@ -20,8 +24,9 @@ update(Directory directory) {
   }
 }
 
-main() {
+void main(List<String> arguments) {
+  bool upgrade = arguments.length > 0 && arguments[0] == '--upgrade';
   String FLUTTER_ROOT = new File(Platform.script.toFilePath()).parent.parent.path;
-  update(new Directory("$FLUTTER_ROOT/packages"));
-  update(new Directory("$FLUTTER_ROOT/examples"));
+  update(new Directory("$FLUTTER_ROOT/packages"), upgrade);
+  update(new Directory("$FLUTTER_ROOT/examples"), upgrade);
 }

--- a/packages/flutter_tools/lib/src/commands/analyze.dart
+++ b/packages/flutter_tools/lib/src/commands/analyze.dart
@@ -121,6 +121,8 @@ class AnalyzeCommand extends FlutterCommand {
       }
     }
 
+    bool foundAnyInCurrentDirectory = false;
+
     if (argResults['current-directory']) {
       // ./*.dart
       Directory currentDirectory = new Directory('.');
@@ -131,8 +133,10 @@ class AnalyzeCommand extends FlutterCommand {
           foundOne = true;
         }
       }
-      if (foundOne)
+      if (foundOne) {
         pubSpecDirectories.add('.');
+        foundAnyInCurrentDirectory = true;
+      }
     }
 
     if (argResults['current-package']) {
@@ -141,6 +145,7 @@ class AnalyzeCommand extends FlutterCommand {
       if (FileSystemEntity.isFileSync(mainPath)) {
         dartFiles.add(mainPath);
         pubSpecDirectories.add('.');
+        foundAnyInCurrentDirectory = true;
       }
     }
 
@@ -180,9 +185,9 @@ class AnalyzeCommand extends FlutterCommand {
     }
     if (hadInconsistentRequirements) {
       if (argResults['flutter-repo'])
-        _logging.warning('You may need to run "dart ${path.normalize(path.relative(path.join(ArtifactStore.flutterRoot, 'dev/update_packages.dart')))}".');
-      if (argResults['current-directory'] || argResults['current-package'])
-        _logging.warning('You may need to run "pub get".');
+        _logging.warning('You may need to run "dart ${path.normalize(path.relative(path.join(ArtifactStore.flutterRoot, 'dev/update_packages.dart')))} --upgrade".');
+      if (foundAnyInCurrentDirectory)
+        _logging.warning('You may need to run "pub upgrade".');
     }
 
     String buildDir = buildConfigurations.firstWhere((BuildConfiguration config) => config.testable, orElse: () => null)?.buildDir;


### PR DESCRIPTION
Add an --upgrade flag to the dev/update_packages.dart flag which runs
'pub upgrade' instead of 'pub get'. Tell people to use this when using
'flutter analyze' since 'pub get' doesn't have the same guarantee of
getting everything in sync.
