### PR TITLE
--trace-startup: non-zero exit code when fails; enable in iOS runtime

### DIFF
--- a/packages/flutter_tools/lib/src/commands/run.dart
+++ b/packages/flutter_tools/lib/src/commands/run.dart
@@ -246,7 +246,7 @@ Future<int> startApp(
       Observatory observatory = await Observatory.connect(result.observatoryPort);
       await downloadStartupTrace(observatory);
     } catch (error) {
-      printError('Error connecting to observatory: $error');
+      printError('Error downloading trace from observatory: $error');
       return 1;
     }
   }

--- a/packages/flutter_tools/lib/src/commands/trace.dart
+++ b/packages/flutter_tools/lib/src/commands/trace.dart
@@ -154,6 +154,11 @@ class Tracing {
 /// Download the startup trace information from the given observatory client and
 /// store it to build/start_up_info.json.
 Future<Null> downloadStartupTrace(Observatory observatory) async {
+  File traceInfoFile = new File('build/start_up_info.json');
+
+  if (await traceInfoFile.exists())
+    await traceInfoFile.delete();
+
   Tracing tracing = new Tracing(observatory);
 
   Map<String, dynamic> timeline = await tracing.stopTracingAndDownloadTimeline(
@@ -173,16 +178,13 @@ Future<Null> downloadStartupTrace(Observatory observatory) async {
   int firstFrameTimestampMicros = extractInstantEventTimestamp(kFirstUsefulFrameEventName);
 
   if (engineEnterTimestampMicros == null) {
-    printError('Engine start event is missing in the timeline. Cannot compute startup time.');
-    return null;
+    throw 'Engine start event is missing in the timeline. Cannot compute startup time.';
   }
 
   if (firstFrameTimestampMicros == null) {
-    printError('First frame event is missing in the timeline. Cannot compute startup time.');
-    return null;
+    throw 'First frame event is missing in the timeline. Cannot compute startup time.';
   }
 
-  File traceInfoFile = new File('build/start_up_info.json');
   int timeToFirstFrameMicros = firstFrameTimestampMicros - engineEnterTimestampMicros;
   Map<String, dynamic> traceInfo = <String, dynamic>{
     'engineEnterTimestampMicros': engineEnterTimestampMicros,

--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -213,6 +213,9 @@ class IOSDevice extends Device {
       // the port picked and scrape that later.
     }
 
+    if (platformArgs['trace-startup'] ?? false)
+      launchArguments.add('--trace-startup');
+
     List<String> launchCommand = <String>[
       '/usr/bin/env',
       'ios-deploy',

--- a/packages/flutter_tools/lib/src/run.dart
+++ b/packages/flutter_tools/lib/src/run.dart
@@ -182,7 +182,12 @@ class RunAndStayResident extends ResidentRunner {
 
     if (serviceProtocol != null && traceStartup) {
       printStatus('Downloading startup trace info...');
-      await downloadStartupTrace(serviceProtocol);
+      try {
+        await downloadStartupTrace(serviceProtocol);
+      } catch(error) {
+        printError(error);
+        return 2;
+      }
       appFinished();
     } else {
       setupTerminal();


### PR DESCRIPTION
Bonus: also delete the old trace info file prior to downloading the new one to prevent mistakenly reading obsolete data.

/cc @chinmaygarde 
