### PR TITLE
Add support for `target` to gradle build

### DIFF
--- a/examples/hello_services/README.md
+++ b/examples/hello_services/README.md
@@ -15,8 +15,8 @@ Create an `ios/Flutter/Generated.xcconfig` file with this entry:
 
 There are a number of other parameters you can control with this file:
 
- * `FLUTTER_APPLICATION_PATH`: The path that contains your `pubspec.yaml` file
-   relative to your `xcodeproj` file.
+ * `FLUTTER_APPLICATION_PATH`: The path to the directory that contains your
+   `pubspec.yaml` file relative to your `xcodeproj` file.
  * `FLUTTER_BUILD_MODE`: Whether to build for `debug`, `profile`, or `release`.
    Defaults to `release`.
  * `FLUTTER_TARGET`: The path to your `main.dart` relative to your
@@ -47,10 +47,18 @@ There are a number of other parameters you can control with this file:
    `android-arm-release` version of `flutter.jar` in the `bin/cache` directory
    of the Flutter SDK.
 
+See `android/app/build.gradle` for project specific settings, including:
+
+ * `source`: The path to the directory that contains your `pubspec.yaml` file
+   relative to your `build.gradle` file.
+ * `target`: The path to your `main.dart` relative to your `pubspec.yaml`.
+   Defaults to `lib/main.dart`.
+
 ### Build
 
-To build direction with gradle, use the following commands:
+To build directly with `gradle`, use the following commands:
 
+ * `cd android`
  * `gradle wrapper`
  * `./gradlew build`
 

--- a/examples/hello_services/android/buildSrc/src/main/groovy/FlutterPlugin.groovy
+++ b/examples/hello_services/android/buildSrc/src/main/groovy/FlutterPlugin.groovy
@@ -87,10 +87,16 @@ class FlutterPlugin implements Plugin<Project> {
             throw new GradleException("Must provide Flutter source directory")
         }
 
+        String target = project.flutter.target;
+        if (target == null) {
+            target = 'lib/main.dart'
+        }
+
         FlutterTask flutterTask = project.tasks.create("flutterBuild", FlutterTask) {
             flutterRoot this.flutterRoot
             buildMode this.buildMode
             localEngine this.localEngine
+            targetPath target
             sourceDir project.file(project.flutter.source)
             intermediateDir project.file("${project.buildDir}/${AndroidProject.FD_INTERMEDIATES}/flutter")
         }
@@ -109,12 +115,14 @@ class FlutterPlugin implements Plugin<Project> {
 
 class FlutterExtension {
     String source
+    String target
 }
 
 class FlutterTask extends DefaultTask {
     File flutterRoot
     String buildMode
     String localEngine
+    String targetPath
 
     @InputDirectory
     File sourceDir
@@ -150,6 +158,7 @@ class FlutterTask extends DefaultTask {
               args "--local-engine", localEngine
             }
             args "build", "aot"
+            args "--target", targetPath
             args "--target-platform", "android-arm"
             args "--output-dir", "${intermediateDir}"
             args "--${buildMode}"
@@ -163,6 +172,7 @@ class FlutterTask extends DefaultTask {
               args "--local-engine", localEngine
             }
             args "build", "flx"
+            args "--target", targetPath
             args "--output-file", "${intermediateDir}/app.flx"
             if (buildMode != "debug") {
               args "--precompiled"


### PR DESCRIPTION
This lets you build something other than `lib/main.dart`.
