### PR TITLE
Added clipping opt-out for Stack.

### DIFF
--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -1394,6 +1394,7 @@ class Stack extends MultiChildRenderObjectWidget {
   Stack({
     Key key,
     this.alignment: FractionalOffset.topLeft,
+    this.overflow: Overflow.clip,
     List<Widget> children: _emptyWidgetList
   }) : super(key: key, children: children);
 
@@ -1405,12 +1406,25 @@ class Stack extends MultiChildRenderObjectWidget {
   /// each non-positioned child will be located at the same global coordinate.
   final FractionalOffset alignment;
 
+  /// Whether overflowing children should be clipped. See [Overflow].
+  ///
+  /// Some children in a stack might overflow its box. When this flag is set to
+  /// [Overflow.clipped], children cannot paint outside of the stack's box.
+  final Overflow overflow;
+
   @override
-  RenderStack createRenderObject(BuildContext context) => new RenderStack(alignment: alignment);
+  RenderStack createRenderObject(BuildContext context) {
+    return new RenderStack(
+      alignment: alignment,
+      overflow: overflow
+    );
+  }
 
   @override
   void updateRenderObject(BuildContext context, RenderStack renderObject) {
-    renderObject.alignment = alignment;
+    renderObject
+      ..alignment = alignment
+      ..overflow = overflow;
   }
 }
 

--- a/packages/flutter/test/widget/stack_test.dart
+++ b/packages/flutter/test/widget/stack_test.dart
@@ -8,6 +8,15 @@ import 'package:flutter/widgets.dart';
 
 import '../rendering/rendering_tester.dart';
 
+class TestPaintingContext implements PaintingContext {
+  final List<Invocation> invocations = <Invocation>[];
+
+  @override
+    void noSuchMethod(Invocation invocation) {
+      invocations.add(invocation);
+    }
+}
+
 void main() {
   testWidgets('Can construct an empty Stack', (WidgetTester tester) async {
     await tester.pumpWidget(new Stack());
@@ -253,4 +262,58 @@ void main() {
     expect(renderBox.size.height, equals(12.0));
   });
 
+  testWidgets('Stack clip test', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      new Center(
+        child: new Stack(
+          children: <Widget>[
+            new Container(
+              width: 100.0,
+              height: 100.0
+            ),
+            new Positioned(
+              top: 0.0,
+              left: 0.0,
+              child: new Container(
+                width: 200.0,
+                height: 200.0
+              )
+            )
+          ]
+        )
+      )
+    );
+
+    RenderBox box = tester.renderObject(find.byType(Stack));
+    TestPaintingContext context = new TestPaintingContext();
+    box.paint(context, Offset.zero);
+    expect(context.invocations.first.memberName, equals(#pushClipRect));
+
+    await tester.pumpWidget(
+      new Center(
+        child: new Stack(
+          overflow: Overflow.visible,
+          children: <Widget>[
+            new Container(
+              width: 100.0,
+              height: 100.0
+            ),
+            new Positioned(
+              top: 0.0,
+              left: 0.0,
+              child: new Container(
+                width: 200.0,
+                height: 200.0
+              )
+            )
+          ]
+        )
+      )
+    );
+
+    box = tester.renderObject(find.byType(Stack));
+    context = new TestPaintingContext();
+    box.paint(context, Offset.zero);
+    expect(context.invocations.first.memberName, equals(#paintChild));
+  });
 }


### PR DESCRIPTION
Added a flag that instructs Stack how to deal with overflowing
children: they can either be clipped or not.
