### PR TITLE
This line isn't useful.

### DIFF
--- a/packages/flutter/lib/src/widgets/binding.dart
+++ b/packages/flutter/lib/src/widgets/binding.dart
@@ -190,7 +190,6 @@ abstract class WidgetsBinding extends BindingBase implements GestureBinding, Ren
       debugShortDescription: '[root]',
       child: app
     ).attachToRenderTree(buildOwner, renderViewElement);
-    beginFrame();
   }
 
   @override


### PR DESCRIPTION
There shouldn't be any reason to do this.

This might cause a minor perf regression until we fix https://github.com/flutter/flutter/issues/3488.
