### PR TITLE
flutter start shouldn't log xcodebuild output

### DIFF
--- a/packages/flutter_tools/lib/src/ios/device_ios.dart
+++ b/packages/flutter_tools/lib/src/ios/device_ios.dart
@@ -539,14 +539,14 @@ Future<bool> _buildIOSXcodeProject(ApplicationPackage app, bool isDevice) async 
     return false;
 
   List<String> command = [
-    '/usr/bin/env', 'xcrun', 'xcodebuild', '-target', 'Runner', '-configuration', 'Release'
+    'xcrun', 'xcodebuild', '-target', 'Runner', '-configuration', 'Release'
   ];
 
   if (!isDevice) {
     command.addAll(['-sdk', 'iphonesimulator']);
   }
 
-  int result = await runCommandAndStreamOutput(command,
+  ProcessResult result = await Process.runSync('/usr/bin/env', command,
       workingDirectory: app.localPath);
-  return result == 0;
+  return result.exitCode == 0;
 }


### PR DESCRIPTION
Xcodebuild produces a lot of output that isn't relevant to developers. We
should hide it by default.

Fixes #1375
