### PR TITLE
Trigger a hot reload / full restart based on SIGUSR1 and SIGUSR2

### DIFF
--- a/packages/flutter_tools/lib/src/hot.dart
+++ b/packages/flutter_tools/lib/src/hot.dart
@@ -118,8 +118,7 @@ class HotRunner extends ResidentRunner {
     Device device, {
     String target,
     DebuggingOptions debuggingOptions,
-    bool usesTerminalUI: true,
-    this.pipe
+    bool usesTerminalUI: true
   }) : super(device,
              target: target,
              debuggingOptions: debuggingOptions,
@@ -132,33 +131,6 @@ class HotRunner extends ResidentRunner {
   String _projectRootPath;
   Set<String> _startupDependencies;
   final AssetBundle bundle = new AssetBundle();
-  final File pipe;
-
-  Future<String> _readFromControlPipe() async {
-    final Stream<List<int>> stream = pipe.openRead();
-    final List<int> bytes = await stream.first;
-    final String string = new String.fromCharCodes(bytes).trim();
-    return string;
-  }
-
-  Future<Null> _startReadingFromControlPipe() async {
-    if (pipe == null)
-      return;
-
-    while (true) {
-      // This loop will only exit if _readFromControlPipe throws an exception.
-      // If no exception is thrown this will keep the flutter command running
-      // until it is explicitly stopped via some other mechanism, for example,
-      // ctrl+c or sending "q" to the control pipe.
-      String result = await _readFromControlPipe();
-      printStatus('Control pipe received "$result"');
-      await processTerminalInput(result);
-      if (result.toLowerCase() == 'q') {
-        printStatus("Finished reading from control pipe");
-        break;
-      }
-    }
-  }
 
   @override
   Future<int> run({
@@ -299,8 +271,6 @@ class HotRunner extends ResidentRunner {
     printStatus('Running ${getDisplayPath(_mainPath)} on ${device.name}...');
     _loaderShowMessage('Launching...');
     await _launchFromDevFS(_package, _mainPath);
-
-    _startReadingFromControlPipe();
 
     printStatus('Application running.');
 

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -65,6 +65,14 @@ abstract class ResidentRunner {
       await cleanupAfterSignal();
       exit(0);
     });
+    ProcessSignal.SIGUSR1.watch().listen((ProcessSignal signal) async {
+      printStatus('Caught SIGUSR1');
+      await restart(fullRestart: false);
+    });
+    ProcessSignal.SIGUSR2.watch().listen((ProcessSignal signal) async {
+      printStatus('Caught SIGUSR2');
+      await restart(fullRestart: true);
+    });
   }
 
   Future<Null> startEchoingDeviceLog() async {


### PR DESCRIPTION
- [x] Remove --control-pipe command option and related code. Reading from a named pipe via dart:io is unreliable today.
- [x] Add --pid-file option which writes the pid of flutter run into a file.
- [x] Wired up SIGUSR1 to hot reload
- [x] Wired up SIGUSR2 to full restart
