### PR TITLE
Show time deltas

### DIFF
--- a/packages/flutter_tools/lib/src/base/logger.dart
+++ b/packages/flutter_tools/lib/src/base/logger.dart
@@ -4,8 +4,10 @@
 
 import 'dart:io';
 
+final _terminal = new _AnsiTerminal();
+
 abstract class Logger {
-  bool verbose = false;
+  bool get isVerbose => false;
 
   /// Display an error level message to the user. Commands should use this if they
   /// fail in some way.
@@ -18,42 +20,33 @@ abstract class Logger {
   /// Use this for verbose tracing output. Users can turn this output on in order
   /// to help diagnose issues with the toolchain or with their setup.
   void printTrace(String message);
+
+  /// Flush any buffered output.
+  void flush() { }
 }
 
 class StdoutLogger implements Logger {
-  DateTime _startTime = new DateTime.now();
-
-  bool verbose = false;
+  bool get isVerbose => false;
 
   void printError(String message, [StackTrace stackTrace]) {
-    stderr.writeln(_prefix + message);
+    stderr.writeln(message);
     if (stackTrace != null)
       stderr.writeln(stackTrace);
   }
 
-  void printStatus(String message) {
-    print(_prefix + message);
-  }
+  void printStatus(String message) => print(message);
 
-  void printTrace(String message) {
-    if (verbose)
-      print('$_prefix- $message');
-  }
+  void printTrace(String message) { }
 
-  String get _prefix {
-    if (!verbose)
-      return '';
-    Duration elapsed = new DateTime.now().difference(_startTime);
-    return '[${elapsed.inMilliseconds.toString().padLeft(4)} ms] ';
-  }
+  void flush() { }
 }
 
 class BufferLogger implements Logger {
+  bool get isVerbose => false;
+
   StringBuffer _error = new StringBuffer();
   StringBuffer _status = new StringBuffer();
   StringBuffer _trace = new StringBuffer();
-
-  bool verbose = false;
 
   String get errorText => _error.toString();
   String get statusText => _status.toString();
@@ -62,4 +55,88 @@ class BufferLogger implements Logger {
   void printError(String message, [StackTrace stackTrace]) => _error.writeln(message);
   void printStatus(String message) => _status.writeln(message);
   void printTrace(String message) => _trace.writeln(message);
+
+  void flush() { }
+}
+
+class VerboseLogger implements Logger {
+  _LogMessage lastMessage;
+
+  bool get isVerbose => true;
+
+  void printError(String message, [StackTrace stackTrace]) {
+    _emit();
+    lastMessage = new _LogMessage(_LogType.error, message, stackTrace);
+  }
+
+  void printStatus(String message) {
+    _emit();
+    lastMessage = new _LogMessage(_LogType.status, message);
+  }
+
+  void printTrace(String message) {
+    _emit();
+    lastMessage = new _LogMessage(_LogType.trace, message);
+  }
+
+  void flush() => _emit();
+
+  void _emit() {
+    lastMessage?.emit();
+    lastMessage = null;
+  }
+}
+
+enum _LogType {
+  error,
+  status,
+  trace
+}
+
+class _LogMessage {
+  _LogMessage(this.type, this.message, [this.stackTrace]) {
+    stopwatch.start();
+  }
+
+  final _LogType type;
+  final String message;
+  final StackTrace stackTrace;
+
+  Stopwatch stopwatch = new Stopwatch();
+
+  void emit() {
+    stopwatch.stop();
+
+    int millis = stopwatch.elapsedMilliseconds;
+    String prefix = '${millis.toString().padLeft(4)} ms • ';
+    String indent = ''.padLeft(prefix.length);
+    if (millis >= 100)
+      prefix = _terminal.writeBold(prefix.substring(0, prefix.length - 3)) + ' • ';
+    String indentMessage = message.replaceAll('\n', '\n$indent');
+
+    if (type == _LogType.error) {
+      stderr.writeln(prefix + _terminal.writeBold(indentMessage));
+      if (stackTrace != null)
+        stderr.writeln(indent + stackTrace.toString().replaceAll('\n', '\n$indent'));
+    } else if (type == _LogType.status) {
+      print(prefix + _terminal.writeBold(indentMessage));
+    } else {
+      print(prefix + indentMessage);
+    }
+  }
+}
+
+class _AnsiTerminal {
+  _AnsiTerminal() {
+    String term = Platform.environment['TERM'];
+    _supportsColor = term != null && term != 'dumb';
+  }
+
+  static const String _bold = '\u001B[1m';
+  static const String _reset = '\u001B[0m';
+
+  bool _supportsColor;
+  bool get supportsColor => _supportsColor;
+
+  String writeBold(String str) => supportsColor ? '$_bold$str$_reset' : str;
 }

--- a/packages/flutter_tools/lib/src/base/process.dart
+++ b/packages/flutter_tools/lib/src/base/process.dart
@@ -85,6 +85,8 @@ String sdkBinaryName(String name) {
 }
 
 bool exitsHappy(List<String> cli) {
+  printTrace(cli.join(' '));
+
   try {
     return Process.runSync(cli.first, cli.sublist(1)).exitCode == 0;
   } catch (error) {

--- a/packages/flutter_tools/lib/src/commands/run.dart
+++ b/packages/flutter_tools/lib/src/commands/run.dart
@@ -128,7 +128,6 @@ class RunCommand extends RunCommandBase {
       debugPort: debugPort
     );
 
-    printTrace('Finished $name command.');
     return result;
   }
 }
@@ -272,10 +271,8 @@ Future delayUntilObservatoryAvailable(String host, int port, {
   while (stopwatch.elapsed <= timeout) {
     try {
       WebSocket ws = await WebSocket.connect(url);
-
-      printTrace('Connected to the observatory port (${stopwatch.elapsedMilliseconds}ms).');
+      printTrace('Connected to the observatory port.');
       ws.close().catchError((error) => null);
-
       return;
     } catch (error) {
       await new Future.delayed(new Duration(milliseconds: 250));

--- a/packages/flutter_tools/lib/src/commands/run_mojo.dart
+++ b/packages/flutter_tools/lib/src/commands/run_mojo.dart
@@ -120,7 +120,7 @@ class RunMojoCommand extends FlutterCommand {
     if (useDevtools) {
       final String buildFlag = argResults['mojo-debug'] ? '--debug' : '--release';
       args.add(buildFlag);
-      if (logger.verbose)
+      if (logger.isVerbose)
         args.add('--verbose');
     }
 

--- a/packages/flutter_tools/lib/src/doctor.dart
+++ b/packages/flutter_tools/lib/src/doctor.dart
@@ -232,7 +232,9 @@ class _AtomValidator extends DoctorValidator {
     ValidationType flutterPluginExists() {
       try {
         // apm list -b -p -i
-        ProcessResult result = Process.runSync('apm', <String>['list', '-b', '-p', '-i']);
+        List<String> args = <String>['list', '-b', '-p', '-i'];
+        printTrace('apm ${args.join(' ')}');
+        ProcessResult result = Process.runSync('apm', args);
         if (result.exitCode != 0)
           return ValidationType.missing;
         bool available = (result.stdout as String).split('\n').any((String line) {

--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -47,7 +47,17 @@ abstract class FlutterCommand extends Command {
     devices ??= new DeviceStore.forConfigs(buildConfigurations);
   }
 
-  Future<int> run() async {
+  Future<int> run() {
+    Stopwatch stopwatch = new Stopwatch()..start();
+
+    return _run().then((int exitCode) {
+      printTrace("'flutter $name' exiting with code $exitCode; "
+        "elasped time ${stopwatch.elapsedMilliseconds}ms.");
+      return exitCode;
+    });
+  }
+
+  Future<int> _run() async {
     if (requiresProjectRoot && !projectRootValidator())
       return 1;
 

--- a/packages/flutter_tools/lib/src/runner/flutter_command_runner.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command_runner.dart
@@ -12,6 +12,7 @@ import 'package:path/path.dart' as path;
 import '../android/android_sdk.dart';
 import '../artifacts.dart';
 import '../base/context.dart';
+import '../base/logger.dart';
 import '../base/process.dart';
 import '../build_configuration.dart';
 import '../globals.dart';
@@ -160,12 +161,19 @@ class FlutterCommandRunner extends CommandRunner {
     return '.';
   }
 
+  Future<dynamic> run(Iterable<String> args) {
+    return super.run(args).then((dynamic result) {
+      logger.flush();
+      return result;
+    });
+  }
+
   Future<int> runCommand(ArgResults globalResults) {
     _globalResults = globalResults;
 
     // Check for verbose.
     if (globalResults['verbose'])
-      logger.verbose = true;
+      context[Logger] = new VerboseLogger();
 
     // we must set ArtifactStore.flutterRoot early because other features use it
     // (e.g. enginePath's initialiser uses it)


### PR DESCRIPTION
@Hixie, show deltas in the verbose output instead of time since startup (fix https://github.com/flutter/flutter/issues/2246). This also prints out the overall time for the command at the end.

```
   0 ms • Using Android SDK at /Users/devoncarew/tools/android-sdk-macosx/.
   5 ms • [/Users/devoncarew/tools/android-sdk-macosx/, SDK version 23, build-tools 23.0.2]
  16 ms • xcode-select --print-path
  59 ms • xcodebuild -version
   3 ms • Xcode 7.2.1
          Build version 7C1002
   9 ms • /Users/devoncarew/tools/android-sdk-macosx/platform-tools/adb devices -l
  18 ms • List of devices attached
          TA95000FQA             device usb:336592896X product:peregrine_retus model:XT1045 device:peregrine
  12 ms • idevice_id -h
   4 ms • which idevice_id
   0 ms • /Users/devoncarew/homebrew/bin/idevice_id
   6 ms • /Users/devoncarew/homebrew/bin/idevice_id -l
  81 ms • /usr/bin/xcrun simctl list --json devices
  30 ms • Downloading toolchain.
  43 ms • /usr/bin/defaults read /Users/devoncarew/flutter/flutter_sunflower/ios/Info CFBundleIdentifier
   1 ms • io.flutter.runner.Runner
  10 ms • /Users/devoncarew/tools/android-sdk-macosx/platform-tools/adb devices -l
   0 ms • List of devices attached
          TA95000FQA             device usb:336592896X product:peregrine_retus model:XT1045 device:peregrine
   4 ms • idevice_id -h
   6 ms • /Users/devoncarew/homebrew/bin/idevice_id -l
  77 ms • /usr/bin/xcrun simctl list --json devices
   4 ms • Running build command.
   0 ms • APK up to date; skipping build step.
   0 ms • Running install command.
  41 ms • /Users/devoncarew/tools/android-sdk-macosx/platform-tools/adb -s TA95000FQA shell cat /data/local/tmp/sky.com.example.flutter_sunflower.sha1
   0 ms • 1d4a99b290492af2a1b0ee08fe6866ec63bf0331
   0 ms • Running build command for AndroidDevice TA95000FQA.
   2 ms • Starting lib/main.dart on XT1045...
   9 ms • /Users/devoncarew/tools/android-sdk-macosx/platform-tools/adb version
   1 ms • Android Debug Bridge version 1.0.32
          Revision 09a0d98bebce-android
   9 ms • /Users/devoncarew/tools/android-sdk-macosx/platform-tools/adb -s TA95000FQA start-server
  27 ms • /Users/devoncarew/tools/android-sdk-macosx/platform-tools/adb -s TA95000FQA shell getprop ro.build.version.sdk
  32 ms • 22
 367 ms • /Users/devoncarew/projects/flutter/flutter/bin/cache/artifacts/engine/darwin-x64/sky_snapshot /Users/devoncarew/flutter/flutter_sunflower/lib/main.dart --package-root=packages --snapshot=build/snapshot_blob.bin
   4 ms • Building build/app.flx
  13 ms • which zip
   0 ms • KeyPair from privatekey.der: null.
 138 ms • Encoding zip file to build/app.zip
  95 ms • zip -q /Users/devoncarew/flutter/flutter_sunflower/build/app.zip snapshot_blob.bin content/ic_add_white_18dp.png content/1.5x/ic_add_white_18dp.png content/2.0x…
  11 ms • zip -q -0 /Users/devoncarew/flutter/flutter_sunflower/build/app.zip AssetManifest.json
  63 ms • Creating flx at build/app.flx.
   0 ms • Built build/app.flx.
   1 ms • Starting bundle for AndroidDevice TA95000FQA.
   0 ms • AndroidDevice TA95000FQA startBundle
   9 ms • /Users/devoncarew/tools/android-sdk-macosx/platform-tools/adb -s TA95000FQA forward tcp:8181 tcp:8181
  31 ms • /Users/devoncarew/tools/android-sdk-macosx/platform-tools/adb -s TA95000FQA -s TA95000FQA logcat -c
 134 ms • /Users/devoncarew/tools/android-sdk-macosx/platform-tools/adb -s TA95000FQA push build/app.flx /data/local/tmp/dev.flx
 628 ms • /Users/devoncarew/tools/android-sdk-macosx/platform-tools/adb -s TA95000FQA shell am start -a android.intent.action.RUN -d /data/local/tmp/dev.flx -f 0x20000000 --ez enable-background-compilation true --ez enable-checked-mode true com.example.flutter_sunflower/org.domokit.sky.shell.SkyActivity
   0 ms • Starting: Intent { act=android.intent.action.RUN dat=/data/local/tmp/dev.flx flg=0x20000000 cmp=com.example.flutter_sunflower/org.domokit.sky.shell.SkyActivity (has extras) }
          Warning: Activity not started, its current task has been brought to the front
   0 ms • 'flutter run' exiting with code 0; elasped time 2022ms.
```
