### PR TITLE
add explicit doc to override default from parent

### DIFF
--- a/packages/flutter/lib/src/widgets/transitions.dart
+++ b/packages/flutter/lib/src/widgets/transitions.dart
@@ -26,6 +26,7 @@ abstract class AnimatedComponent extends StatefulComponent {
 
   Widget build(BuildContext context);
 
+  /// Subclasses typically do not override this method.
   _AnimatedComponentState createState() => new _AnimatedComponentState();
 
   void debugFillDescription(List<String> description) {


### PR DESCRIPTION
Without this, dartdoc walks up the inheritance tree and uses a doc from a parent class. In this case, the doc from the parent class doesn't apply to AnimatedComponent's createState().  (See http://docs.flutter.io/flutter/widgets/AnimatedComponent/createState.html)

@abarth is this an accurate statement for this method? We could be more bold here if we want. "Should not override..."
