### PR TITLE
Fixed a bug related to AnimtedCrossFade.

### DIFF
--- a/packages/flutter/lib/src/widgets/animated_cross_fade.dart
+++ b/packages/flutter/lib/src/widgets/animated_cross_fade.dart
@@ -106,6 +106,8 @@ class _AnimatedCrossFadeState extends State<AnimatedCrossFade> {
   void initState() {
     super.initState();
     _controller = new AnimationController(duration: config.duration);
+    if (config.crossFadeState == CrossFadeState.showSecond)
+      _controller.value = 1.0;
     _firstAnimation = _initAnimation(config.firstCurve, true);
     _secondAnimation = _initAnimation(config.secondCurve, false);
   }

--- a/packages/flutter/test/widget/animated_cross_fade_test.dart
+++ b/packages/flutter/test/widget/animated_cross_fade_test.dart
@@ -54,4 +54,28 @@ void main() {
     expect(box.size.width, equals(150.0));
     expect(box.size.height, equals(150.0));
   });
+
+  testWidgets('AnimatedCrossFade test showSecond', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      new Center(
+        child: new AnimatedCrossFade(
+          firstChild: new SizedBox(
+            width: 100.0,
+            height: 100.0
+          ),
+          secondChild: new SizedBox(
+            width: 200.0,
+            height: 200.0
+          ),
+          duration: const Duration(milliseconds: 200),
+          crossFadeState: CrossFadeState.showSecond
+        )
+      )
+    );
+
+    expect(find.byType(FadeTransition), findsNWidgets(2));
+    RenderBox box = tester.renderObject(find.byType(AnimatedCrossFade));
+    expect(box.size.width, equals(200.0));
+    expect(box.size.height, equals(200.0));
+  });
 }


### PR DESCRIPTION
Fixed a bug where the size of the AnimatedCrossFade would always
start from the size of the first child, irrespective of the
initial crossFadeState argument.
