### PR TITLE
fix two strong mode issues

### DIFF
--- a/packages/flutter/lib/src/widgets/semantics_debugger.dart
+++ b/packages/flutter/lib/src/widgets/semantics_debugger.dart
@@ -123,7 +123,9 @@ class _SemanticsDebuggerEntry {
   int findDepth() {
     if (children == null || children.isEmpty)
       return 1;
-    return children.map((_SemanticsDebuggerEntry e) => e.findDepth()).reduce(math.max) + 1;
+    return children.map((_SemanticsDebuggerEntry e) => e.findDepth()).reduce((int runningDepth, int nextDepth) {
+      return math.max(runningDepth, nextDepth);
+    }) + 1;
   }
 
   static const TextStyle textStyles = const TextStyle(
@@ -346,7 +348,7 @@ class _SemanticsDebuggerPainter extends CustomPainter {
   final Point pointerPosition;
   void paint(Canvas canvas, Size size) {
     _SemanticsDebuggerClient.instance.nodes[0]?.paint(
-      canvas, 
+      canvas,
       _SemanticsDebuggerClient.instance.nodes[0].findDepth()
     );
     if (pointerPosition != null) {


### PR DESCRIPTION
Fix two strong mode issues:

```
[error] Type check failed: math.max (<T extends num>(T, T) → T) is not of type (int, int) → int (flutter/packages/flutter/lib/src/widgets/semantics_debugger.dart, line 126, col 78)
[warning] The argument type '(T, T) → T' cannot be assigned to the parameter type '(int, int) → int' (flutter/packages/flutter/lib/src/widgets/semantics_debugger.dart, line 126, col 78)
```

See also https://github.com/flutter/flutter/pull/1478. TBR, @Hixie 
