### PR TITLE
add docs for -h -v

### DIFF
--- a/packages/flutter_tools/lib/src/commands/listen.dart
+++ b/packages/flutter_tools/lib/src/commands/listen.dart
@@ -12,8 +12,7 @@ import 'start.dart';
 class ListenCommand extends StartCommandBase {
   final String name = 'listen';
   final String description =
-    'Listen for changes to files and reload the running app on all connected devices '
-    '(Android only).';
+    'Listen for changes to files and reload the running app (Android only).';
   final String usageFooter =
     'By default, only listens to "./" and "./lib/". To listen to additional directories, list them on\n'
     'the command line.';

--- a/packages/flutter_tools/lib/src/runner/flutter_command_runner.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command_runner.dart
@@ -45,8 +45,8 @@ class FlutterCommandRunner extends CommandRunner {
     argParser.addOption('package-root',
         help: 'Path to your packages directory.$packagesHelp');
     argParser.addOption('flutter-root',
-        help: 'The root directory of the Flutter repository. Defaults to \$$kFlutterRootEnvironmentVariableName if set,\n'
-              'otherwise defaults to a value derived from the location of this tool.', defaultsTo: _defaultFlutterRoot);
+        help: 'The root directory of the Flutter repository. Defaults to \$$kFlutterRootEnvironmentVariableName if\n'
+              'set, otherwise defaults to a value derived from the location of this tool.', defaultsTo: _defaultFlutterRoot);
 
     if (verboseHelp)
       argParser.addSeparator('Local build selection options (not normally required):');
@@ -119,6 +119,8 @@ class FlutterCommandRunner extends CommandRunner {
             'This path is relative to --engine-src-path. Not normally required.',
         defaultsTo: 'out/ios_sim_Release/');
   }
+
+  final String usageFooter = 'Run "flutter -h -v" for verbose help output, including less commonly used options.';
 
   List<BuildConfiguration> get buildConfigurations {
     if (_buildConfigurations == null)


### PR DESCRIPTION
Add docs about how to invoke verbose help. This:

```
Run "flutter -h -v" for verbose help output, including less commonly used options.
```

gets appended to the current docs.

Plus, make our help text wrap to 100 cols.
