### PR TITLE
add a temporary .analysis_options for flutter_tools

### DIFF
--- a/packages/flutter_tools/.analysis_options
+++ b/packages/flutter_tools/.analysis_options
@@ -1,0 +1,18 @@
+# A temporary file to do some validation in the flutter_tools project. This will
+# go away once we unify `flutter analyze` and analysis server based products.
+
+analyzer:
+  language:
+    enableStrictCallChecks: true
+    enableSuperMixins: true
+  errors:
+    todo: ignore
+linter:
+  rules:
+    - avoid_empty_else
+    - always_declare_return_types
+    - always_specify_types
+    - annotate_overrides
+    - sort_unnamed_constructors_first
+    - unnecessary_brace_in_string_interp
+    - unnecessary_getters_setters


### PR DESCRIPTION
Add a temporary .analysis_options for flutter_tools - this will help me not break travis. `flutter_analysis_options` will remain the system of record. We can delete this file once flutter analyze and analysis server based products are better unified.

@Hixie @pq
