### PR TITLE
Image should handle InheritedWidget ancestor changes

### DIFF
--- a/packages/flutter/lib/src/widgets/image.dart
+++ b/packages/flutter/lib/src/widgets/image.dart
@@ -199,7 +199,6 @@ class _ImageState extends State<Image> {
     // in case the InheritedWidget ancestors it depends on have changed.
     _imageStream?.removeListener(_handleImageChanged);
     _imageStream = null;
-    _imageInfo = null;
     super.deactivate();
   }
 

--- a/packages/flutter/lib/src/widgets/image.dart
+++ b/packages/flutter/lib/src/widgets/image.dart
@@ -194,6 +194,16 @@ class _ImageState extends State<Image> {
   }
 
   @override
+  void deactivate() {
+    // If this image is activated again then force _imageStream to be recreated,
+    // in case the InheritedWidget ancestors it depends on have changed.
+    _imageStream?.removeListener(_handleImageChanged);
+    _imageStream = null;
+    _imageInfo = null;
+    super.deactivate();
+  }
+
+  @override
   void dependenciesChanged() {
     _resolveImage();
     super.dependenciesChanged();
@@ -203,12 +213,6 @@ class _ImageState extends State<Image> {
   void reassemble() {
     _resolveImage();
     super.reassemble();
-  }
-
-  @override
-  void dispose() {
-    _imageStream.removeListener(_handleImageChanged);
-    super.dispose();
   }
 
   void _resolveImage() {

--- a/packages/flutter/test/widget/image_test.dart
+++ b/packages/flutter/test/widget/image_test.dart
@@ -221,6 +221,71 @@ void main() {
     expect(imageProvider._configuration.devicePixelRatio, 10.0);
   });
 
+  testWidgets('Verify ImageProvider configuration inheritance again', (WidgetTester tester) async {
+    final GlobalKey mediaQueryKey1 = new GlobalKey(debugLabel: 'mediaQueryKey1');
+    final GlobalKey mediaQueryKey2 = new GlobalKey(debugLabel: 'mediaQueryKey2');
+    final GlobalKey imageKey = new GlobalKey(debugLabel: 'image');
+    final TestImageProvider imageProvider = new TestImageProvider();
+
+    // This is just a variation on the previous test.  In this version the location
+    // of the Image changes and the MediaQuery widgets do not.
+    await tester.pumpWidget(
+      new Row(
+        children: <Widget> [
+          new MediaQuery(
+            key: mediaQueryKey2,
+            data: new MediaQueryData(
+              devicePixelRatio: 5.0,
+              padding: EdgeInsets.zero,
+            ),
+            child: new Image(
+              key: imageKey,
+              image: imageProvider
+            )
+          ),
+          new MediaQuery(
+            key: mediaQueryKey1,
+            data: new MediaQueryData(
+              devicePixelRatio: 10.0,
+              padding: EdgeInsets.zero,
+            ),
+            child: new Container(width: 100.0)
+          )
+        ]
+      )
+    );
+
+    expect(imageProvider._configuration.devicePixelRatio, 5.0);
+
+    await tester.pumpWidget(
+      new Row(
+        children: <Widget> [
+          new MediaQuery(
+            key: mediaQueryKey2,
+            data: new MediaQueryData(
+              devicePixelRatio: 5.0,
+              padding: EdgeInsets.zero,
+            ),
+            child: new Container(width: 100.0)
+          ),
+          new MediaQuery(
+            key: mediaQueryKey1,
+            data: new MediaQueryData(
+              devicePixelRatio: 10.0,
+              padding: EdgeInsets.zero,
+            ),
+            child: new Image(
+              key: imageKey,
+              image: imageProvider
+            )
+          )
+        ]
+      )
+    );
+
+    expect(imageProvider._configuration.devicePixelRatio, 10.0);
+  });
+
 }
 
 class TestImageProvider extends ImageProvider<TestImageProvider> {


### PR DESCRIPTION
If an image's location in the widget tree changes then the inherited DefaultAssetBundle and MediaQuery widgets it depends on may also change.

If an image's location changes it will be deactivated and then rebuilt. Force the image to be resolved when it's rebuilt in this case.

Fixes #5612
