### PR TITLE
complain on missing entries in flutter.yaml

### DIFF
--- a/bin/flutter
+++ b/bin/flutter
@@ -48,7 +48,7 @@ export PATH="$DART_SDK_PATH/bin:$PATH"
 set +e
 
 if [ $FLUTTER_DEV ]; then
-  "$DART" --packages="$FLUTTER_TOOLS_DIR/.packages" "$SCRIPT_PATH" "$@"
+  "$DART" --packages="$FLUTTER_TOOLS_DIR/.packages" -c "$SCRIPT_PATH" "$@"
 else
   "$DART" "$SNAPSHOT_PATH" "$@"
 fi

--- a/packages/flutter_tools/lib/src/android/android_device.dart
+++ b/packages/flutter_tools/lib/src/android/android_device.dart
@@ -313,6 +313,9 @@ class AndroidDevice extends Device {
       includeRobotoFonts: false
     );
 
+    if (localBundlePath == null)
+      return new LaunchResult.failed();
+
     printTrace('Starting bundle for $this.');
 
     return startBundle(

--- a/packages/flutter_tools/lib/src/commands/build_apk.dart
+++ b/packages/flutter_tools/lib/src/commands/build_apk.dart
@@ -504,6 +504,9 @@ Future<int> buildAndroid(
       mainPath: findMainDartFile(target),
       precompiledSnapshot: isAotBuildMode(buildMode),
       includeRobotoFonts: false);
+
+    if (flxPath == null)
+      return 1;
   }
 
   // Build an AOT snapshot if needed.


### PR DESCRIPTION
- complain on missing entries in flutter.yaml (fix https://github.com/flutter/flutter/issues/3688)
- when flutter.yaml validation fails, don't throw an exception; print a message and fail the flx build

W/ missing assets we now print a warning but do complete the flx build. We could also choose to do a hard fail of the build.

@krisgiesing @jason-simmons 

```
[~/flutter/flutter_sunflower] flutter build apk
Building APK in debug mode (android-arm)...
Warning: unable to locate asset entry in flutter.yaml: "lib/bar.png".
Built build/app.apk (8.5MB).
```
