### PR TITLE
Add asserts to DefaultTextStyle.inherit

### DIFF
--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -1994,6 +1994,8 @@ class DefaultTextStyle extends InheritedWidget {
     TextOverflow overflow,
     Widget child
   }) {
+    assert(context != null);
+    assert(child != null);
     DefaultTextStyle parent = DefaultTextStyle.of(context);
     return new DefaultTextStyle(
       key: key,


### PR DESCRIPTION
The context and child arguments are required.  We should assert that
they're non-null.

Fixes #3843
