### PR TITLE
DoubleTap gesture asserts when rejected

### DIFF
--- a/packages/flutter/test/gestures/pointer_router_test.dart
+++ b/packages/flutter/test/gestures/pointer_router_test.dart
@@ -27,4 +27,19 @@ void main() {
     router.route(pointer3.up());
     expect(callbackRan, isFalse);
   });
+
+  test('Supports re-entrant cancellation', () {
+    bool callbackRan = false;
+    void callback(PointerEvent event) {
+      callbackRan = true;
+    }
+    PointerRouter router = new PointerRouter();
+    router.addRoute(2, (PointerEvent event) {
+      router.removeRoute(2, callback);
+    });
+    router.addRoute(2, callback);
+    TestPointer pointer2 = new TestPointer(2);
+    router.route(pointer2.down(Point.origin));
+    expect(callbackRan, isFalse);
+  });
 }


### PR DESCRIPTION
The pointer router was using an iteration pattern that always delivers
handleEvent calls even if you remove a route during the iteration.
That's awkward to program against and causes trouble for the double-tap
gesture.

This patch switches PointerRouter to using a re-entrant iteration
pattern that supports removing routes (but not adding routes) during the
iteration.
