### PR TITLE
Refactor DeviceLogReader

### DIFF
--- a/packages/flutter_tools/lib/src/base/process.dart
+++ b/packages/flutter_tools/lib/src/base/process.dart
@@ -10,20 +10,30 @@ import '../globals.dart';
 
 typedef String StringConverter(String string);
 
+/// This runs the command in the background from the specified working
+/// directory. Completes when the process has been started.
+Future<Process> runCommand(List<String> cmd, {String workingDirectory}) async {
+  printTrace(cmd.join(' '));
+  String executable = cmd[0];
+  List<String> arguments = cmd.length > 1 ? cmd.sublist(1) : [];
+  Process process = await Process.start(
+    executable,
+    arguments,
+    workingDirectory: workingDirectory
+  );
+  return process;
+}
+
 /// This runs the command and streams stdout/stderr from the child process to
-/// this process' stdout/stderr.
+/// this process' stdout/stderr. Completes with the process's exit code.
 Future<int> runCommandAndStreamOutput(List<String> cmd, {
   String workingDirectory,
   String prefix: '',
   RegExp filter,
   StringConverter mapFunction
 }) async {
-  printTrace(cmd.join(' '));
-  Process process = await Process.start(
-    cmd[0],
-    cmd.sublist(1),
-    workingDirectory: workingDirectory
-  );
+  Process process = await runCommand(cmd,
+                                     workingDirectory: workingDirectory);
   process.stdout
     .transform(UTF8.decoder)
     .transform(const LineSplitter())

--- a/packages/flutter_tools/lib/src/device.dart
+++ b/packages/flutter_tools/lib/src/device.dart
@@ -148,7 +148,11 @@ abstract class Device {
 
   TargetPlatform get platform;
 
-  DeviceLogReader createLogReader();
+  /// Get the log reader for this device.
+  DeviceLogReader get logReader;
+
+  /// Clear the device's logs.
+  void clearLogs();
 
   /// Start an app package on the current device.
   ///
@@ -189,7 +193,21 @@ abstract class Device {
 abstract class DeviceLogReader {
   String get name;
 
-  Future<int> logs({ bool clear: false, bool showPrefix: false });
+  /// A broadcast stream where each element in the string is a line of log
+  /// output.
+  Stream<String> get lines;
+
+  /// Start reading logs from the device.
+  Future start();
+
+  /// Actively reading lines from the log?
+  bool get isReading;
+
+  /// Actively stop reading logs from the device.
+  Future stop();
+
+  /// Completes when the log is finished.
+  Future get finished;
 
   int get hashCode;
   bool operator ==(dynamic other);


### PR DESCRIPTION
- Refactor DeviceLogReader class to be friendly to multiple consumers.
- Keep one lazily constructed singleton DeviceLogReader instance per Device.
- Implement new DeviceLogReader interface for Android, iOS, and iOS Simulator.
- Port logs command to new interface.

Part of #1988 
