### PR TITLE
Add Dart SDK to version info (#4986).

### DIFF
--- a/packages/flutter_tools/lib/src/cache.dart
+++ b/packages/flutter_tools/lib/src/cache.dart
@@ -80,9 +80,7 @@ class Cache {
 
   static String get dartSdkVersion {
     if (_dartSdkVersion == null) {
-      File versionFile = new File(path.join(flutterRoot, 'bin', 'cache', 'dart-sdk.version'));
-      if (versionFile.existsSync())
-        _dartSdkVersion = versionFile.readAsStringSync().trim();
+      _dartSdkVersion = Platform.version;
     }
     return _dartSdkVersion;
   }

--- a/packages/flutter_tools/lib/src/cache.dart
+++ b/packages/flutter_tools/lib/src/cache.dart
@@ -76,6 +76,17 @@ class Cache {
     _lock = null;
   }
 
+  static String _dartSdkVersion;
+
+  static String get dartSdkVersion {
+    if (_dartSdkVersion == null) {
+      File versionFile = new File(path.join(flutterRoot, 'bin', 'cache', 'dart-sdk.version'));
+      if (versionFile.existsSync())
+        _dartSdkVersion = versionFile.readAsStringSync().trim();
+    }
+    return _dartSdkVersion;
+  }
+
   static String _engineRevision;
 
   static String get engineRevision {

--- a/packages/flutter_tools/lib/src/version.dart
+++ b/packages/flutter_tools/lib/src/version.dart
@@ -48,7 +48,7 @@ class FlutterVersion {
   String _frameworkAge;
   String get frameworkAge => _frameworkAge;
 
-  String get dartSdkVersion => Cache.dartSdkVersion;
+  String get dartSdkVersion => Cache.dartSdkVersion.split(' ')[0];
 
   String get engineRevision => Cache.engineRevision;
   String get engineRevisionShort => _shortGitRevision(engineRevision);
@@ -59,7 +59,7 @@ class FlutterVersion {
   String toString() {
     String from = 'Flutter on channel $channel (from ${repositoryUrl == null ? 'unknown source' : repositoryUrl})';
     String flutterText = 'Framework revision $frameworkRevisionShort ($frameworkAge); engine revision $engineRevisionShort';
-    String dartSdkText = 'Dart version $dartSdkVersion';
+    String dartSdkText = 'Flutter tools using Dart version $dartSdkVersion';
 
     return '$from\n$flutterText\n$dartSdkText';
   }

--- a/packages/flutter_tools/lib/src/version.dart
+++ b/packages/flutter_tools/lib/src/version.dart
@@ -59,7 +59,7 @@ class FlutterVersion {
   String toString() {
     String from = 'Flutter on channel $channel (from ${repositoryUrl == null ? 'unknown source' : repositoryUrl})';
     String flutterText = 'Framework revision $frameworkRevisionShort ($frameworkAge); engine revision $engineRevisionShort';
-    String dartSdkText = 'Dart SDK $dartSdkVersion';
+    String dartSdkText = 'Dart version $dartSdkVersion';
 
     return '$from\n$flutterText\n$dartSdkText';
   }

--- a/packages/flutter_tools/lib/src/version.dart
+++ b/packages/flutter_tools/lib/src/version.dart
@@ -48,6 +48,8 @@ class FlutterVersion {
   String _frameworkAge;
   String get frameworkAge => _frameworkAge;
 
+  String get dartSdkVersion => Cache.dartSdkVersion;
+
   String get engineRevision => Cache.engineRevision;
   String get engineRevisionShort => _shortGitRevision(engineRevision);
 
@@ -57,8 +59,9 @@ class FlutterVersion {
   String toString() {
     String from = 'Flutter on channel $channel (from ${repositoryUrl == null ? 'unknown source' : repositoryUrl})';
     String flutterText = 'Framework revision $frameworkRevisionShort ($frameworkAge); engine revision $engineRevisionShort';
+    String dartSdkText = 'Dart SDK $dartSdkVersion';
 
-    return '$from\n$flutterText';
+    return '$from\n$flutterText\n$dartSdkText';
   }
 
   static FlutterVersion getVersion([String flutterRoot]) {


### PR DESCRIPTION
Adds a new SDK line to the `flutter —version` output.

Sample output:

```
[~/src/git/clones/flutter] (master) $ flutter --version
Flutter on channel master (from git@github.com:pq/flutter.git)
Framework revision ec0f880032 (2 hours ago); engine revision 607d379c23
Dart SDK 1.19.0-dev.5.0
```
