### PR TITLE
fix an exception while parsing a services file

### DIFF
--- a/packages/flutter_tools/lib/src/services.dart
+++ b/packages/flutter_tools/lib/src/services.dart
@@ -46,7 +46,7 @@ Future<Null> parseServiceConfigs(
     String serviceRoot = packageMap[service].path;
     dynamic serviceConfig = _loadYamlFile('$serviceRoot/$_kFlutterServicesManifestPath');
     if (serviceConfig == null) {
-      printStatus('No $_kFlutterServicesManifestPath found for service "$serviceRoot". Skipping.');
+      printStatus('No $_kFlutterServicesManifestPath found for service "$serviceRoot"; skipping.');
       continue;
     }
 
@@ -59,7 +59,7 @@ Future<Null> parseServiceConfigs(
       });
     }
 
-    if (jars != null) {
+    if (jars != null && serviceConfig['jars'] is Iterable) {
       for (String jar in serviceConfig['jars'])
         jars.add(new File(await getServiceFromUrl(jar, serviceRoot, service, unzip: false)));
     }


### PR DESCRIPTION
Fix an exception that occurs when parsing a services file (https://github.com/flutter/google_sign_in/blob/master/lib/flutter_services.yaml); fix https://github.com/flutter/flutter/issues/4294.
