### PR TITLE
change how we calculate the temp dir

### DIFF
--- a/packages/flutter_tools/lib/src/commands/build_apk.dart
+++ b/packages/flutter_tools/lib/src/commands/build_apk.dart
@@ -239,7 +239,7 @@ Future<_ApkComponents> _findApkComponents(
 
   await parseServiceConfigs(components.services, jars: components.jars);
 
-  for (File file in [
+  for (File file in <File>[
     components.manifest, components.icuData, components.libSkyShell, components.debugKeystore
   ]..addAll(components.jars)) {
     if (!file.existsSync()) {


### PR DESCRIPTION
- update how we calculate the temp dir in `setup_xcodeproj.dart`. Before we were getting the temp dir and making sure that it existed (`Directory.systemTemp.create()`). The intent was to create a new temp subdir though (`Directory.systemTemp.createTempSync('...')`.
- also, prefer to use dart:io calls where they exist to shelling out

On the bot, we were seeing this command executed:

```
/bin/rm -rf /tmp
```

(https://uberchromegw.corp.google.com/i/client.flutter/builders/Mac/builds/481/steps/drive%20sample_app/logs/stdio)

@chinmaygarde 
