### PR TITLE
Create an empty zip file in ZipToolBuilder if the entry list is empty

### DIFF
--- a/packages/flutter_tools/lib/src/zip.dart
+++ b/packages/flutter_tools/lib/src/zip.dart
@@ -50,6 +50,13 @@ class _ZipToolBuilder extends ZipBuilder {
 
   @override
   void createZip(File outFile, Directory zipBuildDir) {
+    // If there are no assets, then create an empty zip file.
+    if (entries.isEmpty) {
+      List<int> zipData = new ZipEncoder().encode(new Archive());
+      outFile.writeAsBytesSync(zipData);
+      return;
+    }
+
     if (outFile.existsSync())
       outFile.deleteSync();
 


### PR DESCRIPTION
This can happen if you build an FLX in release mode for an app with no assets
(such as the hello_world example)
