### PR TITLE
Rename DefaultTextStyle constructor to explicit

### DIFF
--- a/dev/manual_tests/drag_and_drop.dart
+++ b/dev/manual_tests/drag_and_drop.dart
@@ -97,7 +97,7 @@ class ExampleDragSource extends StatelessWidget {
     if (heavy)
       size *= kHeavyMultiplier;
 
-    Widget contents = new DefaultTextStyle(
+    Widget contents = new DefaultTextStyle.explicit(
       style: Theme.of(context).textTheme.body1,
       textAlign: TextAlign.center,
       child: new Dot(
@@ -185,7 +185,7 @@ class MovableBall extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    Widget ball = new DefaultTextStyle(
+    Widget ball = new DefaultTextStyle.explicit(
       style: Typography.white.body1,
       textAlign: TextAlign.center,
       child: new Dot(

--- a/examples/flutter_gallery/lib/demo/colors_demo.dart
+++ b/examples/flutter_gallery/lib/demo/colors_demo.dart
@@ -84,7 +84,7 @@ class ColorSwatchTabView extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     List<Widget> colorItems =  swatch.colors.keys.map((int index) {
-      return new DefaultTextStyle(
+      return new DefaultTextStyle.explicit(
         style: index > swatch.threshold ? whiteTextStyle : blackTextStyle,
         child: new ColorItem(index: index, color: swatch.colors[index])
       );
@@ -93,7 +93,7 @@ class ColorSwatchTabView extends StatelessWidget {
 
     if (swatch.accentColors != null) {
       colorItems.addAll(swatch.accentColors.keys.map((int index) {
-        return new DefaultTextStyle(
+        return new DefaultTextStyle.explicit(
           style: index > swatch.threshold ? whiteTextStyle : blackTextStyle,
           child: new ColorItem(index: index, color: swatch.accentColors[index], prefix: 'A')
         );

--- a/examples/flutter_gallery/lib/demo/flexible_space_demo.dart
+++ b/examples/flutter_gallery/lib/demo/flexible_space_demo.dart
@@ -18,7 +18,7 @@ class _ContactCategory extends StatelessWidget {
       decoration: new BoxDecoration(
         border: new Border(bottom: new BorderSide(color: Theme.of(context).dividerColor))
       ),
-      child: new DefaultTextStyle(
+      child: new DefaultTextStyle.explicit(
         style: Theme.of(context).textTheme.subhead,
         child: new Row(
           children: <Widget>[

--- a/examples/flutter_gallery/lib/demo/full_screen_dialog_demo.dart
+++ b/examples/flutter_gallery/lib/demo/full_screen_dialog_demo.dart
@@ -31,7 +31,7 @@ class DateTimeItem extends StatelessWidget {
   Widget build(BuildContext context) {
     final ThemeData theme = Theme.of(context);
 
-    return new DefaultTextStyle(
+    return new DefaultTextStyle.explicit(
       style: theme.textTheme.subhead,
       child: new Row(
         children: <Widget>[

--- a/examples/flutter_gallery/lib/demo/progress_indicator_demo.dart
+++ b/examples/flutter_gallery/lib/demo/progress_indicator_demo.dart
@@ -94,7 +94,7 @@ class _ProgressIndicatorDemoState extends State<ProgressIndicatorDemo> {
   Widget build(BuildContext context) {
     return new Scaffold(
       appBar: new AppBar(title: new Text('Progress indicators')),
-      body: new DefaultTextStyle(
+      body: new DefaultTextStyle.explicit(
         style: Theme.of(context).textTheme.title,
         child: new GestureDetector(
           onTap: _handleTap,

--- a/examples/flutter_gallery/lib/demo/scrolling_techniques_demo.dart
+++ b/examples/flutter_gallery/lib/demo/scrolling_techniques_demo.dart
@@ -26,8 +26,8 @@ class _BarGraphic extends StatelessWidget {
       width: 200.0,
       padding: const EdgeInsets.symmetric(horizontal: 16.0),
       decoration: new BoxDecoration(backgroundColor: color),
-      child: new DefaultTextStyle(
-        style: Theme.of(context).textTheme.body1.copyWith(color: Colors.white),
+      child: new DefaultTextStyle.explicit(
+        style: Typography.white.body1,
         child: new Row(
           mainAxisAlignment: MainAxisAlignment.spaceBetween,
           children: <Widget>[

--- a/packages/flutter/lib/src/material/app_bar.dart
+++ b/packages/flutter/lib/src/material/app_bar.dart
@@ -203,7 +203,7 @@ class AppBar extends StatelessWidget {
       child: new Padding(
         padding: new EdgeInsets.only(left: 8.0),
         child: title != null ?
-          new DefaultTextStyle(
+          new DefaultTextStyle.explicit(
             style: centerStyle,
             softWrap: false,
             overflow: TextOverflow.ellipsis,
@@ -218,7 +218,7 @@ class AppBar extends StatelessWidget {
       height: kToolBarHeight,
       child: new IconTheme(
         data: iconTheme,
-        child: new DefaultTextStyle(
+        child: new DefaultTextStyle.explicit(
           style: sideStyle,
           child: new Row(children: toolBarRow)
         )

--- a/packages/flutter/lib/src/material/chip.dart
+++ b/packages/flutter/lib/src/material/chip.dart
@@ -82,7 +82,7 @@ class Chip extends StatelessWidget {
       ));
     }
 
-    children.add(new DefaultTextStyle(
+    children.add(new DefaultTextStyle.explicit(
       style: _kLabelStyle,
       child: label
     ));

--- a/packages/flutter/lib/src/material/circle_avatar.dart
+++ b/packages/flutter/lib/src/material/circle_avatar.dart
@@ -52,7 +52,7 @@ class CircleAvatar extends StatelessWidget {
         shape: BoxShape.circle
       ),
       child: new Center(
-        child: new DefaultTextStyle(
+        child: new DefaultTextStyle.explicit(
           style: theme.primaryTextTheme.title,
           child: child
         )

--- a/packages/flutter/lib/src/material/data_table.dart
+++ b/packages/flutter/lib/src/material/data_table.dart
@@ -403,6 +403,7 @@ class DataTable extends StatelessWidget {
   }
 
   Widget _buildDataCell({
+    BuildContext context,
     EdgeInsets padding,
     Widget label,
     bool numeric,
@@ -421,7 +422,8 @@ class DataTable extends StatelessWidget {
       height: _kDataRowHeight,
       child: new Align(
         alignment: new FractionalOffset(numeric ? 1.0 : 0.0, 0.5), // TODO(ianh): RTL for non-numeric
-        child: new DefaultTextStyle(
+        child: new DefaultTextStyle.inherit(
+          context: context,
           style: new TextStyle(
             // TODO(ianh): font family should be Roboto; see https://github.com/flutter/flutter/issues/3116
             fontSize: 13.0,
@@ -528,6 +530,7 @@ class DataTable extends StatelessWidget {
       for (DataRow row in rows) {
         DataCell cell = row.cells[dataColumnIndex];
         tableRows[rowIndex].children[displayColumnIndex] = _buildDataCell(
+          context: context,
           padding: padding,
           label: cell.widget,
           numeric: column.numeric,

--- a/packages/flutter/lib/src/material/dialog.dart
+++ b/packages/flutter/lib/src/material/dialog.dart
@@ -71,7 +71,7 @@ class Dialog extends StatelessWidget {
         padding = new EdgeInsets.fromLTRB(24.0, 24.0, 24.0, content == null ? 20.0 : 0.0);
       dialogBody.add(new Padding(
         padding: padding,
-        child: new DefaultTextStyle(
+        child: new DefaultTextStyle.explicit(
           style: Theme.of(context).textTheme.title,
           child: title
         )
@@ -84,7 +84,7 @@ class Dialog extends StatelessWidget {
         padding = const EdgeInsets.fromLTRB(24.0, 20.0, 24.0, 24.0);
       dialogBody.add(new Padding(
         padding: padding,
-        child: new DefaultTextStyle(
+        child: new DefaultTextStyle.explicit(
           style: Theme.of(context).textTheme.subhead,
           child: content
         )

--- a/packages/flutter/lib/src/material/drawer_header.dart
+++ b/packages/flutter/lib/src/material/drawer_header.dart
@@ -53,7 +53,7 @@ class DrawerHeader extends StatelessWidget {
           new Flexible(child: new Container()),
           new Container(
             padding: const EdgeInsets.symmetric(horizontal: 16.0),
-            child: new DefaultTextStyle(
+            child: new DefaultTextStyle.explicit(
               style: Theme.of(context).textTheme.body2,
               child: child
             )

--- a/packages/flutter/lib/src/material/drop_down.dart
+++ b/packages/flutter/lib/src/material/drop_down.dart
@@ -277,7 +277,7 @@ class DropDownMenuItem<T> extends StatelessWidget {
     return new Container(
       height: _kMenuItemHeight,
       padding: const EdgeInsets.symmetric(horizontal: 8.0),
-      child: new DefaultTextStyle(
+      child: new DefaultTextStyle.explicit(
         style: Theme.of(context).textTheme.subhead,
         child: new Baseline(
           baselineType: TextBaseline.alphabetic,

--- a/packages/flutter/lib/src/material/flexible_space_bar.dart
+++ b/packages/flutter/lib/src/material/flexible_space_bar.dart
@@ -130,7 +130,7 @@ class _FlexibleSpaceBarState extends State<FlexibleSpaceBar> {
               scale: new Tween<double>(begin: 1.5, end: 1.0).animate(scaleAndAlignCurve),
               child: new Align(
                 alignment: new FractionalOffset(0.0, 1.0),
-                child: new DefaultTextStyle(style: titleStyle, child: config.title)
+                child: new DefaultTextStyle.explicit(style: titleStyle, child: config.title)
               )
             )
           )

--- a/packages/flutter/lib/src/material/grid_tile_bar.dart
+++ b/packages/flutter/lib/src/material/grid_tile_bar.dart
@@ -83,13 +83,13 @@ class GridTileBar extends StatelessWidget {
           child: new Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: <Widget>[
-              new DefaultTextStyle(
+              new DefaultTextStyle.explicit(
                 style: Typography.white.subhead,
                 softWrap: false,
                 overflow: TextOverflow.ellipsis,
                 child: title
               ),
-              new DefaultTextStyle(
+              new DefaultTextStyle.explicit(
                 style: Typography.white.caption,
                 softWrap: false,
                 overflow: TextOverflow.ellipsis,
@@ -102,7 +102,7 @@ class GridTileBar extends StatelessWidget {
     } else if (title != null || subtitle != null) {
       children.add(
         new Flexible(
-          child: new DefaultTextStyle(
+          child: new DefaultTextStyle.explicit(
             style: Typography.white.subhead,
             softWrap: false,
             overflow: TextOverflow.ellipsis,

--- a/packages/flutter/lib/src/material/snack_bar.dart
+++ b/packages/flutter/lib/src/material/snack_bar.dart
@@ -137,7 +137,7 @@ class SnackBar extends StatelessWidget {
       new Flexible(
         child: new Container(
           margin: const EdgeInsets.symmetric(vertical: _kSingleLineVerticalPadding),
-          child: new DefaultTextStyle(
+          child: new DefaultTextStyle.explicit(
             style: Typography.white.subhead,
             child: content
           )

--- a/packages/flutter/lib/src/material/tabs.dart
+++ b/packages/flutter/lib/src/material/tabs.dart
@@ -920,7 +920,7 @@ class _TabBarState<T> extends ScrollableState<TabBar<T>> implements TabBarSelect
 
     Widget contents = new IconTheme(
       data: iconTheme,
-      child: new DefaultTextStyle(
+      child: new DefaultTextStyle.explicit(
         style: textStyle,
         child: new _TabBarWrapper(
           children: tabs,

--- a/packages/flutter/lib/src/material/two_level_list.dart
+++ b/packages/flutter/lib/src/material/two_level_list.dart
@@ -116,7 +116,7 @@ class _TwoLevelSublistState extends State<TwoLevelSublist> {
             child: new TwoLevelListItem(
               onTap: _handleOnTap,
               leading: config.leading,
-              title: new DefaultTextStyle(
+              title: new DefaultTextStyle.explicit(
                 style: Theme.of(context).textTheme.subhead.copyWith(color: _headerColor.evaluate(_easeInAnimation)),
                 child: config.title
               ),

--- a/packages/flutter/lib/src/widgets/app.dart
+++ b/packages/flutter/lib/src/widgets/app.dart
@@ -187,7 +187,7 @@ class WidgetsAppState<T extends WidgetsApp> extends State<T> implements WidgetsB
       )
     );
     if (config.textStyle != null) {
-      new DefaultTextStyle(
+      new DefaultTextStyle.explicit(
         style: config.textStyle,
         child: result
       );

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -1954,9 +1954,12 @@ class RichText extends LeafRenderObjectWidget {
 class DefaultTextStyle extends InheritedWidget {
   /// Creates a default text style for the given subtree.
   ///
+  /// Can be used only with a [TextStyle] whose [TextStyle.inherit] field is
+  /// false.
+  ///
   /// Consider using [DefaultTextStyle.inherit] to inherit styling information
   /// from a the current default text style for a given [BuildContext].
-  DefaultTextStyle({
+  DefaultTextStyle.explicit({
     Key key,
     this.style,
     this.textAlign,
@@ -1968,6 +1971,20 @@ class DefaultTextStyle extends InheritedWidget {
     assert(softWrap != null);
     assert(overflow != null);
     assert(child != null);
+    assert(() {
+      if (style.inherit) {
+        throw new FlutterError(
+          'Inherited style cannot be used with DefaultTextStyle.explicit.\n'
+          'DefaultTextStyle.explicit does not inherit styles from the '
+          'DefaultTextStyle for the current BuildContext. Please either use an '
+          'explicit text style (i.e., one without the "inherit" flag set to '
+          'true) or use the DefaultTextStyle.inherit constructor, which does '
+          'inherit styles from the DefaultTextStyle for the current '
+          'BuildContext.'
+        );
+      }
+      return true;
+    });
   }
 
   /// A const-constructible default text style that provides fallback values.
@@ -1997,7 +2014,7 @@ class DefaultTextStyle extends InheritedWidget {
     assert(context != null);
     assert(child != null);
     DefaultTextStyle parent = DefaultTextStyle.of(context);
-    return new DefaultTextStyle(
+    return new DefaultTextStyle.explicit(
       key: key,
       style: parent.style.merge(style),
       textAlign: textAlign ?? parent.textAlign,

--- a/packages/flutter/lib/src/widgets/implicit_animations.dart
+++ b/packages/flutter/lib/src/widgets/implicit_animations.dart
@@ -560,7 +560,8 @@ class _AnimatedDefaultTextStyleState extends AnimatedWidgetBaseState<AnimatedDef
 
   @override
   Widget build(BuildContext context) {
-    return new DefaultTextStyle(
+    return new DefaultTextStyle.inherit(
+      context: context,
       style: _style.evaluate(animation),
       child: config.child
     );

--- a/packages/flutter/test/widget/scrollable_list_with_inherited_test.dart
+++ b/packages/flutter/test/widget/scrollable_list_with_inherited_test.dart
@@ -14,7 +14,8 @@ Widget buildCard(BuildContext context, int index) {
   return new Container(
     key: new ValueKey<int>(items[index]),
     height: 100.0,
-    child: new DefaultTextStyle(
+    child: new DefaultTextStyle.inherit(
+      context: context,
       style: new TextStyle(fontSize: 2.0 + items.length.toDouble()),
       child: new Text('${items[index]}')
     )


### PR DESCRIPTION
To make it clear that this constructor requires an explicit style. Also
throw a descriptive error recommending the inherit constructor for
styles with the inherit bit set.

Fixes #3842
