### PR TITLE
Update pesto_demo.dart

### DIFF
--- a/examples/flutter_gallery/lib/demo/pesto_demo.dart
+++ b/examples/flutter_gallery/lib/demo/pesto_demo.dart
@@ -174,8 +174,7 @@ class _PestoDemoState extends State<PestoDemo> {
             child: new Text('Return to Gallery'),
             onPressed: () {
               Navigator.openTransaction(context, (NavigatorTransaction transaction) {
-                transaction.pop();  // Close the Drawer
-                transaction.pop();  // Go back to the gallery
+                transaction.pushNamed('/');
               });
             }
           ),


### PR DESCRIPTION
@mpcomplete, have the return to gallery action go to a named route. Otherwise when starting the gallery up to a specific route (flutter run --route /pesto), choosing return to gallery will take you to a blank screen.
