### PR TITLE
Set the ScrollConfiguration for dropdown menus

### DIFF
--- a/examples/flutter_gallery/flutter.yaml
+++ b/examples/flutter_gallery/flutter.yaml
@@ -25,7 +25,6 @@ assets:
   - packages/flutter_gallery_assets/pesto/image9.jpg
   - packages/flutter_gallery_assets/pesto/logo_small.png
   - packages/flutter_gallery_assets/pesto/logo_medium.png
-  - packages/flutter_gallery_assets/pesto/logo_big.png
   - packages/flutter_gallery_assets/pesto/fish.png
   - packages/flutter_gallery_assets/pesto/healthy.png
   - packages/flutter_gallery_assets/pesto/main.png

--- a/examples/flutter_gallery/lib/demo/pesto_demo.dart
+++ b/examples/flutter_gallery/lib/demo/pesto_demo.dart
@@ -12,8 +12,7 @@ const String _kUserImage = 'packages/flutter_gallery_assets/pesto/avatar.jpg';
 // Map of logo images keyed by the minimum height their container needs to be.
 final Map<double, String> _kLogoImages = <double, String>{
   0.0: 'packages/flutter_gallery_assets/pesto/logo_small.png',
-  70.0: 'packages/flutter_gallery_assets/pesto/logo_medium.png',
-  170.0: 'packages/flutter_gallery_assets/pesto/logo_big.png',
+  70.0: 'packages/flutter_gallery_assets/pesto/logo_medium.png'
 };
 
 final ThemeData _kTheme = new ThemeData(

--- a/packages/flutter/lib/src/material/drop_down.dart
+++ b/packages/flutter/lib/src/material/drop_down.dart
@@ -78,10 +78,12 @@ class _DropDownMenuPainter extends CustomPainter {
 // Do not use the platform-specific default scroll configuration.
 // Dropdown menus should never overscroll or display an overscroll indicator.
 class _DropDownScrollConfigurationDelegate extends ScrollConfigurationDelegate {
+  const _DropDownScrollConfigurationDelegate();
+
   @override
   Widget wrapScrollWidget(Widget scrollWidget) => new ClampOverscrolls(value: true, child: scrollWidget);
 }
-final ScrollConfigurationDelegate _dropDownScroll = new _DropDownScrollConfigurationDelegate();
+final ScrollConfigurationDelegate _dropDownScroll = const _DropDownScrollConfigurationDelegate();
 
 class _DropDownMenu<T> extends StatefulWidget {
   _DropDownMenu({

--- a/packages/flutter/lib/src/material/drop_down.dart
+++ b/packages/flutter/lib/src/material/drop_down.dart
@@ -75,6 +75,14 @@ class _DropDownMenuPainter extends CustomPainter {
   }
 }
 
+// Do not use the platform-specific default scroll configuration.
+// Dropdown menus should never overscroll or display an overscroll indicator.
+class _DropDownScrollConfigurationDelegate extends ScrollConfigurationDelegate {
+  @override
+  Widget wrapScrollWidget(Widget scrollWidget) => new ClampOverscrolls(value: true, child: scrollWidget);
+}
+final ScrollConfigurationDelegate _dropDownScroll = new _DropDownScrollConfigurationDelegate();
+
 class _DropDownMenu<T> extends StatefulWidget {
   _DropDownMenu({
     Key key,
@@ -159,12 +167,15 @@ class _DropDownMenuState<T> extends State<_DropDownMenu<T>> {
         child: new Material(
           type: MaterialType.transparency,
           textStyle: route.style,
-          child: new Scrollbar(
-            child: new ScrollableList(
-              scrollableKey: config.route.scrollableKey,
-              padding: _kMenuVerticalPadding,
-              itemExtent: _kMenuItemHeight,
-              children: children
+          child: new ScrollConfiguration(
+            delegate: _dropDownScroll,
+            child: new Scrollbar(
+              child: new ScrollableList(
+                scrollableKey: config.route.scrollableKey,
+                padding: _kMenuVerticalPadding,
+                itemExtent: _kMenuItemHeight,
+                children: children
+              )
             )
           )
         )


### PR DESCRIPTION
- Set the ScrollConfiguration for dropdown menus. They should never overscroll or display an overscroll indicator (no matter what the platform's default scrolling configuration is).
- Leave out the initial "big" Pesto logo, since it only appears in one frame.
