### PR TITLE
Add loader screen for --hot mode

### DIFF
--- a/packages/flutter/bin/loader/README.md
+++ b/packages/flutter/bin/loader/README.md
@@ -1,0 +1,3 @@
+This directory contains a small Flutter application that is run while
+an application is being copied onto the device.
+

--- a/packages/flutter/bin/loader/loader_app.dart
+++ b/packages/flutter/bin/loader/loader_app.dart
@@ -1,0 +1,19 @@
+import 'package:flutter/material.dart';
+
+void main() {
+  runApp(new MaterialApp(
+      title: 'Flutter Initial Load',
+      home: new Scaffold(
+        body: new Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: <Widget>[
+              new Text('Loading application onto device...',
+                       style: new TextStyle(fontSize: 24.0)),
+              new CircularProgressIndicator(value: null)
+            ]
+        )
+      )
+    )
+  );
+}
+

--- a/packages/flutter_tools/lib/src/asset.dart
+++ b/packages/flutter_tools/lib/src/asset.dart
@@ -37,6 +37,7 @@ class AssetBundleEntry {
   }
 
   bool get isStringEntry => _contents != null;
+  int get contentsLength => _contents.length;
 
   final File file;
   final String _contents;


### PR DESCRIPTION
- [x] Add lib/loader.dart and exclude it from analysis because we don't depend on package:flutter.
- [x] Build the APK with the loader.dart script instead of the actual script.
- [x] Tweak some status messages and output the number of MBs copied onto the device.
- [x] Only write assets that have been modified.
