### PR TITLE
RenderFlex shouldn't assert when its out of space

### DIFF
--- a/packages/flutter/lib/src/rendering/flex.dart
+++ b/packages/flutter/lib/src/rendering/flex.dart
@@ -466,14 +466,12 @@ class RenderFlex extends RenderBox with ContainerRenderObjectMixin<RenderBox, Fl
         case FlexDirection.horizontal:
           size = constraints.constrain(new Size(_overflow, crossSize));
           crossSize = size.height;
-          assert(size.width >= _overflow);
-          remainingSpace = size.width - _overflow;
+          remainingSpace = math.max(0.0, size.width - _overflow);
           break;
         case FlexDirection.vertical:
           size = constraints.constrain(new Size(crossSize, _overflow));
           crossSize = size.width;
-          assert(size.height >= _overflow);
-          remainingSpace = size.height - _overflow;
+          remainingSpace = math.max(0.0, size.height - _overflow);
           break;
       }
       _overflow = 0.0;

--- a/packages/unit/test/widget/flex_test.dart
+++ b/packages/unit/test/widget/flex_test.dart
@@ -108,4 +108,46 @@ void main() {
       expect(renderBox.size.height, equals(250.0));
     });
   });
+
+  test('Can layout at zero size', () {
+    final Key childKey = new Key('childKey');
+
+    testWidgets((WidgetTester tester) {
+      tester.pumpWidget(new Center(
+        child: new Container(
+          width: 0.0,
+          height: 0.0,
+          child:  new Column([
+            new Container(
+              key: childKey,
+              width: 100.0,
+              height: 100.0
+            )], justifyContent: FlexJustifyContent.collapse
+          )
+        )
+      ));
+
+      RenderBox renderBox = tester.findElementByKey(childKey).renderObject;
+      expect(renderBox.size.width, equals(0.0));
+      expect(renderBox.size.height, equals(100.0));
+
+      tester.pumpWidget(new Center(
+        child: new Container(
+          width: 0.0,
+          height: 0.0,
+          child:  new Row([
+            new Container(
+              key: childKey,
+              width: 100.0,
+              height: 100.0
+            )], justifyContent: FlexJustifyContent.collapse
+          )
+        )
+      ));
+
+      renderBox = tester.findElementByKey(childKey).renderObject;
+      expect(renderBox.size.width, equals(100.0));
+      expect(renderBox.size.height, equals(0.0));
+    });
+  });
 }


### PR DESCRIPTION
Previously, we would assert with FlexJustifyContent.collapse if we ran out of
space. Now we do the same thing we do for the other types of justification,
which is to let the children's layout overflow.
