### PR TITLE
Reproduce the Shrine home page portrait grid layout

### DIFF
--- a/examples/flutter_gallery/lib/demo/shrine/shrine_page.dart
+++ b/examples/flutter_gallery/lib/demo/shrine/shrine_page.dart
@@ -83,17 +83,18 @@ class ShrinePageState extends State<ShrinePage> {
 
   @override
   Widget build(BuildContext context) {
+    final ShrineTheme theme = ShrineTheme.of(context);
     return new Scaffold(
       key: config.scaffoldKey,
       appBar: new AppBar(
         elevation: _appBarElevation,
-        backgroundColor: Theme.of(context).cardColor,
+        backgroundColor: theme.appBarBackgroundColor,
         iconTheme: Theme.of(context).iconTheme,
         brightness: Brightness.light,
         flexibleSpace: new Container(
           decoration: new BoxDecoration(
             border: new Border(
-              bottom: new BorderSide(color: const Color(0xFFD9D9D9))
+              bottom: new BorderSide(color: theme.dividerColor)
             )
           )
         ),

--- a/examples/flutter_gallery/lib/demo/shrine/shrine_theme.dart
+++ b/examples/flutter_gallery/lib/demo/shrine/shrine_theme.dart
@@ -30,6 +30,11 @@ class ShrineTheme extends InheritedWidget {
     assert(child != null);
   }
 
+  final Color cardBackgroundColor = Colors.white;
+  final Color appBarBackgroundColor = Colors.white;
+  final Color dividerColor = const Color(0xFFD9D9D9);
+  final Color priceHighlightColor = const Color(0xFFFFE0E0);
+
   final TextStyle appBarTitleStyle = robotoRegular20(Colors.black87);
   final TextStyle vendorItemStyle = robotoRegular12(const Color(0xFF81959D));
   final TextStyle priceStyle = robotoRegular14(Colors.black87);

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -24,6 +24,7 @@ export 'package:flutter/rendering.dart' show
     FlowDelegate,
     FlowPaintingContext,
     FractionalOffsetTween,
+    GridChildPlacement,
     GridDelegate,
     GridDelegateWithInOrderChildPlacement,
     GridSpecification,


### PR DESCRIPTION
The Shrine home page arranges the product cards into two columns. The card on every 4th and 5th row spans two columns.

Also:
- Moved more of the app's colors into ShrineTheme.
- Export GridChildPlacement in basic.dart.
