### PR TITLE
Add reference to "mojo:media_service" in sound.dart

### DIFF
--- a/examples/widgets/piano.dart
+++ b/examples/widgets/piano.dart
@@ -64,7 +64,7 @@ class PianoApp extends StatelessComponent {
   Future loadSounds() async {
     MediaServiceProxy mediaService = new MediaServiceProxy.unbound();
     try {
-      shell.connectToService(null, mediaService);
+      shell.connectToService("mojo:media_service", mediaService);
       List<Future<MediaPlayerPrepareResponseParams>> pending = <Future<MediaPlayerPrepareResponseParams>>[];
       for (PianoKey key in keys)
         pending.add(key.load(mediaService));

--- a/packages/flutter_sprites/lib/src/sound.dart
+++ b/packages/flutter_sprites/lib/src/sound.dart
@@ -67,7 +67,7 @@ class SoundEffectStream {
 class SoundEffectPlayer {
   SoundEffectPlayer(int maxStreams) {
     MediaServiceProxy mediaService = new MediaServiceProxy.unbound();
-    shell.connectToService(null, mediaService);
+    shell.connectToService("mojo:media_service", mediaService);
     _soundPool = new SoundPoolProxy.unbound();
     mediaService.ptr.createSoundPool(_soundPool, maxStreams);
   }
@@ -146,7 +146,7 @@ class SoundTrackPlayer {
 
   SoundTrackPlayer() {
     _mediaService = new MediaServiceProxy.unbound();
-    shell.connectToService(null, _mediaService);
+    shell.connectToService("mojo:media_service", _mediaService);
   }
 
   MediaServiceProxy _mediaService;


### PR DESCRIPTION
Related: https://github.com/domokit/mojo/issues/614

Flutter can play sounds using this package. However, when Mojo Shell is running Flutter, it lacks the necessary media service.

This patch creates a hook to the mojo binary `media_service.mojo`. If Mojo Shell is built with this media service, then it will be able to play sounds when running Flutter.
