### PR TITLE
exclude //bin from analysis

### DIFF
--- a/.analysis_options
+++ b/.analysis_options
@@ -19,6 +19,8 @@ analyzer:
     strong_mode_down_cast_composite: ignore
     # we allow having TODOs in the code
     todo: ignore
+  exclude:
+    - 'bin/**'
 
 linter:
   rules:


### PR DESCRIPTION
Exclude the top level `bin/` directory from analysis. Otherwise things like `bin/cache/pkg/` and `bin/cache/dart-sdk` get picked up.
