### PR TITLE
Add note about explicit `pub get` needed.

### DIFF
--- a/packages/flutter_tools/lib/src/commands/build_aot.dart
+++ b/packages/flutter_tools/lib/src/commands/build_aot.dart
@@ -94,6 +94,8 @@ String buildAotSnapshot(
   if (!FileSystemEntity.isDirectorySync(packagesPath)) {
     printError('Could not find packages directory: $packagesPath\n' +
                'Did you run `pub get` in this directory?');
+    printError('This is needed to work around ' +
+               'https://github.com/dart-lang/sdk/issues/26362');
     return null;
   }
 


### PR DESCRIPTION
This fixes confusion I had when trying to use our fancy new AOT support.

Just notes this is a workaround for https://github.com/dart-lang/sdk/issues/26362

@devoncarew @jason-simmons @iposva-google
