### PR TITLE
Make Shrine scroll fast

### DIFF
--- a/examples/flutter_gallery/lib/demo/shrine/shrine_home.dart
+++ b/examples/flutter_gallery/lib/demo/shrine/shrine_home.dart
@@ -268,26 +268,30 @@ class _ShrineHomeState extends State<ShrineHome> {
     final Product featured = _products.firstWhere((Product product) => product.featureDescription != null);
     return new ShrinePage(
       body: new ScrollableViewport(
-        child: new Column(
-          children: <Widget>[
-            new Container(
-              margin: new EdgeInsets.only(bottom: 8.0),
-              child: new FeatureItem(product: featured)
-            ),
-            new FixedColumnCountGrid(
-              columnCount: 2,
-              rowSpacing: 8.0,
-              columnSpacing: 8.0,
-              padding: const EdgeInsets.all(8.0),
-              tileAspectRatio: 160.0 / 216.0, // width/height
-              children: _products.map((Product product) {
-                return new ProductItem(
-                  product: product,
-                  onPressed: () { showOrderPage(product); }
-                );
-              }).toList()
-            )
-          ]
+        child: new RepaintBoundary(
+          child: new Column(
+            children: <Widget>[
+              new Container(
+                margin: new EdgeInsets.only(bottom: 8.0),
+                child: new FeatureItem(product: featured)
+              ),
+              new FixedColumnCountGrid(
+                columnCount: 2,
+                rowSpacing: 8.0,
+                columnSpacing: 8.0,
+                padding: const EdgeInsets.all(8.0),
+                tileAspectRatio: 160.0 / 216.0, // width/height
+                children: _products.map((Product product) {
+                  return new RepaintBoundary(
+                    child: new ProductItem(
+                      product: product,
+                      onPressed: () { showOrderPage(product); }
+                    )
+                  );
+                }).toList()
+              )
+            ]
+          )
         )
       )
     );

--- a/packages/flutter/lib/src/rendering/layer.dart
+++ b/packages/flutter/lib/src/rendering/layer.dart
@@ -7,6 +7,7 @@ import 'dart:ui' show Offset;
 
 import 'package:flutter/painting.dart';
 import 'package:vector_math/vector_math_64.dart';
+import 'package:meta/meta.dart';
 import 'package:mojo_services/mojo/gfx/composition/scene_token.mojom.dart' as mojom;
 
 import 'debug.dart';
@@ -30,6 +31,7 @@ abstract class Layer {
   Layer _previousSibling;
 
   /// Removes this layer from its parent layer's child list
+  @mustCallSuper
   void detach() {
     if (_parent != null)
       _parent._remove(this);
@@ -94,12 +96,15 @@ abstract class Layer {
   }
 
   /// Add additional information to the given description for use by [toStringDeep].
+  @protected
+  @mustCallSuper
   void debugFillDescription(List<String> description) {
     if (debugCreator != null)
       description.add('creator: $debugCreator');
   }
 
   /// Returns a description of this layer's children for use by [toStringDeep].
+  @protected
   String debugDescribeChildren(String prefix) => '';
 }
 


### PR DESCRIPTION
This fix isn't completely statisfying because it has a scaling limit. The ideal
fix would actually viewport the tiles in the grid. However, this fix is much
easier at the moment.

Fixes #4395
