### PR TITLE
Prefer getAdbPath(androidSdk) over androidSdk.adbPath

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_device.dart
+++ b/packages/flutter_tools/lib/src/android/android_device.dart
@@ -17,6 +17,7 @@ import '../globals.dart';
 import '../protocol_discovery.dart';
 import 'adb.dart';
 import 'android.dart';
+import 'android_sdk.dart';
 
 const String _defaultAdbPath = 'adb';
 
@@ -104,7 +105,7 @@ class AndroidDevice extends Device {
   _AndroidDevicePortForwarder _portForwarder;
 
   List<String> adbCommandForDevice(List<String> args) {
-    return <String>[androidSdk.adbPath, '-s', id]..addAll(args);
+    return <String>[getAdbPath(androidSdk), '-s', id]..addAll(args);
   }
 
   bool _isValidAdbVersion(String adbVersion) {
@@ -135,10 +136,10 @@ class AndroidDevice extends Device {
       return false;
 
     try {
-      String adbVersion = runCheckedSync(<String>[androidSdk.adbPath, 'version']);
+      String adbVersion = runCheckedSync(<String>[getAdbPath(androidSdk), 'version']);
       if (_isValidAdbVersion(adbVersion))
         return true;
-      printError('The ADB at "${androidSdk.adbPath}" is too old; please install version 1.0.32 or later.');
+      printError('The ADB at "${getAdbPath(androidSdk)}" is too old; please install version 1.0.32 or later.');
     } catch (error, trace) {
       printError('Error running ADB: $error', trace);
     }
@@ -152,7 +153,7 @@ class AndroidDevice extends Device {
       // output lines like this, which we want to ignore:
       //   adb server is out of date.  killing..
       //   * daemon started successfully *
-      runCheckedSync(<String>[androidSdk.adbPath, 'start-server']);
+      runCheckedSync(<String>[getAdbPath(androidSdk), 'start-server']);
 
       // Sample output: '22'
       String sdkVersion = _getProperty('ro.build.version.sdk');

--- a/packages/flutter_tools/lib/src/android/android_sdk.dart
+++ b/packages/flutter_tools/lib/src/android/android_sdk.dart
@@ -29,6 +29,9 @@ const Map<String, int> _namedVersionMap = const <String, int> {
 };
 
 /// Locate ADB. Prefer to use one from an Android SDK, if we can locate that.
+/// This should be used over accessing androidSdk.adbPath directly because it
+/// will work for those users who have Android Platform Tools installed but
+/// not the full SDK.
 String getAdbPath([AndroidSdk existingSdk]) {
   if (existingSdk?.adbPath != null)
     return existingSdk.adbPath;


### PR DESCRIPTION
For developers with the platform tools installed but no SDK, it prevents
crashing in the flutter tool in favor of more user-friendly error messages
downstream.
