### PR TITLE
Move default back behavior to FlutterWidgetBinding

### DIFF
--- a/packages/flutter/lib/src/material/material_app.dart
+++ b/packages/flutter/lib/src/material/material_app.dart
@@ -86,11 +86,11 @@ class _MaterialAppState extends State<MaterialApp> implements BindingObserver {
     assert(mounted);
     NavigatorState navigator = _navigator.currentState;
     assert(navigator != null);
+    bool result = false;
     navigator.openTransaction((NavigatorTransaction transaction) {
-      if (!transaction.pop())
-        activity.finishCurrentActivity();
+      result = transaction.pop();
     });
-    return true;
+    return result;
   }
 
   void didChangeSize(Size size) => setState(() { _size = size; });

--- a/packages/flutter/lib/src/widgets/binding.dart
+++ b/packages/flutter/lib/src/widgets/binding.dart
@@ -77,8 +77,9 @@ class WidgetFlutterBinding extends BindingBase with Scheduler, Gesturer, Rendere
   void handlePopRoute() {
     for (BindingObserver observer in _observers) {
       if (observer.didPopRoute())
-        break;
+        return;
     }
+    activity.finishCurrentActivity();
   }
 
   void handleAppLifecycleStateChanged(ui.AppLifecycleState state) {


### PR DESCRIPTION
Previously MaterialApp was responsible for ending the activity when the
back stack was empty. However, this behavior is more general than
material. This patch moves the behavior to FlutterWidgetBinding, which
has a global view of all the binding observers.

Fixes #1086
