### PR TITLE
rename the --release and --debug flags

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,7 +86,7 @@ Flutter tests use [package:flutter_test](https://github.com/flutter/flutter/tree
 `flutter test --flutter-repo` is a shortcut for those working on the flutter repository itself which runs all tests inside the `flutter` package regardless of the current working directory.
 To run all the tests for the entire Flutter repository, the same way that Travis runs them, run `travis/test.sh`.
 
-If you've built [your own flutter engine](#working-on-the-engine-and-the-framework-at-the-same-time), you can pass `--debug` or `--release` to change what flutter shell `flutter test` uses.
+If you've built [your own flutter engine](#working-on-the-engine-and-the-framework-at-the-same-time), you can pass `--engine-debug` or `--engine-release` to change what flutter shell `flutter test` uses.
 To do this with the `travis/test.sh` script, you can use the `FLUTTER_ENGINE` environment variable.
 
 Note: Flutter tests are headless, you won't see any UI. You can use
@@ -166,14 +166,14 @@ the following steps.
    configurations (e.g., `out/android_Debug`).
 
 You should now be able to run the tests against your locally built
-engine using the `flutter test --debug` command. To run one of the
+engine using the `flutter test --engine-debug` command. To run one of the
 examples on your device using your locally built engine, use the
-`--debug` option to the `flutter` tool:
+`--engine-debug` option to the `flutter` tool:
 
- * `flutter run --debug`
+ * `flutter run --engine-debug`
 
 If you want to test the release version instead of the debug version,
-use `--release` instead of `--debug`.
+use `--engine-release` instead of `--engine-debug`.
 
 Making a breaking change to the engine
 --------------------------------------

--- a/packages/flutter_tools/lib/src/commands/test.dart
+++ b/packages/flutter_tools/lib/src/commands/test.dart
@@ -138,7 +138,7 @@ class TestCommand extends FlutterCommand {
         return exitCode;
     }
     if (!foundOne) {
-      printError('At least one of --debug or --release must be set, to specify the local build products to test.');
+      printError('At least one of --engine-debug or --engine-release must be set, to specify the local build products to test.');
       return 1;
     }
 

--- a/packages/flutter_tools/lib/src/runner/flutter_command_runner.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command_runner.dart
@@ -61,18 +61,18 @@ class FlutterCommandRunner extends CommandRunner {
     if (verboseHelp)
       argParser.addSeparator('Local build selection options (not normally required):');
 
-    argParser.addFlag('debug',
+    argParser.addFlag('engine-debug',
         negatable: false,
         hide: !verboseHelp,
         help:
             'Set this if you are building Flutter locally and want to use the debug build products.\n'
-            'Defaults to true if --engine-src-path is specified and --release is not, otherwise false.');
-    argParser.addFlag('release',
+            'Defaults to true if --engine-src-path is specified and --engine-release is not, otherwise false.');
+    argParser.addFlag('engine-release',
         negatable: false,
         hide: !verboseHelp,
         help:
             'Set this if you are building Flutter locally and want to use the release build products.\n'
-            'The --release option is not compatible with the listen command on iOS devices and simulators.');
+            'The --engine-release option is not compatible with the listen command on iOS devices and simulators.');
     argParser.addOption('engine-src-path',
         hide: !verboseHelp,
         help:
@@ -216,10 +216,10 @@ class FlutterCommandRunner extends CommandRunner {
     if (enginePath != null) {
       ToolConfiguration.instance.engineSrcPath = enginePath;
 
-      if (globalResults.wasParsed('release'))
-        ToolConfiguration.instance.release = globalResults['release'];
-      if (globalResults.wasParsed('debug'))
-        ToolConfiguration.instance.release = !globalResults['debug'];
+      if (globalResults.wasParsed('engine-release'))
+        ToolConfiguration.instance.engineRelease = globalResults['engine-release'];
+      if (globalResults.wasParsed('engine-debug'))
+        ToolConfiguration.instance.engineRelease = !globalResults['engine-debug'];
     }
 
     // The Android SDK could already have been set by tests.
@@ -247,8 +247,8 @@ class FlutterCommandRunner extends CommandRunner {
 
   String _findEnginePath(ArgResults globalResults) {
     String engineSourcePath = globalResults['engine-src-path'] ?? Platform.environment[kFlutterEngineEnvironmentVariableName];
-    bool isDebug = globalResults['debug'];
-    bool isRelease = globalResults['release'];
+    bool isDebug = globalResults['engine-debug'];
+    bool isRelease = globalResults['engine-release'];
 
     if (engineSourcePath == null && (isDebug || isRelease)) {
       try {
@@ -282,8 +282,8 @@ class FlutterCommandRunner extends CommandRunner {
   }
 
   List<BuildConfiguration> _createBuildConfigurations(ArgResults globalResults) {
-    bool isDebug = globalResults['debug'];
-    bool isRelease = globalResults['release'];
+    bool isDebug = globalResults['engine-debug'];
+    bool isRelease = globalResults['engine-release'];
     HostPlatform hostPlatform = getCurrentHostPlatform();
     TargetPlatform hostPlatformAsTarget = getCurrentHostPlatformAsTarget();
 

--- a/packages/flutter_tools/lib/src/toolchain.dart
+++ b/packages/flutter_tools/lib/src/toolchain.dart
@@ -93,14 +93,14 @@ class ToolConfiguration {
   String engineSrcPath;
 
   /// The engine mode to use (only relevent when [engineSrcPath] is set).
-  bool release;
+  bool engineRelease;
 
   /// Used to override the directory calculated from engineSrcPath (--engine-out-dir).
   String engineOutDir;
 
   bool get isLocalEngine => engineSrcPath != null || engineOutDir != null;
 
-  String get _modeStr => release ? 'Release' : 'Debug';
+  String get _modeStr => engineRelease ? 'Release' : 'Debug';
 
   /// The directory that contains development tools for the given platform. This
   /// includes things like `sky_shell` and `sky_snapshot`.

--- a/packages/flutter_tools/test/toolchain_test.dart
+++ b/packages/flutter_tools/test/toolchain_test.dart
@@ -45,7 +45,7 @@ void main() {
     testUsingContext('using enginePath', () {
       ToolConfiguration toolConfig = new ToolConfiguration();
       toolConfig.engineSrcPath = 'engine';
-      toolConfig.release = true;
+      toolConfig.engineRelease = true;
 
       expect(
         toolConfig.getToolsDirectory(platform: HostPlatform.linux_x64).path,
@@ -56,7 +56,7 @@ void main() {
         'engine/out/android_Release'
       );
 
-      toolConfig.release = false;
+      toolConfig.engineRelease = false;
       expect(
         toolConfig.getToolsDirectory(platform: HostPlatform.linux_x64).path,
         'engine/out/Debug'


### PR DESCRIPTION
- rename the `--release` flag to `--engine-release`
- rename the `--debug` flag to `--engine-debug`

This will give us some flexibility in renaming `develop`, `profile`, and `deploy` (possibly to something like `debug`, `profile`, and `release`).
