### PR TITLE
Enable lining up the last tool bar action trailing list item elements

### DIFF
--- a/examples/material_gallery/lib/demo/list_demo.dart
+++ b/examples/material_gallery/lib/demo/list_demo.dart
@@ -195,7 +195,7 @@ class ListDemoState extends State<ListDemo> {
         child: new Scrollbar(
           child: new MaterialList(
             type: _itemType,
-            padding: new EdgeInsets.all(_dense ? 4.0 : 8.0),
+            padding: new EdgeInsets.symmetric(vertical: _dense ? 4.0 : 8.0),
             children: listItems
           )
         )

--- a/examples/material_gallery/lib/demo/menu_demo.dart
+++ b/examples/material_gallery/lib/demo/menu_demo.dart
@@ -84,7 +84,7 @@ class MenuDemoState extends State<MenuDemo> {
         ]
       ),
       body: new Block(
-        padding: const EdgeInsets.all(8.0),
+        padding: const EdgeInsets.symmetric(vertical: 8.0),
         children: <Widget>[
           // Pressing the PopupMenuButton on the right of this item shows
           // a simple menu with one disabled item. Typically the contents
@@ -92,6 +92,7 @@ class MenuDemoState extends State<MenuDemo> {
           new ListItem(
             title: new Text('An item with a context menu button'),
             trailing: new PopupMenuButton<String>(
+              padding: EdgeInsets.zero,
               onSelected: showMenuSelection,
               itemBuilder: (BuildContext context) => <PopupMenuItem<String>>[
                 new PopupMenuItem<String>(
@@ -115,6 +116,7 @@ class MenuDemoState extends State<MenuDemo> {
           new ListItem(
             title: new Text('An item with a sectioned menu'),
             trailing: new PopupMenuButton<String>(
+              padding: EdgeInsets.zero,
               onSelected: showMenuSelection,
               itemBuilder: (BuildContext context) => <PopupMenuEntry<String>>[
                 new PopupMenuItem<String>(
@@ -153,6 +155,7 @@ class MenuDemoState extends State<MenuDemo> {
           // a menu whose current value is highlighted and aligned over the
           // list item's center line.
           new PopupMenuButton<String>(
+            padding: EdgeInsets.zero,
             initialValue: _simpleValue,
             onSelected: showMenuSelection,
             child: new ListItem(
@@ -179,6 +182,7 @@ class MenuDemoState extends State<MenuDemo> {
           new ListItem(
             title: new Text('An item with a checklist menu'),
             trailing: new PopupMenuButton<String>(
+              padding: EdgeInsets.zero,
               onSelected: showCheckedMenuSelections,
               itemBuilder: (BuildContext context) => <PopupMenuItem<String>>[
                 new CheckedPopupMenuItem<String>(

--- a/packages/flutter/lib/src/material/popup_menu.dart
+++ b/packages/flutter/lib/src/material/popup_menu.dart
@@ -398,6 +398,7 @@ class PopupMenuButton<T> extends StatefulWidget {
     this.onSelected,
     this.tooltip: 'Show menu',
     this.elevation: 8,
+    this.padding: const EdgeInsets.all(8.0),
     this.child
   }) : super(key: key) {
     assert(itemBuilder != null);
@@ -420,6 +421,11 @@ class PopupMenuButton<T> extends StatefulWidget {
   ///
   /// The following elevations have defined shadows: 1, 2, 3, 4, 6, 8, 9, 12, 16, 24
   final int elevation;
+
+  /// Matches IconButton's 8 dps padding by default. In some cases, notably where
+  /// this button appears as the trailing element of a list item, it's useful to be able
+  /// to set the padding to zero.
+  final EdgeInsets padding;
 
   /// The widget below this widget in the tree.
   final Widget child;
@@ -453,6 +459,7 @@ class _PopupMenuButtonState<T> extends State<PopupMenuButton<T>> {
     if (config.child == null) {
       return new IconButton(
         icon: Icons.more_vert,
+        padding: config.padding,
         tooltip: config.tooltip,
         onPressed: () { showButtonMenu(context); }
       );


### PR DESCRIPTION
Added a padding parameter to PopupMenuButton. It just becomes the IconButton's padding.

Only pad scrollable lists vertically. List items already add sufficient horizontal padding.

Fixes #3595
