### PR TITLE
Update to new analyzer and linter.

### DIFF
--- a/packages/flutter_test/pubspec.yaml
+++ b/packages/flutter_test/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
   # We don't actually depend on 'analyzer', but 'test' and 'flutter_tools' do.
   # We pin the version of analyzer we depend on to avoid version skew across our
   # packages.
-  analyzer: 0.27.4-alpha.6
+  analyzer: 0.27.4-alpha.1
 
   flutter:
     path: ../flutter

--- a/packages/flutter_test/pubspec.yaml
+++ b/packages/flutter_test/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
   # We don't actually depend on 'analyzer', but 'test' and 'flutter_tools' do.
   # We pin the version of analyzer we depend on to avoid version skew across our
   # packages.
-  analyzer: 0.27.4-alpha.1
+  analyzer: 0.27.4-alpha.6
 
   flutter:
     path: ../flutter

--- a/packages/flutter_tools/pubspec.yaml
+++ b/packages/flutter_tools/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
   http: ^0.11.3
   json_rpc_2: ^2.0.0
   json_schema: ^1.0.3
-  linter: ^0.1.15
+  linter: ^0.1.17
   mustache4dart: ^1.0.0
   package_config: ^0.1.3
   path: ^1.3.0
@@ -35,7 +35,7 @@ dependencies:
   test: 0.12.13+1
 
   # Pinned in flutter_test as well.
-  analyzer: 0.27.4-alpha.1
+  analyzer: 0.27.4-alpha.6
 
 dev_dependencies:
   mockito: ^0.11.0

--- a/packages/flutter_tools/pubspec.yaml
+++ b/packages/flutter_tools/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
   http: ^0.11.3
   json_rpc_2: ^2.0.0
   json_schema: ^1.0.3
-  linter: ^0.1.17
+  linter: ^0.1.15
   mustache4dart: ^1.0.0
   package_config: ^0.1.3
   path: ^1.3.0
@@ -35,7 +35,7 @@ dependencies:
   test: 0.12.13+1
 
   # Pinned in flutter_test as well.
-  analyzer: 0.27.4-alpha.6
+  analyzer: 0.27.4-alpha.1
 
 dev_dependencies:
   mockito: ^0.11.0


### PR DESCRIPTION
Notably, this will allow us to play with
- the fixed `public_member_api_docs` that now checks for documented getters when checking setters (dart-lang/sdk#57328), and
- the new `comment_references` lint that ensures identifiers referenced in docs are in scope (dart-lang/sdk#57330).
