### PR TITLE
Remove redundant type annotation lint.

### DIFF
--- a/packages/flutter_tools/flutter_analysis_options
+++ b/packages/flutter_tools/flutter_analysis_options
@@ -50,7 +50,6 @@ linter:
     - sort_constructors_first
     - sort_unnamed_constructors_first
     - super_goes_last
-    - type_annotate_public_apis # subset of always_specify_types
     - type_init_formals
     - unnecessary_brace_in_string_interp
     - unnecessary_getters_setters


### PR DESCRIPTION
Since this is a subset of `always_specify_types` or `always_declare_return_types` I think we can safely remove it.

In practice, if you violate you get doubly nagged.

```
[lint] Type annotate public APIs. (packages/flutter_tools/lib/src/dart/runner.dart, line 5, col 1)
[lint] Declare method return types. (packages/flutter_tools/lib/src/dart/runner.dart, line 5, col 1)
```

One warning is probably enough to get the message across? ;)

cc @Hixie
