### PR TITLE
improve device matching error message

### DIFF
--- a/packages/flutter_tools/lib/src/commands/drive.dart
+++ b/packages/flutter_tools/lib/src/commands/drive.dart
@@ -205,11 +205,21 @@ void restoreTargetDeviceFinder() {
 }
 
 Future<Device> findTargetDevice() async {
+  List<Device> devices = await deviceManager.getDevices();
+
   if (deviceManager.hasSpecifiedDeviceId) {
-    return deviceManager.getDeviceById(deviceManager.specifiedDeviceId);
+    if (devices.isEmpty) {
+      printStatus("No devices found with name or id matching '${deviceManager.specifiedDeviceId}'");
+      return null;
+    }
+    if (devices.length > 1) {
+      printStatus("Found ${devices.length} devices with name or id matching '${deviceManager.specifiedDeviceId}':");
+      Device.printDevices(devices);
+      return null;
+    }
+    return devices.first;
   }
 
-  List<Device> devices = await deviceManager.getAllConnectedDevices();
 
   if (os.isMacOS) {
     // On Mac we look for the iOS Simulator. If available, we use that. Then

--- a/packages/flutter_tools/lib/src/device.dart
+++ b/packages/flutter_tools/lib/src/device.dart
@@ -35,13 +35,11 @@ class DeviceManager {
 
   bool get hasSpecifiedDeviceId => specifiedDeviceId != null;
 
-  /// Return the device with the matching ID; else, complete the Future with
-  /// `null`.
-  ///
-  /// This does a case insentitive compare with `deviceId`.
-  Future<Device> getDeviceById(String deviceId, [List<Device> devices]) async {
+  /// Return the devices with a name or id matching [deviceId].
+  /// This does a case insentitive compare with [deviceId].
+  Future<List<Device>> getDevicesById(String deviceId) async {
     deviceId = deviceId.toLowerCase();
-    devices ??= await getAllConnectedDevices();
+    List<Device> devices = await getAllConnectedDevices();
     Device device = devices.firstWhere(
         (Device device) =>
             device.id.toLowerCase() == deviceId ||
@@ -49,15 +47,13 @@ class DeviceManager {
         orElse: () => null);
 
     if (device != null)
-      return device;
+      return <Device>[device];
 
-    // Match on a close id / name.
-    devices = devices.where((Device device) {
+    // Match on a id or name starting with [deviceId].
+    return devices.where((Device device) {
       return (device.id.toLowerCase().startsWith(deviceId) ||
         device.name.toLowerCase().startsWith(deviceId));
     }).toList();
-
-    return devices.length == 1 ? devices.first : null;
   }
 
   /// Return the list of connected devices, filtered by any user-specified device id.
@@ -65,8 +61,7 @@ class DeviceManager {
     if (specifiedDeviceId == null) {
       return getAllConnectedDevices();
     } else {
-      Device device = await getDeviceById(specifiedDeviceId);
-      return device == null ? <Device>[] : <Device>[device];
+      return getDevicesById(specifiedDeviceId);
     }
   }
 

--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -137,7 +137,8 @@ abstract class FlutterCommand extends Command {
       List<Device> devices = await deviceManager.getDevices();
 
       if (devices.isEmpty && deviceManager.hasSpecifiedDeviceId) {
-        printError("No device found with id '${deviceManager.specifiedDeviceId}'.");
+        printStatus("No devices found with name or id "
+            "matching '${deviceManager.specifiedDeviceId}'");
         return 1;
       } else if (devices.isEmpty) {
         printStatus('No connected devices.');
@@ -153,10 +154,15 @@ abstract class FlutterCommand extends Command {
         printStatus('No supported devices connected.');
         return 1;
       } else if (devices.length > 1) {
-        printStatus("More than one device connected; please specify a device with "
-          "the '-d <deviceId>' flag.");
+        if (deviceManager.hasSpecifiedDeviceId) {
+          printStatus("Found ${devices.length} devices with name or id matching "
+              "'${deviceManager.specifiedDeviceId}':");
+        } else {
+          printStatus("More than one device connected; please specify a device with "
+              "the '-d <deviceId>' flag.");
+          devices = await deviceManager.getAllConnectedDevices();
+        }
         printStatus('');
-        devices = await deviceManager.getAllConnectedDevices();
         Device.printDevices(devices);
         return 1;
       } else {

--- a/packages/flutter_tools/test/device_test.dart
+++ b/packages/flutter_tools/test/device_test.dart
@@ -19,23 +19,34 @@ void main() {
     });
 
     testUsingContext('getDeviceById', () async {
-      DeviceManager deviceManager = new DeviceManager();
       _MockDevice device1 = new _MockDevice('Nexus 5', '0553790d0a4e726f');
       _MockDevice device2 = new _MockDevice('Nexus 5X', '01abfc49119c410e');
       _MockDevice device3 = new _MockDevice('iPod touch', '82564b38861a9a5');
       List<Device> devices = <Device>[device1, device2, device3];
+      DeviceManager deviceManager = new TestDeviceManager(devices);
 
-      Future<Null> expectDevice(String id, Device expected) async {
-        expect(await deviceManager.getDeviceById(id, devices), expected);
+      Future<Null> expectDevice(String id, List<Device> expected) async {
+        expect(await deviceManager.getDevicesById(id), expected);
       }
-      expectDevice('01abfc49119c410e', device2);
-      expectDevice('Nexus 5X', device2);
-      expectDevice('0553790d0a4e726f', device1);
-      expectDevice('Nexus 5', device1);
-      expectDevice('0553790', device1);
-      expectDevice('Nexus', null);
+      expectDevice('01abfc49119c410e', <Device>[device2]);
+      expectDevice('Nexus 5X', <Device>[device2]);
+      expectDevice('0553790d0a4e726f', <Device>[device1]);
+      expectDevice('Nexus 5', <Device>[device1]);
+      expectDevice('0553790', <Device>[device1]);
+      expectDevice('Nexus', <Device>[device1, device2]);
     });
   });
+}
+
+class TestDeviceManager extends DeviceManager {
+  final List<Device> allDevices;
+
+  TestDeviceManager(this.allDevices);
+
+  @override
+  Future<List<Device>> getAllConnectedDevices() async {
+    return allDevices;
+  }
 }
 
 class _MockDevice extends Device {

--- a/packages/flutter_tools/test/src/context.dart
+++ b/packages/flutter_tools/test/src/context.dart
@@ -83,7 +83,7 @@ class MockDeviceManager implements DeviceManager {
 
   @override
   Future<List<Device>> getDevicesById(String deviceId) async {
-    return devices.where((Device device) => device.id == deviceId);
+    return devices.where((Device device) => device.id == deviceId).toList();
   }
 
   @override

--- a/packages/flutter_tools/test/src/context.dart
+++ b/packages/flutter_tools/test/src/context.dart
@@ -82,9 +82,8 @@ class MockDeviceManager implements DeviceManager {
   Future<List<Device>> getAllConnectedDevices() => new Future<List<Device>>.value(devices);
 
   @override
-  Future<Device> getDeviceById(String deviceId, [List<Device> _]) {
-    Device device = devices.firstWhere((Device device) => device.id == deviceId, orElse: () => null);
-    return new Future<Device>.value(device);
+  Future<List<Device>> getDevicesById(String deviceId) async {
+    return devices.where((Device device) => device.id == deviceId);
   }
 
   @override
@@ -92,8 +91,7 @@ class MockDeviceManager implements DeviceManager {
     if (specifiedDeviceId == null) {
       return getAllConnectedDevices();
     } else {
-      Device device = await getDeviceById(specifiedDeviceId);
-      return device == null ? <Device>[] : <Device>[device];
+      return getDevicesById(specifiedDeviceId);
     }
   }
 


### PR DESCRIPTION
- improve the error message displayed when multiple device names/ids match the supplied prefix
- refactor getDeviceById
- fixes https://github.com/flutter/flutter/issues/5675
  @devoncarew 
