### PR TITLE
fix the benchmark file written by the analyze command

### DIFF
--- a/packages/flutter_tools/lib/src/commands/analyze.dart
+++ b/packages/flutter_tools/lib/src/commands/analyze.dart
@@ -580,7 +580,7 @@ class AnalyzeCommand extends FlutterCommand {
     String expectedTime = argResults['benchmark-expected'];
 
     Map<String, dynamic> data = <String, dynamic>{
-      'time': (stopwatch.elapsedMilliseconds / 1000.0).toStringAsFixed(3),
+      'time': (stopwatch.elapsedMilliseconds / 1000.0),
       'issues': errorCount
     };
 


### PR DESCRIPTION
Fix the benchmark file written by the analyze command. This was writing the time as a string, not as a number.

```
{
  "time": 34.823,
  "issues": 331
}
```

@pq @yjbanov 
