### PR TITLE
Introduce ScrollableList2

### DIFF
--- a/examples/widgets/media_query.dart
+++ b/examples/widgets/media_query.dart
@@ -72,13 +72,14 @@ class MediaQueryExample extends StatelessComponent {
       items.add(new AdaptiveItem("Item $i"));
 
     if (MediaQuery.of(context).size.width < _gridViewBreakpoint) {
-      return new Block(
-        items.map((AdaptiveItem item) => item.toListItem()).toList()
+      return new ScrollableList2(
+        itemExtent: 50.0,
+        children: items.map((AdaptiveItem item) => item.toListItem()).toList()
       );
     } else {
       return new ScrollableGrid(
-        children: items.map((AdaptiveItem item) => item.toCard()).toList(),
-        delegate: new MaxTileWidthGridDelegate(maxTileWidth: _maxTileWidth)
+        delegate: new MaxTileWidthGridDelegate(maxTileWidth: _maxTileWidth),
+        children: items.map((AdaptiveItem item) => item.toCard()).toList()
       );
     }
   }

--- a/packages/flutter/lib/rendering.dart
+++ b/packages/flutter/lib/rendering.dart
@@ -18,6 +18,7 @@ export 'src/rendering/flex.dart';
 export 'src/rendering/grid.dart';
 export 'src/rendering/image.dart';
 export 'src/rendering/layer.dart';
+export 'src/rendering/list.dart';
 export 'src/rendering/node.dart';
 export 'src/rendering/object.dart';
 export 'src/rendering/overflow.dart';

--- a/packages/flutter/lib/src/rendering/list.dart
+++ b/packages/flutter/lib/src/rendering/list.dart
@@ -1,0 +1,86 @@
+// Copyright 2015 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'box.dart';
+import 'object.dart';
+import 'viewport.dart';
+
+/// Parent data for use with [RenderList].
+class ListParentData extends ContainerBoxParentDataMixin<RenderBox> { }
+
+class RenderList extends RenderVirtualViewport<ListParentData> {
+  RenderList({
+    List<RenderBox> children,
+    double itemExtent,
+    int virtualChildCount,
+    Offset paintOffset: Offset.zero,
+    LayoutCallback callback
+  }) : _itemExtent = itemExtent, super(
+    virtualChildCount: virtualChildCount,
+    paintOffset: paintOffset,
+    callback: callback
+  ) {
+    assert(itemExtent != null);
+    addAll(children);
+  }
+
+  double get itemExtent => _itemExtent;
+  double _itemExtent;
+  void set itemExtent (double newValue) {
+    assert(newValue != null);
+    if (_itemExtent == newValue)
+      return;
+    _itemExtent = newValue;
+    markNeedsLayout();
+  }
+
+  void setupParentData(RenderBox child) {
+    if (child.parentData is! ListParentData)
+      child.parentData = new ListParentData();
+  }
+
+  double get _preferredMainAxisExtent => itemExtent * virtualChildCount;
+
+  double getMinIntrinsicWidth(BoxConstraints constraints) {
+    assert(constraints.isNormalized);
+    return constraints.constrainWidth(0.0);
+  }
+
+  double getMaxIntrinsicWidth(BoxConstraints constraints) {
+    assert(constraints.isNormalized);
+    return constraints.constrainWidth(0.0);
+  }
+
+  double getMinIntrinsicHeight(BoxConstraints constraints) {
+    assert(constraints.isNormalized);
+    return constraints.constrainHeight(_preferredMainAxisExtent);
+  }
+
+  double getMaxIntrinsicHeight(BoxConstraints constraints) {
+    assert(constraints.isNormalized);
+    return constraints.constrainHeight(_preferredMainAxisExtent);
+  }
+
+  void performLayout() {
+    double height = _preferredMainAxisExtent;
+    size = new Size(constraints.maxWidth, constraints.constrainHeight(height));
+
+    if (callback != null)
+      invokeLayoutCallback(callback);
+
+    BoxConstraints innerConstraints =
+        new BoxConstraints.tightFor(width: size.width, height: itemExtent);
+
+    int childIndex = 0;
+    RenderBox child = firstChild;
+    while (child != null) {
+      child.layout(innerConstraints);
+      final ListParentData childParentData = child.parentData;
+      childParentData.offset = new Offset(0.0, childIndex * itemExtent);
+      childIndex += 1;
+      assert(child.parentData == childParentData);
+      child = childParentData.nextSibling;
+    }
+  }
+}

--- a/packages/flutter/lib/src/widgets/scrollable_list.dart
+++ b/packages/flutter/lib/src/widgets/scrollable_list.dart
@@ -1,0 +1,124 @@
+// Copyright 2015 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'framework.dart';
+import 'scrollable.dart';
+import 'virtual_viewport.dart';
+
+import 'package:flutter/animation.dart';
+import 'package:flutter/rendering.dart';
+
+class ScrollableList2 extends Scrollable {
+  ScrollableList2({
+    Key key,
+    double initialScrollOffset,
+    ScrollListener onScroll,
+    SnapOffsetCallback snapOffsetCallback,
+    double snapAlignmentOffset: 0.0,
+    this.itemExtent,
+    this.children
+  }) : super(
+    key: key,
+    initialScrollOffset: initialScrollOffset,
+    // TODO(abarth): Support horizontal offsets.
+    scrollDirection: ScrollDirection.vertical,
+    onScroll: onScroll,
+    snapOffsetCallback: snapOffsetCallback,
+    snapAlignmentOffset: snapAlignmentOffset
+  );
+
+  final double itemExtent;
+  final List<Widget> children;
+
+  ScrollableState createState() => new _ScrollableList2State();
+}
+
+class _ScrollableList2State extends ScrollableState<ScrollableList2> {
+  ScrollBehavior createScrollBehavior() => new OverscrollBehavior();
+  ExtentScrollBehavior get scrollBehavior => super.scrollBehavior;
+
+  void _handleExtentsChanged(double contentExtent, double containerExtent) {
+    setState(() {
+      scrollTo(scrollBehavior.updateExtents(
+        contentExtent: contentExtent,
+        containerExtent: containerExtent,
+        scrollOffset: scrollOffset
+      ));
+    });
+  }
+
+  Widget buildContent(BuildContext context) {
+    return new ListViewport(
+      startOffset: scrollOffset,
+      itemExtent: config.itemExtent,
+      onExtentsChanged: _handleExtentsChanged,
+      children: config.children
+    );
+  }
+}
+
+class ListViewport extends VirtualViewport {
+  ListViewport({
+    Key key,
+    this.startOffset,
+    this.itemExtent,
+    this.onExtentsChanged,
+    this.children
+  });
+
+  final double startOffset;
+  final double itemExtent;
+  final ExtentsChangedCallback onExtentsChanged;
+  final List<Widget> children;
+
+  RenderList createRenderObject() => new RenderList(itemExtent: itemExtent);
+
+  _ListViewportElement createElement() => new _ListViewportElement(this);
+}
+
+class _ListViewportElement extends VirtualViewportElement<ListViewport> {
+  _ListViewportElement(ListViewport widget) : super(widget);
+
+  RenderList get renderObject => super.renderObject;
+
+  int get materializedChildBase => _materializedChildBase;
+  int _materializedChildBase;
+
+  int get materializedChildCount => _materializedChildCount;
+  int _materializedChildCount;
+
+  double get repaintOffsetBase => _repaintOffsetBase;
+  double _repaintOffsetBase;
+
+  double get repaintOffsetLimit =>_repaintOffsetLimit;
+  double _repaintOffsetLimit;
+
+  void updateRenderObject() {
+    renderObject.itemExtent = widget.itemExtent;
+    super.updateRenderObject();
+  }
+
+  double _contentExtent;
+  double _containerExtent;
+
+  void layout(BoxConstraints constraints) {
+    double contentExtent = widget.itemExtent * widget.children.length;
+    double containerExtent = renderObject.size.height;
+
+    _materializedChildBase = (widget.startOffset ~/ widget.itemExtent).clamp(0, widget.children.length);
+    int materializedChildLimit = ((widget.startOffset + containerExtent) / widget.itemExtent).ceil().clamp(0, widget.children.length);
+    _materializedChildCount = materializedChildLimit - _materializedChildBase;
+
+    _repaintOffsetBase = _materializedChildBase * widget.itemExtent;
+    _repaintOffsetLimit = materializedChildLimit * widget.itemExtent;
+
+    super.layout(constraints);
+
+    if (contentExtent != _contentExtent || containerExtent != _containerExtent) {
+      _contentExtent = contentExtent;
+      _containerExtent = containerExtent;
+      widget.onExtentsChanged(_contentExtent, _containerExtent);
+    }
+  }
+}

--- a/packages/flutter/lib/src/widgets/virtual_viewport.dart
+++ b/packages/flutter/lib/src/widgets/virtual_viewport.dart
@@ -1,0 +1,113 @@
+// Copyright 2015 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'basic.dart';
+import 'framework.dart';
+
+import 'package:flutter/rendering.dart';
+
+typedef void ExtentsChangedCallback(double contentExtent, double containerExtent);
+
+abstract class VirtualViewport extends RenderObjectWidget {
+  double get startOffset;
+  List<Widget> get children;
+}
+
+abstract class VirtualViewportElement<T extends VirtualViewport> extends RenderObjectElement<T> {
+  VirtualViewportElement(T widget) : super(widget);
+
+  int get materializedChildBase;
+  int get materializedChildCount;
+  double get repaintOffsetBase;
+  double get repaintOffsetLimit;
+
+  List<Element> _materializedChildren = const <Element>[];
+
+  RenderVirtualViewport get renderObject => super.renderObject;
+
+  void visitChildren(ElementVisitor visitor) {
+    if (_materializedChildren == null)
+      return;
+    for (Element child in _materializedChildren)
+      visitor(child);
+  }
+
+  void mount(Element parent, dynamic newSlot) {
+    super.mount(parent, newSlot);
+    renderObject.callback = layout;
+    updateRenderObject();
+  }
+
+  void unmount() {
+    renderObject.callback = null;
+    super.unmount();
+  }
+
+  void update(T newWidget) {
+    super.update(newWidget);
+    updateRenderObject();
+    if (!renderObject.needsLayout)
+      _materializeChildren();
+  }
+
+  void _updatePaintOffset() {
+    renderObject.paintOffset =
+    renderObject.paintOffset = new Offset(0.0, -(widget.startOffset - repaintOffsetBase));
+  }
+
+  void updateRenderObject() {
+    renderObject.virtualChildCount = widget.children.length;
+
+    if (repaintOffsetBase != null) {
+      _updatePaintOffset();
+
+      // If we don't already need layout, we need to request a layout if the
+      // viewport has shifted to expose new children.
+      if (!renderObject.needsLayout) {
+        if (repaintOffsetBase != null && widget.startOffset < repaintOffsetBase)
+          renderObject.markNeedsLayout();
+        else if (repaintOffsetLimit != null && widget.startOffset + renderObject.size.height > repaintOffsetLimit)
+          renderObject.markNeedsLayout();
+      }
+    }
+  }
+
+  void layout(BoxConstraints constraints) {
+    assert(repaintOffsetBase != null);
+    assert(repaintOffsetLimit != null);
+    _updatePaintOffset();
+    BuildableElement.lockState(_materializeChildren);
+  }
+
+  void _materializeChildren() {
+    int base = materializedChildBase;
+    int count = materializedChildCount;
+    assert(base != null);
+    assert(count != null);
+    List<Widget> newWidgets = new List<Widget>(count);
+    for (int i = 0; i < count; ++i) {
+      int childIndex = base + i;
+      Widget child = widget.children[childIndex];
+      Key key = new ValueKey(child.key ?? childIndex);
+      newWidgets[i] = new RepaintBoundary(key: key, child: child);
+    }
+    _materializedChildren = updateChildren(_materializedChildren, newWidgets);
+  }
+
+  void insertChildRenderObject(RenderObject child, Element slot) {
+    RenderObject nextSibling = slot?.renderObject;
+    renderObject.add(child, before: nextSibling);
+  }
+
+  void moveChildRenderObject(RenderObject child, Element slot) {
+    assert(child.parent == renderObject);
+    RenderObject nextSibling = slot?.renderObject;
+    renderObject.move(child, before: nextSibling);
+  }
+
+  void removeChildRenderObject(RenderObject child) {
+    assert(child.parent == renderObject);
+    renderObject.remove(child);
+  }
+}

--- a/packages/flutter/lib/widgets.dart
+++ b/packages/flutter/lib/widgets.dart
@@ -33,10 +33,12 @@ export 'src/widgets/placeholder.dart';
 export 'src/widgets/routes.dart';
 export 'src/widgets/scrollable.dart';
 export 'src/widgets/scrollable_grid.dart';
+export 'src/widgets/scrollable_list.dart';
 export 'src/widgets/statistics_overlay.dart';
 export 'src/widgets/status_transitions.dart';
 export 'src/widgets/title.dart';
 export 'src/widgets/transitions.dart';
 export 'src/widgets/unique_component.dart';
+export 'src/widgets/virtual_viewport.dart';
 
 export 'package:vector_math/vector_math_64.dart' show Matrix4;


### PR DESCRIPTION
ScrollableList2 uses the same pattern as ScrollableGrid, which requires the
client to allocate widgets for every list item but doesn't inflate them unless
they're actually needed for the view. It improves on the original
ScrollableList by not requiring a rebuild of the whole visible portion of the
list when scrolling. In fact, small scrolls can often be handled entirely by
repainting.
