### PR TITLE
Use https instead of http when downloading Dart.

### DIFF
--- a/bin/cache/update_dart_sdk.sh
+++ b/bin/cache/update_dart_sdk.sh
@@ -34,7 +34,7 @@ if [ ! -f "$DART_SDK_STAMP_PATH" ] || [ "$DART_SDK_VERSION" != `cat "$DART_SDK_S
     DART_CHANNEL="dev"
   fi
 
-  DART_SDK_URL="http://storage.googleapis.com/dart-archive/channels/$DART_CHANNEL/raw/$DART_SDK_VERSION/sdk/$DART_ZIP_NAME"
+  DART_SDK_URL="https://storage.googleapis.com/dart-archive/channels/$DART_CHANNEL/raw/$DART_SDK_VERSION/sdk/$DART_ZIP_NAME"
 
   rm -rf -- "$DART_SDK_PATH"
   mkdir -p -- "$DART_SDK_PATH"


### PR DESCRIPTION
This came up in security review.

@abarth
