### PR TITLE
Update use of `@protected`

### DIFF
--- a/packages/flutter/lib/src/rendering/box.dart
+++ b/packages/flutter/lib/src/rendering/box.dart
@@ -932,6 +932,7 @@ abstract class RenderBox extends RenderObject {
   /// This function must only be called from [getDistanceToBaseline] and
   /// [computeDistanceToActualBaseline]. Do not call this function directly from
   /// outside those two methods.
+  @protected
   @mustCallSuper
   double getDistanceToActualBaseline(TextBaseline baseline) {
     assert(_debugDoingBaseline);

--- a/packages/flutter/lib/src/rendering/node.dart
+++ b/packages/flutter/lib/src/rendering/node.dart
@@ -52,6 +52,7 @@ class AbstractNode {
   int get depth => _depth;
 
   /// Call only from overrides of [redepthChildren]
+  @protected
   void redepthChild(AbstractNode child) {
     assert(child.owner == owner);
     if (child._depth <= _depth) {
@@ -97,6 +98,7 @@ class AbstractNode {
   AbstractNode get parent => _parent;
 
   /// Subclasses should call this function when they acquire a new child.
+  @protected
   @mustCallSuper
   void adoptChild(AbstractNode child) {
     assert(child != null);
@@ -115,6 +117,7 @@ class AbstractNode {
   }
 
   /// Subclasses should call this function when they lose a child.
+  @protected
   @mustCallSuper
   void dropChild(AbstractNode child) {
     assert(child != null);

--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -30,6 +30,7 @@ export 'package:flutter/foundation.dart' show FlutterError, InformationCollector
 /// to other children.
 class ParentData {
   /// Called when the RenderObject is removed from the tree.
+  @protected
   @mustCallSuper
   void detach() { }
 
@@ -1139,7 +1140,6 @@ abstract class RenderObject extends AbstractNode implements HitTestTarget {
   @override
   PipelineOwner get owner => super.owner;
 
-  // Workaround for https://github.com/dart-lang/sdk/issues/25232
   @override
   void attach(PipelineOwner owner) {
     super.attach(owner);

--- a/packages/flutter/lib/src/services/image_stream.dart
+++ b/packages/flutter/lib/src/services/image_stream.dart
@@ -133,7 +133,7 @@ class ImageStream {
     } else {
       result.write('${_completer.runtimeType}; ');
       final List<String> description = <String>[];
-      _completer._debugFillDescription(description);
+      _completer.debugFillDescription(description);
       result.write(description.join('; '));
     }
     result.write(')');
@@ -213,9 +213,6 @@ class ImageStreamCompleter {
       description.add('$_current');
     description.add('${_listeners.length} listener${_listeners.length == 1 ? "" : "s" }');
   }
-
-  // TODO(ianh): remove once @protected allows in-file references
-  void _debugFillDescription(List<String> description) => debugFillDescription(description);
 }
 
 /// Manages the loading of [ui.Image] objects for static [ImageStream]s (those

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -368,6 +368,7 @@ abstract class Widget {
   /// is placed in the tree, it is inflated into an [Element], which means a
   /// widget that is incorporated into the tree multiple times will be inflated
   /// multiple times.
+  @protected
   Element createElement();
 
   /// A short, textual description of this widget.
@@ -393,13 +394,6 @@ abstract class Widget {
   @protected
   @mustCallSuper
   void debugFillDescription(List<String> description) { }
-
-  /// Lets [Element.debugFillDescription] call the @protected method
-  /// [debugFillDescription]. This pattern prevents other unwanted callers
-  /// outside this library.
-  void _debugFillDescription(List<String> description) {
-    debugFillDescription(description);
-  }
 
   /// Whether the `newWidget` can be used to update an [Element] that currently
   /// has the `oldWidget` as its configuration.
@@ -540,6 +534,7 @@ abstract class StatefulWidget extends Widget {
   /// later inserted into the tree again, the framework will call [createState]
   /// again to create a fresh [State] object, simplifying the lifecycle of
   /// [State] objects.
+  @protected
   State createState();
 }
 
@@ -706,6 +701,7 @@ abstract class State<T extends StatefulWidget> {
   ///
   /// If you override this, make sure your method starts with a call to
   /// super.initState().
+  @protected
   @mustCallSuper
   void initState() {
     assert(_debugLifecycleState == _StateLifecycle.created);
@@ -729,6 +725,7 @@ abstract class State<T extends StatefulWidget> {
   /// If you override this, make sure your method starts with a call to
   /// super.didUpdateConfig(oldConfig).
   // TODO(abarth): Add @mustCallSuper.
+  @protected
   void didUpdateConfig(T oldConfig) { }
 
   /// Notify the framework that the internal state of this object has changed.
@@ -813,6 +810,7 @@ abstract class State<T extends StatefulWidget> {
   ///
   /// If you override this, make sure to end your method with a call to
   /// super.deactivate().
+  @protected
   @mustCallSuper
   void deactivate() { }
 
@@ -829,6 +827,7 @@ abstract class State<T extends StatefulWidget> {
   ///
   /// If you override this, make sure to end your method with a call to
   /// super.dispose().
+  @protected
   @mustCallSuper
   void dispose() {
     assert(_debugLifecycleState == _StateLifecycle.ready);
@@ -878,6 +877,7 @@ abstract class State<T extends StatefulWidget> {
   /// this method because they need to do some expensive work (e.g., network
   /// fetches) when their dependencies change, and that work would be too
   /// expensive to do for every build.
+  @protected
   @mustCallSuper
   void dependenciesChanged() { }
 
@@ -965,6 +965,7 @@ abstract class ParentDataWidget<T extends RenderObjectWidget> extends _ProxyWidg
     return result;
   }
 
+  @protected
   void applyParentData(RenderObject renderObject);
 }
 
@@ -975,6 +976,7 @@ abstract class InheritedWidget extends _ProxyWidget {
   @override
   InheritedElement createElement() => new InheritedElement(this);
 
+  @protected
   bool updateShouldNotify(InheritedWidget oldWidget);
 }
 
@@ -991,13 +993,16 @@ abstract class RenderObjectWidget extends Widget {
   /// Creates an instance of the [RenderObject] class that this
   /// [RenderObjectWidget] represents, using the configuration described by this
   /// [RenderObjectWidget].
+  @protected
   RenderObject createRenderObject(BuildContext context);
 
   /// Copies the configuration described by this [RenderObjectWidget] to the
   /// given [RenderObject], which will be of the same type as returned by this
   /// object's [createRenderObject].
+  @protected
   void updateRenderObject(BuildContext context, RenderObject renderObject) { }
 
+  @protected
   void didUnmountRenderObject(RenderObject renderObject) { }
 }
 
@@ -1730,7 +1735,7 @@ abstract class Element implements BuildContext {
     } else {
       if (widget.key != null)
         description.add('${widget.key}');
-      widget._debugFillDescription(description);
+      widget.debugFillDescription(description);
     }
   }
 
@@ -2212,7 +2217,7 @@ class ParentDataElement<T extends RenderObjectWidget> extends _ProxyElement {
   void notifyClients(ParentDataWidget<T> oldWidget) {
     void notifyChildren(Element child) {
       if (child is RenderObjectElement) {
-        child.updateParentData(widget);
+        child._updateParentData(widget);
       } else {
         assert(child is! ParentDataElement<RenderObjectWidget>);
         child.visitChildren(notifyChildren);
@@ -2514,7 +2519,7 @@ abstract class RenderObjectElement extends BuildableElement {
     widget.didUnmountRenderObject(renderObject);
   }
 
-  void updateParentData(ParentDataWidget<RenderObjectWidget> parentData) {
+  void _updateParentData(ParentDataWidget<RenderObjectWidget> parentData) {
     parentData.applyParentData(renderObject);
   }
 
@@ -2534,7 +2539,7 @@ abstract class RenderObjectElement extends BuildableElement {
     _ancestorRenderObjectElement?.insertChildRenderObject(renderObject, newSlot);
     ParentDataElement<RenderObjectWidget> parentDataElement = _findAncestorParentDataElement();
     if (parentDataElement != null)
-      updateParentData(parentDataElement.widget);
+      _updateParentData(parentDataElement.widget);
   }
 
   @override

--- a/packages/flutter/lib/src/widgets/gesture_detector.dart
+++ b/packages/flutter/lib/src/widgets/gesture_detector.dart
@@ -393,7 +393,8 @@ class RawGestureDetectorState extends State<RawGestureDetector> {
     if (!config.excludeFromSemantics) {
       RenderSemanticsGestureHandler semanticsGestureHandler = context.findRenderObject();
       context.visitChildElements((RenderObjectElement element) {
-        element.widget.updateRenderObject(context, semanticsGestureHandler);
+        _GestureSemantics widget = element.widget;
+        widget._updateHandlers(semanticsGestureHandler, _recognizers);
       });
     }
   }
@@ -558,9 +559,7 @@ class _GestureSemantics extends SingleChildRenderObjectWidget {
     return result;
   }
 
-  @override
-  void updateRenderObject(BuildContext context, RenderSemanticsGestureHandler renderObject) {
-    Map<Type, GestureRecognizer> recognizers = owner._recognizers;
+  void _updateHandlers(RenderSemanticsGestureHandler renderObject, Map<Type, GestureRecognizer> recognizers) {
     renderObject
       ..onTap = recognizers.containsKey(TapGestureRecognizer) ? _handleTap : null
       ..onLongPress = recognizers.containsKey(LongPressGestureRecognizer) ? _handleLongPress : null
@@ -568,5 +567,10 @@ class _GestureSemantics extends SingleChildRenderObjectWidget {
           recognizers.containsKey(PanGestureRecognizer) ? _handleHorizontalDragUpdate : null
       ..onVerticalDragUpdate = recognizers.containsKey(VerticalDragGestureRecognizer) ||
           recognizers.containsKey(PanGestureRecognizer) ? _handleVerticalDragUpdate : null;
+  }
+
+  @override
+  void updateRenderObject(BuildContext context, RenderSemanticsGestureHandler renderObject) {
+    _updateHandlers(renderObject, owner._recognizers);
   }
 }


### PR DESCRIPTION
Now that protected can be accessed from inside the same library, we can
use protected in a number of new places and we can remove some
trampolines we were using to work around its previous semantics.
