### PR TITLE
simplify toolchain setup

### DIFF
--- a/packages/flutter_tools/lib/src/application_package.dart
+++ b/packages/flutter_tools/lib/src/application_package.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:async';
 import 'dart:io';
 
 import 'package:path/path.dart' as path;
@@ -118,7 +117,7 @@ class ApplicationPackageStore {
     }
   }
 
-  static Future<ApplicationPackageStore> forConfigs(List<BuildConfiguration> configs) async {
+  static ApplicationPackageStore forConfigs(List<BuildConfiguration> configs) {
     AndroidApk android;
     IOSApp iOS;
 

--- a/packages/flutter_tools/lib/src/commands/build_apk.dart
+++ b/packages/flutter_tools/lib/src/commands/build_apk.dart
@@ -185,8 +185,6 @@ class BuildApkCommand extends FlutterCommand {
       return 1;
     }
 
-    await downloadToolchain();
-
     // TODO(devoncarew): This command should take an arg for the output type (arm / x64).
 
     return await buildAndroid(

--- a/packages/flutter_tools/lib/src/commands/build_flx.dart
+++ b/packages/flutter_tools/lib/src/commands/build_flx.dart
@@ -40,10 +40,7 @@ class BuildFlxCommand extends FlutterCommand {
   @override
   Future<int> runInProject() async {
     String compilerPath = argResults['compiler'];
-
-    if (compilerPath == null)
-      await downloadToolchain();
-    else
+    if (compilerPath != null)
       toolchain = new Toolchain(compiler: new SnapshotCompiler(compilerPath));
 
     String outputPath = argResults['output-file'];

--- a/packages/flutter_tools/lib/src/commands/build_ios.dart
+++ b/packages/flutter_tools/lib/src/commands/build_ios.dart
@@ -31,13 +31,6 @@ class BuildIOSCommand extends FlutterCommand {
       return 1;
     }
 
-    printTrace('Ensuring toolchains are up to date.');
-
-    await Future.wait([
-      downloadToolchain(),
-      downloadApplicationPackages(),
-    ], eagerError: true);
-
     IOSApp app = applicationPackages.iOS;
 
     if (app == null) {

--- a/packages/flutter_tools/lib/src/commands/daemon.dart
+++ b/packages/flutter_tools/lib/src/commands/daemon.dart
@@ -262,11 +262,6 @@ class AppDomain extends Domain {
     Directory.current = new Directory(projectDirectory);
 
     try {
-      await Future.wait([
-        command.downloadToolchain(),
-        command.downloadApplicationPackages(),
-      ], eagerError: true);
-
       int result = await startApp(
         device,
         command.applicationPackages,
@@ -304,11 +299,6 @@ class AppDomain extends Domain {
     Directory.current = new Directory(projectDirectory);
 
     try {
-      await Future.wait([
-        command.downloadToolchain(),
-        command.downloadApplicationPackages(),
-      ], eagerError: true);
-
       ApplicationPackage app = command.applicationPackages.getPackageForPlatform(device.platform);
       return device.stopApp(app);
     } finally {

--- a/packages/flutter_tools/lib/src/commands/drive.dart
+++ b/packages/flutter_tools/lib/src/commands/drive.dart
@@ -80,8 +80,6 @@ class DriveCommand extends RunCommandBase {
 
   @override
   Future<int> runInProject() async {
-    await toolchainDownloader(this);
-
     String testFile = _getTestFile();
     if (testFile == null) {
       return 1;
@@ -310,19 +308,4 @@ Future<int> stopApp(DriveCommand command) async {
       .getPackageForPlatform(command.device.platform);
   bool stopped = await command.device.stopApp(package);
   return stopped ? 0 : 1;
-}
-
-/// Downloads Flutter toolchain.
-typedef Future<Null> ToolchainDownloader(DriveCommand command);
-ToolchainDownloader toolchainDownloader = downloadToolchain;
-void restoreToolchainDownloader() {
-  toolchainDownloader = downloadToolchain;
-}
-
-Future<Null> downloadToolchain(DriveCommand command) async {
-  printTrace('Downloading toolchain.');
-  await Future.wait([
-    command.downloadToolchain(),
-    command.downloadApplicationPackages(),
-  ], eagerError: true);
 }

--- a/packages/flutter_tools/lib/src/commands/install.dart
+++ b/packages/flutter_tools/lib/src/commands/install.dart
@@ -21,8 +21,6 @@ class InstallCommand extends FlutterCommand {
 
   @override
   Future<int> runInProject() async {
-    await downloadApplicationPackages();
-
     Device device = deviceForCommand;
     ApplicationPackage package = applicationPackages.getPackageForPlatform(device.platform);
 

--- a/packages/flutter_tools/lib/src/commands/listen.dart
+++ b/packages/flutter_tools/lib/src/commands/listen.dart
@@ -32,9 +32,6 @@ class ListenCommand extends RunCommandBase {
 
   @override
   Future<int> runInProject() async {
-    await downloadApplicationPackages();
-    await downloadToolchain();
-
     Iterable<String> directories = () sync* {
       yield* argResults.rest;
       yield '.';

--- a/packages/flutter_tools/lib/src/commands/refresh.dart
+++ b/packages/flutter_tools/lib/src/commands/refresh.dart
@@ -34,13 +34,6 @@ class RefreshCommand extends FlutterCommand {
 
   @override
   Future<int> runInProject() async {
-    printTrace('Downloading toolchain.');
-
-    await Future.wait([
-      downloadToolchain(),
-      downloadApplicationPackages(),
-    ], eagerError: true);
-
     Directory tempDir = await Directory.systemTemp.createTemp('flutter_tools');
     try {
       String snapshotPath = path.join(tempDir.path, 'snapshot_blob.bin');

--- a/packages/flutter_tools/lib/src/commands/run.dart
+++ b/packages/flutter_tools/lib/src/commands/run.dart
@@ -94,13 +94,6 @@ class RunCommand extends RunCommandBase {
 
   @override
   Future<int> runInProject() async {
-    printTrace('Downloading toolchain.');
-
-    await Future.wait([
-      downloadToolchain(),
-      downloadApplicationPackages(),
-    ], eagerError: true);
-
     bool clearLogs = argResults['clear-logs'];
 
     int debugPort;

--- a/packages/flutter_tools/lib/src/commands/run_mojo.dart
+++ b/packages/flutter_tools/lib/src/commands/run_mojo.dart
@@ -162,8 +162,6 @@ class RunMojoCommand extends FlutterCommand {
       return 1;
     }
 
-    await downloadToolchain();
-
     String targetApp = argResults['app'];
     if (targetApp == null) {
       targetApp = _kDefaultBundlePath;

--- a/packages/flutter_tools/lib/src/commands/stop.dart
+++ b/packages/flutter_tools/lib/src/commands/stop.dart
@@ -21,7 +21,6 @@ class StopCommand extends FlutterCommand {
 
   @override
   Future<int> runInProject() async {
-    await downloadApplicationPackages();
     Device device = deviceForCommand;
     ApplicationPackage app = applicationPackages.getPackageForPlatform(device.platform);
     printStatus('Stopping apps on ${device.name}.');

--- a/packages/flutter_tools/lib/src/commands/trace.dart
+++ b/packages/flutter_tools/lib/src/commands/trace.dart
@@ -38,8 +38,6 @@ class TraceCommand extends FlutterCommand {
 
   @override
   Future<int> runInProject() async {
-    await downloadApplicationPackages();
-
     ApplicationPackage androidApp = applicationPackages.android;
     AndroidDevice device = deviceForCommand;
 

--- a/packages/flutter_tools/lib/src/ios/plist_utils.dart
+++ b/packages/flutter_tools/lib/src/ios/plist_utils.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:io';
+
 import 'package:path/path.dart' as path;
 
 import '../base/process.dart';
@@ -9,21 +11,22 @@ import '../base/process.dart';
 const String kCFBundleIdentifierKey = "CFBundleIdentifier";
 
 String getValueFromFile(String plistFilePath, String key) {
-  // TODO(chinmaygarde): For now, we only need to read from plist files on a
-  // mac host. If this changes, we will need our own Dart plist reader.
+  // TODO(chinmaygarde): For now, we only need to read from plist files on a mac
+  // host. If this changes, we will need our own Dart plist reader.
 
   // Don't use PlistBuddy since that is not guaranteed to be installed.
   // 'defaults' requires the path to be absolute and without the 'plist'
   // extension.
+
+  if (!FileSystemEntity.isFileSync(plistFilePath))
+    return null;
+
   String normalizedPlistPath = path.withoutExtension(path.absolute(plistFilePath));
 
   try {
     String value = runCheckedSync(<String>[
-      '/usr/bin/defaults',
-      'read',
-      normalizedPlistPath,
-      key
-    ]).trim();
+      '/usr/bin/defaults', 'read', normalizedPlistPath, key
+    ]);
     return value.isEmpty ? null : value;
   } catch (error) {
     return null;

--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -58,12 +58,12 @@ abstract class FlutterCommand extends Command {
     _usesPubOption = true;
   }
 
-  Future<Null> downloadToolchain() async {
-    toolchain ??= await Toolchain.forConfigs(buildConfigurations);
+  void _setupToolchain() {
+    toolchain ??= Toolchain.forConfigs(buildConfigurations);
   }
 
-  Future<Null> downloadApplicationPackages() async {
-    applicationPackages ??= await ApplicationPackageStore.forConfigs(buildConfigurations);
+  void _setupApplicationPackages() {
+    applicationPackages ??= ApplicationPackageStore.forConfigs(buildConfigurations);
   }
 
   @override
@@ -125,6 +125,9 @@ abstract class FlutterCommand extends Command {
       if (exitCode != 0)
         return exitCode;
     }
+
+    _setupToolchain();
+    _setupApplicationPackages();
 
     return await runInProject();
   }

--- a/packages/flutter_tools/lib/src/toolchain.dart
+++ b/packages/flutter_tools/lib/src/toolchain.dart
@@ -57,7 +57,7 @@ class Toolchain {
 
   final SnapshotCompiler compiler;
 
-  static Future<Toolchain> forConfigs(List<BuildConfiguration> configs) async {
+  static Toolchain forConfigs(List<BuildConfiguration> configs) {
     for (BuildConfiguration config in configs) {
       String compilerPath = _getCompilerPath(config);
       if (compilerPath != null)

--- a/packages/flutter_tools/test/drive_test.dart
+++ b/packages/flutter_tools/test/drive_test.dart
@@ -35,7 +35,6 @@ void main() {
       command = new DriveCommand();
       applyMocksToCommand(command);
       useInMemoryFileSystem(cwd: '/some/app');
-      toolchainDownloader = (_) async { };
       targetDeviceFinder = () {
         throw 'Unexpected call to targetDeviceFinder';
       };


### PR DESCRIPTION
The toolchain download is now handled by the flutter.sh script. Remove older code that used to handle downloading - change it to just creating the necessary Dart objects.
