### PR TITLE
RefreshIndicatorState.show()

### DIFF
--- a/examples/flutter_gallery/lib/demo/overscroll_demo.dart
+++ b/examples/flutter_gallery/lib/demo/overscroll_demo.dart
@@ -18,6 +18,8 @@ class OverscrollDemo extends StatefulWidget {
 }
 
 class OverscrollDemoState extends State<OverscrollDemo> {
+  final GlobalKey<ScaffoldState> _scaffoldKey = new GlobalKey<ScaffoldState>();
+  final GlobalKey<RefreshIndicatorState> _refreshIndicatorKey = new GlobalKey<RefreshIndicatorState>();
   static final GlobalKey<ScrollableState> _scrollableKey = new GlobalKey<ScrollableState>();
   static final List<String> _items = <String>[
     'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N'
@@ -28,9 +30,18 @@ class OverscrollDemoState extends State<OverscrollDemo> {
   Future<Null> refresh() {
     Completer<Null> completer = new Completer<Null>();
     new Timer(new Duration(seconds: 3), () { completer.complete(null); });
-    return completer.future;
+    return completer.future.then((_) {
+      _scaffoldKey.currentState.showSnackBar(new SnackBar(
+       content: new Text("Refresh complete"),
+       action: new SnackBarAction(
+         label: 'RETRY',
+         onPressed: () {
+           _refreshIndicatorKey.currentState.show();
+         }
+       )
+      ));
+    });
   }
-
 
   @override
   Widget build(BuildContext context) {
@@ -68,6 +79,7 @@ class OverscrollDemoState extends State<OverscrollDemo> {
         break;
       case IndicatorType.refresh:
         body = new RefreshIndicator(
+          key: _refreshIndicatorKey,
           child: body,
           refresh: refresh,
           scrollableKey: _scrollableKey,
@@ -77,6 +89,7 @@ class OverscrollDemoState extends State<OverscrollDemo> {
     }
 
     return new Scaffold(
+      key: _scaffoldKey,
       appBar: new AppBar(
         title: new Text('$indicatorTypeText'),
         actions: <Widget>[

--- a/packages/flutter/lib/src/material/refresh_indicator.dart
+++ b/packages/flutter/lib/src/material/refresh_indicator.dart
@@ -321,14 +321,14 @@ class RefreshIndicatorState extends State<RefreshIndicator> {
   /// callback is running, it quietly does nothing.
   ///
   /// See also:
-  /// [GlobalKey] (creating the RefreshIndicator with a
-  /// [GlobalKey<RefreshIndicatorState>] will make it possible to refer to
-  /// the [RefreshIndicatorState] later)
+  ///
+  /// * [GlobalKey] (creating the RefreshIndicator with a [GlobalKey<RefreshIndicatorState>]
+  ///   will make it possible to refer to the [RefreshIndicatorState] later)
   Future<Null> show() async {
     if (_mode != _RefreshIndicatorMode.refresh) {
       _sizeController.value = 0.0;
       _scaleController.value = 0.0;
-      _show();
+      await _show();
     }
   }
 


### PR DESCRIPTION
Show the refresh indicator and run the refresh callback as if it had been started interactively.

Fixes #4833
