### PR TITLE
Add a Scrollable builder, refactor ScrollableList, et al

### DIFF
--- a/examples/flutter_gallery/lib/demo/dialog_demo.dart
+++ b/examples/flutter_gallery/lib/demo/dialog_demo.dart
@@ -197,6 +197,14 @@ class DialogDemoState extends State<DialogDemo> {
             }
           )
         ]
+        // Add a little space between the buttons
+        .map((Widget button) {
+          return new Container(
+            padding: const EdgeInsets.symmetric(vertical: 8.0),
+            child: button
+          );
+        })
+        .toList()
       )
     );
   }

--- a/packages/flutter/lib/src/widgets/scrollable_grid.dart
+++ b/packages/flutter/lib/src/widgets/scrollable_grid.dart
@@ -8,13 +8,98 @@ import 'package:collection/collection.dart' show lowerBound;
 import 'package:flutter/rendering.dart';
 
 import 'framework.dart';
-import 'scroll_behavior.dart';
 import 'scrollable.dart';
 import 'virtual_viewport.dart';
+
+class ScrollableGrid extends StatelessWidget {
+  ScrollableGrid({
+    Key key,
+    this.initialScrollOffset,
+    this.onScrollStart,
+    this.onScroll,
+    this.onScrollEnd,
+    this.snapOffsetCallback,
+    this.scrollableKey,
+    this.delegate,
+    this.children
+  }) : super(key: key);
+
+  /// The scroll offset this widget should use when first created.
+  final double initialScrollOffset;
+
+  /// Called whenever this widget starts to scroll.
+  final ScrollListener onScrollStart;
+
+  /// Called whenever this widget's scroll offset changes.
+  final ScrollListener onScroll;
+
+  /// Called whenever this widget stops scrolling.
+  final ScrollListener onScrollEnd;
+
+  /// Called to determine the offset to which scrolling should snap,
+  /// when handling a fling.
+  ///
+  /// This callback, if set, will be called with the offset that the
+  /// Scrollable would have scrolled to in the absence of this
+  /// callback, and a Size describing the size of the Scrollable
+  /// itself.
+  ///
+  /// The callback's return value is used as the new scroll offset to
+  /// aim for.
+  ///
+  /// If the callback simply returns its first argument (the offset),
+  /// then it is as if the callback was null.
+  final SnapOffsetCallback snapOffsetCallback;
+
+  /// The key for the Scrollable created by this widget.
+  final Key scrollableKey;
+
+  final GridDelegate delegate;
+  final Iterable<Widget> children;
+
+  void _handleExtentsChanged(ScrollableState state, double contentExtent, double containerExtent) {
+    state.setState(() {
+      state.didUpdateScrollBehavior(state.scrollBehavior.updateExtents(
+        contentExtent: contentExtent,
+        containerExtent: containerExtent,
+        scrollOffset: state.scrollOffset
+      ));
+    });
+  }
+
+  Widget _buildContent(BuildContext context, ScrollableState state) {
+    return new GridViewport(
+      startOffset: state.scrollOffset,
+      delegate: delegate,
+      onExtentsChanged: (double contentExtent, double containerExtent) {
+        _handleExtentsChanged(state, contentExtent, containerExtent);
+      },
+      children: children
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return new Scrollable(
+      key: scrollableKey,
+      initialScrollOffset: initialScrollOffset,
+      // TODO(abarth): Support horizontal offsets. For horizontally scrolling
+      // grids. For horizontally scrolling grids, we'll probably need to use a
+      // delegate that places children in column-major order.
+      scrollDirection: Axis.vertical,
+      onScrollStart: onScrollStart,
+      onScroll: onScroll,
+      onScrollEnd: onScrollEnd,
+      snapOffsetCallback: snapOffsetCallback,
+      builder: _buildContent
+    );
+  }
+}
 
 /// A vertically scrollable grid.
 ///
 /// Requires that delegate places its children in row-major order.
+/*
 class ScrollableGrid extends Scrollable {
   ScrollableGrid({
     Key key,
@@ -72,6 +157,7 @@ class _ScrollableGridState extends ScrollableState<ScrollableGrid> {
     );
   }
 }
+*/
 
 class GridViewport extends VirtualViewportFromIterable {
   GridViewport({

--- a/packages/flutter/lib/src/widgets/scrollable_grid.dart
+++ b/packages/flutter/lib/src/widgets/scrollable_grid.dart
@@ -11,6 +11,9 @@ import 'framework.dart';
 import 'scrollable.dart';
 import 'virtual_viewport.dart';
 
+/// A vertically scrollable grid.
+///
+/// Requires that delegate places its children in row-major order.
 class ScrollableGrid extends StatelessWidget {
   ScrollableGrid({
     Key key,
@@ -95,69 +98,6 @@ class ScrollableGrid extends StatelessWidget {
     );
   }
 }
-
-/// A vertically scrollable grid.
-///
-/// Requires that delegate places its children in row-major order.
-/*
-class ScrollableGrid extends Scrollable {
-  ScrollableGrid({
-    Key key,
-    double initialScrollOffset,
-    ScrollListener onScrollStart,
-    ScrollListener onScroll,
-    ScrollListener onScrollEnd,
-    SnapOffsetCallback snapOffsetCallback,
-    this.delegate,
-    this.children
-  }) : super(
-    key: key,
-    initialScrollOffset: initialScrollOffset,
-    // TODO(abarth): Support horizontal offsets. For horizontally scrolling
-    // grids. For horizontally scrolling grids, we'll probably need to use a
-    // delegate that places children in column-major order.
-    scrollDirection: Axis.vertical,
-    onScrollStart: onScrollStart,
-    onScroll: onScroll,
-    onScrollEnd: onScrollEnd,
-    snapOffsetCallback: snapOffsetCallback
-  );
-
-  final GridDelegate delegate;
-  final Iterable<Widget> children;
-
-  @override
-  ScrollableState createState() => new _ScrollableGridState();
-}
-
-class _ScrollableGridState extends ScrollableState<ScrollableGrid> {
-  @override
-  ExtentScrollBehavior createScrollBehavior() => new OverscrollBehavior();
-
-  @override
-  ExtentScrollBehavior get scrollBehavior => super.scrollBehavior;
-
-  void _handleExtentsChanged(double contentExtent, double containerExtent) {
-    setState(() {
-      didUpdateScrollBehavior(scrollBehavior.updateExtents(
-        contentExtent: contentExtent,
-        containerExtent: containerExtent,
-        scrollOffset: scrollOffset
-      ));
-    });
-  }
-
-  @override
-  Widget buildContent(BuildContext context) {
-    return new GridViewport(
-      startOffset: scrollOffset,
-      delegate: config.delegate,
-      onExtentsChanged: _handleExtentsChanged,
-      children: config.children
-    );
-  }
-}
-*/
 
 class GridViewport extends VirtualViewportFromIterable {
   GridViewport({

--- a/packages/flutter/test/widget/remember_scroll_position_test.dart
+++ b/packages/flutter/test/widget/remember_scroll_position_test.dart
@@ -46,7 +46,7 @@ void main() {
     expect(find.text('10'), findsNothing);
     expect(find.text('100'), findsNothing);
 
-    ScrollableState targetState = tester.state(find.byType(ScrollableLazyList));
+    ScrollableState targetState = tester.state(find.byType(Scrollable));
     targetState.scrollTo(1000.0);
     await tester.pump(new Duration(seconds: 1));
 

--- a/packages/flutter/test/widget/scroll_events_test.dart
+++ b/packages/flutter/test/widget/scroll_events_test.dart
@@ -7,7 +7,7 @@ import 'package:flutter/widgets.dart';
 
 Widget _buildScroller({Key key, List<String> log}) {
   return new ScrollableViewport(
-    key: key,
+    scrollableKey: key,
     onScrollStart: (double scrollOffset) {
       log.add('scrollstart');
     },

--- a/packages/flutter/test/widget/scroll_interaction_test.dart
+++ b/packages/flutter/test/widget/scroll_interaction_test.dart
@@ -13,8 +13,8 @@ void main() {
       ]
     ));
 
-    ScrollableState<ScrollableViewport> scrollable =
-        tester.state/*<ScrollableState<ScrollableViewport>>*/(find.byType(ScrollableViewport));
+    ScrollableState scrollable =
+      tester.state/*<ScrollableState>*/(find.byType(Scrollable));
 
     expect(scrollable.scrollOffset, equals(0.0));
 

--- a/packages/flutter/test/widget/scrollable_lazy_list_test.dart
+++ b/packages/flutter/test/widget/scrollable_lazy_list_test.dart
@@ -75,10 +75,10 @@ void main() {
       return result;
     };
 
-    GlobalKey<ScrollableState<ScrollableLazyList>> scrollableKey = new GlobalKey<ScrollableState<ScrollableLazyList>>();
+    GlobalKey<ScrollableState> scrollableKey = new GlobalKey<ScrollableState>();
     FlipWidget testWidget = new FlipWidget(
       left: new ScrollableLazyList(
-        key: scrollableKey,
+        scrollableKey: scrollableKey,
         itemBuilder: itemBuilder,
         itemExtent: 200.0,
         initialScrollOffset: 300.0
@@ -123,10 +123,10 @@ void main() {
       return result;
     };
 
-    GlobalKey<ScrollableState<ScrollableLazyList>> scrollableKey = new GlobalKey<ScrollableState<ScrollableLazyList>>();
+    GlobalKey<ScrollableState> scrollableKey = new GlobalKey<ScrollableState>();
     FlipWidget testWidget = new FlipWidget(
       left: new ScrollableLazyList(
-        key: scrollableKey,
+        scrollableKey: scrollableKey,
         itemBuilder: itemBuilder,
         itemExtent: 200.0,
         initialScrollOffset: 300.0,
@@ -167,9 +167,9 @@ void main() {
       return result;
     };
 
-    GlobalKey<ScrollableState<ScrollableLazyList>> scrollableKey = new GlobalKey<ScrollableState<ScrollableLazyList>>();
+    GlobalKey<ScrollableState> scrollableKey = new GlobalKey<ScrollableState>();
     Widget testWidget = new ScrollableLazyList(
-      key: scrollableKey,
+      scrollableKey: scrollableKey,
       itemBuilder: itemBuilder,
       itemExtent: 300.0,
       itemCount: 10

--- a/packages/flutter/test/widget/snap_scrolling_test.dart
+++ b/packages/flutter/test/widget/snap_scrolling_test.dart
@@ -29,7 +29,7 @@ Widget buildFrame() {
     child: new Container(
       height: itemExtent * 2.0,
       child: new ScrollableList(
-        key: scrollableListKey,
+        scrollableKey: scrollableListKey,
         snapOffsetCallback: snapOffsetCallback,
         scrollDirection: scrollDirection,
         itemExtent: itemExtent,


### PR DESCRIPTION
Most Scrollable subclasses can now be redefined using composition instead of subclassing. This will simplify defining an InheritedWidget that supplies ScrollBehaviors and Scrollable wrappers, like Scrollbars and OverscrollIndicators.
- Scrollable and ScrollableState are no longer abstract.
- Scrollable now has a builder parameter whose value is a ScrollBuilder. The Scrollable's 'buildContent()' method calls the builder by default.

```
Widget ScrollBuilder(BuildContext context, ScrollableState state);
```
- The type of ScrollableState's ScrollBehavior property is now an ExtentScrollbehavior. All of the existing Scrollable subclasses essentially did this already.
- For now, ScrollableState defines `createScrollBehavior()`; it returns an `OverscrollWhenScrollableBehavior()`. In the future it will delegate to the inherited scroll configuration widget.
- LazyBlock, ScrollableList, ScrollableLazyList, ScrollableViewport and ScrollableGrid now have-a Scrollable.
- I haven't really added documentation however it was necessary to copy the existing documentation for Scrollable fields that are now just delegated to.
