### PR TITLE
use vendored dart sdk; check the expected version of flutter

### DIFF
--- a/bin/flutter
+++ b/bin/flutter
@@ -37,14 +37,6 @@ if [ ! -f "$SNAPSHOT_PATH" ] || [ ! -f "$STAMP_PATH" ] || [ `cat "$STAMP_PATH"` 
   echo $REVISION > "$STAMP_PATH"
 fi
 
-# Add our internalized version of the Dart SDK to the path ahead of any other
-# versions that might be installed on this machine.
-#
-# TODO(abarth): We should teach flutter_tools to our version of the Dart SDK
-#               explicitly instead of relying upon the PATH.
-#
-export PATH="$DART_SDK_PATH/bin:$PATH"
-
 set +e
 
 if [ $FLUTTER_DEV ]; then

--- a/packages/flutter_tools/lib/src/base/process.dart
+++ b/packages/flutter_tools/lib/src/base/process.dart
@@ -6,9 +6,6 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
-import 'package:path/path.dart' as path;
-
-import '../dart/sdk.dart';
 import '../globals.dart';
 
 typedef String StringConverter(String string);
@@ -89,13 +86,6 @@ String runCheckedSync(List<String> cmd, {
 /// Run cmd and return stdout.
 String runSync(List<String> cmd, { String workingDirectory }) {
   return _runWithLoggingSync(cmd, workingDirectory: workingDirectory);
-}
-
-/// Return the platform specific name for the given Dart SDK binary. So, `pub`
-/// ==> `pub.bat`.  The default SDK location can be overridden with a specified
-/// [sdkLocation].
-String sdkBinaryName(String name, { String sdkLocation }) {
-  return path.absolute(path.join(sdkLocation ?? dartSdkPath, 'bin', Platform.isWindows ? '$name.bat' : name));
 }
 
 bool exitsHappy(List<String> cli) {

--- a/packages/flutter_tools/lib/src/commands/upgrade.dart
+++ b/packages/flutter_tools/lib/src/commands/upgrade.dart
@@ -33,7 +33,7 @@ class UpgradeCommand extends FlutterCommand {
       return 1;
     }
 
-    printStatus('Upgrading Flutter...');
+    printStatus('Upgrading Flutter from ${ArtifactStore.flutterRoot}...');
 
     int code = await runCommandAndStreamOutput(
       <String>['git', 'pull', '--ff-only'],

--- a/packages/flutter_tools/lib/src/dart/pub.dart
+++ b/packages/flutter_tools/lib/src/dart/pub.dart
@@ -11,6 +11,7 @@ import '../base/logger.dart';
 import '../base/process.dart';
 import '../cache.dart';
 import '../globals.dart';
+import 'sdk.dart';
 
 bool _shouldRunPubGet({ File pubSpecYaml, File dotPackages }) {
   if (!dotPackages.existsSync())

--- a/packages/flutter_tools/lib/src/dart/sdk.dart
+++ b/packages/flutter_tools/lib/src/dart/sdk.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:io';
+
 import 'package:path/path.dart' as path;
 
 import '../artifacts.dart';
@@ -9,4 +11,11 @@ import '../artifacts.dart';
 /// Locate the Dart SDK.
 String get dartSdkPath {
   return path.join(ArtifactStore.flutterRoot, 'bin', 'cache', 'dart-sdk');
+}
+
+/// Return the platform specific name for the given Dart SDK binary. So, `pub`
+/// ==> `pub.bat`.  The default SDK location can be overridden with a specified
+/// [sdkLocation].
+String sdkBinaryName(String name, { String sdkLocation }) {
+  return path.absolute(path.join(sdkLocation ?? dartSdkPath, 'bin', Platform.isWindows ? '$name.bat' : name));
 }

--- a/packages/flutter_tools/lib/src/runner/flutter_command_runner.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command_runner.dart
@@ -434,19 +434,33 @@ class FlutterCommandRunner extends CommandRunner {
 
   /// Check that the Flutter being run is the one we're expecting.
   void _checkFlutterCopy() {
-    String cwd = path.normalize(path.absolute(Directory.current.path));
+    String directory = path.normalize(path.absolute(Directory.current.path));
 
-    // Check if the cwd is a flutter dir. `bin/flutter` and `bin/cache/engine.stamp`
-    // exist.
-    if (FileSystemEntity.isFileSync(path.join(cwd, 'bin/flutter')) &&
-        FileSystemEntity.isFileSync(path.join(cwd, 'bin/cache/engine.stamp'))) {
-      if (cwd != ArtifactStore.flutterRoot) {
-        printError(
-          'Warning: the active Flutter is not the one from the current directory.\n'
-          '  Active Flutter   : ${ArtifactStore.flutterRoot}\n'
-          '  Current directory: $cwd\n'
-        );
+    // Check if the cwd is a flutter dir.
+    while (directory.isNotEmpty) {
+      if (_isDirectoryFlutterRepo(directory)) {
+        if (directory != ArtifactStore.flutterRoot) {
+          printError(
+            'Warning: the active Flutter is not the one from the current directory.\n'
+            '  Active Flutter   : ${ArtifactStore.flutterRoot}\n'
+            '  Current directory: $directory\n'
+          );
+        }
+
+        break;
       }
+
+      String parent = path.dirname(directory);
+      if (parent == directory)
+        break;
+      directory = parent;
     }
+  }
+
+  // Check if `bin/flutter` and `bin/cache/engine.stamp` exist.
+  bool _isDirectoryFlutterRepo(String directory) {
+    return
+      FileSystemEntity.isFileSync(path.join(directory, 'bin/flutter')) &&
+      FileSystemEntity.isFileSync(path.join(directory, 'bin/cache/engine.stamp'));
   }
 }

--- a/packages/flutter_tools/lib/src/runner/flutter_command_runner.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command_runner.dart
@@ -207,6 +207,9 @@ class FlutterCommandRunner extends CommandRunner {
     // we must set ArtifactStore.flutterRoot early because other features use it
     // (e.g. enginePath's initialiser uses it)
     ArtifactStore.flutterRoot = path.normalize(path.absolute(globalResults['flutter-root']));
+
+    _checkFlutterCopy();
+
     PackageMap.instance = new PackageMap(path.normalize(path.absolute(
       globalResults.wasParsed('packages') ? globalResults['packages'] : '.packages'
     )));
@@ -427,5 +430,23 @@ class FlutterCommandRunner extends CommandRunner {
         return entity is Directory ? _gatherProjectPaths(entity.path) : <String>[];
       })
       .toList();
+  }
+
+  /// Check that the Flutter being run is the one we're expecting.
+  void _checkFlutterCopy() {
+    String cwd = path.normalize(path.absolute(Directory.current.path));
+
+    // Check if the cwd is a flutter dir. `bin/flutter` and `bin/cache/engine.stamp`
+    // exist.
+    if (FileSystemEntity.isFileSync(path.join(cwd, 'bin/flutter')) &&
+        FileSystemEntity.isFileSync(path.join(cwd, 'bin/cache/engine.stamp'))) {
+      if (cwd != ArtifactStore.flutterRoot) {
+        printError(
+          'Warning: the active Flutter is not the one from the current directory.\n'
+          '  Active Flutter   : ${ArtifactStore.flutterRoot}\n'
+          '  Current directory: $cwd\n'
+        );
+      }
+    }
   }
 }

--- a/packages/flutter_tools/test/create_test.dart
+++ b/packages/flutter_tools/test/create_test.dart
@@ -8,6 +8,7 @@ import 'dart:io';
 import 'package:args/command_runner.dart';
 import 'package:flutter_tools/src/artifacts.dart';
 import 'package:flutter_tools/src/commands/create.dart';
+import 'package:flutter_tools/src/dart/sdk.dart';
 import 'package:path/path.dart' as path;
 import 'package:test/test.dart';
 
@@ -76,7 +77,7 @@ Future<Null> _createAndAnalyzeProject(Directory dir, List<String> createArgs) as
   expect(new File(mainPath).existsSync(), true);
   String flutterToolsPath = path.absolute(path.join('bin', 'flutter_tools.dart'));
   ProcessResult exec = Process.runSync(
-    'dart', <String>[flutterToolsPath, 'analyze'],
+    '$dartSdkPath/bin/dart', <String>[flutterToolsPath, 'analyze'],
     workingDirectory: dir.path
   );
   if (exec.exitCode != 0) {


### PR DESCRIPTION
- don't add the vendored dart sdk to the path before starting flutter_tools
- within the tool, make sure that all the dart process calls go through the vendored dart sdk (fix @jason-simmons's issue from yesterday)

and
- when running `flutter upgrade`, show what flutter dir we're upgrading (in case the dir is surprising to the user)
- when running flutter, make sure that if the current dir is a flutter repo, it's the same one as running process (fix https://github.com/flutter/flutter/issues/3330)
