### PR TITLE
Dead code, switch cleanup and `crypto` bump.

### DIFF
--- a/packages/flutter/lib/src/rendering/block.dart
+++ b/packages/flutter/lib/src/rendering/block.dart
@@ -57,6 +57,8 @@ class RenderBlock extends RenderBox
       case Axis.vertical:
         return new BoxConstraints.tightFor(width: constraints.maxWidth);
     }
+    assert(_mainAxis != null);
+    return null;
   }
 
   double get _mainAxisExtent {
@@ -70,6 +72,8 @@ class RenderBlock extends RenderBox
       case Axis.vertical:
         return parentData.offset.dy + child.size.height;
     }
+    assert(mainAxis != null);
+    return null;
   }
 
   @override
@@ -92,7 +96,6 @@ class RenderBlock extends RenderBox
         'axis. You probably want to put the RenderBlock inside a '
         'RenderViewport with a matching main axis.'
       );
-      return false;
     });
     assert(() {
       switch (mainAxis) {
@@ -118,7 +121,6 @@ class RenderBlock extends RenderBox
         'for example, a RenderIntrinsicWidth or RenderIntrinsicHeight object. '
         'This is relatively expensive, however.' // (that's why we don't do it automatically)
       );
-      return false;
     });
     BoxConstraints innerConstraints = _getInnerConstraints(constraints);
     double position = 0.0;
@@ -187,6 +189,8 @@ class RenderBlock extends RenderBox
       case Axis.vertical:
         return _getIntrinsicCrossAxis((RenderBox child) => child.getMinIntrinsicWidth(height));
     }
+    assert(mainAxis != null);
+    return null;
   }
 
   @override
@@ -197,6 +201,8 @@ class RenderBlock extends RenderBox
       case Axis.vertical:
         return _getIntrinsicCrossAxis((RenderBox child) => child.getMaxIntrinsicWidth(height));
     }
+    assert(mainAxis != null);
+    return null;
   }
 
   @override
@@ -207,6 +213,8 @@ class RenderBlock extends RenderBox
       case Axis.vertical:
         return _getIntrinsicCrossAxis((RenderBox child) => child.getMinIntrinsicHeight(width));
     }
+    assert(mainAxis != null);
+    return null;
   }
 
   @override
@@ -217,6 +225,8 @@ class RenderBlock extends RenderBox
       case Axis.vertical:
         return _getIntrinsicCrossAxis((RenderBox child) => child.getMaxIntrinsicHeight(width));
     }
+    assert(mainAxis != null);
+    return null;
   }
 
   @override

--- a/packages/flutter/lib/src/rendering/list.dart
+++ b/packages/flutter/lib/src/rendering/list.dart
@@ -136,6 +136,8 @@ class RenderList extends RenderVirtualViewport<ListParentData> {
         assert(debugThrowIfNotCheckingIntrinsics());
         return 0.0;
     }
+    assert(mainAxis != null);
+    return null;
   }
 
   @override

--- a/packages/flutter/lib/src/widgets/lazy_block.dart
+++ b/packages/flutter/lib/src/widgets/lazy_block.dart
@@ -324,6 +324,8 @@ class LazyBlockViewport extends RenderObjectWidget {
       case Axis.vertical:
         return padding.vertical;
     }
+    assert(mainAxis != null);
+    return null;
   }
 
   @override
@@ -716,6 +718,8 @@ class _LazyBlockElement extends RenderObjectElement {
         double width = math.max(0.0, constraints.maxWidth - padding);
         return new BoxConstraints.tightFor(width: width);
     }
+    assert(widget.mainAxis != null);
+    return null;
   }
 
   Offset get _initialChildOffset {

--- a/packages/flutter/lib/src/widgets/scrollable.dart
+++ b/packages/flutter/lib/src/widgets/scrollable.dart
@@ -299,6 +299,8 @@ class ScrollableState<T extends Scrollable> extends State<T> {
       case ViewportAnchor.end:
         return scrollOffset;
     }
+    assert(config.scrollAnchor != null);
+    return null;
   }
 
   /// Returns the scroll offset component of the given pixel delta, accounting
@@ -313,6 +315,8 @@ class ScrollableState<T extends Scrollable> extends State<T> {
       case Axis.vertical:
         return pixelOffsetToScrollOffset(pixelDelta.dy);
     }
+    assert(config.scrollDirection != null);
+    return null;
   }
 
   /// Returns a two-dimensional representation of the scroll offset, accounting
@@ -326,6 +330,8 @@ class ScrollableState<T extends Scrollable> extends State<T> {
       case Axis.vertical:
         return new Offset(0.0, scrollOffsetToPixelOffset(scrollOffset));
     }
+    assert(config.scrollDirection != null);
+    return null;
   }
 
   /// The current scroll behavior of this widget.

--- a/packages/flutter/lib/src/widgets/virtual_viewport.dart
+++ b/packages/flutter/lib/src/widgets/virtual_viewport.dart
@@ -83,6 +83,8 @@ abstract class VirtualViewportElement extends RenderObjectElement {
       case Axis.vertical:
         return new Offset(0.0, scrollOffsetToPixelOffset(scrollOffset));
     }
+    assert(renderObject.mainAxis != null);
+    return null;
   }
 
   List<Element> _materializedChildren = const <Element>[];

--- a/packages/flutter/pubspec.yaml
+++ b/packages/flutter/pubspec.yaml
@@ -9,8 +9,7 @@ dependencies:
   intl: '>=0.12.4+2 <0.13.0'
   vector_math: '>=2.0.3 <3.0.0'
 
-  # We need to pin crypto because archive can't handle larger numbers.
-  crypto: 0.9.2
+  crypto: '>=1.1.1 <3.0.0'
 
   meta: ^0.12.0
 

--- a/packages/flutter/pubspec.yaml
+++ b/packages/flutter/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
   vector_math: '>=2.0.3 <3.0.0'
 
   # We need to pin crypto because archive can't handle larger numbers.
-  crypto: 0.9.2
+  crypto: '>=1.1.1 <3.0.0' 
 
   meta: ^0.12.0
 

--- a/packages/flutter_test/test/stack_manipulation_test.dart
+++ b/packages/flutter_test/test/stack_manipulation_test.dart
@@ -19,7 +19,6 @@ void main() {
 
     try {
       throw null;
-      expect(false, isTrue); // shouldn't get here
     } catch (e, stack) {
       StringBuffer information = new StringBuffer();
       expect(reportExpectCall(stack, information), 0);

--- a/packages/flutter_tools/pubspec.yaml
+++ b/packages/flutter_tools/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   archive: ^1.0.20
   args: ^0.13.4
-  crypto: 0.9.2
+  crypto: '>=1.1.1 <3.0.0'
   file: ^0.1.0
   http: ^0.11.3
   json_rpc_2: ^2.0.0

--- a/packages/flx/lib/signing.dart
+++ b/packages/flx/lib/signing.dart
@@ -9,7 +9,7 @@ import 'dart:typed_data';
 
 import 'package:asn1lib/asn1lib.dart';
 import 'package:bignum/bignum.dart';
-import 'package:crypto/crypto.dart' hide BASE64, Digest;
+import 'package:crypto/crypto.dart' hide Digest;
 import 'package:pointycastle/pointycastle.dart';
 
 export 'package:pointycastle/pointycastle.dart' show AsymmetricKeyPair, PublicKey, PrivateKey;

--- a/packages/flx/pubspec.yaml
+++ b/packages/flx/pubspec.yaml
@@ -7,7 +7,7 @@ dependencies:
   bignum: ^0.1.0
   asn1lib: ^0.4.1
   pointycastle: 0.10.0
-  crypto: 0.9.2
+  crypto: '>=1.1.1 <3.0.0' 
 
 environment:
   sdk: '>=1.16.0 <2.0.0'


### PR DESCRIPTION
Prep to get us ready to pull in a new dev SDK and bump our analyzer DEP.
- updates `crypto` (required by fresh analyzer)
- fixes newly flagged dead code warnings
- fixes switches that fall through and don't return

cc @abarth, @Hixie 
