### PR TITLE
Add an option to populate for printing cache paths

### DIFF
--- a/packages/flutter_tools/lib/src/artifacts.dart
+++ b/packages/flutter_tools/lib/src/artifacts.dart
@@ -312,7 +312,7 @@ class ArtifactStore {
     cacheDir.deleteSync(recursive: true);
   }
 
-  static Future populate() {
+  static Future<List<String>> populate() {
     return Future.wait(knownArtifacts.map((artifact) => getPath(artifact)));
   }
 }

--- a/packages/flutter_tools/lib/src/commands/cache.dart
+++ b/packages/flutter_tools/lib/src/commands/cache.dart
@@ -32,9 +32,19 @@ class _PopulateCommand extends Command {
   final String name = 'populate';
   final String description = 'Populates the cache with all known artifacts.';
 
+  _PopulateCommand() {
+    // ArtifactStore would require refactoring to make list a separate command.
+    argParser.addFlag('list', help: 'List cache contents after populating.');
+  }
+
   @override
   Future<int> run() async {
-    await ArtifactStore.populate();
+    List<String> paths = await ArtifactStore.populate();
+    if (argResults['list']) {
+      for (String path in paths) {
+        print(path);
+      }
+    }
     return 0;
   }
 }


### PR DESCRIPTION
This makes it easy to find the path to the cached sky_engine, etc.

Working on making on-host benchmarking easier.  I'll likely
add a flutter command for executing things on-host as well as
make benchmarking work on device.  This is just a stopgap for
simplifying benchmarking solutions in the meanwhile.

@abarth
