### PR TITLE
send application files to the observatory's devfs

### DIFF
--- a/packages/flutter_tools/lib/src/commands/run.dart
+++ b/packages/flutter_tools/lib/src/commands/run.dart
@@ -59,6 +59,10 @@ class RunCommand extends RunCommandBase {
         defaultsTo: true,
         help: 'Don\'t terminate the \'flutter run\' process after starting the application.');
 
+    // Hidden option to ship all the sources of the current project over to the
+    // embedder via the DevFS observatory API.
+    argParser.addFlag('devfs', negatable: false, hide: true);
+
     // Hidden option to enable a benchmarking mode. This will run the given
     // application, measure the startup time and the app restart time, write the
     // results out to 'refresh_benchmark.json', and exit. This flag is intended
@@ -116,7 +120,8 @@ class RunCommand extends RunCommandBase {
       RunAndStayResident runner = new RunAndStayResident(
         deviceForCommand,
         target: target,
-        debuggingOptions: options
+        debuggingOptions: options,
+        useDevFS: argResults['devfs']
       );
 
       return runner.run(

--- a/packages/flutter_tools/lib/src/observatory.dart
+++ b/packages/flutter_tools/lib/src/observatory.dart
@@ -168,10 +168,8 @@ class Observatory {
 
   // Write multiple files into a file system.
   Future<Response> writeDevFSFiles(String fsName, {
-    String path,
     List<DevFSFile> files
   }) {
-    assert(path != null);
     assert(files != null);
 
     return sendRequest('_writeDevFSFiles', <String, dynamic> {
@@ -188,8 +186,10 @@ class Observatory {
   }
 
   /// The complete list of a file system.
-  Future<List<String>> listDevFSFiles() {
-    return sendRequest('_listDevFSFiles').then((Response response) {
+  Future<List<String>> listDevFSFiles(String fsName) {
+    return sendRequest('_listDevFSFiles', <String, dynamic> {
+      'fsName': fsName
+    }).then((Response response) {
       return response.response['files'];
     });
   }

--- a/packages/flutter_tools/lib/src/run.dart
+++ b/packages/flutter_tools/lib/src/run.dart
@@ -433,7 +433,7 @@ class DevFS {
     entries.putIfAbsent(devPath, () => new DevFSFileEntry(devPath, file));
   }
 
-  /// Flush any modified files to the devfs and return the number of files transferred.
+  /// Flush any modified files to the devfs.
   Future<Null> flush() async {
     List<DevFSFileEntry> toSend = entries.values
       .where((DevFSFileEntry entry) => entry.isModified)


### PR DESCRIPTION
- add a hidden option to `flutter run` - `--devfs` - which can send app files over to the observatory's devfs
- on a `d` key press, send all files in the main project directory, recursively in `lib/`, and in all packages referenced by the `.packages` file

For a hello world flutter app this sends 879 files - only about 460 of those are actually live and used by the app. It takes 13-15 seconds to send the initial set of files, either because of the large data transfer over adb, or the base64 -> json -> utf encoding for all the file data. We'll move to a binary encoding in the future and change to code that only sends the minimal set of files.

@yjbanov 

@turnidge, @johnmccutchan, I don't have a way to test this locally -

```
sending devfs://sample_app/packages/yaml/src/yaml_node.dart
sending devfs://sample_app/packages/yaml/src/yaml_node_wrapper.dart
sending devfs://sample_app/packages/yaml/yaml.dart
Sending 879 files...
Error sending DevFS files: JSON-RPC error -32601 (method not found): Method not found (15010ms)
Sending 0 files...
Sent in 4ms.
sending devfs://sample_app/lib/main.dart
Sending 1 files...
Error sending DevFS files: JSON-RPC error -32601 (method not found): Method not found (46ms)
Sending 0 files...
Sent in 3ms.
dsending devfs://sample_app/lib/main.dart
Sending 1 files...
Error sending DevFS files: JSON-RPC error -32601 (method not found): Method not found (13ms)
dSending 0 files...
Sent in 4ms.
Application finished.
```
