### PR TITLE
TwoLevelSublist should have an onOpenChanged callback

### DIFF
--- a/packages/flutter/lib/src/material/two_level_list.dart
+++ b/packages/flutter/lib/src/material/two_level_list.dart
@@ -53,10 +53,17 @@ class TwoLevelListItem extends StatelessWidget {
 }
 
 class TwoLevelSublist extends StatefulWidget {
-  TwoLevelSublist({ Key key, this.leading, this.title, this.children }) : super(key: key);
+  TwoLevelSublist({
+    Key key,
+    this.leading,
+    this.title,
+    this.onOpenChanged,
+    this.children
+  }) : super(key: key);
 
   final Widget leading;
   final Widget title;
+  final ValueChanged<bool> onOpenChanged;
   final List<Widget> children;
 
   @override
@@ -90,6 +97,12 @@ class _TwoLevelSublistState extends State<TwoLevelSublist> {
       _controller.value = 1.0;
   }
 
+  @override
+  void dispose() {
+    _controller.stop();
+    super.dispose();
+  }
+
   void _handleOnTap() {
     setState(() {
       _isExpanded = !_isExpanded;
@@ -99,6 +112,8 @@ class _TwoLevelSublistState extends State<TwoLevelSublist> {
         _controller.reverse();
       PageStorage.of(context)?.writeState(context, _isExpanded);
     });
+    if (config.onOpenChanged != null)
+      config.onOpenChanged(_isExpanded);
   }
 
   Widget buildList(BuildContext context, Widget child) {

--- a/packages/flutter/test/material/two_level_list_test.dart
+++ b/packages/flutter/test/material/two_level_list_test.dart
@@ -66,4 +66,41 @@ void main() {
     expect(getY(bottomKey) - getY(sublistKey), greaterThan(getHeight(topKey)));
     expect(getY(bottomKey) - getY(sublistKey), greaterThan(getHeight(bottomKey)));
   });
+
+  testWidgets('onOpenChanged callback', (WidgetTester tester) async {
+    bool didChangeOpen;
+
+    final Map<String, WidgetBuilder> routes = <String, WidgetBuilder>{
+      '/': (_) {
+        return new Material(
+          child: new Viewport(
+            child: new TwoLevelList(
+              children: <Widget>[
+                new TwoLevelSublist(
+                  title: new Text('Sublist'),
+                  onOpenChanged: (bool opened) {
+                    didChangeOpen = opened;
+                  },
+                  children: <Widget>[
+                    new TwoLevelListItem(title: new Text('0')),
+                    new TwoLevelListItem(title: new Text('1'))
+                  ]
+                ),
+              ]
+            )
+          )
+        );
+      }
+    };
+
+    await tester.pumpWidget(new MaterialApp(routes: routes));
+
+    expect(didChangeOpen, isNull);
+    await tester.tap(find.text('Sublist'));
+    expect(didChangeOpen, isTrue);
+    await tester.pump();
+    await tester.pump(const Duration(seconds: 1));
+    await tester.tap(find.text('Sublist'));
+    expect(didChangeOpen, isFalse);
+  });
 }


### PR DESCRIPTION
Also, fix an animation leak found by the test.

Fixes #4619
