### PR TITLE
Analyze command cleanup.

### DIFF
--- a/packages/flutter_tools/lib/src/commands/analyze.dart
+++ b/packages/flutter_tools/lib/src/commands/analyze.dart
@@ -339,6 +339,7 @@ class AnalyzeCommand extends FlutterCommand {
     RegExp generalPattern = new RegExp(r'^\[(error|warning|hint|lint)\] (.+) \(([^(),]+), line ([0-9]+), col ([0-9]+)\)$');
     RegExp allowedIdentifiersPattern = new RegExp(r'_?([A-Z]|_+)\b');
     RegExp constructorTearOffsPattern = new RegExp('.+#.+// analyzer doesn\'t like constructor tear-offs');
+    RegExp conflictingNamesPattern = new RegExp('^The imported libraries \'([^\']+)\' and \'([^\']+)\' cannot have the same name \'([^\']+)\'\$');
     RegExp missingFilePattern = new RegExp('^Target of URI does not exist: \'([^\')]+)\'\$');
 
     Set<String> changedFiles = new Set<String>(); // files about which we've complained that they changed
@@ -371,8 +372,11 @@ class AnalyzeCommand extends FlutterCommand {
           }
           bool shouldIgnore = false;
           if (filename == mainFile.path) {
+            Match libs = conflictingNamesPattern.firstMatch(errorMessage);
             Match missing = missingFilePattern.firstMatch(errorMessage);
-            if (missing != null) {
+            if (libs != null) {
+              errorLine = '[$level] $errorMessage (${dartFiles[lineNumber-1]})'; // strip the reference to the generated main.dart
+            } else if (missing != null) {
               errorLine = '[$level] File does not exist (${missing[1]})';
             } else {
               errorLine += ' (Please file a bug on the "flutter analyze" command saying that you saw this message.)';


### PR DESCRIPTION
Removing some special-casing in pursuit of aligning `flutter analyze` output with that provided by server/IDEs.  Specifically:
- strong-hints (stale, no longer supported)
- "analyzer says" comment handling in favor of `//ignore`s
- `conflictingNamePattern` --- no longer needed

Next up some of the error filter regexps...
