### PR TITLE
Refactor flx.build() to allow for external toolchain hooks.

### DIFF
--- a/packages/flutter_tools/lib/src/commands/build.dart
+++ b/packages/flutter_tools/lib/src/commands/build.dart
@@ -15,7 +15,7 @@ class BuildCommand extends FlutterCommand {
 
   BuildCommand() {
     argParser.addFlag('precompiled', negatable: false);
-    argParser.addOption('asset-base', defaultsTo: defaultAssetBase);
+    argParser.addOption('asset-base', defaultsTo: defaultMaterialAssetBasePath);
     argParser.addOption('compiler');
     argParser.addOption('target',
       abbr: 't',
@@ -42,7 +42,7 @@ class BuildCommand extends FlutterCommand {
 
     return await build(
       toolchain,
-      assetBase: argResults['asset-base'],
+      materialAssetBasePath: argResults['asset-base'],
       mainPath: argResults.wasParsed('main') ? argResults['main'] : argResults['target'],
       manifestPath: argResults['manifest'],
       outputPath: outputPath,


### PR DESCRIPTION
This splits flx.build() into two methods, flx.build() and
flx.assemble().  builD() now does the following:
1) constructs the manifest map by reading the manifest from the
   file system
2) "compiles" the dart code into the snapshot file
3) Invokes assemble()

This allows external build toolchains to construct their own
manifest map (possibly using a different manifest syntax)
and create their own snapshot file
