### PR TITLE
Remove bogus intrinsic size assert

### DIFF
--- a/packages/flutter/lib/src/rendering/block.dart
+++ b/packages/flutter/lib/src/rendering/block.dart
@@ -151,11 +151,6 @@ class RenderBlock extends RenderBlockBase {
       double childExtent = isVertical ?
         child.getMinIntrinsicHeight(innerConstraints) :
         child.getMinIntrinsicWidth(innerConstraints);
-      assert(() {
-        if (isVertical)
-          return childExtent == child.getMaxIntrinsicHeight(innerConstraints);
-        return childExtent == child.getMaxIntrinsicWidth(innerConstraints);
-      });
       extent += childExtent;
       final BlockParentData childParentData = child.parentData;
       child = childParentData.nextSibling;

--- a/packages/flutter/lib/src/rendering/box.dart
+++ b/packages/flutter/lib/src/rendering/box.dart
@@ -419,7 +419,7 @@ abstract class RenderBox extends RenderObject {
   }
 
   /// Returns the smallest width beyond which increasing the width never
-  /// decreases the height.
+  /// decreases the preferred height.
   ///
   /// Override in subclasses that implement [performLayout].
   double getMaxIntrinsicWidth(BoxConstraints constraints) {
@@ -437,7 +437,7 @@ abstract class RenderBox extends RenderObject {
   }
 
   /// Returns the smallest height beyond which increasing the height never
-  /// decreases the width.
+  /// decreases the preferred width.
   ///
   /// If the layout algorithm used is width-in-height-out, i.e. the height
   /// depends on the width and not vice versa, then this will return the same

--- a/packages/flutter/lib/src/rendering/grid.dart
+++ b/packages/flutter/lib/src/rendering/grid.dart
@@ -166,7 +166,7 @@ abstract class GridDelegate {
   }
 
   /// Returns the smallest width beyond which increasing the width never
-  /// decreases the height.
+  /// decreases the preferred height.
   double getMaxIntrinsicWidth(BoxConstraints constraints, int childCount) {
     return constraints.constrainWidth(_getGridSize(constraints, childCount).width);
   }
@@ -178,7 +178,7 @@ abstract class GridDelegate {
   }
 
   /// Returns the smallest height beyond which increasing the height never
-  /// decreases the width.
+  /// decreases the preferred width.
   double getMaxIntrinsicHeight(BoxConstraints constraints, int childCount) {
     return constraints.constrainHeight(_getGridSize(constraints, childCount).height);
   }


### PR DESCRIPTION
This patch tweaks the definition of max intrinsic size to give implementations
more wiggle room to compute there intrinsic sizes more efficiently.
Specifically, implementations can now ignore the incomming constraint in the
cross axis if they prefer.

This patch removes an assert that is no longer valid w.r.t. the new definition
of intrinsic sizing.

Fixes #2099
