### PR TITLE
Rename RenderObject.hasLayer to isRepaintBoundary

### DIFF
--- a/packages/flutter/lib/src/rendering/block.dart
+++ b/packages/flutter/lib/src/rendering/block.dart
@@ -256,7 +256,7 @@ class RenderBlockViewport extends RenderBlockBase {
        super(children: children, direction: direction, itemExtent: itemExtent, minExtent: minExtent);
 
   bool _inCallback = false;
-  bool get hasLayer => true;
+  bool get isRepaintBoundary => true;
 
   /// Called during [layout] to determine the block's children.
   ///

--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -1287,7 +1287,7 @@ class RenderPointerListener extends RenderProxyBox {
 /// not, we can re-record its display list without re-recording the display list
 /// for the surround tree.
 class RenderRepaintBoundary extends RenderProxyBox {
-  bool get hasLayer => true;
+  bool get isRepaintBoundary => true;
 }
 
 /// Is invisible during hit testing.

--- a/packages/flutter/lib/src/rendering/view.dart
+++ b/packages/flutter/lib/src/rendering/view.dart
@@ -108,7 +108,7 @@ class RenderView extends RenderObject with RenderObjectWithChildMixin<RenderBox>
     return true;
   }
 
-  bool get hasLayer => true;
+  bool get isRepaintBoundary => true;
 
   void paint(PaintingContext context, Offset offset) {
     if (child != null)


### PR DESCRIPTION
Also, introduce alwaysNeedsCompositing to force the "needs compositing"
bit to true without necessarily introducing a ContainerLayer into the
layer tree. A future patch will make use of alwaysNeedsCompositing to
optimize opacity layers.
