### PR TITLE
Update analyzer dep to 0.27.4-alpha.8.

### DIFF
--- a/packages/flutter_test/pubspec.yaml
+++ b/packages/flutter_test/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
   # We don't actually depend on 'analyzer', but 'test' and 'flutter_tools' do.
   # We pin the version of analyzer we depend on to avoid version skew across our
   # packages.
-  analyzer: 0.27.4-alpha.6
+  analyzer: 0.27.4-alpha.8
 
   flutter:
     path: ../flutter

--- a/packages/flutter_tools/pubspec.yaml
+++ b/packages/flutter_tools/pubspec.yaml
@@ -35,7 +35,7 @@ dependencies:
   test: 0.12.13+4
 
   # Pinned in flutter_test as well.
-  analyzer: 0.27.4-alpha.6
+  analyzer: 0.27.4-alpha.8
 
 dev_dependencies:
   mockito: ^0.11.0


### PR DESCRIPTION
Allows us to:
- use new EmbedderSdk (a step towards using SDK summaries)
- enjoy analyzer perf improvements (https://codereview.chromium.org/2011183004/)
