### PR TITLE
rename some flutter command references in readmes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,17 +48,17 @@ Running the examples
 
 To run an example with a prebuilt binary from the cloud, switch to that
 example's directory, run `pub get` to make sure its dependencies have been
-downloaded, and use `flutter start`. Make sure you have a device connected over
+downloaded, and use `flutter run`. Make sure you have a device connected over
 USB and debugging enabled on that device.
 
- * `cd examples/hello_world; flutter start`
+ * `cd examples/hello_world; flutter run`
 
 You can also specify a particular Dart file to run if you want to run an example
 that doesn't have a `lib/main.dart` file using the `-t` command-line option. For
 example, to run the `tabs.dart` example in the [examples/widgets](examples/widgets)
 directory on a connected Android device, from that directory you would run:
 
- * `flutter start -t tabs.dart`
+ * `flutter run -t tabs.dart`
 
 When running code from the examples directory, any changes you make to the
 example code, as well as any changes to Dart code in the
@@ -169,7 +169,7 @@ engine using the `flutter test --debug` command. To run one of the
 examples on your device using your locally built engine, use the
 `--debug` option to the `flutter` tool:
 
- * `flutter start --debug`
+ * `flutter run --debug`
 
 If you want to test the release version instead of the debug version,
 use `--release` instead of `--debug`.

--- a/dev/profile_startup.dart
+++ b/dev/profile_startup.dart
@@ -45,7 +45,7 @@ Future<double> test(String tracesDir, String projectPath, int runNumber) async {
   String tracePath = "${tracesDir}/trace_$runNumber.json";
   runWithLoggingSync([
     'flutter',
-    'start',
+    'run',
     '--no-checked',
     '--trace-startup'
   ], workingDirectory: projectPath);
@@ -84,7 +84,7 @@ main(List<String> args) async {
   String traces_dir = '/tmp';
 
   List<double> times = [];
-  print("Profiling startup using flutter start --trace-startup.");
+  print("Profiling startup using flutter run --trace-startup.");
   print("Measuring from first trace event to completion of first frame upload.");
   print("aka NativeViewGLSurfaceEGL:RealSwapBuffers.\n");
   print("NOTE: If device is not on/unlocked tracing may fail.\n");

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,23 +1,23 @@
 Flutter Examples
 ================
 
-This directory contains several examples of using Flutter.  Each of these is an
+This directory contains several examples of using Flutter. Each of these is an
 individual Dart application package.
 
 To run a sample with the `flutter` tool, run `pub get` inside its directory,
-then run `flutter start`. (See the
+then run `flutter run`. (See the
 [getting started guide](https://flutter.io/getting-started/) to install
 the `flutter` tool.)
 
 Available examples include:
 
-- *Hello, world.* The [hello world app](hello_world) is a basic app that shows
+- **Hello, world** The [hello world app](hello_world) is a basic app that shows
    the text "hello, world."
 
-- *Stocks.* The [stocks app](stocks) is an example of a typical mobile app
+- **Stocks** The [stocks app](stocks) is an example of a typical mobile app
    built using Flutter. The app shows a list of all the stocks in the NASDAQ.
 
-- *Widgets.* The [widget apps](widgets) demonstrate a number of Flutter widgets
+- **Widgets** The [widget apps](widgets) demonstrate a number of Flutter widgets
    so you can experiment with them in a simple container. There is no main.dart
    in this directory because each file is a standalone sample. To run a
-   particular file, use `flutter start -t filename.dart`.
+   particular file, use `flutter run -t filename.dart`.

--- a/examples/layers/README.md
+++ b/examples/layers/README.md
@@ -18,5 +18,5 @@ Flutter's layered architecture.
 To run each example, use the `-t` argument to the `flutter` tool:
 
 ```
-flutter start -t widgets/spinning_square.dart
+flutter run -t widgets/spinning_square.dart
 ```

--- a/examples/widgets/README.md
+++ b/examples/widgets/README.md
@@ -4,7 +4,7 @@ Small examples of the Flutter widget framework
 To run these, open a terminal in this directory and use the following command:
 
 ```bash
-flutter start --checked -t foo.dart
+flutter run -t foo.dart
 ```
 
 ...where `foo.dart` is the file you want to run.


### PR DESCRIPTION
`flutter start` ==> `flutter run` in various misc. places
