### PR TITLE
Remove ScrollDirection.both

### DIFF
--- a/packages/flutter/lib/src/rendering/viewport.dart
+++ b/packages/flutter/lib/src/rendering/viewport.dart
@@ -16,9 +16,6 @@ enum ScrollDirection {
 
   /// Scroll up and down
   vertical,
-
-  /// Scroll in all four cardinal directions
-  both
 }
 
 /// A render object that's bigger on the inside.
@@ -44,8 +41,6 @@ class RenderViewport extends RenderBox with RenderObjectWithChildMixin<RenderBox
 
   bool _offsetIsSane(Offset offset, ScrollDirection direction) {
     switch (direction) {
-      case ScrollDirection.both:
-        return true;
       case ScrollDirection.horizontal:
         return offset.dy == 0.0;
       case ScrollDirection.vertical:
@@ -84,9 +79,6 @@ class RenderViewport extends RenderBox with RenderObjectWithChildMixin<RenderBox
   BoxConstraints _getInnerConstraints(BoxConstraints constraints) {
     BoxConstraints innerConstraints;
     switch (scrollDirection) {
-      case ScrollDirection.both:
-        innerConstraints = new BoxConstraints();
-        break;
       case ScrollDirection.horizontal:
         innerConstraints = constraints.heightConstraints();
         break;

--- a/packages/flutter/lib/src/widgets/mixed_viewport.dart
+++ b/packages/flutter/lib/src/widgets/mixed_viewport.dart
@@ -319,9 +319,6 @@ class _MixedViewportElement extends RenderObjectElement<MixedViewport> {
         return childRenderObject.getMaxIntrinsicHeight(innerConstraints);
       case ScrollDirection.horizontal:
         return childRenderObject.getMaxIntrinsicWidth(innerConstraints);
-      case ScrollDirection.both:
-        assert(false); // we don't support ScrollDirection.both, see issue 888
-        return double.NAN;
     }
   }
 
@@ -331,9 +328,6 @@ class _MixedViewportElement extends RenderObjectElement<MixedViewport> {
         return new BoxConstraints.tightFor(width: constraints.constrainWidth());
       case ScrollDirection.horizontal:
         return new BoxConstraints.tightFor(height: constraints.constrainHeight());
-      case ScrollDirection.both:
-        assert(false); // we don't support ScrollDirection.both, see issue 888
-        return null;
     }
   }
 
@@ -373,7 +367,6 @@ class _MixedViewportElement extends RenderObjectElement<MixedViewport> {
           'width (e.g. inside something else that scrolls horizontally), because it would then just eagerly build ' +
           'all the children. You probably want to put the MixedViewport inside a Container with a fixed width.' is String);
         break;
-      case ScrollDirection.both: assert(false); // we don't support ScrollDirection.both, see issue 888
     }
     final double endOffset = widget.startOffset + extent;
 
@@ -523,7 +516,6 @@ class _MixedViewportElement extends RenderObjectElement<MixedViewport> {
         case ScrollDirection.horizontal:
           renderObject.direction = BlockDirection.horizontal;
           break;
-        case ScrollDirection.both: assert(false); // we don't support ScrollDirection.both, see issue 888
       }
       renderObject.startOffset = _childOffsets[index] - widget.startOffset;
       // Build all the widgets we still need.

--- a/packages/flutter/lib/src/widgets/scrollable.dart
+++ b/packages/flutter/lib/src/widgets/scrollable.dart
@@ -91,9 +91,6 @@ abstract class Scrollable extends StatefulComponent {
         Point scrollableCenter = scrollableBox.localToGlobal(new Point(scrollableSize.width / 2.0, 0.0));
         scrollOffsetDelta = targetCenter.x - scrollableCenter.x;
         break;
-      case ScrollDirection.both:
-        assert(false); // See https://github.com/flutter/engine/issues/888
-        break;
     }
 
     ExtentScrollBehavior scrollBehavior = scrollable.scrollBehavior;


### PR DESCRIPTION
Almost none of the clients of ScrollDirection can handle scrolling in both
directions.

Fixes #151
