### PR TITLE
Remove drawer history entry when drawer is disposed.

### DIFF
--- a/packages/flutter/lib/src/material/drawer.dart
+++ b/packages/flutter/lib/src/material/drawer.dart
@@ -122,6 +122,7 @@ class DrawerControllerState extends State<DrawerController> {
 
   @override
   void dispose() {
+    _historyEntry?.remove();
     _controller
       ..removeListener(_animationChanged)
       ..removeStatusListener(_animationStatusChanged)


### PR DESCRIPTION
BUG=https://github.com/flutter/flutter/issues/5103
