### PR TITLE
analyze more packages

### DIFF
--- a/packages/flutter_tools/lib/src/commands/analyze.dart
+++ b/packages/flutter_tools/lib/src/commands/analyze.dart
@@ -64,6 +64,7 @@ class AnalyzeCommand extends FlutterCommand {
 
       // .../packages/*/bin/*.dart
       // .../packages/*/lib/main.dart
+      // .../packages/*/lib/packageName.dart
       // .../packages/*/test/*_test.dart
       // .../packages/*/test/*/*_test.dart
       // .../packages/*/benchmark/*/*_bench.dart
@@ -156,7 +157,7 @@ class AnalyzeCommand extends FlutterCommand {
 
     if (argResults['current-package']) {
       // ./lib/main.dart
-      String mainPath = path.join('lib', 'main.dart');
+      String mainPath = 'lib/main.dart';
       if (FileSystemEntity.isFileSync(mainPath)) {
         dartFiles.add(mainPath);
         pubSpecDirectories.add('.');
@@ -281,16 +282,16 @@ class AnalyzeCommand extends FlutterCommand {
 
     List<Pattern> patternsToSkip = <Pattern>[
       'Analyzing [${mainFile.path}]...',
-      new RegExp('^\\[hint\\] Unused import \\(${mainFile.path},'),
+      new RegExp('^\\[(hint|error)\\] Unused import \\(${mainFile.path},'),
       new RegExp(r'^\[.+\] .+ \(.+/\.pub-cache/.+'),
       new RegExp(r'^\[error\] Invalid override\. The type of [^ ]+ \(.+\) is not a subtype of [^ ]+ \(.+\)\.'), // we allow type narrowing
-      new RegExp(r'^\[warning\] .+ will need runtime check to cast to type .+'), // https://github.com/dart-lang/sdk/issues/24542
       new RegExp(r'^\[error\] Type check failed: .*\(dynamic\) is not of type'), // allow unchecked casts from dynamic
       new RegExp('^\\[error\\] Target of URI does not exist: \'dart:ui_internals\''), // https://github.com/flutter/flutter/issues/83
+      new RegExp(r'^\[warning\] .+ will need runtime check to cast to type .+'), // https://github.com/dart-lang/sdk/issues/24542
       new RegExp(r'\[lint\] Prefer using lowerCamelCase for constant names.'), // sometimes we have no choice (e.g. when matching other platforms)
       new RegExp(r'\[lint\] Avoid defining a one-member abstract class when a simple function will do.'), // too many false-positives; code review should catch real instances
-      new RegExp(r'[0-9]+ (error|warning|hint|lint).+found\.'),
       new RegExp(r'\[info\] TODO.+'),
+      new RegExp(r'[0-9]+ (error|warning|hint|lint).+found\.'),
       new RegExp(r'^$'),
     ];
 
@@ -309,9 +310,6 @@ class AnalyzeCommand extends FlutterCommand {
           String errorMessage = groups[2];
           int lineNumber = int.parse(groups[4]);
           int colNumber = int.parse(groups[5]);
-          // Ignore issues reported in the stub entry-point file (like unused imports).
-          if (filename == mainFile.path)
-            continue;
           File source = new File(filename);
           List<String> sourceLines = source.readAsLinesSync();
           String sourceLine = (lineNumber < sourceLines.length) ? sourceLines[lineNumber-1] : '';


### PR DESCRIPTION
- look for and analyze `foo/lib/foo.dart` - this catches packages like `flutter_sprites`, which I don't believe had previously been analyzed
- fix an issue where we were deleting the temporary generated main file, then trying to read its source to match against error locations
- skip todo comments (`[info] TODO`) in the results

@Hixie 
