### PR TITLE
Add scroll anchor for Block

### DIFF
--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -65,6 +65,7 @@ export 'package:flutter/rendering.dart' show
     TextStyle,
     TransferMode,
     ValueChanged,
+    ViewportAnchor,
     VoidCallback;
 
 
@@ -796,14 +797,20 @@ class Baseline extends OneChildRenderObjectWidget {
 class Viewport extends OneChildRenderObjectWidget {
   Viewport({
     Key key,
-    this.scrollDirection: Axis.vertical,
     this.paintOffset: Offset.zero,
+    this.scrollDirection: Axis.vertical,
+    this.scrollAnchor: ViewportAnchor.start,
     this.overlayPainter,
     Widget child
   }) : super(key: key, child: child) {
     assert(scrollDirection != null);
     assert(paintOffset != null);
   }
+
+  /// The offset at which to paint the child.
+  ///
+  /// The offset can be non-zero only in the [scrollDirection].
+  final Offset paintOffset;
 
   /// The direction in which the child is permitted to be larger than the viewport
   ///
@@ -812,26 +819,27 @@ class Viewport extends OneChildRenderObjectWidget {
   /// that direction (e.g., the child can be as tall as it wants).
   final Axis scrollDirection;
 
-  /// The offset at which to paint the child.
-  ///
-  /// The offset can be non-zero only in the [scrollDirection].
-  final Offset paintOffset;
+  final ViewportAnchor scrollAnchor;
 
   /// Paints an overlay over the viewport.
   ///
   /// Often used to paint scroll bars.
   final Painter overlayPainter;
 
-  RenderViewport createRenderObject() => new RenderViewport(
-    scrollDirection: scrollDirection,
-    paintOffset: paintOffset,
-    overlayPainter: overlayPainter
-  );
+  RenderViewport createRenderObject() {
+    return new RenderViewport(
+      paintOffset: paintOffset,
+      scrollDirection: scrollDirection,
+      scrollAnchor: scrollAnchor,
+      overlayPainter: overlayPainter
+    );
+  }
 
   void updateRenderObject(RenderViewport renderObject, Viewport oldWidget) {
     // Order dependency: RenderViewport validates scrollOffset based on scrollDirection.
     renderObject
       ..scrollDirection = scrollDirection
+      ..scrollAnchor = scrollAnchor
       ..paintOffset = paintOffset
       ..overlayPainter = overlayPainter;
   }

--- a/packages/flutter/lib/src/widgets/scrollable.dart
+++ b/packages/flutter/lib/src/widgets/scrollable.dart
@@ -520,8 +520,9 @@ class _ScrollableViewportState extends ScrollableState<ScrollableViewport> {
     return new SizeObserver(
       onSizeChanged: _handleViewportSizeChanged,
       child: new Viewport(
-        scrollDirection: config.scrollDirection,
         paintOffset: scrollOffsetToPixelDelta(scrollOffset),
+        scrollDirection: config.scrollDirection,
+        scrollAnchor: config.scrollAnchor,
         child: new SizeObserver(
           onSizeChanged: _handleChildSizeChanged,
           child: config.child
@@ -541,6 +542,7 @@ class Block extends StatelessComponent {
     this.padding,
     this.initialScrollOffset,
     this.scrollDirection: Axis.vertical,
+    this.scrollAnchor: ViewportAnchor.start,
     this.onScroll,
     this.scrollableKey
   }) : super(key: key) {
@@ -552,6 +554,7 @@ class Block extends StatelessComponent {
   final EdgeDims padding;
   final double initialScrollOffset;
   final Axis scrollDirection;
+  final ViewportAnchor scrollAnchor;
   final ScrollListener onScroll;
   final Key scrollableKey;
 
@@ -563,6 +566,7 @@ class Block extends StatelessComponent {
       key: scrollableKey,
       initialScrollOffset: initialScrollOffset,
       scrollDirection: scrollDirection,
+      scrollAnchor: scrollAnchor,
       onScroll: onScroll,
       child: contents
     );

--- a/packages/flutter/test/widget/block_test.dart
+++ b/packages/flutter/test/widget/block_test.dart
@@ -66,4 +66,53 @@ void main() {
       tester.dispatchEvent(pointer.up(), target);
     });
   });
+
+  test('Scroll anchor', () {
+    testWidgets((WidgetTester tester) {
+      int first = 0;
+      int second = 0;
+
+      Widget buildBlock(ViewportAnchor scrollAnchor) {
+        return new Block(
+          key: new UniqueKey(),
+          scrollAnchor: scrollAnchor,
+          children: <Widget>[
+            new GestureDetector(
+              onTap: () { ++first; },
+              child: new Container(
+                height: 2000.0, // more than 600, the height of the test area
+                decoration: new BoxDecoration(
+                  backgroundColor: new Color(0xFF00FF00)
+                )
+              )
+            ),
+            new GestureDetector(
+              onTap: () { ++second; },
+              child: new Container(
+                height: 2000.0, // more than 600, the height of the test area
+                decoration: new BoxDecoration(
+                  backgroundColor: new Color(0xFF0000FF)
+                )
+              )
+            )
+          ]
+        );
+      }
+
+      tester.pumpWidget(buildBlock(ViewportAnchor.end));
+      tester.pump(); // for SizeObservers
+
+      Point target = const Point(200.0, 200.0);
+      tester.tapAt(target);
+      expect(first, equals(0));
+      expect(second, equals(1));
+
+      tester.pumpWidget(buildBlock(ViewportAnchor.start));
+      tester.pump(); // for SizeObservers
+
+      tester.tapAt(target);
+      expect(first, equals(1));
+      expect(second, equals(1));
+    });
+  });
 }


### PR DESCRIPTION
This patch teaches block how to anchor its scrolling to the end rather than the
start.

Fixes #136
