### PR TITLE
Fix the calculation of image heights in ImageFit.scaleDown mode

### DIFF
--- a/packages/flutter/lib/src/painting/box_painter.dart
+++ b/packages/flutter/lib/src/painting/box_painter.dart
@@ -869,7 +869,7 @@ void paintImage({
       if (destinationSize.height > outputSize.height)
         destinationSize = new Size(outputSize.height * aspectRatio, outputSize.height);
       if (destinationSize.width > outputSize.width)
-        destinationSize = new Size(outputSize.width, outputSize.height / aspectRatio);
+        destinationSize = new Size(outputSize.width, outputSize.width / aspectRatio);
       break;
   }
   if (centerSlice != null) {


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/4407
