### PR TITLE
ScrollbarPainter exception when scrolling MaterialList

### DIFF
--- a/packages/flutter/lib/src/rendering/block.dart
+++ b/packages/flutter/lib/src/rendering/block.dart
@@ -313,9 +313,11 @@ class RenderBlockViewport extends RenderBlockBase {
   void set overlayPainter(Painter value) {
     if (_overlayPainter == value)
       return;
-    _overlayPainter?.detach();
+    if (attached)
+      _overlayPainter?.detach();
     _overlayPainter = value;
-    _overlayPainter?.attach(this);
+    if (attached)
+      _overlayPainter?.attach(this);
     markNeedsPaint();
   }
 

--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -345,6 +345,7 @@ abstract class Painter {
 
   void attach(RenderObject renderObject) {
     assert(_renderObject == null);
+    assert(renderObject != null);
     _renderObject = renderObject;
   }
 

--- a/packages/flutter/test/rendering/block_test.dart
+++ b/packages/flutter/test/rendering/block_test.dart
@@ -1,0 +1,40 @@
+// Copyright 2015 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+import 'package:test/test.dart';
+
+import 'rendering_tester.dart';
+
+class TestBlockPainter extends Painter {
+  void paint(PaintingContext context, Offset offset) { }
+}
+
+void main() {
+  test('overlay painters can attach and detach', () {
+    TestBlockPainter first = new TestBlockPainter();
+    TestBlockPainter second = new TestBlockPainter();
+    RenderBlockViewport block = new RenderBlockViewport(overlayPainter: first);
+
+    // The first painter isn't attached because we haven't attached block.
+    expect(first.renderObject, isNull);
+    expect(second.renderObject, isNull);
+
+    block.overlayPainter = second;
+
+    expect(first.renderObject, isNull);
+    expect(second.renderObject, isNull);
+
+    layout(block);
+
+    expect(first.renderObject, isNull);
+    expect(second.renderObject, equals(block));
+
+    block.overlayPainter = first;
+
+    expect(first.renderObject, equals(block));
+    expect(second.renderObject, isNull);
+  });
+}


### PR DESCRIPTION
When assigning a new overlayPainter, we were detaching the old overlay
painter even if the render object itself wasn't attached. Now we only
twiddle the attach/detach state of the overlay painter when we're
attached ourselves.

Fixes #1047
