### PR TITLE
fix a checked mode assertion

### DIFF
--- a/packages/flutter_tools/lib/src/application_package.dart
+++ b/packages/flutter_tools/lib/src/application_package.dart
@@ -146,8 +146,8 @@ class ApplicationPackageStore {
 
         case TargetPlatform.iOS:
         case TargetPlatform.iOSSimulator:
-          assert(iOS == null);
-          iOS = new IOSApp.fromBuildConfiguration(config);
+          if (iOS == null)
+            iOS = new IOSApp.fromBuildConfiguration(config);
           break;
 
         case TargetPlatform.mac:


### PR DESCRIPTION
Fix an assertion (when run in checked mode); it would fire when we had both an ios device and a simulator connected.
