### PR TITLE
applyPaintTransform() improvements

### DIFF
--- a/packages/flutter/lib/src/material/material.dart
+++ b/packages/flutter/lib/src/material/material.dart
@@ -298,17 +298,18 @@ abstract class InkFeature {
     assert(referenceBox.attached);
     assert(!_debugDisposed);
     // find the chain of renderers from us to the feature's referenceBox
-    List<RenderBox> descendants = <RenderBox>[];
+    List<RenderBox> descendants = <RenderBox>[referenceBox];
     RenderBox node = referenceBox;
     while (node != renderer) {
-      descendants.add(node);
       node = node.parent;
       assert(node != null);
+      descendants.add(node);
     }
     // determine the transform that gets our coordinate system to be like theirs
     Matrix4 transform = new Matrix4.identity();
-    for (RenderBox descendant in descendants.reversed)
-      descendant.applyPaintTransform(transform);
+    assert(descendants.length >= 2);
+    for (int index = descendants.length - 1; index > 0; index -= 1)
+      descendants[index].applyPaintTransform(descendants[index - 1], transform);
     paintFeature(canvas, transform);
   }
 

--- a/packages/flutter/lib/src/rendering/block.dart
+++ b/packages/flutter/lib/src/rendering/block.dart
@@ -420,12 +420,12 @@ class RenderBlockViewport extends RenderBlockBase {
     context.pushClipRect(needsCompositing, offset, Point.origin & size, _paintContents);
   }
 
-  void applyPaintTransform(Matrix4 transform) {
-    super.applyPaintTransform(transform);
+  void applyPaintTransform(RenderBox child, Matrix4 transform) {
     if (isVertical)
       transform.translate(0.0, startOffset);
     else
       transform.translate(startOffset, 0.0);
+    super.applyPaintTransform(child, transform);
   }
 
   bool hitTestChildren(HitTestResult result, { Point position }) {

--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -1036,12 +1036,14 @@ abstract class RenderObject extends AbstractNode implements HitTestTarget {
   /// be recorded on separate compositing layers.
   void paint(PaintingContext context, Offset offset) { }
 
-  /// If this render object applies a transform before painting, apply that
-  /// transform to the given matrix
+  /// Applies the transform that would be applied when painting the given child
+  /// to the given matrix.
   ///
   /// Used by coordinate conversion functions to translate coordinates local to
   /// one render object into coordinates local to another render object.
-  void applyPaintTransform(Matrix4 transform) { }
+  void applyPaintTransform(RenderObject child, Matrix4 transform) {
+    assert(child.parent == this);
+  }
 
 
   // EVENTS

--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -974,9 +974,9 @@ class RenderTransform extends RenderProxyBox {
     }
   }
 
-  void applyPaintTransform(Matrix4 transform) {
-    super.applyPaintTransform(transform);
+  void applyPaintTransform(RenderBox child, Matrix4 transform) {
     transform.multiply(_effectiveTransform);
+    super.applyPaintTransform(child, transform);
   }
 
   void debugDescribeSettings(List<String> settings) {

--- a/packages/flutter/lib/src/rendering/viewport.dart
+++ b/packages/flutter/lib/src/rendering/viewport.dart
@@ -164,9 +164,9 @@ class RenderViewport extends RenderBox with RenderObjectWithChildMixin<RenderBox
     }
   }
 
-  void applyPaintTransform(Matrix4 transform) {
-    super.applyPaintTransform(transform);
+  void applyPaintTransform(RenderBox child, Matrix4 transform) {
     transform.translate(-scrollOffset.dx, -scrollOffset.dy);
+    super.applyPaintTransform(child, transform);
   }
 
   bool hitTestChildren(HitTestResult result, { Point position }) {


### PR DESCRIPTION
Previously, applyPaintTransform() had to know how it was positioned in
its parent, even though that's really the parent's responsibility.

Now, applyPaintTransform() is given a child and applies the transform
that it would give the child during paint.

This makes it possible for applyPaintTransform() to work across
coordinate system boundaries (e.g. box to sector, or view to box --
previously, view to box only worked because we explicitly skipped that
step -- since view doesn't actually apply a transform, it doesn't
really matter).
