### PR TITLE
Fix Fast Fling Failure

### DIFF
--- a/packages/flutter/lib/src/gestures/constants.dart
+++ b/packages/flutter/lib/src/gestures/constants.dart
@@ -78,9 +78,9 @@ const double kWindowTouchSlop = 16.0;  // Logical pixels
 /// gesture.
 // TODO(ianh): Make sure nobody has their own version of this.
 const double kMinFlingVelocity = 50.0;  // Logical pixels / second
+// const Velocity kMinFlingVelocity = const Velocity(pixelsPerSecond: 50.0);
 
-/// The maximum velocity of a touch to consider that touch to trigger a fling
-/// gesture.
+/// Drag gesture fling velocities are clipped to this value.
 // TODO(ianh): Make sure nobody has their own version of this.
 const double kMaxFlingVelocity = 8000.0;  // Logical pixels / second
 

--- a/packages/flutter/lib/src/gestures/drag.dart
+++ b/packages/flutter/lib/src/gestures/drag.dart
@@ -31,8 +31,7 @@ typedef void _GesturePolymorphicUpdateCallback<T>(T delta);
 bool _isFlingGesture(Velocity velocity) {
   assert(velocity != null);
   final double speedSquared = velocity.pixelsPerSecond.distanceSquared;
-  return speedSquared > kMinFlingVelocity * kMinFlingVelocity
-      && speedSquared < kMaxFlingVelocity * kMaxFlingVelocity;
+  return speedSquared > kMinFlingVelocity * kMinFlingVelocity;
 }
 
 abstract class _DragGestureRecognizer<T extends dynamic> extends OneSequenceGestureRecognizer {
@@ -119,10 +118,14 @@ abstract class _DragGestureRecognizer<T extends dynamic> extends OneSequenceGest
       assert(tracker != null);
 
       Velocity velocity = tracker.getVelocity();
-      if (velocity != null && _isFlingGesture(velocity))
+      if (velocity != null && _isFlingGesture(velocity)) {
+        final Offset pixelsPerSecond = velocity.pixelsPerSecond;
+        if (pixelsPerSecond.distanceSquared > kMaxFlingVelocity * kMaxFlingVelocity)
+          velocity = new Velocity(pixelsPerSecond: (pixelsPerSecond / pixelsPerSecond.distance) * kMaxFlingVelocity);
         onEnd(velocity);
-      else
+      } else {
         onEnd(Velocity.zero);
+      }
     }
     _velocityTrackers.clear();
   }

--- a/packages/flutter/lib/src/widgets/scrollable.dart
+++ b/packages/flutter/lib/src/widgets/scrollable.dart
@@ -499,8 +499,7 @@ abstract class ScrollableState<T extends Scrollable> extends State<T> {
 
   Future<Null> _handleDragEnd(Velocity velocity) {
     double scrollVelocity = pixelDeltaToScrollOffset(velocity.pixelsPerSecond) / Duration.MILLISECONDS_PER_SECOND;
-    // The gesture velocity properties are pixels/second, config min,max limits are pixels/ms
-    return fling(scrollVelocity.clamp(-kMaxFlingVelocity, kMaxFlingVelocity)).then(_endScroll);
+    return fling(scrollVelocity).then(_endScroll);
   }
 
   Null _endScroll([Null _]) {


### PR DESCRIPTION
Fling velocities are now clipped to kMaxFlingVelocity. Previously flings whose velocity exceeded the threshold were ignored.

Fixes https://github.com/flutter/flutter/issues/2678
