### PR TITLE
don't listen for chromium messages to the adb log

### DIFF
--- a/packages/flutter_tools/lib/src/device.dart
+++ b/packages/flutter_tools/lib/src/device.dart
@@ -852,7 +852,6 @@ class AndroidDevice extends Device {
       'tag', // Only log the tag and the message
       '-s',
       'flutter:V',
-      'chromium:D',
       'ActivityManager:W',
       'System.err:W',
       '*:F',


### PR DESCRIPTION
Don't listen for chromium messages to the adb log - I think this is leftover from when the engine used to log to `chromium`.
