### PR TITLE
Custom layouts use shouldRelayout() delegate methods instead of tokens

### DIFF
--- a/packages/flutter/lib/src/material/scaffold.dart
+++ b/packages/flutter/lib/src/material/scaffold.dart
@@ -95,8 +95,6 @@ class _ScaffoldLayout extends MultiChildLayoutDelegate {
   }
 }
 
-final _ScaffoldLayout _scaffoldLayout = new _ScaffoldLayout();
-
 class Scaffold extends StatefulComponent {
   Scaffold({
     Key key,
@@ -336,9 +334,8 @@ class ScaffoldState extends State<Scaffold> {
       ));
     }
 
-    return new CustomMultiChildLayout(children, delegate: _scaffoldLayout);
+    return new CustomMultiChildLayout(children, delegate: new _ScaffoldLayout());
   }
-
 }
 
 class ScaffoldFeatureController<T extends Widget> {
@@ -397,13 +394,6 @@ class _PersistentBottomSheetState extends State<_PersistentBottomSheet> {
       config.onDismissed();
   }
 
-  double _childHeight;
-  void _updateChildHeight(Size newSize) {
-    setState(() {
-      _childHeight = newSize.height;
-    });
-  }
-
   Widget build(BuildContext context) {
     return new AlignTransition(
       performance: config.performance,
@@ -412,8 +402,7 @@ class _PersistentBottomSheetState extends State<_PersistentBottomSheet> {
       child: new BottomSheet(
         performance: config.performance,
         onClosing: config.onClosing,
-        childHeight: _childHeight,
-        builder: (BuildContext context) => new SizeObserver(child: config.builder(context), onSizeChanged: _updateChildHeight)
+        builder: config.builder
       )
     );
   }

--- a/packages/flutter/lib/src/rendering/custom_layout.dart
+++ b/packages/flutter/lib/src/rendering/custom_layout.dart
@@ -91,6 +91,9 @@ abstract class MultiChildLayoutDelegate {
     }
   }
 
+  /// Override this method to return true when the children need to be laid out.
+  bool shouldRelayout(MultiChildLayoutDelegate oldDelegate) => true;
+
   /// Layout and position all children given this widget's size and the specified
   /// constraints. This method must apply layoutChild() to each child. It should
   /// specify the final position of each child with positionChild().
@@ -126,8 +129,9 @@ class RenderCustomMultiChildLayoutBox extends RenderBox
     assert(newDelegate != null);
     if (_delegate == newDelegate)
       return;
+    if (newDelegate.runtimeType != _delegate.runtimeType || newDelegate.shouldRelayout(_delegate))
+      markNeedsLayout();
     _delegate = newDelegate;
-    markNeedsLayout();
   }
 
   Size _getSize(BoxConstraints constraints) {

--- a/packages/flutter/lib/src/rendering/shifted_box.dart
+++ b/packages/flutter/lib/src/rendering/shifted_box.dart
@@ -257,6 +257,9 @@ class OneChildLayoutDelegate {
 
   /// Returns the position where the child should be placed given the size of this object and the size of the child.
   Point getPositionForChild(Size size, Size childSize) => Point.origin;
+
+  /// Override this method to return true when the child needs to be laid out.
+  bool shouldRelayout(OneChildLayoutDelegate oldDelegate) => true;
 }
 
 /// Defers the layout of its single child to a delegate.
@@ -280,8 +283,9 @@ class RenderCustomOneChildLayoutBox extends RenderShiftedBox {
     assert(newDelegate != null);
     if (_delegate == newDelegate)
       return;
+    if (newDelegate.runtimeType != _delegate.runtimeType || newDelegate.shouldRelayout(_delegate))
+      markNeedsLayout();
     _delegate = newDelegate;
-    markNeedsLayout();
   }
 
   Size _getSize(BoxConstraints constraints) {

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -386,27 +386,16 @@ class CustomOneChildLayout extends OneChildRenderObjectWidget {
   CustomOneChildLayout({
     Key key,
     this.delegate,
-    this.token,
     Widget child
   }) : super(key: key, child: child) {
     assert(delegate != null);
   }
 
-  /// A long-lived delegate that controls the layout of this widget.
-  ///
-  /// Whenever the delegate changes, we need to recompute the layout of this
-  /// widget, which means you might not want to create a new delegate instance
-  /// every time you build this widget. Instead, consider using a long-lived
-  /// deletate (perhaps held in a component's state) that you re-use every time
-  /// you build this widget.
   final OneChildLayoutDelegate delegate;
-  final Object token;
 
   RenderCustomOneChildLayoutBox createRenderObject() => new RenderCustomOneChildLayoutBox(delegate: delegate);
 
   void updateRenderObject(RenderCustomOneChildLayoutBox renderObject, CustomOneChildLayout oldWidget) {
-    if (oldWidget.token != token)
-      renderObject.markNeedsLayout();
     renderObject.delegate = delegate;
   }
 }
@@ -458,23 +447,19 @@ class LayoutId extends ParentDataWidget {
 class CustomMultiChildLayout extends MultiChildRenderObjectWidget {
   CustomMultiChildLayout(List<Widget> children, {
     Key key,
-    this.delegate,
-    this.token
+    this.delegate
   }) : super(key: key, children: children) {
     assert(delegate != null);
   }
 
   /// The delegate that controls the layout of the children.
   final MultiChildLayoutDelegate delegate;
-  final Object token;
 
   RenderCustomMultiChildLayoutBox createRenderObject() {
     return new RenderCustomMultiChildLayoutBox(delegate: delegate);
   }
 
   void updateRenderObject(RenderCustomMultiChildLayoutBox renderObject, CustomMultiChildLayout oldWidget) {
-    if (oldWidget.token != token)
-      renderObject.markNeedsLayout();
     renderObject.delegate = delegate;
   }
 }

--- a/packages/unit/test/widget/custom_multi_child_layout_test.dart
+++ b/packages/unit/test/widget/custom_multi_child_layout_test.dart
@@ -30,20 +30,32 @@ class TestMultiChildLayoutDelegate extends MultiChildLayoutDelegate {
       performLayoutIsChild = isChild('fred');
     }, returnsNormally);
   }
+
+  bool shouldRelayoutCalled = false;
+  bool shouldRelayoutValue = false;
+  bool shouldRelayout(_) {
+    shouldRelayoutCalled = true;
+    return shouldRelayoutValue;
+  }
 }
+
+Widget buildFrame(MultiChildLayoutDelegate delegate) {
+  return new Center(
+    child: new CustomMultiChildLayout([
+        new LayoutId(id: 0, child: new Container(width: 150.0, height: 100.0)),
+        new LayoutId(id: 1, child: new Container(width: 100.0, height: 200.0)),
+      ],
+      delegate: delegate
+    )
+  );
+}
+
 
 void main() {
   test('Control test for CustomMultiChildLayout', () {
     testWidgets((WidgetTester tester) {
       TestMultiChildLayoutDelegate delegate = new TestMultiChildLayoutDelegate();
-      tester.pumpWidget(new Center(
-        child: new CustomMultiChildLayout([
-          new LayoutId(id: 0, child: new Container(width: 150.0, height: 100.0)),
-          new LayoutId(id: 1, child: new Container(width: 100.0, height: 200.0)),
-        ],
-          delegate: delegate
-        )
-      ));
+      tester.pumpWidget(buildFrame(delegate));
 
       expect(delegate.getSizeConstraints.minWidth, 0.0);
       expect(delegate.getSizeConstraints.maxWidth, 800.0);
@@ -61,6 +73,31 @@ void main() {
       expect(delegate.performLayoutSize1.width, 100.0);
       expect(delegate.performLayoutSize1.height, 200.0);
       expect(delegate.performLayoutIsChild, false);
+    });
+  });
+
+  test('Test MultiChildDelegate shouldRelayout method', () {
+    testWidgets((WidgetTester tester) {
+      TestMultiChildLayoutDelegate delegate = new TestMultiChildLayoutDelegate();
+      tester.pumpWidget(buildFrame(delegate));
+
+      // Layout happened because the delegate was set.
+      expect(delegate.performLayoutSize, isNotNull); // i.e. layout happened
+      expect(delegate.shouldRelayoutCalled, isFalse);
+
+      // Layout did not happen because shouldRelayout() returned false.
+      delegate = new TestMultiChildLayoutDelegate();
+      delegate.shouldRelayoutValue = false;
+      tester.pumpWidget(buildFrame(delegate));
+      expect(delegate.shouldRelayoutCalled, isTrue);
+      expect(delegate.performLayoutSize, isNull);
+
+      // Layout happened because shouldRelayout() returned true.
+      delegate = new TestMultiChildLayoutDelegate();
+      delegate.shouldRelayoutValue = true;
+      tester.pumpWidget(buildFrame(delegate));
+      expect(delegate.shouldRelayoutCalled, isTrue);
+      expect(delegate.performLayoutSize, isNotNull);
     });
   });
 

--- a/packages/unit/test/widget/custom_one_child_layout_test.dart
+++ b/packages/unit/test/widget/custom_one_child_layout_test.dart
@@ -32,15 +32,24 @@ class TestOneChildLayoutDelegate extends OneChildLayoutDelegate {
     childSizeFromGetPositionForChild = childSize;
     return Point.origin;
   }
+
+  bool shouldRelayoutCalled = false;
+  bool shouldRelayoutValue = false;
+  bool shouldRelayout(_) {
+    shouldRelayoutCalled = true;
+    return shouldRelayoutValue;
+  }
+}
+
+Widget buildFrame(delegate) {
+  return new Center(child: new CustomOneChildLayout(delegate: delegate, child: new Container()));
 }
 
 void main() {
   test('Control test for CustomOneChildLayout', () {
     testWidgets((WidgetTester tester) {
       TestOneChildLayoutDelegate delegate = new TestOneChildLayoutDelegate();
-      tester.pumpWidget(new Center(
-        child: new CustomOneChildLayout(delegate: delegate, child: new Container())
-      ));
+      tester.pumpWidget(buildFrame(delegate));
 
       expect(delegate.constraintsFromGetSize.minWidth, 0.0);
       expect(delegate.constraintsFromGetSize.maxWidth, 800.0);
@@ -59,4 +68,30 @@ void main() {
       expect(delegate.childSizeFromGetPositionForChild.height, 400.0);
     });
   });
+
+  test('Test OneChildDelegate shouldRelayout method', () {
+    testWidgets((WidgetTester tester) {
+      TestOneChildLayoutDelegate delegate = new TestOneChildLayoutDelegate();
+      tester.pumpWidget(buildFrame(delegate));
+
+      // Layout happened because the delegate was set.
+      expect(delegate.constraintsFromGetConstraintsForChild, isNotNull); // i.e. layout happened
+      expect(delegate.shouldRelayoutCalled, isFalse);
+
+      // Layout did not happen because shouldRelayout() returned false.
+      delegate = new TestOneChildLayoutDelegate();
+      delegate.shouldRelayoutValue = false;
+      tester.pumpWidget(buildFrame(delegate));
+      expect(delegate.shouldRelayoutCalled, isTrue);
+      expect(delegate.constraintsFromGetConstraintsForChild, isNull);
+
+      // Layout happened because shouldRelayout() returned true.
+      delegate = new TestOneChildLayoutDelegate();
+      delegate.shouldRelayoutValue = true;
+      tester.pumpWidget(buildFrame(delegate));
+      expect(delegate.shouldRelayoutCalled, isTrue);
+      expect(delegate.constraintsFromGetConstraintsForChild, isNotNull);
+    });
+  });
+
 }


### PR DESCRIPTION
CustomMultiChildLayout and CustomOneChildLayout now use their delegate's shouldRelayout() method instead of a "token" to decide if layout is needed.

MultiChildLayoutDelegate and OnChildLayoutDelegate are now expected to be stateless, i.e. they'll typically be built each time their custom layout widget is built. If the identical layout delegate is provided to a new custom layout, layout will not happen.

Revised the bottom sheet implementation per the new custom layout classes. Removed a SizeObserver.

Fixes https://github.com/flutter/flutter/issues/899
