### PR TITLE
Various Input and Focus fixes

### DIFF
--- a/packages/flutter/lib/src/material/input.dart
+++ b/packages/flutter/lib/src/material/input.dart
@@ -27,7 +27,9 @@ class Input extends Scrollable {
     key: key,
     initialScrollOffset: 0.0,
     scrollDirection: ScrollDirection.horizontal
-  );
+  ) {
+    assert(key != null);
+  }
 
   final String initialValue;
   final KeyboardType keyboardType;
@@ -78,7 +80,7 @@ class InputState extends ScrollableState<Input> {
   Widget buildContent(BuildContext context) {
     assert(debugCheckHasMaterial(context));
     ThemeData themeData = Theme.of(context);
-    bool focused = Focus.at(context, config);
+    bool focused = Focus.at(context);
 
     if (focused && !_keyboardHandle.attached) {
       _keyboardHandle = keyboard.show(_editableValue.stub, config.keyboardType);
@@ -118,7 +120,17 @@ class InputState extends ScrollableState<Input> {
       scrollOffset: scrollOffsetVector
     ));
 
-    return new Listener(
+    return new GestureDetector(
+      behavior: HitTestBehavior.opaque,
+      onTap: () {
+        if (Focus.at(context)) {
+          assert(_keyboardHandle.attached);
+          _keyboardHandle.showByRequest();
+        } else {
+          Focus.moveTo(config.key);
+          // we'll get told to rebuild and we'll take care of the keyboard then
+        }
+      },
       child: new SizeObserver(
         onSizeChanged: _handleContainerSizeChanged,
         child: new Container(
@@ -136,18 +148,7 @@ class InputState extends ScrollableState<Input> {
             )
           )
         )
-      ),
-      behavior: HitTestBehavior.opaque,
-      onPointerDown: (_) {
-        // TODO(ianh): https://github.com/flutter/engine/issues/1530
-        if (Focus.at(context, config)) {
-          assert(_keyboardHandle.attached);
-          _keyboardHandle.showByRequest();
-        } else {
-          Focus.moveTo(context, config);
-          // we'll get told to rebuild and we'll take care of the keyboard then
-        }
-      }
+      )
     );
   }
 

--- a/packages/flutter/test/widget/focus_test.dart
+++ b/packages/flutter/test/widget/focus_test.dart
@@ -11,9 +11,9 @@ class TestFocusable extends StatelessComponent {
   final String no;
   final String yes;
   Widget build(BuildContext context) {
-    bool focused = Focus.at(context, this);
+    bool focused = Focus.at(context);
     return new GestureDetector(
-      onTap: () { Focus.moveTo(context, this); },
+      onTap: () { Focus.moveTo(key); },
       child: new Text(focused ? yes : no)
     );
   }


### PR DESCRIPTION
Require a Key on Input.

Simplify the API for Focus.at() and Focus.moveTo().
Fixes #236.
This will require an e-mail to flutter-dev.

Make Input grab focus onTap not onPointerDown.
Fixes #189.

Complain when you use Focus.at() with two different GlobalKeys that
are both in the tree at the same time.
Fixes #181.

Add dartdocs for Focus.moveTo() and Focus.moveScopeTo().
