### PR TITLE
RawKeyboardListener asserts if disposed without keyboard

### DIFF
--- a/packages/flutter/lib/src/widgets/raw_keyboard_listener.dart
+++ b/packages/flutter/lib/src/widgets/raw_keyboard_listener.dart
@@ -39,19 +39,20 @@ class _RawKeyboardListenerState extends State<RawKeyboardListener> implements mo
   }
 
   void dispose() {
-    _detachKeyboard();
+    _detachKeyboardIfAttached();
     super.dispose();
   }
 
   void _attachOrDetachKeyboard() {
-    if (config.focused && _stub == null)
-      _attachKeyboard();
-    else if (!config.focused && _stub != null)
-      _detachKeyboard();
+    if (config.focused)
+      _attachKeyboardIfDetached();
+    else
+      _detachKeyboardIfAttached();
   }
 
-  void _attachKeyboard() {
-    assert(_stub == null);
+  void _attachKeyboardIfDetached() {
+    if (_stub != null)
+      return;
     _stub = new mojom.RawKeyboardListenerStub.unbound()..impl = this;
     mojom.RawKeyboardServiceProxy keyboard = new mojom.RawKeyboardServiceProxy.unbound();
     shell.connectToService(null, keyboard);
@@ -59,9 +60,8 @@ class _RawKeyboardListenerState extends State<RawKeyboardListener> implements mo
     keyboard.close();
   }
 
-  void _detachKeyboard() {
-    assert(_stub != null);
-    _stub.close();
+  void _detachKeyboardIfAttached() {
+    _stub?.close();
     _stub = null;
   }
 

--- a/packages/flutter/test/widget/raw_keyboard_listener_test.dart
+++ b/packages/flutter/test/widget/raw_keyboard_listener_test.dart
@@ -1,0 +1,16 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter/widgets.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('Can dispose without keyboard', () {
+    testWidgets((WidgetTester tester) {
+      tester.pumpWidget(new RawKeyboardListener(child: new Container()));
+      tester.pumpWidget(new Container());
+    });
+  });
+}


### PR DESCRIPTION
We need to check whether we're attached to the keyboard before trying to
detach from the keyboard.
