### PR TITLE
Add time to frame tracking to hot run

### DIFF
--- a/packages/flutter_tools/lib/src/base/utils.dart
+++ b/packages/flutter_tools/lib/src/base/utils.dart
@@ -78,6 +78,15 @@ String getSizeAsMB(int bytesLength) {
   return '${(bytesLength / (1024 * 1024)).toStringAsFixed(1)}MB';
 }
 
+String getElapsedAsSeconds(Duration duration) {
+  double seconds = duration.inMilliseconds / Duration.MILLISECONDS_PER_SECOND;
+  return '${seconds.toStringAsFixed(2)} seconds';
+}
+
+String getElapsedAsMilliseconds(Duration duration) {
+  return '${duration.inMilliseconds} ms';
+}
+
 /// Return a relative path if [fullPath] is contained by the cwd, else return an
 /// absolute path.
 String getDisplayPath(String fullPath) {


### PR DESCRIPTION
- [x] Add FirstFrameTimer and wire it up around restart 'R' and hot reload 'r'.
- [x] Print the full time from key press to first frame after a restart / hot reload

This is the same number that we will report on benchmarks. Example output:

```
Hot reload time to frame: 0.69 seconds
```

```
Restart time to frame: 3.71 seconds
```
