### PR TITLE
additional validation for device commands

### DIFF
--- a/packages/flutter_tools/lib/src/base/file_system.dart
+++ b/packages/flutter_tools/lib/src/base/file_system.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'dart:io' as dart_io;
+
 import 'package:file/io.dart';
 import 'package:file/sync_io.dart';
 import 'package:path/path.dart' as path;

--- a/packages/flutter_tools/lib/src/commands/drive.dart
+++ b/packages/flutter_tools/lib/src/commands/drive.dart
@@ -83,6 +83,8 @@ class DriveCommand extends RunCommand {
 
   DriveCommand() : this.custom();
 
+  bool get requiresDevice => true;
+
   @override
   Future<int> runInProject() async {
     String testFile = _getTestFile();

--- a/packages/flutter_tools/lib/src/commands/install.dart
+++ b/packages/flutter_tools/lib/src/commands/install.dart
@@ -3,41 +3,29 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:io';
 
 import '../application_package.dart';
 import '../device.dart';
-import '../ios/simulators.dart';
 import '../runner/flutter_command.dart';
 
 class InstallCommand extends FlutterCommand {
   final String name = 'install';
   final String description = 'Install Flutter apps on attached devices.';
 
-  InstallCommand() {
-    argParser.addFlag('boot', help: 'Boot the iOS Simulator if it isn\'t already running.');
-  }
+  bool get requiresDevice => true;
 
   @override
   Future<int> runInProject() async {
     await downloadApplicationPackagesAndConnectToDevices();
-    bool installedAny = await installApp(
-      devices,
-      applicationPackages,
-      boot: argResults['boot']
-    );
+    bool installedAny = await installApp(devices, applicationPackages);
     return installedAny ? 0 : 2;
   }
 }
 
 Future<bool> installApp(
   DeviceStore devices,
-  ApplicationPackageStore applicationPackages, {
-  bool boot: false
-}) async {
-  if (boot && Platform.isMacOS)
-    await SimControl.boot();
-
+  ApplicationPackageStore applicationPackages
+) async {
   bool installedSomewhere = false;
 
   for (Device device in devices.all) {

--- a/packages/flutter_tools/lib/src/commands/listen.dart
+++ b/packages/flutter_tools/lib/src/commands/listen.dart
@@ -22,6 +22,10 @@ class ListenCommand extends RunCommandBase {
 
   ListenCommand({ this.singleRun: false });
 
+  bool get androidOnly => true;
+
+  bool get requiresDevice => true;
+
   @override
   Future<int> runInProject() async {
     await downloadApplicationPackagesAndConnectToDevices();

--- a/packages/flutter_tools/lib/src/commands/logs.dart
+++ b/packages/flutter_tools/lib/src/commands/logs.dart
@@ -22,6 +22,8 @@ class LogsCommand extends FlutterCommand {
 
   bool get requiresProjectRoot => false;
 
+  bool get requiresDevice => true;
+
   Future<int> runInProject() async {
     List<Device> devices = await deviceManager.getDevices();
 

--- a/packages/flutter_tools/lib/src/commands/refresh.dart
+++ b/packages/flutter_tools/lib/src/commands/refresh.dart
@@ -23,6 +23,10 @@ class RefreshCommand extends FlutterCommand {
     );
   }
 
+  bool get androidOnly => true;
+
+  bool get requiresDevice => true;
+
   @override
   Future<int> runInProject() async {
     printTrace('Downloading toolchain.');

--- a/packages/flutter_tools/lib/src/commands/run.dart
+++ b/packages/flutter_tools/lib/src/commands/run.dart
@@ -55,8 +55,7 @@ abstract class RunCommandBase extends FlutterCommand {
 
 class RunCommand extends RunCommandBase {
   final String name = 'run';
-  final String description =
-    'Run your Flutter app on an attached device (defaults to checked/debug mode).';
+  final String description = 'Run your Flutter app on an attached device.';
   final List<String> aliases = <String>['start'];
 
   RunCommand() {
@@ -77,6 +76,8 @@ class RunCommand extends RunCommandBase {
         defaultsTo: observatoryDefaultPort.toString(),
         help: 'Listen to the given port for a debug connection.');
   }
+
+  bool get requiresDevice => true;
 
   @override
   Future<int> run() async {

--- a/packages/flutter_tools/lib/src/commands/test.dart
+++ b/packages/flutter_tools/lib/src/commands/test.dart
@@ -51,12 +51,17 @@ class TestCommand extends FlutterCommand {
   }
 
   TestCommand() {
-    argParser.addFlag('flutter-repo', help: 'Run tests from the \'flutter\' package in the Flutter repository instead of the current directory.', defaultsTo: false);
+    argParser.addFlag(
+      'flutter-repo',
+      help: 'Run tests from the \'flutter\' package in the Flutter repository instead of the current directory.',
+      defaultsTo: false
+    );
   }
 
   Iterable<String> _findTests(Directory directory) {
     return directory.listSync(recursive: true, followLinks: false)
-                    .where((FileSystemEntity entity) => entity.path.endsWith('_test.dart') && FileSystemEntity.isFileSync(entity.path))
+                    .where((FileSystemEntity entity) => entity.path.endsWith('_test.dart') &&
+                      FileSystemEntity.isFileSync(entity.path))
                     .map((FileSystemEntity entity) => path.absolute(entity.path));
   }
 

--- a/packages/flutter_tools/lib/src/commands/trace.dart
+++ b/packages/flutter_tools/lib/src/commands/trace.dart
@@ -25,6 +25,10 @@ class TraceCommand extends FlutterCommand {
         defaultsTo: '10', abbr: 'd', help: 'Duration in seconds to trace.');
   }
 
+  bool get androidOnly => true;
+
+  bool get requiresDevice => true;
+
   @override
   Future<int> runInProject() async {
     await downloadApplicationPackagesAndConnectToDevices();

--- a/packages/flutter_tools/lib/src/doctor.dart
+++ b/packages/flutter_tools/lib/src/doctor.dart
@@ -39,7 +39,9 @@ class Doctor {
 
   List<DoctorValidator> _validators = <DoctorValidator>[];
 
-  Iterable<Workflow> get workflows => _validators.where((DoctorValidator validator) => validator is Workflow);
+  List<Workflow> get workflows {
+    return new List<Workflow>.from(_validators.where((DoctorValidator validator) => validator is Workflow));
+  }
 
   /// Print a summary of the state of the tooling, as well as how to get more info.
   void summary() => printStatus(summaryText);

--- a/packages/flutter_tools/test/daemon_test.dart
+++ b/packages/flutter_tools/test/daemon_test.dart
@@ -8,12 +8,14 @@ import 'dart:io';
 import 'package:flutter_tools/src/base/context.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/commands/daemon.dart';
+import 'package:flutter_tools/src/device.dart';
 import 'package:flutter_tools/src/doctor.dart';
 import 'package:flutter_tools/src/globals.dart';
 import 'package:flutter_tools/src/ios/mac.dart';
 import 'package:mockito/mockito.dart';
 import 'package:test/test.dart';
 
+import 'src/context.dart';
 import 'src/mocks.dart';
 
 main() => defineTests();
@@ -37,6 +39,7 @@ defineTests() {
       appContext[Doctor] = new Doctor();
       if (Platform.isMacOS)
         appContext[XCode] = new XCode();
+      appContext[DeviceManager] = new MockDeviceManager();
     });
 
     tearDown(() {

--- a/packages/flutter_tools/test/install_test.dart
+++ b/packages/flutter_tools/test/install_test.dart
@@ -31,6 +31,8 @@ defineTests() {
       when(mockDevices.iOSSimulator.isAppInstalled(any)).thenReturn(false);
       when(mockDevices.iOSSimulator.installApp(any)).thenReturn(false);
 
+      testDeviceManager.addDevice(mockDevices.android);
+
       return createTestCommandRunner(command).run(['install']).then((int code) {
         expect(code, equals(0));
       });
@@ -52,6 +54,8 @@ defineTests() {
       when(mockDevices.iOSSimulator.isConnected()).thenReturn(false);
       when(mockDevices.iOSSimulator.isAppInstalled(any)).thenReturn(false);
       when(mockDevices.iOSSimulator.installApp(any)).thenReturn(false);
+
+      testDeviceManager.addDevice(mockDevices.iOS);
 
       return createTestCommandRunner(command).run(['install']).then((int code) {
         expect(code, equals(0));

--- a/packages/flutter_tools/test/listen_test.dart
+++ b/packages/flutter_tools/test/listen_test.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import 'package:flutter_tools/src/commands/listen.dart';
-import 'package:mockito/mockito.dart';
 import 'package:test/test.dart';
 
 import 'src/common.dart';
@@ -14,17 +13,11 @@ main() => defineTests();
 
 defineTests() {
   group('listen', () {
-    testUsingContext('returns 0 when no device is connected', () {
+    testUsingContext('returns 1 when no device is connected', () {
       ListenCommand command = new ListenCommand(singleRun: true);
-      applyMocksToCommand(command);
-      MockDeviceStore mockDevices = command.devices;
-
-      when(mockDevices.android.isConnected()).thenReturn(false);
-      when(mockDevices.iOS.isConnected()).thenReturn(false);
-      when(mockDevices.iOSSimulator.isConnected()).thenReturn(false);
-
+      applyMocksToCommand(command, noDevices: true);
       return createTestCommandRunner(command).run(['listen']).then((int code) {
-        expect(code, equals(0));
+        expect(code, equals(1));
       });
     });
   });

--- a/packages/flutter_tools/test/src/mocks.dart
+++ b/packages/flutter_tools/test/src/mocks.dart
@@ -12,6 +12,8 @@ import 'package:flutter_tools/src/runner/flutter_command.dart';
 import 'package:flutter_tools/src/toolchain.dart';
 import 'package:mockito/mockito.dart';
 
+import 'context.dart';
+
 class MockApplicationPackageStore extends ApplicationPackageStore {
   MockApplicationPackageStore() : super(
     android: new AndroidApk(localPath: '/mock/path/to/android/SkyShell.apk'),
@@ -31,14 +33,17 @@ class MockToolchain extends Toolchain {
 
 class MockAndroidDevice extends Mock implements AndroidDevice {
   TargetPlatform get platform => TargetPlatform.android;
+  bool isSupported() => true;
 }
 
 class MockIOSDevice extends Mock implements IOSDevice {
   TargetPlatform get platform => TargetPlatform.iOS;
+  bool isSupported() => true;
 }
 
 class MockIOSSimulator extends Mock implements IOSSimulator {
   TargetPlatform get platform => TargetPlatform.iOSSimulator;
+  bool isSupported() => true;
 }
 
 class MockDeviceStore extends DeviceStore {
@@ -48,10 +53,13 @@ class MockDeviceStore extends DeviceStore {
     iOSSimulator: new MockIOSSimulator());
 }
 
-void applyMocksToCommand(FlutterCommand command) {
+void applyMocksToCommand(FlutterCommand command, { bool noDevices: false }) {
   command
     ..applicationPackages = new MockApplicationPackageStore()
     ..toolchain = new MockToolchain()
     ..devices = new MockDeviceStore()
     ..projectRootValidator = () => true;
+
+  if (!noDevices)
+    testDeviceManager.addDevice(command.devices.android);
 }


### PR DESCRIPTION
- a command can now specify whether it requires devices present to work
- the parent `FlutterCommand` validates that there is a connected, supported device for those commands

also, remove the `--boot` option from `install`
