### PR TITLE
Improve exceptions and asserts for rendering lib.

### DIFF
--- a/examples/rendering/lib/sector_layout.dart
+++ b/examples/rendering/lib/sector_layout.dart
@@ -79,16 +79,16 @@ abstract class RenderSector extends RenderObject {
   }
 
   SectorConstraints get constraints => super.constraints;
-  bool debugDoesMeetConstraints() {
+  void debugAssertDoesMeetConstraints() {
     assert(constraints != null);
     assert(deltaRadius != null);
     assert(deltaRadius < double.INFINITY);
     assert(deltaTheta != null);
     assert(deltaTheta < double.INFINITY);
-    return constraints.minDeltaRadius <= deltaRadius &&
-           deltaRadius <= math.max(constraints.minDeltaRadius, constraints.maxDeltaRadius) &&
-           constraints.minDeltaTheta <= deltaTheta &&
-           deltaTheta <= math.max(constraints.minDeltaTheta, constraints.maxDeltaTheta);
+    assert(constraints.minDeltaRadius <= deltaRadius);
+    assert(deltaRadius <= math.max(constraints.minDeltaRadius, constraints.maxDeltaRadius));
+    assert(constraints.minDeltaTheta <= deltaTheta);
+    assert(deltaTheta <= math.max(constraints.minDeltaTheta, constraints.maxDeltaTheta));
   }
   void performResize() {
     // default behaviour for subclasses that have sizedByParent = true

--- a/packages/flutter/lib/src/rendering/block.dart
+++ b/packages/flutter/lib/src/rendering/block.dart
@@ -350,8 +350,9 @@ class RenderBlockViewport extends RenderBlockBase {
     double result;
     if (intrinsicCallback == null) {
       assert(() {
-        'RenderBlockViewport does not support returning intrinsic dimensions if the relevant callbacks have not been specified.';
-        return RenderObject.debugInDebugDoesMeetConstraints;
+        if (!RenderObject.debugCheckingIntrinsics)
+          throw new UnsupportedError('$runtimeType does not support returning intrinsic dimensions if the relevant callbacks have not been specified.');
+        return true;
       });
       return constrainer(0.0);
     }

--- a/packages/flutter/lib/src/rendering/view.dart
+++ b/packages/flutter/lib/src/rendering/view.dart
@@ -78,7 +78,7 @@ class RenderView extends RenderObject with RenderObjectWithChildMixin<RenderBox>
 
   // We never call layout() on this class, so this should never get
   // checked. (This class is laid out using scheduleInitialLayout().)
-  bool debugDoesMeetConstraints() { assert(false); return false; }
+  void debugAssertDoesMeetConstraints() { assert(false); }
 
   void performResize() {
     assert(false);

--- a/packages/flutter/lib/src/widgets/mixed_viewport.dart
+++ b/packages/flutter/lib/src/widgets/mixed_viewport.dart
@@ -155,10 +155,14 @@ class _MixedViewportElement extends RenderObjectElement<MixedViewport> {
 
   double _noIntrinsicExtent(BoxConstraints constraints) {
     assert(() {
-      'MixedViewport does not support returning intrinsic dimensions. ' +
-      'Calculating the intrinsic dimensions would require walking the entire child list, ' +
-      'which defeats the entire point of having a lazily-built list of children.';
-      return RenderObject.debugInDebugDoesMeetConstraints;
+      if (!RenderObject.debugCheckingIntrinsics) {
+        throw new UnsupportedError(
+          'MixedViewport does not support returning intrinsic dimensions.\n'
+          'Calculating the intrinsic dimensions would require walking the entire child list,\n'
+          'which defeats the entire point of having a lazily-built list of children.'
+        );
+      }
+      return true;
     });
     return null;
   }

--- a/packages/flutter/lib/src/widgets/scrollable.dart
+++ b/packages/flutter/lib/src/widgets/scrollable.dart
@@ -442,13 +442,14 @@ class ScrollableViewportState extends ScrollableState<ScrollableViewport> {
 class Block extends StatelessComponent {
   Block({
     Key key,
-    this.children,
+    this.children: const <Widget>[],
     this.padding,
     this.initialScrollOffset,
     this.scrollDirection: Axis.vertical,
     this.onScroll,
     this.scrollableKey
   }) : super(key: key) {
+    assert(children != null);
     assert(!children.any((Widget child) => child == null));
   }
 

--- a/packages/flutter/test/widget/custom_multi_child_layout_test.dart
+++ b/packages/flutter/test/widget/custom_multi_child_layout_test.dart
@@ -11,7 +11,7 @@ class TestMultiChildLayoutDelegate extends MultiChildLayoutDelegate {
   BoxConstraints getSizeConstraints;
 
   Size getSize(BoxConstraints constraints) {
-    if (!RenderObject.debugInDebugDoesMeetConstraints)
+    if (!RenderObject.debugCheckingIntrinsics)
       getSizeConstraints = constraints;
     return new Size(200.0, 300.0);
   }
@@ -23,7 +23,7 @@ class TestMultiChildLayoutDelegate extends MultiChildLayoutDelegate {
   bool performLayoutIsChild;
 
   void performLayout(Size size, BoxConstraints constraints) {
-    assert(!RenderObject.debugInDebugDoesMeetConstraints);
+    assert(!RenderObject.debugCheckingIntrinsics);
     expect(() {
       performLayoutSize = size;
       performLayoutConstraints = constraints;
@@ -36,7 +36,7 @@ class TestMultiChildLayoutDelegate extends MultiChildLayoutDelegate {
   bool shouldRelayoutCalled = false;
   bool shouldRelayoutValue = false;
   bool shouldRelayout(_) {
-    assert(!RenderObject.debugInDebugDoesMeetConstraints);
+    assert(!RenderObject.debugCheckingIntrinsics);
     shouldRelayoutCalled = true;
     return shouldRelayoutValue;
   }

--- a/packages/flutter/test/widget/custom_one_child_layout_test.dart
+++ b/packages/flutter/test/widget/custom_one_child_layout_test.dart
@@ -14,13 +14,13 @@ class TestOneChildLayoutDelegate extends OneChildLayoutDelegate {
   Size childSizeFromGetPositionForChild;
 
   Size getSize(BoxConstraints constraints) {
-    if (!RenderObject.debugInDebugDoesMeetConstraints)
+    if (!RenderObject.debugCheckingIntrinsics)
       constraintsFromGetSize = constraints;
     return new Size(200.0, 300.0);
   }
 
   BoxConstraints getConstraintsForChild(BoxConstraints constraints) {
-    assert(!RenderObject.debugInDebugDoesMeetConstraints);
+    assert(!RenderObject.debugCheckingIntrinsics);
     constraintsFromGetConstraintsForChild = constraints;
     return new BoxConstraints(
       minWidth: 100.0,
@@ -31,7 +31,7 @@ class TestOneChildLayoutDelegate extends OneChildLayoutDelegate {
   }
 
   Offset getPositionForChild(Size size, Size childSize) {
-    assert(!RenderObject.debugInDebugDoesMeetConstraints);
+    assert(!RenderObject.debugCheckingIntrinsics);
     sizeFromGetPositionForChild = size;
     childSizeFromGetPositionForChild = childSize;
     return Offset.zero;
@@ -40,7 +40,7 @@ class TestOneChildLayoutDelegate extends OneChildLayoutDelegate {
   bool shouldRelayoutCalled = false;
   bool shouldRelayoutValue = false;
   bool shouldRelayout(_) {
-    assert(!RenderObject.debugInDebugDoesMeetConstraints);
+    assert(!RenderObject.debugCheckingIntrinsics);
     shouldRelayoutCalled = true;
     return shouldRelayoutValue;
   }


### PR DESCRIPTION
- Use actual exceptions rather than assertions containing code
  containing strings when trying to give messages to authors.
- Introduce RenderingError which is an AssertionError that takes a
  string argument, to support the above.
- Provide a BoxDimensions.hasBoundedWidth/hasBoundedHeight API.
- Document BoxDimensions.isNormalized.
- Provide more useful information when we assert isNormalized and find
  that it is false.
- When finding the size is infinite, crawl the tree to figure out which
  render box is likely responsible for the infinite constraints.
- Provide more information when size doesn't match the constraints.
- Provide more information when intrinsic dimension methods violate the
  constraints.
- Only spam a huge amount of information for the first exception from
  the rendering library. I've noticed a lot of people looking at the
  last exception printed rather than the first and that's very
  misleading -- after the rendering library hits an exception, all bets
  are off regarding what'll happen in the future. All kinds of asserts
  might fire.
- Improve docs around the debug methods and flags for the above.
- Make Block default to have no children. Previously, giving no children
  crashed with a confusing message about a null deref in an assert.
