### PR TITLE
Don't give children negative sizes when overconstrained

### DIFF
--- a/packages/flutter/lib/src/rendering/flex.dart
+++ b/packages/flutter/lib/src/rendering/flex.dart
@@ -197,11 +197,11 @@ class RenderFlex extends RenderBox with ContainerRenderObjectMixin<RenderBox, Fl
       BoxConstraints childConstraints;
       switch(_direction) {
         case FlexDirection.horizontal:
-          childConstraints = new BoxConstraints(maxWidth: constraints.maxWidth);
+          childConstraints = new BoxConstraints(maxHeight: constraints.maxHeight);
           availableMainSpace = constraints.maxWidth;
           break;
         case FlexDirection.vertical:
-          childConstraints = new BoxConstraints(maxHeight: constraints.maxHeight);
+          childConstraints = new BoxConstraints(maxWidth: constraints.maxWidth);
           availableMainSpace = constraints.maxHeight;
           break;
       }
@@ -239,7 +239,9 @@ class RenderFlex extends RenderBox with ContainerRenderObjectMixin<RenderBox, Fl
       }
 
       // Determine the spacePerFlex by allocating the remaining available space
-      double spacePerFlex = (availableMainSpace - inflexibleSpace) / totalFlex;
+      // When you're overconstrained spacePerFlex can be negative.
+      double spacePerFlex = math.max(0.0,
+          (availableMainSpace - inflexibleSpace) / totalFlex);
 
       // Size remaining items, find the maximum cross size
       child = firstChild;

--- a/packages/flutter/test/rendering/flex_test.dart
+++ b/packages/flutter/test/rendering/flex_test.dart
@@ -19,6 +19,65 @@ void main() {
     expect(flex.size.height, equals(200.0), reason: "flex height");
   });
 
+  test('Vertical Overflow', () {
+    RenderConstrainedBox flexible = new RenderConstrainedBox(
+      additionalConstraints: const BoxConstraints.expand()
+    );
+    RenderFlex flex = new RenderFlex(
+      direction: FlexDirection.vertical,
+      children: <RenderBox>[
+        new RenderConstrainedBox(additionalConstraints: new BoxConstraints.tightFor(height: 200.0)),
+        flexible,
+      ]
+    );
+    FlexParentData flexParentData = flexible.parentData;
+    flexParentData.flex = 1;
+    BoxConstraints viewport = new BoxConstraints(maxHeight: 100.0, maxWidth: 100.0);
+    layout(flex, constraints: viewport);
+    expect(flexible.size.height, equals(0.0));
+    expect(flex.getMinIntrinsicHeight(viewport), equals(100.0));
+    expect(flex.getMaxIntrinsicHeight(viewport), equals(100.0));
+    expect(flex.getMinIntrinsicWidth(viewport), equals(100.0));
+    expect(flex.getMaxIntrinsicWidth(viewport), equals(100.0));
+  });
+
+  test('Horizontal Overflow', () {
+    RenderConstrainedBox flexible = new RenderConstrainedBox(
+      additionalConstraints: const BoxConstraints.expand()
+    );
+    RenderFlex flex = new RenderFlex(
+      direction: FlexDirection.horizontal,
+      children: <RenderBox>[
+        new RenderConstrainedBox(additionalConstraints: new BoxConstraints.tightFor(width: 200.0)),
+        flexible,
+      ]
+    );
+    FlexParentData flexParentData = flexible.parentData;
+    flexParentData.flex = 1;
+    BoxConstraints viewport = new BoxConstraints(maxHeight: 100.0, maxWidth: 100.0);
+    layout(flex, constraints: viewport);
+    expect(flexible.size.width, equals(0.0));
+    expect(flex.getMinIntrinsicHeight(viewport), equals(100.0));
+    expect(flex.getMaxIntrinsicHeight(viewport), equals(100.0));
+    expect(flex.getMinIntrinsicWidth(viewport), equals(100.0));
+    expect(flex.getMaxIntrinsicWidth(viewport), equals(100.0));
+  });
+
+  test('Vertical Flipped Constraints', () {
+    RenderFlex flex = new RenderFlex(
+      direction: FlexDirection.vertical,
+      children: <RenderBox>[
+        new RenderAspectRatio(aspectRatio: 1.0),
+      ]
+    );
+    BoxConstraints viewport = new BoxConstraints(maxHeight: 200.0, maxWidth: 1000.0);
+    layout(flex, constraints: viewport);
+    expect(flex.getMaxIntrinsicWidth(viewport) , equals(1000.0));
+  });
+
+  // We can't right a horizontal version of the above test due to
+  // RenderAspectRatio being height-in, width-out.
+
   test('Defaults', () {
     RenderFlex flex = new RenderFlex();
     expect(flex.alignItems, equals(FlexAlignItems.center));


### PR DESCRIPTION
We probably need a test here. Not sure how.  @Hixie 
The game was hitting this when in landscape mode.  @vlidholt 
