### PR TITLE
Smart command line interface for flutter run.

### DIFF
--- a/packages/flutter_tools/lib/src/android/gradle.dart
+++ b/packages/flutter_tools/lib/src/android/gradle.dart
@@ -137,7 +137,7 @@ Future<int> buildGradleProject(BuildMode buildMode) async {
         workingDirectory: 'android',
         allowReentrantFlutter: true
       );
-      status.stop(showElapsedTime: true);
+      status.stop();
       if (exitcode != 0)
         return exitcode;
     } catch (error) {
@@ -159,7 +159,7 @@ Future<int> buildGradleProject(BuildMode buildMode) async {
     workingDirectory: 'android',
     allowReentrantFlutter: true
   );
-  status.stop(showElapsedTime: true);
+  status.stop();
 
   if (exitcode == 0) {
     File apkFile = new File(gradleAppOut);

--- a/packages/flutter_tools/lib/src/cache.dart
+++ b/packages/flutter_tools/lib/src/cache.dart
@@ -230,7 +230,7 @@ class MaterialFonts {
       Uri.parse(cache.getVersionFor(kName)), fontsDir, true
     ).then((_) {
       cache.setStampFor(kName, cache.getVersionFor(kName));
-      status.stop(showElapsedTime: true);
+      status.stop();
     }).whenComplete(() {
       status.cancel();
     });
@@ -345,7 +345,7 @@ class FlutterEngine {
       String skyServicesPath = path.join(pkgDir.path, kSkyServices);
       buildSkyEngineSdkSummary(skyEnginePath, skyServicesPath, kSdkBundle);
     } finally {
-      summaryStatus.stop(showElapsedTime: true);
+      summaryStatus.stop();
     }
 
     Directory engineDir = cache.getArtifactDirectory(kName);
@@ -388,7 +388,7 @@ class FlutterEngine {
   Future<Null> _downloadItem(String message, String url, Directory dest) {
     Status status = logger.startProgress(message);
     return Cache._downloadFileToCache(Uri.parse(url), dest, true).then((_) {
-      status.stop(showElapsedTime: true);
+      status.stop();
     }).whenComplete(() {
       status.cancel();
     });

--- a/packages/flutter_tools/lib/src/cli/command.dart
+++ b/packages/flutter_tools/lib/src/cli/command.dart
@@ -1,0 +1,322 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+
+// Splits a line into a list of string args.  Each arg retains any
+// trailing whitespace so that we can reconstruct the original command
+// line from the pieces.
+List<String> _splitLine(String line) {
+  line = line.trimLeft();
+  List<String> args = <String>[];
+  int pos = 0;
+  while (pos < line.length) {
+    int startPos = pos;
+
+    // Advance to end of word.
+    while (pos < line.length && line[pos] != ' ')
+      pos++;
+
+    // Advance to end of spaces.
+    while(pos < line.length && line[pos] == ' ')
+      pos++;
+
+    args.add(line.substring(startPos, pos));
+  }
+  return args;
+}
+
+// Concatenates the first 'count' args.
+String _concatArgs(List<String> args, int count) {
+  if (count == 0) {
+    return '';
+  }
+  return '${args.sublist(0, count).join('')}';
+}
+
+// Shared functionality for RootCommand and Command.
+abstract class _CommandBase {
+  _CommandBase(List<Command> children) {
+    if (children != null) {
+      _children.addAll(children);
+      for (Command child in _children) {
+        child._parent = this;
+      }
+    }
+  }
+
+  // A command may optionally have sub-commands.
+  List<Command> _children = <Command>[];
+
+  _CommandBase _parent;
+  int get _depth => (_parent == null ? 0 : _parent._depth + 1);
+
+  // Override in subclasses to provide command-specific argument completion.
+  //
+  // Given a list of arguments to this command, provide a list of
+  // possible completions for those arguments.
+  Future<List<String>> complete(List<String> args) =>
+    new Future<List<String>>.value(<String>[]);
+
+  // Override in subclasses to provide command-specific execution.
+  Future<Null> run(List<String> args);
+
+  // Returns a list of local subcommands which match the args.
+  List<Command> _matchLocal(String argWithSpace, bool preferExact) {
+    List<Command> matches = <Command>[];
+    String arg = argWithSpace.trimRight();
+    for (Command child in _children) {
+      if (child.name.startsWith(arg) || child.alias == arg) {
+        if (preferExact && ((child.name == arg) || (child.alias == arg))) {
+          return <Command>[child];
+        }
+        matches.add(child);
+      }
+    }
+    return matches;
+  }
+
+  // Returns the set of commands could be triggered by a list of
+  // arguments.
+  List<Command> _match(List<String> args, bool preferExact) {
+    if (args.isEmpty) {
+      return <Command>[];
+    }
+    bool lastArg = (args.length == 1);
+    List<Command> matches = _matchLocal(args[0], !lastArg || preferExact);
+    if (matches.isEmpty) {
+      return <Command>[];
+    } else if (matches.length == 1) {
+      List<Command> childMatches =
+        matches[0]._match(args.sublist(1), preferExact);
+      if (childMatches.isEmpty) {
+        return matches;
+      } else {
+        return childMatches;
+      }
+    } else {
+      return matches;
+    }
+  }
+
+  // Builds a list of completions for this command.
+  Future<List<String>> _buildCompletions(List<String> args,
+                                         bool addEmptyString) {
+    return complete(args.sublist(_depth, args.length))
+      .then((Iterable<String> completions) {
+        if (addEmptyString && completions.isEmpty &&
+            args[args.length - 1] == '') {
+          // Special case allowance for an empty particle at the end of
+          // the command.
+          completions = <String>[''];
+        }
+        String prefix = _concatArgs(args, _depth);
+        return completions.map((String str) => '$prefix$str').toList();
+      });
+  }
+}
+
+class HotKey {
+  HotKey(this.userName, this.runes, this.expansion);
+
+  final String userName;
+  final List<int> runes;
+  final String expansion;
+
+  @override
+  String toString() {
+    return 'HotKey($userName,$expansion)';
+  }
+}
+
+// The root of a tree of commands.
+class RootCommand extends _CommandBase {
+  RootCommand(List<Command> children) : super(children);
+
+  // Provides a list of possible completions for a line of text.
+  Future<List<String>> completeCommand(String line) {
+    List<String> args = _splitLine(line);
+    bool showAll = line.endsWith(' ') || args.isEmpty;
+    if (showAll) {
+      // Adding an empty string to the end causes us to match all
+      // subcommands of the last command.
+      args.add('');
+    }
+    List<Command> commands =  _match(args, false);
+    if (commands.isEmpty) {
+      // No matching commands.
+      return new Future<List<String>>.value(<String>[]);
+    }
+    int matchLen = commands[0]._depth;
+    if (matchLen < args.length) {
+      // We were able to find a command which matches a prefix of the
+      // args, but not the full list.
+      if (commands.length == 1) {
+        // The matching command is unique.  Attempt to provide local
+        // argument completion from the command.
+        return commands[0]._buildCompletions(args, true);
+      } else {
+        // An ambiguous prefix match leaves us nowhere.  The user is
+        // typing a bunch of stuff that we don't know how to complete.
+        return new Future<List<String>>.value(<String>[]);
+      }
+    }
+
+    // We have found a set of commands which match all of the args.
+    // Return the completion strings.
+    String prefix = _concatArgs(args, args.length - 1);
+    List<String> completions =
+        commands.map((Command command) => '$prefix${command.name} ').toList();
+    if (matchLen == args.length) {
+      // If we are showing all possiblities, also include local
+      // completions for the parent command.
+      return commands[0]._parent._buildCompletions(args, false)
+        .then((List<String> localCompletions) {
+          completions.addAll(localCompletions);
+          return completions;
+        });
+    }
+    return new Future<List<String>>.value(completions);
+  }
+
+  // Runs a command.
+  Future<Null> runCommand(String line) {
+    _historyAdvance(line);
+    List<String> args = _splitLine(line);
+    List<Command> commands =  _match(args, true);
+    if (commands.isEmpty) {
+      return new Future<Null>.error(
+          new NoSuchCommandException(line));
+    } else if (commands.length == 1) {
+      return commands[0].run(args.sublist(commands[0]._depth));
+    } else {
+      return new Future<Null>.error(
+          new AmbiguousCommandException(line, commands));
+    }
+  }
+
+  // Find all matching commands.  Useful for implementing help systems.
+  List<Command> matchCommand(List<String> args, bool preferExact) {
+    if (args.isEmpty) {
+      // Adding an empty string to the end causes us to match all
+      // subcommands of the last command.
+      args.add('');
+    }
+    return _match(args, preferExact);
+  }
+
+  // Command line history always contains one slot to hold the current
+  // line, so we start off with one entry.
+  List<String> history = <String>[''];
+  int historyPos = 0;
+
+  String historyPrev(String line) {
+    if (historyPos == 0) {
+      return line;
+    }
+    history[historyPos] = line;
+    historyPos--;
+    return history[historyPos];
+  }
+
+  String historyNext(String line) {
+    if (historyPos == history.length - 1) {
+      return line;
+    }
+    history[historyPos] = line;
+    historyPos++;
+    return history[historyPos];
+  }
+
+  void _historyAdvance(String line) {
+    // Replace the last history line.
+    historyPos = history.length - 1;
+    history[historyPos] = line;
+
+    // Create an empty spot for the next line.
+    history.add('');
+    historyPos++;
+  }
+
+  final List<HotKey> hotKeys = <HotKey>[];
+
+  void addHotKey(String userName, String hotKey, String expansion) {
+    hotKeys.add(new HotKey(userName, hotKey.runes.toList(), expansion));
+  }
+
+  HotKey matchHotKey(List<int> runes) {
+    for (int i = 0; i < hotKeys.length; i++) {
+      List<int> hotKeyRunes = hotKeys[i].runes;
+      if (runes.length < hotKeyRunes.length) {
+        continue;
+      }
+      bool match = true;
+      for (int j = 0; j < hotKeyRunes.length; j++) {
+        if (hotKeyRunes[j] != runes[j]) {
+          match = false;
+          break;
+        }
+      }
+      // We've found a match.
+      if (match) {
+        return hotKeys[i];
+      }
+    }
+    return null;
+  }
+
+  @override
+  Future<Null> run(List<String> args) {
+    throw 'should-not-execute-the-root-command';
+  }
+
+  @override
+  String toString() => 'RootCommand';
+}
+
+// A node in the command tree.
+abstract class Command extends _CommandBase {
+  Command(this.name, List<Command> children) : super(children);
+
+  final String name;
+  String alias;
+
+  String get fullName {
+    if (_parent is RootCommand) {
+      return name;
+    } else {
+      Command parent = _parent;
+      return '${parent.fullName} $name';
+    }
+  }
+
+  @override
+  String toString() => 'Command($name)';
+}
+
+abstract class CommandException implements Exception {
+}
+
+class AmbiguousCommandException extends CommandException {
+  AmbiguousCommandException(this.command, this.matches);
+
+  final String command;
+  final List<Command> matches;
+
+  @override
+  String toString() {
+    List<String> matchNames =
+        matches.map((Command command) => '${command.fullName}').toList();
+    return "Command '$command' is ambiguous: $matchNames";
+  }
+}
+
+class NoSuchCommandException extends CommandException {
+  NoSuchCommandException(this.command);
+
+  final String command;
+
+  @override
+  String toString() => "No such command: '$command'";
+}

--- a/packages/flutter_tools/lib/src/cli/commandline.dart
+++ b/packages/flutter_tools/lib/src/cli/commandline.dart
@@ -1,0 +1,715 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+import 'dart:math';
+
+import 'command.dart';
+import '../base/logger.dart';
+
+class CommandLine {
+  CommandLine(this._cmd,
+              this.term,
+              {Stdin consoleIn,
+               Stdout consoleOut,
+               this.prompt : '> '}) {
+    _stdin = (consoleIn != null ? consoleIn : stdin);
+    _stdout = (consoleOut != null ? consoleOut : stdout);
+    _stdin.echoMode = false;
+    _stdin.lineMode = false;
+    _writePrompt();
+    _stdinSubscription =
+      _stdin.transform(UTF8.decoder).listen(_handleText,
+                                            onError:_stdinError,
+                                            onDone:_stdinDone);
+    _dumbMode = term.isDumb;
+    _resize();
+  }
+
+  // Ctrl keys
+  static const int runeCtrlA       = 0x01;
+  static const int runeCtrlB       = 0x02;
+  static const int runeCtrlD       = 0x04;
+  static const int runeCtrlE       = 0x05;
+  static const int runeCtrlF       = 0x06;
+  static const int runeTAB         = 0x09;
+  static const int runeNewline     = 0x0a;
+  static const int runeCtrlK       = 0x0b;
+  static const int runeCtrlL       = 0x0c;
+  static const int runeCtrlN       = 0x0e;
+  static const int runeCtrlP       = 0x10;
+  static const int runeCtrlU       = 0x15;
+  static const int runeCtrlY       = 0x19;
+  static const int runeESC         = 0x1b;
+  static const int runeSpace       = 0x20;
+  static const int runeA           = 0x41;
+  static const int runeB           = 0x42;
+  static const int runeC           = 0x43;
+  static const int runeD           = 0x44;
+  static const int runeLeftBracket = 0x5b;
+  static const int runeDEL         = 0x7F;
+
+  RootCommand get rootCommand => _cmd;
+  RootCommand _cmd;
+  bool _dumbMode;
+
+  bool get _promptShown => _hideDepth == 0;
+
+  Future<Null> quit() async {
+    await _done();
+  }
+
+  void _stdinError(dynamic e, StackTrace st) {
+    print('Unexpected error reading input: $e\n$st');
+    _done();
+  }
+
+  void _stdinDone() {
+    _done();
+  }
+
+  Future<Null> _done() {
+    _stdin.echoMode = true;
+    _stdin.lineMode = true;
+    Future<Null> future = _stdinSubscription.cancel();
+    if (future != null) {
+      return future;
+    } else {
+      return new Future<Null>.value();
+    }
+  }
+
+  void _resize() {
+    _screenWidth = term.cols - 1;
+  }
+
+  void _handleText(String text) {
+    try {
+      if (!_promptShown) {
+        _bufferedInput.write(text);
+        return;
+      }
+
+      List<int> runes = text.runes.toList();
+      int pos = 0;
+      while (pos < runes.length) {
+        if (!_promptShown) {
+          // A command was processed which hid the prompt.  Buffer
+          // the rest of the input.
+          _bufferedInput.write(
+              new String.fromCharCodes(runes.skip(pos)));
+          return;
+        }
+
+        int rune = runes[pos];
+
+        // Count consecutive tabs because double-tab is meaningful.
+        if (rune == runeTAB) {
+          _tabCount++;
+        } else {
+          _tabCount = 0;
+        }
+
+        if (_isControlRune(rune)) {
+          if (_dumbMode) {
+            pos += _handleControlSequenceDumb(runes, pos);
+          } else {
+            pos += _handleControlSequence(runes, pos);
+          }
+        } else {
+          pos += _handleRegularSequence(runes, pos);
+        }
+      }
+    } catch(e, st) {
+      print('Unexpected error: $e\n$st');
+    }
+  }
+
+  bool _matchRunes(List<int> runes, int pos, List<int> match) {
+    if (runes.length < pos + match.length)
+      return false;
+
+    for (int i = 0; i < match.length; i++) {
+      if (runes[pos + i] != match[i])
+        return false;
+    }
+    return true;
+  }
+
+  int _handleControlSequence(List<int> runes, int pos) {
+    int runesConsumed = 1;  // Most common result.
+    int char = runes[pos];
+    switch (char) {
+      case runeCtrlA:
+        _home();
+        break;
+
+      case runeCtrlB:
+        _leftArrow();
+        break;
+
+      case runeCtrlD:
+        if (_currentLine.length == 0) {
+          // ^D on an empty line means quit.
+          _stdout.writeln("^D");
+          _done();
+        } else {
+          _delete();
+        }
+        break;
+
+      case runeCtrlE:
+        _end();
+        break;
+
+      case runeCtrlF:
+        _rightArrow();
+        break;
+
+      case runeTAB:
+        _complete(_tabCount > 1);
+        break;
+
+      case runeNewline:
+        _newline();
+        break;
+
+      case runeCtrlK:
+        _kill();
+        break;
+
+      case runeCtrlL:
+        _clearScreen();
+        break;
+
+      case runeCtrlN:
+        _historyNext();
+        break;
+
+      case runeCtrlP:
+        _historyPrevious();
+        break;
+
+      case runeCtrlU:
+        _clearLine();
+        break;
+
+      case runeCtrlY:
+        _yank();
+        break;
+
+      case runeESC:
+        if (pos + 1 < runes.length) {
+          if (_matchRunes(runes, pos + 1, <int>[runeLeftBracket, runeA])) {
+            // ^[[A = up arrow
+            _historyPrevious();
+            runesConsumed = 3;
+            break;
+          } else if (_matchRunes(runes, pos + 1,
+                                 <int>[runeLeftBracket, runeB])) {
+            // ^[[B = down arrow
+            _historyNext();
+            runesConsumed = 3;
+          } else if (_matchRunes(runes, pos + 1,
+                                 <int>[runeLeftBracket, runeC])) {
+            // ^[[C = right arrow
+            _rightArrow();
+            runesConsumed = 3;
+          } else if (_matchRunes(runes, pos + 1,
+                                 <int>[runeLeftBracket, runeD])) {
+            // ^[[D = left arrow
+            _leftArrow();
+            runesConsumed = 3;
+          } else {
+            HotKey hotKey = _cmd.matchHotKey(runes.skip(pos).toList());
+            if (hotKey != null) {
+              runesConsumed = hotKey.runes.length;
+              List<int> line = hotKey.expansion.runes.toList();
+              _update(line, line.length);
+              _newline();
+            }
+          }
+        }
+        break;
+
+      case runeDEL:
+        _backspace();
+        break;
+
+      default:
+        // Ignore the escape character.
+        break;
+    }
+    return runesConsumed;
+  }
+
+  int _handleControlSequenceDumb(List<int> runes, int pos) {
+    int runesConsumed = 1;  // Most common result.
+    int char = runes[pos];
+    switch (char) {
+      case runeCtrlD:
+        if (_currentLine.length == 0) {
+          // ^D on an empty line means quit.
+          _stdout.writeln("^D");
+          _done();
+        }
+        break;
+
+      case runeTAB:
+        _complete(_tabCount > 1);
+        break;
+
+      case runeNewline:
+        _newline();
+        break;
+
+      case runeCtrlN:
+        _historyNext();
+        break;
+
+      case runeCtrlP:
+        _historyPrevious();
+        break;
+
+      case runeCtrlU:
+        _clearLine();
+        break;
+
+      case runeESC:
+        if (pos + 1 < runes.length) {
+          if (_matchRunes(runes, pos + 1, <int>[runeLeftBracket, runeA])) {
+            // ^[[A = up arrow
+            _historyPrevious();
+            runesConsumed = 3;
+            break;
+          } else if (_matchRunes(runes, pos + 1,
+                                 <int>[runeLeftBracket, runeB])) {
+            // ^[[B = down arrow
+            _historyNext();
+            runesConsumed = 3;
+          } else if (_matchRunes(runes, pos + 1,
+                                 <int>[runeLeftBracket, runeC])) {
+            // ^[[C = right arrow - Ignore.
+            runesConsumed = 3;
+          } else if (_matchRunes(runes, pos + 1,
+                                 <int>[runeLeftBracket, runeD])) {
+            // ^[[D = left arrow - Ignore.
+            runesConsumed = 3;
+          } else {
+            HotKey hotKey = _cmd.matchHotKey(runes.skip(pos).toList());
+            if (hotKey != null) {
+              runesConsumed = hotKey.runes.length;
+              List<int> line = hotKey.expansion.runes.toList();
+              _update(line, line.length);
+              _newline();
+            }
+          }
+        }
+        break;
+
+      case runeDEL:
+        _backspace();
+        break;
+
+      default:
+        // Ignore the escape character.
+        break;
+    }
+    return runesConsumed;
+  }
+
+  int _handleRegularSequence(List<int> runes, int pos) {
+    int len = pos + 1;
+    while (len < runes.length && !_isControlRune(runes[len])) {
+      len++;
+    }
+    _addChars(runes.getRange(pos, len));
+    return len;
+  }
+
+  bool _isControlRune(int char) {
+    return (char >= 0x00 && char < 0x20) || (char == 0x7f);
+  }
+
+  void _writePromptAndLine() {
+    _writePrompt();
+    int pos = _writeRange(_currentLine, 0, _currentLine.length);
+    _cursorPos = _move(pos, _cursorPos);
+  }
+
+  void _writePrompt() {
+    _resize();
+    _stdout.write(term.toBold(prompt));
+  }
+
+  void _addChars(Iterable<int> chars) {
+    List<int> newLine = <int>[];
+    newLine..addAll(_currentLine.take(_cursorPos))
+           ..addAll(chars)
+           ..addAll(_currentLine.skip(_cursorPos));
+    _update(newLine, (_cursorPos + chars.length));
+  }
+
+  void _backspace() {
+    if (_cursorPos == 0)
+      return;
+
+    List<int> newLine = <int>[];
+    newLine..addAll(_currentLine.take(_cursorPos - 1))
+           ..addAll(_currentLine.skip(_cursorPos));
+    _update(newLine, (_cursorPos - 1));
+  }
+
+  void _delete() {
+    if (_cursorPos == _currentLine.length)
+      return;
+
+    List<int> newLine = <int>[];
+    newLine..addAll(_currentLine.take(_cursorPos))
+           ..addAll(_currentLine.skip(_cursorPos + 1));
+    _update(newLine, _cursorPos);
+  }
+
+  void _home() {
+    _updatePos(0);
+  }
+
+  void _end() {
+    _updatePos(_currentLine.length);
+  }
+
+  void _clearScreen() {
+    _stdout.write(term.clearScreen);
+    _writePromptAndLine();
+  }
+
+  void _kill() {
+    List<int> newLine = <int>[];
+    newLine.addAll(_currentLine.take(_cursorPos));
+    _killBuffer = _currentLine.skip(_cursorPos).toList();
+    _update(newLine, _cursorPos);
+  }
+
+  void _clearLine() {
+    _update(<int>[], 0);
+  }
+
+  void _yank() {
+    List<int> newLine = <int>[];
+    newLine..addAll(_currentLine.take(_cursorPos))
+           ..addAll(_killBuffer)
+           ..addAll(_currentLine.skip(_cursorPos));
+    _update(newLine, (_cursorPos + _killBuffer.length));
+  }
+
+  static String _commonPrefix(String a, String b) {
+    int pos = 0;
+    while (pos < a.length && pos < b.length) {
+      if (a.codeUnitAt(pos) != b.codeUnitAt(pos))
+        break;
+
+      pos++;
+    }
+    return a.substring(0, pos);
+  }
+
+  static String _foldCompletions(List<String> values) {
+    if (values.length == 0)
+      return '';
+
+    String prefix = values[0];
+    for (int i = 1; i < values.length; i++) {
+      prefix = _commonPrefix(prefix, values[i]);
+    }
+    return prefix;
+  }
+
+  Future<Null> _complete(bool showCompletions) async {
+    List<int> linePrefix = _currentLine.take(_cursorPos).toList();
+    String lineAsString = new String.fromCharCodes(linePrefix);
+    List<String> completions = await _cmd.completeCommand(lineAsString);
+    String completion;
+    if (completions.length == 0) {
+      // No completions.  Leave the line alone.
+      return;
+    } else if (completions.length == 1) {
+      // Unambiguous completion.
+      completion = completions[0];
+    } else {
+      // Ambiguous completion.
+      completions = completions.map((String s) => s.trimRight()).toList();
+      completion = _foldCompletions(completions);
+    }
+
+    if (showCompletions) {
+      // User hit double-TAB.  Show them all possible completions.
+      completions.sort((String a, String b) => a.compareTo(b));
+      _move(_cursorPos, _currentLine.length);
+      _stdout.writeln();
+      _stdout.writeln(completions);
+      _writePromptAndLine();
+      return;
+
+    } else {
+      // Apply the current completion.
+      List<int> completionRunes = completion.runes.toList();
+      List<int> newLine = <int>[];
+      newLine..addAll(completionRunes)
+             ..addAll(_currentLine.skip(_cursorPos));
+      _update(newLine, completionRunes.length);
+      return;
+    }
+  }
+
+  Future<Null> _newline() async {
+    _end();
+    _stdout.writeln();
+
+    // Prompt is implicitly hidden at this point.
+    _hideDepth++;
+
+    String text = new String.fromCharCodes(_currentLine);
+    _currentLine = <int>[];
+    _cursorPos = 0;
+    try {
+      await _cmd.runCommand(text);
+    } catch (e) {
+      print('$e');
+    }
+
+    // Reveal the prompt.
+    show();
+  }
+
+  void _leftArrow() {
+    _updatePos(_cursorPos - 1);
+  }
+
+  void _rightArrow() {
+    _updatePos(_cursorPos + 1);
+  }
+
+  void _historyPrevious() {
+    String text = new String.fromCharCodes(_currentLine);
+    List<int> newLine = _cmd.historyPrev(text).runes.toList();
+    _update(newLine, newLine.length);
+  }
+
+  void _historyNext() {
+    String text = new String.fromCharCodes(_currentLine);
+    List<int> newLine = _cmd.historyNext(text).runes.toList();
+    _update(newLine, newLine.length);
+  }
+
+  void _updatePos(int newCursorPos) {
+    if (newCursorPos < 0)
+      return;
+
+    if (newCursorPos > _currentLine.length)
+      return;
+
+    _cursorPos = _move(_cursorPos, newCursorPos);
+  }
+
+  void _update(List<int> newLine, int newCursorPos) {
+    int pos = _cursorPos;
+    int sharedLen = min(_currentLine.length, newLine.length);
+
+    // Find first difference.
+    int diffPos;
+    for (diffPos = 0; diffPos < sharedLen; diffPos++) {
+      if (_currentLine[diffPos] != newLine[diffPos])
+        break;
+    }
+
+    if (_dumbMode) {
+      assert(_cursorPos == _currentLine.length);
+      assert(newCursorPos == newLine.length);
+      if (diffPos == _currentLine.length) {
+        // Write the new text.
+        int pos = _writeRange(newLine, _cursorPos, newLine.length);
+        assert(pos == newCursorPos);
+        _cursorPos = newCursorPos;
+        _currentLine = newLine;
+      } else {
+        // We can't erase, so just move forward.
+        _stdout.writeln();
+        _currentLine = newLine;
+        _cursorPos = newCursorPos;
+        _writePromptAndLine();
+      }
+      return;
+    }
+
+    // Move the cursor to where the difference begins.
+    pos = _move(pos, diffPos);
+
+    // Write the new text.
+    pos = _writeRange(newLine, pos, newLine.length);
+
+    // Clear any extra characters at the end.
+    pos = _clearRange(pos, _currentLine.length);
+
+    // Move the cursor back to the input point.
+    _cursorPos = _move(pos, newCursorPos);
+    _currentLine = newLine;
+  }
+
+  void print(String text) {
+    hide();
+    _stdout.writeln(text);
+    show();
+  }
+
+  void hide() {
+    if (_hideDepth > 0) {
+      _hideDepth++;
+      return;
+    }
+    _hideDepth++;
+    if (_dumbMode) {
+      _stdout.writeln();
+      return;
+    }
+    // We need to erase everything, including the prompt.
+    int curLine = _getLine(_cursorPos);
+    int lastLine = _getLine(_currentLine.length);
+
+    // Go to last line.
+    if (curLine < lastLine) {
+      for (int i = 0; i < (lastLine - curLine); i++) {
+        // This moves us to column 0.
+        _stdout.write(term.cursorDown);
+      }
+      curLine = lastLine;
+    } else {
+      // Move to column 0.
+      _stdout.write('\r');
+    }
+
+    // Work our way up, clearing lines.
+    while (true) {
+      _stdout.write(term.clearEOL);
+      if (curLine > 0) {
+        _stdout.write(term.cursorUp);
+      } else {
+        break;
+      }
+    }
+  }
+
+  void show() {
+    assert(_hideDepth > 0);
+    _hideDepth--;
+    if (_hideDepth > 0)
+      return;
+
+    _writePromptAndLine();
+
+    // If input was buffered while the prompt was hidden, process it
+    // now.
+    if (_bufferedInput.isNotEmpty) {
+      String input = _bufferedInput.toString();
+      _bufferedInput.clear();
+      _handleText(input);
+    }
+  }
+
+  int _writeRange(List<int> text, int pos, int writeToPos) {
+    if (pos >= writeToPos)
+      return pos;
+
+    while (pos < writeToPos) {
+      int margin = _nextMargin(pos);
+      int limit = min(writeToPos, margin);
+      _stdout.write(new String.fromCharCodes(text.getRange(pos, limit)));
+      pos = limit;
+      if (pos == margin)
+        _stdout.write('\n');
+    }
+    return pos;
+  }
+
+  int _clearRange(int pos, int clearToPos) {
+    if (pos >= clearToPos)
+      return pos;
+
+    while (true) {
+      int limit = _nextMargin(pos);
+      _stdout.write(term.clearEOL);
+      if (limit >= clearToPos)
+        return pos;
+
+      _stdout.write('\n');
+      pos = limit;
+    }
+  }
+
+  int _move(int pos, int newPos) {
+    if (pos == newPos)
+      return pos;
+
+    int curCol = _getCol(pos);
+    int curLine = _getLine(pos);
+    int newCol = _getCol(newPos);
+    int newLine = _getLine(newPos);
+
+    if (curLine > newLine) {
+      for (int i = 0; i < (curLine - newLine); i++) {
+        _stdout.write(term.cursorUp);
+      }
+    }
+    if (curLine < newLine) {
+      for (int i = 0; i < (newLine - curLine); i++) {
+        _stdout.write(term.cursorDown);
+      }
+
+      // Moving down resets column to zero, oddly.
+      curCol = 0;
+    }
+    if (curCol > newCol) {
+      for (int i = 0; i < (curCol - newCol); i++) {
+        _stdout.write(term.cursorBack);
+      }
+    }
+    if (curCol < newCol) {
+      for (int i = 0; i < (newCol - curCol); i++) {
+        _stdout.write(term.cursorForward);
+      }
+    }
+
+    return newPos;
+  }
+
+  int _nextMargin(int pos) {
+    int truePos = pos + prompt.length;
+    return ((truePos ~/ _screenWidth) + 1) * _screenWidth - prompt.length;
+  }
+
+  int _getLine(int pos) {
+    int truePos = pos + prompt.length;
+    return truePos ~/ _screenWidth;
+  }
+
+  int _getCol(int pos) {
+    int truePos = pos + prompt.length;
+    return truePos % _screenWidth;
+  }
+
+  Stdin _stdin;
+  StreamSubscription<String> _stdinSubscription;
+  IOSink _stdout;
+  final String prompt;
+  int _hideDepth = 0;
+  final AnsiTerminal term;
+
+  int _screenWidth;
+  List<int> _currentLine = <int>[];  // A list of runes.
+  StringBuffer _bufferedInput = new StringBuffer();
+  int _cursorPos = 0;
+  int _tabCount = 0;
+  List<int> _killBuffer = <int>[];
+}

--- a/packages/flutter_tools/lib/src/commands/analyze.dart
+++ b/packages/flutter_tools/lib/src/commands/analyze.dart
@@ -336,10 +336,10 @@ class AnalyzeCommand extends FlutterCommand {
       analyzedPaths.clear();
       analysisTimer = new Stopwatch()..start();
     } else {
-      analysisStatus?.stop(showElapsedTime: true);
+      analysisStatus?.stop();
       analysisTimer.stop();
 
-      logger.printStatus(terminal.clearScreen(), newline: false);
+      logger.printStatus(terminal.clearScreen, newline: false);
 
       // Remove errors for deleted files, sort, and print errors.
       final List<AnalysisError> errors = <AnalysisError>[];

--- a/packages/flutter_tools/lib/src/commands/build_aot.dart
+++ b/packages/flutter_tools/lib/src/commands/build_aot.dart
@@ -62,7 +62,7 @@ class BuildAotCommand extends BuildSubCommand {
       outputPath: argResults['output-dir'],
       interpreter: argResults['interpreter']
     );
-    status.stop(showElapsedTime: true);
+    status.stop();
 
     if (outputPath == null)
       return 1;

--- a/packages/flutter_tools/lib/src/commands/build_apk.dart
+++ b/packages/flutter_tools/lib/src/commands/build_apk.dart
@@ -549,7 +549,7 @@ Future<int> buildAndroid(
   }
 
   int result = _buildApk(platform, buildMode, components, flxPath, keystore, outputFile);
-  status.stop(showElapsedTime: true);
+  status.stop();
 
   if (result == 0) {
     File apkFile = new File(outputFile);

--- a/packages/flutter_tools/lib/src/commands/build_ios.dart
+++ b/packages/flutter_tools/lib/src/commands/build_ios.dart
@@ -62,7 +62,7 @@ class BuildIOSCommand extends BuildSubCommand {
       buildForDevice: !forSimulator,
       codesign: shouldCodesign
     );
-    status.stop(showElapsedTime: true);
+    status.stop();
 
     if (!result.success) {
       printError('Encountered error while building for $logTarget.');

--- a/packages/flutter_tools/lib/src/commands/drive.dart
+++ b/packages/flutter_tools/lib/src/commands/drive.dart
@@ -133,7 +133,7 @@ class DriveCommand extends RunCommandBase {
         'Missing packages directory; running `pub get` (to work around https://github.com/dart-lang/test/issues/327):'
       );
       await runAsync(<String>[sdkBinaryName('pub'), 'get', '--no-precompile']);
-      status.stop(showElapsedTime: true);
+      status.stop();
     }
 
     Cache.releaseLockEarly();

--- a/packages/flutter_tools/lib/src/commands/test.dart
+++ b/packages/flutter_tools/lib/src/commands/test.dart
@@ -94,7 +94,7 @@ class TestCommand extends FlutterCommand {
   Future<bool> _collectCoverageData(CoverageCollector collector, { bool mergeCoverageData: false }) async {
     Status status = logger.startProgress('Collecting coverage information...');
     String coverageData = await collector.finalizeCoverage();
-    status.stop(showElapsedTime: true);
+    status.stop();
     if (coverageData == null)
       return false;
 

--- a/packages/flutter_tools/lib/src/commands/update_packages.dart
+++ b/packages/flutter_tools/lib/src/commands/update_packages.dart
@@ -45,7 +45,7 @@ class UpdatePackagesCommand extends FlutterCommand {
     new File(path.join(coverageDir, 'lcov.info'))
       ..createSync(recursive: true)
       ..writeAsBytesSync(data, flush: true);
-    status.stop(showElapsedTime: true);
+    status.stop();
   }
 
   @override

--- a/packages/flutter_tools/lib/src/dart/pub.dart
+++ b/packages/flutter_tools/lib/src/dart/pub.dart
@@ -51,7 +51,7 @@ Future<int> pubGet({
       <String>[sdkBinaryName('pub'), '--verbosity=warning', command, '--no-package-symlinks', '--no-precompile'],
       workingDirectory: directory
     );
-    status.stop(showElapsedTime: true);
+    status.stop();
     if (code != 0)
       return code;
   }

--- a/packages/flutter_tools/lib/src/devfs.dart
+++ b/packages/flutter_tools/lib/src/devfs.dart
@@ -297,7 +297,7 @@ class DevFS {
     await _scanDirectory(directory,
                          recursive: true,
                          fileFilter: fileFilter);
-    status.stop(showElapsedTime: true);
+    status.stop();
 
     status = logger.startProgress('Scanning package files...');
     String packagesFilePath = path.join(rootDirectory.path, kPackagesFileName);
@@ -330,7 +330,7 @@ class DevFS {
         }
       }
     }
-    status.stop(showElapsedTime: true);
+    status.stop();
     if (bundle != null) {
       status = logger.startProgress('Scanning asset files...');
       // Synchronize asset bundle.
@@ -340,7 +340,7 @@ class DevFS {
         final String devicePath = path.join('build/flx', entry.archivePath);
         _scanBundleEntry(devicePath, entry, bundleDirty);
       }
-      status.stop(showElapsedTime: true);
+      status.stop();
     }
     // Handle deletions.
     status = logger.startProgress('Scanning for deleted files...');
@@ -354,7 +354,7 @@ class DevFS {
     for (int i = 0; i < toRemove.length; i++) {
       _entries.remove(toRemove[i]);
     }
-    status.stop(showElapsedTime: true);
+    status.stop();
 
     if (_deletedEntries.length > 0) {
       status = logger.startProgress('Removing deleted files...');
@@ -367,7 +367,7 @@ class DevFS {
       await Future.wait(_pendingOperations);
       _pendingOperations.clear();
       _deletedEntries.clear();
-      status.stop(showElapsedTime: true);
+      status.stop();
     } else {
       printStatus("No files to remove.");
     }
@@ -401,7 +401,7 @@ class DevFS {
         _pendingOperations.clear();
       }
       _dirtyEntries.clear();
-      status.stop(showElapsedTime: true);
+      status.stop();
     } else {
       printStatus("No files to update.");
     }

--- a/packages/flutter_tools/test/all.dart
+++ b/packages/flutter_tools/test/all.dart
@@ -17,6 +17,7 @@ import 'android_device_test.dart' as android_device_test;
 import 'android_sdk_test.dart' as android_sdk_test;
 import 'application_package_test.dart' as application_package_test;
 import 'base_utils_test.dart' as base_utils_test;
+import 'cli_command_test.dart' as cli_command_test;
 import 'config_test.dart' as config_test;
 import 'context_test.dart' as context_test;
 import 'create_test.dart' as create_test;
@@ -48,6 +49,7 @@ void main() {
   android_sdk_test.main();
   application_package_test.main();
   base_utils_test.main();
+  cli_command_test.main();
   config_test.main();
   context_test.main();
   create_test.main();

--- a/packages/flutter_tools/test/cli_command_test.dart
+++ b/packages/flutter_tools/test/cli_command_test.dart
@@ -1,0 +1,237 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:flutter_tools/src/cli/command.dart';
+import 'package:test/test.dart';
+
+class TestCommand extends Command {
+  TestCommand(this.out, String name, [List<Command> children])
+    : super(name, children);
+  StringBuffer out;
+
+  @override
+  Future<Null> run(List<String> args) {
+    out.write('executing $name($args)\n');
+    return new Future<Null>.value(null);
+  }
+}
+
+class TestCompleteCommand extends Command {
+  TestCompleteCommand(this.out, String name, List<Command> children)
+    : super(name, children);
+  StringBuffer out;
+
+  @override
+  Future<List<String>> complete(List<String> args) {
+    List<String> possibles = <String>['one ', 'two ', 'three '];
+    return new Future<List<String>>.value(
+        possibles.where((String possible) =>
+          possible.startsWith(args[0])).toList());
+  }
+
+  @override
+  Future<Null> run(List<String> args) {
+    out.write('executing $name($args)\n');
+    return new Future<Null>.value(null);
+  }
+}
+
+void testCommandComplete() {
+  RootCommand cmd =
+      new RootCommand(<Command>[
+        new TestCommand(null, 'alpha'),
+        new TestCommand(null, 'game', <Command>[
+          new TestCommand(null, 'checkers'),
+          new TestCommand(null, 'chess')
+        ]),
+        new TestCommand(null, 'gamera', <Command>[
+          new TestCommand(null, 'london'),
+          new TestCommand(null, 'tokyo'),
+          new TestCommand(null, 'topeka')
+        ]),
+        new TestCompleteCommand(null, 'count', <Command>[
+          new TestCommand(null, 'chocula')])]);
+
+  // Show all commands.
+  cmd.completeCommand('').then((List<String> result) {
+    expect(result, equals(<String>['alpha ', 'game ', 'gamera ', 'count ']));
+  });
+
+  // Substring completion.
+  cmd.completeCommand('al').then((List<String> result) {
+    expect(result, equals(<String>['alpha ']));
+  });
+
+  // Full string completion.
+  cmd.completeCommand('alpha').then((List<String> result) {
+    expect(result, equals(<String>['alpha ']));
+  });
+
+  // Extra space, no subcommands.
+  cmd.completeCommand('alpha ').then((List<String> result) {
+    expect(result, equals(<String>['alpha ']));
+  });
+
+  // Ambiguous completion.
+  cmd.completeCommand('g').then((List<String> result) {
+    expect(result, equals(<String>['game ', 'gamera ']));
+  });
+
+  // Ambiguous completion, exact match not preferred.
+  cmd.completeCommand('game').then((List<String> result) {
+    expect(result, equals(<String>['game ', 'gamera ']));
+  });
+
+  // Show all subcommands.
+  cmd.completeCommand('gamera ').then((List<String> result) {
+    expect(result, equals(
+      <String>['gamera london ', 'gamera tokyo ', 'gamera topeka ']));
+  });
+
+  // Subcommand completion.
+  cmd.completeCommand('gamera l').then((List<String> result) {
+    expect(result, equals(<String>['gamera london ']));
+  });
+
+  // Extra space, with subcommand.
+  cmd.completeCommand('gamera london ').then((List<String> result) {
+    expect(result, equals(<String>['gamera london ']));
+  });
+
+  // Ambiguous subcommand completion.
+  cmd.completeCommand('gamera t').then((List<String> result) {
+    expect(result, equals(<String>['gamera tokyo ', 'gamera topeka ']));
+  });
+
+  // Ambiguous subcommand completion with substring prefix.
+  // Note that the prefix is left alone.
+  cmd.completeCommand('gamer t').then((List<String> result) {
+    expect(result, equals(<String>['gamer tokyo ', 'gamer topeka ']));
+  });
+
+  // Ambiguous but exact prefix is preferred.
+  cmd.completeCommand('game chec').then((List<String> result) {
+    expect(result, equals(<String>['game checkers ']));
+  });
+
+  // Ambiguous non-exact prefix means no matches.
+  cmd.completeCommand('gam chec').then((List<String> result) {
+    expect(result, equals(<String>[]));
+  });
+
+  // Locals + subcommands, show all.
+  cmd.completeCommand('count ').then((List<String> result) {
+      expect(result, equals(<String>[
+        'count chocula ',
+        'count one ',
+        'count two ',
+        'count three '
+      ]));
+    });
+
+  // Locals + subcommands, single local match.
+  cmd.completeCommand('count th').then((List<String> result) {
+    expect(result, equals(<String>['count three ']));
+  });
+
+  // Locals + subcommands, ambiguous local match.
+  cmd.completeCommand('count t').then((List<String> result) {
+    expect(result, equals(<String>['count two ', 'count three ']));
+  });
+
+  // Locals + subcommands, single command match.
+  cmd.completeCommand('co choc').then((List<String> result) {
+    expect(result, equals(<String>['co chocula ']));
+  });
+
+  // We gobble spare spaces in the prefix but not elsewhere.
+  cmd.completeCommand('    game    chec').then((List<String> result) {
+    expect(result, equals(<String>['game    checkers ']));
+  });
+}
+
+void testCommandRunSimple() {
+  // Run a simple command.
+  StringBuffer out = new StringBuffer();
+  RootCommand cmd = new RootCommand(<Command>[new TestCommand(out, 'alpha')]);
+
+  // Full name dispatch works.  Argument passing works.
+  cmd.runCommand('alpha dog').then(expectAsync((_) {
+      expect(out.toString(), contains('executing alpha([dog])\n'));
+      out.clear();
+      // Substring dispatch works.
+      cmd.runCommand('al cat mouse').then(expectAsync((_) {
+          expect(out.toString(), contains('executing alpha([cat , mouse])\n'));
+      }));
+  }));
+}
+
+void testCommandRunSubcommand() {
+  // Run a simple command.
+  StringBuffer out = new StringBuffer();
+  RootCommand cmd =
+      new RootCommand(<Command>[
+        new TestCommand(out, 'alpha', <Command>[
+          new TestCommand(out, 'beta'),
+          new TestCommand(out, 'gamma')])]);
+
+  cmd.runCommand('a b').then(expectAsync((_) {
+      expect(out.toString(), equals('executing beta([])\n'));
+      out.clear();
+      cmd.runCommand('alpha g ').then(expectAsync((_) {
+          expect(out.toString(), equals('executing gamma([])\n'));
+      }));
+  }));
+}
+
+void testCommandRunNotFound() {
+  // Run a simple command.
+  StringBuffer out = new StringBuffer();
+  RootCommand cmd = new RootCommand(<Command>[new TestCommand(out, 'alpha')]);
+  cmd.runCommand('goose').catchError(expectAsync((dynamic e) {
+    expect(e.toString(), equals("No such command: 'goose'"));
+  }));
+}
+
+void testCommandRunAmbiguous() {
+  // Run a simple command.
+  StringBuffer out = new StringBuffer();
+  RootCommand cmd = new RootCommand(<Command>[
+    new TestCommand(out, 'alpha'),
+    new TestCommand(out, 'ankle')]);
+
+  cmd.runCommand('a 55').catchError(expectAsync((dynamic e) {
+      expect(e.toString(),
+             equals("Command 'a 55' is ambiguous: [alpha, ankle]"));
+      out.clear();
+      cmd.runCommand('ankl 55').then(expectAsync((_) {
+          expect(out.toString(), equals('executing ankle([55])\n'));
+      }));
+  }));
+}
+
+void testCommandRunAlias() {
+  // Run a simple command.
+  StringBuffer out = new StringBuffer();
+  Command aliasCmd = new TestCommand(out, 'alpha');
+  aliasCmd.alias = 'a';
+  RootCommand cmd = new RootCommand(<Command>[
+    aliasCmd,
+    new TestCommand(out, 'ankle')]);
+
+  cmd.runCommand('a 55').then(expectAsync((_) {
+    expect(out.toString(), equals('executing alpha([55])\n'));
+  }));
+}
+
+void main() {
+  test('command completion test suite', testCommandComplete);
+  test('run a simple command', testCommandRunSimple);
+  test('run a subcommand', testCommandRunSubcommand);
+  test('run a command which is not found', testCommandRunNotFound);
+  test('run a command which is ambiguous', testCommandRunAmbiguous);
+  test('run a command using an alias', testCommandRunAlias);
+}


### PR DESCRIPTION
New command line code is in the lib/src/cli directory and is a port of
some Observatory and old ddbg (dart command line debugger) code.

Some highlights:
- Emacs-ish command line editing (^A, ^E, ^F, ^B, ^K, left/right arrows, etc.)
- Command history (up/down arrows)
- Command completion (tab)
- Command help system

As part of the change, I rewrote AnsiTerminal to get the relevant
termcap strings from tput directly.

Tested in smart and dumb terminal modes.

Progress spinners now hide/show themselves around log messages, so
gettting a log message while you have an active progress spinner no
longer looks funny.
