### PR TITLE
Improve dartdoc for SystemChrome and SystemSound

### DIFF
--- a/packages/flutter/lib/src/services/path_provider.dart
+++ b/packages/flutter/lib/src/services/path_provider.dart
@@ -41,8 +41,8 @@ class PathProvider {
   ///
   /// Examples:
   ///
-  ///  * iOS: `NSDocumentsDirectory`
-  ///  * Android: The AppData directory.
+  ///  * _iOS_: `NSDocumentsDirectory`
+  ///  * _Android_: The AppData directory.
   static Future<Directory> getApplicationDocumentsDirectory() async {
     return new Directory((await _pathProviderProxy.ptr.applicationDocumentsDirectory()).path);
   }

--- a/packages/flutter/lib/src/services/system_chrome.dart
+++ b/packages/flutter/lib/src/services/system_chrome.dart
@@ -5,6 +5,7 @@
 import 'dart:async';
 
 import 'package:sky_services/flutter/platform/system_chrome.mojom.dart' as mojom;
+import 'package:sky_services/flutter/platform/system_chrome.mojom.dart';
 
 import 'shell.dart';
 
@@ -27,7 +28,7 @@ class SystemChrome {
   ///
   /// Arguments:
   ///
-  ///  * `device_orientation_mask`: A mask of `DeviceOrientation` enum values.
+  ///  * [deviceOrientationMask]: A mask of [DeviceOrientation] enum values.
   ///    The value 0 is synonymous with having all options enabled.
   ///
   /// Return Value:
@@ -44,7 +45,7 @@ class SystemChrome {
   ///
   /// Arguments:
   ///
-  ///  * `style`: A mask of `SystemUIOverlay` enum values that denotes the overlays
+  ///  * [style]: A mask of [SystemUIOverlay] enum values that denotes the overlays
   ///    to show.
   ///
   /// Return Value:

--- a/packages/flutter/lib/src/services/system_sound.dart
+++ b/packages/flutter/lib/src/services/system_sound.dart
@@ -5,6 +5,7 @@
 import 'dart:async';
 
 import 'package:sky_services/flutter/platform/system_sound.mojom.dart' as mojom;
+import 'package:sky_services/flutter/platform/system_sound.mojom.dart' show SystemSoundType;
 
 import 'shell.dart';
 
@@ -31,7 +32,7 @@ class SystemSound {
   ///   boolean indicating if the intent to play the specified sound was
   ///   successfully conveyed to the embedder. No sound may actually play if the
   ///   device is muted or the sound was not available on the platform.
-  static Future<bool> play(mojom.SystemSoundType type) async {
+  static Future<bool> play(SystemSoundType type) async {
     return (await _systemChromeProxy.ptr.play(type)).success;
   }
 }


### PR DESCRIPTION
We need to import these enums in order for the dartdoc to linkify correctly.

Fixes #3668
