### PR TITLE
Improve our scroll physics on iOS

### DIFF
--- a/packages/flutter/lib/src/foundation/assertions.dart
+++ b/packages/flutter/lib/src/foundation/assertions.dart
@@ -326,3 +326,17 @@ class FlutterError extends AssertionError {
       onError(details);
   }
 }
+
+/// Dump the current stack to the console using [debugPrint] and
+/// [FlutterError.defaultStackFilter].
+///
+/// The current stack is obtained using [StackTrace.current].
+///
+/// The `maxFrames` argument can be given to limit the stack to the given number
+/// of lines. By default, all non-filtered stack lines are shown.
+void debugPrintStack({ int maxFrames }) {
+  List<String> lines = StackTrace.current.toString().trimRight().split('\n');
+  if (maxFrames != null)
+    lines = lines.take(maxFrames);
+  debugPrint(FlutterError.defaultStackFilter(lines).join('\n'));
+}

--- a/packages/flutter/lib/src/foundation/platform.dart
+++ b/packages/flutter/lib/src/foundation/platform.dart
@@ -15,15 +15,33 @@ enum TargetPlatform {
   iOS,
 }
 
-/// The [TargetPlatform] that matches the platform on which the framework is currently executing.
+/// The [TargetPlatform] that matches the platform on which the framework is
+/// currently executing.
+///
+/// In a test environment, the platform returned is [TargetPlatform.android]
+/// regardless of the host platform. (Android was chosen because the tests were
+/// originally written assuming Android-like behavior, and we added platform
+/// adaptations for iOS later). Tests can check iOS behavior by using the
+/// platform override APIs (like in [ThemeData.platform] in the material
+/// library).
 TargetPlatform get defaultTargetPlatform {
-  if (Platform.isIOS || Platform.isMacOS)
-    return TargetPlatform.iOS;
-  if (Platform.isAndroid || Platform.isLinux)
-    return TargetPlatform.android;
-  throw new FlutterError(
-    'Unknown platform\n'
-    '${Platform.operatingSystem} was not recognized as a target platform. '
-    'Consider updating the list of TargetPlatforms to include this platform.'
-  );
+  TargetPlatform result;
+  if (Platform.isIOS || Platform.isMacOS) {
+    result = TargetPlatform.iOS;
+  } else if (Platform.isAndroid || Platform.isLinux) {
+    result = TargetPlatform.android;
+  }
+  assert(() {
+    if (Platform.environment.containsKey('FLUTTER_TEST'))
+      result = TargetPlatform.android;
+    return true;
+  });
+  if (result == null) {
+    throw new FlutterError(
+      'Unknown platform.\n'
+      '${Platform.operatingSystem} was not recognized as a target platform. '
+      'Consider updating the list of TargetPlatforms to include this platform.'
+    );
+  }
+  return result;
 }

--- a/packages/flutter/lib/src/foundation/print.dart
+++ b/packages/flutter/lib/src/foundation/print.dart
@@ -160,10 +160,3 @@ Iterable<String> debugWordWrap(String message, int width) sync* {
     }
   }
 }
-
-/// Dump the current stack to the console using [debugPrint].
-///
-/// The current stack is obtained using [StackTrace.current].
-void debugPrintStack() {
-  debugPrint(StackTrace.current.toString());
-}

--- a/packages/flutter/lib/src/material/app.dart
+++ b/packages/flutter/lib/src/material/app.dart
@@ -23,15 +23,6 @@ const TextStyle _errorTextStyle = const TextStyle(
   decorationStyle: TextDecorationStyle.double
 );
 
-/// The visual and interaction design for overscroll.
-enum OverscrollStyle {
-  /// Overscrolls are clamped and indicated with a glow.
-  glow,
-
-  /// Overscrolls are not clamped and indicated with elastic physics.
-  bounce
-}
-
 /// An application that uses material design.
 ///
 /// A convenience widget that wraps a number of widgets that are commonly
@@ -60,7 +51,6 @@ class MaterialApp extends StatefulWidget {
     this.theme,
     this.home,
     this.routes: const <String, WidgetBuilder>{},
-    this.overscrollStyle,
     this.onGenerateRoute,
     this.onLocaleChanged,
     this.debugShowMaterialGrid: false,
@@ -112,11 +102,6 @@ class MaterialApp extends StatefulWidget {
   /// build the page instead.
   final Map<String, WidgetBuilder> routes;
 
-  /// The visual and interaction design for overscroll.
-  ///
-  /// Defaults to being adapted to the current [TargetPlatform].
-  final OverscrollStyle overscrollStyle;
-
   /// The route generator callback used when the app is navigated to a
   /// named route.
   final RouteFactory onGenerateRoute;
@@ -158,13 +143,34 @@ class MaterialApp extends StatefulWidget {
   _MaterialAppState createState() => new _MaterialAppState();
 }
 
-class _IndicatorScrollConfigurationDelegate extends ScrollConfigurationDelegate {
+class _ScrollLikeCupertinoDelegate extends ScrollConfigurationDelegate {
+  const _ScrollLikeCupertinoDelegate();
+
   @override
-  Widget wrapScrollWidget(Widget scrollWidget) => new OverscrollIndicator(child: scrollWidget);
+  TargetPlatform get platform => TargetPlatform.iOS;
+
+  @override
+  ExtentScrollBehavior createScrollBehavior() => new OverscrollWhenScrollableBehavior(platform: TargetPlatform.iOS);
+
+  @override
+  bool updateShouldNotify(ScrollConfigurationDelegate old) => false;
 }
 
-final ScrollConfigurationDelegate _glowScroll = new _IndicatorScrollConfigurationDelegate();
-final ScrollConfigurationDelegate _bounceScroll = new ScrollConfigurationDelegate();
+class _ScrollLikeMountainViewDelegate extends ScrollConfigurationDelegate {
+  const _ScrollLikeMountainViewDelegate();
+
+  @override
+  TargetPlatform get platform => TargetPlatform.android;
+
+  @override
+  ExtentScrollBehavior createScrollBehavior() => new OverscrollWhenScrollableBehavior(platform: TargetPlatform.android);
+
+  @override
+  Widget wrapScrollWidget(Widget scrollWidget) => new OverscrollIndicator(child: scrollWidget);
+
+  @override
+  bool updateShouldNotify(ScrollConfigurationDelegate old) => false;
+}
 
 class _MaterialAppState extends State<MaterialApp> {
   HeroController _heroController;
@@ -195,19 +201,11 @@ class _MaterialAppState extends State<MaterialApp> {
   }
 
   ScrollConfigurationDelegate _getScrollDelegate(TargetPlatform platform) {
-    if (config.overscrollStyle != null) {
-      switch (config.overscrollStyle) {
-        case OverscrollStyle.glow:
-          return _glowScroll;
-        case OverscrollStyle.bounce:
-          return _bounceScroll;
-      }
-    }
     switch (platform) {
       case TargetPlatform.android:
-        return _glowScroll;
+        return const _ScrollLikeMountainViewDelegate();
       case TargetPlatform.iOS:
-        return _bounceScroll;
+        return const _ScrollLikeCupertinoDelegate();
     }
     return null;
   }

--- a/packages/flutter/lib/src/material/drop_down.dart
+++ b/packages/flutter/lib/src/material/drop_down.dart
@@ -78,12 +78,21 @@ class _DropDownMenuPainter extends CustomPainter {
 // Do not use the platform-specific default scroll configuration.
 // Dropdown menus should never overscroll or display an overscroll indicator.
 class _DropDownScrollConfigurationDelegate extends ScrollConfigurationDelegate {
-  const _DropDownScrollConfigurationDelegate();
+  const _DropDownScrollConfigurationDelegate(this._platform);
+
+  @override
+  TargetPlatform get platform => _platform;
+  final TargetPlatform _platform;
+
+  @override
+  ExtentScrollBehavior createScrollBehavior() => new OverscrollWhenScrollableBehavior(platform: platform);
 
   @override
   Widget wrapScrollWidget(Widget scrollWidget) => new ClampOverscrolls(value: true, child: scrollWidget);
+
+  @override
+  bool updateShouldNotify(ScrollConfigurationDelegate old) => platform != old.platform;
 }
-final ScrollConfigurationDelegate _dropDownScroll = const _DropDownScrollConfigurationDelegate();
 
 class _DropDownMenu<T> extends StatefulWidget {
   _DropDownMenu({
@@ -170,7 +179,7 @@ class _DropDownMenuState<T> extends State<_DropDownMenu<T>> {
           type: MaterialType.transparency,
           textStyle: route.style,
           child: new ScrollConfiguration(
-            delegate: _dropDownScroll,
+            delegate: new _DropDownScrollConfigurationDelegate(Theme.of(context).platform),
             child: new Scrollbar(
               child: new ScrollableList(
                 scrollableKey: config.route.scrollableKey,

--- a/packages/flutter/lib/src/material/input.dart
+++ b/packages/flutter/lib/src/material/input.dart
@@ -205,6 +205,7 @@ class _InputState extends State<Input> {
         selectionColor: themeData.textSelectionColor,
         selectionHandleBuilder: buildTextSelectionHandle,
         selectionToolbarBuilder: buildTextSelectionToolbar,
+        platform: Theme.of(context).platform,
         keyboardType: config.keyboardType,
         onChanged: onChanged,
         onSubmitted: onSubmitted

--- a/packages/flutter/lib/src/material/tabs.dart
+++ b/packages/flutter/lib/src/material/tabs.dart
@@ -1090,9 +1090,12 @@ class _TabBarViewState<T> extends PageableListState<TabBarView<T>> implements Ta
 
   @override
   ExtentScrollBehavior get scrollBehavior {
-    _boundedBehavior ??= new BoundedBehavior();
+    _boundedBehavior ??= new BoundedBehavior(platform: platform);
     return _boundedBehavior;
   }
+
+  @override
+  TargetPlatform get platform => Theme.of(context).platform;
 
   void _initSelection(TabBarSelectionState<T> selection) {
     _selection = selection;

--- a/packages/flutter/lib/src/widgets/editable.dart
+++ b/packages/flutter/lib/src/widgets/editable.dart
@@ -169,6 +169,7 @@ class RawInputLine extends Scrollable {
     this.selectionColor,
     this.selectionHandleBuilder,
     this.selectionToolbarBuilder,
+    @required this.platform,
     this.keyboardType,
     this.onChanged,
     this.onSubmitted
@@ -206,6 +207,12 @@ class RawInputLine extends Scrollable {
   /// text selection (e.g. copy and paste).
   final TextSelectionToolbarBuilder selectionToolbarBuilder;
 
+  /// The platform whose behavior should be approximated, in particular
+  /// for scroll physics. (See [ScrollBehavior.platform].)
+  ///
+  /// Must not be null.
+  final TargetPlatform platform;
+
   /// The type of keyboard to use for editing the text.
   final KeyboardType keyboardType;
 
@@ -229,7 +236,7 @@ class RawInputLineState extends ScrollableState<RawInputLine> {
   TextSelectionOverlay _selectionOverlay;
 
   @override
-  ScrollBehavior<double, double> createScrollBehavior() => new BoundedBehavior();
+  ScrollBehavior<double, double> createScrollBehavior() => new BoundedBehavior(platform: config.platform);
 
   @override
   BoundedBehavior get scrollBehavior => super.scrollBehavior;

--- a/packages/flutter/lib/src/widgets/pageable_list.dart
+++ b/packages/flutter/lib/src/widgets/pageable_list.dart
@@ -9,6 +9,7 @@ import 'package:flutter/rendering.dart' show RenderList, ViewportDimensions;
 import 'basic.dart';
 import 'framework.dart';
 import 'scroll_behavior.dart';
+import 'scroll_configuration.dart';
 import 'scrollable.dart';
 import 'virtual_viewport.dart';
 
@@ -292,12 +293,17 @@ abstract class PageableState<T extends Pageable> extends ScrollableState<T> {
   @override
   ExtentScrollBehavior get scrollBehavior {
     if (config.itemsWrap) {
-      _unboundedBehavior ??= new UnboundedBehavior();
+      _unboundedBehavior ??= new UnboundedBehavior(platform: platform);
       return _unboundedBehavior;
     }
-    _overscrollBehavior ??= new OverscrollBehavior();
+    _overscrollBehavior ??= new OverscrollBehavior(platform: platform);
     return _overscrollBehavior;
   }
+
+  /// Returns the style of scrolling to use.
+  ///
+  /// By default, defers to the nearest [ScrollConfiguration].
+  TargetPlatform get platform => ScrollConfiguration.of(context)?.platform;
 
   @override
   ExtentScrollBehavior createScrollBehavior() => scrollBehavior;

--- a/packages/flutter/lib/src/widgets/scrollable.dart
+++ b/packages/flutter/lib/src/widgets/scrollable.dart
@@ -6,8 +6,8 @@ import 'dart:async';
 import 'dart:math' as math;
 import 'dart:ui' as ui show window;
 
-import 'package:flutter/physics.dart';
 import 'package:flutter/gestures.dart';
+import 'package:flutter/physics.dart';
 import 'package:meta/meta.dart';
 
 import 'basic.dart';

--- a/packages/flutter/test/widget/lazy_block_fling_test.dart
+++ b/packages/flutter/test/widget/lazy_block_fling_test.dart
@@ -1,0 +1,42 @@
+// Copyright 2015 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter/material.dart';
+
+const double kHeight = 10.0;
+const double kFlingOffset = kHeight * 20.0;
+
+class TestDelegate extends LazyBlockDelegate {
+  @override
+  Widget buildItem(BuildContext context, int index) {
+    return new Container(height: kHeight);
+  }
+
+  @override
+  double estimateTotalExtent(int firstIndex, int lastIndex, double minOffset, double firstStartOffset, double lastEndOffset) {
+    return double.INFINITY;
+  }
+
+  @override
+  bool shouldRebuild(LazyBlockDelegate oldDelegate) => false;
+}
+
+double currentOffset;
+
+void main() {
+  testWidgets('Flings don\'t stutter', (WidgetTester tester) async {
+    await tester.pumpWidget(new LazyBlock(
+      delegate: new TestDelegate(),
+      onScroll: (double scrollOffset) { currentOffset = scrollOffset; },
+    ));
+    await tester.fling(find.byType(LazyBlock), const Offset(0.0, -kFlingOffset), 1000.0);
+    expect(currentOffset, kFlingOffset);
+    while (tester.binding.transientCallbackCount > 0) {
+      double lastOffset = currentOffset;
+      await tester.pump(const Duration(milliseconds: 20));
+      expect(currentOffset, greaterThan(lastOffset));
+    }
+  }, skip: true); // see https://github.com/flutter/flutter/issues/5339
+}

--- a/packages/flutter/test/widget/scroll_behavior_test.dart
+++ b/packages/flutter/test/widget/scroll_behavior_test.dart
@@ -10,7 +10,8 @@ void main() {
   BoundedBehavior behavior = new BoundedBehavior(
     contentExtent: 150.0,
     containerExtent: 75.0,
-    minScrollOffset: -100.0
+    minScrollOffset: -100.0,
+    platform: TargetPlatform.iOS
   );
     expect(behavior.minScrollOffset, equals(-100.0));
     expect(behavior.maxScrollOffset, equals(-25.0));

--- a/packages/flutter/test/widget/scroll_notification_test.dart
+++ b/packages/flutter/test/widget/scroll_notification_test.dart
@@ -6,7 +6,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/widgets.dart';
 
 void main() {
-  testWidgets('Scroll notifcation basics', (WidgetTester tester) async {
+  testWidgets('Scroll notification basics', (WidgetTester tester) async {
     ScrollNotification notification;
 
     await tester.pumpWidget(new NotificationListener<ScrollNotification>(
@@ -48,7 +48,7 @@ void main() {
     expect(notification.dragEndDetails.velocity, equals(Velocity.zero));
   });
 
-  testWidgets('Scroll notifcation depth', (WidgetTester tester) async {
+  testWidgets('Scroll notification depth', (WidgetTester tester) async {
     final List<ScrollNotificationKind> depth0Kinds = <ScrollNotificationKind>[];
     final List<ScrollNotificationKind> depth1Kinds = <ScrollNotificationKind>[];
     final List<int> depth0Values = <int>[];

--- a/packages/flutter/test/widget/scrollable_fling_test.dart
+++ b/packages/flutter/test/widget/scrollable_fling_test.dart
@@ -1,0 +1,61 @@
+// Copyright 2015 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter/material.dart';
+
+class TestDelegate extends LazyBlockDelegate {
+  @override
+  Widget buildItem(BuildContext context, int index) {
+    return new Text('$index');
+  }
+
+  @override
+  double estimateTotalExtent(int firstIndex, int lastIndex, double minOffset, double firstStartOffset, double lastEndOffset) {
+    return double.INFINITY;
+  }
+
+  @override
+  bool shouldRebuild(LazyBlockDelegate oldDelegate) => false;
+}
+
+double currentOffset;
+
+Future<Null> pumpTest(WidgetTester tester, TargetPlatform platform) async {
+  await tester.pumpWidget(new Container());
+  await tester.pumpWidget(new MaterialApp(
+    theme: new ThemeData(
+      platform: platform
+    ),
+    home: new LazyBlock(
+      delegate: new TestDelegate(),
+      onScroll: (double scrollOffset) { currentOffset = scrollOffset; },
+    ),
+  ));
+  return null;
+}
+
+const double dragOffset = 213.82;
+
+void main() {
+  testWidgets('Flings on different platforms', (WidgetTester tester) async {
+    await pumpTest(tester, TargetPlatform.android);
+    await tester.fling(find.byType(LazyBlock), const Offset(0.0, -dragOffset), 1000.0);
+    expect(currentOffset, dragOffset);
+    await tester.pump(); // trigger fling
+    expect(currentOffset, dragOffset);
+    await tester.pump(const Duration(seconds: 5));
+    final double result1 = currentOffset;
+
+    await pumpTest(tester, TargetPlatform.iOS);
+    await tester.fling(find.byType(LazyBlock), const Offset(0.0, -dragOffset), 1000.0);
+    expect(currentOffset, dragOffset);
+    await tester.pump(); // trigger fling
+    expect(currentOffset, dragOffset);
+    await tester.pump(const Duration(seconds: 5));
+    final double result2 = currentOffset;
+
+    expect(result1, lessThan(result2)); // iOS (result2) is slipperier than Android (result1)
+  });
+}

--- a/packages/flutter_test/lib/src/widget_tester.dart
+++ b/packages/flutter_test/lib/src/widget_tester.dart
@@ -36,9 +36,9 @@ typedef Future<Null> WidgetTesterCallback(WidgetTester widgetTester);
 ///
 /// Example:
 ///
-///     testWidgets('MyWidget', (WidgetTester tester) {
-///       tester.pumpWidget(new MyWidget());
-///       tester.tap(find.text('Save'));
+///     testWidgets('MyWidget', (WidgetTester tester) async {
+///       await tester.pumpWidget(new MyWidget());
+///       await tester.tap(find.text('Save'));
 ///       expect(tester, hasWidget(find.text('Success')));
 ///     });
 void testWidgets(String description, WidgetTesterCallback callback, {
@@ -77,12 +77,12 @@ void testWidgets(String description, WidgetTesterCallback callback, {
 ///
 ///     main() async {
 ///       assert(false); // fail in checked mode
-///       await benchmarkWidgets((WidgetTester tester) {
-///         tester.pumpWidget(new MyWidget());
+///       await benchmarkWidgets((WidgetTester tester) async {
+///         await tester.pumpWidget(new MyWidget());
 ///         final Stopwatch timer = new Stopwatch()..start();
 ///         for (int index = 0; index < 10000; index += 1) {
-///           tester.tap(find.text('Tap me'));
-///           tester.pump();
+///           await tester.tap(find.text('Tap me'));
+///           await tester.pump();
 ///         }
 ///         timer.stop();
 ///         debugPrint('Time taken: ${timer.elapsedMilliseconds}ms');
@@ -99,7 +99,7 @@ Future<Null> benchmarkWidgets(WidgetTesterCallback callback) {
     print('│  enabled will not accurately reflect the performance  │');
     print('│  that will be experienced by end users using release  ╎');
     print('│  builds. Benchmarks should be run using this command  ┆');
-    print('│  line:  flutter run --release -t benchmark.dart       ┊');
+    print('│  line:  flutter run --release benchmark.dart          ┊');
     print('│                                                        ');
     print('└─────────────────────────────────────────────────╌┄┈  🐢');
     return true;
@@ -172,6 +172,7 @@ class WidgetTester extends WidgetController implements HitTestDispatcher {
   ///
   /// This is a convenience function that just calls
   /// [TestWidgetsFlutterBinding.pump].
+  @override
   Future<Null> pump([
     Duration duration,
     EnginePhase phase = EnginePhase.sendSemanticsTree


### PR DESCRIPTION
Changes in this patch:
- iOS now uses a different scrollDrag constant than Android.
  - ScrollConfigurationDelegate now knows about target platforms.
  - ScrollBehaviors now know about target platforms.
  - RawInputLine now has to be told what platform it's targetting.
  - PageableList now has a concept of target platform.
- make debugPrintStack filter its stack.
  - move debugPrintStack to `assertions.dart`.
- add support for limiting the number of frames to debugPrintStack.
- make defaultTargetPlatform default to android in test environments.
- remove OverscrollStyle and MaterialApp's overscrollStyle argument. You
  can now control the overscroll style using Theme.platform.
- the default scroll configuration is now private to avoid people
  relying on the defaultTargetPlatform getter in their subclasses (since
  they really should use Theme.of(context).platform).
- fix some typos I noticed in some tests.
- added a test for flinging scrollables, that checks that the behavior
  differs on the two target platforms.
- made flingFrom and fling in the test API pump the frames.
- added more docs to the test API.
- made the TestAsyncUtils.guard() method report uncaught errors to help
  debug errors when using that API.

I also added a skipped test that shows a bug in LazyBlock flinging.
See https://github.com/flutter/flutter/issues/5339
