### PR TITLE
Pesto: Fix app bar height when returning from recipe page.

### DIFF
--- a/examples/flutter_gallery/lib/demo/pesto_demo.dart
+++ b/examples/flutter_gallery/lib/demo/pesto_demo.dart
@@ -51,7 +51,7 @@ class PestoDemo extends StatefulWidget {
 }
 
 class _PestoDemoState extends State<PestoDemo> {
-  final GlobalKey<ScaffoldState> _scaffoldKey = new GlobalKey<ScaffoldState>();
+  static final GlobalKey<ScaffoldState> _scaffoldKey = new GlobalKey<ScaffoldState>();
   final TextStyle favoritesMessageStyle = _textStyle(16.0);
   final TextStyle userStyle = _textStyle(12.0, FontWeight.bold);
   final TextStyle emailStyle = _textStyle(12.0).copyWith(color: Colors.black54);
@@ -77,7 +77,7 @@ class _PestoDemoState extends State<PestoDemo> {
   Widget _buildAppBar(BuildContext context) {
     final double statusBarHeight = MediaQuery.of(context).padding.top;
     return new AppBar(
-      expandedHeight: 128.0,
+      expandedHeight: _kAppBarHeight,
       actions: <Widget>[
         new IconButton(
           icon: Icons.search,


### PR DESCRIPTION
The problem was that the Scaffold was getting a new key each time we
navigated to the main page. The key influences where page state is
stored, including the scroll offset. So for a single frame, the Scaffold
incorrectly thinks the scroll offset is 0 and the app bar should be
expanded.

BUG=https://github.com/flutter/flutter/issues/4400
