### PR TITLE
RenderFractionalTranslation and Dismissable

### DIFF
--- a/packages/flutter/lib/src/painting/box_painter.dart
+++ b/packages/flutter/lib/src/painting/box_painter.dart
@@ -510,36 +510,55 @@ void paintImage({
 /// FractionalOffset(1.0, 0.0) represents the top right of the Size,
 /// FractionalOffset(0.0, 1.0) represents the bottom left of the Size,
 class FractionalOffset {
-  const FractionalOffset(this.x, this.y);
-  final double x;
-  final double y;
+  const FractionalOffset(this.dx, this.dy);
+  final double dx;
+  final double dy;
+  static const FractionalOffset zero = const FractionalOffset(0.0, 0.0);
+  FractionalOffset operator -() {
+    return new FractionalOffset(-dx, -dy);
+  }
   FractionalOffset operator -(FractionalOffset other) {
-    return new FractionalOffset(x - other.x, y - other.y);
+    return new FractionalOffset(dx - other.dx, dy - other.dy);
   }
   FractionalOffset operator +(FractionalOffset other) {
-    return new FractionalOffset(x + other.x, y + other.y);
+    return new FractionalOffset(dx + other.dx, dy + other.dy);
   }
   FractionalOffset operator *(double other) {
-    return new FractionalOffset(x * other, y * other);
+    return new FractionalOffset(dx * other, dy * other);
+  }
+  FractionalOffset operator /(double other) {
+    return new FractionalOffset(dx / other, dy / other);
+  }
+  FractionalOffset operator ~/(double other) {
+    return new FractionalOffset((dx ~/ other).toDouble(), (dy ~/ other).toDouble());
+  }
+  FractionalOffset operator %(double other) {
+    return new FractionalOffset(dx % other, dy % other);
+  }
+  Offset alongOffset(Offset other) {
+    return new Offset(dx * other.dx, dy * other.dy);
+  }
+  Offset alongSize(Size other) {
+    return new Offset(dx * other.width, dy * other.height);
   }
   bool operator ==(dynamic other) {
     if (other is! FractionalOffset)
       return false;
     final FractionalOffset typedOther = other;
-    return x == typedOther.x &&
-           y == typedOther.y;
+    return dx == typedOther.dx &&
+           dy == typedOther.dy;
   }
-  int get hashCode => hashValues(x, y);
+  int get hashCode => hashValues(dx, dy);
   static FractionalOffset lerp(FractionalOffset a, FractionalOffset b, double t) {
     if (a == null && b == null)
       return null;
     if (a == null)
-      return new FractionalOffset(b.x * t, b.y * t);
+      return new FractionalOffset(b.dx * t, b.dy * t);
     if (b == null)
-      return new FractionalOffset(b.x * (1.0 - t), b.y * (1.0 - t));
-    return new FractionalOffset(ui.lerpDouble(a.x, b.x, t), ui.lerpDouble(a.y, b.y, t));
+      return new FractionalOffset(b.dx * (1.0 - t), b.dy * (1.0 - t));
+    return new FractionalOffset(ui.lerpDouble(a.dx, b.dx, t), ui.lerpDouble(a.dy, b.dy, t));
   }
-  String toString() => '$runtimeType($x, $y)';
+  String toString() => '$runtimeType($dx, $dy)';
 }
 
 /// A background image for a box.
@@ -919,8 +938,8 @@ class _BoxDecorationPainter extends BoxPainter {
       rect: rect,
       image: image,
       colorFilter: backgroundImage.colorFilter,
-      alignX: backgroundImage.alignment?.x,
-      alignY: backgroundImage.alignment?.y,
+      alignX: backgroundImage.alignment?.dx,
+      alignY: backgroundImage.alignment?.dy,
       fit:  backgroundImage.fit,
       repeat: backgroundImage.repeat
     );

--- a/packages/flutter/lib/src/rendering/image.dart
+++ b/packages/flutter/lib/src/rendering/image.dart
@@ -216,8 +216,8 @@ class RenderImage extends RenderBox {
       image: _image,
       colorFilter: _colorFilter,
       fit: _fit,
-      alignX: _alignment?.x,
-      alignY: _alignment?.y,
+      alignX: _alignment?.dx,
+      alignY: _alignment?.dy,
       centerSlice: _centerSlice,
       repeat: _repeat
     );

--- a/packages/flutter/lib/src/rendering/shifted_box.dart
+++ b/packages/flutter/lib/src/rendering/shifted_box.dart
@@ -179,7 +179,7 @@ class RenderPositionedBox extends RenderShiftedBox {
        _widthFactor = widthFactor,
        _heightFactor = heightFactor,
        super(child) {
-    assert(alignment != null && alignment.x != null && alignment.y != null);
+    assert(alignment != null && alignment.dx != null && alignment.dy != null);
     assert(widthFactor == null || widthFactor >= 0.0);
     assert(heightFactor == null || heightFactor >= 0.0);
   }
@@ -196,7 +196,7 @@ class RenderPositionedBox extends RenderShiftedBox {
   FractionalOffset get alignment => _alignment;
   FractionalOffset _alignment;
   void set alignment (FractionalOffset newAlignment) {
-    assert(newAlignment != null && newAlignment.x != null && newAlignment.y != null);
+    assert(newAlignment != null && newAlignment.dx != null && newAlignment.dy != null);
     if (_alignment == newAlignment)
       return;
     _alignment = newAlignment;
@@ -237,9 +237,8 @@ class RenderPositionedBox extends RenderShiftedBox {
       child.layout(constraints.loosen(), parentUsesSize: true);
       size = constraints.constrain(new Size(shrinkWrapWidth ? child.size.width * (_widthFactor ?? 1.0) : double.INFINITY,
                                             shrinkWrapHeight ? child.size.height * (_heightFactor ?? 1.0) : double.INFINITY));
-      final Offset delta = size - child.size;
       final BoxParentData childParentData = child.parentData;
-      childParentData.position = delta.scale(_alignment.x, _alignment.y).toPoint();
+      childParentData.position = _alignment.alongOffset(size - child.size).toPoint();
     } else {
       size = constraints.constrain(new Size(shrinkWrapWidth ? 0.0 : double.INFINITY,
                                             shrinkWrapHeight ? 0.0 : double.INFINITY));

--- a/packages/flutter/lib/src/rendering/stack.dart
+++ b/packages/flutter/lib/src/rendering/stack.dart
@@ -328,9 +328,7 @@ abstract class RenderStackBase extends RenderBox
       final StackParentData childParentData = child.parentData;
 
       if (!childParentData.isPositioned) {
-        double x = (size.width - child.size.width) * alignment.x;
-        double y = (size.height - child.size.height) * alignment.y;
-        childParentData.position = new Point(x, y);
+        childParentData.position = alignment.alongOffset(size - child.size).toPoint();
       } else {
         BoxConstraints childConstraints = const BoxConstraints();
 

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -270,7 +270,7 @@ class ClipOval extends OneChildRenderObjectWidget {
 
 /// Applies a transformation before painting its child.
 class Transform extends OneChildRenderObjectWidget {
-  Transform({ Key key, this.transform, this.origin, this.alignment, Widget child })
+  Transform({ Key key, this.transform, this.origin, this.alignment, this.transformHitTests: true, Widget child })
     : super(key: key, child: child) {
     assert(transform != null);
   }
@@ -291,12 +291,43 @@ class Transform extends OneChildRenderObjectWidget {
   /// If it is specificed at the same time as an offset, both are applied.
   final FractionalOffset alignment;
 
-  RenderTransform createRenderObject() => new RenderTransform(transform: transform, origin: origin, alignment: alignment);
+  /// Whether to apply the translation when performing hit tests.
+  final bool transformHitTests;
+
+  RenderTransform createRenderObject() => new RenderTransform(
+    transform: transform,
+    origin: origin,
+    alignment: alignment,
+    transformHitTests: transformHitTests
+  );
 
   void updateRenderObject(RenderTransform renderObject, Transform oldWidget) {
     renderObject.transform = transform;
     renderObject.origin = origin;
     renderObject.alignment = alignment;
+    renderObject.transformHitTests = transformHitTests;
+  }
+}
+
+/// Applies a translation expressed as a fraction of the box's size before
+/// painting its child.
+class FractionalTranslation extends OneChildRenderObjectWidget {
+  FractionalTranslation({ Key key, this.translation, this.transformHitTests: true, Widget child })
+    : super(key: key, child: child) {
+    assert(translation != null);
+  }
+
+  /// The offset by which to translate the child, as a multiple of its size.
+  final FractionalOffset translation;
+
+  /// Whether to apply the translation when performing hit tests.
+  final bool transformHitTests;
+
+  RenderFractionalTranslation createRenderObject() => new RenderFractionalTranslation(translation: translation, transformHitTests: transformHitTests);
+
+  void updateRenderObject(RenderFractionalTranslation renderObject, FractionalTranslation oldWidget) {
+    renderObject.translation = translation;
+    renderObject.transformHitTests = transformHitTests;
   }
 }
 
@@ -335,7 +366,7 @@ class Align extends OneChildRenderObjectWidget {
     this.heightFactor,
     Widget child
   }) : super(key: key, child: child) {
-    assert(alignment != null && alignment.x != null && alignment.y != null);
+    assert(alignment != null && alignment.dx != null && alignment.dy != null);
     assert(widthFactor == null || widthFactor >= 0.0);
     assert(heightFactor == null || heightFactor >= 0.0);
   }

--- a/packages/flutter/lib/src/widgets/transitions.dart
+++ b/packages/flutter/lib/src/widgets/transitions.dart
@@ -82,18 +82,18 @@ class SlideTransition extends TransitionWithChild {
     Key key,
     this.position,
     PerformanceView performance,
+    this.transformHitTests: true,
     Widget child
   }) : super(key: key,
              performance: performance,
              child: child);
 
-  final AnimatedValue<Point> position;
+  final AnimatedValue<FractionalOffset> position;
+  bool transformHitTests;
 
   Widget buildWithChild(BuildContext context, Widget child) {
     performance.updateVariable(position);
-    Matrix4 transform = new Matrix4.identity()
-      ..translate(position.value.x, position.value.y);
-    return new Transform(transform: transform, child: child);
+    return new FractionalTranslation(translation: position.value, transformHitTests: transformHitTests, child: child);
   }
 }
 


### PR DESCRIPTION
- Add RenderFractionalTranslation, a render box that does a
  translation based on a FractionalOffset.
- Make FractionalOffset more like Offset
  - dx/dy instead of x/y
  - add /, ~/, %
  - add .zero
- Add alongOffset and alongSize to FractionalOffset so that you can
  easily apply FractionalOffset to Offsets and Sizes. (Better name
  suggestions welcome.)
- Add transformHitTests boolean to RenderTransform (also on
  RenderFractionalTranslation), and to classes based on it.
- Remove the fade from Dismissable. We can add it back using the
  builder-with-child pattern like Draggable if we need it. See #1003
  for tha feature request.
- Rename a bunch of variables in dismissable.dart.
- Change the test for dismissable to not handle leftwards dismisses
  one pixel different from rightwards dismisses, and cleaned up the
  resulting effect on the test (mostly making sure we had the right
  number of pumps, with comments explaining what each one was).

Fixes #174.
