### PR TITLE
Make Navigator.canPop handle the no-navigator case

### DIFF
--- a/packages/flutter/lib/src/widgets/navigator.dart
+++ b/packages/flutter/lib/src/widgets/navigator.dart
@@ -145,7 +145,7 @@ class Navigator extends StatefulComponent {
 
   static bool canPop(BuildContext context) {
     NavigatorState navigator = context.ancestorStateOfType(NavigatorState);
-    return navigator.canPop();
+    return navigator != null && navigator.canPop();
   }
 
   static void popAndPushNamed(BuildContext context, String routeName, { Set<Key> mostValuableKeys }) {


### PR DESCRIPTION
Scaffold calls this to see if it should show a back arrow when there's
no drawer. With this change, everything continues to work.

Fixes styled_text and probably others.
