### PR TITLE
Speed up compositing by 5x

### DIFF
--- a/packages/flutter/lib/src/rendering/layer.dart
+++ b/packages/flutter/lib/src/rendering/layer.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:developer';
 import 'dart:ui' as ui show ImageFilter, Picture, SceneBuilder;
 import 'dart:ui' show Offset;
 
@@ -106,9 +105,7 @@ class PictureLayer extends Layer {
 
   @override
   void addToScene(ui.SceneBuilder builder, Offset layerOffset) {
-    Timeline.startSync('PictureLayer::addToScene');
     builder.addPicture(layerOffset, picture);
-    Timeline.finishSync();
   }
 }
 
@@ -123,7 +120,6 @@ class ChildSceneLayer extends Layer {
 
   @override
   void addToScene(ui.SceneBuilder builder, Offset layerOffset) {
-    Timeline.startSync('ChildSceneLayer::addToScene');
     builder.addChildScene(
       offset + layerOffset,
       devicePixelRatio,
@@ -131,7 +127,6 @@ class ChildSceneLayer extends Layer {
       physicalHeight,
       sceneToken.value
     );
-    Timeline.finishSync();
   }
 
   @override
@@ -164,10 +159,8 @@ class PerformanceOverlayLayer extends Layer {
   @override
   void addToScene(ui.SceneBuilder builder, Offset layerOffset) {
     assert(optionsMask != null);
-    Timeline.startSync('PerformanceOverlayLayer::addToScene');
     builder.addPerformanceOverlay(optionsMask, overlayRect.shift(layerOffset));
     builder.setRasterizerTracingThreshold(rasterizerThreshold);
-    Timeline.finishSync();
   }
 }
 
@@ -259,9 +252,7 @@ class ContainerLayer extends Layer {
 
   @override
   void addToScene(ui.SceneBuilder builder, Offset layerOffset) {
-    Timeline.startSync('ContainerLayer::addToScene');
     addChildrenToScene(builder, layerOffset);
-    Timeline.finishSync();
   }
 
   /// Uploads all of this layer's children to the engine
@@ -301,9 +292,7 @@ class OffsetLayer extends ContainerLayer {
 
   @override
   void addToScene(ui.SceneBuilder builder, Offset layerOffset) {
-    Timeline.startSync('OffsetLayer::addToScene');
     addChildrenToScene(builder, offset + layerOffset);
-    Timeline.finishSync();
   }
 
   @override
@@ -325,11 +314,9 @@ class ClipRectLayer extends ContainerLayer {
 
   @override
   void addToScene(ui.SceneBuilder builder, Offset layerOffset) {
-    Timeline.startSync('ClipRectLayer::addToScene');
     builder.pushClipRect(clipRect.shift(layerOffset));
     addChildrenToScene(builder, layerOffset);
     builder.pop();
-    Timeline.finishSync();
   }
 
   @override
@@ -350,11 +337,9 @@ class ClipRRectLayer extends ContainerLayer {
 
   @override
   void addToScene(ui.SceneBuilder builder, Offset layerOffset) {
-    Timeline.startSync('ClipRRectLayer::addToScene');
     builder.pushClipRRect(clipRRect.shift(layerOffset));
     addChildrenToScene(builder, layerOffset);
     builder.pop();
-    Timeline.finishSync();
   }
 
   @override
@@ -375,11 +360,9 @@ class ClipPathLayer extends ContainerLayer {
 
   @override
   void addToScene(ui.SceneBuilder builder, Offset layerOffset) {
-    Timeline.startSync('ClipPathLayer::addToScene');
     builder.pushClipPath(clipPath.shift(layerOffset));
     addChildrenToScene(builder, layerOffset);
     builder.pop();
-    Timeline.finishSync();
   }
 
   @override
@@ -398,13 +381,11 @@ class TransformLayer extends OffsetLayer {
 
   @override
   void addToScene(ui.SceneBuilder builder, Offset layerOffset) {
-    Timeline.startSync('TransformLayer::addToScene');
-    Matrix4 offsetTransform = new Matrix4.identity();
-    offsetTransform.translate(offset.dx + layerOffset.dx, offset.dy + layerOffset.dy);
-    builder.pushTransform((offsetTransform * transform).storage);
+    Matrix4 effectiveTransform = new Matrix4.translationValues(offset.dx + layerOffset.dx, offset.dy + layerOffset.dy, 0.0)
+      ..multiply(transform);
+    builder.pushTransform(effectiveTransform.storage);
     addChildrenToScene(builder, Offset.zero);
     builder.pop();
-    Timeline.finishSync();
   }
 
   @override
@@ -427,11 +408,9 @@ class OpacityLayer extends ContainerLayer {
 
   @override
   void addToScene(ui.SceneBuilder builder, Offset layerOffset) {
-    Timeline.startSync('OpacityLayer::addToScene');
     builder.pushOpacity(alpha);
     addChildrenToScene(builder, layerOffset);
     builder.pop();
-    Timeline.finishSync();
   }
 
   @override
@@ -456,11 +435,9 @@ class ShaderMaskLayer extends ContainerLayer {
 
   @override
   void addToScene(ui.SceneBuilder builder, Offset layerOffset) {
-    Timeline.startSync('ShaderMaskLayer::addToScene');
     builder.pushShaderMask(shader, maskRect.shift(layerOffset), transferMode);
     addChildrenToScene(builder, layerOffset);
     builder.pop();
-    Timeline.finishSync();
   }
 
   @override
@@ -481,10 +458,8 @@ class BackdropFilterLayer extends ContainerLayer {
 
   @override
   void addToScene(ui.SceneBuilder builder, Offset layerOffset) {
-    Timeline.startSync('BackdropFilterLayer::addToScene');
     builder.pushBackdropFilter(filter);
     addChildrenToScene(builder, layerOffset);
     builder.pop();
-    Timeline.finishSync();
   }
 }


### PR DESCRIPTION
According to the profile for the flow manual test, we're spending the vast
majority of our time recording timeline traces. This patch removes the timeline
traces, which greatly improves performance.

Also, optimize TransformLayer to avoid one matrix memcpy. I filed
https://github.com/google/vector_math.dart/issues/166 about an API that would
make this even faster.
