### PR TITLE
Fix the issue that flutter driver does not close _peer

### DIFF
--- a/packages/flutter_driver/lib/src/driver.dart
+++ b/packages/flutter_driver/lib/src/driver.dart
@@ -296,11 +296,10 @@ class FlutterDriver {
   ///
   /// Returns a [Future] that fires once the connection has been closed.
   // TODO(yjbanov): cleanup object references
-  Future<Null> close() async{
+  Future<Null> close() async {
     // Don't leak vm_service_client-specific objects, if any
     await _serviceClient.close();
     await _peer.close();
-    return null;
   }
 }
 

--- a/packages/flutter_driver/lib/src/driver.dart
+++ b/packages/flutter_driver/lib/src/driver.dart
@@ -296,10 +296,12 @@ class FlutterDriver {
   ///
   /// Returns a [Future] that fires once the connection has been closed.
   // TODO(yjbanov): cleanup object references
-  Future<Null> close() => _serviceClient.close().then((_) {
+  Future<Null> close() async{
     // Don't leak vm_service_client-specific objects, if any
+    await _serviceClient.close();
+    await _peer.close();
     return null;
-  });
+  }
 }
 
 /// Encapsulates connection information to an instance of a Flutter application.


### PR DESCRIPTION
Fix the issue that flutter driver does not close _peer when
driver.close() is invoked.  The problem introduces the following
unexpected behavior:
1. Launch an app using "flutter run ..." command
2. Run the flutter driver test using "dart flutter_test.dart"

The test will not exit after running.  The problem will be solved
if _peer is closed.
