### PR TITLE
Rename binding abstract classes

### DIFF
--- a/examples/layers/widgets/spinning_mixed.dart
+++ b/examples/layers/widgets/spinning_mixed.dart
@@ -89,7 +89,7 @@ void rotate(Duration timeStamp) {
 }
 
 void main() {
-  Widgeteer binding = WidgetFlutterBinding.ensureInitialized();
+  WidgetsBinding binding = WidgetsFlutterBinding.ensureInitialized();
   RenderProxyBox proxy = new RenderProxyBox();
   attachWidgetTreeToRenderTree(proxy);
 

--- a/packages/flutter/benchmark/stocks/build_bench.dart
+++ b/packages/flutter/benchmark/stocks/build_bench.dart
@@ -27,7 +27,7 @@ void main() {
     appState = tester.stateOf(find.byType(stocks.StocksApp));
   });
 
-  BuildOwner buildOwner = Widgeteer.instance.buildOwner;
+  BuildOwner buildOwner = WidgetsBinding.instance.buildOwner;
 
   Stopwatch watch = new Stopwatch()
     ..start();

--- a/packages/flutter/benchmark/stocks/layout_bench.dart
+++ b/packages/flutter/benchmark/stocks/layout_bench.dart
@@ -24,14 +24,14 @@ void main() {
 
   ViewConfiguration big = const ViewConfiguration(size: const Size(360.0, 640.0));
   ViewConfiguration small = const ViewConfiguration(size: const Size(355.0, 635.0));
-  RenderView renderView = Widgeteer.instance.renderView;
+  RenderView renderView = WidgetsBinding.instance.renderView;
 
   Stopwatch watch = new Stopwatch()
     ..start();
 
   for (int i = 0; i < _kNumberOfIterations || _kRunForever; ++i) {
     renderView.configuration = (i % 2 == 0) ? big : small;
-    Renderer.instance.pipelineOwner.flushLayout();
+    RendererBinding.instance.pipelineOwner.flushLayout();
   }
 
   watch.stop();

--- a/packages/flutter/lib/rendering.dart
+++ b/packages/flutter/lib/rendering.dart
@@ -14,9 +14,10 @@
 /// top of the rendering library, then you will want to have a binding
 /// (see [BindingBase]). You can use [RenderingFlutterBinding], or you
 /// can create your own binding. If you create your own binding, it
-/// needs to import at least [Scheduler], [Gesturer], [Services], and
-/// [Renderer]. The rendering library does not automatically create a
-/// binding, but relies on one being initialized with those features.
+/// needs to import at least [SchedulerBinding], [GestureBinding],
+/// [ServicesBinding], and [RendererBinding]. The rendering library
+/// does not automatically create a binding, but relies on one being
+/// initialized with those features.
 library rendering;
 
 export 'src/rendering/auto_layout.dart';

--- a/packages/flutter/lib/src/foundation/binding.dart
+++ b/packages/flutter/lib/src/foundation/binding.dart
@@ -30,14 +30,20 @@ typedef Future<Map<String, dynamic>> ServiceExtensionCallback(Map<String, String
 ///
 /// The top-most layer used to write the application will have a
 /// concrete class that inherits from BindingBase and uses all the
-/// various BindingBase mixins (such as [Services]). For example, the
+/// various BindingBase mixins (such as [ServicesBinding]). For example, the
 /// Widgets library in flutter introduces a binding called
-/// [WidgetFlutterBinding]. The relevant library defines how to create
+/// [WidgetsFlutterBinding]. The relevant library defines how to create
 /// the binding. It could be implied (for example,
-/// [WidgetFlutterBinding] is automatically started from [runApp]), or
+/// [WidgetsFlutterBinding] is automatically started from [runApp]), or
 /// the application might be required to explicitly call the
 /// constructor.
 abstract class BindingBase {
+  /// Default abstract constructor for bindings.
+  ///
+  /// First calls [initInstances] to have bindings initialize their
+  /// instance pointers and other state, then calls
+  /// [initServiceExtensions] to have bindings initialize their
+  /// observatory service extensions, if any.
   BindingBase() {
     assert(!_debugInitialized);
     initInstances();

--- a/packages/flutter/lib/src/gestures/binding.dart
+++ b/packages/flutter/lib/src/gestures/binding.dart
@@ -17,7 +17,7 @@ import 'hit_test.dart';
 import 'pointer_router.dart';
 
 /// A binding for the gesture subsystem.
-abstract class Gesturer extends BindingBase implements HitTestable, HitTestDispatcher, HitTestTarget {
+abstract class GestureBinding extends BindingBase implements HitTestable, HitTestDispatcher, HitTestTarget {
 
   @override
   void initInstances() {
@@ -27,8 +27,8 @@ abstract class Gesturer extends BindingBase implements HitTestable, HitTestDispa
   }
 
   /// The singleton instance of this object.
-  static Gesturer get instance => _instance;
-  static Gesturer _instance;
+  static GestureBinding get instance => _instance;
+  static GestureBinding _instance;
 
   void _handlePointerPacket(ByteData serializedPacket) {
     final mojo_bindings.Message message = new mojo_bindings.Message(
@@ -122,7 +122,7 @@ abstract class Gesturer extends BindingBase implements HitTestable, HitTestDispa
 }
 
 /// Variant of [FlutterErrorDetails] with extra fields for the gesture
-/// library's binding's pointer event dispatcher ([Gesturer.dispatchEvent]).
+/// library's binding's pointer event dispatcher ([GestureBinding.dispatchEvent]).
 ///
 /// See also [FlutterErrorDetailsForPointerRouter], which is also used by the
 /// gesture library.
@@ -155,7 +155,7 @@ class FlutterErrorDetailsForPointerEventDispatcher extends FlutterErrorDetails {
 
   /// The hit test result entry for the object whose handleEvent method threw
   /// the exception.
-  /// 
+  ///
   /// The target object itself is given by the [HitTestEntry.target] property of
   /// the hitTestEntry object.
   final HitTestEntry hitTestEntry;

--- a/packages/flutter/lib/src/gestures/multidrag.dart
+++ b/packages/flutter/lib/src/gestures/multidrag.dart
@@ -133,8 +133,8 @@ abstract class MultiDragGestureRecognizer<T extends MultiDragPointerState> exten
     assert(!_pointers.containsKey(event.pointer));
     T state = createNewPointerState(event);
     _pointers[event.pointer] = state;
-    Gesturer.instance.pointerRouter.addRoute(event.pointer, handleEvent);
-    state._setArenaEntry(Gesturer.instance.gestureArena.add(event.pointer, this));
+    GestureBinding.instance.pointerRouter.addRoute(event.pointer, handleEvent);
+    state._setArenaEntry(GestureBinding.instance.gestureArena.add(event.pointer, this));
   }
 
   T createNewPointerState(PointerDownEvent event);
@@ -202,7 +202,7 @@ abstract class MultiDragGestureRecognizer<T extends MultiDragPointerState> exten
   void _removeState(int pointer) {
     assert(_pointers != null);
     assert(_pointers.containsKey(pointer));
-    Gesturer.instance.pointerRouter.removeRoute(pointer, handleEvent);
+    GestureBinding.instance.pointerRouter.removeRoute(pointer, handleEvent);
     _pointers[pointer].dispose();
     _pointers.remove(pointer);
   }

--- a/packages/flutter/lib/src/gestures/multitap.dart
+++ b/packages/flutter/lib/src/gestures/multitap.dart
@@ -36,14 +36,14 @@ class _TapTracker {
   void startTrackingPointer(PointerRoute route) {
     if (!_isTrackingPointer) {
       _isTrackingPointer = true;
-      Gesturer.instance.pointerRouter.addRoute(pointer, route);
+      GestureBinding.instance.pointerRouter.addRoute(pointer, route);
     }
   }
 
   void stopTrackingPointer(PointerRoute route) {
     if (_isTrackingPointer) {
       _isTrackingPointer = false;
-      Gesturer.instance.pointerRouter.removeRoute(pointer, route);
+      GestureBinding.instance.pointerRouter.removeRoute(pointer, route);
     }
   }
 
@@ -91,7 +91,7 @@ class DoubleTapGestureRecognizer extends GestureRecognizer {
     _stopDoubleTapTimer();
     _TapTracker tracker = new _TapTracker(
       event: event,
-      entry: Gesturer.instance.gestureArena.add(event.pointer, this)
+      entry: GestureBinding.instance.gestureArena.add(event.pointer, this)
     );
     _trackers[event.pointer] = tracker;
     tracker.startTrackingPointer(handleEvent);
@@ -154,14 +154,14 @@ class DoubleTapGestureRecognizer extends GestureRecognizer {
       _TapTracker tracker = _firstTap;
       _firstTap = null;
       _reject(tracker);
-      Gesturer.instance.gestureArena.release(tracker.pointer);
+      GestureBinding.instance.gestureArena.release(tracker.pointer);
     }
     _clearTrackers();
   }
 
   void _registerFirstTap(_TapTracker tracker) {
     _startDoubleTapTimer();
-    Gesturer.instance.gestureArena.hold(tracker.pointer);
+    GestureBinding.instance.gestureArena.hold(tracker.pointer);
     // Note, order is important below in order for the clear -> reject logic to
     // work properly.
     _freezeTracker(tracker);
@@ -225,7 +225,7 @@ class _TapGesture extends _TapTracker {
        _lastPosition = event.position,
        super(
     event: event,
-    entry: Gesturer.instance.gestureArena.add(event.pointer, gestureRecognizer)
+    entry: GestureBinding.instance.gestureArena.add(event.pointer, gestureRecognizer)
   ) {
     startTrackingPointer(handleEvent);
     if (longTapDelay > Duration.ZERO) {

--- a/packages/flutter/lib/src/gestures/pointer_router.dart
+++ b/packages/flutter/lib/src/gestures/pointer_router.dart
@@ -101,9 +101,9 @@ class FlutterErrorDetailsForPointerRouter extends FlutterErrorDetails {
   );
 
   /// The pointer router that caught the exception.
-  /// 
-  /// In a typical application, this is the value of [Gesturer.pointerRouter] on
-  /// the binding ([Gesturer.instance]).
+  ///
+  /// In a typical application, this is the value of [GestureBinding.pointerRouter] on
+  /// the binding ([GestureBinding.instance]).
   final PointerRouter router;
 
   /// The callback that threw the exception.

--- a/packages/flutter/lib/src/gestures/recognizer.dart
+++ b/packages/flutter/lib/src/gestures/recognizer.dart
@@ -81,19 +81,19 @@ abstract class OneSequenceGestureRecognizer extends GestureRecognizer {
   void dispose() {
     resolve(GestureDisposition.rejected);
     for (int pointer in _trackedPointers)
-      Gesturer.instance.pointerRouter.removeRoute(pointer, handleEvent);
+      GestureBinding.instance.pointerRouter.removeRoute(pointer, handleEvent);
     _trackedPointers.clear();
     assert(_entries.isEmpty);
   }
 
   void startTrackingPointer(int pointer) {
-    Gesturer.instance.pointerRouter.addRoute(pointer, handleEvent);
+    GestureBinding.instance.pointerRouter.addRoute(pointer, handleEvent);
     _trackedPointers.add(pointer);
-    _entries.add(Gesturer.instance.gestureArena.add(pointer, this));
+    _entries.add(GestureBinding.instance.gestureArena.add(pointer, this));
   }
 
   void stopTrackingPointer(int pointer) {
-    Gesturer.instance.pointerRouter.removeRoute(pointer, handleEvent);
+    GestureBinding.instance.pointerRouter.removeRoute(pointer, handleEvent);
     _trackedPointers.remove(pointer);
     if (_trackedPointers.isEmpty)
       didStopTrackingLastPointer(pointer);

--- a/packages/flutter/lib/src/rendering/binding.dart
+++ b/packages/flutter/lib/src/rendering/binding.dart
@@ -20,7 +20,7 @@ import 'semantics.dart';
 export 'package:flutter/gestures.dart' show HitTestResult;
 
 /// The glue between the render tree and the Flutter engine.
-abstract class Renderer implements Scheduler, Services, HitTestable {
+abstract class RendererBinding extends BindingBase implements SchedulerBinding, ServicesBinding, HitTestable {
   @override
   void initInstances() {
     super.initInstances();
@@ -32,9 +32,9 @@ abstract class Renderer implements Scheduler, Services, HitTestable {
     addPersistentFrameCallback(_handlePersistentFrameCallback);
   }
 
-  /// The current [Renderer], if one has been created.
-  static Renderer get instance => _instance;
-  static Renderer _instance;
+  /// The current [RendererBinding], if one has been created.
+  static RendererBinding get instance => _instance;
+  static RendererBinding _instance;
 
   @override
   void initServiceExtensions() {
@@ -167,19 +167,19 @@ abstract class Renderer implements Scheduler, Services, HitTestable {
 
 /// Prints a textual representation of the entire render tree.
 void debugDumpRenderTree() {
-  debugPrint(Renderer.instance?.renderView?.toStringDeep());
+  debugPrint(RendererBinding.instance?.renderView?.toStringDeep());
 }
 
 /// Prints a textual representation of the entire layer tree.
 void debugDumpLayerTree() {
-  debugPrint(Renderer.instance?.renderView?.layer?.toStringDeep());
+  debugPrint(RendererBinding.instance?.renderView?.layer?.toStringDeep());
 }
 
 /// Prints a textual representation of the entire semantics tree.
 /// This will only work if there is a semantics client attached.
 /// Otherwise, the tree is empty and this will print "null".
 void debugDumpSemanticsTree() {
-  debugPrint(Renderer.instance?.renderView?.debugSemantics?.toStringDeep() ?? 'Semantics not collected.');
+  debugPrint(RendererBinding.instance?.renderView?.debugSemantics?.toStringDeep() ?? 'Semantics not collected.');
 }
 
 /// A concrete binding for applications that use the Rendering framework
@@ -191,7 +191,7 @@ void debugDumpSemanticsTree() {
 /// that layer's binding.
 ///
 /// See also [BindingBase].
-class RenderingFlutterBinding extends BindingBase with Scheduler, Gesturer, Services, Renderer {
+class RenderingFlutterBinding extends BindingBase with SchedulerBinding, GestureBinding, ServicesBinding, RendererBinding {
   RenderingFlutterBinding({ RenderBox root }) {
     assert(renderView != null);
     renderView.child = root;

--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -1096,7 +1096,7 @@ abstract class RenderObject extends AbstractNode implements HitTestTarget {
       });
       if (owner != null)
         owner._nodesNeedingLayout.add(this);
-      Scheduler.instance.ensureVisualUpdate();
+      RendererBinding.instance.ensureVisualUpdate();
     }
   }
 
@@ -1504,7 +1504,7 @@ abstract class RenderObject extends AbstractNode implements HitTestTarget {
       assert(_layer != null);
       if (owner != null)
         owner._nodesNeedingPaint.add(this);
-      Scheduler.instance.ensureVisualUpdate();
+      RendererBinding.instance.ensureVisualUpdate();
     } else if (parent is RenderObject) {
       // We don't have our own layer; one of our ancestors will take
       // care of updating the layer we're in and when they do that
@@ -1518,7 +1518,7 @@ abstract class RenderObject extends AbstractNode implements HitTestTarget {
       // then we have to paint ourselves, since nobody else can paint
       // us. We don't add ourselves to _nodesNeedingPaint in this
       // case, because the root is always told to paint regardless.
-      Scheduler.instance.ensureVisualUpdate();
+      RendererBinding.instance.ensureVisualUpdate();
     }
   }
 
@@ -1626,7 +1626,7 @@ abstract class RenderObject extends AbstractNode implements HitTestTarget {
   /// Requires that this render object is attached, and is the root of
   /// the render tree.
   ///
-  /// See [Renderer] for an example of how this function is used.
+  /// See [RendererBinding] for an example of how this function is used.
   void scheduleInitialSemantics() {
     assert(attached);
     assert(parent is! RenderObject);
@@ -1636,7 +1636,7 @@ abstract class RenderObject extends AbstractNode implements HitTestTarget {
     assert(owner._semanticsEnabled == false);
     owner._semanticsEnabled = true;
     owner._nodesNeedingSemantics.add(this);
-    Scheduler.instance.ensureVisualUpdate();
+    RendererBinding.instance.ensureVisualUpdate();
   }
 
   /// Whether this RenderObject introduces a new box for accessibility purposes.

--- a/packages/flutter/lib/src/rendering/view.dart
+++ b/packages/flutter/lib/src/rendering/view.dart
@@ -5,13 +5,13 @@
 import 'dart:developer';
 import 'dart:ui' as ui show Scene, SceneBuilder, window;
 
-import 'package:flutter/scheduler.dart';
 import 'package:vector_math/vector_math_64.dart';
 
 import 'box.dart';
 import 'debug.dart';
 import 'layer.dart';
 import 'object.dart';
+import 'binding.dart';
 
 /// The layout constraints for the root render object.
 class ViewConfiguration {
@@ -73,7 +73,7 @@ class RenderView extends RenderObject with RenderObjectWithChildMixin<RenderBox>
   void scheduleInitialFrame() {
     scheduleInitialLayout();
     scheduleInitialPaint(new TransformLayer(transform: _logicalToDeviceTransform));
-    Scheduler.instance.ensureVisualUpdate();
+    RendererBinding.instance.ensureVisualUpdate();
   }
 
   // We never call layout() on this class, so this should never get

--- a/packages/flutter/lib/src/scheduler/binding.dart
+++ b/packages/flutter/lib/src/scheduler/binding.dart
@@ -26,7 +26,7 @@ double timeDilation = 1.0;
 /// common time base.
 typedef void FrameCallback(Duration timeStamp);
 
-/// Signature for the [Scheduler.schedulingStrategy] callback. Invoked
+/// Signature for the [SchedulerBinding.schedulingStrategy] callback. Invoked
 /// whenever the system needs to decide whether a task at a given
 /// priority needs to be run.
 ///
@@ -34,7 +34,7 @@ typedef void FrameCallback(Duration timeStamp);
 /// at this time, false otherwise.
 ///
 /// See also [defaultSchedulingStrategy].
-typedef bool SchedulingStrategy({ int priority, Scheduler scheduler });
+typedef bool SchedulingStrategy({ int priority, SchedulerBinding scheduler });
 
 class _TaskEntry {
   const _TaskEntry(this.task, this.priority);
@@ -69,7 +69,7 @@ class _FrameCallbackEntry {
 /// * Non-rendering tasks, to be run between frames. These are given a
 ///   priority and are executed in priority order according to a
 ///   [schedulingStrategy].
-abstract class Scheduler extends BindingBase {
+abstract class SchedulerBinding extends BindingBase {
 
   @override
   void initInstances() {
@@ -78,9 +78,9 @@ abstract class Scheduler extends BindingBase {
     ui.window.onBeginFrame = handleBeginFrame;
   }
 
-  /// The current [Scheduler], if one has been created.
-  static Scheduler get instance => _instance;
-  static Scheduler _instance;
+  /// The current [SchedulerBinding], if one has been created.
+  static SchedulerBinding get instance => _instance;
+  static SchedulerBinding _instance;
 
   @override
   void initServiceExtensions() {
@@ -237,7 +237,7 @@ abstract class Scheduler extends BindingBase {
   /// you want printed when a transient callback is registered:
   ///
   /// ```dart
-  /// assert(Scheduler.instance.debugAssertNoTransientCallbacks(
+  /// assert(SchedulerBinding.instance.debugAssertNoTransientCallbacks(
   ///   'A leak of transient callbacks was detected while doing foo.'
   /// ));
   /// ```
@@ -398,12 +398,12 @@ abstract class Scheduler extends BindingBase {
   }
 }
 
-/// The default [SchedulingStrategy] for [Scheduler.schedulingStrategy].
+/// The default [SchedulingStrategy] for [SchedulerBinding.schedulingStrategy].
 ///
 /// If there are any frame callbacks registered, only runs tasks with
 /// a [Priority] of [Priority.animation] or higher. Otherwise, runs
 /// all tasks.
-bool defaultSchedulingStrategy({ int priority, Scheduler scheduler }) {
+bool defaultSchedulingStrategy({ int priority, SchedulerBinding scheduler }) {
   if (scheduler.transientCallbackCount > 0)
     return priority >= Priority.animation.value;
   return true;

--- a/packages/flutter/lib/src/scheduler/priority.dart
+++ b/packages/flutter/lib/src/scheduler/priority.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// A task priority, as passed to [Scheduler.scheduleTask].
+/// A task priority, as passed to [SchedulerBinding.scheduleTask].
 class Priority {
   const Priority._(this._value);
 

--- a/packages/flutter/lib/src/scheduler/ticker.dart
+++ b/packages/flutter/lib/src/scheduler/ticker.dart
@@ -17,7 +17,7 @@ typedef void TickerCallback(Duration elapsed);
 /// When created, a ticker is initially disabled. Call [start] to
 /// enable the ticker.
 ///
-/// See also [Scheduler.scheduleFrameCallback].
+/// See also [SchedulerBinding.scheduleFrameCallback].
 class Ticker {
   /// Creates a ticker that will call [onTick] once per frame while running.
   Ticker(TickerCallback onTick) : _onTick = onTick;
@@ -53,7 +53,7 @@ class Ticker {
     _startTime = null;
 
     if (_animationId != null) {
-      Scheduler.instance.cancelFrameCallbackWithId(_animationId);
+      SchedulerBinding.instance.cancelFrameCallbackWithId(_animationId);
       _animationId = null;
     }
 
@@ -84,6 +84,6 @@ class Ticker {
   void _scheduleTick({ bool rescheduling: false }) {
     assert(isTicking);
     assert(_animationId == null);
-    _animationId = Scheduler.instance.scheduleFrameCallback(_tick, rescheduling: rescheduling);
+    _animationId = SchedulerBinding.instance.scheduleFrameCallback(_tick, rescheduling: rescheduling);
   }
 }

--- a/packages/flutter/lib/src/services/binding.dart
+++ b/packages/flutter/lib/src/services/binding.dart
@@ -6,7 +6,16 @@ import 'package:flutter/foundation.dart';
 
 import 'shell.dart';
 
-abstract class Services extends BindingBase {
+/// Ensures that the [MojoShell] singleton is created synchronously
+/// during binding initialization. This allows other binding classes
+/// to register services in the same call stack as the services are
+/// offered to the embedder, thus avoiding any potential race
+/// conditions. For example, without this, the embedder might have
+/// requested a service before the Dart VM has started running; if the
+/// [MojoShell] is then created in an earlier call stack than the
+/// server for that service is provided, then the request will be
+/// rejected as not matching any registered servers.
+abstract class ServicesBinding extends BindingBase {
   @override
   void initInstances() {
     super.initInstances();

--- a/packages/flutter/lib/src/services/shell.dart
+++ b/packages/flutter/lib/src/services/shell.dart
@@ -18,7 +18,7 @@ typedef bool OverrideConnectToService(String url, Object proxy);
 /// Manages connections with embedder-provided services.
 class MojoShell {
   /// Creates the MojoShell singleton. This constructor can only be called once.
-  /// If your application uses bindings, it is called by the [Services] binding.
+  /// If your application uses bindings, it is called by the [ServicesBinding] binding.
   /// (See [BindingBase] for more details on bindings. Any application using
   /// the Flutter 'rendering' or 'widgets' libraries uses a binding.)
   MojoShell() {

--- a/packages/flutter/lib/src/widgets/app.dart
+++ b/packages/flutter/lib/src/widgets/app.dart
@@ -109,12 +109,12 @@ class WidgetsAppState<T extends WidgetsApp> extends State<T> implements WidgetsB
     super.initState();
     _navigator = new GlobalObjectKey(this);
     didChangeLocale(ui.window.locale);
-    Widgeteer.instance.addObserver(this);
+    WidgetsBinding.instance.addObserver(this);
   }
 
   @override
   void dispose() {
-    Widgeteer.instance.removeObserver(this);
+    WidgetsBinding.instance.removeObserver(this);
     super.dispose();
   }
 

--- a/packages/flutter/lib/src/widgets/binding.dart
+++ b/packages/flutter/lib/src/widgets/binding.dart
@@ -17,7 +17,7 @@ export 'dart:ui' show AppLifecycleState, Locale;
 
 /// Interface for classes that register with the Widgets layer binding.
 ///
-/// See [Widgeteer.addObserver] and [Widgeteer.removeObserver].
+/// See [WidgetsBinding.addObserver] and [WidgetsBinding.removeObserver].
 abstract class WidgetsBindingObserver {
   /// Called when the system tells the app to pop the current route.
   /// For example, on Android, this is called when the user presses
@@ -48,7 +48,7 @@ abstract class WidgetsBindingObserver {
 }
 
 /// The glue between the widgets layer and the Flutter engine.
-abstract class Widgeteer implements Gesturer, Renderer {
+abstract class WidgetsBinding extends BindingBase implements GestureBinding, RendererBinding {
   @override
   void initInstances() {
     super.initInstances();
@@ -59,13 +59,13 @@ abstract class Widgeteer implements Gesturer, Renderer {
     ui.window.onAppLifecycleStateChanged = handleAppLifecycleStateChanged;
   }
 
-  /// The current [Widgeteer], if one has been created.
+  /// The current [WidgetsBinding], if one has been created.
   ///
   /// If you need the binding to be constructed before calling [runApp],
   /// you can ensure a Widget binding has been constructed by calling the
-  /// `WidgetFlutterBinding.ensureInitialized()` function.
-  static Widgeteer get instance => _instance;
-  static Widgeteer _instance;
+  /// `WidgetsFlutterBinding.ensureInitialized()` function.
+  static WidgetsBinding get instance => _instance;
+  static WidgetsBinding _instance;
 
   @override
   void initServiceExtensions() {
@@ -202,19 +202,19 @@ abstract class Widgeteer implements Gesturer, Renderer {
 
 /// Inflate the given widget and attach it to the screen.
 ///
-/// Initializes the binding using [WidgetFlutterBinding] if necessary.
+/// Initializes the binding using [WidgetsFlutterBinding] if necessary.
 void runApp(Widget app) {
-  WidgetFlutterBinding.ensureInitialized()._runApp(app);
+  WidgetsFlutterBinding.ensureInitialized()._runApp(app);
 }
 
 /// Print a string representation of the currently running app.
 void debugDumpApp() {
-  assert(Widgeteer.instance != null);
-  assert(Widgeteer.instance.renderViewElement != null);
+  assert(WidgetsBinding.instance != null);
+  assert(WidgetsBinding.instance.renderViewElement != null);
   String mode = 'RELEASE MODE';
   assert(() { mode = 'CHECKED MODE'; return true; });
-  debugPrint('${Widgeteer.instance.runtimeType} - $mode');
-  debugPrint(Widgeteer.instance.renderViewElement.toStringDeep());
+  debugPrint('${WidgetsBinding.instance.runtimeType} - $mode');
+  debugPrint(WidgetsBinding.instance.renderViewElement.toStringDeep());
 }
 
 /// This class provides a bridge from a RenderObject to an Element tree. The
@@ -269,7 +269,7 @@ class RenderObjectToWidgetAdapter<T extends RenderObject> extends RenderObjectWi
 /// In typical usage, it will be instantiated for a RenderObjectToWidgetAdapter
 /// whose container is the RenderView that connects to the Flutter engine. In
 /// this usage, it is normally instantiated by the bootstrapping logic in the
-/// WidgetFlutterBinding singleton created by runApp().
+/// WidgetsFlutterBinding singleton created by runApp().
 class RenderObjectToWidgetElement<T extends RenderObject> extends RootRenderObjectElement {
   RenderObjectToWidgetElement(RenderObjectToWidgetAdapter<T> widget) : super(widget);
 
@@ -323,16 +323,16 @@ class RenderObjectToWidgetElement<T extends RenderObject> extends RootRenderObje
 
 /// A concrete binding for applications based on the Widgets framework.
 /// This is the glue that binds the framework to the Flutter engine.
-class WidgetFlutterBinding extends BindingBase with Scheduler, Gesturer, Services, Renderer, Widgeteer {
-  /// Creates and initializes the WidgetFlutterBinding. This function
+class WidgetsFlutterBinding extends BindingBase with SchedulerBinding, GestureBinding, ServicesBinding, RendererBinding, WidgetsBinding {
+  /// Creates and initializes the WidgetsFlutterBinding. This function
   /// is idempotent; calling it a second time will just return the
   /// previously-created instance.
   ///
   /// You only need to call this method if you need the binding to be
   /// initialized before calling [runApp].
-  static WidgetFlutterBinding ensureInitialized() {
-    if (Widgeteer.instance == null)
-      new WidgetFlutterBinding();
-    return Widgeteer.instance;
+  static WidgetsFlutterBinding ensureInitialized() {
+    if (WidgetsBinding.instance == null)
+      new WidgetsFlutterBinding();
+    return WidgetsBinding.instance;
   }
 }

--- a/packages/flutter/lib/src/widgets/drag_target.dart
+++ b/packages/flutter/lib/src/widgets/drag_target.dart
@@ -417,7 +417,7 @@ class _DragAvatar<T> extends Drag {
     _lastOffset = globalPosition - dragStartPoint;
     _entry.markNeedsBuild();
     HitTestResult result = new HitTestResult();
-    Widgeteer.instance.hitTest(result, globalPosition + feedbackOffset);
+    WidgetsBinding.instance.hitTest(result, globalPosition + feedbackOffset);
 
     List<_DragTargetState<T>> targets = _getDragTargets(result.path).toList();
 

--- a/packages/flutter/lib/src/widgets/gesture_detector.dart
+++ b/packages/flutter/lib/src/widgets/gesture_detector.dart
@@ -339,7 +339,7 @@ class RawGestureDetectorState extends State<RawGestureDetector> {
       // tree is different from the owner assigned to the renderer instance.
       // Once elements have a notion of owners this assertion can be written
       // more clearly.
-      if (!Renderer.instance.pipelineOwner.debugDoingLayout) {
+      if (!RendererBinding.instance.pipelineOwner.debugDoingLayout) {
         throw new FlutterError(
           'Unexpected call to replaceGestureRecognizers() method of RawGestureDetectorState.\n'
           'The replaceGestureRecognizers() method can only be called during the layout phase. '

--- a/packages/flutter/lib/src/widgets/heroes.dart
+++ b/packages/flutter/lib/src/widgets/heroes.dart
@@ -4,9 +4,8 @@
 
 import 'dart:collection';
 
-import 'package:flutter/scheduler.dart';
-
 import 'basic.dart';
+import 'binding.dart';
 import 'framework.dart';
 import 'navigator.dart';
 import 'overlay.dart';
@@ -444,7 +443,7 @@ class HeroController extends NavigatorObserver {
   void _checkForHeroQuest() {
     if (_from != null && _to != null && _from != _to) {
       _to.offstage = _to.animation.status != AnimationStatus.completed;
-      Scheduler.instance.addPostFrameCallback(_updateQuest);
+      WidgetsBinding.instance.addPostFrameCallback(_updateQuest);
     }
   }
 

--- a/packages/flutter/test/animation/animation_controller_test.dart
+++ b/packages/flutter/test/animation/animation_controller_test.dart
@@ -3,13 +3,12 @@
 // found in the LICENSE file.
 
 import 'package:flutter/animation.dart';
-import 'package:flutter/scheduler.dart';
 import 'package:flutter/widgets.dart';
 import 'package:test/test.dart';
 
 void main() {
   test("Can set value during status callback", () {
-    WidgetFlutterBinding.ensureInitialized();
+    WidgetsFlutterBinding.ensureInitialized();
     AnimationController controller = new AnimationController(
       duration: const Duration(milliseconds: 100)
     );
@@ -30,10 +29,10 @@ void main() {
     controller.forward();
     expect(didComplete, isFalse);
     expect(didDismiss, isFalse);
-    Scheduler.instance.handleBeginFrame(const Duration(seconds: 1));
+    WidgetsBinding.instance.handleBeginFrame(const Duration(seconds: 1));
     expect(didComplete, isFalse);
     expect(didDismiss, isFalse);
-    Scheduler.instance.handleBeginFrame(const Duration(seconds: 2));
+    WidgetsBinding.instance.handleBeginFrame(const Duration(seconds: 2));
     expect(didComplete, isTrue);
     expect(didDismiss, isTrue);
 
@@ -41,7 +40,7 @@ void main() {
   });
 
   test("Receives status callbacks for forward and reverse", () {
-    WidgetFlutterBinding.ensureInitialized();
+    WidgetsFlutterBinding.ensureInitialized();
     AnimationController controller = new AnimationController(
       duration: const Duration(milliseconds: 100)
     );
@@ -87,16 +86,16 @@ void main() {
     controller.reverse();
     log.clear();
 
-    Scheduler.instance.handleBeginFrame(const Duration(seconds: 10));
+    WidgetsBinding.instance.handleBeginFrame(const Duration(seconds: 10));
     expect(log, equals([]));
     expect(valueLog, equals([]));
-    Scheduler.instance.handleBeginFrame(const Duration(seconds: 20));
+    WidgetsBinding.instance.handleBeginFrame(const Duration(seconds: 20));
     expect(log, equals([]));
     expect(valueLog, equals([]));
-    Scheduler.instance.handleBeginFrame(const Duration(seconds: 30));
+    WidgetsBinding.instance.handleBeginFrame(const Duration(seconds: 30));
     expect(log, equals([]));
     expect(valueLog, equals([]));
-    Scheduler.instance.handleBeginFrame(const Duration(seconds: 40));
+    WidgetsBinding.instance.handleBeginFrame(const Duration(seconds: 40));
     expect(log, equals([]));
     expect(valueLog, equals([]));
 
@@ -104,7 +103,7 @@ void main() {
   });
 
   test("Forward and reverse from values", () {
-    WidgetFlutterBinding.ensureInitialized();
+    WidgetsFlutterBinding.ensureInitialized();
     AnimationController controller = new AnimationController(
       duration: const Duration(milliseconds: 100)
     );

--- a/packages/flutter/test/gestures/double_tap_test.dart
+++ b/packages/flutter/test/gestures/double_tap_test.dart
@@ -24,7 +24,7 @@ class TestGestureArenaMember extends GestureArenaMember {
 }
 
 void main() {
-  setUp(ensureGesturer);
+  setUp(ensureGestureBinding);
 
   // Down/up pair 1: normal tap sequence
   const PointerDownEvent down1 = const PointerDownEvent(
@@ -95,25 +95,25 @@ void main() {
     };
 
     tap.addPointer(down1);
-    Gesturer.instance.gestureArena.close(1);
+    GestureBinding.instance.gestureArena.close(1);
     expect(doubleTapRecognized, isFalse);
-    Gesturer.instance.pointerRouter.route(down1);
+    GestureBinding.instance.pointerRouter.route(down1);
     expect(doubleTapRecognized, isFalse);
 
-    Gesturer.instance.pointerRouter.route(up1);
+    GestureBinding.instance.pointerRouter.route(up1);
     expect(doubleTapRecognized, isFalse);
-    Gesturer.instance.gestureArena.sweep(1);
+    GestureBinding.instance.gestureArena.sweep(1);
     expect(doubleTapRecognized, isFalse);
 
     tap.addPointer(down2);
-    Gesturer.instance.gestureArena.close(2);
+    GestureBinding.instance.gestureArena.close(2);
     expect(doubleTapRecognized, isFalse);
-    Gesturer.instance.pointerRouter.route(down2);
+    GestureBinding.instance.pointerRouter.route(down2);
     expect(doubleTapRecognized, isFalse);
 
-    Gesturer.instance.pointerRouter.route(up2);
+    GestureBinding.instance.pointerRouter.route(up2);
     expect(doubleTapRecognized, isTrue);
-    Gesturer.instance.gestureArena.sweep(2);
+    GestureBinding.instance.gestureArena.sweep(2);
     expect(doubleTapRecognized, isTrue);
 
     tap.dispose();
@@ -128,25 +128,25 @@ void main() {
     };
 
     tap.addPointer(down1);
-    Gesturer.instance.gestureArena.close(1);
+    GestureBinding.instance.gestureArena.close(1);
     expect(doubleTapRecognized, isFalse);
-    Gesturer.instance.pointerRouter.route(down1);
+    GestureBinding.instance.pointerRouter.route(down1);
     expect(doubleTapRecognized, isFalse);
 
-    Gesturer.instance.pointerRouter.route(up1);
+    GestureBinding.instance.pointerRouter.route(up1);
     expect(doubleTapRecognized, isFalse);
-    Gesturer.instance.gestureArena.sweep(1);
+    GestureBinding.instance.gestureArena.sweep(1);
     expect(doubleTapRecognized, isFalse);
 
     tap.addPointer(down3);
-    Gesturer.instance.gestureArena.close(3);
+    GestureBinding.instance.gestureArena.close(3);
     expect(doubleTapRecognized, isFalse);
-    Gesturer.instance.pointerRouter.route(down3);
+    GestureBinding.instance.pointerRouter.route(down3);
     expect(doubleTapRecognized, isFalse);
 
-    Gesturer.instance.pointerRouter.route(up3);
+    GestureBinding.instance.pointerRouter.route(up3);
     expect(doubleTapRecognized, isFalse);
-    Gesturer.instance.gestureArena.sweep(3);
+    GestureBinding.instance.gestureArena.sweep(3);
     expect(doubleTapRecognized, isFalse);
 
     tap.dispose();
@@ -161,27 +161,27 @@ void main() {
     };
 
     tap.addPointer(down4);
-    Gesturer.instance.gestureArena.close(4);
+    GestureBinding.instance.gestureArena.close(4);
     expect(doubleTapRecognized, isFalse);
-    Gesturer.instance.pointerRouter.route(down4);
+    GestureBinding.instance.pointerRouter.route(down4);
     expect(doubleTapRecognized, isFalse);
 
-    Gesturer.instance.pointerRouter.route(move4);
+    GestureBinding.instance.pointerRouter.route(move4);
     expect(doubleTapRecognized, isFalse);
-    Gesturer.instance.pointerRouter.route(up4);
+    GestureBinding.instance.pointerRouter.route(up4);
     expect(doubleTapRecognized, isFalse);
-    Gesturer.instance.gestureArena.sweep(4);
+    GestureBinding.instance.gestureArena.sweep(4);
     expect(doubleTapRecognized, isFalse);
 
     tap.addPointer(down1);
-    Gesturer.instance.gestureArena.close(1);
+    GestureBinding.instance.gestureArena.close(1);
     expect(doubleTapRecognized, isFalse);
-    Gesturer.instance.pointerRouter.route(down2);
+    GestureBinding.instance.pointerRouter.route(down2);
     expect(doubleTapRecognized, isFalse);
 
-    Gesturer.instance.pointerRouter.route(up1);
+    GestureBinding.instance.pointerRouter.route(up1);
     expect(doubleTapRecognized, isFalse);
-    Gesturer.instance.gestureArena.sweep(1);
+    GestureBinding.instance.gestureArena.sweep(1);
     expect(doubleTapRecognized, isFalse);
 
     tap.dispose();
@@ -197,26 +197,26 @@ void main() {
 
     new FakeAsync().run((FakeAsync async) {
       tap.addPointer(down1);
-      Gesturer.instance.gestureArena.close(1);
+      GestureBinding.instance.gestureArena.close(1);
       expect(doubleTapRecognized, isFalse);
-      Gesturer.instance.pointerRouter.route(down1);
+      GestureBinding.instance.pointerRouter.route(down1);
       expect(doubleTapRecognized, isFalse);
 
-      Gesturer.instance.pointerRouter.route(up1);
+      GestureBinding.instance.pointerRouter.route(up1);
       expect(doubleTapRecognized, isFalse);
-      Gesturer.instance.gestureArena.sweep(1);
+      GestureBinding.instance.gestureArena.sweep(1);
       expect(doubleTapRecognized, isFalse);
 
       async.elapse(new Duration(milliseconds: 5000));
       tap.addPointer(down2);
-      Gesturer.instance.gestureArena.close(2);
+      GestureBinding.instance.gestureArena.close(2);
       expect(doubleTapRecognized, isFalse);
-      Gesturer.instance.pointerRouter.route(down2);
+      GestureBinding.instance.pointerRouter.route(down2);
       expect(doubleTapRecognized, isFalse);
 
-      Gesturer.instance.pointerRouter.route(up2);
+      GestureBinding.instance.pointerRouter.route(up2);
       expect(doubleTapRecognized, isFalse);
-      Gesturer.instance.gestureArena.sweep(2);
+      GestureBinding.instance.gestureArena.sweep(2);
       expect(doubleTapRecognized, isFalse);
     });
 
@@ -233,38 +233,38 @@ void main() {
 
     new FakeAsync().run((FakeAsync async) {
       tap.addPointer(down1);
-      Gesturer.instance.gestureArena.close(1);
+      GestureBinding.instance.gestureArena.close(1);
       expect(doubleTapRecognized, isFalse);
-      Gesturer.instance.pointerRouter.route(down1);
+      GestureBinding.instance.pointerRouter.route(down1);
       expect(doubleTapRecognized, isFalse);
 
-      Gesturer.instance.pointerRouter.route(up1);
+      GestureBinding.instance.pointerRouter.route(up1);
       expect(doubleTapRecognized, isFalse);
-      Gesturer.instance.gestureArena.sweep(1);
+      GestureBinding.instance.gestureArena.sweep(1);
       expect(doubleTapRecognized, isFalse);
 
       async.elapse(new Duration(milliseconds: 5000));
       tap.addPointer(down2);
-      Gesturer.instance.gestureArena.close(2);
+      GestureBinding.instance.gestureArena.close(2);
       expect(doubleTapRecognized, isFalse);
-      Gesturer.instance.pointerRouter.route(down2);
+      GestureBinding.instance.pointerRouter.route(down2);
       expect(doubleTapRecognized, isFalse);
 
-      Gesturer.instance.pointerRouter.route(up2);
+      GestureBinding.instance.pointerRouter.route(up2);
       expect(doubleTapRecognized, isFalse);
-      Gesturer.instance.gestureArena.sweep(2);
+      GestureBinding.instance.gestureArena.sweep(2);
       expect(doubleTapRecognized, isFalse);
 
       async.elapse(new Duration(milliseconds: 100));
       tap.addPointer(down5);
-      Gesturer.instance.gestureArena.close(5);
+      GestureBinding.instance.gestureArena.close(5);
       expect(doubleTapRecognized, isFalse);
-      Gesturer.instance.pointerRouter.route(down5);
+      GestureBinding.instance.pointerRouter.route(down5);
       expect(doubleTapRecognized, isFalse);
 
-      Gesturer.instance.pointerRouter.route(up5);
+      GestureBinding.instance.pointerRouter.route(up5);
       expect(doubleTapRecognized, isTrue);
-      Gesturer.instance.gestureArena.sweep(5);
+      GestureBinding.instance.gestureArena.sweep(5);
       expect(doubleTapRecognized, isTrue);
     });
 
@@ -281,26 +281,26 @@ void main() {
 
     new FakeAsync().run((FakeAsync async) {
       tap.addPointer(down1);
-      Gesturer.instance.gestureArena.close(1);
+      GestureBinding.instance.gestureArena.close(1);
       expect(doubleTapRecognized, isFalse);
-      Gesturer.instance.pointerRouter.route(down1);
+      GestureBinding.instance.pointerRouter.route(down1);
       expect(doubleTapRecognized, isFalse);
 
       async.elapse(new Duration(milliseconds: 1000));
-      Gesturer.instance.pointerRouter.route(up1);
+      GestureBinding.instance.pointerRouter.route(up1);
       expect(doubleTapRecognized, isFalse);
-      Gesturer.instance.gestureArena.sweep(1);
+      GestureBinding.instance.gestureArena.sweep(1);
       expect(doubleTapRecognized, isFalse);
 
       tap.addPointer(down2);
-      Gesturer.instance.gestureArena.close(2);
+      GestureBinding.instance.gestureArena.close(2);
       expect(doubleTapRecognized, isFalse);
-      Gesturer.instance.pointerRouter.route(down2);
+      GestureBinding.instance.pointerRouter.route(down2);
       expect(doubleTapRecognized, isFalse);
 
-      Gesturer.instance.pointerRouter.route(up2);
+      GestureBinding.instance.pointerRouter.route(up2);
       expect(doubleTapRecognized, isTrue);
-      Gesturer.instance.gestureArena.sweep(2);
+      GestureBinding.instance.gestureArena.sweep(2);
       expect(doubleTapRecognized, isTrue);
     });
 
@@ -316,25 +316,25 @@ void main() {
     };
 
     tap.addPointer(down1);
-    Gesturer.instance.gestureArena.close(1);
+    GestureBinding.instance.gestureArena.close(1);
     expect(doubleTapRecognized, isFalse);
-    Gesturer.instance.pointerRouter.route(down1);
+    GestureBinding.instance.pointerRouter.route(down1);
     expect(doubleTapRecognized, isFalse);
 
     tap.addPointer(down2);
-    Gesturer.instance.gestureArena.close(2);
+    GestureBinding.instance.gestureArena.close(2);
     expect(doubleTapRecognized, isFalse);
-    Gesturer.instance.pointerRouter.route(down1);
-    expect(doubleTapRecognized, isFalse);
-
-    Gesturer.instance.pointerRouter.route(up1);
-    expect(doubleTapRecognized, isFalse);
-    Gesturer.instance.gestureArena.sweep(1);
+    GestureBinding.instance.pointerRouter.route(down1);
     expect(doubleTapRecognized, isFalse);
 
-    Gesturer.instance.pointerRouter.route(up2);
+    GestureBinding.instance.pointerRouter.route(up1);
     expect(doubleTapRecognized, isFalse);
-    Gesturer.instance.gestureArena.sweep(2);
+    GestureBinding.instance.gestureArena.sweep(1);
+    expect(doubleTapRecognized, isFalse);
+
+    GestureBinding.instance.pointerRouter.route(up2);
+    expect(doubleTapRecognized, isFalse);
+    GestureBinding.instance.gestureArena.sweep(2);
     expect(doubleTapRecognized, isFalse);
 
     tap.dispose();
@@ -349,36 +349,36 @@ void main() {
     };
 
     tap.addPointer(down1);
-    Gesturer.instance.gestureArena.close(1);
+    GestureBinding.instance.gestureArena.close(1);
     expect(doubleTapRecognized, isFalse);
-    Gesturer.instance.pointerRouter.route(down1);
+    GestureBinding.instance.pointerRouter.route(down1);
     expect(doubleTapRecognized, isFalse);
 
     tap.addPointer(down2);
-    Gesturer.instance.gestureArena.close(2);
+    GestureBinding.instance.gestureArena.close(2);
     expect(doubleTapRecognized, isFalse);
-    Gesturer.instance.pointerRouter.route(down1);
-    expect(doubleTapRecognized, isFalse);
-
-    Gesturer.instance.pointerRouter.route(up1);
-    expect(doubleTapRecognized, isFalse);
-    Gesturer.instance.gestureArena.sweep(1);
+    GestureBinding.instance.pointerRouter.route(down1);
     expect(doubleTapRecognized, isFalse);
 
-    Gesturer.instance.pointerRouter.route(up2);
+    GestureBinding.instance.pointerRouter.route(up1);
     expect(doubleTapRecognized, isFalse);
-    Gesturer.instance.gestureArena.sweep(2);
+    GestureBinding.instance.gestureArena.sweep(1);
+    expect(doubleTapRecognized, isFalse);
+
+    GestureBinding.instance.pointerRouter.route(up2);
+    expect(doubleTapRecognized, isFalse);
+    GestureBinding.instance.gestureArena.sweep(2);
     expect(doubleTapRecognized, isFalse);
 
     tap.addPointer(down1);
-    Gesturer.instance.gestureArena.close(1);
+    GestureBinding.instance.gestureArena.close(1);
     expect(doubleTapRecognized, isFalse);
-    Gesturer.instance.pointerRouter.route(down1);
+    GestureBinding.instance.pointerRouter.route(down1);
     expect(doubleTapRecognized, isFalse);
 
-    Gesturer.instance.pointerRouter.route(up1);
+    GestureBinding.instance.pointerRouter.route(up1);
     expect(doubleTapRecognized, isTrue);
-    Gesturer.instance.gestureArena.sweep(1);
+    GestureBinding.instance.gestureArena.sweep(1);
     expect(doubleTapRecognized, isTrue);
 
     tap.dispose();
@@ -395,29 +395,29 @@ void main() {
 
     tap.addPointer(down1);
     TestGestureArenaMember member = new TestGestureArenaMember();
-    GestureArenaEntry entry = Gesturer.instance.gestureArena.add(1, member);
-    Gesturer.instance.gestureArena.close(1);
+    GestureArenaEntry entry = GestureBinding.instance.gestureArena.add(1, member);
+    GestureBinding.instance.gestureArena.close(1);
     expect(doubleTapRecognized, isFalse);
-    Gesturer.instance.pointerRouter.route(down1);
+    GestureBinding.instance.pointerRouter.route(down1);
     expect(doubleTapRecognized, isFalse);
 
-    Gesturer.instance.pointerRouter.route(up1);
+    GestureBinding.instance.pointerRouter.route(up1);
     expect(doubleTapRecognized, isFalse);
     entry.resolve(GestureDisposition.accepted);
     expect(member.accepted, isTrue);
     expect(doubleTapRecognized, isFalse);
-    Gesturer.instance.gestureArena.sweep(1);
+    GestureBinding.instance.gestureArena.sweep(1);
     expect(doubleTapRecognized, isFalse);
 
     tap.addPointer(down2);
-    Gesturer.instance.gestureArena.close(2);
+    GestureBinding.instance.gestureArena.close(2);
     expect(doubleTapRecognized, isFalse);
-    Gesturer.instance.pointerRouter.route(down2);
+    GestureBinding.instance.pointerRouter.route(down2);
     expect(doubleTapRecognized, isFalse);
 
-    Gesturer.instance.pointerRouter.route(up2);
+    GestureBinding.instance.pointerRouter.route(up2);
     expect(doubleTapRecognized, isFalse);
-    Gesturer.instance.gestureArena.sweep(2);
+    GestureBinding.instance.gestureArena.sweep(2);
     expect(doubleTapRecognized, isFalse);
 
     tap.dispose();
@@ -433,29 +433,29 @@ void main() {
 
     tap.addPointer(down1);
     TestGestureArenaMember member = new TestGestureArenaMember();
-    GestureArenaEntry entry = Gesturer.instance.gestureArena.add(1, member);
-    Gesturer.instance.gestureArena.close(1);
+    GestureArenaEntry entry = GestureBinding.instance.gestureArena.add(1, member);
+    GestureBinding.instance.gestureArena.close(1);
     expect(doubleTapRecognized, isFalse);
-    Gesturer.instance.pointerRouter.route(down1);
+    GestureBinding.instance.pointerRouter.route(down1);
     expect(doubleTapRecognized, isFalse);
 
-    Gesturer.instance.pointerRouter.route(up1);
+    GestureBinding.instance.pointerRouter.route(up1);
     expect(doubleTapRecognized, isFalse);
-    Gesturer.instance.gestureArena.sweep(1);
+    GestureBinding.instance.gestureArena.sweep(1);
     expect(doubleTapRecognized, isFalse);
 
     entry.resolve(GestureDisposition.accepted);
     expect(member.accepted, isTrue);
 
     tap.addPointer(down2);
-    Gesturer.instance.gestureArena.close(2);
+    GestureBinding.instance.gestureArena.close(2);
     expect(doubleTapRecognized, isFalse);
-    Gesturer.instance.pointerRouter.route(down2);
+    GestureBinding.instance.pointerRouter.route(down2);
     expect(doubleTapRecognized, isFalse);
 
-    Gesturer.instance.pointerRouter.route(up2);
+    GestureBinding.instance.pointerRouter.route(up2);
     expect(doubleTapRecognized, isFalse);
-    Gesturer.instance.gestureArena.sweep(2);
+    GestureBinding.instance.gestureArena.sweep(2);
     expect(doubleTapRecognized, isFalse);
 
     tap.dispose();
@@ -471,29 +471,29 @@ void main() {
 
     tap.addPointer(down1);
     TestGestureArenaMember member = new TestGestureArenaMember();
-    GestureArenaEntry entry = Gesturer.instance.gestureArena.add(1, member);
-    Gesturer.instance.gestureArena.close(1);
+    GestureArenaEntry entry = GestureBinding.instance.gestureArena.add(1, member);
+    GestureBinding.instance.gestureArena.close(1);
     expect(doubleTapRecognized, isFalse);
-    Gesturer.instance.pointerRouter.route(down1);
+    GestureBinding.instance.pointerRouter.route(down1);
     expect(doubleTapRecognized, isFalse);
 
-    Gesturer.instance.pointerRouter.route(up1);
+    GestureBinding.instance.pointerRouter.route(up1);
     expect(doubleTapRecognized, isFalse);
-    Gesturer.instance.gestureArena.sweep(1);
+    GestureBinding.instance.gestureArena.sweep(1);
     expect(doubleTapRecognized, isFalse);
 
     tap.addPointer(down2);
-    Gesturer.instance.gestureArena.close(2);
+    GestureBinding.instance.gestureArena.close(2);
     expect(doubleTapRecognized, isFalse);
-    Gesturer.instance.pointerRouter.route(down2);
+    GestureBinding.instance.pointerRouter.route(down2);
     expect(doubleTapRecognized, isFalse);
 
     entry.resolve(GestureDisposition.accepted);
     expect(member.accepted, isTrue);
 
-    Gesturer.instance.pointerRouter.route(up2);
+    GestureBinding.instance.pointerRouter.route(up2);
     expect(doubleTapRecognized, isFalse);
-    Gesturer.instance.gestureArena.sweep(2);
+    GestureBinding.instance.gestureArena.sweep(2);
     expect(doubleTapRecognized, isFalse);
 
     tap.dispose();
@@ -510,15 +510,15 @@ void main() {
     new FakeAsync().run((FakeAsync async) {
       tap.addPointer(down1);
       TestGestureArenaMember member = new TestGestureArenaMember();
-      Gesturer.instance.gestureArena.add(1, member);
-      Gesturer.instance.gestureArena.close(1);
+      GestureBinding.instance.gestureArena.add(1, member);
+      GestureBinding.instance.gestureArena.close(1);
       expect(doubleTapRecognized, isFalse);
-      Gesturer.instance.pointerRouter.route(down1);
+      GestureBinding.instance.pointerRouter.route(down1);
       expect(doubleTapRecognized, isFalse);
 
-      Gesturer.instance.pointerRouter.route(up1);
+      GestureBinding.instance.pointerRouter.route(up1);
       expect(doubleTapRecognized, isFalse);
-      Gesturer.instance.gestureArena.sweep(1);
+      GestureBinding.instance.gestureArena.sweep(1);
       expect(doubleTapRecognized, isFalse);
 
       expect(member.accepted, isFalse);

--- a/packages/flutter/test/gestures/gesture_binding_test.dart
+++ b/packages/flutter/test/gestures/gesture_binding_test.dart
@@ -12,7 +12,7 @@ import 'package:test/test.dart';
 
 typedef void HandleEventCallback(PointerEvent event);
 
-class TestGestureFlutterBinding extends BindingBase with Gesturer {
+class TestGestureFlutterBinding extends BindingBase with GestureBinding {
   HandleEventCallback callback;
 
   @override
@@ -20,19 +20,19 @@ class TestGestureFlutterBinding extends BindingBase with Gesturer {
     if (callback != null)
       callback(event);
     super.handleEvent(event, entry);
-  }  
+  }
 }
 
 TestGestureFlutterBinding _binding = new TestGestureFlutterBinding();
 
-void ensureTestGesturer() {
+void ensureTestGestureBinding() {
   if (_binding == null)
     _binding = new TestGestureFlutterBinding();
-  assert(Gesturer.instance != null);
+  assert(GestureBinding.instance != null);
 }
 
 void main() {
-  setUp(ensureTestGesturer);
+  setUp(ensureTestGestureBinding);
 
   test('Pointer tap events', () {
     mojo_bindings.Encoder encoder = new mojo_bindings.Encoder();

--- a/packages/flutter/test/gestures/gesture_tester.dart
+++ b/packages/flutter/test/gestures/gesture_tester.dart
@@ -5,10 +5,10 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 
-class TestGestureFlutterBinding extends BindingBase with Gesturer { }
+class TestGestureFlutterBinding extends BindingBase with GestureBinding { }
 
-void ensureGesturer() {
-  if (Gesturer.instance == null)
+void ensureGestureBinding() {
+  if (GestureBinding.instance == null)
     new TestGestureFlutterBinding();
-  assert(Gesturer.instance != null);
+  assert(GestureBinding.instance != null);
 }

--- a/packages/flutter/test/gestures/long_press_test.dart
+++ b/packages/flutter/test/gestures/long_press_test.dart
@@ -19,7 +19,7 @@ const PointerUpEvent up = const PointerUpEvent(
 );
 
 void main() {
-  setUp(ensureGesturer);
+  setUp(ensureGestureBinding);
 
   test('Should recognize long press', () {
     LongPressGestureRecognizer longPress = new LongPressGestureRecognizer();
@@ -31,9 +31,9 @@ void main() {
 
     new FakeAsync().run((FakeAsync async) {
       longPress.addPointer(down);
-      Gesturer.instance.gestureArena.close(5);
+      GestureBinding.instance.gestureArena.close(5);
       expect(longPressRecognized, isFalse);
-      Gesturer.instance.pointerRouter.route(down);
+      GestureBinding.instance.pointerRouter.route(down);
       expect(longPressRecognized, isFalse);
       async.elapse(const Duration(milliseconds: 300));
       expect(longPressRecognized, isFalse);
@@ -54,13 +54,13 @@ void main() {
 
     new FakeAsync().run((FakeAsync async) {
       longPress.addPointer(down);
-      Gesturer.instance.gestureArena.close(5);
+      GestureBinding.instance.gestureArena.close(5);
       expect(longPressRecognized, isFalse);
-      Gesturer.instance.pointerRouter.route(down);
+      GestureBinding.instance.pointerRouter.route(down);
       expect(longPressRecognized, isFalse);
       async.elapse(const Duration(milliseconds: 300));
       expect(longPressRecognized, isFalse);
-      Gesturer.instance.pointerRouter.route(up);
+      GestureBinding.instance.pointerRouter.route(up);
       expect(longPressRecognized, isFalse);
       async.elapse(const Duration(seconds: 1));
       expect(longPressRecognized, isFalse);
@@ -86,10 +86,10 @@ void main() {
     new FakeAsync().run((FakeAsync async) {
       tap.addPointer(down);
       longPress.addPointer(down);
-      Gesturer.instance.gestureArena.close(5);
+      GestureBinding.instance.gestureArena.close(5);
       expect(tapDownRecognized, isFalse);
       expect(longPressRecognized, isFalse);
-      Gesturer.instance.pointerRouter.route(down);
+      GestureBinding.instance.pointerRouter.route(down);
       expect(tapDownRecognized, isFalse);
       expect(longPressRecognized, isFalse);
       async.elapse(const Duration(milliseconds: 300));

--- a/packages/flutter/test/gestures/scale_test.dart
+++ b/packages/flutter/test/gestures/scale_test.dart
@@ -9,11 +9,11 @@ import 'package:test/test.dart';
 import 'gesture_tester.dart';
 
 void main() {
-  setUp(ensureGesturer);
+  setUp(ensureGestureBinding);
 
   test('Should recognize scale gestures', () {
-    GestureArenaManager gestureArena = Gesturer.instance.gestureArena;
-    PointerRouter pointerRouter = Gesturer.instance.pointerRouter;
+    GestureArenaManager gestureArena = GestureBinding.instance.gestureArena;
+    PointerRouter pointerRouter = GestureBinding.instance.pointerRouter;
     ScaleGestureRecognizer scale = new ScaleGestureRecognizer();
     TapGestureRecognizer tap = new TapGestureRecognizer();
 

--- a/packages/flutter/test/gestures/scroll_test.dart
+++ b/packages/flutter/test/gestures/scroll_test.dart
@@ -9,11 +9,11 @@ import 'package:test/test.dart';
 import 'gesture_tester.dart';
 
 void main() {
-  setUp(ensureGesturer);
+  setUp(ensureGestureBinding);
 
   test('Should recognize pan', () {
-    GestureArenaManager gestureArena = Gesturer.instance.gestureArena;
-    PointerRouter pointerRouter = Gesturer.instance.pointerRouter;
+    GestureArenaManager gestureArena = GestureBinding.instance.gestureArena;
+    PointerRouter pointerRouter = GestureBinding.instance.pointerRouter;
     PanGestureRecognizer pan = new PanGestureRecognizer();
     TapGestureRecognizer tap = new TapGestureRecognizer();
 

--- a/packages/flutter/test/gestures/tap_test.dart
+++ b/packages/flutter/test/gestures/tap_test.dart
@@ -17,7 +17,7 @@ class TestGestureArenaMember extends GestureArenaMember {
 }
 
 void main() {
-  setUp(ensureGesturer);
+  setUp(ensureGestureBinding);
 
   // Down/up pair 1: normal tap sequence
   const PointerDownEvent down1 = const PointerDownEvent(
@@ -66,14 +66,14 @@ void main() {
     };
 
     tap.addPointer(down1);
-    Gesturer.instance.gestureArena.close(1);
+    GestureBinding.instance.gestureArena.close(1);
     expect(tapRecognized, isFalse);
-    Gesturer.instance.pointerRouter.route(down1);
+    GestureBinding.instance.pointerRouter.route(down1);
     expect(tapRecognized, isFalse);
 
-    Gesturer.instance.pointerRouter.route(up1);
+    GestureBinding.instance.pointerRouter.route(up1);
     expect(tapRecognized, isTrue);
-    Gesturer.instance.gestureArena.sweep(1);
+    GestureBinding.instance.gestureArena.sweep(1);
     expect(tapRecognized, isTrue);
 
     tap.dispose();
@@ -88,25 +88,25 @@ void main() {
     };
 
     tap.addPointer(down1);
-    Gesturer.instance.gestureArena.close(1);
+    GestureBinding.instance.gestureArena.close(1);
     expect(tapsRecognized, 0);
-    Gesturer.instance.pointerRouter.route(down1);
+    GestureBinding.instance.pointerRouter.route(down1);
     expect(tapsRecognized, 0);
 
-    Gesturer.instance.pointerRouter.route(up1);
+    GestureBinding.instance.pointerRouter.route(up1);
     expect(tapsRecognized, 1);
-    Gesturer.instance.gestureArena.sweep(1);
+    GestureBinding.instance.gestureArena.sweep(1);
     expect(tapsRecognized, 1);
 
     tap.addPointer(down1);
-    Gesturer.instance.gestureArena.close(1);
+    GestureBinding.instance.gestureArena.close(1);
     expect(tapsRecognized, 1);
-    Gesturer.instance.pointerRouter.route(down1);
+    GestureBinding.instance.pointerRouter.route(down1);
     expect(tapsRecognized, 1);
 
-    Gesturer.instance.pointerRouter.route(up1);
+    GestureBinding.instance.pointerRouter.route(up1);
     expect(tapsRecognized, 2);
-    Gesturer.instance.gestureArena.sweep(1);
+    GestureBinding.instance.gestureArena.sweep(1);
     expect(tapsRecognized, 2);
 
     tap.dispose();
@@ -121,26 +121,26 @@ void main() {
     };
 
     tap.addPointer(down1);
-    Gesturer.instance.gestureArena.close(1);
+    GestureBinding.instance.gestureArena.close(1);
     expect(tapsRecognized, 0);
-    Gesturer.instance.pointerRouter.route(down1);
+    GestureBinding.instance.pointerRouter.route(down1);
     expect(tapsRecognized, 0);
 
     tap.addPointer(down2);
-    Gesturer.instance.gestureArena.close(2);
+    GestureBinding.instance.gestureArena.close(2);
     expect(tapsRecognized, 0);
-    Gesturer.instance.pointerRouter.route(down1);
+    GestureBinding.instance.pointerRouter.route(down1);
     expect(tapsRecognized, 0);
 
 
-    Gesturer.instance.pointerRouter.route(up1);
+    GestureBinding.instance.pointerRouter.route(up1);
     expect(tapsRecognized, 1);
-    Gesturer.instance.gestureArena.sweep(1);
+    GestureBinding.instance.gestureArena.sweep(1);
     expect(tapsRecognized, 1);
 
-    Gesturer.instance.pointerRouter.route(up2);
+    GestureBinding.instance.pointerRouter.route(up2);
     expect(tapsRecognized, 1);
-    Gesturer.instance.gestureArena.sweep(2);
+    GestureBinding.instance.gestureArena.sweep(2);
     expect(tapsRecognized, 1);
 
     tap.dispose();
@@ -159,20 +159,20 @@ void main() {
     };
 
     tap.addPointer(down3);
-    Gesturer.instance.gestureArena.close(3);
+    GestureBinding.instance.gestureArena.close(3);
     expect(tapRecognized, isFalse);
     expect(tapCanceled, isFalse);
-    Gesturer.instance.pointerRouter.route(down3);
+    GestureBinding.instance.pointerRouter.route(down3);
     expect(tapRecognized, isFalse);
     expect(tapCanceled, isFalse);
 
-    Gesturer.instance.pointerRouter.route(move3);
+    GestureBinding.instance.pointerRouter.route(move3);
     expect(tapRecognized, isFalse);
     expect(tapCanceled, isTrue);
-    Gesturer.instance.pointerRouter.route(up3);
+    GestureBinding.instance.pointerRouter.route(up3);
     expect(tapRecognized, isFalse);
     expect(tapCanceled, isTrue);
-    Gesturer.instance.gestureArena.sweep(3);
+    GestureBinding.instance.gestureArena.sweep(3);
     expect(tapRecognized, isFalse);
     expect(tapCanceled, isTrue);
 
@@ -189,16 +189,16 @@ void main() {
 
     new FakeAsync().run((FakeAsync async) {
       tap.addPointer(down1);
-      Gesturer.instance.gestureArena.close(1);
+      GestureBinding.instance.gestureArena.close(1);
       expect(tapRecognized, isFalse);
-      Gesturer.instance.pointerRouter.route(down1);
+      GestureBinding.instance.pointerRouter.route(down1);
       expect(tapRecognized, isFalse);
 
       async.elapse(new Duration(milliseconds: 500));
       expect(tapRecognized, isFalse);
-      Gesturer.instance.pointerRouter.route(up1);
+      GestureBinding.instance.pointerRouter.route(up1);
       expect(tapRecognized, isTrue);
-      Gesturer.instance.gestureArena.sweep(1);
+      GestureBinding.instance.gestureArena.sweep(1);
       expect(tapRecognized, isTrue);
     });
 
@@ -215,16 +215,16 @@ void main() {
 
     tap.addPointer(down1);
     TestGestureArenaMember member = new TestGestureArenaMember();
-    GestureArenaEntry entry = Gesturer.instance.gestureArena.add(1, member);
-    Gesturer.instance.gestureArena.hold(1);
-    Gesturer.instance.gestureArena.close(1);
+    GestureArenaEntry entry = GestureBinding.instance.gestureArena.add(1, member);
+    GestureBinding.instance.gestureArena.hold(1);
+    GestureBinding.instance.gestureArena.close(1);
     expect(tapRecognized, isFalse);
-    Gesturer.instance.pointerRouter.route(down1);
+    GestureBinding.instance.pointerRouter.route(down1);
     expect(tapRecognized, isFalse);
 
-    Gesturer.instance.pointerRouter.route(up1);
+    GestureBinding.instance.pointerRouter.route(up1);
     expect(tapRecognized, isFalse);
-    Gesturer.instance.gestureArena.sweep(1);
+    GestureBinding.instance.gestureArena.sweep(1);
     expect(tapRecognized, isFalse);
 
     entry.resolve(GestureDisposition.accepted);
@@ -243,16 +243,16 @@ void main() {
 
     tap.addPointer(down1);
     TestGestureArenaMember member = new TestGestureArenaMember();
-    GestureArenaEntry entry = Gesturer.instance.gestureArena.add(1, member);
-    Gesturer.instance.gestureArena.hold(1);
-    Gesturer.instance.gestureArena.close(1);
+    GestureArenaEntry entry = GestureBinding.instance.gestureArena.add(1, member);
+    GestureBinding.instance.gestureArena.hold(1);
+    GestureBinding.instance.gestureArena.close(1);
     expect(tapRecognized, isFalse);
-    Gesturer.instance.pointerRouter.route(down1);
+    GestureBinding.instance.pointerRouter.route(down1);
     expect(tapRecognized, isFalse);
 
-    Gesturer.instance.pointerRouter.route(up1);
+    GestureBinding.instance.pointerRouter.route(up1);
     expect(tapRecognized, isFalse);
-    Gesturer.instance.gestureArena.sweep(1);
+    GestureBinding.instance.gestureArena.sweep(1);
     expect(tapRecognized, isFalse);
 
     entry.resolve(GestureDisposition.rejected);

--- a/packages/flutter/test/material/slider_test.dart
+++ b/packages/flutter/test/material/slider_test.dart
@@ -37,7 +37,7 @@ void main() {
       tester.tap(find.byKey(sliderKey));
       expect(value, equals(0.5));
       tester.pump(); // No animation should start.
-      expect(Scheduler.instance.transientCallbackCount, equals(0));
+      expect(SchedulerBinding.instance.transientCallbackCount, equals(0));
     });
   });
 
@@ -78,13 +78,13 @@ void main() {
       expect(value, equals(80.0));
 
       tester.pump(); // Starts animation.
-      expect(Scheduler.instance.transientCallbackCount, greaterThan(0));
+      expect(SchedulerBinding.instance.transientCallbackCount, greaterThan(0));
       tester.pump(const Duration(milliseconds: 200));
       tester.pump(const Duration(milliseconds: 200));
       tester.pump(const Duration(milliseconds: 200));
       tester.pump(const Duration(milliseconds: 200));
       // Animation complete.
-      expect(Scheduler.instance.transientCallbackCount, equals(0));
+      expect(SchedulerBinding.instance.transientCallbackCount, equals(0));
     });
   });
 }

--- a/packages/flutter/test/rendering/rendering_tester.dart
+++ b/packages/flutter/test/rendering/rendering_tester.dart
@@ -30,7 +30,7 @@ enum EnginePhase {
   sendSemanticsTree
 }
 
-class TestRenderingFlutterBinding extends BindingBase with Scheduler, Services, Renderer, Gesturer {
+class TestRenderingFlutterBinding extends BindingBase with SchedulerBinding, ServicesBinding, RendererBinding, GestureBinding {
   @override
   void initRenderView() {
     if (renderView == null) {

--- a/packages/flutter/test/scheduler/animation_test.dart
+++ b/packages/flutter/test/scheduler/animation_test.dart
@@ -6,10 +6,10 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:test/test.dart';
 
-class TestSchedulerBinding extends BindingBase with Scheduler { }
+class TestSchedulerBinding extends BindingBase with SchedulerBinding { }
 
 void main() {
-  Scheduler scheduler = new TestSchedulerBinding();
+  SchedulerBinding scheduler = new TestSchedulerBinding();
 
   test("Check for a time dilation being in effect", () {
     expect(timeDilation, equals(1.0));

--- a/packages/flutter/test/scheduler/scheduler_test.dart
+++ b/packages/flutter/test/scheduler/scheduler_test.dart
@@ -6,19 +6,19 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:test/test.dart';
 
-class TestSchedulerBinding extends BindingBase with Scheduler { }
+class TestSchedulerBinding extends BindingBase with SchedulerBinding { }
 
 class TestStrategy {
   int allowedPriority = 10000;
 
-  bool shouldRunTaskWithPriority({ int priority, Scheduler scheduler }) {
+  bool shouldRunTaskWithPriority({ int priority, SchedulerBinding scheduler }) {
     return priority >= allowedPriority;
   }
 }
 
 void main() {
   test("Tasks are executed in the right order", () {
-    Scheduler scheduler = new TestSchedulerBinding();
+    SchedulerBinding scheduler = new TestSchedulerBinding();
     TestStrategy strategy = new TestStrategy();
     scheduler.schedulingStrategy = strategy.shouldRunTaskWithPriority;
     List<int> input = <int>[2, 23, 23, 11, 0, 80, 3];

--- a/packages/flutter/test/widget/form_test.dart
+++ b/packages/flutter/test/widget/form_test.dart
@@ -26,7 +26,7 @@ class MockKeyboard implements mojom.Keyboard {
 }
 
 void main() {
-  WidgetFlutterBinding.ensureInitialized(); // for serviceMocker
+  WidgetsFlutterBinding.ensureInitialized(); // for serviceMocker
   MockKeyboard mockKeyboard = new MockKeyboard();
   serviceMocker.registerMockService(mojom.Keyboard.serviceName, mockKeyboard);
 

--- a/packages/flutter/test/widget/independent_widget_layout_test.dart
+++ b/packages/flutter/test/widget/independent_widget_layout_test.dart
@@ -18,7 +18,7 @@ class OffscreenRenderView extends RenderView {
   void scheduleInitialFrame() {
     scheduleInitialLayout();
     scheduleInitialPaint(new TransformLayer(transform: new Matrix4.identity()));
-    // Don't call Scheduler.instance.ensureVisualUpdate()
+    // Don't call SchedulerBinding.instance.ensureVisualUpdate()
   }
 
   @override

--- a/packages/flutter/test/widget/input_test.dart
+++ b/packages/flutter/test/widget/input_test.dart
@@ -27,7 +27,7 @@ class MockKeyboard implements mojom.Keyboard {
 }
 
 void main() {
-  WidgetFlutterBinding.ensureInitialized(); // for serviceMocker
+  WidgetsFlutterBinding.ensureInitialized(); // for serviceMocker
   MockKeyboard mockKeyboard = new MockKeyboard();
   serviceMocker.registerMockService(mojom.Keyboard.serviceName, mockKeyboard);
 

--- a/packages/flutter_driver/lib/src/extension.dart
+++ b/packages/flutter_driver/lib/src/extension.dart
@@ -21,7 +21,7 @@ const String _extensionMethodName = 'driver';
 const String _extensionMethod = 'ext.flutter.$_extensionMethodName';
 const Duration _kDefaultTimeout = const Duration(seconds: 5);
 
-class _DriverBinding extends WidgetFlutterBinding { // TODO(ianh): refactor so we're not extending a concrete binding
+class _DriverBinding extends WidgetsFlutterBinding { // TODO(ianh): refactor so we're not extending a concrete binding
   @override
   void initServiceExtensions() {
     super.initServiceExtensions();
@@ -41,9 +41,9 @@ class _DriverBinding extends WidgetFlutterBinding { // TODO(ianh): refactor so w
 /// Call this function prior to running your application, e.g. before you call
 /// `runApp`.
 void enableFlutterDriverExtension() {
-  assert(Widgeteer.instance == null);
+  assert(WidgetsBinding.instance == null);
   new _DriverBinding();
-  assert(Widgeteer.instance is _DriverBinding);
+  assert(WidgetsBinding.instance is _DriverBinding);
 }
 
 /// Handles a command and returns a result.
@@ -109,7 +109,7 @@ class FlutterDriverExtension {
       // Lazy-initialize the frame callback because the renderer is not yet
       // available at the time the extension is registered.
       StreamController<Duration> frameReadyController = new StreamController<Duration>.broadcast(sync: true);
-      Scheduler.instance.addPersistentFrameCallback((Duration timestamp) {
+      SchedulerBinding.instance.addPersistentFrameCallback((Duration timestamp) {
         frameReadyController.add(timestamp);
       });
       _onFrameReadyStream = frameReadyController.stream;

--- a/packages/flutter_markdown/test/flutter_markdown_test.dart
+++ b/packages/flutter_markdown/test/flutter_markdown_test.dart
@@ -100,9 +100,9 @@ void main() {
       tester.pumpWidget(new Markdown(data: "Data1"));
       _expectTextStrings(tester.widgets, <String>["Data1"]);
 
-      String stateBefore = Widgeteer.instance.renderViewElement.toStringDeep();
+      String stateBefore = WidgetsBinding.instance.renderViewElement.toStringDeep();
       tester.pumpWidget(new Markdown(data: "Data1"));
-      String stateAfter = Widgeteer.instance.renderViewElement.toStringDeep();
+      String stateAfter = WidgetsBinding.instance.renderViewElement.toStringDeep();
       expect(stateBefore, equals(stateAfter));
 
       tester.pumpWidget(new Markdown(data: "Data2"));
@@ -119,9 +119,9 @@ void main() {
 
       tester.pumpWidget(new Markdown(data: "Test", markdownStyle: style1));
 
-      String stateBefore = Widgeteer.instance.renderViewElement.toStringDeep();
+      String stateBefore = WidgetsBinding.instance.renderViewElement.toStringDeep();
       tester.pumpWidget(new Markdown(data: "Test", markdownStyle: style2));
-      String stateAfter = Widgeteer.instance.renderViewElement.toStringDeep();
+      String stateAfter = WidgetsBinding.instance.renderViewElement.toStringDeep();
       expect(stateBefore, isNot(stateAfter));
     });
   });

--- a/packages/flutter_sprites/lib/src/sprite_box.dart
+++ b/packages/flutter_sprites/lib/src/sprite_box.dart
@@ -367,7 +367,7 @@ class SpriteBox extends RenderBox {
   // Updates
 
   void _scheduleTick() {
-    Scheduler.instance.scheduleFrameCallback(_tick);
+    SchedulerBinding.instance.scheduleFrameCallback(_tick);
   }
 
   void _tick(Duration timeStamp) {

--- a/packages/flutter_test/lib/src/binding.dart
+++ b/packages/flutter_test/lib/src/binding.dart
@@ -14,6 +14,7 @@ import 'package:quiver/time.dart';
 import 'instrumentation.dart';
 
 /// Enumeration of possible phases to reach in pumpWidget.
+// TODO(ianh): Merge with identical code in the rendering test code.
 enum EnginePhase {
   layout,
   compositingBits,
@@ -23,7 +24,7 @@ enum EnginePhase {
   sendSemanticsTree
 }
 
-class _SteppedWidgetFlutterBinding extends WidgetFlutterBinding { // TODO(ianh): refactor so we're not extending a concrete binding
+class _SteppedWidgetFlutterBinding extends WidgetsFlutterBinding { // TODO(ianh): refactor so we're not extending a concrete binding
   _SteppedWidgetFlutterBinding(this.async);
 
   final FakeAsync async;
@@ -31,10 +32,10 @@ class _SteppedWidgetFlutterBinding extends WidgetFlutterBinding { // TODO(ianh):
   /// Creates and initializes the binding. This constructor is
   /// idempotent; calling it a second time will just return the
   /// previously-created instance.
-  static Widgeteer ensureInitialized(FakeAsync async) {
-    if (Widgeteer.instance == null)
+  static WidgetsBinding ensureInitialized(FakeAsync async) {
+    if (WidgetsBinding.instance == null)
       new _SteppedWidgetFlutterBinding(async);
-    return Widgeteer.instance;
+    return WidgetsBinding.instance;
   }
 
   EnginePhase phase = EnginePhase.sendSemanticsTree;
@@ -47,7 +48,7 @@ class _SteppedWidgetFlutterBinding extends WidgetFlutterBinding { // TODO(ianh):
     buildOwner.finalizeTree();
   }
 
-  // Cloned from Renderer.beginFrame() but with early-exit semantics.
+  // Cloned from RendererBinding.beginFrame() but with early-exit semantics.
   void _beginFrame() {
     assert(renderView != null);
     pipelineOwner.flushLayout();
@@ -125,7 +126,7 @@ class ElementTreeTester extends Instrumentation {
     if (duration != null)
       async.elapse(duration);
     if (binding is _SteppedWidgetFlutterBinding) {
-      // Some tests call WidgetFlutterBinding.ensureInitialized() manually, so
+      // Some tests call WidgetsFlutterBinding.ensureInitialized() manually, so
       // we can't actually be sure we have a stepped binding.
       _SteppedWidgetFlutterBinding steppedBinding = binding;
       steppedBinding.phase = phase ?? EnginePhase.sendSemanticsTree;
@@ -187,7 +188,7 @@ void testElementTree(callback(ElementTreeTester tester)) {
       callback(tester);
       runApp(new Container(key: new UniqueKey())); // Unmount any remaining widgets.
       async.flushMicrotasks();
-      assert(Scheduler.instance.debugAssertNoTransientCallbacks(
+      assert(SchedulerBinding.instance.debugAssertNoTransientCallbacks(
         'An animation is still running even after the widget tree was disposed.'
       ));
       assert(() {

--- a/packages/flutter_test/lib/src/instrumentation.dart
+++ b/packages/flutter_test/lib/src/instrumentation.dart
@@ -15,10 +15,10 @@ typedef Point SizeToPointFunction(Size size);
 /// This class provides hooks for accessing the rendering tree and dispatching
 /// fake tap/drag/etc. events.
 class Instrumentation {
-  Instrumentation({ Widgeteer binding })
-    : this.binding = binding ?? WidgetFlutterBinding.ensureInitialized();
+  Instrumentation({ WidgetsBinding binding })
+    : this.binding = binding ?? WidgetsFlutterBinding.ensureInitialized();
 
-  final Widgeteer binding;
+  final WidgetsBinding binding;
 
   /// Returns a list of all the [Layer] objects in the rendering.
   List<Layer> get layers => _layers(binding.renderView.layer);

--- a/packages/flutter_test/lib/src/service_mocker.dart
+++ b/packages/flutter_test/lib/src/service_mocker.dart
@@ -29,7 +29,7 @@ class ServiceMocker {
 
   // Provide a mock implementation for a Mojo interface.
   // Make sure you initialise the binding before calling this.
-  // For example, by calling `WidgetFlutterBinding.ensureInitialized();`
+  // For example, by calling `WidgetsFlutterBinding.ensureInitialized();`
   void registerMockService(String interfaceName, Object mock) {
     _interfaceMocks[interfaceName] = mock;
   }

--- a/packages/flutter_test/lib/src/test_pointer.dart
+++ b/packages/flutter_test/lib/src/test_pointer.dart
@@ -125,13 +125,13 @@ class TestGesture {
   }) {
     // hit test
     final HitTestResult result = new HitTestResult();
-    target ??= Gesturer.instance;
+    target ??= GestureBinding.instance;
     assert(target != null);
     target.hitTest(result, downLocation);
 
     // dispatch down event
     final TestPointer testPointer = new TestPointer(pointer);
-    dispatcher ??= Gesturer.instance;
+    dispatcher ??= GestureBinding.instance;
     assert(dispatcher != null);
     dispatcher.dispatchEvent(testPointer.down(downLocation), result);
 

--- a/packages/flutter_test/lib/src/widget_tester.dart
+++ b/packages/flutter_test/lib/src/widget_tester.dart
@@ -48,7 +48,7 @@ class WidgetTester {
 
   /// The binding instance that the widget tester is using when it
   /// needs a binding (e.g. for event dispatch).
-  Widgeteer get binding => elementTreeTester.binding;
+  WidgetsBinding get binding => elementTreeTester.binding;
 
   /// Renders the UI from the given [widget].
   ///


### PR DESCRIPTION
The old names were getting silly and started stepping on valuable namespace.

The new names are consistent and clear.
