### PR TITLE
Add `flutter precache`

### DIFF
--- a/packages/flutter_tools/lib/executable.dart
+++ b/packages/flutter_tools/lib/executable.dart
@@ -23,6 +23,7 @@ import 'src/commands/drive.dart';
 import 'src/commands/install.dart';
 import 'src/commands/listen.dart';
 import 'src/commands/logs.dart';
+import 'src/commands/precache.dart';
 import 'src/commands/refresh.dart';
 import 'src/commands/run.dart';
 import 'src/commands/run_mojo.dart';
@@ -63,6 +64,7 @@ Future<Null> main(List<String> args) async {
     ..addCommand(new InstallCommand())
     ..addCommand(new ListenCommand())
     ..addCommand(new LogsCommand())
+    ..addCommand(new PrecacheCommand())
     ..addCommand(new RefreshCommand())
     ..addCommand(new RunCommand())
     ..addCommand(new RunMojoCommand(hidden: !verboseHelp))

--- a/packages/flutter_tools/lib/src/commands/create.dart
+++ b/packages/flutter_tools/lib/src/commands/create.dart
@@ -11,6 +11,7 @@ import 'package:path/path.dart' as path;
 import '../android/android.dart' as android;
 import '../artifacts.dart';
 import '../base/utils.dart';
+import '../cache.dart';
 import '../dart/pub.dart';
 import '../globals.dart';
 import '../template.dart';
@@ -65,6 +66,8 @@ class CreateCommand extends Command {
       printError('variable was specified. Unable to find package:flutter.');
       return 2;
     }
+
+    await Cache.instance.updateAll();
 
     String flutterRoot = path.absolute(ArtifactStore.flutterRoot);
 

--- a/packages/flutter_tools/lib/src/commands/precache.dart
+++ b/packages/flutter_tools/lib/src/commands/precache.dart
@@ -1,0 +1,23 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:args/command_runner.dart';
+
+import '../cache.dart';
+
+class PrecacheCommand extends Command {
+  @override
+  final String name = 'precache';
+
+  @override
+  final String description = 'Populates the Flutter tool\'s cache of binary artifacts.';
+
+  @override
+  Future<int> run() async {
+    await Cache.instance.updateAll();
+    return 0;
+  }
+}


### PR DESCRIPTION
This command explicitly populates the flutter tool's cache of binary artifacts.
Also, teach `flutter create` to update the cache in case its the first command
that a user runs.
