### PR TITLE
More flexibility for defining the locations of assets packaged in an FLX

### DIFF
--- a/packages/flutter_tools/lib/flutter_tools.dart
+++ b/packages/flutter_tools/lib/flutter_tools.dart
@@ -13,6 +13,7 @@ Future<int> assembleFlx({
   Map<String, dynamic> manifestDescriptor: const <String, dynamic>{},
   File snapshotFile: null,
   String assetBasePath: flx.defaultAssetBasePath,
+  Map<String, String> assetPathOverrides: const <String, String>{},
   String outputPath: flx.defaultFlxOutputPath,
   String privateKeyPath: flx.defaultPrivateKeyPath
 }) async {
@@ -20,6 +21,7 @@ Future<int> assembleFlx({
     manifestDescriptor: manifestDescriptor,
     snapshotFile: snapshotFile,
     assetBasePath: assetBasePath,
+    assetPathOverrides: assetPathOverrides,
     outputPath: outputPath,
     privateKeyPath: privateKeyPath
   );


### PR DESCRIPTION
- Add a map of relative to absolute paths for assets located outside the app's
  source directory
- If a "packages" directory exists, obtain assets from there instead of
  using the packages/ prefix to indicate package map lookup
