### PR TITLE
remove the _embedder.yaml file

### DIFF
--- a/packages/flutter/lib/_embedder.yaml
+++ b/packages/flutter/lib/_embedder.yaml
@@ -1,3 +1,0 @@
-analyzer:
-  language:
-    enableSuperMixins: true


### PR DESCRIPTION
Remove the _embedder.yaml file in the flutter package; the info in here will migrate to the sky_engine embedder file (fix https://github.com/flutter/flutter/issues/2468).
