### PR TITLE
remove no longer needed code from the service protocol extensions

### DIFF
--- a/packages/flutter/lib/src/rendering/debug.dart
+++ b/packages/flutter/lib/src/rendering/debug.dart
@@ -87,27 +87,11 @@ void initServiceExtensions() {
   _extensionsInitialized = true;
 
   assert(() {
-    developer.registerExtension('flutter', _flutter);
     developer.registerExtension('flutter.debugPaint', _debugPaint);
     developer.registerExtension('flutter.timeDilation', _timeDilation);
 
-    // Emit an info level log message; this tells the debugger that the Flutter
-    // service extensions are registered.
-    developer.log('Flutter initialized', name: 'flutter', level: 800);
-
     return true;
   });
-}
-
-/// Just respond to the request. Clients can use the existence of this call to
-/// know that the debug client is a Flutter app.
-Future<developer.ServiceExtensionResponse> _flutter(String method, Map<String, String> parameters) {
-  return new Future<developer.ServiceExtensionResponse>.value(
-    new developer.ServiceExtensionResponse.result(JSON.encode({
-      'type': '_extensionType',
-      'method': method
-    }))
-  );
 }
 
 /// Toggle the [debugPaintSizeEnabled] setting.


### PR DESCRIPTION
Remove the `flutter` service protocol extension and the `Flutter initialized` log event. The service protocol now has ways for clients to introspect what extensions are available.
