### PR TITLE
Route.didMount should throw a useful error message

### DIFF
--- a/packages/flutter/lib/src/widgets/binding.dart
+++ b/packages/flutter/lib/src/widgets/binding.dart
@@ -349,14 +349,30 @@ class RenderObjectToWidgetElement<T extends RenderObject> extends RootRenderObje
   void mount(Element parent, dynamic newSlot) {
     assert(parent == null);
     super.mount(parent, newSlot);
-    _child = updateChild(_child, widget.child, _rootChildSlot);
+    _rebuild();
   }
 
   @override
   void update(RenderObjectToWidgetAdapter<T> newWidget) {
     super.update(newWidget);
     assert(widget == newWidget);
-    _child = updateChild(_child, widget.child, _rootChildSlot);
+    _rebuild();
+  }
+
+  void _rebuild() {
+    try {
+      _child = updateChild(_child, widget.child, _rootChildSlot);
+      assert(_child != null);
+    } catch (exception, stack) {
+      FlutterError.reportError(new FlutterErrorDetails(
+        exception: exception,
+        stack: stack,
+        library: 'widgets library',
+        context: 'attaching to the render tree'
+      ));
+      Widget error = new ErrorWidget(exception);
+      _child = updateChild(null, error, _rootChildSlot);
+    }
   }
 
   @override

--- a/packages/flutter/lib/src/widgets/routes.dart
+++ b/packages/flutter/lib/src/widgets/routes.dart
@@ -525,14 +525,17 @@ abstract class ModalRoute<T> extends TransitionRoute<T> with LocalHistoryRoute<T
   @override
   void didPush() {
     if (!settings.isInitialRoute) {
-      BuildContext overlayContext = navigator.overlay.context;
-      if (overlayContext == null) {
-        throw new FlutterError(
-          'Unable to find the BuildContext for the Navigator\'s overlay.\n'
-          'Did you remember to pass the settings object to the route\'s '
-          'constructor in your onGenerateRoute callback?'
-        );
-      }
+      BuildContext overlayContext = navigator.overlay?.context;
+      assert(() {
+        if (overlayContext == null) {
+          throw new FlutterError(
+            'Unable to find the BuildContext for the Navigator\'s overlay.\n'
+            'Did you remember to pass the settings object to the route\'s '
+            'constructor in your onGenerateRoute callback?'
+          );
+        }
+        return true;
+      });
       Focus.moveScopeTo(focusKey, context: overlayContext);
     }
     super.didPush();

--- a/packages/flutter/test/widget/navigator_test.dart
+++ b/packages/flutter/test/widget/navigator_test.dart
@@ -112,4 +112,16 @@ void main() {
     expect(exception, new isInstanceOf<FlutterError>());
     expect('$exception', startsWith('openTransaction called with a context'));
   });
+
+  testWidgets('Missing settings in onGenerateRoute throws exception', (WidgetTester tester) async {
+    await tester.pumpWidget(new Navigator(
+      onGenerateRoute: (RouteSettings settings) {
+        return new MaterialPageRoute<Null>(
+          builder: (BuildContext context) => new Container()
+        );
+      }
+    ));
+    Object exception = tester.takeException();
+    expect(exception is FlutterError, isTrue);
+  });
 }


### PR DESCRIPTION
The error code path wasn't actually getting the point where it would throw the
useful error message. Also, fix error recovery when runApp fails.

Fixes #4655
