### PR TITLE
send ext.flutter.debugDumpApp; ext.flutter.reassemble

### DIFF
--- a/packages/flutter/lib/src/rendering/binding.dart
+++ b/packages/flutter/lib/src/rendering/binding.dart
@@ -57,6 +57,14 @@ abstract class RendererBinding extends BindingBase implements SchedulerBinding, 
     });
 
     assert(() {
+      registerSignalServiceExtension(
+        name: 'debugDumpRenderTree',
+        callback: debugDumpRenderTree
+      );
+      return true;
+    });
+
+    assert(() {
       // this service extension only works in checked mode
       registerBoolServiceExtension(
         name: 'repaintRainbow',

--- a/packages/flutter/lib/src/widgets/binding.dart
+++ b/packages/flutter/lib/src/widgets/binding.dart
@@ -72,6 +72,11 @@ abstract class WidgetsBinding extends BindingBase implements GestureBinding, Ren
   void initServiceExtensions() {
     super.initServiceExtensions();
 
+    registerSignalServiceExtension(
+      name: 'debugDumpApp',
+      callback: debugDumpApp
+    );
+
     registerBoolServiceExtension(
       name: 'showPerformanceOverlay',
       getter: () => WidgetsApp.showPerformanceOverlayOverride,

--- a/packages/flutter_tools/lib/src/device.dart
+++ b/packages/flutter_tools/lib/src/device.dart
@@ -191,6 +191,8 @@ abstract class Device {
 
   bool get supportsRestart => false;
 
+  bool get restartSendsFrameworkInitEvent => true;
+
   /// Restart the given app; the application will already have been launched with
   /// [startApp].
   Future<bool> restartApp(

--- a/packages/flutter_tools/lib/src/observatory.dart
+++ b/packages/flutter_tools/lib/src/observatory.dart
@@ -215,6 +215,12 @@ class Observatory {
     }).then((dynamic result) => new Response(result));
   }
 
+  Future<Response> flutterDebugDumpRenderTree(String isolateId) {
+    return peer.sendRequest('ext.flutter.debugDumpRenderTree', <String, dynamic>{
+      'isolateId': isolateId
+    }).then((dynamic result) => new Response(result));
+  }
+
   /// Causes the application to pick up any changed code.
   Future<Response> flutterReassemble(String isolateId) {
     return peer.sendRequest('ext.flutter.reassemble', <String, dynamic>{

--- a/packages/flutter_tools/lib/src/run.dart
+++ b/packages/flutter_tools/lib/src/run.dart
@@ -259,8 +259,10 @@ class RunAndStayResident {
             _stopApp();
           } else if (useDevFS && lower == 'd') {
             _updateDevFS();
-          } else if (lower == 'a') {
+          } else if (lower == 'w') {
             _debugDumpApp();
+          } else if (lower == 't') {
+            _debugDumpRenderTree();
           }
         });
       }
@@ -301,6 +303,10 @@ class RunAndStayResident {
 
   void _debugDumpApp() {
     observatory.flutterDebugDumpApp(observatory.firstIsolateId);
+  }
+
+  void _debugDumpRenderTree() {
+    observatory.flutterDebugDumpRenderTree(observatory.firstIsolateId);
   }
 
   DevFS devFS;
@@ -371,7 +377,7 @@ class RunAndStayResident {
   void _printHelp() {
     String restartText = device.supportsRestart ? ', "r" or F5 to restart the app,' : '';
     printStatus('Type "h" or F1 for help$restartText and "q", F10, or ctrl-c to quit.');
-    printStatus('Type "a" to print the widget hierarchy of the current app.');
+    printStatus('Type "w" to print the widget hierarchy of the app, and "t" for the render tree.');
 
     if (useDevFS)
       printStatus('Type "d" to send modified project files to the the client\'s DevFS.');


### PR DESCRIPTION
Some leftovers from a previous PR:
- expose `debugDumpApp()` as a service protocol extension and wire it up to the `flutter run` UI

and:
- after we successfully restart an isolate, send `ext.flutter.reassemble` to refresh the UI
