### PR TITLE
Add a 'Return to Gallery' drawer option to Pesto.

### DIFF
--- a/examples/flutter_gallery/lib/demo/pesto_demo.dart
+++ b/examples/flutter_gallery/lib/demo/pesto_demo.dart
@@ -168,7 +168,17 @@ class _PestoDemoState extends State<PestoDemo> {
             child: new Text('Favorites'),
             selected: config.showFavorites,
             onPressed: () { _showFavorites(context); }
-          )
+          ),
+          new Divider(),
+          new DrawerItem(
+            new Text('Return to Gallery'),
+            onPressed: () {
+              Navigator.openTransaction(context, (NavigatorTransaction transaction) {
+                transaction.pop();  // Close the Drawer
+                transaction.pop();  // Go back to the gallery
+              });
+            }
+          ),
         ]
       )
     );

--- a/examples/flutter_gallery/lib/demo/pesto_demo.dart
+++ b/examples/flutter_gallery/lib/demo/pesto_demo.dart
@@ -171,7 +171,7 @@ class _PestoDemoState extends State<PestoDemo> {
           ),
           new Divider(),
           new DrawerItem(
-            new Text('Return to Gallery'),
+            child: new Text('Return to Gallery'),
             onPressed: () {
               Navigator.openTransaction(context, (NavigatorTransaction transaction) {
                 transaction.pop();  // Close the Drawer


### PR DESCRIPTION
BUG=https://github.com/flutter/flutter/issues/4402
