### PR TITLE
improve startup time

### DIFF
--- a/packages/flutter_tools/lib/flutter_tools.dart
+++ b/packages/flutter_tools/lib/flutter_tools.dart
@@ -3,8 +3,7 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-
-import 'package:archive/archive.dart';
+import 'dart:io';
 
 import 'src/flx.dart' as flx;
 
@@ -12,7 +11,7 @@ import 'src/flx.dart' as flx;
 /// pre-compiled snapshot.
 Future<int> assembleFlx({
   Map manifestDescriptor: const {},
-  ArchiveFile snapshotFile: null,
+  File snapshotFile: null,
   String assetBasePath: flx.defaultAssetBasePath,
   String materialAssetBasePath: flx.defaultMaterialAssetBasePath,
   String outputPath: flx.defaultFlxOutputPath,

--- a/packages/flutter_tools/lib/src/base/process.dart
+++ b/packages/flutter_tools/lib/src/base/process.dart
@@ -65,8 +65,12 @@ Future<Process> runDetached(List<String> cmd) {
 
 /// Run cmd and return stdout.
 /// Throws an error if cmd exits with a non-zero value.
-String runCheckedSync(List<String> cmd, { String workingDirectory }) {
-  return _runWithLoggingSync(cmd, workingDirectory: workingDirectory, checked: true, noisyErrors: true);
+String runCheckedSync(List<String> cmd, {
+  String workingDirectory, bool truncateCommand: false
+}) {
+  return _runWithLoggingSync(
+    cmd, workingDirectory: workingDirectory, checked: true, noisyErrors: true, truncateCommand: truncateCommand
+  );
 }
 
 /// Run cmd and return stdout.
@@ -91,9 +95,13 @@ bool exitsHappy(List<String> cli) {
 String _runWithLoggingSync(List<String> cmd, {
   bool checked: false,
   bool noisyErrors: false,
-  String workingDirectory
+  String workingDirectory,
+  bool truncateCommand: false
 }) {
-  printTrace(cmd.join(' '));
+  String cmdText = cmd.join(' ');
+  if (truncateCommand && cmdText.length > 160)
+    cmdText = cmdText.substring(0, 160) + '…';
+  printTrace(cmdText);
   ProcessResult results =
       Process.runSync(cmd[0], cmd.getRange(1, cmd.length).toList(), workingDirectory: workingDirectory);
   if (results.exitCode != 0) {

--- a/packages/flutter_tools/lib/src/base/utils.dart
+++ b/packages/flutter_tools/lib/src/base/utils.dart
@@ -3,6 +3,15 @@
 // found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:io';
+
+import 'package:crypto/crypto.dart';
+
+String calculateSha(File file) {
+  SHA1 sha1 = new SHA1();
+  sha1.add(file.readAsBytesSync());
+  return CryptoUtils.bytesToHex(sha1.close());
+}
 
 /// A class to maintain a list of items, fire events when items are added or
 /// removed, and calculate a diff of changes when a new list of items is

--- a/packages/flutter_tools/lib/src/zip.dart
+++ b/packages/flutter_tools/lib/src/zip.dart
@@ -1,0 +1,117 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:io';
+import 'dart:convert' show UTF8;
+
+import 'package:archive/archive.dart';
+import 'package:path/path.dart' as path;
+
+import 'base/process.dart';
+
+abstract class ZipBuilder {
+  factory ZipBuilder() {
+    if (exitsHappy(<String>['which', 'zip'])) {
+      return new _ZipToolBuilder();
+    } else {
+      return new _ArchiveZipBuilder();
+    }
+  }
+
+  ZipBuilder._();
+
+  List<ZipEntry> entries = <ZipEntry>[];
+
+  void addEntry(ZipEntry entry) => entries.add(entry);
+
+  void createZip(File outFile, Directory zipBuildDir);
+}
+
+class ZipEntry {
+  ZipEntry.fromFile(this.archivePath, File file) {
+    this._file = file;
+  }
+
+  ZipEntry.fromString(this.archivePath, String contents) {
+    this._contents = contents;
+  }
+
+  final String archivePath;
+
+  File _file;
+  String _contents;
+
+  bool get isStringEntry => _contents != null;
+}
+
+class _ArchiveZipBuilder extends ZipBuilder {
+  _ArchiveZipBuilder() : super._();
+
+  void createZip(File outFile, Directory zipBuildDir) {
+    Archive archive = new Archive();
+
+    for (ZipEntry entry in entries) {
+      if (entry.isStringEntry) {
+        List<int> data = UTF8.encode(entry._contents);
+        archive.addFile(new ArchiveFile.noCompress(entry.archivePath, data.length, data));
+      } else {
+        List<int> data = entry._file.readAsBytesSync();
+        archive.addFile(new ArchiveFile(entry.archivePath, data.length, data));
+      }
+    }
+
+    List<int> zipData = new ZipEncoder().encode(archive);
+    outFile.writeAsBytesSync(zipData);
+  }
+}
+
+class _ZipToolBuilder extends ZipBuilder {
+  _ZipToolBuilder() : super._();
+
+  void createZip(File outFile, Directory zipBuildDir) {
+    if (outFile.existsSync())
+      outFile.deleteSync();
+
+    if (zipBuildDir.existsSync())
+      zipBuildDir.deleteSync(recursive: true);
+    zipBuildDir.createSync(recursive: true);
+
+    for (ZipEntry entry in entries) {
+      if (entry.isStringEntry) {
+        List<int> data = UTF8.encode(entry._contents);
+        File file = new File(path.join(zipBuildDir.path, entry.archivePath));
+        file.parent.createSync(recursive: true);
+        file.writeAsBytesSync(data);
+      } else {
+        List<int> data = entry._file.readAsBytesSync();
+        File file = new File(path.join(zipBuildDir.path, entry.archivePath));
+        file.parent.createSync(recursive: true);
+        file.writeAsBytesSync(data);
+      }
+    }
+
+    runCheckedSync(
+      <String>['zip', '-q', outFile.absolute.path]..addAll(_getCompressedNames()),
+      workingDirectory: zipBuildDir.path,
+      truncateCommand: true
+    );
+    runCheckedSync(
+      <String>['zip', '-q', '-0', outFile.absolute.path]..addAll(_getStoredNames()),
+      workingDirectory: zipBuildDir.path,
+      truncateCommand: true
+    );
+  }
+
+  Iterable<String> _getCompressedNames() {
+    return entries
+      .where((ZipEntry entry) => !entry.isStringEntry)
+      .map((ZipEntry entry) => entry.archivePath);
+  }
+
+  Iterable<String> _getStoredNames() {
+    return entries
+      .where((ZipEntry entry) => entry.isStringEntry)
+      .map((ZipEntry entry) => entry.archivePath);
+  }
+}

--- a/packages/flx/lib/bundle.dart
+++ b/packages/flx/lib/bundle.dart
@@ -71,7 +71,7 @@ class Bundle {
   Bundle.fromContent({
     this.path,
     this.manifest,
-    contentBytes,
+    List<int> contentBytes,
     AsymmetricKeyPair keyPair
   }) : _contentBytes = contentBytes {
     assert(path != null);


### PR DESCRIPTION
More changes to improve the startup time:
- re-write the archiving code to use the `zip` cli utility if we can find it (~1000ms => ~240ms)
- calculate the apk sha when we build it, and store it to disk, instead of each time we start the app (~260ms)
- rely on the SHA being correct on the device, to imply that the app exists on the device - don't run `shell pm path app.id` (~420ms)

Also, some changes to store more build artifacts in the `build/` dir, instead of in temporary directories.
