### PR TITLE
rename the platform constants

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_device.dart
+++ b/packages/flutter_tools/lib/src/android/android_device.dart
@@ -52,9 +52,9 @@ class AndroidDevice extends Device {
 
   bool get isLocalEmulator {
     if (_isLocalEmulator == null) {
-      // sample values: x86, armeabi-v7a
+      // http://developer.android.com/ndk/guides/abis.html (x86, armeabi-v7a, ...)
       String value = runCheckedSync(adbCommandForDevice(['shell', 'getprop', 'ro.product.cpu.abi']));
-      _isLocalEmulator = value == 'x86';
+      _isLocalEmulator = value.startsWith('x86');
     }
 
     return _isLocalEmulator;

--- a/packages/flutter_tools/lib/src/android/android_device.dart
+++ b/packages/flutter_tools/lib/src/android/android_device.dart
@@ -48,7 +48,17 @@ class AndroidDevice extends Device {
   final String modelID;
   final String deviceCodeName;
 
-  bool get isLocalEmulator => false;
+  bool _isLocalEmulator;
+
+  bool get isLocalEmulator {
+    if (_isLocalEmulator == null) {
+      // sample values: x86, armeabi-v7a
+      String value = runCheckedSync(adbCommandForDevice(['shell', 'getprop', 'ro.product.cpu.abi']));
+      _isLocalEmulator = value == 'x86';
+    }
+
+    return _isLocalEmulator;
+  }
 
   _AdbLogReader _logReader;
   _AndroidDevicePortForwarder _portForwarder;
@@ -59,8 +69,7 @@ class AndroidDevice extends Device {
 
   bool _isValidAdbVersion(String adbVersion) {
     // Sample output: 'Android Debug Bridge version 1.0.31'
-    Match versionFields =
-        new RegExp(r'(\d+)\.(\d+)\.(\d+)').firstMatch(adbVersion);
+    Match versionFields = new RegExp(r'(\d+)\.(\d+)\.(\d+)').firstMatch(adbVersion);
     if (versionFields != null) {
       int majorVersion = int.parse(versionFields[1]);
       int minorVersion = int.parse(versionFields[2]);
@@ -275,8 +284,9 @@ class AndroidDevice extends Device {
     return runCommandAndStreamOutput(command).then((int exitCode) => exitCode == 0);
   }
 
+  // TODO(devoncarew): Return android_arm or android_x64 based on [isLocalEmulator].
   @override
-  TargetPlatform get platform => TargetPlatform.android;
+  TargetPlatform get platform => TargetPlatform.android_arm;
 
   void clearLogs() {
     runSync(adbCommandForDevice(<String>['logcat', '-c']));
@@ -584,7 +594,7 @@ class _AndroidDevicePortForwarder extends DevicePortForwarder {
     return ports;
   }
 
-  Future<int> forward(int devicePort, {int hostPort: null}) async {
+  Future<int> forward(int devicePort, { int hostPort }) async {
     if ((hostPort == null) || (hostPort == 0)) {
       // Auto select host port.
       hostPort = await findAvailablePort();

--- a/packages/flutter_tools/lib/src/application_package.dart
+++ b/packages/flutter_tools/lib/src/application_package.dart
@@ -115,13 +115,13 @@ class ApplicationPackageStore {
 
   ApplicationPackage getPackageForPlatform(TargetPlatform platform) {
     switch (platform) {
-      case TargetPlatform.android:
+      case TargetPlatform.android_arm:
         return android;
-      case TargetPlatform.iOS:
-      case TargetPlatform.iOSSimulator:
+      case TargetPlatform.ios_arm:
+      case TargetPlatform.ios_x64:
         return iOS;
-      case TargetPlatform.mac:
-      case TargetPlatform.linux:
+      case TargetPlatform.darwin_x64:
+      case TargetPlatform.linux_x64:
         return null;
     }
   }
@@ -132,7 +132,7 @@ class ApplicationPackageStore {
 
     for (BuildConfiguration config in configs) {
       switch (config.targetPlatform) {
-        case TargetPlatform.android:
+        case TargetPlatform.android_arm:
           assert(android == null);
           android = AndroidApk.getCustomApk();
           // Fall back to the prebuilt or engine-provided apk if we can't build
@@ -145,18 +145,18 @@ class ApplicationPackageStore {
             android = new AndroidApk(localPath: localPath);
           } else {
             Artifact artifact = ArtifactStore.getArtifact(
-              type: ArtifactType.shell, targetPlatform: TargetPlatform.android);
+              type: ArtifactType.shell, targetPlatform: TargetPlatform.android_arm);
             android = new AndroidApk(localPath: await ArtifactStore.getPath(artifact));
           }
           break;
 
-        case TargetPlatform.iOS:
-        case TargetPlatform.iOSSimulator:
+        case TargetPlatform.ios_arm:
+        case TargetPlatform.ios_x64:
           iOS ??= new IOSApp.fromBuildConfiguration(config);
           break;
 
-        case TargetPlatform.mac:
-        case TargetPlatform.linux:
+        case TargetPlatform.darwin_x64:
+        case TargetPlatform.linux_x64:
           break;
       }
     }

--- a/packages/flutter_tools/lib/src/artifacts.dart
+++ b/packages/flutter_tools/lib/src/artifacts.dart
@@ -23,15 +23,15 @@ String _getNameForHostPlatform(HostPlatform platform) {
 
 String _getNameForTargetPlatform(TargetPlatform platform) {
   switch (platform) {
-    case TargetPlatform.android:
+    case TargetPlatform.android_arm:
       return 'android-arm';
-    case TargetPlatform.iOS:
+    case TargetPlatform.ios_arm:
       return 'ios-arm';
-    case TargetPlatform.iOSSimulator:
+    case TargetPlatform.ios_x64:
       return 'ios-x64';
-    case TargetPlatform.mac:
+    case TargetPlatform.darwin_x64:
       return 'darwin-x64';
-    case TargetPlatform.linux:
+    case TargetPlatform.linux_x64:
       return 'linux-x64';
   }
 }
@@ -77,13 +77,13 @@ class ArtifactStore {
       name: 'Sky Shell',
       fileName: 'SkyShell.apk',
       type: ArtifactType.shell,
-      targetPlatform: TargetPlatform.android
+      targetPlatform: TargetPlatform.android_arm
     ),
     const Artifact._(
       name: 'Sky Shell',
       fileName: 'sky_shell',
       type: ArtifactType.shell,
-      targetPlatform: TargetPlatform.linux
+      targetPlatform: TargetPlatform.linux_x64
     ),
     const Artifact._(
       name: 'Sky Snapshot',
@@ -101,37 +101,37 @@ class ArtifactStore {
       name: 'Flutter for Mojo',
       fileName: 'flutter.mojo',
       type: ArtifactType.mojo,
-      targetPlatform: TargetPlatform.android
+      targetPlatform: TargetPlatform.android_arm
     ),
     const Artifact._(
       name: 'Flutter for Mojo',
       fileName: 'flutter.mojo',
       type: ArtifactType.mojo,
-      targetPlatform: TargetPlatform.linux
+      targetPlatform: TargetPlatform.linux_x64
     ),
     const Artifact._(
       name: 'Compiled Java code',
       fileName: 'classes.dex.jar',
       type: ArtifactType.androidClassesJar,
-      targetPlatform: TargetPlatform.android
+      targetPlatform: TargetPlatform.android_arm
     ),
     const Artifact._(
       name: 'ICU data table',
       fileName: 'icudtl.dat',
       type: ArtifactType.androidIcuData,
-      targetPlatform: TargetPlatform.android
+      targetPlatform: TargetPlatform.android_arm
     ),
     const Artifact._(
       name: 'Key Store',
       fileName: 'chromium-debug.keystore',
       type: ArtifactType.androidKeystore,
-      targetPlatform: TargetPlatform.android
+      targetPlatform: TargetPlatform.android_arm
     ),
     const Artifact._(
       name: 'Compiled C++ code',
       fileName: 'libsky_shell.so',
       type: ArtifactType.androidLibSkyShell,
-      targetPlatform: TargetPlatform.android
+      targetPlatform: TargetPlatform.android_arm
     ),
   ];
 

--- a/packages/flutter_tools/lib/src/base/process.dart
+++ b/packages/flutter_tools/lib/src/base/process.dart
@@ -132,7 +132,7 @@ String _runWithLoggingSync(List<String> cmd, {
   }
   if (results.stdout.trim().isNotEmpty)
     printTrace(results.stdout.trim());
-  return results.stdout;
+  return results.stdout.trim();
 }
 
 class ProcessExit implements Exception {

--- a/packages/flutter_tools/lib/src/build_configuration.dart
+++ b/packages/flutter_tools/lib/src/build_configuration.dart
@@ -20,11 +20,11 @@ enum HostPlatform {
 }
 
 enum TargetPlatform {
-  android,
-  iOS,
-  iOSSimulator,
-  mac,
-  linux,
+  android_arm,
+  ios_arm,
+  ios_x64,
+  darwin_x64,
+  linux_x64
 }
 
 HostPlatform getCurrentHostPlatform() {
@@ -38,18 +38,17 @@ HostPlatform getCurrentHostPlatform() {
 
 TargetPlatform getCurrentHostPlatformAsTarget() {
   if (Platform.isMacOS)
-    return TargetPlatform.mac;
+    return TargetPlatform.darwin_x64;
   if (Platform.isLinux)
-    return TargetPlatform.linux;
+    return TargetPlatform.linux_x64;
   printError('Unsupported host platform, defaulting to Linux');
-  return TargetPlatform.linux;
+  return TargetPlatform.linux_x64;
 }
 
 class BuildConfiguration {
   BuildConfiguration.prebuilt({
     this.hostPlatform,
     this.targetPlatform,
-    this.deviceId,
     this.testable: false
   }) : type = BuildType.prebuilt, buildDir = null;
 
@@ -59,7 +58,6 @@ class BuildConfiguration {
     this.targetPlatform,
     String enginePath,
     String buildPath,
-    this.deviceId,
     this.testable: false
   }) : buildDir = path.normalize(path.join(enginePath, buildPath)) {
     assert(type == BuildType.debug || type == BuildType.release);
@@ -69,6 +67,5 @@ class BuildConfiguration {
   final HostPlatform hostPlatform;
   final TargetPlatform targetPlatform;
   final String buildDir;
-  final String deviceId;
   final bool testable;
 }

--- a/packages/flutter_tools/lib/src/commands/apk.dart
+++ b/packages/flutter_tools/lib/src/commands/apk.dart
@@ -226,7 +226,7 @@ Future<_ApkComponents> _findApkComponents(
     ];
     Iterable<Future<String>> pathFutures = artifactTypes.map(
         (ArtifactType type) => ArtifactStore.getPath(ArtifactStore.getArtifact(
-            type: type, targetPlatform: TargetPlatform.android)));
+            type: type, targetPlatform: TargetPlatform.android_arm)));
     artifactPaths = await Future.wait(pathFutures);
   }
 
@@ -392,7 +392,7 @@ Future<int> buildAndroid({
   }
 
   BuildConfiguration config = configs.firstWhere(
-    (BuildConfiguration bc) => bc.targetPlatform == TargetPlatform.android
+    (BuildConfiguration bc) => bc.targetPlatform == TargetPlatform.android_arm
   );
   _ApkComponents components = await _findApkComponents(config, enginePath, manifest, resources);
   if (components == null) {

--- a/packages/flutter_tools/lib/src/commands/run_mojo.dart
+++ b/packages/flutter_tools/lib/src/commands/run_mojo.dart
@@ -71,7 +71,7 @@ class RunMojoCommand extends FlutterCommand {
   BuildConfiguration _getCurrentHostConfig() {
     BuildConfiguration result;
     TargetPlatform target = argResults['android'] ?
-      TargetPlatform.android : getCurrentHostPlatformAsTarget();
+      TargetPlatform.android_arm : getCurrentHostPlatformAsTarget();
     for (BuildConfiguration config in buildConfigurations) {
       if (config.targetPlatform == target) {
         result = config;
@@ -93,7 +93,7 @@ class RunMojoCommand extends FlutterCommand {
 
     String flutterPath;
     if (config == null || config.type == BuildType.prebuilt) {
-      TargetPlatform targetPlatform = argResults['android'] ? TargetPlatform.android : TargetPlatform.linux;
+      TargetPlatform targetPlatform = argResults['android'] ? TargetPlatform.android_arm : TargetPlatform.linux_x64;
       Artifact artifact = ArtifactStore.getArtifact(type: ArtifactType.mojo, targetPlatform: targetPlatform);
       flutterPath = _makePathAbsolute(await ArtifactStore.getPath(artifact));
     } else {

--- a/packages/flutter_tools/lib/src/commands/test.dart
+++ b/packages/flutter_tools/lib/src/commands/test.dart
@@ -47,9 +47,9 @@ class TestCommand extends FlutterCommand {
       return await ArtifactStore.getPath(artifact);
     } else {
       switch (config.targetPlatform) {
-        case TargetPlatform.linux:
+        case TargetPlatform.linux_x64:
           return path.join(config.buildDir, 'sky_shell');
-        case TargetPlatform.mac:
+        case TargetPlatform.darwin_x64:
           return path.join(config.buildDir, 'SkyShell.app', 'Contents', 'MacOS', 'SkyShell');
         default:
           throw new Exception('Unsupported platform.');

--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -224,7 +224,7 @@ class IOSDevice extends Device {
   }
 
   @override
-  TargetPlatform get platform => TargetPlatform.iOS;
+  TargetPlatform get platform => TargetPlatform.ios_arm;
 
   DeviceLogReader get logReader {
     if (_logReader == null)

--- a/packages/flutter_tools/lib/src/ios/simulators.dart
+++ b/packages/flutter_tools/lib/src/ios/simulators.dart
@@ -536,7 +536,7 @@ class IOSSimulator extends Device {
   }
 
   @override
-  TargetPlatform get platform => TargetPlatform.iOSSimulator;
+  TargetPlatform get platform => TargetPlatform.ios_x64;
 
   DeviceLogReader get logReader {
     if (_logReader == null)

--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -80,7 +80,7 @@ abstract class FlutterCommand extends Command {
       devices = devices.where((Device device) => device.isSupported()).toList();
 
       if (androidOnly)
-        devices = devices.where((Device device) => device.platform == TargetPlatform.android).toList();
+        devices = devices.where((Device device) => device.platform == TargetPlatform.android_arm).toList();
 
       if (devices.isEmpty) {
         printStatus('No supported devices connected.');

--- a/packages/flutter_tools/lib/src/runner/flutter_command_runner.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command_runner.dart
@@ -269,14 +269,13 @@ class FlutterCommandRunner extends CommandRunner {
     if (enginePath == null) {
       configs.add(new BuildConfiguration.prebuilt(
         hostPlatform: hostPlatform,
-        targetPlatform: TargetPlatform.android,
-        deviceId: globalResults['device-id']
+        targetPlatform: TargetPlatform.android_arm
       ));
 
       if (hostPlatform == HostPlatform.linux) {
         configs.add(new BuildConfiguration.prebuilt(
           hostPlatform: HostPlatform.linux,
-          targetPlatform: TargetPlatform.linux,
+          targetPlatform: TargetPlatform.linux_x64,
           testable: true
         ));
       }
@@ -284,14 +283,12 @@ class FlutterCommandRunner extends CommandRunner {
       if (hostPlatform == HostPlatform.mac) {
         configs.add(new BuildConfiguration.prebuilt(
           hostPlatform: HostPlatform.mac,
-          targetPlatform: TargetPlatform.iOS,
-          deviceId: globalResults['device-id']
+          targetPlatform: TargetPlatform.ios_arm
         ));
 
         configs.add(new BuildConfiguration.prebuilt(
           hostPlatform: HostPlatform.mac,
-          targetPlatform: TargetPlatform.iOSSimulator,
-          deviceId: globalResults['device-id']
+          targetPlatform: TargetPlatform.ios_x64
         ));
       }
     } else {
@@ -305,10 +302,9 @@ class FlutterCommandRunner extends CommandRunner {
         configs.add(new BuildConfiguration.local(
           type: BuildType.debug,
           hostPlatform: hostPlatform,
-          targetPlatform: TargetPlatform.android,
+          targetPlatform: TargetPlatform.android_arm,
           enginePath: enginePath,
-          buildPath: globalResults['android-debug-build-path'],
-          deviceId: globalResults['device-id']
+          buildPath: globalResults['android-debug-build-path']
         ));
 
         configs.add(new BuildConfiguration.local(
@@ -324,19 +320,17 @@ class FlutterCommandRunner extends CommandRunner {
           configs.add(new BuildConfiguration.local(
             type: BuildType.debug,
             hostPlatform: hostPlatform,
-            targetPlatform: TargetPlatform.iOS,
+            targetPlatform: TargetPlatform.ios_arm,
             enginePath: enginePath,
-            buildPath: globalResults['ios-debug-build-path'],
-            deviceId: globalResults['device-id']
+            buildPath: globalResults['ios-debug-build-path']
           ));
 
           configs.add(new BuildConfiguration.local(
             type: BuildType.debug,
             hostPlatform: hostPlatform,
-            targetPlatform: TargetPlatform.iOSSimulator,
+            targetPlatform: TargetPlatform.ios_x64,
             enginePath: enginePath,
-            buildPath: globalResults['ios-sim-debug-build-path'],
-            deviceId: globalResults['device-id']
+            buildPath: globalResults['ios-sim-debug-build-path']
           ));
         }
       }
@@ -345,10 +339,9 @@ class FlutterCommandRunner extends CommandRunner {
         configs.add(new BuildConfiguration.local(
           type: BuildType.release,
           hostPlatform: hostPlatform,
-          targetPlatform: TargetPlatform.android,
+          targetPlatform: TargetPlatform.android_arm,
           enginePath: enginePath,
-          buildPath: globalResults['android-release-build-path'],
-          deviceId: globalResults['device-id']
+          buildPath: globalResults['android-release-build-path']
         ));
 
         configs.add(new BuildConfiguration.local(
@@ -364,19 +357,17 @@ class FlutterCommandRunner extends CommandRunner {
           configs.add(new BuildConfiguration.local(
             type: BuildType.release,
             hostPlatform: hostPlatform,
-            targetPlatform: TargetPlatform.iOS,
+            targetPlatform: TargetPlatform.ios_arm,
             enginePath: enginePath,
-            buildPath: globalResults['ios-release-build-path'],
-            deviceId: globalResults['device-id']
+            buildPath: globalResults['ios-release-build-path']
           ));
 
           configs.add(new BuildConfiguration.local(
             type: BuildType.release,
             hostPlatform: hostPlatform,
-            targetPlatform: TargetPlatform.iOSSimulator,
+            targetPlatform: TargetPlatform.ios_x64,
             enginePath: enginePath,
-            buildPath: globalResults['ios-sim-release-build-path'],
-            deviceId: globalResults['device-id']
+            buildPath: globalResults['ios-sim-release-build-path']
           ));
         }
       }

--- a/packages/flutter_tools/test/src/mocks.dart
+++ b/packages/flutter_tools/test/src/mocks.dart
@@ -32,17 +32,17 @@ class MockToolchain extends Toolchain {
 }
 
 class MockAndroidDevice extends Mock implements AndroidDevice {
-  TargetPlatform get platform => TargetPlatform.android;
+  TargetPlatform get platform => TargetPlatform.android_arm;
   bool isSupported() => true;
 }
 
 class MockIOSDevice extends Mock implements IOSDevice {
-  TargetPlatform get platform => TargetPlatform.iOS;
+  TargetPlatform get platform => TargetPlatform.ios_arm;
   bool isSupported() => true;
 }
 
 class MockIOSSimulator extends Mock implements IOSSimulator {
-  TargetPlatform get platform => TargetPlatform.iOSSimulator;
+  TargetPlatform get platform => TargetPlatform.ios_x64;
   bool isSupported() => true;
 }
 


### PR DESCRIPTION
- rename the `TargetPlatform` constants (`android` ==> `android_arm`, `iOSSimulator` ==> `ios_x64`, ...) in prep for adding an `android_x64` at some point
- remove some dead code (a no longer used field) in the `BuildConfiguration` class
- implement `AndroidDevice. isLocalEmulator` to be able to determine whether the target is an arm or x86 device
