### PR TITLE
LayoutId should default to using its id as its key

### DIFF
--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -304,9 +304,10 @@ class LayoutId extends ParentDataWidget {
   LayoutId({
     Key key,
     Widget child,
-    this.id
-  }) : super(key: key, child: child) {
+    Object id
+  }) : id = id, super(key: key ?? new ValueKey(id), child: child) {
     assert(child != null);
+    assert(id != null);
   }
 
   final Object id;


### PR DESCRIPTION
This default seems likely to be benefitial because typically the LayoutIds
coorespond to semantic slots in a bespoke layout.
