### PR TITLE
 AppBar bottom widget, not necessarily a TabBar

### DIFF
--- a/examples/flutter_gallery/lib/demo/colors_demo.dart
+++ b/examples/flutter_gallery/lib/demo/colors_demo.dart
@@ -119,7 +119,7 @@ class ColorsDemo extends StatelessWidget {
         appBar: new AppBar(
           elevation: 0,
           title: new Text('Colors'),
-          tabBar: new TabBar<ColorSwatch>(
+          bottom: new TabBar<ColorSwatch>(
             isScrollable: true,
             labels: new Map<ColorSwatch, TabLabel>.fromIterable(colorSwatches, value: (ColorSwatch swatch) {
               return new TabLabel(text: swatch.name);

--- a/examples/flutter_gallery/lib/demo/scrollable_tabs_demo.dart
+++ b/examples/flutter_gallery/lib/demo/scrollable_tabs_demo.dart
@@ -71,7 +71,7 @@ class ScrollableTabsDemoState extends State<ScrollableTabsDemo> {
               ]
             )
           ],
-          tabBar: new TabBar<IconData>(
+          bottom: new TabBar<IconData>(
             isScrollable: true,
             labels: new Map<IconData, TabLabel>.fromIterable(
               icons,

--- a/examples/flutter_gallery/lib/demo/tabs_demo.dart
+++ b/examples/flutter_gallery/lib/demo/tabs_demo.dart
@@ -50,7 +50,7 @@ class TabsDemoState extends State<TabsDemo> {
         appBarBehavior: AppBarBehavior.under,
         appBar: new AppBar(
           title: new Text('Tabs and scrolling'),
-          tabBar: new TabBar<_Page>(
+          bottom: new TabBar<_Page>(
             labels: new Map<_Page, TabLabel>.fromIterable(_pages, value: (_Page page) {
               return new TabLabel(text: page.label);
             })

--- a/examples/flutter_gallery/lib/demo/tabs_fab_demo.dart
+++ b/examples/flutter_gallery/lib/demo/tabs_fab_demo.dart
@@ -100,7 +100,7 @@ class _TabsFabDemoState extends State<TabsFabDemo> {
         key: scaffoldKey,
         appBar: new AppBar(
           title: new Text('FAB per tab'),
-          tabBar: new TabBar<_Page>(
+          bottom: new TabBar<_Page>(
             labels: new Map<_Page, TabLabel>.fromIterable(pages, value: (_Page page) => page.tabLabel)
           )
         ),

--- a/examples/flutter_gallery/lib/demo/two_level_list_demo.dart
+++ b/examples/flutter_gallery/lib/demo/two_level_list_demo.dart
@@ -11,20 +11,41 @@ class TwoLevelListDemo extends StatelessWidget {
   Widget build(BuildContext context) {
     return new Scaffold(
       appBar: new AppBar(title: new Text('Expand/collapse list control')),
-      body: new TwoLevelList(
-        type: MaterialListType.oneLine,
+      body: new Column(
         children: <Widget>[
-          new TwoLevelListItem(title: new Text('Top')),
-          new TwoLevelSublist(
-            title: new Text('Sublist'),
-            children: <Widget>[
-              new TwoLevelListItem(title: new Text('One')),
-              new TwoLevelListItem(title: new Text('Two')),
-              new TwoLevelListItem(title: new Text('Free')),
-              new TwoLevelListItem(title: new Text('Four'))
-            ]
+          new Container(
+            height: 56.0,
+            child: new Material(
+              elevation: 4,
+              type: MaterialType.canvas,
+              child: new Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 24.0),
+                child: new Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: <Widget>[
+                    new Text('foo'),
+                    new Text('bar')
+                  ]
+                )
+              )
+            )
           ),
-          new TwoLevelListItem(title: new Text('Bottom'))
+          new TwoLevelList(
+            type: MaterialListType.oneLine,
+            children: <Widget>[
+              new TwoLevelListItem(title: new Text('Top')),
+              new TwoLevelSublist(
+                title: new Text('Sublist'),
+                children: <Widget>[
+                  new TwoLevelListItem(title: new Text('One')),
+                  new TwoLevelListItem(title: new Text('Two')),
+                  new TwoLevelListItem(title: new Text('Free')),
+                  new TwoLevelListItem(title: new Text('Four'))
+                ]
+              ),
+              new TwoLevelListItem(title: new Text('Bottom'))
+            ]
+          )
         ]
       )
     );

--- a/examples/flutter_gallery/lib/demo/two_level_list_demo.dart
+++ b/examples/flutter_gallery/lib/demo/two_level_list_demo.dart
@@ -11,41 +11,21 @@ class TwoLevelListDemo extends StatelessWidget {
   Widget build(BuildContext context) {
     return new Scaffold(
       appBar: new AppBar(title: new Text('Expand/collapse list control')),
-      body: new Column(
+      body: new TwoLevelList(
+        type: MaterialListType.oneLine,
         children: <Widget>[
-          new Container(
-            height: 56.0,
-            child: new Material(
-              elevation: 4,
-              type: MaterialType.canvas,
-              child: new Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 24.0),
-                child: new Row(
-                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                  children: <Widget>[
-                    new Text('foo'),
-                    new Text('bar')
-                  ]
-                )
-              )
-            )
-          ),
-          new TwoLevelList(
-            type: MaterialListType.oneLine,
-            children: <Widget>[
-              new TwoLevelListItem(title: new Text('Top')),
-              new TwoLevelSublist(
-                title: new Text('Sublist'),
-                children: <Widget>[
-                  new TwoLevelListItem(title: new Text('One')),
-                  new TwoLevelListItem(title: new Text('Two')),
-                  new TwoLevelListItem(title: new Text('Free')),
-                  new TwoLevelListItem(title: new Text('Four'))
-                ]
-              ),
-              new TwoLevelListItem(title: new Text('Bottom'))
-            ]
-          )
+          new TwoLevelListItem(title: new Text('Top')),
+          new TwoLevelSublist(
+             title: new Text('Sublist'),
+              children: <Widget>[
+                new TwoLevelListItem(title: new Text('One')),
+                new TwoLevelListItem(title: new Text('Two')),
+                // https://en.wikipedia.org/wiki/Free_Four
+                new TwoLevelListItem(title: new Text('Free')),
+                new TwoLevelListItem(title: new Text('Four'))
+              ]
+           ),
+           new TwoLevelListItem(title: new Text('Bottom'))
         ]
       )
     );

--- a/examples/flutter_gallery/lib/gallery/demo.dart
+++ b/examples/flutter_gallery/lib/gallery/demo.dart
@@ -73,7 +73,7 @@ class TabbedComponentDemoScaffold extends StatelessWidget {
       child: new Scaffold(
         appBar: new AppBar(
           title: new Text(title),
-          tabBar: new TabBar<ComponentDemoTabData>(
+          bottom: new TabBar<ComponentDemoTabData>(
             isScrollable: true,
             labels: ComponentDemoTabData.buildTabLabels(demos)
           )

--- a/examples/stocks/lib/stock_home.dart
+++ b/examples/stocks/lib/stock_home.dart
@@ -241,7 +241,7 @@ class StockHomeState extends State<StockHome> {
           ]
         )
       ],
-      tabBar: new TabBar<StockHomeTab>(
+      bottom: new TabBar<StockHomeTab>(
         labels: <StockHomeTab, TabLabel>{
           StockHomeTab.market: new TabLabel(text: StockStrings.of(context).market()),
           StockHomeTab.portfolio: new TabLabel(text: StockStrings.of(context).portfolio())

--- a/packages/flutter/lib/src/material/app_bar.dart
+++ b/packages/flutter/lib/src/material/app_bar.dart
@@ -27,6 +27,7 @@ abstract class AppBarBottomWidget extends Widget {
 // Tablet/Desktop: 64dp
 
 /// A material design app bar.
+///
 /// An app bar consists of a toolbar and potentially other widgets, such as a
 /// [TabBar] and a [FlexibleSpaceBar]. App bars typically expose one or more
 /// common actions with [IconButtons]s which are optionally followed by a

--- a/packages/flutter/lib/src/material/scaffold.dart
+++ b/packages/flutter/lib/src/material/scaffold.dart
@@ -20,24 +20,27 @@ const double _kFloatingActionButtonMargin = 16.0; // TODO(hmuller): should be de
 const Duration _kFloatingActionButtonSegue = const Duration(milliseconds: 200);
 final Tween<double> _kFloatingActionButtonTurnTween = new Tween<double>(begin: -0.125, end: 0.0);
 
-/// The Scaffold's appbar is the toolbar, tabbar, and the "flexible space" that's
-/// stacked behind them. The Scaffold's appBarBehavior defines how the appbar
-/// responds to scrolling the application.
+/// The Scaffold's appbar is the toolbar, bottom, and the "flexible space"
+/// that's stacked behind them. The Scaffold's appBarBehavior defines how
+/// its layout responds to scrolling the application's body.
 enum AppBarBehavior {
-  /// The tool bar's layout does not respond to scrolling.
+  /// The app bar's layout does not respond to scrolling.
   anchor,
 
-  /// The tool bar's appearance and layout depend on the scrollOffset of the
+  /// The app bar's appearance and layout depend on the scrollOffset of the
   /// Scrollable identified by the Scaffold's scrollableKey. With the scrollOffset
   /// at 0.0, scrolling downwards causes the toolbar's flexible space to shrink,
-  /// and then the entire toolbar fade outs and scrolls off the top of the screen.
-  /// Scrolling upwards always causes the toolbar to reappear.
+  /// and then the app bar fades out and scrolls off the top of the screen.
+  /// Scrolling upwards always causes the app bar's bottom widget to reappear
+  /// if the bottom widget isn't null, otherwise the app bar's toolbar reappears.
   scroll,
 
-  /// The tool bar's appearance and layout depend on the scrollOffset of the
+  /// The app bar's appearance and layout depend on the scrollOffset of the
   /// Scrollable identified by the Scaffold's scrollableKey. With the scrollOffset
   /// at 0.0, Scrolling downwards causes the toolbar's flexible space to shrink.
-  /// Other than that, the toolbar remains anchored at the top.
+  /// If the bottom widget isn't null the app bar shrinks to the bottom widget's
+  /// [AppBarBottomWidget.bottomHeight], otherwise the app bar shrinks to its
+  /// [AppBar.collapsedHeight].
   under,
 }
 
@@ -612,13 +615,14 @@ class ScaffoldState extends State<Scaffold> {
   Widget _buildScrollableAppBar(BuildContext context, EdgeInsets padding) {
     final double expandedHeight = (config.appBar?.expandedHeight ?? 0.0) + padding.top;
     final double collapsedHeight = (config.appBar?.collapsedHeight ?? 0.0) + padding.top;
-    final double minimumHeight = (config.appBar?.minimumHeight ?? 0.0) + padding.top;
+    final double bottomHeight = config.appBar?.bottomHeight + padding.top;
+    final double underHeight = config.appBar.bottom != null ? bottomHeight : collapsedHeight;
     Widget appBar;
 
-    if (_scrollOffset <= expandedHeight && _scrollOffset >= expandedHeight - minimumHeight) {
+    if (_scrollOffset <= expandedHeight && _scrollOffset >= expandedHeight - underHeight) {
       // scrolled to the top, flexible space collapsed, only the toolbar and tabbar are (partially) visible.
       if (config.appBarBehavior == AppBarBehavior.under) {
-        appBar = _buildAnchoredAppBar(expandedHeight, minimumHeight, padding);
+        appBar = _buildAnchoredAppBar(expandedHeight, underHeight, padding);
       } else {
         final double height = math.max(_floatingAppBarHeight, expandedHeight - _scrollOffset);
         _appBarController.value = (expandedHeight - height) / expandedHeight;
@@ -630,7 +634,7 @@ class ScaffoldState extends State<Scaffold> {
     } else if (_scrollOffset > expandedHeight) {
       // scrolled past the entire app bar, maybe show the "floating" toolbar.
       if (config.appBarBehavior == AppBarBehavior.under) {
-        appBar = _buildAnchoredAppBar(expandedHeight, minimumHeight, padding);
+        appBar = _buildAnchoredAppBar(expandedHeight, underHeight, padding);
       } else {
         _floatingAppBarHeight = (_floatingAppBarHeight + _scrollOffsetDelta).clamp(0.0, collapsedHeight);
         _appBarController.value = (expandedHeight - _floatingAppBarHeight) / expandedHeight;

--- a/packages/flutter/lib/src/material/tabs.dart
+++ b/packages/flutter/lib/src/material/tabs.dart
@@ -10,6 +10,7 @@ import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 import 'package:meta/meta.dart';
 
+import 'app_bar.dart';
 import 'colors.dart';
 import 'debug.dart';
 import 'icon.dart';
@@ -643,7 +644,7 @@ class TabBarSelectionState<T> extends State<TabBarSelection<T>> {
 ///  * [TabBarView]
 ///  * [AppBar.tabBar]
 ///  * <https://www.google.com/design/spec/components/tabs.html>
-class TabBar<T> extends Scrollable {
+class TabBar<T> extends Scrollable implements AppBarBottomWidget {
   TabBar({
     Key key,
     this.labels,
@@ -671,7 +672,9 @@ class TabBar<T> extends Scrollable {
   /// the color of the theme's body2 text color is used.
   final Color labelColor;
 
-  double get minimumHeight {
+  /// The height of the tab labels and indicator.
+  @override
+  double get bottomHeight {
     for (TabLabel label in labels.values) {
       if (label.text != null && (label.icon != null || label.iconBuilder != null))
         return _kTextAndIconTabHeight + _kTabIndicatorHeight;


### PR DESCRIPTION
The AppBar widget that appears below the toolbar no longer has to be a TabBar. It does have to implement AppBarBottomWidget, which just reports the bottom widget's height.

Removed the minimumHeight AppBar parameter.
