### PR TITLE
Teach flutter to build app.a

### DIFF
--- a/packages/flutter_tools/lib/src/commands/build_apk.dart
+++ b/packages/flutter_tools/lib/src/commands/build_apk.dart
@@ -513,7 +513,7 @@ Future<int> buildAndroid(
 
   // Build an AOT snapshot if needed.
   if (isAotBuildMode(buildMode) && aotPath == null) {
-    aotPath = buildAotSnapshot(findMainDartFile(target), buildMode);
+    aotPath = buildAotSnapshot(findMainDartFile(target), platform, buildMode);
     if (aotPath == null) {
       printError('Failed to build AOT snapshot');
       return 1;


### PR DESCRIPTION
On iOS, we use Xcode to build a static library that contains the precompiled
code. This code is currently unused, but it will be used by the new Xcode
harness to factor out as much complexity as possible into the flutter tool.
