### PR TITLE
rename the service protocol extensions

### DIFF
--- a/packages/flutter/lib/src/rendering/debug.dart
+++ b/packages/flutter/lib/src/rendering/debug.dart
@@ -87,8 +87,8 @@ void initServiceExtensions() {
   _extensionsInitialized = true;
 
   assert(() {
-    developer.registerExtension('flutter.debugPaint', _debugPaint);
-    developer.registerExtension('flutter.timeDilation', _timeDilation);
+    developer.registerExtension('ext.flutter.debugPaint', _debugPaint);
+    developer.registerExtension('ext.flutter.timeDilation', _timeDilation);
 
     return true;
   });


### PR DESCRIPTION
Rename the service protocol extensions to start with `ext.`.

@yjbanov @johnmccutchan 
