### PR TITLE
Move Scaffold over to using AnimationController

### DIFF
--- a/examples/material_gallery/lib/demo/page_selector_demo.dart
+++ b/examples/material_gallery/lib/demo/page_selector_demo.dart
@@ -15,7 +15,7 @@ class PageSelectorDemo extends StatelessComponent {
     CurvedAnimation animation = new CurvedAnimation(parent: selection.animation, curve: Curves.ease);
     return new AnimatedBuilder(
       animation: animation,
-      builder: (BuildContext context) {
+      builder: (BuildContext context, Widget child) {
         Color background = selection.value == iconName ? _selectedColor.end : _selectedColor.begin;
         if (selection.valueIsChanging) {
           // Then the selection's performance is animating from previousValue to value.

--- a/examples/material_gallery/lib/demo/page_selector_demo.dart
+++ b/examples/material_gallery/lib/demo/page_selector_demo.dart
@@ -12,9 +12,9 @@ class PageSelectorDemo extends StatelessComponent {
     final ColorTween _previousColor = new ColorTween(begin: color, end: Colors.transparent);
     final TabBarSelectionState selection = TabBarSelection.of(context);
 
-    Animation animation = new CurvedAnimation(parent: selection.animation, curve: Curves.ease);
-    return new AnimationWatchingBuilder(
-      watchable: animation,
+    CurvedAnimation animation = new CurvedAnimation(parent: selection.animation, curve: Curves.ease);
+    return new AnimatedBuilder(
+      animation: animation,
       builder: (BuildContext context) {
         Color background = selection.value == iconName ? _selectedColor.end : _selectedColor.begin;
         if (selection.valueIsChanging) {

--- a/examples/material_gallery/lib/demo/progress_indicator_demo.dart
+++ b/examples/material_gallery/lib/demo/progress_indicator_demo.dart
@@ -47,7 +47,7 @@ class _ProgressIndicatorDemoState extends State<ProgressIndicatorDemo> {
     controller.play(direction);
   }
 
-  Widget buildIndicators(BuildContext context) {
+  Widget buildIndicators(BuildContext context, Widget child) {
     List<Widget> indicators = <Widget>[
         new SizedBox(
           width: 200.0,

--- a/examples/material_gallery/lib/demo/progress_indicator_demo.dart
+++ b/examples/material_gallery/lib/demo/progress_indicator_demo.dart
@@ -27,7 +27,7 @@ class _ProgressIndicatorDemoState extends State<ProgressIndicatorDemo> {
     });
   }
 
-  Animation animation;
+  Animated<double> animation;
   AnimationController controller;
 
   void handleTap() {
@@ -55,19 +55,19 @@ class _ProgressIndicatorDemoState extends State<ProgressIndicatorDemo> {
         ),
         new LinearProgressIndicator(),
         new LinearProgressIndicator(),
-        new LinearProgressIndicator(value: animation.progress),
+        new LinearProgressIndicator(value: animation.value),
         new CircularProgressIndicator(),
         new SizedBox(
             width: 20.0,
             height: 20.0,
-            child: new CircularProgressIndicator(value: animation.progress)
+            child: new CircularProgressIndicator(value: animation.value)
         ),
         new SizedBox(
           width: 50.0,
           height: 30.0,
-          child: new CircularProgressIndicator(value: animation.progress)
+          child: new CircularProgressIndicator(value: animation.value)
         ),
-        new Text("${(animation.progress * 100.0).toStringAsFixed(1)}%" + (controller.isAnimating ? '' : ' (paused)'))
+        new Text("${(animation.value * 100.0).toStringAsFixed(1)}%" + (controller.isAnimating ? '' : ' (paused)'))
     ];
     return new Column(
       children: indicators
@@ -87,8 +87,8 @@ class _ProgressIndicatorDemoState extends State<ProgressIndicatorDemo> {
           behavior: HitTestBehavior.opaque,
           child: new Container(
             padding: const EdgeDims.symmetric(vertical: 12.0, horizontal: 8.0),
-            child: new AnimationWatchingBuilder(
-              watchable: animation,
+            child: new AnimatedBuilder(
+              animation: animation,
               builder: buildIndicators
             )
           )

--- a/examples/widgets/smooth_resize.dart
+++ b/examples/widgets/smooth_resize.dart
@@ -33,14 +33,14 @@ class CardTransition extends StatelessComponent {
   });
 
   final Widget child;
-  final Animation animation;
+  final Animated<double> animation;
   final Evaluatable<double> x;
   final Evaluatable<double> opacity;
   final Evaluatable<double> scale;
 
   Widget build(BuildContext context) {
-    return new AnimationWatchingBuilder(
-      watchable: animation,
+    return new AnimatedBuilder(
+      animation: animation,
       builder: (BuildContext context) {
         double currentScale = scale.evaluate(animation);
         Matrix4 transform = new Matrix4.identity()
@@ -62,7 +62,7 @@ class SmoothBlockState extends State<SmoothBlock> {
 
   double _height = 100.0;
 
-  Widget _handleEnter(Animation animation, Widget child) {
+  Widget _handleEnter(Animated<double> animation, Widget child) {
     return new CardTransition(
       x: new Tween<double>(begin: -200.0, end: 0.0),
       opacity: new Tween<double>(begin: 0.0, end: 1.0),
@@ -72,7 +72,7 @@ class SmoothBlockState extends State<SmoothBlock> {
     );
   }
 
-  Widget _handleExit(Animation animation, Widget child) {
+  Widget _handleExit(Animated<double> animation, Widget child) {
     return new CardTransition(
       x: new Tween<double>(begin: 0.0, end: 200.0),
       opacity: new Tween<double>(begin: 1.0, end: 0.0),

--- a/examples/widgets/smooth_resize.dart
+++ b/examples/widgets/smooth_resize.dart
@@ -41,7 +41,7 @@ class CardTransition extends StatelessComponent {
   Widget build(BuildContext context) {
     return new AnimatedBuilder(
       animation: animation,
-      builder: (BuildContext context) {
+      builder: (BuildContext context, Widget child) {
         double currentScale = scale.evaluate(animation);
         Matrix4 transform = new Matrix4.identity()
           ..translate(x.evaluate(animation))
@@ -53,7 +53,8 @@ class CardTransition extends StatelessComponent {
             child: child
           )
         );
-      }
+      },
+      child: child
     );
   }
 }

--- a/packages/flutter/lib/animation.dart
+++ b/packages/flutter/lib/animation.dart
@@ -8,6 +8,7 @@
 library animation;
 
 export 'src/animation/animated_value.dart';
+export 'src/animation/animations.dart';
 export 'src/animation/clamped_simulation.dart';
 export 'src/animation/curves.dart';
 export 'src/animation/forces.dart';

--- a/packages/flutter/lib/src/animation/animations.dart
+++ b/packages/flutter/lib/src/animation/animations.dart
@@ -1,0 +1,248 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:ui' show VoidCallback;
+
+import 'animated_value.dart';
+import 'listener_helpers.dart';
+import 'tween.dart';
+
+class AlwaysCompleteAnimation extends Animated<double> {
+  const AlwaysCompleteAnimation();
+
+  // this performance never changes state
+  void addListener(VoidCallback listener) { }
+  void removeListener(VoidCallback listener) { }
+  void addStatusListener(PerformanceStatusListener listener) { }
+  void removeStatusListener(PerformanceStatusListener listener) { }
+  PerformanceStatus get status => PerformanceStatus.completed;
+  AnimationDirection get direction => AnimationDirection.forward;
+  double get value => 1.0;
+}
+
+const AlwaysCompleteAnimation kAlwaysCompleteAnimation = const AlwaysCompleteAnimation();
+
+class AlwaysDismissedAnimation extends Animated<double> {
+  const AlwaysDismissedAnimation();
+
+  // this performance never changes state
+  void addListener(VoidCallback listener) { }
+  void removeListener(VoidCallback listener) { }
+  void addStatusListener(PerformanceStatusListener listener) { }
+  void removeStatusListener(PerformanceStatusListener listener) { }
+  PerformanceStatus get status => PerformanceStatus.dismissed;
+  AnimationDirection get direction => AnimationDirection.forward;
+  double get value => 0.0;
+}
+
+const AlwaysDismissedAnimation kAlwaysDismissedAnimation = const AlwaysDismissedAnimation();
+
+class ProxyAnimation extends Animated<double>
+  with LazyListenerMixin, LocalPerformanceListenersMixin, LocalPerformanceStatusListenersMixin {
+  ProxyAnimation([Animated<double> animation]) {
+    _masterAnimation = animation;
+    if (_masterAnimation == null) {
+      _status = PerformanceStatus.dismissed;
+      _direction = AnimationDirection.forward;
+      _value = 0.0;
+    }
+  }
+
+  PerformanceStatus _status;
+  AnimationDirection _direction;
+  double _value;
+
+  Animated<double> get masterAnimation => _masterAnimation;
+  Animated<double> _masterAnimation;
+  void set masterAnimation(Animated<double> value) {
+    if (value == _masterAnimation)
+      return;
+    if (_masterAnimation != null) {
+      _status = _masterAnimation.status;
+      _direction = _masterAnimation.direction;
+      _value = _masterAnimation.value;
+      if (isListening)
+        didStopListening();
+    }
+    _masterAnimation = value;
+    if (_masterAnimation != null) {
+      if (isListening)
+        didStartListening();
+      if (_value != _masterAnimation.value)
+        notifyListeners();
+      if (_status != _masterAnimation.status)
+        notifyStatusListeners(_masterAnimation.status);
+      _status = null;
+      _direction = null;
+      _value = null;
+    }
+  }
+
+  void didStartListening() {
+    if (_masterAnimation != null) {
+      _masterAnimation.addListener(notifyListeners);
+      _masterAnimation.addStatusListener(notifyStatusListeners);
+    }
+  }
+
+  void didStopListening() {
+    if (_masterAnimation != null) {
+      _masterAnimation.removeListener(notifyListeners);
+      _masterAnimation.removeStatusListener(notifyStatusListeners);
+    }
+  }
+
+  PerformanceStatus get status => _masterAnimation != null ? _masterAnimation.status : _status;
+  AnimationDirection get direction => _masterAnimation != null ? _masterAnimation.direction : _direction;
+  double get value => _masterAnimation != null ? _masterAnimation.value : _value;
+}
+
+class ReverseAnimation extends Animated<double>
+  with LazyListenerMixin, LocalPerformanceStatusListenersMixin {
+  ReverseAnimation(this.masterAnimation);
+
+  final Animated<double> masterAnimation;
+
+  void addListener(VoidCallback listener) {
+    didRegisterListener();
+    masterAnimation.addListener(listener);
+  }
+  void removeListener(VoidCallback listener) {
+    masterAnimation.removeListener(listener);
+    didUnregisterListener();
+  }
+
+  void didStartListening() {
+    masterAnimation.addStatusListener(_statusChangeHandler);
+  }
+
+  void didStopListening() {
+    masterAnimation.removeStatusListener(_statusChangeHandler);
+  }
+
+  void _statusChangeHandler(PerformanceStatus status) {
+    notifyStatusListeners(_reverseStatus(status));
+  }
+
+  PerformanceStatus get status => _reverseStatus(masterAnimation.status);
+  AnimationDirection get direction => _reverseDirection(masterAnimation.direction);
+  double get value => 1.0 - masterAnimation.value;
+
+  PerformanceStatus _reverseStatus(PerformanceStatus status) {
+    switch (status) {
+      case PerformanceStatus.forward: return PerformanceStatus.reverse;
+      case PerformanceStatus.reverse: return PerformanceStatus.forward;
+      case PerformanceStatus.completed: return PerformanceStatus.dismissed;
+      case PerformanceStatus.dismissed: return PerformanceStatus.completed;
+    }
+  }
+
+  AnimationDirection _reverseDirection(AnimationDirection direction) {
+    switch (direction) {
+      case AnimationDirection.forward: return AnimationDirection.reverse;
+      case AnimationDirection.reverse: return AnimationDirection.forward;
+    }
+  }
+}
+
+enum _TrainHoppingMode { minimize, maximize }
+
+/// This animation starts by proxying one animation, but can be given a
+/// second animation. When their times cross (either because the second is
+/// going in the opposite direction, or because the one overtakes the other),
+/// the animation hops over to proxying the second animation, and the second
+/// animation becomes the new "first" performance.
+///
+/// Since this object must track the two animations even when it has no
+/// listeners of its own, instead of shutting down when all its listeners are
+/// removed, it exposes a [dispose()] method. Call this method to shut this
+/// object down.
+class TrainHoppingAnimation extends Animated<double>
+  with EagerListenerMixin, LocalPerformanceListenersMixin, LocalPerformanceStatusListenersMixin {
+  TrainHoppingAnimation(this._currentTrain, this._nextTrain, { this.onSwitchedTrain }) {
+    assert(_currentTrain != null);
+    if (_nextTrain != null) {
+      if (_currentTrain.value > _nextTrain.value) {
+        _mode = _TrainHoppingMode.maximize;
+      } else {
+        _mode = _TrainHoppingMode.minimize;
+        if (_currentTrain.value == _nextTrain.value) {
+          _currentTrain = _nextTrain;
+          _nextTrain = null;
+        }
+      }
+    }
+    _currentTrain.addStatusListener(_statusChangeHandler);
+    _currentTrain.addListener(_valueChangeHandler);
+    if (_nextTrain != null)
+      _nextTrain.addListener(_valueChangeHandler);
+    assert(_mode != null);
+  }
+
+  Animated<double> get currentTrain => _currentTrain;
+  Animated<double> _currentTrain;
+  Animated<double> _nextTrain;
+  _TrainHoppingMode _mode;
+
+  VoidCallback onSwitchedTrain;
+
+  PerformanceStatus _lastStatus;
+  void _statusChangeHandler(PerformanceStatus status) {
+    assert(_currentTrain != null);
+    if (status != _lastStatus) {
+      notifyListeners();
+      _lastStatus = status;
+    }
+    assert(_lastStatus != null);
+  }
+
+  PerformanceStatus get status => _currentTrain.status;
+  AnimationDirection get direction => _currentTrain.direction;
+
+  double _lastValue;
+  void _valueChangeHandler() {
+    assert(_currentTrain != null);
+    bool hop = false;
+    if (_nextTrain != null) {
+      switch (_mode) {
+        case _TrainHoppingMode.minimize:
+          hop = _nextTrain.value <= _currentTrain.value;
+          break;
+        case _TrainHoppingMode.maximize:
+          hop = _nextTrain.value >= _currentTrain.value;
+          break;
+      }
+      if (hop) {
+        _currentTrain.removeStatusListener(_statusChangeHandler);
+        _currentTrain.removeListener(_valueChangeHandler);
+        _currentTrain = _nextTrain;
+        _nextTrain.addListener(_valueChangeHandler);
+        _statusChangeHandler(_nextTrain.status);
+      }
+    }
+    double newValue = value;
+    if (newValue != _lastValue) {
+      notifyListeners();
+      _lastValue = newValue;
+    }
+    assert(_lastValue != null);
+    if (hop && onSwitchedTrain != null)
+      onSwitchedTrain();
+  }
+
+  double get value => _currentTrain.value;
+
+  /// Frees all the resources used by this performance.
+  /// After this is called, this object is no longer usable.
+  void dispose() {
+    assert(_currentTrain != null);
+    _currentTrain.removeStatusListener(_statusChangeHandler);
+    _currentTrain.removeListener(_valueChangeHandler);
+    _currentTrain = null;
+    if (_nextTrain != null) {
+      _nextTrain.removeListener(_valueChangeHandler);
+      _nextTrain = null;
+    }
+  }
+}

--- a/packages/flutter/lib/src/animation/tween.dart
+++ b/packages/flutter/lib/src/animation/tween.dart
@@ -97,7 +97,7 @@ abstract class Evaluatable<T> {
 
   T evaluate(Animated<double> animation);
 
-  Animated<T> watch(Animated<double> parent) {
+  Animated<T> animate(Animated<double> parent) {
     return new _AnimatedEvaluation<T>(parent, this);
   }
 }
@@ -258,7 +258,11 @@ class _RepeatingSimulation extends Simulation {
 }
 
 class CurvedAnimation extends Animated<double> with ProxyAnimatedMixin {
-  CurvedAnimation({ this.parent, this.curve, this.reverseCurve }) {
+  CurvedAnimation({
+    this.parent,
+    this.curve: Curves.linear,
+    this.reverseCurve
+  }) {
     assert(parent != null);
     assert(curve != null);
     parent.addStatusListener(_handleStatusChanged);
@@ -372,4 +376,19 @@ class IntTween extends Tween<int> {
   // The inherited lerp() function doesn't work with ints because it multiplies
   // the begin and end types by a double, and int * double returns a double.
   int lerp(double t) => (begin + (end - begin) * t).round();
+}
+
+class CurveTween extends Evaluatable<double> {
+  CurveTween({ this.curve });
+
+  Curve curve;
+
+  double evaluate(Animated<double> animation) {
+    double t = animation.value;
+    if (t == 0.0 || t == 1.0) {
+      assert(curve.transform(t).round() == t);
+      return t;
+    }
+    return curve.transform(t);
+  }
 }

--- a/packages/flutter/lib/src/material/bottom_sheet.dart
+++ b/packages/flutter/lib/src/material/bottom_sheet.dart
@@ -129,41 +129,17 @@ class _ModalBottomSheet extends StatefulComponent {
 }
 
 class _ModalBottomSheetState extends State<_ModalBottomSheet> {
-  // TODO(abarth): Delete _controllerPerformanceAdaptor when navigator uses
-  // AnimationController and friends.
-  AnimationController _controllerPerformanceAdaptor;
-
-  void initState() {
-    super.initState();
-    _controllerPerformanceAdaptor = new AnimationController();
-    _updateControllerPerformanceAdaptor();
-  }
-
-  void didUpdateConfig(_ModalBottomSheet oldConfig) {
-    if (config.route.performance != oldConfig.route.performance)
-      _updateControllerPerformanceAdaptor();
-  }
-
-  void _updateControllerPerformanceAdaptor() {
-    Performance performance = config.route.performance;
-    _controllerPerformanceAdaptor
-      ..duration = performance.duration
-      ..value = performance.progress;
-    if (performance.isAnimating)
-      _controllerPerformanceAdaptor.play(performance.direction);
-  }
-
   Widget build(BuildContext context) {
     return new GestureDetector(
       onTap: () => Navigator.pop(context),
       child: new AnimatedBuilder(
-        animation: _controllerPerformanceAdaptor,
+        animation: config.route.animation,
         builder: (BuildContext context) {
           return new ClipRect(
             child: new CustomOneChildLayout(
-              delegate: new _ModalBottomSheetLayout(config.route.performance.progress),
+              delegate: new _ModalBottomSheetLayout(config.route.animation.value),
               child: new BottomSheet(
-                animationController: _controllerPerformanceAdaptor,
+                animationController: config.route.animation,
                 onClosing: () => Navigator.pop(context),
                 builder: config.route.builder
               )
@@ -191,7 +167,7 @@ class _ModalBottomSheetRoute<T> extends PopupRoute<T> {
     return BottomSheet.createAnimationController();
   }
 
-  Widget buildPage(BuildContext context, PerformanceView performance, PerformanceView forwardPerformance) {
+  Widget buildPage(BuildContext context, Animated<double> animation, Animated<double> forwardAnimation) {
     return new _ModalBottomSheet(route: this);
   }
 }

--- a/packages/flutter/lib/src/material/bottom_sheet.dart
+++ b/packages/flutter/lib/src/material/bottom_sheet.dart
@@ -134,7 +134,7 @@ class _ModalBottomSheetState extends State<_ModalBottomSheet> {
       onTap: () => Navigator.pop(context),
       child: new AnimatedBuilder(
         animation: config.route.animation,
-        builder: (BuildContext context) {
+        builder: (BuildContext context, Widget child) {
           return new ClipRect(
             child: new CustomOneChildLayout(
               delegate: new _ModalBottomSheetLayout(config.route.animation.value),

--- a/packages/flutter/lib/src/material/dialog.dart
+++ b/packages/flutter/lib/src/material/dialog.dart
@@ -133,7 +133,7 @@ class _DialogRoute<T> extends PopupRoute<T> {
   }
 
   Widget buildTransitions(BuildContext context, PerformanceView performance, PerformanceView forwardPerformance, Widget child) {
-    return new FadeTransition(
+    return new OldFadeTransition(
       performance: performance,
       opacity: new AnimatedValue<double>(0.0, end: 1.0, curve: Curves.easeOut),
       child: child

--- a/packages/flutter/lib/src/material/dialog.dart
+++ b/packages/flutter/lib/src/material/dialog.dart
@@ -128,14 +128,16 @@ class _DialogRoute<T> extends PopupRoute<T> {
   bool get barrierDismissable => true;
   Color get barrierColor => Colors.black54;
 
-  Widget buildPage(BuildContext context, PerformanceView performance, PerformanceView forwardPerformance) {
+  Widget buildPage(BuildContext context, Animated<double> animation, Animated<double> forwardAnimation) {
     return child;
   }
 
-  Widget buildTransitions(BuildContext context, PerformanceView performance, PerformanceView forwardPerformance, Widget child) {
-    return new OldFadeTransition(
-      performance: performance,
-      opacity: new AnimatedValue<double>(0.0, end: 1.0, curve: Curves.easeOut),
+  Widget buildTransitions(BuildContext context, Animated<double> animation, Animated<double> forwardAnimation, Widget child) {
+    return new FadeTransition(
+      opacity: new CurvedAnimation(
+        parent: animation,
+        curve: Curves.easeOut
+      ),
       child: child
     );
   }

--- a/packages/flutter/lib/src/material/dropdown.dart
+++ b/packages/flutter/lib/src/material/dropdown.dart
@@ -87,7 +87,7 @@ class _DropDownMenu<T> extends StatusTransitionComponent {
         final double end = (start + 1.5 * unit).clamp(0.0, 1.0);
         opacity = new AnimatedValue<double>(0.0, end: 1.0, curve: new Interval(start, end), reverseCurve: const Interval(0.75, 1.0));
       }
-      children.add(new FadeTransition(
+      children.add(new OldFadeTransition(
         performance: route.performance,
         opacity: opacity,
         child: new InkWell(
@@ -120,7 +120,7 @@ class _DropDownMenu<T> extends StatusTransitionComponent {
       reverseCurve: const Interval(0.0, 0.001)
     );
 
-    return new FadeTransition(
+    return new OldFadeTransition(
       performance: route.performance,
       opacity: menuOpacity,
       child: new BuilderTransition(

--- a/packages/flutter/lib/src/material/dropdown.dart
+++ b/packages/flutter/lib/src/material/dropdown.dart
@@ -62,7 +62,7 @@ class _DropDownMenu<T> extends StatusTransitionComponent {
   _DropDownMenu({
     Key key,
     _DropDownRoute<T> route
-  }) : route = route, super(key: key, performance: route.performance);
+  }) : route = route, super(key: key, animation: route.animation);
 
   final _DropDownRoute<T> route;
 
@@ -79,16 +79,15 @@ class _DropDownMenu<T> extends StatusTransitionComponent {
     final double unit = 0.5 / (route.items.length + 1.5);
     final List<Widget> children = <Widget>[];
     for (int itemIndex = 0; itemIndex < route.items.length; ++itemIndex) {
-      AnimatedValue<double> opacity;
+      CurvedAnimation opacity;
       if (itemIndex == route.selectedIndex) {
-        opacity = new AnimatedValue<double>(0.0, end: 1.0, curve: const Interval(0.0, 0.001), reverseCurve: const Interval(0.75, 1.0));
+        opacity = new CurvedAnimation(parent: route.animation, curve: const Interval(0.0, 0.001), reverseCurve: const Interval(0.75, 1.0));
       } else {
         final double start = (0.5 + (itemIndex + 1) * unit).clamp(0.0, 1.0);
         final double end = (start + 1.5 * unit).clamp(0.0, 1.0);
-        opacity = new AnimatedValue<double>(0.0, end: 1.0, curve: new Interval(start, end), reverseCurve: const Interval(0.75, 1.0));
+        opacity = new CurvedAnimation(parent: route.animation, curve: new Interval(start, end), reverseCurve: const Interval(0.75, 1.0));
       }
-      children.add(new OldFadeTransition(
-        performance: route.performance,
+      children.add(new FadeTransition(
         opacity: opacity,
         child: new InkWell(
           child: new Container(
@@ -103,42 +102,45 @@ class _DropDownMenu<T> extends StatusTransitionComponent {
       ));
     }
 
-    final AnimatedValue<double> menuOpacity = new AnimatedValue<double>(0.0,
-      end: 1.0,
+    final CurvedAnimation opacity = new CurvedAnimation(
+      parent: route.animation,
       curve: const Interval(0.0, 0.25),
       reverseCurve: const Interval(0.75, 1.0)
     );
 
-    final AnimatedValue<double> menuTop = new AnimatedValue<double>(route.rect.top,
-      end: route.rect.top - route.selectedIndex * route.rect.height,
-      curve: const Interval(0.25, 0.5),
-      reverseCurve: const Interval(0.0, 0.001)
-    );
-    final AnimatedValue<double> menuBottom = new AnimatedValue<double>(route.rect.bottom,
-      end: menuTop.end + route.items.length * route.rect.height,
+    final CurvedAnimation resize = new CurvedAnimation(
+      parent: route.animation,
       curve: const Interval(0.25, 0.5),
       reverseCurve: const Interval(0.0, 0.001)
     );
 
-    return new OldFadeTransition(
-      performance: route.performance,
-      opacity: menuOpacity,
-      child: new BuilderTransition(
-        performance: route.performance,
-        variables: <AnimatedValue<double>>[menuTop, menuBottom],
+    final Tween<double> menuTop = new Tween<double>(
+      begin: route.rect.top,
+      end: route.rect.top - route.selectedIndex * route.rect.height
+    );
+    final Tween<double> menuBottom = new Tween<double>(
+      begin: route.rect.bottom,
+      end: menuTop.end + route.items.length * route.rect.height
+    );
+
+    Widget child = new Material(
+      type: MaterialType.transparency,
+      child: new Block(children)
+    );
+    return new FadeTransition(
+      opacity: opacity,
+      child: new AnimatedBuilder(
+        animation: resize,
         builder: (BuildContext context) {
           return new CustomPaint(
             painter: new _DropDownMenuPainter(
               color: Theme.of(context).canvasColor,
               elevation: route.elevation,
-              menuTop: menuTop.value,
-              menuBottom: menuBottom.value,
+              menuTop: menuTop.evaluate(resize),
+              menuBottom: menuBottom.evaluate(resize),
               renderBox: context.findRenderObject()
             ),
-            child: new Material(
-              type: MaterialType.transparency,
-              child: new Block(children)
-            )
+            child: child
           );
         }
       )
@@ -190,7 +192,7 @@ class _DropDownRoute<T> extends PopupRoute<_DropDownRouteResult<T>> {
     );
   }
 
-  Widget buildPage(BuildContext context, PerformanceView performance, PerformanceView forwardPerformance) {
+  Widget buildPage(BuildContext context, Animated<double> animation, Animated<double> forwardAnimation) {
     return new _DropDownMenu(route: this);
   }
 }

--- a/packages/flutter/lib/src/material/dropdown.dart
+++ b/packages/flutter/lib/src/material/dropdown.dart
@@ -131,7 +131,7 @@ class _DropDownMenu<T> extends StatusTransitionComponent {
       opacity: opacity,
       child: new AnimatedBuilder(
         animation: resize,
-        builder: (BuildContext context) {
+        builder: (BuildContext context, Widget child) {
           return new CustomPaint(
             painter: new _DropDownMenuPainter(
               color: Theme.of(context).canvasColor,
@@ -142,7 +142,8 @@ class _DropDownMenu<T> extends StatusTransitionComponent {
             ),
             child: child
           );
-        }
+        },
+        child: child
       )
     );
   }

--- a/packages/flutter/lib/src/material/floating_action_button.dart
+++ b/packages/flutter/lib/src/material/floating_action_button.dart
@@ -40,20 +40,29 @@ class FloatingActionButton extends StatefulComponent {
 }
 
 class _FloatingActionButtonState extends State<FloatingActionButton> {
-  final Performance _childSegue = new Performance(duration: _kChildSegue);
+  Animated<double> _childSegue;
+  AnimationController _childSegueController;
 
   void initState() {
     super.initState();
-    _childSegue.play();
+    _childSegueController = new AnimationController(duration: _kChildSegue)
+      ..forward();
+    _childSegue = new Tween<double>(
+      begin: -0.125,
+      end: 0.0
+    ).animate(new CurvedAnimation(
+      parent: _childSegueController,
+      curve: _kChildSegueInterval
+    ));
   }
 
   void didUpdateConfig(FloatingActionButton oldConfig) {
     super.didUpdateConfig(oldConfig);
     if (Widget.canUpdate(oldConfig.child, config.child) && config.backgroundColor == oldConfig.backgroundColor)
       return;
-    _childSegue
-      ..progress = 0.0
-      ..play();
+    _childSegueController
+      ..value = 0.0
+      ..forward();
   }
 
   bool _highlight = false;
@@ -87,8 +96,7 @@ class _FloatingActionButtonState extends State<FloatingActionButton> {
             child: new IconTheme(
               data: new IconThemeData(color: iconThemeColor),
               child: new RotationTransition(
-                performance: _childSegue,
-                turns: new AnimatedValue<double>(-0.125, end: 0.0, curve: _kChildSegueInterval),
+                turns: _childSegue,
                 child: config.child
               )
             )

--- a/packages/flutter/lib/src/material/page.dart
+++ b/packages/flutter/lib/src/material/page.dart
@@ -7,31 +7,32 @@ import 'dart:async';
 import 'package:flutter/animation.dart';
 import 'package:flutter/widgets.dart';
 
-class _MaterialPageTransition extends TransitionWithChild {
+class _MaterialPageTransition extends AnimatedComponent {
   _MaterialPageTransition({
     Key key,
-    PerformanceView performance,
-    Widget child
-  }) : super(key: key,
-             performance: performance,
-             child: child);
+    Animated<double> animation,
+    this.child
+  }) : super(
+    key: key,
+    animation: new CurvedAnimation(parent: animation, curve: Curves.easeOut)
+  );
 
-  final AnimatedValue<Point> _position =
-     new AnimatedValue<Point>(const Point(0.0, 75.0), end: Point.origin, curve: Curves.easeOut);
+  final Widget child;
 
-  final AnimatedValue<double> _opacity =
-     new AnimatedValue<double>(0.0, end: 1.0, curve: Curves.easeOut);
+  final Tween<Point> _position = new Tween<Point>(
+    begin: const Point(0.0, 75.0),
+    end: Point.origin
+  );
 
-  Widget buildWithChild(BuildContext context, Widget child) {
-    performance.updateVariable(_position);
-    performance.updateVariable(_opacity);
+  Widget build(BuildContext context) {
+    Point position = _position.evaluate(animation);
     Matrix4 transform = new Matrix4.identity()
-      ..translate(_position.value.x, _position.value.y);
+      ..translate(position.x, position.y);
     return new Transform(
       transform: transform,
       // TODO(ianh): tell the transform to be un-transformed for hit testing
       child: new Opacity(
-        opacity: _opacity.value,
+        opacity: animation.value,
         child: child
       )
     );
@@ -56,7 +57,7 @@ class MaterialPageRoute<T> extends PageRoute<T> {
   Color get barrierColor => null;
   bool canTransitionFrom(TransitionRoute nextRoute) => false;
 
-  Widget buildPage(BuildContext context, PerformanceView performance, PerformanceView forwardPerformance) {
+  Widget buildPage(BuildContext context, Animated<double> animation, Animated<double> forwardAnimation) {
     Widget result = builder(context);
     assert(() {
       if (result == null)
@@ -67,9 +68,9 @@ class MaterialPageRoute<T> extends PageRoute<T> {
     return result;
   }
 
-  Widget buildTransitions(BuildContext context, PerformanceView performance, PerformanceView forwardPerformance, Widget child) {
+  Widget buildTransitions(BuildContext context, Animated<double> animation, Animated<double> forwardAnimation, Widget child) {
     return new _MaterialPageTransition(
-      performance: performance,
+      animation: animation,
       child: child
     );
   }

--- a/packages/flutter/lib/src/material/popup_menu.dart
+++ b/packages/flutter/lib/src/material/popup_menu.dart
@@ -61,7 +61,7 @@ class _PopupMenu<T> extends StatelessComponent {
     for (int i = 0; i < route.items.length; ++i) {
       double start = (i + 1) * unit;
       double end = (start + 1.5 * unit).clamp(0.0, 1.0);
-      children.add(new FadeTransition(
+      children.add(new OldFadeTransition(
         performance: route.performance,
         opacity: new AnimatedValue<double>(0.0, end: 1.0, curve: new Interval(start, end)),
         child: new InkWell(

--- a/packages/flutter/lib/src/material/popup_menu.dart
+++ b/packages/flutter/lib/src/material/popup_menu.dart
@@ -96,7 +96,7 @@ class _PopupMenu<T> extends StatelessComponent {
 
     return new AnimatedBuilder(
       animation: route.animation,
-      builder: (BuildContext context) {
+      builder: (BuildContext context, Widget child) {
         return new Opacity(
           opacity: opacity.evaluate(route.animation),
           child: new Material(
@@ -110,7 +110,8 @@ class _PopupMenu<T> extends StatelessComponent {
             )
           )
         );
-      }
+      },
+      child: child
     );
   }
 }

--- a/packages/flutter/lib/src/material/popup_menu.dart
+++ b/packages/flutter/lib/src/material/popup_menu.dart
@@ -61,9 +61,12 @@ class _PopupMenu<T> extends StatelessComponent {
     for (int i = 0; i < route.items.length; ++i) {
       double start = (i + 1) * unit;
       double end = (start + 1.5 * unit).clamp(0.0, 1.0);
-      children.add(new OldFadeTransition(
-        performance: route.performance,
-        opacity: new AnimatedValue<double>(0.0, end: 1.0, curve: new Interval(start, end)),
+      CurvedAnimation opacity = new CurvedAnimation(
+        parent: route.animation,
+        curve: new Interval(start, end)
+      );
+      children.add(new FadeTransition(
+        opacity: opacity,
         child: new InkWell(
           onTap: () => Navigator.pop(context, route.items[i].value),
           child: route.items[i]
@@ -71,38 +74,39 @@ class _PopupMenu<T> extends StatelessComponent {
       );
     }
 
-    final AnimatedValue<double> opacity = new AnimatedValue<double>(0.0, end: 1.0, curve: new Interval(0.0, 1.0 / 3.0));
-    final AnimatedValue<double> width = new AnimatedValue<double>(0.0, end: 1.0, curve: new Interval(0.0, unit));
-    final AnimatedValue<double> height = new AnimatedValue<double>(0.0, end: 1.0, curve: new Interval(0.0, unit * route.items.length));
+    final CurveTween opacity = new CurveTween(curve: new Interval(0.0, 1.0 / 3.0));
+    final CurveTween width = new CurveTween(curve: new Interval(0.0, unit));
+    final CurveTween height = new CurveTween(curve: new Interval(0.0, unit * route.items.length));
 
-    return new BuilderTransition(
-      performance: route.performance,
-      variables: <AnimatedValue<double>>[opacity, width, height],
+    Widget child = new ConstrainedBox(
+      constraints: new BoxConstraints(
+        minWidth: _kMenuMinWidth,
+        maxWidth: _kMenuMaxWidth
+      ),
+      child: new IntrinsicWidth(
+        stepWidth: _kMenuWidthStep,
+        child: new Block(
+          children,
+          padding: const EdgeDims.symmetric(
+            vertical: _kMenuVerticalPadding
+          )
+        )
+      )
+    );
+
+    return new AnimatedBuilder(
+      animation: route.animation,
       builder: (BuildContext context) {
         return new Opacity(
-          opacity: opacity.value,
+          opacity: opacity.evaluate(route.animation),
           child: new Material(
             type: MaterialType.card,
             elevation: route.elevation,
             child: new Align(
               alignment: const FractionalOffset(1.0, 0.0),
-              widthFactor: width.value,
-              heightFactor: height.value,
-              child: new ConstrainedBox(
-                constraints: new BoxConstraints(
-                  minWidth: _kMenuMinWidth,
-                  maxWidth: _kMenuMaxWidth
-                ),
-                child: new IntrinsicWidth(
-                  stepWidth: _kMenuWidthStep,
-                  child: new Block(
-                    children,
-                    padding: const EdgeDims.symmetric(
-                      vertical: _kMenuVerticalPadding
-                    )
-                  )
-                )
-              )
+              widthFactor: width.evaluate(route.animation),
+              heightFactor: height.evaluate(route.animation),
+              child: child
             )
           )
         );
@@ -127,18 +131,18 @@ class _PopupMenuRoute<T> extends PopupRoute<T> {
     return position;
   }
 
-  PerformanceView createPerformance() {
-    return new CurvedPerformance(
-      super.createPerformance(),
+  Animated<double> createAnimation() {
+    return new CurvedAnimation(
+      parent: super.createAnimation(),
       reverseCurve: new Interval(0.0, _kMenuCloseIntervalEnd)
-     );
+    );
   }
 
   Duration get transitionDuration => _kMenuDuration;
   bool get barrierDismissable => true;
   Color get barrierColor => null;
 
-  Widget buildPage(BuildContext context, PerformanceView performance, PerformanceView forwardPerformance) {
+  Widget buildPage(BuildContext context, Animated<double> animation, Animated<double> forwardAnimation) {
     return new _PopupMenu(route: this);
   }
 }

--- a/packages/flutter/lib/src/material/progress_indicator.dart
+++ b/packages/flutter/lib/src/material/progress_indicator.dart
@@ -63,7 +63,7 @@ class _ProgressIndicatorState extends State<ProgressIndicator> {
 
     return new AnimatedBuilder(
       animation: _animation,
-      builder: (BuildContext context) {
+      builder: (BuildContext context, Widget child) {
         return config._buildIndicator(context, _animation.value);
       }
     );

--- a/packages/flutter/lib/src/material/progress_indicator.dart
+++ b/packages/flutter/lib/src/material/progress_indicator.dart
@@ -27,7 +27,7 @@ abstract class ProgressIndicator extends StatefulComponent {
   Color _getBackgroundColor(BuildContext context) => Theme.of(context).primarySwatch[200];
   Color _getValueColor(BuildContext context) => Theme.of(context).primaryColor;
 
-  Widget _buildIndicator(BuildContext context, double performanceValue);
+  Widget _buildIndicator(BuildContext context, double animationValue);
 
   _ProgressIndicatorState createState() => new _ProgressIndicatorState();
 
@@ -38,36 +38,33 @@ abstract class ProgressIndicator extends StatefulComponent {
 }
 
 class _ProgressIndicatorState extends State<ProgressIndicator> {
-
-  ValuePerformance<double> _performance;
+  Animated<double> _animation;
+  AnimationController _controller;
 
   void initState() {
     super.initState();
-    _performance = new ValuePerformance<double>(
-      variable: new AnimatedValue<double>(0.0, end: 1.0, curve: Curves.ease),
+    _controller = new AnimationController(
       duration: const Duration(milliseconds: 1500)
-    );
-    _performance.addStatusListener((PerformanceStatus status) {
+    )..addStatusListener((PerformanceStatus status) {
       if (status == PerformanceStatus.completed)
         _restartAnimation();
-    });
-    _performance.play();
+    })..forward();
+    _animation = new CurvedAnimation(parent: _controller, curve: Curves.ease);
   }
 
   void _restartAnimation() {
-    _performance.progress = 0.0;
-    _performance.play();
+    _controller.value = 0.0;
+    _controller.forward();
   }
 
   Widget build(BuildContext context) {
     if (config.value != null)
-      return config._buildIndicator(context, _performance.value);
+      return config._buildIndicator(context, _animation.value);
 
-    return new BuilderTransition(
-      variables: <AnimatedValue<double>>[_performance.variable],
-      performance: _performance.view,
+    return new AnimatedBuilder(
+      animation: _animation,
       builder: (BuildContext context) {
-        return config._buildIndicator(context, _performance.value);
+        return config._buildIndicator(context, _animation.value);
       }
     );
   }
@@ -78,13 +75,13 @@ class _LinearProgressIndicatorPainter extends CustomPainter {
     this.backgroundColor,
     this.valueColor,
     this.value,
-    this.performanceValue
+    this.animationValue
   });
 
   final Color backgroundColor;
   final Color valueColor;
   final double value;
-  final double performanceValue;
+  final double animationValue;
 
   void paint(Canvas canvas, Size size) {
     Paint paint = new Paint()
@@ -97,7 +94,7 @@ class _LinearProgressIndicatorPainter extends CustomPainter {
       double width = value.clamp(0.0, 1.0) * size.width;
       canvas.drawRect(Point.origin & new Size(width, size.height), paint);
     } else {
-      double startX = size.width * (1.5 * performanceValue - 0.5);
+      double startX = size.width * (1.5 * animationValue - 0.5);
       double endX = startX + 0.5 * size.width;
       double x = startX.clamp(0.0, size.width);
       double width = endX.clamp(0.0, size.width) - x;
@@ -109,7 +106,7 @@ class _LinearProgressIndicatorPainter extends CustomPainter {
     return oldPainter.backgroundColor != backgroundColor
         || oldPainter.valueColor != valueColor
         || oldPainter.value != value
-        || oldPainter.performanceValue != performanceValue;
+        || oldPainter.animationValue != animationValue;
   }
 }
 
@@ -119,7 +116,7 @@ class LinearProgressIndicator extends ProgressIndicator {
     double value
   }) : super(key: key, value: value);
 
-  Widget _buildIndicator(BuildContext context, double performanceValue) {
+  Widget _buildIndicator(BuildContext context, double animationValue) {
     return new Container(
       constraints: new BoxConstraints.tightFor(
         width: double.INFINITY,
@@ -130,7 +127,7 @@ class LinearProgressIndicator extends ProgressIndicator {
           backgroundColor: _getBackgroundColor(context),
           valueColor: _getValueColor(context),
           value: value,
-          performanceValue: performanceValue
+          animationValue: animationValue
         )
       )
     );
@@ -147,12 +144,12 @@ class _CircularProgressIndicatorPainter extends CustomPainter {
   const _CircularProgressIndicatorPainter({
     this.valueColor,
     this.value,
-    this.performanceValue
+    this.animationValue
   });
 
   final Color valueColor;
   final double value;
-  final double performanceValue;
+  final double animationValue;
 
   void paint(Canvas canvas, Size size) {
     Paint paint = new Paint()
@@ -166,7 +163,7 @@ class _CircularProgressIndicatorPainter extends CustomPainter {
         ..arcTo(Point.origin & size, _kStartAngle, angle, false);
       canvas.drawPath(path, paint);
     } else {
-      double startAngle = _kTwoPI * (1.75 * performanceValue - 0.75);
+      double startAngle = _kTwoPI * (1.75 * animationValue - 0.75);
       double endAngle = startAngle + _kTwoPI * 0.75;
       double arcAngle = startAngle.clamp(0.0, _kTwoPI);
       double arcSweep = endAngle.clamp(0.0, _kTwoPI) - arcAngle;
@@ -179,7 +176,7 @@ class _CircularProgressIndicatorPainter extends CustomPainter {
   bool shouldRepaint(_CircularProgressIndicatorPainter oldPainter) {
     return oldPainter.valueColor != valueColor
         || oldPainter.value != value
-        || oldPainter.performanceValue != performanceValue;
+        || oldPainter.animationValue != animationValue;
   }
 }
 
@@ -189,7 +186,7 @@ class CircularProgressIndicator extends ProgressIndicator {
     double value
   }) : super(key: key, value: value);
 
-  Widget _buildIndicator(BuildContext context, double performanceValue) {
+  Widget _buildIndicator(BuildContext context, double animationValue) {
     return new Container(
       constraints: new BoxConstraints(
         minWidth: _kMinCircularProgressIndicatorSize,
@@ -199,7 +196,7 @@ class CircularProgressIndicator extends ProgressIndicator {
         painter: new _CircularProgressIndicatorPainter(
           valueColor: _getValueColor(context),
           value: value,
-          performanceValue: performanceValue
+          animationValue: animationValue
         )
       )
     );

--- a/packages/flutter/lib/src/material/scaffold.dart
+++ b/packages/flutter/lib/src/material/scaffold.dart
@@ -145,7 +145,7 @@ class _FloatingActionButtonTransitionState extends State<_FloatingActionButtonTr
         scale: new Tween<double>(
           begin: 1.0,
           end: 0.0
-        ).watch(new CurvedAnimation(
+        ).animate(new CurvedAnimation(
           parent: controller,
           curve: const Interval(0.0, 0.5, curve: Curves.easeIn)
         )),

--- a/packages/flutter/lib/src/material/scaffold.dart
+++ b/packages/flutter/lib/src/material/scaffold.dart
@@ -473,20 +473,20 @@ class _PersistentBottomSheetState extends State<_PersistentBottomSheet> {
   }
 
   Widget build(BuildContext context) {
-    Widget child = new BottomSheet(
-      animationController: config.animationController,
-      onClosing: config.onClosing,
-      builder: config.builder
-    );
     return new AnimatedBuilder(
       animation: config.animationController,
-      builder: (BuildContext context) {
+      builder: (BuildContext context, Widget child) {
         return new Align(
           alignment: const FractionalOffset(0.0, 0.0),
           heightFactor: config.animationController.value,
           child: child
         );
-      }
+      },
+      child: new BottomSheet(
+        animationController: config.animationController,
+        onClosing: config.onClosing,
+        builder: config.builder
+      )
     );
   }
 

--- a/packages/flutter/lib/src/material/snack_bar.dart
+++ b/packages/flutter/lib/src/material/snack_bar.dart
@@ -85,38 +85,38 @@ class SnackBar extends StatelessComponent {
     CurvedAnimation heightAnimation = new CurvedAnimation(parent: animation, curve: _snackBarHeightCurve);
     CurvedAnimation fadeAnimation = new CurvedAnimation(parent: animation, curve: _snackBarFadeCurve);
     ThemeData theme = Theme.of(context);
-    Widget child = new Material(
-      elevation: 6,
-      color: _kSnackBackground,
-      child: new Container(
-        margin: const EdgeDims.symmetric(horizontal: _kSideMargins),
-        child: new Theme(
-          data: new ThemeData(
-            brightness: ThemeBrightness.dark,
-            accentColor: theme.accentColor,
-            accentColorBrightness: theme.accentColorBrightness,
-            text: Typography.white
-          ),
-          child: new FadeTransition(
-            opacity: fadeAnimation,
-            child: new Row(
-              children: children,
-              alignItems: FlexAlignItems.center
-            )
-          )
-        )
-      )
-    );
     return new ClipRect(
       child: new AnimatedBuilder(
         animation: heightAnimation,
-        builder: (BuildContext context) {
+        builder: (BuildContext context, Widget child) {
           return new Align(
             alignment: const FractionalOffset(0.0, 0.0),
             heightFactor: heightAnimation.value,
             child: child
           );
-        }
+        },
+        child: new Material(
+          elevation: 6,
+          color: _kSnackBackground,
+          child: new Container(
+            margin: const EdgeDims.symmetric(horizontal: _kSideMargins),
+            child: new Theme(
+              data: new ThemeData(
+                brightness: ThemeBrightness.dark,
+                accentColor: theme.accentColor,
+                accentColorBrightness: theme.accentColorBrightness,
+                text: Typography.white
+              ),
+              child: new FadeTransition(
+                opacity: fadeAnimation,
+                child: new Row(
+                  children: children,
+                  alignItems: FlexAlignItems.center
+                )
+              )
+            )
+          )
+        )
       )
     );
   }

--- a/packages/flutter/lib/src/material/tabs.dart
+++ b/packages/flutter/lib/src/material/tabs.dart
@@ -415,10 +415,10 @@ class TabBarSelection<T> extends StatefulComponent {
 
 class TabBarSelectionState<T> extends State<TabBarSelection<T>> {
 
-  Animation get animation => _controller.view;
+  Animated<double> get animation => _controller.view;
   // Both the TabBar and TabBarView classes access _performance because they
   // alternately drive selection progress between tabs.
-  final AnimationController _controller = new AnimationController(duration: _kTabBarScroll, progress: 1.0);
+  final AnimationController _controller = new AnimationController(duration: _kTabBarScroll, value: 1.0);
   final Map<T, int> _valueToIndex = new Map<T, int>();
 
   void _initValueToIndex() {
@@ -480,22 +480,22 @@ class TabBarSelectionState<T> extends State<TabBarSelection<T>> {
     // one. Convert progress to reflect the fact that we're now moving between (just)
     // the previous and current selection index.
 
-    double progress;
+    double value;
     if (_controller.status == PerformanceStatus.completed)
-      progress = 0.0;
+      value = 0.0;
     else if (_previousValue == values.first)
-      progress = _controller.progress;
+      value = _controller.value;
     else if (_previousValue == values.last)
-      progress = 1.0 - _controller.progress;
+      value = 1.0 - _controller.value;
     else if (previousIndex < index)
-      progress = (_controller.progress - 0.5) * 2.0;
+      value = (_controller.value - 0.5) * 2.0;
     else
-      progress = 1.0 - _controller.progress * 2.0;
+      value = 1.0 - _controller.value * 2.0;
 
     _controller
-      ..progress = progress
+      ..value = value
       ..forward().then((_) {
-        if (_controller.progress == 1.0) {
+        if (_controller.value == 1.0) {
           if (config.onChanged != null)
             config.onChanged(_value);
           _valueIsChanging = false;
@@ -612,7 +612,7 @@ class _TabBarState<T> extends ScrollableState<TabBar<T>> implements TabBarSelect
       _valueIsChanging = true;
     }
     Rect oldRect = _indicatorRect;
-    double t = _selection.animation.progress;
+    double t = _selection.animation.value;
     if (_valueIsChanging) {
       // When _valueIsChanging is true, we're animating based on a ticker and
       // want to curve the animation. When _valueIsChanging is false, we're
@@ -676,9 +676,9 @@ class _TabBarState<T> extends ScrollableState<TabBar<T>> implements TabBarSelect
       labelColor = isSelectedTab ? selectedColor : color;
       if (_selection.valueIsChanging) {
         if (isSelectedTab)
-          labelColor = Color.lerp(color, selectedColor, _selection.animation.progress);
+          labelColor = Color.lerp(color, selectedColor, _selection.animation.value);
         else if (isPreviouslySelectedTab)
-          labelColor = Color.lerp(selectedColor, color, _selection.animation.progress);
+          labelColor = Color.lerp(selectedColor, color, _selection.animation.value);
       }
     }
     return new _Tab(
@@ -876,7 +876,7 @@ class _TabBarViewState extends PageableListState<TabBarView> implements TabBarSe
       return;
     // The TabBar is driving the TabBarSelection performance.
 
-    final Animation animation = _selection.animation;
+    final Animated<double> animation = _selection.animation;
 
     if (animation.status == PerformanceStatus.completed) {
       _updateItemsAndScrollBehavior();
@@ -898,9 +898,9 @@ class _TabBarViewState extends PageableListState<TabBarView> implements TabBarSe
     }
 
     if (_scrollDirection == AnimationDirection.forward)
-      scrollTo(animation.progress);
+      scrollTo(animation.value);
     else
-      scrollTo(1.0 - animation.progress);
+      scrollTo(1.0 - animation.value);
   }
 
   void dispatchOnScroll() {
@@ -911,9 +911,9 @@ class _TabBarViewState extends PageableListState<TabBarView> implements TabBarSe
     final AnimationController controller = _selection._controller;
 
     if (_selection.index == 0 || _selection.index == _tabCount - 1)
-      controller.progress = scrollOffset;
+      controller.value = scrollOffset;
     else
-      controller.progress = scrollOffset / 2.0;
+      controller.value = scrollOffset / 2.0;
   }
 
   Future fling(Offset scrollVelocity) {

--- a/packages/flutter/lib/src/material/tooltip.dart
+++ b/packages/flutter/lib/src/material/tooltip.dart
@@ -71,13 +71,13 @@ class Tooltip extends StatefulComponent {
 
 class _TooltipState extends State<Tooltip> {
 
-  Performance _performance;
+  AnimationController _controller;
   OverlayEntry _entry;
   Timer _timer;
 
   void initState() {
     super.initState();
-    _performance = new Performance(duration: config.fadeDuration)
+    _controller = new AnimationController(duration: config.fadeDuration)
       ..addStatusListener((PerformanceStatus status) {
         switch (status) {
           case PerformanceStatus.completed:
@@ -100,7 +100,7 @@ class _TooltipState extends State<Tooltip> {
   void didUpdateConfig(Tooltip oldConfig) {
     super.didUpdateConfig(oldConfig);
     if (config.fadeDuration != oldConfig.fadeDuration)
-      _performance.duration = config.fadeDuration;
+      _controller.duration = config.fadeDuration;
     if (_entry != null &&
         (config.message != oldConfig.message ||
          config.backgroundColor != oldConfig.backgroundColor ||
@@ -117,7 +117,7 @@ class _TooltipState extends State<Tooltip> {
   }
 
   void resetShowTimer() {
-    assert(_performance.status == PerformanceStatus.completed);
+    assert(_controller.status == PerformanceStatus.completed);
     assert(_entry != null);
     _timer = new Timer(config.showDuration, hideTooltip);
   }
@@ -136,7 +136,10 @@ class _TooltipState extends State<Tooltip> {
           height: config.height,
           padding: config.padding,
           opacity: config.opacity,
-          performance: _performance,
+          animation: new CurvedAnimation(
+            parent: _controller,
+            curve: Curves.ease
+          ),
           target: target,
           verticalOffset: config.verticalOffset,
           screenEdgeMargin: config.screenEdgeMargin,
@@ -146,9 +149,9 @@ class _TooltipState extends State<Tooltip> {
       Overlay.of(context).insert(_entry);
     }
     _timer?.cancel();
-    if (_performance.status != PerformanceStatus.completed) {
+    if (_controller.status != PerformanceStatus.completed) {
       _timer = null;
-      _performance.forward();
+      _controller.forward();
     } else {
       resetShowTimer();
     }
@@ -158,7 +161,7 @@ class _TooltipState extends State<Tooltip> {
     assert(_entry != null);
     _timer?.cancel();
     _timer = null;
-    _performance.reverse();
+    _controller.reverse();
   }
 
   void deactivate() {
@@ -232,7 +235,7 @@ class _TooltipOverlay extends StatelessComponent {
     this.height,
     this.padding,
     this.opacity,
-    this.performance,
+    this.animation,
     this.target,
     this.verticalOffset,
     this.screenEdgeMargin,
@@ -246,7 +249,7 @@ class _TooltipOverlay extends StatelessComponent {
   final double borderRadius;
   final double height;
   final EdgeDims padding;
-  final PerformanceView performance;
+  final Animated<double> animation;
   final Point target;
   final double verticalOffset;
   final EdgeDims screenEdgeMargin;
@@ -266,9 +269,8 @@ class _TooltipOverlay extends StatelessComponent {
             screenEdgeMargin: screenEdgeMargin,
             preferBelow: preferBelow
           ),
-          child: new OldFadeTransition(
-            performance: performance,
-            opacity: new AnimatedValue<double>(0.0, end: 1.0, curve: Curves.ease),
+          child: new FadeTransition(
+            opacity: animation,
             child: new Opacity(
               opacity: opacity,
               child: new Container(

--- a/packages/flutter/lib/src/material/tooltip.dart
+++ b/packages/flutter/lib/src/material/tooltip.dart
@@ -158,7 +158,7 @@ class _TooltipState extends State<Tooltip> {
     assert(_entry != null);
     _timer?.cancel();
     _timer = null;
-    _performance.reverse();    
+    _performance.reverse();
   }
 
   void deactivate() {
@@ -266,7 +266,7 @@ class _TooltipOverlay extends StatelessComponent {
             screenEdgeMargin: screenEdgeMargin,
             preferBelow: preferBelow
           ),
-          child: new FadeTransition(
+          child: new OldFadeTransition(
             performance: performance,
             opacity: new AnimatedValue<double>(0.0, end: 1.0, curve: Curves.ease),
             child: new Opacity(

--- a/packages/flutter/lib/src/widgets/enter_exit_transition.dart
+++ b/packages/flutter/lib/src/widgets/enter_exit_transition.dart
@@ -91,9 +91,9 @@ class _Entry {
   }
 }
 
-typedef Widget TransitionBuilderCallback(Animation animation, Widget child);
+typedef Widget TransitionBuilderCallback(Animated<double> animation, Widget child);
 
-Widget _identityTransition(Animation animation, Widget child) => child;
+Widget _identityTransition(Animated<double> animation, Widget child) => child;
 
 class EnterExitTransition extends StatefulComponent {
   EnterExitTransition({

--- a/packages/flutter/lib/src/widgets/modal_barrier.dart
+++ b/packages/flutter/lib/src/widgets/modal_barrier.dart
@@ -43,38 +43,23 @@ class ModalBarrier extends StatelessComponent {
 }
 
 /// Prevents the user from interacting with widgets behind itself.
-class AnimatedModalBarrier extends StatelessComponent {
+class AnimatedModalBarrier extends AnimatedComponent {
   AnimatedModalBarrier({
     Key key,
-    this.color,
-    this.performance,
+    Animated<Color> color,
     this.dismissable: true
-  }) : super(key: key);
+  }) : color = color, super(key: key, animation: color);
 
   /// If non-null, fill the barrier with this color.
-  ///
-  /// The barrier will animate this color according to the given [performance].
-  final AnimatedColorValue color;
-
-  /// The performance to use when animating the given [color].
-  final PerformanceView performance;
+  final Animated<Color> color;
 
   /// Whether touching the barrier will pop the current route off the [Navigator].
   final bool dismissable;
 
   Widget build(BuildContext context) {
-    return new BuilderTransition(
-      performance: performance,
-      variables: <AnimatedColorValue>[color],
-      builder: (BuildContext context) {
-        return new IgnorePointer(
-          ignoring: performance.status == PerformanceStatus.reverse,
-          child: new ModalBarrier(
-            color: color.value,
-            dismissable: dismissable
-          )
-        );
-      }
+    return new ModalBarrier(
+      color: color.value,
+      dismissable: dismissable
     );
   }
 }

--- a/packages/flutter/lib/src/widgets/pages.dart
+++ b/packages/flutter/lib/src/widgets/pages.dart
@@ -21,11 +21,11 @@ abstract class PageRoute<T> extends ModalRoute<T> {
   bool canTransitionTo(TransitionRoute nextRoute) => nextRoute is PageRoute;
   bool canTransitionFrom(TransitionRoute nextRoute) => nextRoute is PageRoute;
 
-  Performance createPerformanceController() {
-    Performance performance = super.createPerformanceController();
+  AnimationController createAnimationController() {
+    AnimationController controller = super.createAnimationController();
     if (settings.isInitialRoute)
-      performance.progress = 1.0;
-    return performance;
+      controller.value = 1.0;
+    return controller;
   }
 
   /// Subclasses can override this method to customize how heroes are inserted.

--- a/packages/flutter/lib/src/widgets/status_transitions.dart
+++ b/packages/flutter/lib/src/widgets/status_transitions.dart
@@ -9,12 +9,12 @@ import 'framework.dart';
 abstract class StatusTransitionComponent extends StatefulComponent {
   StatusTransitionComponent({
     Key key,
-    this.performance
+    this.animation
   }) : super(key: key) {
-    assert(performance != null);
+    assert(animation != null);
   }
 
-  final PerformanceView performance;
+  final Animated<double> animation;
 
   Widget build(BuildContext context);
 
@@ -24,18 +24,18 @@ abstract class StatusTransitionComponent extends StatefulComponent {
 class _StatusTransitionState extends State<StatusTransitionComponent> {
   void initState() {
     super.initState();
-    config.performance.addStatusListener(_performanceStatusChanged);
+    config.animation.addStatusListener(_performanceStatusChanged);
   }
 
   void didUpdateConfig(StatusTransitionComponent oldConfig) {
-    if (config.performance != oldConfig.performance) {
-      oldConfig.performance.removeStatusListener(_performanceStatusChanged);
-      config.performance.addStatusListener(_performanceStatusChanged);
+    if (config.animation != oldConfig.animation) {
+      oldConfig.animation.removeStatusListener(_performanceStatusChanged);
+      config.animation.addStatusListener(_performanceStatusChanged);
     }
   }
 
   void dispose() {
-    config.performance.removeStatusListener(_performanceStatusChanged);
+    config.animation.removeStatusListener(_performanceStatusChanged);
     super.dispose();
   }
 

--- a/packages/flutter/lib/src/widgets/transitions.dart
+++ b/packages/flutter/lib/src/widgets/transitions.dart
@@ -360,16 +360,20 @@ class BuilderTransition extends TransitionComponent {
   }
 }
 
+typedef Widget TransitionBuilder(BuildContext context, Widget child);
+
 class AnimatedBuilder extends AnimatedComponent {
   AnimatedBuilder({
     Key key,
     Animated<Object> animation,
-    this.builder
+    this.builder,
+    this.child
   }) : super(key: key, animation: animation);
 
-  final WidgetBuilder builder;
+  final TransitionBuilder builder;
+  final Widget child;
 
   Widget build(BuildContext context) {
-    return builder(context);
+    return builder(context, child);
   }
 }

--- a/packages/flutter/lib/src/widgets/transitions.dart
+++ b/packages/flutter/lib/src/widgets/transitions.dart
@@ -170,21 +170,19 @@ class ScaleTransition extends AnimatedComponent {
   }
 }
 
-class RotationTransition extends TransitionWithChild {
+class RotationTransition extends AnimatedComponent {
   RotationTransition({
     Key key,
-    this.turns,
-    PerformanceView performance,
-    Widget child
-  }) : super(key: key,
-             performance: performance,
-             child: child);
+    Animated<double> turns,
+    this.child
+  }) : turns = turns, super(key: key, animation: turns);
 
-  final AnimatedValue<double> turns;
+  final Animated<double> turns;
+  final Widget child;
 
-  Widget buildWithChild(BuildContext context, Widget child) {
-    performance.updateVariable(turns);
-    Matrix4 transform = new Matrix4.rotationZ(turns.value * math.PI * 2.0);
+  Widget build(BuildContext context) {
+    double turnsValue = turns.value;
+    Matrix4 transform = new Matrix4.rotationZ(turnsValue * math.PI * 2.0);
     return new Transform(
       transform: transform,
       alignment: const FractionalOffset(0.5, 0.5),
@@ -307,9 +305,9 @@ class AlignTransition extends TransitionWithChild {
 /// This class specializes the interpolation of AnimatedValue<RelativeRect> to
 /// be appropriate for rectangles that are described in terms of offsets from
 /// other rectangles.
-class AnimatedRelativeRectValue extends AnimatedValue<RelativeRect> {
-  AnimatedRelativeRectValue(RelativeRect begin, { RelativeRect end, Curve curve, Curve reverseCurve })
-    : super(begin, end: end, curve: curve, reverseCurve: reverseCurve);
+class RelativeRectTween extends Tween<RelativeRect> {
+  RelativeRectTween({ RelativeRect begin, RelativeRect end })
+    : super(begin: begin, end: end);
 
   RelativeRect lerp(double t) => RelativeRect.lerp(begin, end, t);
 }
@@ -320,22 +318,19 @@ class AnimatedRelativeRectValue extends AnimatedValue<RelativeRect> {
 /// of the performance.
 ///
 /// Only works if it's the child of a [Stack].
-class PositionedTransition extends TransitionWithChild {
+class PositionedTransition extends AnimatedComponent {
   PositionedTransition({
     Key key,
-    this.rect,
-    PerformanceView performance,
-    Widget child
-  }) : super(key: key,
-             performance: performance,
-             child: child) {
+    Animated<RelativeRect> rect,
+    this.child
+  }) : rect = rect, super(key: key, animation: rect) {
     assert(rect != null);
   }
 
-  final AnimatedRelativeRectValue rect;
+  final Animated<RelativeRect> rect;
+  final Widget child;
 
-  Widget buildWithChild(BuildContext context, Widget child) {
-    performance.updateVariable(rect);
+  Widget build(BuildContext context) {
     return new Positioned(
       top: rect.value.top,
       right: rect.value.right,

--- a/packages/flutter/test/widget/page_forward_transitions_test.dart
+++ b/packages/flutter/test/widget/page_forward_transitions_test.dart
@@ -7,21 +7,22 @@ import 'package:flutter/animation.dart';
 import 'package:flutter/material.dart';
 import 'package:test/test.dart' hide TypeMatcher;
 
-class TestTransition extends TransitionComponent {
+class TestTransition extends AnimatedComponent {
   TestTransition({
     Key key,
     this.childFirstHalf,
     this.childSecondHalf,
-    PerformanceView performance
-  }) : super(key: key, performance: performance) {
-    assert(performance != null);
+    Animated<double> animation
+  }) : super(key: key, animation: animation) {
+    assert(animation != null);
   }
 
   final Widget childFirstHalf;
   final Widget childSecondHalf;
 
   Widget build(BuildContext context) {
-    if (performance.progress >= 0.5)
+    final Animated<double> animation = this.animation;
+    if (animation.value >= 0.5)
       return childSecondHalf;
     return childFirstHalf;
   }
@@ -32,7 +33,7 @@ class TestRoute<T> extends PageRoute<T> {
   final Widget child;
   Duration get transitionDuration => kMaterialPageRouteTransitionDuration;
   Color get barrierColor => null;
-  Widget buildPage(BuildContext context, PerformanceView performance, PerformanceView forwardPerformance) {
+  Widget buildPage(BuildContext context, Animated<double> animation, Animated<double> forwardAnimation) {
     return child;
   }
 }
@@ -81,12 +82,12 @@ void main() {
                           new TestTransition(
                             childFirstHalf: new Text('A'),
                             childSecondHalf: new Text('B'),
-                            performance: route.performance
+                            animation: route.animation
                           ),
                           new TestTransition(
                             childFirstHalf: new Text('C'),
                             childSecondHalf: new Text('D'),
-                            performance: route.forwardPerformance
+                            animation: route.forwardAnimation
                           ),
                         ]
                       );

--- a/packages/flutter/test/widget/positioned_test.dart
+++ b/packages/flutter/test/widget/positioned_test.dart
@@ -13,18 +13,17 @@ void main() {
   test('Can animate position data', () {
     testWidgets((WidgetTester tester) {
 
-      final AnimatedRelativeRectValue rect = new AnimatedRelativeRectValue(
-        new RelativeRect.fromRect(
+      final RelativeRectTween rect = new RelativeRectTween(
+        begin: new RelativeRect.fromRect(
           new Rect.fromLTRB(10.0, 20.0, 20.0, 30.0),
           new Rect.fromLTRB(0.0, 10.0, 100.0, 110.0)
         ),
         end: new RelativeRect.fromRect(
           new Rect.fromLTRB(80.0, 90.0, 90.0, 100.0),
           new Rect.fromLTRB(0.0, 10.0, 100.0, 110.0)
-        ),
-        curve: Curves.linear
+        )
       );
-      final Performance performance = new Performance(
+      final AnimationController controller = new AnimationController(
         duration: const Duration(seconds: 10)
       );
       final List<Size> sizes = <Size>[];
@@ -46,8 +45,7 @@ void main() {
             child: new Stack(
               children: <Widget>[
                 new PositionedTransition(
-                  rect: rect,
-                  performance: performance,
+                  rect: rect.animate(controller),
                   child: new Container(
                     key: key
                   )
@@ -58,7 +56,7 @@ void main() {
         )
       ); // t=0
       recordMetrics();
-      performance.play();
+      controller.forward();
       tester.pump(); // t=0 again
       recordMetrics();
       tester.pump(const Duration(seconds: 1)); // t=1


### PR DESCRIPTION
Also, clean up the class hierarchy for AnimationController now that
we've renamed progress to value. That means everything in the hierarchy
now has a value, include Watchable. This patch renames Watchable to
Animated<T>, which lets us use that type almost everywhere.

I've added some ducktape to modal bottom sheets to avoid having to
refactor all of Navigator to use AnimationController. I'll remove the
ducktape in the next patch.
