### PR TITLE
Tapping through drag targets.

### DIFF
--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -2193,20 +2193,31 @@ class ExcludeSemantics extends OneChildRenderObjectWidget {
 }
 
 class MetaData extends OneChildRenderObjectWidget {
-  MetaData({ Key key, Widget child, this.metaData })
-    : super(key: key, child: child);
+  MetaData({
+    Key key,
+    Widget child,
+    this.metaData,
+    this.behavior: HitTestBehavior.deferToChild
+  }) : super(key: key, child: child);
 
   final dynamic metaData;
+  final HitTestBehavior behavior;
 
-  RenderMetaData createRenderObject() => new RenderMetaData(metaData: metaData);
+  RenderMetaData createRenderObject() => new RenderMetaData(
+    metaData: metaData,
+    behavior: behavior
+  );
 
   void updateRenderObject(RenderMetaData renderObject, MetaData oldWidget) {
-    renderObject.metaData = metaData;
+    renderObject
+      ..metaData = metaData
+      ..behavior = behavior;
   }
 
   void debugFillDescription(List<String> description) {
     super.debugFillDescription(description);
-    description.add('$metaData');
+    description.add('behavior: $behavior');
+    description.add('metaData: $metaData');
   }
 }
 

--- a/packages/flutter/lib/src/widgets/drag_target.dart
+++ b/packages/flutter/lib/src/widgets/drag_target.dart
@@ -288,6 +288,7 @@ class _DragTargetState<T> extends State<DragTarget<T>> {
   Widget build(BuildContext context) {
     return new MetaData(
       metaData: this,
+      behavior: HitTestBehavior.translucent,
       child: config.builder(context,
                             new UnmodifiableListView<T>(_candidateData),
                             new UnmodifiableListView<dynamic>(_rejectedData)


### PR DESCRIPTION
Factor out the HitTestBehavior logic so that RenderMetaData can use it.

Use that in DragTarget.
