### PR TITLE
Increased text margin in typography demo.

### DIFF
--- a/examples/flutter_gallery/lib/demo/typography_demo.dart
+++ b/examples/flutter_gallery/lib/demo/typography_demo.dart
@@ -26,7 +26,7 @@ class TextStyleItem extends StatelessWidget {
         crossAxisAlignment: CrossAxisAlignment.start,
         children: <Widget>[
           new SizedBox(
-            width: 64.0,
+            width: 72.0,
             child: new Text(name, style: nameStyle)
           ),
           new Flexible(


### PR DESCRIPTION
Subheading title was too close to the actual example. This commit
increases the size of its box. Fixes #5682.
