### PR TITLE
runApp inside onPressed throws an exception

### DIFF
--- a/packages/flutter/lib/src/gestures/drag.dart
+++ b/packages/flutter/lib/src/gestures/drag.dart
@@ -212,7 +212,7 @@ abstract class DragGestureRecognizer extends OneSequenceGestureRecognizer {
 
   @override
   void rejectGesture(int pointer) {
-    ensureNotTrackingPointer(pointer);
+    stopTrackingPointer(pointer);
   }
 
   @override

--- a/packages/flutter/lib/src/gestures/recognizer.dart
+++ b/packages/flutter/lib/src/gestures/recognizer.dart
@@ -114,16 +114,12 @@ abstract class OneSequenceGestureRecognizer extends GestureRecognizer {
   ///
   /// Use [startTrackingPointer] to add the routes in the first place.
   void stopTrackingPointer(int pointer) {
-    GestureBinding.instance.pointerRouter.removeRoute(pointer, handleEvent);
-    _trackedPointers.remove(pointer);
-    if (_trackedPointers.isEmpty)
-      didStopTrackingLastPointer(pointer);
-  }
-
-  /// Calls [stopTrackingPointer] if the pointer with the given ID is being tracked by this recognizer.
-  void ensureNotTrackingPointer(int pointer) {
-    if (_trackedPointers.contains(pointer))
-      stopTrackingPointer(pointer);
+    if (_trackedPointers.contains(pointer)) {
+      GestureBinding.instance.pointerRouter.removeRoute(pointer, handleEvent);
+      _trackedPointers.remove(pointer);
+      if (_trackedPointers.isEmpty)
+        didStopTrackingLastPointer(pointer);
+    }
   }
 
   /// Stops tracking the pointer associated with the given event if the event is

--- a/packages/flutter/test/widget/run_app_test.dart
+++ b/packages/flutter/test/widget/run_app_test.dart
@@ -1,0 +1,23 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('runApp inside onPressed does not throw', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      new Material(
+        child: new RaisedButton(
+          onPressed: () {
+            runApp(new Center(child: new Text('Done')));
+          },
+          child: new Text('GO')
+        )
+      )
+    );
+    await tester.tap(find.text('GO'));
+    expect(find.text('Done'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
We were trying to unregister the pointer route twice. Now we only unregister it
once.

Fixes #4341
