### PR TITLE
Let flutter build aot select a target platform

### DIFF
--- a/packages/flutter_tools/lib/src/build_info.dart
+++ b/packages/flutter_tools/lib/src/build_info.dart
@@ -69,6 +69,24 @@ String getNameForTargetPlatform(TargetPlatform platform) {
   assert(false);
 }
 
+TargetPlatform getTargetPlatformForName(String platform) {
+  switch (platform) {
+    case 'android-arm':
+      return TargetPlatform.android_arm;
+    case 'android-x64':
+      return TargetPlatform.android_x64;
+    case 'android-x86':
+      return TargetPlatform.android_x86;
+    case 'ios':
+      return TargetPlatform.ios;
+    case 'darwin-x64':
+      return TargetPlatform.darwin_x64;
+    case 'linux-x64':
+      return TargetPlatform.linux_x64;
+  }
+  return null;
+}
+
 HostPlatform getCurrentHostPlatform() {
   if (Platform.isMacOS)
     return HostPlatform.darwin_x64;

--- a/packages/flutter_tools/lib/src/commands/build_ios.dart
+++ b/packages/flutter_tools/lib/src/commands/build_ios.dart
@@ -22,7 +22,7 @@ class BuildIOSCommand extends FlutterCommand {
   final String name = 'ios';
 
   @override
-  final String description = 'Build an iOS application bundle (Mac OSX host only).';
+  final String description = 'Build an iOS application bundle (Mac OS X host only).';
 
   @override
   Future<int> runInProject() async {
@@ -46,7 +46,7 @@ class BuildIOSCommand extends FlutterCommand {
       printStatus('You will have to manually codesign before deploying to device.');
     }
 
-    String logTarget = forSimulator ? "simulator" : "device";
+    String logTarget = forSimulator ? 'simulator' : 'device';
 
     printStatus('Building $app for $logTarget...');
 


### PR DESCRIPTION
Currently only android-arm and ios are supported target platforms.
