### PR TITLE
Pass the local engine config through Xcode

### DIFF
--- a/packages/flutter_tools/lib/src/base/process.dart
+++ b/packages/flutter_tools/lib/src/base/process.dart
@@ -10,6 +10,8 @@ import '../globals.dart';
 
 typedef String StringConverter(String string);
 
+final Map<String, String> childEnvironmentOverrides = new Map<String, String>();
+
 /// This runs the command in the background from the specified working
 /// directory. Completes when the process has been started.
 Future<Process> runCommand(List<String> cmd, { String workingDirectory }) async {
@@ -19,7 +21,8 @@ Future<Process> runCommand(List<String> cmd, { String workingDirectory }) async 
   Process process = await Process.start(
     executable,
     arguments,
-    workingDirectory: workingDirectory
+    workingDirectory: workingDirectory,
+    environment: childEnvironmentOverrides
   );
   return process;
 }
@@ -108,8 +111,11 @@ String _runWithLoggingSync(List<String> cmd, {
   if (truncateCommand && cmdText.length > 160)
     cmdText = cmdText.substring(0, 160) + '…';
   printTrace(cmdText);
-  ProcessResult results =
-      Process.runSync(cmd[0], cmd.getRange(1, cmd.length).toList(), workingDirectory: workingDirectory);
+  ProcessResult results = Process.runSync(
+    cmd[0], cmd.getRange(1, cmd.length).toList(),
+    workingDirectory: workingDirectory,
+    environment: childEnvironmentOverrides
+  );
 
   printTrace('Exit code ${results.exitCode} from: ${cmd.join(' ')}');
 

--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -151,7 +151,8 @@ Future<bool> buildIOSXcodeProject(ApplicationPackage app, BuildMode mode,
   printTrace(commands.join(' '));
 
   ProcessResult result = Process.runSync(
-    commands.first, commands.sublist(1), workingDirectory: app.rootPath
+    commands.first, commands.sublist(1), workingDirectory: app.rootPath,
+    environment: childEnvironmentOverrides
   );
 
   if (result.exitCode != 0) {


### PR DESCRIPTION
This passes the information through Xcode to the `flutter build aot` call via
the environment so that it picks up the right artifacts.

Fixes #4186
