### PR TITLE
[driver] propagate exit code from package:test

### DIFF
--- a/packages/flutter_tools/lib/src/commands/drive.dart
+++ b/packages/flutter_tools/lib/src/commands/drive.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:io' as io;
 
 import 'package:path/path.dart' as path;
 import 'package:test/src/executable.dart' as executable; // ignore: implementation_imports
@@ -110,7 +111,6 @@ class DriveCommand extends RunCommandBase {
 
     try {
       return await testRunner([testFile])
-        .then((_) => 0)
         .catchError((dynamic error, dynamic stackTrace) {
           printError('CAUGHT EXCEPTION: $error\n$stackTrace');
           return 1;
@@ -285,15 +285,16 @@ Future<int> startApp(DriveCommand command) async {
 }
 
 /// Runs driver tests.
-typedef Future<Null> TestRunner(List<String> testArgs);
+typedef Future<int> TestRunner(List<String> testArgs);
 TestRunner testRunner = runTests;
 void restoreTestRunner() {
   testRunner = runTests;
 }
 
-Future<Null> runTests(List<String> testArgs) {
+Future<int> runTests(List<String> testArgs) async {
   printTrace('Running driver tests.');
-  return executable.main(testArgs);
+  await executable.main(testArgs);
+  return io.exitCode;
 }
 
 

--- a/packages/flutter_tools/test/drive_test.dart
+++ b/packages/flutter_tools/test/drive_test.dart
@@ -146,7 +146,7 @@ void main() {
       });
       testRunner = expectAsync((List<String> testArgs) {
         expect(testArgs, [testFile]);
-        return new Future<Null>.value();
+        return new Future<int>.value(0);
       });
       appStopper = expectAsync((_) {
         return new Future<int>.value(0);
@@ -162,6 +162,37 @@ void main() {
       ];
       return createTestCommandRunner(command).run(args).then((int code) {
         expect(code, equals(0));
+        BufferLogger buffer = logger;
+        expect(buffer.errorText, isEmpty);
+      });
+    });
+
+    testUsingContext('returns exitCode set by test runner', () async {
+      withMockDevice();
+
+      String testApp = '/some/app/test/e2e.dart';
+      String testFile = '/some/app/test_driver/e2e_test.dart';
+
+      appStarter = expectAsync((_) {
+        return new Future<int>.value(0);
+      });
+      testRunner = expectAsync((_) {
+        return new Future<int>.value(123);
+      });
+      appStopper = expectAsync((_) {
+        return new Future<int>.value(0);
+      });
+
+      MemoryFileSystem memFs = fs;
+      await memFs.file(testApp).writeAsString('main() {}');
+      await memFs.file(testFile).writeAsString('main() {}');
+
+      List<String> args = [
+        'drive',
+        '--target=$testApp',
+      ];
+      return createTestCommandRunner(command).run(args).then((int code) {
+        expect(code, equals(123));
         BufferLogger buffer = logger;
         expect(buffer.errorText, isEmpty);
       });


### PR DESCRIPTION
Driver returns exit code 0 even when tests fail. This commit fixes it by
propagating the exit code set by `package:test`.

**NOTE**: this PR will cause the infra bot to start failing. This is expected as currently the bot is showing a false positive.
