### PR TITLE
Scrollable's callbacks should follow a state machine

### DIFF
--- a/packages/flutter/test/widget/scroll_events_test.dart
+++ b/packages/flutter/test/widget/scroll_events_test.dart
@@ -1,0 +1,98 @@
+// Copyright 2015 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter/widgets.dart';
+import 'package:test/test.dart';
+
+Widget _buildScroller({Key key, List<String> log}) {
+  return new ScrollableViewport(
+    key: key,
+    onScrollStart: (double scrollOffset) {
+      log.add('scrollstart');
+    },
+    onScroll: (double scrollOffset) {
+      log.add('scroll');
+    },
+    onScrollEnd: (double scrollOffset) {
+      log.add('scrollend');
+    },
+    child: new Container(width: 1000.0, height: 1000.0)
+  );
+}
+
+void main() {
+  test('Scroll event drag', () {
+    testWidgets((WidgetTester tester) {
+      List<String> log = <String>[];
+      tester.pumpWidget(_buildScroller(log: log));
+
+      expect(log, equals([]));
+      TestGesture gesture = tester.startGesture(new Point(100.0, 100.0));
+      expect(log, equals(['scrollstart']));
+      tester.pump(const Duration(seconds: 1));
+      expect(log, equals(['scrollstart']));
+      gesture.moveBy(new Offset(-10.0, -10.0));
+      expect(log, equals(['scrollstart', 'scroll']));
+      tester.pump(const Duration(seconds: 1));
+      expect(log, equals(['scrollstart', 'scroll']));
+      gesture.up();
+      expect(log, equals(['scrollstart', 'scroll']));
+      tester.pump(const Duration(seconds: 1));
+      expect(log, equals(['scrollstart', 'scroll', 'scrollend']));
+    });
+  });
+
+  test('Scroll scrollTo animation', () {
+    testWidgets((WidgetTester tester) {
+      GlobalKey<ScrollableState> scrollKey = new GlobalKey<ScrollableState>();
+      List<String> log = <String>[];
+      tester.pumpWidget(_buildScroller(key: scrollKey, log: log));
+
+      expect(log, equals([]));
+      scrollKey.currentState.scrollTo(100.0, duration: const Duration(seconds: 1));
+      expect(log, equals(['scrollstart']));
+      tester.pump(const Duration(milliseconds: 100));
+      expect(log, equals(['scrollstart']));
+      tester.pump(const Duration(milliseconds: 100));
+      expect(log, equals(['scrollstart', 'scroll']));
+      tester.pump(const Duration(milliseconds: 1500));
+      expect(log, equals(['scrollstart', 'scroll', 'scroll', 'scrollend']));
+    });
+  });
+
+  test('Scroll scrollTo no animation', () {
+    testWidgets((WidgetTester tester) {
+      GlobalKey<ScrollableState> scrollKey = new GlobalKey<ScrollableState>();
+      List<String> log = <String>[];
+      tester.pumpWidget(_buildScroller(key: scrollKey, log: log));
+
+      expect(log, equals([]));
+      scrollKey.currentState.scrollTo(100.0);
+      expect(log, equals(['scrollstart', 'scroll', 'scrollend']));
+    });
+  });
+
+  test('Scroll during animation', () {
+    testWidgets((WidgetTester tester) {
+      GlobalKey<ScrollableState> scrollKey = new GlobalKey<ScrollableState>();
+      List<String> log = <String>[];
+      tester.pumpWidget(_buildScroller(key: scrollKey, log: log));
+
+      expect(log, equals([]));
+      scrollKey.currentState.scrollTo(100.0, duration: const Duration(seconds: 1));
+      expect(log, equals(['scrollstart']));
+      tester.pump(const Duration(milliseconds: 100));
+      expect(log, equals(['scrollstart']));
+      tester.pump(const Duration(milliseconds: 100));
+      expect(log, equals(['scrollstart', 'scroll']));
+      scrollKey.currentState.scrollTo(100.0);
+      expect(log, equals(['scrollstart', 'scroll', 'scroll']));
+      tester.pump(const Duration(milliseconds: 100));
+      expect(log, equals(['scrollstart', 'scroll', 'scroll', 'scrollend']));
+      tester.pump(const Duration(milliseconds: 1500));
+      expect(log, equals(['scrollstart', 'scroll', 'scroll', 'scrollend']));
+    });
+  });
+}

--- a/packages/newton/lib/src/scroll_simulation.dart
+++ b/packages/newton/lib/src/scroll_simulation.dart
@@ -64,4 +64,8 @@ class ScrollSimulation extends SimulationGroup {
 
     return false;
   }
+
+  String toString() {
+    return 'ScrollSimulation(leadingExtent: $_leadingExtent, trailingExtent: $_trailingExtent)';
+  }
 }

--- a/packages/newton/lib/src/tolerance.dart
+++ b/packages/newton/lib/src/tolerance.dart
@@ -11,6 +11,8 @@ class Tolerance {
 
   const Tolerance({this.distance: epsilonDefault, this.time: epsilonDefault,
       this.velocity: epsilonDefault});
+
+  String toString() => 'Tolerance(distance: $distance, time=$time, velocity: $velocity)';
 }
 
 const double epsilonDefault = 1e-3;


### PR DESCRIPTION
Now onScroll callbacks are always bracketed by onScrollStart and onScrollEnd
callbacks.

Fixes #1822
