### PR TITLE
Replace the checked flag in DebuggingOptions with the build mode

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_device.dart
+++ b/packages/flutter_tools/lib/src/android/android_device.dart
@@ -269,7 +269,7 @@ class AndroidDevice extends Device {
     if (route != null)
       cmd.addAll(<String>['--es', 'route', route]);
     if (options.debuggingEnabled) {
-      if (options.checked)
+      if (options.buildMode == BuildMode.debug)
         cmd.addAll(<String>['--ez', 'enable-checked-mode', 'true']);
       if (options.startPaused)
         cmd.addAll(<String>['--ez', 'start-paused', 'true']);
@@ -334,6 +334,7 @@ class AndroidDevice extends Device {
 
     String localBundlePath = await flx.buildFlx(
       mainPath: mainPath,
+      precompiledSnapshot: isAotBuildMode(debuggingOptions.buildMode),
       includeRobotoFonts: false
     );
 

--- a/packages/flutter_tools/lib/src/commands/build_apk.dart
+++ b/packages/flutter_tools/lib/src/commands/build_apk.dart
@@ -452,7 +452,10 @@ Future<int> buildAndroid(
     };
   }
 
-  if (!force && !_needsRebuild(outputFile, manifest, extraFiles)) {
+  // In debug (JIT) mode, the snapshot lives in the FLX, and we can skip the APK
+  // rebuild if none of the resources in the APK are stale.
+  // In AOT modes, the snapshot lives in the APK, so the APK must be rebuilt.
+  if (!isAotBuildMode(buildMode) && !force && !_needsRebuild(outputFile, manifest, extraFiles)) {
     printTrace('APK up to date; skipping build step.');
     return 0;
   }

--- a/packages/flutter_tools/lib/src/commands/drive.dart
+++ b/packages/flutter_tools/lib/src/commands/drive.dart
@@ -269,8 +269,7 @@ Future<int> startApp(DriveCommand command, BuildMode buildMode) async {
     mainPath: mainPath,
     route: command.route,
     debuggingOptions: new DebuggingOptions.enabled(
-      // TODO(devoncarew): Change this to 'buildMode == BuildMode.debug'.
-      checked: command.argResults['checked'],
+      buildMode,
       startPaused: true,
       observatoryPort: command.debugPort
     ),

--- a/packages/flutter_tools/lib/src/commands/listen.dart
+++ b/packages/flutter_tools/lib/src/commands/listen.dart
@@ -8,7 +8,6 @@ import 'dart:io';
 import '../base/os.dart';
 import '../base/process.dart';
 import '../device.dart';
-import '../build_info.dart';
 import '../globals.dart';
 import 'run.dart';
 
@@ -63,7 +62,7 @@ class ListenCommand extends RunCommandBase {
         target: target,
         install: firstTime,
         stop: true,
-        debuggingOptions: new DebuggingOptions.enabled(checked: getBuildMode() == BuildMode.debug),
+        debuggingOptions: new DebuggingOptions.enabled(getBuildMode()),
         traceStartup: traceStartup,
         route: route
       );

--- a/packages/flutter_tools/lib/src/commands/run.dart
+++ b/packages/flutter_tools/lib/src/commands/run.dart
@@ -24,13 +24,6 @@ abstract class RunCommandBase extends FlutterCommand {
   RunCommandBase() {
     addBuildModeFlags();
 
-    // TODO(devoncarew): Remove in favor of --debug/--profile/--release.
-    argParser.addFlag('checked',
-        negatable: true,
-        defaultsTo: true,
-        help: 'Run the application in checked ("slow") mode.\n'
-          'Note: this flag will be removed in favor of the --debug/--profile/--release flags.');
-
     argParser.addFlag('trace-startup',
         negatable: true,
         defaultsTo: false,
@@ -112,11 +105,10 @@ class RunCommand extends RunCommandBase {
     DebuggingOptions options;
 
     if (getBuildMode() != BuildMode.debug) {
-      options = new DebuggingOptions.disabled();
+      options = new DebuggingOptions.disabled(getBuildMode());
     } else {
       options = new DebuggingOptions.enabled(
-        // TODO(devoncarew): Change this to 'getBuildMode() == BuildMode.debug'.
-        checked: argResults['checked'],
+        getBuildMode(),
         startPaused: argResults['start-paused'],
         observatoryPort: debugPort
       );

--- a/packages/flutter_tools/lib/src/device.dart
+++ b/packages/flutter_tools/lib/src/device.dart
@@ -225,23 +225,21 @@ abstract class Device {
 }
 
 class DebuggingOptions {
-  DebuggingOptions.enabled({
-    this.checked: true,
+  DebuggingOptions.enabled(this.buildMode, {
     this.startPaused: false,
     this.observatoryPort,
     this.diagnosticPort
    }) : debuggingEnabled = true;
 
-  DebuggingOptions.disabled() :
+  DebuggingOptions.disabled(this.buildMode) :
     debuggingEnabled = false,
-    checked = false,
     startPaused = false,
     observatoryPort = null,
     diagnosticPort = null;
 
   final bool debuggingEnabled;
 
-  final bool checked;
+  final BuildMode buildMode;
   final bool startPaused;
   final int observatoryPort;
   final int diagnosticPort;

--- a/packages/flutter_tools/lib/src/ios/simulators.dart
+++ b/packages/flutter_tools/lib/src/ios/simulators.dart
@@ -457,7 +457,7 @@ class IOSSimulator extends Device {
     ];
 
     if (debuggingOptions.debuggingEnabled) {
-      if (debuggingOptions.checked)
+      if (debuggingOptions.buildMode == BuildMode.debug)
         args.add("--enable-checked-mode");
       if (debuggingOptions.startPaused)
         args.add("--start-paused");


### PR DESCRIPTION
This also fixes some related problems affecting "flutter run":
- FLXes built during AndroidDevice.startApp need to match the build mode
- APKs should always be rebuilt if the build mode uses AOT compilation
