### PR TITLE
Make the widgets binding reusable.

### DIFF
--- a/examples/layers/widgets/spinning_mixed.dart
+++ b/examples/layers/widgets/spinning_mixed.dart
@@ -89,7 +89,7 @@ void rotate(Duration timeStamp) {
 }
 
 void main() {
-  WidgetFlutterBinding.ensureInitialized();
+  Widgeteer binding = WidgetFlutterBinding.ensureInitialized();
   RenderProxyBox proxy = new RenderProxyBox();
   attachWidgetTreeToRenderTree(proxy);
 
@@ -101,6 +101,6 @@ void main() {
   transformBox = new RenderTransform(child: flexRoot, transform: new Matrix4.identity());
   RenderPadding root = new RenderPadding(padding: new EdgeInsets.all(80.0), child: transformBox);
 
-  WidgetFlutterBinding.instance.renderView.child = root;
-  WidgetFlutterBinding.instance.addPersistentFrameCallback(rotate);
+  binding.renderView.child = root;
+  binding.addPersistentFrameCallback(rotate);
 }

--- a/packages/flutter/benchmark/stocks/build_bench.dart
+++ b/packages/flutter/benchmark/stocks/build_bench.dart
@@ -27,14 +27,14 @@ void main() {
     appState = tester.stateOf(find.byType(stocks.StocksApp));
   });
 
-  WidgetFlutterBinding binding = WidgetFlutterBinding.instance;
+  BuildOwner buildOwner = Widgeteer.instance.buildOwner;
 
   Stopwatch watch = new Stopwatch()
     ..start();
 
   for (int i = 0; i < _kNumberOfIterations || _kRunForever; ++i) {
     appState.setState(_doNothing);
-    binding.buildOwner.buildDirtyElements();
+    buildOwner.buildDirtyElements();
   }
 
   watch.stop();

--- a/packages/flutter/benchmark/stocks/layout_bench.dart
+++ b/packages/flutter/benchmark/stocks/layout_bench.dart
@@ -24,14 +24,14 @@ void main() {
 
   ViewConfiguration big = const ViewConfiguration(size: const Size(360.0, 640.0));
   ViewConfiguration small = const ViewConfiguration(size: const Size(355.0, 635.0));
-  RenderView renderView = WidgetFlutterBinding.instance.renderView;
+  RenderView renderView = Widgeteer.instance.renderView;
 
   Stopwatch watch = new Stopwatch()
     ..start();
 
   for (int i = 0; i < _kNumberOfIterations || _kRunForever; ++i) {
     renderView.configuration = (i % 2 == 0) ? big : small;
-    WidgetFlutterBinding.instance.pipelineOwner.flushLayout();
+    Renderer.instance.pipelineOwner.flushLayout();
   }
 
   watch.stop();

--- a/packages/flutter/lib/src/rendering/binding.dart
+++ b/packages/flutter/lib/src/rendering/binding.dart
@@ -20,9 +20,7 @@ import 'semantics.dart';
 export 'package:flutter/gestures.dart' show HitTestResult;
 
 /// The glue between the render tree and the Flutter engine.
-abstract class Renderer extends Object with Scheduler, Services
-  implements HitTestable {
-
+abstract class Renderer implements Scheduler, Services, HitTestable {
   @override
   void initInstances() {
     super.initInstances();
@@ -73,6 +71,12 @@ abstract class Renderer extends Object with Scheduler, Services
     });
   }
 
+  /// Creates a [RenderView] object to be the root of the
+  /// [RenderObject] rendering tree, and initializes it so that it
+  /// will be rendered when the engine is next ready to display a
+  /// frame.
+  ///
+  /// Called automatically when the binding is created.
   void initRenderView() {
     if (renderView == null) {
       renderView = new RenderView();
@@ -88,6 +92,8 @@ abstract class Renderer extends Object with Scheduler, Services
   /// The render tree that's attached to the output surface.
   RenderView get renderView => _renderView;
   RenderView _renderView;
+  /// Sets the given [RenderView] object (which must not be null), and its tree, to
+  /// be the new render tree to display. The previous tree, if any, is detached.
   void set renderView(RenderView value) {
     assert(value != null);
     if (_renderView == value)
@@ -98,11 +104,17 @@ abstract class Renderer extends Object with Scheduler, Services
     _renderView.attach(pipelineOwner);
   }
 
+  /// Invoked when the system metrics change.
+  ///
+  /// See [ui.window.onMetricsChanged].
   void handleMetricsChanged() {
     assert(renderView != null);
     renderView.configuration = new ViewConfiguration(size: ui.window.size);
   }
 
+  /// Prepares the rendering library to handle semantics requests from the engine.
+  ///
+  /// Called automatically when the binding is created.
   void initSemantics() {
     SemanticsNode.onSemanticsEnabled = renderView.scheduleInitialSemantics;
     shell.provideService(mojom.SemanticsServer.serviceName, (core.MojoMessagePipeEndpoint endpoint) {
@@ -116,6 +128,8 @@ abstract class Renderer extends Object with Scheduler, Services
   }
 
   /// Pump the rendering pipeline to generate a frame.
+  ///
+  /// Called automatically by the engine when it is time to lay out and paint a frame.
   void beginFrame() {
     assert(renderView != null);
     pipelineOwner.flushLayout();

--- a/packages/flutter/lib/src/widgets/app.dart
+++ b/packages/flutter/lib/src/widgets/app.dart
@@ -98,7 +98,7 @@ class WidgetsApp extends StatefulWidget {
   WidgetsAppState<WidgetsApp> createState() => new WidgetsAppState<WidgetsApp>();
 }
 
-class WidgetsAppState<T extends WidgetsApp> extends State<T> implements BindingObserver {
+class WidgetsAppState<T extends WidgetsApp> extends State<T> implements WidgetsBindingObserver {
 
   GlobalObjectKey _navigator;
 
@@ -109,12 +109,12 @@ class WidgetsAppState<T extends WidgetsApp> extends State<T> implements BindingO
     super.initState();
     _navigator = new GlobalObjectKey(this);
     didChangeLocale(ui.window.locale);
-    WidgetFlutterBinding.instance.addObserver(this);
+    Widgeteer.instance.addObserver(this);
   }
 
   @override
   void dispose() {
-    WidgetFlutterBinding.instance.removeObserver(this);
+    Widgeteer.instance.removeObserver(this);
     super.dispose();
   }
 

--- a/packages/flutter/lib/src/widgets/drag_target.dart
+++ b/packages/flutter/lib/src/widgets/drag_target.dart
@@ -417,7 +417,7 @@ class _DragAvatar<T> extends Drag {
     _lastOffset = globalPosition - dragStartPoint;
     _entry.markNeedsBuild();
     HitTestResult result = new HitTestResult();
-    WidgetFlutterBinding.instance.hitTest(result, globalPosition + feedbackOffset);
+    Widgeteer.instance.hitTest(result, globalPosition + feedbackOffset);
 
     List<_DragTargetState<T>> targets = _getDragTargets(result.path).toList();
 

--- a/packages/flutter_driver/lib/src/extension.dart
+++ b/packages/flutter_driver/lib/src/extension.dart
@@ -21,7 +21,7 @@ const String _extensionMethodName = 'driver';
 const String _extensionMethod = 'ext.flutter.$_extensionMethodName';
 const Duration _kDefaultTimeout = const Duration(seconds: 5);
 
-class _DriverBinding extends WidgetFlutterBinding {
+class _DriverBinding extends WidgetFlutterBinding { // TODO(ianh): refactor so we're not extending a concrete binding
   @override
   void initServiceExtensions() {
     super.initServiceExtensions();
@@ -41,9 +41,9 @@ class _DriverBinding extends WidgetFlutterBinding {
 /// Call this function prior to running your application, e.g. before you call
 /// `runApp`.
 void enableFlutterDriverExtension() {
-  assert(WidgetFlutterBinding.instance == null);
+  assert(Widgeteer.instance == null);
   new _DriverBinding();
-  assert(WidgetFlutterBinding.instance is _DriverBinding);
+  assert(Widgeteer.instance is _DriverBinding);
 }
 
 /// Handles a command and returns a result.

--- a/packages/flutter_markdown/test/flutter_markdown_test.dart
+++ b/packages/flutter_markdown/test/flutter_markdown_test.dart
@@ -100,9 +100,9 @@ void main() {
       tester.pumpWidget(new Markdown(data: "Data1"));
       _expectTextStrings(tester.widgets, <String>["Data1"]);
 
-      String stateBefore = WidgetFlutterBinding.instance.renderViewElement.toStringDeep();
+      String stateBefore = Widgeteer.instance.renderViewElement.toStringDeep();
       tester.pumpWidget(new Markdown(data: "Data1"));
-      String stateAfter = WidgetFlutterBinding.instance.renderViewElement.toStringDeep();
+      String stateAfter = Widgeteer.instance.renderViewElement.toStringDeep();
       expect(stateBefore, equals(stateAfter));
 
       tester.pumpWidget(new Markdown(data: "Data2"));
@@ -119,9 +119,9 @@ void main() {
 
       tester.pumpWidget(new Markdown(data: "Test", markdownStyle: style1));
 
-      String stateBefore = WidgetFlutterBinding.instance.renderViewElement.toStringDeep();
+      String stateBefore = Widgeteer.instance.renderViewElement.toStringDeep();
       tester.pumpWidget(new Markdown(data: "Test", markdownStyle: style2));
-      String stateAfter = WidgetFlutterBinding.instance.renderViewElement.toStringDeep();
+      String stateAfter = Widgeteer.instance.renderViewElement.toStringDeep();
       expect(stateBefore, isNot(stateAfter));
     });
   });

--- a/packages/flutter_test/lib/flutter_test.dart
+++ b/packages/flutter_test/lib/flutter_test.dart
@@ -5,7 +5,7 @@
 /// Testing library for flutter, built on top of `package:test`.
 library flutter_test;
 
-export 'src/element_tree_tester.dart';
+export 'src/binding.dart';
 export 'src/instrumentation.dart';
 export 'src/service_mocker.dart';
 export 'src/test_pointer.dart';

--- a/packages/flutter_test/lib/src/binding.dart
+++ b/packages/flutter_test/lib/src/binding.dart
@@ -23,18 +23,18 @@ enum EnginePhase {
   sendSemanticsTree
 }
 
-class _SteppedWidgetFlutterBinding extends WidgetFlutterBinding {
-  _SteppedWidgetFlutterBinding._(this.async);
+class _SteppedWidgetFlutterBinding extends WidgetFlutterBinding { // TODO(ianh): refactor so we're not extending a concrete binding
+  _SteppedWidgetFlutterBinding(this.async);
 
   final FakeAsync async;
 
   /// Creates and initializes the binding. This constructor is
   /// idempotent; calling it a second time will just return the
   /// previously-created instance.
-  static WidgetFlutterBinding ensureInitialized(FakeAsync async) {
-    if (WidgetFlutterBinding.instance == null)
-      new _SteppedWidgetFlutterBinding._(async);
-    return WidgetFlutterBinding.instance;
+  static Widgeteer ensureInitialized(FakeAsync async) {
+    if (Widgeteer.instance == null)
+      new _SteppedWidgetFlutterBinding(async);
+    return Widgeteer.instance;
   }
 
   EnginePhase phase = EnginePhase.sendSemanticsTree;

--- a/packages/flutter_test/lib/src/instrumentation.dart
+++ b/packages/flutter_test/lib/src/instrumentation.dart
@@ -17,10 +17,10 @@ typedef Point SizeToPointFunction(Size size);
 /// This class provides hooks for accessing the rendering tree and dispatching
 /// fake tap/drag/etc. events.
 class Instrumentation {
-  Instrumentation({ WidgetFlutterBinding binding })
+  Instrumentation({ Widgeteer binding })
     : this.binding = binding ?? WidgetFlutterBinding.ensureInitialized();
 
-  final WidgetFlutterBinding binding;
+  final Widgeteer binding;
 
   /// Returns a list of all the [Layer] objects in the rendering.
   List<Layer> get layers => _layers(binding.renderView.layer);

--- a/packages/flutter_test/lib/src/widget_tester.dart
+++ b/packages/flutter_test/lib/src/widget_tester.dart
@@ -7,7 +7,7 @@ import 'package:flutter/widgets.dart';
 import 'package:quiver/testing/async.dart';
 import 'package:test/test.dart';
 
-import 'element_tree_tester.dart';
+import 'binding.dart';
 import 'test_pointer.dart';
 
 /// Runs the [callback] inside the Flutter test environment.
@@ -57,7 +57,7 @@ class WidgetTester {
   /// Exposes the [Element] tree created from widgets.
   final ElementTreeTester elementTreeTester;
 
-  WidgetFlutterBinding get binding => elementTreeTester.binding;
+  Widgeteer get binding => elementTreeTester.binding;
 
   /// Renders the UI from the given [widget].
   ///


### PR DESCRIPTION
Previously the widgets layer only provided a concrete binding, which
makes it awkward to extend it compared to other bindings. This moves
widgets to the same style as the other layers.

In a subsequent patch I'll use this to make the tests layer saner.
