### PR TITLE
[driver] fix observatory port # and timeline data extraction

### DIFF
--- a/packages/flutter_tools/lib/src/commands/drive.dart
+++ b/packages/flutter_tools/lib/src/commands/drive.dart
@@ -10,7 +10,6 @@ import 'package:test/src/executable.dart' as executable; // ignore: implementati
 
 import '../android/android_device.dart' show AndroidDevice;
 import '../application_package.dart';
-import '../base/common.dart';
 import '../base/file_system.dart';
 import '../base/os.dart';
 import '../device.dart';
@@ -61,7 +60,7 @@ class DriveCommand extends RunCommandBase {
     );
 
     argParser.addOption('debug-port',
-        defaultsTo: observatoryDefaultPort.toString(),
+        defaultsTo: '8182',
         help: 'Listen to the given port for a debug connection.');
   }
 


### PR DESCRIPTION
The way we pick observatory port # has changed and we have broken
logic that handles port 8181. To fix the buildbot, switch to port
8182. We can later figure out what we want to do when we clean up
port handling.

The old VM extention for extracting the timeline data is gone.
Switch to the new '_getVMTimeline' API.

/cc @chinmaygarde 
