### PR TITLE
Enable the gallery smoke test

### DIFF
--- a/examples/flutter_gallery/test/smoke_test.dart
+++ b/examples/flutter_gallery/test/smoke_test.dart
@@ -98,5 +98,5 @@ void main() {
     await tester.tap(find.text('Light'));
     await tester.pump();
     await tester.pump(const Duration(seconds: 1)); // Wait until it's changed.
-  }, skip: true);
+  });
 }


### PR DESCRIPTION
With the new test infrastructure, I've been able to run the smoke test more than 70x without a hang. So I'm unskipping it.

Fixes #3735
