### PR TITLE
Center AppBar title on iOS

### DIFF
--- a/packages/flutter/lib/src/animation/animations.dart
+++ b/packages/flutter/lib/src/animation/animations.dart
@@ -395,7 +395,7 @@ class CurvedAnimation extends Animation<double> with AnimationWithParentMixin<do
         final double roundedTransformedValue = transformedValue.round().toDouble();
         if (roundedTransformedValue != t) {
           throw new FlutterError(
-            'Invalided curve endpoint at $t.\n'
+            'Invalid curve endpoint at $t.\n'
             'Curves must map 0.0 to near zero and 1.0 to near one but '
             '${activeCurve.runtimeType} mapped $t to $transformedValue, which '
             'is near $roundedTransformedValue.'

--- a/packages/flutter/lib/src/material/flexible_space_bar.dart
+++ b/packages/flutter/lib/src/material/flexible_space_bar.dart
@@ -83,7 +83,7 @@ class _FlexibleSpaceBarState extends State<FlexibleSpaceBar> {
       case TargetPlatform.iOS:
         return true;
     }
-    return false;
+    return null;
   }
 
   @override

--- a/packages/flutter/test/material/app_bar_test.dart
+++ b/packages/flutter/test/material/app_bar_test.dart
@@ -6,15 +6,13 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  testWidgets('FlexibleSpaceBar centers title on iOS', (WidgetTester tester) async {
+  testWidgets('AppBar centers title on iOS', (WidgetTester tester) async {
     await tester.pumpWidget(
       new MaterialApp(
         theme: new ThemeData(platform: TargetPlatform.android),
         home: new Scaffold(
           appBar: new AppBar(
-            flexibleSpace: new FlexibleSpaceBar(
-              title: new Text('X')
-            )
+            title: new Text('X')
           )
         )
       )
@@ -33,9 +31,7 @@ void main() {
         theme: new ThemeData(platform: TargetPlatform.iOS),
         home: new Scaffold(
           appBar: new AppBar(
-            flexibleSpace: new FlexibleSpaceBar(
-              title: new Text('X')
-            )
+            title: new Text('X')
           )
         )
       )


### PR DESCRIPTION
This patch adapts the AppBar to feel more like iOS by centering the title.

Fixes #4962
