### PR TITLE
fixes to flutter analyze for the latest dev sdk

### DIFF
--- a/packages/flutter_tools/lib/src/commands/analyze.dart
+++ b/packages/flutter_tools/lib/src/commands/analyze.dart
@@ -265,7 +265,7 @@ class AnalyzeCommand extends FlutterCommand {
 
     List<Pattern> patternsToSkip = <Pattern>[
       'Analyzing [${mainFile.path}]...',
-      new RegExp('^\\[hint\\] Unused import \\(${mainFile.path},'),
+      new RegExp('^\\[(hint|error)\\] Unused import \\(${mainFile.path},'),
       new RegExp(r'^\[.+\] .+ \(.+/\.pub-cache/.+'),
       new RegExp(r'^\[error\] Invalid override\. The type of [^ ]+ \(.+\) is not a subtype of [^ ]+ \(.+\)\.'), // we allow type narrowing
       new RegExp(r'^\[warning\] .+ will need runtime check to cast to type .+'), // https://github.com/dart-lang/sdk/issues/24542
@@ -273,6 +273,7 @@ class AnalyzeCommand extends FlutterCommand {
       new RegExp('^\\[error\\] Target of URI does not exist: \'dart:ui_internals\''), // https://github.com/flutter/flutter/issues/83
       new RegExp(r'\[lint\] Prefer using lowerCamelCase for constant names.'), // sometimes we have no choice (e.g. when matching other platforms)
       new RegExp(r'\[lint\] Avoid defining a one-member abstract class when a simple function will do.'), // too many false-positives; code review should catch real instances
+      new RegExp(r'\[info\] TODO.+'),
       new RegExp(r'[0-9]+ (error|warning|hint|lint).+found\.'),
       new RegExp(r'^$'),
     ];

--- a/packages/flutter_tools/lib/src/commands/daemon.dart
+++ b/packages/flutter_tools/lib/src/commands/daemon.dart
@@ -30,11 +30,7 @@ const String command = 'command';
 /// process).
 class DaemonCommand extends FlutterCommand {
   final String name = 'daemon';
-  final String description =
-      'Run a persistent, JSON-RPC based server to communicate with devices.';
-  final String usageFooter =
-      '\nThis command is intended to be used by tooling environments that need '
-      'a programatic interface into launching Flutter applications.';
+  final String description = 'Run a persistent, JSON-RPC based server to communicate with devices.';
 
   @override
   Future<int> runInProject() async {


### PR DESCRIPTION
Some fixes to `flutter analyze` so it'll work with the dev sdk (we're running the stable one on the bot).
- `Unused import` gets promoted from a hint to an error
- `TODO`s are reported in the issue stream (so we filter them out)
- remove one place where strong mode complains about overriding shadowing superclass fields

```
[error] Field declaration Command.usageFooter cannot be overridden in DaemonCommand. (flutter/packages/flutter_tools/lib/src/commands/daemon.dart, line 35, col 3)
```
