### PR TITLE
Added action to Pesto FAB.

### DIFF
--- a/examples/flutter_gallery/lib/demo/pesto_demo.dart
+++ b/examples/flutter_gallery/lib/demo/pesto_demo.dart
@@ -98,7 +98,11 @@ class _RecipeGridPageState extends State<RecipeGridPage> {
         drawer: buildDrawer(context),
         floatingActionButton: new FloatingActionButton(
           child: new Icon(Icons.edit),
-          onPressed: () { }
+          onPressed: () {
+            scaffoldKey.currentState.showSnackBar(new SnackBar(
+              content: new Text('Not supported.')
+            ));
+          }
         ),
         body: buildBody(context, statusBarHeight)
       )


### PR DESCRIPTION
The floating action button inside of the Pesto demo now opens up
a snackbar. Fixes #5685.
