### PR TITLE
Nesting MaterialApps should not assert

### DIFF
--- a/packages/flutter/lib/src/widgets/navigator.dart
+++ b/packages/flutter/lib/src/widgets/navigator.dart
@@ -4,6 +4,7 @@
 
 import 'package:meta/meta.dart';
 
+import 'focus.dart';
 import 'framework.dart';
 import 'overlay.dart';
 
@@ -20,6 +21,12 @@ abstract class Route<T> {
 
   /// The overlay entries for this route.
   List<OverlayEntry> get overlayEntries => const <OverlayEntry>[];
+
+  /// The key this route will use for its root [Focus] widget, if any.
+  ///
+  /// If this route is the first route shown by the navigator, the navigator
+  /// will initialize its [Focus] to this key.
+  GlobalKey get focusKey => null;
 
   /// Called when the route is inserted into the navigator.
   ///
@@ -515,14 +522,23 @@ class NavigatorState extends State<Navigator> {
     return true;
   }
 
+  // TODO(abarth): We should be able to take a focusScopeKey as configuration
+  // information in case our parent wants to control whether we are focused.
+  final GlobalKey _focusScopeKey = new GlobalKey();
+
   @override
   Widget build(BuildContext context) {
     assert(!_debugLocked);
     assert(_history.isNotEmpty);
     _hadTransaction = false;
-    return new Overlay(
-      key: _overlayKey,
-      initialEntries: _history.first.overlayEntries
+    final Route<dynamic> initialRoute = _history.first;
+    return new Focus(
+      key: _focusScopeKey,
+      initiallyFocusedScope: initialRoute.focusKey,
+      child: new Overlay(
+        key: _overlayKey,
+        initialEntries: initialRoute.overlayEntries
+      )
     );
   }
 }

--- a/packages/flutter/lib/src/widgets/routes.dart
+++ b/packages/flutter/lib/src/widgets/routes.dart
@@ -431,7 +431,7 @@ class _ModalScopeState extends State<_ModalScope> {
       );
     }
     contents = new Focus(
-      key: new GlobalObjectKey(config.route),
+      key: config.route.focusKey,
       child: new RepaintBoundary(child: contents)
     );
     return contents;
@@ -520,9 +520,28 @@ abstract class ModalRoute<T> extends TransitionRoute<T> with LocalHistoryRoute<T
   }
 
   @override
+  GlobalKey get focusKey => new GlobalObjectKey(this);
+
+  @override
   void didPush() {
-    Focus.moveScopeTo(new GlobalObjectKey(this), context: navigator.context);
+    if (!settings.isInitialRoute) {
+      BuildContext overlayContext = navigator.overlay.context;
+      if (overlayContext == null) {
+        throw new FlutterError(
+          'Unable to find the BuildContext for the Navigator\'s overlay.\n'
+          'Did you remember to pass the settings object to the route\'s '
+          'constructor in your onGenerateRoute callback?'
+        );
+      }
+      Focus.moveScopeTo(focusKey, context: overlayContext);
+    }
     super.didPush();
+  }
+
+  @override
+  void didPopNext(Route<dynamic> nextRoute) {
+    Focus.moveScopeTo(focusKey, context: navigator.overlay.context);
+    super.didPopNext(nextRoute);
   }
 
   // The API for subclasses to override - used by this class

--- a/packages/flutter/test/material/app_test.dart
+++ b/packages/flutter/test/material/app_test.dart
@@ -1,0 +1,33 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter/material.dart';
+
+void main() {
+  testWidgets('Can nest apps', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      new MaterialApp(
+        home: new MaterialApp(
+          home: new Text('Home sweet home')
+        )
+      )
+    );
+
+    expect(find.text('Home sweet home'), findsOneWidget);
+  });
+
+  testWidgets('Focus handling', (WidgetTester tester) async {
+    GlobalKey inputKey = new GlobalKey();
+    await tester.pumpWidget(new MaterialApp(
+      home: new Material(
+        child: new Center(
+          child: new Input(key: inputKey, autofocus: true)
+        )
+      )
+    ));
+
+    expect(Focus.at(inputKey.currentContext), isTrue);
+  });
+}

--- a/packages/flutter/test/widget/page_forward_transitions_test.dart
+++ b/packages/flutter/test/widget/page_forward_transitions_test.dart
@@ -98,8 +98,8 @@ void main() {
                 )
               );
             case '/2': return new TestRoute<Null>(settings: settings, child: new Text('E'));
-            case '/3': return new TestRoute<Null> (settings: settings, child: new Text('F'));
-            case '/4': return new TestRoute<Null> (settings: settings, child: new Text('G'));
+            case '/3': return new TestRoute<Null>(settings: settings, child: new Text('F'));
+            case '/4': return new TestRoute<Null>(settings: settings, child: new Text('G'));
           }
         }
       )

--- a/packages/flutter/test/widget/remember_scroll_position_test.dart
+++ b/packages/flutter/test/widget/remember_scroll_position_test.dart
@@ -26,10 +26,17 @@ void main() {
     await tester.pumpWidget(new Navigator(
       key: navigatorKey,
       onGenerateRoute: (RouteSettings settings) {
-        if (settings.name == '/')
-          return new MaterialPageRoute<Null>(builder: (_) => new Container(child: new ThePositiveNumbers()));
-        else if (settings.name == '/second')
-          return new MaterialPageRoute<Null>(builder: (_) => new Container(child: new ThePositiveNumbers()));
+        if (settings.name == '/') {
+          return new MaterialPageRoute<Null>(
+            settings: settings,
+            builder: (_) => new Container(child: new ThePositiveNumbers())
+          );
+        } else if (settings.name == '/second') {
+          return new MaterialPageRoute<Null>(
+            settings: settings,
+            builder: (_) => new Container(child: new ThePositiveNumbers())
+          );
+        }
         return null;
       }
     ));


### PR DESCRIPTION
Turns out we weren't managing focus correct between navigator routes because we
were missing a Focus widget above the routes. However, adding this widget
caused us to explode at startup because the initial route was trying to move
focus during the build phase.

This patch teaches Focus to have an initiallyFocusedScope, which can be use to
initialize the child focus scope.

Fixes #4065
