### PR TITLE
show build progress; print app sizes

### DIFF
--- a/packages/flutter_tools/lib/src/base/process.dart
+++ b/packages/flutter_tools/lib/src/base/process.dart
@@ -164,6 +164,8 @@ class RunResult {
   final ProcessResult processResult;
 
   int get exitCode => processResult.exitCode;
+  String get stdout => processResult.stdout;
+  String get stderr => processResult.stderr;
 
   @override
   String toString() {

--- a/packages/flutter_tools/lib/src/base/utils.dart
+++ b/packages/flutter_tools/lib/src/base/utils.dart
@@ -71,6 +71,11 @@ String toPrettyJson(Object jsonable) {
   return new JsonEncoder.withIndent('  ').convert(jsonable) + '\n';
 }
 
+/// Return a String - with units - for the size in MB of the given number of bytes.
+String getSizeAsMB(int bytesLength) {
+  return '${(bytesLength / (1024 * 1024)).toStringAsFixed(1)}MB';
+}
+
 /// A class to maintain a list of items, fire events when items are added or
 /// removed, and calculate a diff of changes when a new list of items is
 /// available.

--- a/packages/flutter_tools/lib/src/commands/build_apk.dart
+++ b/packages/flutter_tools/lib/src/commands/build_apk.dart
@@ -541,8 +541,8 @@ Future<int> buildAndroid(
   status.stop(showElapsedTime: true);
 
   if (result == 0) {
-    double size = new File(outputFile).lengthSync() / (1024 * 1024);
-    printStatus('Built $outputFile (${size.toStringAsFixed(1)}MB).');
+    File apkFile = new File(outputFile);
+    printStatus('Built $outputFile (${getSizeAsMB(apkFile.lengthSync())}).');
 
     _writeBuildMetaEntry(
       path.dirname(outputFile),

--- a/packages/flutter_tools/lib/src/commands/build_ios.dart
+++ b/packages/flutter_tools/lib/src/commands/build_ios.dart
@@ -3,8 +3,12 @@
 // found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:io';
+
+import 'package:path/path.dart' as path;
 
 import '../application_package.dart';
+import '../base/logger.dart';
 import '../build_info.dart';
 import '../globals.dart';
 import '../ios/mac.dart';
@@ -42,25 +46,38 @@ class BuildIOSCommand extends FlutterCommand {
     bool shouldCodesign = argResults['codesign'];
 
     if (!forSimulator && !shouldCodesign) {
-      printStatus('Warning: Building for device with codesigning disabled.');
-      printStatus('You will have to manually codesign before deploying to device.');
+      printStatus('Warning: Building for device with codesigning disabled. You will '
+        'have to manually codesign before deploying to device.');
     }
 
     String logTarget = forSimulator ? 'simulator' : 'device';
 
-    printStatus('Building $app for $logTarget...');
-
-    bool result = await buildIOSXcodeProject(app, getBuildMode(),
+    String typeName = path.basename(tools.getEngineArtifactsDirectory(TargetPlatform.ios, getBuildMode()).path);
+    Status status = logger.startProgress('Building $app for $logTarget ($typeName)...');
+    XcodeBuildResult result = await buildXcodeProject(app, getBuildMode(),
         buildForDevice: !forSimulator,
         codesign: shouldCodesign);
+    status.stop(showElapsedTime: true);
 
-    if (!result) {
+    if (!result.success) {
       printError('Encountered error while building for $logTarget.');
       return 1;
     }
 
-    printStatus('Built in ios/.generated.');
+    if (result.output != null) {
+      double size = _calcDirectorySize(new Directory(result.output)) / (1024 * 1024);
+      printStatus('Built ${result.output} (${size.toStringAsFixed(1)}MB).');
+    }
 
     return 0;
+  }
+
+  int _calcDirectorySize(Directory directory) {
+    int size = 0;
+    for (FileSystemEntity entity in directory.listSync(recursive: true, followLinks: false)) {
+      if (entity is File)
+        size += entity.lengthSync();
+    }
+    return size;
   }
 }

--- a/packages/flutter_tools/lib/src/commands/build_ios.dart
+++ b/packages/flutter_tools/lib/src/commands/build_ios.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:io';
 
 import 'package:path/path.dart' as path;
 

--- a/packages/flutter_tools/lib/src/commands/build_ios.dart
+++ b/packages/flutter_tools/lib/src/commands/build_ios.dart
@@ -64,22 +64,9 @@ class BuildIOSCommand extends FlutterCommand {
       return 1;
     }
 
-    if (result.output != null) {
-      // TODO(devoncarew): We're printing the size of the (uncompressed) .app directory
-      // here, but what we really care about is the size of the installed .ipa file.
-      double size = _calcDirectorySize(new Directory(result.output)) / (1024 * 1024);
-      printStatus('Built ${result.output} (${size.toStringAsFixed(1)}MB).');
-    }
+    if (result.output != null)
+      printStatus('Built ${result.output}.');
 
     return 0;
-  }
-
-  int _calcDirectorySize(Directory directory) {
-    int size = 0;
-    for (FileSystemEntity entity in directory.listSync(recursive: true, followLinks: false)) {
-      if (entity is File)
-        size += entity.lengthSync();
-    }
-    return size;
   }
 }

--- a/packages/flutter_tools/lib/src/commands/build_ios.dart
+++ b/packages/flutter_tools/lib/src/commands/build_ios.dart
@@ -65,6 +65,8 @@ class BuildIOSCommand extends FlutterCommand {
     }
 
     if (result.output != null) {
+      // TODO(devoncarew): We're printing the size of the (uncompressed) .app directory
+      // here, but what we really care about is the size of the installed .ipa file.
       double size = _calcDirectorySize(new Directory(result.output)) / (1024 * 1024);
       printStatus('Built ${result.output} (${size.toStringAsFixed(1)}MB).');
     }

--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -180,8 +180,8 @@ class IOSDevice extends Device {
     printTrace('Building ${app.name} for $id');
 
     // Step 1: Install the precompiled/DBC application if necessary.
-    bool buildResult = await buildIOSXcodeProject(app, mode, buildForDevice: true);
-    if (!buildResult) {
+    XcodeBuildResult buildResult = await buildXcodeProject(app, mode, buildForDevice: true);
+    if (!buildResult.success) {
       printError('Could not build the precompiled application for the device.');
       return new LaunchResult.failed();
     }

--- a/packages/flutter_tools/lib/src/ios/simulators.dart
+++ b/packages/flutter_tools/lib/src/ios/simulators.dart
@@ -548,8 +548,8 @@ class IOSSimulator extends Device {
   Future<bool> _buildAndInstallApplicationBundle(ApplicationPackage app) async {
     // Step 1: Build the Xcode project.
     // The build mode for the simulator is always debug.
-    bool buildResult = await buildIOSXcodeProject(app, BuildMode.debug, buildForDevice: false);
-    if (!buildResult) {
+    XcodeBuildResult buildResult = await buildXcodeProject(app, BuildMode.debug, buildForDevice: false);
+    if (!buildResult.success) {
       printError('Could not build the application for the simulator.');
       return false;
     }


### PR DESCRIPTION
Unify the output of build apk, build aot, and build ios a bit; show a spinner for the long running tasks, and print the artifact location and size for ios.

```
[~/projects/flutter/flutter/examples/flutter_gallery] flutter build aot
Building AOT snapshot in release mode (android-arm-release)...  15.3s
Built to build/aot/.

[~/projects/flutter/flutter/examples/flutter_gallery] flutter build apk
Building APK in release mode (android-arm-release)...      
Warning: signing the APK using the debug keystore.
Built build/app.apk (20.1MB).

[~/projects/flutter/flutter/examples/flutter_gallery] flutter build ios --no-codesign
Warning: Building for device with codesigning disabled. You will have to manually codesign before deploying to device.
Building io.flutter.gallery for device (ios-release)...  35.8s
Built ios/.generated/build/Release-iphoneos/Runner.app (69.2MB).
```
