### PR TITLE
fix a launch issue when the user has deleted the app

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_device.dart
+++ b/packages/flutter_tools/lib/src/android/android_device.dart
@@ -147,7 +147,11 @@ class AndroidDevice extends Device {
 
   @override
   bool isAppInstalled(ApplicationPackage app) {
-    // Just check for the existence of the application SHA.
+    // This call takes 400ms - 600ms.
+    if (runCheckedSync(adbCommandForDevice(['shell', 'pm', 'path', app.id])).isEmpty)
+      return false;
+
+    // Check the application SHA.
     return _getDeviceApkSha1(app) == _getSourceSha1(app);
   }
 


### PR DESCRIPTION
Fix a launch issue when the user has deleted the app (introduced in https://github.com/flutter/flutter/commit/5bce2fbdec781b4cd8d272cb1e89dc46461d1899). fix https://github.com/flutter/flutter/issues/2579

This makes all android launches slightly slower, but I couldn't find a quicker way to verify that the app is installed.
