### PR TITLE
fix the zip tool when building for ios

### DIFF
--- a/packages/flutter_tools/lib/src/zip.dart
+++ b/packages/flutter_tools/lib/src/zip.dart
@@ -91,16 +91,21 @@ class _ZipToolBuilder extends ZipBuilder {
       }
     }
 
-    runCheckedSync(
-      <String>['zip', '-q', outFile.absolute.path]..addAll(_getCompressedNames()),
-      workingDirectory: zipBuildDir.path,
-      truncateCommand: true
-    );
-    runCheckedSync(
-      <String>['zip', '-q', '-0', outFile.absolute.path]..addAll(_getStoredNames()),
-      workingDirectory: zipBuildDir.path,
-      truncateCommand: true
-    );
+    if (_getCompressedNames().isNotEmpty) {
+      runCheckedSync(
+        <String>['zip', '-q', outFile.absolute.path]..addAll(_getCompressedNames()),
+        workingDirectory: zipBuildDir.path,
+        truncateCommand: true
+      );
+    }
+
+    if (_getStoredNames().isNotEmpty) {
+      runCheckedSync(
+        <String>['zip', '-q', '-0', outFile.absolute.path]..addAll(_getStoredNames()),
+        workingDirectory: zipBuildDir.path,
+        truncateCommand: true
+      );
+    }
   }
 
   Iterable<String> _getCompressedNames() {


### PR DESCRIPTION
Fix the zip tool when building for ios. We were creating invalid args to the `zip` tool when there were no entries to add (no snapshot file?).
