### PR TITLE
Decide whether to compress files in the FLX based on filename extensions

### DIFF
--- a/packages/flutter_tools/lib/src/zip.dart
+++ b/packages/flutter_tools/lib/src/zip.dart
@@ -88,15 +88,23 @@ class _ZipToolBuilder extends ZipBuilder {
     }
   }
 
+  static const List<String> _kNoCompressFileExtensions = const <String>['.png', '.jpg'];
+
+  bool isAssetCompressed(AssetBundleEntry entry) {
+    return !_kNoCompressFileExtensions.any(
+        (String extension) => entry.archivePath.endsWith(extension)
+    );
+  }
+
   Iterable<String> _getCompressedNames() {
     return entries
-      .where((AssetBundleEntry entry) => !entry.isStringEntry)
+      .where(isAssetCompressed)
       .map((AssetBundleEntry entry) => entry.archivePath);
   }
 
   Iterable<String> _getStoredNames() {
     return entries
-      .where((AssetBundleEntry entry) => entry.isStringEntry)
+      .where((AssetBundleEntry entry) => !isAssetCompressed(entry))
       .map((AssetBundleEntry entry) => entry.archivePath);
   }
 }


### PR DESCRIPTION
Previously the FLX builder compressed assets only if they were not dynamically
generated.  This meant that the license file was not compressed.
