### PR TITLE
fix to showing a progress display for long tasks

### DIFF
--- a/packages/flutter_tools/lib/src/base/logger.dart
+++ b/packages/flutter_tools/lib/src/base/logger.dart
@@ -243,7 +243,7 @@ class _AnsiStatus extends Status {
       double seconds = stopwatch.elapsedMilliseconds / 1000.0;
       print('\b\b\b\b${seconds.toStringAsFixed(1)}s');
     } else {
-      print('\b');
+      print('\b ');
     }
 
     timer.cancel();
@@ -255,7 +255,7 @@ class _AnsiStatus extends Status {
       return;
     live = false;
 
-    print('\b');
+    print('\b ');
     timer.cancel();
   }
 }

--- a/packages/flutter_tools/lib/src/commands/precache.dart
+++ b/packages/flutter_tools/lib/src/commands/precache.dart
@@ -18,7 +18,7 @@ class PrecacheCommand extends Command {
   @override
   Future<int> run() async {
     if (cache.isUpToDate())
-      printStatus('All up-to-date.');
+      printStatus('Already up-to-date.');
     else
       await cache.updateAll();
 

--- a/packages/flutter_tools/lib/src/runner/flutter_command_runner.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command_runner.dart
@@ -196,8 +196,8 @@ class FlutterCommandRunner extends CommandRunner {
     if (globalResults['verbose'])
       context[Logger] = new VerboseLogger();
 
-    if (!globalResults['color'])
-      logger.supportsColor = false;
+    if (globalResults.wasParsed('color'))
+      logger.supportsColor = globalResults['color'];
 
     // we must set ArtifactStore.flutterRoot early because other features use it
     // (e.g. enginePath's initialiser uses it)


### PR DESCRIPTION
- fix a regression where we wouldn't show the progress spinner for long tasks
- fix a display issue where some cruft would be left behind on the display if the task was interrupted by other output
