### PR TITLE
better track flutter versions

### DIFF
--- a/packages/flutter_tools/lib/src/commands/config.dart
+++ b/packages/flutter_tools/lib/src/commands/config.dart
@@ -23,7 +23,7 @@ class ConfigCommand extends FlutterCommand {
   final String description =
     'Configure Flutter settings.\n\n'
     'The Flutter tool anonymously reports feature usage statistics and basic crash reports to help improve\n'
-    'Flutter tools over time. See Google\'s privacy policy: www.google.com/intl/en/policies/privacy';
+    'Flutter tools over time. See Google\'s privacy policy: https://www.google.com/intl/en/policies/privacy/';
 
   @override
   final List<String> aliases = <String>['configure'];

--- a/packages/flutter_tools/lib/src/usage.dart
+++ b/packages/flutter_tools/lib/src/usage.dart
@@ -19,7 +19,8 @@ const String _kFlutterUA = 'UA-67589403-5';
 
 class Usage {
   Usage() {
-    _analytics = new AnalyticsIO(_kFlutterUA, 'flutter', FlutterVersion.getVersionString());
+    String version = FlutterVersion.getVersionString(whitelistBranchName: true);
+    _analytics = new AnalyticsIO(_kFlutterUA, 'flutter', version);
     _analytics.analyticsOpt = AnalyticsOpt.optOut;
   }
 
@@ -51,7 +52,7 @@ class Usage {
     if (isFirstRun)
       return new _MockUsageTimer();
     else
-      return new UsageTimer._(event, _analytics.startTimer(event));
+      return new UsageTimer._(event, _analytics.startTimer(event, category: 'flutter'));
   }
 
   void sendException(dynamic exception, StackTrace trace) {


### PR DESCRIPTION
- in some git checkouts, we can have trouble getting the git commit and branch; add fallbacks for those cases
- only send in known branch names to analytics; we don't want to send in arbitrary branch names the user may be working on
- fix an issue where we were shortening the engine commit hash, but doing it in the context of the flutter repo. We now just do a fixed length truncate at 10 chars
