### PR TITLE
Improve the debugPaintPointersEnabled feature.

### DIFF
--- a/packages/flutter/lib/src/material/slider.dart
+++ b/packages/flutter/lib/src/material/slider.dart
@@ -326,6 +326,7 @@ class _RenderSlider extends RenderConstrainedBox implements SemanticActionHandle
 
   @override
   void handleEvent(PointerEvent event, BoxHitTestEntry entry) {
+    assert(debugHandleEvent(event, entry));
     if (event is PointerDownEvent && isInteractive)
       _drag.addPointer(event);
   }

--- a/packages/flutter/lib/src/material/switch.dart
+++ b/packages/flutter/lib/src/material/switch.dart
@@ -286,6 +286,7 @@ class _RenderSwitch extends RenderToggleable {
 
   @override
   void handleEvent(PointerEvent event, BoxHitTestEntry entry) {
+    assert(debugHandleEvent(event, entry));
     if (event is PointerDownEvent && onChanged != null)
       _drag.addPointer(event);
     super.handleEvent(event, entry);

--- a/packages/flutter/lib/src/material/toggleable.dart
+++ b/packages/flutter/lib/src/material/toggleable.dart
@@ -242,6 +242,7 @@ abstract class RenderToggleable extends RenderConstrainedBox implements Semantic
 
   @override
   void handleEvent(PointerEvent event, BoxHitTestEntry entry) {
+    assert(debugHandleEvent(event, entry));
     if (event is PointerDownEvent && isInteractive)
       _tap.addPointer(event);
   }

--- a/packages/flutter/lib/src/rendering/debug.dart
+++ b/packages/flutter/lib/src/rendering/debug.dart
@@ -42,10 +42,15 @@ bool debugPaintLayerBordersEnabled = false;
 /// The color to use when painting Layer borders.
 Color debugPaintLayerBordersColor = const Color(0xFFFF9800);
 
-/// Causes RenderBox objects to flash while they are being tapped.
-bool debugPaintPointersEnabled = false;
+/// Causes objects like [RenderPointerListener] to flash while they are being
+/// tapped. This can be useful to see how large the hit box is, e.g. when
+/// debugging buttons that are harder to hit than expected.
+///
+/// For details on how to support this in your [RenderBox] subclass, see
+/// [RenderBox.debugHandleEvent].
+bool debugPaintPointersEnabled = true;
 
-/// The color to use when reporting pointers.
+/// The color to use when reporting pointers for [debugPaintPointersEnabled].
 int debugPaintPointersColorValue = 0x00BBBB;
 
 /// Overlay a rotating set of colors when repainting layers in checked mode.

--- a/packages/flutter/lib/src/rendering/editable_line.dart
+++ b/packages/flutter/lib/src/rendering/editable_line.dart
@@ -209,6 +209,7 @@ class RenderEditableLine extends RenderBox {
 
   @override
   void handleEvent(PointerEvent event, BoxHitTestEntry entry) {
+    assert(debugHandleEvent(event, entry));
     if (event is PointerDownEvent && onSelectionChanged != null) {
       _tap.addPointer(event);
       _longPress.addPointer(event);

--- a/packages/flutter/lib/src/rendering/paragraph.dart
+++ b/packages/flutter/lib/src/rendering/paragraph.dart
@@ -132,6 +132,7 @@ class RenderParagraph extends RenderBox {
 
   @override
   void handleEvent(PointerEvent event, BoxHitTestEntry entry) {
+    assert(debugHandleEvent(event, entry));
     if (event is! PointerDownEvent)
       return;
     _layoutText(minWidth: constraints.minWidth, maxWidth: constraints.maxWidth);

--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -1771,6 +1771,7 @@ class RenderPointerListener extends RenderProxyBoxWithHitTestBehavior {
 
   @override
   void handleEvent(PointerEvent event, HitTestEntry entry) {
+    assert(debugHandleEvent(event, entry));
     if (onPointerDown != null && event is PointerDownEvent)
       return onPointerDown(event);
     if (onPointerMove != null && event is PointerMoveEvent)


### PR DESCRIPTION
We have so many render objects going on these days that showing every
box that gets an event just makes the screen blue. This limits it down
to only the ones that are actually doing something with the events.

I need this to help track down https://github.com/flutter/flutter/issues/5201
