### PR TITLE
run flutter doctor as part of create

### DIFF
--- a/packages/flutter_tools/lib/src/commands/create.dart
+++ b/packages/flutter_tools/lib/src/commands/create.dart
@@ -80,13 +80,6 @@ class CreateCommand extends Command {
 
     printStatus('');
 
-    String message = '''
-All done! To run your application:
-
-  \$ cd ${projectDir.path}
-  \$ flutter run
-''';
-
     if (argResults['pub']) {
       int code = await pubGet(directory: projectDir.path);
       if (code != 0)
@@ -94,7 +87,32 @@ All done! To run your application:
     }
 
     printStatus('');
-    printStatus(message);
+
+    // Run doctor; tell the user the next steps.
+    if (doctor.canLaunchAnything) {
+      // Let them know a summary of the state of their tooling.
+      doctor.summary();
+
+      printStatus('''
+All done! In order to run your application, type:
+
+  \$ cd ${projectDir.path}
+  \$ flutter run
+''');
+    } else {
+      printStatus("You'll need to install additional components before you can run "
+        "your Flutter app:");
+      printStatus('');
+
+      // Give the user more detailed analysis.
+      doctor.diagnose();
+      printStatus('');
+      printStatus("After installing components, run 'flutter doctor' in order to "
+        "re-validate your setup.");
+      printStatus("When complete, type 'flutter run' from the '${projectDir.path}' "
+        "directory in order to launch your app.");
+    }
+
     return 0;
   }
 
@@ -105,7 +123,7 @@ All done! To run your application:
     String projectIdentifier = _createProjectIdentifier(path.basename(dirPath));
     String relativeFlutterPackagesDirectory = path.relative(flutterPackagesDirectory, from: dirPath);
 
-    printStatus('Creating ${path.basename(projectName)}...');
+    printStatus('Creating project ${path.basename(projectName)}:');
 
     projectDir.createSync(recursive: true);
 
@@ -117,7 +135,7 @@ All done! To run your application:
     };
 
     if (renderDriverTest)
-      templateContext['withDriverTest?'] = {};
+      templateContext['withDriverTest?'] = <String, dynamic>{};
 
     Template createTemplate = new Template.fromName('create');
     createTemplate.render(new Directory(dirPath), templateContext,

--- a/packages/flutter_tools/lib/src/dart/pub.dart
+++ b/packages/flutter_tools/lib/src/dart/pub.dart
@@ -29,7 +29,7 @@ Future<int> pubGet({
   }
 
   if (!pubSpecLock.existsSync() || pubSpecYaml.lastModifiedSync().isAfter(pubSpecLock.lastModifiedSync())) {
-    printStatus("Running 'pub get' in '$directory'...");
+    printStatus("Running 'pub get' in $directory${Platform.pathSeparator}...");
     int code = await runCommandAndStreamOutput(
       <String>[sdkBinaryName('pub'), '--verbosity=warning', 'get'],
       workingDirectory: directory

--- a/packages/flutter_tools/lib/src/template.dart
+++ b/packages/flutter_tools/lib/src/template.dart
@@ -38,8 +38,7 @@ class Template {
       return;
     }
 
-    List<FileSystemEntity> templateFiles =
-        templateSource.listSync(recursive: true);
+    List<FileSystemEntity> templateFiles = templateSource.listSync(recursive: true);
 
     for (FileSystemEntity entity in templateFiles) {
       if (entity is! File) {
@@ -67,8 +66,7 @@ class Template {
 
     String destinationDirPath = destination.absolute.path;
 
-    _templateFilePaths.forEach((String relativeDestPath,
-        String absoluteSrcPath) {
+    _templateFilePaths.forEach((String relativeDestPath, String absoluteSrcPath) {
       String finalDestinationPath = path
           .join(destinationDirPath, relativeDestPath)
           .replaceAll(_kCopyTemplateExtension, '')
@@ -83,14 +81,14 @@ class Template {
       if (finalDestinationFile.existsSync()) {
         if (overwriteExisting) {
           finalDestinationFile.delete(recursive: true);
-          printStatus('$relativePathForLogging exists. Overwriting.');
+          printStatus('  $relativePathForLogging (overwritten)');
         } else {
           // The file exists but we cannot overwrite it, move on.
-          printStatus('$relativePathForLogging exists. Skipping.');
+          printStatus('  $relativePathForLogging (existing - skipped)');
           return;
         }
       } else {
-        printStatus('$relativePathForLogging created.');
+        printStatus('  $relativePathForLogging');
       }
 
       finalDestinationFile.createSync(recursive: true);


### PR DESCRIPTION
- run flutter doctor as part of create (fix https://github.com/flutter/flutter/issues/1964)
- make the output of create a bit more terse (we have started creating a lot of files)

Output for an install w/ either an ios or android toolchain installed:

```
Creating project foo_bar...
32 files created.

Running 'pub get' in 'foo_bar'...

[✓] The iOS toolchain is fully installed.
[✓] The Android toolchain is fully installed.
[✓] The Atom development environment is fully installed.

All done! In order to run your application, type:

  $ cd foo_bar
  $ flutter run
```

Output of an install w/o a working toolchain:

```
Creating project foo_bar...
32 files created.

Running 'pub get' in 'foo_bar'...

You'll need to install additional components before you can run your Flutter app:

[✓] iOS toolchain - develop for iOS devices (installed)
  [✓] XCode - enable development for iOS devices (installed)
    [✓] version - Xcode minimum version of 7.2.0 (installed)
    [✓] EULA - XCode end user license agreement (installed)
  [✓] brew - install additional development packages (installed)
    [✓] ideviceinstaller - discover connected iOS devices (installed)
    [✓] ios-deploy - deploy to connected iOS devices (installed)

[✓] Android toolchain - develop for Android devices (installed)
  [✓] Android SDK - enable development for Android devices (installed)

[✓] Atom development environment - a lightweight development environment for Flutter (installed)
  [✓] Atom editor (installed)
  [✓] Flutter plugin - adds Flutter specific functionality to Atom (installed)

After installing components, you can run 'flutter doctor' in order to valid your setup.
```
