### PR TITLE
some performance optimizations for starting apps

### DIFF
--- a/packages/flutter_tools/lib/src/commands/listen.dart
+++ b/packages/flutter_tools/lib/src/commands/listen.dart
@@ -46,12 +46,12 @@ class ListenCommand extends RunCommandBase {
         applicationPackages,
         toolchain,
         buildConfigurations,
-        target: argResults['target'],
+        target: target,
         install: firstTime,
         stop: true,
-        checked: argResults['checked'],
-        traceStartup: argResults['trace-startup'],
-        route: argResults['route']
+        checked: checked,
+        traceStartup: traceStartup,
+        route: route
       );
       firstTime = false;
     } while (!singleRun && result == 0 && _watchDirectory(watchCommand));

--- a/packages/flutter_tools/lib/src/commands/run.dart
+++ b/packages/flutter_tools/lib/src/commands/run.dart
@@ -65,7 +65,7 @@ class RunCommand extends RunCommandBase {
 
   RunCommand() {
     argParser.addFlag('full-restart',
-        defaultsTo: true,
+        defaultsTo: false,
         help: 'Stop any currently running application process before starting the app.');
     argParser.addFlag('clear-logs',
         defaultsTo: true,
@@ -116,13 +116,13 @@ class RunCommand extends RunCommandBase {
       applicationPackages,
       toolchain,
       buildConfigurations,
-      target: argResults['target'],
+      target: target,
       enginePath: runner.enginePath,
       install: true,
       stop: argResults['full-restart'],
-      checked: argResults['checked'],
-      traceStartup: argResults['trace-startup'],
-      route: argResults['route'],
+      checked: checked,
+      traceStartup: traceStartup,
+      route: route,
       clearLogs: clearLogs,
       startPaused: argResults['start-paused'],
       debugPort: debugPort
@@ -140,7 +140,7 @@ Future<int> startApp(
   List<BuildConfiguration> configs, {
   String target,
   String enginePath,
-  bool stop: true,
+  bool stop: false,
   bool install: true,
   bool checked: true,
   bool traceStartup: false,

--- a/packages/flutter_tools/lib/src/flx.dart
+++ b/packages/flutter_tools/lib/src/flx.dart
@@ -148,9 +148,7 @@ bool _addAssetFile(Archive archive, _Asset asset) {
     return false;
   }
   List<int> content = file.readAsBytesSync();
-  archive.addFile(
-    new ArchiveFile.noCompress(asset.key, content.length, content)
-  );
+  archive.addFile(new ArchiveFile.noCompress(asset.key, content.length, content));
   return true;
 }
 
@@ -287,14 +285,19 @@ Future<int> assemble({
   if (fontManifest != null)
     archive.addFile(fontManifest);
 
-  printTrace('Calling CipherParameters.seedRandom().');
-  CipherParameters.get().seedRandom();
-
   AsymmetricKeyPair keyPair = keyPairFromPrivateKeyFileSync(privateKeyPath);
   printTrace('KeyPair from $privateKeyPath: $keyPair.');
+
+  if (keyPair != null) {
+    printTrace('Calling CipherParameters.seedRandom().');
+    CipherParameters.get().seedRandom();
+  }
+
   printTrace('Encoding zip file.');
   Uint8List zipBytes = new Uint8List.fromList(new ZipEncoder().encode(archive));
+
   ensureDirectoryExists(outputPath);
+
   printTrace('Creating flx at $outputPath.');
   Bundle bundle = new Bundle.fromContent(
     path: outputPath,
@@ -303,5 +306,8 @@ Future<int> assemble({
     keyPair: keyPair
   );
   bundle.writeSync();
+
+  printTrace('Built and signed flx at $outputPath.');
+
   return 0;
 }

--- a/packages/flutter_tools/lib/src/ios/simulators.dart
+++ b/packages/flutter_tools/lib/src/ios/simulators.dart
@@ -32,7 +32,9 @@ class IOSSimulators extends PollingDeviceDiscovery {
 
 class IOSSimulatorUtils {
   /// Returns [IOSSimulatorUtils] active in the current app context (i.e. zone).
-  static IOSSimulatorUtils get instance => context[IOSSimulatorUtils] ?? (context[IOSSimulatorUtils] = new IOSSimulatorUtils());
+  static IOSSimulatorUtils get instance {
+    return context[IOSSimulatorUtils] ?? (context[IOSSimulatorUtils] = new IOSSimulatorUtils());
+  }
 
   List<IOSSimulator> getAttachedDevices() {
     if (!xcode.isInstalledAndMeetsVersionCheck)
@@ -238,12 +240,7 @@ class IOSSimulator extends Device {
     }
   }
 
-  @override
-  bool isConnected() {
-    if (!Platform.isMacOS)
-      return false;
-    return SimControl.instance.getConnectedDevices().any((SimDevice device) => device.udid == id);
-  }
+  bool isConnected() => Platform.isMacOS;
 
   @override
   bool isSupported() {

--- a/packages/flx/lib/signing.dart
+++ b/packages/flx/lib/signing.dart
@@ -9,8 +9,8 @@ import 'dart:typed_data';
 
 import 'package:asn1lib/asn1lib.dart';
 import 'package:bignum/bignum.dart';
-import 'package:pointycastle/pointycastle.dart';
 import 'package:crypto/crypto.dart';
+import 'package:pointycastle/pointycastle.dart';
 
 export 'package:pointycastle/pointycastle.dart' show AsymmetricKeyPair;
 
@@ -82,8 +82,11 @@ Uint8List serializeManifest(Map manifestDescriptor, ECPublicKey publicKey, Uint8
   if (publicKey != null)
     outputManifest['key'] = BASE64.encode(publicKey.Q.getEncoded());
 
-  Uint8List zipHash = new Digest(_params.hashAlgorithm).process(zipBytes);
-  BigInteger zipHashInt = new BigInteger.fromBytes(1, zipHash);
+  SHA256 sha = new SHA256();
+  sha.add(zipBytes);
+  List<int> hash = sha.close();
+
+  BigInteger zipHashInt = new BigInteger.fromBytes(1, hash);
   outputManifest['content-hash'] = zipHashInt.intValue();
 
   return new Uint8List.fromList(UTF8.encode(JSON.encode(outputManifest)));


### PR DESCRIPTION
Some performance optimizations for starting apps:
- only seed the random value if we're going to use it (~600ms)
- switch to the sha256 implementation from `crypto` (~700ms => 70ms)
- default to not calling stop when starting an app. Android is ok w/ it, and stop isn't implemented for iOS (stop was ~500ms)
- reduce the number of times we call `simctl list --json` - each call was ~100ms, and we had 5-6 calls. Down to 2 now. This is the `isConnected` change. The semantics of that method are different now that we only create a `Device` instance for devices that actually exist
