### PR TITLE
RenderCustomMultiChildLayoutBox shouldn't be sizedByParent

### DIFF
--- a/packages/flutter/lib/src/rendering/custom_layout.dart
+++ b/packages/flutter/lib/src/rendering/custom_layout.dart
@@ -249,13 +249,8 @@ class RenderCustomMultiChildLayoutBox extends RenderBox
     return _getSize(constraints).height;
   }
 
-  bool get sizedByParent => true;
-
-  void performResize() {
-    size = _getSize(constraints);
-  }
-
   void performLayout() {
+    size = _getSize(constraints);
     delegate._callPerformLayout(size, firstChild);
   }
 

--- a/packages/flutter/test/widget/custom_multi_child_layout_test.dart
+++ b/packages/flutter/test/widget/custom_multi_child_layout_test.dart
@@ -53,6 +53,19 @@ Widget buildFrame(MultiChildLayoutDelegate delegate) {
   );
 }
 
+class PreferredSizeDelegate extends MultiChildLayoutDelegate {
+  PreferredSizeDelegate({ this.preferredSize });
+
+  final Size preferredSize;
+
+  Size getSize(BoxConstraints constraints) => preferredSize;
+
+  void performLayout(Size size) { }
+
+  bool shouldRelayout(PreferredSizeDelegate oldDelegate) {
+    return preferredSize != oldDelegate.preferredSize;
+  }
+}
 
 void main() {
   test('Control test for CustomMultiChildLayout', () {
@@ -122,6 +135,32 @@ void main() {
         )
       ));
 
+    });
+  });
+
+  test('Loose constraints', () {
+    testWidgets((WidgetTester tester) {
+      Key key = new UniqueKey();
+      tester.pumpWidget(new Center(
+        child: new CustomMultiChildLayout(
+          key: key,
+          delegate: new PreferredSizeDelegate(preferredSize: new Size(300.0, 200.0))
+        )
+      ));
+
+      RenderBox box = tester.findElementByKey(key).renderObject;
+      expect(box.size.width, equals(300.0));
+      expect(box.size.height, equals(200.0));
+
+      tester.pumpWidget(new Center(
+        child: new CustomMultiChildLayout(
+          key: key,
+          delegate: new PreferredSizeDelegate(preferredSize: new Size(350.0, 250.0))
+        )
+      ));
+
+      expect(box.size.width, equals(350.0));
+      expect(box.size.height, equals(250.0));
     });
   });
 }


### PR DESCRIPTION
The getSize function from MultiChildLayoutDelegate might depend on information
other than the incomming constraints.

Fixes #2077
