### PR TITLE
Define LayoutWidgetBuilder in terms of BoxConstraints instead of Size

### DIFF
--- a/examples/flutter_gallery/lib/demo/pesto_demo.dart
+++ b/examples/flutter_gallery/lib/demo/pesto_demo.dart
@@ -90,7 +90,8 @@ class _PestoDemoState extends State<PestoDemo> {
         )
       ],
       flexibleSpace: new LayoutBuilder(
-        builder: (BuildContext context, Size size) {
+        builder: (BuildContext context, BoxConstraints constraints) {
+          final Size size = constraints.biggest;
           double appBarHeight = size.height - statusBarHeight;
           double bestHeight = _kLogoImages.keys.lastWhere(
             (double height) => appBarHeight >= height

--- a/examples/flutter_gallery/lib/demo/pesto_demo.dart
+++ b/examples/flutter_gallery/lib/demo/pesto_demo.dart
@@ -294,27 +294,33 @@ class _RecipePageState extends State<_RecipePage> {
     return new Stack(
       children: <Widget>[
         _buildContainer(context),
-        new Padding(
-          padding: new EdgeInsets.only(top: statusBarHeight),
-          child: new AppBar(
-            backgroundColor: Colors.transparent,
-            elevation: 0,
-            leading: new IconButton(
-              icon: Icons.arrow_back,
-              onPressed: () => Navigator.pop(context),
-              tooltip: 'Back'
-            ),
-            actions: <Widget>[
-              new PopupMenuButton<String>(
-                onSelected: (String item) {},
-                itemBuilder: (BuildContext context) => <PopupMenuItem<String>>[
-                  _buildMenuItem(Icons.share, 'Tweet recipe'),
-                  _buildMenuItem(Icons.email, 'Email recipe'),
-                  _buildMenuItem(Icons.message, 'Message recipe'),
-                  _buildMenuItem(Icons.people, 'Share on Facebook'),
-                ]
-              )
-            ]
+        new Positioned(
+          top: 0.0,
+          left: 0.0,
+          right: 0.0,
+          child: new Container(
+            height: kToolBarHeight + statusBarHeight,
+            padding: new EdgeInsets.only(top: statusBarHeight),
+            child: new AppBar(
+              backgroundColor: Colors.transparent,
+              elevation: 0,
+              leading: new IconButton(
+                icon: Icons.arrow_back,
+                onPressed: () => Navigator.pop(context),
+                tooltip: 'Back'
+              ),
+              actions: <Widget>[
+                new PopupMenuButton<String>(
+                  onSelected: (String item) {},
+                  itemBuilder: (BuildContext context) => <PopupMenuItem<String>>[
+                    _buildMenuItem(Icons.share, 'Tweet recipe'),
+                    _buildMenuItem(Icons.email, 'Email recipe'),
+                    _buildMenuItem(Icons.message, 'Message recipe'),
+                    _buildMenuItem(Icons.people, 'Share on Facebook'),
+                  ]
+                )
+              ]
+            )
           )
         )
       ]

--- a/packages/flutter/lib/src/material/app_bar.dart
+++ b/packages/flutter/lib/src/material/app_bar.dart
@@ -275,6 +275,8 @@ class AppBar extends StatelessWidget {
           child: appBar
         )
       );
+    } else if (flexibleSpace != null) {
+      appBar = new Positioned(top: 0.0, left: 0.0, right: 0.0, child: appBar);
     }
 
     if (flexibleSpace != null) {

--- a/packages/flutter/lib/src/material/app_bar.dart
+++ b/packages/flutter/lib/src/material/app_bar.dart
@@ -178,8 +178,9 @@ class AppBar extends StatelessWidget {
     return ((appBarHeight - statusBarHeight) / tabBarHeight).clamp(0.0, 1.0);
   }
 
-  Widget _buildForSize(BuildContext context, Size size) {
-    assert(size.height < double.INFINITY);
+  Widget _buildForSize(BuildContext context, BoxConstraints constraints) {
+    assert(constraints.maxHeight < double.INFINITY);
+    final Size size = constraints.biggest;
     final double statusBarHeight = MediaQuery.of(context).padding.top;
     final ThemeData theme = Theme.of(context);
 

--- a/packages/flutter/lib/src/widgets/layout_builder.dart
+++ b/packages/flutter/lib/src/widgets/layout_builder.dart
@@ -17,7 +17,7 @@ typedef Widget LayoutWidgetBuilder(BuildContext context, BoxConstraints constrai
 /// function at layout time and provides the parent widget's constraints. This
 /// is useful when the parent constrains the child's size and doesn't depend on
 /// the child's intrinsic size. The LayoutBuilder's final size will match its
-/// child's size modulo the incoming constraints.
+/// child's size.
 class LayoutBuilder extends RenderObjectWidget {
   /// Creates a widget that defers its building until layout.
   ///

--- a/packages/flutter/test/widget/layout_builder_test.dart
+++ b/packages/flutter/test/widget/layout_builder_test.dart
@@ -10,19 +10,20 @@ void main() {
   testWidgets('LayoutBuilder parent size', (WidgetTester tester) async {
     Size layoutBuilderSize;
     Key childKey = new UniqueKey();
+    Key parentKey = new UniqueKey();
 
     await tester.pumpWidget(
       new Center(
-        child: new SizedBox(
-          width: 100.0,
-          height: 200.0,
+        child: new ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 100.0, maxHeight: 200.0),
           child: new LayoutBuilder(
-            builder: (BuildContext context, Size size) {
-              layoutBuilderSize = size;
+            key: parentKey,
+            builder: (BuildContext context, BoxConstraints constraints) {
+              layoutBuilderSize = constraints.biggest;
               return new SizedBox(
                 key: childKey,
-                width: size.width / 2.0,
-                height: size.height / 2.0
+                width: layoutBuilderSize.width / 2.0,
+                height: layoutBuilderSize.height / 2.0
               );
             }
           )
@@ -31,46 +32,56 @@ void main() {
     );
 
     expect(layoutBuilderSize, const Size(100.0, 200.0));
-    RenderBox box = tester.renderObject(find.byKey(childKey));
-    expect(box.size, equals(const Size(50.0, 100.0)));
+    RenderBox parentBox = tester.renderObject(find.byKey(parentKey));
+    expect(parentBox.size, equals(const Size(50.0, 100.0)));
+    RenderBox childBox = tester.renderObject(find.byKey(childKey));
+    expect(childBox.size, equals(const Size(50.0, 100.0)));
   });
 
   testWidgets('LayoutBuilder stateful child', (WidgetTester tester) async {
     Size layoutBuilderSize;
     StateSetter setState;
     Key childKey = new UniqueKey();
+    Key parentKey = new UniqueKey();
     double childWidth = 10.0;
     double childHeight = 20.0;
 
     await tester.pumpWidget(
-      new LayoutBuilder(
-        builder: (BuildContext context, Size size) {
-          layoutBuilderSize = size;
-          return new StatefulBuilder(
-            builder: (BuildContext context, StateSetter setter) {
-              setState = setter;
-              return new SizedBox(
-                key: childKey,
-                width: childWidth,
-                height: childHeight
-              );
-            }
-          );
-        }
+      new Center(
+        child: new LayoutBuilder(
+          key: parentKey,
+          builder: (BuildContext context, BoxConstraints constraints) {
+            layoutBuilderSize = constraints.biggest;
+            return new StatefulBuilder(
+              builder: (BuildContext context, StateSetter setter) {
+                setState = setter;
+                return new SizedBox(
+                  key: childKey,
+                  width: childWidth,
+                  height: childHeight
+                );
+              }
+            );
+          }
+        )
       )
     );
 
     expect(layoutBuilderSize, equals(const Size(800.0, 600.0)));
-    RenderBox box = tester.renderObject(find.byKey(childKey));
-    expect(box.size, equals(const Size(10.0, 20.0)));
+    RenderBox parentBox = tester.renderObject(find.byKey(parentKey));
+    expect(parentBox.size, equals(const Size(10.0, 20.0)));
+    RenderBox childBox = tester.renderObject(find.byKey(childKey));
+    expect(childBox.size, equals(const Size(10.0, 20.0)));
 
     setState(() {
       childWidth = 100.0;
       childHeight = 200.0;
     });
     await tester.pump();
-    box = tester.renderObject(find.byKey(childKey));
-    expect(box.size, equals(const Size(100.0, 200.0)));
+    parentBox = tester.renderObject(find.byKey(parentKey));
+    expect(parentBox.size, equals(const Size(100.0, 200.0)));
+    childBox = tester.renderObject(find.byKey(childKey));
+    expect(childBox.size, equals(const Size(100.0, 200.0)));
   });
 
   testWidgets('LayoutBuilder stateful parent', (WidgetTester tester) async {
@@ -89,12 +100,12 @@ void main() {
               width: childWidth,
               height: childHeight,
               child: new LayoutBuilder(
-                builder: (BuildContext context, Size size) {
-                  layoutBuilderSize = size;
+                builder: (BuildContext context, BoxConstraints constraints) {
+                  layoutBuilderSize = constraints.biggest;
                   return new SizedBox(
                     key: childKey,
-                    width: size.width,
-                    height: size.height
+                    width: layoutBuilderSize.width,
+                    height: layoutBuilderSize.height
                   );
                 }
               )
@@ -117,10 +128,11 @@ void main() {
     expect(box.size, equals(const Size(100.0, 200.0)));
   });
 
+
   testWidgets('LayoutBuilder and Inherited -- do not rebuild when not using inherited', (WidgetTester tester) async {
     int built = 0;
     Widget target = new LayoutBuilder(
-      builder: (BuildContext context, Size size) {
+      builder: (BuildContext context, BoxConstraints constraints) {
         built += 1;
         return new Container();
       }
@@ -143,7 +155,7 @@ void main() {
   testWidgets('LayoutBuilder and Inherited -- do rebuild when using inherited', (WidgetTester tester) async {
     int built = 0;
     Widget target = new LayoutBuilder(
-      builder: (BuildContext context, Size size) {
+      builder: (BuildContext context, BoxConstraints constraints) {
         built += 1;
         MediaQuery.of(context);
         return new Container();


### PR DESCRIPTION
Change the LayoutWidgetBuilder's second parameter to be the incoming constraints instead of the value of constraints.biggest.

The LayoutWidgetBuilder's size is now defined by the size of its child modulo the incoming constraints.

Fixes #4524
