### PR TITLE
Handle dragging a bottom sheet past the bottom

### DIFF
--- a/packages/flutter/lib/src/material/bottom_sheet.dart
+++ b/packages/flutter/lib/src/material/bottom_sheet.dart
@@ -108,11 +108,13 @@ class _BottomSheetState extends State<BottomSheet> {
       return;
     if (details.velocity.pixelsPerSecond.dy > _kMinFlingVelocity) {
       double flingVelocity = -details.velocity.pixelsPerSecond.dy / _childHeight;
-      config.animationController.fling(velocity: flingVelocity);
+      if (config.animationController.value > 0.0)
+        config.animationController.fling(velocity: flingVelocity);
       if (flingVelocity < 0.0)
         config.onClosing();
     } else if (config.animationController.value < _kCloseProgressThreshold) {
-      config.animationController.fling(velocity: -1.0);
+      if (config.animationController.value > 0.0)
+        config.animationController.fling(velocity: -1.0);
       config.onClosing();
     } else {
       config.animationController.forward();

--- a/packages/flutter/lib/src/material/scaffold.dart
+++ b/packages/flutter/lib/src/material/scaffold.dart
@@ -454,7 +454,7 @@ class ScaffoldState extends State<Scaffold> {
 
   // PERSISTENT BOTTOM SHEET API
 
-  List<Widget> _dismissedBottomSheets;
+  final List<Widget> _dismissedBottomSheets = <Widget>[];
   PersistentBottomSheetController<dynamic> _currentBottomSheet;
 
   /// Shows a persistent material design bottom sheet.
@@ -491,9 +491,11 @@ class ScaffoldState extends State<Scaffold> {
         assert(_currentBottomSheet._widget == bottomSheet);
         assert(bottomSheetKey.currentState != null);
         bottomSheetKey.currentState.close();
-        _dismissedBottomSheets ??= <Widget>[];
-        _dismissedBottomSheets.add(bottomSheet);
-        _currentBottomSheet = null;
+        if (controller.status != AnimationStatus.dismissed)
+          _dismissedBottomSheets.add(bottomSheet);
+        setState(() {
+          _currentBottomSheet = null;
+        });
         completer.complete();
       }
     );
@@ -505,10 +507,11 @@ class ScaffoldState extends State<Scaffold> {
         entry.remove();
       },
       onDismissed: () {
-        assert(_dismissedBottomSheets != null);
-        setState(() {
-          _dismissedBottomSheets.remove(bottomSheet);
-        });
+        if (_dismissedBottomSheets.contains(bottomSheet)) {
+          setState(() {
+            _dismissedBottomSheets.remove(bottomSheet);
+          });
+        }
       },
       builder: builder
     );
@@ -728,10 +731,9 @@ class ScaffoldState extends State<Scaffold> {
     }
     // Otherwise the AppBar will be part of a [app bar, body] Stack. See AppBarBehavior.scroll below.
 
-    if (_currentBottomSheet != null ||
-        (_dismissedBottomSheets != null && _dismissedBottomSheets.isNotEmpty)) {
+    if (_currentBottomSheet != null || _dismissedBottomSheets.isNotEmpty) {
       final List<Widget> bottomSheets = <Widget>[];
-      if (_dismissedBottomSheets != null && _dismissedBottomSheets.isNotEmpty)
+      if (_dismissedBottomSheets.isNotEmpty)
         bottomSheets.addAll(_dismissedBottomSheets);
       if (_currentBottomSheet != null)
         bottomSheets.add(_currentBottomSheet._widget);

--- a/packages/flutter/test/widget/bottom_sheet_test.dart
+++ b/packages/flutter/test/widget/bottom_sheet_test.dart
@@ -110,4 +110,33 @@ void main() {
     expect(find.text('BottomSheet'), findsNothing);
   });
 
+  testWidgets('Verify that dragging past the bottom dismisses a persistent BottomSheet', (WidgetTester tester) async {
+    // This is a regression test for https://github.com/flutter/flutter/issues/5528
+    GlobalKey<ScaffoldState> scaffoldKey = new GlobalKey<ScaffoldState>();
+
+    await tester.pumpWidget(new MaterialApp(
+      home: new Scaffold(
+        key: scaffoldKey,
+        body: new Center(child: new Text('body'))
+      )
+    ));
+
+    scaffoldKey.currentState.showBottomSheet((BuildContext context) {
+      return new Container(
+        margin: new EdgeInsets.all(40.0),
+        child: new Text('BottomSheet')
+      );
+    });
+
+    await tester.pump(); // bottom sheet show animation starts
+    await tester.pump(new Duration(seconds: 1)); // animation done
+    expect(find.text('BottomSheet'), findsOneWidget);
+
+    await tester.fling(find.text('BottomSheet'), const Offset(0.0, 400.0), 1000.0);
+    await tester.pump(); // drain the microtask queue (Future completion callback)
+    await tester.pump(); // bottom sheet dismiss animation starts
+    await tester.pump(new Duration(seconds: 1)); // animation done
+
+    expect(find.text('BottomSheet'), findsNothing);
+  });
 }


### PR DESCRIPTION
There were two problems here:
- BottomSheet was responding to a drag-end event by flinging its controller towards 0.0. Even if the controller's value was already 0.0.
- The Scaffold assumed that the bottom sheet would always call its onDismissed callback before its onClosing callback. If the user drags the bottom sheet off the bottom of the screen, onDismissed is called first because the controller's value reaches zero when the bottom sheet disappears. 

Fixes #5528
Fixes #3232
