### PR TITLE
add a dev mode to the flutter script

### DIFF
--- a/bin/flutter
+++ b/bin/flutter
@@ -15,6 +15,11 @@ SCRIPT_PATH="$FLUTTER_TOOLS_DIR/bin/flutter_tools.dart"
 # TODO(abarth): We shouldn't require dart to be on the user's path.
 DART=dart
 
+if [ -n $FLUTTER_DEV ]; then
+  $DART --checked --package-root="$FLUTTER_TOOLS_DIR/packages" "$SCRIPT_PATH" "$@"
+  exit 0
+fi
+
 REVISION=`(cd "$FLUTTER_ROOT"; git rev-parse HEAD)`
 if [ ! -f "$SNAPSHOT_PATH" ] || [ ! -f "$STAMP_PATH" ] || [ `cat "$STAMP_PATH"` != "$REVISION" ] || [ "$FLUTTER_TOOLS_DIR/pubspec.yaml" -nt "$FLUTTER_TOOLS_DIR/pubspec.lock" ]; then
   echo Updating flutter tool...

--- a/bin/flutter.bat
+++ b/bin/flutter.bat
@@ -13,6 +13,11 @@ SET script_path=%flutter_tools_dir%\bin\flutter_tools.dart
 REM TODO: Don't require dart to be on the user's path
 SET dart=dart
 
+IF "%FLUTTER_DEV%" == "" GOTO no_flutter_dev
+CALL %dart% --checked --package-root="%flutter_tools_dir%\packages" "%script_path%" %*
+EXIT /B %ERRORLEVEL%
+:no_flutter_dev
+
 REM Set current working directory to the flutter directory
 PUSHD %flutter_root%
 REM IF doesn't have an "or". Instead, just use GOTO


### PR DESCRIPTION
If there's a `FLUTTER_DEV` env var defined when the flutter script is run, it does not use the cached snapshot. In addition, in runs the script in checked mode.

Not necessarily critical to land this, although it has been useful for me locally.
