### PR TITLE
start the simulator with -arch x86_64

### DIFF
--- a/packages/flutter_tools/lib/src/ios/device_ios.dart
+++ b/packages/flutter_tools/lib/src/ios/device_ios.dart
@@ -522,7 +522,7 @@ Future<bool> _buildIOSXcodeProject(ApplicationPackage app, bool isDevice) async 
   ];
 
   if (!isDevice) {
-    commands.addAll(<String>['-sdk', 'iphonesimulator']);
+    commands.addAll(<String>['-sdk', 'iphonesimulator', '-arch', 'x86_64']);
   }
 
   try {


### PR DESCRIPTION
@chinmaygarde, pass additional flags into `xcodebuild` when building for the simulator.
