### PR TITLE
make --device-id work with ios devices too

### DIFF
--- a/packages/flutter_tools/lib/src/commands/start.dart
+++ b/packages/flutter_tools/lib/src/commands/start.dart
@@ -28,8 +28,6 @@ String findMainDartFile([String target]) {
   }
 }
 
-// We don't yet support iOS here. https://github.com/flutter/flutter/issues/1036
-
 abstract class StartCommandBase extends FlutterCommand {
   StartCommandBase() {
     argParser.addFlag('checked',
@@ -51,7 +49,7 @@ abstract class StartCommandBase extends FlutterCommand {
 class StartCommand extends StartCommandBase {
   final String name = 'start';
   final String description = 'Start your Flutter app on an attached device '
-                             '(defaults to checked/debug mode) (Android only).';
+                             '(defaults to checked/debug mode).';
 
   StartCommand() {
     argParser.addFlag('full-restart',
@@ -138,6 +136,8 @@ Future<int> startApp(
       platformArgs['trace-startup'] = traceStartup;
     if (clearLogs != null)
       platformArgs['clear-logs'] = clearLogs;
+
+    printStatus('Starting $mainPath on ${device.name}...');
 
     bool result = await device.startApp(
       package,

--- a/packages/flutter_tools/lib/src/device.dart
+++ b/packages/flutter_tools/lib/src/device.dart
@@ -131,17 +131,14 @@ class DeviceStore {
       device = devices.firstWhere(
           (Device dev) => (dev.id == config.deviceId),
           orElse: () => null);
-      if (device == null) {
-        printError('Warning: Device ID ${config.deviceId} not found');
-      }
     } else if (devices.length == 1) {
       // Step 2: If no identifier is specified and there is only one connected
       // device, pick that one.
       device = devices[0];
     } else if (devices.length > 1) {
       // Step 3: D:
-      printTrace('Multiple devices are connected, but no device ID was specified.');
-      printTrace('Attempting to launch on all connected devices.');
+      printStatus('Multiple devices are connected, but no device ID was specified.');
+      printStatus('Attempting to launch on all connected devices.');
     }
 
     return device;

--- a/packages/flutter_tools/lib/src/runner/flutter_command_runner.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command_runner.dart
@@ -42,8 +42,9 @@ class FlutterCommandRunner extends CommandRunner {
         help: 'The root directory of the Flutter repository. Defaults to \$$kFlutterRootEnvironmentVariableName if set,\n'
               'otherwise defaults to a value derived from the location of this tool.', defaultsTo: _defaultFlutterRoot);
 
-    argParser.addOption('android-device-id',
-        help: 'Serial number of the target Android device.');
+    argParser.addOption('device-id',
+        abbr: 'd',
+        help: 'Target device id.');
 
     argParser.addSeparator('Local build selection options (not normally required):');
     argParser.addFlag('debug',
@@ -208,7 +209,7 @@ class FlutterCommandRunner extends CommandRunner {
       configs.add(new BuildConfiguration.prebuilt(
         hostPlatform: hostPlatform,
         targetPlatform: TargetPlatform.android,
-        deviceId: globalResults['android-device-id']
+        deviceId: globalResults['device-id']
       ));
 
       if (hostPlatform == HostPlatform.linux) {
@@ -222,12 +223,14 @@ class FlutterCommandRunner extends CommandRunner {
       if (hostPlatform == HostPlatform.mac) {
         configs.add(new BuildConfiguration.prebuilt(
           hostPlatform: HostPlatform.mac,
-          targetPlatform: TargetPlatform.iOS
+          targetPlatform: TargetPlatform.iOS,
+          deviceId: globalResults['device-id']
         ));
 
         configs.add(new BuildConfiguration.prebuilt(
           hostPlatform: HostPlatform.mac,
-          targetPlatform: TargetPlatform.iOSSimulator
+          targetPlatform: TargetPlatform.iOSSimulator,
+          deviceId: globalResults['device-id']
         ));
       }
     } else {
@@ -244,7 +247,7 @@ class FlutterCommandRunner extends CommandRunner {
           targetPlatform: TargetPlatform.android,
           enginePath: enginePath,
           buildPath: globalResults['android-debug-build-path'],
-          deviceId: globalResults['android-device-id']
+          deviceId: globalResults['device-id']
         ));
 
         configs.add(new BuildConfiguration.local(
@@ -262,7 +265,8 @@ class FlutterCommandRunner extends CommandRunner {
             hostPlatform: hostPlatform,
             targetPlatform: TargetPlatform.iOS,
             enginePath: enginePath,
-            buildPath: globalResults['ios-debug-build-path']
+            buildPath: globalResults['ios-debug-build-path'],
+            deviceId: globalResults['device-id']
           ));
 
           configs.add(new BuildConfiguration.local(
@@ -270,7 +274,8 @@ class FlutterCommandRunner extends CommandRunner {
             hostPlatform: hostPlatform,
             targetPlatform: TargetPlatform.iOSSimulator,
             enginePath: enginePath,
-            buildPath: globalResults['ios-sim-debug-build-path']
+            buildPath: globalResults['ios-sim-debug-build-path'],
+            deviceId: globalResults['device-id']
           ));
         }
       }
@@ -282,7 +287,7 @@ class FlutterCommandRunner extends CommandRunner {
           targetPlatform: TargetPlatform.android,
           enginePath: enginePath,
           buildPath: globalResults['android-release-build-path'],
-          deviceId: globalResults['android-device-id']
+          deviceId: globalResults['device-id']
         ));
 
         configs.add(new BuildConfiguration.local(
@@ -300,7 +305,8 @@ class FlutterCommandRunner extends CommandRunner {
             hostPlatform: hostPlatform,
             targetPlatform: TargetPlatform.iOS,
             enginePath: enginePath,
-            buildPath: globalResults['ios-release-build-path']
+            buildPath: globalResults['ios-release-build-path'],
+            deviceId: globalResults['device-id']
           ));
 
           configs.add(new BuildConfiguration.local(
@@ -308,7 +314,8 @@ class FlutterCommandRunner extends CommandRunner {
             hostPlatform: hostPlatform,
             targetPlatform: TargetPlatform.iOSSimulator,
             enginePath: enginePath,
-            buildPath: globalResults['ios-sim-release-build-path']
+            buildPath: globalResults['ios-sim-release-build-path'],
+            deviceId: globalResults['device-id']
           ));
         }
       }


### PR DESCRIPTION
- change the `--android-device-id` flag to `--device-id` (or `-d`)
- make it work for iOS devices as well
- only start one device if a device id is specified
- print out the app name we're starting and the device it's starting on

```
[~/flutter/flutter_sunflower] flutter list
2 connected devices:

Nexus 7 (05a02bac)
iPhone 6s Plus (8AC808E1-6BAE-4153-BBC5-77F83814D414)

[~/flutter/flutter_sunflower] flutter start
Starting /Users/devoncarew/flutter/flutter_sunflower/lib/main.dart on Nexus 7...
Starting /Users/devoncarew/flutter/flutter_sunflower/lib/main.dart on iPhone 6s Plus...

[~/flutter/flutter_sunflower] flutter -d05a02bac start
Starting /Users/devoncarew/flutter/flutter_sunflower/lib/main.dart on Nexus 7...

[~/flutter/flutter_sunflower] flutter -d8AC808E1-6BAE-4153-BBC5-77F83814D414 start
Starting /Users/devoncarew/flutter/flutter_sunflower/lib/main.dart on iPhone 6s Plus...
```
