### PR TITLE
Not for review

### DIFF
--- a/examples/widgets/flutter.yaml
+++ b/examples/widgets/flutter.yaml
@@ -10,6 +10,7 @@ material-design-icons:
   - name: action/home
   - name: action/language
   - name: action/list
+  - name: content/add
   - name: device/dvr
   - name: editor/format_align_center
   - name: editor/format_align_left

--- a/packages/flutter/lib/src/material/floating_action_button.dart
+++ b/packages/flutter/lib/src/material/floating_action_button.dart
@@ -2,18 +2,24 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:flutter/animation.dart';
 import 'package:flutter/widgets.dart';
 
 import 'icon_theme.dart';
 import 'icon_theme_data.dart';
 import 'ink_well.dart';
 import 'material.dart';
+import 'tabs.dart';
 import 'theme.dart';
 
 // TODO(eseidel): This needs to change based on device size?
 // http://www.google.com/design/spec/layout/metrics-keylines.html#metrics-keylines-keylines-spacing
 const double _kSize = 56.0;
 const double _kSizeMini = 40.0;
+const Duration _kShowDuration = const Duration(milliseconds: 200);
+
+// TODO(hansmuller) use ItemBuilder<T> when TabBarSelection<T> exists
+typedef Widget PerTabChildBuilder<T>(BuildContext context, int index);
 
 class FloatingActionButton extends StatefulComponent {
   const FloatingActionButton({
@@ -23,7 +29,9 @@ class FloatingActionButton extends StatefulComponent {
     this.elevation: 6,
     this.highlightElevation: 12,
     this.onPressed,
-    this.mini: false
+    this.mini: false,
+    this.perTabChildBuilder,
+    this.tabBarSelection // TODO: remove once this is fixed https://github.com/flutter/flutter/issues/835
   }) : super(key: key);
 
   final Widget child;
@@ -32,11 +40,48 @@ class FloatingActionButton extends StatefulComponent {
   final int elevation;
   final int highlightElevation;
   final bool mini;
+  final PerTabChildBuilder perTabChildBuilder;
+  final TabBarSelection tabBarSelection;
 
   _FloatingActionButtonState createState() => new _FloatingActionButtonState();
 }
 
 class _FloatingActionButtonState extends State<FloatingActionButton> {
+  Performance _showPerformance;
+
+  void initState() {
+    super.initState();
+    if (config.tabBarSelection != null)
+      config.tabBarSelection.performance.addListener(_handleTabProgressChange);
+  }
+
+  void dispose() {
+    if (config.tabBarSelection != null)
+      config.tabBarSelection.performance.removeListener(_handleTabProgressChange);
+    super.dispose();
+  }
+
+  void didUpdateConfig(FloatingActionButton oldConfig) {
+    super.didUpdateConfig(oldConfig);
+    if (config.tabBarSelection?.performance != oldConfig.tabBarSelection?.performance) {
+      // TBD: remove the old listener if any, add the new one if any
+    }
+  }
+
+  void _handleTabProgressChange() {
+    if (config.tabBarSelection.indexIsChanging) {
+      setState(() {
+        if (config.tabBarSelection.performance.status == PerformanceStatus.completed) {
+          _showPerformance = new Performance(duration: _kShowDuration)
+          ..addListener(() { setState(() {}); })
+          ..forward().then((_) {
+            _showPerformance = null;
+          });
+        }
+      });
+    }
+  }
+
   bool _highlight = false;
 
   void _handleHighlightChanged(bool value) {
@@ -46,6 +91,15 @@ class _FloatingActionButtonState extends State<FloatingActionButton> {
   }
 
   Widget build(BuildContext context) {
+    Widget child = config.child;
+    if (config.perTabChildBuilder != null) {
+      int index = config.tabBarSelection.indexIsChanging ? config.tabBarSelection.previousIndex : config.tabBarSelection.index;
+      child = config.perTabChildBuilder(context, index);
+    }
+
+    if (child == null)
+      return new Container();
+
     IconThemeColor iconThemeColor = IconThemeColor.white;
     Color materialColor = config.backgroundColor;
     if (materialColor == null) {
@@ -54,20 +108,35 @@ class _FloatingActionButtonState extends State<FloatingActionButton> {
       iconThemeColor = themeData.accentColorBrightness == ThemeBrightness.dark ? IconThemeColor.white : IconThemeColor.black;
     }
 
-    return new Material(
-      color: materialColor,
-      type: MaterialType.circle,
-      elevation: _highlight ? config.highlightElevation : config.elevation,
-      child: new Container(
-        width: config.mini ? _kSizeMini : _kSize,
-        height: config.mini ? _kSizeMini : _kSize,
-        child: new InkWell(
-          onTap: config.onPressed,
-          onHighlightChanged: _handleHighlightChanged,
-          child: new Center(
-            child: new IconTheme(
-              data: new IconThemeData(color: iconThemeColor),
-              child: config.child
+    final double outerRadius = config.mini ? _kSizeMini : _kSize;
+    double innerRadius = outerRadius;
+    if (child != null) {
+      if (config.tabBarSelection != null && config.tabBarSelection.indexIsChanging)
+        innerRadius = new AnimatedValue<double>(outerRadius, end: 0.0, curve: Curves.ease)
+          .lerp(config.tabBarSelection.performance.progress);
+      else if (_showPerformance != null)
+        innerRadius = new AnimatedValue<double>(0.0, end: outerRadius, curve: Curves.ease)
+          .lerp(_showPerformance.progress);
+    }
+
+    return new SizedBox(
+      width: outerRadius,
+      height: outerRadius,
+      child: new Center(
+        child: new Material(
+          color: materialColor,
+          type: MaterialType.circle,
+          elevation: _highlight ? config.highlightElevation : config.elevation,
+          child: new SizedBox(
+            width: innerRadius,
+            height: innerRadius,
+            child: new InkWell(
+              onTap: config.onPressed,
+              onHighlightChanged: _handleHighlightChanged,
+              child: new IconTheme(
+                data: new IconThemeData(color: iconThemeColor),
+                child: child
+              )
             )
           )
         )


### PR DESCRIPTION
- TabBarSelection should be a widget whose state can be found with TabBarSelection.of(context), per https://github.com/flutter/flutter/issues/835. Given that the tabBarSelection parameter in the implementation (way) below wouldn't be needed.
- TabBarSelection should manage a typed selection rather than just an integer index.

```
class TabBarSelection<T> {
  ...
  T firstValue;    // was implicitly 0
  T previousValue; // was int previousIndex
  T value;         // was int index
  T lastValue;     // was int maxIndex
}
```
- Should FAB always require a builder function for its child?
- The FAB should not animate when the old FAB child is the same as the new one. To figure that out during a tab index change, I guess that FAB would need to build the child for the previously selected tab and the new one, and then compare keys?
- It would be simpler if the FAB child builder could deal with the simple case, and the tab-specific case. Maybe by defining it like this:

```
typedef Widget fabChildBuilder(BuildContext context, { dynamic tabValue });
// Not sure how to give the tabValue parameter it's proper T type.
```

The assumption is that the provider of the builder function will now if they need to use the tabValue or not.
- TabBarSelection onChange needs to be a listener list since TabBarSelections are expected to be shared.
- What happens to code that's listening to an ancestor TabBarSelection if the TabBarSelection disappears (isn't built) or is replaced?
- The code that animates the FAB child after the tab selection change has finished expands it like this:

```
Performance _showPerformance;
// ...
_showPerformance = new Performance(duration: _kShowDuration)
  ..addListener(() { setState(() {}); })
  ..forward().then((_) {
    _showPerformance = null;
  });
// And then in the build function...
// Where innerRadius is the current radius of the FAB child and outerRadius is the final radius.
innerRadius = new AnimatedValue<double>(0.0, end: outerRadius, curve: Curves.ease)
  .lerp(_showPerformance.progress);
```

Mabe there's a slicker way to accomplish this?

Here's an app that uses the current implementation:

```
import 'package:flutter/material.dart';

class TabsApp extends StatefulComponent {
  TabsApp();

  TabsAppState createState() => new TabsAppState();
}

class TabsAppState extends State<TabsApp> {
  final List<String> labels = ["One", "Two", "Free", "Four", "Five"];
  TabBarSelection tabBarSelection;

  void initState() {
    super.initState();
    tabBarSelection = new TabBarSelection(maxIndex: labels.length - 1);
  }

  Widget buildTabView(BuildContext context, String label, int index) {
    return new Container(
      child: new Center(
        key: new ValueKey<String>(label),
        child: new Text(label)
      )
    );
  }

  Widget build(BuildContext context) {
    return new Scaffold(
      toolBar: new ToolBar(
        elevation: 0,
        center: new Text('TabBar Demo'),
        tabBar: new TabBar(
          selection: tabBarSelection,
          labels: labels.map((s) => new TabLabel(text: s)).toList()
        )
      ),

      body: new TabBarView<String>(
        selection: tabBarSelection,
        items: labels,
        itemBuilder: buildTabView
      ),

      floatingActionButton: new FloatingActionButton(
        child: new Icon(icon: 'content/add'),
        tabBarSelection: tabBarSelection,
        perTabChildBuilder: ((BuildContext context, int index) {
          if (index == 2)
            return null;  // No FAB for this tab
          return new Icon(icon: 'content/add');
        })
      )
    );
  }
}

void main() {
  runApp(new MaterialApp(
    title: 'TabsApp',
    theme: new ThemeData(brightness: ThemeBrightness.light),
    routes: {
      '/': (RouteArguments args) => new TabsApp()
    }
  ));
}
```
