### PR TITLE
show the error codes in flutter analyze --watch

### DIFF
--- a/packages/flutter_tools/lib/src/commands/analyze.dart
+++ b/packages/flutter_tools/lib/src/commands/analyze.dart
@@ -465,8 +465,11 @@ class AnalyzeCommand extends FlutterCommand {
 
       errors.sort();
 
-      for (AnalysisError error in errors)
+      for (AnalysisError error in errors) {
         printStatus(error.toString());
+        if (error.code != null)
+          printTrace('error code: ${error.code}');
+      }
 
       // Print an analysis summary.
       String errorsMessage;
@@ -744,6 +747,7 @@ class AnalysisError implements Comparable<AnalysisError> {
   int get severityLevel => _severityMap[severity] ?? 0;
   String get type => json['type'];
   String get message => json['message'];
+  String get code => json['code'];
 
   String get file => json['location']['file'];
   int get startLine => json['location']['startLine'];


### PR DESCRIPTION
If a error code is sent by the analysis server, show it in `flutter analyze --watch`. Older versions of the sdk don't send error codes. I tried upgrading to `1.16.0-dev.0.0` (the latest) but that was cut after the codes were added to the stream.

The next sdk dev release should have the error codes.
