### PR TITLE
Use a named argument for Widget children

### DIFF
--- a/examples/address_book/lib/main.dart
+++ b/examples/address_book/lib/main.dart
@@ -17,7 +17,8 @@ class Field extends StatelessComponent {
   final String placeholder;
 
   Widget build(BuildContext context) {
-    return new Row(<Widget>[
+    return new Row(
+      children: <Widget>[
         new Padding(
           padding: const EdgeDims.symmetric(horizontal: 16.0),
           child: new Icon(icon: icon)

--- a/examples/fitness/lib/feed.dart
+++ b/examples/fitness/lib/feed.dart
@@ -35,7 +35,7 @@ class DialogMenuItem extends StatelessComponent {
         onTap: onPressed,
         child: new Padding(
           padding: const EdgeDims.symmetric(horizontal: 16.0),
-          child: new Row(children)
+          child: new Row(children: children)
         )
       )
     );
@@ -163,7 +163,7 @@ class FeedFragmentState extends State<FeedFragment> {
       return new Container();
     if (config.userData.items.length == 0) {
       return new Row(
-        <Widget>[new Text("No data yet.\nAdd some!", style: style)],
+        children: <Widget>[new Text("No data yet.\nAdd some!", style: style)],
         justifyContent: FlexJustifyContent.center
       );
     }

--- a/examples/fitness/lib/meal.dart
+++ b/examples/fitness/lib/meal.dart
@@ -35,7 +35,7 @@ class MealRow extends FitnessItemRow {
       )
     ];
     return new Row(
-      children,
+      children: children,
       alignItems: FlexAlignItems.baseline,
       textBaseline: DefaultTextStyle.of(context).textBaseline
     );

--- a/examples/fitness/lib/measurement.dart
+++ b/examples/fitness/lib/measurement.dart
@@ -47,7 +47,7 @@ class MeasurementRow extends FitnessItemRow {
       )
     ];
     return new Row(
-      children,
+      children: children,
       alignItems: FlexAlignItems.baseline,
       textBaseline: DefaultTextStyle.of(context).textBaseline
     );
@@ -124,24 +124,30 @@ class MeasurementFragmentState extends State<MeasurementFragment> {
     // TODO(jackson): Revisit the layout of this pane to be more maintainable
     return new Container(
       padding: const EdgeDims.all(20.0),
-      child: new Column(<Widget>[
-        new GestureDetector(
-          onTap: _handleDatePressed,
-          child: new Container(
-            height: 50.0,
-            child: new Column(<Widget>[
-              new Text('Measurement Date'),
-              new Text(measurement.displayDate, style: Theme.of(context).text.caption),
-            ], alignItems: FlexAlignItems.start)
-          )
-        ),
-        new Input(
-          key: weightKey,
-          placeholder: 'Enter weight',
-          keyboardType: KeyboardType.NUMBER,
-          onChanged: _handleWeightChanged
-        ),
-      ], alignItems: FlexAlignItems.stretch)
+      child: new Column(
+        children: <Widget>[
+          new GestureDetector(
+            onTap: _handleDatePressed,
+            child: new Container(
+              height: 50.0,
+              child: new Column(
+                children: <Widget>[
+                  new Text('Measurement Date'),
+                  new Text(measurement.displayDate, style: Theme.of(context).text.caption),
+                ],
+                alignItems: FlexAlignItems.start
+              )
+            )
+          ),
+          new Input(
+            key: weightKey,
+            placeholder: 'Enter weight',
+            keyboardType: KeyboardType.NUMBER,
+            onChanged: _handleWeightChanged
+          ),
+        ],
+        alignItems: FlexAlignItems.stretch
+      )
     );
   }
 

--- a/examples/fitness/lib/settings.dart
+++ b/examples/fitness/lib/settings.dart
@@ -89,14 +89,17 @@ class SettingsFragmentState extends State<SettingsFragment> {
     return new Block(<Widget>[
         new DrawerItem(
           onPressed: () { _handleBackupChanged(!(config.userData.backupMode == BackupMode.enabled)); },
-          child: new Row(<Widget>[
-            new Flexible(child: new Text('Back up data to the cloud')),
-            new Switch(value: config.userData.backupMode == BackupMode.enabled, onChanged: _handleBackupChanged),
-          ])
+          child: new Row(
+            children: <Widget>[
+              new Flexible(child: new Text('Back up data to the cloud')),
+              new Switch(value: config.userData.backupMode == BackupMode.enabled, onChanged: _handleBackupChanged),
+            ]
+          )
         ),
         new DrawerItem(
           onPressed: () => _handleGoalWeightPressed(),
-          child: new Column(<Widget>[
+          child: new Column(
+            children: <Widget>[
               new Text('Goal Weight'),
               new Text(goalWeightText, style: Theme.of(context).text.caption),
             ],

--- a/examples/material_gallery/lib/demo/date_picker_demo.dart
+++ b/examples/material_gallery/lib/demo/date_picker_demo.dart
@@ -31,13 +31,16 @@ class _DatePickerDemoState extends State<DatePickerDemo> {
   }
 
   Widget build(BuildContext context) {
-    return new Column([
-      new Text(new DateFormat.yMMMd().format(_selectedDate)),
-      new RaisedButton(
-        onPressed: _handleSelectDate,
-        child: new Text('SELECT DATE')
-      ),
-    ], justifyContent: FlexJustifyContent.center);
+    return new Column(
+      children: <Widget>[
+        new Text(new DateFormat.yMMMd().format(_selectedDate)),
+        new RaisedButton(
+          onPressed: _handleSelectDate,
+          child: new Text('SELECT DATE')
+        ),
+      ],
+      justifyContent: FlexJustifyContent.center
+    );
   }
 }
 

--- a/examples/material_gallery/lib/demo/page_selector_demo.dart
+++ b/examples/material_gallery/lib/demo/page_selector_demo.dart
@@ -65,31 +65,35 @@ class TabViewDemo extends StatelessComponent {
       values: _iconNames,
       child: new Builder(
         builder: (BuildContext context) {
-          return new Column([
-            new Container(
-              margin: const EdgeDims.only(top: 16.0),
-              child: new Row(<Widget>[
-                new IconButton(
-                  icon: "navigation/arrow_back",
-                  onPressed: () { _handleArrowButtonPress(context, -1); }
-                ),
-                new Row(
-                  _iconNames.map((String name) => _buildTabIndicator(context, name)).toList(),
-                  justifyContent: FlexJustifyContent.collapse
-                ),
-                new IconButton(
-                  icon: "navigation/arrow_forward",
-                  onPressed: () { _handleArrowButtonPress(context, 1); }
-                )],
-                justifyContent: FlexJustifyContent.spaceBetween
+          return new Column(
+            children: <Widget>[
+              new Container(
+                margin: const EdgeDims.only(top: 16.0),
+                child: new Row(
+                  children: <Widget>[
+                    new IconButton(
+                      icon: "navigation/arrow_back",
+                      onPressed: () { _handleArrowButtonPress(context, -1); }
+                    ),
+                    new Row(
+                      children: _iconNames.map((String name) => _buildTabIndicator(context, name)).toList(),
+                      justifyContent: FlexJustifyContent.collapse
+                    ),
+                    new IconButton(
+                      icon: "navigation/arrow_forward",
+                      onPressed: () { _handleArrowButtonPress(context, 1); }
+                    )
+                  ],
+                  justifyContent: FlexJustifyContent.spaceBetween
+                )
+              ),
+              new Flexible(
+                child: new TabBarView(
+                  children: _iconNames.map(_buildTabView).toList()
+                )
               )
-            ),
-            new Flexible(
-              child: new TabBarView(
-                children: _iconNames.map(_buildTabView).toList()
-              )
-            )
-          ]);
+            ]
+          );
         }
       )
     );

--- a/examples/material_gallery/lib/demo/selection_controls_demo.dart
+++ b/examples/material_gallery/lib/demo/selection_controls_demo.dart
@@ -34,28 +34,43 @@ class _SelectionControlsDemoState extends State<SelectionControlsDemo> {
   }
 
   Widget build(BuildContext context) {
-    return new Column(<Widget>[
-      new Row(<Widget>[
-        new Checkbox(value: _checkboxValue, onChanged: _setCheckboxValue),
-        new Checkbox(value: false), // Disabled
-        new Checkbox(value: true), // Disabled
-      ], justifyContent: FlexJustifyContent.spaceAround),
-      new Row(<int>[0, 1, 2].map((int i) {
-        return new Radio<int>(
-          value: i,
-          groupValue: _radioValue,
-          onChanged: _setRadioValue
-        );
-      }).toList(), justifyContent: FlexJustifyContent.spaceAround),
-      new Row(<int>[0, 1].map((int i) {
-        return new Radio<int>(value: i, groupValue: 0); // Disabled
-      }).toList(), justifyContent: FlexJustifyContent.spaceAround),
-      new Row(<Widget>[
-        new Switch(value: _switchValue, onChanged: _setSwitchValue),
-        new Switch(value: false), // Disabled
-        new Switch(value: true), // Disabled
-      ], justifyContent: FlexJustifyContent.spaceAround),
-    ], justifyContent: FlexJustifyContent.spaceAround);
+    return new Column(
+      children: <Widget>[
+        new Row(
+          children: <Widget>[
+            new Checkbox(value: _checkboxValue, onChanged: _setCheckboxValue),
+            new Checkbox(value: false), // Disabled
+            new Checkbox(value: true), // Disabled
+          ],
+          justifyContent: FlexJustifyContent.spaceAround
+        ),
+        new Row(
+          children: <int>[0, 1, 2].map((int i) {
+            return new Radio<int>(
+              value: i,
+              groupValue: _radioValue,
+              onChanged: _setRadioValue
+            );
+          }).toList(),
+          justifyContent: FlexJustifyContent.spaceAround
+        ),
+        new Row(
+          children: <int>[0, 1].map((int i) {
+            return new Radio<int>(value: i, groupValue: 0); // Disabled
+          }).toList(),
+          justifyContent: FlexJustifyContent.spaceAround
+        ),
+        new Row(
+          children: <Widget>[
+            new Switch(value: _switchValue, onChanged: _setSwitchValue),
+            new Switch(value: false), // Disabled
+            new Switch(value: true), // Disabled
+          ],
+          justifyContent: FlexJustifyContent.spaceAround
+        ),
+      ],
+      justifyContent: FlexJustifyContent.spaceAround
+    );
   }
 }
 

--- a/examples/material_gallery/lib/demo/slider_demo.dart
+++ b/examples/material_gallery/lib/demo/slider_demo.dart
@@ -18,35 +18,41 @@ class _SliderDemoState extends State<SliderDemo> {
       new Container(
         height: 100.0,
         child: new Center(
-          child:  new Row([
-            new Slider(
-              value: _value,
-              min: 0.0,
-              max: 100.0,
-              onChanged: (double value) {
-                setState(() {
-                  _value = value;
-                });
-              }
-            ),
-            new Container(
-              padding: const EdgeDims.symmetric(horizontal: 16.0),
-              child: new Text(_value.round().toString().padLeft(3, '0'))
-            ),
-          ], justifyContent: FlexJustifyContent.collapse)
+          child:  new Row(
+            children: <Widget>[
+              new Slider(
+                value: _value,
+                min: 0.0,
+                max: 100.0,
+                onChanged: (double value) {
+                  setState(() {
+                    _value = value;
+                  });
+                }
+              ),
+              new Container(
+                padding: const EdgeDims.symmetric(horizontal: 16.0),
+                child: new Text(_value.round().toString().padLeft(3, '0'))
+              ),
+            ],
+            justifyContent: FlexJustifyContent.collapse
+          )
         )
       ),
       new Container(
         height: 100.0,
         child: new Center(
-          child:  new Row([
-            // Disabled, but tracking the slider above.
-            new Slider(value: _value / 100.0),
-            new Container(
-              padding: const EdgeDims.symmetric(horizontal: 16.0),
-              child: new Text((_value / 100.0).toStringAsFixed(2))
-            ),
-          ], justifyContent: FlexJustifyContent.collapse)
+          child:  new Row(
+            children: <Widget>[
+              // Disabled, but tracking the slider above.
+              new Slider(value: _value / 100.0),
+              new Container(
+                padding: const EdgeDims.symmetric(horizontal: 16.0),
+                child: new Text((_value / 100.0).toStringAsFixed(2))
+              ),
+            ],
+            justifyContent: FlexJustifyContent.collapse
+          )
         )
       )
 

--- a/examples/material_gallery/lib/demo/time_picker_demo.dart
+++ b/examples/material_gallery/lib/demo/time_picker_demo.dart
@@ -28,13 +28,16 @@ class _TimePickerDemoState extends State<TimePickerDemo> {
   }
 
   Widget build(BuildContext context) {
-    return new Column([
-      new Text('$_selectedTime'),
-      new RaisedButton(
-        onPressed: _handleSelectTime,
-        child: new Text('SELECT TIME')
-      ),
-    ], justifyContent: FlexJustifyContent.center);
+    return new Column(
+      children: <Widget>[
+        new Text('$_selectedTime'),
+        new RaisedButton(
+          onPressed: _handleSelectTime,
+          child: new Text('SELECT TIME')
+        ),
+      ],
+      justifyContent: FlexJustifyContent.center
+    );
   }
 }
 

--- a/examples/material_gallery/lib/gallery_page.dart
+++ b/examples/material_gallery/lib/gallery_page.dart
@@ -33,17 +33,19 @@ class _GalleryPageState extends State<GalleryPage> {
 
     // TODO(eseidel): We should make this into a shared DrawerFooter.
     items.add(new DrawerDivider());
-    items.add(new DrawerItem(child: new Flex([
-      new Text("Made with Flutter "),
-      new Container(
-        margin: const EdgeDims.symmetric(horizontal: 5.0),
-        child: new AssetImage(
-            name: 'assets/flutter_logo.png',
-            height: 16.0,
-            fit: ImageFit.contain
+    items.add(new DrawerItem(child: new Flex(
+      children: <Widget>[
+        new Text("Made with Flutter "),
+        new Container(
+          margin: const EdgeDims.symmetric(horizontal: 5.0),
+          child: new AssetImage(
+              name: 'assets/flutter_logo.png',
+              height: 16.0,
+              fit: ImageFit.contain
+          )
         )
-      )
-    ])));
+      ]
+    )));
 
     return new Drawer(child: new Block(items));
   }

--- a/examples/mine_digger/lib/main.dart
+++ b/examples/mine_digger/lib/main.dart
@@ -139,7 +139,7 @@ class MineDiggerState extends State<MineDigger> {
       }
       flexRows.add(
         new Row(
-          row,
+          children: row,
           justifyContent: FlexJustifyContent.center,
           key: new ValueKey<int>(iy)
         )
@@ -157,7 +157,7 @@ class MineDiggerState extends State<MineDigger> {
       padding: new EdgeDims.all(10.0),
       margin: new EdgeDims.all(10.0),
       decoration: new BoxDecoration(backgroundColor: const Color(0xFF6B6B6B)),
-      child: new Column(flexRows)
+      child: new Column(children: flexRows)
     );
   }
 

--- a/examples/stocks/lib/stock_home.dart
+++ b/examples/stocks/lib/stock_home.dart
@@ -114,18 +114,22 @@ class StockHomeState extends State<StockHome> {
         new DrawerItem(
           icon: 'action/thumb_up',
           onPressed: () => _handleStockModeChange(StockMode.optimistic),
-          child: new Row(<Widget>[
-            new Flexible(child: new Text('Optimistic')),
-            new Radio<StockMode>(value: StockMode.optimistic, groupValue: config.configuration.stockMode, onChanged: _handleStockModeChange)
-          ])
+          child: new Row(
+            children: <Widget>[
+              new Flexible(child: new Text('Optimistic')),
+              new Radio<StockMode>(value: StockMode.optimistic, groupValue: config.configuration.stockMode, onChanged: _handleStockModeChange)
+            ]
+          )
         ),
         new DrawerItem(
           icon: 'action/thumb_down',
           onPressed: () => _handleStockModeChange(StockMode.pessimistic),
-          child: new Row(<Widget>[
-            new Flexible(child: new Text('Pessimistic')),
-            new Radio<StockMode>(value: StockMode.pessimistic, groupValue: config.configuration.stockMode, onChanged: _handleStockModeChange)
-          ])
+          child: new Row(
+            children: <Widget>[
+              new Flexible(child: new Text('Pessimistic')),
+              new Radio<StockMode>(value: StockMode.pessimistic, groupValue: config.configuration.stockMode, onChanged: _handleStockModeChange)
+            ]
+          )
         ),
         new DrawerDivider(),
         new DrawerItem(
@@ -241,12 +245,14 @@ class StockHomeState extends State<StockHome> {
       // TODO(ianh): Fill this out.
       context: context,
       builder: (BuildContext context) {
-        return new Column([
-          new Input(
-            key: companyNameKey,
-            placeholder: 'Company Name'
-          ),
-        ]);
+        return new Column(
+          children: <Widget>[
+            new Input(
+              key: companyNameKey,
+              placeholder: 'Company Name'
+            ),
+          ]
+        );
       }
     );
   }

--- a/examples/stocks/lib/stock_menu.dart
+++ b/examples/stocks/lib/stock_menu.dart
@@ -19,7 +19,8 @@ Future showStockMenu({BuildContext context, bool autorefresh, ValueChanged<bool>
     items: <PopupMenuItem>[
       new PopupMenuItem(
         value: _MenuItems.autorefresh,
-        child: new Row(<Widget>[
+        child: new Row(
+          children: <Widget>[
             new Flexible(child: new Text('Autorefresh')),
             new StatefulBuilder(
               builder: (BuildContext context, StateSetter setState) {
@@ -75,16 +76,18 @@ Future showStockMenu({BuildContext context, bool autorefresh, ValueChanged<bool>
           content: new Text('This feature has not yet been implemented.'),
           actions: <Widget>[
             new FlatButton(
-              child: new Row(<Widget>[
-                new Icon(
-                  icon: 'device/dvr',
-                  size: IconSize.s18
-                ),
-                new Container(
-                  width: 8.0
-                ),
-                new Text('DUMP APP TO CONSOLE'),
-              ]),
+              child: new Row(
+                children: <Widget>[
+                  new Icon(
+                    icon: 'device/dvr',
+                    size: IconSize.s18
+                  ),
+                  new Container(
+                    width: 8.0
+                  ),
+                  new Text('DUMP APP TO CONSOLE'),
+                ]
+              ),
               onPressed: () { debugDumpApp(); }
             ),
             new FlatButton(

--- a/examples/stocks/lib/stock_row.dart
+++ b/examples/stocks/lib/stock_row.dart
@@ -67,7 +67,8 @@ class StockRow extends StatelessComponent {
             bottom: new BorderSide(color: Theme.of(context).dividerColor)
           )
         ),
-        child: new Row(<Widget>[
+        child: new Row(
+          children: <Widget>[
             new Container(
               margin: const EdgeDims.only(right: 5.0),
               child: new Hero(
@@ -77,7 +78,8 @@ class StockRow extends StatelessComponent {
               )
             ),
             new Flexible(
-              child: new Row(<Widget>[
+              child: new Row(
+                children: <Widget>[
                   new Flexible(
                     flex: 2,
                     child: new Text(

--- a/examples/stocks/lib/stock_settings.dart
+++ b/examples/stocks/lib/stock_settings.dart
@@ -82,35 +82,41 @@ class StockSettingsState extends State<StockSettings> {
       new DrawerItem(
         icon: 'action/thumb_up',
         onPressed: () => _confirmOptimismChange(),
-        child: new Row(<Widget>[
-          new Flexible(child: new Text('Everything is awesome')),
-          new Checkbox(
-            value: config.configuration.stockMode == StockMode.optimistic,
-            onChanged: (bool value) => _confirmOptimismChange()
-          ),
-        ])
+        child: new Row(
+          children: <Widget>[
+            new Flexible(child: new Text('Everything is awesome')),
+            new Checkbox(
+              value: config.configuration.stockMode == StockMode.optimistic,
+              onChanged: (bool value) => _confirmOptimismChange()
+            ),
+          ]
+        )
       ),
       new DrawerItem(
         icon: 'action/backup',
         onPressed: () { _handleBackupChanged(!(config.configuration.backupMode == BackupMode.enabled)); },
-        child: new Row(<Widget>[
-          new Flexible(child: new Text('Back up stock list to the cloud')),
-          new Switch(
-            value: config.configuration.backupMode == BackupMode.enabled,
-            onChanged: _handleBackupChanged
-          ),
-        ])
+        child: new Row(
+          children: <Widget>[
+            new Flexible(child: new Text('Back up stock list to the cloud')),
+            new Switch(
+              value: config.configuration.backupMode == BackupMode.enabled,
+              onChanged: _handleBackupChanged
+            ),
+          ]
+        )
       ),
       new DrawerItem(
         icon: 'action/picture_in_picture',
         onPressed: () { _handleShowPerformanceOverlayChanged(!config.configuration.showPerformanceOverlay); },
-        child: new Row(<Widget>[
-          new Flexible(child: new Text('Show rendering performance overlay')),
-          new Switch(
-            value: config.configuration.showPerformanceOverlay,
-            onChanged: _handleShowPerformanceOverlayChanged
-          ),
-        ])
+        child: new Row(
+          children: <Widget>[
+            new Flexible(child: new Text('Show rendering performance overlay')),
+            new Switch(
+              value: config.configuration.showPerformanceOverlay,
+              onChanged: _handleShowPerformanceOverlayChanged
+            ),
+          ]
+        )
       ),
     ];
     assert(() {
@@ -119,24 +125,28 @@ class StockSettingsState extends State<StockSettings> {
         new DrawerItem(
           icon: 'editor/border_clear',
           onPressed: () { _handleShowGridChanged(!config.configuration.debugShowGrid); },
-          child: new Row(<Widget>[
-            new Flexible(child: new Text('Show material grid (for debugging)')),
-            new Switch(
-              value: config.configuration.debugShowGrid,
-              onChanged: _handleShowGridChanged
-            ),
-          ])
+          child: new Row(
+            children: <Widget>[
+              new Flexible(child: new Text('Show material grid (for debugging)')),
+              new Switch(
+                value: config.configuration.debugShowGrid,
+                onChanged: _handleShowGridChanged
+              ),
+            ]
+          )
         ),
         new DrawerItem(
           icon: 'editor/border_all',
           onPressed: () { _handleShowSizesChanged(!config.configuration.debugShowSizes); },
-          child: new Row(<Widget>[
-            new Flexible(child: new Text('Show construction lines (for debugging)')),
-            new Switch(
-              value: config.configuration.debugShowSizes,
-              onChanged: _handleShowSizesChanged
-            ),
-          ])
+          child: new Row(
+            children: <Widget>[
+              new Flexible(child: new Text('Show construction lines (for debugging)')),
+              new Switch(
+                value: config.configuration.debugShowSizes,
+                onChanged: _handleShowSizesChanged
+              ),
+            ]
+          )
         )
       ]);
       return true;

--- a/examples/stocks/lib/stock_symbol_viewer.dart
+++ b/examples/stocks/lib/stock_symbol_viewer.dart
@@ -18,8 +18,10 @@ class StockSymbolView extends StatelessComponent {
     TextStyle headings = Theme.of(context).text.body2;
     return new Container(
       padding: new EdgeDims.all(20.0),
-      child: new Column(<Widget>[
-          new Row(<Widget>[
+      child: new Column(
+        children: <Widget>[
+          new Row(
+            children: <Widget>[
               new Text(
                 '${stock.symbol}',
                 style: Theme.of(context).text.display2

--- a/examples/widgets/card_collection.dart
+++ b/examples/widgets/card_collection.dart
@@ -209,13 +209,15 @@ class CardCollectionState extends State<CardCollection> {
   Widget buildDrawerCheckbox(String label, bool value, void callback(), { bool enabled: true }) {
     return new DrawerItem(
       onPressed: enabled ? callback : null,
-      child: new Row(<Widget>[
-        new Flexible(child: new Text(label)),
-        new Checkbox(
-          value: value,
-          onChanged: enabled ? (_) { callback(); } : null
-        )
-      ])
+      child: new Row(
+        children: <Widget>[
+          new Flexible(child: new Text(label)),
+          new Checkbox(
+            value: value,
+            onChanged: enabled ? (_) { callback(); } : null
+          )
+        ]
+      )
     );
   }
 
@@ -223,14 +225,16 @@ class CardCollectionState extends State<CardCollection> {
     return new DrawerItem(
       icon: icon,
       onPressed: enabled ? () { onChanged(itemValue); } : null,
-      child: new Row(<Widget>[
-        new Flexible(child: new Text(label)),
-        new Radio<Map<int, Color>>(
-          value: itemValue,
-          groupValue: currentValue,
-          onChanged: enabled ? onChanged : null
-        )
-      ])
+      child: new Row(
+        children: <Widget>[
+          new Flexible(child: new Text(label)),
+          new Radio<Map<int, Color>>(
+            value: itemValue,
+            groupValue: currentValue,
+            onChanged: enabled ? onChanged : null
+          )
+        ]
+      )
     );
   }
 
@@ -238,14 +242,16 @@ class CardCollectionState extends State<CardCollection> {
     return new DrawerItem(
       icon: icon,
       onPressed: enabled ? () { onChanged(itemValue); } : null,
-      child: new Row(<Widget>[
-        new Flexible(child: new Text(label)),
-        new Radio<DismissDirection>(
-          value: itemValue,
-          groupValue: currentValue,
-          onChanged: enabled ? onChanged : null
-        )
-      ])
+      child: new Row(
+        children: <Widget>[
+          new Flexible(child: new Text(label)),
+          new Radio<DismissDirection>(
+            value: itemValue,
+            groupValue: currentValue,
+            onChanged: enabled ? onChanged : null
+          )
+        ]
+      )
     );
   }
 
@@ -253,14 +259,16 @@ class CardCollectionState extends State<CardCollection> {
     return new DrawerItem(
       icon: icon,
       onPressed: enabled ? () { onChanged(itemValue); } : null,
-      child: new Row(<Widget>[
-        new Flexible(child: new Text(label)),
-        new Radio<TextStyle>(
-          value: itemValue,
-          groupValue: currentValue,
-          onChanged: enabled ? onChanged : null
-        )
-      ])
+      child: new Row(
+        children: <Widget>[
+          new Flexible(child: new Text(label)),
+          new Radio<TextStyle>(
+            value: itemValue,
+            groupValue: currentValue,
+            onChanged: enabled ? onChanged : null
+          )
+        ]
+      )
     );
   }
 
@@ -307,7 +315,8 @@ class CardCollectionState extends State<CardCollection> {
               style: DefaultTextStyle.of(context).merge(cardLabelStyle).merge(_textStyle).copyWith(
                 fontSize: _varyFontSizes ? _cardModels.length.toDouble() : null
               ),
-              child: new Column(<Widget>[
+              child: new Column(
+                children: <Widget>[
                   new Text(cardModel.label)
                 ],
                 alignItems: FlexAlignItems.stretch,
@@ -357,11 +366,13 @@ class CardCollectionState extends State<CardCollection> {
           child: new Container(
             height: cardModel.height,
             decoration: new BoxDecoration(backgroundColor: Theme.of(context).primaryColor),
-            child: new Row(<Widget>[
-              leftArrowIcon,
-              new Flexible(child: new Text(backgroundMessage, style: backgroundTextStyle)),
-              rightArrowIcon
-            ])
+            child: new Row(
+              children: <Widget>[
+                leftArrowIcon,
+                new Flexible(child: new Text(backgroundMessage, style: backgroundTextStyle)),
+                rightArrowIcon
+              ]
+            )
           )
         )
       )
@@ -370,7 +381,7 @@ class CardCollectionState extends State<CardCollection> {
     return new IconTheme(
       key: cardModel.key,
       data: const IconThemeData(color: IconThemeColor.white),
-      child: new Stack(<Widget>[background, card])
+      child: new Stack(children: <Widget>[background, card])
     );
   }
 
@@ -409,11 +420,14 @@ class CardCollectionState extends State<CardCollection> {
       );
     }
 
-    if (_sunshine)
-      cardCollection = new Stack(<Widget>[
-        new Column(<Widget>[new NetworkImage(src: _sunshineURL)]),
-        new ShaderMask(child: cardCollection, shaderCallback: _createShader)
-      ]);
+    if (_sunshine) {
+      cardCollection = new Stack(
+        children: <Widget>[
+          new Column(children: <Widget>[new NetworkImage(src: _sunshineURL)]),
+          new ShaderMask(child: cardCollection, shaderCallback: _createShader)
+        ]
+      );
+    }
 
     Widget body = new SizeObserver(
       onSizeChanged: _updateCardCollectionSize,
@@ -434,7 +448,7 @@ class CardCollectionState extends State<CardCollection> {
           )
         )
       );
-      body = new Stack(<Widget>[body, indicator]);
+      body = new Stack(children: <Widget>[body, indicator]);
     }
 
     return new Theme(

--- a/examples/widgets/container.dart
+++ b/examples/widgets/container.dart
@@ -6,7 +6,8 @@ import 'package:flutter/material.dart';
 
 class ContainerApp extends StatelessComponent {
   Widget build(BuildContext context) {
-    return new Column(<Widget>[
+    return new Column(
+      children: <Widget>[
         new Container(
           padding: new EdgeDims.all(10.0),
           margin: new EdgeDims.all(10.0),
@@ -20,15 +21,17 @@ class ContainerApp extends StatelessComponent {
         new Container(
           decoration: new BoxDecoration(backgroundColor: const Color(0xFFFFFF00)),
           padding: new EdgeDims.symmetric(horizontal: 50.0, vertical: 75.0),
-          child: new Row(<Widget>[
-            new RaisedButton(
-              child: new Text('PRESS ME'),
-              onPressed: () => print("Hello World")
-            ),
-            new RaisedButton(
-              child: new Text('DISABLED')
-            )
-          ])
+          child: new Row(
+            children: <Widget>[
+              new RaisedButton(
+                child: new Text('PRESS ME'),
+                onPressed: () => print("Hello World")
+              ),
+              new RaisedButton(
+                child: new Text('DISABLED')
+              )
+            ]
+          )
         ),
         new Flexible(
           child: new Container(

--- a/examples/widgets/drag_and_drop.dart
+++ b/examples/widgets/drag_and_drop.dart
@@ -135,37 +135,44 @@ class DragAndDropApp extends StatelessComponent {
       toolBar: new ToolBar(
         center: new Text('Drag and Drop Flutter Demo')
       ),
-      body: new Column(<Widget>[
-        new Flexible(child: new Row(<Widget>[
-            new ExampleDragSource(
-              color: const Color(0xFFFFF000),
-              under: true,
-              heavy: false,
-              child: new Text('under')
-            ),
-            new ExampleDragSource(
-              color: const Color(0xFF0FFF00),
-              under: false,
-              heavy: true,
-              child: new Text('long-press above')
-            ),
-            new ExampleDragSource(
-              color: const Color(0xFF00FFF0),
-              under: false,
-              heavy: false,
-              child: new Text('above')
-            ),
-          ],
-          alignItems: FlexAlignItems.center,
-          justifyContent: FlexJustifyContent.spaceAround
-        )),
-        new Flexible(child: new Row(<Widget>[
-          new Flexible(child: new ExampleDragTarget()),
-          new Flexible(child: new ExampleDragTarget()),
-          new Flexible(child: new ExampleDragTarget()),
-          new Flexible(child: new ExampleDragTarget()),
-        ])),
-      ])
+      body: new Column(
+        children: <Widget>[
+          new Flexible(child: new Row(
+            children: <Widget>[
+              new ExampleDragSource(
+                color: const Color(0xFFFFF000),
+                under: true,
+                heavy: false,
+                child: new Text('under')
+              ),
+              new ExampleDragSource(
+                color: const Color(0xFF0FFF00),
+                under: false,
+                heavy: true,
+                child: new Text('long-press above')
+              ),
+              new ExampleDragSource(
+                color: const Color(0xFF00FFF0),
+                under: false,
+                heavy: false,
+                child: new Text('above')
+              ),
+            ],
+            alignItems: FlexAlignItems.center,
+            justifyContent: FlexJustifyContent.spaceAround
+          )),
+          new Flexible(
+            child: new Row(
+              children: <Widget>[
+                new Flexible(child: new ExampleDragTarget()),
+                new Flexible(child: new ExampleDragTarget()),
+                new Flexible(child: new ExampleDragTarget()),
+                new Flexible(child: new ExampleDragTarget()),
+              ]
+            )
+          ),
+        ]
+      )
     );
   }
 }

--- a/examples/widgets/gestures.dart
+++ b/examples/widgets/gestures.dart
@@ -138,68 +138,79 @@ class ScaleAppState extends State<ScaleApp> {
       child: new Scaffold(
         toolBar: new ToolBar(
             center: new Text('Gestures Demo')),
-        body: new Stack([
-          new GestureDetector(
-            onScaleStart: _scaleEnabled ? _handleScaleStart : null,
-            onScaleUpdate: _scaleEnabled ? _handleScaleUpdate : null,
-            onTap: _tapEnabled ? _handleColorChange : null,
-            onDoubleTap: _doubleTapEnabled ? _handleScaleReset : null,
-            onLongPress: _longPressEnabled ? _handleDirectionChange : null,
-            child: new CustomPaint(
-              painter: new _GesturePainter(
-                zoom: _zoom,
-                offset: _offset,
-                swatch: _swatch,
-                forward: _forward,
-                scaleEnabled: _scaleEnabled,
-                tapEnabled: _tapEnabled,
-                doubleTapEnabled: _doubleTapEnabled,
-                longPressEnabled: _longPressEnabled
-              )
-            )
-          ),
-          new Positioned(
-            bottom: 0.0,
-            left: 0.0,
-            child: new Card(
-              child: new Container(
-                padding: new EdgeDims.all(4.0),
-                child: new Column([
-                    new Row([
-                      new Checkbox(
-                        value: _scaleEnabled,
-                        onChanged: (bool value) { setState(() { _scaleEnabled = value; }); }
-                      ),
-                      new Text('Scale'),
-                    ]),
-                    new Row([
-                      new Checkbox(
-                        value: _tapEnabled,
-                        onChanged: (bool value) { setState(() { _tapEnabled = value; }); }
-                      ),
-                      new Text('Tap'),
-                    ]),
-                    new Row([
-                      new Checkbox(
-                        value: _doubleTapEnabled,
-                        onChanged: (bool value) { setState(() { _doubleTapEnabled = value; }); }
-                      ),
-                      new Text('Double Tap'),
-                    ]),
-                    new Row([
-                      new Checkbox(
-                        value: _longPressEnabled,
-                        onChanged: (bool value) { setState(() { _longPressEnabled = value; }); }
-                      ),
-                      new Text('Long Press'),
-                    ]),
-                  ],
-                  alignItems: FlexAlignItems.start
+        body: new Stack(
+          children: <Widget>[
+            new GestureDetector(
+              onScaleStart: _scaleEnabled ? _handleScaleStart : null,
+              onScaleUpdate: _scaleEnabled ? _handleScaleUpdate : null,
+              onTap: _tapEnabled ? _handleColorChange : null,
+              onDoubleTap: _doubleTapEnabled ? _handleScaleReset : null,
+              onLongPress: _longPressEnabled ? _handleDirectionChange : null,
+              child: new CustomPaint(
+                painter: new _GesturePainter(
+                  zoom: _zoom,
+                  offset: _offset,
+                  swatch: _swatch,
+                  forward: _forward,
+                  scaleEnabled: _scaleEnabled,
+                  tapEnabled: _tapEnabled,
+                  doubleTapEnabled: _doubleTapEnabled,
+                  longPressEnabled: _longPressEnabled
                 )
               )
-            )
-          ),
-        ])
+            ),
+            new Positioned(
+              bottom: 0.0,
+              left: 0.0,
+              child: new Card(
+                child: new Container(
+                  padding: new EdgeDims.all(4.0),
+                  child: new Column(
+                    children: <Widget>[
+                      new Row(
+                        children: <Widget>[
+                          new Checkbox(
+                            value: _scaleEnabled,
+                            onChanged: (bool value) { setState(() { _scaleEnabled = value; }); }
+                          ),
+                          new Text('Scale'),
+                        ]
+                      ),
+                      new Row(
+                        children: <Widget>[
+                          new Checkbox(
+                            value: _tapEnabled,
+                            onChanged: (bool value) { setState(() { _tapEnabled = value; }); }
+                          ),
+                          new Text('Tap'),
+                        ]
+                      ),
+                      new Row(
+                        children: <Widget>[
+                          new Checkbox(
+                            value: _doubleTapEnabled,
+                            onChanged: (bool value) { setState(() { _doubleTapEnabled = value; }); }
+                          ),
+                          new Text('Double Tap'),
+                        ]
+                      ),
+                      new Row(
+                        children: <Widget>[
+                          new Checkbox(
+                            value: _longPressEnabled,
+                            onChanged: (bool value) { setState(() { _longPressEnabled = value; }); }
+                          ),
+                          new Text('Long Press'),
+                        ]
+                      ),
+                    ],
+                    alignItems: FlexAlignItems.start
+                  )
+                )
+              )
+            ),
+          ]
+        )
       )
     );
   }

--- a/examples/widgets/hero_under.dart
+++ b/examples/widgets/hero_under.dart
@@ -59,20 +59,22 @@ class HeroDemo extends StatelessComponent {
         child: new GestureDetector(
           onTap: () => Navigator.push(context, new CrabRoute()),
           child: new Card(
-            child: new Row(<Widget>[
-              new HeroImage(
-                size: const Size(100.0, 100.0)
-              ),
-              new Flexible(
-                child: new Container(
-                  padding: const EdgeDims.all(10.0),
-                  child: new Text(
-                    "Low Crab Diet",
-                    style: Theme.of(context).text.title
+            child: new Row(
+              children: <Widget>[
+                new HeroImage(
+                  size: const Size(100.0, 100.0)
+                ),
+                new Flexible(
+                  child: new Container(
+                    padding: const EdgeDims.all(10.0),
+                    child: new Text(
+                      "Low Crab Diet",
+                      style: Theme.of(context).text.title
+                    )
                   )
                 )
-              )
-            ])
+              ]
+            )
           )
         )
       )
@@ -94,34 +96,39 @@ class CrabPage extends StatelessComponent {
       color: const Color(0x00000000),
       child: new Block(
         <Widget>[
-          new Stack(<Widget>[
-            new HeroImage(
-              size: new Size(ui.window.size.width, ui.window.size.width)
-            ),
-            new ToolBar(
-              padding: new EdgeDims.only(top: ui.window.padding.top),
-              backgroundColor: const Color(0x00000000),
-              left: new IconButton(
-                icon: "navigation/arrow_back",
-                onPressed: () => Navigator.pop(context)
+          new Stack(
+            children: <Widget>[
+              new HeroImage(
+                size: new Size(ui.window.size.width, ui.window.size.width)
               ),
-              right: <Widget>[
-                  new IconButton(icon: "navigation/more_vert")
-              ]
-            ),
-            new Positioned(
-              bottom: 10.0,
-              left: 10.0,
-              child: new Text("Low Crab Diet", style: titleStyle)
-            )
-          ]),
+              new ToolBar(
+                padding: new EdgeDims.only(top: ui.window.padding.top),
+                backgroundColor: const Color(0x00000000),
+                left: new IconButton(
+                  icon: "navigation/arrow_back",
+                  onPressed: () => Navigator.pop(context)
+                ),
+                right: <Widget>[
+                    new IconButton(icon: "navigation/more_vert")
+                ]
+              ),
+              new Positioned(
+                bottom: 10.0,
+                left: 10.0,
+                child: new Text("Low Crab Diet", style: titleStyle)
+              )
+            ]
+          ),
           new Material(
             child: new Container(
               padding: const EdgeDims.all(10.0),
-              child: new Column(<Widget>[
-                new Text(kText, style: Theme.of(context).text.body1),
-                new Container(height: 800.0),
-              ], alignItems: FlexAlignItems.start)
+              child: new Column(
+                children: <Widget>[
+                  new Text(kText, style: Theme.of(context).text.body1),
+                  new Container(height: 800.0),
+                ],
+                alignItems: FlexAlignItems.start
+              )
             )
           )
         ]

--- a/examples/widgets/indexed_stack.dart
+++ b/examples/widgets/indexed_stack.dart
@@ -30,7 +30,7 @@ class IndexedStackDemoState extends State<IndexedStackDemo> {
 
   Widget build(BuildContext context) {
     List<PopupMenuItem> items = _buildMenu();
-    IndexedStack indexedStack = new IndexedStack(items, index: _itemIndex, alignment: const FractionalOffset(0.5, 0.0));
+    IndexedStack indexedStack = new IndexedStack(children: items, index: _itemIndex, alignment: const FractionalOffset(0.5, 0.0));
 
     return new Scaffold(
       toolBar: new ToolBar(center: new Text('IndexedStackDemo Demo')),

--- a/examples/widgets/media_query.dart
+++ b/examples/widgets/media_query.dart
@@ -17,7 +17,7 @@ class AdaptiveItem {
 
   Widget toListItem() {
     return new Row(
-      <Widget>[
+      children: <Widget>[
         new Container(
           width: 32.0,
           height: 32.0,
@@ -34,7 +34,7 @@ class AdaptiveItem {
   Widget toCard() {
     return new Card(
       child: new Column(
-        <Widget>[
+        children: <Widget>[
           new Flexible(
             child: new Container(
               decoration: new BoxDecoration(
@@ -45,7 +45,7 @@ class AdaptiveItem {
           new Container(
             margin: const EdgeDims.only(left: 8.0),
             child: new Row(
-              <Widget>[
+              children: <Widget>[
                 new Flexible(
                   child: new Text(name)
                 ),

--- a/examples/widgets/overlay_geometry.dart
+++ b/examples/widgets/overlay_geometry.dart
@@ -169,7 +169,7 @@ class OverlayGeometryAppState extends State<OverlayGeometryApp> {
     ];
     for (MarkerType type in markers.keys)
       layers.add(new Marker(type: type, position: markers[type]));
-    return new Stack(layers);
+    return new Stack(children: layers);
   }
 }
 

--- a/examples/widgets/pageable_list.dart
+++ b/examples/widgets/pageable_list.dart
@@ -95,10 +95,12 @@ class PageableListAppState extends State<PageableListApp> {
         ),
         new DrawerItem(
           onPressed: toggleItemsWrap,
-          child: new Row(<Widget>[
-            new Flexible(child: new Text('Scrolling wraps around')),
-            new Checkbox(value: itemsWrap)
-          ])
+          child: new Row(
+            children: <Widget>[
+              new Flexible(child: new Text('Scrolling wraps around')),
+              new Checkbox(value: itemsWrap)
+            ]
+          )
         )
       ])
     );

--- a/examples/widgets/piano.dart
+++ b/examples/widgets/piano.dart
@@ -88,7 +88,7 @@ class PianoApp extends StatelessComponent {
         )
       ));
     }
-    return new Column(children);
+    return new Column(children: children);
   }
 }
 

--- a/examples/widgets/progress_indicator.dart
+++ b/examples/widgets/progress_indicator.dart
@@ -70,7 +70,7 @@ class ProgressIndicatorAppState extends State<ProgressIndicatorApp> {
         new Text("${(valueAnimation.value * 100.0).toStringAsFixed(1)}%" + (valueAnimation.isAnimating ? '' : ' (paused)'))
     ];
     return new Column(
-      indicators
+      children: indicators
         .map((Widget c) => new Container(child: c, margin: const EdgeDims.symmetric(vertical: 15.0, horizontal: 20.0)))
         .toList(),
       justifyContent: FlexJustifyContent.center

--- a/examples/widgets/raw_keyboard.dart
+++ b/examples/widgets/raw_keyboard.dart
@@ -53,7 +53,8 @@ class HardwareKeyDemoState extends State<HardwareKeyDemo> implements mojo.RawKey
         child: new Text("Press a key", style: Typography.black.display1)
       );
     }
-    return new Column([
+    return new Column(
+      children: <Widget>[
         new Text(
           '${_event.type}',
           style: Typography.black.body2
@@ -62,7 +63,9 @@ class HardwareKeyDemoState extends State<HardwareKeyDemo> implements mojo.RawKey
           '${_event.keyData.keyCode}',
           style: Typography.black.display4
         )
-    ], justifyContent: FlexJustifyContent.center);
+      ],
+      justifyContent: FlexJustifyContent.center
+    );
   }
 
   Widget build(BuildContext context)  {

--- a/examples/widgets/sector.dart
+++ b/examples/widgets/sector.dart
@@ -68,33 +68,39 @@ class SectorAppState extends State<SectorApp> {
   }
 
   Widget buildBody() {
-    return new Column(<Widget>[
+    return new Column(
+      children: <Widget>[
         new Container(
           padding: new EdgeDims.symmetric(horizontal: 8.0, vertical: 25.0),
-          child: new Row(<Widget>[
+          child: new Row(
+            children: <Widget>[
               new RaisedButton(
                 child: new IntrinsicWidth(
-                  child: new Row(<Widget>[
-                    new Container(
-                      padding: new EdgeDims.all(4.0),
-                      margin: new EdgeDims.only(right: 10.0),
-                      child: new WidgetToRenderBoxAdapter(sectorAddIcon)
-                    ),
-                    new Text('ADD SECTOR'),
-                  ])
+                  child: new Row(
+                    children: <Widget>[
+                      new Container(
+                        padding: new EdgeDims.all(4.0),
+                        margin: new EdgeDims.only(right: 10.0),
+                        child: new WidgetToRenderBoxAdapter(sectorAddIcon)
+                      ),
+                      new Text('ADD SECTOR'),
+                    ]
+                  )
                 ),
                 onPressed: _enabledAdd ? addSector : null
               ),
               new RaisedButton(
                 child: new IntrinsicWidth(
-                  child: new Row(<Widget>[
-                    new Container(
-                      padding: new EdgeDims.all(4.0),
-                      margin: new EdgeDims.only(right: 10.0),
-                      child: new WidgetToRenderBoxAdapter(sectorRemoveIcon)
-                    ),
-                    new Text('REMOVE SECTOR'),
-                  ])
+                  child: new Row(
+                    children: <Widget>[
+                      new Container(
+                        padding: new EdgeDims.all(4.0),
+                        margin: new EdgeDims.only(right: 10.0),
+                        child: new WidgetToRenderBoxAdapter(sectorRemoveIcon)
+                      ),
+                      new Text('REMOVE SECTOR'),
+                    ]
+                  )
                 ),
                 onPressed: _enabledRemove ? removeSector : null
               )

--- a/examples/widgets/spinning_mixed.dart
+++ b/examples/widgets/spinning_mixed.dart
@@ -37,15 +37,18 @@ void attachWidgetTreeToRenderTree(RenderProxyBox container) {
     container: container,
     child: new Container(
       height: 300.0,
-      child: new Column(<Widget>[
+      child: new Column(
+        children: <Widget>[
           new Rectangle(const Color(0xFF00FFFF)),
           new Container(
             padding: new EdgeDims.all(10.0),
             margin: new EdgeDims.all(10.0),
             decoration: new BoxDecoration(backgroundColor: const Color(0xFFCCCCCC)),
-            child: new Row(<Widget>[
+            child: new Row(
+              children: <Widget>[
                 new RaisedButton(
-                  child: new Row(<Widget>[
+                  child: new Row(
+                    children: <Widget>[
                       new NetworkImage(src: "http://flutter.io/favicon.ico"),
                       new Text('PRESS ME'),
                     ]

--- a/examples/widgets/styled_text.dart
+++ b/examples/widgets/styled_text.dart
@@ -89,7 +89,8 @@ HAL: This mission is too important for me to allow you to jeopardize it.''';
 
     Widget body = new Container(
         padding: new EdgeDims.symmetric(horizontal: 8.0),
-        child: new Column(children,
+        child: new Column(
+          children: children,
           justifyContent: FlexJustifyContent.center,
           alignItems: FlexAlignItems.start
         )

--- a/packages/flutter/lib/src/material/chip.dart
+++ b/packages/flutter/lib/src/material/chip.dart
@@ -79,7 +79,10 @@ class Chip extends StatelessComponent {
         backgroundColor: Colors.grey[300],
         borderRadius: 16.0
       ),
-      child: new Row(children, justifyContent: FlexJustifyContent.collapse)
+      child: new Row(
+        children: children,
+        justifyContent: FlexJustifyContent.collapse
+      )
     );
   }
 }

--- a/packages/flutter/lib/src/material/date_picker.dart
+++ b/packages/flutter/lib/src/material/date_picker.dart
@@ -89,13 +89,16 @@ class _DatePickerState extends State<DatePicker> {
         );
         break;
     }
-    return new Column(<Widget>[
-      header,
-      new Container(
-        height: _calendarHeight,
-        child: picker
-      )
-    ], alignItems: FlexAlignItems.stretch);
+    return new Column(
+      children: <Widget>[
+        header,
+        new Container(
+          height: _calendarHeight,
+          child: picker
+        )
+      ],
+      alignItems: FlexAlignItems.stretch
+    );
   }
 
 }
@@ -138,20 +141,22 @@ class _DatePickerHeader extends StatelessComponent {
     return new Container(
       padding: new EdgeDims.all(10.0),
       decoration: new BoxDecoration(backgroundColor: theme.primaryColor),
-      child: new Column(<Widget>[
-        new GestureDetector(
-          onTap: () => _handleChangeMode(_DatePickerMode.day),
-          child: new Text(new DateFormat("MMM").format(selectedDate).toUpperCase(), style: monthStyle)
-        ),
-        new GestureDetector(
-          onTap: () => _handleChangeMode(_DatePickerMode.day),
-          child: new Text(new DateFormat("d").format(selectedDate), style: dayStyle)
-        ),
-        new GestureDetector(
-          onTap: () => _handleChangeMode(_DatePickerMode.year),
-          child: new Text(new DateFormat("yyyy").format(selectedDate), style: yearStyle)
-        )
-      ])
+      child: new Column(
+        children: <Widget>[
+          new GestureDetector(
+            onTap: () => _handleChangeMode(_DatePickerMode.day),
+            child: new Text(new DateFormat("MMM").format(selectedDate).toUpperCase(), style: monthStyle)
+          ),
+          new GestureDetector(
+            onTap: () => _handleChangeMode(_DatePickerMode.day),
+            child: new Text(new DateFormat("d").format(selectedDate), style: dayStyle)
+          ),
+          new GestureDetector(
+            onTap: () => _handleChangeMode(_DatePickerMode.year),
+            child: new Text(new DateFormat("yyyy").format(selectedDate), style: yearStyle)
+          )
+        ]
+      )
     );
   }
 }
@@ -190,7 +195,7 @@ class DayPicker extends StatelessComponent {
     List<Widget> rows = <Widget>[
       new Text(new DateFormat("MMMM y").format(displayedMonth), style: monthStyle),
       new Flex(
-        headers,
+        children: headers,
         justifyContent: FlexJustifyContent.spaceAround
       )
     ];
@@ -255,11 +260,11 @@ class DayPicker extends StatelessComponent {
     for (int w = 0; w < weeksShown; w++) {
       int startIndex = w * days.length;
       rows.add(new Row(
-        labels.sublist(startIndex, startIndex + days.length)
+        children: labels.sublist(startIndex, startIndex + days.length)
       ));
     }
 
-    return new Column(rows);
+    return new Column(children: rows);
   }
 }
 

--- a/packages/flutter/lib/src/material/dialog.dart
+++ b/packages/flutter/lib/src/material/dialog.dart
@@ -89,7 +89,8 @@ class Dialog extends StatelessComponent {
       dialogBody.add(new ButtonTheme(
         color: ButtonColor.accent,
         child: new Container(
-          child: new Row(actions,
+          child: new Row(
+            children: actions,
             justifyContent: FlexJustifyContent.end
           )
         )

--- a/packages/flutter/lib/src/material/drawer.dart
+++ b/packages/flutter/lib/src/material/drawer.dart
@@ -173,36 +173,38 @@ class DrawerControllerState extends State<DrawerController> {
         onHorizontalDragUpdate: _move,
         onHorizontalDragEnd: _settle,
         child: new RepaintBoundary(
-          child: new Stack(<Widget>[
-            new GestureDetector(
-              onTap: close,
-              child: new DecoratedBox(
-                decoration: new BoxDecoration(
-                  backgroundColor: _color.value
-                ),
-                child: new Container()
-              )
-            ),
-            new Align(
-              alignment: const FractionalOffset(0.0, 0.5),
-              child: new Listener(
-                onPointerDown: _handlePointerDown,
-                child: new Align(
-                  alignment: const FractionalOffset(1.0, 0.5),
-                  widthFactor: _performance.progress,
-                  child: new SizeObserver(
-                    onSizeChanged: _handleSizeChanged,
-                    child: new RepaintBoundary(
-                      child: new Focus(
-                        key: new GlobalObjectKey(config.key),
-                        child: config.child
+          child: new Stack(
+            children: <Widget>[
+              new GestureDetector(
+                onTap: close,
+                child: new DecoratedBox(
+                  decoration: new BoxDecoration(
+                    backgroundColor: _color.value
+                  ),
+                  child: new Container()
+                )
+              ),
+              new Align(
+                alignment: const FractionalOffset(0.0, 0.5),
+                child: new Listener(
+                  onPointerDown: _handlePointerDown,
+                  child: new Align(
+                    alignment: const FractionalOffset(1.0, 0.5),
+                    widthFactor: _performance.progress,
+                    child: new SizeObserver(
+                      onSizeChanged: _handleSizeChanged,
+                      child: new RepaintBoundary(
+                        child: new Focus(
+                          key: new GlobalObjectKey(config.key),
+                          child: config.child
+                        )
                       )
                     )
                   )
                 )
               )
-            )
-          ])
+            ]
+          )
         )
       );
     }

--- a/packages/flutter/lib/src/material/drawer_header.dart
+++ b/packages/flutter/lib/src/material/drawer_header.dart
@@ -31,15 +31,17 @@ class DrawerHeader extends StatelessComponent {
       ),
       padding: const EdgeDims.only(bottom: 7.0),
       margin: const EdgeDims.only(bottom: 8.0),
-      child: new Column(<Widget>[
-        new Flexible(child: new Container()),
-        new Container(
-          padding: const EdgeDims.symmetric(horizontal: 16.0),
-          child: new DefaultTextStyle(
-            style: Theme.of(context).text.body2,
-            child: child
+      child: new Column(
+        children: <Widget>[
+          new Flexible(child: new Container()),
+          new Container(
+            padding: const EdgeDims.symmetric(horizontal: 16.0),
+            child: new DefaultTextStyle(
+              style: Theme.of(context).text.body2,
+              child: child
+            )
           )
-        )]
+        ]
       )
     );
   }

--- a/packages/flutter/lib/src/material/drawer_item.dart
+++ b/packages/flutter/lib/src/material/drawer_item.dart
@@ -46,9 +46,9 @@ class DrawerItem extends StatelessComponent {
   Widget build(BuildContext context) {
     ThemeData themeData = Theme.of(context);
 
-    List<Widget> flexChildren = new List<Widget>();
+    List<Widget> children = <Widget>[];
     if (icon != null) {
-      flexChildren.add(
+      children.add(
         new Padding(
           padding: const EdgeDims.symmetric(horizontal: 16.0),
           child: new Icon(
@@ -58,7 +58,7 @@ class DrawerItem extends StatelessComponent {
         )
       );
     }
-    flexChildren.add(
+    children.add(
       new Flexible(
         child: new Padding(
           padding: const EdgeDims.symmetric(horizontal: 16.0),
@@ -74,7 +74,7 @@ class DrawerItem extends StatelessComponent {
       height: 48.0,
       child: new InkWell(
         onTap: onPressed,
-        child: new Row(flexChildren)
+        child: new Row(children: children)
       )
     );
   }

--- a/packages/flutter/lib/src/material/dropdown.dart
+++ b/packages/flutter/lib/src/material/dropdown.dart
@@ -289,18 +289,19 @@ class _DropDownButtonState<T> extends State<DropDownButton<T>> {
       onTap: _handleTap,
       child: new Container(
         decoration: new BoxDecoration(border: _kDropDownUnderline),
-        child: new Row(<Widget>[
-          new IndexedStack(
-            config.items,
-            key: indexedStackKey,
-            index: _selectedIndex,
-            alignment: const FractionalOffset(0.5, 0.0)
-          ),
-          new Container(
-            child: new Icon(icon: 'navigation/arrow_drop_down', size: IconSize.s36),
-            padding: const EdgeDims.only(top: 6.0)
-          )
-        ],
+        child: new Row(
+          children: <Widget>[
+            new IndexedStack(
+              children: config.items,
+              key: indexedStackKey,
+              index: _selectedIndex,
+              alignment: const FractionalOffset(0.5, 0.0)
+            ),
+            new Container(
+              child: new Icon(icon: 'navigation/arrow_drop_down', size: IconSize.s36),
+              padding: const EdgeDims.only(top: 6.0)
+            )
+          ],
           justifyContent: FlexJustifyContent.collapse
         )
       )

--- a/packages/flutter/lib/src/material/input.dart
+++ b/packages/flutter/lib/src/material/input.dart
@@ -134,7 +134,7 @@ class InputState extends ScrollableState<Input> {
       child: new SizeObserver(
         onSizeChanged: _handleContainerSizeChanged,
         child: new Container(
-          child: new Stack(textChildren),
+          child: new Stack(children: textChildren),
           margin: config.isDense ?
             const EdgeDims.symmetric(vertical: 4.0) :
             const EdgeDims.symmetric(vertical: 8.0),

--- a/packages/flutter/lib/src/material/list_item.dart
+++ b/packages/flutter/lib/src/material/list_item.dart
@@ -51,7 +51,7 @@ class ListItem extends StatelessComponent {
       onLongPress: onLongPress,
       child: new Padding(
         padding: const EdgeDims.symmetric(horizontal: 16.0),
-        child: new Row(children)
+        child: new Row(children: children)
       )
     );
   }

--- a/packages/flutter/lib/src/material/material_app.dart
+++ b/packages/flutter/lib/src/material/material_app.dart
@@ -175,10 +175,12 @@ class _MaterialAppState extends State<MaterialApp> implements BindingObserver {
       return true;
     });
     if (config.showPerformanceOverlay) {
-      result = new Stack([
-        result,
-        new Positioned(bottom: 0.0, left: 0.0, right: 0.0, child: new PerformanceOverlay.allEnabled()),
-      ]);
+      result = new Stack(
+        children: <Widget>[
+          result,
+          new Positioned(bottom: 0.0, left: 0.0, right: 0.0, child: new PerformanceOverlay.allEnabled()),
+        ]
+      );
     }
     return result;
   }

--- a/packages/flutter/lib/src/material/scaffold.dart
+++ b/packages/flutter/lib/src/material/scaffold.dart
@@ -314,7 +314,7 @@ class ScaffoldState extends State<Scaffold> {
       if (_currentBottomSheet != null)
         bottomSheets.add(_currentBottomSheet._widget);
       Widget stack = new Stack(
-        bottomSheets,
+        children: bottomSheets,
         alignment: const FractionalOffset(0.5, 1.0) // bottom-aligned, centered
       );
       _addIfNonNull(children, stack, _Child.bottomSheet);
@@ -335,7 +335,7 @@ class ScaffoldState extends State<Scaffold> {
       ));
     }
 
-    return new CustomMultiChildLayout(children, delegate: new _ScaffoldLayout());
+    return new CustomMultiChildLayout(children: children, delegate: new _ScaffoldLayout());
   }
 }
 

--- a/packages/flutter/lib/src/material/snack_bar.dart
+++ b/packages/flutter/lib/src/material/snack_bar.dart
@@ -103,7 +103,7 @@ class SnackBar extends StatelessComponent {
                 performance: performance,
                 opacity: new AnimatedValue<double>(0.0, end: 1.0, curve: _snackBarFadeCurve),
                 child: new Row(
-                  children,
+                  children: children,
                   alignItems: FlexAlignItems.center
                 )
               )

--- a/packages/flutter/lib/src/material/tabs.dart
+++ b/packages/flutter/lib/src/material/tabs.dart
@@ -331,7 +331,7 @@ class _Tab extends StatelessComponent {
       labelContent = _buildLabelIcon();
     } else {
       labelContent = new Column(
-        <Widget>[
+        children: <Widget>[
           new Container(
             child: _buildLabelIcon(),
             margin: const EdgeDims.only(bottom: 10.0)

--- a/packages/flutter/lib/src/material/time_picker.dart
+++ b/packages/flutter/lib/src/material/time_picker.dart
@@ -123,20 +123,23 @@ class _TimePickerState extends State<TimePicker> {
       onModeChanged: _handleModeChanged,
       onChanged: config.onChanged
     );
-    return new Column(<Widget>[
-      header,
-      new AspectRatio(
-        aspectRatio: 1.0,
-        child: new Container(
-          margin: const EdgeDims.all(12.0),
-          child: new _Dial(
-            mode: _mode,
-            selectedTime: config.selectedTime,
-            onChanged: config.onChanged
+    return new Column(
+      children: <Widget>[
+        header,
+        new AspectRatio(
+          aspectRatio: 1.0,
+          child: new Container(
+            margin: const EdgeDims.all(12.0),
+            child: new _Dial(
+              mode: _mode,
+              selectedTime: config.selectedTime,
+              onChanged: config.onChanged
+            )
           )
         )
-      )
-    ], alignItems: FlexAlignItems.stretch);
+      ],
+      alignItems: FlexAlignItems.stretch
+    );
   }
 }
 
@@ -199,31 +202,37 @@ class _TimePickerHeader extends StatelessComponent {
     return new Container(
       padding: kDialogHeadingPadding,
       decoration: new BoxDecoration(backgroundColor: theme.primaryColor),
-      child: new Row(<Widget>[
-        new GestureDetector(
-          onTap: () => _handleChangeMode(_TimePickerMode.hour),
-          child: new Text(selectedTime.hourOfPeriodLabel, style: hourStyle)
-        ),
-        new Text(':', style: inactiveStyle),
-        new GestureDetector(
-          onTap: () => _handleChangeMode(_TimePickerMode.minute),
-          child: new Text(selectedTime.minuteLabel, style: minuteStyle)
-        ),
-        new GestureDetector(
-          onTap: _handleChangeDayPeriod,
-          behavior: HitTestBehavior.opaque,
-          child: new Container(
-            padding: const EdgeDims.only(left: 16.0, right: 24.0),
-            child: new Column([
-              new Text('AM', style: amStyle),
-              new Container(
-                padding: const EdgeDims.only(top: 4.0),
-                child: new Text('PM', style: pmStyle)
-              ),
-            ], justifyContent: FlexJustifyContent.end)
+      child: new Row(
+        children: <Widget>[
+          new GestureDetector(
+            onTap: () => _handleChangeMode(_TimePickerMode.hour),
+            child: new Text(selectedTime.hourOfPeriodLabel, style: hourStyle)
+          ),
+          new Text(':', style: inactiveStyle),
+          new GestureDetector(
+            onTap: () => _handleChangeMode(_TimePickerMode.minute),
+            child: new Text(selectedTime.minuteLabel, style: minuteStyle)
+          ),
+          new GestureDetector(
+            onTap: _handleChangeDayPeriod,
+            behavior: HitTestBehavior.opaque,
+            child: new Container(
+              padding: const EdgeDims.only(left: 16.0, right: 24.0),
+              child: new Column(
+                children: <Widget>[
+                  new Text('AM', style: amStyle),
+                  new Container(
+                    padding: const EdgeDims.only(top: 4.0),
+                    child: new Text('PM', style: pmStyle)
+                  ),
+                ],
+                justifyContent: FlexJustifyContent.end
+              )
+            )
           )
-        )
-      ], justifyContent: FlexJustifyContent.end)
+        ],
+        justifyContent: FlexJustifyContent.end
+      )
     );
   }
 }

--- a/packages/flutter/lib/src/material/tool_bar.dart
+++ b/packages/flutter/lib/src/material/tool_bar.dart
@@ -95,7 +95,7 @@ class ToolBar extends StatelessComponent {
         height: kToolBarHeight,
         child: new DefaultTextStyle(
           style: sideStyle,
-          child: new Row(firstRow)
+          child: new Row(children: firstRow)
         )
       )
     ];
@@ -123,7 +123,7 @@ class ToolBar extends StatelessComponent {
       child: new Container(
         padding: combinedPadding,
         child: new Column(
-          rows,
+          children: rows,
           justifyContent: FlexJustifyContent.collapse
         )
       )

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -464,6 +464,8 @@ class LayoutId extends ParentDataWidget<CustomMultiChildLayout> {
   }
 }
 
+const List<Widget> _emptyWidgetList = const <Widget>[];
+
 /// Defers the layout of multiple children to a delegate.
 ///
 /// The delegate can determine the layout constraints for each child and can
@@ -471,8 +473,9 @@ class LayoutId extends ParentDataWidget<CustomMultiChildLayout> {
 /// size of the parent, but the size of the parent cannot depend on the sizes of
 /// the children.
 class CustomMultiChildLayout extends MultiChildRenderObjectWidget {
-  CustomMultiChildLayout(List<Widget> children, {
+  CustomMultiChildLayout({
     Key key,
+    List<Widget> children: _emptyWidgetList,
     this.delegate
   }) : super(key: key, children: children) {
     assert(delegate != null);
@@ -927,8 +930,9 @@ class Container extends StatelessComponent {
 ///
 /// For details about the block layout algorithm, see [RenderBlockBase].
 class BlockBody extends MultiChildRenderObjectWidget {
-  BlockBody(List<Widget> children, {
+  BlockBody({
     Key key,
+    List<Widget> children: _emptyWidgetList,
     this.direction: Axis.vertical
   }) : super(key: key, children: children) {
     assert(direction != null);
@@ -946,7 +950,7 @@ class BlockBody extends MultiChildRenderObjectWidget {
 
 abstract class StackRenderObjectWidgetBase extends MultiChildRenderObjectWidget {
   StackRenderObjectWidgetBase({
-    List<Widget> children,
+    List<Widget> children: _emptyWidgetList,
     Key key
   }) : super(key: key, children: children);
 }
@@ -956,8 +960,9 @@ abstract class StackRenderObjectWidgetBase extends MultiChildRenderObjectWidget 
 /// For details about the stack layout algorithm, see [RenderStack]. To control
 /// the position of child widgets, see the [Positioned] widget.
 class Stack extends StackRenderObjectWidgetBase {
-  Stack(List<Widget> children, {
+  Stack({
     Key key,
+    List<Widget> children: _emptyWidgetList,
     this.alignment: const FractionalOffset(0.0, 0.0)
   }) : super(key: key, children: children);
 
@@ -973,8 +978,9 @@ class Stack extends StackRenderObjectWidgetBase {
 
 /// A [Stack] that shows a single child at once.
 class IndexedStack extends StackRenderObjectWidgetBase {
-  IndexedStack(List<Widget> children, {
+  IndexedStack({
     Key key,
+    List<Widget> children: _emptyWidgetList,
     this.alignment: const FractionalOffset(0.0, 0.0),
     this.index: 0
   }) : super(key: key, children: children) {
@@ -1113,7 +1119,7 @@ class Positioned extends ParentDataWidget<StackRenderObjectWidgetBase> {
 
 abstract class GridRenderObjectWidgetBase extends MultiChildRenderObjectWidget {
   GridRenderObjectWidgetBase({
-    List<Widget> children,
+    List<Widget> children: _emptyWidgetList,
     Key key
   }) : super(key: key, children: children) {
     _delegate = createDelegate();
@@ -1135,7 +1141,7 @@ abstract class GridRenderObjectWidgetBase extends MultiChildRenderObjectWidget {
 ///
 /// For details about the grid layout algorithm, see [RenderGrid].
 class CustomGrid extends GridRenderObjectWidgetBase {
-  CustomGrid(List<Widget> children, { Key key, this.delegate })
+  CustomGrid({ Key key, List<Widget> children: _emptyWidgetList, this.delegate })
     : super(key: key, children: children) {
     assert(delegate != null);
   }
@@ -1150,8 +1156,9 @@ class CustomGrid extends GridRenderObjectWidgetBase {
 ///
 /// For details about the grid layout algorithm, see [MaxTileWidthGridDelegate].
 class FixedColumnCountGrid extends GridRenderObjectWidgetBase {
-  FixedColumnCountGrid(List<Widget> children, {
+  FixedColumnCountGrid({
     Key key,
+    List<Widget> children: _emptyWidgetList,
     this.columnCount,
     this.tileAspectRatio: 1.0,
     this.padding: EdgeDims.zero
@@ -1181,8 +1188,9 @@ class FixedColumnCountGrid extends GridRenderObjectWidgetBase {
 ///
 /// For details about the grid layout algorithm, see [MaxTileWidthGridDelegate].
 class MaxTileWidthGrid extends GridRenderObjectWidgetBase {
-  MaxTileWidthGrid(List<Widget> children, {
+  MaxTileWidthGrid({
     Key key,
+    List<Widget> children: _emptyWidgetList,
     this.maxTileWidth,
     this.tileAspectRatio: 1.0,
     this.padding: EdgeDims.zero
@@ -1238,8 +1246,9 @@ class GridPlacementData<DataType, WidgetType extends RenderObjectWidget> extends
 /// For details about the flex layout algorithm, see [RenderFlex]. To control
 /// the flex of child widgets, see the [Flexible] widget.
 class Flex extends MultiChildRenderObjectWidget {
-  Flex(List<Widget> children, {
+  Flex({
     Key key,
+    List<Widget> children: _emptyWidgetList,
     this.direction: FlexDirection.horizontal,
     this.justifyContent: FlexJustifyContent.start,
     this.alignItems: FlexAlignItems.center,
@@ -1270,12 +1279,20 @@ class Flex extends MultiChildRenderObjectWidget {
 /// For details about the flex layout algorithm, see [RenderFlex]. To control
 /// the flex of child widgets, see the [Flexible] widget.
 class Row extends Flex {
-  Row(List<Widget> children, {
+  Row({
     Key key,
+    List<Widget> children: _emptyWidgetList,
     justifyContent: FlexJustifyContent.start,
     alignItems: FlexAlignItems.center,
     textBaseline
-  }) : super(children, key: key, direction: FlexDirection.horizontal, justifyContent: justifyContent, alignItems: alignItems, textBaseline: textBaseline);
+  }) : super(
+    children: children,
+    key: key,
+    direction: FlexDirection.horizontal,
+    justifyContent: justifyContent,
+    alignItems: alignItems,
+    textBaseline: textBaseline
+  );
 }
 
 /// Lays out child elements in a column.
@@ -1283,12 +1300,20 @@ class Row extends Flex {
 /// For details about the flex layout algorithm, see [RenderFlex]. To control
 /// the flex of child widgets, see the [Flexible] widget.
 class Column extends Flex {
-  Column(List<Widget> children, {
+  Column({
     Key key,
+    List<Widget> children: _emptyWidgetList,
     justifyContent: FlexJustifyContent.start,
     alignItems: FlexAlignItems.center,
     textBaseline
-  }) : super(children, key: key, direction: FlexDirection.vertical, justifyContent: justifyContent, alignItems: alignItems, textBaseline: textBaseline);
+  }) : super(
+    children: children,
+    key: key,
+    direction: FlexDirection.vertical,
+    justifyContent: justifyContent,
+    alignItems: alignItems,
+    textBaseline: textBaseline
+  );
 }
 
 /// Controls how a child of a [Flex], [Row], or [Column] flexes.

--- a/packages/flutter/lib/src/widgets/enter_exit_transition.dart
+++ b/packages/flutter/lib/src/widgets/enter_exit_transition.dart
@@ -171,17 +171,19 @@ class _EnterExitTransitionState extends State<EnterExitTransition> {
       size: _entries.last.childSize,
       duration: config.duration,
       curve: config.curve,
-      child: new Stack(_entries.map((_Entry entry) {
-        return new SizeObserver(
-          key: new ObjectKey(entry),
-          onSizeChanged: (Size newSize) {
-            setState(() {
-              entry.childSize = newSize;
-            });
-          },
-          child: entry.currentTransition
-        );
-      }).toList())
+      child: new Stack(
+        children: _entries.map((_Entry entry) {
+          return new SizeObserver(
+            key: new ObjectKey(entry),
+            onSizeChanged: (Size newSize) {
+              setState(() {
+                entry.childSize = newSize;
+              });
+            },
+            child: entry.currentTransition
+          );
+        }).toList()
+      )
     );
   }
 }

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -282,6 +282,7 @@ abstract class OneChildRenderObjectWidget extends RenderObjectWidget {
 abstract class MultiChildRenderObjectWidget extends RenderObjectWidget {
   MultiChildRenderObjectWidget({ Key key, this.children })
     : super(key: key) {
+    assert(children != null);
     assert(!children.any((Widget child) => child == null));
   }
 

--- a/packages/flutter/lib/src/widgets/overlay.dart
+++ b/packages/flutter/lib/src/widgets/overlay.dart
@@ -152,7 +152,7 @@ class OverlayState extends State<Overlay> {
         break;
     }
 
-    return new Stack(backwardsChildren.reversed.toList(growable: false));
+    return new Stack(children: backwardsChildren.reversed.toList(growable: false));
   }
 
   void debugFillDescription(List<String> description) {

--- a/packages/flutter/lib/src/widgets/scrollable.dart
+++ b/packages/flutter/lib/src/widgets/scrollable.dart
@@ -425,7 +425,7 @@ class Block extends StatelessComponent {
   final ScrollListener onScroll;
 
   Widget build(BuildContext context) {
-    Widget contents = new BlockBody(children, direction: scrollDirection);
+    Widget contents = new BlockBody(children: children, direction: scrollDirection);
     if (padding != null)
       contents = new Padding(padding: padding, child: contents);
     return new ScrollableViewport(

--- a/packages/flutter/test/widget/animated_positioned_test.dart
+++ b/packages/flutter/test/widget/animated_positioned_test.dart
@@ -16,7 +16,7 @@ void main() {
 
       tester.pumpWidget(
         new Stack(
-          <Widget>[
+          children: <Widget>[
             new AnimatedPositioned(
               child: new Container(key: key),
               left: 50.0,
@@ -39,7 +39,7 @@ void main() {
 
       tester.pumpWidget(
         new Stack(
-          <Widget>[
+          children: <Widget>[
             new AnimatedPositioned(
               child: new Container(key: key),
               left: 37.0,
@@ -77,7 +77,7 @@ void main() {
 
       tester.pumpWidget(
         new Stack(
-          <Widget>[
+          children: <Widget>[
             new AnimatedPositioned(
               child: new Container(key: key),
               left: 0.0,
@@ -100,7 +100,7 @@ void main() {
 
       tester.pumpWidget(
         new Stack(
-          <Widget>[
+          children: <Widget>[
             new AnimatedPositioned(
               child: new Container(key: key),
               left: 100.0,
@@ -123,7 +123,7 @@ void main() {
 
       tester.pumpWidget(
         new Stack(
-          <Widget>[
+          children: <Widget>[
             new AnimatedPositioned(
               child: new Container(key: key),
               left: 150.0,
@@ -160,7 +160,7 @@ void main() {
 
       tester.pumpWidget(
         new Stack(
-          <Widget>[
+          children: <Widget>[
             new AnimatedPositioned(
               child: new Container(key: key),
               left: 0.0,
@@ -183,7 +183,7 @@ void main() {
 
       tester.pumpWidget(
         new Stack(
-          <Widget>[
+          children: <Widget>[
             new AnimatedPositioned(
               child: new Container(key: key),
               left: 0.0,

--- a/packages/flutter/test/widget/coordinates_test.dart
+++ b/packages/flutter/test/widget/coordinates_test.dart
@@ -14,26 +14,28 @@ void main() {
       Key keyB = new GlobalKey();
 
       tester.pumpWidget(
-        new Stack(<Widget>[
-          new Positioned(
-            top: 100.0,
-            left: 100.0,
-            child: new SizedBox(
-              key: keyA,
-              width: 10.0,
-              height: 10.0
-            )
-          ),
-          new Positioned(
-            left: 100.0,
-            top: 200.0,
-            child: new SizedBox(
-              key: keyB,
-              width: 20.0,
-              height: 10.0
-            )
-          ),
-        ])
+        new Stack(
+          children: <Widget>[
+            new Positioned(
+              top: 100.0,
+              left: 100.0,
+              child: new SizedBox(
+                key: keyA,
+                width: 10.0,
+                height: 10.0
+              )
+            ),
+            new Positioned(
+              left: 100.0,
+              top: 200.0,
+              child: new SizedBox(
+                key: keyB,
+                width: 20.0,
+                height: 10.0
+              )
+            ),
+          ]
+        )
       );
 
       expect((tester.findElementByKey(keyA).renderObject as RenderBox).localToGlobal(const Point(0.0, 0.0)),

--- a/packages/flutter/test/widget/custom_multi_child_layout_test.dart
+++ b/packages/flutter/test/widget/custom_multi_child_layout_test.dart
@@ -41,7 +41,8 @@ class TestMultiChildLayoutDelegate extends MultiChildLayoutDelegate {
 
 Widget buildFrame(MultiChildLayoutDelegate delegate) {
   return new Center(
-    child: new CustomMultiChildLayout([
+    child: new CustomMultiChildLayout(
+      children: <Widget>[
         new LayoutId(id: 0, child: new Container(width: 150.0, height: 100.0)),
         new LayoutId(id: 1, child: new Container(width: 100.0, height: 200.0)),
       ],
@@ -105,16 +106,22 @@ void main() {
     testWidgets((WidgetTester tester) {
       TestMultiChildLayoutDelegate delegate = new TestMultiChildLayoutDelegate();
       tester.pumpWidget(new Center(
-        child: new CustomMultiChildLayout([
-          new LayoutId(
-            id: 0,
-            child: new CustomMultiChildLayout([
-              new LayoutId(id: 0, child: new Container(width: 150.0, height: 100.0)),
-              new LayoutId(id: 1, child: new Container(width: 100.0, height: 200.0)),
-            ], delegate: delegate)
-          ),
-          new LayoutId(id: 1, child: new Container(width: 100.0, height: 200.0)),
-        ], delegate: delegate)
+        child: new CustomMultiChildLayout(
+          children: <Widget>[
+            new LayoutId(
+              id: 0,
+              child: new CustomMultiChildLayout(
+                children: <Widget>[
+                  new LayoutId(id: 0, child: new Container(width: 150.0, height: 100.0)),
+                  new LayoutId(id: 1, child: new Container(width: 100.0, height: 200.0)),
+                ],
+                delegate: delegate
+              )
+            ),
+            new LayoutId(id: 1, child: new Container(width: 100.0, height: 200.0)),
+          ],
+          delegate: delegate
+        )
       ));
 
     });

--- a/packages/flutter/test/widget/dismissable_test.dart
+++ b/packages/flutter/test/widget/dismissable_test.dart
@@ -274,10 +274,12 @@ void main() {
         child: new Container(
           width: 100.0,
           height: 1000.0,
-          child: new Column(<Widget>[
-            new Test1215DismissableComponent('1'),
-            new Test1215DismissableComponent('2')
-          ])
+          child: new Column(
+            children: <Widget>[
+              new Test1215DismissableComponent('1'),
+              new Test1215DismissableComponent('2')
+            ]
+          )
         )
       ));
       expect(tester.findText('1'), isNotNull);

--- a/packages/flutter/test/widget/draggable_test.dart
+++ b/packages/flutter/test/widget/draggable_test.dart
@@ -15,7 +15,8 @@ void main() {
 
       tester.pumpWidget(new MaterialApp(
         routes: <String, RouteBuilder>{
-          '/': (RouteArguments args) { return new Column(<Widget>[
+          '/': (RouteArguments args) { return new Column(
+            children: <Widget>[
               new Draggable(
                 data: 1,
                 child: new Text('Source'),

--- a/packages/flutter/test/widget/duplicate_key_test.dart
+++ b/packages/flutter/test/widget/duplicate_key_test.dart
@@ -37,10 +37,12 @@ class KeyedWrapper extends StatelessComponent {
 }
 
 Widget builder() {
-  return new Column(<Widget>[
-    new KeyedWrapper(items[1].key1, items[1].key2),
-    new KeyedWrapper(items[0].key1, items[0].key2)
-  ]);
+  return new Column(
+    children: <Widget>[
+      new KeyedWrapper(items[1].key1, items[1].key2),
+      new KeyedWrapper(items[0].key1, items[0].key2)
+    ]
+  );
 }
 
 void main() {

--- a/packages/flutter/test/widget/flex_test.dart
+++ b/packages/flutter/test/widget/flex_test.dart
@@ -16,29 +16,33 @@ void main() {
           decoration: const BoxDecoration(
             backgroundColor: const Color(0xFF00FF00)
           ),
-          child: new Stack(<Widget>[
-            new Positioned(
-              top: 10.0,
-              left: 10.0,
-              child: new Column(<Widget>[
-                new GestureDetector(
-                  onTap: () {
-                    didReceiveTap = true;
-                  },
-                  child: new Container(
-                    decoration: const BoxDecoration(
-                      backgroundColor: const Color(0xFF0000FF)
-                    ),
-                    width: 100.0,
-                    height: 100.0,
-                    child: new Center(
-                      child: new Text('X')
+          child: new Stack(
+            children: <Widget>[
+              new Positioned(
+                top: 10.0,
+                left: 10.0,
+                child: new Column(
+                  children: <Widget>[
+                    new GestureDetector(
+                      onTap: () {
+                        didReceiveTap = true;
+                      },
+                      child: new Container(
+                        decoration: const BoxDecoration(
+                          backgroundColor: const Color(0xFF0000FF)
+                        ),
+                        width: 100.0,
+                        height: 100.0,
+                        child: new Center(
+                          child: new Text('X')
+                        )
+                      )
                     )
-                  )
+                  ]
                 )
-              ])
-            )
-          ])
+              )
+            ]
+          )
         )
       );
 
@@ -53,10 +57,11 @@ void main() {
     // Row without justifyContent: FlexJustifyContent.collapse
     testWidgets((WidgetTester tester) {
       tester.pumpWidget(new Center(
-        child: new Row([
-          new Container(width: 10.0, height: 100.0),
-          new Container(width: 30.0, height: 100.0)
-        ],
+        child: new Row(
+          children: <Widget>[
+            new Container(width: 10.0, height: 100.0),
+            new Container(width: 30.0, height: 100.0)
+          ],
           key: flexKey
         )
       ));
@@ -66,10 +71,11 @@ void main() {
 
       // Row with justifyContent: FlexJustifyContent.collapse
       tester.pumpWidget(new Center(
-        child: new Row([
-          new Container(width: 10.0, height: 100.0),
-          new Container(width: 30.0, height: 100.0)
-        ],
+        child: new Row(
+          children: <Widget>[
+            new Container(width: 10.0, height: 100.0),
+            new Container(width: 30.0, height: 100.0)
+          ],
           key: flexKey,
           justifyContent: FlexJustifyContent.collapse
         )
@@ -82,10 +88,11 @@ void main() {
     // Column without justifyContent: FlexJustifyContent.collapse
     testWidgets((WidgetTester tester) {
       tester.pumpWidget(new Center(
-        child: new Column([
-          new Container(width: 100.0, height: 100.0),
-          new Container(width: 100.0, height: 150.0)
-        ],
+        child: new Column(
+          children: <Widget>[
+            new Container(width: 100.0, height: 100.0),
+            new Container(width: 100.0, height: 150.0)
+          ],
           key: flexKey
         )
       ));
@@ -95,10 +102,11 @@ void main() {
 
       // Column with justifyContent: FlexJustifyContent.collapse
       tester.pumpWidget(new Center(
-        child: new Column([
-          new Container(width: 100.0, height: 100.0),
-          new Container(width: 100.0, height: 150.0)
-        ],
+        child: new Column(
+          children: <Widget>[
+            new Container(width: 100.0, height: 100.0),
+            new Container(width: 100.0, height: 150.0)
+          ],
           key: flexKey,
           justifyContent: FlexJustifyContent.collapse
         )
@@ -117,12 +125,15 @@ void main() {
         child: new Container(
           width: 0.0,
           height: 0.0,
-          child:  new Column([
-            new Container(
-              key: childKey,
-              width: 100.0,
-              height: 100.0
-            )], justifyContent: FlexJustifyContent.collapse
+          child:  new Column(
+            children: <Widget>[
+              new Container(
+                key: childKey,
+                width: 100.0,
+                height: 100.0
+              )
+            ],
+            justifyContent: FlexJustifyContent.collapse
           )
         )
       ));
@@ -135,12 +146,15 @@ void main() {
         child: new Container(
           width: 0.0,
           height: 0.0,
-          child:  new Row([
-            new Container(
-              key: childKey,
-              width: 100.0,
-              height: 100.0
-            )], justifyContent: FlexJustifyContent.collapse
+          child:  new Row(
+            children: <Widget>[
+              new Container(
+                key: childKey,
+                width: 100.0,
+                height: 100.0
+              )
+            ],
+            justifyContent: FlexJustifyContent.collapse
           )
         )
       ));

--- a/packages/flutter/test/widget/focus_test.dart
+++ b/packages/flutter/test/widget/focus_test.dart
@@ -26,11 +26,13 @@ void main() {
       GlobalKey keyB = new GlobalKey();
       tester.pumpWidget(
         new Focus(
-          child: new Column(<Widget>[
-            // reverse these when you fix https://github.com/flutter/engine/issues/1495
-            new TestFocusable('b', 'B FOCUSED', keyB),
-            new TestFocusable('a', 'A FOCUSED', keyA),
-          ])
+          child: new Column(
+            children: <Widget>[
+              // reverse these when you fix https://github.com/flutter/engine/issues/1495
+              new TestFocusable('b', 'B FOCUSED', keyB),
+              new TestFocusable('a', 'A FOCUSED', keyA),
+            ]
+          )
         )
       );
       expect(tester.findText('a'),         isNull);

--- a/packages/flutter/test/widget/gesture_detector_test.dart
+++ b/packages/flutter/test/widget/gesture_detector_test.dart
@@ -144,30 +144,32 @@ void main() {
 
       void pumpWidgetTree(HitTestBehavior behavior) {
         tester.pumpWidget(
-          new Stack([
-            new Listener(
-              onPointerDown: (_) {
-                didReceivePointerDown = true;
-              },
-              child: new Container(
+          new Stack(
+            children: <Widget>[
+              new Listener(
+                onPointerDown: (_) {
+                  didReceivePointerDown = true;
+                },
+                child: new Container(
+                  width: 100.0,
+                  height: 100.0,
+                  decoration: const BoxDecoration(
+                    backgroundColor: const Color(0xFF00FF00)
+                  )
+                )
+              ),
+              new Container(
                 width: 100.0,
                 height: 100.0,
-                decoration: const BoxDecoration(
-                  backgroundColor: const Color(0xFF00FF00)
+                child: new GestureDetector(
+                  onTap: () {
+                    didTap = true;
+                  },
+                  behavior: behavior
                 )
               )
-            ),
-            new Container(
-              width: 100.0,
-              height: 100.0,
-              child: new GestureDetector(
-                onTap: () {
-                  didTap = true;
-                },
-                behavior: behavior
-              )
-            )
-          ])
+            ]
+          )
         );
       }
 

--- a/packages/flutter/test/widget/multichild_test.dart
+++ b/packages/flutter/test/widget/multichild_test.dart
@@ -36,64 +36,76 @@ void main() {
     testWidgets((WidgetTester tester) {
 
       tester.pumpWidget(
-        new Stack(<Widget>[
-          new DecoratedBox(decoration: kBoxDecorationA),
-          new DecoratedBox(decoration: kBoxDecorationB),
-          new DecoratedBox(decoration: kBoxDecorationC),
-        ])
+        new Stack(
+          children: <Widget>[
+            new DecoratedBox(decoration: kBoxDecorationA),
+            new DecoratedBox(decoration: kBoxDecorationB),
+            new DecoratedBox(decoration: kBoxDecorationC),
+          ]
+        )
       );
 
       checkTree(tester, <BoxDecoration>[kBoxDecorationA, kBoxDecorationB, kBoxDecorationC]);
 
       tester.pumpWidget(
-        new Stack(<Widget>[
-          new DecoratedBox(decoration: kBoxDecorationA),
-          new DecoratedBox(decoration: kBoxDecorationC),
-        ])
+        new Stack(
+          children: <Widget>[
+            new DecoratedBox(decoration: kBoxDecorationA),
+            new DecoratedBox(decoration: kBoxDecorationC),
+          ]
+        )
       );
 
       checkTree(tester, <BoxDecoration>[kBoxDecorationA, kBoxDecorationC]);
 
       tester.pumpWidget(
-        new Stack(<Widget>[
-          new DecoratedBox(decoration: kBoxDecorationA),
-          new DecoratedBox(key: new Key('b'), decoration: kBoxDecorationB),
-          new DecoratedBox(decoration: kBoxDecorationC),
-        ])
+        new Stack(
+          children: <Widget>[
+            new DecoratedBox(decoration: kBoxDecorationA),
+            new DecoratedBox(key: new Key('b'), decoration: kBoxDecorationB),
+            new DecoratedBox(decoration: kBoxDecorationC),
+          ]
+        )
       );
 
       checkTree(tester, <BoxDecoration>[kBoxDecorationA, kBoxDecorationB, kBoxDecorationC]);
 
       tester.pumpWidget(
-        new Stack(<Widget>[
-          new DecoratedBox(key: new Key('b'), decoration: kBoxDecorationB),
-          new DecoratedBox(decoration: kBoxDecorationC),
-          new DecoratedBox(key: new Key('a'), decoration: kBoxDecorationA),
-        ])
+        new Stack(
+          children: <Widget>[
+            new DecoratedBox(key: new Key('b'), decoration: kBoxDecorationB),
+            new DecoratedBox(decoration: kBoxDecorationC),
+            new DecoratedBox(key: new Key('a'), decoration: kBoxDecorationA),
+          ]
+        )
       );
 
       checkTree(tester, <BoxDecoration>[kBoxDecorationB, kBoxDecorationC, kBoxDecorationA]);
 
       tester.pumpWidget(
-        new Stack(<Widget>[
-          new DecoratedBox(key: new Key('a'), decoration: kBoxDecorationA),
-          new DecoratedBox(decoration: kBoxDecorationC),
-          new DecoratedBox(key: new Key('b'), decoration: kBoxDecorationB),
-        ])
+        new Stack(
+          children: <Widget>[
+            new DecoratedBox(key: new Key('a'), decoration: kBoxDecorationA),
+            new DecoratedBox(decoration: kBoxDecorationC),
+            new DecoratedBox(key: new Key('b'), decoration: kBoxDecorationB),
+          ]
+        )
       );
 
       checkTree(tester, <BoxDecoration>[kBoxDecorationA, kBoxDecorationC, kBoxDecorationB]);
 
       tester.pumpWidget(
-        new Stack(<Widget>[
-          new DecoratedBox(decoration: kBoxDecorationC),
-        ])
+        new Stack(
+          children: <Widget>[
+            new DecoratedBox(decoration: kBoxDecorationC),
+          ]
+        )
       );
 
       checkTree(tester, <BoxDecoration>[kBoxDecorationC]);
 
       tester.pumpWidget(
-        new Stack(<Widget>[])
+        new Stack()
       );
 
       checkTree(tester, <BoxDecoration>[]);
@@ -105,103 +117,117 @@ void main() {
     testWidgets((WidgetTester tester) {
 
       tester.pumpWidget(
-        new Stack(<Widget>[
-          new DecoratedBox(decoration: kBoxDecorationA),
-          new DecoratedBox(decoration: kBoxDecorationB),
-          new DecoratedBox(decoration: kBoxDecorationC),
-        ])
+        new Stack(
+          children: <Widget>[
+            new DecoratedBox(decoration: kBoxDecorationA),
+            new DecoratedBox(decoration: kBoxDecorationB),
+            new DecoratedBox(decoration: kBoxDecorationC),
+          ]
+        )
       );
 
       checkTree(tester, <BoxDecoration>[kBoxDecorationA, kBoxDecorationB, kBoxDecorationC]);
 
       tester.pumpWidget(
-        new Stack(<Widget>[
-          new DecoratedBox(decoration: kBoxDecorationA),
-          new Container(
-            child: new DecoratedBox(decoration: kBoxDecorationB)
-          ),
-          new DecoratedBox(decoration: kBoxDecorationC),
-        ])
-      );
-
-      checkTree(tester, <BoxDecoration>[kBoxDecorationA, kBoxDecorationB, kBoxDecorationC]);
-
-      tester.pumpWidget(
-        new Stack(<Widget>[
-          new DecoratedBox(decoration: kBoxDecorationA),
-          new Container(
-            child: new Container(
+        new Stack(
+          children: <Widget>[
+            new DecoratedBox(decoration: kBoxDecorationA),
+            new Container(
               child: new DecoratedBox(decoration: kBoxDecorationB)
-            )
-          ),
-          new DecoratedBox(decoration: kBoxDecorationC),
-        ])
+            ),
+            new DecoratedBox(decoration: kBoxDecorationC),
+          ]
+        )
       );
 
       checkTree(tester, <BoxDecoration>[kBoxDecorationA, kBoxDecorationB, kBoxDecorationC]);
 
       tester.pumpWidget(
-        new Stack(<Widget>[
-          new Container(
-            child: new Container(
-              child: new DecoratedBox(decoration: kBoxDecorationB)
-            )
-          ),
-          new Container(
-            child: new DecoratedBox(decoration: kBoxDecorationA)
-          ),
-          new DecoratedBox(decoration: kBoxDecorationC),
-        ])
+        new Stack(
+          children: <Widget>[
+            new DecoratedBox(decoration: kBoxDecorationA),
+            new Container(
+              child: new Container(
+                child: new DecoratedBox(decoration: kBoxDecorationB)
+              )
+            ),
+            new DecoratedBox(decoration: kBoxDecorationC),
+          ]
+        )
+      );
+
+      checkTree(tester, <BoxDecoration>[kBoxDecorationA, kBoxDecorationB, kBoxDecorationC]);
+
+      tester.pumpWidget(
+        new Stack(
+          children: <Widget>[
+            new Container(
+              child: new Container(
+                child: new DecoratedBox(decoration: kBoxDecorationB)
+              )
+            ),
+            new Container(
+              child: new DecoratedBox(decoration: kBoxDecorationA)
+            ),
+            new DecoratedBox(decoration: kBoxDecorationC),
+          ]
+        )
       );
 
       checkTree(tester, <BoxDecoration>[kBoxDecorationB, kBoxDecorationA, kBoxDecorationC]);
 
       tester.pumpWidget(
-        new Stack(<Widget>[
-          new Container(
-            child: new DecoratedBox(decoration: kBoxDecorationB)
-          ),
-          new Container(
-            child: new DecoratedBox(decoration: kBoxDecorationA)
-          ),
-          new DecoratedBox(decoration: kBoxDecorationC),
-        ])
+        new Stack(
+          children: <Widget>[
+            new Container(
+              child: new DecoratedBox(decoration: kBoxDecorationB)
+            ),
+            new Container(
+              child: new DecoratedBox(decoration: kBoxDecorationA)
+            ),
+            new DecoratedBox(decoration: kBoxDecorationC),
+          ]
+        )
       );
 
       checkTree(tester, <BoxDecoration>[kBoxDecorationB, kBoxDecorationA, kBoxDecorationC]);
 
       tester.pumpWidget(
-        new Stack(<Widget>[
-          new Container(
-            key: new Key('b'),
-            child: new DecoratedBox(decoration: kBoxDecorationB)
-          ),
-          new Container(
-            key: new Key('a'),
-            child: new DecoratedBox(decoration: kBoxDecorationA)
-          ),
-        ])
+        new Stack(
+          children: <Widget>[
+            new Container(
+              key: new Key('b'),
+              child: new DecoratedBox(decoration: kBoxDecorationB)
+            ),
+            new Container(
+              key: new Key('a'),
+              child: new DecoratedBox(decoration: kBoxDecorationA)
+            ),
+          ]
+        )
       );
 
       checkTree(tester, <BoxDecoration>[kBoxDecorationB, kBoxDecorationA]);
 
       tester.pumpWidget(
-        new Stack(<Widget>[
-          new Container(
-            key: new Key('a'),
-            child: new DecoratedBox(decoration: kBoxDecorationA)
-          ),
-          new Container(
-            key: new Key('b'),
-            child: new DecoratedBox(decoration: kBoxDecorationB)
-          ),
-        ])
+        new Stack(
+          children: <Widget>[
+            new Container(
+              key: new Key('a'),
+              child: new DecoratedBox(decoration: kBoxDecorationA)
+            ),
+            new Container(
+              key: new Key('b'),
+              child: new DecoratedBox(decoration: kBoxDecorationB)
+            ),
+          ]
+        )
       );
 
       checkTree(tester, <BoxDecoration>[kBoxDecorationA, kBoxDecorationB]);
 
       tester.pumpWidget(
-        new Stack(<Widget>[])
+        new Stack()
       );
 
       checkTree(tester, <BoxDecoration>[]);
@@ -211,22 +237,26 @@ void main() {
   test('MultiChildRenderObjectElement with stateful components', () {
     testWidgets((WidgetTester tester) {
       tester.pumpWidget(
-        new Stack(<Widget>[
-          new DecoratedBox(decoration: kBoxDecorationA),
-          new DecoratedBox(decoration: kBoxDecorationB),
-        ])
+        new Stack(
+          children: <Widget>[
+            new DecoratedBox(decoration: kBoxDecorationA),
+            new DecoratedBox(decoration: kBoxDecorationB),
+          ]
+        )
       );
 
       checkTree(tester, <BoxDecoration>[kBoxDecorationA, kBoxDecorationB]);
 
       tester.pumpWidget(
-        new Stack(<Widget>[
-          new FlipComponent(
-            left: new DecoratedBox(decoration: kBoxDecorationA),
-            right: new DecoratedBox(decoration: kBoxDecorationB)
-          ),
-          new DecoratedBox(decoration: kBoxDecorationC),
-        ])
+        new Stack(
+          children: <Widget>[
+            new FlipComponent(
+              left: new DecoratedBox(decoration: kBoxDecorationA),
+              right: new DecoratedBox(decoration: kBoxDecorationB)
+            ),
+            new DecoratedBox(decoration: kBoxDecorationC),
+          ]
+        )
       );
 
       checkTree(tester, <BoxDecoration>[kBoxDecorationA, kBoxDecorationC]);
@@ -237,12 +267,14 @@ void main() {
       checkTree(tester, <BoxDecoration>[kBoxDecorationB, kBoxDecorationC]);
 
       tester.pumpWidget(
-        new Stack(<Widget>[
-          new FlipComponent(
-            left: new DecoratedBox(decoration: kBoxDecorationA),
-            right: new DecoratedBox(decoration: kBoxDecorationB)
-          ),
-        ])
+        new Stack(
+          children: <Widget>[
+            new FlipComponent(
+              left: new DecoratedBox(decoration: kBoxDecorationA),
+              right: new DecoratedBox(decoration: kBoxDecorationB)
+            ),
+          ]
+        )
       );
 
       checkTree(tester, <BoxDecoration>[kBoxDecorationB]);
@@ -253,24 +285,28 @@ void main() {
       checkTree(tester, <BoxDecoration>[kBoxDecorationA]);
 
       tester.pumpWidget(
-        new Stack(<Widget>[
-          new FlipComponent(
-            key: new Key('flip'),
-            left: new DecoratedBox(decoration: kBoxDecorationA),
-            right: new DecoratedBox(decoration: kBoxDecorationB)
-          ),
-        ])
+        new Stack(
+          children: <Widget>[
+            new FlipComponent(
+              key: new Key('flip'),
+              left: new DecoratedBox(decoration: kBoxDecorationA),
+              right: new DecoratedBox(decoration: kBoxDecorationB)
+            ),
+          ]
+        )
       );
 
       tester.pumpWidget(
-        new Stack(<Widget>[
-          new DecoratedBox(key: new Key('c'), decoration: kBoxDecorationC),
-          new FlipComponent(
-            key: new Key('flip'),
-            left: new DecoratedBox(decoration: kBoxDecorationA),
-            right: new DecoratedBox(decoration: kBoxDecorationB)
-          ),
-        ])
+        new Stack(
+          children: <Widget>[
+            new DecoratedBox(key: new Key('c'), decoration: kBoxDecorationC),
+            new FlipComponent(
+              key: new Key('flip'),
+              left: new DecoratedBox(decoration: kBoxDecorationA),
+              right: new DecoratedBox(decoration: kBoxDecorationB)
+            ),
+          ]
+        )
       );
 
       checkTree(tester, <BoxDecoration>[kBoxDecorationC, kBoxDecorationA]);
@@ -281,14 +317,16 @@ void main() {
       checkTree(tester, <BoxDecoration>[kBoxDecorationC, kBoxDecorationB]);
 
       tester.pumpWidget(
-        new Stack(<Widget>[
-          new FlipComponent(
-            key: new Key('flip'),
-            left: new DecoratedBox(decoration: kBoxDecorationA),
-            right: new DecoratedBox(decoration: kBoxDecorationB)
-          ),
-          new DecoratedBox(key: new Key('c'), decoration: kBoxDecorationC),
-        ])
+        new Stack(
+          children: <Widget>[
+            new FlipComponent(
+              key: new Key('flip'),
+              left: new DecoratedBox(decoration: kBoxDecorationA),
+              right: new DecoratedBox(decoration: kBoxDecorationB)
+            ),
+            new DecoratedBox(key: new Key('c'), decoration: kBoxDecorationC),
+          ]
+        )
       );
 
       checkTree(tester, <BoxDecoration>[kBoxDecorationB, kBoxDecorationC]);

--- a/packages/flutter/test/widget/page_forward_transitions_test.dart
+++ b/packages/flutter/test/widget/page_forward_transitions_test.dart
@@ -76,18 +76,20 @@ void main() {
                     key: insideKey,
                     builder: (BuildContext context) {
                       PageRoute route = ModalRoute.of(context);
-                      return new Column([
-                        new TestTransition(
-                          childFirstHalf: new Text('A'),
-                          childSecondHalf: new Text('B'),
-                          performance: route.performance
-                        ),
-                        new TestTransition(
-                          childFirstHalf: new Text('C'),
-                          childSecondHalf: new Text('D'),
-                          performance: route.forwardPerformance
-                        ),
-                      ]);
+                      return new Column(
+                        children: <Widget>[
+                          new TestTransition(
+                            childFirstHalf: new Text('A'),
+                            childSecondHalf: new Text('B'),
+                            performance: route.performance
+                          ),
+                          new TestTransition(
+                            childFirstHalf: new Text('C'),
+                            childSecondHalf: new Text('D'),
+                            performance: route.forwardPerformance
+                          ),
+                        ]
+                      );
                     }
                   )
                 );

--- a/packages/flutter/test/widget/parent_data_test.dart
+++ b/packages/flutter/test/widget/parent_data_test.dart
@@ -65,15 +65,17 @@ void main() {
     testWidgets((WidgetTester tester) {
 
       tester.pumpWidget(
-        new Stack(<Widget>[
-          new DecoratedBox(decoration: kBoxDecorationA),
-          new Positioned(
-            top: 10.0,
-            left: 10.0,
-            child: new DecoratedBox(decoration: kBoxDecorationB)
-          ),
-          new DecoratedBox(decoration: kBoxDecorationC),
-        ])
+        new Stack(
+          children: <Widget>[
+            new DecoratedBox(decoration: kBoxDecorationA),
+            new Positioned(
+              top: 10.0,
+              left: 10.0,
+              child: new DecoratedBox(decoration: kBoxDecorationB)
+            ),
+            new DecoratedBox(decoration: kBoxDecorationC),
+          ]
+        )
       );
 
       checkTree(tester, <TestParentData>[
@@ -83,19 +85,21 @@ void main() {
       ]);
 
       tester.pumpWidget(
-        new Stack(<Widget>[
-          new Positioned(
-            bottom: 5.0,
-            right: 7.0,
-            child: new DecoratedBox(decoration: kBoxDecorationA)
-          ),
-          new Positioned(
-            top: 10.0,
-            left: 10.0,
-            child: new DecoratedBox(decoration: kBoxDecorationB)
-          ),
-          new DecoratedBox(decoration: kBoxDecorationC),
-        ])
+        new Stack(
+          children: <Widget>[
+            new Positioned(
+              bottom: 5.0,
+              right: 7.0,
+              child: new DecoratedBox(decoration: kBoxDecorationA)
+            ),
+            new Positioned(
+              top: 10.0,
+              left: 10.0,
+              child: new DecoratedBox(decoration: kBoxDecorationB)
+            ),
+            new DecoratedBox(decoration: kBoxDecorationC),
+          ]
+        )
       );
 
       checkTree(tester, <TestParentData>[
@@ -109,19 +113,21 @@ void main() {
       DecoratedBox kDecoratedBoxC = new DecoratedBox(decoration: kBoxDecorationC);
 
       tester.pumpWidget(
-        new Stack(<Widget>[
-          new Positioned(
-            bottom: 5.0,
-            right: 7.0,
-            child: kDecoratedBoxA
-          ),
-          new Positioned(
-            top: 10.0,
-            left: 10.0,
-            child: kDecoratedBoxB
-          ),
-          kDecoratedBoxC,
-        ])
+        new Stack(
+          children: <Widget>[
+            new Positioned(
+              bottom: 5.0,
+              right: 7.0,
+              child: kDecoratedBoxA
+            ),
+            new Positioned(
+              top: 10.0,
+              left: 10.0,
+              child: kDecoratedBoxB
+            ),
+            kDecoratedBoxC,
+          ]
+        )
       );
 
       checkTree(tester, <TestParentData>[
@@ -131,19 +137,21 @@ void main() {
       ]);
 
       tester.pumpWidget(
-        new Stack(<Widget>[
-          new Positioned(
-            bottom: 6.0,
-            right: 8.0,
-            child: kDecoratedBoxA
-          ),
-          new Positioned(
-            left: 10.0,
-            right: 10.0,
-            child: kDecoratedBoxB
-          ),
-          kDecoratedBoxC,
-        ])
+        new Stack(
+          children: <Widget>[
+            new Positioned(
+              bottom: 6.0,
+              right: 8.0,
+              child: kDecoratedBoxA
+            ),
+            new Positioned(
+              left: 10.0,
+              right: 10.0,
+              child: kDecoratedBoxB
+            ),
+            kDecoratedBoxC,
+          ]
+        )
       );
 
       checkTree(tester, <TestParentData>[
@@ -153,15 +161,17 @@ void main() {
       ]);
 
       tester.pumpWidget(
-        new Stack(<Widget>[
-          kDecoratedBoxA,
-          new Positioned(
-            left: 11.0,
-            right: 12.0,
-            child: new Container(child: kDecoratedBoxB)
-          ),
-          kDecoratedBoxC,
-        ])
+        new Stack(
+          children: <Widget>[
+            kDecoratedBoxA,
+            new Positioned(
+              left: 11.0,
+              right: 12.0,
+              child: new Container(child: kDecoratedBoxB)
+            ),
+            kDecoratedBoxC,
+          ]
+        )
       );
 
       checkTree(tester, <TestParentData>[
@@ -171,19 +181,21 @@ void main() {
       ]);
 
       tester.pumpWidget(
-        new Stack(<Widget>[
-          kDecoratedBoxA,
-          new Positioned(
-            right: 10.0,
-            child: new Container(child: kDecoratedBoxB)
-          ),
-          new Container(
-            child: new Positioned(
-              top: 8.0,
-              child: kDecoratedBoxC
+        new Stack(
+          children: <Widget>[
+            kDecoratedBoxA,
+            new Positioned(
+              right: 10.0,
+              child: new Container(child: kDecoratedBoxB)
+            ),
+            new Container(
+              child: new Positioned(
+                top: 8.0,
+                child: kDecoratedBoxC
+              )
             )
-          )
-        ])
+          ]
+        )
       );
 
       checkTree(tester, <TestParentData>[
@@ -193,12 +205,14 @@ void main() {
       ]);
 
       tester.pumpWidget(
-        new Stack(<Widget>[
-          new Positioned(
-            right: 10.0,
-            child: new FlipComponent(left: kDecoratedBoxA, right: kDecoratedBoxB)
-          ),
-        ])
+        new Stack(
+          children: <Widget>[
+            new Positioned(
+              right: 10.0,
+              child: new FlipComponent(left: kDecoratedBoxA, right: kDecoratedBoxB)
+            ),
+          ]
+        )
       );
 
       checkTree(tester, <TestParentData>[
@@ -213,12 +227,14 @@ void main() {
       ]);
 
       tester.pumpWidget(
-        new Stack(<Widget>[
-          new Positioned(
-            top: 7.0,
-            child: new FlipComponent(left: kDecoratedBoxA, right: kDecoratedBoxB)
-          ),
-        ])
+        new Stack(
+          children: <Widget>[
+            new Positioned(
+              top: 7.0,
+              child: new FlipComponent(left: kDecoratedBoxA, right: kDecoratedBoxB)
+            ),
+          ]
+        )
       );
 
       checkTree(tester, <TestParentData>[
@@ -233,7 +249,7 @@ void main() {
       ]);
 
       tester.pumpWidget(
-        new Stack(<Widget>[])
+        new Stack()
       );
 
       checkTree(tester, <TestParentData>[]);
@@ -245,36 +261,40 @@ void main() {
       expect(cachedException, isNull);
 
       tester.pumpWidget(
-        new Stack(<Widget>[
-          new Positioned(
-            top: 5.0,
-            bottom: 8.0,
-            child: new Positioned(
-              top: 6.0,
-              left: 7.0,
-              child: new DecoratedBox(decoration: kBoxDecorationB)
+        new Stack(
+          children: <Widget>[
+            new Positioned(
+              top: 5.0,
+              bottom: 8.0,
+              child: new Positioned(
+                top: 6.0,
+                left: 7.0,
+                child: new DecoratedBox(decoration: kBoxDecorationB)
+              )
             )
-          )
-        ])
+          ]
+        )
       );
 
       expect(cachedException, isNotNull);
       cachedException = null;
 
-      tester.pumpWidget(new Stack(<Widget>[]));
+      tester.pumpWidget(new Stack());
 
       checkTree(tester, <TestParentData>[]);
       expect(cachedException, isNull);
 
       tester.pumpWidget(
         new Container(
-          child: new Flex(<Widget>[
-            new Positioned(
-              top: 6.0,
-              left: 7.0,
-              child: new DecoratedBox(decoration: kBoxDecorationB)
-            )
-          ])
+          child: new Flex(
+            children: <Widget>[
+              new Positioned(
+                top: 6.0,
+                left: 7.0,
+                child: new DecoratedBox(decoration: kBoxDecorationB)
+              )
+            ]
+          )
         )
       );
 
@@ -282,7 +302,7 @@ void main() {
       cachedException = null;
 
       tester.pumpWidget(
-        new Stack(<Widget>[])
+        new Stack()
       );
 
       checkTree(tester, <TestParentData>[]);
@@ -294,30 +314,15 @@ void main() {
       GlobalKey key = new GlobalKey();
 
       tester.pumpWidget(
-        new Stack(<Widget>[
-          new Positioned(
-            top: 10.0,
-            left: 10.0,
-            child: new DecoratedBox(key: key, decoration: kBoxDecorationA)
-          )
-        ])
-      );
-
-      checkTree(tester, <TestParentData>[
-        new TestParentData(top: 10.0, left: 10.0),
-      ]);
-
-      tester.pumpWidget(
-        new Stack(<Widget>[
-          new Positioned(
-            top: 10.0,
-            left: 10.0,
-            child: new DecoratedBox(
-              decoration: kBoxDecorationB,
+        new Stack(
+          children: <Widget>[
+            new Positioned(
+              top: 10.0,
+              left: 10.0,
               child: new DecoratedBox(key: key, decoration: kBoxDecorationA)
             )
-          )
-        ])
+          ]
+        )
       );
 
       checkTree(tester, <TestParentData>[
@@ -325,13 +330,34 @@ void main() {
       ]);
 
       tester.pumpWidget(
-        new Stack(<Widget>[
-          new Positioned(
-            top: 10.0,
-            left: 10.0,
-            child: new DecoratedBox(key: key, decoration: kBoxDecorationA)
-          )
-        ])
+        new Stack(
+          children: <Widget>[
+            new Positioned(
+              top: 10.0,
+              left: 10.0,
+              child: new DecoratedBox(
+                decoration: kBoxDecorationB,
+                child: new DecoratedBox(key: key, decoration: kBoxDecorationA)
+              )
+            )
+          ]
+        )
+      );
+
+      checkTree(tester, <TestParentData>[
+        new TestParentData(top: 10.0, left: 10.0),
+      ]);
+
+      tester.pumpWidget(
+        new Stack(
+          children: <Widget>[
+            new Positioned(
+              top: 10.0,
+              left: 10.0,
+              child: new DecoratedBox(key: key, decoration: kBoxDecorationA)
+            )
+          ]
+        )
       );
 
       checkTree(tester, <TestParentData>[

--- a/packages/flutter/test/widget/positioned_test.dart
+++ b/packages/flutter/test/widget/positioned_test.dart
@@ -43,15 +43,17 @@ void main() {
           child: new Container(
             height: 100.0,
             width: 100.0,
-            child: new Stack(<Widget>[
-              new PositionedTransition(
-                rect: rect,
-                performance: performance,
-                child: new Container(
-                  key: key
+            child: new Stack(
+              children: <Widget>[
+                new PositionedTransition(
+                  rect: rect,
+                  performance: performance,
+                  child: new Container(
+                    key: key
+                  )
                 )
-              )
-            ])
+              ]
+            )
           )
         )
       ); // t=0

--- a/packages/flutter/test/widget/reparent_state_test.dart
+++ b/packages/flutter/test/widget/reparent_state_test.dart
@@ -32,17 +32,19 @@ void main() {
 
       StateMarker grandchild = new StateMarker();
       tester.pumpWidget(
-        new Stack(<Widget>[
-          new Container(
-            child: new StateMarker(key: left)
-          ),
-          new Container(
-            child: new StateMarker(
-              key: right,
-              child: grandchild
-            )
-          ),
-        ])
+        new Stack(
+          children: <Widget>[
+            new Container(
+              child: new StateMarker(key: left)
+            ),
+            new Container(
+              child: new StateMarker(
+                key: right,
+                child: grandchild
+              )
+            ),
+          ]
+        )
       );
 
       (left.currentState as StateMarkerState).marker = "left";
@@ -54,17 +56,19 @@ void main() {
 
       StateMarker newGrandchild = new StateMarker();
       tester.pumpWidget(
-        new Stack(<Widget>[
-          new Container(
-            child: new StateMarker(
-              key: right,
-              child: newGrandchild
-            )
-          ),
-          new Container(
-            child: new StateMarker(key: left)
-          ),
-        ])
+        new Stack(
+          children: <Widget>[
+            new Container(
+              child: new StateMarker(
+                key: right,
+                child: newGrandchild
+              )
+            ),
+            new Container(
+              child: new StateMarker(key: left)
+            ),
+          ]
+        )
       );
 
       expect((left.currentState as StateMarkerState).marker, equals("left"));

--- a/packages/flutter/test/widget/stack_test.dart
+++ b/packages/flutter/test/widget/stack_test.dart
@@ -12,13 +12,13 @@ import '../rendering/rendering_tester.dart';
 void main() {
   test('Can construct an empty Stack', () {
     testWidgets((WidgetTester tester) {
-      tester.pumpWidget(new Stack(<Widget>[]));
+      tester.pumpWidget(new Stack());
     });
   });
 
   test('Can construct an empty Centered Stack', () {
     testWidgets((WidgetTester tester) {
-      tester.pumpWidget(new Center(child: new Stack(<Widget>[])));
+      tester.pumpWidget(new Center(child: new Stack()));
     });
   });
 
@@ -27,16 +27,18 @@ void main() {
       Key key = new Key('container');
 
       tester.pumpWidget(
-        new Stack(<Widget>[
-          new Positioned(
-            left: 10.0,
-            child: new Container(
-              key: key,
-              width: 10.0,
-              height: 10.0
+        new Stack(
+          children: <Widget>[
+            new Positioned(
+              left: 10.0,
+              child: new Container(
+                key: key,
+                width: 10.0,
+                height: 10.0
+              )
             )
-          )
-        ])
+          ]
+        )
       );
 
       Element container;
@@ -52,16 +54,18 @@ void main() {
       expect(parentData.height, isNull);
 
       tester.pumpWidget(
-        new Stack(<Widget>[
-          new Positioned(
-            right: 10.0,
-            child: new Container(
-              key: key,
-              width: 10.0,
-              height: 10.0
+        new Stack(
+          children: <Widget>[
+            new Positioned(
+              right: 10.0,
+              child: new Container(
+                key: key,
+                width: 10.0,
+                height: 10.0
+              )
             )
-          )
-        ])
+          ]
+        )
       );
 
       container = tester.findElementByKey(key);
@@ -80,7 +84,7 @@ void main() {
       Key key = new Key('container');
       Container container = new Container(key: key, width: 10.0, height: 10.0);
 
-      tester.pumpWidget(new Stack(<Widget>[ new Positioned(left: 10.0, child: container) ]));
+      tester.pumpWidget(new Stack(children: <Widget>[ new Positioned(left: 10.0, child: container) ]));
       Element containerElement = tester.findElementByKey(key);
 
       StackParentData parentData;
@@ -92,7 +96,7 @@ void main() {
       expect(parentData.width, isNull);
       expect(parentData.height, isNull);
 
-      tester.pumpWidget(new Stack(<Widget>[ container ]));
+      tester.pumpWidget(new Stack(children: <Widget>[ container ]));
       containerElement = tester.findElementByKey(key);
 
       parentData = containerElement.renderObject.parentData;
@@ -112,7 +116,8 @@ void main() {
 
       tester.pumpWidget(
         new Center(
-          child: new Stack(<Widget>[
+          child: new Stack(
+            children: <Widget>[
               new Container(key: child0Key, width: 20.0, height: 20.0),
               new Container(key: child1Key, width: 10.0, height: 10.0)
             ],
@@ -133,13 +138,13 @@ void main() {
 
   test('Can construct an empty IndexedStack', () {
     testWidgets((WidgetTester tester) {
-      tester.pumpWidget(new IndexedStack(<Widget>[]));
+      tester.pumpWidget(new IndexedStack());
     });
   });
 
   test('Can construct an empty Centered IndexedStack', () {
     testWidgets((WidgetTester tester) {
-      tester.pumpWidget(new Center(child: new IndexedStack(<Widget>[])));
+      tester.pumpWidget(new Center(child: new IndexedStack()));
     });
   });
 
@@ -158,7 +163,7 @@ void main() {
             )
           );
         });
-        return new Center(child: new IndexedStack(items, index: index));
+        return new Center(child: new IndexedStack(children: items, index: index));
       }
 
       tester.pumpWidget(buildFrame(0));
@@ -186,7 +191,7 @@ void main() {
         List<Widget> items = new List<Widget>.generate(itemCount, (i) {
           return new GestureDetector(child: new Text('$i'), onTap: () { itemsTapped.add(i); });
         });
-        return new Center(child: new IndexedStack(items, key: key, index: index));
+        return new Center(child: new IndexedStack(children: items, key: key, index: index));
       }
 
       tester.pumpWidget(buildFrame(0));
@@ -210,14 +215,16 @@ void main() {
       );
 
       tester.pumpWidget(
-        new Stack(<Widget>[
-          new Positioned(
-            left: 10.0,
-            width: 11.0,
-            height: 12.0,
-            child: new DecoratedBox(key: key, decoration: kBoxDecoration)
-          )
-        ])
+        new Stack(
+          children: <Widget>[
+            new Positioned(
+              left: 10.0,
+              width: 11.0,
+              height: 12.0,
+              child: new DecoratedBox(key: key, decoration: kBoxDecoration)
+            )
+          ]
+        )
       );
 
       Element box;
@@ -239,14 +246,16 @@ void main() {
       expect(renderBox.size.height, equals(12.0));
 
       tester.pumpWidget(
-        new Stack(<Widget>[
-          new Positioned(
-            right: 10.0,
-            width: 11.0,
-            height: 12.0,
-            child: new DecoratedBox(key: key, decoration: kBoxDecoration)
-          )
-        ])
+        new Stack(
+          children: <Widget>[
+            new Positioned(
+              right: 10.0,
+              width: 11.0,
+              height: 12.0,
+              child: new DecoratedBox(key: key, decoration: kBoxDecoration)
+            )
+          ]
+        )
       );
 
       box = tester.findElementByKey(key);

--- a/packages/flutter/test/widget/syncing_test.dart
+++ b/packages/flutter/test/widget/syncing_test.dart
@@ -115,22 +115,24 @@ void main() {
     testWidgets((WidgetTester tester) {
       Widget a = new TestWidget(persistentState: 0x61, syncedState: 0x41, child: new Text('apple'));
       Widget b = new TestWidget(persistentState: 0x62, syncedState: 0x42, child: new Text('banana'));
-      tester.pumpWidget(new Column(<Widget>[]));
+      tester.pumpWidget(new Column());
 
       GlobalKey keyA = new GlobalKey();
       GlobalKey keyB = new GlobalKey();
 
       tester.pumpWidget(
-        new Column(<Widget>[
-          new Container(
-            key: keyA,
-            child: a
-          ),
-          new Container(
-            key: keyB,
-            child: b
-          )
-        ])
+        new Column(
+          children: <Widget>[
+            new Container(
+              key: keyA,
+              child: a
+            ),
+            new Container(
+              key: keyB,
+              child: b
+            )
+          ]
+        )
       );
 
       TestWidgetState first, second;
@@ -146,16 +148,18 @@ void main() {
       expect(second.syncedState, equals(0x42));
 
       tester.pumpWidget(
-        new Column(<Widget>[
-          new Container(
-            key: keyA,
-            child: a
-          ),
-          new Container(
-            key: keyB,
-            child: b
-          )
-        ])
+        new Column(
+          children: <Widget>[
+            new Container(
+              key: keyA,
+              child: a
+            ),
+            new Container(
+              key: keyB,
+              child: b
+            )
+          ]
+        )
       );
 
       first = tester.findStateByConfig(a);
@@ -173,16 +177,18 @@ void main() {
       // since they are both "old" nodes, they shouldn't sync with each other even though they look alike
 
       tester.pumpWidget(
-        new Column(<Widget>[
-          new Container(
-            key: keyA,
-            child: b
-          ),
-          new Container(
-            key: keyB,
-            child: a
-          )
-        ])
+        new Column(
+          children: <Widget>[
+            new Container(
+              key: keyA,
+              child: b
+            ),
+            new Container(
+              key: keyB,
+              child: a
+            )
+          ]
+        )
       );
 
       first = tester.findStateByConfig(b);

--- a/packages/flutter/test/widget/transform_test.dart
+++ b/packages/flutter/test/widget/transform_test.dart
@@ -11,41 +11,43 @@ void main() {
     testWidgets((WidgetTester tester) {
       bool didReceiveTap = false;
       tester.pumpWidget(
-        new Stack(<Widget>[
-          new Positioned(
-            top: 100.0,
-            left: 100.0,
-            child: new Container(
-              width: 100.0,
-              height: 100.0,
-              decoration: new BoxDecoration(
-                backgroundColor: new Color(0xFF0000FF)
+        new Stack(
+          children: <Widget>[
+            new Positioned(
+              top: 100.0,
+              left: 100.0,
+              child: new Container(
+                width: 100.0,
+                height: 100.0,
+                decoration: new BoxDecoration(
+                  backgroundColor: new Color(0xFF0000FF)
+                )
               )
-            )
-          ),
-          new Positioned(
-            top: 100.0,
-            left: 100.0,
-            child: new Container(
-              width: 100.0,
-              height: 100.0,
-              child: new Transform(
-                transform: new Matrix4.identity().scale(0.5, 0.5),
-                origin: new Offset(100.0, 50.0),
-                child: new GestureDetector(
-                  onTap: () {
-                    didReceiveTap = true;
-                  },
-                  child: new Container(
-                    decoration: new BoxDecoration(
-                      backgroundColor: new Color(0xFF00FFFF)
+            ),
+            new Positioned(
+              top: 100.0,
+              left: 100.0,
+              child: new Container(
+                width: 100.0,
+                height: 100.0,
+                child: new Transform(
+                  transform: new Matrix4.identity().scale(0.5, 0.5),
+                  origin: new Offset(100.0, 50.0),
+                  child: new GestureDetector(
+                    onTap: () {
+                      didReceiveTap = true;
+                    },
+                    child: new Container(
+                      decoration: new BoxDecoration(
+                        backgroundColor: new Color(0xFF00FFFF)
+                      )
                     )
                   )
                 )
               )
             )
-          )
-        ])
+          ]
+        )
       );
 
       expect(didReceiveTap, isFalse);
@@ -60,41 +62,43 @@ void main() {
     testWidgets((WidgetTester tester) {
       bool didReceiveTap = false;
       tester.pumpWidget(
-        new Stack(<Widget>[
-          new Positioned(
-            top: 100.0,
-            left: 100.0,
-            child: new Container(
-              width: 100.0,
-              height: 100.0,
-              decoration: new BoxDecoration(
-                backgroundColor: new Color(0xFF0000FF)
+        new Stack(
+          children: <Widget>[
+            new Positioned(
+              top: 100.0,
+              left: 100.0,
+              child: new Container(
+                width: 100.0,
+                height: 100.0,
+                decoration: new BoxDecoration(
+                  backgroundColor: new Color(0xFF0000FF)
+                )
               )
-            )
-          ),
-          new Positioned(
-            top: 100.0,
-            left: 100.0,
-            child: new Container(
-              width: 100.0,
-              height: 100.0,
-              child: new Transform(
-                transform: new Matrix4.identity().scale(0.5, 0.5),
-                alignment: new FractionalOffset(1.0, 0.5),
-                child: new GestureDetector(
-                  onTap: () {
-                    didReceiveTap = true;
-                  },
-                  child: new Container(
-                    decoration: new BoxDecoration(
-                      backgroundColor: new Color(0xFF00FFFF)
+            ),
+            new Positioned(
+              top: 100.0,
+              left: 100.0,
+              child: new Container(
+                width: 100.0,
+                height: 100.0,
+                child: new Transform(
+                  transform: new Matrix4.identity().scale(0.5, 0.5),
+                  alignment: new FractionalOffset(1.0, 0.5),
+                  child: new GestureDetector(
+                    onTap: () {
+                      didReceiveTap = true;
+                    },
+                    child: new Container(
+                      decoration: new BoxDecoration(
+                        backgroundColor: new Color(0xFF00FFFF)
+                      )
                     )
                   )
                 )
               )
             )
-          )
-        ])
+          ]
+        )
       );
 
       expect(didReceiveTap, isFalse);
@@ -109,42 +113,44 @@ void main() {
     testWidgets((WidgetTester tester) {
       bool didReceiveTap = false;
       tester.pumpWidget(
-        new Stack(<Widget>[
-          new Positioned(
-            top: 100.0,
-            left: 100.0,
-            child: new Container(
-              width: 100.0,
-              height: 100.0,
-              decoration: new BoxDecoration(
-                backgroundColor: new Color(0xFF0000FF)
+        new Stack(
+          children: <Widget>[
+            new Positioned(
+              top: 100.0,
+              left: 100.0,
+              child: new Container(
+                width: 100.0,
+                height: 100.0,
+                decoration: new BoxDecoration(
+                  backgroundColor: new Color(0xFF0000FF)
+                )
               )
-            )
-          ),
-          new Positioned(
-            top: 100.0,
-            left: 100.0,
-            child: new Container(
-              width: 100.0,
-              height: 100.0,
-              child: new Transform(
-                transform: new Matrix4.identity().scale(0.5, 0.5),
-                origin: new Offset(100.0, 0.0),
-                alignment: new FractionalOffset(0.0, 0.5),
-                child: new GestureDetector(
-                  onTap: () {
-                    didReceiveTap = true;
-                  },
-                  child: new Container(
-                    decoration: new BoxDecoration(
-                      backgroundColor: new Color(0xFF00FFFF)
+            ),
+            new Positioned(
+              top: 100.0,
+              left: 100.0,
+              child: new Container(
+                width: 100.0,
+                height: 100.0,
+                child: new Transform(
+                  transform: new Matrix4.identity().scale(0.5, 0.5),
+                  origin: new Offset(100.0, 0.0),
+                  alignment: new FractionalOffset(0.0, 0.5),
+                  child: new GestureDetector(
+                    onTap: () {
+                      didReceiveTap = true;
+                    },
+                    child: new Container(
+                      decoration: new BoxDecoration(
+                        backgroundColor: new Color(0xFF00FFFF)
+                      )
                     )
                   )
                 )
               )
             )
-          )
-        ])
+          ]
+        )
       );
 
       expect(didReceiveTap, isFalse);


### PR DESCRIPTION
Previously we used a positional argument for widgets that had multiple
children. Now we use a named argument that defaults to an empty list.

Fixes #241
