### PR TITLE
A tap is not a scroll

### DIFF
--- a/packages/flutter/lib/src/material/overscroll_indicator.dart
+++ b/packages/flutter/lib/src/material/overscroll_indicator.dart
@@ -132,7 +132,6 @@ class _OverscrollIndicatorState extends State<OverscrollIndicator> {
   void _hide() {
     _hideTimer?.cancel();
     _hideTimer = null;
-    // Gaurding _hide() being called while indicator is already animating.
     if (!_extentAnimation.isAnimating) {
       _extentAnimation.reverse();
     }
@@ -188,21 +187,24 @@ class _OverscrollIndicatorState extends State<OverscrollIndicator> {
   }
 
   bool _handleScrollNotification(ScrollNotification notification) {
-    if (notification.depth != 0)
+    if (config.scrollableKey == null) {
+        if (notification.depth != 0)
+          return false;
+    } else if (config.scrollableKey != notification.scrollable.config.key) {
       return false;
-    if (config.scrollableKey == null || config.scrollableKey == notification.scrollable.config.key) {
-      final ScrollableState scrollable = notification.scrollable;
-      switch(notification.kind) {
-        case ScrollNotificationKind.started:
-          _onScrollStarted(scrollable);
-          break;
-        case ScrollNotificationKind.updated:
-          _onScrollUpdated(scrollable);
-          break;
-        case ScrollNotificationKind.ended:
-          _onScrollEnded(scrollable);
-          break;
-      }
+    }
+
+    final ScrollableState scrollable = notification.scrollable;
+    switch(notification.kind) {
+      case ScrollNotificationKind.started:
+        _onScrollStarted(scrollable);
+        break;
+      case ScrollNotificationKind.updated:
+        _onScrollUpdated(scrollable);
+        break;
+      case ScrollNotificationKind.ended:
+        _onScrollEnded(scrollable);
+        break;
     }
     return false;
   }

--- a/packages/flutter/lib/src/material/scrollbar.dart
+++ b/packages/flutter/lib/src/material/scrollbar.dart
@@ -111,7 +111,7 @@ class _ScrollbarState extends State<Scrollbar> {
   }
 
   @override
-  dispose() {
+  void dispose() {
     _fade.stop();
     super.dispose();
   }

--- a/packages/flutter/lib/src/material/scrollbar.dart
+++ b/packages/flutter/lib/src/material/scrollbar.dart
@@ -110,6 +110,12 @@ class _ScrollbarState extends State<Scrollbar> {
     _opacity = new CurvedAnimation(parent: _fade, curve: Curves.ease);
   }
 
+  @override
+  dispose() {
+    _fade.stop();
+    super.dispose();
+  }
+
   void _updateState(ScrollableState scrollable) {
     if (scrollable.scrollBehavior is! ExtentScrollBehavior)
       return;
@@ -127,11 +133,12 @@ class _ScrollbarState extends State<Scrollbar> {
 
   void _onScrollUpdated(ScrollableState scrollable) {
     _updateState(scrollable);
-    if (_scrollOffsetAnchor != _scrollOffset && _fade.value == 0.0 && !_fade.isAnimating) {
-      _fade.forward(); // Lazily start the scrollbar fade-in.
-    } else if (!_fade.isAnimating) {
+    if (!_fade.isAnimating) {
+      if (_scrollOffsetAnchor != _scrollOffset && _fade.value == 0.0)
+        _fade.forward(); // Lazily start the scrollbar fade-in.
       setState(() {
-        // The scrollbar has faded in, rebuild it per the new scrollable state.
+        // If the scrollbar has faded in, rebuild it per the new scrollable state.
+        // If the fade-in is underway this setState() will have no effect.
       });
     }
   }

--- a/packages/flutter/lib/src/widgets/scroll_behavior.dart
+++ b/packages/flutter/lib/src/widgets/scroll_behavior.dart
@@ -7,7 +7,6 @@ import 'dart:math' as math;
 import 'package:flutter/physics.dart';
 import 'package:meta/meta.dart';
 
-const double _kSecondsPerMillisecond = 1000.0;
 const double _kScrollDrag = 0.025;
 
 // TODO(hansmuller): Simplify these classes. We're no longer using the ScrollBehavior<T, U>
@@ -151,14 +150,12 @@ class BoundedBehavior extends ExtentScrollBehavior {
 }
 
 Simulation _createScrollSimulation(double position, double velocity, double minScrollOffset, double maxScrollOffset) {
-  final double startVelocity = velocity * _kSecondsPerMillisecond;
   final SpringDescription spring = new SpringDescription.withDampingRatio(mass: 1.0, springConstant: 170.0, ratio: 1.1);
-  return new ScrollSimulation(position, startVelocity, minScrollOffset, maxScrollOffset, spring, _kScrollDrag);
+  return new ScrollSimulation(position, velocity, minScrollOffset, maxScrollOffset, spring, _kScrollDrag);
 }
 
 Simulation _createSnapScrollSimulation(double startOffset, double endOffset, double startVelocity, double endVelocity) {
-  final double velocity = startVelocity * _kSecondsPerMillisecond;
-  return new FrictionSimulation.through(startOffset, endOffset, velocity, endVelocity);
+  return new FrictionSimulation.through(startOffset, endOffset, startVelocity, endVelocity);
 }
 
 /// A scroll behavior that does not prevent the user from exeeding scroll bounds.
@@ -169,9 +166,8 @@ class UnboundedBehavior extends ExtentScrollBehavior {
 
   @override
   Simulation createScrollSimulation(double position, double velocity) {
-    double velocityPerSecond = velocity * 1000.0;
     return new BoundedFrictionSimulation(
-      _kScrollDrag, position, velocityPerSecond, double.NEGATIVE_INFINITY, double.INFINITY
+      _kScrollDrag, position, velocity, double.NEGATIVE_INFINITY, double.INFINITY
     );
   }
 

--- a/packages/flutter/test/widget/snap_scrolling_test.dart
+++ b/packages/flutter/test/widget/snap_scrolling_test.dart
@@ -51,7 +51,7 @@ Future<Null> fling(double velocity) {
 }
 
 void main() {
-  testWidgets('ScrollableList snap scrolling, fling(0.8)', (WidgetTester tester) async {
+  testWidgets('ScrollableList snap scrolling', (WidgetTester tester) async {
     await tester.pumpWidget(buildFrame());
 
     scrollOffset = 0.0;
@@ -60,7 +60,7 @@ void main() {
 
     Duration dt = const Duration(seconds: 2);
 
-    fling(1.0);
+    fling(1000.0);
     await tester.pump(); // Start the scheduler at 0.0
     await tester.pump(dt);
     expect(scrollOffset, closeTo(200.0, 1.0));
@@ -69,7 +69,7 @@ void main() {
     await tester.pump();
     expect(scrollOffset, 0.0);
 
-    fling(2.0);
+    fling(2000.0);
     await tester.pump();
     await tester.pump(dt);
     expect(scrollOffset, closeTo(400.0, 1.0));
@@ -78,7 +78,7 @@ void main() {
     await tester.pump();
     expect(scrollOffset, 400.0);
 
-    fling(-0.8);
+    fling(-800.0);
     await tester.pump();
     await tester.pump(dt);
     expect(scrollOffset, closeTo(0.0, 1.0));
@@ -87,7 +87,7 @@ void main() {
     await tester.pump();
     expect(scrollOffset, 800.0);
 
-    fling(-2.0);
+    fling(-2000.0);
     await tester.pump();
     await tester.pump(dt);
     expect(scrollOffset, closeTo(200.0, 1.0));
@@ -97,7 +97,7 @@ void main() {
     expect(scrollOffset, 800.0);
 
     bool completed = false;
-    fling(-2.0).then((_) {
+    fling(-2000.0).then((_) {
       completed = true;
       expectSync(scrollOffset, closeTo(200.0, 1.0));
     });


### PR DESCRIPTION
- All of the scrollable and scroll behavior velocities are now just logical pixels per second.
- Scrollbar and OverscrollIndicator now appear if the scroll-start notification's depth is 0 or if a scrollable key was specified and it matches.
- Scrollbar fades-in once the scrollOffset changes, rather than on the scroll-start notification.

Mostly fixes #5013

We no longer run the entire end animation upon tap but we still generate one frame.
