### PR TITLE
Speedup devFS writing and improve status information

### DIFF
--- a/packages/flutter_tools/lib/src/ios/simulators.dart
+++ b/packages/flutter_tools/lib/src/ios/simulators.dart
@@ -363,7 +363,7 @@ class IOSSimulator extends Device {
   bool get supportsHotMode => true;
 
   @override
-  bool get needsDevFS => false;
+  bool get needsDevFS => true;
 
   _IOSSimulatorLogReader _logReader;
   _IOSSimulatorDevicePortForwarder _portForwarder;

--- a/packages/flutter_tools/lib/src/observatory.dart
+++ b/packages/flutter_tools/lib/src/observatory.dart
@@ -13,7 +13,7 @@ import 'globals.dart';
 
 // TODO(johnmccutchan): Rename this class to ServiceProtocol or VmService.
 class Observatory {
-  Observatory._(this.peer, this.port) {
+  Observatory._(this.peer, this.port, this.httpAddress) {
     peer.registerMethod('streamNotify', (rpc.Parameters event) {
       _handleStreamNotify(event.asMap);
     });
@@ -33,9 +33,10 @@ class Observatory {
     WebSocket ws = await WebSocket.connect(uri.toString());
     rpc.Peer peer = new rpc.Peer(new IOWebSocketChannel(ws));
     peer.listen();
-    return new Observatory._(peer, port);
+    Uri httpAddress = new Uri(scheme: 'http', host: '127.0.0.1', port: port);
+    return new Observatory._(peer, port, httpAddress);
   }
-
+  final Uri httpAddress;
   final rpc.Peer peer;
   final int port;
 


### PR DESCRIPTION
- [x] Improve the status logging of a DevFS sync (separate updates for each phase)
- [x] Use new compressed HTTP PUT DevFS write path (speeds up writes ~33%)
- [x] Fix a bug where source assets (LICENSE, *Manifest.json) would be deleted on the second sync
