### PR TITLE
Ensure that DropDownMenus are always onscreen

### DIFF
--- a/packages/flutter/test/material/drop_down_test.dart
+++ b/packages/flutter/test/material/drop_down_test.dart
@@ -1,0 +1,54 @@
+// Copyright 2015 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter/material.dart';
+import 'package:test/test.dart';
+
+void main() {
+  testWidgets('Drop down screen edges', (WidgetTester tester) {
+    int value = 4;
+    List<DropDownMenuItem<int>> items = <DropDownMenuItem<int>>[];
+    for (int i = 0; i < 20; ++i)
+      items.add(new DropDownMenuItem<int>(value: i, child: new Text('$i')));
+
+    void handleChanged(int newValue) {
+      value = newValue;
+    }
+
+    DropDownButton<int> button = new DropDownButton<int>(
+      value: value,
+      onChanged: handleChanged,
+      items: items
+    );
+
+    tester.pumpWidget(
+      new MaterialApp(
+        home: new Material(
+          child: new Align(
+            alignment: FractionalOffset.topCenter,
+            child:button
+          )
+        )
+      )
+    );
+
+    tester.tap(find.text('4'));
+    tester.pump();
+    tester.pump(const Duration(seconds: 1)); // finish the menu animation
+
+    tester.tap(find.byConfig(button));
+
+    // Ideally this would be 4 because the menu would be overscrolled to the
+    // correct position, but currently we just reposition the menu so that it
+    // is visible on screen.
+    expect(value, 0);
+
+    // TODO(abarth): Remove these calls to pump once navigator cleans up its
+    // pop transitions.
+    tester.pump();
+    tester.pump(const Duration(seconds: 1)); // finish the menu animation
+
+  });
+}


### PR DESCRIPTION
This patch sizes the menu such that it is always on screen, but doesn't scroll
the menu to ensure that the currently selected item is always visible and on
top of the button. That will need to wait for a later patch.

Also, teach CustomPaint how to repaint animations more efficiently.

Fixes #3720
