### PR TITLE
add a source_graph library to find the transitive deps of an entry-point

### DIFF
--- a/packages/flutter_tools/benchmark/source_graph_benchmark.dart
+++ b/packages/flutter_tools/benchmark/source_graph_benchmark.dart
@@ -15,8 +15,5 @@ void main() {
   stopwatch.stop();
   print('${graph.sources.length} sources parsed in ${stopwatch.elapsedMilliseconds}ms.');
 
-  stopwatch = new Stopwatch()..start();
-  graph.reparseSources();
-  stopwatch.stop();
-  print('${graph.changes.length} sources reparsed in ${stopwatch.elapsedMilliseconds}ms.');
+  // TODO(devoncarew): Benchmark an incremental `reparseSources()` mode.
 }

--- a/packages/flutter_tools/benchmark/source_graph_benchmark.dart
+++ b/packages/flutter_tools/benchmark/source_graph_benchmark.dart
@@ -1,0 +1,22 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:io';
+
+import 'package:flutter_tools/src/dart/source_graph.dart';
+
+void main() {
+  Directory directory = new Directory('../../examples/flutter_gallery');
+  SourceGraph graph = new SourceGraph(directory, 'lib/main.dart');
+
+  Stopwatch stopwatch = new Stopwatch()..start();
+  graph.initialParse();
+  stopwatch.stop();
+  print('${graph.sources.length} sources parsed in ${stopwatch.elapsedMilliseconds}ms.');
+
+  stopwatch = new Stopwatch()..start();
+  graph.reparseSources();
+  stopwatch.stop();
+  print('${graph.changes.length} sources reparsed in ${stopwatch.elapsedMilliseconds}ms.');
+}

--- a/packages/flutter_tools/lib/src/dart/source_graph.dart
+++ b/packages/flutter_tools/lib/src/dart/source_graph.dart
@@ -1,0 +1,288 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:io';
+
+import 'package:analyzer/analyzer.dart';
+import 'package:analyzer/src/generated/java_io.dart'; // ignore: implementation_imports
+import 'package:analyzer/src/generated/sdk.dart'; // ignore: implementation_imports
+import 'package:analyzer/src/generated/sdk_io.dart'; // ignore: implementation_imports
+import 'package:package_config/packages_file.dart' as packages;
+import 'package:path/path.dart' as path;
+import 'package:yaml/yaml.dart' as yaml;
+
+import 'sdk.dart';
+
+// TODO: do we need to traverse into dart: libraries? Or ones that are really packages?
+
+// TODO: added, changed, and removed sources
+
+// TODO: For performance, the lexer should not lex the entire file.
+
+// TODO: switch to sources having sourcerefs that need to be resolved
+
+// TODO: they should know - independently of being dirty - whether all their
+// refs were resolved
+
+// TODO: support conditional directives
+
+class SourceGraph {
+  SourceGraph(this.directory, this.entryPointPath, { this.parseEmbedderSource: false });
+
+  final Directory directory;
+  final String entryPointPath;
+  final bool parseEmbedderSource;
+
+  PackagesFile _packagesFile;
+  Map<String, String> _dartLibraryMap = <String, String>{};
+  bool _wasIncremental = false;
+  Map<String, GraphSource> _sourceMap = <String, GraphSource>{};
+  List<GraphChange> _changes = <GraphChange>[];
+
+  /// Whether the last parse was incremental, or a full re-parse.
+  bool get wasIncremental => _wasIncremental;
+
+  Iterable<GraphSource> get sources => _sourceMap.values;
+
+  List<GraphChange> get changes => _changes;
+
+  void initialParse() {
+    _fullParse();
+  }
+
+  void reparseSources() {
+    if (!_packagesFile.isUpToDate) {
+      _fullParse();
+      return;
+    }
+
+    _wasIncremental = true;
+
+    // TODO: start with the root node again
+
+
+    // TODO: find any out-of-date sources
+
+
+    // TODO: find any sources that didn't resolve their dependencies
+
+
+    // Parse any dirty sources.
+    while (sources.any((GraphSource source) => source.dirty)) {
+      for (GraphSource source in sources.where((GraphSource source) => source.dirty).toList()) {
+        source.parse();
+      }
+    }
+
+    // TODO: check for no longer referenced sources
+
+  }
+
+  /// Flush any cached file contents.
+  void flushCachedFileContents() {
+    for (GraphSource source in sources)
+      source.flushCachedFileContents();
+  }
+
+  void _fullParse() {
+    _wasIncremental = false;
+
+    _sourceMap.clear();
+    _changes.clear();
+
+    if (parseEmbedderSource) {
+      // Parse the libraries.dart file - use that info to resolve dart: references.
+      _dartLibraryMap.clear();
+      String sdkPath = dartSdkPath;
+      File librariesFile = new File(path.join(sdkPath, 'lib/_internal/libraries.dart'));
+      if (librariesFile.existsSync()) {
+        SdkLibrariesReader reader = new SdkLibrariesReader(false);
+        LibraryMap dartLibraryMap = reader.readFromFile(
+          new JavaFile(librariesFile.path), librariesFile.readAsStringSync()
+        );
+
+        String libPath = path.normalize(path.absolute(path.join(dartSdkPath, 'lib')));
+        for (SdkLibrary library in dartLibraryMap.sdkLibraries)
+          _dartLibraryMap[library.shortName] = path.join(libPath, library.path);
+      }
+    }
+
+    // Parse the .packages file.
+    _packagesFile = new PackagesFile(new File(path.join(directory.path, '.packages')));
+    _packagesFile.parse();
+
+    GraphSource root = _getCreateSource(path.join(directory.path, entryPointPath));
+    root.parse();
+
+    // Parse any dirty sources.
+    while (sources.any((GraphSource source) => source.dirty)) {
+      for (GraphSource source in sources.where((GraphSource source) => source.dirty).toList()) {
+        source.parse();
+      }
+    }
+  }
+
+  GraphSource _getCreateSource(String resolvedPath) {
+    if (_sourceMap.containsKey(resolvedPath)) {
+      return _sourceMap[resolvedPath];
+    } else {
+      GraphSource source = new GraphSource(this, resolvedPath);
+      _sourceMap[resolvedPath] = source;
+      return source;
+    }
+  }
+
+  String _resolveDirectiveUri(String uriString, String basePath) {
+    if (!uriString.contains(':')) {
+      return path.normalize(path.join(path.dirname(basePath), uriString));
+    } else {
+      Uri uri = Uri.parse(uriString);
+
+      if (uri.scheme == 'dart') {
+        if (parseEmbedderSource) {
+          // dart:
+          if (_packagesFile.canResolveDart) {
+            return _packagesFile.resolveDart(uri.toString());
+          } else {
+            return _dartLibraryMap[uri.toString()];
+          }
+        } else {
+          return null;
+        }
+      } else if (uri.scheme == 'package') {
+        // package:
+        String root = uri.pathSegments.first;
+        String relPath = uri.pathSegments.sublist(1).join('/');
+        return _packagesFile.resolvePackage(root, relPath);
+      } else {
+        return null;
+      }
+    }
+  }
+}
+
+class GraphSource {
+  GraphSource(this.graph, this.fullpath);
+
+  final SourceGraph graph;
+  final String fullpath;
+  final List<GraphSourceReference> references = <GraphSourceReference>[];
+  bool dirty = true;
+  DateTime _stamp;
+  String _cachedSource;
+
+  bool get isUpToDate => _file.lastModifiedSync() == _stamp;
+
+  String getSource() {
+    if (_cachedSource != null && isUpToDate)
+      return _cachedSource;
+
+    _cachedSource = _file.readAsStringSync();
+    _stamp = _file.lastModifiedSync();
+    return _cachedSource;
+  }
+
+  void parse() {
+    dirty = false;
+    references.clear();
+
+    CompilationUnit unit = parseDirectives(getSource(), name: fullpath, suppressErrors: true);
+
+    for (Directive directive in unit.directives) {
+      if (directive is ExportDirective || directive is ImportDirective || directive is PartDirective) {
+        UriBasedDirective uriBasedDirective = directive;
+        String uri = uriBasedDirective.uri.stringValue;
+
+        GraphSourceReference reference = new GraphSourceReference(this, uri);
+        references.add(reference);
+
+        // TODO: resolve the reference
+
+        String resolvedPath = graph._resolveDirectiveUri(uri, fullpath);
+        // TODO: it's ok if parseEmbedderSource and the dart: ref didn't resolve
+
+        // TODO: What to do if this doesn't return a value?
+        if (resolvedPath != null) {
+          graph._getCreateSource(resolvedPath);
+        }
+      }
+    }
+  }
+
+  File get _file => new File(fullpath);
+
+  @override
+  String toString() => fullpath;
+
+  bool get hasCachedFileContents => _cachedSource != null;
+
+  void flushCachedFileContents() {
+    _cachedSource = null;
+  }
+}
+
+class GraphSourceReference {
+  GraphSourceReference(this.parent, this.uri);
+
+  final GraphSource parent;
+  final String uri;
+
+  bool resolved;
+  bool unneeded;
+
+}
+
+class GraphChange {
+
+}
+
+class PackagesFile {
+  PackagesFile(this.file);
+
+  final File file;
+  DateTime _stamp;
+  Map<String, Uri> _packageInfo;
+
+  String _embedderFilePath;
+  Map<String, String> _embeddedLibs;
+
+  bool get isUpToDate => file.lastModifiedSync() == _stamp;
+
+  void parse() {
+    _packageInfo = packages.parse(file.readAsBytesSync(), file.parent.uri);
+    _stamp = file.lastModifiedSync();
+
+    // Look for am _embedder.yaml file with a embedded_libs section.
+    _embedderFilePath = null;
+    _embeddedLibs = null;
+
+    for (Uri uri in _packageInfo.values) {
+      if (uri.scheme == 'file' || uri.scheme.isEmpty) {
+        File embedder = new File(path.join(uri.path, '_embedder.yaml'));
+        if (embedder.existsSync()) {
+          dynamic contents = yaml.loadYaml(embedder.readAsStringSync());
+          _embedderFilePath = path.absolute(embedder.parent.path);
+          _embeddedLibs = contents is Map ? contents['embedded_libs'] : null;
+          break;
+        }
+      }
+    }
+  }
+
+  String resolvePackage(String packageName, String relPath) {
+    Uri uri = _packageInfo[packageName];
+    if (uri == null)
+      return null;
+    return path.normalize(path.join(uri.path, relPath));
+  }
+
+  bool get canResolveDart => _embeddedLibs != null;
+
+  String resolveDart(String dartUri) {
+    String dartPath = _embeddedLibs[dartUri];
+    if (dartPath == null)
+      return null;
+    return path.normalize(path.join(_embedderFilePath, dartPath));
+  }
+}

--- a/packages/flutter_tools/lib/src/dart/source_graph.dart
+++ b/packages/flutter_tools/lib/src/dart/source_graph.dart
@@ -81,20 +81,13 @@ class SourceGraph {
 
     // Parse any dirty sources.
     while (sources.any((GraphSource source) => source.dirty)) {
-      for (GraphSource source in sources.where((GraphSource source) => source.dirty).toList()) {
+      for (GraphSource source in sources.where((GraphSource source) => source.dirty).toList())
         source.parse();
-      }
     }
   }
 
   GraphSource _getCreateSource(String resolvedPath) {
-    if (_sourceMap.containsKey(resolvedPath)) {
-      return _sourceMap[resolvedPath];
-    } else {
-      GraphSource source = new GraphSource(this, resolvedPath);
-      _sourceMap[resolvedPath] = source;
-      return source;
-    }
+    return _sourceMap.putIfAbsent(resolvedPath, () => new GraphSource(this, resolvedPath));
   }
 
   String _resolveDirectiveUri(String uriString, String basePath) {
@@ -154,9 +147,8 @@ class GraphSource {
     CompilationUnit unit = parseDirectives(getSource(), name: fullpath, suppressErrors: true);
 
     for (Directive directive in unit.directives) {
-      if (directive is ExportDirective || directive is ImportDirective || directive is PartDirective) {
-        UriBasedDirective uriBasedDirective = directive;
-        String uri = uriBasedDirective.uri.stringValue;
+      if (directive is UriBasedDirective) {
+        String uri = directive.uri.stringValue;
 
         GraphSourceReference reference = new GraphSourceReference(this, uri);
 

--- a/packages/flutter_tools/test/all.dart
+++ b/packages/flutter_tools/test/all.dart
@@ -25,6 +25,7 @@ import 'logs_test.dart' as logs_test;
 import 'os_utils_test.dart' as os_utils_test;
 import 'protocol_discovery_test.dart' as protocol_discovery_test;
 import 'run_test.dart' as run_test;
+import 'source_graph_test.dart' as source_graph_test;
 import 'stop_test.dart' as stop_test;
 import 'toolchain_test.dart' as toolchain_test;
 import 'trace_test.dart' as trace_test;
@@ -49,6 +50,7 @@ void main() {
   os_utils_test.main();
   protocol_discovery_test.main();
   run_test.main();
+  source_graph_test.main();
   stop_test.main();
   toolchain_test.main();
   trace_test.main();

--- a/packages/flutter_tools/test/source_graph_test.dart
+++ b/packages/flutter_tools/test/source_graph_test.dart
@@ -1,0 +1,91 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:io';
+
+import 'package:args/command_runner.dart';
+import 'package:flutter_tools/src/cache.dart';
+import 'package:flutter_tools/src/commands/create.dart';
+import 'package:flutter_tools/src/dart/source_graph.dart';
+import 'package:flutter_tools/src/runner/flutter_command_runner.dart';
+import 'package:test/test.dart';
+
+import 'src/common.dart';
+import 'src/context.dart';
+
+void main() {
+  group('source_graph', () {
+    Directory temp;
+
+    setUp(() {
+      FlutterCommandRunner.initFlutterRoot();
+      temp = Directory.systemTemp.createTempSync('flutter_tools');
+    });
+
+    tearDown(() {
+      temp.deleteSync(recursive: true);
+    });
+
+    test('reparse with no changes', () {
+      Directory directory = new Directory('../../examples/flutter_gallery');
+      SourceGraph graph = new SourceGraph(directory, 'lib/main.dart');
+
+      graph.initialParse();
+      expect(graph.sources.length, greaterThan(100));
+
+      graph.reparseSources();
+      expect(graph.wasIncremental, true);
+      expect(graph.changes.length, 0);
+    });
+
+    testUsingContext('reparse with changes', () async {
+      await _createProject(temp);
+
+      // initial parse
+      SourceGraph graph = new SourceGraph(temp, 'lib/main.dart');
+      graph.initialParse();
+      expect(graph.sources.length, greaterThan(100));
+
+      // touch the main file
+      File mainFile = new File('${temp.path}/lib/main.dart');
+      mainFile.writeAsStringSync(mainFile.readAsStringSync() + '\n');
+      graph.reparseSources();
+      expect(graph.wasIncremental, true);
+      expect(graph.changes.length, 1);
+
+      // expect no changes
+      graph.reparseSources();
+      expect(graph.wasIncremental, true);
+      expect(graph.changes.length, 1);
+
+      // change an import
+      // TODO:
+
+      // touch the .packages file
+      File packagesFile = new File('${temp.path}/.packages');
+      packagesFile.writeAsStringSync(packagesFile.readAsStringSync() + '\n');
+      graph.reparseSources();
+      expect(graph.wasIncremental, false);
+    });
+
+    test('flush cached file contents', () {
+      SourceGraph graph = new SourceGraph(Directory.current, 'test/source_graph_test.dart');
+      graph.initialParse();
+      expect(graph.sources.length, greaterThan(100));
+      expect(graph.sources.first.hasCachedFileContents, true);
+
+      graph.flushCachedFileContents();
+      expect(graph.sources.first.hasCachedFileContents, false);
+    });
+  });
+}
+
+Future<Null> _createProject(Directory dir) async {
+  Cache.flutterRoot = '../..';
+  CreateCommand command = new CreateCommand();
+  CommandRunner runner = createTestCommandRunner(command);
+  int code = await runner.run(<String>['create', dir.path]);
+  expect(code, 0);
+}

--- a/packages/flutter_tools/test/source_graph_test.dart
+++ b/packages/flutter_tools/test/source_graph_test.dart
@@ -28,19 +28,15 @@ void main() {
       temp.deleteSync(recursive: true);
     });
 
-    test('reparse with no changes', () {
+    test('initial parse', () {
       Directory directory = new Directory('../../examples/flutter_gallery');
       SourceGraph graph = new SourceGraph(directory, 'lib/main.dart');
 
       graph.initialParse();
       expect(graph.sources.length, greaterThan(100));
-
-      graph.reparseSources();
-      expect(graph.wasIncremental, true);
-      expect(graph.changes.length, 0);
     });
 
-    testUsingContext('reparse with changes', () async {
+    testUsingContext('parse with changes', () async {
       await _createProject(temp);
 
       // initial parse
@@ -48,20 +44,9 @@ void main() {
       graph.initialParse();
       expect(graph.sources.length, greaterThan(100));
 
-      // touch the main file
-      File mainFile = new File('${temp.path}/lib/main.dart');
-      mainFile.writeAsStringSync(mainFile.readAsStringSync() + '\n');
-      graph.reparseSources();
-      expect(graph.wasIncremental, true);
-      expect(graph.changes.length, 1);
+      // TODO(devoncarew): touch the main file, verify incremental is correct
 
-      // expect no changes
-      graph.reparseSources();
-      expect(graph.wasIncremental, true);
-      expect(graph.changes.length, 1);
-
-      // change an import
-      // TODO:
+      // TODO(devoncarew): reparse with no changes, expect that there are no changes
 
       // touch the .packages file
       File packagesFile = new File('${temp.path}/.packages');


### PR DESCRIPTION
This uses the analyzer library to parse the directives of dart files, traversing from an entry-point to all referenced sources. This will be used to send dart sources to the VM's dev FS. This is non-incremental - incrementality will be added as follow-on work.

Parsing the graph for flutter_gallery:

```
452 sources parsed in 684ms.
```

Making it incremental will drop later parses to ~ms range, and there's some additional possible optimization w/ only tokenizing the parts of the source file that we need (the directives).

@bwilkerson for review

/cc @johnmccutchan @turnidge
