### PR TITLE
bump our dep on the test package

### DIFF
--- a/packages/flutter_driver/pubspec.yaml
+++ b/packages/flutter_driver/pubspec.yaml
@@ -20,6 +20,6 @@ dependencies:
     path: '../flutter_test'
 
 dev_dependencies:
-  test: 0.12.13+4
+  test: 0.12.13+5
   mockito: '^0.11.0'
   quiver: '^0.21.4'

--- a/packages/flutter_test/pubspec.yaml
+++ b/packages/flutter_test/pubspec.yaml
@@ -5,7 +5,7 @@ dependencies:
   # The flutter tools depend on very specific internal implementation
   # details of the 'test' package, which change between versions, so
   # here we pin it precisely to avoid version skew across our packages.
-  test: 0.12.13+4
+  test: 0.12.13+5
 
   # We don't actually depend on 'analyzer', but 'test' and 'flutter_tools' do.
   # We pin the version of analyzer we depend on to avoid version skew across our

--- a/packages/flutter_tools/pubspec.yaml
+++ b/packages/flutter_tools/pubspec.yaml
@@ -29,7 +29,7 @@ dependencies:
   # We depend on very specific internal implementation details of the
   # 'test' package, which change between versions, so here we pin it
   # precisely.
-  test: 0.12.13+4
+  test: 0.12.13+5
 
   # Pinned in flutter_test as well.
   analyzer: 0.27.4-alpha.9


### PR DESCRIPTION
Bump our dep on the test package - the sdk constraint on `0.12.13+4` means it doesn't work with the newer `1.18.0-dev` SDKs.
