### PR TITLE
Less tree walking for compositing bits updates.

### DIFF
--- a/packages/flutter/lib/src/rendering/binding.dart
+++ b/packages/flutter/lib/src/rendering/binding.dart
@@ -69,7 +69,7 @@ abstract class Renderer extends Scheduler
   void beginFrame() {
     assert(renderView != null);
     RenderObject.flushLayout();
-    renderView.updateCompositingBits();
+    RenderObject.flushCompositingBits();
     RenderObject.flushPaint();
     renderView.compositeFrame();
   }

--- a/packages/flutter/test/rendering/rendering_tester.dart
+++ b/packages/flutter/test/rendering/rendering_tester.dart
@@ -21,6 +21,7 @@ class TestRenderView extends RenderView {
 
 enum EnginePhase {
   layout,
+  compositingBits,
   paint,
   composite
 }
@@ -39,7 +40,9 @@ class TestRenderingFlutterBinding extends BindingBase with Scheduler, Renderer, 
     RenderObject.flushLayout();
     if (phase == EnginePhase.layout)
       return;
-    renderer.renderView.updateCompositingBits();
+    RenderObject.flushCompositingBits();
+    if (phase == EnginePhase.compositingBits)
+      return;
     RenderObject.flushPaint();
     if (phase == EnginePhase.paint)
       return;

--- a/packages/flutter/test/rendering/stack_test.dart
+++ b/packages/flutter/test/rendering/stack_test.dart
@@ -10,18 +10,21 @@ import 'rendering_tester.dart';
 void main() {
   test('Stack can layout with top, right, bottom, left 0.0', () {
     RenderBox size = new RenderConstrainedBox(
-      additionalConstraints: new BoxConstraints.tight(const Size(100.0, 100.0)));
+      additionalConstraints: new BoxConstraints.tight(const Size(100.0, 100.0))
+    );
 
     RenderBox red = new RenderDecoratedBox(
       decoration: new BoxDecoration(
         backgroundColor: const Color(0xFFFF0000)
       ),
-      child: size);
+      child: size
+    );
 
     RenderBox green = new RenderDecoratedBox(
       decoration: new BoxDecoration(
         backgroundColor: const Color(0xFFFF0000)
-      ));
+      )
+    );
 
     RenderBox stack = new RenderStack(children: <RenderBox>[red, green]);
     (green.parentData as StackParentData)


### PR DESCRIPTION
Use the same technique for updating compositing bits as layout and
painting. This avoids walking the entire rendering tree when all you
need to update is a small subtree.
