### PR TITLE
Remove pub package version skew

### DIFF
--- a/packages/cassowary/pubspec.yaml
+++ b/packages/cassowary/pubspec.yaml
@@ -6,6 +6,5 @@ homepage: https://github.com/flutter/flutter/tree/master/packages/cassowary
 environment:
   sdk: '>=1.0.0 <2.0.0'
 dev_dependencies:
-  flutter_tools:
-    path: ../flutter_tools
-  test: any # constrained by the dependency in flutter_tools
+  flutter_test:
+    path: ../flutter_test

--- a/packages/flutter_markdown/pubspec.yaml
+++ b/packages/flutter_markdown/pubspec.yaml
@@ -11,8 +11,5 @@ dependencies:
   string_scanner: "0.1.4+1"
 
 dev_dependencies:
-  flutter_tools:
-    path: ../flutter_tools
-  test: any # constrained by the dependency in flutter_tools
   flutter_test:
     path: ../flutter_test

--- a/packages/flutter_sprites/pubspec.yaml
+++ b/packages/flutter_sprites/pubspec.yaml
@@ -10,6 +10,5 @@ dependencies:
     path: ../flutter
 
 dev_dependencies:
-  flutter_tools:
-    path: ../flutter_tools
-  test: any # constrained by the dependency in flutter_tools
+  flutter_test:
+    path: ../flutter_test

--- a/packages/flutter_test/pubspec.yaml
+++ b/packages/flutter_test/pubspec.yaml
@@ -2,5 +2,9 @@ name: flutter_test
 dependencies:
   test: 0.12.13
   quiver: ^0.21.4
+
+  # Not needed directly but transitively included due to package:test.
+  analyzer: 0.27.2
+
   flutter:
     path: ../flutter

--- a/packages/flutter_tools/pubspec.yaml
+++ b/packages/flutter_tools/pubspec.yaml
@@ -8,7 +8,6 @@ environment:
   sdk: '>=1.12.0 <2.0.0'
 
 dependencies:
-  analyzer: '>=0.26.1+17' # see note below
   archive: ^1.0.20
   args: ^0.13.4
   crypto: 0.9.2
@@ -20,12 +19,14 @@ dependencies:
   path: ^1.3.0
   pub_semver: ^1.0.0
   stack_trace: ^1.4.0
-  test: 0.12.13 # see note below
   yaml: ^2.1.3
   xml: ^2.4.1
 
   flx:
     path: ../flx
+
+  test: 0.12.13 # see note below
+  analyzer: '0.27.2' # see note below
 
 # A note about 'test':
 # We depend on very specific internal implementation details of the

--- a/packages/flx/pubspec.yaml
+++ b/packages/flx/pubspec.yaml
@@ -13,9 +13,8 @@ environment:
   sdk: '>=1.12.0 <2.0.0'
 
 dev_dependencies:
-  flutter_tools:
-    path: ../flutter_tools
-  test: any # constrained by the dependency in flutter_tools
+  flutter_test:
+    path: ../flutter_test
 
 # Exclude this package from the hosted API docs.
 dartdoc:

--- a/packages/newton/pubspec.yaml
+++ b/packages/newton/pubspec.yaml
@@ -6,6 +6,5 @@ homepage: https://github.com/flutter/flutter/tree/master/packages/newton
 environment:
   sdk: '>=1.0.0 <2.0.0'
 dev_dependencies:
-  flutter_tools:
-    path: ../flutter_tools
-  test: any # constrained by the dependency in flutter_tools
+  flutter_test:
+    path: ../flutter_test

--- a/packages/playfair/pubspec.yaml
+++ b/packages/playfair/pubspec.yaml
@@ -9,9 +9,8 @@ dependencies:
     path: ../flutter
 
 dev_dependencies:
-  flutter_tools:
-    path: ../flutter_tools
-  test: any # constrained by the dependency in flutter_tools
+  flutter_test:
+    path: ../flutter_test
 
 environment:
   sdk: '>=1.12.0 <2.0.0'


### PR DESCRIPTION
We need to pin the version of package:analyzer we use to avoid version skew
within our project.
