### PR TITLE
Remove the _EquationMember.hashCode override

### DIFF
--- a/packages/cassowary/lib/equation_member.dart
+++ b/packages/cassowary/lib/equation_member.dart
@@ -24,8 +24,4 @@ abstract class _EquationMember {
   Expression operator *(_EquationMember m) => asExpression() * m;
 
   Expression operator /(_EquationMember m) => asExpression() / m;
-
-  @override
-  int get hashCode =>
-      throw "An equation member is not comparable and cannot be added to collections";
 }

--- a/packages/flutter_tools/.analysis_options
+++ b/packages/flutter_tools/.analysis_options
@@ -13,6 +13,7 @@ analyzer:
     todo: ignore
 linter:
   rules:
+    - avoid_empty_else
     - always_declare_return_types
     # we'll turn on avoid_as as soon as it doesn't complain about "as dynamic"
     # - avoid_as
@@ -20,6 +21,7 @@ linter:
     # sometimes we have no choice (e.g. when matching other platforms)
     # - constant_identifier_names
     - empty_constructor_bodies
+    - hash_and_equals
     # disabled until regexp fix is pulled in (https://github.com/flutter/flutter/pull/1996)
     # - library_names
     - library_prefixes


### PR DESCRIPTION
Since we removed our operator== overload, we can now allow people to put
these in collections again.

Also, turn on two more analyzer lints: avoid_empty_else and hash_and_equals.
