### PR TITLE
implement --watch for flutter analyze

### DIFF
--- a/packages/flutter_tools/lib/src/dart/sdk.dart
+++ b/packages/flutter_tools/lib/src/dart/sdk.dart
@@ -1,0 +1,8 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:io';
+
+/// Locate the Dart SDK by finding the Dart VM and going up two directories.
+String get dartSdkPath => new File(Platform.executable).parent.parent.path;

--- a/packages/flutter_tools/test/analyze_test.dart
+++ b/packages/flutter_tools/test/analyze_test.dart
@@ -1,0 +1,87 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:io';
+
+import 'package:flutter_tools/src/base/os.dart';
+import 'package:flutter_tools/src/commands/analyze.dart';
+import 'package:flutter_tools/src/dart/pub.dart';
+import 'package:flutter_tools/src/dart/sdk.dart';
+import 'package:path/path.dart' as path;
+import 'package:test/test.dart';
+
+import 'src/context.dart';
+
+main() => defineTests();
+
+defineTests() {
+  AnalysisServer server;
+  Directory tempDir;
+
+  setUp(() {
+    tempDir = Directory.systemTemp.createTempSync('analysis_test');
+  });
+
+  tearDown(() {
+    tempDir?.deleteSync(recursive: true);
+    return server?.dispose();
+  });
+
+  group('analyze', () {
+    testUsingContext('AnalysisServer success', () async {
+      _createSampleProject(tempDir);
+
+      await pubGet(directory: tempDir.path);
+
+      server = new AnalysisServer(dartSdkPath, <String>[tempDir.path]);
+
+      int errorCount = 0;
+      Future onDone = server.onAnalyzing.where((bool analyzing) => analyzing == false).first;
+      server.onErrors.listen((FileAnalysisErrors errors) => errorCount += errors.errors.length);
+
+      await server.start();
+      await onDone;
+
+      expect(errorCount, 0);
+    }, overrides: <Type, dynamic>{
+      OperatingSystemUtils: os
+    });
+
+    testUsingContext('AnalysisServer errors', () async {
+      _createSampleProject(tempDir, brokenCode: true);
+
+      await pubGet(directory: tempDir.path);
+
+      server = new AnalysisServer(dartSdkPath, <String>[tempDir.path]);
+
+      int errorCount = 0;
+      Future onDone = server.onAnalyzing.where((bool analyzing) => analyzing == false).first;
+      server.onErrors.listen((FileAnalysisErrors errors) => errorCount += errors.errors.length);
+
+      await server.start();
+      await onDone;
+
+      expect(errorCount, 2);
+    }, overrides: <Type, dynamic>{
+      OperatingSystemUtils: os
+    });
+  });
+}
+
+void _createSampleProject(Directory directory, { bool brokenCode: false }) {
+  File pubspecFile = new File(path.join(directory.path, 'pubspec.yaml'));
+  pubspecFile.writeAsStringSync('''
+name: foo_project
+''');
+
+  File dartFile = new File(path.join(directory.path, 'lib', 'main.dart'));
+  dartFile.parent.createSync();
+  dartFile.writeAsStringSync('''
+void main() {
+  print('hello world');
+  ${brokenCode ? 'prints("hello world");' : ''}
+}
+''');
+}


### PR DESCRIPTION
- implement `flutter analyze --watch` by starting an instance of the analysis server
- the incremental analysis time is ~100ms (w/ a startup time of ~100s)
- this compares to ~50 seconds for `flutter analyze --flutter-repo`. I think the analysis server is slower for the first run because it analyzes the libraries referenced by the 14 flutter repo packages separately.

Some sample output:

```
Analyzing flutter...
0 issues found • analyzed 547 files, 95.82 seconds

warning • The method 'adds' is not defined for the class 'StreamController<bool>' • packages/flutter_tools/lib/src/commands/analyze.dart:677:28
1 new issue, 1 total • analyzed 4 files, 0.10 seconds

1 issue fixed, 0 remaining • analyzed 4 files, 0.10 seconds

no issues found • analyzed 4 files, 0.10 seconds

  error • Expected to find ';' • packages/flutter_tools/lib/src/commands/analyze.dart:682:5
warning • The method 'r' is not defined for the class 'AnalysisServer' • packages/flutter_tools/lib/src/commands/analyze.dart:682:15
warning • Undefined name 'printErro' • packages/flutter_tools/lib/src/commands/analyze.dart:682:5
3 new issues, 3 total • analyzed 4 files, 0.11 seconds

3 issues fixed, 0 remaining • analyzed 4 files, 0.11 seconds
```

@Hixie, @pq

Also @pq, we'll need to get the analysis configuration into sky_engine's _embedder.yaml file. I think `_embedder.yaml` support is close? In which case we'll want to prefer putting config in there (instead of finding a way to share the command-line regex code).
