### PR TITLE
Remove unreferenced getter "debugDoesLayoutWithCallback".

### DIFF
--- a/packages/flutter/lib/src/rendering/block.dart
+++ b/packages/flutter/lib/src/rendering/block.dart
@@ -402,9 +402,6 @@ class RenderBlockViewport extends RenderBlockBase {
   // scroll the RenderBlockViewport, it would shift in its parent if
   // the parent was baseline-aligned, which makes no sense.
 
-  // TODO(abarth): debugDoesLayoutWithCallback appears to be unreferenced.
-  bool get debugDoesLayoutWithCallback => true;
-
   void performLayout() {
     if (_callback != null) {
       try {

--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -786,7 +786,7 @@ abstract class RenderObject extends AbstractNode implements HitTestTarget {
   /// information without informing this render object.
   void performLayout();
 
-  /// Allows this render object to mutation its child list during layout and
+  /// Allows this render object to mutate its child list during layout and
   /// invokes callback.
   void invokeLayoutCallback(LayoutCallback callback) {
     assert(_debugMutationsLocked);


### PR DESCRIPTION
I think I wanted to use this at some point but ended up going a
different direction. Instead, object.dart has a private field that
serves a similar purpose.
