### PR TITLE
Showing the material grid shouldn't lose app state

### DIFF
--- a/packages/flutter/lib/src/material/app.dart
+++ b/packages/flutter/lib/src/material/app.dart
@@ -175,6 +175,7 @@ class _MaterialAppState extends State<MaterialApp> {
     Widget result = new AnimatedTheme(
       data: theme,
       child: new WidgetsApp(
+        key: new GlobalObjectKey(this),
         title: config.title,
         textStyle: _errorTextStyle,
         color: theme?.primaryColor ?? Colors.blue[500], // blue[500] is the primary color of the default theme

--- a/packages/flutter/test/material/app_test.dart
+++ b/packages/flutter/test/material/app_test.dart
@@ -5,6 +5,26 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/material.dart';
 
+class StateMarker extends StatefulWidget {
+  StateMarker({ Key key, this.child }) : super(key: key);
+
+  final Widget child;
+
+  @override
+  StateMarkerState createState() => new StateMarkerState();
+}
+
+class StateMarkerState extends State<StateMarker> {
+  String marker;
+
+  @override
+  Widget build(BuildContext context) {
+    if (config.child != null)
+      return config.child;
+    return new Container();
+  }
+}
+
 void main() {
   testWidgets('Can nest apps', (WidgetTester tester) async {
     await tester.pumpWidget(
@@ -29,5 +49,27 @@ void main() {
     ));
 
     expect(Focus.at(inputKey.currentContext), isTrue);
+  });
+
+  testWidgets('Can show grid without losing sync', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      new MaterialApp(
+        home: new StateMarker()
+      )
+    );
+
+    StateMarkerState state1 = tester.state(find.byType(StateMarker));
+    state1.marker = 'original';
+
+    await tester.pumpWidget(
+      new MaterialApp(
+        debugShowMaterialGrid: true,
+        home: new StateMarker()
+      )
+    );
+
+    StateMarkerState state2 = tester.state(find.byType(StateMarker));
+    expect(state1, equals(state2));
+    expect(state2.marker, equals('original'));
   });
 }


### PR DESCRIPTION
Previously adding the GridPaper caused us to lose all the state in our app. Now
we use a global key to keep our state.

Fixes #4648
