### PR TITLE
Add a --full-restart flag to the start command that controls whether …

### DIFF
--- a/packages/flutter_tools/lib/src/android/device_android.dart
+++ b/packages/flutter_tools/lib/src/android/device_android.dart
@@ -253,7 +253,6 @@ class AndroidDevice extends Device {
   }
 
   bool startBundle(AndroidApk apk, String bundlePath, {
-    bool poke: false,
     bool checked: true,
     bool traceStartup: false,
     String route,
@@ -266,8 +265,7 @@ class AndroidDevice extends Device {
       return false;
     }
 
-    if (!poke)
-      _forwardObservatoryPort();
+    _forwardObservatoryPort();
 
     if (clearLogs)
       this.clearLogs();
@@ -278,6 +276,7 @@ class AndroidDevice extends Device {
       'shell', 'am', 'start',
       '-a', 'android.intent.action.RUN',
       '-d', deviceTmpPath,
+      '-f', '0x20000000',  // FLAG_ACTIVITY_SINGLE_TOP
     ]);
     if (checked)
       cmd.addAll(['--ez', 'enable-checked-mode', 'true']);
@@ -309,7 +308,6 @@ class AndroidDevice extends Device {
         if (startBundle(
           package,
           buildResult.localBundlePath,
-          poke: platformArgs['poke'],
           checked: checked,
           traceStartup: platformArgs['trace-startup'],
           route: route,

--- a/packages/flutter_tools/lib/src/commands/start.dart
+++ b/packages/flutter_tools/lib/src/commands/start.dart
@@ -54,9 +54,9 @@ class StartCommand extends StartCommandBase {
                              '(defaults to checked/debug mode) (Android only).';
 
   StartCommand() {
-    argParser.addFlag('poke',
-        negatable: false,
-        help: 'Restart the connection to the server.');
+    argParser.addFlag('full-restart',
+        defaultsTo: true,
+        help: 'Stop any currently running application process before starting the app.');
     argParser.addFlag('clear-logs',
         defaultsTo: true,
         help: 'Clear log history before starting the app.');
@@ -71,21 +71,18 @@ class StartCommand extends StartCommandBase {
       downloadApplicationPackagesAndConnectToDevices(),
     ], eagerError: true);
 
-    bool poke = argResults['poke'];
     bool clearLogs = argResults['clear-logs'];
 
-    // Only stop and reinstall if the user did not specify a poke.
     int result = await startApp(
       devices,
       applicationPackages,
       toolchain,
       target: argResults['target'],
-      install: !poke,
-      stop: !poke,
+      install: true,
+      stop: argResults['full-restart'],
       checked: argResults['checked'],
       traceStartup: argResults['trace-startup'],
       route: argResults['route'],
-      poke: poke,
       clearLogs: clearLogs
     );
 
@@ -104,7 +101,6 @@ Future<int> startApp(
   bool checked: true,
   bool traceStartup: false,
   String route,
-  bool poke: false,
   bool clearLogs: false
 }) async {
 
@@ -138,8 +134,6 @@ Future<int> startApp(
 
     Map<String, dynamic> platformArgs = <String, dynamic>{};
 
-    if (poke != null)
-      platformArgs['poke'] = poke;
     if (traceStartup != null)
       platformArgs['trace-startup'] = traceStartup;
     if (clearLogs != null)


### PR DESCRIPTION
…we stop the application process

SkyActivity now allows reloading application Dart code within an existing
activity.  If a SkyActivity instance is already running, then passing
--no-full-restart will restart the Dart code without killing and restarting
the SkyShell application.
(full-restart will remain the default until the engine
that supports this is rolled out)

Also remove the obsolete --poke flag
