### PR TITLE
RefreshIndicator dismiss transition, remain visible during refresh, etc

### DIFF
--- a/examples/flutter_gallery/lib/demo/overscroll_demo.dart
+++ b/examples/flutter_gallery/lib/demo/overscroll_demo.dart
@@ -70,7 +70,8 @@ class OverscrollDemoState extends State<OverscrollDemo> {
         body = new RefreshIndicator(
           child: body,
           refresh: refresh,
-          scrollableKey: _scrollableKey
+          scrollableKey: _scrollableKey,
+          location: RefreshIndicatorLocation.top
         );
         break;
     }

--- a/packages/flutter/lib/src/material/refresh_indicator.dart
+++ b/packages/flutter/lib/src/material/refresh_indicator.dart
@@ -184,7 +184,7 @@ class _RefreshIndicatorState extends State<RefreshIndicator> {
     final double scrollOffset = scrollable.scrollOffset;
     switch (config.location) {
       case RefreshIndicatorLocation.top:
-        return  scrollOffset <= minScrollOffset;
+        return scrollOffset <= minScrollOffset;
       case RefreshIndicatorLocation.bottom:
         return scrollOffset >= maxScrollOffset;
       case RefreshIndicatorLocation.both:

--- a/packages/flutter/lib/src/material/refresh_indicator.dart
+++ b/packages/flutter/lib/src/material/refresh_indicator.dart
@@ -238,7 +238,7 @@ class _RefreshIndicatorState extends State<RefreshIndicator> {
     if (!_isValidScrollable(scrollable))
       return;
 
-    final dragOffsetDelta = scrollable.pixelOffsetToScrollOffset(event.delta.dy);
+    final double dragOffsetDelta = scrollable.pixelOffsetToScrollOffset(event.delta.dy);
     _dragOffset += dragOffsetDelta / 2.0;
     if (_dragOffset.abs() < kPixelScrollTolerance.distance)
       return;


### PR DESCRIPTION
- The refresh indicator now slides out of view if it wasn't dragged far enough to trigger the refresh callback.
- Once a refresh is underway, the indicator stays put, even if the underlying scrollable is scrolled.
- The implementation now keeps track of the overscroll distance (_dragOffset) itself. The refresh indicator will appear even if overscrolling isn't possible.

Fixes #4829
Fixes #4831
Fixes #4834
