### PR TITLE
test command checks for test dir

### DIFF
--- a/packages/flutter_tools/lib/executable.dart
+++ b/packages/flutter_tools/lib/executable.dart
@@ -8,7 +8,6 @@ import 'dart:io';
 import 'package:args/command_runner.dart';
 import 'package:stack_trace/stack_trace.dart';
 
-import 'src/base/context.dart';
 import 'src/base/process.dart';
 import 'src/commands/analyze.dart';
 import 'src/commands/apk.dart';
@@ -70,7 +69,8 @@ Future main(List<String> args) async {
       // We've caught an exit code.
       exit(error.exitCode);
     } else {
-      printError(error, chain.terse.toTrace());
+      stderr.writeln(error);
+      stderr.writeln(chain.terse);
       exit(1);
     }
   });

--- a/packages/flutter_tools/lib/src/commands/test.dart
+++ b/packages/flutter_tools/lib/src/commands/test.dart
@@ -90,8 +90,14 @@ class TestCommand extends FlutterCommand {
 
     Directory testDir = runFlutterTests ? _flutterUnitTestDir : _currentPackageTestDir;
 
-    if (testArgs.isEmpty)
+    if (testArgs.isEmpty) {
+      if (!testDir.existsSync()) {
+        printError("Test directory '${testDir.path}' not found.");
+        return 1;
+      }
+
       testArgs.addAll(_findTests(testDir));
+    }
 
     testArgs.insert(0, '--');
     if (Platform.environment['TERM'] == 'dumb')


### PR DESCRIPTION
- if there's no `test/` dir, have the `flutter test` command complain (it was throwing an exception)
- fix a regression where the stack traces for exceptions reverted to a more verbose style (restore the terse stack traces)
