### PR TITLE
Upload lcov.info to Google Storage

### DIFF
--- a/dev/bots/setup.sh
+++ b/dev/bots/setup.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
-set -ex
+set -e
+
+echo $KEY_FILE | base64 --decode > ../gcloud_key_file.json
+
+set -x
+
+export CLOUDSDK_CORE_DISABLE_PROMPTS=1
+curl https://sdk.cloud.google.com | bash
 
 # disable analytics on the bots and download Flutter dependencies
 ./bin/flutter config --no-analytics

--- a/dev/bots/test.sh
+++ b/dev/bots/test.sh
@@ -24,7 +24,7 @@ flutter analyze --flutter-repo
 (cd dev/automated_tests; flutter test test_smoke_test/pass_test.dart > /dev/null)
 
 COVERAGE_FLAG=
-if [ -n $TRAVIS ] && [ $TRAVIS_PULL_REQUEST == "false" ]; then
+if [ -n "$TRAVIS" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
   COVERAGE_FLAG=--coverage
 fi
 
@@ -44,3 +44,12 @@ fi
 # generate and analyze our large sample app
 dart dev/tools/mega_gallery.dart
 (cd dev/benchmarks/mega_gallery; flutter analyze --watch --benchmark)
+
+if [ -n "$COVERAGE_FLAG" ]; then
+  GSUTIL=$HOME/google-cloud-sdk/bin/gsutil
+  GCLOUD=$HOME/google-cloud-sdk/bin/gcloud
+
+  $GCLOUD auth activate-service-account --key-file ../gcloud_key_file.json
+  STORAGE_URL=gs://flutter_infra/flutter/coverage/lcov.info
+  $GSUTIL cp packages/flutter/coverage/lcov.info $STORAGE_URL
+fi


### PR DESCRIPTION
Uploading the coverage data file to Google Storage will make it easier
for folks to get current coverage data quickly.
