### PR TITLE
send debug events for flutter lifecycle events

### DIFF
--- a/packages/flutter/lib/src/foundation/binding.dart
+++ b/packages/flutter/lib/src/foundation/binding.dart
@@ -56,9 +56,9 @@ abstract class BindingBase {
     initServiceExtensions();
     assert(_debugServiceExtensionsRegistered);
 
-    developer.Timeline.finishSync();
-
     developer.postEvent('Flutter.FrameworkInitialization', <String, dynamic>{});
+
+    developer.Timeline.finishSync();
   }
 
   static bool _debugInitialized = false;

--- a/packages/flutter/lib/src/foundation/binding.dart
+++ b/packages/flutter/lib/src/foundation/binding.dart
@@ -57,6 +57,8 @@ abstract class BindingBase {
     assert(_debugServiceExtensionsRegistered);
 
     developer.Timeline.finishSync();
+
+    developer.postEvent('Flutter.FrameworkInitialization', <String, dynamic>{});
   }
 
   static bool _debugInitialized = false;

--- a/packages/flutter/lib/src/widgets/binding.dart
+++ b/packages/flutter/lib/src/widgets/binding.dart
@@ -208,6 +208,7 @@ abstract class WidgetsBinding extends BindingBase implements GestureBinding, Ren
     if (_needToReportFirstFrame) {
       if (_thisFrameWasUseful) {
         developer.Timeline.instantSync('Widgets completed first useful frame');
+        developer.postEvent('Flutter.FirstFrame', <String, dynamic>{});
         _needToReportFirstFrame = false;
       } else {
         _thisFrameWasUseful = true;

--- a/packages/flutter/lib/src/widgets/navigator.dart
+++ b/packages/flutter/lib/src/widgets/navigator.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:developer' as developer;
+
 import 'framework.dart';
 import 'overlay.dart';
 
@@ -358,6 +360,7 @@ class NavigatorState extends State<Navigator> {
       if (oldRoute != null)
         oldRoute.didChangeNext(route);
       config.observer?.didPush(route, oldRoute);
+      developer.postEvent('Flutter.Route', <String, dynamic>{ 'route': route.toString() });
     });
     assert(() { _debugLocked = false; return true; });
   }

--- a/packages/flutter/lib/src/widgets/navigator.dart
+++ b/packages/flutter/lib/src/widgets/navigator.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:developer' as developer;
-
 import 'framework.dart';
 import 'overlay.dart';
 
@@ -360,7 +358,6 @@ class NavigatorState extends State<Navigator> {
       if (oldRoute != null)
         oldRoute.didChangeNext(route);
       config.observer?.didPush(route, oldRoute);
-      developer.postEvent('Flutter.Route', <String, dynamic>{ 'route': route.toString() });
     });
     assert(() { _debugLocked = false; return true; });
   }


### PR DESCRIPTION
@Hixie, this sends flutter lifecycle events as observatory debug events. These are a little easier to watch for on the debug client side, and much less high volume, than the timeline events.

The route event is more of an FYI - I don't expect to land it this PR. The text I currently get for it is `MaterialPageRoute<Null>("/", animation: AnimationController(⏭ 1.000; paused; for MaterialPageRoute<Null>(/)))`. I'd instead want something like `/` or `/foo`. In the fullness of time, it'd be great to be able to set and get the route, and receive events when it changes.
