### PR TITLE
Polish selection controls

### DIFF
--- a/packages/flutter/lib/src/material/checkbox.dart
+++ b/packages/flutter/lib/src/material/checkbox.dart
@@ -112,7 +112,7 @@ class _RenderCheckbox extends RenderToggleable {
     final double offsetX = _kOffset + offset.dx;
     final double offsetY = _kOffset + offset.dy;
 
-    paintRadialReaction(canvas, offset + const Offset(kRadialReactionRadius, kRadialReactionRadius));
+    paintRadialReaction(canvas, offset, const Point(kRadialReactionRadius, kRadialReactionRadius));
 
     double t = position.value;
 

--- a/packages/flutter/lib/src/material/radio.dart
+++ b/packages/flutter/lib/src/material/radio.dart
@@ -112,7 +112,7 @@ class _RenderRadio extends RenderToggleable {
   void paint(PaintingContext context, Offset offset) {
     final Canvas canvas = context.canvas;
 
-    paintRadialReaction(canvas, offset + const Offset(kRadialReactionRadius, kRadialReactionRadius));
+    paintRadialReaction(canvas, offset, const Point(kRadialReactionRadius, kRadialReactionRadius));
 
     Point center = (offset & size).center;
     Color radioColor = onChanged != null ? activeColor : inactiveColor;

--- a/packages/flutter/lib/src/material/switch.dart
+++ b/packages/flutter/lib/src/material/switch.dart
@@ -135,7 +135,6 @@ class _RenderSwitch extends RenderToggleable {
          activeColor: activeColor,
          inactiveColor: inactiveColor,
          onChanged: onChanged,
-         minRadialReactionRadius: _kThumbRadius,
          size: const Size(_kSwitchWidth, _kSwitchHeight)
        ) {
     _drag = new HorizontalDragGestureRecognizer()
@@ -248,12 +247,12 @@ class _RenderSwitch extends RenderToggleable {
     RRect trackRRect = new RRect.fromRectXY(trackRect, _kTrackRadius, _kTrackRadius);
     canvas.drawRRect(trackRRect, paint);
 
-    Offset thumbOffset = new Offset(
-      offset.dx + kRadialReactionRadius + currentPosition * _trackInnerLength,
-      offset.dy + size.height / 2.0
+    Point thumbPosition = new Point(
+      kRadialReactionRadius + currentPosition * _trackInnerLength,
+      size.height / 2.0
     );
 
-    paintRadialReaction(canvas, thumbOffset);
+    paintRadialReaction(canvas, offset, thumbPosition);
 
     BoxPainter thumbPainter;
     if (_inactiveThumbDecoration == null && _activeThumbDecoration == null) {
@@ -272,10 +271,10 @@ class _RenderSwitch extends RenderToggleable {
     // The thumb contracts slightly during the animation
     double inset = 2.0 - (currentPosition - 0.5).abs() * 2.0;
     double radius = _kThumbRadius - inset;
-    Rect thumbRect = new Rect.fromLTRB(thumbOffset.dx - radius,
-                                       thumbOffset.dy - radius,
-                                       thumbOffset.dx + radius,
-                                       thumbOffset.dy + radius);
+    Rect thumbRect = new Rect.fromLTRB(thumbPosition.x + offset.dx - radius,
+                                       thumbPosition.y + offset.dy - radius,
+                                       thumbPosition.x + offset.dx + radius,
+                                       thumbPosition.y + offset.dy + radius);
     thumbPainter.paint(canvas, thumbRect);
   }
 }


### PR DESCRIPTION
The touch ripple now starts at the touch location instead of being
centered on the widget.

Fixes #2652
