### PR TITLE
PathProvider.getTemporaryDirectory() never resolves

### DIFF
--- a/packages/flutter/lib/src/services/path_provider.dart
+++ b/packages/flutter/lib/src/services/path_provider.dart
@@ -11,7 +11,7 @@ import 'shell.dart';
 
 mojom.PathProviderProxy _initPathProviderProxy() {
   mojom.PathProviderProxy proxy = new mojom.PathProviderProxy.unbound();
-  shell.connectToViewAssociatedService(proxy);
+  shell.connectToService('mojo:flutter_platform', proxy);
   return proxy;
 }
 

--- a/packages/flutter/lib/src/services/system_chrome.dart
+++ b/packages/flutter/lib/src/services/system_chrome.dart
@@ -13,7 +13,7 @@ export 'package:sky_services/flutter/platform/system_chrome.mojom.dart' show Dev
 
 mojom.SystemChromeProxy _initSystemChromeProxy() {
   mojom.SystemChromeProxy proxy = new mojom.SystemChromeProxy.unbound();
-  shell.connectToViewAssociatedService(proxy);
+  shell.connectToService('mojo:flutter_platform', proxy);
   return proxy;
 }
 

--- a/packages/flutter/lib/src/services/system_sound.dart
+++ b/packages/flutter/lib/src/services/system_sound.dart
@@ -13,7 +13,7 @@ export 'package:sky_services/flutter/platform/system_sound.mojom.dart' show Syst
 
 mojom.SystemSoundProxy _initSystemSoundProxy() {
   mojom.SystemSoundProxy proxy = new mojom.SystemSoundProxy.unbound();
-  shell.connectToViewAssociatedService(proxy);
+  shell.connectToService('mojo:flutter_platform', proxy);
   return proxy;
 }
 


### PR DESCRIPTION
We were looking for this service in the wrong service provider.

Fixes #3683
