### PR TITLE
Teach hero observer about the risks of frame-0-pop

### DIFF
--- a/packages/flutter/lib/src/scheduler/binding.dart
+++ b/packages/flutter/lib/src/scheduler/binding.dart
@@ -504,6 +504,12 @@ abstract class SchedulerBinding extends BindingBase {
 
     Timeline.finishSync();
 
+    assert(() {
+      if (debugPrintEndFrameBanner)
+        debugPrint('━━━━━━━┫ End of Frame ┣━━━━━━━');
+      return true;
+    });
+
     // All frame-related callbacks have been executed. Run lower-priority tasks.
     _runTasks();
   }

--- a/packages/flutter/lib/src/scheduler/debug.dart
+++ b/packages/flutter/lib/src/scheduler/debug.dart
@@ -4,3 +4,9 @@
 
 /// Print a banner at the beginning of each frame.
 bool debugPrintBeginFrameBanner = false;
+
+/// Print a banner at the end of each frame.
+///
+/// Combined with [debugPrintBeginFrameBanner], this can be helpful for
+/// determining if code is running during a frame or between frames.
+bool debugPrintEndFrameBanner = false;


### PR DESCRIPTION
If a route is already dismissed when it's popped, there's no point
trying to animate heroes, because it's going to be gone before the
heroes code can look at it.
