### PR TITLE
rename the init command to create

### DIFF
--- a/packages/flutter_tools/lib/executable.dart
+++ b/packages/flutter_tools/lib/executable.dart
@@ -14,8 +14,8 @@ import 'src/commands/analyze.dart';
 import 'src/commands/apk.dart';
 import 'src/commands/build.dart';
 import 'src/commands/cache.dart';
+import 'src/commands/create.dart';
 import 'src/commands/daemon.dart';
-import 'src/commands/init.dart';
 import 'src/commands/install.dart';
 import 'src/commands/ios.dart';
 import 'src/commands/list.dart';
@@ -60,8 +60,8 @@ Future main(List<String> args) async {
     ..addCommand(new ApkCommand())
     ..addCommand(new BuildCommand())
     ..addCommand(new CacheCommand())
+    ..addCommand(new CreateCommand())
     ..addCommand(new DaemonCommand())
-    ..addCommand(new InitCommand())
     ..addCommand(new InstallCommand())
     ..addCommand(new IOSCommand())
     ..addCommand(new ListCommand())
@@ -75,6 +75,11 @@ Future main(List<String> args) async {
     ..addCommand(new UpgradeCommand());
 
   return Chain.capture(() async {
+    // Convert `flutter init` invocations to `flutter create` ones.
+    // TODO(devoncarew): Remove this after a few releases.
+    if (args.isNotEmpty && args[0] == 'init')
+      args[0] = 'create';
+
     dynamic result = await runner.run(args);
     if (result is int)
       exit(result);

--- a/packages/flutter_tools/lib/src/commands/create.dart
+++ b/packages/flutter_tools/lib/src/commands/create.dart
@@ -14,11 +14,11 @@ import '../artifacts.dart';
 import '../base/logging.dart';
 import '../base/process.dart';
 
-class InitCommand extends Command {
-  final String name = 'init';
+class CreateCommand extends Command {
+  final String name = 'create';
   final String description = 'Create a new Flutter project.';
 
-  InitCommand() {
+  CreateCommand() {
     argParser.addOption('out', abbr: 'o', help: 'The output directory.');
     argParser.addFlag('pub',
         defaultsTo: true,
@@ -46,7 +46,6 @@ class InitCommand extends Command {
       return 2;
     }
 
-    // TODO: Confirm overwrite of an existing directory with the user.
     Directory out = new Directory(argResults['out']);
 
     new FlutterSimpleTemplate().generateInto(out, flutterPackagePath);

--- a/packages/flutter_tools/test/create_test.dart
+++ b/packages/flutter_tools/test/create_test.dart
@@ -7,14 +7,14 @@ import 'dart:io';
 import 'package:args/command_runner.dart';
 import 'package:path/path.dart' as path;
 import 'package:flutter_tools/src/artifacts.dart';
-import 'package:flutter_tools/src/commands/init.dart';
+import 'package:flutter_tools/src/commands/create.dart';
 import 'package:flutter_tools/src/base/process.dart';
 import 'package:test/test.dart';
 
 main() => defineTests();
 
 defineTests() {
-  group('init', () {
+  group('create', () {
     Directory temp;
 
     setUp(() {
@@ -31,17 +31,18 @@ defineTests() {
       // Verify that we create a project that is well-formed.
       test('flutter-simple', () async {
         ArtifactStore.flutterRoot = '../..';
-        InitCommand command = new InitCommand();
+        CreateCommand command = new CreateCommand();
         CommandRunner runner = new CommandRunner('test_flutter', '')
           ..addCommand(command);
-        await runner.run(['init', '--out', temp.path])
+        await runner.run(['create', '--out', temp.path])
             .then((int code) => expect(code, equals(0)));
 
         String mainPath = path.join(temp.path, 'lib', 'main.dart');
         expect(new File(mainPath).existsSync(), true);
         ProcessResult exec = Process.runSync(
-            sdkBinaryName('dartanalyzer'), ['--fatal-warnings', mainPath],
-            workingDirectory: temp.path);
+          sdkBinaryName('dartanalyzer'), ['--fatal-warnings', mainPath],
+          workingDirectory: temp.path
+        );
         if (exec.exitCode != 0) {
           print(exec.stdout);
           print(exec.stderr);


### PR DESCRIPTION
- rename the `init` command to `create`
- support calls to `init` for the time being, to gives tools time where they can call both the old and the new command
- fix https://github.com/flutter/flutter/issues/1373
