### PR TITLE
flutter analyze test

### DIFF
--- a/packages/flutter_tools/lib/src/runner/flutter_command_runner.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command_runner.dart
@@ -150,13 +150,17 @@ class FlutterCommandRunner extends CommandRunner {
     if (Platform.environment.containsKey(kFlutterRootEnvironmentVariableName))
       return Platform.environment[kFlutterRootEnvironmentVariableName];
     try {
+      if (Platform.script.scheme == 'data')
+        return '../..'; // we're running as a test
       String script = Platform.script.toFilePath();
       if (path.basename(script) == kSnapshotFileName)
         return path.dirname(path.dirname(path.dirname(script)));
       if (path.basename(script) == kFlutterToolsScriptFileName)
         return path.dirname(path.dirname(path.dirname(path.dirname(script))));
     } catch (error) {
-      printTrace('Unable to locate fluter root: $error');
+      // we don't have a logger at the time this is run
+      // (which is why we don't use printTrace here)
+      print('Unable to locate flutter root: $error');
     }
     return '.';
   }

--- a/packages/flutter_tools/test/analyze_duplicate_names_test.dart
+++ b/packages/flutter_tools/test/analyze_duplicate_names_test.dart
@@ -1,0 +1,48 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:io';
+
+import 'package:flutter_tools/src/base/os.dart';
+import 'package:flutter_tools/src/commands/analyze.dart';
+import 'package:path/path.dart' as path;
+import 'package:test/test.dart';
+
+import 'src/common.dart';
+import 'src/context.dart';
+import 'src/mocks.dart';
+
+void main() {
+  Directory tempDir;
+
+  setUp(() {
+    tempDir = Directory.systemTemp.createTempSync('analysis_duplicate_names_test');
+  });
+
+  tearDown(() {
+    tempDir?.deleteSync(recursive: true);
+  });
+
+  group('analyze', () {
+    testUsingContext('flutter analyze with two files with the same name', () async {
+
+      File dartFileA = new File(path.join(tempDir.path, 'a.dart'));
+      dartFileA.parent.createSync();
+      dartFileA.writeAsStringSync('library test;');
+      File dartFileB = new File(path.join(tempDir.path, 'b.dart'));
+      dartFileB.writeAsStringSync('library test;');
+
+      AnalyzeCommand command = new AnalyzeCommand();
+      applyMocksToCommand(command);
+      return createTestCommandRunner(command).run(['analyze', '--no-current-package', '--no-current-directory', dartFileA.path, dartFileB.path]).then((int code) {
+        expect(code, equals(1));
+        expect(testLogger.errorText, '[warning] The imported libraries \'a.dart\' and \'b.dart\' cannot have the same name \'test\' (${dartFileB.path})\n');
+        expect(testLogger.statusText, 'Analyzing 2 entry points...\n');
+      });
+
+    }, overrides: <Type, dynamic>{
+      OperatingSystemUtils: os
+    });
+  });
+}

--- a/packages/flutter_tools/test/drive_test.dart
+++ b/packages/flutter_tools/test/drive_test.dart
@@ -68,8 +68,9 @@ void main() {
       return createTestCommandRunner(command).run(args).then((int code) {
         expect(code, equals(1));
         BufferLogger buffer = logger;
-        expect(buffer.errorText,
-            contains('Test file not found: /some/app/test_driver/e2e_test.dart'));
+        expect(buffer.errorText, contains(
+          'Test file not found: /some/app/test_driver/e2e_test.dart'
+        ));
       });
     });
 


### PR DESCRIPTION
Test that flutter analyze catches no error if two imported libraries
have the same name.

Also, make tests know how to find the flutter root and fix style in one
test to be consistent with the rest of the file.
