### PR TITLE
remove the --resident flag

### DIFF
--- a/packages/flutter_tools/lib/src/commands/run.dart
+++ b/packages/flutter_tools/lib/src/commands/run.dart
@@ -55,15 +55,11 @@ class RunCommand extends RunCommandBase {
         help: 'Listen to the given port for a debug connection (defaults to $kDefaultObservatoryPort).');
     usesPubOption();
 
-    argParser.addFlag('resident',
-        defaultsTo: true,
-        help: 'Don\'t terminate the \'flutter run\' process after starting the application.');
-
     // Option to enable hot reloading.
     argParser.addFlag('hot',
                       negatable: false,
                       defaultsTo: false,
-                      help: 'Run with support for hot reloading. Requires resident.');
+                      help: 'Run with support for hot reloading.');
 
     // Hidden option to enable a benchmarking mode. This will run the given
     // application, measure the startup time and the app restart time, write the
@@ -131,34 +127,18 @@ class RunCommand extends RunCommandBase {
       }
     }
 
-    if (argResults['resident']) {
-      RunAndStayResident runner = new RunAndStayResident(
-        deviceForCommand,
-        target: targetFile,
-        debuggingOptions: options,
-        hotMode: argResults['hot']
-      );
+    RunAndStayResident runner = new RunAndStayResident(
+      deviceForCommand,
+      target: targetFile,
+      debuggingOptions: options,
+      hotMode: argResults['hot']
+    );
 
-      return runner.run(
-        traceStartup: traceStartup,
-        benchmark: argResults['benchmark'],
-        route: route
-      );
-    } else {
-      // TODO(devoncarew): Remove this path and support the `--no-resident` option
-      // using the `RunAndStayResident` class.
-      return startApp(
-        deviceForCommand,
-        target: targetFile,
-        stop: argResults['full-restart'],
-        install: true,
-        debuggingOptions: options,
-        traceStartup: traceStartup,
-        benchmark: argResults['benchmark'],
-        route: route,
-        buildMode: getBuildMode()
-      );
-    }
+    return runner.run(
+      traceStartup: traceStartup,
+      benchmark: argResults['benchmark'],
+      route: route
+    );
   }
 }
 

--- a/packages/flutter_tools/lib/src/run.dart
+++ b/packages/flutter_tools/lib/src/run.dart
@@ -65,6 +65,8 @@ class RunAndStayResident {
 
   Observatory observatory;
 
+  bool get observatoryConnected => observatory != null;
+
   /// Start the app and keep the process running during its lifetime.
   Future<int> run({
     bool traceStartup: false,
@@ -277,7 +279,7 @@ class RunAndStayResident {
           if (lower == 'h' || lower == '?' || code == AnsiTerminal.KEY_F1) {
             // F1, help
             _printHelp();
-          } else if (lower == 'r' || code == AnsiTerminal.KEY_F5) {
+          } else if ((lower == 'r' || code == AnsiTerminal.KEY_F5) && observatoryConnected) {
             // F5, restart
             if (hotMode && code == 'r') {
               // lower-case 'r'
@@ -290,9 +292,9 @@ class RunAndStayResident {
           } else if (lower == 'q' || code == AnsiTerminal.KEY_F10) {
             // F10, exit
             _stopApp();
-          } else if (lower == 'w') {
+          } else if (lower == 'w' && observatoryConnected) {
             _debugDumpApp();
-          } else if (lower == 't') {
+          } else if (lower == 't' && observatoryConnected) {
             _debugDumpRenderTree();
           }
         });
@@ -437,7 +439,7 @@ class RunAndStayResident {
     String cold = '';
     if (hotMode)
       hot = 'Type "r" or F5 to perform a hot reload of the app';
-    if (device.supportsRestart) {
+    if (device.supportsRestart && debuggingOptions.buildMode == BuildMode.debug) {
       if (hotMode) {
         cold = ', and "R" to cold restart the app';
       } else {
@@ -446,7 +448,8 @@ class RunAndStayResident {
     }
     if (hot != '' || cold != '')
       printStatus('$hot$cold.', emphasis: true);
-    printStatus('Type "w" to print the widget hierarchy of the app, and "t" for the render tree.', emphasis: true);
+    if (observatoryConnected)
+      printStatus('Type "w" to print the widget hierarchy of the app, and "t" for the render tree.', emphasis: true);
   }
 
   Future<dynamic> _stopLogger() {


### PR DESCRIPTION
- remove the `--resident` flag from flutter run (just default to always running in that mode)
- make sure we don't offer to reload if we're not in debug mode
- make sure we don't offer to dump widget information if there's no observatory connection
- fix https://github.com/flutter/flutter/issues/5224
