### PR TITLE
decouple `flutter drive` from `flutter start`; make things in `flutter_tools` more testable

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_device.dart
+++ b/packages/flutter_tools/lib/src/android/android_device.dart
@@ -54,6 +54,8 @@ class AndroidDevice extends Device {
 
   bool _connected;
 
+  bool get isLocalEmulator => false;
+
   List<String> adbCommandForDevice(List<String> args) {
     return <String>[androidSdk.adbPath, '-s', id]..addAll(args);
   }

--- a/packages/flutter_tools/lib/src/base/os.dart
+++ b/packages/flutter_tools/lib/src/base/os.dart
@@ -5,7 +5,10 @@
 import 'dart:async';
 import 'dart:io';
 
-final OperatingSystemUtils os = new OperatingSystemUtils._();
+import 'context.dart';
+
+/// Returns [OperatingSystemUtils] active in the current app context (i.e. zone).
+OperatingSystemUtils get os => context[OperatingSystemUtils] ?? (context[OperatingSystemUtils] = new OperatingSystemUtils._());
 
 abstract class OperatingSystemUtils {
   factory OperatingSystemUtils._() {
@@ -16,6 +19,14 @@ abstract class OperatingSystemUtils {
     }
   }
 
+  OperatingSystemUtils._private();
+
+  String get operatingSystem => Platform.operatingSystem;
+
+  bool get isMacOS => operatingSystem == 'macos';
+  bool get isWindows => operatingSystem == 'windows';
+  bool get isLinux => operatingSystem == 'linux';
+
   /// Make the given file executable. This may be a no-op on some platforms.
   ProcessResult makeExecutable(File file);
 
@@ -24,7 +35,9 @@ abstract class OperatingSystemUtils {
   File which(String execName);
 }
 
-class _PosixUtils implements OperatingSystemUtils {
+class _PosixUtils extends OperatingSystemUtils {
+  _PosixUtils() : super._private();
+
   ProcessResult makeExecutable(File file) {
     return Process.runSync('chmod', ['u+x', file.path]);
   }
@@ -40,7 +53,9 @@ class _PosixUtils implements OperatingSystemUtils {
   }
 }
 
-class _WindowsUtils implements OperatingSystemUtils {
+class _WindowsUtils extends OperatingSystemUtils {
+  _WindowsUtils() : super._private();
+
   // This is a no-op.
   ProcessResult makeExecutable(File file) {
     return new ProcessResult(0, 0, null, null);

--- a/packages/flutter_tools/lib/src/commands/run.dart
+++ b/packages/flutter_tools/lib/src/commands/run.dart
@@ -51,6 +51,11 @@ abstract class RunCommandBase extends FlutterCommand {
     argParser.addOption('route',
         help: 'Which route to load when starting the app.');
   }
+
+  bool get checked => argResults['checked'];
+  bool get traceStartup => argResults['trace-startup'];
+  String get target => argResults['target'];
+  String get route => argResults['route'];
 }
 
 class RunCommand extends RunCommandBase {
@@ -219,7 +224,7 @@ Future<int> startApp(
       // wait for the observatory port to become available before returning from
       // `startApp()`.
       if (startPaused && device.supportsStartPaused) {
-        await _delayUntilObservatoryAvailable('localhost', debugPort);
+        await delayUntilObservatoryAvailable('localhost', debugPort);
       }
     }
   }
@@ -242,7 +247,7 @@ Future<int> startApp(
 ///
 /// This does not fail if we're unable to connect, and times out after the given
 /// [timeout].
-Future _delayUntilObservatoryAvailable(String host, int port, {
+Future delayUntilObservatoryAvailable(String host, int port, {
   Duration timeout: const Duration(seconds: 10)
 }) async {
   Stopwatch stopwatch = new Stopwatch()..start();

--- a/packages/flutter_tools/lib/src/device.dart
+++ b/packages/flutter_tools/lib/src/device.dart
@@ -130,6 +130,9 @@ abstract class Device {
 
   bool get supportsStartPaused => true;
 
+  /// Whether it is an emulated device running on localhost.
+  bool get isLocalEmulator;
+
   /// Install an app package on the current device
   bool installApp(ApplicationPackage app);
 
@@ -259,7 +262,7 @@ class DeviceStore {
           break;
         case TargetPlatform.iOSSimulator:
           assert(iOSSimulator == null);
-          iOSSimulator = _deviceForConfig(config, IOSSimulator.getAttachedDevices());
+          iOSSimulator = _deviceForConfig(config, IOSSimulatorUtils.instance.getAttachedDevices());
           break;
         case TargetPlatform.mac:
         case TargetPlatform.linux:

--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -62,6 +62,8 @@ class IOSDevice extends Device {
 
   final String name;
 
+  bool get isLocalEmulator => false;
+
   bool get supportsStartPaused => false;
 
   static List<IOSDevice> getAttachedDevices([IOSDevice mockIOS]) {

--- a/packages/flutter_tools/test/listen_test.dart
+++ b/packages/flutter_tools/test/listen_test.dart
@@ -15,7 +15,7 @@ defineTests() {
   group('listen', () {
     testUsingContext('returns 1 when no device is connected', () {
       ListenCommand command = new ListenCommand(singleRun: true);
-      applyMocksToCommand(command, noDevices: true);
+      applyMocksToCommand(command);
       return createTestCommandRunner(command).run(['listen']).then((int code) {
         expect(code, equals(1));
       });

--- a/packages/flutter_tools/test/src/context.dart
+++ b/packages/flutter_tools/test/src/context.dart
@@ -7,9 +7,13 @@ import 'dart:io';
 
 import 'package:flutter_tools/src/base/context.dart';
 import 'package:flutter_tools/src/base/logger.dart';
+import 'package:flutter_tools/src/base/os.dart';
 import 'package:flutter_tools/src/device.dart';
 import 'package:flutter_tools/src/doctor.dart';
 import 'package:flutter_tools/src/ios/mac.dart';
+import 'package:flutter_tools/src/ios/simulators.dart';
+
+import 'package:mockito/mockito.dart';
 import 'package:test/test.dart';
 
 /// Return the test logger. This assumes that the current Logger is a BufferLogger.
@@ -37,6 +41,15 @@ void testUsingContext(String description, dynamic testMethod(), {
 
     if (!overrides.containsKey(Doctor))
       testContext[Doctor] = new MockDoctor();
+
+    if (!overrides.containsKey(SimControl))
+      testContext[SimControl] = new MockSimControl();
+
+    if (!overrides.containsKey(OperatingSystemUtils))
+      testContext[OperatingSystemUtils] = new MockOperatingSystemUtils();
+
+    if (!overrides.containsKey(IOSSimulatorUtils))
+      testContext[IOSSimulatorUtils] = new MockIOSSimulatorUtils();
 
     if (Platform.isMacOS) {
       if (!overrides.containsKey(XCode))
@@ -76,3 +89,13 @@ class MockDoctor extends Doctor {
   // True for testing.
   bool get canLaunchAnything => true;
 }
+
+class MockSimControl extends Mock implements SimControl {
+  MockSimControl() {
+    when(this.getConnectedDevices()).thenReturn([]);
+  }
+}
+
+class MockOperatingSystemUtils extends Mock implements OperatingSystemUtils {}
+
+class MockIOSSimulatorUtils extends Mock implements IOSSimulatorUtils {}

--- a/packages/flutter_tools/test/src/mocks.dart
+++ b/packages/flutter_tools/test/src/mocks.dart
@@ -12,8 +12,6 @@ import 'package:flutter_tools/src/runner/flutter_command.dart';
 import 'package:flutter_tools/src/toolchain.dart';
 import 'package:mockito/mockito.dart';
 
-import 'context.dart';
-
 class MockApplicationPackageStore extends ApplicationPackageStore {
   MockApplicationPackageStore() : super(
     android: new AndroidApk(localPath: '/mock/path/to/android/SkyShell.apk'),
@@ -53,13 +51,10 @@ class MockDeviceStore extends DeviceStore {
     iOSSimulator: new MockIOSSimulator());
 }
 
-void applyMocksToCommand(FlutterCommand command, { bool noDevices: false }) {
+void applyMocksToCommand(FlutterCommand command) {
   command
     ..applicationPackages = new MockApplicationPackageStore()
     ..toolchain = new MockToolchain()
     ..devices = new MockDeviceStore()
     ..projectRootValidator = () => true;
-
-  if (!noDevices)
-    testDeviceManager.addDevice(command.devices.android);
 }


### PR DESCRIPTION
`flutter start`'s method of finding devices to run the app on is not suitable for `flutter drive`.

This commit also refactors several tool services to allow mocking in unit tests:
- adopts the pattern `MyServiceClass.instance` in several classes, which delegates to `AppContext` to get instances, allowing mocking in tests
- add a way to fake current operating system in `OperatingSystemUtils` so we can test some Mac-specific code on Travis
- extracted building for a single device out of `buildAll`
- added `Device.isLocalEmulator`, needed to be able to detect a running iOS Simulator (and other emulators in the future).
