### PR TITLE
Unify logging

### DIFF
--- a/packages/flutter_tools/lib/executable.dart
+++ b/packages/flutter_tools/lib/executable.dart
@@ -6,9 +6,9 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:args/command_runner.dart';
-import 'package:logging/logging.dart';
 import 'package:stack_trace/stack_trace.dart';
 
+import 'src/base/context.dart';
 import 'src/base/process.dart';
 import 'src/commands/analyze.dart';
 import 'src/commands/apk.dart';
@@ -33,28 +33,6 @@ import 'src/runner/flutter_command_runner.dart';
 ///
 /// This function is intended to be used from the [flutter] command line tool.
 Future main(List<String> args) async {
-  DateTime startTime = new DateTime.now();
-
-  // This level can be adjusted by users through the `--verbose` option.
-  Logger.root.level = Level.WARNING;
-  Logger.root.onRecord.listen((LogRecord record) {
-    String prefix = '';
-    if (Logger.root.level <= Level.FINE) {
-      Duration elapsed = record.time.difference(startTime);
-      prefix = '[${elapsed.inMilliseconds.toString().padLeft(4)} ms] ';
-    }
-    String level = record.level.name.toLowerCase();
-    if (record.level >= Level.WARNING) {
-      stderr.writeln('$prefix$level: ${record.message}');
-    } else {
-      print('$prefix$level: ${record.message}');
-    }
-    if (record.error != null)
-      stderr.writeln(record.error);
-    if (record.stackTrace != null)
-      stderr.writeln(record.stackTrace);
-  });
-
   FlutterCommandRunner runner = new FlutterCommandRunner()
     ..addCommand(new AnalyzeCommand())
     ..addCommand(new ApkCommand())
@@ -92,8 +70,7 @@ Future main(List<String> args) async {
       // We've caught an exit code.
       exit(error.exitCode);
     } else {
-      stderr.writeln(error);
-      Logger.root.log(Level.SEVERE, '\nException:', null, chain.terse.toTrace());
+      printError(error, chain.terse.toTrace());
       exit(1);
     }
   });

--- a/packages/flutter_tools/lib/src/android/adb.dart
+++ b/packages/flutter_tools/lib/src/android/adb.dart
@@ -5,7 +5,7 @@
 import 'dart:async';
 import 'dart:io';
 
-import '../base/logging.dart';
+import '../base/context.dart';
 import '../base/process.dart';
 
 // https://android.googlesource.com/platform/system/core/+/android-4.4_r1/adb/OVERVIEW.TXT
@@ -83,11 +83,11 @@ class Adb {
     controller = new StreamController(
       onListen: () async {
         socket = await Socket.connect(InternetAddress.LOOPBACK_IP_V4, adbServerPort);
-        logging.fine('--> host:track-devices');
+        printTrace('--> host:track-devices');
         socket.add(_createAdbRequest('host:track-devices'));
         socket.listen((List<int> data) {
           String stringResult = new String.fromCharCodes(data);
-          logging.fine('<-- ${stringResult.trim()}');
+          printTrace('<-- ${stringResult.trim()}');
           _AdbServerResponse response = new _AdbServerResponse(
             stringResult,
             noStatus: !isFirstNotification
@@ -116,14 +116,14 @@ class Adb {
     Socket socket = await Socket.connect(InternetAddress.LOOPBACK_IP_V4, adbServerPort);
 
     try {
-      logging.fine('--> $command');
+      printTrace('--> $command');
       socket.add(_createAdbRequest(command));
       List<List<int>> result = await socket.toList();
       List<int> data = result.fold(<int>[], (List<int> previous, List<int> element) {
         return previous..addAll(element);
       });
       String stringResult = new String.fromCharCodes(data);
-      logging.fine('<-- ${stringResult.trim()}');
+      printTrace('<-- ${stringResult.trim()}');
       return stringResult;
     } finally {
       socket.destroy();

--- a/packages/flutter_tools/lib/src/base/context.dart
+++ b/packages/flutter_tools/lib/src/base/context.dart
@@ -1,0 +1,70 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:io';
+
+final AppContext _defaultContext = new _DefaultAppContext();
+
+/// A singleton for application functionality. This singleton can be different
+/// on a per-Zone basis.
+AppContext get context {
+  AppContext currentContext = Zone.current['context'];
+  return currentContext == null ? _defaultContext : currentContext;
+}
+
+/// Display an error level message to the user. Commands should use this if they
+/// fail in some way.
+void printError(String message, [StackTrace stackTrace]) => context.printError(message, stackTrace);
+
+/// Display normal output of the command. This should be used for things like
+/// progress messages, success messages, or just normal command output.
+void printStatus(String message) => context.printStatus(message);
+
+/// Use this for verbose tracing output. Users can turn this output on in order
+/// to help diagnose issues with the toolchain or with their setup.
+void printTrace(String message) => context.printTrace(message);
+
+abstract class AppContext {
+  bool get verbose;
+  set verbose(bool value);
+
+  void printError(String message, [StackTrace stackTrace]);
+  void printStatus(String message);
+  void printTrace(String message);
+}
+
+class _DefaultAppContext implements AppContext {
+  DateTime _startTime = new DateTime.now();
+
+  bool _verbose = false;
+
+  bool get verbose => _verbose;
+
+  set verbose(bool value) {
+    _verbose = value;
+  }
+
+  void printError(String message, [StackTrace stackTrace]) {
+    stderr.writeln(_prefix + message);
+    if (stackTrace != null)
+      stderr.writeln(stackTrace);
+  }
+
+  void printStatus(String message) {
+    print(_prefix + message);
+  }
+
+  void printTrace(String message) {
+    if (_verbose)
+      print('$_prefix- $message');
+  }
+
+  String get _prefix {
+    if (!_verbose)
+      return '';
+    Duration elapsed = new DateTime.now().difference(_startTime);
+    return '[${elapsed.inMilliseconds.toString().padLeft(4)} ms] ';
+  }
+}

--- a/packages/flutter_tools/lib/src/base/logging.dart
+++ b/packages/flutter_tools/lib/src/base/logging.dart
@@ -1,7 +1,0 @@
-// Copyright 2015 The Chromium Authors. All rights reserved.
-// Use of this source code is governed by a BSD-style license that can be
-// found in the LICENSE file.
-
-import 'package:logging/logging.dart';
-
-final Logger logging = new Logger('flutter_tools');

--- a/packages/flutter_tools/lib/src/build_configuration.dart
+++ b/packages/flutter_tools/lib/src/build_configuration.dart
@@ -6,7 +6,7 @@ import 'dart:io';
 
 import 'package:path/path.dart' as path;
 
-import 'base/logging.dart';
+import 'base/context.dart';
 
 enum BuildType {
   prebuilt,
@@ -32,7 +32,7 @@ HostPlatform getCurrentHostPlatform() {
     return HostPlatform.mac;
   if (Platform.isLinux)
     return HostPlatform.linux;
-  logging.warning('Unsupported host platform, defaulting to Linux');
+  printError('Unsupported host platform, defaulting to Linux');
   return HostPlatform.linux;
 }
 
@@ -41,7 +41,7 @@ TargetPlatform getCurrentHostPlatformAsTarget() {
     return TargetPlatform.mac;
   if (Platform.isLinux)
     return TargetPlatform.linux;
-  logging.warning('Unsupported host platform, defaulting to Linux');
+  printError('Unsupported host platform, defaulting to Linux');
   return TargetPlatform.linux;
 }
 

--- a/packages/flutter_tools/lib/src/commands/apk.dart
+++ b/packages/flutter_tools/lib/src/commands/apk.dart
@@ -11,8 +11,8 @@ import 'package:yaml/yaml.dart';
 
 import '../android/device_android.dart';
 import '../artifacts.dart';
+import '../base/context.dart';
 import '../base/file_system.dart';
-import '../base/logging.dart';
 import '../base/process.dart';
 import '../build_configuration.dart';
 import '../flx.dart' as flx;
@@ -251,25 +251,25 @@ class ApkCommand extends FlutterCommand {
 
     if (!components.resources.existsSync()) {
       // TODO(eseidel): This level should be higher when path is manually set.
-      logging.info('Can not locate Resources: ${components.resources}, ignoring.');
+      printStatus('Can not locate Resources: ${components.resources}, ignoring.');
       components.resources = null;
     }
 
     if (!components.androidSdk.existsSync()) {
-      logging.severe('Can not locate Android SDK: $androidSdkPath');
+      printError('Can not locate Android SDK: $androidSdkPath');
       return null;
     }
     if (!(new _ApkBuilder(components.androidSdk.path).checkSdkPath())) {
-      logging.severe('Can not locate expected Android SDK tools at $androidSdkPath');
-      logging.severe('You must install version $_kAndroidPlatformVersion of the SDK platform');
-      logging.severe('and version $_kBuildToolsVersion of the build tools.');
+      printError('Can not locate expected Android SDK tools at $androidSdkPath');
+      printError('You must install version $_kAndroidPlatformVersion of the SDK platform');
+      printError('and version $_kBuildToolsVersion of the build tools.');
       return null;
     }
     for (File f in [components.manifest, components.icuData,
                     components.libSkyShell, components.debugKeystore]
                     ..addAll(components.jars)) {
       if (!f.existsSync()) {
-        logging.severe('Can not locate file: ${f.path}');
+        printError('Can not locate file: ${f.path}');
         return null;
       }
     }
@@ -327,7 +327,7 @@ class ApkCommand extends FlutterCommand {
       ensureDirectoryExists(finalApk.path);
       builder.align(unalignedApk, finalApk);
 
-      print('APK generated: ${finalApk.path}');
+      printStatus('APK generated: ${finalApk.path}');
 
       return 0;
     } finally {
@@ -342,7 +342,7 @@ class ApkCommand extends FlutterCommand {
     String keyPassword;
 
     if (argResults['keystore'].isEmpty) {
-      logging.warning('Signing the APK using the debug keystore');
+      printError('Signing the APK using the debug keystore');
       keystore = components.debugKeystore;
       keystorePassword = _kDebugKeystorePassword;
       keyAlias = _kDebugKeystoreKeyAlias;
@@ -352,7 +352,7 @@ class ApkCommand extends FlutterCommand {
       keystorePassword = argResults['keystore-password'];
       keyAlias = argResults['keystore-key-alias'];
       if (keystorePassword.isEmpty || keyAlias.isEmpty) {
-        logging.severe('Must provide a keystore password and a key alias');
+        printError('Must provide a keystore password and a key alias');
         return 1;
       }
       keyPassword = argResults['keystore-key-password'];
@@ -373,7 +373,7 @@ class ApkCommand extends FlutterCommand {
 
     _ApkComponents components = await _findApkComponents(config);
     if (components == null) {
-      logging.severe('Unable to build APK.');
+      printError('Unable to build APK.');
       return 1;
     }
 
@@ -381,8 +381,8 @@ class ApkCommand extends FlutterCommand {
 
     if (!flxPath.isEmpty) {
       if (!FileSystemEntity.isFileSync(flxPath)) {
-        logging.severe('FLX does not exist: $flxPath');
-        logging.severe('(Omit the --flx option to build the FLX automatically)');
+        printError('FLX does not exist: $flxPath');
+        printError('(Omit the --flx option to build the FLX automatically)');
         return 1;
       }
       return _buildApk(components, flxPath);

--- a/packages/flutter_tools/lib/src/commands/build.dart
+++ b/packages/flutter_tools/lib/src/commands/build.dart
@@ -4,7 +4,7 @@
 
 import 'dart:async';
 
-import '../base/logging.dart';
+import '../base/context.dart';
 import '../flx.dart';
 import '../runner/flutter_command.dart';
 import '../toolchain.dart';
@@ -45,9 +45,9 @@ class BuildCommand extends FlutterCommand {
       precompiledSnapshot: argResults['precompiled']
     ).then((int result) {
       if (result == 0)
-        print('Built $outputPath.');
+        printStatus('Built $outputPath.');
       else
-        logging.severe('Error building $outputPath: $result.');
+        printError('Error building $outputPath: $result.');
       return result;
     });
   }

--- a/packages/flutter_tools/lib/src/commands/list.dart
+++ b/packages/flutter_tools/lib/src/commands/list.dart
@@ -4,6 +4,7 @@
 
 import 'dart:async';
 
+import '../base/context.dart';
 import '../device.dart';
 import '../runner/flutter_command.dart';
 
@@ -19,12 +20,13 @@ class ListCommand extends FlutterCommand {
     List<Device> devices = await deviceManager.getDevices();
 
     if (devices.isEmpty) {
-      print('No connected devices.');
+      printStatus('No connected devices.');
     } else {
-      print('${devices.length} connected ${pluralize('device', devices.length)}:');
-      print('');
+      printStatus('${devices.length} connected ${pluralize('device', devices.length)}:');
+      printStatus('');
+
       for (Device device in devices) {
-        print('${device.name} (${device.id})');
+        printStatus('${device.name} (${device.id})');
       }
     }
 

--- a/packages/flutter_tools/lib/src/commands/listen.dart
+++ b/packages/flutter_tools/lib/src/commands/listen.dart
@@ -5,7 +5,7 @@
 import 'dart:async';
 import 'dart:io';
 
-import '../base/logging.dart';
+import '../base/context.dart';
 import '../base/process.dart';
 import 'start.dart';
 
@@ -36,7 +36,7 @@ class ListenCommand extends StartCommandBase {
     int result = 0;
     bool firstTime = true;
     do {
-      logging.info('Updating running Flutter apps...');
+      printStatus('Updating running Flutter apps...');
       result = await startApp(
         devices,
         applicationPackages,
@@ -58,7 +58,7 @@ class ListenCommand extends StartCommandBase {
       try {
         runCheckedSync(<String>['which', 'fswatch']);
       } catch (e) {
-        logging.severe('"listen" command is only useful if you have installed '
+        printError('"listen" command is only useful if you have installed '
             'fswatch on Mac.  Run "brew install fswatch" to install it with '
             'homebrew.');
         return null;
@@ -68,7 +68,7 @@ class ListenCommand extends StartCommandBase {
       try {
         runCheckedSync(<String>['which', 'inotifywait']);
       } catch (e) {
-        logging.severe('"listen" command is only useful if you have installed '
+        printError('"listen" command is only useful if you have installed '
             'inotifywait on Linux.  Run "apt-get install inotify-tools" or '
             'equivalent to install it.');
         return null;
@@ -82,18 +82,18 @@ class ListenCommand extends StartCommandBase {
         'modify,close_write,move,create,delete',
       ]..addAll(directories);
     } else {
-      logging.severe('"listen" command is only available on Mac and Linux.');
+      printError('"listen" command is only available on Mac and Linux.');
     }
     return null;
   }
 
   bool _watchDirectory(List<String> watchCommand) {
-    logging.info('Attempting to listen to these directories: ${watchCommand.join(", ")}');
+    printStatus('Attempting to listen to these directories: ${watchCommand.join(", ")}');
     assert(watchCommand != null);
     try {
       runCheckedSync(watchCommand);
     } catch (e) {
-      logging.warning('Watching directories failed.', e);
+      printError('Watching directories failed.', e);
       return false;
     }
     return true;

--- a/packages/flutter_tools/lib/src/commands/run_mojo.dart
+++ b/packages/flutter_tools/lib/src/commands/run_mojo.dart
@@ -5,11 +5,10 @@
 import 'dart:async';
 import 'dart:io';
 
-import 'package:logging/logging.dart';
 import 'package:path/path.dart' as path;
 
 import '../artifacts.dart';
-import '../base/logging.dart';
+import '../base/context.dart';
 import '../base/process.dart';
 import '../build_configuration.dart';
 import '../flx.dart' as flx;
@@ -119,12 +118,8 @@ class RunMojoCommand extends FlutterCommand {
     if (useDevtools) {
       final String buildFlag = argResults['mojo-debug'] ? '--debug' : '--release';
       args.add(buildFlag);
-      if (logging.level <= Level.INFO) {
+      if (context.verbose)
         args.add('--verbose');
-        if (logging.level <= Level.FINE) {
-          args.add('--verbose');
-        }
-      }
     }
 
     if (argResults['checked']) {
@@ -132,19 +127,19 @@ class RunMojoCommand extends FlutterCommand {
     }
 
     args.addAll(argResults.rest);
-    print(args);
+    printStatus('$args');
     return args;
   }
 
   @override
   Future<int> runInProject() async {
     if ((argResults['mojo-path'] == null && argResults['devtools-path'] == null) || (argResults['mojo-path'] != null && argResults['devtools-path'] != null)) {
-      logging.severe('Must specify either --mojo-path or --devtools-path.');
+      printError('Must specify either --mojo-path or --devtools-path.');
       return 1;
     }
 
     if (argResults['mojo-debug'] && argResults['mojo-release']) {
-      logging.severe('Cannot specify both --mojo-debug and --mojo-release');
+      printError('Cannot specify both --mojo-debug and --mojo-release');
       return 1;
     }
 

--- a/packages/flutter_tools/lib/src/commands/start.dart
+++ b/packages/flutter_tools/lib/src/commands/start.dart
@@ -8,7 +8,7 @@ import 'dart:io';
 import 'package:path/path.dart' as path;
 
 import '../application_package.dart';
-import '../base/logging.dart';
+import '../base/context.dart';
 import '../device.dart';
 import '../runner/flutter_command.dart';
 import '../toolchain.dart';
@@ -64,7 +64,7 @@ class StartCommand extends StartCommandBase {
 
   @override
   Future<int> runInProject() async {
-    logging.fine('Downloading toolchain.');
+    printTrace('Downloading toolchain.');
 
     await Future.wait([
       downloadToolchain(),
@@ -89,7 +89,7 @@ class StartCommand extends StartCommandBase {
       clearLogs: clearLogs
     );
 
-    logging.fine('Finished start command.');
+    printTrace('Finished start command.');
     return result;
   }
 }
@@ -113,17 +113,17 @@ Future<int> startApp(
     String message = 'Tried to run $mainPath, but that file does not exist.';
     if (target == null)
       message += '\nConsider using the -t option to specify the Dart file to start.';
-    logging.severe(message);
+    printError(message);
     return 1;
   }
 
   if (stop) {
-    logging.fine('Running stop command.');
+    printTrace('Running stop command.');
     stopAll(devices, applicationPackages);
   }
 
   if (install) {
-    logging.fine('Running install command.');
+    printTrace('Running install command.');
     installApp(devices, applicationPackages);
   }
 
@@ -134,7 +134,7 @@ Future<int> startApp(
     if (package == null || !device.isConnected())
       continue;
 
-    logging.fine('Running build command for $device.');
+    printTrace('Running build command for $device.');
 
     Map<String, dynamic> platformArgs = <String, dynamic>{};
 
@@ -155,7 +155,7 @@ Future<int> startApp(
     );
 
     if (!result) {
-      logging.severe('Could not start \'${package.name}\' on \'${device.id}\'');
+      printError('Could not start \'${package.name}\' on \'${device.id}\'');
     } else {
       startedSomething = true;
     }
@@ -163,9 +163,9 @@ Future<int> startApp(
 
   if (!startedSomething) {
     if (!devices.all.any((device) => device.isConnected())) {
-      logging.severe('Unable to run application - no connected devices.');
+      printError('Unable to run application - no connected devices.');
     } else {
-      logging.severe('Unable to run application.');
+      printError('Unable to run application.');
     }
   }
 

--- a/packages/flutter_tools/lib/src/commands/test.dart
+++ b/packages/flutter_tools/lib/src/commands/test.dart
@@ -9,7 +9,7 @@ import 'package:path/path.dart' as path;
 import 'package:test/src/executable.dart' as executable;
 
 import '../artifacts.dart';
-import '../base/logging.dart';
+import '../base/context.dart';
 import '../build_configuration.dart';
 import '../runner/flutter_command.dart';
 import '../test/loader.dart' as loader;
@@ -105,7 +105,7 @@ class TestCommand extends FlutterCommand {
       foundOne = true;
       loader.shellPath = path.absolute(await _getShellPath(config));
       if (!FileSystemEntity.isFileSync(loader.shellPath)) {
-          logging.severe('Cannot find Flutter shell at ${loader.shellPath}');
+          printError('Cannot find Flutter shell at ${loader.shellPath}');
         return 1;
       }
       await _runTests(testArgs, testDir);
@@ -113,7 +113,7 @@ class TestCommand extends FlutterCommand {
         return exitCode;
     }
     if (!foundOne) {
-      stderr.writeln('At least one of --debug or --release must be set, to specify the local build products to test.');
+      printError('At least one of --debug or --release must be set, to specify the local build products to test.');
       return 1;
     }
 

--- a/packages/flutter_tools/lib/src/commands/trace.dart
+++ b/packages/flutter_tools/lib/src/commands/trace.dart
@@ -6,7 +6,7 @@ import 'dart:async';
 
 import '../android/device_android.dart';
 import '../application_package.dart';
-import '../base/logging.dart';
+import '../base/context.dart';
 import '../runner/flutter_command.dart';
 
 class TraceCommand extends FlutterCommand {
@@ -30,7 +30,7 @@ class TraceCommand extends FlutterCommand {
     await downloadApplicationPackagesAndConnectToDevices();
 
     if (!devices.android.isConnected()) {
-      logging.warning('No device connected, so no trace was completed.');
+      printError('No device connected, so no trace was completed.');
       return 1;
     }
 
@@ -56,9 +56,9 @@ class TraceCommand extends FlutterCommand {
   Future _stopTracing(AndroidDevice android, AndroidApk androidApp) async {
     String tracePath = await android.stopTracing(androidApp, outPath: argResults['out']);
     if (tracePath == null) {
-      logging.warning('No trace file saved.');
+      printError('No trace file saved.');
     } else {
-      print('Trace file saved to $tracePath');
+      printStatus('Trace file saved to $tracePath');
     }
   }
 }

--- a/packages/flutter_tools/lib/src/commands/upgrade.dart
+++ b/packages/flutter_tools/lib/src/commands/upgrade.dart
@@ -5,6 +5,7 @@
 import 'dart:async';
 
 import '../artifacts.dart';
+import '../base/context.dart';
 import '../base/process.dart';
 import '../runner/flutter_command.dart';
 
@@ -19,7 +20,7 @@ class UpgradeCommand extends FlutterCommand {
         'git', 'rev-parse', '@{u}'
       ], workingDirectory: ArtifactStore.flutterRoot);
     } catch (e) {
-      print('Unable to upgrade Flutter. No upstream repository configured for Flutter.');
+      printError('Unable to upgrade Flutter. No upstream repository configured for Flutter.');
       return 1;
     }
 

--- a/packages/flutter_tools/lib/src/device.dart
+++ b/packages/flutter_tools/lib/src/device.dart
@@ -6,7 +6,7 @@ import 'dart:async';
 
 import 'android/device_android.dart';
 import 'application_package.dart';
-import 'base/logging.dart';
+import 'base/context.dart';
 import 'build_configuration.dart';
 import 'ios/device_ios.dart';
 import 'toolchain.dart';
@@ -132,7 +132,7 @@ class DeviceStore {
           (Device dev) => (dev.id == config.deviceId),
           orElse: () => null);
       if (device == null) {
-        logging.severe('Warning: Device ID ${config.deviceId} not found');
+        printError('Warning: Device ID ${config.deviceId} not found');
       }
     } else if (devices.length == 1) {
       // Step 2: If no identifier is specified and there is only one connected
@@ -140,8 +140,8 @@ class DeviceStore {
       device = devices[0];
     } else if (devices.length > 1) {
       // Step 3: D:
-      logging.fine('Multiple devices are connected, but no device ID was specified.');
-      logging.fine('Attempting to launch on all connected devices.');
+      printTrace('Multiple devices are connected, but no device ID was specified.');
+      printTrace('Attempting to launch on all connected devices.');
     }
 
     return device;

--- a/packages/flutter_tools/lib/src/flx.dart
+++ b/packages/flutter_tools/lib/src/flx.dart
@@ -12,8 +12,8 @@ import 'package:flx/signing.dart';
 import 'package:path/path.dart' as path;
 import 'package:yaml/yaml.dart';
 
+import 'base/context.dart';
 import 'base/file_system.dart';
-import 'base/logging.dart';
 import 'toolchain.dart';
 
 const String defaultMainPath = 'lib/main.dart';
@@ -158,7 +158,7 @@ Future<int> build(
   String privateKeyPath: defaultPrivateKeyPath,
   bool precompiledSnapshot: false
 }) async {
-  logging.fine('Building $outputPath');
+  printTrace('Building $outputPath');
 
   Map manifestDescriptor = _loadManifest(manifestPath);
 
@@ -174,7 +174,7 @@ Future<int> build(
     // content equivalents
     int result = await toolchain.compiler.compile(mainPath: mainPath, snapshotPath: snapshotPath);
     if (result != 0) {
-      logging.severe('Failed to run the Flutter compiler. Exit code: $result');
+      printError('Failed to run the Flutter compiler. Exit code: $result');
       return result;
     }
 
@@ -184,7 +184,7 @@ Future<int> build(
   for (_Asset asset in assets) {
     ArchiveFile file = _createFile(asset.key, asset.base);
     if (file == null) {
-      stderr.writeln('Cannot find asset "${asset.key}" in directory "${path.absolute(asset.base)}".');
+      printError('Cannot find asset "${asset.key}" in directory "${path.absolute(asset.base)}".');
       return 1;
     }
     archive.addFile(file);

--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -8,6 +8,7 @@ import 'dart:io';
 import 'package:args/command_runner.dart';
 
 import '../application_package.dart';
+import '../base/context.dart';
 import '../build_configuration.dart';
 import '../device.dart';
 import '../toolchain.dart';
@@ -55,7 +56,7 @@ abstract class FlutterCommand extends Command {
 
   bool validateProjectRoot() {
     if (!FileSystemEntity.isFileSync('pubspec.yaml')) {
-      stderr.writeln(projectRootValidationErrorMessage);
+      printError(projectRootValidationErrorMessage);
       return false;
     }
     return true;

--- a/packages/flutter_tools/lib/src/test/loader.dart
+++ b/packages/flutter_tools/lib/src/test/loader.dart
@@ -7,8 +7,6 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:path/path.dart' as path;
-import 'package:flutter_tools/src/test/json_socket.dart';
-import 'package:flutter_tools/src/test/remote_test.dart';
 import 'package:stack_trace/stack_trace.dart';
 import 'package:test/src/backend/group.dart';
 import 'package:test/src/backend/metadata.dart';
@@ -20,6 +18,9 @@ import 'package:test/src/runner/runner_suite.dart';
 import 'package:test/src/runner/vm/environment.dart';
 import 'package:test/src/util/io.dart';
 import 'package:test/src/util/remote_exception.dart';
+
+import 'json_socket.dart';
+import 'remote_test.dart';
 
 void installHook() {
   hack.loadVMFileHook = _loadVMFile;

--- a/packages/flutter_tools/lib/src/test/remote_listener.dart
+++ b/packages/flutter_tools/lib/src/test/remote_listener.dart
@@ -14,8 +14,8 @@ import 'package:test/src/backend/live_test.dart';
 import 'package:test/src/backend/metadata.dart';
 import 'package:test/src/backend/operating_system.dart';
 import 'package:test/src/backend/suite.dart';
-import 'package:test/src/backend/test_platform.dart';
 import 'package:test/src/backend/test.dart';
+import 'package:test/src/backend/test_platform.dart';
 import 'package:test/src/util/remote_exception.dart';
 
 final OperatingSystem currentOS = (() {

--- a/packages/flutter_tools/lib/src/test/remote_test.dart
+++ b/packages/flutter_tools/lib/src/test/remote_test.dart
@@ -5,18 +5,18 @@
 import 'dart:async';
 
 import 'package:stack_trace/stack_trace.dart';
+import 'package:test/src/backend/group.dart';
 import 'package:test/src/backend/live_test.dart';
 import 'package:test/src/backend/live_test_controller.dart';
 import 'package:test/src/backend/metadata.dart';
 import 'package:test/src/backend/operating_system.dart';
-import 'package:test/src/backend/group.dart';
 import 'package:test/src/backend/state.dart';
 import 'package:test/src/backend/suite.dart';
 import 'package:test/src/backend/test.dart';
 import 'package:test/src/backend/test_platform.dart';
 import 'package:test/src/util/remote_exception.dart';
 
-import 'package:flutter_tools/src/test/json_socket.dart';
+import 'json_socket.dart';
 
 class RemoteTest extends Test {
   RemoteTest(this.name, this.metadata, this._socket, this._index);

--- a/packages/flutter_tools/test/context_test.dart
+++ b/packages/flutter_tools/test/context_test.dart
@@ -1,0 +1,66 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:flutter_tools/src/base/context.dart';
+import 'package:test/test.dart';
+
+main() => defineTests();
+
+defineTests() {
+  group('DeviceManager', () {
+    test('error', () async {
+      MockContext mockContext = new MockContext();
+
+      runZoned(() {
+        printError('foo bar');
+      }, zoneValues: {'context': mockContext});
+
+      expect(mockContext.errorText, 'foo bar\n');
+      expect(mockContext.statusText, '');
+      expect(mockContext.traceText, '');
+    });
+
+    test('status', () async {
+      MockContext mockContext = new MockContext();
+
+      runZoned(() {
+        printStatus('foo bar');
+      }, zoneValues: {'context': mockContext});
+
+      expect(mockContext.errorText, '');
+      expect(mockContext.statusText, 'foo bar\n');
+      expect(mockContext.traceText, '');
+    });
+
+    test('trace', () async {
+      MockContext mockContext = new MockContext();
+
+      runZoned(() {
+        printTrace('foo bar');
+      }, zoneValues: {'context': mockContext});
+
+      expect(mockContext.errorText, '');
+      expect(mockContext.statusText, '');
+      expect(mockContext.traceText, 'foo bar\n');
+    });
+  });
+}
+
+class MockContext implements AppContext {
+  bool verbose = false;
+
+  StringBuffer _error = new StringBuffer();
+  StringBuffer _status = new StringBuffer();
+  StringBuffer _trace = new StringBuffer();
+
+  String get errorText => _error.toString();
+  String get statusText => _status.toString();
+  String get traceText => _trace.toString();
+
+  void printError(String message, [StackTrace stackTrace]) => _error.writeln(message);
+  void printStatus(String message) => _status.writeln(message);
+  void printTrace(String message) => _trace.writeln(message);
+}

--- a/packages/flutter_tools/test/create_test.dart
+++ b/packages/flutter_tools/test/create_test.dart
@@ -5,10 +5,10 @@
 import 'dart:io';
 
 import 'package:args/command_runner.dart';
-import 'package:path/path.dart' as path;
 import 'package:flutter_tools/src/artifacts.dart';
-import 'package:flutter_tools/src/commands/create.dart';
 import 'package:flutter_tools/src/base/process.dart';
+import 'package:flutter_tools/src/commands/create.dart';
+import 'package:path/path.dart' as path;
 import 'package:test/test.dart';
 
 main() => defineTests();

--- a/packages/flutter_tools/test/device_test.dart
+++ b/packages/flutter_tools/test/device_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2015 The Chromium Authors. All rights reserved.
+// Copyright 2016 The Chromium Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/flutter_tools/test/install_test.dart
+++ b/packages/flutter_tools/test/install_test.dart
@@ -3,8 +3,8 @@
 // found in the LICENSE file.
 
 import 'package:args/command_runner.dart';
-import 'package:mockito/mockito.dart';
 import 'package:flutter_tools/src/commands/install.dart';
+import 'package:mockito/mockito.dart';
 import 'package:test/test.dart';
 
 import 'src/mocks.dart';

--- a/packages/flutter_tools/test/list_test.dart
+++ b/packages/flutter_tools/test/list_test.dart
@@ -5,8 +5,8 @@
 import 'dart:io';
 
 import 'package:args/command_runner.dart';
-import 'package:mockito/mockito.dart';
 import 'package:flutter_tools/src/commands/list.dart';
+import 'package:mockito/mockito.dart';
 import 'package:test/test.dart';
 
 import 'src/mocks.dart';

--- a/packages/flutter_tools/test/listen_test.dart
+++ b/packages/flutter_tools/test/listen_test.dart
@@ -3,8 +3,8 @@
 // found in the LICENSE file.
 
 import 'package:args/command_runner.dart';
-import 'package:mockito/mockito.dart';
 import 'package:flutter_tools/src/commands/listen.dart';
+import 'package:mockito/mockito.dart';
 import 'package:test/test.dart';
 
 import 'src/mocks.dart';

--- a/packages/flutter_tools/test/logs_test.dart
+++ b/packages/flutter_tools/test/logs_test.dart
@@ -3,8 +3,8 @@
 // found in the LICENSE file.
 
 import 'package:args/command_runner.dart';
-import 'package:mockito/mockito.dart';
 import 'package:flutter_tools/src/commands/logs.dart';
+import 'package:mockito/mockito.dart';
 import 'package:test/test.dart';
 
 import 'src/mocks.dart';

--- a/packages/flutter_tools/test/os_utils_test.dart
+++ b/packages/flutter_tools/test/os_utils_test.dart
@@ -5,8 +5,8 @@
 import 'dart:io';
 
 import 'package:flutter_tools/src/base/os.dart';
-import 'package:test/test.dart';
 import 'package:path/path.dart' as path;
+import 'package:test/test.dart';
 
 main() => defineTests();
 

--- a/packages/flutter_tools/test/stop_test.dart
+++ b/packages/flutter_tools/test/stop_test.dart
@@ -3,8 +3,8 @@
 // found in the LICENSE file.
 
 import 'package:args/command_runner.dart';
-import 'package:mockito/mockito.dart';
 import 'package:flutter_tools/src/commands/stop.dart';
+import 'package:mockito/mockito.dart';
 import 'package:test/test.dart';
 
 import 'src/mocks.dart';

--- a/packages/flutter_tools/test/trace_test.dart
+++ b/packages/flutter_tools/test/trace_test.dart
@@ -3,8 +3,8 @@
 // found in the LICENSE file.
 
 import 'package:args/command_runner.dart';
-import 'package:mockito/mockito.dart';
 import 'package:flutter_tools/src/commands/trace.dart';
+import 'package:mockito/mockito.dart';
 import 'package:test/test.dart';
 
 import 'src/mocks.dart';


### PR DESCRIPTION
Re-work how we do logging in flutter_tools. Move everything to using `printError()`, `printStatus()`, and `printTrace()`. Use Zones so that some call paths in the app can override the default implementations (for testing, and for the daemon). 

Removed references to the `logging` package. We had not been specifying the package in the pubspec - just depending on it being available transitively. Probably a good case for an analysis lint.

I experimented with naming the methods `status()`, `error()`, and `trace()`. We could also just use `print()` for the status level messages, and capture the call with some more Zone work.

adding @Hixie since this relates to https://github.com/flutter/flutter/issues/461
