### PR TITLE
fix a mac test

### DIFF
--- a/packages/flutter_tools/lib/src/commands/create.dart
+++ b/packages/flutter_tools/lib/src/commands/create.dart
@@ -128,7 +128,10 @@ All done! In order to run your application, type:
 
   void _renderTemplates(String projectName, String dirPath,
       String flutterPackagesDirectory, { bool renderDriverTest: false }) {
-    String relativeFlutterPackagesDirectory = path.relative(flutterPackagesDirectory, from: dirPath);
+    String relativePackagesDirectory = path.relative(
+      flutterPackagesDirectory,
+      from: path.join(dirPath, 'pubspec.yaml')
+    );
 
     printStatus('Creating project ${path.basename(projectName)}:');
 
@@ -139,7 +142,7 @@ All done! In order to run your application, type:
       'androidIdentifier': _createAndroidIdentifier(projectName),
       'iosIdentifier': _createUTIIdentifier(projectName),
       'description': description,
-      'flutterPackagesDirectory': relativeFlutterPackagesDirectory,
+      'flutterPackagesDirectory': relativePackagesDirectory,
       'androidMinApiLevel': android.minApiLevel
     };
 

--- a/packages/flutter_tools/test/create_test.dart
+++ b/packages/flutter_tools/test/create_test.dart
@@ -27,34 +27,28 @@ defineTests() {
       temp.deleteSync(recursive: true);
     });
 
-    // This test consistently times out on our windows bot. The code is already
-    // covered on the linux one.
-    // Also fails on mac, with create --out returning '69'
-    // TODO(devoncarew): https://github.com/flutter/flutter/issues/1709
-    if (Platform.isLinux) {
-      // Verify that we create a project that is well-formed.
-      testUsingContext('flutter-simple', () async {
-        ArtifactStore.flutterRoot = '../..';
-        CreateCommand command = new CreateCommand();
-        CommandRunner runner = new CommandRunner('test_flutter', '')
-          ..addCommand(command);
-        await runner.run(['create', '--out', temp.path])
-            .then((int code) => expect(code, equals(0)));
+    // Verify that we create a project that is well-formed.
+    testUsingContext('flutter-simple', () async {
+      ArtifactStore.flutterRoot = '../..';
+      CreateCommand command = new CreateCommand();
+      CommandRunner runner = new CommandRunner('test_flutter', '')
+        ..addCommand(command);
+      await runner.run(['create', '--out', temp.path])
+          .then((int code) => expect(code, equals(0)));
 
-        String mainPath = path.join(temp.path, 'lib', 'main.dart');
-        expect(new File(mainPath).existsSync(), true);
-        ProcessResult exec = Process.runSync(
-          sdkBinaryName('dartanalyzer'), ['--fatal-warnings', mainPath],
-          workingDirectory: temp.path
-        );
-        if (exec.exitCode != 0) {
-          print(exec.stdout);
-          print(exec.stderr);
-        }
-        expect(exec.exitCode, 0);
-      },
-      // This test can take a while due to network requests.
-      timeout: new Timeout(new Duration(minutes: 2)));
-    }
+      String mainPath = path.join(temp.path, 'lib', 'main.dart');
+      expect(new File(mainPath).existsSync(), true);
+      ProcessResult exec = Process.runSync(
+        sdkBinaryName('dartanalyzer'), ['--fatal-warnings', mainPath],
+        workingDirectory: temp.path
+      );
+      if (exec.exitCode != 0) {
+        print(exec.stdout);
+        print(exec.stderr);
+      }
+      expect(exec.exitCode, 0);
+    },
+    // This test can take a while due to network requests.
+    timeout: new Timeout(new Duration(minutes: 2)));
   });
 }


### PR DESCRIPTION
- fix a mac test (for the create command); fix https://github.com/flutter/flutter/issues/1709

I think some relative paths (like the one for the mac temp dir) confused `path.relative()`; making it clear that it was supposed to be relative to a dir fixes it for me locally. I would like to see how the bots like it -
