### PR TITLE
fail flutter analyze when there are errors

### DIFF
--- a/packages/flutter_tools/lib/src/commands/analyze.dart
+++ b/packages/flutter_tools/lib/src/commands/analyze.dart
@@ -347,7 +347,7 @@ class AnalyzeCommand extends FlutterCommand {
 
       if (firstAnalysis && _isBenchmarking) {
         _writeBenchmark(analysisTimer, issueCount, -1); // TODO(ianh): track members missing dartdocs instead of saying -1
-        server.dispose().then((_) => exit(0));
+        server.dispose().then((_) => exit(issueCount > 0 ? 1 : 0));
       }
 
       firstAnalysis = false;


### PR DESCRIPTION
When running `flutter analyze --watch --benchmark`, return the appropriate exit code if there are analysis errors.
