### PR TITLE
OverscrollIndicator tracks horizontal drag input, etc

### DIFF
--- a/packages/flutter/lib/src/gestures/drag.dart
+++ b/packages/flutter/lib/src/gestures/drag.dart
@@ -56,7 +56,8 @@ class DragUpdateDetails {
   /// coordinates of [delta] and the other coordinate must be zero.
   DragUpdateDetails({
     this.delta: Offset.zero,
-    this.primaryDelta
+    this.primaryDelta,
+    this.globalPosition
   }) {
     assert(primaryDelta == null
         || (primaryDelta == delta.dx && delta.dy == 0.0)
@@ -79,6 +80,9 @@ class DragUpdateDetails {
   /// respectively). Otherwise, if the [GestureDragUpdateCallback] is for a
   /// two-dimensional drag (e.g., a pan), then this value is null.
   final double primaryDelta;
+
+  /// The pointer's global position.
+  final Point globalPosition;
 }
 
 /// Signature for when a pointer that is in contact with the screen and moving
@@ -184,7 +188,8 @@ abstract class DragGestureRecognizer extends OneSequenceGestureRecognizer {
         if (onUpdate != null) {
           onUpdate(new DragUpdateDetails(
             delta: _getDeltaForDetails(delta),
-            primaryDelta: _getPrimaryDeltaForDetails(delta)
+            primaryDelta: _getPrimaryDeltaForDetails(delta),
+            globalPosition: event.position
           ));
         }
       } else {

--- a/packages/flutter/lib/src/material/overscroll_indicator.dart
+++ b/packages/flutter/lib/src/material/overscroll_indicator.dart
@@ -23,7 +23,7 @@ const Duration _kTimeoutDuration = const Duration(milliseconds: 500);
 // Fade-out duration if the fade-out was triggered by the timer.
 const Duration _kTimeoutHideDuration = const Duration(milliseconds: 2000);
 
-// Fade-out duration if the fade-out was triggered by an "up" gesture.
+// Fade-out duration if the fade-out was triggered by an input gesture.
 const Duration _kNormalHideDuration = const Duration(milliseconds: 600);
 
 

--- a/packages/flutter/lib/src/widgets/scrollable.dart
+++ b/packages/flutter/lib/src/widgets/scrollable.dart
@@ -365,7 +365,7 @@ class ScrollableState<T extends Scrollable> extends State<T> {
     _setScrollOffset(_controller.value);
   }
 
-  void _setScrollOffset(double newScrollOffset) {
+  void _setScrollOffset(double newScrollOffset, [DragUpdateDetails details]) {
     if (_scrollOffset == newScrollOffset)
       return;
     setState(() {
@@ -374,6 +374,7 @@ class ScrollableState<T extends Scrollable> extends State<T> {
     PageStorage.of(context)?.writeState(context, _scrollOffset);
     _startScroll();
     dispatchOnScroll();
+    new ScrollNotification(this, ScrollNotificationKind.updated, details).dispatch(context);
     _endScroll();
   }
 
@@ -381,9 +382,13 @@ class ScrollableState<T extends Scrollable> extends State<T> {
   ///
   /// If a non-null [duration] is provided, the widget will animate to the new
   /// scroll offset over the given duration with the given curve.
-  Future<Null> scrollBy(double scrollDelta, { Duration duration, Curve curve: Curves.ease }) {
+  Future<Null> scrollBy(double scrollDelta, {
+    Duration duration,
+    Curve curve: Curves.ease,
+    DragUpdateDetails details
+  }) {
     double newScrollOffset = scrollBehavior.applyCurve(_scrollOffset, scrollDelta);
-    return scrollTo(newScrollOffset, duration: duration, curve: curve);
+    return scrollTo(newScrollOffset, duration: duration, curve: curve, details: details);
   }
 
   /// Scroll this widget to the given scroll offset.
@@ -394,13 +399,17 @@ class ScrollableState<T extends Scrollable> extends State<T> {
   /// This function does not accept a zero duration. To jump-scroll to
   /// the new offset, do not provide a duration, rather than providing
   /// a zero duration.
-  Future<Null> scrollTo(double newScrollOffset, { Duration duration, Curve curve: Curves.ease }) {
+  Future<Null> scrollTo(double newScrollOffset, {
+    Duration duration,
+    Curve curve: Curves.ease,
+    DragUpdateDetails details
+  }) {
     if (newScrollOffset == _scrollOffset)
       return new Future<Null>.value();
 
     if (duration == null) {
       _stop();
-      _setScrollOffset(newScrollOffset);
+      _setScrollOffset(newScrollOffset, details);
       return new Future<Null>.value();
     }
 
@@ -549,7 +558,6 @@ class ScrollableState<T extends Scrollable> extends State<T> {
     assert(_numberOfInProgressScrolls > 0);
     if (config.onScroll != null)
       config.onScroll(_scrollOffset);
-    new ScrollNotification(this, ScrollNotificationKind.updated).dispatch(context);
   }
 
   void _handleDragDown(_) {
@@ -563,13 +571,15 @@ class ScrollableState<T extends Scrollable> extends State<T> {
   }
 
   void _handleDragStart(DragStartDetails details) {
-    _startScroll();
+    _startScroll(details);
   }
 
-  void _startScroll() {
+  void _startScroll([DragStartDetails details]) {
     _numberOfInProgressScrolls += 1;
-    if (_numberOfInProgressScrolls == 1)
+    if (_numberOfInProgressScrolls == 1) {
       dispatchOnScrollStart();
+      new ScrollNotification(this, ScrollNotificationKind.started, details).dispatch(context);
+    }
   }
 
   /// Calls the onScrollStart callback.
@@ -579,23 +589,26 @@ class ScrollableState<T extends Scrollable> extends State<T> {
     assert(_numberOfInProgressScrolls == 1);
     if (config.onScrollStart != null)
       config.onScrollStart(_scrollOffset);
-    new ScrollNotification(this, ScrollNotificationKind.started).dispatch(context);
   }
 
   void _handleDragUpdate(DragUpdateDetails details) {
-    scrollBy(pixelOffsetToScrollOffset(details.primaryDelta));
+    scrollBy(pixelOffsetToScrollOffset(details.primaryDelta), details: details);
   }
 
   void _handleDragEnd(DragEndDetails details) {
     final double scrollVelocity = pixelDeltaToScrollOffset(details.velocity.pixelsPerSecond);
-    fling(scrollVelocity).then(_endScroll);
+    fling(scrollVelocity).then((Null value) {
+      _endScroll(value, details);
+    });
   }
 
-  Null _endScroll([Null _]) {
+  Null _endScroll([Null _, DragEndDetails details]) {
     _numberOfInProgressScrolls -= 1;
     if (_numberOfInProgressScrolls == 0) {
       _simulation = null;
       dispatchOnScrollEnd();
+      if (mounted)
+        new ScrollNotification(this, ScrollNotificationKind.ended, details).dispatch(context);
     }
     return null;
   }
@@ -607,8 +620,6 @@ class ScrollableState<T extends Scrollable> extends State<T> {
     assert(_numberOfInProgressScrolls == 0);
     if (config.onScrollEnd != null)
       config.onScrollEnd(_scrollOffset);
-    if (mounted)
-      new ScrollNotification(this, ScrollNotificationKind.ended).dispatch(context);
   }
 
   final GlobalKey<RawGestureDetectorState> _gestureDetectorKey = new GlobalKey<RawGestureDetectorState>();
@@ -716,13 +727,25 @@ enum ScrollNotificationKind {
 /// * [NotificationListener]
 class ScrollNotification extends Notification {
   /// Creates a notification about scrolling.
-  ScrollNotification(this.scrollable, this.kind);
+  ScrollNotification(this.scrollable, this.kind, [dynamic details]) : _details = details {
+    assert(scrollable != null);
+    assert(kind != null);
+    assert(details == null
+        || (kind == ScrollNotificationKind.started && details is DragStartDetails)
+        || (kind == ScrollNotificationKind.updated && details is DragUpdateDetails)
+        || (kind == ScrollNotificationKind.ended && details is DragEndDetails));
+  }
 
   /// Indicates if we're at the start, middle, or end of a scroll.
   final ScrollNotificationKind kind;
 
   /// The scrollable that scrolled.
   final ScrollableState scrollable;
+
+  DragStartDetails get dragStartDetails => kind == ScrollNotificationKind.started ? _details : null;
+  DragUpdateDetails get dragUpdateDetails => kind == ScrollNotificationKind.updated ? _details : null;
+  DragEndDetails get dragEndDetails => kind == ScrollNotificationKind.ended ? _details : null;
+  final dynamic _details;
 
   /// The number of scrollable widgets that have already received this
   /// notification. Typically listeners only respond to notifications

--- a/packages/flutter/test/widget/scroll_notification_test.dart
+++ b/packages/flutter/test/widget/scroll_notification_test.dart
@@ -23,16 +23,29 @@ void main() {
     await tester.pump(const Duration(seconds: 1));
     expect(notification.kind, equals(ScrollNotificationKind.started));
     expect(notification.depth, equals(0));
+    expect(notification.dragStartDetails, isNotNull);
+    expect(notification.dragStartDetails.globalPosition, equals(new Point(100.0, 100.0)));
+    expect(notification.dragUpdateDetails, isNull);
+    expect(notification.dragEndDetails, isNull);
 
     await gesture.moveBy(new Offset(-10.0, -10.0));
     await tester.pump(const Duration(seconds: 1));
     expect(notification.kind, equals(ScrollNotificationKind.updated));
     expect(notification.depth, equals(0));
+    expect(notification.dragStartDetails, isNull);
+    expect(notification.dragUpdateDetails, isNotNull);
+    expect(notification.dragUpdateDetails.globalPosition, equals(new Point(90.0, 90.0)));
+    expect(notification.dragUpdateDetails.delta, equals(new Offset(0.0, -10.0)));
+    expect(notification.dragEndDetails, isNull);
 
     await gesture.up();
     await tester.pump(const Duration(seconds: 1));
     expect(notification.kind, equals(ScrollNotificationKind.ended));
     expect(notification.depth, equals(0));
+    expect(notification.dragStartDetails, isNull);
+    expect(notification.dragUpdateDetails, isNull);
+    expect(notification.dragEndDetails, isNotNull);
+    expect(notification.dragEndDetails.velocity, equals(Velocity.zero));
   });
 
   testWidgets('Scroll notifcation depth', (WidgetTester tester) async {


### PR DESCRIPTION
The overscroll indicator now appears and behaves just about the same as the native version.
- The overscroll indicator now tracks the drag's position in the cross-axis direction.
- The indicator is rendered with a circle instead of a bezier.
- Previously the indicator always faded-out in 200ms. Now if the overscroll ends normally then the fade-out animation's duration is 600ms. If the indicator times out instead, then the fade-out animation's duration is 2 seconds.
- ScrollNotifications now include gesture details to enable tracking the input gesture's cross-axis location and DragUpdateDetails includes the pointer's global position.

Fixes: #3327
Fixes: #4129
Fixes: #4406
Fixes: #4129
