### PR TITLE
Re-enable `one_member_abstracts` lint (#3608).

### DIFF
--- a/examples/flutter_gallery/lib/gallery/syntax_highlighter.dart
+++ b/examples/flutter_gallery/lib/gallery/syntax_highlighter.dart
@@ -40,7 +40,7 @@ class SyntaxHighlighterStyle {
   final TextStyle constantStyle;
 }
 
-abstract class SyntaxHighlighter { //ignore: one_member_abstracts
+abstract class SyntaxHighlighter { // ignore: one_member_abstracts
   TextSpan format(String src);
 }
 

--- a/examples/flutter_gallery/lib/gallery/syntax_highlighter.dart
+++ b/examples/flutter_gallery/lib/gallery/syntax_highlighter.dart
@@ -40,7 +40,7 @@ class SyntaxHighlighterStyle {
   final TextStyle constantStyle;
 }
 
-abstract class SyntaxHighlighter {
+abstract class SyntaxHighlighter { //ignore: one_member_abstracts
   TextSpan format(String src);
 }
 

--- a/packages/flutter_tools/flutter_analysis_options
+++ b/packages/flutter_tools/flutter_analysis_options
@@ -40,7 +40,7 @@ linter:
     - library_names
     - library_prefixes
     - non_constant_identifier_names
-    # - one_member_abstracts # https://github.com/dart-lang/linter/issues/203
+    - one_member_abstracts
     - package_api_docs
     - package_names
     - package_prefixed_library_names


### PR DESCRIPTION
More context in https://github.com/flutter/flutter/issues/3608.

Leaving it to @vlidholt to decide if `SyntaxHighlighter` wants to be a closure (in which case we can remove the `//ignore`). 
