### PR TITLE
name and grammar tweaks

### DIFF
--- a/packages/flutter_tools/lib/src/artifacts.dart
+++ b/packages/flutter_tools/lib/src/artifacts.dart
@@ -8,10 +8,10 @@ import 'dart:io';
 import 'package:archive/archive.dart';
 import 'package:path/path.dart' as path;
 
-import 'build_configuration.dart';
+import 'base/logging.dart';
 import 'base/os.dart';
 import 'base/process.dart';
-import 'base/logging.dart';
+import 'build_configuration.dart';
 
 String _getNameForHostPlatform(HostPlatform platform) {
   switch (platform) {

--- a/packages/flutter_tools/lib/src/commands/ios.dart
+++ b/packages/flutter_tools/lib/src/commands/ios.dart
@@ -7,14 +7,13 @@ import "dart:io";
 
 import "package:path/path.dart" as path;
 
-import "../runner/flutter_command_runner.dart";
-import "../runner/flutter_command.dart";
 import "../artifacts.dart";
+import "../runner/flutter_command.dart";
+import "../runner/flutter_command_runner.dart";
 
 class IOSCommand extends FlutterCommand {
   final String name = "ios";
-
-  final String description = "Commands for creating and updating Flutter iOS projects";
+  final String description = "Commands for creating and updating Flutter iOS projects.";
 
   final bool requiresProjectRoot = true;
 

--- a/packages/flutter_tools/lib/src/commands/logs.dart
+++ b/packages/flutter_tools/lib/src/commands/logs.dart
@@ -9,7 +9,7 @@ import '../runner/flutter_command.dart';
 
 class LogsCommand extends FlutterCommand {
   final String name = 'logs';
-  final String description = 'Show logs for running Sky apps.';
+  final String description = 'Show logs for running Flutter apps.';
 
   LogsCommand() {
     argParser.addFlag('clear',

--- a/packages/flutter_tools/lib/src/toolchain.dart
+++ b/packages/flutter_tools/lib/src/toolchain.dart
@@ -8,8 +8,8 @@ import 'dart:io';
 import 'package:path/path.dart' as path;
 
 import 'artifacts.dart';
-import 'build_configuration.dart';
 import 'base/process.dart';
+import 'build_configuration.dart';
 
 class Compiler {
   Compiler(this._path);

--- a/packages/flutter_tools/test/daemon_test.dart
+++ b/packages/flutter_tools/test/daemon_test.dart
@@ -4,8 +4,8 @@
 
 import 'dart:async';
 
-import 'package:mockito/mockito.dart';
 import 'package:flutter_tools/src/commands/daemon.dart';
+import 'package:mockito/mockito.dart';
 import 'package:test/test.dart';
 
 import 'src/mocks.dart';


### PR DESCRIPTION
- terminate a command description with a period (to match the other commands)
- sort some directives
- rename one `Sky` instance to `Flutter`
