### PR TITLE
Refresh indicator

### DIFF
--- a/examples/flutter_gallery/lib/demo/overscroll_demo.dart
+++ b/examples/flutter_gallery/lib/demo/overscroll_demo.dart
@@ -18,6 +18,7 @@ class OverscrollDemo extends StatefulWidget {
 }
 
 class OverscrollDemoState extends State<OverscrollDemo> {
+  static final GlobalKey<ScrollableState> _scrollableKey = new GlobalKey<ScrollableState>();
   static final List<String> _items = <String>[
     'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N'
   ];
@@ -50,6 +51,7 @@ class OverscrollDemoState extends State<OverscrollDemo> {
       child: new MaterialList(
         type: MaterialListType.threeLine,
         padding: const EdgeInsets.all(8.0),
+        scrollableKey: _scrollableKey,
         children: _items.map((String item) {
           return new ListItem(
             isThreeLine: true,
@@ -65,7 +67,11 @@ class OverscrollDemoState extends State<OverscrollDemo> {
         body = new OverscrollIndicator(child: body);
         break;
       case IndicatorType.refresh:
-        body = new RefreshIndicator(child: body, refresh: refresh);
+        body = new RefreshIndicator(
+          child: body,
+          refresh: refresh,
+          scrollableKey: _scrollableKey
+        );
         break;
     }
 

--- a/packages/flutter/lib/src/animation/curves.dart
+++ b/packages/flutter/lib/src/animation/curves.dart
@@ -60,6 +60,8 @@ class SawTooth extends Curve {
 
   @override
   double transform(double t) {
+    if (t == 1.0)
+      return 1.0;
     t *= count;
     return t - t.truncateToDouble();
   }

--- a/packages/flutter/lib/src/material/list.dart
+++ b/packages/flutter/lib/src/material/list.dart
@@ -96,7 +96,7 @@ class MaterialList extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return new ScrollableList(
-      key: scrollableKey,
+      scrollableKey: scrollableKey,
       initialScrollOffset: initialScrollOffset,
       scrollDirection: Axis.vertical,
       onScrollStart: onScrollStart,

--- a/packages/flutter/lib/src/material/progress_indicator.dart
+++ b/packages/flutter/lib/src/material/progress_indicator.dart
@@ -287,8 +287,11 @@ class CircularProgressIndicator extends ProgressIndicator {
     Key key,
     double value,
     Color backgroundColor,
+    this.controller,
     Animation<Color> valueColor
   }) : super(key: key, value: value, backgroundColor: backgroundColor, valueColor: valueColor);
+
+  final AnimationController controller;
 
   @override
   _CircularProgressIndicatorState createState() => new _CircularProgressIndicatorState();
@@ -317,15 +320,17 @@ class _CircularProgressIndicatorState extends State<CircularProgressIndicator> {
   @override
   void initState() {
     super.initState();
-    _controller = new AnimationController(
-      duration: const Duration(milliseconds: 6666)
-    )..repeat();
+    _controller = _buildController();
   }
 
   @override
   void dispose() {
     _controller.dispose();
     super.dispose();
+  }
+
+  AnimationController _buildController() {
+    return new AnimationController(duration: const Duration(milliseconds: 6666))..repeat();
   }
 
   Widget _buildIndicator(BuildContext context, double headValue, double tailValue, int stepValue, double rotationValue) {
@@ -348,11 +353,7 @@ class _CircularProgressIndicatorState extends State<CircularProgressIndicator> {
     );
   }
 
-  @override
-  Widget build(BuildContext context) {
-    if (config.value != null)
-      return _buildIndicator(context, 0.0, 0.0, 0, 0.0);
-
+  Widget _buildAnimation() {
     return new AnimatedBuilder(
       animation: _controller,
       builder: (BuildContext context, Widget child) {
@@ -365,6 +366,13 @@ class _CircularProgressIndicatorState extends State<CircularProgressIndicator> {
         );
       }
     );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (config.value != null)
+      return _buildIndicator(context, 0.0, 0.0, 0, 0.0);
+    return _buildAnimation();
   }
 }
 
@@ -438,7 +446,12 @@ class RefreshProgressIndicator extends CircularProgressIndicator {
     double value,
     Color backgroundColor,
     Animation<Color> valueColor
-  }) : super(key: key, value: value, backgroundColor: backgroundColor, valueColor: valueColor);
+  }) : super(
+    key: key,
+    value: value,
+    backgroundColor: backgroundColor,
+    valueColor: valueColor
+  );
 
   @override
   _RefreshProgressIndicatorState createState() => new _RefreshProgressIndicatorState();
@@ -446,6 +459,19 @@ class RefreshProgressIndicator extends CircularProgressIndicator {
 
 class _RefreshProgressIndicatorState extends _CircularProgressIndicatorState {
   static double _kIndicatorSize = 40.0;
+
+  // Always show the indeterminate version of the circular progress indicator.
+  // When value is non-null the sweep of the progress indicator arrow's arc
+  // varies from 0 to about 270 degrees. When value is null the arrow animates
+  // starting from wherever we left it.
+  @override
+  Widget build(BuildContext context) {
+    if (config.value != null)
+      _controller.value = config.value / 10.0;
+    else
+      _controller.forward();
+    return _buildAnimation();
+  }
 
   @override
   Widget _buildIndicator(BuildContext context, double headValue, double tailValue, int stepValue, double rotationValue) {
@@ -462,8 +488,8 @@ class _RefreshProgressIndicatorState extends _CircularProgressIndicatorState {
           child: new CustomPaint(
             painter: new _RefreshProgressIndicatorPainter(
               valueColor: config._getValueColor(context),
-              value: config.value, // may be null
-              headValue: headValue, // remaining arguments are ignored if config.value is not null
+              value: null, // Draw the indeterminate progress indicator.
+              headValue: headValue,
               tailValue: tailValue,
               stepValue: stepValue,
               rotationValue: rotationValue,

--- a/packages/flutter/lib/src/material/progress_indicator.dart
+++ b/packages/flutter/lib/src/material/progress_indicator.dart
@@ -287,11 +287,8 @@ class CircularProgressIndicator extends ProgressIndicator {
     Key key,
     double value,
     Color backgroundColor,
-    this.controller,
     Animation<Color> valueColor
   }) : super(key: key, value: value, backgroundColor: backgroundColor, valueColor: valueColor);
-
-  final AnimationController controller;
 
   @override
   _CircularProgressIndicatorState createState() => new _CircularProgressIndicatorState();

--- a/packages/flutter/test/material/refresh_indicator_test.dart
+++ b/packages/flutter/test/material/refresh_indicator_test.dart
@@ -7,8 +7,9 @@ import 'dart:async';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/material.dart';
 
-void main() {
+final GlobalKey<ScrollableState> scrollableKey = new GlobalKey<ScrollableState>();
 
+void main() {
   bool refreshCalled = false;
 
   Future<Null> refresh() {
@@ -19,8 +20,10 @@ void main() {
   testWidgets('RefreshIndicator', (WidgetTester tester) async {
     await tester.pumpWidget(
       new RefreshIndicator(
+        scrollableKey: scrollableKey,
         refresh: refresh,
         child: new Block(
+          scrollableKey: scrollableKey,
           children: <String>['A', 'B', 'C', 'D', 'E', 'F'].map((String item) {
             return new SizedBox(
               height: 200.0,
@@ -31,7 +34,7 @@ void main() {
       )
     );
 
-    await tester.fling(find.text('A'), const Offset(0.0, 200.0), -1000.0);
+    await tester.fling(find.text('A'), const Offset(0.0, 300.0), -1000.0);
     await tester.pump();
     await tester.pump(const Duration(seconds: 1)); // finish the scroll animation
     await tester.pump(const Duration(seconds: 1)); // finish the indicator settle animation


### PR DESCRIPTION
- Now displays the correct animation during a drag.
- Handles overlapping calls to the refresh callback.
- Forced SawToothCurve(t == 1.0) to transform to 1.0.

The implementation listens to the pointer instead of ScrollNotifications. At least for now, it's necessary to identify the scrollable that's driving the refresh indicator with a scrollableKey.

Fixes #4130
