### PR TITLE
TabPageSelector demo: use chevron icons instead of arrows

### DIFF
--- a/examples/flutter_gallery/lib/demo/page_selector_demo.dart
+++ b/examples/flutter_gallery/lib/demo/page_selector_demo.dart
@@ -39,14 +39,14 @@ class PageSelectorDemo extends StatelessWidget {
                   child: new Row(
                     children: <Widget>[
                       new IconButton(
-                        icon: Icons.arrow_back,
+                        icon: Icons.chevron_left,
                         color: color,
                         onPressed: () { _handleArrowButtonPress(context, -1); },
                         tooltip: 'Page back'
                       ),
                       new TabPageSelector<IconData>(),
                       new IconButton(
-                        icon: Icons.arrow_forward,
+                        icon: Icons.chevron_right,
                         color: color,
                         onPressed: () { _handleArrowButtonPress(context, 1); },
                         tooltip: 'Page forward'


### PR DESCRIPTION
Fixes #4143
