### PR TITLE
Update to latest analyzer (w/ cleanup).

### DIFF
--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -465,9 +465,6 @@ abstract class StatelessWidget extends Widget {
   /// inserted into the tree in multiple places at once.
   @protected
   Widget build(BuildContext context);
-
-  /// Trampoline to make the [build] closure library-accessible.
-  WidgetBuilder get _build => build;
 }
 
 /// A widget that has mutable state.
@@ -2012,7 +2009,7 @@ abstract class ComponentElement extends BuildableElement {
 /// Instantiation of [StatelessWidget]s.
 class StatelessElement extends ComponentElement {
   StatelessElement(StatelessWidget widget) : super(widget) {
-    _builder = widget._build;
+    _builder = widget.build;
   }
 
   @override
@@ -2022,14 +2019,14 @@ class StatelessElement extends ComponentElement {
   void update(StatelessWidget newWidget) {
     super.update(newWidget);
     assert(widget == newWidget);
-    _builder = widget._build;
+    _builder = widget.build;
     _dirty = true;
     rebuild();
   }
 
   @override
   void _reassemble() {
-    _builder = widget._build;
+    _builder = widget.build;
     super._reassemble();
   }
 }

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -867,9 +867,6 @@ abstract class State<T extends StatefulWidget> {
   @protected
   Widget build(BuildContext context);
 
-  /// Trampoline to make the [build] closure library-accessible.
-  WidgetBuilder get _build => build;
-
   /// Called when a dependencies of this [State] object changes.
   ///
   /// For example, if the previous call to [build] referenced an
@@ -2039,7 +2036,7 @@ class StatefulElement extends ComponentElement {
     assert(_state._element == null);
     _state._element = this;
     assert(_builder == _buildNothing);
-    _builder = _state._build;
+    _builder = _state.build;
     assert(_state._config == null);
     _state._config = widget;
     assert(_state._debugLifecycleState == _StateLifecycle.created);
@@ -2050,7 +2047,7 @@ class StatefulElement extends ComponentElement {
 
   @override
   void _reassemble() {
-    _builder = state._build;
+    _builder = state.build;
     super._reassemble();
   }
 

--- a/packages/flutter_test/pubspec.yaml
+++ b/packages/flutter_test/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
   # We don't actually depend on 'analyzer', but 'test' and 'flutter_tools' do.
   # We pin the version of analyzer we depend on to avoid version skew across our
   # packages.
-  analyzer: 0.27.4-alpha.14
+  analyzer: 0.27.4-alpha.15
 
   flutter:
     path: ../flutter

--- a/packages/flutter_tools/pubspec.yaml
+++ b/packages/flutter_tools/pubspec.yaml
@@ -38,7 +38,7 @@ dependencies:
   test: 0.12.13+5
 
   # Pinned in flutter_test as well.
-  analyzer: 0.27.4-alpha.14
+  analyzer: 0.27.4-alpha.15
 
 dev_dependencies:
   mockito: ^0.11.0


### PR DESCRIPTION
Syncs up with our current `1.18.0-dev.3.0` Dart SDK and includes a fix to `@protected` that lets us get rid of the trampoline work-around.  (I think there are others we can cleanup but these are the ones I know about...)

/cc @Hixie, @abarth  
