### PR TITLE
TabView should keep state

### DIFF
--- a/packages/flutter/lib/src/material/tabs.dart
+++ b/packages/flutter/lib/src/material/tabs.dart
@@ -959,9 +959,12 @@ class _TabBarViewState<T> extends PageableListState<TabBarView<T>> implements Ta
 
   void _updateItemsFromChildren(int first, int second, [int third]) {
     List<Widget> widgets = config.children;
-    _items = <Widget>[widgets[first], widgets[second]];
+    _items = <Widget>[
+      new KeyedSubtree.wrap(widgets[first], first),
+      new KeyedSubtree.wrap(widgets[second], second),
+    ];
     if (third != null)
-      _items.add(widgets[third]);
+      _items.add(new KeyedSubtree.wrap(widgets[third], third));
   }
 
   void _updateItemsForSelectedIndex(int selectedIndex) {

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -2616,12 +2616,22 @@ class MetaData extends SingleChildRenderObjectWidget {
   }
 }
 
+/// Always builds the given child.
+///
+/// Useful for attaching a key to an existing widget.
 class KeyedSubtree extends StatelessWidget {
+  /// Creates a widget that always builds the given child.
   KeyedSubtree({ Key key, this.child })
     : super(key: key);
 
   /// The widget below this widget in the tree.
   final Widget child;
+
+  /// Creates a KeyedSubtree for child with a key that's based on the child's existing key or childIndex.
+  factory KeyedSubtree.wrap(Widget child, int childIndex) {
+    Key key = child.key != null ? new ValueKey<Key>(child.key) : new ValueKey<int>(childIndex);
+    return new KeyedSubtree(key: key, child: child);
+  }
 
   /// Wrap each item in a KeyedSubtree whose key is based on the item's existing key or
   /// its list index + baseIndex.
@@ -2631,18 +2641,14 @@ class KeyedSubtree extends StatelessWidget {
 
     List<Widget> itemsWithUniqueKeys = <Widget>[];
     int itemIndex = baseIndex;
-    for(Widget item in items) {
-      itemsWithUniqueKeys.add(new KeyedSubtree(
-        key: item.key != null ? new ValueKey<Key>(item.key) : new ValueKey<int>(itemIndex),
-        child: item
-      ));
+    for (Widget item in items) {
+      itemsWithUniqueKeys.add(new KeyedSubtree.wrap(item, itemIndex));
       itemIndex += 1;
     }
 
     assert(!debugItemsHaveDuplicateKeys(itemsWithUniqueKeys));
     return itemsWithUniqueKeys;
   }
-
 
   @override
   Widget build(BuildContext context) => child;

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -1158,6 +1158,9 @@ abstract class Element implements BuildContext {
     return renderObjectAncestor?.renderObject;
   }
 
+  /// Calls visitor for each ancestor element.
+  ///
+  /// Continues until visitor reaches the root or until visitor returns false.
   @override
   void visitAncestorElements(bool visitor(Element element)) {
     Element ancestor = _parent;


### PR DESCRIPTION
Previously, we lost sync with the tab view contents when switching tabs. Now we
key the subtrees to make sure they keep their state across tab animations.

Fixes #3147
