### PR TITLE
Fixed VirtualViewport child key assignment

### DIFF
--- a/packages/flutter/lib/src/widgets/debug.dart
+++ b/packages/flutter/lib/src/widgets/debug.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:collection';
+
 import 'framework.dart';
 import 'media_query.dart';
 
@@ -21,4 +23,24 @@ bool debugCheckHasMediaQuery(BuildContext context) {
     return true;
   });
   return true;
+}
+
+bool debugHasDuplicateKeys(Widget parent, Iterable<Widget> children) {
+  assert(() {
+    Set<Key> keySet = new HashSet<Key>();
+    for (Widget child in children) {
+      assert(child != null);
+      if (child.key == null)
+        continue;
+      if (!keySet.add(child.key)) {
+        throw new FlutterError(
+          'Duplicate keys found.\n'
+          'If multiple keyed nodes exist as children of another node, they must have unique keys.\n'
+          '$parent has multiple children with key "${child.key}".'
+        );
+      }
+    }
+    return true;
+  });
+  return false;
 }

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -5,6 +5,8 @@
 import 'dart:async';
 import 'dart:collection';
 
+import 'debug.dart';
+
 import 'package:flutter/rendering.dart';
 
 export 'dart:ui' show hashValues, hashList;
@@ -1935,7 +1937,7 @@ class SingleChildRenderObjectElement extends RenderObjectElement {
 /// Instantiation of RenderObjectWidgets that can have a list of children
 class MultiChildRenderObjectElement extends RenderObjectElement {
   MultiChildRenderObjectElement(MultiChildRenderObjectWidget widget) : super(widget) {
-    assert(!_debugHasDuplicateIds());
+    assert(!debugHasDuplicateKeys(widget, widget.children));
   }
 
   @override
@@ -1966,24 +1968,6 @@ class MultiChildRenderObjectElement extends RenderObjectElement {
     assert(child.parent == renderObject);
     renderObject.remove(child);
     assert(renderObject == this.renderObject);
-  }
-
-  bool _debugHasDuplicateIds() {
-    Set<Key> idSet = new HashSet<Key>();
-    for (Widget child in widget.children) {
-      assert(child != null);
-      if (child.key == null)
-        continue; // when these nodes are reordered, we just reassign the data
-
-      if (!idSet.add(child.key)) {
-        throw new FlutterError(
-          'Duplicate keys found.\n'
-          'If multiple keyed nodes exist as children of another node, they must have unique keys.\n'
-          '$widget has multiple children with key "${child.key}".'
-        );
-      }
-    }
-    return false;
   }
 
   @override

--- a/packages/flutter/lib/src/widgets/virtual_viewport.dart
+++ b/packages/flutter/lib/src/widgets/virtual_viewport.dart
@@ -5,6 +5,7 @@
 import 'dart:math' as math;
 
 import 'basic.dart';
+import 'debug.dart';
 import 'framework.dart';
 
 import 'package:flutter/rendering.dart';
@@ -169,9 +170,10 @@ abstract class VirtualViewportElement extends RenderObjectElement {
     for (int i = 0; i < count; ++i) {
       int childIndex = base + i;
       Widget child = _widgetProvider.getChild(childIndex);
-      Key key = new ValueKey<Key>(child.key) ?? new ValueKey<int>(childIndex);
+      Key key = child.key != null ? new ValueKey<Key>(child.key) : new ValueKey<int>(childIndex);
       newWidgets[i] = new RepaintBoundary(key: key, child: child);
     }
+    assert(!debugHasDuplicateKeys(widget, newWidgets));
     _materializedChildren = updateChildren(_materializedChildren, newWidgets);
   }
 


### PR DESCRIPTION
VirtualViewport children that lacked keys were all assigned the same null key.

Added an assert that verifies that all of the viewport's materialized children have unique keys.

Fixes https://github.com/flutter/flutter/issues/2830
