### PR TITLE
Fix analyzer warnings

### DIFF
--- a/examples/material_gallery/lib/demo/tabs_fab_demo.dart
+++ b/examples/material_gallery/lib/demo/tabs_fab_demo.dart
@@ -31,7 +31,7 @@ class TabsFabDemo extends StatefulWidget {
 }
 
 class _TabsFabDemoState extends State<TabsFabDemo> {
-  final GlobalKey scaffoldKey = new GlobalKey();
+  final GlobalKey<ScaffoldState> scaffoldKey = new GlobalKey<ScaffoldState>();
   final List<_Page> pages = <_Page>[
     new _Page(label: 'Blue', colors: Colors.indigo, icon: Icons.add),
     new _Page(label: 'Eco', colors: Colors.green, icon: Icons.create),

--- a/packages/flutter/lib/src/widgets/scrollable.dart
+++ b/packages/flutter/lib/src/widgets/scrollable.dart
@@ -546,7 +546,7 @@ abstract class ScrollableState<T extends Scrollable> extends State<T> {
       config.onScrollEnd(_scrollOffset);
   }
 
-  final GlobalKey _gestureDetectorKey = new GlobalKey();
+  final GlobalKey<RawGestureDetectorState> _gestureDetectorKey = new GlobalKey<RawGestureDetectorState>();
 
   @override
   Widget build(BuildContext context) {

--- a/packages/flutter/test/widget/tooltip_test.dart
+++ b/packages/flutter/test/widget/tooltip_test.dart
@@ -10,6 +10,21 @@ import 'package:test/test.dart';
 
 import 'test_semantics.dart';
 
+// This file uses "as dynamic" in a few places to defeat the static
+// analysis. In general you want to avoid using this style in your
+// code, as it will cause the analyzer to be unable to help you catch
+// errors.
+//
+// In this case, we do it because we are trying to call internal
+// methods of the tooltip code in order to test it. Normally, the
+// state of a tooltip is a private class, but by using a GlobalKey we
+// can get a handle to that object and by using "as dynamic" we can
+// bypass the analyzer's type checks and call methods that we aren't
+// supposed to be able to know about.
+//
+// It's ok to do this in tests, but you really don't want to do it in
+// production code.
+
 void main() {
   test('Does tooltip end up in the right place - top left', () {
     testWidgets((WidgetTester tester) {
@@ -47,7 +62,7 @@ void main() {
           ]
         )
       );
-      key.currentState.showTooltip();
+      (key.currentState as dynamic).showTooltip(); // before using "as dynamic" in your code, see note top of file
       tester.pump(const Duration(seconds: 2)); // faded in, show timer started (and at 0.0)
 
       /********************* 800x600 screen
@@ -101,7 +116,7 @@ void main() {
           ]
         )
       );
-      key.currentState.showTooltip();
+      (key.currentState as dynamic).showTooltip(); // before using "as dynamic" in your code, see note top of file
       tester.pump(const Duration(seconds: 2)); // faded in, show timer started (and at 0.0)
 
       /********************* 800x600 screen
@@ -157,7 +172,7 @@ void main() {
           ]
         )
       );
-      key.currentState.showTooltip();
+      (key.currentState as dynamic).showTooltip(); // before using "as dynamic" in your code, see note top of file
       tester.pump(const Duration(seconds: 2)); // faded in, show timer started (and at 0.0)
 
       // we try to put it here but it doesn't fit:
@@ -224,7 +239,7 @@ void main() {
           ]
         )
       );
-      key.currentState.showTooltip();
+      (key.currentState as dynamic).showTooltip(); // before using "as dynamic" in your code, see note top of file
       tester.pump(const Duration(seconds: 2)); // faded in, show timer started (and at 0.0)
 
       /********************* 800x600 screen
@@ -279,7 +294,7 @@ void main() {
           ]
         )
       );
-      key.currentState.showTooltip();
+      (key.currentState as dynamic).showTooltip(); // before using "as dynamic" in your code, see note top of file
       tester.pump(const Duration(seconds: 2)); // faded in, show timer started (and at 0.0)
 
       /********************* 800x600 screen
@@ -336,7 +351,7 @@ void main() {
           ]
         )
       );
-      key.currentState.showTooltip();
+      (key.currentState as dynamic).showTooltip(); // before using "as dynamic" in your code, see note top of file
       tester.pump(const Duration(seconds: 2)); // faded in, show timer started (and at 0.0)
 
       /********************* 800x600 screen
@@ -404,7 +419,8 @@ void main() {
       expect(client.updates[1], isNull);
       client.updates.clear();
 
-      key.currentState.showTooltip(); // this triggers a rebuild of the semantics because the tree changes
+      // before using "as dynamic" in your code, see note top of file
+      (key.currentState as dynamic).showTooltip(); // this triggers a rebuild of the semantics because the tree changes
 
       tester.pump(const Duration(seconds: 2)); // faded in, show timer started (and at 0.0)
       expect(client.updates.length, equals(2));

--- a/packages/flutter_tools/lib/src/commands/build_ios.dart
+++ b/packages/flutter_tools/lib/src/commands/build_ios.dart
@@ -3,15 +3,12 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:io';
 
 import '../application_package.dart';
 import '../build_configuration.dart';
 import '../globals.dart';
 import '../ios/mac.dart';
 import '../runner/flutter_command.dart';
-
-import 'package:path/path.dart' as path;
 
 class BuildIOSCommand extends FlutterCommand {
   BuildIOSCommand() {


### PR DESCRIPTION
Fix some legit uses of GlobalKey to specify the type they want.

Fix some sketchy uses of GlobalKey in tests to fake it with "as
dynamic".

Remove some extraneous imports that made the build red.
