### PR TITLE
Update to latest analyzer (0.27.4-alpha.14) and misc. analysis fixes.

### DIFF
--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -304,6 +304,9 @@ abstract class Widget {
   }
 }
 
+/// The signature of build() functions.
+typedef Widget _BuildFunction(BuildContext context);
+
 /// StatelessWidgets describe a way to compose other Widgets to form reusable
 /// parts, which doesn't depend on anything other than the configuration
 /// information in the object itself. (For compositions that can change
@@ -328,7 +331,7 @@ abstract class StatelessWidget extends Widget {
   Widget build(BuildContext context);
 
   /// Trampoline to make the [build] closure library-accessible.
-  Widget _build(BuildContext context) => build(context);
+  _BuildFunction get _build => build;
 }
 
 /// StatefulWidgets provide the configuration for
@@ -488,7 +491,7 @@ abstract class State<T extends StatefulWidget> {
   Widget build(BuildContext context);
 
   /// Trampoline to make the [build] closure library-accessible.
-  Widget _build(BuildContext context) => build(context);
+  _BuildFunction get _build => build;
 
   /// Called when an Inherited widget in the ancestor chain has changed. Usually
   /// there is nothing to do here; whenever this is called, build() is also

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -304,9 +304,6 @@ abstract class Widget {
   }
 }
 
-/// The signature of build() functions.
-typedef Widget _BuildFunction(BuildContext context);
-
 /// StatelessWidgets describe a way to compose other Widgets to form reusable
 /// parts, which doesn't depend on anything other than the configuration
 /// information in the object itself. (For compositions that can change
@@ -331,7 +328,7 @@ abstract class StatelessWidget extends Widget {
   Widget build(BuildContext context);
 
   /// Trampoline to make the [build] closure library-accessible.
-  _BuildFunction get _build => build;
+  WidgetBuilder get _build => build;
 }
 
 /// StatefulWidgets provide the configuration for
@@ -491,7 +488,7 @@ abstract class State<T extends StatefulWidget> {
   Widget build(BuildContext context);
 
   /// Trampoline to make the [build] closure library-accessible.
-  _BuildFunction get _build => build;
+  WidgetBuilder get _build => build;
 
   /// Called when an Inherited widget in the ancestor chain has changed. Usually
   /// there is nothing to do here; whenever this is called, build() is also

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -326,6 +326,9 @@ abstract class StatelessWidget extends Widget {
   /// provides the set of inherited widgets for this location in the tree.
   @protected
   Widget build(BuildContext context);
+
+  /// Trampoline to make the [build] closure library-accessible.
+  Widget _build(BuildContext context) => build(context);
 }
 
 /// StatefulWidgets provide the configuration for
@@ -483,6 +486,9 @@ abstract class State<T extends StatefulWidget> {
   /// signature used by [StatelessWidget.build] and other widgets.
   @protected
   Widget build(BuildContext context);
+
+  /// Trampoline to make the [build] closure library-accessible.
+  Widget _build(BuildContext context) => build(context);
 
   /// Called when an Inherited widget in the ancestor chain has changed. Usually
   /// there is nothing to do here; whenever this is called, build() is also
@@ -1606,7 +1612,7 @@ abstract class ComponentElement extends BuildableElement {
 /// Instantiation of [StatelessWidget]s.
 class StatelessElement extends ComponentElement {
   StatelessElement(StatelessWidget widget) : super(widget) {
-    _builder = widget.build;
+    _builder = widget._build;
   }
 
   @override
@@ -1616,14 +1622,14 @@ class StatelessElement extends ComponentElement {
   void update(StatelessWidget newWidget) {
     super.update(newWidget);
     assert(widget == newWidget);
-    _builder = widget.build;
+    _builder = widget._build;
     _dirty = true;
     rebuild();
   }
 
   @override
   void _reassemble() {
-    _builder = widget.build;
+    _builder = widget._build;
     super._reassemble();
   }
 }
@@ -1636,7 +1642,7 @@ class StatefulElement extends ComponentElement {
     assert(_state._element == null);
     _state._element = this;
     assert(_builder == _buildNothing);
-    _builder = _state.build;
+    _builder = _state._build;
     assert(_state._config == null);
     _state._config = widget;
     assert(_state._debugLifecycleState == _StateLifecycle.created);
@@ -1647,7 +1653,7 @@ class StatefulElement extends ComponentElement {
 
   @override
   void _reassemble() {
-    _builder = state.build;
+    _builder = state._build;
     super._reassemble();
   }
 

--- a/packages/flutter_test/pubspec.yaml
+++ b/packages/flutter_test/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
   # We don't actually depend on 'analyzer', but 'test' and 'flutter_tools' do.
   # We pin the version of analyzer we depend on to avoid version skew across our
   # packages.
-  analyzer: 0.27.4-alpha.9
+  analyzer: 0.27.4-alpha.14
 
   flutter:
     path: ../flutter

--- a/packages/flutter_tools/pubspec.yaml
+++ b/packages/flutter_tools/pubspec.yaml
@@ -33,7 +33,7 @@ dependencies:
   test: 0.12.13+5
 
   # Pinned in flutter_test as well.
-  analyzer: 0.27.4-alpha.9
+  analyzer: 0.27.4-alpha.14
 
 dev_dependencies:
   mockito: ^0.11.0


### PR DESCRIPTION
- brings in analyzer version (`0.27.4-alpha.14`) which corresponds to the current Dart SDK (`1.18.0-dev.2.0`)
- updates analysis to use preferred API for embedder URI resolution
- adds trampolines to `State` and `StatelessWidget` to allow for warning-free within-library `@protected` access (needed since we closed off access to `@protected` closures from outside subclasses)
- turns off cache dependency tracking for analysis (in DDC this amounted to a 10% speed improvement)
