### PR TITLE
suppress exceptions from loader progress display messages

### DIFF
--- a/packages/flutter_tools/lib/src/vmservice.dart
+++ b/packages/flutter_tools/lib/src/vmservice.dart
@@ -770,22 +770,25 @@ class Isolate extends ServiceObjectOwner {
 
   // Loader page extension methods.
 
-  Future<Map<String, dynamic>> flutterLoaderShowMessage(String message) {
-    return invokeRpcRaw('ext.flutter.loaderShowMessage', <String, dynamic> {
+  void flutterLoaderShowMessage(String message) {
+    // Invoke loaderShowMessage; ignore any returned errors.
+    invokeRpcRaw('ext.flutter.loaderShowMessage', <String, dynamic> {
       'value': message
-    });
+    }).catchError((dynamic error) => null);
   }
 
-  Future<Map<String, dynamic>> flutterLoaderSetProgress(double progress) {
-    return invokeRpcRaw('ext.flutter.loaderSetProgress', <String, dynamic>{
+  void flutterLoaderSetProgress(double progress) {
+    // Invoke loaderSetProgress; ignore any returned errors.
+    invokeRpcRaw('ext.flutter.loaderSetProgress', <String, dynamic>{
       'loaderSetProgress': progress
-    });
+    }).catchError((dynamic error) => null);
   }
 
-  Future<Map<String, dynamic>> flutterLoaderSetProgressMax(double max) {
-    return invokeRpcRaw('ext.flutter.loaderSetProgressMax', <String, dynamic>{
+  void flutterLoaderSetProgressMax(double max) {
+    // Invoke loaderSetProgressMax; ignore any returned errors.
+    invokeRpcRaw('ext.flutter.loaderSetProgressMax', <String, dynamic>{
       'loaderSetProgressMax': max
-    });
+    }).catchError((dynamic error) => null);
   }
 
   /// Causes the application to pick up any changed code.


### PR DESCRIPTION
@Hixie, @johnmccutchan, suppress exceptions from loader progress display messages. We can start sending progress messages for populating the devfs before the loader app has registered its service protocol handlers. In this case we print a substantial number of exceptions at app startup. This changes the `flutterLoaderShowMessage` methods to sending progress info on a best effort basis.
