### PR TITLE
Fix an incorrect covariant function type.

### DIFF
--- a/packages/flutter/test/widget/draggable_test.dart
+++ b/packages/flutter/test/widget/draggable_test.dart
@@ -835,7 +835,7 @@ void main() {
                 }
               ),
               new DragTarget<ExtendedDragTargetData>(
-                builder: (BuildContext context, List<ExtendedDragTargetData> data, List<ExtendedDragTargetData> rejects) {
+                builder: (BuildContext context, List<ExtendedDragTargetData> data, List<dynamic> rejects) {
                   return new IgnorePointer(
                     child: new Container(
                       height: 100.0,


### PR DESCRIPTION
The type of rejects should be `List<dynamic>` to match the type that
DragTarget expects. Since the function doesn't use rejects anyway,
there's no need to tighten the type.

Fixes one of the strong_mode_static_type_error errors that is currently
being ignored.
