### PR TITLE
add a --deploy flag to build apk

### DIFF
--- a/packages/flutter_tools/lib/src/build_configuration.dart
+++ b/packages/flutter_tools/lib/src/build_configuration.dart
@@ -14,6 +14,19 @@ enum BuildType {
   debug,
 }
 
+/// The type of build - `develop`, `profile`, or `deploy`.
+enum BuildVariant {
+  develop,
+  profile,
+  deploy
+}
+
+String getVariantName(BuildVariant variant) {
+  String name = '$variant';
+  int index = name.indexOf('.');
+  return index == -1 ? name : name.substring(index + 1);
+}
+
 enum HostPlatform {
   mac,
   linux,

--- a/packages/flutter_tools/lib/src/build_configuration.dart
+++ b/packages/flutter_tools/lib/src/build_configuration.dart
@@ -14,10 +14,11 @@ enum BuildType {
   debug,
 }
 
-/// The type of build - `develop`, `profile`, or `deploy`.
+/// The type of build - `develop` or `deploy`.
+///
+/// TODO(devoncarew): Add a `profile` variant.
 enum BuildVariant {
   develop,
-  profile,
   deploy
 }
 

--- a/packages/flutter_tools/lib/src/commands/build_apk.dart
+++ b/packages/flutter_tools/lib/src/commands/build_apk.dart
@@ -177,9 +177,9 @@ class BuildApkCommand extends FlutterCommand {
 
   @override
   final String description = 'Build an Android APK file from your app.\n\n'
-    'This command can build develop and deploy versions of your application. \'develop\' builds support\n'
-    'debugging and a quick development cycle. \'deploy\' builds don\'t support debugging and are suitable\n'
-    'for deploying to app stores.';
+    'This command can build development and deployable versions of your application. \'develop\' builds\n'
+    'support debugging and a quick development cycle. \'deploy\' builds don\'t support debugging and are\n'
+    'suitable for deploying to app stores.';
 
   @override
   Future<int> runInProject() async {

--- a/packages/flutter_tools/lib/src/commands/build_apk.dart
+++ b/packages/flutter_tools/lib/src/commands/build_apk.dart
@@ -220,7 +220,7 @@ class BuildApkCommand extends FlutterCommand {
         keyAlias: argResults['keystore-key-alias'],
         keyPassword: argResults['keystore-key-password']
       ),
-      buildForDeploy: variant
+      buildVariant: variant
     );
   }
 }
@@ -231,9 +231,9 @@ Future<_ApkComponents> _findApkComponents(
   String enginePath,
   String manifest,
   String resources,
-  BuildVariant buildForDeploy
+  BuildVariant buildVariant
 ) async {
-  // TODO(devoncarew): Get the right artifacts for [buildForDeploy].
+  // TODO(devoncarew): Get the right artifacts for [buildVariant].
 
   List<String> artifactPaths;
   if (enginePath != null) {
@@ -287,11 +287,11 @@ int _buildApk(
   String flxPath,
   ApkKeystoreInfo keystore,
   String outputFile,
-  BuildVariant buildForDeploy
+  BuildVariant buildVariant
 ) {
   Directory tempDir = Directory.systemTemp.createTempSync('flutter_tools');
 
-  printTrace('Building APK; buildForDeploy: ${getVariantName(buildForDeploy)}.');
+  printTrace('Building APK; buildVariant: ${getVariantName(buildVariant)}.');
 
   try {
     _ApkBuilder builder = new _ApkBuilder(androidSdk.latestVersion);
@@ -408,7 +408,7 @@ Future<int> buildAndroid(
   String target,
   String flxPath,
   ApkKeystoreInfo keystore,
-  BuildVariant buildForDeploy: BuildVariant.develop
+  BuildVariant buildVariant: BuildVariant.develop
 }) async {
   // Validate that we can find an android sdk.
   if (androidSdk == null) {
@@ -440,7 +440,7 @@ Future<int> buildAndroid(
 
   BuildConfiguration config = configs.firstWhere((BuildConfiguration bc) => bc.targetPlatform == platform);
   _ApkComponents components = await _findApkComponents(
-    platform, config, enginePath, manifest, resources, buildForDeploy
+    platform, config, enginePath, manifest, resources, buildVariant
   );
 
   if (components == null) {
@@ -448,7 +448,7 @@ Future<int> buildAndroid(
     return 1;
   }
 
-  printStatus('Building APK in ${getVariantName(buildForDeploy)} mode...');
+  printStatus('Building APK in ${getVariantName(buildVariant)} mode...');
 
   if (flxPath != null && flxPath.isNotEmpty) {
     if (!FileSystemEntity.isFileSync(flxPath)) {
@@ -457,7 +457,7 @@ Future<int> buildAndroid(
       return 1;
     }
 
-    return _buildApk(platform, components, flxPath, keystore, outputFile, buildForDeploy);
+    return _buildApk(platform, components, flxPath, keystore, outputFile, buildVariant);
   } else {
     // Find the path to the main Dart file; build the FLX.
     String mainPath = findMainDartFile(target);
@@ -466,7 +466,7 @@ Future<int> buildAndroid(
         mainPath: mainPath,
         includeRobotoFonts: false);
 
-    return _buildApk(platform, components, localBundlePath, keystore, outputFile, buildForDeploy);
+    return _buildApk(platform, components, localBundlePath, keystore, outputFile, buildVariant);
   }
 }
 
@@ -476,7 +476,7 @@ Future<int> buildApk(
   List<BuildConfiguration> configs, {
   String enginePath,
   String target,
-  BuildVariant buildForDeploy: BuildVariant.develop
+  BuildVariant buildVariant: BuildVariant.develop
 }) async {
   if (!FileSystemEntity.isFileSync(_kDefaultAndroidManifestPath)) {
     printError('Cannot build APK. Missing $_kDefaultAndroidManifestPath.');
@@ -490,7 +490,7 @@ Future<int> buildApk(
     enginePath: enginePath,
     force: false,
     target: target,
-    buildForDeploy: buildForDeploy
+    buildVariant: buildVariant
   );
 
   return result;

--- a/packages/flutter_tools/lib/src/commands/build_apk.dart
+++ b/packages/flutter_tools/lib/src/commands/build_apk.dart
@@ -196,7 +196,10 @@ class BuildApkCommand extends FlutterCommand {
       return 1;
     }
 
-    bool buildForDeploy = argResults['deploy'];
+    BuildVariant variant = BuildVariant.develop;
+
+    if (argResults['deploy'])
+      variant = BuildVariant.deploy;
 
     // TODO(devoncarew): This command should take an arg for the output type (arm / x64).
 
@@ -217,7 +220,7 @@ class BuildApkCommand extends FlutterCommand {
         keyAlias: argResults['keystore-key-alias'],
         keyPassword: argResults['keystore-key-password']
       ),
-      buildForDeploy: buildForDeploy
+      buildForDeploy: variant
     );
   }
 }
@@ -228,7 +231,7 @@ Future<_ApkComponents> _findApkComponents(
   String enginePath,
   String manifest,
   String resources,
-  bool buildForDeploy
+  BuildVariant buildForDeploy
 ) async {
   // TODO(devoncarew): Get the right artifacts for [buildForDeploy].
 
@@ -284,12 +287,11 @@ int _buildApk(
   String flxPath,
   ApkKeystoreInfo keystore,
   String outputFile,
-  bool buildForDeploy
+  BuildVariant buildForDeploy
 ) {
   Directory tempDir = Directory.systemTemp.createTempSync('flutter_tools');
 
-  // TODO(devoncarew): Use the [buildForDeploy] param.
-  printTrace('Building APK; buildForDeploy: $buildForDeploy.');
+  printTrace('Building APK; buildForDeploy: ${getVariantName(buildForDeploy)}.');
 
   try {
     _ApkBuilder builder = new _ApkBuilder(androidSdk.latestVersion);
@@ -406,7 +408,7 @@ Future<int> buildAndroid(
   String target,
   String flxPath,
   ApkKeystoreInfo keystore,
-  bool buildForDeploy: false
+  BuildVariant buildForDeploy: BuildVariant.develop
 }) async {
   // Validate that we can find an android sdk.
   if (androidSdk == null) {
@@ -446,7 +448,7 @@ Future<int> buildAndroid(
     return 1;
   }
 
-  printStatus('Building APK in ${buildForDeploy ? 'deploy' : 'develop'} mode...');
+  printStatus('Building APK in ${getVariantName(buildForDeploy)} mode...');
 
   if (flxPath != null && flxPath.isNotEmpty) {
     if (!FileSystemEntity.isFileSync(flxPath)) {
@@ -474,7 +476,7 @@ Future<int> buildApk(
   List<BuildConfiguration> configs, {
   String enginePath,
   String target,
-  bool buildForDeploy: false
+  BuildVariant buildForDeploy: BuildVariant.develop
 }) async {
   if (!FileSystemEntity.isFileSync(_kDefaultAndroidManifestPath)) {
     printError('Cannot build APK. Missing $_kDefaultAndroidManifestPath.');

--- a/packages/flutter_tools/lib/src/commands/build_apk.dart
+++ b/packages/flutter_tools/lib/src/commands/build_apk.dart
@@ -205,6 +205,7 @@ class BuildApkCommand extends FlutterCommand {
 
     return await buildAndroid(
       TargetPlatform.android_arm,
+      variant,
       toolchain: toolchain,
       configs: buildConfigurations,
       enginePath: runner.enginePath,
@@ -219,8 +220,7 @@ class BuildApkCommand extends FlutterCommand {
         password: argResults['keystore-password'],
         keyAlias: argResults['keystore-key-alias'],
         keyPassword: argResults['keystore-key-password']
-      ),
-      buildVariant: variant
+      )
     );
   }
 }
@@ -283,12 +283,15 @@ Future<_ApkComponents> _findApkComponents(
 
 int _buildApk(
   TargetPlatform platform,
+  BuildVariant buildVariant,
   _ApkComponents components,
   String flxPath,
   ApkKeystoreInfo keystore,
-  String outputFile,
-  BuildVariant buildVariant
+  String outputFile
 ) {
+  assert(platform != null);
+  assert(buildVariant != null);
+
   Directory tempDir = Directory.systemTemp.createTempSync('flutter_tools');
 
   printTrace('Building APK; buildVariant: ${getVariantName(buildVariant)}.');
@@ -397,7 +400,8 @@ bool _needsRebuild(String apkPath, String manifest) {
 }
 
 Future<int> buildAndroid(
-  TargetPlatform platform, {
+  TargetPlatform platform,
+  BuildVariant buildVariant, {
   Toolchain toolchain,
   List<BuildConfiguration> configs,
   String enginePath,
@@ -407,8 +411,7 @@ Future<int> buildAndroid(
   String outputFile: _kDefaultOutputPath,
   String target,
   String flxPath,
-  ApkKeystoreInfo keystore,
-  BuildVariant buildVariant: BuildVariant.develop
+  ApkKeystoreInfo keystore
 }) async {
   // Validate that we can find an android sdk.
   if (androidSdk == null) {
@@ -457,7 +460,7 @@ Future<int> buildAndroid(
       return 1;
     }
 
-    return _buildApk(platform, components, flxPath, keystore, outputFile, buildVariant);
+    return _buildApk(platform, buildVariant, components, flxPath, keystore, outputFile);
   } else {
     // Find the path to the main Dart file; build the FLX.
     String mainPath = findMainDartFile(target);
@@ -466,7 +469,7 @@ Future<int> buildAndroid(
         mainPath: mainPath,
         includeRobotoFonts: false);
 
-    return _buildApk(platform, components, localBundlePath, keystore, outputFile, buildVariant);
+    return _buildApk(platform, buildVariant, components, localBundlePath, keystore, outputFile);
   }
 }
 
@@ -485,12 +488,12 @@ Future<int> buildApk(
 
   int result = await buildAndroid(
     platform,
+    buildVariant,
     toolchain: toolchain,
     configs: configs,
     enginePath: enginePath,
     force: false,
-    target: target,
-    buildVariant: buildVariant
+    target: target
   );
 
   return result;

--- a/packages/flutter_tools/lib/src/commands/drive.dart
+++ b/packages/flutter_tools/lib/src/commands/drive.dart
@@ -242,7 +242,7 @@ Future<int> startApp(DriveCommand command) async {
   // TODO(devoncarew): We should remove the need to special case here.
   if (command.device is AndroidDevice) {
     printTrace('Building an APK.');
-    int result = await build_apk.build(
+    int result = await build_apk.buildApk(
       command.device.platform, command.toolchain, command.buildConfigurations,
       enginePath: command.runner.enginePath, target: command.target
     );

--- a/packages/flutter_tools/lib/src/commands/run.dart
+++ b/packages/flutter_tools/lib/src/commands/run.dart
@@ -162,13 +162,17 @@ Future<int> startApp(
     return 1;
   }
 
-  if (install) {
+  // TODO(devoncarew): We shouldn't have to do type checks here.
+  if (install && device is AndroidDevice) {
     printTrace('Running build command.');
-    int result = await buildForDevice(
-      device, applicationPackages, toolchain, configs,
+
+    int result = await buildApk(
+      device.platform, toolchain, configs,
       enginePath: enginePath,
-      target: target
+      target: target,
+      buildForDeploy: false
     );
+
     if (result != 0)
       return result;
   }

--- a/packages/flutter_tools/lib/src/commands/run.dart
+++ b/packages/flutter_tools/lib/src/commands/run.dart
@@ -170,7 +170,7 @@ Future<int> startApp(
       device.platform, toolchain, configs,
       enginePath: enginePath,
       target: target,
-      buildForDeploy: BuildVariant.develop
+      buildVariant: BuildVariant.develop
     );
 
     if (result != 0)

--- a/packages/flutter_tools/lib/src/commands/run.dart
+++ b/packages/flutter_tools/lib/src/commands/run.dart
@@ -170,7 +170,7 @@ Future<int> startApp(
       device.platform, toolchain, configs,
       enginePath: enginePath,
       target: target,
-      buildForDeploy: false
+      buildForDeploy: BuildVariant.develop
     );
 
     if (result != 0)


### PR DESCRIPTION
- add a `--deploy` (and a `--develop`) flag to `flutter build apk`. This doesn't do anything right now, but sets the stage for us to implement different build functionality for the two builds.
- some minor cleanup (removing a method w/ one caller, and changing methods names to clarify when we're doing something android/apk specific)

@jason-simmons, @chinmaygarde I _think_ the next step is to start building and uploading `gen_snapshot` into the `darwin-x64` google storage bucket, and then using that binary when building the deploy APK, instead of the `sky_snapshot` binary. Does that sound right?
