### PR TITLE
Handle changing clip delegates

### DIFF
--- a/packages/flutter/test/widget/clip_test.dart
+++ b/packages/flutter/test/widget/clip_test.dart
@@ -15,7 +15,25 @@ class PathClipper extends CustomClipper<Path> {
       ..addRect(new Rect.fromLTWH(50.0, 50.0, 100.0, 100.0));
   }
   @override
-  bool shouldRepaint(PathClipper oldWidget) => false;
+  bool shouldRepaint(PathClipper oldClipper) => false;
+}
+
+class ValueClipper<T> extends CustomClipper<T> {
+  ValueClipper(this.message, this.value);
+
+  final String message;
+  final T value;
+
+  @override
+  T getClip(Size size) {
+    log.add(message);
+    return value;
+  }
+
+  @override
+  bool shouldRepaint(ValueClipper<T> oldClipper) {
+    return oldClipper.message != message || oldClipper.value != value;
+  }
 }
 
 void main() {
@@ -26,7 +44,6 @@ void main() {
         child: new GestureDetector(
           behavior: HitTestBehavior.opaque,
           onTap: () { log.add('tap'); },
-          child: new Container()
         )
       )
     );
@@ -47,7 +64,6 @@ void main() {
         child: new GestureDetector(
           behavior: HitTestBehavior.opaque,
           onTap: () { log.add('tap'); },
-          child: new Container()
         )
       )
     );
@@ -61,4 +77,127 @@ void main() {
     expect(log, equals(<String>['tap']));
     log.clear();
   });
+
+  testWidgets('ClipRect', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      new Align(
+        alignment: FractionalOffset.topLeft,
+        child: new SizedBox(
+          width: 100.0,
+          height: 100.0,
+          child: new ClipRect(
+            clipper: new ValueClipper<Rect>('a', new Rect.fromLTWH(5.0, 5.0, 10.0, 10.0)),
+            child: new GestureDetector(
+              behavior: HitTestBehavior.opaque,
+              onTap: () { log.add('tap'); },
+            )
+          )
+        )
+      )
+    );
+    expect(log, equals(<String>['a']));
+
+    await tester.tapAt(new Point(10.0, 10.0));
+    expect(log, equals(<String>['a', 'tap']));
+
+    await tester.tapAt(new Point(100.0, 100.0));
+    expect(log, equals(<String>['a', 'tap']));
+
+    await tester.pumpWidget(
+      new Align(
+        alignment: FractionalOffset.topLeft,
+        child: new SizedBox(
+          width: 100.0,
+          height: 100.0,
+          child: new ClipRect(
+            clipper: new ValueClipper<Rect>('a', new Rect.fromLTWH(5.0, 5.0, 10.0, 10.0)),
+            child: new GestureDetector(
+              behavior: HitTestBehavior.opaque,
+              onTap: () { log.add('tap'); },
+            )
+          )
+        )
+      )
+    );
+    expect(log, equals(<String>['a', 'tap']));
+
+    await tester.pumpWidget(
+      new Align(
+        alignment: FractionalOffset.topLeft,
+        child: new SizedBox(
+          width: 200.0,
+          height: 200.0,
+          child: new ClipRect(
+            clipper: new ValueClipper<Rect>('a', new Rect.fromLTWH(5.0, 5.0, 10.0, 10.0)),
+            child: new GestureDetector(
+              behavior: HitTestBehavior.opaque,
+              onTap: () { log.add('tap'); },
+            )
+          )
+        )
+      )
+    );
+    expect(log, equals(<String>['a', 'tap', 'a']));
+
+    await tester.pumpWidget(
+      new Align(
+        alignment: FractionalOffset.topLeft,
+        child: new SizedBox(
+          width: 200.0,
+          height: 200.0,
+          child: new ClipRect(
+            clipper: new ValueClipper<Rect>('a', new Rect.fromLTWH(5.0, 5.0, 10.0, 10.0)),
+            child: new GestureDetector(
+              behavior: HitTestBehavior.opaque,
+              onTap: () { log.add('tap'); },
+            )
+          )
+        )
+      )
+    );
+    expect(log, equals(<String>['a', 'tap', 'a']));
+
+    await tester.pumpWidget(
+      new Align(
+        alignment: FractionalOffset.topLeft,
+        child: new SizedBox(
+          width: 200.0,
+          height: 200.0,
+          child: new ClipRect(
+            clipper: new ValueClipper<Rect>('b', new Rect.fromLTWH(5.0, 5.0, 10.0, 10.0)),
+            child: new GestureDetector(
+              behavior: HitTestBehavior.opaque,
+              onTap: () { log.add('tap'); },
+            )
+          )
+        )
+      )
+    );
+    expect(log, equals(<String>['a', 'tap', 'a', 'b']));
+
+    await tester.pumpWidget(
+      new Align(
+        alignment: FractionalOffset.topLeft,
+        child: new SizedBox(
+          width: 200.0,
+          height: 200.0,
+          child: new ClipRect(
+            clipper: new ValueClipper<Rect>('c', new Rect.fromLTWH(25.0, 25.0, 10.0, 10.0)),
+            child: new GestureDetector(
+              behavior: HitTestBehavior.opaque,
+              onTap: () { log.add('tap'); },
+            )
+          )
+        )
+      )
+    );
+    expect(log, equals(<String>['a', 'tap', 'a', 'b', 'c']));
+
+    await tester.tapAt(new Point(30.0, 30.0));
+    expect(log, equals(<String>['a', 'tap', 'a', 'b', 'c', 'tap']));
+
+    await tester.tapAt(new Point(100.0, 100.0));
+    expect(log, equals(<String>['a', 'tap', 'a', 'b', 'c', 'tap']));
+  });
+
 }


### PR DESCRIPTION
Turns out that previously we weren't updating the clip if the layout
didn't change, even if the delegate was different.

this was found by customer:pink
