### PR TITLE
Remove ModalPosition

### DIFF
--- a/examples/material_gallery/lib/demo/grid_list_demo.dart
+++ b/examples/material_gallery/lib/demo/grid_list_demo.dart
@@ -221,9 +221,8 @@ class GridListDemoState extends State<GridListDemo> {
     ];
 
     final EdgeInsets padding = MediaQuery.of(context).padding;
-    final ModalPosition position = new ModalPosition(
-      right: padding.right + 16.0,
-      top: padding.top + 16.0
+    final RelativeRect position = new RelativeRect.fromLTRB(
+      0.0, padding.top + 16.0, padding.right + 16.0, 0.0
     );
 
     showMenu(context: context, position: position, items: items).then((GridDemoTileStyle value) {

--- a/packages/flutter/lib/src/material/popup_menu.dart
+++ b/packages/flutter/lib/src/material/popup_menu.dart
@@ -328,17 +328,12 @@ class _PopupMenu<T> extends StatelessWidget {
 class _PopupMenuRouteLayout extends SingleChildLayoutDelegate {
   _PopupMenuRouteLayout(this.position, this.selectedItemOffset);
 
-  final ModalPosition position;
+  final RelativeRect position;
   final double selectedItemOffset;
 
   @override
   BoxConstraints getConstraintsForChild(BoxConstraints constraints) {
-    return new BoxConstraints(
-      minWidth: 0.0,
-      maxWidth: constraints.maxWidth,
-      minHeight: 0.0,
-      maxHeight: constraints.maxHeight
-    );
+    return constraints.loosen();
   }
 
   // Put the child wherever position specifies, so long as it will fit within the
@@ -380,13 +375,10 @@ class _PopupMenuRoute<T> extends PopupRoute<T> {
     this.elevation
   }) : super(completer: completer);
 
-  final ModalPosition position;
+  final RelativeRect position;
   final List<PopupMenuEntry<T>> items;
   final dynamic initialValue;
   final int elevation;
-
-  @override
-  ModalPosition getPosition(BuildContext context) => null;
 
   @override
   Animation<double> createAnimation() {
@@ -416,13 +408,9 @@ class _PopupMenuRoute<T> extends PopupRoute<T> {
         selectedItemOffset += items[i].height;
       }
     }
-    final Size screenSize = MediaQuery.of(context).size;
-    return new ConstrainedBox(
-      constraints: new BoxConstraints(maxWidth: screenSize.width, maxHeight: screenSize.height),
-      child: new CustomSingleChildLayout(
-        delegate: new _PopupMenuRouteLayout(position, selectedItemOffset),
-        child: new _PopupMenu<T>(route: this)
-      )
+    return new CustomSingleChildLayout(
+      delegate: new _PopupMenuRouteLayout(position, selectedItemOffset),
+      child: new _PopupMenu<T>(route: this)
     );
   }
 }
@@ -434,7 +422,7 @@ class _PopupMenuRoute<T> extends PopupRoute<T> {
 /// implies the menu's origin.
 Future<dynamic/*=T*/> showMenu/*<T>*/({
   BuildContext context,
-  ModalPosition position,
+  RelativeRect position,
   List<PopupMenuEntry<dynamic/*=T*/>> items,
   dynamic/*=T*/ initialValue,
   int elevation: 8
@@ -518,9 +506,9 @@ class _PopupMenuButtonState<T> extends State<PopupMenuButton<T>> {
       elevation: config.elevation,
       items: config.itemBuilder(context),
       initialValue: config.initialValue,
-      position: new ModalPosition(
-        left: topLeft.x,
-        top: topLeft.y + (config.initialValue != null ? renderBox.size.height / 2.0 : 0.0)
+      position: new RelativeRect.fromLTRB(
+        topLeft.x, topLeft.y + (config.initialValue != null ? renderBox.size.height / 2.0 : 0.0),
+        0.0, 0.0
       )
     )
     .then((T value) {


### PR DESCRIPTION
Clients of getPosition should just use a one-child custom layout delegate
instead.

Fixes #2484
