### PR TITLE
Hot reload UI polish

### DIFF
--- a/packages/flutter/bin/loader/loader_app.dart
+++ b/packages/flutter/bin/loader/loader_app.dart
@@ -1,19 +1,104 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 
+String message = 'Flutter Debug Loader';
+String explanation = 'Please stand by...';
+double progress = 0.0;
+double progressMax = 0.0;
+StateSetter setState = (VoidCallback fn) => fn();
+Timer connectionTimeout;
+
 void main() {
-  runApp(new MaterialApp(
-      title: 'Flutter Initial Load',
+  new LoaderBinding();
+  runApp(
+    new MaterialApp(
+      title: 'Flutter Debug Loader',
+      debugShowCheckedModeBanner: false,
       home: new Scaffold(
-        body: new Column(
-            mainAxisAlignment: MainAxisAlignment.center,
-            children: <Widget>[
-              new Text('Loading application onto device...',
-                       style: new TextStyle(fontSize: 24.0)),
-              new CircularProgressIndicator(value: null)
-            ]
+        body: new StatefulBuilder(
+          builder: (BuildContext context, StateSetter setStateRef) {
+            setState = setStateRef;
+            return new Column(
+              children: <Widget>[
+                new Flexible(
+                  child: new Container() // TODO(ianh): replace this with our logo in a Center box
+                ),
+                new Flexible(
+                  child: new Builder(
+                    builder: (BuildContext context) {
+                      List<Widget> children = <Widget>[];
+                      children.add(new Text(
+                        message,
+                        style: new TextStyle(fontSize: 24.0),
+                        textAlign: TextAlign.center
+                      ));
+                      if (progressMax >= 0.0) {
+                        children.add(new SizedBox(height: 18.0));
+                        children.add(new Center(child: new CircularProgressIndicator(value: progressMax > 0 ? progress / progressMax : null)));
+                      }
+                      return new Block(children: children);
+                    }
+                  )
+                ),
+                new Flexible(
+                  child: new Block(
+                    padding: new EdgeInsets.symmetric(horizontal: 16.0),
+                    children: <Widget>[ new Text(explanation, textAlign: TextAlign.center) ]
+                  )
+                ),
+              ]
+            );
+          }
         )
       )
     )
   );
+  connectionTimeout = new Timer(const Duration(seconds: 8), () {
+    setState(() {
+      explanation =
+        'This is a hot-reload-enabled debug-mode Flutter application. '
+        'To launch this application, please use the "flutter run" command. '
+        'To be able to launch a Flutter application in debug mode from the '
+        'device, please use "flutter run --no-hot". To install a release '
+        'mode build of this application on your device, use "flutter install".';
+      progressMax = -1.0;
+    });
+  });
 }
 
+class LoaderBinding extends WidgetsFlutterBinding {
+  @override
+  void initServiceExtensions() {
+    super.initServiceExtensions();
+    registerStringServiceExtension(
+      name: 'loaderShowMessage',
+      getter: () => message,
+      setter: (String value) {
+        connectionTimeout?.cancel();
+        connectionTimeout = null;
+        setState(() {
+          message = value;
+        });
+      }
+    );
+    registerNumericServiceExtension(
+      name: 'loaderSetProgress',
+      getter: () => progress,
+      setter: (double value) {
+        setState(() {
+          progress = value;
+        });
+      }
+    );
+    registerNumericServiceExtension(
+      name: 'loaderSetProgressMax',
+      getter: () => progressMax,
+      setter: (double value) {
+        setState(() {
+          progressMax = value;
+        });
+      }
+    );
+  }
+}

--- a/packages/flutter/lib/src/foundation/binding.dart
+++ b/packages/flutter/lib/src/foundation/binding.dart
@@ -203,6 +203,34 @@ abstract class BindingBase {
     );
   }
 
+  /// Registers a service extension method with the given name (full name
+  /// "ext.flutter.name"), which optionally takes a single argument with the
+  /// name "value". If the argument is omitted, the value is to be read,
+  /// otherwise it is to be set. Returns the current value.
+  ///
+  /// Calls the `getter` callback to obtain the value when
+  /// responding to the service extension method being called.
+  ///
+  /// Calls the `setter` callback with the new value when the
+  /// service extension method is called with a new value.
+  void registerStringServiceExtension({
+    @required String name,
+    @required ValueGetter<String> getter,
+    @required ValueSetter<String> setter
+  }) {
+    assert(name != null);
+    assert(getter != null);
+    assert(setter != null);
+    registerServiceExtension(
+      name: name,
+      callback: (Map<String, String> parameters) async {
+        if (parameters.containsKey('value'))
+          setter(parameters['value']);
+        return <String, dynamic>{ 'value': getter() };
+      }
+    );
+  }
+
   /// Registers a service extension method with the given name (full
   /// name "ext.flutter.name"). The given callback is called when the
   /// extension method is called. The callback must return a [Future]

--- a/packages/flutter/lib/src/rendering/binding.dart
+++ b/packages/flutter/lib/src/rendering/binding.dart
@@ -56,13 +56,10 @@ abstract class RendererBinding extends BindingBase implements SchedulerBinding, 
       return true;
     });
 
-    assert(() {
-      registerSignalServiceExtension(
-        name: 'debugDumpRenderTree',
-        callback: debugDumpRenderTree
-      );
-      return true;
-    });
+    registerSignalServiceExtension(
+      name: 'debugDumpRenderTree',
+      callback: debugDumpRenderTree
+    );
 
     assert(() {
       // this service extension only works in checked mode

--- a/packages/flutter_tools/lib/src/base/logger.dart
+++ b/packages/flutter_tools/lib/src/base/logger.dart
@@ -13,6 +13,7 @@ abstract class Logger {
 
   bool quiet = false;
 
+  bool get supportsColor => terminal.supportsColor;
   set supportsColor(bool value) {
     terminal.supportsColor = value;
   }
@@ -76,7 +77,7 @@ class StdoutLogger extends Logger {
     _status?.cancel();
     _status = null;
 
-    if (terminal.supportsColor) {
+    if (supportsColor) {
       _status = new _AnsiStatus(message);
       return _status;
     } else {

--- a/packages/flutter_tools/lib/src/commands/run.dart
+++ b/packages/flutter_tools/lib/src/commands/run.dart
@@ -63,7 +63,7 @@ class RunCommand extends RunCommandBase {
     argParser.addFlag('hot',
                       negatable: false,
                       defaultsTo: false,
-                      help: 'Run with support for hot reloading.');
+                      help: 'Run with support for hot reloading. Requires resident.');
 
     // Hidden option to enable a benchmarking mode. This will run the given
     // application, measure the startup time and the app restart time, write the

--- a/packages/flutter_tools/lib/src/observatory.dart
+++ b/packages/flutter_tools/lib/src/observatory.dart
@@ -9,6 +9,8 @@ import 'dart:io';
 import 'package:json_rpc_2/json_rpc_2.dart' as rpc;
 import 'package:web_socket_channel/io.dart';
 
+import 'globals.dart';
+
 // TODO(johnmccutchan): Rename this class to ServiceProtocol or VmService.
 class Observatory {
   Observatory._(this.peer, this.port) {
@@ -202,6 +204,38 @@ class Observatory {
     return peer.sendRequest('ext.flutter.debugDumpRenderTree', <String, dynamic>{
       'isolateId': isolateId
     }).then((dynamic result) => new Response(result));
+  }
+
+  // Loader page extension methods.
+
+  Future<Response> flutterLoaderShowMessage(String isolateId, String message) {
+    return peer.sendRequest('ext.flutter.loaderShowMessage', <String, dynamic>{
+      'isolateId': isolateId,
+      'value': message
+    }).then(
+      (dynamic result) => new Response(result),
+      onError: (dynamic exception) { printTrace('ext.flutter.loaderShowMessage: $exception'); }
+    );
+  }
+
+  Future<Response> flutterLoaderSetProgress(String isolateId, double progress) {
+    return peer.sendRequest('ext.flutter.loaderSetProgress', <String, dynamic>{
+      'isolateId': isolateId,
+      'loaderSetProgress': progress
+    }).then(
+      (dynamic result) => new Response(result),
+      onError: (dynamic exception) { printTrace('ext.flutter.loaderSetProgress: $exception'); }
+    );
+  }
+
+  Future<Response> flutterLoaderSetProgressMax(String isolateId, double max) {
+    return peer.sendRequest('ext.flutter.loaderSetProgressMax', <String, dynamic>{
+      'isolateId': isolateId,
+      'loaderSetProgressMax': max
+    }).then(
+      (dynamic result) => new Response(result),
+      onError: (dynamic exception) { printTrace('ext.flutter.loaderSetProgressMax: $exception'); }
+    );
   }
 
   /// Causes the application to pick up any changed code.

--- a/packages/flutter_tools/test/devfs_test.dart
+++ b/packages/flutter_tools/test/devfs_test.dart
@@ -58,17 +58,17 @@ void main() {
       expect(devFSOperations.contains('deleteFile test bar/foo.txt'), isTrue);
     });
     testUsingContext('add file in an asset bundle', () async {
-      await devFS.update(assetBundle);
+      await devFS.update(bundle: assetBundle);
       expect(devFSOperations.contains('writeFile test build/flx/a.txt'), isTrue);
     });
     testUsingContext('add a file to the asset bundle', () async {
       assetBundle.entries.add(new AssetBundleEntry.fromString('b.txt', ''));
-      await devFS.update(assetBundle);
+      await devFS.update(bundle: assetBundle);
       expect(devFSOperations.contains('writeFile test build/flx/b.txt'), isTrue);
     });
     testUsingContext('delete a file from the asset bundle', () async {
       assetBundle.entries.clear();
-      await devFS.update(assetBundle);
+      await devFS.update(bundle: assetBundle);
       expect(devFSOperations.contains('deleteFile test build/flx/b.txt'), isTrue);
     });
     testUsingContext('delete dev file system', () async {


### PR DESCRIPTION
General improvoments to the loader app:
- Show a message after 8 seconds if no connection comes in.
- Show a progress bar as files are being uploaded.
- Hide the spinner just before launching the application.

General improvements to the "flutter run" UI:
- Add "?" key as a silent alias for "h".
- Make the help text bold so it doesn't get mixed with the logs.
- Make "R" do a cold restart when hot reload is enabled.

Supporting features and bug fixes:
- Add support for string service extensions.

Other bug fixes:
- Expose debugDumpRenderTree() outside debug mode.
- Logger.supportsColor was missing a getter.
- Mention in the usage docs that --hot requires --resident.
- Trivial style fixes.
