### PR TITLE
Make `flutter start` not report erroneous failure

### DIFF
--- a/packages/flutter_tools/lib/src/commands/start.dart
+++ b/packages/flutter_tools/lib/src/commands/start.dart
@@ -108,6 +108,8 @@ abstract class StartCommandBase extends FlutterCommand {
         bool result = await device.startApp(package);
         if (!result) {
           logging.severe('Could not start \'${package.name}\' on \'${device.id}\'');
+        } else {
+          startedSomething = true;
         }
       }
     }


### PR DESCRIPTION
Was failing when starting in the iOS Simulator

@chinmaygarde
