### PR TITLE
send the base uri back to debuggers

### DIFF
--- a/packages/flutter_tools/lib/src/commands/daemon.dart
+++ b/packages/flutter_tools/lib/src/commands/daemon.dart
@@ -382,13 +382,14 @@ class AppDomain extends Domain {
 
   Future<bool> restart(Map<String, dynamic> args) async {
     String appId = _getStringArg(args, 'appId', required: true);
+    bool fullRestart = _getBoolArg(args, 'fullRestart') ?? false;
 
     AppInstance app = _getApp(appId);
     if (app == null)
       throw "app '$appId' not found";
 
     return app._runInZone(this, () {
-      return app.restart();
+      return app.restart(fullRestart: fullRestart);
     });
   }
 
@@ -589,7 +590,9 @@ class AppInstance {
 
   _AppRunLogger _logger;
 
-  Future<bool> restart() => runner.restart();
+  Future<bool> restart({ bool fullRestart: false }) {
+    return runner.restart(fullRestart: fullRestart);
+  }
 
   Future<Null> stop() => runner.stop();
 

--- a/packages/flutter_tools/lib/src/hot.dart
+++ b/packages/flutter_tools/lib/src/hot.dart
@@ -381,7 +381,14 @@ class HotRunner extends ResidentRunner {
   }
 
   @override
-  Future<bool> restart() => _reloadSources();
+  Future<bool> restart({ bool fullRestart: false }) async {
+    if (fullRestart) {
+      _restartFromSources();
+      return true;
+    } else {
+      return _reloadSources();
+    }
+  }
 
   Future<bool> _reloadSources() async {
     if (serviceProtocol.firstIsolateId == null)

--- a/packages/flutter_tools/lib/src/hot.dart
+++ b/packages/flutter_tools/lib/src/hot.dart
@@ -383,7 +383,7 @@ class HotRunner extends ResidentRunner {
   @override
   Future<bool> restart({ bool fullRestart: false }) async {
     if (fullRestart) {
-      _restartFromSources();
+      await _restartFromSources();
       return true;
     } else {
       return _reloadSources();

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -32,7 +32,7 @@ abstract class ResidentRunner {
 
   /// Start the app and keep the process running during its lifetime.
   Future<int> run({
-    Completer<int> observatoryPortCompleter,
+    Completer<DebugConnectionInfo> connectionInfoCompleter,
     String route,
     bool shouldBuild: true
   });
@@ -207,4 +207,11 @@ String getMissingPackageHintForPlatform(TargetPlatform platform) {
     default:
       return null;
   }
+}
+
+class DebugConnectionInfo {
+  DebugConnectionInfo(this.port, { this.baseUri });
+
+  final int port;
+  final String baseUri;
 }

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -37,7 +37,7 @@ abstract class ResidentRunner {
     bool shouldBuild: true
   });
 
-  Future<bool> restart();
+  Future<bool> restart({ bool fullRestart: false });
 
   Future<Null> stop() async {
     await stopEchoingDeviceLog();

--- a/packages/flutter_tools/lib/src/run.dart
+++ b/packages/flutter_tools/lib/src/run.dart
@@ -58,7 +58,7 @@ class RunAndStayResident extends ResidentRunner {
   }
 
   @override
-  Future<bool> restart() async {
+  Future<bool> restart({ bool fullRestart: false }) async {
     if (serviceProtocol == null) {
       printError('Debugging is not enabled.');
       return false;

--- a/packages/flutter_tools/lib/src/run.dart
+++ b/packages/flutter_tools/lib/src/run.dart
@@ -39,7 +39,7 @@ class RunAndStayResident extends ResidentRunner {
 
   @override
   Future<int> run({
-    Completer<int> observatoryPortCompleter,
+    Completer<DebugConnectionInfo> connectionInfoCompleter,
     String route,
     bool shouldBuild: true
   }) {
@@ -48,7 +48,7 @@ class RunAndStayResident extends ResidentRunner {
       return _run(
         traceStartup: traceStartup,
         benchmark: benchmark,
-        observatoryPortCompleter: observatoryPortCompleter,
+        connectionInfoCompleter: connectionInfoCompleter,
         route: route,
         shouldBuild: shouldBuild
       );
@@ -94,7 +94,7 @@ class RunAndStayResident extends ResidentRunner {
   Future<int> _run({
     bool traceStartup: false,
     bool benchmark: false,
-    Completer<int> observatoryPortCompleter,
+    Completer<DebugConnectionInfo> connectionInfoCompleter,
     String route,
     bool shouldBuild: true
   }) async {
@@ -175,8 +175,8 @@ class RunAndStayResident extends ResidentRunner {
 
     startTime.stop();
 
-    if (observatoryPortCompleter != null && _result.hasObservatory)
-      observatoryPortCompleter.complete(_result.observatoryPort);
+    if (connectionInfoCompleter != null && _result.hasObservatory)
+      connectionInfoCompleter.complete(new DebugConnectionInfo(_result.observatoryPort));
 
     // Connect to observatory.
     if (debuggingOptions.debuggingEnabled) {


### PR DESCRIPTION
- when starting an app via the daemon protocol's app.start method, pass the `baseUri` value from the devfs back to the calling client
- map a restart request to a hot reload when the client passes in `hot`
- send fewer `Syncing files to device` messages to the device when starting up

@johnmccutchan 
