### PR TITLE
Hide EditableString implementation details

### DIFF
--- a/packages/flutter/lib/src/material/input.dart
+++ b/packages/flutter/lib/src/material/input.dart
@@ -109,7 +109,7 @@ class _InputState extends State<Input> {
                                    _editableString.selection.end);
     } else if (!focused && _keyboardHandle.attached) {
       _keyboardHandle.release();
-      _editableString.composing = TextRange.empty;
+      _editableString.didDetachKeyboard();
     }
   }
 

--- a/packages/flutter/lib/src/services/keyboard.dart
+++ b/packages/flutter/lib/src/services/keyboard.dart
@@ -23,8 +23,10 @@ class _KeyboardConnection {
   static final _KeyboardConnection instance = new _KeyboardConnection();
 }
 
+/// An interface to the system's keyboard.
+///
+/// Most clients will want to use the [keyboard] singleton instance.
 class Keyboard {
-
   Keyboard(this.service);
 
   // The service is exposed in case you need direct access.


### PR DESCRIPTION
Previously, EditableString had many public members because it needed to
implement the KeyboardClient interface. However, that's confusing
because these methods cannot be called directly.

Now EditableString holds a private implementation of the KeyboardClient,
which hides the implementation details.

Fixes #208
Fixes #209
