### PR TITLE
Support multilicense LICENSE files generically.

### DIFF
--- a/packages/flutter/lib/src/foundation/licenses.dart
+++ b/packages/flutter/lib/src/foundation/licenses.dart
@@ -243,8 +243,14 @@ class LicenseEntryWithLineBreaks extends LicenseEntry {
 /// The flutter tool will automatically collect the contents of all the LICENSE
 /// files found at the root of each package into a single LICENSE file in the
 /// default asset bundle. Each license in that file is separated from the next
-/// by a line of eighty hyphens (`-`). The `services` package registers a
-/// license collector that splits that file and adds each entry to the registry.
+/// by a line of eighty hyphens (`-`), and begins with a list of package names
+/// that the license applies to, one to a line, separated from the next by a
+/// blank line. The `services` package registers a license collector that splits
+/// that file and adds each entry to the registry.
+///
+/// The LICENSE files in each package can either consist of a single license, or
+/// can be in the format described above. In the latter case, each component
+/// license and list of package names is merged independently.
 class LicenseRegistry {
   LicenseRegistry._();
 

--- a/packages/flutter_tools/lib/src/commands/build_flx.dart
+++ b/packages/flutter_tools/lib/src/commands/build_flx.dart
@@ -22,6 +22,7 @@ class BuildFlxCommand extends BuildSubCommand {
     argParser.addOption('depfile', defaultsTo: defaultDepfilePath);
     argParser.addOption('working-dir', defaultsTo: defaultWorkingDirPath);
     argParser.addFlag('include-roboto-fonts', defaultsTo: true);
+    argParser.addFlag('report-licensed-packages', help: 'Whether to report the names of all the packages that are included in the application\'s LICENSE file.', defaultsTo: false);
     usesPubOption();
   }
 
@@ -49,7 +50,8 @@ class BuildFlxCommand extends BuildSubCommand {
       privateKeyPath: argResults['private-key'],
       workingDirPath: argResults['working-dir'],
       precompiledSnapshot: argResults['precompiled'],
-      includeRobotoFonts: argResults['include-roboto-fonts']
+      includeRobotoFonts: argResults['include-roboto-fonts'],
+      reportLicensedPackages: argResults['report-licensed-packages']
     ).then((int result) {
       if (result == 0)
         printStatus('Built $outputPath.');

--- a/packages/flutter_tools/lib/src/flx.dart
+++ b/packages/flutter_tools/lib/src/flx.dart
@@ -77,7 +77,8 @@ Future<int> build({
   String privateKeyPath: defaultPrivateKeyPath,
   String workingDirPath: defaultWorkingDirPath,
   bool precompiledSnapshot: false,
-  bool includeRobotoFonts: true
+  bool includeRobotoFonts: true,
+  bool reportLicensedPackages: false
 }) async {
   File snapshotFile;
 
@@ -105,7 +106,8 @@ Future<int> build({
     outputPath: outputPath,
     privateKeyPath: privateKeyPath,
     workingDirPath: workingDirPath,
-    includeRobotoFonts: includeRobotoFonts
+    includeRobotoFonts: includeRobotoFonts,
+    reportLicensedPackages: reportLicensedPackages
   );
 }
 
@@ -115,15 +117,19 @@ Future<int> assemble({
   String outputPath: defaultFlxOutputPath,
   String privateKeyPath: defaultPrivateKeyPath,
   String workingDirPath: defaultWorkingDirPath,
-  bool includeRobotoFonts: true
+  bool includeRobotoFonts: true,
+  bool reportLicensedPackages: false
 }) async {
   printTrace('Building $outputPath');
 
   // Build the asset bundle.
   AssetBundle assetBundle = new AssetBundle();
-  int result = await assetBundle.build(manifestPath: manifestPath,
-                                       workingDirPath: workingDirPath,
-                                       includeRobotoFonts: includeRobotoFonts);
+  int result = await assetBundle.build(
+    manifestPath: manifestPath,
+    workingDirPath: workingDirPath,
+    includeRobotoFonts: includeRobotoFonts,
+    reportLicensedPackages: reportLicensedPackages
+  );
   if (result != 0) {
     return result;
   }


### PR DESCRIPTION
Also, add a "flutter build flx --report-licensed-packages" option for
when you need to get the list of the packages affected by licenses.
