### PR TITLE
Improve error messages when build fails

### DIFF
--- a/packages/flutter_tools/lib/src/commands/build.dart
+++ b/packages/flutter_tools/lib/src/commands/build.dart
@@ -164,7 +164,8 @@ class BuildCommand extends FlutterCommand {
         outputPath: localBundlePath,
         mainPath: mainPath
       );
-      onBundleAvailable(localBundlePath);
+      if (result == 0)
+        onBundleAvailable(localBundlePath);
     } finally {
       tempDir.deleteSync(recursive: true);
     }
@@ -195,8 +196,10 @@ class BuildCommand extends FlutterCommand {
       // In a precompiled snapshot, the instruction buffer contains script
       // content equivalents
       int result = await toolchain.compiler.compile(mainPath: mainPath, snapshotPath: snapshotPath);
-      if (result != 0)
+      if (result != 0) {
+        logging.severe('Failed to run the Flutter compiler. Exit code: $result');
         return result;
+      }
 
       archive.addFile(_createSnapshotFile(snapshotPath));
     }


### PR DESCRIPTION
Instead of failing with a cryptic error message about app.flx, we now fail with
an explicit message about the compiler.

Releated to #865
