### PR TITLE
be more lenient when looking for matching android sdk components

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_sdk.dart
+++ b/packages/flutter_tools/lib/src/android/android_sdk.dart
@@ -147,10 +147,7 @@ class AndroidSdk {
         .toList();
     }
 
-    // Here we match up platforms with cooresponding build-tools. If we don't
-    // have a match, we don't return anything for that platform version. So if
-    // the user only has 'android-22' and 'build-tools/19.0.0', we don't find
-    // an Android sdk.
+    // Match up platforms with the best cooresponding build-tools.
     _sdkVersions = platforms.map((String platformName) {
       int platformVersion;
 
@@ -166,6 +163,9 @@ class AndroidSdk {
       Version buildToolsVersion = Version.primary(buildTools.where((Version version) {
         return version.major == platformVersion;
       }).toList());
+
+      if (buildToolsVersion == null)
+        buildToolsVersion = Version.primary(buildTools);
 
       if (buildToolsVersion == null)
         return null;

--- a/packages/flutter_tools/lib/src/android/android_sdk.dart
+++ b/packages/flutter_tools/lib/src/android/android_sdk.dart
@@ -164,8 +164,7 @@ class AndroidSdk {
         return version.major == platformVersion;
       }).toList());
 
-      if (buildToolsVersion == null)
-        buildToolsVersion = Version.primary(buildTools);
+      buildToolsVersion ??= Version.primary(buildTools);
 
       if (buildToolsVersion == null)
         return null;


### PR DESCRIPTION
Be more lenient when looking for matching android sdk components. If we can match a `platforms` version with a `build-tools` version - even if they're not identical - do that.
