### PR TITLE
allow per-command analytics suppression

### DIFF
--- a/packages/flutter_tools/lib/src/commands/config.dart
+++ b/packages/flutter_tools/lib/src/commands/config.dart
@@ -9,11 +9,9 @@ import '../runner/flutter_command.dart';
 
 class ConfigCommand extends FlutterCommand {
   ConfigCommand() {
-    String usageStatus = flutterUsage.enabled ? 'enabled' : 'disabled';
-
     argParser.addFlag('analytics',
       negatable: true,
-      help: 'Enable or disable reporting anonymously tool usage statistics and crash reports.\n(currently $usageStatus)');
+      help: 'Enable or disable reporting anonymously tool usage statistics and crash reports.');
   }
 
   @override
@@ -27,6 +25,9 @@ class ConfigCommand extends FlutterCommand {
 
   @override
   final List<String> aliases = <String>['configure'];
+
+  @override
+  String get usageFooter => 'Analytics reporting is currently ${flutterUsage.enabled ? 'enabled' : 'disabled'}.';
 
   @override
   bool get requiresProjectRoot => false;

--- a/packages/flutter_tools/lib/src/runner/flutter_command_runner.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command_runner.dart
@@ -44,6 +44,10 @@ class FlutterCommandRunner extends CommandRunner {
         negatable: true,
         hide: !verboseHelp,
         help: 'Whether to use terminal colors.');
+    argParser.addFlag('suppress-analytics',
+        negatable: false,
+        hide: !verboseHelp,
+        help: 'Suppress analytics reporting when this command runs.');
 
     String packagesHelp;
     if (FileSystemEntity.isFileSync('.packages'))
@@ -128,9 +132,12 @@ class FlutterCommandRunner extends CommandRunner {
     if (globalResults.wasParsed('color'))
       logger.supportsColor = globalResults['color'];
 
-    // we must set Cache.flutterRoot early because other features use it
-    // (e.g. enginePath's initialiser uses it)
+    // We must set Cache.flutterRoot early because other features use it (e.g.
+    // enginePath's initialiser uses it).
     Cache.flutterRoot = path.normalize(path.absolute(globalResults['flutter-root']));
+
+    if (globalResults['suppress-analytics'])
+      flutterUsage.suppressAnalytics = true;
 
     _checkFlutterCopy();
 

--- a/packages/flutter_tools/lib/src/usage.dart
+++ b/packages/flutter_tools/lib/src/usage.dart
@@ -44,10 +44,18 @@ class Usage {
   Analytics _analytics;
 
   bool _printedUsage = false;
+  bool _suppressAnalytics = false;
 
   bool get isFirstRun => _analytics.firstRun;
 
   bool get enabled => _analytics.enabled;
+
+  bool get suppressAnalytics => _suppressAnalytics || _analytics.firstRun;
+
+  /// Suppress analytics for this session.
+  set suppressAnalytics(bool value) {
+    _suppressAnalytics = value;
+  }
 
   /// Enable or disable reporting analytics.
   set enabled(bool value) {
@@ -55,24 +63,24 @@ class Usage {
   }
 
   void sendCommand(String command) {
-    if (!isFirstRun)
+    if (!suppressAnalytics)
       _analytics.sendScreenView(command);
   }
 
   void sendEvent(String category, String parameter) {
-    if (!isFirstRun)
+    if (!suppressAnalytics)
       _analytics.sendEvent(category, parameter);
   }
 
   UsageTimer startTimer(String event) {
-    if (isFirstRun)
+    if (suppressAnalytics)
       return new _MockUsageTimer();
     else
       return new UsageTimer._(event, _analytics.startTimer(event, category: 'flutter'));
   }
 
   void sendException(dynamic exception, StackTrace trace) {
-    if (!isFirstRun)
+    if (!suppressAnalytics)
       _analytics.sendException('${exception.runtimeType}; ${sanitizeStacktrace(trace)}');
   }
 

--- a/packages/flutter_tools/pubspec.yaml
+++ b/packages/flutter_tools/pubspec.yaml
@@ -21,7 +21,7 @@ dependencies:
   path: ^1.3.0
   pub_semver: ^1.0.0
   stack_trace: ^1.4.0
-  usage: ^2.2.0+1
+  usage: ^2.2.1
   web_socket_channel: ^1.0.0
   xml: ^2.4.1
   yaml: ^2.1.3

--- a/packages/flutter_tools/test/src/context.dart
+++ b/packages/flutter_tools/test/src/context.dart
@@ -121,6 +121,12 @@ class MockUsage implements Usage {
   bool get isFirstRun => false;
 
   @override
+  bool get suppressAnalytics => false;
+
+  @override
+  set suppressAnalytics(bool value) { }
+
+  @override
   bool get enabled => true;
 
   @override


### PR DESCRIPTION
- allow per-command analytics suppression (work towards https://github.com/flutter/flutter/issues/3862)
- fix an issue where the analytics object was constructed before flutterRoot had been set; as a result the version we were reported was wonky

The usage now looks like `flutter --suppress-analytics build apk`.
