### PR TITLE
Add lints to the analyze command.

### DIFF
--- a/packages/flutter_tools/lib/src/commands/analyze.dart
+++ b/packages/flutter_tools/lib/src/commands/analyze.dart
@@ -307,14 +307,18 @@ analyzer:
     todo: ignore
 linter:
   rules:
+    - avoid_as
+    - avoid_empty_else
     - camel_case_types
     # sometimes we have no choice (e.g. when matching other platforms)
     # - constant_identifier_names
     - empty_constructor_bodies
+    - hash_and_equals
     # disabled until regexp fix is pulled in (https://github.com/flutter/flutter/pull/1996)
     # - library_names
     - library_prefixes
     - non_constant_identifier_names
+    - prefer_is_not_empty
     # too many false-positives; code review should catch real instances
     # - one_member_abstracts
     - slash_for_doc_comments


### PR DESCRIPTION
Specifically:
- `avoid_as`
- `avoid_empty_else`
- `hash_and_equals`
- `prefer_is_not_empty`

Before this can land, the following warnings need to get vetted/addressed:

```
[lint] Always override `hashCode` if overriding `==` (src/flutter/packages/cassowary/lib/equation_member.dart, line 29, col 11)
[lint] Use isNotEmpty for Iterables and Maps. (src/flutter/packages/flutter/lib/src/gestures/arena.dart, line 103, col 9)
[lint] Avoid using `as`. (src/flutter/packages/flutter/lib/src/rendering/object.dart, line 546, col 49)
[lint] Avoid using `as`. (src/flutter/packages/flutter/lib/src/rendering/object.dart, line 569, col 49)
[lint] Avoid using `as`. (src/flutter/packages/flutter/lib/src/rendering/object.dart, line 602, col 51)
[lint] Use isNotEmpty for Iterables and Maps. (src/flutter/packages/flutter/lib/src/widgets/framework.dart, line 152, col 9)
[lint] Use isNotEmpty for Iterables and Maps. (src/flutter/packages/flutter/lib/src/widgets/framework.dart, line 1701, col 28)
[lint] Avoid using `as`. (src/flutter/packages/flutter/lib/src/widgets/scrollable.dart, line 718, col 37)
[lint] Avoid using `as`. (src/flutter/packages/flutter/test/rendering/stack_test.dart, line 30, col 6)
[lint] Avoid using `as`. (src/flutter/packages/flutter/test/widget/asset_vendor_test.dart, line 72, col 39)
[lint] Avoid using `as`. (src/flutter/packages/flutter/test/widget/asset_vendor_test.dart, line 111, col 10)
[lint] Avoid using `as`. (src/flutter/packages/flutter/test/widget/asset_vendor_test.dart, line 115, col 10)
[lint] Avoid using `as`. (src/flutter/packages/flutter/test/widget/build_scope_test.dart, line 107, col 8)
[lint] Avoid using `as`. (src/flutter/packages/flutter/test/widget/build_scope_test.dart, line 110, col 8)
[lint] Avoid using `as`. (src/flutter/packages/flutter/test/widget/coordinates_test.dart, line 41, col 15)
[lint] Avoid using `as`. (src/flutter/packages/flutter/test/widget/coordinates_test.dart, line 44, col 15)
[lint] Avoid using `as`. (src/flutter/packages/flutter/test/widget/coordinates_test.dart, line 47, col 15)
[lint] Avoid using `as`. (src/flutter/packages/flutter/test/widget/input_test.dart, line 51, col 30)
[lint] Avoid using `as`. (src/flutter/packages/flutter/test/widget/input_test.dart, line 68, col 15)
[lint] Avoid using `as`. (src/flutter/packages/flutter/test/widget/input_test.dart, line 71, col 15)
[lint] Avoid using `as`. (src/flutter/packages/flutter/test/widget/parent_data_test.dart, line 38, col 16)
[lint] Avoid using `as`. (src/flutter/packages/flutter/test/widget/reparent_state_test.dart, line 50, col 8)
[lint] Avoid using `as`. (src/flutter/packages/flutter/test/widget/reparent_state_test.dart, line 51, col 8)
[lint] Avoid using `as`. (src/flutter/packages/flutter/test/widget/reparent_state_test.dart, line 74, col 15)
[lint] Avoid using `as`. (src/flutter/packages/flutter/test/widget/reparent_state_test.dart, line 75, col 15)
[lint] Avoid using `as`. (src/flutter/packages/flutter/test/widget/reparent_state_test.dart, line 93, col 15)
[lint] Avoid using `as`. (src/flutter/packages/flutter/test/widget/reparent_state_test.dart, line 116, col 8)
[lint] Avoid using `as`. (src/flutter/packages/flutter/test/widget/reparent_state_test.dart, line 117, col 8)
[lint] Avoid using `as`. (src/flutter/packages/flutter/test/widget/reparent_state_test.dart, line 136, col 15)
[lint] Avoid using `as`. (src/flutter/packages/flutter/test/widget/reparent_state_test.dart, line 137, col 15)
[lint] Avoid using `as`. (src/flutter/packages/flutter/test/widget/reparent_state_test.dart, line 155, col 15)
[lint] Avoid using `as`. (src/flutter/packages/flutter/test/widget/reparent_state_test.dart, line 166, col 8)
[lint] Avoid using `as`. (src/flutter/packages/flutter/test/widget/reparent_state_test.dart, line 179, col 15)
[lint] Avoid using `as`. (src/flutter/packages/flutter/test/widget/reparent_state_test.dart, line 183, col 15)
[lint] Avoid using `as`. (src/flutter/packages/flutter_test/lib/src/instrumentation.dart, line 141, col 21)
[lint] Avoid using `as`. (src/flutter/packages/flutter_test/lib/src/instrumentation.dart, line 148, col 21)
[lint] Avoid using `as`. (src/flutter/packages/flutter_test/lib/src/service_mocker.dart, line 23, col 8)
[lint] Avoid using `as`. (src/flutter/packages/flutter_tools/lib/src/application_package.dart, line 71, col 35)
[lint] Use isNotEmpty for Iterables and Maps. (src/flutter/packages/flutter_tools/lib/src/commands/apk.dart, line 405, col 7)
```

cc @Hixie 
