### PR TITLE
Skip flutter_simple in create_test on Mac for now

### DIFF
--- a/packages/flutter_tools/test/create_test.dart
+++ b/packages/flutter_tools/test/create_test.dart
@@ -27,7 +27,9 @@ defineTests() {
 
     // This test consistently times out on our windows bot. The code is already
     // covered on the linux one.
-    if (!Platform.isWindows) {
+    // Also fails on mac, with create --out returning '69'
+    // TODO(devoncarew): https://github.com/flutter/flutter/issues/1709
+    if (Platform.isLinux) {
       // Verify that we create a project that is well-formed.
       test('flutter-simple', () async {
         ArtifactStore.flutterRoot = '../..';


### PR DESCRIPTION
Returns 69 instead of 0 in the `create --out` part.
https://github.com/flutter/flutter/issues/1709

@devoncarew
