### PR TITLE
[flutter_test] new WidgetTester API based on finder objects

### DIFF
--- a/dev/manual_tests/test/card_collection_test.dart
+++ b/dev/manual_tests/test/card_collection_test.dart
@@ -15,27 +15,27 @@ void main() {
       tester.pump(); // see https://github.com/flutter/flutter/issues/1865
       tester.pump(); // triggers a frame
 
-      Element navigationMenu = tester.findElement((Element element) {
+      Finder navigationMenu = find.byElement((Element element) {
         Widget widget = element.widget;
         if (widget is Tooltip)
           return widget.message == 'Open navigation menu';
         return false;
       });
 
-      expect(navigationMenu, isNotNull);
+      expect(tester, hasWidget(navigationMenu));
 
       tester.tap(navigationMenu);
       tester.pump(); // start opening menu
       tester.pump(const Duration(seconds: 1)); // wait til it's really opened
 
       // smoke test for various checkboxes
-      tester.tap(tester.findText('Make card labels editable'));
+      tester.tap(find.text('Make card labels editable'));
       tester.pump();
-      tester.tap(tester.findText('Let the sun shine'));
+      tester.tap(find.text('Let the sun shine'));
       tester.pump();
-      tester.tap(tester.findText('Make card labels editable'));
+      tester.tap(find.text('Make card labels editable'));
       tester.pump();
-      tester.tap(tester.findText('Vary font sizes'));
+      tester.tap(find.text('Vary font sizes'));
       tester.pump();
     });
   });

--- a/examples/hello_world/test/hello_test.dart
+++ b/examples/hello_world/test/hello_test.dart
@@ -13,7 +13,7 @@ void main() {
       hello_world.main(); // builds the app and schedules a frame but doesn't trigger one
       tester.pump(); // triggers a frame
 
-      expect(tester.findText('Hello, world!'), isNotNull);
+      expect(tester, hasWidget(find.text('Hello, world!')));
     });
   });
 }

--- a/examples/material_gallery/test/smoke_test.dart
+++ b/examples/material_gallery/test/smoke_test.dart
@@ -16,45 +16,45 @@ void main() {
       tester.pump(); // triggers a frame
 
       // Try loading Weather demo
-      tester.tap(tester.findText('Demos'));
+      tester.tap(find.text('Demos'));
       tester.pump();
       tester.pump(const Duration(seconds: 1)); // wait til it's really opened
 
-      tester.tap(tester.findText('Weather'));
+      tester.tap(find.text('Weather'));
       tester.pump();
       tester.pump(const Duration(seconds: 1)); // wait til it's really opened
 
       // Go back
-      Element backButton = tester.findElement((Element element) {
+      Finder backButton = find.byElement((Element element) {
         Widget widget = element.widget;
         if (widget is Tooltip)
           return widget.message == 'Back';
         return false;
       });
-      expect(backButton, isNotNull);
+      expect(tester, hasWidget(backButton));
       tester.tap(backButton);
       tester.pump(); // start going back
       tester.pump(const Duration(seconds: 1)); // wait til it's finished
 
       // Open menu
-      Element navigationMenu = tester.findElement((Element element) {
+      Finder navigationMenu = find.byElement((Element element) {
         Widget widget = element.widget;
         if (widget is Tooltip)
           return widget.message == 'Open navigation menu';
         return false;
       });
-      expect(navigationMenu, isNotNull);
+      expect(tester, hasWidget(navigationMenu));
       tester.tap(navigationMenu);
       tester.pump(); // start opening menu
       tester.pump(const Duration(seconds: 1)); // wait til it's really opened
 
       // switch theme
-      tester.tap(tester.findText('Dark'));
+      tester.tap(find.text('Dark'));
       tester.pump();
       tester.pump(const Duration(seconds: 1)); // wait til it's changed
 
       // switch theme
-      tester.tap(tester.findText('Light'));
+      tester.tap(find.text('Light'));
       tester.pump();
       tester.pump(const Duration(seconds: 1)); // wait til it's changed
     });

--- a/examples/stocks/test/icon_color_test.dart
+++ b/examples/stocks/test/icon_color_test.dart
@@ -38,7 +38,7 @@ Element findElementOfExactWidgetTypeGoingUp(Element node, Type targetType) {
 
 final RegExp materialIconAssetNameColorExtractor = new RegExp(r'[^/]+/ic_.+_(white|black)_[0-9]+dp\.png');
 
-void checkIconColor(WidgetTester tester, String label, Color color) {
+void checkIconColor(ElementTreeTester tester, String label, Color color) {
   // The icon is going to be in the same merged semantics box as the text
   // regardless of how the menu item is represented, so this is a good
   // way to find the menu item. I hope.
@@ -59,11 +59,11 @@ void main() {
       tester.pump(); // triggers a frame
 
       // sanity check
-      expect(tester.findText('MARKET'), isNotNull);
-      expect(tester.findText('Help & Feedback'), isNull);
+      expect(tester, hasWidget(find.text('MARKET')));
+      expect(tester, doesNotHaveWidget(find.text('Help & Feedback')));
       tester.pump(new Duration(seconds: 2));
-      expect(tester.findText('MARKET'), isNotNull);
-      expect(tester.findText('Help & Feedback'), isNull);
+      expect(tester, hasWidget(find.text('MARKET')));
+      expect(tester, doesNotHaveWidget(find.text('Help & Feedback')));
 
       // drag the drawer out
       Point left = new Point(0.0, ui.window.size.height / 2.0);
@@ -74,24 +74,24 @@ void main() {
       tester.pump();
       gesture.up();
       tester.pump();
-      expect(tester.findText('MARKET'), isNotNull);
-      expect(tester.findText('Help & Feedback'), isNotNull);
+      expect(tester, hasWidget(find.text('MARKET')));
+      expect(tester, hasWidget(find.text('Help & Feedback')));
 
       // check the colour of the icon - light mode
-      checkIconColor(tester, 'Stock List', Colors.purple[500]); // theme primary color
-      checkIconColor(tester, 'Account Balance', Colors.black45); // enabled
-      checkIconColor(tester, 'Help & Feedback', Colors.black26); // disabled
+      checkIconColor(tester.elementTreeTester, 'Stock List', Colors.purple[500]); // theme primary color
+      checkIconColor(tester.elementTreeTester, 'Account Balance', Colors.black45); // enabled
+      checkIconColor(tester.elementTreeTester, 'Help & Feedback', Colors.black26); // disabled
 
       // switch to dark mode
-      tester.tap(tester.findText('Pessimistic'));
+      tester.tap(find.text('Pessimistic'));
       tester.pump(); // get the tap and send the notification that the theme has changed
       tester.pump(); // start the theme transition
       tester.pump(const Duration(seconds: 5)); // end the transition
 
       // check the colour of the icon - dark mode
-      checkIconColor(tester, 'Stock List', Colors.redAccent[200]); // theme accent color
-      checkIconColor(tester, 'Account Balance', Colors.white); // enabled
-      checkIconColor(tester, 'Help & Feedback', Colors.white30); // disabled
+      checkIconColor(tester.elementTreeTester, 'Stock List', Colors.redAccent[200]); // theme accent color
+      checkIconColor(tester.elementTreeTester, 'Account Balance', Colors.white); // enabled
+      checkIconColor(tester.elementTreeTester, 'Help & Feedback', Colors.white30); // disabled
 
     });
   });

--- a/examples/stocks/test/locale_test.dart
+++ b/examples/stocks/test/locale_test.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:stocks/main.dart' as stocks;
 import 'package:stocks/stock_data.dart' as stock_data;
@@ -14,15 +13,13 @@ void main() {
   test("Test changing locale", () {
     testWidgets((WidgetTester tester) {
       stocks.main();
-      tester.async.flushMicrotasks(); // see https://github.com/flutter/flutter/issues/1865
+      tester.flushMicrotasks(); // see https://github.com/flutter/flutter/issues/1865
       tester.pump();
 
-      Element tab = tester.findText('MARKET');
-      expect(tab, isNotNull);
+      expect(tester, hasWidget(find.text('MARKET')));
       tester.setLocale("es", "US");
       tester.pump();
-      Text text = tab.widget;
-      expect(text.data, equals("MERCADO"));
+      expect(tester, hasWidget(find.text('MERCADO')));
 
       // TODO(abarth): We're leaking an animation. We should track down the leak
       // and plug it rather than waiting for the animation to end here.

--- a/packages/flutter/benchmark/stocks/build_bench.dart
+++ b/packages/flutter/benchmark/stocks/build_bench.dart
@@ -24,7 +24,7 @@ void main() {
     tester.tapAt(new Point(20.0, 20.0)); // Open drawer
     tester.pump(); // Start drawer animation
     tester.pump(const Duration(seconds: 1)); // Complete drawer animation
-    appState = tester.findStateOfType(stocks.StocksAppState);
+    appState = tester.stateOf(find.byType(stocks.StocksApp));
   });
 
   WidgetFlutterBinding binding = WidgetFlutterBinding.instance;

--- a/packages/flutter/test/material/slider_test.dart
+++ b/packages/flutter/test/material/slider_test.dart
@@ -34,7 +34,7 @@ void main() {
       );
 
       expect(value, equals(0.0));
-      tester.tap(tester.findElementByKey(sliderKey));
+      tester.tap(find.byKey(sliderKey));
       expect(value, equals(0.5));
       tester.pump(); // No animation should start.
       expect(Scheduler.instance.transientCallbackCount, equals(0));
@@ -70,11 +70,11 @@ void main() {
       );
 
       expect(value, equals(0.0));
-      tester.tap(tester.findElementByKey(sliderKey));
+      tester.tap(find.byKey(sliderKey));
       expect(value, equals(50.0));
-      tester.scroll(tester.findElementByKey(sliderKey), const Offset(5.0, 0.0));
+      tester.scroll(find.byKey(sliderKey), const Offset(5.0, 0.0));
       expect(value, equals(50.0));
-      tester.scroll(tester.findElementByKey(sliderKey), const Offset(40.0, 0.0));
+      tester.scroll(find.byKey(sliderKey), const Offset(40.0, 0.0));
       expect(value, equals(80.0));
 
       tester.pump(); // Starts animation.

--- a/packages/flutter/test/material/snack_bar_test.dart
+++ b/packages/flutter/test/material/snack_bar_test.dart
@@ -37,24 +37,24 @@ void main() {
           }
         }
       ));
-      expect(tester.findText(helloSnackBar), isNull);
-      tester.tap(tester.findElementByKey(tapTarget));
-      expect(tester.findText(helloSnackBar), isNull);
+      expect(tester, doesNotHaveWidget(find.text(helloSnackBar)));
+      tester.tap(find.byKey(tapTarget));
+      expect(tester, doesNotHaveWidget(find.text(helloSnackBar)));
       tester.pump(); // schedule animation
-      expect(tester.findText(helloSnackBar), isNotNull);
+      expect(tester, hasWidget(find.text(helloSnackBar)));
       tester.pump(); // begin animation
-      expect(tester.findText(helloSnackBar), isNotNull);
+      expect(tester, hasWidget(find.text(helloSnackBar)));
       tester.pump(new Duration(milliseconds: 750)); // 0.75s // animation last frame; two second timer starts here
-      expect(tester.findText(helloSnackBar), isNotNull);
+      expect(tester, hasWidget(find.text(helloSnackBar)));
       tester.pump(new Duration(milliseconds: 750)); // 1.50s
-      expect(tester.findText(helloSnackBar), isNotNull);
+      expect(tester, hasWidget(find.text(helloSnackBar)));
       tester.pump(new Duration(milliseconds: 750)); // 2.25s
-      expect(tester.findText(helloSnackBar), isNotNull);
+      expect(tester, hasWidget(find.text(helloSnackBar)));
       tester.pump(new Duration(milliseconds: 750)); // 3.00s // timer triggers to dismiss snackbar, reverse animation is scheduled
       tester.pump(); // begin animation
-      expect(tester.findText(helloSnackBar), isNotNull); // frame 0 of dismiss animation
+      expect(tester, hasWidget(find.text(helloSnackBar))); // frame 0 of dismiss animation
       tester.pump(new Duration(milliseconds: 750)); // 3.75s // last frame of animation, snackbar removed from build
-      expect(tester.findText(helloSnackBar), isNull);
+      expect(tester, doesNotHaveWidget(find.text(helloSnackBar)));
     });
   });
 
@@ -89,53 +89,53 @@ void main() {
           }
         }
       ));
-      expect(tester.findText('bar1'), isNull);
-      expect(tester.findText('bar2'), isNull);
-      tester.tap(tester.findElementByKey(tapTarget)); // queue bar1
-      tester.tap(tester.findElementByKey(tapTarget)); // queue bar2
-      expect(tester.findText('bar1'), isNull);
-      expect(tester.findText('bar2'), isNull);
+      expect(tester, doesNotHaveWidget(find.text('bar1')));
+      expect(tester, doesNotHaveWidget(find.text('bar2')));
+      tester.tap(find.byKey(tapTarget)); // queue bar1
+      tester.tap(find.byKey(tapTarget)); // queue bar2
+      expect(tester, doesNotHaveWidget(find.text('bar1')));
+      expect(tester, doesNotHaveWidget(find.text('bar2')));
       tester.pump(); // schedule animation for bar1
-      expect(tester.findText('bar1'), isNotNull);
-      expect(tester.findText('bar2'), isNull);
+      expect(tester, hasWidget(find.text('bar1')));
+      expect(tester, doesNotHaveWidget(find.text('bar2')));
       tester.pump(); // begin animation
-      expect(tester.findText('bar1'), isNotNull);
-      expect(tester.findText('bar2'), isNull);
+      expect(tester, hasWidget(find.text('bar1')));
+      expect(tester, doesNotHaveWidget(find.text('bar2')));
       tester.pump(new Duration(milliseconds: 750)); // 0.75s // animation last frame; two second timer starts here
-      expect(tester.findText('bar1'), isNotNull);
-      expect(tester.findText('bar2'), isNull);
+      expect(tester, hasWidget(find.text('bar1')));
+      expect(tester, doesNotHaveWidget(find.text('bar2')));
       tester.pump(new Duration(milliseconds: 750)); // 1.50s
-      expect(tester.findText('bar1'), isNotNull);
-      expect(tester.findText('bar2'), isNull);
+      expect(tester, hasWidget(find.text('bar1')));
+      expect(tester, doesNotHaveWidget(find.text('bar2')));
       tester.pump(new Duration(milliseconds: 750)); // 2.25s
-      expect(tester.findText('bar1'), isNotNull);
-      expect(tester.findText('bar2'), isNull);
+      expect(tester, hasWidget(find.text('bar1')));
+      expect(tester, doesNotHaveWidget(find.text('bar2')));
       tester.pump(new Duration(milliseconds: 750)); // 3.00s // timer triggers to dismiss snackbar, reverse animation is scheduled
       tester.pump(); // begin animation
-      expect(tester.findText('bar1'), isNotNull);
-      expect(tester.findText('bar2'), isNull);
+      expect(tester, hasWidget(find.text('bar1')));
+      expect(tester, doesNotHaveWidget(find.text('bar2')));
       tester.pump(new Duration(milliseconds: 750)); // 3.75s // last frame of animation, snackbar removed from build, new snack bar put in its place
-      expect(tester.findText('bar1'), isNull);
-      expect(tester.findText('bar2'), isNotNull);
+      expect(tester, doesNotHaveWidget(find.text('bar1')));
+      expect(tester, hasWidget(find.text('bar2')));
       tester.pump(); // begin animation
-      expect(tester.findText('bar1'), isNull);
-      expect(tester.findText('bar2'), isNotNull);
+      expect(tester, doesNotHaveWidget(find.text('bar1')));
+      expect(tester, hasWidget(find.text('bar2')));
       tester.pump(new Duration(milliseconds: 750)); // 4.50s // animation last frame; two second timer starts here
-      expect(tester.findText('bar1'), isNull);
-      expect(tester.findText('bar2'), isNotNull);
+      expect(tester, doesNotHaveWidget(find.text('bar1')));
+      expect(tester, hasWidget(find.text('bar2')));
       tester.pump(new Duration(milliseconds: 750)); // 5.25s
-      expect(tester.findText('bar1'), isNull);
-      expect(tester.findText('bar2'), isNotNull);
+      expect(tester, doesNotHaveWidget(find.text('bar1')));
+      expect(tester, hasWidget(find.text('bar2')));
       tester.pump(new Duration(milliseconds: 750)); // 6.00s
-      expect(tester.findText('bar1'), isNull);
-      expect(tester.findText('bar2'), isNotNull);
+      expect(tester, doesNotHaveWidget(find.text('bar1')));
+      expect(tester, hasWidget(find.text('bar2')));
       tester.pump(new Duration(milliseconds: 750)); // 6.75s // timer triggers to dismiss snackbar, reverse animation is scheduled
       tester.pump(); // begin animation
-      expect(tester.findText('bar1'), isNull);
-      expect(tester.findText('bar2'), isNotNull);
+      expect(tester, doesNotHaveWidget(find.text('bar1')));
+      expect(tester, hasWidget(find.text('bar2')));
       tester.pump(new Duration(milliseconds: 750)); // 7.50s // last frame of animation, snackbar removed from build, new snack bar put in its place
-      expect(tester.findText('bar1'), isNull);
-      expect(tester.findText('bar2'), isNull);
+      expect(tester, doesNotHaveWidget(find.text('bar1')));
+      expect(tester, doesNotHaveWidget(find.text('bar2')));
     });
   });
 
@@ -172,62 +172,62 @@ void main() {
           }
         }
       ));
-      expect(tester.findText('bar1'), isNull);
-      expect(tester.findText('bar2'), isNull);
+      expect(tester, doesNotHaveWidget(find.text('bar1')));
+      expect(tester, doesNotHaveWidget(find.text('bar2')));
       time = 1000;
-      tester.tap(tester.findElementByKey(tapTarget)); // queue bar1
+      tester.tap(find.byKey(tapTarget)); // queue bar1
       ScaffoldFeatureController<SnackBar, Null> firstController = lastController;
       time = 2;
-      tester.tap(tester.findElementByKey(tapTarget)); // queue bar2
-      expect(tester.findText('bar1'), isNull);
-      expect(tester.findText('bar2'), isNull);
+      tester.tap(find.byKey(tapTarget)); // queue bar2
+      expect(tester, doesNotHaveWidget(find.text('bar1')));
+      expect(tester, doesNotHaveWidget(find.text('bar2')));
       tester.pump(); // schedule animation for bar1
-      expect(tester.findText('bar1'), isNotNull);
-      expect(tester.findText('bar2'), isNull);
+      expect(tester, hasWidget(find.text('bar1')));
+      expect(tester, doesNotHaveWidget(find.text('bar2')));
       tester.pump(); // begin animation
-      expect(tester.findText('bar1'), isNotNull);
-      expect(tester.findText('bar2'), isNull);
+      expect(tester, hasWidget(find.text('bar1')));
+      expect(tester, doesNotHaveWidget(find.text('bar2')));
       tester.pump(new Duration(milliseconds: 750)); // 0.75s // animation last frame; two second timer starts here
-      expect(tester.findText('bar1'), isNotNull);
-      expect(tester.findText('bar2'), isNull);
+      expect(tester, hasWidget(find.text('bar1')));
+      expect(tester, doesNotHaveWidget(find.text('bar2')));
       tester.pump(new Duration(milliseconds: 750)); // 1.50s
-      expect(tester.findText('bar1'), isNotNull);
-      expect(tester.findText('bar2'), isNull);
+      expect(tester, hasWidget(find.text('bar1')));
+      expect(tester, doesNotHaveWidget(find.text('bar2')));
       tester.pump(new Duration(milliseconds: 750)); // 2.25s
-      expect(tester.findText('bar1'), isNotNull);
-      expect(tester.findText('bar2'), isNull);
+      expect(tester, hasWidget(find.text('bar1')));
+      expect(tester, doesNotHaveWidget(find.text('bar2')));
       tester.pump(new Duration(milliseconds: 10000)); // 12.25s
-      expect(tester.findText('bar1'), isNotNull);
-      expect(tester.findText('bar2'), isNull);
+      expect(tester, hasWidget(find.text('bar1')));
+      expect(tester, doesNotHaveWidget(find.text('bar2')));
 
       firstController.close(); // snackbar is manually dismissed
 
       tester.pump(new Duration(milliseconds: 750)); // 13.00s // reverse animation is scheduled
       tester.pump(); // begin animation
-      expect(tester.findText('bar1'), isNotNull);
-      expect(tester.findText('bar2'), isNull);
+      expect(tester, hasWidget(find.text('bar1')));
+      expect(tester, doesNotHaveWidget(find.text('bar2')));
       tester.pump(new Duration(milliseconds: 750)); // 13.75s // last frame of animation, snackbar removed from build, new snack bar put in its place
-      expect(tester.findText('bar1'), isNull);
-      expect(tester.findText('bar2'), isNotNull);
+      expect(tester, doesNotHaveWidget(find.text('bar1')));
+      expect(tester, hasWidget(find.text('bar2')));
       tester.pump(); // begin animation
-      expect(tester.findText('bar1'), isNull);
-      expect(tester.findText('bar2'), isNotNull);
+      expect(tester, doesNotHaveWidget(find.text('bar1')));
+      expect(tester, hasWidget(find.text('bar2')));
       tester.pump(new Duration(milliseconds: 750)); // 14.50s // animation last frame; two second timer starts here
-      expect(tester.findText('bar1'), isNull);
-      expect(tester.findText('bar2'), isNotNull);
+      expect(tester, doesNotHaveWidget(find.text('bar1')));
+      expect(tester, hasWidget(find.text('bar2')));
       tester.pump(new Duration(milliseconds: 750)); // 15.25s
-      expect(tester.findText('bar1'), isNull);
-      expect(tester.findText('bar2'), isNotNull);
+      expect(tester, doesNotHaveWidget(find.text('bar1')));
+      expect(tester, hasWidget(find.text('bar2')));
       tester.pump(new Duration(milliseconds: 750)); // 16.00s
-      expect(tester.findText('bar1'), isNull);
-      expect(tester.findText('bar2'), isNotNull);
+      expect(tester, doesNotHaveWidget(find.text('bar1')));
+      expect(tester, hasWidget(find.text('bar2')));
       tester.pump(new Duration(milliseconds: 750)); // 16.75s // timer triggers to dismiss snackbar, reverse animation is scheduled
       tester.pump(); // begin animation
-      expect(tester.findText('bar1'), isNull);
-      expect(tester.findText('bar2'), isNotNull);
+      expect(tester, doesNotHaveWidget(find.text('bar1')));
+      expect(tester, hasWidget(find.text('bar2')));
       tester.pump(new Duration(milliseconds: 750)); // 17.50s // last frame of animation, snackbar removed from build, new snack bar put in its place
-      expect(tester.findText('bar1'), isNull);
-      expect(tester.findText('bar2'), isNull);
+      expect(tester, doesNotHaveWidget(find.text('bar1')));
+      expect(tester, doesNotHaveWidget(find.text('bar2')));
     });
   });
 
@@ -262,23 +262,23 @@ void main() {
           }
         }
       ));
-      expect(tester.findText('bar1'), isNull);
-      expect(tester.findText('bar2'), isNull);
-      tester.tap(tester.findElementByKey(tapTarget)); // queue bar1
-      tester.tap(tester.findElementByKey(tapTarget)); // queue bar2
-      expect(tester.findText('bar1'), isNull);
-      expect(tester.findText('bar2'), isNull);
+      expect(tester, doesNotHaveWidget(find.text('bar1')));
+      expect(tester, doesNotHaveWidget(find.text('bar2')));
+      tester.tap(find.byKey(tapTarget)); // queue bar1
+      tester.tap(find.byKey(tapTarget)); // queue bar2
+      expect(tester, doesNotHaveWidget(find.text('bar1')));
+      expect(tester, doesNotHaveWidget(find.text('bar2')));
       tester.pump(); // schedule animation for bar1
-      expect(tester.findText('bar1'), isNotNull);
-      expect(tester.findText('bar2'), isNull);
+      expect(tester, hasWidget(find.text('bar1')));
+      expect(tester, doesNotHaveWidget(find.text('bar2')));
       tester.pump(); // begin animation
-      expect(tester.findText('bar1'), isNotNull);
-      expect(tester.findText('bar2'), isNull);
+      expect(tester, hasWidget(find.text('bar1')));
+      expect(tester, doesNotHaveWidget(find.text('bar2')));
       tester.pump(new Duration(milliseconds: 750)); // 0.75s // animation last frame; two second timer starts here
-      tester.scroll(tester.findText('bar1'), new Offset(0.0, 50.0));
+      tester.scroll(find.text('bar1'), new Offset(0.0, 50.0));
       tester.pump(); // bar1 dismissed, bar2 begins animating
-      expect(tester.findText('bar1'), isNull);
-      expect(tester.findText('bar2'), isNotNull);
+      expect(tester, doesNotHaveWidget(find.text('bar1')));
+      expect(tester, hasWidget(find.text('bar2')));
     });
   });
 
@@ -312,17 +312,17 @@ void main() {
           }
         }
       ));
-      tester.tap(tester.findText('X'));
+      tester.tap(find.text('X'));
       tester.pump(); // start animation
       tester.pump(const Duration(milliseconds: 750));
 
       expect(tapCount, equals(0));
-      tester.tap(tester.findText('ACTION'));
+      tester.tap(find.text('ACTION'));
       expect(tapCount, equals(1));
-      tester.tap(tester.findText('ACTION'));
+      tester.tap(find.text('ACTION'));
       expect(tapCount, equals(1));
       tester.pump();
-      tester.tap(tester.findText('ACTION'));
+      tester.tap(find.text('ACTION'));
       expect(tapCount, equals(1));
     });
   });

--- a/packages/flutter/test/material/tabs_test.dart
+++ b/packages/flutter/test/material/tabs_test.dart
@@ -47,21 +47,21 @@ void main() {
       List<String> tabs = <String>['A', 'B', 'C'];
 
       tester.pumpWidget(buildFrame(tabs: tabs, value: 'C', isScrollable: false));
-      TabBarSelectionState<String> selection = TabBarSelection.of(tester.findText('A'));
+      TabBarSelectionState<String> selection = TabBarSelection.of(tester.elementTreeTester.findText('A'));
       expect(selection, isNotNull);
       expect(selection.indexOf('A'), equals(0));
       expect(selection.indexOf('B'), equals(1));
       expect(selection.indexOf('C'), equals(2));
-      expect(tester.findText('A'), isNotNull);
-      expect(tester.findText('B'), isNotNull);
-      expect(tester.findText('C'), isNotNull);
+      expect(tester, hasWidget(find.text('A')));
+      expect(tester, hasWidget(find.text('B')));
+      expect(tester, hasWidget(find.text('C')));
       expect(selection.index, equals(2));
       expect(selection.previousIndex, equals(2));
       expect(selection.value, equals('C'));
       expect(selection.previousValue, equals('C'));
 
       tester.pumpWidget(buildFrame(tabs: tabs, value: 'C' ,isScrollable: false));
-      tester.tap(tester.findText('B'));
+      tester.tap(find.text('B'));
       tester.pump();
       expect(selection.valueIsChanging, true);
       tester.pump(const Duration(seconds: 1)); // finish the animation
@@ -72,7 +72,7 @@ void main() {
       expect(selection.previousIndex, equals(2));
 
       tester.pumpWidget(buildFrame(tabs: tabs, value: 'C', isScrollable: false));
-      tester.tap(tester.findText('C'));
+      tester.tap(find.text('C'));
       tester.pump();
       tester.pump(const Duration(seconds: 1));
       expect(selection.value, equals('C'));
@@ -81,7 +81,7 @@ void main() {
       expect(selection.previousIndex, equals(1));
 
       tester.pumpWidget(buildFrame(tabs: tabs, value: 'C', isScrollable: false));
-      tester.tap(tester.findText('A'));
+      tester.tap(find.text('A'));
       tester.pump();
       tester.pump(const Duration(seconds: 1));
       expect(selection.value, equals('A'));
@@ -96,25 +96,25 @@ void main() {
       List<String> tabs = <String>['A', 'B', 'C'];
 
       tester.pumpWidget(buildFrame(tabs: tabs, value: 'C', isScrollable: true));
-      TabBarSelectionState<String> selection = TabBarSelection.of(tester.findText('A'));
+      TabBarSelectionState<String> selection = TabBarSelection.of(tester.elementTreeTester.findText('A'));
       expect(selection, isNotNull);
-      expect(tester.findText('A'), isNotNull);
-      expect(tester.findText('B'), isNotNull);
-      expect(tester.findText('C'), isNotNull);
+      expect(tester, hasWidget(find.text('A')));
+      expect(tester, hasWidget(find.text('B')));
+      expect(tester, hasWidget(find.text('C')));
       expect(selection.value, equals('C'));
 
       tester.pumpWidget(buildFrame(tabs: tabs, value: 'C', isScrollable: true));
-      tester.tap(tester.findText('B'));
+      tester.tap(find.text('B'));
       tester.pump();
       expect(selection.value, equals('B'));
 
       tester.pumpWidget(buildFrame(tabs: tabs, value: 'C', isScrollable: true));
-      tester.tap(tester.findText('C'));
+      tester.tap(find.text('C'));
       tester.pump();
       expect(selection.value, equals('C'));
 
       tester.pumpWidget(buildFrame(tabs: tabs, value: 'C', isScrollable: true));
-      tester.tap(tester.findText('A'));
+      tester.tap(find.text('A'));
       tester.pump();
       expect(selection.value, equals('A'));
     });
@@ -125,20 +125,20 @@ void main() {
       List<String> tabs = <String>['AAAAAA', 'BBBBBB', 'CCCCCC', 'DDDDDD', 'EEEEEE', 'FFFFFF', 'GGGGGG', 'HHHHHH', 'IIIIII', 'JJJJJJ', 'KKKKKK', 'LLLLLL'];
       Key tabBarKey = new Key('TabBar');
       tester.pumpWidget(buildFrame(tabs: tabs, value: 'AAAAAA', isScrollable: true, tabBarKey: tabBarKey));
-      TabBarSelectionState<String> selection = TabBarSelection.of(tester.findText('AAAAAA'));
+      TabBarSelectionState<String> selection = TabBarSelection.of(tester.elementTreeTester.findText('AAAAAA'));
       expect(selection, isNotNull);
       expect(selection.value, equals('AAAAAA'));
 
-      expect(tester.getSize(tester.findElementByKey(tabBarKey)).width, equals(800.0));
+      expect(tester.getSize(find.byKey(tabBarKey)).width, equals(800.0));
       // The center of the FFFFFF item is to the right of the TabBar's center
-      expect(tester.getCenter(tester.findText('FFFFFF')).x, greaterThan(401.0));
+      expect(tester.getCenter(find.text('FFFFFF')).x, greaterThan(401.0));
 
-      tester.tap(tester.findText('FFFFFF'));
+      tester.tap(find.text('FFFFFF'));
       tester.pump();
       tester.pump(const Duration(seconds: 1)); // finish the scroll animation
       expect(selection.value, equals('FFFFFF'));
       // The center of the FFFFFF item is now at the TabBar's center
-      expect(tester.getCenter(tester.findText('FFFFFF')).x, closeTo(400.0, 1.0));
+      expect(tester.getCenter(find.text('FFFFFF')).x, closeTo(400.0, 1.0));
     });
   });
 
@@ -148,16 +148,16 @@ void main() {
       List<String> tabs = <String>['AAAAAA', 'BBBBBB', 'CCCCCC', 'DDDDDD', 'EEEEEE', 'FFFFFF', 'GGGGGG', 'HHHHHH', 'IIIIII', 'JJJJJJ', 'KKKKKK', 'LLLLLL'];
       Key tabBarKey = new Key('TabBar');
       tester.pumpWidget(buildFrame(tabs: tabs, value: 'AAAAAA', isScrollable: true, tabBarKey: tabBarKey));
-      TabBarSelectionState<String> selection = TabBarSelection.of(tester.findText('AAAAAA'));
+      TabBarSelectionState<String> selection = TabBarSelection.of(tester.elementTreeTester.findText('AAAAAA'));
       expect(selection, isNotNull);
       expect(selection.value, equals('AAAAAA'));
 
       // Fling-scroll the TabBar to the left
-      expect(tester.getCenter(tester.findText('HHHHHH')).x, lessThan(700.0));
-      tester.fling(tester.findElementByKey(tabBarKey), const Offset(-20.0, 0.0), 1000.0);
+      expect(tester.getCenter(find.text('HHHHHH')).x, lessThan(700.0));
+      tester.fling(find.byKey(tabBarKey), const Offset(-20.0, 0.0), 1000.0);
       tester.pump();
       tester.pump(const Duration(seconds: 1)); // finish the scroll animation
-      expect(tester.getCenter(tester.findText('HHHHHH')).x, lessThan(500.0));
+      expect(tester.getCenter(find.text('HHHHHH')).x, lessThan(500.0));
 
       // Scrolling the TabBar doesn't change the selection
       expect(selection.value, equals('AAAAAA'));
@@ -191,22 +191,11 @@ void main() {
       }
 
       StateMarkerState findStateMarkerState(String name) {
-        Element secondLabel = tester.findText(name);
-        expect(secondLabel, isNotNull);
-        StatefulElement secondMarker;
-        secondLabel.visitAncestorElements((Element element) {
-          if (element.widget is StateMarker) {
-            secondMarker = element;
-            return false;
-          }
-          return true;
-        });
-        expect(secondMarker, isNotNull);
-        return secondMarker.state;
+        return tester.stateOf(find.widgetWithText(StateMarker, name));
       }
 
       tester.pumpWidget(builder());
-      TestGesture gesture = tester.startGesture(tester.getCenter(tester.findText(tabs[0])));
+      TestGesture gesture = tester.startGesture(tester.getCenter(find.text(tabs[0])));
       gesture.moveBy(new Offset(-600.0, 0.0));
       tester.pump();
       expect(value, equals(tabs[0]));
@@ -220,7 +209,7 @@ void main() {
 
       // Move to the third tab.
 
-      gesture = tester.startGesture(tester.getCenter(tester.findText(tabs[1])));
+      gesture = tester.startGesture(tester.getCenter(find.text(tabs[1])));
       gesture.moveBy(new Offset(-600.0, 0.0));
       gesture.up();
       tester.pump();
@@ -231,11 +220,11 @@ void main() {
 
       // The state is now gone.
 
-      expect(tester.findText(tabs[1]), isNull);
+      expect(tester, doesNotHaveWidget(find.text(tabs[1])));
 
       // Move back to the second tab.
 
-      gesture = tester.startGesture(tester.getCenter(tester.findText(tabs[2])));
+      gesture = tester.startGesture(tester.getCenter(find.text(tabs[2])));
       gesture.moveBy(new Offset(600.0, 0.0));
       tester.pump();
       StateMarkerState markerState = findStateMarkerState(tabs[1]);

--- a/packages/flutter/test/widget/animated_container_test.dart
+++ b/packages/flutter/test/widget/animated_container_test.dart
@@ -102,7 +102,7 @@ void main() {
   });
 
   test('Animation rerun', () {
-    testWidgets((WidgetTester tester) {
+    testElementTree((ElementTreeTester tester) {
       tester.pumpWidget(
         new Center(
           child: new AnimatedContainer(

--- a/packages/flutter/test/widget/aspect_ratio_test.dart
+++ b/packages/flutter/test/widget/aspect_ratio_test.dart
@@ -7,7 +7,7 @@ import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 import 'package:test/test.dart';
 
-Size _getSize(WidgetTester tester, BoxConstraints constraints, double aspectRatio) {
+Size _getSize(ElementTreeTester tester, BoxConstraints constraints, double aspectRatio) {
   Key childKey = new UniqueKey();
   tester.pumpWidget(
     new Center(
@@ -28,14 +28,14 @@ Size _getSize(WidgetTester tester, BoxConstraints constraints, double aspectRati
 
 void main() {
   test('Aspect ratio control test', () {
-    testWidgets((WidgetTester tester) {
+    testElementTree((ElementTreeTester tester) {
       expect(_getSize(tester, new BoxConstraints.loose(new Size(500.0, 500.0)), 2.0), equals(new Size(500.0, 250.0)));
       expect(_getSize(tester, new BoxConstraints.loose(new Size(500.0, 500.0)), 0.5), equals(new Size(250.0, 500.0)));
     });
   });
 
   test('Aspect ratio infinite width', () {
-    testWidgets((WidgetTester tester) {
+    testElementTree((ElementTreeTester tester) {
       Key childKey = new UniqueKey();
       tester.pumpWidget(
         new Center(

--- a/packages/flutter/test/widget/asset_vendor_test.dart
+++ b/packages/flutter/test/widget/asset_vendor_test.dart
@@ -120,15 +120,15 @@ Widget buildImageAtRatio(String image, Key key, double ratio, bool inferSize) {
   );
 }
 
-RenderImage getRenderImage(WidgetTester tester, Key key) {
+RenderImage getRenderImage(ElementTreeTester tester, Key key) {
   return tester.findElementByKey(key).renderObject;
 }
 
-TestImage getTestImage(WidgetTester tester, Key key) {
+TestImage getTestImage(ElementTreeTester tester, Key key) {
   return getRenderImage(tester, key).image;
 }
 
-void pumpTreeToLayout(WidgetTester tester, Widget widget) {
+void pumpTreeToLayout(ElementTreeTester tester, Widget widget) {
   Duration pumpDuration = const Duration(milliseconds: 0);
   EnginePhase pumpPhase = EnginePhase.layout;
   tester.pumpWidget(widget, pumpDuration, pumpPhase);
@@ -139,7 +139,7 @@ void main() {
 
   test('Image for device pixel ratio 1.0', () {
     const double ratio = 1.0;
-    testWidgets((WidgetTester tester) {
+    testElementTree((ElementTreeTester tester) {
       Key key = new GlobalKey();
       pumpTreeToLayout(tester, buildImageAtRatio(image, key, ratio, false));
       expect(getRenderImage(tester, key).size, const Size(200.0, 200.0));
@@ -153,7 +153,7 @@ void main() {
 
   test('Image for device pixel ratio 0.5', () {
     const double ratio = 0.5;
-    testWidgets((WidgetTester tester) {
+    testElementTree((ElementTreeTester tester) {
       Key key = new GlobalKey();
       pumpTreeToLayout(tester, buildImageAtRatio(image, key, ratio, false));
       expect(getRenderImage(tester, key).size, const Size(200.0, 200.0));
@@ -167,7 +167,7 @@ void main() {
 
   test('Image for device pixel ratio 1.5', () {
     const double ratio = 1.5;
-    testWidgets((WidgetTester tester) {
+    testElementTree((ElementTreeTester tester) {
       Key key = new GlobalKey();
       pumpTreeToLayout(tester, buildImageAtRatio(image, key, ratio, false));
       expect(getRenderImage(tester, key).size, const Size(200.0, 200.0));
@@ -181,7 +181,7 @@ void main() {
 
   test('Image for device pixel ratio 1.75', () {
     const double ratio = 1.75;
-    testWidgets((WidgetTester tester) {
+    testElementTree((ElementTreeTester tester) {
       Key key = new GlobalKey();
       pumpTreeToLayout(tester, buildImageAtRatio(image, key, ratio, false));
       expect(getRenderImage(tester, key).size, const Size(200.0, 200.0));
@@ -195,7 +195,7 @@ void main() {
 
   test('Image for device pixel ratio 2.3', () {
     const double ratio = 2.3;
-    testWidgets((WidgetTester tester) {
+    testElementTree((ElementTreeTester tester) {
       Key key = new GlobalKey();
       pumpTreeToLayout(tester, buildImageAtRatio(image, key, ratio, false));
       expect(getRenderImage(tester, key).size, const Size(200.0, 200.0));
@@ -209,7 +209,7 @@ void main() {
 
   test('Image for device pixel ratio 3.7', () {
     const double ratio = 3.7;
-    testWidgets((WidgetTester tester) {
+    testElementTree((ElementTreeTester tester) {
       Key key = new GlobalKey();
       pumpTreeToLayout(tester, buildImageAtRatio(image, key, ratio, false));
       expect(getRenderImage(tester, key).size, const Size(200.0, 200.0));
@@ -223,7 +223,7 @@ void main() {
 
   test('Image for device pixel ratio 5.1', () {
     const double ratio = 5.1;
-    testWidgets((WidgetTester tester) {
+    testElementTree((ElementTreeTester tester) {
       Key key = new GlobalKey();
       pumpTreeToLayout(tester, buildImageAtRatio(image, key, ratio, false));
       expect(getRenderImage(tester, key).size, const Size(200.0, 200.0));

--- a/packages/flutter/test/widget/block_test.dart
+++ b/packages/flutter/test/widget/block_test.dart
@@ -23,14 +23,14 @@ void main() {
         )
       );
 
-      Point middleOfContainer = tester.getCenter(tester.findText('Hello'));
-      Point target = tester.getCenter(tester.findElementByKey(blockKey));
+      Point middleOfContainer = tester.getCenter(find.text('Hello'));
+      Point target = tester.getCenter(find.byKey(blockKey));
       TestGesture gesture = tester.startGesture(target);
       gesture.moveBy(const Offset(0.0, -10.0));
 
       tester.pump(const Duration(milliseconds: 1));
 
-      expect(tester.getCenter(tester.findText('Hello')) == middleOfContainer, isTrue);
+      expect(tester.getCenter(find.text('Hello')) == middleOfContainer, isTrue);
 
       gesture.up();
     });
@@ -50,17 +50,17 @@ void main() {
         )
       );
 
-      Point middleOfContainer = tester.getCenter(tester.findText('Hello'));
+      Point middleOfContainer = tester.getCenter(find.text('Hello'));
       expect(middleOfContainer.x, equals(400.0));
       expect(middleOfContainer.y, equals(1000.0));
 
-      Point target = tester.getCenter(tester.findElementByKey(blockKey));
+      Point target = tester.getCenter(find.byKey(blockKey));
       TestGesture gesture = tester.startGesture(target);
       gesture.moveBy(const Offset(0.0, -10.0));
 
       tester.pump(); // redo layout
 
-      expect(tester.getCenter(tester.findText('Hello')), isNot(equals(middleOfContainer)));
+      expect(tester.getCenter(find.text('Hello')), isNot(equals(middleOfContainer)));
 
       gesture.up();
     });

--- a/packages/flutter/test/widget/bottom_sheet_test.dart
+++ b/packages/flutter/test/widget/bottom_sheet_test.dart
@@ -23,7 +23,7 @@ void main() {
       ));
 
       tester.pump();
-      expect(tester.findText('BottomSheet'), isNull);
+      expect(tester, doesNotHaveWidget(find.text('BottomSheet')));
 
       showModalBottomSheet/*<Null>*/(
         context: context,
@@ -35,28 +35,28 @@ void main() {
 
       tester.pump(); // bottom sheet show animation starts
       tester.pump(new Duration(seconds: 1)); // animation done
-      expect(tester.findText('BottomSheet'), isNotNull);
+      expect(tester, hasWidget(find.text('BottomSheet')));
       expect(showBottomSheetThenCalled, isFalse);
 
       // Tap on the the bottom sheet itself to dismiss it
-      tester.tap(tester.findText('BottomSheet'));
+      tester.tap(find.text('BottomSheet'));
       tester.pump(); // bottom sheet dismiss animation starts
       expect(showBottomSheetThenCalled, isTrue);
       tester.pump(new Duration(seconds: 1)); // last frame of animation (sheet is entirely off-screen, but still present)
       tester.pump(new Duration(seconds: 1)); // frame after the animation (sheet has been removed)
-      expect(tester.findText('BottomSheet'), isNull);
+      expect(tester, doesNotHaveWidget(find.text('BottomSheet')));
 
       showModalBottomSheet/*<Null>*/(context: context, builder: (BuildContext context) => new Text('BottomSheet'));
       tester.pump(); // bottom sheet show animation starts
       tester.pump(new Duration(seconds: 1)); // animation done
-      expect(tester.findText('BottomSheet'), isNotNull);
+      expect(tester, hasWidget(find.text('BottomSheet')));
 
       // Tap above the the bottom sheet to dismiss it
       tester.tapAt(new Point(20.0, 20.0));
       tester.pump(); // bottom sheet dismiss animation starts
       tester.pump(new Duration(seconds: 1)); // animation done
       tester.pump(new Duration(seconds: 1)); // rebuild frame
-      expect(tester.findText('BottomSheet'), isNull);
+      expect(tester, doesNotHaveWidget(find.text('BottomSheet')));
     });
   });
 
@@ -77,7 +77,7 @@ void main() {
       ));
 
       expect(showBottomSheetThenCalled, isFalse);
-      expect(tester.findText('BottomSheet'), isNull);
+      expect(tester, doesNotHaveWidget(find.text('BottomSheet')));
 
       scaffoldKey.currentState.showBottomSheet((BuildContext context) {
         return new Container(
@@ -89,33 +89,33 @@ void main() {
       });
 
       expect(showBottomSheetThenCalled, isFalse);
-      expect(tester.findText('BottomSheet'), isNull);
+      expect(tester, doesNotHaveWidget(find.text('BottomSheet')));
 
       tester.pump(); // bottom sheet show animation starts
 
       expect(showBottomSheetThenCalled, isFalse);
-      expect(tester.findText('BottomSheet'), isNotNull);
+      expect(tester, hasWidget(find.text('BottomSheet')));
 
       tester.pump(new Duration(seconds: 1)); // animation done
 
       expect(showBottomSheetThenCalled, isFalse);
-      expect(tester.findText('BottomSheet'), isNotNull);
+      expect(tester, hasWidget(find.text('BottomSheet')));
 
-      tester.fling(tester.findText('BottomSheet'), const Offset(0.0, 20.0), 1000.0);
+      tester.fling(find.text('BottomSheet'), const Offset(0.0, 20.0), 1000.0);
       tester.pump(); // drain the microtask queue (Future completion callback)
 
       expect(showBottomSheetThenCalled, isTrue);
-      expect(tester.findText('BottomSheet'), isNotNull);
+      expect(tester, hasWidget(find.text('BottomSheet')));
 
       tester.pump(); // bottom sheet dismiss animation starts
 
       expect(showBottomSheetThenCalled, isTrue);
-      expect(tester.findText('BottomSheet'), isNotNull);
+      expect(tester, hasWidget(find.text('BottomSheet')));
 
       tester.pump(new Duration(seconds: 1)); // animation done
 
       expect(showBottomSheetThenCalled, isTrue);
-      expect(tester.findText('BottomSheet'), isNull);
+      expect(tester, doesNotHaveWidget(find.text('BottomSheet')));
     });
   });
 

--- a/packages/flutter/test/widget/box_decoration_test.dart
+++ b/packages/flutter/test/widget/box_decoration_test.dart
@@ -38,7 +38,7 @@ void main() {
           )
         )
       );
-      expect(tester.getSize(tester.findElementByKey(key)), equals(const Size(45.0, 45.0)));
+      expect(tester.getSize(find.byKey(key)), equals(const Size(45.0, 45.0)));
     });
   });
 }

--- a/packages/flutter/test/widget/coordinates_test.dart
+++ b/packages/flutter/test/widget/coordinates_test.dart
@@ -9,7 +9,7 @@ import 'package:test/test.dart';
 
 void main() {
   test('Comparing coordinates', () {
-    testWidgets((WidgetTester tester) {
+    testElementTree((ElementTreeTester tester) {
       Key keyA = new GlobalKey();
       Key keyB = new GlobalKey();
 

--- a/packages/flutter/test/widget/custom_multi_child_layout_test.dart
+++ b/packages/flutter/test/widget/custom_multi_child_layout_test.dart
@@ -146,7 +146,7 @@ void main() {
   });
 
   test('Loose constraints', () {
-    testWidgets((WidgetTester tester) {
+    testElementTree((ElementTreeTester tester) {
       Key key = new UniqueKey();
       tester.pumpWidget(new Center(
         child: new CustomMultiChildLayout(

--- a/packages/flutter/test/widget/date_picker_test_disabled.dart
+++ b/packages/flutter/test/widget/date_picker_test_disabled.dart
@@ -29,12 +29,12 @@ void main() {
       tester.pumpWidget(widget);
 
       expect(currentValue, isNull);
-      tester.tap(tester.findText('2015'));
+      tester.tap(find.text('2015'));
       tester.pumpWidget(widget);
-      tester.tap(tester.findText('2014'));
+      tester.tap(find.text('2014'));
       tester.pumpWidget(widget);
       expect(currentValue, equals(new DateTime(2014, 6, 9)));
-      tester.tap(tester.findText('30'));
+      tester.tap(find.text('30'));
       expect(currentValue, equals(new DateTime(2013, 1, 30)));
     });
   });

--- a/packages/flutter/test/widget/dismissable_test.dart
+++ b/packages/flutter/test/widget/dismissable_test.dart
@@ -52,8 +52,8 @@ Widget widgetBuilder() {
   );
 }
 
-void dismissElement(WidgetTester tester, Element itemElement, { DismissDirection gestureDirection }) {
-  assert(itemElement != null);
+void dismissElement(WidgetTester tester, Finder finder, { DismissDirection gestureDirection }) {
+  assert(tester.exists(finder));
   assert(gestureDirection != DismissDirection.horizontal);
   assert(gestureDirection != DismissDirection.vertical);
 
@@ -63,24 +63,24 @@ void dismissElement(WidgetTester tester, Element itemElement, { DismissDirection
     case DismissDirection.endToStart:
       // getTopRight() returns a point that's just beyond itemWidget's right
       // edge and outside the Dismissable event listener's bounds.
-      downLocation = tester.getTopRight(itemElement) + const Offset(-0.1, 0.0);
-      upLocation = tester.getTopLeft(itemElement);
+      downLocation = tester.getTopRight(finder) + const Offset(-0.1, 0.0);
+      upLocation = tester.getTopLeft(finder);
       break;
     case DismissDirection.startToEnd:
       // we do the same thing here to keep the test symmetric
-      downLocation = tester.getTopLeft(itemElement) + const Offset(0.1, 0.0);
-      upLocation = tester.getTopRight(itemElement);
+      downLocation = tester.getTopLeft(finder) + const Offset(0.1, 0.0);
+      upLocation = tester.getTopRight(finder);
       break;
     case DismissDirection.up:
       // getBottomLeft() returns a point that's just below itemWidget's bottom
       // edge and outside the Dismissable event listener's bounds.
-      downLocation = tester.getBottomLeft(itemElement) + const Offset(0.0, -0.1);
-      upLocation = tester.getTopLeft(itemElement);
+      downLocation = tester.getBottomLeft(finder) + const Offset(0.0, -0.1);
+      upLocation = tester.getTopLeft(finder);
       break;
     case DismissDirection.down:
       // again with doing the same here for symmetry
-      downLocation = tester.getTopLeft(itemElement) + const Offset(0.1, 0.0);
-      upLocation = tester.getBottomLeft(itemElement);
+      downLocation = tester.getTopLeft(finder) + const Offset(0.1, 0.0);
+      upLocation = tester.getBottomLeft(finder);
       break;
     default:
       fail("unsupported gestureDirection");
@@ -95,10 +95,10 @@ void dismissItem(WidgetTester tester, int item, { DismissDirection gestureDirect
   assert(gestureDirection != DismissDirection.horizontal);
   assert(gestureDirection != DismissDirection.vertical);
 
-  Element itemElement = tester.findText(item.toString());
-  expect(itemElement, isNotNull);
+  Finder itemFinder = find.text(item.toString());
+  expect(tester, hasWidget(itemFinder));
 
-  dismissElement(tester, itemElement, gestureDirection: gestureDirection);
+  dismissElement(tester, itemFinder, gestureDirection: gestureDirection);
 
   tester.pumpWidget(widgetBuilder()); // start the slide
   tester.pumpWidget(widgetBuilder(), const Duration(seconds: 1)); // finish the slide and start shrinking...
@@ -139,12 +139,12 @@ void main() {
       expect(dismissedItems, isEmpty);
 
       dismissItem(tester, 0, gestureDirection: DismissDirection.startToEnd);
-      expect(tester.findText('0'), isNull);
+      expect(tester, doesNotHaveWidget(find.text('0')));
       expect(dismissedItems, equals([0]));
       expect(reportedDismissDirection, DismissDirection.startToEnd);
 
       dismissItem(tester, 1, gestureDirection: DismissDirection.endToStart);
-      expect(tester.findText('1'), isNull);
+      expect(tester, doesNotHaveWidget(find.text('1')));
       expect(dismissedItems, equals([0, 1]));
       expect(reportedDismissDirection, DismissDirection.endToStart);
     });
@@ -159,12 +159,12 @@ void main() {
       expect(dismissedItems, isEmpty);
 
       dismissItem(tester, 0, gestureDirection: DismissDirection.up);
-      expect(tester.findText('0'), isNull);
+      expect(tester, doesNotHaveWidget(find.text('0')));
       expect(dismissedItems, equals([0]));
       expect(reportedDismissDirection, DismissDirection.up);
 
       dismissItem(tester, 1, gestureDirection: DismissDirection.down);
-      expect(tester.findText('1'), isNull);
+      expect(tester, doesNotHaveWidget(find.text('1')));
       expect(dismissedItems, equals([0, 1]));
       expect(reportedDismissDirection, DismissDirection.down);
     });
@@ -179,12 +179,12 @@ void main() {
       expect(dismissedItems, isEmpty);
 
       dismissItem(tester, 0, gestureDirection: DismissDirection.startToEnd);
-      expect(tester.findText('0'), isNotNull);
+      expect(tester, hasWidget(find.text('0')));
       expect(dismissedItems, isEmpty);
       dismissItem(tester, 1, gestureDirection: DismissDirection.startToEnd);
 
       dismissItem(tester, 0, gestureDirection: DismissDirection.endToStart);
-      expect(tester.findText('0'), isNull);
+      expect(tester, doesNotHaveWidget(find.text('0')));
       expect(dismissedItems, equals([0]));
       dismissItem(tester, 1, gestureDirection: DismissDirection.endToStart);
     });
@@ -199,11 +199,11 @@ void main() {
       expect(dismissedItems, isEmpty);
 
       dismissItem(tester, 0, gestureDirection: DismissDirection.endToStart);
-      expect(tester.findText('0'), isNotNull);
+      expect(tester, hasWidget(find.text('0')));
       expect(dismissedItems, isEmpty);
 
       dismissItem(tester, 0, gestureDirection: DismissDirection.startToEnd);
-      expect(tester.findText('0'), isNull);
+      expect(tester, doesNotHaveWidget(find.text('0')));
       expect(dismissedItems, equals([0]));
     });
   });
@@ -217,11 +217,11 @@ void main() {
       expect(dismissedItems, isEmpty);
 
       dismissItem(tester, 0, gestureDirection: DismissDirection.down);
-      expect(tester.findText('0'), isNotNull);
+      expect(tester, hasWidget(find.text('0')));
       expect(dismissedItems, isEmpty);
 
       dismissItem(tester, 0, gestureDirection: DismissDirection.up);
-      expect(tester.findText('0'), isNull);
+      expect(tester, doesNotHaveWidget(find.text('0')));
       expect(dismissedItems, equals([0]));
     });
   });
@@ -235,11 +235,11 @@ void main() {
       expect(dismissedItems, isEmpty);
 
       dismissItem(tester, 0, gestureDirection: DismissDirection.up);
-      expect(tester.findText('0'), isNotNull);
+      expect(tester, hasWidget(find.text('0')));
       expect(dismissedItems, isEmpty);
 
       dismissItem(tester, 0, gestureDirection: DismissDirection.down);
-      expect(tester.findText('0'), isNull);
+      expect(tester, doesNotHaveWidget(find.text('0')));
       expect(dismissedItems, equals([0]));
     });
   });
@@ -256,9 +256,7 @@ void main() {
       dismissDirection = DismissDirection.down;
 
       tester.pumpWidget(widgetBuilder());
-      Element itemElement = tester.findText('0');
-
-      Point location = tester.getTopLeft(itemElement);
+      Point location = tester.getTopLeft(find.text('0'));
       Offset offset = new Offset(0.0, 5.0);
       TestGesture gesture = tester.startGesture(location, pointer: 5);
       gesture.moveBy(offset);
@@ -293,18 +291,18 @@ void main() {
           )
         )
       ));
-      expect(tester.findText('1'), isNotNull);
-      expect(tester.findText('2'), isNotNull);
-      dismissElement(tester, tester.findText('2'), gestureDirection: DismissDirection.startToEnd);
+      expect(tester, hasWidget(find.text('1')));
+      expect(tester, hasWidget(find.text('2')));
+      dismissElement(tester, find.text('2'), gestureDirection: DismissDirection.startToEnd);
       tester.pump(); // start the slide away
       tester.pump(new Duration(seconds: 1)); // finish the slide away
-      expect(tester.findText('1'), isNotNull);
-      expect(tester.findText('2'), isNull);
-      dismissElement(tester, tester.findText('1'), gestureDirection: DismissDirection.startToEnd);
+      expect(tester, hasWidget(find.text('1')));
+      expect(tester, doesNotHaveWidget(find.text('2')));
+      dismissElement(tester, find.text('1'), gestureDirection: DismissDirection.startToEnd);
       tester.pump(); // start the slide away
       tester.pump(new Duration(seconds: 1)); // finish the slide away (at which point the child is no longer included in the tree)
-      expect(tester.findText('1'), isNull);
-      expect(tester.findText('2'), isNull);
+      expect(tester, doesNotHaveWidget(find.text('1')));
+      expect(tester, doesNotHaveWidget(find.text('2')));
     });
   });
 
@@ -317,13 +315,12 @@ void main() {
       tester.pumpWidget(widgetBuilder());
       expect(dismissedItems, isEmpty);
 
-      Element itemElement = tester.findText(0.toString());
-      expect(itemElement, isNotNull);
-      dismissElement(tester, itemElement, gestureDirection: DismissDirection.startToEnd);
+      Finder itemFinder = find.text('0');
+      expect(tester, hasWidget(itemFinder));
+      dismissElement(tester, itemFinder, gestureDirection: DismissDirection.startToEnd);
       tester.pump();
 
-      Element backgroundElement = tester.findText('background');
-      RenderBox backgroundBox = backgroundElement.findRenderObject();
+      RenderBox backgroundBox = tester.renderObjectOf(find.text('background'));
       expect(backgroundBox.size.height, equals(100.0));
     });
   });

--- a/packages/flutter/test/widget/draggable_test.dart
+++ b/packages/flutter/test/widget/draggable_test.dart
@@ -29,35 +29,35 @@ void main() {
       }));
 
       expect(accepted, isEmpty);
-      expect(tester.findText('Source'), isNotNull);
-      expect(tester.findText('Dragging'), isNull);
-      expect(tester.findText('Target'), isNotNull);
+      expect(tester, hasWidget(find.text('Source')));
+      expect(tester, doesNotHaveWidget(find.text('Dragging')));
+      expect(tester, hasWidget(find.text('Target')));
 
-      Point firstLocation = tester.getCenter(tester.findText('Source'));
+      Point firstLocation = tester.getCenter(find.text('Source'));
       TestGesture gesture = tester.startGesture(firstLocation, pointer: 7);
       tester.pump();
 
       expect(accepted, isEmpty);
-      expect(tester.findText('Source'), isNotNull);
-      expect(tester.findText('Dragging'), isNotNull);
-      expect(tester.findText('Target'), isNotNull);
+      expect(tester, hasWidget(find.text('Source')));
+      expect(tester, hasWidget(find.text('Dragging')));
+      expect(tester, hasWidget(find.text('Target')));
 
-      Point secondLocation = tester.getCenter(tester.findText('Target'));
+      Point secondLocation = tester.getCenter(find.text('Target'));
       gesture.moveTo(secondLocation);
       tester.pump();
 
       expect(accepted, isEmpty);
-      expect(tester.findText('Source'), isNotNull);
-      expect(tester.findText('Dragging'), isNotNull);
-      expect(tester.findText('Target'), isNotNull);
+      expect(tester, hasWidget(find.text('Source')));
+      expect(tester, hasWidget(find.text('Dragging')));
+      expect(tester, hasWidget(find.text('Target')));
 
       gesture.up();
       tester.pump();
 
       expect(accepted, equals(<int>[1]));
-      expect(tester.findText('Source'), isNotNull);
-      expect(tester.findText('Dragging'), isNull);
-      expect(tester.findText('Target'), isNotNull);
+      expect(tester, hasWidget(find.text('Source')));
+      expect(tester, doesNotHaveWidget(find.text('Dragging')));
+      expect(tester, hasWidget(find.text('Target')));
     });
   });
 
@@ -93,30 +93,30 @@ void main() {
       }));
 
       expect(events, isEmpty);
-      expect(tester.findText('Source'), isNotNull);
-      expect(tester.findText('Dragging'), isNull);
-      expect(tester.findText('Target'), isNotNull);
-      expect(tester.findText('Button'), isNotNull);
+      expect(tester, hasWidget(find.text('Source')));
+      expect(tester, doesNotHaveWidget(find.text('Dragging')));
+      expect(tester, hasWidget(find.text('Target')));
+      expect(tester, hasWidget(find.text('Button')));
 
       // taps (we check both to make sure the test is consistent)
 
       expect(events, isEmpty);
-      tester.tap(tester.findText('Button'));
+      tester.tap(find.text('Button'));
       expect(events, equals(<String>['tap']));
       events.clear();
 
       expect(events, isEmpty);
-      tester.tap(tester.findText('Target'));
+      tester.tap(find.text('Target'));
       expect(events, equals(<String>['tap']));
       events.clear();
 
       // drag and drop
 
-      firstLocation = tester.getCenter(tester.findText('Source'));
+      firstLocation = tester.getCenter(find.text('Source'));
       TestGesture gesture = tester.startGesture(firstLocation, pointer: 7);
       tester.pump();
 
-      secondLocation = tester.getCenter(tester.findText('Target'));
+      secondLocation = tester.getCenter(find.text('Target'));
       gesture.moveTo(secondLocation);
       tester.pump();
 
@@ -128,17 +128,17 @@ void main() {
 
       // drag and tap and drop
 
-      firstLocation = tester.getCenter(tester.findText('Source'));
+      firstLocation = tester.getCenter(find.text('Source'));
       gesture = tester.startGesture(firstLocation, pointer: 7);
       tester.pump();
 
-      secondLocation = tester.getCenter(tester.findText('Target'));
+      secondLocation = tester.getCenter(find.text('Target'));
       gesture.moveTo(secondLocation);
       tester.pump();
 
       expect(events, isEmpty);
-      tester.tap(tester.findText('Button'));
-      tester.tap(tester.findText('Target'));
+      tester.tap(find.text('Button'));
+      tester.tap(find.text('Target'));
       gesture.up();
       tester.pump();
       expect(events, equals(<String>['tap', 'tap', 'drop']));
@@ -174,19 +174,19 @@ void main() {
       }));
 
       expect(events, isEmpty);
-      expect(tester.findText('Button'), isNotNull);
-      expect(tester.findText('Target'), isNotNull);
+      expect(tester, hasWidget(find.text('Button')));
+      expect(tester, hasWidget(find.text('Target')));
 
       expect(events, isEmpty);
-      tester.tap(tester.findText('Button'));
+      tester.tap(find.text('Button'));
       expect(events, equals(<String>['tap']));
       events.clear();
 
-      firstLocation = tester.getCenter(tester.findText('Button'));
+      firstLocation = tester.getCenter(find.text('Button'));
       TestGesture gesture = tester.startGesture(firstLocation, pointer: 7);
       tester.pump();
 
-      secondLocation = tester.getCenter(tester.findText('Target'));
+      secondLocation = tester.getCenter(find.text('Target'));
       gesture.moveTo(secondLocation);
       tester.pump();
 
@@ -221,18 +221,18 @@ void main() {
       }));
 
       expect(events, isEmpty);
-      expect(tester.findText('Source'), isNotNull);
-      expect(tester.findText('Target'), isNotNull);
+      expect(tester, hasWidget(find.text('Source')));
+      expect(tester, hasWidget(find.text('Target')));
 
       expect(events, isEmpty);
-      tester.tap(tester.findText('Source'));
+      tester.tap(find.text('Source'));
       expect(events, isEmpty);
 
-      firstLocation = tester.getCenter(tester.findText('Source'));
+      firstLocation = tester.getCenter(find.text('Source'));
       TestGesture gesture = tester.startGesture(firstLocation, pointer: 7);
       tester.pump();
 
-      secondLocation = tester.getCenter(tester.findText('Target'));
+      secondLocation = tester.getCenter(find.text('Target'));
       gesture.moveTo(secondLocation);
       tester.pump();
 
@@ -266,20 +266,20 @@ void main() {
       }));
 
       expect(events, isEmpty);
-      expect(tester.findText('Source'), isNotNull);
-      expect(tester.findText('Target'), isNotNull);
+      expect(tester, hasWidget(find.text('Source')));
+      expect(tester, hasWidget(find.text('Target')));
 
       expect(events, isEmpty);
-      tester.tap(tester.findText('Source'));
+      tester.tap(find.text('Source'));
       expect(events, isEmpty);
 
-      firstLocation = tester.getCenter(tester.findText('Source'));
+      firstLocation = tester.getCenter(find.text('Source'));
       TestGesture gesture = tester.startGesture(firstLocation, pointer: 7);
       tester.pump();
 
       tester.pump(const Duration(seconds: 20));
 
-      secondLocation = tester.getCenter(tester.findText('Target'));
+      secondLocation = tester.getCenter(find.text('Target'));
       gesture.moveTo(secondLocation);
       tester.pump();
 
@@ -319,14 +319,14 @@ void main() {
       }));
 
       expect(events, isEmpty);
-      expect(tester.findText('Target'), isNotNull);
-      expect(tester.findText('H'), isNotNull);
-      expect(tester.findText('V'), isNotNull);
+      expect(tester, hasWidget(find.text('Target')));
+      expect(tester, hasWidget(find.text('H')));
+      expect(tester, hasWidget(find.text('V')));
 
       // vertical draggable drags vertically
       expect(events, isEmpty);
-      firstLocation = tester.getCenter(tester.findText('V'));
-      secondLocation = tester.getCenter(tester.findText('Target'));
+      firstLocation = tester.getCenter(find.text('V'));
+      secondLocation = tester.getCenter(find.text('Target'));
       TestGesture gesture = tester.startGesture(firstLocation, pointer: 7);
       tester.pump();
       gesture.moveTo(secondLocation);
@@ -334,14 +334,14 @@ void main() {
       gesture.up();
       tester.pump();
       expect(events, equals(<String>['drop 2']));
-      expect(tester.getCenter(tester.findText('Target')).y, greaterThan(0.0));
+      expect(tester.getCenter(find.text('Target')).y, greaterThan(0.0));
       events.clear();
 
       // horizontal draggable drags horizontally
       expect(events, isEmpty);
-      firstLocation = tester.getTopLeft(tester.findText('H'));
-      secondLocation = tester.getTopRight(tester.findText('H'));
-      thirdLocation = tester.getCenter(tester.findText('Target'));
+      firstLocation = tester.getTopLeft(find.text('H'));
+      secondLocation = tester.getTopRight(find.text('H'));
+      thirdLocation = tester.getCenter(find.text('Target'));
       gesture = tester.startGesture(firstLocation, pointer: 7);
       tester.pump();
       gesture.moveTo(secondLocation);
@@ -351,15 +351,15 @@ void main() {
       gesture.up();
       tester.pump();
       expect(events, equals(<String>['drop 1']));
-      expect(tester.getCenter(tester.findText('Target')).y, greaterThan(0.0));
+      expect(tester.getCenter(find.text('Target')).y, greaterThan(0.0));
       events.clear();
 
       // vertical draggable drags horizontally when there's no competition
       // from other gesture detectors
       expect(events, isEmpty);
-      firstLocation = tester.getTopLeft(tester.findText('V'));
-      secondLocation = tester.getTopRight(tester.findText('V'));
-      thirdLocation = tester.getCenter(tester.findText('Target'));
+      firstLocation = tester.getTopLeft(find.text('V'));
+      secondLocation = tester.getTopRight(find.text('V'));
+      thirdLocation = tester.getCenter(find.text('Target'));
       gesture = tester.startGesture(firstLocation, pointer: 7);
       tester.pump();
       gesture.moveTo(secondLocation);
@@ -369,14 +369,14 @@ void main() {
       gesture.up();
       tester.pump();
       expect(events, equals(<String>['drop 2']));
-      expect(tester.getCenter(tester.findText('Target')).y, greaterThan(0.0));
+      expect(tester.getCenter(find.text('Target')).y, greaterThan(0.0));
       events.clear();
 
       // horizontal draggable doesn't drag vertically when there is competition
       // for vertical gestures
       expect(events, isEmpty);
-      firstLocation = tester.getCenter(tester.findText('H'));
-      secondLocation = tester.getCenter(tester.findText('Target'));
+      firstLocation = tester.getCenter(find.text('H'));
+      secondLocation = tester.getCenter(find.text('Target'));
       gesture = tester.startGesture(firstLocation, pointer: 7);
       tester.pump();
       gesture.moveTo(secondLocation);
@@ -384,7 +384,7 @@ void main() {
       gesture.up();
       tester.pump();
       expect(events, equals(<String>[]));
-      expect(tester.getCenter(tester.findText('Target')).y, lessThan(0.0));
+      expect(tester.getCenter(find.text('Target')).y, lessThan(0.0));
       events.clear();
     });
   });
@@ -418,14 +418,14 @@ void main() {
       }));
 
       expect(events, isEmpty);
-      expect(tester.findText('Target'), isNotNull);
-      expect(tester.findText('H'), isNotNull);
-      expect(tester.findText('V'), isNotNull);
+      expect(tester, hasWidget(find.text('Target')));
+      expect(tester, hasWidget(find.text('H')));
+      expect(tester, hasWidget(find.text('V')));
 
       // horizontal draggable drags horizontally
       expect(events, isEmpty);
-      firstLocation = tester.getCenter(tester.findText('H'));
-      secondLocation = tester.getCenter(tester.findText('Target'));
+      firstLocation = tester.getCenter(find.text('H'));
+      secondLocation = tester.getCenter(find.text('Target'));
       TestGesture gesture = tester.startGesture(firstLocation, pointer: 7);
       tester.pump();
       gesture.moveTo(secondLocation);
@@ -433,14 +433,14 @@ void main() {
       gesture.up();
       tester.pump();
       expect(events, equals(<String>['drop 1']));
-      expect(tester.getCenter(tester.findText('Target')).x, greaterThan(0.0));
+      expect(tester.getCenter(find.text('Target')).x, greaterThan(0.0));
       events.clear();
 
       // vertical draggable drags vertically
       expect(events, isEmpty);
-      firstLocation = tester.getTopLeft(tester.findText('V'));
-      secondLocation = tester.getBottomLeft(tester.findText('V'));
-      thirdLocation = tester.getCenter(tester.findText('Target'));
+      firstLocation = tester.getTopLeft(find.text('V'));
+      secondLocation = tester.getBottomLeft(find.text('V'));
+      thirdLocation = tester.getCenter(find.text('Target'));
       gesture = tester.startGesture(firstLocation, pointer: 7);
       tester.pump();
       gesture.moveTo(secondLocation);
@@ -450,15 +450,15 @@ void main() {
       gesture.up();
       tester.pump();
       expect(events, equals(<String>['drop 2']));
-      expect(tester.getCenter(tester.findText('Target')).x, greaterThan(0.0));
+      expect(tester.getCenter(find.text('Target')).x, greaterThan(0.0));
       events.clear();
 
       // horizontal draggable drags vertically when there's no competition
       // from other gesture detectors
       expect(events, isEmpty);
-      firstLocation = tester.getTopLeft(tester.findText('H'));
-      secondLocation = tester.getBottomLeft(tester.findText('H'));
-      thirdLocation = tester.getCenter(tester.findText('Target'));
+      firstLocation = tester.getTopLeft(find.text('H'));
+      secondLocation = tester.getBottomLeft(find.text('H'));
+      thirdLocation = tester.getCenter(find.text('Target'));
       gesture = tester.startGesture(firstLocation, pointer: 7);
       tester.pump();
       gesture.moveTo(secondLocation);
@@ -468,14 +468,14 @@ void main() {
       gesture.up();
       tester.pump();
       expect(events, equals(<String>['drop 1']));
-      expect(tester.getCenter(tester.findText('Target')).x, greaterThan(0.0));
+      expect(tester.getCenter(find.text('Target')).x, greaterThan(0.0));
       events.clear();
 
       // vertical draggable doesn't drag horizontally when there is competition
       // for horizontal gestures
       expect(events, isEmpty);
-      firstLocation = tester.getCenter(tester.findText('V'));
-      secondLocation = tester.getCenter(tester.findText('Target'));
+      firstLocation = tester.getCenter(find.text('V'));
+      secondLocation = tester.getCenter(find.text('Target'));
       gesture = tester.startGesture(firstLocation, pointer: 7);
       tester.pump();
       gesture.moveTo(secondLocation);
@@ -483,7 +483,7 @@ void main() {
       gesture.up();
       tester.pump();
       expect(events, equals(<String>[]));
-      expect(tester.getCenter(tester.findText('Target')).x, lessThan(0.0));
+      expect(tester.getCenter(find.text('Target')).x, lessThan(0.0));
       events.clear();
     });
   });
@@ -516,38 +516,38 @@ void main() {
       }));
 
       expect(accepted, isEmpty);
-      expect(tester.findText('Source'), isNotNull);
-      expect(tester.findText('Dragging'), isNull);
-      expect(tester.findText('Target'), isNotNull);
+      expect(tester, hasWidget(find.text('Source')));
+      expect(tester, doesNotHaveWidget(find.text('Dragging')));
+      expect(tester, hasWidget(find.text('Target')));
       expect(onDraggableCanceledCalled, isFalse);
 
-      Point firstLocation = tester.getCenter(tester.findText('Source'));
+      Point firstLocation = tester.getCenter(find.text('Source'));
       TestGesture gesture = tester.startGesture(firstLocation, pointer: 7);
       tester.pump();
 
       expect(accepted, isEmpty);
-      expect(tester.findText('Source'), isNotNull);
-      expect(tester.findText('Dragging'), isNotNull);
-      expect(tester.findText('Target'), isNotNull);
+      expect(tester, hasWidget(find.text('Source')));
+      expect(tester, hasWidget(find.text('Dragging')));
+      expect(tester, hasWidget(find.text('Target')));
       expect(onDraggableCanceledCalled, isFalse);
 
-      Point secondLocation = tester.getCenter(tester.findText('Target'));
+      Point secondLocation = tester.getCenter(find.text('Target'));
       gesture.moveTo(secondLocation);
       tester.pump();
 
       expect(accepted, isEmpty);
-      expect(tester.findText('Source'), isNotNull);
-      expect(tester.findText('Dragging'), isNotNull);
-      expect(tester.findText('Target'), isNotNull);
+      expect(tester, hasWidget(find.text('Source')));
+      expect(tester, hasWidget(find.text('Dragging')));
+      expect(tester, hasWidget(find.text('Target')));
       expect(onDraggableCanceledCalled, isFalse);
 
       gesture.up();
       tester.pump();
 
       expect(accepted, equals(<int>[1]));
-      expect(tester.findText('Source'), isNotNull);
-      expect(tester.findText('Dragging'), isNull);
-      expect(tester.findText('Target'), isNotNull);
+      expect(tester, hasWidget(find.text('Source')));
+      expect(tester, doesNotHaveWidget(find.text('Dragging')));
+      expect(tester, hasWidget(find.text('Target')));
       expect(onDraggableCanceledCalled, isFalse);
     });
   });
@@ -585,38 +585,38 @@ void main() {
       }));
 
       expect(accepted, isEmpty);
-      expect(tester.findText('Source'), isNotNull);
-      expect(tester.findText('Dragging'), isNull);
-      expect(tester.findText('Target'), isNotNull);
+      expect(tester, hasWidget(find.text('Source')));
+      expect(tester, doesNotHaveWidget(find.text('Dragging')));
+      expect(tester, hasWidget(find.text('Target')));
       expect(onDraggableCanceledCalled, isFalse);
 
-      Point firstLocation = tester.getTopLeft(tester.findText('Source'));
+      Point firstLocation = tester.getTopLeft(find.text('Source'));
       TestGesture gesture = tester.startGesture(firstLocation, pointer: 7);
       tester.pump();
 
       expect(accepted, isEmpty);
-      expect(tester.findText('Source'), isNotNull);
-      expect(tester.findText('Dragging'), isNotNull);
-      expect(tester.findText('Target'), isNotNull);
+      expect(tester, hasWidget(find.text('Source')));
+      expect(tester, hasWidget(find.text('Dragging')));
+      expect(tester, hasWidget(find.text('Target')));
       expect(onDraggableCanceledCalled, isFalse);
 
-      Point secondLocation = tester.getCenter(tester.findText('Target'));
+      Point secondLocation = tester.getCenter(find.text('Target'));
       gesture.moveTo(secondLocation);
       tester.pump();
 
       expect(accepted, isEmpty);
-      expect(tester.findText('Source'), isNotNull);
-      expect(tester.findText('Dragging'), isNotNull);
-      expect(tester.findText('Target'), isNotNull);
+      expect(tester, hasWidget(find.text('Source')));
+      expect(tester, hasWidget(find.text('Dragging')));
+      expect(tester, hasWidget(find.text('Target')));
       expect(onDraggableCanceledCalled, isFalse);
 
       gesture.up();
       tester.pump();
 
       expect(accepted, isEmpty);
-      expect(tester.findText('Source'), isNotNull);
-      expect(tester.findText('Dragging'), isNull);
-      expect(tester.findText('Target'), isNotNull);
+      expect(tester, hasWidget(find.text('Source')));
+      expect(tester, doesNotHaveWidget(find.text('Dragging')));
+      expect(tester, hasWidget(find.text('Target')));
       expect(onDraggableCanceledCalled, isTrue);
       expect(onDraggableCanceledVelocity, equals(Velocity.zero));
       expect(onDraggableCanceledOffset,
@@ -657,19 +657,19 @@ void main() {
       }));
 
       expect(accepted, isEmpty);
-      expect(tester.findText('Source'), isNotNull);
-      expect(tester.findText('Dragging'), isNull);
-      expect(tester.findText('Target'), isNotNull);
+      expect(tester, hasWidget(find.text('Source')));
+      expect(tester, doesNotHaveWidget(find.text('Dragging')));
+      expect(tester, hasWidget(find.text('Target')));
       expect(onDraggableCanceledCalled, isFalse);
 
-      Point flingStart = tester.getTopLeft(tester.findText('Source'));
+      Point flingStart = tester.getTopLeft(find.text('Source'));
       tester.flingFrom(flingStart, new Offset(0.0, 100.0), 1000.0);
       tester.pump();
 
       expect(accepted, isEmpty);
-      expect(tester.findText('Source'), isNotNull);
-      expect(tester.findText('Dragging'), isNull);
-      expect(tester.findText('Target'), isNotNull);
+      expect(tester, hasWidget(find.text('Source')));
+      expect(tester, doesNotHaveWidget(find.text('Dragging')));
+      expect(tester, hasWidget(find.text('Target')));
       expect(onDraggableCanceledCalled, isTrue);
       expect(onDraggableCanceledVelocity.pixelsPerSecond.dx.abs(),
           lessThan(0.0000001));
@@ -720,16 +720,16 @@ void main() {
 
       expect(acceptedInts, isEmpty);
       expect(acceptedDoubles, isEmpty);
-      expect(tester.findText('IntSource'), isNotNull);
-      expect(tester.findText('IntDragging'), isNull);
-      expect(tester.findText('DoubleSource'), isNotNull);
-      expect(tester.findText('DoubleDragging'), isNull);
-      expect(tester.findText('Target1'), isNotNull);
-      expect(tester.findText('Target2'), isNotNull);
+      expect(tester, hasWidget(find.text('IntSource')));
+      expect(tester, doesNotHaveWidget(find.text('IntDragging')));
+      expect(tester, hasWidget(find.text('DoubleSource')));
+      expect(tester, doesNotHaveWidget(find.text('DoubleDragging')));
+      expect(tester, hasWidget(find.text('Target1')));
+      expect(tester, hasWidget(find.text('Target2')));
 
-      Point intLocation = tester.getCenter(tester.findText('IntSource'));
-      Point doubleLocation = tester.getCenter(tester.findText('DoubleSource'));
-      Point targetLocation = tester.getCenter(tester.findText('Target1'));
+      Point intLocation = tester.getCenter(find.text('IntSource'));
+      Point doubleLocation = tester.getCenter(find.text('DoubleSource'));
+      Point targetLocation = tester.getCenter(find.text('Target1'));
 
       // Drag the double draggable.
       TestGesture doubleGesture =
@@ -738,24 +738,24 @@ void main() {
 
       expect(acceptedInts, isEmpty);
       expect(acceptedDoubles, isEmpty);
-      expect(tester.findText('IntDragging'), isNull);
-      expect(tester.findText('DoubleDragging'), isNotNull);
+      expect(tester, doesNotHaveWidget(find.text('IntDragging')));
+      expect(tester, hasWidget(find.text('DoubleDragging')));
 
       doubleGesture.moveTo(targetLocation);
       tester.pump();
 
       expect(acceptedInts, isEmpty);
       expect(acceptedDoubles, isEmpty);
-      expect(tester.findText('IntDragging'), isNull);
-      expect(tester.findText('DoubleDragging'), isNotNull);
+      expect(tester, doesNotHaveWidget(find.text('IntDragging')));
+      expect(tester, hasWidget(find.text('DoubleDragging')));
 
       doubleGesture.up();
       tester.pump();
 
       expect(acceptedInts, isEmpty);
       expect(acceptedDoubles, equals(<double>[1.0]));
-      expect(tester.findText('IntDragging'), isNull);
-      expect(tester.findText('DoubleDragging'), isNull);
+      expect(tester, doesNotHaveWidget(find.text('IntDragging')));
+      expect(tester, doesNotHaveWidget(find.text('DoubleDragging')));
 
       acceptedDoubles.clear();
 
@@ -765,24 +765,24 @@ void main() {
 
       expect(acceptedInts, isEmpty);
       expect(acceptedDoubles, isEmpty);
-      expect(tester.findText('IntDragging'), isNotNull);
-      expect(tester.findText('DoubleDragging'), isNull);
+      expect(tester, hasWidget(find.text('IntDragging')));
+      expect(tester, doesNotHaveWidget(find.text('DoubleDragging')));
 
       intGesture.moveTo(targetLocation);
       tester.pump();
 
       expect(acceptedInts, isEmpty);
       expect(acceptedDoubles, isEmpty);
-      expect(tester.findText('IntDragging'), isNotNull);
-      expect(tester.findText('DoubleDragging'), isNull);
+      expect(tester, hasWidget(find.text('IntDragging')));
+      expect(tester, doesNotHaveWidget(find.text('DoubleDragging')));
 
       intGesture.up();
       tester.pump();
 
       expect(acceptedInts, equals(<int>[1]));
       expect(acceptedDoubles, isEmpty);
-      expect(tester.findText('IntDragging'), isNull);
-      expect(tester.findText('DoubleDragging'), isNull);
+      expect(tester, doesNotHaveWidget(find.text('IntDragging')));
+      expect(tester, doesNotHaveWidget(find.text('DoubleDragging')));
     });
   });
 
@@ -818,8 +818,8 @@ void main() {
         },
       }));
 
-      Point dragTargetLocation = tester.getCenter(tester.findText('Source'));
-      Point targetLocation = tester.getCenter(tester.findText('Target1'));
+      Point dragTargetLocation = tester.getCenter(find.text('Source'));
+      Point targetLocation = tester.getCenter(find.text('Target1'));
 
       for (int i = 0; i < 2; i += 1) {
         TestGesture gesture = tester.startGesture(dragTargetLocation);

--- a/packages/flutter/test/widget/drawer_test.dart
+++ b/packages/flutter/test/widget/drawer_test.dart
@@ -28,17 +28,17 @@ void main() {
         )
       );
       tester.pump(); // no effect
-      expect(tester.findText('drawer'), isNull);
+      expect(tester, doesNotHaveWidget(find.text('drawer')));
       scaffoldKey.currentState.openDrawer();
       tester.pump(); // drawer should be starting to animate in
-      expect(tester.findText('drawer'), isNotNull);
+      expect(tester, hasWidget(find.text('drawer')));
       tester.pump(new Duration(seconds: 1)); // animation done
-      expect(tester.findText('drawer'), isNotNull);
+      expect(tester, hasWidget(find.text('drawer')));
       Navigator.pop(context);
       tester.pump(); // drawer should be starting to animate away
-      expect(tester.findText('drawer'), isNotNull);
+      expect(tester, hasWidget(find.text('drawer')));
       tester.pump(new Duration(seconds: 1)); // animation done
-      expect(tester.findText('drawer'), isNull);
+      expect(tester, doesNotHaveWidget(find.text('drawer')));
     });
   });
 
@@ -59,24 +59,24 @@ void main() {
         )
       );
       tester.pump(); // no effect
-      expect(tester.findText('drawer'), isNull);
+      expect(tester, doesNotHaveWidget(find.text('drawer')));
       scaffoldKey.currentState.openDrawer();
       tester.pump(); // drawer should be starting to animate in
-      expect(tester.findText('drawer'), isNotNull);
+      expect(tester, hasWidget(find.text('drawer')));
       tester.pump(new Duration(seconds: 1)); // animation done
-      expect(tester.findText('drawer'), isNotNull);
-      tester.tap(tester.findText('drawer'));
+      expect(tester, hasWidget(find.text('drawer')));
+      tester.tap(find.text('drawer'));
       tester.pump(); // nothing should have happened
-      expect(tester.findText('drawer'), isNotNull);
+      expect(tester, hasWidget(find.text('drawer')));
       tester.pump(new Duration(seconds: 1)); // ditto
-      expect(tester.findText('drawer'), isNotNull);
+      expect(tester, hasWidget(find.text('drawer')));
       tester.tapAt(const Point(750.0, 100.0)); // on the mask
       tester.pump();
       tester.pump(new Duration(milliseconds: 10));
       // drawer should be starting to animate away
-      expect(tester.findText('drawer'), isNotNull);
+      expect(tester, hasWidget(find.text('drawer')));
       tester.pump(new Duration(seconds: 1)); // animation done
-      expect(tester.findText('drawer'), isNull);
+      expect(tester, doesNotHaveWidget(find.text('drawer')));
     });
   });
 
@@ -108,18 +108,18 @@ void main() {
           }
         )
       );
-      expect(tester.findText('drawer'), isNull);
+      expect(tester, doesNotHaveWidget(find.text('drawer')));
       scaffoldKey.currentState.openDrawer();
       tester.pump(); // drawer should be starting to animate in
-      expect(tester.findText('drawer'), isNotNull);
+      expect(tester, hasWidget(find.text('drawer')));
       tester.pump(new Duration(seconds: 1)); // animation done
-      expect(tester.findText('drawer'), isNotNull);
+      expect(tester, hasWidget(find.text('drawer')));
 
       tester.tapAt(const Point(750.0, 100.0)); // on the mask
       tester.pump();
       tester.pump(new Duration(milliseconds: 10));
       // drawer should be starting to animate away
-      RenderBox textBox = tester.findText('drawer').renderObject;
+      RenderBox textBox = tester.renderObjectOf(find.text('drawer'));
       double textLeft = textBox.localToGlobal(Point.origin).x;
       expect(textLeft, lessThan(0.0));
 

--- a/packages/flutter/test/widget/duplicate_key_test.dart
+++ b/packages/flutter/test/widget/duplicate_key_test.dart
@@ -58,7 +58,7 @@ void main() {
   test('duplicate key smoke test', () {
     testWidgets((WidgetTester tester) {
       tester.pumpWidget(builder());
-      StatefulLeafState leaf = tester.findStateOfType(StatefulLeafState);
+      StatefulLeafState leaf = tester.stateOf(find.byType(StatefulLeaf));
       leaf.test();
       tester.pump();
       Item lastItem = items[1];

--- a/packages/flutter/test/widget/flex_test.dart
+++ b/packages/flutter/test/widget/flex_test.dart
@@ -46,7 +46,7 @@ void main() {
         )
       );
 
-      tester.tap(tester.findText('X'));
+      tester.tap(find.text('X'));
       expect(didReceiveTap, isTrue);
     });
   });
@@ -65,7 +65,7 @@ void main() {
           key: flexKey
         )
       ));
-      RenderBox renderBox = tester.findElementByKey(flexKey).renderObject;
+      RenderBox renderBox = tester.renderObjectOf(find.byKey(flexKey));
       expect(renderBox.size.width, equals(800.0));
       expect(renderBox.size.height, equals(100.0));
 
@@ -80,7 +80,7 @@ void main() {
           mainAxisAlignment: MainAxisAlignment.collapse
         )
       ));
-      renderBox = tester.findElementByKey(flexKey).renderObject;
+      renderBox = tester.renderObjectOf(find.byKey(flexKey));
       expect(renderBox.size.width, equals(40.0));
       expect(renderBox.size.height, equals(100.0));
     });
@@ -96,7 +96,7 @@ void main() {
           key: flexKey
         )
       ));
-      RenderBox renderBox = tester.findElementByKey(flexKey).renderObject;
+      RenderBox renderBox = tester.renderObjectOf(find.byKey(flexKey));
       expect(renderBox.size.width, equals(100.0));
       expect(renderBox.size.height, equals(600.0));
 
@@ -111,7 +111,7 @@ void main() {
           mainAxisAlignment: MainAxisAlignment.collapse
         )
       ));
-      renderBox = tester.findElementByKey(flexKey).renderObject;
+      renderBox = tester.renderObjectOf(find.byKey(flexKey));
       expect(renderBox.size.width, equals(100.0));
       expect(renderBox.size.height, equals(250.0));
     });
@@ -138,7 +138,7 @@ void main() {
         )
       ));
 
-      RenderBox renderBox = tester.findElementByKey(childKey).renderObject;
+      RenderBox renderBox = tester.renderObjectOf(find.byKey(childKey));
       expect(renderBox.size.width, equals(0.0));
       expect(renderBox.size.height, equals(100.0));
 
@@ -159,7 +159,7 @@ void main() {
         )
       ));
 
-      renderBox = tester.findElementByKey(childKey).renderObject;
+      renderBox = tester.renderObjectOf(find.byKey(childKey));
       expect(renderBox.size.width, equals(100.0));
       expect(renderBox.size.height, equals(0.0));
     });

--- a/packages/flutter/test/widget/focus_test.dart
+++ b/packages/flutter/test/widget/focus_test.dart
@@ -53,34 +53,34 @@ void main() {
           )
         )
       );
-      expect(tester.findText('a'),         isNull);
-      expect(tester.findText('A FOCUSED'), isNotNull);
-      expect(tester.findText('b'),         isNotNull);
-      expect(tester.findText('B FOCUSED'), isNull);
-      tester.tap(tester.findText('A FOCUSED'));
+      expect(tester, doesNotHaveWidget(find.text('a')));
+      expect(tester, hasWidget(find.text('A FOCUSED')));
+      expect(tester, hasWidget(find.text('b')));
+      expect(tester, doesNotHaveWidget(find.text('B FOCUSED')));
+      tester.tap(find.text('A FOCUSED'));
       tester.pump();
-      expect(tester.findText('a'),         isNull);
-      expect(tester.findText('A FOCUSED'), isNotNull);
-      expect(tester.findText('b'),         isNotNull);
-      expect(tester.findText('B FOCUSED'), isNull);
-      tester.tap(tester.findText('A FOCUSED'));
+      expect(tester, doesNotHaveWidget(find.text('a')));
+      expect(tester, hasWidget(find.text('A FOCUSED')));
+      expect(tester, hasWidget(find.text('b')));
+      expect(tester, doesNotHaveWidget(find.text('B FOCUSED')));
+      tester.tap(find.text('A FOCUSED'));
       tester.pump();
-      expect(tester.findText('a'),         isNull);
-      expect(tester.findText('A FOCUSED'), isNotNull);
-      expect(tester.findText('b'),         isNotNull);
-      expect(tester.findText('B FOCUSED'), isNull);
-      tester.tap(tester.findText('b'));
+      expect(tester, doesNotHaveWidget(find.text('a')));
+      expect(tester, hasWidget(find.text('A FOCUSED')));
+      expect(tester, hasWidget(find.text('b')));
+      expect(tester, doesNotHaveWidget(find.text('B FOCUSED')));
+      tester.tap(find.text('b'));
       tester.pump();
-      expect(tester.findText('a'),         isNotNull);
-      expect(tester.findText('A FOCUSED'), isNull);
-      expect(tester.findText('b'),         isNull);
-      expect(tester.findText('B FOCUSED'), isNotNull);
-      tester.tap(tester.findText('a'));
+      expect(tester, hasWidget(find.text('a')));
+      expect(tester, doesNotHaveWidget(find.text('A FOCUSED')));
+      expect(tester, doesNotHaveWidget(find.text('b')));
+      expect(tester, hasWidget(find.text('B FOCUSED')));
+      tester.tap(find.text('a'));
       tester.pump();
-      expect(tester.findText('a'),         isNull);
-      expect(tester.findText('A FOCUSED'), isNotNull);
-      expect(tester.findText('b'),         isNotNull);
-      expect(tester.findText('B FOCUSED'), isNull);
+      expect(tester, doesNotHaveWidget(find.text('a')));
+      expect(tester, hasWidget(find.text('A FOCUSED')));
+      expect(tester, hasWidget(find.text('b')));
+      expect(tester, doesNotHaveWidget(find.text('B FOCUSED')));
     });
   });
 
@@ -100,20 +100,20 @@ void main() {
         )
       );
 
-      expect(tester.findText('a'),         isNotNull);
-      expect(tester.findText('A FOCUSED'), isNull);
+      expect(tester, hasWidget(find.text('a')));
+      expect(tester, doesNotHaveWidget(find.text('A FOCUSED')));
 
       Focus.moveTo(keyA);
       tester.pump();
 
-      expect(tester.findText('a'),         isNull);
-      expect(tester.findText('A FOCUSED'), isNotNull);
+      expect(tester, doesNotHaveWidget(find.text('a')));
+      expect(tester, hasWidget(find.text('A FOCUSED')));
 
       Focus.clear(keyA.currentContext);
       tester.pump();
 
-      expect(tester.findText('a'),         isNotNull);
-      expect(tester.findText('A FOCUSED'), isNull);
+      expect(tester, hasWidget(find.text('a')));
+      expect(tester, doesNotHaveWidget(find.text('A FOCUSED')));
     });
   });
 
@@ -138,14 +138,14 @@ void main() {
         )
       );
 
-      expect(tester.findText('a'),         isNotNull);
-      expect(tester.findText('A FOCUSED'), isNull);
+      expect(tester, hasWidget(find.text('a')));
+      expect(tester, doesNotHaveWidget(find.text('A FOCUSED')));
 
       Focus.moveTo(keyA);
       tester.pump();
 
-      expect(tester.findText('a'),         isNull);
-      expect(tester.findText('A FOCUSED'), isNotNull);
+      expect(tester, doesNotHaveWidget(find.text('a')));
+      expect(tester, hasWidget(find.text('A FOCUSED')));
 
       Focus.moveScopeTo(keyChildFocus, context: keyA.currentContext);
 
@@ -172,8 +172,8 @@ void main() {
         )
       );
 
-      expect(tester.findText('a'),         isNotNull);
-      expect(tester.findText('A FOCUSED'), isNull);
+      expect(tester, hasWidget(find.text('a')));
+      expect(tester, doesNotHaveWidget(find.text('A FOCUSED')));
 
       tester.pumpWidget(
         new Focus(
@@ -192,13 +192,13 @@ void main() {
       );
 
       // Focus has received the removal notification but we haven't rebuilt yet.
-      expect(tester.findText('a'),         isNotNull);
-      expect(tester.findText('A FOCUSED'), isNull);
+      expect(tester, hasWidget(find.text('a')));
+      expect(tester, doesNotHaveWidget(find.text('A FOCUSED')));
 
       tester.pump();
 
-      expect(tester.findText('a'),         isNull);
-      expect(tester.findText('A FOCUSED'), isNotNull);
+      expect(tester, doesNotHaveWidget(find.text('a')));
+      expect(tester, hasWidget(find.text('A FOCUSED')));
     });
   });
 }

--- a/packages/flutter/test/widget/form_test.dart
+++ b/packages/flutter/test/widget/form_test.dart
@@ -101,8 +101,7 @@ void main() {
         tester.pumpWidget(builder());
 
         // Check for a new Text widget with our error text.
-        Element errorElement = tester.findText(errorText(testValue));
-        expect(errorElement, isNotNull);
+        expect(tester, hasWidget(find.text(errorText(testValue))));
       }
 
       checkErrorText('Test');
@@ -157,8 +156,7 @@ void main() {
         expect(fieldValue, equals(testValue));
 
         // Check for a new Text widget with our error text.
-        Element errorElement = tester.findText(errorText(testValue));
-        expect(errorElement, isNotNull);
+        expect(tester, hasWidget(find.text(errorText(testValue))));
       }
 
       checkErrorText('Test');

--- a/packages/flutter/test/widget/heroes_test.dart
+++ b/packages/flutter/test/widget/heroes_test.dart
@@ -51,101 +51,101 @@ void main() {
 
       // the initial setup.
 
-      expect(tester.findElementByKey(firstKey), isOnStage);
-      expect(tester.findElementByKey(firstKey), isInCard);
-      expect(tester.findElementByKey(secondKey), isNull);
+      expect(find.byKey(firstKey), isOnStage(tester));
+      expect(find.byKey(firstKey), isInCard(tester));
+      expect(tester, doesNotHaveWidget(find.byKey(secondKey)));
 
-      tester.tap(tester.findText('two'));
+      tester.tap(find.text('two'));
       tester.pump(); // begin navigation
 
       // at this stage, the second route is off-stage, so that we can form the
       // hero party.
 
-      expect(tester.findElementByKey(firstKey), isOnStage);
-      expect(tester.findElementByKey(firstKey), isInCard);
-      expect(tester.findElementByKey(secondKey), isOffStage);
-      expect(tester.findElementByKey(secondKey), isInCard);
+      expect(find.byKey(firstKey), isOnStage(tester));
+      expect(find.byKey(firstKey), isInCard(tester));
+      expect(find.byKey(secondKey), isOffStage(tester));
+      expect(find.byKey(secondKey), isInCard(tester));
 
       tester.pump();
 
       // at this stage, the heroes have just gone on their journey, we are
       // seeing them at t=16ms. The original page no longer contains the hero.
 
-      expect(tester.findElementByKey(firstKey), isNull);
-      expect(tester.findElementByKey(secondKey), isOnStage);
-      expect(tester.findElementByKey(secondKey), isNotInCard);
+      expect(tester, doesNotHaveWidget(find.byKey(firstKey)));
+      expect(find.byKey(secondKey), isOnStage(tester));
+      expect(find.byKey(secondKey), isNotInCard(tester));
 
       tester.pump();
 
       // t=32ms for the journey. Surely they are still at it.
 
-      expect(tester.findElementByKey(firstKey), isNull);
-      expect(tester.findElementByKey(secondKey), isOnStage);
-      expect(tester.findElementByKey(secondKey), isNotInCard);
+      expect(tester, doesNotHaveWidget(find.byKey(firstKey)));
+      expect(find.byKey(secondKey), isOnStage(tester));
+      expect(find.byKey(secondKey), isNotInCard(tester));
 
       tester.pump(new Duration(seconds: 1));
 
       // t=1.032s for the journey. The journey has ended (it ends this frame, in
       // fact). The hero should now be in the new page, on-stage.
 
-      expect(tester.findElementByKey(firstKey), isNull);
-      expect(tester.findElementByKey(secondKey), isOnStage);
-      expect(tester.findElementByKey(secondKey), isInCard);
+      expect(tester, doesNotHaveWidget(find.byKey(firstKey)));
+      expect(find.byKey(secondKey), isOnStage(tester));
+      expect(find.byKey(secondKey), isInCard(tester));
 
       tester.pump();
 
       // Should not change anything.
 
-      expect(tester.findElementByKey(firstKey), isNull);
-      expect(tester.findElementByKey(secondKey), isOnStage);
-      expect(tester.findElementByKey(secondKey), isInCard);
+      expect(tester, doesNotHaveWidget(find.byKey(firstKey)));
+      expect(find.byKey(secondKey), isOnStage(tester));
+      expect(find.byKey(secondKey), isInCard(tester));
 
       // Now move on to view 3
 
-      tester.tap(tester.findText('three'));
+      tester.tap(find.text('three'));
       tester.pump(); // begin navigation
 
       // at this stage, the second route is off-stage, so that we can form the
       // hero party.
 
-      expect(tester.findElementByKey(secondKey), isOnStage);
-      expect(tester.findElementByKey(secondKey), isInCard);
-      expect(tester.findElementByKey(thirdKey), isOffStage);
-      expect(tester.findElementByKey(thirdKey), isInCard);
+      expect(find.byKey(secondKey), isOnStage(tester));
+      expect(find.byKey(secondKey), isInCard(tester));
+      expect(find.byKey(thirdKey), isOffStage(tester));
+      expect(find.byKey(thirdKey), isInCard(tester));
 
       tester.pump();
 
       // at this stage, the heroes have just gone on their journey, we are
       // seeing them at t=16ms. The original page no longer contains the hero.
 
-      expect(tester.findElementByKey(secondKey), isNull);
-      expect(tester.findElementByKey(thirdKey), isOnStage);
-      expect(tester.findElementByKey(thirdKey), isNotInCard);
+      expect(tester, doesNotHaveWidget(find.byKey(secondKey)));
+      expect(find.byKey(thirdKey), isOnStage(tester));
+      expect(find.byKey(thirdKey), isNotInCard(tester));
 
       tester.pump();
 
       // t=32ms for the journey. Surely they are still at it.
 
-      expect(tester.findElementByKey(secondKey), isNull);
-      expect(tester.findElementByKey(thirdKey), isOnStage);
-      expect(tester.findElementByKey(thirdKey), isNotInCard);
+      expect(tester, doesNotHaveWidget(find.byKey(secondKey)));
+      expect(find.byKey(thirdKey), isOnStage(tester));
+      expect(find.byKey(thirdKey), isNotInCard(tester));
 
       tester.pump(new Duration(seconds: 1));
 
       // t=1.032s for the journey. The journey has ended (it ends this frame, in
       // fact). The hero should now be in the new page, on-stage.
 
-      expect(tester.findElementByKey(secondKey), isNull);
-      expect(tester.findElementByKey(thirdKey), isOnStage);
-      expect(tester.findElementByKey(thirdKey), isInCard);
+      expect(tester, doesNotHaveWidget(find.byKey(secondKey)));
+      expect(find.byKey(thirdKey), isOnStage(tester));
+      expect(find.byKey(thirdKey), isInCard(tester));
 
       tester.pump();
 
       // Should not change anything.
 
-      expect(tester.findElementByKey(secondKey), isNull);
-      expect(tester.findElementByKey(thirdKey), isOnStage);
-      expect(tester.findElementByKey(thirdKey), isInCard);
+      expect(tester, doesNotHaveWidget(find.byKey(secondKey)));
+      expect(find.byKey(thirdKey), isOnStage(tester));
+      expect(find.byKey(thirdKey), isInCard(tester));
     });
   });
 }

--- a/packages/flutter/test/widget/hyperlink_test.dart
+++ b/packages/flutter/test/widget/hyperlink_test.dart
@@ -45,8 +45,7 @@ void main() {
         )
       );
 
-      Element element = tester.findElementByKey(textKey);
-      RenderBox box = element.renderObject;
+      RenderBox box = tester.renderObjectOf(find.byKey(textKey));
 
       expect(didTapLeft, isFalse);
       expect(didTapRight, isFalse);

--- a/packages/flutter/test/widget/icon_test.dart
+++ b/packages/flutter/test/widget/icon_test.dart
@@ -18,7 +18,7 @@ void main() {
           child: new Icon(icon: Icons.add)
         )
       );
-      Text text = tester.findWidgetOfType(Text);
+      Text text = tester.widget(find.byType(Text));
       expect(text.style.color, equals(Colors.green[500].withOpacity(0.5)));
     });
   });

--- a/packages/flutter/test/widget/image_test.dart
+++ b/packages/flutter/test/widget/image_test.dart
@@ -24,7 +24,7 @@ void main() {
       );
 
       ImageResource imageResource = imageCache.load(testUrl, scale: 1.0);
-      expect(tester.findElementByKey(new ObjectKey(imageResource)), isNotNull);
+      expect(tester, hasWidget(find.byKey(new ObjectKey(imageResource))));
     });
   });
 
@@ -40,7 +40,7 @@ void main() {
       );
 
       ImageResource imageResource = imageCache.load(testUrl, scale: 1.0);
-      expect(tester.findElementByKey(new ObjectKey(imageResource)), isNull);
+      expect(tester, doesNotHaveWidget(find.byKey(new ObjectKey(imageResource))));
     });
   });
 
@@ -50,7 +50,7 @@ void main() {
       tester.pumpWidget(new AsyncImage(provider: imageProvider));
 
       ImageResource imageResource = imageCache.loadProvider(imageProvider);
-      expect(tester.findElementByKey(new ObjectKey(imageResource)), isNotNull);
+      expect(tester, hasWidget(find.byKey(new ObjectKey(imageResource))));
     });
   });
 
@@ -65,7 +65,7 @@ void main() {
       );
 
       ImageResource imageResource = imageCache.loadProvider(imageProvider);
-      expect(tester.findElementByKey(new ObjectKey(imageResource)), isNull);
+      expect(tester, doesNotHaveWidget(find.byKey(new ObjectKey(imageResource))));
     });
   });
 
@@ -81,7 +81,7 @@ void main() {
       );
 
       ImageResource imageResource = assetBundle.loadImage(name);
-      expect(tester.findElementByKey(new ObjectKey(imageResource)), isNotNull);
+      expect(tester, hasWidget(find.byKey(new ObjectKey(imageResource))));
     });
   });
 
@@ -98,7 +98,7 @@ void main() {
       );
 
       ImageResource imageResource = assetBundle.loadImage(name);
-      expect(tester.findElementByKey(new ObjectKey(imageResource)), isNull);
+      expect(tester, doesNotHaveWidget(find.byKey(new ObjectKey(imageResource))));
     });
   });
 
@@ -120,7 +120,7 @@ void main() {
       expect(renderImage.image, isNull);
 
       imageProvider1.complete();
-      tester.async.flushMicrotasks(); // resolve the future from the image provider
+      tester.flushMicrotasks(); // resolve the future from the image provider
       tester.pump(null, EnginePhase.layout);
 
       renderImage = key.currentContext.findRenderObject();
@@ -160,7 +160,7 @@ void main() {
       expect(renderImage.image, isNull);
 
       imageProvider1.complete();
-      tester.async.flushMicrotasks(); // resolve the future from the image provider
+      tester.flushMicrotasks(); // resolve the future from the image provider
       tester.pump(null, EnginePhase.layout);
 
       renderImage = key.currentContext.findRenderObject();

--- a/packages/flutter/test/widget/input_test.dart
+++ b/packages/flutter/test/widget/input_test.dart
@@ -51,8 +51,9 @@ void main() {
 
       tester.pumpWidget(builder());
 
-      Element input = tester.findElementByKey(inputKey);
-      RenderBox inputBox = input.renderObject;
+      RenderBox findInputBox() => tester.renderObjectOf(find.byKey(inputKey));
+
+      RenderBox inputBox = findInputBox();
       Size emptyInputSize = inputBox.size;
 
       void enterText(String testValue) {
@@ -70,11 +71,11 @@ void main() {
       }
 
       enterText(' ');
-      expect(input.renderObject, equals(inputBox));
+      expect(findInputBox(), equals(inputBox));
       expect(inputBox.size, equals(emptyInputSize));
 
       enterText('Test');
-      expect(input.renderObject, equals(inputBox));
+      expect(findInputBox(), equals(inputBox));
       expect(inputBox.size, equals(emptyInputSize));
     });
   });
@@ -96,7 +97,7 @@ void main() {
 
       tester.pumpWidget(builder());
 
-      RawInputLineState editableText = tester.findStateOfType(RawInputLineState);
+      RawInputLineState editableText = tester.stateOf(find.byType(RawInputLine));
 
       // Check that the cursor visibility toggles after each blink interval.
       void checkCursorToggle() {

--- a/packages/flutter/test/widget/lazy_block_viewport_test.dart
+++ b/packages/flutter/test/widget/lazy_block_viewport_test.dart
@@ -36,8 +36,7 @@ void main() {
 
       tester.pumpWidget(builder());
 
-      StatefulElement element = tester.findElement((Element element) => element.widget is FlipWidget);
-      FlipWidgetState testWidget = element.state;
+      FlipWidgetState testWidget = tester.stateOf(find.byType(FlipWidget));
 
       expect(callbackTracker, equals([0, 1, 2, 3, 4, 5]));
 
@@ -176,8 +175,7 @@ void main() {
         );
       };
 
-      ElementVisitor collectText = (Element element) {
-        final Widget widget = element.widget;
+      void collectText(Widget widget) {
         if (widget is Text)
           text.add(widget.data);
       };
@@ -193,7 +191,7 @@ void main() {
 
       expect(callbackTracker, equals([0, 1, 2]));
       callbackTracker.clear();
-      tester.walkElements(collectText);
+      tester.widgets.forEach(collectText);
       expect(text, equals(['0', '1', '2']));
       text.clear();
 
@@ -201,7 +199,7 @@ void main() {
 
       expect(callbackTracker, equals([0, 1, 2]));
       callbackTracker.clear();
-      tester.walkElements(collectText);
+      tester.widgets.forEach(collectText);
       expect(text, equals(['0', '1', '2']));
       text.clear();
     });
@@ -237,7 +235,7 @@ void main() {
         )
       );
 
-      DecoratedBox widget = tester.findWidgetOfType(DecoratedBox);
+      DecoratedBox widget = tester.widget(find.byType(DecoratedBox));
       BoxDecoration decoraton = widget.decoration;
       expect(decoraton.backgroundColor, equals(Colors.blue[500]));
 
@@ -247,7 +245,7 @@ void main() {
 
       tester.pump();
 
-      widget = tester.findWidgetOfType(DecoratedBox);
+      widget = tester.widget(find.byType(DecoratedBox));
       decoraton = widget.decoration;
       expect(decoraton.backgroundColor, equals(Colors.green[500]));
     });
@@ -274,7 +272,7 @@ void main() {
         )
       );
 
-      RenderBox firstBox = tester.findText('0').findRenderObject();
+      RenderBox firstBox = tester.renderObjectOf(find.text('0'));
       Point upperLeft = firstBox.localToGlobal(Point.origin);
       expect(upperLeft, equals(new Point(7.0, 3.0)));
       expect(firstBox.size.width, equals(800.0 - 12.0));

--- a/packages/flutter/test/widget/listener_test.dart
+++ b/packages/flutter/test/widget/listener_test.dart
@@ -33,7 +33,7 @@ void main() {
         )
       );
 
-      tester.tap(tester.findText('X'));
+      tester.tap(find.text('X'));
 
       expect(log, equals([
         'bottom',

--- a/packages/flutter/test/widget/modal_barrier_test.dart
+++ b/packages/flutter/test/widget/modal_barrier_test.dart
@@ -35,7 +35,7 @@ void main() {
       );
 
       tester.pumpWidget(subject);
-      tester.tap(tester.findText('target'));
+      tester.tap(find.text('target'));
       tester.pumpWidget(subject);
       expect(tapped, isFalse,
         reason: 'because the tap is prevented by ModalBarrier');
@@ -52,7 +52,7 @@ void main() {
       );
 
       tester.pumpWidget(subject);
-      tester.tap(tester.findText('target'));
+      tester.tap(find.text('target'));
       tester.pumpWidget(subject);
       expect(tapped, isTrue,
         reason: 'because the tap is not prevented by ModalBarrier');
@@ -69,19 +69,19 @@ void main() {
       tester.pumpWidget(new MaterialApp(routes: routes));
 
       // Initially the barrier is not visible
-      expect(tester.findElementByKey(const ValueKey<String>('barrier')), isNull);
+      expect(tester, doesNotHaveWidget(find.byKey(const ValueKey<String>('barrier'))));
 
       // Tapping on X routes to the barrier
-      tester.tap(tester.findText('X'));
+      tester.tap(find.text('X'));
       tester.pump();  // begin transition
       tester.pump(const Duration(seconds: 1));  // end transition
 
       // Tap on the barrier to dismiss it
-      tester.tap(tester.findElementByKey(const ValueKey<String>('barrier')));
+      tester.tap(find.byKey(const ValueKey<String>('barrier')));
       tester.pump();  // begin transition
       tester.pump(const Duration(seconds: 1));  // end transition
 
-      expect(tester.findElementByKey(const ValueKey<String>('barrier')), isNull,
+      expect(tester, doesNotHaveWidget(find.byKey(const ValueKey<String>('barrier'))),
         reason: 'because the barrier was dismissed');
     });
   });

--- a/packages/flutter/test/widget/multichild_test.dart
+++ b/packages/flutter/test/widget/multichild_test.dart
@@ -11,7 +11,7 @@ import 'test_widgets.dart';
 
 void checkTree(WidgetTester tester, List<BoxDecoration> expectedDecorations) {
   MultiChildRenderObjectElement element =
-      tester.findElement((Element element) => element is MultiChildRenderObjectElement);
+      tester.elementOf(find.byElement((Element element) => element is MultiChildRenderObjectElement));
   expect(element, isNotNull);
   expect(element.renderObject is RenderStack, isTrue);
   RenderStack renderObject = element.renderObject;

--- a/packages/flutter/test/widget/navigator_test.dart
+++ b/packages/flutter/test/widget/navigator_test.dart
@@ -77,27 +77,27 @@ void main() {
 
       tester.pumpWidget(new MaterialApp(routes: routes));
 
-      expect(tester.findText('X'), isNotNull);
-      expect(tester.findText('Y'), isNull);
+      expect(tester, hasWidget(find.text('X')));
+      expect(tester, doesNotHaveWidget(find.text('Y')));
 
-      tester.tap(tester.findText('X'));
+      tester.tap(find.text('X'));
       tester.pump(const Duration(milliseconds: 10));
 
-      expect(tester.findText('X'), isNotNull);
-      expect(tester.findText('Y'), isNotNull);
+      expect(tester, hasWidget(find.text('X')));
+      expect(tester, hasWidget(find.text('Y')));
 
       tester.pump(const Duration(milliseconds: 10));
       tester.pump(const Duration(milliseconds: 10));
       tester.pump(const Duration(seconds: 1));
 
-      tester.tap(tester.findText('Y'));
+      tester.tap(find.text('Y'));
       tester.pump(const Duration(milliseconds: 10));
       tester.pump(const Duration(milliseconds: 10));
       tester.pump(const Duration(milliseconds: 10));
       tester.pump(const Duration(seconds: 1));
 
-      expect(tester.findText('X'), isNotNull);
-      expect(tester.findText('Y'), isNull);
+      expect(tester, hasWidget(find.text('X')));
+      expect(tester, doesNotHaveWidget(find.text('Y')));
     });
   });
 
@@ -112,7 +112,7 @@ void main() {
         }
       );
       tester.pumpWidget(widget);
-      tester.tap(tester.findElementByKey(targetKey));
+      tester.tap(find.byKey(targetKey));
       expect(exception, new isInstanceOf<FlutterError>());
       expect('$exception', startsWith('openTransaction called with a context'));
     });

--- a/packages/flutter/test/widget/page_forward_transitions_test.dart
+++ b/packages/flutter/test/widget/page_forward_transitions_test.dart
@@ -56,19 +56,19 @@ void main() {
 
       String state() {
         String result = '';
-        if (tester.findText('A') != null)
+        if (tester.exists(find.text('A')))
           result += 'A';
-        if (tester.findText('B') != null)
+        if (tester.exists(find.text('B')))
           result += 'B';
-        if (tester.findText('C') != null)
+        if (tester.exists(find.text('C')))
           result += 'C';
-        if (tester.findText('D') != null)
+        if (tester.exists(find.text('D')))
           result += 'D';
-        if (tester.findText('E') != null)
+        if (tester.exists(find.text('E')))
           result += 'E';
-        if (tester.findText('F') != null)
+        if (tester.exists(find.text('F')))
           result += 'F';
-        if (tester.findText('G') != null)
+        if (tester.exists(find.text('G')))
           result += 'G';
         return result;
       }

--- a/packages/flutter/test/widget/page_transitions_test.dart
+++ b/packages/flutter/test/widget/page_transitions_test.dart
@@ -26,9 +26,9 @@ void main() {
 
       tester.pumpWidget(new MaterialApp(routes: routes));
 
-      expect(tester.findText('Home'), isOnStage);
-      expect(tester.findText('Settings'), isNull);
-      expect(tester.findText('Overlay'), isNull);
+      expect(find.text('Home'), isOnStage(tester));
+      expect(tester, doesNotHaveWidget(find.text('Settings')));
+      expect(tester, doesNotHaveWidget(find.text('Overlay')));
 
       expect(Navigator.canPop(containerKey1.currentContext), isFalse);
       Navigator.pushNamed(containerKey1.currentContext, '/settings');
@@ -36,63 +36,63 @@ void main() {
 
       tester.pump();
 
-      expect(tester.findText('Home'), isOnStage);
-      expect(tester.findText('Settings'), isOffStage);
-      expect(tester.findText('Overlay'), isNull);
+      expect(find.text('Home'), isOnStage(tester));
+      expect(find.text('Settings'), isOffStage(tester));
+      expect(tester, doesNotHaveWidget(find.text('Overlay')));
 
       tester.pump(const Duration(milliseconds: 16));
 
-      expect(tester.findText('Home'), isOnStage);
-      expect(tester.findText('Settings'), isOnStage);
-      expect(tester.findText('Overlay'), isNull);
+      expect(find.text('Home'), isOnStage(tester));
+      expect(find.text('Settings'), isOnStage(tester));
+      expect(tester, doesNotHaveWidget(find.text('Overlay')));
 
       tester.pump(const Duration(seconds: 1));
 
-      expect(tester.findText('Home'), isNull);
-      expect(tester.findText('Settings'), isOnStage);
-      expect(tester.findText('Overlay'), isNull);
+      expect(tester, doesNotHaveWidget(find.text('Home')));
+      expect(find.text('Settings'), isOnStage(tester));
+      expect(tester, doesNotHaveWidget(find.text('Overlay')));
 
       Navigator.push(containerKey2.currentContext, new TestOverlayRoute());
 
       tester.pump();
 
-      expect(tester.findText('Home'), isNull);
-      expect(tester.findText('Settings'), isOnStage);
-      expect(tester.findText('Overlay'), isOnStage);
+      expect(tester, doesNotHaveWidget(find.text('Home')));
+      expect(find.text('Settings'), isOnStage(tester));
+      expect(find.text('Overlay'), isOnStage(tester));
 
       tester.pump(const Duration(seconds: 1));
 
-      expect(tester.findText('Home'), isNull);
-      expect(tester.findText('Settings'), isOnStage);
-      expect(tester.findText('Overlay'), isOnStage);
+      expect(tester, doesNotHaveWidget(find.text('Home')));
+      expect(find.text('Settings'), isOnStage(tester));
+      expect(find.text('Overlay'), isOnStage(tester));
 
       expect(Navigator.canPop(containerKey2.currentContext), isTrue);
       Navigator.pop(containerKey2.currentContext);
       tester.pump();
 
-      expect(tester.findText('Home'), isNull);
-      expect(tester.findText('Settings'), isOnStage);
-      expect(tester.findText('Overlay'), isNull);
+      expect(tester, doesNotHaveWidget(find.text('Home')));
+      expect(find.text('Settings'), isOnStage(tester));
+      expect(tester, doesNotHaveWidget(find.text('Overlay')));
 
       tester.pump(const Duration(seconds: 1));
 
-      expect(tester.findText('Home'), isNull);
-      expect(tester.findText('Settings'), isOnStage);
-      expect(tester.findText('Overlay'), isNull);
+      expect(tester, doesNotHaveWidget(find.text('Home')));
+      expect(find.text('Settings'), isOnStage(tester));
+      expect(tester, doesNotHaveWidget(find.text('Overlay')));
 
       expect(Navigator.canPop(containerKey2.currentContext), isTrue);
       Navigator.pop(containerKey2.currentContext);
       tester.pump();
 
-      expect(tester.findText('Home'), isOnStage);
-      expect(tester.findText('Settings'), isOnStage);
-      expect(tester.findText('Overlay'), isNull);
+      expect(find.text('Home'), isOnStage(tester));
+      expect(find.text('Settings'), isOnStage(tester));
+      expect(tester, doesNotHaveWidget(find.text('Overlay')));
 
       tester.pump(const Duration(seconds: 1));
 
-      expect(tester.findText('Home'), isOnStage);
-      expect(tester.findText('Settings'), isNull);
-      expect(tester.findText('Overlay'), isNull);
+      expect(find.text('Home'), isOnStage(tester));
+      expect(tester, doesNotHaveWidget(find.text('Settings')));
+      expect(tester, doesNotHaveWidget(find.text('Overlay')));
 
       expect(Navigator.canPop(containerKey1.currentContext), isFalse);
 

--- a/packages/flutter/test/widget/pageable_list_test.dart
+++ b/packages/flutter/test/widget/pageable_list_test.dart
@@ -44,7 +44,7 @@ Widget buildFrame({
 
 void page(WidgetTester tester, Offset offset) {
   String itemText = currentPage != null ? currentPage.toString() : '0';
-  tester.scroll(tester.findText(itemText), offset);
+  tester.scroll(find.text(itemText), offset);
   // One frame to start the animation, a second to complete it.
   tester.pump();
   tester.pump(const Duration(seconds: 1));
@@ -67,22 +67,22 @@ void main() {
       pageLeft(tester);
       expect(currentPage, equals(1));
 
-      expect(tester.findText('0'), isNull);
-      expect(tester.findText('1'), isNotNull);
-      expect(tester.findText('2'), isNull);
-      expect(tester.findText('3'), isNull);
-      expect(tester.findText('4'), isNull);
-      expect(tester.findText('5'), isNull);
+      expect(tester, doesNotHaveWidget(find.text('0')));
+      expect(tester, hasWidget(find.text('1')));
+      expect(tester, doesNotHaveWidget(find.text('2')));
+      expect(tester, doesNotHaveWidget(find.text('3')));
+      expect(tester, doesNotHaveWidget(find.text('4')));
+      expect(tester, doesNotHaveWidget(find.text('5')));
 
       pageRight(tester);
       expect(currentPage, equals(0));
 
-      expect(tester.findText('0'), isNotNull);
-      expect(tester.findText('1'), isNull);
-      expect(tester.findText('2'), isNull);
-      expect(tester.findText('3'), isNull);
-      expect(tester.findText('4'), isNull);
-      expect(tester.findText('5'), isNull);
+      expect(tester, hasWidget(find.text('0')));
+      expect(tester, doesNotHaveWidget(find.text('1')));
+      expect(tester, doesNotHaveWidget(find.text('2')));
+      expect(tester, doesNotHaveWidget(find.text('3')));
+      expect(tester, doesNotHaveWidget(find.text('4')));
+      expect(tester, doesNotHaveWidget(find.text('5')));
 
       pageRight(tester);
       expect(currentPage, equals(0));
@@ -96,32 +96,32 @@ void main() {
       pageRight(tester);
       expect(currentPage, equals(4));
 
-      expect(tester.findText('0'), isNull);
-      expect(tester.findText('1'), isNull);
-      expect(tester.findText('2'), isNull);
-      expect(tester.findText('3'), isNull);
-      expect(tester.findText('4'), isNotNull);
-      expect(tester.findText('5'), isNull);
+      expect(tester, doesNotHaveWidget(find.text('0')));
+      expect(tester, doesNotHaveWidget(find.text('1')));
+      expect(tester, doesNotHaveWidget(find.text('2')));
+      expect(tester, doesNotHaveWidget(find.text('3')));
+      expect(tester, hasWidget(find.text('4')));
+      expect(tester, doesNotHaveWidget(find.text('5')));
 
       pageLeft(tester);
       expect(currentPage, equals(5));
 
-      expect(tester.findText('0'), isNull);
-      expect(tester.findText('1'), isNull);
-      expect(tester.findText('2'), isNull);
-      expect(tester.findText('3'), isNull);
-      expect(tester.findText('4'), isNull);
-      expect(tester.findText('5'), isNotNull);
+      expect(tester, doesNotHaveWidget(find.text('0')));
+      expect(tester, doesNotHaveWidget(find.text('1')));
+      expect(tester, doesNotHaveWidget(find.text('2')));
+      expect(tester, doesNotHaveWidget(find.text('3')));
+      expect(tester, doesNotHaveWidget(find.text('4')));
+      expect(tester, hasWidget(find.text('5')));
 
       pageLeft(tester);
       expect(currentPage, equals(5));
 
-      expect(tester.findText('0'), isNull);
-      expect(tester.findText('1'), isNull);
-      expect(tester.findText('2'), isNull);
-      expect(tester.findText('3'), isNull);
-      expect(tester.findText('4'), isNull);
-      expect(tester.findText('5'), isNotNull);
+      expect(tester, doesNotHaveWidget(find.text('0')));
+      expect(tester, doesNotHaveWidget(find.text('1')));
+      expect(tester, doesNotHaveWidget(find.text('2')));
+      expect(tester, doesNotHaveWidget(find.text('3')));
+      expect(tester, doesNotHaveWidget(find.text('4')));
+      expect(tester, hasWidget(find.text('5')));
     });
   });
 
@@ -146,42 +146,42 @@ void main() {
       pageRight(tester);
       expect(currentPage, equals(4));
 
-      expect(tester.findText('0'), isNull);
-      expect(tester.findText('1'), isNull);
-      expect(tester.findText('2'), isNull);
-      expect(tester.findText('3'), isNull);
-      expect(tester.findText('4'), isNotNull);
-      expect(tester.findText('5'), isNull);
+      expect(tester, doesNotHaveWidget(find.text('0')));
+      expect(tester, doesNotHaveWidget(find.text('1')));
+      expect(tester, doesNotHaveWidget(find.text('2')));
+      expect(tester, doesNotHaveWidget(find.text('3')));
+      expect(tester, hasWidget(find.text('4')));
+      expect(tester, doesNotHaveWidget(find.text('5')));
 
       pageLeft(tester);
       expect(currentPage, equals(5));
 
-      expect(tester.findText('0'), isNull);
-      expect(tester.findText('1'), isNull);
-      expect(tester.findText('2'), isNull);
-      expect(tester.findText('3'), isNull);
-      expect(tester.findText('4'), isNull);
-      expect(tester.findText('5'), isNotNull);
+      expect(tester, doesNotHaveWidget(find.text('0')));
+      expect(tester, doesNotHaveWidget(find.text('1')));
+      expect(tester, doesNotHaveWidget(find.text('2')));
+      expect(tester, doesNotHaveWidget(find.text('3')));
+      expect(tester, doesNotHaveWidget(find.text('4')));
+      expect(tester, hasWidget(find.text('5')));
 
       pageLeft(tester);
       expect(currentPage, equals(0));
 
-      expect(tester.findText('0'), isNotNull);
-      expect(tester.findText('1'), isNull);
-      expect(tester.findText('2'), isNull);
-      expect(tester.findText('3'), isNull);
-      expect(tester.findText('4'), isNull);
-      expect(tester.findText('5'), isNull);
+      expect(tester, hasWidget(find.text('0')));
+      expect(tester, doesNotHaveWidget(find.text('1')));
+      expect(tester, doesNotHaveWidget(find.text('2')));
+      expect(tester, doesNotHaveWidget(find.text('3')));
+      expect(tester, doesNotHaveWidget(find.text('4')));
+      expect(tester, doesNotHaveWidget(find.text('5')));
 
       pageLeft(tester);
       expect(currentPage, equals(1));
 
-      expect(tester.findText('0'), isNull);
-      expect(tester.findText('1'), isNotNull);
-      expect(tester.findText('2'), isNull);
-      expect(tester.findText('3'), isNull);
-      expect(tester.findText('4'), isNull);
-      expect(tester.findText('5'), isNull);
+      expect(tester, doesNotHaveWidget(find.text('0')));
+      expect(tester, hasWidget(find.text('1')));
+      expect(tester, doesNotHaveWidget(find.text('2')));
+      expect(tester, doesNotHaveWidget(find.text('3')));
+      expect(tester, doesNotHaveWidget(find.text('4')));
+      expect(tester, doesNotHaveWidget(find.text('5')));
     });
   });
 
@@ -238,12 +238,12 @@ void main() {
       pageSize = new Size(pageSize.height, pageSize.width);
       tester.pumpWidget(buildFrame(itemsWrap: true));
 
-      expect(tester.findText('0'), isNull);
-      expect(tester.findText('1'), isNull);
-      expect(tester.findText('2'), isNull);
-      expect(tester.findText('3'), isNull);
-      expect(tester.findText('4'), isNull);
-      expect(tester.findText('5'), isNotNull);
+      expect(tester, doesNotHaveWidget(find.text('0')));
+      expect(tester, doesNotHaveWidget(find.text('1')));
+      expect(tester, doesNotHaveWidget(find.text('2')));
+      expect(tester, doesNotHaveWidget(find.text('3')));
+      expect(tester, doesNotHaveWidget(find.text('4')));
+      expect(tester, hasWidget(find.text('5')));
 
       box = globalKeys[5].currentContext.findRenderObject();
       expect(box.size.width, equals(pageSize.width));

--- a/packages/flutter/test/widget/parent_data_test.dart
+++ b/packages/flutter/test/widget/parent_data_test.dart
@@ -20,7 +20,7 @@ class TestParentData {
 
 void checkTree(WidgetTester tester, List<TestParentData> expectedParentData) {
   MultiChildRenderObjectElement element =
-      tester.findElement((Element element) => element is MultiChildRenderObjectElement);
+      tester.elementOf(find.byElement((Element element) => element is MultiChildRenderObjectElement));
   expect(element, isNotNull);
   expect(element.renderObject is RenderStack, isTrue);
   RenderStack renderObject = element.renderObject;

--- a/packages/flutter/test/widget/progress_indicator_test.dart
+++ b/packages/flutter/test/widget/progress_indicator_test.dart
@@ -9,7 +9,7 @@ import 'package:test/test.dart';
 
 void main() {
   test('LinearProgressIndicator changes when its value changes', () {
-    testWidgets((WidgetTester tester) {
+    testElementTree((ElementTreeTester tester) {
       tester.pumpWidget(new Block(children: <Widget>[new LinearProgressIndicator(value: 0.0)]));
 
       List<Layer> layers1 = tester.layers;

--- a/packages/flutter/test/widget/remember_scroll_position_test.dart
+++ b/packages/flutter/test/widget/remember_scroll_position_test.dart
@@ -38,36 +38,34 @@ void main() {
 
       // we're 600 pixels high, each item is 100 pixels high, scroll position is
       // zero, so we should have exactly 6 items, 0..5.
-      expect(tester.findText('0'), isNotNull);
-      expect(tester.findText('1'), isNotNull);
-      expect(tester.findText('2'), isNotNull);
-      expect(tester.findText('3'), isNotNull);
-      expect(tester.findText('4'), isNotNull);
-      expect(tester.findText('5'), isNotNull);
-      expect(tester.findText('6'), isNull);
-      expect(tester.findText('10'), isNull);
-      expect(tester.findText('100'), isNull);
+      expect(tester, hasWidget(find.text('0')));
+      expect(tester, hasWidget(find.text('1')));
+      expect(tester, hasWidget(find.text('2')));
+      expect(tester, hasWidget(find.text('3')));
+      expect(tester, hasWidget(find.text('4')));
+      expect(tester, hasWidget(find.text('5')));
+      expect(tester, doesNotHaveWidget(find.text('6')));
+      expect(tester, doesNotHaveWidget(find.text('10')));
+      expect(tester, doesNotHaveWidget(find.text('100')));
 
-      StatefulElement target =
-        tester.findElement((Element element) => element.widget is ScrollableLazyList);
-      ScrollableState targetState = target.state;
+      ScrollableState targetState = tester.stateOf(find.byType(ScrollableLazyList));
       targetState.scrollTo(1000.0);
       tester.pump(new Duration(seconds: 1));
 
       // we're 600 pixels high, each item is 100 pixels high, scroll position is
       // 1000, so we should have exactly 6 items, 10..15.
 
-      expect(tester.findText('0'), isNull);
-      expect(tester.findText('8'), isNull);
-      expect(tester.findText('9'), isNull);
-      expect(tester.findText('10'), isNotNull);
-      expect(tester.findText('11'), isNotNull);
-      expect(tester.findText('12'), isNotNull);
-      expect(tester.findText('13'), isNotNull);
-      expect(tester.findText('14'), isNotNull);
-      expect(tester.findText('15'), isNotNull);
-      expect(tester.findText('16'), isNull);
-      expect(tester.findText('100'), isNull);
+      expect(tester, doesNotHaveWidget(find.text('0')));
+      expect(tester, doesNotHaveWidget(find.text('8')));
+      expect(tester, doesNotHaveWidget(find.text('9')));
+      expect(tester, hasWidget(find.text('10')));
+      expect(tester, hasWidget(find.text('11')));
+      expect(tester, hasWidget(find.text('12')));
+      expect(tester, hasWidget(find.text('13')));
+      expect(tester, hasWidget(find.text('14')));
+      expect(tester, hasWidget(find.text('15')));
+      expect(tester, doesNotHaveWidget(find.text('16')));
+      expect(tester, doesNotHaveWidget(find.text('100')));
 
       navigatorKey.currentState.openTransaction(
         (NavigatorTransaction transaction) => transaction.pushNamed('/second')
@@ -76,15 +74,15 @@ void main() {
       tester.pump(new Duration(seconds: 1));
 
       // same as the first list again
-      expect(tester.findText('0'), isNotNull);
-      expect(tester.findText('1'), isNotNull);
-      expect(tester.findText('2'), isNotNull);
-      expect(tester.findText('3'), isNotNull);
-      expect(tester.findText('4'), isNotNull);
-      expect(tester.findText('5'), isNotNull);
-      expect(tester.findText('6'), isNull);
-      expect(tester.findText('10'), isNull);
-      expect(tester.findText('100'), isNull);
+      expect(tester, hasWidget(find.text('0')));
+      expect(tester, hasWidget(find.text('1')));
+      expect(tester, hasWidget(find.text('2')));
+      expect(tester, hasWidget(find.text('3')));
+      expect(tester, hasWidget(find.text('4')));
+      expect(tester, hasWidget(find.text('5')));
+      expect(tester, doesNotHaveWidget(find.text('6')));
+      expect(tester, doesNotHaveWidget(find.text('10')));
+      expect(tester, doesNotHaveWidget(find.text('100')));
 
       navigatorKey.currentState.openTransaction(
         (NavigatorTransaction transaction) => transaction.pop()
@@ -95,17 +93,17 @@ void main() {
       // we're 600 pixels high, each item is 100 pixels high, scroll position is
       // 1000, so we should have exactly 6 items, 10..15.
 
-      expect(tester.findText('0'), isNull);
-      expect(tester.findText('8'), isNull);
-      expect(tester.findText('9'), isNull);
-      expect(tester.findText('10'), isNotNull);
-      expect(tester.findText('11'), isNotNull);
-      expect(tester.findText('12'), isNotNull);
-      expect(tester.findText('13'), isNotNull);
-      expect(tester.findText('14'), isNotNull);
-      expect(tester.findText('15'), isNotNull);
-      expect(tester.findText('16'), isNull);
-      expect(tester.findText('100'), isNull);
+      expect(tester, doesNotHaveWidget(find.text('0')));
+      expect(tester, doesNotHaveWidget(find.text('8')));
+      expect(tester, doesNotHaveWidget(find.text('9')));
+      expect(tester, hasWidget(find.text('10')));
+      expect(tester, hasWidget(find.text('11')));
+      expect(tester, hasWidget(find.text('12')));
+      expect(tester, hasWidget(find.text('13')));
+      expect(tester, hasWidget(find.text('14')));
+      expect(tester, hasWidget(find.text('15')));
+      expect(tester, doesNotHaveWidget(find.text('16')));
+      expect(tester, doesNotHaveWidget(find.text('100')));
 
     });
   });

--- a/packages/flutter/test/widget/render_object_widget_test.dart
+++ b/packages/flutter/test/widget/render_object_widget_test.dart
@@ -43,7 +43,7 @@ class TestOrientedBox extends SingleChildRenderObjectWidget {
 
 void main() {
   test('RenderObjectWidget smoke test', () {
-    testWidgets((WidgetTester tester) {
+    testElementTree((ElementTreeTester tester) {
       tester.pumpWidget(new DecoratedBox(decoration: kBoxDecorationA));
       SingleChildRenderObjectElement element =
           tester.findElement((Element element) => element is SingleChildRenderObjectElement);
@@ -64,7 +64,7 @@ void main() {
   });
 
   test('RenderObjectWidget can add and remove children', () {
-    testWidgets((WidgetTester tester) {
+    testElementTree((ElementTreeTester tester) {
 
       void checkFullTree() {
         SingleChildRenderObjectElement element =
@@ -150,7 +150,7 @@ void main() {
   });
 
   test('Detached render tree is intact', () {
-    testWidgets((WidgetTester tester) {
+    testElementTree((ElementTreeTester tester) {
 
       tester.pumpWidget(new DecoratedBox(
         decoration: kBoxDecorationA,
@@ -194,7 +194,7 @@ void main() {
   });
 
   test('Can watch inherited widgets', () {
-    testWidgets((WidgetTester tester) {
+    testElementTree((ElementTreeTester tester) {
       Key boxKey = new UniqueKey();
       TestOrientedBox box = new TestOrientedBox(key: boxKey);
 

--- a/packages/flutter/test/widget/reparent_state_test.dart
+++ b/packages/flutter/test/widget/reparent_state_test.dart
@@ -77,7 +77,7 @@ void main() {
       StateMarkerState rightState = right.currentState;
       rightState.marker = "right";
 
-      StateMarkerState grandchildState = tester.findStateByConfig(grandchild);
+      StateMarkerState grandchildState = tester.stateOf(find.byConfig(grandchild));
       expect(grandchildState, isNotNull);
       grandchildState.marker = "grandchild";
 
@@ -103,7 +103,7 @@ void main() {
       expect(right.currentState, equals(rightState));
       expect(rightState.marker, equals("right"));
 
-      StateMarkerState newGrandchildState = tester.findStateByConfig(newGrandchild);
+      StateMarkerState newGrandchildState = tester.stateOf(find.byConfig(newGrandchild));
       expect(newGrandchildState, isNotNull);
       expect(newGrandchildState, equals(grandchildState));
       expect(newGrandchildState.marker, equals("grandchild"));
@@ -148,7 +148,7 @@ void main() {
       StateMarkerState rightState = right.currentState;
       rightState.marker = "right";
 
-      StateMarkerState grandchildState = tester.findStateByConfig(grandchild);
+      StateMarkerState grandchildState = tester.stateOf(find.byConfig(grandchild));
       expect(grandchildState, isNotNull);
       grandchildState.marker = "grandchild";
 
@@ -170,7 +170,7 @@ void main() {
       expect(right.currentState, equals(rightState));
       expect(rightState.marker, equals("right"));
 
-      StateMarkerState newGrandchildState = tester.findStateByConfig(newGrandchild);
+      StateMarkerState newGrandchildState = tester.stateOf(find.byConfig(newGrandchild));
       expect(newGrandchildState, isNotNull);
       expect(newGrandchildState, equals(grandchildState));
       expect(newGrandchildState.marker, equals("grandchild"));

--- a/packages/flutter/test/widget/rotated_box_test.dart
+++ b/packages/flutter/test/widget/rotated_box_test.dart
@@ -42,7 +42,7 @@ void main() {
         )
       );
 
-      RenderBox box = tester.findElementByKey(rotatedBoxKey).renderObject;
+      RenderBox box = tester.elementTreeTester.findElementByKey(rotatedBoxKey).renderObject;
       expect(box.size.width, equals(65.0));
       expect(box.size.height, equals(175.0));
 

--- a/packages/flutter/test/widget/scrollable_lazy_list_test.dart
+++ b/packages/flutter/test/widget/scrollable_lazy_list_test.dart
@@ -39,8 +39,7 @@ void main() {
 
       tester.pumpWidget(builder());
 
-      StatefulElement element = tester.findElement((Element element) => element.widget is FlipWidget);
-      FlipWidgetState testWidget = element.state;
+      FlipWidgetState testWidget = tester.stateOf(find.byType(FlipWidget));
 
       expect(callbackTracker, equals([0, 1, 2, 3, 4, 5]));
 

--- a/packages/flutter/test/widget/scrollable_list_hit_testing_test.dart
+++ b/packages/flutter/test/widget/scrollable_list_hit_testing_test.dart
@@ -31,21 +31,21 @@ void main() {
           )
         )
       ));
-      tester.scroll(tester.findText('2'), const Offset(-280.0, 0.0));
+      tester.scroll(find.text('2'), const Offset(-280.0, 0.0));
       tester.pump(const Duration(seconds: 1));
       // screen is 800px wide, and has the following items:
       //  -280..10  = 0
       //    10..300 = 1
       //   300..590 = 2
       //   590..880 = 3
-      expect(tester.findText('0'), isNotNull);
-      expect(tester.findText('1'), isNotNull);
-      expect(tester.findText('2'), isNotNull);
-      expect(tester.findText('3'), isNotNull);
-      expect(tester.findText('4'), isNull);
-      expect(tester.findText('5'), isNull);
+      expect(tester, hasWidget(find.text('0')));
+      expect(tester, hasWidget(find.text('1')));
+      expect(tester, hasWidget(find.text('2')));
+      expect(tester, hasWidget(find.text('3')));
+      expect(tester, doesNotHaveWidget(find.text('4')));
+      expect(tester, doesNotHaveWidget(find.text('5')));
       expect(tapped, equals([]));
-      tester.tap(tester.findText('2'));
+      tester.tap(find.text('2'));
       expect(tapped, equals([2]));
     });
   });
@@ -71,23 +71,23 @@ void main() {
           )
         )
       ));
-      tester.scroll(tester.findText('1'), const Offset(0.0, -280.0));
+      tester.scroll(find.text('1'), const Offset(0.0, -280.0));
       tester.pump(const Duration(seconds: 1));
       // screen is 600px tall, and has the following items:
       //  -280..10  = 0
       //    10..300 = 1
       //   300..590 = 2
       //   590..880 = 3
-      expect(tester.findText('0'), isNotNull);
-      expect(tester.findText('1'), isNotNull);
-      expect(tester.findText('2'), isNotNull);
-      expect(tester.findText('3'), isNotNull);
-      expect(tester.findText('4'), isNull);
-      expect(tester.findText('5'), isNull);
+      expect(tester, hasWidget(find.text('0')));
+      expect(tester, hasWidget(find.text('1')));
+      expect(tester, hasWidget(find.text('2')));
+      expect(tester, hasWidget(find.text('3')));
+      expect(tester, doesNotHaveWidget(find.text('4')));
+      expect(tester, doesNotHaveWidget(find.text('5')));
       expect(tapped, equals([]));
-      tester.tap(tester.findText('1'));
+      tester.tap(find.text('1'));
       expect(tapped, equals([1]));
-      tester.tap(tester.findText('3'));
+      tester.tap(find.text('3'));
       expect(tapped, equals([1])); // the center of the third item is off-screen so it shouldn't get hit
     });
   });

--- a/packages/flutter/test/widget/scrollable_list_horizontal_test.dart
+++ b/packages/flutter/test/widget/scrollable_list_horizontal_test.dart
@@ -33,60 +33,60 @@ void main() {
       tester.pumpWidget(buildFrame(ViewportAnchor.start));
 
       tester.pump(const Duration(seconds: 1));
-      tester.scroll(tester.findText('1'), const Offset(-300.0, 0.0));
+      tester.scroll(find.text('1'), const Offset(-300.0, 0.0));
       tester.pump(const Duration(seconds: 1));
       // screen is 800px wide, and has the following items:
       //   -10..280 = 1
       //   280..570 = 2
       //   570..860 = 3
-      expect(tester.findText('0'), isNull);
-      expect(tester.findText('1'), isNotNull);
-      expect(tester.findText('2'), isNotNull);
-      expect(tester.findText('3'), isNotNull);
-      expect(tester.findText('4'), isNull);
-      expect(tester.findText('5'), isNull);
+      expect(tester, doesNotHaveWidget(find.text('0')));
+      expect(tester, hasWidget(find.text('1')));
+      expect(tester, hasWidget(find.text('2')));
+      expect(tester, hasWidget(find.text('3')));
+      expect(tester, doesNotHaveWidget(find.text('4')));
+      expect(tester, doesNotHaveWidget(find.text('5')));
 
       // the center of item 3 is visible, so this works;
       // if item 3 was a bit wider, such that its center was past the 800px mark, this would fail,
       // because it wouldn't be hit tested when scrolling from its center, as scroll() does.
       tester.pump(const Duration(seconds: 1));
-      tester.scroll(tester.findText('3'), const Offset(-290.0, 0.0));
+      tester.scroll(find.text('3'), const Offset(-290.0, 0.0));
       tester.pump(const Duration(seconds: 1));
       // screen is 800px wide, and has the following items:
       //   -10..280 = 2
       //   280..570 = 3
       //   570..860 = 4
-      expect(tester.findText('0'), isNull);
-      expect(tester.findText('1'), isNull);
-      expect(tester.findText('2'), isNotNull);
-      expect(tester.findText('3'), isNotNull);
-      expect(tester.findText('4'), isNotNull);
-      expect(tester.findText('5'), isNull);
+      expect(tester, doesNotHaveWidget(find.text('0')));
+      expect(tester, doesNotHaveWidget(find.text('1')));
+      expect(tester, hasWidget(find.text('2')));
+      expect(tester, hasWidget(find.text('3')));
+      expect(tester, hasWidget(find.text('4')));
+      expect(tester, doesNotHaveWidget(find.text('5')));
 
       tester.pump(const Duration(seconds: 1));
-      tester.scroll(tester.findText('3'), const Offset(0.0, -290.0));
+      tester.scroll(find.text('3'), const Offset(0.0, -290.0));
       tester.pump(const Duration(seconds: 1));
       // unchanged
-      expect(tester.findText('0'), isNull);
-      expect(tester.findText('1'), isNull);
-      expect(tester.findText('2'), isNotNull);
-      expect(tester.findText('3'), isNotNull);
-      expect(tester.findText('4'), isNotNull);
-      expect(tester.findText('5'), isNull);
+      expect(tester, doesNotHaveWidget(find.text('0')));
+      expect(tester, doesNotHaveWidget(find.text('1')));
+      expect(tester, hasWidget(find.text('2')));
+      expect(tester, hasWidget(find.text('3')));
+      expect(tester, hasWidget(find.text('4')));
+      expect(tester, doesNotHaveWidget(find.text('5')));
 
       tester.pump(const Duration(seconds: 1));
-      tester.scroll(tester.findText('3'), const Offset(-290.0, 0.0));
+      tester.scroll(find.text('3'), const Offset(-290.0, 0.0));
       tester.pump(const Duration(seconds: 1));
       // screen is 800px wide, and has the following items:
       //   -10..280 = 3
       //   280..570 = 4
       //   570..860 = 5
-      expect(tester.findText('0'), isNull);
-      expect(tester.findText('1'), isNull);
-      expect(tester.findText('2'), isNull);
-      expect(tester.findText('3'), isNotNull);
-      expect(tester.findText('4'), isNotNull);
-      expect(tester.findText('5'), isNotNull);
+      expect(tester, doesNotHaveWidget(find.text('0')));
+      expect(tester, doesNotHaveWidget(find.text('1')));
+      expect(tester, doesNotHaveWidget(find.text('2')));
+      expect(tester, hasWidget(find.text('3')));
+      expect(tester, hasWidget(find.text('4')));
+      expect(tester, hasWidget(find.text('5')));
 
       tester.pump(const Duration(seconds: 1));
       // at this point we can drag 60 pixels further before we hit the friction zone
@@ -94,58 +94,58 @@ void main() {
       // to move item 3 entirely off screen therefore takes:
       //  60 + (290-60)*2 = 520 pixels
       // plus a couple more to be sure
-      tester.scroll(tester.findText('3'), const Offset(-522.0, 0.0));
+      tester.scroll(find.text('3'), const Offset(-522.0, 0.0));
       tester.pump(); // just after release
       // screen is 800px wide, and has the following items:
       //   -11..279 = 4
       //   279..569 = 5
-      expect(tester.findText('0'), isNull);
-      expect(tester.findText('1'), isNull);
-      expect(tester.findText('2'), isNull);
-      expect(tester.findText('3'), isNull);
-      expect(tester.findText('4'), isNotNull);
-      expect(tester.findText('5'), isNotNull);
+      expect(tester, doesNotHaveWidget(find.text('0')));
+      expect(tester, doesNotHaveWidget(find.text('1')));
+      expect(tester, doesNotHaveWidget(find.text('2')));
+      expect(tester, doesNotHaveWidget(find.text('3')));
+      expect(tester, hasWidget(find.text('4')));
+      expect(tester, hasWidget(find.text('5')));
       tester.pump(const Duration(seconds: 1)); // a second after release
       // screen is 800px wide, and has the following items:
       //   -70..220 = 3
       //   220..510 = 4
       //   510..800 = 5
-      expect(tester.findText('0'), isNull);
-      expect(tester.findText('1'), isNull);
-      expect(tester.findText('2'), isNull);
-      expect(tester.findText('3'), isNotNull);
-      expect(tester.findText('4'), isNotNull);
-      expect(tester.findText('5'), isNotNull);
+      expect(tester, doesNotHaveWidget(find.text('0')));
+      expect(tester, doesNotHaveWidget(find.text('1')));
+      expect(tester, doesNotHaveWidget(find.text('2')));
+      expect(tester, hasWidget(find.text('3')));
+      expect(tester, hasWidget(find.text('4')));
+      expect(tester, hasWidget(find.text('5')));
 
       tester.pumpWidget(new Container());
       tester.pumpWidget(buildFrame(ViewportAnchor.start), const Duration(seconds: 1));
-      tester.scroll(tester.findText('2'), const Offset(-280.0, 0.0));
+      tester.scroll(find.text('2'), const Offset(-280.0, 0.0));
       tester.pump(const Duration(seconds: 1));
       // screen is 800px wide, and has the following items:
       //  -280..10  = 0
       //    10..300 = 1
       //   300..590 = 2
       //   590..880 = 3
-      expect(tester.findText('0'), isNotNull);
-      expect(tester.findText('1'), isNotNull);
-      expect(tester.findText('2'), isNotNull);
-      expect(tester.findText('3'), isNotNull);
-      expect(tester.findText('4'), isNull);
-      expect(tester.findText('5'), isNull);
+      expect(tester, hasWidget(find.text('0')));
+      expect(tester, hasWidget(find.text('1')));
+      expect(tester, hasWidget(find.text('2')));
+      expect(tester, hasWidget(find.text('3')));
+      expect(tester, doesNotHaveWidget(find.text('4')));
+      expect(tester, doesNotHaveWidget(find.text('5')));
       tester.pump(const Duration(seconds: 1));
-      tester.scroll(tester.findText('2'), const Offset(-290.0, 0.0));
+      tester.scroll(find.text('2'), const Offset(-290.0, 0.0));
       tester.pump(const Duration(seconds: 1));
       // screen is 800px wide, and has the following items:
       //  -280..10  = 1
       //    10..300 = 2
       //   300..590 = 3
       //   590..880 = 4
-      expect(tester.findText('0'), isNull);
-      expect(tester.findText('1'), isNotNull);
-      expect(tester.findText('2'), isNotNull);
-      expect(tester.findText('3'), isNotNull);
-      expect(tester.findText('4'), isNotNull);
-      expect(tester.findText('5'), isNull);
+      expect(tester, doesNotHaveWidget(find.text('0')));
+      expect(tester, hasWidget(find.text('1')));
+      expect(tester, hasWidget(find.text('2')));
+      expect(tester, hasWidget(find.text('3')));
+      expect(tester, hasWidget(find.text('4')));
+      expect(tester, doesNotHaveWidget(find.text('5')));
     });
   });
 
@@ -158,67 +158,67 @@ void main() {
       //   -70..220 = 3
       //   220..510 = 4
       //   510..800 = 5
-      expect(tester.findText('0'), isNull);
-      expect(tester.findText('1'), isNull);
-      expect(tester.findText('2'), isNull);
-      expect(tester.findText('3'), isNotNull);
-      expect(tester.findText('4'), isNotNull);
-      expect(tester.findText('5'), isNotNull);
+      expect(tester, doesNotHaveWidget(find.text('0')));
+      expect(tester, doesNotHaveWidget(find.text('1')));
+      expect(tester, doesNotHaveWidget(find.text('2')));
+      expect(tester, hasWidget(find.text('3')));
+      expect(tester, hasWidget(find.text('4')));
+      expect(tester, hasWidget(find.text('5')));
 
-      tester.scroll(tester.findText('5'), const Offset(300.0, 0.0));
+      tester.scroll(find.text('5'), const Offset(300.0, 0.0));
       tester.pump(const Duration(seconds: 1));
       // screen is 800px wide, and has the following items:
       //   -80..210 = 2
       //   230..520 = 3
       //   520..810 = 4
-      expect(tester.findText('0'), isNull);
-      expect(tester.findText('1'), isNull);
-      expect(tester.findText('2'), isNotNull);
-      expect(tester.findText('3'), isNotNull);
-      expect(tester.findText('4'), isNotNull);
-      expect(tester.findText('5'), isNull);
+      expect(tester, doesNotHaveWidget(find.text('0')));
+      expect(tester, doesNotHaveWidget(find.text('1')));
+      expect(tester, hasWidget(find.text('2')));
+      expect(tester, hasWidget(find.text('3')));
+      expect(tester, hasWidget(find.text('4')));
+      expect(tester, doesNotHaveWidget(find.text('5')));
 
       // the center of item 3 is visible, so this works;
       // if item 3 was a bit wider, such that its center was past the 800px mark, this would fail,
       // because it wouldn't be hit tested when scrolling from its center, as scroll() does.
       tester.pump(const Duration(seconds: 1));
-      tester.scroll(tester.findText('3'), const Offset(290.0, 0.0));
+      tester.scroll(find.text('3'), const Offset(290.0, 0.0));
       tester.pump(const Duration(seconds: 1));
       // screen is 800px wide, and has the following items:
       //   -10..280 = 1
       //   280..570 = 2
       //   570..860 = 3
-      expect(tester.findText('0'), isNull);
-      expect(tester.findText('1'), isNotNull);
-      expect(tester.findText('2'), isNotNull);
-      expect(tester.findText('3'), isNotNull);
-      expect(tester.findText('4'), isNull);
-      expect(tester.findText('5'), isNull);
+      expect(tester, doesNotHaveWidget(find.text('0')));
+      expect(tester, hasWidget(find.text('1')));
+      expect(tester, hasWidget(find.text('2')));
+      expect(tester, hasWidget(find.text('3')));
+      expect(tester, doesNotHaveWidget(find.text('4')));
+      expect(tester, doesNotHaveWidget(find.text('5')));
 
       tester.pump(const Duration(seconds: 1));
-      tester.scroll(tester.findText('3'), const Offset(0.0, 290.0));
+      tester.scroll(find.text('3'), const Offset(0.0, 290.0));
       tester.pump(const Duration(seconds: 1));
       // unchanged
-      expect(tester.findText('0'), isNull);
-      expect(tester.findText('1'), isNotNull);
-      expect(tester.findText('2'), isNotNull);
-      expect(tester.findText('3'), isNotNull);
-      expect(tester.findText('4'), isNull);
-      expect(tester.findText('5'), isNull);
+      expect(tester, doesNotHaveWidget(find.text('0')));
+      expect(tester, hasWidget(find.text('1')));
+      expect(tester, hasWidget(find.text('2')));
+      expect(tester, hasWidget(find.text('3')));
+      expect(tester, doesNotHaveWidget(find.text('4')));
+      expect(tester, doesNotHaveWidget(find.text('5')));
 
       tester.pump(const Duration(seconds: 1));
-      tester.scroll(tester.findText('2'), const Offset(290.0, 0.0));
+      tester.scroll(find.text('2'), const Offset(290.0, 0.0));
       tester.pump(const Duration(seconds: 1));
       // screen is 800px wide, and has the following items:
       //   -10..280 = 0
       //   280..570 = 1
       //   570..860 = 2
-      expect(tester.findText('0'), isNotNull);
-      expect(tester.findText('1'), isNotNull);
-      expect(tester.findText('2'), isNotNull);
-      expect(tester.findText('3'), isNull);
-      expect(tester.findText('4'), isNull);
-      expect(tester.findText('5'), isNull);
+      expect(tester, hasWidget(find.text('0')));
+      expect(tester, hasWidget(find.text('1')));
+      expect(tester, hasWidget(find.text('2')));
+      expect(tester, doesNotHaveWidget(find.text('3')));
+      expect(tester, doesNotHaveWidget(find.text('4')));
+      expect(tester, doesNotHaveWidget(find.text('5')));
 
       tester.pump(const Duration(seconds: 1));
       // at this point we can drag 60 pixels further before we hit the friction zone
@@ -226,28 +226,28 @@ void main() {
       // to move item 3 entirely off screen therefore takes:
       //  60 + (290-60)*2 = 520 pixels
       // plus a couple more to be sure
-      tester.scroll(tester.findText('1'), const Offset(522.0, 0.0));
+      tester.scroll(find.text('1'), const Offset(522.0, 0.0));
       tester.pump(); // just after release
       // screen is 800px wide, and has the following items:
       //   280..570 = 0
       //   570..860 = 1
-      expect(tester.findText('0'), isNotNull);
-      expect(tester.findText('1'), isNotNull);
-      expect(tester.findText('2'), isNull);
-      expect(tester.findText('3'), isNull);
-      expect(tester.findText('4'), isNull);
-      expect(tester.findText('5'), isNull);
+      expect(tester, hasWidget(find.text('0')));
+      expect(tester, hasWidget(find.text('1')));
+      expect(tester, doesNotHaveWidget(find.text('2')));
+      expect(tester, doesNotHaveWidget(find.text('3')));
+      expect(tester, doesNotHaveWidget(find.text('4')));
+      expect(tester, doesNotHaveWidget(find.text('5')));
       tester.pump(const Duration(seconds: 1)); // a second after release
       // screen is 800px wide, and has the following items:
       //     0..290 = 0
       //   290..580 = 1
       //   580..870 = 2
-      expect(tester.findText('0'), isNotNull);
-      expect(tester.findText('1'), isNotNull);
-      expect(tester.findText('2'), isNotNull);
-      expect(tester.findText('3'), isNull);
-      expect(tester.findText('4'), isNull);
-      expect(tester.findText('5'), isNull);
+      expect(tester, hasWidget(find.text('0')));
+      expect(tester, hasWidget(find.text('1')));
+      expect(tester, hasWidget(find.text('2')));
+      expect(tester, doesNotHaveWidget(find.text('3')));
+      expect(tester, doesNotHaveWidget(find.text('4')));
+      expect(tester, doesNotHaveWidget(find.text('5')));
     });
   });
 }

--- a/packages/flutter/test/widget/scrollable_list_vertical_test.dart
+++ b/packages/flutter/test/widget/scrollable_list_vertical_test.dart
@@ -26,43 +26,43 @@ void main() {
       tester.pumpWidget(buildFrame());
 
       tester.pump();
-      tester.scroll(tester.findText('1'), const Offset(0.0, -300.0));
+      tester.scroll(find.text('1'), const Offset(0.0, -300.0));
       tester.pump();
       // screen is 600px high, and has the following items:
       //   -10..280 = 1
       //   280..570 = 2
       //   570..860 = 3
-      expect(tester.findText('0'), isNull);
-      expect(tester.findText('1'), isNotNull);
-      expect(tester.findText('2'), isNotNull);
-      expect(tester.findText('3'), isNotNull);
-      expect(tester.findText('4'), isNull);
-      expect(tester.findText('5'), isNull);
+      expect(tester, doesNotHaveWidget(find.text('0')));
+      expect(tester, hasWidget(find.text('1')));
+      expect(tester, hasWidget(find.text('2')));
+      expect(tester, hasWidget(find.text('3')));
+      expect(tester, doesNotHaveWidget(find.text('4')));
+      expect(tester, doesNotHaveWidget(find.text('5')));
 
       tester.pump();
-      tester.scroll(tester.findText('2'), const Offset(0.0, -290.0));
+      tester.scroll(find.text('2'), const Offset(0.0, -290.0));
       tester.pump();
       // screen is 600px high, and has the following items:
       //   -10..280 = 2
       //   280..570 = 3
       //   570..860 = 4
-      expect(tester.findText('0'), isNull);
-      expect(tester.findText('1'), isNull);
-      expect(tester.findText('2'), isNotNull);
-      expect(tester.findText('3'), isNotNull);
-      expect(tester.findText('4'), isNotNull);
-      expect(tester.findText('5'), isNull);
+      expect(tester, doesNotHaveWidget(find.text('0')));
+      expect(tester, doesNotHaveWidget(find.text('1')));
+      expect(tester, hasWidget(find.text('2')));
+      expect(tester, hasWidget(find.text('3')));
+      expect(tester, hasWidget(find.text('4')));
+      expect(tester, doesNotHaveWidget(find.text('5')));
 
       tester.pump();
-      tester.scroll(tester.findText('3'), const Offset(-300.0, 0.0));
+      tester.scroll(find.text('3'), const Offset(-300.0, 0.0));
       tester.pump();
       // nothing should have changed
-      expect(tester.findText('0'), isNull);
-      expect(tester.findText('1'), isNull);
-      expect(tester.findText('2'), isNotNull);
-      expect(tester.findText('3'), isNotNull);
-      expect(tester.findText('4'), isNotNull);
-      expect(tester.findText('5'), isNull);
+      expect(tester, doesNotHaveWidget(find.text('0')));
+      expect(tester, doesNotHaveWidget(find.text('1')));
+      expect(tester, hasWidget(find.text('2')));
+      expect(tester, hasWidget(find.text('3')));
+      expect(tester, hasWidget(find.text('4')));
+      expect(tester, doesNotHaveWidget(find.text('5')));
     });
   });
 
@@ -85,25 +85,25 @@ void main() {
       // screen is 600px high, and has the following items:
       //   250..540 = 0
       //   540..830 = 1
-      expect(tester.findText('0'), isNotNull);
-      expect(tester.findText('1'), isNotNull);
-      expect(tester.findText('2'), isNull);
-      expect(tester.findText('3'), isNull);
-      expect(tester.findText('4'), isNull);
-      expect(tester.findText('5'), isNull);
+      expect(tester, hasWidget(find.text('0')));
+      expect(tester, hasWidget(find.text('1')));
+      expect(tester, doesNotHaveWidget(find.text('2')));
+      expect(tester, doesNotHaveWidget(find.text('3')));
+      expect(tester, doesNotHaveWidget(find.text('4')));
+      expect(tester, doesNotHaveWidget(find.text('5')));
 
-      tester.scroll(tester.findText('0'), const Offset(0.0, -300.0));
+      tester.scroll(find.text('0'), const Offset(0.0, -300.0));
       tester.pump();
       // screen is 600px high, and has the following items:
       //   -50..240 = 0
       //   240..530 = 1
       //   530..820 = 2
-      expect(tester.findText('0'), isNotNull);
-      expect(tester.findText('1'), isNotNull);
-      expect(tester.findText('2'), isNotNull);
-      expect(tester.findText('3'), isNull);
-      expect(tester.findText('4'), isNull);
-      expect(tester.findText('5'), isNull);
+      expect(tester, hasWidget(find.text('0')));
+      expect(tester, hasWidget(find.text('1')));
+      expect(tester, hasWidget(find.text('2')));
+      expect(tester, doesNotHaveWidget(find.text('3')));
+      expect(tester, doesNotHaveWidget(find.text('4')));
+      expect(tester, doesNotHaveWidget(find.text('5')));
     });
   });
 }

--- a/packages/flutter/test/widget/scrollable_list_with_inherited_test.dart
+++ b/packages/flutter/test/widget/scrollable_list_with_inherited_test.dart
@@ -31,16 +31,16 @@ void main() {
   test('LazyBlock is a build function (smoketest)', () {
     testWidgets((WidgetTester tester) {
       tester.pumpWidget(buildFrame());
-      expect(tester.findText('0'), isNotNull);
-      expect(tester.findText('1'), isNotNull);
-      expect(tester.findText('2'), isNotNull);
-      expect(tester.findText('3'), isNotNull);
+      expect(tester, hasWidget(find.text('0')));
+      expect(tester, hasWidget(find.text('1')));
+      expect(tester, hasWidget(find.text('2')));
+      expect(tester, hasWidget(find.text('3')));
       items.removeAt(2);
       tester.pumpWidget(buildFrame());
-      expect(tester.findText('0'), isNotNull);
-      expect(tester.findText('1'), isNotNull);
-      expect(tester.findText('2'), isNull);
-      expect(tester.findText('3'), isNotNull);
+      expect(tester, hasWidget(find.text('0')));
+      expect(tester, hasWidget(find.text('1')));
+      expect(tester, doesNotHaveWidget(find.text('2')));
+      expect(tester, hasWidget(find.text('3')));
     });
   });
 }

--- a/packages/flutter/test/widget/set_state_2_test.dart
+++ b/packages/flutter/test/widget/set_state_2_test.dart
@@ -41,7 +41,7 @@ void main() {
         }
       ));
       log.add('---');
-      tester.tap(tester.findText('inner'));;
+      tester.tap(find.text('inner'));;
       tester.pump();
       log.add('---');
       expect(log, equals(<String>[

--- a/packages/flutter/test/widget/set_state_test.dart
+++ b/packages/flutter/test/widget/set_state_test.dart
@@ -64,7 +64,7 @@ void main() {
   test('setState() smoke test', () {
     testWidgets((WidgetTester tester) {
       tester.pumpWidget(new Outside());
-      Point location = tester.getCenter(tester.findText('INSIDE'));
+      Point location = tester.getCenter(find.text('INSIDE'));
       TestGesture gesture = tester.startGesture(location);
       tester.pump();
       gesture.up();

--- a/packages/flutter/test/widget/stack_test.dart
+++ b/packages/flutter/test/widget/stack_test.dart
@@ -23,7 +23,7 @@ void main() {
   });
 
   test('Can change position data', () {
-    testWidgets((WidgetTester tester) {
+    testElementTree((ElementTreeTester tester) {
       Key key = new Key('container');
 
       tester.pumpWidget(
@@ -80,7 +80,7 @@ void main() {
   });
 
   test('Can remove parent data', () {
-    testWidgets((WidgetTester tester) {
+    testElementTree((ElementTreeTester tester) {
       Key key = new Key('container');
       Container container = new Container(key: key, width: 10.0, height: 10.0);
 
@@ -110,7 +110,7 @@ void main() {
   });
 
   test('Can align non-positioned children', () {
-    testWidgets((WidgetTester tester) {
+    testElementTree((ElementTreeTester tester) {
       Key child0Key = new Key('child0');
       Key child1Key = new Key('child1');
 
@@ -167,9 +167,9 @@ void main() {
       }
 
       tester.pumpWidget(buildFrame(0));
-      expect(tester.findText('0'), isNotNull);
-      expect(tester.findText('1'), isNotNull);
-      expect(tester.findText('2'), isNotNull);
+      expect(tester, hasWidget(find.text('0')));
+      expect(tester, hasWidget(find.text('1')));
+      expect(tester, hasWidget(find.text('2')));
       expect(itemsPainted, equals([0]));
 
       tester.pumpWidget(buildFrame(1));
@@ -196,18 +196,18 @@ void main() {
 
       tester.pumpWidget(buildFrame(0));
       expect(itemsTapped, isEmpty);
-      tester.tap(tester.findElementByKey(key));
+      tester.tap(find.byKey(key));
       expect(itemsTapped, [0]);
 
       tester.pumpWidget(buildFrame(2));
       expect(itemsTapped, isEmpty);
-      tester.tap(tester.findElementByKey(key));
+      tester.tap(find.byKey(key));
       expect(itemsTapped, [2]);
     });
   });
 
   test('Can set width and height', () {
-    testWidgets((WidgetTester tester) {
+    testElementTree((ElementTreeTester tester) {
       Key key = new Key('container');
 
       BoxDecoration kBoxDecoration = new BoxDecoration(

--- a/packages/flutter/test/widget/stateful_component_test.dart
+++ b/packages/flutter/test/widget/stateful_component_test.dart
@@ -15,7 +15,7 @@ void main() {
 
       void checkTree(BoxDecoration expectedDecoration) {
         SingleChildRenderObjectElement element =
-            tester.findElement((Element element) => element is SingleChildRenderObjectElement);
+            tester.elementOf(find.byElement((Element element) => element is SingleChildRenderObjectElement));
         expect(element, isNotNull);
         expect(element.renderObject is RenderDecoratedBox, isTrue);
         RenderDecoratedBox renderObject = element.renderObject;

--- a/packages/flutter/test/widget/stateful_components_test.dart
+++ b/packages/flutter/test/widget/stateful_components_test.dart
@@ -46,7 +46,7 @@ class OuterContainerState extends State<OuterContainer> {
 
 void main() {
   test('resync stateful widget', () {
-    testWidgets((WidgetTester tester) {
+    testElementTree((ElementTreeTester tester) {
       Key innerKey = new Key('inner');
       Key outerKey = new Key('outer');
 

--- a/packages/flutter/test/widget/syncing_test.dart
+++ b/packages/flutter/test/widget/syncing_test.dart
@@ -56,7 +56,7 @@ void main() {
         )
       );
 
-      TestWidgetState state = tester.findStateOfType(TestWidgetState);
+      TestWidgetState state = tester.stateOf(find.byType(TestWidget));
 
       expect(state.persistentState, equals(1));
       expect(state.updates, equals(0));
@@ -92,7 +92,7 @@ void main() {
         )
       );
 
-      TestWidgetState state = tester.findStateOfType(TestWidgetState);
+      TestWidgetState state = tester.stateOf(find.byType(TestWidget));
 
       expect(state.persistentState, equals(10));
       expect(state.updates, equals(0));
@@ -106,7 +106,7 @@ void main() {
         )
       );
 
-      state = tester.findStateOfType(TestWidgetState);
+      state = tester.stateOf(find.byType(TestWidget));
 
       expect(state.persistentState, equals(11));
       expect(state.updates, equals(0));
@@ -116,7 +116,7 @@ void main() {
   });
 
   test('swap instances around', () {
-    testWidgets((WidgetTester tester) {
+    testElementTree((ElementTreeTester tester) {
       Widget a = new TestWidget(persistentState: 0x61, syncedState: 0x41, child: new Text('apple'));
       Widget b = new TestWidget(persistentState: 0x62, syncedState: 0x42, child: new Text('banana'));
       tester.pumpWidget(new Column());

--- a/packages/flutter/test/widget/table_test.dart
+++ b/packages/flutter/test/widget/table_test.dart
@@ -9,7 +9,7 @@ import 'package:test/test.dart';
 
 void main() {
   test('Table widget - control test', () {
-    testWidgets((WidgetTester tester) {
+    testElementTree((ElementTreeTester tester) {
       tester.pumpWidget(
         new Table(
           children: <TableRow>[
@@ -41,7 +41,7 @@ void main() {
     });
   });
   test('Table widget - changing table dimensions', () {
-    testWidgets((WidgetTester tester) {
+    testElementTree((ElementTreeTester tester) {
       tester.pumpWidget(
         new Table(
           children: <TableRow>[
@@ -92,7 +92,7 @@ void main() {
     });
   });
   test('Table widget - repump test', () {
-    testWidgets((WidgetTester tester) {
+    testElementTree((ElementTreeTester tester) {
       tester.pumpWidget(
         new Table(
           children: <TableRow>[
@@ -145,7 +145,7 @@ void main() {
     });
   });
   test('Table widget - intrinsic sizing test', () {
-    testWidgets((WidgetTester tester) {
+    testElementTree((ElementTreeTester tester) {
       tester.pumpWidget(
         new Table(
           defaultColumnWidth: const IntrinsicColumnWidth(),
@@ -179,7 +179,7 @@ void main() {
     });
   });
   test('Table widget - intrinsic sizing test, resizing', () {
-    testWidgets((WidgetTester tester) {
+    testElementTree((ElementTreeTester tester) {
       tester.pumpWidget(
         new Table(
           defaultColumnWidth: const IntrinsicColumnWidth(),
@@ -235,7 +235,7 @@ void main() {
     });
   });
   test('Table widget - intrinsic sizing test, changing column widths', () {
-    testWidgets((WidgetTester tester) {
+    testElementTree((ElementTreeTester tester) {
       tester.pumpWidget(
         new Table(
           children: <TableRow>[
@@ -290,7 +290,7 @@ void main() {
     });
   });
   test('Table widget - moving test', () {
-    testWidgets((WidgetTester tester) {
+    testElementTree((ElementTreeTester tester) {
       List<BuildContext> contexts = <BuildContext>[];
       tester.pumpWidget(
         new Table(

--- a/packages/flutter/test/widget/test_matchers.dart
+++ b/packages/flutter/test/widget/test_matchers.dart
@@ -3,12 +3,13 @@
 // found in the LICENSE file.
 
 import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
 import 'package:test/test.dart';
 
-bool _hasAncestorOfType(Element element, Type targetType) {
-  expect(element, isNotNull);
+bool _hasAncestorOfType(WidgetTester tester, Finder finder, Type targetType) {
+  expect(tester, hasWidget(finder));
   bool result = false;
-  element.visitAncestorElements((Element ancestor) {
+  finder.findFirst(tester).visitAncestorElements((Element ancestor) {
     if (ancestor.widget.runtimeType == targetType) {
       result = true;
       return false;
@@ -19,46 +20,54 @@ bool _hasAncestorOfType(Element element, Type targetType) {
 }
 
 class _IsOnStage extends Matcher {
-  const _IsOnStage();
+  const _IsOnStage(this.tester);
+
+  final WidgetTester tester;
 
   @override
-  bool matches(Element item, Map<dynamic, dynamic> matchState) => !_hasAncestorOfType(item, OffStage);
+  bool matches(Finder finder, Map<dynamic, dynamic> matchState) => !_hasAncestorOfType(tester, finder, OffStage);
 
   @override
   Description describe(Description description) => description.add('onstage');
 }
 
 class _IsOffStage extends Matcher {
-  const _IsOffStage();
+  const _IsOffStage(this.tester);
+
+  final WidgetTester tester;
 
   @override
-  bool matches(Element item, Map<dynamic, dynamic> matchState) => _hasAncestorOfType(item, OffStage);
+  bool matches(Finder finder, Map<dynamic, dynamic> matchState) => _hasAncestorOfType(tester, finder, OffStage);
 
   @override
   Description describe(Description description) => description.add('offstage');
 }
 
 class _IsInCard extends Matcher {
-  const _IsInCard();
+  const _IsInCard(this.tester);
+
+  final WidgetTester tester;
 
   @override
-  bool matches(Element item, Map<dynamic, dynamic> matchState) => _hasAncestorOfType(item, Card);
+  bool matches(Finder finder, Map<dynamic, dynamic> matchState) => _hasAncestorOfType(tester, finder, Card);
 
   @override
   Description describe(Description description) => description.add('in card');
 }
 
 class _IsNotInCard extends Matcher {
-  const _IsNotInCard();
+  const _IsNotInCard(this.tester);
+
+  final WidgetTester tester;
 
   @override
-  bool matches(Element item, Map<dynamic, dynamic> matchState) => !_hasAncestorOfType(item, Card);
+  bool matches(Finder finder, Map<dynamic, dynamic> matchState) => !_hasAncestorOfType(tester, finder, Card);
 
   @override
   Description describe(Description description) => description.add('not in card');
 }
 
-const Matcher isOnStage = const _IsOnStage();
-const Matcher isOffStage = const _IsOffStage();
-const Matcher isInCard = const _IsInCard();
-const Matcher isNotInCard = const _IsNotInCard();
+Matcher isOnStage(WidgetTester tester) => new _IsOnStage(tester);
+Matcher isOffStage(WidgetTester tester) => new _IsOffStage(tester);
+Matcher isInCard(WidgetTester tester) => new _IsInCard(tester);
+Matcher isNotInCard(WidgetTester tester) => new _IsNotInCard(tester);

--- a/packages/flutter/test/widget/test_widgets.dart
+++ b/packages/flutter/test/widget/test_widgets.dart
@@ -4,7 +4,6 @@
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/widgets.dart';
-import 'package:test/test.dart';
 
 final BoxDecoration kBoxDecorationA = new BoxDecoration(
   backgroundColor: const Color(0xFFFF0000)
@@ -55,10 +54,6 @@ class FlipWidgetState extends State<FlipWidget> {
 }
 
 void flipStatefulWidget(WidgetTester tester) {
-  StatefulElement stateElement =
-      tester.findElement((Element element) => element is StatefulElement);
-  expect(stateElement, isNotNull);
-  expect(stateElement.state is FlipWidgetState, isTrue);
-  FlipWidgetState state = stateElement.state;
+  FlipWidgetState state = tester.stateOf(find.byType(FlipWidget));
   state.flip();
 }

--- a/packages/flutter/test/widget/tooltip_test.dart
+++ b/packages/flutter/test/widget/tooltip_test.dart
@@ -27,7 +27,7 @@ import 'test_semantics.dart';
 
 void main() {
   test('Does tooltip end up in the right place - top left', () {
-    testWidgets((WidgetTester tester) {
+    testElementTree((ElementTreeTester tester) {
       GlobalKey key = new GlobalKey();
       tester.pumpWidget(
         new Overlay(
@@ -81,7 +81,7 @@ void main() {
   });
 
   test('Does tooltip end up in the right place - center prefer above fits', () {
-    testWidgets((WidgetTester tester) {
+    testElementTree((ElementTreeTester tester) {
       GlobalKey key = new GlobalKey();
       tester.pumpWidget(
         new Overlay(
@@ -137,7 +137,7 @@ void main() {
   });
 
   test('Does tooltip end up in the right place - center prefer above does not fit', () {
-    testWidgets((WidgetTester tester) {
+    testElementTree((ElementTreeTester tester) {
       GlobalKey key = new GlobalKey();
       tester.pumpWidget(
         new Overlay(
@@ -204,7 +204,7 @@ void main() {
   });
 
   test('Does tooltip end up in the right place - center prefer below fits', () {
-    testWidgets((WidgetTester tester) {
+    testElementTree((ElementTreeTester tester) {
       GlobalKey key = new GlobalKey();
       tester.pumpWidget(
         new Overlay(
@@ -259,7 +259,7 @@ void main() {
   });
 
   test('Does tooltip end up in the right place - way off to the right', () {
-    testWidgets((WidgetTester tester) {
+    testElementTree((ElementTreeTester tester) {
       GlobalKey key = new GlobalKey();
       tester.pumpWidget(
         new Overlay(
@@ -316,7 +316,7 @@ void main() {
   });
 
   test('Does tooltip end up in the right place - near the edge', () {
-    testWidgets((WidgetTester tester) {
+    testElementTree((ElementTreeTester tester) {
       GlobalKey key = new GlobalKey();
       tester.pumpWidget(
         new Overlay(
@@ -373,7 +373,7 @@ void main() {
   });
 
   test('Does tooltip contribute semantics', () {
-    testWidgets((WidgetTester tester) {
+    testElementTree((ElementTreeTester tester) {
       TestSemanticsListener client = new TestSemanticsListener();
       GlobalKey key = new GlobalKey();
       tester.pumpWidget(

--- a/packages/flutter/test/widget/two_level_list_test.dart
+++ b/packages/flutter/test/widget/two_level_list_test.dart
@@ -39,12 +39,12 @@ void main() {
     testWidgets((WidgetTester tester) {
       tester.pumpWidget(new MaterialApp(routes: routes));
 
-      expect(tester.findText('Top'), isNotNull);
-      expect(tester.findText('Sublist'), isNotNull);
-      expect(tester.findText('Bottom'), isNotNull);
+      expect(tester, hasWidget(find.text('Top')));
+      expect(tester, hasWidget(find.text('Sublist')));
+      expect(tester, hasWidget(find.text('Bottom')));
 
-      double getY(Key key) => tester.getTopLeft(tester.findElementByKey(key)).y;
-      double getHeight(Key key) => tester.getSize(tester.findElementByKey(key)).height;
+      double getY(Key key) => tester.getTopLeft(find.byKey(key)).y;
+      double getHeight(Key key) => tester.getSize(find.byKey(key)).height;
 
       expect(getY(topKey), lessThan(getY(sublistKey)));
       expect(getY(sublistKey), lessThan(getY(bottomKey)));
@@ -53,15 +53,15 @@ void main() {
       expect(getHeight(topKey), equals(getHeight(sublistKey) - 2.0));
       expect(getHeight(bottomKey), equals(getHeight(sublistKey) - 2.0));
 
-      tester.tap(tester.findText('Sublist'));
+      tester.tap(find.text('Sublist'));
       tester.pump(const Duration(seconds: 1));
       tester.pump(const Duration(seconds: 1));
 
-      expect(tester.findText('Top'), isNotNull);
-      expect(tester.findText('Sublist'), isNotNull);
-      expect(tester.findText('0'), isNotNull);
-      expect(tester.findText('1'), isNotNull);
-      expect(tester.findText('Bottom'), isNotNull);
+      expect(tester, hasWidget(find.text('Top')));
+      expect(tester, hasWidget(find.text('Sublist')));
+      expect(tester, hasWidget(find.text('0')));
+      expect(tester, hasWidget(find.text('1')));
+      expect(tester, hasWidget(find.text('Bottom')));
 
       expect(getY(topKey), lessThan(getY(sublistKey)));
       expect(getY(sublistKey), lessThan(getY(bottomKey)));

--- a/packages/flutter_test/lib/flutter_test.dart
+++ b/packages/flutter_test/lib/flutter_test.dart
@@ -5,6 +5,7 @@
 /// Testing library for flutter, built on top of `package:test`.
 library flutter_test;
 
+export 'src/element_tree_tester.dart';
 export 'src/instrumentation.dart';
 export 'src/service_mocker.dart';
 export 'src/test_pointer.dart';

--- a/packages/flutter_test/lib/src/element_tree_tester.dart
+++ b/packages/flutter_test/lib/src/element_tree_tester.dart
@@ -1,0 +1,207 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:ui' as ui show window;
+
+import 'package:flutter/rendering.dart';
+import 'package:flutter/scheduler.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
+import 'package:quiver/testing/async.dart';
+import 'package:quiver/time.dart';
+
+import 'instrumentation.dart';
+
+/// Enumeration of possible phases to reach in pumpWidget.
+enum EnginePhase {
+  layout,
+  compositingBits,
+  paint,
+  composite,
+  flushSemantics,
+  sendSemanticsTree
+}
+
+class _SteppedWidgetFlutterBinding extends WidgetFlutterBinding {
+
+  /// Creates and initializes the binding. This constructor is
+  /// idempotent; calling it a second time will just return the
+  /// previously-created instance.
+  static WidgetFlutterBinding ensureInitialized() {
+    if (WidgetFlutterBinding.instance == null)
+      new _SteppedWidgetFlutterBinding();
+    return WidgetFlutterBinding.instance;
+  }
+
+  EnginePhase phase = EnginePhase.sendSemanticsTree;
+
+  // Pump the rendering pipeline up to the given phase.
+  @override
+  void beginFrame() {
+    buildOwner.buildDirtyElements();
+    _beginFrame();
+    buildOwner.finalizeTree();
+  }
+
+  // Cloned from Renderer.beginFrame() but with early-exit semantics.
+  void _beginFrame() {
+    assert(renderView != null);
+    pipelineOwner.flushLayout();
+    if (phase == EnginePhase.layout)
+      return;
+    pipelineOwner.flushCompositingBits();
+    if (phase == EnginePhase.compositingBits)
+      return;
+    pipelineOwner.flushPaint();
+    if (phase == EnginePhase.paint)
+      return;
+    renderView.compositeFrame(); // this sends the bits to the GPU
+    if (phase == EnginePhase.composite)
+      return;
+    if (SemanticsNode.hasListeners) {
+      pipelineOwner.flushSemantics();
+      if (phase == EnginePhase.flushSemantics)
+        return;
+      SemanticsNode.sendSemanticsTree();
+    }
+  }
+}
+
+/// Helper class for flutter tests providing fake async.
+///
+/// This class extends Instrumentation to also abstract away the beginFrame
+/// and async/clock access to allow writing tests which depend on the passage
+/// of time without actually moving the clock forward.
+class ElementTreeTester extends Instrumentation {
+  ElementTreeTester._(FakeAsync async)
+    : async = async,
+      clock = async.getClock(new DateTime.utc(2015, 1, 1)),
+      super(binding: _SteppedWidgetFlutterBinding.ensureInitialized()) {
+    timeDilation = 1.0;
+    ui.window.onBeginFrame = null;
+    debugPrint = _synchronousDebugPrint;
+  }
+
+  void _synchronousDebugPrint(String message, { int wrapWidth }) {
+    if (wrapWidth != null) {
+      print(message.split('\n').expand((String line) => debugWordWrap(line, wrapWidth)).join('\n'));
+    } else {
+      print(message);
+    }
+  }
+
+
+  final FakeAsync async;
+  final Clock clock;
+
+  /// Calls [runApp] with the given widget, then triggers a frame sequence and
+  /// flushes microtasks, by calling [pump] with the same duration (if any).
+  /// The supplied [EnginePhase] is the final phase reached during the pump pass;
+  /// if not supplied, the whole pass is executed.
+  void pumpWidget(Widget widget, [ Duration duration, EnginePhase phase ]) {
+    runApp(widget);
+    pump(duration, phase);
+  }
+
+  /// Triggers a frame sequence (build/layout/paint/etc),
+  /// then flushes microtasks.
+  ///
+  /// If duration is set, then advances the clock by that much first.
+  /// Doing this flushes microtasks.
+  ///
+  /// The supplied EnginePhase is the final phase reached during the pump pass;
+  /// if not supplied, the whole pass is executed.
+  void pump([ Duration duration, EnginePhase phase ]) {
+    if (duration != null)
+      async.elapse(duration);
+    if (binding is _SteppedWidgetFlutterBinding) {
+      // Some tests call WidgetFlutterBinding.ensureInitialized() manually, so
+      // we can't actually be sure we have a stepped binding.
+      _SteppedWidgetFlutterBinding steppedBinding = binding;
+      steppedBinding.phase = phase ?? EnginePhase.sendSemanticsTree;
+    } else {
+      // Can't step to a given phase in that case
+      assert(phase == null);
+    }
+    binding.handleBeginFrame(new Duration(
+      milliseconds: clock.now().millisecondsSinceEpoch)
+    );
+    async.flushMicrotasks();
+  }
+
+  /// Artificially calls dispatchLocaleChanged on the Widget binding,
+  /// then flushes microtasks.
+  void setLocale(String languageCode, String countryCode) {
+    Locale locale = new Locale(languageCode, countryCode);
+    binding.dispatchLocaleChanged(locale);
+    async.flushMicrotasks();
+  }
+
+  @override
+  void dispatchEvent(PointerEvent event, HitTestResult result) {
+    super.dispatchEvent(event, result);
+    async.flushMicrotasks();
+  }
+
+  /// Returns the exception most recently caught by the Flutter framework.
+  ///
+  /// Call this if you expect an exception during a test. If an exception is
+  /// thrown and this is not called, then the exception is rethrown when
+  /// the [testWidgets] call completes.
+  ///
+  /// If two exceptions are thrown in a row without the first one being
+  /// acknowledged with a call to this method, then when the second exception is
+  /// thrown, they are both dumped to the console and then the second is
+  /// rethrown from the exception handler. This will likely result in the
+  /// framework entering a highly unstable state and everything collapsing.
+  ///
+  /// It's safe to call this when there's no pending exception; it will return
+  /// null in that case.
+  dynamic takeException() {
+    dynamic result = _pendingException;
+    _pendingException = null;
+    return result;
+  }
+  dynamic _pendingException;
+}
+
+void testElementTree(callback(ElementTreeTester tester)) {
+  new FakeAsync().run((FakeAsync async) {
+    FlutterExceptionHandler oldHandler = FlutterError.onError;
+    try {
+      ElementTreeTester tester = new ElementTreeTester._(async);
+      FlutterError.onError = (FlutterErrorDetails details) {
+        if (tester._pendingException != null) {
+          FlutterError.dumpErrorToConsole(tester._pendingException);
+          FlutterError.dumpErrorToConsole(details.exception);
+          tester._pendingException = 'An uncaught exception was thrown.';
+          throw details.exception;
+        }
+        tester._pendingException = details;
+      };
+      runApp(new Container(key: new UniqueKey())); // Reset the tree to a known state.
+      callback(tester);
+      runApp(new Container(key: new UniqueKey())); // Unmount any remaining widgets.
+      async.flushMicrotasks();
+      assert(Scheduler.instance.debugAssertNoTransientCallbacks(
+        'An animation is still running even after the widget tree was disposed.'
+      ));
+      assert(() {
+        'A Timer is still running even after the widget tree was disposed.';
+        return async.periodicTimerCount == 0;
+      });
+      assert(() {
+        'A Timer is still running even after the widget tree was disposed.';
+        return async.nonPeriodicTimerCount == 0;
+      });
+      assert(async.microtaskCount == 0); // Shouldn't be possible.
+      if (tester._pendingException != null) {
+        FlutterError.dumpErrorToConsole(tester._pendingException);
+        throw 'An exception (shown above) was thrown during the test.';
+      }
+    } finally {
+      FlutterError.onError = oldHandler;
+    }
+  });
+}

--- a/packages/flutter_test/lib/src/instrumentation.dart
+++ b/packages/flutter_test/lib/src/instrumentation.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:collection';
+
 import 'package:flutter/gestures.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
@@ -59,6 +61,20 @@ class Instrumentation {
       return e;
     }
     return null;
+  }
+
+  /// Returns all elements ordered in a depth-first traversal fashion.
+  ///
+  /// The returned iterable is lazy. It does not walk the entire element tree
+  /// immediately, but rather a chunk at a time as the iteration progresses
+  /// using [Iterator.moveNext].
+  Iterable<Element> get allElements {
+    return new _DepthFirstChildIterable(binding.renderViewElement);
+  }
+
+  /// Returns all elements that satisfy [predicate].
+  Iterable<Element> findElements(bool predicate(Element element)) {
+    return allElements.where(predicate);
   }
 
   /// Returns the first element that corresponds to a widget with the
@@ -282,5 +298,44 @@ class TestGesture {
     assert(_isDown);
     _isDown = false;
     _target.dispatchEvent(pointer.cancel(), _result);
+  }
+}
+
+class _DepthFirstChildIterable extends IterableBase<Element> {
+  _DepthFirstChildIterable(this.rootElement);
+
+  Element rootElement;
+
+  @override
+  Iterator<Element> get iterator => new _DepthFirstChildIterator(rootElement);
+}
+
+class _DepthFirstChildIterator implements Iterator<Element> {
+  _DepthFirstChildIterator(Element rootElement)
+      : _stack = _reverseChildrenOf(rootElement).toList();
+
+  Element _current;
+
+  final List<Element> _stack;
+
+  @override
+  Element get current => _current;
+
+  @override
+  bool moveNext() {
+    if (_stack.isEmpty)
+      return false;
+
+    _current = _stack.removeLast();
+    // Stack children in reverse order to traverse first branch first
+    _stack.addAll(_reverseChildrenOf(_current));
+
+    return true;
+  }
+
+  static Iterable<Element> _reverseChildrenOf(Element element) {
+    List<Element> children = <Element>[];
+    element.visitChildren(children.add);
+    return children.reversed;
   }
 }

--- a/packages/flutter_test/test/widget_tester_test.dart
+++ b/packages/flutter_test/test/widget_tester_test.dart
@@ -1,0 +1,62 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('hasWidget', () {
+    test('succeeds', () {
+      testWidgets((WidgetTester tester) {
+        tester.pumpWidget(new Text('foo'));
+        expect(tester, hasWidget(find.text('foo')));
+      });
+    });
+
+    test('fails with a descriptive message', () {
+      testWidgets((WidgetTester tester) {
+        TestFailure failure;
+        try {
+          expect(tester, hasWidget(find.text('foo')));
+        } catch(e) {
+          failure = e;
+        }
+
+        expect(failure, isNotNull);
+        String message = failure.message;
+        expect(message, contains('Expected: widget with text "foo" exists in the element tree'));
+        expect(message, contains("Actual: <Instance of 'WidgetTester'>"));
+        expect(message, contains('Which: Does not contain widget with text "foo"'));
+      });
+    });
+  });
+
+  group('doesNotHaveWidget', () {
+    test('succeeds', () {
+      testWidgets((WidgetTester tester) {
+        expect(tester, doesNotHaveWidget(find.text('foo')));
+      });
+    });
+
+    test('fails with a descriptive message', () {
+      testWidgets((WidgetTester tester) {
+        tester.pumpWidget(new Text('foo'));
+
+        TestFailure failure;
+        try {
+          expect(tester, doesNotHaveWidget(find.text('foo')));
+        } catch(e) {
+          failure = e;
+        }
+
+        expect(failure, isNotNull);
+        String message = failure.message;
+        expect(message, contains('Expected: widget with text "foo" does not exist in the element tree'));
+        expect(message, contains("Actual: <Instance of 'WidgetTester'>"));
+        expect(message, contains('Which: Contains widget with text "foo"'));
+      });
+    });
+  });
+}

--- a/travis/test.sh
+++ b/travis/test.sh
@@ -14,6 +14,7 @@ flutter analyze --flutter-repo --no-current-directory --no-current-package --con
 (cd packages/flutter; flutter test)
 (cd packages/flutter_driver; dart -c test/all.dart)
 (cd packages/flutter_sprites; flutter test)
+(cd packages/flutter_test; flutter test)
 (cd packages/flutter_tools; dart -c test/all.dart)
 (cd packages/flx; dart -c test/all.dart)
 (cd packages/newton; dart -c test/all.dart)


### PR DESCRIPTION
Refactor the `package:flutter_test` API according to [the new design](https://docs.google.com/document/d/1266XuPpImmTVsvePulaZcP1HipgYtaNp8tAoDzc8680/edit) based on finder objects.
