### PR TITLE
Cleanup empty statements.

### DIFF
--- a/packages/flutter/lib/src/painting/box_painter.dart
+++ b/packages/flutter/lib/src/painting/box_painter.dart
@@ -272,7 +272,8 @@ class Border {
         }
         canvas.drawPath(path, paint);
         break;
-      case BorderStyle.none: ;
+      case BorderStyle.none:
+        break;
     }
 
     switch (right.style) {
@@ -290,7 +291,8 @@ class Border {
         }
         canvas.drawPath(path, paint);
         break;
-      case BorderStyle.none: ;
+      case BorderStyle.none:
+        break;
     }
 
     switch (bottom.style) {
@@ -308,7 +310,8 @@ class Border {
         }
         canvas.drawPath(path, paint);
         break;
-      case BorderStyle.none: ;
+      case BorderStyle.none:
+        break;
     }
 
     switch (left.style) {
@@ -326,7 +329,8 @@ class Border {
         }
         canvas.drawPath(path, paint);
         break;
-      case BorderStyle.none: ;
+      case BorderStyle.none:
+        break;
     }
   }
 

--- a/packages/flutter/lib/src/rendering/flow.dart
+++ b/packages/flutter/lib/src/rendering/flow.dart
@@ -335,7 +335,7 @@ class RenderFlow extends RenderBox
 
     void painter(PaintingContext context, Offset offset) {
       context.paintChild(child, offset);
-    };
+    }
     if (opacity == 1.0) {
       _paintingContext.pushTransform(needsCompositing, _paintingOffset, transform, painter);
     } else {

--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -871,7 +871,7 @@ class PipelineOwner {
       for (RenderObject node in dirtyNodes..sort((RenderObject a, RenderObject b) => b.depth - a.depth)) {
         if (node._needsPaint && node.owner == this)
           PaintingContext.repaintCompositedChild(node);
-      };
+      }
       assert(_nodesNeedingPaint.length == 0);
     } finally {
       _debugDoingPaint = false;

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -2756,9 +2756,9 @@ class Semantics extends SingleChildRenderObjectWidget {
   void debugFillDescription(List<String> description) {
     super.debugFillDescription(description);
     description.add('container: $container');
-    if (checked != null);
+    if (checked != null)
       description.add('checked: $checked');
-    if (label != null);
+    if (label != null)
       description.add('label: "$label"');
   }
 }

--- a/packages/flutter/test/widget/lazy_block_viewport_test.dart
+++ b/packages/flutter/test/widget/lazy_block_viewport_test.dart
@@ -170,7 +170,7 @@ void main() {
     void collectText(Widget widget) {
       if (widget is Text)
         text.add(widget.data);
-    };
+    }
 
     Widget builder() {
       return new LazyBlockViewport(

--- a/packages/flutter/test/widget/set_state_2_test.dart
+++ b/packages/flutter/test/widget/set_state_2_test.dart
@@ -39,7 +39,7 @@ void main() {
       }
     ));
     log.add('---');
-    await tester.tap(find.text('inner'));;
+    await tester.tap(find.text('inner'));
     await tester.pump();
     log.add('---');
     expect(log, equals(<String>[

--- a/packages/flutter_sprites/test/node_test.dart
+++ b/packages/flutter_sprites/test/node_test.dart
@@ -167,7 +167,7 @@ void main() {
     {
       Node rootNode = new Node();
 
-      Node node0 = new Node()..zPosition = -1.0;;
+      Node node0 = new Node()..zPosition = -1.0;
       Node node1 = new Node();
       Node node2 = new Node()..zPosition = 1.0;
 

--- a/packages/flutter_tools/lib/src/commands/build_apk.dart
+++ b/packages/flutter_tools/lib/src/commands/build_apk.dart
@@ -461,7 +461,7 @@ Future<int> buildAndroid(
         String targetPath = entity.path.substring(assetsDir.path.length);
         extraFiles["assets/$targetPath"] = entity;
       }
-    };
+    }
   }
 
   // In debug (JIT) mode, the snapshot lives in the FLX, and we can skip the APK

--- a/packages/flutter_tools/lib/src/ios/simulators.dart
+++ b/packages/flutter_tools/lib/src/ios/simulators.dart
@@ -660,7 +660,7 @@ class IOSSimulator extends Device {
         String name = path.basename(entity.path);
         return entity is File && name.startsWith('Simulator') && name.endsWith('.png');
       }));
-    };
+    }
 
     Set<File> existingScreenshots = getScreenshots();
 


### PR DESCRIPTION
The new `empty_statements` lint (in the next DEV roll), flags these empty statements.  Harmless, except the one in `basic.dart` that fixes a real-life bug. :)
