### PR TITLE
Reset _simulation at the end of a fling

### DIFF
--- a/packages/flutter/lib/src/animation/animation_controller.dart
+++ b/packages/flutter/lib/src/animation/animation_controller.dart
@@ -126,7 +126,7 @@ class AnimationController extends Animation<double>
 
   /// The amount of time that has passed between the time the animation started and the most recent tick of the animation.
   ///
-  /// If the controller is not animating, the last elapsed duration is null;
+  /// If the controller is not animating, the last elapsed duration is null.
   Duration get lastElapsedDuration => _lastElapsedDuration;
   Duration _lastElapsedDuration;
 
@@ -212,7 +212,7 @@ class AnimationController extends Animation<double>
     assert(simulation != null);
     assert(!isAnimating);
     _simulation = simulation;
-    _lastElapsedDuration = const Duration();
+    _lastElapsedDuration = Duration.ZERO;
     _value = simulation.x(0.0).clamp(lowerBound, upperBound);
     Future<Null> result = _ticker.start();
     _checkStatusChanged();

--- a/packages/flutter/test/widget/scroll_interaction_test.dart
+++ b/packages/flutter/test/widget/scroll_interaction_test.dart
@@ -1,0 +1,39 @@
+// Copyright 2015 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter/widgets.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('Scroll flings twice in a row does not crash', () {
+    testWidgets((WidgetTester tester) {
+      tester.pumpWidget(new Block(
+        children: <Widget>[
+          new Container(height: 100000.0)          
+        ]
+      ));
+
+      ScrollableState<ScrollableViewport> scrollable =
+          tester.stateOf/*<ScrollableState<ScrollableViewport>>*/(find.byType(ScrollableViewport));
+
+      expect(scrollable.scrollOffset, equals(0.0));
+
+      tester.flingFrom(new Point(200.0, 300.0), new Offset(0.0, -200.0), 500.0);
+      tester.pump();
+      tester.pump(const Duration(seconds: 5));
+
+      expect(scrollable.scrollOffset, greaterThan(0.0));
+
+      double oldOffset = scrollable.scrollOffset;
+
+      tester.flingFrom(new Point(200.0, 300.0), new Offset(0.0, -200.0), 500.0);
+      tester.pump();
+      tester.pump(const Duration(seconds: 5));
+
+      expect(scrollable.scrollOffset, greaterThan(oldOffset));
+      
+    });
+  });
+}

--- a/packages/flutter_test/lib/src/widget_tester.dart
+++ b/packages/flutter_test/lib/src/widget_tester.dart
@@ -126,7 +126,7 @@ class WidgetTester {
   }
 
   /// Finds the first state object, searching in the depth-first traversal order.
-  State stateOf(Finder finder) {
+  State/*=T*/ stateOf/*<T extends State>*/(Finder finder) {
     Element element = finder.findFirst(this);
     Widget widget = element.widget;
 


### PR DESCRIPTION
Also a bit of code cleanup.

The key part of this patch is the addition in `_endScroll` to reset
`_simulation`. It seems like this was the one place where it's possible
for us to end the animation but not reset our state. Since we assert
that are state is coherent, we were hitting asserts when a fling
finished and then you interacted with the widget again.
