### PR TITLE
send the reload source command for ios simulators

### DIFF
--- a/packages/flutter_tools/lib/src/commands/daemon.dart
+++ b/packages/flutter_tools/lib/src/commands/daemon.dart
@@ -17,6 +17,7 @@ import '../ios/devices.dart';
 import '../ios/simulators.dart';
 import '../run.dart';
 import '../runner/flutter_command.dart';
+import 'run.dart' as run;
 
 const String protocolVersion = '0.2.0';
 
@@ -291,6 +292,7 @@ class AppDomain extends Domain {
     String route = _getStringArg(args, 'route');
     String mode = _getStringArg(args, 'mode');
     String target = _getStringArg(args, 'target');
+    bool reloadSources = _getBoolArg(args, 'reload-sources');
 
     Device device = daemon.deviceDomain._getDevice(deviceId);
     if (device == null)
@@ -298,6 +300,9 @@ class AppDomain extends Domain {
 
     if (!FileSystemEntity.isDirectorySync(projectDirectory))
       throw "'$projectDirectory' does not exist";
+
+    if (reloadSources != null)
+      run.useReloadSources = reloadSources;
 
     BuildMode buildMode = getBuildModeForName(mode) ?? BuildMode.debug;
     DebuggingOptions options;

--- a/packages/flutter_tools/lib/src/commands/run.dart
+++ b/packages/flutter_tools/lib/src/commands/run.dart
@@ -19,6 +19,9 @@ import 'build_apk.dart';
 import 'install.dart';
 import 'trace.dart';
 
+/// Whether the user has passed the `--reload-sources` command-line option.
+bool useReloadSources = false;
+
 abstract class RunCommandBase extends FlutterCommand {
   RunCommandBase() {
     addBuildModeFlags(defaultToRelease: false);
@@ -62,6 +65,9 @@ class RunCommand extends RunCommandBase {
     // Hidden option to ship all the sources of the current project over to the
     // embedder via the DevFS observatory API.
     argParser.addFlag('devfs', negatable: false, hide: true);
+
+    // Send the _reloadSource command to the VM.
+    argParser.addFlag('reload-sources', negatable: true, defaultsTo: false, hide: true);
 
     // Hidden option to enable a benchmarking mode. This will run the given
     // application, measure the startup time and the app restart time, write the
@@ -115,6 +121,8 @@ class RunCommand extends RunCommandBase {
     }
 
     Cache.releaseLockEarly();
+
+    useReloadSources = argResults['reload-sources'];
 
     if (argResults['resident']) {
       RunAndStayResident runner = new RunAndStayResident(

--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -318,12 +318,7 @@ class IOSDevice extends Device {
     String mainPath,
     Observatory observatory
   }) async {
-    return observatory.isolateReload(observatory.firstIsolateId).then((Response response) {
-      return true;
-    }).catchError((dynamic error) {
-      printError('Error restarting app: $error');
-      return false;
-    });
+    throw 'unsupported';
   }
 
   @override

--- a/packages/flutter_tools/lib/src/ios/simulators.dart
+++ b/packages/flutter_tools/lib/src/ios/simulators.dart
@@ -13,9 +13,11 @@ import '../application_package.dart';
 import '../base/context.dart';
 import '../base/process.dart';
 import '../build_info.dart';
+import '../commands/run.dart' as run;
 import '../device.dart';
 import '../flx.dart' as flx;
 import '../globals.dart';
+import '../observatory.dart';
 import '../protocol_discovery.dart';
 import 'mac.dart';
 
@@ -571,6 +573,21 @@ class IOSSimulator extends Device {
   Future<bool> _sideloadUpdatedAssetsForInstalledApplicationBundle(
       ApplicationPackage app) async {
     return (await flx.build(precompiledSnapshot: true)) == 0;
+  }
+
+  @override
+  bool get supportsRestart => run.useReloadSources;
+
+  @override
+  Future<bool> restartApp(
+    ApplicationPackage package,
+    LaunchResult result, {
+    String mainPath,
+    Observatory observatory
+  }) async {
+    if (observatory.firstIsolateId == null)
+      throw 'Application isolate not found';
+    return observatory.reloadSources(observatory.firstIsolateId);
   }
 
   @override

--- a/packages/flutter_tools/lib/src/observatory.dart
+++ b/packages/flutter_tools/lib/src/observatory.dart
@@ -9,6 +9,8 @@ import 'dart:io';
 import 'package:json_rpc_2/json_rpc_2.dart' as rpc;
 import 'package:web_socket_channel/io.dart';
 
+import 'globals.dart';
+
 class Observatory {
   Observatory._(this.peer, this.port) {
     peer.registerMethod('streamNotify', (rpc.Parameters event) {
@@ -113,10 +115,17 @@ class Observatory {
     });
   }
 
-  Future<Response> isolateReload(String isolateId) {
-    return sendRequest('isolateReload', <String, dynamic>{
-      'isolateId': isolateId
-    });
+  Future<bool> reloadSources(String isolateId) async {
+    Future<Event> future = onIsolateEvent
+      .where((Event event) => event.kind == 'IsolateReload')
+      .single;
+
+    await sendRequest('_reloadSources', <String, dynamic>{ 'isolateId': isolateId });
+    Event event = await future.timeout(new Duration(seconds: 20));
+    dynamic error = event.response['reloadError'];
+    if (error != null)
+      printError('Error reloading application sources: $error');
+    return error == null;
   }
 
   Future<Response> clearVMTimeline() => sendRequest('_clearVMTimeline');

--- a/packages/flutter_tools/lib/src/observatory.dart
+++ b/packages/flutter_tools/lib/src/observatory.dart
@@ -116,12 +116,12 @@ class Observatory {
   }
 
   Future<bool> reloadSources(String isolateId) async {
-    Future<Event> future = onIsolateEvent
+    Future<Event> whenIsolateReloads = onIsolateEvent
       .where((Event event) => event.kind == 'IsolateReload')
       .single;
 
     await sendRequest('_reloadSources', <String, dynamic>{ 'isolateId': isolateId });
-    Event event = await future.timeout(new Duration(seconds: 20));
+    Event event = await whenIsolateReloads.timeout(new Duration(seconds: 20));
     dynamic error = event.response['reloadError'];
     if (error != null)
       printError('Error reloading application sources: $error');


### PR DESCRIPTION
When running against an iOS simulator, optionally send the observatory `_reloadSources` command. This is enabled via `flutter run --reload-sources`.

@yjbanov 

/cc @johnmccutchan @turnidge
