### PR TITLE
refactor build command into two files

### DIFF
--- a/packages/flutter_tools/lib/src/commands/apk.dart
+++ b/packages/flutter_tools/lib/src/commands/apk.dart
@@ -13,8 +13,8 @@ import '../base/logging.dart';
 import '../base/process.dart';
 import '../build_configuration.dart';
 import '../device.dart';
+import '../flx.dart' as flx;
 import '../runner/flutter_command.dart';
-import 'build.dart';
 import 'start.dart';
 
 const String _kDefaultAndroidManifestPath = 'apk/AndroidManifest.xml';
@@ -305,10 +305,9 @@ class ApkCommand extends FlutterCommand {
       String mainPath = StartCommandBase.findMainDartFile(argResults['target']);
 
       // Build the FLX.
-      BuildCommand builder = new BuildCommand();
-      builder.inheritFromParent(this);
       int result;
-      await builder.buildInTempDir(
+      await flx.buildInTempDir(
+        toolchain,
         mainPath: mainPath,
         onBundleAvailable: (String localBundlePath) {
           result = _buildApk(components, localBundlePath);

--- a/packages/flutter_tools/lib/src/commands/build.dart
+++ b/packages/flutter_tools/lib/src/commands/build.dart
@@ -3,117 +3,11 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:io';
-import 'dart:typed_data';
 
-import 'package:archive/archive.dart';
-import 'package:flx/bundle.dart';
-import 'package:flx/signing.dart';
-import 'package:path/path.dart' as path;
-import 'package:yaml/yaml.dart';
-
-import '../base/file_system.dart';
 import '../base/logging.dart';
+import '../flx.dart';
 import '../runner/flutter_command.dart';
 import '../toolchain.dart';
-
-const String _kSnapshotKey = 'snapshot_blob.bin';
-const List<String> _kDensities = const ['drawable-xxhdpi'];
-const List<String> _kThemes = const ['white', 'black'];
-const List<int> _kSizes = const [18, 24, 36, 48];
-
-class _Asset {
-  final String base;
-  final String key;
-
-  _Asset({ this.base, this.key });
-}
-
-Iterable<_Asset> _parseAssets(Map manifestDescriptor, String manifestPath) sync* {
-  if (manifestDescriptor == null || !manifestDescriptor.containsKey('assets'))
-    return;
-  String basePath = path.dirname(path.absolute(manifestPath));
-  for (String asset in manifestDescriptor['assets'])
-    yield new _Asset(base: basePath, key: asset);
-}
-
-class _MaterialAsset {
-  final String name;
-  final String density;
-  final String theme;
-  final int size;
-
-  _MaterialAsset(Map descriptor)
-    : name = descriptor['name'],
-      density = descriptor['density'],
-      theme = descriptor['theme'],
-      size = descriptor['size'];
-
-  String get key {
-    List<String> parts = name.split('/');
-    String category = parts[0];
-    String subtype = parts[1];
-    return '$category/$density/ic_${subtype}_${theme}_${size}dp.png';
-  }
-}
-
-List _generateValues(Map assetDescriptor, String key, List defaults) {
-  if (assetDescriptor.containsKey(key))
-    return [assetDescriptor[key]];
-  return defaults;
-}
-
-Iterable<_MaterialAsset> _generateMaterialAssets(Map assetDescriptor) sync* {
-  Map currentAssetDescriptor = new Map.from(assetDescriptor);
-  for (String density in _generateValues(assetDescriptor, 'density', _kDensities)) {
-    currentAssetDescriptor['density'] = density;
-    for (String theme in _generateValues(assetDescriptor, 'theme', _kThemes)) {
-      currentAssetDescriptor['theme'] = theme;
-      for (int size in _generateValues(assetDescriptor, 'size', _kSizes)) {
-        currentAssetDescriptor['size'] = size;
-        yield new _MaterialAsset(currentAssetDescriptor);
-      }
-    }
-  }
-}
-
-Iterable<_MaterialAsset> _parseMaterialAssets(Map manifestDescriptor) sync* {
-  if (manifestDescriptor == null || !manifestDescriptor.containsKey('material-design-icons'))
-    return;
-  for (Map assetDescriptor in manifestDescriptor['material-design-icons']) {
-    for (_MaterialAsset asset in _generateMaterialAssets(assetDescriptor)) {
-      yield asset;
-    }
-  }
-}
-
-dynamic _loadManifest(String manifestPath) {
-  if (manifestPath == null || !FileSystemEntity.isFileSync(manifestPath))
-    return null;
-  String manifestDescriptor = new File(manifestPath).readAsStringSync();
-  return loadYaml(manifestDescriptor);
-}
-
-ArchiveFile _createFile(String key, String assetBase) {
-  File file = new File('$assetBase/$key');
-  if (!file.existsSync())
-    return null;
-  List<int> content = file.readAsBytesSync();
-  return new ArchiveFile.noCompress(key, content.length, content);
-}
-
-ArchiveFile _createSnapshotFile(String snapshotPath) {
-  File file = new File(snapshotPath);
-  List<int> content = file.readAsBytesSync();
-  return new ArchiveFile(_kSnapshotKey, content.length, content);
-}
-
-const String _kDefaultAssetBase = 'packages/material_design_icons/icons';
-const String _kDefaultMainPath = 'lib/main.dart';
-const String _kDefaultManifestPath = 'flutter.yaml';
-const String _kDefaultOutputPath = 'build/app.flx';
-const String _kDefaultSnapshotPath = 'build/snapshot_blob.bin';
-const String _kDefaultPrivateKeyPath = 'privatekey.der';
 
 class BuildCommand extends FlutterCommand {
   final String name = 'build';
@@ -121,16 +15,15 @@ class BuildCommand extends FlutterCommand {
 
   BuildCommand() {
     argParser.addFlag('precompiled', negatable: false);
-    argParser.addOption('asset-base', defaultsTo: _kDefaultAssetBase);
+    argParser.addOption('asset-base', defaultsTo: defaultAssetBase);
     argParser.addOption('compiler');
-    argParser.addOption('main', defaultsTo: _kDefaultMainPath);
-    argParser.addOption('manifest', defaultsTo: _kDefaultManifestPath);
-    argParser.addOption('private-key', defaultsTo: _kDefaultPrivateKeyPath);
-    argParser.addOption('output-file', abbr: 'o', defaultsTo: _kDefaultOutputPath);
-    argParser.addOption('snapshot', defaultsTo: _kDefaultSnapshotPath);
+    argParser.addOption('main', defaultsTo: defaultMainPath);
+    argParser.addOption('manifest', defaultsTo: defaultManifestPath);
+    argParser.addOption('private-key', defaultsTo: defaultPrivateKeyPath);
+    argParser.addOption('output-file', abbr: 'o', defaultsTo: defaultFlxOutputPath);
+    argParser.addOption('snapshot', defaultsTo: defaultSnapshotPath);
   }
 
-  @override
   Future<int> runInProject() async {
     String compilerPath = argResults['compiler'];
 
@@ -139,98 +32,23 @@ class BuildCommand extends FlutterCommand {
     else
       toolchain = new Toolchain(compiler: new Compiler(compilerPath));
 
+    String outputPath = argResults['output-file'];
+
     return await build(
+      toolchain,
       assetBase: argResults['asset-base'],
       mainPath: argResults['main'],
       manifestPath: argResults['manifest'],
-      outputPath: argResults['output-file'],
+      outputPath: outputPath,
       snapshotPath: argResults['snapshot'],
       privateKeyPath: argResults['private-key'],
       precompiledSnapshot: argResults['precompiled']
-    );
-  }
-
-  Future<int> buildInTempDir({
-    String mainPath: _kDefaultMainPath,
-    void onBundleAvailable(String bundlePath)
-  }) async {
-    int result;
-    Directory tempDir = await Directory.systemTemp.createTemp('flutter_tools');
-    try {
-      String localBundlePath = path.join(tempDir.path, 'app.flx');
-      String localSnapshotPath = path.join(tempDir.path, 'snapshot_blob.bin');
-      result = await build(
-        snapshotPath: localSnapshotPath,
-        outputPath: localBundlePath,
-        mainPath: mainPath
-      );
+    ).then((int result) {
       if (result == 0)
-        onBundleAvailable(localBundlePath);
-    } finally {
-      tempDir.deleteSync(recursive: true);
-    }
-    return result;
-  }
-
-  Future<int> build({
-    String assetBase: _kDefaultAssetBase,
-    String mainPath: _kDefaultMainPath,
-    String manifestPath: _kDefaultManifestPath,
-    String outputPath: _kDefaultOutputPath,
-    String snapshotPath: _kDefaultSnapshotPath,
-    String privateKeyPath: _kDefaultPrivateKeyPath,
-    bool precompiledSnapshot: false
-  }) async {
-    logging.fine('Building $outputPath');
-
-    Map manifestDescriptor = _loadManifest(manifestPath);
-
-    Iterable<_Asset> assets = _parseAssets(manifestDescriptor, manifestPath);
-    Iterable<_MaterialAsset> materialAssets = _parseMaterialAssets(manifestDescriptor);
-
-    Archive archive = new Archive();
-
-    if (!precompiledSnapshot) {
-      ensureDirectoryExists(snapshotPath);
-
-      // In a precompiled snapshot, the instruction buffer contains script
-      // content equivalents
-      int result = await toolchain.compiler.compile(mainPath: mainPath, snapshotPath: snapshotPath);
-      if (result != 0) {
-        logging.severe('Failed to run the Flutter compiler. Exit code: $result');
-        return result;
-      }
-
-      archive.addFile(_createSnapshotFile(snapshotPath));
-    }
-
-    for (_Asset asset in assets) {
-      ArchiveFile file = _createFile(asset.key, asset.base);
-      if (file == null) {
-        stderr.writeln('Cannot find asset "${asset.key}" in directory "${path.absolute(asset.base)}".');
-        return 1;
-      }
-      archive.addFile(file);
-    }
-
-    for (_MaterialAsset asset in materialAssets) {
-      ArchiveFile file = _createFile(asset.key, assetBase);
-      if (file != null)
-        archive.addFile(file);
-    }
-
-    await CipherParameters.get().seedRandom();
-
-    AsymmetricKeyPair keyPair = keyPairFromPrivateKeyFileSync(privateKeyPath);
-    Uint8List zipBytes = new Uint8List.fromList(new ZipEncoder().encode(archive));
-    ensureDirectoryExists(outputPath);
-    Bundle bundle = new Bundle.fromContent(
-      path: outputPath,
-      manifest: manifestDescriptor,
-      contentBytes: zipBytes,
-      keyPair: keyPair
-    );
-    bundle.writeSync();
-    return 0;
+        print('Built $outputPath.');
+      else
+        logging.severe('Error building $outputPath: $result.');
+      return result;
+    });
   }
 }

--- a/packages/flutter_tools/lib/src/commands/list.dart
+++ b/packages/flutter_tools/lib/src/commands/list.dart
@@ -49,9 +49,9 @@ class ListCommand extends FlutterCommand {
       }
     }
 
-    if (details) {
+    if (details)
       print('iOS Simulators:');
-    }
+
     for (IOSSimulator device in IOSSimulator.getAttachedDevices(devices.iOSSimulator)) {
       if (details) {
         print('${device.id}\t${device.name}');

--- a/packages/flutter_tools/lib/src/commands/run_mojo.dart
+++ b/packages/flutter_tools/lib/src/commands/run_mojo.dart
@@ -12,8 +12,8 @@ import '../artifacts.dart';
 import '../base/logging.dart';
 import '../base/process.dart';
 import '../build_configuration.dart';
+import '../flx.dart' as flx;
 import '../runner/flutter_command.dart';
-import 'build.dart';
 import 'start.dart';
 
 const String _kDefaultBundlePath = 'build/app.flx';
@@ -156,9 +156,11 @@ class RunMojoCommand extends FlutterCommand {
 
       String mainPath = StartCommandBase.findMainDartFile(argResults['target']);
 
-      BuildCommand builder = new BuildCommand();
-      builder.inheritFromParent(this);
-      int result = await builder.build(mainPath: mainPath, outputPath: bundlePath);
+      int result = await flx.build(
+        toolchain,
+        mainPath: mainPath,
+        outputPath: bundlePath
+      );
       if (result != 0)
         return result;
     }

--- a/packages/flutter_tools/lib/src/commands/start.dart
+++ b/packages/flutter_tools/lib/src/commands/start.dart
@@ -11,8 +11,8 @@ import '../application_package.dart';
 import '../base/logging.dart';
 import '../build_configuration.dart';
 import '../device.dart';
+import '../flx.dart' as flx;
 import '../runner/flutter_command.dart';
-import 'build.dart';
 import 'install.dart';
 import 'stop.dart';
 
@@ -87,21 +87,22 @@ abstract class StartCommandBase extends FlutterCommand {
       logging.fine('Running build command for $device.');
 
       if (device.platform == TargetPlatform.android) {
-        BuildCommand builder = new BuildCommand();
-        builder.inheritFromParent(this);
-        await builder.buildInTempDir(
-            mainPath: mainPath,
-            onBundleAvailable: (String localBundlePath) {
-              logging.fine('Starting bundle for $device.');
-              final AndroidDevice androidDevice = device; // https://github.com/flutter/flutter/issues/1035
-              if (androidDevice.startBundle(package, localBundlePath,
-                  poke: poke,
-                  checked: argResults['checked'],
-                  traceStartup: argResults['trace-startup'],
-                  route: argResults['route'],
-                  clearLogs: clearLogs))
-                startedSomething = true;
+        await flx.buildInTempDir(
+          toolchain,
+          mainPath: mainPath,
+          onBundleAvailable: (String localBundlePath) {
+            logging.fine('Starting bundle for $device.');
+            final AndroidDevice androidDevice = device; // https://github.com/flutter/flutter/issues/1035
+            if (androidDevice.startBundle(package, localBundlePath,
+              poke: poke,
+              checked: argResults['checked'],
+              traceStartup: argResults['trace-startup'],
+              route: argResults['route'],
+              clearLogs: clearLogs
+            )) {
+              startedSomething = true;
             }
+          }
         );
       } else {
         bool result = await device.startApp(package);

--- a/packages/flutter_tools/lib/src/flx.dart
+++ b/packages/flutter_tools/lib/src/flx.dart
@@ -1,0 +1,202 @@
+// Copyright 2015 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:archive/archive.dart';
+import 'package:flx/bundle.dart';
+import 'package:flx/signing.dart';
+import 'package:path/path.dart' as path;
+import 'package:yaml/yaml.dart';
+
+import 'base/file_system.dart';
+import 'base/logging.dart';
+import 'toolchain.dart';
+
+const String defaultMainPath = 'lib/main.dart';
+const String defaultAssetBase = 'packages/material_design_icons/icons';
+const String defaultManifestPath = 'flutter.yaml';
+const String defaultFlxOutputPath = 'build/app.flx';
+const String defaultSnapshotPath = 'build/snapshot_blob.bin';
+const String defaultPrivateKeyPath = 'privatekey.der';
+
+const String _kSnapshotKey = 'snapshot_blob.bin';
+const List<String> _kDensities = const ['drawable-xxhdpi'];
+const List<String> _kThemes = const ['white', 'black'];
+const List<int> _kSizes = const [18, 24, 36, 48];
+
+class _Asset {
+  final String base;
+  final String key;
+
+  _Asset({ this.base, this.key });
+}
+
+Iterable<_Asset> _parseAssets(Map manifestDescriptor, String manifestPath) sync* {
+  if (manifestDescriptor == null || !manifestDescriptor.containsKey('assets'))
+    return;
+  String basePath = path.dirname(path.absolute(manifestPath));
+  for (String asset in manifestDescriptor['assets'])
+    yield new _Asset(base: basePath, key: asset);
+}
+
+class _MaterialAsset {
+  final String name;
+  final String density;
+  final String theme;
+  final int size;
+
+  _MaterialAsset(Map descriptor)
+    : name = descriptor['name'],
+      density = descriptor['density'],
+      theme = descriptor['theme'],
+      size = descriptor['size'];
+
+  String get key {
+    List<String> parts = name.split('/');
+    String category = parts[0];
+    String subtype = parts[1];
+    return '$category/$density/ic_${subtype}_${theme}_${size}dp.png';
+  }
+}
+
+List _generateValues(Map assetDescriptor, String key, List defaults) {
+  if (assetDescriptor.containsKey(key))
+    return [assetDescriptor[key]];
+  return defaults;
+}
+
+Iterable<_MaterialAsset> _generateMaterialAssets(Map assetDescriptor) sync* {
+  Map currentAssetDescriptor = new Map.from(assetDescriptor);
+  for (String density in _generateValues(assetDescriptor, 'density', _kDensities)) {
+    currentAssetDescriptor['density'] = density;
+    for (String theme in _generateValues(assetDescriptor, 'theme', _kThemes)) {
+      currentAssetDescriptor['theme'] = theme;
+      for (int size in _generateValues(assetDescriptor, 'size', _kSizes)) {
+        currentAssetDescriptor['size'] = size;
+        yield new _MaterialAsset(currentAssetDescriptor);
+      }
+    }
+  }
+}
+
+Iterable<_MaterialAsset> _parseMaterialAssets(Map manifestDescriptor) sync* {
+  if (manifestDescriptor == null || !manifestDescriptor.containsKey('material-design-icons'))
+    return;
+  for (Map assetDescriptor in manifestDescriptor['material-design-icons']) {
+    for (_MaterialAsset asset in _generateMaterialAssets(assetDescriptor)) {
+      yield asset;
+    }
+  }
+}
+
+dynamic _loadManifest(String manifestPath) {
+  if (manifestPath == null || !FileSystemEntity.isFileSync(manifestPath))
+    return null;
+  String manifestDescriptor = new File(manifestPath).readAsStringSync();
+  return loadYaml(manifestDescriptor);
+}
+
+ArchiveFile _createFile(String key, String assetBase) {
+  File file = new File('$assetBase/$key');
+  if (!file.existsSync())
+    return null;
+  List<int> content = file.readAsBytesSync();
+  return new ArchiveFile.noCompress(key, content.length, content);
+}
+
+ArchiveFile _createSnapshotFile(String snapshotPath) {
+  File file = new File(snapshotPath);
+  List<int> content = file.readAsBytesSync();
+  return new ArchiveFile(_kSnapshotKey, content.length, content);
+}
+
+Future<int> buildInTempDir(
+  Toolchain toolchain, {
+  String mainPath: defaultMainPath,
+  void onBundleAvailable(String bundlePath)
+}) async {
+  int result;
+  Directory tempDir = await Directory.systemTemp.createTemp('flutter_tools');
+  try {
+    String localBundlePath = path.join(tempDir.path, 'app.flx');
+    String localSnapshotPath = path.join(tempDir.path, 'snapshot_blob.bin');
+    result = await build(
+      toolchain,
+      snapshotPath: localSnapshotPath,
+      outputPath: localBundlePath,
+      mainPath: mainPath
+    );
+    if (result == 0)
+      onBundleAvailable(localBundlePath);
+  } finally {
+    tempDir.deleteSync(recursive: true);
+  }
+  return result;
+}
+
+Future<int> build(
+  Toolchain toolchain, {
+  String assetBase: defaultAssetBase,
+  String mainPath: defaultMainPath,
+  String manifestPath: defaultManifestPath,
+  String outputPath: defaultFlxOutputPath,
+  String snapshotPath: defaultSnapshotPath,
+  String privateKeyPath: defaultPrivateKeyPath,
+  bool precompiledSnapshot: false
+}) async {
+  logging.fine('Building $outputPath');
+
+  Map manifestDescriptor = _loadManifest(manifestPath);
+
+  Iterable<_Asset> assets = _parseAssets(manifestDescriptor, manifestPath);
+  Iterable<_MaterialAsset> materialAssets = _parseMaterialAssets(manifestDescriptor);
+
+  Archive archive = new Archive();
+
+  if (!precompiledSnapshot) {
+    ensureDirectoryExists(snapshotPath);
+
+    // In a precompiled snapshot, the instruction buffer contains script
+    // content equivalents
+    int result = await toolchain.compiler.compile(mainPath: mainPath, snapshotPath: snapshotPath);
+    if (result != 0) {
+      logging.severe('Failed to run the Flutter compiler. Exit code: $result');
+      return result;
+    }
+
+    archive.addFile(_createSnapshotFile(snapshotPath));
+  }
+
+  for (_Asset asset in assets) {
+    ArchiveFile file = _createFile(asset.key, asset.base);
+    if (file == null) {
+      stderr.writeln('Cannot find asset "${asset.key}" in directory "${path.absolute(asset.base)}".');
+      return 1;
+    }
+    archive.addFile(file);
+  }
+
+  for (_MaterialAsset asset in materialAssets) {
+    ArchiveFile file = _createFile(asset.key, assetBase);
+    if (file != null)
+      archive.addFile(file);
+  }
+
+  await CipherParameters.get().seedRandom();
+
+  AsymmetricKeyPair keyPair = keyPairFromPrivateKeyFileSync(privateKeyPath);
+  Uint8List zipBytes = new Uint8List.fromList(new ZipEncoder().encode(archive));
+  ensureDirectoryExists(outputPath);
+  Bundle bundle = new Bundle.fromContent(
+    path: outputPath,
+    manifest: manifestDescriptor,
+    contentBytes: zipBytes,
+    keyPair: keyPair
+  );
+  bundle.writeSync();
+  return 0;
+}


### PR DESCRIPTION
In a few places we were instantiating the `build` command purely to get access to its build functionality. This refactors the code into a library which can build `flx` files and a `BuildCommand` which calls that library.
- most of `commands/build.dart` moved into `flx.dart`
- `commands/build.dart` is now just a subclass of `FlutterCommand` and calls build() methods from the flx library
- calls to BuildCommand moved to calls in flx build()
- the BuildCommand prints out a success message when it completes
