### PR TITLE
optimize flutter update-packages

### DIFF
--- a/packages/flutter_driver/pubspec.yaml
+++ b/packages/flutter_driver/pubspec.yaml
@@ -17,6 +17,6 @@ dependencies:
     path: '../flutter_test'
 
 dev_dependencies:
-  test: '>=0.12.6 <1.0.0'
+  test: 0.12.13
   mockito: ^0.11.0
-  quiver: '>=0.21.4 <0.22.0'
+  quiver: ^0.21.4

--- a/packages/flutter_tools/lib/executable.dart
+++ b/packages/flutter_tools/lib/executable.dart
@@ -97,12 +97,18 @@ Future<Null> main(List<String> args) async {
       // We've crashed; emit a log report.
       stderr.writeln();
       stderr.writeln('Oops; flutter has exited unexpectedly: "$error"');
-
-      File file = _createCrashReport(args, error, chain);
-
       stderr.writeln();
-      stderr.writeln('Crash report written to ${path.relative(file.path)}.');
-      stderr.writeln('Please let us know at https://github.com/flutter/flutter/issues!');
+
+      if (Platform.environment.containsKey('FLUTTER_DEV')) {
+        // If we're working in the tools themselves, just print the stack trace.
+        stderr.writeln(chain.terse.toString());
+      } else {
+        File file = _createCrashReport(args, error, chain);
+
+        stderr.writeln('Crash report written to ${path.relative(file.path)}.');
+        stderr.writeln('Please let us know at https://github.com/flutter/flutter/issues!');
+      }
+
       exit(1);
     }
   });

--- a/packages/flutter_tools/lib/src/commands/analyze.dart
+++ b/packages/flutter_tools/lib/src/commands/analyze.dart
@@ -7,8 +7,8 @@ import 'dart:collection';
 import 'dart:convert';
 import 'dart:io';
 
-import 'package:den_api/den_api.dart';
 import 'package:path/path.dart' as path;
+import 'package:yaml/yaml.dart' as yaml;
 
 import '../artifacts.dart';
 import '../base/process.dart';
@@ -123,11 +123,10 @@ class AnalyzeCommand extends FlutterCommand {
   bool get requiresProjectRoot => false;
 
   @override
-  Future<int> runInProject() async {
-    return argResults['watch'] ? _analyzeWatch() : _analyzeOnce();
-  }
+  Future<int> runInProject() => argResults['watch'] ? _analyzeWatch() : _analyzeOnce();
 
   List<String> flutterRootComponents;
+
   bool isFlutterLibrary(String filename) {
     flutterRootComponents ??= path.normalize(path.absolute(ArtifactStore.flutterRoot)).split(path.separator);
     List<String> filenameComponents = path.normalize(path.absolute(filename)).split(path.separator);
@@ -243,8 +242,8 @@ class AnalyzeCommand extends FlutterCommand {
         // we are analyzing the actual canonical source for this package;
         // make sure we remember that, in case all the packages are actually
         // pointing elsewhere somehow.
-        Pubspec pubSpecYaml = await Pubspec.load(pubSpecYamlPath);
-        String packageName = pubSpecYaml.name;
+        yaml.YamlMap pubSpecYaml = yaml.loadYaml(new File(pubSpecYamlPath).readAsStringSync());
+        String packageName = pubSpecYaml['name'];
         String packagePath = path.normalize(path.absolute(path.join(directory.path, 'lib')));
         dependencies.addCanonicalCase(packageName, packagePath, pubSpecYamlPath);
       }

--- a/packages/flutter_tools/lib/src/commands/update_packages.dart
+++ b/packages/flutter_tools/lib/src/commands/update_packages.dart
@@ -5,23 +5,14 @@
 import 'dart:async';
 import 'dart:io';
 
+import 'package:path/path.dart' as path;
+import 'package:yaml/yaml.dart' as yaml;
+
 import '../artifacts.dart';
+import '../base/utils.dart';
 import '../dart/pub.dart';
 import '../globals.dart';
 import '../runner/flutter_command.dart';
-
-Future<int> _runPub(Directory directory, { bool upgrade: false }) async {
-  int updateCount = 0;
-  for (FileSystemEntity dir in directory.listSync()) {
-    if (dir is Directory && FileSystemEntity.isFileSync(dir.path + Platform.pathSeparator + 'pubspec.yaml')) {
-      updateCount++;
-      // TODO(eseidel): Should this fail immediately if pubGet fails?
-      // Currently we're ignoring the return code.
-      await pubGet(directory: dir.path, upgrade: upgrade, checkLastModified: false);
-    }
-  }
-  return updateCount;
-}
 
 class UpdatePackagesCommand extends FlutterCommand {
   UpdatePackagesCommand({ this.hidden: false }) {
@@ -47,12 +38,238 @@ class UpdatePackagesCommand extends FlutterCommand {
   @override
   Future<int> runInProject() async {
     Stopwatch timer = new Stopwatch()..start();
-    int count = 0;
+
     bool upgrade = argResults['upgrade'];
-    count += await _runPub(new Directory("${ArtifactStore.flutterRoot}/packages"), upgrade: upgrade);
-    count += await _runPub(new Directory("${ArtifactStore.flutterRoot}/examples"), upgrade: upgrade);
-    count += await _runPub(new Directory("${ArtifactStore.flutterRoot}/dev"), upgrade: upgrade);
-    printStatus('Ran "pub" $count time${count == 1 ? "" : "s"} in ${timer.elapsedMilliseconds} ms');
+
+    List<PackageInfo> packages = <PackageInfo>[];
+    _parsePackages(new Directory("${ArtifactStore.flutterRoot}/packages"), packages);
+    _parsePackages(new Directory("${ArtifactStore.flutterRoot}/examples"), packages);
+    _parsePackages(new Directory("${ArtifactStore.flutterRoot}/dev"), packages);
+
+    String validationResult = _validatePackages(packages);
+
+    if (validationResult.isNotEmpty) {
+      printError(validationResult);
+      return 1;
+    }
+
+    int result = await _getUpgrade(packages, upgrade: upgrade);
+
+    if (result == 0) {
+      printStatus('');
+      printStatus('Elapsed time ${(timer.elapsedMilliseconds / 1000).toStringAsFixed(3)} seconds.');
+    }
+
+    return result;
+  }
+
+  void _parsePackages(Directory directory, List<PackageInfo> packages) {
+    for (FileSystemEntity dir in directory.listSync()) {
+      if (dir is! Directory)
+        continue;
+
+      File pubspec = new File(path.join(dir.path, 'pubspec.yaml'));
+      if (pubspec.existsSync())
+        packages.add(new PackageInfo(dir));
+    }
+  }
+
+  String _validatePackages(List<PackageInfo> packages) {
+    StringBuffer buf = new StringBuffer();
+
+    // Remove all the relative references to other repo packages.
+    for (String name in packages.map((PackageInfo package) => package.name))
+      for (PackageInfo package in packages)
+        package.removePathRef(name);
+
+    // Check for compatible versions.
+    Map<String, Dep> deps = <String, Dep>{};
+
+    for (PackageInfo package in packages) {
+      for (Dep dep in package.deps.values) {
+        deps[dep.name] = _getMostSpecificDep(deps[dep.name], dep);
+
+        // There's a validation error.
+        if (deps[dep.name] == null)
+          _printErrorFor(packages, buf, dep.name);
+      }
+    }
+
+    return buf.toString();
+  }
+
+  void _printErrorFor(List<PackageInfo> packages, StringBuffer buf, String name) {
+    buf.writeln('Package conflict for "$name":');
+
+    for (PackageInfo package in packages) {
+      Dep dep = package.deps[name];
+      if (dep == null || dep.isAny)
+        continue;
+      buf.writeln('  package ${package.name} uses as "$dep"');
+    }
+  }
+
+  Future<int> _getUpgrade(List<PackageInfo> packages, { bool upgrade: false }) async {
+    for (PackageInfo package in packages) {
+      for (Dep dep in package.deps.values)
+        if (dep.isPath)
+          dep.normalize();
+    }
+
+    Map<String, Dep> deps = <String, Dep>{};
+
+    // Create the repo package references.
+    Set<String> repoRefs = new Set<String>();
+    for (PackageInfo package in packages) {
+      Dep dep = new Dep(package, package.name, <String, dynamic>{ 'path': package.dir.path });
+      deps[package.name] = dep;
+      repoRefs.add(package.name);
+    }
+
+    // Create the direct references.
+    Set<String> directRefs = new Set<String>();
+    for (PackageInfo package in packages) {
+      for (Dep dep in package.deps.values) {
+        directRefs.add(dep.name);
+        deps[dep.name] = _getMostSpecificDep(deps[dep.name], dep);
+      }
+    }
+
+    final String kPackageProjectName = 'repo_packages';
+
+    Directory packageDir = new Directory(path.join(ArtifactStore.getBaseCacheDir().path, kPackageProjectName));
+    packageDir.createSync(recursive: true);
+    File pubspecFile = new File(path.join(packageDir.path, 'pubspec.yaml'));
+
+    String contents = 'name: $kPackageProjectName\n';
+    contents += 'dependencies:\n';
+    contents += deps.values.map((Dep dep) => dep.pubFormat).join('\n');
+
+    pubspecFile.writeAsStringSync(contents);
+
+    int result = await pubGet(directory: packageDir.path, upgrade: upgrade);
+
+    if (result != 0)
+      return result;
+
+    String packagesSource = new File(path.join(packageDir.path, '.packages')).readAsStringSync();
+    String lockSource = new File(path.join(packageDir.path, 'pubspec.lock')).readAsStringSync();
+
+    // Remove the synthetic project reference.
+    packagesSource = (packagesSource.split('\n')..removeWhere((String line) {
+      return line.startsWith('$kPackageProjectName:');
+    })).join('\n');
+
+    // Print the versions used.
+    printStatus('');
+    printStatus('Repo packages (${packages.length}):');
+    for (PackageInfo package in packages)
+      printStatus('  ${path.relative(package.dir.path, from: ArtifactStore.flutterRoot)}');
+
+    yaml.YamlMap publock = yaml.loadYaml(lockSource);
+
+    printStatus('');
+    printStatus('Direct depencencies (${directRefs.length}):');
+    for (String ref in directRefs.toList()..sort())
+      printStatus('  $ref: ${publock['packages'][ref]['version']}');
+
+    Set<String> transitiveRefs = new Set<String>();
+
+    for (String key in publock['packages'].keys)
+      if (!repoRefs.contains(key) && !directRefs.contains(key))
+        transitiveRefs.add(key);
+
+    printStatus('');
+    printStatus('Transitive depencencies (${transitiveRefs.length}):');
+    for (String key in transitiveRefs.toList()..sort())
+      printStatus('  $key: ${publock['packages'][key]['version']}');
+
+    // Copy the .packages file around.
+    for (PackageInfo package in packages) {
+      File destPackages = new File(path.join(package.dir.path, '.packages'));
+      File destLock = new File(path.join(package.dir.path, 'pubspec.lock'));
+
+      destPackages.writeAsStringSync(packagesSource);
+      destLock.writeAsStringSync(lockSource);
+    }
+
     return 0;
+  }
+
+  Dep _getMostSpecificDep(Dep dep1, Dep dep2) {
+    if (dep1 == null)
+      return dep2;
+    if (dep2 == null)
+      return dep1;
+    if (dep1.isAny)
+      return dep2;
+    if (dep2.isAny)
+      return dep1;
+
+    if (dep1 == dep2)
+      return dep1;
+
+    return null;
+  }
+}
+
+class PackageInfo {
+  PackageInfo(this.dir) {
+    package = yaml.loadYaml(new File(path.join(dir.path, 'pubspec.yaml')).readAsStringSync());
+
+    if (package.containsKey('dependencies'))
+      package['dependencies'].forEach((String key, dynamic dep) => deps[key] = new Dep(this, key, dep));
+    if (package.containsKey('dev_dependencies'))
+      package['dev_dependencies'].forEach((String key, dynamic dep) => deps[key] = new Dep(this, key, dep));
+  }
+
+  final Directory dir;
+  final Map<String, Dep> deps = <String, Dep>{};
+  yaml.YamlMap package;
+
+  String get name => package['name'];
+
+  void removePathRef(String name) {
+    Dep dep = deps[name];
+    if (dep != null && dep.isPath)
+      deps.remove(name);
+  }
+
+  @override
+  String toString() => '$name $deps';
+}
+
+class Dep {
+  Dep(this.package, this.name, this.dep);
+
+  final PackageInfo package;
+  final String name;
+  dynamic dep;
+
+  bool get isHosted => dep is String;
+
+  bool get isAny => dep == 'any';
+
+  bool get isPath => dep is Map<String, dynamic> && dep['path'] != null;
+
+  String get pubFormat {
+    if (isPath)
+      return '  $name:\n    path: \'${dep['path']}\'';
+    else
+      return '  $name: \'$dep\'';
+  }
+
+  @override
+  String toString() => '$dep';
+
+  @override
+  bool operator==(dynamic other) => other is Dep && pubFormat == other.pubFormat;
+
+  @override
+  int get hashCode => pubFormat.hashCode;
+
+  void normalize() {
+    String pathValue = path.normalize(path.join(package.dir.path, dep['path']));
+    dep = <String, dynamic> { 'path': pathValue };
   }
 }

--- a/packages/flutter_tools/lib/src/commands/update_packages.dart
+++ b/packages/flutter_tools/lib/src/commands/update_packages.dart
@@ -9,7 +9,6 @@ import 'package:path/path.dart' as path;
 import 'package:yaml/yaml.dart' as yaml;
 
 import '../artifacts.dart';
-import '../base/utils.dart';
 import '../dart/pub.dart';
 import '../globals.dart';
 import '../runner/flutter_command.dart';

--- a/packages/flutter_tools/lib/src/dart/pub.dart
+++ b/packages/flutter_tools/lib/src/dart/pub.dart
@@ -32,10 +32,14 @@ Future<int> pubGet({
   if (!checkLastModified || !dotPackages.existsSync() || pubSpecYaml.lastModifiedSync().isAfter(dotPackages.lastModifiedSync())) {
     String command = upgrade ? 'upgrade' : 'get';
     printStatus("Running 'pub $command' in $directory${Platform.pathSeparator}...");
-    int code = await runCommandAndStreamOutput(
-      <String>[sdkBinaryName('pub'), '--verbosity=warning', command, '--no-package-symlinks'],
-      workingDirectory: directory
-    );
+    int code = await runCommandAndStreamOutput(<String>[
+      sdkBinaryName('pub'),
+      '--verbosity=warning',
+      command,
+      '--no-package-symlinks',
+      // '--no-precompile' // TODO(devoncarew): Available with 1.16.0-dev.3.0.
+    ], workingDirectory: directory);
+
     if (code != 0)
       return code;
   }

--- a/packages/flutter_tools/pubspec.yaml
+++ b/packages/flutter_tools/pubspec.yaml
@@ -12,7 +12,6 @@ dependencies:
   archive: ^1.0.20
   args: ^0.13.4
   crypto: 0.9.2
-  den_api: ^0.1.0
   file: ^0.1.0
   json_schema: ^1.0.3
   mustache4dart: ^1.0.0


### PR DESCRIPTION
- optimize flutter update-packages (fix https://github.com/flutter/flutter/issues/1313, fix https://github.com/flutter/flutter/issues/2104)
- for `flutter update-packages`, scan all the pubspecs, create a new synthetic pubspec, store it in the `bin/cache/artifacts/repo_packages` dir, run pub get/upgrade on that, and then copy the resulting .packages and lock file to the ~15 repo dart projects. flutter update-packages time drops from ~130 seconds to 13. We keep the temp dir in the cache so that subsequent runs are faster (~1-2 seconds).

When we switch to `1.16.0-dev.3.0` we can start using --no-precompile which should halve the initial time.

The output is pretty verbose, but this should only be run by repo developers, and it's nice to have a clear picture of all the packages that we're using.

```
Running 'pub get' in /Users/devoncarew/projects/flutter/flutter/bin/cache/artifacts/repo_packages/...

Repo packages (15):
  packages/cassowary
  packages/flutter
  packages/flutter_driver
  packages/flutter_markdown
  packages/flutter_sprites
  packages/flutter_test
  packages/flutter_tools
  packages/flx
  packages/newton
  packages/playfair
  examples/hello_world
  examples/layers
  examples/material_gallery
  examples/stocks
  dev/manual_tests

Direct depencencies (31):
  analyzer: 0.27.2
  archive: 1.0.20
  args: 0.13.4
  asn1lib: 0.4.1
  bignum: 0.1.0
  box2d: 0.2.0
  collection: 1.5.1
  crypto: 0.9.2
  file: 0.1.0
  flutter_gallery_assets: 0.0.12
  intl: 0.12.7
  json_rpc_2: 1.2.0
  json_schema: 1.0.3
  markdown: 0.9.0
  matcher: 0.12.0+2
  mockito: 0.11.0
  mustache4dart: 1.0.10
  package_config: 0.1.3
  path: 1.3.9
  pointycastle: 0.10.0
  pub_semver: 1.2.3
  quiver: 0.21.4
  sky_engine: 0.0.99
  sky_services: 0.0.99
  stack_trace: 1.6.4
  string_scanner: 0.1.4+1
  test: 0.12.13
  vector_math: 1.4.7
  vm_service_client: 0.1.2+1
  xml: 2.4.2
  yaml: 2.1.8

Transitive depencencies (39):
  async: 1.9.0
  barback: 0.15.2+7
  boolean_selector: 1.0.0
  charcode: 1.1.0
  cli_util: 0.0.1+2
  code_transformers: 0.4.2+1
  convert: 1.0.1
  csslib: 0.12.2
  dart_style: 0.2.4
  fixnum: 0.10.2
  glob: 1.1.1
  html: 0.12.2+1
  http_multi_server: 2.0.0
  http_parser: 2.2.1
  logging: 0.11.2
  mime: 0.9.3
  mojo: 0.4.17
  mojo_sdk: 0.2.20
  mojo_services: 0.4.23
  petitparser: 1.5.1
  plugin: 0.1.0
  pool: 1.2.1
  quiver_collection: 1.0.0
  quiver_iterables: 1.0.0
  quiver_pattern: 1.0.0
  reflectable: 0.5.3
  shelf: 0.6.5
  shelf_static: 0.2.3+3
  shelf_web_socket: 0.2.0
  source_map_stack_trace: 1.0.4
  source_maps: 0.10.1+1
  source_span: 1.2.2
  stream_channel: 1.3.1
  typed_data: 1.1.2
  utf: 0.9.0+3
  watcher: 0.9.7
  web_socket_channel: 1.0.2
  when: 0.2.0
  which: 0.1.3

Elapsed time 11.735 seconds.
```
