### PR TITLE
Don't rebuild routes on the second animation frame

### DIFF
--- a/packages/flutter/lib/src/material/bottom_sheet.dart
+++ b/packages/flutter/lib/src/material/bottom_sheet.dart
@@ -186,7 +186,7 @@ class _ModalBottomSheetState<T> extends State<_ModalBottomSheet<T>> {
             child: new CustomSingleChildLayout(
               delegate: new _ModalBottomSheetLayout(config.route.animation.value),
               child: new BottomSheet(
-                animationController: config.route.animation,
+                animationController: config.route._animationController,
                 onClosing: () => Navigator.pop(context),
                 builder: config.route.builder
               )
@@ -215,9 +215,13 @@ class _ModalBottomSheetRoute<T> extends PopupRoute<T> {
   @override
   Color get barrierColor => Colors.black54;
 
+  AnimationController _animationController;
+
   @override
   AnimationController createAnimationController() {
-    return BottomSheet.createAnimationController();
+    assert(_animationController == null);
+    _animationController = BottomSheet.createAnimationController();
+    return _animationController;
   }
 
   @override

--- a/packages/flutter/test/material/app_test.dart
+++ b/packages/flutter/test/material/app_test.dart
@@ -72,4 +72,49 @@ void main() {
     expect(state1, equals(state2));
     expect(state2.marker, equals('original'));
   });
+
+  testWidgets('Do not rebuild page on the second frame of the route transition', (WidgetTester tester) async {
+    int buildCounter = 0;
+    await tester.pumpWidget(
+      new MaterialApp(
+        home: new Builder(
+          builder: (BuildContext context) {
+            return new Material(
+              child: new RaisedButton(
+                child: new Text('X'),
+                onPressed: () { Navigator.of(context).pushNamed('/next'); }
+              )
+            );
+          }
+        ),
+        routes: <String, WidgetBuilder>{
+          '/next': (BuildContext context) {
+            return new Builder(
+              builder: (BuildContext context) {
+                ++buildCounter;
+                return new Container();
+              }
+            );
+          }
+        }
+      )
+    );
+
+    expect(buildCounter, 0);
+    await tester.tap(find.text('X'));
+    expect(buildCounter, 0);
+    await tester.pump();
+    expect(buildCounter, 1);
+    await tester.pump(const Duration(milliseconds: 10));
+    expect(buildCounter, 1);
+    await tester.pump(const Duration(milliseconds: 10));
+    expect(buildCounter, 1);
+    await tester.pump(const Duration(milliseconds: 10));
+    expect(buildCounter, 1);
+    await tester.pump(const Duration(milliseconds: 10));
+    expect(buildCounter, 1);
+    await tester.pump(const Duration(seconds: 1));
+    expect(buildCounter, 2);
+  });
+
 }


### PR DESCRIPTION
Previously we would rebuild every route on the second animation frame to
rejigger the offstage bit and the animations. Now we build the page once and
update the offstage bit in place and update the animations using
ProxyAnimations.
