### PR TITLE
Make update-packages cover dev/benchmarks.

### DIFF
--- a/packages/flutter_tools/lib/src/commands/update_packages.dart
+++ b/packages/flutter_tools/lib/src/commands/update_packages.dart
@@ -55,6 +55,7 @@ class UpdatePackagesCommand extends FlutterCommand {
       count += await _runPub(new Directory("${ArtifactStore.flutterRoot}/packages"), upgrade: upgrade);
       count += await _runPub(new Directory("${ArtifactStore.flutterRoot}/examples"), upgrade: upgrade);
       count += await _runPub(new Directory("${ArtifactStore.flutterRoot}/dev"), upgrade: upgrade);
+      count += await _runPub(new Directory("${ArtifactStore.flutterRoot}/dev/benchmarks"), upgrade: upgrade);
 
       double seconds = timer.elapsedMilliseconds / 1000.0;
       printStatus('\nRan \'pub\' $count time${count == 1 ? "" : "s"} in ${seconds.toStringAsFixed(1)}s.');


### PR DESCRIPTION
update-packages only looks one level down, instead of
changing that, I'm just adding dev/benchmarks explicitly.

This will unbreak the bots which are dying trying to
flutter drive dev/benchmarks/complex_layout without
pub get having been run there.

@yjbanov @devoncarew
