### PR TITLE
fix an issue where --hot would not exit

### DIFF
--- a/packages/flutter_tools/lib/src/devfs.dart
+++ b/packages/flutter_tools/lib/src/devfs.dart
@@ -264,9 +264,9 @@ class DevFS {
     return _baseUri;
   }
 
-  Future<dynamic> destroy() async {
+  Future<dynamic> destroy() {
     printTrace('DevFS: Deleted filesystem on the device ($_baseUri)');
-    return await _operations.destroy(fsName);
+    return _operations.destroy(fsName);
   }
 
   void _reset() {

--- a/packages/flutter_tools/lib/src/hot.dart
+++ b/packages/flutter_tools/lib/src/hot.dart
@@ -390,7 +390,7 @@ class HotRunner extends ResidentRunner {
       // Cleanup the devFS; don't wait indefinitely, and ignore any errors.
       await _devFS.destroy()
         .timeout(new Duration(milliseconds: 250))
-        .catchError((error) {
+        .catchError((dynamic error) {
           printTrace('$error');
         });
     }
@@ -513,6 +513,7 @@ class HotRunner extends ResidentRunner {
     await stopApp();
   }
 
+  @override
   Future<Null> preStop() => _cleanupDevFS();
 
   @override

--- a/packages/flutter_tools/lib/src/hot.dart
+++ b/packages/flutter_tools/lib/src/hot.dart
@@ -295,7 +295,7 @@ class HotRunner extends ResidentRunner {
     }
 
     await viewManager.refresh();
-    printStatus('Connected to view: ${viewManager.mainView}');
+    printStatus('Connected to view \'${viewManager.mainView}\'.');
 
     printStatus('Running ${getDisplayPath(_mainPath)} on ${device.name}...');
     _loaderShowMessage('Launching...');
@@ -313,7 +313,7 @@ class HotRunner extends ResidentRunner {
     // Finish the file sync now.
     await _updateDevFS();
 
-    return await waitForAppToFinish();
+    return waitForAppToFinish();
   }
 
   @override
@@ -375,9 +375,8 @@ class HotRunner extends ResidentRunner {
   }
 
   Future<Null> _evictDirtyAssets() async {
-    if (_devFS.dirtyAssetEntries.length == 0) {
+    if (_devFS.dirtyAssetEntries.length == 0)
       return;
-    }
     if (serviceProtocol.firstIsolateId == null)
       throw 'Application isolate not found';
     for (DevFSEntry entry in _devFS.dirtyAssetEntries) {
@@ -388,8 +387,12 @@ class HotRunner extends ResidentRunner {
 
   Future<Null> _cleanupDevFS() async {
     if (_devFS != null) {
-      // Cleanup the devFS.
-      await _devFS.destroy();
+      // Cleanup the devFS; don't wait indefinitely, and ignore any errors.
+      await _devFS.destroy()
+        .timeout(new Duration(milliseconds: 250))
+        .catchError((error) {
+          printTrace('$error');
+        });
     }
     _devFS = null;
   }
@@ -499,9 +502,8 @@ class HotRunner extends ResidentRunner {
 
   @override
   void printHelp() {
-    printStatus('Type "h" or F1 for this help message. Type "q", F10, or ctrl-c to quit.', emphasis: true);
-    printStatus('Type "r" or F5 to perform a hot reload of the app.', emphasis: true);
-    printStatus('Type "R" to restart the app', emphasis: true);
+    printStatus('Type "h" or F1 for this help message; type "q", F10, or ctrl-c to quit.', emphasis: true);
+    printStatus('Type "r" or F5 to perform a hot reload of the app, and "R" to restart the app.', emphasis: true);
     printStatus('Type "w" to print the widget hierarchy of the app, and "t" for the render tree.', emphasis: true);
   }
 
@@ -510,6 +512,8 @@ class HotRunner extends ResidentRunner {
     await stopEchoingDeviceLog();
     await stopApp();
   }
+
+  Future<Null> preStop() => _cleanupDevFS();
 
   @override
   Future<Null> cleanupAtFinish() async {

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -43,6 +43,7 @@ abstract class ResidentRunner {
 
   Future<Null> stop() async {
     await stopEchoingDeviceLog();
+    await preStop();
     return stopApp();
   }
 
@@ -127,7 +128,7 @@ abstract class ResidentRunner {
       return true;
     } else if (lower == 'q' || character == AnsiTerminal.KEY_F10) {
       // F10, exit
-      await stopApp();
+      await stop();
       return true;
     }
 
@@ -171,15 +172,16 @@ abstract class ResidentRunner {
     return exitCode;
   }
 
-  Future<Null> stopApp() {
+  Future<Null> preStop() async { }
+
+  Future<Null> stopApp() async {
     if (serviceProtocol != null && !serviceProtocol.isClosed) {
       if (serviceProtocol.isolates.isNotEmpty) {
         serviceProtocol.flutterExit(serviceProtocol.firstIsolateId);
-        return new Future<Null>.delayed(new Duration(milliseconds: 100));
+        await new Future<Null>.delayed(new Duration(milliseconds: 100));
       }
     }
     appFinished();
-    return new Future<Null>.value();
   }
 
   /// Called when a signal has requested we exit.

--- a/packages/flutter_tools/lib/src/run.dart
+++ b/packages/flutter_tools/lib/src/run.dart
@@ -213,7 +213,7 @@ class RunAndStayResident extends ResidentRunner {
       stop();
     }
 
-    return await waitForAppToFinish();
+    return waitForAppToFinish();
   }
 
   @override


### PR DESCRIPTION
- fix an issue where `flutter run --hot` would not exit (fix https://github.com/flutter/flutter/issues/5418)

The app on the phone was being closed before we cleaned up the dev file system (`_devFS.destroy()`). The call to dispose the dev fs would fail (or not return?), and the completer that we were waiting on to exit the process would never be completed. This PR ensures that the devfs is disposed before the app is closed, and that we're tolerant of issues calling _devFS.destroy().

Also, some tweaks to the verbiage and instructions.

@eseidelGoogle, @johnmccutchan 
