### PR TITLE
Remove test dependency from package:flutter

### DIFF
--- a/packages/flutter/pubspec.yaml
+++ b/packages/flutter/pubspec.yaml
@@ -7,14 +7,8 @@ homepage: http://flutter.io
 dependencies:
   collection: '>=1.1.3 <2.0.0'
   intl: '>=0.12.4+2 <0.13.0'
-  material_design_icons: '>=0.0.3 <0.1.0'
   vector_math: '>=1.4.5 <2.0.0'
   quiver: '>=0.21.4 <0.22.0'
-
-  # See the comment in flutter_tools' pubspec.yaml. We have to pin it
-  # here also because sky_services depends on mojo_sdk which depends
-  # on test.
-  test: 0.12.11+1
 
   # We have to pin analyzer to 0.27.1 because the flx package depends
   # on pointycastle which depends on reflectable which depends on
@@ -23,6 +17,10 @@ dependencies:
   # results in 'flutter analyze' (which uses an entirely different
   # analyzer, by the way!) complaining about the inconsistency.
   analyzer: 0.27.1
+
+  # TODO(abarth): Remove once we've updated the iOS build to not assert that
+  # this package exists.
+  material_design_icons: '>=0.0.3 <0.1.0'
 
   sky_engine:
     path: ../../bin/cache/pkg/sky_engine

--- a/packages/flutter_test/lib/src/service_mocker.dart
+++ b/packages/flutter_test/lib/src/service_mocker.dart
@@ -1,3 +1,7 @@
+// Copyright 2015 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 import 'package:flutter/services.dart';
 import 'package:mojo/bindings.dart' as bindings;
 

--- a/packages/flutter_test/pubspec.yaml
+++ b/packages/flutter_test/pubspec.yaml
@@ -4,7 +4,3 @@ dependencies:
   quiver: ^0.21.4
   flutter:
     path: ../flutter
-
-  # So that the test harness is available when running the tests.
-  flutter_tools:
-    path: ../flutter_tools

--- a/packages/flutter_tools/pubspec.yaml
+++ b/packages/flutter_tools/pubspec.yaml
@@ -28,8 +28,7 @@ dependencies:
 # A note about 'test':
 # We depend on very specific internal implementation details of the
 # 'test' package, which change between versions, so here we pin it
-# precisely. This is also pinned in the 'flutter' package.
-# See also https://github.com/dart-lang/test/pull/320
+# precisely.
 
 # A note about 'analyzer':
 # We don't actually depend on 'analyzer', but 'test' does. We aren't


### PR DESCRIPTION
The mojo_sdk has cleaned up its dependencies, so we no longer need to depend on
package:test from package:flutter.
