### PR TITLE
Input asserts while keyboard is dismissed

### DIFF
--- a/packages/flutter/lib/src/material/input.dart
+++ b/packages/flutter/lib/src/material/input.dart
@@ -80,7 +80,7 @@ const Curve _kTransitionCurve = Curves.ease;
 class _InputState extends State<Input> {
   String _value;
   EditableString _editableString;
-  KeyboardHandle _keyboardHandle = KeyboardHandle.unattached;
+  KeyboardHandle _keyboardHandle;
 
   // Used by tests.
   EditableString get editableValue => _editableString;
@@ -96,19 +96,22 @@ class _InputState extends State<Input> {
   }
 
   void dispose() {
-    if (_keyboardHandle.attached)
+    if (_isAttachedToKeyboard)
       _keyboardHandle.release();
     super.dispose();
   }
 
+  bool get _isAttachedToKeyboard => _keyboardHandle != null && _keyboardHandle.attached;
+
   void _attachOrDetachKeyboard(bool focused) {
-    if (focused && !_keyboardHandle.attached) {
-      _keyboardHandle = keyboard.show(_editableString.stub, config.keyboardType);
+    if (focused && !_isAttachedToKeyboard) {
+      _keyboardHandle = keyboard.show(_editableString.createStub(), config.keyboardType);
       _keyboardHandle.setText(_editableString.text);
       _keyboardHandle.setSelection(_editableString.selection.start,
                                    _editableString.selection.end);
-    } else if (!focused && _keyboardHandle.attached) {
+    } else if (!focused && _isAttachedToKeyboard) {
       _keyboardHandle.release();
+      _keyboardHandle = null;
       _editableString.didDetachKeyboard();
     }
   }
@@ -251,7 +254,7 @@ class _InputState extends State<Input> {
       behavior: HitTestBehavior.opaque,
       onTap: () {
         if (Focus.at(context)) {
-          assert(_keyboardHandle.attached);
+          assert(_isAttachedToKeyboard);
           _keyboardHandle.showByRequest();
         } else {
           Focus.moveTo(config.key);

--- a/packages/flutter/lib/src/widgets/editable.dart
+++ b/packages/flutter/lib/src/widgets/editable.dart
@@ -64,7 +64,6 @@ class _KeyboardClientImpl implements KeyboardClient {
   }) {
     assert(onUpdated != null);
     assert(onSubmitted != null);
-    stub = new KeyboardClientStub.unbound()..impl = this;
     selection = new TextRange(start: text.length, end: text.length);
   }
 
@@ -84,7 +83,9 @@ class _KeyboardClientImpl implements KeyboardClient {
   TextRange selection = TextRange.empty;
 
   /// A keyboard client stub that can be attached to a keyboard service.
-  KeyboardClientStub stub;
+  KeyboardClientStub createStub() {
+    return new KeyboardClientStub.unbound()..impl = this;
+  }
 
   void _delete(TextRange range) {
     if (range.isCollapsed || !range.isValid) return;
@@ -196,7 +197,7 @@ class EditableString {
   /// A keyboard client stub that can be attached to a keyboard service.
   ///
   /// See [Keyboard].
-  KeyboardClientStub get stub => _client.stub;
+  KeyboardClientStub createStub() => _client.createStub();
 
   void didDetachKeyboard() {
     _client.composing = TextRange.empty;


### PR DESCRIPTION
Now we recreate the stub every time we try to connect to the keyboard. The
underlying message pipe in the stub cannot be re-used, which is why we
previously asserted.

Fixes #776
