### PR TITLE
Gallery demo start-time performance test

### DIFF
--- a/examples/material_gallery/lib/demo/fitness_demo.dart
+++ b/examples/material_gallery/lib/demo/fitness_demo.dart
@@ -4,7 +4,6 @@
 
 import 'dart:async';
 import 'dart:math' as math;
-import 'dart:ui' as ui;
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_sprites/flutter_sprites.dart';
@@ -288,7 +287,7 @@ class _ProgressCircle extends NodeWithSize {
     Paint circlePaint = new Paint()
       ..color = Colors.white30
       ..strokeWidth = 24.0
-      ..style = ui.PaintingStyle.stroke;
+      ..style = PaintingStyle.stroke;
 
     canvas.drawCircle(
       new Point(size.width / 2.0, size.height / 2.0),
@@ -299,7 +298,7 @@ class _ProgressCircle extends NodeWithSize {
     Paint pathPaint = new Paint()
       ..color = Colors.purple[500]
       ..strokeWidth = 25.0
-      ..style = ui.PaintingStyle.stroke;
+      ..style = PaintingStyle.stroke;
 
     double angle = value.clamp(0.0, 1.0) * _kSweep;
     Path path = new Path()

--- a/examples/material_gallery/lib/gallery/app.dart
+++ b/examples/material_gallery/lib/gallery/app.dart
@@ -44,6 +44,16 @@ final Map<String, WidgetBuilder> kRoutes = <String, WidgetBuilder>{
   TypographyDemo.routeName: (BuildContext context) => new TypographyDemo(),
 };
 
+final ThemeData _kGalleryLightTheme = new ThemeData(
+  brightness: ThemeBrightness.light,
+  primarySwatch: Colors.purple
+);
+
+final ThemeData _kGalleryDarkTheme = new ThemeData(
+  brightness: ThemeBrightness.dark,
+  primarySwatch: Colors.purple
+);
+
 class GalleryApp extends StatefulWidget {
   GalleryApp({ Key key }) : super(key: key);
 
@@ -73,13 +83,3 @@ class GalleryAppState extends State<GalleryApp> {
     );
   }
 }
-
-ThemeData _kGalleryLightTheme = new ThemeData(
-  brightness: ThemeBrightness.light,
-  primarySwatch: Colors.purple
-);
-
-ThemeData _kGalleryDarkTheme = new ThemeData(
-  brightness: ThemeBrightness.dark,
-  primarySwatch: Colors.purple
-);

--- a/examples/material_gallery/lib/gallery/item.dart
+++ b/examples/material_gallery/lib/gallery/item.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:developer';
+
 import 'package:flutter/material.dart';
 
 typedef Widget GalleryDemoBuilder();
@@ -21,8 +23,13 @@ class GalleryItem extends StatelessWidget {
       leading: leading,
       title: new Text(title),
       onTap: () {
-        if (routeName != null)
+        if (routeName != null) {
+          Timeline.instantSync('Start Transition', arguments: <String, String>{
+            'from': '/',
+            'to': routeName
+          });
           Navigator.pushNamed(context, routeName);
+        }
       }
     );
   }

--- a/examples/material_gallery/test_driver/transitions_perf.dart
+++ b/examples/material_gallery/test_driver/transitions_perf.dart
@@ -1,0 +1,11 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_driver/driver_extension.dart';
+import 'package:material_gallery/main.dart' as app;
+
+void main() {
+  enableFlutterDriverExtension();
+  app.main();
+}

--- a/examples/material_gallery/test_driver/transitions_perf_test.dart
+++ b/examples/material_gallery/test_driver/transitions_perf_test.dart
@@ -1,0 +1,90 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:flutter_driver/flutter_driver.dart';
+import 'package:test/test.dart';
+
+// Warning: the following strings must be kept in sync with GalleryHome.
+const List<String> demoCategories = const <String>['Demos', 'Components', 'Style'];
+
+const List<String> demoNames = const <String>[
+  'Weather',
+  'Fitness',
+  'Fancy lines'//,
+  /*
+  'Flexible space toolbar',
+  'Floating action button',
+  'Buttons',
+  'Cards',
+  'Chips',
+  'Date picker',
+  'Data tables',
+  'Dialog',
+  'Drop-down button',
+  'Expand/collapse list control',
+  'Grid',
+  'Icons',
+  'Leave-behind list items',
+  'List',
+  'Menus',
+  'Modal bottom sheet',
+  'Over-scroll',
+  'Page selector',
+  'Persistent bottom sheet',
+  'Progress indicators',
+  'Scrollable tabs',
+  'Selection controls',
+  'Sliders',
+  'Snackbar',
+  'Tabs',
+  'Text fields',
+  'Time picker',
+  'Tooltips',
+  'Colors',
+  'Typography'
+  */
+];
+
+void main() {
+  group('flutter gallery transitions', () {
+    FlutterDriver driver;
+    setUpAll(() async {
+      driver = await FlutterDriver.connect();
+    });
+
+    tearDownAll(() async {
+      if (driver != null)
+        driver.close();
+    });
+
+    test('all demos', () async {
+      Timeline timeline = await driver.traceAction(() async {
+        // Expand the demo category submenus.
+        for (String category in demoCategories.reversed) {
+          await driver.tap(find.text(category));
+          await new Future<Null>.delayed(new Duration(milliseconds: 500));
+        }
+        // Scroll each demo menu item into view, launch the demo and
+        // return to the demo menu 5x.
+        for(String demoName in demoNames) {
+          SerializableFinder menuItem = find.text(demoName);
+          await driver.scrollToVisible(menuItem);
+          await new Future<Null>.delayed(new Duration(milliseconds: 500));
+
+          for(int i = 0; i < 5; i += 1) {
+            await driver.tap(menuItem); // Launch the demo
+            await new Future<Null>.delayed(new Duration(milliseconds: 500));
+            await driver.tap(find.byTooltip('Back'));
+            await new Future<Null>.delayed(new Duration(milliseconds: 1000));
+          }
+        }
+      });
+      new TimelineSummary.summarize(timeline)
+        ..writeSummaryToFile('transitions_perf', pretty: true)
+        ..writeTimelineToFile('transitions_perf', pretty: true);
+    }, timeout: new Timeout(new Duration(minutes: 15)));
+  });
+}

--- a/examples/material_gallery/test_driver/transitions_perf_test.dart
+++ b/examples/material_gallery/test_driver/transitions_perf_test.dart
@@ -13,8 +13,7 @@ const List<String> demoCategories = const <String>['Demos', 'Components', 'Style
 const List<String> demoNames = const <String>[
   'Weather',
   'Fitness',
-  'Fancy lines'//,
-  /*
+  'Fancy lines',
   'Flexible space toolbar',
   'Floating action button',
   'Buttons',
@@ -45,7 +44,6 @@ const List<String> demoNames = const <String>[
   'Tooltips',
   'Colors',
   'Typography'
-  */
 ];
 
 void main() {

--- a/examples/material_gallery/test_driver/transitions_perf_test.dart
+++ b/examples/material_gallery/test_driver/transitions_perf_test.dart
@@ -66,20 +66,21 @@ void main() {
           await new Future<Null>.delayed(new Duration(milliseconds: 500));
         }
         // Scroll each demo menu item into view, launch the demo and
-        // return to the demo menu 5x.
+        // return to the demo menu 2x.
         for(String demoName in demoNames) {
           SerializableFinder menuItem = find.text(demoName);
           await driver.scrollToVisible(menuItem);
           await new Future<Null>.delayed(new Duration(milliseconds: 500));
 
-          for(int i = 0; i < 5; i += 1) {
+          for(int i = 0; i < 2; i += 1) {
             await driver.tap(menuItem); // Launch the demo
             await new Future<Null>.delayed(new Duration(milliseconds: 500));
             await driver.tap(find.byTooltip('Back'));
             await new Future<Null>.delayed(new Duration(milliseconds: 1000));
           }
         }
-      });
+      },
+      categories: '[Dart, GC, Compiler]');
       new TimelineSummary.summarize(timeline)
         ..writeSummaryToFile('transitions_perf', pretty: true)
         ..writeTimelineToFile('transitions_perf', pretty: true);

--- a/examples/material_gallery/test_driver/transitions_perf_test.dart
+++ b/examples/material_gallery/test_driver/transitions_perf_test.dart
@@ -69,7 +69,7 @@ void main() {
         // return to the demo menu 2x.
         for(String demoName in demoNames) {
           SerializableFinder menuItem = find.text(demoName);
-          await driver.scrollToVisible(menuItem);
+          await driver.scrollIntoView(menuItem);
           await new Future<Null>.delayed(new Duration(milliseconds: 500));
 
           for(int i = 0; i < 2; i += 1) {
@@ -80,7 +80,11 @@ void main() {
           }
         }
       },
-      categories: '[Dart, GC, Compiler]');
+      categories: const <TracingCategory>[
+        TracingCategory.dart,
+        TracingCategory.gc,
+        TracingCategory.compiler
+      ]);
       new TimelineSummary.summarize(timeline)
         ..writeSummaryToFile('transitions_perf', pretty: true)
         ..writeTimelineToFile('transitions_perf', pretty: true);

--- a/packages/flutter_driver/lib/flutter_driver.dart
+++ b/packages/flutter_driver/lib/flutter_driver.dart
@@ -15,7 +15,8 @@ export 'src/driver.dart' show
   find,
   CommonFinders,
   EvaluatorFunction,
-  FlutterDriver;
+  FlutterDriver,
+  TracingCategory;
 
 export 'src/error.dart' show
   DriverError,

--- a/packages/flutter_driver/lib/src/driver.dart
+++ b/packages/flutter_driver/lib/src/driver.dart
@@ -34,6 +34,8 @@ String _tracingCategoriesToString(List<TracingCategory> categories) {
       case TracingCategory.gc: return 'GC';
       case TracingCategory.isolate: return 'Isolate';
       case TracingCategory.vm: return 'VM';
+      default:
+        throw 'Unknown tracing category $category';
     }
   }).join(', ');
   return '[$contents]';

--- a/packages/flutter_driver/lib/src/driver.dart
+++ b/packages/flutter_driver/lib/src/driver.dart
@@ -21,7 +21,7 @@ final Logger _log = new Logger('FlutterDriver');
 ///
 /// Examples:
 ///
-///     driver.tap(find.byText('Save'));
+///     driver.tap(find.text('Save'));
 ///     driver.scroll(find.byValueKey(42));
 const CommonFinders find = const CommonFinders._();
 
@@ -209,6 +209,12 @@ class FlutterDriver {
   /// second). It defaults to 60Hz.
   Future<Null> scroll(SerializableFinder finder, double dx, double dy, Duration duration, {int frequency: 60}) async {
     return await _sendCommand(new Scroll(finder, dx, dy, duration, frequency)).then((Map<String, dynamic> _) => null);
+  }
+
+  /// Tell the driver to ensure that the widget located by [finder] has been
+  /// scrolled completely into view. See [Scrollable.ensureVisible].
+  Future<Null> scrollToVisible(SerializableFinder finder) async {
+    return await _sendCommand(new ScrollToVisible(finder)).then((Map<String, dynamic> _) => null);
   }
 
   /// Returns the text in the `Text` widget located by [finder].

--- a/packages/flutter_driver/lib/src/driver.dart
+++ b/packages/flutter_driver/lib/src/driver.dart
@@ -240,7 +240,7 @@ class FlutterDriver {
   /// Scrolls the Scrollable ancestor of the widget located by [finder]
   /// until the widget is completely visible.
   Future<Null> scrollIntoView(SerializableFinder finder) async {
-    return await _sendCommand(new ScrollToVisible(finder)).then((Map<String, dynamic> _) => null);
+    return await _sendCommand(new ScrollIntoView(finder)).then((Map<String, dynamic> _) => null);
   }
 
   /// Returns the text in the `Text` widget located by [finder].

--- a/packages/flutter_driver/lib/src/driver.dart
+++ b/packages/flutter_driver/lib/src/driver.dart
@@ -36,7 +36,7 @@ String _tracingCategoriesToString(List<TracingCategory> categories) {
       case TracingCategory.vm: return 'VM';
     }
   }).join(', ');
-  return "[$contents]";
+  return '[$contents]';
 }
 
 final Logger _log = new Logger('FlutterDriver');

--- a/packages/flutter_driver/lib/src/driver.dart
+++ b/packages/flutter_driver/lib/src/driver.dart
@@ -223,7 +223,7 @@ class FlutterDriver {
   }
 
   /// Starts recording performance traces.
-  Future<Null> startTracing({ categories: '[all]' }) async {
+  Future<Null> startTracing({ String categories: '[all]' }) async {
     try {
       await _peer.sendRequest(_kSetVMTimelineFlagsMethod, {'recordedStreams': categories});
       return null;
@@ -257,7 +257,7 @@ class FlutterDriver {
   ///
   /// This is merely a convenience wrapper on top of [startTracing] and
   /// [stopTracingAndDownloadTimeline].
-  Future<Timeline> traceAction(Future<dynamic> action(), { categories: '[all]' }) async {
+  Future<Timeline> traceAction(Future<dynamic> action(), { String categories: '[all]' }) async {
     await startTracing(categories: categories);
     await action();
     return stopTracingAndDownloadTimeline();

--- a/packages/flutter_driver/lib/src/driver.dart
+++ b/packages/flutter_driver/lib/src/driver.dart
@@ -223,9 +223,9 @@ class FlutterDriver {
   }
 
   /// Starts recording performance traces.
-  Future<Null> startTracing() async {
+  Future<Null> startTracing({ categories: '[all]' }) async {
     try {
-      await _peer.sendRequest(_kSetVMTimelineFlagsMethod, {'recordedStreams': '[all]'});
+      await _peer.sendRequest(_kSetVMTimelineFlagsMethod, {'recordedStreams': categories});
       return null;
     } catch(error, stackTrace) {
       throw new DriverError(
@@ -257,8 +257,8 @@ class FlutterDriver {
   ///
   /// This is merely a convenience wrapper on top of [startTracing] and
   /// [stopTracingAndDownloadTimeline].
-  Future<Timeline> traceAction(Future<dynamic> action()) async {
-    await startTracing();
+  Future<Timeline> traceAction(Future<dynamic> action(), { categories: '[all]' }) async {
+    await startTracing(categories: categories);
     await action();
     return stopTracingAndDownloadTimeline();
   }

--- a/packages/flutter_driver/lib/src/extension.dart
+++ b/packages/flutter_driver/lib/src/extension.dart
@@ -72,7 +72,7 @@ class FlutterDriverExtension {
       'tap': Tap.deserialize,
       'get_text': GetText.deserialize,
       'scroll': Scroll.deserialize,
-      'scrollIntoView': ScrollToVisible.deserialize,
+      'scrollIntoView': ScrollIntoView.deserialize,
       'waitFor': WaitFor.deserialize,
     });
 
@@ -209,7 +209,7 @@ class FlutterDriverExtension {
     return new ScrollResult();
   }
 
-  Future<ScrollResult> scrollIntoView(ScrollToVisible command) async {
+  Future<ScrollResult> scrollIntoView(ScrollIntoView command) async {
     Finder target = await _waitForElement(_createFinder(command.finder));
     await Scrollable.ensureVisible(target.evaluate().single);
     return new ScrollResult();

--- a/packages/flutter_driver/lib/src/extension.dart
+++ b/packages/flutter_driver/lib/src/extension.dart
@@ -63,7 +63,7 @@ class FlutterDriverExtension {
       'tap': tap,
       'get_text': getText,
       'scroll': scroll,
-      'scrollToVisible': scrollToVisible,
+      'scrollIntoView': scrollIntoView,
       'waitFor': waitFor,
     });
 
@@ -72,7 +72,7 @@ class FlutterDriverExtension {
       'tap': Tap.deserialize,
       'get_text': GetText.deserialize,
       'scroll': Scroll.deserialize,
-      'scrollToVisible': ScrollToVisible.deserialize,
+      'scrollIntoView': ScrollToVisible.deserialize,
       'waitFor': WaitFor.deserialize,
     });
 
@@ -209,9 +209,8 @@ class FlutterDriverExtension {
     return new ScrollResult();
   }
 
-  Future<ScrollResult> scrollToVisible(ScrollToVisible command) async {
+  Future<ScrollResult> scrollIntoView(ScrollToVisible command) async {
     Finder target = await _waitForElement(_createFinder(command.finder));
-    // ScrollableState scrollable = Scrollable.of(context); => null implies failure
     await Scrollable.ensureVisible(target.evaluate().single);
     return new ScrollResult();
   }

--- a/packages/flutter_driver/lib/src/extension.dart
+++ b/packages/flutter_driver/lib/src/extension.dart
@@ -210,9 +210,9 @@ class FlutterDriverExtension {
   }
 
   Future<ScrollResult> scrollToVisible(ScrollToVisible command) async {
-    Element target = await _runFinder(command.finder);
+    Finder target = await _waitForElement(_createFinder(command.finder));
     // ScrollableState scrollable = Scrollable.of(context); => null implies failure
-    await Scrollable.ensureVisible(target);
+    await Scrollable.ensureVisible(target.evaluate().single);
     return new ScrollResult();
   }
 

--- a/packages/flutter_driver/lib/src/extension.dart
+++ b/packages/flutter_driver/lib/src/extension.dart
@@ -63,6 +63,7 @@ class FlutterDriverExtension {
       'tap': tap,
       'get_text': getText,
       'scroll': scroll,
+      'scrollToVisible': scrollToVisible,
       'waitFor': waitFor,
     });
 
@@ -71,6 +72,7 @@ class FlutterDriverExtension {
       'tap': Tap.deserialize,
       'get_text': GetText.deserialize,
       'scroll': Scroll.deserialize,
+      'scrollToVisible': ScrollToVisible.deserialize,
       'waitFor': WaitFor.deserialize,
     });
 
@@ -204,6 +206,13 @@ class FlutterDriverExtension {
     }
     prober.binding.dispatchEvent(pointer.up(), hitTest);
 
+    return new ScrollResult();
+  }
+
+  Future<ScrollResult> scrollToVisible(ScrollToVisible command) async {
+    Element target = await _runFinder(command.finder);
+    // ScrollableState scrollable = Scrollable.of(context); => null implies failure
+    await Scrollable.ensureVisible(target);
     return new ScrollResult();
   }
 

--- a/packages/flutter_driver/lib/src/gesture.dart
+++ b/packages/flutter_driver/lib/src/gesture.dart
@@ -73,11 +73,11 @@ class Scroll extends CommandWithTarget {
   });
 }
 
-/// Command the driver ensure that the element represented by [finder] has been
-/// scrolled completely into view.  See [Scrollable.ensureVisible].
+/// Command the driver to ensure that the element represented by [finder]
+/// has been scrolled completely into view.
 class ScrollToVisible extends CommandWithTarget {
   @override
-  final String kind = 'scrollToVisible';
+  final String kind = 'scrollIntoView';
 
   ScrollToVisible(SerializableFinder finder) : super(finder);
 

--- a/packages/flutter_driver/lib/src/gesture.dart
+++ b/packages/flutter_driver/lib/src/gesture.dart
@@ -75,14 +75,14 @@ class Scroll extends CommandWithTarget {
 
 /// Command the driver to ensure that the element represented by [finder]
 /// has been scrolled completely into view.
-class ScrollToVisible extends CommandWithTarget {
+class ScrollIntoView extends CommandWithTarget {
   @override
   final String kind = 'scrollIntoView';
 
-  ScrollToVisible(SerializableFinder finder) : super(finder);
+  ScrollIntoView(SerializableFinder finder) : super(finder);
 
-  static ScrollToVisible deserialize(Map<String, dynamic> json) {
-    return new ScrollToVisible(SerializableFinder.deserialize(json));
+  static ScrollIntoView deserialize(Map<String, dynamic> json) {
+    return new ScrollIntoView(SerializableFinder.deserialize(json));
   }
 }
 

--- a/packages/flutter_driver/lib/src/gesture.dart
+++ b/packages/flutter_driver/lib/src/gesture.dart
@@ -73,6 +73,19 @@ class Scroll extends CommandWithTarget {
   });
 }
 
+/// Command the driver ensure that the element represented by [finder] has been
+/// scrolled completely into view.  See [Scrollable.ensureVisible].
+class ScrollToVisible extends CommandWithTarget {
+  @override
+  final String kind = 'scrollToVisible';
+
+  ScrollToVisible(SerializableFinder finder) : super(finder);
+
+  static ScrollToVisible deserialize(Map<String, dynamic> json) {
+    return new ScrollToVisible(SerializableFinder.deserialize(json));
+  }
+}
+
 class ScrollResult extends Result {
   static ScrollResult fromJson(Map<String, dynamic> json) {
     return new ScrollResult();

--- a/packages/flutter_driver/test/flutter_driver_test.dart
+++ b/packages/flutter_driver/test/flutter_driver_test.dart
@@ -235,6 +235,31 @@ void main() {
         expect(timeline.events.single.name, 'test event');
       });
     });
+
+    group('traceAction categories', () {
+      test('specify non-default categories', () async {
+        bool actionCalled = false;
+        bool categoriesSpecified = false;
+
+        when(mockPeer.sendRequest('_setVMTimelineFlags', argThat(equals({'recordedStreams': '[Dart GC Compiler]'}))))
+          .thenAnswer((_) async {
+            categoriesSpecified = true;
+            return null;
+          });
+
+        await driver.traceAction(() {
+          actionCalled = true;
+        },
+        categories: const <TracingCategory>[
+          TracingCategory.dart,
+          TracingCategory.gc,
+          TracingCategory.compiler
+        ]);
+
+        expect(actionCalled, isTrue);
+        expect(categoriesSpecified, isTrue);
+      });
+    });
   });
 }
 


### PR DESCRIPTION
Added a performance test to material gallery that collects data about how long it takes to start each demo.

The performance test launches and exits all ~23 gallery demos twice. It takes about 2 minutes to run.

Also:
- Added scrollToVisible() and timeline trace event category parameters to FlutterDriver.
- A few minor demo cleanups.
