### PR TITLE
Simple version of the iOS back gesture.

### DIFF
--- a/packages/flutter/lib/src/material/page.dart
+++ b/packages/flutter/lib/src/material/page.dart
@@ -5,20 +5,23 @@
 import 'dart:async';
 
 import 'package:flutter/widgets.dart';
+import 'material.dart';
+import 'theme.dart';
 
-final FractionalOffsetTween _kMaterialPageTransitionTween = new FractionalOffsetTween(
-  begin: FractionalOffset.bottomLeft,
-  end: FractionalOffset.topLeft
-);
+// Used for Android and Fuchsia.
+class _MountainViewPageTransition extends AnimatedWidget {
+  static final FractionalOffsetTween _kTween = new FractionalOffsetTween(
+    begin: FractionalOffset.bottomLeft,
+    end: FractionalOffset.topLeft
+  );
 
-class _MaterialPageTransition extends AnimatedWidget {
-  _MaterialPageTransition({
+  _MountainViewPageTransition({
     Key key,
     Animation<double> animation,
     this.child
   }) : super(
     key: key,
-    animation: _kMaterialPageTransitionTween.animate(new CurvedAnimation(
+    animation: _kTween.animate(new CurvedAnimation(
       parent: animation, // The route's linear 0.0 - 1.0 animation.
       curve: Curves.fastOutSlowIn
     )
@@ -33,6 +36,108 @@ class _MaterialPageTransition extends AnimatedWidget {
       position: animation,
       child: child
     );
+  }
+}
+
+// Used for iOS.
+class _CupertinoPageTransition extends AnimatedWidget {
+  static final FractionalOffsetTween _kTween = new FractionalOffsetTween(
+    begin: FractionalOffset.topRight,
+    end: -FractionalOffset.topRight
+  );
+
+  _CupertinoPageTransition({
+    Key key,
+    Animation<double> animation,
+    this.child
+  }) : super(
+    key: key,
+    animation: _kTween.animate(new CurvedAnimation(
+      parent: animation,
+      curve: new _CupertinoTransitionCurve()
+    )
+  ));
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    // TODO(ianh): tell the transform to be un-transformed for hit testing
+    // but not while being controlled by a gesture.
+    return new SlideTransition(
+      position: animation,
+      child: new Material(
+        elevation: 6,
+        child: child
+      )
+    );
+  }
+}
+
+class AnimationMean extends CompoundAnimation<double> {
+  AnimationMean({
+    Animation<double> left,
+    Animation<double> right,
+  }) : super(first: left, next: right);
+
+  @override
+  double get value => (first.value + next.value) / 2.0;
+}
+
+// Custom curve for iOS page transitions. The halfway point is when the page
+// is fully on-screen. 0.0 is fully off-screen to the right. 1.0 is off-screen
+// to the left.
+class _CupertinoTransitionCurve extends Curve {
+  _CupertinoTransitionCurve();
+
+  @override
+  double transform(double t) {
+    if (t > 0.5)
+      return (t - 0.5) / 3.0 + 0.5;
+    return t;
+  }
+}
+
+// This class responds to drag gestures to control the route's transition
+// animation progress. Used for iOS back gesture.
+class _CupertinoBackGestureController extends NavigationGestureController {
+  _CupertinoBackGestureController({
+    NavigatorState navigator,
+    this.controller,
+    this.onDisposed,
+  }) : super(navigator);
+
+  AnimationController controller;
+  VoidCallback onDisposed;
+
+  @override
+  void dispose() {
+    super.dispose();
+    onDisposed();
+    controller.removeStatusListener(handleStatusChanged);
+    controller = null;
+  }
+
+  @override
+  void dragUpdate(double delta) {
+    controller.value -= delta;
+  }
+
+  @override
+  void dragEnd() {
+    if (controller.value <= 0.5) {
+      navigator.pop();
+    } else {
+      controller.forward();
+    }
+    // Don't end the gesture until the transition completes.
+    handleStatusChanged(controller.status);
+    controller?.addStatusListener(handleStatusChanged);
+  }
+
+  void handleStatusChanged(AnimationStatus status) {
+    if (status == AnimationStatus.dismissed || status == AnimationStatus.completed)
+      dispose();
   }
 }
 
@@ -64,7 +169,28 @@ class MaterialPageRoute<T> extends PageRoute<T> {
   Color get barrierColor => null;
 
   @override
-  bool canTransitionFrom(TransitionRoute<dynamic> nextRoute) => false;
+  bool canTransitionFrom(TransitionRoute<dynamic> nextRoute) {
+    return nextRoute is MaterialPageRoute<dynamic>;
+  }
+
+  @override
+  void dispose() {
+    super.dispose();
+    backGestureController?.dispose();
+  }
+
+  _CupertinoBackGestureController backGestureController;
+
+  @override
+  NavigationGestureController startPopGesture(NavigatorState navigator) {
+    assert(backGestureController == null);
+    backGestureController = new _CupertinoBackGestureController(
+      navigator: navigator,
+      controller: controller,
+      onDisposed: () { backGestureController = null; }
+    );
+    return backGestureController;
+  }
 
   @override
   Widget buildPage(BuildContext context, Animation<double> animation, Animation<double> forwardAnimation) {
@@ -83,10 +209,28 @@ class MaterialPageRoute<T> extends PageRoute<T> {
 
   @override
   Widget buildTransitions(BuildContext context, Animation<double> animation, Animation<double> forwardAnimation, Widget child) {
-    return new _MaterialPageTransition(
-      animation: animation,
-      child: child
-    );
+    // TODO(mpcomplete): This hack prevents the previousRoute from animating
+    // when we pop(). Remove once we fix this bug:
+    // https://github.com/flutter/flutter/issues/5577
+    if (!Navigator.of(context).userGestureInProgress)
+      forwardAnimation = kAlwaysDismissedAnimation;
+
+    ThemeData theme = Theme.of(context);
+    switch (theme.platform) {
+      case TargetPlatform.fuchsia:
+      case TargetPlatform.android:
+        return new _MountainViewPageTransition(
+          animation: animation,
+          child: child
+        );
+      case TargetPlatform.iOS:
+        return new _CupertinoPageTransition(
+          animation: new AnimationMean(left: animation, right: forwardAnimation),
+          child: child
+        );
+    }
+
+    return null;
   }
 
   @override

--- a/packages/flutter/lib/src/widgets/heroes.dart
+++ b/packages/flutter/lib/src/widgets/heroes.dart
@@ -467,8 +467,21 @@ class HeroController extends NavigatorObserver {
     }
   }
 
+  // Disable Hero animations while a user gesture is controlling the navigation.
+  bool _questsEnabled = true;
+
+  @override
+  void didStartUserGesture() {
+    _questsEnabled = false;
+  }
+
+  @override
+  void didStopUserGesture() {
+    _questsEnabled = true;
+  }
+
   void _checkForHeroQuest() {
-    if (_from != null && _to != null && _from != _to) {
+    if (_from != null && _to != null && _from != _to && _questsEnabled) {
       _to.offstage = _to.animation.status != AnimationStatus.completed;
       WidgetsBinding.instance.addPostFrameCallback(_updateQuest);
     }

--- a/packages/flutter/lib/src/widgets/routes.dart
+++ b/packages/flutter/lib/src/widgets/routes.dart
@@ -109,6 +109,9 @@ abstract class TransitionRoute<T> extends OverlayRoute<T> {
   /// forward transition.
   Animation<double> get animation => _animation;
   Animation<double> _animation;
+
+  @protected
+  AnimationController get controller => _controller;
   AnimationController _controller;
 
   /// Called to create the animation controller that will drive the transitions to


### PR DESCRIPTION
Doesn't do any of the fancy effects. Just lets the user control the
back transition by sliding from the left, like a drawer. Hero
transitions are disabled during the gesture.

BUG=https://github.com/flutter/flutter/issues/4817
