### PR TITLE
add back a call to device.stop() from the run command

### DIFF
--- a/packages/flutter_tools/lib/src/android/adb.dart
+++ b/packages/flutter_tools/lib/src/android/adb.dart
@@ -234,12 +234,16 @@ class AdbDevice {
   }
 }
 
+final RegExp _whitespaceRegex = new RegExp(r'\s+');
+
 String cleanAdbDeviceName(String name) {
   // Some emulators use `___` in the name as separators.
   name = name.replaceAll('___', ', ');
 
   // Convert `Nexus_7` / `Nexus_5X` style names to `Nexus 7` ones.
   name = name.replaceAll('_', ' ');
+
+  name = name.replaceAll(_whitespaceRegex, ' ').trim();
 
   return name;
 }

--- a/packages/flutter_tools/lib/src/android/android_device.dart
+++ b/packages/flutter_tools/lib/src/android/android_device.dart
@@ -207,6 +207,7 @@ class AndroidDevice extends Device {
       this.clearLogs();
 
     runCheckedSync(adbCommandForDevice(<String>['push', bundlePath, _deviceBundlePath]));
+
     List<String> cmd = adbCommandForDevice(<String>[
       'shell', 'am', 'start',
       '-a', 'android.intent.action.RUN',
@@ -270,10 +271,9 @@ class AndroidDevice extends Device {
     }
   }
 
-  Future<bool> stopApp(ApplicationPackage app) async {
-    final AndroidApk apk = app;
-    runSync(adbCommandForDevice(<String>['shell', 'am', 'force-stop', apk.id]));
-    return true;
+  Future<bool> stopApp(ApplicationPackage app) {
+    List<String> command = adbCommandForDevice(<String>['shell', 'am', 'force-stop', app.id]);
+    return runCommandAndStreamOutput(command).then((int exitCode) => exitCode == 0);
   }
 
   @override

--- a/packages/flutter_tools/lib/src/commands/apk.dart
+++ b/packages/flutter_tools/lib/src/commands/apk.dart
@@ -349,16 +349,20 @@ bool _needsRebuild(String apkPath, String manifest) {
   Iterable<FileStat> dependenciesStat = [
     manifest,
     _kFlutterManifestPath,
-    _kPackagesStatusPath,
-    '$apkPath.sha1'
+    _kPackagesStatusPath
   ].map((String path) => FileStat.statSync(path));
 
   if (apkStat.type == FileSystemEntityType.NOT_FOUND)
     return true;
+
   for (FileStat dep in dependenciesStat) {
     if (dep.modified == null || dep.modified.isAfter(apkStat.modified))
       return true;
   }
+
+  if (!FileSystemEntity.isFileSync('$apkPath.sha1'))
+    return true;
+
   return false;
 }
 

--- a/packages/flutter_tools/lib/src/commands/run.dart
+++ b/packages/flutter_tools/lib/src/commands/run.dart
@@ -169,9 +169,10 @@ Future<int> startApp(
       return result;
   }
 
-  // TODO: Move this into the startApp() device impl. They should wait on the
-  // stop command to complete before (re-)starting the app. We could plumb a
-  // Future through the start command from here, but that seems a little messy.
+  // TODO(devoncarew): Move this into the device.startApp() impls. They should
+  // wait on the stop command to complete before (re-)starting the app. We could
+  // plumb a Future through the start command from here, but that seems a little
+  // messy.
   if (stop) {
     for (Device device in devices.all) {
       if (!device.isSupported())

--- a/packages/flutter_tools/lib/src/commands/run.dart
+++ b/packages/flutter_tools/lib/src/commands/run.dart
@@ -19,7 +19,6 @@ import '../toolchain.dart';
 import 'apk.dart';
 import 'devices.dart';
 import 'install.dart';
-import 'stop.dart';
 
 /// Given the value of the --target option, return the path of the Dart file
 /// where the app's main function should be.
@@ -65,7 +64,7 @@ class RunCommand extends RunCommandBase {
 
   RunCommand() {
     argParser.addFlag('full-restart',
-        defaultsTo: false,
+        defaultsTo: true,
         help: 'Stop any currently running application process before starting the app.');
     argParser.addFlag('clear-logs',
         defaultsTo: true,
@@ -111,6 +110,7 @@ class RunCommand extends RunCommandBase {
       return 1;
     }
 
+    // TODO(devoncarew): Switch this to using [devicesForCommand].
     int result = await startApp(
       devices,
       applicationPackages,
@@ -140,7 +140,7 @@ Future<int> startApp(
   List<BuildConfiguration> configs, {
   String target,
   String enginePath,
-  bool stop: false,
+  bool stop: true,
   bool install: true,
   bool checked: true,
   bool traceStartup: false,
@@ -169,10 +169,25 @@ Future<int> startApp(
       return result;
   }
 
+  // TODO: Move this into the startApp() device impl. They should wait on the
+  // stop command to complete before (re-)starting the app. We could plumb a
+  // Future through the start command from here, but that seems a little messy.
   if (stop) {
-    printTrace('Running stop command.');
-    await stopAll(devices, applicationPackages);
+    for (Device device in devices.all) {
+      if (!device.isSupported())
+        continue;
+
+      ApplicationPackage package = applicationPackages.getPackageForPlatform(device.platform);
+      if (package != null) {
+        printTrace("Stopping app '${package.name}' on ${device.name}.");
+        // We don't wait for the stop command to complete.
+        device.stopApp(package);
+      }
+    }
   }
+
+  // Allow any stop commands from above to start work.
+  await new Future.delayed(Duration.ZERO);
 
   if (install) {
     printTrace('Running install command.');
@@ -193,8 +208,6 @@ Future<int> startApp(
       unsupportedCount++;
       continue;
     }
-
-    printTrace('Running build command for $device.');
 
     Map<String, dynamic> platformArgs = <String, dynamic>{};
 
@@ -223,9 +236,8 @@ Future<int> startApp(
       // If the user specified --start-paused (and the device supports it) then
       // wait for the observatory port to become available before returning from
       // `startApp()`.
-      if (startPaused && device.supportsStartPaused) {
+      if (startPaused && device.supportsStartPaused)
         await delayUntilObservatoryAvailable('localhost', debugPort);
-      }
     }
   }
 


### PR DESCRIPTION
- revert a change to not call device.stop() from the run command (fix https://github.com/flutter/flutter/issues/2251). Instead, we initiate an async stop call (`adb shell am force-stop`).
- fix an issue with our APK dirty logic where we would check against the timestamp of the .sha1 file. That file is generally written after the APK, so the APK would always seem dirty. Instead, we just ensure that a sha file exists
- slight tweak to the adb device name cleanup to handle some emulator names
