### PR TITLE
RenderPerformanceOverlay needs alwaysNeedsCompositing

### DIFF
--- a/packages/flutter/lib/src/rendering/performance_overlay.dart
+++ b/packages/flutter/lib/src/rendering/performance_overlay.dart
@@ -67,6 +67,7 @@ class RenderPerformanceOverlay extends RenderBox {
   }
 
   bool get sizedByParent => true;
+  bool get alwaysNeedsCompositing => true;
 
   double getMinIntrinsicWidth(BoxConstraints constraints) {
     return constraints.constrainWidth(0.0);
@@ -101,6 +102,7 @@ class RenderPerformanceOverlay extends RenderBox {
   }
 
   void paint(PaintingContext context, Offset offset) {
+    assert(needsCompositing);
     context.pushPerformanceOverlay(offset, optionsMask, rasterizerThreshold, size);
   }
 }


### PR DESCRIPTION
The performance overlay is always drawn using the compositor. We should tell
the rest of the system that it's going to make a composited layer.

Fixes #1177
