### PR TITLE
ChildView throws exceptions outside MojoShell

### DIFF
--- a/packages/flutter/lib/src/rendering/child_view.dart
+++ b/packages/flutter/lib/src/rendering/child_view.dart
@@ -36,6 +36,8 @@ final mojom.ViewProxy _viewProxy = _initViewProxy();
 final mojom.View _view = _viewProxy?.ptr;
 
 mojom.ViewContainer _initViewContainer() {
+  if (_view == null)
+    return null;
   mojom.ViewContainerProxy viewContainerProxy = new mojom.ViewContainerProxy.unbound();
   _view.getContainer(viewContainerProxy);
   viewContainerProxy.ptr.setListener(new mojom.ViewContainerListenerStub.unbound()..impl = _ViewContainerListenerImpl.instance);


### PR DESCRIPTION
We're missing a null check.

Fixes #2949
