### PR TITLE
Support hairline borders

### DIFF
--- a/dev/manual_tests/drag_and_drop.dart
+++ b/dev/manual_tests/drag_and_drop.dart
@@ -64,7 +64,7 @@ class DotState extends State<Dot> {
         height: config.size,
         decoration: new BoxDecoration(
           backgroundColor: config.color,
-          border: new Border.all(color: const Color(0xFF000000), width: taps.toDouble()),
+          border: new Border.all(width: taps.toDouble()),
           shape: BoxShape.circle
         ),
         child: config.child

--- a/examples/layers/widgets/sectors.dart
+++ b/examples/layers/widgets/sectors.dart
@@ -134,7 +134,7 @@ class SectorAppState extends State<SectorApp> {
           child: new Container(
             margin: new EdgeInsets.all(8.0),
             decoration: new BoxDecoration(
-              border: new Border.all(color: new Color(0xFF000000))
+              border: new Border.all()
             ),
             padding: new EdgeInsets.all(8.0),
             child: new WidgetToRenderBoxAdapter(

--- a/examples/material_gallery/lib/demo/list_demo.dart
+++ b/examples/material_gallery/lib/demo/list_demo.dart
@@ -42,7 +42,7 @@ class ListDemoState extends State<ListDemo> {
     _bottomSheet = scaffoldKey.currentState.showBottomSheet((BuildContext bottomSheetContext) {
       return new Container(
         decoration: new BoxDecoration(
-          border: new Border(top: new BorderSide(color: Colors.black26, width: 1.0))
+          border: new Border(top: new BorderSide(color: Colors.black26))
         ),
         child: new Column(
           mainAxisAlignment: MainAxisAlignment.collapse,

--- a/examples/material_gallery/lib/demo/persistent_bottom_sheet_demo.dart
+++ b/examples/material_gallery/lib/demo/persistent_bottom_sheet_demo.dart
@@ -16,7 +16,7 @@ class PersistentBottomSheetDemo extends StatelessWidget {
     Scaffold.of(context).showBottomSheet((_) {
       return new Container(
         decoration: new BoxDecoration(
-          border: new Border(top: new BorderSide(color: Colors.black26, width: 1.0))
+          border: new Border(top: new BorderSide(color: Colors.black26))
         ),
         child: new Padding(
           padding: const EdgeInsets.all(32.0),

--- a/examples/stocks/lib/stock_symbol_viewer.dart
+++ b/examples/stocks/lib/stock_symbol_viewer.dart
@@ -100,7 +100,7 @@ class StockSymbolBottomSheet extends StatelessWidget {
     return new Container(
       padding: new EdgeInsets.all(10.0),
       decoration: new BoxDecoration(
-        border: new Border(top: new BorderSide(color: Colors.black26, width: 1.0))
+        border: new Border(top: new BorderSide(color: Colors.black26))
       ),
       child: new StockSymbolView(stock: stock)
    );


### PR DESCRIPTION
Previously, border with '0' was ambiguous. Sometimes we treated it as
hairline borders, sometimes as "don't show the border", though even in
the latter case we did some graphics work sometimes. Now we have an
explicit BorderStyle.none flag to not draw the border efficiently.
