### PR TITLE
Test harness should check for running Timers and AnimationControllers

### DIFF
--- a/examples/stocks/test/locale_test.dart
+++ b/examples/stocks/test/locale_test.dart
@@ -22,6 +22,10 @@ void main() {
       tester.setLocale("es", "US");
       tester.pump();
       expect(tab.widget.data, equals("MERCADO"));
+
+      // TODO(abarth): We're leaking an animation. We should track down the leak
+      // and plug it rather than waiting for the animation to end here.
+      tester.pump(const Duration(seconds: 1));
     });
   });
 }

--- a/packages/flutter/lib/src/material/progress_indicator.dart
+++ b/packages/flutter/lib/src/material/progress_indicator.dart
@@ -92,6 +92,11 @@ class _LinearProgressIndicatorState extends State<LinearProgressIndicator> {
     _animation = new CurvedAnimation(parent: _controller, curve: Curves.fastOutSlowIn);
   }
 
+  void dispose() {
+    _controller.stop();
+    super.dispose();
+  }
+
   Widget _buildIndicator(BuildContext context, double animationValue) {
     return new Container(
       constraints: new BoxConstraints.tightFor(
@@ -209,13 +214,18 @@ final Animatable<int> _kStepTween = new StepTween(begin: 0, end: 5);
 final Animatable<double> _kRotationTween = new CurveTween(curve: new SawTooth(5));
 
 class _CircularProgressIndicatorState extends State<CircularProgressIndicator> {
-  AnimationController _animationController;
+  AnimationController _controller;
 
   void initState() {
     super.initState();
-    _animationController = new AnimationController(
+    _controller = new AnimationController(
       duration: const Duration(milliseconds: 6666)
     )..repeat();
+  }
+
+  void dispose() {
+    _controller.stop();
+    super.dispose();
   }
 
   Widget _buildIndicator(BuildContext context, double headValue, double tailValue, int stepValue, double rotationValue) {
@@ -242,14 +252,14 @@ class _CircularProgressIndicatorState extends State<CircularProgressIndicator> {
       return _buildIndicator(context, 0.0, 0.0, 0, 0.0);
 
     return new AnimatedBuilder(
-      animation: _animationController,
+      animation: _controller,
       builder: (BuildContext context, Widget child) {
         return _buildIndicator(
           context,
-          _kStrokeHeadTween.evaluate(_animationController),
-          _kStrokeTailTween.evaluate(_animationController),
-          _kStepTween.evaluate(_animationController),
-          _kRotationTween.evaluate(_animationController)
+          _kStrokeHeadTween.evaluate(_controller),
+          _kStrokeTailTween.evaluate(_controller),
+          _kStepTween.evaluate(_controller),
+          _kRotationTween.evaluate(_controller)
         );
       }
     );

--- a/packages/flutter/lib/src/material/scaffold.dart
+++ b/packages/flutter/lib/src/material/scaffold.dart
@@ -281,6 +281,7 @@ class ScaffoldState extends State<Scaffold> {
            _snackBarController.status == AnimationStatus.completed);
     _snackBars.first._completer.complete();
     _snackBarController.reverse();
+    _snackBarTimer?.cancel();
     _snackBarTimer = null;
   }
 

--- a/packages/flutter/test/widget/positioned_test.dart
+++ b/packages/flutter/test/widget/positioned_test.dart
@@ -70,6 +70,7 @@ void main() {
       expect(sizes, equals([const Size(10.0, 10.0), const Size(10.0, 10.0), const Size(10.0, 10.0), const Size(10.0, 10.0), const Size(10.0, 10.0), const Size(10.0, 10.0)]));
       expect(positions, equals([const Offset(10.0, 10.0), const Offset(10.0, 10.0), const Offset(17.0, 17.0), const Offset(24.0, 24.0), const Offset(45.0, 45.0), const Offset(80.0, 80.0)]));
 
+      controller.stop();
     });
   });
 


### PR DESCRIPTION
After running a widget test, we now clear out the widget tree and check that we
didn't leak any timers or animations.

Also, fix several bugs that this addtional check revealed.

Fixes #2481
