### PR TITLE
show better errors for gradle build failures

### DIFF
--- a/packages/flutter_tools/lib/executable.dart
+++ b/packages/flutter_tools/lib/executable.dart
@@ -106,8 +106,8 @@ Future<Null> main(List<String> args) async {
 
       flutterUsage.sendException(error, chain);
 
-      if (Platform.environment.containsKey('FLUTTER_DEV') || isRunningOnBot) {
-        // If we're working on the tools themselves, just print the stack trace.
+      if (isRunningOnBot) {
+        // Print the stack trace on the bots - don't write a crash report.
         stderr.writeln('$error');
         stderr.writeln(chain.terse.toString());
       } else {

--- a/packages/flutter_tools/lib/src/android/gradle.dart
+++ b/packages/flutter_tools/lib/src/android/gradle.dart
@@ -130,15 +130,20 @@ Future<int> buildGradleProject(BuildMode buildMode) async {
     }
 
     // Run 'gradle wrapper'.
-    Status status = logger.startProgress('Running \'gradle wrapper\'...');
-    int exitcode = await runCommandAndStreamOutput(
-      <String>[gradle, 'wrapper'],
-      workingDirectory: 'android',
-      allowReentrantFlutter: true
-    );
-    status.stop(showElapsedTime: true);
-    if (exitcode != 0)
-      return exitcode;
+    try {
+      Status status = logger.startProgress('Running \'gradle wrapper\'...');
+      int exitcode = await runCommandAndStreamOutput(
+        <String>[gradle, 'wrapper'],
+        workingDirectory: 'android',
+        allowReentrantFlutter: true
+      );
+      status.stop(showElapsedTime: true);
+      if (exitcode != 0)
+        return exitcode;
+    } catch (error) {
+      printError('$error');
+      return 1;
+    }
 
     gradlew = locateProjectGradlew();
     if (gradlew == null) {

--- a/packages/flutter_tools/lib/src/base/logger.dart
+++ b/packages/flutter_tools/lib/src/base/logger.dart
@@ -6,6 +6,8 @@ import 'dart:async';
 import 'dart:convert' show ASCII;
 import 'dart:io';
 
+import 'package:stack_trace/stack_trace.dart';
+
 final AnsiTerminal terminal = new AnsiTerminal();
 
 abstract class Logger {
@@ -55,7 +57,7 @@ class StdoutLogger extends Logger {
 
     stderr.writeln(message);
     if (stackTrace != null)
-      stderr.writeln(stackTrace);
+      stderr.writeln(new Chain.forTrace(stackTrace).terse.toString());
   }
 
   @override


### PR DESCRIPTION
- fix #5358 
- show better errors for gradle build errors (print the process exception, not a stack trace)
- print terse stack traces when we do show traces to users
- remove an old reference to the env var `FLUTTER_DEV`

```
Running 'pub get' in hello_services...               0.6s
Running 'gradle wrapper'...                              
ProcessException: No such file or directory
  Command: /Users/.../bin/gradle wrapper
```
