### PR TITLE
A blinking cursor should push only one frame

### DIFF
--- a/packages/flutter/lib/src/material/drawer.dart
+++ b/packages/flutter/lib/src/material/drawer.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:flutter/scheduler.dart';
 import 'package:flutter/widgets.dart';
 
 import 'colors.dart';
@@ -171,7 +170,6 @@ class DrawerControllerState extends State<DrawerController> {
   }
 
   double get _width {
-    assert(!Scheduler.debugInFrame); // we should never try to read the tree state while building or laying out
     RenderBox drawerBox = _drawerKey.currentContext?.findRenderObject();
     if (drawerBox != null)
       return drawerBox.size.width;

--- a/packages/flutter/lib/src/scheduler/binding.dart
+++ b/packages/flutter/lib/src/scheduler/binding.dart
@@ -86,7 +86,7 @@ abstract class Scheduler extends BindingBase {
   void initServiceExtensions() {
     super.initServiceExtensions();
     registerNumericServiceExtension(
-      name: 'timeDilation', 
+      name: 'timeDilation',
       getter: () => timeDilation,
       setter: (double value) {
         timeDilation = value;
@@ -94,9 +94,8 @@ abstract class Scheduler extends BindingBase {
     );
   }
 
-
   /// The strategy to use when deciding whether to run a task or not.
-  /// 
+  ///
   /// Defaults to [defaultSchedulingStrategy].
   SchedulingStrategy schedulingStrategy = defaultSchedulingStrategy;
 
@@ -118,7 +117,6 @@ abstract class Scheduler extends BindingBase {
     if (isFirstTask)
       _ensureEventLoopCallback();
   }
-
 
   // Whether this scheduler already requested to be called from the event loop.
   bool _hasRequestedAnEventLoopCallback = false;
@@ -155,10 +153,9 @@ abstract class Scheduler extends BindingBase {
     } else {
       // TODO(floitsch): we shouldn't need to request a frame. Just schedule
       // an event-loop callback.
-      ensureVisualUpdate();
+      _scheduleFrame();
     }
   }
-
 
   int _nextFrameCallbackId = 0; // positive
   Map<int, _FrameCallbackEntry> _transientCallbacks = <int, _FrameCallbackEntry>{};
@@ -187,7 +184,7 @@ abstract class Scheduler extends BindingBase {
   /// Callbacks registered with this method can be canceled using
   /// [cancelFrameCallbackWithId].
   int scheduleFrameCallback(FrameCallback callback, { bool rescheduling: false }) {
-    ensureVisualUpdate();
+    _scheduleFrame();
     return addFrameCallback(callback, rescheduling: rescheduling);
   }
 
@@ -270,7 +267,6 @@ abstract class Scheduler extends BindingBase {
     return true;
   }
 
-
   final List<FrameCallback> _persistentCallbacks = new List<FrameCallback>();
 
   /// Adds a persistent frame callback.
@@ -285,7 +281,6 @@ abstract class Scheduler extends BindingBase {
   void addPersistentFrameCallback(FrameCallback callback) {
     _persistentCallbacks.add(callback);
   }
-
 
   final List<FrameCallback> _postFrameCallbacks = new List<FrameCallback>();
 
@@ -306,10 +301,11 @@ abstract class Scheduler extends BindingBase {
     _postFrameCallbacks.add(callback);
   }
 
+  // Whether this scheduler as requested that handleBeginFrame be called soon.
+  bool _hasScheduledFrame = false;
 
-  // Whether this scheduler already requested to be called at the beginning of
-  // the next frame.
-  bool _hasRequestedABeginFrameCallback = false;
+  // Whether this scheduler is currently producing a frame in handleBeginFrame.
+  bool _isProducingFrame = false;
 
   /// If necessary, schedules a new frame by calling
   /// [ui.window.scheduleFrame].
@@ -319,19 +315,17 @@ abstract class Scheduler extends BindingBase {
   /// device's screen is turned off it will typically be delayed until
   /// the screen is on and the application is visible.)
   void ensureVisualUpdate() {
-    if (_hasRequestedABeginFrameCallback)
+    if (_hasScheduledFrame || _isProducingFrame)
       return;
-    ui.window.scheduleFrame();
-    _hasRequestedABeginFrameCallback = true;
+    _scheduleFrame();
   }
 
-  /// Whether the scheduler is currently handling a "begin frame"
-  /// callback.
-  ///
-  /// True while [handleBeginFrame] is running in checked mode. False
-  /// otherwise.
-  static bool get debugInFrame => _debugInFrame;
-  static bool _debugInFrame = false;
+  void _scheduleFrame() {
+    if (_hasScheduledFrame)
+      return;
+    ui.window.scheduleFrame();
+    _hasScheduledFrame = true;
+  }
 
   /// Called by the engine to produce a new frame.
   ///
@@ -342,11 +336,11 @@ abstract class Scheduler extends BindingBase {
   /// callbacks registered by [addPostFrameCallback].
   void handleBeginFrame(Duration rawTimeStamp) {
     Timeline.startSync('Begin frame');
-    assert(!_debugInFrame);
-    assert(() { _debugInFrame = true; return true; });
+    assert(!_isProducingFrame);
+    _isProducingFrame = true;
+    _hasScheduledFrame = false;
     Duration timeStamp = new Duration(
         microseconds: (rawTimeStamp.inMicroseconds / timeDilation).round());
-    _hasRequestedABeginFrameCallback = false;
     _invokeTransientFrameCallbacks(timeStamp);
 
     for (FrameCallback callback in _persistentCallbacks)
@@ -358,7 +352,7 @@ abstract class Scheduler extends BindingBase {
     for (FrameCallback callback in localPostFrameCallbacks)
       _invokeFrameCallback(callback, timeStamp);
 
-    assert(() { _debugInFrame = false; return true; });
+    _isProducingFrame = false;
     Timeline.finishSync();
 
     // All frame-related callbacks have been executed. Run lower-priority tasks.
@@ -367,7 +361,7 @@ abstract class Scheduler extends BindingBase {
 
   void _invokeTransientFrameCallbacks(Duration timeStamp) {
     Timeline.startSync('Animate');
-    assert(_debugInFrame);
+    assert(_isProducingFrame);
     Map<int, _FrameCallbackEntry> callbacks = _transientCallbacks;
     _transientCallbacks = new Map<int, _FrameCallbackEntry>();
     callbacks.forEach((int id, _FrameCallbackEntry callbackEntry) {


### PR DESCRIPTION
Prior to this patch, we were pushing two frames each time the cursor blinked.
In turning the cursor on or off, the markNeedsPaint call was triggering another
frame to be scheduled because we cleared a bit in the scheduler at the
beginning of the frame instead of at the end of the frame.

To implement scheduling correctly, we actually need two bits: one for
ensureVisualUpdate, which just promises to get to the end of the pipeline soon,
and scheduleFrame, which promises to get to the beginning of the pipeline soon.
