### PR TITLE
handle an exit code from android n

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_device.dart
+++ b/packages/flutter_tools/lib/src/android/android_device.dart
@@ -54,13 +54,19 @@ class AndroidDevice extends Device {
 
   String _getProperty(String name) {
     if (_properties == null) {
-      String getpropOutput = runCheckedSync(adbCommandForDevice(<String>['shell', 'getprop']));
-      RegExp propertyExp = new RegExp(r'\[(.*?)\]: \[(.*?)\]');
       _properties = <String, String>{};
-      for (Match m in propertyExp.allMatches(getpropOutput)) {
-        _properties[m.group(1)] = m.group(2);
+
+      try {
+        String getpropOutput = runCheckedSync(adbCommandForDevice(<String>['shell', 'getprop']));
+        RegExp propertyExp = new RegExp(r'\[(.*?)\]: \[(.*?)\]');
+        for (Match m in propertyExp.allMatches(getpropOutput))
+          _properties[m.group(1)] = m.group(2);
+      } catch (error, trace) {
+        printError('Error reteiving device properties: $error');
+        printTrace(trace.toString());
       }
     }
+
     return _properties[name];
   }
 

--- a/packages/flutter_tools/lib/src/android/android_device.dart
+++ b/packages/flutter_tools/lib/src/android/android_device.dart
@@ -62,7 +62,7 @@ class AndroidDevice extends Device {
         for (Match m in propertyExp.allMatches(getpropOutput))
           _properties[m.group(1)] = m.group(2);
       } catch (error, trace) {
-        printError('Error reteiving device properties: $error');
+        printError('Error retrieving device properties: $error');
         printTrace(trace.toString());
       }
     }

--- a/packages/flutter_tools/lib/src/base/context.dart
+++ b/packages/flutter_tools/lib/src/base/context.dart
@@ -59,8 +59,9 @@ class AppContext {
   }
 
   dynamic runInZone(dynamic method(), { ErrorHandler onError }) {
-    return runZoned(method,
-      zoneValues: <String, dynamic>{'context': this},
+    return runZoned(
+      method,
+      zoneValues: <String, dynamic>{ 'context': this },
       onError: onError
     );
   }

--- a/packages/flutter_tools/lib/src/base/context.dart
+++ b/packages/flutter_tools/lib/src/base/context.dart
@@ -6,6 +6,8 @@ import 'dart:async';
 
 final AppContext _defaultContext = new AppContext();
 
+typedef void ErrorHandler(dynamic error);
+
 /// A singleton for application functionality. This singleton can be different
 /// on a per-Zone basis.
 AppContext get context {
@@ -56,7 +58,10 @@ class AppContext {
     }
   }
 
-  dynamic runInZone(dynamic method()) {
-    return runZoned(method, zoneValues: <String, dynamic>{'context': this});
+  dynamic runInZone(dynamic method(), { ErrorHandler onError }) {
+    return runZoned(method,
+      zoneValues: <String, dynamic>{'context': this},
+      onError: onError
+    );
   }
 }

--- a/packages/flutter_tools/lib/src/commands/daemon.dart
+++ b/packages/flutter_tools/lib/src/commands/daemon.dart
@@ -64,13 +64,17 @@ class DaemonCommand extends FlutterCommand {
       }, daemonCommand: this, notifyingLogger: notifyingLogger);
 
       return daemon.onExit;
-    });
+    }, onError: _handleError);
   }
 
   dynamic _jsonEncodeObject(dynamic object) {
     if (object is Device)
       return _deviceToMap(object);
     return object;
+  }
+
+  void _handleError(dynamic error) {
+    printError('Error from flutter daemon: $error');
   }
 }
 


### PR DESCRIPTION
- fix an issue with a changed exit code w/ the android n tools (fix https://github.com/flutter/flutter/issues/3910)
- make the flutter daemon more resilient to exceptions thrown while it's running (before, the top level handler in executable would print the error and call `exit`)
