### PR TITLE
Dismissable doesn't resize from its full size

### DIFF
--- a/packages/flutter/lib/src/widgets/dismissable.dart
+++ b/packages/flutter/lib/src/widgets/dismissable.dart
@@ -76,7 +76,7 @@ class Dismissable extends StatefulWidget {
   /// A widget that is stacked behind the child. If secondaryBackground is also
   /// specified then this widget only appears when the child has been dragged
   /// down or to the right.
-  final  Widget background;
+  final Widget background;
 
   /// A widget that is stacked behind the child and is exposed when the child
   /// has been dragged up or to the left. It may only be specified when background
@@ -119,6 +119,7 @@ class _DismissableState extends State<Dismissable> {
 
   double _dragExtent = 0.0;
   bool _dragUnderway = false;
+  Size _sizePriorToCollapse;
 
   @override
   void dispose() {
@@ -261,6 +262,7 @@ class _DismissableState extends State<Dismissable> {
     assert(_moveController != null);
     assert(_moveController.isCompleted);
     assert(_resizeController == null);
+    assert(_sizePriorToCollapse == null);
     if (config.resizeDuration == null) {
       if (config.onDismissed != null)
         config.onDismissed(_dismissDirection);
@@ -269,6 +271,8 @@ class _DismissableState extends State<Dismissable> {
         ..addListener(_handleResizeProgressChanged);
       _resizeController.forward();
       setState(() {
+        RenderBox box = context.findRenderObject();
+        _sizePriorToCollapse = box.size;
         _resizeAnimation = new Tween<double>(
           begin: 1.0,
           end: 0.0
@@ -315,8 +319,12 @@ class _DismissableState extends State<Dismissable> {
 
       return new SizeTransition(
         sizeFactor: _resizeAnimation,
-        axis: _directionIsXAxis ? Axis.horizontal : Axis.vertical,
-        child: background
+        axis: _directionIsXAxis ? Axis.vertical : Axis.horizontal,
+        child: new SizedBox(
+          width: _sizePriorToCollapse.width,
+          height: _sizePriorToCollapse.height,
+          child: background
+        )
       );
     }
 

--- a/packages/flutter/test/widget/dismissable_test.dart
+++ b/packages/flutter/test/widget/dismissable_test.dart
@@ -12,6 +12,7 @@ Axis scrollDirection = Axis.vertical;
 DismissDirection dismissDirection = DismissDirection.horizontal;
 DismissDirection reportedDismissDirection;
 List<int> dismissedItems = <int>[];
+Widget background;
 
 void handleOnResize(int item) {
   expect(dismissedItems.contains(item), isFalse);
@@ -29,6 +30,7 @@ Widget buildDismissableItem(int item) {
     direction: dismissDirection,
     onDismissed: (DismissDirection direction) { handleOnDismissed(direction, item); },
     onResize: () { handleOnResize(item); },
+    background: background,
     child: new Container(
       width: itemExtent,
       height: itemExtent,
@@ -123,11 +125,15 @@ class Test1215DismissableWidget extends StatelessWidget {
 }
 
 void main() {
+  setUp(() {
+    dismissedItems = <int>[];
+    background = null;
+  });
+
   test('Horizontal drag triggers dismiss scrollDirection=vertical', () {
     testWidgets((WidgetTester tester) {
       scrollDirection = Axis.vertical;
       dismissDirection = DismissDirection.horizontal;
-      dismissedItems = <int>[];
 
       tester.pumpWidget(widgetBuilder());
       expect(dismissedItems, isEmpty);
@@ -148,7 +154,6 @@ void main() {
     testWidgets((WidgetTester tester) {
       scrollDirection = Axis.horizontal;
       dismissDirection = DismissDirection.vertical;
-      dismissedItems = <int>[];
 
       tester.pumpWidget(widgetBuilder());
       expect(dismissedItems, isEmpty);
@@ -169,7 +174,6 @@ void main() {
     testWidgets((WidgetTester tester) {
       scrollDirection = Axis.vertical;
       dismissDirection = DismissDirection.endToStart;
-      dismissedItems = <int>[];
 
       tester.pumpWidget(widgetBuilder());
       expect(dismissedItems, isEmpty);
@@ -190,7 +194,6 @@ void main() {
     testWidgets((WidgetTester tester) {
       scrollDirection = Axis.vertical;
       dismissDirection = DismissDirection.startToEnd;
-      dismissedItems = <int>[];
 
       tester.pumpWidget(widgetBuilder());
       expect(dismissedItems, isEmpty);
@@ -209,7 +212,6 @@ void main() {
     testWidgets((WidgetTester tester) {
       scrollDirection = Axis.horizontal;
       dismissDirection = DismissDirection.up;
-      dismissedItems = <int>[];
 
       tester.pumpWidget(widgetBuilder());
       expect(dismissedItems, isEmpty);
@@ -228,7 +230,6 @@ void main() {
     testWidgets((WidgetTester tester) {
       scrollDirection = Axis.horizontal;
       dismissDirection = DismissDirection.down;
-      dismissedItems = <int>[];
 
       tester.pumpWidget(widgetBuilder());
       expect(dismissedItems, isEmpty);
@@ -253,7 +254,6 @@ void main() {
     testWidgets((WidgetTester tester) {
       scrollDirection = Axis.horizontal;
       dismissDirection = DismissDirection.down;
-      dismissedItems = <int>[];
 
       tester.pumpWidget(widgetBuilder());
       Element itemElement = tester.findText('0');
@@ -305,6 +305,26 @@ void main() {
       tester.pump(new Duration(seconds: 1)); // finish the slide away (at which point the child is no longer included in the tree)
       expect(tester.findText('1'), isNull);
       expect(tester.findText('2'), isNull);
+    });
+  });
+
+  test('Dismissable starts from the full size when collapsing', () {
+    testWidgets((WidgetTester tester) {
+      scrollDirection = Axis.vertical;
+      dismissDirection = DismissDirection.horizontal;
+      background = new Text('background');
+
+      tester.pumpWidget(widgetBuilder());
+      expect(dismissedItems, isEmpty);
+
+      Element itemElement = tester.findText(0.toString());
+      expect(itemElement, isNotNull);
+      dismissElement(tester, itemElement, gestureDirection: DismissDirection.startToEnd);
+      tester.pump();
+
+      Element backgroundElement = tester.findText('background');
+      RenderBox backgroundBox = backgroundElement.findRenderObject();
+      expect(backgroundBox.size.height, equals(100.0));
     });
   });
 }


### PR DESCRIPTION
Previously we'd snap to the size of the background widget before resizing to
zero. Now we force the background widget to match the size of the dimissable
widget at the time it was dismissed.

Fixes #3092
