### PR TITLE
Add a Key to FlutterDemo widget

### DIFF
--- a/packages/flutter_tools/templates/create/lib/main.dart.tmpl
+++ b/packages/flutter_tools/templates/create/lib/main.dart.tmpl
@@ -20,6 +20,8 @@ void main() {
 }
 
 class FlutterDemo extends StatefulWidget {
+  FlutterDemo({ Key key }) : super(key: key);
+
   @override
   _FlutterDemoState createState() => new _FlutterDemoState();
 }


### PR DESCRIPTION
It's a good practice to let clients supply a key for every widget.

Fixes #2910
