### PR TITLE
Improve how ImageIcon does opacity

### DIFF
--- a/packages/flutter/lib/src/material/image_icon.dart
+++ b/packages/flutter/lib/src/material/image_icon.dart
@@ -61,9 +61,12 @@ class ImageIcon extends StatelessWidget {
       return new SizedBox(width: iconSize, height: iconSize);
 
     final double iconOpacity = iconTheme.opacity;
-    final Color iconColor = color ?? iconTheme.color;
+    Color iconColor = color ?? iconTheme.color;
 
-    Widget result = new Image(
+    if (iconOpacity != null && iconOpacity != 1.0)
+      iconColor = iconColor.withOpacity(iconColor.opacity * iconOpacity);
+
+    return new Image(
       image: image,
       width: iconSize,
       height: iconSize,
@@ -71,15 +74,6 @@ class ImageIcon extends StatelessWidget {
       fit: ImageFit.scaleDown,
       alignment: FractionalOffset.center
     );
-
-    if (iconOpacity != 1.0) {
-      result = new Opacity(
-        opacity: iconOpacity,
-        child: result
-      );
-    }
-
-    return result;
   }
 
   @override


### PR DESCRIPTION
Putting the opacity in the color is much faster than using an opacity
widget because the opacity widget creates an offscreen buffer.

Fixes #4651
