### PR TITLE
several fixes to the doctor command

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_workflow.dart
+++ b/packages/flutter_tools/lib/src/android/android_workflow.dart
@@ -2,6 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:io';
+
+import '../base/os.dart';
 import '../doctor.dart';
 import '../globals.dart';
 import 'android_sdk.dart';
@@ -37,14 +40,47 @@ class AndroidWorkflow extends DoctorValidator implements Workflow {
       if (androidSdk.latestVersion != null) {
         sdkVersionText = 'Android SDK ${androidSdk.latestVersion.buildToolsVersionName}';
 
-        messages.add(new ValidationMessage('Platform ${androidSdk.latestVersion.platformVersionName}'));
-        messages.add(new ValidationMessage('Build-tools ${androidSdk.latestVersion.buildToolsVersionName}'));
+        messages.add(new ValidationMessage(
+          'Platform ${androidSdk.latestVersion.platformVersionName}, '
+          'build-tools ${androidSdk.latestVersion.buildToolsVersionName}'
+        ));
       }
 
       List<String> validationResult = androidSdk.validateSdkWellFormed();
 
       if (validationResult.isEmpty) {
-        type = ValidationType.installed;
+        const String _kJdkDownload = 'https://www.oracle.com/technetwork/java/javase/downloads/';
+
+        String javaVersion;
+
+        try {
+          printTrace('java -version');
+
+          ProcessResult result = Process.runSync('java', <String>['-version']);
+          if (result.exitCode == 0) {
+            javaVersion = result.stderr;
+            List<String> versionLines = javaVersion.split('\n');
+            javaVersion = versionLines.length >= 2 ? versionLines[1] : versionLines[0];
+          }
+        } catch (error) {
+        }
+
+        if (javaVersion != null) {
+          type = ValidationType.installed;
+
+          messages.add(new ValidationMessage(javaVersion));
+
+          if (os.which('jarsigner') == null) {
+            messages.add(new ValidationMessage.error(
+              'The jarsigner utility was not found; this is used to build Android APKs. You may need to install\n'
+              'or re-install the Java JDK: $_kJdkDownload.'
+            ));
+          }
+        } else {
+          messages.add(new ValidationMessage.error(
+            'No Java SDK found; you can download Java from $_kJdkDownload.'
+          ));
+        }
       } else {
         messages.addAll(validationResult.map((String message) {
           return new ValidationMessage.error(message);

--- a/packages/flutter_tools/lib/src/doctor.dart
+++ b/packages/flutter_tools/lib/src/doctor.dart
@@ -189,12 +189,15 @@ class _FlutterValidator extends DoctorValidator {
 
     FlutterVersion version = FlutterVersion.getVersion();
 
-    messages.add(new ValidationMessage('Flutter root at ${version.flutterRoot}'));
-    messages.add(new ValidationMessage('Framework revision ${version.frameworkRevisionShort} '
-      '(${version.frameworkAge}, channel ${version.channel})'));
-    messages.add(new ValidationMessage('Engine revision ${version.engineRevisionShort}'));
+    messages.add(new ValidationMessage('Flutter at ${version.flutterRoot}'));
+    messages.add(new ValidationMessage(
+      'Framework revision ${version.frameworkRevisionShort} '
+      '(${version.frameworkAge}), '
+      'engine revision ${version.engineRevisionShort}'
+    ));
 
-    return new ValidationResult(ValidationType.installed, messages, statusInfo: osName());
+    return new ValidationResult(ValidationType.installed, messages,
+      statusInfo: 'on ${osName()}, channel ${version.channel}');
   }
 }
 
@@ -238,7 +241,7 @@ class _AtomValidator extends DoctorValidator {
         File packageFile = new File(path.join(flutterPluginPath, 'package.json'));
         dynamic packageInfo = JSON.decode(packageFile.readAsStringSync());
         String version = packageInfo['version'];
-        messages.add(new ValidationMessage('Atom installed; flutter plugin version $version'));
+        messages.add(new ValidationMessage('Atom installed; Flutter plugin version $version'));
       } catch (error) {
         printTrace('Unable to read flutter plugin version: $error');
       }

--- a/packages/flutter_tools/lib/src/ios/ios_workflow.dart
+++ b/packages/flutter_tools/lib/src/ios/ios_workflow.dart
@@ -4,6 +4,7 @@
 
 import 'dart:io';
 
+import '../base/os.dart';
 import '../base/process.dart';
 import '../doctor.dart';
 import 'mac.dart';
@@ -36,10 +37,11 @@ class IOSWorkflow extends DoctorValidator implements Workflow {
     if (xcode.isInstalled) {
       installCount++;
 
+      messages.add(new ValidationMessage('XCode at ${xcode.xcodeSelectPath}'));
+
       xcodeVersionInfo = xcode.xcodeVersionText;
       if (xcodeVersionInfo.contains(','))
         xcodeVersionInfo = xcodeVersionInfo.substring(0, xcodeVersionInfo.indexOf(','));
-
       messages.add(new ValidationMessage(xcode.xcodeVersionText));
 
       if (!xcode.isInstalledAndMeetsVersionCheck) {
@@ -62,18 +64,14 @@ class IOSWorkflow extends DoctorValidator implements Workflow {
     }
 
     // brew installed
-    if (exitsHappy(<String>['brew', '-v'])) {
+    if (os.which('brew') != null) {
       installCount++;
-
-      List<String> installed = <String>[];
 
       if (!exitsHappy(<String>['ideviceinstaller', '-h'])) {
         messages.add(new ValidationMessage.error(
           'ideviceinstaller not available; this is used to discover connected iOS devices.\n'
           'Install via \'brew install ideviceinstaller\'.'
         ));
-      } else {
-        installed.add('ideviceinstaller');
       }
 
       if (!hasIDeviceId) {
@@ -81,12 +79,7 @@ class IOSWorkflow extends DoctorValidator implements Workflow {
           'ios-deploy not available; this is used to deploy to connected iOS devices.\n'
           'Install via \'brew install ios-deploy\'.'
         ));
-      } else {
-        installed.add('ios-deploy');
       }
-
-      if (installed.isNotEmpty)
-          messages.add(new ValidationMessage(installed.join(', ') + ' installed'));
     } else {
       messages.add(new ValidationMessage.error(
         'Brew not installed; use this to install tools for iOS device development.\n'

--- a/packages/flutter_tools/lib/src/runner/version.dart
+++ b/packages/flutter_tools/lib/src/runner/version.dart
@@ -45,11 +45,10 @@ class FlutterVersion {
 
   @override
   String toString() {
-    String from = repositoryUrl == null ? 'Flutter from unknown source' : 'Flutter from $repositoryUrl (on channel $channel)';
-    String flutterText = 'Framework: $frameworkRevisionShort ($frameworkAge)';
-    String engineText =  'Engine:    $engineRevisionShort';
+    String from = 'Flutter on channel $channel (from ${repositoryUrl == null ? 'unknown source' : repositoryUrl})';
+    String flutterText = 'Framework revision $frameworkRevisionShort ($frameworkAge); engine revision $engineRevisionShort';
 
-    return '$from\n\n$flutterText\n$engineText';
+    return '$from\n$flutterText';
   }
 
   static FlutterVersion getVersion([String flutterRoot]) {


### PR DESCRIPTION
- for android, verify that we can find a JDK (fix https://github.com/flutter/flutter/issues/1983)
- look for and complain if we can't find jarsigner (fix https://github.com/flutter/flutter/issues/2327)
- print out the path from `xcode-select` - show which xcode we're using

```
[✓] Flutter (on Mac OS, channel master)
    • Flutter at /Users/devoncarew/projects/flutter/flutter
    • Framework revision dff356f (77 minutes ago), engine revision b7419de

[✓] Android toolchain - develop for Android devices (Android SDK 23.0.2)
    • Android SDK at /Users/devoncarew/tools/android-sdk-macosx
    • Platform android-23, build-tools 23.0.2
    • Java(TM) SE Runtime Environment (build 1.8.0_72-b15)

[✓] iOS toolchain - develop for iOS devices (Xcode 7.2.1)
    • XCode at /Applications/Xcode.app/Contents/Developer
    • Xcode 7.2.1, Build version 7C1002

[✓] Atom - a lightweight development environment for Flutter
    • Atom installed; Flutter plugin version 0.2.1
```

flutter --version:

```
Flutter on channel master (from https://github.com/flutter/flutter.git)
Framework revision dff356f (77 minutes ago); engine revision b7419de
```
