### PR TITLE
re-work the doctor command

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_sdk.dart
+++ b/packages/flutter_tools/lib/src/android/android_sdk.dart
@@ -102,20 +102,16 @@ class AndroidSdk {
 
   String get adbPath => getPlatformToolsPath('adb');
 
-  bool validateSdkWellFormed({ bool complain: false }) {
-    if (!FileSystemEntity.isFileSync(adbPath)) {
-      if (complain)
-        printError('Android SDK file not found: $adbPath.');
-      return false;
-    }
+  /// Validate the Android SDK. This returns an empty list if there are no
+  /// issues; otherwise, it returns a list of issues found.
+  List<String> validateSdkWellFormed() {
+    if (!FileSystemEntity.isFileSync(adbPath))
+      return <String>['Android SDK file not found: $adbPath.'];
 
-    if (sdkVersions.isEmpty) {
-      if (complain)
-        printError('Android SDK does not have the proper build-tools.');
-      return false;
-    }
+    if (sdkVersions.isEmpty || latestVersion == null)
+      return <String>['Android SDK does not have the proper build-tools.'];
 
-    return latestVersion.validateSdkWellFormed(complain: complain);
+    return latestVersion.validateSdkWellFormed();
   }
 
   String getPlatformToolsPath(String binaryName) {
@@ -215,12 +211,20 @@ class AndroidSdkVersion implements Comparable<AndroidSdkVersion> {
 
   String get zipalignPath => getBuildToolsPath('zipalign');
 
-  bool validateSdkWellFormed({ bool complain: false }) {
-    return
-      _exists(androidJarPath, complain: complain) &&
-      _exists(aaptPath, complain: complain) &&
-      _exists(dxPath, complain: complain) &&
-      _exists(zipalignPath, complain: complain);
+  List<String> validateSdkWellFormed() {
+    if (_exists(androidJarPath) != null)
+      return <String>[_exists(androidJarPath)];
+
+    if (_exists(aaptPath) != null)
+      return <String>[_exists(aaptPath)];
+
+    if (_exists(dxPath) != null)
+      return <String>[_exists(dxPath)];
+
+    if (_exists(zipalignPath) != null)
+      return <String>[_exists(zipalignPath)];
+
+    return <String>[];
   }
 
   String getPlatformsPath(String itemName) {
@@ -237,13 +241,9 @@ class AndroidSdkVersion implements Comparable<AndroidSdkVersion> {
   @override
   String toString() => '[${sdk.directory}, SDK version $sdkLevel, build-tools $buildToolsVersionName]';
 
-  bool _exists(String path, { bool complain: false }) {
-    if (!FileSystemEntity.isFileSync(path)) {
-      if (complain)
-        printError('Android SDK file not found: $path.');
-      return false;
-    }
-
-    return true;
+  String _exists(String path) {
+    if (!FileSystemEntity.isFileSync(path))
+      return 'Android SDK file not found: $path.';
+    return null;
   }
 }

--- a/packages/flutter_tools/lib/src/commands/build_apk.dart
+++ b/packages/flutter_tools/lib/src/commands/build_apk.dart
@@ -178,7 +178,9 @@ class BuildApkCommand extends FlutterCommand {
       return 1;
     }
 
-    if (!androidSdk.validateSdkWellFormed(complain: true)) {
+    List<String> validationResult = androidSdk.validateSdkWellFormed();
+    if (validationResult.isNotEmpty) {
+      validationResult.forEach(printError);
       printError('Try re-installing or updating your Android SDK.');
       return 1;
     }
@@ -375,7 +377,9 @@ Future<int> buildAndroid({
     return 1;
   }
 
-  if (!androidSdk.validateSdkWellFormed(complain: true)) {
+  List<String> validationResult = androidSdk.validateSdkWellFormed();
+  if (validationResult.isNotEmpty) {
+    validationResult.forEach(printError);
     printError('Try re-installing or updating your Android SDK.');
     return 1;
   }

--- a/packages/flutter_tools/lib/src/commands/doctor.dart
+++ b/packages/flutter_tools/lib/src/commands/doctor.dart
@@ -4,10 +4,8 @@
 
 import 'dart:async';
 
-import '../artifacts.dart';
 import '../globals.dart';
 import '../runner/flutter_command.dart';
-import '../runner/version.dart';
 
 class DoctorCommand extends FlutterCommand {
   @override
@@ -21,18 +19,8 @@ class DoctorCommand extends FlutterCommand {
 
   @override
   Future<int> runInProject() async {
-    // general info
-    String flutterRoot = ArtifactStore.flutterRoot;
-    printStatus('Flutter root: $flutterRoot.');
-    printStatus('');
-
     // doctor
     doctor.diagnose();
-    printStatus('');
-
-    // version
-    printStatus(getVersion(flutterRoot));
-
     return 0;
   }
 }

--- a/packages/flutter_tools/lib/src/commands/upgrade.dart
+++ b/packages/flutter_tools/lib/src/commands/upgrade.dart
@@ -22,7 +22,7 @@ class UpgradeCommand extends FlutterCommand {
 
   @override
   Future<int> runInProject() async {
-    printStatus(getVersion(ArtifactStore.flutterRoot));
+    printStatus(FlutterVersion.getVersion(ArtifactStore.flutterRoot).toString());
 
     try {
       runCheckedSync(<String>[
@@ -50,7 +50,7 @@ class UpgradeCommand extends FlutterCommand {
       return code;
 
     printStatus('');
-    printStatus(getVersion(ArtifactStore.flutterRoot));
+    printStatus(FlutterVersion.getVersion(ArtifactStore.flutterRoot).toString());
 
     return 0;
   }

--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -79,7 +79,7 @@ class IOSDevice extends Device {
   bool get supportsStartPaused => false;
 
   static List<IOSDevice> getAttachedDevices([IOSDevice mockIOS]) {
-    if (!doctor.iosWorkflow.hasIdeviceId)
+    if (!doctor.iosWorkflow.hasIDeviceId)
       return <IOSDevice>[];
 
     List<IOSDevice> devices = [];

--- a/packages/flutter_tools/lib/src/ios/ios_workflow.dart
+++ b/packages/flutter_tools/lib/src/ios/ios_workflow.dart
@@ -8,112 +8,96 @@ import '../base/process.dart';
 import '../doctor.dart';
 import 'mac.dart';
 
-class IOSWorkflow extends Workflow {
-  @override
-  String get label => 'iOS toolchain';
+XCode get xcode => XCode.instance;
+
+class IOSWorkflow extends DoctorValidator implements Workflow {
+  IOSWorkflow() : super('iOS toolchain - develop for iOS devices');
 
   @override
   bool get appliesToHostPlatform => Platform.isMacOS;
 
   // We need xcode (+simctl) to list simulator devices, and idevice_id to list real devices.
   @override
-  bool get canListDevices => XCode.instance.isInstalledAndMeetsVersionCheck;
+  bool get canListDevices => xcode.isInstalledAndMeetsVersionCheck;
 
   // We need xcode to launch simulator devices, and ideviceinstaller and ios-deploy
   // for real devices.
   @override
-  bool get canLaunchDevices => XCode.instance.isInstalledAndMeetsVersionCheck;
+  bool get canLaunchDevices => xcode.isInstalledAndMeetsVersionCheck;
+
+  bool get hasIDeviceId => exitsHappy(<String>['idevice_id', '-h']);
 
   @override
   ValidationResult validate() {
-    Validator iosValidator = new Validator(
-      label,
-      description: 'develop for iOS devices'
+    List<ValidationMessage> messages = <ValidationMessage>[];
+    int installCount = 0;
+    String xcodeVersionInfo;
+
+    if (xcode.isInstalled) {
+      installCount++;
+
+      xcodeVersionInfo = xcode.xcodeVersionText;
+      if (xcodeVersionInfo.contains(','))
+        xcodeVersionInfo = xcodeVersionInfo.substring(0, xcodeVersionInfo.indexOf(','));
+
+      messages.add(new ValidationMessage(xcode.xcodeVersionText));
+
+      if (!xcode.isInstalledAndMeetsVersionCheck) {
+        messages.add(new ValidationMessage.error(
+          'Flutter requires a minimum XCode version of $kXcodeRequiredVersionMajor.$kXcodeRequiredVersionMinor.0.\n'
+          'Download the latest version or update via the Mac App Store.'
+        ));
+      }
+
+      if (!xcode.eulaSigned) {
+        messages.add(new ValidationMessage.error(
+          'XCode end user license agreement not signed; open XCode or run the command \'sudo xcodebuild -license\'.'
+        ));
+      }
+    } else {
+      messages.add(new ValidationMessage.error(
+        'XCode not installed; this is necessary for iOS development.\n'
+        'Download at https://developer.apple.com/xcode/download/.'
+      ));
+    }
+
+    // brew installed
+    if (exitsHappy(<String>['brew', '-v'])) {
+      installCount++;
+
+      List<String> installed = <String>[];
+
+      if (!exitsHappy(<String>['ideviceinstaller', '-h'])) {
+        messages.add(new ValidationMessage.error(
+          'ideviceinstaller not available; this is used to discover connected iOS devices.\n'
+          'Install via \'brew install ideviceinstaller\'.'
+        ));
+      } else {
+        installed.add('ideviceinstaller');
+      }
+
+      if (!hasIDeviceId) {
+        messages.add(new ValidationMessage.error(
+          'ios-deploy not available; this is used to deploy to connected iOS devices.\n'
+          'Install via \'brew install ios-deploy\'.'
+        ));
+      } else {
+        installed.add('ios-deploy');
+      }
+
+      if (installed.isNotEmpty)
+          messages.add(new ValidationMessage(installed.join(', ') + ' installed'));
+    } else {
+      messages.add(new ValidationMessage.error(
+        'Brew not installed; use this to install tools for iOS device development.\n'
+        'Download brew at http://brew.sh/.'
+      ));
+    }
+
+    return new ValidationResult(
+      installCount == 2 ? ValidationType.installed : installCount == 1 ? ValidationType.partial : ValidationType.missing,
+      messages,
+      statusInfo: xcodeVersionInfo
     );
-
-    ValidationType xcodeExists() {
-      return XCode.instance.isInstalled ? ValidationType.installed : ValidationType.missing;
-    };
-
-    ValidationType xcodeVersionSatisfactory() {
-      return XCode.instance.isInstalledAndMeetsVersionCheck ? ValidationType.installed : ValidationType.missing;
-    };
-
-    ValidationType xcodeEulaSigned() {
-      return XCode.instance.eulaSigned ? ValidationType.installed : ValidationType.missing;
-    };
-
-    ValidationType brewExists() {
-      return exitsHappy(<String>['brew', '-v'])
-        ? ValidationType.installed : ValidationType.missing;
-    };
-
-    ValidationType ideviceinstallerExists() {
-      return exitsHappy(<String>['ideviceinstaller', '-h'])
-        ? ValidationType.installed : ValidationType.missing;
-    };
-
-    ValidationType iosdeployExists() {
-      return hasIdeviceId ? ValidationType.installed : ValidationType.missing;
-    };
-
-    Validator xcodeValidator = new Validator(
-      'XCode',
-      description: 'enable development for iOS devices',
-      resolution: 'Download at https://developer.apple.com/xcode/download/',
-      validatorFunction: xcodeExists
-    );
-
-    iosValidator.addValidator(xcodeValidator);
-
-    xcodeValidator.addValidator(new Validator(
-      'version',
-      description: 'Xcode minimum version of $kXcodeRequiredVersionMajor.$kXcodeRequiredVersionMinor.0',
-      resolution: 'Download the latest version or update via the Mac App Store',
-      validatorFunction: xcodeVersionSatisfactory
-    ));
-
-    xcodeValidator.addValidator(new Validator(
-      'EULA',
-      description: 'XCode end user license agreement',
-      resolution: "Open XCode or run the command 'sudo xcodebuild -license'",
-      validatorFunction: xcodeEulaSigned
-    ));
-
-    Validator brewValidator = new Validator(
-      'brew',
-      description: 'install additional development packages',
-      resolution: 'Download at http://brew.sh/',
-      validatorFunction: brewExists
-    );
-
-    iosValidator.addValidator(brewValidator);
-
-    brewValidator.addValidator(new Validator(
-      'ideviceinstaller',
-      description: 'discover connected iOS devices',
-      resolution: "Install via 'brew install ideviceinstaller'",
-      validatorFunction: ideviceinstallerExists
-    ));
-
-    brewValidator.addValidator(new Validator(
-      'ios-deploy',
-      description: 'deploy to connected iOS devices',
-      resolution: "Install via 'brew install ios-deploy'",
-      validatorFunction: iosdeployExists
-    ));
-
-    return iosValidator.validate();
-  }
-
-  @override
-  void diagnose() => validate().print();
-
-  bool get hasIdeviceId => exitsHappy(<String>['idevice_id', '-h']);
-
-  /// Return whether the tooling to list and deploy to real iOS devices (not the
-  /// simulator) is installed on the user's machine.
-  bool get canWorkWithIOSDevices {
-    return exitsHappy(<String>['ideviceinstaller', '-h']) && hasIdeviceId;
   }
 }

--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -54,27 +54,24 @@ class XCode {
     }
   }
 
-  bool _xcodeVersionSatisfactory;
+  String _xcodeVersionText;
+
+  String get xcodeVersionText {
+    if (_xcodeVersionText == null)
+      _xcodeVersionText = runSync(<String>['xcodebuild', '-version']).replaceAll('\n', ', ');
+    return _xcodeVersionText;
+  }
+
   bool get xcodeVersionSatisfactory {
-    if (_xcodeVersionSatisfactory != null)
-      return _xcodeVersionSatisfactory;
+    RegExp regex = new RegExp(r'Xcode ([0-9.]+)');
 
-    try {
-      String output = runSync(<String>['xcodebuild', '-version']);
-      RegExp regex = new RegExp(r'Xcode ([0-9.]+)');
+    String version = regex.firstMatch(xcodeVersionText).group(1);
+    List<String> components = version.split('.');
 
-      String version = regex.firstMatch(output).group(1);
-      List<String> components = version.split('.');
+    int major = int.parse(components[0]);
+    int minor = components.length == 1 ? 0 : int.parse(components[1]);
 
-      int major = int.parse(components[0]);
-      int minor = components.length == 1 ? 0 : int.parse(components[1]);
-
-      _xcodeVersionSatisfactory = _xcodeVersionCheckValid(major, minor);
-    } catch (error) {
-      _xcodeVersionSatisfactory = false;
-    }
-
-    return _xcodeVersionSatisfactory;
+    return _xcodeVersionCheckValid(major, minor);
   }
 }
 

--- a/packages/flutter_tools/lib/src/runner/flutter_command_runner.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command_runner.dart
@@ -200,16 +200,8 @@ class FlutterCommandRunner extends CommandRunner {
       }
     }
 
-    if (androidSdk != null) {
-      printTrace('Using Android SDK at ${androidSdk.directory}.');
-      if (androidSdk.latestVersion != null)
-        printTrace('${androidSdk.latestVersion}');
-    }
-
     if (globalResults['version']) {
-      printStatus(getVersion(ArtifactStore.flutterRoot));
-      printStatus('');
-      doctor.summary();
+      printStatus(FlutterVersion.getVersion(ArtifactStore.flutterRoot).toString());
       return new Future<int>.value(0);
     }
 

--- a/packages/flutter_tools/lib/src/runner/version.dart
+++ b/packages/flutter_tools/lib/src/runner/version.dart
@@ -5,26 +5,54 @@
 import '../artifacts.dart';
 import '../base/process.dart';
 
-String getVersion(String flutterRoot) {
-  String upstream = runSync([
-    'git', 'rev-parse', '--abbrev-ref', '--symbolic', '@{u}'
-  ], workingDirectory: flutterRoot).trim();
-  String repository;
-  int slash = upstream.indexOf('/');
-  if (slash != -1) {
-    String remote = upstream.substring(0, slash);
-    repository = runSync([
-      'git', 'ls-remote', '--get-url', remote
-    ], workingDirectory: flutterRoot).trim();
-    upstream = upstream.substring(slash + 1);
+class FlutterVersion {
+  FlutterVersion(this.flutterRoot) {
+    _channel = _runGit('git rev-parse --abbrev-ref --symbolic @{u}');
+
+    int slash = _channel.indexOf('/');
+    if (slash != -1) {
+      String remote = _channel.substring(0, slash);
+      _repositoryUrl = _runGit('git ls-remote --get-url $remote');
+      _channel = _channel.substring(slash + 1);
+    } else if (_channel.isEmpty) {
+      _channel = 'unknown';
+    }
+
+    _frameworkRevision = _runGit('git log -n 1 --pretty=format:%H');
+    _frameworkAge = _runGit('git log -n 1 --pretty=format:%ar');
   }
-  String revision = runSync([
-    'git', 'log', '-n', '1', '--pretty=format:%H (%ar)'
-  ], workingDirectory: flutterRoot).trim();
 
-  String from = repository == null ? 'Flutter from unknown source' : 'Flutter from $repository (on $upstream)';
-  String flutterVersion = 'Framework: $revision';
-  String engineRevision = 'Engine:    ${ArtifactStore.engineRevision}';
+  final String flutterRoot;
 
-  return '$from\n$flutterVersion\n$engineRevision';
+  String _repositoryUrl;
+  String get repositoryUrl => _repositoryUrl;
+
+  String _channel;
+  /// `master`, `alpha`, `hackathon`, ...
+  String get channel => _channel;
+
+  String _frameworkRevision;
+  String get frameworkRevision => _frameworkRevision;
+  String get frameworkRevisionShort => _runGit('git rev-parse --short $frameworkRevision');
+
+  String _frameworkAge;
+  String get frameworkAge => _frameworkAge;
+
+  String get engineRevision => ArtifactStore.engineRevision;
+  String get engineRevisionShort => _runGit('git rev-parse --short $engineRevision');
+
+  String _runGit(String command) => runSync(command.split(' '), workingDirectory: flutterRoot);
+
+  @override
+  String toString() {
+    String from = repositoryUrl == null ? 'Flutter from unknown source' : 'Flutter from $repositoryUrl (on channel $channel)';
+    String flutterText = 'Framework: $frameworkRevisionShort ($frameworkAge)';
+    String engineText =  'Engine:    $engineRevisionShort';
+
+    return '$from\n\n$flutterText\n$engineText';
+  }
+
+  static FlutterVersion getVersion([String flutterRoot]) {
+    return new FlutterVersion(flutterRoot != null ? flutterRoot : ArtifactStore.flutterRoot);
+  }
 }


### PR DESCRIPTION
Re-work the doctor command:
- it's easier to add arbitrary messages to the doctor output (they can show up as either errors or just messages)
- the presentation is flatter, instead of nested
- we can now show version info for installed components better

This should also do a better job of diagnosing why we couldn't run some android launches (missing some android sdk components).

```
[✓] Flutter (a8c03d6 on channel )
    • Flutter root at /Users/devoncarew/projects/flutter/flutter
    • Framework revision a8c03d6 (49 seconds ago)
    • Engine revision b7419de

[✓] Android toolchain - develop for Android devices (Android SDK 23.0.2)
    • Android SDK at /Users/devoncarew/tools/android-sdk-macosx
    • Platform android-23
    • Build-tools 23.0.2

[✓] iOS toolchain - enable development for iOS devices (Xcode 7.2.1)
    • Xcode 7.2.1, Build version 7C1002

[✓] Atom - a lightweight development environment for Flutter
    • Flutter plugin version 0.2.1
```

fix https://github.com/flutter/flutter/issues/2132
