### PR TITLE
Cleanup dangling comment references.

### DIFF
--- a/packages/flutter_markdown/lib/src/markdown_style.dart
+++ b/packages/flutter_markdown/lib/src/markdown_style.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:flutter/material.dart';
+import 'markdown.dart';
 import 'markdown_style_raw.dart';
 
 /// Style used for rendering markdown formatted text using the [MarkdownBody]

--- a/packages/flutter_markdown/lib/src/markdown_style_raw.dart
+++ b/packages/flutter_markdown/lib/src/markdown_style_raw.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:flutter/widgets.dart';
+import 'markdown.dart';
 
 /// Style used for rendering markdown formatted text using the [MarkdownBody]
 /// widget.

--- a/packages/flutter_sprites/lib/src/constraint.dart
+++ b/packages/flutter_sprites/lib/src/constraint.dart
@@ -5,8 +5,8 @@ part of flutter_sprites;
 /// constraints property.
 ///
 /// Constrains are applied after the update calls are
-/// completed. They can also be applied at any time by calling a [Node]'s
-/// [applyConstraints] method. It's possible to create custom constraints by
+/// completed. They can also be applied at any time by calling
+/// [Node.applyConstraints]. It's possible to create custom constraints by
 /// overriding this class and implementing the [constrain] method.
 abstract class Constraint {
   /// Called before the node's update method is called. This method can be

--- a/packages/flutter_tools/lib/executable.dart
+++ b/packages/flutter_tools/lib/executable.dart
@@ -42,7 +42,7 @@ import 'src/runner/flutter_command_runner.dart';
 
 /// Main entry point for commands.
 ///
-/// This function is intended to be used from the [flutter] command line tool.
+/// This function is intended to be used from the `flutter` command line tool.
 Future<Null> main(List<String> args) async {
   bool help = args.contains('-h') || args.contains('--help');
   bool verbose = args.contains('-v') || args.contains('--verbose');

--- a/packages/flutter_tools/lib/src/device.dart
+++ b/packages/flutter_tools/lib/src/device.dart
@@ -247,7 +247,7 @@ class DebuggingOptions {
   bool get hasObservatoryPort => observatoryPort != null;
 
   /// Return the user specified observatory port. If that isn't available,
-  /// return [defaultObservatoryPort], or a port close to that one.
+  /// return [kDefaultObservatoryPort], or a port close to that one.
   Future<int> findBestObservatoryPort() {
     if (hasObservatoryPort)
       return new Future<int>.value(observatoryPort);
@@ -257,7 +257,7 @@ class DebuggingOptions {
   bool get hasDiagnosticPort => diagnosticPort != null;
 
   /// Return the user specified diagnostic port. If that isn't available,
-  /// return [defaultObservatoryPort], or a port close to that one.
+  /// return [kDefaultDiagnosticPort], or a port close to that one.
   Future<int> findBestDiagnosticPort() {
     return findPreferredPort(diagnosticPort ?? kDefaultDiagnosticPort);
   }


### PR DESCRIPTION
Quick pass at fixing a few dangling references as revealed by the new `comment_references` lint (https://github.com/dart-lang/sdk/issues/57330).

There's a bunch more to do here before we can turn it on by default (~430 lints as of now).  Many of them are a simple matter of adding an import (e.g., `dart:async` for library docs that reference `Future`) but others will require a bit of thought.  Probably best done by the folks writing the code. :)
