### PR TITLE
Change Block children to be a named parameter

### DIFF
--- a/examples/address_book/lib/main.dart
+++ b/examples/address_book/lib/main.dart
@@ -56,7 +56,7 @@ class AddressBookHome extends StatelessComponent {
   static final GlobalKey noteKey = new GlobalKey(debugLabel: 'note field');
 
   Widget buildBody(BuildContext context) {
-    return new Block(<Widget>[
+    return new Block(children: <Widget>[
       new AspectRatio(
         aspectRatio: 16.0 / 9.0,
         child: new Container(

--- a/examples/fitness/lib/feed.dart
+++ b/examples/fitness/lib/feed.dart
@@ -64,7 +64,7 @@ class FeedFragmentState extends State<FeedFragment> {
 
   Widget _buildDrawer() {
     return new Drawer(
-      child: new Block(<Widget>[
+      child: new Block(children: <Widget>[
         new DrawerHeader(child: new Text('Fitness')),
         new DrawerItem(
           icon: 'action/view_list',
@@ -239,7 +239,7 @@ class AddItemDialogState extends State<AddItemDialog> {
     }
     return new Dialog(
       title: new Text("What are you doing?"),
-      content: new Block(menuItems),
+      content: new Block(children: menuItems),
       actions: <Widget>[
         new FlatButton(
           child: new Text('CANCEL'),

--- a/examples/fitness/lib/meal.dart
+++ b/examples/fitness/lib/meal.dart
@@ -85,7 +85,7 @@ class MealFragmentState extends State<MealFragment> {
 
   Widget buildBody() {
     Meal meal = new Meal(when: new DateTime.now());
-    return new Block(<Widget>[
+    return new Block(children: <Widget>[
         new Text(meal.displayDate),
         new Input(
           key: descriptionKey,

--- a/examples/fitness/lib/settings.dart
+++ b/examples/fitness/lib/settings.dart
@@ -87,7 +87,7 @@ class SettingsFragmentState extends State<SettingsFragment> {
   }
 
   Widget buildSettingsPane(BuildContext context) {
-    return new Block(<Widget>[
+    return new Block(children: <Widget>[
         new DrawerItem(
           onPressed: () { _handleBackupChanged(!(config.userData.backupMode == BackupMode.enabled)); },
           child: new Row(

--- a/examples/material_gallery/lib/demo/chip_demo.dart
+++ b/examples/material_gallery/lib/demo/chip_demo.dart
@@ -37,12 +37,14 @@ class _ChipDemoState extends State<ChipDemo> {
 
     return new Scaffold(
       toolBar: new ToolBar(center: new Text("Chips")),
-      body: new Block(chips.map((Widget widget) {
-        return new Container(
-          height: 100.0,
-          child: new Center(child: widget)
-        );
-      }).toList())
+      body: new Block(
+        children: chips.map((Widget widget) {
+          return new Container(
+            height: 100.0,
+            child: new Center(child: widget)
+          );
+        }).toList()
+      )
     );
   }
 }

--- a/examples/material_gallery/lib/demo/slider_demo.dart
+++ b/examples/material_gallery/lib/demo/slider_demo.dart
@@ -14,7 +14,7 @@ class _SliderDemoState extends State<SliderDemo> {
   Widget build(BuildContext context) {
     return new Scaffold(
       toolBar: new ToolBar(center: new Text("Sliders")),
-      body: new Block(<Widget>[
+      body: new Block(children: <Widget>[
         new Container(
           height: 100.0,
           child: new Center(

--- a/examples/material_gallery/lib/main.dart
+++ b/examples/material_gallery/lib/main.dart
@@ -128,7 +128,7 @@ class GalleryHome extends StatelessComponent {
       body: new Padding(
         padding: const EdgeDims.all(4.0),
         child: new Block(
-          <Widget>[
+          children: <Widget>[
             new Row(
               children: <Widget>[
                 new GallerySection(

--- a/examples/stocks/lib/stock_home.dart
+++ b/examples/stocks/lib/stock_home.dart
@@ -71,7 +71,7 @@ class StockHomeState extends State<StockHome> {
 
   Widget _buildDrawer(BuildContext context) {
     return new Drawer(
-      child: new Block(<Widget>[
+      child: new Block(children: <Widget>[
         new DrawerHeader(child: new Text('Stocks')),
         new DrawerItem(
           icon: 'action/assessment',

--- a/examples/stocks/lib/stock_settings.dart
+++ b/examples/stocks/lib/stock_settings.dart
@@ -152,7 +152,7 @@ class StockSettingsState extends State<StockSettings> {
       return true;
     });
     return new Block(
-      rows,
+      children: rows,
       padding: const EdgeDims.symmetric(vertical: 20.0)
     );
   }

--- a/examples/stocks/lib/stock_symbol_viewer.dart
+++ b/examples/stocks/lib/stock_symbol_viewer.dart
@@ -59,12 +59,14 @@ class StockSymbolPage extends StatelessComponent {
       toolBar: new ToolBar(
         center: new Text(stock.name)
       ),
-      body: new Block(<Widget>[
-        new Container(
-          margin: new EdgeDims.all(20.0),
-          child: new Card(child: new StockSymbolView(stock: stock))
-        )
-      ])
+      body: new Block(
+        children: <Widget>[
+          new Container(
+            margin: new EdgeDims.all(20.0),
+            child: new Card(child: new StockSymbolView(stock: stock))
+          )
+        ]
+      )
     );
   }
 }

--- a/examples/widgets/card_collection.dart
+++ b/examples/widgets/card_collection.dart
@@ -121,7 +121,7 @@ class CardCollectionState extends State<CardCollection> {
     return new Drawer(
       child: new IconTheme(
         data: const IconThemeData(color: IconThemeColor.black),
-        child: new Block(<Widget>[
+        child: new Block(children: <Widget>[
           new DrawerHeader(child: new Text('Options')),
           buildDrawerCheckbox("Make card labels editable", _editable, _toggleEditable),
           buildDrawerCheckbox("Snap fling scrolls to center", _snapToCenter, _toggleSnapToCenter),

--- a/examples/widgets/hero_under.dart
+++ b/examples/widgets/hero_under.dart
@@ -95,7 +95,7 @@ class CrabPage extends StatelessComponent {
     return new Material(
       color: const Color(0x00000000),
       child: new Block(
-        <Widget>[
+        children: <Widget>[
           new Stack(
             children: <Widget>[
               new HeroImage(

--- a/examples/widgets/horizontal_scrolling.dart
+++ b/examples/widgets/horizontal_scrolling.dart
@@ -41,7 +41,7 @@ class HorizontalScrollingApp extends StatelessComponent {
     return new Center(
       child: new Container(
         height: 50.0,
-        child: new Block(circles, scrollDirection: Axis.horizontal)
+        child: new Block(children: circles, scrollDirection: Axis.horizontal)
       )
     );
   }

--- a/examples/widgets/http_post.dart
+++ b/examples/widgets/http_post.dart
@@ -53,10 +53,12 @@ class PostDemoState extends State<PostDemo> {
       ),
       body: new Material(
         child: new Block(
-          [new Text(
-            "${_response ?? 'Loading...'}",
-            style: Typography.black.body1
-          )]
+          children: <Widget>[
+            new Text(
+              "${_response ?? 'Loading...'}",
+              style: Typography.black.body1
+            )
+          ]
         )
       ),
       floatingActionButton: new FloatingActionButton(

--- a/examples/widgets/mimic_demo.dart
+++ b/examples/widgets/mimic_demo.dart
@@ -88,7 +88,7 @@ class _MimicDemoState extends State<MimicDemo> {
     return new GestureDetector(
       onTap: _handleTap,
       onLongPress: _reset,
-      child: new Block(children)
+      child: new Block(children: children)
     );
   }
 }

--- a/examples/widgets/navigation.dart
+++ b/examples/widgets/navigation.dart
@@ -8,7 +8,8 @@ class Home extends StatelessComponent {
   Widget build(BuildContext context) {
     return new Material(
       child: new Center(
-        child: new Block(<Widget>[
+        child: new Block(
+          children: <Widget>[
             new Text(
               'You are at home.',
               style: Theme.of(context).text.display2.copyWith(textAlign: TextAlign.center)
@@ -34,7 +35,8 @@ class Shopping extends StatelessComponent {
     return new Material(
       color: Colors.deepPurple[300],
       child: new Center(
-        child: new Block(<Widget>[
+        child: new Block(
+          children: <Widget>[
             new Text(
               'Village Shop',
               style: Theme.of(context).text.display2.copyWith(textAlign: TextAlign.center)
@@ -60,7 +62,8 @@ class Adventure extends StatelessComponent {
     return new Material(
       color: Colors.red[300],
       child: new Center(
-        child: new Block(<Widget>[
+        child: new Block(
+          children: <Widget>[
             new Text(
               'Monster\'s Lair',
               style: Theme.of(context).text.display2.copyWith(textAlign: TextAlign.center)

--- a/examples/widgets/pageable_list.dart
+++ b/examples/widgets/pageable_list.dart
@@ -79,7 +79,7 @@ class PageableListAppState extends State<PageableListApp> {
 
   Widget _buildDrawer() {
     return new Drawer(
-      child: new Block(<Widget>[
+      child: new Block(children: <Widget>[
         new DrawerHeader(child: new Text('Options')),
         new DrawerItem(
           icon: 'navigation/more_horiz',

--- a/examples/widgets/smooth_resize.dart
+++ b/examples/widgets/smooth_resize.dart
@@ -106,7 +106,7 @@ class SmoothBlockState extends State<SmoothBlock> {
 
 class SmoothResizeDemo extends StatelessComponent {
   Widget build(BuildContext context) {
-    return new Block(_kColors.map((Map<int, Color> color) => new SmoothBlock(color: color)).toList());
+    return new Block(children: _kColors.map((Map<int, Color> color) => new SmoothBlock(color: color)).toList());
   }
 }
 

--- a/packages/flutter/lib/src/material/dialog.dart
+++ b/packages/flutter/lib/src/material/dialog.dart
@@ -107,7 +107,7 @@ class Dialog extends StatelessComponent {
             color: _getColor(context),
             type: MaterialType.card,
             child: new IntrinsicWidth(
-              child: new Block(dialogBody)
+              child: new Block(children: dialogBody)
             )
           )
         )

--- a/packages/flutter/lib/src/material/dropdown.dart
+++ b/packages/flutter/lib/src/material/dropdown.dart
@@ -125,7 +125,7 @@ class _DropDownMenu<T> extends StatusTransitionComponent {
 
     Widget child = new Material(
       type: MaterialType.transparency,
-      child: new Block(children)
+      child: new Block(children: children)
     );
     return new FadeTransition(
       opacity: opacity,

--- a/packages/flutter/lib/src/material/popup_menu.dart
+++ b/packages/flutter/lib/src/material/popup_menu.dart
@@ -86,7 +86,7 @@ class _PopupMenu<T> extends StatelessComponent {
       child: new IntrinsicWidth(
         stepWidth: _kMenuWidthStep,
         child: new Block(
-          children,
+          children: children,
           padding: const EdgeDims.symmetric(
             vertical: _kMenuVerticalPadding
           )

--- a/packages/flutter/lib/src/material/two_level_list.dart
+++ b/packages/flutter/lib/src/material/two_level_list.dart
@@ -155,5 +155,5 @@ class TwoLevelList extends StatelessComponent {
   final List<Widget> items;
   final MaterialListType type;
 
-  Widget build(BuildContext context) => new Block(items);
+  Widget build(BuildContext context) => new Block(children: items);
 }

--- a/packages/flutter/lib/src/widgets/scrollable.dart
+++ b/packages/flutter/lib/src/widgets/scrollable.dart
@@ -436,8 +436,9 @@ class ScrollableViewportState extends ScrollableState<ScrollableViewport> {
 /// fixed number of children that you wish to arrange in a block layout and that
 /// might exceed the height of its container (and therefore need to scroll).
 class Block extends StatelessComponent {
-  Block(this.children, {
+  Block({
     Key key,
+    this.children,
     this.padding,
     this.initialScrollOffset,
     this.scrollDirection: Axis.vertical,

--- a/packages/flutter/test/widget/block_test.dart
+++ b/packages/flutter/test/widget/block_test.dart
@@ -12,13 +12,15 @@ void main() {
   test('Cannot scroll a non-overflowing block', () {
     testWidgets((WidgetTester tester) {
       tester.pumpWidget(
-        new Block(<Widget>[
-          new Container(
-            height: 200.0, // less than 600, the height of the test area
-            child: new Text('Hello')
-          )
-        ],
-        key: blockKey)
+        new Block(
+          key: blockKey,
+          children: <Widget>[
+            new Container(
+              height: 200.0, // less than 600, the height of the test area
+              child: new Text('Hello')
+            )
+          ]
+        )
       );
       tester.pump(); // for SizeObservers
 
@@ -39,13 +41,15 @@ void main() {
   test('Can scroll an overflowing block', () {
     testWidgets((WidgetTester tester) {
       tester.pumpWidget(
-        new Block(<Widget>[
-          new Container(
-            height: 2000.0, // more than 600, the height of the test area
-            child: new Text('Hello')
-          )
-        ],
-        key: blockKey)
+        new Block(
+          key: blockKey,
+          children: <Widget>[
+            new Container(
+              height: 2000.0, // more than 600, the height of the test area
+              child: new Text('Hello')
+            )
+          ]
+        )
       );
       tester.pump(); // for SizeObservers
 

--- a/packages/flutter/test/widget/center_test.dart
+++ b/packages/flutter/test/widget/center_test.dart
@@ -9,7 +9,7 @@ import 'package:test/test.dart';
 void main() {
   test('Can be placed in an infinite box', () {
     testWidgets((WidgetTester tester) {
-      tester.pumpWidget(new Block(<Widget>[new Center()]));
+      tester.pumpWidget(new Block(children: <Widget>[new Center()]));
     });
   });
 }

--- a/packages/flutter/test/widget/date_picker_test.dart
+++ b/packages/flutter/test/widget/date_picker_test.dart
@@ -12,16 +12,18 @@ void main() {
       DateTime currentValue;
 
       Widget widget = new Material(
-        child: new Block(<Widget>[
-          new DatePicker(
-            selectedDate: new DateTime.utc(2015, 6, 9, 7, 12),
-            firstDate: new DateTime.utc(2013),
-            lastDate: new DateTime.utc(2018),
-            onChanged: (DateTime dateTime) {
-              currentValue = dateTime;
-            }
-          )
-        ])
+        child: new Block(
+          children: <Widget>[
+            new DatePicker(
+              selectedDate: new DateTime.utc(2015, 6, 9, 7, 12),
+              firstDate: new DateTime.utc(2013),
+              lastDate: new DateTime.utc(2018),
+              onChanged: (DateTime dateTime) {
+                currentValue = dateTime;
+              }
+            )
+          ]
+        )
       );
 
       tester.pumpWidget(widget);

--- a/packages/flutter/test/widget/heroes_test.dart
+++ b/packages/flutter/test/widget/heroes_test.dart
@@ -14,7 +14,7 @@ Key thirdKey = new Key('third');
 
 final Map<String, RouteBuilder> routes = <String, RouteBuilder>{
   '/': (RouteArguments args) => new Material(
-    child: new Block([
+    child: new Block(children: <Widget>[
       new Container(height: 100.0, width: 100.0),
       new Card(child: new Hero(tag: 'a', child: new Container(height: 100.0, width: 100.0, key: firstKey))),
       new Container(height: 100.0, width: 100.0),
@@ -22,7 +22,7 @@ final Map<String, RouteBuilder> routes = <String, RouteBuilder>{
     ])
   ),
   '/two': (RouteArguments args) => new Material(
-    child: new Block([
+    child: new Block(children: <Widget>[
       new Container(height: 150.0, width: 150.0),
       new Card(child: new Hero(tag: 'a', child: new Container(height: 150.0, width: 150.0, key: secondKey))),
       new Container(height: 150.0, width: 150.0),
@@ -34,7 +34,7 @@ final Map<String, RouteBuilder> routes = <String, RouteBuilder>{
 class ThreeRoute extends MaterialPageRoute {
   ThreeRoute() : super(builder: (BuildContext context) {
     return new Material(
-      child: new Block([
+      child: new Block(children: <Widget>[
         new Container(height: 200.0, width: 200.0),
         new Card(child: new Hero(tag: 'a', child: new Container(height: 200.0, width: 200.0, key: thirdKey))),
         new Container(height: 200.0, width: 200.0),

--- a/packages/flutter/test/widget/progress_indicator_test.dart
+++ b/packages/flutter/test/widget/progress_indicator_test.dart
@@ -10,11 +10,11 @@ import 'package:test/test.dart';
 void main() {
   test('LinearProgressIndicator changes when its value changes', () {
     testWidgets((WidgetTester tester) {
-      tester.pumpWidget(new Block(<Widget>[new LinearProgressIndicator(value: 0.0)]));
+      tester.pumpWidget(new Block(children: <Widget>[new LinearProgressIndicator(value: 0.0)]));
 
       List<Layer> layers1 = tester.layers;
 
-      tester.pumpWidget(new Block(<Widget>[new LinearProgressIndicator(value: 0.5)]));
+      tester.pumpWidget(new Block(children: <Widget>[new LinearProgressIndicator(value: 0.5)]));
 
       List<Layer> layers2 = tester.layers;
       expect(layers1, isNot(equals(layers2)));


### PR DESCRIPTION
This is a backwards incompatible change.

When it wasn't going to be too disruptive I changed code like

```
new Block(<Widget>[
  someChild,
  someOtherChild,
  etc
])
```

to Flutter normal format

```
new Block(
  children: <Widget>[
    someChild,
    someOtherChild,
    etc
  ]
)
```

But in most cases I just tucked the children: keyword in before the list of chidlren.
