### PR TITLE
[driver] actually start the timer when connecting

### DIFF
--- a/packages/flutter_driver/lib/src/driver.dart
+++ b/packages/flutter_driver/lib/src/driver.dart
@@ -312,7 +312,7 @@ void restoreVmServiceConnectFunction() {
 ///
 /// Times out after 30 seconds.
 Future<VMServiceClient> _waitAndConnect(String url) async {
-  Stopwatch timer = new Stopwatch();
+  Stopwatch timer = new Stopwatch()..start();
   Future<VMServiceClient> attemptConnection() {
     return VMServiceClient.connect(url)
       .catchError((dynamic e) async {


### PR DESCRIPTION
Otherwise we'll never time out.
