### PR TITLE
add an atom launch config to the starter app

### DIFF
--- a/packages/flutter_tools/lib/src/ios/setup_xcodeproj.dart
+++ b/packages/flutter_tools/lib/src/ios/setup_xcodeproj.dart
@@ -150,8 +150,7 @@ Future<int> setupXcodeProjectHarness(String flutterProjectPath) async {
   revisionFile.writeAsStringSync(ArtifactStore.engineRevision);
 
   // Step 5: Tell the user the location of the generated project.
-  printStatus('Xcode project created at $xcodeprojPath/.');
-  printStatus('User editable settings are in $iosFilesPath/.');
+  printStatus('Xcode project created in $iosFilesPath/.');
 
   return 0;
 }

--- a/packages/flutter_tools/templates/create/.atom/launches.tmpl/main.yaml.tmpl
+++ b/packages/flutter_tools/templates/create/.atom/launches.tmpl/main.yaml.tmpl
@@ -1,0 +1,10 @@
+# Flutter launch configuration for lib/main.dart.
+type: flutter
+path: lib/main.dart
+
+flutter:
+  checked: true
+  debug: true
+  route:
+  # Additional args for the flutter run command:
+  args:


### PR DESCRIPTION
Add an atom launch config to the starter app. This fixes an issue where when a project is first created atom claims that there are no runnable apps.
