### PR TITLE
Update gallery application version and label

### DIFF
--- a/examples/flutter_gallery/android/AndroidManifest.xml
+++ b/examples/flutter_gallery/android/AndroidManifest.xml
@@ -8,7 +8,7 @@
     <uses-sdk android:minSdkVersion="14" android:targetSdkVersion="21" />
     <uses-permission android:name="android.permission.INTERNET"/>
 
-    <application android:icon="@mipmap/ic_launcher" android:label="Flutter Gallery" android:name="org.domokit.sky.shell.SkyApplication">
+    <application android:icon="@mipmap/ic_launcher" android:label="Gallery" android:name="org.domokit.sky.shell.SkyApplication">
         <activity android:configChanges="orientation|keyboardHidden|keyboard|screenSize" android:hardwareAccelerated="true" android:launchMode="singleTask" android:name="org.domokit.sky.shell.SkyActivity" android:theme="@android:style/Theme.Black.NoTitleBar" android:screenOrientation="sensorPortrait">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/examples/flutter_gallery/ios/Runner/Info.plist
+++ b/examples/flutter_gallery/ios/Runner/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>
-	<string>Flutter Gallery</string>
+	<string>Gallery</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>

--- a/examples/flutter_gallery/lib/gallery/drawer.dart
+++ b/examples/flutter_gallery/lib/gallery/drawer.dart
@@ -119,7 +119,7 @@ class GalleryDrawer extends StatelessWidget {
             )
           ),
           new AboutDrawerItem(
-            applicationVersion: '2016 Q2 Preview',
+            applicationVersion: '2016 Q3 Preview',
             applicationIcon: new AssetImage('packages/flutter_gallery_assets/about_logo.png'),
             applicationLegalese: '© 2016 The Chromium Authors',
             aboutBoxChildren: <Widget>[


### PR DESCRIPTION
- The application's label is now just "Gallery". Since it appears below our logo, the Flutter part is pretty explicit anyway.
- The application's version is now '2016 Q3 Preview'

Fixes: #5356
Fixes: #5357
Fixes: #5360
