### PR TITLE
Remove PointerRouter and GestureArena arguments

### DIFF
--- a/packages/flutter/lib/src/gestures/drag.dart
+++ b/packages/flutter/lib/src/gestures/drag.dart
@@ -32,17 +32,6 @@ bool _isFlingGesture(Velocity velocity) {
 }
 
 abstract class _DragGestureRecognizer<T extends dynamic> extends OneSequenceGestureRecognizer {
-  _DragGestureRecognizer({
-    PointerRouter router,
-    GestureArena gestureArena,
-    this.onStart,
-    this.onUpdate,
-    this.onEnd
-  }) : super(
-    router: router,
-    gestureArena: gestureArena
-  );
-
   GestureDragStartCallback onStart;
   _GesturePolymorphicUpdateCallback<T> onUpdate;
   GestureDragEndCallback onEnd;
@@ -126,20 +115,6 @@ abstract class _DragGestureRecognizer<T extends dynamic> extends OneSequenceGest
 }
 
 class VerticalDragGestureRecognizer extends _DragGestureRecognizer<double> {
-  VerticalDragGestureRecognizer({
-    PointerRouter router,
-    GestureArena gestureArena,
-    GestureDragStartCallback onStart,
-    GestureDragUpdateCallback onUpdate,
-    GestureDragEndCallback onEnd
-  }) : super(
-    router: router,
-    gestureArena: gestureArena,
-    onStart: onStart,
-    onUpdate: onUpdate,
-    onEnd: onEnd
-  );
-
   double get _initialPendingDragDelta => 0.0;
   double _getDragDelta(PointerEvent event) => event.delta.dy;
   bool get _hasSufficientPendingDragDeltaToAccept => _pendingDragDelta.abs() > kTouchSlop;
@@ -148,20 +123,6 @@ class VerticalDragGestureRecognizer extends _DragGestureRecognizer<double> {
 }
 
 class HorizontalDragGestureRecognizer extends _DragGestureRecognizer<double> {
-  HorizontalDragGestureRecognizer({
-    PointerRouter router,
-    GestureArena gestureArena,
-    GestureDragStartCallback onStart,
-    GestureDragUpdateCallback onUpdate,
-    GestureDragEndCallback onEnd
-  }) : super(
-    router: router,
-    gestureArena: gestureArena,
-    onStart: onStart,
-    onUpdate: onUpdate,
-    onEnd: onEnd
-  );
-
   double get _initialPendingDragDelta => 0.0;
   double _getDragDelta(PointerEvent event) => event.delta.dx;
   bool get _hasSufficientPendingDragDeltaToAccept => _pendingDragDelta.abs() > kTouchSlop;
@@ -170,20 +131,6 @@ class HorizontalDragGestureRecognizer extends _DragGestureRecognizer<double> {
 }
 
 class PanGestureRecognizer extends _DragGestureRecognizer<Offset> {
-  PanGestureRecognizer({
-    PointerRouter router,
-    GestureArena gestureArena,
-    GesturePanStartCallback onStart,
-    GesturePanUpdateCallback onUpdate,
-    GesturePanEndCallback onEnd
-  }) : super(
-    router: router,
-    gestureArena: gestureArena,
-    onStart: onStart,
-    onUpdate: onUpdate,
-    onEnd: onEnd
-  );
-
   Offset get _initialPendingDragDelta => Offset.zero;
   Offset _getDragDelta(PointerEvent event) => event.delta;
   bool get _hasSufficientPendingDragDeltaToAccept {

--- a/packages/flutter/lib/src/gestures/long_press.dart
+++ b/packages/flutter/lib/src/gestures/long_press.dart
@@ -5,22 +5,13 @@
 import 'arena.dart';
 import 'constants.dart';
 import 'events.dart';
-import 'pointer_router.dart';
 import 'recognizer.dart';
 
 typedef void GestureLongPressCallback();
 
 /// The user has pressed down at this location for a long period of time.
 class LongPressGestureRecognizer extends PrimaryPointerGestureRecognizer {
-  LongPressGestureRecognizer({
-    PointerRouter router,
-    GestureArena gestureArena,
-    this.onLongPress
-  }) : super(
-    router: router,
-    gestureArena: gestureArena,
-    deadline: kLongPressTimeout
-  );
+  LongPressGestureRecognizer() : super(deadline: kLongPressTimeout);
 
   GestureLongPressCallback onLongPress;
 

--- a/packages/flutter/lib/src/gestures/multidrag.dart
+++ b/packages/flutter/lib/src/gestures/multidrag.dart
@@ -6,9 +6,9 @@ import 'dart:async';
 import 'dart:ui' show Point, Offset;
 
 import 'arena.dart';
+import 'binding.dart';
 import 'constants.dart';
 import 'events.dart';
-import 'pointer_router.dart';
 import 'recognizer.dart';
 import 'velocity_tracker.dart';
 
@@ -121,18 +121,6 @@ abstract class MultiDragPointerState {
 }
 
 abstract class MultiDragGestureRecognizer<T extends MultiDragPointerState> extends GestureRecognizer {
-
-  MultiDragGestureRecognizer({
-    PointerRouter pointerRouter,
-    GestureArena gestureArena,
-    this.onStart
-  }) : _pointerRouter = pointerRouter, _gestureArena = gestureArena {
-    assert(pointerRouter != null);
-    assert(gestureArena != null);
-  }
-
-  final PointerRouter _pointerRouter;
-  final GestureArena _gestureArena;
   GestureMultiDragStartCallback onStart;
 
   Map<int, T> _pointers = <int, T>{};
@@ -144,8 +132,8 @@ abstract class MultiDragGestureRecognizer<T extends MultiDragPointerState> exten
     assert(!_pointers.containsKey(event.pointer));
     T state = createNewPointerState(event);
     _pointers[event.pointer] = state;
-    _pointerRouter.addRoute(event.pointer, handleEvent);
-    state._setArenaEntry(_gestureArena.add(event.pointer, this));
+    Gesturer.instance.pointerRouter.addRoute(event.pointer, handleEvent);
+    state._setArenaEntry(Gesturer.instance.gestureArena.add(event.pointer, this));
   }
 
   T createNewPointerState(PointerDownEvent event);
@@ -211,7 +199,7 @@ abstract class MultiDragGestureRecognizer<T extends MultiDragPointerState> exten
   void _removeState(int pointer) {
     assert(_pointers != null);
     assert(_pointers.containsKey(pointer));
-    _pointerRouter.removeRoute(pointer, handleEvent);
+    Gesturer.instance.pointerRouter.removeRoute(pointer, handleEvent);
     _pointers[pointer].dispose();
     _pointers.remove(pointer);
   }
@@ -241,12 +229,6 @@ class _ImmediatePointerState extends MultiDragPointerState {
 }
 
 class ImmediateMultiDragGestureRecognizer extends MultiDragGestureRecognizer<_ImmediatePointerState> {
-  ImmediateMultiDragGestureRecognizer({
-    PointerRouter pointerRouter,
-    GestureArena gestureArena,
-    GestureMultiDragStartCallback onStart
-  }) : super(pointerRouter: pointerRouter, gestureArena: gestureArena, onStart: onStart);
-
   _ImmediatePointerState createNewPointerState(PointerDownEvent event) {
     return new _ImmediatePointerState(event.position);
   }
@@ -270,12 +252,6 @@ class _HorizontalPointerState extends MultiDragPointerState {
 }
 
 class HorizontalMultiDragGestureRecognizer extends MultiDragGestureRecognizer<_HorizontalPointerState> {
-  HorizontalMultiDragGestureRecognizer({
-    PointerRouter pointerRouter,
-    GestureArena gestureArena,
-    GestureMultiDragStartCallback onStart
-  }) : super(pointerRouter: pointerRouter, gestureArena: gestureArena, onStart: onStart);
-
   _HorizontalPointerState createNewPointerState(PointerDownEvent event) {
     return new _HorizontalPointerState(event.position);
   }
@@ -299,12 +275,6 @@ class _VerticalPointerState extends MultiDragPointerState {
 }
 
 class VerticalMultiDragGestureRecognizer extends MultiDragGestureRecognizer<_VerticalPointerState> {
-  VerticalMultiDragGestureRecognizer({
-    PointerRouter pointerRouter,
-    GestureArena gestureArena,
-    GestureMultiDragStartCallback onStart
-  }) : super(pointerRouter: pointerRouter, gestureArena: gestureArena, onStart: onStart);
-
   _VerticalPointerState createNewPointerState(PointerDownEvent event) {
     return new _VerticalPointerState(event.position);
   }
@@ -360,12 +330,8 @@ class _DelayedPointerState extends MultiDragPointerState {
 
 class DelayedMultiDragGestureRecognizer extends MultiDragGestureRecognizer<_DelayedPointerState> {
   DelayedMultiDragGestureRecognizer({
-    PointerRouter pointerRouter,
-    GestureArena gestureArena,
-    GestureMultiDragStartCallback onStart,
     Duration delay: kLongPressTimeout
-  }) : _delay = delay,
-       super(pointerRouter: pointerRouter, gestureArena: gestureArena, onStart: onStart) {
+  }) : _delay = delay {
     assert(delay != null);
   }
 

--- a/packages/flutter/lib/src/gestures/recognizer.dart
+++ b/packages/flutter/lib/src/gestures/recognizer.dart
@@ -7,6 +7,7 @@ import 'dart:collection';
 import 'dart:ui' show Point, Offset;
 
 import 'arena.dart';
+import 'binding.dart';
 import 'constants.dart';
 import 'events.dart';
 import 'pointer_router.dart';
@@ -56,18 +57,6 @@ abstract class GestureRecognizer extends GestureArenaMember {
 /// which manages each pointer independently and can consider multiple
 /// simultaneous touches to each result in a separate tap.
 abstract class OneSequenceGestureRecognizer extends GestureRecognizer {
-  OneSequenceGestureRecognizer({
-    PointerRouter router,
-    GestureArena gestureArena
-  }) : _router = router,
-       _gestureArena = gestureArena {
-    assert(_router != null);
-    assert(_gestureArena != null);
-  }
-
-  PointerRouter _router;
-  GestureArena _gestureArena;
-
   final List<GestureArenaEntry> _entries = <GestureArenaEntry>[];
   final Set<int> _trackedPointers = new HashSet<int>();
 
@@ -86,21 +75,19 @@ abstract class OneSequenceGestureRecognizer extends GestureRecognizer {
   void dispose() {
     resolve(GestureDisposition.rejected);
     for (int pointer in _trackedPointers)
-      _router.removeRoute(pointer, handleEvent);
+      Gesturer.instance.pointerRouter.removeRoute(pointer, handleEvent);
     _trackedPointers.clear();
     assert(_entries.isEmpty);
-    _router = null;
-    _gestureArena = null;
   }
 
   void startTrackingPointer(int pointer) {
-    _router.addRoute(pointer, handleEvent);
+    Gesturer.instance.pointerRouter.addRoute(pointer, handleEvent);
     _trackedPointers.add(pointer);
-    _entries.add(_gestureArena.add(pointer, this));
+    _entries.add(Gesturer.instance.gestureArena.add(pointer, this));
   }
 
   void stopTrackingPointer(int pointer) {
-    _router.removeRoute(pointer, handleEvent);
+    Gesturer.instance.pointerRouter.removeRoute(pointer, handleEvent);
     _trackedPointers.remove(pointer);
     if (_trackedPointers.isEmpty)
       didStopTrackingLastPointer(pointer);
@@ -120,14 +107,7 @@ enum GestureRecognizerState {
 }
 
 abstract class PrimaryPointerGestureRecognizer extends OneSequenceGestureRecognizer {
-  PrimaryPointerGestureRecognizer({
-    PointerRouter router,
-    GestureArena gestureArena,
-    this.deadline
-  }) : super(
-    router: router,
-    gestureArena: gestureArena
-  );
+  PrimaryPointerGestureRecognizer({ this.deadline });
 
   final Duration deadline;
 

--- a/packages/flutter/lib/src/gestures/scale.dart
+++ b/packages/flutter/lib/src/gestures/scale.dart
@@ -19,17 +19,6 @@ typedef void GestureScaleUpdateCallback(double scale, Point focalPoint);
 typedef void GestureScaleEndCallback();
 
 class ScaleGestureRecognizer extends OneSequenceGestureRecognizer {
-  ScaleGestureRecognizer({
-    PointerRouter router,
-    GestureArena gestureArena,
-    this.onStart,
-    this.onUpdate,
-    this.onEnd
-  }) : super(
-    router: router,
-    gestureArena: gestureArena
-  );
-
   GestureScaleStartCallback onStart;
   GestureScaleUpdateCallback onUpdate;
   GestureScaleEndCallback onEnd;

--- a/packages/flutter/lib/src/gestures/tap.dart
+++ b/packages/flutter/lib/src/gestures/tap.dart
@@ -5,7 +5,6 @@
 import 'arena.dart';
 import 'constants.dart';
 import 'events.dart';
-import 'pointer_router.dart';
 import 'recognizer.dart';
 
 typedef void GestureTapDownCallback(Point globalPosition);
@@ -17,18 +16,7 @@ typedef void GestureTapCancelCallback();
 /// pointer per gesture. That is, during tap recognition, extra pointer events
 /// are ignored: down-1, down-2, up-1, up-2 produces only one tap on up-1.
 class TapGestureRecognizer extends PrimaryPointerGestureRecognizer {
-  TapGestureRecognizer({
-    PointerRouter router,
-    GestureArena gestureArena,
-    this.onTapDown,
-    this.onTapUp,
-    this.onTap,
-    this.onTapCancel
-  }) : super(
-    router: router,
-    gestureArena: gestureArena,
-    deadline: kPressTimeout
-  );
+  TapGestureRecognizer() : super(deadline: kPressTimeout);
 
   GestureTapDownCallback onTapDown;
   GestureTapUpCallback onTapUp;

--- a/packages/flutter/lib/src/material/slider.dart
+++ b/packages/flutter/lib/src/material/slider.dart
@@ -84,7 +84,7 @@ class _RenderSlider extends RenderConstrainedBox {
        _activeColor = activeColor,
         super(additionalConstraints: const BoxConstraints.tightFor(width: _kTrackWidth + 2 * _kReactionRadius, height: 2 * _kReactionRadius)) {
     assert(value != null && value >= 0.0 && value <= 1.0);
-    _drag = new HorizontalDragGestureRecognizer(router: Gesturer.instance.pointerRouter, gestureArena: Gesturer.instance.gestureArena)
+    _drag = new HorizontalDragGestureRecognizer()
       ..onStart = _handleDragStart
       ..onUpdate = _handleDragUpdate
       ..onEnd = _handleDragEnd;

--- a/packages/flutter/lib/src/material/switch.dart
+++ b/packages/flutter/lib/src/material/switch.dart
@@ -112,7 +112,7 @@ class _RenderSwitch extends RenderToggleable {
    ) {
     _activeTrackColor = activeTrackColor;
     _inactiveTrackColor = inactiveTrackColor;
-    _drag = new HorizontalDragGestureRecognizer(router: Gesturer.instance.pointerRouter, gestureArena: Gesturer.instance.gestureArena)
+    _drag = new HorizontalDragGestureRecognizer()
       ..onStart = _handleDragStart
       ..onUpdate = _handleDragUpdate
       ..onEnd = _handleDragEnd;

--- a/packages/flutter/lib/src/material/toggleable.dart
+++ b/packages/flutter/lib/src/material/toggleable.dart
@@ -30,7 +30,7 @@ abstract class RenderToggleable extends RenderConstrainedBox implements Semantic
     assert(value != null);
     assert(activeColor != null);
     assert(inactiveColor != null);
-    _tap = new TapGestureRecognizer(router: Gesturer.instance.pointerRouter, gestureArena: Gesturer.instance.gestureArena)
+    _tap = new TapGestureRecognizer()
       ..onTapDown = _handleTapDown
       ..onTap = _handleTap
       ..onTapUp = _handleTapUp

--- a/packages/flutter/lib/src/rendering/editable_line.dart
+++ b/packages/flutter/lib/src/rendering/editable_line.dart
@@ -39,7 +39,7 @@ class RenderEditableLine extends RenderBox {
       ..maxWidth = double.INFINITY
       ..minHeight = 0.0
       ..maxHeight = double.INFINITY;
-    _tap = new TapGestureRecognizer(router: Gesturer.instance.pointerRouter, gestureArena: Gesturer.instance.gestureArena)
+    _tap = new TapGestureRecognizer()
       ..onTapDown = _handleTapDown
       ..onTap = _handleTap
       ..onTapCancel = _handleTapCancel;

--- a/packages/flutter/lib/src/widgets/drag_target.dart
+++ b/packages/flutter/lib/src/widgets/drag_target.dart
@@ -82,7 +82,7 @@ abstract class DraggableBase<T> extends StatefulComponent {
 
   /// Should return a new MultiDragGestureRecognizer instance
   /// constructed with the given arguments.
-  MultiDragGestureRecognizer createRecognizer(PointerRouter router, GestureArena arena, GestureMultiDragStartCallback starter);
+  MultiDragGestureRecognizer createRecognizer(GestureMultiDragStartCallback onStart);
 
   _DraggableState<T> createState() => new _DraggableState<T>();
 }
@@ -109,12 +109,8 @@ class Draggable<T> extends DraggableBase<T> {
     maxSimultaneousDrags: maxSimultaneousDrags
   );
 
-  MultiDragGestureRecognizer createRecognizer(PointerRouter router, GestureArena arena, GestureMultiDragStartCallback starter) {
-    return new ImmediateMultiDragGestureRecognizer(
-      pointerRouter: router,
-      gestureArena: arena,
-      onStart: starter
-    );
+  MultiDragGestureRecognizer createRecognizer(GestureMultiDragStartCallback onStart) {
+    return new ImmediateMultiDragGestureRecognizer()..onStart = onStart;
   }
 }
 
@@ -141,12 +137,8 @@ class HorizontalDraggable<T> extends DraggableBase<T> {
     maxSimultaneousDrags: maxSimultaneousDrags
   );
 
-  MultiDragGestureRecognizer createRecognizer(PointerRouter router, GestureArena arena, GestureMultiDragStartCallback starter) {
-    return new HorizontalMultiDragGestureRecognizer(
-      pointerRouter: router,
-      gestureArena: arena,
-      onStart: starter
-    );
+  MultiDragGestureRecognizer createRecognizer(GestureMultiDragStartCallback onStart) {
+    return new HorizontalMultiDragGestureRecognizer()..onStart = onStart;
   }
 }
 
@@ -173,12 +165,8 @@ class VerticalDraggable<T> extends DraggableBase<T> {
     maxSimultaneousDrags: maxSimultaneousDrags
   );
 
-  MultiDragGestureRecognizer createRecognizer(PointerRouter router, GestureArena arena, GestureMultiDragStartCallback starter) {
-    return new VerticalMultiDragGestureRecognizer(
-      pointerRouter: router,
-      gestureArena: arena,
-      onStart: starter
-    );
+  MultiDragGestureRecognizer createRecognizer(GestureMultiDragStartCallback onStart) {
+    return new VerticalMultiDragGestureRecognizer()..onStart = onStart;
   }
 }
 
@@ -204,18 +192,14 @@ class LongPressDraggable<T> extends DraggableBase<T> {
     maxSimultaneousDrags: maxSimultaneousDrags
   );
 
-  MultiDragGestureRecognizer createRecognizer(PointerRouter router, GestureArena arena, GestureMultiDragStartCallback starter) {
-    return new DelayedMultiDragGestureRecognizer(
-      pointerRouter: router,
-      gestureArena: arena,
-      delay: kLongPressTimeout,
-      onStart: (Point position) {
-        Drag result = starter(position);
+  MultiDragGestureRecognizer createRecognizer(GestureMultiDragStartCallback onStart) {
+    return new DelayedMultiDragGestureRecognizer()
+      ..onStart = (Point position) {
+        Drag result = onStart(position);
         if (result != null)
           userFeedback.performHapticFeedback(HapticFeedbackType.virtualKey);
         return result;
-      }
-    );
+      };
   }
 }
 
@@ -223,11 +207,7 @@ class _DraggableState<T> extends State<DraggableBase<T>> {
 
   void initState() {
     super.initState();
-    _recognizer = config.createRecognizer(
-      Gesturer.instance.pointerRouter,
-      Gesturer.instance.gestureArena,
-      _startDrag
-    );
+    _recognizer = config.createRecognizer(_startDrag);
   }
 
   GestureRecognizer _recognizer;

--- a/packages/flutter/lib/src/widgets/gesture_detector.dart
+++ b/packages/flutter/lib/src/widgets/gesture_detector.dart
@@ -28,7 +28,7 @@ export 'package:flutter/gestures.dart' show
   GestureScaleEndCallback,
   Velocity;
 
-typedef GestureRecognizer GestureRecognizerFactory(GestureRecognizer recognizer, PointerRouter router, GestureArena arena);
+typedef GestureRecognizer GestureRecognizerFactory(GestureRecognizer recognizer);
 
 /// A widget that detects gestures.
 ///
@@ -152,8 +152,8 @@ class GestureDetector extends StatelessComponent {
     Map<Type, GestureRecognizerFactory> gestures = <Type, GestureRecognizerFactory>{};
 
     if (onTapDown != null || onTapUp != null || onTap != null || onTapCancel != null) {
-      gestures[TapGestureRecognizer] = (TapGestureRecognizer recognizer, PointerRouter router, GestureArena arena) {
-        return (recognizer ??= new TapGestureRecognizer(router: router, gestureArena: arena))
+      gestures[TapGestureRecognizer] = (TapGestureRecognizer recognizer) {
+        return (recognizer ??= new TapGestureRecognizer())
           ..onTapDown = onTapDown
           ..onTapUp = onTapUp
           ..onTap = onTap
@@ -162,22 +162,22 @@ class GestureDetector extends StatelessComponent {
     }
 
     if (onDoubleTap != null) {
-      gestures[DoubleTapGestureRecognizer] = (DoubleTapGestureRecognizer recognizer, PointerRouter router, GestureArena arena) {
-        return (recognizer ??= new DoubleTapGestureRecognizer(router: router, gestureArena: arena))
+      gestures[DoubleTapGestureRecognizer] = (DoubleTapGestureRecognizer recognizer) {
+        return (recognizer ??= new DoubleTapGestureRecognizer())
           ..onDoubleTap = onDoubleTap;
       };
     }
 
     if (onLongPress != null) {
-      gestures[LongPressGestureRecognizer] = (LongPressGestureRecognizer recognizer, PointerRouter router, GestureArena arena) {
-        return (recognizer ??= new LongPressGestureRecognizer(router: router, gestureArena: arena))
+      gestures[LongPressGestureRecognizer] = (LongPressGestureRecognizer recognizer) {
+        return (recognizer ??= new LongPressGestureRecognizer())
           ..onLongPress = onLongPress;
       };
     }
 
     if (onVerticalDragStart != null || onVerticalDragUpdate != null || onVerticalDragEnd != null) {
-      gestures[VerticalDragGestureRecognizer] = (VerticalDragGestureRecognizer recognizer, PointerRouter router, GestureArena arena) {
-        return (recognizer ??= new VerticalDragGestureRecognizer(router: router, gestureArena: arena))
+      gestures[VerticalDragGestureRecognizer] = (VerticalDragGestureRecognizer recognizer) {
+        return (recognizer ??= new VerticalDragGestureRecognizer())
           ..onStart = onVerticalDragStart
           ..onUpdate = onVerticalDragUpdate
           ..onEnd = onVerticalDragEnd;
@@ -185,8 +185,8 @@ class GestureDetector extends StatelessComponent {
     }
 
     if (onHorizontalDragStart != null || onHorizontalDragUpdate != null || onHorizontalDragEnd != null) {
-      gestures[HorizontalDragGestureRecognizer] = (HorizontalDragGestureRecognizer recognizer, PointerRouter router, GestureArena arena) {
-        return (recognizer ??= new HorizontalDragGestureRecognizer(router: router, gestureArena: arena))
+      gestures[HorizontalDragGestureRecognizer] = (HorizontalDragGestureRecognizer recognizer) {
+        return (recognizer ??= new HorizontalDragGestureRecognizer())
           ..onStart = onHorizontalDragStart
           ..onUpdate = onHorizontalDragUpdate
           ..onEnd = onHorizontalDragEnd;
@@ -194,8 +194,8 @@ class GestureDetector extends StatelessComponent {
     }
 
     if (onPanStart != null || onPanUpdate != null || onPanEnd != null) {
-      gestures[PanGestureRecognizer] = (PanGestureRecognizer recognizer, PointerRouter router, GestureArena arena) {
-        return (recognizer ??= new PanGestureRecognizer(router: router, gestureArena: arena))
+      gestures[PanGestureRecognizer] = (PanGestureRecognizer recognizer) {
+        return (recognizer ??= new PanGestureRecognizer())
           ..onStart = onPanStart
           ..onUpdate = onPanUpdate
           ..onEnd = onPanEnd;
@@ -203,14 +203,14 @@ class GestureDetector extends StatelessComponent {
     }
 
     if (onScaleStart != null || onScaleUpdate != null || onScaleEnd != null) {
-      gestures[ScaleGestureRecognizer] = (ScaleGestureRecognizer recognizer, PointerRouter router, GestureArena arena) {
-        return (recognizer ??= new ScaleGestureRecognizer(router: router, gestureArena: arena))
+      gestures[ScaleGestureRecognizer] = (ScaleGestureRecognizer recognizer) {
+        return (recognizer ??= new ScaleGestureRecognizer())
           ..onStart = onScaleStart
           ..onUpdate = onScaleUpdate
           ..onEnd = onScaleEnd;
       };
     }
-    
+
     return new RawGestureDetector(
       gestures: gestures,
       behavior: behavior,
@@ -314,14 +314,12 @@ class RawGestureDetectorState extends State<RawGestureDetector> {
   }
 
   void _syncAll(Map<Type, GestureRecognizerFactory> gestures) {
-    final PointerRouter pointerRouter = Gesturer.instance.pointerRouter;
-    final GestureArena gestureArena = Gesturer.instance.gestureArena;
     assert(_recognizers != null);
     Map<Type, GestureRecognizer> oldRecognizers = _recognizers;
     _recognizers = <Type, GestureRecognizer>{};
     for (Type type in gestures.keys) {
       assert(!_recognizers.containsKey(type));
-      _recognizers[type] = gestures[type](oldRecognizers[type], pointerRouter, gestureArena);
+      _recognizers[type] = gestures[type](oldRecognizers[type]);
       assert(_recognizers[type].runtimeType == type);
     }
     for (Type type in oldRecognizers.keys) {

--- a/packages/flutter/test/gestures/double_tap_test.dart
+++ b/packages/flutter/test/gestures/double_tap_test.dart
@@ -6,6 +6,8 @@ import 'package:flutter/gestures.dart';
 import 'package:quiver/testing/async.dart';
 import 'package:test/test.dart';
 
+import 'gesture_tester.dart';
+
 class TestGestureArenaMember extends GestureArenaMember {
   void acceptGesture(Object key) {
     accepted = true;
@@ -18,6 +20,7 @@ class TestGestureArenaMember extends GestureArenaMember {
 }
 
 void main() {
+  setUp(ensureGesturer);
 
   // Down/up pair 1: normal tap sequence
   const PointerDownEvent down1 = const PointerDownEvent(
@@ -80,12 +83,7 @@ void main() {
   );
 
   test('Should recognize double tap', () {
-    PointerRouter router = new PointerRouter();
-    GestureArena gestureArena = new GestureArena();
-    DoubleTapGestureRecognizer tap = new DoubleTapGestureRecognizer(
-      router: router,
-      gestureArena: gestureArena
-    );
+    DoubleTapGestureRecognizer tap = new DoubleTapGestureRecognizer();
 
     bool doubleTapRecognized = false;
     tap.onDoubleTap = () {
@@ -93,37 +91,32 @@ void main() {
     };
 
     tap.addPointer(down1);
-    gestureArena.close(1);
+    Gesturer.instance.gestureArena.close(1);
     expect(doubleTapRecognized, isFalse);
-    router.route(down1);
+    Gesturer.instance.pointerRouter.route(down1);
     expect(doubleTapRecognized, isFalse);
 
-    router.route(up1);
+    Gesturer.instance.pointerRouter.route(up1);
     expect(doubleTapRecognized, isFalse);
-    gestureArena.sweep(1);
+    Gesturer.instance.gestureArena.sweep(1);
     expect(doubleTapRecognized, isFalse);
 
     tap.addPointer(down2);
-    gestureArena.close(2);
+    Gesturer.instance.gestureArena.close(2);
     expect(doubleTapRecognized, isFalse);
-    router.route(down2);
+    Gesturer.instance.pointerRouter.route(down2);
     expect(doubleTapRecognized, isFalse);
 
-    router.route(up2);
+    Gesturer.instance.pointerRouter.route(up2);
     expect(doubleTapRecognized, isTrue);
-    gestureArena.sweep(2);
+    Gesturer.instance.gestureArena.sweep(2);
     expect(doubleTapRecognized, isTrue);
 
     tap.dispose();
   });
 
   test('Inter-tap distance cancels double tap', () {
-    PointerRouter router = new PointerRouter();
-    GestureArena gestureArena = new GestureArena();
-    DoubleTapGestureRecognizer tap = new DoubleTapGestureRecognizer(
-      router: router,
-      gestureArena: gestureArena
-    );
+    DoubleTapGestureRecognizer tap = new DoubleTapGestureRecognizer();
 
     bool doubleTapRecognized = false;
     tap.onDoubleTap = () {
@@ -131,37 +124,32 @@ void main() {
     };
 
     tap.addPointer(down1);
-    gestureArena.close(1);
+    Gesturer.instance.gestureArena.close(1);
     expect(doubleTapRecognized, isFalse);
-    router.route(down1);
+    Gesturer.instance.pointerRouter.route(down1);
     expect(doubleTapRecognized, isFalse);
 
-    router.route(up1);
+    Gesturer.instance.pointerRouter.route(up1);
     expect(doubleTapRecognized, isFalse);
-    gestureArena.sweep(1);
+    Gesturer.instance.gestureArena.sweep(1);
     expect(doubleTapRecognized, isFalse);
 
     tap.addPointer(down3);
-    gestureArena.close(3);
+    Gesturer.instance.gestureArena.close(3);
     expect(doubleTapRecognized, isFalse);
-    router.route(down3);
+    Gesturer.instance.pointerRouter.route(down3);
     expect(doubleTapRecognized, isFalse);
 
-    router.route(up3);
+    Gesturer.instance.pointerRouter.route(up3);
     expect(doubleTapRecognized, isFalse);
-    gestureArena.sweep(3);
+    Gesturer.instance.gestureArena.sweep(3);
     expect(doubleTapRecognized, isFalse);
 
     tap.dispose();
   });
 
   test('Intra-tap distance cancels double tap', () {
-    PointerRouter router = new PointerRouter();
-    GestureArena gestureArena = new GestureArena();
-    DoubleTapGestureRecognizer tap = new DoubleTapGestureRecognizer(
-      router: router,
-      gestureArena: gestureArena
-    );
+    DoubleTapGestureRecognizer tap = new DoubleTapGestureRecognizer();
 
     bool doubleTapRecognized = false;
     tap.onDoubleTap = () {
@@ -169,39 +157,34 @@ void main() {
     };
 
     tap.addPointer(down4);
-    gestureArena.close(4);
+    Gesturer.instance.gestureArena.close(4);
     expect(doubleTapRecognized, isFalse);
-    router.route(down4);
+    Gesturer.instance.pointerRouter.route(down4);
     expect(doubleTapRecognized, isFalse);
 
-    router.route(move4);
+    Gesturer.instance.pointerRouter.route(move4);
     expect(doubleTapRecognized, isFalse);
-    router.route(up4);
+    Gesturer.instance.pointerRouter.route(up4);
     expect(doubleTapRecognized, isFalse);
-    gestureArena.sweep(4);
+    Gesturer.instance.gestureArena.sweep(4);
     expect(doubleTapRecognized, isFalse);
 
     tap.addPointer(down1);
-    gestureArena.close(1);
+    Gesturer.instance.gestureArena.close(1);
     expect(doubleTapRecognized, isFalse);
-    router.route(down2);
+    Gesturer.instance.pointerRouter.route(down2);
     expect(doubleTapRecognized, isFalse);
 
-    router.route(up1);
+    Gesturer.instance.pointerRouter.route(up1);
     expect(doubleTapRecognized, isFalse);
-    gestureArena.sweep(1);
+    Gesturer.instance.gestureArena.sweep(1);
     expect(doubleTapRecognized, isFalse);
 
     tap.dispose();
   });
 
   test('Inter-tap delay cancels double tap', () {
-    PointerRouter router = new PointerRouter();
-    GestureArena gestureArena = new GestureArena();
-    DoubleTapGestureRecognizer tap = new DoubleTapGestureRecognizer(
-      router: router,
-      gestureArena: gestureArena
-    );
+    DoubleTapGestureRecognizer tap = new DoubleTapGestureRecognizer();
 
     bool doubleTapRecognized = false;
     tap.onDoubleTap = () {
@@ -210,26 +193,26 @@ void main() {
 
     new FakeAsync().run((FakeAsync async) {
       tap.addPointer(down1);
-      gestureArena.close(1);
+      Gesturer.instance.gestureArena.close(1);
       expect(doubleTapRecognized, isFalse);
-      router.route(down1);
+      Gesturer.instance.pointerRouter.route(down1);
       expect(doubleTapRecognized, isFalse);
 
-      router.route(up1);
+      Gesturer.instance.pointerRouter.route(up1);
       expect(doubleTapRecognized, isFalse);
-      gestureArena.sweep(1);
+      Gesturer.instance.gestureArena.sweep(1);
       expect(doubleTapRecognized, isFalse);
 
       async.elapse(new Duration(milliseconds: 5000));
       tap.addPointer(down2);
-      gestureArena.close(2);
+      Gesturer.instance.gestureArena.close(2);
       expect(doubleTapRecognized, isFalse);
-      router.route(down2);
+      Gesturer.instance.pointerRouter.route(down2);
       expect(doubleTapRecognized, isFalse);
 
-      router.route(up2);
+      Gesturer.instance.pointerRouter.route(up2);
       expect(doubleTapRecognized, isFalse);
-      gestureArena.sweep(2);
+      Gesturer.instance.gestureArena.sweep(2);
       expect(doubleTapRecognized, isFalse);
     });
 
@@ -237,12 +220,7 @@ void main() {
   });
 
   test('Inter-tap delay resets double tap, allowing third tap to be a double-tap', () {
-    PointerRouter router = new PointerRouter();
-    GestureArena gestureArena = new GestureArena();
-    DoubleTapGestureRecognizer tap = new DoubleTapGestureRecognizer(
-      router: router,
-      gestureArena: gestureArena
-    );
+    DoubleTapGestureRecognizer tap = new DoubleTapGestureRecognizer();
 
     bool doubleTapRecognized = false;
     tap.onDoubleTap = () {
@@ -251,38 +229,38 @@ void main() {
 
     new FakeAsync().run((FakeAsync async) {
       tap.addPointer(down1);
-      gestureArena.close(1);
+      Gesturer.instance.gestureArena.close(1);
       expect(doubleTapRecognized, isFalse);
-      router.route(down1);
+      Gesturer.instance.pointerRouter.route(down1);
       expect(doubleTapRecognized, isFalse);
 
-      router.route(up1);
+      Gesturer.instance.pointerRouter.route(up1);
       expect(doubleTapRecognized, isFalse);
-      gestureArena.sweep(1);
+      Gesturer.instance.gestureArena.sweep(1);
       expect(doubleTapRecognized, isFalse);
 
       async.elapse(new Duration(milliseconds: 5000));
       tap.addPointer(down2);
-      gestureArena.close(2);
+      Gesturer.instance.gestureArena.close(2);
       expect(doubleTapRecognized, isFalse);
-      router.route(down2);
+      Gesturer.instance.pointerRouter.route(down2);
       expect(doubleTapRecognized, isFalse);
 
-      router.route(up2);
+      Gesturer.instance.pointerRouter.route(up2);
       expect(doubleTapRecognized, isFalse);
-      gestureArena.sweep(2);
+      Gesturer.instance.gestureArena.sweep(2);
       expect(doubleTapRecognized, isFalse);
 
       async.elapse(new Duration(milliseconds: 100));
       tap.addPointer(down5);
-      gestureArena.close(5);
+      Gesturer.instance.gestureArena.close(5);
       expect(doubleTapRecognized, isFalse);
-      router.route(down5);
+      Gesturer.instance.pointerRouter.route(down5);
       expect(doubleTapRecognized, isFalse);
 
-      router.route(up5);
+      Gesturer.instance.pointerRouter.route(up5);
       expect(doubleTapRecognized, isTrue);
-      gestureArena.sweep(5);
+      Gesturer.instance.gestureArena.sweep(5);
       expect(doubleTapRecognized, isTrue);
     });
 
@@ -290,12 +268,7 @@ void main() {
   });
 
   test('Intra-tap delay does not cancel double tap', () {
-    PointerRouter router = new PointerRouter();
-    GestureArena gestureArena = new GestureArena();
-    DoubleTapGestureRecognizer tap = new DoubleTapGestureRecognizer(
-      router: router,
-      gestureArena: gestureArena
-    );
+    DoubleTapGestureRecognizer tap = new DoubleTapGestureRecognizer();
 
     bool doubleTapRecognized = false;
     tap.onDoubleTap = () {
@@ -304,26 +277,26 @@ void main() {
 
     new FakeAsync().run((FakeAsync async) {
       tap.addPointer(down1);
-      gestureArena.close(1);
+      Gesturer.instance.gestureArena.close(1);
       expect(doubleTapRecognized, isFalse);
-      router.route(down1);
+      Gesturer.instance.pointerRouter.route(down1);
       expect(doubleTapRecognized, isFalse);
 
       async.elapse(new Duration(milliseconds: 1000));
-      router.route(up1);
+      Gesturer.instance.pointerRouter.route(up1);
       expect(doubleTapRecognized, isFalse);
-      gestureArena.sweep(1);
+      Gesturer.instance.gestureArena.sweep(1);
       expect(doubleTapRecognized, isFalse);
 
       tap.addPointer(down2);
-      gestureArena.close(2);
+      Gesturer.instance.gestureArena.close(2);
       expect(doubleTapRecognized, isFalse);
-      router.route(down2);
+      Gesturer.instance.pointerRouter.route(down2);
       expect(doubleTapRecognized, isFalse);
 
-      router.route(up2);
+      Gesturer.instance.pointerRouter.route(up2);
       expect(doubleTapRecognized, isTrue);
-      gestureArena.sweep(2);
+      Gesturer.instance.gestureArena.sweep(2);
       expect(doubleTapRecognized, isTrue);
     });
 
@@ -331,12 +304,7 @@ void main() {
   });
 
   test('Should not recognize two overlapping taps', () {
-    PointerRouter router = new PointerRouter();
-    GestureArena gestureArena = new GestureArena();
-    DoubleTapGestureRecognizer tap = new DoubleTapGestureRecognizer(
-      router: router,
-      gestureArena: gestureArena
-    );
+    DoubleTapGestureRecognizer tap = new DoubleTapGestureRecognizer();
 
     bool doubleTapRecognized = false;
     tap.onDoubleTap = () {
@@ -344,37 +312,32 @@ void main() {
     };
 
     tap.addPointer(down1);
-    gestureArena.close(1);
+    Gesturer.instance.gestureArena.close(1);
     expect(doubleTapRecognized, isFalse);
-    router.route(down1);
+    Gesturer.instance.pointerRouter.route(down1);
     expect(doubleTapRecognized, isFalse);
 
     tap.addPointer(down2);
-    gestureArena.close(2);
+    Gesturer.instance.gestureArena.close(2);
     expect(doubleTapRecognized, isFalse);
-    router.route(down1);
-    expect(doubleTapRecognized, isFalse);
-
-    router.route(up1);
-    expect(doubleTapRecognized, isFalse);
-    gestureArena.sweep(1);
+    Gesturer.instance.pointerRouter.route(down1);
     expect(doubleTapRecognized, isFalse);
 
-    router.route(up2);
+    Gesturer.instance.pointerRouter.route(up1);
     expect(doubleTapRecognized, isFalse);
-    gestureArena.sweep(2);
+    Gesturer.instance.gestureArena.sweep(1);
+    expect(doubleTapRecognized, isFalse);
+
+    Gesturer.instance.pointerRouter.route(up2);
+    expect(doubleTapRecognized, isFalse);
+    Gesturer.instance.gestureArena.sweep(2);
     expect(doubleTapRecognized, isFalse);
 
     tap.dispose();
   });
 
   test('Should recognize one tap of group followed by second tap', () {
-    PointerRouter router = new PointerRouter();
-    GestureArena gestureArena = new GestureArena();
-    DoubleTapGestureRecognizer tap = new DoubleTapGestureRecognizer(
-      router: router,
-      gestureArena: gestureArena
-    );
+    DoubleTapGestureRecognizer tap = new DoubleTapGestureRecognizer();
 
     bool doubleTapRecognized = false;
     tap.onDoubleTap = () {
@@ -382,36 +345,36 @@ void main() {
     };
 
     tap.addPointer(down1);
-    gestureArena.close(1);
+    Gesturer.instance.gestureArena.close(1);
     expect(doubleTapRecognized, isFalse);
-    router.route(down1);
+    Gesturer.instance.pointerRouter.route(down1);
     expect(doubleTapRecognized, isFalse);
 
     tap.addPointer(down2);
-    gestureArena.close(2);
+    Gesturer.instance.gestureArena.close(2);
     expect(doubleTapRecognized, isFalse);
-    router.route(down1);
-    expect(doubleTapRecognized, isFalse);
-
-    router.route(up1);
-    expect(doubleTapRecognized, isFalse);
-    gestureArena.sweep(1);
+    Gesturer.instance.pointerRouter.route(down1);
     expect(doubleTapRecognized, isFalse);
 
-    router.route(up2);
+    Gesturer.instance.pointerRouter.route(up1);
     expect(doubleTapRecognized, isFalse);
-    gestureArena.sweep(2);
+    Gesturer.instance.gestureArena.sweep(1);
+    expect(doubleTapRecognized, isFalse);
+
+    Gesturer.instance.pointerRouter.route(up2);
+    expect(doubleTapRecognized, isFalse);
+    Gesturer.instance.gestureArena.sweep(2);
     expect(doubleTapRecognized, isFalse);
 
     tap.addPointer(down1);
-    gestureArena.close(1);
+    Gesturer.instance.gestureArena.close(1);
     expect(doubleTapRecognized, isFalse);
-    router.route(down1);
+    Gesturer.instance.pointerRouter.route(down1);
     expect(doubleTapRecognized, isFalse);
 
-    router.route(up1);
+    Gesturer.instance.pointerRouter.route(up1);
     expect(doubleTapRecognized, isTrue);
-    gestureArena.sweep(1);
+    Gesturer.instance.gestureArena.sweep(1);
     expect(doubleTapRecognized, isTrue);
 
     tap.dispose();
@@ -419,12 +382,7 @@ void main() {
   });
 
   test('Should cancel on arena reject during first tap', () {
-    PointerRouter router = new PointerRouter();
-    GestureArena gestureArena = new GestureArena();
-    DoubleTapGestureRecognizer tap = new DoubleTapGestureRecognizer(
-      router: router,
-      gestureArena: gestureArena
-    );
+    DoubleTapGestureRecognizer tap = new DoubleTapGestureRecognizer();
 
     bool doubleTapRecognized = false;
     tap.onDoubleTap = () {
@@ -433,41 +391,36 @@ void main() {
 
     tap.addPointer(down1);
     TestGestureArenaMember member = new TestGestureArenaMember();
-    GestureArenaEntry entry = gestureArena.add(1, member);
-    gestureArena.close(1);
+    GestureArenaEntry entry = Gesturer.instance.gestureArena.add(1, member);
+    Gesturer.instance.gestureArena.close(1);
     expect(doubleTapRecognized, isFalse);
-    router.route(down1);
+    Gesturer.instance.pointerRouter.route(down1);
     expect(doubleTapRecognized, isFalse);
 
-    router.route(up1);
+    Gesturer.instance.pointerRouter.route(up1);
     expect(doubleTapRecognized, isFalse);
     entry.resolve(GestureDisposition.accepted);
     expect(member.accepted, isTrue);
     expect(doubleTapRecognized, isFalse);
-    gestureArena.sweep(1);
+    Gesturer.instance.gestureArena.sweep(1);
     expect(doubleTapRecognized, isFalse);
 
     tap.addPointer(down2);
-    gestureArena.close(2);
+    Gesturer.instance.gestureArena.close(2);
     expect(doubleTapRecognized, isFalse);
-    router.route(down2);
+    Gesturer.instance.pointerRouter.route(down2);
     expect(doubleTapRecognized, isFalse);
 
-    router.route(up2);
+    Gesturer.instance.pointerRouter.route(up2);
     expect(doubleTapRecognized, isFalse);
-    gestureArena.sweep(2);
+    Gesturer.instance.gestureArena.sweep(2);
     expect(doubleTapRecognized, isFalse);
 
     tap.dispose();
   });
 
   test('Should cancel on arena reject between taps', () {
-    PointerRouter router = new PointerRouter();
-    GestureArena gestureArena = new GestureArena();
-    DoubleTapGestureRecognizer tap = new DoubleTapGestureRecognizer(
-      router: router,
-      gestureArena: gestureArena
-    );
+    DoubleTapGestureRecognizer tap = new DoubleTapGestureRecognizer();
 
     bool doubleTapRecognized = false;
     tap.onDoubleTap = () {
@@ -476,41 +429,36 @@ void main() {
 
     tap.addPointer(down1);
     TestGestureArenaMember member = new TestGestureArenaMember();
-    GestureArenaEntry entry = gestureArena.add(1, member);
-    gestureArena.close(1);
+    GestureArenaEntry entry = Gesturer.instance.gestureArena.add(1, member);
+    Gesturer.instance.gestureArena.close(1);
     expect(doubleTapRecognized, isFalse);
-    router.route(down1);
+    Gesturer.instance.pointerRouter.route(down1);
     expect(doubleTapRecognized, isFalse);
 
-    router.route(up1);
+    Gesturer.instance.pointerRouter.route(up1);
     expect(doubleTapRecognized, isFalse);
-    gestureArena.sweep(1);
+    Gesturer.instance.gestureArena.sweep(1);
     expect(doubleTapRecognized, isFalse);
 
     entry.resolve(GestureDisposition.accepted);
     expect(member.accepted, isTrue);
 
     tap.addPointer(down2);
-    gestureArena.close(2);
+    Gesturer.instance.gestureArena.close(2);
     expect(doubleTapRecognized, isFalse);
-    router.route(down2);
+    Gesturer.instance.pointerRouter.route(down2);
     expect(doubleTapRecognized, isFalse);
 
-    router.route(up2);
+    Gesturer.instance.pointerRouter.route(up2);
     expect(doubleTapRecognized, isFalse);
-    gestureArena.sweep(2);
+    Gesturer.instance.gestureArena.sweep(2);
     expect(doubleTapRecognized, isFalse);
 
     tap.dispose();
   });
 
   test('Should cancel on arena reject during last tap', () {
-    PointerRouter router = new PointerRouter();
-    GestureArena gestureArena = new GestureArena();
-    DoubleTapGestureRecognizer tap = new DoubleTapGestureRecognizer(
-      router: router,
-      gestureArena: gestureArena
-    );
+    DoubleTapGestureRecognizer tap = new DoubleTapGestureRecognizer();
 
     bool doubleTapRecognized = false;
     tap.onDoubleTap = () {
@@ -519,41 +467,36 @@ void main() {
 
     tap.addPointer(down1);
     TestGestureArenaMember member = new TestGestureArenaMember();
-    GestureArenaEntry entry = gestureArena.add(1, member);
-    gestureArena.close(1);
+    GestureArenaEntry entry = Gesturer.instance.gestureArena.add(1, member);
+    Gesturer.instance.gestureArena.close(1);
     expect(doubleTapRecognized, isFalse);
-    router.route(down1);
+    Gesturer.instance.pointerRouter.route(down1);
     expect(doubleTapRecognized, isFalse);
 
-    router.route(up1);
+    Gesturer.instance.pointerRouter.route(up1);
     expect(doubleTapRecognized, isFalse);
-    gestureArena.sweep(1);
+    Gesturer.instance.gestureArena.sweep(1);
     expect(doubleTapRecognized, isFalse);
 
     tap.addPointer(down2);
-    gestureArena.close(2);
+    Gesturer.instance.gestureArena.close(2);
     expect(doubleTapRecognized, isFalse);
-    router.route(down2);
+    Gesturer.instance.pointerRouter.route(down2);
     expect(doubleTapRecognized, isFalse);
 
     entry.resolve(GestureDisposition.accepted);
     expect(member.accepted, isTrue);
 
-    router.route(up2);
+    Gesturer.instance.pointerRouter.route(up2);
     expect(doubleTapRecognized, isFalse);
-    gestureArena.sweep(2);
+    Gesturer.instance.gestureArena.sweep(2);
     expect(doubleTapRecognized, isFalse);
 
     tap.dispose();
   });
 
   test('Passive gesture should trigger on double tap cancel', () {
-    PointerRouter router = new PointerRouter();
-    GestureArena gestureArena = new GestureArena();
-    DoubleTapGestureRecognizer tap = new DoubleTapGestureRecognizer(
-      router: router,
-      gestureArena: gestureArena
-    );
+    DoubleTapGestureRecognizer tap = new DoubleTapGestureRecognizer();
 
     bool doubleTapRecognized = false;
     tap.onDoubleTap = () {
@@ -563,15 +506,15 @@ void main() {
     new FakeAsync().run((FakeAsync async) {
       tap.addPointer(down1);
       TestGestureArenaMember member = new TestGestureArenaMember();
-      gestureArena.add(1, member);
-      gestureArena.close(1);
+      Gesturer.instance.gestureArena.add(1, member);
+      Gesturer.instance.gestureArena.close(1);
       expect(doubleTapRecognized, isFalse);
-      router.route(down1);
+      Gesturer.instance.pointerRouter.route(down1);
       expect(doubleTapRecognized, isFalse);
 
-      router.route(up1);
+      Gesturer.instance.pointerRouter.route(up1);
       expect(doubleTapRecognized, isFalse);
-      gestureArena.sweep(1);
+      Gesturer.instance.gestureArena.sweep(1);
       expect(doubleTapRecognized, isFalse);
 
       expect(member.accepted, isFalse);

--- a/packages/flutter/test/gestures/gesture_tester.dart
+++ b/packages/flutter/test/gestures/gesture_tester.dart
@@ -1,0 +1,14 @@
+// Copyright 2015 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/services.dart';
+import 'package:flutter/gestures.dart';
+
+class TestGestureFlutterBinding extends BindingBase with Gesturer { }
+
+void ensureGesturer() {
+  if (Gesturer.instance == null)
+    new TestGestureFlutterBinding();
+  assert(Gesturer.instance != null);
+}

--- a/packages/flutter/test/gestures/long_press_test.dart
+++ b/packages/flutter/test/gestures/long_press_test.dart
@@ -6,6 +6,8 @@ import 'package:quiver/testing/async.dart';
 import 'package:flutter/gestures.dart';
 import 'package:test/test.dart';
 
+import 'gesture_tester.dart';
+
 const PointerDownEvent down = const PointerDownEvent(
   pointer: 5,
   position: const Point(10.0, 10.0)
@@ -17,13 +19,10 @@ const PointerUpEvent up = const PointerUpEvent(
 );
 
 void main() {
+  setUp(ensureGesturer);
+
   test('Should recognize long press', () {
-    PointerRouter router = new PointerRouter();
-    GestureArena gestureArena = new GestureArena();
-    LongPressGestureRecognizer longPress = new LongPressGestureRecognizer(
-      router: router,
-      gestureArena: gestureArena
-    );
+    LongPressGestureRecognizer longPress = new LongPressGestureRecognizer();
 
     bool longPressRecognized = false;
     longPress.onLongPress = () {
@@ -32,9 +31,9 @@ void main() {
 
     new FakeAsync().run((FakeAsync async) {
       longPress.addPointer(down);
-      gestureArena.close(5);
+      Gesturer.instance.gestureArena.close(5);
       expect(longPressRecognized, isFalse);
-      router.route(down);
+      Gesturer.instance.pointerRouter.route(down);
       expect(longPressRecognized, isFalse);
       async.elapse(const Duration(milliseconds: 300));
       expect(longPressRecognized, isFalse);
@@ -46,12 +45,7 @@ void main() {
   });
 
   test('Up cancels long press', () {
-    PointerRouter router = new PointerRouter();
-    GestureArena gestureArena = new GestureArena();
-    LongPressGestureRecognizer longPress = new LongPressGestureRecognizer(
-      router: router,
-      gestureArena: gestureArena
-    );
+    LongPressGestureRecognizer longPress = new LongPressGestureRecognizer();
 
     bool longPressRecognized = false;
     longPress.onLongPress = () {
@@ -60,13 +54,13 @@ void main() {
 
     new FakeAsync().run((FakeAsync async) {
       longPress.addPointer(down);
-      gestureArena.close(5);
+      Gesturer.instance.gestureArena.close(5);
       expect(longPressRecognized, isFalse);
-      router.route(down);
+      Gesturer.instance.pointerRouter.route(down);
       expect(longPressRecognized, isFalse);
       async.elapse(const Duration(milliseconds: 300));
       expect(longPressRecognized, isFalse);
-      router.route(up);
+      Gesturer.instance.pointerRouter.route(up);
       expect(longPressRecognized, isFalse);
       async.elapse(const Duration(seconds: 1));
       expect(longPressRecognized, isFalse);
@@ -76,16 +70,8 @@ void main() {
   });
 
   test('Should recognize both tap down and long press', () {
-    PointerRouter router = new PointerRouter();
-    GestureArena gestureArena = new GestureArena();
-    LongPressGestureRecognizer longPress = new LongPressGestureRecognizer(
-      router: router,
-      gestureArena: gestureArena
-    );
-    TapGestureRecognizer tap = new TapGestureRecognizer(
-      router: router,
-      gestureArena: gestureArena
-    );
+    LongPressGestureRecognizer longPress = new LongPressGestureRecognizer();
+    TapGestureRecognizer tap = new TapGestureRecognizer();
 
     bool tapDownRecognized = false;
     tap.onTapDown = (_) {
@@ -100,10 +86,10 @@ void main() {
     new FakeAsync().run((FakeAsync async) {
       tap.addPointer(down);
       longPress.addPointer(down);
-      gestureArena.close(5);
+      Gesturer.instance.gestureArena.close(5);
       expect(tapDownRecognized, isFalse);
       expect(longPressRecognized, isFalse);
-      router.route(down);
+      Gesturer.instance.pointerRouter.route(down);
       expect(tapDownRecognized, isFalse);
       expect(longPressRecognized, isFalse);
       async.elapse(const Duration(milliseconds: 300));

--- a/packages/flutter/test/gestures/scale_test.dart
+++ b/packages/flutter/test/gestures/scale_test.dart
@@ -6,18 +6,16 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/gestures.dart';
 import 'package:test/test.dart';
 
+import 'gesture_tester.dart';
+
 void main() {
+  setUp(ensureGesturer);
+
   test('Should recognize scale gestures', () {
-    PointerRouter router = new PointerRouter();
-    GestureArena gestureArena = new GestureArena();
-    ScaleGestureRecognizer scale = new ScaleGestureRecognizer(
-      router: router,
-      gestureArena: gestureArena
-    );
-    TapGestureRecognizer tap = new TapGestureRecognizer(
-      router: router,
-      gestureArena: gestureArena
-    );
+    GestureArena gestureArena = Gesturer.instance.gestureArena;
+    PointerRouter pointerRouter = Gesturer.instance.pointerRouter;
+    ScaleGestureRecognizer scale = new ScaleGestureRecognizer();
+    TapGestureRecognizer tap = new TapGestureRecognizer();
 
     bool didStartScale = false;
     Point updatedFocalPoint;
@@ -56,14 +54,14 @@ void main() {
     expect(didTap, isFalse);
 
     // One-finger panning
-    router.route(down);
+    pointerRouter.route(down);
     expect(didStartScale, isFalse);
     expect(updatedScale, isNull);
     expect(updatedFocalPoint, isNull);
     expect(didEndScale, isFalse);
     expect(didTap, isFalse);
 
-    router.route(pointer1.move(const Point(20.0, 30.0)));
+    pointerRouter.route(pointer1.move(const Point(20.0, 30.0)));
     expect(didStartScale, isTrue);
     didStartScale = false;
     expect(updatedFocalPoint, const Point(20.0, 30.0));
@@ -79,7 +77,7 @@ void main() {
     scale.addPointer(down2);
     tap.addPointer(down2);
     gestureArena.close(2);
-    router.route(down2);
+    pointerRouter.route(down2);
 
     expect(didEndScale, isTrue);
     didEndScale = false;
@@ -88,7 +86,7 @@ void main() {
     expect(didStartScale, isFalse);
 
     // Zoom in
-    router.route(pointer2.move(const Point(0.0, 10.0)));
+    pointerRouter.route(pointer2.move(const Point(0.0, 10.0)));
     expect(didStartScale, isTrue);
     didStartScale = false;
     expect(updatedFocalPoint, const Point(10.0, 20.0));
@@ -99,7 +97,7 @@ void main() {
     expect(didTap, isFalse);
 
     // Zoom out
-    router.route(pointer2.move(const Point(15.0, 25.0)));
+    pointerRouter.route(pointer2.move(const Point(15.0, 25.0)));
     expect(updatedFocalPoint, const Point(17.5, 27.5));
     updatedFocalPoint = null;
     expect(updatedScale, 0.5);
@@ -112,7 +110,7 @@ void main() {
     scale.addPointer(down3);
     tap.addPointer(down3);
     gestureArena.close(3);
-    router.route(down3);
+    pointerRouter.route(down3);
 
     expect(didEndScale, isTrue);
     didEndScale = false;
@@ -121,7 +119,7 @@ void main() {
     expect(didStartScale, isFalse);
 
     // Zoom in
-    router.route(pointer3.move(const Point(55.0, 65.0)));
+    pointerRouter.route(pointer3.move(const Point(55.0, 65.0)));
     expect(didStartScale, isTrue);
     didStartScale = false;
     expect(updatedFocalPoint, const Point(30.0, 40.0));
@@ -132,9 +130,9 @@ void main() {
     expect(didTap, isFalse);
 
     // Return to original positions but with different fingers
-    router.route(pointer1.move(const Point(25.0, 35.0)));
-    router.route(pointer2.move(const Point(20.0, 30.0)));
-    router.route(pointer3.move(const Point(15.0, 25.0)));
+    pointerRouter.route(pointer1.move(const Point(25.0, 35.0)));
+    pointerRouter.route(pointer2.move(const Point(20.0, 30.0)));
+    pointerRouter.route(pointer3.move(const Point(15.0, 25.0)));
     expect(didStartScale, isFalse);
     expect(updatedFocalPoint, const Point(20.0, 30.0));
     updatedFocalPoint = null;
@@ -143,7 +141,7 @@ void main() {
     expect(didEndScale, isFalse);
     expect(didTap, isFalse);
 
-    router.route(pointer1.up());
+    pointerRouter.route(pointer1.up());
     expect(didStartScale, isFalse);
     expect(updatedFocalPoint, isNull);
     expect(updatedScale, isNull);
@@ -152,7 +150,7 @@ void main() {
     expect(didTap, isFalse);
 
     // Continue scaling with two fingers
-    router.route(pointer3.move(const Point(10.0, 20.0)));
+    pointerRouter.route(pointer3.move(const Point(10.0, 20.0)));
     expect(didStartScale, isTrue);
     didStartScale = false;
     expect(updatedFocalPoint, const Point(15.0, 25.0));
@@ -160,7 +158,7 @@ void main() {
     expect(updatedScale, 2.0);
     updatedScale = null;
 
-    router.route(pointer2.up());
+    pointerRouter.route(pointer2.up());
     expect(didStartScale, isFalse);
     expect(updatedFocalPoint, isNull);
     expect(updatedScale, isNull);
@@ -169,7 +167,7 @@ void main() {
     expect(didTap, isFalse);
 
     // Continue panning with one finger
-    router.route(pointer3.move(const Point(0.0, 0.0)));
+    pointerRouter.route(pointer3.move(const Point(0.0, 0.0)));
     expect(didStartScale, isTrue);
     didStartScale = false;
     expect(updatedFocalPoint, const Point(0.0, 0.0));
@@ -178,7 +176,7 @@ void main() {
     updatedScale = null;
 
     // We are done
-    router.route(pointer3.up());
+    pointerRouter.route(pointer3.up());
     expect(didStartScale, isFalse);
     expect(updatedFocalPoint, isNull);
     expect(updatedScale, isNull);

--- a/packages/flutter/test/gestures/scroll_test.dart
+++ b/packages/flutter/test/gestures/scroll_test.dart
@@ -6,18 +6,16 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/gestures.dart';
 import 'package:test/test.dart';
 
+import 'gesture_tester.dart';
+
 void main() {
+  setUp(ensureGesturer);
+
   test('Should recognize pan', () {
-    PointerRouter router = new PointerRouter();
-    GestureArena gestureArena = new GestureArena();
-    PanGestureRecognizer pan = new PanGestureRecognizer(
-      router: router,
-      gestureArena: gestureArena
-    );
-    TapGestureRecognizer tap = new TapGestureRecognizer(
-      router: router,
-      gestureArena: gestureArena
-    );
+    GestureArena gestureArena = Gesturer.instance.gestureArena;
+    PointerRouter pointerRouter = Gesturer.instance.pointerRouter;
+    PanGestureRecognizer pan = new PanGestureRecognizer();
+    TapGestureRecognizer tap = new TapGestureRecognizer();
 
     bool didStartPan = false;
     pan.onStart = (_) {
@@ -49,13 +47,13 @@ void main() {
     expect(didEndPan, isFalse);
     expect(didTap, isFalse);
 
-    router.route(down);
+    pointerRouter.route(down);
     expect(didStartPan, isFalse);
     expect(updatedScrollDelta, isNull);
     expect(didEndPan, isFalse);
     expect(didTap, isFalse);
 
-    router.route(pointer.move(const Point(20.0, 20.0)));
+    pointerRouter.route(pointer.move(const Point(20.0, 20.0)));
     expect(didStartPan, isTrue);
     didStartPan = false;
     expect(updatedScrollDelta, const Offset(10.0, 10.0));
@@ -63,14 +61,14 @@ void main() {
     expect(didEndPan, isFalse);
     expect(didTap, isFalse);
 
-    router.route(pointer.move(const Point(20.0, 25.0)));
+    pointerRouter.route(pointer.move(const Point(20.0, 25.0)));
     expect(didStartPan, isFalse);
     expect(updatedScrollDelta, const Offset(0.0, 5.0));
     updatedScrollDelta = null;
     expect(didEndPan, isFalse);
     expect(didTap, isFalse);
 
-    router.route(pointer.up());
+    pointerRouter.route(pointer.up());
     expect(didStartPan, isFalse);
     expect(updatedScrollDelta, isNull);
     expect(didEndPan, isTrue);

--- a/packages/flutter/test/gestures/tap_test.dart
+++ b/packages/flutter/test/gestures/tap_test.dart
@@ -6,12 +6,15 @@ import 'package:flutter/gestures.dart';
 import 'package:quiver/testing/async.dart';
 import 'package:test/test.dart';
 
+import 'gesture_tester.dart';
+
 class TestGestureArenaMember extends GestureArenaMember {
   void acceptGesture(Object key) {}
   void rejectGesture(Object key) {}
 }
 
 void main() {
+  setUp(ensureGesturer);
 
   // Down/up pair 1: normal tap sequence
   const PointerDownEvent down1 = const PointerDownEvent(
@@ -52,12 +55,7 @@ void main() {
   );
 
   test('Should recognize tap', () {
-    PointerRouter router = new PointerRouter();
-    GestureArena gestureArena = new GestureArena();
-    TapGestureRecognizer tap = new TapGestureRecognizer(
-      router: router,
-      gestureArena: gestureArena
-    );
+    TapGestureRecognizer tap = new TapGestureRecognizer();
 
     bool tapRecognized = false;
     tap.onTap = () {
@@ -65,26 +63,21 @@ void main() {
     };
 
     tap.addPointer(down1);
-    gestureArena.close(1);
+    Gesturer.instance.gestureArena.close(1);
     expect(tapRecognized, isFalse);
-    router.route(down1);
+    Gesturer.instance.pointerRouter.route(down1);
     expect(tapRecognized, isFalse);
 
-    router.route(up1);
+    Gesturer.instance.pointerRouter.route(up1);
     expect(tapRecognized, isTrue);
-    gestureArena.sweep(1);
+    Gesturer.instance.gestureArena.sweep(1);
     expect(tapRecognized, isTrue);
 
     tap.dispose();
   });
 
   test('No duplicate tap events', () {
-    PointerRouter router = new PointerRouter();
-    GestureArena gestureArena = new GestureArena();
-    TapGestureRecognizer tap = new TapGestureRecognizer(
-      router: router,
-      gestureArena: gestureArena
-    );
+    TapGestureRecognizer tap = new TapGestureRecognizer();
 
     int tapsRecognized = 0;
     tap.onTap = () {
@@ -92,37 +85,32 @@ void main() {
     };
 
     tap.addPointer(down1);
-    gestureArena.close(1);
+    Gesturer.instance.gestureArena.close(1);
     expect(tapsRecognized, 0);
-    router.route(down1);
+    Gesturer.instance.pointerRouter.route(down1);
     expect(tapsRecognized, 0);
 
-    router.route(up1);
+    Gesturer.instance.pointerRouter.route(up1);
     expect(tapsRecognized, 1);
-    gestureArena.sweep(1);
+    Gesturer.instance.gestureArena.sweep(1);
     expect(tapsRecognized, 1);
 
     tap.addPointer(down1);
-    gestureArena.close(1);
+    Gesturer.instance.gestureArena.close(1);
     expect(tapsRecognized, 1);
-    router.route(down1);
+    Gesturer.instance.pointerRouter.route(down1);
     expect(tapsRecognized, 1);
 
-    router.route(up1);
+    Gesturer.instance.pointerRouter.route(up1);
     expect(tapsRecognized, 2);
-    gestureArena.sweep(1);
+    Gesturer.instance.gestureArena.sweep(1);
     expect(tapsRecognized, 2);
 
     tap.dispose();
   });
 
   test('Should not recognize two overlapping taps', () {
-    PointerRouter router = new PointerRouter();
-    GestureArena gestureArena = new GestureArena();
-    TapGestureRecognizer tap = new TapGestureRecognizer(
-      router: router,
-      gestureArena: gestureArena
-    );
+    TapGestureRecognizer tap = new TapGestureRecognizer();
 
     int tapsRecognized = 0;
     tap.onTap = () {
@@ -130,38 +118,33 @@ void main() {
     };
 
     tap.addPointer(down1);
-    gestureArena.close(1);
+    Gesturer.instance.gestureArena.close(1);
     expect(tapsRecognized, 0);
-    router.route(down1);
+    Gesturer.instance.pointerRouter.route(down1);
     expect(tapsRecognized, 0);
 
     tap.addPointer(down2);
-    gestureArena.close(2);
+    Gesturer.instance.gestureArena.close(2);
     expect(tapsRecognized, 0);
-    router.route(down1);
+    Gesturer.instance.pointerRouter.route(down1);
     expect(tapsRecognized, 0);
 
 
-    router.route(up1);
+    Gesturer.instance.pointerRouter.route(up1);
     expect(tapsRecognized, 1);
-    gestureArena.sweep(1);
+    Gesturer.instance.gestureArena.sweep(1);
     expect(tapsRecognized, 1);
 
-    router.route(up2);
+    Gesturer.instance.pointerRouter.route(up2);
     expect(tapsRecognized, 1);
-    gestureArena.sweep(2);
+    Gesturer.instance.gestureArena.sweep(2);
     expect(tapsRecognized, 1);
 
     tap.dispose();
   });
 
   test('Distance cancels tap', () {
-    PointerRouter router = new PointerRouter();
-    GestureArena gestureArena = new GestureArena();
-    TapGestureRecognizer tap = new TapGestureRecognizer(
-      router: router,
-      gestureArena: gestureArena
-    );
+    TapGestureRecognizer tap = new TapGestureRecognizer();
 
     bool tapRecognized = false;
     tap.onTap = () {
@@ -173,20 +156,20 @@ void main() {
     };
 
     tap.addPointer(down3);
-    gestureArena.close(3);
+    Gesturer.instance.gestureArena.close(3);
     expect(tapRecognized, isFalse);
     expect(tapCanceled, isFalse);
-    router.route(down3);
+    Gesturer.instance.pointerRouter.route(down3);
     expect(tapRecognized, isFalse);
     expect(tapCanceled, isFalse);
 
-    router.route(move3);
+    Gesturer.instance.pointerRouter.route(move3);
     expect(tapRecognized, isFalse);
     expect(tapCanceled, isTrue);
-    router.route(up3);
+    Gesturer.instance.pointerRouter.route(up3);
     expect(tapRecognized, isFalse);
     expect(tapCanceled, isTrue);
-    gestureArena.sweep(3);
+    Gesturer.instance.gestureArena.sweep(3);
     expect(tapRecognized, isFalse);
     expect(tapCanceled, isTrue);
 
@@ -194,12 +177,7 @@ void main() {
   });
 
   test('Timeout does not cancel tap', () {
-    PointerRouter router = new PointerRouter();
-    GestureArena gestureArena = new GestureArena();
-    TapGestureRecognizer tap = new TapGestureRecognizer(
-      router: router,
-      gestureArena: gestureArena
-    );
+    TapGestureRecognizer tap = new TapGestureRecognizer();
 
     bool tapRecognized = false;
     tap.onTap = () {
@@ -208,16 +186,16 @@ void main() {
 
     new FakeAsync().run((FakeAsync async) {
       tap.addPointer(down1);
-      gestureArena.close(1);
+      Gesturer.instance.gestureArena.close(1);
       expect(tapRecognized, isFalse);
-      router.route(down1);
+      Gesturer.instance.pointerRouter.route(down1);
       expect(tapRecognized, isFalse);
 
       async.elapse(new Duration(milliseconds: 500));
       expect(tapRecognized, isFalse);
-      router.route(up1);
+      Gesturer.instance.pointerRouter.route(up1);
       expect(tapRecognized, isTrue);
-      gestureArena.sweep(1);
+      Gesturer.instance.gestureArena.sweep(1);
       expect(tapRecognized, isTrue);
     });
 
@@ -225,12 +203,7 @@ void main() {
   });
 
   test('Should yield to other arena members', () {
-    PointerRouter router = new PointerRouter();
-    GestureArena gestureArena = new GestureArena();
-    TapGestureRecognizer tap = new TapGestureRecognizer(
-      router: router,
-      gestureArena: gestureArena
-    );
+    TapGestureRecognizer tap = new TapGestureRecognizer();
 
     bool tapRecognized = false;
     tap.onTap = () {
@@ -239,16 +212,16 @@ void main() {
 
     tap.addPointer(down1);
     TestGestureArenaMember member = new TestGestureArenaMember();
-    GestureArenaEntry entry = gestureArena.add(1, member);
-    gestureArena.hold(1);
-    gestureArena.close(1);
+    GestureArenaEntry entry = Gesturer.instance.gestureArena.add(1, member);
+    Gesturer.instance.gestureArena.hold(1);
+    Gesturer.instance.gestureArena.close(1);
     expect(tapRecognized, isFalse);
-    router.route(down1);
+    Gesturer.instance.pointerRouter.route(down1);
     expect(tapRecognized, isFalse);
 
-    router.route(up1);
+    Gesturer.instance.pointerRouter.route(up1);
     expect(tapRecognized, isFalse);
-    gestureArena.sweep(1);
+    Gesturer.instance.gestureArena.sweep(1);
     expect(tapRecognized, isFalse);
 
     entry.resolve(GestureDisposition.accepted);
@@ -258,12 +231,7 @@ void main() {
   });
 
   test('Should trigger on release of held arena', () {
-    PointerRouter router = new PointerRouter();
-    GestureArena gestureArena = new GestureArena();
-    TapGestureRecognizer tap = new TapGestureRecognizer(
-      router: router,
-      gestureArena: gestureArena
-    );
+    TapGestureRecognizer tap = new TapGestureRecognizer();
 
     bool tapRecognized = false;
     tap.onTap = () {
@@ -272,16 +240,16 @@ void main() {
 
     tap.addPointer(down1);
     TestGestureArenaMember member = new TestGestureArenaMember();
-    GestureArenaEntry entry = gestureArena.add(1, member);
-    gestureArena.hold(1);
-    gestureArena.close(1);
+    GestureArenaEntry entry = Gesturer.instance.gestureArena.add(1, member);
+    Gesturer.instance.gestureArena.hold(1);
+    Gesturer.instance.gestureArena.close(1);
     expect(tapRecognized, isFalse);
-    router.route(down1);
+    Gesturer.instance.pointerRouter.route(down1);
     expect(tapRecognized, isFalse);
 
-    router.route(up1);
+    Gesturer.instance.pointerRouter.route(up1);
     expect(tapRecognized, isFalse);
-    gestureArena.sweep(1);
+    Gesturer.instance.gestureArena.sweep(1);
     expect(tapRecognized, isFalse);
 
     entry.resolve(GestureDisposition.rejected);

--- a/packages/flutter/test/widget/hyperlink_test.dart
+++ b/packages/flutter/test/widget/hyperlink_test.dart
@@ -11,22 +11,16 @@ void main() {
   test('Can tap a hyperlink', () {
     testWidgets((WidgetTester tester) {
       bool didTapLeft = false;
-      TapGestureRecognizer tapLeft = new TapGestureRecognizer(
-        router: Gesturer.instance.pointerRouter,
-        gestureArena: Gesturer.instance.gestureArena,
-        onTap: () {
+      TapGestureRecognizer tapLeft = new TapGestureRecognizer()
+        ..onTap = () {
           didTapLeft = true;
-        }
-      );
+        };
 
       bool didTapRight = false;
-      TapGestureRecognizer tapRight = new TapGestureRecognizer(
-        router: Gesturer.instance.pointerRouter,
-        gestureArena: Gesturer.instance.gestureArena,
-        onTap: () {
+      TapGestureRecognizer tapRight = new TapGestureRecognizer()
+        ..onTap = () {
           didTapRight = true;
-        }
-      );
+        };
 
       Key textKey = new Key('text');
 


### PR DESCRIPTION
There's no reason to make clients supply a PointerRounter and a
GestureArena when constructing gesture recognizers. These objects are
statics and the gesture recognizers can just grab them directly.

Also, remove the callback constructor arguments. Almost no code used
them. Instead, people seem to prefer using the `..` operator to set
callbacks on the recognizers. Removing the arguments removes a bunch of
boilerplate.
