### PR TITLE
Remove "Drop-down button" from the transtions perf test.

### DIFF
--- a/examples/flutter_gallery/test_driver/transitions_perf_test.dart
+++ b/examples/flutter_gallery/test_driver/transitions_perf_test.dart
@@ -23,7 +23,6 @@ const List<String> demoNames = const <String>[
   'Date picker',
   'Data tables',
   'Dialog',
-  'Drop-down button',
   'Expand/collapse list control',
   'Floating action button',
   'Grid',


### PR DESCRIPTION
It's no longer part of the gallery app.

BUG=https://github.com/flutter/flutter/issues/4390
