### PR TITLE
Flutter driver commands for controlling the Input widget

### DIFF
--- a/packages/flutter_driver/lib/src/driver.dart
+++ b/packages/flutter_driver/lib/src/driver.dart
@@ -12,6 +12,7 @@ import 'error.dart';
 import 'find.dart';
 import 'gesture.dart';
 import 'health.dart';
+import 'input.dart';
 import 'message.dart';
 import 'timeline.dart';
 
@@ -212,6 +213,24 @@ class FlutterDriver {
   Future<Null> tap(SerializableFinder finder) async {
     await _sendCommand(new Tap(finder));
     return null;
+  }
+
+  /// Sets the text value of the `Input` widget located by [finder].
+  ///
+  /// This command invokes the `onChanged` handler of the `Input` widget with
+  /// the provided [text].
+  Future<Null> setInputText(SerializableFinder finder, String text) async {
+    await _sendCommand(new SetInputText(finder, text));
+    return null;
+  }
+
+  /// Submits the current text value of the `Input` widget located by [finder].
+  ///
+  /// This command invokes the `onSubmitted` handler of the `Input` widget and
+  /// the returns the submitted text value.
+  Future<String> submitInputText(SerializableFinder finder) async {
+    Map<String, dynamic> json = await _sendCommand(new SubmitInputText(finder));
+    return json['text'];
   }
 
   /// Waits until [finder] locates the target.

--- a/packages/flutter_driver/lib/src/extension.dart
+++ b/packages/flutter_driver/lib/src/extension.dart
@@ -14,6 +14,7 @@ import 'error.dart';
 import 'find.dart';
 import 'gesture.dart';
 import 'health.dart';
+import 'input.dart';
 import 'message.dart';
 
 const String _extensionMethodName = 'driver';
@@ -64,6 +65,8 @@ class FlutterDriverExtension {
       'get_text': getText,
       'scroll': scroll,
       'scrollIntoView': scrollIntoView,
+      'setInputText': setInputText,
+      'submitInputText': submitInputText,
       'waitFor': waitFor,
     });
 
@@ -73,6 +76,8 @@ class FlutterDriverExtension {
       'get_text': GetText.deserialize,
       'scroll': Scroll.deserialize,
       'scrollIntoView': ScrollIntoView.deserialize,
+      'setInputText': SetInputText.deserialize,
+      'submitInputText': SubmitInputText.deserialize,
       'waitFor': WaitFor.deserialize,
     });
 
@@ -213,6 +218,20 @@ class FlutterDriverExtension {
     Finder target = await _waitForElement(_createFinder(command.finder));
     await Scrollable.ensureVisible(target.evaluate().single);
     return new ScrollResult();
+  }
+
+  Future<SetInputTextResult> setInputText(SetInputText command) async {
+    Finder target = await _waitForElement(_createFinder(command.finder));
+    Input input = target.evaluate().single.widget;
+    input.onChanged(new InputValue(text: command.text));
+    return new SetInputTextResult();
+  }
+
+  Future<SubmitInputTextResult> submitInputText(SubmitInputText command) async {
+    Finder target = await _waitForElement(_createFinder(command.finder));
+    Input input = target.evaluate().single.widget;
+    input.onSubmitted(input.value);
+    return new SubmitInputTextResult(input.value.text);
   }
 
   Future<GetTextResult> getText(GetText command) async {

--- a/packages/flutter_driver/lib/src/extension.dart
+++ b/packages/flutter_driver/lib/src/extension.dart
@@ -65,8 +65,8 @@ class FlutterDriverExtension {
       'get_text': getText,
       'scroll': scroll,
       'scrollIntoView': scrollIntoView,
-      'setInputText': setInputText,
-      'submitInputText': submitInputText,
+      'setInputText': _setInputText,
+      'submitInputText': _submitInputText,
       'waitFor': waitFor,
     });
 
@@ -220,14 +220,14 @@ class FlutterDriverExtension {
     return new ScrollResult();
   }
 
-  Future<SetInputTextResult> setInputText(SetInputText command) async {
+  Future<SetInputTextResult> _setInputText(SetInputText command) async {
     Finder target = await _waitForElement(_createFinder(command.finder));
     Input input = target.evaluate().single.widget;
     input.onChanged(new InputValue(text: command.text));
     return new SetInputTextResult();
   }
 
-  Future<SubmitInputTextResult> submitInputText(SubmitInputText command) async {
+  Future<SubmitInputTextResult> _submitInputText(SubmitInputText command) async {
     Finder target = await _waitForElement(_createFinder(command.finder));
     Input input = target.evaluate().single.widget;
     input.onSubmitted(input.value);

--- a/packages/flutter_driver/lib/src/input.dart
+++ b/packages/flutter_driver/lib/src/input.dart
@@ -1,0 +1,62 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'message.dart';
+import 'find.dart';
+
+class SetInputText extends CommandWithTarget {
+  @override
+  final String kind = 'setInputText';
+
+  SetInputText(SerializableFinder finder, this.text) : super(finder);
+
+  final String text;
+
+  static SetInputText deserialize(Map<String, dynamic> json) {
+    String text = json['text'];
+    return new SetInputText(SerializableFinder.deserialize(json), text);
+  }
+
+  @override
+  Map<String, String> serialize() {
+    Map<String, String> json = super.serialize();
+    json['text'] = text;
+    return json;
+  }
+}
+
+class SetInputTextResult extends Result {
+  static SetInputTextResult fromJson(Map<String, dynamic> json) {
+    return new SetInputTextResult();
+  }
+
+  @override
+  Map<String, dynamic> toJson() => <String, dynamic>{};
+}
+
+class SubmitInputText extends CommandWithTarget {
+  @override
+  final String kind = 'submitInputText';
+
+  SubmitInputText(SerializableFinder finder) : super(finder);
+
+  static SubmitInputText deserialize(Map<String, dynamic> json) {
+    return new SubmitInputText(SerializableFinder.deserialize(json));
+  }
+}
+
+class SubmitInputTextResult extends Result {
+  SubmitInputTextResult(this.text);
+
+  final String text;
+
+  static SubmitInputTextResult fromJson(Map<String, dynamic> json) {
+    return new SubmitInputTextResult(json['text']);
+  }
+
+  @override
+  Map<String, dynamic> toJson() => <String, dynamic>{
+    'text': text
+  };
+}


### PR DESCRIPTION
This commit introduces two new driver commands for controlling the
material Input widget.
- `setInputText(SerializableFinder finder, String text)`
- `submitInputText(SerializableFinder finder)`

Since it is not possible to directly modify the `Input` widget text,
these driver commands invokes the handler functions of the `Input`
widget: `onChanged` and `onSubmitted`, respectively. The `submitInputText`
command returns the submitted string as a result.

This allows to write integration tests for the firechat app, for example.
