### PR TITLE
Add a non-null builder assert to Builders, renamed IndexedBuilder

### DIFF
--- a/packages/flutter/lib/src/material/bottom_sheet.dart
+++ b/packages/flutter/lib/src/material/bottom_sheet.dart
@@ -52,6 +52,7 @@ class BottomSheet extends StatefulWidget {
     this.builder
   }) : super(key: key) {
     assert(onClosing != null);
+    assert(builder != null);
   }
 
   /// The animation that controls the bottom sheet's position.

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -2893,7 +2893,9 @@ class KeyedSubtree extends StatelessWidget {
 
 /// A platonic widget that invokes a closure to obtain its child widget.
 class Builder extends StatelessWidget {
-  Builder({ Key key, this.builder }) : super(key: key);
+  Builder({ Key key, this.builder }) : super(key: key) {
+    assert(builder != null);
+  }
 
   /// Called to obtain the child widget.
   ///
@@ -2910,7 +2912,9 @@ class Builder extends StatelessWidget {
 
 typedef Widget StatefulWidgetBuilder(BuildContext context, StateSetter setState);
 class StatefulBuilder extends StatefulWidget {
-  StatefulBuilder({ Key key, this.builder }) : super(key: key);
+  StatefulBuilder({ Key key, this.builder }) : super(key: key) {
+    assert(builder != null);
+  }
 
   final StatefulWidgetBuilder builder;
 

--- a/packages/flutter/lib/src/widgets/drag_target.dart
+++ b/packages/flutter/lib/src/widgets/drag_target.dart
@@ -348,6 +348,7 @@ class _DragTargetState<T> extends State<DragTarget<T>> {
 
   @override
   Widget build(BuildContext context) {
+    assert(config.builder != null);
     return new MetaData(
       metaData: this,
       behavior: HitTestBehavior.translucent,

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -1472,7 +1472,7 @@ abstract class BuildableElement extends Element {
 }
 
 typedef Widget WidgetBuilder(BuildContext context);
-typedef Widget IndexedBuilder(BuildContext context, int index);
+typedef Widget IndexedWidgetBuilder(BuildContext context, int index);
 
 // See ComponentElement._builder.
 Widget _buildNothing(BuildContext context) => null;

--- a/packages/flutter/lib/src/widgets/layout_builder.dart
+++ b/packages/flutter/lib/src/widgets/layout_builder.dart
@@ -17,7 +17,9 @@ typedef Widget LayoutWidgetBuilder(BuildContext context, Size size);
 /// when the parent constrains the child's size and doesn't depend on the child's
 /// intrinsic size.
 class LayoutBuilder extends RenderObjectWidget {
-  LayoutBuilder({ Key key, this.builder }) : super(key: key);
+  LayoutBuilder({ Key key, this.builder }) : super(key: key) {
+    assert(builder != null);
+  }
 
   /// Called at layout time to construct the widget tree. The builder must not
   /// return null.

--- a/packages/flutter/lib/src/widgets/lazy_block.dart
+++ b/packages/flutter/lib/src/widgets/lazy_block.dart
@@ -15,7 +15,7 @@ import 'scroll_behavior.dart';
 /// Provides children for [LazyBlock] or [LazyBlockViewport].
 ///
 /// See also [LazyBlockBuilder] for an implementation of LazyBlockDelegate based
-/// on an [IndexedBuilder] closure.
+/// on an [IndexedWidgetBuilder] closure.
 abstract class LazyBlockDelegate {
   /// Abstract const constructor. This constructor enables subclasses to provide
   /// const constructors so that they can be used in const expressions.
@@ -49,7 +49,7 @@ abstract class LazyBlockDelegate {
   bool shouldRebuild(LazyBlockDelegate oldDelegate);
 }
 
-/// Uses an [IndexedBuilder] to provide children for [LazyBlock].
+/// Uses an [IndexedWidgetBuilder] to provide children for [LazyBlock].
 ///
 /// A LazyBlockBuilder rebuilds the children whenever the [LazyBlock] is
 /// rebuilt, similar to the behavior of [Builder].
@@ -65,13 +65,13 @@ class LazyBlockBuilder extends LazyBlockDelegate {
   ///
   /// This function might be called with index parameters in any order. This
   /// function should return null for indices that exceed the number of children
-  /// provided by this delegate. If this function must not return a null value
+  /// provided by this delegate. This function must not return a null value
   /// for an index if it previously returned a non-null value for that index or
   /// a larger index.
   ///
   /// This function might be called during the build or layout phases of the
   /// pipeline.
-  final IndexedBuilder builder;
+  final IndexedWidgetBuilder builder;
 
   @override
   Widget buildItem(BuildContext context, int index) => builder(context, index);
@@ -478,7 +478,7 @@ class _LazyBlockElement extends RenderObjectElement {
 
   @override
   void performRebuild() {
-    IndexedBuilder builder = widget.delegate.buildItem;
+    IndexedWidgetBuilder builder = widget.delegate.buildItem;
     List<Widget> widgets = <Widget>[];
     for (int i = 0; i < _children.length; ++i) {
       int logicalIndex = _firstChildLogicalIndex + i;
@@ -494,7 +494,7 @@ class _LazyBlockElement extends RenderObjectElement {
   void _layout(BoxConstraints constraints) {
     final double blockExtent = _getMainAxisExtent(renderObject.size);
 
-    final IndexedBuilder builder = widget.delegate.buildItem;
+    final IndexedWidgetBuilder builder = widget.delegate.buildItem;
     final double startLogicalOffset = widget.startOffset;
     final double endLogicalOffset = startLogicalOffset + blockExtent;
     final _RenderLazyBlock block = renderObject;

--- a/packages/flutter/lib/src/widgets/overlay.dart
+++ b/packages/flutter/lib/src/widgets/overlay.dart
@@ -44,7 +44,9 @@ class OverlayEntry {
   OverlayEntry({
     this.builder,
     bool opaque: false
-  }) : _opaque = opaque;
+  }) : _opaque = opaque {
+    assert(builder != null);
+  }
 
   /// This entry will include the widget built by this builder in the overlay at the entry's position.
   ///

--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -36,7 +36,9 @@ class TextSelectionHandles {
     this.renderObject,
     this.onSelectionHandleChanged,
     this.builder
-  }): _selection = selection;
+  }): _selection = selection {
+    assert(builder != null);
+  }
 
   // TODO(mpcomplete): what if the renderObject is removed or replaced, or
   // moves? Not sure what cases I need to handle, or how to handle them.

--- a/packages/flutter/lib/src/widgets/transitions.dart
+++ b/packages/flutter/lib/src/widgets/transitions.dart
@@ -349,7 +349,9 @@ class AnimatedBuilder extends AnimatedWidget {
     Animation<Object> animation,
     this.builder,
     this.child
-  }) : super(key: key, animation: animation);
+  }) : super(key: key, animation: animation) {
+    assert(builder != null);
+  }
 
   /// Called every time the animation changes value.
   final TransitionBuilder builder;

--- a/packages/flutter/test/widget/lazy_block_viewport_test.dart
+++ b/packages/flutter/test/widget/lazy_block_viewport_test.dart
@@ -61,7 +61,7 @@ void main() {
 
     double offset = 300.0;
 
-    IndexedBuilder itemBuilder = (BuildContext context, int i) {
+    IndexedWidgetBuilder itemBuilder = (BuildContext context, int i) {
       callbackTracker.add(i);
       return new Container(
         key: new ValueKey<int>(i),
@@ -111,7 +111,7 @@ void main() {
 
     double offset = 300.0;
 
-    IndexedBuilder itemBuilder = (BuildContext context, int i) {
+    IndexedWidgetBuilder itemBuilder = (BuildContext context, int i) {
       callbackTracker.add(i);
       return new Container(
         key: new ValueKey<int>(i),
@@ -158,7 +158,7 @@ void main() {
     List<int> callbackTracker = <int>[];
     List<String> text = <String>[];
 
-    IndexedBuilder itemBuilder = (BuildContext context, int i) {
+    IndexedWidgetBuilder itemBuilder = (BuildContext context, int i) {
       callbackTracker.add(i);
       return new Container(
         key: new ValueKey<int>(i),
@@ -201,7 +201,7 @@ void main() {
     StateSetter setState;
     ThemeData themeData = new ThemeData.light();
 
-    IndexedBuilder itemBuilder = (BuildContext context, int i) {
+    IndexedWidgetBuilder itemBuilder = (BuildContext context, int i) {
       return new Container(
         key: new ValueKey<int>(i),
         width: 500.0, // this should be ignored
@@ -242,7 +242,7 @@ void main() {
   });
 
   testWidgets('LazyBlockViewport padding', (WidgetTester tester) {
-    IndexedBuilder itemBuilder = (BuildContext context, int i) {
+    IndexedWidgetBuilder itemBuilder = (BuildContext context, int i) {
       return new Container(
         key: new ValueKey<int>(i),
         width: 500.0, // this should be ignored


### PR DESCRIPTION
LayoutBuilder and LazyBlock already did this. See https://github.com/flutter/flutter/pull/3670#discussion_r61921196.

IndexedBuilder is now IndexedWidgetBuilder for consistency with WidgetBuilder, StatefulWidgetBuilder, and LayoutWidgetBuilder.

Fixes #3680
