### PR TITLE
use --no-precompile

### DIFF
--- a/packages/flutter_tools/lib/src/base/logger.dart
+++ b/packages/flutter_tools/lib/src/base/logger.dart
@@ -207,7 +207,7 @@ class _AnsiStatus extends Status {
   _AnsiStatus(this.message) {
     stopwatch = new Stopwatch()..start();
 
-    stdout.write('${message.padRight(40)}     ');
+    stdout.write('${message.padRight(44)}     ');
     stdout.write('${_progress[0]}');
 
     timer = new Timer.periodic(new Duration(milliseconds: 100), _callback);

--- a/packages/flutter_tools/lib/src/base/process.dart
+++ b/packages/flutter_tools/lib/src/base/process.dart
@@ -6,6 +6,9 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:path/path.dart' as path;
+
+import '../dart/sdk.dart';
 import '../globals.dart';
 
 typedef String StringConverter(String string);
@@ -91,7 +94,7 @@ String runSync(List<String> cmd, { String workingDirectory }) {
 /// Return the platform specific name for the given Dart SDK binary. So, `pub`
 /// ==> `pub.bat`.
 String sdkBinaryName(String name) {
-  return Platform.isWindows ? '$name.bat' : name;
+  return path.absolute(path.join(dartSdkPath, 'bin', Platform.isWindows ? '$name.bat' : name));
 }
 
 bool exitsHappy(List<String> cli) {

--- a/packages/flutter_tools/lib/src/commands/update_packages.dart
+++ b/packages/flutter_tools/lib/src/commands/update_packages.dart
@@ -56,7 +56,8 @@ class UpdatePackagesCommand extends FlutterCommand {
       count += await _runPub(new Directory("${ArtifactStore.flutterRoot}/examples"), upgrade: upgrade);
       count += await _runPub(new Directory("${ArtifactStore.flutterRoot}/dev"), upgrade: upgrade);
 
-      printStatus('Ran "pub" $count time${count == 1 ? "" : "s"} in ${timer.elapsedMilliseconds} ms');
+      double seconds = timer.elapsedMilliseconds / 1000.0;
+      printStatus('\nRan \'pub\' $count time${count == 1 ? "" : "s"} in ${seconds.toStringAsFixed(1)}s.');
 
       return 0;
     } on int catch (code) {

--- a/packages/flutter_tools/lib/src/dart/pub.dart
+++ b/packages/flutter_tools/lib/src/dart/pub.dart
@@ -7,6 +7,7 @@ import 'dart:io';
 
 import 'package:path/path.dart' as path;
 
+import '../base/logger.dart';
 import '../base/process.dart';
 import '../globals.dart';
 
@@ -31,11 +32,12 @@ Future<int> pubGet({
 
   if (!checkLastModified || !dotPackages.existsSync() || pubSpecYaml.lastModifiedSync().isAfter(dotPackages.lastModifiedSync())) {
     String command = upgrade ? 'upgrade' : 'get';
-    printStatus("Running 'pub $command' in $directory${Platform.pathSeparator}...");
+    Status status = logger.startProgress("Running 'pub $command' in ${path.basename(directory)}...");
     int code = await runCommandAndStreamOutput(
-      <String>[sdkBinaryName('pub'), '--verbosity=warning', command, '--no-package-symlinks'],
+      <String>[sdkBinaryName('pub'), '--verbosity=warning', command, '--no-package-symlinks', '--no-precompile'],
       workingDirectory: directory
     );
+    status.stop(showElapsedTime: true);
     if (code != 0)
       return code;
   }


### PR DESCRIPTION
W/ the rev to the latest sdk, we can use the pub flag `--no-precompile`. This makes a _very_ slight performance improvement in update-packages.

```
Running 'pub upgrade' in cassowary...         5.8s
Running 'pub upgrade' in flutter...           4.5s
Running 'pub upgrade' in flutter_driver...    4.8s
Running 'pub upgrade' in flutter_markdown...  6.0s
Running 'pub upgrade' in flutter_sprites...   5.8s
Running 'pub upgrade' in flutter_test...      4.5s
Running 'pub upgrade' in flutter_tools...     5.3s
Running 'pub upgrade' in flx...               5.4s
Running 'pub upgrade' in newton...            5.3s
Running 'pub upgrade' in playfair...          5.9s
Running 'pub upgrade' in hello_world...       3.1s
Running 'pub upgrade' in layers...            3.1s
Running 'pub upgrade' in material_gallery...  3.3s
Running 'pub upgrade' in stocks...            5.1s
Running 'pub upgrade' in docs...              5.2s
Running 'pub upgrade' in manual_tests...      3.4s

Ran 'pub' 16 times in 76.3s.
```
