### PR TITLE
Activity clean-up

### DIFF
--- a/examples/rendering/interactive_flex.dart
+++ b/examples/rendering/interactive_flex.dart
@@ -121,6 +121,6 @@ Pancetta meatball tongue tenderloin rump tail jowl boudin.""";
     child: row
   );
 
-  updateTaskDescription('Interactive Flex', topColor);
+  updateTaskDescription(label: 'Interactive Flex', color: topColor);
   new DemoBinding(root: root);
 }

--- a/packages/flutter/lib/src/services/activity.dart
+++ b/packages/flutter/lib/src/services/activity.dart
@@ -11,7 +11,7 @@ import 'shell.dart';
 
 export 'package:sky_services/activity/activity.mojom.dart';
 
-/// Dart wrapper around Activity mojo service available in Sky on Android.
+/// Dart wrapper around Activity mojo service available in Flutter on Android.
 ///
 /// Most clients will want to use these methods instead of the activity service
 /// directly.
@@ -50,8 +50,10 @@ final PathService pathService = _pathServiceProxy.ptr;
 Color _cachedPrimaryColor;
 String _cachedLabel;
 
-/// Sets the TaskDescription for the current Activity
-void updateTaskDescription(String label, Color color) {
+/// Sets the TaskDescription for the current Activity.
+/// The color, if provided, must be opaque.
+void updateTaskDescription({ String label, Color color }) {
+  assert(color == null || color.alpha == 0xFF);
   if (_cachedPrimaryColor == color && _cachedLabel == label)
     return;
 

--- a/packages/flutter/lib/src/widgets/title.dart
+++ b/packages/flutter/lib/src/widgets/title.dart
@@ -7,7 +7,9 @@ import 'package:flutter/widgets.dart';
 
 /// Controls the description of this app in the operating system.
 class Title extends StatelessComponent {
-  Title({ this.title, this.child, this.color });
+  Title({ this.title, this.child, this.color }) {
+    assert(color == null || color.alpha == 0xFF);
+  }
 
   final Widget child;
 
@@ -18,13 +20,15 @@ class Title extends StatelessComponent {
   final Color color;
 
   Widget build(BuildContext context) {
-    updateTaskDescription(title, color);
+    updateTaskDescription(label: title, color: color);
     return child;
   }
 
   void debugFillDescription(List<String> description) {
     super.debugFillDescription(description);
-    description.add('"$title"');
-    description.add('color: $color');
+    if (title != null)
+      description.add('"$title"');
+    if (color != null)
+      description.add('color: $color');
   }
 }


### PR DESCRIPTION
Turns out Android crashes if the colour is not opaque, so we enforce
that at the Dart level.

Also, since label and colour are both actually optional, make them
named arguments.
