### PR TITLE
flutter init should gitignore .atom

### DIFF
--- a/packages/flutter_tools/lib/src/commands/init.dart
+++ b/packages/flutter_tools/lib/src/commands/init.dart
@@ -160,6 +160,7 @@ String _normalizeProjectName(String name) {
 
 const String _gitignore = r'''
 .DS_Store
+.atom/
 .idea
 .packages
 .pub/


### PR DESCRIPTION
We now create a .atom folder to hold settings for the Atom project. We
should gitignore that folder our project template.
