### PR TITLE
add the engine revision to --version

### DIFF
--- a/packages/flutter_tools/lib/src/artifacts.dart
+++ b/packages/flutter_tools/lib/src/artifacts.dart
@@ -204,7 +204,6 @@ class ArtifactStore {
 
   static String get engineRevision {
     if (_engineRevision == null) {
-      ensurePackageRootIsValid();
       File revisionFile = new File(path.join(packageRoot, 'sky_engine', 'REVISION'));
       if (revisionFile.existsSync())
         _engineRevision = revisionFile.readAsStringSync();

--- a/packages/flutter_tools/lib/src/commands/upgrade.dart
+++ b/packages/flutter_tools/lib/src/commands/upgrade.dart
@@ -8,6 +8,7 @@ import '../artifacts.dart';
 import '../base/context.dart';
 import '../base/process.dart';
 import '../runner/flutter_command.dart';
+import '../runner/version.dart';
 
 class UpgradeCommand extends FlutterCommand {
   final String name = 'upgrade';
@@ -15,6 +16,8 @@ class UpgradeCommand extends FlutterCommand {
 
   @override
   Future<int> runInProject() async {
+    printStatus(getVersion(ArtifactStore.flutterRoot));
+
     try {
       runCheckedSync(<String>[
         'git', 'rev-parse', '@{u}'
@@ -24,6 +27,9 @@ class UpgradeCommand extends FlutterCommand {
       return 1;
     }
 
+    printStatus('');
+    printStatus('Upgrading Flutter...');
+
     int code = await runCommandAndStreamOutput(<String>[
       'git', 'pull', '--ff-only'
     ], workingDirectory: ArtifactStore.flutterRoot);
@@ -31,6 +37,15 @@ class UpgradeCommand extends FlutterCommand {
     if (code != 0)
       return code;
 
-    return await runCommandAndStreamOutput([sdkBinaryName('pub'), 'upgrade']);
+    printStatus('');
+    code = await runCommandAndStreamOutput([sdkBinaryName('pub'), 'upgrade']);
+
+    if (code != 0)
+      return code;
+
+    printStatus('');
+    printStatus(getVersion(ArtifactStore.flutterRoot));
+
+    return 0;
   }
 }

--- a/packages/flutter_tools/lib/src/runner/version.dart
+++ b/packages/flutter_tools/lib/src/runner/version.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import '../artifacts.dart';
 import '../base/process.dart';
 
 String getVersion(String flutterRoot) {
@@ -20,5 +21,12 @@ String getVersion(String flutterRoot) {
   String revision = runSync([
     'git', 'log', '-n', '1', '--pretty=format:%H (%ar)'
   ], workingDirectory: flutterRoot).trim();
-  return 'Flutter\nRepository: $repository\nBranch: $upstream\nRevision: $revision';
+
+  String version = 'Flutter from $repository (on $upstream)\nflutter revision: $revision';
+
+  String engineRevision = ArtifactStore.engineRevision;
+  if (engineRevision != null)
+    version += '\nengine revision : $engineRevision';
+
+  return version;
 }


### PR DESCRIPTION
Related to https://github.com/flutter/flutter/issues/1470, show the engine revision in `--version`. This will make is easier for users to report engine revisions.

Also, for `upgrade`, print the version info before and after the upgrade.

New text for `--version`:

```
Flutter from https://github.com/flutter/flutter.git (on master)
flutter revision: 1b75de1b164a3c5f668933a7603aa9094c181aae (16 hours ago)
engine revision : 9ee9721b1b0379da1dae7ed27243da7635d55a3a
```
