### PR TITLE
More BoxConstraints asserts

### DIFF
--- a/packages/flutter/lib/src/rendering/block.dart
+++ b/packages/flutter/lib/src/rendering/block.dart
@@ -164,7 +164,7 @@ class RenderBlock extends RenderBlockBase {
   }
 
   double getMinIntrinsicWidth(BoxConstraints constraints) {
-    assert(constraints.isNormalized);
+    assert(constraints.debugAssertIsNormalized);
     if (isVertical) {
       return _getIntrinsicCrossAxis(
         constraints,
@@ -176,7 +176,7 @@ class RenderBlock extends RenderBlockBase {
   }
 
   double getMaxIntrinsicWidth(BoxConstraints constraints) {
-    assert(constraints.isNormalized);
+    assert(constraints.debugAssertIsNormalized);
     if (isVertical) {
       return _getIntrinsicCrossAxis(
         constraints,
@@ -188,7 +188,7 @@ class RenderBlock extends RenderBlockBase {
   }
 
   double getMinIntrinsicHeight(BoxConstraints constraints) {
-    assert(constraints.isNormalized);
+    assert(constraints.debugAssertIsNormalized);
     if (isVertical)
       return _getIntrinsicMainAxis(constraints, constraints.constrainHeight);
     return _getIntrinsicCrossAxis(
@@ -199,7 +199,7 @@ class RenderBlock extends RenderBlockBase {
   }
 
   double getMaxIntrinsicHeight(BoxConstraints constraints) {
-    assert(constraints.isNormalized);
+    assert(constraints.debugAssertIsNormalized);
     if (isVertical)
       return _getIntrinsicMainAxis(constraints, constraints.constrainHeight);
     return _getIntrinsicCrossAxis(
@@ -367,28 +367,28 @@ class RenderBlockViewport extends RenderBlockBase {
   }
 
   double getMinIntrinsicWidth(BoxConstraints constraints) {
-    assert(constraints.isNormalized);
+    assert(constraints.debugAssertIsNormalized);
     if (isVertical)
       return _getIntrinsicDimension(constraints, minCrossAxisExtentCallback, constraints.constrainWidth);
     return constraints.constrainWidth(minExtent);
   }
 
   double getMaxIntrinsicWidth(BoxConstraints constraints) {
-    assert(constraints.isNormalized);
+    assert(constraints.debugAssertIsNormalized);
     if (isVertical)
       return _getIntrinsicDimension(constraints, maxCrossAxisExtentCallback, constraints.constrainWidth);
     return _getIntrinsicDimension(constraints, totalExtentCallback, new BoxConstraints(minWidth: minExtent).enforce(constraints).constrainWidth);
   }
 
   double getMinIntrinsicHeight(BoxConstraints constraints) {
-    assert(constraints.isNormalized);
+    assert(constraints.debugAssertIsNormalized);
     if (!isVertical)
       return _getIntrinsicDimension(constraints, minCrossAxisExtentCallback, constraints.constrainHeight);
     return constraints.constrainHeight(0.0);
   }
 
   double getMaxIntrinsicHeight(BoxConstraints constraints) {
-    assert(constraints.isNormalized);
+    assert(constraints.debugAssertIsNormalized);
     if (!isVertical)
       return _getIntrinsicDimension(constraints, maxCrossAxisExtentCallback, constraints.constrainHeight);
     return _getIntrinsicDimension(constraints, totalExtentCallback, new BoxConstraints(minHeight: minExtent).enforce(constraints).constrainHeight);

--- a/packages/flutter/lib/src/rendering/box.dart
+++ b/packages/flutter/lib/src/rendering/box.dart
@@ -95,6 +95,21 @@ class BoxConstraints extends Constraints {
       minHeight = height != null ? height : double.INFINITY,
       maxHeight = height != null ? height : double.INFINITY;
 
+  /// Returns new box constraints that remove the minimum width and height requirements.
+  BoxConstraints copyWith({
+    double minWidth,
+    double maxWidth,
+    double minHeight,
+    double maxHeight
+  }) {
+    return new BoxConstraints(
+      minWidth: minWidth ?? this.minWidth,
+      maxWidth: maxWidth ?? this.maxWidth,
+      minHeight: minHeight ?? this.minHeight,
+      maxHeight: maxHeight ?? this.maxHeight
+    );
+  }
+
   /// Returns new box constraints that are smaller by the given edge dimensions.
   BoxConstraints deflate(EdgeDims edges) {
     assert(edges != null);

--- a/packages/flutter/lib/src/rendering/editable_line.dart
+++ b/packages/flutter/lib/src/rendering/editable_line.dart
@@ -132,22 +132,22 @@ class RenderEditableLine extends RenderBox {
   }
 
   double getMinIntrinsicWidth(BoxConstraints constraints) {
-    assert(constraints.isNormalized);
+    assert(constraints.debugAssertIsNormalized);
     return constraints.constrainWidth(0.0);
   }
 
   double getMaxIntrinsicWidth(BoxConstraints constraints) {
-    assert(constraints.isNormalized);
+    assert(constraints.debugAssertIsNormalized);
     return constraints.constrainWidth(0.0);
   }
 
   double getMinIntrinsicHeight(BoxConstraints constraints) {
-    assert(constraints.isNormalized);
+    assert(constraints.debugAssertIsNormalized);
     return constraints.constrainHeight(_preferredHeight);
   }
 
   double getMaxIntrinsicHeight(BoxConstraints constraints) {
-    assert(constraints.isNormalized);
+    assert(constraints.debugAssertIsNormalized);
     return constraints.constrainHeight(_preferredHeight);
   }
 
@@ -183,7 +183,7 @@ class RenderEditableLine extends RenderBox {
   // TODO(abarth): This logic should live in TextPainter and be shared with RenderParagraph.
   void _layoutText(BoxConstraints constraints) {
     assert(constraints != null);
-    assert(constraints.isNormalized);
+    assert(constraints.debugAssertIsNormalized);
     if (_constraintsForCurrentLayout == constraints)
       return; // already cached this layout
     _textPainter.maxWidth = constraints.maxWidth;

--- a/packages/flutter/lib/src/rendering/flex.dart
+++ b/packages/flutter/lib/src/rendering/flex.dart
@@ -142,7 +142,7 @@ class RenderFlex extends RenderBox with ContainerRenderObjectMixin<RenderBox, Fl
   double _getIntrinsicSize({ BoxConstraints constraints,
                              FlexDirection sizingDirection,
                              _ChildSizingFunction childSize }) {
-    assert(constraints.isNormalized);
+    assert(constraints.debugAssertIsNormalized);
     // http://www.w3.org/TR/2015/WD-css-flexbox-1-20150514/#intrinsic-sizes
     if (_direction == sizingDirection) {
       // INTRINSIC MAIN SIZE

--- a/packages/flutter/lib/src/rendering/grid.dart
+++ b/packages/flutter/lib/src/rendering/grid.dart
@@ -371,22 +371,22 @@ class RenderGrid extends RenderVirtualViewport<GridParentData> {
   }
 
   double getMinIntrinsicWidth(BoxConstraints constraints) {
-    assert(constraints.isNormalized);
+    assert(constraints.debugAssertIsNormalized);
     return _delegate.getMinIntrinsicWidth(constraints, virtualChildCount);
   }
 
   double getMaxIntrinsicWidth(BoxConstraints constraints) {
-    assert(constraints.isNormalized);
+    assert(constraints.debugAssertIsNormalized);
     return _delegate.getMaxIntrinsicWidth(constraints, virtualChildCount);
   }
 
   double getMinIntrinsicHeight(BoxConstraints constraints) {
-    assert(constraints.isNormalized);
+    assert(constraints.debugAssertIsNormalized);
     return _delegate.getMinIntrinsicHeight(constraints, virtualChildCount);
   }
 
   double getMaxIntrinsicHeight(BoxConstraints constraints) {
-    assert(constraints.isNormalized);
+    assert(constraints.debugAssertIsNormalized);
     return _delegate.getMaxIntrinsicHeight(constraints, virtualChildCount);
   }
 

--- a/packages/flutter/lib/src/rendering/image.dart
+++ b/packages/flutter/lib/src/rendering/image.dart
@@ -206,26 +206,26 @@ class RenderImage extends RenderBox {
   }
 
   double getMinIntrinsicWidth(BoxConstraints constraints) {
-    assert(constraints.isNormalized);
+    assert(constraints.debugAssertIsNormalized);
     if (_width == null && _height == null)
       return constraints.constrainWidth(0.0);
     return _sizeForConstraints(constraints).width;
   }
 
   double getMaxIntrinsicWidth(BoxConstraints constraints) {
-    assert(constraints.isNormalized);
+    assert(constraints.debugAssertIsNormalized);
     return _sizeForConstraints(constraints).width;
   }
 
   double getMinIntrinsicHeight(BoxConstraints constraints) {
-    assert(constraints.isNormalized);
+    assert(constraints.debugAssertIsNormalized);
     if (_width == null && _height == null)
       return constraints.constrainHeight(0.0);
     return _sizeForConstraints(constraints).height;
   }
 
   double getMaxIntrinsicHeight(BoxConstraints constraints) {
-    assert(constraints.isNormalized);
+    assert(constraints.debugAssertIsNormalized);
     return _sizeForConstraints(constraints).height;
   }
 

--- a/packages/flutter/lib/src/rendering/list.dart
+++ b/packages/flutter/lib/src/rendering/list.dart
@@ -79,7 +79,7 @@ class RenderList extends RenderVirtualViewport<ListParentData> {
   }
 
   double _getIntrinsicWidth(BoxConstraints constraints) {
-    assert(constraints.isNormalized);
+    assert(constraints.debugAssertIsNormalized);
     switch (scrollDirection) {
       case Axis.vertical:
         return constraints.constrainWidth(0.0);
@@ -97,7 +97,7 @@ class RenderList extends RenderVirtualViewport<ListParentData> {
   }
 
   double _getIntrinsicHeight(BoxConstraints constraints) {
-    assert(constraints.isNormalized);
+    assert(constraints.debugAssertIsNormalized);
     switch (scrollDirection) {
       case Axis.vertical:
         return constraints.constrainHeight(_preferredExtent);

--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -740,8 +740,8 @@ abstract class RenderObject extends AbstractNode implements HitTestTarget {
           List<String> descendants = <String>[];
           const int maxDepth = 5;
           void visitor(RenderObject child) {
-            descendants.add('${"  " * depth}$child');
             depth += 1;
+            descendants.add('${"  " * depth}$child');
             if (depth < maxDepth)
               child.visitChildren(visitor);
             depth -= 1;

--- a/packages/flutter/lib/src/rendering/overflow.dart
+++ b/packages/flutter/lib/src/rendering/overflow.dart
@@ -29,22 +29,22 @@ class RenderSizedOverflowBox extends RenderBox with RenderObjectWithChildMixin<R
   }
 
   double getMinIntrinsicWidth(BoxConstraints constraints) {
-    assert(constraints.isNormalized);
+    assert(constraints.debugAssertIsNormalized);
     return constraints.constrainWidth(_requestedSize.width);
   }
 
   double getMaxIntrinsicWidth(BoxConstraints constraints) {
-    assert(constraints.isNormalized);
+    assert(constraints.debugAssertIsNormalized);
     return constraints.constrainWidth(_requestedSize.width);
   }
 
   double getMinIntrinsicHeight(BoxConstraints constraints) {
-    assert(constraints.isNormalized);
+    assert(constraints.debugAssertIsNormalized);
     return constraints.constrainHeight(_requestedSize.height);
   }
 
   double getMaxIntrinsicHeight(BoxConstraints constraints) {
-    assert(constraints.isNormalized);
+    assert(constraints.debugAssertIsNormalized);
     return constraints.constrainHeight(_requestedSize.height);
   }
 

--- a/packages/flutter/lib/src/rendering/paragraph.dart
+++ b/packages/flutter/lib/src/rendering/paragraph.dart
@@ -46,7 +46,7 @@ class RenderParagraph extends RenderBox {
   // TODO(abarth): This logic should live in TextPainter and be shared with RenderEditableLine.
   void _layoutText(BoxConstraints constraints) {
     assert(constraints != null);
-    assert(constraints.isNormalized);
+    assert(constraints.debugAssertIsNormalized);
     if (_constraintsForCurrentLayout == constraints)
       return; // already cached this layout
     _textPainter.maxWidth = constraints.maxWidth;
@@ -78,12 +78,12 @@ class RenderParagraph extends RenderBox {
   }
 
   double getMinIntrinsicHeight(BoxConstraints constraints) {
-    assert(constraints.isNormalized);
+    assert(constraints.debugAssertIsNormalized);
     return _getIntrinsicHeight(constraints);
   }
 
   double getMaxIntrinsicHeight(BoxConstraints constraints) {
-    assert(constraints.isNormalized);
+    assert(constraints.debugAssertIsNormalized);
     return _getIntrinsicHeight(constraints);
   }
 

--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -39,28 +39,28 @@ class RenderProxyBox extends RenderBox with RenderObjectWithChildMixin<RenderBox
   }
 
   double getMinIntrinsicWidth(BoxConstraints constraints) {
-    assert(constraints.isNormalized);
+    assert(constraints.debugAssertIsNormalized);
     if (child != null)
       return child.getMinIntrinsicWidth(constraints);
     return super.getMinIntrinsicWidth(constraints);
   }
 
   double getMaxIntrinsicWidth(BoxConstraints constraints) {
-    assert(constraints.isNormalized);
+    assert(constraints.debugAssertIsNormalized);
     if (child != null)
       return child.getMaxIntrinsicWidth(constraints);
     return super.getMaxIntrinsicWidth(constraints);
   }
 
   double getMinIntrinsicHeight(BoxConstraints constraints) {
-    assert(constraints.isNormalized);
+    assert(constraints.debugAssertIsNormalized);
     if (child != null)
       return child.getMinIntrinsicHeight(constraints);
     return super.getMinIntrinsicHeight(constraints);
   }
 
   double getMaxIntrinsicHeight(BoxConstraints constraints) {
-    assert(constraints.isNormalized);
+    assert(constraints.debugAssertIsNormalized);
     if (child != null)
       return child.getMaxIntrinsicHeight(constraints);
     return super.getMaxIntrinsicHeight(constraints);
@@ -162,7 +162,7 @@ class RenderConstrainedBox extends RenderProxyBox {
     BoxConstraints additionalConstraints
   }) : _additionalConstraints = additionalConstraints, super(child) {
     assert(additionalConstraints != null);
-    assert(additionalConstraints.isNormalized);
+    assert(additionalConstraints.debugAssertIsNormalized);
   }
 
   /// Additional constraints to apply to [child] during layout
@@ -170,7 +170,7 @@ class RenderConstrainedBox extends RenderProxyBox {
   BoxConstraints _additionalConstraints;
   void set additionalConstraints (BoxConstraints newConstraints) {
     assert(newConstraints != null);
-    assert(newConstraints.isNormalized);
+    assert(newConstraints.debugAssertIsNormalized);
     if (_additionalConstraints == newConstraints)
       return;
     _additionalConstraints = newConstraints;
@@ -178,28 +178,28 @@ class RenderConstrainedBox extends RenderProxyBox {
   }
 
   double getMinIntrinsicWidth(BoxConstraints constraints) {
-    assert(constraints.isNormalized);
+    assert(constraints.debugAssertIsNormalized);
     if (child != null)
       return child.getMinIntrinsicWidth(_additionalConstraints.enforce(constraints));
     return _additionalConstraints.enforce(constraints).constrainWidth(0.0);
   }
 
   double getMaxIntrinsicWidth(BoxConstraints constraints) {
-    assert(constraints.isNormalized);
+    assert(constraints.debugAssertIsNormalized);
     if (child != null)
       return child.getMaxIntrinsicWidth(_additionalConstraints.enforce(constraints));
     return _additionalConstraints.enforce(constraints).constrainWidth(0.0);
   }
 
   double getMinIntrinsicHeight(BoxConstraints constraints) {
-    assert(constraints.isNormalized);
+    assert(constraints.debugAssertIsNormalized);
     if (child != null)
       return child.getMinIntrinsicHeight(_additionalConstraints.enforce(constraints));
     return _additionalConstraints.enforce(constraints).constrainHeight(0.0);
   }
 
   double getMaxIntrinsicHeight(BoxConstraints constraints) {
-    assert(constraints.isNormalized);
+    assert(constraints.debugAssertIsNormalized);
     if (child != null)
       return child.getMaxIntrinsicHeight(_additionalConstraints.enforce(constraints));
     return _additionalConstraints.enforce(constraints).constrainHeight(0.0);
@@ -306,28 +306,28 @@ class RenderFractionallySizedBox extends RenderProxyBox {
   }
 
   double getMinIntrinsicWidth(BoxConstraints constraints) {
-    assert(constraints.isNormalized);
+    assert(constraints.debugAssertIsNormalized);
     if (child != null)
       return child.getMinIntrinsicWidth(_getInnerConstraints(constraints));
     return _getInnerConstraints(constraints).constrainWidth(0.0);
   }
 
   double getMaxIntrinsicWidth(BoxConstraints constraints) {
-    assert(constraints.isNormalized);
+    assert(constraints.debugAssertIsNormalized);
     if (child != null)
       return child.getMaxIntrinsicWidth(_getInnerConstraints(constraints));
     return _getInnerConstraints(constraints).constrainWidth(0.0);
   }
 
   double getMinIntrinsicHeight(BoxConstraints constraints) {
-    assert(constraints.isNormalized);
+    assert(constraints.debugAssertIsNormalized);
     if (child != null)
       return child.getMinIntrinsicHeight(_getInnerConstraints(constraints));
     return _getInnerConstraints(constraints).constrainHeight(0.0);
   }
 
   double getMaxIntrinsicHeight(BoxConstraints constraints) {
-    assert(constraints.isNormalized);
+    assert(constraints.debugAssertIsNormalized);
     if (child != null)
       return child.getMaxIntrinsicHeight(_getInnerConstraints(constraints));
     return _getInnerConstraints(constraints).constrainHeight(0.0);
@@ -396,7 +396,7 @@ class RenderAspectRatio extends RenderProxyBox {
   }
 
   Size _applyAspectRatio(BoxConstraints constraints) {
-    assert(constraints.isNormalized);
+    assert(constraints.debugAssertIsNormalized);
     double width = constraints.constrainWidth();
     double height = constraints.constrainHeight(width / _aspectRatio);
     return new Size(width, height);
@@ -475,12 +475,12 @@ class RenderIntrinsicWidth extends RenderProxyBox {
   }
 
   double getMinIntrinsicWidth(BoxConstraints constraints) {
-    assert(constraints.isNormalized);
+    assert(constraints.debugAssertIsNormalized);
     return getMaxIntrinsicWidth(constraints);
   }
 
   double getMaxIntrinsicWidth(BoxConstraints constraints) {
-    assert(constraints.isNormalized);
+    assert(constraints.debugAssertIsNormalized);
     if (child == null)
       return constraints.constrainWidth(0.0);
     double childResult = child.getMaxIntrinsicWidth(constraints);
@@ -488,7 +488,7 @@ class RenderIntrinsicWidth extends RenderProxyBox {
   }
 
   double getMinIntrinsicHeight(BoxConstraints constraints) {
-    assert(constraints.isNormalized);
+    assert(constraints.debugAssertIsNormalized);
     if (child == null)
       return constraints.constrainHeight(0.0);
     double childResult = child.getMinIntrinsicHeight(_getInnerConstraints(constraints));
@@ -496,7 +496,7 @@ class RenderIntrinsicWidth extends RenderProxyBox {
   }
 
   double getMaxIntrinsicHeight(BoxConstraints constraints) {
-    assert(constraints.isNormalized);
+    assert(constraints.debugAssertIsNormalized);
     if (child == null)
       return constraints.constrainHeight(0.0);
     double childResult = child.getMaxIntrinsicHeight(_getInnerConstraints(constraints));
@@ -545,26 +545,26 @@ class RenderIntrinsicHeight extends RenderProxyBox {
   }
 
   double getMinIntrinsicWidth(BoxConstraints constraints) {
-    assert(constraints.isNormalized);
+    assert(constraints.debugAssertIsNormalized);
     if (child == null)
       return constraints.constrainWidth(0.0);
     return child.getMinIntrinsicWidth(_getInnerConstraints(constraints));
   }
 
   double getMaxIntrinsicWidth(BoxConstraints constraints) {
-    assert(constraints.isNormalized);
+    assert(constraints.debugAssertIsNormalized);
     if (child == null)
       return constraints.constrainWidth(0.0);
     return child.getMaxIntrinsicWidth(_getInnerConstraints(constraints));
   }
 
   double getMinIntrinsicHeight(BoxConstraints constraints) {
-    assert(constraints.isNormalized);
+    assert(constraints.debugAssertIsNormalized);
     return getMaxIntrinsicHeight(constraints);
   }
 
   double getMaxIntrinsicHeight(BoxConstraints constraints) {
-    assert(constraints.isNormalized);
+    assert(constraints.debugAssertIsNormalized);
     if (child == null)
       return constraints.constrainHeight(0.0);
     return child.getMaxIntrinsicHeight(constraints);

--- a/packages/flutter/lib/src/rendering/shifted_box.dart
+++ b/packages/flutter/lib/src/rendering/shifted_box.dart
@@ -19,28 +19,28 @@ abstract class RenderShiftedBox extends RenderBox with RenderObjectWithChildMixi
   }
 
   double getMinIntrinsicWidth(BoxConstraints constraints) {
-    assert(constraints.isNormalized);
+    assert(constraints.debugAssertIsNormalized);
     if (child != null)
       return child.getMinIntrinsicWidth(constraints);
     return super.getMinIntrinsicWidth(constraints);
   }
 
   double getMaxIntrinsicWidth(BoxConstraints constraints) {
-    assert(constraints.isNormalized);
+    assert(constraints.debugAssertIsNormalized);
     if (child != null)
       return child.getMaxIntrinsicWidth(constraints);
     return super.getMaxIntrinsicWidth(constraints);
   }
 
   double getMinIntrinsicHeight(BoxConstraints constraints) {
-    assert(constraints.isNormalized);
+    assert(constraints.debugAssertIsNormalized);
     if (child != null)
       return child.getMinIntrinsicHeight(constraints);
     return super.getMinIntrinsicHeight(constraints);
   }
 
   double getMaxIntrinsicHeight(BoxConstraints constraints) {
-    assert(constraints.isNormalized);
+    assert(constraints.debugAssertIsNormalized);
     if (child != null)
       return child.getMaxIntrinsicHeight(constraints);
     return super.getMaxIntrinsicHeight(constraints);
@@ -107,7 +107,7 @@ class RenderPadding extends RenderShiftedBox {
   }
 
   double getMinIntrinsicWidth(BoxConstraints constraints) {
-    assert(constraints.isNormalized);
+    assert(constraints.debugAssertIsNormalized);
     double totalPadding = padding.left + padding.right;
     if (child != null)
       return constraints.constrainWidth(child.getMinIntrinsicWidth(constraints.deflate(padding)) + totalPadding);
@@ -115,7 +115,7 @@ class RenderPadding extends RenderShiftedBox {
   }
 
   double getMaxIntrinsicWidth(BoxConstraints constraints) {
-    assert(constraints.isNormalized);
+    assert(constraints.debugAssertIsNormalized);
     double totalPadding = padding.left + padding.right;
     if (child != null)
       return constraints.constrainWidth(child.getMaxIntrinsicWidth(constraints.deflate(padding)) + totalPadding);
@@ -123,7 +123,7 @@ class RenderPadding extends RenderShiftedBox {
   }
 
   double getMinIntrinsicHeight(BoxConstraints constraints) {
-    assert(constraints.isNormalized);
+    assert(constraints.debugAssertIsNormalized);
     double totalPadding = padding.top + padding.bottom;
     if (child != null)
       return constraints.constrainHeight(child.getMinIntrinsicHeight(constraints.deflate(padding)) + totalPadding);
@@ -131,7 +131,7 @@ class RenderPadding extends RenderShiftedBox {
   }
 
   double getMaxIntrinsicHeight(BoxConstraints constraints) {
-    assert(constraints.isNormalized);
+    assert(constraints.debugAssertIsNormalized);
     double totalPadding = padding.top + padding.bottom;
     if (child != null)
       return constraints.constrainHeight(child.getMaxIntrinsicHeight(constraints.deflate(padding)) + totalPadding);
@@ -465,22 +465,22 @@ class RenderOverflowBox extends RenderShiftedBox {
   }
 
   double getMinIntrinsicWidth(BoxConstraints constraints) {
-    assert(constraints.isNormalized);
+    assert(constraints.debugAssertIsNormalized);
     return constraints.minWidth;
   }
 
   double getMaxIntrinsicWidth(BoxConstraints constraints) {
-    assert(constraints.isNormalized);
+    assert(constraints.debugAssertIsNormalized);
     return constraints.minWidth;
   }
 
   double getMinIntrinsicHeight(BoxConstraints constraints) {
-    assert(constraints.isNormalized);
+    assert(constraints.debugAssertIsNormalized);
     return constraints.minHeight;
   }
 
   double getMaxIntrinsicHeight(BoxConstraints constraints) {
-    assert(constraints.isNormalized);
+    assert(constraints.debugAssertIsNormalized);
     return constraints.minHeight;
   }
 
@@ -554,22 +554,22 @@ class RenderCustomOneChildLayoutBox extends RenderShiftedBox {
   }
 
   double getMinIntrinsicWidth(BoxConstraints constraints) {
-    assert(constraints.isNormalized);
+    assert(constraints.debugAssertIsNormalized);
     return _getSize(constraints).width;
   }
 
   double getMaxIntrinsicWidth(BoxConstraints constraints) {
-    assert(constraints.isNormalized);
+    assert(constraints.debugAssertIsNormalized);
     return _getSize(constraints).width;
   }
 
   double getMinIntrinsicHeight(BoxConstraints constraints) {
-    assert(constraints.isNormalized);
+    assert(constraints.debugAssertIsNormalized);
     return _getSize(constraints).height;
   }
 
   double getMaxIntrinsicHeight(BoxConstraints constraints) {
-    assert(constraints.isNormalized);
+    assert(constraints.debugAssertIsNormalized);
     return _getSize(constraints).height;
   }
 
@@ -582,7 +582,7 @@ class RenderCustomOneChildLayoutBox extends RenderShiftedBox {
   void performLayout() {
     if (child != null) {
       BoxConstraints childConstraints = delegate.getConstraintsForChild(constraints);
-      assert(childConstraints.isNormalized);
+      assert(childConstraints.debugAssertIsNormalized);
       child.layout(childConstraints, parentUsesSize: !childConstraints.isTight);
       final BoxParentData childParentData = child.parentData;
       childParentData.offset = delegate.getPositionForChild(size, childConstraints.isTight ? childConstraints.smallest : child.size);

--- a/packages/flutter/lib/src/rendering/stack.dart
+++ b/packages/flutter/lib/src/rendering/stack.dart
@@ -220,7 +220,7 @@ abstract class RenderStackBase extends RenderBox
   }
 
   double getMinIntrinsicWidth(BoxConstraints constraints) {
-    assert(constraints.isNormalized);
+    assert(constraints.debugAssertIsNormalized);
     double width = constraints.minWidth;
     RenderBox child = firstChild;
     while (child != null) {
@@ -235,7 +235,7 @@ abstract class RenderStackBase extends RenderBox
   }
 
   double getMaxIntrinsicWidth(BoxConstraints constraints) {
-    assert(constraints.isNormalized);
+    assert(constraints.debugAssertIsNormalized);
     bool hasNonPositionedChildren = false;
     double width = constraints.minWidth;
     RenderBox child = firstChild;
@@ -255,7 +255,7 @@ abstract class RenderStackBase extends RenderBox
   }
 
   double getMinIntrinsicHeight(BoxConstraints constraints) {
-    assert(constraints.isNormalized);
+    assert(constraints.debugAssertIsNormalized);
     double height = constraints.minHeight;
     RenderBox child = firstChild;
     while (child != null) {
@@ -270,7 +270,7 @@ abstract class RenderStackBase extends RenderBox
   }
 
   double getMaxIntrinsicHeight(BoxConstraints constraints) {
-    assert(constraints.isNormalized);
+    assert(constraints.debugAssertIsNormalized);
     bool hasNonPositionedChildren = false;
     double height = constraints.minHeight;
     RenderBox child = firstChild;

--- a/packages/flutter/lib/src/rendering/viewport.dart
+++ b/packages/flutter/lib/src/rendering/viewport.dart
@@ -195,28 +195,28 @@ class RenderViewport extends RenderViewportBase with RenderObjectWithChildMixin<
   }
 
   double getMinIntrinsicWidth(BoxConstraints constraints) {
-    assert(constraints.isNormalized);
+    assert(constraints.debugAssertIsNormalized);
     if (child != null)
       return constraints.constrainWidth(child.getMinIntrinsicWidth(_getInnerConstraints(constraints)));
     return super.getMinIntrinsicWidth(constraints);
   }
 
   double getMaxIntrinsicWidth(BoxConstraints constraints) {
-    assert(constraints.isNormalized);
+    assert(constraints.debugAssertIsNormalized);
     if (child != null)
       return constraints.constrainWidth(child.getMaxIntrinsicWidth(_getInnerConstraints(constraints)));
     return super.getMaxIntrinsicWidth(constraints);
   }
 
   double getMinIntrinsicHeight(BoxConstraints constraints) {
-    assert(constraints.isNormalized);
+    assert(constraints.debugAssertIsNormalized);
     if (child != null)
       return constraints.constrainHeight(child.getMinIntrinsicHeight(_getInnerConstraints(constraints)));
     return super.getMinIntrinsicHeight(constraints);
   }
 
   double getMaxIntrinsicHeight(BoxConstraints constraints) {
-    assert(constraints.isNormalized);
+    assert(constraints.debugAssertIsNormalized);
     if (child != null)
       return constraints.constrainHeight(child.getMaxIntrinsicHeight(_getInnerConstraints(constraints)));
     return super.getMaxIntrinsicHeight(constraints);


### PR DESCRIPTION
The asserting will continue until morale improves!
- Convert all assert(*.isNormalized) checks to use the new
  debugAssertIsNormalized technology.
- Convert CustomMultiChildLayout to use the new RenderingError
  technology to greatly improve the detail in errors you get when
  writing CustomMultiChildLayout delegates.
- Add BoxConstraints.copyWith().
- Indent the descendants in the rendering exception data dump so that
  when you have multiple children it's clearer what's going on.
