### PR TITLE
Fix position of the overlay

### DIFF
--- a/packages/flutter/lib/src/rendering/performance_overlay.dart
+++ b/packages/flutter/lib/src/rendering/performance_overlay.dart
@@ -83,14 +83,14 @@ class RenderPerformanceOverlay extends RenderBox {
   }
 
   double get intrinsicHeight {
-    const double kGraphHeight = 80.0; // must match value in performance_overlay_layer.cc
+    const double kDefaultGraphHeight = 80.0;
     double result = 0.0;
     if ((optionsMask | (1 << PerformanceOverlayOption.displayRasterizerStatistics.index) > 0) ||
         (optionsMask | (1 << PerformanceOverlayOption.visualizeRasterizerStatistics.index) > 0))
-      result += kGraphHeight;
+      result += kDefaultGraphHeight;
     if ((optionsMask | (1 << PerformanceOverlayOption.displayEngineStatistics.index) > 0) ||
         (optionsMask | (1 << PerformanceOverlayOption.visualizeEngineStatistics.index) > 0))
-      result += kGraphHeight;
+      result += kDefaultGraphHeight;
     return result;
   }
 

--- a/packages/flutter/lib/src/widgets/app.dart
+++ b/packages/flutter/lib/src/widgets/app.dart
@@ -202,7 +202,7 @@ class WidgetsAppState<T extends WidgetsApp> extends State<T> implements BindingO
       result = new Stack(
         children: <Widget>[
           result,
-          new Positioned(bottom: 0.0, left: 0.0, right: 0.0, child: new PerformanceOverlay.allEnabled()),
+          new Positioned(top: 0.0, left: 0.0, right: 0.0, child: new PerformanceOverlay.allEnabled()),
         ]
       );
     }


### PR DESCRIPTION
Now that the overlay actually respects the position we give it, put it
somewhere where the keyboard won't overlap it.
