### PR TITLE
Add the ability to give flexible children loose constraints

### DIFF
--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -1752,12 +1752,26 @@ class Flexible extends ParentDataWidget<Flex> {
   /// according to the flex factors of the flexible children.
   final int flex;
 
+  /// Whether to apply tight or loose constraints to this child if this child has a non-null [flex].
+  ///
+  /// Ignored if [flex] is null. If this property is null, the child will be
+  /// given tight constraints.
+  FlexConstraintType constraintType;
+
   @override
   void applyParentData(RenderObject renderObject) {
     assert(renderObject.parentData is FlexParentData);
     final FlexParentData parentData = renderObject.parentData;
+    bool needsLayout = false;
     if (parentData.flex != flex) {
       parentData.flex = flex;
+      needsLayout = true;
+    }
+    if (parentData.constraintType != constraintType) {
+      parentData.constraintType = constraintType;
+      needsLayout = true;
+    }
+    if (needsLayout) {
       AbstractNode targetParent = renderObject.parent;
       if (targetParent is RenderObject)
         targetParent.markNeedsLayout();

--- a/packages/flutter/test/rendering/flex_test.dart
+++ b/packages/flutter/test/rendering/flex_test.dart
@@ -166,4 +166,40 @@ void main() {
     expect(getOffset(box3).dy, equals(275.0));
     expect(box3.size.height, equals(100.0));
   });
+
+  test('Loose constraints', () {
+    RenderConstrainedBox box1 = new RenderConstrainedBox(additionalConstraints: new BoxConstraints.tightFor(width: 200.0, height: 200.0));
+    RenderConstrainedBox box2 = new RenderConstrainedBox(additionalConstraints: new BoxConstraints.tightFor(width: 100.0, height: 100.0));
+    RenderConstrainedBox box3 = new RenderConstrainedBox(additionalConstraints: new BoxConstraints.tightFor(width: 100.0, height: 100.0));
+    RenderFlex flex = new RenderFlex();
+    flex.addAll(<RenderBox>[box1, box2, box3]);
+    FlexParentData childParentData2 = box2.parentData;
+    childParentData2
+      ..flex = 1
+      ..constraintType = FlexConstraintType.loose;
+    FlexParentData childParentData3 = box3.parentData;
+    childParentData3.flex = 1;
+    layout(flex, constraints: const BoxConstraints(
+      minWidth: 0.0, maxWidth: 500.0, minHeight: 0.0, maxHeight: 400.0)
+    );
+    Offset getOffset(RenderBox box) {
+      FlexParentData parentData = box.parentData;
+      return parentData.offset;
+    }
+    expect(getOffset(box1).dx, equals(0.0));
+    expect(box1.size.width, equals(200.0));
+    expect(getOffset(box2).dx, equals(200.0));
+    expect(box2.size.width, equals(100.0));
+    expect(getOffset(box3).dx, equals(300.0));
+    expect(box3.size.width, equals(150.0));
+
+    flex.direction = FlexDirection.vertical;
+    pumpFrame();
+    expect(getOffset(box1).dy, equals(0.0));
+    expect(box1.size.height, equals(200.0));
+    expect(getOffset(box2).dy, equals(200.0));
+    expect(box2.size.height, equals(100.0));
+    expect(getOffset(box3).dy, equals(300.0));
+    expect(box3.size.height, equals(100.0));
+  });
 }


### PR DESCRIPTION
There are some use cases where we want to add some content to the side of
another widget and have that widget able to expand to fill the remaining space.

Related to #3633
