### PR TITLE
Prefer implict `equals` matcher in test expectations.

### DIFF
--- a/packages/flutter_tools/test/analytics_test.dart
+++ b/packages/flutter_tools/test/analytics_test.dart
@@ -41,12 +41,12 @@ void main() {
       CreateCommand command = new CreateCommand();
       CommandRunner runner = createTestCommandRunner(command);
       int code = await runner.run(<String>['create', '--no-pub', temp.path]);
-      expect(code, equals(0));
+      expect(code, 0);
       expect(count, 0);
 
       flutterUsage.enabled = true;
       code = await runner.run(<String>['create', '--no-pub', temp.path]);
-      expect(code, equals(0));
+      expect(code, 0);
       expect(count, flutterUsage.isFirstRun ? 0 : 2);
 
       count = 0;
@@ -54,7 +54,7 @@ void main() {
       DoctorCommand doctorCommand = new DoctorCommand();
       runner = createTestCommandRunner(doctorCommand);
       code = await runner.run(<String>['doctor']);
-      expect(code, equals(0));
+      expect(code, 0);
       expect(count, 0);
     }, overrides: <Type, dynamic>{
       Usage: new Usage()

--- a/packages/flutter_tools/test/analyze_duplicate_names_test.dart
+++ b/packages/flutter_tools/test/analyze_duplicate_names_test.dart
@@ -38,7 +38,7 @@ void main() {
       return createTestCommandRunner(command).run(
         <String>['analyze', '--no-current-package', '--no-current-directory', dartFileA.path, dartFileB.path]
       ).then((int code) {
-        expect(code, equals(1));
+        expect(code, 1);
         expect(testLogger.errorText, '[warning] The imported libraries \'a.dart\' and \'b.dart\' cannot have the same name \'test\' (${dartFileB.path})\n');
         expect(testLogger.statusText, 'Analyzing 2 entry points...\n');
       });

--- a/packages/flutter_tools/test/android_device_test.dart
+++ b/packages/flutter_tools/test/android_device_test.dart
@@ -12,7 +12,7 @@ void main() {
     testUsingContext('stores the requested id', () {
       String deviceId = '1234';
       AndroidDevice device = new AndroidDevice(deviceId);
-      expect(device.id, equals(deviceId));
+      expect(device.id, deviceId);
     });
   });
 

--- a/packages/flutter_tools/test/create_test.dart
+++ b/packages/flutter_tools/test/create_test.dart
@@ -43,10 +43,10 @@ void main() {
       CommandRunner runner = createTestCommandRunner(command);
 
       int code = await runner.run(<String>['create', '--no-pub', temp.path]);
-      expect(code, equals(0));
+      expect(code, 0);
 
       code = await runner.run(<String>['create', '--no-pub', temp.path]);
-      expect(code, equals(0));
+      expect(code, 0);
     });
 
     // Verify that we fail with an error code when the file exists.
@@ -57,7 +57,7 @@ void main() {
       File existingFile = new File("${temp.path.toString()}/bad");
       if (!existingFile.existsSync()) existingFile.createSync();
       int code = await runner.run(<String>['create', existingFile.path]);
-      expect(code, equals(1));
+      expect(code, 1);
     });
   });
 }
@@ -70,7 +70,7 @@ Future<Null> _createAndAnalyzeProject(Directory dir, List<String> createArgs) as
   args.addAll(createArgs);
   args.add(dir.path);
   int code = await runner.run(args);
-  expect(code, equals(0));
+  expect(code, 0);
 
   String mainPath = path.join(dir.path, 'lib', 'main.dart');
   expect(new File(mainPath).existsSync(), true);

--- a/packages/flutter_tools/test/devices.test.dart
+++ b/packages/flutter_tools/test/devices.test.dart
@@ -15,14 +15,14 @@ void main() {
     testUsingContext('returns 0 when called', () {
       DevicesCommand command = new DevicesCommand();
       return createTestCommandRunner(command).run(<String>['list']).then((int code) {
-        expect(code, equals(0));
+        expect(code, 0);
       });
     });
 
     testUsingContext('no error when no connected devices', () {
       DevicesCommand command = new DevicesCommand();
       return createTestCommandRunner(command).run(<String>['list']).then((int code) {
-        expect(code, equals(0));
+        expect(code, 0);
         expect(testLogger.statusText, contains('No connected devices'));
       });
     }, overrides: <Type, dynamic>{

--- a/packages/flutter_tools/test/drive_test.dart
+++ b/packages/flutter_tools/test/drive_test.dart
@@ -65,7 +65,7 @@ void main() {
         '--target=/some/app/test/e2e.dart',
       ];
       return createTestCommandRunner(command).run(args).then((int code) {
-        expect(code, equals(1));
+        expect(code, 1);
         BufferLogger buffer = logger;
         expect(buffer.errorText, contains(
           'Test file not found: /some/app/test_driver/e2e_test.dart'
@@ -89,7 +89,7 @@ void main() {
         '--target=$testApp',
       ];
       return createTestCommandRunner(command).run(args).then((int code) {
-        expect(code, equals(1));
+        expect(code, 1);
         BufferLogger buffer = logger;
         expect(buffer.errorText, contains(
           'Application failed to start. Will not run test. Quitting.'
@@ -107,7 +107,7 @@ void main() {
         '--target=$appFile',
       ];
       return createTestCommandRunner(command).run(args).then((int code) {
-        expect(code, equals(1));
+        expect(code, 1);
         BufferLogger buffer = logger;
         expect(buffer.errorText, contains(
           'Application file $appFile is outside the package directory $packageDir'
@@ -125,7 +125,7 @@ void main() {
         '--target=$appFile',
       ];
       return createTestCommandRunner(command).run(args).then((int code) {
-        expect(code, equals(1));
+        expect(code, 1);
         BufferLogger buffer = logger;
         expect(buffer.errorText, contains(
           'Application file main.dart must reside in one of the '
@@ -160,7 +160,7 @@ void main() {
         '--target=$testApp',
       ];
       return createTestCommandRunner(command).run(args).then((int code) {
-        expect(code, equals(0));
+        expect(code, 0);
         BufferLogger buffer = logger;
         expect(buffer.errorText, isEmpty);
       });
@@ -191,7 +191,7 @@ void main() {
         '--target=$testApp',
       ];
       return createTestCommandRunner(command).run(args).then((int code) {
-        expect(code, equals(123));
+        expect(code, 123);
         BufferLogger buffer = logger;
         expect(buffer.errorText, isEmpty);
       });

--- a/packages/flutter_tools/test/install_test.dart
+++ b/packages/flutter_tools/test/install_test.dart
@@ -22,7 +22,7 @@ void main() {
       testDeviceManager.addDevice(device);
 
       return createTestCommandRunner(command).run(<String>['install']).then((int code) {
-        expect(code, equals(0));
+        expect(code, 0);
       });
     });
 
@@ -36,7 +36,7 @@ void main() {
       testDeviceManager.addDevice(device);
 
       return createTestCommandRunner(command).run(<String>['install']).then((int code) {
-        expect(code, equals(0));
+        expect(code, 0);
       });
     });
   });

--- a/packages/flutter_tools/test/listen_test.dart
+++ b/packages/flutter_tools/test/listen_test.dart
@@ -15,7 +15,7 @@ void main() {
       ListenCommand command = new ListenCommand(singleRun: true);
       applyMocksToCommand(command);
       return createTestCommandRunner(command).run(<String>['listen']).then((int code) {
-        expect(code, equals(1));
+        expect(code, 1);
       });
     });
   });

--- a/packages/flutter_tools/test/logs_test.dart
+++ b/packages/flutter_tools/test/logs_test.dart
@@ -15,7 +15,7 @@ void main() {
       LogsCommand command = new LogsCommand();
       applyMocksToCommand(command);
       return createTestCommandRunner(command).run(<String>['-d', 'abc123', 'logs']).then((int code) {
-        expect(code, equals(1));
+        expect(code, 1);
       });
     });
   });

--- a/packages/flutter_tools/test/run_test.dart
+++ b/packages/flutter_tools/test/run_test.dart
@@ -15,7 +15,7 @@ void main() {
       RunCommand command = new RunCommand();
       applyMocksToCommand(command);
       return createTestCommandRunner(command).run(<String>['run', '-t', 'abc123']).then((int code) {
-        expect(code, equals(1));
+        expect(code, 1);
       });
     });
   });

--- a/packages/flutter_tools/test/stop_test.dart
+++ b/packages/flutter_tools/test/stop_test.dart
@@ -21,7 +21,7 @@ void main() {
       when(device.stopApp(any)).thenReturn(new Future<bool>.value(true));
       testDeviceManager.addDevice(device);
       return createTestCommandRunner(command).run(<String>['stop']).then((int code) {
-        expect(code, equals(0));
+        expect(code, 0);
       });
     });
 
@@ -33,7 +33,7 @@ void main() {
       testDeviceManager.addDevice(device);
 
       return createTestCommandRunner(command).run(<String>['stop']).then((int code) {
-        expect(code, equals(0));
+        expect(code, 0);
       });
     });
   });

--- a/packages/flutter_tools/test/trace_test.dart
+++ b/packages/flutter_tools/test/trace_test.dart
@@ -15,7 +15,7 @@ void main() {
       TraceCommand command = new TraceCommand();
       applyMocksToCommand(command);
       return createTestCommandRunner(command).run(<String>['trace']).then((int code) {
-        expect(code, equals(1));
+        expect(code, 1);
       });
     });
   });


### PR DESCRIPTION
@Hixie: as per our conversation, using the implicit `equals` matcher (see test docs [here](https://www.dartdocs.org/documentation/test/0.12.13%2B1/test/expect.html)) can make expectations a wee bit more concise.
