### PR TITLE
Move flutter drive to use 8183 to not conflict with diagnostic server

### DIFF
--- a/packages/flutter_driver/lib/src/driver.dart
+++ b/packages/flutter_driver/lib/src/driver.dart
@@ -41,8 +41,8 @@ class FlutterDriver {
   /// Resumes the application if it is currently paused (e.g. at a breakpoint).
   ///
   /// [dartVmServiceUrl] is the URL to Dart observatory (a.k.a. VM service). By
-  /// default it connects to `http://localhost:8182`.
-  static Future<FlutterDriver> connect({String dartVmServiceUrl: 'http://localhost:8182'}) async {
+  /// default it connects to `http://localhost:8183`.
+  static Future<FlutterDriver> connect({String dartVmServiceUrl: 'http://localhost:8183'}) async {
     // Connect to Dart VM servcies
     _log.info('Connecting to Flutter application at $dartVmServiceUrl');
     VMServiceClientConnection connection = await vmServiceConnectFunction(dartVmServiceUrl);

--- a/packages/flutter_tools/lib/src/commands/drive.dart
+++ b/packages/flutter_tools/lib/src/commands/drive.dart
@@ -60,7 +60,7 @@ class DriveCommand extends RunCommandBase {
     );
 
     argParser.addOption('debug-port',
-        defaultsTo: '8182',
+        defaultsTo: '8183',
         help: 'Listen to the given port for a debug connection.');
   }
 


### PR DESCRIPTION
When @jason-simmons  added the diagnostic server on Android this
happened to conflict with flutter drive's usage of 8182.

We really should fix both of these port users to be dynamic
but this fixes https://github.com/flutter/flutter/issues/3291
for now.

@yjbanov
