### PR TITLE
Support "flutter refresh" in the Gradle-based sample project

### DIFF
--- a/examples/hello_android/app/src/main/java/com/example/flutter/ExampleActivity.java
+++ b/examples/hello_android/app/src/main/java/com/example/flutter/ExampleActivity.java
@@ -6,6 +6,8 @@ package com.example.flutter;
 
 import android.app.Activity;
 import android.content.Context;
+import android.content.Intent;
+import android.content.pm.ApplicationInfo;
 import android.location.Location;
 import android.location.LocationManager;
 import android.os.Bundle;
@@ -74,6 +76,20 @@ public class ExampleActivity extends Activity {
     protected void onResume() {
         super.onResume();
         flutterView.onResume();
+    }
+
+    @Override
+    protected void onNewIntent(Intent intent) {
+        // Reload the Flutter Dart code when the activity receives an intent
+        // from the "flutter refresh" command.
+        // This feature should only be enabled during development.  Use the
+        // debuggable flag as an indicator that we are in development mode.
+        if ((getApplicationInfo().flags & ApplicationInfo.FLAG_DEBUGGABLE) != 0) {
+            if (Intent.ACTION_RUN.equals(intent.getAction())) {
+                flutterView.runFromBundle(intent.getDataString(),
+                                          intent.getStringExtra("snapshot"));
+            }
+        }
     }
 
     private void sendGetRandom() {

--- a/packages/flutter_tools/lib/src/android/android_device.dart
+++ b/packages/flutter_tools/lib/src/android/android_device.dart
@@ -418,7 +418,7 @@ class AndroidDevice extends Device {
   @override
   bool isSupported() => true;
 
-  Future<bool> refreshSnapshot(AndroidApk apk, String snapshotPath) async {
+  Future<bool> refreshSnapshot(String activity, String snapshotPath) async {
     if (!FileSystemEntity.isFileSync(snapshotPath)) {
       printError('Cannot find $snapshotPath');
       return false;
@@ -432,7 +432,7 @@ class AndroidDevice extends Device {
       '-d', _deviceBundlePath,
       '-f', '0x20000000',  // FLAG_ACTIVITY_SINGLE_TOP
       '--es', 'snapshot', _deviceSnapshotPath,
-      apk.launchActivity,
+      activity,
     ]);
     runCheckedSync(cmd);
     return true;

--- a/packages/flutter_tools/lib/src/commands/refresh.dart
+++ b/packages/flutter_tools/lib/src/commands/refresh.dart
@@ -20,6 +20,10 @@ class RefreshCommand extends FlutterCommand {
 
   RefreshCommand() {
     usesTargetOption();
+
+    argParser.addOption('activity',
+      help: 'The Android activity that will be told to reload the Flutter code.'
+    );
   }
 
   @override
@@ -49,11 +53,19 @@ class RefreshCommand extends FlutterCommand {
         return result;
       }
 
+      String activity = argResults['activity'];
+      if (activity == null) {
+        if (applicationPackages.android != null) {
+          activity = applicationPackages.android.launchActivity;
+        } else {
+          printError('Unable to find the activity to be refreshed.');
+          return 1;
+        }
+      }
+
       AndroidDevice device = deviceForCommand;
 
-      bool success = await device.refreshSnapshot(
-        applicationPackages.android, snapshotPath
-      );
+      bool success = await device.refreshSnapshot(activity, snapshotPath);
       if (!success) {
         printError('Error refreshing snapshot on $device.');
         return 1;


### PR DESCRIPTION
After deploying and launching the APK, the app's Dart code can be updated with:
- cd app/src/flutter
- flutter refresh --activity=com.example.flutter/.ExampleActivity
