### PR TITLE
When using flutter run, build the workspace instead of the project.

### DIFF
--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -123,6 +123,9 @@ Future<XcodeBuildResult> buildXcodeProject({
     'build',
     '-configuration', 'Release',
     'ONLY_ACTIVE_ARCH=YES',
+    '-workspace', 'Runner.xcworkspace',
+    '-scheme', 'Runner',
+    "BUILD_DIR=${path.absolute(app.rootPath, 'build')}",
   ];
 
   if (buildForDevice) {


### PR DESCRIPTION
This allows flutter run to build the templates generated in #4893.
