### PR TITLE
rename list->devices, start->run

### DIFF
--- a/packages/flutter_tools/lib/executable.dart
+++ b/packages/flutter_tools/lib/executable.dart
@@ -17,14 +17,14 @@ import 'src/commands/build.dart';
 import 'src/commands/cache.dart';
 import 'src/commands/create.dart';
 import 'src/commands/daemon.dart';
+import 'src/commands/devices.dart';
 import 'src/commands/install.dart';
 import 'src/commands/ios.dart';
-import 'src/commands/list.dart';
 import 'src/commands/listen.dart';
 import 'src/commands/logs.dart';
 import 'src/commands/refresh.dart';
+import 'src/commands/run.dart';
 import 'src/commands/run_mojo.dart';
-import 'src/commands/start.dart';
 import 'src/commands/stop.dart';
 import 'src/commands/test.dart';
 import 'src/commands/trace.dart';
@@ -38,22 +38,23 @@ import 'src/runner/flutter_command_runner.dart';
 Future main(List<String> args) async {
   bool help = args.contains('-h') || args.contains('--help');
   bool verbose = args.contains('-v') || args.contains('--verbose');
+  bool verboseHelp = help && verbose;
 
-  FlutterCommandRunner runner = new FlutterCommandRunner(verboseHelp: help && verbose)
+  FlutterCommandRunner runner = new FlutterCommandRunner(verboseHelp: verboseHelp)
     ..addCommand(new AnalyzeCommand())
     ..addCommand(new ApkCommand())
     ..addCommand(new BuildCommand())
     ..addCommand(new CacheCommand())
     ..addCommand(new CreateCommand())
-    ..addCommand(new DaemonCommand())
+    ..addCommand(new DaemonCommand(hideCommand: !verboseHelp))
+    ..addCommand(new DevicesCommand())
     ..addCommand(new InstallCommand())
     ..addCommand(new IOSCommand())
-    ..addCommand(new ListCommand())
     ..addCommand(new ListenCommand())
     ..addCommand(new LogsCommand())
     ..addCommand(new RefreshCommand())
+    ..addCommand(new RunCommand())
     ..addCommand(new RunMojoCommand())
-    ..addCommand(new StartCommand())
     ..addCommand(new StopCommand())
     ..addCommand(new TestCommand())
     ..addCommand(new TraceCommand())

--- a/packages/flutter_tools/lib/src/artifacts.dart
+++ b/packages/flutter_tools/lib/src/artifacts.dart
@@ -306,7 +306,7 @@ class ArtifactStore {
 
   static final Map<String, Future> _pendingZipDownloads = new Map<String, Future>();
 
-  static Directory _getBaseCacheDir() {
+  static Directory getBaseCacheDir() {
     if (flutterRoot == null) {
       printError('FLUTTER_ROOT not specified. Cannot find artifact cache.');
       throw new ProcessExit(2);
@@ -319,7 +319,7 @@ class ArtifactStore {
 
   static Directory _getCacheDirForPlatform(String platform) {
     validateSkyEnginePackage();
-    Directory baseDir = _getBaseCacheDir();
+    Directory baseDir = getBaseCacheDir();
     // TODO(jamesr): Add support for more configurations.
     String config = 'Release';
     Directory artifactSpecificDir = new Directory(path.join(
@@ -344,7 +344,7 @@ class ArtifactStore {
 
   static Future<String> getThirdPartyFile(String urlStr, String cacheSubdir, bool unzip) async {
     Uri url = Uri.parse(urlStr);
-    Directory baseDir = _getBaseCacheDir();
+    Directory baseDir = getBaseCacheDir();
     Directory cacheDir = new Directory(path.join(
         baseDir.path, 'third_party', cacheSubdir));
     File cachedFile = new File(
@@ -361,7 +361,7 @@ class ArtifactStore {
   }
 
   static void clear() {
-    Directory cacheDir = _getBaseCacheDir();
+    Directory cacheDir = getBaseCacheDir();
     printTrace('Clearing cache directory ${cacheDir.path}');
     cacheDir.deleteSync(recursive: true);
   }

--- a/packages/flutter_tools/lib/src/commands/apk.dart
+++ b/packages/flutter_tools/lib/src/commands/apk.dart
@@ -20,7 +20,7 @@ import '../flx.dart' as flx;
 import '../runner/flutter_command.dart';
 import '../services.dart';
 import '../toolchain.dart';
-import 'start.dart';
+import 'run.dart';
 
 const String _kDefaultAndroidManifestPath = 'android/AndroidManifest.xml';
 const String _kDefaultOutputPath = 'build/app.apk';

--- a/packages/flutter_tools/lib/src/commands/cache.dart
+++ b/packages/flutter_tools/lib/src/commands/cache.dart
@@ -7,10 +7,12 @@ import 'dart:async';
 import 'package:args/command_runner.dart';
 
 import '../artifacts.dart';
+import '../base/globals.dart';
 
 class CacheCommand extends Command {
   final String name = 'cache';
   final String description = 'Manages Flutter\'s cache of binary artifacts.';
+
   CacheCommand() {
     addSubcommand(new _ClearCommand());
     addSubcommand(new _PopulateCommand());
@@ -24,6 +26,7 @@ class _ClearCommand extends Command {
   @override
   Future<int> run() async {
     await ArtifactStore.clear();
+    printStatus('Cleared cache directory ${ArtifactStore.getBaseCacheDir().path}.');
     return 0;
   }
 }

--- a/packages/flutter_tools/lib/src/commands/daemon.dart
+++ b/packages/flutter_tools/lib/src/commands/daemon.dart
@@ -16,7 +16,7 @@ import '../device.dart';
 import '../ios/device_ios.dart';
 import '../ios/simulator.dart';
 import '../runner/flutter_command.dart';
-import 'start.dart';
+import 'run.dart';
 import 'stop.dart' as stop;
 
 const String protocolVersion = '0.1.0';
@@ -28,10 +28,15 @@ const String protocolVersion = '0.1.0';
 /// It can be shutdown with a `daemon.shutdown` command (or by killing the
 /// process).
 class DaemonCommand extends FlutterCommand {
+  DaemonCommand({ this.hideCommand: false });
+
   final String name = 'daemon';
   final String description = 'Run a persistent, JSON-RPC based server to communicate with devices.';
+  final bool hideCommand;
 
   bool get requiresProjectRoot => false;
+
+  bool get hidden => hideCommand;
 
   Future<int> runInProject() {
     printStatus('Starting device daemon...');
@@ -246,7 +251,6 @@ class AppDomain extends Domain {
     // command. This would have race conditions with other commands happening in
     // parallel and doesn't play well with the caching built into `FlutterCommand`.
     // TODO(devoncarew): Make flutter_tools work better with commands run from any directory.
-    // TODO(devoncarew): Use less (or more explicit) caching.
     Directory cwd = Directory.current;
     Directory.current = new Directory(projectDirectory);
 

--- a/packages/flutter_tools/lib/src/commands/devices.dart
+++ b/packages/flutter_tools/lib/src/commands/devices.dart
@@ -8,9 +8,10 @@ import '../base/globals.dart';
 import '../device.dart';
 import '../runner/flutter_command.dart';
 
-class ListCommand extends FlutterCommand {
-  final String name = 'list';
+class DevicesCommand extends FlutterCommand {
+  final String name = 'devices';
   final String description = 'List all connected devices.';
+  final List<String> aliases = <String>['list'];
 
   bool get requiresProjectRoot => false;
 

--- a/packages/flutter_tools/lib/src/commands/ios.dart
+++ b/packages/flutter_tools/lib/src/commands/ios.dart
@@ -115,7 +115,7 @@ class IOSCommand extends FlutterCommand {
   void _setupXcodeProjXcconfig(String filePath) {
     StringBuffer localsBuffer = new StringBuffer();
 
-    localsBuffer.writeln("// Generated. Do not edit or check into version control!");
+    localsBuffer.writeln("// This is a generated file; do not edit or check into version control.");
     localsBuffer.writeln("// Recreate using `flutter ios --init`.");
 
     String flutterRoot = path.normalize(Platform.environment[kFlutterRootEnvironmentVariableName]);
@@ -164,8 +164,9 @@ class IOSCommand extends FlutterCommand {
     revisionFile.writeAsStringSync(ArtifactStore.engineRevision);
 
     // Step 6: Tell the user the location of the generated project.
-    printStatus("An Xcode project has been placed in 'ios/'.");
-    printStatus("You may edit it to modify iOS specific configuration.");
+    printStatus("Xcode project created at $xcodeprojPath/.");
+    printStatus("User editable settings are in $iosFilesPath/.");
+
     return 0;
   }
 

--- a/packages/flutter_tools/lib/src/commands/listen.dart
+++ b/packages/flutter_tools/lib/src/commands/listen.dart
@@ -7,9 +7,9 @@ import 'dart:io';
 
 import '../base/globals.dart';
 import '../base/process.dart';
-import 'start.dart';
+import 'run.dart';
 
-class ListenCommand extends StartCommandBase {
+class ListenCommand extends RunCommandBase {
   final String name = 'listen';
   final String description =
     'Listen for changes to files and reload the running app (Android only).';

--- a/packages/flutter_tools/lib/src/commands/run.dart
+++ b/packages/flutter_tools/lib/src/commands/run.dart
@@ -32,8 +32,8 @@ String findMainDartFile([String target]) {
   }
 }
 
-abstract class StartCommandBase extends FlutterCommand {
-  StartCommandBase() {
+abstract class RunCommandBase extends FlutterCommand {
+  RunCommandBase() {
     argParser.addFlag('checked',
         negatable: true,
         defaultsTo: true,
@@ -51,12 +51,13 @@ abstract class StartCommandBase extends FlutterCommand {
   }
 }
 
-class StartCommand extends StartCommandBase {
-  final String name = 'start';
-  final String description = 'Start your Flutter app on an attached device '
-                             '(defaults to checked/debug mode).';
+class RunCommand extends RunCommandBase {
+  final String name = 'run';
+  final String description =
+    'Run your Flutter app on an attached device (defaults to checked/debug mode).';
+  final List<String> aliases = <String>['start'];
 
-  StartCommand() {
+  RunCommand() {
     argParser.addFlag('full-restart',
         defaultsTo: true,
         help: 'Stop any currently running application process before starting the app.');

--- a/packages/flutter_tools/lib/src/commands/run_mojo.dart
+++ b/packages/flutter_tools/lib/src/commands/run_mojo.dart
@@ -13,7 +13,7 @@ import '../base/process.dart';
 import '../build_configuration.dart';
 import '../flx.dart' as flx;
 import '../runner/flutter_command.dart';
-import 'start.dart';
+import 'run.dart';
 
 const String _kDefaultBundlePath = 'build/app.flx';
 

--- a/packages/flutter_tools/lib/src/commands/test.dart
+++ b/packages/flutter_tools/lib/src/commands/test.dart
@@ -16,7 +16,7 @@ import '../test/loader.dart' as loader;
 
 class TestCommand extends FlutterCommand {
   String get name => 'test';
-  String get description => 'Runs Flutter unit tests for the current project.';
+  String get description => 'Runs Flutter unit tests for the current project (Linux only).';
 
   bool get requiresProjectRoot => false;
 

--- a/packages/flutter_tools/lib/src/runner/flutter_command_runner.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command_runner.dart
@@ -47,8 +47,8 @@ class FlutterCommandRunner extends CommandRunner {
     argParser.addOption('package-root',
         help: 'Path to your packages directory.$packagesHelp');
     argParser.addOption('flutter-root',
-        help: 'The root directory of the Flutter repository. Defaults to \$$kFlutterRootEnvironmentVariableName if\n'
-              'set, otherwise defaults to a value derived from the location of this tool.', defaultsTo: _defaultFlutterRoot);
+        help: 'The root directory of the Flutter repository. Uses \$$kFlutterRootEnvironmentVariableName if set,\n'
+              'otherwise defaults to a value derived from the location of this tool.', defaultsTo: _defaultFlutterRoot);
 
     if (verboseHelp)
       argParser.addSeparator('Local build selection options (not normally required):');

--- a/packages/flutter_tools/test/devices.test.dart
+++ b/packages/flutter_tools/test/devices.test.dart
@@ -3,7 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:flutter_tools/src/android/android_sdk.dart';
-import 'package:flutter_tools/src/commands/list.dart';
+import 'package:flutter_tools/src/commands/devices.dart';
 import 'package:flutter_tools/src/device.dart';
 import 'package:test/test.dart';
 
@@ -13,16 +13,16 @@ import 'src/context.dart';
 main() => defineTests();
 
 defineTests() {
-  group('list', () {
+  group('devices', () {
     testUsingContext('returns 0 when called', () {
-      ListCommand command = new ListCommand();
+      DevicesCommand command = new DevicesCommand();
       return createTestCommandRunner(command).run(['list']).then((int code) {
         expect(code, equals(0));
       });
     });
 
     testUsingContext('no error when no connected devices', () {
-      ListCommand command = new ListCommand();
+      DevicesCommand command = new DevicesCommand();
       return createTestCommandRunner(command).run(['list']).then((int code) {
         expect(code, equals(0));
         expect(testLogger.statusText, contains('No connected devices'));


### PR DESCRIPTION
- rename `flutter start` to `flutter run` (fix https://github.com/flutter/flutter/issues/1655). keep `start` as an alias
- rename `flutter list` to `devices` (w/ `list` as an alias)
- hide the `daemon` command
