### PR TITLE
Remove `analyze` tear-off regexp.

### DIFF
--- a/packages/flutter_tools/lib/src/commands/analyze.dart
+++ b/packages/flutter_tools/lib/src/commands/analyze.dart
@@ -354,7 +354,6 @@ class AnalyzeCommand extends FlutterCommand {
     RegExp generalPattern = new RegExp(r'^\[(error|warning|hint|lint)\] (.+) \(([^(),]+), line ([0-9]+), col ([0-9]+)\)$');
     RegExp allowedIdentifiersPattern = new RegExp(r'_?([A-Z]|_+)\b');
     RegExp classesWithOptionalTypeArgumentsPattern = new RegExp(r'\b(GlobalKey|State|ScrollableState|Element|StatelessElement|TypeMatcher)\b');
-    RegExp constructorTearOffsPattern = new RegExp('.+#.+// analyzer doesn\'t like constructor tear-offs');
     RegExp conflictingNamesPattern = new RegExp('^The imported libraries \'([^\']+)\' and \'([^\']+)\' cannot have the same name \'([^\']+)\'\$');
     RegExp missingFilePattern = new RegExp('^Target of URI does not exist: \'([^\')]+)\'\$');
     RegExp documentAllMembersPattern = new RegExp('^Document all public memm?bers\$');
@@ -416,8 +415,6 @@ class AnalyzeCommand extends FlutterCommand {
             // see https://github.com/dart-lang/linter/issues/196
             if (classesWithOptionalTypeArgumentsPattern.matchAsPrefix(sourceLine, colNumber-1) != null)
               shouldIgnore = true;
-          } else if (constructorTearOffsPattern.allMatches(sourceLine).isNotEmpty) {
-            shouldIgnore = true;
           }
           if (shouldIgnore)
             continue;


### PR DESCRIPTION
In the spirit of https://github.com/flutter/flutter/issues/1220, remove the tear-off regexp in favor of in-line suppressions (if needed).

cc @Hixie 
