### PR TITLE
fix a race condition with isolate notification

### DIFF
--- a/packages/flutter_tools/lib/src/commands/run.dart
+++ b/packages/flutter_tools/lib/src/commands/run.dart
@@ -394,10 +394,10 @@ class _RunAndStayResident {
       observatory = await Observatory.connect(result.observatoryPort);
       printTrace('Connected to observatory port: ${result.observatoryPort}.');
 
+      observatory.populateIsolateInfo();
       observatory.onExtensionEvent.listen((Event event) {
         printTrace(event.toString());
       });
-
       observatory.onIsolateEvent.listen((Event event) {
         printTrace(event.toString());
       });

--- a/packages/flutter_tools/lib/src/observatory.dart
+++ b/packages/flutter_tools/lib/src/observatory.dart
@@ -74,9 +74,9 @@ class Observatory {
     _getEventController(data['streamId']).add(event);
   }
 
-  void populateIsolateInfo() {
+  Future<Null> populateIsolateInfo() async {
     // Calling this has the side effect of populating the isolate information.
-    waitFirstIsolate;
+    await waitFirstIsolate;
   }
 
   Future<IsolateRef> get waitFirstIsolate async {

--- a/packages/flutter_tools/lib/src/observatory.dart
+++ b/packages/flutter_tools/lib/src/observatory.dart
@@ -74,6 +74,11 @@ class Observatory {
     _getEventController(data['streamId']).add(event);
   }
 
+  void populateIsolateInfo() {
+    // Calling this has the side effect of populating the isolate information.
+    waitFirstIsolate;
+  }
+
   Future<IsolateRef> get waitFirstIsolate async {
     if (isolates.isNotEmpty)
       return isolates.first;


### PR DESCRIPTION
Fix a race condition with isolate notification. With a recent refactoring, I introduced a race condition in flutter run; this requests all isolates at startup in order to make sure we have a full list of available isolates.
