### PR TITLE
Ease Material route animations

### DIFF
--- a/packages/flutter/lib/src/material/page.dart
+++ b/packages/flutter/lib/src/material/page.dart
@@ -18,8 +18,11 @@ class _MaterialPageTransition extends AnimatedWidget {
     this.child
   }) : super(
     key: key,
-    animation: _kMaterialPageTransitionTween.animate(animation)
-  );
+    animation: _kMaterialPageTransitionTween.animate(new CurvedAnimation(
+      parent: animation, // The route's linear 0.0 - 1.0 animation.
+      curve: Curves.fastOutSlowIn
+    )
+  ));
 
   final Widget child;
 
@@ -62,14 +65,6 @@ class MaterialPageRoute<T> extends PageRoute<T> {
 
   @override
   bool canTransitionFrom(TransitionRoute<dynamic> nextRoute) => false;
-
-  @override
-  Animation<double> createAnimation() {
-    return new CurvedAnimation(
-      parent: super.createAnimation(),
-      curve: Curves.fastOutSlowIn
-    );
-  }
 
   @override
   Widget buildPage(BuildContext context, Animation<double> animation, Animation<double> forwardAnimation) {

--- a/packages/flutter/lib/src/material/page.dart
+++ b/packages/flutter/lib/src/material/page.dart
@@ -64,6 +64,14 @@ class MaterialPageRoute<T> extends PageRoute<T> {
   bool canTransitionFrom(TransitionRoute<dynamic> nextRoute) => false;
 
   @override
+  Animation<double> createAnimation() {
+    return new CurvedAnimation(
+      parent: super.createAnimation(),
+      curve: Curves.easeOut
+    );
+  }
+
+  @override
   Widget buildPage(BuildContext context, Animation<double> animation, Animation<double> forwardAnimation) {
     Widget result = builder(context);
     assert(() {

--- a/packages/flutter/lib/src/material/page.dart
+++ b/packages/flutter/lib/src/material/page.dart
@@ -18,7 +18,7 @@ class _MaterialPageTransition extends AnimatedWidget {
     this.child
   }) : super(
     key: key,
-    animation: _kMaterialPageTransitionTween.animate(new CurvedAnimation(parent: animation, curve: Curves.fastOutSlowIn))
+    animation: _kMaterialPageTransitionTween.animate(animation)
   );
 
   final Widget child;
@@ -67,7 +67,7 @@ class MaterialPageRoute<T> extends PageRoute<T> {
   Animation<double> createAnimation() {
     return new CurvedAnimation(
       parent: super.createAnimation(),
-      curve: Curves.easeOut
+      curve: Curves.fastOutSlowIn
     );
   }
 

--- a/packages/flutter/lib/src/widgets/heroes.dart
+++ b/packages/flutter/lib/src/widgets/heroes.dart
@@ -474,7 +474,7 @@ class HeroController extends NavigatorObserver {
       if (previousRoute is PageRoute<dynamic>) // could be null
         _from = previousRoute;
       _to = route;
-      _animation = route.animation;
+      _animation = new CurvedAnimation(parent: route.animation, curve: Curves.fastOutSlowIn);
       _checkForHeroQuest();
     }
   }
@@ -488,7 +488,7 @@ class HeroController extends NavigatorObserver {
       if (previousRoute is PageRoute<dynamic>) {
         _to = previousRoute;
         _from = route;
-        _animation = route.animation;
+        _animation = new CurvedAnimation(parent: route.animation, curve: Curves.fastOutSlowIn);
         _checkForHeroQuest();
       }
     }


### PR DESCRIPTION
This affects the Material vertical slide-into-place animation as well any attendant hero animations.

Fixes #5096
