### PR TITLE
Custom switch images are nutty

### DIFF
--- a/examples/flutter_gallery/lib/demo/selection_controls_demo.dart
+++ b/examples/flutter_gallery/lib/demo/selection_controls_demo.dart
@@ -168,11 +168,14 @@ class _SelectionControlsDemoState extends State<SelectionControlsDemo> {
       child: new Row(
         mainAxisSize: MainAxisSize.min,
         children: <Widget>[
-          new Switch(value: switchValue, onChanged: (bool value) {
-            setState(() {
+          new Switch(
+            value: switchValue,
+            onChanged: (bool value) {
+              setState(() {
               switchValue = value;
-            });
-          }),
+              });
+            }
+          ),
           // Disabled switches
           new Switch(value: true, onChanged: null),
           new Switch(value: false, onChanged: null)

--- a/packages/flutter/lib/src/painting/box_painter.dart
+++ b/packages/flutter/lib/src/painting/box_painter.dart
@@ -864,11 +864,12 @@ void paintImage({
       break;
     case ImageFit.scaleDown:
       sourceSize = inputSize;
-      destinationSize = outputSize;
-      if (sourceSize.height > destinationSize.height)
-        destinationSize = new Size(sourceSize.width * destinationSize.height / sourceSize.height, sourceSize.height);
-      if (sourceSize.width > destinationSize.width)
-        destinationSize = new Size(destinationSize.width, sourceSize.height * destinationSize.width / sourceSize.width);
+      destinationSize = inputSize;
+      final double aspectRatio = inputSize.width / inputSize.height;
+      if (destinationSize.height > outputSize.height)
+        destinationSize = new Size(outputSize.height * aspectRatio, outputSize.height);
+      if (destinationSize.width > outputSize.width)
+        destinationSize = new Size(outputSize.width, outputSize.height / aspectRatio);
       break;
   }
   if (centerSlice != null) {

--- a/packages/flutter/test/material/switch_test.dart
+++ b/packages/flutter/test/material/switch_test.dart
@@ -71,45 +71,4 @@ void main() {
     await tester.tap(find.byKey(switchKey));
     expect(value, isTrue);
   });
-
-  testWidgets('Switch listens to the decorations it paints', (WidgetTester tester) async {
-    TestDecoration activeDecoration = new TestDecoration();
-    TestDecoration inactiveDecoration = new TestDecoration();
-
-    Widget build(bool active, TestDecoration activeDecoration, TestDecoration inactiveDecoration) {
-      return new Material(
-        child: new Center(
-          child: new Switch(
-            value: active,
-            onChanged: null,
-            activeThumbDecoration: activeDecoration,
-            inactiveThumbDecoration: inactiveDecoration
-          )
-        )
-      );
-    }
-
-    // no build yet
-    expect(activeDecoration.listeners, 0);
-    expect(inactiveDecoration.listeners, 0);
-
-    await tester.pumpWidget(build(false, activeDecoration, inactiveDecoration));
-    expect(activeDecoration.listeners, 0);
-    expect(inactiveDecoration.listeners, 1);
-
-    await tester.pumpWidget(build(true, activeDecoration, inactiveDecoration));
-    // started the animation, but we're on frame 0
-    expect(activeDecoration.listeners, 0);
-    expect(inactiveDecoration.listeners, 2);
-
-    await tester.pump(const Duration(milliseconds: 30)); // slightly into the animation
-    // we're painting some lerped decoration that doesn't exactly match either
-    expect(activeDecoration.listeners, 0);
-    expect(inactiveDecoration.listeners, 2);
-
-    await tester.pump(const Duration(seconds: 1)); // ended animation
-    expect(activeDecoration.listeners, 1);
-    expect(inactiveDecoration.listeners, 2);
-
-  });
 }


### PR DESCRIPTION
Rather than requiring the developer to specify a full Decoration, we now
just take an ImageProvider for the thumb image. Also, fix
ImageFit.scaleDown to actually work.

Fixes #4571
Fixes #4673
