### PR TITLE
refactor flutter logs

### DIFF
--- a/packages/flutter_tools/lib/src/commands/ios.dart
+++ b/packages/flutter_tools/lib/src/commands/ios.dart
@@ -17,8 +17,6 @@ class IOSCommand extends FlutterCommand {
   final String name = "ios";
   final String description = "Commands for creating and updating Flutter iOS projects.";
 
-  final bool requiresProjectRoot = true;
-
   IOSCommand() {
     argParser.addFlag('init', help: 'Initialize the Xcode project for building the iOS application');
   }

--- a/packages/flutter_tools/lib/src/commands/start.dart
+++ b/packages/flutter_tools/lib/src/commands/start.dart
@@ -134,8 +134,6 @@ Future<int> startApp(
 
     if (traceStartup != null)
       platformArgs['trace-startup'] = traceStartup;
-    if (clearLogs != null)
-      platformArgs['clear-logs'] = clearLogs;
 
     printStatus('Starting ${_getDisplayPath(mainPath)} on ${device.name}...');
 
@@ -145,6 +143,7 @@ Future<int> startApp(
       mainPath: mainPath,
       route: route,
       checked: checked,
+      clearLogs: clearLogs,
       platformArgs: platformArgs
     );
 

--- a/packages/flutter_tools/lib/src/runner/flutter_command_runner.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command_runner.dart
@@ -142,11 +142,16 @@ class FlutterCommandRunner extends CommandRunner {
   String get _defaultFlutterRoot {
     if (Platform.environment.containsKey(kFlutterRootEnvironmentVariableName))
       return Platform.environment[kFlutterRootEnvironmentVariableName];
-    String script = Platform.script.toFilePath();
-    if (path.basename(script) == kSnapshotFileName)
-      return path.dirname(path.dirname(path.dirname(script)));
-    if (path.basename(script) == kFlutterToolsScriptFileName)
-      return path.dirname(path.dirname(path.dirname(path.dirname(script))));
+
+    try {
+      String script = Platform.script.toFilePath();
+      if (path.basename(script) == kSnapshotFileName)
+        return path.dirname(path.dirname(path.dirname(script)));
+      if (path.basename(script) == kFlutterToolsScriptFileName)
+        return path.dirname(path.dirname(path.dirname(path.dirname(script))));
+    } catch (error) {
+      printTrace('Unable to locate fluter root: $error');
+    }
     return '.';
   }
 

--- a/packages/flutter_tools/test/logs_test.dart
+++ b/packages/flutter_tools/test/logs_test.dart
@@ -4,7 +4,7 @@
 
 import 'package:args/command_runner.dart';
 import 'package:flutter_tools/src/commands/logs.dart';
-import 'package:mockito/mockito.dart';
+import 'package:flutter_tools/src/runner/flutter_command_runner.dart';
 import 'package:test/test.dart';
 
 import 'src/mocks.dart';
@@ -13,18 +13,13 @@ main() => defineTests();
 
 defineTests() {
   group('logs', () {
-    test('returns 0 when no device is connected', () {
+    test('fail with a bad device id', () {
       LogsCommand command = new LogsCommand();
       applyMocksToCommand(command);
-      MockDeviceStore mockDevices = command.devices;
-
-      when(mockDevices.android.isConnected()).thenReturn(false);
-      when(mockDevices.iOS.isConnected()).thenReturn(false);
-      when(mockDevices.iOSSimulator.isConnected()).thenReturn(false);
-
-      CommandRunner runner = new CommandRunner('test_flutter', '')
-        ..addCommand(command);
-      runner.run(['logs']).then((int code) => expect(code, equals(0)));
+      CommandRunner runner = new FlutterCommandRunner()..addCommand(command);
+      runner.run(<String>['-d', 'abc123', 'logs']).then((int code) {
+        expect(code, equals(1));
+      });
     });
   });
 }


### PR DESCRIPTION
Refactor the `flutter logs` command.
- fix https://github.com/flutter/flutter/issues/1377
- implement clear logs for ios simulator
- refactor logging so that a device can create and provide a LogReader. Different devices might create the same log reader - as in the case of android - or one per device. The logs command de-dups the log readers and then asks them to start reading the logs
- if there are no devices connected, print that and exit
- at start, print which devices we think we're listening to (`Logging for Android, iPhone 6s...`)
- change the logging prefix to use the device name
- log all the output from the ios simulator. This is very verbose, but filtering the log is problematic as not all lines important to the user mention flutter. We use some regexs to try and make the log output more readable.
- tail the simulator log starting from the first line. Otherwise the app can crash between between when `start` is run and `logs`, and the user will have no indication of the crash in the logs output
- in addition, listen to the system log for crashes in the simulator. This location is where info about crash report files are written.

```
Logging for iPhone 6s...
[iPhone 6s] CoreSimulatorBridge: Requesting installation of file:///Users/devoncarew/flutter/flutter_sunflower/ios/build/Release-iphonesimulator/Runner.app/ with options: {
[iPhone 6s]         CFBundleIdentifier = "io.flutter.runner.Runner";
[iPhone 6s]         PackageType = Developer;
[iPhone 6s]         SimulatorRootPath = "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk";
[iPhone 6s]         SimulatorUserPath = "/Users/devoncarew/Library/Developer/CoreSimulator/Devices/B0484E69-8A54-4CCF-8804-4780BD7D5DD4/data";
[iPhone 6s]     }
[iPhone 6s] CoreSimulatorBridge: LaunchServices: installing app for existing placeholder <LSApplicationProxy: 0x7fb30d205820> io.flutter.runner.Runner <(null) *Not found in database*>
[iPhone 6s] CoreSimulatorBridge: LaunchServices: Not creating progress for <LSApplicationProxy: 0x7fb30d205820> io.flutter.runner.Runner <(null) *Not found in database*> since it is not a placeholder.
[iPhone 6s] installd: 0x700000117000 -[MIClientConnection installPath:withOptions:completion:]: Install of "/Users/devoncarew/flutter/flutter_sunflower/ios/build/Release-iphonesimulator/Runner.app" type Developer (LSInstallType = (null)) requested by CoreSimulatorBridge (pid 90443)
[iPhone 6s] installd: 0x700000094000 MDMCreateDeltaDirectory: calling MDMDirectoryDiff with:
[iPhone 6s]     state->old_bundle: /Users/devoncarew/Library/Developer/CoreSimulator/Devices/B0484E69-8A54-4CCF-8804-4780BD7D5DD4/data/Containers/Bundle/Application/4588EF8A-7E17-46C7-92D1-B01570C81C35/Runner.app
[iPhone 6s]     state->new_bundle: /Users/devoncarew/flutter/flutter_sunflower/ios/build/Release-iphonesimulator/Runner.app
[iPhone 6s]     state->dst_bundle: /Users/devoncarew/Library/Developer/CoreSimulator/Devices/B0484E69-8A54-4CCF-8804-4780BD7D5DD4/data/Library/Caches/com.apple.mobile.installd.staging/temp.rKh3Am/extracted/Payload//Runner.app, binaryDiff flag: FALSE
[iPhone 6s]         dst_ipa: /Users/devoncarew/Library/Developer/CoreSimulator/Devices/B0484E69-8A54-4CCF-8804-4780BD7D5DD4/data/Library/Caches/com.apple.mobile.installd.staging/temp.rKh3Am/extracted
[iPhone 6s] installd: 0x70000019a000 __MDMDirectoryDiff_block_invoke37: calling writeDictToFile with: /Users/devoncarew/Library/Developer/CoreSimulator/Devices/B0484E69-8A54-4CCF-8804-4780BD7D5DD4/data/Library/Caches/com.apple.mobile.installd.staging/temp.rKh3Am/extracted/ManifestCache.plist
[iPhone 6s] installd: 0x70000019a000 writeDictToFile: ==== Successfully wrote Manifest cache to /Users/devoncarew/Library/Developer/CoreSimulator/Devices/B0484E69-8A54-4CCF-8804-4780BD7D5DD4/data/Library/Caches/com.apple.mobile.installd.staging/temp.rKh3Am/extracted/ManifestCache.plist
[iPhone 6s] installd: 0x700000094000 -[MIInstaller performInstallationWithError:]: Installing <MIInstallableBundlePatch ID=io.flutter.runner.Runner; Version=1, ShortVersion=1.0>
[iPhone 6s] installd: 0x700000094000 -[MIInstallableBundlePatch applyPatchWithError:]: Attempting patch update of io.flutter.runner.Runner from 1 (1.0) to 1 (1.0)
[iPhone 6s] installd: 0x700000094000 -[MIInstallableBundle _refreshUUIDForContainer:withError:]: Data container for io.flutter.runner.Runner is now at /Users/devoncarew/Library/Developer/CoreSimulator/Devices/B0484E69-8A54-4CCF-8804-4780BD7D5DD4/data/Containers/Data/Application/964BCE38-9CE9-44F4-9C67-EE98AC3459E2
[iPhone 6s] installd: 0x700000094000 -[MIContainer makeContainerLiveReplacingContainer:reason:withError:]: Made container live for io.flutter.runner.Runner at /Users/devoncarew/Library/Developer/CoreSimulator/Devices/B0484E69-8A54-4CCF-8804-4780BD7D5DD4/data/Containers/Bundle/Application/A20C9784-08B6-4A75-B12A-D6C981FCE61F
[iPhone 6s] installd: 0x700000094000 -[MIInstaller performInstallationWithError:]: Install Successful; Staging: 0.04s; Waiting: 0.00s; Preflight/Patch: 0.01s, Verifying: 0.00s; Overall: 0.07s
[iPhone 6s] CoreSimulatorBridge: LaunchServices: NotifiedObservers <LSApplicationProxy: 0x7fb30d30b2c0> io.flutter.runner.Runner <file:///Users/devoncarew/Library/Developer/CoreSimulator/Devices/B0484E69-8A54-4CCF-8804-4780BD7D5DD4/data/Containers/Bundle/Application/A20C9784-08B6-4A75-B12A-D6C981FCE61F/Runner.app> was installed
[iPhone 6s] lsd: LaunchServices: Updating identifier store
[iPhone 6s] pkd: releasing plug-in hold D2B2B2BD-10F2-4DA9-866D-ADFF5D3E895F at client's request
[iPhone 6s] SpringBoard: Installed apps did change.
[iPhone 6s]     Added: {(
[iPhone 6s]     )}
[iPhone 6s]     Removed: {(
[iPhone 6s]     )}
[iPhone 6s]     Modified: {(
[iPhone 6s]         "io.flutter.runner.Runner"
[iPhone 6s]     )}
[iPhone 6s] SpringBoard: throwing out icon because its isn't visible in the model : node=<SBApplicationIcon: 0x7fdc4ac45d50; nodeID: "com.apple.camera"> com.apple.camera
[iPhone 6s] searchd: tcp_connection_set_tfo 6 TFO is not yet supported on Simulator
[iPhone 6s] SpringBoard: Reply Error: Connection interrupted
[iPhone 6s] CoreSimulatorBridge: Requesting launch of io.flutter.runner.Runner with options: {
[iPhone 6s]         environment =     {
[iPhone 6s]         };
[iPhone 6s]     }
[iPhone 6s] assertiond: assertion failed: 15C50 13C75: assertiond + 12188 [8CF1968D-3466-38B7-B225-3F6F5B64C552]: 0x1
[iPhone 6s] SpringBoard: LICreateIconForImage passed NULL CGImageRef image
[iPhone 6s] backboardd: SecTaskLoadEntitlements failed error=22 cs_flags=200, task->pid_self=-1
[iPhone 6s] backboardd: SecTaskCopyDebugDescription: FlutterRunner[90982]
[iPhone 6s] backboardd: SecTaskLoadEntitlements failed error=22 cs_flags=200, task->pid_self=-1
[iPhone 6s] backboardd: SecTaskCopyDebugDescription: FlutterRunner[90982]
[iPhone 6s] backboardd: SecTaskLoadEntitlements failed error=22 cs_flags=200, task->pid_self=-1
[iPhone 6s] backboardd: SecTaskCopyDebugDescription: FlutterRunner[90982]
[iPhone 6s] backboardd: SecTaskLoadEntitlements failed error=22 cs_flags=200, task->pid_self=-1
[iPhone 6s] backboardd: SecTaskCopyDebugDescription: FlutterRunner[90982]
[iPhone 6s] backboardd: SecTaskLoadEntitlements failed error=22 cs_flags=200, task->pid_self=-1
[iPhone 6s] backboardd: SecTaskCopyDebugDescription: FlutterRunner[90982]
[iPhone 6s] FlutterRunner: assertion failed: 15C50 13C75: libxpc.dylib + 58018 [3E9AE163-9A95-35D3-BA2C-2E7144498580]: 0x7d
[iPhone 6s] assertiond: assertion failed: 15C50 13C75: assertiond + 12188 [8CF1968D-3466-38B7-B225-3F6F5B64C552]: 0x1
[iPhone 6s] --- last message repeated 1 time ---
[iPhone 6s] SpringBoard: [MPUSystemMediaControls] Updating supported commands for now playing application.
[iPhone 6s] SpringBoard: BSXPCMessage received error for message: Connection interrupted
[iPhone 6s] com.apple.CoreSimulator.SimDevice.B0484E69-8A54-4CCF-8804-4780BD7D5DD4.launchd_sim[90418] (UIKitApplication:io.flutter.runner.Runner[0xba57]: Service exited due to signal: Trace/BPT trap: 5
[iPhone 6s] SpringBoard: HW kbd: Failed to set (null) as keyboard focus
[iPhone 6s] assertiond: assertion failed: 15C50 13C75: assertiond + 12188 [8CF1968D-3466-38B7-B225-3F6F5B64C552]: 0x1
[iPhone 6s] SpringBoard: BSXPCMessage received error for message: Connection invalid
[iPhone 6s] SpringBoard: Application 'UIKitApplication:io.flutter.runner.Runner[0xba57]' crashed.
[iPhone 6s] assertiond: assertion failed: 15C50 13C75: assertiond + 12188 [8CF1968D-3466-38B7-B225-3F6F5B64C552]: 0x1
[iPhone 6s] assertiond: notify_suspend_pid() failed with error 7
[iPhone 6s] assertiond: assertion failed: 15C50 13C75: assertiond + 12188 [8CF1968D-3466-38B7-B225-3F6F5B64C552]: 0x1
[iPhone 6s] SpringBoard: Reply Error: Connection interrupted
[iPhone 6s] ReportCrash: Saved crash report for FlutterRunner[90982] version 1.0 (1) to /Users/devoncarew/Library/Logs/DiagnosticReports/FlutterRunner_2016-02-01-105423_devoncarew-macbookpro3.crash
```
