### PR TITLE
Generalize grid layout

### DIFF
--- a/examples/rendering/render_grid.dart
+++ b/examples/rendering/render_grid.dart
@@ -20,7 +20,10 @@ Color randomColor() {
 
 RenderBox buildGridExample() {
   List<RenderBox> children = new List<RenderBox>.generate(30, (_) => new RenderSolidColorBox(randomColor()));
-  return new RenderGrid(children: children, maxChildExtent: 100.0);
+  return new RenderGrid(
+    children: children,
+    delegate: new MaxTileWidthGridDelegate(maxTileWidth: 100.0)
+  );
 }
 
 main() => new RenderingFlutterBinding(root: buildGridExample());

--- a/examples/widgets/media_query.dart
+++ b/examples/widgets/media_query.dart
@@ -62,7 +62,7 @@ class AdaptiveItem {
 }
 
 class MediaQueryExample extends StatelessComponent {
-  static const double _maxChildExtent = 150.0;
+  static const double _maxTileWidth = 150.0;
   static const double _gridViewBreakpoint = 450.0;
 
   Widget _buildBody(BuildContext context) {
@@ -78,9 +78,9 @@ class MediaQueryExample extends StatelessComponent {
     } else {
       return new Block(
         <Widget>[
-          new Grid(
+          new MaxTileWidthGrid(
             items.map((AdaptiveItem item) => item.toCard()).toList(),
-            maxChildExtent: _maxChildExtent
+            maxTileWidth: _maxTileWidth
           )
         ]
       );

--- a/packages/flutter/lib/src/painting/edge_dims.dart
+++ b/packages/flutter/lib/src/painting/edge_dims.dart
@@ -43,8 +43,17 @@ class EdgeDims {
   /// Whether every dimension is non-negative.
   bool get isNonNegative => top >= 0.0 && right >= 0.0 && bottom >= 0.0 && left >= 0.0;
 
-  /// The size that this edge dims would occupy with an empty interior.
-  ui.Size get collapsedSize => new ui.Size(left + right, top + bottom);
+  /// The total offset in the vertical direction.
+  double get horizontal => left + right;
+
+  /// The total offset in the horizontal direction.
+  double get vertical => top + bottom;
+
+  /// The size that this EdgeDims would occupy with an empty interior.
+  ui.Size get collapsedSize => new ui.Size(horizontal, vertical);
+
+  /// An EdgeDims with top and bottom as well as left and right flipped.
+  EdgeDims get flipped => new EdgeDims.TRBL(bottom, left, top, right);
 
   ui.Rect inflateRect(ui.Rect rect) {
     return new ui.Rect.fromLTRB(rect.left - left, rect.top - top, rect.right + right, rect.bottom + bottom);

--- a/packages/flutter/lib/src/rendering/box.dart
+++ b/packages/flutter/lib/src/rendering/box.dart
@@ -374,7 +374,7 @@ abstract class RenderBox extends RenderObject {
     return constraints.constrainWidth(0.0);
   }
 
-  /// Return the minimum height that this box could be without failing to render
+  /// Return the minimum height that this box could be without failing to paint
   /// its contents within itself.
   ///
   /// Override in subclasses that implement [performLayout].

--- a/packages/flutter/test/rendering/grid_test.dart
+++ b/packages/flutter/test/rendering/grid_test.dart
@@ -16,7 +16,10 @@ void main() {
       new RenderDecoratedBox(decoration: new BoxDecoration())
     ];
 
-    RenderGrid grid = new RenderGrid(children: children, maxChildExtent: 100.0);
+    RenderGrid grid = new RenderGrid(
+      children: children,
+      delegate: new MaxTileWidthGridDelegate(maxTileWidth: 100.0)
+    );
     layout(grid, constraints: const BoxConstraints(maxWidth: 200.0));
 
     children.forEach((RenderBox child) {
@@ -28,7 +31,7 @@ void main() {
     expect(grid.size.height, equals(200.0), reason: "grid height");
 
     expect(grid.needsLayout, equals(false));
-    grid.maxChildExtent = 60.0;
+    grid.delegate = new MaxTileWidthGridDelegate(maxTileWidth: 60.0);
     expect(grid.needsLayout, equals(true));
 
     pumpFrame();


### PR DESCRIPTION
This patch make grid layout much more flexible. The behavior is factored
out into a GridDelegate that's modeled after the custom layout
delegates. The patch includes a MaxTileWidthGridDelegate that implements
the old behavior and a FixedColumnCountGridDelegate that implements a
grid layout with a fixed number of columns.

Fixes #1048
