### PR TITLE
Deploy mustCallSuper

### DIFF
--- a/packages/flutter/lib/src/gestures/multitap.dart
+++ b/packages/flutter/lib/src/gestures/multitap.dart
@@ -157,6 +157,7 @@ class DoubleTapGestureRecognizer extends GestureRecognizer {
   @override
   void dispose() {
     _reset();
+    super.dispose();
   }
 
   void _reset() {
@@ -400,6 +401,7 @@ class MultiTapGestureRecognizer extends GestureRecognizer {
       gesture.cancel();
     // Rejection of each gesture should cause it to be removed from our map
     assert(_gestureMap.isEmpty);
+    super.dispose();
   }
 
   @override

--- a/packages/flutter/lib/src/gestures/recognizer.dart
+++ b/packages/flutter/lib/src/gestures/recognizer.dart
@@ -6,6 +6,8 @@ import 'dart:async';
 import 'dart:collection';
 import 'dart:ui' show Point, Offset;
 
+import 'package:meta/meta.dart';
+
 import 'arena.dart';
 import 'binding.dart';
 import 'constants.dart';
@@ -40,6 +42,7 @@ abstract class GestureRecognizer extends GestureArenaMember {
   /// when the object is no longer needed (e.g. when a gesture
   /// recogniser is being unregistered from a [GestureDetector], the
   /// GestureDetector widget calls this method).
+  @mustCallSuper
   void dispose() { }
 
   /// Returns a very short pretty description of the gesture that the
@@ -89,6 +92,7 @@ abstract class OneSequenceGestureRecognizer extends GestureRecognizer {
       GestureBinding.instance.pointerRouter.removeRoute(pointer, handleEvent);
     _trackedPointers.clear();
     assert(_entries.isEmpty);
+    super.dispose();
   }
 
   /// Causes events related to the given pointer ID to be routed to this recognizer.

--- a/packages/flutter/lib/src/material/flexible_space_bar.dart
+++ b/packages/flutter/lib/src/material/flexible_space_bar.dart
@@ -59,6 +59,7 @@ class _FlexibleSpaceBarState extends State<FlexibleSpaceBar> {
   void deactivate() {
     _scaffoldAnimation?.removeListener(_handleTick);
     _scaffoldAnimation = null;
+    super.deactivate();
   }
 
   @override

--- a/packages/flutter/lib/src/material/tabs.dart
+++ b/packages/flutter/lib/src/material/tabs.dart
@@ -620,6 +620,7 @@ class TabBarSelectionState<T> extends State<TabBarSelection<T>> {
     }
     assert(_animationListeners.isEmpty);
     _writeValue();
+    super.deactivate();
   }
 
   @override

--- a/packages/flutter/lib/src/rendering/node.dart
+++ b/packages/flutter/lib/src/rendering/node.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:meta/meta.dart';
+
 /// An abstract node in a tree
 ///
 /// AbstractNode has as notion of depth, attachment, and parent, but does not
@@ -73,6 +75,7 @@ class AbstractNode {
   ///
   /// Typically called only from the parent's attach(), and to mark the root of
   /// a tree attached.
+  @mustCallSuper
   void attach(Object owner) {
     assert(owner != null);
     assert(_owner == null);
@@ -83,6 +86,7 @@ class AbstractNode {
   ///
   /// Typically called only from the parent's detach(), and to mark the root of
   /// a tree detached.
+  @mustCallSuper
   void detach() {
     assert(_owner != null);
     _owner = null;

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -377,6 +377,7 @@ abstract class State<T extends StatefulWidget> {
   ///
   /// If you override this, make sure your method starts with a call to
   /// super.initState().
+  @mustCallSuper
   void initState() {
     assert(_debugLifecycleState == _StateLifecycle.created);
     assert(() { _debugLifecycleState = _StateLifecycle.initialized; return true; });
@@ -441,6 +442,7 @@ abstract class State<T extends StatefulWidget> {
   /// Use this to clean up any links between this state and other
   /// elements in the tree (e.g. if you have provided an ancestor with
   /// a pointer to a descendant's renderObject).
+  @mustCallSuper
   void deactivate() { }
 
   /// Called when this object is removed from the tree permanently.
@@ -449,6 +451,7 @@ abstract class State<T extends StatefulWidget> {
   ///
   /// If you override this, make sure to end your method with a call to
   /// super.dispose().
+  @mustCallSuper
   void dispose() {
     assert(_debugLifecycleState == _StateLifecycle.ready);
     assert(() { _debugLifecycleState = _StateLifecycle.defunct; return true; });
@@ -987,6 +990,7 @@ abstract class Element implements BuildContext {
   /// created. Use this to initialize state that depends on having a parent. For
   /// state that is independent of the position in the tree, it's better to just
   /// initialize the Element in the constructor.
+  @mustCallSuper
   void mount(Element parent, dynamic newSlot) {
     assert(_debugLifecycleState == _ElementLifecycle.initial);
     assert(widget != null);
@@ -1010,6 +1014,7 @@ abstract class Element implements BuildContext {
   }
 
   /// Called when an Element receives a new configuration widget.
+  @mustCallSuper
   void update(Widget newWidget) {
     assert(_debugLifecycleState == _ElementLifecycle.active);
     assert(widget != null);
@@ -1141,6 +1146,7 @@ abstract class Element implements BuildContext {
 
   /// Called when a previously de-activated widget (see [deactivate]) is reused
   /// instead of being unmounted (see [unmount]).
+  @mustCallSuper
   void activate() {
     assert(_debugLifecycleState == _ElementLifecycle.inactive);
     assert(widget != null);
@@ -1156,6 +1162,7 @@ abstract class Element implements BuildContext {
 
   // TODO(ianh): Define activation/deactivation thoroughly (other methods point
   // here for details).
+  @mustCallSuper
   void deactivate() {
     assert(_debugLifecycleState == _ElementLifecycle.active);
     assert(widget != null);
@@ -1183,6 +1190,7 @@ abstract class Element implements BuildContext {
 
   /// Called when an Element is removed from the tree permanently after having
   /// been deactivated (see [deactivate]).
+  @mustCallSuper
   void unmount() {
     assert(_debugLifecycleState == _ElementLifecycle.inactive);
     assert(widget != null);


### PR DESCRIPTION
This patch starts using the mustCallSuper annotation for several of the key
lifecycle callbacks in the framework. I haven't added it to didUpdateConfig
because there are a large number of non-compliant overrides. We should discuss
whether we want to use it there.
