### PR TITLE
Refactor the build commands

### DIFF
--- a/packages/flutter_tools/lib/executable.dart
+++ b/packages/flutter_tools/lib/executable.dart
@@ -12,7 +12,6 @@ import 'src/base/context.dart';
 import 'src/base/logger.dart';
 import 'src/base/process.dart';
 import 'src/commands/analyze.dart';
-import 'src/commands/apk.dart';
 import 'src/commands/build.dart';
 import 'src/commands/create.dart';
 import 'src/commands/daemon.dart';
@@ -50,7 +49,6 @@ Future<Null> main(List<String> args) async {
 
   FlutterCommandRunner runner = new FlutterCommandRunner(verboseHelp: verboseHelp)
     ..addCommand(new AnalyzeCommand())
-    ..addCommand(new ApkCommand())
     ..addCommand(new BuildCommand())
     ..addCommand(new CreateCommand())
     ..addCommand(new DaemonCommand(hidden: !verboseHelp))

--- a/packages/flutter_tools/lib/src/commands/build.dart
+++ b/packages/flutter_tools/lib/src/commands/build.dart
@@ -1,77 +1,53 @@
-// Copyright 2015 The Chromium Authors. All rights reserved.
+// Copyright 2016 The Chromium Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:io';
 
-import '../flx.dart';
-import '../dart/pub.dart';
 import '../globals.dart';
 import '../runner/flutter_command.dart';
-import '../toolchain.dart';
+import 'build_apk.dart';
+import 'build_flx.dart';
 
 class BuildCommand extends FlutterCommand {
+  BuildCommand() {
+    addSubcommand(new BuildApkCommand());
+    addSubcommand(new BuildCleanCommand());
+    addSubcommand(new BuildFlxCommand());
+  }
+
   @override
   final String name = 'build';
 
   @override
-  final String description = 'Package your Flutter app into an FLX.';
-
-  BuildCommand() {
-    argParser.addFlag('precompiled', negatable: false);
-    // This option is still referenced by the iOS build scripts. We should
-    // remove it once we've updated those build scripts.
-    argParser.addOption('asset-base', help: 'Ignored. Will be removed.', hide: true);
-    argParser.addOption('compiler');
-    argParser.addOption('manifest', defaultsTo: defaultManifestPath);
-    argParser.addOption('private-key', defaultsTo: defaultPrivateKeyPath);
-    argParser.addOption('output-file', abbr: 'o', defaultsTo: defaultFlxOutputPath);
-    argParser.addOption('snapshot', defaultsTo: defaultSnapshotPath);
-    argParser.addOption('depfile', defaultsTo: defaultDepfilePath);
-    argParser.addOption('working-dir', defaultsTo: defaultWorkingDirPath);
-    argParser.addFlag('pub',
-        defaultsTo: true,
-        help: 'Whether to run "pub get" before building the app.');
-    addTargetOption();
-  }
+  final String description = 'Flutter build commands.';
 
   @override
-  Future<int> run() async {
-    if (argResults['pub']) {
-      int exitCode = await pubGet();
-      if (exitCode != 0)
-        return exitCode;
-    }
-    return await super.run();
-  }
+  Future<int> runInProject() => new Future<int>.value(0);
+}
+
+class BuildCleanCommand extends FlutterCommand {
+  @override
+  final String name = 'clean';
+
+  @override
+  final String description = 'Delete the build/ directory.';
 
   @override
   Future<int> runInProject() async {
-    String compilerPath = argResults['compiler'];
+    Directory buildDir = new Directory('build');
+    printStatus("Deleting '${buildDir.path}${Platform.pathSeparator}'.");
 
-    if (compilerPath == null)
-      await downloadToolchain();
-    else
-      toolchain = new Toolchain(compiler: new Compiler(compilerPath));
+    if (!buildDir.existsSync())
+      return 0;
 
-    String outputPath = argResults['output-file'];
-
-    return await build(
-      toolchain,
-      mainPath: argResults['target'],
-      manifestPath: argResults['manifest'],
-      outputPath: outputPath,
-      snapshotPath: argResults['snapshot'],
-      depfilePath: argResults['depfile'],
-      privateKeyPath: argResults['private-key'],
-      workingDirPath: argResults['working-dir'],
-      precompiledSnapshot: argResults['precompiled']
-    ).then((int result) {
-      if (result == 0)
-        printStatus('Built $outputPath.');
-      else
-        printError('Error building $outputPath: $result.');
-      return result;
-    });
+    try {
+      buildDir.deleteSync(recursive: true);
+      return 0;
+    } catch (error) {
+      printError(error.toString());
+      return 1;
+    }
   }
 }

--- a/packages/flutter_tools/lib/src/commands/build_flx.dart
+++ b/packages/flutter_tools/lib/src/commands/build_flx.dart
@@ -1,0 +1,68 @@
+// Copyright 2015 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+
+import '../flx.dart';
+import '../globals.dart';
+import '../runner/flutter_command.dart';
+import '../toolchain.dart';
+
+class BuildFlxCommand extends FlutterCommand {
+  BuildFlxCommand() {
+    usesTargetOption();
+    argParser.addFlag('precompiled', negatable: false);
+    // This option is still referenced by the iOS build scripts. We should
+    // remove it once we've updated those build scripts.
+    argParser.addOption('asset-base', help: 'Ignored. Will be removed.', hide: true);
+    argParser.addOption('compiler');
+    argParser.addOption('manifest', defaultsTo: defaultManifestPath);
+    argParser.addOption('private-key', defaultsTo: defaultPrivateKeyPath);
+    argParser.addOption('output-file', abbr: 'o', defaultsTo: defaultFlxOutputPath);
+    argParser.addOption('snapshot', defaultsTo: defaultSnapshotPath);
+    argParser.addOption('depfile', defaultsTo: defaultDepfilePath);
+    argParser.addOption('working-dir', defaultsTo: defaultWorkingDirPath);
+    usesPubOption();
+  }
+
+  @override
+  final String name = 'flx';
+
+  @override
+  final String description = 'Build a Flutter FLX file from your app.';
+
+  @override
+  final String usageFooter = 'FLX files are archives of your application code and resources; '
+    'they are used by some Flutter Android and iOS runtimes.';
+
+  @override
+  Future<int> runInProject() async {
+    String compilerPath = argResults['compiler'];
+
+    if (compilerPath == null)
+      await downloadToolchain();
+    else
+      toolchain = new Toolchain(compiler: new Compiler(compilerPath));
+
+    String outputPath = argResults['output-file'];
+
+    return await build(
+      toolchain,
+      mainPath: argResults['target'],
+      manifestPath: argResults['manifest'],
+      outputPath: outputPath,
+      snapshotPath: argResults['snapshot'],
+      depfilePath: argResults['depfile'],
+      privateKeyPath: argResults['private-key'],
+      workingDirPath: argResults['working-dir'],
+      precompiledSnapshot: argResults['precompiled']
+    ).then((int result) {
+      if (result == 0)
+        printStatus('Built $outputPath.');
+      else
+        printError('Error building $outputPath: $result.');
+      return result;
+    });
+  }
+}

--- a/packages/flutter_tools/lib/src/commands/drive.dart
+++ b/packages/flutter_tools/lib/src/commands/drive.dart
@@ -15,7 +15,7 @@ import '../base/os.dart';
 import '../device.dart';
 import '../globals.dart';
 import '../ios/simulators.dart' show SimControl, IOSSimulatorUtils;
-import 'apk.dart' as apk;
+import 'build_apk.dart' as build_apk;
 import 'run.dart';
 
 /// Runs integration (a.k.a. end-to-end) tests.
@@ -244,7 +244,7 @@ Future<int> startApp(DriveCommand command) async {
 
   if (command.device is AndroidDevice) {
     printTrace('Building an APK.');
-    int result = await apk.build(command.toolchain, command.buildConfigurations,
+    int result = await build_apk.build(command.toolchain, command.buildConfigurations,
       enginePath: command.runner.enginePath, target: command.target);
 
     if (result != 0)

--- a/packages/flutter_tools/lib/src/commands/refresh.dart
+++ b/packages/flutter_tools/lib/src/commands/refresh.dart
@@ -19,7 +19,7 @@ class RefreshCommand extends FlutterCommand {
   final String description = 'Build and deploy the Dart code in a Flutter app (Android only).';
 
   RefreshCommand() {
-    addTargetOption();
+    usesTargetOption();
   }
 
   @override

--- a/packages/flutter_tools/lib/src/commands/run.dart
+++ b/packages/flutter_tools/lib/src/commands/run.dart
@@ -15,7 +15,7 @@ import '../device.dart';
 import '../globals.dart';
 import '../runner/flutter_command.dart';
 import '../toolchain.dart';
-import 'apk.dart';
+import 'build_apk.dart';
 import 'install.dart';
 
 /// Given the value of the --target option, return the path of the Dart file
@@ -43,7 +43,7 @@ abstract class RunCommandBase extends FlutterCommand {
         help: 'Start tracing during startup.');
     argParser.addOption('route',
         help: 'Which route to load when starting the app.');
-    addTargetOption();
+    usesTargetOption();
   }
 
   bool get checked => argResults['checked'];
@@ -73,12 +73,10 @@ class RunCommand extends RunCommandBase {
         defaultsTo: false,
         negatable: false,
         help: 'Start in a paused mode and wait for a debugger to connect.');
-    argParser.addFlag('pub',
-        defaultsTo: true,
-        help: 'Whether to run "pub get" before running the app.');
     argParser.addOption('debug-port',
         defaultsTo: observatoryDefaultPort.toString(),
         help: 'Listen to the given port for a debug connection.');
+    usesPubOption();
   }
 
   @override

--- a/packages/flutter_tools/test/src/mocks.dart
+++ b/packages/flutter_tools/test/src/mocks.dart
@@ -101,5 +101,5 @@ void applyMocksToCommand(FlutterCommand command) {
   command
     ..applicationPackages = new MockApplicationPackageStore()
     ..toolchain = new MockToolchain()
-    ..projectRootValidator = () => true;
+    ..commandValidator = () => true;
 }


### PR DESCRIPTION
- introduce a new `flutter build` command that contains several subcommands
- `flutter apk` becomes `flutter build apk`
- the existing `flutter build` (creating a flx file) becomes `flutter build flx`
- add a new `flutter build clean` command
- tweak some command descriptions and option defaults

```
[~/flutter/flutter_sunflower] flutter build -h
Flutter build commands.

Usage: flutter build <subcommand> [arguments]
-h, --help    Print this usage information.

Available subcommands:
  apk     Build an Android APK file from your app.
  clean   Delete the build/ directory.
  flx     Build a Flutter FLX file from your app.

Run "flutter help" to see global options.
```

fix #2741
