### PR TITLE
Block should work inside LazyBlock

### DIFF
--- a/packages/flutter/lib/src/widgets/binding.dart
+++ b/packages/flutter/lib/src/widgets/binding.dart
@@ -285,7 +285,7 @@ class RenderObjectToWidgetAdapter<T extends RenderObject> extends RenderObjectWi
       } else {
         element.update(this);
       }
-    }, building: true, context: 'while attaching root widget to rendering tree');
+    }, building: true);
     return element;
   }
 

--- a/packages/flutter/lib/src/widgets/virtual_viewport.dart
+++ b/packages/flutter/lib/src/widgets/virtual_viewport.dart
@@ -164,7 +164,7 @@ abstract class VirtualViewportElement extends RenderObjectElement {
     assert(startOffsetBase != null);
     assert(startOffsetLimit != null);
     _updatePaintOffset();
-    owner.lockState(_materializeChildren, building: true, context: 'during $runtimeType layout');
+    owner.lockState(_materializeChildren, building: true);
   }
 
   void _materializeChildren() {

--- a/packages/flutter/test/widget/lazy_block_test.dart
+++ b/packages/flutter/test/widget/lazy_block_test.dart
@@ -1,0 +1,34 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter/material.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('Block inside LazyBlock', () {
+    testWidgets((WidgetTester tester) {
+      tester.pumpWidget(new LazyBlock(
+        delegate: new LazyBlockChildren(
+          children: <Widget>[
+            new Block(
+              children: <Widget>[
+                new Text('1'),
+                new Text('2'),
+                new Text('3'),
+              ]
+            ),
+            new Block(
+              children: <Widget>[
+                new Text('4'),
+                new Text('5'),
+                new Text('6'),
+              ]
+            ),
+          ]
+        )
+      ));
+    });
+  });
+}


### PR DESCRIPTION
Previously we were locking down the state even when calling layout in
LazyBlock. Now we lock only when building children. Making this work well
involved moving the catch out of lockState and into the few callers who
actually wanted it.

Fixes #3534
