### PR TITLE
Add a bool to indicate whether we're in MojoShell

### DIFF
--- a/packages/flutter/lib/shell.dart
+++ b/packages/flutter/lib/shell.dart
@@ -48,6 +48,9 @@ class MojoShell {
   }
   final ApplicationConnection _embedderConnection = _initEmbedderConnection();
 
+  /// Whether [connectToApplication] is able to connect to other applications.
+  bool get canConnectToOtherApplications => _shell != null;
+
   /// Attempts to connect to an application via the Mojo shell.
   ApplicationConnection connectToApplication(String url) {
     if (_shell == null)


### PR DESCRIPTION
In MojoShell, we can connect to other applications. This patch adds a bool that
clients can use to check whether that feature is available without needing to
try to connect to an application.
