### PR TITLE
Remove IconThemeColor

### DIFF
--- a/examples/widgets/card_collection.dart
+++ b/examples/widgets/card_collection.dart
@@ -120,7 +120,7 @@ class CardCollectionState extends State<CardCollection> {
   Widget _buildDrawer() {
     return new Drawer(
       child: new IconTheme(
-        data: const IconThemeData(color: IconThemeColor.black),
+        data: const IconThemeData(color: Colors.black),
         child: new Block(children: <Widget>[
           new DrawerHeader(child: new Text('Options')),
           buildDrawerCheckbox("Make card labels editable", _editable, _toggleEditable),
@@ -385,7 +385,7 @@ class CardCollectionState extends State<CardCollection> {
 
     return new IconTheme(
       key: cardModel.key,
-      data: const IconThemeData(color: IconThemeColor.white),
+      data: const IconThemeData(color: Colors.white),
       child: new Stack(children: <Widget>[background, card])
     );
   }

--- a/examples/widgets/pageable_list.dart
+++ b/examples/widgets/pageable_list.dart
@@ -124,7 +124,7 @@ class PageableListAppState extends State<PageableListApp> {
 
   Widget build(BuildContext context) {
     return new IconTheme(
-      data: const IconThemeData(color: IconThemeColor.white),
+      data: const IconThemeData(color: Colors.white),
       child: new Scaffold(
         toolBar: _buildToolBar(),
         drawer: _buildDrawer(),

--- a/packages/flutter/lib/src/material/floating_action_button.dart
+++ b/packages/flutter/lib/src/material/floating_action_button.dart
@@ -4,8 +4,9 @@
 
 import 'package:flutter/widgets.dart';
 
-import 'icon_theme.dart';
+import 'colors.dart';
 import 'icon_theme_data.dart';
+import 'icon_theme.dart';
 import 'ink_well.dart';
 import 'material.dart';
 import 'theme.dart';
@@ -94,17 +95,17 @@ class _FloatingActionButtonState extends State<FloatingActionButton> {
   }
 
   Widget build(BuildContext context) {
-    IconThemeColor iconThemeColor = IconThemeColor.white;
+    Color iconColor = Colors.white;
     Color materialColor = config.backgroundColor;
     if (materialColor == null) {
       ThemeData themeData = Theme.of(context);
       materialColor = themeData.accentColor;
-      iconThemeColor = themeData.accentColorBrightness == ThemeBrightness.dark ? IconThemeColor.white : IconThemeColor.black;
+      iconColor = themeData.accentColorBrightness == ThemeBrightness.dark ? Colors.white : Colors.black;
     }
 
     Widget result = new Center(
       child: new IconTheme(
-        data: new IconThemeData(color: iconThemeColor),
+        data: new IconThemeData(color: iconColor),
         child: new RotationTransition(
           turns: _childSegue,
           child: config.child

--- a/packages/flutter/lib/src/material/grid_tile_bar.dart
+++ b/packages/flutter/lib/src/material/grid_tile_bar.dart
@@ -4,6 +4,7 @@
 
 import 'package:flutter/widgets.dart';
 
+import 'colors.dart';
 import 'icon_theme.dart';
 import 'icon_theme_data.dart';
 import 'typography.dart';
@@ -77,7 +78,7 @@ class GridTileBar extends StatelessComponent {
       padding: padding,
       decoration: decoration,
       child: new IconTheme(
-        data: new IconThemeData(color: IconThemeColor.white),
+        data: new IconThemeData(color: Colors.white),
         child: new Row(
           alignItems: FlexAlignItems.center,
           children: children

--- a/packages/flutter/lib/src/material/icon.dart
+++ b/packages/flutter/lib/src/material/icon.dart
@@ -7,7 +7,6 @@ import 'package:flutter/widgets.dart';
 import 'colors.dart';
 import 'icons.dart';
 import 'icon_theme.dart';
-import 'icon_theme_data.dart';
 import 'theme.dart';
 
 class Icon extends StatelessComponent {
@@ -15,53 +14,43 @@ class Icon extends StatelessComponent {
     Key key,
     this.size: 24.0,
     this.icon,
-    this.colorTheme,
     this.color
   }) : super(key: key) {
     assert(size != null);
   }
 
+  /// The size of the icon in logical pixels.
+  ///
+  /// Icons occupy a square with width and height equal to size.
   final double size;
+
+  /// The icon to display.
   final IconData icon;
-  final IconThemeColor colorTheme;
+
+  /// The color to use when drawing the icon.
   final Color color;
 
-  IconThemeColor _getIconThemeColor(BuildContext context) {
-    IconThemeColor iconThemeColor = colorTheme;
-    if (iconThemeColor == null) {
-      IconThemeData iconThemeData = IconTheme.of(context);
-      iconThemeColor = iconThemeData == null ? null : iconThemeData.color;
+  Color _getDefaultColorForThemeBrightness(ThemeBrightness brightness) {
+    switch (brightness) {
+      case ThemeBrightness.dark:
+        return Colors.white;
+      case ThemeBrightness.light:
+        return Colors.black;
     }
-    if (iconThemeColor == null) {
-      ThemeBrightness themeBrightness = Theme.of(context).brightness;
-      iconThemeColor = themeBrightness == ThemeBrightness.dark ? IconThemeColor.white : IconThemeColor.black;
-    }
-    return iconThemeColor;
+  }
+
+  Color _getDefaultColor(BuildContext context) {
+    return IconTheme.of(context)?.color ?? _getDefaultColorForThemeBrightness(Theme.of(context).brightness);
   }
 
   Widget build(BuildContext context) {
-    if (icon == null) {
-      return new SizedBox(
-        width: size,
-        height: size
-      );
-    }
+    if (icon == null)
+      return new SizedBox(width: size, height: size);
 
-    Color iconColor = color;
+    Color iconColor = color ?? _getDefaultColor(context);
     final int iconAlpha = (255.0 * (IconTheme.of(context)?.clampedOpacity ?? 1.0)).round();
-    if (color != null) {
-        if (iconAlpha != 255)
-          iconColor = color.withAlpha((iconAlpha * color.opacity).round());
-    } else {
-      switch(_getIconThemeColor(context)) {
-        case IconThemeColor.black:
-          iconColor = Colors.black.withAlpha(iconAlpha);
-          break;
-        case IconThemeColor.white:
-          iconColor = Colors.white.withAlpha(iconAlpha);
-          break;
-      }
-    }
+    if (iconAlpha != 255)
+        iconColor = color.withAlpha((iconAlpha * color.opacity).round());
 
     return new SizedBox(
       width: size,
@@ -83,8 +72,6 @@ class Icon extends StatelessComponent {
     super.debugFillDescription(description);
     description.add('$icon');
     description.add('size: $size');
-    if (this.colorTheme != null)
-      description.add('colorTheme: $colorTheme');
     if (this.color != null)
       description.add('color: $color');
   }

--- a/packages/flutter/lib/src/material/icon_button.dart
+++ b/packages/flutter/lib/src/material/icon_button.dart
@@ -6,7 +6,6 @@ import 'package:flutter/widgets.dart';
 
 import 'icon.dart';
 import 'icons.dart';
-import 'icon_theme_data.dart';
 import 'ink_well.dart';
 import 'theme.dart';
 import 'tooltip.dart';
@@ -25,21 +24,32 @@ class IconButton extends StatelessComponent {
     Key key,
     this.size: 24.0,
     this.icon,
-    this.colorTheme,
     this.color,
     this.onPressed,
     this.tooltip
   }) : super(key: key);
 
+  /// The size of the icon inside the button.
+  ///
+  /// The button itself will be larger than the icon by 8.0 logical pixels in
+  /// each direction.
   final double size;
+
+  /// The icon to display inside the button.
   final IconData icon;
-  final IconThemeColor colorTheme;
+
+  /// The color to use for the icon inside the button.
   final Color color;
 
   /// The callback that is invoked when the button is tapped or otherwise activated.
   ///
   /// If this is set to null, the button will be disabled.
   final VoidCallback onPressed;
+
+  /// Text that describes the action that will occur when the button is pressed.
+  ///
+  /// This text is displayed when the user long-presses on the button and is
+  /// used for accessibility.
   final String tooltip;
 
   Widget build(BuildContext context) {
@@ -48,7 +58,6 @@ class IconButton extends StatelessComponent {
       child: new Icon(
         size: size,
         icon: icon,
-        colorTheme: colorTheme,
         color: onPressed != null ? color : Theme.of(context).disabledColor
       )
     );
@@ -69,8 +78,6 @@ class IconButton extends StatelessComponent {
     description.add('$icon');
     if (onPressed == null)
       description.add('disabled');
-    if (colorTheme != null)
-      description.add('$colorTheme');
     if (tooltip != null)
       description.add('tooltip: "$tooltip"');
   }

--- a/packages/flutter/lib/src/material/icon_theme_data.dart
+++ b/packages/flutter/lib/src/material/icon_theme_data.dart
@@ -3,21 +3,22 @@
 // found in the LICENSE file.
 
 import 'dart:ui' as ui show lerpDouble;
-import 'dart:ui' show hashValues;
-
-enum IconThemeColor { white, black }
+import 'dart:ui' show Color, hashValues;
 
 class IconThemeData {
   const IconThemeData({ this.color, this.opacity });
 
-  final IconThemeColor color;
+  /// The default color for icons.
+  final Color color;
+
+  /// An opacity to apply to both explicit and default icon colors.
   final double opacity;
 
   double get clampedOpacity => (opacity ?? 1.0).clamp(0.0, 1.0);
 
   static IconThemeData lerp(IconThemeData begin, IconThemeData end, double t) {
     return new IconThemeData(
-      color: t < 0.5 ? begin.color : end.color,
+      color: Color.lerp(begin.color, end.color, t),
       opacity: ui.lerpDouble(begin.clampedOpacity, end.clampedOpacity, t)
     );
   }

--- a/packages/flutter/lib/src/material/theme_data.dart
+++ b/packages/flutter/lib/src/material/theme_data.dart
@@ -125,7 +125,7 @@ class ThemeData {
     errorColor ??= Colors.red[700];
     text ??= isDark ? Typography.white : Typography.black;
     primaryTextTheme ??= primaryColorBrightness == ThemeBrightness.dark ? Typography.white : Typography.black;
-    primaryIconTheme ??= primaryColorBrightness == ThemeBrightness.dark ? const IconThemeData(color: IconThemeColor.white) : const IconThemeData(color: IconThemeColor.black);
+    primaryIconTheme ??= primaryColorBrightness == ThemeBrightness.dark ? const IconThemeData(color: Colors.white) : const IconThemeData(color: Colors.black);
     return new ThemeData.raw(
       brightness: brightness,
       primaryColor: primaryColor,


### PR DESCRIPTION
This enum doesn't make sense anymore now that we can arbitrarily colorize
icons.  Instead, we just use a Color, which is both simpler and can be
interpolated during animations.

Fixes #1279
