### PR TITLE
Fix analyzer field overrides.

### DIFF
--- a/packages/flutter_tools/lib/src/dart/analysis.dart
+++ b/packages/flutter_tools/lib/src/dart/analysis.dart
@@ -196,8 +196,13 @@ class AnalysisErrorDescription {
 }
 
 class DriverOptions extends AnalysisOptionsImpl {
-  @override
-  int cacheSize = 512;
+
+  DriverOptions() {
+    // Set defaults.
+    cacheSize = 512;
+    lint = true;
+    generateSdkErrors = false;
+  }
 
   /// The path to the dart SDK.
   String dartSdkPath;
@@ -211,14 +216,8 @@ class DriverOptions extends AnalysisOptionsImpl {
   /// The path to analysis options.
   String analysisOptionsFile;
 
-  @override
-  bool generateSdkErrors = false;
-
   /// Analysis options map.
   Map<Object, Object> analysisOptions;
-
-  @override
-  bool lint = true;
 
   /// Out sink for logging.
   IOSink outSink = stdout;


### PR DESCRIPTION
Cleans up 3 of the 4 violations of the `overriden_field` lint.

The last one is more interesting and I'll defer to someone closer to that code:

```
[lint] Do not override fields. (packages/flutter/test/rendering/rendering_tester.dart, line 91, col 14)
```

cc @Hixie 
