### PR TITLE
fix adb shell pm path

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_device.dart
+++ b/packages/flutter_tools/lib/src/android/android_device.dart
@@ -189,9 +189,14 @@ class AndroidDevice extends Device {
 
   @override
   bool isAppInstalled(ApplicationPackage app) {
-    // This call takes 400ms - 600ms.
-    if (runCheckedSync(adbCommandForDevice(<String>['shell', 'pm', 'path', app.id])).isEmpty)
+    try {
+      // This call takes 400ms - 600ms.
+      String result = runCheckedSync(adbCommandForDevice(<String>['shell', 'pm', 'path', app.id]));
+      if (result.isEmpty)
+        return false;
+    } catch (error) {
       return false;
+    }
 
     // Check the application SHA.
     return _getDeviceApkSha1(app) == _getSourceSha1(app);


### PR DESCRIPTION
- handle error exit codes from `adb shell pm path` when we're checking whether an app is already installed (fix https://github.com/flutter/flutter/issues/3825)
