### PR TITLE
Expose markNeedsBuild on MimicOverlayEntry

### DIFF
--- a/packages/flutter/lib/src/widgets/mimic.dart
+++ b/packages/flutter/lib/src/widgets/mimic.dart
@@ -59,6 +59,10 @@ class MimicOverlayEntry {
     return _performance.play();
   }
 
+  void markNeedsBuild() {
+   _overlayEntry?.markNeedsBuild();
+ }
+
   void dispose() {
     _targetKey = null;
     _curve = null;


### PR DESCRIPTION
We expose this function on OverlayEntry to let you drive animations in the
overlay. The same use case applies to MimicOverlayEntry.
