### PR TITLE
move services to using cache.dart

### DIFF
--- a/packages/flutter_tools/flutter_analysis_options
+++ b/packages/flutter_tools/flutter_analysis_options
@@ -4,7 +4,7 @@
 # to opt-in to all desired lints (https://github.com/dart-lang/sdk/issues/25843).
 # For a list of lints, see: http://dart-lang.github.io/linter/lints/
 
-# This file is the .analyzis_options file used by "flutter analyze".
+# This file is the .analysis_options file used by "flutter analyze".
 # It isn't named that because otherwise editors like Atom would try
 # to use it, and that wouldn't work because it enables things that
 # need to be silenced, in particular, public_member_api_docs.

--- a/packages/flutter_tools/lib/src/commands/run_mojo.dart
+++ b/packages/flutter_tools/lib/src/commands/run_mojo.dart
@@ -105,9 +105,8 @@ class RunMojoCommand extends FlutterCommand {
       flutterPath = _makePathAbsolute(localPath);
     }
 
-    if (argResults['android']) {
+    if (argResults['android'])
       args.add('--android');
-    }
 
     final Uri appUri = Uri.parse(targetApp);
     if (appUri.scheme.isEmpty || appUri.scheme == 'file') {
@@ -141,9 +140,8 @@ class RunMojoCommand extends FlutterCommand {
         args.add('--verbose');
     }
 
-    if (argResults['checked']) {
+    if (argResults['checked'])
       args.add('--args-for=mojo:flutter --enable-checked-mode');
-    }
 
     args.addAll(argResults.rest);
     printStatus('$args');

--- a/packages/flutter_tools/lib/src/commands/skia.dart
+++ b/packages/flutter_tools/lib/src/commands/skia.dart
@@ -4,6 +4,7 @@
 
 import 'dart:async';
 import 'dart:io';
+
 import 'package:http/http.dart' as http;
 
 import '../base/common.dart';

--- a/packages/flutter_tools/lib/src/services.dart
+++ b/packages/flutter_tools/lib/src/services.dart
@@ -9,7 +9,6 @@ import 'dart:io';
 import 'package:path/path.dart' as path;
 import 'package:yaml/yaml.dart';
 
-import 'artifacts.dart';
 import 'globals.dart';
 import 'package_map.dart';
 
@@ -75,7 +74,7 @@ Future<String> getServiceFromUrl(
     return url.replaceAll('android-sdk:', '${androidSdk.directory}/');
   } else if (url.startsWith("http")) {
     // It's a regular file to download.
-    return await ArtifactStore.getThirdPartyFile(url, serviceName, unzip);
+    return await cache.getThirdPartyFile(url, serviceName, unzip: unzip);
   } else {
     // Assume url is a path relative to the service's root dir.
     return path.join(rootDir, url);

--- a/packages/flutter_tools/lib/src/zip.dart
+++ b/packages/flutter_tools/lib/src/zip.dart
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:io';
 import 'dart:convert' show UTF8;
+import 'dart:io';
 
 import 'package:archive/archive.dart';
 import 'package:path/path.dart' as path;


### PR DESCRIPTION
Change to using cache.dart for downloading the services related artifacts. This is in preparation for moving off using `Artifact`s and `ArtifactStore` to find engine artifacts.
