### PR TITLE
When a list is scrolling, children can't be tapped

### DIFF
--- a/packages/flutter/lib/src/widgets/scrollable.dart
+++ b/packages/flutter/lib/src/widgets/scrollable.dart
@@ -259,7 +259,8 @@ class ScrollableState<T extends Scrollable> extends State<T> {
 
   @override
   void dispose() {
-    _stop();
+    _controller.dispose();
+    _simulation = null;
     super.dispose();
   }
 
@@ -367,8 +368,10 @@ class ScrollableState<T extends Scrollable> extends State<T> {
   }
 
   void _handleAnimationStatusChanged(AnimationStatus status) {
-    if (!_controller.isAnimating)
-      _simulation = null;
+    setState(() {
+      if (!_controller.isAnimating)
+        _simulation = null;
+    });
   }
 
   void _setScrollOffset(double newScrollOffset, { DragUpdateDetails details }) {
@@ -579,9 +582,12 @@ class ScrollableState<T extends Scrollable> extends State<T> {
   }
 
   void _stop() {
+    assert(mounted);
     assert(_controller.isAnimating || _simulation == null);
-    _controller.stop();
-    _simulation = null;
+    setState(() {
+      _controller.stop();
+      _simulation = null;
+    });
   }
 
   void _handleDragStart(DragStartDetails details) {
@@ -652,7 +658,10 @@ class ScrollableState<T extends Scrollable> extends State<T> {
       key: _gestureDetectorKey,
       gestures: buildGestureDetectors(),
       behavior: HitTestBehavior.opaque,
-      child: buildContent(context)
+      child: new IgnorePointer(
+        ignoring: _controller.isAnimating,
+        child: buildContent(context)
+      )
     );
   }
 

--- a/packages/flutter/test/widget/scrollable_fling_test.dart
+++ b/packages/flutter/test/widget/scrollable_fling_test.dart
@@ -58,4 +58,49 @@ void main() {
 
     expect(result1, lessThan(result2)); // iOS (result2) is slipperier than Android (result1)
   });
+
+  testWidgets('fling and tap to stop', (WidgetTester tester) async {
+    List<String> log = <String>[];
+
+    List<Widget> textWidgets = <Widget>[];
+    for (int i = 0; i < 250; i++)
+      textWidgets.add(new GestureDetector(onTap: () { log.add('tap $i'); }, child: new Text('$i')));
+    await tester.pumpWidget(new Block(children: textWidgets));
+
+    expect(log, equals(<String>[]));
+    await tester.tap(find.byType(Scrollable));
+    await tester.pump(const Duration(milliseconds: 50));
+    expect(log, equals(<String>['tap 18']));
+    await tester.fling(find.byType(Scrollable), new Offset(0.0, -200.0), 1000.0);
+    await tester.pump(const Duration(milliseconds: 50));
+    expect(log, equals(<String>['tap 18']));
+    await tester.tap(find.byType(Scrollable));
+    await tester.pump(const Duration(milliseconds: 50));
+    expect(log, equals(<String>['tap 18']));
+    await tester.tap(find.byType(Scrollable));
+    await tester.pump(const Duration(milliseconds: 50));
+    expect(log, equals(<String>['tap 18', 'tap 31']));
+  });
+
+  testWidgets('fling and wait and tap', (WidgetTester tester) async {
+    List<String> log = <String>[];
+
+    List<Widget> textWidgets = <Widget>[];
+    for (int i = 0; i < 250; i++)
+      textWidgets.add(new GestureDetector(onTap: () { log.add('tap $i'); }, child: new Text('$i')));
+    await tester.pumpWidget(new Block(children: textWidgets));
+
+    expect(log, equals(<String>[]));
+    await tester.tap(find.byType(Scrollable));
+    await tester.pump(const Duration(milliseconds: 50));
+    expect(log, equals(<String>['tap 18']));
+    await tester.fling(find.byType(Scrollable), new Offset(0.0, -200.0), 1000.0);
+    await tester.pump(const Duration(milliseconds: 50));
+    expect(log, equals(<String>['tap 18']));
+    await tester.pump(const Duration(seconds: 50));
+    expect(log, equals(<String>['tap 18']));
+    await tester.tap(find.byType(Scrollable));
+    await tester.pump(const Duration(milliseconds: 50));
+    expect(log, equals(<String>['tap 18', 'tap 48']));
+  });
 }


### PR DESCRIPTION
Fixes #5023 better than #5222 did.

The key difference is that since the controller's state is now used in the build function, we have to setState() in the _stop() function and in the status handler.

Also added more tests.
