### PR TITLE
Assert binding ready before getting a11y listener

### DIFF
--- a/packages/flutter/lib/src/rendering/semantics.dart
+++ b/packages/flutter/lib/src/rendering/semantics.dart
@@ -349,8 +349,10 @@ class SemanticsNode extends AbstractNode {
   static bool get hasListeners => _listeners != null && _listeners.length > 0;
   static VoidCallback onSemanticsEnabled; // set by the binding
   static void addListener(mojom.SemanticsListener listener) {
-    if (!hasListeners)
+    if (!hasListeners) {
+      assert(onSemanticsEnabled != null); // initialise the binding _before_ adding listeners
       onSemanticsEnabled();
+    }
     _listeners ??= <mojom.SemanticsListener>[];
     _listeners.add(listener);
   }


### PR DESCRIPTION
This adds an assert to verify that we have already got a binding when we
get a semantics listener. Otherwise we crash. (I mean, we still crash,
but now in checked mode we crash on an assert instead. Progress?)
