### PR TITLE
Remove two `flutter analyze` regular expressions

### DIFF
--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -942,6 +942,12 @@ abstract class RenderObject extends AbstractNode implements HitTestTarget {
   @override
   PipelineOwner get owner => super.owner;
 
+  // Workaround for https://github.com/dart-lang/sdk/issues/25232
+  @override
+  void attach(PipelineOwner owner) {
+    super.attach(owner);
+  }
+
   bool _needsLayout = true;
   /// Whether this render object's layout information is dirty.
   bool get needsLayout => _needsLayout;

--- a/packages/flutter/lib/src/rendering/viewport.dart
+++ b/packages/flutter/lib/src/rendering/viewport.dart
@@ -336,6 +336,12 @@ class RenderViewport extends RenderViewportBase with RenderObjectWithChildMixin<
     return null;
   }
 
+  // Workaround for https://github.com/dart-lang/sdk/issues/25232
+  @override
+  void applyPaintTransform(RenderBox child, Matrix4 transform) {
+    super.applyPaintTransform(child, transform);
+  }
+
   @override
   bool hitTestChildren(HitTestResult result, { Point position }) {
     if (child != null) {
@@ -400,6 +406,12 @@ abstract class RenderVirtualViewport<T extends ContainerBoxParentDataMixin<Rende
 
   @override
   Rect describeApproximatePaintClip(RenderObject child) => Point.origin & size;
+
+  // Workaround for https://github.com/dart-lang/sdk/issues/25232
+  @override
+  void applyPaintTransform(RenderBox child, Matrix4 transform) {
+    super.applyPaintTransform(child, transform);
+  }
 
   @override
   void debugFillDescription(List<String> description) {

--- a/packages/flutter_tools/lib/src/commands/analyze.dart
+++ b/packages/flutter_tools/lib/src/commands/analyze.dart
@@ -346,8 +346,6 @@ class AnalyzeCommand extends FlutterCommand {
       'Analyzing [${mainFile.path}]...',
       new RegExp('^\\[(hint|error)\\] Unused import \\(${mainFile.path},'),
       new RegExp(r'^\[.+\] .+ \(.+/\.pub-cache/.+'),
-      new RegExp('\\[warning\\] Missing concrete implementation of \'RenderObject\\.applyPaintTransform\''), // https://github.com/dart-lang/sdk/issues/25232
-      new RegExp('\\[warning\\] Missing concrete implementation of \'AbstractNode\\.attach\''), // https://github.com/dart-lang/sdk/issues/25232
       new RegExp(r'[0-9]+ (error|warning|hint|lint).+found\.'),
       new RegExp(r'^$'),
     ];


### PR DESCRIPTION
We can work around these in code rather than by post-processing the analyzer
output.
