### PR TITLE
allow any android sdk version

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_sdk.dart
+++ b/packages/flutter_tools/lib/src/android/android_sdk.dart
@@ -1,0 +1,214 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:io';
+
+import 'package:path/path.dart' as path;
+import 'package:pub_semver/pub_semver.dart';
+
+import '../base/globals.dart';
+import '../base/os.dart';
+
+// Android SDK layout:
+//
+// $ANDROID_HOME/platform-tools/adb
+// $ANDROID_HOME/build-tools/19.1.0/aapt, dx, zipalign
+// $ANDROID_HOME/build-tools/22.0.1/aapt
+// $ANDROID_HOME/build-tools/23.0.2/aapt
+// $ANDROID_HOME/platforms/android-22/android.jar
+// $ANDROID_HOME/platforms/android-23/android.jar
+
+// TODO(devoncarew): We need a way to locate the Android SDK w/o using an environment variable.
+// Perhaps something like `flutter config --android-home=foo/bar`.
+
+/// Locate ADB. Prefer to use one from an Android SDK, if we can locate that.
+String getAdbPath() {
+  AndroidSdk sdk = AndroidSdk.locateAndroidSdk();
+
+  if (sdk?.latestVersion == null) {
+    return os.which('adb')?.path;
+  } else {
+    return sdk.adbPath;
+  }
+}
+
+class AndroidSdk {
+  AndroidSdk(this.directory) {
+    _init();
+  }
+
+  final String directory;
+
+  List<AndroidSdkVersion> _sdkVersions;
+  AndroidSdkVersion _latestVersion;
+
+  static AndroidSdk locateAndroidSdk() {
+    // TODO: Use explicit configuration information from a metadata file?
+
+    if (Platform.environment.containsKey('ANDROID_HOME')) {
+      String homeDir = Platform.environment['ANDROID_HOME'];
+      if (validSdkDirectory(homeDir))
+        return new AndroidSdk(homeDir);
+      if (validSdkDirectory(path.join(homeDir, 'sdk')))
+        return new AndroidSdk(path.join(homeDir, 'sdk'));
+    }
+
+    File aaptBin = os.which('aapt'); // in build-tools/$version/aapt
+    if (aaptBin != null) {
+      String dir = aaptBin.parent.parent.parent.path;
+      if (validSdkDirectory(dir))
+        return new AndroidSdk(dir);
+    }
+
+    File adbBin = os.which('adb'); // in platform-tools/adb
+    if (adbBin != null) {
+      String dir = adbBin.parent.parent.path;
+      if (validSdkDirectory(dir))
+        return new AndroidSdk(dir);
+    }
+
+    // No dice.
+    printTrace('Unable to locate an Android SDK.');
+    return null;
+  }
+
+  static bool validSdkDirectory(String dir) {
+    return FileSystemEntity.isDirectorySync(path.join(dir, 'platform-tools'));
+  }
+
+  List<AndroidSdkVersion> get sdkVersions => _sdkVersions;
+
+  AndroidSdkVersion get latestVersion => _latestVersion;
+
+  String get adbPath => getPlatformToolsPath('adb');
+
+  bool validateSdkWellFormed({ bool complain: false }) {
+    if (!FileSystemEntity.isFileSync(adbPath)) {
+      if (complain)
+        printError('Android SDK file not found: $adbPath.');
+      return false;
+    }
+
+    if (sdkVersions.isEmpty) {
+      if (complain)
+        printError('Android SDK does not have the proper build-tools.');
+      return false;
+    }
+
+    return latestVersion.validateSdkWellFormed(complain: complain);
+  }
+
+  String getPlatformToolsPath(String binaryName) {
+    return path.join(directory, 'platform-tools', binaryName);
+  }
+
+  void _init() {
+    List<String> platforms = <String>[]; // android-22, ...
+
+    Directory platformsDir = new Directory(path.join(directory, 'platforms'));
+    if (platformsDir.existsSync()) {
+      platforms = platformsDir
+        .listSync()
+        .map((FileSystemEntity entity) => path.basename(entity.path))
+        .where((String name) => name.startsWith('android-'))
+        .toList();
+    }
+
+    List<Version> buildToolsVersions = <Version>[]; // 19.1.0, 22.0.1, ...
+
+    Directory buildToolsDir = new Directory(path.join(directory, 'build-tools'));
+    if (buildToolsDir.existsSync()) {
+      buildToolsVersions = buildToolsDir
+        .listSync()
+        .map((FileSystemEntity entity) {
+          try {
+            return new Version.parse(path.basename(entity.path));
+          } catch (error) {
+            return null;
+          }
+        })
+        .where((Version version) => version != null)
+        .toList();
+    }
+
+    // Here we match up platforms with cooresponding build-tools. If we don't
+    // have a match, we don't return anything for that platform version. So if
+    // the user only have 'android-22' and 'build-tools/19.0.0', we don't find
+    // an Android sdk.
+    _sdkVersions = platforms.map((String platform) {
+      int sdkVersion;
+
+      try {
+        sdkVersion = int.parse(platform.substring('android-'.length));
+      } catch (error) {
+        return null;
+      }
+
+      Version buildToolsVersion = Version.primary(buildToolsVersions.where((Version version) {
+        return version.major == sdkVersion;
+      }).toList());
+
+      if (buildToolsVersion == null)
+        return null;
+
+      return new AndroidSdkVersion(this, platform, buildToolsVersion.toString());
+    }).where((AndroidSdkVersion version) => version != null).toList();
+
+    _sdkVersions.sort();
+
+    _latestVersion = _sdkVersions.isEmpty ? null : _sdkVersions.last;
+  }
+
+  String toString() => 'AndroidSdk: $directory';
+}
+
+class AndroidSdkVersion implements Comparable<AndroidSdkVersion> {
+  AndroidSdkVersion(this.sdk, this.androidVersion, this.buildToolsVersion);
+
+  final AndroidSdk sdk;
+  final String androidVersion;
+  final String buildToolsVersion;
+
+  int get sdkLevel => int.parse(androidVersion.substring('android-'.length));
+
+  String get androidJarPath => getPlatformsPath('android.jar');
+
+  String get aaptPath => getBuildToolsPath('aapt');
+
+  String get dxPath => getBuildToolsPath('dx');
+
+  String get zipalignPath => getBuildToolsPath('zipalign');
+
+  bool validateSdkWellFormed({ bool complain: false }) {
+    return
+      _exists(androidJarPath, complain: complain) &&
+      _exists(aaptPath, complain: complain) &&
+      _exists(dxPath, complain: complain) &&
+      _exists(zipalignPath, complain: complain);
+  }
+
+  String getPlatformsPath(String itemName) {
+    return path.join(sdk.directory, 'platforms', androidVersion, itemName);
+  }
+
+  String getBuildToolsPath(String binaryName) {
+    return path.join(sdk.directory, 'build-tools', buildToolsVersion, binaryName);
+  }
+
+  int compareTo(AndroidSdkVersion other) {
+    return sdkLevel - other.sdkLevel;
+  }
+
+  String toString() => '[${sdk.directory}, SDK version $sdkLevel, build-tools $buildToolsVersion]';
+
+  bool _exists(String path, { bool complain: false }) {
+    if (!FileSystemEntity.isFileSync(path)) {
+      if (complain)
+        printError('Android SDK file not found: $path.');
+      return false;
+    }
+
+    return true;
+  }
+}

--- a/packages/flutter_tools/lib/src/base/context.dart
+++ b/packages/flutter_tools/lib/src/base/context.dart
@@ -16,6 +16,14 @@ AppContext get context {
 class AppContext {
   Map<Type, dynamic> _instances = <Type, dynamic>{};
 
+  bool isSet(Type type) {
+    if (_instances.containsKey(type))
+      return true;
+
+    AppContext parent = _calcParent(Zone.current);
+    return parent != null ? parent.isSet(type) : false;
+  }
+
   dynamic getVariable(Type type) {
     if (_instances.containsKey(type))
       return _instances[type];

--- a/packages/flutter_tools/lib/src/base/globals.dart
+++ b/packages/flutter_tools/lib/src/base/globals.dart
@@ -2,12 +2,14 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import '../android/android_sdk.dart';
 import '../device.dart';
 import 'context.dart';
 import 'logger.dart';
 
 DeviceManager get deviceManager => context[DeviceManager];
 Logger get logger => context[Logger];
+AndroidSdk get androidSdk => context[AndroidSdk];
 
 /// Display an error level message to the user. Commands should use this if they
 /// fail in some way.

--- a/packages/flutter_tools/lib/src/base/os.dart
+++ b/packages/flutter_tools/lib/src/base/os.dart
@@ -18,11 +18,25 @@ abstract class OperatingSystemUtils {
 
   /// Make the given file executable. This may be a no-op on some platforms.
   ProcessResult makeExecutable(File file);
+
+  /// Return the path (with symlinks resolved) to the given executable, or `null`
+  /// if `which` was not able to locate the binary.
+  File which(String execName);
 }
 
 class _PosixUtils implements OperatingSystemUtils {
   ProcessResult makeExecutable(File file) {
     return Process.runSync('chmod', ['u+x', file.path]);
+  }
+
+  /// Return the path (with symlinks resolved) to the given executable, or `null`
+  /// if `which` was not able to locate the binary.
+  File which(String execName) {
+    ProcessResult result = Process.runSync('which', <String>[execName]);
+    if (result.exitCode != 0)
+      return null;
+    String path = result.stdout.trim().split('\n').first.trim();
+    return new File(new File(path).resolveSymbolicLinksSync());
   }
 }
 
@@ -30,6 +44,10 @@ class _WindowsUtils implements OperatingSystemUtils {
   // This is a no-op.
   ProcessResult makeExecutable(File file) {
     return new ProcessResult(0, 0, null, null);
+  }
+
+  File which(String execName) {
+    throw new UnimplementedError('_WindowsUtils.which');
   }
 }
 

--- a/packages/flutter_tools/lib/src/commands/daemon.dart
+++ b/packages/flutter_tools/lib/src/commands/daemon.dart
@@ -7,6 +7,7 @@ import 'dart:convert';
 import 'dart:io';
 
 import '../android/adb.dart';
+import '../android/android_sdk.dart';
 import '../android/device_android.dart';
 import '../base/context.dart';
 import '../base/globals.dart';

--- a/packages/flutter_tools/lib/src/commands/refresh.dart
+++ b/packages/flutter_tools/lib/src/commands/refresh.dart
@@ -32,7 +32,7 @@ class RefreshCommand extends FlutterCommand {
       downloadApplicationPackagesAndConnectToDevices(),
     ], eagerError: true);
 
-    if (!devices.android.isConnected()) {
+    if (devices.android == null || !devices.android.isConnected()) {
       printError('No device connected.');
       return 1;
     }

--- a/packages/flutter_tools/lib/src/commands/trace.dart
+++ b/packages/flutter_tools/lib/src/commands/trace.dart
@@ -29,7 +29,7 @@ class TraceCommand extends FlutterCommand {
   Future<int> runInProject() async {
     await downloadApplicationPackagesAndConnectToDevices();
 
-    if (!devices.android.isConnected()) {
+    if (devices.android == null || !devices.android.isConnected()) {
       printError('No device connected, so no trace was completed.');
       return 1;
     }

--- a/packages/flutter_tools/lib/src/ios/device_ios.dart
+++ b/packages/flutter_tools/lib/src/ios/device_ios.dart
@@ -402,6 +402,8 @@ class _IOSDeviceLogReader extends DeviceLogReader {
     if (!device.isConnected())
       return 2;
 
+    // TODO(devoncarew): This regex should use the CFBundleIdentifier value from
+    // the user's plist (instead of `flutter.runner.Runner`).
     return await runCommandAndStreamOutput(
       <String>[device.loggerPath],
       prefix: '[$name] ',

--- a/packages/flutter_tools/lib/src/runner/flutter_command_runner.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command_runner.dart
@@ -9,7 +9,9 @@ import 'package:args/args.dart';
 import 'package:args/command_runner.dart';
 import 'package:path/path.dart' as path;
 
+import '../android/android_sdk.dart';
 import '../artifacts.dart';
+import '../base/context.dart';
 import '../base/globals.dart';
 import '../base/process.dart';
 import '../build_configuration.dart';
@@ -166,6 +168,22 @@ class FlutterCommandRunner extends CommandRunner {
 
     // See if the user specified a specific device.
     deviceManager.specifiedDeviceId = globalResults['device-id'];
+
+    // The Android SDK could already have been set by tests.
+    if (!context.isSet(AndroidSdk)) {
+      if (enginePath != null) {
+        context[AndroidSdk] = new AndroidSdk('$enginePath/third_party/android_tools/sdk');
+      } else {
+        context[AndroidSdk] = AndroidSdk.locateAndroidSdk();
+      }
+    }
+
+    if (androidSdk != null) {
+      printTrace('Using Android SDK at ${androidSdk.directory}.');
+
+      if (androidSdk.latestVersion != null)
+        printTrace('${androidSdk.latestVersion}');
+    }
 
     ArtifactStore.flutterRoot = path.normalize(path.absolute(globalResults['flutter-root']));
     if (globalResults.wasParsed('package-root'))

--- a/packages/flutter_tools/lib/src/services.dart
+++ b/packages/flutter_tools/lib/src/services.dart
@@ -10,6 +10,7 @@ import 'package:path/path.dart' as path;
 import 'package:yaml/yaml.dart';
 
 import 'artifacts.dart';
+import 'base/globals.dart';
 
 const String _kFlutterManifestPath = 'flutter.yaml';
 
@@ -23,7 +24,7 @@ dynamic _loadYamlFile(String path) {
 /// Loads all services specified in `flutter.yaml`. Parses each service config file,
 /// storing metadata in [services] and the list of jar files in [jars].
 Future parseServiceConfigs(
-  List<Map<String, String>> services, { List<File> jars, String androidSdk }
+  List<Map<String, String>> services, { List<File> jars }
 ) async {
   if (!ArtifactStore.isPackageRootValid)
     return;
@@ -49,17 +50,17 @@ Future parseServiceConfigs(
 
     if (jars != null) {
       for (String jar in serviceConfig['jars'])
-        jars.add(new File(await getServiceFromUrl(jar, serviceRoot, service, androidSdk: androidSdk, unzip: false)));
+        jars.add(new File(await getServiceFromUrl(jar, serviceRoot, service, unzip: false)));
     }
   }
 }
 
 Future<String> getServiceFromUrl(
-  String url, String rootDir, String serviceName, { String androidSdk, bool unzip: false }
+  String url, String rootDir, String serviceName, { bool unzip: false }
 ) async {
-  if (url.startsWith("android-sdk:")) {
+  if (url.startsWith("android-sdk:") && androidSdk != null) {
     // It's something shipped in the standard android SDK.
-    return url.replaceAll('android-sdk:', '$androidSdk/');
+    return url.replaceAll('android-sdk:', '${androidSdk.directory}/');
   } else if (url.startsWith("http")) {
     // It's a regular file to download.
     return await ArtifactStore.getThirdPartyFile(url, serviceName, unzip);

--- a/packages/flutter_tools/pubspec.yaml
+++ b/packages/flutter_tools/pubspec.yaml
@@ -15,6 +15,7 @@ dependencies:
   den_api: ^0.1.0
   mustache4dart: ^1.0.0
   path: ^1.3.0
+  pub_semver: ^1.0.0
   stack_trace: ^1.4.0
   test: 0.12.6+1 # see note below
   yaml: ^2.1.3

--- a/packages/flutter_tools/test/android_device_test.dart
+++ b/packages/flutter_tools/test/android_device_test.dart
@@ -5,7 +5,7 @@
 import 'package:flutter_tools/src/android/device_android.dart';
 import 'package:test/test.dart';
 
-import 'src/test_context.dart';
+import 'src/context.dart';
 
 main() => defineTests();
 

--- a/packages/flutter_tools/test/create_test.dart
+++ b/packages/flutter_tools/test/create_test.dart
@@ -11,7 +11,7 @@ import 'package:flutter_tools/src/commands/create.dart';
 import 'package:path/path.dart' as path;
 import 'package:test/test.dart';
 
-import 'src/test_context.dart';
+import 'src/context.dart';
 
 main() => defineTests();
 

--- a/packages/flutter_tools/test/daemon_test.dart
+++ b/packages/flutter_tools/test/daemon_test.dart
@@ -16,11 +16,17 @@ import 'src/mocks.dart';
 main() => defineTests();
 
 defineTests() {
-  group('daemon', () {
-    Daemon daemon;
-    AppContext appContext;
-    NotifyingLogger notifyingLogger;
+  Daemon daemon;
+  AppContext appContext;
+  NotifyingLogger notifyingLogger;
 
+  void _testUsingContext(String description, dynamic testMethod()) {
+    test(description, () {
+      return appContext.runInZone(testMethod);
+    });
+  }
+
+  group('daemon', () {
     setUp(() {
       appContext = new AppContext();
       notifyingLogger = new NotifyingLogger();
@@ -32,7 +38,7 @@ defineTests() {
         return daemon.shutdown();
     });
 
-    test('daemon.version', () async {
+    _testUsingContext('daemon.version', () async {
       StreamController<Map<String, dynamic>> commands = new StreamController();
       StreamController<Map<String, dynamic>> responses = new StreamController();
       daemon = new Daemon(
@@ -47,7 +53,7 @@ defineTests() {
       expect(response['result'] is String, true);
     });
 
-    test('daemon.logMessage', () {
+    _testUsingContext('daemon.logMessage', () {
       return appContext.runInZone(() async {
         StreamController<Map<String, dynamic>> commands = new StreamController();
         StreamController<Map<String, dynamic>> responses = new StreamController();
@@ -68,7 +74,7 @@ defineTests() {
       });
     });
 
-    test('daemon.shutdown', () async {
+    _testUsingContext('daemon.shutdown', () async {
       StreamController<Map<String, dynamic>> commands = new StreamController();
       StreamController<Map<String, dynamic>> responses = new StreamController();
       daemon = new Daemon(
@@ -82,7 +88,7 @@ defineTests() {
       });
     });
 
-    test('daemon.stopAll', () async {
+    _testUsingContext('daemon.stopAll', () async {
       DaemonCommand command = new DaemonCommand();
       applyMocksToCommand(command);
 
@@ -112,7 +118,7 @@ defineTests() {
       expect(response['result'], true);
     });
 
-    test('device.getDevices', () async {
+    _testUsingContext('device.getDevices', () async {
       StreamController<Map<String, dynamic>> commands = new StreamController();
       StreamController<Map<String, dynamic>> responses = new StreamController();
       daemon = new Daemon(

--- a/packages/flutter_tools/test/device_test.dart
+++ b/packages/flutter_tools/test/device_test.dart
@@ -5,7 +5,7 @@
 import 'package:flutter_tools/src/device.dart';
 import 'package:test/test.dart';
 
-import 'src/test_context.dart';
+import 'src/context.dart';
 
 main() => defineTests();
 

--- a/packages/flutter_tools/test/install_test.dart
+++ b/packages/flutter_tools/test/install_test.dart
@@ -2,18 +2,19 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:args/command_runner.dart';
 import 'package:flutter_tools/src/commands/install.dart';
 import 'package:mockito/mockito.dart';
 import 'package:test/test.dart';
 
+import 'src/common.dart';
+import 'src/context.dart';
 import 'src/mocks.dart';
 
 main() => defineTests();
 
 defineTests() {
   group('install', () {
-    test('returns 0 when Android is connected and ready for an install', () {
+    testUsingContext('returns 0 when Android is connected and ready for an install', () {
       InstallCommand command = new InstallCommand();
       applyMocksToCommand(command);
       MockDeviceStore mockDevices = command.devices;
@@ -30,13 +31,12 @@ defineTests() {
       when(mockDevices.iOSSimulator.isAppInstalled(any)).thenReturn(false);
       when(mockDevices.iOSSimulator.installApp(any)).thenReturn(false);
 
-
-      CommandRunner runner = new CommandRunner('test_flutter', '')
-        ..addCommand(command);
-      return runner.run(['install']).then((int code) => expect(code, equals(0)));
+      return createTestCommandRunner(command).run(['install']).then((int code) {
+        expect(code, equals(0));
+      });
     });
 
-    test('returns 0 when iOS is connected and ready for an install', () {
+    testUsingContext('returns 0 when iOS is connected and ready for an install', () {
       InstallCommand command = new InstallCommand();
       applyMocksToCommand(command);
       MockDeviceStore mockDevices = command.devices;
@@ -53,9 +53,9 @@ defineTests() {
       when(mockDevices.iOSSimulator.isAppInstalled(any)).thenReturn(false);
       when(mockDevices.iOSSimulator.installApp(any)).thenReturn(false);
 
-      CommandRunner runner = new CommandRunner('test_flutter', '')
-        ..addCommand(command);
-      return runner.run(['install']).then((int code) => expect(code, equals(0)));
+      return createTestCommandRunner(command).run(['install']).then((int code) {
+        expect(code, equals(0));
+      });
     });
   });
 }

--- a/packages/flutter_tools/test/list_test.dart
+++ b/packages/flutter_tools/test/list_test.dart
@@ -2,43 +2,34 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:io';
-
-import 'package:args/command_runner.dart';
+import 'package:flutter_tools/src/android/android_sdk.dart';
 import 'package:flutter_tools/src/commands/list.dart';
-import 'package:mockito/mockito.dart';
+import 'package:flutter_tools/src/device.dart';
 import 'package:test/test.dart';
 
-import 'src/mocks.dart';
-import 'src/test_context.dart';
+import 'src/common.dart';
+import 'src/context.dart';
 
 main() => defineTests();
 
 defineTests() {
   group('list', () {
     testUsingContext('returns 0 when called', () {
-      final String mockCommand = Platform.isWindows ? 'cmd /c echo' : 'echo';
-
       ListCommand command = new ListCommand();
-      applyMocksToCommand(command);
-      MockDeviceStore mockDevices = command.devices;
+      return createTestCommandRunner(command).run(['list']).then((int code) {
+        expect(code, equals(0));
+      });
+    });
 
-      // Avoid relying on adb being installed on the test system.
-      // Instead, cause the test to run the echo command.
-      when(mockDevices.android.adbPath).thenReturn(mockCommand);
-
-      // Avoid relying on idevice* being installed on the test system.
-      // Instead, cause the test to run the echo command.
-      when(mockDevices.iOS.informerPath).thenReturn(mockCommand);
-      when(mockDevices.iOS.installerPath).thenReturn(mockCommand);
-      when(mockDevices.iOS.listerPath).thenReturn(mockCommand);
-
-      // Avoid relying on xcrun being installed on the test system.
-      // Instead, cause the test to run the echo command.
-      when(mockDevices.iOSSimulator.xcrunPath).thenReturn(mockCommand);
-
-      CommandRunner runner = new CommandRunner('test_flutter', '')..addCommand(command);
-      return runner.run(['list']).then((int code) => expect(code, equals(0)));
+    testUsingContext('no error when no connected devices', () {
+      ListCommand command = new ListCommand();
+      return createTestCommandRunner(command).run(['list']).then((int code) {
+        expect(code, equals(0));
+        expect(testLogger.statusText, contains('No connected devices'));
+      });
+    }, overrides: <Type, dynamic>{
+      AndroidSdk: null,
+      DeviceManager: new DeviceManager()
     });
   });
 }

--- a/packages/flutter_tools/test/listen_test.dart
+++ b/packages/flutter_tools/test/listen_test.dart
@@ -2,14 +2,13 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:args/command_runner.dart';
 import 'package:flutter_tools/src/commands/listen.dart';
-import 'package:flutter_tools/src/runner/flutter_command_runner.dart';
 import 'package:mockito/mockito.dart';
 import 'package:test/test.dart';
 
+import 'src/common.dart';
+import 'src/context.dart';
 import 'src/mocks.dart';
-import 'src/test_context.dart';
 
 main() => defineTests();
 
@@ -24,8 +23,9 @@ defineTests() {
       when(mockDevices.iOS.isConnected()).thenReturn(false);
       when(mockDevices.iOSSimulator.isConnected()).thenReturn(false);
 
-      CommandRunner runner = new FlutterCommandRunner()..addCommand(command);
-      return runner.run(['listen']).then((int code) => expect(code, equals(0)));
+      return createTestCommandRunner(command).run(['listen']).then((int code) {
+        expect(code, equals(0));
+      });
     });
   });
 }

--- a/packages/flutter_tools/test/logs_test.dart
+++ b/packages/flutter_tools/test/logs_test.dart
@@ -2,13 +2,12 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:args/command_runner.dart';
 import 'package:flutter_tools/src/commands/logs.dart';
-import 'package:flutter_tools/src/runner/flutter_command_runner.dart';
 import 'package:test/test.dart';
 
+import 'src/common.dart';
+import 'src/context.dart';
 import 'src/mocks.dart';
-import 'src/test_context.dart';
 
 main() => defineTests();
 
@@ -17,8 +16,7 @@ defineTests() {
     testUsingContext('fail with a bad device id', () {
       LogsCommand command = new LogsCommand();
       applyMocksToCommand(command);
-      CommandRunner runner = new FlutterCommandRunner()..addCommand(command);
-      return runner.run(<String>['-d', 'abc123', 'logs']).then((int code) {
+      return createTestCommandRunner(command).run(<String>['-d', 'abc123', 'logs']).then((int code) {
         expect(code, equals(1));
       });
     });

--- a/packages/flutter_tools/test/src/common.dart
+++ b/packages/flutter_tools/test/src/common.dart
@@ -1,0 +1,11 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:args/command_runner.dart';
+import 'package:flutter_tools/src/runner/flutter_command.dart';
+import 'package:flutter_tools/src/runner/flutter_command_runner.dart';
+
+CommandRunner createTestCommandRunner(FlutterCommand command) {
+  return new FlutterCommandRunner()..addCommand(command);
+}

--- a/packages/flutter_tools/test/src/context.dart
+++ b/packages/flutter_tools/test/src/context.dart
@@ -9,12 +9,25 @@ import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/device.dart';
 import 'package:test/test.dart';
 
-void testUsingContext(String description, dynamic testMethod(), { Timeout timeout }) {
+/// Return the test logger. This assumes that the current Logger is a BufferLogger.
+BufferLogger get testLogger => context[Logger];
+
+void testUsingContext(String description, dynamic testMethod(), {
+  Timeout timeout,
+  Map<Type, dynamic> overrides: const <Type, dynamic>{}
+}) {
   test(description, () {
     AppContext testContext = new AppContext();
 
-    testContext[Logger] = new BufferLogger();
-    testContext[DeviceManager] = new MockDeviceManager();
+    overrides.forEach((Type type, dynamic value) {
+      testContext[type] = value;
+    });
+
+    if (!overrides.containsKey(Logger))
+      testContext[Logger] = new BufferLogger();
+
+    if (!overrides.containsKey(DeviceManager))
+      testContext[DeviceManager] = new MockDeviceManager();
 
     return testContext.runInZone(testMethod);
   }, timeout: timeout);

--- a/packages/flutter_tools/test/stop_test.dart
+++ b/packages/flutter_tools/test/stop_test.dart
@@ -2,18 +2,19 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:args/command_runner.dart';
 import 'package:flutter_tools/src/commands/stop.dart';
 import 'package:mockito/mockito.dart';
 import 'package:test/test.dart';
 
+import 'src/common.dart';
+import 'src/context.dart';
 import 'src/mocks.dart';
 
 main() => defineTests();
 
 defineTests() {
   group('stop', () {
-    test('returns 0 when Android is connected and ready to be stopped', () {
+    testUsingContext('returns 0 when Android is connected and ready to be stopped', () {
       StopCommand command = new StopCommand();
       applyMocksToCommand(command);
       MockDeviceStore mockDevices = command.devices;
@@ -27,12 +28,12 @@ defineTests() {
       when(mockDevices.iOSSimulator.isConnected()).thenReturn(false);
       when(mockDevices.iOSSimulator.stopApp(any)).thenReturn(false);
 
-      CommandRunner runner = new CommandRunner('test_flutter', '')
-        ..addCommand(command);
-      return runner.run(['stop']).then((int code) => expect(code, equals(0)));
+      return createTestCommandRunner(command).run(['stop']).then((int code) {
+        expect(code, equals(0));
+      });
     });
 
-    test('returns 0 when iOS is connected and ready to be stopped', () {
+    testUsingContext('returns 0 when iOS is connected and ready to be stopped', () {
       StopCommand command = new StopCommand();
       applyMocksToCommand(command);
       MockDeviceStore mockDevices = command.devices;
@@ -46,9 +47,9 @@ defineTests() {
       when(mockDevices.iOSSimulator.isConnected()).thenReturn(false);
       when(mockDevices.iOSSimulator.stopApp(any)).thenReturn(false);
 
-      CommandRunner runner = new CommandRunner('test_flutter', '')
-        ..addCommand(command);
-      return runner.run(['stop']).then((int code) => expect(code, equals(0)));
+      return createTestCommandRunner(command).run(['stop']).then((int code) {
+        expect(code, equals(0));
+      });
     });
   });
 }

--- a/packages/flutter_tools/test/trace_test.dart
+++ b/packages/flutter_tools/test/trace_test.dart
@@ -2,13 +2,13 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:args/command_runner.dart';
 import 'package:flutter_tools/src/commands/trace.dart';
 import 'package:mockito/mockito.dart';
 import 'package:test/test.dart';
 
+import 'src/common.dart';
+import 'src/context.dart';
 import 'src/mocks.dart';
-import 'src/test_context.dart';
 
 main() => defineTests();
 
@@ -21,9 +21,9 @@ defineTests() {
 
       when(mockDevices.android.isConnected()).thenReturn(false);
 
-      CommandRunner runner = new CommandRunner('test_flutter', '')
-        ..addCommand(command);
-      return runner.run(['trace']).then((int code) => expect(code, equals(1)));
+      return createTestCommandRunner(command).run(['trace']).then((int code) {
+        expect(code, equals(1));
+      });
     });
   });
 }


### PR DESCRIPTION
- write a wrapper around the android sdk, w/ some logic to auto-locate it (w/ and w/o an environment variable set)
- `androidSdk` is now a global variable - populated when we can locate an sdk, and `null` if not
- remove the tight version restriction on the android sdk - this only worked for people that had an engine checkout. we now parse what's in the android sdk, match up the `build-tools/` and `platforms/` versions, and use that.
- print warnings if the android sdk is mal-formed, but don't print warnings if it's not there. So having an android sdk is optional

Two things I'd like to do in follow-up PRs:

We require tools to be installed in order to discover devices. For commands that need devices:
- if neither toolchain (android or ios) is set up, complain
- otherwise, look for devices for the installed toolchain; don't complain about the other toolchain being missing

Also, it would be good to have a way to configure where the android sdk is w/o using env variables or requiring a param passed into every cli command. I'm considering add a `flutter config` command. It would look something like this:

```
flutter config --android-home=/foo/bar/baz
```

And our instructions would call it out as a way to point flutter to a specific sdk. The data would persist on disk in some metadata file. I'll open a bug to discuss.
