### PR TITLE
Fixed a tabs scrolling typo

### DIFF
--- a/packages/flutter/lib/src/material/tabs.dart
+++ b/packages/flutter/lib/src/material/tabs.dart
@@ -839,7 +839,7 @@ class _TabBarViewState<T> extends PageableListState<TabBarView<T>> implements Ta
       scrollTo(scrollBehavior.updateExtents(contentExtent: 2.0, containerExtent: 1.0, scrollOffset: 0.0));
     } else if (selectedIndex == _tabCount - 1) {
       _updateItems(selectedIndex - 1, selectedIndex);
-      scrollTo(scrollBehavior.updateExtents(contentExtent: 1.0, containerExtent: 1.0, scrollOffset: 1.0));
+      scrollTo(scrollBehavior.updateExtents(contentExtent: 2.0, containerExtent: 1.0, scrollOffset: 1.0));
     } else {
       _updateItems(selectedIndex - 1, selectedIndex, selectedIndex + 1);
       scrollTo(scrollBehavior.updateExtents(contentExtent: 3.0, containerExtent: 1.0, scrollOffset: 1.0));


### PR DESCRIPTION
When the last tab was selected the 2nd to last tab view was being shown.
