### PR TITLE
hide some unnecessary headers from the generated docs

### DIFF
--- a/dev/docs/styles.html
+++ b/dev/docs/styles.html
@@ -51,8 +51,7 @@
   }
 
   .sidebar h5 {
-    padding-top: 0 !important;
-    text-transform: uppercase;
+    display: none;
   }
 
   .sidebar-offcanvas-left {

--- a/dev/tools/dartdoc.dart
+++ b/dev/tools/dartdoc.dart
@@ -100,7 +100,7 @@ void createIndexAndCleanup() {
 void removeOldFlutterDocsDir() {
   try {
     new Directory('$kDocRoot/flutter').deleteSync(recursive: true);
-  } catch(e) {
+  } catch (e) {
     // If the directory does not exist, that's OK.
   }
 }
@@ -109,8 +109,8 @@ void renameApiDir() {
   new Directory('$kDocRoot/api').renameSync('$kDocRoot/flutter');
 }
 
-File copyIndexToRootOfDocs() {
-  return new File('$kDocRoot/flutter/index.html').copySync('$kDocRoot/index.html');
+void copyIndexToRootOfDocs() {
+  new File('$kDocRoot/flutter/index.html').copySync('$kDocRoot/index.html');
 }
 
 void addHtmlBaseToIndex() {


### PR DESCRIPTION
Related to https://github.com/dart-lang/dartdoc/issues/1146, hide some unnecessary headers in the generated docs.

<img width="269" alt="screen shot 2016-07-22 at 10 08 49 pm" src="https://cloud.githubusercontent.com/assets/1269969/17075929/0644b834-5059-11e6-8196-851fad23c2e0.png">
