### PR TITLE
exclude the i18n files from analysis

### DIFF
--- a/examples/stocks/.analysis_options
+++ b/examples/stocks/.analysis_options
@@ -1,3 +1,3 @@
 analyzer:
   exclude:
-    - 'ios/.generated/**'
+    - 'lib/i18n/stock_messages_*.dart'


### PR DESCRIPTION
Exclude the i18n files from analysis. A few of the lints in the _embedder.yaml file trigger here; this excludes these files from analysis. @Hixie @pq
