### PR TITLE
Fix escaping of spaces when passing launch arguments to the iOS device.

### DIFF
--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -231,7 +231,7 @@ class IOSDevice extends Device {
 
     if (launchArguments.length > 0) {
       launchCommand.add('--args');
-      launchCommand.add('"${launchArguments.join(" ")}"');
+      launchCommand.add('${launchArguments.join(" ")}');
     }
 
     int installationResult = -1;


### PR DESCRIPTION
`Process.start` seems to be escaping as needed.

Fixes https://github.com/flutter/flutter/issues/5565
