### PR TITLE
iOS tools cleanup

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_device.dart
+++ b/packages/flutter_tools/lib/src/android/android_device.dart
@@ -187,7 +187,7 @@ class AndroidDevice extends Device {
   }
 
   String _getSourceSha1(ApplicationPackage app) {
-    File shaFile = new File('${app.localPath}.sha1');
+    File shaFile = new File('${app.apkPath}.sha1');
     return shaFile.existsSync() ? shaFile.readAsStringSync() : '';
   }
 
@@ -207,15 +207,15 @@ class AndroidDevice extends Device {
 
   @override
   bool installApp(ApplicationPackage app) {
-    if (!FileSystemEntity.isFileSync(app.localPath)) {
-      printError('"${app.localPath}" does not exist.');
+    if (!FileSystemEntity.isFileSync(app.apkPath)) {
+      printError('"${app.apkPath}" does not exist.');
       return false;
     }
 
     if (!_checkForSupportedAdbVersion() || !_checkForSupportedAndroidVersion())
       return false;
 
-    String installOut = runCheckedSync(adbCommandForDevice(<String>['install', '-r', app.localPath]));
+    String installOut = runCheckedSync(adbCommandForDevice(<String>['install', '-r', app.apkPath]));
     RegExp failureExp = new RegExp(r'^Failure.*$', multiLine: true);
     String failure = failureExp.stringMatch(installOut);
     if (failure != null) {

--- a/packages/flutter_tools/lib/src/android/android_device.dart
+++ b/packages/flutter_tools/lib/src/android/android_device.dart
@@ -187,7 +187,8 @@ class AndroidDevice extends Device {
   }
 
   String _getSourceSha1(ApplicationPackage app) {
-    File shaFile = new File('${app.apkPath}.sha1');
+    AndroidApk apk = app;
+    File shaFile = new File('${apk.apkPath}.sha1');
     return shaFile.existsSync() ? shaFile.readAsStringSync() : '';
   }
 
@@ -207,15 +208,16 @@ class AndroidDevice extends Device {
 
   @override
   bool installApp(ApplicationPackage app) {
-    if (!FileSystemEntity.isFileSync(app.apkPath)) {
-      printError('"${app.apkPath}" does not exist.');
+    AndroidApk apk = app;
+    if (!FileSystemEntity.isFileSync(apk.apkPath)) {
+      printError('"${apk.apkPath}" does not exist.');
       return false;
     }
 
     if (!_checkForSupportedAdbVersion() || !_checkForSupportedAndroidVersion())
       return false;
 
-    String installOut = runCheckedSync(adbCommandForDevice(<String>['install', '-r', app.apkPath]));
+    String installOut = runCheckedSync(adbCommandForDevice(<String>['install', '-r', apk.apkPath]));
     RegExp failureExp = new RegExp(r'^Failure.*$', multiLine: true);
     String failure = failureExp.stringMatch(installOut);
     if (failure != null) {

--- a/packages/flutter_tools/lib/src/application_package.dart
+++ b/packages/flutter_tools/lib/src/application_package.dart
@@ -11,6 +11,9 @@ import 'build_info.dart';
 import 'ios/plist_utils.dart';
 
 abstract class ApplicationPackage {
+  /// Path to the package's root folder.
+  final String rootPath;
+
   /// Path to the actual apk or bundle.
   final String localPath;
 
@@ -20,10 +23,11 @@ abstract class ApplicationPackage {
   /// File name of the apk or bundle.
   final String name;
 
-  ApplicationPackage({
-    String localPath,
-    this.id
-  }) : localPath = localPath, name = path.basename(localPath) {
+  ApplicationPackage({String rootPath, String localPath, this.id})
+      : rootPath = rootPath,
+        localPath = localPath,
+        name = path.basename(localPath) {
+    assert(rootPath != null);
     assert(localPath != null);
     assert(id != null);
   }
@@ -39,10 +43,11 @@ class AndroidApk extends ApplicationPackage {
   final String launchActivity;
 
   AndroidApk({
-    String localPath,
+    String androidBuildDir,
+    String androidApkPath,
     String id,
     this.launchActivity
-  }) : super(localPath: localPath, id: id) {
+  }) : super(rootPath: androidBuildDir, localPath: androidApkPath, id: id) {
     assert(launchActivity != null);
   }
 
@@ -71,16 +76,25 @@ class AndroidApk extends ApplicationPackage {
     if (id == null || launchActivity == null)
       return null;
 
-    String localPath = path.join('build', 'app.apk');
-    return new AndroidApk(localPath: localPath, id: id, launchActivity: launchActivity);
+    return new AndroidApk(
+      androidBuildDir: 'build',
+      androidApkPath: path.join('build', 'app.apk'),
+      id: id,
+      launchActivity: launchActivity
+    );
   }
 }
 
 class IOSApp extends ApplicationPackage {
   IOSApp({
     String iosProjectDir,
+    String iosAppPath,
     String iosProjectBundleId
-  }) : super(localPath: iosProjectDir, id: iosProjectBundleId);
+  }) : super(
+    rootPath: iosProjectDir,
+    localPath: iosAppPath,
+    id: iosProjectBundleId
+  );
 
   factory IOSApp.fromCurrentDirectory() {
     if (getCurrentHostPlatform() != HostPlatform.darwin_x64)
@@ -92,7 +106,11 @@ class IOSApp extends ApplicationPackage {
       return null;
 
     String projectDir = path.join('ios', '.generated');
-    return new IOSApp(iosProjectDir: projectDir, iosProjectBundleId: value);
+    return new IOSApp(
+      iosProjectDir: projectDir,
+      iosAppPath: path.join(projectDir, 'build', 'Release-iphoneos', 'Runner.app'),
+      iosProjectBundleId: value
+    );
   }
 
   @override

--- a/packages/flutter_tools/lib/src/application_package.dart
+++ b/packages/flutter_tools/lib/src/application_package.dart
@@ -118,7 +118,7 @@ class IOSApp extends ApplicationPackage {
   String get deviceBundlePath => _buildAppPath('iphoneos');
 
   String _buildAppPath(String type) {
-    return path.join(rootPath, 'build', 'Release-${type}', kBundleName);
+    return path.join(rootPath, 'build', 'Release-$type', kBundleName);
   }
 }
 

--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -6,8 +6,6 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
-import 'package:path/path.dart' as path;
-
 import '../application_package.dart';
 import '../base/os.dart';
 import '../base/process.dart';
@@ -127,7 +125,8 @@ class IOSDevice extends Device {
   @override
   bool installApp(ApplicationPackage app) {
     try {
-      runCheckedSync(<String>[installerPath, '-i', app.deviceBundlePath]);
+      IOSApp iosApp = app;
+      runCheckedSync(<String>[installerPath, '-i', iosApp.deviceBundlePath]);
       return true;
     } catch (e) {
       return false;
@@ -172,7 +171,8 @@ class IOSDevice extends Device {
     }
 
     // Step 2: Check that the application exists at the specified path.
-    Directory bundle = new Directory(app.deviceBundlePath);
+    IOSApp iosApp = app;
+    Directory bundle = new Directory(iosApp.deviceBundlePath);
     bool bundleExists = bundle.existsSync();
     if (!bundleExists) {
       printError('Could not find the built application bundle at ${bundle.path}.');

--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -172,7 +172,7 @@ class IOSDevice extends Device {
     }
 
     // Step 2: Check that the application exists at the specified path.
-    Directory bundle = new Directory(path.join(app.localPath, 'build', 'Release-iphoneos', 'Runner.app'));
+    Directory bundle = new Directory(app.localPath);
     bool bundleExists = bundle.existsSync();
     if (!bundleExists) {
       printError('Could not find the built application bundle at ${bundle.path}.');
@@ -187,6 +187,7 @@ class IOSDevice extends Device {
       id,
       '--bundle',
       bundle.path,
+      '--justlaunch',
     ]);
 
     if (installationResult != 0) {

--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -127,7 +127,7 @@ class IOSDevice extends Device {
   @override
   bool installApp(ApplicationPackage app) {
     try {
-      runCheckedSync(<String>[installerPath, '-i', app.localPath]);
+      runCheckedSync(<String>[installerPath, '-i', app.deviceBundlePath]);
       return true;
     } catch (e) {
       return false;
@@ -172,7 +172,7 @@ class IOSDevice extends Device {
     }
 
     // Step 2: Check that the application exists at the specified path.
-    Directory bundle = new Directory(app.localPath);
+    Directory bundle = new Directory(app.deviceBundlePath);
     bool bundleExists = bundle.existsSync();
     if (!bundleExists) {
       printError('Could not find the built application bundle at ${bundle.path}.');

--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -120,7 +120,7 @@ Future<bool> buildIOSXcodeProject(ApplicationPackage app, BuildMode mode,
   // Before the build, all service definitions must be updated and the dylibs
   // copied over to a location that is suitable for Xcodebuild to find them.
 
-  await _addServicesToBundle(new Directory(app.localPath));
+  await _addServicesToBundle(new Directory(app.rootPath));
 
   List<String> commands = <String>[
     '/usr/bin/env',
@@ -151,7 +151,7 @@ Future<bool> buildIOSXcodeProject(ApplicationPackage app, BuildMode mode,
   printTrace(commands.join(' '));
 
   ProcessResult result = Process.runSync(
-    commands.first, commands.sublist(1), workingDirectory: app.localPath
+    commands.first, commands.sublist(1), workingDirectory: app.rootPath
   );
 
   if (result.exitCode != 0) {
@@ -199,7 +199,7 @@ bool _validateEngineRevision(ApplicationPackage app) {
 }
 
 String _getIOSEngineRevision(ApplicationPackage app) {
-  File revisionFile = new File(path.join(app.localPath, 'REVISION'));
+  File revisionFile = new File(path.join(app.rootPath, 'REVISION'));
   if (revisionFile.existsSync()) {
     // The format is 'REVISION-mode'. We only need the revision.
     String revisionStamp = revisionFile.readAsStringSync().trim();

--- a/packages/flutter_tools/lib/src/ios/simulators.dart
+++ b/packages/flutter_tools/lib/src/ios/simulators.dart
@@ -363,7 +363,8 @@ class IOSSimulator extends Device {
   @override
   bool installApp(ApplicationPackage app) {
     try {
-      SimControl.instance.install(id, app.simulatorBundlePath);
+      IOSApp iosApp = app;
+      SimControl.instance.install(id, iosApp.simulatorBundlePath);
       return true;
     } catch (e) {
       return false;
@@ -541,7 +542,8 @@ class IOSSimulator extends Device {
     }
 
     // Step 2: Assert that the Xcode project was successfully built.
-    Directory bundle = new Directory(app.simulatorBundlePath);
+    IOSApp iosApp = app;
+    Directory bundle = new Directory(iosApp.simulatorBundlePath);
     bool bundleExists = await bundle.exists();
     if (!bundleExists) {
       printError('Could not find the built application bundle at ${bundle.path}.');

--- a/packages/flutter_tools/lib/src/ios/simulators.dart
+++ b/packages/flutter_tools/lib/src/ios/simulators.dart
@@ -424,6 +424,7 @@ class IOSSimulator extends Device {
   @override
   bool isAppInstalled(ApplicationPackage app) {
     try {
+      // TODO(tvolkert): This logic is wrong; simulatorHomeDirectory always exists
       String simulatorHomeDirectory = _getSimulatorAppHomeDirectory(app);
       return FileSystemEntity.isDirectorySync(simulatorHomeDirectory);
     } catch (e) {
@@ -540,7 +541,7 @@ class IOSSimulator extends Device {
     }
 
     // Step 2: Assert that the Xcode project was successfully built.
-    Directory bundle = new Directory(path.join(app.localPath, 'build', 'Release-iphonesimulator', 'Runner.app'));
+    Directory bundle = new Directory(app.localPath);
     bool bundleExists = await bundle.exists();
     if (!bundleExists) {
       printError('Could not find the built application bundle at ${bundle.path}.');

--- a/packages/flutter_tools/lib/src/ios/simulators.dart
+++ b/packages/flutter_tools/lib/src/ios/simulators.dart
@@ -363,7 +363,7 @@ class IOSSimulator extends Device {
   @override
   bool installApp(ApplicationPackage app) {
     try {
-      SimControl.instance.install(id, app.localPath);
+      SimControl.instance.install(id, app.simulatorBundlePath);
       return true;
     } catch (e) {
       return false;
@@ -541,7 +541,7 @@ class IOSSimulator extends Device {
     }
 
     // Step 2: Assert that the Xcode project was successfully built.
-    Directory bundle = new Directory(app.localPath);
+    Directory bundle = new Directory(app.simulatorBundlePath);
     bool bundleExists = await bundle.exists();
     if (!bundleExists) {
       printError('Could not find the built application bundle at ${bundle.path}.');

--- a/packages/flutter_tools/test/src/mocks.dart
+++ b/packages/flutter_tools/test/src/mocks.dart
@@ -16,13 +16,14 @@ import 'package:mockito/mockito.dart';
 class MockApplicationPackageStore extends ApplicationPackageStore {
   MockApplicationPackageStore() : super(
     android: new AndroidApk(
-      localPath: '/mock/path/to/android/SkyShell.apk',
+      buildDir: '/mock/path/to/android',
       id: 'io.flutter.android.mock',
+      apkPath: '/mock/path/to/android/SkyShell.apk',
       launchActivity: 'io.flutter.android.mock.MockActivity'
     ),
     iOS: new IOSApp(
-      iosProjectDir: '/mock/path/to/iOS/SkyShell.app',
-      iosProjectBundleId: 'io.flutter.ios.mock'
+      projectDir: '/mock/path/to/iOS/SkyShell.app',
+      projectBundleId: 'io.flutter.ios.mock'
     )
   );
 }


### PR DESCRIPTION
1) Fix `flutter install` on both device and simulator to refer to the actual
   bundle and not just the .generated folder
2) Fix `flutter run` on device to actually run vs just installing

Still TODO:
1) Discovered that isAppInstalled on iOS simulator always reports true,
   meaning it'll never actually try to install the app.

Fixes #3947
Fixes #1823
