### PR TITLE
Correct layout in the flexible_space_demo.dart

### DIFF
--- a/examples/flutter_gallery/lib/demo/flexible_space_demo.dart
+++ b/examples/flutter_gallery/lib/demo/flexible_space_demo.dart
@@ -47,9 +47,11 @@ class _ContactItem extends StatelessWidget {
     columnChildren.add(new Text(lines.last, style: Theme.of(context).textTheme.caption));
 
     List<Widget> rowChildren = <Widget>[
-      new Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: columnChildren
+      new Flexible(
+        child: new Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: columnChildren
+        )
       )
     ];
     if (icon != null) {


### PR DESCRIPTION
The Column that contains a _ContactItem's lines of text needs to be wrapped with a Flexible widget so that its width is constrained to the available width.

Without the Flexible widget the Row that contains the _ContactItem's Column allows the Column to occupy as much horizontal space as it wants. When one of the Column's Text children got really wide, the Column would overflow the available space - rather than wrapping. With the Flexible widget the Column's width is constrained to whatever space is left after allocating space for the rest of the Row's elements.
