### PR TITLE
Fix analyzer error messages.

### DIFF
--- a/packages/flutter_tools/lib/src/dart/analysis.dart
+++ b/packages/flutter_tools/lib/src/dart/analysis.dart
@@ -217,10 +217,8 @@ class AnalysisErrorDescription {
   String get errorType {
     ErrorSeverity severity = errorCode.errorSeverity;
     if (severity == ErrorSeverity.INFO) {
-      if (errorCode.type == ErrorType.HINT ||
-          errorCode.type == ErrorType.LINT) {
+      if (errorCode.type == ErrorType.HINT || errorCode.type == ErrorType.LINT)
         return errorCode.type.displayName;
-      }
     }
     return severity.displayName;
   }

--- a/packages/flutter_tools/lib/src/dart/analysis.dart
+++ b/packages/flutter_tools/lib/src/dart/analysis.dart
@@ -214,7 +214,16 @@ class AnalysisErrorDescription {
 
   ErrorCode get errorCode => error.errorCode;
 
-  String get errorType => error.errorCode.type.displayName;
+  String get errorType {
+    ErrorSeverity severity = errorCode.errorSeverity;
+    if (severity == ErrorSeverity.INFO) {
+      if (errorCode.type == ErrorType.HINT ||
+          errorCode.type == ErrorType.LINT) {
+        return errorCode.type.displayName;
+      }
+    }
+    return severity.displayName;
+  }
 
   LineInfo_Location get location => line.getLocation(error.offset);
 


### PR DESCRIPTION
Will have the result of restoring `[static warning]` to `[warning]`, etc.

(This is essentially how we handle it in the analyzer CLI.)

cc @Hixie 
