### PR TITLE
General flutter_tools refactoring

### DIFF
--- a/packages/flutter_tools/lib/flutter_tools.dart
+++ b/packages/flutter_tools/lib/flutter_tools.dart
@@ -2,16 +2,14 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-library flutter_tools;
-
 import 'dart:async';
 
 import 'package:archive/archive.dart';
 
 import 'src/flx.dart' as flx;
 
-/// Assembles a Flutter .flx file from a pre-existing manifest descriptor
-/// and a pre-compiled snapshot.
+/// Assembles a Flutter .flx file from a pre-existing manifest descriptor and a
+/// pre-compiled snapshot.
 Future<int> assembleFlx({
   Map manifestDescriptor: const {},
   ArchiveFile snapshotFile: null,

--- a/packages/flutter_tools/lib/src/android/adb.dart
+++ b/packages/flutter_tools/lib/src/android/adb.dart
@@ -19,7 +19,7 @@ class Adb {
 
   final String adbPath;
 
-  Map<String, String> _idToNameCache = <String, String>{};
+  final Map<String, String> _idToNameCache = <String, String>{};
 
   bool exists() {
     try {

--- a/packages/flutter_tools/lib/src/commands/apk.dart
+++ b/packages/flutter_tools/lib/src/commands/apk.dart
@@ -366,7 +366,7 @@ int _buildApk(
     ensureDirectoryExists(finalApk.path);
     builder.align(unalignedApk, finalApk);
 
-    printStatus('APK generated: ${finalApk.path}');
+    printStatus('Generated APK to ${finalApk.path}.');
 
     return 0;
   } finally {
@@ -520,7 +520,7 @@ Future<ApplicationPackageStore> buildAll(
     // TODO(mpcomplete): Temporary hack. We only support the apk builder atm.
     if (package == applicationPackages.android) {
       if (!FileSystemEntity.isFileSync(_kDefaultAndroidManifestPath)) {
-        printStatus('Using pre-built SkyShell.apk');
+        printStatus('Using pre-built SkyShell.apk.');
         continue;
       }
 

--- a/packages/flutter_tools/lib/src/commands/daemon.dart
+++ b/packages/flutter_tools/lib/src/commands/daemon.dart
@@ -362,7 +362,7 @@ class AndroidDeviceDiscovery {
       if (androidDevice == null) {
         // device added
         androidDevice = new AndroidDevice(
-          id: device.id,
+          device.id,
           productID: device.productID,
           modelID: device.modelID,
           deviceCodeName: device.deviceCodeName,
@@ -384,11 +384,6 @@ class AndroidDeviceDiscovery {
     // device removed
     for (AndroidDevice device in currentDevices) {
       _devices.remove(device.id);
-
-      // I don't know the purpose of this cache or if it's a good idea. We should
-      // probably have a DeviceManager singleton class to coordinate known devices
-      // and different device discovery mechanisms.
-      Device.removeFromCache(device.id);
 
       removedController.add(device);
     }
@@ -424,7 +419,7 @@ class IOSSimulatorDeviceDiscovery {
 
       if (androidDevice == null) {
         // device added
-        androidDevice = new IOSSimulator(id: device.udid, name: device.name);
+        androidDevice = new IOSSimulator(device.udid, name: device.name);
         _devices[androidDevice.id] = androidDevice;
         addedController.add(androidDevice);
       } else {
@@ -435,8 +430,6 @@ class IOSSimulatorDeviceDiscovery {
     // device removed
     for (IOSSimulator device in currentDevices) {
       _devices.remove(device.id);
-
-      Device.removeFromCache(device.id);
 
       removedController.add(device);
     }

--- a/packages/flutter_tools/lib/src/device.dart
+++ b/packages/flutter_tools/lib/src/device.dart
@@ -66,18 +66,9 @@ abstract class DeviceDiscovery {
 }
 
 abstract class Device {
+  Device(this.id);
+
   final String id;
-  static Map<String, Device> _deviceCache = {};
-
-  static Device unique(String id, Device constructor(String id)) {
-    return _deviceCache.putIfAbsent(id, () => constructor(id));
-  }
-
-  static void removeFromCache(String id) {
-    _deviceCache.remove(id);
-  }
-
-  Device.fromId(this.id);
 
   String get name;
 
@@ -133,6 +124,12 @@ abstract class DeviceLogReader {
 
 // TODO(devoncarew): Unify this with [DeviceManager].
 class DeviceStore {
+  DeviceStore({
+    this.android,
+    this.iOS,
+    this.iOSSimulator
+  });
+
   final AndroidDevice android;
   final IOSDevice iOS;
   final IOSSimulator iOSSimulator;
@@ -147,12 +144,6 @@ class DeviceStore {
       result.add(iOSSimulator);
     return result;
   }
-
-  DeviceStore({
-    this.android,
-    this.iOS,
-    this.iOSSimulator
-  });
 
   static Device _deviceForConfig(BuildConfiguration config, List<Device> devices) {
     Device device = null;
@@ -194,10 +185,6 @@ class DeviceStore {
         case TargetPlatform.iOSSimulator:
           assert(iOSSimulator == null);
           iOSSimulator = _deviceForConfig(config, IOSSimulator.getAttachedDevices());
-          if (iOSSimulator == null) {
-            // Creates a simulator with the default identifier
-            iOSSimulator = new IOSSimulator();
-          }
           break;
         case TargetPlatform.mac:
         case TargetPlatform.linux:

--- a/packages/flutter_tools/lib/src/flx.dart
+++ b/packages/flutter_tools/lib/src/flx.dart
@@ -33,8 +33,8 @@ Map<String, double> _kIconDensities = {
   'xxhdpi' : 3.0,
   'xxxhdpi' : 4.0
 };
-const List<String> _kThemes = const ['white', 'black'];
-const List<int> _kSizes = const [18, 24, 36, 48];
+const List<String> _kThemes = const <String>['white', 'black'];
+const List<int> _kSizes = const <int>[18, 24, 36, 48];
 
 class _Asset {
   final String source;

--- a/packages/flutter_tools/test/android_device_test.dart
+++ b/packages/flutter_tools/test/android_device_test.dart
@@ -9,22 +9,10 @@ main() => defineTests();
 
 defineTests() {
   group('android_device', () {
-    test('uses the correct default ID', () {
-      AndroidDevice android = new AndroidDevice();
-      expect(android.id, equals(AndroidDevice.defaultDeviceID));
-    });
-
     test('stores the requested id', () {
       String deviceId = '1234';
-      AndroidDevice android = new AndroidDevice(id: deviceId);
-      expect(android.id, equals(deviceId));
-    });
-
-    test('correctly creates only one of each requested device id', () {
-      String deviceID = '1234';
-      AndroidDevice a1 = new AndroidDevice(id: deviceID);
-      AndroidDevice a2 = new AndroidDevice(id: deviceID);
-      expect(a1, equals(a2));
+      AndroidDevice device = new AndroidDevice(deviceId);
+      expect(device.id, equals(deviceId));
     });
   });
 }


### PR DESCRIPTION
Remove the static device cache from `Device`. This removes some of the redundant locations where sets of devices are stored, and simplifies Device ctors.
- remove `Device.unique` and `Device.removeFromCache`
- remove the Device factory constructors
- the three device types no longer have default ids - they must be constructed around a real device
- some style nits
