### PR TITLE
Use _ScaffoldLayout to position scroll-resizable appbars

### DIFF
--- a/examples/material_gallery/lib/gallery/home.dart
+++ b/examples/material_gallery/lib/gallery/home.dart
@@ -50,13 +50,15 @@ class GalleryHome extends StatefulWidget {
 }
 
 class GalleryHomeState extends State<GalleryHome> {
-  final Key _scrollableKey = new UniqueKey();
+  final Key _homeKey = new ValueKey<String>("Gallery Home");
+  final Key _listKey = new ValueKey<String>("Gallery List");
 
   @override
   Widget build(BuildContext context) {
     final double statusBarHight = (MediaQuery.of(context)?.padding ?? EdgeInsets.zero).top;
 
     return new Scaffold(
+      key: _homeKey,
       drawer: new GalleryDrawer(),
       appBar: new AppBar(
         expandedHeight: _kFlexibleSpaceMaxHeight,
@@ -65,13 +67,12 @@ class GalleryHomeState extends State<GalleryHome> {
           title: new Text("Flutter Gallery")
         )
       ),
-      scrollableKey: _scrollableKey,
+      scrollableKey: _listKey,
       appBarBehavior: AppBarBehavior.under,
       body: new TwoLevelList(
         scrollablePadding: new EdgeInsets.only(top: _kFlexibleSpaceMaxHeight + statusBarHight),
-        key: _scrollableKey,
         type: MaterialListType.oneLine,
-        scrollableKey: _scrollableKey,
+        scrollableKey: _listKey,
         items: <Widget>[
           new TwoLevelSublist(
             leading: new Icon(icon: Icons.star),

--- a/packages/flutter/lib/src/material/scaffold.dart
+++ b/packages/flutter/lib/src/material/scaffold.dart
@@ -50,9 +50,10 @@ enum _ScaffoldSlot {
 }
 
 class _ScaffoldLayout extends MultiChildLayoutDelegate {
-  _ScaffoldLayout({ this.padding });
+  _ScaffoldLayout({ this.padding, this.appBarBehavior: AppBarBehavior.anchor });
 
   final EdgeInsets padding;
+  final AppBarBehavior appBarBehavior;
 
   @override
   void performLayout(Size size) {
@@ -68,7 +69,9 @@ class _ScaffoldLayout extends MultiChildLayoutDelegate {
     double contentBottom = size.height - padding.bottom;
 
     if (hasChild(_ScaffoldSlot.appBar)) {
-      contentTop = layoutChild(_ScaffoldSlot.appBar, fullWidthConstraints).height;
+      final double appBarHeight = layoutChild(_ScaffoldSlot.appBar, fullWidthConstraints).height;
+      if (appBarBehavior == AppBarBehavior.anchor)
+        contentTop = appBarHeight;
       positionChild(_ScaffoldSlot.appBar, Offset.zero);
     }
 
@@ -522,6 +525,8 @@ class ScaffoldState extends State<Scaffold> {
         constraints: new BoxConstraints(maxHeight: expandedHeight)
       );
       _addIfNonNull(children, appBar, _ScaffoldSlot.appBar);
+    } else {
+      children.add(new LayoutId(child: _buildScrollableAppBar(context), id: _ScaffoldSlot.appBar));
     }
     // Otherwise the AppBar will be part of a [app bar, body] Stack. See AppBarBehavior.scroll below.
 
@@ -565,21 +570,12 @@ class ScaffoldState extends State<Scaffold> {
     if (config.appBarBehavior != AppBarBehavior.anchor) {
       application = new NotificationListener<ScrollNotification>(
         onNotification: _handleScrollNotification,
-        child: new Stack(
-          children: <Widget> [
-            new CustomMultiChildLayout(
-              children: children,
-              delegate: new _ScaffoldLayout(
-                padding: EdgeInsets.zero
-              )
-            ),
-            new Positioned(
-              top: 0.0,
-              left: 0.0,
-              right: 0.0,
-              child: _buildScrollableAppBar(context)
-            )
-          ]
+        child: new CustomMultiChildLayout(
+          children: children,
+          delegate: new _ScaffoldLayout(
+            padding: EdgeInsets.zero,
+            appBarBehavior: config.appBarBehavior
+          )
         )
       );
     } else {


### PR DESCRIPTION
Use _ScaffoldLayout to layout the appbar, even if it's going to be resized when the app is scrolled. As a consequence, the drawer is always stacked on top of the appbar.

Fixes https://github.com/flutter/flutter/issues/2923
