### PR TITLE
misc tool ui changes

### DIFF
--- a/packages/flutter_tools/lib/executable.dart
+++ b/packages/flutter_tools/lib/executable.dart
@@ -42,6 +42,12 @@ Future<Null> main(List<String> args) async {
   bool verbose = args.contains('-v') || args.contains('--verbose');
   bool verboseHelp = help && verbose;
 
+  if (verboseHelp) {
+    // Remove the verbose option; for help, users don't need to see verbose logs.
+    args = new List<String>.from(args);
+    args.removeWhere((String option) => option == '-v' || option == '--verbose');
+  }
+
   FlutterCommandRunner runner = new FlutterCommandRunner(verboseHelp: verboseHelp)
     ..addCommand(new AnalyzeCommand())
     ..addCommand(new ApkCommand())
@@ -75,7 +81,10 @@ Future<Null> main(List<String> args) async {
       exit(result);
   }, onError: (dynamic error, Chain chain) {
     if (error is UsageException) {
-      stderr.writeln(error);
+      stderr.writeln(error.message);
+      stderr.writeln();
+      stderr.writeln("Run 'flutter -h' (or 'flutter <command> -h') for available "
+        "flutter commands and options.");
       // Argument error exit code.
       exit(64);
     } else if (error is ProcessExit) {

--- a/packages/flutter_tools/lib/src/artifacts.dart
+++ b/packages/flutter_tools/lib/src/artifacts.dart
@@ -21,7 +21,7 @@ String _getNameForHostPlatform(HostPlatform platform) {
   }
 }
 
-String _getNameForTargetPlatform(TargetPlatform platform) {
+String getNameForTargetPlatform(TargetPlatform platform) {
   switch (platform) {
     case TargetPlatform.android_arm:
       return 'android-arm';
@@ -63,7 +63,7 @@ class Artifact {
 
   String get platform {
     if (targetPlatform != null)
-      return _getNameForTargetPlatform(targetPlatform);
+      return getNameForTargetPlatform(targetPlatform);
     if (hostPlatform != null)
       return _getNameForHostPlatform(hostPlatform);
     assert(false);

--- a/packages/flutter_tools/lib/src/commands/devices.dart
+++ b/packages/flutter_tools/lib/src/commands/devices.dart
@@ -29,9 +29,7 @@ class DevicesCommand extends FlutterCommand {
       printStatus('No connected devices.');
     } else {
       printStatus('${devices.length} connected ${pluralize('device', devices.length)}:\n');
-
-      for (Device device in devices)
-        printStatus(device.fullDescription);
+      Device.printDevices(devices);
     }
 
     return 0;

--- a/packages/flutter_tools/lib/src/device.dart
+++ b/packages/flutter_tools/lib/src/device.dart
@@ -3,12 +3,15 @@
 // found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:math' as math;
 
 import 'android/android_device.dart';
 import 'application_package.dart';
+import 'artifacts.dart';
 import 'base/common.dart';
 import 'base/utils.dart';
 import 'build_configuration.dart';
+import 'globals.dart';
 import 'ios/devices.dart';
 import 'ios/simulators.dart';
 import 'toolchain.dart';
@@ -140,11 +143,6 @@ abstract class Device {
 
   bool get supportsStartPaused => true;
 
-  String get fullDescription {
-    String supportIndicator = isSupported() ? '' : ' - unsupported';
-    return '$name ($id)$supportIndicator';
-  }
-
   /// Whether it is an emulated device running on localhost.
   bool get isLocalEmulator;
 
@@ -202,6 +200,23 @@ abstract class Device {
   }
 
   String toString() => name;
+
+  static void printDevices(List<Device> devices) {
+    int nameWidth = 0;
+    int idWidth = 0;
+
+    for (Device device in devices) {
+      nameWidth = math.max(nameWidth, device.name.length);
+      idWidth = math.max(idWidth, device.id.length);
+    }
+
+    for (Device device in devices) {
+      String supportIndicator = device.isSupported() ? '' : ' (unsupported)';
+      printStatus('${device.name.padRight(nameWidth)} • '
+        '${device.id.padRight(idWidth)} • '
+        '${getNameForTargetPlatform(device.platform)}$supportIndicator');
+    }
+  }
 }
 
 class ForwardedPort {

--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -47,8 +47,8 @@ abstract class FlutterCommand extends Command {
     Stopwatch stopwatch = new Stopwatch()..start();
 
     return _run().then((int exitCode) {
-      printTrace("'flutter $name' exiting with code $exitCode; "
-        "elasped time ${stopwatch.elapsedMilliseconds}ms.");
+      int ms = stopwatch.elapsedMilliseconds;
+      printTrace("'flutter $name' took ${ms}ms; exiting with code $exitCode.");
       return exitCode;
     });
   }
@@ -90,8 +90,7 @@ abstract class FlutterCommand extends Command {
           "the '-d <deviceId>' flag.");
         printStatus('');
         devices = await deviceManager.getAllConnectedDevices();
-        for (Device device in devices)
-          printStatus(device.fullDescription);
+        Device.printDevices(devices);
         return 1;
       } else {
         _deviceForCommand = devices.single;

--- a/packages/flutter_tools/lib/src/template.dart
+++ b/packages/flutter_tools/lib/src/template.dart
@@ -72,9 +72,7 @@ class Template {
           .replaceAll(_kCopyTemplateExtension, '')
           .replaceAll(_kTemplateExtension, '');
       File finalDestinationFile = new File(finalDestinationPath);
-      String relativePathForLogging = relativeDestPath
-          .replaceAll(_kCopyTemplateExtension, '')
-          .replaceAll(_kTemplateExtension, '');
+      String relativePathForLogging = path.relative(finalDestinationFile.path);
 
       // Step 1: Check if the file needs to be overwritten.
 


### PR DESCRIPTION
- when run with `-h -v`, we show the hidden options, but don't emit verbose logging w/ timing info
- on a bad cli option or command, show the error message and how to get more help, but don't dump the full usage message (it's ~40 lines, and obscures the error at the top)
- when listing devices, align the name column, and show the device architecture
- fix an issue in the template generator where some templates (the drive test template) wouldn't show the correct relative path info
