### PR TITLE
Fix truncated dartdoc.

### DIFF
--- a/packages/flutter/lib/src/widgets/scrollable_list.dart
+++ b/packages/flutter/lib/src/widgets/scrollable_list.dart
@@ -317,7 +317,7 @@ class ListViewport extends _VirtualListViewport with VirtualViewportFromIterable
 /// the same size (extent) in the scrollDirection. For example for
 /// ScrollDirection.vertical itemExtent is the height of each item. Use this
 /// widget when you have a large number of children or when you are concerned
-// about offscreen widgets consuming resources.
+/// about offscreen widgets consuming resources.
 class ScrollableLazyList extends Scrollable {
   ScrollableLazyList({
     Key key,


### PR DESCRIPTION
Note that the /// part of the doc was published, only the // line was
omitted. This means that we can safely put // comments between /// docs
and the member they are documenting.
