### PR TITLE
Add even more careful checks around BoxConstraints

### DIFF
--- a/examples/layers/rendering/src/sector_layout.dart
+++ b/examples/layers/rendering/src/sector_layout.dart
@@ -43,7 +43,7 @@ class SectorConstraints extends Constraints {
   bool get isNormalized => minDeltaRadius <= maxDeltaRadius && minDeltaTheta <= maxDeltaTheta;
 
   @override
-  bool get debugAssertIsNormalized {
+  bool debugAssertIsValid({ bool isAppliedConstraint: false }) {
     assert(isNormalized);
     return isNormalized;
   }

--- a/packages/flutter/lib/src/rendering/block.dart
+++ b/packages/flutter/lib/src/rendering/block.dart
@@ -171,7 +171,7 @@ class RenderBlock extends RenderBox
 
   @override
   double getMinIntrinsicWidth(BoxConstraints constraints) {
-    assert(constraints.debugAssertIsNormalized);
+    assert(constraints.debugAssertIsValid());
     switch (mainAxis) {
       case Axis.horizontal:
         return _getIntrinsicMainAxis(constraints, constraints.constrainWidth);
@@ -186,7 +186,7 @@ class RenderBlock extends RenderBox
 
   @override
   double getMaxIntrinsicWidth(BoxConstraints constraints) {
-    assert(constraints.debugAssertIsNormalized);
+    assert(constraints.debugAssertIsValid());
     switch (mainAxis) {
       case Axis.horizontal:
         return _getIntrinsicMainAxis(constraints, constraints.constrainWidth);
@@ -201,7 +201,7 @@ class RenderBlock extends RenderBox
 
   @override
   double getMinIntrinsicHeight(BoxConstraints constraints) {
-    assert(constraints.debugAssertIsNormalized);
+    assert(constraints.debugAssertIsValid());
     switch (mainAxis) {
       case Axis.horizontal:
         return _getIntrinsicCrossAxis(
@@ -216,7 +216,7 @@ class RenderBlock extends RenderBox
 
   @override
   double getMaxIntrinsicHeight(BoxConstraints constraints) {
-    assert(constraints.debugAssertIsNormalized);
+    assert(constraints.debugAssertIsValid());
     switch (mainAxis) {
       case Axis.horizontal:
         return _getIntrinsicCrossAxis(

--- a/packages/flutter/lib/src/rendering/box.dart
+++ b/packages/flutter/lib/src/rendering/box.dart
@@ -109,7 +109,7 @@ class BoxConstraints extends Constraints {
   /// Returns new box constraints that are smaller by the given edge dimensions.
   BoxConstraints deflate(EdgeInsets edges) {
     assert(edges != null);
-    assert(debugAssertIsNormalized);
+    assert(debugAssertIsValid());
     double horizontal = edges.left + edges.right;
     double vertical = edges.top + edges.bottom;
     double deflatedMinWidth = math.max(0.0, minWidth - horizontal);
@@ -124,7 +124,7 @@ class BoxConstraints extends Constraints {
 
   /// Returns new box constraints that remove the minimum width and height requirements.
   BoxConstraints loosen() {
-    assert(debugAssertIsNormalized);
+    assert(debugAssertIsValid());
     return new BoxConstraints(
       minWidth: 0.0,
       maxWidth: maxWidth,
@@ -175,14 +175,14 @@ class BoxConstraints extends Constraints {
   /// Returns the width that both satisfies the constraints and is as close as
   /// possible to the given width.
   double constrainWidth([double width = double.INFINITY]) {
-    assert(debugAssertIsNormalized);
+    assert(debugAssertIsValid());
     return width.clamp(minWidth, maxWidth);
   }
 
   /// Returns the height that both satisfies the constraints and is as close as
   /// possible to the given height.
   double constrainHeight([double height = double.INFINITY]) {
-    assert(debugAssertIsNormalized);
+    assert(debugAssertIsValid());
     return height.clamp(minHeight, maxHeight);
   }
 
@@ -222,7 +222,7 @@ class BoxConstraints extends Constraints {
 
   /// Whether the given size satisfies the constraints.
   bool isSatisfiedBy(Size size) {
-    assert(debugAssertIsNormalized);
+    assert(debugAssertIsValid());
     return (minWidth <= size.width) && (size.width <= maxWidth) &&
            (minHeight <= size.height) && (size.height <= maxHeight);
   }
@@ -273,8 +273,8 @@ class BoxConstraints extends Constraints {
       return b * t;
     if (b == null)
       return a * (1.0 - t);
-    assert(a.debugAssertIsNormalized);
-    assert(b.debugAssertIsNormalized);
+    assert(a.debugAssertIsValid());
+    assert(b.debugAssertIsValid());
     return new BoxConstraints(
       minWidth: ui.lerpDouble(a.minWidth, b.minWidth, t),
       maxWidth: ui.lerpDouble(a.maxWidth, b.maxWidth, t),
@@ -303,7 +303,7 @@ class BoxConstraints extends Constraints {
   }
 
   @override
-  bool get debugAssertIsNormalized {
+  bool debugAssertIsValid({ bool isAppliedConstraint: false }) {
     assert(() {
       if (minWidth.isNaN || maxWidth.isNaN || minHeight.isNaN || maxHeight.isNaN) {
         List<String> affectedFieldsList = <String>[];
@@ -340,7 +340,16 @@ class BoxConstraints extends Constraints {
         throw new FlutterError('BoxConstraints has non-normalized width constraints.\n$this');
       if (maxHeight < minHeight)
         throw new FlutterError('BoxConstraints has non-normalized height constraints.\n$this');
-      return isNormalized;
+      if (isAppliedConstraint) {
+        if (minWidth.isInfinite && minHeight.isInfinite)
+          throw new FlutterError('BoxConstraints requires infinite width and infinite height.\n$this');
+        if (minWidth.isInfinite)
+          throw new FlutterError('BoxConstraints requires infinite width.\n$this');
+        if (minHeight.isInfinite)
+          throw new FlutterError('BoxConstraints requires infinite height.\n$this');
+      }
+      assert(isNormalized);
+      return true;
     });
     return isNormalized;
   }
@@ -356,13 +365,13 @@ class BoxConstraints extends Constraints {
 
   @override
   bool operator ==(dynamic other) {
-    assert(debugAssertIsNormalized);
+    assert(debugAssertIsValid());
     if (identical(this, other))
       return true;
     if (other is! BoxConstraints)
       return false;
     final BoxConstraints typedOther = other;
-    assert(typedOther.debugAssertIsNormalized);
+    assert(typedOther.debugAssertIsValid());
     return minWidth == typedOther.minWidth &&
            maxWidth == typedOther.maxWidth &&
            minHeight == typedOther.minHeight &&
@@ -371,7 +380,7 @@ class BoxConstraints extends Constraints {
 
   @override
   int get hashCode {
-    assert(debugAssertIsNormalized);
+    assert(debugAssertIsValid());
     return hashValues(minWidth, maxWidth, minHeight, maxHeight);
   }
 
@@ -451,7 +460,7 @@ abstract class RenderBox extends RenderObject {
   ///
   /// Override in subclasses that implement [performLayout].
   double getMinIntrinsicWidth(BoxConstraints constraints) {
-    assert(constraints.debugAssertIsNormalized);
+    assert(constraints.debugAssertIsValid());
     return constraints.constrainWidth(0.0);
   }
 
@@ -460,7 +469,7 @@ abstract class RenderBox extends RenderObject {
   ///
   /// Override in subclasses that implement [performLayout].
   double getMaxIntrinsicWidth(BoxConstraints constraints) {
-    assert(constraints.debugAssertIsNormalized);
+    assert(constraints.debugAssertIsValid());
     return constraints.constrainWidth(0.0);
   }
 
@@ -469,7 +478,7 @@ abstract class RenderBox extends RenderObject {
   ///
   /// Override in subclasses that implement [performLayout].
   double getMinIntrinsicHeight(BoxConstraints constraints) {
-    assert(constraints.debugAssertIsNormalized);
+    assert(constraints.debugAssertIsValid());
     return constraints.constrainHeight(0.0);
   }
 
@@ -482,7 +491,7 @@ abstract class RenderBox extends RenderObject {
   ///
   /// Override in subclasses that implement [performLayout].
   double getMaxIntrinsicHeight(BoxConstraints constraints) {
-    assert(constraints.debugAssertIsNormalized);
+    assert(constraints.debugAssertIsValid());
     return constraints.constrainHeight(0.0);
   }
 

--- a/packages/flutter/lib/src/rendering/custom_layout.dart
+++ b/packages/flutter/lib/src/rendering/custom_layout.dart
@@ -57,7 +57,7 @@ abstract class MultiChildLayoutDelegate {
         );
       }
       try {
-        assert(constraints.debugAssertIsNormalized);
+        assert(constraints.debugAssertIsValid(isAppliedConstraint: true));
       } on AssertionError catch (exception) {
         throw new FlutterError(
           'The $this custom multichild layout delegate provided invalid box constraints for the child with id "$childId".\n'
@@ -232,7 +232,7 @@ class RenderCustomMultiChildLayoutBox extends RenderBox
   }
 
   Size _getSize(BoxConstraints constraints) {
-    assert(constraints.debugAssertIsNormalized);
+    assert(constraints.debugAssertIsValid());
     return constraints.constrain(_delegate.getSize(constraints));
   }
 

--- a/packages/flutter/lib/src/rendering/editable_line.dart
+++ b/packages/flutter/lib/src/rendering/editable_line.dart
@@ -133,25 +133,25 @@ class RenderEditableLine extends RenderBox {
 
   @override
   double getMinIntrinsicWidth(BoxConstraints constraints) {
-    assert(constraints.debugAssertIsNormalized);
+    assert(constraints.debugAssertIsValid());
     return constraints.constrainWidth(0.0);
   }
 
   @override
   double getMaxIntrinsicWidth(BoxConstraints constraints) {
-    assert(constraints.debugAssertIsNormalized);
+    assert(constraints.debugAssertIsValid());
     return constraints.constrainWidth(0.0);
   }
 
   @override
   double getMinIntrinsicHeight(BoxConstraints constraints) {
-    assert(constraints.debugAssertIsNormalized);
+    assert(constraints.debugAssertIsValid());
     return constraints.constrainHeight(_preferredHeight);
   }
 
   @override
   double getMaxIntrinsicHeight(BoxConstraints constraints) {
-    assert(constraints.debugAssertIsNormalized);
+    assert(constraints.debugAssertIsValid());
     return constraints.constrainHeight(_preferredHeight);
   }
 
@@ -190,7 +190,7 @@ class RenderEditableLine extends RenderBox {
   // TODO(abarth): This logic should live in TextPainter and be shared with RenderParagraph.
   void _layoutText(BoxConstraints constraints) {
     assert(constraints != null);
-    assert(constraints.debugAssertIsNormalized);
+    assert(constraints.debugAssertIsValid());
     if (_constraintsForCurrentLayout == constraints)
       return; // already cached this layout
     _textPainter.maxWidth = constraints.maxWidth;

--- a/packages/flutter/lib/src/rendering/flex.dart
+++ b/packages/flutter/lib/src/rendering/flex.dart
@@ -144,7 +144,7 @@ class RenderFlex extends RenderBox with ContainerRenderObjectMixin<RenderBox, Fl
   double _getIntrinsicSize({ BoxConstraints constraints,
                              FlexDirection sizingDirection,
                              _ChildSizingFunction childSize }) {
-    assert(constraints.debugAssertIsNormalized);
+    assert(constraints.debugAssertIsValid());
     // http://www.w3.org/TR/2015/WD-css-flexbox-1-20150514/#intrinsic-sizes
     if (_direction == sizingDirection) {
       // INTRINSIC MAIN SIZE

--- a/packages/flutter/lib/src/rendering/grid.dart
+++ b/packages/flutter/lib/src/rendering/grid.dart
@@ -430,25 +430,25 @@ class RenderGrid extends RenderVirtualViewport<GridParentData> {
 
   @override
   double getMinIntrinsicWidth(BoxConstraints constraints) {
-    assert(constraints.debugAssertIsNormalized);
+    assert(constraints.debugAssertIsValid());
     return _delegate.getMinIntrinsicWidth(constraints, virtualChildCount);
   }
 
   @override
   double getMaxIntrinsicWidth(BoxConstraints constraints) {
-    assert(constraints.debugAssertIsNormalized);
+    assert(constraints.debugAssertIsValid());
     return _delegate.getMaxIntrinsicWidth(constraints, virtualChildCount);
   }
 
   @override
   double getMinIntrinsicHeight(BoxConstraints constraints) {
-    assert(constraints.debugAssertIsNormalized);
+    assert(constraints.debugAssertIsValid());
     return _delegate.getMinIntrinsicHeight(constraints, virtualChildCount);
   }
 
   @override
   double getMaxIntrinsicHeight(BoxConstraints constraints) {
-    assert(constraints.debugAssertIsNormalized);
+    assert(constraints.debugAssertIsValid());
     return _delegate.getMaxIntrinsicHeight(constraints, virtualChildCount);
   }
 

--- a/packages/flutter/lib/src/rendering/image.dart
+++ b/packages/flutter/lib/src/rendering/image.dart
@@ -205,7 +205,7 @@ class RenderImage extends RenderBox {
 
   @override
   double getMinIntrinsicWidth(BoxConstraints constraints) {
-    assert(constraints.debugAssertIsNormalized);
+    assert(constraints.debugAssertIsValid());
     if (_width == null && _height == null)
       return constraints.constrainWidth(0.0);
     return _sizeForConstraints(constraints).width;
@@ -213,13 +213,13 @@ class RenderImage extends RenderBox {
 
   @override
   double getMaxIntrinsicWidth(BoxConstraints constraints) {
-    assert(constraints.debugAssertIsNormalized);
+    assert(constraints.debugAssertIsValid());
     return _sizeForConstraints(constraints).width;
   }
 
   @override
   double getMinIntrinsicHeight(BoxConstraints constraints) {
-    assert(constraints.debugAssertIsNormalized);
+    assert(constraints.debugAssertIsValid());
     if (_width == null && _height == null)
       return constraints.constrainHeight(0.0);
     return _sizeForConstraints(constraints).height;
@@ -227,7 +227,7 @@ class RenderImage extends RenderBox {
 
   @override
   double getMaxIntrinsicHeight(BoxConstraints constraints) {
-    assert(constraints.debugAssertIsNormalized);
+    assert(constraints.debugAssertIsValid());
     return _sizeForConstraints(constraints).height;
   }
 

--- a/packages/flutter/lib/src/rendering/list.dart
+++ b/packages/flutter/lib/src/rendering/list.dart
@@ -82,7 +82,7 @@ class RenderList extends RenderVirtualViewport<ListParentData> {
   }
 
   double _getIntrinsicWidth(BoxConstraints constraints) {
-    assert(constraints.debugAssertIsNormalized);
+    assert(constraints.debugAssertIsValid());
     switch (mainAxis) {
       case Axis.vertical:
         return constraints.constrainWidth(0.0);
@@ -102,7 +102,7 @@ class RenderList extends RenderVirtualViewport<ListParentData> {
   }
 
   double _getIntrinsicHeight(BoxConstraints constraints) {
-    assert(constraints.debugAssertIsNormalized);
+    assert(constraints.debugAssertIsValid());
     switch (mainAxis) {
       case Axis.vertical:
         return constraints.constrainHeight(_preferredExtent);

--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -382,9 +382,25 @@ abstract class Constraints {
   /// Whether the constraint is expressed in a consistent manner.
   bool get isNormalized;
 
-  /// Same as [isNormalized] but, in checked mode, throws an exception
-  /// if isNormalized is false.
-  bool get debugAssertIsNormalized;
+  /// Asserts that the constraints are valid.
+  ///
+  /// This might involve checks more detailed than [isNormalized].
+  ///
+  /// For example, the [BoxConstraints] subclass verifies that the
+  /// constraints are not [NaN].
+  ///
+  /// If the [isAppliedConstraint] argument is true, then even
+  /// stricter rules are enforced. This argument is set to true when
+  /// checking constraints that are about to be applied to a
+  /// [RenderObject] during layout, as opposed to constraints that may
+  /// be further affected by other constraints. For example, the
+  /// asserts for verifying the validity of
+  /// [RenderConstrainedBox.additionalConstraints] do not set this
+  /// argument, but the asserts for verifying the argument passed to
+  /// the [layout] method do.
+  ///
+  /// Returns the same as [isNormalized] if asserts are disabled.
+  bool debugAssertIsValid({ bool isAppliedConstraint: false });
 }
 
 typedef void RenderObjectVisitor(RenderObject child);
@@ -1136,7 +1152,7 @@ abstract class RenderObject extends AbstractNode implements HitTestTarget {
   /// work to update its layout information.
   void layout(Constraints constraints, { bool parentUsesSize: false }) {
     assert(constraints != null);
-    assert(constraints.debugAssertIsNormalized);
+    assert(constraints.debugAssertIsValid(isAppliedConstraint: true));
     assert(!_debugDoingThisResize);
     assert(!_debugDoingThisLayout);
     final RenderObject parent = this.parent;

--- a/packages/flutter/lib/src/rendering/paragraph.dart
+++ b/packages/flutter/lib/src/rendering/paragraph.dart
@@ -36,7 +36,7 @@ class RenderParagraph extends RenderBox {
   // TODO(abarth): This logic should live in TextPainter and be shared with RenderEditableLine.
   void _layoutText(BoxConstraints constraints) {
     assert(constraints != null);
-    assert(constraints.debugAssertIsNormalized);
+    assert(constraints.debugAssertIsValid());
     if (_constraintsForCurrentLayout == constraints)
       return; // already cached this layout
     _textPainter.maxWidth = constraints.maxWidth;
@@ -71,13 +71,13 @@ class RenderParagraph extends RenderBox {
 
   @override
   double getMinIntrinsicHeight(BoxConstraints constraints) {
-    assert(constraints.debugAssertIsNormalized);
+    assert(constraints.debugAssertIsValid());
     return _getIntrinsicHeight(constraints);
   }
 
   @override
   double getMaxIntrinsicHeight(BoxConstraints constraints) {
-    assert(constraints.debugAssertIsNormalized);
+    assert(constraints.debugAssertIsValid());
     return _getIntrinsicHeight(constraints);
   }
 

--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -37,7 +37,7 @@ class RenderProxyBox extends RenderBox with RenderObjectWithChildMixin<RenderBox
 
   @override
   double getMinIntrinsicWidth(BoxConstraints constraints) {
-    assert(constraints.debugAssertIsNormalized);
+    assert(constraints.debugAssertIsValid());
     if (child != null)
       return child.getMinIntrinsicWidth(constraints);
     return super.getMinIntrinsicWidth(constraints);
@@ -45,7 +45,7 @@ class RenderProxyBox extends RenderBox with RenderObjectWithChildMixin<RenderBox
 
   @override
   double getMaxIntrinsicWidth(BoxConstraints constraints) {
-    assert(constraints.debugAssertIsNormalized);
+    assert(constraints.debugAssertIsValid());
     if (child != null)
       return child.getMaxIntrinsicWidth(constraints);
     return super.getMaxIntrinsicWidth(constraints);
@@ -53,7 +53,7 @@ class RenderProxyBox extends RenderBox with RenderObjectWithChildMixin<RenderBox
 
   @override
   double getMinIntrinsicHeight(BoxConstraints constraints) {
-    assert(constraints.debugAssertIsNormalized);
+    assert(constraints.debugAssertIsValid());
     if (child != null)
       return child.getMinIntrinsicHeight(constraints);
     return super.getMinIntrinsicHeight(constraints);
@@ -61,7 +61,7 @@ class RenderProxyBox extends RenderBox with RenderObjectWithChildMixin<RenderBox
 
   @override
   double getMaxIntrinsicHeight(BoxConstraints constraints) {
-    assert(constraints.debugAssertIsNormalized);
+    assert(constraints.debugAssertIsValid());
     if (child != null)
       return child.getMaxIntrinsicHeight(constraints);
     return super.getMaxIntrinsicHeight(constraints);
@@ -170,7 +170,7 @@ class RenderConstrainedBox extends RenderProxyBox {
     BoxConstraints additionalConstraints
   }) : _additionalConstraints = additionalConstraints, super(child) {
     assert(additionalConstraints != null);
-    assert(additionalConstraints.debugAssertIsNormalized);
+    assert(additionalConstraints.debugAssertIsValid());
   }
 
   /// Additional constraints to apply to [child] during layout
@@ -178,7 +178,7 @@ class RenderConstrainedBox extends RenderProxyBox {
   BoxConstraints _additionalConstraints;
   void set additionalConstraints (BoxConstraints newConstraints) {
     assert(newConstraints != null);
-    assert(newConstraints.debugAssertIsNormalized);
+    assert(newConstraints.debugAssertIsValid());
     if (_additionalConstraints == newConstraints)
       return;
     _additionalConstraints = newConstraints;
@@ -187,7 +187,7 @@ class RenderConstrainedBox extends RenderProxyBox {
 
   @override
   double getMinIntrinsicWidth(BoxConstraints constraints) {
-    assert(constraints.debugAssertIsNormalized);
+    assert(constraints.debugAssertIsValid());
     if (child != null)
       return child.getMinIntrinsicWidth(_additionalConstraints.enforce(constraints));
     return _additionalConstraints.enforce(constraints).constrainWidth(0.0);
@@ -195,7 +195,7 @@ class RenderConstrainedBox extends RenderProxyBox {
 
   @override
   double getMaxIntrinsicWidth(BoxConstraints constraints) {
-    assert(constraints.debugAssertIsNormalized);
+    assert(constraints.debugAssertIsValid());
     if (child != null)
       return child.getMaxIntrinsicWidth(_additionalConstraints.enforce(constraints));
     return _additionalConstraints.enforce(constraints).constrainWidth(0.0);
@@ -203,7 +203,7 @@ class RenderConstrainedBox extends RenderProxyBox {
 
   @override
   double getMinIntrinsicHeight(BoxConstraints constraints) {
-    assert(constraints.debugAssertIsNormalized);
+    assert(constraints.debugAssertIsValid());
     if (child != null)
       return child.getMinIntrinsicHeight(_additionalConstraints.enforce(constraints));
     return _additionalConstraints.enforce(constraints).constrainHeight(0.0);
@@ -211,7 +211,7 @@ class RenderConstrainedBox extends RenderProxyBox {
 
   @override
   double getMaxIntrinsicHeight(BoxConstraints constraints) {
-    assert(constraints.debugAssertIsNormalized);
+    assert(constraints.debugAssertIsValid());
     if (child != null)
       return child.getMaxIntrinsicHeight(_additionalConstraints.enforce(constraints));
     return _additionalConstraints.enforce(constraints).constrainHeight(0.0);
@@ -317,7 +317,7 @@ class RenderAspectRatio extends RenderProxyBox {
   }
 
   Size _applyAspectRatio(BoxConstraints constraints) {
-    assert(constraints.debugAssertIsNormalized);
+    assert(constraints.debugAssertIsValid());
     assert(() {
       if (!constraints.hasBoundedWidth && !constraints.hasBoundedHeight) {
         throw new FlutterError(
@@ -446,13 +446,13 @@ class RenderIntrinsicWidth extends RenderProxyBox {
 
   @override
   double getMinIntrinsicWidth(BoxConstraints constraints) {
-    assert(constraints.debugAssertIsNormalized);
+    assert(constraints.debugAssertIsValid());
     return getMaxIntrinsicWidth(constraints);
   }
 
   @override
   double getMaxIntrinsicWidth(BoxConstraints constraints) {
-    assert(constraints.debugAssertIsNormalized);
+    assert(constraints.debugAssertIsValid());
     if (child == null)
       return constraints.constrainWidth(0.0);
     double childResult = child.getMaxIntrinsicWidth(constraints);
@@ -461,7 +461,7 @@ class RenderIntrinsicWidth extends RenderProxyBox {
 
   @override
   double getMinIntrinsicHeight(BoxConstraints constraints) {
-    assert(constraints.debugAssertIsNormalized);
+    assert(constraints.debugAssertIsValid());
     if (child == null)
       return constraints.constrainHeight(0.0);
     double childResult = child.getMinIntrinsicHeight(_getInnerConstraints(constraints));
@@ -470,7 +470,7 @@ class RenderIntrinsicWidth extends RenderProxyBox {
 
   @override
   double getMaxIntrinsicHeight(BoxConstraints constraints) {
-    assert(constraints.debugAssertIsNormalized);
+    assert(constraints.debugAssertIsValid());
     if (child == null)
       return constraints.constrainHeight(0.0);
     double childResult = child.getMaxIntrinsicHeight(_getInnerConstraints(constraints));
@@ -522,7 +522,7 @@ class RenderIntrinsicHeight extends RenderProxyBox {
 
   @override
   double getMinIntrinsicWidth(BoxConstraints constraints) {
-    assert(constraints.debugAssertIsNormalized);
+    assert(constraints.debugAssertIsValid());
     if (child == null)
       return constraints.constrainWidth(0.0);
     return child.getMinIntrinsicWidth(_getInnerConstraints(constraints));
@@ -530,7 +530,7 @@ class RenderIntrinsicHeight extends RenderProxyBox {
 
   @override
   double getMaxIntrinsicWidth(BoxConstraints constraints) {
-    assert(constraints.debugAssertIsNormalized);
+    assert(constraints.debugAssertIsValid());
     if (child == null)
       return constraints.constrainWidth(0.0);
     return child.getMaxIntrinsicWidth(_getInnerConstraints(constraints));
@@ -538,13 +538,13 @@ class RenderIntrinsicHeight extends RenderProxyBox {
 
   @override
   double getMinIntrinsicHeight(BoxConstraints constraints) {
-    assert(constraints.debugAssertIsNormalized);
+    assert(constraints.debugAssertIsValid());
     return getMaxIntrinsicHeight(constraints);
   }
 
   @override
   double getMaxIntrinsicHeight(BoxConstraints constraints) {
-    assert(constraints.debugAssertIsNormalized);
+    assert(constraints.debugAssertIsValid());
     if (child == null)
       return constraints.constrainHeight(0.0);
     return child.getMaxIntrinsicHeight(constraints);

--- a/packages/flutter/lib/src/rendering/rotated_box.dart
+++ b/packages/flutter/lib/src/rendering/rotated_box.dart
@@ -41,7 +41,7 @@ class RenderRotatedBox extends RenderBox with RenderObjectWithChildMixin<RenderB
 
   @override
   double getMinIntrinsicWidth(BoxConstraints constraints) {
-    assert(constraints.debugAssertIsNormalized);
+    assert(constraints.debugAssertIsValid());
     if (child != null)
       return _isVertical ? child.getMinIntrinsicHeight(constraints.flipped) : child.getMinIntrinsicWidth(constraints);
     return super.getMinIntrinsicWidth(constraints);
@@ -49,7 +49,7 @@ class RenderRotatedBox extends RenderBox with RenderObjectWithChildMixin<RenderB
 
   @override
   double getMaxIntrinsicWidth(BoxConstraints constraints) {
-    assert(constraints.debugAssertIsNormalized);
+    assert(constraints.debugAssertIsValid());
     if (child != null)
       return _isVertical ? child.getMaxIntrinsicHeight(constraints.flipped) : child.getMaxIntrinsicWidth(constraints);
     return super.getMaxIntrinsicWidth(constraints);
@@ -57,7 +57,7 @@ class RenderRotatedBox extends RenderBox with RenderObjectWithChildMixin<RenderB
 
   @override
   double getMinIntrinsicHeight(BoxConstraints constraints) {
-    assert(constraints.debugAssertIsNormalized);
+    assert(constraints.debugAssertIsValid());
     if (child != null)
       return _isVertical ? child.getMinIntrinsicWidth(constraints.flipped) : child.getMinIntrinsicHeight(constraints);
     return super.getMinIntrinsicHeight(constraints);
@@ -65,7 +65,7 @@ class RenderRotatedBox extends RenderBox with RenderObjectWithChildMixin<RenderB
 
   @override
   double getMaxIntrinsicHeight(BoxConstraints constraints) {
-    assert(constraints.debugAssertIsNormalized);
+    assert(constraints.debugAssertIsValid());
     if (child != null)
       return _isVertical ? child.getMaxIntrinsicWidth(constraints.flipped) : child.getMaxIntrinsicHeight(constraints);
     return super.getMaxIntrinsicHeight(constraints);

--- a/packages/flutter/lib/src/rendering/shifted_box.dart
+++ b/packages/flutter/lib/src/rendering/shifted_box.dart
@@ -17,7 +17,7 @@ abstract class RenderShiftedBox extends RenderBox with RenderObjectWithChildMixi
 
   @override
   double getMinIntrinsicWidth(BoxConstraints constraints) {
-    assert(constraints.debugAssertIsNormalized);
+    assert(constraints.debugAssertIsValid());
     if (child != null)
       return child.getMinIntrinsicWidth(constraints);
     return super.getMinIntrinsicWidth(constraints);
@@ -25,7 +25,7 @@ abstract class RenderShiftedBox extends RenderBox with RenderObjectWithChildMixi
 
   @override
   double getMaxIntrinsicWidth(BoxConstraints constraints) {
-    assert(constraints.debugAssertIsNormalized);
+    assert(constraints.debugAssertIsValid());
     if (child != null)
       return child.getMaxIntrinsicWidth(constraints);
     return super.getMaxIntrinsicWidth(constraints);
@@ -33,7 +33,7 @@ abstract class RenderShiftedBox extends RenderBox with RenderObjectWithChildMixi
 
   @override
   double getMinIntrinsicHeight(BoxConstraints constraints) {
-    assert(constraints.debugAssertIsNormalized);
+    assert(constraints.debugAssertIsValid());
     if (child != null)
       return child.getMinIntrinsicHeight(constraints);
     return super.getMinIntrinsicHeight(constraints);
@@ -41,7 +41,7 @@ abstract class RenderShiftedBox extends RenderBox with RenderObjectWithChildMixi
 
   @override
   double getMaxIntrinsicHeight(BoxConstraints constraints) {
-    assert(constraints.debugAssertIsNormalized);
+    assert(constraints.debugAssertIsValid());
     if (child != null)
       return child.getMaxIntrinsicHeight(constraints);
     return super.getMaxIntrinsicHeight(constraints);
@@ -112,7 +112,7 @@ class RenderPadding extends RenderShiftedBox {
 
   @override
   double getMinIntrinsicWidth(BoxConstraints constraints) {
-    assert(constraints.debugAssertIsNormalized);
+    assert(constraints.debugAssertIsValid());
     double totalPadding = padding.left + padding.right;
     if (child != null)
       return constraints.constrainWidth(child.getMinIntrinsicWidth(constraints.deflate(padding)) + totalPadding);
@@ -121,7 +121,7 @@ class RenderPadding extends RenderShiftedBox {
 
   @override
   double getMaxIntrinsicWidth(BoxConstraints constraints) {
-    assert(constraints.debugAssertIsNormalized);
+    assert(constraints.debugAssertIsValid());
     double totalPadding = padding.left + padding.right;
     if (child != null)
       return constraints.constrainWidth(child.getMaxIntrinsicWidth(constraints.deflate(padding)) + totalPadding);
@@ -130,7 +130,7 @@ class RenderPadding extends RenderShiftedBox {
 
   @override
   double getMinIntrinsicHeight(BoxConstraints constraints) {
-    assert(constraints.debugAssertIsNormalized);
+    assert(constraints.debugAssertIsValid());
     double totalPadding = padding.top + padding.bottom;
     if (child != null)
       return constraints.constrainHeight(child.getMinIntrinsicHeight(constraints.deflate(padding)) + totalPadding);
@@ -139,7 +139,7 @@ class RenderPadding extends RenderShiftedBox {
 
   @override
   double getMaxIntrinsicHeight(BoxConstraints constraints) {
-    assert(constraints.debugAssertIsNormalized);
+    assert(constraints.debugAssertIsValid());
     double totalPadding = padding.top + padding.bottom;
     if (child != null)
       return constraints.constrainHeight(child.getMaxIntrinsicHeight(constraints.deflate(padding)) + totalPadding);
@@ -494,25 +494,25 @@ class RenderConstrainedOverflowBox extends RenderAligningShiftedBox {
 
   @override
   double getMinIntrinsicWidth(BoxConstraints constraints) {
-    assert(constraints.debugAssertIsNormalized);
+    assert(constraints.debugAssertIsValid());
     return constraints.minWidth;
   }
 
   @override
   double getMaxIntrinsicWidth(BoxConstraints constraints) {
-    assert(constraints.debugAssertIsNormalized);
+    assert(constraints.debugAssertIsValid());
     return constraints.minWidth;
   }
 
   @override
   double getMinIntrinsicHeight(BoxConstraints constraints) {
-    assert(constraints.debugAssertIsNormalized);
+    assert(constraints.debugAssertIsValid());
     return constraints.minHeight;
   }
 
   @override
   double getMaxIntrinsicHeight(BoxConstraints constraints) {
-    assert(constraints.debugAssertIsNormalized);
+    assert(constraints.debugAssertIsValid());
     return constraints.minHeight;
   }
 
@@ -567,25 +567,25 @@ class RenderSizedOverflowBox extends RenderAligningShiftedBox {
 
   @override
   double getMinIntrinsicWidth(BoxConstraints constraints) {
-    assert(constraints.debugAssertIsNormalized);
+    assert(constraints.debugAssertIsValid());
     return constraints.constrainWidth(_requestedSize.width);
   }
 
   @override
   double getMaxIntrinsicWidth(BoxConstraints constraints) {
-    assert(constraints.debugAssertIsNormalized);
+    assert(constraints.debugAssertIsValid());
     return constraints.constrainWidth(_requestedSize.width);
   }
 
   @override
   double getMinIntrinsicHeight(BoxConstraints constraints) {
-    assert(constraints.debugAssertIsNormalized);
+    assert(constraints.debugAssertIsValid());
     return constraints.constrainHeight(_requestedSize.height);
   }
 
   @override
   double getMaxIntrinsicHeight(BoxConstraints constraints) {
-    assert(constraints.debugAssertIsNormalized);
+    assert(constraints.debugAssertIsValid());
     return constraints.constrainHeight(_requestedSize.height);
   }
 
@@ -683,7 +683,7 @@ class RenderFractionallySizedOverflowBox extends RenderAligningShiftedBox {
 
   @override
   double getMinIntrinsicWidth(BoxConstraints constraints) {
-    assert(constraints.debugAssertIsNormalized);
+    assert(constraints.debugAssertIsValid());
     if (child != null)
       return constraints.constrainWidth(child.getMinIntrinsicWidth(_getInnerConstraints(constraints)));
     return constraints.constrainWidth(_getInnerConstraints(constraints).constrainWidth(0.0));
@@ -691,7 +691,7 @@ class RenderFractionallySizedOverflowBox extends RenderAligningShiftedBox {
 
   @override
   double getMaxIntrinsicWidth(BoxConstraints constraints) {
-    assert(constraints.debugAssertIsNormalized);
+    assert(constraints.debugAssertIsValid());
     if (child != null)
       return constraints.constrainWidth(child.getMaxIntrinsicWidth(_getInnerConstraints(constraints)));
     return constraints.constrainWidth(_getInnerConstraints(constraints).constrainWidth(0.0));
@@ -699,7 +699,7 @@ class RenderFractionallySizedOverflowBox extends RenderAligningShiftedBox {
 
   @override
   double getMinIntrinsicHeight(BoxConstraints constraints) {
-    assert(constraints.debugAssertIsNormalized);
+    assert(constraints.debugAssertIsValid());
     if (child != null)
       return constraints.constrainHeight(child.getMinIntrinsicHeight(_getInnerConstraints(constraints)));
     return constraints.constrainHeight(_getInnerConstraints(constraints).constrainHeight(0.0));
@@ -707,7 +707,7 @@ class RenderFractionallySizedOverflowBox extends RenderAligningShiftedBox {
 
   @override
   double getMaxIntrinsicHeight(BoxConstraints constraints) {
-    assert(constraints.debugAssertIsNormalized);
+    assert(constraints.debugAssertIsValid());
     if (child != null)
       return constraints.constrainHeight(child.getMaxIntrinsicHeight(_getInnerConstraints(constraints)));
     return constraints.constrainHeight(_getInnerConstraints(constraints).constrainHeight(0.0));
@@ -779,25 +779,25 @@ class RenderCustomSingleChildLayoutBox extends RenderShiftedBox {
 
   @override
   double getMinIntrinsicWidth(BoxConstraints constraints) {
-    assert(constraints.debugAssertIsNormalized);
+    assert(constraints.debugAssertIsValid());
     return _getSize(constraints).width;
   }
 
   @override
   double getMaxIntrinsicWidth(BoxConstraints constraints) {
-    assert(constraints.debugAssertIsNormalized);
+    assert(constraints.debugAssertIsValid());
     return _getSize(constraints).width;
   }
 
   @override
   double getMinIntrinsicHeight(BoxConstraints constraints) {
-    assert(constraints.debugAssertIsNormalized);
+    assert(constraints.debugAssertIsValid());
     return _getSize(constraints).height;
   }
 
   @override
   double getMaxIntrinsicHeight(BoxConstraints constraints) {
-    assert(constraints.debugAssertIsNormalized);
+    assert(constraints.debugAssertIsValid());
     return _getSize(constraints).height;
   }
 
@@ -813,7 +813,7 @@ class RenderCustomSingleChildLayoutBox extends RenderShiftedBox {
   void performLayout() {
     if (child != null) {
       BoxConstraints childConstraints = delegate.getConstraintsForChild(constraints);
-      assert(childConstraints.debugAssertIsNormalized);
+      assert(childConstraints.debugAssertIsValid(isAppliedConstraint: true));
       child.layout(childConstraints, parentUsesSize: !childConstraints.isTight);
       final BoxParentData childParentData = child.parentData;
       childParentData.offset = delegate.getPositionForChild(size, childConstraints.isTight ? childConstraints.smallest : child.size);

--- a/packages/flutter/lib/src/rendering/stack.dart
+++ b/packages/flutter/lib/src/rendering/stack.dart
@@ -225,7 +225,7 @@ abstract class RenderStackBase extends RenderBox
 
   @override
   double getMinIntrinsicWidth(BoxConstraints constraints) {
-    assert(constraints.debugAssertIsNormalized);
+    assert(constraints.debugAssertIsValid());
     double width = constraints.minWidth;
     RenderBox child = firstChild;
     while (child != null) {
@@ -241,7 +241,7 @@ abstract class RenderStackBase extends RenderBox
 
   @override
   double getMaxIntrinsicWidth(BoxConstraints constraints) {
-    assert(constraints.debugAssertIsNormalized);
+    assert(constraints.debugAssertIsValid());
     bool hasNonPositionedChildren = false;
     double width = constraints.minWidth;
     RenderBox child = firstChild;
@@ -262,7 +262,7 @@ abstract class RenderStackBase extends RenderBox
 
   @override
   double getMinIntrinsicHeight(BoxConstraints constraints) {
-    assert(constraints.debugAssertIsNormalized);
+    assert(constraints.debugAssertIsValid());
     double height = constraints.minHeight;
     RenderBox child = firstChild;
     while (child != null) {
@@ -278,7 +278,7 @@ abstract class RenderStackBase extends RenderBox
 
   @override
   double getMaxIntrinsicHeight(BoxConstraints constraints) {
-    assert(constraints.debugAssertIsNormalized);
+    assert(constraints.debugAssertIsValid());
     bool hasNonPositionedChildren = false;
     double height = constraints.minHeight;
     RenderBox child = firstChild;

--- a/packages/flutter/lib/src/rendering/table.dart
+++ b/packages/flutter/lib/src/rendering/table.dart
@@ -636,7 +636,7 @@ class RenderTable extends RenderBox {
 
   @override
   double getMinIntrinsicWidth(BoxConstraints constraints) {
-    assert(constraints.debugAssertIsNormalized);
+    assert(constraints.debugAssertIsValid());
     assert(_children.length == rows * columns);
     double totalMinWidth = 0.0;
     for (int x = 0; x < columns; x += 1) {
@@ -649,7 +649,7 @@ class RenderTable extends RenderBox {
 
   @override
   double getMaxIntrinsicWidth(BoxConstraints constraints) {
-    assert(constraints.debugAssertIsNormalized);
+    assert(constraints.debugAssertIsValid());
     assert(_children.length == rows * columns);
     double totalMaxWidth = 0.0;
     for (int x = 0; x < columns; x += 1) {
@@ -664,7 +664,7 @@ class RenderTable extends RenderBox {
   double getMinIntrinsicHeight(BoxConstraints constraints) {
     // winner of the 2016 world's most expensive intrinsic dimension function award
     // honorable mention, most likely to improve if taught about memoization award
-    assert(constraints.debugAssertIsNormalized);
+    assert(constraints.debugAssertIsValid());
     assert(_children.length == rows * columns);
     final List<double> widths = computeColumnWidths(constraints);
     double rowTop = 0.0;

--- a/packages/flutter/lib/src/rendering/viewport.dart
+++ b/packages/flutter/lib/src/rendering/viewport.dart
@@ -246,7 +246,7 @@ class RenderViewport extends RenderViewportBase with RenderObjectWithChildMixin<
 
   @override
   double getMinIntrinsicWidth(BoxConstraints constraints) {
-    assert(constraints.debugAssertIsNormalized);
+    assert(constraints.debugAssertIsValid());
     if (child != null)
       return constraints.constrainWidth(child.getMinIntrinsicWidth(_getInnerConstraints(constraints)));
     return super.getMinIntrinsicWidth(constraints);
@@ -254,7 +254,7 @@ class RenderViewport extends RenderViewportBase with RenderObjectWithChildMixin<
 
   @override
   double getMaxIntrinsicWidth(BoxConstraints constraints) {
-    assert(constraints.debugAssertIsNormalized);
+    assert(constraints.debugAssertIsValid());
     if (child != null)
       return constraints.constrainWidth(child.getMaxIntrinsicWidth(_getInnerConstraints(constraints)));
     return super.getMaxIntrinsicWidth(constraints);
@@ -262,7 +262,7 @@ class RenderViewport extends RenderViewportBase with RenderObjectWithChildMixin<
 
   @override
   double getMinIntrinsicHeight(BoxConstraints constraints) {
-    assert(constraints.debugAssertIsNormalized);
+    assert(constraints.debugAssertIsValid());
     if (child != null)
       return constraints.constrainHeight(child.getMinIntrinsicHeight(_getInnerConstraints(constraints)));
     return super.getMinIntrinsicHeight(constraints);
@@ -270,7 +270,7 @@ class RenderViewport extends RenderViewportBase with RenderObjectWithChildMixin<
 
   @override
   double getMaxIntrinsicHeight(BoxConstraints constraints) {
-    assert(constraints.debugAssertIsNormalized);
+    assert(constraints.debugAssertIsValid());
     if (child != null)
       return constraints.constrainHeight(child.getMaxIntrinsicHeight(_getInnerConstraints(constraints)));
     return super.getMaxIntrinsicHeight(constraints);

--- a/packages/flutter/lib/src/widgets/lazy_block.dart
+++ b/packages/flutter/lib/src/widgets/lazy_block.dart
@@ -264,13 +264,13 @@ class _RenderLazyBlock extends RenderVirtualViewport<_LazyBlockParentData> {
 
   @override
   double getMinIntrinsicWidth(BoxConstraints constraints) {
-    assert(constraints.debugAssertIsNormalized);
+    assert(constraints.debugAssertIsValid());
     return getIntrinsicWidth(constraints);
   }
 
   @override
   double getMaxIntrinsicWidth(BoxConstraints constraints) {
-    assert(constraints.debugAssertIsNormalized);
+    assert(constraints.debugAssertIsValid());
     return getIntrinsicWidth(constraints);
   }
 
@@ -286,13 +286,13 @@ class _RenderLazyBlock extends RenderVirtualViewport<_LazyBlockParentData> {
 
   @override
   double getMinIntrinsicHeight(BoxConstraints constraints) {
-    assert(constraints.debugAssertIsNormalized);
+    assert(constraints.debugAssertIsValid());
     return getIntrinsicHeight(constraints);
   }
 
   @override
   double getMaxIntrinsicHeight(BoxConstraints constraints) {
-    assert(constraints.debugAssertIsNormalized);
+    assert(constraints.debugAssertIsValid());
     return getIntrinsicHeight(constraints);
   }
 

--- a/packages/flutter/test/rendering/constraints_test.dart
+++ b/packages/flutter/test/rendering/constraints_test.dart
@@ -37,7 +37,7 @@ void main() {
     result = 'no exception';
     try {
       BoxConstraints constraints = new BoxConstraints(minWidth: double.NAN, maxWidth: double.NAN, minHeight: 2.0, maxHeight: double.NAN);
-      assert(constraints.debugAssertIsNormalized);
+      assert(constraints.debugAssertIsValid());
     } on FlutterError catch (e) {
       result = '$e';
     }
@@ -49,7 +49,7 @@ void main() {
     result = 'no exception';
     try {
       BoxConstraints constraints = new BoxConstraints(minHeight: double.NAN);
-      assert(constraints.debugAssertIsNormalized);
+      assert(constraints.debugAssertIsValid());
     } on FlutterError catch (e) {
       result = '$e';
     }
@@ -61,7 +61,7 @@ void main() {
     result = 'no exception';
     try {
       BoxConstraints constraints = new BoxConstraints(minHeight: double.NAN, maxWidth: 0.0/0.0);
-      assert(constraints.debugAssertIsNormalized);
+      assert(constraints.debugAssertIsValid());
     } on FlutterError catch (e) {
       result = '$e';
     }


### PR DESCRIPTION
I ran into a case where I was setting minHeight=∞ and then calling
layout() with that constraint, which is all kinds of bad. To try to
catch this earlier, this patch now provides a way to catch constraints
that are requiring infinite values.

We don't _always_ check this because there are valid uses for
BoxConstraints.biggest, e.g. as an additionalConstraint.
