### PR TITLE
BuilderTransition no longer requires variables

### DIFF
--- a/packages/flutter/lib/src/widgets/transitions.dart
+++ b/packages/flutter/lib/src/widgets/transitions.dart
@@ -259,7 +259,7 @@ typedef Widget BuilderFunction(BuildContext context);
 class BuilderTransition extends TransitionComponent {
   BuilderTransition({
     Key key,
-    this.variables,
+    this.variables: const <AnimatedValue>[],
     this.builder,
     PerformanceView performance
   }) : super(key: key,


### PR DESCRIPTION
Sometimes you want to just make a transition driven straight from the
performance's progress, rather than with an explicit variable.
