### PR TITLE
filter offline devices from notifications

### DIFF
--- a/packages/flutter_tools/lib/src/android/adb.dart
+++ b/packages/flutter_tools/lib/src/android/adb.dart
@@ -103,6 +103,9 @@ class Adb {
           } else {
             List<AdbDevice> devices = devicesText.split('\n').map((String deviceInfo) {
               return new AdbDevice(deviceInfo);
+            }).where((AdbDevice device) {
+              // Filter unauthorized devices - we can't connect to them.
+              return !device.isUnauthorized && !device.isOffline;
             }).toList();
 
             await _populateDeviceNames(devices);
@@ -194,6 +197,10 @@ class AdbDevice {
   final Map<String, String> _info = <String, String>{};
 
   bool get isAvailable => status == 'device';
+
+  bool get isUnauthorized => status == 'unauthorized';
+
+  bool get isOffline => status == 'offline';
 
   /// Device model; can be null. `XT1045`, `Nexus_7`
   String get modelID => _info['model'];


### PR DESCRIPTION
Don't report offline devices when notifying about found devices (ADB offline devices will be reported once they're back online).
