### PR TITLE
Allow collection of trace files when adbd is not running as root

### DIFF
--- a/packages/flutter_tools/lib/src/commands/trace.dart
+++ b/packages/flutter_tools/lib/src/commands/trace.dart
@@ -43,17 +43,18 @@ class TraceCommand extends FlutterCommand {
       devices.android.startTracing(androidApp);
       await new Future.delayed(
           new Duration(seconds: int.parse(argResults['duration'])),
-          () => _stopTracing(devices.android, androidApp));
+          () => _stopTracing(devices.android, androidApp)
+      );
     } else if (argResults['stop']) {
-      _stopTracing(devices.android, androidApp);
+      await _stopTracing(devices.android, androidApp);
     } else {
       devices.android.startTracing(androidApp);
     }
     return 0;
   }
 
-  void _stopTracing(AndroidDevice android, AndroidApk androidApp) {
-    String tracePath = android.stopTracing(androidApp, outPath: argResults['out']);
+  Future _stopTracing(AndroidDevice android, AndroidApk androidApp) async {
+    String tracePath = await android.stopTracing(androidApp, outPath: argResults['out']);
     if (tracePath == null) {
       logging.warning('No trace file saved.');
     } else {


### PR DESCRIPTION
Also fix a bug where the trace command may capture the wrong file
if multiple trace file paths are in the Android log buffer.

Previously we found a lower bound timestamp for the trace path log
by running the date command on the device and parsing the result on
the host.  This could yield an inaccurate result if the device and
host are using different time zones.

The command will now obtain the most recent timestamp in the device's
time format by running logcat.
