### PR TITLE
Convert TabBar to TabBar<T> and TabBarSelection to TabBarSelection<T>

### DIFF
--- a/examples/material_gallery/lib/demo/tabs_demo.dart
+++ b/examples/material_gallery/lib/demo/tabs_demo.dart
@@ -9,16 +9,15 @@ import 'widget_demo.dart';
 final List<String> _iconNames = <String>["event", "home", "android", "alarm", "face", "language"];
 
 Widget _buildTabBarSelection(_, Widget child) {
-  return new TabBarSelection(
-    maxIndex: _iconNames.length - 1,
-    child: child
-  );
+  return new TabBarSelection<String>(values: _iconNames, child: child);
 }
 
 Widget _buildTabBar(_) {
-  return new TabBar(
+  return new TabBar<String>(
     isScrollable: true,
-    labels: _iconNames.map((String iconName) => new TabLabel(text: iconName, icon: "action/$iconName")).toList()
+    labels: new Map.fromIterable(
+      _iconNames,
+      value: (String iconName) => new TabLabel(text: iconName, icon: "action/$iconName"))
   );
 }
 

--- a/examples/stocks/lib/stock_home.dart
+++ b/examples/stocks/lib/stock_home.dart
@@ -161,16 +161,14 @@ class StockHomeState extends State<StockHome> {
           onPressed: _handleMenuShow
         )
       ],
-      tabBar: new TabBar(
-        labels: <TabLabel>[
-          new TabLabel(text: StockStrings.of(context).market()),
-          new TabLabel(text: StockStrings.of(context).portfolio())
-        ]
+      tabBar: new TabBar<StockHomeTab>(
+        labels: <StockHomeTab, TabLabel>{
+          StockHomeTab.market: new TabLabel(text: StockStrings.of(context).market()),
+          StockHomeTab.portfolio: new TabLabel(text: StockStrings.of(context).portfolio())
+        }
       )
     );
   }
-
-  int selectedTabIndex = 0;
 
   Iterable<Stock> _getStockList(Iterable<String> symbols) {
     return symbols.map((String symbol) => config.stocks[symbol])
@@ -266,8 +264,8 @@ class StockHomeState extends State<StockHome> {
   }
 
   Widget build(BuildContext context) {
-    return new TabBarSelection(
-      maxIndex: 1,
+    return new TabBarSelection<StockHomeTab>(
+      values: <StockHomeTab>[StockHomeTab.market, StockHomeTab.portfolio],
       child: new Scaffold(
         key: _scaffoldKey,
         toolBar: _isSearching ? buildSearchBar() : buildToolBar(),

--- a/packages/flutter/test/widget/tabs_test.dart
+++ b/packages/flutter/test/widget/tabs_test.dart
@@ -7,13 +7,13 @@ import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:test/test.dart';
 
-Widget buildFrame({ List<String> tabs, bool isScrollable: false }) {
+Widget buildFrame({ List<String> tabs, String value, bool isScrollable: false }) {
   return new Material(
-    child: new TabBarSelection(
-      index: 2,
-      maxIndex: tabs.length - 1,
-      child: new TabBar(
-        labels: tabs.map((String tab) => new TabLabel(text: tab)).toList(),
+    child: new TabBarSelection<String>(
+      value: value,
+      values: tabs,
+      child: new TabBar<String>(
+        labels: new Map<String, TabLabel>.fromIterable(tabs, value: (String tab) => new TabLabel(text: tab)),
         isScrollable: isScrollable
       )
     )
@@ -25,28 +25,48 @@ void main() {
     testWidgets((WidgetTester tester) {
       List<String> tabs = <String>['A', 'B', 'C'];
 
-      tester.pumpWidget(buildFrame(tabs: tabs, isScrollable: false));
-      TabBarSelectionState selection = tester.findStateOfType(TabBarSelectionState);
+      tester.pumpWidget(buildFrame(tabs: tabs, value: 'C', isScrollable: false));
+      TabBarSelectionState<String> selection = TabBarSelection.of(tester.findText('A'));
       expect(selection, isNotNull);
+      expect(selection.indexOf('A'), equals(0));
+      expect(selection.indexOf('B'), equals(1));
+      expect(selection.indexOf('C'), equals(2));
       expect(tester.findText('A'), isNotNull);
       expect(tester.findText('B'), isNotNull);
       expect(tester.findText('C'), isNotNull);
       expect(selection.index, equals(2));
+      expect(selection.previousIndex, equals(2));
+      expect(selection.value, equals('C'));
+      expect(selection.previousValue, equals('C'));
 
-      tester.pumpWidget(buildFrame(tabs: tabs, isScrollable: false));
+      tester.pumpWidget(buildFrame(tabs: tabs, value: 'C' ,isScrollable: false));
       tester.tap(tester.findText('B'));
       tester.pump();
+      expect(selection.valueIsChanging, true);
+      tester.pump(const Duration(seconds: 1)); // finish the animation
+      expect(selection.valueIsChanging, false);
+      expect(selection.value, equals('B'));
+      expect(selection.previousValue, equals('C'));
       expect(selection.index, equals(1));
+      expect(selection.previousIndex, equals(2));
 
-      tester.pumpWidget(buildFrame(tabs: tabs, isScrollable: false));
+      tester.pumpWidget(buildFrame(tabs: tabs, value: 'C', isScrollable: false));
       tester.tap(tester.findText('C'));
       tester.pump();
+      tester.pump(const Duration(seconds: 1));
+      expect(selection.value, equals('C'));
+      expect(selection.previousValue, equals('B'));
       expect(selection.index, equals(2));
+      expect(selection.previousIndex, equals(1));
 
-      tester.pumpWidget(buildFrame(tabs: tabs, isScrollable: false));
+      tester.pumpWidget(buildFrame(tabs: tabs, value: 'C', isScrollable: false));
       tester.tap(tester.findText('A'));
       tester.pump();
+      tester.pump(const Duration(seconds: 1));
+      expect(selection.value, equals('A'));
+      expect(selection.previousValue, equals('C'));
       expect(selection.index, equals(0));
+      expect(selection.previousIndex, equals(2));
     });
   });
 
@@ -54,28 +74,28 @@ void main() {
     testWidgets((WidgetTester tester) {
       List<String> tabs = <String>['A', 'B', 'C'];
 
-      tester.pumpWidget(buildFrame(tabs: tabs, isScrollable: true));
-      TabBarSelectionState selection = tester.findStateOfType(TabBarSelectionState);
+      tester.pumpWidget(buildFrame(tabs: tabs, value: 'C', isScrollable: true));
+      TabBarSelectionState<String> selection = TabBarSelection.of(tester.findText('A'));
       expect(selection, isNotNull);
       expect(tester.findText('A'), isNotNull);
       expect(tester.findText('B'), isNotNull);
       expect(tester.findText('C'), isNotNull);
-      expect(selection.index, equals(2));
+      expect(selection.value, equals('C'));
 
-      tester.pumpWidget(buildFrame(tabs: tabs, isScrollable: true));
+      tester.pumpWidget(buildFrame(tabs: tabs, value: 'C', isScrollable: true));
       tester.tap(tester.findText('B'));
       tester.pump();
-      expect(selection.index, equals(1));
+      expect(selection.value, equals('B'));
 
-      tester.pumpWidget(buildFrame(tabs: tabs, isScrollable: true));
+      tester.pumpWidget(buildFrame(tabs: tabs, value: 'C', isScrollable: true));
       tester.tap(tester.findText('C'));
       tester.pump();
-      expect(selection.index, equals(2));
+      expect(selection.value, equals('C'));
 
-      tester.pumpWidget(buildFrame(tabs: tabs, isScrollable: true));
+      tester.pumpWidget(buildFrame(tabs: tabs, value: 'C', isScrollable: true));
       tester.tap(tester.findText('A'));
       tester.pump();
-      expect(selection.index, equals(0));
+      expect(selection.value, equals('A'));
     });
   });
 }


### PR DESCRIPTION
The TabBarSelection constructor no longer has the odd maxIndex parameter and the selection is initialized by value rather than the index of the selected tab.

TabBar<T> has a Map<T, TabLabel> labels parameter instead of List<TabLabel>.
