### PR TITLE
Licenses

### DIFF
--- a/dev/bots/test.sh
+++ b/dev/bots/test.sh
@@ -9,7 +9,7 @@ detect_error_on_exit() {
     set +x
     if [[ $exit_code -ne 0 ]]; then
         echo -e "\x1B[31m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\x1B[0m"
-        echo -e "\x1B[31m\x1B[1mError:\x1B[0m\x1B[31m script exited early due to error ($exit_code)"
+        echo -e "\x1B[1mError:\x1B[31m script exited early due to error ($exit_code)\x1B[0m"
         echo -e "\x1B[31m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\x1B[0m"
     fi
 }

--- a/packages/flutter/lib/src/foundation/binding.dart
+++ b/packages/flutter/lib/src/foundation/binding.dart
@@ -11,7 +11,6 @@ import 'package:meta/meta.dart';
 
 import 'assertions.dart';
 import 'basic_types.dart';
-import 'licenses.dart';
 
 /// Signature for service extensions.
 ///
@@ -75,12 +74,7 @@ abstract class BindingBase {
   /// `initInstances()`.
   void initInstances() {
     assert(!_debugInitialized);
-    LicenseRegistry.addLicense(_addLicenses);
     assert(() { _debugInitialized = true; return true; });
-  }
-
-  Iterable<LicenseEntry> _addLicenses() sync* {
-    // TODO(ianh): Populate the license registry.
   }
 
   /// Called when the binding is initialized, to register service

--- a/packages/flutter/lib/src/services/binding.dart
+++ b/packages/flutter/lib/src/services/binding.dart
@@ -2,8 +2,11 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:async';
+
 import 'package:flutter/foundation.dart';
 
+import 'asset_bundle.dart';
 import 'shell.dart';
 
 /// Ensures that the [MojoShell] singleton is created synchronously
@@ -15,10 +18,24 @@ import 'shell.dart';
 /// [MojoShell] is then created in an earlier call stack than the
 /// server for that service is provided, then the request will be
 /// rejected as not matching any registered servers.
+///
+/// The ServicesBinding also registers a [LicenseEntryCollector] that exposes
+/// the licenses found in the LICENSE file stored at the root of the asset
+/// bundle.
 abstract class ServicesBinding extends BindingBase {
   @override
   void initInstances() {
     super.initInstances();
     new MojoShell();
+    LicenseRegistry.addLicense(_addLicenses);
+  }
+
+  static final String _licenseSeparator = '\n' + ('-' * 80) + '\n';
+
+  Stream<LicenseEntry> _addLicenses() async* {
+    final String rawLicenses = await rootBundle.loadString('LICENSE', cache: false);
+    final List<String> licenses = rawLicenses.split(_licenseSeparator);
+    for (String license in licenses)
+      yield new LicenseEntryWithLineBreaks(license);
   }
 }

--- a/packages/flutter/test/foundation/licenses_test.dart
+++ b/packages/flutter/test/foundation/licenses_test.dart
@@ -172,22 +172,18 @@ S
     expect(paragraphs, hasLength(1));
   });
 
-  test('LicenseRegistry', () {
-    expect(LicenseRegistry.licenses, isEmpty);
-    LicenseRegistry.addLicense(() {
-      return <LicenseEntry>[
-        new LicenseEntryWithLineBreaks('A'),
-        new LicenseEntryWithLineBreaks('B'),
-      ];
+  test('LicenseRegistry', () async {
+    expect(await LicenseRegistry.licenses.toList(), isEmpty);
+    LicenseRegistry.addLicense(() async* {
+      yield new LicenseEntryWithLineBreaks('A');
+      yield new LicenseEntryWithLineBreaks('B');
     });
-    LicenseRegistry.addLicense(() {
-      return <LicenseEntry>[
-        new LicenseEntryWithLineBreaks('C'),
-        new LicenseEntryWithLineBreaks('D'),
-      ];
+    LicenseRegistry.addLicense(() async* {
+      yield new LicenseEntryWithLineBreaks('C');
+      yield new LicenseEntryWithLineBreaks('D');
     });
-    expect(LicenseRegistry.licenses, hasLength(4));
-    List<LicenseEntry> licenses = LicenseRegistry.licenses.toList();
+    expect(await LicenseRegistry.licenses.toList(), hasLength(4));
+    List<LicenseEntry> licenses = await LicenseRegistry.licenses.toList();
     expect(licenses, hasLength(4));
     expect(licenses[0].paragraphs.single.text, 'A');
     expect(licenses[1].paragraphs.single.text, 'B');

--- a/packages/flutter_tools/lib/src/dart/package_map.dart
+++ b/packages/flutter_tools/lib/src/dart/package_map.dart
@@ -28,8 +28,7 @@ class PackageMap {
   final String packagesPath;
 
   Map<String, Uri> get map {
-    if (_map == null)
-      _map = _parse(packagesPath);
+    _map ??= _parse(packagesPath);
     return _map;
   }
   Map<String, Uri> _map;


### PR DESCRIPTION
This makes the about page show the licenses of all the Dart packages that a Flutter app uses.

Issues that this does not yet resolve:
- I'm still working on getting the full list of licenses for the sky_engine package.
- Some of the licenses don't print very readably.
- There's no scrollbar on the license page.

I'll provide fixes for the first two in the coming days, but this should unblock anyone who is wanting to see something here, even if it's not quite complete. :-)

---

The patch makes the following changes: 
- The license registry is now asynchronous, since the data comes from disk.
- I moved the default license collector from the foundation package to the services package since it uses the default asset bundle now.
- The FLX builder now includes the LICENSE files of each Dart package mentioned in the `.packages` file.
