### PR TITLE
Update analyzer dep to 0.27.4-alpha.9

### DIFF
--- a/packages/flutter_test/pubspec.yaml
+++ b/packages/flutter_test/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
   # We don't actually depend on 'analyzer', but 'test' and 'flutter_tools' do.
   # We pin the version of analyzer we depend on to avoid version skew across our
   # packages.
-  analyzer: 0.27.4-alpha.6
+  analyzer: 0.27.4-alpha.9
 
   flutter:
     path: ../flutter

--- a/packages/flutter_tools/pubspec.yaml
+++ b/packages/flutter_tools/pubspec.yaml
@@ -35,7 +35,7 @@ dependencies:
   test: 0.12.13+4
 
   # Pinned in flutter_test as well.
-  analyzer: 0.27.4-alpha.6
+  analyzer: 0.27.4-alpha.9
 
 dev_dependencies:
   mockito: ^0.11.0


### PR DESCRIPTION
Update analyzer dep to 0.27.4-alpha.9 to enjoy analyzer perf improvements (https://codereview.chromium.org/2011183004/) (and keep in sync with the SDK).

(This is a revisit to https://github.com/flutter/flutter/pull/4253.)

@Hixie @devoncarew 
