### PR TITLE
Handle the case of a null body in response.dart

### DIFF
--- a/packages/flutter/lib/src/http/response.dart
+++ b/packages/flutter/lib/src/http/response.dart
@@ -15,7 +15,7 @@ class Response {
   /// The result of decoding [bodyBytes] using ISO-8859-1.
   ///
   /// If [bodyBytes] is null, this will also be null.
-  String get body => _encodingForHeaders(headers).decode(bodyBytes);
+  String get body => bodyBytes == null ? null : _encodingForHeaders(headers).decode(bodyBytes);
 
   /// The raw byte stream.
   final Uint8List bodyBytes;
@@ -80,6 +80,8 @@ String _getCharset(String contentType) {
 }
 
 Encoding _encodingForHeaders(Map<String, String> headers) {
+  if (headers == null)
+    return LATIN1;
   String contentType = headers['content-type'];
   if (contentType == null)
     return LATIN1;


### PR DESCRIPTION
We're supposed to return a null string when the HTTP response doesn't have a
body. Also handle the case of not having a headers map.
