### PR TITLE
AspectRatio has incorrect intrinsic sizing

### DIFF
--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -374,6 +374,8 @@ class RenderAspectRatio extends RenderProxyBox {
     RenderBox child,
     double aspectRatio
   }) : _aspectRatio = aspectRatio, super(child) {
+    assert(_aspectRatio > 0.0);
+    assert(_aspectRatio.isFinite);
     assert(_aspectRatio != null);
   }
 
@@ -385,6 +387,8 @@ class RenderAspectRatio extends RenderProxyBox {
   double _aspectRatio;
   void set aspectRatio (double newAspectRatio) {
     assert(newAspectRatio != null);
+    assert(newAspectRatio > 0.0);
+    assert(newAspectRatio.isFinite);
     if (_aspectRatio == newAspectRatio)
       return;
     _aspectRatio = newAspectRatio;
@@ -393,22 +397,26 @@ class RenderAspectRatio extends RenderProxyBox {
 
   @override
   double getMinIntrinsicWidth(BoxConstraints constraints) {
+    assert(constraints.debugAssertIsValid());
     return constraints.minWidth;
   }
 
   @override
   double getMaxIntrinsicWidth(BoxConstraints constraints) {
-    return constraints.maxWidth;
+    assert(constraints.debugAssertIsValid());
+    return constraints.constrainWidth(constraints.maxHeight * aspectRatio);
   }
 
   @override
   double getMinIntrinsicHeight(BoxConstraints constraints) {
+    assert(constraints.debugAssertIsValid());
     return constraints.minHeight;
   }
 
   @override
   double getMaxIntrinsicHeight(BoxConstraints constraints) {
-    return constraints.maxHeight;
+    assert(constraints.debugAssertIsValid());
+    return constraints.constrainHeight(constraints.maxWidth / aspectRatio);
   }
 
   Size _applyAspectRatio(BoxConstraints constraints) {

--- a/packages/flutter/test/rendering/aspect_ratio_test.dart
+++ b/packages/flutter/test/rendering/aspect_ratio_test.dart
@@ -1,0 +1,24 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/rendering.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('Intrinsic sizing', () {
+    RenderAspectRatio box = new RenderAspectRatio(aspectRatio: 2.0);
+
+    BoxConstraints constraints = new BoxConstraints.loose(new Size(200.0, 200.0));
+    expect(box.getMinIntrinsicWidth(constraints), equals(0.0));
+    expect(box.getMaxIntrinsicWidth(constraints), equals(200.0));
+    expect(box.getMinIntrinsicHeight(constraints), equals(0.0));
+    expect(box.getMaxIntrinsicHeight(constraints), equals(100.0));
+
+    constraints = new BoxConstraints(maxHeight: 400.0);
+    expect(box.getMinIntrinsicWidth(constraints), equals(0.0));
+    expect(box.getMaxIntrinsicWidth(constraints), equals(800.0));
+    expect(box.getMinIntrinsicHeight(constraints), equals(0.0));
+    expect(box.getMaxIntrinsicHeight(constraints), equals(400.0));
+  });
+}


### PR DESCRIPTION
If there's a max height or width, we should factor that into the intrinsic
sizing for the other dimension.
