### PR TITLE
Let MaterialApp.onGenerateRoute return a Route

### DIFF
--- a/examples/stocks/lib/main.dart
+++ b/examples/stocks/lib/main.dart
@@ -8,7 +8,6 @@ import 'dart:async';
 import 'dart:math' as math;
 import 'dart:ui' as ui;
 
-import 'package:flutter/animation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/painting.dart';
@@ -74,16 +73,19 @@ class StocksAppState extends State<StocksApp> {
     }
   }
 
-  RouteBuilder _getRoute(String name) {
-    List<String> path = name.split('/');
+  Route _getRoute(NamedRouteSettings settings) {
+    List<String> path = settings.name.split('/');
     if (path[0] != '')
       return null;
     if (path[1] == 'stock') {
       if (path.length != 3)
         return null;
-      if (_stocks.containsKey(path[2]))
-        return (RouteArguments args) => new StockSymbolPage(stock: _stocks[path[2]]);
-      return null;
+      if (_stocks.containsKey(path[2])) {
+        return new MaterialPageRoute(
+          settings: settings,
+          builder: (BuildContext context) => new StockSymbolPage(stock: _stocks[path[2]])
+        );
+      }
     }
     return null;
   }

--- a/examples/stocks/lib/stock_home.dart
+++ b/examples/stocks/lib/stock_home.dart
@@ -145,22 +145,13 @@ class StockHomeState extends State<StockHome> {
   }
 
   Widget buildToolBar() {
-    PageRoute page = ModalRoute.of(context);
     return new ToolBar(
       elevation: 0,
       left: new IconButton(
         icon: "navigation/menu",
         onPressed: () => _scaffoldKey.currentState?.openDrawer()
       ),
-      center: new FadeTransition(
-        opacity: new AnimatedValue<double>(
-          1.0,
-          end: 0.0,
-          curve: const Interval(0.0, 0.5)
-        ),
-        performance: page.forwardPerformance,
-        child: new Text('Stocks')
-      ),
+      center: new Text('Stocks'),
       right: <Widget>[
         new IconButton(
           icon: "action/search",

--- a/examples/stocks/lib/stock_symbol_viewer.dart
+++ b/examples/stocks/lib/stock_symbol_viewer.dart
@@ -5,7 +5,7 @@
 part of stocks;
 
 class StockSymbolView extends StatelessComponent {
-  StockSymbolView({ this.stock});
+  StockSymbolView({ this.stock });
 
   final Stock stock;
 
@@ -20,28 +20,28 @@ class StockSymbolView extends StatelessComponent {
       padding: new EdgeDims.all(20.0),
       child: new Column(<Widget>[
           new Row(<Widget>[
-            new Text(
-              '${stock.symbol}',
-              style: Theme.of(context).text.display2
-            ),
-            new Hero(
-              key: new ObjectKey(stock),
-              tag: StockRowPartKind.arrow,
-              turns: 2,
-              child: new StockArrow(percentChange: stock.percentChange)
-            ),
-          ],
-          justifyContent: FlexJustifyContent.spaceBetween
-        ),
-        new Text('Last Sale', style: headings),
-        new Text('$lastSale ($changeInPrice)'),
-        new Container(
-          height: 8.0
-        ),
-        new Text('Market Cap', style: headings),
-        new Text('${stock.marketCap}'),
-      ],
-         justifyContent: FlexJustifyContent.collapse
+              new Text(
+                '${stock.symbol}',
+                style: Theme.of(context).text.display2
+              ),
+              new Hero(
+                key: new ObjectKey(stock),
+                tag: StockRowPartKind.arrow,
+                turns: 2,
+                child: new StockArrow(percentChange: stock.percentChange)
+              ),
+            ],
+            justifyContent: FlexJustifyContent.spaceBetween
+          ),
+          new Text('Last Sale', style: headings),
+          new Text('$lastSale ($changeInPrice)'),
+          new Container(
+            height: 8.0
+          ),
+          new Text('Market Cap', style: headings),
+          new Text('${stock.marketCap}'),
+        ],
+        justifyContent: FlexJustifyContent.collapse
       )
     );
   }
@@ -53,7 +53,6 @@ class StockSymbolPage extends StatelessComponent {
   final Stock stock;
 
   Widget build(BuildContext context) {
-    PageRoute page = ModalRoute.of(context);
     return new Scaffold(
       toolBar: new ToolBar(
         left: new IconButton(
@@ -62,15 +61,7 @@ class StockSymbolPage extends StatelessComponent {
             Navigator.pop(context);
           }
         ),
-        center: new FadeTransition(
-          opacity: new AnimatedValue<double>(
-            0.0,
-            end: 1.0,
-            curve: const Interval(0.5, 1.0)
-          ),
-          performance: page.performance,
-          child: new Text(stock.name)
-        )
+        center: new Text(stock.name)
       ),
       body: new Block(<Widget>[
         new Container(

--- a/packages/flutter/lib/src/material/material_app.dart
+++ b/packages/flutter/lib/src/material/material_app.dart
@@ -37,7 +37,6 @@ class RouteArguments {
   final BuildContext context;
 }
 typedef Widget RouteBuilder(RouteArguments args);
-typedef RouteBuilder RouteGenerator(String name);
 
 class MaterialApp extends StatefulComponent {
   MaterialApp({
@@ -54,7 +53,7 @@ class MaterialApp extends StatefulComponent {
   final String title;
   final ThemeData theme;
   final Map<String, RouteBuilder> routes;
-  final RouteGenerator onGenerateRoute;
+  final RouteFactory onGenerateRoute;
 
   _MaterialAppState createState() => new _MaterialAppState();
 }
@@ -93,13 +92,18 @@ class _MaterialAppState extends State<MaterialApp> implements BindingObserver {
   final HeroController _heroController = new HeroController();
 
   Route _generateRoute(NamedRouteSettings settings) {
-    return new MaterialPageRoute(
-      builder: (BuildContext context) {
-        RouteBuilder builder = config.routes[settings.name] ?? config.onGenerateRoute(settings.name);
-        return builder(new RouteArguments(context: context));
-      },
-      settings: settings
-    );
+    RouteBuilder builder = config.routes[settings.name];
+    if (builder != null) {
+      return new MaterialPageRoute(
+        builder: (BuildContext context) {
+          return builder(new RouteArguments(context: context));
+        },
+        settings: settings
+      );
+    }
+    if (config.onGenerateRoute != null)
+      return config.onGenerateRoute(settings);
+    return null;
   }
 
   Widget build(BuildContext context) {

--- a/packages/flutter/lib/src/material/page.dart
+++ b/packages/flutter/lib/src/material/page.dart
@@ -52,7 +52,6 @@ class MaterialPageRoute<T> extends PageRoute<T> {
   final WidgetBuilder builder;
 
   Duration get transitionDuration => kMaterialPageRouteTransitionDuration;
-  bool get barrierDismissable => false;
   Color get barrierColor => Colors.black54;
 
   Widget buildPage(BuildContext context) {

--- a/packages/flutter/lib/src/widgets/navigator.dart
+++ b/packages/flutter/lib/src/widgets/navigator.dart
@@ -197,7 +197,13 @@ class NavigatorState extends State<Navigator> {
       name: name,
       mostValuableKeys: mostValuableKeys
     );
-    _push(config.onGenerateRoute(settings) ?? config.onUnknownRoute(settings));
+    Route route = config.onGenerateRoute(settings);
+    if (route == null) {
+      assert(config.onUnknownRoute != null);
+      route = config.onUnknownRoute(settings);
+      assert(route != null);
+    }
+    _push(route);
   }
 
   void _push(Route route, { Set<Key> mostValuableKeys }) {

--- a/packages/flutter/lib/src/widgets/routes.dart
+++ b/packages/flutter/lib/src/widgets/routes.dart
@@ -433,4 +433,5 @@ abstract class PageRoute<T> extends ModalRoute<T> {
     NamedRouteSettings settings: const NamedRouteSettings()
   }) : super(completer: completer, settings: settings);
   bool get opaque => true;
+  bool get barrierDismissable => false;
 }

--- a/packages/flutter_test/lib/src/widget_tester.dart
+++ b/packages/flutter_test/lib/src/widget_tester.dart
@@ -21,6 +21,7 @@ class WidgetTester {
       clock = async.getClock(new DateTime.utc(2015, 1, 1)) {
     timeDilation = 1.0;
     ui.window.onBeginFrame = null;
+    runApp(new ErrorWidget()); // flush out the last build entirely
   }
 
   final FakeAsync async;

--- a/packages/unit/test/widget/bottom_sheet_test.dart
+++ b/packages/unit/test/widget/bottom_sheet_test.dart
@@ -65,14 +65,14 @@ void main() {
       bool showBottomSheetThenCalled = false;
 
       tester.pumpWidget(new MaterialApp(
-          routes: <String, RouteBuilder>{
-            '/': (RouteArguments args) {
-              return new Scaffold(
-                key: scaffoldKey,
-                body: new Center(child: new Text('body'))
-              );
-            }
+        routes: <String, RouteBuilder>{
+          '/': (RouteArguments args) {
+            return new Scaffold(
+              key: scaffoldKey,
+              body: new Center(child: new Text('body'))
+            );
           }
+        }
       ));
 
       expect(showBottomSheetThenCalled, isFalse);

--- a/packages/unit/test/widget/pageable_list_test.dart
+++ b/packages/unit/test/widget/pageable_list_test.dart
@@ -50,9 +50,7 @@ void pageRight(WidgetTester tester) {
 }
 
 void main() {
-  // PageableList with itemsWrap: false
-
-  test('Scroll left from page 0 to page 1', () {
+  test('PageableList with itemsWrap: false', () {
     testWidgets((WidgetTester tester) {
       currentPage = null;
       itemsWrap = false;
@@ -60,32 +58,14 @@ void main() {
       expect(currentPage, isNull);
       pageLeft(tester);
       expect(currentPage, equals(1));
-    });
-  });
-
-  test('Scroll right from page 1 to page 0', () {
-    testWidgets((WidgetTester tester) {
-      itemsWrap = false;
-      tester.pumpWidget(buildFrame());
-      expect(currentPage, equals(1));
       pageRight(tester);
-      expect(currentPage, equals(0));
-    });
-  });
-
-  test('Scroll right from page 0 does nothing (underscroll)', () {
-    testWidgets((WidgetTester tester) {
-      itemsWrap = false;
-      tester.pumpWidget(buildFrame());
       expect(currentPage, equals(0));
       pageRight(tester);
       expect(currentPage, equals(0));
     });
   });
 
-  // PageableList with itemsWrap: true
-
-  test('Scroll left page 0 to page 1, itemsWrap: true', () {
+  test('PageableList with itemsWrap: true', () {
     testWidgets((WidgetTester tester) {
       tester.pumpWidget(new Container());
       currentPage = null;
@@ -94,21 +74,7 @@ void main() {
       expect(currentPage, isNull);
       pageLeft(tester);
       expect(currentPage, equals(1));
-    });
-  });
-
-  test('Scroll right from page 1 to page 0, itemsWrap: true', () {
-    testWidgets((WidgetTester tester) {
-      tester.pumpWidget(buildFrame());
-      expect(currentPage, equals(1));
       pageRight(tester);
-      expect(currentPage, equals(0));
-    });
-  });
-
-  test('Scroll right from page 0 to page 5, itemsWrap: true (underscroll)', () {
-    testWidgets((WidgetTester tester) {
-      tester.pumpWidget(buildFrame());
       expect(currentPage, equals(0));
       pageRight(tester);
       expect(currentPage, equals(5));


### PR DESCRIPTION
Also:
- minor code reindents in places.
- reset the widget tree between tests.
- once you generate a route, don't let its builder change
  (previously it would keep changing as the routes table changed).
- revert the stocks app toolbar-fading-on-forward-transition thing.
