### PR TITLE
pubspec normalization; remove den

### DIFF
--- a/packages/flutter_driver/pubspec.yaml
+++ b/packages/flutter_driver/pubspec.yaml
@@ -17,6 +17,6 @@ dependencies:
     path: '../flutter_test'
 
 dev_dependencies:
-  test: '>=0.12.6 <1.0.0'
+  test: 0.12.13
   mockito: ^0.11.0
-  quiver: '>=0.21.4 <0.22.0'
+  quiver: ^0.21.4

--- a/packages/flutter_tools/lib/executable.dart
+++ b/packages/flutter_tools/lib/executable.dart
@@ -98,11 +98,18 @@ Future<Null> main(List<String> args) async {
       stderr.writeln();
       stderr.writeln('Oops; flutter has exited unexpectedly: "$error"');
 
-      File file = _createCrashReport(args, error, chain);
-
       stderr.writeln();
-      stderr.writeln('Crash report written to ${path.relative(file.path)}.');
-      stderr.writeln('Please let us know at https://github.com/flutter/flutter/issues!');
+
+      if (Platform.environment.containsKey('FLUTTER_DEV')) {
+        // If we're working in the tools themselves, just print the stack trace.
+        stderr.writeln(chain.terse.toString());
+      } else {
+        File file = _createCrashReport(args, error, chain);
+
+        stderr.writeln('Crash report written to ${path.relative(file.path)}.');
+        stderr.writeln('Please let us know at https://github.com/flutter/flutter/issues!');
+      }
+
       exit(1);
     }
   });

--- a/packages/flutter_tools/lib/src/commands/analyze.dart
+++ b/packages/flutter_tools/lib/src/commands/analyze.dart
@@ -7,7 +7,7 @@ import 'dart:collection';
 import 'dart:convert';
 import 'dart:io';
 
-import 'package:den_api/den_api.dart';
+import 'package:yaml/yaml.dart' as yaml;
 import 'package:path/path.dart' as path;
 
 import '../artifacts.dart';
@@ -123,9 +123,7 @@ class AnalyzeCommand extends FlutterCommand {
   bool get requiresProjectRoot => false;
 
   @override
-  Future<int> runInProject() async {
-    return argResults['watch'] ? _analyzeWatch() : _analyzeOnce();
-  }
+  Future<int> runInProject() => argResults['watch'] ? _analyzeWatch() : _analyzeOnce();
 
   List<String> flutterRootComponents;
   bool isFlutterLibrary(String filename) {
@@ -243,8 +241,8 @@ class AnalyzeCommand extends FlutterCommand {
         // we are analyzing the actual canonical source for this package;
         // make sure we remember that, in case all the packages are actually
         // pointing elsewhere somehow.
-        Pubspec pubSpecYaml = await Pubspec.load(pubSpecYamlPath);
-        String packageName = pubSpecYaml.name;
+        yaml.YamlMap pubSpecYaml = yaml.loadYaml(new File(pubSpecYamlPath).readAsStringSync());
+        String packageName = pubSpecYaml['name'];
         String packagePath = path.normalize(path.absolute(path.join(directory.path, 'lib')));
         dependencies.addCanonicalCase(packageName, packagePath, pubSpecYamlPath);
       }

--- a/packages/flutter_tools/pubspec.yaml
+++ b/packages/flutter_tools/pubspec.yaml
@@ -12,7 +12,6 @@ dependencies:
   archive: ^1.0.20
   args: ^0.13.4
   crypto: 0.9.2
-  den_api: ^0.1.0
   file: ^0.1.0
   json_schema: ^1.0.3
   mustache4dart: ^1.0.0


### PR DESCRIPTION
Some changes from https://github.com/flutter/flutter/pull/3029:
- normalize the text of the version deps on `test` and `quiver`
- remove the use of the `den` package
- when running in `FLUTTER_DEV` mode, just dump traces to stdout
