### PR TITLE
expose routes to development tools

### DIFF
--- a/packages/flutter/lib/src/foundation/binding.dart
+++ b/packages/flutter/lib/src/foundation/binding.dart
@@ -90,6 +90,7 @@ abstract class BindingBase {
   /// this method to register them using calls to
   /// [registerSignalServiceExtension],
   /// [registerBoolServiceExtension],
+  /// [registerStringServiceExtension],
   /// [registerNumericServiceExtension], and
   /// [registerServiceExtension] (in increasing order of complexity).
   ///
@@ -173,6 +174,35 @@ abstract class BindingBase {
         if (parameters.containsKey('enabled'))
           setter(parameters['enabled'] == 'true');
         return <String, dynamic>{ 'enabled': getter() };
+      }
+    );
+  }
+
+  /// Registers a service extension method with the given name (full
+  /// name "ext.flutter.name"), which takes a single argument with the
+  /// same name as the method which, if present, must have a string value,
+  /// and can be omitted to read the current value. (Other arguments are
+  /// ignored.)
+  ///
+  /// Calls the `getter` callback to obtain the value when
+  /// responding to the service extension method being called.
+  ///
+  /// Calls the `setter` callback with the new value when the
+  /// service extension method is called with a new value.
+  void registerStringServiceExtension({
+    @required String name,
+    @required ValueGetter<String> getter,
+    @required ValueSetter<String> setter
+  }) {
+    assert(name != null);
+    assert(getter != null);
+    assert(setter != null);
+    registerServiceExtension(
+      name: name,
+      callback: (Map<String, String> parameters) async {
+        if (parameters.containsKey(name))
+          setter(parameters[name]);
+        return <String, dynamic>{ name: getter() };
       }
     );
   }

--- a/packages/flutter/lib/src/widgets/app.dart
+++ b/packages/flutter/lib/src/widgets/app.dart
@@ -108,7 +108,7 @@ class WidgetsApp extends StatefulWidget {
   _WidgetsAppState createState() => new _WidgetsAppState();
 }
 
-class _WidgetsAppState extends State<WidgetsApp> implements WidgetsBindingObserver {
+class _WidgetsAppState extends State<WidgetsApp> implements WidgetsBindingObserver, NavigatorOwner {
   GlobalObjectKey _navigator;
   LocaleQueryData _localeData;
 
@@ -212,4 +212,6 @@ class _WidgetsAppState extends State<WidgetsApp> implements WidgetsBindingObserv
     return result;
   }
 
+  @override
+  NavigatorState get navigator => _navigator.currentState;
 }

--- a/packages/flutter/lib/src/widgets/binding.dart
+++ b/packages/flutter/lib/src/widgets/binding.dart
@@ -13,6 +13,7 @@ import 'package:flutter/services.dart';
 
 import 'app.dart';
 import 'framework.dart';
+import 'navigator.dart';
 
 export 'dart:ui' show AppLifecycleState, Locale;
 
@@ -72,6 +73,11 @@ abstract class WidgetsBinding extends BindingBase implements GestureBinding, Ren
   void initServiceExtensions() {
     super.initServiceExtensions();
 
+    registerSignalServiceExtension(
+      name: 'debugDumpApp',
+      callback: debugDumpApp
+    );
+
     registerBoolServiceExtension(
       name: 'showPerformanceOverlay',
       getter: () => WidgetsApp.showPerformanceOverlayOverride,
@@ -82,6 +88,22 @@ abstract class WidgetsBinding extends BindingBase implements GestureBinding, Ren
         buildOwner.reassemble(renderViewElement);
       }
     );
+
+    registerStringServiceExtension(
+      name: 'applicationRoute',
+      getter: () => _navigatorState?.currentRoute?.settings?.name,
+      setter: (String route) {
+        _navigatorState?.pushNamed(route);
+      }
+    );
+  }
+
+  NavigatorState get _navigatorState {
+    NavigatorOwner observer = WidgetsBinding.instance._observers.firstWhere(
+      (WidgetsBindingObserver observer) => observer is NavigatorOwner,
+      orElse: () => null
+    );
+    return observer?.navigator;
   }
 
   /// The [BuildOwner] in charge of executing the build pipeline for the

--- a/packages/flutter/lib/src/widgets/routes.dart
+++ b/packages/flutter/lib/src/widgets/routes.dart
@@ -455,6 +455,7 @@ abstract class ModalRoute<T> extends TransitionRoute<T> with LocalHistoryRoute<T
   /// The settings for this route.
   ///
   /// See [RouteSettings] for details.
+  @override
   final RouteSettings settings;
 
   /// Returns the modal route most closely associated with the given context.

--- a/packages/flutter_tools/lib/src/observatory.dart
+++ b/packages/flutter_tools/lib/src/observatory.dart
@@ -215,6 +215,27 @@ class Observatory {
 
   // Flutter extension methods.
 
+  Future<Response> flutterDebugDumpApp(String isolateId) {
+    return peer.sendRequest('ext.flutter.debugDumpApp', <String, dynamic>{
+      'isolateId': isolateId
+    }).then((dynamic result) => new Response(result));
+  }
+
+  Future<Response> flutterSetApplicationRoute(String isolateId, String route) {
+    return peer.sendRequest('ext.flutter.applicationRoute', <String, dynamic>{
+      'isolateId': isolateId,
+      'applicationRoute': route
+    }).then((dynamic result) => new Response(result));
+  }
+
+  /// Called when application code has changed to cause the application to pick
+  /// up any changed code.
+  Future<Response> flutterReassemble(String isolateId) {
+    return peer.sendRequest('ext.flutter.reassemble', <String, dynamic>{
+      'isolateId': isolateId
+    }).then((dynamic result) => new Response(result));
+  }
+
   Future<Response> flutterExit(String isolateId) {
     return peer.sendRequest('ext.flutter.exit', <String, dynamic>{
       'isolateId': isolateId
@@ -279,6 +300,7 @@ class Event extends Response {
 
   /// Only valid for [kind] == `Extension`.
   String get extensionKind => response['extensionKind'];
+  Map<String, dynamic> get extensionData => response['extensionData'];
 }
 
 class IsolateRef extends Response {

--- a/packages/flutter_tools/lib/src/run.dart
+++ b/packages/flutter_tools/lib/src/run.dart
@@ -211,6 +211,12 @@ class RunAndStayResident {
       observatory.onIsolateEvent.listen((Event event) {
         printTrace(event.toString());
       });
+      observatory.onExtensionEvent
+        .where((Event event) => event.extensionKind == 'Flutter.RouteChanged')
+        .listen((Event event) {
+          String route = event.extensionData['route'];
+          printStatus('[$route]');
+        });
 
       if (benchmark)
         await observatory.waitFirstIsolate;
@@ -255,6 +261,8 @@ class RunAndStayResident {
             _stopApp();
           } else if (useDevFS && lower == 'd') {
             _updateDevFS();
+          } else if (lower == 'a') {
+            _debugDumpApp();
           }
         });
       }
@@ -291,6 +299,10 @@ class RunAndStayResident {
       _stopLogger();
       return exitCode;
     });
+  }
+
+  void _debugDumpApp() {
+    observatory.flutterDebugDumpApp(observatory.firstIsolateId);
   }
 
   DevFS devFS;
@@ -361,6 +373,7 @@ class RunAndStayResident {
   void _printHelp() {
     String restartText = device.supportsRestart ? ', "r" or F5 to restart the app,' : '';
     printStatus('Type "h" or F1 for help$restartText and "q", F10, or ctrl-c to quit.');
+    printStatus('Type "a" to print a summary of the current app.');
 
     if (useDevFS)
       printStatus('Type "d" to send modified project files to the the client\'s DevFS.');


### PR DESCRIPTION
- register a service extension to expose getting and setting the current route (fix https://github.com/flutter/flutter/issues/4701)
- fire events when the route changes
- expose the `RouteSettings settings` field on Routes in order to get access to the route name
- when the route changes, print the new route as part of `flutter run`

and
- register a service extension to expose `debugDumpApp()`; expose the ability to call it from `flutter run`

@Hixie @abarth 
