### PR TITLE
Adds the ability to move the caret by tapping

### DIFF
--- a/packages/flutter/lib/src/painting/text_editing.dart
+++ b/packages/flutter/lib/src/painting/text_editing.dart
@@ -2,38 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Whether a [TextPosition] is visually upstream or downstream of its offset.
-///
-/// For example, when a text position exists at a line break, a single offset has
-/// two visual positions, one prior to the line break (at the end of the first
-/// line) and one after the line break (at the start of the second line). A text
-/// affinity disambiguates between those cases. (Something similar happens with
-/// between runs of bidirectional text.)
-enum TextAffinity {
-  /// The position has affinity for the upstream side of the text position.
-  ///
-  /// For example, if the offset of the text position is a line break, the
-  /// position represents the end of the first line.
-  upstream,
+import 'dart:ui' show TextAffinity, TextPosition;
 
-  /// The position has affinity for the downstream side of the text position.
-  ///
-  /// For example, if the offset of the text position is a line break, the
-  /// position represents the start of the second line.
-  downstream
-}
-
-/// A visual position in a string of text.
-class TextPosition {
-  const TextPosition({ this.offset, this.affinity: TextAffinity.downstream });
-
-  /// The index of the character just prior to the position.
-  final int offset;
-
-  /// If the offset has more than one visual location (e.g., occurs at a line
-  /// break), which of the two locations is represented by this position.
-  final TextAffinity affinity;
-}
+export 'dart:ui' show TextAffinity, TextPosition;
 
 /// A range of characters in a string of text.
 class TextRange {
@@ -97,9 +68,15 @@ class TextSelection extends TextRange {
 
   const TextSelection.collapsed({
     int offset,
-    this.affinity: TextAffinity.downstream,
-    this.isDirectional: false
-  }) : baseOffset = offset, extentOffset = offset, super.collapsed(offset);
+    this.affinity: TextAffinity.downstream
+  }) : baseOffset = offset, extentOffset = offset, isDirectional = false, super.collapsed(offset);
+
+  TextSelection.fromPosition(TextPosition position)
+    : baseOffset = position.offset,
+      extentOffset = position.offset,
+      affinity = position.affinity,
+      isDirectional = false,
+      super.collapsed(position.offset);
 
   /// The offset at which the selection originates.
   ///
@@ -141,4 +118,8 @@ class TextSelection extends TextRange {
   ///
   /// Might be larger than, smaller than, or equal to base.
   TextPosition get extent => new TextPosition(offset: extentOffset, affinity: affinity);
+
+  String toString() {
+    return '$runtimeType(baseOffset: $baseOffset, extentOffset: $extentOffset, affinity: $affinity, isDirectional: $isDirectional)';
+  }
 }

--- a/packages/flutter/lib/src/painting/text_painter.dart
+++ b/packages/flutter/lib/src/painting/text_painter.dart
@@ -265,4 +265,9 @@ class TextPainter {
     return _paragraph.getBoxesForRange(selection.start, selection.end);
   }
 
+  TextPosition getPositionForOffset(Offset offset) {
+    assert(!_needsLayout);
+    return _paragraph.getPositionForOffset(offset);
+  }
+
 }

--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -1115,9 +1115,6 @@ class RenderFractionalTranslation extends RenderProxyBox {
   }
 }
 
-/// Called when a size changes.
-typedef void SizeChangedCallback(Size newSize);
-
 /// Calls [onSizeChanged] whenever the child's layout size changes
 ///
 /// Because size observer calls its callback during layout, you cannot modify
@@ -1131,7 +1128,7 @@ class RenderSizeObserver extends RenderProxyBox {
   }
 
   /// The callback to call whenever the child's layout size changes
-  SizeChangedCallback onSizeChanged;
+  ValueChanged<Size> onSizeChanged;
 
   void performLayout() {
     Size oldSize = hasSize ? size : null;
@@ -1540,7 +1537,7 @@ class RenderSemanticAnnotations extends RenderProxyBox {
   /// If 'container' is true, this RenderObject will introduce a new
   /// node in the semantics tree. Otherwise, the semantics will be
   /// merged with the semantics of any ancestors.
-  /// 
+  ///
   /// The 'container' flag is implicitly set to true on the immediate
   /// semantics-providing descendants of a node where multiple
   /// children have semantics or have descendants providing semantics.

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -819,7 +819,7 @@ class SizeObserver extends OneChildRenderObjectWidget {
   }
 
   /// The callback to call whenever the child's layout size changes
-  final SizeChangedCallback onSizeChanged;
+  final ValueChanged<Size> onSizeChanged;
 
   RenderSizeObserver createRenderObject() => new RenderSizeObserver(onSizeChanged: onSizeChanged);
 

--- a/packages/flutter/lib/src/widgets/editable.dart
+++ b/packages/flutter/lib/src/widgets/editable.dart
@@ -158,6 +158,10 @@ class EditableString {
   /// The range of text that is currently selected.
   TextSelection get selection => _client.selection;
 
+  void setSelection(TextSelection selection) {
+    _client.selection = selection;
+  }
+
   /// A keyboard client stub that can be attached to a keyboard service.
   ///
   /// See [Keyboard].
@@ -180,7 +184,8 @@ class RawEditableLine extends Scrollable {
     this.hideText: false,
     this.style,
     this.cursorColor,
-    this.selectionColor
+    this.selectionColor,
+    this.onSelectionChanged
   }) : super(
     key: key,
     initialScrollOffset: 0.0,
@@ -204,6 +209,9 @@ class RawEditableLine extends Scrollable {
 
   /// The color to use when painting the selection.
   final Color selectionColor;
+
+  /// Called when the user requests a change to the selection.
+  final ValueChanged<TextSelection> onSelectionChanged;
 
   RawEditableTextState createState() => new RawEditableTextState();
 }
@@ -290,6 +298,7 @@ class RawEditableTextState extends ScrollableState<RawEditableLine> {
         selectionColor: config.selectionColor,
         hideText: config.hideText,
         onContentSizeChanged: _handleContentSizeChanged,
+        onSelectionChanged: config.onSelectionChanged,
         paintOffset: new Offset(-scrollOffset, 0.0)
       )
     );
@@ -306,6 +315,7 @@ class _EditableLineWidget extends LeafRenderObjectWidget {
     this.selectionColor,
     this.hideText,
     this.onContentSizeChanged,
+    this.onSelectionChanged,
     this.paintOffset
   }) : super(key: key);
 
@@ -315,7 +325,8 @@ class _EditableLineWidget extends LeafRenderObjectWidget {
   final bool showCursor;
   final Color selectionColor;
   final bool hideText;
-  final SizeChangedCallback onContentSizeChanged;
+  final ValueChanged<Size> onContentSizeChanged;
+  final ValueChanged<TextSelection> onSelectionChanged;
   final Offset paintOffset;
 
   RenderEditableLine createRenderObject() {
@@ -326,19 +337,22 @@ class _EditableLineWidget extends LeafRenderObjectWidget {
       selectionColor: selectionColor,
       selection: value.selection,
       onContentSizeChanged: onContentSizeChanged,
+      onSelectionChanged: onSelectionChanged,
       paintOffset: paintOffset
     );
   }
 
   void updateRenderObject(RenderEditableLine renderObject,
                           _EditableLineWidget oldWidget) {
-    renderObject.text = _styledTextSpan;
-    renderObject.cursorColor = cursorColor;
-    renderObject.showCursor = showCursor;
-    renderObject.selectionColor = selectionColor;
-    renderObject.selection = value.selection;
-    renderObject.onContentSizeChanged = onContentSizeChanged;
-    renderObject.paintOffset = paintOffset;
+    renderObject
+      ..text = _styledTextSpan
+      ..cursorColor = cursorColor
+      ..showCursor = showCursor
+      ..selectionColor = selectionColor
+      ..selection = value.selection
+      ..onContentSizeChanged = onContentSizeChanged
+      ..onSelectionChanged = onSelectionChanged
+      ..paintOffset = paintOffset;
   }
 
   StyledTextSpan get _styledTextSpan {


### PR DESCRIPTION
Now the text input control knows how to move the caret when you tap
inside the string. There's still some rough edges to polish up, but this
patch is the first step.

Fixes #108
