### PR TITLE
Turn on `avoid_return_types_on_setters` and cleanup annotated setters.

### DIFF
--- a/dev/benchmarks/complex_layout/lib/main.dart
+++ b/dev/benchmarks/complex_layout/lib/main.dart
@@ -30,7 +30,7 @@ class ComplexLayoutAppState extends State<ComplexLayoutApp> {
 
   bool _lightTheme = true;
   bool get lightTheme => _lightTheme;
-  void set lightTheme(bool value) {
+  set lightTheme(bool value) {
     setState(() {
       _lightTheme = value;
     });

--- a/examples/flutter_gallery/lib/demo/weather_demo.dart
+++ b/examples/flutter_gallery/lib/demo/weather_demo.dart
@@ -239,7 +239,7 @@ class WeatherWorld extends NodeWithSize {
 
   WeatherType _weatherType = WeatherType.sun;
 
-  void set weatherType(WeatherType weatherType) {
+  set weatherType(WeatherType weatherType) {
     if (weatherType == _weatherType)
       return;
 
@@ -331,7 +331,7 @@ class CloudLayer extends Node {
     return sprite;
   }
 
-  void set active(bool active) {
+  set active(bool active) {
     double opacity;
     if (active) opacity = 1.0;
     else opacity = 0.0;
@@ -368,7 +368,7 @@ class Sun extends Node {
   Sprite _sun;
   List<Ray> _rays;
 
-  void set active(bool active) {
+  set active(bool active) {
     actions.stopAll();
 
     double targetOpacity;
@@ -473,7 +473,7 @@ class Rain extends Node {
     addChild(particles);
   }
 
-  void set active(bool active) {
+  set active(bool active) {
     actions.stopAll();
     for (ParticleSystem system in _particles) {
       if (active) {
@@ -542,7 +542,7 @@ class Snow extends Node {
     addChild(particles);
   }
 
-  void set active(bool active) {
+  set active(bool active) {
     actions.stopAll();
     for (ParticleSystem system in _particles) {
       if (active) {

--- a/examples/layers/rendering/src/sector_layout.dart
+++ b/examples/layers/rendering/src/sector_layout.dart
@@ -148,7 +148,7 @@ abstract class RenderDecoratedSector extends RenderSector {
 
   BoxDecoration _decoration;
   BoxDecoration get decoration => _decoration;
-  void set decoration (BoxDecoration value) {
+  set decoration (BoxDecoration value) {
     if (value == _decoration)
       return;
     _decoration = value;
@@ -220,7 +220,7 @@ class RenderSectorRing extends RenderSectorWithChildren {
 
   double _desiredDeltaRadius;
   double get desiredDeltaRadius => _desiredDeltaRadius;
-  void set desiredDeltaRadius(double value) {
+  set desiredDeltaRadius(double value) {
     assert(value != null);
     if (_desiredDeltaRadius != value) {
       _desiredDeltaRadius = value;
@@ -230,7 +230,7 @@ class RenderSectorRing extends RenderSectorWithChildren {
 
   double _padding;
   double get padding => _padding;
-  void set padding(double value) {
+  set padding(double value) {
     // TODO(ianh): avoid code duplication
     assert(value != null);
     if (_padding != value) {
@@ -334,7 +334,7 @@ class RenderSectorSlice extends RenderSectorWithChildren {
 
   double _desiredDeltaTheta;
   double get desiredDeltaTheta => _desiredDeltaTheta;
-  void set desiredDeltaTheta(double value) {
+  set desiredDeltaTheta(double value) {
     assert(value != null);
     if (_desiredDeltaTheta != value) {
       _desiredDeltaTheta = value;
@@ -344,7 +344,7 @@ class RenderSectorSlice extends RenderSectorWithChildren {
 
   double _padding;
   double get padding => _padding;
-  void set padding(double value) {
+  set padding(double value) {
     // TODO(ianh): avoid code duplication
     assert(value != null);
     if (_padding != value) {
@@ -442,7 +442,7 @@ class RenderBoxToRenderSectorAdapter extends RenderBox with RenderObjectWithChil
 
   double _innerRadius;
   double get innerRadius => _innerRadius;
-  void set innerRadius(double value) {
+  set innerRadius(double value) {
     _innerRadius = value;
     markNeedsLayout();
   }

--- a/packages/flutter/lib/src/animation/animation_controller.dart
+++ b/packages/flutter/lib/src/animation/animation_controller.dart
@@ -116,7 +116,7 @@ class AnimationController extends Animation<double>
   ///
   /// Value listeners are notified even if this does not change the value.
   /// Status listeners are notified if the animation was previously playing.
-  void set value(double newValue) {
+  set value(double newValue) {
     assert(newValue != null);
     stop();
     _value = newValue.clamp(lowerBound, upperBound);

--- a/packages/flutter/lib/src/animation/animations.dart
+++ b/packages/flutter/lib/src/animation/animations.dart
@@ -163,7 +163,7 @@ class ProxyAnimation extends Animation<double>
   /// will be transparently updated to be listening to the new parent animation.
   Animation<double> get parent => _parent;
   Animation<double> _parent;
-  void set parent(Animation<double> value) {
+  set parent(Animation<double> value) {
     if (value == _parent)
       return;
     if (_parent != null) {

--- a/packages/flutter/lib/src/cassowary/param.dart
+++ b/packages/flutter/lib/src/cassowary/param.dart
@@ -57,5 +57,5 @@ class Param extends EquationMember {
   double get value => variable.value;
 
   String get name => variable.name;
-  void set name(String name) { variable.name = name; }
+  set name(String name) { variable.name = name; }
 }

--- a/packages/flutter/lib/src/gestures/multidrag.dart
+++ b/packages/flutter/lib/src/gestures/multidrag.dart
@@ -357,7 +357,7 @@ class DelayedMultiDragGestureRecognizer extends MultiDragGestureRecognizer<_Dela
 
   Duration get delay => _delay;
   Duration _delay;
-  void set delay(Duration value) {
+  set delay(Duration value) {
     assert(value != null);
     _delay = value;
   }

--- a/packages/flutter/lib/src/material/material.dart
+++ b/packages/flutter/lib/src/material/material.dart
@@ -89,7 +89,7 @@ abstract class InkHighlight {
 
   /// The color of the ink used to emphasize part of the material.
   Color get color;
-  void set color(Color value);
+  set color(Color value);
 }
 
 /// An interface for creating [InkSplash]s and [InkHighlight]s on a material.
@@ -596,7 +596,7 @@ class _InkHighlight extends InkFeature implements InkHighlight {
   Color _color;
 
   @override
-  void set color(Color value) {
+  set color(Color value) {
     if (value == _color)
       return;
     _color = value;

--- a/packages/flutter/lib/src/material/slider.dart
+++ b/packages/flutter/lib/src/material/slider.dart
@@ -220,7 +220,7 @@ class _RenderSlider extends RenderConstrainedBox {
 
   double get value => _value;
   double _value;
-  void set value(double newValue) {
+  set value(double newValue) {
     assert(newValue != null && newValue >= 0.0 && newValue <= 1.0);
     if (newValue == _value)
       return;
@@ -233,7 +233,7 @@ class _RenderSlider extends RenderConstrainedBox {
 
   int get divisions => _divisions;
   int _divisions;
-  void set divisions(int newDivisions) {
+  set divisions(int newDivisions) {
     if (newDivisions == _divisions)
       return;
     _divisions = newDivisions;
@@ -242,7 +242,7 @@ class _RenderSlider extends RenderConstrainedBox {
 
   String get label => _label;
   String _label;
-  void set label(String newLabel) {
+  set label(String newLabel) {
     if (newLabel == _label)
       return;
     _label = newLabel;
@@ -262,7 +262,7 @@ class _RenderSlider extends RenderConstrainedBox {
 
   Color get activeColor => _activeColor;
   Color _activeColor;
-  void set activeColor(Color value) {
+  set activeColor(Color value) {
     if (value == _activeColor)
       return;
     _activeColor = value;

--- a/packages/flutter/lib/src/material/switch.dart
+++ b/packages/flutter/lib/src/material/switch.dart
@@ -192,7 +192,7 @@ class _RenderSwitch extends RenderToggleable {
 
   Decoration get activeThumbDecoration => _activeThumbDecoration;
   Decoration _activeThumbDecoration;
-  void set activeThumbDecoration(Decoration value) {
+  set activeThumbDecoration(Decoration value) {
     if (value == _activeThumbDecoration)
       return;
     _activeThumbDecoration = value;
@@ -201,7 +201,7 @@ class _RenderSwitch extends RenderToggleable {
 
   Decoration get inactiveThumbDecoration => _inactiveThumbDecoration;
   Decoration _inactiveThumbDecoration;
-  void set inactiveThumbDecoration(Decoration value) {
+  set inactiveThumbDecoration(Decoration value) {
     if (value == _inactiveThumbDecoration)
       return;
     _inactiveThumbDecoration = value;
@@ -210,7 +210,7 @@ class _RenderSwitch extends RenderToggleable {
 
   Color get activeTrackColor => _activeTrackColor;
   Color _activeTrackColor;
-  void set activeTrackColor(Color value) {
+  set activeTrackColor(Color value) {
     assert(value != null);
     if (value == _activeTrackColor)
       return;
@@ -220,7 +220,7 @@ class _RenderSwitch extends RenderToggleable {
 
   Color get inactiveTrackColor => _inactiveTrackColor;
   Color _inactiveTrackColor;
-  void set inactiveTrackColor(Color value) {
+  set inactiveTrackColor(Color value) {
     assert(value != null);
     if (value == _inactiveTrackColor)
       return;

--- a/packages/flutter/lib/src/material/tabs.dart
+++ b/packages/flutter/lib/src/material/tabs.dart
@@ -49,7 +49,7 @@ class _RenderTabBar extends RenderBox with
 
   int _selectedIndex;
   int get selectedIndex => _selectedIndex;
-  void set selectedIndex(int value) {
+  set selectedIndex(int value) {
     if (_selectedIndex != value) {
       _selectedIndex = value;
       markNeedsPaint();
@@ -58,7 +58,7 @@ class _RenderTabBar extends RenderBox with
 
   Color _indicatorColor;
   Color get indicatorColor => _indicatorColor;
-  void set indicatorColor(Color value) {
+  set indicatorColor(Color value) {
     if (_indicatorColor != value) {
       _indicatorColor = value;
       markNeedsPaint();
@@ -67,7 +67,7 @@ class _RenderTabBar extends RenderBox with
 
   Rect _indicatorRect;
   Rect get indicatorRect => _indicatorRect;
-  void set indicatorRect(Rect value) {
+  set indicatorRect(Rect value) {
     if (_indicatorRect != value) {
       _indicatorRect = value;
       markNeedsPaint();
@@ -76,7 +76,7 @@ class _RenderTabBar extends RenderBox with
 
   bool _textAndIcons;
   bool get textAndIcons => _textAndIcons;
-  void set textAndIcons(bool value) {
+  set textAndIcons(bool value) {
     if (_textAndIcons != value) {
       _textAndIcons = value;
       markNeedsLayout();
@@ -85,7 +85,7 @@ class _RenderTabBar extends RenderBox with
 
   bool _isScrollable;
   bool get isScrollable => _isScrollable;
-  void set isScrollable(bool value) {
+  set isScrollable(bool value) {
     if (_isScrollable != value) {
       _isScrollable = value;
       markNeedsLayout();
@@ -552,7 +552,7 @@ class TabBarSelectionState<T> extends State<TabBarSelection<T>> {
 
   T get value => _value;
   T _value;
-  void set value(T newValue) {
+  set value(T newValue) {
     if (newValue == _value)
       return;
     _previousValue = _value;

--- a/packages/flutter/lib/src/material/toggleable.dart
+++ b/packages/flutter/lib/src/material/toggleable.dart
@@ -64,7 +64,7 @@ abstract class RenderToggleable extends RenderConstrainedBox implements Semantic
   /// the new value.
   bool get value => _value;
   bool _value;
-  void set value(bool value) {
+  set value(bool value) {
     assert(value != null);
     if (value == _value)
       return;
@@ -84,7 +84,7 @@ abstract class RenderToggleable extends RenderConstrainedBox implements Semantic
   /// For example, a checkbox should use this color when checked.
   Color get activeColor => _activeColor;
   Color _activeColor;
-  void set activeColor(Color value) {
+  set activeColor(Color value) {
     assert(value != null);
     if (value == _activeColor)
       return;
@@ -97,7 +97,7 @@ abstract class RenderToggleable extends RenderConstrainedBox implements Semantic
   /// For example, a checkbox should use this color when unchecked.
   Color get inactiveColor => _inactiveColor;
   Color _inactiveColor;
-  void set inactiveColor(Color value) {
+  set inactiveColor(Color value) {
     assert(value != null);
     if (value == _inactiveColor)
       return;
@@ -118,7 +118,7 @@ abstract class RenderToggleable extends RenderConstrainedBox implements Semantic
   /// displayed using a grey color and its value cannot be changed.
   ValueChanged<bool> get onChanged => _onChanged;
   ValueChanged<bool> _onChanged;
-  void set onChanged(ValueChanged<bool> value) {
+  set onChanged(ValueChanged<bool> value) {
     if (value == _onChanged)
       return;
     final bool wasInteractive = isInteractive;

--- a/packages/flutter/lib/src/painting/text_painter.dart
+++ b/packages/flutter/lib/src/painting/text_painter.dart
@@ -43,7 +43,7 @@ class TextPainter {
   /// The (potentially styled) text to paint.
   TextSpan get text => _text;
   TextSpan _text;
-  void set text(TextSpan value) {
+  set text(TextSpan value) {
     assert(value == null || value.debugAssertValid());
     if (_text == value)
       return;
@@ -55,7 +55,7 @@ class TextPainter {
   /// How the text should be aligned horizontally.
   TextAlign get textAlign => _textAlign;
   TextAlign _textAlign;
-  void set textAlign(TextAlign value) {
+  set textAlign(TextAlign value) {
     if (_textAlign == value)
       return;
     _textAlign = value;

--- a/packages/flutter/lib/src/physics/simulation_group.dart
+++ b/packages/flutter/lib/src/physics/simulation_group.dart
@@ -69,7 +69,7 @@ abstract class SimulationGroup extends Simulation {
   }
 
   @override
-  void set tolerance(Tolerance t) {
+  set tolerance(Tolerance t) {
     currentSimulation.tolerance = t;
     super.tolerance = t;
   }

--- a/packages/flutter/lib/src/rendering/auto_layout.dart
+++ b/packages/flutter/lib/src/rendering/auto_layout.dart
@@ -51,7 +51,7 @@ class AutoLayoutParentData extends ContainerBoxParentDataMixin<RenderBox> {
 
   AutoLayoutRect get rect => _rect;
   AutoLayoutRect _rect;
-  void set rect(AutoLayoutRect value) {
+  set rect(AutoLayoutRect value) {
     if (_rect == value)
       return;
     if (_rect != null)
@@ -142,7 +142,7 @@ class RenderAutoLayout extends RenderBox
 
   AutoLayoutDelegate get delegate => _delegate;
   AutoLayoutDelegate _delegate;
-  void set delegate(AutoLayoutDelegate newDelegate) {
+  set delegate(AutoLayoutDelegate newDelegate) {
     if (_delegate == newDelegate)
       return;
     AutoLayoutDelegate oldDelegate = _delegate;

--- a/packages/flutter/lib/src/rendering/binding.dart
+++ b/packages/flutter/lib/src/rendering/binding.dart
@@ -94,7 +94,7 @@ abstract class RendererBinding extends BindingBase implements SchedulerBinding, 
   RenderView _renderView;
   /// Sets the given [RenderView] object (which must not be null), and its tree, to
   /// be the new render tree to display. The previous tree, if any, is detached.
-  void set renderView(RenderView value) {
+  set renderView(RenderView value) {
     assert(value != null);
     if (_renderView == value)
       return;

--- a/packages/flutter/lib/src/rendering/block.dart
+++ b/packages/flutter/lib/src/rendering/block.dart
@@ -42,7 +42,7 @@ class RenderBlock extends RenderBox
   /// The direction to use as the main axis.
   Axis get mainAxis => _mainAxis;
   Axis _mainAxis;
-  void set mainAxis (Axis value) {
+  set mainAxis (Axis value) {
     if (_mainAxis != value) {
       _mainAxis = value;
       markNeedsLayout();

--- a/packages/flutter/lib/src/rendering/box.dart
+++ b/packages/flutter/lib/src/rendering/box.dart
@@ -537,7 +537,7 @@ abstract class RenderBox extends RenderObject {
   }
   bool get hasSize => _size != null;
   Size _size;
-  void set size(Size value) {
+  set size(Size value) {
     assert(!(debugDoingThisResize && debugDoingThisLayout));
     assert(sizedByParent || !debugDoingThisResize);
     assert(() {

--- a/packages/flutter/lib/src/rendering/child_view.dart
+++ b/packages/flutter/lib/src/rendering/child_view.dart
@@ -218,7 +218,7 @@ class RenderChildView extends RenderBox {
   /// The child to display.
   ChildViewConnection get child => _child;
   ChildViewConnection _child;
-  void set child (ChildViewConnection value) {
+  set child (ChildViewConnection value) {
     if (value == _child)
       return;
     if (attached && _child != null) {
@@ -242,7 +242,7 @@ class RenderChildView extends RenderBox {
   /// The device pixel ratio to provide the child.
   double get scale => _scale;
   double _scale;
-  void set scale (double value) {
+  set scale (double value) {
     if (value == _scale)
       return;
     _scale = value;

--- a/packages/flutter/lib/src/rendering/custom_layout.dart
+++ b/packages/flutter/lib/src/rendering/custom_layout.dart
@@ -222,7 +222,7 @@ class RenderCustomMultiChildLayoutBox extends RenderBox
   /// The delegate that controls the layout of the children.
   MultiChildLayoutDelegate get delegate => _delegate;
   MultiChildLayoutDelegate _delegate;
-  void set delegate (MultiChildLayoutDelegate newDelegate) {
+  set delegate (MultiChildLayoutDelegate newDelegate) {
     assert(newDelegate != null);
     if (_delegate == newDelegate)
       return;

--- a/packages/flutter/lib/src/rendering/editable_line.dart
+++ b/packages/flutter/lib/src/rendering/editable_line.dart
@@ -62,7 +62,7 @@ class RenderEditableLine extends RenderBox {
   /// The text to display
   TextSpan get text => _textPainter.text;
   final TextPainter _textPainter;
-  void set text(TextSpan value) {
+  set text(TextSpan value) {
     if (_textPainter.text == value)
       return;
     TextSpan oldStyledText = _textPainter.text;
@@ -74,7 +74,7 @@ class RenderEditableLine extends RenderBox {
 
   Color get cursorColor => _cursorColor;
   Color _cursorColor;
-  void set cursorColor(Color value) {
+  set cursorColor(Color value) {
     if (_cursorColor == value)
       return;
     _cursorColor = value;
@@ -83,7 +83,7 @@ class RenderEditableLine extends RenderBox {
 
   bool get showCursor => _showCursor;
   bool _showCursor;
-  void set showCursor(bool value) {
+  set showCursor(bool value) {
     if (_showCursor == value)
       return;
     _showCursor = value;
@@ -92,7 +92,7 @@ class RenderEditableLine extends RenderBox {
 
   Color get selectionColor => _selectionColor;
   Color _selectionColor;
-  void set selectionColor(Color value) {
+  set selectionColor(Color value) {
     if (_selectionColor == value)
       return;
     _selectionColor = value;
@@ -103,7 +103,7 @@ class RenderEditableLine extends RenderBox {
 
   TextSelection get selection => _selection;
   TextSelection _selection;
-  void set selection(TextSelection value) {
+  set selection(TextSelection value) {
     if (_selection == value)
       return;
     _selection = value;
@@ -113,7 +113,7 @@ class RenderEditableLine extends RenderBox {
 
   Offset get paintOffset => _paintOffset;
   Offset _paintOffset;
-  void set paintOffset(Offset value) {
+  set paintOffset(Offset value) {
     if (_paintOffset == value)
       return;
     _paintOffset = value;

--- a/packages/flutter/lib/src/rendering/flex.dart
+++ b/packages/flutter/lib/src/rendering/flex.dart
@@ -107,7 +107,7 @@ class RenderFlex extends RenderBox with ContainerRenderObjectMixin<RenderBox, Fl
   /// The direction to use as the main axis.
   FlexDirection get direction => _direction;
   FlexDirection _direction;
-  void set direction (FlexDirection value) {
+  set direction (FlexDirection value) {
     if (_direction != value) {
       _direction = value;
       markNeedsLayout();
@@ -117,7 +117,7 @@ class RenderFlex extends RenderBox with ContainerRenderObjectMixin<RenderBox, Fl
   /// How the children should be placed along the main axis.
   MainAxisAlignment get mainAxisAlignment => _mainAxisAlignment;
   MainAxisAlignment _mainAxisAlignment;
-  void set mainAxisAlignment (MainAxisAlignment value) {
+  set mainAxisAlignment (MainAxisAlignment value) {
     if (_mainAxisAlignment != value) {
       _mainAxisAlignment = value;
       markNeedsLayout();
@@ -127,7 +127,7 @@ class RenderFlex extends RenderBox with ContainerRenderObjectMixin<RenderBox, Fl
   /// How the children should be placed along the cross axis.
   CrossAxisAlignment get crossAxisAlignment => _crossAxisAlignment;
   CrossAxisAlignment _crossAxisAlignment;
-  void set crossAxisAlignment (CrossAxisAlignment value) {
+  set crossAxisAlignment (CrossAxisAlignment value) {
     if (_crossAxisAlignment != value) {
       _crossAxisAlignment = value;
       markNeedsLayout();
@@ -137,7 +137,7 @@ class RenderFlex extends RenderBox with ContainerRenderObjectMixin<RenderBox, Fl
   /// If aligning items according to their baseline, which baseline to use.
   TextBaseline get textBaseline => _textBaseline;
   TextBaseline _textBaseline;
-  void set textBaseline (TextBaseline value) {
+  set textBaseline (TextBaseline value) {
     if (_textBaseline != value) {
       _textBaseline = value;
       markNeedsLayout();

--- a/packages/flutter/lib/src/rendering/flow.dart
+++ b/packages/flutter/lib/src/rendering/flow.dart
@@ -202,7 +202,7 @@ class RenderFlow extends RenderBox
   /// [FlowDelegate.shouldRelayout] and [FlowDelegate.shouldRepaint] functions
   /// to determine whether the new delegate requires this object to update its
   /// layout or painting.
-  void set delegate (FlowDelegate newDelegate) {
+  set delegate (FlowDelegate newDelegate) {
     assert(newDelegate != null);
     if (_delegate == newDelegate)
       return;

--- a/packages/flutter/lib/src/rendering/grid.dart
+++ b/packages/flutter/lib/src/rendering/grid.dart
@@ -384,7 +384,7 @@ class RenderGrid extends RenderVirtualViewport<GridParentData> {
   /// The delegate that controls the layout of the children.
   GridDelegate get delegate => _delegate;
   GridDelegate _delegate;
-  void set delegate (GridDelegate newDelegate) {
+  set delegate (GridDelegate newDelegate) {
     assert(newDelegate != null);
     if (_delegate == newDelegate)
       return;
@@ -396,7 +396,7 @@ class RenderGrid extends RenderVirtualViewport<GridParentData> {
   }
 
   @override
-  void set mainAxis(Axis value) {
+  set mainAxis(Axis value) {
     assert(() {
       if (value != Axis.vertical)
         throw new FlutterError('RenderGrid doesn\'t yet support horizontal scrolling.');
@@ -414,7 +414,7 @@ class RenderGrid extends RenderVirtualViewport<GridParentData> {
   /// the virtual child i to the indices of its children.
   int get virtualChildBase => _virtualChildBase;
   int _virtualChildBase;
-  void set virtualChildBase(int value) {
+  set virtualChildBase(int value) {
     assert(value != null);
     if (_virtualChildBase == value)
       return;

--- a/packages/flutter/lib/src/rendering/image.dart
+++ b/packages/flutter/lib/src/rendering/image.dart
@@ -41,7 +41,7 @@ class RenderImage extends RenderBox {
   /// The image to display.
   ui.Image get image => _image;
   ui.Image _image;
-  void set image (ui.Image value) {
+  set image (ui.Image value) {
     if (value == _image)
       return;
     _image = value;
@@ -56,7 +56,7 @@ class RenderImage extends RenderBox {
   /// aspect ratio.
   double get width => _width;
   double _width;
-  void set width (double value) {
+  set width (double value) {
     if (value == _width)
       return;
     _width = value;
@@ -69,7 +69,7 @@ class RenderImage extends RenderBox {
   /// aspect ratio.
   double get height => _height;
   double _height;
-  void set height (double value) {
+  set height (double value) {
     if (value == _height)
       return;
     _height = value;
@@ -81,7 +81,7 @@ class RenderImage extends RenderBox {
   /// Used when determining the best display size for the image.
   double get scale => _scale;
   double _scale;
-  void set scale (double value) {
+  set scale (double value) {
     assert(value != null);
     if (value == _scale)
       return;
@@ -102,7 +102,7 @@ class RenderImage extends RenderBox {
   /// If non-null, apply this color filter to the image before painting.
   Color get color => _color;
   Color _color;
-  void set color (Color value) {
+  set color (Color value) {
     if (value == _color)
       return;
     _color = value;
@@ -113,7 +113,7 @@ class RenderImage extends RenderBox {
   /// How to inscribe the image into the place allocated during layout.
   ImageFit get fit => _fit;
   ImageFit _fit;
-  void set fit (ImageFit value) {
+  set fit (ImageFit value) {
     if (value == _fit)
       return;
     _fit = value;
@@ -123,7 +123,7 @@ class RenderImage extends RenderBox {
   /// How to align the image within its bounds.
   FractionalOffset get alignment => _alignment;
   FractionalOffset _alignment;
-  void set alignment (FractionalOffset value) {
+  set alignment (FractionalOffset value) {
     if (value == _alignment)
       return;
     _alignment = value;
@@ -133,7 +133,7 @@ class RenderImage extends RenderBox {
   /// How to repeat this image if it doesn't fill its layout bounds.
   ImageRepeat get repeat => _repeat;
   ImageRepeat _repeat;
-  void set repeat (ImageRepeat value) {
+  set repeat (ImageRepeat value) {
     if (value == _repeat)
       return;
     _repeat = value;
@@ -149,7 +149,7 @@ class RenderImage extends RenderBox {
   /// the center slice will be stretched only vertically.
   Rect get centerSlice => _centerSlice;
   Rect _centerSlice;
-  void set centerSlice (Rect value) {
+  set centerSlice (Rect value) {
     if (value == _centerSlice)
       return;
     _centerSlice = value;

--- a/packages/flutter/lib/src/rendering/list.dart
+++ b/packages/flutter/lib/src/rendering/list.dart
@@ -37,7 +37,7 @@ class RenderList extends RenderVirtualViewport<ListParentData> {
 
   double get itemExtent => _itemExtent;
   double _itemExtent;
-  void set itemExtent (double newValue) {
+  set itemExtent (double newValue) {
     assert(newValue != null);
     if (_itemExtent == newValue)
       return;
@@ -47,7 +47,7 @@ class RenderList extends RenderVirtualViewport<ListParentData> {
 
   EdgeInsets get padding => _padding;
   EdgeInsets _padding;
-  void set padding (EdgeInsets newValue) {
+  set padding (EdgeInsets newValue) {
     if (_padding == newValue)
       return;
     _padding = newValue;

--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -1929,7 +1929,7 @@ abstract class RenderObjectWithChildMixin<ChildType extends RenderObject> implem
   ChildType _child;
   /// The render object's unique child
   ChildType get child => _child;
-  void set child (ChildType value) {
+  set child (ChildType value) {
     if (_child != null)
       dropChild(_child);
     _child = value;

--- a/packages/flutter/lib/src/rendering/paragraph.dart
+++ b/packages/flutter/lib/src/rendering/paragraph.dart
@@ -44,7 +44,7 @@ class RenderParagraph extends RenderBox {
 
   /// The text to display
   TextSpan get text => _textPainter.text;
-  void set text(TextSpan value) {
+  set text(TextSpan value) {
     assert(value != null);
     if (_textPainter.text == value)
       return;
@@ -56,7 +56,7 @@ class RenderParagraph extends RenderBox {
 
   /// How the text should be aligned horizontally.
   TextAlign get textAlign => _textPainter.textAlign;
-  void set textAlign(TextAlign value) {
+  set textAlign(TextAlign value) {
     if (_textPainter.textAlign == value)
       return;
     _textPainter.textAlign = value;
@@ -68,7 +68,7 @@ class RenderParagraph extends RenderBox {
   /// If false, the glyphs in the text will be positioned as if there was unlimited horizontal space.
   bool get softWrap => _softWrap;
   bool _softWrap;
-  void set softWrap(bool value) {
+  set softWrap(bool value) {
     assert(value != null);
     if (_softWrap == value)
       return;
@@ -79,7 +79,7 @@ class RenderParagraph extends RenderBox {
   /// How visual overflow should be handled.
   TextOverflow get overflow => _overflow;
   TextOverflow _overflow;
-  void set overflow(TextOverflow value) {
+  set overflow(TextOverflow value) {
     assert(value != null);
     if (_overflow == value)
       return;

--- a/packages/flutter/lib/src/rendering/performance_overlay.dart
+++ b/packages/flutter/lib/src/rendering/performance_overlay.dart
@@ -50,7 +50,7 @@ class RenderPerformanceOverlay extends RenderBox {
   /// PerformanceOverlayOption to enable.
   int get optionsMask => _optionsMask;
   int _optionsMask;
-  void set optionsMask(int mask) {
+  set optionsMask(int mask) {
     if (mask == _optionsMask)
       return;
     _optionsMask = mask;
@@ -59,7 +59,7 @@ class RenderPerformanceOverlay extends RenderBox {
 
   int get rasterizerThreshold => _rasterizerThreshold;
   int _rasterizerThreshold;
-  void set rasterizerThreshold (int threshold) {
+  set rasterizerThreshold (int threshold) {
     if (threshold == _rasterizerThreshold)
       return;
     _rasterizerThreshold = threshold;

--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -177,7 +177,7 @@ class RenderConstrainedBox extends RenderProxyBox {
   /// Additional constraints to apply to [child] during layout
   BoxConstraints get additionalConstraints => _additionalConstraints;
   BoxConstraints _additionalConstraints;
-  void set additionalConstraints (BoxConstraints newConstraints) {
+  set additionalConstraints (BoxConstraints newConstraints) {
     assert(newConstraints != null);
     assert(newConstraints.debugAssertIsValid());
     if (_additionalConstraints == newConstraints)
@@ -264,7 +264,7 @@ class RenderLimitedBox extends RenderProxyBox {
   /// The value to use for maxWidth if the incoming maxWidth constraint is infinite.
   double get maxWidth => _maxWidth;
   double _maxWidth;
-  void set maxWidth (double value) {
+  set maxWidth (double value) {
     assert(value != null && value >= 0.0);
     if (_maxWidth == value)
       return;
@@ -275,7 +275,7 @@ class RenderLimitedBox extends RenderProxyBox {
   /// The value to use for maxHeight if the incoming maxHeight constraint is infinite.
   double get maxHeight => _maxHeight;
   double _maxHeight;
-  void set maxHeight (double value) {
+  set maxHeight (double value) {
     assert(value != null && value >= 0.0);
     if (_maxHeight == value)
       return;
@@ -386,7 +386,7 @@ class RenderAspectRatio extends RenderProxyBox {
   /// a 16:9 width:height aspect ratio would have a value of 16.0/9.0.
   double get aspectRatio => _aspectRatio;
   double _aspectRatio;
-  void set aspectRatio (double newAspectRatio) {
+  set aspectRatio (double newAspectRatio) {
     assert(newAspectRatio != null);
     assert(newAspectRatio > 0.0);
     assert(newAspectRatio.isFinite);
@@ -516,7 +516,7 @@ class RenderIntrinsicWidth extends RenderProxyBox {
   /// If non-null, force the child's width to be a multiple of this value.
   double get stepWidth => _stepWidth;
   double _stepWidth;
-  void set stepWidth(double newStepWidth) {
+  set stepWidth(double newStepWidth) {
     if (newStepWidth == _stepWidth)
       return;
     _stepWidth = newStepWidth;
@@ -526,7 +526,7 @@ class RenderIntrinsicWidth extends RenderProxyBox {
   /// If non-null, force the child's height to be a multiple of this value.
   double get stepHeight => _stepHeight;
   double _stepHeight;
-  void set stepHeight(double newStepHeight) {
+  set stepHeight(double newStepHeight) {
     if (newStepHeight == _stepHeight)
       return;
     _stepHeight = newStepHeight;
@@ -702,7 +702,7 @@ class RenderOpacity extends RenderProxyBox {
   /// expensive.
   double get opacity => _opacity;
   double _opacity;
-  void set opacity (double newOpacity) {
+  set opacity (double newOpacity) {
     assert(newOpacity != null);
     assert(newOpacity >= 0.0 && newOpacity <= 1.0);
     if (_opacity == newOpacity)
@@ -751,7 +751,7 @@ class RenderShaderMask extends RenderProxyBox {
 
   ShaderCallback get shaderCallback => _shaderCallback;
   ShaderCallback _shaderCallback;
-  void set shaderCallback (ShaderCallback newShaderCallback) {
+  set shaderCallback (ShaderCallback newShaderCallback) {
     assert(newShaderCallback != null);
     if (_shaderCallback == newShaderCallback)
       return;
@@ -761,7 +761,7 @@ class RenderShaderMask extends RenderProxyBox {
 
   TransferMode get transferMode => _transferMode;
   TransferMode _transferMode;
-  void set transferMode (TransferMode newTransferMode) {
+  set transferMode (TransferMode newTransferMode) {
     assert(newTransferMode != null);
     if (_transferMode == newTransferMode)
       return;
@@ -790,7 +790,7 @@ class RenderBackdropFilter extends RenderProxyBox {
 
   ui.ImageFilter get filter => _filter;
   ui.ImageFilter _filter;
-  void set filter (ui.ImageFilter newFilter) {
+  set filter (ui.ImageFilter newFilter) {
     assert(newFilter != null);
     if (_filter == newFilter)
       return;
@@ -840,7 +840,7 @@ abstract class _RenderCustomClip<T> extends RenderProxyBox {
   /// If non-null, determines which clip to use on the child.
   CustomClipper<T> get clipper => _clipper;
   CustomClipper<T> _clipper;
-  void set clipper (CustomClipper<T> newClipper) {
+  set clipper (CustomClipper<T> newClipper) {
     if (_clipper == newClipper)
       return;
     CustomClipper<T> oldClipper = _clipper;
@@ -920,7 +920,7 @@ class RenderClipRRect extends RenderProxyBox {
   /// object.
   double get xRadius => _xRadius;
   double _xRadius;
-  void set xRadius (double newXRadius) {
+  set xRadius (double newXRadius) {
     assert(newXRadius != null);
     if (_xRadius == newXRadius)
       return;
@@ -934,7 +934,7 @@ class RenderClipRRect extends RenderProxyBox {
   /// object.
   double get yRadius => _yRadius;
   double _yRadius;
-  void set yRadius (double newYRadius) {
+  set yRadius (double newYRadius) {
     assert(newYRadius != null);
     if (_yRadius == newYRadius)
       return;
@@ -1068,7 +1068,7 @@ class RenderDecoratedBox extends RenderProxyBox {
   /// Commonly a [BoxDecoration].
   Decoration get decoration => _decoration;
   Decoration _decoration;
-  void set decoration (Decoration newDecoration) {
+  set decoration (Decoration newDecoration) {
     assert(newDecoration != null);
     if (newDecoration == _decoration)
       return;
@@ -1082,7 +1082,7 @@ class RenderDecoratedBox extends RenderProxyBox {
   /// Whether to paint the box decoration behind or in front of the child.
   DecorationPosition get position => _position;
   DecorationPosition _position;
-  void set position (DecorationPosition newPosition) {
+  set position (DecorationPosition newPosition) {
     assert(newPosition != null);
     if (newPosition == _position)
       return;
@@ -1164,7 +1164,7 @@ class RenderTransform extends RenderProxyBox {
   /// translation. This property is provided just for convenience.
   Offset get origin => _origin;
   Offset _origin;
-  void set origin (Offset newOrigin) {
+  set origin (Offset newOrigin) {
     if (_origin == newOrigin)
       return;
     _origin = newOrigin;
@@ -1177,7 +1177,7 @@ class RenderTransform extends RenderProxyBox {
   /// If it is specified at the same time as an offset, both are applied.
   FractionalOffset get alignment => _alignment;
   FractionalOffset _alignment;
-  void set alignment (FractionalOffset newAlignment) {
+  set alignment (FractionalOffset newAlignment) {
     assert(newAlignment == null || (newAlignment.dx != null && newAlignment.dy != null));
     if (_alignment == newAlignment)
       return;
@@ -1197,7 +1197,7 @@ class RenderTransform extends RenderProxyBox {
   Matrix4 _transform;
 
   /// The matrix to transform the child by during painting.
-  void set transform(Matrix4 newTransform) {
+  set transform(Matrix4 newTransform) {
     assert(newTransform != null);
     if (_transform == newTransform)
       return;
@@ -1324,7 +1324,7 @@ class RenderFractionalTranslation extends RenderProxyBox {
   /// The translation to apply to the child, as a multiple of the size.
   FractionalOffset get translation => _translation;
   FractionalOffset _translation;
-  void set translation (FractionalOffset newTranslation) {
+  set translation (FractionalOffset newTranslation) {
     assert(newTranslation == null || (newTranslation.dx != null && newTranslation.dy != null));
     if (_translation == newTranslation)
       return;
@@ -1504,7 +1504,7 @@ class RenderCustomPaint extends RenderProxyBox {
   /// delegate will be invoked.
   ///
   /// If the new value is null, then there is no background custom painter.
-  void set painter (CustomPainter newPainter) {
+  set painter (CustomPainter newPainter) {
     if (_painter == newPainter)
       return;
     CustomPainter oldPainter = _painter;
@@ -1529,7 +1529,7 @@ class RenderCustomPaint extends RenderProxyBox {
   /// delegate will be invoked.
   ///
   /// If the new value is null, then there is no foreground custom painter.
-  void set foregroundPainter (CustomPainter newPainter) {
+  set foregroundPainter (CustomPainter newPainter) {
     if (_foregroundPainter == newPainter)
       return;
     CustomPainter oldPainter = _foregroundPainter;
@@ -1818,7 +1818,7 @@ class RenderIgnorePointer extends RenderProxyBox {
 
   bool get ignoring => _ignoring;
   bool _ignoring;
-  void set ignoring(bool value) {
+  set ignoring(bool value) {
     assert(value != null);
     if (value == _ignoring)
       return;
@@ -1829,7 +1829,7 @@ class RenderIgnorePointer extends RenderProxyBox {
 
   bool get ignoringSemantics => _ignoringSemantics;
   bool _ignoringSemantics;
-  void set ignoringSemantics(bool value) {
+  set ignoringSemantics(bool value) {
     if (value == _ignoringSemantics)
       return;
     bool oldEffectiveValue = _effectiveIgnoringSemantics;
@@ -1898,7 +1898,7 @@ class RenderSemanticsGestureHandler extends RenderProxyBox implements SemanticAc
 
   GestureTapCallback get onTap => _onTap;
   GestureTapCallback _onTap;
-  void set onTap(GestureTapCallback value) {
+  set onTap(GestureTapCallback value) {
     if (_onTap == value)
       return;
     bool didHaveSemantics = hasSemantics;
@@ -1910,7 +1910,7 @@ class RenderSemanticsGestureHandler extends RenderProxyBox implements SemanticAc
 
   GestureLongPressCallback get onLongPress => _onLongPress;
   GestureLongPressCallback _onLongPress;
-  void set onLongPress(GestureLongPressCallback value) {
+  set onLongPress(GestureLongPressCallback value) {
     if (_onLongPress == value)
       return;
     bool didHaveSemantics = hasSemantics;
@@ -1922,7 +1922,7 @@ class RenderSemanticsGestureHandler extends RenderProxyBox implements SemanticAc
 
   GestureDragUpdateCallback get onHorizontalDragUpdate => _onHorizontalDragUpdate;
   GestureDragUpdateCallback _onHorizontalDragUpdate;
-  void set onHorizontalDragUpdate(GestureDragUpdateCallback value) {
+  set onHorizontalDragUpdate(GestureDragUpdateCallback value) {
     if (_onHorizontalDragUpdate == value)
       return;
     bool didHaveSemantics = hasSemantics;
@@ -1934,7 +1934,7 @@ class RenderSemanticsGestureHandler extends RenderProxyBox implements SemanticAc
 
   GestureDragUpdateCallback get onVerticalDragUpdate => _onVerticalDragUpdate;
   GestureDragUpdateCallback _onVerticalDragUpdate;
-  void set onVerticalDragUpdate(GestureDragUpdateCallback value) {
+  set onVerticalDragUpdate(GestureDragUpdateCallback value) {
     if (_onVerticalDragUpdate == value)
       return;
     bool didHaveSemantics = hasSemantics;
@@ -2034,7 +2034,7 @@ class RenderSemanticAnnotations extends RenderProxyBox {
   /// you can use a [RenderMergeSemantics].
   bool get container => _container;
   bool _container;
-  void set container(bool value) {
+  set container(bool value) {
     assert(value != null);
     if (container == value)
       return;
@@ -2046,7 +2046,7 @@ class RenderSemanticAnnotations extends RenderProxyBox {
   /// "isChecked" semantic to the given value.
   bool get checked => _checked;
   bool _checked;
-  void set checked(bool value) {
+  set checked(bool value) {
     if (checked == value)
       return;
     bool hadValue = checked != null;
@@ -2057,7 +2057,7 @@ class RenderSemanticAnnotations extends RenderProxyBox {
   /// If non-null, sets the "label" semantic to the given value.
   String get label => _label;
   String _label;
-  void set label(String value) {
+  set label(String value) {
     if (label == value)
       return;
     bool hadValue = label != null;

--- a/packages/flutter/lib/src/rendering/rotated_box.dart
+++ b/packages/flutter/lib/src/rendering/rotated_box.dart
@@ -29,7 +29,7 @@ class RenderRotatedBox extends RenderBox with RenderObjectWithChildMixin<RenderB
   /// The number of clockwise quarter turns the child should be rotated.
   int get quarterTurns => _quarterTurns;
   int _quarterTurns;
-  void set quarterTurns(int value) {
+  set quarterTurns(int value) {
     assert(value != null);
     if (_quarterTurns == value)
       return;

--- a/packages/flutter/lib/src/rendering/semantics.dart
+++ b/packages/flutter/lib/src/rendering/semantics.dart
@@ -80,7 +80,7 @@ class SemanticsNode extends AbstractNode {
 
   Matrix4 get transform => _transform;
   Matrix4 _transform; // defaults to null, which we say means the identity matrix
-  void set transform (Matrix4 value) {
+  set transform (Matrix4 value) {
     if (!MatrixUtils.matrixEquals(_transform, value)) {
       _transform = value;
       _markDirty();
@@ -89,7 +89,7 @@ class SemanticsNode extends AbstractNode {
 
   Rect get rect => _rect;
   Rect _rect = Rect.zero;
-  void set rect (Rect value) {
+  set rect (Rect value) {
     assert(value != null);
     if (_rect != value) {
       _rect = value;
@@ -119,34 +119,34 @@ class SemanticsNode extends AbstractNode {
   }
 
   bool get mergeAllDescendantsIntoThisNode => _flags[_SemanticFlags.mergeAllDescendantsIntoThisNode];
-  void set mergeAllDescendantsIntoThisNode(bool value) => _setFlag(_SemanticFlags.mergeAllDescendantsIntoThisNode, value);
+  set mergeAllDescendantsIntoThisNode(bool value) => _setFlag(_SemanticFlags.mergeAllDescendantsIntoThisNode, value);
 
   bool get _inheritedMergeAllDescendantsIntoThisNode => _flags[_SemanticFlags.inheritedMergeAllDescendantsIntoThisNode];
-  void set _inheritedMergeAllDescendantsIntoThisNode(bool value) => _setFlag(_SemanticFlags.inheritedMergeAllDescendantsIntoThisNode, value);
+  set _inheritedMergeAllDescendantsIntoThisNode(bool value) => _setFlag(_SemanticFlags.inheritedMergeAllDescendantsIntoThisNode, value);
 
   bool get _shouldMergeAllDescendantsIntoThisNode => mergeAllDescendantsIntoThisNode || _inheritedMergeAllDescendantsIntoThisNode;
 
   bool get canBeTapped => _flags[_SemanticFlags.canBeTapped];
-  void set canBeTapped(bool value) => _setFlag(_SemanticFlags.canBeTapped, value, needsHandler: true);
+  set canBeTapped(bool value) => _setFlag(_SemanticFlags.canBeTapped, value, needsHandler: true);
 
   bool get canBeLongPressed => _flags[_SemanticFlags.canBeLongPressed];
-  void set canBeLongPressed(bool value) => _setFlag(_SemanticFlags.canBeLongPressed, value, needsHandler: true);
+  set canBeLongPressed(bool value) => _setFlag(_SemanticFlags.canBeLongPressed, value, needsHandler: true);
 
   bool get canBeScrolledHorizontally => _flags[_SemanticFlags.canBeScrolledHorizontally];
-  void set canBeScrolledHorizontally(bool value) => _setFlag(_SemanticFlags.canBeScrolledHorizontally, value, needsHandler: true);
+  set canBeScrolledHorizontally(bool value) => _setFlag(_SemanticFlags.canBeScrolledHorizontally, value, needsHandler: true);
 
   bool get canBeScrolledVertically => _flags[_SemanticFlags.canBeScrolledVertically];
-  void set canBeScrolledVertically(bool value) => _setFlag(_SemanticFlags.canBeScrolledVertically, value, needsHandler: true);
+  set canBeScrolledVertically(bool value) => _setFlag(_SemanticFlags.canBeScrolledVertically, value, needsHandler: true);
 
   bool get hasCheckedState => _flags[_SemanticFlags.hasCheckedState];
-  void set hasCheckedState(bool value) => _setFlag(_SemanticFlags.hasCheckedState, value);
+  set hasCheckedState(bool value) => _setFlag(_SemanticFlags.hasCheckedState, value);
 
   bool get isChecked => _flags[_SemanticFlags.isChecked];
-  void set isChecked(bool value) => _setFlag(_SemanticFlags.isChecked, value);
+  set isChecked(bool value) => _setFlag(_SemanticFlags.isChecked, value);
 
   String get label => _label;
   String _label = '';
-  void set label(String value) {
+  set label(String value) {
     assert(value != null);
     if (_label != value) {
       _label = value;

--- a/packages/flutter/lib/src/rendering/shifted_box.dart
+++ b/packages/flutter/lib/src/rendering/shifted_box.dart
@@ -101,7 +101,7 @@ class RenderPadding extends RenderShiftedBox {
   /// The amount to pad the child in each dimension.
   EdgeInsets get padding => _padding;
   EdgeInsets _padding;
-  void set padding (EdgeInsets value) {
+  set padding (EdgeInsets value) {
     assert(value != null);
     assert(value.isNonNegative);
     if (_padding == value)
@@ -241,7 +241,7 @@ abstract class RenderAligningShiftedBox extends RenderShiftedBox {
   /// Sets the alignment to a new value, and triggers a layout update.
   ///
   /// The new alignment must not be null or have any null properties.
-  void set alignment (FractionalOffset newAlignment) {
+  set alignment (FractionalOffset newAlignment) {
     assert(newAlignment != null && newAlignment.dx != null && newAlignment.dy != null);
     if (_alignment == newAlignment)
       return;
@@ -301,7 +301,7 @@ class RenderPositionedBox extends RenderAligningShiftedBox {
   /// Can be both greater and less than 1.0 but must be positive.
   double get widthFactor => _widthFactor;
   double _widthFactor;
-  void set widthFactor (double value) {
+  set widthFactor (double value) {
     assert(value == null || value >= 0.0);
     if (_widthFactor == value)
       return;
@@ -314,7 +314,7 @@ class RenderPositionedBox extends RenderAligningShiftedBox {
   /// Can be both greater and less than 1.0 but must be positive.
   double get heightFactor => _heightFactor;
   double _heightFactor;
-  void set heightFactor (double value) {
+  set heightFactor (double value) {
     assert(value == null || value >= 0.0);
     if (_heightFactor == value)
       return;
@@ -443,7 +443,7 @@ class RenderConstrainedOverflowBox extends RenderAligningShiftedBox {
   /// default) to use the constraint from the parent instead.
   double get minWidth => _minWidth;
   double _minWidth;
-  void set minWidth (double value) {
+  set minWidth (double value) {
     if (_minWidth == value)
       return;
     _minWidth = value;
@@ -454,7 +454,7 @@ class RenderConstrainedOverflowBox extends RenderAligningShiftedBox {
   /// default) to use the constraint from the parent instead.
   double get maxWidth => _maxWidth;
   double _maxWidth;
-  void set maxWidth (double value) {
+  set maxWidth (double value) {
     if (_maxWidth == value)
       return;
     _maxWidth = value;
@@ -465,7 +465,7 @@ class RenderConstrainedOverflowBox extends RenderAligningShiftedBox {
   /// default) to use the constraint from the parent instead.
   double get minHeight => _minHeight;
   double _minHeight;
-  void set minHeight (double value) {
+  set minHeight (double value) {
     if (_minHeight == value)
       return;
     _minHeight = value;
@@ -476,7 +476,7 @@ class RenderConstrainedOverflowBox extends RenderAligningShiftedBox {
   /// default) to use the constraint from the parent instead.
   double get maxHeight => _maxHeight;
   double _maxHeight;
-  void set maxHeight (double value) {
+  set maxHeight (double value) {
     if (_maxHeight == value)
       return;
     _maxHeight = value;
@@ -557,7 +557,7 @@ class RenderSizedOverflowBox extends RenderAligningShiftedBox {
   /// The size this render box should attempt to be.
   Size get requestedSize => _requestedSize;
   Size _requestedSize;
-  void set requestedSize (Size value) {
+  set requestedSize (Size value) {
     assert(value != null);
     if (_requestedSize == value)
       return;
@@ -635,7 +635,7 @@ class RenderFractionallySizedOverflowBox extends RenderAligningShiftedBox {
   /// given the incoming width constraings.
   double get widthFactor => _widthFactor;
   double _widthFactor;
-  void set widthFactor (double value) {
+  set widthFactor (double value) {
     assert(value == null || value >= 0.0);
     if (_widthFactor == value)
       return;
@@ -650,7 +650,7 @@ class RenderFractionallySizedOverflowBox extends RenderAligningShiftedBox {
   /// given the incoming width constraings.
   double get heightFactor => _heightFactor;
   double _heightFactor;
-  void set heightFactor (double value) {
+  set heightFactor (double value) {
     assert(value == null || value >= 0.0);
     if (_heightFactor == value)
       return;
@@ -764,7 +764,7 @@ class RenderCustomSingleChildLayoutBox extends RenderShiftedBox {
   /// A delegate that controls this object's layout.
   SingleChildLayoutDelegate get delegate => _delegate;
   SingleChildLayoutDelegate _delegate;
-  void set delegate (SingleChildLayoutDelegate newDelegate) {
+  set delegate (SingleChildLayoutDelegate newDelegate) {
     assert(newDelegate != null);
     if (_delegate == newDelegate)
       return;
@@ -856,7 +856,7 @@ class RenderBaseline extends RenderShiftedBox {
   /// the child's baseline.
   double get baseline => _baseline;
   double _baseline;
-  void set baseline (double value) {
+  set baseline (double value) {
     assert(value != null);
     if (_baseline == value)
       return;
@@ -867,7 +867,7 @@ class RenderBaseline extends RenderShiftedBox {
   /// The type of baseline to use for positioning the child.
   TextBaseline get baselineType => _baselineType;
   TextBaseline _baselineType;
-  void set baselineType (TextBaseline value) {
+  set baselineType (TextBaseline value) {
     assert(value != null);
     if (_baselineType == value)
       return;

--- a/packages/flutter/lib/src/rendering/stack.dart
+++ b/packages/flutter/lib/src/rendering/stack.dart
@@ -159,7 +159,7 @@ class StackParentData extends ContainerBoxParentDataMixin<RenderBox> {
 
   /// Get or set the current values in terms of a RelativeRect object.
   RelativeRect get rect => new RelativeRect.fromLTRB(left, top, right, bottom);
-  void set rect(RelativeRect value) {
+  set rect(RelativeRect value) {
     top = value.top;
     right = value.right;
     bottom = value.bottom;
@@ -216,7 +216,7 @@ abstract class RenderStackBase extends RenderBox
 
   FractionalOffset get alignment => _alignment;
   FractionalOffset _alignment;
-  void set alignment (FractionalOffset value) {
+  set alignment (FractionalOffset value) {
     if (_alignment != value) {
       _alignment = value;
       markNeedsLayout();
@@ -475,7 +475,7 @@ class RenderIndexedStack extends RenderStackBase {
 
   int get index => _index;
   int _index;
-  void set index (int value) {
+  set index (int value) {
     assert(value != null);
     if (_index != value) {
       _index = value;

--- a/packages/flutter/lib/src/rendering/table.dart
+++ b/packages/flutter/lib/src/rendering/table.dart
@@ -421,7 +421,7 @@ class RenderTable extends RenderBox {
 
   int get columns => _columns;
   int _columns;
-  void set columns(int value) {
+  set columns(int value) {
     assert(value != null);
     assert(value >= 0);
     if (value == columns)
@@ -449,7 +449,7 @@ class RenderTable extends RenderBox {
 
   int get rows => _rows;
   int _rows;
-  void set rows(int value) {
+  set rows(int value) {
     assert(value != null);
     assert(value >= 0);
     if (value == rows)
@@ -467,7 +467,7 @@ class RenderTable extends RenderBox {
 
   Map<int, TableColumnWidth> get columnWidths => new Map<int, TableColumnWidth>.unmodifiable(_columnWidths);
   Map<int, TableColumnWidth> _columnWidths;
-  void set columnWidths(Map<int, TableColumnWidth> value) {
+  set columnWidths(Map<int, TableColumnWidth> value) {
     value ??= new HashMap<int, TableColumnWidth>();
     if (_columnWidths == value)
       return;
@@ -484,7 +484,7 @@ class RenderTable extends RenderBox {
 
   TableColumnWidth get defaultColumnWidth => _defaultColumnWidth;
   TableColumnWidth _defaultColumnWidth;
-  void set defaultColumnWidth(TableColumnWidth value) {
+  set defaultColumnWidth(TableColumnWidth value) {
     assert(value != null);
     if (defaultColumnWidth == value)
       return;
@@ -494,7 +494,7 @@ class RenderTable extends RenderBox {
 
   TableBorder get border => _border;
   TableBorder _border;
-  void set border(TableBorder value) {
+  set border(TableBorder value) {
     if (border == value)
       return;
     _border = value;
@@ -504,7 +504,7 @@ class RenderTable extends RenderBox {
   List<Decoration> get rowDecorations => new List<Decoration>.unmodifiable(_rowDecorations ?? const <Decoration>[]);
   List<Decoration> _rowDecorations;
   List<BoxPainter> _rowDecorationPainters;
-  void set rowDecorations(List<Decoration> value) {
+  set rowDecorations(List<Decoration> value) {
     if (_rowDecorations == value)
       return;
     _removeListenersIfNeeded();
@@ -535,7 +535,7 @@ class RenderTable extends RenderBox {
 
   TableCellVerticalAlignment get defaultVerticalAlignment => _defaultVerticalAlignment;
   TableCellVerticalAlignment _defaultVerticalAlignment;
-  void set defaultVerticalAlignment (TableCellVerticalAlignment value) {
+  set defaultVerticalAlignment (TableCellVerticalAlignment value) {
     if (_defaultVerticalAlignment == value)
       return;
     _defaultVerticalAlignment = value;
@@ -544,7 +544,7 @@ class RenderTable extends RenderBox {
 
   TextBaseline get textBaseline => _textBaseline;
   TextBaseline _textBaseline;
-  void set textBaseline (TextBaseline value) {
+  set textBaseline (TextBaseline value) {
     if (_textBaseline == value)
       return;
     _textBaseline = value;

--- a/packages/flutter/lib/src/rendering/view.dart
+++ b/packages/flutter/lib/src/rendering/view.dart
@@ -57,7 +57,7 @@ class RenderView extends RenderObject with RenderObjectWithChildMixin<RenderBox>
   /// The constraints used for the root layout.
   ViewConfiguration get configuration => _configuration;
   ViewConfiguration _configuration;
-  void set configuration(ViewConfiguration value) {
+  set configuration(ViewConfiguration value) {
     if (configuration == value)
       return;
     _configuration = value;

--- a/packages/flutter/lib/src/rendering/viewport.dart
+++ b/packages/flutter/lib/src/rendering/viewport.dart
@@ -107,7 +107,7 @@ class RenderViewportBase extends RenderBox {
   /// The offset can be non-zero only in the [mainAxis].
   Offset get paintOffset => _paintOffset;
   Offset _paintOffset;
-  void set paintOffset(Offset value) {
+  set paintOffset(Offset value) {
     assert(value != null);
     if (value == _paintOffset)
       return;
@@ -124,7 +124,7 @@ class RenderViewportBase extends RenderBox {
   /// is vertical).
   Axis get mainAxis => _mainAxis;
   Axis _mainAxis;
-  void set mainAxis(Axis value) {
+  set mainAxis(Axis value) {
     assert(value != null);
     if (value == _mainAxis)
       return;
@@ -138,7 +138,7 @@ class RenderViewportBase extends RenderBox {
   /// See [ViewportAnchor] for more detail.
   ViewportAnchor get anchor => _anchor;
   ViewportAnchor _anchor;
-  void set anchor(ViewportAnchor value) {
+  set anchor(ViewportAnchor value) {
     assert(value != null);
     if (value == _anchor)
       return;
@@ -149,7 +149,7 @@ class RenderViewportBase extends RenderBox {
 
   RenderObjectPainter get overlayPainter => _overlayPainter;
   RenderObjectPainter _overlayPainter;
-  void set overlayPainter(RenderObjectPainter value) {
+  set overlayPainter(RenderObjectPainter value) {
     if (_overlayPainter == value)
       return;
     if (attached)
@@ -174,7 +174,7 @@ class RenderViewportBase extends RenderBox {
 
   ViewportDimensions get dimensions => _dimensions;
   ViewportDimensions _dimensions = ViewportDimensions.zero;
-  void set dimensions(ViewportDimensions value) {
+  set dimensions(ViewportDimensions value) {
     assert(debugDoingThisLayout);
     _dimensions = value;
   }
@@ -362,7 +362,7 @@ abstract class RenderVirtualViewport<T extends ContainerBoxParentDataMixin<Rende
 
   int get virtualChildCount => _virtualChildCount;
   int _virtualChildCount;
-  void set virtualChildCount(int value) {
+  set virtualChildCount(int value) {
     if (_virtualChildCount == value)
       return;
     _virtualChildCount = value;
@@ -375,7 +375,7 @@ abstract class RenderVirtualViewport<T extends ContainerBoxParentDataMixin<Rende
   /// example so the child list contains only visible children.
   LayoutCallback get callback => _callback;
   LayoutCallback _callback;
-  void set callback(LayoutCallback value) {
+  set callback(LayoutCallback value) {
     if (value == _callback)
       return;
     _callback = value;

--- a/packages/flutter/lib/src/services/image_cache.dart
+++ b/packages/flutter/lib/src/services/image_cache.dart
@@ -115,7 +115,7 @@ class ImageCache {
   /// extraneous elements are evicted immediately. Setting this to zero and then
   /// returning it to its original value will therefore immediately clear the
   /// cache.
-  void set maximumSize(int value) {
+  set maximumSize(int value) {
     assert(value != null);
     assert(value >= 0);
     if (value == maximumSize)

--- a/packages/flutter/lib/src/widgets/layout_builder.dart
+++ b/packages/flutter/lib/src/widgets/layout_builder.dart
@@ -37,7 +37,7 @@ class _RenderLayoutBuilder extends RenderBox with RenderObjectWithChildMixin<Ren
 
   LayoutCallback get callback => _callback;
   LayoutCallback _callback;
-  void set callback(LayoutCallback value) {
+  set callback(LayoutCallback value) {
     if (value == _callback)
       return;
     _callback = value;

--- a/packages/flutter/lib/src/widgets/overlay.dart
+++ b/packages/flutter/lib/src/widgets/overlay.dart
@@ -60,7 +60,7 @@ class OverlayEntry {
   /// entries below that entry for efficiency.
   bool get opaque => _opaque;
   bool _opaque;
-  void set opaque (bool value) {
+  set opaque (bool value) {
     if (_opaque == value)
       return;
     assert(_overlay != null);

--- a/packages/flutter/lib/src/widgets/placeholder.dart
+++ b/packages/flutter/lib/src/widgets/placeholder.dart
@@ -22,7 +22,7 @@ class PlaceholderState extends State<Placeholder> {
   /// Mutating this field will cause this widget to rebuild with the new child.
   Widget get child => _child;
   Widget _child;
-  void set child(Widget child) {
+  set child(Widget child) {
     if (_child == child)
       return;
     setState(() {

--- a/packages/flutter/lib/src/widgets/routes.dart
+++ b/packages/flutter/lib/src/widgets/routes.dart
@@ -511,7 +511,7 @@ abstract class ModalRoute<T> extends TransitionRoute<T> with LocalHistoryRoute<T
   /// widgets being animated as part of the transition.
   bool get offstage => _offstage;
   bool _offstage = false;
-  void set offstage (bool value) {
+  set offstage (bool value) {
     if (_offstage == value)
       return;
     _offstage = value;

--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -40,7 +40,7 @@ abstract class TextSelectionDelegate {
   InputValue get inputValue;
 
   /// Sets the current text input (replaces the whole line).
-  void set inputValue(InputValue value);
+  set inputValue(InputValue value);
 
   /// Hides the text selection toolbar.
   void hideToolbar();
@@ -147,7 +147,7 @@ class TextSelectionOverlay implements TextSelectionDelegate {
   InputValue get inputValue => _input;
 
   @override
-  void set inputValue(InputValue value) {
+  set inputValue(InputValue value) {
     update(value);
     if (onSelectionOverlayChanged != null)
       onSelectionOverlayChanged(value);

--- a/packages/flutter/test/widget/snap_scrolling_test.dart
+++ b/packages/flutter/test/widget/snap_scrolling_test.dart
@@ -43,7 +43,7 @@ Widget buildFrame() {
 ScrollableState get scrollableState => scrollableListKey.currentState;
 
 double get scrollOffset =>  scrollableState.scrollOffset;
-void set scrollOffset(double value) {
+set scrollOffset(double value) {
   scrollableState.scrollTo(value);
 }
 

--- a/packages/flutter_markdown/lib/src/markdown_raw.dart
+++ b/packages/flutter_markdown/lib/src/markdown_raw.dart
@@ -348,7 +348,7 @@ class _Block {
   List<_Block> subBlocks;
 
   bool get open => _open;
-  void set open(bool open) {
+  set open(bool open) {
     _open = open;
     if (!open && subBlocks.length > 0)
       subBlocks.last.isLast = true;

--- a/packages/flutter_sprites/lib/src/effect_line.dart
+++ b/packages/flutter_sprites/lib/src/effect_line.dart
@@ -67,7 +67,7 @@ class EffectLine extends Node {
 
   List<Point> get points => _points;
 
-  void set points(List<Point> points) {
+  set points(List<Point> points) {
     _points = points;
     _pointAges = <double>[];
     for (int i = 0; i < _points.length; i++) {

--- a/packages/flutter_sprites/lib/src/label.dart
+++ b/packages/flutter_sprites/lib/src/label.dart
@@ -13,7 +13,7 @@ class Label extends Node {
   /// The text being drawn by the label.
   String get text => _text;
   String _text;
-  void set text(String text) {
+  set text(String text) {
     _text = text;
     _painter = null;
   }
@@ -21,7 +21,7 @@ class Label extends Node {
   /// The style to draw the text in.
   TextStyle get textStyle => _textStyle;
   TextStyle _textStyle;
-  void set textStyle(TextStyle textStyle) {
+  set textStyle(TextStyle textStyle) {
     _textStyle = textStyle;
     _painter = null;
   }

--- a/packages/flutter_sprites/lib/src/nine_slice_sprite.dart
+++ b/packages/flutter_sprites/lib/src/nine_slice_sprite.dart
@@ -28,7 +28,7 @@ class NineSliceSprite extends NodeWithSize with SpritePaint {
 
   Texture _texture;
 
-  void set texture(Texture texture) {
+  set texture(Texture texture) {
     _texture = texture;
     _isDirty = true;
     if (texture == null) {
@@ -49,7 +49,7 @@ class NineSliceSprite extends NodeWithSize with SpritePaint {
 
   EdgeInsets _insets;
 
-  void set insets(EdgeInsets insets) {
+  set insets(EdgeInsets insets) {
     assert(insets != null);
     _insets = insets;
     _isDirty = true;
@@ -61,13 +61,13 @@ class NineSliceSprite extends NodeWithSize with SpritePaint {
 
   bool _drawCenterPart = true;
 
-  void set drawCenterPart(bool drawCenterPart) {
+  set drawCenterPart(bool drawCenterPart) {
     _drawCenterPart = drawCenterPart;
     _isDirty = true;
   }
 
   @override
-  void set size(Size size) {
+  set size(Size size) {
     super.size = size;
     _isDirty = true;
   }

--- a/packages/flutter_sprites/lib/src/node.dart
+++ b/packages/flutter_sprites/lib/src/node.dart
@@ -93,7 +93,7 @@ class Node {
     return _constraints;
   }
 
-  void set constraints(List<Constraint> constraints) {
+  set constraints(List<Constraint> constraints) {
     _constraints = constraints;
     if (_spriteBox != null) _spriteBox._constrainedNodes = null;
   }
@@ -131,7 +131,7 @@ class Node {
   ///     myNode.rotation = 45.0;
   double get rotation => _rotation;
 
-  void set rotation(double rotation) {
+  set rotation(double rotation) {
     assert(rotation != null);
 
     _rotation = rotation;
@@ -144,7 +144,7 @@ class Node {
   ///     myNode.position = new Point(42.0, 42.0);
   Point get position => _position;
 
-  void set position(Point position) {
+  set position(Point position) {
     assert(position != null);
 
     _position = position;
@@ -156,7 +156,7 @@ class Node {
   ///     myNode.skewX = 45.0;
   double get skewX => _skewX;
 
-  void set skewX (double skewX) {
+  set skewX (double skewX) {
     assert(skewX != null);
     _skewX = skewX;
     invalidateTransformMatrix();
@@ -167,7 +167,7 @@ class Node {
   ///     myNode.skewY = 45.0;
   double get skewY => _skewY;
 
-  void set skewY (double skewY) {
+  set skewY (double skewY) {
     assert(skewY != null);
     _skewY = skewY;
     invalidateTransformMatrix();
@@ -183,7 +183,7 @@ class Node {
   ///     nodeBehind.zPosition = -1.0;
   double get zPosition => _zPosition;
 
-  void set zPosition(double zPosition) {
+  set zPosition(double zPosition) {
     assert(zPosition != null);
     _zPosition = zPosition;
     if (_parent != null) {
@@ -201,7 +201,7 @@ class Node {
     return _scaleX;
   }
 
-  void set scale(double scale) {
+  set scale(double scale) {
     assert(scale != null);
 
     _scaleX = _scaleY = scale;
@@ -213,7 +213,7 @@ class Node {
   ///     myNode.scaleX = 5.0;
   double get scaleX => _scaleX;
 
-  void set scaleX(double scaleX) {
+  set scaleX(double scaleX) {
     assert(scaleX != null);
 
     _scaleX = scaleX;
@@ -225,7 +225,7 @@ class Node {
   ///     myNode.scaleY = 5.0;
   double get scaleY => _scaleY;
 
-  void set scaleY(double scaleY) {
+  set scaleY(double scaleY) {
     assert(scaleY != null);
 
     _scaleY = scaleY;
@@ -599,7 +599,7 @@ class Node {
   ///     }
   bool get userInteractionEnabled => _userInteractionEnabled;
 
-  void set userInteractionEnabled(bool userInteractionEnabled) {
+  set userInteractionEnabled(bool userInteractionEnabled) {
     _userInteractionEnabled = userInteractionEnabled;
     if (_spriteBox != null) _spriteBox._eventTargets = null;
   }

--- a/packages/flutter_sprites/lib/src/node3d.dart
+++ b/packages/flutter_sprites/lib/src/node3d.dart
@@ -13,7 +13,7 @@ class Node3D extends Node {
   /// The node's rotation around the x axis in degrees.
   double get rotationX => _rotationX;
 
-  void set rotationX(double rotationX) {
+  set rotationX(double rotationX) {
     _rotationX = rotationX;
     invalidateTransformMatrix();
   }
@@ -23,7 +23,7 @@ class Node3D extends Node {
   /// The node's rotation around the y axis in degrees.
   double get rotationY => _rotationY;
 
-  void set rotationY(double rotationY) {
+  set rotationY(double rotationY) {
     _rotationY = rotationY;
     invalidateTransformMatrix();
   }
@@ -33,7 +33,7 @@ class Node3D extends Node {
   /// The projection depth. Default value is 500.0.
   double get projectionDepth => _projectionDepth;
 
-  void set projectionDepth(double projectionDepth) {
+  set projectionDepth(double projectionDepth) {
     _projectionDepth = projectionDepth;
     invalidateTransformMatrix();
   }

--- a/packages/flutter_sprites/lib/src/particle_system.dart
+++ b/packages/flutter_sprites/lib/src/particle_system.dart
@@ -160,7 +160,7 @@ class ParticleSystem extends Node {
 
   Vector2 _gravity;
 
-  void set gravity(Offset gravity) {
+  set gravity(Offset gravity) {
     if (gravity == null)
       _gravity = null;
     else

--- a/packages/flutter_sprites/lib/src/sound.dart
+++ b/packages/flutter_sprites/lib/src/sound.dart
@@ -33,7 +33,7 @@ class SoundEffectStream {
 
   bool get paused => _paused;
   bool _paused;
-  void set paused(bool value) {
+  set paused(bool value) {
     _paused = value;
     if (_paused) {
       _soundPool.ptr.pause(_streamId);
@@ -44,21 +44,21 @@ class SoundEffectStream {
 
   double get leftVolume => _leftVolume;
   double _leftVolume;
-  void set leftVolume(double value) {
+  set leftVolume(double value) {
     _leftVolume = value;
     _soundPool.ptr.setVolume(_streamId, <double>[_leftVolume, _rightVolume]);
   }
 
   double get rightVolume => _rightVolume;
   double _rightVolume;
-  void set rightVolume(double value) {
+  set rightVolume(double value) {
     _rightVolume = value;
     _soundPool.ptr.setVolume(_streamId, <double>[_leftVolume, _rightVolume]);
   }
 
   double get pitch => _pitch;
   double _pitch;
-  void set pitch(double value) {
+  set pitch(double value) {
     _pitch = value;
     _soundPool.ptr.setRate(_streamId, _pitch);
   }
@@ -108,7 +108,7 @@ class SoundEffectPlayer {
 
   bool get paused => _paused;
 
-  void set paused(bool value) {
+  set paused(bool value) {
     _paused = value;
     if (_paused) {
       _soundPool.ptr.pauseAll();

--- a/packages/flutter_sprites/lib/src/sprite.dart
+++ b/packages/flutter_sprites/lib/src/sprite.dart
@@ -92,7 +92,7 @@ abstract class SpritePaint {
   ///     mySprite.opacity = 0.5;
   double get opacity => _opacity;
 
-  void set opacity(double opacity) {
+  set opacity(double opacity) {
     assert(opacity != null);
     assert(opacity >= 0.0 && opacity <= 1.0);
     _opacity = opacity;

--- a/packages/flutter_sprites/lib/src/sprite_box.dart
+++ b/packages/flutter_sprites/lib/src/sprite_box.dart
@@ -74,7 +74,7 @@ class SpriteBox extends RenderBox {
   // Root node for drawing
   NodeWithSize _rootNode;
 
-  void set rootNode (NodeWithSize value) {
+  set rootNode (NodeWithSize value) {
     if (value == _rootNode) return;
 
     // Ensure that the root node has a size
@@ -105,7 +105,7 @@ class SpriteBox extends RenderBox {
   // Transformation mode
   SpriteBoxTransformMode _transformMode;
 
-  void set transformMode (SpriteBoxTransformMode value) {
+  set transformMode (SpriteBoxTransformMode value) {
     if (value == _transformMode)
       return;
     _transformMode = value;

--- a/packages/flutter_sprites/lib/src/textured_line.dart
+++ b/packages/flutter_sprites/lib/src/textured_line.dart
@@ -22,7 +22,7 @@ class TexturedLinePainter {
 
   List<Point> get points => _points;
 
-  void set points(List<Point> points) {
+  set points(List<Point> points) {
     _points = points;
     _calculatedTextureStops = null;
   }
@@ -33,7 +33,7 @@ class TexturedLinePainter {
 
   Texture get texture => _texture;
 
-  void set texture(Texture texture) {
+  set texture(Texture texture) {
     _texture = texture;
     if (texture == null) {
       _cachedPaint = new Paint();
@@ -71,7 +71,7 @@ class TexturedLinePainter {
 
   double get textureLoopLength => textureLoopLength;
 
-  void set textureLoopLength(double textureLoopLength) {
+  set textureLoopLength(double textureLoopLength) {
     _textureLoopLength = textureLoopLength;
     _calculatedTextureStops = null;
   }

--- a/packages/flutter_tools/flutter_analysis_options
+++ b/packages/flutter_tools/flutter_analysis_options
@@ -31,7 +31,7 @@ linter:
     - annotate_overrides
     - avoid_as
     - avoid_init_to_null
-    # - avoid_return_types_on_setters # https://github.com/dart-lang/linter/issues/202
+    - avoid_return_types_on_setters
     - camel_case_types
     # - constant_identifier_names # https://github.com/dart-lang/linter/issues/204 (and 203)
     - empty_constructor_bodies

--- a/packages/flutter_tools/lib/src/android/adb.dart
+++ b/packages/flutter_tools/lib/src/android/adb.dart
@@ -204,7 +204,7 @@ class AdbDevice {
   /// Device model; can be null. `XT1045`, `Nexus_7`
   String get modelID => _info['model'];
 
-  void set modelID(String value) {
+  set modelID(String value) {
     _info['model'] = value;
   }
 

--- a/packages/playfair/lib/src/base.dart
+++ b/packages/playfair/lib/src/base.dart
@@ -79,7 +79,7 @@ class _RenderChart extends RenderConstrainedBox {
   final ChartPainter _painter;
 
   ChartData get data => _painter.data;
-  void set data(ChartData value) {
+  set data(ChartData value) {
     assert(value != null);
     if (value == _painter.data)
       return;
@@ -88,7 +88,7 @@ class _RenderChart extends RenderConstrainedBox {
   }
 
   TextTheme get textTheme => _painter.textTheme;
-  void set textTheme(TextTheme value) {
+  set textTheme(TextTheme value) {
     assert(value != null);
     if (value == _painter.textTheme)
       return;
@@ -125,7 +125,7 @@ class ChartPainter {
 
   ChartData _data;
   ChartData get data => _data;
-  void set data(ChartData value) {
+  set data(ChartData value) {
     assert(data != null);
     if (_data == value)
       return;
@@ -135,7 +135,7 @@ class ChartPainter {
 
   TextTheme _textTheme;
   TextTheme get textTheme => _textTheme;
-  void set textTheme(TextTheme value) {
+  set textTheme(TextTheme value) {
     assert(value != null);
     if (_textTheme == value)
       return;


### PR DESCRIPTION
It's safe to remove the unneeded `void`s from setters since the blocking issues in the
`always_declare_return_types` lint have been fixed (https://github.com/dart-lang/sdk/issues/57299).  We can also safely flip the bit on  `avoid_return_types_on_setters`.
