### PR TITLE
Make `flutter list` not crash on linux.

### DIFF
--- a/packages/flutter_tools/lib/src/commands/list.dart
+++ b/packages/flutter_tools/lib/src/commands/list.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:io';
 
 import '../android/device_android.dart';
 import '../ios/device_ios.dart';
@@ -43,25 +44,27 @@ class ListCommand extends FlutterCommand {
       }
     }
 
-    if (details)
-      print('iOS Devices:');
+    if (Platform.isMacOS) {
+      if (details)
+        print('iOS Devices:');
 
-    for (IOSDevice device in IOSDevice.getAttachedDevices(devices.iOS)) {
-      if (details) {
-        print('${device.id}\t${device.name}');
-      } else {
-        print(device.id);
+      for (IOSDevice device in IOSDevice.getAttachedDevices(devices.iOS)) {
+        if (details) {
+          print('${device.id}\t${device.name}');
+        } else {
+          print(device.id);
+        }
       }
-    }
 
-    if (details)
-      print('iOS Simulators:');
+      if (details)
+        print('iOS Simulators:');
 
-    for (IOSSimulator device in IOSSimulator.getAttachedDevices(devices.iOSSimulator)) {
-      if (details) {
-        print('${device.id}\t${device.name}');
-      } else {
-        print(device.id);
+      for (IOSSimulator device in IOSSimulator.getAttachedDevices(devices.iOSSimulator)) {
+        if (details) {
+          print('${device.id}\t${device.name}');
+        } else {
+          print(device.id);
+        }
       }
     }
 

--- a/packages/flutter_tools/lib/src/ios/device_ios.dart
+++ b/packages/flutter_tools/lib/src/ios/device_ios.dart
@@ -21,10 +21,6 @@ class IOSDevice extends Device {
       'To work with iOS devices, please install ideviceinstaller. '
       'If you use homebrew, you can install it with '
       '"\$ brew install ideviceinstaller".';
-  static const String _linuxInstructions =
-      'To work with iOS devices, please install ideviceinstaller. '
-      'On Ubuntu or Debian, you can install it with '
-      '"\$ apt-get install ideviceinstaller".';
 
   String _installerPath;
   String get installerPath => _installerPath;
@@ -100,19 +96,16 @@ class IOSDevice extends Device {
   static final Map<String, String> _commandMap = {};
   static String _checkForCommand(
     String command, [
-    String macInstructions = _macInstructions,
-    String linuxInstructions = _linuxInstructions
+    String macInstructions = _macInstructions
   ]) {
     return _commandMap.putIfAbsent(command, () {
       try {
         command = runCheckedSync(['which', command]).trim();
       } catch (e) {
         if (Platform.isMacOS) {
-          logging.severe(macInstructions);
-        } else if (Platform.isLinux) {
-          logging.severe(linuxInstructions);
+          logging.severe('$command not found. $macInstructions');
         } else {
-          logging.severe('$command is not available on your platform.');
+          logging.severe('Cannot control iOS devices or simulators.  $command is not available on your platform.');
         }
       }
       return command;
@@ -331,9 +324,12 @@ class IOSSimulator extends Device {
 
   static List<IOSSimulator> getAttachedDevices([IOSSimulator mockIOS]) {
     List<IOSSimulator> devices = [];
-    _IOSSimulatorInfo deviceInfo = _getRunningSimulatorInfo(mockIOS);
-    if (deviceInfo != null)
-      devices.add(new IOSSimulator(id: deviceInfo.id, name: deviceInfo.name));
+    try {
+      _IOSSimulatorInfo deviceInfo = _getRunningSimulatorInfo(mockIOS);
+      if (deviceInfo != null)
+        devices.add(new IOSSimulator(id: deviceInfo.id, name: deviceInfo.name));
+    } catch (e) {
+    }
     return devices;
   }
 


### PR DESCRIPTION
Turns out linux does have an ideviceinstaller package
however it doesn't contain idevice_id or any of the
other tools we use.  Furthermore we don't have
xcrun or the rest of xcode on linux so we can't
manipulate simulators either.

No sense in printing out a warning that ios isn't supported
every time on linux, so I wrapped that block in osx only.

@chinmaygarde @devoncarew
