### PR TITLE
Part 2 of independent layout pipelines

### DIFF
--- a/examples/layers/widgets/spinning_mixed.dart
+++ b/examples/layers/widgets/spinning_mixed.dart
@@ -33,6 +33,7 @@ class Rectangle extends StatelessWidget {
 
 double value;
 RenderObjectToWidgetElement<RenderBox> element;
+BuildOwner owner;
 void attachWidgetTreeToRenderTree(RenderProxyBox container) {
   element = new RenderObjectToWidgetAdapter<RenderBox>(
     container: container,
@@ -70,7 +71,7 @@ void attachWidgetTreeToRenderTree(RenderProxyBox container) {
         mainAxisAlignment: MainAxisAlignment.spaceBetween
       )
     )
-  ).attachToRenderTree(element);
+  ).attachToRenderTree(owner, element);
 }
 
 Duration timeBase;

--- a/packages/flutter/benchmark/stocks/build_bench.dart
+++ b/packages/flutter/benchmark/stocks/build_bench.dart
@@ -34,7 +34,7 @@ void main() {
 
   for (int i = 0; i < _kNumberOfIterations || _kRunForever; ++i) {
     appState.setState(_doNothing);
-    binding.buildDirtyElements();
+    binding.buildOwner.buildDirtyElements();
   }
 
   watch.stop();

--- a/packages/flutter/lib/src/widgets/mixed_viewport.dart
+++ b/packages/flutter/lib/src/widgets/mixed_viewport.dart
@@ -252,7 +252,7 @@ class _MixedViewportElement extends RenderObjectElement {
       _resetCache();
       _lastLayoutConstraints = constraints;
     }
-    BuildableElement.lockState(() {
+    owner.lockState(() {
       _doLayout(constraints);
     }, building: true);
   }

--- a/packages/flutter/lib/src/widgets/virtual_viewport.dart
+++ b/packages/flutter/lib/src/widgets/virtual_viewport.dart
@@ -157,7 +157,7 @@ abstract class VirtualViewportElement extends RenderObjectElement {
     assert(startOffsetBase != null);
     assert(startOffsetLimit != null);
     _updatePaintOffset();
-    BuildableElement.lockState(_materializeChildren, building: true);
+    owner.lockState(_materializeChildren, building: true);
   }
 
   void _materializeChildren() {

--- a/packages/flutter/test/widget/independent_widget_layout_test.dart
+++ b/packages/flutter/test/widget/independent_widget_layout_test.dart
@@ -1,0 +1,163 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+import 'package:test/test.dart';
+
+const Size _kTestViewSize = const Size(800.0, 600.0);
+
+class OffscreenRenderView extends RenderView {
+  OffscreenRenderView() {
+    configuration = new ViewConfiguration(size: _kTestViewSize);
+  }
+
+  @override
+  void scheduleInitialFrame() {
+    scheduleInitialLayout();
+    scheduleInitialPaint(new TransformLayer(transform: new Matrix4.identity()));
+    // Don't call Scheduler.instance.ensureVisualUpdate()
+  }
+
+  @override
+  void compositeFrame() {
+    // Don't draw to ui.window
+  }
+}
+
+class OffscreenWidgetTree {
+  OffscreenWidgetTree() {
+    renderView.attach(pipelineOwner);
+    renderView.scheduleInitialFrame();
+  }
+
+  final RenderView renderView = new OffscreenRenderView();
+  final BuildOwner buildOwner = new BuildOwner();
+  final PipelineOwner pipelineOwner = new PipelineOwner();
+  RenderObjectToWidgetElement<RenderBox> root;
+
+  void pumpWidget(Widget app) {
+    root = new RenderObjectToWidgetAdapter<RenderBox>(
+      container: renderView,
+      debugShortDescription: '[root]',
+      child: app
+    ).attachToRenderTree(buildOwner, root);
+    pumpFrame();
+  }
+
+  void pumpFrame() {
+    buildOwner.buildDirtyElements();
+    pipelineOwner.flushLayout();
+    pipelineOwner.flushCompositingBits();
+    pipelineOwner.flushPaint();
+    renderView.compositeFrame();
+    if (SemanticsNode.hasListeners) {
+      pipelineOwner.flushSemantics();
+      SemanticsNode.sendSemanticsTree();
+    }
+    buildOwner.finalizeTree();
+  }
+
+}
+
+class Counter {
+  int count = 0;
+}
+
+class Trigger {
+  VoidCallback callback;
+  void fire() {
+    if (callback != null)
+      callback();
+  }
+}
+
+class TriggerableWidget extends StatefulWidget {
+  TriggerableWidget({ this.trigger, this.counter });
+  final Trigger trigger;
+  final Counter counter;
+  @override
+  TriggerableState createState() => new TriggerableState();
+}
+
+class TriggerableState extends State<TriggerableWidget> {
+  @override
+  void initState() {
+    super.initState();
+    config.trigger.callback = this.fire;
+  }
+
+  @override
+  void didUpdateConfig(TriggerableWidget oldConfig) {
+    config.trigger.callback = this.fire;
+  }
+
+  int _count = 0;
+  void fire() {
+    setState(() {
+      _count++;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    config.counter.count++;
+    return new Text("Bang $_count!");
+  }
+}
+
+void main() {
+  test('no crosstalk between widget build owners', () {
+    testWidgets((WidgetTester tester) {
+      Trigger trigger1 = new Trigger();
+      Counter counter1 = new Counter();
+      Trigger trigger2 = new Trigger();
+      Counter counter2 = new Counter();
+      OffscreenWidgetTree tree = new OffscreenWidgetTree();
+      // Both counts should start at zero
+      expect(counter1.count, equals(0));
+      expect(counter2.count, equals(0));
+      // Lay out the "onscreen" in the default test binding
+      tester.pumpWidget(new TriggerableWidget(trigger: trigger1, counter: counter1));
+      // Only the "onscreen" widget should have built
+      expect(counter1.count, equals(1));
+      expect(counter2.count, equals(0));
+      // Lay out the "offscreen" in a separate tree
+      tree.pumpWidget(new TriggerableWidget(trigger: trigger2, counter: counter2));
+      // Now both widgets should have built
+      expect(counter1.count, equals(1));
+      expect(counter2.count, equals(1));
+      // Mark both as needing layout
+      trigger1.fire();
+      trigger2.fire();
+      // Marking as needing layout shouldn't immediately build anything
+      expect(counter1.count, equals(1));
+      expect(counter2.count, equals(1));
+      // Pump the "onscreen" layout
+      tester.pump();
+      // Only the "onscreen" widget should have rebuilt
+      expect(counter1.count, equals(2));
+      expect(counter2.count, equals(1));
+      // Pump the "offscreen" layout
+      tree.pumpFrame();
+      // Now both widgets should have rebuilt
+      expect(counter1.count, equals(2));
+      expect(counter2.count, equals(2));
+      // Mark both as needing layout, again
+      trigger1.fire();
+      trigger2.fire();
+      // Now pump the "offscreen" layout first
+      tree.pumpFrame();
+      // Only the "offscreen" widget should have rebuilt
+      expect(counter1.count, equals(2));
+      expect(counter2.count, equals(3));
+      // Pump the "onscreen" layout
+      tester.pump();
+      // Now both widgets should have rebuilt
+      expect(counter1.count, equals(3));
+      expect(counter2.count, equals(3));
+    });
+  });
+}

--- a/packages/flutter_test/lib/src/widget_tester.dart
+++ b/packages/flutter_test/lib/src/widget_tester.dart
@@ -38,9 +38,9 @@ class _SteppedWidgetFlutterBinding extends WidgetFlutterBinding {
   // Pump the rendering pipeline up to the given phase.
   @override
   void beginFrame() {
-    buildDirtyElements();
+    buildOwner.buildDirtyElements();
     _beginFrame();
-    Element.finalizeTree();
+    buildOwner.finalizeTree();
   }
 
   // Cloned from Renderer.beginFrame() but with early-exit semantics.
@@ -84,7 +84,7 @@ class WidgetTester extends Instrumentation {
   final FakeAsync async;
   final Clock clock;
 
-  /// Calls [runApp()] with the given widget, then triggers a frame sequent and
+  /// Calls [runApp()] with the given widget, then triggers a frame sequence and
   /// flushes microtasks, by calling [pump()] with the same duration (if any).
   /// The supplied EnginePhase is the final phase reached during the pump pass;
   /// if not supplied, the whole pass is executed.


### PR DESCRIPTION
Adds BuildOwner to manage the dirty list and build processing for
widgets/elements, and adds a widget unit test to make sure separation
is enforced.

Fixes #2723
