### PR TITLE
Add a FLUTTER_MODE variable to the generated Xcconfig and fix snapshot generation on all targets.

### DIFF
--- a/packages/flutter_tools/bin/xcode_backend.sh
+++ b/packages/flutter_tools/bin/xcode_backend.sh
@@ -57,17 +57,23 @@ BuildApp() {
     local_engine_flag="--local-engine=$LOCAL_ENGINE"
   fi
 
+  local flutter_mode="release"
+  if [[ -n "$FLUTTER_MODE" ]]; then
+    flutter_mode=${FLUTTER_MODE}
+  fi
+
   if [[ $CURRENT_ARCH != "x86_64" ]]; then
-    local interpreter_flag="--interpreter"
-    if [[ "$DART_EXPERIMENTAL_INTERPRETER" != "1" ]]; then
-      interpreter_flag=""
+    local aot_flags=""
+    if [[ "$flutter_mode" == "debug" ]]; then
+      aot_flags="--interpreter --debug"
+    else
+      aot_flags="--${flutter_mode}"
     fi
 
     RunCommand ${FLUTTER_ROOT}/bin/flutter --suppress-analytics build aot \
       --target-platform=ios                                               \
       --target=${target_path}                                             \
-      --release                                                           \
-      ${interpreter_flag}                                                 \
+      ${aot_flags}                                                        \
       ${local_engine_flag}
 
     if [[ $? -ne 0 ]]; then
@@ -81,7 +87,7 @@ BuildApp() {
   fi
 
   local precompilation_flag=""
-  if [[ $CURRENT_ARCH != "x86_64" ]] && [[ "$DART_EXPERIMENTAL_INTERPRETER" != "1" ]]; then
+  if [[ $CURRENT_ARCH != "x86_64" ]] && [[ "$flutter_mode" != "debug" ]]; then
     precompilation_flag="--precompiled"
   fi
 

--- a/packages/flutter_tools/lib/src/commands/build_aot.dart
+++ b/packages/flutter_tools/lib/src/commands/build_aot.dart
@@ -107,7 +107,7 @@ Future<String> _buildAotSnapshot(
   String outputPath: _kDefaultAotOutputDir,
   bool interpreter: false
 }) async {
-  if (!isAotBuildMode(buildMode)) {
+  if (!isAotBuildMode(buildMode) && !interpreter) {
     printError('${toTitleCase(getModeName(buildMode))} mode does not support AOT compilation.');
     return null;
   }

--- a/packages/flutter_tools/lib/src/ios/setup_xcodeproj.dart
+++ b/packages/flutter_tools/lib/src/ios/setup_xcodeproj.dart
@@ -69,6 +69,9 @@ void updateXcodeGeneratedProperties(String projectPath, BuildMode mode, String t
   // Relative to FLUTTER_APPLICATION_PATH, which is [Directory.current].
   localsBuffer.writeln('FLUTTER_TARGET=$target');
 
+  // The runtime mode for the current build.
+  localsBuffer.writeln('FLUTTER_MODE=${getModeName(mode)}');
+
   String flutterFrameworkDir = path.normalize(tools.getEngineArtifactsDirectory(TargetPlatform.ios, mode).path);
   localsBuffer.writeln('FLUTTER_FRAMEWORK_DIR=$flutterFrameworkDir');
 


### PR DESCRIPTION
Get rid of the DART_EXPERIMENTAL_INTERPRETER_FLAG.

cc @abarth 
