### PR TITLE
Remove devicestore

### DIFF
--- a/packages/flutter_tools/lib/src/application_package.dart
+++ b/packages/flutter_tools/lib/src/application_package.dart
@@ -29,6 +29,10 @@ abstract class ApplicationPackage {
     assert(localPath != null);
     assert(id != null);
   }
+
+  String get displayName => name;
+
+  String toString() => displayName;
 }
 
 class AndroidApk extends ApplicationPackage {
@@ -99,6 +103,8 @@ class IOSApp extends ApplicationPackage {
     String projectDir = path.join("ios", ".generated");
     return new IOSApp(iosProjectDir: projectDir, iosProjectBundleId: value);
   }
+
+  String get displayName => id;
 }
 
 class ApplicationPackageStore {

--- a/packages/flutter_tools/lib/src/commands/apk.dart
+++ b/packages/flutter_tools/lib/src/commands/apk.dart
@@ -422,14 +422,14 @@ Future<int> buildAndroid({
 // TODO(mpcomplete): move this to Device?
 /// This is currently Android specific.
 Future<int> buildAll(
-  DeviceStore devices,
+  List<Device> devices,
   ApplicationPackageStore applicationPackages,
   Toolchain toolchain,
   List<BuildConfiguration> configs, {
   String enginePath,
   String target: ''
 }) async {
-  for (Device device in devices.all) {
+  for (Device device in devices) {
     ApplicationPackage package = applicationPackages.getPackageForPlatform(device.platform);
     if (package == null)
       continue;
@@ -437,14 +437,6 @@ Future<int> buildAll(
     // TODO(mpcomplete): Temporary hack. We only support the apk builder atm.
     if (package != applicationPackages.android)
       continue;
-
-    // TODO(devoncarew): Remove this warning after a few releases.
-    if (FileSystemEntity.isDirectorySync('apk') && !FileSystemEntity.isDirectorySync('android')) {
-      // Tell people the android directory location changed.
-      printStatus(
-        "Warning: Flutter now looks for Android resources in the android/ directory; "
-        "consider renaming your 'apk/' directory to 'android/'.");
-    }
 
     int result = await build(toolchain, configs, enginePath: enginePath, target: target);
     if (result != 0)

--- a/packages/flutter_tools/lib/src/commands/daemon.dart
+++ b/packages/flutter_tools/lib/src/commands/daemon.dart
@@ -256,11 +256,11 @@ class AppDomain extends Domain {
     try {
       await Future.wait([
         command.downloadToolchain(),
-        command.downloadApplicationPackagesAndConnectToDevices(),
+        command.downloadApplicationPackages(),
       ], eagerError: true);
 
       int result = await startApp(
-        command.devices,
+        device,
         command.applicationPackages,
         command.toolchain,
         command.buildConfigurations,

--- a/packages/flutter_tools/lib/src/commands/devices.dart
+++ b/packages/flutter_tools/lib/src/commands/devices.dart
@@ -30,10 +30,8 @@ class DevicesCommand extends FlutterCommand {
     } else {
       printStatus('${devices.length} connected ${pluralize('device', devices.length)}:\n');
 
-      for (Device device in devices) {
-        String supportIndicator = device.isSupported() ? '' : ' - unsupported';
-        printStatus('${device.name} (${device.id})$supportIndicator');
-      }
+      for (Device device in devices)
+        printStatus(device.fullDescription);
     }
 
     return 0;

--- a/packages/flutter_tools/lib/src/commands/drive.dart
+++ b/packages/flutter_tools/lib/src/commands/drive.dart
@@ -315,6 +315,6 @@ Future<Null> downloadToolchain(DriveCommand command) async {
   printTrace('Downloading toolchain.');
   await Future.wait([
     command.downloadToolchain(),
-    command.downloadApplicationPackagesAndConnectToDevices(),
+    command.downloadApplicationPackages(),
   ], eagerError: true);
 }

--- a/packages/flutter_tools/lib/src/commands/listen.dart
+++ b/packages/flutter_tools/lib/src/commands/listen.dart
@@ -28,7 +28,7 @@ class ListenCommand extends RunCommandBase {
 
   @override
   Future<int> runInProject() async {
-    await downloadApplicationPackagesAndConnectToDevices();
+    await downloadApplicationPackages();
     await downloadToolchain();
 
     List<String> watchCommand = _constructWatchCommand(() sync* {
@@ -42,7 +42,7 @@ class ListenCommand extends RunCommandBase {
     do {
       printStatus('Updating running Flutter apps...');
       result = await startApp(
-        devices,
+        deviceForCommand,
         applicationPackages,
         toolchain,
         buildConfigurations,

--- a/packages/flutter_tools/lib/src/commands/refresh.dart
+++ b/packages/flutter_tools/lib/src/commands/refresh.dart
@@ -7,6 +7,7 @@ import 'dart:io';
 
 import 'package:path/path.dart' as path;
 
+import '../android/android_device.dart';
 import '../globals.dart';
 import '../runner/flutter_command.dart';
 
@@ -28,13 +29,8 @@ class RefreshCommand extends FlutterCommand {
 
     await Future.wait([
       downloadToolchain(),
-      downloadApplicationPackagesAndConnectToDevices(),
+      downloadApplicationPackages(),
     ], eagerError: true);
-
-    if (devices.android == null) {
-      printError('No device connected.');
-      return 1;
-    }
 
     Directory tempDir = await Directory.systemTemp.createTemp('flutter_tools');
     try {
@@ -48,11 +44,13 @@ class RefreshCommand extends FlutterCommand {
         return result;
       }
 
-      bool success = await devices.android.refreshSnapshot(
-          applicationPackages.android, snapshotPath
+      AndroidDevice device = deviceForCommand;
+
+      bool success = await device.refreshSnapshot(
+        applicationPackages.android, snapshotPath
       );
       if (!success) {
-        printError('Error refreshing snapshot on ${devices.android.name}.');
+        printError('Error refreshing snapshot on $device.');
         return 1;
       }
 

--- a/packages/flutter_tools/lib/src/commands/trace.dart
+++ b/packages/flutter_tools/lib/src/commands/trace.dart
@@ -31,28 +31,24 @@ class TraceCommand extends FlutterCommand {
 
   @override
   Future<int> runInProject() async {
-    await downloadApplicationPackagesAndConnectToDevices();
-
-    if (devices.android == null) {
-      printError('No device connected, so no trace was completed.');
-      return 1;
-    }
+    await downloadApplicationPackages();
 
     ApplicationPackage androidApp = applicationPackages.android;
+    AndroidDevice device = deviceForCommand;
 
     if ((!argResults['start'] && !argResults['stop']) ||
         (argResults['start'] && argResults['stop'])) {
       // Setting neither flags or both flags means do both commands and wait
       // duration seconds in between.
-      devices.android.startTracing(androidApp);
+      device.startTracing(androidApp);
       await new Future.delayed(
-          new Duration(seconds: int.parse(argResults['duration'])),
-          () => _stopTracing(devices.android, androidApp)
+        new Duration(seconds: int.parse(argResults['duration'])),
+        () => _stopTracing(device, androidApp)
       );
     } else if (argResults['stop']) {
-      await _stopTracing(devices.android, androidApp);
+      await _stopTracing(device, androidApp);
     } else {
-      devices.android.startTracing(androidApp);
+      device.startTracing(androidApp);
     }
     return 0;
   }

--- a/packages/flutter_tools/test/install_test.dart
+++ b/packages/flutter_tools/test/install_test.dart
@@ -15,18 +15,11 @@ void main() {
     testUsingContext('returns 0 when Android is connected and ready for an install', () {
       InstallCommand command = new InstallCommand();
       applyMocksToCommand(command);
-      MockDeviceStore mockDevices = command.devices;
 
-      when(mockDevices.android.isAppInstalled(any)).thenReturn(false);
-      when(mockDevices.android.installApp(any)).thenReturn(true);
-
-      when(mockDevices.iOS.isAppInstalled(any)).thenReturn(false);
-      when(mockDevices.iOS.installApp(any)).thenReturn(false);
-
-      when(mockDevices.iOSSimulator.isAppInstalled(any)).thenReturn(false);
-      when(mockDevices.iOSSimulator.installApp(any)).thenReturn(false);
-
-      testDeviceManager.addDevice(mockDevices.android);
+      MockAndroidDevice device = new MockAndroidDevice();
+      when(device.isAppInstalled(any)).thenReturn(false);
+      when(device.installApp(any)).thenReturn(true);
+      testDeviceManager.addDevice(device);
 
       return createTestCommandRunner(command).run(['install']).then((int code) {
         expect(code, equals(0));
@@ -36,18 +29,11 @@ void main() {
     testUsingContext('returns 0 when iOS is connected and ready for an install', () {
       InstallCommand command = new InstallCommand();
       applyMocksToCommand(command);
-      MockDeviceStore mockDevices = command.devices;
 
-      when(mockDevices.android.isAppInstalled(any)).thenReturn(false);
-      when(mockDevices.android.installApp(any)).thenReturn(false);
-
-      when(mockDevices.iOS.isAppInstalled(any)).thenReturn(false);
-      when(mockDevices.iOS.installApp(any)).thenReturn(true);
-
-      when(mockDevices.iOSSimulator.isAppInstalled(any)).thenReturn(false);
-      when(mockDevices.iOSSimulator.installApp(any)).thenReturn(false);
-
-      testDeviceManager.addDevice(mockDevices.iOS);
+      MockIOSDevice device = new MockIOSDevice();
+      when(device.isAppInstalled(any)).thenReturn(false);
+      when(device.installApp(any)).thenReturn(true);
+      testDeviceManager.addDevice(device);
 
       return createTestCommandRunner(command).run(['install']).then((int code) {
         expect(code, equals(0));

--- a/packages/flutter_tools/test/src/mocks.dart
+++ b/packages/flutter_tools/test/src/mocks.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'dart:async';
+
 import 'package:flutter_tools/src/android/android_device.dart';
 import 'package:flutter_tools/src/application_package.dart';
 import 'package:flutter_tools/src/build_configuration.dart';
@@ -45,13 +46,6 @@ class MockIOSSimulator extends Mock implements IOSSimulator {
   bool isSupported() => true;
 }
 
-class MockDeviceStore extends DeviceStore {
-  MockDeviceStore() : super(
-    android: new MockAndroidDevice(),
-    iOS: new MockIOSDevice(),
-    iOSSimulator: new MockIOSSimulator());
-}
-
 class MockDeviceLogReader extends DeviceLogReader {
   String get name => 'MockLogReader';
 
@@ -89,6 +83,5 @@ void applyMocksToCommand(FlutterCommand command) {
   command
     ..applicationPackages = new MockApplicationPackageStore()
     ..toolchain = new MockToolchain()
-    ..devices = new MockDeviceStore()
     ..projectRootValidator = () => true;
 }


### PR DESCRIPTION
- Remove the `DeviceStore` class. It was an older way to locate connected devices and was largely replaced by the `DeviceManager` class.
- enforce that most commands require the user to specify a specific device to run on (if we can't infer which device to use)
- allow the `--device-id` option to work with prefixs of device ids (or device names)
