### PR TITLE
Specify that flutter start defaults to checked/default

### DIFF
--- a/packages/flutter_tools/lib/src/commands/start.dart
+++ b/packages/flutter_tools/lib/src/commands/start.dart
@@ -116,7 +116,7 @@ abstract class StartCommandBase extends FlutterCommand {
 
 class StartCommand extends StartCommandBase {
   final String name = 'start';
-  final String description = 'Start your Flutter app on attached devices (Android only).';
+  final String description = 'Start your Flutter app on attached devices (defaults to checked/debug mode) (Android only).';
 
   StartCommand() {
     argParser.addFlag('poke',


### PR DESCRIPTION
Hopefully makes it easier to understand that the default is the "slow" mode.
