### PR TITLE
add a --quiet option to flutter_tools

### DIFF
--- a/packages/flutter_tools/lib/src/base/logger.dart
+++ b/packages/flutter_tools/lib/src/base/logger.dart
@@ -11,6 +11,8 @@ final AnsiTerminal terminal = new AnsiTerminal();
 abstract class Logger {
   bool get isVerbose => false;
 
+  bool quiet = false;
+
   set supportsColor(bool value) {
     terminal.supportsColor = value;
   }

--- a/packages/flutter_tools/lib/src/commands/run.dart
+++ b/packages/flutter_tools/lib/src/commands/run.dart
@@ -412,7 +412,8 @@ class _RunAndStayResident {
 
       _handleExit();
     } else {
-      _printHelp();
+      if (!logger.quiet)
+        _printHelp();
 
       terminal.singleCharMode = true;
 

--- a/packages/flutter_tools/lib/src/runner/flutter_command_runner.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command_runner.dart
@@ -34,6 +34,10 @@ class FlutterCommandRunner extends CommandRunner {
         abbr: 'v',
         negatable: false,
         help: 'Noisy logging, including all shell commands executed.');
+    argParser.addFlag('quiet',
+        negatable: false,
+        hide: !verboseHelp,
+        help: 'Reduce the amount of output from some commands.');
     argParser.addOption('device-id',
         abbr: 'd',
         help: 'Target device id.');
@@ -128,6 +132,8 @@ class FlutterCommandRunner extends CommandRunner {
     // Check for verbose.
     if (globalResults['verbose'])
       context[Logger] = new VerboseLogger();
+
+    logger.quiet = globalResults['quiet'];
 
     if (globalResults.wasParsed('color'))
       logger.supportsColor = globalResults['color'];


### PR DESCRIPTION
- add a --quiet option to flutter_tools. This can be used to quiet some commands; specifically, when some output doesn't make sense when the flutter tool is launched from an IDE.
