### PR TITLE
Makes it easier to hit IconButton

### DIFF
--- a/packages/flutter/lib/src/material/icon_button.dart
+++ b/packages/flutter/lib/src/material/icon_button.dart
@@ -26,6 +26,7 @@ class IconButton extends StatelessComponent {
     // 8.0 pixel padding as well as the icon.
     return new GestureDetector(
       onTap: onPressed,
+      behavior: HitTestBehavior.opaque,
       child: new Padding(
         padding: const EdgeDims.all(8.0),
         child: new Icon(


### PR DESCRIPTION
The right fix here is to use a radial reaction, but for now we can just make
the gesture detector including the padding acround the icon in its hit test
region.

Fixes #575
