### PR TITLE
More gallery tweaks

### DIFF
--- a/examples/flutter_gallery/lib/demo/contacts_demo.dart
+++ b/examples/flutter_gallery/lib/demo/contacts_demo.dart
@@ -82,7 +82,7 @@ class ContactsDemo extends StatefulWidget {
 class ContactsDemoState extends State<ContactsDemo> {
   final GlobalKey<ScaffoldState> _scaffoldKey = new GlobalKey<ScaffoldState>();
   final double _appBarHeight = 256.0;
-  AppBarBehavior _appBarBehavior = AppBarBehavior.scroll;
+  AppBarBehavior _appBarBehavior = AppBarBehavior.under;
 
   @override
   Widget build(BuildContext context) {

--- a/packages/flutter/lib/src/material/progress_indicator.dart
+++ b/packages/flutter/lib/src/material/progress_indicator.dart
@@ -54,11 +54,11 @@ abstract class ProgressIndicator extends StatefulWidget {
   /// color use: `new AlwaysStoppedAnimation<Color>(color)`.
   ///
   /// If null, the progress indicator is rendered with the current theme's
-  /// [ThemeData.primaryColor].
+  /// [ThemeData.accentColor].
   final Animation<Color> valueColor;
 
   Color _getBackgroundColor(BuildContext context) => backgroundColor ?? Theme.of(context).backgroundColor;
-  Color _getValueColor(BuildContext context) => valueColor?.value ?? Theme.of(context).primaryColor;
+  Color _getValueColor(BuildContext context) => valueColor?.value ?? Theme.of(context).accentColor;
 
   @override
   void debugFillDescription(List<String> description) {

--- a/packages/flutter/lib/src/material/refresh_indicator.dart
+++ b/packages/flutter/lib/src/material/refresh_indicator.dart
@@ -125,7 +125,7 @@ class RefreshIndicator extends StatefulWidget {
   final RefreshIndicatorLocation location;
 
   /// The progress indicator's foreground color. The current theme's
-  /// [ThemeData.primaryColor] by default.
+  /// [ThemeData.accentColor] by default.
   final Color color;
 
   /// The progress indicator's background color. The current theme's
@@ -168,8 +168,8 @@ class RefreshIndicatorState extends State<RefreshIndicator> {
 
     // Fully opaque when we've reached config.displacement.
     _valueColor = new ColorTween(
-      begin: (config.color ?? theme.primaryColor).withOpacity(0.0),
-      end: (config.color ?? theme.primaryColor).withOpacity(1.0)
+      begin: (config.color ?? theme.accentColor).withOpacity(0.0),
+      end: (config.color ?? theme.accentColor).withOpacity(1.0)
     )
     .animate(new CurvedAnimation(
       parent: _sizeController,


### PR DESCRIPTION
- Contacts demo: scroll under the app bar by default.
- Make progress indicators' valueColor the accentColor (not the primaryColor) by default. So that they can be seen in the dark theme.

Fixes #5119
