### PR TITLE
Add support for passing --trace-startup on Android

### DIFF
--- a/packages/flutter_tools/lib/src/commands/start.dart
+++ b/packages/flutter_tools/lib/src/commands/start.dart
@@ -27,6 +27,10 @@ class StartCommand extends FlutterCommand {
         negatable: true,
         defaultsTo: true,
         help: 'Toggle Dart\'s checked mode.');
+    argParser.addFlag('trace-startup',
+        negatable: true,
+        defaultsTo: false,
+        help: 'Start tracing during startup.');
     argParser.addOption('target',
         defaultsTo: '',
         abbr: 't',
@@ -101,6 +105,7 @@ class StartCommand extends FlutterCommand {
             if (device.startBundle(package, localBundlePath,
                                    poke: poke,
                                    checked: argResults['checked'],
+                                   traceStartup: argResults['trace-startup'],
                                    route: argResults['route']))
               startedSomething = true;
           }

--- a/packages/flutter_tools/lib/src/device.dart
+++ b/packages/flutter_tools/lib/src/device.dart
@@ -771,6 +771,7 @@ class AndroidDevice extends Device {
   bool startBundle(AndroidApk apk, String bundlePath, {
     bool poke,
     bool checked,
+    bool traceStartup,
     String route
   }) {
     logging.fine('$this startBundle');
@@ -792,6 +793,8 @@ class AndroidDevice extends Device {
     ]);
     if (checked)
       cmd.addAll(['--ez', 'enable-checked-mode', 'true']);
+    if (traceStartup)
+        cmd.addAll(['--ez', 'trace-startup', 'true']);
     if (route != null)
       cmd.addAll(['--es', 'route', route]);
     cmd.add(apk.launchActivity);


### PR DESCRIPTION
iOS takes a different codepath and will need more work.

@chinmaygarde
