### PR TITLE
support hot mode from the daemon protocol

### DIFF
--- a/packages/flutter_tools/lib/src/commands/daemon.dart
+++ b/packages/flutter_tools/lib/src/commands/daemon.dart
@@ -13,8 +13,10 @@ import '../build_info.dart';
 import '../cache.dart';
 import '../device.dart';
 import '../globals.dart';
+import '../hot.dart';
 import '../ios/devices.dart';
 import '../ios/simulators.dart';
+import '../resident_runner.dart';
 import '../run.dart';
 import '../runner/flutter_command.dart';
 
@@ -291,7 +293,7 @@ class AppDomain extends Domain {
     String route = _getStringArg(args, 'route');
     String mode = _getStringArg(args, 'mode');
     String target = _getStringArg(args, 'target');
-    // TODO(johnmccutchan): Wire up support for hot mode.
+    bool hotMode = _getBoolArg(args, 'hot') ?? false;
 
     Device device = daemon.deviceDomain._getDevice(deviceId);
     if (device == null)
@@ -319,12 +321,23 @@ class AppDomain extends Domain {
     Directory cwd = Directory.current;
     Directory.current = new Directory(projectDirectory);
 
-    RunAndStayResident runner = new RunAndStayResident(
-      device,
-      target: target,
-      debuggingOptions: options,
-      usesTerminalUI: false
-    );
+    ResidentRunner runner;
+
+    if (hotMode) {
+      runner = new HotRunner(
+        device,
+        target: target,
+        debuggingOptions: options,
+        usesTerminalUI: false
+      );
+    } else {
+      runner = new RunAndStayResident(
+        device,
+        target: target,
+        debuggingOptions: options,
+        usesTerminalUI: false
+      );
+    }
 
     AppInstance app = new AppInstance(_getNextAppId(), runner);
     _apps.add(app);
@@ -567,7 +580,7 @@ class AppInstance {
   AppInstance(this.id, [this.runner]);
 
   final String id;
-  final RunAndStayResident runner;
+  final ResidentRunner runner;
 
   _AppRunLogger _logger;
 

--- a/packages/flutter_tools/lib/src/commands/daemon.dart
+++ b/packages/flutter_tools/lib/src/commands/daemon.dart
@@ -344,7 +344,7 @@ class AppDomain extends Domain {
     _sendAppEvent(app, 'start', <String, dynamic>{
       'deviceId': deviceId,
       'directory': projectDirectory,
-      'supportsRestart': device.supportsRestart
+      'supportsRestart': device.supportsRestart && hotMode
     });
 
     Completer<int> observatoryPortCompleter;

--- a/packages/flutter_tools/lib/src/commands/run.dart
+++ b/packages/flutter_tools/lib/src/commands/run.dart
@@ -129,25 +129,25 @@ class RunCommand extends RunCommandBase {
       }
     }
 
+    ResidentRunner runner;
+
     if (argResults['hot']) {
-      HotRunner runner = new HotRunner(
+      runner = new HotRunner(
         deviceForCommand,
         target: targetFile,
         debuggingOptions: options
       );
-      return runner.run(route: route);
     } else {
-      RunAndStayResident runner = new RunAndStayResident(
+      runner = new RunAndStayResident(
         deviceForCommand,
         target: targetFile,
-        debuggingOptions: options
-      );
-      return runner.run(
+        debuggingOptions: options,
         traceStartup: traceStartup,
-        benchmark: argResults['benchmark'],
-        route: route
+        benchmark: argResults['benchmark']
       );
     }
+
+    return runner.run(route: route);
   }
 }
 

--- a/packages/flutter_tools/lib/src/hot.dart
+++ b/packages/flutter_tools/lib/src/hot.dart
@@ -45,10 +45,7 @@ class HotRunner extends ResidentRunner {
   final AssetBundle bundle = new AssetBundle();
 
   @override
-  Future<int> run({
-    Completer<int> observatoryPortCompleter,
-    String route
-  }) {
+  Future<int> run({ Completer<int> observatoryPortCompleter, String route }) {
     // Don't let uncaught errors kill the process.
     return runZoned(() {
       return _run(

--- a/packages/flutter_tools/lib/src/hot.dart
+++ b/packages/flutter_tools/lib/src/hot.dart
@@ -44,7 +44,7 @@ class HotRunner extends ResidentRunner {
   String _mainPath;
   final AssetBundle bundle = new AssetBundle();
 
-  /// Start the app and keep the process running during its lifetime.
+  @override
   Future<int> run({
     Completer<int> observatoryPortCompleter,
     String route
@@ -296,6 +296,9 @@ class HotRunner extends ResidentRunner {
     printStatus('Reloaded $loadedLibraryCount out of $finalLibraryCount libraries.');
     return true;
   }
+
+  @override
+  Future<bool> restart() => _reloadSources();
 
   Future<bool> _reloadSources() async {
     if (serviceProtocol.firstIsolateId == null)

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -30,6 +30,11 @@ abstract class ResidentRunner {
   Observatory serviceProtocol;
   StreamSubscription<String> _loggingSubscription;
 
+  /// Start the app and keep the process running during its lifetime.
+  Future<int> run({ Completer<int> observatoryPortCompleter, String route });
+
+  Future<bool> restart();
+
   Future<Null> stop() async {
     await stopEchoingDeviceLog();
     return stopApp();

--- a/packages/flutter_tools/lib/src/run.dart
+++ b/packages/flutter_tools/lib/src/run.dart
@@ -21,7 +21,9 @@ class RunAndStayResident extends ResidentRunner {
     Device device, {
     String target,
     DebuggingOptions debuggingOptions,
-    bool usesTerminalUI: true
+    bool usesTerminalUI: true,
+    this.traceStartup: false,
+    this.benchmark: false
   }) : super(device,
              target: target,
              debuggingOptions: debuggingOptions,
@@ -30,14 +32,11 @@ class RunAndStayResident extends ResidentRunner {
   ApplicationPackage _package;
   String _mainPath;
   LaunchResult _result;
+  bool traceStartup;
+  bool benchmark;
 
   @override
-  Future<int> run({
-    bool traceStartup: false,
-    bool benchmark: false,
-    Completer<int> observatoryPortCompleter,
-    String route
-  }) {
+  Future<int> run({ Completer<int> observatoryPortCompleter, String route }) {
     // Don't let uncaught errors kill the process.
     return runZoned(() {
       return _run(

--- a/packages/flutter_tools/lib/src/run.dart
+++ b/packages/flutter_tools/lib/src/run.dart
@@ -31,7 +31,7 @@ class RunAndStayResident extends ResidentRunner {
   String _mainPath;
   LaunchResult _result;
 
-  /// Start the app and keep the process running during its lifetime.
+  @override
   Future<int> run({
     bool traceStartup: false,
     bool benchmark: false,
@@ -51,6 +51,7 @@ class RunAndStayResident extends ResidentRunner {
     });
   }
 
+  @override
   Future<bool> restart() async {
     if (serviceProtocol == null) {
       printError('Debugging is not enabled.');


### PR DESCRIPTION
- support the `hot` parameter for the app.start daemon call
- use it to delegate to either the HotRunner or the RunAndStayResident

This lets IDEs toggle on and issue hot reload calls.

@johnmccutchan 
