### PR TITLE
Material gallery crashes when you press the drop-down button

### DIFF
--- a/packages/flutter/lib/src/material/material.dart
+++ b/packages/flutter/lib/src/material/material.dart
@@ -25,7 +25,10 @@ enum MaterialType {
   circle,
 
   /// Rounded edges, no color by default (used for MaterialButton buttons).
-  button
+  button,
+
+  /// A transparent piece of material that draws ink splashes and highlights.
+  transparency
 }
 
 const Map<MaterialType, double> kMaterialEdges = const <MaterialType, double>{
@@ -33,6 +36,7 @@ const Map<MaterialType, double> kMaterialEdges = const <MaterialType, double>{
   MaterialType.card: 2.0,
   MaterialType.circle: null,
   MaterialType.button: 2.0,
+  MaterialType.transparency: null,
 };
 
 abstract class InkSplash {
@@ -141,17 +145,19 @@ class _MaterialState extends State<Material> {
         child: contents
       );
     }
-    contents = new AnimatedContainer(
-      curve: Curves.ease,
-      duration: kThemeChangeDuration,
-      decoration: new BoxDecoration(
-        backgroundColor: backgroundColor,
-        borderRadius: kMaterialEdges[config.type],
-        boxShadow: config.elevation == 0 ? null : elevationToShadow[config.elevation],
-        shape: config.type == MaterialType.circle ? Shape.circle : Shape.rectangle
-      ),
-      child: contents
-    );
+    if (config.type != MaterialType.transparency) {
+      contents = new AnimatedContainer(
+        curve: Curves.ease,
+        duration: kThemeChangeDuration,
+        decoration: new BoxDecoration(
+          backgroundColor: backgroundColor,
+          borderRadius: kMaterialEdges[config.type],
+          boxShadow: config.elevation == 0 ? null : elevationToShadow[config.elevation],
+          shape: config.type == MaterialType.circle ? Shape.circle : Shape.rectangle
+        ),
+        child: contents
+      );
+    }
     return contents;
   }
 }

--- a/packages/flutter/lib/src/material/popup_menu.dart
+++ b/packages/flutter/lib/src/material/popup_menu.dart
@@ -123,6 +123,10 @@ class _PopupMenuRoute<T> extends PopupRoute<T> {
   final List<PopupMenuItem<T>> items;
   final int elevation;
 
+  ModalPosition getPosition(BuildContext context) {
+    return position;
+  }
+
   PerformanceView createPerformance() {
     return new CurvedPerformance(
       super.createPerformance(),

--- a/packages/flutter/lib/src/widgets/routes.dart
+++ b/packages/flutter/lib/src/widgets/routes.dart
@@ -349,7 +349,7 @@ class _ModalScopeState extends State<_ModalScope> {
       );
     }
     contents = new RepaintBoundary(child: contents);
-    ModalPosition position = config.route.position;
+    ModalPosition position = config.route.getPosition(context);
     if (position == null)
       return contents;
     return new Positioned(
@@ -388,7 +388,7 @@ abstract class ModalRoute<T> extends TransitionRoute<T> with LocalHistoryRoute<T
 
   // The API for subclasses to override - used by _ModalScope
 
-  ModalPosition get position => null;
+  ModalPosition getPosition(BuildContext context) => null;
   Widget buildPage(BuildContext context, PerformanceView performance, PerformanceView forwardPerformance);
   Widget buildTransitions(BuildContext context, PerformanceView performance, PerformanceView forwardPerformance, Widget child) {
     return child;


### PR DESCRIPTION
Now use use the route's getPosition function to position the drop-down menu.
Also, fix a number of other related bugs that blocked the dropdown button from
working correctly. The dropdown menu still has the following issues:

1) In the exit animation, the background of the menu disappears too quickly
   because of incorrect paint bounds computations in the layer tree.
2) The drop down menu isn't positioned correctly after the device rotates.
   We'll need to address this issue in a separate patch.

Fixes #630
