### PR TITLE
fix a regression in adb forward

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_device.dart
+++ b/packages/flutter_tools/lib/src/android/android_device.dart
@@ -549,12 +549,9 @@ class _AndroidDevicePortForwarder extends DevicePortForwarder {
   List<ForwardedPort> get forwardedPorts {
     final List<ForwardedPort> ports = <ForwardedPort>[];
 
-    String stdout = runCheckedSync(
-      <String>[
-        androidSdk.adbPath,
-        'forward',
-        '--list'
-      ]);
+    String stdout = runCheckedSync(device.adbCommandForDevice(
+      <String>['forward', '--list']
+    ));
 
     List<String> lines = LineSplitter.split(stdout).toList();
     for (String line in lines) {
@@ -586,24 +583,16 @@ class _AndroidDevicePortForwarder extends DevicePortForwarder {
       hostPort = await findAvailablePort();
     }
 
-    runCheckedSync(
-      <String>[
-        androidSdk.adbPath,
-        'forward',
-        'tcp:$hostPort',
-        'tcp:$devicePort',
-      ]);
+    runCheckedSync(device.adbCommandForDevice(
+      <String>['forward', 'tcp:$hostPort', 'tcp:$devicePort']
+    ));
 
     return hostPort;
   }
 
   Future unforward(ForwardedPort forwardedPort) async {
-    runCheckedSync(
-      <String>[
-        androidSdk.adbPath,
-        'forward',
-        '--remove',
-        'tcp:${forwardedPort.hostPort}'
-      ]);
+    runCheckedSync(device.adbCommandForDevice(
+      <String>['forward', '--remove', 'tcp:${forwardedPort.hostPort}']
+    ));
   }
 }


### PR DESCRIPTION
Fix a regression in adb forward. In my review of this I was incorrect - we do need to specify the device to use for forwarding (`-s deviceId`), esp. when there is more than one device connected.

@johnmccutchan 
