### PR TITLE
`flutter start` crashes when port 8181 is in use

### DIFF
--- a/packages/flutter_tools/lib/src/device.dart
+++ b/packages/flutter_tools/lib/src/device.dart
@@ -772,7 +772,11 @@ class AndroidDevice extends Device {
   void _forwardObservatoryPort() {
     // Set up port forwarding for observatory.
     String portString = 'tcp:$_observatoryPort';
-    runCheckedSync(adbCommandForDevice(['forward', portString, portString]));
+    try {
+      runCheckedSync(adbCommandForDevice(['forward', portString, portString]));
+    } catch (e) {
+      logging.warning('Unable to forward observatory port ($_observatoryPort):\n$e');
+    }
   }
 
   bool startBundle(AndroidApk apk, String bundlePath, {


### PR DESCRIPTION
Catch the error and log a warning.

Fixes #1050
