### PR TITLE
Clean up prints in services/*

### DIFF
--- a/packages/flutter/lib/src/http/mojo_client.dart
+++ b/packages/flutter/lib/src/http/mojo_client.dart
@@ -149,8 +149,14 @@ class MojoClient {
       ByteData data = await mojo.DataPipeDrainer.drainHandle(response.body);
       Uint8List bodyBytes = new Uint8List.view(data.buffer);
       return new Response(bodyBytes: bodyBytes, statusCode: response.statusCode);
-    } catch (e) {
-      print("NetworkService unavailable $e");
+    } catch (exception) {
+      assert(() {
+        debugPrint('-- EXCEPTION CAUGHT BY NETWORKING HTTP LIBRARY -------------------------');
+        debugPrint('An exception was raised while sending bytes to the Mojo network library:');
+        debugPrint('$exception');
+        debugPrint('------------------------------------------------------------------------');
+        return true;
+      });
       return new Response(statusCode: 500);
     } finally {
       loader.close();

--- a/packages/flutter/lib/src/services/image_cache.dart
+++ b/packages/flutter/lib/src/services/image_cache.dart
@@ -52,15 +52,14 @@ class _UrlFetcher implements ImageProvider {
 
   @override
   Future<ImageInfo> loadImage() async {
-    UrlResponse response = await fetchUrl(_url);
-    if (response.statusCode >= 400) {
-      print("Failed (${response.statusCode}) to load image $_url");
-      return null;
+    UrlResponse response = await fetchUrl(_url, require200: true);
+    if (response != null) {
+      return new ImageInfo(
+        image: await decodeImageFromDataPipe(response.body),
+        scale: _scale
+      );
     }
-    return new ImageInfo(
-      image: await decodeImageFromDataPipe(response.body),
-      scale: _scale
-    );
+    return null;
   }
 
   @override


### PR DESCRIPTION
We really shouldn't have two separate network library wrappers... I filed https://github.com/flutter/flutter/issues/2889 on that. But for now, this makes one of them have a generally better error handling story, and makes the other one only dump to the console in debug mode. It also makes both use debugPrint instead of print, and makes one use the 'mojom' prefix for mojom imports.

Fixes https://github.com/flutter/flutter/issues/2807
