### PR TITLE
Dispose AnimationController in examples

### DIFF
--- a/examples/layers/services/isolate.dart
+++ b/examples/layers/services/isolate.dart
@@ -228,6 +228,12 @@ class IsolateExampleState extends State<StatefulWidget> {
   }
 
   @override
+  void dispose() {
+    _animation.dispose();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
     return new Material(
       child: new Column(

--- a/examples/layers/widgets/spinning_square.dart
+++ b/examples/layers/widgets/spinning_square.dart
@@ -24,6 +24,12 @@ class _SpinningSquareState extends State<SpinningSquare> {
   }
 
   @override
+  void dispose() {
+    _animation.dispose();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
     return new RotationTransition(
       turns: _animation,


### PR DESCRIPTION
These examples should show the best practices for working with
AnimationControllers.

Fixes #5206
