### PR TITLE
remove iosSimulator field from ApplicationPackageStore

### DIFF
--- a/packages/flutter_tools/lib/src/application_package.dart
+++ b/packages/flutter_tools/lib/src/application_package.dart
@@ -88,36 +88,32 @@ class IOSApp extends ApplicationPackage {
   }) : super(localPath: iosProjectDir, id: iosProjectBundleId);
 
   factory IOSApp.fromBuildConfiguration(BuildConfiguration config) {
-    if (getCurrentHostPlatform() != HostPlatform.mac) {
+    if (getCurrentHostPlatform() != HostPlatform.mac)
       return null;
-    }
 
     String plistPath = path.join("ios", "Info.plist");
-    String id = plistValueForKey(plistPath, kCFBundleIdentifierKey);
-    if (id == "") {
+    String value = getValueFromFile(plistPath, kCFBundleIdentifierKey);
+    if (value == null)
       return null;
-    }
 
     String projectDir = path.join("ios", ".generated");
-    return new IOSApp(iosProjectDir: projectDir, iosProjectBundleId: id);
+    return new IOSApp(iosProjectDir: projectDir, iosProjectBundleId: value);
   }
 }
 
 class ApplicationPackageStore {
   final AndroidApk android;
   final IOSApp iOS;
-  final IOSApp iOSSimulator;
 
-  ApplicationPackageStore({ this.android, this.iOS, this.iOSSimulator });
+  ApplicationPackageStore({ this.android, this.iOS });
 
   ApplicationPackage getPackageForPlatform(TargetPlatform platform) {
     switch (platform) {
       case TargetPlatform.android:
         return android;
       case TargetPlatform.iOS:
-        return iOS;
       case TargetPlatform.iOSSimulator:
-        return iOSSimulator;
+        return iOS;
       case TargetPlatform.mac:
       case TargetPlatform.linux:
         return null;
@@ -127,7 +123,6 @@ class ApplicationPackageStore {
   static Future<ApplicationPackageStore> forConfigs(List<BuildConfiguration> configs) async {
     AndroidApk android;
     IOSApp iOS;
-    IOSApp iOSSimulator;
 
     for (BuildConfiguration config in configs) {
       switch (config.targetPlatform) {
@@ -150,13 +145,9 @@ class ApplicationPackageStore {
           break;
 
         case TargetPlatform.iOS:
+        case TargetPlatform.iOSSimulator:
           assert(iOS == null);
           iOS = new IOSApp.fromBuildConfiguration(config);
-          break;
-
-        case TargetPlatform.iOSSimulator:
-          assert(iOSSimulator == null);
-          iOSSimulator = new IOSApp.fromBuildConfiguration(config);
           break;
 
         case TargetPlatform.mac:
@@ -165,6 +156,6 @@ class ApplicationPackageStore {
       }
     }
 
-    return new ApplicationPackageStore(android: android, iOS: iOS, iOSSimulator: iOSSimulator);
+    return new ApplicationPackageStore(android: android, iOS: iOS);
   }
 }

--- a/packages/flutter_tools/lib/src/commands/devices.dart
+++ b/packages/flutter_tools/lib/src/commands/devices.dart
@@ -27,11 +27,11 @@ class DevicesCommand extends FlutterCommand {
     if (devices.isEmpty) {
       printStatus('No connected devices.');
     } else {
-      printStatus('${devices.length} connected ${pluralize('device', devices.length)}:');
+      printStatus('${devices.length} connected ${pluralize('device', devices.length)}:\n');
 
       for (Device device in devices) {
-        String supportIndicator = device.isSupported() ? '' : '- unsupported';
-        printStatus('${device.name} (${device.id}) $supportIndicator');
+        String supportIndicator = device.isSupported() ? '' : ' - unsupported';
+        printStatus('${device.name} (${device.id})$supportIndicator');
       }
     }
 

--- a/packages/flutter_tools/lib/src/commands/run.dart
+++ b/packages/flutter_tools/lib/src/commands/run.dart
@@ -170,6 +170,7 @@ Future<int> startApp(
 
   if (install) {
     printTrace('Running install command.');
+    // TODO(devoncarew): This fails for ios devices - we haven't built yet.
     await installApp(devices, applicationPackages);
   }
 

--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -59,9 +59,8 @@ class XCode {
 
   bool _xcodeVersionSatisfactory;
   bool get xcodeVersionSatisfactory {
-    if (_xcodeVersionSatisfactory != null) {
+    if (_xcodeVersionSatisfactory != null)
       return _xcodeVersionSatisfactory;
-    }
 
     try {
       String output = runSync(<String>['xcodebuild', '-version']);

--- a/packages/flutter_tools/lib/src/ios/plist_utils.dart
+++ b/packages/flutter_tools/lib/src/ios/plist_utils.dart
@@ -8,7 +8,7 @@ import '../base/process.dart';
 
 const String kCFBundleIdentifierKey = "CFBundleIdentifier";
 
-String plistValueForKey(String plistFilePath, String plistKey) {
+String getValueFromFile(String plistFilePath, String key) {
   // TODO(chinmaygarde): For now, we only need to read from plist files on a
   // mac host. If this changes, we will need our own Dart plist reader.
 
@@ -18,12 +18,14 @@ String plistValueForKey(String plistFilePath, String plistKey) {
   String normalizedPlistPath = path.withoutExtension(path.absolute(plistFilePath));
 
   try {
-    return runCheckedSync([
+    String value = runCheckedSync(<String>[
       '/usr/bin/defaults',
       'read',
       normalizedPlistPath,
-      plistKey]).trim();
+      key
+    ]).trim();
+    return value.isEmpty ? null : value;
   } catch (error) {
-    return "";
+    return null;
   }
 }

--- a/packages/flutter_tools/test/src/mocks.dart
+++ b/packages/flutter_tools/test/src/mocks.dart
@@ -15,10 +15,11 @@ import 'package:mockito/mockito.dart';
 class MockApplicationPackageStore extends ApplicationPackageStore {
   MockApplicationPackageStore() : super(
     android: new AndroidApk(localPath: '/mock/path/to/android/SkyShell.apk'),
-    iOS: new IOSApp(iosProjectDir: '/mock/path/to/iOS/SkyShell.app',
-                    iosProjectBundleId: 'io.flutter.ios.mock'),
-    iOSSimulator: new IOSApp(iosProjectDir: '/mock/path/to/iOSSimulator/SkyShell.app',
-                             iosProjectBundleId: 'io.flutter.ios.mock'));
+    iOS: new IOSApp(
+      iosProjectDir: '/mock/path/to/iOS/SkyShell.app',
+      iosProjectBundleId: 'io.flutter.ios.mock'
+    )
+  );
 }
 
 class MockCompiler extends Mock implements Compiler {


### PR DESCRIPTION
Remove the `iOSSimulator` field from ApplicationPackageStore. I believe that ios devices and ios simulators share the same `ApplicationPackage` - both point into `ios/.generated`.

@chinmaygarde 
