### PR TITLE
Changed IconButton not to exceed its splash size.

### DIFF
--- a/packages/flutter/lib/src/material/icon_button.dart
+++ b/packages/flutter/lib/src/material/icon_button.dart
@@ -11,6 +11,7 @@ import 'icon_theme.dart';
 import 'icon_theme_data.dart';
 import 'icons.dart';
 import 'ink_well.dart';
+import 'material.dart';
 import 'theme.dart';
 import 'tooltip.dart';
 
@@ -123,15 +124,20 @@ class IconButton extends StatelessWidget {
       child: new LimitedBox(
         maxWidth: size,
         maxHeight: size,
-        child: new Align(
-          alignment: alignment,
-          child: new IconTheme.merge(
-            context: context,
-            data: new IconThemeData(
-              size: size,
-              color: currentColor
-            ),
-            child: icon
+        child: new ConstrainedBox(
+          constraints: new BoxConstraints.loose(
+            const Size.square(kDefaultSplashRadius * 2.0)
+          ),
+          child: new Align(
+            alignment: alignment,
+            child: new IconTheme.merge(
+              context: context,
+              data: new IconThemeData(
+                size: size,
+                color: currentColor
+              ),
+              child: icon
+            )
           )
         )
       )

--- a/packages/flutter/lib/src/material/material.dart
+++ b/packages/flutter/lib/src/material/material.dart
@@ -288,7 +288,7 @@ class _MaterialState extends State<Material> {
 const Duration _kHighlightFadeDuration = const Duration(milliseconds: 200);
 const Duration _kUnconfirmedSplashDuration = const Duration(seconds: 1);
 
-const double _kDefaultSplashRadius = 35.0; // logical pixels
+const double kDefaultSplashRadius = 35.0; // logical pixels
 const double _kSplashConfirmedVelocity = 1.0; // logical pixels per millisecond
 const double _kSplashInitialSize = 0.0; // logical pixels
 
@@ -326,7 +326,7 @@ class _RenderInkFeatures extends RenderProxyBox implements MaterialInkController
       radius = _getSplashTargetSize(size, position);
     } else {
       assert(rectCallback == null);
-      radius = _kDefaultSplashRadius;
+      radius = kDefaultSplashRadius;
     }
     _InkSplash splash = new _InkSplash(
       renderer: this,
@@ -639,7 +639,7 @@ class _InkHighlight extends InkFeature implements InkHighlight {
     if (shape == BoxShape.rectangle)
       canvas.drawRect(rect, paint);
     else
-      canvas.drawCircle(rect.center, _kDefaultSplashRadius, paint);
+      canvas.drawCircle(rect.center, kDefaultSplashRadius, paint);
   }
 
   @override

--- a/packages/flutter/test/material/icon_button_test.dart
+++ b/packages/flutter/test/material/icon_button_test.dart
@@ -1,0 +1,46 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('IconButton test constrained size', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      new Material(
+        child: new Center(
+          child: new IconButton(
+            padding: EdgeInsets.zero,
+            onPressed: () {},
+            icon: new Icon(Icons.ac_unit)
+          )
+        )
+      )
+    );
+
+    RenderBox box = tester.renderObject(find.byType(IconButton));
+    expect(box.size.width, equals(kDefaultSplashRadius * 2.0));
+    expect(box.size.height, equals(kDefaultSplashRadius * 2.0));
+  });
+
+  testWidgets('IconButton AppBar size', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      new Scaffold(
+        appBar: new AppBar(
+          actions: <Widget>[
+            new IconButton(
+              padding: EdgeInsets.zero,
+              onPressed: () {},
+              icon: new Icon(Icons.ac_unit)
+            )
+          ]
+        )
+      )
+    );
+
+    RenderBox barBox = tester.renderObject(find.byType(AppBar));
+    RenderBox iconBox = tester.renderObject(find.byType(IconButton));
+    expect(iconBox.size.height, equals(barBox.size.height));
+  });
+}


### PR DESCRIPTION
Using IconButton inside of a bigger Material before would result
in having a hit box as large as the whole Material. This commit
constrains the size of the hit box and splashes to the default
diameter of a splash.
