### PR TITLE
Analyze CLI option to specify a custom Dart SDK.

### DIFF
--- a/packages/flutter_tools/lib/src/base/process.dart
+++ b/packages/flutter_tools/lib/src/base/process.dart
@@ -92,9 +92,10 @@ String runSync(List<String> cmd, { String workingDirectory }) {
 }
 
 /// Return the platform specific name for the given Dart SDK binary. So, `pub`
-/// ==> `pub.bat`.
-String sdkBinaryName(String name) {
-  return path.absolute(path.join(dartSdkPath, 'bin', Platform.isWindows ? '$name.bat' : name));
+/// ==> `pub.bat`.  The default SDK location can be overridden with a specified
+/// [sdkLocation].
+String sdkBinaryName(String name, {String sdkLocation}) {
+  return path.absolute(path.join(sdkLocation ?? dartSdkPath, 'bin', Platform.isWindows ? '$name.bat' : name));
 }
 
 bool exitsHappy(List<String> cli) {

--- a/packages/flutter_tools/lib/src/base/process.dart
+++ b/packages/flutter_tools/lib/src/base/process.dart
@@ -94,7 +94,7 @@ String runSync(List<String> cmd, { String workingDirectory }) {
 /// Return the platform specific name for the given Dart SDK binary. So, `pub`
 /// ==> `pub.bat`.  The default SDK location can be overridden with a specified
 /// [sdkLocation].
-String sdkBinaryName(String name, {String sdkLocation}) {
+String sdkBinaryName(String name, { String sdkLocation }) {
   return path.absolute(path.join(sdkLocation ?? dartSdkPath, 'bin', Platform.isWindows ? '$name.bat' : name));
 }
 

--- a/packages/flutter_tools/lib/src/commands/analyze.dart
+++ b/packages/flutter_tools/lib/src/commands/analyze.dart
@@ -100,6 +100,8 @@ class AnalyzeCommand extends FlutterCommand {
     argParser.addFlag('preamble', help: 'Display the number of files that will be analyzed.', defaultsTo: true);
     argParser.addFlag('congratulate', help: 'Show output even when there are no errors, warnings, hints, or lints.', defaultsTo: true);
     argParser.addFlag('watch', help: 'Run analysis continuously, watching the filesystem for changes.', negatable: false);
+    argParser.addOption('dart-sdk', help: 'The path to the Dart SDK.', hide: true);
+
     usesPubOption();
   }
 
@@ -293,7 +295,7 @@ class AnalyzeCommand extends FlutterCommand {
     File packagesFile = new File(path.join(host.path, '.packages'))..writeAsStringSync(packagesBody.toString());
 
     List<String> cmd = <String>[
-      sdkBinaryName('dartanalyzer'),
+      sdkBinaryName('dartanalyzer', sdkLocation: argResults['dart-sdk']),
       // do not set '--warnings', since that will include the entire Dart SDK
       '--ignore-unrecognized-flags',
       '--enable_type_checks',


### PR DESCRIPTION
Handy for testing against specific local SDK builds.

(Note that the option is hidden.)
