### PR TITLE
"flutter create" can generate a basic driver test; "flutter drive" gains new options

### DIFF
--- a/packages/flutter_tools/lib/src/base/file_system.dart
+++ b/packages/flutter_tools/lib/src/base/file_system.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:io' as dart_io;
 import 'package:file/io.dart';
 import 'package:file/sync_io.dart';
 import 'package:path/path.dart' as path;
@@ -16,16 +17,42 @@ export 'package:file/sync_io.dart';
 FileSystem fs = new LocalFileSystem();
 SyncFileSystem syncFs = new SyncLocalFileSystem();
 
+typedef String CurrentDirectoryGetter();
+
+final CurrentDirectoryGetter _defaultCurrentDirectoryGetter = () {
+  return dart_io.Directory.current.path;
+};
+
+/// Points to the current working directory (like `pwd`).
+CurrentDirectoryGetter getCurrentDirectory = _defaultCurrentDirectoryGetter;
+
+/// Exits the process with the given [exitCode].
+typedef void ExitFunction([int exitCode]);
+
+final ExitFunction _defaultExitFunction = ([int exitCode]) {
+  dart_io.exit(exitCode);
+};
+
+/// Exits the process.
+ExitFunction exit = _defaultExitFunction;
+
 /// Restores [fs] and [syncFs] to the default local disk-based implementation.
 void restoreFileSystem() {
   fs = new LocalFileSystem();
   syncFs = new SyncLocalFileSystem();
+  getCurrentDirectory = _defaultCurrentDirectoryGetter;
+  exit = _defaultExitFunction;
 }
 
-void useInMemoryFileSystem() {
+/// Uses in-memory replacments for `dart:io` functionality. Useful in tests.
+void useInMemoryFileSystem({ cwd: '/', ExitFunction exitFunction }) {
   MemoryFileSystem memFs = new MemoryFileSystem();
   fs = memFs;
   syncFs = new SyncMemoryFileSystem(backedBy: memFs.storage);
+  getCurrentDirectory = () => cwd;
+  exit = exitFunction ?? ([int exitCode]) {
+    throw new Exception('Exited with code $exitCode');
+  };
 }
 
 /// Create the ancestor directories of a file path if they do not already exist.


### PR DESCRIPTION
"flutter create" adds option `--with-driver-test` that adds
dependencies to `flutter_driver` in `pubspec.yaml` and creates
a basic driver test runnable via `flutter drive
--target=test_driver/e2e.dart`

"flutter drive" new options:
- `--keep-app-running` tells the driver to not stop the app after tests
  are done
- `--use-existing-app` tells the driver to not start a new app but use
  an already running instance
