### PR TITLE
Make rootBundle handle the no-mojo case.

### DIFF
--- a/packages/flutter/lib/src/services/asset_bundle.dart
+++ b/packages/flutter/lib/src/services/asset_bundle.dart
@@ -106,7 +106,7 @@ class MojoAssetBundle extends CachingAssetBundle {
 AssetBundle _initRootBundle() {
   int h = ui.MojoServices.takeRootBundle();
   if (h == core.MojoHandle.INVALID)
-    return null;
+    return new NetworkAssetBundle(Uri.base);
   core.MojoHandle handle = new core.MojoHandle(h);
   return new MojoAssetBundle(new AssetBundleProxy.fromHandle(handle));
 }

--- a/packages/flutter/lib/src/widgets/app.dart
+++ b/packages/flutter/lib/src/widgets/app.dart
@@ -20,14 +20,6 @@ import 'performance_overlay.dart';
 import 'semantics_debugger.dart';
 import 'title.dart';
 
-AssetBundle _initDefaultBundle() {
-  if (rootBundle != null)
-    return rootBundle;
-  return new NetworkAssetBundle(Uri.base);
-}
-
-final AssetBundle _defaultBundle = _initDefaultBundle();
-
 typedef Future<LocaleQueryData> LocaleChangedCallback(Locale locale);
 
 /// A convenience class that wraps a number of widgets that are commonly
@@ -173,7 +165,7 @@ class WidgetsAppState<T extends WidgetsApp> extends State<T> implements BindingO
       child: new LocaleQuery(
         data: _localeData,
         child: new AssetVendor(
-          bundle: _defaultBundle,
+          bundle: rootBundle,
           devicePixelRatio: ui.window.devicePixelRatio,
           child: new Title(
             title: config.title,


### PR DESCRIPTION
The defaulting logic for bundles really belongs in the services layer,
not the widgets layer. This way we can tell non-widget code just to use
rootBundle if it just wants to read a JSON file or some such.
