### PR TITLE
Smoothly scale the Pesto logo as the app bar resizes.

### DIFF
--- a/dev/benchmarks/complex_layout/pubspec.yaml
+++ b/dev/benchmarks/complex_layout/pubspec.yaml
@@ -6,7 +6,9 @@ dependencies:
     path: ../../../packages/flutter
   flutter_driver:
     path: ../../../packages/flutter_driver
-  flutter_gallery_assets: '0.0.20'
+  # Also update dev/manual_tests/pubspec.yaml
+  # and examples/flutter_gallery/pubspec.yaml
+  flutter_gallery_assets: '0.0.21'
 
 dev_dependencies:
   flutter_test:

--- a/dev/manual_tests/pubspec.yaml
+++ b/dev/manual_tests/pubspec.yaml
@@ -4,7 +4,9 @@ dependencies:
     path: ../../packages/flutter
   flutter_sprites:
     path: ../../packages/flutter_sprites
-  flutter_gallery_assets: '0.0.20'
+  # Also update dev/manual_tests/pubspec.yaml
+  # and dev/benchmarks/complex_layout/pubspec.yaml
+  flutter_gallery_assets: '0.0.21'
 
 dev_dependencies:
   test: any # flutter_test provides the version constraints

--- a/examples/flutter_gallery/flutter.yaml
+++ b/examples/flutter_gallery/flutter.yaml
@@ -35,8 +35,6 @@ assets:
   - packages/flutter_gallery_assets/ali_connors.png
   - packages/flutter_gallery_assets/kangaroo_valley_safari.png
   - packages/flutter_gallery_assets/top_10_australian_beaches.png
-  - packages/flutter_gallery_assets/grain.png
-  - packages/flutter_gallery_assets/fancylines.png
   - packages/flutter_gallery_assets/landscape_0.jpg
   - packages/flutter_gallery_assets/landscape_1.jpg
   - packages/flutter_gallery_assets/landscape_2.jpg

--- a/examples/flutter_gallery/lib/demo/pesto_demo.dart
+++ b/examples/flutter_gallery/lib/demo/pesto_demo.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:math';
+
 import 'package:flutter/material.dart';
 
 const String _kUserName = 'Jonathan';
@@ -13,6 +15,7 @@ final Map<double, String> _kLogoImages = <double, String>{
   70.0: 'packages/flutter_gallery_assets/pesto/logo_medium.png',
   170.0: 'packages/flutter_gallery_assets/pesto/logo_big.png',
 };
+
 final ThemeData _kTheme = new ThemeData(
   brightness: Brightness.light,
   primarySwatch: Colors.teal,
@@ -108,12 +111,18 @@ class _PestoDemoState extends State<PestoDemo> {
           double bestHeight = _kLogoImages.keys.lastWhere(
             (double height) => appBarHeight >= height
           );
+          // Extra padding. Calculated to give about 16px on the bottom for the
+          // `small` logo at its native size, and 30px for the `medium`.
+          double extraPadding = min(0.19 * appBarHeight + 5.4, 40.0);
           return new Padding(
-            padding: new EdgeInsets.only(top: statusBarHeight),
+            padding: new EdgeInsets.only(
+              top: statusBarHeight + 0.5 * extraPadding,
+              bottom: extraPadding
+            ),
             child: new Center(
               child: new AssetImage(
                 name: _kLogoImages[bestHeight],
-                fit: ImageFit.none
+                fit: ImageFit.scaleDown
               )
             )
           );

--- a/examples/flutter_gallery/pubspec.yaml
+++ b/examples/flutter_gallery/pubspec.yaml
@@ -8,7 +8,9 @@ dependencies:
     path: ../../packages/flutter
   flutter_markdown:
     path: ../../packages/flutter_markdown
-  flutter_gallery_assets: '0.0.20'
+  # Also update dev/benchmarks/complex_layout/pubspec.yaml
+  # and examples/flutter_gallery/pubspec.yaml
+  flutter_gallery_assets: '0.0.21'
 
 dev_dependencies:
   test: any # flutter_test provides the version constraints


### PR DESCRIPTION
Also update the assets version to pull in better quality logo images.

BUG=https://github.com/flutter/flutter/issues/4407
