### PR TITLE
Added BorderRadius.

### DIFF
--- a/dev/benchmarks/complex_layout/lib/main.dart
+++ b/dev/benchmarks/complex_layout/lib/main.dart
@@ -412,7 +412,7 @@ class ItemImageBox extends StatelessWidget {
                   child: new Container(
                     decoration: new BoxDecoration(
                       backgroundColor: Colors.black54,
-                      borderRadius: 2.0
+                      borderRadius: new BorderRadius.circular(2.0)
                     ),
                     padding: new EdgeInsets.all(4.0),
                     child: new RichText(

--- a/examples/flutter_gallery/lib/demo/shrine/shrine_home.dart
+++ b/examples/flutter_gallery/lib/demo/shrine/shrine_home.dart
@@ -76,8 +76,7 @@ class VendorItem extends StatelessWidget {
           new SizedBox(
             width: 24.0,
             child: new ClipRRect(
-              xRadius: 12.0,
-              yRadius: 12.0,
+              borderRadius: new BorderRadius.circular(12.0),
               child: new Image.asset(vendor.avatarAsset, fit: ImageFit.cover)
             )
           ),

--- a/packages/flutter/lib/src/material/checkbox.dart
+++ b/packages/flutter/lib/src/material/checkbox.dart
@@ -119,7 +119,7 @@ class _CheckboxRenderObjectWidget extends LeafRenderObjectWidget {
 
 const double _kMidpoint = 0.5;
 const double _kEdgeSize = Checkbox.width;
-const double _kEdgeRadius = 1.0;
+const Radius _kEdgeRadius = const Radius.circular(1.0);
 const double _kStrokeWidth = 2.0;
 
 class _RenderCheckbox extends RenderToggleable {
@@ -159,7 +159,7 @@ class _RenderCheckbox extends RenderToggleable {
     double rectSize = _kEdgeSize - inset * _kStrokeWidth;
     Rect rect = new Rect.fromLTWH(offsetX + inset, offsetY + inset, rectSize, rectSize);
 
-    RRect outer = new RRect.fromRectXY(rect, _kEdgeRadius, _kEdgeRadius);
+    RRect outer = new RRect.fromRectAndRadius(rect, _kEdgeRadius);
     if (t <= 0.5) {
       // Outline
       RRect inner = outer.deflate(math.min(rectSize / 2.0, _kStrokeWidth + rectSize * t));

--- a/packages/flutter/lib/src/material/chip.dart
+++ b/packages/flutter/lib/src/material/chip.dart
@@ -112,7 +112,7 @@ class Chip extends StatelessWidget {
         padding: new EdgeInsets.only(left: leftPadding, right: rightPadding),
         decoration: new BoxDecoration(
           backgroundColor: Colors.grey[300],
-          borderRadius: 16.0
+          borderRadius: new BorderRadius.circular(16.0)
         ),
         child: new Row(
           children: children,

--- a/packages/flutter/lib/src/material/drop_down.dart
+++ b/packages/flutter/lib/src/material/drop_down.dart
@@ -37,7 +37,7 @@ class _DropDownMenuPainter extends CustomPainter {
          // configuration in the paint() function and you must provide some sort
          // of onChanged callback here.
          backgroundColor: color,
-         borderRadius: 2.0,
+         borderRadius: new BorderRadius.circular(2.0),
          boxShadow: kElevationToShadow[elevation]
        ).createBoxPainter(),
        super(repaint: resize);

--- a/packages/flutter/lib/src/material/material.dart
+++ b/packages/flutter/lib/src/material/material.dart
@@ -45,11 +45,11 @@ enum MaterialType {
 ///
 ///  * [MaterialType]
 ///  * [Material]
-const Map<MaterialType, double> kMaterialEdges = const <MaterialType, double>{
+final Map<MaterialType, BorderRadius> kMaterialEdges = <MaterialType, BorderRadius> {
   MaterialType.canvas: null,
-  MaterialType.card: 2.0,
+  MaterialType.card: new BorderRadius.circular(2.0),
   MaterialType.circle: null,
-  MaterialType.button: 2.0,
+  MaterialType.button: new BorderRadius.circular(2.0),
   MaterialType.transparency: null,
 };
 
@@ -257,8 +257,7 @@ class _MaterialState extends State<Material> {
       contents = new ClipOval(child: contents);
     } else if (kMaterialEdges[config.type] != null) {
       contents = new ClipRRect(
-        xRadius: kMaterialEdges[config.type],
-        yRadius: kMaterialEdges[config.type],
+        borderRadius: kMaterialEdges[config.type],
         child: contents
       );
     }

--- a/packages/flutter/lib/src/material/switch.dart
+++ b/packages/flutter/lib/src/material/switch.dart
@@ -334,7 +334,7 @@ class _RenderSwitch extends RenderToggleable {
       size.width - 2.0 * trackHorizontalPadding,
       _kTrackHeight
     );
-    final RRect trackRRect = new RRect.fromRectXY(trackRect, _kTrackRadius, _kTrackRadius);
+    final RRect trackRRect = new RRect.fromRectAndRadius(trackRect, const Radius.circular(_kTrackRadius));
     canvas.drawRRect(trackRRect, paint);
 
     final Point thumbPosition = new Point(

--- a/packages/flutter/lib/src/material/tooltip.dart
+++ b/packages/flutter/lib/src/material/tooltip.dart
@@ -284,7 +284,7 @@ class _TooltipOverlay extends StatelessWidget {
               child: new Container(
                 decoration: new BoxDecoration(
                   backgroundColor: Colors.grey[700],
-                  borderRadius: 2.0
+                  borderRadius: new BorderRadius.circular(2.0)
                 ),
                 height: height,
                 padding: padding,

--- a/packages/flutter/lib/src/painting/basic_types.dart
+++ b/packages/flutter/lib/src/painting/basic_types.dart
@@ -17,6 +17,7 @@ export 'dart:ui' show
   PaintingStyle,
   Path,
   Point,
+  Radius,
   RRect,
   RSTransform,
   Rect,

--- a/packages/flutter/lib/src/painting/box_painter.dart
+++ b/packages/flutter/lib/src/painting/box_painter.dart
@@ -339,7 +339,7 @@ class Border {
     Paint paint = new Paint()
       ..color = top.color;
     double radius = _getEffectiveBorderRadius(rect, borderRadius);
-    RRect outer = new RRect.fromRectXY(rect, radius, radius);
+    RRect outer = new RRect.fromRectAndRadius(rect, new Radius.circular(radius));
     double width = top.width;
     if (width == 0.0) {
       paint
@@ -347,7 +347,7 @@ class Border {
         ..strokeWidth = 0.0;
       canvas.drawRRect(outer, paint);
     } else {
-      RRect inner = new RRect.fromRectXY(rect.deflate(width), radius - width, radius - width);
+      RRect inner = new RRect.fromRectAndRadius(rect.deflate(width), new Radius.circular(radius - width));
       canvas.drawDRRect(outer, inner, paint);
     }
   }
@@ -1304,7 +1304,7 @@ class BoxDecoration extends Decoration {
     switch (shape) {
       case BoxShape.rectangle:
         if (borderRadius != null) {
-          RRect bounds = new RRect.fromRectXY(Point.origin & size, borderRadius, borderRadius);
+          RRect bounds = new RRect.fromRectAndRadius(Point.origin & size, new Radius.circular(borderRadius));
           return bounds.contains(position);
         }
         return true;
@@ -1371,7 +1371,7 @@ class _BoxDecorationPainter extends BoxPainter {
           canvas.drawRect(rect, paint);
         } else {
           double radius = _getEffectiveBorderRadius(rect, _decoration.borderRadius);
-          canvas.drawRRect(new RRect.fromRectXY(rect, radius, radius), paint);
+          canvas.drawRRect(new RRect.fromRectAndRadius(rect, new Radius.circular(radius)), paint);
         }
         break;
     }

--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -992,7 +992,7 @@ class RenderClipRRect extends RenderProxyBox {
   void paint(PaintingContext context, Offset offset) {
     if (child != null) {
       Rect rect = Point.origin & size;
-      RRect rrect = new RRect.fromRectXY(rect, xRadius, yRadius);
+      RRect rrect = new RRect.fromRectAndRadius(rect, new Radius.elliptical(xRadius, yRadius));
       context.pushClipRRect(needsCompositing, offset, rect, rrect, super.paint);
     }
   }

--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -943,45 +943,32 @@ class RenderClipRect extends _RenderCustomClip<Rect> {
 
 /// Clips its child using a rounded rectangle.
 ///
-/// Creates a rounded rectangle from its layout dimensions and the given x and
-/// y radius values and prevents its child from painting outside that rounded
+/// Creates a rounded rectangle from its layout dimensions and the given border
+/// radius and prevents its child from painting outside that rounded
 /// rectangle.
 class RenderClipRRect extends RenderProxyBox {
   /// Creates a rounded-rectangular clip.
+  ///
+  /// The [borderRadius] defaults to [BorderRadius.zero], i.e. a rectangle with
+  /// right-angled corners.
   RenderClipRRect({
     RenderBox child,
-    double xRadius,
-    double yRadius
-  }) : _xRadius = xRadius, _yRadius = yRadius, super(child) {
-    assert(_xRadius != null);
-    assert(_yRadius != null);
+    BorderRadius borderRadius: BorderRadius.zero
+  }) : _borderRadius = borderRadius, super(child) {
+    assert(_borderRadius != null);
   }
 
-  /// The radius of the rounded corners in the horizontal direction in logical pixels.
+  /// The border radius of the rounded corners..
   ///
-  /// Values are clamped to be between zero and half the width of the render
-  /// object.
-  double get xRadius => _xRadius;
-  double _xRadius;
-  set xRadius (double newXRadius) {
-    assert(newXRadius != null);
-    if (_xRadius == newXRadius)
+  /// Values are clamped so that horizontal and vertical radii sums do not
+  /// exceed width/height.
+  BorderRadius get borderRadius => _borderRadius;
+  BorderRadius _borderRadius;
+  set borderRadius (BorderRadius value) {
+    assert(value != null);
+    if (_borderRadius == value)
       return;
-    _xRadius = newXRadius;
-    markNeedsPaint();
-  }
-
-  /// The radius of the rounded corners in the vertical direction in logical pixels.
-  ///
-  /// Values are clamped to be between zero and half the height of the render
-  /// object.
-  double get yRadius => _yRadius;
-  double _yRadius;
-  set yRadius (double newYRadius) {
-    assert(newYRadius != null);
-    if (_yRadius == newYRadius)
-      return;
-    _yRadius = newYRadius;
+    _borderRadius = value;
     markNeedsPaint();
   }
 
@@ -992,7 +979,7 @@ class RenderClipRRect extends RenderProxyBox {
   void paint(PaintingContext context, Offset offset) {
     if (child != null) {
       Rect rect = Point.origin & size;
-      RRect rrect = new RRect.fromRectAndRadius(rect, new Radius.elliptical(xRadius, yRadius));
+      RRect rrect = borderRadius.toRRect(rect);
       context.pushClipRRect(needsCompositing, offset, rect, rrect, super.paint);
     }
   }

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -277,31 +277,23 @@ class ClipRRect extends SingleChildRenderObjectWidget {
   /// Creates a rounded-rectangular clip.
   ClipRRect({
     Key key,
-    @required this.xRadius,
-    @required this.yRadius,
+    @required this.borderRadius,
     Widget child
   }) : super(key: key, child: child);
 
-  /// The radius of the rounded corners in the horizontal direction in logical pixels.
+  /// The border radius of the rounded corners.
   ///
   /// Values are clamped to be between zero and half the width of the render
   /// object.
-  final double xRadius;
-
-  /// The radius of the rounded corners in the vertical direction in logical pixels.
-  ///
-  /// Values are clamped to be between zero and half the height of the render
-  /// object.
-  final double yRadius;
+  final BorderRadius borderRadius;
 
   @override
-  RenderClipRRect createRenderObject(BuildContext context) => new RenderClipRRect(xRadius: xRadius, yRadius: yRadius);
+  RenderClipRRect createRenderObject(BuildContext context) => new RenderClipRRect(borderRadius: borderRadius);
 
   @override
   void updateRenderObject(BuildContext context, RenderClipRRect renderObject) {
     renderObject
-      ..xRadius = xRadius
-      ..yRadius = yRadius;
+      ..borderRadius = borderRadius;
   }
 }
 

--- a/packages/flutter/test/ui/rrect_test.dart
+++ b/packages/flutter/test/ui/rrect_test.dart
@@ -8,40 +8,40 @@ import 'package:test/test.dart';
 
 void main() {
   test("RRect.contains()", () {
-    RRect rrect = new RRect.fromRectCustom(
+    RRect rrect = new RRect.fromRectAndCorners(
       new Rect.fromLTRB(1.0, 1.0, 2.0, 2.0),
-      new Radius.circular(0.5),
-      new Radius.circular(0.25),
-      new Radius.elliptical(0.25, 0.75),
-      Radius.zero
+      topLeft: const Radius.circular(0.5),
+      topRight: const Radius.circular(0.25),
+      bottomRight: const Radius.elliptical(0.25, 0.75),
+      bottomLeft: Radius.zero
     );
 
-    expect(rrect.contains(new Point(1.0, 1.0)), equals(false));
-    expect(rrect.contains(new Point(1.1, 1.1)), equals(false));
-    expect(rrect.contains(new Point(1.15, 1.15)), equals(true));
-    expect(rrect.contains(new Point(2.0, 1.0)), equals(false));
-    expect(rrect.contains(new Point(1.93, 1.07)), equals(false));
-    expect(rrect.contains(new Point(1.97, 1.7)), equals(false));
-    expect(rrect.contains(new Point(1.7, 1.97)), equals(true));
-    expect(rrect.contains(new Point(1.0, 1.99)), equals(true));
+    expect(rrect.contains(const Point(1.0, 1.0)), isFalse);
+    expect(rrect.contains(const Point(1.1, 1.1)), isFalse);
+    expect(rrect.contains(const Point(1.15, 1.15)), isTrue);
+    expect(rrect.contains(const Point(2.0, 1.0)), isFalse);
+    expect(rrect.contains(const Point(1.93, 1.07)), isFalse);
+    expect(rrect.contains(const Point(1.97, 1.7)), isFalse);
+    expect(rrect.contains(const Point(1.7, 1.97)), isTrue);
+    expect(rrect.contains(const Point(1.0, 1.99)), isTrue);
   });
 
   test("RRect.contains() large radii", () {
-    RRect rrect = new RRect.fromRectCustom(
+    RRect rrect = new RRect.fromRectAndCorners(
       new Rect.fromLTRB(1.0, 1.0, 2.0, 2.0),
-      new Radius.circular(5000.0),
-      new Radius.circular(2500.0),
-      new Radius.elliptical(2500.0, 7500.0),
-      Radius.zero
+      topLeft: const Radius.circular(5000.0),
+      topRight: const Radius.circular(2500.0),
+      bottomRight: const Radius.elliptical(2500.0, 7500.0),
+      bottomLeft: Radius.zero
     );
 
-    expect(rrect.contains(new Point(1.0, 1.0)), equals(false));
-    expect(rrect.contains(new Point(1.1, 1.1)), equals(false));
-    expect(rrect.contains(new Point(1.15, 1.15)), equals(true));
-    expect(rrect.contains(new Point(2.0, 1.0)), equals(false));
-    expect(rrect.contains(new Point(1.93, 1.07)), equals(false));
-    expect(rrect.contains(new Point(1.97, 1.7)), equals(false));
-    expect(rrect.contains(new Point(1.7, 1.97)), equals(true));
-    expect(rrect.contains(new Point(1.0, 1.99)), equals(true));
+    expect(rrect.contains(const Point(1.0, 1.0)), isFalse);
+    expect(rrect.contains(const Point(1.1, 1.1)), isFalse);
+    expect(rrect.contains(const Point(1.15, 1.15)), isTrue);
+    expect(rrect.contains(const Point(2.0, 1.0)), isFalse);
+    expect(rrect.contains(const Point(1.93, 1.07)), isFalse);
+    expect(rrect.contains(const Point(1.97, 1.7)), isFalse);
+    expect(rrect.contains(const Point(1.7, 1.97)), isTrue);
+    expect(rrect.contains(const Point(1.0, 1.99)), isTrue);
   });
 }

--- a/packages/flutter/test/ui/rrect_test.dart
+++ b/packages/flutter/test/ui/rrect_test.dart
@@ -1,0 +1,47 @@
+// Copyright 2015 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/painting.dart';
+
+import 'package:test/test.dart';
+
+void main() {
+  test("RRect.contains()", () {
+    RRect rrect = new RRect.fromRectCustom(
+      new Rect.fromLTRB(1.0, 1.0, 2.0, 2.0),
+      new Radius.circular(0.5),
+      new Radius.circular(0.25),
+      new Radius.elliptical(0.25, 0.75),
+      Radius.zero
+    );
+
+    expect(rrect.contains(new Point(1.0, 1.0)), equals(false));
+    expect(rrect.contains(new Point(1.1, 1.1)), equals(false));
+    expect(rrect.contains(new Point(1.15, 1.15)), equals(true));
+    expect(rrect.contains(new Point(2.0, 1.0)), equals(false));
+    expect(rrect.contains(new Point(1.93, 1.07)), equals(false));
+    expect(rrect.contains(new Point(1.97, 1.7)), equals(false));
+    expect(rrect.contains(new Point(1.7, 1.97)), equals(true));
+    expect(rrect.contains(new Point(1.0, 1.99)), equals(true));
+  });
+
+  test("RRect.contains() large radii", () {
+    RRect rrect = new RRect.fromRectCustom(
+      new Rect.fromLTRB(1.0, 1.0, 2.0, 2.0),
+      new Radius.circular(5000.0),
+      new Radius.circular(2500.0),
+      new Radius.elliptical(2500.0, 7500.0),
+      Radius.zero
+    );
+
+    expect(rrect.contains(new Point(1.0, 1.0)), equals(false));
+    expect(rrect.contains(new Point(1.1, 1.1)), equals(false));
+    expect(rrect.contains(new Point(1.15, 1.15)), equals(true));
+    expect(rrect.contains(new Point(2.0, 1.0)), equals(false));
+    expect(rrect.contains(new Point(1.93, 1.07)), equals(false));
+    expect(rrect.contains(new Point(1.97, 1.7)), equals(false));
+    expect(rrect.contains(new Point(1.7, 1.97)), equals(true));
+    expect(rrect.contains(new Point(1.0, 1.99)), equals(true));
+  });
+}

--- a/packages/flutter_markdown/lib/src/markdown_style.dart
+++ b/packages/flutter_markdown/lib/src/markdown_style.dart
@@ -33,12 +33,12 @@ class MarkdownStyle extends MarkdownStyleRaw{
     blockquotePadding: 8.0,
     blockquoteDecoration: new BoxDecoration(
       backgroundColor: Colors.blue[100],
-      borderRadius: 2.0
+      borderRadius: new BorderRadius.circular(2.0)
     ),
     codeblockPadding: 8.0,
     codeblockDecoration: new BoxDecoration(
       backgroundColor: Colors.grey[100],
-      borderRadius: 2.0
+      borderRadius: new BorderRadius.circular(2.0)
     )
   );
 
@@ -67,12 +67,12 @@ class MarkdownStyle extends MarkdownStyleRaw{
     blockquotePadding: 8.0,
     blockquoteDecoration: new BoxDecoration(
       backgroundColor: Colors.blue[100],
-      borderRadius: 2.0
+      borderRadius: new BorderRadius.circular(2.0)
     ),
     codeblockPadding: 8.0,
     codeblockDecoration: new BoxDecoration(
       backgroundColor: Colors.grey[100],
-      borderRadius: 2.0
+      borderRadius: new BorderRadius.circular(2.0)
     )
   );
 }


### PR DESCRIPTION
Changed API to use the new version of `RRect` (with the custom corner radii) and added `BorderRadius` (similar to `EdgeInsets`) to make use of these custom corner radii.

Depends on [flutter/engine/2832](https://github.com/flutter/engine/pull/2832).
