### PR TITLE
[driver] output per-frame build times in the timeline summary

### DIFF
--- a/packages/flutter_driver/lib/src/timeline_summary.dart
+++ b/packages/flutter_driver/lib/src/timeline_summary.dart
@@ -57,6 +57,9 @@ class TimelineSummary {
       'average_frame_build_time_millis': computeAverageFrameBuildTimeMillis(),
       'missed_frame_build_budget_count': computeMissedFrameBuildBudgetCount(),
       'frame_count': countFrames(),
+      'frame_build_times': _extractBeginFrameEvents()
+        .map((TimedEvent event) => event.duration.inMicroseconds)
+        .toList()
     };
   }
 

--- a/packages/flutter_driver/test/src/timeline_summary_test.dart
+++ b/packages/flutter_driver/test/src/timeline_summary_test.dart
@@ -98,6 +98,7 @@ void main() {
             'average_frame_build_time_millis': 7.0,
             'missed_frame_build_budget_count': 2,
             'frame_count': 3,
+            'frame_build_times': <int>[9000, 1000, 11000],
           }
         );
       });
@@ -132,6 +133,7 @@ void main() {
           'average_frame_build_time_millis': 7.0,
           'missed_frame_build_budget_count': 2,
           'frame_count': 3,
+          'frame_build_times': <int>[9000, 1000, 11000],
         });
       });
     });


### PR DESCRIPTION
This will give us data to draw frame build chart, like this:

<img width="262" alt="screen shot 2016-04-14 at 10 32 17 am" src="https://cloud.githubusercontent.com/assets/211513/14537552/4d7ccd84-022c-11e6-802e-17d8488e9c11.png">

@sethladd 
