### PR TITLE
Scrollable physics should be reasonable when sizes change

### DIFF
--- a/packages/flutter/lib/src/animation/animation_controller.dart
+++ b/packages/flutter/lib/src/animation/animation_controller.dart
@@ -124,6 +124,12 @@ class AnimationController extends Animation<double>
     _checkStatusChanged();
   }
 
+  /// The amount of time that has passed between the time the animation started and the most recent tick of the animation.
+  ///
+  /// If the controller is not animating, the last elapsed duration is null;
+  Duration get lastElapsedDuration => _lastElapsedDuration;
+  Duration _lastElapsedDuration;
+
   /// Whether this animation is currently animating in either the forward or reverse direction.
   bool get isAnimating => _ticker.isTicking;
 
@@ -205,6 +211,7 @@ class AnimationController extends Animation<double>
     assert(simulation != null);
     assert(!isAnimating);
     _simulation = simulation;
+    _lastElapsedDuration = const Duration();
     _value = simulation.x(0.0).clamp(lowerBound, upperBound);
     Future<Null> result = _ticker.start();
     _checkStatusChanged();
@@ -214,6 +221,7 @@ class AnimationController extends Animation<double>
   /// Stops running this animation.
   void stop() {
     _simulation = null;
+    _lastElapsedDuration = null;
     _ticker.stop();
   }
 
@@ -233,6 +241,7 @@ class AnimationController extends Animation<double>
   }
 
   void _tick(Duration elapsed) {
+    _lastElapsedDuration = elapsed;
     double elapsedInSeconds = elapsed.inMicroseconds.toDouble() / Duration.MICROSECONDS_PER_SECOND;
     _value = _simulation.x(elapsedInSeconds).clamp(lowerBound, upperBound);
     if (_simulation.isDone(elapsedInSeconds))

--- a/packages/flutter/lib/src/material/tabs.dart
+++ b/packages/flutter/lib/src/material/tabs.dart
@@ -768,7 +768,7 @@ class _TabBarState<T> extends ScrollableState<TabBar<T>> implements TabBarSelect
   }
 
   void _updateScrollBehavior() {
-    scrollTo(scrollBehavior.updateExtents(
+    didUpdateScrollBehavior(scrollBehavior.updateExtents(
       containerExtent: config.scrollDirection == Axis.vertical ? _viewportSize.height : _viewportSize.width,
       contentExtent: _tabWidths.reduce((double sum, double width) => sum + width),
       scrollOffset: scrollOffset
@@ -943,11 +943,11 @@ class _TabBarViewState<T> extends PageableListState<TabBarView<T>> implements Ta
 
   void _updateScrollBehaviorForSelectedIndex(int selectedIndex) {
     if (selectedIndex == 0) {
-      scrollTo(scrollBehavior.updateExtents(contentExtent: 2.0, containerExtent: 1.0, scrollOffset: 0.0));
+      didUpdateScrollBehavior(scrollBehavior.updateExtents(contentExtent: 2.0, containerExtent: 1.0, scrollOffset: 0.0));
     } else if (selectedIndex == _tabCount - 1) {
-      scrollTo(scrollBehavior.updateExtents(contentExtent: 2.0, containerExtent: 1.0, scrollOffset: 1.0));
+      didUpdateScrollBehavior(scrollBehavior.updateExtents(contentExtent: 2.0, containerExtent: 1.0, scrollOffset: 1.0));
     } else {
-      scrollTo(scrollBehavior.updateExtents(contentExtent: 3.0, containerExtent: 1.0, scrollOffset: 1.0));
+      didUpdateScrollBehavior(scrollBehavior.updateExtents(contentExtent: 3.0, containerExtent: 1.0, scrollOffset: 1.0));
     }
   }
 

--- a/packages/flutter/lib/src/widgets/editable.dart
+++ b/packages/flutter/lib/src/widgets/editable.dart
@@ -235,7 +235,7 @@ class RawInputLineState extends ScrollableState<RawInputLine> {
     // render object via our return value.
     _containerWidth = dimensions.containerSize.width;
     _contentWidth = dimensions.contentSize.width;
-    scrollTo(scrollBehavior.updateExtents(
+    didUpdateScrollBehavior(scrollBehavior.updateExtents(
       contentExtent: _contentWidth,
       containerExtent: _containerWidth,
       // Set the scroll offset to match the content width so that the

--- a/packages/flutter/lib/src/widgets/pageable_list.dart
+++ b/packages/flutter/lib/src/widgets/pageable_list.dart
@@ -147,7 +147,7 @@ class PageableListState<T extends PageableList> extends ScrollableState<T> {
 
   void _updateScrollBehavior() {
     config.scrollableListPainter?.contentExtent = _itemCount.toDouble();
-    scrollTo(scrollBehavior.updateExtents(
+    didUpdateScrollBehavior(scrollBehavior.updateExtents(
       contentExtent: _itemCount.toDouble(),
       containerExtent: 1.0,
       scrollOffset: scrollOffset

--- a/packages/flutter/lib/src/widgets/scrollable_grid.dart
+++ b/packages/flutter/lib/src/widgets/scrollable_grid.dart
@@ -50,7 +50,7 @@ class _ScrollableGridState extends ScrollableState<ScrollableGrid> {
 
   void _handleExtentsChanged(double contentExtent, double containerExtent) {
     setState(() {
-      scrollTo(scrollBehavior.updateExtents(
+      didUpdateScrollBehavior(scrollBehavior.updateExtents(
         contentExtent: contentExtent,
         containerExtent: containerExtent,
         scrollOffset: scrollOffset

--- a/packages/flutter/lib/src/widgets/scrollable_list.dart
+++ b/packages/flutter/lib/src/widgets/scrollable_list.dart
@@ -55,7 +55,7 @@ class _ScrollableListState extends ScrollableState<ScrollableList> {
   void _handleExtentsChanged(double contentExtent, double containerExtent) {
     config.scrollableListPainter?.contentExtent = contentExtent;
     setState(() {
-      scrollTo(scrollBehavior.updateExtents(
+      didUpdateScrollBehavior(scrollBehavior.updateExtents(
         contentExtent: config.itemsWrap ? double.INFINITY : contentExtent,
         containerExtent: containerExtent,
         scrollOffset: scrollOffset
@@ -338,7 +338,7 @@ class _ScrollableLazyListState extends ScrollableState<ScrollableLazyList> {
   void _handleExtentsChanged(double contentExtent, double containerExtent) {
     config.scrollableListPainter?.contentExtent = contentExtent;
     setState(() {
-      scrollTo(scrollBehavior.updateExtents(
+      didUpdateScrollBehavior(scrollBehavior.updateExtents(
         contentExtent: contentExtent,
         containerExtent: containerExtent,
         scrollOffset: scrollOffset


### PR DESCRIPTION
Previously, when the content extent changed during a scroll interaction, we'd
stop the current scroll interaction and reset the scroll offset. Now we try to
continue the scroll interaction (e.g., drag, fling, or overscroll) even through
the underlying scroll behavior has changed.

For physics-based scroll interactions, we keep the current position and
velocity and recompute the operative forces. For drag interactions, we keep the
current position and continue to let the user drag the scroll offset.

After this patch, we still disrupt non-physical scroll animations that are
operating outside the new scroll bounds because it's not clear how we can
sensibly modify them to work with the new scroll bounds.
