### PR TITLE
remove the debug:true param from the atom launch config

### DIFF
--- a/packages/flutter_tools/lib/src/run.dart
+++ b/packages/flutter_tools/lib/src/run.dart
@@ -30,8 +30,6 @@ String findMainDartFile([String target]) {
     return targetPath;
 }
 
-// TODO: split out the cli part of the UI from this class
-
 class RunAndStayResident {
   RunAndStayResident(
     this.device, {

--- a/packages/flutter_tools/templates/create/.atom/launches.tmpl/main.yaml.tmpl
+++ b/packages/flutter_tools/templates/create/.atom/launches.tmpl/main.yaml.tmpl
@@ -3,8 +3,6 @@ type: flutter
 path: lib/main.dart
 
 flutter:
-  # Enable or disable debugging.
-  debug: true
   # The starting route for the app.
   route:
   # Additional args for the flutter run command.


### PR DESCRIPTION
- remove the debug:true param from the atom launch config; this param isn't used anymore (we now pass in the debug/profile/release build modes via the UI)
- remove a no longer relevant TODO
