### PR TITLE
Simplify the AutoLayout API

### DIFF
--- a/examples/layers/rendering/autolayout.dart
+++ b/examples/layers/rendering/autolayout.dart
@@ -14,33 +14,33 @@ class _MyAutoLayoutDelegate extends AutoLayoutDelegate {
   AutoLayoutParams p3 = new AutoLayoutParams();
   AutoLayoutParams p4 = new AutoLayoutParams();
 
-  List<al.Constraint> getConstraints(AutoLayoutParams parentParams) {
+  List<al.Constraint> getConstraints(AutoLayoutParams parent) {
     return <al.Constraint>[
       // Sum of widths of each box must be equal to that of the container
-      (p1.width + p2.width + p3.width == parentParams.width) as al.Constraint,
+      parent.width.equals(p1.width + p2.width + p3.width),
 
       // The boxes must be stacked left to right
-      p1.rightEdge <= p2.leftEdge,
-      p2.rightEdge <= p3.leftEdge,
+      p1.right <= p2.left,
+      p2.right <= p3.left,
 
       // The widths of the first and the third boxes should be equal
-      (p1.width == p3.width) as al.Constraint,
+      p1.width.equals(p3.width),
 
       // The width of the second box should be twice as much as that of the first
       // and third
-      (p2.width * al.cm(2.0) == p1.width) as al.Constraint,
+      p1.width.equals(p2.width * al.cm(2.0)),
 
       // The height of the three boxes should be equal to that of the container
-      (p1.height == p2.height) as al.Constraint,
-      (p2.height == p3.height) as al.Constraint,
-      (p3.height == parentParams.height) as al.Constraint,
+      p1.height.equals(p2.height),
+      p2.height.equals(p3.height),
+      p3.height.equals(parent.height),
 
       // The fourth box should be half as wide as the second and must be attached
       // to the right edge of the same (by its center)
-      (p4.width == p2.width / al.cm(2.0)) as al.Constraint,
-      (p4.height == al.cm(50.0)) as al.Constraint,
-      (p4.horizontalCenter == p2.rightEdge) as al.Constraint,
-      (p4.verticalCenter == p2.height / al.cm(2.0)) as al.Constraint,
+      p4.width.equals(p2.width / al.cm(2.0)),
+      p4.height.equals(al.cm(50.0)),
+      p4.horizontalCenter.equals(p2.right),
+      p4.verticalCenter.equals(p2.height / al.cm(2.0)),
     ];
   }
 

--- a/examples/layers/rendering/autolayout.dart
+++ b/examples/layers/rendering/autolayout.dart
@@ -9,12 +9,12 @@ import 'package:cassowary/cassowary.dart' as al;
 import 'package:flutter/rendering.dart';
 
 class _MyAutoLayoutDelegate extends AutoLayoutDelegate {
-  AutoLayoutParams p1 = new AutoLayoutParams();
-  AutoLayoutParams p2 = new AutoLayoutParams();
-  AutoLayoutParams p3 = new AutoLayoutParams();
-  AutoLayoutParams p4 = new AutoLayoutParams();
+  AutoLayoutRect p1 = new AutoLayoutRect();
+  AutoLayoutRect p2 = new AutoLayoutRect();
+  AutoLayoutRect p3 = new AutoLayoutRect();
+  AutoLayoutRect p4 = new AutoLayoutRect();
 
-  List<al.Constraint> getConstraints(AutoLayoutParams parent) {
+  List<al.Constraint> getConstraints(AutoLayoutRect parent) {
     return <al.Constraint>[
       // Sum of widths of each box must be equal to that of the container
       parent.width.equals(p1.width + p2.width + p3.width),
@@ -76,10 +76,10 @@ void main() {
   AutoLayoutParentData parentData3 = c3.parentData;
   AutoLayoutParentData parentData4 = c4.parentData;
 
-  parentData1.params = delegate.p1;
-  parentData2.params = delegate.p2;
-  parentData3.params = delegate.p3;
-  parentData4.params = delegate.p4;
+  parentData1.rect = delegate.p1;
+  parentData2.rect = delegate.p2;
+  parentData3.rect = delegate.p3;
+  parentData4.rect = delegate.p4;
 
   new RenderingFlutterBinding(root: root);
 }

--- a/examples/layers/widgets/autolayout.dart
+++ b/examples/layers/widgets/autolayout.dart
@@ -8,12 +8,12 @@ import 'package:cassowary/cassowary.dart' as al;
 import 'package:flutter/widgets.dart';
 
 class _MyAutoLayoutDelegate extends AutoLayoutDelegate {
-  AutoLayoutParams p1 = new AutoLayoutParams();
-  AutoLayoutParams p2 = new AutoLayoutParams();
-  AutoLayoutParams p3 = new AutoLayoutParams();
-  AutoLayoutParams p4 = new AutoLayoutParams();
+  AutoLayoutRect p1 = new AutoLayoutRect();
+  AutoLayoutRect p2 = new AutoLayoutRect();
+  AutoLayoutRect p3 = new AutoLayoutRect();
+  AutoLayoutRect p4 = new AutoLayoutRect();
 
-  List<al.Constraint> getConstraints(AutoLayoutParams parent) {
+  List<al.Constraint> getConstraints(AutoLayoutRect parent) {
     return <al.Constraint>[
       // Sum of widths of each box must be equal to that of the container
       parent.width.equals(p1.width + p2.width + p3.width),
@@ -58,25 +58,25 @@ class _ColoredBoxesState extends State<ColoredBoxes> {
       delegate: delegate,
       children: <Widget>[
         new AutoLayoutChild(
-          params: delegate.p1,
+          rect: delegate.p1,
           child: new DecoratedBox(
             decoration: new BoxDecoration(backgroundColor: const Color(0xFFFF0000))
           )
         ),
         new AutoLayoutChild(
-          params: delegate.p2,
+          rect: delegate.p2,
           child: new DecoratedBox(
             decoration: new BoxDecoration(backgroundColor: const Color(0xFF00FF00))
           )
         ),
         new AutoLayoutChild(
-          params: delegate.p3,
+          rect: delegate.p3,
           child: new DecoratedBox(
             decoration: new BoxDecoration(backgroundColor: const Color(0xFF0000FF))
           )
         ),
         new AutoLayoutChild(
-          params: delegate.p4,
+          rect: delegate.p4,
           child: new DecoratedBox(
             decoration: new BoxDecoration(backgroundColor: const Color(0xFFFFFFFF))
           )

--- a/examples/layers/widgets/autolayout.dart
+++ b/examples/layers/widgets/autolayout.dart
@@ -13,53 +13,37 @@ class _MyAutoLayoutDelegate extends AutoLayoutDelegate {
   AutoLayoutParams p3 = new AutoLayoutParams();
   AutoLayoutParams p4 = new AutoLayoutParams();
 
-  List<al.Constraint> getConstraints(AutoLayoutParams parentParams) {
+  List<al.Constraint> getConstraints(AutoLayoutParams parent) {
     return <al.Constraint>[
       // Sum of widths of each box must be equal to that of the container
-      (p1.width + p2.width + p3.width == parentParams.width) as al.Constraint,
+      parent.width.equals(p1.width + p2.width + p3.width),
 
       // The boxes must be stacked left to right
-      p1.rightEdge <= p2.leftEdge,
-      p2.rightEdge <= p3.leftEdge,
+      p1.right <= p2.left,
+      p2.right <= p3.left,
 
       // The widths of the first and the third boxes should be equal
-      (p1.width == p3.width) as al.Constraint,
+      p1.width.equals(p3.width),
 
       // The width of the second box should be twice as much as that of the first
       // and third
-      (p2.width * al.cm(2.0) == p1.width) as al.Constraint,
+      p1.width.equals(p2.width * al.cm(2.0)),
 
       // The height of the three boxes should be equal to that of the container
-      (p1.height == p2.height) as al.Constraint,
-      (p2.height == p3.height) as al.Constraint,
-      (p3.height == parentParams.height) as al.Constraint,
+      p1.height.equals(p2.height),
+      p2.height.equals(p3.height),
+      p3.height.equals(parent.height),
 
       // The fourth box should be half as wide as the second and must be attached
       // to the right edge of the same (by its center)
-      (p4.width == p2.width / al.cm(2.0)) as al.Constraint,
-      (p4.height == al.cm(50.0)) as al.Constraint,
-      (p4.horizontalCenter == p2.rightEdge) as al.Constraint,
-      (p4.verticalCenter == p2.height / al.cm(2.0)) as al.Constraint,
+      p4.width.equals(p2.width / al.cm(2.0)),
+      p4.height.equals(al.cm(50.0)),
+      p4.horizontalCenter.equals(p2.right),
+      p4.verticalCenter.equals(p2.height / al.cm(2.0)),
     ];
   }
 
-  bool shouldUpdateConstraints(AutoLayoutDelegate oldDelegate) => true;
-}
-
-class ColoredBox extends StatelessComponent {
-  ColoredBox({ Key key, this.params, this.color }) : super(key: key);
-
-  final AutoLayoutParams params;
-  final Color color;
-
-  Widget build(BuildContext context) {
-    return new AutoLayoutChild(
-      params: params,
-      child: new DecoratedBox(
-        decoration: new BoxDecoration(backgroundColor: color)
-      )
-    );
-  }
+  bool shouldUpdateConstraints(_MyAutoLayoutDelegate oldDelegate) => true;
 }
 
 class ColoredBoxes extends StatefulComponent {
@@ -73,10 +57,30 @@ class _ColoredBoxesState extends State<ColoredBoxes> {
     return new AutoLayout(
       delegate: delegate,
       children: <Widget>[
-        new ColoredBox(params: delegate.p1, color: const Color(0xFFFF0000)),
-        new ColoredBox(params: delegate.p2, color: const Color(0xFF00FF00)),
-        new ColoredBox(params: delegate.p3, color: const Color(0xFF0000FF)),
-        new ColoredBox(params: delegate.p4, color: const Color(0xFFFFFFFF)),
+        new AutoLayoutChild(
+          params: delegate.p1,
+          child: new DecoratedBox(
+            decoration: new BoxDecoration(backgroundColor: const Color(0xFFFF0000))
+          )
+        ),
+        new AutoLayoutChild(
+          params: delegate.p2,
+          child: new DecoratedBox(
+            decoration: new BoxDecoration(backgroundColor: const Color(0xFF00FF00))
+          )
+        ),
+        new AutoLayoutChild(
+          params: delegate.p3,
+          child: new DecoratedBox(
+            decoration: new BoxDecoration(backgroundColor: const Color(0xFF0000FF))
+          )
+        ),
+        new AutoLayoutChild(
+          params: delegate.p4,
+          child: new DecoratedBox(
+            decoration: new BoxDecoration(backgroundColor: const Color(0xFFFFFFFF))
+          )
+        ),
       ]
     );
   }

--- a/packages/cassowary/lib/equation_member.dart
+++ b/packages/cassowary/lib/equation_member.dart
@@ -15,7 +15,7 @@ abstract class _EquationMember {
 
   Constraint operator <=(_EquationMember m) => asExpression() <= m;
 
-  operator ==(_EquationMember m) => asExpression() == m;
+  Constraint equals(_EquationMember m) => asExpression().equals(m);
 
   Expression operator +(_EquationMember m) => asExpression() + m;
 

--- a/packages/cassowary/lib/expression.dart
+++ b/packages/cassowary/lib/expression.dart
@@ -57,8 +57,8 @@ class Expression extends _EquationMember {
   Constraint operator <=(_EquationMember value) =>
       _createConstraint(value, Relation.lessThanOrEqualTo);
 
-  operator ==(_EquationMember value) =>
-    _createConstraint(value, Relation.equalTo); // analyzer says "Type check failed" // analyzer says "The return type 'Constraint' is not a 'bool', as defined by the method '=='"
+  Constraint equals(_EquationMember value) =>
+    _createConstraint(value, Relation.equalTo);
 
   Expression operator +(_EquationMember m) {
     if (m is ConstantMember) {

--- a/packages/cassowary/test/cassowary_test.dart
+++ b/packages/cassowary/test/cassowary_test.dart
@@ -243,7 +243,7 @@ void main() {
     expect(c1.expression.constant, -20.0);
     expect(c1.relation, Relation.greaterThanOrEqualTo);
 
-    var c2 = (right - left == cm(30.0)) as Constraint;
+    var c2 = (right - left).equals(cm(30.0));
     expect(c2 is Constraint, true);
     expect(c2.expression.constant, -30.0);
     expect(c2.relation, Relation.equalTo);
@@ -438,7 +438,7 @@ void main() {
 
     Solver s = new Solver();
 
-    expect(s.addConstraint((right + left == mid * cm(2.0)) as Constraint),
+    expect(s.addConstraint((right + left).equals(mid * cm(2.0))),
         Result.success);
     expect(s.addConstraint(right - left >= cm(100.0)), Result.success);
     expect(s.addConstraint(left >= cm(0.0)), Result.success);
@@ -460,7 +460,7 @@ void main() {
     var c = (left >= cm(0.0));
 
     expect(s.addConstraints([
-      (left + right == cm(2.0) * mid) as Constraint,
+      (left + right).equals(cm(2.0) * mid),
       (right - left >= cm(100.0)),
       c
     ]), Result.success);
@@ -476,7 +476,7 @@ void main() {
 
     Solver s = new Solver();
 
-    expect(s.addConstraint((right + left == mid * cm(2.0)) as Constraint),
+    expect(s.addConstraint((right + left).equals(mid * cm(2.0))),
         Result.success);
     expect(s.addConstraint(right - left >= cm(100.0)), Result.success);
     expect(s.addConstraint(left >= cm(0.0)), Result.success);
@@ -496,7 +496,7 @@ void main() {
     var right = new Param(100.0);
     var c1 = right >= left;
     var c2 = right <= left;
-    var c3 = (right == left) as Constraint;
+    var c3 = right.equals(left);
 
     Solver s = new Solver();
     expect(s.addConstraint(c1), Result.success);
@@ -519,9 +519,9 @@ void main() {
     solver.suggestValueForVariable(container.variable, 100.0);
 
     solver.addConstraint((p1 >= cm(30.0)) | Priority.strong);
-    solver.addConstraint(((p1 == p3) as Constraint) | Priority.medium);
-    solver.addConstraint((p2 == cm(2.0) * p1) as Constraint);
-    solver.addConstraint((container == (p1 + p2 + p3)) as Constraint);
+    solver.addConstraint(p1.equals(p3) | Priority.medium);
+    solver.addConstraint(p2.equals(cm(2.0) * p1));
+    solver.addConstraint(container.equals(p1 + p2 + p3));
 
     solver.flushUpdates();
 
@@ -541,7 +541,7 @@ void main() {
 
     expect(s.addEditVariable(mid.variable, Priority.strong), Result.success);
 
-    expect(s.addConstraint((mid * cm(2.0) == left + right) as Constraint),
+    expect(s.addConstraint((mid * cm(2.0)).equals(left + right)),
         Result.success);
     expect(s.addConstraint(left >= cm(0.0)), Result.success);
 
@@ -565,7 +565,7 @@ void main() {
 
     expect(s.addEditVariable(mid.variable, Priority.strong), Result.success);
 
-    expect(s.addConstraint((mid * cm(2.0) == left + right) as Constraint),
+    expect(s.addConstraint((mid * cm(2.0)).equals(left + right)),
         Result.success);
     expect(s.addConstraint(left >= cm(10.0)), Result.success);
 
@@ -590,7 +590,7 @@ void main() {
     Param left = new Param();
     Param right = new Param();
 
-    expect((left == right).runtimeType, Constraint);
+    expect(left.equals(right).runtimeType, Constraint);
   });
 
   test('bulk_add_edit_variables', () {

--- a/packages/flutter/lib/src/widgets/auto_layout.dart
+++ b/packages/flutter/lib/src/widgets/auto_layout.dart
@@ -27,8 +27,8 @@ class AutoLayout extends MultiChildRenderObjectWidget {
 }
 
 class AutoLayoutChild extends ParentDataWidget<AutoLayout> {
-  AutoLayoutChild({ Key key, this.params, Widget child })
-    : super(key: key, child: child);
+  AutoLayoutChild({ AutoLayoutParams params, Widget child })
+    : params = params, super(key: new ObjectKey(params), child: child);
 
   final AutoLayoutParams params;
 

--- a/packages/flutter/lib/src/widgets/auto_layout.dart
+++ b/packages/flutter/lib/src/widgets/auto_layout.dart
@@ -7,7 +7,7 @@ import 'package:flutter/rendering.dart';
 import 'framework.dart';
 
 export 'package:flutter/rendering.dart' show
-    AutoLayoutParams,
+    AutoLayoutRect,
     AutoLayoutDelegate;
 
 class AutoLayout extends MultiChildRenderObjectWidget {
@@ -27,16 +27,16 @@ class AutoLayout extends MultiChildRenderObjectWidget {
 }
 
 class AutoLayoutChild extends ParentDataWidget<AutoLayout> {
-  AutoLayoutChild({ AutoLayoutParams params, Widget child })
-    : params = params, super(key: new ObjectKey(params), child: child);
+  AutoLayoutChild({ AutoLayoutRect rect, Widget child })
+    : rect = rect, super(key: new ObjectKey(rect), child: child);
 
-  final AutoLayoutParams params;
+  final AutoLayoutRect rect;
 
   void applyParentData(RenderObject renderObject) {
     assert(renderObject.parentData is AutoLayoutParentData);
     final AutoLayoutParentData parentData = renderObject.parentData;
     // AutoLayoutParentData filters out redundant writes and marks needs layout
     // as appropriate.
-    parentData.params = params;
+    parentData.rect = rect;
   }
 }


### PR DESCRIPTION
This patch makes it easier to use the auto layout API:
- We no longer use operator== because that requires an ugly cast by the
  API user.
- Also, "leftEdge" is now just "left" for less verbosity.
- AutoLayoutChild not implies its key from the AutoLayoutParam object.
- We now correctly layout every child of a RenderAutoLayout object even
  if the solver doesn't flush any updates to that child.
