### PR TITLE
Improve tolerance for ending scroll animations

### DIFF
--- a/packages/newton/lib/src/spring_simulation.dart
+++ b/packages/newton/lib/src/spring_simulation.dart
@@ -57,10 +57,10 @@ class SpringSimulation extends Simulation {
 
   double dx(double time) => _solution.dx(time);
 
-  @override
-  bool isDone(double time) =>
-      _nearEqual(x(time), _endPosition, this.tolerance.distance) &&
-          _nearZero(dx(time), this.tolerance.velocity);
+  bool isDone(double time) {
+    return _nearZero(_solution.x(time), tolerance.distance) &&
+           _nearZero(_solution.dx(time), tolerance.velocity);
+  }
 }
 
 /// A SpringSimulation where the value of x() is guaranteed to have exactly the
@@ -69,16 +69,5 @@ class ScrollSpringSimulation extends SpringSimulation {
   ScrollSpringSimulation(SpringDescription desc, double start, double end, double velocity)
     : super(desc, start, end, velocity);
 
-  bool _isDone(double position, double velocity) {
-    return _nearEqual(position, _endPosition, tolerance.distance) && _nearZero(velocity, tolerance.velocity);
-  }
-
-  @override
-  double x(double time) {
-    double xAtTime = super.x(time);
-    return _isDone(xAtTime, dx(time)) ? _endPosition : xAtTime;
-  }
-
-  @override
-  bool isDone(double time) => _isDone(x(time), dx(time));
+  double x(double time) => isDone(time) ? _endPosition : super.x(time);
 }


### PR DESCRIPTION
We had the units wrong on the tolerances. Previously we multiplied by the
device pixel ratio, which meant we got larger tolerances as we got more
resolution. Also, simplify logic in Newton for applying the tolerances.

Fixes #828
