### PR TITLE
get a bug fix for multi-line command descriptions

### DIFF
--- a/packages/flutter_tools/lib/src/commands/listen.dart
+++ b/packages/flutter_tools/lib/src/commands/listen.dart
@@ -11,8 +11,11 @@ import 'start.dart';
 
 class ListenCommand extends StartCommandBase {
   final String name = 'listen';
-  final String description = 'Listen for changes to files and reload the running app on all connected devices (Android only).'
-      ' By default, only listens to "./" and "./lib/". To listen to additional directories, list them on the command line.';
+  final String description =
+      'Listen for changes to files and reload the running app on all\n'
+      'connected devices (Android only). By default, only listens to\n'
+      '"./" and "./lib/". To listen to additional directories, list them on\n'
+      'the command line.';
 
   /// Only run once.  Used for testing.
   final bool singleRun;

--- a/packages/flutter_tools/pubspec.yaml
+++ b/packages/flutter_tools/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   analyzer: '>=0.26.1+17' # see note below
   archive: ^1.0.20
-  args: ^0.13.0
+  args: ^0.13.2+1
   crypto: ^0.9.1
   den_api: ^0.1.0
   mustache4dart: ^1.0.0


### PR DESCRIPTION
Note: the bump for args dependency version, which was required to fix the bug with multi-line command descriptions
