### PR TITLE
Fix `flutter stop` to stop the right Android activity.

### DIFF
--- a/packages/flutter_tools/lib/src/commands/start.dart
+++ b/packages/flutter_tools/lib/src/commands/start.dart
@@ -142,7 +142,7 @@ Future<int> startApp(
 
   if (install) {
     printTrace('Running build command.');
-    applicationPackages = await buildAll(
+    await buildAll(
       devices, applicationPackages, toolchain, configs,
       enginePath: enginePath,
       target: target);


### PR DESCRIPTION
Previously we'd always stop org.domokit.sky.shell. If an
AndroidManifest.xml exists, we'll use the activity specified in there
instead.

Fixes https://github.com/flutter/flutter/issues/1651
