### PR TITLE
DatePicker et al updates

### DIFF
--- a/packages/flutter/lib/src/material/date_picker.dart
+++ b/packages/flutter/lib/src/material/date_picker.dart
@@ -229,24 +229,26 @@ class DayPicker extends StatelessWidget {
       if (day < 1 || day > daysInMonth) {
         item = new Text("");
       } else {
-        // Put a light circle around the selected day
         BoxDecoration decoration;
-        if (selectedDate.year == year &&
-            selectedDate.month == month &&
-            selectedDate.day == day)
+        TextStyle itemStyle = dayStyle;
+
+        if (selectedDate.year == year && selectedDate.month == month && selectedDate.day == day) {
+          // The selected day gets a circle background highlight, and a contrasting text color.
+          final ThemeData theme = Theme.of(context);
+          itemStyle = itemStyle.copyWith(
+            color: (theme.brightness == ThemeBrightness.light) ? Colors.white : Colors.black87
+          );
           decoration = new BoxDecoration(
-            backgroundColor: themeData.backgroundColor,
+            backgroundColor: themeData.accentColor,
             shape: BoxShape.circle
           );
-
-        // Use a different font color for the current day
-        TextStyle itemStyle = dayStyle;
-        if (currentDate.year == year &&
-            currentDate.month == month &&
-            currentDate.day == day)
-          itemStyle = itemStyle.copyWith(color: themeData.primaryColor);
+        } else if (currentDate.year == year && currentDate.month == month && currentDate.day == day) {
+          // The current day gets a different text color.
+          itemStyle = itemStyle.copyWith(color: themeData.accentColor);
+        }
 
         item = new GestureDetector(
+          behavior: HitTestBehavior.translucent,
           onTap: () {
             DateTime result = new DateTime(year, month, day);
             onChanged(result);
@@ -285,6 +287,7 @@ class MonthPicker extends StatefulWidget {
     assert(selectedDate != null);
     assert(onChanged != null);
     assert(lastDate.isAfter(firstDate));
+    assert(selectedDate.isAfter(firstDate) || selectedDate.isAtSameMomentAs(firstDate));
   }
 
   final DateTime selectedDate;
@@ -321,6 +324,10 @@ class _MonthPickerState extends State<MonthPicker> {
     });
   }
 
+  int _monthDelta(DateTime startDate, DateTime endDate) {
+    return (endDate.year - startDate.year) * 12 + endDate.month - startDate.month;
+  }
+
   List<Widget> buildItems(BuildContext context, int start, int count) {
     List<Widget> result = new List<Widget>();
     DateTime startDate = new DateTime(config.firstDate.year + start ~/ 12, config.firstDate.month + start % 12);
@@ -344,8 +351,10 @@ class _MonthPickerState extends State<MonthPicker> {
   @override
   Widget build(BuildContext context) {
     return new ScrollableLazyList(
+      key: new ValueKey<DateTime>(config.selectedDate),
+      initialScrollOffset: config.itemExtent * _monthDelta(config.firstDate, config.selectedDate),
       itemExtent: config.itemExtent,
-      itemCount: (config.lastDate.year - config.firstDate.year) * 12 + config.lastDate.month - config.firstDate.month + 1,
+      itemCount: _monthDelta(config.firstDate, config.lastDate) + 1,
       itemBuilder: buildItems
     );
   }

--- a/packages/flutter/lib/src/material/date_picker_dialog.dart
+++ b/packages/flutter/lib/src/material/date_picker_dialog.dart
@@ -9,6 +9,8 @@ import 'package:flutter/widgets.dart';
 import 'dialog.dart';
 import 'date_picker.dart';
 import 'flat_button.dart';
+import 'theme.dart';
+import 'theme_data.dart';
 
 class _DatePickerDialog extends StatefulWidget {
   _DatePickerDialog({
@@ -51,6 +53,7 @@ class _DatePickerDialogState extends State<_DatePickerDialog> {
 
   @override
   Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
     return new Dialog(
       content: new DatePicker(
         selectedDate: _selectedDate,
@@ -61,10 +64,12 @@ class _DatePickerDialogState extends State<_DatePickerDialog> {
       contentPadding: EdgeInsets.zero,
       actions: <Widget>[
         new FlatButton(
+          textColor: theme.accentColor,
           child: new Text('CANCEL'),
           onPressed: _handleCancel
         ),
         new FlatButton(
+          textColor: theme.accentColor,
           child: new Text('OK'),
           onPressed: _handleOk
         ),

--- a/packages/flutter/lib/src/material/theme_data.dart
+++ b/packages/flutter/lib/src/material/theme_data.dart
@@ -61,7 +61,7 @@ class ThemeData {
     primarySwatch ??= Colors.blue;
     primaryColor ??= isDark ? Colors.grey[900] : primarySwatch[500];
     primaryColorBrightness ??= ThemeBrightness.dark;
-    accentColor ??= primarySwatch[500];
+    accentColor ??= isDark ? Colors.tealAccent[200] : primarySwatch[500];
     accentColorBrightness ??= ThemeBrightness.dark;
     canvasColor ??= isDark ? Colors.grey[850] : Colors.grey[50];
     cardColor ??= isDark ? Colors.grey[800] : Colors.white;


### PR DESCRIPTION
Changed the meaning of ThemeData.accentColor for the dark theme.  It was the primaryColor which worked nicely if the primary color was bright (amber worked great) but not so well for darker primary colors.

The hit target area for DayPicker days is as big as possible.

DatePicker initially scrolls to the selectedDate's month.

DatePickerDialog uses the Theme's accentColor for OK and CANCEL.

Fixes https://github.com/flutter/flutter/issues/1201
Fixes https://github.com/flutter/flutter/issues/2989
Fixes https://github.com/flutter/flutter/issues/1097
