### PR TITLE
Use relative paths in lcov.info

### DIFF
--- a/packages/flutter_tools/lib/src/test/coverage_collector.dart
+++ b/packages/flutter_tools/lib/src/test/coverage_collector.dart
@@ -63,8 +63,9 @@ class CoverageCollector {
     await finishPendingJobs();
     printTrace('formating coverage data');
     Resolver resolver = new Resolver(packagesPath: PackageMap.globalPackagesPath);
-    Formatter formater = new LcovFormatter(resolver);
-    List<String> reportOn = <String>[path.join(Directory.current.path, 'lib')];
-    return await formater.format(_globalHitmap, reportOn: reportOn);
+    LcovFormatter formater = new LcovFormatter(resolver);
+    String packagePath = Directory.current.path;
+    List<String> reportOn = <String>[path.join(packagePath, 'lib')];
+    return await formater.format(_globalHitmap, reportOn: reportOn, basePath: packagePath);
   }
 }

--- a/packages/flutter_tools/pubspec.yaml
+++ b/packages/flutter_tools/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   archive: ^1.0.20
   args: ^0.13.4
-  coverage: ^0.7.8
+  coverage: ^0.7.9
   crypto: '>=1.1.1 <3.0.0'
   file: ^0.1.0
   http: ^0.11.3


### PR DESCRIPTION
Using relative paths makes it easier to share lcov.info files across machines.
