### PR TITLE
SizeObserver crusade: ScrollableViewport and tabs

### DIFF
--- a/packages/flutter/lib/src/services/binding.dart
+++ b/packages/flutter/lib/src/services/binding.dart
@@ -37,6 +37,8 @@ abstract class BindingBase {
   void initInstances() {
     assert(() { _debugInitialized = true; return true; });
   }
+
+  String toString() => '<$runtimeType>';
 }
 
 // A replacement for shell.connectToService.  Implementations should return true

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -43,7 +43,9 @@ export 'package:flutter/rendering.dart' show
     RelativeRect,
     ShaderCallback,
     ValueChanged,
-    ViewportAnchor;
+    ViewportAnchor,
+    ViewportDimensions,
+    ViewportDimensionsChangeCallback;
 
 // PAINTING NODES
 
@@ -777,6 +779,7 @@ class Viewport extends OneChildRenderObjectWidget {
     this.scrollDirection: Axis.vertical,
     this.scrollAnchor: ViewportAnchor.start,
     this.overlayPainter,
+    this.onPaintOffsetUpdateNeeded,
     Widget child
   }) : super(key: key, child: child) {
     assert(scrollDirection != null);
@@ -802,11 +805,14 @@ class Viewport extends OneChildRenderObjectWidget {
   /// Often used to paint scroll bars.
   final Painter overlayPainter;
 
+  final ViewportDimensionsChangeCallback onPaintOffsetUpdateNeeded;
+
   RenderViewport createRenderObject() {
     return new RenderViewport(
       paintOffset: paintOffset,
       scrollDirection: scrollDirection,
       scrollAnchor: scrollAnchor,
+      onPaintOffsetUpdateNeeded: onPaintOffsetUpdateNeeded,
       overlayPainter: overlayPainter
     );
   }
@@ -817,6 +823,7 @@ class Viewport extends OneChildRenderObjectWidget {
       ..scrollDirection = scrollDirection
       ..scrollAnchor = scrollAnchor
       ..paintOffset = paintOffset
+      ..onPaintOffsetUpdateNeeded = onPaintOffsetUpdateNeeded
       ..overlayPainter = overlayPainter;
   }
 }

--- a/packages/flutter/lib/src/widgets/gesture_detector.dart
+++ b/packages/flutter/lib/src/widgets/gesture_detector.dart
@@ -280,29 +280,29 @@ class RawGestureDetectorState extends State<RawGestureDetector> {
   void replaceGestureRecognizers(Map<Type, GestureRecognizerFactory> gestures) {
     assert(() {
       RenderObject renderObject = context.findRenderObject();
-      assert(renderObject is RenderPointerListener);
-      RenderPointerListener listener = renderObject;
-      RenderBox descendant = listener.child;
       if (!config.excludeFromSemantics) {
-        assert(descendant is RenderSemanticsGestureHandler);
-        RenderSemanticsGestureHandler semanticsGestureHandler = descendant;
-        descendant = semanticsGestureHandler.child;
+        assert(renderObject is RenderSemanticsGestureHandler);
+        RenderSemanticsGestureHandler semanticsGestureHandler = renderObject;
+        renderObject = semanticsGestureHandler.child;
       }
-      assert(descendant != null);
-      if (!descendant.debugDoingThisLayout) {
+      assert(renderObject is RenderPointerListener);
+      RenderPointerListener pointerListener = renderObject;
+      renderObject = pointerListener.child;
+      if (!renderObject.debugDoingThisLayout) {
         throw new WidgetError(
           'replaceGestureRecognizers() can only be called during the layout phase of the GestureDetector\'s nearest descendant RenderObjectWidget.\n'
           'In this particular case, that is:\n'
-          '  $descendant'
+          '  $renderObject'
         );
       }
       return true;
     });
     _syncAll(gestures);
     if (!config.excludeFromSemantics) {
-      RenderPointerListener listener = context.findRenderObject();
-      RenderSemanticsGestureHandler semanticsGestureHandler = listener.child;
-      context.visitChildElements((RenderObjectElement element) => element.widget.updateRenderObject(semanticsGestureHandler, null));
+      RenderSemanticsGestureHandler semanticsGestureHandler = context.findRenderObject();
+      context.visitChildElements((RenderObjectElement element) {
+        element.widget.updateRenderObject(semanticsGestureHandler, null);
+      });
     }
   }
 

--- a/packages/flutter/lib/src/widgets/mixed_viewport.dart
+++ b/packages/flutter/lib/src/widgets/mixed_viewport.dart
@@ -10,7 +10,6 @@ import 'framework.dart';
 import 'basic.dart';
 
 typedef Widget IndexedBuilder(BuildContext context, int index); // return null if index is greater than index of last entry
-typedef void ExtentsUpdateCallback(double newExtents);
 typedef void InvalidatorCallback(Iterable<int> indices);
 typedef void InvalidatorAvailableCallback(InvalidatorCallback invalidator);
 
@@ -23,7 +22,7 @@ class MixedViewport extends RenderObjectWidget {
     this.direction: Axis.vertical,
     this.builder,
     this.token,
-    this.onExtentsUpdate,
+    this.onExtentChanged,
     this.onInvalidatorAvailable
   }) : super(key: key);
 
@@ -31,7 +30,7 @@ class MixedViewport extends RenderObjectWidget {
   final Axis direction;
   final IndexedBuilder builder;
   final Object token; // change this if the list changed (i.e. there are added, removed, or resorted items)
-  final ExtentsUpdateCallback onExtentsUpdate;
+  final ValueChanged<double> onExtentChanged;
   final InvalidatorAvailableCallback onInvalidatorAvailable; // call the callback this gives to invalidate sizes
 
   _MixedViewportElement createElement() => new _MixedViewportElement(this);
@@ -108,8 +107,8 @@ class _MixedViewportElement extends RenderObjectElement<MixedViewport> {
   /// The constraints for which the current offsets are valid.
   BoxConstraints _lastLayoutConstraints;
 
-  /// The last value that was sent to onExtentsUpdate.
-  double _lastReportedExtents;
+  /// The last value that was sent to onExtentChanged.
+  double _lastReportedExtent;
 
   RenderBlockViewport get renderObject => super.renderObject;
 
@@ -227,11 +226,11 @@ class _MixedViewportElement extends RenderObjectElement<MixedViewport> {
     BuildableElement.lockState(() {
       _doLayout(constraints);
     }, building: true);
-    if (widget.onExtentsUpdate != null) {
-      final double newExtents = _didReachLastChild ? _childOffsets.last : null;
-      if (newExtents != _lastReportedExtents) {
-        _lastReportedExtents = newExtents;
-        widget.onExtentsUpdate(_lastReportedExtents);
+    if (widget.onExtentChanged != null) {
+      final double newExtent = _didReachLastChild ? _childOffsets.last : null;
+      if (newExtent != _lastReportedExtent) {
+        _lastReportedExtent = newExtent;
+        widget.onExtentChanged(_lastReportedExtent);
       }
     }
   }

--- a/packages/flutter/lib/src/widgets/scroll_behavior.dart
+++ b/packages/flutter/lib/src/widgets/scroll_behavior.dart
@@ -35,6 +35,15 @@ abstract class ScrollBehavior<T, U> {
 
   /// Whether this scroll behavior currently permits scrolling
   bool get isScrollable => true;
+
+  String toString() {
+    List<String> description = <String>[];
+    debugFillDescription(description);
+    return '$runtimeType(${description.join("; ")})';
+  }
+  void debugFillDescription(List<String> description) {
+    description.add(isScrollable ? 'scrollable' : 'not scrollable');
+  }
 }
 
 /// A scroll behavior for a scrollable widget with linear extent (i.e.
@@ -74,6 +83,13 @@ abstract class ExtentScrollBehavior extends ScrollBehavior<double, double> {
 
   /// The maximum value the scroll offset can obtain.
   double get maxScrollOffset;
+
+  void debugFillDescription(List<String> description) {
+    super.debugFillDescription(description);
+    description.add('content: ${contentExtent.toStringAsFixed(1)}');
+    description.add('container: ${contentExtent.toStringAsFixed(1)}');
+    description.add('range: ${minScrollOffset?.toStringAsFixed(1)} .. ${maxScrollOffset?.toStringAsFixed(1)}');
+  }
 }
 
 /// A scroll behavior that prevents the user from exceeding scroll bounds.

--- a/packages/flutter/test/widget/block_test.dart
+++ b/packages/flutter/test/widget/block_test.dart
@@ -50,16 +50,18 @@ void main() {
           ]
         )
       );
-      tester.pump(); // for SizeObservers
 
       Point middleOfContainer = tester.getCenter(tester.findText('Hello'));
+      expect(middleOfContainer.x, equals(400.0));
+      expect(middleOfContainer.y, equals(1000.0));
+
       Point target = tester.getCenter(tester.findElementByKey(blockKey));
       TestGesture gesture = tester.startGesture(target);
       gesture.moveBy(const Offset(0.0, -10.0));
 
-      tester.pump(const Duration(milliseconds: 1));
+      tester.pump(); // redo layout
 
-      expect(tester.getCenter(tester.findText('Hello')) == middleOfContainer, isFalse);
+      expect(tester.getCenter(tester.findText('Hello')), isNot(equals(middleOfContainer)));
 
       gesture.up();
     });

--- a/packages/flutter_test/lib/src/widget_tester.dart
+++ b/packages/flutter_test/lib/src/widget_tester.dart
@@ -6,6 +6,7 @@ import 'dart:ui' as ui show window;
 
 import 'package:quiver/testing/async.dart';
 import 'package:quiver/time.dart';
+import 'package:flutter/rendering.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:flutter/widgets.dart';
 
@@ -55,6 +56,11 @@ class WidgetTester extends Instrumentation {
     binding.handleBeginFrame(new Duration(
       milliseconds: clock.now().millisecondsSinceEpoch)
     );
+    async.flushMicrotasks();
+  }
+
+  void dispatchEvent(PointerEvent event, HitTestResult result) {
+    super.dispatchEvent(event, result);
     async.flushMicrotasks();
   }
 }


### PR DESCRIPTION
Removes the SizeObserver from ScrollableViewport and TabBar, making it update the scroll position during layout before paint, and making it update the gesture detector at the same time, before semantics.

Also:
- add operator==/hashCode/toString to ViewportDimensions
- add toString to BindingBase
- add toString and debugFillDescription to ScrollBehavior
- fix a bug in the RawGestureDetectorState's replaceGestureRecognizers
- rename MixedViewport's onExtentsUpdate to onExtentChanged
- replace ExtentsUpdateCallback with ValueChanged<double>
- remove a microtask for dispatching scroll start, since it
  did not appear to have any purpose
- added dartdocs to Instrumentation until I understood it
- made all event dispatch in Instrumentation drain microtasks
