### PR TITLE
Grammar check on README in Flutter gallery example

### DIFF
--- a/examples/flutter_gallery/README.md
+++ b/examples/flutter_gallery/README.md
@@ -18,7 +18,7 @@ the [Flutter Setup](https://flutter.io/setup/) guide.
 * `flutter upgrade`
 * `flutter run --release`
 
-The `flutter run --release` command both builds and installed the Flutter app.
+The `flutter run --release` command both builds and installs the Flutter app.
 
 ## Icon
 


### PR DESCRIPTION
installed changed to installs:
The `flutter run --release` command both builds and installed the Flutter app.
changed to 
The `flutter run --release` command both builds and installs the Flutter app.
