### PR TITLE
Fix time picker

### DIFF
--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -232,7 +232,7 @@ class PaintingContext {
     } else {
       canvas.saveLayer(bounds.shift(offset), _disableAntialias);
       canvas.clipRRect(clipRRect.shift(offset));
-      painter(this, Offset.zero);
+      painter(this, offset);
       canvas.restore();
     }
   }


### PR DESCRIPTION
We were painting the contents of the RRect clip at the wrong offset. This patch makes RRect match Rect and Path clips.

Fixes #1194
