### PR TITLE
Add a repaint boundary to the cards on the shrine order page

### DIFF
--- a/examples/flutter_gallery/lib/demo/shrine/shrine_order.dart
+++ b/examples/flutter_gallery/lib/demo/shrine/shrine_order.dart
@@ -196,10 +196,15 @@ class _OrderPageState extends State<OrderPage> {
             children: config.products
               .where((Product product) => product != config.order.product)
               .map((Product product) {
-              return new Card(
-                elevation: 0,
-                child: new Image.asset(product.imageAsset, fit: ImageFit.contain)
-              );
+                return new RepaintBoundary(
+                  child: new Card(
+                    elevation: 1,
+                    child: new Image.asset(
+                      product.imageAsset,
+                      fit: ImageFit.contain
+                    )
+                  )
+                );
             }).toList()
           )
         ]


### PR DESCRIPTION
Improve scrolling performance by adding a repaint boundary and (to effectively set the RenderObject's isComplex hint) to improve raster caching, add a shadow to the cards on the Shrine order page.
