### PR TITLE
`flutter run` should fail if `pub get` fails.

### DIFF
--- a/packages/flutter_tools/lib/src/commands/run.dart
+++ b/packages/flutter_tools/lib/src/commands/run.dart
@@ -81,8 +81,11 @@ class RunCommand extends RunCommandBase {
 
   @override
   Future<int> run() async {
-    if (argResults['pub'])
-      await pubGet();
+    if (argResults['pub']) {
+      int exitCode = await pubGet();
+      if (exitCode != 0)
+        return exitCode;
+    }
     return await super.run();
   }
 

--- a/packages/flutter_tools/lib/src/commands/update_packages.dart
+++ b/packages/flutter_tools/lib/src/commands/update_packages.dart
@@ -15,6 +15,8 @@ Future<int> _runPub(Directory directory, { bool upgrade: false }) async {
   for (FileSystemEntity dir in directory.listSync()) {
     if (dir is Directory && FileSystemEntity.isFileSync(dir.path + Platform.pathSeparator + 'pubspec.yaml')) {
       updateCount++;
+      // TODO(eseidel): Should this fail immediately if pubGet fails?
+      // Currently we're ignoring the return code.
       await pubGet(directory: dir.path, upgrade: upgrade, checkLastModified: false);
     }
   }


### PR DESCRIPTION
Previously we were ignoring the return code and continuing.

@devoncarew
