### PR TITLE
Recognize Fuchsia as a target platform

### DIFF
--- a/packages/flutter/lib/src/foundation/platform.dart
+++ b/packages/flutter/lib/src/foundation/platform.dart
@@ -11,6 +11,9 @@ enum TargetPlatform {
   /// Android: <https://www.android.com/>
   android,
 
+  /// Fuchsia: <https://fuchsia.googlesource.com/>
+  fuchsia,
+
   /// iOS: <http://www.apple.com/ios/>
   iOS,
 }
@@ -30,6 +33,8 @@ TargetPlatform get defaultTargetPlatform {
     result = TargetPlatform.iOS;
   } else if (Platform.isAndroid || Platform.isLinux) {
     result = TargetPlatform.android;
+  } else if (Platform.operatingSystem == "fuchsia") {
+    result = TargetPlatform.fuchsia;
   }
   assert(() {
     if (Platform.environment.containsKey('FLUTTER_TEST'))

--- a/packages/flutter/lib/src/material/app.dart
+++ b/packages/flutter/lib/src/material/app.dart
@@ -157,10 +157,10 @@ class _ScrollLikeCupertinoDelegate extends ScrollConfigurationDelegate {
 }
 
 class _ScrollLikeMountainViewDelegate extends ScrollConfigurationDelegate {
-  const _ScrollLikeMountainViewDelegate();
+  const _ScrollLikeMountainViewDelegate(this.platform);
 
   @override
-  TargetPlatform get platform => TargetPlatform.android;
+  final TargetPlatform platform;
 
   @override
   ExtentScrollBehavior createScrollBehavior() => new OverscrollWhenScrollableBehavior(platform: TargetPlatform.android);
@@ -203,7 +203,9 @@ class _MaterialAppState extends State<MaterialApp> {
   ScrollConfigurationDelegate _getScrollDelegate(TargetPlatform platform) {
     switch (platform) {
       case TargetPlatform.android:
-        return const _ScrollLikeMountainViewDelegate();
+        return const _ScrollLikeMountainViewDelegate(TargetPlatform.android);
+      case TargetPlatform.fuchsia:
+        return const _ScrollLikeMountainViewDelegate(TargetPlatform.fuchsia);
       case TargetPlatform.iOS:
         return const _ScrollLikeCupertinoDelegate();
     }

--- a/packages/flutter/lib/src/material/app_bar.dart
+++ b/packages/flutter/lib/src/material/app_bar.dart
@@ -254,6 +254,7 @@ class AppBar extends StatelessWidget {
     assert(themeData.platform != null);
     switch (themeData.platform) {
       case TargetPlatform.android:
+      case TargetPlatform.fuchsia:
         return false;
       case TargetPlatform.iOS:
         return true;

--- a/packages/flutter/lib/src/material/flexible_space_bar.dart
+++ b/packages/flutter/lib/src/material/flexible_space_bar.dart
@@ -64,6 +64,7 @@ class _FlexibleSpaceBarState extends State<FlexibleSpaceBar> {
     assert(theme.platform != null);
     switch (theme.platform) {
       case TargetPlatform.android:
+      case TargetPlatform.fuchsia:
         return false;
       case TargetPlatform.iOS:
         return true;

--- a/packages/flutter/lib/src/widgets/scroll_behavior.dart
+++ b/packages/flutter/lib/src/widgets/scroll_behavior.dart
@@ -75,6 +75,7 @@ abstract class ScrollBehavior<T, U> {
     assert(platform != null);
     switch (platform) {
       case TargetPlatform.android:
+      case TargetPlatform.fuchsia:
         return _kScrollDragMountainView;
       case TargetPlatform.iOS:
         return _kScrollDragCupertino;


### PR DESCRIPTION
Currently, we just treat Fuchsia as TargetPlatform.android, but we might
want to do something more sophisticated in the future.
