### PR TITLE
make the apk building part of flutter run optional

### DIFF
--- a/packages/flutter_tools/lib/src/commands/run.dart
+++ b/packages/flutter_tools/lib/src/commands/run.dart
@@ -56,6 +56,9 @@ class RunCommand extends RunCommandBase {
         help: 'Start in a paused mode and wait for a debugger to connect.');
     argParser.addOption('debug-port',
         help: 'Listen to the given port for a debug connection (defaults to $kDefaultObservatoryPort).');
+    argParser.addFlag('build',
+        defaultsTo: true,
+        help: 'If necessary, build the app before running.');
     usesPubOption();
 
     // Option to enable hot reloading.
@@ -171,7 +174,7 @@ class RunCommand extends RunCommandBase {
       );
     }
 
-    return runner.run(route: route);
+    return runner.run(route: route, shouldBuild: argResults['build']);
   }
 }
 

--- a/packages/flutter_tools/lib/src/hot.dart
+++ b/packages/flutter_tools/lib/src/hot.dart
@@ -76,12 +76,17 @@ class HotRunner extends ResidentRunner {
   }
 
   @override
-  Future<int> run({ Completer<int> observatoryPortCompleter, String route }) {
+  Future<int> run({
+    Completer<int> observatoryPortCompleter,
+    String route,
+    bool shouldBuild: true
+  }) {
     // Don't let uncaught errors kill the process.
     return runZoned(() {
       return _run(
         observatoryPortCompleter: observatoryPortCompleter,
-        route: route
+        route: route,
+        shouldBuild: shouldBuild
       );
     }, onError: (dynamic error, StackTrace stackTrace) {
       printError('Exception from flutter run: $error', stackTrace);
@@ -90,7 +95,8 @@ class HotRunner extends ResidentRunner {
 
   Future<int> _run({
     Completer<int> observatoryPortCompleter,
-    String route
+    String route,
+    bool shouldBuild: true
   }) async {
     _mainPath = findMainDartFile(target);
     if (!FileSystemEntity.isFileSync(_mainPath)) {
@@ -113,7 +119,7 @@ class HotRunner extends ResidentRunner {
     }
 
     // TODO(devoncarew): We shouldn't have to do type checks here.
-    if (device is AndroidDevice) {
+    if (shouldBuild && device is AndroidDevice) {
       printTrace('Running build command.');
 
       int result = await buildApk(

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -31,7 +31,11 @@ abstract class ResidentRunner {
   StreamSubscription<String> _loggingSubscription;
 
   /// Start the app and keep the process running during its lifetime.
-  Future<int> run({ Completer<int> observatoryPortCompleter, String route });
+  Future<int> run({
+    Completer<int> observatoryPortCompleter,
+    String route,
+    bool shouldBuild: true
+  });
 
   Future<bool> restart();
 

--- a/packages/flutter_tools/lib/src/run.dart
+++ b/packages/flutter_tools/lib/src/run.dart
@@ -36,14 +36,19 @@ class RunAndStayResident extends ResidentRunner {
   bool benchmark;
 
   @override
-  Future<int> run({ Completer<int> observatoryPortCompleter, String route }) {
+  Future<int> run({
+    Completer<int> observatoryPortCompleter,
+    String route,
+    bool shouldBuild: true
+  }) {
     // Don't let uncaught errors kill the process.
     return runZoned(() {
       return _run(
         traceStartup: traceStartup,
         benchmark: benchmark,
         observatoryPortCompleter: observatoryPortCompleter,
-        route: route
+        route: route,
+        shouldBuild: shouldBuild
       );
     }, onError: (dynamic error, StackTrace stackTrace) {
       printError('Exception from flutter run: $error', stackTrace);
@@ -88,7 +93,8 @@ class RunAndStayResident extends ResidentRunner {
     bool traceStartup: false,
     bool benchmark: false,
     Completer<int> observatoryPortCompleter,
-    String route
+    String route,
+    bool shouldBuild: true
   }) async {
     _mainPath = findMainDartFile(target);
     if (!FileSystemEntity.isFileSync(_mainPath)) {
@@ -113,7 +119,7 @@ class RunAndStayResident extends ResidentRunner {
     Stopwatch startTime = new Stopwatch()..start();
 
     // TODO(devoncarew): We shouldn't have to do type checks here.
-    if (device is AndroidDevice) {
+    if (shouldBuild && device is AndroidDevice) {
       printTrace('Running build command.');
 
       int result = await buildApk(


### PR DESCRIPTION
- add a `--build` (`--no-build`) option to `flutter run`, defaulting to true. This makes the building part of flutter run optional and will be used in cases where a separate build system is creating the built APK.

@johnmccutchan @cbracken 
