### PR TITLE
Rationalise all our exception handling.

### DIFF
--- a/packages/flutter/lib/src/http/mojo_client.dart
+++ b/packages/flutter/lib/src/http/mojo_client.dart
@@ -149,14 +149,14 @@ class MojoClient {
       ByteData data = await mojo.DataPipeDrainer.drainHandle(response.body);
       Uint8List bodyBytes = new Uint8List.view(data.buffer);
       return new Response(bodyBytes: bodyBytes, statusCode: response.statusCode);
-    } catch (exception) {
-      assert(() {
-        debugPrint('-- EXCEPTION CAUGHT BY NETWORKING HTTP LIBRARY -------------------------');
-        debugPrint('An exception was raised while sending bytes to the Mojo network library:');
-        debugPrint('$exception');
-        debugPrint('------------------------------------------------------------------------');
-        return true;
-      });
+    } catch (exception, stack) {
+      FlutterError.reportError(new FlutterErrorDetails(
+        exception: exception,
+        stack: stack,
+        library: 'networking HTTP library',
+        context: 'while sending bytes to the Mojo network library',
+        silent: true
+      ));
       return new Response(statusCode: 500);
     } finally {
       loader.close();

--- a/packages/flutter/lib/src/rendering/box.dart
+++ b/packages/flutter/lib/src/rendering/box.dart
@@ -795,10 +795,13 @@ abstract class RenderBox extends RenderObject {
   void performLayout() {
     assert(() {
       if (!sizedByParent) {
-        debugPrint('$runtimeType needs to either override performLayout() to\n'
-          'set size and lay out children, or, set sizedByParent to true\n'
-          'so that performResize() sizes the render object.');
-        assert(sizedByParent);
+        throw new FlutterError(
+          '$runtimeType did not implement performLayout().\n'
+          'RenderBox subclasses need to either override performLayout() to '
+          'set a size and lay out any children, or, set sizedByParent to true '
+          'so that performResize() sizes the render object.'
+        );
+        return true;
       }
       return true;
     });

--- a/packages/flutter/lib/src/scheduler/scheduler.dart
+++ b/packages/flutter/lib/src/scheduler/scheduler.dart
@@ -24,15 +24,7 @@ double timeDilation = 1.0;
 /// common time base.
 typedef void FrameCallback(Duration timeStamp);
 
-typedef void SchedulerExceptionHandler(dynamic exception, StackTrace stack);
-
 typedef bool SchedulingStrategy({ int priority, Scheduler scheduler });
-
-/// This callback is invoked whenever an exception is caught by the scheduler.
-/// The 'exception' argument contains the object that was thrown, and the
-/// 'stack' argument contains the stack trace. If the callback is set, it is
-/// invoked instead of printing the information to the console.
-SchedulerExceptionHandler debugSchedulerExceptionHandler;
 
 /// An entry in the scheduler's priority queue.
 ///
@@ -277,16 +269,12 @@ abstract class Scheduler extends BindingBase {
     try {
       callback(timeStamp);
     } catch (exception, stack) {
-      if (debugSchedulerExceptionHandler != null) {
-        debugSchedulerExceptionHandler(exception, stack);
-      } else {
-        debugPrint('-- EXCEPTION CAUGHT BY SCHEDULER LIBRARY -------------------------------');
-        debugPrint('An exception was raised during a scheduler callback:');
-        debugPrint('$exception');
-        debugPrint('Stack trace:');
-        debugPrint('$stack');
-        debugPrint('------------------------------------------------------------------------');
-      }
+      FlutterError.reportError(new FlutterErrorDetails(
+        exception: exception,
+        stack: stack,
+        library: 'scheduler library',
+        context: 'during a scheduler callback'
+      ));
     }
   }
 

--- a/packages/flutter/lib/src/services/assertions.dart
+++ b/packages/flutter/lib/src/services/assertions.dart
@@ -2,6 +2,79 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'print.dart';
+
+/// Signature for [FlutterError.onException] handler.
+typedef void FlutterExceptionHandler(FlutterErrorDetails details);
+
+/// Signature for [FlutterErrorDetails.informationCollector] callback.
+///
+/// The text written to the information argument may contain newlines but should
+/// not end with a newline.
+typedef void FlutterInformationCollector(StringBuffer information);
+
+/// Class for information provided to [FlutterExceptionHandler] callbacks.
+///
+/// See [FlutterError.onError].
+class FlutterErrorDetails {
+  /// Creates a [FlutterErrorDetails] object with the given arguments setting
+  /// the object's properties.
+  ///
+  /// The framework calls this constructor when catching an exception that will
+  /// subsequently be reported using [FlutterError.onError].
+  const FlutterErrorDetails({
+    this.exception,
+    this.stack,
+    this.library: 'Flutter framework',
+    this.context,
+    this.informationCollector,
+    this.silent: false
+  });
+
+  /// The exception. Often this will be an [AssertionError], maybe specifically
+  /// a [FlutterError]. However, this could be any value at all.
+  final dynamic exception;
+
+  /// The stack trace from where the [exception] was thrown (as opposed to where
+  /// it was caught).
+  ///
+  /// StackTrace objects are opaque except for their [toString] function. A
+  /// stack trace is not expected to be machine-readable.
+  final StackTrace stack;
+
+  /// A human-readable brief name describing the library that caught the error
+  /// message. This is used by the default error handler in the header dumped to
+  /// the console.
+  final String library;
+
+  /// A human-readable description of where the error was caught (as opposed to
+  /// where it was thrown).
+  final String context;
+
+  /// A callback which, when invoked with a [StringBuffer] will write to that buffer
+  /// information that could help with debugging the problem.
+  ///
+  /// Information collector callbacks can be expensive, so the generated information
+  /// should be cached, rather than the callback being invoked multiple times.
+  final FlutterInformationCollector informationCollector;
+
+  /// Whether this error should be ignored by the default error reporting
+  /// behavior in release mode.
+  ///
+  /// If this is false, the default, then the default error handler will always
+  /// dump this error to the console.
+  ///
+  /// If this is true, then the default error handler would only dump this error
+  /// to the console in checked mode. In release mode, the error is ignored.
+  ///
+  /// This is used by certain exception handlers that catch errors that could be
+  /// triggered by environmental conditions (as opposed to logic errors). For
+  /// example, the HTTP library sets this flag so as to not report every 404
+  /// error to the console on end-user devices, while still allowing a custom
+  /// error handler to see the errors even in release builds.
+  final bool silent;
+}
+
 /// Error class used to report Flutter-specific assertion failures and
 /// contract violations.
 class FlutterError extends AssertionError {
@@ -17,14 +90,16 @@ class FlutterError extends AssertionError {
 
   /// The message associated with this error.
   ///
-  /// The message may have newlines in it. The first line should be a
-  /// terse description of the error, e.g. "Incorrect GlobalKey usage"
-  /// or "setState() or markNeedsBuild() called during build".
-  /// Subsequent lines can then contain more information. In some
-  /// cases, when a FlutterError is reported to the user, only the
-  /// first line is included. For example, Flutter will typically only
-  /// fully report the first exception at runtime, displaying only the
-  /// first line of subsequent errors.
+  /// The message may have newlines in it. The first line should be a terse
+  /// description of the error, e.g. "Incorrect GlobalKey usage" or "setState()
+  /// or markNeedsBuild() called during build". Subsequent lines should contain
+  /// substantial additional information, ideally sufficient to develop a
+  /// correct solution to the problem.
+  ///
+  /// In some cases, when a FlutterError is reported to the user, only the first
+  /// line is included. For example, Flutter will typically only fully report
+  /// the first exception at runtime, displaying only the first line of
+  /// subsequent errors.
   ///
   /// All sentences in the error should be correctly punctuated (i.e.,
   /// do end the error message with a period).
@@ -32,4 +107,70 @@ class FlutterError extends AssertionError {
 
   @override
   String toString() => message;
+
+  /// Called whenever the Flutter framework catches an error.
+  ///
+  /// The default behavior is to invoke [dumpErrorToConsole].
+  ///
+  /// You can set this to your own function to override this default behavior.
+  /// For example, you could report all errors to your server.
+  ///
+  /// If the error handler throws an exception, it will not be caught by the
+  /// Flutter framework.
+  ///
+  /// Set this to null to silently catch and ignore errors. This is not
+  /// recommended.
+  static FlutterExceptionHandler onError = dumpErrorToConsole;
+
+  static int _errorCount = 0;
+
+  /// Prints the given exception details to the console.
+  ///
+  /// The first time this is called, it dumps a very verbose message to the
+  /// console using [debugPrint].
+  ///
+  /// Subsequent calls only dump the first line of the exception.
+  ///
+  /// This is the default behavior for the [onError] handler.
+  static void dumpErrorToConsole(FlutterErrorDetails details) {
+    assert(details != null);
+    assert(details.exception != null);
+    bool reportError = !details.silent;
+    assert(() {
+      // In checked mode, we ignore the "silent" flag.
+      reportError = true;
+      return true;
+    });
+    if (!reportError)
+      return;
+    if (_errorCount == 0) {
+      final String header = '-- EXCEPTION CAUGHT BY ${details.library} '.toUpperCase();
+      const String footer = '------------------------------------------------------------------------';
+      debugPrint('$header${"-" * (footer.length - header.length)}');
+      debugPrint('The following exception was raised${ details.context != null ? " ${details.context}" : ""}:');
+      debugPrint('${details.exception}');
+      if (details.informationCollector != null) {
+        StringBuffer information = new StringBuffer();
+        details.informationCollector(information);
+        debugPrint(information.toString());
+      }
+      if (details.stack != null) {
+        debugPrint('Stack trace:');
+        debugPrint('${details.stack}$footer');
+      } else {
+        debugPrint(footer);
+      }
+    } else {
+      debugPrint('Another exception was raised: ${details.exception.toString().split("\n")[0]}');
+    }
+    _errorCount += 1;
+  }
+
+  /// Calls [onError] with the given details, unless it is null.
+  static void reportError(FlutterErrorDetails details) {
+    assert(details != null);
+    assert(details.exception != null);
+    if (onError != null)
+      onError(details);
+  }
 }

--- a/packages/flutter/lib/src/services/fetch.dart
+++ b/packages/flutter/lib/src/services/fetch.dart
@@ -8,8 +8,8 @@ import 'package:mojo/mojo/url_request.mojom.dart' as mojom;
 import 'package:mojo/mojo/url_response.mojom.dart' as mojom;
 import 'package:mojo_services/mojo/url_loader.mojom.dart' as mojom;
 
+import 'assertions.dart';
 import '../http/mojo_client.dart';
-import 'print.dart';
 
 export 'package:mojo/mojo/url_response.mojom.dart' show UrlResponse;
 
@@ -27,14 +27,17 @@ Future<mojom.UrlResponse> fetch(mojom.UrlRequest request, { bool require200: fal
         message.writeln('Protocol error: ${response.statusCode} ${response.statusLine ?? "<no server message>"}');
       if (response.url != request.url)
         message.writeln('Final URL after redirects was: ${response.url}');
-      throw message;
+      throw message; // this is not a FlutterError, because it's a real error, not an assertion
     }
     return response;
-  } catch (exception) {
-    debugPrint('-- EXCEPTION CAUGHT BY NETWORKING HTTP LIBRARY -------------------------');
-    debugPrint('An exception was raised while sending bytes to the Mojo network library:');
-    debugPrint('$exception');
-    debugPrint('------------------------------------------------------------------------');
+  } catch (exception, stack) {
+    FlutterError.reportError(new FlutterErrorDetails(
+      exception: exception,
+      stack: stack,
+      library: 'fetch service',
+      context: 'while sending bytes to the Mojo network library',
+      silent: true
+    ));
     return null;
   } finally {
     loader.close();

--- a/packages/flutter/lib/src/services/image_resource.dart
+++ b/packages/flutter/lib/src/services/image_resource.dart
@@ -5,7 +5,7 @@
 import 'dart:async';
 import 'dart:ui' as ui show Image;
 
-import 'print.dart';
+import 'assertions.dart';
 
 /// A [ui.Image] object with its corresponding scale.
 ///
@@ -61,7 +61,7 @@ class ImageResource {
     _futureImage.then(
       _handleImageLoaded,
       onError: (dynamic exception, dynamic stack) {
-        _handleImageError('Failed to load image:', exception, stack);
+        _handleImageError('while loading an image', exception, stack);
       }
     );
   }
@@ -86,7 +86,7 @@ class ImageResource {
       try {
         listener(_image);
       } catch (exception, stack) {
-        _handleImageError('The following exception was thrown by a synchronously-invoked image listener:', exception, stack);
+        _handleImageError('by a synchronously-invoked image listener', exception, stack);
       }
     }
   }
@@ -109,18 +109,18 @@ class ImageResource {
       try {
         listener(_image);
       } catch (exception, stack) {
-        _handleImageError('The following exception was thrown by an image listener:', exception, stack);
+        _handleImageError('by an image listener', exception, stack);
       }
     }
   }
 
-  void _handleImageError(String message, dynamic exception, dynamic stack) {
-    debugPrint('-- EXCEPTION CAUGHT BY SERVICES LIBRARY --------------------------------');
-    debugPrint(message);
-    debugPrint('$exception');
-    debugPrint('Stack trace:');
-    debugPrint('$stack');
-    debugPrint('------------------------------------------------------------------------');
+  void _handleImageError(String context, dynamic exception, dynamic stack) {
+    FlutterError.reportError(new FlutterErrorDetails(
+      exception: exception,
+      stack: stack,
+      library: 'image resource service',
+      context: context
+    ));
   }
 
   @override

--- a/packages/flutter/lib/src/widgets/binding.dart
+++ b/packages/flutter/lib/src/widgets/binding.dart
@@ -170,7 +170,7 @@ class RenderObjectToWidgetAdapter<T extends RenderObject> extends RenderObjectWi
       } else {
         element.update(this);
       }
-    }, building: true);
+    }, building: true, context: 'while attaching root widget to rendering tree');
     return element;
   }
 

--- a/packages/flutter/lib/src/widgets/mixed_viewport.dart
+++ b/packages/flutter/lib/src/widgets/mixed_viewport.dart
@@ -254,7 +254,7 @@ class _MixedViewportElement extends RenderObjectElement {
     }
     owner.lockState(() {
       _doLayout(constraints);
-    }, building: true);
+    }, building: true, context: 'during $runtimeType layout');
   }
 
   void postLayout() {

--- a/packages/flutter/lib/src/widgets/virtual_viewport.dart
+++ b/packages/flutter/lib/src/widgets/virtual_viewport.dart
@@ -157,7 +157,7 @@ abstract class VirtualViewportElement extends RenderObjectElement {
     assert(startOffsetBase != null);
     assert(startOffsetLimit != null);
     _updatePaintOffset();
-    owner.lockState(_materializeChildren, building: true);
+    owner.lockState(_materializeChildren, building: true, context: 'during $runtimeType layout');
   }
 
   void _materializeChildren() {

--- a/packages/flutter/test/widget/image_test.dart
+++ b/packages/flutter/test/widget/image_test.dart
@@ -112,18 +112,16 @@ void main() {
           child: new AsyncImage(
             provider: imageProvider1
           )
-        )
+        ),
+        null,
+        EnginePhase.layout
       );
       RenderImage renderImage = key.currentContext.findRenderObject();
       expect(renderImage.image, isNull);
 
-      // An exception will be thrown when we try to draw the image.  Catch it.
-      RenderingExceptionHandler originalRenderingExceptionHandler = debugRenderingExceptionHandler;
-      debugRenderingExceptionHandler = (_, __, ___, ____) => null;
       imageProvider1.complete();
-      tester.pump();
-      tester.pump();
-      debugRenderingExceptionHandler = originalRenderingExceptionHandler;
+      tester.async.flushMicrotasks(); // resolve the future from the image provider
+      tester.pump(null, EnginePhase.layout);
 
       renderImage = key.currentContext.findRenderObject();
       expect(renderImage.image, isNotNull);
@@ -135,7 +133,9 @@ void main() {
           child: new AsyncImage(
             provider: imageProvider2
           )
-        )
+        ),
+        null,
+        EnginePhase.layout
       );
 
       renderImage = key.currentContext.findRenderObject();
@@ -152,18 +152,16 @@ void main() {
         new AsyncImage(
             key: key,
             provider: imageProvider1
-        )
+        ),
+        null,
+        EnginePhase.layout
       );
       RenderImage renderImage = key.currentContext.findRenderObject();
       expect(renderImage.image, isNull);
 
-      // An exception will be thrown when we try to draw the image.  Catch it.
-      RenderingExceptionHandler originalRenderingExceptionHandler = debugRenderingExceptionHandler;
-      debugRenderingExceptionHandler = (_, __, ___, ____) => null;
       imageProvider1.complete();
-      tester.pump();
-      tester.pump();
-      debugRenderingExceptionHandler = originalRenderingExceptionHandler;
+      tester.async.flushMicrotasks(); // resolve the future from the image provider
+      tester.pump(null, EnginePhase.layout);
 
       renderImage = key.currentContext.findRenderObject();
       expect(renderImage.image, isNotNull);
@@ -173,7 +171,9 @@ void main() {
         new AsyncImage(
           key: key,
           provider: imageProvider2
-        )
+        ),
+        null,
+        EnginePhase.layout
       );
 
       renderImage = key.currentContext.findRenderObject();

--- a/packages/flutter/test/widget/parent_data_test.dart
+++ b/packages/flutter/test/widget/parent_data_test.dart
@@ -48,20 +48,6 @@ void checkTree(WidgetTester tester, List<TestParentData> expectedParentData) {
 final TestParentData kNonPositioned = new TestParentData();
 
 void main() {
-  dynamic cachedException;
-
-  setUp(() {
-    assert(cachedException == null);
-    debugWidgetsExceptionHandler = (String context, dynamic exception, StackTrace stack) {
-      cachedException = exception;
-    };
-  });
-
-  tearDown(() {
-    cachedException = null;
-    debugWidgetsExceptionHandler = null;
-  });
-
   test('ParentDataWidget control test', () {
     testWidgets((WidgetTester tester) {
 
@@ -259,8 +245,6 @@ void main() {
 
   test('ParentDataWidget conflicting data', () {
     testWidgets((WidgetTester tester) {
-      expect(cachedException, isNull);
-
       tester.pumpWidget(
         new Stack(
           children: <Widget>[
@@ -276,14 +260,11 @@ void main() {
           ]
         )
       );
-
-      expect(cachedException, isNotNull);
-      cachedException = null;
+      expect(tester.takeException(), isNotNull);
 
       tester.pumpWidget(new Stack());
 
       checkTree(tester, <TestParentData>[]);
-      expect(cachedException, isNull);
 
       tester.pumpWidget(
         new Container(
@@ -298,9 +279,7 @@ void main() {
           )
         )
       );
-
-      expect(cachedException, isNotNull);
-      cachedException = null;
+      expect(tester.takeException(), isNotNull);
 
       tester.pumpWidget(
         new Stack()


### PR DESCRIPTION
- Create a FlutterErrorDetails struct-like class that describes an
  exception along with more details that aren't in the exception, like
  where it was caught and what was going on when it was caught.
- Provide a FlutterError static API for handling these objects:
  - FlutterError.onError which is called whenever Flutter catches an
    error.
  - FlutterError.reportError() which handles an error.
  - FlutterError.dumpErrorToConsole() which is the default behavior
    for onError.
- Removes all the existing exception handler callbacks.
- Replaces all the existing places that described exceptions using
  debugPrint with calls to FlutterError.reportError().
- Extend lockState() to also catch exceptions, so that we catch
  exceptions that happen during finalizers.
- Make the test framework catch errors and treat them as failures.
- Provide a mechanism to override this behavior in the test framework.
- Make the tests that used to depend on the exception handler
  callbacks use this new mechanism.
- Make pump() also support the phase argument.
- Improve some tests using these new features.

Fixes #2356, #2988, #2985, #2220.
