### PR TITLE
warn when flutter doesn't match the pubspec version

### DIFF
--- a/packages/flutter_tools/lib/src/dart/package_map.dart
+++ b/packages/flutter_tools/lib/src/dart/package_map.dart
@@ -7,7 +7,7 @@ import 'dart:io';
 import 'package:package_config/packages_file.dart' as packages_file;
 import 'package:path/path.dart' as path;
 
-const String _kPackages = '.packages';
+const String kPackagesFileName = '.packages';
 
 Map<String, Uri> _parse(String packagesPath) {
   List<int> source = new File(packagesPath).readAsBytesSync();

--- a/packages/flutter_tools/lib/src/flx.dart
+++ b/packages/flutter_tools/lib/src/flx.dart
@@ -15,8 +15,8 @@ import 'package:yaml/yaml.dart';
 import 'base/file_system.dart' show ensureDirectoryExists;
 import 'base/process.dart';
 import 'cache.dart';
+import 'dart/package_map.dart';
 import 'globals.dart';
-import 'package_map.dart';
 import 'toolchain.dart';
 import 'zip.dart';
 

--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -9,11 +9,11 @@ import 'package:args/command_runner.dart';
 
 import '../application_package.dart';
 import '../build_info.dart';
+import '../dart/package_map.dart';
 import '../dart/pub.dart';
 import '../device.dart';
 import '../flx.dart' as flx;
 import '../globals.dart';
-import '../package_map.dart';
 import '../usage.dart';
 import 'flutter_command_runner.dart';
 

--- a/packages/flutter_tools/lib/src/services.dart
+++ b/packages/flutter_tools/lib/src/services.dart
@@ -9,8 +9,8 @@ import 'dart:io';
 import 'package:path/path.dart' as path;
 import 'package:yaml/yaml.dart';
 
+import 'dart/package_map.dart';
 import 'globals.dart';
-import 'package_map.dart';
 
 const String _kFlutterManifestPath = 'flutter.yaml';
 const String _kFlutterServicesManifestPath = 'flutter_services.yaml';

--- a/packages/flutter_tools/lib/src/test/flutter_platform.dart
+++ b/packages/flutter_tools/lib/src/test/flutter_platform.dart
@@ -14,7 +14,7 @@ import 'package:test/src/backend/test_platform.dart'; // ignore: implementation_
 import 'package:test/src/runner/plugin/platform.dart'; // ignore: implementation_imports
 import 'package:test/src/runner/plugin/hack_register_platform.dart' as hack; // ignore: implementation_imports
 
-import '../package_map.dart';
+import '../dart/package_map.dart';
 
 final String _kSkyShell = Platform.environment['SKY_SHELL'];
 const String _kHost = '127.0.0.1';


### PR DESCRIPTION
Recognize when the flutter currently running is not the same as the one referenced in the project's pubspec; hard stop the flutter_tools process if that's the case (fix https://github.com/flutter/flutter/issues/4084).
