### PR TITLE
print the os from flutter doctor

### DIFF
--- a/packages/flutter_tools/lib/src/doctor.dart
+++ b/packages/flutter_tools/lib/src/doctor.dart
@@ -14,6 +14,18 @@ import 'globals.dart';
 import 'ios/ios_workflow.dart';
 import 'runner/version.dart';
 
+
+const Map<String, String> _osNames = const <String, String>{
+  'macos': 'Mac OS',
+  'linux': 'Linux',
+  'windows': 'Windows'
+};
+
+String osName() {
+  String os = Platform.operatingSystem;
+  return _osNames.containsKey(os) ? _osNames[os] : os;
+}
+
 class Doctor {
   Doctor() {
     _validators.add(new _FlutterValidator());
@@ -179,11 +191,10 @@ class _FlutterValidator extends DoctorValidator {
 
     messages.add(new ValidationMessage('Flutter root at ${version.flutterRoot}'));
     messages.add(new ValidationMessage('Framework revision ${version.frameworkRevisionShort} '
-      '(${version.frameworkAge})'));
+      '(${version.frameworkAge}, channel ${version.channel})'));
     messages.add(new ValidationMessage('Engine revision ${version.engineRevisionShort}'));
 
-    return new ValidationResult(ValidationType.installed, messages,
-      statusInfo: '${version.frameworkRevisionShort} - channel ${version.channel}');
+    return new ValidationResult(ValidationType.installed, messages, statusInfo: osName());
   }
 }
 

--- a/packages/flutter_tools/lib/src/runner/flutter_command_runner.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command_runner.dart
@@ -49,8 +49,8 @@ class FlutterCommandRunner extends CommandRunner {
         hide: !verboseHelp,
         help: 'Path to your packages directory.$packagesHelp');
     argParser.addOption('flutter-root',
-        help: 'The root directory of the Flutter repository. Uses \$$kFlutterRootEnvironmentVariableName if set,\n'
-              'otherwise defaults to a value derived from the location of this tool.', defaultsTo: _defaultFlutterRoot);
+        help: 'The root directory of the Flutter repository (uses \$$kFlutterRootEnvironmentVariableName if set).',
+              defaultsTo: _defaultFlutterRoot);
 
     if (verboseHelp)
       argParser.addSeparator('Local build selection options (not normally required):');
@@ -126,9 +126,7 @@ class FlutterCommandRunner extends CommandRunner {
 
   @override
   String get usageFooter {
-    return 'Run "flutter -h -v" for verbose help output, including less commonly used options.\n'
-           '\n'
-           '${doctor.summaryText}';
+    return 'Run "flutter -h -v" for verbose help output, including less commonly used options.';
   }
 
   List<BuildConfiguration> get buildConfigurations {


### PR DESCRIPTION
- print the OS from flutter doctor (fix https://github.com/flutter/flutter/issues/2173)
- don't show the doctor summary in flutter -h (fix https://github.com/flutter/flutter/issues/2169, and perhaps also fix https://github.com/flutter/flutter/issues/2863)

```
[✓] Flutter (macos)
    • Flutter root at /Users/devoncarew/projects/flutter/flutter
    • Framework revision d7e4f78 (12 minutes ago, channel master)
    • Engine revision b7419de
...
```
