### PR TITLE
updateChildren() needs to walk the list forward

### DIFF
--- a/packages/flutter/lib/src/widgets/homogeneous_viewport.dart
+++ b/packages/flutter/lib/src/widgets/homogeneous_viewport.dart
@@ -118,14 +118,12 @@ abstract class _ViewportBaseElement<T extends _ViewportBase> extends RenderObjec
   }
 
   void insertChildRenderObject(RenderObject child, Element slot) {
-    RenderObject nextSibling = slot?.renderObject;
-    renderObject.add(child, before: nextSibling);
+    renderObject.insert(child, after: slot?.renderObject);
   }
 
   void moveChildRenderObject(RenderObject child, Element slot) {
     assert(child.parent == renderObject);
-    RenderObject nextSibling = slot?.renderObject;
-    renderObject.move(child, before: nextSibling);
+    renderObject.move(child, after: slot?.renderObject);
   }
 
   void removeChildRenderObject(RenderObject child) {

--- a/packages/flutter/lib/src/widgets/mixed_viewport.dart
+++ b/packages/flutter/lib/src/widgets/mixed_viewport.dart
@@ -552,14 +552,12 @@ class _MixedViewportElement extends RenderObjectElement<MixedViewport> {
     if (haveChildren) {
       // Place all our children in our RenderObject.
       // All the children we are placing are in builtChildren and newChildren.
-      // We will walk them backwards so we can set the slots at the same time.
-      Element nextSibling = null;
-      while (index > startIndex) {
-        index -= 1;
-        final Element element = builtChildren[index];
-        if (element.slot != nextSibling)
-          updateSlotForChild(element, nextSibling);
-        nextSibling = element;
+      Element previousChild = null;
+      for (int i = startIndex; i < index; ++i) {
+        final Element element = builtChildren[i];
+        if (element.slot != previousChild)
+          updateSlotForChild(element, previousChild);
+        previousChild = element;
       }
     }
 
@@ -577,20 +575,19 @@ class _MixedViewportElement extends RenderObjectElement<MixedViewport> {
     if (slot == _omit)
       return;
     assert(slot == null || slot is Element);
-    RenderObject nextSibling = slot?.renderObject;
-    renderObject.add(child, before: nextSibling);
+    renderObject.insert(child, after: slot?.renderObject);
   }
 
   void moveChildRenderObject(RenderObject child, dynamic slot) {
     if (slot == _omit)
       return;
     assert(slot == null || slot is Element);
-    RenderObject nextSibling = slot?.renderObject;
-    assert(nextSibling == null || nextSibling.parent == renderObject);
+    RenderObject previousSibling = slot?.renderObject;
+    assert(previousSibling == null || previousSibling.parent == renderObject);
     if (child.parent == renderObject)
-      renderObject.move(child, before: nextSibling);
+      renderObject.move(child, after: previousSibling);
     else
-      renderObject.add(child, before: nextSibling);
+      renderObject.insert(child, after: previousSibling);
   }
 
   void removeChildRenderObject(RenderObject child) {

--- a/packages/flutter/lib/src/widgets/virtual_viewport.dart
+++ b/packages/flutter/lib/src/widgets/virtual_viewport.dart
@@ -149,14 +149,12 @@ abstract class VirtualViewportElement<T extends VirtualViewport> extends RenderO
   }
 
   void insertChildRenderObject(RenderObject child, Element slot) {
-    RenderObject nextSibling = slot?.renderObject;
-    renderObject.add(child, before: nextSibling);
+    renderObject.insert(child, after: slot?.renderObject);
   }
 
   void moveChildRenderObject(RenderObject child, Element slot) {
     assert(child.parent == renderObject);
-    RenderObject nextSibling = slot?.renderObject;
-    renderObject.move(child, before: nextSibling);
+    renderObject.move(child, after: slot?.renderObject);
   }
 
   void removeChildRenderObject(RenderObject child) {

--- a/packages/flutter/test/widget/focus_test.dart
+++ b/packages/flutter/test/widget/focus_test.dart
@@ -36,16 +36,15 @@ void main() {
         new Focus(
           child: new Column(
             children: <Widget>[
-              // reverse these when you fix https://github.com/flutter/engine/issues/1495
-              new TestFocusable(
-                key: keyB,
-                no: 'b',
-                yes: 'B FOCUSED'
-              ),
               new TestFocusable(
                 key: keyA,
                 no: 'a',
                 yes: 'A FOCUSED'
+              ),
+              new TestFocusable(
+                key: keyB,
+                no: 'b',
+                yes: 'B FOCUSED'
               ),
             ]
           )


### PR DESCRIPTION
This patch changes the framework to walk the child list forwards so that build
functions with global side effects do sensible things. Specifically, if you
have a number of autofocusable children, the first one the list will acquire
the focus because it gets built first now.

Fixes #182
