### PR TITLE
Loosen dependencies on string_scanner

### DIFF
--- a/examples/flutter_gallery/pubspec.yaml
+++ b/examples/flutter_gallery/pubspec.yaml
@@ -2,7 +2,7 @@ name: flutter_gallery
 dependencies:
   intl: '>=0.12.4+2 <0.13.0'
   collection: '>=1.4.0 <2.0.0'
-  string_scanner: '0.1.4+1'
+  string_scanner: '^0.1.5'
 
   flutter:
     path: ../../packages/flutter

--- a/packages/flutter_markdown/pubspec.yaml
+++ b/packages/flutter_markdown/pubspec.yaml
@@ -7,8 +7,8 @@ homepage: http://flutter.io
 dependencies:
   flutter:
     path: ../flutter
-  markdown: "0.9.0"
-  string_scanner: "0.1.4+1"
+  markdown: '^0.9.0'
+  string_scanner: '^0.1.5'
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Now that there's a new string_scanner in town, we're having dependency
resolution conflict because of flutter_markdown's tight dependency. This
patch loosens the dependency and resolves the conflict.
