### PR TITLE
dissallow -release mode on emulators

### DIFF
--- a/packages/flutter_tools/lib/src/base/process.dart
+++ b/packages/flutter_tools/lib/src/base/process.dart
@@ -77,6 +77,7 @@ Future<Process> runDetached(List<String> cmd) {
 }
 
 /// Run cmd and return stdout.
+///
 /// Throws an error if cmd exits with a non-zero value.
 String runCheckedSync(List<String> cmd, {
   String workingDirectory, bool truncateCommand: false

--- a/packages/flutter_tools/lib/src/base/utils.dart
+++ b/packages/flutter_tools/lib/src/base/utils.dart
@@ -39,6 +39,12 @@ String camelCase(String str) {
   return str;
 }
 
+String toTitleCase(String str) {
+  if (str.isEmpty)
+    return str;
+  return str.substring(0, 1).toUpperCase() + str.substring(1);
+}
+
 /// Return the plural of the given word (`cat(s)`).
 String pluralize(String word, int count) => count == 1 ? word : word + 's';
 

--- a/packages/flutter_tools/lib/src/build_info.dart
+++ b/packages/flutter_tools/lib/src/build_info.dart
@@ -27,6 +27,9 @@ bool isAotBuildMode(BuildMode mode) {
   return mode == BuildMode.profile || mode == BuildMode.release;
 }
 
+// Returns true if the given build mode can be used on emulators / simulators.
+bool isEmulatorBuildMode(BuildMode mode) => mode == BuildMode.debug;
+
 enum HostPlatform {
   darwin_x64,
   linux_x64,

--- a/packages/flutter_tools/lib/src/commands/run.dart
+++ b/packages/flutter_tools/lib/src/commands/run.dart
@@ -22,7 +22,7 @@ import 'trace.dart';
 
 abstract class RunCommandBase extends FlutterCommand {
   RunCommandBase() {
-    addBuildModeFlags();
+    addBuildModeFlags(defaultToRelease: false);
 
     argParser.addFlag('trace-startup',
         negatable: true,
@@ -97,6 +97,11 @@ class RunCommand extends RunCommandBase {
         printError('Invalid port for `--debug-port`: $error');
         return 1;
       }
+    }
+
+    if (deviceForCommand.isLocalEmulator && !isEmulatorBuildMode(getBuildMode())) {
+      printError('${toTitleCase(getModeName(getBuildMode()))} mode is not supported for emulators.');
+      return 1;
     }
 
     DebuggingOptions options;

--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -65,13 +65,13 @@ abstract class FlutterCommand extends Command {
 
     argParser.addFlag('debug',
       negatable: false,
-      help: 'Build a debug version of your app.');
+      help: 'Build a debug version of your app${defaultToRelease ? '' : ' (default mode)'}.');
     argParser.addFlag('profile',
       negatable: false,
       help: 'Build a version of your app specialized for performance profiling.');
     argParser.addFlag('release',
       negatable: false,
-      help: 'Build a release version of your app.');
+      help: 'Build a release version of your app${defaultToRelease ? ' (default mode)' : ''}.');
   }
 
   BuildMode getBuildMode() {

--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -43,6 +43,8 @@ abstract class FlutterCommand extends Command {
 
   bool get shouldRunPub => _usesPubOption && argResults['pub'];
 
+  BuildMode _defaultBuildMode;
+
   void usesTargetOption() {
     argParser.addOption('target',
       abbr: 't',
@@ -58,13 +60,15 @@ abstract class FlutterCommand extends Command {
     _usesPubOption = true;
   }
 
-  void addBuildModeFlags() {
+  void addBuildModeFlags({ bool defaultToRelease: true }) {
+    _defaultBuildMode = defaultToRelease ? BuildMode.release : BuildMode.debug;
+
     argParser.addFlag('debug',
       negatable: false,
-      help: 'Build a debug version of your app (the default).');
+      help: 'Build a debug version of your app.');
     argParser.addFlag('profile',
       negatable: false,
-      help: 'Build a profile (ahead of time compilation) version of your app.');
+      help: 'Build a version of your app specialized for performance profiling.');
     argParser.addFlag('release',
       negatable: false,
       help: 'Build a release version of your app.');
@@ -73,14 +77,14 @@ abstract class FlutterCommand extends Command {
   BuildMode getBuildMode() {
     List<bool> modeFlags = <bool>[argResults['debug'], argResults['profile'], argResults['release']];
     if (modeFlags.where((bool flag) => flag).length > 1)
-      throw new UsageException('Only one of --debug, --profile, or --release should be specified.', null);
-
-    BuildMode mode = BuildMode.debug;
+      throw new UsageException('Only one of --debug, --profile, or --release can be specified.', null);
+    if (argResults['debug'])
+      return BuildMode.debug;
     if (argResults['profile'])
-      mode = BuildMode.profile;
+      return BuildMode.profile;
     if (argResults['release'])
-      mode = BuildMode.release;
-    return mode;
+      return BuildMode.release;
+    return _defaultBuildMode;
   }
 
   void _setupApplicationPackages() {


### PR DESCRIPTION
- fail with a good error if `flutter run --release` or `--profile` is used with emulators/simulators (fix #4197, #4200)
- if there are errors running process from `flutter build aot`, fail with an error to the user, not a stack trace (fix https://github.com/flutter/flutter/issues/4106)
- have flutter build apk, flutter build ios, and flutter build aot default to --release, and flutter run default to --debug (fix https://github.com/flutter/flutter/issues/4148)
