### PR TITLE
log the contents of .packages and pubspec.lock on buildbots

### DIFF
--- a/packages/flutter_tools/lib/src/commands/build.dart
+++ b/packages/flutter_tools/lib/src/commands/build.dart
@@ -5,8 +5,11 @@
 import 'dart:async';
 import 'dart:io';
 
+import 'package:meta/meta.dart';
+
 import '../globals.dart';
 import '../runner/flutter_command.dart';
+import '../base/utils.dart';
 import 'build_apk.dart';
 import 'build_aot.dart';
 import 'build_flx.dart';
@@ -29,6 +32,29 @@ class BuildCommand extends FlutterCommand {
 
   @override
   Future<int> runInProject() => new Future<int>.value(0);
+}
+
+abstract class BuildSubCommand extends FlutterCommand {
+  @override
+  @mustCallSuper
+  Future<int> runInProject() async {
+    if (isRunningOnBot) {
+      File dotPackages = new File('.packages');
+      printStatus('Contents of .packages:');
+      if (dotPackages.existsSync())
+        printStatus(dotPackages.readAsStringSync());
+      else
+        printError('File not found: ${dotPackages.absolute.path}');
+
+      File pubspecLock = new File('pubspec.lock');
+      printStatus('Contents of pubspec.lock:');
+      if (pubspecLock.existsSync())
+        printStatus(pubspecLock.readAsStringSync());
+      else
+        printError('File not found: ${pubspecLock.absolute.path}');
+    }
+    return 0;
+  }
 }
 
 class BuildCleanCommand extends FlutterCommand {

--- a/packages/flutter_tools/lib/src/commands/build_aot.dart
+++ b/packages/flutter_tools/lib/src/commands/build_aot.dart
@@ -14,7 +14,7 @@ import '../build_info.dart';
 import '../dart/package_map.dart';
 import '../globals.dart';
 import '../run.dart';
-import '../runner/flutter_command.dart';
+import 'build.dart';
 
 const String _kDefaultAotOutputDir = 'build/aot';
 
@@ -23,7 +23,7 @@ const List<String> kAotSnapshotFiles = const <String>[
   'snapshot_aot_instr', 'snapshot_aot_isolate', 'snapshot_aot_rodata', 'snapshot_aot_vmisolate',
 ];
 
-class BuildAotCommand extends FlutterCommand {
+class BuildAotCommand extends BuildSubCommand {
   BuildAotCommand() {
     usesTargetOption();
     addBuildModeFlags();
@@ -45,6 +45,7 @@ class BuildAotCommand extends FlutterCommand {
 
   @override
   Future<int> runInProject() async {
+    await super.runInProject();
     String targetPlatform = argResults['target-platform'];
     TargetPlatform platform = getTargetPlatformForName(targetPlatform);
     if (platform == null) {

--- a/packages/flutter_tools/lib/src/commands/build_apk.dart
+++ b/packages/flutter_tools/lib/src/commands/build_apk.dart
@@ -19,9 +19,9 @@ import '../build_info.dart';
 import '../flx.dart' as flx;
 import '../globals.dart';
 import '../run.dart';
-import '../runner/flutter_command.dart';
 import '../services.dart';
 import 'build_aot.dart';
+import 'build.dart';
 
 export '../android/android_device.dart' show AndroidDevice;
 
@@ -159,7 +159,7 @@ class ApkKeystoreInfo {
   final String keyPassword;
 }
 
-class BuildApkCommand extends FlutterCommand {
+class BuildApkCommand extends BuildSubCommand {
   BuildApkCommand() {
     usesTargetOption();
     addBuildModeFlags();
@@ -203,6 +203,7 @@ class BuildApkCommand extends FlutterCommand {
 
   @override
   Future<int> runInProject() async {
+    await super.runInProject();
     if (isProjectUsingGradle()) {
       return await buildAndroidWithGradle(
         TargetPlatform.android_arm,

--- a/packages/flutter_tools/lib/src/commands/build_flx.dart
+++ b/packages/flutter_tools/lib/src/commands/build_flx.dart
@@ -6,9 +6,9 @@ import 'dart:async';
 
 import '../flx.dart';
 import '../globals.dart';
-import '../runner/flutter_command.dart';
+import 'build.dart';
 
-class BuildFlxCommand extends FlutterCommand {
+class BuildFlxCommand extends BuildSubCommand {
   BuildFlxCommand() {
     usesTargetOption();
     argParser.addFlag('precompiled', negatable: false);
@@ -37,6 +37,7 @@ class BuildFlxCommand extends FlutterCommand {
 
   @override
   Future<int> runInProject() async {
+    await super.runInProject();
     String outputPath = argResults['output-file'];
 
     return await build(

--- a/packages/flutter_tools/lib/src/commands/build_ios.dart
+++ b/packages/flutter_tools/lib/src/commands/build_ios.dart
@@ -11,9 +11,9 @@ import '../base/logger.dart';
 import '../build_info.dart';
 import '../globals.dart';
 import '../ios/mac.dart';
-import '../runner/flutter_command.dart';
+import 'build.dart';
 
-class BuildIOSCommand extends FlutterCommand {
+class BuildIOSCommand extends BuildSubCommand {
   BuildIOSCommand() {
     usesTargetOption();
     addBuildModeFlags();
@@ -30,6 +30,7 @@ class BuildIOSCommand extends FlutterCommand {
 
   @override
   Future<int> runInProject() async {
+    await super.runInProject();
     if (getCurrentHostPlatform() != HostPlatform.darwin_x64) {
       printError('Building for iOS is only supported on the Mac.');
       return 1;

--- a/packages/flutter_tools/pubspec.yaml
+++ b/packages/flutter_tools/pubspec.yaml
@@ -22,6 +22,7 @@ dependencies:
   json_schema: 1.0.3
 
   linter: ^0.1.17
+  meta: ^0.12.0
   mustache4dart: ^1.0.0
   package_config: '>=0.1.5 <2.0.0'
   path: ^1.3.0


### PR DESCRIPTION
This will allow us to more accurately reproduce broken builds locally. Right now we do not know which versions of Dart packages were used to build an app.

/cc @devoncarew 
