### PR TITLE
Tooltip can disappear too quickly

### DIFF
--- a/packages/flutter/lib/src/material/tooltip.dart
+++ b/packages/flutter/lib/src/material/tooltip.dart
@@ -123,8 +123,12 @@ class _TooltipState extends State<Tooltip> {
   }
 
   void ensureTooltipVisible() {
-    if (_entry != null)
+    if (_entry != null) {
+      _timer?.cancel();
+      _timer = null;
+      _controller.forward();
       return;  // Already visible.
+    }
     RenderBox box = context.findRenderObject();
     Point target = box.localToGlobal(box.size.center(Point.origin));
     _entry = new OverlayEntry(builder: (BuildContext context) {
@@ -158,7 +162,7 @@ class _TooltipState extends State<Tooltip> {
   void _handlePointerEvent(PointerEvent event) {
     assert(_entry != null);
     if (event is PointerUpEvent || event is PointerCancelEvent)
-      _timer = new Timer(_kShowDuration, _controller.reverse);
+      _timer ??= new Timer(_kShowDuration, _controller.reverse);
     else if (event is PointerDownEvent)
       _controller.reverse();
   }
@@ -174,6 +178,7 @@ class _TooltipState extends State<Tooltip> {
   void dispose() {
     if (_entry != null)
       _removeEntry();
+    _controller.stop();
     super.dispose();
   }
 

--- a/packages/flutter/test/material/tooltip_test.dart
+++ b/packages/flutter/test/material/tooltip_test.dart
@@ -2,10 +2,11 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
-import 'package:flutter_test/flutter_test.dart';
 
 import '../rendering/test_semantics_client.dart';
 
@@ -391,6 +392,43 @@ void main() {
     expect(tip.localToGlobal(tip.size.topLeft(Point.origin)).y, equals(310.0));
     expect(tip.localToGlobal(tip.size.bottomRight(Point.origin)).x, equals(790.0));
     expect(tip.localToGlobal(tip.size.bottomRight(Point.origin)).y, equals(320.0));
+  });
+
+  testWidgets('Tooltip stays around', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      new MaterialApp(
+        home: new Center(
+          child: new Tooltip(
+            message: 'TIP',
+            child: new Container(
+              width: 100.0,
+              height: 100.0,
+              decoration: new BoxDecoration(
+                backgroundColor: Colors.green[500]
+              )
+            )
+          )
+        )
+      )
+    );
+
+    Finder tooltip = find.byType(Tooltip);
+    TestGesture gesture = await tester.startGesture(tester.getCenter(tooltip));
+    await tester.pump(kLongPressTimeout);
+    await tester.pump(const Duration(milliseconds: 10));
+    await gesture.up();
+    expect(find.text('TIP'), findsOneWidget);
+    await tester.tap(tooltip);
+    await tester.pump(const Duration(milliseconds: 10));
+    gesture = await tester.startGesture(tester.getCenter(tooltip));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 300));
+    expect(find.text('TIP'), findsNothing);
+    await tester.pump(kLongPressTimeout);
+    expect(find.text('TIP'), findsOneWidget);
+    await tester.pump(kLongPressTimeout);
+    expect(find.text('TIP'), findsOneWidget);
+    gesture.up();
   });
 
   testWidgets('Does tooltip contribute semantics', (WidgetTester tester) async {


### PR DESCRIPTION
We were stacking up two dismiss timers. Now we don't start a new timer
if we've already got one. Also, fix an animation leak caught by the
test.

Fixes #4640
