### PR TITLE
add the dart vm version to flutter doctor

### DIFF
--- a/packages/flutter_tools/lib/executable.dart
+++ b/packages/flutter_tools/lib/executable.dart
@@ -96,9 +96,10 @@ Future<Null> main(List<String> args) async {
     } else {
       // We've crashed; emit a log report.
       stderr.writeln();
-      stderr.writeln('Oops; flutter has exited unexpectedly: "$error"');
-
-      stderr.writeln();
+      if (error is String)
+        stderr.writeln('Oops; flutter has exited unexpectedly: "$error".');
+      else
+        stderr.writeln('Oops; flutter has exited unexpectedly.');
 
       if (Platform.environment.containsKey('FLUTTER_DEV')) {
         // If we're working in the tools themselves, just print the stack trace.
@@ -106,8 +107,9 @@ Future<Null> main(List<String> args) async {
       } else {
         File file = _createCrashReport(args, error, chain);
 
-        stderr.writeln('Crash report written to ${path.relative(file.path)}.');
-        stderr.writeln('Please let us know at https://github.com/flutter/flutter/issues!');
+        stderr.writeln(
+          'Crash report written to ${path.relative(file.path)}; '
+          'please let us know at https://github.com/flutter/flutter/issues.');
       }
 
       exit(1);
@@ -127,10 +129,10 @@ File _createCrashReport(List<String> args, dynamic error, Chain chain) {
 
   buf.writeln('## exception\n');
   buf.writeln('$error\n');
-  buf.writeln('${chain.terse}');
+  buf.writeln('```\n${chain.terse}```\n');
 
   buf.writeln('## flutter doctor\n');
-  buf.writeln(_doctorText());
+  buf.writeln('```\n${_doctorText()}```');
 
   crashFile.writeAsStringSync(buf.toString());
 
@@ -148,6 +150,6 @@ String _doctorText() {
 
     return logger.statusText;
   } catch (error, trace) {
-    return 'encountered exception: $error\n\n```\n${trace.toString().trim()}\n```\n';
+    return 'encountered exception: $error\n\n${trace.toString().trim()}\n';
   }
 }

--- a/packages/flutter_tools/lib/src/commands/doctor.dart
+++ b/packages/flutter_tools/lib/src/commands/doctor.dart
@@ -19,7 +19,6 @@ class DoctorCommand extends FlutterCommand {
 
   @override
   Future<int> runInProject() async {
-    // doctor
     doctor.diagnose();
     return 0;
   }

--- a/packages/flutter_tools/lib/src/doctor.dart
+++ b/packages/flutter_tools/lib/src/doctor.dart
@@ -14,7 +14,6 @@ import 'globals.dart';
 import 'ios/ios_workflow.dart';
 import 'runner/version.dart';
 
-
 const Map<String, String> _osNames = const <String, String>{
   'macos': 'Mac OS',
   'linux': 'Linux',
@@ -196,8 +195,19 @@ class _FlutterValidator extends DoctorValidator {
       'engine revision ${version.engineRevisionShort}'
     ));
 
+    String dartVersion = _getDartVersion();
+    if (dartVersion != null)
+      messages.add(new ValidationMessage(dartVersion));
+    else
+      messages.add(new ValidationMessage.error('Unable to find the Dart executable on the path.'));
+
     return new ValidationResult(ValidationType.installed, messages,
       statusInfo: 'on ${osName()}, channel ${version.channel}');
+  }
+
+  String _getDartVersion() {
+    ProcessResult result = Process.runSync('dart', <String>['--version']);
+    return result.exitCode != 0 ? null : result.stderr.trim();
   }
 }
 

--- a/packages/flutter_tools/lib/src/doctor.dart
+++ b/packages/flutter_tools/lib/src/doctor.dart
@@ -195,19 +195,8 @@ class _FlutterValidator extends DoctorValidator {
       'engine revision ${version.engineRevisionShort}'
     ));
 
-    String dartVersion = _getDartVersion();
-    if (dartVersion != null)
-      messages.add(new ValidationMessage(dartVersion));
-    else
-      messages.add(new ValidationMessage.error('Unable to find the Dart executable on the path.'));
-
     return new ValidationResult(ValidationType.installed, messages,
       statusInfo: 'on ${osName()}, channel ${version.channel}');
-  }
-
-  String _getDartVersion() {
-    ProcessResult result = Process.runSync('dart', <String>['--version']);
-    return result.exitCode != 0 ? null : result.stderr.trim();
   }
 }
 


### PR DESCRIPTION
- print the dart vm version used in flutter doctor
- when showing a crash, only print the exception message if it might be useful to the user (i.e., don't just print `"3"`

```
[✓] Flutter (on Mac OS, channel unknown)
    • Flutter at /Users/devoncarew/projects/flutter/flutter
    • Framework revision 911f119 (2 minutes ago), engine revision 893425d
    • Dart VM version: 1.15.0 (Wed Mar  9 09:55:45 2016) on "macos_x64"
```

@pq 
