### PR TITLE
Support undo in the leave-behind demo

### DIFF
--- a/examples/material_gallery/lib/demo/leave_behind_demo.dart
+++ b/examples/material_gallery/lib/demo/leave_behind_demo.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:collection/collection.dart' show lowerBound;
+
 import 'package:flutter/material.dart';
 
 enum LeaveBehindDemoAction {
@@ -67,6 +69,15 @@ class LeaveBehindDemoState extends State<LeaveBehindDemo> {
     }
   }
 
+  void handleUndo(LeaveBehindItem item) {
+    int insertionIndex = lowerBound(leaveBehindItems, item,
+      compare: (LeaveBehindItem a, LeaveBehindItem b) => a.index.compareTo(b.index)
+    );
+    setState(() {
+      leaveBehindItems.insert(insertionIndex, item);
+    });
+  }
+
   Widget buildItem(LeaveBehindItem item) {
     final ThemeData theme = Theme.of(context);
     return new Dismissable(
@@ -78,7 +89,11 @@ class LeaveBehindDemoState extends State<LeaveBehindDemo> {
         });
         final String action = (direction == DismissDirection.left) ? 'archived' : 'deleted';
         _scaffoldKey.currentState.showSnackBar(new SnackBar(
-          content: new Text('You $action item ${item.index}')
+          content: new Text('You $action item ${item.index}'),
+          action: new SnackBarAction(
+            label: 'UNDO',
+            onPressed: () { handleUndo(item); }
+          )
         ));
       },
       background: new Container(

--- a/examples/material_gallery/lib/demo/snack_bar_demo.dart
+++ b/examples/material_gallery/lib/demo/snack_bar_demo.dart
@@ -33,7 +33,7 @@ class SnackBarDemo extends StatelessComponent {
               Scaffold.of(context).showSnackBar(new SnackBar(
                 content: new Text('This is a SnackBar'),
                 action: new SnackBarAction(
-                  label: 'Action',
+                  label: 'ACTION',
                   onPressed: () {
                     Scaffold.of(context).showSnackBar(new SnackBar(
                       content: new Text("You pressed the SnackBar's Action")

--- a/examples/material_gallery/pubspec.yaml
+++ b/examples/material_gallery/pubspec.yaml
@@ -1,6 +1,7 @@
 name: material_gallery
 dependencies:
   intl: '>=0.12.4+2 <0.13.0'
+  collection: '>=1.4.0 <2.0.0'
 
   flutter:
     path: ../../packages/flutter

--- a/examples/widgets/card_collection.dart
+++ b/examples/widgets/card_collection.dart
@@ -298,7 +298,7 @@ class CardCollectionState extends State<CardCollection> {
     Widget card = new Dismissable(
       key: new ObjectKey(cardModel),
       direction: _dismissDirection,
-      onResized: () { _invalidator(<int>[index]); },
+      onResize: () { _invalidator(<int>[index]); },
       onDismissed: (DismissDirection direction) { dismissCard(cardModel); },
       child: new Card(
         color: _primaryColor[cardModel.color],

--- a/packages/flutter/lib/src/widgets/dismissable.dart
+++ b/packages/flutter/lib/src/widgets/dismissable.dart
@@ -58,7 +58,7 @@ class Dismissable extends StatefulComponent {
     this.child,
     this.background,
     this.secondaryBackground,
-    this.onResized,
+    this.onResize,
     this.onDismissed,
     this.direction: DismissDirection.horizontal
   }) : super(key: key) {
@@ -79,7 +79,7 @@ class Dismissable extends StatefulComponent {
   final Widget secondaryBackground;
 
   /// Called when the widget changes size (i.e., when contracting before being dismissed).
-  final VoidCallback onResized;
+  final VoidCallback onResize;
 
   /// Called when the widget has been dismissed, after finishing resizing.
   final DismissDirectionCallback onDismissed;
@@ -263,12 +263,11 @@ class _DismissableState extends State<Dismissable> {
 
   void _handleResizeProgressChanged() {
     if (_resizeController.isCompleted) {
-      if (config.onDismissed != null) {
+      if (config.onDismissed != null)
         config.onDismissed(_dismissDirection);
-      }
     } else {
-      if (config.onResized != null)
-        config.onResized();
+      if (config.onResize != null)
+        config.onResize();
     }
   }
 

--- a/packages/flutter/test/widget/dismissable_test.dart
+++ b/packages/flutter/test/widget/dismissable_test.dart
@@ -13,7 +13,7 @@ DismissDirection dismissDirection = DismissDirection.horizontal;
 DismissDirection reportedDismissDirection;
 List<int> dismissedItems = <int>[];
 
-void handleOnResized(int item) {
+void handleOnResize(int item) {
   expect(dismissedItems.contains(item), isFalse);
 }
 
@@ -28,7 +28,7 @@ Widget buildDismissableItem(int item) {
     key: new ValueKey<int>(item),
     direction: dismissDirection,
     onDismissed: (DismissDirection direction) { handleOnDismissed(direction, item); },
-    onResized: () { handleOnResized(item); },
+    onResize: () { handleOnResize(item); },
     child: new Container(
       width: itemExtent,
       height: itemExtent,


### PR DESCRIPTION
Allow the user to undo a dismiss by tapping UNDO in the corresponding snack-bar.

This seems like a better UI idiom than having the user click a button that appears in the Dismissable's background.

Also:
- Renamed Dismissable onResized to onResize, since it's not called after the resize is complete, but during the resize animation.
