### PR TITLE
update listen to work w/ ios devices

### DIFF
--- a/packages/flutter_tools/lib/src/commands/listen.dart
+++ b/packages/flutter_tools/lib/src/commands/listen.dart
@@ -5,30 +5,27 @@
 import 'dart:async';
 import 'dart:io';
 
+import '../base/os.dart';
 import '../base/process.dart';
 import '../globals.dart';
 import 'run.dart';
 
 class ListenCommand extends RunCommandBase {
+  ListenCommand({ this.singleRun: false });
+
   @override
   final String name = 'listen';
 
   @override
-  final String description =
-    'Listen for changes to files and reload the running app (Android only).';
+  final String description = 'Listen for changes to files and reload the running app.';
 
   @override
   final String usageFooter =
     'By default, only listens to "./" and "./lib/". To listen to additional directories, list them on\n'
     'the command line.';
 
-  /// Only run once.  Used for testing.
+  /// Only run once. Used for testing.
   final bool singleRun;
-
-  ListenCommand({ this.singleRun: false });
-
-  @override
-  bool get androidOnly => true;
 
   @override
   bool get requiresDevice => true;
@@ -38,16 +35,30 @@ class ListenCommand extends RunCommandBase {
     await downloadApplicationPackages();
     await downloadToolchain();
 
-    List<String> watchCommand = _constructWatchCommand(() sync* {
+    Iterable<String> directories = () sync* {
       yield* argResults.rest;
       yield '.';
       yield 'lib';
-    }());
+    }();
+
+    List<String> watchCommand = _constructWatchCommand(directories);
+
+    if (watchCommand == null)
+      return 1;
+
+    printStatus('Listening for changes in '
+      '${directories.map((String name) => "'$name${Platform.pathSeparator}'").join(', ')}'
+      '.');
 
     int result = 0;
     bool firstTime = true;
     do {
-      printStatus('Updating running Flutter apps...');
+      printStatus('');
+
+      // TODO(devoncarew): We could print out here what changes we detected that caused a re-run.
+      if (!firstTime)
+        printStatus('Re-running app...');
+
       result = await startApp(
         deviceForCommand,
         applicationPackages,
@@ -62,45 +73,43 @@ class ListenCommand extends RunCommandBase {
       );
       firstTime = false;
     } while (!singleRun && result == 0 && _watchDirectory(watchCommand));
+
     return 0;
   }
 
   List<String> _constructWatchCommand(Iterable<String> directories) {
     if (Platform.isMacOS) {
-      try {
-        runCheckedSync(<String>['which', 'fswatch']);
-      } catch (e) {
+      if (os.which('fswatch') == null) {
         printError('"listen" command is only useful if you have installed '
-            'fswatch on Mac.  Run "brew install fswatch" to install it with '
-            'homebrew.');
+          'fswatch on Mac. Run "brew install fswatch" to install it with homebrew.');
         return null;
+      } else {
+        return <String>['fswatch', '-r', '-v', '-1']..addAll(directories);
       }
-      return <String>['fswatch', '-r', '-v', '-1']..addAll(directories);
     } else if (Platform.isLinux) {
-      try {
-        runCheckedSync(<String>['which', 'inotifywait']);
-      } catch (e) {
+      if (os.which('inotifywait') == null) {
         printError('"listen" command is only useful if you have installed '
-            'inotifywait on Linux.  Run "apt-get install inotify-tools" or '
-            'equivalent to install it.');
+          'inotifywait on Linux. Run "apt-get install inotify-tools" or '
+          'equivalent to install it.');
         return null;
+      } else {
+        return <String>[
+          'inotifywait',
+          '-r',
+          '-e',
+          // Only listen for events that matter, to avoid triggering constantly
+          // from the editor watching files.
+          'modify,close_write,move,create,delete',
+        ]..addAll(directories);
       }
-      return <String>[
-        'inotifywait',
-        '-r',
-        '-e',
-        // Only listen for events that matter, to avoid triggering constantly
-        // from the editor watching files.
-        'modify,close_write,move,create,delete',
-      ]..addAll(directories);
     } else {
       printError('"listen" command is only available on Mac and Linux.');
     }
+
     return null;
   }
 
   bool _watchDirectory(List<String> watchCommand) {
-    printStatus('Attempting to listen to these directories: ${watchCommand.join(", ")}');
     assert(watchCommand != null);
     try {
       runCheckedSync(watchCommand);


### PR DESCRIPTION
- update the listen command to work on ios devices (this command pre-dated ios support; I just had to remove the android specific flag)
- update the output of the command a bit
- fix https://github.com/flutter/flutter/issues/2754

@Hixie 

```
[~/flutter/flutter_sunflower] flutter listen
Listening for changes in './', 'lib/'.

Starting lib/main.dart on iPhone 6s...

Re-running app...
Starting lib/main.dart on iPhone 6s...

Re-running app...
Starting lib/main.dart on iPhone 6s...
^C
```
