### PR TITLE
TimePicker layout tweaks

### DIFF
--- a/examples/flutter_gallery/lib/demo/dialog_demo.dart
+++ b/examples/flutter_gallery/lib/demo/dialog_demo.dart
@@ -64,6 +64,15 @@ class DialogDemo extends StatefulWidget {
 class DialogDemoState extends State<DialogDemo> {
   final GlobalKey<ScaffoldState> _scaffoldKey = new GlobalKey<ScaffoldState>();
 
+  TimeOfDay _selectedTime;
+
+  @override
+  void initState() {
+    final DateTime now = new DateTime.now();
+    _selectedTime = new TimeOfDay(hour: now.hour, minute: now.minute);
+    super.initState();
+  }
+
   void showDemoDialog/*<T>*/({ BuildContext context, Dialog dialog }) {
     showDialog/*<T>*/(
       context: context,
@@ -177,10 +186,11 @@ class DialogDemoState extends State<DialogDemo> {
             onPressed: () {
               showTimePicker(
                 context: context,
-                initialTime: const TimeOfDay(hour: 15, minute: 30)
+                initialTime: _selectedTime
               )
-              .then((TimeOfDay value) { // The value passed to Navigator.pop() or null.
-                if (value != null) {
+              .then((TimeOfDay value) {
+                if (value != _selectedTime) {
+                  _selectedTime = value;
                   _scaffoldKey.currentState.showSnackBar(new SnackBar(
                     content: new Text('You selected: $value')
                   ));

--- a/examples/flutter_gallery/lib/demo/dialog_demo.dart
+++ b/examples/flutter_gallery/lib/demo/dialog_demo.dart
@@ -68,9 +68,9 @@ class DialogDemoState extends State<DialogDemo> {
 
   @override
   void initState() {
+    super.initState();
     final DateTime now = new DateTime.now();
     _selectedTime = new TimeOfDay(hour: now.hour, minute: now.minute);
-    super.initState();
   }
 
   void showDemoDialog/*<T>*/({ BuildContext context, Dialog dialog }) {

--- a/packages/flutter/lib/src/material/time_picker.dart
+++ b/packages/flutter/lib/src/material/time_picker.dart
@@ -99,8 +99,8 @@ class TimeOfDay {
 }
 
 enum _TimePickerMode { hour, minute }
-const double _kHeaderFontSize = 65.0;
-const double _kPreferredDialExtent = 300.0;
+const double _kHeaderFontSize = 60.0;
+const double _kPreferredDialExtent = 296.0;
 
 /// A material design time picker.
 ///
@@ -250,8 +250,7 @@ class _TimePickerHeader extends StatelessWidget {
     );
 
     return new Container(
-      height: 100.0,
-      padding: const EdgeInsets.symmetric(horizontal: 24.0),
+      height: 96.0,
       decoration: new BoxDecoration(backgroundColor: backgroundColor),
       child: new Row(
         children: <Widget>[
@@ -274,7 +273,7 @@ class _TimePickerHeader extends StatelessWidget {
                     onTap: () => _handleChangeMode(_TimePickerMode.minute),
                     child: new Text(selectedTime.minuteLabel, style: minuteStyle)
                   ),
-                  new Container(width: 16.0, height: 0.0),  // Horizontal spacer
+                  new Container(width: 8.0, height: 0.0),  // Horizontal spacer
                   new GestureDetector(
                     onTap: _handleChangeDayPeriod,
                     behavior: HitTestBehavior.opaque,

--- a/packages/flutter/lib/src/material/time_picker_dialog.dart
+++ b/packages/flutter/lib/src/material/time_picker_dialog.dart
@@ -71,7 +71,16 @@ class _TimePickerDialogState extends State<_TimePickerDialog> {
 ///
 /// The returned Future resolves to the time selected by the user when the user
 /// closes the dialog. If the user cancels the dialog, the Future resolves to
-/// the initialTime.
+/// the [initialTime].
+///
+/// To show a dialog with [initialTime] equal to the current time:
+/// ```dart
+/// final DateTime now = new DateTime.now();
+/// showTimePicker(
+///   initialTime: new TimeOfDay(hour: now.hour, minute: now.minute),
+///   context: context
+/// );
+/// ```
 ///
 /// See also:
 ///


### PR DESCRIPTION
- Made some small adjustments to TimePicker dimensions based on https://github.com/android/platform_frameworks_base/blob/master/core/res/res/values/dimens_material.xml
- Made the confirmation dialog demo's "no selection" scenario keep quiet
- Added a small example to the showTimePicker() dartdoc to relate the initialTime parameter to DateTime.

Fixed #5012
Fixes #5019
