### PR TITLE
Push nested routes

### DIFF
--- a/packages/flutter/lib/src/widgets/navigator.dart
+++ b/packages/flutter/lib/src/widgets/navigator.dart
@@ -322,10 +322,16 @@ class NavigatorState extends State<Navigator> {
     super.initState();
     assert(config.observer == null || config.observer.navigator == null);
     config.observer?._navigator = this;
-    _push(config.onGenerateRoute(new RouteSettings(
-      name: config.initialRoute ?? Navigator.defaultRouteName,
-      isInitialRoute: true
-    )));
+
+    bool isFirst = true;
+
+    for (String route in _splitRoute(config.initialRoute ?? Navigator.defaultRouteName)) {
+      _push(config.onGenerateRoute(new RouteSettings(
+        name: route,
+        isInitialRoute: isFirst
+      )));
+      isFirst = false;
+    }
   }
 
   @override
@@ -540,6 +546,23 @@ class NavigatorState extends State<Navigator> {
         initialEntries: initialRoute.overlayEntries
       )
     );
+  }
+
+  /// Return a hierarchical sequence of routes from the given route, e.g.
+  /// '/a/b/c' ==> '/', '/a', '/a/b', '/a/b/c'.
+  static Iterable<String> _splitRoute(String route) sync* {
+    if (route.isEmpty || !route.startsWith('/')) {
+      yield route;
+    } else {
+      yield '/';
+
+      StringBuffer buffer = new StringBuffer();
+
+      for (String fragment in route.substring(1).split('/')) {
+        buffer.write('/$fragment');
+        yield buffer.toString();
+      }
+    }
   }
 }
 

--- a/packages/flutter/lib/src/widgets/navigator.dart
+++ b/packages/flutter/lib/src/widgets/navigator.dart
@@ -324,8 +324,8 @@ class NavigatorState extends State<Navigator> {
     config.observer?._navigator = this;
 
     bool isFirst = true;
-
-    for (String route in _splitRoute(config.initialRoute ?? Navigator.defaultRouteName)) {
+    List<String> routes = _splitRoute(config.initialRoute ?? Navigator.defaultRouteName).toList();
+    for (String route in routes) {
       _push(config.onGenerateRoute(new RouteSettings(
         name: route,
         isInitialRoute: isFirst
@@ -559,8 +559,10 @@ class NavigatorState extends State<Navigator> {
       StringBuffer buffer = new StringBuffer();
 
       for (String fragment in route.substring(1).split('/')) {
-        buffer.write('/$fragment');
-        yield buffer.toString();
+        if (fragment.isNotEmpty) {
+          buffer.write('/$fragment');
+          yield buffer.toString();
+        }
       }
     }
   }

--- a/packages/flutter/lib/src/widgets/navigator.dart
+++ b/packages/flutter/lib/src/widgets/navigator.dart
@@ -323,14 +323,12 @@ class NavigatorState extends State<Navigator> {
     assert(config.observer == null || config.observer.navigator == null);
     config.observer?._navigator = this;
 
-    bool isFirst = true;
     List<String> routes = _splitRoute(config.initialRoute ?? Navigator.defaultRouteName).toList();
     for (String route in routes) {
       _push(config.onGenerateRoute(new RouteSettings(
         name: route,
-        isInitialRoute: isFirst
+        isInitialRoute: true
       )));
-      isFirst = false;
     }
   }
 


### PR DESCRIPTION
Some work towards https://github.com/flutter/flutter/issues/4702.

When I run this against flutter_gallery with the route `/buttons`, I get the following exception (on pushing `/buttons`, after pushing `/`):

```
I/flutter : ══╡ EXCEPTION CAUGHT BY WIDGETS LIBRARY ╞═══════════════════════════════════════════════════════════
I/flutter : The following assertion was thrown building Title("Flutter Gallery"; color: Color(0xff009688)):
I/flutter : Unable to find the BuildContext for the Navigator's overlay.
I/flutter : Did you remember to pass the settings object to the route's constructor in your onGenerateRoute
I/flutter : callback?
I/flutter : When the exception was thrown, this was the stack:
I/flutter : #0      ModalRoute.didPush.<anonymous closure> (package:flutter/src/widgets/routes.dart:531)
I/flutter : #1      _AssertionError._checkAssertion (dart:core-patch/errors_patch.dart:31)
I/flutter : #2      ModalRoute.didPush (package:flutter/src/widgets/routes.dart:529)
I/flutter : #3      NavigatorState._push.<anonymous closure> (package:flutter/src/widgets/navigator.dart:401)
I/flutter : #4      State.setState (package:flutter/src/widgets/framework.dart:781)
I/flutter : #5      NavigatorState._push (package:flutter/src/widgets/navigator.dart:396)
I/flutter : #6      NavigatorState.initState (package:flutter/src/widgets/navigator.dart:332)
```

@Hixie, does anything jump out at you here? Something simple? Perhaps something I'm doing that's not expected by the framework?
