### PR TITLE
Migrate `enable-strict-call-checks` flag to options file.

### DIFF
--- a/packages/flutter_tools/flutter_analysis_options
+++ b/packages/flutter_tools/flutter_analysis_options
@@ -11,6 +11,7 @@
 
 analyzer:
   language:
+    enableStrictCallChecks: true
     enableSuperMixins: true
   strong-mode: true
   errors:

--- a/packages/flutter_tools/lib/src/commands/analyze.dart
+++ b/packages/flutter_tools/lib/src/commands/analyze.dart
@@ -295,7 +295,6 @@ class AnalyzeCommand extends FlutterCommand {
       sdkBinaryName('dartanalyzer'),
       // do not set '--warnings', since that will include the entire Dart SDK
       '--ignore-unrecognized-flags',
-      '--enable-strict-call-checks', //TODO(pq): migrate to options once supported (dart/sdk#25983)
       '--enable_type_checks',
       '--package-warnings',
       '--fatal-warnings',


### PR DESCRIPTION
As per https://github.com/dart-lang/sdk/issues/25723, moves last command-line flag to `.analysis_options`.
