### PR TITLE
SizeObserver crusade: drawer

### DIFF
--- a/packages/flutter/lib/src/scheduler/scheduler.dart
+++ b/packages/flutter/lib/src/scheduler/scheduler.dart
@@ -215,11 +215,12 @@ abstract class Scheduler extends BindingBase {
     _postFrameCallbacks.add(callback);
   }
 
-  bool _isInFrame = false;
+  static bool get debugInFrame => _debugInFrame;
+  static bool _debugInFrame = false;
 
   void _invokeTransientFrameCallbacks(Duration timeStamp) {
     Timeline.startSync('Animate');
-    assert(_isInFrame);
+    assert(_debugInFrame);
     Map<int, FrameCallback> callbacks = _transientCallbacks;
     _transientCallbacks = new Map<int, FrameCallback>();
     callbacks.forEach((int id, FrameCallback callback) {
@@ -239,8 +240,8 @@ abstract class Scheduler extends BindingBase {
   /// [addPostFrameCallback].
   void handleBeginFrame(Duration rawTimeStamp) {
     Timeline.startSync('Begin frame');
-    assert(!_isInFrame);
-    _isInFrame = true;
+    assert(!_debugInFrame);
+    assert(() { _debugInFrame = true; return true; });
     Duration timeStamp = new Duration(
         microseconds: (rawTimeStamp.inMicroseconds / timeDilation).round());
     _hasRequestedABeginFrameCallback = false;
@@ -255,7 +256,7 @@ abstract class Scheduler extends BindingBase {
     for (FrameCallback callback in localPostFrameCallbacks)
       invokeFrameCallback(callback, timeStamp);
 
-    _isInFrame = false;
+    assert(() { _debugInFrame = false; return true; });
     Timeline.finishSync();
 
     // All frame-related callbacks have been executed. Run lower-priority tasks.


### PR DESCRIPTION
Drawer doesn't need a SizeObserver, since it only looks at the size
in event handlers. It can just go and probe the tree to read the size.

Also, change from using _kEdgeDragWidth to using _kWidth when figuring
out how much of the drawer to show when dragging it from the edge, since
that is more likely to match the drawer's width.
