### PR TITLE
Enable ALL THE LINTS

### DIFF
--- a/dev/manual_tests/raw_keyboard.dart
+++ b/dev/manual_tests/raw_keyboard.dart
@@ -37,7 +37,7 @@ class RawKeyboardDemo extends StatefulComponent {
 }
 
 class _HardwareKeyDemoState extends State<RawKeyboardDemo> {
-  mojom.InputEvent _event = null;
+  mojom.InputEvent _event;
 
   void _handleKey(mojom.InputEvent event) {
     setState(() {

--- a/packages/cassowary/lib/constant_member.dart
+++ b/packages/cassowary/lib/constant_member.dart
@@ -5,13 +5,13 @@
 part of cassowary;
 
 class ConstantMember extends _EquationMember {
+  ConstantMember(this.value);
+
   @override
   final double value;
 
   @override
   bool get isConstant => true;
-
-  ConstantMember(this.value);
 
   @override
   Expression asExpression() => new Expression([], this.value);

--- a/packages/cassowary/lib/expression.dart
+++ b/packages/cassowary/lib/expression.dart
@@ -5,6 +5,11 @@
 part of cassowary;
 
 class Expression extends _EquationMember {
+  Expression(this.terms, this.constant);
+  Expression.fromExpression(Expression expr)
+    : this.terms = new List<Term>.from(expr.terms),
+      this.constant = expr.constant;
+
   final List<Term> terms;
 
   final double constant;
@@ -14,11 +19,6 @@ class Expression extends _EquationMember {
 
   @override
   double get value => terms.fold(constant, (value, term) => value + term.value);
-
-  Expression(this.terms, this.constant);
-  Expression.fromExpression(Expression expr)
-      : this.terms = new List<Term>.from(expr.terms),
-        this.constant = expr.constant;
 
   @override
   Expression asExpression() => this;

--- a/packages/cassowary/lib/term.dart
+++ b/packages/cassowary/lib/term.dart
@@ -5,14 +5,14 @@
 part of cassowary;
 
 class Term extends _EquationMember {
+  Term(this.variable, this.coefficient);
+
   final Variable variable;
   final double coefficient;
 
   bool get isConstant => false;
 
   double get value => coefficient * variable.value;
-
-  Term(this.variable, this.coefficient);
 
   Expression asExpression() =>
       new Expression([new Term(this.variable, this.coefficient)], 0.0);

--- a/packages/flutter/lib/src/gestures/arena.dart
+++ b/packages/flutter/lib/src/gestures/arena.dart
@@ -100,7 +100,7 @@ class GestureArena {
       return;  // This arena is being held for a long-lived member
     }
     _arenas.remove(arenaKey);
-    if (!state.members.isEmpty) {
+    if (state.members.isNotEmpty) {
       // First member wins
       state.members.first.acceptGesture(arenaKey);
       // Give all the other members the bad news

--- a/packages/flutter/lib/src/gestures/hit_test.dart
+++ b/packages/flutter/lib/src/gestures/hit_test.dart
@@ -5,12 +5,12 @@
 import 'events.dart';
 
 /// An object that can hit-test pointers.
-abstract class HitTestable {
+abstract class HitTestable { // ignore: one_member_abstracts
   void hitTest(HitTestResult result, Point position);
 }
 
 /// An object that can handle events.
-abstract class HitTestTarget {
+abstract class HitTestTarget { // ignore: one_member_abstracts
   /// Override this function to receive events.
   void handleEvent(PointerEvent event, HitTestEntry entry);
 }

--- a/packages/flutter/lib/src/material/date_picker.dart
+++ b/packages/flutter/lib/src/material/date_picker.dart
@@ -226,7 +226,7 @@ class DayPicker extends StatelessComponent {
         item = new Text("");
       } else {
         // Put a light circle around the selected day
-        BoxDecoration decoration = null;
+        BoxDecoration decoration;
         if (selectedDate.year == year &&
             selectedDate.month == month &&
             selectedDate.day == day)

--- a/packages/flutter/lib/src/material/popup_menu.dart
+++ b/packages/flutter/lib/src/material/popup_menu.dart
@@ -304,7 +304,7 @@ class _PopupMenuRoute<T> extends PopupRoute<T> {
   Color get barrierColor => null;
 
   Widget buildPage(BuildContext context, Animation<double> animation, Animation<double> forwardAnimation) {
-    double selectedItemOffset = null;
+    double selectedItemOffset;
     if (initialValue != null) {
       selectedItemOffset = 0.0;
       for (int i = 0; i < items.length; i++) {

--- a/packages/flutter/lib/src/material/theme_data.dart
+++ b/packages/flutter/lib/src/material/theme_data.dart
@@ -28,55 +28,6 @@ const Color _kDarkThemeHighlightColor = const Color(0x40CCCCCC);
 const Color _kDarkThemeSplashColor = const Color(0x40CCCCCC);
 
 class ThemeData {
-
-  ThemeData.raw({
-    this.brightness,
-    this.primaryColor,
-    this.primaryColorBrightness,
-    this.accentColor,
-    this.accentColorBrightness,
-    this.canvasColor,
-    this.cardColor,
-    this.dividerColor,
-    this.highlightColor,
-    this.splashColor,
-    this.unselectedColor,
-    this.disabledColor,
-    this.buttonColor,
-    this.selectionColor,
-    this.backgroundColor,
-    this.indicatorColor,
-    this.hintColor,
-    this.hintOpacity,
-    this.errorColor,
-    this.text,
-    this.primaryTextTheme,
-    this.primaryIconTheme
-  }) {
-    assert(brightness != null);
-    assert(primaryColor != null);
-    assert(primaryColorBrightness != null);
-    assert(accentColor != null);
-    assert(accentColorBrightness != null);
-    assert(canvasColor != null);
-    assert(cardColor != null);
-    assert(dividerColor != null);
-    assert(highlightColor != null);
-    assert(splashColor != null);
-    assert(unselectedColor != null);
-    assert(disabledColor != null);
-    assert(buttonColor != null);
-    assert(selectionColor != null);
-    assert(disabledColor != null);
-    assert(indicatorColor != null);
-    assert(hintColor != null);
-    assert(hintOpacity != null);
-    assert(errorColor != null);
-    assert(text != null);
-    assert(primaryTextTheme != null);
-    assert(primaryIconTheme != null);
-  }
-
   factory ThemeData({
     ThemeBrightness brightness,
     Map<int, Color> primarySwatch,
@@ -150,6 +101,54 @@ class ThemeData {
       primaryTextTheme: primaryTextTheme,
       primaryIconTheme: primaryIconTheme
     );
+  }
+
+  ThemeData.raw({
+    this.brightness,
+    this.primaryColor,
+    this.primaryColorBrightness,
+    this.accentColor,
+    this.accentColorBrightness,
+    this.canvasColor,
+    this.cardColor,
+    this.dividerColor,
+    this.highlightColor,
+    this.splashColor,
+    this.unselectedColor,
+    this.disabledColor,
+    this.buttonColor,
+    this.selectionColor,
+    this.backgroundColor,
+    this.indicatorColor,
+    this.hintColor,
+    this.hintOpacity,
+    this.errorColor,
+    this.text,
+    this.primaryTextTheme,
+    this.primaryIconTheme
+  }) {
+    assert(brightness != null);
+    assert(primaryColor != null);
+    assert(primaryColorBrightness != null);
+    assert(accentColor != null);
+    assert(accentColorBrightness != null);
+    assert(canvasColor != null);
+    assert(cardColor != null);
+    assert(dividerColor != null);
+    assert(highlightColor != null);
+    assert(splashColor != null);
+    assert(unselectedColor != null);
+    assert(disabledColor != null);
+    assert(buttonColor != null);
+    assert(selectionColor != null);
+    assert(disabledColor != null);
+    assert(indicatorColor != null);
+    assert(hintColor != null);
+    assert(hintOpacity != null);
+    assert(errorColor != null);
+    assert(text != null);
+    assert(primaryTextTheme != null);
+    assert(primaryIconTheme != null);
   }
 
   factory ThemeData.light() => new ThemeData(brightness: ThemeBrightness.light);

--- a/packages/flutter/lib/src/painting/decoration.dart
+++ b/packages/flutter/lib/src/painting/decoration.dart
@@ -23,6 +23,6 @@ abstract class Decoration {
   String toString([String prefix = '']) => '$prefix$runtimeType';
 }
 
-abstract class BoxPainter {
+abstract class BoxPainter { // ignore: one_member_abstracts
   void paint(Canvas canvas, Rect rect);
 }

--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -773,7 +773,7 @@ abstract class RenderObject extends AbstractNode implements HitTestTarget {
   bool get debugDoingThisResize => _debugDoingThisResize;
   bool _debugDoingThisLayout = false;
   bool get debugDoingThisLayout => _debugDoingThisLayout;
-  static RenderObject _debugActiveLayout = null;
+  static RenderObject _debugActiveLayout;
   static RenderObject get debugActiveLayout => _debugActiveLayout;
   bool _debugMutationsLocked = false;
   bool _debugCanParentUseSize;
@@ -1140,7 +1140,7 @@ abstract class RenderObject extends AbstractNode implements HitTestTarget {
   static bool get debugDoingPaint => _debugDoingPaint;
   bool _debugDoingThisPaint = false;
   bool get debugDoingThisPaint => _debugDoingThisPaint;
-  static RenderObject _debugActivePaint = null;
+  static RenderObject _debugActivePaint;
   static RenderObject get debugActivePaint => _debugActivePaint;
 
   static List<RenderObject> _nodesNeedingPaint = <RenderObject>[];

--- a/packages/flutter/lib/src/services/image_cache.dart
+++ b/packages/flutter/lib/src/services/image_cache.dart
@@ -12,17 +12,17 @@ import 'fetch.dart';
 import 'image_decoder.dart';
 import 'image_resource.dart';
 
-/// Implements a way to retrieve an image, for example by fetching it from the network.
-/// Also used as a key in the image cache.
-abstract class ImageProvider {
+/// Implements a way to retrieve an image, for example by fetching it from the
+/// network. Also used as a key in the image cache.
+abstract class ImageProvider { // ignore: one_member_abstracts
   Future<ImageInfo> loadImage();
 }
 
 class _UrlFetcher implements ImageProvider {
+  _UrlFetcher(this._url, this._scale);
+
   final String _url;
   final double _scale;
-
-  _UrlFetcher(this._url, this._scale);
 
   Future<ImageInfo> loadImage() async {
     UrlResponse response = await fetchUrl(_url);

--- a/packages/flutter/lib/src/widgets/asset_vendor.dart
+++ b/packages/flutter/lib/src/widgets/asset_vendor.dart
@@ -15,7 +15,7 @@ import 'basic.dart';
 import 'framework.dart';
 
 // Base class for asset resolvers.
-abstract class _AssetResolver {
+abstract class _AssetResolver { // ignore: one_member_abstracts
   // Return a resolved asset key for the asset named [name].
   Future<String> resolve(String name);
 }
@@ -77,12 +77,15 @@ class _ResolutionAwareAssetBundle extends _ResolvingAssetBundle {
 // of asset variants to choose from.
 abstract class _VariantAssetResolver extends _AssetResolver {
   _VariantAssetResolver({ this.bundle });
+
   final AssetBundle bundle;
+
   // TODO(kgiesing): Ideally, this cache would be on an object with the same
   // lifetime as the asset bundle it wraps. However, that won't matter until we
   // need to change AssetVendors frequently; as of this writing we only have
   // one.
   Map<String, List<String>> _assetManifest;
+
   Future _initializer;
 
   Future _loadManifest() async {

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -18,12 +18,12 @@ export 'package:flutter/rendering.dart' show RenderObject, RenderBox, debugPrint
 ///
 /// Keys must be unique amongst the Elements with the same parent.
 abstract class Key {
-  /// Default constructor, used by subclasses.
-  const Key.constructor(); // so that subclasses can call us, since the Key() factory constructor shadows the implicit constructor
-
   /// Construct a ValueKey<String> with the given String.
   /// This is the simplest way to create keys.
   factory Key(String value) => new ValueKey<String>(value);
+
+  /// Default constructor, used by subclasses.
+  const Key.constructor(); // so that subclasses can call us, since the Key() factory constructor shadows the implicit constructor
 }
 
 /// A kind of [Key] that uses a value of a particular type to identify itself.
@@ -72,11 +72,11 @@ typedef void GlobalKeyRemoveListener(GlobalKey key);
 /// used by components that need to communicate with other components across the
 /// application's element tree.
 abstract class GlobalKey<T extends State<StatefulComponent>> extends Key {
-  const GlobalKey.constructor() : super.constructor(); // so that subclasses can call us, since the Key() factory constructor shadows the implicit constructor
-
   /// Constructs a LabeledGlobalKey, which is a GlobalKey with a label used for debugging.
   /// The label is not used for comparing the identity of the key.
   factory GlobalKey({ String debugLabel }) => new LabeledGlobalKey<T>(debugLabel); // the label is purely for debugging purposes and is otherwise ignored
+
+  const GlobalKey.constructor() : super.constructor(); // so that subclasses can call us, since the Key() factory constructor shadows the implicit constructor
 
   static final Map<GlobalKey, Element> _registry = new Map<GlobalKey, Element>();
   static final Map<GlobalKey, int> _debugDuplicates = new Map<GlobalKey, int>();
@@ -149,7 +149,7 @@ abstract class GlobalKey<T extends State<StatefulComponent>> extends Key {
       message += 'The following GlobalKey was found multiple times among mounted elements: $key (${_debugDuplicates[key]} instances)\n';
       message += 'The most recently registered instance is: ${_registry[key]}\n';
     }
-    if (!_debugDuplicates.isEmpty) {
+    if (_debugDuplicates.isNotEmpty) {
       throw new WidgetError(
         'Incorrect GlobalKey usage.\n'
         '$message'
@@ -1678,7 +1678,7 @@ abstract class RenderObjectElement<T extends RenderObjectWidget> extends Buildab
     }
 
     // clean up any of the remaining middle nodes from the old list
-    if (haveOldChildren && !oldKeyedChildren.isEmpty) {
+    if (haveOldChildren && oldKeyedChildren.isNotEmpty) {
       for (Element oldChild in oldKeyedChildren.values)
         _deactivateChild(oldChild);
     }

--- a/packages/flutter/lib/src/widgets/mixed_viewport.dart
+++ b/packages/flutter/lib/src/widgets/mixed_viewport.dart
@@ -210,7 +210,7 @@ class _MixedViewportElement extends RenderObjectElement<MixedViewport> {
       assert(renderObject != null);
       final int startIndex = _firstVisibleChildIndex;
       int lastIndex = startIndex + _childrenByKey.length - 1;
-      Element previousChild = null;
+      Element previousChild;
       for (int index = startIndex; index <= lastIndex; index += 1) {
         final Widget newWidget = _buildWidgetAt(index);
         final _ChildKey key = new _ChildKey.fromWidget(newWidget);
@@ -598,7 +598,7 @@ class _MixedViewportElement extends RenderObjectElement<MixedViewport> {
       assert(index != null);
       // Place all our children in our RenderObject.
       // All the children we are placing are in builtChildren and newChildren.
-      Element previousChild = null;
+      Element previousChild;
       for (int i = startIndex; i < index; ++i) {
         final Element element = builtChildren[i];
         if (element.slot != previousChild)

--- a/packages/flutter/test/scheduler/scheduler_test.dart
+++ b/packages/flutter/test/scheduler/scheduler_test.dart
@@ -10,7 +10,7 @@ import 'package:test/test.dart';
 
 class TestSchedulerBinding extends BindingBase with Scheduler { }
 
-class TestStrategy implements SchedulingStrategy {
+class TestStrategy {
   int allowedPriority = 10000;
 
   bool shouldRunTaskWithPriority({ int priority, Scheduler scheduler }) {
@@ -22,7 +22,7 @@ void main() {
   test("Tasks are executed in the right order", () {
     Scheduler scheduler = new TestSchedulerBinding();
     TestStrategy strategy = new TestStrategy();
-    scheduler.schedulingStrategy = strategy;
+    scheduler.schedulingStrategy = strategy.shouldRunTaskWithPriority;
     List<int> input = <int>[2, 23, 23, 11, 0, 80, 3];
     List<int> executedTasks = <int>[];
 

--- a/packages/flutter/test/widget/asset_vendor_test.dart
+++ b/packages/flutter/test/widget/asset_vendor_test.dart
@@ -45,7 +45,7 @@ class TestAssetBundle extends AssetBundle {
     return null;
   }
   Future<core.MojoDataPipeConsumer> load(String key) {
-    core.MojoDataPipeConsumer pipe = null;
+    core.MojoDataPipeConsumer pipe;
     switch (key) {
       case 'assets/image.png':
         pipe = new TestMojoDataPipeConsumer(1.0);

--- a/packages/flutter/test/widget/pageable_list_test.dart
+++ b/packages/flutter/test/widget/pageable_list_test.dart
@@ -10,7 +10,7 @@ import 'package:test/test.dart';
 Size pageSize = new Size(600.0, 300.0);
 const List<int> defaultPages = const <int>[0, 1, 2, 3, 4, 5];
 final List<GlobalKey> globalKeys = defaultPages.map((_) => new GlobalKey()).toList();
-int currentPage = null;
+int currentPage;
 
 Widget buildPage(int page) {
   return new Container(

--- a/packages/flutter_driver/lib/src/driver.dart
+++ b/packages/flutter_driver/lib/src/driver.dart
@@ -26,6 +26,7 @@ typedef dynamic EvaluatorFunction();
 
 /// Drives a Flutter Application running in another process.
 class FlutterDriver {
+  FlutterDriver.connectedTo(this._serviceClient, this._appIsolate);
 
   static const String _kFlutterExtensionMethod = 'ext.flutter_driver';
   static const Duration _kDefaultTimeout = const Duration(seconds: 5);
@@ -139,8 +140,6 @@ class FlutterDriver {
     _log.info('Connected to Flutter application.');
     return driver;
   }
-
-  FlutterDriver.connectedTo(this._serviceClient, this._appIsolate);
 
   /// Client connected to the Dart VM running the Flutter application
   final VMServiceClient _serviceClient;

--- a/packages/flutter_driver/lib/src/find.dart
+++ b/packages/flutter_driver/lib/src/find.dart
@@ -124,26 +124,26 @@ class ByValueKey extends SearchSpecification {
 
 /// Command to read the text from a given element.
 class GetText extends CommandWithTarget {
+  /// [targetRef] identifies an element that contains a piece of text.
+  GetText(ObjectRef targetRef) : super(targetRef);
+
   final String kind = 'get_text';
 
   static GetText deserialize(Map<String, String> json) {
     return new GetText(new ObjectRef(json['targetRef']));
   }
 
-  /// [targetRef] identifies an element that contains a piece of text.
-  GetText(ObjectRef targetRef) : super(targetRef);
-
   Map<String, String> serialize() => super.serialize();
 }
 
 class GetTextResult extends Result {
-  static GetTextResult fromJson(Map<String, dynamic> json) {
-    return new GetTextResult(json['text']);
-  }
-
   GetTextResult(this.text);
 
   final String text;
+
+  static GetTextResult fromJson(Map<String, dynamic> json) {
+    return new GetTextResult(json['text']);
+  }
 
   Map<String, dynamic> toJson() => {
     'text': text,

--- a/packages/flutter_driver/lib/src/message.dart
+++ b/packages/flutter_driver/lib/src/message.dart
@@ -16,7 +16,7 @@ abstract class Command {
 
 /// An object sent from a Flutter application back to the Flutter Driver in
 /// response to a command.
-abstract class Result {
+abstract class Result { // ignore: one_member_abstracts
   /// Serializes this message to a JSON map.
   Map<String, dynamic> toJson();
 }

--- a/packages/flutter_driver/lib/src/retry.dart
+++ b/packages/flutter_driver/lib/src/retry.dart
@@ -24,9 +24,9 @@ Future<dynamic> retry(Action action, Duration timeout,
   assert(pauseBetweenRetries != null);
 
   Stopwatch sw = stopwatchFactory()..start();
-  dynamic result = null;
-  dynamic lastError = null;
-  dynamic lastStackTrace = null;
+  dynamic result;
+  dynamic lastError;
+  dynamic lastStackTrace;
   bool success = false;
 
   while(!success && sw.elapsed < timeout) {

--- a/packages/flutter_markdown/lib/src/markdown_raw.dart
+++ b/packages/flutter_markdown/lib/src/markdown_raw.dart
@@ -211,7 +211,7 @@ class _Renderer implements md.NodeVisitor {
       _Block newBlock = new _Block(element.tag, element.attributes, _markdownStyle, new List<String>.from(_listIndents), blockList.length);
       blockList.add(newBlock);
     } else {
-      _LinkInfo linkInfo = null;
+      _LinkInfo linkInfo;
       if (element.tag == 'a') {
         linkInfo = _linkHandler.createLinkInfo(element.attributes['href']);
       }
@@ -419,7 +419,7 @@ class _Block {
         children.add(_stackToTextSpan(list[i]));
       }
 
-      String text = null;
+      String text;
       if (children.length == 1 && _isPlainText(children[0])) {
         text = children[0].text;
         children = null;
@@ -493,12 +493,13 @@ class _LinkHandler {
   }
 }
 
-abstract class SyntaxHighlighter {
+abstract class SyntaxHighlighter { // ignore: one_member_abstracts
   TextSpan format(String source);
 }
 
 class _DefaultSyntaxHighlighter extends SyntaxHighlighter{
   _DefaultSyntaxHighlighter(this.style);
+
   final TextStyle style;
 
   TextSpan format(String source) {

--- a/packages/flutter_sprites/lib/src/action.dart
+++ b/packages/flutter_sprites/lib/src/action.dart
@@ -42,22 +42,21 @@ typedef void SetterCallback(dynamic value);
 /// The abstract class for an action that changes properties over a time
 /// interval, optionally using an easing curve.
 abstract class ActionInterval extends Action {
-  double _duration;
-
-  bool _firstTick = true;
-  double _elapsed = 0.0;
+  ActionInterval([this._duration = 0.0, this.curve]);
 
   /// The duration, in seconds, of the action.
   ///
   ///     double myTime = myAction.duration;
   double get duration => _duration;
+  double _duration;
 
   /// The animation curve used to ease the animation.
   ///
   ///     myAction.curve = bounceOut;
   Curve curve;
 
-  ActionInterval([this._duration = 0.0, this.curve]);
+  bool _firstTick = true;
+  double _elapsed = 0.0;
 
   void step(double dt) {
     if (_firstTick) {

--- a/packages/flutter_sprites/lib/src/node.dart
+++ b/packages/flutter_sprites/lib/src/node.dart
@@ -15,6 +15,14 @@ double convertRadians2Degrees(double radians) => radians * 180.0/math.PI;
 /// rotation, and scaling) of a node also affects its children.
 class Node {
 
+  // Constructors
+
+  /// Creates a new [Node] without any transformation.
+  ///
+  ///     Node myNode = new Node();
+  Node();
+
+
   // Member variables
 
   SpriteBox _spriteBox;
@@ -101,12 +109,6 @@ class Node {
     }
   }
 
-  // Constructors
-
-  /// Creates a new [Node] without any transformation.
-  ///
-  ///     Node myNode = new Node();
-  Node();
 
   // Property setters and getters
 

--- a/packages/flutter_sprites/lib/src/physics_body.dart
+++ b/packages/flutter_sprites/lib/src/physics_body.dart
@@ -310,7 +310,7 @@ class PhysicsBody {
 
   double gravityScale;
 
-  Object _collisionCategory = null;
+  Object _collisionCategory;
 
   /// The collision category assigned to this body. The default value is
   /// "Default". The body will only collide with bodies that have the either
@@ -326,7 +326,7 @@ class PhysicsBody {
     _updateFilter();
   }
 
-  List<Object> _collisionMask = null;
+  List<Object> _collisionMask;
 
   /// A list of collision categories that this object will collide with. If set
   /// to null (the default value) the body will collide with all other bodies.

--- a/packages/flutter_sprites/lib/src/physics_world.dart
+++ b/packages/flutter_sprites/lib/src/physics_world.dart
@@ -385,8 +385,8 @@ class _ContactHandler extends box2d.ContactListener {
 
       if (match) {
         // We have contact and a matched callback, setup contact info
-        List<Point> touchingPoints = null;
-        Offset touchingNormal = null;
+        List<Point> touchingPoints;
+        Offset touchingNormal;
 
         // Fetch touching points, if any
         if (b2Contact.isTouching()) {

--- a/packages/flutter_sprites/lib/src/sound.dart
+++ b/packages/flutter_sprites/lib/src/sound.dart
@@ -135,18 +135,18 @@ class SoundTrack {
 SoundTrackPlayer _sharedSoundTrackPlayer;
 
 class SoundTrackPlayer {
-  Set<SoundTrack> _soundTracks = new HashSet<SoundTrack>();
-
-  static SoundTrackPlayer sharedInstance() {
-    return _sharedSoundTrackPlayer ??= new SoundTrackPlayer();
-  }
-
   SoundTrackPlayer() {
     _mediaService = new MediaServiceProxy.unbound();
     shell.connectToService("mojo:media_service", _mediaService);
   }
 
   MediaServiceProxy _mediaService;
+
+  Set<SoundTrack> _soundTracks = new HashSet<SoundTrack>();
+
+  static SoundTrackPlayer sharedInstance() {
+    return _sharedSoundTrackPlayer ??= new SoundTrackPlayer();
+  }
 
   Future<SoundTrack> load(Future<MojoDataPipeConsumer> pipe) async {
     // Create media player

--- a/packages/flutter_sprites/lib/src/sprite_box.dart
+++ b/packages/flutter_sprites/lib/src/sprite_box.dart
@@ -23,6 +23,45 @@ enum SpriteBoxTransformMode {
 
 class SpriteBox extends RenderBox {
 
+  // Setup
+
+  /// Creates a new SpriteBox with a node as its content, by default uses letterboxing.
+  ///
+  /// The [rootNode] provides the content of the node tree, typically it's a custom subclass of [NodeWithSize]. The
+  /// [mode] provides different ways to scale the content to best fit it to the screen. In most cases it's preferred to
+  /// use a [SpriteWidget] that automatically wraps the SpriteBox.
+  ///
+  ///     var spriteBox = new SpriteBox(myNode, SpriteBoxTransformMode.fixedHeight);
+  SpriteBox(NodeWithSize rootNode, [SpriteBoxTransformMode mode = SpriteBoxTransformMode.letterbox]) {
+    assert(rootNode != null);
+    assert(rootNode._spriteBox == null);
+
+    // Setup transform mode
+    this.transformMode = mode;
+
+    // Setup root node
+    this.rootNode = rootNode;
+  }
+
+  void _removeSpriteBoxReference(Node node) {
+    node._spriteBox = null;
+    for (Node child in node._children) {
+      _removeSpriteBoxReference(child);
+    }
+  }
+
+  void _addSpriteBoxReference(Node node) {
+    node._spriteBox = this;
+    for (Node child in node._children) {
+      _addSpriteBoxReference(child);
+    }
+  }
+
+  void attach() {
+    super.attach();
+    _scheduleTick();
+  }
+
   // Member variables
 
   // Root node for drawing
@@ -91,45 +130,6 @@ class SpriteBox extends RenderBox {
   }
 
   bool _initialized = false;
-
-  // Setup
-
-  /// Creates a new SpriteBox with a node as its content, by default uses letterboxing.
-  ///
-  /// The [rootNode] provides the content of the node tree, typically it's a custom subclass of [NodeWithSize]. The
-  /// [mode] provides different ways to scale the content to best fit it to the screen. In most cases it's preferred to
-  /// use a [SpriteWidget] that automatically wraps the SpriteBox.
-  ///
-  ///     var spriteBox = new SpriteBox(myNode, SpriteBoxTransformMode.fixedHeight);
-  SpriteBox(NodeWithSize rootNode, [SpriteBoxTransformMode mode = SpriteBoxTransformMode.letterbox]) {
-    assert(rootNode != null);
-    assert(rootNode._spriteBox == null);
-
-    // Setup transform mode
-    this.transformMode = mode;
-
-    // Setup root node
-    this.rootNode = rootNode;
-  }
-
-  void _removeSpriteBoxReference(Node node) {
-    node._spriteBox = null;
-    for (Node child in node._children) {
-      _removeSpriteBoxReference(child);
-    }
-  }
-
-  void _addSpriteBoxReference(Node node) {
-    node._spriteBox = this;
-    for (Node child in node._children) {
-      _addSpriteBoxReference(child);
-    }
-  }
-
-  void attach() {
-    super.attach();
-    _scheduleTick();
-  }
 
   // Properties
 

--- a/packages/flutter_sprites/lib/src/textured_line.dart
+++ b/packages/flutter_sprites/lib/src/textured_line.dart
@@ -263,7 +263,7 @@ Vector2 _vectorDirection(Vector2 a, Vector2 b) {
 
 List<Vector2> _computeMiterList(List<Vector2> points, bool closed) {
   List<Vector2> out = <Vector2>[];
-  Vector2 curNormal = null;
+  Vector2 curNormal;
 
   if (closed) {
     points = new List<Vector2>.from(points);

--- a/packages/flutter_tools/.analysis_options
+++ b/packages/flutter_tools/.analysis_options
@@ -15,20 +15,30 @@ linter:
   rules:
     - avoid_empty_else
     - always_declare_return_types
-    # we'll turn on avoid_as as soon as it doesn't complain about "as dynamic"
-    # - avoid_as
+    # - always_specify_types # still a lot of work to do before enabling this one
+    # - annotate_overrides # still a lot of work to do before enabling this one
+    # - avoid_as # https://github.com/dart-lang/linter/issues/195
+    - avoid_init_to_null
+    # - avoid_return_types_on_setters # still a lot of work to do before enabling this one
     - camel_case_types
-    # sometimes we have no choice (e.g. when matching other platforms)
-    # - constant_identifier_names
+    # - constant_identifier_names # still a lot of work to do before enabling this one
     - empty_constructor_bodies
     - hash_and_equals
-    # disabled until regexp fix is pulled in (https://github.com/flutter/flutter/pull/1996)
-    # - library_names
+    # - implementation_imports # "// ignore:" isn't working yet
+    - library_names
     - library_prefixes
     - non_constant_identifier_names
-    # too many false-positives; code review should catch real instances
-    # - one_member_abstracts
+    # - one_member_abstracts # "// ignore:" isn't working yet
+    - package_api_docs
+    - package_names
+    - package_prefixed_library_names
+    - prefer_is_not_empty
+    # - public_member_api_docs # still a lot of work to do before enabling this one
     - slash_for_doc_comments
+    - sort_constructors_first
+    - sort_unnamed_constructors_first
     - super_goes_last
+    # - type_annotate_public_apis # see always_specify_types, which this is a subset of
     - type_init_formals
     - unnecessary_brace_in_string_interp
+    - unnecessary_getters_setters

--- a/packages/flutter_tools/lib/src/android/android_device.dart
+++ b/packages/flutter_tools/lib/src/android/android_device.dart
@@ -329,7 +329,7 @@ class AndroidDevice extends Device {
     RegExp traceRegExp = new RegExp(r'Saving trace to (\S+)', multiLine: true);
     RegExp completeRegExp = new RegExp(r'Trace complete', multiLine: true);
 
-    String tracePath = null;
+    String tracePath;
     bool isComplete = false;
     while (!isComplete) {
       List<String> args = <String>['logcat', '-d'];

--- a/packages/flutter_tools/lib/src/commands/analyze.dart
+++ b/packages/flutter_tools/lib/src/commands/analyze.dart
@@ -109,9 +109,6 @@ void _addFlatPackageList(String subPath, List<String> dartFiles, Set<String> pub
 class FileChanged { }
 
 class AnalyzeCommand extends FlutterCommand {
-  String get name => 'analyze';
-  String get description => 'Analyze the project\'s Dart code.';
-
   AnalyzeCommand() {
     argParser.addFlag('flutter-repo', help: 'Include all the examples and tests from the Flutter repository.', defaultsTo: false);
     argParser.addFlag('current-directory', help: 'Include all the Dart files in the current directory, if any.', defaultsTo: true);
@@ -121,6 +118,8 @@ class AnalyzeCommand extends FlutterCommand {
     argParser.addFlag('watch', help: 'Run analysis continuously, watching the filesystem for changes.', negatable: false);
   }
 
+  String get name => 'analyze';
+  String get description => 'Analyze the project\'s Dart code.';
   bool get requiresProjectRoot => false;
 
   bool get isFlutterRepo {

--- a/packages/flutter_tools/lib/src/commands/apk.dart
+++ b/packages/flutter_tools/lib/src/commands/apk.dart
@@ -402,7 +402,7 @@ Future<int> buildAndroid({
 
   printStatus('Building APK...');
 
-  if (!flxPath.isEmpty) {
+  if (flxPath.isNotEmpty) {
     if (!FileSystemEntity.isFileSync(flxPath)) {
       printError('FLX does not exist: $flxPath');
       printError('(Omit the --flx option to build the FLX automatically)');

--- a/packages/flutter_tools/lib/src/commands/drive.dart
+++ b/packages/flutter_tools/lib/src/commands/drive.dart
@@ -5,7 +5,7 @@
 import 'dart:async';
 
 import 'package:path/path.dart' as path;
-import 'package:test/src/executable.dart' as executable;
+import 'package:test/src/executable.dart' as executable; // ignore: implementation_imports
 
 import '../android/android_device.dart' show AndroidDevice;
 import '../application_package.dart';

--- a/packages/flutter_tools/lib/src/commands/test.dart
+++ b/packages/flutter_tools/lib/src/commands/test.dart
@@ -6,7 +6,7 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:path/path.dart' as path;
-import 'package:test/src/executable.dart' as executable;
+import 'package:test/src/executable.dart' as executable; // ignore: implementation_imports
 
 import '../artifacts.dart';
 import '../build_configuration.dart';
@@ -15,9 +15,16 @@ import '../runner/flutter_command.dart';
 import '../test/flutter_platform.dart' as loader;
 
 class TestCommand extends FlutterCommand {
+  TestCommand() {
+    argParser.addFlag(
+      'flutter-repo',
+      help: 'Run tests from the \'flutter\' package in the Flutter repository instead of the current directory.',
+      defaultsTo: false
+    );
+  }
+
   String get name => 'test';
   String get description => 'Run Flutter unit tests for the current project (Linux only).';
-
   bool get requiresProjectRoot => false;
 
   @override
@@ -48,14 +55,6 @@ class TestCommand extends FlutterCommand {
           throw new Exception('Unsupported platform.');
       }
     }
-  }
-
-  TestCommand() {
-    argParser.addFlag(
-      'flutter-repo',
-      help: 'Run tests from the \'flutter\' package in the Flutter repository instead of the current directory.',
-      defaultsTo: false
-    );
   }
 
   Iterable<String> _findTests(Directory directory) {

--- a/packages/flutter_tools/lib/src/device.dart
+++ b/packages/flutter_tools/lib/src/device.dart
@@ -223,43 +223,6 @@ class DeviceStore {
     this.iOSSimulator
   });
 
-  final AndroidDevice android;
-  final IOSDevice iOS;
-  final IOSSimulator iOSSimulator;
-
-  List<Device> get all {
-    List<Device> result = <Device>[];
-    if (android != null)
-      result.add(android);
-    if (iOS != null)
-      result.add(iOS);
-    if (iOSSimulator != null)
-      result.add(iOSSimulator);
-    return result;
-  }
-
-  static Device _deviceForConfig(BuildConfiguration config, List<Device> devices) {
-    Device device = null;
-
-    if (config.deviceId != null) {
-      // Step 1: If a device identifier is specified, try to find a device
-      // matching that specific identifier
-      device = devices.firstWhere(
-          (Device dev) => (dev.id == config.deviceId),
-          orElse: () => null);
-    } else if (devices.length == 1) {
-      // Step 2: If no identifier is specified and there is only one connected
-      // device, pick that one.
-      device = devices[0];
-    } else if (devices.length > 1) {
-      // Step 3: D:
-      printStatus('Multiple devices are connected, but no device ID was specified.');
-      printStatus('Attempting to launch on all connected devices.');
-    }
-
-    return device;
-  }
-
   factory DeviceStore.forConfigs(List<BuildConfiguration> configs) {
     AndroidDevice android;
     IOSDevice iOS;
@@ -286,5 +249,42 @@ class DeviceStore {
     }
 
     return new DeviceStore(android: android, iOS: iOS, iOSSimulator: iOSSimulator);
+  }
+
+  final AndroidDevice android;
+  final IOSDevice iOS;
+  final IOSSimulator iOSSimulator;
+
+  List<Device> get all {
+    List<Device> result = <Device>[];
+    if (android != null)
+      result.add(android);
+    if (iOS != null)
+      result.add(iOS);
+    if (iOSSimulator != null)
+      result.add(iOSSimulator);
+    return result;
+  }
+
+  static Device _deviceForConfig(BuildConfiguration config, List<Device> devices) {
+    Device device;
+
+    if (config.deviceId != null) {
+      // Step 1: If a device identifier is specified, try to find a device
+      // matching that specific identifier
+      device = devices.firstWhere(
+          (Device dev) => (dev.id == config.deviceId),
+          orElse: () => null);
+    } else if (devices.length == 1) {
+      // Step 2: If no identifier is specified and there is only one connected
+      // device, pick that one.
+      device = devices[0];
+    } else if (devices.length > 1) {
+      // Step 3: D:
+      printStatus('Multiple devices are connected, but no device ID was specified.');
+      printStatus('Attempting to launch on all connected devices.');
+    }
+
+    return device;
   }
 }

--- a/packages/flutter_tools/lib/src/template.dart
+++ b/packages/flutter_tools/lib/src/template.dart
@@ -25,12 +25,6 @@ const String _kCopyTemplateExtension = '.copy.tmpl';
 /// Files in the destination will not contain either the '.tmpl' or '.copy.tmpl'
 /// extensions.
 class Template {
-  factory Template.fromName(String name) {
-    // All named templates are placed in the 'templates' directory
-    Directory templateDir = _templateDirectoryInPackage(name);
-    return new Template(templateDir, templateDir);
-  }
-
   Template(Directory templateSource, Directory baseDir) {
     _templateFilePaths = new Map<String, String>();
 
@@ -56,6 +50,12 @@ class Template {
         _templateFilePaths[relativePath] = path.absolute(entity.path);
       }
     }
+  }
+
+  factory Template.fromName(String name) {
+    // All named templates are placed in the 'templates' directory
+    Directory templateDir = _templateDirectoryInPackage(name);
+    return new Template(templateDir, templateDir);
   }
 
   Map<String /* relative */, String /* absolute source */> _templateFilePaths;

--- a/packages/flutter_tools/lib/src/test/flutter_platform.dart
+++ b/packages/flutter_tools/lib/src/test/flutter_platform.dart
@@ -10,9 +10,9 @@ import 'package:async/async.dart';
 import 'package:path/path.dart' as path;
 import 'package:stream_channel/stream_channel.dart';
 
-import 'package:test/src/backend/test_platform.dart';
-import 'package:test/src/runner/plugin/platform.dart';
-import 'package:test/src/runner/plugin/hack_register_platform.dart' as hack;
+import 'package:test/src/backend/test_platform.dart'; // ignore: implementation_imports
+import 'package:test/src/runner/plugin/platform.dart'; // ignore: implementation_imports
+import 'package:test/src/runner/plugin/hack_register_platform.dart' as hack; // ignore: implementation_imports
 
 import '../artifacts.dart';
 

--- a/packages/newton/lib/src/friction_simulation.dart
+++ b/packages/newton/lib/src/friction_simulation.dart
@@ -8,16 +8,26 @@ import 'simulation.dart';
 import 'tolerance.dart';
 
 class FrictionSimulation extends Simulation {
+  FrictionSimulation(double drag, double position, double velocity)
+    : _drag = drag,
+      _dragLog = math.log(drag),
+      _x = position,
+      _v = velocity;
+
+  // A friction simulation that starts and ends at the specified positions
+  // and velocities.
+  factory FrictionSimulation.through(double startPosition, double endPosition, double startVelocity, double endVelocity) {
+    return new FrictionSimulation(
+      _dragFor(startPosition, endPosition, startVelocity, endVelocity),
+      startPosition,
+      startVelocity)
+      .. tolerance = new Tolerance(velocity: endVelocity.abs());
+  }
+
   final double _drag;
   final double _dragLog;
   final double _x;
   final double _v;
-
-  FrictionSimulation(double drag, double position, double velocity)
-      : _drag = drag,
-        _dragLog = math.log(drag),
-        _x = position,
-        _v = velocity;
 
   // Return the drag value for a FrictionSimulation whose x() and dx() values pass
   // through the specified start and end position/velocity values.
@@ -28,16 +38,6 @@ class FrictionSimulation extends Simulation {
   // x1 = x0 + (v0 * D^((log(v1) - log(v0)) / log(D))) / log(D) - v0 / log(D), find D
   static double _dragFor(double startPosition, double endPosition, double startVelocity, double endVelocity) {
     return math.pow(math.E, (startVelocity - endVelocity) / (startPosition - endPosition));
-  }
-
-  // A friction simulation that starts and ends at the specified positions
-  // and velocities.
-  factory FrictionSimulation.through(double startPosition, double endPosition, double startVelocity, double endVelocity) {
-    return new FrictionSimulation(
-      _dragFor(startPosition, endPosition, startVelocity, endVelocity),
-      startPosition,
-      startVelocity)
-      .. tolerance = new Tolerance(velocity: endVelocity.abs());
   }
 
   double x(double time) => _x + _v * math.pow(_drag, time) / _dragLog - _v / _dragLog;


### PR DESCRIPTION
Well, all the easy ones, anyway.

For some reason `// ignore:` isn't working for me so I've disabled
lints that need that. Also disabled those that require a ton of work
(which I'm doing, but not in this PR, to keep it reviewable).

This adds:
- avoid_init_to_null
- library_names
- package_api_docs
- package_names
- package_prefixed_library_names
- prefer_is_not_empty
- sort_constructors_first
- sort_unnamed_constructors_first
- unnecessary_getters_setters
