### PR TITLE
Remove the unimplemented `more` option from the copy/paste toolbar.

### DIFF
--- a/packages/flutter/lib/src/material/text_selection.dart
+++ b/packages/flutter/lib/src/material/text_selection.dart
@@ -9,8 +9,6 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter/services.dart';
 
 import 'flat_button.dart';
-import 'icon_button.dart';
-import 'icons.dart';
 import 'material.dart';
 import 'theme.dart';
 

--- a/packages/flutter/lib/src/material/text_selection.dart
+++ b/packages/flutter/lib/src/material/text_selection.dart
@@ -40,8 +40,6 @@ class _TextSelectionToolbar extends StatelessWidget {
     if (value.text.isNotEmpty) {
       if (value.selection.isCollapsed)
         items.add(new FlatButton(child: new Text('SELECT ALL'), onPressed: _handleSelectAll));
-      // TODO(mpcomplete): implement `more` menu.
-      items.add(new IconButton(icon: Icons.more_vert));
     }
 
     return new Material(


### PR DESCRIPTION
Punting this feature for the near time, so I'm removing the dead option
from the toolbar.
