### PR TITLE
fix an issue with logging ios simulator output

### DIFF
--- a/packages/flutter_tools/lib/src/commands/logs.dart
+++ b/packages/flutter_tools/lib/src/commands/logs.dart
@@ -50,7 +50,7 @@ class LogsCommand extends FlutterCommand {
       readers.add(device.createLogReader());
     }
 
-    printStatus('Logging for ${readers.join(', ')}...');
+    printStatus('Showing logs for ${readers.join(', ')}:');
 
     List<int> results = await Future.wait(readers.map((DeviceLogReader reader) async {
       int result = await reader.logs(clear: clear);


### PR DESCRIPTION
Fix the last bit of https://github.com/flutter/flutter/issues/1652; in atom you'd see:

```
Logging for iPhone 6s...
Error listening to iPhone 6s logs.
```

when running against the ios simulator. This makes our log clearing logic a little more friendly to the simulator.
