### PR TITLE
GestureDetector fills its parent if child-less.

### DIFF
--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -1713,6 +1713,10 @@ typedef void PointerUpEventListener(PointerUpEvent event);
 typedef void PointerCancelEventListener(PointerCancelEvent event);
 
 /// Calls callbacks in response to pointer events.
+///
+/// If it has a child, defers to the child for sizing behavior.
+///
+/// If it does not have a child, grows to fit the parent-provided constraints.
 class RenderPointerListener extends RenderProxyBoxWithHitTestBehavior {
   /// Creates a render object that forwards point events to callbacks.
   ///
@@ -1732,11 +1736,18 @@ class RenderPointerListener extends RenderProxyBoxWithHitTestBehavior {
   /// Called when a pointer that triggered an [onPointerDown] changes position.
   PointerMoveEventListener onPointerMove;
 
-  /// Called when a pointer that triggered an [onPointerDown] is no longer in contact with the screen.
+  /// Called when a pointer that triggered an [onPointerDown] is no longer in
+  /// contact with the screen.
   PointerUpEventListener onPointerUp;
 
-  /// Called when the input from a pointer that triggered an [onPointerDown] is no longer directed towards this receiver.
+  /// Called when the input from a pointer that triggered an [onPointerDown] is
+  /// no longer directed towards this receiver.
   PointerCancelEventListener onPointerCancel;
+
+  @override
+  void performResize() {
+    size = constraints.biggest;
+  }
 
   @override
   void handleEvent(PointerEvent event, HitTestEntry entry) {

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -2477,6 +2477,9 @@ class WidgetToRenderBoxAdapter extends LeafRenderObjectWidget {
 ///
 /// Rather than listening for raw pointer events, consider listening for
 /// higher-level gestures using [GestureDetector].
+///
+/// If it has a child, this widget defers to the child for sizing behavior. If
+/// it does not have a child, it grows to fit the parent instead.
 class Listener extends SingleChildRenderObjectWidget {
   /// Creates a widget that forwards point events to callbacks.
   ///

--- a/packages/flutter/lib/src/widgets/gesture_detector.dart
+++ b/packages/flutter/lib/src/widgets/gesture_detector.dart
@@ -40,6 +40,9 @@ typedef GestureRecognizer GestureRecognizerFactory(GestureRecognizer recognizer)
 ///
 /// Attempts to recognize gestures that correspond to its non-null callbacks.
 ///
+/// If this widget has a child, it defers to that child for its sizing behavior.
+/// If it does not have a child, it grows to fit the parent instead.
+///
 /// GestureDetector also listens for accessibility events and maps
 /// them to the callbacks. To ignore accessibility events, set
 /// [excludeFromSemantics] to true.

--- a/packages/flutter/test/widget/gesture_detector_test.dart
+++ b/packages/flutter/test/widget/gesture_detector_test.dart
@@ -190,4 +190,37 @@ void main() {
     expect(didTap, isTrue);
 
   });
+
+  testWidgets('Empty', (WidgetTester tester) async {
+    bool didTap = false;
+    await tester.pumpWidget(
+      new Center(
+        child: new GestureDetector(
+          onTap: () {
+            didTap = true;
+          },
+        )
+      )
+    );
+    expect(didTap, isFalse);
+    await tester.tapAt(new Point(10.0, 10.0));
+    expect(didTap, isTrue);
+  });
+
+  testWidgets('Only container', (WidgetTester tester) async {
+    bool didTap = false;
+    await tester.pumpWidget(
+      new Center(
+        child: new GestureDetector(
+          onTap: () {
+            didTap = true;
+          },
+          child: new Container(),
+        )
+      )
+    );
+    expect(didTap, isFalse);
+    await tester.tapAt(new Point(10.0, 10.0));
+    expect(didTap, isFalse);
+  });
 }


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/5380
