### PR TITLE
avoid sending analytics on ci systems

### DIFF
--- a/packages/flutter_tools/lib/executable.dart
+++ b/packages/flutter_tools/lib/executable.dart
@@ -102,7 +102,7 @@ Future<Null> main(List<String> args) async {
 
       flutterUsage.sendException(error, chain);
 
-      if (Platform.environment.containsKey('FLUTTER_DEV') || isRunningOnTravis()) {
+      if (Platform.environment.containsKey('FLUTTER_DEV') || isRunningOnBot) {
         // If we're working on the tools themselves, just print the stack trace.
         stderr.writeln('$error');
         stderr.writeln(chain.terse.toString());

--- a/packages/flutter_tools/lib/executable.dart
+++ b/packages/flutter_tools/lib/executable.dart
@@ -102,7 +102,7 @@ Future<Null> main(List<String> args) async {
 
       flutterUsage.sendException(error, chain);
 
-      if (Platform.environment.containsKey('FLUTTER_DEV')) {
+      if (Platform.environment.containsKey('FLUTTER_DEV') || isRunningOnTravis()) {
         // If we're working on the tools themselves, just print the stack trace.
         stderr.writeln('$error');
         stderr.writeln(chain.terse.toString());

--- a/packages/flutter_tools/lib/src/base/utils.dart
+++ b/packages/flutter_tools/lib/src/base/utils.dart
@@ -8,6 +8,12 @@ import 'dart:io';
 import 'package:crypto/crypto.dart';
 import 'package:path/path.dart' as path;
 
+bool isRunningOnTravis() {
+  // https://docs.travis-ci.com/user/environment-variables/#Default-Environment-Variables
+  return Platform.environment['TRAVIS'] == 'true' ||
+    Platform.environment['CONTINUOUS_INTEGRATION'] == 'true';
+}
+
 String hex(List<int> bytes) {
   StringBuffer result = new StringBuffer();
   for (int part in bytes)

--- a/packages/flutter_tools/lib/src/base/utils.dart
+++ b/packages/flutter_tools/lib/src/base/utils.dart
@@ -8,9 +8,10 @@ import 'dart:io';
 import 'package:crypto/crypto.dart';
 import 'package:path/path.dart' as path;
 
-bool isRunningOnTravis() {
+bool get isRunningOnBot {
   // https://docs.travis-ci.com/user/environment-variables/#Default-Environment-Variables
-  return Platform.environment['TRAVIS'] == 'true' ||
+  return
+    Platform.environment['TRAVIS'] == 'true' ||
     Platform.environment['CONTINUOUS_INTEGRATION'] == 'true';
 }
 

--- a/packages/flutter_tools/lib/src/commands/upgrade.dart
+++ b/packages/flutter_tools/lib/src/commands/upgrade.dart
@@ -10,7 +10,7 @@ import '../base/process.dart';
 import '../dart/pub.dart';
 import '../globals.dart';
 import '../runner/flutter_command.dart';
-import '../runner/version.dart';
+import '../version.dart';
 
 class UpgradeCommand extends FlutterCommand {
   @override

--- a/packages/flutter_tools/lib/src/doctor.dart
+++ b/packages/flutter_tools/lib/src/doctor.dart
@@ -12,7 +12,7 @@ import 'base/context.dart';
 import 'base/os.dart';
 import 'globals.dart';
 import 'ios/ios_workflow.dart';
-import 'runner/version.dart';
+import 'version.dart';
 
 const Map<String, String> _osNames = const <String, String>{
   'macos': 'Mac OS',

--- a/packages/flutter_tools/lib/src/runner/flutter_command_runner.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command_runner.dart
@@ -18,7 +18,7 @@ import '../build_configuration.dart';
 import '../globals.dart';
 import '../package_map.dart';
 import '../toolchain.dart';
-import 'version.dart';
+import '../version.dart';
 
 const String kFlutterRootEnvironmentVariableName = 'FLUTTER_ROOT'; // should point to //flutter/ (root of flutter/flutter repo)
 const String kFlutterEngineEnvironmentVariableName = 'FLUTTER_ENGINE'; // should point to //engine/src/ (root of flutter/engine repo)

--- a/packages/flutter_tools/lib/src/usage.dart
+++ b/packages/flutter_tools/lib/src/usage.dart
@@ -31,7 +31,7 @@ class Usage {
       runningOnCI = true;
 
     // Check for common CI systems.
-    if (isRunningOnTravis())
+    if (isRunningOnBot)
       runningOnCI = true;
 
     // If we think we're running on a CI system, default to not sending analytics.

--- a/packages/flutter_tools/lib/src/version.dart
+++ b/packages/flutter_tools/lib/src/version.dart
@@ -4,8 +4,8 @@
 
 import 'dart:io';
 
-import '../artifacts.dart';
-import '../base/process.dart';
+import 'artifacts.dart';
+import 'base/process.dart';
 
 final Set<String> kKnownBranchNames = new Set<String>.from(<String>[
   'master',
@@ -64,7 +64,7 @@ class FlutterVersion {
     return new FlutterVersion(flutterRoot != null ? flutterRoot : ArtifactStore.flutterRoot);
   }
 
-  /// Return a short string for the version (`a76bc8e22b/alpha`).
+  /// Return a short string for the version (`alpha/a76bc8e22b`).
   static String getVersionString({ bool whitelistBranchName: false }) {
     final String cwd = ArtifactStore.flutterRoot;
 
@@ -80,7 +80,7 @@ class FlutterVersion {
         branch = 'dev';
     }
 
-    return '$commit/$branch';
+    return '$branch/$commit';
   }
 }
 

--- a/travis/setup.sh
+++ b/travis/setup.sh
@@ -1,10 +1,8 @@
 #!/bin/bash
 set -ex
 
-# Download dependencies flutter
-./bin/flutter --version
-
-# Disable analytics on the bots (to avoid skewing analytics data).
+# disable analytics on the bots and download Flutter dependencies
 ./bin/flutter config --no-analytics
 
+# run pub get in all the repo packages
 ./bin/flutter update-packages


### PR DESCRIPTION
- avoid sending analytics on ci systems (travis, and systems that don't do a full git checkout). before, we were turning analytics off for specific bots
- some work to pretty print the usage disclaimer text (fix https://github.com/flutter/flutter/issues/3710)
- on travis, don't write a crash report on a failure - print the stack trace to stdout
