### PR TITLE
Make 'flutter analyze' support analyzing arbitrary files

### DIFF
--- a/packages/flutter_tools/lib/src/runner/flutter_command_runner.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command_runner.dart
@@ -147,9 +147,9 @@ class FlutterCommandRunner extends CommandRunner {
       Logger.root.level = Level.FINE;
 
     _globalResults = globalResults;
-    ArtifactStore.flutterRoot = globalResults['flutter-root'];
+    ArtifactStore.flutterRoot = path.normalize(path.absolute(globalResults['flutter-root']));
     if (globalResults.wasParsed('package-root'))
-      ArtifactStore.packageRoot = globalResults['package-root'];
+      ArtifactStore.packageRoot = path.normalize(path.absolute(globalResults['package-root']));
 
     if (globalResults['version']) {
       print(getVersion(ArtifactStore.flutterRoot));


### PR DESCRIPTION
Before we didn't know how to find the packages of random files. Now we do.
