### PR TITLE
fix a test on the mac

### DIFF
--- a/packages/flutter_tools/lib/src/commands/create.dart
+++ b/packages/flutter_tools/lib/src/commands/create.dart
@@ -119,18 +119,18 @@ abstract class Template {
     printStatus('Creating ${path.basename(projectName)}...');
     dir.createSync(recursive: true);
 
-    // If there's a good relative path use it; else fall back to an absolute path.
-    if (_hasRelativePath(flutterPackagePath, dirPath)) {
-      flutterPackagePath = path.relative(flutterPackagePath, from: dirPath);
-    } else {
-      flutterPackagePath = path.absolute(flutterPackagePath);
-    }
+    String pubspecPath = path.relative(flutterPackagePath, from: dirPath);
+
+    // If we can't validate the relative path, use an absolute one.
+    String resolvedPath = path.join(dirPath, pubspecPath);
+    if (!FileSystemEntity.isDirectorySync(resolvedPath))
+      pubspecPath = path.absolute(flutterPackagePath);
 
     files.forEach((String filePath, String contents) {
       Map m = {
         'projectName': projectName,
         'description': description,
-        'flutterPackagePath': flutterPackagePath
+        'flutterPackagePath': pubspecPath
       };
       contents = mustache.render(contents, m);
       filePath = filePath.replaceAll('/', Platform.pathSeparator);
@@ -139,16 +139,6 @@ abstract class Template {
       file.writeAsStringSync(contents);
       printStatus('  ${file.path}');
     });
-  }
-
-  bool _hasRelativePath(String path1, String path2) {
-    List<String> parts1 = path.split(path1);
-    List<String> parts2 = path.split(path2);
-
-    if (parts1.length < 2 || parts2.length < 2)
-      return false;
-
-    return (path1[0] == path2[0]) && (path1[1] == path2[1]);
   }
 
   String toString() => name;

--- a/packages/flutter_tools/test/create_test.dart
+++ b/packages/flutter_tools/test/create_test.dart
@@ -25,34 +25,28 @@ defineTests() {
       temp.deleteSync(recursive: true);
     });
 
-    // This test consistently times out on our windows bot. The code is already
-    // covered on the linux one.
-    // Also fails on mac, with create --out returning '69'
-    // TODO(devoncarew): https://github.com/flutter/flutter/issues/1709
-    if (Platform.isLinux) {
-      // Verify that we create a project that is well-formed.
-      test('flutter-simple', () async {
-        ArtifactStore.flutterRoot = '../..';
-        CreateCommand command = new CreateCommand();
-        CommandRunner runner = new CommandRunner('test_flutter', '')
-          ..addCommand(command);
-        await runner.run(['create', '--out', temp.path])
-            .then((int code) => expect(code, equals(0)));
+    // Verify that we create a project that is well-formed.
+    test('flutter-simple', () async {
+      ArtifactStore.flutterRoot = '../..';
+      CreateCommand command = new CreateCommand();
+      CommandRunner runner = new CommandRunner('test_flutter', '')
+        ..addCommand(command);
+      await runner.run(['create', '--out', temp.path])
+          .then((int code) => expect(code, equals(0)));
 
-        String mainPath = path.join(temp.path, 'lib', 'main.dart');
-        expect(new File(mainPath).existsSync(), true);
-        ProcessResult exec = Process.runSync(
-          sdkBinaryName('dartanalyzer'), ['--fatal-warnings', mainPath],
-          workingDirectory: temp.path
-        );
-        if (exec.exitCode != 0) {
-          print(exec.stdout);
-          print(exec.stderr);
-        }
-        expect(exec.exitCode, 0);
-      },
-      // This test can take a while due to network requests.
-      timeout: new Timeout(new Duration(minutes: 2)));
-    }
+      String mainPath = path.join(temp.path, 'lib', 'main.dart');
+      expect(new File(mainPath).existsSync(), true);
+      ProcessResult exec = Process.runSync(
+        sdkBinaryName('dartanalyzer'), ['--fatal-warnings', mainPath],
+        workingDirectory: temp.path
+      );
+      if (exec.exitCode != 0) {
+        print(exec.stdout);
+        print(exec.stderr);
+      }
+      expect(exec.exitCode, 0);
+    },
+    // This test can take a while due to network requests.
+    timeout: new Timeout(new Duration(minutes: 2)));
   });
 }


### PR DESCRIPTION
Fix a test failure on the mac (fix https://github.com/flutter/flutter/issues/1709). `path.relative` was not creating correct relative paths. We work around it by using absolute paths if there is no good relative path between two directories (if the relative path would go all the way up to the filesystem root and back down).

@eseidelGoogle
