### PR TITLE
remove the isConnected() method from device

### DIFF
--- a/packages/flutter_tools/lib/src/commands/apk.dart
+++ b/packages/flutter_tools/lib/src/commands/apk.dart
@@ -430,7 +430,7 @@ Future<int> buildAll(
 }) async {
   for (Device device in devices.all) {
     ApplicationPackage package = applicationPackages.getPackageForPlatform(device.platform);
-    if (package == null || !device.isConnected())
+    if (package == null)
       continue;
 
     // TODO(mpcomplete): Temporary hack. We only support the apk builder atm.

--- a/packages/flutter_tools/lib/src/commands/daemon.dart
+++ b/packages/flutter_tools/lib/src/commands/daemon.dart
@@ -347,7 +347,7 @@ Map<String, dynamic> _deviceToMap(Device device) {
     'id': device.id,
     'name': device.name,
     'platform': _enumToString(device.platform),
-    'available': device.isConnected()
+    'available': true
   };
 }
 

--- a/packages/flutter_tools/lib/src/commands/install.dart
+++ b/packages/flutter_tools/lib/src/commands/install.dart
@@ -30,7 +30,7 @@ Future<bool> installApp(
 
   for (Device device in devices.all) {
     ApplicationPackage package = applicationPackages.getPackageForPlatform(device.platform);
-    if (package == null || !device.isConnected() || device.isAppInstalled(package))
+    if (package == null || device.isAppInstalled(package))
       continue;
     if (device.installApp(package))
       installedSomewhere = true;

--- a/packages/flutter_tools/lib/src/commands/refresh.dart
+++ b/packages/flutter_tools/lib/src/commands/refresh.dart
@@ -36,7 +36,7 @@ class RefreshCommand extends FlutterCommand {
       downloadApplicationPackagesAndConnectToDevices(),
     ], eagerError: true);
 
-    if (devices.android == null || !devices.android.isConnected()) {
+    if (devices.android == null) {
       printError('No device connected.');
       return 1;
     }

--- a/packages/flutter_tools/lib/src/commands/run.dart
+++ b/packages/flutter_tools/lib/src/commands/run.dart
@@ -185,7 +185,7 @@ Future<int> startApp(
 
   for (Device device in devices.all) {
     ApplicationPackage package = applicationPackages.getPackageForPlatform(device.platform);
-    if (package == null || !device.isConnected())
+    if (package == null)
       continue;
 
     if (!device.isSupported()) {
@@ -230,13 +230,14 @@ Future<int> startApp(
   }
 
   if (!startedSomething) {
-    int connected = devices.all.where((device) => device.isConnected()).length;
     String message = 'Unable to run application';
-    if (connected == 0) {
+
+    if (devices.all.isEmpty) {
       message += ' - no connected devices.';
     } else if (unsupportedCount != 0) {
       message += ' - $unsupportedCount unsupported ${pluralize('device', unsupportedCount)} connected';
     }
+
     printError(message);
   }
 

--- a/packages/flutter_tools/lib/src/commands/stop.dart
+++ b/packages/flutter_tools/lib/src/commands/stop.dart
@@ -26,7 +26,7 @@ Future<bool> stopAll(DeviceStore devices, ApplicationPackageStore applicationPac
 
   for (Device device in devices.all) {
     ApplicationPackage package = applicationPackages.getPackageForPlatform(device.platform);
-    if (package == null || !device.isConnected())
+    if (package == null)
       continue;
     if (await device.stopApp(package))
       stoppedSomething = true;

--- a/packages/flutter_tools/lib/src/commands/trace.dart
+++ b/packages/flutter_tools/lib/src/commands/trace.dart
@@ -33,7 +33,7 @@ class TraceCommand extends FlutterCommand {
   Future<int> runInProject() async {
     await downloadApplicationPackagesAndConnectToDevices();
 
-    if (devices.android == null || !devices.android.isConnected()) {
+    if (devices.android == null) {
       printError('No device connected, so no trace was completed.');
       return 1;
     }

--- a/packages/flutter_tools/lib/src/device.dart
+++ b/packages/flutter_tools/lib/src/device.dart
@@ -136,9 +136,6 @@ abstract class Device {
   /// Install an app package on the current device
   bool installApp(ApplicationPackage app);
 
-  /// Check if the device is currently connected
-  bool isConnected();
-
   /// Check if the device is supported by Flutter
   bool isSupported();
 

--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -126,9 +126,6 @@ class IOSDevice extends Device {
   }
 
   @override
-  bool isConnected() => _getAttachedDeviceIDs().contains(id);
-
-  @override
   bool isSupported() => true;
 
   @override
@@ -235,9 +232,6 @@ class _IOSDeviceLogReader extends DeviceLogReader {
 
   // TODO(devoncarew): Support [clear].
   Future<int> logs({ bool clear: false, bool showPrefix: false }) async {
-    if (!device.isConnected())
-      return 2;
-
     return await runCommandAndStreamOutput(
       <String>[device.loggerPath],
       prefix: showPrefix ? '[$name] ' : '',

--- a/packages/flutter_tools/lib/src/ios/simulators.dart
+++ b/packages/flutter_tools/lib/src/ios/simulators.dart
@@ -229,9 +229,6 @@ class IOSSimulator extends Device {
 
   @override
   bool installApp(ApplicationPackage app) {
-    if (!isConnected())
-      return false;
-
     try {
       SimControl.instance.install(id, app.localPath);
       return true;
@@ -239,8 +236,6 @@ class IOSSimulator extends Device {
       return false;
     }
   }
-
-  bool isConnected() => Platform.isMacOS;
 
   @override
   bool isSupported() {
@@ -419,9 +414,6 @@ class _IOSSimulatorLogReader extends DeviceLogReader {
   String get name => device.name;
 
   Future<int> logs({ bool clear: false, bool showPrefix: false }) async {
-    if (!device.isConnected())
-      return 2;
-
     if (clear)
       device.clearLogs();
 

--- a/packages/flutter_tools/test/daemon_test.dart
+++ b/packages/flutter_tools/test/daemon_test.dart
@@ -112,13 +112,8 @@ defineTests() {
 
       MockDeviceStore mockDevices = command.devices;
 
-      when(mockDevices.android.isConnected()).thenReturn(true);
       when(mockDevices.android.stopApp(any)).thenReturn(true);
-
-      when(mockDevices.iOS.isConnected()).thenReturn(false);
       when(mockDevices.iOS.stopApp(any)).thenReturn(false);
-
-      when(mockDevices.iOSSimulator.isConnected()).thenReturn(false);
       when(mockDevices.iOSSimulator.stopApp(any)).thenReturn(false);
 
       commands.add({'id': 0, 'method': 'app.stopAll'});

--- a/packages/flutter_tools/test/install_test.dart
+++ b/packages/flutter_tools/test/install_test.dart
@@ -19,15 +19,12 @@ defineTests() {
       applyMocksToCommand(command);
       MockDeviceStore mockDevices = command.devices;
 
-      when(mockDevices.android.isConnected()).thenReturn(true);
       when(mockDevices.android.isAppInstalled(any)).thenReturn(false);
       when(mockDevices.android.installApp(any)).thenReturn(true);
 
-      when(mockDevices.iOS.isConnected()).thenReturn(false);
       when(mockDevices.iOS.isAppInstalled(any)).thenReturn(false);
       when(mockDevices.iOS.installApp(any)).thenReturn(false);
 
-      when(mockDevices.iOSSimulator.isConnected()).thenReturn(false);
       when(mockDevices.iOSSimulator.isAppInstalled(any)).thenReturn(false);
       when(mockDevices.iOSSimulator.installApp(any)).thenReturn(false);
 
@@ -43,15 +40,12 @@ defineTests() {
       applyMocksToCommand(command);
       MockDeviceStore mockDevices = command.devices;
 
-      when(mockDevices.android.isConnected()).thenReturn(false);
       when(mockDevices.android.isAppInstalled(any)).thenReturn(false);
       when(mockDevices.android.installApp(any)).thenReturn(false);
 
-      when(mockDevices.iOS.isConnected()).thenReturn(true);
       when(mockDevices.iOS.isAppInstalled(any)).thenReturn(false);
       when(mockDevices.iOS.installApp(any)).thenReturn(true);
 
-      when(mockDevices.iOSSimulator.isConnected()).thenReturn(false);
       when(mockDevices.iOSSimulator.isAppInstalled(any)).thenReturn(false);
       when(mockDevices.iOSSimulator.installApp(any)).thenReturn(false);
 

--- a/packages/flutter_tools/test/src/context.dart
+++ b/packages/flutter_tools/test/src/context.dart
@@ -48,8 +48,11 @@ void testUsingContext(String description, dynamic testMethod(), {
     if (!overrides.containsKey(OperatingSystemUtils))
       testContext[OperatingSystemUtils] = new MockOperatingSystemUtils();
 
-    if (!overrides.containsKey(IOSSimulatorUtils))
-      testContext[IOSSimulatorUtils] = new MockIOSSimulatorUtils();
+    if (!overrides.containsKey(IOSSimulatorUtils)) {
+      MockIOSSimulatorUtils mock = new MockIOSSimulatorUtils();
+      when(mock.getAttachedDevices()).thenReturn(<IOSSimulator>[]);
+      testContext[IOSSimulatorUtils] = mock;
+    }
 
     if (Platform.isMacOS) {
       if (!overrides.containsKey(XCode))

--- a/packages/flutter_tools/test/stop_test.dart
+++ b/packages/flutter_tools/test/stop_test.dart
@@ -19,13 +19,8 @@ defineTests() {
       applyMocksToCommand(command);
       MockDeviceStore mockDevices = command.devices;
 
-      when(mockDevices.android.isConnected()).thenReturn(true);
       when(mockDevices.android.stopApp(any)).thenReturn(true);
-
-      when(mockDevices.iOS.isConnected()).thenReturn(false);
       when(mockDevices.iOS.stopApp(any)).thenReturn(false);
-
-      when(mockDevices.iOSSimulator.isConnected()).thenReturn(false);
       when(mockDevices.iOSSimulator.stopApp(any)).thenReturn(false);
 
       return createTestCommandRunner(command).run(['stop']).then((int code) {
@@ -38,13 +33,8 @@ defineTests() {
       applyMocksToCommand(command);
       MockDeviceStore mockDevices = command.devices;
 
-      when(mockDevices.android.isConnected()).thenReturn(false);
       when(mockDevices.android.stopApp(any)).thenReturn(false);
-
-      when(mockDevices.iOS.isConnected()).thenReturn(true);
       when(mockDevices.iOS.stopApp(any)).thenReturn(true);
-
-      when(mockDevices.iOSSimulator.isConnected()).thenReturn(false);
       when(mockDevices.iOSSimulator.stopApp(any)).thenReturn(false);
 
       return createTestCommandRunner(command).run(['stop']).then((int code) {

--- a/packages/flutter_tools/test/trace_test.dart
+++ b/packages/flutter_tools/test/trace_test.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import 'package:flutter_tools/src/commands/trace.dart';
-import 'package:mockito/mockito.dart';
 import 'package:test/test.dart';
 
 import 'src/common.dart';
@@ -17,10 +16,6 @@ defineTests() {
     testUsingContext('returns 1 when no Android device is connected', () {
       TraceCommand command = new TraceCommand();
       applyMocksToCommand(command);
-      MockDeviceStore mockDevices = command.devices;
-
-      when(mockDevices.android.isConnected()).thenReturn(false);
-
       return createTestCommandRunner(command).run(['trace']).then((int code) {
         expect(code, equals(1));
       });


### PR DESCRIPTION
Remove the isConnected() method from device. We now only create a `Device` instance if there's a real device associated w/ it (we had previously speculatively created one for android, ios device, and ios simulator).

@yjbanov 
