### PR TITLE
Add Tween, a stateless replacement for AnimatedValue

### DIFF
--- a/examples/widgets/progress_indicator.dart
+++ b/examples/widgets/progress_indicator.dart
@@ -5,6 +5,13 @@
 import 'package:flutter/animation.dart';
 import 'package:flutter/material.dart';
 
+final Tween _kValueTween = new Tween<double>(
+  begin: 0.0,
+  end: 1.0,
+  curve: const Interval(0.0, 0.9, curve: Curves.ease),
+  reverseCurve: Curves.ease
+);
+
 class ProgressIndicatorApp extends StatefulComponent {
   ProgressIndicatorAppState createState() => new ProgressIndicatorAppState();
 }
@@ -12,22 +19,17 @@ class ProgressIndicatorApp extends StatefulComponent {
 class ProgressIndicatorAppState extends State<ProgressIndicatorApp> {
   void initState() {
     super.initState();
-    valueAnimation = new ValuePerformance<double>()
+    valueAnimation = new Performance()
       ..duration = const Duration(milliseconds: 1500)
-      ..variable = new AnimatedValue<double>(
-        0.0,
-        end: 1.0,
-        curve: new Interval(0.0, 0.9, curve: Curves.ease),
-        reverseCurve: Curves.ease
-      );
-    valueAnimation.addStatusListener((PerformanceStatus status) {
-      if (status == PerformanceStatus.dismissed || status == PerformanceStatus.completed)
-        reverseValueAnimationDirection();
-    });
-    valueAnimation.play(valueAnimationDirection);
+      ..addStatusListener((PerformanceStatus status) {
+        if (status == PerformanceStatus.dismissed
+            || status == PerformanceStatus.completed)
+          reverseValueAnimationDirection();
+      })
+      ..play(valueAnimationDirection);
   }
 
-  ValuePerformance<double> valueAnimation;
+  Performance valueAnimation;
   AnimationDirection valueAnimationDirection = AnimationDirection.forward;
 
   void handleTap() {
@@ -48,6 +50,7 @@ class ProgressIndicatorAppState extends State<ProgressIndicatorApp> {
   }
 
   Widget buildIndicators(BuildContext context) {
+    double value = _kValueTween.evaluate(valueAnimation);
     List<Widget> indicators = <Widget>[
         new SizedBox(
           width: 200.0,
@@ -55,19 +58,19 @@ class ProgressIndicatorAppState extends State<ProgressIndicatorApp> {
         ),
         new LinearProgressIndicator(),
         new LinearProgressIndicator(),
-        new LinearProgressIndicator(value: valueAnimation.value),
+        new LinearProgressIndicator(value: value),
         new CircularProgressIndicator(),
         new SizedBox(
             width: 20.0,
             height: 20.0,
-            child: new CircularProgressIndicator(value: valueAnimation.value)
+            child: new CircularProgressIndicator(value: value)
         ),
         new SizedBox(
           width: 50.0,
           height: 30.0,
-          child: new CircularProgressIndicator(value: valueAnimation.value)
+          child: new CircularProgressIndicator(value: value)
         ),
-        new Text("${(valueAnimation.value * 100.0).toStringAsFixed(1)}%" + (valueAnimation.isAnimating ? '' : ' (paused)'))
+        new Text("${(value* 100.0).toStringAsFixed(1)}%" + (valueAnimation.isAnimating ? '' : ' (paused)'))
     ];
     return new Column(
       indicators
@@ -83,7 +86,6 @@ class ProgressIndicatorAppState extends State<ProgressIndicatorApp> {
       child: new Container(
         padding: const EdgeDims.symmetric(vertical: 12.0, horizontal: 8.0),
         child: new BuilderTransition(
-          variables: <AnimatedValue<double>>[valueAnimation.variable],
           performance: valueAnimation.view,
           builder: buildIndicators
         )

--- a/packages/flutter/lib/animation.dart
+++ b/packages/flutter/lib/animation.dart
@@ -16,3 +16,4 @@ export 'src/animation/performance.dart';
 export 'src/animation/scroll_behavior.dart';
 export 'src/animation/simulation_stepper.dart';
 export 'src/animation/ticker.dart';
+export 'src/animation/tweens.dart';

--- a/packages/flutter/lib/src/animation/tweens.dart
+++ b/packages/flutter/lib/src/animation/tweens.dart
@@ -1,0 +1,38 @@
+// Copyright 2015 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:ui' show Color, Size, Rect;
+
+import 'curves.dart';
+import 'performance.dart';
+
+class ColorTween extends Tween<Color> {
+  ColorTween({ Color begin,  Color end, Curve curve, Curve reverseCurve })
+    : super(begin: begin, end: end, curve: curve, reverseCurve: reverseCurve);
+
+  Color lerp(double t) => Color.lerp(begin, end, t);
+}
+
+class SizeTween extends Tween<Size> {
+  SizeTween({ Size begin,  Size end, Curve curve, Curve reverseCurve })
+    : super(begin: begin, end: end, curve: curve, reverseCurve: reverseCurve);
+
+  Size lerp(double t) => Size.lerp(begin, end, t);
+}
+
+class RectTween extends Tween<Rect> {
+  RectTween({ Rect begin,  Rect end, Curve curve, Curve reverseCurve })
+    : super(begin: begin, end: end, curve: curve, reverseCurve: reverseCurve);
+
+  Rect lerp(double t) => Rect.lerp(begin, end, t);
+}
+
+class IntTween extends Tween<int> {
+  IntTween({ int begin,  int end, Curve curve, Curve reverseCurve })
+  : super(begin: begin, end: end, curve: curve, reverseCurve: reverseCurve);
+
+  // The inherited lerp() function doesn't work with ints because it multiplies
+  // the begin and end types by a double, and int * double returns a double.
+  int lerp(double t) => (begin + (end - begin) * t).round();
+}


### PR DESCRIPTION
Previously, we used AnimatedValue, which needed to be mutated every frame,
which cause complexity when we passed AnimatedValues between components. After
this patch, we have Tween, which is similar but just provides a view on a
performance.

See #216
