### PR TITLE
add a validator for Atom

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_workflow.dart
+++ b/packages/flutter_tools/lib/src/android/android_workflow.dart
@@ -7,7 +7,7 @@ import '../globals.dart';
 import 'android_sdk.dart';
 
 class AndroidWorkflow extends Workflow {
-  AndroidWorkflow() : super('Android');
+  String get label => 'Android toolchain';
 
   bool get appliesToHostPlatform => true;
 
@@ -17,11 +17,11 @@ class AndroidWorkflow extends Workflow {
 
   ValidationResult validate() {
     Validator androidValidator = new Validator(
-      '$name toolchain',
+      label,
       description: 'develop for Android devices'
     );
 
-    Function _sdkExists = () {
+    ValidationType sdkExists() {
       return androidSdk == null ? ValidationType.missing : ValidationType.installed;
     };
 
@@ -29,7 +29,7 @@ class AndroidWorkflow extends Workflow {
       'Android SDK',
       description: 'enable development for Android devices',
       resolution: 'Download at https://developer.android.com/sdk/',
-      validatorFunction: _sdkExists
+      validatorFunction: sdkExists
     ));
 
     return androidValidator.validate();

--- a/packages/flutter_tools/lib/src/application_package.dart
+++ b/packages/flutter_tools/lib/src/application_package.dart
@@ -146,8 +146,7 @@ class ApplicationPackageStore {
 
         case TargetPlatform.iOS:
         case TargetPlatform.iOSSimulator:
-          if (iOS == null)
-            iOS = new IOSApp.fromBuildConfiguration(config);
+          iOS ??= new IOSApp.fromBuildConfiguration(config);
           break;
 
         case TargetPlatform.mac:

--- a/packages/flutter_tools/lib/src/ios/ios_workflow.dart
+++ b/packages/flutter_tools/lib/src/ios/ios_workflow.dart
@@ -10,7 +10,7 @@ import '../globals.dart';
 import 'mac.dart';
 
 class IOSWorkflow extends Workflow {
-  IOSWorkflow() : super('iOS');
+  String get label => 'iOS toolchain';
 
   bool get appliesToHostPlatform => Platform.isMacOS;
 
@@ -23,33 +23,33 @@ class IOSWorkflow extends Workflow {
 
   ValidationResult validate() {
     Validator iosValidator = new Validator(
-      '$name toolchain',
+      label,
       description: 'develop for iOS devices'
     );
 
-    Function _xcodeExists = () {
+    ValidationType xcodeExists() {
       return xcode.isInstalled ? ValidationType.installed : ValidationType.missing;
     };
 
-    Function _xcodeVersionSatisfactory = () {
+    ValidationType xcodeVersionSatisfactory() {
       return xcode.isInstalledAndMeetsVersionCheck ? ValidationType.installed : ValidationType.missing;
     };
 
-    Function _xcodeEulaSigned = () {
+    ValidationType xcodeEulaSigned() {
       return xcode.eulaSigned ? ValidationType.installed : ValidationType.missing;
     };
 
-    Function _brewExists = () {
+    ValidationType brewExists() {
       return exitsHappy(<String>['brew', '-v'])
         ? ValidationType.installed : ValidationType.missing;
     };
 
-    Function _ideviceinstallerExists = () {
+    ValidationType ideviceinstallerExists() {
       return exitsHappy(<String>['ideviceinstaller', '-h'])
         ? ValidationType.installed : ValidationType.missing;
     };
 
-    Function _iosdeployExists = () {
+    ValidationType iosdeployExists() {
       return hasIdeviceId ? ValidationType.installed : ValidationType.missing;
     };
 
@@ -57,7 +57,7 @@ class IOSWorkflow extends Workflow {
       'XCode',
       description: 'enable development for iOS devices',
       resolution: 'Download at https://developer.apple.com/xcode/download/',
-      validatorFunction: _xcodeExists
+      validatorFunction: xcodeExists
     );
 
     iosValidator.addValidator(xcodeValidator);
@@ -66,21 +66,21 @@ class IOSWorkflow extends Workflow {
       'version',
       description: 'Xcode minimum version of $kXcodeRequiredVersionMajor.$kXcodeRequiredVersionMinor.0',
       resolution: 'Download the latest version or update via the Mac App Store',
-      validatorFunction: _xcodeVersionSatisfactory
+      validatorFunction: xcodeVersionSatisfactory
     ));
 
     xcodeValidator.addValidator(new Validator(
       'EULA',
       description: 'XCode end user license agreement',
       resolution: "Open XCode or run the command 'sudo xcodebuild -license'",
-      validatorFunction: _xcodeEulaSigned
+      validatorFunction: xcodeEulaSigned
     ));
 
     Validator brewValidator = new Validator(
       'brew',
       description: 'install additional development packages',
       resolution: 'Download at http://brew.sh/',
-      validatorFunction: _brewExists
+      validatorFunction: brewExists
     );
 
     iosValidator.addValidator(brewValidator);
@@ -89,14 +89,14 @@ class IOSWorkflow extends Workflow {
       'ideviceinstaller',
       description: 'discover connected iOS devices',
       resolution: "Install via 'brew install ideviceinstaller'",
-      validatorFunction: _ideviceinstallerExists
+      validatorFunction: ideviceinstallerExists
     ));
 
     brewValidator.addValidator(new Validator(
       'ios-deploy',
       description: 'deploy to connected iOS devices',
       resolution: "Install via 'brew install ios-deploy'",
-      validatorFunction: _iosdeployExists
+      validatorFunction: iosdeployExists
     ));
 
     return iosValidator.validate();


### PR DESCRIPTION
- add a doctor validator for Atom (fix https://github.com/flutter/flutter/issues/1982)
- some refactoring to separate those doctor validators that can launch something (Workflows), and are critical to running an app, and those that we just want to print the status of (DoctorValidators)
- address some review comments from previous PRs

```
Flutter root: /Users/devoncarew/projects/flutter/flutter.

[✓] iOS toolchain - develop for iOS devices (installed)
  [✓] XCode - enable development for iOS devices (installed)
    [✓] version - Xcode minimum version of 7.2.0 (installed)
    [✓] EULA - XCode end user license agreement (installed)
  [✓] brew - install additional development packages (installed)
    [✓] ideviceinstaller - discover connected iOS devices (installed)
    [✓] ios-deploy - deploy to connected iOS devices (installed)

[✓] Android toolchain - develop for Android devices (installed)
  [✓] Android SDK - enable development for Android devices (installed)

[✓] Atom development environment - a lightweight development environment for Flutter (installed)
  [✓] Atom editor (installed)
  [✓] Flutter plugin - adds Flutter specific functionality to Atom (installed)

Flutter from https://github.com/flutter/flutter.git (on master)
flutter revision: 3f8fdb661f452d588899a766f414d40dfba9dc4c (12 hours ago)
engine revision : 6e736e7a76600640c5bd854c2fc9ed0f664ee26e
```
