### PR TITLE
Flexible AppBar with a TabBar

### DIFF
--- a/examples/material_gallery/lib/demo/flexible_space_demo.dart
+++ b/examples/material_gallery/lib/demo/flexible_space_demo.dart
@@ -82,6 +82,7 @@ class FlexibleSpaceDemoState extends State<FlexibleSpaceDemo> {
 
   @override
   Widget build(BuildContext context) {
+    final double statusBarHeight = (MediaQuery.of(context)?.padding ?? EdgeInsets.zero).top;
     return new Theme(
       data: new ThemeData(
         brightness: ThemeBrightness.light,
@@ -89,10 +90,10 @@ class FlexibleSpaceDemoState extends State<FlexibleSpaceDemo> {
       ),
       child: new Scaffold(
         key: scaffoldKey,
-        appBarHeight: appBarHeight,
         scrollableKey: scrollableKey,
         appBarBehavior: _appBarBehavior,
         appBar: new AppBar(
+          expandedHeight: appBarHeight,
           actions: <Widget>[
             new IconButton(
               icon: Icons.create,
@@ -134,7 +135,7 @@ class FlexibleSpaceDemoState extends State<FlexibleSpaceDemo> {
         ),
         body: new Block(
           scrollableKey: scrollableKey,
-          padding: new EdgeInsets.only(top: appBarHeight),
+          padding: new EdgeInsets.only(top: appBarHeight + statusBarHeight),
           children: <Widget>[
             new _ContactCategory(
               icon: Icons.call,

--- a/examples/material_gallery/lib/demo/scrollable_tabs_demo.dart
+++ b/examples/material_gallery/lib/demo/scrollable_tabs_demo.dart
@@ -1,0 +1,109 @@
+// Copyright 2015 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+
+enum TabsDemoStyle {
+  iconsAndText,
+  iconsOnly,
+  textOnly
+}
+
+class ScrollableTabsDemo extends StatefulWidget {
+  @override
+  ScrollableTabsDemoState createState() => new ScrollableTabsDemoState();
+}
+
+class ScrollableTabsDemoState extends State<ScrollableTabsDemo> {
+  final List<IconData> icons = <IconData>[
+    Icons.event,
+    Icons.home,
+    Icons.android,
+    Icons.alarm,
+    Icons.face,
+    Icons.language,
+  ];
+
+  final Map<IconData, String> labels = <IconData, String>{
+    Icons.event: 'EVENT',
+    Icons.home: 'HOME',
+    Icons.android: 'ANDROID',
+    Icons.alarm: 'ALARM',
+    Icons.face: 'FACE',
+    Icons.language: 'LANGUAGE',
+  };
+
+  TabsDemoStyle _demoStyle = TabsDemoStyle.iconsAndText;
+
+  void changeDemoStyle(TabsDemoStyle style) {
+    setState(() {
+      _demoStyle = style;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final Color iconColor = Theme.of(context).accentColor;
+    return new TabBarSelection<IconData>(
+      values: icons,
+      child: new Scaffold(
+        appBar: new AppBar(
+          title: new Text('Scrollable Tabs'),
+          actions: <Widget>[
+            new PopupMenuButton<TabsDemoStyle>(
+              onSelected: changeDemoStyle,
+              items: <PopupMenuItem<TabsDemoStyle>>[
+                new PopupMenuItem<TabsDemoStyle>(
+                  value: TabsDemoStyle.iconsAndText,
+                  child: new Text('Icons and Text')
+                ),
+                new PopupMenuItem<TabsDemoStyle>(
+                  value: TabsDemoStyle.iconsOnly,
+                  child: new Text('Icons Only')
+                ),
+                new PopupMenuItem<TabsDemoStyle>(
+                  value: TabsDemoStyle.textOnly,
+                  child: new Text('Text Only')
+                ),
+              ]
+            )
+          ],
+          tabBar: new TabBar<IconData>(
+            isScrollable: true,
+            labels: new Map<IconData, TabLabel>.fromIterable(
+              icons,
+              value: (IconData icon) {
+                switch(_demoStyle) {
+                  case TabsDemoStyle.iconsAndText:
+                    return new TabLabel(text: labels[icon], icon: icon);
+                  case TabsDemoStyle.iconsOnly:
+                    return new TabLabel(icon: icon);
+                  case TabsDemoStyle.textOnly:
+                    return new TabLabel(text: labels[icon]);
+                }
+              }
+            )
+          )
+        ),
+        body: new TabBarView<IconData>(
+          children: icons.map((IconData icon) {
+            return new Container(
+              key: new ObjectKey(icon),
+              padding: const EdgeInsets.all(12.0),
+              child:new Card(
+                child: new Center(
+                  child: new Icon(
+                    icon: icon,
+                    color: iconColor,
+                    size: 128.0
+                  )
+                )
+              )
+            );
+          }).toList()
+        )
+      )
+    );
+  }
+}

--- a/examples/material_gallery/lib/demo/tabs_demo.dart
+++ b/examples/material_gallery/lib/demo/tabs_demo.dart
@@ -4,55 +4,74 @@
 
 import 'package:flutter/material.dart';
 
-class TabsDemo extends StatelessWidget {
-  final List<IconData> icons = <IconData>[
-    Icons.event,
-    Icons.home,
-    Icons.android,
-    Icons.alarm,
-    Icons.face,
-    Icons.language,
-  ];
+class _Page {
+  _Page({ this.label });
 
-  final Map<IconData, String> labels = <IconData, String>{
-    Icons.event: 'EVENT',
-    Icons.home: 'HOME',
-    Icons.android: 'ANDROID',
-    Icons.alarm: 'ALARM',
-    Icons.face: 'FACE',
-    Icons.language: 'LANGUAGE',
-  };
+  final GlobalKey<ScrollableState<Scrollable>> key = new GlobalKey<ScrollableState<Scrollable>>();
+  final String label;
+}
+
+final List<_Page> _pages = <_Page>[
+  new _Page(label: 'ONE'),
+  new _Page(label: 'TWO'),
+  new _Page(label: 'FREE'),
+  new _Page(label: 'FOUR')
+];
+
+class TabsDemo extends StatefulWidget {
+  @override
+  TabsDemoState createState() => new TabsDemoState();
+}
+
+class TabsDemoState extends State<TabsDemo> {
+  _Page _selectedPage;
+  double _scrollOffset = 0.0;
+
+  @override
+  void initState() {
+    super.initState();
+    _selectedPage = _pages[0];
+  }
 
   @override
   Widget build(BuildContext context) {
-    final Color iconColor = Theme.of(context).accentColor;
-    return new TabBarSelection<IconData>(
-      values: icons,
+    final double statusBarHeight = (MediaQuery.of(context)?.padding ?? EdgeInsets.zero).top;
+    return new TabBarSelection<_Page>(
+      values: _pages,
+      onChanged: (_Page value) {
+        setState(() {
+          _selectedPage = value;
+          _selectedPage.key.currentState.scrollTo(_scrollOffset);
+        });
+      },
       child: new Scaffold(
+        scrollableKey: _selectedPage.key,
+        appBarBehavior: AppBarBehavior.under,
         appBar: new AppBar(
-          title: new Text("Scrollable Tabs"),
-          tabBar: new TabBar<IconData>(
-            isScrollable: true,
-            labels: new Map<IconData, TabLabel>.fromIterable(
-              icons,
-              value: (IconData icon) => new TabLabel(text: labels[icon], icon: icon)
-            )
+          title: new Text('Tabs and Scrolling'),
+          tabBar: new TabBar<_Page>(
+            labels: new Map<_Page, TabLabel>.fromIterable(_pages, value: (_Page page) {
+              return new TabLabel(text: page.label);
+            })
           )
         ),
-        body: new TabBarView<IconData>(
-          children: icons.map((IconData icon) {
-            return new Container(
-              key: new ObjectKey(icon),
-              padding: const EdgeInsets.all(12.0),
-              child: new Card(
-                child: new Center(
-                  child: new Icon(
-                    icon: icon,
-                    color: iconColor,
-                    size: 128.0
+        body: new TabBarView<_Page>(
+          children: _pages.map((_Page page) {
+            return new Block(
+              padding: new EdgeInsets.only(top: kTextTabBarHeight + kToolBarHeight + statusBarHeight),
+              scrollableKey: page.key,
+              onScroll: (double value) { _scrollOffset = value; },
+              children: new List<Widget>.generate(6, (int i) {
+                return new Container(
+                  padding: const EdgeInsets.all(8.0),
+                  height: 192.0,
+                  child: new Card(
+                    child: new Center(
+                      child: new Text('Tab $page.label, item $i')
+                    )
                   )
-                )
-              )
+                );
+              })
             );
           }).toList()
         )

--- a/examples/material_gallery/lib/demo/tabs_fab_demo.dart
+++ b/examples/material_gallery/lib/demo/tabs_fab_demo.dart
@@ -34,7 +34,6 @@ class _TabsFabDemoState extends State<TabsFabDemo> {
   final GlobalKey scaffoldKey = new GlobalKey();
   final List<_Page> pages = <_Page>[
     new _Page(label: 'Blue', colors: Colors.indigo, icon: Icons.add),
-    new _Page(label: 'Too', colors: Colors.indigo, icon: Icons.add),
     new _Page(label: 'Eco', colors: Colors.green, icon: Icons.create),
     new _Page(label: 'No'),
     new _Page(label: 'Teal', colors: Colors.teal, icon: Icons.add),

--- a/examples/material_gallery/lib/gallery/home.dart
+++ b/examples/material_gallery/lib/gallery/home.dart
@@ -30,6 +30,7 @@ import '../demo/toggle_controls_demo.dart';
 import '../demo/scrolling_techniques_demo.dart';
 import '../demo/slider_demo.dart';
 import '../demo/snack_bar_demo.dart';
+import '../demo/scrollable_tabs_demo.dart';
 import '../demo/tabs_demo.dart';
 import '../demo/tabs_fab_demo.dart';
 import '../demo/text_field_demo.dart';
@@ -49,14 +50,15 @@ class GalleryHome extends StatefulWidget {
 class GalleryHomeState extends State<GalleryHome> {
   @override
   Widget build(BuildContext context) {
+    final double appBarHeight = 128.0;
     return new Scaffold(
-      appBarHeight: 128.0,
       drawer: new GalleryDrawer(),
       appBar: new AppBar(
+        expandedHeight: appBarHeight,
         flexibleSpace: (BuildContext context) {
           return new Container(
-            padding: const EdgeInsets.only(left: 16.0, bottom: 24.0),
-            height: 128.0,
+            padding: const EdgeInsets.only(left: 64.0),
+            height: appBarHeight,
             child: new Align(
               alignment: const FractionalOffset(0.0, 1.0),
               child: new Text('Flutter Gallery', style: Typography.white.headline)
@@ -118,6 +120,7 @@ class GalleryHomeState extends State<GalleryHome> {
                   new GalleryDemo(title: 'Page Selector', builder: () => new PageSelectorDemo()),
                   new GalleryDemo(title: 'Persistent Bottom Sheet', builder: () => new PersistentBottomSheetDemo()),
                   new GalleryDemo(title: 'Progress Indicators', builder: () => new ProgressIndicatorDemo()),
+                  new GalleryDemo(title: 'Scrollable Tabs', builder: () => new ScrollableTabsDemo()),
                   new GalleryDemo(title: 'Selection Controls', builder: () => new ToggleControlsDemo()),
                   new GalleryDemo(title: 'Sliders', builder: () => new SliderDemo()),
                   new GalleryDemo(title: 'SnackBar', builder: () => new SnackBarDemo()),

--- a/examples/material_gallery/lib/gallery/section.dart
+++ b/examples/material_gallery/lib/gallery/section.dart
@@ -25,6 +25,7 @@ class GallerySection extends StatelessWidget {
   }
 
   void showDemos(BuildContext context) {
+    final double statusBarHeight = (MediaQuery.of(context)?.padding ?? EdgeInsets.zero).top;
     final ThemeData theme = new ThemeData(
       brightness: Theme.of(context).brightness,
       primarySwatch: colors
@@ -36,16 +37,16 @@ class GallerySection extends StatelessWidget {
         return new Theme(
           data: theme,
           child: new Scaffold(
-            appBarHeight: appBarHeight,
             appBarBehavior: AppBarBehavior.under,
             scrollableKey: scrollableKey,
             appBar: new AppBar(
+              expandedHeight: appBarHeight,
               flexibleSpace: (BuildContext context) => new FlexibleSpaceBar(title: new Text(title))
             ),
             body: new Material(
               child: new MaterialList(
                 scrollableKey: scrollableKey,
-                scrollablePadding: new EdgeInsets.only(top: appBarHeight),
+                scrollablePadding: new EdgeInsets.only(top: appBarHeight + statusBarHeight),
                 type: MaterialListType.oneLine,
                 children: (demos ?? const <GalleryDemo>[]).map((GalleryDemo demo) {
                   return new ListItem(

--- a/packages/flutter/lib/src/material/constants.dart
+++ b/packages/flutter/lib/src/material/constants.dart
@@ -13,8 +13,8 @@ const double kToolBarHeight = 56.0;
 const double kExtendedAppBarHeight = 128.0;
 
 const double kTextTabBarHeight = 48.0;
-const double kIconTabBarHeight = 48.0;
-const double kTextandIconTabBarHeight = 72.0;
+const double kIconTabBarHeight = 26.0;
+const double kTextAndIconTabBarHeight = 74.0;
 
 // https://www.google.com/design/spec/layout/metrics-keylines.html#metrics-keylines-keylines-spacing
 const double kListTitleHeight = 72.0;

--- a/packages/flutter/lib/src/material/flexible_space_bar.dart
+++ b/packages/flutter/lib/src/material/flexible_space_bar.dart
@@ -25,10 +25,10 @@ class _FlexibleSpaceBarState extends State<FlexibleSpaceBar> {
   @override
   Widget build(BuildContext context) {
     assert(debugCheckHasScaffold(context));
-    final double appBarHeight = Scaffold.of(context).appBarHeight;
+    final double statusBarHeight = (MediaQuery.of(context)?.padding ?? EdgeInsets.zero).top;
     final Animation<double> animation = Scaffold.of(context).appBarAnimation;
-    final EdgeInsets toolBarPadding = MediaQuery.of(context)?.padding ?? EdgeInsets.zero;
-    final double toolBarHeight = kToolBarHeight + toolBarPadding.top;
+    final double appBarHeight = Scaffold.of(context).appBarHeight + statusBarHeight;
+    final double toolBarHeight = kToolBarHeight + statusBarHeight;
     final List<Widget> children = <Widget>[];
 
     // background image
@@ -46,7 +46,10 @@ class _FlexibleSpaceBarState extends State<FlexibleSpaceBar> {
         right: 0.0,
         child: new Opacity(
           opacity: new Tween<double>(begin: 1.0, end: 0.0).evaluate(opacityCurve),
-          child: config.image
+          child: new SizedBox(
+            height: appBarHeight + statusBarHeight,
+            child: config.image
+          )
         )
        ));
     }
@@ -64,7 +67,7 @@ class _FlexibleSpaceBarState extends State<FlexibleSpaceBar> {
         color: titleStyle.color.withAlpha(new Tween<double>(begin: 255.0, end: 0.0).evaluate(opacityCurve).toInt())
       );
       final double yAlignStart = 1.0;
-      final double yAlignEnd = (toolBarPadding.top + kToolBarHeight / 2.0) / toolBarHeight;
+      final double yAlignEnd = (statusBarHeight + kToolBarHeight / 2.0) / toolBarHeight;
       final double scaleAndAlignEnd = (appBarHeight - toolBarHeight) / appBarHeight;
       final CurvedAnimation scaleAndAlignCurve = new CurvedAnimation(
         parent: animation,

--- a/packages/flutter/lib/src/material/tabs.dart
+++ b/packages/flutter/lib/src/material/tabs.dart
@@ -592,6 +592,14 @@ class TabBar<T> extends Scrollable {
   final Map<T, TabLabel> labels;
   final bool isScrollable;
 
+  double get minimumHeight {
+    for (TabLabel label in labels.values) {
+      if (label.text != null && (label.icon != null || label.iconBuilder != null))
+        return _kTextAndIconTabHeight + _kTabIndicatorHeight;
+    }
+    return _kTabHeight + _kTabIndicatorHeight;
+  }
+
   @override
   _TabBarState<T> createState() => new _TabBarState<T>();
 }
@@ -810,9 +818,9 @@ class _TabBarState<T> extends ScrollableState<TabBar<T>> implements TabBarSelect
       indicatorColor = Colors.white;
     }
 
-    TextStyle textStyle = themeData.primaryTextTheme.body1;
+    TextStyle textStyle = themeData.primaryTextTheme.body2;
     IconThemeData iconTheme = themeData.primaryIconTheme;
-    Color textColor = themeData.primaryTextTheme.body1.color.withAlpha(0xB2); // 70% alpha
+    Color textColor = themeData.primaryTextTheme.body2.color.withAlpha(0xB2); // 70% alpha
 
     List<Widget> tabs = <Widget>[];
     bool textAndIcons = false;


### PR DESCRIPTION
Added support for the `scroll` and `under` AppBarBehaviors for AppBars that have TabBars.

There's a new gallery "Tabs" demo that shows how this can work.

Sadly, this not the AppBar finale. Among the problems that still need to be addressed:
- Setting up a flexible AppBar is too complicated. Currently one must identify the scrollable that drives the AppBar resize with a key, specify the same key as the value of the Scaffold's scrollableKey, specify a Scaffold appBarBehavior, and pad the top of the Scrollable to match the AppBar's "extended" height - including the status bar's height.
- The Scaffold should compute the size the AppBar at layout time, rather than at build time.
- Exactly how best to handle a flexible TabBar with scrollable TabViews is still an open question. The current Tabs demo is isn't really an answer.
- When the selected tab changes, if it's necessary to scroll a TabView to sync its flexible AppBar up with its (saved) scroll offset, the scroll animation should be be driven by the tab change animation.

Fixes https://github.com/flutter/flutter/issues/2627
Fixes https://github.com/flutter/flutter/issues/1546
Fixes https://github.com/flutter/flutter/issues/1806
