### PR TITLE
Hide routes from the API when they're not needed.

### DIFF
--- a/dev/benchmarks/complex_layout/lib/main.dart
+++ b/dev/benchmarks/complex_layout/lib/main.dart
@@ -24,9 +24,7 @@ class ComplexLayoutAppState extends State<ComplexLayoutApp> {
     return new MaterialApp(
       theme: lightTheme ? new ThemeData.light() : new ThemeData.dark(),
       title: 'Advanced Layout',
-      routes: <String, WidgetBuilder>{
-        '/': (BuildContext context) => new ComplexLayout(),
-      }
+      home: new ComplexLayout()
     );
   }
 

--- a/dev/manual_tests/card_collection.dart
+++ b/dev/manual_tests/card_collection.dart
@@ -465,8 +465,6 @@ class CardCollectionState extends State<CardCollection> {
 void main() {
   runApp(new MaterialApp(
     title: 'Cards',
-    routes: <String, WidgetBuilder>{
-      '/': (BuildContext context) => new CardCollection(),
-    }
+    home: new CardCollection()
   ));
 }

--- a/dev/manual_tests/drag_and_drop.dart
+++ b/dev/manual_tests/drag_and_drop.dart
@@ -298,8 +298,6 @@ class DragAndDropAppState extends State<DragAndDropApp> {
 void main() {
   runApp(new MaterialApp(
     title: 'Drag and Drop Flutter Demo',
-    routes: <String, WidgetBuilder>{
-     '/': (BuildContext context) => new DragAndDropApp()
-    }
+    home: new DragAndDropApp()
   ));
 }

--- a/dev/manual_tests/mozart.dart
+++ b/dev/manual_tests/mozart.dart
@@ -249,6 +249,6 @@ class _WindowManagerState extends State<WindowManager> {
 void main() {
   runApp(new MaterialApp(
     title: 'Mozart',
-    routes: <String, WidgetBuilder>{ '/': (_) => new WindowManager() }
+    home: new WindowManager()
   ));
 }

--- a/dev/manual_tests/overlay_geometry.dart
+++ b/dev/manual_tests/overlay_geometry.dart
@@ -201,8 +201,6 @@ void main() {
       accentColor: Colors.redAccent[200]
     ),
     title: 'Cards',
-    routes: <String, WidgetBuilder>{
-      '/': (BuildContext context) => new OverlayGeometryApp()
-    }
+    home: new OverlayGeometryApp()
   ));
 }

--- a/dev/manual_tests/pageable_list.dart
+++ b/dev/manual_tests/pageable_list.dart
@@ -145,8 +145,6 @@ void main() {
       primarySwatch: Colors.blue,
       accentColor: Colors.redAccent[200]
     ),
-    routes: <String, WidgetBuilder>{
-      '/': (BuildContext context) => new PageableListApp(),
-    }
+    home: new PageableListApp()
   ));
 }

--- a/dev/manual_tests/raw_keyboard.dart
+++ b/dev/manual_tests/raw_keyboard.dart
@@ -9,25 +9,19 @@ import 'package:sky_services/sky/input_event.mojom.dart' as mojom;
 GlobalKey _key = new GlobalKey();
 
 void main() {
-  runApp(
-    new MaterialApp(
-      title: "Hardware Key Demo",
-      routes: <String, WidgetBuilder>{
-        '/': (BuildContext context) {
-          return new Scaffold(
-            appBar: new AppBar(
-              title: new Text("Hardware Key Demo")
-            ),
-            body: new Material(
-              child: new RawKeyboardDemo(
-                key: _key
-              )
-            )
-          );
-        }
-      }
+  runApp(new MaterialApp(
+    title: "Hardware Key Demo",
+    home: new Scaffold(
+      appBar: new AppBar(
+        title: new Text("Hardware Key Demo")
+      ),
+      body: new Material(
+        child: new RawKeyboardDemo(
+          key: _key
+        )
+      )
     )
-  );
+  ));
 }
 
 class RawKeyboardDemo extends StatefulWidget {

--- a/examples/layers/services/isolate.dart
+++ b/examples/layers/services/isolate.dart
@@ -301,11 +301,5 @@ class IsolateExampleState extends State<StatefulWidget> {
 }
 
 void main() {
-  runApp(
-    new MaterialApp(
-      routes: <String, WidgetBuilder>{
-        '/': (BuildContext context) => new IsolateExampleWidget()
-      }
-    )
-  );
+  runApp(new MaterialApp(home: new IsolateExampleWidget()));
 }

--- a/examples/layers/widgets/gestures.dart
+++ b/examples/layers/widgets/gestures.dart
@@ -218,14 +218,9 @@ class _GestureDemoState extends State<GestureDemo> {
 void main() {
   runApp(new MaterialApp(
     theme: new ThemeData.dark(),
-    routes: <String, WidgetBuilder>{
-      '/': (BuildContext context) {
-        return new Scaffold(
-          appBar: new AppBar(
-              title: new Text('Gestures Demo')),
-          body: new GestureDemo()
-        );
-      }
-    }
+    home: new Scaffold(
+      appBar: new AppBar(title: new Text('Gestures Demo')),
+      body: new GestureDemo()
+    )
   ));
 }

--- a/examples/layers/widgets/media_query.dart
+++ b/examples/layers/widgets/media_query.dart
@@ -100,15 +100,11 @@ final List<String> _kNames = _initNames();
 void main() {
   runApp(new MaterialApp(
     title: 'Media Query Example',
-    routes: <String, WidgetBuilder>{
-      '/': (BuildContext context) {
-        return new Scaffold(
-          appBar: new AppBar(
-            title: new Text('Media Query Example')
-          ),
-          body: new Material(child: new AdaptiveContainer(names: _kNames))
-        );
-      }
-    }
+    home: new Scaffold(
+      appBar: new AppBar(
+        title: new Text('Media Query Example')
+      ),
+      body: new Material(child: new AdaptiveContainer(names: _kNames))
+    )
   ));
 }

--- a/examples/layers/widgets/sectors.dart
+++ b/examples/layers/widgets/sectors.dart
@@ -153,16 +153,12 @@ class SectorAppState extends State<SectorApp> {
     return new MaterialApp(
       theme: new ThemeData.light(),
       title: 'Sector Layout',
-      routes: <String, WidgetBuilder>{
-        '/': (BuildContext context) {
-          return new Scaffold(
-            appBar: new AppBar(
-              title: new Text('Sector Layout in a Widget Tree')
-            ),
-            body: buildBody()
-          );
-        }
-      }
+      home: new Scaffold(
+        appBar: new AppBar(
+          title: new Text('Sector Layout in a Widget Tree')
+        ),
+        body: buildBody()
+      )
     );
   }
 }

--- a/examples/layers/widgets/styled_text.dart
+++ b/examples/layers/widgets/styled_text.dart
@@ -122,17 +122,14 @@ class _StyledTextDemoState extends State<StyledTextDemo> {
 void main() {
   runApp(new MaterialApp(
     theme: new ThemeData.light(),
-    routes: <String, WidgetBuilder>{
-      '/': (BuildContext context) {
-        return new Scaffold(
-          appBar: new AppBar(
-            title: new Text('Hal and Dave')),
-          body: new Material(
-            color: Colors.grey[50],
-            child: new StyledTextDemo()
-          )
-        );
-      }
-    }
+    home: new Scaffold(
+      appBar: new AppBar(
+        title: new Text('Hal and Dave')
+      ),
+      body: new Material(
+        color: Colors.grey[50],
+        child: new StyledTextDemo()
+      )
+    )
   ));
 }

--- a/examples/material_gallery/lib/gallery/app.dart
+++ b/examples/material_gallery/lib/gallery/app.dart
@@ -24,16 +24,14 @@ class GalleryAppState extends State<GalleryApp> {
       title: 'Flutter Material Gallery',
       theme: _useLightTheme ? _kGalleryLightTheme : _kGalleryDarkTheme,
       showPerformanceOverlay: _showPerformanceOverlay,
-      routes: {
-        '/': (BuildContext context) => new GalleryHome(
-          useLightTheme: _useLightTheme,
-          onThemeChanged: (bool value) { setState(() { _useLightTheme = value; }); },
-          showPerformanceOverlay: _showPerformanceOverlay,
-          onShowPerformanceOverlayChanged: (bool value) { setState(() { _showPerformanceOverlay = value; }); },
-          timeDilation: timeDilation,
-          onTimeDilationChanged: (double value) { setState(() { timeDilation = value; }); }
-        )
-      }
+      home: new GalleryHome(
+        useLightTheme: _useLightTheme,
+        onThemeChanged: (bool value) { setState(() { _useLightTheme = value; }); },
+        showPerformanceOverlay: _showPerformanceOverlay,
+        onShowPerformanceOverlayChanged: (bool value) { setState(() { _showPerformanceOverlay = value; }); },
+        timeDilation: timeDilation,
+        onTimeDilationChanged: (double value) { setState(() { timeDilation = value; }); }
+      )
     );
   }
 }

--- a/packages/flutter/lib/src/material/app.dart
+++ b/packages/flutter/lib/src/material/app.dart
@@ -36,10 +36,18 @@ const TextStyle _errorTextStyle = const TextStyle(
 ///  * [Scaffold]
 ///  * [MaterialPageRoute]
 class MaterialApp extends WidgetsApp {
+  /// Creates a MaterialApp.
+  ///
+  /// At least one of [home], [routes], or [onGenerateRoute] must be
+  /// given. If only [routes] is given, it must include an entry for
+  /// the [Navigator.defaultRouteName] (`'/'`).
+  ///
+  /// See also the [new WidgetsApp] constructor (which this extends).
   MaterialApp({
     Key key,
     String title,
     ThemeData theme,
+    Widget home,
     Map<String, WidgetBuilder> routes: const <String, WidgetBuilder>{},
     RouteFactory onGenerateRoute,
     LocaleChangedCallback onLocaleChanged,
@@ -48,6 +56,7 @@ class MaterialApp extends WidgetsApp {
     bool showSemanticsDebugger: false,
     bool debugShowCheckedModeBanner: true
   }) : theme = theme,
+       home = home,
        routes = routes,
        super(
     key: key,
@@ -56,6 +65,8 @@ class MaterialApp extends WidgetsApp {
     color: theme?.primaryColor ?? Colors.blue[500], // blue[500] is the primary color of the default theme
     onGenerateRoute: (RouteSettings settings) {
       WidgetBuilder builder = routes[settings.name];
+      if (builder == null && home != null && settings.name == Navigator.defaultRouteName)
+        builder = (BuildContext context) => home;
       if (builder != null) {
         return new MaterialPageRoute<Null>(
           builder: builder,
@@ -72,10 +83,29 @@ class MaterialApp extends WidgetsApp {
     debugShowCheckedModeBanner: debugShowCheckedModeBanner
   ) {
     assert(debugShowMaterialGrid != null);
+    assert(routes != null);
+    assert(!routes.containsKey(Navigator.defaultRouteName) || (home == null));
+    assert(routes.containsKey(Navigator.defaultRouteName) || (home != null) || (onGenerateRoute != null));
   }
 
   /// The colors to use for the application's widgets.
   final ThemeData theme;
+
+  /// The widget for the default route of the app
+  /// ([Navigator.defaultRouteName], which is `'/'`).
+  ///
+  /// This is the page that is displayed first when the application is
+  /// started normally.
+  ///
+  /// To be able to directly call [Theme.of], [MediaQuery.of],
+  /// [LocaleQuery.of], etc, in the code sets the [home] argument in
+  /// the constructor, you can use a [Builder] widget to get a
+  /// [BuildContext].
+  ///
+  /// If this is not specified, then either the route with name `'/'`
+  /// must be given in [routes], or the [onGenerateRoute] callback
+  /// must be able to build a widget for that route.
+  final Widget home;
 
   /// The application's top-level routing table.
   ///
@@ -83,6 +113,15 @@ class MaterialApp extends WidgetsApp {
   /// looked up in this map. If the name is present, the associated
   /// [WidgetBuilder] is used to construct a [MaterialPageRoute] that performs
   /// an appropriate transition, including [Hero] animations, to the new route.
+  ///
+  /// If the app only has one page, then you can specify it using [home] instead.
+  ///
+  /// If [home] is specified, then it is an error to provide a route
+  /// in this map for the [Navigator.defaultRouteName] route (`'/'`).
+  ///
+  /// If a route is requested that is not specified in this table (or
+  /// by [home]), then the [onGenerateRoute] callback is invoked to
+  /// build the page instead.
   final Map<String, WidgetBuilder> routes;
 
   /// Turns on a [GridPaper] overlay that paints a baseline grid

--- a/packages/flutter/lib/src/material/page.dart
+++ b/packages/flutter/lib/src/material/page.dart
@@ -66,9 +66,12 @@ class MaterialPageRoute<T> extends PageRoute<T> {
   Widget buildPage(BuildContext context, Animation<double> animation, Animation<double> forwardAnimation) {
     Widget result = builder(context);
     assert(() {
-      if (result == null)
-        debugPrint('The builder for route \'${settings.name}\' returned null. Route builders must never return null.');
-      assert(result != null && 'A route builder returned null. See the previous log message for details.' is String);
+      if (result == null) {
+        throw new FlutterError(
+          'The builder for route "${settings.name}" returned null.\n'
+          'Route builders must never return null.'
+        );
+      }
       return true;
     });
     return result;

--- a/packages/flutter/test/material/snack_bar_test.dart
+++ b/packages/flutter/test/material/snack_bar_test.dart
@@ -12,30 +12,26 @@ void main() {
       String helloSnackBar = 'Hello SnackBar';
       Key tapTarget = new Key('tap-target');
       tester.pumpWidget(new MaterialApp(
-        routes: <String, WidgetBuilder>{
-          '/': (BuildContext context) {
-            return new Scaffold(
-              body: new Builder(
-                builder: (BuildContext context) {
-                  return new GestureDetector(
-                    onTap: () {
-                      Scaffold.of(context).showSnackBar(new SnackBar(
-                        content: new Text(helloSnackBar),
-                        duration: new Duration(seconds: 2)
-                      ));
-                    },
-                    behavior: HitTestBehavior.opaque,
-                    child: new Container(
-                      height: 100.0,
-                      width: 100.0,
-                      key: tapTarget
-                    )
-                  );
-                }
-              )
-            );
-          }
-        }
+        home: new Scaffold(
+          body: new Builder(
+            builder: (BuildContext context) {
+              return new GestureDetector(
+                onTap: () {
+                  Scaffold.of(context).showSnackBar(new SnackBar(
+                    content: new Text(helloSnackBar),
+                    duration: new Duration(seconds: 2)
+                  ));
+                },
+                behavior: HitTestBehavior.opaque,
+                child: new Container(
+                  height: 100.0,
+                  width: 100.0,
+                  key: tapTarget
+                )
+              );
+            }
+          )
+        )
       ));
       expect(tester, doesNotHaveWidget(find.text(helloSnackBar)));
       tester.tap(find.byKey(tapTarget));
@@ -63,31 +59,27 @@ void main() {
       int snackBarCount = 0;
       Key tapTarget = new Key('tap-target');
       tester.pumpWidget(new MaterialApp(
-        routes: <String, WidgetBuilder>{
-          '/': (BuildContext context) {
-            return new Scaffold(
-              body: new Builder(
-                builder: (BuildContext context) {
-                  return new GestureDetector(
-                    onTap: () {
-                      snackBarCount += 1;
-                      Scaffold.of(context).showSnackBar(new SnackBar(
-                        content: new Text("bar$snackBarCount"),
-                        duration: new Duration(seconds: 2)
-                      ));
-                    },
-                    behavior: HitTestBehavior.opaque,
-                    child: new Container(
-                      height: 100.0,
-                      width: 100.0,
-                      key: tapTarget
-                    )
-                  );
-                }
-              )
-            );
-          }
-        }
+        home: new Scaffold(
+          body: new Builder(
+            builder: (BuildContext context) {
+              return new GestureDetector(
+                onTap: () {
+                  snackBarCount += 1;
+                  Scaffold.of(context).showSnackBar(new SnackBar(
+                    content: new Text("bar$snackBarCount"),
+                    duration: new Duration(seconds: 2)
+                  ));
+                },
+                behavior: HitTestBehavior.opaque,
+                child: new Container(
+                  height: 100.0,
+                  width: 100.0,
+                  key: tapTarget
+                )
+              );
+            }
+          )
+        )
       ));
       expect(tester, doesNotHaveWidget(find.text('bar1')));
       expect(tester, doesNotHaveWidget(find.text('bar2')));
@@ -146,31 +138,27 @@ void main() {
       int time;
       ScaffoldFeatureController<SnackBar, Null> lastController;
       tester.pumpWidget(new MaterialApp(
-        routes: <String, WidgetBuilder>{
-          '/': (BuildContext context) {
-            return new Scaffold(
-              body: new Builder(
-                builder: (BuildContext context) {
-                  return new GestureDetector(
-                    onTap: () {
-                      snackBarCount += 1;
-                      lastController = Scaffold.of(context).showSnackBar(new SnackBar(
-                        content: new Text("bar$snackBarCount"),
-                        duration: new Duration(seconds: time)
-                      ));
-                    },
-                    behavior: HitTestBehavior.opaque,
-                    child: new Container(
-                      height: 100.0,
-                      width: 100.0,
-                      key: tapTarget
-                    )
-                  );
-                }
-              )
-            );
-          }
-        }
+        home: new Scaffold(
+          body: new Builder(
+            builder: (BuildContext context) {
+              return new GestureDetector(
+                onTap: () {
+                  snackBarCount += 1;
+                  lastController = Scaffold.of(context).showSnackBar(new SnackBar(
+                    content: new Text("bar$snackBarCount"),
+                    duration: new Duration(seconds: time)
+                  ));
+                },
+                behavior: HitTestBehavior.opaque,
+                child: new Container(
+                  height: 100.0,
+                  width: 100.0,
+                  key: tapTarget
+                )
+              );
+            }
+          )
+        )
       ));
       expect(tester, doesNotHaveWidget(find.text('bar1')));
       expect(tester, doesNotHaveWidget(find.text('bar2')));
@@ -236,31 +224,27 @@ void main() {
       int snackBarCount = 0;
       Key tapTarget = new Key('tap-target');
       tester.pumpWidget(new MaterialApp(
-        routes: <String, WidgetBuilder>{
-          '/': (BuildContext context) {
-            return new Scaffold(
-              body: new Builder(
-                builder: (BuildContext context) {
-                  return new GestureDetector(
-                    onTap: () {
-                      snackBarCount += 1;
-                      Scaffold.of(context).showSnackBar(new SnackBar(
-                        content: new Text("bar$snackBarCount"),
-                        duration: new Duration(seconds: 2)
-                      ));
-                    },
-                    behavior: HitTestBehavior.opaque,
-                    child: new Container(
-                      height: 100.0,
-                      width: 100.0,
-                      key: tapTarget
-                    )
-                  );
-                }
-              )
-            );
-          }
-        }
+        home: new Scaffold(
+          body: new Builder(
+            builder: (BuildContext context) {
+              return new GestureDetector(
+                onTap: () {
+                  snackBarCount += 1;
+                  Scaffold.of(context).showSnackBar(new SnackBar(
+                    content: new Text("bar$snackBarCount"),
+                    duration: new Duration(seconds: 2)
+                  ));
+                },
+                behavior: HitTestBehavior.opaque,
+                child: new Container(
+                  height: 100.0,
+                  width: 100.0,
+                  key: tapTarget
+                )
+              );
+            }
+          )
+        )
       ));
       expect(tester, doesNotHaveWidget(find.text('bar1')));
       expect(tester, doesNotHaveWidget(find.text('bar2')));
@@ -286,31 +270,27 @@ void main() {
     testWidgets((WidgetTester tester) {
       int tapCount = 0;
       tester.pumpWidget(new MaterialApp(
-        routes: <String, WidgetBuilder>{
-          '/': (BuildContext context) {
-            return new Scaffold(
-              body: new Builder(
-                builder: (BuildContext context) {
-                  return new GestureDetector(
-                    onTap: () {
-                      Scaffold.of(context).showSnackBar(new SnackBar(
-                        content: new Text('I am a snack bar.'),
-                        duration: new Duration(seconds: 2),
-                        action: new SnackBarAction(
-                          label: 'ACTION',
-                          onPressed: () {
-                            ++tapCount;
-                          }
-                        )
-                      ));
-                    },
-                    child: new Text('X')
-                  );
-                }
-              )
-            );
-          }
-        }
+        home: new Scaffold(
+          body: new Builder(
+            builder: (BuildContext context) {
+              return new GestureDetector(
+                onTap: () {
+                  Scaffold.of(context).showSnackBar(new SnackBar(
+                    content: new Text('I am a snack bar.'),
+                    duration: new Duration(seconds: 2),
+                    action: new SnackBarAction(
+                      label: 'ACTION',
+                      onPressed: () {
+                        ++tapCount;
+                      }
+                    )
+                  ));
+                },
+                child: new Text('X')
+              );
+            }
+          )
+        )
       ));
       tester.tap(find.text('X'));
       tester.pump(); // start animation

--- a/packages/flutter/test/widget/bottom_sheet_rebuild_test.dart
+++ b/packages/flutter/test/widget/bottom_sheet_rebuild_test.dart
@@ -14,19 +14,15 @@ void main() {
       int buildCount = 0;
 
       tester.pumpWidget(new MaterialApp(
-        routes: <String, WidgetBuilder>{
-          '/': (BuildContext context) {
-            return new Scaffold(
-              key: scaffoldKey,
-              body: new Center(child: new Text('body'))
-            );
-          }
-        }
+        home: new Scaffold(
+          key: scaffoldKey,
+          body: new Center(child: new Text('body'))
+        )
       ));
 
       bottomSheet = scaffoldKey.currentState.showBottomSheet/*<Null>*/((_) {
         return new Builder(
-          builder: (_) {
+          builder: (BuildContext context) {
             buildCount += 1;
             return new Container(height: 200.0);
           }

--- a/packages/flutter/test/widget/bottom_sheet_test.dart
+++ b/packages/flutter/test/widget/bottom_sheet_test.dart
@@ -10,23 +10,23 @@ import 'package:test/test.dart';
 void main() {
   test('Verify that a tap dismisses a modal BottomSheet', () {
     testWidgets((WidgetTester tester) {
-      BuildContext context;
+      BuildContext savedContext;
       bool showBottomSheetThenCalled = false;
 
       tester.pumpWidget(new MaterialApp(
-          routes: <String, WidgetBuilder>{
-            '/': (BuildContext ctx) {
-              context = ctx;
-              return new Container();
-            }
+        home: new Builder(
+          builder: (BuildContext context) {
+            savedContext = context;
+            return new Container();
           }
+        )
       ));
 
       tester.pump();
       expect(tester, doesNotHaveWidget(find.text('BottomSheet')));
 
       showModalBottomSheet/*<Null>*/(
-        context: context,
+        context: savedContext,
         builder: (BuildContext context) => new Text('BottomSheet')
       ).then((Null result) {
         expect(result, isNull);
@@ -46,7 +46,7 @@ void main() {
       tester.pump(new Duration(seconds: 1)); // frame after the animation (sheet has been removed)
       expect(tester, doesNotHaveWidget(find.text('BottomSheet')));
 
-      showModalBottomSheet/*<Null>*/(context: context, builder: (BuildContext context) => new Text('BottomSheet'));
+      showModalBottomSheet/*<Null>*/(context: savedContext, builder: (BuildContext context) => new Text('BottomSheet'));
       tester.pump(); // bottom sheet show animation starts
       tester.pump(new Duration(seconds: 1)); // animation done
       expect(tester, hasWidget(find.text('BottomSheet')));
@@ -66,14 +66,10 @@ void main() {
       bool showBottomSheetThenCalled = false;
 
       tester.pumpWidget(new MaterialApp(
-        routes: <String, WidgetBuilder>{
-          '/': (BuildContext context) {
-            return new Scaffold(
-              key: scaffoldKey,
-              body: new Center(child: new Text('body'))
-            );
-          }
-        }
+        home: new Scaffold(
+          key: scaffoldKey,
+          body: new Center(child: new Text('body'))
+        )
       ));
 
       expect(showBottomSheetThenCalled, isFalse);

--- a/packages/flutter/test/widget/draggable_test.dart
+++ b/packages/flutter/test/widget/draggable_test.dart
@@ -11,22 +11,25 @@ void main() {
     testWidgets((WidgetTester tester) {
       List<int> accepted = <int>[];
 
-      tester.pumpWidget(new MaterialApp(routes: <String, WidgetBuilder>{
-        '/': (BuildContext context) {
-          return new Column(children: <Widget>[
+      tester.pumpWidget(new MaterialApp(
+        home: new Column(
+          children: <Widget>[
             new Draggable<int>(
-                data: 1,
-                child: new Text('Source'),
-                feedback: new Text('Dragging')),
-            new DragTarget<int>(builder:
-                (BuildContext context, List<int> data, List<dynamic> rejects) {
-              return new Container(height: 100.0, child: new Text('Target'));
-            }, onAccept: (int data) {
-              accepted.add(data);
-            }),
-          ]);
-        },
-      }));
+              data: 1,
+              child: new Text('Source'),
+              feedback: new Text('Dragging')
+            ),
+            new DragTarget<int>(
+              builder: (BuildContext context, List<int> data, List<dynamic> rejects) {
+                return new Container(height: 100.0, child: new Text('Target'));
+              },
+              onAccept: (int data) {
+                accepted.add(data);
+              }
+            ),
+          ]
+        )
+      ));
 
       expect(accepted, isEmpty);
       expect(tester, hasWidget(find.text('Source')));
@@ -66,31 +69,38 @@ void main() {
       List<String> events = <String>[];
       Point firstLocation, secondLocation;
 
-      tester.pumpWidget(new MaterialApp(routes: <String, WidgetBuilder>{
-        '/': (BuildContext context) {
-          return new Column(children: <Widget>[
+      tester.pumpWidget(new MaterialApp(
+        home: new Column(
+          children: <Widget>[
             new Draggable<int>(
-                data: 1,
-                child: new Text('Source'),
-                feedback: new Text('Dragging')),
-            new Stack(children: <Widget>[
-              new GestureDetector(
+              data: 1,
+              child: new Text('Source'),
+              feedback: new Text('Dragging')
+            ),
+            new Stack(
+              children: <Widget>[
+                new GestureDetector(
                   behavior: HitTestBehavior.opaque,
                   onTap: () {
                     events.add('tap');
                   },
-                  child: new Container(child: new Text('Button'))),
-              new DragTarget<int>(builder: (BuildContext context,
-                  List<int> data, List<dynamic> rejects) {
-                return new IgnorePointer(
-                    child: new Container(child: new Text('Target')));
-              }, onAccept: (int data) {
-                events.add('drop');
-              }),
-            ]),
-          ]);
-        },
-      }));
+                  child: new Container(child: new Text('Button')
+                )
+              ),
+              new DragTarget<int>(
+                builder: (BuildContext context, List<int> data, List<dynamic> rejects) {
+                  return new IgnorePointer(
+                    child: new Container(child: new Text('Target'))
+                  );
+                },
+                onAccept: (int data) {
+                  events.add('drop');
+                }),
+              ]
+            ),
+          ]
+        )
+      ));
 
       expect(events, isEmpty);
       expect(tester, hasWidget(find.text('Source')));
@@ -151,27 +161,31 @@ void main() {
       List<String> events = <String>[];
       Point firstLocation, secondLocation;
 
-      tester.pumpWidget(new MaterialApp(routes: <String, WidgetBuilder>{
-        '/': (BuildContext context) {
-          return new Column(children: <Widget>[
+      tester.pumpWidget(new MaterialApp(
+        home: new Column(
+          children: <Widget>[
             new Draggable<int>(
-                data: 1,
-                child: new GestureDetector(
-                    behavior: HitTestBehavior.opaque,
-                    onTap: () {
-                      events.add('tap');
-                    },
-                    child: new Container(child: new Text('Button'))),
-                feedback: new Text('Dragging')),
-            new DragTarget<int>(builder:
-                (BuildContext context, List<int> data, List<dynamic> rejects) {
-              return new Text('Target');
-            }, onAccept: (int data) {
-              events.add('drop');
-            }),
-          ]);
-        },
-      }));
+              data: 1,
+              child: new GestureDetector(
+                behavior: HitTestBehavior.opaque,
+                onTap: () {
+                  events.add('tap');
+                },
+                child: new Container(child: new Text('Button'))
+              ),
+              feedback: new Text('Dragging')
+            ),
+            new DragTarget<int>(
+              builder: (BuildContext context, List<int> data, List<dynamic> rejects) {
+                return new Text('Target');
+              },
+              onAccept: (int data) {
+                events.add('drop');
+              }
+            ),
+          ]
+        )
+      ));
 
       expect(events, isEmpty);
       expect(tester, hasWidget(find.text('Button')));
@@ -203,22 +217,25 @@ void main() {
       List<String> events = <String>[];
       Point firstLocation, secondLocation;
 
-      tester.pumpWidget(new MaterialApp(routes: <String, WidgetBuilder>{
-        '/': (BuildContext context) {
-          return new Column(children: <Widget>[
+      tester.pumpWidget(new MaterialApp(
+        home: new Column(
+          children: <Widget>[
             new LongPressDraggable<int>(
-                data: 1,
-                child: new Text('Source'),
-                feedback: new Text('Dragging')),
-            new DragTarget<int>(builder:
-                (BuildContext context, List<int> data, List<dynamic> rejects) {
-              return new Text('Target');
-            }, onAccept: (int data) {
-              events.add('drop');
-            }),
-          ]);
-        },
-      }));
+              data: 1,
+              child: new Text('Source'),
+              feedback: new Text('Dragging')
+            ),
+            new DragTarget<int>(
+              builder: (BuildContext context, List<int> data, List<dynamic> rejects) {
+                return new Text('Target');
+              },
+              onAccept: (int data) {
+                events.add('drop');
+              }
+            ),
+          ]
+        )
+      ));
 
       expect(events, isEmpty);
       expect(tester, hasWidget(find.text('Source')));
@@ -248,22 +265,25 @@ void main() {
       List<String> events = <String>[];
       Point firstLocation, secondLocation;
 
-      tester.pumpWidget(new MaterialApp(routes: <String, WidgetBuilder>{
-        '/': (BuildContext context) {
-          return new Column(children: <Widget>[
+      tester.pumpWidget(new MaterialApp(
+        home: new Column(
+          children: <Widget>[
             new Draggable<int>(
-                data: 1,
-                child: new Text('Source'),
-                feedback: new Text('Dragging')),
-            new DragTarget<int>(builder:
-                (BuildContext context, List<int> data, List<dynamic> rejects) {
-              return new Text('Target');
-            }, onAccept: (int data) {
-              events.add('drop');
-            }),
-          ]);
-        },
-      }));
+              data: 1,
+              child: new Text('Source'),
+              feedback: new Text('Dragging')
+            ),
+            new DragTarget<int>(
+              builder: (BuildContext context, List<int> data, List<dynamic> rejects) {
+                return new Text('Target');
+              },
+              onAccept: (int data) {
+                events.add('drop');
+              }
+            ),
+          ]
+        )
+      ));
 
       expect(events, isEmpty);
       expect(tester, hasWidget(find.text('Source')));
@@ -296,27 +316,35 @@ void main() {
       List<String> events = <String>[];
       Point firstLocation, secondLocation, thirdLocation;
 
-      tester.pumpWidget(new MaterialApp(routes: <String, WidgetBuilder>{
-        '/': (BuildContext context) {
-          return new Block(children: <Widget>[
-            new DragTarget<int>(builder:
-                (BuildContext context, List<int> data, List<dynamic> rejects) {
-              return new Text('Target');
-            }, onAccept: (int data) {
-              events.add('drop $data');
-            }),
+      tester.pumpWidget(new MaterialApp(
+        home: new Block(
+          children: <Widget>[
+            new DragTarget<int>(
+              builder: (BuildContext context, List<int> data, List<dynamic> rejects) {
+                return new Text('Target');
+              },
+              onAccept: (int data) {
+                events.add('drop $data');
+              }
+            ),
             new Container(height: 400.0),
             new HorizontalDraggable<int>(
-                data: 1, child: new Text('H'), feedback: new Text('Dragging')),
+              data: 1,
+              child: new Text('H'),
+              feedback: new Text('Dragging')
+            ),
             new VerticalDraggable<int>(
-                data: 2, child: new Text('V'), feedback: new Text('Dragging')),
+              data: 2,
+              child: new Text('V'),
+              feedback: new Text('Dragging')
+            ),
             new Container(height: 500.0),
             new Container(height: 500.0),
             new Container(height: 500.0),
             new Container(height: 500.0),
-          ]);
-        },
-      }));
+          ]
+        )
+      ));
 
       expect(events, isEmpty);
       expect(tester, hasWidget(find.text('Target')));
@@ -395,27 +423,36 @@ void main() {
       List<String> events = <String>[];
       Point firstLocation, secondLocation, thirdLocation;
 
-      tester.pumpWidget(new MaterialApp(routes: <String, WidgetBuilder>{
-        '/': (BuildContext context) {
-          return new Block(scrollDirection: Axis.horizontal, children: <Widget>[
-            new DragTarget<int>(builder:
-                (BuildContext context, List<int> data, List<dynamic> rejects) {
-              return new Text('Target');
-            }, onAccept: (int data) {
-              events.add('drop $data');
-            }),
+      tester.pumpWidget(new MaterialApp(
+        home: new Block(
+          scrollDirection: Axis.horizontal,
+          children: <Widget>[
+            new DragTarget<int>(
+              builder: (BuildContext context, List<int> data, List<dynamic> rejects) {
+                return new Text('Target');
+              },
+              onAccept: (int data) {
+                events.add('drop $data');
+              }
+            ),
             new Container(width: 400.0),
             new HorizontalDraggable<int>(
-                data: 1, child: new Text('H'), feedback: new Text('Dragging')),
+              data: 1,
+              child: new Text('H'),
+              feedback: new Text('Dragging')
+            ),
             new VerticalDraggable<int>(
-                data: 2, child: new Text('V'), feedback: new Text('Dragging')),
+              data: 2,
+              child: new Text('V'),
+              feedback: new Text('Dragging')
+            ),
             new Container(width: 500.0),
             new Container(width: 500.0),
             new Container(width: 500.0),
             new Container(width: 500.0),
-          ]);
-        },
-      }));
+          ]
+        )
+      ));
 
       expect(events, isEmpty);
       expect(tester, hasWidget(find.text('Target')));
@@ -495,25 +532,28 @@ void main() {
       List<int> accepted = <int>[];
       bool onDraggableCanceledCalled = false;
 
-      tester.pumpWidget(new MaterialApp(routes: <String, WidgetBuilder>{
-        '/': (BuildContext context) {
-          return new Column(children: <Widget>[
+      tester.pumpWidget(new MaterialApp(
+        home: new Column(
+          children: <Widget>[
             new Draggable<int>(
-                data: 1,
-                child: new Text('Source'),
-                feedback: new Text('Dragging'),
-                onDraggableCanceled: (Velocity velocity, Offset offset) {
-                  onDraggableCanceledCalled = true;
-                }),
-            new DragTarget<int>(builder:
-                (BuildContext context, List<int> data, List<dynamic> rejects) {
-              return new Container(height: 100.0, child: new Text('Target'));
-            }, onAccept: (int data) {
-              accepted.add(data);
-            }),
-          ]);
-        },
-      }));
+              data: 1,
+              child: new Text('Source'),
+              feedback: new Text('Dragging'),
+              onDraggableCanceled: (Velocity velocity, Offset offset) {
+                onDraggableCanceledCalled = true;
+              }
+            ),
+            new DragTarget<int>(
+              builder: (BuildContext context, List<int> data, List<dynamic> rejects) {
+                return new Container(height: 100.0, child: new Text('Target'));
+              },
+              onAccept: (int data) {
+                accepted.add(data);
+              }
+            ),
+          ]
+        )
+      ));
 
       expect(accepted, isEmpty);
       expect(tester, hasWidget(find.text('Source')));
@@ -561,28 +601,31 @@ void main() {
       Velocity onDraggableCanceledVelocity;
       Offset onDraggableCanceledOffset;
 
-      tester.pumpWidget(new MaterialApp(routes: <String, WidgetBuilder>{
-        '/': (BuildContext context) {
-          return new Column(children: <Widget>[
+      tester.pumpWidget(new MaterialApp(
+        home: new Column(
+          children: <Widget>[
             new Draggable<int>(
-                data: 1,
-                child: new Text('Source'),
-                feedback: new Text('Dragging'),
-                onDraggableCanceled: (Velocity velocity, Offset offset) {
-                  onDraggableCanceledCalled = true;
-                  onDraggableCanceledVelocity = velocity;
-                  onDraggableCanceledOffset = offset;
-                }),
+              data: 1,
+              child: new Text('Source'),
+              feedback: new Text('Dragging'),
+              onDraggableCanceled: (Velocity velocity, Offset offset) {
+                onDraggableCanceledCalled = true;
+                onDraggableCanceledVelocity = velocity;
+                onDraggableCanceledOffset = offset;
+              }
+            ),
             new DragTarget<int>(
-                builder: (BuildContext context, List<int> data,
-                    List<dynamic> rejects) {
-                  return new Container(
-                      height: 100.0, child: new Text('Target'));
-                },
-                onWillAccept: (int data) => false),
-          ]);
-        },
-      }));
+              builder: (BuildContext context, List<int> data, List<dynamic> rejects) {
+                return new Container(
+                  height: 100.0,
+                  child: new Text('Target')
+                );
+              },
+              onWillAccept: (int data) => false
+            ),
+          ]
+        )
+      ));
 
       expect(accepted, isEmpty);
       expect(tester, hasWidget(find.text('Source')));
@@ -633,28 +676,29 @@ void main() {
       Velocity onDraggableCanceledVelocity;
       Offset onDraggableCanceledOffset;
 
-      tester.pumpWidget(new MaterialApp(routes: <String, WidgetBuilder>{
-        '/': (BuildContext context) {
-          return new Column(children: <Widget>[
-            new Draggable<int>(
-                data: 1,
-                child: new Text('Source'),
-                feedback: new Text('Source'),
-                onDraggableCanceled: (Velocity velocity, Offset offset) {
-                  onDraggableCanceledCalled = true;
-                  onDraggableCanceledVelocity = velocity;
-                  onDraggableCanceledOffset = offset;
-                }),
-            new DragTarget<int>(
-                builder: (BuildContext context, List<int> data,
-                    List<dynamic> rejects) {
-                  return new Container(
-                      height: 100.0, child: new Text('Target'));
-                },
-                onWillAccept: (int data) => false),
-          ]);
-        },
-      }));
+      tester.pumpWidget(new MaterialApp(
+        home: new Column(children: <Widget>[
+          new Draggable<int>(
+            data: 1,
+            child: new Text('Source'),
+            feedback: new Text('Source'),
+            onDraggableCanceled: (Velocity velocity, Offset offset) {
+              onDraggableCanceledCalled = true;
+              onDraggableCanceledVelocity = velocity;
+              onDraggableCanceledOffset = offset;
+            }
+          ),
+          new DragTarget<int>(
+            builder: (BuildContext context, List<int> data, List<dynamic> rejects) {
+              return new Container(
+                height: 100.0,
+                child: new Text('Target')
+              );
+            },
+            onWillAccept: (int data) => false),
+          ]
+        )
+      ));
 
       expect(accepted, isEmpty);
       expect(tester, hasWidget(find.text('Source')));
@@ -683,40 +727,56 @@ void main() {
   });
 
   test('Drag and drop - allow pass thru of unaccepted data test', () {
-    testWidgets((WidgetTester tester) {
+      testWidgets((WidgetTester tester) {
       List<int> acceptedInts = <int>[];
       List<double> acceptedDoubles = <double>[];
 
-      tester.pumpWidget(new MaterialApp(routes: <String, WidgetBuilder>{
-        '/': (BuildContext context) {
-          return new Column(children: <Widget>[
+      tester.pumpWidget(new MaterialApp(
+        home: new Column(
+          children: <Widget>[
             new Draggable<int>(
-                data: 1,
-                child: new Text('IntSource'),
-                feedback: new Text('IntDragging')),
+              data: 1,
+              child: new Text('IntSource'),
+              feedback: new Text('IntDragging')
+            ),
             new Draggable<double>(
-                data: 1.0,
-                child: new Text('DoubleSource'),
-                feedback: new Text('DoubleDragging')),
-            new Stack(children: [
-              new DragTarget<int>(builder: (BuildContext context,
-                  List<int> data, List<dynamic> rejects) {
-                return new IgnorePointer(child: new Container(
-                    height: 100.0, child: new Text('Target1')));
-              }, onAccept: (int data) {
-                acceptedInts.add(data);
-              }),
-              new DragTarget<double>(builder: (BuildContext context,
-                  List<double> data, List<dynamic> rejects) {
-                return new IgnorePointer(child: new Container(
-                    height: 100.0, child: new Text('Target2')));
-              }, onAccept: (double data) {
-                acceptedDoubles.add(data);
-              }),
-            ])
-          ]);
-        },
-      }));
+              data: 1.0,
+              child: new Text('DoubleSource'),
+              feedback: new Text('DoubleDragging')
+            ),
+            new Stack(
+              children: <Widget>[
+                new DragTarget<int>(
+                  builder: (BuildContext context, List<int> data, List<dynamic> rejects) {
+                    return new IgnorePointer(
+                      child: new Container(
+                        height: 100.0,
+                        child: new Text('Target1')
+                      )
+                    );
+                  },
+                  onAccept: (int data) {
+                    acceptedInts.add(data);
+                  }
+                ),
+                new DragTarget<double>(
+                  builder: (BuildContext context, List<double> data, List<dynamic> rejects) {
+                    return new IgnorePointer(
+                      child: new Container(
+                        height: 100.0,
+                        child: new Text('Target2')
+                      )
+                    );
+                  },
+                  onAccept: (double data) {
+                    acceptedDoubles.add(data);
+                  }
+                ),
+              ]
+            )
+          ]
+        )
+      ));
 
       expect(acceptedInts, isEmpty);
       expect(acceptedDoubles, isEmpty);
@@ -791,32 +851,46 @@ void main() {
       List<DragTargetData> acceptedDragTargetDatas = <DragTargetData>[];
       List<ExtendedDragTargetData> acceptedExtendedDragTargetDatas = <ExtendedDragTargetData>[];
       DragTargetData dragTargetData = new DragTargetData();
-      tester.pumpWidget(new MaterialApp(routes: <String, WidgetBuilder>{
-        '/': (BuildContext context) {
-          return new Column(children: <Widget>[
+      tester.pumpWidget(new MaterialApp(
+        home: new Column(
+          children: <Widget>[
             new Draggable<DragTargetData>(
-                data: dragTargetData,
-                child: new Text('Source'),
-                feedback: new Text('Dragging')),
-            new Stack(children: [
-              new DragTarget<DragTargetData>(builder: (BuildContext context,
-                  List<DragTargetData> data, List<dynamic> rejects) {
-                return new IgnorePointer(child: new Container(
-                    height: 100.0, child: new Text('Target1')));
-              }, onAccept: (DragTargetData data) {
-                acceptedDragTargetDatas.add(data);
-              }),
-              new DragTarget<ExtendedDragTargetData>(builder: (BuildContext context,
-                  List<ExtendedDragTargetData> data, List<ExtendedDragTargetData> rejects) {
-                return new IgnorePointer(child: new Container(
-                    height: 100.0, child: new Text('Target2')));
-              }, onAccept: (ExtendedDragTargetData data) {
-                acceptedExtendedDragTargetDatas.add(data);
-              }),
-            ])
-          ]);
-        },
-      }));
+              data: dragTargetData,
+              child: new Text('Source'),
+              feedback: new Text('Dragging')
+            ),
+            new Stack(
+              children: <Widget>[
+                new DragTarget<DragTargetData>(
+                  builder: (BuildContext context, List<DragTargetData> data, List<dynamic> rejects) {
+                    return new IgnorePointer(
+                      child: new Container(
+                        height: 100.0,
+                        child: new Text('Target1')
+                      )
+                    );
+                  }, onAccept: (DragTargetData data) {
+                    acceptedDragTargetDatas.add(data);
+                  }
+                ),
+                new DragTarget<ExtendedDragTargetData>(
+                  builder: (BuildContext context, List<ExtendedDragTargetData> data, List<ExtendedDragTargetData> rejects) {
+                    return new IgnorePointer(
+                      child: new Container(
+                        height: 100.0,
+                        child: new Text('Target2')
+                      )
+                    );
+                  },
+                  onAccept: (ExtendedDragTargetData data) {
+                    acceptedExtendedDragTargetDatas.add(data);
+                  }
+                ),
+              ]
+            )
+          ]
+        )
+      ));
 
       Point dragTargetLocation = tester.getCenter(find.text('Source'));
       Point targetLocation = tester.getCenter(find.text('Target1'));

--- a/packages/flutter/test/widget/drawer_test.dart
+++ b/packages/flutter/test/widget/drawer_test.dart
@@ -12,19 +12,19 @@ void main() {
   test('Drawer control test', () {
     testWidgets((WidgetTester tester) {
       GlobalKey<ScaffoldState> scaffoldKey = new GlobalKey<ScaffoldState>();
-      BuildContext context;
+      BuildContext savedContext;
       tester.pumpWidget(
         new MaterialApp(
-          routes: <String, WidgetBuilder>{
-            '/': (BuildContext ctx) {
-              context = ctx;
+          home: new Builder(
+            builder: (BuildContext context) {
+              savedContext = context;
               return new Scaffold(
                 key: scaffoldKey,
                 drawer: new Text('drawer'),
                 body: new Container()
               );
             }
-          }
+          )
         )
       );
       tester.pump(); // no effect
@@ -34,7 +34,7 @@ void main() {
       expect(tester, hasWidget(find.text('drawer')));
       tester.pump(new Duration(seconds: 1)); // animation done
       expect(tester, hasWidget(find.text('drawer')));
-      Navigator.pop(context);
+      Navigator.pop(savedContext);
       tester.pump(); // drawer should be starting to animate away
       expect(tester, hasWidget(find.text('drawer')));
       tester.pump(new Duration(seconds: 1)); // animation done
@@ -47,15 +47,11 @@ void main() {
       GlobalKey<ScaffoldState> scaffoldKey = new GlobalKey<ScaffoldState>();
       tester.pumpWidget(
         new MaterialApp(
-          routes: <String, WidgetBuilder>{
-            '/': (BuildContext context) {
-              return new Scaffold(
-                key: scaffoldKey,
-                drawer: new Text('drawer'),
-                body: new Container()
-              );
-            }
-          }
+          home: new Scaffold(
+            key: scaffoldKey,
+            drawer: new Text('drawer'),
+            body: new Container()
+          )
         )
       );
       tester.pump(); // no effect
@@ -85,27 +81,23 @@ void main() {
       GlobalKey<ScaffoldState> scaffoldKey = new GlobalKey<ScaffoldState>();
       tester.pumpWidget(
         new MaterialApp(
-          routes: <String, WidgetBuilder>{
-            '/': (BuildContext context) {
-              return new Scaffold(
-                key: scaffoldKey,
-                drawer: new Drawer(
-                  child: new Block(
-                    children: <Widget>[
-                      new Text('drawer'),
-                      new Container(
-                        height: 1000.0,
-                        decoration: new BoxDecoration(
-                          backgroundColor: Colors.blue[500]
-                        )
-                      ),
-                    ]
-                  )
-                ),
-                body: new Container()
-              );
-            }
-          }
+          home: new Scaffold(
+            key: scaffoldKey,
+            drawer: new Drawer(
+              child: new Block(
+                children: <Widget>[
+                  new Text('drawer'),
+                  new Container(
+                    height: 1000.0,
+                    decoration: new BoxDecoration(
+                      backgroundColor: Colors.blue[500]
+                    )
+                  ),
+                ]
+              )
+            ),
+            body: new Container()
+          )
         )
       );
       expect(tester, doesNotHaveWidget(find.text('drawer')));

--- a/packages/flutter_markdown/example/demo.dart
+++ b/packages/flutter_markdown/example/demo.dart
@@ -21,7 +21,7 @@ You can use [hyperlinks](hyperlink) in markdown
 ## Code blocks
 Formatted Dart code looks really pretty too. This is an example of how to create your own Markdown widget:
 
-    new Markdown(data: "Hello _world_!");
+    new Markdown(data: 'Hello _world_!');
 
 Enjoy!
 """;
@@ -29,11 +29,9 @@ Enjoy!
 void main() {
   runApp(new MaterialApp(
     title: "Markdown Demo",
-    routes: <String, WidgetBuilder>{
-      '/': (BuildContext context) => new Scaffold(
-        appBar: new AppBar(title: new Text("Markdown Demo")),
-        body: new Markdown(data: _kMarkdownData)
-      )
-    }
+    home: new Scaffold(
+      appBar: new AppBar(title: new Text('Markdown Demo')),
+      body: new Markdown(data: _kMarkdownData)
+    )
   ));
 }

--- a/packages/flutter_tools/templates/create/lib/main.dart.tmpl
+++ b/packages/flutter_tools/templates/create/lib/main.dart.tmpl
@@ -15,9 +15,7 @@ void main() {
       theme: new ThemeData(
         primarySwatch: Colors.blue
       ),
-      routes: <String, WidgetBuilder>{
-        '/': (BuildContext context) => new FlutterDemo()
-      }
+      home: new FlutterDemo()
     )
   );
 }


### PR DESCRIPTION
The 'routes' table is a point of confusion with new developers. By
providing a 'home' argument that sets the '/' route, we can delay the
point at which we teach developers about 'routes' until the point where
they want to have a second route.

cc @abarth for review
cc @qchong, @collinjackson for impact on codelab

Fixes https://github.com/flutter/flutter/issues/3340
