### PR TITLE
Remove references to dart:ui_internals

### DIFF
--- a/packages/flutter/lib/src/rendering/child_view.dart
+++ b/packages/flutter/lib/src/rendering/child_view.dart
@@ -3,7 +3,7 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:ui_internals' as internals;
+import 'dart:ui' as ui;
 
 import 'package:flutter/services.dart';
 import 'package:mojo_services/mojo/gfx/composition/scene_token.mojom.dart' as mojom;
@@ -18,7 +18,7 @@ import 'box.dart';
 import 'object.dart';
 
 mojom.ViewHostProxy _initViewHostProxy() {
-  int viewHost = internals.takeViewHostHandle();
+  int viewHost = ui.takeViewHostHandle();
   assert(() {
     if (viewHost == 0)
       debugPrint('Child view are supported only when running in Mojo shell.');

--- a/packages/flutter/lib/src/services/asset_bundle.dart
+++ b/packages/flutter/lib/src/services/asset_bundle.dart
@@ -3,7 +3,7 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:ui_internals' as internals;
+import 'dart:ui' as ui;
 import 'dart:typed_data';
 
 import 'package:flutter/http.dart' as http;
@@ -95,7 +95,7 @@ class MojoAssetBundle extends CachingAssetBundle {
 AssetBundle _initRootBundle() {
   try {
     AssetBundleProxy bundle = new AssetBundleProxy.fromHandle(
-      new core.MojoHandle(internals.takeRootBundleHandle())
+      new core.MojoHandle(ui.takeRootBundleHandle())
     );
     return new MojoAssetBundle(bundle);
   } catch (e) {

--- a/packages/flutter/lib/src/services/binding.dart
+++ b/packages/flutter/lib/src/services/binding.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:ui_internals' as internals;
+import 'dart:ui' as ui;
 
 import 'package:mojo/application.dart';
 import 'package:mojo/bindings.dart' as bindings;
@@ -55,7 +55,7 @@ abstract class MojoShell extends BindingBase {
   static MojoShell get instance => _instance;
 
   static mojom.ShellProxy _initShellProxy() {
-    core.MojoHandle shellHandle = new core.MojoHandle(internals.takeShellProxyHandle());
+    core.MojoHandle shellHandle = new core.MojoHandle(ui.takeShellProxyHandle());
     if (!shellHandle.isValid)
       return null;
     return new mojom.ShellProxy.fromHandle(shellHandle);
@@ -63,8 +63,8 @@ abstract class MojoShell extends BindingBase {
   final mojom.Shell _shell = _initShellProxy()?.ptr;
 
   static ApplicationConnection _initEmbedderConnection() {
-    core.MojoHandle servicesHandle = new core.MojoHandle(internals.takeServicesProvidedByEmbedder());
-    core.MojoHandle exposedServicesHandle = new core.MojoHandle(internals.takeServicesProvidedToEmbedder());
+    core.MojoHandle servicesHandle = new core.MojoHandle(ui.takeServicesProvidedByEmbedder());
+    core.MojoHandle exposedServicesHandle = new core.MojoHandle(ui.takeServicesProvidedToEmbedder());
     if (!servicesHandle.isValid || !exposedServicesHandle.isValid)
       return null;
     mojom.ServiceProviderProxy services = new mojom.ServiceProviderProxy.fromHandle(servicesHandle);

--- a/packages/flutter/lib/src/services/service_registry.dart
+++ b/packages/flutter/lib/src/services/service_registry.dart
@@ -2,13 +2,13 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:ui_internals' as internals;
+import 'dart:ui' as ui;
 
 import 'package:mojo_services/mojo/service_registry.mojom.dart';
 import 'package:mojo/core.dart' as core;
 
 ServiceRegistryProxy _initServiceRegistryProxy() {
-  core.MojoHandle serviceRegistryHandle = new core.MojoHandle(internals.takeServiceRegistry());
+  core.MojoHandle serviceRegistryHandle = new core.MojoHandle(ui.takeServiceRegistry());
   if (!serviceRegistryHandle.isValid)
     return null;
   return new ServiceRegistryProxy.fromHandle(serviceRegistryHandle);


### PR DESCRIPTION
This library is being folded into dart:ui.

Fixes #83
