### PR TITLE
Scrollable sometimes pushes frames forever

### DIFF
--- a/packages/flutter/lib/src/widgets/scrollable.dart
+++ b/packages/flutter/lib/src/widgets/scrollable.dart
@@ -444,7 +444,7 @@ abstract class ScrollableState<T extends Scrollable> extends State<T> {
   Simulation _createFlingSimulation(double scrollVelocity) {
     final Simulation simulation =  scrollBehavior.createScrollSimulation(scrollOffset, scrollVelocity);
     if (simulation != null) {
-      final double endVelocity = pixelOffsetToScrollOffset(kPixelScrollTolerance.velocity).abs() * (scrollVelocity < 0.0 ? -1.0 : 1.0);
+      final double endVelocity = pixelOffsetToScrollOffset(kPixelScrollTolerance.velocity).abs();
       final double endDistance = pixelOffsetToScrollOffset(kPixelScrollTolerance.distance).abs();
       simulation.tolerance = new Tolerance(velocity: endVelocity, distance: endDistance);
     }

--- a/packages/newton/lib/src/friction_simulation.dart
+++ b/packages/newton/lib/src/friction_simulation.dart
@@ -47,7 +47,7 @@ class FrictionSimulation extends Simulation {
   double dx(double time) => _v * math.pow(_drag, time);
 
   @override
-  bool isDone(double time) => dx(time).abs() < this.tolerance.velocity;
+  bool isDone(double time) => dx(time).abs() < tolerance.velocity;
 }
 
 class BoundedFrictionSimulation extends FrictionSimulation {

--- a/packages/newton/lib/src/utils.dart
+++ b/packages/newton/lib/src/utils.dart
@@ -2,7 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-bool nearEqual(double a, double b, double epsilon) =>
-    (a > (b - epsilon)) && (a < (b + epsilon));
+bool nearEqual(double a, double b, double epsilon) {
+  assert(epsilon >= 0.0);
+  return (a > (b - epsilon)) && (a < (b + epsilon));
+}
 
 bool nearZero(double a, double epsilon) => nearEqual(a, 0.0, epsilon);


### PR DESCRIPTION
We were setting a negative velocity tolerance, which never triggered because we
assume tolerances are positive numbers. Now we use a positive tolerance and
assert to catch this case in the future.

Fixes #2765
