### PR TITLE
Be explicit about the theme in the starter app

### DIFF
--- a/packages/flutter_tools/templates/create/lib/main.dart.tmpl
+++ b/packages/flutter_tools/templates/create/lib/main.dart.tmpl
@@ -12,6 +12,9 @@ void main() {
   runApp(
     new MaterialApp(
       title: 'Flutter Demo',
+      theme: new ThemeData(
+        primarySwatch: Colors.blue
+      ),
       routes: <String, WidgetBuilder>{
         '/': (BuildContext context) => new FlutterDemo()
       }


### PR DESCRIPTION
This gives developers a breadcrumb they can follow to customize the
theme of their app. Previously, some customers were trying to set a
theme by manually configuring the colors of all their widgets.

Fixes #2980
