### PR TITLE
Fix crash when dumping the app if it uses RichText

### DIFF
--- a/examples/stocks/lib/stock_symbol_viewer.dart
+++ b/examples/stocks/lib/stock_symbol_viewer.dart
@@ -46,6 +46,19 @@ class StockSymbolView extends StatelessComponent {
           ),
           new Text('Market Cap', style: headings),
           new Text('${stock.marketCap}'),
+          new Container(
+            height: 8.0
+          ),
+          new RichText(
+            text: new TextSpan(
+              style: DefaultTextStyle.of(context).merge(new TextStyle(fontSize: 8.0)),
+              text: 'Prices may be delayed by ',
+              children: <TextSpan>[
+                new TextSpan(text: 'several', style: new TextStyle(fontStyle: FontStyle.italic)),
+                new TextSpan(text: ' years.'),
+              ]
+            )
+          ),
         ],
         justifyContent: FlexJustifyContent.collapse
       )

--- a/packages/flutter/lib/services.dart
+++ b/packages/flutter/lib/services.dart
@@ -12,6 +12,7 @@
 library services;
 
 export 'src/services/activity.dart';
+export 'src/services/assertions.dart';
 export 'src/services/asset_bundle.dart';
 export 'src/services/binding.dart';
 export 'src/services/fetch.dart';

--- a/packages/flutter/lib/src/rendering/paragraph.dart
+++ b/packages/flutter/lib/src/rendering/paragraph.dart
@@ -15,6 +15,7 @@ class RenderParagraph extends RenderBox {
     TextSpan text
   ) : _textPainter = new TextPainter(text) {
     assert(text != null);
+    assert(text.debugAssertValid());
   }
 
   final TextPainter _textPainter;
@@ -24,6 +25,7 @@ class RenderParagraph extends RenderBox {
   /// The text to display
   TextSpan get text => _textPainter.text;
   void set text(TextSpan value) {
+    assert(value.debugAssertValid());
     if (_textPainter.text == value)
       return;
     _textPainter.text = value;

--- a/packages/flutter/lib/src/services/assertions.dart
+++ b/packages/flutter/lib/src/services/assertions.dart
@@ -1,0 +1,9 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+class FlutterError extends AssertionError {
+  FlutterError(this.message);
+  final String message;
+  String toString() => message;
+}

--- a/packages/flutter/test/painting/text_span_test.dart
+++ b/packages/flutter/test/painting/text_span_test.dart
@@ -27,4 +27,38 @@ void main() {
     expect(b1 == a2, isFalse);
     expect(c1 == b2, isFalse);
   });
+
+  test("TextSpan ", () {
+    final TextSpan test = new TextSpan(
+      text: 'a',
+      style: new TextStyle(
+        fontSize: 10.0
+      ),
+      children: <TextSpan>[
+        new TextSpan(
+          text: 'b',
+          children: <TextSpan>[
+            new TextSpan()
+          ]
+        ),
+        null,
+        new TextSpan(
+          text: 'c'
+        ),
+      ]
+    );
+    expect(test.toString(), equals(
+      'TextSpan:\n'
+      '  inherit: true\n'
+      '  size: 10.0\n'
+      '  "a"\n'
+      '  TextSpan:\n'
+      '    "b"\n'
+      '    TextSpan:\n'
+      '      (empty)\n'
+      '  <null>\n'
+      '  TextSpan:\n'
+      '    "c"\n'
+    ));
+  });
 }


### PR DESCRIPTION
Specifically:
- Handle null styles in TextSpan without crashing in toString().
- Handle null children in TextSpan child lists without crashing in
  toString().
- Handle entirely empty TextSpans in toString() explicitly.
- Assert that TextSpans don't contain nulls in various places. This is
  done more often than one might think necessary, because it turns out
  that TextSpan takes a (mutable) List for one of its arguments, so
  who knows what it will contain at any given time. By asserting all
  over the place, hopefully we'll catch it near the change if they do
  change it.
- Add a RichText example to Stocks to exercise RichText and TextSpans.

See also: https://github.com/flutter/flutter/issues/2514, https://github.com/flutter/flutter/issues/2519
