### PR TITLE
Fix assert in Stocks app

### DIFF
--- a/packages/flutter/lib/src/widgets/scrollable_grid.dart
+++ b/packages/flutter/lib/src/widgets/scrollable_grid.dart
@@ -142,7 +142,7 @@ class _GridViewportElement extends VirtualViewportElement<GridViewport> {
     _materializedChildBase = (materializedRowBase * _specification.columnCount).clamp(0, renderObject.virtualChildCount);
     _materializedChildCount = (materializedRowLimit * _specification.columnCount).clamp(0, renderObject.virtualChildCount) - _materializedChildBase;
     _repaintOffsetBase = _specification.rowOffsets[materializedRowBase];
-    _repaintOffsetLimit = _specification.rowOffsets[materializedRowLimit];
+    _repaintOffsetLimit = _specification.rowOffsets[materializedRowLimit] - containerExtent;
 
     super.layout(constraints);
 

--- a/packages/flutter/lib/src/widgets/scrollable_list.dart
+++ b/packages/flutter/lib/src/widgets/scrollable_list.dart
@@ -170,7 +170,7 @@ class _ListViewportElement extends VirtualViewportElement<ListViewport> {
 
     _materializedChildCount = materializedChildLimit - _materializedChildBase;
     _repaintOffsetBase = _materializedChildBase * widget.itemExtent;
-    _repaintOffsetLimit = materializedChildLimit * widget.itemExtent;
+    _repaintOffsetLimit = materializedChildLimit * widget.itemExtent - containerExtent;
 
     super.layout(constraints);
 

--- a/packages/flutter/lib/src/widgets/virtual_viewport.dart
+++ b/packages/flutter/lib/src/widgets/virtual_viewport.dart
@@ -69,15 +69,6 @@ abstract class VirtualViewportElement<T extends VirtualViewport> extends RenderO
     }
   }
 
-  double get _containerExtent {
-    switch (widget.scrollDirection) {
-      case ScrollDirection.vertical:
-        return renderObject.size.height;
-      case ScrollDirection.horizontal:
-        return renderObject.size.width;
-    }
-  }
-
   void updateRenderObject() {
     renderObject.virtualChildCount = widget.children.length;
 
@@ -89,7 +80,7 @@ abstract class VirtualViewportElement<T extends VirtualViewport> extends RenderO
       if (!renderObject.needsLayout) {
         if (repaintOffsetBase != null && widget.startOffset < repaintOffsetBase)
           renderObject.markNeedsLayout();
-        else if (repaintOffsetLimit != null && widget.startOffset + _containerExtent > repaintOffsetLimit)
+        else if (repaintOffsetLimit != null && widget.startOffset > repaintOffsetLimit)
           renderObject.markNeedsLayout();
       }
     }


### PR DESCRIPTION
When paging a scrollable list, we were trying to read the render object's size
at a time when we're not allowed to read it. Instead, encode the information
into the repaint limit, which is more correct (and faster) anyway.
