### PR TITLE
Tab labels incorrectly fade out

### DIFF
--- a/packages/flutter/lib/src/painting/text_painter.dart
+++ b/packages/flutter/lib/src/painting/text_painter.dart
@@ -38,7 +38,7 @@ class TextPainter {
   }
 
   ui.Paragraph _paragraph;
-  bool _needsLayout = false;
+  bool _needsLayout = true;
 
   /// The (potentially styled) text to paint.
   TextSpan get text => _text;

--- a/packages/flutter/lib/src/rendering/paragraph.dart
+++ b/packages/flutter/lib/src/rendering/paragraph.dart
@@ -148,15 +148,19 @@ class RenderParagraph extends RenderBox {
   @override
   void performLayout() {
     _layoutText(minWidth: constraints.minWidth, maxWidth: constraints.maxWidth);
-    size = constraints.constrain(_textPainter.size);
+    // We grab _textPainter.size here because assigning to `size` will trigger
+    // us to validate our intrinsic sizes, which will change _textPainter's
+    // layout because the intrinsic size calculations are destructive.
+    final Size textSize = _textPainter.size;
+    size = constraints.constrain(textSize);
 
-    final bool didOverflowWidth = size.width < _textPainter.width;
+    final bool didOverflowWidth = size.width < textSize.width;
     // TODO(abarth): We're only measuring the sizes of the line boxes here. If
     // the glyphs draw outside the line boxes, we might think that there isn't
     // visual overflow when there actually is visual overflow. This can become
     // a problem if we start having horizontal overflow and introduce a clip
     // that affects the actual (but undetected) vertical overflow.
-    _hasVisualOverflow = didOverflowWidth || size.height < _textPainter.height;
+    _hasVisualOverflow = didOverflowWidth || size.height < textSize.height;
     if (didOverflowWidth) {
       switch (_overflow) {
         case TextOverflow.clip:


### PR DESCRIPTION
Assigning to `size` called our intrinsic sizing functions re-entrantly, which
is a destructive operation on TextPainter. Ideally we'd made that a
non-destructive operation, but in the meantime we can fix the tab fading issue
by grabbing the text size before assigning to `size`.

Fixes #4365
