### PR TITLE
Added support for Dismissable leave-behind list items

### DIFF
--- a/examples/material_gallery/lib/demo/leave_behind_demo.dart
+++ b/examples/material_gallery/lib/demo/leave_behind_demo.dart
@@ -1,0 +1,149 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+
+enum LeaveBehindDemoAction {
+  reset,
+  horizontalSwipe,
+  leftSwipe,
+  rightSwipe
+}
+
+class LeaveBehindItem {
+  LeaveBehindItem({ this.index, this.name, this.subject, this.body });
+
+  LeaveBehindItem.from(LeaveBehindItem item)
+    : index = item.index, name = item.name, subject = item.subject, body = item.body;
+
+  final int index;
+  final String name;
+  final String subject;
+  final String body;
+}
+
+class LeaveBehindDemo extends StatefulComponent {
+  LeaveBehindDemo({ Key key }) : super(key: key);
+
+  LeaveBehindDemoState createState() => new LeaveBehindDemoState();
+}
+
+class LeaveBehindDemoState extends State<LeaveBehindDemo> {
+  final GlobalKey<ScaffoldState> _scaffoldKey = new GlobalKey<ScaffoldState>();
+  DismissDirection _dismissDirection = DismissDirection.horizontal;
+  List<LeaveBehindItem> leaveBehindItems;
+
+  void initListItems() {
+    leaveBehindItems = new List.generate(16, (int index) {
+      return new LeaveBehindItem(
+        index: index,
+        name: 'Item $index Sender',
+        subject: 'Subject: $index',
+        body: "[$index] first line of the message's body..."
+      );
+    });
+  }
+
+  void initState() {
+    super.initState();
+    initListItems();
+  }
+
+  void handleDemoAction(LeaveBehindDemoAction action) {
+    switch(action) {
+      case LeaveBehindDemoAction.reset:
+        initListItems();
+        break;
+      case LeaveBehindDemoAction.horizontalSwipe:
+        _dismissDirection = DismissDirection.horizontal;
+        break;
+      case LeaveBehindDemoAction.leftSwipe:
+        _dismissDirection = DismissDirection.left;
+        break;
+      case LeaveBehindDemoAction.rightSwipe:
+        _dismissDirection = DismissDirection.right;
+        break;
+    }
+  }
+
+  Widget buildItem(LeaveBehindItem item) {
+    final ThemeData theme = Theme.of(context);
+    return new Dismissable(
+      key: new ObjectKey(item),
+      direction: _dismissDirection,
+      onDismissed: (DismissDirection direction) {
+        setState(() {
+          leaveBehindItems.remove(item);
+        });
+        final String action = (direction == DismissDirection.left) ? 'archived' : 'deleted';
+        _scaffoldKey.currentState.showSnackBar(new SnackBar(
+          content: new Text('You $action item ${item.index}')
+        ));
+      },
+      background: new Container(
+        decoration: new BoxDecoration(backgroundColor: theme.primaryColor),
+        child: new ListItem(
+          left: new Icon(icon: Icons.delete, color: Colors.white, size: 36.0)
+        )
+      ),
+      secondaryBackground: new Container(
+        decoration: new BoxDecoration(backgroundColor: theme.primaryColor),
+        child: new ListItem(
+          right: new Icon(icon: Icons.archive, color: Colors.white, size: 36.0)
+        )
+      ),
+      child: new Container(
+        decoration: new BoxDecoration(
+          backgroundColor: theme.canvasColor,
+          border: new Border(bottom: new BorderSide(color: theme.dividerColor))
+        ),
+        child: new ListItem(
+          primary: new Text(item.name),
+          secondary: new Text('${item.subject}\n${item.body}'),
+          isThreeLine: true
+        )
+      )
+    );
+  }
+
+  Widget build(BuildContext context) {
+    return new Scaffold(
+      key: _scaffoldKey,
+      toolBar: new ToolBar(
+        center: new Text('Swipe Items to Dismiss'),
+        right: <Widget>[
+          new PopupMenuButton<LeaveBehindDemoAction>(
+            onSelected: handleDemoAction,
+            items: <PopupMenuEntry>[
+              new PopupMenuItem<LeaveBehindDemoAction>(
+                value: LeaveBehindDemoAction.reset,
+                child: new Text('Reset the list')
+              ),
+              new PopupMenuDivider(),
+              new CheckedPopupMenuItem<LeaveBehindDemoAction>(
+                value: LeaveBehindDemoAction.horizontalSwipe,
+                checked: _dismissDirection == DismissDirection.horizontal,
+                child: new Text('Hoizontal swipe')
+              ),
+              new CheckedPopupMenuItem<LeaveBehindDemoAction>(
+                value: LeaveBehindDemoAction.leftSwipe,
+                checked: _dismissDirection == DismissDirection.left,
+                child: new Text('Only swipe left')
+              ),
+              new CheckedPopupMenuItem<LeaveBehindDemoAction>(
+                value: LeaveBehindDemoAction.rightSwipe,
+                checked: _dismissDirection == DismissDirection.right,
+                child: new Text('Only swipe right')
+              )
+            ]
+          )
+        ]
+      ),
+      body: new Block(
+        padding: new EdgeDims.all(4.0),
+        children: leaveBehindItems.map(buildItem).toList()
+      )
+    );
+  }
+}

--- a/examples/material_gallery/lib/gallery/home.dart
+++ b/examples/material_gallery/lib/gallery/home.dart
@@ -19,6 +19,7 @@ import '../demo/drop_down_demo.dart';
 import '../demo/fitness_demo.dart';
 import '../demo/grid_list_demo.dart';
 import '../demo/icons_demo.dart';
+import '../demo/leave_behind_demo.dart';
 import '../demo/list_demo.dart';
 import '../demo/modal_bottom_sheet_demo.dart';
 import '../demo/menu_demo.dart';
@@ -107,6 +108,7 @@ class GalleryHomeState extends State<GalleryHome> {
                   new GalleryDemo(title: 'Floating Action Button', builder: () => new TabsFabDemo()),
                   new GalleryDemo(title: 'Grid', builder: () => new GridListDemo()),
                   new GalleryDemo(title: 'Icons', builder: () => new IconsDemo()),
+                  new GalleryDemo(title: 'Leave-behind List Items', builder: () => new LeaveBehindDemo()),
                   new GalleryDemo(title: 'List', builder: () => new ListDemo()),
                   new GalleryDemo(title: 'Modal Bottom Sheet', builder: () => new ModalBottomSheetDemo()),
                   new GalleryDemo(title: 'Menus', builder: () => new MenuDemo()),

--- a/examples/material_gallery/lib/gallery/section.dart
+++ b/examples/material_gallery/lib/gallery/section.dart
@@ -67,7 +67,7 @@ class GallerySection extends StatelessComponent {
       primarySwatch: colors
     );
     final TextStyle titleTextStyle = theme.text.title.copyWith(
-      color: theme.brightness == ThemeBrightness.dark ?  Colors.black : Colors.white
+      color: Colors.white
     );
     return new Flexible(
       child: new GestureDetector(

--- a/examples/widgets/card_collection.dart
+++ b/examples/widgets/card_collection.dart
@@ -296,6 +296,7 @@ class CardCollectionState extends State<CardCollection> {
 
     CardModel cardModel = _cardModels[index];
     Widget card = new Dismissable(
+      key: new ObjectKey(cardModel),
       direction: _dismissDirection,
       onResized: () { _invalidator(<int>[index]); },
       onDismissed: (DismissDirection direction) { dismissCard(cardModel); },

--- a/packages/flutter/lib/src/material/list_item.dart
+++ b/packages/flutter/lib/src/material/list_item.dart
@@ -28,7 +28,6 @@ class ListItem extends StatelessComponent {
     this.onTap,
     this.onLongPress
   }) : super(key: key) {
-    assert(primary != null);
     assert(isThreeLine ? secondary != null : true);
   }
 
@@ -117,7 +116,7 @@ class ListItem extends StatelessComponent {
 
     final Widget primaryLine = new DefaultTextStyle(
       style: primaryTextStyle(context),
-      child: primary
+      child: primary ?? new Container()
     );
     Widget center = primaryLine;
     if (isTwoLine || isThreeLine) {

--- a/packages/flutter/test/widget/dismissable_test.dart
+++ b/packages/flutter/test/widget/dismissable_test.dart
@@ -110,6 +110,7 @@ class Test1215DismissableComponent extends StatelessComponent {
   final String text;
   Widget build(BuildContext context) {
     return new Dismissable(
+      key: new ObjectKey(text),
       child: new AspectRatio(
         aspectRatio: 1.0,
         child: new Text(this.text)


### PR DESCRIPTION
Dismissables can specify a background widget that's stacked behind the Dismissable's child. This makes it easy to implement the Material Design "leave-behind" idiom.

See the "Leave-behind" subsection of https://www.google.com/design/spec/components/lists-controls.html#lists-controls-types-of-list-controls

The value of the Dismissable's background is a DismissDirection Map. If different actions are associated with flinging to the left or right (or up and down), then different backgrounds are usually needed.

Added a leave-behind gallery demo.

Also:
- Fixed Gallery home screen's text color; dark theme
- Made ListItem's primary widget optional
