### PR TITLE
update the cache earlier

### DIFF
--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -160,7 +160,8 @@ abstract class FlutterCommand extends Command {
       }
     }
 
-    // Populate the cache.
+    // Populate the cache. We call this before pub get below so that the sky_engine
+    // package is available in the flutter cache for pub to find.
     await cache.updateAll();
 
     if (shouldRunPub) {

--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -160,14 +160,14 @@ abstract class FlutterCommand extends Command {
       }
     }
 
+    // Populate the cache.
+    await cache.updateAll();
+
     if (shouldRunPub) {
       int exitCode = await pubGet();
       if (exitCode != 0)
         return exitCode;
     }
-
-    // Populate the cache.
-    await cache.updateAll();
 
     if (flutterUsage.isFirstRun)
       flutterUsage.printUsage();


### PR DESCRIPTION
- update the flutter cache earlier (fix https://github.com/flutter/flutter/issues/5269)

pub get was running before we'd downloaded the packages (like sky_engine) to the flutter cache; this moves cache population to before we try and run pub get.
