### PR TITLE
@override annotation cleanup.

### DIFF
--- a/packages/cassowary/lib/constant_member.dart
+++ b/packages/cassowary/lib/constant_member.dart
@@ -5,12 +5,15 @@
 part of cassowary;
 
 class ConstantMember extends _EquationMember {
+  @override
   final double value;
 
+  @override
   bool get isConstant => true;
 
   ConstantMember(this.value);
 
+  @override
   Expression asExpression() => new Expression([], this.value);
 }
 

--- a/packages/cassowary/lib/constraint.dart
+++ b/packages/cassowary/lib/constraint.dart
@@ -15,6 +15,7 @@ class Constraint {
 
   Constraint operator |(double p) => this..priority = p;
 
+  @override
   String toString() {
     StringBuffer buffer = new StringBuffer();
     buffer.write(expression.toString());

--- a/packages/cassowary/lib/equation_member.dart
+++ b/packages/cassowary/lib/equation_member.dart
@@ -25,6 +25,7 @@ abstract class _EquationMember {
 
   Expression operator /(_EquationMember m) => asExpression() / m;
 
+  @override
   int get hashCode =>
       throw "An equation member is not comparable and cannot be added to collections";
 }

--- a/packages/cassowary/lib/expression.dart
+++ b/packages/cassowary/lib/expression.dart
@@ -9,8 +9,10 @@ class Expression extends _EquationMember {
 
   final double constant;
 
+  @override
   bool get isConstant => terms.length == 0;
 
+  @override
   double get value => terms.fold(constant, (value, term) => value + term.value);
 
   Expression(this.terms, this.constant);
@@ -18,6 +20,7 @@ class Expression extends _EquationMember {
       : this.terms = new List<Term>.from(expr.terms),
         this.constant = expr.constant;
 
+  @override
   Expression asExpression() => this;
 
   Constraint _createConstraint(
@@ -51,15 +54,19 @@ class Expression extends _EquationMember {
     return null;
   }
 
+  @override
   Constraint operator >=(_EquationMember value) =>
       _createConstraint(value, Relation.greaterThanOrEqualTo);
 
+  @override
   Constraint operator <=(_EquationMember value) =>
       _createConstraint(value, Relation.lessThanOrEqualTo);
 
+  @override
   Constraint equals(_EquationMember value) =>
     _createConstraint(value, Relation.equalTo);
 
+  @override
   Expression operator +(_EquationMember m) {
     if (m is ConstantMember) {
       return new Expression(new List.from(terms), constant + m.value);
@@ -83,6 +90,7 @@ class Expression extends _EquationMember {
     return null;
   }
 
+  @override
   Expression operator -(_EquationMember m) {
     if (m is ConstantMember) {
       return new Expression(new List.from(terms), constant - m.value);

--- a/packages/cassowary/lib/variable.dart
+++ b/packages/cassowary/lib/variable.dart
@@ -23,5 +23,6 @@ class Variable {
 
   String get debugName => _elvis(name, 'variable$_tick');
 
+  @override
   String toString() => debugName;
 }


### PR DESCRIPTION
Added missing @override annotations (as per the `annotate_overrides` lint rule).

cc: @Hixie 
