### PR TITLE
Make _initRootBundle more robust

### DIFF
--- a/packages/flutter/lib/src/services/asset_bundle.dart
+++ b/packages/flutter/lib/src/services/asset_bundle.dart
@@ -96,14 +96,11 @@ class MojoAssetBundle extends CachingAssetBundle {
 }
 
 AssetBundle _initRootBundle() {
-  try {
-    AssetBundleProxy bundle = new AssetBundleProxy.fromHandle(
-      new core.MojoHandle(ui.takeRootBundleHandle())
-    );
-    return new MojoAssetBundle(bundle);
-  } catch (e) {
+  int h = ui.takeRootBundleHandle();
+  if (h == core.MojoHandle.INVALID)
     return null;
-  }
+  core.MojoHandle handle = new core.MojoHandle(h);
+  return new MojoAssetBundle(new AssetBundleProxy.fromHandle(handle));
 }
 
 final AssetBundle rootBundle = _initRootBundle();

--- a/packages/flutter/lib/src/services/print.dart
+++ b/packages/flutter/lib/src/services/print.dart
@@ -46,9 +46,5 @@ void _debugPrintTask() {
 }
 
 void debugPrintStack() {
-  try {
-    throw new Exception();
-  } catch (e, stack) {
-    debugPrint(stack.toString());
-  }
+  debugPrint(StackTrace.current.toString());
 }


### PR DESCRIPTION
Rather than catching every exception, we now handle the one specific case where
we legitimately cannot create the root bundle.

Fixes #900
