### PR TITLE
Remove reference to scheduler in animation.

### DIFF
--- a/packages/flutter/lib/src/animation/scheduler.dart
+++ b/packages/flutter/lib/src/animation/scheduler.dart
@@ -1,5 +1,0 @@
-// Copyright 2015 The Chromium Authors. All rights reserved.
-// Use of this source code is governed by a BSD-style license that can be
-// found in the LICENSE file.
-
-export '../scheduler/scheduler.dart';

--- a/packages/flutter/lib/src/animation/ticker.dart
+++ b/packages/flutter/lib/src/animation/ticker.dart
@@ -4,7 +4,7 @@
 
 import 'dart:async';
 
-import 'scheduler.dart';
+import 'package:flutter/scheduler.dart';
 
 typedef TickerCallback(Duration elapsed);
 


### PR DESCRIPTION
This adds a dependency from animation to the scheduler, but that's not unexpected.
