### PR TITLE
remove an extraneous line of output when launching the simulator

### DIFF
--- a/packages/flutter_tools/lib/src/ios/device_ios.dart
+++ b/packages/flutter_tools/lib/src/ios/device_ios.dart
@@ -476,18 +476,13 @@ class IOSSimulator extends Device {
     }
 
     // Step 4: Launch the updated application in the simulator
-    int launchResult = await runCommandAndStreamOutput([
+    runCheckedSync([
       xcrunPath,
       'simctl',
       'launch',
       id == defaultDeviceID ? 'booted' : id,
       app.id
     ]);
-
-    if (launchResult != 0) {
-      printError('Could not launch the freshly installed application on the simulator');
-      return false;
-    }
 
     printTrace('Successfully started ${app.name} on $id');
     return true;


### PR DESCRIPTION
Remove an extraneous line of output when launching the simulator. Before we showed:

```
[~/flutter/flutter_sunflower] flutter -d B0484E69-8A54-4CCF-8804-4780BD7D5DD4 start
Starting lib/main.dart on iPhone 6s...
io.flutter.runner.Runner: 67375
```

This removes `io.flutter.runner.Runner: 67375` - it wasn't totally clear to the user what that's for.

@chinmaygarde 
