### PR TITLE
run pub with --no-package-symlinks

### DIFF
--- a/packages/cassowary/test/all.dart
+++ b/packages/cassowary/test/all.dart
@@ -1,0 +1,9 @@
+// Copyright (c) 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'cassowary_test.dart' as cassowary_test;
+
+void main() {
+  cassowary_test.main();
+}

--- a/packages/cassowary/test/cassowary_test.dart
+++ b/packages/cassowary/test/cassowary_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-library cassowary.test;
-
 import 'package:test/test.dart';
 
 import 'package:cassowary/cassowary.dart';

--- a/packages/flutter_driver/test/all.dart
+++ b/packages/flutter_driver/test/all.dart
@@ -1,0 +1,11 @@
+// Copyright (c) 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'flutter_driver_test.dart' as flutter_driver_test;
+import 'retry_test.dart' as retry_test;
+
+void main() {
+  flutter_driver_test.main();
+  retry_test.main();
+}

--- a/packages/flutter_driver/test/flutter_driver_test.dart
+++ b/packages/flutter_driver/test/flutter_driver_test.dart
@@ -3,7 +3,7 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-import 'package:test/test.dart';
+
 import 'package:flutter_driver/src/driver.dart';
 import 'package:flutter_driver/src/error.dart';
 import 'package:flutter_driver/src/health.dart';
@@ -11,6 +11,7 @@ import 'package:flutter_driver/src/message.dart';
 import 'package:json_rpc_2/json_rpc_2.dart' as rpc;
 import 'package:mockito/mockito.dart';
 import 'package:quiver/testing/async.dart';
+import 'package:test/test.dart';
 import 'package:vm_service_client/vm_service_client.dart';
 
 void main() {

--- a/packages/flutter_tools/lib/src/commands/analyze.dart
+++ b/packages/flutter_tools/lib/src/commands/analyze.dart
@@ -122,12 +122,6 @@ class AnalyzeCommand extends FlutterCommand {
   @override
   bool get requiresProjectRoot => false;
 
-  bool get isFlutterRepo {
-    return FileSystemEntity.isDirectorySync('examples') &&
-      FileSystemEntity.isDirectorySync('packages') &&
-      FileSystemEntity.isFileSync('bin/flutter');
-  }
-
   @override
   Future<int> runInProject() async {
     return argResults['watch'] ? _analyzeWatch() : _analyzeOnce();
@@ -658,7 +652,7 @@ class AnalysisServer {
     List<String> args = <String>[snapshot, '--sdk', sdk];
 
     printTrace('dart ${args.join(' ')}');
-    _process = await Process.start('dart', args);
+    _process = await Process.start(path.join(dartSdkPath, 'bin', 'dart'), args);
     _process.exitCode.whenComplete(() => _process = null);
 
     Stream<String> errorStream = _process.stderr.transform(UTF8.decoder).transform(const LineSplitter());

--- a/packages/flutter_tools/lib/src/dart/pub.dart
+++ b/packages/flutter_tools/lib/src/dart/pub.dart
@@ -20,7 +20,6 @@ Future<int> pubGet({
     directory = Directory.current.path;
 
   File pubSpecYaml = new File(path.join(directory, 'pubspec.yaml'));
-  File pubSpecLock = new File(path.join(directory, 'pubspec.lock'));
   File dotPackages = new File(path.join(directory, '.packages'));
 
   if (!pubSpecYaml.existsSync()) {
@@ -30,21 +29,20 @@ Future<int> pubGet({
     return 1;
   }
 
-  if (!checkLastModified || !pubSpecLock.existsSync() || pubSpecYaml.lastModifiedSync().isAfter(pubSpecLock.lastModifiedSync())) {
+  if (!checkLastModified || !dotPackages.existsSync() || pubSpecYaml.lastModifiedSync().isAfter(dotPackages.lastModifiedSync())) {
     String command = upgrade ? 'upgrade' : 'get';
     printStatus("Running 'pub $command' in $directory${Platform.pathSeparator}...");
     int code = await runCommandAndStreamOutput(
-      <String>[sdkBinaryName('pub'), '--verbosity=warning', command],
+      <String>[sdkBinaryName('pub'), '--verbosity=warning', command, '--no-package-symlinks'],
       workingDirectory: directory
     );
     if (code != 0)
       return code;
   }
 
-  if ((pubSpecLock.existsSync() && pubSpecLock.lastModifiedSync().isAfter(pubSpecYaml.lastModifiedSync())) &&
-      (dotPackages.existsSync() && dotPackages.lastModifiedSync().isAfter(pubSpecYaml.lastModifiedSync())))
+  if (dotPackages.existsSync() && dotPackages.lastModifiedSync().isAfter(pubSpecYaml.lastModifiedSync()))
     return 0;
 
-  printError('$directory: pubspec.yaml, pubspec.lock, and .packages are in an inconsistent state');
+  printError('$directory: pubspec.yaml and .packages are in an inconsistent state');
   return 1;
 }

--- a/packages/flutter_tools/lib/src/dart/sdk.dart
+++ b/packages/flutter_tools/lib/src/dart/sdk.dart
@@ -2,7 +2,11 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:io';
+import 'package:path/path.dart' as path;
 
-/// Locate the Dart SDK by finding the Dart VM and going up two directories.
-String get dartSdkPath => new File(Platform.executable).parent.parent.path;
+import '../artifacts.dart';
+
+/// Locate the Dart SDK.
+String get dartSdkPath {
+  return path.join(ArtifactStore.flutterRoot, 'bin', 'cache', 'dart-sdk');
+}

--- a/packages/flutter_tools/lib/src/runner/flutter_command_runner.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command_runner.dart
@@ -146,7 +146,7 @@ class FlutterCommandRunner extends CommandRunner {
 
   ArgResults _globalResults;
 
-  String get _defaultFlutterRoot {
+  static String get _defaultFlutterRoot {
     if (Platform.environment.containsKey(kFlutterRootEnvironmentVariableName))
       return Platform.environment[kFlutterRootEnvironmentVariableName];
     try {
@@ -157,6 +157,12 @@ class FlutterCommandRunner extends CommandRunner {
         return path.dirname(path.dirname(path.dirname(script)));
       if (path.basename(script) == kFlutterToolsScriptFileName)
         return path.dirname(path.dirname(path.dirname(path.dirname(script))));
+
+      // If run from a bare script within the repo.
+      if (script.contains('flutter/packages/'))
+        return script.substring(0, script.indexOf('flutter/packages/') + 8);
+      if (script.contains('flutter/examples/'))
+        return script.substring(0, script.indexOf('flutter/examples/') + 8);
     } catch (error) {
       // we don't have a logger at the time this is run
       // (which is why we don't use printTrace here)
@@ -362,5 +368,10 @@ class FlutterCommandRunner extends CommandRunner {
     }
 
     return configs;
+  }
+
+  static void initFlutterRoot() {
+    if (ArtifactStore.flutterRoot == null)
+      ArtifactStore.flutterRoot = _defaultFlutterRoot;
   }
 }

--- a/packages/flutter_tools/test/all.dart
+++ b/packages/flutter_tools/test/all.dart
@@ -1,0 +1,50 @@
+// Copyright (c) 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// TODO(devoncarew): These `all.dart` test files are here to work around
+// https://github.com/dart-lang/test/issues/327; the `test` package currently
+// doesn't support running without symlinks. We can delete these files once that
+// fix lands.
+
+import 'adb_test.dart' as adb_test;
+import 'analyze_duplicate_names_test.dart' as analyze_duplicate_names_test;
+import 'analyze_test.dart' as analyze_test;
+import 'android_device_test.dart' as android_device_test;
+import 'android_sdk_test.dart' as android_sdk_test;
+import 'base_utils_test.dart' as base_utils_test;
+import 'context_test.dart' as context_test;
+import 'create_test.dart' as create_test;
+import 'daemon_test.dart' as daemon_test;
+import 'device_test.dart' as device_test;
+import 'drive_test.dart' as drive_test;
+import 'install_test.dart' as install_test;
+import 'listen_test.dart' as listen_test;
+import 'logs_test.dart' as logs_test;
+import 'os_utils_test.dart' as os_utils_test;
+import 'run_test.dart' as run_test;
+import 'service_protocol_test.dart' as service_protocol_test;
+import 'stop_test.dart' as stop_test;
+import 'trace_test.dart' as trace_test;
+
+void main() {
+  adb_test.main();
+  analyze_duplicate_names_test.main();
+  analyze_test.main();
+  android_device_test.main();
+  android_sdk_test.main();
+  base_utils_test.main();
+  context_test.main();
+  create_test.main();
+  daemon_test.main();
+  device_test.main();
+  drive_test.main();
+  install_test.main();
+  listen_test.main();
+  logs_test.main();
+  os_utils_test.main();
+  run_test.main();
+  service_protocol_test.main();
+  stop_test.main();
+  trace_test.main();
+}

--- a/packages/flutter_tools/test/analyze_test.dart
+++ b/packages/flutter_tools/test/analyze_test.dart
@@ -9,6 +9,7 @@ import 'package:flutter_tools/src/base/os.dart';
 import 'package:flutter_tools/src/commands/analyze.dart';
 import 'package:flutter_tools/src/dart/pub.dart';
 import 'package:flutter_tools/src/dart/sdk.dart';
+import 'package:flutter_tools/src/runner/flutter_command_runner.dart';
 import 'package:path/path.dart' as path;
 import 'package:test/test.dart';
 
@@ -19,6 +20,7 @@ void main() {
   Directory tempDir;
 
   setUp(() {
+    FlutterCommandRunner.initFlutterRoot();
     tempDir = Directory.systemTemp.createTempSync('analysis_test');
   });
 

--- a/packages/flx/test/all.dart
+++ b/packages/flx/test/all.dart
@@ -1,0 +1,11 @@
+// Copyright (c) 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'bundle_test.dart' as bundle_test;
+import 'signing_test.dart' as signing_test;
+
+void main() {
+  bundle_test.main();
+  signing_test.main();
+}

--- a/packages/newton/test/all.dart
+++ b/packages/newton/test/all.dart
@@ -1,0 +1,9 @@
+// Copyright (c) 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'newton_test.dart' as newton_test;
+
+void main() {
+  newton_test.main();
+}

--- a/travis/test.sh
+++ b/travis/test.sh
@@ -6,15 +6,12 @@ export PATH="$PWD/bin:$PATH"
 # analyze all the Dart code in the repo
 flutter analyze --flutter-repo --no-current-directory --no-current-package --congratulate
 
-(cd packages/cassowary; pub run test -j1)
+(cd packages/cassowary; dart -c test/all.dart)
 (cd packages/flutter; flutter test)
+(cd packages/flutter_driver; dart -c test/all.dart)
 (cd packages/flutter_sprites; flutter test)
-(cd packages/flutter_tools; pub run test)
-# (cd packages/flutter_test; ) # No tests to run.
-(cd packages/flx; pub run test -j1)
-(cd packages/newton; pub run test -j1)
-# (cd packages/playfair; ) # No tests to run.
-# (cd packages/updater; ) # No tests to run.
-(cd packages/flutter_driver; pub run test -j1)
+(cd packages/flutter_tools; dart -c test/all.dart)
+(cd packages/flx; dart -c test/all.dart)
+(cd packages/newton; dart -c test/all.dart)
 
 (cd examples/stocks; flutter test)


### PR DESCRIPTION
- run pub with `--no-package-symlinks` (fix https://github.com/flutter/flutter/issues/2941)
- resolve `packages/foo` references in futter.yaml files using info from the .packages file

I'm not 100% sure that this has caught all the places using symlinks; we can back out the use of the flag if there are issues.
