### PR TITLE
fixes found when running through the getting started process

### DIFF
--- a/packages/flutter_tools/lib/src/android/adb.dart
+++ b/packages/flutter_tools/lib/src/android/adb.dart
@@ -181,9 +181,8 @@ class AdbDevice {
       }
     }
 
-    // Convert `Nexus_7` / `Nexus_5X` style names to `Nexus 7` ones.
     if (modelID != null)
-      modelID = modelID.replaceAll('_', ' ');
+      modelID = cleanAdbDeviceName(modelID);
   }
 
   static final RegExp deviceRegex = new RegExp(r'^(\S+)\s+(\S+)(.*)');
@@ -233,6 +232,16 @@ class AdbDevice {
       return '$id ($status) - $modelID';
     }
   }
+}
+
+String cleanAdbDeviceName(String name) {
+  // Some emulators use `___` in the name as separators.
+  name = name.replaceAll('___', ', ');
+
+  // Convert `Nexus_7` / `Nexus_5X` style names to `Nexus 7` ones.
+  name = name.replaceAll('_', ' ');
+
+  return name;
 }
 
 List<int> _createAdbRequest(String payload) {

--- a/packages/flutter_tools/lib/src/android/android_sdk.dart
+++ b/packages/flutter_tools/lib/src/android/android_sdk.dart
@@ -23,7 +23,10 @@ import '../base/os.dart';
 // Perhaps something like `flutter config --android-home=foo/bar`.
 
 /// Locate ADB. Prefer to use one from an Android SDK, if we can locate that.
-String getAdbPath() {
+String getAdbPath([AndroidSdk existingSdk]) {
+  if (existingSdk?.adbPath != null)
+    return existingSdk.adbPath;
+
   AndroidSdk sdk = AndroidSdk.locateAndroidSdk();
 
   if (sdk?.latestVersion == null) {

--- a/packages/flutter_tools/lib/src/commands/apk.dart
+++ b/packages/flutter_tools/lib/src/commands/apk.dart
@@ -369,6 +369,17 @@ Future<int> buildAndroid({
   String flxPath: '',
   ApkKeystoreInfo keystore
 }) async {
+  // Validate that we can find an android sdk.
+  if (androidSdk == null) {
+    printError('No Android SDK found.');
+    return 1;
+  }
+
+  if (!androidSdk.validateSdkWellFormed(complain: true)) {
+    printError('Try re-installing or updating your Android SDK.');
+    return 1;
+  }
+
   if (!force && !_needsRebuild(outputFile, manifest)) {
     printTrace('APK up to date. Skipping build step.');
     return 0;
@@ -437,13 +448,17 @@ Future buildAll(
         continue;
       }
 
-      await buildAndroid(
+      int result = await buildAndroid(
         toolchain: toolchain,
         configs: configs,
         enginePath: enginePath,
         force: false,
         target: target
       );
+      if (result != 0)
+        return result;
     }
   }
+
+  return 0;
 }

--- a/packages/flutter_tools/lib/src/commands/create.dart
+++ b/packages/flutter_tools/lib/src/commands/create.dart
@@ -57,7 +57,7 @@ class CreateCommand extends Command {
 All done! To run your application:
 
   \$ cd ${out.path}
-  \$ flutter start
+  \$ flutter run
 ''';
 
     if (argResults['pub']) {
@@ -152,8 +152,8 @@ class FlutterSimpleTemplate extends Template {
 
     // Android files.
     files['android/AndroidManifest.xml'] = _apkManifest;
-    // Create a file here, so we create the directory for the user and it gets committed with git.
-    files['android/res/README.md'] = _androidResReadme;
+    // Create a file here in order to create the res/ directory and ensure it gets committed to git.
+    files['android/res/.empty'] = _androidEmptyFile;
 
     // iOS files.
     files.addAll(iosTemplateFiles);
@@ -285,6 +285,6 @@ final String _apkManifest = '''
 </manifest>
 ''';
 
-final String _androidResReadme = '''
+final String _androidEmptyFile = '''
 Place Android resources here (http://developer.android.com/guide/topics/resources/overview.html).
 ''';

--- a/packages/flutter_tools/lib/src/commands/daemon.dart
+++ b/packages/flutter_tools/lib/src/commands/daemon.dart
@@ -356,7 +356,7 @@ class AndroidDeviceDiscovery {
 
   void _initAdb() {
     if (_adb == null) {
-      _adb = new Adb(getAdbPath());
+      _adb = new Adb(getAdbPath(androidSdk));
       if (!_adb.exists())
         _adb = null;
     }

--- a/packages/flutter_tools/lib/src/commands/logs.dart
+++ b/packages/flutter_tools/lib/src/commands/logs.dart
@@ -23,9 +23,6 @@ class LogsCommand extends FlutterCommand {
   bool get requiresProjectRoot => false;
 
   Future<int> runInProject() async {
-    DeviceManager deviceManager = new DeviceManager();
-    deviceManager.specifiedDeviceId = globalResults['device-id'];
-
     List<Device> devices = await deviceManager.getDevices();
 
     if (devices.isEmpty && deviceManager.hasSpecifiedDeviceId) {

--- a/packages/flutter_tools/lib/src/commands/run.dart
+++ b/packages/flutter_tools/lib/src/commands/run.dart
@@ -131,7 +131,6 @@ Future<int> startApp(
   bool startPaused: false,
   int debugPort: observatoryDefaultPort
 }) async {
-
   String mainPath = findMainDartFile(target);
   if (!FileSystemEntity.isFileSync(mainPath)) {
     String message = 'Tried to run $mainPath, but that file does not exist.';
@@ -143,11 +142,13 @@ Future<int> startApp(
 
   if (install) {
     printTrace('Running build command.');
-    await buildAll(
+    int result = await buildAll(
       devices, applicationPackages, toolchain, configs,
       enginePath: enginePath,
       target: target
     );
+    if (result != 0)
+      return result;
   }
 
   if (stop) {


### PR DESCRIPTION
- make some ADB device names more readable
- for `flutter devices`, fallback on just using `adb` if we can locate that but not a full android sdk
- listen to result codes when building apks; fail the build appropriately
- fix an issue where a `README.md` file in the android/res directory would confuse the android tools; instead, use `.empty`
- convert some places where we failed with exception stacktraces to cleaner error messages
- fix an issue where we didn't listen to ios simulator logs the very first time that simulator was run (when trying to tail a non-existent file)
