### PR TITLE
Add an option to specify a working directory for the FLX builder

### DIFF
--- a/packages/flutter_tools/lib/src/commands/build.dart
+++ b/packages/flutter_tools/lib/src/commands/build.dart
@@ -24,6 +24,7 @@ class BuildCommand extends FlutterCommand {
     argParser.addOption('output-file', abbr: 'o', defaultsTo: defaultFlxOutputPath);
     argParser.addOption('snapshot', defaultsTo: defaultSnapshotPath);
     argParser.addOption('depfile', defaultsTo: defaultDepfilePath);
+    argParser.addOption('working-dir', defaultsTo: defaultWorkingDirPath);
     addTargetOption();
   }
 
@@ -45,6 +46,7 @@ class BuildCommand extends FlutterCommand {
       snapshotPath: argResults['snapshot'],
       depfilePath: argResults['depfile'],
       privateKeyPath: argResults['private-key'],
+      workingDirPath: argResults['working-dir'],
       precompiledSnapshot: argResults['precompiled']
     ).then((int result) {
       if (result == 0)

--- a/packages/flutter_tools/lib/src/flx.dart
+++ b/packages/flutter_tools/lib/src/flx.dart
@@ -24,6 +24,7 @@ const String defaultFlxOutputPath = 'build/app.flx';
 const String defaultSnapshotPath = 'build/snapshot_blob.bin';
 const String defaultDepfilePath = 'build/snapshot_blob.bin.d';
 const String defaultPrivateKeyPath = 'privatekey.der';
+const String defaultWorkingDirPath = 'build/flx';
 
 const String _kSnapshotKey = 'snapshot_blob.bin';
 
@@ -163,6 +164,7 @@ Future<int> build(
   String snapshotPath: defaultSnapshotPath,
   String depfilePath: defaultDepfilePath,
   String privateKeyPath: defaultPrivateKeyPath,
+  String workingDirPath: defaultWorkingDirPath,
   bool precompiledSnapshot: false
 }) async {
   Map manifestDescriptor = _loadManifest(manifestPath);
@@ -189,7 +191,8 @@ Future<int> build(
       snapshotFile: snapshotFile,
       assetBasePath: assetBasePath,
       outputPath: outputPath,
-      privateKeyPath: privateKeyPath
+      privateKeyPath: privateKeyPath,
+      workingDirPath: workingDirPath
   );
 }
 
@@ -198,7 +201,8 @@ Future<int> assemble({
   File snapshotFile,
   String assetBasePath: defaultAssetBasePath,
   String outputPath: defaultFlxOutputPath,
-  String privateKeyPath: defaultPrivateKeyPath
+  String privateKeyPath: defaultPrivateKeyPath,
+  String workingDirPath: defaultWorkingDirPath
 }) async {
   printTrace('Building $outputPath');
 
@@ -250,7 +254,7 @@ Future<int> assemble({
 
   File zipFile = new File(outputPath.substring(0, outputPath.length - 4) + '.zip');
   printTrace('Encoding zip file to ${zipFile.path}');
-  zipBuilder.createZip(zipFile, new Directory('build/flx'));
+  zipBuilder.createZip(zipFile, new Directory(workingDirPath));
   List<int> zipBytes = zipFile.readAsBytesSync();
 
   ensureDirectoryExists(outputPath);


### PR DESCRIPTION
This allows building an FLX without leaving any temporary files in the app's
source directory
