### PR TITLE
Add a Performance Overlay toggle to the Gallery app

### DIFF
--- a/examples/material_gallery/lib/gallery/app.dart
+++ b/examples/material_gallery/lib/gallery/app.dart
@@ -16,16 +16,20 @@ class GalleryApp extends StatefulWidget {
 
 class GalleryAppState extends State<GalleryApp> {
   bool _useLightTheme = true;
+  bool _showPerformanceOverlay = false;
 
   @override
   Widget build(BuildContext context) {
     return new MaterialApp(
       title: 'Flutter Material Gallery',
       theme: _useLightTheme ? _kGalleryLightTheme : _kGalleryDarkTheme,
+      showPerformanceOverlay: _showPerformanceOverlay,
       routes: {
         '/': (BuildContext context) => new GalleryHome(
-          theme: _useLightTheme,
+          useLightTheme: _useLightTheme,
           onThemeChanged: (bool value) { setState(() { _useLightTheme = value; }); },
+          showPerformanceOverlay: _showPerformanceOverlay,
+          onShowPerformanceOverlayChanged: (bool value) { setState(() { _showPerformanceOverlay = value; }); },
           timeDilation: timeDilation,
           onTimeDilationChanged: (double value) { setState(() { timeDilation = value; }); }
         )

--- a/examples/material_gallery/lib/gallery/drawer.dart
+++ b/examples/material_gallery/lib/gallery/drawer.dart
@@ -7,20 +7,25 @@ import 'package:flutter/material.dart';
 class GalleryDrawer extends StatelessWidget {
   GalleryDrawer({
     Key key,
-    this.theme,
+    this.useLightTheme,
     this.onThemeChanged,
     this.timeDilation,
-    this.onTimeDilationChanged
+    this.onTimeDilationChanged,
+    this.showPerformanceOverlay,
+    this.onShowPerformanceOverlayChanged
   }) : super(key: key) {
     assert(onThemeChanged != null);
     assert(onTimeDilationChanged != null);
   }
 
-  final bool theme;
+  final bool useLightTheme;
   final ValueChanged<bool> onThemeChanged;
 
   final double timeDilation;
   final ValueChanged<double> onTimeDilationChanged;
+
+  final bool showPerformanceOverlay;
+  final ValueChanged<bool> onShowPerformanceOverlayChanged;
 
   @override
   Widget build(BuildContext context) {
@@ -31,13 +36,13 @@ class GalleryDrawer extends StatelessWidget {
           new DrawerItem(
             icon: Icons.brightness_5,
             onPressed: () { onThemeChanged(true); },
-            selected: theme,
+            selected: useLightTheme,
             child: new Row(
               children: <Widget>[
                 new Flexible(child: new Text('Light')),
                 new Radio<bool>(
                   value: true,
-                  groupValue: theme,
+                  groupValue: useLightTheme,
                   onChanged: onThemeChanged
                 )
               ]
@@ -46,13 +51,13 @@ class GalleryDrawer extends StatelessWidget {
           new DrawerItem(
             icon: Icons.brightness_7,
             onPressed: () { onThemeChanged(false); },
-            selected: theme,
+            selected: useLightTheme,
             child: new Row(
               children: <Widget>[
                 new Flexible(child: new Text('Dark')),
                 new Radio<bool>(
                   value: false,
-                  groupValue: theme,
+                  groupValue: useLightTheme,
                   onChanged: onThemeChanged
                 )
               ]
@@ -72,7 +77,21 @@ class GalleryDrawer extends StatelessWidget {
                 )
               ]
             )
-          )
+          ),
+          new DrawerItem(
+            icon: Icons.assessment,
+            onPressed: () { onShowPerformanceOverlayChanged(!showPerformanceOverlay); },
+            selected: showPerformanceOverlay,
+            child: new Row(
+              children: <Widget>[
+                new Flexible(child: new Text('Performance Overlay')),
+                new Checkbox(
+                  value: showPerformanceOverlay,
+                  onChanged: (bool value) { onShowPerformanceOverlayChanged(!showPerformanceOverlay); }
+                )
+              ]
+            )
+          ),
         ]
       )
     );

--- a/examples/material_gallery/lib/gallery/home.dart
+++ b/examples/material_gallery/lib/gallery/home.dart
@@ -46,20 +46,26 @@ const double _kFlexibleSpaceMaxHeight = 256.0;
 class GalleryHome extends StatefulWidget {
   GalleryHome({
     Key key,
-    this.theme,
+    this.useLightTheme,
     this.onThemeChanged,
     this.timeDilation,
-    this.onTimeDilationChanged
+    this.onTimeDilationChanged,
+    this.showPerformanceOverlay,
+    this.onShowPerformanceOverlayChanged
   }) : super(key: key) {
     assert(onThemeChanged != null);
     assert(onTimeDilationChanged != null);
+    assert(onShowPerformanceOverlayChanged != null);
   }
 
-  final bool theme;
+  final bool useLightTheme;
   final ValueChanged<bool> onThemeChanged;
 
   final double timeDilation;
   final ValueChanged<double> onTimeDilationChanged;
+
+  final bool showPerformanceOverlay;
+  final ValueChanged<bool> onShowPerformanceOverlayChanged;
 
   @override
   GalleryHomeState createState() => new GalleryHomeState();
@@ -76,10 +82,12 @@ class GalleryHomeState extends State<GalleryHome> {
     return new Scaffold(
       key: _homeKey,
       drawer: new GalleryDrawer(
-        theme: config.theme,
+        useLightTheme: config.useLightTheme,
         onThemeChanged: config.onThemeChanged,
         timeDilation: config.timeDilation,
-        onTimeDilationChanged: config.onTimeDilationChanged
+        onTimeDilationChanged: config.onTimeDilationChanged,
+        showPerformanceOverlay: config.showPerformanceOverlay,
+        onShowPerformanceOverlayChanged: config.onShowPerformanceOverlayChanged
       ),
       appBar: new AppBar(
         expandedHeight: _kFlexibleSpaceMaxHeight,


### PR DESCRIPTION
It's not clear to me that we want to keep this option.  But for the
short term I think it's useful to have in the Gallery to make
performance testing much easier.

I also changed "theme" to "useLightTheme" to better match the
boolean option it was (as opposed to a theme object or enum).

I have a separate branch in progress to make this togglable in all apps
from Atom:
https://github.com/flutter/flutter/compare/master...eseidelGoogle:overlay_atom

@HansMuller @Hixie 
