### PR TITLE
Correct the TabBarView swipe selection change animation

### DIFF
--- a/examples/material_gallery/lib/demo/tabs_demo.dart
+++ b/examples/material_gallery/lib/demo/tabs_demo.dart
@@ -6,8 +6,8 @@ import 'package:flutter/material.dart';
 
 import 'widget_demo.dart';
 
-final TabBarSelection _selection = new TabBarSelection();
 final List<String> _iconNames = <String>["event", "home", "android", "alarm", "face", "language"];
+final TabBarSelection _selection = new TabBarSelection(maxIndex: _iconNames.length - 1);
 
 Widget buildTabBar(_) {
   return new TabBar(

--- a/examples/stocks/lib/stock_home.dart
+++ b/examples/stocks/lib/stock_home.dart
@@ -30,7 +30,7 @@ class StockHomeState extends State<StockHome> {
     super.initState();
     _tabBarSelection = PageStorage.of(context)?.readState(context);
     if (_tabBarSelection == null) {
-      _tabBarSelection = new TabBarSelection();
+      _tabBarSelection = new TabBarSelection(maxIndex: 1);
       PageStorage.of(context)?.writeState(context, _tabBarSelection);
     }
   }

--- a/packages/flutter/test/widget/tabs_test.dart
+++ b/packages/flutter/test/widget/tabs_test.dart
@@ -23,7 +23,7 @@ void main() {
   test('TabBar tap selects tab', () {
     testWidgets((WidgetTester tester) {
       List<String> tabs = <String>['A', 'B', 'C'];
-      selection = new TabBarSelection(index: 2);
+      selection = new TabBarSelection(index: 2, maxIndex: tabs.length - 1);
 
       tester.pumpWidget(buildFrame(tabs: tabs, isScrollable: false));
       expect(tester.findText('A'), isNotNull);
@@ -51,7 +51,7 @@ void main() {
   test('Scrollable TabBar tap selects tab', () {
     testWidgets((WidgetTester tester) {
       List<String> tabs = <String>['A', 'B', 'C'];
-      selection = new TabBarSelection(index: 2);
+      selection = new TabBarSelection(index: 2, maxIndex: tabs.length - 1);
 
       tester.pumpWidget(buildFrame(tabs: tabs, isScrollable: true));
       expect(tester.findText('A'), isNotNull);


### PR DESCRIPTION
The TabBarSelection change animation needs to start where the fling's drag gesture ended rather than from zero.  The intial vlaue of progress for the TabBarSelection's performance is now converted from the range used during an interactive drag, to the range used when animating from the previously selected tab to the new one.

TabBarSelection now requires a maxIndex parameter.
