### PR TITLE
upgrade to test 0.12.13

### DIFF
--- a/examples/hello_android/app/src/flutter/lib/main.dart
+++ b/examples/hello_android/app/src/flutter/lib/main.dart
@@ -7,8 +7,8 @@ import 'dart:convert';
 import 'dart:math';
 
 import 'package:flutter/material.dart';
-import 'package:flutter/widgets.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
 
 final Random random = new Random();
 
@@ -43,7 +43,7 @@ class _HelloAndroidState extends State<HelloAndroid> {
               child: new Text('Get Location'),
               onPressed: _getLocation
             ),
-            new Text('Latitude: ${_latitude}, Longitude: ${_longitude}'),
+            new Text('Latitude: $_latitude, Longitude: $_longitude'),
           ]
         )
       )

--- a/packages/flutter_test/pubspec.yaml
+++ b/packages/flutter_test/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_test
 dependencies:
-  test: 0.12.11+1
+  test: 0.12.13
   quiver: ^0.21.4
   flutter:
     path: ../flutter

--- a/packages/flutter_tools/pubspec.yaml
+++ b/packages/flutter_tools/pubspec.yaml
@@ -19,7 +19,7 @@ dependencies:
   path: ^1.3.0
   pub_semver: ^1.0.0
   stack_trace: ^1.4.0
-  test: 0.12.11+1 # see note below
+  test: 0.12.13 # see note below
   yaml: ^2.1.3
   xml: ^2.4.1
 


### PR DESCRIPTION
- upgrade to test 0.12.13 (test `0.12.11+1` doesn't support dart sdks > 1.15). This will let us upgrade to a 1.16 based dart sdk
- fix two analysis warnings in the hello_android example
