### PR TITLE
add support for a FLUTTER_DEV env var in the flutter script

### DIFF
--- a/bin/flutter
+++ b/bin/flutter
@@ -37,7 +37,12 @@ export PATH="$DART_SDK_PATH/bin:$PATH"
 
 set +e
 
-"$DART" "$SNAPSHOT_PATH" "$@"
+if [ $FLUTTER_DEV ]; then
+  echo -e "(FLUTTER_DEV set - ignoring $SNAPSHOT_PATH)\n"
+  "$DART" --package-root="$FLUTTER_TOOLS_DIR/packages" "$SCRIPT_PATH" "$@"
+else
+  "$DART" "$SNAPSHOT_PATH" "$@"
+fi
 
 # The VM exits with code 253 if the snapshot version is out-of-date.
 # If it is, we need to snapshot it again.


### PR DESCRIPTION
If the developer has a `FLUTTER_DEV` env var defined, then run the flutter_tools code directly, and not the cached snapshot. This is useful when working on the flutter_tools package.
