### PR TITLE
Literals get type annotations.

### DIFF
--- a/packages/flutter_driver/lib/src/driver.dart
+++ b/packages/flutter_driver/lib/src/driver.dart
@@ -252,7 +252,7 @@ class FlutterDriver {
   Future<Null> startTracing({List<TracingCategory> categories: _defaultCategories}) async {
     assert(categories != null && categories.length > 0);
     try {
-      await _peer.sendRequest(_kSetVMTimelineFlagsMethod, {
+      await _peer.sendRequest(_kSetVMTimelineFlagsMethod, <String, String>{
         'recordedStreams': _tracingCategoriesToString(categories)
       });
       return null;
@@ -268,7 +268,7 @@ class FlutterDriver {
   /// Stops recording performance traces and downloads the timeline.
   Future<Timeline> stopTracingAndDownloadTimeline() async {
     try {
-      await _peer.sendRequest(_kSetVMTimelineFlagsMethod, {'recordedStreams': '[]'});
+      await _peer.sendRequest(_kSetVMTimelineFlagsMethod, <String, String>{'recordedStreams': '[]'});
       return new Timeline.fromJson(await _peer.sendRequest(_kGetVMTimelineMethod));
     } catch(error, stackTrace) {
       throw new DriverError(

--- a/packages/flutter_driver/lib/src/find.dart
+++ b/packages/flutter_driver/lib/src/find.dart
@@ -91,7 +91,7 @@ abstract class SerializableFinder {
     throw new DriverError('Unsupported search specification type $finderType');
   }
 
-  Map<String, String> serialize() => {
+  Map<String, String> serialize() => <String, String>{
     'finderType': finderType,
   };
 }
@@ -107,7 +107,7 @@ class ByTooltipMessage extends SerializableFinder {
   final String text;
 
   @override
-  Map<String, String> serialize() => super.serialize()..addAll({
+  Map<String, String> serialize() => super.serialize()..addAll(<String, String>{
     'text': text,
   });
 
@@ -126,7 +126,7 @@ class ByText extends SerializableFinder {
   final String text;
 
   @override
-  Map<String, String> serialize() => super.serialize()..addAll({
+  Map<String, String> serialize() => super.serialize()..addAll(<String, String>{
     'text': text,
   });
 
@@ -160,7 +160,7 @@ class ByValueKey extends SerializableFinder {
   final String keyValueType;
 
   @override
-  Map<String, String> serialize() => super.serialize()..addAll({
+  Map<String, String> serialize() => super.serialize()..addAll(<String, String>{
     'keyValueString': keyValueString,
     'keyValueType': keyValueType,
   });
@@ -205,7 +205,7 @@ class GetTextResult extends Result {
   }
 
   @override
-  Map<String, dynamic> toJson() => {
+  Map<String, dynamic> toJson() => <String, String>{
     'text': text,
   };
 }

--- a/packages/flutter_driver/lib/src/gesture.dart
+++ b/packages/flutter_driver/lib/src/gesture.dart
@@ -25,7 +25,7 @@ class TapResult extends Result {
   }
 
   @override
-  Map<String, dynamic> toJson() => {};
+  Map<String, dynamic> toJson() => <String, dynamic>{};
 }
 
 
@@ -65,7 +65,7 @@ class Scroll extends CommandWithTarget {
   final int frequency;
 
   @override
-  Map<String, String> serialize() => super.serialize()..addAll({
+  Map<String, String> serialize() => super.serialize()..addAll(<String, String>{
     'dx': '$dx',
     'dy': '$dy',
     'duration': '${duration.inMicroseconds}',
@@ -92,5 +92,5 @@ class ScrollResult extends Result {
   }
 
   @override
-  Map<String, dynamic> toJson() => {};
+  Map<String, dynamic> toJson() => <String, dynamic>{};
 }

--- a/packages/flutter_driver/lib/src/health.dart
+++ b/packages/flutter_driver/lib/src/health.dart
@@ -13,7 +13,7 @@ class GetHealth implements Command {
   static GetHealth deserialize(Map<String, String> json) => new GetHealth();
 
   @override
-  Map<String, String> serialize() => const {};
+  Map<String, String> serialize() => const <String, String>{};
 }
 
 /// Application health status.
@@ -42,7 +42,7 @@ class Health extends Result {
   final HealthStatus status;
 
   @override
-  Map<String, dynamic> toJson() => {
+  Map<String, dynamic> toJson() => <String, dynamic>{
     'status': _healthStatusIndex.toSimpleName(status)
   };
 }

--- a/packages/flutter_driver/lib/src/matcher_util.dart
+++ b/packages/flutter_driver/lib/src/matcher_util.dart
@@ -6,7 +6,7 @@ import 'package:matcher/matcher.dart';
 
 /// Matches [value] against the [matcher].
 MatchResult match(dynamic value, Matcher matcher) {
-  Map<dynamic, dynamic> matchState = {};
+  Map<dynamic, dynamic> matchState = <dynamic, dynamic>{};
   if (matcher.matches(value, matchState)) {
     return new MatchResult._matched();
   } else {

--- a/packages/flutter_driver/test/flutter_driver_test.dart
+++ b/packages/flutter_driver/test/flutter_driver_test.dart
@@ -32,7 +32,7 @@ void main() {
       mockVM = new MockVM();
       mockIsolate = new MockIsolate();
       when(mockClient.getVM()).thenReturn(mockVM);
-      when(mockVM.isolates).thenReturn([mockIsolate]);
+      when(mockVM.isolates).thenReturn(<VMRunnableIsolate>[mockIsolate]);
       when(mockIsolate.loadRunnable()).thenReturn(mockIsolate);
       when(mockIsolate.invokeExtension(any, any))
           .thenReturn(new Future<Map<String, dynamic>>.value(<String, String>{'status': 'ok'}));
@@ -126,7 +126,7 @@ void main() {
 
       test('finds by ValueKey', () async {
         when(mockIsolate.invokeExtension(any, any)).thenAnswer((Invocation i) {
-          expect(i.positionalArguments[1], {
+          expect(i.positionalArguments[1], <String, String>{
             'command': 'tap',
             'finderType': 'ByValueKey',
             'keyValueString': 'foo',
@@ -169,7 +169,7 @@ void main() {
             'keyValueString': '123',
             'keyValueType': 'int'
           });
-          return new Future<Map<String, dynamic>>.value({
+          return new Future<Map<String, dynamic>>.value(<String, String>{
             'text': 'hello'
           });
         });
@@ -191,7 +191,7 @@ void main() {
             'text': 'foo',
             'timeout': '1000',
           });
-          return new Future<Map<String, dynamic>>.value({});
+          return new Future<Map<String, dynamic>>.value(<String, dynamic>{});
         });
         await driver.waitFor(find.byTooltip('foo'), timeout: new Duration(seconds: 1));
       });
@@ -203,13 +203,13 @@ void main() {
         bool startTracingCalled = false;
         bool stopTracingCalled = false;
 
-        when(mockPeer.sendRequest('_setVMTimelineFlags', argThat(equals({'recordedStreams': '[all]'}))))
+        when(mockPeer.sendRequest('_setVMTimelineFlags', argThat(equals(<String, dynamic>{'recordedStreams': '[all]'}))))
           .thenAnswer((_) async {
             startTracingCalled = true;
             return null;
           });
 
-        when(mockPeer.sendRequest('_setVMTimelineFlags', argThat(equals({'recordedStreams': '[]'}))))
+        when(mockPeer.sendRequest('_setVMTimelineFlags', argThat(equals(<String, dynamic>{'recordedStreams': '[]'}))))
           .thenAnswer((_) async {
             stopTracingCalled = true;
             return null;
@@ -217,8 +217,8 @@ void main() {
 
         when(mockPeer.sendRequest('_getVMTimeline')).thenAnswer((_) async {
           return <String, dynamic> {
-            'traceEvents': [
-              {
+            'traceEvents': <dynamic>[
+              <String, String>{
                 'name': 'test event'
               }
             ],
@@ -242,13 +242,13 @@ void main() {
         bool startTracingCalled = false;
         bool stopTracingCalled = false;
 
-        when(mockPeer.sendRequest('_setVMTimelineFlags', argThat(equals({'recordedStreams': '[Dart, GC, Compiler]'}))))
+        when(mockPeer.sendRequest('_setVMTimelineFlags', argThat(equals(<String, dynamic>{'recordedStreams': '[Dart, GC, Compiler]'}))))
           .thenAnswer((_) async {
             startTracingCalled = true;
             return null;
           });
 
-        when(mockPeer.sendRequest('_setVMTimelineFlags', argThat(equals({'recordedStreams': '[]'}))))
+        when(mockPeer.sendRequest('_setVMTimelineFlags', argThat(equals(<String, dynamic>{'recordedStreams': '[]'}))))
           .thenAnswer((_) async {
             stopTracingCalled = true;
             return null;
@@ -256,8 +256,8 @@ void main() {
 
         when(mockPeer.sendRequest('_getVMTimeline')).thenAnswer((_) async {
           return <String, dynamic> {
-            'traceEvents': [
-              {
+            'traceEvents': <dynamic>[
+              <String, String>{
                 'name': 'test event'
               }
             ],

--- a/packages/flutter_driver/test/src/timeline_summary_test.dart
+++ b/packages/flutter_driver/test/src/timeline_summary_test.dart
@@ -28,7 +28,7 @@ void main() {
     group('frame_count', () {
       test('counts frames', () {
         expect(
-          summarize([
+          summarize(<Map<String, dynamic>>[
             begin(1000), end(2000),
             begin(3000), end(5000),
           ]).countFrames(),
@@ -39,12 +39,12 @@ void main() {
 
     group('average_frame_build_time_millis', () {
       test('returns null when there is no data', () {
-        expect(summarize([]).computeAverageFrameBuildTimeMillis(), isNull);
+        expect(summarize(<Map<String, dynamic>>[]).computeAverageFrameBuildTimeMillis(), isNull);
       });
 
       test('computes average frame build time in milliseconds', () {
         expect(
-          summarize([
+          summarize(<Map<String, dynamic>>[
             begin(1000), end(2000),
             begin(3000), end(5000),
           ]).computeAverageFrameBuildTimeMillis(),
@@ -54,7 +54,7 @@ void main() {
 
       test('skips leading "end" events', () {
         expect(
-          summarize([
+          summarize(<Map<String, dynamic>>[
             end(1000),
             begin(2000), end(4000),
           ]).computeAverageFrameBuildTimeMillis(),
@@ -64,7 +64,7 @@ void main() {
 
       test('skips trailing "begin" events', () {
         expect(
-          summarize([
+          summarize(<Map<String, dynamic>>[
             begin(2000), end(4000),
             begin(5000),
           ]).computeAverageFrameBuildTimeMillis(),
@@ -75,19 +75,19 @@ void main() {
 
     group('worst_frame_build_time_millis', () {
       test('returns null when there is no data', () {
-        expect(summarize([]).computeWorstFrameBuildTimeMillis(), isNull);
+        expect(summarize(<Map<String, dynamic>>[]).computeWorstFrameBuildTimeMillis(), isNull);
       });
 
       test('computes worst frame build time in milliseconds', () {
         expect(
-          summarize([
+          summarize(<Map<String, dynamic>>[
             begin(1000), end(2000),
             begin(3000), end(5000),
           ]).computeWorstFrameBuildTimeMillis(),
           2.0
         );
         expect(
-          summarize([
+          summarize(<Map<String, dynamic>>[
             begin(3000), end(5000),
             begin(1000), end(2000),
           ]).computeWorstFrameBuildTimeMillis(),
@@ -97,7 +97,7 @@ void main() {
 
       test('skips leading "end" events', () {
         expect(
-          summarize([
+          summarize(<Map<String, dynamic>>[
             end(1000),
             begin(2000), end(4000),
           ]).computeWorstFrameBuildTimeMillis(),
@@ -107,7 +107,7 @@ void main() {
 
       test('skips trailing "begin" events', () {
         expect(
-          summarize([
+          summarize(<Map<String, dynamic>>[
             begin(2000), end(4000),
             begin(5000),
           ]).computeWorstFrameBuildTimeMillis(),
@@ -118,7 +118,7 @@ void main() {
 
     group('computeMissedFrameBuildBudgetCount', () {
       test('computes the number of missed build budgets', () {
-        TimelineSummary summary = summarize([
+        TimelineSummary summary = summarize(<Map<String, dynamic>>[
           begin(1000), end(10000),
           begin(11000), end(12000),
           begin(13000), end(23000),
@@ -132,12 +132,12 @@ void main() {
     group('summaryJson', () {
       test('computes and returns summary as JSON', () {
         expect(
-          summarize([
+          summarize(<Map<String, dynamic>>[
             begin(1000), end(10000),
             begin(11000), end(12000),
             begin(13000), end(24000),
           ]).summaryJson,
-          {
+          <String, dynamic>{
             'average_frame_build_time_millis': 7.0,
             'worst_frame_build_time_millis': 11.0,
             'missed_frame_build_budget_count': 2,
@@ -158,7 +158,7 @@ void main() {
       });
 
       test('writes timeline to JSON file', () async {
-        await summarize([{'foo': 'bar'}])
+        await summarize(<Map<String, String>>[<String, String>{'foo': 'bar'}])
           .writeTimelineToFile('test', destinationDirectory: '/temp');
         String written =
             await fs.file('/temp/test.timeline.json').readAsString();
@@ -166,14 +166,14 @@ void main() {
       });
 
       test('writes summary to JSON file', () async {
-        await summarize([
+        await summarize(<Map<String, dynamic>>[
           begin(1000), end(10000),
           begin(11000), end(12000),
           begin(13000), end(24000),
         ]).writeSummaryToFile('test', destinationDirectory: '/temp');
         String written =
             await fs.file('/temp/test.timeline_summary.json').readAsString();
-        expect(JSON.decode(written), {
+        expect(JSON.decode(written), <String, dynamic>{
           'average_frame_build_time_millis': 7.0,
           'worst_frame_build_time_millis': 11.0,
           'missed_frame_build_budget_count': 2,

--- a/packages/flutter_driver/test/src/timeline_test.dart
+++ b/packages/flutter_driver/test/src/timeline_test.dart
@@ -8,9 +8,9 @@ import 'package:flutter_driver/src/timeline.dart';
 void main() {
   group('Timeline', () {
     test('parses JSON', () {
-      Timeline timeline = new Timeline.fromJson({
-        'traceEvents': [
-          {
+      Timeline timeline = new Timeline.fromJson(<String, dynamic>{
+        'traceEvents': <Map<String, dynamic>>[
+          <String, dynamic>{
             'name': 'test event',
             'cat': 'test category',
             'ph': 'B',
@@ -19,12 +19,12 @@ void main() {
             'dur': 345,
             'ts': 456,
             'tts': 567,
-            'args': {
+            'args': <String, dynamic>{
               'arg1': true,
             }
           },
           // Tests that we don't choke on missing data
-          {}
+          <String, dynamic>{}
         ]
       });
 
@@ -39,7 +39,7 @@ void main() {
       expect(e1.duration, const Duration(microseconds: 345));
       expect(e1.timestampMicros, 456);
       expect(e1.threadTimestampMicros, 567);
-      expect(e1.arguments, { 'arg1': true });
+      expect(e1.arguments, <String, dynamic>{ 'arg1': true });
 
       TimelineEvent e2 = timeline.events[1];
       expect(e2.name, isNull);

--- a/packages/flutter_sprites/lib/src/nine_slice_sprite.dart
+++ b/packages/flutter_sprites/lib/src/nine_slice_sprite.dart
@@ -92,7 +92,7 @@ class NineSliceSprite extends NodeWithSize with SpritePaint {
 
     if (_isDirty) {
       // Calcuate vertices and indices.
-      _vertices = [
+      _vertices = <Point>[
         Point.origin,
 
       ];

--- a/packages/flutter_sprites/test/action_test.dart
+++ b/packages/flutter_sprites/test/action_test.dart
@@ -158,7 +158,7 @@ void main() {
     ActionTween tween0 = new ActionTween((double a) => value0 = a, 0.0, 1.0, 10.0);
     ActionTween tween1 = new ActionTween((double a) => value1 = a, 0.0, 1.0, 20.0);
 
-    ActionGroup group = new ActionGroup([tween0, tween1]);
+    ActionGroup group = new ActionGroup(<ActionTween>[tween0, tween1]);
     expect(group.duration, closeTo(20.0, epsilon));
 
     group.update(0.0);
@@ -180,7 +180,7 @@ void main() {
     ActionTween tween0 = new ActionTween((double a) => doubleValue = a, 0.0, 1.0, 4.0);
     ActionTween tween1 = new ActionTween((double a) => doubleValue = a, 1.0, 0.0, 12.0);
 
-    ActionSequence sequence = new ActionSequence([tween0, tween1]);
+    ActionSequence sequence = new ActionSequence(<ActionTween>[tween0, tween1]);
     expect(sequence.duration, closeTo(16.0, epsilon));
 
     sequence.update(0.0);

--- a/packages/flutter_sprites/test/constraint_test.dart
+++ b/packages/flutter_sprites/test/constraint_test.dart
@@ -19,7 +19,7 @@ void main() {
     parent.addChild(node0);
     parent.addChild(node1);
 
-    node1.constraints = [(new ConstraintPositionToNode(node0))];
+    node1.constraints = <Constraint>[(new ConstraintPositionToNode(node0))];
 
     node0.position = const Point(100.0, 50.0);
     node1.applyConstraints(0.1);
@@ -37,7 +37,7 @@ void main() {
     parent.addChild(node0);
     parent.addChild(node1);
 
-    node1.constraints = [(new ConstraintRotationToNode(node0))];
+    node1.constraints = <Constraint>[(new ConstraintRotationToNode(node0))];
 
     node1.applyConstraints(0.1);
 
@@ -53,7 +53,7 @@ void main() {
     parent.addChild(node0);
     parent.addChild(node1);
 
-    node1.constraints = [(new ConstraintRotationToNodeRotation(node0, baseRotation: 10.0))];
+    node1.constraints = <Constraint>[(new ConstraintRotationToNodeRotation(node0, baseRotation: 10.0))];
 
     node0.rotation = 90.0;
     node1.applyConstraints(0.1);
@@ -69,7 +69,7 @@ void main() {
     parent.addChild(node0);
 
     Constraint constraint = new ConstraintRotationToMovement();
-    node0.constraints = [constraint];
+    node0.constraints = <Constraint>[constraint];
 
     node0.position = const Point(0.0, 0.0);
     constraint.preUpdate(node0, 0.1);


### PR DESCRIPTION
As per the recent fix to the `always_specify_types` lint (https://github.com/dart-lang/sdk/issues/57296), literal maps and lists are now expected to be explicitly typed.

Running that lint on the repo identifies quite a few spots to update.  This focuses on `flutter_driver` and `flutter_sprites` (somewhat arbitrarily) but the changes are fairly representative.

Note there are a number of places where I made a quick judgement on how specific to make the types.  Feedback on those is welcome.  (Especially as we move forward with more.)
