### PR TITLE
adjust upgrade command

### DIFF
--- a/packages/flutter_tools/lib/executable.dart
+++ b/packages/flutter_tools/lib/executable.dart
@@ -141,6 +141,6 @@ String _doctorText() {
 
     return logger.statusText;
   } catch (error, trace) {
-    return 'encountered exception: $error\n$trace';
+    return 'encountered exception: $error\n\n```\n${trace.toString().trim()}\n```\n';
   }
 }

--- a/packages/flutter_tools/lib/src/commands/upgrade.dart
+++ b/packages/flutter_tools/lib/src/commands/upgrade.dart
@@ -3,9 +3,11 @@
 // found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:io';
 
 import '../artifacts.dart';
 import '../base/process.dart';
+import '../dart/pub.dart';
 import '../globals.dart';
 import '../runner/flutter_command.dart';
 import '../runner/version.dart';
@@ -44,18 +46,21 @@ class UpgradeCommand extends FlutterCommand {
       return code;
 
     // Causes us to update our locally cached packages.
+    printStatus('');
     code = await runCommandAndStreamOutput(<String>[
       'bin/flutter', '--version'
     ], workingDirectory: ArtifactStore.flutterRoot);
 
-    printStatus('');
-    code = await runCommandAndStreamOutput([sdkBinaryName('pub'), 'upgrade']);
-
     if (code != 0)
       return code;
 
-    printStatus('');
-    printStatus(FlutterVersion.getVersion(ArtifactStore.flutterRoot).toString());
+    if (FileSystemEntity.isFileSync('pubspec.yaml')) {
+      printStatus('');
+      code = await pubGet(upgrade: true, checkLastModified: false);
+
+      if (code != 0)
+        return code;
+    }
 
     return 0;
   }

--- a/packages/flutter_tools/lib/src/flx.dart
+++ b/packages/flutter_tools/lib/src/flx.dart
@@ -33,11 +33,11 @@ const String _kFontSetMaterial = 'material';
 const String _kFontSetRoboto = 'roboto';
 
 class _Asset {
+  _Asset({ this.source, this.base, this.key });
+
   final String source;
   final String base;
   final String key;
-
-  _Asset({ this.source, this.base, this.key });
 }
 
 Map<String, dynamic> _readMaterialFontsManifest() {
@@ -196,10 +196,10 @@ Future<String> buildFlx(
 
 /// The result from [buildInTempDir]. Note that this object should be disposed after use.
 class DirectoryResult {
+  DirectoryResult(this.directory, this.localBundlePath);
+
   final Directory directory;
   final String localBundlePath;
-
-  DirectoryResult(this.directory, this.localBundlePath);
 
   /// Call this to delete the temporary directory.
   void dispose() {


### PR DESCRIPTION
- only print out the flutter version at the beginning and after the upgrade
- only run pub upgrade if we're in a dart project

```
Flutter on channel master (from https://github.com/flutter/flutter.git)
Framework revision d5deea4 (10 hours ago); engine revision ce3b454

Upgrading Flutter...
From https://github.com/flutter/flutter
   d5deea4..a003d17  master     -> upstream/master
   0eab5e6..d5deea4  alpha      -> upstream/alpha
 + 94f6600...5a49c68 dialog     -> upstream/dialog  (forced update)
Updating d5deea4..a003d17
Fast-forward
 examples/material_gallery/lib/demo/dialog_demo.dart | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)

Building flutter tool...

Flutter on channel master (from https://github.com/flutter/flutter.git)
Framework revision a003d17 (26 minutes ago); engine revision ce3b454

Running 'pub upgrade' in /Users/devoncarew/flutter/flutter_sunflower/...
```
