### PR TITLE
Add a service extension for toggling the PerformanceOverlay

### DIFF
--- a/packages/flutter/lib/src/widgets/app.dart
+++ b/packages/flutter/lib/src/widgets/app.dart
@@ -92,6 +92,8 @@ class WidgetsApp extends StatefulWidget {
   /// representative of what will happen in release mode.
   final bool debugShowCheckedModeBanner;
 
+  static bool showPerformanceOverlayOverride = false;
+
   @override
   WidgetsAppState<WidgetsApp> createState() => new WidgetsAppState<WidgetsApp>();
 }
@@ -186,7 +188,7 @@ class WidgetsAppState<T extends WidgetsApp> extends State<T> implements BindingO
         child: result
       );
     }
-    if (config.showPerformanceOverlay) {
+    if (config.showPerformanceOverlay || WidgetsApp.showPerformanceOverlayOverride) {
       result = new Stack(
         children: <Widget>[
           result,

--- a/packages/flutter/lib/src/widgets/binding.dart
+++ b/packages/flutter/lib/src/widgets/binding.dart
@@ -10,6 +10,7 @@ import 'package:flutter/rendering.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:flutter/services.dart';
 
+import 'app.dart';
 import 'framework.dart';
 
 export 'dart:ui' show AppLifecycleState, Locale;
@@ -50,6 +51,22 @@ class WidgetFlutterBinding extends BindingBase with Scheduler, Gesturer, Service
     ui.window.onLocaleChanged = handleLocaleChanged;
     ui.window.onPopRoute = handlePopRoute;
     ui.window.onAppLifecycleStateChanged = handleAppLifecycleStateChanged;
+  }
+
+  @override
+  void initServiceExtensions() {
+    super.initServiceExtensions();
+
+    registerBoolServiceExtension(
+      name: 'showPerformanceOverlay',
+      getter: () => WidgetsApp.showPerformanceOverlayOverride,
+      setter: (bool value) {
+        if (WidgetsApp.showPerformanceOverlayOverride == value)
+          return;
+        WidgetsApp.showPerformanceOverlayOverride = value;
+        buildOwner.reassemble(renderViewElement);
+      }
+    );
   }
 
   /// The one static instance of this class.
@@ -113,13 +130,13 @@ class WidgetFlutterBinding extends BindingBase with Scheduler, Gesturer, Service
       container: renderView,
       debugShortDescription: '[root]',
       child: app
-    ).attachToRenderTree(buildOwner, _renderViewElement);
+    ).attachToRenderTree(buildOwner, renderViewElement);
     beginFrame();
   }
 
   @override
   void reassembleApplication() {
-    buildOwner.reassemble(_renderViewElement);
+    buildOwner.reassemble(renderViewElement);
     super.reassembleApplication();
   }
 }


### PR DESCRIPTION
This only works for apps which use WidgetsApp.  Apps which don't
(like the game) could presumably read the static themselves
off of WidgetsApp.

@devoncarew @hixie
