### PR TITLE
Don't pick up Android SDK from local engine

### DIFF
--- a/packages/flutter_tools/lib/src/runner/flutter_command_runner.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command_runner.dart
@@ -165,13 +165,8 @@ class FlutterCommandRunner extends CommandRunner {
     }
 
     // The Android SDK could already have been set by tests.
-    if (!context.isSet(AndroidSdk)) {
-      if (enginePath != null) {
-        context[AndroidSdk] = new AndroidSdk('$enginePath/third_party/android_tools/sdk');
-      } else {
-        context[AndroidSdk] = AndroidSdk.locateAndroidSdk();
-      }
-    }
+    if (!context.isSet(AndroidSdk))
+      context[AndroidSdk] = AndroidSdk.locateAndroidSdk();
 
     if (globalResults['version']) {
       flutterUsage.sendCommand('version');


### PR DESCRIPTION
It can cause trouble if the user has a newer Android SDK installed normally.
Instead, just use the normal Android SDK.
