### PR TITLE
run pub get (w/ symlinks) for flutter drive

### DIFF
--- a/packages/flutter_tools/lib/src/commands/drive.dart
+++ b/packages/flutter_tools/lib/src/commands/drive.dart
@@ -12,8 +12,11 @@ import '../android/android_device.dart' show AndroidDevice;
 import '../application_package.dart';
 import '../base/file_system.dart';
 import '../base/common.dart';
+import '../base/logger.dart';
 import '../base/os.dart';
+import '../base/process.dart';
 import '../build_info.dart';
+import '../dart/sdk.dart';
 import '../device.dart';
 import '../globals.dart';
 import '../ios/simulators.dart' show SimControl, IOSSimulatorUtils;
@@ -119,6 +122,15 @@ class DriveCommand extends RunCommandBase {
       }
     } else {
       printStatus('Will connect to already running application instance.');
+    }
+
+    // Check for the existance of a `packages/` directory; pub test does not yet
+    // support running without symlinks.
+    // TODO(devoncarew): Remove once https://github.com/dart-lang/test/issues/327 is fixed.
+    if (!new io.Directory('packages').existsSync()) {
+      Status status = logger.startProgress('Running pub get...');
+      await runAsync(<String>[sdkBinaryName('pub'), 'get', '--no-precompile']);
+      status.stop(showElapsedTime: true);
     }
 
     try {

--- a/packages/flutter_tools/lib/src/commands/drive.dart
+++ b/packages/flutter_tools/lib/src/commands/drive.dart
@@ -126,9 +126,10 @@ class DriveCommand extends RunCommandBase {
 
     // Check for the existance of a `packages/` directory; pub test does not yet
     // support running without symlinks.
-    // TODO(devoncarew): Remove once https://github.com/dart-lang/test/issues/327 is fixed.
     if (!new io.Directory('packages').existsSync()) {
-      Status status = logger.startProgress('Running pub get...');
+      Status status = logger.startProgress(
+        'Missing packages directory; running `pub get` (to work around https://github.com/dart-lang/test/issues/327):'
+      );
       await runAsync(<String>[sdkBinaryName('pub'), 'get', '--no-precompile']);
       status.stop(showElapsedTime: true);
     }


### PR DESCRIPTION
Attempt to fix the `drive sample_app` failure on the mac bot: https://uberchromegw.corp.google.com/i/client.flutter/builders/Mac/builds/1077/steps/drive%20sample_app/logs/stdio

I was not able to track down why or when this was introduced, but it looks like flutter drive fails because it's not able to load `package:stream_channel` as part of the `test` invocation, because `test` only looks for the packages using the `packages/` symlinks - it doesn't support non-symlink setups. This is a long-standing bug in test, coming up on a year.

This fix runs a raw `pub get` as part of flutter drive if there is no packages/ symlink folder.
