### PR TITLE
Provide details when reporting invalid constraints

### DIFF
--- a/examples/layers/rendering/src/sector_layout.dart
+++ b/examples/layers/rendering/src/sector_layout.dart
@@ -43,7 +43,10 @@ class SectorConstraints extends Constraints {
   bool get isNormalized => minDeltaRadius <= maxDeltaRadius && minDeltaTheta <= maxDeltaTheta;
 
   @override
-  bool debugAssertIsValid({ bool isAppliedConstraint: false }) {
+  bool debugAssertIsValid({
+    bool isAppliedConstraint: false,
+    InformationCollector informationCollector
+  }) {
     assert(isNormalized);
     return isNormalized;
   }

--- a/packages/flutter/lib/src/gestures/binding.dart
+++ b/packages/flutter/lib/src/gestures/binding.dart
@@ -134,7 +134,7 @@ class FlutterErrorDetailsForPointerEventDispatcher extends FlutterErrorDetails {
     String context,
     this.event,
     this.hitTestEntry,
-    FlutterInformationCollector informationCollector,
+    InformationCollector informationCollector,
     bool silent: false
   }) : super(
     exception: exception,

--- a/packages/flutter/lib/src/gestures/pointer_router.dart
+++ b/packages/flutter/lib/src/gestures/pointer_router.dart
@@ -89,7 +89,7 @@ class FlutterErrorDetailsForPointerRouter extends FlutterErrorDetails {
     this.router,
     this.route,
     this.event,
-    FlutterInformationCollector informationCollector,
+    InformationCollector informationCollector,
     bool silent: false
   }) : super(
     exception: exception,

--- a/packages/flutter/lib/src/rendering/box.dart
+++ b/packages/flutter/lib/src/rendering/box.dart
@@ -303,8 +303,17 @@ class BoxConstraints extends Constraints {
   }
 
   @override
-  bool debugAssertIsValid({ bool isAppliedConstraint: false }) {
+  bool debugAssertIsValid({
+    bool isAppliedConstraint: false,
+    InformationCollector informationCollector
+  }) {
     assert(() {
+      void throwError(String message) {
+        StringBuffer information = new StringBuffer();
+        if (informationCollector != null)
+          informationCollector(information);
+        throw new FlutterError('$message\n${information}The offending constraints were:\n  $this');
+      }
       if (minWidth.isNaN || maxWidth.isNaN || minHeight.isNaN || maxHeight.isNaN) {
         List<String> affectedFieldsList = <String>[];
         if (minWidth.isNaN)
@@ -326,27 +335,27 @@ class BoxConstraints extends Constraints {
         } else {
           whichFields = affectedFieldsList.single;
         }
-        throw new FlutterError('BoxConstraints has ${affectedFieldsList.length == 1 ? 'a NaN value' : 'NaN values' } in $whichFields.\n$this');
+        throwError('BoxConstraints has ${affectedFieldsList.length == 1 ? 'a NaN value' : 'NaN values' } in $whichFields.');
       }
       if (minWidth < 0.0 && minHeight < 0.0)
-        throw new FlutterError('BoxConstraints has both a negative minimum width and a negative minimum height.\n$this');
+        throwError('BoxConstraints has both a negative minimum width and a negative minimum height.');
       if (minWidth < 0.0)
-        throw new FlutterError('BoxConstraints has a negative minimum width.\n$this');
+        throwError('BoxConstraints has a negative minimum width.');
       if (minHeight < 0.0)
-        throw new FlutterError('BoxConstraints has a negative minimum height.\n$this');
+        throwError('BoxConstraints has a negative minimum height.');
       if (maxWidth < minWidth && maxHeight < minHeight)
-        throw new FlutterError('BoxConstraints has both width and height constraints non-normalized.\n$this');
+        throwError('BoxConstraints has both width and height constraints non-normalized.');
       if (maxWidth < minWidth)
-        throw new FlutterError('BoxConstraints has non-normalized width constraints.\n$this');
+        throwError('BoxConstraints has non-normalized width constraints.');
       if (maxHeight < minHeight)
-        throw new FlutterError('BoxConstraints has non-normalized height constraints.\n$this');
+        throwError('BoxConstraints has non-normalized height constraints.');
       if (isAppliedConstraint) {
         if (minWidth.isInfinite && minHeight.isInfinite)
-          throw new FlutterError('BoxConstraints requires infinite width and infinite height.\n$this');
+          throwError('BoxConstraints forces an infinite width and infinite height.');
         if (minWidth.isInfinite)
-          throw new FlutterError('BoxConstraints requires infinite width.\n$this');
+          throwError('BoxConstraints forces an infinite width.');
         if (minHeight.isInfinite)
-          throw new FlutterError('BoxConstraints requires infinite height.\n$this');
+          throwError('BoxConstraints forces an infinite height.');
       }
       assert(isNormalized);
       return true;

--- a/packages/flutter/lib/src/services/assertions.dart
+++ b/packages/flutter/lib/src/services/assertions.dart
@@ -7,11 +7,9 @@ import 'print.dart';
 /// Signature for [FlutterError.onException] handler.
 typedef void FlutterExceptionHandler(FlutterErrorDetails details);
 
-/// Signature for [FlutterErrorDetails.informationCollector] callback.
-///
-/// The text written to the information argument may contain newlines but should
-/// not end with a newline.
-typedef void FlutterInformationCollector(StringBuffer information);
+/// Signature for [FlutterErrorDetails.informationCollector] callback
+/// and other callbacks that collect information into a string buffer.
+typedef void InformationCollector(StringBuffer information);
 
 /// Class for information provided to [FlutterExceptionHandler] callbacks.
 ///
@@ -56,7 +54,10 @@ class FlutterErrorDetails {
   ///
   /// Information collector callbacks can be expensive, so the generated information
   /// should be cached, rather than the callback being invoked multiple times.
-  final FlutterInformationCollector informationCollector;
+  ///
+  /// The text written to the information argument may contain newlines but should
+  /// not end with a newline.
+  final InformationCollector informationCollector;
 
   /// Whether this error should be ignored by the default error reporting
   /// behavior in release mode.
@@ -124,7 +125,7 @@ class FlutterError extends AssertionError {
 
   static int _errorCount = 0;
 
-  static const int _kWrapWidth = 120;
+  static const int _kWrapWidth = 100;
 
   /// Prints the given exception details to the console.
   ///

--- a/packages/flutter/test/rendering/constraints_test.dart
+++ b/packages/flutter/test/rendering/constraints_test.dart
@@ -43,7 +43,8 @@ void main() {
     }
     expect(result, equals(
       'BoxConstraints has NaN values in minWidth, maxWidth, and maxHeight.\n'
-      'BoxConstraints(NaN<=w<=NaN, 2.0<=h<=NaN; NOT NORMALIZED)'
+      'The offending constraints were:\n'
+      '  BoxConstraints(NaN<=w<=NaN, 2.0<=h<=NaN; NOT NORMALIZED)'
     ));
 
     result = 'no exception';
@@ -55,7 +56,8 @@ void main() {
     }
     expect(result, equals(
       'BoxConstraints has a NaN value in minHeight.\n'
-      'BoxConstraints(0.0<=w<=Infinity, NaN<=h<=Infinity; NOT NORMALIZED)'
+      'The offending constraints were:\n'
+      '  BoxConstraints(0.0<=w<=Infinity, NaN<=h<=Infinity; NOT NORMALIZED)'
     ));
 
     result = 'no exception';
@@ -67,7 +69,8 @@ void main() {
     }
     expect(result, equals(
       'BoxConstraints has NaN values in maxWidth and minHeight.\n'
-      'BoxConstraints(0.0<=w<=NaN, NaN<=h<=Infinity; NOT NORMALIZED)'
+      'The offending constraints were:\n'
+      '  BoxConstraints(0.0<=w<=NaN, NaN<=h<=Infinity; NOT NORMALIZED)'
     ));
   });
 }


### PR DESCRIPTION
This also shrinks the width of the error messages a bit because now that
we use 'package:' URLs the stacks are a bit narrower.
