### PR TITLE
Gallery Tweaks

### DIFF
--- a/examples/material_gallery/lib/demo/modal_bottom_sheet_demo.dart
+++ b/examples/material_gallery/lib/demo/modal_bottom_sheet_demo.dart
@@ -16,22 +16,18 @@ class ModalBottomSheetDemo extends StatelessWidget {
     return new Scaffold(
       appBar: new AppBar(title: new Text("Modal Bottom Sheet")),
       body: new Center(
-        child: new Container(
-          width: 200.0,
-          height: 200.0,
-          child: new RaisedButton(
-            child: new Text('Show the modal bottom sheet', style: textStyle),
-            onPressed: () {
-              showModalBottomSheet/*<Null>*/(context: context, builder: (BuildContext context) {
-                return new Container(
-                  child: new Padding(
-                    padding: const EdgeInsets.all(32.0),
-                    child: new Text("This is the modal bottom sheet. Click anywhere to dismiss.", style: textStyle)
-                  )
-                );
-              });
-            }
-          )
+        child: new RaisedButton(
+          child: new Text('SHOW BOTTOM SHEET'),
+          onPressed: () {
+            showModalBottomSheet/*<Null>*/(context: context, builder: (BuildContext context) {
+              return new Container(
+                child: new Padding(
+                  padding: const EdgeInsets.all(32.0),
+                  child: new Text("This is the modal bottom sheet. Click anywhere to dismiss.", style: textStyle)
+                )
+              );
+            });
+          }
         )
       )
     );

--- a/examples/material_gallery/lib/demo/persistent_bottom_sheet_demo.dart
+++ b/examples/material_gallery/lib/demo/persistent_bottom_sheet_demo.dart
@@ -4,7 +4,13 @@
 
 import 'package:flutter/material.dart';
 
-class PersistentBottomSheetDemo extends StatelessWidget {
+class PersistentBottomSheetDemo extends StatefulWidget {
+  @override
+  _PersistentBottomSheetDemoState createState() => new _PersistentBottomSheetDemoState();
+}
+
+class _PersistentBottomSheetDemoState extends State<PersistentBottomSheetDemo> {
+  final GlobalKey<ScaffoldState> _scaffoldKey = new GlobalKey<ScaffoldState>();
 
   final TextStyle textStyle = new TextStyle(
     color: Colors.indigo[400],
@@ -12,8 +18,20 @@ class PersistentBottomSheetDemo extends StatelessWidget {
     textAlign: TextAlign.center
   );
 
-  void showBottomSheet(BuildContext context) {
-    Scaffold.of(context).showBottomSheet((_) {
+  VoidCallback _showBottomSheetCallback;
+
+  @override
+  void initState() {
+    super.initState();
+    _showBottomSheetCallback = showBottomSheet;
+  }
+
+
+  void showBottomSheet() {
+    setState(() { // disable the button
+      _showBottomSheetCallback = null;
+    });
+    _scaffoldKey.currentState.showBottomSheet/*<Null>*/((BuildContext context) {
       return new Container(
         decoration: new BoxDecoration(
           border: new Border(top: new BorderSide(color: Colors.black26))
@@ -23,30 +41,28 @@ class PersistentBottomSheetDemo extends StatelessWidget {
           child: new Text("This is a Material persistent bottom sheet. Drag downwards to dismiss it.", style: textStyle)
         )
       );
+    })
+    .closed.then((_) {
+      setState(() { // re-enable the button
+        _showBottomSheetCallback = showBottomSheet;
+      });
     });
   }
 
   @override
-  Widget build(BuildContext notUsed) { // Can't find the Scaffold from this context.
+  Widget build(BuildContext context) {
     return new Scaffold(
+      key: _scaffoldKey,
       appBar: new AppBar(title: new Text("Persistent Bottom Sheet")),
       floatingActionButton: new FloatingActionButton(
         child: new Icon(icon: Icons.add),
         backgroundColor: Colors.redAccent[200]
       ),
-      body: new Builder(
-        builder: (BuildContext context) {
-          return new Center(
-            child: new Container(
-              width: 200.0,
-              height: 200.0,
-              child: new RaisedButton(
-                onPressed: () { showBottomSheet(context); },
-                child: new Text('Show the persistent bottom sheet', style: textStyle)
-              )
-            )
-          );
-        }
+      body: new Center(
+        child: new RaisedButton(
+          onPressed: _showBottomSheetCallback,
+          child: new Text('SHOW BOTTOM SHEET')
+        )
       )
     );
   }

--- a/examples/material_gallery/lib/demo/snack_bar_demo.dart
+++ b/examples/material_gallery/lib/demo/snack_bar_demo.dart
@@ -17,8 +17,15 @@ const String _text2 =
 const String _text3 =
   "By default snackbars automatically disappear after a few seconds ";
 
-class SnackBarDemo extends StatelessWidget {
+class SnackBarDemo extends StatefulWidget {
   SnackBarDemo({ Key key }) : super(key: key);
+
+  @override
+  _SnackBarDemoState createState() => new _SnackBarDemoState();
+}
+
+class _SnackBarDemoState extends State<SnackBarDemo> {
+  int _snackBarIndex = 1;
 
   Widget buildBody(BuildContext context) {
     return new Padding(
@@ -27,21 +34,24 @@ class SnackBarDemo extends StatelessWidget {
         children: <Widget>[
           new Text(_text1),
           new Text(_text2),
-          new RaisedButton(
-            child: new Text('Show a SnackBar'),
-            onPressed: () {
-              Scaffold.of(context).showSnackBar(new SnackBar(
-                content: new Text('This is a SnackBar'),
-                action: new SnackBarAction(
-                  label: 'ACTION',
-                  onPressed: () {
-                    Scaffold.of(context).showSnackBar(new SnackBar(
-                      content: new Text("You pressed the SnackBar's Action")
-                    ));
-                  }
-                )
-              ));
-            }
+          new Center(
+            child: new RaisedButton(
+              child: new Text('SHOW A SNACKBAR'),
+              onPressed: () {
+                final int thisSnackBarIndex = _snackBarIndex++;
+                Scaffold.of(context).showSnackBar(new SnackBar(
+                  content: new Text('This is SnackBar #$thisSnackBarIndex'),
+                  action: new SnackBarAction(
+                    label: 'ACTION',
+                    onPressed: () {
+                      Scaffold.of(context).showSnackBar(new SnackBar(
+                        content: new Text("You pressed SnackBar $thisSnackBarIndex's Action")
+                      ));
+                    }
+                  )
+                ));
+              }
+            )
           ),
           new Text(_text3),
         ]


### PR DESCRIPTION
- Rightsized the snackbar gallery demo button and numbered the snackbars.
- The persistent bottom sheet gallery demo disables its "show" button while the sheet is up.
- The persistent and modal bottom sheet gallery apps now feature a conventional raised button with an upper-case label.

Fixes: https://github.com/flutter/flutter/issues/2700
Fixes: https://github.com/flutter/flutter/issues/3072
Fixes: https://github.com/flutter/flutter/issues/3073
