### PR TITLE
Re-enable iOS back gesture.

### DIFF
--- a/packages/flutter/lib/src/material/scaffold.dart
+++ b/packages/flutter/lib/src/material/scaffold.dart
@@ -22,9 +22,6 @@ const double _kFloatingActionButtonMargin = 16.0; // TODO(hmuller): should be de
 const Duration _kFloatingActionButtonSegue = const Duration(milliseconds: 200);
 final Tween<double> _kFloatingActionButtonTurnTween = new Tween<double>(begin: -0.125, end: 0.0);
 
-// iOS back gesture is in development. This flag will go away when it's ready
-// to ship.
-const bool _kBackGestureEnabled = false;
 const double _kBackGestureWidth = 20.0;
 
 /// The Scaffold's appbar is the toolbar, bottom, and the "flexible space"
@@ -700,9 +697,7 @@ class ScaffoldState extends State<Scaffold> {
   NavigationGestureController _backGestureController;
 
   bool _shouldHandleBackGesture() {
-    return _kBackGestureEnabled &&
-      Theme.of(context).platform == TargetPlatform.iOS &&
-      Navigator.canPop(context);
+    return Theme.of(context).platform == TargetPlatform.iOS && Navigator.canPop(context);
   }
 
   void _handleDragStart(DragStartDetails details) {

--- a/packages/flutter/test/widget/page_transitions_test.dart
+++ b/packages/flutter/test/widget/page_transitions_test.dart
@@ -121,9 +121,8 @@ void main() {
     await gesture.moveBy(new Offset(50.0, 0.0));
     await tester.pump();
 
-    // TODO(mpcomplete): back gesture disabled. Home should be onstage when
-    // it is reenabled.
-    expect(find.text('Home'), findsNothing);
+    // Home is now visible.
+    expect(find.text('Home'), isOnstage);
     expect(find.text('Settings'), isOnstage);
   });
 


### PR DESCRIPTION
The iOS transition is the more buggy part of this feature, and it wasn't
disabled. Let's just leave them enabled while I work on improvements.
