### PR TITLE
Support for Material arc point and rect transitions 

### DIFF
--- a/examples/flutter_gallery/lib/demo/all.dart
+++ b/examples/flutter_gallery/lib/demo/all.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+export 'animation_demo.dart';
 export 'buttons_demo.dart';
 export 'contacts_demo.dart';
 export 'cards_demo.dart';

--- a/examples/flutter_gallery/lib/demo/animation_demo.dart
+++ b/examples/flutter_gallery/lib/demo/animation_demo.dart
@@ -1,0 +1,254 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:math' as math;
+import 'dart:ui' show lerpDouble;
+
+import 'package:flutter/material.dart';
+import 'package:meta/meta.dart'; // @required
+
+enum _DragTarget {
+  start,
+  end
+}
+
+class _Background extends CustomPainter {
+  _Background({
+    Animation<double> repaint,
+    this.arc,
+    this.themeData
+  }) : _repaint = repaint, super(repaint: repaint);
+
+  static final double pointRadius = 6.0;
+
+  final MaterialArc arc;
+  final ThemeData themeData;
+  Animation<double> _repaint;
+
+  void drawPoint(Canvas canvas, Point p, Color color) {
+    final Paint paint = new Paint()
+      ..color = color.withOpacity(0.25)
+      ..style = PaintingStyle.fill;
+    canvas.drawCircle(p, pointRadius, paint);
+    paint
+      ..color = color
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = 2.0;
+    canvas.drawCircle(p, pointRadius + 1.0, paint);
+  }
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final Color color = themeData.primaryColor;
+    final Paint paint = new Paint();
+
+    if (arc._center != null)
+      drawPoint(canvas, arc._center, Colors.blue[400]);
+
+    paint
+      ..color = themeData.primaryColor.withOpacity(0.25)
+      ..strokeWidth = 4.0
+      ..style = PaintingStyle.stroke;
+    if (arc._center != null && arc._radius != null)
+      canvas.drawCircle(arc._center, arc._radius, paint);
+    else {
+      canvas.drawLine(arc.a, arc.b, paint);
+    }
+
+    drawPoint(canvas, arc.a, color);
+    drawPoint(canvas, arc.b, color);
+
+    final Point animatedPoint = new MaterialArcAnimation(arc: arc, parent: _repaint).value;
+    paint
+      ..color = color
+      ..style = PaintingStyle.fill;
+    canvas.drawCircle(animatedPoint, pointRadius, paint);
+  }
+
+  @override
+  bool shouldRepaint(_Background oldBackground) => true;
+}
+
+class MaterialArc {
+  MaterialArc(this.a, this.b) {
+    // An explanation with a diagram can be found at https://goo.gl/vMSdRg
+    final Offset delta = b - a;
+    final double deltaX = delta.dx.abs();
+    final double deltaY = delta.dy.abs();
+    final double distanceFromAtoB = delta.distance;
+    final Point c = new Point(b.x, a.y);
+
+    double sweepAngle() => 2.0 *  math.asin(distanceFromAtoB / (2.0 * _radius));
+
+    if (deltaX > 2.0 && deltaY > 2.0) {
+      if (deltaX < deltaY) {
+        _radius = distanceFromAtoB * distanceFromAtoB / (c - a).distance / 2.0;
+        _center = new Point(b.x + _radius * (a.x - b.x).sign, b.y);
+        if (a.x < b.x) {
+          _startAngle = sweepAngle() * (a.y - b.y).sign;
+          _endAngle = 0.0;
+        } else {
+          _startAngle = math.PI + sweepAngle() * (b.y - a.y).sign;
+          _endAngle = math.PI;
+        }
+      } else {
+        _radius = distanceFromAtoB * distanceFromAtoB / (c - b).distance / 2.0;
+        _center = new Point(a.x, a.y + (b.y - a.y).sign * _radius);
+        if (a.y < b.y) {
+          _startAngle = -math.PI / 2.0;
+          _endAngle = _startAngle + sweepAngle() * (b.x - a.x).sign;
+        } else {
+          _startAngle = math.PI / 2.0;
+          _endAngle = _startAngle + sweepAngle() * (a.x - b.x).sign;
+        }
+      }
+    }
+  }
+
+  final Point a;
+  final Point b;
+
+  Point _center;
+  double _radius;
+  double _startAngle;
+  double _endAngle;
+
+  Point transform(double t) {
+    if (_startAngle == null || _endAngle == null)
+      return Point.lerp(a, b, t);
+    final double angle = lerpDouble(_startAngle, _endAngle, t);
+    final double x = math.cos(angle) * _radius;
+    final double y = math.sin(angle) * _radius;
+    return  _center + new Offset(x, y);
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    if (identical(this, other))
+      return true;
+    if (other is! MaterialArc)
+      return false;
+    final MaterialArc typedOther = other;
+    return _center == typedOther._center
+      && _radius == typedOther._radius
+      && _startAngle == typedOther._startAngle
+      && _endAngle == typedOther._endAngle;
+  }
+
+  @override
+  int get hashCode => hashValues(_center, _radius, _startAngle, _endAngle);
+
+  @override
+  String toString() => '[MaterialArc center=$_center radius=$_radius startAngle=$_startAngle endAngle=$_endAngle]';
+}
+
+
+class MaterialArcAnimation extends Animation<Point> with AnimationWithParentMixin<double> {
+  MaterialArcAnimation({
+    @required this.parent,
+    @required this.arc
+  }) {
+    assert(parent != null);
+    assert(arc != null);
+  }
+
+  @override
+  final Animation<double> parent;
+
+  MaterialArc arc;
+
+  @override
+  Point get value {
+    double t = parent.value;
+    if (t == 0.0)
+      return arc.a;
+    if (t == 1.0)
+      return arc.b;
+    return arc.transform(t);
+  }
+}
+
+class AnimationDemo extends StatefulWidget {
+  AnimationDemo({ Key key }) : super(key: key);
+
+  static const String routeName = '/animation';
+
+  @override
+  AnimationDemoState createState() => new AnimationDemoState();
+}
+
+class AnimationDemoState extends State<AnimationDemo> {
+  final GlobalKey<ScaffoldState> _scaffoldKey = new GlobalKey<ScaffoldState>();
+  final GlobalKey _backgroundKey = new GlobalKey();
+  AnimationController _controller = new AnimationController(duration: const Duration(milliseconds: 300));
+
+  _DragTarget _dragTarget;
+  Point _start = const Point(225.0, 175.0);
+  Point _end = const Point(150.0, 300.0);
+
+  void _handlePointerDown(PointerDownEvent event) {
+    final RenderBox box = _backgroundKey.currentContext.findRenderObject();
+    final double startOffset = (box.localToGlobal(_start) - event.position).distance;
+    final double endOffset = (box.localToGlobal(_end) - event.position).distance;
+    if (startOffset < endOffset && startOffset < 50.0)
+      _dragTarget = _DragTarget.start;
+    else if (endOffset < 50.0)
+      _dragTarget = _DragTarget.end;
+    else
+      _dragTarget = null;
+  }
+
+  void _handlePointerMove(PointerMoveEvent event) {
+    switch (_dragTarget) {
+      case _DragTarget.start:
+        setState(() {
+          _start = _start + event.delta;
+        });
+        break;
+      case _DragTarget.end:
+        setState(() {
+          _end = _end + event.delta;
+        });
+        break;
+    }
+  }
+
+  void _handlePointerUp(PointerEvent event) {
+    _dragTarget = null;
+  }
+
+  Future<Null> _play() async {
+    await _controller.forward();
+    return _controller.reverse();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final MaterialArc arc = new MaterialArc(_start, _end);
+    return new Scaffold(
+      key: _scaffoldKey,
+      appBar: new AppBar(
+        title: new Text('Animation')
+      ),
+      floatingActionButton: new FloatingActionButton(
+        onPressed: _play,
+        child: new Icon(Icons.autorenew)
+      ),
+      body: new Listener(
+        onPointerDown: _handlePointerDown,
+        onPointerMove: _handlePointerMove,
+        onPointerUp: _handlePointerUp,
+        child: new CustomPaint(
+          key: _backgroundKey,
+          painter: new _Background(
+            repaint: _controller,
+            themeData: Theme.of(context),
+            arc: arc
+          )
+        )
+      )
+    );
+  }
+}

--- a/examples/flutter_gallery/lib/demo/animation_demo.dart
+++ b/examples/flutter_gallery/lib/demo/animation_demo.dart
@@ -11,17 +11,160 @@ enum _DragTarget {
   end
 }
 
-class _Background extends CustomPainter {
-  _Background({
+class _PointDemoPainter extends CustomPainter {
+  _PointDemoPainter({
     Animation<double> repaint,
-    this.arc,
-    this.themeData
+    this.arc
   }) : _repaint = repaint, super(repaint: repaint);
 
   static final double pointRadius = 6.0;
 
-  final MaterialRectArc arc;
-  final ThemeData themeData;
+  final MaterialPointArcTween arc;
+  Animation<double> _repaint;
+
+  void drawPoint(Canvas canvas, Point point, Color color) {
+    final Paint paint = new Paint()
+      ..color = color.withOpacity(0.25)
+      ..style = PaintingStyle.fill;
+    canvas.drawCircle(point, pointRadius, paint);
+    paint
+      ..color = color
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = 2.0;
+    canvas.drawCircle(point, pointRadius + 1.0, paint);
+  }
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final Paint paint = new Paint();
+
+    if (arc.center != null)
+      drawPoint(canvas, arc.center, Colors.blue[400]);
+
+    paint
+      ..color = Colors.green[500].withOpacity(0.25)
+      ..strokeWidth = 4.0
+      ..style = PaintingStyle.stroke;
+    if (arc.center != null && arc.radius != null)
+      canvas.drawCircle(arc.center, arc.radius, paint);
+    else {
+      canvas.drawLine(arc.begin, arc.end, paint);
+    }
+
+    drawPoint(canvas, arc.begin, Colors.green[500]);
+    drawPoint(canvas, arc.end, Colors.red[500]);
+
+    paint
+      ..color = Colors.green[500]
+      ..style = PaintingStyle.fill;
+    canvas.drawCircle(arc.lerp(_repaint.value), pointRadius, paint);
+  }
+
+  @override
+  hitTest(Point position) {
+    return (arc.begin - position).distance < 50.0 || (arc.end - position).distance < 50.0;
+  }
+
+  @override
+  bool shouldRepaint(_PointDemoPainter oldPainter) => true;
+}
+
+
+class _PointDemo extends StatefulWidget {
+  _PointDemo({ Key key, this.controller }) : super(key: key);
+
+  final AnimationController controller;
+
+  @override
+  _PointDemoState createState() => new _PointDemoState();
+}
+
+class _PointDemoState extends State<_PointDemo> {
+  final GlobalKey _painterKey = new GlobalKey();
+
+  CurvedAnimation _animation;
+  _DragTarget _dragTarget;
+  Point _begin = const Point(180.0, 110.0);
+  Point _end = const Point(37.0, 250.0);
+
+  @override
+  void initState() {
+    super.initState();
+    _animation = new CurvedAnimation(parent: config.controller, curve: Curves.ease);
+  }
+
+  @override
+  void dispose() {
+    config.controller.stop();
+    super.dispose();
+  }
+
+  void _handlePointerDown(PointerDownEvent event) {
+    final RenderBox box = _painterKey.currentContext.findRenderObject();
+    final double startOffset = (box.localToGlobal(_begin) - event.position).distance;
+    final double endOffset = (box.localToGlobal(_end) - event.position).distance;
+    if (startOffset < endOffset && startOffset < 50.0)
+      _dragTarget = _DragTarget.start;
+    else if (endOffset < 50.0)
+      _dragTarget = _DragTarget.end;
+    else
+      _dragTarget = null;
+  }
+
+  void _handlePointerMove(PointerMoveEvent event) {
+    switch (_dragTarget) {
+      case _DragTarget.start:
+        setState(() {
+          _begin = _begin + event.delta;
+        });
+        break;
+      case _DragTarget.end:
+        setState(() {
+          _end = _end + event.delta;
+        });
+        break;
+    }
+  }
+
+  void _handlePointerUp(PointerEvent event) {
+    _dragTarget = null;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final MaterialPointArcTween arc = new MaterialPointArcTween(begin: _begin, end: _end);
+    return new Listener(
+      onPointerDown: _handlePointerDown,
+      onPointerMove: _handlePointerMove,
+      onPointerUp: _handlePointerUp,
+      child: new CustomPaint(
+        key: _painterKey,
+        painter: new _PointDemoPainter(
+          repaint: _animation,
+          arc: arc
+        ),
+        child: new Padding(
+          padding: const EdgeInsets.all(16.0),
+          child: new Text(
+            "Tap the refresh button to run the animation. Drag the green "
+            "and red points to change the animation's path.",
+            style: Theme.of(context).textTheme.caption.copyWith(fontSize: 16.0)
+          )
+        )
+      )
+    );
+  }
+}
+
+class _RectangleDemoPainter extends CustomPainter {
+  _RectangleDemoPainter({
+    Animation<double> repaint,
+    this.arc
+  }) : _repaint = repaint, super(repaint: repaint);
+
+  static final double pointRadius = 6.0;
+
+  final MaterialRectArcTween arc;
   Animation<double> _repaint;
 
   void drawPoint(Canvas canvas, Point p, Color color) {
@@ -49,45 +192,45 @@ class _Background extends CustomPainter {
   void paint(Canvas canvas, Size size) {
     drawRect(canvas, arc.begin, Colors.green[500]);
     drawRect(canvas, arc.end, Colors.red[500]);
-
-    //Point corner = _cornerFor(materialRect.start, materialRect._diagonal.endId);
-    //drawPoint(canvas, corner, Colors.red[500]);
-
-    drawRect(canvas, arc.transform(_repaint.value), Colors.blue[500]);
+    drawRect(canvas, arc.lerp(_repaint.value), Colors.blue[500]);
   }
 
   @override
-  bool shouldRepaint(_Background oldBackground) => true;
+  bool shouldRepaint(_RectangleDemoPainter oldPainter) => true;
 }
 
-class AnimationDemo extends StatefulWidget {
-  AnimationDemo({ Key key }) : super(key: key);
+class _RectangleDemo extends StatefulWidget {
+  _RectangleDemo({ Key key, this.controller }) : super(key: key);
 
-  static const String routeName = '/animation';
+  final AnimationController controller;
 
   @override
-  AnimationDemoState createState() => new AnimationDemoState();
+  _RectangleDemoState createState() => new _RectangleDemoState();
 }
 
-class AnimationDemoState extends State<AnimationDemo> {
-  final GlobalKey<ScaffoldState> _scaffoldKey = new GlobalKey<ScaffoldState>();
-  final GlobalKey _backgroundKey = new GlobalKey();
-  final AnimationController _controller = new AnimationController(duration: const Duration(milliseconds: 1000));
+class _RectangleDemoState extends State<_RectangleDemo> {
+  final GlobalKey _painterKey = new GlobalKey();
 
   CurvedAnimation _animation;
   _DragTarget _dragTarget;
-  Rect _start = new Rect.fromLTWH(150.0, 100.0, 150.0, 100.0);
-  Rect _end = new Rect.fromLTWH(200.0, 300.0, 100.0, 150.0);
+  Rect _begin = new Rect.fromLTRB(180.0, 100.0, 330.0, 200.0);
+  Rect _end = new Rect.fromLTRB(32.0, 275.0, 132.0, 425.0);
 
   @override
   void initState() {
     super.initState();
-    _animation = new CurvedAnimation(parent: _controller, curve: Curves.ease);
+    _animation = new CurvedAnimation(parent: config.controller, curve: Curves.ease);
+  }
+
+  @override
+  void dispose() {
+    config.controller.stop();
+    super.dispose();
   }
 
   void _handlePointerDown(PointerDownEvent event) {
-    final RenderBox box = _backgroundKey.currentContext.findRenderObject();
-    final double startOffset = (box.localToGlobal(_start.center) - event.position).distance;
+    final RenderBox box = _painterKey.currentContext.findRenderObject();
+    final double startOffset = (box.localToGlobal(_begin.center) - event.position).distance;
     final double endOffset = (box.localToGlobal(_end.center) - event.position).distance;
     if (startOffset < endOffset && startOffset < 50.0)
       _dragTarget = _DragTarget.start;
@@ -101,7 +244,7 @@ class AnimationDemoState extends State<AnimationDemo> {
     switch (_dragTarget) {
       case _DragTarget.start:
         setState(() {
-          _start = _start.shift(event.delta);
+          _begin = _begin.shift(event.delta);
         });
         break;
       case _DragTarget.end:
@@ -116,47 +259,97 @@ class AnimationDemoState extends State<AnimationDemo> {
     _dragTarget = null;
   }
 
+  @override
+  Widget build(BuildContext context) {
+    final MaterialRectArcTween arc = new MaterialRectArcTween(begin: _begin, end: _end);
+    return new Listener(
+      onPointerDown: _handlePointerDown,
+      onPointerMove: _handlePointerMove,
+      onPointerUp: _handlePointerUp,
+      child: new CustomPaint(
+        key: _painterKey,
+        painter: new _RectangleDemoPainter(
+          repaint: _animation,
+          arc: arc
+        ),
+        child: new Padding(
+          padding: const EdgeInsets.all(16.0),
+          child: new Text(
+            "Tap the refresh button to run the animation. Drag the rectangles "
+            "to change the animation's path.",
+            style: Theme.of(context).textTheme.caption.copyWith(fontSize: 16.0)
+          )
+        )
+      )
+    );
+  }
+}
+
+typedef Widget _DemoBuilder(_ArcDemo demo);
+
+class _ArcDemo {
+  _ArcDemo(String _title, this.builder) : title = _title, key = new GlobalKey(debugLabel: _title);
+
+  final AnimationController controller = new AnimationController(duration: const Duration(milliseconds: 1000));
+  final String title;
+  final _DemoBuilder builder;
+  final GlobalKey key;
+}
+
+class AnimationDemo extends StatefulWidget {
+  AnimationDemo({ Key key }) : super(key: key);
+
+  static const String routeName = '/animation';
+
+  @override
+  _AnimationDemoState createState() => new _AnimationDemoState();
+}
+
+class _AnimationDemoState extends State<AnimationDemo> {
+  static final GlobalKey<TabBarSelectionState<_ArcDemo>> _tabsKey = new GlobalKey<TabBarSelectionState<_ArcDemo>>();
+
+  static final List<_ArcDemo> _allDemos = <_ArcDemo>[
+    new _ArcDemo('POINT', (_ArcDemo demo) {
+      return new _PointDemo(
+        key: demo.key,
+        controller: demo.controller
+      );
+    }),
+    new _ArcDemo('RECTANGLE', (_ArcDemo demo) {
+      return new _RectangleDemo(
+        key: demo.key,
+        controller: demo.controller
+      );
+    })
+  ];
+
   Future<Null> _play() async {
-    await _controller.forward();
-    return _controller.reverse();
+    _ArcDemo demo = _tabsKey.currentState.value;
+    await demo.controller.forward();
+    if (demo.key.currentState != null && demo.key.currentState.mounted)
+      demo.controller.reverse();
   }
 
   @override
   Widget build(BuildContext context) {
-    final MaterialRectArc arc = new MaterialRectArc(begin: _start, end: _end);
-    return new Scaffold(
-      key: _scaffoldKey,
-      appBar: new AppBar(
-        title: new Text('Animation'),
-        actions: <Widget>[
-          new IconButton(
-              icon: new Icon(Icons.rotate_90_degrees_ccw),
-            tooltip: 'Toggle arc path',
-            onPressed: () {
-              /*
-              setState(() {
-                _simpleInterpolation = !_simpleInterpolation;
-              });
-              */
-            }
+    return new TabBarSelection<_ArcDemo>(
+      key: _tabsKey,
+      values: _allDemos,
+      child: new Scaffold(
+        appBar: new AppBar(
+          title: new Text('Animation'),
+          bottom: new TabBar<_ArcDemo>(
+            labels: new Map<_ArcDemo, TabLabel>.fromIterable(_allDemos, value: (_ArcDemo demo) {
+              return new TabLabel(text: demo.title);
+            })
           )
-        ]
-      ),
-      floatingActionButton: new FloatingActionButton(
-        onPressed: _play,
-        child: new Icon(Icons.autorenew)
-      ),
-      body: new Listener(
-        onPointerDown: _handlePointerDown,
-        onPointerMove: _handlePointerMove,
-        onPointerUp: _handlePointerUp,
-        child: new CustomPaint(
-          key: _backgroundKey,
-          painter: new _Background(
-            repaint: _animation,
-            themeData: Theme.of(context),
-            arc: arc
-          )
+        ),
+        floatingActionButton: new FloatingActionButton(
+          onPressed: _play,
+          child: new Icon(Icons.refresh)
+        ),
+        body: new TabBarView<_ArcDemo>(
+          children: _allDemos.map((_ArcDemo demo) => demo.builder(demo)).toList()
         )
       )
     );

--- a/examples/flutter_gallery/lib/demo/animation_demo.dart
+++ b/examples/flutter_gallery/lib/demo/animation_demo.dart
@@ -20,25 +20,25 @@ const double _kTargetSlop = 2500.0;
 const double _kPointRadius = 6.0;
 
 class _DragHandler extends Drag {
-  _DragHandler(this.updateCallback, this.cancelCallback, this.endCallback);
+  _DragHandler(this.onUpdate, this.onCancel, this.onEnd);
 
-  final GestureDragUpdateCallback updateCallback;
-  final GestureDragCancelCallback cancelCallback;
-  final GestureDragEndCallback endCallback;
+  final GestureDragUpdateCallback onUpdate;
+  final GestureDragCancelCallback onCancel;
+  final GestureDragEndCallback onEnd;
 
   @override
   void update(DragUpdateDetails details)  {
-    updateCallback(details);
+    onUpdate(details);
   }
 
   @override
   void cancel()  {
-    cancelCallback();
+    onCancel();
   }
 
   @override
   void end(DragEndDetails details)  {
-    endCallback(details);
+    onEnd(details);
   }
 }
 
@@ -98,7 +98,7 @@ class _PointDemoPainter extends CustomPainter {
   }
 
   @override
-  bool shouldRepaint(_PointDemoPainter oldPainter) => true;
+  bool shouldRepaint(_PointDemoPainter oldPainter) => arc != oldPainter.arc;
 }
 
 class _PointDemo extends StatefulWidget {
@@ -255,7 +255,7 @@ class _RectangleDemoPainter extends CustomPainter {
   }
 
   @override
-  bool shouldRepaint(_RectangleDemoPainter oldPainter) => true;
+  bool shouldRepaint(_RectangleDemoPainter oldPainter) => arc != oldPainter.arc;
 }
 
 class _RectangleDemo extends StatefulWidget {

--- a/examples/flutter_gallery/lib/demo/animation_demo.dart
+++ b/examples/flutter_gallery/lib/demo/animation_demo.dart
@@ -3,103 +3,24 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:math' as math;
-import 'dart:ui' show lerpDouble;
 
 import 'package:flutter/material.dart';
-import 'package:meta/meta.dart'; // @required
-
-bool _simpleInterpolation = false;
 
 enum _DragTarget {
   start,
   end
 }
 
-enum _CornerId {
-  topLeft,
-  topRight,
-  bottomLeft,
-  bottomRight
-}
-
-class _Diagonal {
-  const _Diagonal(this.startId, this.endId);
-  final _CornerId startId;
-  final _CornerId endId;
-}
-
-Point _cornerFor(Rect rect, _CornerId id) {
-  switch(id) {
-    case _CornerId.topLeft: return rect.topLeft;
-    case _CornerId.topRight: return rect.topRight;
-    case _CornerId.bottomLeft: return rect.bottomLeft;
-    case _CornerId.bottomRight: return rect.bottomRight;
-  }
-  return Point.origin;
-}
-
-class MaterialRect {
-  static final List<_Diagonal> _allDiagonals = <_Diagonal>[
-    const _Diagonal(_CornerId.topLeft, _CornerId.bottomRight),
-    const _Diagonal(_CornerId.bottomRight, _CornerId.topLeft),
-    const _Diagonal(_CornerId.topRight, _CornerId.bottomLeft),
-    const _Diagonal(_CornerId.bottomLeft, _CornerId.topRight),
-  ];
-
-  MaterialRect(this.start, this.end) {
-    _centersVector = end.center - start.center;
-
-    double maxSupport = 0.0;
-    for (_Diagonal diagonal in _allDiagonals) {
-      final double support = _diagonalSupport(diagonal);
-      if (support > maxSupport) {
-        _diagonal = diagonal;
-        maxSupport = support;
-      }
-    }
-
-    _startArc = new MaterialArc(_cornerFor(start, _diagonal.startId), _cornerFor(end, _diagonal.startId));
-    _endArc = new MaterialArc(_cornerFor(start, _diagonal.endId), _cornerFor(end, _diagonal.endId));
-  }
-
-  final Rect start;
-  final Rect end;
-
-  Offset _centersVector;
-  _Diagonal _diagonal;
-  MaterialArc _startArc;
-  MaterialArc _endArc;
-
-  double _diagonalSupport(_Diagonal diagonal) {
-    final Offset delta = _cornerFor(start, diagonal.endId) - _cornerFor(start, diagonal.startId);
-    final double length = delta.distance;
-    return _centersVector.dx * delta.dx / length + _centersVector.dy * delta.dy / length;
-  }
-
-  Rect transform(double t) {
-    if (_simpleInterpolation)
-      return Rect.lerp(start, end, t);
-    Point startArcPoint = _startArc.transform(t);
-    Point endArcPoint = _endArc.transform(t);
-    double minX = math.min(startArcPoint.x, endArcPoint.x);
-    double maxX = math.max(startArcPoint.x, endArcPoint.x);
-    double minY = math.min(startArcPoint.y, endArcPoint.y);
-    double maxY = math.max(startArcPoint.y, endArcPoint.y);
-    return new Rect.fromLTRB(minX, minY, maxX, maxY);
-  }
-}
-
 class _Background extends CustomPainter {
   _Background({
     Animation<double> repaint,
-    this.materialRect,
+    this.arc,
     this.themeData
   }) : _repaint = repaint, super(repaint: repaint);
 
   static final double pointRadius = 6.0;
 
-  final MaterialRect materialRect;
+  final MaterialRectArc arc;
   final ThemeData themeData;
   Animation<double> _repaint;
 
@@ -126,116 +47,17 @@ class _Background extends CustomPainter {
 
   @override
   void paint(Canvas canvas, Size size) {
-    drawRect(canvas, materialRect.start, Colors.green[500]);
-    drawRect(canvas, materialRect.end, Colors.red[500]);
+    drawRect(canvas, arc.begin, Colors.green[500]);
+    drawRect(canvas, arc.end, Colors.red[500]);
 
-    Point corner = _cornerFor(materialRect.start, materialRect._diagonal.endId);
-    drawPoint(canvas, corner, Colors.red[500]);
+    //Point corner = _cornerFor(materialRect.start, materialRect._diagonal.endId);
+    //drawPoint(canvas, corner, Colors.red[500]);
 
-    drawRect(canvas, materialRect.transform(_repaint.value), Colors.blue[500]);
+    drawRect(canvas, arc.transform(_repaint.value), Colors.blue[500]);
   }
 
   @override
   bool shouldRepaint(_Background oldBackground) => true;
-}
-
-class MaterialArc {
-  MaterialArc(this.a, this.b) {
-    // An explanation with a diagram can be found at https://goo.gl/vMSdRg
-    final Offset delta = b - a;
-    final double deltaX = delta.dx.abs();
-    final double deltaY = delta.dy.abs();
-    final double distanceFromAtoB = delta.distance;
-    final Point c = new Point(b.x, a.y);
-
-    double sweepAngle() => 2.0 *  math.asin(distanceFromAtoB / (2.0 * _radius));
-
-    if (deltaX > 2.0 && deltaY > 2.0) {
-      if (deltaX < deltaY) {
-        _radius = distanceFromAtoB * distanceFromAtoB / (c - a).distance / 2.0;
-        _center = new Point(b.x + _radius * (a.x - b.x).sign, b.y);
-        if (a.x < b.x) {
-          _startAngle = sweepAngle() * (a.y - b.y).sign;
-          _endAngle = 0.0;
-        } else {
-          _startAngle = math.PI + sweepAngle() * (b.y - a.y).sign;
-          _endAngle = math.PI;
-        }
-      } else {
-        _radius = distanceFromAtoB * distanceFromAtoB / (c - b).distance / 2.0;
-        _center = new Point(a.x, a.y + (b.y - a.y).sign * _radius);
-        if (a.y < b.y) {
-          _startAngle = -math.PI / 2.0;
-          _endAngle = _startAngle + sweepAngle() * (b.x - a.x).sign;
-        } else {
-          _startAngle = math.PI / 2.0;
-          _endAngle = _startAngle + sweepAngle() * (a.x - b.x).sign;
-        }
-      }
-    }
-  }
-
-  final Point a;
-  final Point b;
-
-  Point _center;
-  double _radius;
-  double _startAngle;
-  double _endAngle;
-
-  Point transform(double t) {
-    if (_startAngle == null || _endAngle == null)
-      return Point.lerp(a, b, t);
-    final double angle = lerpDouble(_startAngle, _endAngle, t);
-    final double x = math.cos(angle) * _radius;
-    final double y = math.sin(angle) * _radius;
-    return  _center + new Offset(x, y);
-  }
-
-  @override
-  bool operator ==(dynamic other) {
-    if (identical(this, other))
-      return true;
-    if (other is! MaterialArc)
-      return false;
-    final MaterialArc typedOther = other;
-    return _center == typedOther._center
-      && _radius == typedOther._radius
-      && _startAngle == typedOther._startAngle
-      && _endAngle == typedOther._endAngle;
-  }
-
-  @override
-  int get hashCode => hashValues(_center, _radius, _startAngle, _endAngle);
-
-  @override
-  String toString() => '[MaterialArc center=$_center radius=$_radius startAngle=$_startAngle endAngle=$_endAngle]';
-}
-
-
-class MaterialArcAnimation extends Animation<Point> with AnimationWithParentMixin<double> {
-  MaterialArcAnimation({
-    @required this.parent,
-    @required this.arc
-  }) {
-    assert(parent != null);
-    assert(arc != null);
-  }
-
-  @override
-  final Animation<double> parent;
-
-  MaterialArc arc;
-
-  @override
-  Point get value {
-    double t = parent.value;
-    if (t == 0.0)
-      return arc.a;
-    if (t == 1.0)
-      return arc.b;
-    return arc.transform(t);
-  }
 }
 
 class AnimationDemo extends StatefulWidget {
@@ -257,6 +79,7 @@ class AnimationDemoState extends State<AnimationDemo> {
   Rect _start = new Rect.fromLTWH(150.0, 100.0, 150.0, 100.0);
   Rect _end = new Rect.fromLTWH(200.0, 300.0, 100.0, 150.0);
 
+  @override
   void initState() {
     super.initState();
     _animation = new CurvedAnimation(parent: _controller, curve: Curves.ease);
@@ -300,19 +123,21 @@ class AnimationDemoState extends State<AnimationDemo> {
 
   @override
   Widget build(BuildContext context) {
-    final MaterialRect materialRect = new MaterialRect(_start, _end);
+    final MaterialRectArc arc = new MaterialRectArc(begin: _start, end: _end);
     return new Scaffold(
       key: _scaffoldKey,
       appBar: new AppBar(
-        title: new Text('Animation - ${_simpleInterpolation ? "simple" : "arc"}'),
+        title: new Text('Animation'),
         actions: <Widget>[
           new IconButton(
               icon: new Icon(Icons.rotate_90_degrees_ccw),
             tooltip: 'Toggle arc path',
             onPressed: () {
+              /*
               setState(() {
                 _simpleInterpolation = !_simpleInterpolation;
               });
+              */
             }
           )
         ]
@@ -330,7 +155,7 @@ class AnimationDemoState extends State<AnimationDemo> {
           painter: new _Background(
             repaint: _animation,
             themeData: Theme.of(context),
-            materialRect: materialRect
+            arc: arc
           )
         )
       )

--- a/examples/flutter_gallery/lib/gallery/item.dart
+++ b/examples/flutter_gallery/lib/gallery/item.dart
@@ -45,6 +45,13 @@ class GalleryItem extends StatelessWidget {
 final List<GalleryItem> kAllGalleryItems = <GalleryItem>[
   // Demos
   new GalleryItem(
+    title: 'Animation',
+    subtitle: 'Material motion for points',
+    category: 'Demos',
+    routeName: AnimationDemo.routeName,
+    buildRoute: (BuildContext context) => new AnimationDemo()
+  ),
+  new GalleryItem(
     title: 'Pesto',
     subtitle: 'A simple recipe browser',
     category: 'Demos',

--- a/examples/flutter_gallery/lib/gallery/item.dart
+++ b/examples/flutter_gallery/lib/gallery/item.dart
@@ -45,13 +45,6 @@ class GalleryItem extends StatelessWidget {
 final List<GalleryItem> kAllGalleryItems = <GalleryItem>[
   // Demos
   new GalleryItem(
-    title: 'Animation',
-    subtitle: 'Material motion for points',
-    category: 'Demos',
-    routeName: AnimationDemo.routeName,
-    buildRoute: (BuildContext context) => new AnimationDemo()
-  ),
-  new GalleryItem(
     title: 'Pesto',
     subtitle: 'A simple recipe browser',
     category: 'Demos',
@@ -73,6 +66,13 @@ final List<GalleryItem> kAllGalleryItems = <GalleryItem>[
     buildRoute: (BuildContext context) => new ContactsDemo()
   ),
   // Components
+  new GalleryItem(
+    title: 'Animation',
+    subtitle: 'Material motion for points',
+    category: 'Demos',
+    routeName: AnimationDemo.routeName,
+    buildRoute: (BuildContext context) => new AnimationDemo()
+  ),
   new GalleryItem(
     title: 'Buttons',
     subtitle: 'All kinds: flat, raised, dropdown, icon, etc',

--- a/examples/flutter_gallery/lib/gallery/item.dart
+++ b/examples/flutter_gallery/lib/gallery/item.dart
@@ -68,8 +68,7 @@ final List<GalleryItem> kAllGalleryItems = <GalleryItem>[
   // Components
   new GalleryItem(
     title: 'Animation',
-    subtitle: 'Material motion for points',
-    category: 'Demos',
+    subtitle: 'Material motion for points and rectangles',
     routeName: AnimationDemo.routeName,
     buildRoute: (BuildContext context) => new AnimationDemo()
   ),

--- a/packages/flutter/lib/material.dart
+++ b/packages/flutter/lib/material.dart
@@ -14,6 +14,7 @@ library material;
 export 'src/material/about.dart';
 export 'src/material/app.dart';
 export 'src/material/app_bar.dart';
+export 'src/material/arc.dart';
 export 'src/material/bottom_sheet.dart';
 export 'src/material/button.dart';
 export 'src/material/button_bar.dart';

--- a/packages/flutter/lib/src/material/app.dart
+++ b/packages/flutter/lib/src/material/app.dart
@@ -7,6 +7,7 @@ import 'dart:io' show Platform;
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 
+import 'arc.dart';
 import 'colors.dart';
 import 'overscroll_indicator.dart';
 import 'page.dart';
@@ -152,7 +153,17 @@ final ScrollConfigurationDelegate _indicatorScroll = new _IndicatorScrollConfigu
 final ScrollConfigurationDelegate _bounceScroll = new ScrollConfigurationDelegate();
 
 class _MaterialAppState extends State<MaterialApp> {
-  final HeroController _heroController = new HeroController();
+  HeroController _heroController;
+
+  @override
+  void initState() {
+    super.initState();
+    _heroController = new HeroController(createRectTween: _createRectTween);
+  }
+
+  RectTween _createRectTween(Rect begin, Rect end) {
+    return new MaterialRectArcTween(begin: begin, end: end);
+  }
 
   Route<dynamic> _onGenerateRoute(RouteSettings settings) {
     WidgetBuilder builder = config.routes[settings.name];

--- a/packages/flutter/lib/src/material/arc.dart
+++ b/packages/flutter/lib/src/material/arc.dart
@@ -3,7 +3,7 @@
 // found in the LICENSE file.
 
 import 'dart:math' as math;
-import 'dart:ui' show lerpDouble;
+import 'dart:ui' show hashValues, lerpDouble;
 
 import 'package:flutter/material.dart';
 import 'package:meta/meta.dart';
@@ -22,7 +22,7 @@ const double _kOnAxisDelta = 2.0;
 ///
 /// See also:
 ///
-/// [MaterialRectArcTween]
+/// * [MaterialRectArcTween]
 class MaterialPointArcTween extends Tween<Point> {
   MaterialPointArcTween({
     @required Point begin,
@@ -111,6 +111,20 @@ class MaterialPointArcTween extends Tween<Point> {
   }
 
   @override
+  bool operator ==(dynamic other) {
+    if (identical(this, other))
+      return true;
+    if (other is! MaterialPointArcTween)
+      return false;
+    final MaterialPointArcTween typedOther = other;
+    return begin == typedOther.begin
+        && end == typedOther.end;
+  }
+
+  @override
+  int get hashCode => hashValues(begin, end);
+
+  @override
   String toString() {
     return '$runtimeType($begin \u2192 $end center=$center, radius=$radius, beginAngle=$beginAngle, endAngle=$endAngle)';
   }
@@ -143,8 +157,8 @@ const List<_Diagonal> _allDiagonals = const <_Diagonal>[
 ///
 /// See also:
 ///
-/// [RectTween] (linear rectangle interpolation)
-/// [MaterialPointArcTween]
+/// * [RectTween] (linear rectangle interpolation)
+/// * [MaterialPointArcTween]
 class MaterialRectArcTween extends RectTween {
   MaterialRectArcTween({
     @required Rect begin,
@@ -191,11 +205,11 @@ class MaterialRectArcTween extends RectTween {
 
   /// The path of the corresponding [begin], [end] rectangle corners that lead
   /// the animation.
-  MaterialPointArcTween get  beginArc => _beginArc;
+  MaterialPointArcTween get beginArc => _beginArc;
 
   /// The path of the corresponding [begin], [end] rectangle corners that trail
   /// the animation.
-  MaterialPointArcTween get  endArc => _endArc;
+  MaterialPointArcTween get endArc => _endArc;
 
   /// Setting the arc's [begin] parameter is not supported. Construct a new arc instead.
   @override
@@ -217,6 +231,20 @@ class MaterialRectArcTween extends RectTween {
       return end;
     return new Rect.fromPoints(_beginArc.lerp(t), _endArc.lerp(t));
   }
+
+  @override
+  bool operator ==(dynamic other) {
+    if (identical(this, other))
+      return true;
+    if (other is! MaterialRectArcTween)
+      return false;
+    final MaterialRectArcTween typedOther = other;
+    return begin == typedOther.begin
+        && end == typedOther.end;
+  }
+
+  @override
+  int get hashCode => hashValues(begin, end);
 
   @override
   String toString() {

--- a/packages/flutter/lib/src/material/arc.dart
+++ b/packages/flutter/lib/src/material/arc.dart
@@ -1,0 +1,174 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:math' as math;
+import 'dart:ui' show lerpDouble;
+
+import 'package:flutter/material.dart';
+import 'package:meta/meta.dart'; // @required definition
+
+abstract class _MaterialArc<T> {
+  _MaterialArc({ this.begin, this.end });
+
+  final T begin;
+  final T end;
+
+  T transform(double t);
+}
+
+class MaterialPointArc extends _MaterialArc<Point> {
+  MaterialPointArc({
+    @required Point begin,
+    @required Point end
+  }) : super(begin: begin, end: end) {
+    // An explanation with a diagram can be found at https://goo.gl/vMSdRg
+    final Offset delta = end - begin;
+    final double deltaX = delta.dx.abs();
+    final double deltaY = delta.dy.abs();
+    final double distanceFromAtoB = delta.distance;
+    final Point c = new Point(end.x, begin.y);
+
+    double sweepAngle() => 2.0 *  math.asin(distanceFromAtoB / (2.0 * _radius));
+
+    if (deltaX > 2.0 && deltaY > 2.0) {
+      if (deltaX < deltaY) {
+        _radius = distanceFromAtoB * distanceFromAtoB / (c - begin).distance / 2.0;
+        _center = new Point(end.x + _radius * (begin.x - end.x).sign, end.y);
+        if (begin.x < end.x) {
+          _beginAngle = sweepAngle() * (begin.y - end.y).sign;
+          _endAngle = 0.0;
+        } else {
+          _beginAngle = math.PI + sweepAngle() * (end.y - begin.y).sign;
+          _endAngle = math.PI;
+        }
+      } else {
+        _radius = distanceFromAtoB * distanceFromAtoB / (c - end).distance / 2.0;
+        _center = new Point(begin.x, begin.y + (end.y - begin.y).sign * _radius);
+        if (begin.y < end.y) {
+          _beginAngle = -math.PI / 2.0;
+          _endAngle = _beginAngle + sweepAngle() * (end.x - begin.x).sign;
+        } else {
+          _beginAngle = math.PI / 2.0;
+          _endAngle = _beginAngle + sweepAngle() * (begin.x - end.x).sign;
+        }
+      }
+    }
+  }
+
+  Point _center;
+  double _radius;
+  double _beginAngle;
+  double _endAngle;
+
+  @override
+  Point transform(double t) {
+    if (_beginAngle == null || _endAngle == null)
+      return Point.lerp(begin, end, t);
+    final double angle = lerpDouble(_beginAngle, _endAngle, t);
+    final double x = math.cos(angle) * _radius;
+    final double y = math.sin(angle) * _radius;
+    return  _center + new Offset(x, y);
+  }
+}
+
+enum _CornerId {
+  topLeft,
+  topRight,
+  bottomLeft,
+  bottomRight
+}
+
+class _Diagonal {
+  const _Diagonal(this.beginId, this.endId);
+  final _CornerId beginId;
+  final _CornerId endId;
+}
+
+class MaterialRectArc extends _MaterialArc<Rect> {
+  static final List<_Diagonal> _allDiagonals = <_Diagonal>[
+    const _Diagonal(_CornerId.topLeft, _CornerId.bottomRight),
+    const _Diagonal(_CornerId.bottomRight, _CornerId.topLeft),
+    const _Diagonal(_CornerId.topRight, _CornerId.bottomLeft),
+    const _Diagonal(_CornerId.bottomLeft, _CornerId.topRight),
+  ];
+
+  MaterialRectArc({
+    @required Rect begin,
+    @required Rect end
+  }) : super(begin: begin, end: end) {
+    final Offset centersVector = end.center - begin.center;
+    double maxSupport = 0.0;
+    for (_Diagonal diagonal in _allDiagonals) {
+      final double support = _diagonalSupport(centersVector, diagonal);
+      if (support > maxSupport) {
+        _diagonal = diagonal;
+        maxSupport = support;
+      }
+    }
+    _beginArc = new MaterialPointArc(
+      begin: _cornerFor(begin, _diagonal.beginId),
+      end: _cornerFor(end, _diagonal.beginId)
+    );
+    _endArc = new MaterialPointArc(
+      begin: _cornerFor(begin, _diagonal.endId),
+      end: _cornerFor(end, _diagonal.endId)
+    );
+  }
+
+  _Diagonal _diagonal;
+  MaterialPointArc _beginArc;
+  MaterialPointArc _endArc;
+
+  Point _cornerFor(Rect rect, _CornerId id) {
+    switch (id) {
+      case _CornerId.topLeft: return rect.topLeft;
+      case _CornerId.topRight: return rect.topRight;
+      case _CornerId.bottomLeft: return rect.bottomLeft;
+      case _CornerId.bottomRight: return rect.bottomRight;
+    }
+    return Point.origin;
+  }
+
+  double _diagonalSupport(Offset centersVector, _Diagonal diagonal) {
+    final Offset delta = _cornerFor(begin, diagonal.endId) - _cornerFor(begin, diagonal.beginId);
+    final double length = delta.distance;
+    return centersVector.dx * delta.dx / length + centersVector.dy * delta.dy / length;
+  }
+
+  @override
+  Rect transform(double t) {
+    Point beginArcPoint = _beginArc.transform(t);
+    Point endArcPoint = _endArc.transform(t);
+    double minX = math.min(beginArcPoint.x, endArcPoint.x);
+    double maxX = math.max(beginArcPoint.x, endArcPoint.x);
+    double minY = math.min(beginArcPoint.y, endArcPoint.y);
+    double maxY = math.max(beginArcPoint.y, endArcPoint.y);
+    return new Rect.fromLTRB(minX, minY, maxX, maxY);
+  }
+}
+
+class MaterialPointArcTween extends Tween<Point> {
+  MaterialPointArcTween({
+    @required Point begin,
+    @required Point end
+  }) : _arc = new MaterialPointArc(begin: begin, end: end), super(begin: begin, end: end);
+
+  final MaterialPointArc _arc;
+
+  @override
+  Point lerp(double t) => _arc.transform(t);
+}
+
+class MaterialRectArcTween extends Tween<Rect> {
+  MaterialRectArcTween({
+    @required Rect begin,
+    @required Rect end
+  }) : _arc = new MaterialRectArc(begin: begin, end: end), super(begin: begin, end: end);
+
+  final MaterialRectArc _arc;
+
+  @override
+  Rect lerp(double t) => _arc.transform(t);
+}

--- a/packages/flutter/lib/src/material/arc.dart
+++ b/packages/flutter/lib/src/material/arc.dart
@@ -8,6 +8,10 @@ import 'dart:ui' show lerpDouble;
 import 'package:flutter/material.dart';
 import 'package:meta/meta.dart';
 
+// How close the begin and end points must be to an axis to be considered
+// vertical or horizontal.
+const double _kOnAxisDelta = 2.0;
+
 /// A Tween that animates a point along a circular arc.
 ///
 /// The arc's radius is related to the bounding box that contains the [begin]
@@ -31,9 +35,9 @@ class MaterialPointArcTween extends Tween<Point> {
     final double distanceFromAtoB = delta.distance;
     final Point c = new Point(end.x, begin.y);
 
-    double sweepAngle() => 2.0 *  math.asin(distanceFromAtoB / (2.0 * _radius));
+    double sweepAngle() => 2.0 * math.asin(distanceFromAtoB / (2.0 * _radius));
 
-    if (deltaX > 2.0 && deltaY > 2.0) {
+    if (deltaX > _kOnAxisDelta && deltaY > _kOnAxisDelta) {
       if (deltaX < deltaY) {
         _radius = distanceFromAtoB * distanceFromAtoB / (c - begin).distance / 2.0;
         _center = new Point(end.x + _radius * (begin.x - end.x).sign, end.y);
@@ -94,6 +98,10 @@ class MaterialPointArcTween extends Tween<Point> {
 
   @override
   Point lerp(double t) {
+    if (t == 0.0)
+      return begin;
+    if (t == 1.0)
+      return end;
     if (_beginAngle == null || _endAngle == null)
       return Point.lerp(begin, end, t);
     final double angle = lerpDouble(_beginAngle, _endAngle, t);
@@ -203,6 +211,10 @@ class MaterialRectArcTween extends RectTween {
 
   @override
   Rect lerp(double t) {
+    if (t == 0.0)
+      return begin;
+    if (t == 1.0)
+      return end;
     return new Rect.fromPoints(_beginArc.lerp(t), _endArc.lerp(t));
   }
 

--- a/packages/flutter/lib/src/material/arc.dart
+++ b/packages/flutter/lib/src/material/arc.dart
@@ -8,7 +8,17 @@ import 'dart:ui' show lerpDouble;
 import 'package:flutter/material.dart';
 import 'package:meta/meta.dart';
 
-/// TBD: explain about the degenerate cases, etc.
+/// A Tween that animates a point along a circular arc.
+///
+/// The arc's radius is related to the bounding box that contains the [begin]
+/// and [end] points. If the bounding box is taller than it is wide, then the
+/// center of the circle will be horizontally aligned with the end point.
+/// Otherwise the center of the circle will be aligned with the begin point.
+/// The arc's sweep is always less than or equal to 90 degrees.
+///
+/// See also:
+///
+/// [MaterialRectArcTween]
 class MaterialPointArcTween extends Tween<Point> {
   MaterialPointArcTween({
     @required Point begin,
@@ -53,7 +63,7 @@ class MaterialPointArcTween extends Tween<Point> {
   double _beginAngle;
   double _endAngle;
 
-  /// The center of the circular arc, null if begin and end are horiztonally or
+  /// The center of the circular arc, null if [begin] and [end] are horiztonally or
   /// vertically aligned.
   Point get center => _center;
 
@@ -118,6 +128,15 @@ const List<_Diagonal> _allDiagonals = const <_Diagonal>[
   const _Diagonal(_CornerId.bottomLeft, _CornerId.topRight),
 ];
 
+/// A Tween that animates a rectangle from [begin] to [end].
+///
+/// The rectangle corners whose diagonal is closest to the overall direction of
+/// the animation follow arcs defined with [MaterialPointArcTween].
+///
+/// See also:
+///
+/// [RectTween] (linear rectangle interpolation)
+/// [MaterialPointArcTween]
 class MaterialRectArcTween extends RectTween {
   MaterialRectArcTween({
     @required Rect begin,
@@ -162,8 +181,12 @@ class MaterialRectArcTween extends RectTween {
     return centersVector.dx * delta.dx / length + centersVector.dy * delta.dy / length;
   }
 
+  /// The path of the corresponding [begin], [end] rectangle corners that lead
+  /// the animation.
   MaterialPointArcTween get  beginArc => _beginArc;
 
+  /// The path of the corresponding [begin], [end] rectangle corners that trail
+  /// the animation.
   MaterialPointArcTween get  endArc => _endArc;
 
   /// Setting the arc's [begin] parameter is not supported. Construct a new arc instead.

--- a/packages/flutter/lib/src/material/page.dart
+++ b/packages/flutter/lib/src/material/page.dart
@@ -61,7 +61,7 @@ class MaterialPageRoute<T> extends PageRoute<T> {
   final WidgetBuilder builder;
 
   @override
-  Duration get transitionDuration => const Duration(milliseconds: 150);
+  Duration get transitionDuration => const Duration(milliseconds: 300);
 
   @override
   Color get barrierColor => null;

--- a/packages/flutter/lib/src/widgets/heroes.dart
+++ b/packages/flutter/lib/src/widgets/heroes.dart
@@ -307,7 +307,7 @@ class HeroParty {
     return result;
   }
 
-  RectTween doCreateRectTween(Rect begin, Rect end) {
+  RectTween _doCreateRectTween(Rect begin, Rect end) {
     if (createRectTween != null)
       return createRectTween(begin, end);
     return new RectTween(begin: begin, end: end);
@@ -360,7 +360,7 @@ class HeroParty {
         targetRect: targetRect,
         targetTurns: targetTurns.floor(),
         targetState: targetState,
-        currentRect: doCreateRectTween(sourceRect, targetRect),
+        currentRect: _doCreateRectTween(sourceRect, targetRect),
         currentTurns: createTurnsTween(sourceTurns, targetTurns)
       ));
     }

--- a/packages/flutter/lib/src/widgets/transitions.dart
+++ b/packages/flutter/lib/src/widgets/transitions.dart
@@ -320,6 +320,35 @@ class PositionedTransition extends AnimatedWidget {
   }
 }
 
+class RelativePositionedTransition extends AnimatedWidget {
+  RelativePositionedTransition({
+    Key key,
+    @required Animation<Rect> rect,
+    @required this.size,
+    this.child
+  }) : super(key: key, animation: rect);
+
+  /// The animation that controls the child's size and position.
+  Animation<Rect> get rect => animation;
+
+  final Size size;
+
+  /// The widget below this widget in the tree.
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    final RelativeRect offsets = new RelativeRect.fromSize(rect.value, size);
+    return new Positioned(
+      top: offsets.top,
+      right: offsets.right,
+      bottom: offsets.bottom,
+      left: offsets.left,
+      child: child
+    );
+  }
+}
+
 /// A builder that builds a widget given a child.
 typedef Widget TransitionBuilder(BuildContext context, Widget child);
 

--- a/packages/flutter/lib/src/widgets/transitions.dart
+++ b/packages/flutter/lib/src/widgets/transitions.dart
@@ -292,6 +292,10 @@ class RelativeRectTween extends Tween<RelativeRect> {
 /// position to and end position over the lifetime of the animation.
 ///
 /// Only works if it's the child of a [Stack].
+///
+/// See also:
+///
+/// * [RelativePositionedTransition]
 class PositionedTransition extends AnimatedWidget {
   /// Creates a transition for [Positioned].
   ///
@@ -320,6 +324,15 @@ class PositionedTransition extends AnimatedWidget {
   }
 }
 
+/// Animated version of [Positioned] which transitions the child's position
+/// based on the value of [rect] relative to a bounding box with the
+/// specified [size].
+///
+/// Only works if it's the child of a [Stack].
+///
+/// See also:
+///
+/// * [PositionedTransition]
 class RelativePositionedTransition extends AnimatedWidget {
   RelativePositionedTransition({
     Key key,
@@ -331,6 +344,8 @@ class RelativePositionedTransition extends AnimatedWidget {
   /// The animation that controls the child's size and position.
   Animation<Rect> get rect => animation;
 
+  /// The [Positioned] widget's offsets are relative to a box of this
+  /// size whose origin is 0,0.
   final Size size;
 
   /// The widget below this widget in the tree.

--- a/packages/flutter/test/material/arc_test.dart
+++ b/packages/flutter/test/material/arc_test.dart
@@ -1,0 +1,80 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter/material.dart';
+
+void main() {
+  test('on-axis MaterialPointArcTween', () {
+    MaterialPointArcTween tween = new MaterialPointArcTween(
+      begin: Point.origin,
+      end: new Point(0.0, 10.0)
+    );
+    expect(tween.lerp(0.5), equals(new Point(0.0, 5.0)));
+    expect(tween, hasOneLineDescription);
+
+    tween = new MaterialPointArcTween(
+      begin: Point.origin,
+      end: new Point(10.0, 0.0)
+    );
+    expect(tween.lerp(0.5), equals(new Point(5.0, 0.0)));
+  });
+
+  test('on-axis MaterialRectArcTween', () {
+    MaterialRectArcTween tween = new MaterialRectArcTween(
+      begin: new Rect.fromLTWH(0.0, 0.0, 10.0, 10.0),
+      end: new Rect.fromLTWH(0.0, 10.0, 10.0, 10.0)
+    );
+    expect(tween.lerp(0.5), equals(new Rect.fromLTWH(0.0, 5.0, 10.0, 10.0)));
+    expect(tween, hasOneLineDescription);
+
+    tween = new MaterialRectArcTween(
+      begin: new Rect.fromLTWH(0.0, 0.0, 10.0, 10.0),
+      end: new Rect.fromLTWH(10.0, 0.0, 10.0, 10.0)
+    );
+    expect(tween.lerp(0.5), equals(new Rect.fromLTWH(5.0, 0.0, 10.0, 10.0)));
+  });
+
+  test('MaterialPointArcTween', () {
+    final Point begin = const Point(180.0, 110.0);
+    final Point end = const Point(37.0, 250.0);
+
+    MaterialPointArcTween tween = new MaterialPointArcTween(begin: begin, end: end);
+    expect(tween.lerp(0.0), begin);
+    expect((tween.lerp(0.25) - const Point(126.0, 120.0)).distance, closeTo(0.0, 2.0));
+    expect((tween.lerp(0.75) - const Point(48.0, 196.0)).distance, closeTo(0.0, 2.0));
+    expect(tween.lerp(1.0), end);
+
+    tween = new MaterialPointArcTween(begin: end, end: begin);
+    expect(tween.lerp(0.0), end);
+    expect((tween.lerp(0.25) - const Point(91.0, 239.0)).distance, closeTo(0.0, 2.0));
+    expect((tween.lerp(0.75) - const Point(168.3, 163.8)).distance, closeTo(0.0, 2.0));
+    expect(tween.lerp(1.0), begin);
+  });
+
+  test('MaterialRectArcTween', () {
+    final Rect begin = new Rect.fromLTRB(180.0, 100.0, 330.0, 200.0);
+    final Rect end = new Rect.fromLTRB(32.0, 275.0, 132.0, 425.0);
+
+    bool sameRect(Rect a, Rect b) {
+      return (a.left - b.left).abs() < 2.0
+        && (a.top - b.top).abs() < 2.0
+        && (a.right - b.right).abs() < 2.0
+        && (a.bottom - b.bottom).abs() < 2.0;
+    }
+
+    MaterialRectArcTween tween = new MaterialRectArcTween(begin: begin, end: end);
+    expect(tween.lerp(0.0), begin);
+    expect(sameRect(tween.lerp(0.25), new Rect.fromLTRB(120.0, 113.0, 259.0, 237.0)), isTrue);
+    expect(sameRect(tween.lerp(0.75), new Rect.fromLTRB(42.3, 206.5, 153.5, 354.7)), isTrue);
+    expect(tween.lerp(1.0), end);
+
+    tween = new MaterialRectArcTween(begin: end, end: begin);
+    expect(tween.lerp(0.0), end);
+    expect(sameRect(tween.lerp(0.25), new Rect.fromLTRB(92.0, 262.0, 203.0, 388.0)), isTrue);
+    expect(sameRect(tween.lerp(0.75), new Rect.fromLTRB(169.7, 168.5, 308.5, 270.3)), isTrue);
+    expect(tween.lerp(1.0), begin);
+  });
+
+}

--- a/packages/flutter_tools/lib/src/devfs.dart
+++ b/packages/flutter_tools/lib/src/devfs.dart
@@ -79,12 +79,16 @@ class ServiceProtocolDevFSOperations implements DevFSOperations {
       return e;
     }
     String fileContents = BASE64.encode(bytes);
+    try {
     return await serviceProtocol.sendRequest('_writeDevFSFile',
                                              <String, dynamic> {
                                                 'fsName': fsName,
                                                 'path': entry.devicePath,
                                                 'fileContents': fileContents
                                              });
+    } catch (e) {
+      print('failed on ${entry.devicePath} $e');
+    }
   }
 
   @override


### PR DESCRIPTION
Added Tween classes that lerp points and rectangles along circular arc paths.

A brief description of how the arc is computed given a pair of points can be found here: https://goo.gl/vMSdRg

Hero transitions in material apps use the new tweens to transform the bounds of the hero widget.
