### PR TITLE
Stocks has both tabs reified in the wiget tree

### DIFF
--- a/packages/flutter/lib/src/widgets/pageable_list.dart
+++ b/packages/flutter/lib/src/widgets/pageable_list.dart
@@ -225,10 +225,10 @@ class _PageViewportElement extends VirtualViewportElement<PageViewport> {
     return -(widget.startOffset - startOffsetBase) * _containerExtent;
   }
 
-  void updateRenderObject() {
+  void updateRenderObject(PageViewport oldWidget) {
     renderObject.scrollDirection = widget.scrollDirection;
     renderObject.overlayPainter = widget.overlayPainter;
-    super.updateRenderObject();
+    super.updateRenderObject(oldWidget);
   }
 
   double _containerExtent;

--- a/packages/flutter/lib/src/widgets/scrollable_grid.dart
+++ b/packages/flutter/lib/src/widgets/scrollable_grid.dart
@@ -122,9 +122,9 @@ class _GridViewportElement extends VirtualViewportElement<GridViewport> {
   double get startOffsetLimit =>_startOffsetLimit;
   double _startOffsetLimit;
 
-  void updateRenderObject() {
+  void updateRenderObject(GridViewport oldWidget) {
     renderObject.delegate = widget.delegate;
-    super.updateRenderObject();
+    super.updateRenderObject(oldWidget);
   }
 
   double _contentExtent;

--- a/packages/flutter/lib/src/widgets/scrollable_list.dart
+++ b/packages/flutter/lib/src/widgets/scrollable_list.dart
@@ -135,12 +135,12 @@ class _ListViewportElement extends VirtualViewportElement<ListViewport> {
   double get startOffsetLimit =>_startOffsetLimit;
   double _startOffsetLimit;
 
-  void updateRenderObject() {
+  void updateRenderObject(ListViewport oldWidget) {
     renderObject.scrollDirection = widget.scrollDirection;
     renderObject.itemExtent = widget.itemExtent;
     renderObject.padding = widget.padding;
     renderObject.overlayPainter = widget.overlayPainter;
-    super.updateRenderObject();
+    super.updateRenderObject(oldWidget);
   }
 
   double _contentExtent;


### PR DESCRIPTION
We were recomputing which widgets to show only when we were on the other side
of the repaint boundaries. That doesn't work well for pageable lists because we
come to rest exactly on a repaint boundary, which means we don't cull the other
page.

After this patch, we recompute the set of widgets using an edge-trigger when we
hit the boundary. That's better than using a level-trigger so that we don't
continuously recompute the set of widget as we sit at the boundary.
