### PR TITLE
Navigator.popUntil

### DIFF
--- a/packages/flutter/lib/src/widgets/navigator.dart
+++ b/packages/flutter/lib/src/widgets/navigator.dart
@@ -137,6 +137,12 @@ class Navigator extends StatefulComponent {
     });
     return returnValue;
   }
+ 
+  static void popUntil(BuildContext context, Route targetRoute) {
+    openTransaction(context, (NavigatorTransaction transaction) {
+      transaction.popUntil(targetRoute);
+    });
+  }
 
   static bool canPop(BuildContext context) {
     NavigatorState navigator = context.ancestorStateOfType(NavigatorState);


### PR DESCRIPTION
This was already supported in the underlying classes but somehow not
exposed by Navigator itself.
