### PR TITLE
filter an assertiond log message from ios

### DIFF
--- a/packages/flutter_tools/lib/src/ios/simulators.dart
+++ b/packages/flutter_tools/lib/src/ios/simulators.dart
@@ -731,6 +731,11 @@ class _IOSSimulatorLogReader extends DeviceLogReader {
           category == 'searchd')
         return null;
 
+      // assertiond: assertion failed: 15E65 13E230: assertiond + 15801 [3C808658-78EC-3950-A264-79A64E0E463B]: 0x1
+      if (category == 'assertiond' && content.startsWith('assertion failed: ')
+           && content.endsWith(']: 0x1'))
+         return null;
+
       _lastWasFiltered = false;
 
       if (category == 'Runner')


### PR DESCRIPTION
Filter an assertiond log message from the ios simulator (fix https://github.com/flutter/flutter/issues/1989).

@tvolkert @chinmaygarde 
