### PR TITLE
don't print installing device twice

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_device.dart
+++ b/packages/flutter_tools/lib/src/android/android_device.dart
@@ -183,7 +183,6 @@ class AndroidDevice extends Device {
     if (!_checkForSupportedAdbVersion() || !_checkForSupportedAndroidVersion())
       return false;
 
-    printStatus('Installing ${app.name} on device.');
     runCheckedSync(adbCommandForDevice(<String>['install', '-r', app.localPath]));
     runCheckedSync(adbCommandForDevice(<String>['shell', 'echo', '-n', _getSourceSha1(app), '>', _getDeviceSha1Path(app)]));
     return true;

--- a/packages/flutter_tools/lib/src/base/logger.dart
+++ b/packages/flutter_tools/lib/src/base/logger.dart
@@ -6,12 +6,9 @@ import 'dart:async';
 import 'dart:io';
 
 final _AnsiTerminal _terminal = new _AnsiTerminal();
-final String _sep = Platform.isWindows ? '-' : '•';
 
 abstract class Logger {
   bool get isVerbose => false;
-
-  String get separator => _sep;
 
   set supportsColor(bool value) {
     _terminal.supportsColor = value;
@@ -177,10 +174,10 @@ class _LogMessage {
     stopwatch.stop();
 
     int millis = stopwatch.elapsedMilliseconds;
-    String prefix = '${millis.toString().padLeft(4)} ms $_sep ';
+    String prefix = '${millis.toString().padLeft(4)} ms • ';
     String indent = ''.padLeft(prefix.length);
     if (millis >= 100)
-      prefix = _terminal.writeBold(prefix.substring(0, prefix.length - 3)) + ' $_sep ';
+      prefix = _terminal.writeBold(prefix.substring(0, prefix.length - 3)) + ' • ';
     String indentMessage = message.replaceAll('\n', '\n$indent');
 
     if (type == _LogType.error) {

--- a/packages/flutter_tools/lib/src/commands/analyze.dart
+++ b/packages/flutter_tools/lib/src/commands/analyze.dart
@@ -7,10 +7,11 @@ import 'dart:collection';
 import 'dart:convert';
 import 'dart:io';
 
-import 'package:yaml/yaml.dart' as yaml;
 import 'package:path/path.dart' as path;
+import 'package:yaml/yaml.dart' as yaml;
 
 import '../artifacts.dart';
+import '../base/logger.dart';
 import '../base/process.dart';
 import '../base/utils.dart';
 import '../build_configuration.dart';
@@ -111,7 +112,7 @@ class AnalyzeCommand extends FlutterCommand {
     argParser.addFlag('flutter-repo', help: 'Include all the examples and tests from the Flutter repository.', defaultsTo: false);
     argParser.addFlag('current-directory', help: 'Include all the Dart files in the current directory, if any.', defaultsTo: true);
     argParser.addFlag('current-package', help: 'Include the lib/main.dart file from the current directory, if any.', defaultsTo: true);
-    argParser.addFlag('dartdocs', help: 'List every public member that is lacking documentation. (Only examines files in the Flutter repository.)', defaultsTo: false);
+    argParser.addFlag('dartdocs', help: 'List every public member that is lacking documentation (only examines files in the Flutter repository).', defaultsTo: false);
     argParser.addFlag('preamble', help: 'Display the number of files that will be analyzed.', defaultsTo: true);
     argParser.addFlag('congratulate', help: 'Show output even when there are no errors, warnings, hints, or lints.', defaultsTo: true);
     argParser.addFlag('watch', help: 'Run analysis continuously, watching the filesystem for changes.', negatable: false);
@@ -323,11 +324,12 @@ class AnalyzeCommand extends FlutterCommand {
       mainFile.path
     ];
 
+    Status status;
     if (argResults['preamble']) {
       if (dartFiles.length == 1) {
-        printStatus('Analyzing ${dartFiles.first}...');
+        status = logger.startProgress('Analyzing ${path.relative(dartFiles.first)}...');
       } else {
-        printStatus('Analyzing ${dartFiles.length} entry points...');
+        status = logger.startProgress('Analyzing ${dartFiles.length} entry points...');
       }
       for (String file in dartFiles)
         printTrace(file);
@@ -351,6 +353,7 @@ class AnalyzeCommand extends FlutterCommand {
     });
 
     int exitCode = await process.exitCode;
+    status.stop(showElapsedTime: true);
 
     List<Pattern> patternsToSkip = <Pattern>[
       'Analyzing [${mainFile.path}]...',
@@ -530,7 +533,7 @@ class AnalyzeCommand extends FlutterCommand {
 
       String files = '${analyzedPaths.length} ${pluralize('file', analyzedPaths.length)}';
       String seconds = (analysisTimer.elapsedMilliseconds / 1000.0).toStringAsFixed(2);
-      printStatus('$errorsMessage ${logger.separator} analyzed $files, $seconds seconds');
+      printStatus('$errorsMessage • analyzed $files, $seconds seconds');
 
       firstAnalysis = false;
     }
@@ -799,8 +802,7 @@ class AnalysisError implements Comparable<AnalysisError> {
   @override
   String toString() {
     String relativePath = path.relative(file);
-    String sep = logger.separator;
-    return '${severity.toLowerCase().padLeft(7)} $sep $message $sep $relativePath:$startLine:$startColumn';
+    return '${severity.toLowerCase().padLeft(7)} • $message • $relativePath:$startLine:$startColumn';
   }
 }
 

--- a/packages/flutter_tools/lib/src/commands/run.dart
+++ b/packages/flutter_tools/lib/src/commands/run.dart
@@ -192,7 +192,7 @@ Future<int> startApp(
   await new Future<Duration>.delayed(Duration.ZERO);
 
   if (install) {
-    printTrace('Running install command.');
+    printStatus('Installing $package to $device...');
 
     // TODO(devoncarew): This fails for ios devices - we haven't built yet.
     await installApp(device, package);

--- a/packages/flutter_tools/lib/src/device.dart
+++ b/packages/flutter_tools/lib/src/device.dart
@@ -222,8 +222,8 @@ abstract class Device {
 
     for (Device device in devices) {
       String supportIndicator = device.isSupported() ? '' : ' (unsupported)';
-      printStatus('${device.name.padRight(nameWidth)} ${logger.separator} '
-        '${device.id.padRight(idWidth)} ${logger.separator} '
+      printStatus('${device.name.padRight(nameWidth)} • '
+        '${device.id.padRight(idWidth)} • '
         '${getNameForTargetPlatform(device.platform)}$supportIndicator');
     }
   }

--- a/packages/flutter_tools/lib/src/doctor.dart
+++ b/packages/flutter_tools/lib/src/doctor.dart
@@ -109,7 +109,7 @@ class Doctor {
       else
         printStatus('${result.leadingBox} ${validator.title}');
 
-      final String separator = Platform.isWindows ? ' ' : logger.separator;
+      final String separator = Platform.isWindows ? ' ' : '•';
 
       for (ValidationMessage message in result.messages) {
         if (message.isError) {


### PR DESCRIPTION
- when running `flutter install`, don't print 'installing to device...' twice (fix #3484)
- simplify some logging code around printing a separator char
