### PR TITLE
Flinging continuously should have one scroll start/end pair

### DIFF
--- a/packages/flutter/test/widget/scroll_events_test.dart
+++ b/packages/flutter/test/widget/scroll_events_test.dart
@@ -95,4 +95,45 @@ void main() {
       expect(log, equals(['scrollstart', 'scroll', 'scroll', 'scrollend']));
     });
   });
+
+  test('Scroll during animation', () {
+    testWidgets((WidgetTester tester) {
+      GlobalKey<ScrollableState> scrollKey = new GlobalKey<ScrollableState>();
+      List<String> log = <String>[];
+      tester.pumpWidget(_buildScroller(key: scrollKey, log: log));
+
+      expect(log, equals([]));
+      scrollKey.currentState.scrollTo(100.0, duration: const Duration(seconds: 1));
+      expect(log, equals(['scrollstart']));
+      tester.pump(const Duration(milliseconds: 100));
+      expect(log, equals(['scrollstart']));
+      tester.pump(const Duration(milliseconds: 100));
+      expect(log, equals(['scrollstart', 'scroll']));
+      scrollKey.currentState.scrollTo(100.0, duration: const Duration(seconds: 1));
+      expect(log, equals(['scrollstart', 'scroll']));
+      tester.pump(const Duration(milliseconds: 100));
+      expect(log, equals(['scrollstart', 'scroll']));
+      tester.pump(const Duration(milliseconds: 1500));
+      expect(log, equals(['scrollstart', 'scroll', 'scroll', 'scrollend']));
+    });
+  });
+
+  test('fling, fling generates one start/end pair', () {
+    testWidgets((WidgetTester tester) {
+      GlobalKey<ScrollableState> scrollKey = new GlobalKey<ScrollableState>();
+      List<String> log = <String>[];
+      tester.pumpWidget(_buildScroller(key: scrollKey, log: log));
+
+      expect(log, equals([]));
+      tester.flingFrom(new Point(100.0, 100.0), new Offset(-50.0, -50.0), 500.0);
+      tester.pump(new Duration(seconds: 1));
+      log.removeWhere((String value) => value == 'scroll');
+      expect(log, equals(['scrollstart']));
+      tester.flingFrom(new Point(100.0, 100.0), new Offset(-50.0, -50.0), 500.0);
+      tester.pump(new Duration(seconds: 1));
+      tester.pump(new Duration(seconds: 1));
+      log.removeWhere((String value) => value == 'scroll');
+      expect(log, equals(['scrollstart', 'scrollend']));
+    });
+  });
 }


### PR DESCRIPTION
Previously we got confused and started sending start/end pairs for each tick of
the fling animation.

Fixes #2430
