### PR TITLE
Improve asserts around BoxConstraints

### DIFF
--- a/examples/rendering/lib/sector_layout.dart
+++ b/examples/rendering/lib/sector_layout.dart
@@ -39,6 +39,10 @@ class SectorConstraints extends Constraints {
   bool get isTight => minDeltaTheta >= maxDeltaTheta && minDeltaTheta >= maxDeltaTheta;
 
   bool get isNormalized => minDeltaRadius <= maxDeltaRadius && minDeltaTheta <= maxDeltaTheta;
+  bool get debugAssertIsNormalized {
+    assert(isNormalized);
+    return isNormalized;
+  }
 }
 
 class SectorDimensions {

--- a/packages/flutter/lib/src/rendering/box.dart
+++ b/packages/flutter/lib/src/rendering/box.dart
@@ -272,12 +272,21 @@ class BoxConstraints extends Constraints {
   /// normalized and have undefined behavior when they are not. In
   /// checked mode, many of these APIs will assert if the constraints
   /// are not normalized.
-  bool get isNormalized => minWidth <= maxWidth && minHeight <= maxHeight;
+  bool get isNormalized {
+    return minWidth >= 0.0 &&
+           minWidth <= maxWidth &&
+           minHeight >= 0.0 &&
+           minHeight <= maxHeight;
+  }
 
-  /// Same as [isNormalized] but, in checked mode, throws an exception
-  /// if isNormalized is false.
   bool get debugAssertIsNormalized {
     assert(() {
+      if (minWidth < 0.0 && minHeight < 0.0)
+        throw new RenderingError('BoxConstraints has both a negative minimum width and a negative minimum height.\n$this');
+      if (minWidth < 0.0)
+        throw new RenderingError('BoxConstraints has a negative minimum width.\n$this');
+      if (minHeight < 0.0)
+        throw new RenderingError('BoxConstraints has a negative minimum height.\n$this');
       if (maxWidth < minWidth && maxHeight < minHeight)
         throw new RenderingError('BoxConstraints has both width and height constraints non-normalized.\n$this');
       if (maxWidth < minWidth)

--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -353,6 +353,10 @@ abstract class Constraints {
 
   /// Whether the constraint is expressed in a consistent manner.
   bool get isNormalized;
+
+  /// Same as [isNormalized] but, in checked mode, throws an exception
+  /// if isNormalized is false.
+  bool get debugAssertIsNormalized;
 }
 
 typedef void RenderObjectVisitor(RenderObject child);
@@ -975,7 +979,7 @@ abstract class RenderObject extends AbstractNode implements HitTestTarget {
   /// implemented here) to return early if the child does not need to do any
   /// work to update its layout information.
   void layout(Constraints constraints, { bool parentUsesSize: false }) {
-    assert(constraints.isNormalized);
+    assert(constraints.debugAssertIsNormalized);
     assert(!_debugDoingThisResize);
     assert(!_debugDoingThisLayout);
     final RenderObject parent = this.parent;


### PR DESCRIPTION
Negative constraints never make sense, so catch those too.

Make RenderObject.layout's isNormalized assert use the newer more fancy
debug version of isNormalized.
