### PR TITLE
Skip "list of devices" header from adb

### DIFF
--- a/packages/flutter_tools/lib/src/device.dart
+++ b/packages/flutter_tools/lib/src/device.dart
@@ -536,6 +536,9 @@ class AndroidDevice extends Device {
       if (line.startsWith('* daemon '))
         continue;
 
+      if (line.startsWith('List of devices'))
+        continue;
+
       if (deviceRegex1.hasMatch(line)) {
         Match match = deviceRegex1.firstMatch(line);
         String deviceID = match[1];


### PR DESCRIPTION
Sometimes "adb devices" prints a header. We should skip over the header
instead of complaining that we don't recognize it.

Fixes #1293
