### PR TITLE
Use the same logic in flushPaint as flushLayout

### DIFF
--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -742,7 +742,7 @@ class PipelineOwner {
     Timeline.startSync('Compositing Bits');
     _nodesNeedingCompositingBitsUpdate.sort((RenderObject a, RenderObject b) => a.depth - b.depth);
     for (RenderObject node in _nodesNeedingCompositingBitsUpdate) {
-      if (node.owner == this)
+      if (node._needsCompositingBitsUpdate && node.owner == this)
         node._updateCompositingBits();
     }
     _nodesNeedingCompositingBitsUpdate.clear();
@@ -767,8 +767,7 @@ class PipelineOwner {
       _nodesNeedingPaint = <RenderObject>[];
       // Sort the dirty nodes in reverse order (deepest first).
       for (RenderObject node in dirtyNodes..sort((RenderObject a, RenderObject b) => b.depth - a.depth)) {
-        assert(node._needsPaint);
-        if (node.owner == this)
+        if (node._needsPaint && node.owner == this)
           PaintingContext.repaintCompositedChild(node);
       };
       assert(_nodesNeedingPaint.length == 0);

--- a/packages/flutter/test/rendering/repaint_boundary_test.dart
+++ b/packages/flutter/test/rendering/repaint_boundary_test.dart
@@ -1,0 +1,37 @@
+// Copyright 2015 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/rendering.dart';
+import 'package:test/test.dart';
+
+import 'rendering_tester.dart';
+
+void main() {
+  test("nested repaint boundaries - smoke test", () {
+    RenderOpacity a, b, c;
+    a = new RenderOpacity(
+      opacity: 1.0,
+      child: new RenderRepaintBoundary(
+        child: b = new RenderOpacity(
+          opacity: 1.0,
+          child: new RenderRepaintBoundary(
+            child: c = new RenderOpacity(
+              opacity: 1.0
+            )
+          )
+        )
+      )
+    );
+    layout(a, phase: EnginePhase.flushSemantics);
+    c.opacity = 0.9;
+    layout(a, phase: EnginePhase.flushSemantics);
+    a.opacity = 0.8;
+    c.opacity = 0.8;
+    layout(a, phase: EnginePhase.flushSemantics);
+    a.opacity = 0.7;
+    b.opacity = 0.7;
+    c.opacity = 0.7;
+    layout(a, phase: EnginePhase.flushSemantics);
+  });
+}


### PR DESCRIPTION
If two repaint boundaries mark themselves dirty, but the second one is a
child of the first, then the second one will get repainted by the first
and then when we come to paint it directly, we get confused because it
isn't dirty any more.

We ran into this in layout before. Apply the same fix. Also, apply the
same fix to composition while we're at it.

Fixes https://github.com/flutter/flutter/issues/3283
