### PR TITLE
Remove the assert when opening popup menus.

### DIFF
--- a/packages/flutter/lib/src/rendering/binding.dart
+++ b/packages/flutter/lib/src/rendering/binding.dart
@@ -7,12 +7,12 @@ import 'dart:ui' as ui;
 
 import 'package:flutter/animation.dart';
 import 'package:flutter/gestures.dart';
-import 'package:flutter/rendering.dart';
 import 'package:mojo/bindings.dart' as bindings;
 import 'package:mojo/core.dart' as core;
 import 'package:sky_services/pointer/pointer.mojom.dart';
 
 import 'box.dart';
+import 'debug.dart';
 import 'hit_test.dart';
 import 'object.dart';
 import 'view.dart';

--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -62,7 +62,6 @@ class PaintingContext {
   PaintingContext._(this._containerLayer, this._paintBounds) {
     assert(_containerLayer != null);
     assert(_paintBounds != null);
-    assert(!_paintBounds.isEmpty);
   }
 
   final ContainerLayer _containerLayer;


### PR DESCRIPTION
Some paint bounds are in fact empty, e.g. at the start of a growing
animation if there's also a fade, the initial 0x0 box will also be
opacity:0, and might get a dedicated layer and PaintingContext.

Fixes #650.

Also, fix an error in the imports to binding.dart that should be causing all kinds of problems yet somehow isn't. 
