### PR TITLE
Added AppBarBehavior.under, etc

### DIFF
--- a/examples/material_gallery/lib/demo/flexible_space_demo.dart
+++ b/examples/material_gallery/lib/demo/flexible_space_demo.dart
@@ -72,8 +72,10 @@ class FlexibleSpaceDemo extends StatefulWidget {
 }
 
 class FlexibleSpaceDemoState extends State<FlexibleSpaceDemo> {
+  final GlobalKey<ScaffoldState> scaffoldKey = new GlobalKey<ScaffoldState>();
   final double appBarHeight = 256.0;
   final Key scrollableKey = new UniqueKey();
+  AppBarBehavior _appBarBehavior = AppBarBehavior.scroll;
 
   Widget build(BuildContext context) {
     return new Theme(
@@ -82,18 +84,37 @@ class FlexibleSpaceDemoState extends State<FlexibleSpaceDemo> {
         primarySwatch: Colors.indigo
       ),
       child: new Scaffold(
+        key: scaffoldKey,
         appBarHeight: appBarHeight,
         scrollableKey: scrollableKey,
-        appBarBehavior: AppBarBehavior.scroll,
+        appBarBehavior: _appBarBehavior,
         appBar: new AppBar(
           actions: <Widget>[
             new IconButton(
               icon: Icons.create,
-              tooltip: 'Search'
+              tooltip: 'Search',
+              onPressed: () {
+                scaffoldKey.currentState.showSnackBar(new SnackBar(
+                  content: new Text('Not supported.')
+                ));
+              }
             ),
-            new IconButton(
-              icon: Icons.more_vert,
-              tooltip: 'Show menu'
+            new PopupMenuButton<AppBarBehavior>(
+              onSelected: (AppBarBehavior value) {
+                setState(() {
+                  _appBarBehavior = value;
+                });
+              },
+              items: <PopupMenuItem<AppBarBehavior>>[
+                new PopupMenuItem<AppBarBehavior>(
+                  value: AppBarBehavior.scroll,
+                  child: new Text('AppBar scrolls away')
+                ),
+                new PopupMenuItem<AppBarBehavior>(
+                  value: AppBarBehavior.under,
+                  child: new Text('AppBar stays put')
+                )
+              ]
             )
           ],
           flexibleSpace: (BuildContext context) {

--- a/examples/material_gallery/lib/gallery/section.dart
+++ b/examples/material_gallery/lib/gallery/section.dart
@@ -37,7 +37,7 @@ class GallerySection extends StatelessWidget {
           data: theme,
           child: new Scaffold(
             appBarHeight: appBarHeight,
-            appBarBehavior: AppBarBehavior.scroll,
+            appBarBehavior: AppBarBehavior.under,
             scrollableKey: scrollableKey,
             appBar: new AppBar(
               flexibleSpace: (BuildContext context) => new FlexibleSpaceBar(title: new Text(title))

--- a/packages/flutter/lib/src/material/app_bar.dart
+++ b/packages/flutter/lib/src/material/app_bar.dart
@@ -117,7 +117,7 @@ class AppBar extends StatelessWidget {
 
     // If the toolBar's height shrinks below toolBarHeight, it will be clipped and bottom
     // justified. This is so that the toolbar appears to move upwards as its height is reduced.
-    final double toolBarHeight = kAppBarHeight + combinedPadding.top + combinedPadding.bottom;
+    final double toolBarHeight = kToolBarHeight + combinedPadding.top + combinedPadding.bottom;
     final Widget toolBar = new ConstrainedBox(
       constraints: new BoxConstraints(maxHeight: toolBarHeight),
       child: new Padding(

--- a/packages/flutter/lib/src/material/constants.dart
+++ b/packages/flutter/lib/src/material/constants.dart
@@ -9,7 +9,7 @@ import 'package:flutter/widgets.dart';
 // Mobile Landscape: 48dp
 // Mobile Portrait: 56dp
 // Tablet/Desktop: 64dp
-const double kAppBarHeight = 56.0;
+const double kToolBarHeight = 56.0;
 const double kExtendedAppBarHeight = 128.0;
 
 const double kTextTabBarHeight = 48.0;

--- a/packages/flutter/lib/src/material/flexible_space_bar.dart
+++ b/packages/flutter/lib/src/material/flexible_space_bar.dart
@@ -27,7 +27,7 @@ class _FlexibleSpaceBarState extends State<FlexibleSpaceBar> {
     final double appBarHeight = Scaffold.of(context).appBarHeight;
     final Animation<double> animation = Scaffold.of(context).appBarAnimation;
     final EdgeInsets toolBarPadding = MediaQuery.of(context)?.padding ?? EdgeInsets.zero;
-    final double toolBarHeight = kAppBarHeight + toolBarPadding.top;
+    final double toolBarHeight = kToolBarHeight + toolBarPadding.top;
     final List<Widget> children = <Widget>[];
 
     // background image
@@ -63,7 +63,7 @@ class _FlexibleSpaceBarState extends State<FlexibleSpaceBar> {
         color: titleStyle.color.withAlpha(new Tween<double>(begin: 255.0, end: 0.0).evaluate(opacityCurve).toInt())
       );
       final double yAlignStart = 1.0;
-      final double yAlignEnd = (toolBarPadding.top + kAppBarHeight / 2.0) / toolBarHeight;
+      final double yAlignEnd = (toolBarPadding.top + kToolBarHeight / 2.0) / toolBarHeight;
       final double scaleAndAlignEnd = (appBarHeight - toolBarHeight) / appBarHeight;
       final CurvedAnimation scaleAndAlignCurve = new CurvedAnimation(
         parent: animation,

--- a/packages/flutter/lib/src/widgets/scrollable_list.dart
+++ b/packages/flutter/lib/src/widgets/scrollable_list.dart
@@ -45,7 +45,7 @@ class ScrollableList extends Scrollable {
 }
 
 class _ScrollableListState extends ScrollableState<ScrollableList> {
-  ScrollBehavior<double, double> createScrollBehavior() => new OverscrollBehavior();
+  ScrollBehavior<double, double> createScrollBehavior() => new OverscrollWhenScrollableBehavior();
   ExtentScrollBehavior get scrollBehavior => super.scrollBehavior;
 
   void _handleExtentsChanged(double contentExtent, double containerExtent) {


### PR DESCRIPTION
The gallery 'Scrolling Techniques' demo (under Patterns) can be used to try the new AppBarBehavior. Select 'AppBar stays put' from the toolbar's actions menu.

ScrollableLists now have the same ScrollBehavior as ScrollableViewport (so Block too): they only scroll when the child's extent is bigger than its container.

Toolbars no longer overscroll. Fixed https://github.com/flutter/flutter/issues/1719
