### PR TITLE
`flutter upgrade` needed twice if sky_services dependencies change

### DIFF
--- a/packages/flutter_tools/lib/src/commands/upgrade.dart
+++ b/packages/flutter_tools/lib/src/commands/upgrade.dart
@@ -43,6 +43,11 @@ class UpgradeCommand extends FlutterCommand {
     if (code != 0)
       return code;
 
+    // Causes us to update our locally cached packages.
+    code = await runCommandAndStreamOutput(<String>[
+      'bin/flutter', '--version'
+    ], workingDirectory: ArtifactStore.flutterRoot);
+
     printStatus('');
     code = await runCommandAndStreamOutput([sdkBinaryName('pub'), 'upgrade']);
 


### PR DESCRIPTION
Now we run `flutter --version` to update our local cache of packages before
running `pub upgrade`, which reads from that cache.

Fixes #2953
