### PR TITLE
Catch un-normalized BoxConstraints

### DIFF
--- a/examples/rendering/lib/sector_layout.dart
+++ b/examples/rendering/lib/sector_layout.dart
@@ -37,6 +37,8 @@ class SectorConstraints extends Constraints {
   }
 
   bool get isTight => minDeltaTheta >= maxDeltaTheta && minDeltaTheta >= maxDeltaTheta;
+
+  bool get isNormalized => minDeltaRadius <= maxDeltaRadius && minDeltaTheta <= maxDeltaTheta;
 }
 
 class SectorDimensions {

--- a/packages/flutter/lib/src/rendering/block.dart
+++ b/packages/flutter/lib/src/rendering/block.dart
@@ -167,6 +167,7 @@ class RenderBlock extends RenderBlockBase {
   }
 
   double getMinIntrinsicWidth(BoxConstraints constraints) {
+    assert(constraints.isNormalized);
     if (isVertical) {
       return _getIntrinsicCrossAxis(
         constraints,
@@ -177,6 +178,7 @@ class RenderBlock extends RenderBlockBase {
   }
 
   double getMaxIntrinsicWidth(BoxConstraints constraints) {
+    assert(constraints.isNormalized);
     if (isVertical) {
       return _getIntrinsicCrossAxis(
         constraints,
@@ -187,6 +189,7 @@ class RenderBlock extends RenderBlockBase {
   }
 
   double getMinIntrinsicHeight(BoxConstraints constraints) {
+    assert(constraints.isNormalized);
     if (isVertical)
       return _getIntrinsicMainAxis(constraints);
     return _getIntrinsicCrossAxis(
@@ -196,6 +199,7 @@ class RenderBlock extends RenderBlockBase {
   }
 
   double getMaxIntrinsicHeight(BoxConstraints constraints) {
+    assert(constraints.isNormalized);
     if (isVertical)
       return _getIntrinsicMainAxis(constraints);
     return _getIntrinsicCrossAxis(
@@ -361,24 +365,28 @@ class RenderBlockViewport extends RenderBlockBase {
   }
 
   double getMinIntrinsicWidth(BoxConstraints constraints) {
+    assert(constraints.isNormalized);
     if (isVertical)
       return _getIntrinsicDimension(constraints, minCrossAxisExtentCallback, constraints.constrainWidth);
     return constraints.constrainWidth(minExtent);
   }
 
   double getMaxIntrinsicWidth(BoxConstraints constraints) {
+    assert(constraints.isNormalized);
     if (isVertical)
       return _getIntrinsicDimension(constraints, maxCrossAxisExtentCallback, constraints.constrainWidth);
     return _getIntrinsicDimension(constraints, totalExtentCallback, new BoxConstraints(minWidth: minExtent).enforce(constraints).constrainWidth);
   }
 
   double getMinIntrinsicHeight(BoxConstraints constraints) {
+    assert(constraints.isNormalized);
     if (!isVertical)
       return _getIntrinsicDimension(constraints, minCrossAxisExtentCallback, constraints.constrainHeight);
     return constraints.constrainHeight(0.0);
   }
 
   double getMaxIntrinsicHeight(BoxConstraints constraints) {
+    assert(constraints.isNormalized);
     if (!isVertical)
       return _getIntrinsicDimension(constraints, maxCrossAxisExtentCallback, constraints.constrainHeight);
     return _getIntrinsicDimension(constraints, totalExtentCallback, new BoxConstraints(minHeight: minExtent).enforce(constraints).constrainHeight);

--- a/packages/flutter/lib/src/rendering/custom_layout.dart
+++ b/packages/flutter/lib/src/rendering/custom_layout.dart
@@ -41,6 +41,7 @@ abstract class MultiChildLayoutDelegate {
       'A MultiChildLayoutDelegate cannot layout the same child more than once.';
       return _debugChildrenNeedingLayout.remove(child);
     });
+    assert(constraints.isNormalized);
     child.layout(constraints, parentUsesSize: true);
     return child.size;
   }
@@ -130,6 +131,7 @@ class RenderCustomMultiChildLayoutBox extends RenderBox
   }
 
   Size _getSize(BoxConstraints constraints) {
+    assert(constraints.isNormalized);
     return constraints.constrain(_delegate.getSize(constraints));
   }
 

--- a/packages/flutter/lib/src/rendering/editable_paragraph.dart
+++ b/packages/flutter/lib/src/rendering/editable_paragraph.dart
@@ -60,6 +60,7 @@ class RenderEditableParagraph extends RenderParagraph {
   }
 
   BoxConstraints _getTextContraints(BoxConstraints constraints) {
+    assert(constraints.isNormalized);
     return new BoxConstraints(
       minWidth: 0.0,
       maxWidth: double.INFINITY,

--- a/packages/flutter/lib/src/rendering/flex.dart
+++ b/packages/flutter/lib/src/rendering/flex.dart
@@ -148,6 +148,7 @@ class RenderFlex extends RenderBox with ContainerRenderObjectMixin<RenderBox, Fl
   double _getIntrinsicSize({ BoxConstraints constraints,
                              FlexDirection sizingDirection,
                              _ChildSizingFunction childSize }) {
+    assert(constraints.isNormalized);
     // http://www.w3.org/TR/2015/WD-css-flexbox-1-20150514/#intrinsic-sizes
     if (_direction == sizingDirection) {
       // INTRINSIC MAIN SIZE

--- a/packages/flutter/lib/src/rendering/grid.dart
+++ b/packages/flutter/lib/src/rendering/grid.dart
@@ -74,21 +74,25 @@ class RenderGrid extends RenderBox with ContainerRenderObjectMixin<RenderBox, Gr
   }
 
   double getMinIntrinsicWidth(BoxConstraints constraints) {
+    assert(constraints.isNormalized);
     // We can render at any width.
     return constraints.constrainWidth(0.0);
   }
 
   double getMaxIntrinsicWidth(BoxConstraints constraints) {
+    assert(constraints.isNormalized);
     double maxWidth = childCount * _maxChildExtent;
     return constraints.constrainWidth(maxWidth);
   }
 
   double getMinIntrinsicHeight(BoxConstraints constraints) {
+    assert(constraints.isNormalized);
     double desiredHeight = _computeMetrics().size.height;
     return constraints.constrainHeight(desiredHeight);
   }
 
   double getMaxIntrinsicHeight(BoxConstraints constraints) {
+    assert(constraints.isNormalized);
     return getMinIntrinsicHeight(constraints);
   }
 

--- a/packages/flutter/lib/src/rendering/image.dart
+++ b/packages/flutter/lib/src/rendering/image.dart
@@ -172,22 +172,26 @@ class RenderImage extends RenderBox {
   }
 
   double getMinIntrinsicWidth(BoxConstraints constraints) {
+    assert(constraints.isNormalized);
     if (_width == null && _height == null)
       return constraints.constrainWidth(0.0);
     return _sizeForConstraints(constraints).width;
   }
 
   double getMaxIntrinsicWidth(BoxConstraints constraints) {
+    assert(constraints.isNormalized);
     return _sizeForConstraints(constraints).width;
   }
 
   double getMinIntrinsicHeight(BoxConstraints constraints) {
+    assert(constraints.isNormalized);
     if (_width == null && _height == null)
       return constraints.constrainHeight(0.0);
     return _sizeForConstraints(constraints).height;
   }
 
   double getMaxIntrinsicHeight(BoxConstraints constraints) {
+    assert(constraints.isNormalized);
     return _sizeForConstraints(constraints).height;
   }
 

--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -366,6 +366,9 @@ abstract class Constraints {
 
   /// Whether there is exactly one size possible given these constraints
   bool get isTight;
+
+  /// Whether the constraint is expressed in a consistent manner.
+  bool get isNormalized;
 }
 
 typedef void RenderObjectVisitor(RenderObject child);
@@ -657,6 +660,7 @@ abstract class RenderObject extends AbstractNode implements HitTestTarget {
   /// implemented here) to return early if the child does not need to do any
   /// work to update its layout information.
   void layout(Constraints constraints, { bool parentUsesSize: false }) {
+    assert(constraints.isNormalized);
     assert(!_debugDoingThisResize);
     assert(!_debugDoingThisLayout);
     final RenderObject parent = this.parent;

--- a/packages/flutter/lib/src/rendering/overflow.dart
+++ b/packages/flutter/lib/src/rendering/overflow.dart
@@ -93,18 +93,22 @@ class RenderOverflowBox extends RenderBox with RenderObjectWithChildMixin<Render
   }
 
   double getMinIntrinsicWidth(BoxConstraints constraints) {
+    assert(constraints.isNormalized);
     return constraints.constrainWidth();
   }
 
   double getMaxIntrinsicWidth(BoxConstraints constraints) {
+    assert(constraints.isNormalized);
     return constraints.constrainWidth();
   }
 
   double getMinIntrinsicHeight(BoxConstraints constraints) {
+    assert(constraints.isNormalized);
     return constraints.constrainHeight();
   }
 
   double getMaxIntrinsicHeight(BoxConstraints constraints) {
+    assert(constraints.isNormalized);
     return constraints.constrainHeight();
   }
 
@@ -165,18 +169,22 @@ class RenderSizedOverflowBox extends RenderBox with RenderObjectWithChildMixin<R
   }
 
   double getMinIntrinsicWidth(BoxConstraints constraints) {
+    assert(constraints.isNormalized);
     return constraints.constrainWidth(_requestedSize.width);
   }
 
   double getMaxIntrinsicWidth(BoxConstraints constraints) {
+    assert(constraints.isNormalized);
     return constraints.constrainWidth(_requestedSize.width);
   }
 
   double getMinIntrinsicHeight(BoxConstraints constraints) {
+    assert(constraints.isNormalized);
     return constraints.constrainWidth(_requestedSize.height);
   }
 
   double getMaxIntrinsicHeight(BoxConstraints constraints) {
+    assert(constraints.isNormalized);
     return constraints.constrainWidth(_requestedSize.height);
   }
 

--- a/packages/flutter/lib/src/rendering/paragraph.dart
+++ b/packages/flutter/lib/src/rendering/paragraph.dart
@@ -49,6 +49,7 @@ class RenderParagraph extends RenderBox {
 
   void layoutText(BoxConstraints constraints) {
     assert(constraints != null);
+    assert(constraints.isNormalized);
     if (_constraintsForCurrentLayout == constraints)
       return; // already cached this layout
     textPainter.maxWidth = constraints.maxWidth;
@@ -80,10 +81,12 @@ class RenderParagraph extends RenderBox {
   }
 
   double getMinIntrinsicHeight(BoxConstraints constraints) {
+    assert(constraints.isNormalized);
     return _getIntrinsicHeight(constraints);
   }
 
   double getMaxIntrinsicHeight(BoxConstraints constraints) {
+    assert(constraints.isNormalized);
     return _getIntrinsicHeight(constraints);
   }
 

--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -38,24 +38,28 @@ class RenderProxyBox extends RenderBox with RenderObjectWithChildMixin<RenderBox
   }
 
   double getMinIntrinsicWidth(BoxConstraints constraints) {
+    assert(constraints.isNormalized);
     if (child != null)
       return child.getMinIntrinsicWidth(constraints);
     return super.getMinIntrinsicWidth(constraints);
   }
 
   double getMaxIntrinsicWidth(BoxConstraints constraints) {
+    assert(constraints.isNormalized);
     if (child != null)
       return child.getMaxIntrinsicWidth(constraints);
     return super.getMaxIntrinsicWidth(constraints);
   }
 
   double getMinIntrinsicHeight(BoxConstraints constraints) {
+    assert(constraints.isNormalized);
     if (child != null)
       return child.getMinIntrinsicHeight(constraints);
     return super.getMinIntrinsicHeight(constraints);
   }
 
   double getMaxIntrinsicHeight(BoxConstraints constraints) {
+    assert(constraints.isNormalized);
     if (child != null)
       return child.getMaxIntrinsicHeight(constraints);
     return super.getMaxIntrinsicHeight(constraints);
@@ -102,6 +106,7 @@ class RenderConstrainedBox extends RenderProxyBox {
     BoxConstraints additionalConstraints
   }) : _additionalConstraints = additionalConstraints, super(child) {
     assert(additionalConstraints != null);
+    assert(additionalConstraints.isNormalized);
   }
 
   /// Additional constraints to apply to [child] during layout
@@ -109,6 +114,7 @@ class RenderConstrainedBox extends RenderProxyBox {
   BoxConstraints _additionalConstraints;
   void set additionalConstraints (BoxConstraints newConstraints) {
     assert(newConstraints != null);
+    assert(newConstraints.isNormalized);
     if (_additionalConstraints == newConstraints)
       return;
     _additionalConstraints = newConstraints;
@@ -116,24 +122,28 @@ class RenderConstrainedBox extends RenderProxyBox {
   }
 
   double getMinIntrinsicWidth(BoxConstraints constraints) {
+    assert(constraints.isNormalized);
     if (child != null)
       return child.getMinIntrinsicWidth(_additionalConstraints.enforce(constraints));
     return _additionalConstraints.enforce(constraints).constrainWidth(0.0);
   }
 
   double getMaxIntrinsicWidth(BoxConstraints constraints) {
+    assert(constraints.isNormalized);
     if (child != null)
       return child.getMaxIntrinsicWidth(_additionalConstraints.enforce(constraints));
     return _additionalConstraints.enforce(constraints).constrainWidth(0.0);
   }
 
   double getMinIntrinsicHeight(BoxConstraints constraints) {
+    assert(constraints.isNormalized);
     if (child != null)
       return child.getMinIntrinsicHeight(_additionalConstraints.enforce(constraints));
     return _additionalConstraints.enforce(constraints).constrainHeight(0.0);
   }
 
   double getMaxIntrinsicHeight(BoxConstraints constraints) {
+    assert(constraints.isNormalized);
     if (child != null)
       return child.getMaxIntrinsicHeight(_additionalConstraints.enforce(constraints));
     return _additionalConstraints.enforce(constraints).constrainHeight(0.0);
@@ -221,24 +231,28 @@ class RenderFractionallySizedBox extends RenderProxyBox {
   }
 
   double getMinIntrinsicWidth(BoxConstraints constraints) {
+    assert(constraints.isNormalized);
     if (child != null)
       return child.getMinIntrinsicWidth(_getInnerConstraints(constraints));
     return _getInnerConstraints(constraints).constrainWidth(0.0);
   }
 
   double getMaxIntrinsicWidth(BoxConstraints constraints) {
+    assert(constraints.isNormalized);
     if (child != null)
       return child.getMaxIntrinsicWidth(_getInnerConstraints(constraints));
     return _getInnerConstraints(constraints).constrainWidth(0.0);
   }
 
   double getMinIntrinsicHeight(BoxConstraints constraints) {
+    assert(constraints.isNormalized);
     if (child != null)
       return child.getMinIntrinsicHeight(_getInnerConstraints(constraints));
     return _getInnerConstraints(constraints).constrainHeight(0.0);
   }
 
   double getMaxIntrinsicHeight(BoxConstraints constraints) {
+    assert(constraints.isNormalized);
     if (child != null)
       return child.getMaxIntrinsicHeight(_getInnerConstraints(constraints));
     return _getInnerConstraints(constraints).constrainHeight(0.0);
@@ -307,6 +321,7 @@ class RenderAspectRatio extends RenderProxyBox {
   }
 
   Size _applyAspectRatio(BoxConstraints constraints) {
+    assert(constraints.isNormalized);
     double width = constraints.constrainWidth();
     double height = constraints.constrainHeight(width / _aspectRatio);
     return new Size(width, height);
@@ -385,10 +400,12 @@ class RenderIntrinsicWidth extends RenderProxyBox {
   }
 
   double getMinIntrinsicWidth(BoxConstraints constraints) {
+    assert(constraints.isNormalized);
     return getMaxIntrinsicWidth(constraints);
   }
 
   double getMaxIntrinsicWidth(BoxConstraints constraints) {
+    assert(constraints.isNormalized);
     if (child == null)
       return constraints.constrainWidth(0.0);
     double childResult = child.getMaxIntrinsicWidth(constraints);
@@ -396,6 +413,7 @@ class RenderIntrinsicWidth extends RenderProxyBox {
   }
 
   double getMinIntrinsicHeight(BoxConstraints constraints) {
+    assert(constraints.isNormalized);
     if (child == null)
       return constraints.constrainHeight(0.0);
     double childResult = child.getMinIntrinsicHeight(_getInnerConstraints(constraints));
@@ -403,6 +421,7 @@ class RenderIntrinsicWidth extends RenderProxyBox {
   }
 
   double getMaxIntrinsicHeight(BoxConstraints constraints) {
+    assert(constraints.isNormalized);
     if (child == null)
       return constraints.constrainHeight(0.0);
     double childResult = child.getMaxIntrinsicHeight(_getInnerConstraints(constraints));
@@ -451,22 +470,26 @@ class RenderIntrinsicHeight extends RenderProxyBox {
   }
 
   double getMinIntrinsicWidth(BoxConstraints constraints) {
+    assert(constraints.isNormalized);
     if (child == null)
       return constraints.constrainWidth(0.0);
     return child.getMinIntrinsicWidth(_getInnerConstraints(constraints));
   }
 
   double getMaxIntrinsicWidth(BoxConstraints constraints) {
+    assert(constraints.isNormalized);
     if (child == null)
       return constraints.constrainWidth(0.0);
     return child.getMaxIntrinsicWidth(_getInnerConstraints(constraints));
   }
 
   double getMinIntrinsicHeight(BoxConstraints constraints) {
+    assert(constraints.isNormalized);
     return getMaxIntrinsicHeight(constraints);
   }
 
   double getMaxIntrinsicHeight(BoxConstraints constraints) {
+    assert(constraints.isNormalized);
     if (child == null)
       return constraints.constrainHeight(0.0);
     return child.getMaxIntrinsicHeight(constraints);

--- a/packages/flutter/lib/src/rendering/shifted_box.dart
+++ b/packages/flutter/lib/src/rendering/shifted_box.dart
@@ -7,33 +7,36 @@ import 'package:flutter/painting.dart';
 import 'box.dart';
 import 'object.dart';
 
+/// Abstract class for one-child-layout render boxes that provide control over
+/// the child's position.
 abstract class RenderShiftedBox extends RenderBox with RenderObjectWithChildMixin<RenderBox> {
-
-  // Abstract class for one-child-layout render boxes
-
   RenderShiftedBox(RenderBox child) {
     this.child = child;
   }
 
   double getMinIntrinsicWidth(BoxConstraints constraints) {
+    assert(constraints.isNormalized);
     if (child != null)
       return child.getMinIntrinsicWidth(constraints);
     return super.getMinIntrinsicWidth(constraints);
   }
 
   double getMaxIntrinsicWidth(BoxConstraints constraints) {
+    assert(constraints.isNormalized);
     if (child != null)
       return child.getMaxIntrinsicWidth(constraints);
     return super.getMaxIntrinsicWidth(constraints);
   }
 
   double getMinIntrinsicHeight(BoxConstraints constraints) {
+    assert(constraints.isNormalized);
     if (child != null)
       return child.getMinIntrinsicHeight(constraints);
     return super.getMinIntrinsicHeight(constraints);
   }
 
   double getMaxIntrinsicHeight(BoxConstraints constraints) {
+    assert(constraints.isNormalized);
     if (child != null)
       return child.getMaxIntrinsicHeight(constraints);
     return super.getMaxIntrinsicHeight(constraints);
@@ -100,6 +103,7 @@ class RenderPadding extends RenderShiftedBox {
   }
 
   double getMinIntrinsicWidth(BoxConstraints constraints) {
+    assert(constraints.isNormalized);
     double totalPadding = padding.left + padding.right;
     if (child != null)
       return child.getMinIntrinsicWidth(constraints.deflate(padding)) + totalPadding;
@@ -107,6 +111,7 @@ class RenderPadding extends RenderShiftedBox {
   }
 
   double getMaxIntrinsicWidth(BoxConstraints constraints) {
+    assert(constraints.isNormalized);
     double totalPadding = padding.left + padding.right;
     if (child != null)
       return child.getMaxIntrinsicWidth(constraints.deflate(padding)) + totalPadding;
@@ -114,6 +119,7 @@ class RenderPadding extends RenderShiftedBox {
   }
 
   double getMinIntrinsicHeight(BoxConstraints constraints) {
+    assert(constraints.isNormalized);
     double totalPadding = padding.top + padding.bottom;
     if (child != null)
       return child.getMinIntrinsicHeight(constraints.deflate(padding)) + totalPadding;
@@ -121,6 +127,7 @@ class RenderPadding extends RenderShiftedBox {
   }
 
   double getMaxIntrinsicHeight(BoxConstraints constraints) {
+    assert(constraints.isNormalized);
     double totalPadding = padding.top + padding.bottom;
     if (child != null)
       return child.getMaxIntrinsicHeight(constraints.deflate(padding)) + totalPadding;
@@ -282,18 +289,22 @@ class RenderCustomOneChildLayoutBox extends RenderShiftedBox {
   }
 
   double getMinIntrinsicWidth(BoxConstraints constraints) {
+    assert(constraints.isNormalized);
     return _getSize(constraints).width;
   }
 
   double getMaxIntrinsicWidth(BoxConstraints constraints) {
+    assert(constraints.isNormalized);
     return _getSize(constraints).width;
   }
 
   double getMinIntrinsicHeight(BoxConstraints constraints) {
+    assert(constraints.isNormalized);
     return _getSize(constraints).height;
   }
 
   double getMaxIntrinsicHeight(BoxConstraints constraints) {
+    assert(constraints.isNormalized);
     return _getSize(constraints).height;
   }
 
@@ -305,9 +316,11 @@ class RenderCustomOneChildLayoutBox extends RenderShiftedBox {
 
   void performLayout() {
     if (child != null) {
-      child.layout(delegate.getConstraintsForChild(constraints), parentUsesSize: true);
+      BoxConstraints childConstraints = delegate.getConstraintsForChild(constraints);
+      assert(childConstraints.isNormalized);
+      child.layout(childConstraints, parentUsesSize: !childConstraints.isTight);
       final BoxParentData childParentData = child.parentData;
-      childParentData.position = delegate.getPositionForChild(size, child.size);
+      childParentData.position = delegate.getPositionForChild(size, childConstraints.isTight ? childConstraints.smallest : child.size);
     }
   }
 }

--- a/packages/flutter/lib/src/rendering/stack.dart
+++ b/packages/flutter/lib/src/rendering/stack.dart
@@ -222,6 +222,7 @@ abstract class RenderStackBase extends RenderBox
   }
 
   double getMinIntrinsicWidth(BoxConstraints constraints) {
+    assert(constraints.isNormalized);
     double width = constraints.minWidth;
     RenderBox child = firstChild;
     while (child != null) {
@@ -236,6 +237,7 @@ abstract class RenderStackBase extends RenderBox
   }
 
   double getMaxIntrinsicWidth(BoxConstraints constraints) {
+    assert(constraints.isNormalized);
     bool hasNonPositionedChildren = false;
     double width = constraints.minWidth;
     RenderBox child = firstChild;
@@ -255,6 +257,7 @@ abstract class RenderStackBase extends RenderBox
   }
 
   double getMinIntrinsicHeight(BoxConstraints constraints) {
+    assert(constraints.isNormalized);
     double height = constraints.minHeight;
     RenderBox child = firstChild;
     while (child != null) {
@@ -269,6 +272,7 @@ abstract class RenderStackBase extends RenderBox
   }
 
   double getMaxIntrinsicHeight(BoxConstraints constraints) {
+    assert(constraints.isNormalized);
     bool hasNonPositionedChildren = false;
     double height = constraints.minHeight;
     RenderBox child = firstChild;

--- a/packages/flutter/lib/src/rendering/statistics_box.dart
+++ b/packages/flutter/lib/src/rendering/statistics_box.dart
@@ -34,18 +34,22 @@ class RenderStatisticsBox extends RenderBox {
   bool get sizedByParent => true;
 
   double getMinIntrinsicWidth(BoxConstraints constraints) {
+    assert(constraints.isNormalized);
     return constraints.minWidth;
   }
 
   double getMaxIntrinsicWidth(BoxConstraints constraints) {
+    assert(constraints.isNormalized);
     return constraints.maxWidth;
   }
 
   double getMinIntrinsicHeight(BoxConstraints constraints) {
+    assert(constraints.isNormalized);
     return constraints.minHeight;
   }
 
   double getMaxIntrinsicHeight(BoxConstraints constraints) {
+    assert(constraints.isNormalized);
     return constraints.maxHeight;
   }
 

--- a/packages/flutter/lib/src/rendering/viewport.dart
+++ b/packages/flutter/lib/src/rendering/viewport.dart
@@ -98,24 +98,28 @@ class RenderViewport extends RenderBox with RenderObjectWithChildMixin<RenderBox
   }
 
   double getMinIntrinsicWidth(BoxConstraints constraints) {
+    assert(constraints.isNormalized);
     if (child != null)
       return child.getMinIntrinsicWidth(_getInnerConstraints(constraints));
     return super.getMinIntrinsicWidth(constraints);
   }
 
   double getMaxIntrinsicWidth(BoxConstraints constraints) {
+    assert(constraints.isNormalized);
     if (child != null)
       return child.getMaxIntrinsicWidth(_getInnerConstraints(constraints));
     return super.getMaxIntrinsicWidth(constraints);
   }
 
   double getMinIntrinsicHeight(BoxConstraints constraints) {
+    assert(constraints.isNormalized);
     if (child != null)
       return child.getMinIntrinsicHeight(_getInnerConstraints(constraints));
     return super.getMinIntrinsicHeight(constraints);
   }
 
   double getMaxIntrinsicHeight(BoxConstraints constraints) {
+    assert(constraints.isNormalized);
     if (child != null)
       return child.getMaxIntrinsicHeight(_getInnerConstraints(constraints));
     return super.getMaxIntrinsicHeight(constraints);

--- a/packages/unit/test/rendering/flex_test.dart
+++ b/packages/unit/test/rendering/flex_test.dart
@@ -8,7 +8,7 @@ void main() {
     RenderDecoratedBox box = new RenderDecoratedBox(decoration: new BoxDecoration());
     RenderFlex flex = new RenderFlex(children: <RenderBox>[box]);
     layout(flex, constraints: const BoxConstraints(
-      minWidth: 200.0, maxWidth: 100.0, minHeight: 200.0, maxHeight: 100.0)
+      minWidth: 200.0, maxWidth: 200.0, minHeight: 200.0, maxHeight: 200.0)
     );
 
     expect(flex.size.width, equals(200.0), reason: "flex width");


### PR DESCRIPTION
Add BoxConstraints.isNormalized feature.

Use this feature in asserts in all the intrinsic dimension methods, in
various relevant BoxConstraints methods, and in layout().

Wrap the _DebugSize logic in BoxConstraints.constrain() in an assert
block to avoid a branch in release mode.

Remove the logic in BoxConstraints.isSatisfiedBy() that dealt with
non-normalized values.

Add BoxConstraints.normalize().

Make RenderCustomOneChildLayoutBox.performLayout() only set
parentUsesSize on the child if the constraints aren't tight.
