### PR TITLE
refactor the list command

### DIFF
--- a/packages/flutter_tools/lib/src/commands/daemon.dart
+++ b/packages/flutter_tools/lib/src/commands/daemon.dart
@@ -325,7 +325,7 @@ class AndroidDeviceDiscovery {
 
   void _initAdb() {
     if (_adb == null) {
-      _adb = new Adb(AndroidDevice.getAdbPath());
+      _adb = new Adb(getAdbPath());
       if (!_adb.exists())
         _adb = null;
     }

--- a/packages/flutter_tools/lib/src/commands/list.dart
+++ b/packages/flutter_tools/lib/src/commands/list.dart
@@ -3,71 +3,33 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:io';
 
-import '../android/device_android.dart';
-import '../ios/device_ios.dart';
+import '../device.dart';
 import '../runner/flutter_command.dart';
 
 class ListCommand extends FlutterCommand {
   final String name = 'list';
   final String description = 'List all connected devices.';
 
-  ListCommand() {
-    argParser.addFlag('details',
-        abbr: 'd',
-        negatable: false,
-        help: 'Log additional details about attached devices.');
-  }
-
   bool get requiresProjectRoot => false;
 
-  @override
   Future<int> runInProject() async {
-    connectToDevices();
+    DeviceManager deviceManager = new DeviceManager();
 
-    bool details = argResults['details'];
+    List<Device> devices = await deviceManager.getDevices();
 
-    if (details)
-      print('Android Devices:');
-
-    // TODO(devoncarew): We should have a more generic mechanism for device discovery.
-    // DeviceDiscoveryService? DeviceDiscoveryParticipant?
-    for (AndroidDevice device in AndroidDevice.getAttachedDevices(devices.android)) {
-      if (details) {
-        print('${device.id}\t'
-            '${device.modelID}\t'
-            '${device.productID}\t'
-            '${device.deviceCodeName}');
-      } else {
-        print(device.id);
-      }
-    }
-
-    if (Platform.isMacOS) {
-      if (details)
-        print('iOS Devices:');
-
-      for (IOSDevice device in IOSDevice.getAttachedDevices(devices.iOS)) {
-        if (details) {
-          print('${device.id}\t${device.name}');
-        } else {
-          print(device.id);
-        }
-      }
-
-      if (details)
-        print('iOS Simulators:');
-
-      for (IOSSimulator device in IOSSimulator.getAttachedDevices(devices.iOSSimulator)) {
-        if (details) {
-          print('${device.id}\t${device.name}');
-        } else {
-          print(device.id);
-        }
+    if (devices.isEmpty) {
+      print('No connected devices.');
+    } else {
+      print('${devices.length} connected ${pluralize('device', devices.length)}:');
+      print('');
+      for (Device device in devices) {
+        print('${device.name} (${device.id})');
       }
     }
 
     return 0;
   }
 }
+
+String pluralize(String word, int count) => count == 1 ? word : word + 's';

--- a/packages/flutter_tools/lib/src/ios/device_ios.dart
+++ b/packages/flutter_tools/lib/src/ios/device_ios.dart
@@ -14,6 +14,32 @@ import '../build_configuration.dart';
 import '../device.dart';
 import '../toolchain.dart';
 
+class IOSDeviceDiscovery extends DeviceDiscovery {
+  List<Device> _devices = <Device>[];
+
+  bool get supportsPlatform => Platform.isMacOS;
+
+  Future init() {
+    _devices = IOSDevice.getAttachedDevices();
+    return new Future.value();
+  }
+
+  List<Device> get devices => _devices;
+}
+
+class IOSSimulatorDiscovery extends DeviceDiscovery {
+  List<Device> _devices = <Device>[];
+
+  bool get supportsPlatform => Platform.isMacOS;
+
+  Future init() {
+    _devices = IOSSimulator.getAttachedDevices();
+    return new Future.value();
+  }
+
+  List<Device> get devices => _devices;
+}
+
 class IOSDevice extends Device {
   static final String defaultDeviceID = 'default_ios_id';
 
@@ -90,7 +116,7 @@ class IOSDevice extends Device {
     String informerPath = (mockIOS != null)
         ? mockIOS.informerPath
         : _checkForCommand('ideviceinfo');
-    return runSync([informerPath, '-k', 'DeviceName', '-u', deviceID]);
+    return runSync([informerPath, '-k', 'DeviceName', '-u', deviceID]).trim();
   }
 
   static final Map<String, String> _commandMap = {};

--- a/packages/flutter_tools/test/device_test.dart
+++ b/packages/flutter_tools/test/device_test.dart
@@ -1,0 +1,19 @@
+// Copyright 2015 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_tools/src/device.dart';
+import 'package:test/test.dart';
+
+main() => defineTests();
+
+defineTests() {
+  group('DeviceManager', () {
+    test('getDevices', () async {
+      // Test that DeviceManager.getDevices() doesn't throw.
+      DeviceManager deviceManager = new DeviceManager();
+      List<Device> devices = await deviceManager.getDevices();
+      expect(devices, isList);
+    });
+  });
+}


### PR DESCRIPTION
Refactor the list command:
- Create a DeviceManager class which can provide a list of all connected devices
- Create a DeviceDiscovery interface, and three implementations (android, ios, ios simulator)
- have `flutter list` use this API; its implementation gets much simpler
- drop the `-d` cli arg
- re-do the `list` output

old output:

```
[~/projects/flutter/flutter] flutter list
05a02bac
0afdca8704778c765a61e98a7d4415173ca11a4c

[~/projects/flutter/flutter] flutter list -d
Android Devices:
05a02bac    Nexus_7 razor   flo
iOS Devices:
0afdca8704778c765a61e98a7d4415173ca11a4c    Devon Carew’s iPod

iOS Simulators:
```

new output:

```
No connected devices.
```

```
3 connected devices:

Nexus 7 (05a02bac)
Nexus 5X (00bc2d02b19217ad)
iPhone 6s Plus (8AC808E1-6BAE-4153-BBC5-77F83814D414)
```
