### PR TITLE
Don't animate fab in a new scaffold

### DIFF
--- a/packages/flutter/lib/src/material/floating_action_button.dart
+++ b/packages/flutter/lib/src/material/floating_action_button.dart
@@ -43,7 +43,7 @@ class FloatingActionButton extends StatefulWidget {
   /// Most commonly used in the [Scaffold.floatingActionButton] field.
   const FloatingActionButton({
     Key key,
-    this.child,
+    @required this.child,
     this.tooltip,
     this.backgroundColor,
     this.elevation: 6,

--- a/packages/flutter/lib/src/material/scaffold.dart
+++ b/packages/flutter/lib/src/material/scaffold.dart
@@ -155,6 +155,11 @@ class _FloatingActionButtonTransitionState extends State<_FloatingActionButtonTr
   @override
   void initState() {
     super.initState();
+    // If we start out with a child, have the child appear fully visible instead
+    // of animating in.
+    if (config.child != null)
+      _currentController.value = 1.0;
+
     _previousAnimation = new CurvedAnimation(
       parent: _previousController,
       curve: Curves.easeIn
@@ -165,7 +170,6 @@ class _FloatingActionButtonTransitionState extends State<_FloatingActionButtonTr
     );
 
     _previousController.addStatusListener(_handleAnimationStatusChanged);
-    _currentController.forward();
   }
 
   @override

--- a/packages/flutter/test/material/scaffold_test.dart
+++ b/packages/flutter/test/material/scaffold_test.dart
@@ -40,4 +40,40 @@ void main() {
     bodyBox = tester.renderObject(find.byKey(bodyKey));
     expect(bodyBox.size, equals(new Size(800.0, 544.0)));
   });
+
+  testWidgets('Floating action animation', (WidgetTester tester) async {
+    await tester.pumpWidget(new Scaffold(
+      floatingActionButton: new FloatingActionButton(
+        key: new Key("one"),
+        onPressed: null,
+        child: new Text("1")
+      )
+    ));
+
+    expect(tester.binding.transientCallbackCount, 0);
+
+    await tester.pumpWidget(new Scaffold(
+      floatingActionButton: new FloatingActionButton(
+        key: new Key("two"),
+        onPressed: null,
+        child: new Text("2")
+      )
+    ));
+
+    expect(tester.binding.transientCallbackCount, greaterThan(0));
+    await tester.pumpWidget(new Container());
+    expect(tester.binding.transientCallbackCount, 0);
+    await tester.pumpWidget(new Scaffold());
+    expect(tester.binding.transientCallbackCount, 0);
+
+    await tester.pumpWidget(new Scaffold(
+      floatingActionButton: new FloatingActionButton(
+        key: new Key("one"),
+        onPressed: null,
+        child: new Text("1")
+      )
+    ));
+
+    expect(tester.binding.transientCallbackCount, greaterThan(0));
+  });
 }


### PR DESCRIPTION
If the scaffold is new and has a floating action button, we skip the entrance
animation for the fab.

Fixes #4445
