### PR TITLE
Move flx.dart to lib to represent public API

### DIFF
--- a/packages/flutter/lib/src/services/image_resource.dart
+++ b/packages/flutter/lib/src/services/image_resource.dart
@@ -22,7 +22,7 @@ typedef void ImageListener(ImageInfo image);
 /// image object might change over time, either because the image is animating
 /// or because the underlying image resource was mutated.
 class ImageResource {
-  ImageResource(this._futureImage) {
+  ImageResource(this._futureImage, { this.scale : 1.0 }) {
     _futureImage.then(_handleImageLoaded, onError: (exception, stack) => _handleImageError('Failed to load image:', exception, stack));
   }
 

--- a/packages/flutter/lib/src/widgets/asset_vendor.dart
+++ b/packages/flutter/lib/src/widgets/asset_vendor.dart
@@ -5,6 +5,7 @@
 import 'dart:async';
 import 'dart:collection';
 import 'dart:convert';
+import 'dart:ui' as ui;
 
 import 'package:flutter/services.dart';
 import 'package:mojo/core.dart' as core;

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -1675,6 +1675,7 @@ class _ImageListenerState extends State<RawImageResource> {
   void _handleImageChanged(ImageInfo resolvedImage) {
     setState(() {
       _resolvedImage = resolvedImage;
+      _scale = config.image.scale;
     });
   }
 

--- a/packages/flutter_tools/lib/flutter_tools.dart
+++ b/packages/flutter_tools/lib/flutter_tools.dart
@@ -1,0 +1,31 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+library flutter_tools;
+
+import 'dart:async';
+
+import 'package:archive/archive.dart';
+
+import 'src/flx.dart' as flx;
+
+/// Assembles a Flutter .flx file from a pre-existing manifest descriptor
+/// and a pre-compiled snapshot.
+Future<int> assembleFlx({
+  Map manifestDescriptor: const {},
+  ArchiveFile snapshotFile: null,
+  String assetBasePath: flx.defaultAssetBasePath,
+  String materialAssetBasePath: flx.defaultMaterialAssetBasePath,
+  String outputPath: flx.defaultFlxOutputPath,
+  String privateKeyPath: flx.defaultPrivateKeyPath
+}) async {
+  return flx.assemble(
+      manifestDescriptor: manifestDescriptor,
+      snapshotFile: snapshotFile,
+      assetBasePath: assetBasePath,
+      materialAssetBasePath: materialAssetBasePath,
+      outputPath: outputPath,
+      privateKeyPath: privateKeyPath
+  );
+}

--- a/packages/flutter_tools/lib/flx.dart
+++ b/packages/flutter_tools/lib/flx.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+library flutter_tools.flx;
+
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
@@ -13,9 +15,9 @@ import 'package:flx/signing.dart';
 import 'package:path/path.dart' as path;
 import 'package:yaml/yaml.dart';
 
-import 'base/context.dart';
-import 'base/file_system.dart';
-import 'toolchain.dart';
+import 'src/base/context.dart';
+import 'src/base/file_system.dart';
+import 'src/toolchain.dart';
 
 const String defaultMainPath = 'lib/main.dart';
 const String defaultAssetBasePath = '.';
@@ -245,9 +247,6 @@ Future<int> build(
 
 /// Assembles a Flutter .flx file from a pre-existing manifest descriptor
 /// and a pre-compiled snapshot.
-///
-/// This may be called by external build toolchains, so practice caution
-/// when changing this method signature (alert flutter-dev).
 Future<int> assemble({
   Map manifestDescriptor: const {},
   ArchiveFile snapshotFile: null,

--- a/packages/flutter_tools/lib/flx.dart
+++ b/packages/flutter_tools/lib/flx.dart
@@ -245,8 +245,6 @@ Future<int> build(
   );
 }
 
-/// Assembles a Flutter .flx file from a pre-existing manifest descriptor
-/// and a pre-compiled snapshot.
 Future<int> assemble({
   Map manifestDescriptor: const {},
   ArchiveFile snapshotFile: null,

--- a/packages/flutter_tools/lib/src/android/device_android.dart
+++ b/packages/flutter_tools/lib/src/android/device_android.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:crypto/crypto.dart';
+import 'package:flutter_tools/flx.dart' as flx;
 import 'package:path/path.dart' as path;
 
 import '../application_package.dart';
@@ -15,7 +16,6 @@ import '../base/os.dart';
 import '../base/process.dart';
 import '../build_configuration.dart';
 import '../device.dart';
-import '../flx.dart' as flx;
 import '../toolchain.dart';
 import 'android.dart';
 

--- a/packages/flutter_tools/lib/src/commands/apk.dart
+++ b/packages/flutter_tools/lib/src/commands/apk.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:flutter_tools/flx.dart' as flx;
 import 'package:path/path.dart' as path;
 import 'package:yaml/yaml.dart';
 import 'package:xml/xml.dart' as xml;
@@ -18,7 +19,6 @@ import '../base/file_system.dart';
 import '../base/process.dart';
 import '../build_configuration.dart';
 import '../device.dart';
-import '../flx.dart' as flx;
 import '../runner/flutter_command.dart';
 import '../toolchain.dart';
 import 'start.dart';

--- a/packages/flutter_tools/lib/src/commands/build.dart
+++ b/packages/flutter_tools/lib/src/commands/build.dart
@@ -4,8 +4,9 @@
 
 import 'dart:async';
 
+import 'package:flutter_tools/flx.dart' as flx;
+
 import '../base/context.dart';
-import '../flx.dart';
 import '../runner/flutter_command.dart';
 import '../toolchain.dart';
 
@@ -15,19 +16,19 @@ class BuildCommand extends FlutterCommand {
 
   BuildCommand() {
     argParser.addFlag('precompiled', negatable: false);
-    argParser.addOption('asset-base', defaultsTo: defaultMaterialAssetBasePath);
+    argParser.addOption('asset-base', defaultsTo: flx.defaultMaterialAssetBasePath);
     argParser.addOption('compiler');
     argParser.addOption('target',
       abbr: 't',
-      defaultsTo: defaultMainPath,
+      defaultsTo: flx.defaultMainPath,
       help: 'Target app path / main entry-point file.'
     );
     // TODO(devoncarew): Remove this once the xcode project is switched over.
     argParser.addOption('main', hide: true);
-    argParser.addOption('manifest', defaultsTo: defaultManifestPath);
-    argParser.addOption('private-key', defaultsTo: defaultPrivateKeyPath);
-    argParser.addOption('output-file', abbr: 'o', defaultsTo: defaultFlxOutputPath);
-    argParser.addOption('snapshot', defaultsTo: defaultSnapshotPath);
+    argParser.addOption('manifest', defaultsTo: flx.defaultManifestPath);
+    argParser.addOption('private-key', defaultsTo: flx.defaultPrivateKeyPath);
+    argParser.addOption('output-file', abbr: 'o', defaultsTo: flx.defaultFlxOutputPath);
+    argParser.addOption('snapshot', defaultsTo: flx.defaultSnapshotPath);
   }
 
   Future<int> runInProject() async {
@@ -40,7 +41,7 @@ class BuildCommand extends FlutterCommand {
 
     String outputPath = argResults['output-file'];
 
-    return await build(
+    return await flx.build(
       toolchain,
       materialAssetBasePath: argResults['asset-base'],
       mainPath: argResults.wasParsed('main') ? argResults['main'] : argResults['target'],

--- a/packages/flutter_tools/lib/src/commands/run_mojo.dart
+++ b/packages/flutter_tools/lib/src/commands/run_mojo.dart
@@ -5,13 +5,13 @@
 import 'dart:async';
 import 'dart:io';
 
+import 'package:flutter_tools/flx.dart' as flx;
 import 'package:path/path.dart' as path;
 
 import '../artifacts.dart';
 import '../base/context.dart';
 import '../base/process.dart';
 import '../build_configuration.dart';
-import '../flx.dart' as flx;
 import '../runner/flutter_command.dart';
 import 'start.dart';
 

--- a/packages/flutter_tools/lib/src/commands/start.dart
+++ b/packages/flutter_tools/lib/src/commands/start.dart
@@ -5,6 +5,7 @@
 import 'dart:async';
 import 'dart:io';
 
+import 'package:flutter_tools/flx.dart' as flx;
 import 'package:path/path.dart' as path;
 
 import '../application_package.dart';
@@ -12,7 +13,6 @@ import '../base/common.dart';
 import '../base/context.dart';
 import '../build_configuration.dart';
 import '../device.dart';
-import '../flx.dart';
 import '../runner/flutter_command.dart';
 import '../toolchain.dart';
 import 'apk.dart';
@@ -44,7 +44,7 @@ abstract class StartCommandBase extends FlutterCommand {
         help: 'Start tracing during startup.');
     argParser.addOption('target',
         abbr: 't',
-        defaultsTo: defaultMainPath,
+        defaultsTo: flx.defaultMainPath,
         help: 'Target app path / main entry-point file.');
     argParser.addOption('route',
         help: 'Which route to load when starting the app.');


### PR DESCRIPTION
Now that it's being referenced by external callers,
it should live in lib instead of src so we know to
be more careful with API changes.
