### PR TITLE
Always using OpacityLayer for blending

### DIFF
--- a/packages/flutter/lib/src/rendering/layer.dart
+++ b/packages/flutter/lib/src/rendering/layer.dart
@@ -372,11 +372,7 @@ class TransformLayer extends ContainerLayer {
 
 /// A composited layer that makes its children partially transparent
 class OpacityLayer extends ContainerLayer {
-  OpacityLayer({ Offset offset: Offset.zero, this.bounds, this.alpha }) : super(offset: offset);
-
-  /// Unused
-  Rect bounds;
-  // TODO(abarth): Remove.
+  OpacityLayer({ Offset offset: Offset.zero, this.alpha }) : super(offset: offset);
 
   /// The amount to multiply into the alpha channel
   ///
@@ -386,14 +382,13 @@ class OpacityLayer extends ContainerLayer {
 
   void addToScene(ui.SceneBuilder builder, Offset layerOffset) {
     Offset childOffset = offset + layerOffset;
-    builder.pushOpacity(alpha, bounds?.shift(childOffset));
+    builder.pushOpacity(alpha, null);
     addChildrenToScene(builder, childOffset);
     builder.pop();
   }
 
   void debugDescribeSettings(List<String> settings) {
     super.debugDescribeSettings(settings);
-    settings.add('bounds: $bounds');
     settings.add('alpha: $alpha');
   }
 }


### PR DESCRIPTION
We don't know how to accuately compute paint bounds in the render tree.
Instead, we can rely on the compositor to compute the paint bounds for
us if we use OpacityLayer to do our opacity blends.

Fixes the shadow when closing the menu in the stocks app.
