### PR TITLE
Revised PageableList et al

### DIFF
--- a/examples/widgets/pageable_list.dart
+++ b/examples/widgets/pageable_list.dart
@@ -120,18 +120,11 @@ class PageableListAppState extends State<PageableListApp> {
   }
 
   Widget _buildBody(BuildContext context) {
-    Widget list = new PageableList<CardModel>(
+    return new PageableList<CardModel>(
       items: cardModels,
       itemsWrap: itemsWrap,
       itemBuilder: buildCard,
-      scrollDirection: scrollDirection,
-      itemExtent: (scrollDirection == ScrollDirection.vertical)
-          ? pageSize.height
-          : pageSize.width
-    );
-    return new SizeObserver(
-      onSizeChanged: updatePageSize,
-      child: list
+      scrollDirection: scrollDirection
     );
   }
 

--- a/packages/flutter/lib/src/gestures/drag.dart
+++ b/packages/flutter/lib/src/gestures/drag.dart
@@ -105,7 +105,8 @@ abstract class _DragGestureRecognizer<T extends dynamic> extends OneSequenceGest
       Offset velocity = tracker.getVelocity();
       if (velocity != null && _isFlingGesture(velocity))
         onEnd(velocity);
-      onEnd(Offset.zero);
+      else
+        onEnd(Offset.zero);
     }
     _velocityTrackers.clear();
   }

--- a/packages/flutter/lib/src/widgets/homogeneous_viewport.dart
+++ b/packages/flutter/lib/src/widgets/homogeneous_viewport.dart
@@ -11,49 +11,39 @@ import 'basic.dart';
 
 typedef List<Widget> ListBuilder(BuildContext context, int startIndex, int count);
 
-class HomogeneousViewport extends RenderObjectWidget {
-  HomogeneousViewport({
+abstract class _ViewportBase extends RenderObjectWidget {
+  _ViewportBase({
     Key key,
     this.builder,
     this.itemsWrap: false,
-    this.itemExtent, // required, must be non-zero
-    this.itemCount, // optional, but you cannot shrink-wrap this class or otherwise use its intrinsic dimensions if you don't specify it
+    this.itemCount,
     this.direction: ScrollDirection.vertical,
     this.startOffset: 0.0,
     this.overlayPainter
-  }) : super(key: key) {
-    assert(itemExtent != null);
-    assert(itemExtent > 0);
-  }
+  }) : super(key: key);
 
   final ListBuilder builder;
   final bool itemsWrap;
-  final double itemExtent;
   final int itemCount;
   final ScrollDirection direction;
   final double startOffset;
   final Painter overlayPainter;
 
-  _HomogeneousViewportElement createElement() => new _HomogeneousViewportElement(this);
-
   // we don't pass constructor arguments to the RenderBlockViewport() because until
   // we know our children, the constructor arguments we could give have no effect
   RenderBlockViewport createRenderObject() => new RenderBlockViewport();
 
-  bool isLayoutDifferentThan(HomogeneousViewport oldWidget) {
+  bool isLayoutDifferentThan(_ViewportBase oldWidget) {
     // changing the builder doesn't imply the layout changed
     return itemsWrap != oldWidget.itemsWrap ||
-           itemExtent != oldWidget.itemExtent ||
            itemCount != oldWidget.itemCount ||
            direction != oldWidget.direction ||
            startOffset != oldWidget.startOffset;
   }
-
-  // all the actual work is done in the element
 }
 
-class _HomogeneousViewportElement extends RenderObjectElement<HomogeneousViewport> {
-  _HomogeneousViewportElement(HomogeneousViewport widget) : super(widget);
+abstract class _ViewportBaseElement<T extends _ViewportBase> extends RenderObjectElement<T> {
+  _ViewportBaseElement(T widget) : super(widget);
 
   List<Element> _children = const <Element>[];
   int _layoutFirstIndex;
@@ -86,7 +76,7 @@ class _HomogeneousViewportElement extends RenderObjectElement<HomogeneousViewpor
     super.unmount();
   }
 
-  void update(HomogeneousViewport newWidget) {
+  void update(T newWidget) {
     bool needLayout = newWidget.isLayoutDifferentThan(widget);
     super.update(newWidget);
     if (needLayout)
@@ -98,6 +88,86 @@ class _HomogeneousViewportElement extends RenderObjectElement<HomogeneousViewpor
   void reinvokeBuilders() {
     _updateChildren();
   }
+
+  void layout(BoxConstraints constraints);
+
+  void _updateChildren() {
+    assert(_layoutFirstIndex != null);
+    assert(_layoutItemCount != null);
+    List<Widget> newWidgets;
+    if (_layoutItemCount > 0)
+      newWidgets = widget.builder(this, _layoutFirstIndex, _layoutItemCount).map((Widget widget) {
+        return new RepaintBoundary(key: new ValueKey<Key>(widget.key), child: widget);
+      }).toList();
+    else
+      newWidgets = <Widget>[];
+    _children = updateChildren(_children, newWidgets);
+  }
+
+  double getTotalExtent(BoxConstraints constraints);
+
+  double getMinCrossAxisExtent(BoxConstraints constraints) {
+    return 0.0;
+  }
+
+  double getMaxCrossAxisExtent(BoxConstraints constraints) {
+    if (widget.direction == ScrollDirection.vertical)
+      return constraints.maxWidth;
+    return constraints.maxHeight;
+  }
+
+  void insertChildRenderObject(RenderObject child, Element slot) {
+    RenderObject nextSibling = slot?.renderObject;
+    renderObject.add(child, before: nextSibling);
+  }
+
+  void moveChildRenderObject(RenderObject child, Element slot) {
+    assert(child.parent == renderObject);
+    RenderObject nextSibling = slot?.renderObject;
+    renderObject.move(child, before: nextSibling);
+  }
+
+  void removeChildRenderObject(RenderObject child) {
+    assert(child.parent == renderObject);
+    renderObject.remove(child);
+  }
+
+}
+
+class HomogeneousViewport extends _ViewportBase {
+  HomogeneousViewport({
+    Key key,
+    ListBuilder builder,
+    bool itemsWrap: false,
+    int itemCount, // optional, but you cannot shrink-wrap this class or otherwise use its intrinsic dimensions if you don't specify it
+    ScrollDirection direction: ScrollDirection.vertical,
+    double startOffset: 0.0,
+    Painter overlayPainter,
+    this.itemExtent // required, must be non-zero
+  }) : super(
+    key: key,
+    builder: builder,
+    itemsWrap: itemsWrap,
+    itemCount: itemCount,
+    direction: direction,
+    startOffset: startOffset,
+    overlayPainter: overlayPainter
+  ) {
+    assert(itemExtent != null);
+    assert(itemExtent > 0);
+  }
+
+  final double itemExtent;
+
+  _HomogeneousViewportElement createElement() => new _HomogeneousViewportElement(this);
+
+  bool isLayoutDifferentThan(HomogeneousViewport oldWidget) {
+    return itemExtent != oldWidget.itemExtent || super.isLayoutDifferentThan(oldWidget);
+  }
+}
+
+class _HomogeneousViewportElement extends _ViewportBaseElement<HomogeneousViewport> {
+  _HomogeneousViewportElement(HomogeneousViewport widget) : super(widget);
 
   void layout(BoxConstraints constraints) {
     // We enter a build scope (meaning that markNeedsBuild() is forbidden)
@@ -144,48 +214,85 @@ class _HomogeneousViewportElement extends RenderObjectElement<HomogeneousViewpor
     }, building: true);
   }
 
-  void _updateChildren() {
-    assert(_layoutFirstIndex != null);
-    assert(_layoutItemCount != null);
-    List<Widget> newWidgets;
-    if (_layoutItemCount > 0)
-      newWidgets = widget.builder(this, _layoutFirstIndex, _layoutItemCount).map((Widget widget) {
-        return new RepaintBoundary(key: new ValueKey<Key>(widget.key), child: widget);
-      }).toList();
-    else
-      newWidgets = <Widget>[];
-    _children = updateChildren(_children, newWidgets);
-  }
-
   double getTotalExtent(BoxConstraints constraints) {
     // constraints is null when called by layout() above
     return widget.itemCount != null ? widget.itemCount * widget.itemExtent : double.INFINITY;
   }
+}
 
-  double getMinCrossAxisExtent(BoxConstraints constraints) {
-    return 0.0;
+class HomogeneousPageViewport extends _ViewportBase {
+  HomogeneousPageViewport({
+    Key key,
+    ListBuilder builder,
+    bool itemsWrap: false,
+    int itemCount, // optional, but you cannot shrink-wrap this class or otherwise use its intrinsic dimensions if you don't specify it
+    ScrollDirection direction: ScrollDirection.vertical,
+    double startOffset: 0.0,
+    Painter overlayPainter
+  }) : super(
+    key: key,
+    builder: builder,
+    itemsWrap: itemsWrap,
+    itemCount: itemCount,
+    direction: direction,
+    startOffset: startOffset,
+    overlayPainter: overlayPainter
+   );
+
+  _HomogeneousPageViewportElement createElement() => new _HomogeneousPageViewportElement(this);
+}
+
+class _HomogeneousPageViewportElement extends _ViewportBaseElement<HomogeneousPageViewport> {
+  _HomogeneousPageViewportElement(HomogeneousPageViewport widget) : super(widget);
+
+  void layout(BoxConstraints constraints) {
+    // We enter a build scope (meaning that markNeedsBuild() is forbidden)
+    // because we are in the middle of layout and if we allowed people to set
+    // state, they'd expect to have that state reflected immediately, which, if
+    // we were to try to honour it, would potentially result in assertions
+    // because you can't normally mutate the render object tree during layout.
+    // (If there were a way to limit these writes to descendants of this, it'd
+    // be ok because we are exempt from that assert since we are still actively
+    // doing our own layout.)
+    BuildableElement.lockState(() {
+      double itemExtent = widget.direction == ScrollDirection.vertical ? constraints.maxHeight : constraints.maxWidth;
+      double contentExtent = itemExtent * widget.itemCount;
+      double offset;
+      if (widget.startOffset <= 0.0 && !widget.itemsWrap) {
+        _layoutFirstIndex = 0;
+        offset = -widget.startOffset * itemExtent;
+      } else {
+        _layoutFirstIndex = widget.startOffset.floor();
+        offset = -((widget.startOffset * itemExtent) % itemExtent);
+      }
+      if (itemExtent < double.INFINITY) {
+        _layoutItemCount = ((contentExtent - offset) / contentExtent).ceil();
+        if (widget.itemCount != null && !widget.itemsWrap)
+          _layoutItemCount = math.min(_layoutItemCount, widget.itemCount - _layoutFirstIndex);
+      } else {
+        assert(() {
+          'This HomogeneousPageViewport has no specified number of items (meaning it has infinite items), ' +
+          'and has been placed in an unconstrained environment where all items can be rendered. ' +
+          'It is most likely that you have placed your HomogeneousPageViewport (which is an internal ' +
+          'component of several scrollable widgets) inside either another scrolling box, a flexible ' +
+          'box (Row, Column), or a Stack, without giving it a specific size.';
+          return widget.itemCount != null;
+        });
+        _layoutItemCount = widget.itemCount - _layoutFirstIndex;
+      }
+      _layoutItemCount = math.max(0, _layoutItemCount);
+      _updateChildren();
+      // Update the renderObject configuration
+      renderObject.direction = widget.direction == ScrollDirection.vertical ? BlockDirection.vertical : BlockDirection.horizontal;
+      renderObject.itemExtent = itemExtent;
+      renderObject.minExtent = itemExtent;
+      renderObject.startOffset = offset;
+      renderObject.overlayPainter = widget.overlayPainter;
+    }, building: true);
   }
 
-  double getMaxCrossAxisExtent(BoxConstraints constraints) {
-    if (widget.direction == ScrollDirection.vertical)
-      return constraints.maxWidth;
-    return constraints.maxHeight;
+  double getTotalExtent(BoxConstraints constraints) {
+    double itemExtent = widget.direction == ScrollDirection.vertical ? constraints.maxHeight : constraints.maxWidth;
+    return widget.itemCount != null ? widget.itemCount * itemExtent : double.INFINITY;
   }
-
-  void insertChildRenderObject(RenderObject child, Element slot) {
-    RenderObject nextSibling = slot?.renderObject;
-    renderObject.add(child, before: nextSibling);
-  }
-
-  void moveChildRenderObject(RenderObject child, Element slot) {
-    assert(child.parent == renderObject);
-    RenderObject nextSibling = slot?.renderObject;
-    renderObject.move(child, before: nextSibling);
-  }
-
-  void removeChildRenderObject(RenderObject child) {
-    assert(child.parent == renderObject);
-    renderObject.remove(child);
-  }
-
 }

--- a/packages/flutter/lib/src/widgets/pageable_list.dart
+++ b/packages/flutter/lib/src/widgets/pageable_list.dart
@@ -1,0 +1,185 @@
+// Copyright 2015 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:math' as math;
+
+import 'package:flutter/animation.dart';
+import 'package:flutter/gestures.dart';
+import 'package:flutter/rendering.dart';
+
+import 'basic.dart';
+import 'framework.dart';
+import 'homogeneous_viewport.dart';
+import 'scrollable.dart';
+
+enum ItemsSnapAlignment { item, adjacentItem }
+
+typedef void PageChangedCallback(int newPage);
+
+class PageableList<T> extends Scrollable {
+  PageableList({
+    Key key,
+    initialScrollOffset,
+    ScrollDirection scrollDirection: ScrollDirection.vertical,
+    ScrollListener onScrollStart,
+    ScrollListener onScroll,
+    ScrollListener onScrollEnd,
+    SnapOffsetCallback snapOffsetCallback,
+    double snapAlignmentOffset: 0.0,
+    this.items,
+    this.itemBuilder,
+    this.itemsWrap: false,
+    this.itemsSnapAlignment: ItemsSnapAlignment.adjacentItem,
+    this.onPageChanged,
+    this.scrollableListPainter,
+    this.duration: const Duration(milliseconds: 200),
+    this.curve: Curves.ease
+  }) : super(
+    key: key,
+    initialScrollOffset: initialScrollOffset,
+    scrollDirection: scrollDirection,
+    onScrollStart: onScrollStart,
+    onScroll: onScroll,
+    onScrollEnd: onScrollEnd,
+    snapOffsetCallback: snapOffsetCallback,
+    snapAlignmentOffset: snapAlignmentOffset
+  );
+
+  final List<T> items;
+  final ItemBuilder<T> itemBuilder;
+  final ItemsSnapAlignment itemsSnapAlignment;
+  final bool itemsWrap;
+  final PageChangedCallback onPageChanged;
+  final ScrollableListPainter scrollableListPainter;
+  final Duration duration;
+  final Curve curve;
+
+  PageableListState<T, PageableList<T>> createState() => new PageableListState<T, PageableList<T>>();
+}
+
+class PageableListState<T, Config extends PageableList<T>> extends ScrollableState<Config> {
+
+  int get itemCount => config.items?.length ?? 0;
+  int _previousItemCount;
+
+  double pixelToScrollOffset(double value) {
+    final RenderBox box = context.findRenderObject();
+    if (box == null || !box.hasSize)
+      return 0.0;
+    final double pixelScrollExtent = config.scrollDirection == ScrollDirection.vertical ? box.size.height : box.size.width;
+    return pixelScrollExtent == 0.0 ? 0.0 : value / pixelScrollExtent;
+  }
+
+  void didUpdateConfig(Config oldConfig) {
+    super.didUpdateConfig(oldConfig);
+
+    bool scrollBehaviorUpdateNeeded = config.scrollDirection != oldConfig.scrollDirection;
+
+    if (config.itemsWrap != oldConfig.itemsWrap)
+      scrollBehaviorUpdateNeeded = true;
+
+    if (itemCount != _previousItemCount) {
+      _previousItemCount = itemCount;
+      scrollBehaviorUpdateNeeded = true;
+    }
+
+    if (scrollBehaviorUpdateNeeded)
+      _updateScrollBehavior();
+  }
+
+  void _updateScrollBehavior() {
+    // if you don't call this from build(), you must call it from setState().
+    if (config.scrollableListPainter != null)
+      config.scrollableListPainter.contentExtent = itemCount.toDouble();
+    scrollTo(scrollBehavior.updateExtents(
+      contentExtent: itemCount.toDouble(),
+      containerExtent: 1.0,
+      scrollOffset: scrollOffset
+    ));
+  }
+
+  void dispatchOnScrollStart() {
+    super.dispatchOnScrollStart();
+    config.scrollableListPainter?.scrollStarted();
+  }
+
+  void dispatchOnScroll() {
+    super.dispatchOnScroll();
+    if (config.scrollableListPainter != null)
+      config.scrollableListPainter.scrollOffset = scrollOffset;
+  }
+
+  void dispatchOnScrollEnd() {
+    super.dispatchOnScrollEnd();
+    config.scrollableListPainter?.scrollEnded();
+  }
+
+  Widget buildContent(BuildContext context) {
+    if (itemCount != _previousItemCount) {
+      _previousItemCount = itemCount;
+      _updateScrollBehavior();
+    }
+    return new HomogeneousPageViewport(
+      builder: buildItems,
+      itemsWrap: config.itemsWrap,
+      itemCount: itemCount,
+      direction: config.scrollDirection,
+      startOffset: scrollOffset,
+      overlayPainter: config.scrollableListPainter
+    );
+  }
+
+  ScrollBehavior createScrollBehavior() {
+    return config.itemsWrap ? new UnboundedBehavior() : new OverscrollBehavior();
+  }
+
+  ExtentScrollBehavior get scrollBehavior => super.scrollBehavior;
+
+  bool get snapScrollOffsetChanges => config.itemsSnapAlignment == ItemsSnapAlignment.item;
+
+  double snapScrollOffset(double newScrollOffset) {
+    double previousItemOffset = newScrollOffset.floorToDouble();
+    double nextItemOffset = newScrollOffset.ceilToDouble();
+    return (newScrollOffset - previousItemOffset < 0.5 ? previousItemOffset : nextItemOffset)
+      .clamp(scrollBehavior.minScrollOffset, scrollBehavior.maxScrollOffset);
+  }
+
+  Future _flingToAdjacentItem(Offset velocity) {
+    double scrollVelocity = scrollDirectionVelocity(velocity);
+    double newScrollOffset = snapScrollOffset(scrollOffset + scrollVelocity.sign)
+      .clamp(snapScrollOffset(scrollOffset - 0.5), snapScrollOffset(scrollOffset + 0.5));
+    return scrollTo(newScrollOffset, duration: config.duration, curve: config.curve)
+      .then(_notifyPageChanged);
+  }
+
+  Future fling(Offset velocity) {
+    switch(config.itemsSnapAlignment) {
+      case ItemsSnapAlignment.adjacentItem:
+        return _flingToAdjacentItem(velocity);
+      default:
+        return super.fling(velocity).then(_notifyPageChanged);
+    }
+  }
+
+  Future settleScrollOffset() {
+    return scrollTo(snapScrollOffset(scrollOffset), duration: config.duration, curve: config.curve)
+      .then(_notifyPageChanged);
+  }
+
+  List<Widget> buildItems(BuildContext context, int start, int count) {
+    List<Widget> result = new List<Widget>();
+    int begin = config.itemsWrap ? start : math.max(0, start);
+    int end = config.itemsWrap ? begin + count : math.min(begin + count, config.items.length);
+    for (int i = begin; i < end; ++i)
+      result.add(config.itemBuilder(context, config.items[i % itemCount], i));
+    assert(result.every((Widget item) => item.key != null));
+    return result;
+  }
+
+  void _notifyPageChanged(_) {
+    if (config.onPageChanged != null)
+      config.onPageChanged(itemCount == 0 ? 0 : scrollOffset.floor() % itemCount);
+  }
+}

--- a/packages/flutter/lib/widgets.dart
+++ b/packages/flutter/lib/widgets.dart
@@ -28,6 +28,7 @@ export 'src/widgets/notification_listener.dart';
 export 'src/widgets/overlay.dart';
 export 'src/widgets/page_storage.dart';
 export 'src/widgets/pages.dart';
+export 'src/widgets/pageable_list.dart';
 export 'src/widgets/placeholder.dart';
 export 'src/widgets/routes.dart';
 export 'src/widgets/scrollable.dart';

--- a/packages/unit/test/widget/pageable_list_test.dart
+++ b/packages/unit/test/widget/pageable_list_test.dart
@@ -27,7 +27,6 @@ Widget buildFrame() {
     items: pages,
     itemBuilder: buildPage,
     itemsWrap: itemsWrap,
-    itemExtent: pageSize.width,
     scrollDirection: ScrollDirection.horizontal,
     onPageChanged: (int page) { currentPage = page; }
   );

--- a/packages/unit/test/widget/snap_scrolling_test.dart
+++ b/packages/unit/test/widget/snap_scrolling_test.dart
@@ -57,7 +57,7 @@ Future fling(double velocity) {
 }
 
 void main() {
-  test('ScrollableList snap scrolling, fling(-800)', () {
+  test('ScrollableList snap scrolling, fling(-0.8)', () {
     testWidgets((WidgetTester tester) {
       tester.pumpWidget(buildFrame());
 
@@ -67,7 +67,7 @@ void main() {
 
       Duration dt = const Duration(seconds: 2);
 
-      fling(-800.0);
+      fling(-0.8);
       tester.pump(); // Start the scheduler at 0.0
       tester.pump(dt);
       expect(scrollOffset, closeTo(200.0, 1.0));
@@ -76,7 +76,7 @@ void main() {
       tester.pump();
       expect(scrollOffset, 0.0);
 
-      fling(-2000.0);
+      fling(-2.0);
       tester.pump();
       tester.pump(dt);
       expect(scrollOffset, closeTo(400.0, 1.0));
@@ -85,7 +85,7 @@ void main() {
       tester.pump();
       expect(scrollOffset, 400.0);
 
-      fling(800.0);
+      fling(0.8);
       tester.pump();
       tester.pump(dt);
       expect(scrollOffset, closeTo(0.0, 1.0));
@@ -94,7 +94,7 @@ void main() {
       tester.pump();
       expect(scrollOffset, 800.0);
 
-      fling(2000.0);
+      fling(2.0);
       tester.pump();
       tester.pump(dt);
       expect(scrollOffset, closeTo(200.0, 1.0));
@@ -104,7 +104,7 @@ void main() {
       expect(scrollOffset, 800.0);
 
       bool completed = false;
-      fling(2000.0).then((_) {
+      fling(2.0).then((_) {
         completed = true;
         expect(scrollOffset, closeTo(200.0, 1.0));
       });


### PR DESCRIPTION
- An itemExtent-computing SizeObserver is no longer needed to use PageableList. The PageableList just uses its own size as the itemExtent.
- Added the itemsSnapAlignment property to PageableList which enables snapping scrolls to an adjacent item (the default), or any item boundary no not at all.
- PageableList scrollOffsets now vary from 0.0 to itemCount instead of 0.0 to itemExtent \* itemCount. Using logical coordinates instead of pixel coordinates means that the scroll position is insensitive to changes in the PageablList's size.
- Added HomogenousPageViewport which is used by PageableList. HomogenousPageViewport scrollOffsets are defined as for PageableList.
- Factored the (substantial) common parts of HomogenousViewport HomogenousPageViewport into  a file private _ViewportBase class.
  
  -Removed PageableWidgetList. PageableList now just extends Scrollable. Moved PageableList into its own file.
- Removed the pixel dependencies from ScrollBehavior. ScrollBehavior.createFlingSimulation() no longer sets the simulation's tolerance. The caller must do this instead.
- Scrollable now uses pixelToScrollOffset() to convert from input gesture positions and velocities to scrollOffsets.

Fixes https://github.com/flutter/flutter/issues/710
