### PR TITLE
[driver] "waitFor" command in place of broken "exists"

### DIFF
--- a/packages/flutter_driver/lib/src/extension.dart
+++ b/packages/flutter_driver/lib/src/extension.dart
@@ -59,6 +59,7 @@ class FlutterDriverExtension {
       'tap': tap,
       'get_text': getText,
       'scroll': scroll,
+      'waitFor': waitFor,
     };
 
     _commandDeserializers = <String, CommandDeserializerCallback>{
@@ -66,6 +67,7 @@ class FlutterDriverExtension {
       'tap': Tap.deserialize,
       'get_text': GetText.deserialize,
       'scroll': Scroll.deserialize,
+      'waitFor': WaitFor.deserialize,
     };
 
     _finders = <String, FinderCallback>{
@@ -168,6 +170,13 @@ class FlutterDriverExtension {
     Element target = await _runFinder(command.finder);
     prober.tap(target);
     return new TapResult();
+  }
+
+  Future<WaitForResult> waitFor(WaitFor command) async {
+    if (await _runFinder(command.finder) != null)
+      return new WaitForResult();
+    else
+      return null;
   }
 
   Future<ScrollResult> scroll(Scroll command) async {

--- a/packages/flutter_driver/lib/src/extension.dart
+++ b/packages/flutter_driver/lib/src/extension.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:developer';
 import 'package:flutter/material.dart';
+import 'package:flutter/scheduler.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter_test/src/instrumentation.dart';
@@ -16,11 +17,9 @@ import 'find.dart';
 import 'gesture.dart';
 import 'health.dart';
 import 'message.dart';
-import 'retry.dart';
 
 const String _extensionMethod = 'ext.flutter_driver';
 const Duration _kDefaultTimeout = const Duration(seconds: 5);
-const Duration _kDefaultPauseBetweenRetries = const Duration(milliseconds: 160);
 
 bool _flutterDriverExtensionEnabled = false;
 
@@ -54,34 +53,33 @@ class FlutterDriverExtension {
   static final Logger _log = new Logger('FlutterDriverExtension');
 
   FlutterDriverExtension() {
-    _commandHandlers = <String, CommandHandlerCallback>{
+    _commandHandlers.addAll(<String, CommandHandlerCallback>{
       'get_health': getHealth,
       'tap': tap,
       'get_text': getText,
       'scroll': scroll,
       'waitFor': waitFor,
-    };
+    });
 
-    _commandDeserializers = <String, CommandDeserializerCallback>{
+    _commandDeserializers.addAll(<String, CommandDeserializerCallback>{
       'get_health': GetHealth.deserialize,
       'tap': Tap.deserialize,
       'get_text': GetText.deserialize,
       'scroll': Scroll.deserialize,
       'waitFor': WaitFor.deserialize,
-    };
+    });
 
-    _finders = <String, FinderCallback>{
+    _finders.addAll(<String, FinderCallback>{
       'ByValueKey': _findByValueKey,
       'ByTooltipMessage': _findByTooltipMessage,
       'ByText': _findByText,
-    };
+    });
   }
 
   final Instrumentation prober = new Instrumentation();
-
-  Map<String, CommandHandlerCallback> _commandHandlers;
-  Map<String, CommandDeserializerCallback> _commandDeserializers;
-  Map<String, FinderCallback> _finders;
+  final Map<String, CommandHandlerCallback> _commandHandlers = <String, CommandHandlerCallback>{};
+  final Map<String, CommandDeserializerCallback> _commandDeserializers = <String, CommandDeserializerCallback>{};
+  final Map<String, FinderCallback> _finders = <String, FinderCallback>{};
 
   Future<ServiceExtensionResponse> call(Map<String, String> params) async {
     try {
@@ -112,16 +110,42 @@ class FlutterDriverExtension {
     }
   }
 
+  Stream<Duration> _onFrameReadyStream;
+  Stream<Duration> get _onFrameReady {
+    if (_onFrameReadyStream == null) {
+      // Lazy-initialize the frame callback because the renderer is not yet
+      // available at the time the extension is registered.
+      StreamController<Duration> frameReadyController = new StreamController<Duration>.broadcast(sync: true);
+      Scheduler.instance.addPersistentFrameCallback((Duration timestamp) {
+        frameReadyController.add(timestamp);
+      });
+      _onFrameReadyStream = frameReadyController.stream;
+    }
+    return _onFrameReadyStream;
+  }
+
   Future<Health> getHealth(GetHealth command) async => new Health(HealthStatus.ok);
 
-  /// Runs object [finder] repeatedly until it finds an [Element].
+  /// Runs [locator] repeatedly until it finds an [Element] or times out.
   Future<Element> _waitForElement(String descriptionGetter(), Element locator()) {
-    return retry(locator, _kDefaultTimeout, _kDefaultPauseBetweenRetries, predicate: (dynamic object) {
-      return object != null;
-    }).catchError((Object error, Object stackTrace) {
-      _log.warning('Timed out waiting for ${descriptionGetter()}');
-      return null;
+    Completer<Element> completer = new Completer<Element>();
+    StreamSubscription<Duration> subscription;
+
+    Timer timeout = new Timer(_kDefaultTimeout, () {
+      subscription.cancel();
+      completer.completeError('Timed out waiting for ${descriptionGetter()}');
     });
+
+    subscription = _onFrameReady.listen((Duration duration) {
+      Element element = locator();
+      if (element != null) {
+        subscription.cancel();
+        timeout.cancel();
+        completer.complete(element);
+      }
+    });
+
+    return completer.future;
   }
 
   Future<Element> _findByValueKey(ByValueKey byKey) async {

--- a/packages/flutter_driver/lib/src/find.dart
+++ b/packages/flutter_driver/lib/src/find.dart
@@ -37,35 +37,44 @@ abstract class CommandWithTarget extends Command {
   Map<String, String> serialize() => finder.serialize();
 }
 
-/// Checks if the widget identified by the given finder exists.
-class Exists extends CommandWithTarget {
+/// Waits until [finder] can locate the target.
+class WaitFor extends CommandWithTarget {
   @override
-  final String kind = 'exists';
+  final String kind = 'waitFor';
 
-  Exists(SerializableFinder finder) : super(finder);
+  WaitFor(SerializableFinder finder, {this.timeout})
+      : super(finder);
 
-  static Exists deserialize(Map<String, String> json) {
-    return new Exists(SerializableFinder.deserialize(json));
+  final Duration timeout;
+
+  static WaitFor deserialize(Map<String, String> json) {
+    Duration timeout = json['timeout'] != null
+      ? new Duration(milliseconds: int.parse(json['timeout']))
+      : null;
+    return new WaitFor(SerializableFinder.deserialize(json), timeout: timeout);
   }
 
   @override
-  Map<String, String> serialize() => super.serialize();
+  Map<String, String> serialize() {
+    Map<String, String> json = super.serialize();
+
+    if (timeout != null) {
+      json['timeout'] = '${timeout.inMilliseconds}';
+    }
+
+    return json;
+  }
 }
 
-class ExistsResult extends Result {
-  ExistsResult(this.exists);
+class WaitForResult extends Result {
+  WaitForResult();
 
-  static ExistsResult fromJson(Map<String, dynamic> json) {
-    return new ExistsResult(json['exists']);
+  static WaitForResult fromJson(Map<String, dynamic> json) {
+    return new WaitForResult();
   }
 
-  /// Whether the widget was found on the UI or not.
-  final bool exists;
-
   @override
-  Map<String, dynamic> toJson() => {
-    'exists': exists,
-  };
+  Map<String, dynamic> toJson() => <String, dynamic>{};
 }
 
 /// Describes how to the driver should search for elements.

--- a/packages/flutter_driver/test/flutter_driver_test.dart
+++ b/packages/flutter_driver/test/flutter_driver_test.dart
@@ -10,7 +10,6 @@ import 'package:flutter_driver/src/health.dart';
 import 'package:flutter_driver/src/timeline.dart';
 import 'package:json_rpc_2/json_rpc_2.dart' as rpc;
 import 'package:mockito/mockito.dart';
-import 'package:quiver/testing/async.dart';
 import 'package:test/test.dart';
 import 'package:vm_service_client/vm_service_client.dart';
 
@@ -180,54 +179,21 @@ void main() {
     });
 
     group('waitFor', () {
-      test('waits for a condition', () {
-        expect(
-          driver.waitFor(() {
-            return new Future<int>.delayed(
-              new Duration(milliseconds: 50),
-              () => 123
-            );
-          }, equals(123)),
-          completion(123)
-        );
+      test('requires a target reference', () async {
+        expect(driver.waitFor(null), throwsA(new isInstanceOf<DriverError>()));
       });
 
-      test('retries a correct number of times', () {
-        new FakeAsync().run((FakeAsync fakeAsync) {
-          int retryCount = 0;
-
-          expect(
-            driver.waitFor(
-              () {
-                retryCount++;
-                return retryCount;
-              },
-              equals(2),
-              timeout: new Duration(milliseconds: 30),
-              pauseBetweenRetries: new Duration(milliseconds: 10)
-            ),
-            completion(2)
-          );
-
-          fakeAsync.elapse(new Duration(milliseconds: 50));
-
-          // Check that we didn't retry more times than necessary
-          expect(retryCount, 2);
+      test('sends the waitFor command', () async {
+        when(mockIsolate.invokeExtension(any, any)).thenAnswer((Invocation i) {
+          expect(i.positionalArguments[1], <String, dynamic>{
+            'command': 'waitFor',
+            'finderType': 'ByTooltipMessage',
+            'text': 'foo',
+            'timeout': '1000',
+          });
+          return new Future<Map<String, dynamic>>.value({});
         });
-      });
-
-      test('times out', () async {
-        bool timedOut = false;
-        await driver.waitFor(
-          () => 1,
-          equals(2),
-          timeout: new Duration(milliseconds: 10),
-          pauseBetweenRetries: new Duration(milliseconds: 2)
-        ).catchError((dynamic err, dynamic stack) {
-          timedOut = true;
-        });
-
-        expect(timedOut, isTrue);
+        await driver.waitFor(find.byTooltip('foo'), timeout: new Duration(seconds: 1));
       });
     });
 

--- a/packages/flutter_tools/templates/driver/main_test.dart.tmpl
+++ b/packages/flutter_tools/templates/driver/main_test.dart.tmpl
@@ -22,15 +22,17 @@ void main() {
     });
 
     test('tap on the floating action button; verify counter', () async {
-      // Find floating action button (fab) to tap on
+      // Finds the floating action button (fab) to tap on
       SerializableFinder fab = find.byTooltip('Increment');
-      expect(await driver.exists(fab), isTrue);
+
+      // Wait for the floating action button to appear
+      await driver.waitFor(fab);
 
       // Tap on the fab
       await driver.tap(fab);
 
       // Wait for text to change to the desired value
-      expect(await driver.exists(find.text('Button tapped 1 time.')), isTrue);
+      await driver.waitFor(find.text('Button tapped 1 time.'));
     });
   });
 }


### PR DESCRIPTION
- Replace the driver-side polling "waitFor" method with one executed on the extension side
- Delete the half-implemented "Exists" command (currently breaks the `sample_app` integration test)
