### PR TITLE
Remove FLUTTER_DEV environment var

### DIFF
--- a/bin/flutter
+++ b/bin/flutter
@@ -15,11 +15,6 @@ SCRIPT_PATH="$FLUTTER_TOOLS_DIR/bin/flutter_tools.dart"
 # TODO(abarth): We shouldn't require dart to be on the user's path.
 DART=dart
 
-if [ -n $FLUTTER_DEV ]; then
-  $DART --checked --package-root="$FLUTTER_TOOLS_DIR/packages" "$SCRIPT_PATH" "$@"
-  exit 0
-fi
-
 REVISION=`(cd "$FLUTTER_ROOT"; git rev-parse HEAD)`
 if [ ! -f "$SNAPSHOT_PATH" ] || [ ! -f "$STAMP_PATH" ] || [ `cat "$STAMP_PATH"` != "$REVISION" ] || [ "$FLUTTER_TOOLS_DIR/pubspec.yaml" -nt "$FLUTTER_TOOLS_DIR/pubspec.lock" ]; then
   echo Updating flutter tool...

--- a/bin/flutter.bat
+++ b/bin/flutter.bat
@@ -13,11 +13,6 @@ SET script_path=%flutter_tools_dir%\bin\flutter_tools.dart
 REM TODO: Don't require dart to be on the user's path
 SET dart=dart
 
-IF "%FLUTTER_DEV%" == "" GOTO no_flutter_dev
-CALL %dart% --checked --package-root="%flutter_tools_dir%\packages" "%script_path%" %*
-EXIT /B %ERRORLEVEL%
-:no_flutter_dev
-
 REM Set current working directory to the flutter directory
 PUSHD %flutter_root%
 REM IF doesn't have an "or". Instead, just use GOTO


### PR DESCRIPTION
This check is triggering even for folks who don't have FLUTTER_DEV set, which
is breaking their toolchain because we're not running `pub get` on the
flutter_tools package.
