### PR TITLE
Scroll focused input widgets into view

### DIFF
--- a/packages/flutter/lib/src/animation/animation_controller.dart
+++ b/packages/flutter/lib/src/animation/animation_controller.dart
@@ -145,13 +145,22 @@ class AnimationController extends Animation<double>
   }
 
   Future animateTo(double target, { Duration duration, Curve curve: Curves.linear }) {
-    Duration remainingDuration = (duration ?? this.duration) * (target - _value).abs();
+    Duration simulationDuration = duration;
+    if (simulationDuration == null) {
+      double range = upperBound - lowerBound;
+      if (range.isFinite) {
+        double remainingFraction = (target - _value).abs() / range;
+        simulationDuration = this.duration * remainingFraction;
+      }
+    }
     stop();
-    if (remainingDuration == Duration.ZERO)
+    if (simulationDuration == Duration.ZERO) {
+      assert(value == target);
       return new Future.value();
-    assert(remainingDuration > Duration.ZERO);
+    }
+    assert(simulationDuration > Duration.ZERO);
     assert(!isAnimating);
-    return _startSimulation(new _TweenSimulation(_value, target, remainingDuration, curve));
+    return _startSimulation(new _TweenSimulation(_value, target, simulationDuration, curve));
   }
 
   Future _startSimulation(Simulation simulation) {

--- a/packages/flutter/lib/src/material/scaffold.dart
+++ b/packages/flutter/lib/src/material/scaffold.dart
@@ -366,7 +366,7 @@ class ScaffoldState extends State<Scaffold> {
   }
 
   Widget build(BuildContext context) {
-    EdgeDims padding = MediaQuery.of(context).padding;
+    EdgeDims padding = MediaQuery.of(context)?.padding ?? EdgeDims.zero;
 
     if (_snackBars.length > 0) {
       ModalRoute route = ModalRoute.of(context);


### PR DESCRIPTION
When opening the keyboard or focusing an input widget, we should scroll the
widget into view so that the user can see what they're typing.
