### PR TITLE
Adds initial version of Markdown renderer

### DIFF
--- a/examples/material_gallery/lib/demo/weather_demo.dart
+++ b/examples/material_gallery/lib/demo/weather_demo.dart
@@ -17,12 +17,12 @@ enum WeatherType {
   snow
 }
 
-class WeathersDemo extends StatefulComponent {
-  WeathersDemo({ Key key }) : super(key: key);
-  _WeathersDemoState createState() => new _WeathersDemoState();
+class WeatherDemo extends StatefulComponent {
+  WeatherDemo({ Key key }) : super(key: key);
+  _WeatherDemoState createState() => new _WeatherDemoState();
 }
 
-class _WeathersDemoState extends State<WeathersDemo> {
+class _WeatherDemoState extends State<WeatherDemo> {
 
   Future _loadAssets(AssetBundle bundle) async {
     _images = new ImageMap(bundle);
@@ -62,7 +62,7 @@ class _WeathersDemoState extends State<WeathersDemo> {
     if (!assetsLoaded) {
       return new Scaffold(
         toolBar: new ToolBar(
-          center: new Text("Weathers")
+          center: new Text("Weather")
         ),
         body: new Container(
           decoration: new BoxDecoration(
@@ -74,7 +74,7 @@ class _WeathersDemoState extends State<WeathersDemo> {
 
     return new Scaffold(
       toolBar: new ToolBar(
-        center: new Text("Weathers")
+        center: new Text("Weather")
       ),
       body: new Material(
         child: new Stack(

--- a/examples/material_gallery/lib/gallery/home.dart
+++ b/examples/material_gallery/lib/gallery/home.dart
@@ -35,7 +35,7 @@ import '../demo/time_picker_demo.dart';
 import '../demo/tooltip_demo.dart';
 import '../demo/two_level_list_demo.dart';
 import '../demo/typography_demo.dart';
-import '../demo/weathers_demo.dart';
+import '../demo/weather_demo.dart';
 
 class GalleryHome extends StatefulComponent {
   GalleryHome({ Key key }) : super(key: key);
@@ -70,7 +70,7 @@ class GalleryHomeState extends State<GalleryHome> {
                 image: 'assets/section_animation.png',
                 colors: Colors.purple,
                 demos: <GalleryDemo>[
-                  new GalleryDemo(title: 'Weathers', builder: () => new WeathersDemo()),
+                  new GalleryDemo(title: 'Weather', builder: () => new WeatherDemo()),
                   new GalleryDemo(title: 'Fitness', builder: () => new FitnessDemo())
                 ]
               ),


### PR DESCRIPTION
Initial version of a Markdown renderer and a Dart syntax highlighter. Some stuff left to do:
- Add support for links
- Better custom loading of images
- Potentially break out the parsed markdown data out of the Markdown widget
- API documentation
