### PR TITLE
Add a test to stocks for changing the locale

### DIFF
--- a/examples/stocks/pubspec.yaml
+++ b/examples/stocks/pubspec.yaml
@@ -4,3 +4,6 @@ dependencies:
     path: ../../packages/flutter
 
   intl: '>=0.12.4+2 <0.13.0'
+dev_dependencies:
+  flutter_test:
+    path: ../../packages/flutter_test

--- a/examples/stocks/tests/locale_test.dart
+++ b/examples/stocks/tests/locale_test.dart
@@ -1,0 +1,23 @@
+
+import 'package:test/test.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter/material.dart';
+import 'package:stocks/main.dart' as stocks;
+import 'package:stocks/stock_data.dart' as stock_data;
+
+void main() {
+  stock_data.StockDataFetcher.actuallyFetchData = false;
+
+  test("Test changing locale", () {
+    testWidgets((WidgetTester tester) {
+      stocks.main();
+      tester.pump(const Duration(seconds: 1)); // Unclear why duration is required.
+
+      Element<Text> tab = tester.findText('MARKET');
+      expect(tab, isNotNull);
+      tester.setLocale("es", "US");
+      tester.pump();
+      expect(tab.widget.data, equals("MERCADO"));
+    });
+  });
+}

--- a/packages/flutter/lib/src/rendering/binding.dart
+++ b/packages/flutter/lib/src/rendering/binding.dart
@@ -29,7 +29,7 @@ class _PointerState {
     _pointerCount += 1;
     _pointer = _pointerCount;
   }
-  
+
   bool get down => _down;
   bool _down = false;
   void setDown() {
@@ -247,8 +247,12 @@ class FlutterBinding extends HitTestTarget {
   }
 
   void _handleLocaleChanged() {
+    dispatchLocaleChanged(ui.window.locale);
+  }
+
+  void dispatchLocaleChanged(ui.Locale locale) {
     for (BindingObserver observer in _observers)
-      observer.didChangeLocale(ui.window.locale);
+      observer.didChangeLocale(locale);
   }
 
   void _handlePersistentFrameCallback(Duration timeStamp) {

--- a/packages/flutter_test/lib/src/widget_tester.dart
+++ b/packages/flutter_test/lib/src/widget_tester.dart
@@ -32,6 +32,12 @@ class WidgetTester {
     pump(duration);
   }
 
+  void setLocale(String languageCode, String countryCode) {
+    ui.Locale locale = new ui.Locale(languageCode, countryCode);
+    FlutterBinding.instance.dispatchLocaleChanged(locale);
+    async.flushMicrotasks();
+  }
+
   void pump([ Duration duration ]) {
     if (duration != null)
       async.elapse(duration);

--- a/travis/test.sh
+++ b/travis/test.sh
@@ -1,11 +1,13 @@
 #!/bin/bash
 set -ex
 
+export PATH="$PWD/bin:$PATH"
+
 # analyze all the Dart code in the repo
-./bin/flutter analyze --flutter-repo --no-current-directory --no-current-package --congratulate
+flutter analyze --flutter-repo --no-current-directory --no-current-package --congratulate
 
 # flutter package tests
-./bin/flutter test --flutter-repo
+flutter test --flutter-repo
 
 (cd packages/cassowary; pub run test -j1)
 # (cd packages/flutter_sprites; ) # No tests to run.
@@ -14,6 +16,8 @@ set -ex
 (cd packages/newton; pub run test -j1)
 # (cd packages/playfair; ) # No tests to run.
 # (cd packages/updater; ) # No tests to run.
+
+(cd examples/stocks; flutter test)
 
 if [ $TRAVIS_PULL_REQUEST = "false" ]; then
   if [ $TRAVIS_BRANCH = "master" ]; then


### PR DESCRIPTION
I had to add a setLocale method to WidgetTester and
split the code in FlutterBinding which handled locale
changes to allow me to dispatch a locale change w/o actually
changing what the c++ code reports as the locale.

Also added the test to Travis.

@abarth @jason-simmons
