### PR TITLE
Remove Scaffold scrollableKey use in gallery demos

### DIFF
--- a/examples/material_gallery/lib/demo/flexible_space_demo.dart
+++ b/examples/material_gallery/lib/demo/flexible_space_demo.dart
@@ -77,7 +77,6 @@ class FlexibleSpaceDemo extends StatefulWidget {
 class FlexibleSpaceDemoState extends State<FlexibleSpaceDemo> {
   final GlobalKey<ScaffoldState> _scaffoldKey = new GlobalKey<ScaffoldState>();
   final double _appBarHeight = 256.0;
-  final Key _scrollableKey = new UniqueKey();
   AppBarBehavior _appBarBehavior = AppBarBehavior.scroll;
 
   @override
@@ -90,7 +89,6 @@ class FlexibleSpaceDemoState extends State<FlexibleSpaceDemo> {
       ),
       child: new Scaffold(
         key: _scaffoldKey,
-        scrollableKey: _scrollableKey,
         appBarBehavior: _appBarBehavior,
         appBar: new AppBar(
           expandedHeight: _appBarHeight,
@@ -132,7 +130,6 @@ class FlexibleSpaceDemoState extends State<FlexibleSpaceDemo> {
           )
         ),
         body: new Block(
-          scrollableKey: _scrollableKey,
           padding: new EdgeInsets.only(top: _appBarHeight + statusBarHeight),
           children: <Widget>[
             new _ContactCategory(

--- a/examples/material_gallery/lib/demo/tabs_demo.dart
+++ b/examples/material_gallery/lib/demo/tabs_demo.dart
@@ -45,7 +45,6 @@ class TabsDemoState extends State<TabsDemo> {
         });
       },
       child: new Scaffold(
-        scrollableKey: _selectedPage.key,
         appBarBehavior: AppBarBehavior.under,
         appBar: new AppBar(
           title: new Text('Tabs and scrolling'),

--- a/examples/material_gallery/lib/gallery/home.dart
+++ b/examples/material_gallery/lib/gallery/home.dart
@@ -75,7 +75,6 @@ class GalleryHome extends StatefulWidget {
 
 class GalleryHomeState extends State<GalleryHome> {
   final Key _homeKey = new ValueKey<String>("Gallery Home");
-  final Key _listKey = new ValueKey<String>("Gallery List");
 
   @override
   Widget build(BuildContext context) {
@@ -98,12 +97,10 @@ class GalleryHomeState extends State<GalleryHome> {
           background: new GalleryHeader()
         )
       ),
-      scrollableKey: _listKey,
       appBarBehavior: AppBarBehavior.under,
       body: new TwoLevelList(
         padding: new EdgeInsets.only(top: _kFlexibleSpaceMaxHeight + statusBarHight),
         type: MaterialListType.oneLine,
-        scrollableKey: _listKey,
         children: <Widget>[
           new TwoLevelSublist(
             leading: new Icon(icon: Icons.star),

--- a/packages/flutter/lib/src/material/scaffold.dart
+++ b/packages/flutter/lib/src/material/scaffold.dart
@@ -490,7 +490,7 @@ class ScaffoldState extends State<Scaffold> {
     final ScrollableState scrollable = notification.scrollable;
     if ((scrollable.config.scrollDirection == Axis.vertical) &&
         (config.scrollableKey == null || config.scrollableKey == scrollable.config.key)) {
-      final double newScrollOffset = notification.scrollable.scrollOffset;
+      final double newScrollOffset = scrollable.scrollOffset;
       setState(() {
         _scrollOffsetDelta = _scrollOffset - newScrollOffset;
         _scrollOffset = newScrollOffset;

--- a/packages/flutter/lib/src/material/scaffold.dart
+++ b/packages/flutter/lib/src/material/scaffold.dart
@@ -487,7 +487,9 @@ class ScaffoldState extends State<Scaffold> {
   double _floatingAppBarHeight = 0.0;
 
   bool _handleScrollNotification(ScrollNotification notification) {
-    if (config.scrollableKey == null || config.scrollableKey == notification.scrollable.config.key) {
+    final ScrollableState scrollable = notification.scrollable;
+    if ((scrollable.config.scrollDirection == Axis.vertical) &&
+        (config.scrollableKey == null || config.scrollableKey == scrollable.config.key)) {
       final double newScrollOffset = notification.scrollable.scrollOffset;
       setState(() {
         _scrollOffsetDelta = _scrollOffset - newScrollOffset;


### PR DESCRIPTION
Obviated the need for this feature in the gallery demos - app bar animations now only occur on vertical scrolls.
