### PR TITLE
Rename some of the functions from the scheduler.

### DIFF
--- a/packages/flutter/lib/src/animation/ticker.dart
+++ b/packages/flutter/lib/src/animation/ticker.dart
@@ -40,7 +40,7 @@ class Ticker {
     _startTime = null;
 
     if (_animationId != null) {
-      scheduler.cancelAnimationFrame(_animationId);
+      scheduler.cancelFrameCallbackWithId(_animationId);
       _animationId = null;
     }
 
@@ -74,6 +74,6 @@ class Ticker {
   void _scheduleTick() {
     assert(isTicking);
     assert(_animationId == null);
-    _animationId = scheduler.requestAnimationFrame(_tick);
+    _animationId = scheduler.scheduleFrameCallback(_tick);
   }
 }

--- a/packages/flutter/lib/src/widgets/hero_controller.dart
+++ b/packages/flutter/lib/src/widgets/hero_controller.dart
@@ -55,7 +55,7 @@ class HeroController extends NavigatorObserver {
   void _checkForHeroQuest() {
     if (_from != null && _to != null && _from != _to) {
       _to.offstage = _to.performance.status != PerformanceStatus.completed;
-      scheduler.requestPostFrameCallback(_updateQuest);
+      scheduler.addPostFrameCallback(_updateQuest);
     }
   }
 

--- a/packages/flutter_sprites/lib/src/sprite_box.dart
+++ b/packages/flutter_sprites/lib/src/sprite_box.dart
@@ -361,7 +361,7 @@ class SpriteBox extends RenderBox {
   // Updates
 
   void _scheduleTick() {
-    scheduler.requestAnimationFrame(_tick);
+    scheduler.scheduleFrameCallback(_tick);
   }
 
   void _tick(Duration timeStamp) {

--- a/packages/flutter_test/lib/src/widget_tester.dart
+++ b/packages/flutter_test/lib/src/widget_tester.dart
@@ -34,7 +34,8 @@ class WidgetTester {
   void pump([ Duration duration ]) {
     if (duration != null)
       async.elapse(duration);
-    scheduler.beginFrame(new Duration(milliseconds: clock.now().millisecondsSinceEpoch));
+    scheduler.handleBeginFrame(new Duration(
+        milliseconds: clock.now().millisecondsSinceEpoch));
     async.flushMicrotasks();
   }
 

--- a/packages/unit/test/scheduler/animation_test.dart
+++ b/packages/unit/test/scheduler/animation_test.dart
@@ -17,7 +17,7 @@ void main() {
       expect(secondCallbackRan, isFalse);
       expect(timeStamp.inMilliseconds, equals(16));
       firstCallbackRan = true;
-      scheduler.cancelAnimationFrame(secondId);
+      scheduler.cancelFrameCallbackWithId(secondId);
     }
 
     void secondCallback(Duration timeStamp) {
@@ -27,10 +27,10 @@ void main() {
       secondCallbackRan = true;
     }
 
-    scheduler.requestAnimationFrame(firstCallback);
-    secondId = scheduler.requestAnimationFrame(secondCallback);
+    scheduler.scheduleFrameCallback(firstCallback);
+    secondId = scheduler.scheduleFrameCallback(secondCallback);
 
-    scheduler.beginFrame(const Duration(milliseconds: 16));
+    scheduler.handleBeginFrame(const Duration(milliseconds: 16));
 
     expect(firstCallbackRan, isTrue);
     expect(secondCallbackRan, isFalse);
@@ -38,7 +38,7 @@ void main() {
     firstCallbackRan = false;
     secondCallbackRan = false;
 
-    scheduler.beginFrame(const Duration(milliseconds: 32));
+    scheduler.handleBeginFrame(const Duration(milliseconds: 32));
 
     expect(firstCallbackRan, isFalse);
     expect(secondCallbackRan, isFalse);

--- a/packages/unit/test/scheduler/scheduler_test.dart
+++ b/packages/unit/test/scheduler/scheduler_test.dart
@@ -28,17 +28,17 @@ void main() {
       scheduleAddingTask(x);
     }
     strategy.allowedPriority = 100;
-    for (int i = 0; i < 3; i++) scheduler.tick();
+    for (int i = 0; i < 3; i++) scheduler.handleEventLoopCallback();
     expect(executedTasks.isEmpty, isTrue);
 
     strategy.allowedPriority = 50;
-    for (int i = 0; i < 3; i++) scheduler.tick();
+    for (int i = 0; i < 3; i++) scheduler.handleEventLoopCallback();
     expect(executedTasks.length, equals(1));
     expect(executedTasks.single, equals(80));
     executedTasks.clear();
 
     strategy.allowedPriority = 20;
-    for (int i = 0; i < 3; i++) scheduler.tick();
+    for (int i = 0; i < 3; i++) scheduler.handleEventLoopCallback();
     expect(executedTasks.length, equals(2));
     expect(executedTasks[0], equals(23));
     expect(executedTasks[1], equals(23));
@@ -48,21 +48,21 @@ void main() {
     scheduleAddingTask(19);
     scheduleAddingTask(5);
     scheduleAddingTask(97);
-    for (int i = 0; i < 3; i++) scheduler.tick();
+    for (int i = 0; i < 3; i++) scheduler.handleEventLoopCallback();
     expect(executedTasks.length, equals(2));
     expect(executedTasks[0], equals(99));
     expect(executedTasks[1], equals(97));
     executedTasks.clear();
 
     strategy.allowedPriority = 10;
-    for (int i = 0; i < 3; i++) scheduler.tick();
+    for (int i = 0; i < 3; i++) scheduler.handleEventLoopCallback();
     expect(executedTasks.length, equals(2));
     expect(executedTasks[0], equals(19));
     expect(executedTasks[1], equals(11));
     executedTasks.clear();
 
     strategy.allowedPriority = 1;
-    for (int i = 0; i < 4; i++) scheduler.tick();
+    for (int i = 0; i < 4; i++) scheduler.handleEventLoopCallback();
     expect(executedTasks.length, equals(3));
     expect(executedTasks[0], equals(5));
     expect(executedTasks[1], equals(3));
@@ -70,7 +70,7 @@ void main() {
     executedTasks.clear();
 
     strategy.allowedPriority = 0;
-    scheduler.tick();
+    scheduler.handleEventLoopCallback();
     expect(executedTasks.length, equals(1));
     expect(executedTasks[0], equals(0));
   });


### PR DESCRIPTION
The names are probably less familiar, but more consistent:
- FrameCallback: a callback that is relative to the frame and wants the
  frame offset (a duration) as argument.
- addXFrameCallback: adds the given callback to the internal lists/maps.
- scheduleXFrameCallback (currently only X = ""): add the callback, but
  also trigger a new frame.
- handleX: the method that is invoked when the event-loop or the frame
  calls into the scheduler.
- ensureXYZ: ensure that the callback happens.
  Unfortunately there is the ambiguity between a "callback": it can be a
  closure, or the action of doing a callback, so we end up with:
  ensureBeginFrameCallback, and ensureEventLoopCallback, where
  "callback" means the action of being called back.
