### PR TITLE
minor update to flutter daemon

### DIFF
--- a/packages/flutter_tools/lib/executable.dart
+++ b/packages/flutter_tools/lib/executable.dart
@@ -53,7 +53,7 @@ Future<Null> main(List<String> args) async {
     ..addCommand(new ApkCommand())
     ..addCommand(new BuildCommand())
     ..addCommand(new CreateCommand())
-    ..addCommand(new DaemonCommand(hideCommand: !verboseHelp))
+    ..addCommand(new DaemonCommand(hidden: !verboseHelp))
     ..addCommand(new DevicesCommand())
     ..addCommand(new DoctorCommand())
     ..addCommand(new DriveCommand())
@@ -62,11 +62,11 @@ Future<Null> main(List<String> args) async {
     ..addCommand(new LogsCommand())
     ..addCommand(new RefreshCommand())
     ..addCommand(new RunCommand())
-    ..addCommand(new RunMojoCommand(hideCommand: !verboseHelp))
+    ..addCommand(new RunMojoCommand(hidden: !verboseHelp))
     ..addCommand(new StopCommand())
     ..addCommand(new TestCommand())
     ..addCommand(new TraceCommand())
-    ..addCommand(new UpdatePackagesCommand(hideCommand: !verboseHelp))
+    ..addCommand(new UpdatePackagesCommand(hidden: !verboseHelp))
     ..addCommand(new UpgradeCommand());
 
   return Chain.capture(() async {

--- a/packages/flutter_tools/lib/src/commands/daemon.dart
+++ b/packages/flutter_tools/lib/src/commands/daemon.dart
@@ -26,20 +26,19 @@ const String protocolVersion = '0.1.0';
 /// It can be shutdown with a `daemon.shutdown` command (or by killing the
 /// process).
 class DaemonCommand extends FlutterCommand {
-  DaemonCommand({ bool hideCommand: false }) : _hideCommand = hideCommand;
+  DaemonCommand({ this.hidden: false });
 
   @override
   final String name = 'daemon';
 
   @override
   final String description = 'Run a persistent, JSON-RPC based server to communicate with devices.';
-  final bool _hideCommand;
 
   @override
   bool get requiresProjectRoot => false;
 
   @override
-  bool get hidden => _hideCommand;
+  final bool hidden;
 
   @override
   Future<int> runInProject() {
@@ -391,8 +390,7 @@ Map<String, dynamic> _deviceToMap(Device device) {
   return <String, dynamic>{
     'id': device.id,
     'name': device.name,
-    'platform': _enumToString(device.platform),
-    'available': true
+    'platform': _enumToString(device.platform)
   };
 }
 

--- a/packages/flutter_tools/lib/src/commands/run_mojo.dart
+++ b/packages/flutter_tools/lib/src/commands/run_mojo.dart
@@ -23,9 +23,11 @@ class RunMojoCommand extends FlutterCommand {
 
   @override
   final String description = 'Run a Flutter app in mojo (from github.com/domokit/mojo).';
-  final bool _hideCommand;
 
-  RunMojoCommand({ bool hideCommand: false }) : _hideCommand = hideCommand {
+  @override
+  final bool hidden;
+
+  RunMojoCommand({ this.hidden: false }) {
     argParser.addFlag('android', negatable: false, help: 'Run on an Android device');
     argParser.addFlag('checked', negatable: false, help: 'Run Flutter in checked mode');
     argParser.addFlag('mojo-debug', negatable: false, help: 'Use Debug build of mojo');
@@ -42,9 +44,6 @@ class RunMojoCommand extends FlutterCommand {
 
   @override
   bool get requiresProjectRoot => false;
-
-  @override
-  bool get hidden => _hideCommand;
 
   // TODO(abarth): Why not use path.absolute?
   String _makePathAbsolute(String relativePath) {

--- a/packages/flutter_tools/lib/src/commands/update_packages.dart
+++ b/packages/flutter_tools/lib/src/commands/update_packages.dart
@@ -24,7 +24,7 @@ Future<int> _runPub(Directory directory, { bool upgrade: false }) async {
 }
 
 class UpdatePackagesCommand extends FlutterCommand {
-  UpdatePackagesCommand({ bool hideCommand: false }) : _hideCommand = hideCommand {
+  UpdatePackagesCommand({ this.hidden: false }) {
     argParser.addFlag(
       'upgrade',
       help: 'Run "pub upgrade" rather than "pub get".',
@@ -39,8 +39,7 @@ class UpdatePackagesCommand extends FlutterCommand {
   final String description = 'Update the packages inside the Flutter repo.';
 
   @override
-  bool get hidden => _hideCommand;
-  final bool _hideCommand;
+  final bool hidden;
 
   @override
   bool get requiresProjectRoot => false;

--- a/packages/flutter_tools/tool/daemon_client.dart
+++ b/packages/flutter_tools/tool/daemon_client.dart
@@ -16,7 +16,7 @@ Process daemon;
 //   devices: list devices
 
 Future<Null> main() async {
-  daemon = await Process.start('flutter', ['daemon']);
+  daemon = await Process.start('dart', ['bin/flutter_tools.dart', 'daemon']);
   print('daemon process started, pid: ${daemon.pid}');
 
   daemon.stdout

--- a/packages/playfair/lib/src/base.dart
+++ b/packages/playfair/lib/src/base.dart
@@ -46,6 +46,7 @@ class Chart extends StatelessWidget {
 
   final ChartData data;
 
+  @override
   Widget build(BuildContext context) {
     return new _ChartWrapper(textTheme: Theme.of(context).textTheme, data: data);
   }
@@ -57,8 +58,10 @@ class _ChartWrapper extends LeafRenderObjectWidget {
   final TextTheme textTheme;
   final ChartData data;
 
+  @override
   _RenderChart createRenderObject(BuildContext context) => new _RenderChart(textTheme: textTheme, data: data);
 
+  @override
   void updateRenderObject(BuildContext context, _RenderChart renderObject) {
     renderObject
       ..textTheme = textTheme
@@ -93,6 +96,7 @@ class _RenderChart extends RenderConstrainedBox {
     markNeedsPaint();
   }
 
+  @override
   void paint(PaintingContext context, Offset offset) {
     assert(size.width != null);
     assert(size.height != null);


### PR DESCRIPTION
- have the flutter daemon manual tester (`tool/daemon_client.dart`) call directly into the entrypoint instead of using the flutter shell - we can see changes w/o having to delete the flutter_tools stamp file
- make the code a bit terser around hiding flutter commands
- add some override annotations to `playfair`
