### PR TITLE
Tapping drawer during animation causes it to stick

### DIFF
--- a/packages/flutter/lib/src/gestures/recognizer.dart
+++ b/packages/flutter/lib/src/gestures/recognizer.dart
@@ -99,6 +99,11 @@ abstract class OneSequenceGestureRecognizer extends GestureRecognizer {
       didStopTrackingLastPointer(pointer);
   }
 
+  void ensureNotTrackingPointer(int pointer) {
+    if (_trackedPointers.contains(pointer))
+      stopTrackingPointer(pointer);
+  }
+
   void stopTrackingIfPointerNoLongerDown(PointerEvent event) {
     if (event is PointerUpEvent || event is PointerCancelEvent)
       stopTrackingPointer(event.pointer);

--- a/packages/flutter/lib/src/material/drawer.dart
+++ b/packages/flutter/lib/src/material/drawer.dart
@@ -122,9 +122,19 @@ class DrawerControllerState extends State<DrawerController> {
 
   AnimationController _controller;
 
-  void _handleTapDown(Point position) {
+  void _handleDragDown(Point position) {
     _controller.stop();
     _ensureHistoryEntry();
+  }
+
+  void _handleDragCancel() {
+    if (_controller.isDismissed || _controller.isAnimating)
+      return;
+    if (_controller.value < 0.5) {
+      close();
+    } else {
+      open();
+    }
   }
 
   double get _width {
@@ -179,8 +189,10 @@ class DrawerControllerState extends State<DrawerController> {
     } else {
       return new GestureDetector(
         key: _gestureDetectorKey,
+        onHorizontalDragDown: _handleDragDown,
         onHorizontalDragUpdate: _move,
         onHorizontalDragEnd: _settle,
+        onHorizontalDragCancel: _handleDragCancel,
         child: new RepaintBoundary(
           child: new Stack(
             children: <Widget>[
@@ -195,16 +207,13 @@ class DrawerControllerState extends State<DrawerController> {
               ),
               new Align(
                 alignment: const FractionalOffset(0.0, 0.5),
-                child: new GestureDetector(
-                  onTapDown: _handleTapDown,
-                  child: new Align(
-                    alignment: const FractionalOffset(1.0, 0.5),
-                    widthFactor: _controller.value,
-                    child: new RepaintBoundary(
-                      child: new Focus(
-                        key: _drawerKey,
-                        child: config.child
-                      )
+                child: new Align(
+                  alignment: const FractionalOffset(1.0, 0.5),
+                  widthFactor: _controller.value,
+                  child: new RepaintBoundary(
+                    child: new Focus(
+                      key: _drawerKey,
+                      child: config.child
                     )
                   )
                 )

--- a/packages/flutter/lib/src/widgets/gesture_detector.dart
+++ b/packages/flutter/lib/src/widgets/gesture_detector.dart
@@ -14,15 +14,16 @@ export 'package:flutter/gestures.dart' show
   GestureTapCallback,
   GestureTapCancelCallback,
   GestureLongPressCallback,
+  GestureDragDownCallback,
   GestureDragStartCallback,
   GestureDragUpdateCallback,
   GestureDragEndCallback,
-  GestureDragStartCallback,
-  GestureDragUpdateCallback,
-  GestureDragEndCallback,
+  GestureDragCancelCallback,
+  GesturePanDownCallback,
   GesturePanStartCallback,
   GesturePanUpdateCallback,
   GesturePanEndCallback,
+  GesturePanCancelCallback,
   GestureScaleStartCallback,
   GestureScaleUpdateCallback,
   GestureScaleEndCallback,
@@ -49,15 +50,21 @@ class GestureDetector extends StatelessWidget {
     this.onTapCancel,
     this.onDoubleTap,
     this.onLongPress,
+    this.onVerticalDragDown,
     this.onVerticalDragStart,
     this.onVerticalDragUpdate,
     this.onVerticalDragEnd,
+    this.onVerticalDragCancel,
+    this.onHorizontalDragDown,
     this.onHorizontalDragStart,
     this.onHorizontalDragUpdate,
     this.onHorizontalDragEnd,
+    this.onHorizontalDragCancel,
+    this.onPanDown,
     this.onPanStart,
     this.onPanUpdate,
     this.onPanEnd,
+    this.onPanCancel,
     this.onScaleStart,
     this.onScaleUpdate,
     this.onScaleEnd,
@@ -116,6 +123,9 @@ class GestureDetector extends StatelessWidget {
   final GestureLongPressCallback onLongPress;
 
   /// A pointer has contacted the screen and might begin to move vertically.
+  final GestureDragDownCallback onVerticalDragDown;
+
+  /// A pointer has contacted the screen and has begun to move vertically.
   final GestureDragStartCallback onVerticalDragStart;
 
   /// A pointer that is in contact with the screen and moving vertically has
@@ -127,7 +137,14 @@ class GestureDetector extends StatelessWidget {
   /// specific velocity when it stopped contacting the screen.
   final GestureDragEndCallback onVerticalDragEnd;
 
+  /// The pointer that previously triggered the [onVerticalDragDown] did not
+  /// end up moving vertically.
+  final GestureDragCancelCallback onVerticalDragCancel;
+
   /// A pointer has contacted the screen and might begin to move horizontally.
+  final GestureDragDownCallback onHorizontalDragDown;
+
+  /// A pointer has contacted the screen and has begun to move horizontally.
   final GestureDragStartCallback onHorizontalDragStart;
 
   /// A pointer that is in contact with the screen and moving horizontally has
@@ -139,9 +156,15 @@ class GestureDetector extends StatelessWidget {
   /// specific velocity when it stopped contacting the screen.
   final GestureDragEndCallback onHorizontalDragEnd;
 
+  /// The pointer that previously triggered the [onHorizontalDragDown] did not
+  /// end up moving horizontally.
+  final GestureDragCancelCallback onHorizontalDragCancel;
+
+  final GesturePanDownCallback onPanDown;
   final GesturePanStartCallback onPanStart;
   final GesturePanUpdateCallback onPanUpdate;
   final GesturePanEndCallback onPanEnd;
+  final GesturePanCancelCallback onPanCancel;
 
   final GestureScaleStartCallback onScaleStart;
   final GestureScaleUpdateCallback onScaleUpdate;
@@ -185,30 +208,48 @@ class GestureDetector extends StatelessWidget {
       };
     }
 
-    if (onVerticalDragStart != null || onVerticalDragUpdate != null || onVerticalDragEnd != null) {
+    if (onVerticalDragDown != null ||
+        onVerticalDragStart != null ||
+        onVerticalDragUpdate != null ||
+        onVerticalDragEnd != null ||
+        onVerticalDragCancel != null) {
       gestures[VerticalDragGestureRecognizer] = (VerticalDragGestureRecognizer recognizer) {
         return (recognizer ??= new VerticalDragGestureRecognizer())
+          ..onDown = onVerticalDragDown
           ..onStart = onVerticalDragStart
           ..onUpdate = onVerticalDragUpdate
-          ..onEnd = onVerticalDragEnd;
+          ..onEnd = onVerticalDragEnd
+          ..onCancel = onVerticalDragCancel;
       };
     }
 
-    if (onHorizontalDragStart != null || onHorizontalDragUpdate != null || onHorizontalDragEnd != null) {
+    if (onHorizontalDragDown != null ||
+        onHorizontalDragStart != null ||
+        onHorizontalDragUpdate != null ||
+        onHorizontalDragEnd != null ||
+        onHorizontalDragCancel != null) {
       gestures[HorizontalDragGestureRecognizer] = (HorizontalDragGestureRecognizer recognizer) {
         return (recognizer ??= new HorizontalDragGestureRecognizer())
+          ..onDown = onHorizontalDragDown
           ..onStart = onHorizontalDragStart
           ..onUpdate = onHorizontalDragUpdate
-          ..onEnd = onHorizontalDragEnd;
+          ..onEnd = onHorizontalDragEnd
+          ..onCancel = onHorizontalDragCancel;
       };
     }
 
-    if (onPanStart != null || onPanUpdate != null || onPanEnd != null) {
+    if (onPanDown != null ||
+        onPanStart != null ||
+        onPanUpdate != null ||
+        onPanEnd != null ||
+        onPanCancel != null) {
       gestures[PanGestureRecognizer] = (PanGestureRecognizer recognizer) {
         return (recognizer ??= new PanGestureRecognizer())
+          ..onDown = onPanDown
           ..onStart = onPanStart
           ..onUpdate = onPanUpdate
-          ..onEnd = onPanEnd;
+          ..onEnd = onPanEnd
+          ..onCancel = onPanCancel;
       };
     }
 

--- a/packages/flutter/lib/src/widgets/scrollable.dart
+++ b/packages/flutter/lib/src/widgets/scrollable.dart
@@ -470,7 +470,7 @@ abstract class ScrollableState<T extends Scrollable> extends State<T> {
       config.onScroll(_scrollOffset);
   }
 
-  void _handlePointerDown(_) {
+  void _handleDragDown(_) {
     _controller.stop();
   }
 
@@ -527,10 +527,7 @@ abstract class ScrollableState<T extends Scrollable> extends State<T> {
       key: _gestureDetectorKey,
       gestures: buildGestureDetectors(),
       behavior: HitTestBehavior.opaque,
-      child: new Listener(
-        child: buildContent(context),
-        onPointerDown: _handlePointerDown
-      )
+      child: buildContent(context)
     );
   }
 
@@ -559,6 +556,7 @@ abstract class ScrollableState<T extends Scrollable> extends State<T> {
           return <Type, GestureRecognizerFactory>{
             VerticalDragGestureRecognizer: (VerticalDragGestureRecognizer recognizer) {
               return (recognizer ??= new VerticalDragGestureRecognizer())
+                ..onDown = _handleDragDown
                 ..onStart = _handleDragStart
                 ..onUpdate = _handleDragUpdate
                 ..onEnd = _handleDragEnd;
@@ -568,6 +566,7 @@ abstract class ScrollableState<T extends Scrollable> extends State<T> {
           return <Type, GestureRecognizerFactory>{
             HorizontalDragGestureRecognizer: (HorizontalDragGestureRecognizer recognizer) {
               return (recognizer ??= new HorizontalDragGestureRecognizer())
+                ..onDown = _handleDragDown
                 ..onStart = _handleDragStart
                 ..onUpdate = _handleDragUpdate
                 ..onEnd = _handleDragEnd;


### PR DESCRIPTION
The problem was we were using a tap gesture to stop the motion of the
drawer and a drag gesture to settle it. That can cause a broken
lifecycle. Now we use a single drag recognizer to drive the whole
lifecycle.

Fixes #775
Fixes #1276
