### PR TITLE
tightenWidth(), tightenHeight() => tighten(width:, height:)

### DIFF
--- a/packages/flutter/lib/src/material/scaffold.dart
+++ b/packages/flutter/lib/src/material/scaffold.dart
@@ -39,7 +39,7 @@ class _ScaffoldLayout extends MultiChildLayoutDelegate {
     // in this case the toolbar appears -after- the body in the stacking order,
     // so the toolbar's shadow is drawn on top of the body.
 
-    final BoxConstraints fullWidthConstraints = looseConstraints.tightenWidth(size.width);
+    final BoxConstraints fullWidthConstraints = looseConstraints.tighten(width: size.width);
     Size toolBarSize = Size.zero;
 
     if (isChild(_Child.toolBar)) {
@@ -49,7 +49,7 @@ class _ScaffoldLayout extends MultiChildLayoutDelegate {
 
     if (isChild(_Child.body)) {
       final double bodyHeight = size.height - toolBarSize.height;
-      final BoxConstraints bodyConstraints = fullWidthConstraints.tightenHeight(bodyHeight);
+      final BoxConstraints bodyConstraints = fullWidthConstraints.tighten(height: bodyHeight);
       layoutChild(_Child.body, bodyConstraints);
       positionChild(_Child.body, new Offset(0.0, toolBarSize.height));
     }

--- a/packages/flutter/lib/src/rendering/box.dart
+++ b/packages/flutter/lib/src/rendering/box.dart
@@ -124,22 +124,14 @@ class BoxConstraints extends Constraints {
     );
   }
 
-  /// Returns new box constraints with a tight width as close to the given width
-  /// as possible while still respecting the original box constraints.
-  BoxConstraints tightenWidth(double width) {
-    return new BoxConstraints(minWidth: math.max(math.min(maxWidth, width), minWidth),
-                              maxWidth: math.max(math.min(maxWidth, width), minWidth),
-                              minHeight: minHeight,
-                              maxHeight: maxHeight);
-  }
-
-  /// Returns new box constraints with a tight height as close to the given
-  /// height as possible while still respecting the original box constraints.
-  BoxConstraints tightenHeight(double height) {
-    return new BoxConstraints(minWidth: minWidth,
-                              maxWidth: maxWidth,
-                              minHeight: math.max(math.min(maxHeight, height), minHeight),
-                              maxHeight: math.max(math.min(maxHeight, height), minHeight));
+  /// Returns new box constraints with a tight width and/or height as close to
+  /// the given width and height as possible while still respecting the original
+  /// box constraints.
+  BoxConstraints tighten({ double width, double height }) {
+    return new BoxConstraints(minWidth: width == null ? minWidth : math.max(math.min(maxWidth, width), minWidth),
+                              maxWidth: width == null ? maxWidth : math.max(math.min(maxWidth, width), minWidth),
+                              minHeight: height == null ? minHeight : math.max(math.min(maxHeight, height), minHeight),
+                              maxHeight: height == null ? maxHeight : math.max(math.min(maxHeight, height), minHeight));
   }
 
   /// Returns box constraints with the same width constraints but with

--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -415,7 +415,7 @@ class RenderIntrinsicWidth extends RenderProxyBox {
       return constraints;
     double width = child.getMaxIntrinsicWidth(constraints);
     assert(width == constraints.constrainWidth(width));
-    return constraints.tightenWidth(_applyStep(width, _stepWidth));
+    return constraints.tighten(width: _applyStep(width, _stepWidth));
   }
 
   double getMinIntrinsicWidth(BoxConstraints constraints) {
@@ -451,7 +451,7 @@ class RenderIntrinsicWidth extends RenderProxyBox {
     if (child != null) {
       BoxConstraints childConstraints = _getInnerConstraints(constraints);
       if (_stepHeight != null)
-        childConstraints.tightenHeight(getMaxIntrinsicHeight(childConstraints));
+        childConstraints.tighten(height: getMaxIntrinsicHeight(childConstraints));
       child.layout(childConstraints, parentUsesSize: true);
       size = child.size;
     } else {
@@ -485,7 +485,7 @@ class RenderIntrinsicHeight extends RenderProxyBox {
       return constraints;
     double height = child.getMaxIntrinsicHeight(constraints);
     assert(height == constraints.constrainHeight(height));
-    return constraints.tightenHeight(height);
+    return constraints.tighten(height: height);
   }
 
   double getMinIntrinsicWidth(BoxConstraints constraints) {

--- a/packages/flutter/lib/src/rendering/stack.dart
+++ b/packages/flutter/lib/src/rendering/stack.dart
@@ -333,14 +333,14 @@ abstract class RenderStackBase extends RenderBox
         BoxConstraints childConstraints = const BoxConstraints();
 
         if (childParentData.left != null && childParentData.right != null)
-          childConstraints = childConstraints.tightenWidth(size.width - childParentData.right - childParentData.left);
+          childConstraints = childConstraints.tighten(width: size.width - childParentData.right - childParentData.left);
         else if (childParentData.width != null)
-          childConstraints = childConstraints.tightenWidth(childParentData.width);
+          childConstraints = childConstraints.tighten(width: childParentData.width);
 
         if (childParentData.top != null && childParentData.bottom != null)
-          childConstraints = childConstraints.tightenHeight(size.height - childParentData.bottom - childParentData.top);
+          childConstraints = childConstraints.tighten(height: size.height - childParentData.bottom - childParentData.top);
         else if (childParentData.height != null)
-          childConstraints = childConstraints.tightenHeight(childParentData.height);
+          childConstraints = childConstraints.tighten(height: childParentData.height);
 
         child.layout(childConstraints, parentUsesSize: true);
 

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -509,12 +509,7 @@ class SizedBox extends OneChildRenderObjectWidget {
   );
 
   BoxConstraints get _additionalConstraints {
-    BoxConstraints result = const BoxConstraints();
-    if (width != null)
-      result = result.tightenWidth(width);
-    if (height != null)
-      result = result.tightenHeight(height);
-    return result;
+    return new BoxConstraints.tightFor(width: width, height: height);
   }
 
   void updateRenderObject(RenderConstrainedBox renderObject, SizedBox oldWidget) {

--- a/packages/flutter/test/rendering/box_test.dart
+++ b/packages/flutter/test/rendering/box_test.dart
@@ -25,7 +25,7 @@ void main() {
 
   test('Flex and padding', () {
     RenderBox size = new RenderConstrainedBox(
-      additionalConstraints: new BoxConstraints().tightenHeight(100.0)
+      additionalConstraints: new BoxConstraints().tighten(height: 100.0)
     );
     RenderBox inner = new RenderDecoratedBox(
       decoration: new BoxDecoration(


### PR DESCRIPTION
This makes it more consistent with tightFor(), and also makes it
easier to tighten both directions at once when you're not sure you
will always do so (e.g. if you have a height and width that might be
null, and want to tighten whichever ones aren't null).
