### PR TITLE
[driver] fix a race in finder logic

### DIFF
--- a/packages/flutter_driver/lib/src/extension.dart
+++ b/packages/flutter_driver/lib/src/extension.dart
@@ -120,7 +120,14 @@ class FlutterDriverExtension {
   Future<Health> getHealth(GetHealth command) async => new Health(HealthStatus.ok);
 
   /// Runs [locator] repeatedly until it finds an [Element] or times out.
-  Future<Element> _waitForElement(String descriptionGetter(), Element locator()) {
+  Future<Element> _waitForElement(String descriptionGetter(), Element locator()) async {
+    // Short-circuit if the element is already on the UI
+    Element element = locator();
+    if (element != null) {
+      return element;
+    }
+
+    // No element yet, so we retry on frames rendered in the future.
     Completer<Element> completer = new Completer<Element>();
     StreamSubscription<Duration> subscription;
 


### PR DESCRIPTION
If the driver arrives at a stable UI (no new frames are generated), the finder will time out waiting for the next frame to fire. Instead, we should first check if the desired element is already on the UI and subscribe to frames only if there isn't one.
