### PR TITLE
remove the --checked option

### DIFF
--- a/packages/flutter_tools/lib/src/commands/listen.dart
+++ b/packages/flutter_tools/lib/src/commands/listen.dart
@@ -8,6 +8,7 @@ import 'dart:io';
 import '../base/os.dart';
 import '../base/process.dart';
 import '../device.dart';
+import '../build_configuration.dart';
 import '../globals.dart';
 import 'run.dart';
 
@@ -63,7 +64,7 @@ class ListenCommand extends RunCommandBase {
         target: target,
         install: firstTime,
         stop: true,
-        debuggingOptions: new DebuggingOptions.enabled(checked: checked),
+        debuggingOptions: new DebuggingOptions.enabled(checked: getBuildMode() == BuildMode.debug),
         traceStartup: traceStartup,
         route: route
       );

--- a/packages/flutter_tools/lib/src/commands/run.dart
+++ b/packages/flutter_tools/lib/src/commands/run.dart
@@ -20,10 +20,12 @@ import 'install.dart';
 
 abstract class RunCommandBase extends FlutterCommand {
   RunCommandBase() {
-    argParser.addFlag('checked',
-        negatable: true,
-        defaultsTo: true,
-        help: 'Toggle Dart\'s checked mode.');
+    addBuildModeFlags();
+
+    // TODO(devoncarew): This flag is ignored, and should be removed once tools
+    // no longer pass in `--checked`.
+    argParser.addFlag('checked', negatable: true, hide: true);
+
     argParser.addFlag('trace-startup',
         negatable: true,
         defaultsTo: false,
@@ -33,7 +35,6 @@ abstract class RunCommandBase extends FlutterCommand {
     usesTargetOption();
   }
 
-  bool get checked => argResults['checked'];
   bool get traceStartup => argResults['trace-startup'];
   String get target => argResults['target'];
   String get route => argResults['route'];
@@ -50,7 +51,6 @@ class RunCommand extends RunCommandBase {
   final List<String> aliases = <String>['start'];
 
   RunCommand() {
-    addBuildModeFlags();
     argParser.addFlag('full-restart',
         defaultsTo: true,
         help: 'Stop any currently running application process before running the app.');
@@ -105,7 +105,7 @@ class RunCommand extends RunCommandBase {
       options = new DebuggingOptions.disabled();
     } else {
       options = new DebuggingOptions.enabled(
-        checked: checked,
+        checked: getBuildMode() == BuildMode.debug,
         startPaused: argResults['start-paused'],
         observatoryPort: debugPort
       );

--- a/packages/flutter_tools/test/drive_test.dart
+++ b/packages/flutter_tools/test/drive_test.dart
@@ -38,7 +38,7 @@ void main() {
       targetDeviceFinder = () {
         throw 'Unexpected call to targetDeviceFinder';
       };
-      appStarter = (_) {
+      appStarter = (_, __) {
         throw 'Unexpected call to appStarter';
       };
       testRunner = (_) {
@@ -75,7 +75,7 @@ void main() {
 
     testUsingContext('returns 1 when app fails to run', () async {
       withMockDevice();
-      appStarter = expectAsync((_) async => 1);
+      appStarter = expectAsync((_, __) async => 1);
 
       String testApp = '/some/app/test_driver/e2e.dart';
       String testFile = '/some/app/test_driver/e2e_test.dart';
@@ -140,7 +140,7 @@ void main() {
       String testApp = '/some/app/test/e2e.dart';
       String testFile = '/some/app/test_driver/e2e_test.dart';
 
-      appStarter = expectAsync((_) {
+      appStarter = expectAsync((_, __) {
         return new Future<int>.value(0);
       });
       testRunner = expectAsync((List<String> testArgs) {
@@ -172,7 +172,7 @@ void main() {
       String testApp = '/some/app/test/e2e.dart';
       String testFile = '/some/app/test_driver/e2e_test.dart';
 
-      appStarter = expectAsync((_) {
+      appStarter = expectAsync((_, __) {
         return new Future<int>.value(0);
       });
       testRunner = expectAsync((_) {


### PR DESCRIPTION
Remove the `--checked` (and `--no-checked`) option from run, drive, and listen. Use `--debug` to imply checked mode, and the other two run options (profile, release) don't use checked mode.
