### PR TITLE
fix a regression in flutter logs

### DIFF
--- a/packages/flutter_tools/lib/src/commands/logs.dart
+++ b/packages/flutter_tools/lib/src/commands/logs.dart
@@ -55,9 +55,9 @@ class LogsCommand extends FlutterCommand {
       StreamSubscription subscription = reader.lines.listen((String line) {
         if (devices.length > 1) {
           // Prefix with the name of the device.
-          print('[${reader.name}] $line');
+          printStatus('[${reader.name}] $line');
         } else {
-          print(line);
+          printStatus(line);
         }
       });
       // Wait for the log reader to be finished.


### PR DESCRIPTION
- fix a regression in flutter logs (fix https://github.com/flutter/flutter/issues/2522)
- ensure that we don't pass the `-T` option after the logcat `-s` option - that needs to go last on the line
- fix some places where we were passing in adb -s deviceId twice
- fix one place where we were calling print() instead of printStatus()

@abarth 
