### PR TITLE
Scaffold should respect window.padding.bottom

### DIFF
--- a/packages/flutter/lib/src/material/material_app.dart
+++ b/packages/flutter/lib/src/material/material_app.dart
@@ -68,17 +68,24 @@ class MaterialApp extends StatefulComponent {
   _MaterialAppState createState() => new _MaterialAppState();
 }
 
+EdgeDims _getPadding(ui.Window window) {
+  ui.WindowPadding padding = ui.window.padding;
+  return new EdgeDims.TRBL(padding.top, padding.right, padding.bottom, padding.left);
+}
+
 class _MaterialAppState extends State<MaterialApp> implements BindingObserver {
 
   GlobalObjectKey _navigator;
 
   Size _size;
+  EdgeDims _padding;
   LocaleQueryData _localeData;
 
   void initState() {
     super.initState();
     _navigator = new GlobalObjectKey(this);
     _size = ui.window.size;
+    _padding = _getPadding(ui.window);
     didChangeLocale(ui.window.locale);
     WidgetFlutterBinding.instance.addObserver(this);
   }
@@ -99,7 +106,12 @@ class _MaterialAppState extends State<MaterialApp> implements BindingObserver {
     return result;
   }
 
-  void didChangeSize(Size size) => setState(() { _size = size; });
+  void didChangeSize(Size size) {
+    setState(() {
+      _size = size;
+      _padding = _getPadding(ui.window);
+    });
+  }
 
   void didChangeLocale(ui.Locale locale) {
     if (config.onLocaleChanged != null) {
@@ -138,7 +150,7 @@ class _MaterialAppState extends State<MaterialApp> implements BindingObserver {
 
     ThemeData theme = config.theme ?? new ThemeData.fallback();
     Widget result = new MediaQuery(
-      data: new MediaQueryData(size: _size),
+      data: new MediaQueryData(size: _size, padding: _padding),
       child: new LocaleQuery(
         data: _localeData,
         child: new AnimatedTheme(

--- a/packages/flutter/lib/src/widgets/media_query.dart
+++ b/packages/flutter/lib/src/widgets/media_query.dart
@@ -16,10 +16,13 @@ enum Orientation {
 
 /// The result of a media query.
 class MediaQueryData {
-  const MediaQueryData({ this.size });
+  const MediaQueryData({ this.size, this.padding });
 
   /// The size of the media (e.g, the size of the screen).
   final Size size;
+
+  /// The padding around the edges of the media (e.g., the screen).
+  final EdgeDims padding;
 
   /// The orientation of the media (e.g., whether the device is in landscape or portrait mode).
   Orientation get orientation {
@@ -30,7 +33,8 @@ class MediaQueryData {
     if (other.runtimeType != runtimeType)
       return false;
     MediaQueryData typedOther = other;
-    return typedOther.size == size;
+    return typedOther.size == size
+        && typedOther.padding == padding;
   }
 
   int get hashCode => size.hashCode;


### PR DESCRIPTION
The space for the keyboard is now represented as bottom padding for the window.
By teaching the scaffold to respect the bottom window padding, we move the
floating action button and snackbars out of the way of the keyboard.

This currently works on Android. I'll need to see how to get the keyboard
geometry on iOS for a similar effect.

Fixes #103
