### PR TITLE
wait for flutter start to return until the obs. port is available

### DIFF
--- a/packages/flutter_tools/lib/src/device.dart
+++ b/packages/flutter_tools/lib/src/device.dart
@@ -98,6 +98,8 @@ abstract class Device {
 
   String get name;
 
+  bool get supportsStartPaused => true;
+
   /// Install an app package on the current device
   bool installApp(ApplicationPackage app);
 

--- a/packages/flutter_tools/lib/src/ios/device_ios.dart
+++ b/packages/flutter_tools/lib/src/ios/device_ios.dart
@@ -82,6 +82,8 @@ class IOSDevice extends Device {
 
   final String name;
 
+  bool get supportsStartPaused => false;
+
   static List<IOSDevice> getAttachedDevices([IOSDevice mockIOS]) {
     List<IOSDevice> devices = [];
     for (String id in _getAttachedDeviceIDs(mockIOS)) {


### PR DESCRIPTION
In support of `--start-paused`, don't return from `flutter start` until the observatory port is available for debuggers to connect to.
