### PR TITLE
Add input#hideText

### DIFF
--- a/packages/flutter/lib/src/material/input.dart
+++ b/packages/flutter/lib/src/material/input.dart
@@ -21,6 +21,7 @@ class Input extends Scrollable {
     GlobalKey key,
     this.initialValue: '',
     this.placeholder,
+    this.hideText: false,
     this.onChanged,
     this.keyboardType: KeyboardType.TEXT,
     this.onSubmitted
@@ -33,6 +34,7 @@ class Input extends Scrollable {
   final String initialValue;
   final KeyboardType keyboardType;
   final String placeholder;
+  final bool hideText;
   final ValueChanged<String> onChanged;
   final ValueChanged<String> onSubmitted;
 
@@ -110,6 +112,7 @@ class InputState extends ScrollableState<Input> {
       value: _editableValue,
       focused: focused,
       style: textStyle,
+      hideText: config.hideText,
       cursorColor: cursorColor,
       onContentSizeChanged: _handleContentSizeChanged,
       scrollOffset: scrollOffsetVector

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -144,6 +144,7 @@ class EditableText extends StatefulComponent {
     Key key,
     this.value,
     this.focused: false,
+    this.hideText: false,
     this.style,
     this.cursorColor,
     this.onContentSizeChanged,
@@ -152,6 +153,7 @@ class EditableText extends StatefulComponent {
 
   final EditableString value;
   final bool focused;
+  final bool hideText;
   final TextStyle style;
   final Color cursorColor;
   final SizeChangedCallback onContentSizeChanged;
@@ -216,6 +218,7 @@ class EditableTextState extends State<EditableText> {
         style: config.style,
         cursorColor: config.cursorColor,
         showCursor: _showCursor,
+        hideText: config.hideText,
         onContentSizeChanged: config.onContentSizeChanged,
         scrollOffset: config.scrollOffset
       )
@@ -232,6 +235,7 @@ class _EditableTextWidget extends LeafRenderObjectWidget {
     this.style,
     this.cursorColor,
     this.showCursor,
+    this.hideText,
     this.onContentSizeChanged,
     this.scrollOffset
   }) : super(key: key);
@@ -240,6 +244,7 @@ class _EditableTextWidget extends LeafRenderObjectWidget {
   final TextStyle style;
   final Color cursorColor;
   final bool showCursor;
+  final bool hideText;
   final SizeChangedCallback onContentSizeChanged;
   final Offset scrollOffset;
 
@@ -264,7 +269,7 @@ class _EditableTextWidget extends LeafRenderObjectWidget {
 
   // Construct a TextSpan that renders the EditableString using the chosen style.
   TextSpan _buildTextSpan() {
-    if (value.composing.isValid) {
+    if (!hideText && value.composing.isValid) {
       TextStyle composingStyle = style.merge(
         const TextStyle(decoration: underline)
       );
@@ -279,6 +284,8 @@ class _EditableTextWidget extends LeafRenderObjectWidget {
     }
 
     String text = value.text;
+    if (hideText)
+      text = new String.fromCharCodes(new List<int>.filled(text.length, 0x2022));
     return new StyledTextSpan(style, <TextSpan>[
       new PlainTextSpan(text.isEmpty ? _kZeroWidthSpace : text)
     ]);

--- a/packages/unit/test/widget/input_test.dart
+++ b/packages/unit/test/widget/input_test.dart
@@ -138,4 +138,27 @@ void main() {
       expect(input.editableValue.selection.start, equals(0));
     });
   });
+
+  test('hideText control test', () {
+    testWidgets((WidgetTester tester) {
+      GlobalKey inputKey = new GlobalKey();
+
+      Widget builder() {
+        return new Center(
+          child: new Input(
+            key: inputKey,
+            hideText: true,
+            placeholder: 'Placeholder'
+          )
+        );
+      }
+
+      tester.pumpWidget(builder());
+
+      const String testValue = 'ABC';
+      mockKeyboard.client.commitText(testValue, testValue.length);
+
+      tester.pump();
+    });
+  });
 }


### PR DESCRIPTION
This feature can be used to implement password fields, where the user doesn't
want the text displayed on screen. Currently all the characters are hidden.
Eventualy we'll want to show the most recent character for some timeout.

Fixes #636
