### PR TITLE
Wire up ios-profile and ios-release. Switching between debug, profile and release starts the build process from scratch.

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_device.dart
+++ b/packages/flutter_tools/lib/src/android/android_device.dart
@@ -325,7 +325,8 @@ class AndroidDevice extends Device {
 
   @override
   Future<LaunchResult> startApp(
-    ApplicationPackage package, {
+    ApplicationPackage package,
+    BuildMode mode, {
     String mainPath,
     String route,
     DebuggingOptions debuggingOptions,

--- a/packages/flutter_tools/lib/src/build_info.dart
+++ b/packages/flutter_tools/lib/src/build_info.dart
@@ -60,7 +60,7 @@ String getNameForTargetPlatform(TargetPlatform platform) {
     case TargetPlatform.android_x86:
       return 'android-x86';
     case TargetPlatform.ios:
-      return 'ios_release';
+      return 'ios';
     case TargetPlatform.darwin_x64:
       return 'darwin-x64';
     case TargetPlatform.linux_x64:

--- a/packages/flutter_tools/lib/src/cache.dart
+++ b/packages/flutter_tools/lib/src/cache.dart
@@ -210,7 +210,7 @@ class FlutterEngine {
     ];
 
     if (Platform.isMacOS)
-      dirs.add('ios_release');
+      dirs.addAll(<String>['ios', 'ios-profile', 'ios-release']);
     else if (Platform.isLinux)
       dirs.add('linux-x64');
 

--- a/packages/flutter_tools/lib/src/commands/build_ios.dart
+++ b/packages/flutter_tools/lib/src/commands/build_ios.dart
@@ -12,6 +12,7 @@ import '../runner/flutter_command.dart';
 
 class BuildIOSCommand extends FlutterCommand {
   BuildIOSCommand() {
+    addBuildModeFlags();
     argParser.addFlag('simulator', help: 'Build for the iOS simulator instead of the device.');
     argParser.addFlag('codesign', negatable: true, defaultsTo: true,
         help: 'Codesign the application bundle (only available on device builds).');
@@ -49,8 +50,9 @@ class BuildIOSCommand extends FlutterCommand {
 
     printStatus('Building $app for $logTarget...');
 
-    bool result = await buildIOSXcodeProject(app,
-        buildForDevice: !forSimulator, codesign: shouldCodesign);
+    bool result = await buildIOSXcodeProject(app, getBuildMode(),
+        buildForDevice: !forSimulator,
+        codesign: shouldCodesign);
 
     if (!result) {
       printError('Encountered error while building for $logTarget.');

--- a/packages/flutter_tools/lib/src/commands/drive.dart
+++ b/packages/flutter_tools/lib/src/commands/drive.dart
@@ -266,6 +266,7 @@ Future<int> startApp(DriveCommand command, BuildMode buildMode) async {
   printTrace('Starting application.');
   LaunchResult result = await command.device.startApp(
     package,
+    buildMode,
     mainPath: mainPath,
     route: command.route,
     debuggingOptions: new DebuggingOptions.enabled(

--- a/packages/flutter_tools/lib/src/commands/run.dart
+++ b/packages/flutter_tools/lib/src/commands/run.dart
@@ -215,6 +215,7 @@ Future<int> startApp(
 
   LaunchResult result = await device.startApp(
     package,
+    buildMode,
     mainPath: mainPath,
     route: route,
     debuggingOptions: debuggingOptions,
@@ -359,6 +360,7 @@ class _RunAndStayResident {
 
     LaunchResult result = await device.startApp(
       package,
+      buildMode,
       mainPath: mainPath,
       debuggingOptions: debuggingOptions,
       platformArgs: platformArgs

--- a/packages/flutter_tools/lib/src/device.dart
+++ b/packages/flutter_tools/lib/src/device.dart
@@ -175,9 +175,10 @@ abstract class Device {
   /// Start an app package on the current device.
   ///
   /// [platformArgs] allows callers to pass platform-specific arguments to the
-  /// start call.
+  /// start call. The build mode is not used by all platforms.
   Future<LaunchResult> startApp(
-    ApplicationPackage package, {
+    ApplicationPackage package,
+    BuildMode mode, {
     String mainPath,
     String route,
     DebuggingOptions debuggingOptions,

--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -153,7 +153,8 @@ class IOSDevice extends Device {
 
   @override
   Future<LaunchResult> startApp(
-    ApplicationPackage app, {
+    ApplicationPackage app,
+    BuildMode mode, {
     String mainPath,
     String route,
     DebuggingOptions debuggingOptions,
@@ -163,8 +164,8 @@ class IOSDevice extends Device {
     // TODO(devoncarew): Handle startPaused, debugPort.
     printTrace('Building ${app.name} for $id');
 
-    // Step 1: Install the precompiled application if necessary.
-    bool buildResult = await buildIOSXcodeProject(app, buildForDevice: true);
+    // Step 1: Install the precompiled/DBC application if necessary.
+    bool buildResult = await buildIOSXcodeProject(app, mode, buildForDevice: true);
     if (!buildResult) {
       printError('Could not build the precompiled application for the device.');
       return new LaunchResult.failed();

--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -11,6 +11,7 @@ import 'package:path/path.dart' as path;
 import '../application_package.dart';
 import '../base/context.dart';
 import '../base/process.dart';
+import '../build_info.dart';
 import '../cache.dart';
 import '../globals.dart';
 import '../services.dart';
@@ -96,13 +97,13 @@ bool _xcodeVersionCheckValid(int major, int minor) {
   return false;
 }
 
-Future<bool> buildIOSXcodeProject(ApplicationPackage app,
+Future<bool> buildIOSXcodeProject(ApplicationPackage app, BuildMode mode,
     { bool buildForDevice, bool codesign: true }) async {
   String flutterProjectPath = Directory.current.path;
 
-  if (xcodeProjectRequiresUpdate()) {
+  if (xcodeProjectRequiresUpdate(mode)) {
     printTrace('Initializing the Xcode project.');
-    if ((await setupXcodeProjectHarness(flutterProjectPath)) != 0) {
+    if ((await setupXcodeProjectHarness(flutterProjectPath, mode)) != 0) {
       printError('Could not initialize the Xcode project.');
       return false;
     }
@@ -200,7 +201,9 @@ bool _validateEngineRevision(ApplicationPackage app) {
 String _getIOSEngineRevision(ApplicationPackage app) {
   File revisionFile = new File(path.join(app.localPath, 'REVISION'));
   if (revisionFile.existsSync()) {
-    return revisionFile.readAsStringSync().trim();
+    // The format is 'REVISION-mode'. We only need the revision.
+    String revisionStamp = revisionFile.readAsStringSync().trim();
+    return revisionStamp.split('-')[0];
   } else {
     return null;
   }

--- a/packages/flutter_tools/lib/src/ios/simulators.dart
+++ b/packages/flutter_tools/lib/src/ios/simulators.dart
@@ -433,7 +433,8 @@ class IOSSimulator extends Device {
 
   @override
   Future<LaunchResult> startApp(
-    ApplicationPackage app, {
+    ApplicationPackage app,
+    BuildMode mode, {
     String mainPath,
     String route,
     DebuggingOptions debuggingOptions,
@@ -531,7 +532,8 @@ class IOSSimulator extends Device {
 
   Future<bool> _buildAndInstallApplicationBundle(ApplicationPackage app) async {
     // Step 1: Build the Xcode project.
-    bool buildResult = await buildIOSXcodeProject(app, buildForDevice: false);
+    // The build mode for the simulator is always debug.
+    bool buildResult = await buildIOSXcodeProject(app, BuildMode.debug, buildForDevice: false);
     if (!buildResult) {
       printError('Could not build the application for the simulator.');
       return false;


### PR DESCRIPTION
The revision stamp file now includes the variant being built at that revision. If that changes (or the revision itself is updated), the entire process starts over.
