### PR TITLE
update to CONTRIBUTING.md to use the new update-packages command

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,11 +37,11 @@ Getting the code and configuring your environment
  * `git remote add upstream git@github.com:flutter/flutter.git` (So that you
    fetch from the master repository, not your clone, when running `git fetch`
    et al.)
- * Run `dart ./dev/update_packages.dart` This will fetch all the Dart packages that
-   Flutter depends on. You can replicate what this script does by running
-   `pub get` in each directory that contains a `pubspec.yaml` file.
  * Add this repository's `bin` directory to your path. That will let you use the
    `flutter` command in this directory more easily.
+ * Run `flutter update-packages` This will fetch all the Dart packages that
+   Flutter depends on. You can replicate what this script does by running
+   `pub get` in each directory that contains a `pubspec.yaml` file.
 
 Running the examples
 --------------------


### PR DESCRIPTION
The new `flutter update-packages` command replaces the old `./dev/update_packages.dart`. This update fixes the docs.
