### PR TITLE
Fix some intrinsic constraints contract violations.

### DIFF
--- a/packages/flutter/lib/src/rendering/box.dart
+++ b/packages/flutter/lib/src/rendering/box.dart
@@ -531,15 +531,30 @@ abstract class RenderBox extends RenderObject {
   /// The box constraints most recently received from the parent.
   BoxConstraints get constraints => super.constraints;
   bool debugDoesMeetConstraints() {
+    assert(!RenderObject.debugInDebugDoesMeetConstraints);
+    RenderObject.debugInDebugDoesMeetConstraints = true;
     assert(constraints != null);
+    // verify that the size is not infinite
     assert(_size != null);
     assert(() {
       'See https://flutter.io/layout/#unbounded-constraints';
       return !_size.isInfinite;
     });
+    // verify that the size is within the constraints
     bool result = constraints.isSatisfiedBy(_size);
     if (!result)
       debugPrint("${this.runtimeType} does not meet its constraints. Constraints: $constraints, size: $_size");
+    // verify that the intrinsics are also within the constraints
+    double intrinsic;
+    intrinsic = getMinIntrinsicWidth(constraints);
+    assert(intrinsic == constraints.constrainWidth(intrinsic));
+    intrinsic = getMaxIntrinsicWidth(constraints);
+    assert(intrinsic == constraints.constrainWidth(intrinsic));
+    intrinsic = getMinIntrinsicHeight(constraints);
+    assert(intrinsic == constraints.constrainHeight(intrinsic));
+    intrinsic = getMaxIntrinsicHeight(constraints);
+    assert(intrinsic == constraints.constrainHeight(intrinsic));
+    RenderObject.debugInDebugDoesMeetConstraints = false;
     return result;
   }
 

--- a/packages/flutter/lib/src/rendering/shifted_box.dart
+++ b/packages/flutter/lib/src/rendering/shifted_box.dart
@@ -110,7 +110,7 @@ class RenderPadding extends RenderShiftedBox {
     assert(constraints.isNormalized);
     double totalPadding = padding.left + padding.right;
     if (child != null)
-      return child.getMinIntrinsicWidth(constraints.deflate(padding)) + totalPadding;
+      return constraints.constrainWidth(child.getMinIntrinsicWidth(constraints.deflate(padding)) + totalPadding);
     return constraints.constrainWidth(totalPadding);
   }
 
@@ -118,7 +118,7 @@ class RenderPadding extends RenderShiftedBox {
     assert(constraints.isNormalized);
     double totalPadding = padding.left + padding.right;
     if (child != null)
-      return child.getMaxIntrinsicWidth(constraints.deflate(padding)) + totalPadding;
+      return constraints.constrainWidth(child.getMaxIntrinsicWidth(constraints.deflate(padding)) + totalPadding);
     return constraints.constrainWidth(totalPadding);
   }
 
@@ -126,7 +126,7 @@ class RenderPadding extends RenderShiftedBox {
     assert(constraints.isNormalized);
     double totalPadding = padding.top + padding.bottom;
     if (child != null)
-      return child.getMinIntrinsicHeight(constraints.deflate(padding)) + totalPadding;
+      return constraints.constrainHeight(child.getMinIntrinsicHeight(constraints.deflate(padding)) + totalPadding);
     return constraints.constrainHeight(totalPadding);
   }
 
@@ -134,7 +134,7 @@ class RenderPadding extends RenderShiftedBox {
     assert(constraints.isNormalized);
     double totalPadding = padding.top + padding.bottom;
     if (child != null)
-      return child.getMaxIntrinsicHeight(constraints.deflate(padding)) + totalPadding;
+      return constraints.constrainHeight(child.getMaxIntrinsicHeight(constraints.deflate(padding)) + totalPadding);
     return constraints.constrainHeight(totalPadding);
   }
 

--- a/packages/flutter/lib/src/rendering/viewport.dart
+++ b/packages/flutter/lib/src/rendering/viewport.dart
@@ -88,28 +88,28 @@ class RenderViewport extends RenderBox with RenderObjectWithChildMixin<RenderBox
   double getMinIntrinsicWidth(BoxConstraints constraints) {
     assert(constraints.isNormalized);
     if (child != null)
-      return child.getMinIntrinsicWidth(_getInnerConstraints(constraints));
+      return constraints.constrainWidth(child.getMinIntrinsicWidth(_getInnerConstraints(constraints)));
     return super.getMinIntrinsicWidth(constraints);
   }
 
   double getMaxIntrinsicWidth(BoxConstraints constraints) {
     assert(constraints.isNormalized);
     if (child != null)
-      return child.getMaxIntrinsicWidth(_getInnerConstraints(constraints));
+      return constraints.constrainWidth(child.getMaxIntrinsicWidth(_getInnerConstraints(constraints)));
     return super.getMaxIntrinsicWidth(constraints);
   }
 
   double getMinIntrinsicHeight(BoxConstraints constraints) {
     assert(constraints.isNormalized);
     if (child != null)
-      return child.getMinIntrinsicHeight(_getInnerConstraints(constraints));
+      return constraints.constrainHeight(child.getMinIntrinsicHeight(_getInnerConstraints(constraints)));
     return super.getMinIntrinsicHeight(constraints);
   }
 
   double getMaxIntrinsicHeight(BoxConstraints constraints) {
     assert(constraints.isNormalized);
     if (child != null)
-      return child.getMaxIntrinsicHeight(_getInnerConstraints(constraints));
+      return constraints.constrainHeight(child.getMaxIntrinsicHeight(_getInnerConstraints(constraints)));
     return super.getMaxIntrinsicHeight(constraints);
   }
 

--- a/packages/flutter/lib/src/widgets/mixed_viewport.dart
+++ b/packages/flutter/lib/src/widgets/mixed_viewport.dart
@@ -156,7 +156,7 @@ class _MixedViewportElement extends RenderObjectElement<MixedViewport> {
       'MixedViewport does not support returning intrinsic dimensions. ' +
       'Calculating the intrinsic dimensions would require walking the entire child list, ' +
       'which defeats the entire point of having a lazily-built list of children.';
-      return false;
+      return RenderObject.debugInDebugDoesMeetConstraints;
     });
     return null;
   }

--- a/packages/flutter/test/rendering/block_test.dart
+++ b/packages/flutter/test/rendering/block_test.dart
@@ -13,6 +13,54 @@ class TestBlockPainter extends Painter {
 }
 
 void main() {
+  test('block intrinsics', () {
+    RenderParagraph paragraph = new RenderParagraph(
+      new StyledTextSpan(
+        new TextStyle(
+          height: 1.0
+        ),
+        <TextSpan>[new PlainTextSpan('Hello World')]
+      )
+    );
+    const BoxConstraints unconstrained = const BoxConstraints();
+    double textWidth = paragraph.getMaxIntrinsicWidth(unconstrained);
+    double oneLineTextHeight = paragraph.getMinIntrinsicHeight(unconstrained);
+    final BoxConstraints constrained = new BoxConstraints(maxWidth: textWidth * 0.9);
+    double wrappedTextWidth = paragraph.getMinIntrinsicWidth(unconstrained);
+    double twoLinesTextHeight = paragraph.getMinIntrinsicHeight(constrained);
+
+    // controls
+    expect(wrappedTextWidth, lessThan(textWidth));
+    expect(paragraph.getMinIntrinsicWidth(unconstrained), equals(wrappedTextWidth));
+    expect(paragraph.getMaxIntrinsicWidth(constrained), equals(constrained.maxWidth));
+
+    expect(oneLineTextHeight, lessThan(twoLinesTextHeight));
+    expect(twoLinesTextHeight, lessThan(oneLineTextHeight * 3.0));
+    expect(paragraph.getMaxIntrinsicHeight(unconstrained), equals(oneLineTextHeight));
+    expect(paragraph.getMaxIntrinsicHeight(constrained), equals(twoLinesTextHeight));
+
+    RenderBox testBlock = new RenderBlock(
+      children: <RenderBox>[
+        paragraph,
+      ]
+    );
+    expect(testBlock.getMinIntrinsicWidth(unconstrained), equals(wrappedTextWidth));
+    expect(testBlock.getMinIntrinsicWidth(constrained), equals(wrappedTextWidth));
+    expect(testBlock.getMaxIntrinsicWidth(unconstrained), equals(textWidth));
+    expect(testBlock.getMaxIntrinsicWidth(constrained), equals(constrained.maxWidth));
+    expect(testBlock.getMinIntrinsicHeight(unconstrained), equals(oneLineTextHeight));
+    expect(testBlock.getMinIntrinsicHeight(constrained), equals(twoLinesTextHeight));
+    expect(testBlock.getMaxIntrinsicHeight(unconstrained), equals(oneLineTextHeight));
+    expect(testBlock.getMaxIntrinsicHeight(constrained), equals(twoLinesTextHeight));
+
+    final BoxConstraints empty = new BoxConstraints.tight(Size.zero);
+    expect(testBlock.getMinIntrinsicWidth(empty), equals(0.0));
+    expect(testBlock.getMaxIntrinsicWidth(empty), equals(0.0));
+    expect(testBlock.getMinIntrinsicHeight(empty), equals(0.0));
+    expect(testBlock.getMaxIntrinsicHeight(empty), equals(0.0));
+  });
+
+
   test('overlay painters can attach and detach', () {
     TestBlockPainter first = new TestBlockPainter();
     TestBlockPainter second = new TestBlockPainter();

--- a/packages/flutter/test/widget/custom_multi_child_layout_test.dart
+++ b/packages/flutter/test/widget/custom_multi_child_layout_test.dart
@@ -11,7 +11,8 @@ class TestMultiChildLayoutDelegate extends MultiChildLayoutDelegate {
   BoxConstraints getSizeConstraints;
 
   Size getSize(BoxConstraints constraints) {
-    getSizeConstraints = constraints;
+    if (!RenderObject.debugInDebugDoesMeetConstraints)
+      getSizeConstraints = constraints;
     return new Size(200.0, 300.0);
   }
 
@@ -22,6 +23,7 @@ class TestMultiChildLayoutDelegate extends MultiChildLayoutDelegate {
   bool performLayoutIsChild;
 
   void performLayout(Size size, BoxConstraints constraints) {
+    assert(!RenderObject.debugInDebugDoesMeetConstraints);
     expect(() {
       performLayoutSize = size;
       performLayoutConstraints = constraints;
@@ -34,6 +36,7 @@ class TestMultiChildLayoutDelegate extends MultiChildLayoutDelegate {
   bool shouldRelayoutCalled = false;
   bool shouldRelayoutValue = false;
   bool shouldRelayout(_) {
+    assert(!RenderObject.debugInDebugDoesMeetConstraints);
     shouldRelayoutCalled = true;
     return shouldRelayoutValue;
   }

--- a/packages/flutter/test/widget/custom_one_child_layout_test.dart
+++ b/packages/flutter/test/widget/custom_one_child_layout_test.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 import 'package:test/test.dart';
 
@@ -13,11 +14,13 @@ class TestOneChildLayoutDelegate extends OneChildLayoutDelegate {
   Size childSizeFromGetPositionForChild;
 
   Size getSize(BoxConstraints constraints) {
-    constraintsFromGetSize = constraints;
+    if (!RenderObject.debugInDebugDoesMeetConstraints)
+      constraintsFromGetSize = constraints;
     return new Size(200.0, 300.0);
   }
 
   BoxConstraints getConstraintsForChild(BoxConstraints constraints) {
+    assert(!RenderObject.debugInDebugDoesMeetConstraints);
     constraintsFromGetConstraintsForChild = constraints;
     return new BoxConstraints(
       minWidth: 100.0,
@@ -28,6 +31,7 @@ class TestOneChildLayoutDelegate extends OneChildLayoutDelegate {
   }
 
   Offset getPositionForChild(Size size, Size childSize) {
+    assert(!RenderObject.debugInDebugDoesMeetConstraints);
     sizeFromGetPositionForChild = size;
     childSizeFromGetPositionForChild = childSize;
     return Offset.zero;
@@ -36,6 +40,7 @@ class TestOneChildLayoutDelegate extends OneChildLayoutDelegate {
   bool shouldRelayoutCalled = false;
   bool shouldRelayoutValue = false;
   bool shouldRelayout(_) {
+    assert(!RenderObject.debugInDebugDoesMeetConstraints);
     shouldRelayoutCalled = true;
     return shouldRelayoutValue;
   }


### PR DESCRIPTION
RenderBlock wasn't constraining the results.
RenderPadding wasn't constraining the results (which matters
especially when the constraints can't fit the padding in the first
place).
RenderViewport wasn't constraining the results.

Add a test for the block case.

To catch this kind of thing in the future, add some asserts to
debugDoesMeetConstraints() that all four intrinsic functions return
values that are within the constraints.

RenderBlockViewport doesn't support returning intrinsics, so turn off
the "no intrinsic support" asserts (and return zero) when we're doing
this new assert.

This new assert screwed up the custom layout classes' tests, so adjust
those tests to ignore the callbacks invoked from these asserts.

Add to the _debugReportException() method a short summary of the
descendants of this node. It's important to have this information when
debugging errors like these intrinsic constraints contract violations
because often nodes just pass the values through to their child so you
have to go several steps down to find the actual problem.

Fixes https://github.com/flutter/flutter/issues/1210
