### PR TITLE
Keyboard doesn't dismiss when the drawer comes up

### DIFF
--- a/packages/flutter/lib/src/material/drawer.dart
+++ b/packages/flutter/lib/src/material/drawer.dart
@@ -81,6 +81,8 @@ class DrawerControllerState extends State<DrawerController> {
   }
 
   LocalHistoryEntry _historyEntry;
+  // TODO(abarth): This should be a GlobalValueKey when those exist.
+  GlobalKey get _focusKey => new GlobalObjectKey(config.key);
 
   void _ensureHistoryEntry() {
     if (_historyEntry == null) {
@@ -88,6 +90,7 @@ class DrawerControllerState extends State<DrawerController> {
       if (route != null) {
         _historyEntry = new LocalHistoryEntry(onRemove: _handleHistoryEntryRemoved);
         route.addLocalHistoryEntry(_historyEntry);
+        Focus.moveScopeTo(_focusKey, context: context);
       }
     }
   }
@@ -194,7 +197,7 @@ class DrawerControllerState extends State<DrawerController> {
                       onSizeChanged: _handleSizeChanged,
                       child: new RepaintBoundary(
                         child: new Focus(
-                          key: new GlobalObjectKey(config.key),
+                          key: _focusKey,
                           child: config.child
                         )
                       )

--- a/packages/flutter/lib/src/widgets/routes.dart
+++ b/packages/flutter/lib/src/widgets/routes.dart
@@ -339,20 +339,20 @@ class _ModalScopeState extends State<_ModalScope> {
     if (config.route.offstage) {
       contents = new OffStage(child: contents);
     } else {
-      contents = new Focus(
-        key: new GlobalObjectKey(config.route),
-        child: new IgnorePointer(
-          ignoring: config.route.animation?.status == AnimationStatus.reverse,
-          child: config.route.buildTransitions(
-            context,
-            config.route.animation,
-            config.route.forwardAnimation,
-            contents
-          )
+      contents = new IgnorePointer(
+        ignoring: config.route.animation?.status == AnimationStatus.reverse,
+        child: config.route.buildTransitions(
+          context,
+          config.route.animation,
+          config.route.forwardAnimation,
+          contents
         )
       );
     }
-    contents = new RepaintBoundary(child: contents);
+    contents = new Focus(
+      key: new GlobalObjectKey(config.route),
+      child: new RepaintBoundary(child: contents)
+    );
     ModalPosition position = config.route.getPosition(context);
     if (position == null)
       return contents;
@@ -401,6 +401,10 @@ abstract class ModalRoute<T> extends TransitionRoute<T> with LocalHistoryRoute<T
     return child;
   }
 
+  void didPush() {
+    Focus.moveScopeTo(new GlobalObjectKey(this), context: navigator.context);
+    super.didPush();
+  }
 
   // The API for subclasses to override - used by this class
 


### PR DESCRIPTION
When introducing Focus widgets for the Drawer (and ModalRoutes), we weren't
actually giving them the focus. Now we move the focus scope when pushing modal
routes.

Fixes #184
