### PR TITLE
Tabs and scrolling has odd card text

### DIFF
--- a/examples/flutter_gallery/lib/demo/tabs_demo.dart
+++ b/examples/flutter_gallery/lib/demo/tabs_demo.dart
@@ -68,7 +68,7 @@ class TabsDemoState extends State<TabsDemo> {
                   height: 192.0,
                   child: new Card(
                     child: new Center(
-                      child: new Text('Tab $page.label, item $i')
+                      child: new Text('Tab ${page.label}, item $i')
                     )
                   )
                 );

--- a/packages/flutter/lib/src/widgets/scrollable.dart
+++ b/packages/flutter/lib/src/widgets/scrollable.dart
@@ -854,7 +854,7 @@ class Block extends StatelessWidget {
     if (padding != null)
       contents = new Padding(padding: padding, child: contents);
     return new ScrollableViewport(
-      key: scrollableKey,
+      scrollableKey: scrollableKey,
       initialScrollOffset: initialScrollOffset,
       scrollDirection: scrollDirection,
       scrollAnchor: scrollAnchor,


### PR DESCRIPTION
Looks like our intent here was to show the tab label rather than
"Instance of '_Page'".

Also, fix an issue where the scrollableKey wasn't being forwarded to the
actual scrollable.

Fixes #3090
