### PR TITLE
add timing info for flx creation

### DIFF
--- a/packages/flutter_tools/lib/src/commands/run.dart
+++ b/packages/flutter_tools/lib/src/commands/run.dart
@@ -123,7 +123,7 @@ class RunCommand extends RunCommandBase {
       debugPort: debugPort
     );
 
-    printTrace('Finished start command.');
+    printTrace('Finished $name command.');
     return result;
   }
 }

--- a/packages/flutter_tools/lib/src/flx.dart
+++ b/packages/flutter_tools/lib/src/flx.dart
@@ -295,7 +295,7 @@ Future<int> assemble({
   printTrace('Encoding zip file.');
   Uint8List zipBytes = new Uint8List.fromList(new ZipEncoder().encode(archive));
   ensureDirectoryExists(outputPath);
-  printTrace('Creating flx at ${outputPath}.');
+  printTrace('Creating flx at $outputPath.');
   Bundle bundle = new Bundle.fromContent(
     path: outputPath,
     manifest: manifestDescriptor,

--- a/packages/flutter_tools/lib/src/flx.dart
+++ b/packages/flutter_tools/lib/src/flx.dart
@@ -256,7 +256,7 @@ Future<int> build(
 
 Future<int> assemble({
   Map manifestDescriptor: const {},
-  ArchiveFile snapshotFile: null,
+  ArchiveFile snapshotFile,
   String assetBasePath: defaultAssetBasePath,
   String materialAssetBasePath: defaultMaterialAssetBasePath,
   String outputPath: defaultFlxOutputPath,
@@ -287,11 +287,15 @@ Future<int> assemble({
   if (fontManifest != null)
     archive.addFile(fontManifest);
 
-  await CipherParameters.get().seedRandom();
+  printTrace('Calling CipherParameters.seedRandom().');
+  CipherParameters.get().seedRandom();
 
   AsymmetricKeyPair keyPair = keyPairFromPrivateKeyFileSync(privateKeyPath);
+  printTrace('KeyPair from $privateKeyPath: $keyPair.');
+  printTrace('Encoding zip file.');
   Uint8List zipBytes = new Uint8List.fromList(new ZipEncoder().encode(archive));
   ensureDirectoryExists(outputPath);
+  printTrace('Creating flx at ${outputPath}.');
   Bundle bundle = new Bundle.fromContent(
     path: outputPath,
     manifest: manifestDescriptor,

--- a/packages/flx/lib/bundle.dart
+++ b/packages/flx/lib/bundle.dart
@@ -72,7 +72,7 @@ class Bundle {
     this.path,
     this.manifest,
     contentBytes,
-    AsymmetricKeyPair keyPair: null
+    AsymmetricKeyPair keyPair
   }) : _contentBytes = contentBytes {
     assert(path != null);
     assert(manifest != null);

--- a/packages/flx/test/signing_test.dart
+++ b/packages/flx/test/signing_test.dart
@@ -34,7 +34,7 @@ main() async {
 
   // Set up a key generator.
   CipherParameters cipher = CipherParameters.get();
-  await cipher.seedRandom();
+  cipher.seedRandom();
   ECKeyGeneratorParameters ecParams = new ECKeyGeneratorParameters(cipher.domain);
   ParametersWithRandom<ECKeyGeneratorParameters> keyGeneratorParams =
     new ParametersWithRandom<ECKeyGeneratorParameters>(ecParams, cipher.random);


### PR DESCRIPTION
@mpcomplete, add some timing info for flx creation. I'm seeing roughly 600ms to call `CipherParameters.get().seedRandom()`, and about 1000ms to create the zip (via the `new ZipEncoder().encode(archive)` call). For comparison, shelling out to `zip` takes ~75ms.
