### PR TITLE
Proof of concept for Firebase support in Flutter framework

### DIFF
--- a/packages/firebase/lib/firebase.dart
+++ b/packages/firebase/lib/firebase.dart
@@ -1,0 +1,11 @@
+// Copyright 2015 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+/// Service exposed to Flutter apps that implements a subset of the Firebase
+/// API.
+///
+/// This library will probably be moved into a separate package eventually.
+library firebase;
+
+export 'src/firebase.dart';

--- a/packages/firebase/lib/src/firebase.dart
+++ b/packages/firebase/lib/src/firebase.dart
@@ -1,0 +1,38 @@
+// Copyright 2015, the Flutter authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:flutter/services.dart';
+import 'package:sky_services/firebase/firebase.mojom.dart' as mojo;
+
+export 'package:sky_services/firebase/firebase.mojom.dart' show DataSnapshot, EventType;
+
+class Firebase {
+
+  mojo.FirebaseProxy _firebase;
+
+  Firebase(String url) : _firebase = new mojo.FirebaseProxy.unbound() {
+    shell.connectToService("firebase::Firebase", _firebase);
+    _firebase.ptr.initWithUrl(url);
+  }
+
+  Firebase._withProxy(mojo.FirebaseProxy firebase) : _firebase = firebase;
+
+  Firebase get root {
+    mojo.FirebaseProxy proxy = new mojo.FirebaseProxy.unbound();
+    _firebase.ptr.getRoot(proxy);
+    return new Firebase._withProxy(proxy);
+  }
+
+  Firebase childByAppendingPath(String path) {
+    mojo.FirebaseProxy proxy = new mojo.FirebaseProxy.unbound();
+    _firebase.ptr.getChild(path, proxy);
+    return new Firebase._withProxy(proxy);
+  }
+
+  Future<mojo.DataSnapshot> once(mojo.EventType eventType) async {
+    return (await _firebase.ptr.observeSingleEventOfType(eventType)).snapshot;
+  }
+}


### PR DESCRIPTION
Basic Firebase support on iOS and Android. The Flutter tool isn't able to build custom Java/Objective-C yet, so you can't actually use this unless you're building with ninja.
