### PR TITLE
don't rewrite the console in non-ansi mode

### DIFF
--- a/packages/flutter_tools/lib/src/commands/test.dart
+++ b/packages/flutter_tools/lib/src/commands/test.dart
@@ -163,7 +163,7 @@ class TestCommand extends FlutterCommand {
 
     testArgs.insert(0, '--');
     if (!terminal.supportsColor)
-      testArgs.insert(0, '--no-color');
+      testArgs.insertAll(0, <String>['--no-color', '-rexpanded']);
 
     if (argResults['coverage'])
       testArgs.insert(0, '--concurrency=1');


### PR DESCRIPTION
If the console doesn't support ansi codes, don't use the compact (re-writing) output format of `test`.

@abarth 
