### PR TITLE
add --start-paused,--debug-port flags

### DIFF
--- a/packages/flutter_tools/lib/src/base/common.dart
+++ b/packages/flutter_tools/lib/src/base/common.dart
@@ -1,0 +1,5 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+const int observatoryDefaultPort = 8181;

--- a/packages/flutter_tools/lib/src/base/os.dart
+++ b/packages/flutter_tools/lib/src/base/os.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:async';
 import 'dart:io';
 
 final OperatingSystemUtils os = new OperatingSystemUtils._();
@@ -30,4 +31,11 @@ class _WindowsUtils implements OperatingSystemUtils {
   ProcessResult makeExecutable(File file) {
     return new ProcessResult(0, 0, null, null);
   }
+}
+
+Future<int> findAvailablePort() async {
+  ServerSocket socket = await ServerSocket.bind(InternetAddress.LOOPBACK_IP_V4, 0);
+  int port = socket.port;
+  await socket.close();
+  return port;
 }

--- a/packages/flutter_tools/lib/src/commands/start.dart
+++ b/packages/flutter_tools/lib/src/commands/start.dart
@@ -8,6 +8,7 @@ import 'dart:io';
 import 'package:path/path.dart' as path;
 
 import '../application_package.dart';
+import '../base/common.dart';
 import '../base/context.dart';
 import '../device.dart';
 import '../runner/flutter_command.dart';
@@ -58,6 +59,13 @@ class StartCommand extends StartCommandBase {
     argParser.addFlag('clear-logs',
         defaultsTo: true,
         help: 'Clear log history before starting the app.');
+    argParser.addFlag('start-paused',
+        defaultsTo: false,
+        negatable: false,
+        help: 'Start in a paused mode and wait for a debugger to connect.');
+    argParser.addOption('debug-port',
+        defaultsTo: observatoryDefaultPort.toString(),
+        help: 'Listen to the given port for a debug connection.');
   }
 
   @override
@@ -71,6 +79,15 @@ class StartCommand extends StartCommandBase {
 
     bool clearLogs = argResults['clear-logs'];
 
+    int debugPort;
+
+    try {
+      debugPort = int.parse(argResults['debug-port']);
+    } catch (error) {
+      printError('Invalid port for `--debug-port`: $error');
+      return 1;
+    }
+
     int result = await startApp(
       devices,
       applicationPackages,
@@ -81,7 +98,9 @@ class StartCommand extends StartCommandBase {
       checked: argResults['checked'],
       traceStartup: argResults['trace-startup'],
       route: argResults['route'],
-      clearLogs: clearLogs
+      clearLogs: clearLogs,
+      startPaused: argResults['start-paused'],
+      debugPort: debugPort
     );
 
     printTrace('Finished start command.');
@@ -99,7 +118,9 @@ Future<int> startApp(
   bool checked: true,
   bool traceStartup: false,
   String route,
-  bool clearLogs: false
+  bool clearLogs: false,
+  bool startPaused: false,
+  int debugPort: observatoryDefaultPort
 }) async {
 
   String mainPath = findMainDartFile(target);
@@ -144,6 +165,8 @@ Future<int> startApp(
       route: route,
       checked: checked,
       clearLogs: clearLogs,
+      startPaused: startPaused,
+      debugPort: debugPort,
       platformArgs: platformArgs
     );
 

--- a/packages/flutter_tools/lib/src/device.dart
+++ b/packages/flutter_tools/lib/src/device.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 
 import 'android/device_android.dart';
 import 'application_package.dart';
+import 'base/common.dart';
 import 'base/context.dart';
 import 'build_configuration.dart';
 import 'ios/device_ios.dart';
@@ -104,6 +105,8 @@ abstract class Device {
     String route,
     bool checked: true,
     bool clearLogs: false,
+    bool startPaused: false,
+    int debugPort: observatoryDefaultPort,
     Map<String, dynamic> platformArgs
   });
 

--- a/packages/flutter_tools/lib/src/ios/device_ios.dart
+++ b/packages/flutter_tools/lib/src/ios/device_ios.dart
@@ -8,6 +8,7 @@ import 'dart:io';
 import 'package:path/path.dart' as path;
 
 import '../application_package.dart';
+import '../base/common.dart';
 import '../base/context.dart';
 import '../base/process.dart';
 import '../build_configuration.dart';
@@ -185,9 +186,12 @@ class IOSDevice extends Device {
     String route,
     bool checked: true,
     bool clearLogs: false,
+    bool startPaused: false,
+    int debugPort: observatoryDefaultPort,
     Map<String, dynamic> platformArgs
   }) async {
     // TODO(chinmaygarde): Use checked, mainPath, route, clearLogs.
+    // TODO(devoncarew): Handle startPaused, debugPort.
     printTrace('Building ${app.name} for $id');
 
     // Step 1: Install the precompiled application if necessary
@@ -431,9 +435,12 @@ class IOSSimulator extends Device {
     String route,
     bool checked: true,
     bool clearLogs: false,
+    bool startPaused: false,
+    int debugPort: observatoryDefaultPort,
     Map<String, dynamic> platformArgs
   }) async {
     // TODO(chinmaygarde): Use checked, mainPath, route.
+    // TODO(devoncarew): Handle startPaused, debugPort.
     printTrace('Building ${app.name} for $id');
 
     if (clearLogs)


### PR DESCRIPTION
Some work towards https://github.com/flutter/flutter/issues/1457.
- add a `--debug-port` flag to allow the user to select the observatory port. This will let multiple apps run and be debuggable at the same time. `flutter_tools` will auto-select an available port on an arg of `0`.
- add a `--start-paused` flag. This will cause the VM to start isolates in a paused mode. We pass the flag to the engine currently - there is not yet a corresponding impl in the engine.

Android is wired up; iOS has TODOs.
