### PR TITLE
Fix dependency skew.

### DIFF
--- a/dev/manual_tests/pubspec.yaml
+++ b/dev/manual_tests/pubspec.yaml
@@ -2,3 +2,7 @@ name: flutter_manual_tests
 dependencies:
   flutter:
     path: ../../packages/flutter
+dev_dependencies:
+  test: any # flutter_test provides the version constraints
+  flutter_test:
+    path: ../../packages/flutter_test

--- a/dev/manual_tests/test/card_collection_test.dart
+++ b/dev/manual_tests/test/card_collection_test.dart
@@ -1,0 +1,42 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:test/test.dart';
+
+import '../card_collection.dart' as card_collection;
+
+void main() {
+  test("Card Collection smoke test", () {
+    testWidgets((WidgetTester tester) {
+      card_collection.main(); // builds the app and schedules a frame but doesn't trigger one
+      tester.pump(); // see https://github.com/flutter/flutter/issues/1865
+      tester.pump(); // triggers a frame
+
+      Element navigationMenu = tester.findElement((Element element) {
+        Widget widget = element.widget;
+        if (widget is Tooltip)
+          return widget.message == 'Open navigation menu';
+        return false;
+      });
+
+      expect(navigationMenu, isNotNull);
+
+      tester.tap(navigationMenu);
+      tester.pump(); // start opening menu
+      tester.pump(const Duration(seconds: 1)); // wait til it's really opened
+
+      // smoke test for various checkboxes
+      tester.tap(tester.findText('Make card labels editable'));
+      tester.pump();
+      tester.tap(tester.findText('Let the sun shine'));
+      tester.pump();
+      tester.tap(tester.findText('Make card labels editable'));
+      tester.pump();
+      tester.tap(tester.findText('Vary font sizes'));
+      tester.pump();
+    });
+  });
+}

--- a/examples/hello_world/pubspec.yaml
+++ b/examples/hello_world/pubspec.yaml
@@ -2,3 +2,7 @@ name: hello_world
 dependencies:
   flutter:
     path: ../../packages/flutter
+dev_dependencies:
+  test: any # flutter_test provides the version constraints
+  flutter_test:
+    path: ../../packages/flutter_test

--- a/examples/hello_world/test/hello_test.dart
+++ b/examples/hello_world/test/hello_test.dart
@@ -1,0 +1,19 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:test/test.dart';
+
+import '../lib/main.dart' as hello_world;
+
+void main() {
+  test("Hello world smoke test", () {
+    testWidgets((WidgetTester tester) {
+      hello_world.main(); // builds the app and schedules a frame but doesn't trigger one
+      tester.pump(); // triggers a frame
+
+      expect(tester.findText('Hello, world!'), isNotNull);
+    });
+  });
+}

--- a/examples/layers/pubspec.yaml
+++ b/examples/layers/pubspec.yaml
@@ -2,3 +2,7 @@ name: flutter_examples_layers
 dependencies:
   flutter:
     path: ../../packages/flutter
+dev_dependencies:
+  test: any # flutter_test provides the version constraints
+  flutter_test:
+    path: ../../packages/flutter_test

--- a/examples/layers/test/sector_test.dart
+++ b/examples/layers/test/sector_test.dart
@@ -1,0 +1,12 @@
+// Copyright 2015 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import '../rendering/src/sector_layout.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('SectorConstraints', () {
+    expect(const SectorConstraints().isTight, isFalse);
+  });
+}

--- a/examples/material_gallery/pubspec.yaml
+++ b/examples/material_gallery/pubspec.yaml
@@ -11,3 +11,8 @@ dependencies:
   flutter_markdown:
     path: ../../packages/flutter_markdown
   flutter_gallery_assets: '0.0.15'
+
+dev_dependencies:
+  test: any # flutter_test provides the version constraints
+  flutter_test:
+    path: ../../packages/flutter_test

--- a/examples/material_gallery/test/smoke_test.dart
+++ b/examples/material_gallery/test/smoke_test.dart
@@ -1,0 +1,62 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:test/test.dart';
+
+import '../lib/main.dart' as material_gallery;
+
+void main() {
+  test('Material Gallery app smoke test', () {
+    testWidgets((WidgetTester tester) {
+      material_gallery.main(); // builds the app and schedules a frame but doesn't trigger one
+      tester.pump(); // see https://github.com/flutter/flutter/issues/1865
+      tester.pump(); // triggers a frame
+
+      // Try loading Weather demo
+      tester.tap(tester.findText('Demos'));
+      tester.pump();
+      tester.pump(const Duration(seconds: 1)); // wait til it's really opened
+
+      tester.tap(tester.findText('Weather'));
+      tester.pump();
+      tester.pump(const Duration(seconds: 1)); // wait til it's really opened
+
+      // Go back
+      Element backButton = tester.findElement((Element element) {
+        Widget widget = element.widget;
+        if (widget is Tooltip)
+          return widget.message == 'Back';
+        return false;
+      });
+      expect(backButton, isNotNull);
+      tester.tap(backButton);
+      tester.pump(); // start going back
+      tester.pump(const Duration(seconds: 1)); // wait til it's finished
+
+      // Open menu
+      Element navigationMenu = tester.findElement((Element element) {
+        Widget widget = element.widget;
+        if (widget is Tooltip)
+          return widget.message == 'Open navigation menu';
+        return false;
+      });
+      expect(navigationMenu, isNotNull);
+      tester.tap(navigationMenu);
+      tester.pump(); // start opening menu
+      tester.pump(const Duration(seconds: 1)); // wait til it's really opened
+
+      // switch theme
+      tester.tap(tester.findText('Dark'));
+      tester.pump();
+      tester.pump(const Duration(seconds: 1)); // wait til it's changed
+
+      // switch theme
+      tester.tap(tester.findText('Light'));
+      tester.pump();
+      tester.pump(const Duration(seconds: 1)); // wait til it's changed
+    });
+  });
+}

--- a/packages/flutter/lib/src/material/toggleable.dart
+++ b/packages/flutter/lib/src/material/toggleable.dart
@@ -117,6 +117,38 @@ abstract class RenderToggleable extends RenderConstrainedBox implements Semantic
   TapGestureRecognizer _tap;
   Point _downPosition;
 
+  @override
+  void attach(PipelineOwner owner) {
+    super.attach(owner);
+    if (_positionController != null) {
+      if (value)
+        _positionController.forward();
+      else
+        _positionController.reverse();
+    }
+    if (_reactionController != null && isInteractive) {
+      switch (_reactionController.status) {
+        case AnimationStatus.forward:
+          _reactionController.forward();
+          break;
+        case AnimationStatus.reverse:
+          _reactionController.reverse();
+          break;
+        case AnimationStatus.dismissed:
+        case AnimationStatus.completed:
+          // nothing to do
+          break;
+      }
+    }
+  }
+
+  @override
+  void detach() {
+    _positionController?.stop();
+    _reactionController?.stop();
+    super.detach();
+  }
+
   void _handlePositionStateChanged(AnimationStatus status) {
     if (isInteractive) {
       if (status == AnimationStatus.completed && !_value)

--- a/packages/flutter/lib/src/scheduler/ticker.dart
+++ b/packages/flutter/lib/src/scheduler/ticker.dart
@@ -69,12 +69,12 @@ class Ticker {
 
     // The onTick callback may have scheduled another tick already.
     if (isTicking && _animationId == null)
-      _scheduleTick();
+      _scheduleTick(rescheduling: true);
   }
 
-  void _scheduleTick() {
+  void _scheduleTick({ bool rescheduling: false }) {
     assert(isTicking);
     assert(_animationId == null);
-    _animationId = Scheduler.instance.scheduleFrameCallback(_tick);
+    _animationId = Scheduler.instance.scheduleFrameCallback(_tick, rescheduling: rescheduling);
   }
 }

--- a/travis/test.sh
+++ b/travis/test.sh
@@ -14,4 +14,8 @@ flutter analyze --flutter-repo --no-current-directory --no-current-package --con
 (cd packages/flx; dart -c test/all.dart)
 (cd packages/newton; dart -c test/all.dart)
 
+(cd dev/manual_tests; flutter test)
+(cd examples/hello_world; flutter test)
+(cd examples/layers; flutter test)
+(cd examples/material_gallery; flutter test)
 (cd examples/stocks; flutter test)


### PR DESCRIPTION
...by adding tests to our examples that don't import flutter_test, which
pins the relevant dependencies.

Also, provide more information when complaining about leaked transient
callbacks in tests.

Also, make tests display full information when they have an exception,
by bypassing the throttling we have for Android logging in tests.

Also, make the word wrapping not wrap stack traces if they happen to
be included in exception output.

Also, fix a leaked transient callback in the checkbox code.
