### PR TITLE
Tapping drawer during animation causes it to stick

### DIFF
--- a/packages/flutter/lib/src/gestures/recognizer.dart
+++ b/packages/flutter/lib/src/gestures/recognizer.dart
@@ -81,6 +81,11 @@ abstract class OneSequenceGestureRecognizer extends GestureRecognizer {
       didStopTrackingLastPointer(pointer);
   }
 
+  void ensureNotTrackingPointer(int pointer) {
+    if (_trackedPointers.contains(pointer))
+      stopTrackingPointer(pointer);
+  }
+
   void stopTrackingIfPointerNoLongerDown(PointerEvent event) {
     if (event is PointerUpEvent || event is PointerCancelEvent)
       stopTrackingPointer(event.pointer);

--- a/packages/flutter/lib/src/material/drawer.dart
+++ b/packages/flutter/lib/src/material/drawer.dart
@@ -125,7 +125,7 @@ class DrawerControllerState extends State<DrawerController> {
     });
   }
 
-  void _handleTapDown(Point position) {
+  void _down(Point position) {
     _controller.stop();
     _ensureHistoryEntry();
   }
@@ -140,6 +140,16 @@ class DrawerControllerState extends State<DrawerController> {
     if (velocity.dx.abs() >= _kMinFlingVelocity) {
       _controller.fling(velocity: velocity.dx / _width);
     } else if (_controller.value < 0.5) {
+      close();
+    } else {
+      open();
+    }
+  }
+
+  void _cancel() {
+    if (_controller.isDismissed)
+      return;
+    if (_controller.value < 0.5) {
       close();
     } else {
       open();
@@ -173,8 +183,10 @@ class DrawerControllerState extends State<DrawerController> {
     } else {
       return new GestureDetector(
         key: _gestureDetectorKey,
+        onHorizontalDragDown: _down,
         onHorizontalDragUpdate: _move,
         onHorizontalDragEnd: _settle,
+        onHorizontalDragCancel: _cancel,
         child: new RepaintBoundary(
           child: new Stack(
             children: <Widget>[
@@ -189,18 +201,15 @@ class DrawerControllerState extends State<DrawerController> {
               ),
               new Align(
                 alignment: const FractionalOffset(0.0, 0.5),
-                child: new GestureDetector(
-                  onTapDown: _handleTapDown,
-                  child: new Align(
-                    alignment: const FractionalOffset(1.0, 0.5),
-                    widthFactor: _controller.value,
-                    child: new SizeObserver(
-                      onSizeChanged: _handleSizeChanged,
-                      child: new RepaintBoundary(
-                        child: new Focus(
-                          key: _focusKey,
-                          child: config.child
-                        )
+                child: new Align(
+                  alignment: const FractionalOffset(1.0, 0.5),
+                  widthFactor: _controller.value,
+                  child: new SizeObserver(
+                    onSizeChanged: _handleSizeChanged,
+                    child: new RepaintBoundary(
+                      child: new Focus(
+                        key: _focusKey,
+                        child: config.child
                       )
                     )
                   )

--- a/packages/flutter/lib/src/widgets/gesture_detector.dart
+++ b/packages/flutter/lib/src/widgets/gesture_detector.dart
@@ -14,15 +14,16 @@ export 'package:flutter/gestures.dart' show
   GestureTapCallback,
   GestureTapCancelCallback,
   GestureLongPressCallback,
+  GestureDragDownCallback,
   GestureDragStartCallback,
   GestureDragUpdateCallback,
   GestureDragEndCallback,
-  GestureDragStartCallback,
-  GestureDragUpdateCallback,
-  GestureDragEndCallback,
+  GestureDragCancelCallback,
+  GesturePanDownCallback,
   GesturePanStartCallback,
   GesturePanUpdateCallback,
   GesturePanEndCallback,
+  GesturePanCancelCallback,
   GestureScaleStartCallback,
   GestureScaleUpdateCallback,
   GestureScaleEndCallback;
@@ -46,15 +47,21 @@ class GestureDetector extends StatefulComponent {
     this.onTapCancel,
     this.onDoubleTap,
     this.onLongPress,
+    this.onVerticalDragDown,
     this.onVerticalDragStart,
     this.onVerticalDragUpdate,
     this.onVerticalDragEnd,
+    this.onVerticalDragCancel,
+    this.onHorizontalDragDown,
     this.onHorizontalDragStart,
     this.onHorizontalDragUpdate,
     this.onHorizontalDragEnd,
+    this.onHorizontalDragCancel,
+    this.onPanDown,
     this.onPanStart,
     this.onPanUpdate,
     this.onPanEnd,
+    this.onPanCancel,
     this.onScaleStart,
     this.onScaleUpdate,
     this.onScaleEnd,
@@ -88,6 +95,9 @@ class GestureDetector extends StatefulComponent {
   final GestureLongPressCallback onLongPress;
 
   /// A pointer has contacted the screen and might begin to move vertically.
+  final GestureDragDownCallback onVerticalDragDown;
+
+  /// A pointer has contacted the screen and has begun to move vertically.
   final GestureDragStartCallback onVerticalDragStart;
 
   /// A pointer that is in contact with the screen and moving vertically has
@@ -99,7 +109,14 @@ class GestureDetector extends StatefulComponent {
   /// specific velocity when it stopped contacting the screen.
   final GestureDragEndCallback onVerticalDragEnd;
 
+  /// A pointer that previously triggered an onVerticalDragDown callback did not
+  /// end up moving vertically.
+  final GestureDragCancelCallback onVerticalDragCancel;
+
   /// A pointer has contacted the screen and might begin to move horizontally.
+  final GestureDragDownCallback onHorizontalDragDown;
+
+  /// A pointer has contacted the screen and has begun to move horizontally.
   final GestureDragStartCallback onHorizontalDragStart;
 
   /// A pointer that is in contact with the screen and moving horizontally has
@@ -111,9 +128,15 @@ class GestureDetector extends StatefulComponent {
   /// specific velocity when it stopped contacting the screen.
   final GestureDragEndCallback onHorizontalDragEnd;
 
+  /// A pointer that previously triggered an onHorizontalDragDown callback did
+  /// not end up moving horizontally.
+  final GestureDragCancelCallback onHorizontalDragCancel;
+
+  final GesturePanDownCallback onPanDown;
   final GesturePanStartCallback onPanStart;
   final GesturePanUpdateCallback onPanUpdate;
   final GesturePanEndCallback onPanEnd;
+  final GesturePanCancelCallback onPanCancel;
 
   final GestureScaleStartCallback onScaleStart;
   final GestureScaleUpdateCallback onScaleUpdate;
@@ -205,39 +228,57 @@ class _GestureDetectorState extends State<GestureDetector> {
   }
 
   void _syncVerticalDrag() {
-    if (config.onVerticalDragStart == null && config.onVerticalDragUpdate == null && config.onVerticalDragEnd == null) {
+    if (config.onVerticalDragDown == null &&
+        config.onVerticalDragStart == null &&
+        config.onVerticalDragUpdate == null &&
+        config.onVerticalDragEnd == null &&
+        config.onVerticalDragCancel == null) {
       _verticalDrag = _ensureDisposed(_verticalDrag);
     } else {
       _verticalDrag ??= new VerticalDragGestureRecognizer(router: _router, gestureArena: Gesturer.instance.gestureArena);
       _verticalDrag
+        ..onDown = config.onVerticalDragDown
         ..onStart = config.onVerticalDragStart
         ..onUpdate = config.onVerticalDragUpdate
-        ..onEnd = config.onVerticalDragEnd;
+        ..onEnd = config.onVerticalDragEnd
+        ..onCancel = config.onVerticalDragCancel;
     }
   }
 
   void _syncHorizontalDrag() {
-    if (config.onHorizontalDragStart == null && config.onHorizontalDragUpdate == null && config.onHorizontalDragEnd == null) {
+    if (config.onHorizontalDragDown == null &&
+        config.onHorizontalDragStart == null &&
+        config.onHorizontalDragUpdate == null &&
+        config.onHorizontalDragEnd == null &&
+        config.onHorizontalDragCancel == null) {
       _horizontalDrag = _ensureDisposed(_horizontalDrag);
     } else {
       _horizontalDrag ??= new HorizontalDragGestureRecognizer(router: _router, gestureArena: Gesturer.instance.gestureArena);
       _horizontalDrag
+        ..onDown = config.onHorizontalDragDown
         ..onStart = config.onHorizontalDragStart
         ..onUpdate = config.onHorizontalDragUpdate
-        ..onEnd = config.onHorizontalDragEnd;
+        ..onEnd = config.onHorizontalDragEnd
+        ..onCancel = config.onHorizontalDragCancel;
     }
   }
 
   void _syncPan() {
-    if (config.onPanStart == null && config.onPanUpdate == null && config.onPanEnd == null) {
+    if (config.onPanDown == null &&
+        config.onPanStart == null &&
+        config.onPanUpdate == null &&
+        config.onPanEnd == null &&
+        config.onPanCancel == null) {
       _pan = _ensureDisposed(_pan);
     } else {
       assert(_scale == null);  // Scale is a superset of pan; just use scale
       _pan ??= new PanGestureRecognizer(router: _router, gestureArena: Gesturer.instance.gestureArena);
       _pan
+        ..onDown = config.onPanStart
         ..onStart = config.onPanStart
         ..onUpdate = config.onPanUpdate
-        ..onEnd = config.onPanEnd;
+        ..onEnd = config.onPanEnd
+        ..onCancel = config.onPanCancel;
     }
   }
 

--- a/packages/flutter/lib/src/widgets/scrollable.dart
+++ b/packages/flutter/lib/src/widgets/scrollable.dart
@@ -198,6 +198,12 @@ abstract class ScrollableState<T extends Scrollable> extends State<T> {
     return _scrollBehavior;
   }
 
+  GestureDragDownCallback _getDragDownHandler(Axis direction) {
+    if (config.scrollDirection != direction || !scrollBehavior.isScrollable)
+      return null;
+    return _handleDragDown;
+  }
+
   GestureDragStartCallback _getDragStartHandler(Axis direction) {
     if (config.scrollDirection != direction || !scrollBehavior.isScrollable)
       return null;
@@ -218,17 +224,16 @@ abstract class ScrollableState<T extends Scrollable> extends State<T> {
 
   Widget build(BuildContext context) {
     return new GestureDetector(
+      onVerticalDragDown: _getDragDownHandler(Axis.vertical),
       onVerticalDragStart: _getDragStartHandler(Axis.vertical),
       onVerticalDragUpdate: _getDragUpdateHandler(Axis.vertical),
       onVerticalDragEnd: _getDragEndHandler(Axis.vertical),
+      onHorizontalDragDown: _getDragDownHandler(Axis.horizontal),
       onHorizontalDragStart: _getDragStartHandler(Axis.horizontal),
       onHorizontalDragUpdate: _getDragUpdateHandler(Axis.horizontal),
       onHorizontalDragEnd: _getDragEndHandler(Axis.horizontal),
       behavior: HitTestBehavior.opaque,
-      child: new Listener(
-        child: buildContent(context),
-        onPointerDown: _handlePointerDown
-      )
+      child: buildContent(context)
     );
   }
 
@@ -399,7 +404,7 @@ abstract class ScrollableState<T extends Scrollable> extends State<T> {
       config.onScrollEnd(_scrollOffset);
   }
 
-  void _handlePointerDown(_) {
+  void _handleDragDown(_) {
     _controller.stop();
   }
 


### PR DESCRIPTION
The problem was we were using a tap gesture to stop the motion of the
drawer and a drag gesture to settle it. That can cause a broken
lifecycle. Now we use a single drag recognizer to drive the whole
lifecycle.

Fixes #775
