### PR TITLE
Make it easier to disable print throttling.

### DIFF
--- a/packages/flutter_test/lib/src/binding.dart
+++ b/packages/flutter_test/lib/src/binding.dart
@@ -339,17 +339,9 @@ class AutomatedTestWidgetsFlutterBinding extends TestWidgetsFlutterBinding {
 
   @override
   void initInstances() {
-    debugPrint = _synchronousDebugPrint;
+    debugPrint = debugPrintSynchronously;
     super.initInstances();
     ui.window.onBeginFrame = null;
-  }
-
-  void _synchronousDebugPrint(String message, { int wrapWidth }) {
-    if (wrapWidth != null) {
-      print(message.split('\n').expand((String line) => debugWordWrap(line, wrapWidth)).join('\n'));
-    } else {
-      print(message);
-    }
   }
 
   FakeAsync _fakeAsync;


### PR DESCRIPTION
This exposes the default throttling implementation, and an alternative
non-throttling implementation, of `debugPrint`.
