### PR TITLE
Don't autofocus Input widgets by default

### DIFF
--- a/examples/fitness/lib/meal.dart
+++ b/examples/fitness/lib/meal.dart
@@ -89,6 +89,7 @@ class MealFragmentState extends State<MealFragment> {
         new Text(meal.displayDate),
         new Input(
           key: descriptionKey,
+          autofocus: true,
           placeholder: 'Describe meal',
           onChanged: _handleDescriptionChanged
         ),

--- a/examples/fitness/lib/measurement.dart
+++ b/examples/fitness/lib/measurement.dart
@@ -141,6 +141,7 @@ class MeasurementFragmentState extends State<MeasurementFragment> {
           ),
           new Input(
             key: weightKey,
+            autofocus: true,
             placeholder: 'Enter weight',
             keyboardType: KeyboardType.number,
             onChanged: _handleWeightChanged

--- a/examples/fitness/lib/settings.dart
+++ b/examples/fitness/lib/settings.dart
@@ -62,6 +62,7 @@ class SettingsFragmentState extends State<SettingsFragment> {
         title: new Text("Goal Weight"),
         content: new Input(
           key: weightGoalKey,
+          autofocus: true,
           placeholder: 'Goal weight in lbs',
           keyboardType: KeyboardType.number,
           onChanged: _handleGoalWeightChanged

--- a/examples/stocks/lib/stock_home.dart
+++ b/examples/stocks/lib/stock_home.dart
@@ -236,6 +236,7 @@ class StockHomeState extends State<StockHome> {
       ),
       center: new Input(
         key: searchFieldKey,
+        autofocus: true,
         placeholder: 'Search stocks',
         onChanged: _handleSearchQueryChanged
       ),
@@ -252,6 +253,7 @@ class StockHomeState extends State<StockHome> {
           children: <Widget>[
             new Input(
               key: companyNameKey,
+              autofocus: true,
               placeholder: 'Company Name'
             ),
           ]

--- a/packages/flutter/lib/src/material/input.dart
+++ b/packages/flutter/lib/src/material/input.dart
@@ -12,6 +12,7 @@ import 'theme.dart';
 export 'package:flutter/rendering.dart' show ValueChanged;
 export 'package:flutter/services.dart' show KeyboardType;
 
+/// A material design text input widget.
 class Input extends Scrollable {
   Input({
     GlobalKey key,
@@ -19,6 +20,7 @@ class Input extends Scrollable {
     this.placeholder,
     this.hideText: false,
     this.isDense: false,
+    this.autofocus: false,
     this.onChanged,
     this.keyboardType: KeyboardType.text,
     this.onSubmitted
@@ -30,12 +32,28 @@ class Input extends Scrollable {
     assert(key != null);
   }
 
+  /// Initial editable text for the widget.
   final String initialValue;
+
+  /// The type of keyboard to use for editing the text.
   final KeyboardType keyboardType;
+
+  /// Hint text to show when the widget doesn't contain editable text.
   final String placeholder;
+
+  /// Whether to hide the text being edited (e.g., for passwords).
   final bool hideText;
+
+  /// Whether the input widget is part of a dense form (i.e., uses less vertical space).
   final bool isDense;
+
+  /// Whether this input widget should focus itself is nothing else is already focused.
+  final bool autofocus;
+
+  /// Called when the text being edited changes.
   final ValueChanged<String> onChanged;
+
+  /// Called when the user indicates that they are done editing the text in the widget.
   final ValueChanged<String> onSubmitted;
 
   InputState createState() => new InputState();
@@ -79,7 +97,7 @@ class InputState extends ScrollableState<Input> {
   Widget buildContent(BuildContext context) {
     assert(debugCheckHasMaterial(context));
     ThemeData themeData = Theme.of(context);
-    bool focused = Focus.at(context);
+    bool focused = Focus.at(context, autofocus: config.autofocus);
 
     if (focused && !_keyboardHandle.attached) {
       _keyboardHandle = keyboard.show(_editableValue.stub, config.keyboardType);

--- a/packages/flutter/lib/src/widgets/focus.dart
+++ b/packages/flutter/lib/src/widgets/focus.dart
@@ -84,7 +84,7 @@ class Focus extends StatefulComponent {
 
   static GlobalKey debugOnlyFocusedKey;
 
-  static bool at(BuildContext context, { bool autofocus: true }) {
+  static bool at(BuildContext context, { bool autofocus: false }) {
     assert(context != null);
     assert(context.widget != null);
     assert(context.widget.key != null);
@@ -109,7 +109,7 @@ class Focus extends StatefulComponent {
     return true;
   }
 
-  static bool _atScope(BuildContext context, { bool autofocus: true }) {
+  static bool _atScope(BuildContext context, { bool autofocus: false }) {
     assert(context != null);
     assert(context.widget != null);
     assert(context.widget is Focus);
@@ -126,7 +126,7 @@ class Focus extends StatefulComponent {
 
   /// Focuses a particular widget, identified by its GlobalKey.
   /// The widget must be in the widget tree.
-  /// 
+  ///
   /// Don't call moveTo() from your build() functions, it's intended to be
   /// called from event listeners, e.g. in response to a finger tap or tab key.
   static void moveTo(GlobalKey key) {
@@ -138,7 +138,7 @@ class Focus extends StatefulComponent {
 
   /// Focuses a particular focus scope, identified by its GlobalKey. The widget
   /// must be in the widget tree.
-  /// 
+  ///
   /// Don't call moveScopeTo() from your build() functions, it's intended to be
   /// called from event listeners, e.g. in response to a finger tap or tab key.
   static void moveScopeTo(GlobalKey key) {

--- a/packages/flutter/test/widget/focus_test.dart
+++ b/packages/flutter/test/widget/focus_test.dart
@@ -11,7 +11,7 @@ class TestFocusable extends StatelessComponent {
   final String no;
   final String yes;
   Widget build(BuildContext context) {
-    bool focused = Focus.at(context);
+    bool focused = Focus.at(context, autofocus: true);
     return new GestureDetector(
       onTap: () { Focus.moveTo(key); },
       child: new Text(focused ? yes : no)


### PR DESCRIPTION
Instead, require the developer to opt-in to autofocusing because autofocusing
can be disruptive.

Fixes #1307
