### PR TITLE
Remove stray print from material gallery.

### DIFF
--- a/examples/material_gallery/lib/gallery/example_code_parser.dart
+++ b/examples/material_gallery/lib/gallery/example_code_parser.dart
@@ -11,11 +11,8 @@ const String _kEndTag = '// END';
 Map<String, String> _exampleCode;
 
 Future<String> getExampleCode(String tag, AssetBundle bundle) async {
-  print('getExampleCode tag: $tag bundle: $bundle');
-
   if (_exampleCode == null)
     await _parseExampleCode(bundle);
-
   return _exampleCode[tag];
 }
 


### PR DESCRIPTION
Makes the tests noisy.

@vlidholt 
