### PR TITLE
Explicitly specify the sdk and arch when building for an iOS device

### DIFF
--- a/packages/flutter_tools/lib/src/ios/device_ios.dart
+++ b/packages/flutter_tools/lib/src/ios/device_ios.dart
@@ -530,7 +530,9 @@ Future<bool> _buildIOSXcodeProject(ApplicationPackage app, bool isDevice) async 
     '/usr/bin/env', 'xcrun', 'xcodebuild', '-target', 'Runner', '-configuration', 'Release'
   ];
 
-  if (!isDevice) {
+  if (isDevice) {
+    commands.addAll(<String>['-sdk', 'iphoneos', '-arch', 'arm64']);
+  } else {
     commands.addAll(<String>['-sdk', 'iphonesimulator', '-arch', 'x86_64']);
   }
 


### PR DESCRIPTION
This fixes the application crashing on the device when built with the command line tools but is fine when building for the device.

cc @devoncarew @mpcomplete 
