### PR TITLE
don't resolve symlinks as part of which

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_sdk.dart
+++ b/packages/flutter_tools/lib/src/android/android_sdk.dart
@@ -78,6 +78,8 @@ class AndroidSdk {
 
     File aaptBin = os.which('aapt'); // in build-tools/$version/aapt
     if (aaptBin != null) {
+      // Make sure we're using the aapt from the SDK.
+      aaptBin = new File(aaptBin.resolveSymbolicLinksSync());
       String dir = aaptBin.parent.parent.parent.path;
       if (validSdkDirectory(dir))
         return new AndroidSdk(dir);
@@ -85,6 +87,8 @@ class AndroidSdk {
 
     File adbBin = os.which('adb'); // in platform-tools/adb
     if (adbBin != null) {
+      // Make sure we're using the adb from the SDK.
+      adbBin = new File(adbBin.resolveSymbolicLinksSync());
       String dir = adbBin.parent.parent.path;
       if (validSdkDirectory(dir))
         return new AndroidSdk(dir);

--- a/packages/flutter_tools/lib/src/base/os.dart
+++ b/packages/flutter_tools/lib/src/base/os.dart
@@ -54,8 +54,8 @@ class _PosixUtils extends OperatingSystemUtils {
     return Process.runSync('chmod', <String>['a+x', file.path]);
   }
 
-  /// Return the path (with symlinks resolved) to the given executable, or `null`
-  /// if `which` was not able to locate the binary.
+  /// Return the path to the given executable, or `null` if `which` was not able
+  /// to locate the binary.
   @override
   File which(String execName) {
     ProcessResult result = Process.runSync('which', <String>[execName]);

--- a/packages/flutter_tools/lib/src/base/os.dart
+++ b/packages/flutter_tools/lib/src/base/os.dart
@@ -62,7 +62,7 @@ class _PosixUtils extends OperatingSystemUtils {
     if (result.exitCode != 0)
       return null;
     String path = result.stdout.trim().split('\n').first.trim();
-    return new File(new File(path).resolveSymbolicLinksSync());
+    return new File(path);
   }
 
   // unzip -o -q zipfile -d dest


### PR DESCRIPTION
- don't resolve symlinks as part of our `which` implementation (fix https://github.com/flutter/flutter/issues/5164)
- continue to resolve symlinks when we're looking for binaries in order to locate related SDKs. Some systems, like brew, will put symlinks to the tools in one `bin/` directory, but we want to know where those links resolve to in order to locate their parent SDK (line the Android SDK).
