### PR TITLE
make the drive output prettier

### DIFF
--- a/packages/flutter_driver/lib/src/error.dart
+++ b/packages/flutter_driver/lib/src/error.dart
@@ -57,8 +57,10 @@ class LogRecord {
   final String loggerName;
   final String message;
 
+  String get levelDescription => level.toString().split(".").last;
+
   @override
-  String toString() => '[${"$level".split(".").last}] $loggerName: $message';
+  String toString() => '[${levelDescription.padRight(5)}] $loggerName: $message';
 }
 
 /// Package-private; users should use other public logging libraries.

--- a/packages/flutter_tools/lib/src/commands/drive.dart
+++ b/packages/flutter_tools/lib/src/commands/drive.dart
@@ -308,7 +308,8 @@ void restoreTestRunner() {
 
 Future<int> runTests(List<String> testArgs) async {
   printTrace('Running driver tests.');
-  await executable.main(testArgs);
+  List<String> args = testArgs.toList()..add('-rexpanded');
+  await executable.main(args);
   return io.exitCode;
 }
 


### PR DESCRIPTION
Make the `drive` output look slightly nicer. From:

```
00:00 +0: end-to-end test (setUpAll)                                                               [info] FlutterDriver: Connecting to Flutter application at http://localhost:8183
[trace] FlutterDriver: Looking for the isolate
[trace] FlutterDriver: Isolate is paused at start.
[trace] FlutterDriver: Attempting to resume isolate
[trace] FlutterDriver: Waiting for service extension
[info] FlutterDriver: Connected to Flutter application.
00:01 +1: All tests passed!                                                                        
Stopping application instance.
```

to:

```
00:00 +0: end-to-end test (setUpAll)
[info ] FlutterDriver: Connecting to Flutter application at http://localhost:8183
[trace] FlutterDriver: Looking for the isolate
[trace] FlutterDriver: Isolate is paused at start.
[trace] FlutterDriver: Attempting to resume isolate
[trace] FlutterDriver: Waiting for service extension
[info ] FlutterDriver: Connected to Flutter application.
00:00 +0: end-to-end test tap on the floating action button; verify counter
00:01 +1: end-to-end test (tearDownAll)
00:01 +1: All tests passed!
Stopping application instance.
```

@yjbanov 
