### PR TITLE
Test BottomSheet rebuilding with ScaffoldFeatureController.setState()

### DIFF
--- a/packages/flutter/test/widget/bottom_sheet_rebuild_test.dart
+++ b/packages/flutter/test/widget/bottom_sheet_rebuild_test.dart
@@ -1,0 +1,45 @@
+// Copyright 2015 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter/material.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('Verify that a BottomSheet can be rebuilt with ScaffoldFeatureController.setState()', () {
+    testWidgets((WidgetTester tester) {
+      final GlobalKey<ScaffoldState> scaffoldKey = new GlobalKey<ScaffoldState>();
+      ScaffoldFeatureController bottomSheet;
+      int buildCount = 0;
+
+      tester.pumpWidget(new MaterialApp(
+        routes: <String, RouteBuilder>{
+          '/': (RouteArguments args) {
+            return new Scaffold(
+              key: scaffoldKey,
+              body: new Center(child: new Text('body'))
+            );
+          }
+        }
+      ));
+
+      bottomSheet = scaffoldKey.currentState.showBottomSheet((_) {
+        return new Builder(
+          builder: (_) {
+            buildCount += 1;
+            return new Container(height: 200.0);
+          }
+        );
+      });
+
+      tester.pump();
+      expect(buildCount, equals(1));
+
+      bottomSheet.setState((){ });
+      tester.pump();
+      expect(buildCount, equals(2));
+    });
+  });
+
+}


### PR DESCRIPTION
https://github.com/flutter/flutter/pull/2110 depends on this feature, at least for now.

See also: https://github.com/flutter/flutter/issues/2115
