### PR TITLE
ImageCache should be a public type

### DIFF
--- a/packages/flutter/lib/src/services/image_cache.dart
+++ b/packages/flutter/lib/src/services/image_cache.dart
@@ -45,8 +45,8 @@ class _UrlFetcher implements ImageProvider {
 
 const int _kDefaultSize = 1000;
 
-class _ImageCache {
-  _ImageCache._();
+class ImageCache {
+  ImageCache._();
 
   final LruMap<ImageProvider, ImageResource> _cache =
       new LruMap<ImageProvider, ImageResource>(maximumSize: _kDefaultSize);
@@ -65,4 +65,4 @@ class _ImageCache {
   }
 }
 
-final _ImageCache imageCache = new _ImageCache._();
+final ImageCache imageCache = new ImageCache._();


### PR DESCRIPTION
We expose `imageCache`, which is an ImageCache, but previously the class
was private which means there was no documentation for the methods on
that object.

Fixes #1750
