### PR TITLE
two fixes for checked mode

### DIFF
--- a/packages/flutter_tools/lib/src/commands/apk.dart
+++ b/packages/flutter_tools/lib/src/commands/apk.dart
@@ -439,7 +439,7 @@ bool _needsRebuild(String apkPath, String manifest) {
   // Note: This list of dependencies is imperfect, but will do for now. We
   // purposely don't include the .dart files, because we can load those
   // over the network without needing to rebuild (at least on Android).
-  List<FileStat> dependenciesStat = [
+  Iterable<FileStat> dependenciesStat = [
     manifest,
     _kFlutterManifestPath,
     _kPackagesStatusPath

--- a/packages/flutter_tools/lib/src/flx.dart
+++ b/packages/flutter_tools/lib/src/flx.dart
@@ -99,10 +99,12 @@ class _MaterialAsset extends _Asset {
   }
 }
 
-List _generateValues(Map assetDescriptor, String key, List defaults) {
-  if (assetDescriptor.containsKey(key))
-    return [assetDescriptor[key]];
-  return defaults;
+Iterable/*<T>*/ _generateValues/*<T>*/(
+  Map/*<String, T>*/ assetDescriptor,
+  String key,
+  Iterable/*<T>*/ defaults
+) {
+  return assetDescriptor.containsKey(key) ? /*<T>*/[assetDescriptor[key]] : defaults;
 }
 
 void _accumulateMaterialAssets(Map<_Asset, List<_Asset>> result, Map assetDescriptor, String assetBase) {


### PR DESCRIPTION
Fixes for two runtime checked mode failures, both places where Iterables are used as Lists.

For the `_generateValues` location I also added generic method args, since some of the params varied from `List<int>` to `List<String>` to `Iterable<String>` . The critical bit though is either using Iterables or calling toList() on the results or `map()` or `Map.keys`.
