### PR TITLE
make the usage text more visible

### DIFF
--- a/packages/flutter_tools/lib/executable.dart
+++ b/packages/flutter_tools/lib/executable.dart
@@ -6,7 +6,6 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:args/command_runner.dart';
-import 'package:path/path.dart' as path;
 import 'package:stack_trace/stack_trace.dart';
 
 import 'src/base/context.dart';
@@ -84,13 +83,8 @@ Future<Null> main(List<String> args) async {
     context[DeviceManager] = new DeviceManager();
     Doctor.initGlobal();
 
-    if (flutterUsage.isFirstRun) {
-      printStatus(
-        'The Flutter tool anonymously reports feature usage statistics and basic crash reports to Google to\n'
-        'help Google contribute improvements to Flutter over time. Use "flutter config" to control this\n'
-        'behavior. See Google\'s privacy policy: https://www.google.com/intl/en/policies/privacy/\n'
-      );
-    }
+    if (flutterUsage.isFirstRun)
+      flutterUsage.printUsage();
 
     dynamic result = await runner.run(args);
 
@@ -126,7 +120,7 @@ Future<Null> main(List<String> args) async {
         File file = _createCrashReport(args, error, chain);
 
         stderr.writeln(
-          'Crash report written to ${path.relative(file.path)}; '
+          'Crash report written to ${file.path};\n'
           'please let us know at https://github.com/flutter/flutter/issues.');
       }
 

--- a/packages/flutter_tools/lib/executable.dart
+++ b/packages/flutter_tools/lib/executable.dart
@@ -83,13 +83,8 @@ Future<Null> main(List<String> args) async {
     context[DeviceManager] = new DeviceManager();
     Doctor.initGlobal();
 
-    if (flutterUsage.isFirstRun)
-      flutterUsage.printUsage();
-
     dynamic result = await runner.run(args);
-
-    if (result is int)
-      _exit(result);
+    _exit(result is int ? result : 0);
   }, onError: (dynamic error, Chain chain) {
     if (error is UsageException) {
       stderr.writeln(error.message);
@@ -167,6 +162,9 @@ String _doctorText() {
 }
 
 Future<Null> _exit(int code) async {
+  if (flutterUsage.isFirstRun)
+    flutterUsage.printUsage();
+
   // Send any last analytics calls that are in progress without overly delaying
   // the tool's exit (we wait a maximum of 250ms).
   if (flutterUsage.enabled) {

--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -163,6 +163,9 @@ abstract class FlutterCommand extends Command {
     // Populate the cache.
     await cache.updateAll();
 
+    if (flutterUsage.isFirstRun)
+      flutterUsage.printUsage();
+
     _setupToolchain();
     _setupApplicationPackages();
 

--- a/packages/flutter_tools/lib/src/usage.dart
+++ b/packages/flutter_tools/lib/src/usage.dart
@@ -30,6 +30,8 @@ class Usage {
 
   Analytics _analytics;
 
+  bool _printedUsage = false;
+
   bool get isFirstRun => _analytics.firstRun;
 
   bool get enabled => _analytics.enabled;
@@ -74,14 +76,24 @@ class Usage {
   }
 
   void printUsage() {
-    printStatus('''
-Flutter - https://flutter.io - version ${FlutterVersion.getVersionString(whitelistBranchName: true)}
+    if (_printedUsage)
+      return;
+    _printedUsage = true;
 
-  The Flutter tool anonymously reports feature usage statistics and basic crash reports to Google in
-  order to help Google contribute improvements to Flutter over time. Use "flutter config" to control
-  this behavior. See Google's privacy policy: https://www.google.com/intl/en/policies/privacy/
-'''
-    );
+    final String versionString = FlutterVersion.getVersionString(whitelistBranchName: true);
+
+    printStatus('');
+    printStatus('''
+  ╔════════════════════════════════════════════════════════════════════════════════════════════════════╗
+  ║              Welcome to Flutter! - Flutter version $versionString - https://flutter.io             ║
+  ║                                                                                                    ║
+  ║ The Flutter tool anonymously reports feature usage statistics and basic crash reports to Google in ║
+  ║ order to help Google contribute improvements to Flutter over time. See Google's privacy policy:    ║
+  ║ https://www.google.com/intl/en/policies/privacy/                                                   ║
+  ║                                                                                                    ║
+  ║                 Use "flutter config --no-analytics" to disable analytics reporting                 ║
+  ╚════════════════════════════════════════════════════════════════════════════════════════════════════╝
+  ''', emphasis: true);
   }
 }
 

--- a/packages/flutter_tools/lib/src/usage.dart
+++ b/packages/flutter_tools/lib/src/usage.dart
@@ -8,6 +8,7 @@ import 'package:usage/src/usage_impl_io.dart';
 import 'package:usage/usage.dart';
 
 import 'base/context.dart';
+import 'globals.dart';
 import 'runner/version.dart';
 
 // TODO(devoncarew): We'll need to do some work on the user agent in order to
@@ -70,6 +71,17 @@ class Usage {
     // events to not be reported. Perhaps we could send the analytics pings
     // out-of-process from flutter_tools?
     return _analytics.waitForLastPing(timeout: new Duration(milliseconds: 250));
+  }
+
+  void printUsage() {
+    printStatus('''
+Flutter - https://flutter.io - version ${FlutterVersion.getVersionString(whitelistBranchName: true)}
+
+  The Flutter tool anonymously reports feature usage statistics and basic crash reports to Google in
+  order to help Google contribute improvements to Flutter over time. Use "flutter config" to control
+  this behavior. See Google's privacy policy: https://www.google.com/intl/en/policies/privacy/
+'''
+    );
   }
 }
 

--- a/packages/flutter_tools/test/src/context.dart
+++ b/packages/flutter_tools/test/src/context.dart
@@ -143,6 +143,9 @@ class MockUsage implements Usage {
 
   @override
   Future<Null> ensureAnalyticsSent() => new Future<Null>.value();
+
+  @override
+  void printUsage() { }
 }
 
 class _MockUsageTimer implements UsageTimer {


### PR DESCRIPTION
Use whitespace and indent to make the first-run usage text more visible:

```
[~/projects/flutter/flutter] flutter
Flutter - https://flutter.io - version 6072552868/master

  The Flutter tool anonymously reports feature usage statistics and basic crash reports to Google in
  order to help Google contribute improvements to Flutter over time. Use "flutter config" to control
  this behavior. See Google's privacy policy: https://www.google.com/intl/en/policies/privacy/

Manage your Flutter app development.

Usage: flutter <command> [arguments]

Global options:
-h, --help            Print this usage information.
-v, --verbose         Noisy logging, including all shell commands executed.
...
```

I experimented with changing where it displayed but had some issues with long and short running commands; happy to iterate on the look.

@Hixie 
