### PR TITLE
Add a profile build mode flag for building APKs with AOT compilation

### DIFF
--- a/packages/flutter_tools/lib/src/build_configuration.dart
+++ b/packages/flutter_tools/lib/src/build_configuration.dart
@@ -15,11 +15,10 @@ enum BuildType {
   debug,
 }
 
-/// The type of build - `debug` or `release`.
-///
-/// TODO(devoncarew): Add a `profile` mode.
+/// The type of build - `debug`, `profile`, or `release`.
 enum BuildMode {
   debug,
+  profile,
   release
 }
 

--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -64,16 +64,23 @@ abstract class FlutterCommand extends Command {
     argParser.addFlag('debug',
       negatable: false,
       help: 'Build a debug version of your app (the default).');
+    argParser.addFlag('profile',
+      hide: true,
+      negatable: false,
+      help: 'Build a profile (ahead of time compilation) version of your app.');
     argParser.addFlag('release',
       negatable: false,
       help: 'Build a release version of your app.');
   }
 
   BuildMode getBuildMode() {
-    if (argResults['debug'] && argResults['release'])
-      throw new UsageException('Only one of --debug or --release should be specified.', null);
+    List<bool> modeFlags = [argResults['debug'], argResults['profile'], argResults['release']];
+    if (modeFlags.where((bool flag) => flag).length > 1)
+      throw new UsageException('Only one of --debug, --profile, or --release should be specified.', null);
 
     BuildMode mode = BuildMode.debug;
+    if (argResults['profile'])
+      mode = BuildMode.profile;
     if (argResults['release'])
       mode = BuildMode.release;
     return mode;

--- a/packages/flutter_tools/lib/src/toolchain.dart
+++ b/packages/flutter_tools/lib/src/toolchain.dart
@@ -159,7 +159,11 @@ class ToolConfiguration {
       }
 
       // Return something like 'out/android_Release'.
-      return new Directory(path.join(engineSrcPath, 'out/${type}_$_modeStr'));
+      String buildOutputPath = 'out/${type}_$_modeStr';
+      if (mode == BuildMode.profile)
+        buildOutputPath += '_Deploy';
+
+      return new Directory(path.join(engineSrcPath, buildOutputPath));
     } else {
       // For now, only suffix for deploy variants.
       String suffix = mode == BuildMode.release ? '-${getModeName(mode)}' : '';


### PR DESCRIPTION
This is currently hidden for development use.  It will select artifacts from
the android_{Debug,Release}_Deploy output in a local engine build.
