### PR TITLE
Container's child is now inset by the Container's border

### DIFF
--- a/packages/flutter/lib/src/material/two_level_list.dart
+++ b/packages/flutter/lib/src/material/two_level_list.dart
@@ -110,7 +110,7 @@ class _TwoLevelSublistState extends State<TwoLevelSublist> {
             onTap: _handleOnTap,
             left: config.left,
             center: new DefaultTextStyle(
-              style: Theme.of(context).text.body1.copyWith(color: _headerColor.evaluate(_easeInAnimation)),
+              style: Theme.of(context).text.subhead.copyWith(color: _headerColor.evaluate(_easeInAnimation)),
               child: config.center
             ),
             right: new RotationTransition(
@@ -136,7 +136,7 @@ class _TwoLevelSublistState extends State<TwoLevelSublist> {
     final ThemeData theme = Theme.of(context);
     _borderColor.end = theme.dividerColor;
     _headerColor
-      ..begin = theme.text.body1.color
+      ..begin = theme.text.subhead.color
       ..end = theme.accentColor;
     _iconColor
       ..begin = theme.unselectedColor

--- a/packages/flutter/lib/src/painting/box_painter.dart
+++ b/packages/flutter/lib/src/painting/box_painter.dart
@@ -793,6 +793,9 @@ class BoxDecoration extends Decoration {
   /// The shape to fill the background color into and to cast as a shadow.
   final BoxShape shape;
 
+  /// The inset space occupied by the border.
+  EdgeDims get padding => border?.dimensions;
+
   /// Returns a new box decoration that is scaled by the given factor.
   BoxDecoration scale(double factor) {
     // TODO(abarth): Scale ALL the things.

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -109,6 +109,7 @@ class ShaderMask extends OneChildRenderObjectWidget {
 }
 
 /// Paints a [Decoration] either before or after its child paints.
+/// Container insets its child by the widths of the borders, this Widget does not.
 ///
 /// Commonly used with [BoxDecoration].
 class DecoratedBox extends OneChildRenderObjectWidget {

--- a/packages/flutter/test/widget/box_decoration_test.dart
+++ b/packages/flutter/test/widget/box_decoration_test.dart
@@ -22,4 +22,23 @@ void main() {
       );
     });
   });
+
+  test('Bordered Container insets its child', () {
+    testWidgets((WidgetTester tester) {
+      Key key = new Key('outerContainer');
+      tester.pumpWidget(
+        new Center(
+          child: new Container(
+            key: key,
+            decoration: new BoxDecoration(border: new Border.all(width: 10.0)),
+            child: new Container(
+              width: 25.0,
+              height: 25.0
+            )
+          )
+        )
+      );
+      expect(tester.getSize(tester.findElementByKey(key)), equals(const Size(45.0, 45.0)));
+    });
+  });
 }

--- a/packages/flutter/test/widget/two_level_list_test.dart
+++ b/packages/flutter/test/widget/two_level_list_test.dart
@@ -49,8 +49,9 @@ void main() {
       expect(getY(topKey), lessThan(getY(sublistKey)));
       expect(getY(sublistKey), lessThan(getY(bottomKey)));
 
-      expect(getHeight(topKey), equals(getHeight(sublistKey)));
-      expect(getHeight(sublistKey), equals(getHeight(bottomKey)));
+      // The sublist has a one pixel border above and below.
+      expect(getHeight(topKey), equals(getHeight(sublistKey) - 2.0));
+      expect(getHeight(bottomKey), equals(getHeight(sublistKey) - 2.0));
 
       tester.tap(tester.findText('Sublist'));
       tester.pump(const Duration(seconds: 1));


### PR DESCRIPTION
BoxDecoration now overrides 'get padding'. Thanks to @Hixie for this fix.

Also: correct the font used for TwoLevelList items.

Fixes https://github.com/flutter/flutter/issues/2386
