### PR TITLE
Provide framework-only timing information

### DIFF
--- a/packages/flutter_tools/lib/src/commands/run.dart
+++ b/packages/flutter_tools/lib/src/commands/run.dart
@@ -416,6 +416,7 @@ Future<Null> _downloadStartupTrace(int observatoryPort, Device device) async {
 
   if (frameworkInitTimestampMicros != null) {
     traceInfo['timeToFrameworkInitMicros'] = frameworkInitTimestampMicros - engineEnterTimestampMicros;
+    traceInfo['timeAfterFrameworkInitMicros'] = timeToFirstFrameMicros - frameworkInitTimestampMicros;
   }
 
   await traceInfoFile.writeAsString(JSON.encode(traceInfo));


### PR DESCRIPTION
This makes it easier to generate charts that show the engine time and
the framework time separately.
