### PR TITLE
Add a default MediaQuery value

### DIFF
--- a/examples/material_gallery/lib/demo/flexible_space_demo.dart
+++ b/examples/material_gallery/lib/demo/flexible_space_demo.dart
@@ -82,7 +82,7 @@ class FlexibleSpaceDemoState extends State<FlexibleSpaceDemo> {
 
   @override
   Widget build(BuildContext context) {
-    final double statusBarHeight = (MediaQuery.of(context)?.padding ?? EdgeInsets.zero).top;
+    final double statusBarHeight = MediaQuery.of(context).padding.top;
     return new Theme(
       data: new ThemeData(
         brightness: ThemeBrightness.light,

--- a/examples/material_gallery/lib/demo/tabs_demo.dart
+++ b/examples/material_gallery/lib/demo/tabs_demo.dart
@@ -35,7 +35,7 @@ class TabsDemoState extends State<TabsDemo> {
 
   @override
   Widget build(BuildContext context) {
-    final double statusBarHeight = (MediaQuery.of(context)?.padding ?? EdgeInsets.zero).top;
+    final double statusBarHeight = MediaQuery.of(context).padding.top;
     return new TabBarSelection<_Page>(
       values: _pages,
       onChanged: (_Page value) {

--- a/examples/material_gallery/lib/gallery/section.dart
+++ b/examples/material_gallery/lib/gallery/section.dart
@@ -25,7 +25,7 @@ class GallerySection extends StatelessWidget {
   }
 
   void showDemos(BuildContext context) {
-    final double statusBarHeight = (MediaQuery.of(context)?.padding ?? EdgeInsets.zero).top;
+    final double statusBarHeight = MediaQuery.of(context).padding.top;
     final ThemeData theme = new ThemeData(
       brightness: Theme.of(context).brightness,
       primarySwatch: colors

--- a/packages/flutter/lib/src/material/app_bar.dart
+++ b/packages/flutter/lib/src/material/app_bar.dart
@@ -110,7 +110,7 @@ class AppBar extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final double statusBarHeight = (MediaQuery.of(context)?.padding ?? EdgeInsets.zero).top;
+    final double statusBarHeight = MediaQuery.of(context).padding.top;
     final ThemeData theme = Theme.of(context);
 
     IconThemeData iconTheme = theme.primaryIconTheme;

--- a/packages/flutter/lib/src/material/drawer_header.dart
+++ b/packages/flutter/lib/src/material/drawer_header.dart
@@ -20,7 +20,7 @@ class DrawerHeader extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     assert(debugCheckHasMaterial(context));
-    final double statusBarHeight = (MediaQuery.of(context)?.padding ?? EdgeInsets.zero).top;
+    final double statusBarHeight = MediaQuery.of(context).padding.top;
     return new Container(
       height: statusBarHeight + kMaterialDrawerHeight,
       decoration: new BoxDecoration(

--- a/packages/flutter/lib/src/material/flexible_space_bar.dart
+++ b/packages/flutter/lib/src/material/flexible_space_bar.dart
@@ -25,7 +25,7 @@ class _FlexibleSpaceBarState extends State<FlexibleSpaceBar> {
   @override
   Widget build(BuildContext context) {
     assert(debugCheckHasScaffold(context));
-    final double statusBarHeight = (MediaQuery.of(context)?.padding ?? EdgeInsets.zero).top;
+    final double statusBarHeight = MediaQuery.of(context).padding.top;
     final Animation<double> animation = Scaffold.of(context).appBarAnimation;
     final double appBarHeight = Scaffold.of(context).appBarHeight + statusBarHeight;
     final double toolBarHeight = kToolBarHeight + statusBarHeight;

--- a/packages/flutter/lib/src/material/scaffold.dart
+++ b/packages/flutter/lib/src/material/scaffold.dart
@@ -453,7 +453,7 @@ class ScaffoldState extends State<Scaffold> {
   }
 
   Widget _buildScrollableAppBar(BuildContext context) {
-    final EdgeInsets padding = MediaQuery.of(context)?.padding ?? EdgeInsets.zero;
+    final EdgeInsets padding = MediaQuery.of(context).padding;
     final double expandedHeight = (config.appBar?.expandedHeight ?? 0.0) + padding.top;
     final double collapsedHeight = (config.appBar?.collapsedHeight ?? 0.0) + padding.top;
     final double minimumHeight = (config.appBar?.minimumHeight ?? 0.0) + padding.top;
@@ -500,7 +500,7 @@ class ScaffoldState extends State<Scaffold> {
 
   @override
   Widget build(BuildContext context) {
-    final EdgeInsets padding = MediaQuery.of(context)?.padding ?? EdgeInsets.zero;
+    final EdgeInsets padding = MediaQuery.of(context).padding;
 
     if (_snackBars.length > 0) {
       final ModalRoute<dynamic> route = ModalRoute.of(context);

--- a/packages/flutter/lib/src/painting/edge_insets.dart
+++ b/packages/flutter/lib/src/painting/edge_insets.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:ui' as ui show lerpDouble;
+import 'dart:ui' as ui show lerpDouble, WindowPadding;
 
 import 'basic_types.dart';
 
@@ -23,20 +23,26 @@ class EdgeInsets {
 
   /// Constructs insets where all the offsets are value.
   const EdgeInsets.all(double value)
-      : top = value, right = value, bottom = value, left = value;
+      : left = value, top = value, right = value, bottom = value;
 
   /// Constructs insets with only the given values non-zero.
   const EdgeInsets.only({
+    this.left: 0.0,
     this.top: 0.0,
     this.right: 0.0,
-    this.bottom: 0.0,
-    this.left: 0.0
+    this.bottom: 0.0
   });
 
   /// Constructs insets with symmetrical vertical and horizontal offsets.
   const EdgeInsets.symmetric({ double vertical: 0.0,
                              double horizontal: 0.0 })
-    : top = vertical, left = horizontal, bottom = vertical, right = horizontal;
+    : left = horizontal, top = vertical, right = horizontal, bottom = vertical;
+
+  EdgeInsets.fromWindowPadding(ui.WindowPadding padding)
+    : left = padding.left, top = padding.top, right = padding.right, bottom = padding.bottom;
+
+  /// The offset from the left.
+  final double left;
 
   /// The offset from the top.
   final double top;
@@ -47,11 +53,8 @@ class EdgeInsets {
   /// The offset from the bottom.
   final double bottom;
 
-  /// The offset from the left.
-  final double left;
-
   /// Whether every dimension is non-negative.
-  bool get isNonNegative => top >= 0.0 && right >= 0.0 && bottom >= 0.0 && left >= 0.0;
+  bool get isNonNegative => left >= 0.0 && top >= 0.0 && right >= 0.0 && bottom >= 0.0;
 
   /// The total offset in the vertical direction.
   double get horizontal => left + right;
@@ -151,15 +154,15 @@ class EdgeInsets {
     if (other is! EdgeInsets)
       return false;
     final EdgeInsets typedOther = other;
-    return top == typedOther.top &&
+    return left == typedOther.left &&
+           top == typedOther.top &&
            right == typedOther.right &&
-           bottom == typedOther.bottom &&
-           left == typedOther.left;
+           bottom == typedOther.bottom;
   }
 
   @override
-  int get hashCode => hashValues(top, left, bottom, right);
+  int get hashCode => hashValues(left, top, right, bottom);
 
   @override
-  String toString() => "EdgeInsets($top, $right, $bottom, $left)";
+  String toString() => "EdgeInsets($left, $top, $right, $bottom)";
 }

--- a/packages/flutter/lib/src/widgets/app.dart
+++ b/packages/flutter/lib/src/widgets/app.dart
@@ -104,10 +104,6 @@ class WidgetsApp extends StatefulWidget {
   WidgetsAppState<WidgetsApp> createState() => new WidgetsAppState<WidgetsApp>();
 }
 
-EdgeInsets _getPadding(ui.WindowPadding padding) {
-  return new EdgeInsets.fromLTRB(padding.left, padding.top, padding.right, padding.bottom);
-}
-
 class WidgetsAppState<T extends WidgetsApp> extends State<T> implements BindingObserver {
 
   GlobalObjectKey _navigator;
@@ -173,11 +169,7 @@ class WidgetsAppState<T extends WidgetsApp> extends State<T> implements BindingO
     }
 
     Widget result = new MediaQuery(
-      data: new MediaQueryData(
-        size: ui.window.size,
-        devicePixelRatio: ui.window.devicePixelRatio,
-        padding: _getPadding(ui.window.padding)
-      ),
+      data: new MediaQueryData.fromWindow(ui.window),
       child: new LocaleQuery(
         data: _localeData,
         child: new AssetVendor(

--- a/packages/flutter/lib/src/widgets/child_view.dart
+++ b/packages/flutter/lib/src/widgets/child_view.dart
@@ -4,7 +4,6 @@
 
 import 'package:flutter/rendering.dart';
 
-import 'debug.dart';
 import 'framework.dart';
 import 'media_query.dart';
 
@@ -17,7 +16,6 @@ class ChildView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    assert(debugCheckHasMediaQuery(context));
     return new _ChildViewWidget(
       child: child,
       scale: MediaQuery.of(context).devicePixelRatio

--- a/packages/flutter/lib/src/widgets/debug.dart
+++ b/packages/flutter/lib/src/widgets/debug.dart
@@ -5,25 +5,6 @@
 import 'dart:collection';
 
 import 'framework.dart';
-import 'media_query.dart';
-
-bool debugCheckHasMediaQuery(BuildContext context) {
-  assert(() {
-    if (MediaQuery.of(context) == null) {
-      Element element = context;
-      throw new FlutterError(
-        'No MediaQuery widget found.\n'
-        '${element.widget.runtimeType} widgets require a MediaQuery widget ancestor.\n'
-        'The specific widget that could not find a MediaQuery ancestor was:\n'
-        '  ${element.widget}'
-        'The ownership chain for the affected widget is:\n'
-        '  ${element.debugGetOwnershipChain(10)}'
-      );
-    }
-    return true;
-  });
-  return true;
-}
 
 Key _firstNonUniqueKey(Iterable<Widget> widgets) {
   Set<Key> keySet = new HashSet<Key>();

--- a/packages/flutter/lib/src/widgets/focus.dart
+++ b/packages/flutter/lib/src/widgets/focus.dart
@@ -300,14 +300,12 @@ class _FocusState extends State<Focus> {
   @override
   Widget build(BuildContext context) {
     MediaQueryData data = MediaQuery.of(context);
-    if (data != null) {
-      Size newMediaSize = data.size;
-      EdgeInsets newMediaPadding = data.padding;
-      if (newMediaSize != _mediaSize || newMediaPadding != _mediaPadding) {
-        _mediaSize = newMediaSize;
-        _mediaPadding = newMediaPadding;
-        scheduleMicrotask(_ensureVisibleIfFocused);
-      }
+    Size newMediaSize = data.size;
+    EdgeInsets newMediaPadding = data.padding;
+    if (newMediaSize != _mediaSize || newMediaPadding != _mediaPadding) {
+      _mediaSize = newMediaSize;
+      _mediaPadding = newMediaPadding;
+      scheduleMicrotask(_ensureVisibleIfFocused);
     }
     return new Semantics(
       container: true,

--- a/packages/flutter/lib/src/widgets/media_query.dart
+++ b/packages/flutter/lib/src/widgets/media_query.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:ui' as ui;
+
 import 'basic.dart';
 import 'framework.dart';
 
@@ -17,6 +19,11 @@ enum Orientation {
 /// The result of a media query.
 class MediaQueryData {
   const MediaQueryData({ this.size, this.devicePixelRatio, this.padding });
+
+  MediaQueryData.fromWindow(ui.Window window)
+    : size = window.size,
+      devicePixelRatio = window.devicePixelRatio,
+      padding = new EdgeInsets.fromWindowPadding(window.padding);
 
   /// The size of the media (e.g, the size of the screen).
   final Size size;
@@ -76,7 +83,7 @@ class MediaQuery extends InheritedWidget {
   /// keeping your widget up-to-date.
   static MediaQueryData of(BuildContext context) {
     MediaQuery query = context.inheritFromWidgetOfExactType(MediaQuery);
-    return query == null ? null : query.data;
+    return query?.data ?? new MediaQueryData.fromWindow(ui.window);
   }
 
   @override

--- a/packages/flutter/test/widget/media_query_test.dart
+++ b/packages/flutter/test/widget/media_query_test.dart
@@ -1,0 +1,28 @@
+// Copyright 2015 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:ui' as ui;
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter/widgets.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('MediaQuery has a default', () {
+    testWidgets((WidgetTester tester) {
+      Size size;
+
+      tester.pumpWidget(
+        new Builder(
+          builder: (BuildContext context) {
+            size = MediaQuery.of(context).size;
+            return new Container();
+          }
+        )
+      );
+
+      expect(size, equals(ui.window.size));
+    });
+  });
+}


### PR DESCRIPTION
Now MediaQuery.of always returns a non-null value. By default, you get the
values associated with the current ui.Window.

Fixes #2894
