### PR TITLE
Provide a safe time to update a WidgetToRenderBoxAdapter

### DIFF
--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -1910,7 +1910,7 @@ class AssetImage extends StatelessComponent {
 /// widget enforces that restriction by keying itself using a [GlobalObjectKey]
 /// for the given render object.
 class WidgetToRenderBoxAdapter extends LeafRenderObjectWidget {
-  WidgetToRenderBoxAdapter(RenderBox renderBox)
+  WidgetToRenderBoxAdapter({ RenderBox renderBox, this.onBuild })
     : renderBox = renderBox,
       // WidgetToRenderBoxAdapter objects are keyed to their render box. This
       // prevents the widget being used in the widget hierarchy in two different
@@ -1923,7 +1923,18 @@ class WidgetToRenderBoxAdapter extends LeafRenderObjectWidget {
   /// The render box to place in the widget tree.
   final RenderBox renderBox;
 
+  /// Called when it is safe to update the render box and its descendants. If
+  /// you update the RenderObject subtree under this widget outside of
+  /// invocations of this callback, features like hit-testing will fail as the
+  /// tree will be dirty.
+  final VoidCallback onBuild;
+
   RenderBox createRenderObject() => renderBox;
+
+  void updateRenderObject(RenderBox renderObject, WidgetToRenderBoxAdapter oldWidget) {
+    if (onBuild != null)
+      onBuild();
+  }
 }
 
 


### PR DESCRIPTION
If you change the RenderObject tree between frames, you'll assert if
you subsequently hit test. So e.g. if you get two button presses back
to back, and you mutate the tree synchronously in response to the
first one, the second will assert.

This adds an onBuild callback to WidgetToRenderBoxAdapter to make it
easier to do the updates at the right time, i.e., during widget build.
It'll be called whenever you rebuild the WidgetToRenderBoxAdapter
itself, so all you have to do to use it is call setState() on whoever
is building the WidgetToRenderBoxAdapter.
