### PR TITLE
Fix app bar padding without leading widget

### DIFF
--- a/packages/flutter/lib/src/material/app_bar.dart
+++ b/packages/flutter/lib/src/material/app_bar.dart
@@ -134,16 +134,18 @@ class AppBar extends StatelessWidget {
     }
 
     final List<Widget> toolBarRow = <Widget>[];
-    if (leading != null)
-      toolBarRow.add(leading);
-    toolBarRow.add(
-      new Flexible(
-        child: new Padding(
-          padding: new EdgeInsets.only(left: 24.0),
-          child: title != null ? new DefaultTextStyle(style: centerStyle, child: title) : null
-        )
+    if (leading != null) {
+      toolBarRow.add(new Padding(
+        padding: new EdgeInsets.only(right: 16.0),
+        child: leading
+      ));
+    }
+    toolBarRow.add(new Flexible(
+      child: new Padding(
+        padding: new EdgeInsets.only(left: 8.0),
+        child: title != null ? new DefaultTextStyle(style: centerStyle, child: title) : null
       )
-    );
+    ));
     if (actions != null)
       toolBarRow.addAll(actions);
 


### PR DESCRIPTION
If there's no leading widget, we just want 8.0 pixels of padding instead of all
the padding to get over to the 72.0 pixel key line.

Fixes #2912
