### PR TITLE
SizeObserver crusade: snap alignment

### DIFF
--- a/packages/flutter/lib/src/widgets/pageable_list.dart
+++ b/packages/flutter/lib/src/widgets/pageable_list.dart
@@ -28,7 +28,6 @@ class PageableList extends Scrollable {
     ScrollListener onScroll,
     ScrollListener onScrollEnd,
     SnapOffsetCallback snapOffsetCallback,
-    double snapAlignmentOffset: 0.0,
     this.itemsWrap: false,
     this.itemsSnapAlignment: ItemsSnapAlignment.adjacentItem,
     this.onPageChanged,
@@ -44,8 +43,7 @@ class PageableList extends Scrollable {
     onScrollStart: onScrollStart,
     onScroll: onScroll,
     onScrollEnd: onScrollEnd,
-    snapOffsetCallback: snapOffsetCallback,
-    snapAlignmentOffset: snapAlignmentOffset
+    snapOffsetCallback: snapOffsetCallback
   );
 
   final bool itemsWrap;

--- a/packages/flutter/lib/src/widgets/scrollable_grid.dart
+++ b/packages/flutter/lib/src/widgets/scrollable_grid.dart
@@ -20,7 +20,6 @@ class ScrollableGrid extends Scrollable {
     double initialScrollOffset,
     ScrollListener onScroll,
     SnapOffsetCallback snapOffsetCallback,
-    double snapAlignmentOffset: 0.0,
     this.delegate,
     this.children
   }) : super(
@@ -31,8 +30,7 @@ class ScrollableGrid extends Scrollable {
     // delegate that places children in column-major order.
     scrollDirection: Axis.vertical,
     onScroll: onScroll,
-    snapOffsetCallback: snapOffsetCallback,
-    snapAlignmentOffset: snapAlignmentOffset
+    snapOffsetCallback: snapOffsetCallback
   );
 
   final GridDelegate delegate;

--- a/packages/flutter/lib/src/widgets/scrollable_list.dart
+++ b/packages/flutter/lib/src/widgets/scrollable_list.dart
@@ -19,7 +19,6 @@ class ScrollableList extends Scrollable {
     ViewportAnchor scrollAnchor: ViewportAnchor.start,
     ScrollListener onScroll,
     SnapOffsetCallback snapOffsetCallback,
-    double snapAlignmentOffset: 0.0,
     this.itemExtent,
     this.itemsWrap: false,
     this.padding,
@@ -31,8 +30,7 @@ class ScrollableList extends Scrollable {
     scrollDirection: scrollDirection,
     scrollAnchor: scrollAnchor,
     onScroll: onScroll,
-    snapOffsetCallback: snapOffsetCallback,
-    snapAlignmentOffset: snapAlignmentOffset
+    snapOffsetCallback: snapOffsetCallback
   ) {
     assert(itemExtent != null);
   }
@@ -269,7 +267,6 @@ class ScrollableLazyList extends Scrollable {
     ViewportAnchor scrollAnchor: ViewportAnchor.start,
     ScrollListener onScroll,
     SnapOffsetCallback snapOffsetCallback,
-    double snapAlignmentOffset: 0.0,
     this.itemExtent,
     this.itemCount,
     this.itemBuilder,
@@ -281,8 +278,7 @@ class ScrollableLazyList extends Scrollable {
     scrollDirection: scrollDirection,
     scrollAnchor: scrollAnchor,
     onScroll: onScroll,
-    snapOffsetCallback: snapOffsetCallback,
-    snapAlignmentOffset: snapAlignmentOffset
+    snapOffsetCallback: snapOffsetCallback
   ) {
     assert(itemExtent != null);
     assert(itemBuilder != null);

--- a/packages/flutter/test/widget/snap_scrolling_test.dart
+++ b/packages/flutter/test/widget/snap_scrolling_test.dart
@@ -20,7 +20,7 @@ Widget buildItem(int item) {
   );
 }
 
-double snapOffsetCallback(double offset) {
+double snapOffsetCallback(double offset, Size size) {
   return (offset / itemExtent).floor() * itemExtent;
 }
 


### PR DESCRIPTION
Remove the SizeObserver you need to use snap alignment in lists by
having the lists provide the size themselves in the callback.

Also, remove snapAlignmentOffset since we couldn't figure out how to
explain it and it's not really needed.
