### PR TITLE
AppBar extensions for Scaffold et al

### DIFF
--- a/examples/material_gallery/lib/main.dart
+++ b/examples/material_gallery/lib/main.dart
@@ -46,14 +46,23 @@ class GallerySection extends StatelessComponent {
       brightness: ThemeBrightness.light,
       primarySwatch: colors
     );
+    final appBarHeight = 200.0;
+    final scrollableKey = new ValueKey<String>(title); // assume section titles differ
     Navigator.push(context, new MaterialPageRoute(
       builder: (BuildContext context) {
         return new Theme(
           data: theme,
           child: new Scaffold(
-            toolBar: new ToolBar(center: new Text(title)),
+            appBarHeight: appBarHeight,
+            appBarBehavior: AppBarBehavior.scroll,
+            scrollableKey: scrollableKey,
+            toolBar: new ToolBar(
+              flexibleSpace: (BuildContext context) => new FlexibleSpaceBar(title: new Text(title))
+            ),
             body: new Material(
               child: new MaterialList(
+                scrollableKey: scrollableKey,
+                scrollablePadding: new EdgeDims.only(top: appBarHeight),
                 type: MaterialListType.oneLine,
                 children: (demos ?? <GalleryDemo>[]).map((GalleryDemo demo) {
                   return new ListItem(
@@ -116,14 +125,18 @@ class GalleryHome extends StatelessComponent {
 
   Widget build(BuildContext context) {
     return new Scaffold(
+      appBarHeight: 128.0,
       toolBar: new ToolBar(
-        bottom: new Container(
-          padding: const EdgeDims.only(left: 16.0, bottom: 24.0),
-          child: new Align(
-            alignment: const FractionalOffset(0.0, 1.0),
-            child: new Text('Flutter Gallery', style: Typography.white.headline)
-          )
-        )
+        flexibleSpace: (BuildContext context) {
+          return new Container(
+            padding: const EdgeDims.only(left: 16.0, bottom: 24.0),
+            height: 128.0,
+            child: new Align(
+              alignment: const FractionalOffset(0.0, 1.0),
+              child: new Text('Flutter Gallery', style: Typography.white.headline)
+            )
+          );
+        }
       ),
       body: new Padding(
         padding: const EdgeDims.all(4.0),

--- a/examples/widgets/card_collection.dart
+++ b/examples/widgets/card_collection.dart
@@ -272,18 +272,21 @@ class CardCollectionState extends State<CardCollection> {
     );
   }
 
-  Widget _buildToolBar() {
+  Widget _buildToolBar(BuildContext context) {
     return new ToolBar(
       right: <Widget>[
         new Text(_dismissDirectionText(_dismissDirection))
       ],
-      bottom: new Padding(
-        padding: const EdgeDims.only(left: 72.0),
-        child: new Align(
-          alignment: const FractionalOffset(0.0, 0.5),
-          child: new Text('Swipe Away: ${_cardModels.length}')
-        )
-      )
+      flexibleSpace: (_) {
+        return new Container(
+          padding: const EdgeDims.only(left: 72.0),
+          height: 128.0,
+          child: new Align(
+            alignment: const FractionalOffset(0.0, 0.75),
+            child: new Text('Swipe Away: ${_cardModels.length}', style: Theme.of(context).primaryTextTheme.title)
+          )
+        );
+      }
     );
   }
 
@@ -456,7 +459,7 @@ class CardCollectionState extends State<CardCollection> {
         primarySwatch: _primaryColor
       ),
       child: new Scaffold(
-        toolBar: _buildToolBar(),
+        toolBar: _buildToolBar(context),
         drawer: _buildDrawer(),
         body: body
       )

--- a/examples/widgets/flutter.yaml
+++ b/examples/widgets/flutter.yaml
@@ -1,6 +1,7 @@
 name: widgets
 assets:
   - assets/starcircle.png
+  - assets/ali_connors.png
 material-design-icons:
   - name: action/account_circle
   - name: action/alarm

--- a/packages/flutter/lib/material.dart
+++ b/packages/flutter/lib/material.dart
@@ -23,6 +23,7 @@ export 'src/material/drawer_header.dart';
 export 'src/material/drawer_item.dart';
 export 'src/material/dropdown.dart';
 export 'src/material/flat_button.dart';
+export 'src/material/flexible_space_bar.dart';
 export 'src/material/floating_action_button.dart';
 export 'src/material/icon.dart';
 export 'src/material/icon_button.dart';

--- a/packages/flutter/lib/src/material/constants.dart
+++ b/packages/flutter/lib/src/material/constants.dart
@@ -15,6 +15,10 @@ const double kStatusBarHeight = 50.0;
 const double kToolBarHeight = 56.0;
 const double kExtendedToolBarHeight = 128.0;
 
+const double kTextTabBarHeight = 48.0;
+const double kIconTabBarHeight = 48.0;
+const double kTextandIconTabBarHeight = 72.0;
+
 // https://www.google.com/design/spec/layout/metrics-keylines.html#metrics-keylines-keylines-spacing
 const double kListTitleHeight = 72.0;
 const double kListSubtitleHeight = 48.0;

--- a/packages/flutter/lib/src/material/debug.dart
+++ b/packages/flutter/lib/src/material/debug.dart
@@ -5,6 +5,7 @@
 import 'package:flutter/widgets.dart';
 
 import 'material.dart';
+import 'scaffold.dart';
 
 bool debugCheckHasMaterial(BuildContext context) {
   assert(() {
@@ -13,6 +14,21 @@ bool debugCheckHasMaterial(BuildContext context) {
       throw new WidgetError(
         'Missing Material widget.',
         '${context.widget} needs to be placed inside a Material widget. Ownership chain:\n${element.debugGetOwnershipChain(10)}'
+      );
+    }
+    return true;
+  });
+  return true;
+}
+
+
+bool debugCheckHasScaffold(BuildContext context) {
+  assert(() {
+    if (Scaffold.of(context) == null) {
+      Element element = context;
+      throw new WidgetError(
+        'Missing Scaffold widget.',
+        '${context.widget} needs to be placed inside the body of a Scaffold widget. Ownership chain:\n${element.debugGetOwnershipChain(10)}'
       );
     }
     return true;

--- a/packages/flutter/lib/src/material/flexible_space_bar.dart
+++ b/packages/flutter/lib/src/material/flexible_space_bar.dart
@@ -1,0 +1,94 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:math' as math;
+
+import 'package:flutter/animation.dart';
+import 'package:flutter/widgets.dart';
+
+import 'debug.dart';
+import 'constants.dart';
+import 'scaffold.dart';
+import 'theme.dart';
+
+class FlexibleSpaceBar extends StatefulComponent {
+  FlexibleSpaceBar({ Key key, this.title, this.image }) : super(key: key);
+
+  final Widget title;
+  final Widget image;
+
+  _FlexibleSpaceBarState createState() => new _FlexibleSpaceBarState();
+}
+
+class _FlexibleSpaceBarState extends State<FlexibleSpaceBar> {
+
+  Widget build(BuildContext context) {
+    assert(debugCheckHasScaffold(context));
+    final double appBarHeight = Scaffold.of(context).appBarHeight;
+    final Animation<double> animation = Scaffold.of(context).appBarAnimation;
+    final EdgeDims toolBarPadding = MediaQuery.of(context)?.padding ?? EdgeDims.zero;
+    final double toolBarHeight = kToolBarHeight + toolBarPadding.top;
+    final List<Widget> children = <Widget>[];
+
+    // background image
+    if (config.image != null) {
+      final double fadeStart = (appBarHeight - toolBarHeight * 2.0) / appBarHeight;
+      final double fadeEnd = (appBarHeight - toolBarHeight) / appBarHeight;
+      final CurvedAnimation opacityCurve = new CurvedAnimation(
+        parent: animation,
+        curve: new Interval(math.max(0.0, fadeStart), math.min(fadeEnd, 1.0))
+      );
+      final double parallax = new Tween<double>(begin: 0.0, end: appBarHeight / 4.0).evaluate(animation);
+      children.add(new Positioned(
+        top: -parallax,
+        left: 0.0,
+        right: 0.0,
+        child: new Opacity(
+          opacity: new Tween<double>(begin: 1.0, end: 0.0).evaluate(opacityCurve),
+          child: config.image
+        )
+       ));
+    }
+
+    // title
+    if (config.title != null) {
+      final double fadeStart = (appBarHeight - toolBarHeight) / appBarHeight;
+      final double fadeEnd = (appBarHeight - toolBarHeight / 2.0) / appBarHeight;
+      final CurvedAnimation opacityCurve = new CurvedAnimation(
+        parent: animation,
+        curve: new Interval(fadeStart, fadeEnd)
+      );
+      TextStyle titleStyle = Theme.of(context).primaryTextTheme.title;
+      titleStyle = titleStyle.copyWith(
+        color: titleStyle.color.withAlpha(new Tween<double>(begin: 255.0, end: 0.0).evaluate(opacityCurve).toInt())
+      );
+      final double yAlignStart = 1.0;
+      final double yAlignEnd = (toolBarPadding.top + kToolBarHeight / 2.0) / toolBarHeight;
+      final double scaleAndAlignEnd = (appBarHeight - toolBarHeight) / appBarHeight;
+      final CurvedAnimation scaleAndAlignCurve = new CurvedAnimation(
+        parent: animation,
+        curve: new Interval(0.0, scaleAndAlignEnd)
+      );
+      children.add(new Padding(
+        padding: const EdgeDims.only(left: 72.0, bottom: 14.0),
+        child: new Align(
+          alignment: new Tween<FractionalOffset>(
+            begin: new FractionalOffset(0.0, yAlignStart),
+            end: new FractionalOffset(0.0, yAlignEnd)
+          ).evaluate(scaleAndAlignCurve),
+          child: new ScaleTransition(
+            alignment: const FractionalOffset(0.0, 1.0),
+            scale: new Tween<double>(begin: 1.5, end: 1.0).animate(scaleAndAlignCurve),
+            child: new Align(
+              alignment: new FractionalOffset(0.0, 1.0),
+              child: new DefaultTextStyle(style: titleStyle, child: config.title)
+            )
+          )
+        )
+      ));
+    }
+
+    return new ClipRect(child: new Stack(children: children));
+  }
+}

--- a/packages/flutter/lib/src/material/icon.dart
+++ b/packages/flutter/lib/src/material/icon.dart
@@ -4,9 +4,10 @@
 
 import 'package:flutter/widgets.dart';
 
-import 'theme.dart';
+import 'colors.dart';
 import 'icon_theme.dart';
 import 'icon_theme_data.dart';
+import 'theme.dart';
 
 enum IconSize {
   s18,
@@ -39,7 +40,7 @@ class Icon extends StatelessComponent {
   final IconThemeColor colorTheme;
   final Color color;
 
-  String _getColorSuffix(BuildContext context) {
+  IconThemeColor _getIconThemeColor(BuildContext context) {
     IconThemeColor iconThemeColor = colorTheme;
     if (iconThemeColor == null) {
       IconThemeData iconThemeData = IconTheme.of(context);
@@ -49,12 +50,7 @@ class Icon extends StatelessComponent {
       ThemeBrightness themeBrightness = Theme.of(context).brightness;
       iconThemeColor = themeBrightness == ThemeBrightness.dark ? IconThemeColor.white : IconThemeColor.black;
     }
-    switch(iconThemeColor) {
-      case IconThemeColor.white:
-        return "white";
-      case IconThemeColor.black:
-        return "black";
-    }
+    return iconThemeColor;
   }
 
   Widget build(BuildContext context) {
@@ -65,13 +61,41 @@ class Icon extends StatelessComponent {
       category = parts[0];
       subtype = parts[1];
     }
-    String colorSuffix = _getColorSuffix(context);
-    int iconSize = _kIconSize[size];
+    final IconThemeColor iconThemeColor = _getIconThemeColor(context);
+    final int iconSize = _kIconSize[size];
+
+    String colorSuffix;
+    switch(iconThemeColor) {
+      case IconThemeColor.black:
+        colorSuffix = "black";
+        break;
+      case IconThemeColor.white:
+        colorSuffix = "white";
+        break;
+    }
+
+    Color iconColor = color;
+    final int iconAlpha = (255.0 * (IconTheme.of(context)?.clampedOpacity ?? 1.0)).round();
+    if (iconAlpha != 255) {
+      if (color != null)
+        iconColor = color.withAlpha(iconAlpha);
+      else {
+        switch(iconThemeColor) {
+          case IconThemeColor.black:
+            iconColor = Colors.black.withAlpha(iconAlpha);
+            break;
+          case IconThemeColor.white:
+            iconColor = Colors.white.withAlpha(iconAlpha);
+            break;
+        }
+      }
+    }
+
     return new AssetImage(
       name: '$category/ic_${subtype}_${colorSuffix}_${iconSize}dp.png',
       width: iconSize.toDouble(),
       height: iconSize.toDouble(),
-      color: color
+      color: iconColor
     );
   }
 

--- a/packages/flutter/lib/src/material/icon_theme_data.dart
+++ b/packages/flutter/lib/src/material/icon_theme_data.dart
@@ -2,15 +2,22 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:ui' as ui;
+
 enum IconThemeColor { white, black }
 
 class IconThemeData {
-  const IconThemeData({ this.color });
+  const IconThemeData({ this.color, this.opacity });
+
   final IconThemeColor color;
+  final double opacity;
+
+  double get clampedOpacity => (opacity ?? 1.0).clamp(0.0, 1.0);
 
   static IconThemeData lerp(IconThemeData begin, IconThemeData end, double t) {
     return new IconThemeData(
-      color: t < 0.5 ? begin.color : end.color
+      color: t < 0.5 ? begin.color : end.color,
+      opacity: ui.lerpDouble(begin.clampedOpacity, end.clampedOpacity, t)
     );
   }
 
@@ -18,10 +25,10 @@ class IconThemeData {
     if (other is! IconThemeData)
       return false;
     final IconThemeData typedOther = other;
-    return color == typedOther.color;
+    return color == typedOther.color && opacity == typedOther.opacity;
   }
 
-  int get hashCode => color.hashCode;
+  int get hashCode => ui.hashValues(color, opacity);
 
   String toString() => '$color';
 }

--- a/packages/flutter/lib/src/material/material_list.dart
+++ b/packages/flutter/lib/src/material/material_list.dart
@@ -27,13 +27,17 @@ class MaterialList extends StatefulComponent {
     this.initialScrollOffset,
     this.onScroll,
     this.type: MaterialListType.twoLine,
-    this.children
+    this.children,
+    this.scrollablePadding: EdgeDims.zero,
+    this.scrollableKey
   }) : super(key: key);
 
   final double initialScrollOffset;
   final ScrollListener onScroll;
   final MaterialListType type;
   final Iterable<Widget> children;
+  final EdgeDims scrollablePadding;
+  final Key scrollableKey;
 
   _MaterialListState createState() => new _MaterialListState();
 }
@@ -43,11 +47,12 @@ class _MaterialListState extends State<MaterialList> {
 
   Widget build(BuildContext context) {
     return new ScrollableList(
+      key: config.scrollableKey,
       initialScrollOffset: config.initialScrollOffset,
       scrollDirection: Axis.vertical,
       onScroll: config.onScroll,
       itemExtent: kListItemExtent[config.type],
-      padding: const EdgeDims.symmetric(vertical: 8.0),
+      padding: const EdgeDims.symmetric(vertical: 8.0) + config.scrollablePadding,
       scrollableListPainter: _scrollbarPainter,
       children: config.children
     );

--- a/packages/flutter/lib/src/rendering/list.dart
+++ b/packages/flutter/lib/src/rendering/list.dart
@@ -151,7 +151,7 @@ class RenderList extends RenderVirtualViewport<ListParentData> implements HasScr
         break;
       case Axis.horizontal:
         itemWidth = itemExtent ?? size.width;
-        itemHeight = math.max(0, size.height - (padding == null ? 0.0 : padding.vertical));
+        itemHeight = math.max(0.0, size.height - (padding == null ? 0.0 : padding.vertical));
         x = padding != null ? padding.left : 0.0;
         dx = itemWidth;
         break;

--- a/packages/flutter/lib/src/widgets/scrollable.dart
+++ b/packages/flutter/lib/src/widgets/scrollable.dart
@@ -377,12 +377,16 @@ class ScrollableViewport extends Scrollable {
     this.child,
     double initialScrollOffset,
     Axis scrollDirection: Axis.vertical,
-    ScrollListener onScroll
+    ScrollListener onScrollStart,
+    ScrollListener onScroll,
+    ScrollListener onScrollEnd
   }) : super(
     key: key,
     scrollDirection: scrollDirection,
     initialScrollOffset: initialScrollOffset,
-    onScroll: onScroll
+    onScrollStart: onScrollStart,
+    onScroll: onScroll,
+    onScrollEnd: onScrollEnd
   );
 
   final Widget child;

--- a/packages/flutter/lib/src/widgets/scrollable_list.dart
+++ b/packages/flutter/lib/src/widgets/scrollable_list.dart
@@ -158,11 +158,12 @@ class _ListViewportElement extends VirtualViewportElement<ListViewport> {
   void layout(BoxConstraints constraints) {
     final int length = renderObject.virtualChildCount;
     final double itemExtent = widget.itemExtent;
+    final EdgeDims padding = widget.padding ?? EdgeDims.zero;
 
-    double contentExtent = widget.itemExtent * length;
+    double contentExtent = widget.itemExtent * length + padding.top + padding.bottom;
     double containerExtent = _getContainerExtentFromRenderObject();
 
-    _materializedChildBase = math.max(0, widget.startOffset ~/ itemExtent);
+    _materializedChildBase = math.max(0, (widget.startOffset - padding.top) ~/ itemExtent);
     int materializedChildLimit = math.max(0, ((widget.startOffset + containerExtent) / itemExtent).ceil());
 
     if (!widget.itemsWrap) {


### PR DESCRIPTION
Add support for the appbar behavior described in the "Flexible space with image" section of https://www.google.com/design/spec/patterns/scrolling-techniques.html#scrolling-techniques-scrolling.

For now, an "AppBar" is a toolbar, a toolbar and a tabbar arranged in a column, or a toolbar and flexible space widget arranged in a stack with the toolbar on top. The AppBar occupies the space behind the status bar, i.e. its origin is at the top of the screen.

The Scaffold listens for scroll notifications from a Scrollable descendant identified by scrollableKey. Scrolling downwards from the top causes the Scaffold to shrink its appBar's height from appBarHeight to 0. Scrolling downwards when the appBar isn't visible causes its toolbar to reappear. Applications can specify the flexibleSpace - essentially the appbar's background - with a WidgetBuilder. The contents of the flexible space can track the appbar's relative height with Scaffold.of(context).appBarAnimation, an animation that's 0.0 when the appbar is fully visible and 1.0 when it has disappeared.

Added FlexibleSpaceBar to simplify building a flexible space widget that animates a title and a background image per the Material Design spec.

To enable the new behavior, specify the following Scaffold properties:

```
return new Scaffold(
  appBarHeight: appBarHeight,
  scrollableKey: scrollableKey,
  appBarBehavior: AppBarBehavior.scroll,
  ...
)
```

AppBarHeight should be greater than kToolBarHeight. Typically it will be much greater.

ScrollableKey identifies the Scrollable that the Scaffold will track.

AppBarBehavior.scroll indicates that the appbar will resize in response to scrolling.

The Scrollable must be a descendant of the Scaffold body and must specify the same scrollableKey as well as a padding value that accounts for the appbar's height. For example:

```
  body: new ScrollableViewport(
    key: scrollableKey,
    child: new Padding(padding: new EdgeDims.only(top: appBarHeight)
    ...
   )
```

Also:
- Added scrollableKey and scrollablePadding to MaterialList. They're applied to the ScrollableList child.
- Fixed the padding support in ScrollableList.
- Added a foregroundAlpha property to ToolBar. It controls the opacity of the icon and text themes' colors.
- Removed the toolbar's "bottom" widget property. Use the flexibleSpace WidgetBuilder instead.
