### PR TITLE
Add an .analysis_options to package:flutter

### DIFF
--- a/packages/flutter/.analysis_options
+++ b/packages/flutter/.analysis_options
@@ -1,15 +1,4 @@
-# Specify analysis options.
-#
-# Note that until there is a default "all-in" lint rule-set we need
-# to opt-in to all desired lints (https://github.com/dart-lang/sdk/issues/25843).
-# For a list of lints, see: http://dart-lang.github.io/linter/lints/
-
-# This file is the .analysis_options file used by "flutter analyze".
-# It isn't named that because otherwise editors like Atom would try
-# to use it, and that wouldn't work because it enables things that
-# need to be silenced, in particular, public_member_api_docs.
-
-# Please keep synchronized with //packages/flutter/.analysis_options
+# Please keep synchronized with //packages/flutter_tools/flutter_analysis_options
 
 analyzer:
   language:
@@ -47,7 +36,7 @@ linter:
     - package_names
     - package_prefixed_library_names
     - prefer_is_not_empty
-    - public_member_api_docs
+    # - public_member_api_docs
     - slash_for_doc_comments
     - sort_constructors_first
     - sort_unnamed_constructors_first

--- a/packages/flutter_test/lib/src/widget_tester.dart
+++ b/packages/flutter_test/lib/src/widget_tester.dart
@@ -118,8 +118,10 @@ class WidgetTester {
     Element element = finder.findFirst(this);
     Widget widget = element.widget;
 
-    if (widget is StatefulWidget)
-      return (element as StatefulElement).state;
+    if (widget is StatefulWidget) {
+      StatefulElement statefulElement = element;
+      return statefulElement.state;
+    }
 
     throw new ElementNotFoundError(
       'Widget of type ${widget.runtimeType} found by ${finder.description} does not correspond to a StatefulWidget'

--- a/packages/flutter_tools/lib/src/cache.dart
+++ b/packages/flutter_tools/lib/src/cache.dart
@@ -143,7 +143,8 @@ class Cache {
       os.unzip(tempFile, location);
       tempFile.deleteSync();
     } else {
-      (location as File).writeAsBytesSync(fileBytes, flush: true);
+      File file = location;
+      file.writeAsBytesSync(fileBytes, flush: true);
     }
   }
 }


### PR DESCRIPTION
We no longer _embedder.yaml to turn these settings on for all Dart clients. In
order to get these lints in Atom when working on the framework, we need to turn
them on explicitly.
