### PR TITLE
Better failure when run from non-flutter projects

### DIFF
--- a/packages/.gitignore
+++ b/packages/.gitignore
@@ -6,3 +6,4 @@
 build/
 packages
 pubspec.lock
+.atom/

--- a/packages/flutter_tools/lib/src/artifacts.dart
+++ b/packages/flutter_tools/lib/src/artifacts.dart
@@ -192,6 +192,14 @@ class ArtifactStore {
     }
   }
 
+  static void ensureHasSkyEnginePackage() {
+    Directory skyEnginePackage = new Directory(path.join(packageRoot, 'sky_engine'));
+    if (!skyEnginePackage.existsSync()) {
+      stderr.writeln("Cannot locate the sky_engine package; did you include 'flutter' in your pubspec.yaml file?");
+      throw new ProcessExit(2);
+    }
+  }
+
   static String _engineRevision;
 
   static String get engineRevision {
@@ -274,6 +282,7 @@ class ArtifactStore {
   }
 
   static Directory _getCacheDirForPlatform(String platform) {
+    ensureHasSkyEnginePackage();
     Directory baseDir = _getBaseCacheDir();
     // TODO(jamesr): Add support for more configurations.
     String config = 'Release';

--- a/packages/flutter_tools/lib/src/commands/start.dart
+++ b/packages/flutter_tools/lib/src/commands/start.dart
@@ -144,7 +144,7 @@ class StartCommand extends StartCommandBase {
     await Future.wait([
       downloadToolchain(),
       downloadApplicationPackagesAndConnectToDevices(),
-    ]);
+    ], eagerError: true);
 
     bool poke = argResults['poke'];
     bool clearLogs = argResults['clear-logs'];


### PR DESCRIPTION
When running many flutter commands from a non-flutter project, we throw an exception from the `path` package:

```
Invalid argument(s): join("/home/flutter/bin/cache/artifacts", "sky_engine", null, "Release", "linux-x64"): part 2 was null, but part 3 was not.
severe: 
Exception:
package:path/src/context.dart 925                                 _validateArgList
package:path/src/context.dart 220                                 Context.join
package:path/path.dart 244                                        join
package:flutter_tools/src/artifacts.dart 280                      ArtifactStore._getCacheDirForPlatform
package:flutter_tools/src/artifacts.dart 288                      ArtifactStore.getPath.<async>
dart:async                                                        _Completer.completeError
package:flutter_tools/src/artifacts.dart 300                      ArtifactStore.getPath.<async>
dart:async                                                        Future.Future.microtask
package:flutter_tools/src/artifacts.dart                          ArtifactStore.getPath
package:flutter_tools/src/toolchain.dart 41                       _getCompilerPath.
```

This PR changes the error to:

```
Cannot locate the sky_engine package; did you include 'flutter' in your pubspec.yaml file?
```

And also addresses a problem where errors for `flutter start` could be duplicated to the console.
