### PR TITLE
Remove unused consts in floating action button code.

### DIFF
--- a/packages/flutter/lib/src/material/floating_action_button.dart
+++ b/packages/flutter/lib/src/material/floating_action_button.dart
@@ -17,8 +17,6 @@ import 'tooltip.dart';
 // http://www.google.com/design/spec/layout/metrics-keylines.html#metrics-keylines-keylines-spacing
 const double _kSize = 56.0;
 const double _kSizeMini = 40.0;
-const Duration _kChildSegue = const Duration(milliseconds: 400);
-const Interval _kChildSegueInterval = const Interval(0.65, 1.0);
 
 /// A material design floating action button.
 ///


### PR DESCRIPTION
FAB segue animation is done in scaffold and the consts are there.
