### PR TITLE
Add a control pipe that can trigger terminal commands

### DIFF
--- a/packages/flutter_tools/lib/src/base/os.dart
+++ b/packages/flutter_tools/lib/src/base/os.dart
@@ -40,6 +40,9 @@ abstract class OperatingSystemUtils {
   /// if `which` was not able to locate the binary.
   File which(String execName);
 
+  /// Return the File representing a new pipe.
+  File makePipe(String path);
+
   void unzip(File file, Directory targetDirectory);
 }
 
@@ -66,6 +69,12 @@ class _PosixUtils extends OperatingSystemUtils {
   @override
   void unzip(File file, Directory targetDirectory) {
     runSync(<String>['unzip', '-o', '-q', file.path, '-d', targetDirectory.path]);
+  }
+
+  @override
+  File makePipe(String path) {
+    runSync(<String>['mkfifo', path]);
+    return new File(path);
   }
 }
 
@@ -100,6 +109,11 @@ class _WindowsUtils extends OperatingSystemUtils {
         destFile.parent.createSync(recursive: true);
       destFile.writeAsBytesSync(archiveFile.content);
     }
+  }
+
+  @override
+  File makePipe(String path) {
+    throw new UnsupportedError('makePipe is not implemented on Windows.');
   }
 }
 

--- a/packages/flutter_tools/lib/src/run.dart
+++ b/packages/flutter_tools/lib/src/run.dart
@@ -208,12 +208,12 @@ class RunAndStayResident extends ResidentRunner {
   }
 
   @override
-  void handleTerminalCommand(String code) {
+  Future<Null> handleTerminalCommand(String code) async {
     String lower = code.toLowerCase();
     if (lower == 'r' || code == AnsiTerminal.KEY_F5) {
       if (device.supportsRestart) {
         // F5, restart
-        restart();
+        await restart();
       }
     }
   }


### PR DESCRIPTION
- [x] Add --control-pipe <path-to-pipe> option to `run --hot`
- [x] Strings written into the control pipe are passed to `handleTerminalCommand`

Launch:

```
flutter run --hot --control-pipe /tmp/my.pipe
```

Reload:

```
echo "r" > /tmp/my.pipe
```

Restart:

```
echo "R" > /tmp/my.pipe
```
