### PR TITLE
fix analysis errors and warnings in the stocks example

### DIFF
--- a/examples/stocks/lib/i18n/stock_messages_en.dart
+++ b/examples/stocks/lib/i18n/stock_messages_en.dart
@@ -6,7 +6,7 @@
  */
 
 library messages_en;
-import 'package:intl/intl.dart';
+
 import 'package:intl/message_lookup_by_library.dart';
 
 final messages = new MessageLookup();

--- a/examples/stocks/lib/i18n/stock_messages_es.dart
+++ b/examples/stocks/lib/i18n/stock_messages_es.dart
@@ -6,7 +6,7 @@
  */
 
 library messages_es;
-import 'package:intl/intl.dart';
+
 import 'package:intl/message_lookup_by_library.dart';
 
 final messages = new MessageLookup();

--- a/packages/flutter/pubspec.yaml
+++ b/packages/flutter/pubspec.yaml
@@ -25,6 +25,8 @@ dependencies:
 dev_dependencies:
   flutter_test:
     path: ../flutter_test
+  stocks:
+    path: ../../examples/stocks
 
 environment:
   sdk: '>=1.12.0 <2.0.0'


### PR DESCRIPTION
- added a dev time dep from the flutter package to the stocks example. It looks like the flutter/benchmark folder depends on the stocks example code
- fix two unused imports in generated intl code (filed an issue against the intl package to not generate the unused imports in the first place)
