### PR TITLE
remove old command aliases

### DIFF
--- a/packages/flutter_tools/lib/src/cache.dart
+++ b/packages/flutter_tools/lib/src/cache.dart
@@ -269,8 +269,7 @@ class FlutterEngine {
     for (String pkgName in _getPackageDirs()) {
       Directory dir = new Directory(path.join(pkgDir.path, pkgName));
       if (!dir.existsSync() || allDirty) {
-        await _downloadItem('Downloading engine package $pkgName...',
-          url + pkgName + '.zip', pkgDir);
+        await _downloadItem('Downloading package $pkgName...', url + pkgName + '.zip', pkgDir);
       }
     }
 
@@ -288,8 +287,7 @@ class FlutterEngine {
       String urlPath = toolsDir[1];
       Directory dir = new Directory(path.join(engineDir.path, cacheDir));
       if (!dir.existsSync() || allDirty) {
-        await _downloadItem('Downloading engine tools $cacheDir...',
-          url + urlPath, dir);
+        await _downloadItem('Downloading $cacheDir tools...', url + urlPath, dir);
         _makeFilesExecutable(dir);
       }
     }

--- a/packages/flutter_tools/lib/src/commands/create.dart
+++ b/packages/flutter_tools/lib/src/commands/create.dart
@@ -42,9 +42,6 @@ class CreateCommand extends FlutterCommand {
     'If run on a project that already exists, this will repair the project, recreating any files that are missing.';
 
   @override
-  final List<String> aliases = <String>['init'];
-
-  @override
   bool get requiresProjectRoot => false;
 
   @override

--- a/packages/flutter_tools/lib/src/commands/devices.dart
+++ b/packages/flutter_tools/lib/src/commands/devices.dart
@@ -17,9 +17,6 @@ class DevicesCommand extends FlutterCommand {
   final String description = 'List all connected devices.';
 
   @override
-  final List<String> aliases = <String>['list'];
-
-  @override
   bool get requiresProjectRoot => false;
 
   @override

--- a/packages/flutter_tools/lib/src/commands/run.dart
+++ b/packages/flutter_tools/lib/src/commands/run.dart
@@ -45,9 +45,6 @@ class RunCommand extends RunCommandBase {
   @override
   final String description = 'Run your Flutter app on an attached device.';
 
-  @override
-  final List<String> aliases = <String>['start'];
-
   RunCommand() {
     argParser.addFlag('full-restart',
         defaultsTo: true,

--- a/packages/flutter_tools/templates/create/.atom/launches.tmpl/main.yaml.tmpl
+++ b/packages/flutter_tools/templates/create/.atom/launches.tmpl/main.yaml.tmpl
@@ -3,8 +3,9 @@ type: flutter
 path: lib/main.dart
 
 flutter:
-  checked: true
+  # Enable or disable debugging.
   debug: true
+  # The starting route for the app.
   route:
-  # Additional args for the flutter run command:
+  # Additional args for the flutter run command.
   args:


### PR DESCRIPTION
- remove old command aliases
- remove the checked mode option from the launch config file that `flutter create` creates
- some text changes to make the output from `flutter precache` line up vertically
