### PR TITLE
Disabled IconButtons render correctly

### DIFF
--- a/packages/flutter/lib/src/material/icon.dart
+++ b/packages/flutter/lib/src/material/icon.dart
@@ -84,7 +84,7 @@ class Icon extends StatelessComponent {
     final int iconAlpha = (255.0 * (IconTheme.of(context)?.clampedOpacity ?? 1.0)).round();
     if (iconAlpha != 255) {
       if (color != null) {
-        iconColor = color.withAlpha(iconAlpha);
+        iconColor = color.withAlpha((iconAlpha * color.opacity).round());
       } else {
         switch(iconThemeColor) {
           case IconThemeColor.black:

--- a/packages/flutter/lib/src/material/icon_button.dart
+++ b/packages/flutter/lib/src/material/icon_button.dart
@@ -7,6 +7,7 @@ import 'package:flutter/widgets.dart';
 import 'icon.dart';
 import 'icon_theme_data.dart';
 import 'ink_well.dart';
+import 'theme.dart';
 import 'tooltip.dart';
 
 /// A material design "icon button".
@@ -47,7 +48,7 @@ class IconButton extends StatelessComponent {
         size: size,
         icon: icon,
         colorTheme: colorTheme,
-        color: color
+        color: onPressed != null ? color : Theme.of(context).disabledColor
       )
     );
     if (tooltip != null) {


### PR DESCRIPTION
- Disabled icons are rendererd with the theme's disabled color.
- The IconTheme's opacity is multiplied by icon color's opacity.

Fixes https://github.com/flutter/flutter/issues/2053
