### PR TITLE
log for specific adb devices

### DIFF
--- a/packages/flutter_tools/lib/src/commands/logs.dart
+++ b/packages/flutter_tools/lib/src/commands/logs.dart
@@ -35,15 +35,15 @@ class LogsCommand extends FlutterCommand {
 
     bool clear = argResults['clear'];
 
-    Set<DeviceLogReader> readers = new Set<DeviceLogReader>();
+    List<DeviceLogReader> readers = new List<DeviceLogReader>();
     for (Device device in devices) {
       readers.add(device.createLogReader());
     }
 
-    printStatus('Showing logs for ${readers.join(', ')}:');
+    printStatus('Showing ${readers.join(', ')} logs:');
 
     List<int> results = await Future.wait(readers.map((DeviceLogReader reader) async {
-      int result = await reader.logs(clear: clear);
+      int result = await reader.logs(clear: clear, showPrefix: devices.length > 1);
       if (result != 0)
         printError('Error listening to $reader logs.');
       return result;

--- a/packages/flutter_tools/lib/src/device.dart
+++ b/packages/flutter_tools/lib/src/device.dart
@@ -189,7 +189,7 @@ abstract class Device {
 abstract class DeviceLogReader {
   String get name;
 
-  Future<int> logs({ bool clear: false });
+  Future<int> logs({ bool clear: false, bool showPrefix: false });
 
   int get hashCode;
   bool operator ==(dynamic other);

--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -232,13 +232,13 @@ class _IOSDeviceLogReader extends DeviceLogReader {
   String get name => device.name;
 
   // TODO(devoncarew): Support [clear].
-  Future<int> logs({ bool clear: false }) async {
+  Future<int> logs({ bool clear: false, bool showPrefix: false }) async {
     if (!device.isConnected())
       return 2;
 
     return await runCommandAndStreamOutput(
       <String>[device.loggerPath],
-      prefix: '[$name] ',
+      prefix: showPrefix ? '[$name] ' : '',
       filter: new RegExp(r'Runner')
     );
   }

--- a/packages/flutter_tools/lib/src/ios/simulators.dart
+++ b/packages/flutter_tools/lib/src/ios/simulators.dart
@@ -410,7 +410,7 @@ class _IOSSimulatorLogReader extends DeviceLogReader {
 
   String get name => device.name;
 
-  Future<int> logs({ bool clear: false }) async {
+  Future<int> logs({ bool clear: false, bool showPrefix: false }) async {
     if (!device.isConnected())
       return 2;
 
@@ -432,7 +432,7 @@ class _IOSSimulatorLogReader extends DeviceLogReader {
 
     Future<int> result = runCommandAndStreamOutput(
       <String>['tail', '-n', '+0', '-F', device.logFilePath],
-      prefix: '[$name] ',
+      prefix: showPrefix ? '[$name] ' : '',
       mapFunction: (String string) {
         Match match = mapRegex.matchAsPrefix(string);
         if (match != null) {
@@ -465,7 +465,7 @@ class _IOSSimulatorLogReader extends DeviceLogReader {
     // ReportCrash[37965]: Saved crash report for FlutterRunner[37941]...
     runCommandAndStreamOutput(
       <String>['tail', '-F', '/private/var/log/system.log'],
-      prefix: '[$name] ',
+      prefix: showPrefix ? '[$name] ' : '',
       filter: new RegExp(r' FlutterRunner\[\d+\] '),
       mapFunction: (String string) {
         Match match = mapRegex.matchAsPrefix(string);


### PR DESCRIPTION
- always pass `adb logcat` the specific android device to log for
- the logging code will only prefix the log output (`[Nexus 5X] ...`) if there is more than one device connected
