### PR TITLE
Refactor the Gesturer's interfaces

### DIFF
--- a/packages/flutter/lib/src/gestures/binding.dart
+++ b/packages/flutter/lib/src/gestures/binding.dart
@@ -17,7 +17,7 @@ import 'hit_test.dart';
 import 'pointer_router.dart';
 
 /// A binding for the gesture subsystem.
-abstract class Gesturer extends BindingBase implements HitTestTarget, HitTestable {
+abstract class Gesturer extends BindingBase implements HitTestable, HitTestDispatcher, HitTestTarget {
 
   @override
   void initInstances() {
@@ -75,12 +75,13 @@ abstract class Gesturer extends BindingBase implements HitTestTarget, HitTestabl
   }
 
   /// Determine which [HitTestTarget] objects are located at a given position.
-  @override
+  @override // from HitTestable
   void hitTest(HitTestResult result, Point position) {
     result.add(new HitTestEntry(this));
   }
 
-  /// Dispatch the given event to the path of the given hit test result
+  /// Dispatch the given event to the path of the given hit test result.
+  @override // from HitTestDispatcher
   void dispatchEvent(PointerEvent event, HitTestResult result) {
     assert(result != null);
     for (HitTestEntry entry in result.path) {
@@ -105,7 +106,7 @@ abstract class Gesturer extends BindingBase implements HitTestTarget, HitTestabl
     }
   }
 
-  @override
+  @override // from HitTestTarget
   void handleEvent(PointerEvent event, HitTestEntry entry) {
     pointerRouter.route(event);
     if (event is PointerDownEvent) {

--- a/packages/flutter/lib/src/gestures/binding.dart
+++ b/packages/flutter/lib/src/gestures/binding.dart
@@ -80,7 +80,11 @@ abstract class Gesturer extends BindingBase implements HitTestable, HitTestDispa
     result.add(new HitTestEntry(this));
   }
 
-  /// Dispatch the given event to the path of the given hit test result.
+  /// Dispatch an event to a hit test result's path.
+  ///
+  /// This sends the given event to every [HitTestTarget] in the entries
+  /// of the given [HitTestResult], and catches exceptions that any of
+  /// the handlers might throw. The `result` argument must not be null.
   @override // from HitTestDispatcher
   void dispatchEvent(PointerEvent event, HitTestResult result) {
     assert(result != null);

--- a/packages/flutter/lib/src/gestures/hit_test.dart
+++ b/packages/flutter/lib/src/gestures/hit_test.dart
@@ -9,6 +9,12 @@ abstract class HitTestable { // ignore: one_member_abstracts
   void hitTest(HitTestResult result, Point position);
 }
 
+/// An object that can dispatch events.
+abstract class HitTestDispatcher { // ignore: one_member_abstracts
+  /// Override this function to dispatch events.
+  void dispatchEvent(PointerEvent event, HitTestResult result);
+}
+
 /// An object that can handle events.
 abstract class HitTestTarget { // ignore: one_member_abstracts
   /// Override this function to receive events.


### PR DESCRIPTION
This makes them more coherent.

It also makes it easier for the tests to override each specific part of
hit-testing, should that be necessary.
