### PR TITLE
AspectRatio should attempt to fit its height

### DIFF
--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -702,16 +702,39 @@ class OffStage extends OneChildRenderObjectWidget {
   RenderOffStage createRenderObject(BuildContext context) => new RenderOffStage();
 }
 
-/// Forces child to layout at a specific aspect ratio.
+/// Attempts to size the child to a specific aspect ratio.
 ///
-/// See [RenderAspectRatio] for details.
+/// The widget first tries the largest width permited by the layout
+/// constraints. The height of the widget is determined by applying the
+/// given aspect ratio to the width, expressed as a ratio of width to height.
+///
+/// For example, a 16:9 width:height aspect ratio would have a value of
+/// 16.0/9.0. If the maximum width is infinite, the initial width is determined
+/// by applying the aspect ratio to the maximum height.
+///
+/// Now consider a second example, this time with an aspect ratio of 2.0 and
+/// layout constraints that require the width to be between 0.0 and 100.0 and
+/// the height to be between 0.0 and 100.0. We'll select a width of 100.0 (the
+/// biggest allowed) and a height of 50.0 (to match the aspect ratio).
+///
+/// In that same situation, if the aspect ratio is 0.5, we'll also select a
+/// width of 100.0 (still the biggest allowed) and we'll attempt to use a height
+/// of 200.0. Unfortunately, that violates the constraints because the child can
+/// be at most 100.0 pixels tall. The widget will then take that value
+/// and apply the aspect ratio again to obtain a width of 50.0. That width is
+/// permitted by the constraints and the child receives a width of 50.0 and a
+/// height of 100.0. If the width were not permitted, the widget would
+/// continue iterating through the constraints. If the widget does not
+/// find a feasible size after consulting each constraint, the widget
+/// will eventually select a size for the child that meets the layout
+/// constraints but fails to meet the aspect ratio constraints.
 class AspectRatio extends OneChildRenderObjectWidget {
   AspectRatio({ Key key, this.aspectRatio, Widget child })
     : super(key: key, child: child) {
     assert(aspectRatio != null);
   }
 
-  /// The aspect ratio to use when computing the height from the width.
+  /// The aspect ratio to attempt to use.
   ///
   /// The aspect ratio is expressed as a ratio of width to height. For example,
   /// a 16:9 width:height aspect ratio would have a value of 16.0/9.0.

--- a/packages/flutter/test/widget/aspect_ratio_test.dart
+++ b/packages/flutter/test/widget/aspect_ratio_test.dart
@@ -1,0 +1,57 @@
+// Copyright 2015 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter/widgets.dart';
+import 'package:test/test.dart';
+
+Size _getSize(WidgetTester tester, BoxConstraints constraints, double aspectRatio) {
+  Key childKey = new UniqueKey();
+  tester.pumpWidget(
+    new Center(
+      child: new ConstrainedBox(
+        constraints: constraints,
+        child: new AspectRatio(
+          aspectRatio: aspectRatio,
+          child: new Container(
+            key: childKey
+          )
+        )
+      )
+    )
+  );
+  RenderBox box = tester.findElementByKey(childKey).renderObject;
+  return box.size;
+}
+
+void main() {
+  test('Aspect ratio control test', () {
+    testWidgets((WidgetTester tester) {
+      expect(_getSize(tester, new BoxConstraints.loose(new Size(500.0, 500.0)), 2.0), equals(new Size(500.0, 250.0)));
+      expect(_getSize(tester, new BoxConstraints.loose(new Size(500.0, 500.0)), 0.5), equals(new Size(250.0, 500.0)));
+    });
+  });
+
+  test('Aspect ratio infinite width', () {
+    testWidgets((WidgetTester tester) {
+      Key childKey = new UniqueKey();
+      tester.pumpWidget(
+        new Center(
+          child: new Viewport(
+            scrollDirection: Axis.horizontal,
+            child: new AspectRatio(
+              aspectRatio: 2.0,
+              child: new Container(
+                key: childKey
+              )
+            )
+          )
+        )
+      );
+      RenderBox box = tester.findElementByKey(childKey).renderObject;
+      expect(box.size, equals(new Size(1200.0, 600.0)));
+    });
+  });
+}


### PR DESCRIPTION
If there's not enough height for the given aspect ratio, we now try to see if
using the height to infer the width will fit the given constraints. The
algorithm we use is similar to the one we use for RenderImage.

Fixes #2620
