### PR TITLE
filter some noisy messages from adb logcat

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_device.dart
+++ b/packages/flutter_tools/lib/src/android/android_device.dart
@@ -381,7 +381,7 @@ class AndroidDevice extends Device {
     if (tracePath != null) {
       String localPath = (outPath != null) ? outPath : path.basename(tracePath);
 
-      // Run cat via ADB to print the captured trace file.  (adb pull will be unable
+      // Run cat via ADB to print the captured trace file. (adb pull will be unable
       // to access the file if it does not have root permissions)
       IOSink catOutput = new File(localPath).openWrite();
       List<String> catCommand = adbCommandForDevice(
@@ -566,6 +566,10 @@ class _AdbLogReader extends DeviceLogReader {
   }
 
   void _onLine(String line) {
+    // Filter out some noisy ActivityManager notifications.
+    if (line.startsWith('W/ActivityManager: getRunningAppProcesses'))
+      return;
+
     _linesStreamController.add(line);
   }
 


### PR DESCRIPTION
- filter some messages from adb logcat - fix https://github.com/flutter/flutter/issues/2853

We do get some messages on `W/ActivityManager` related to the user's app, otherwise I think we could just not include this category.

Messages we get (which we want):

```
W/ActivityManager: Force removing ActivityRecord{35fcfc4e u0 com.example.flutter_sunflower/org.domokit.sky.shell.SkyActivity t1103}: app died, no saved state
```

and messages which we're filtering:

```
W/ActivityManager: getRunningAppProcesses: caller 10014 does not hold REAL_GET_TASKS; limiting output
```
