### PR TITLE
Handle stateful widgets in layout builders.

### DIFF
--- a/dev/benchmarks/microbenchmarks/lib/stocks/build_bench.dart
+++ b/dev/benchmarks/microbenchmarks/lib/stocks/build_bench.dart
@@ -30,7 +30,7 @@ Future<Null> main() async {
     watch.start();
     while (watch.elapsed < kBenchmarkTime) {
       appState.markNeedsBuild();
-      buildOwner.buildDirtyElements();
+      buildOwner.buildScope(WidgetsBinding.instance.renderViewElement);
       iterations += 1;
     }
     watch.stop();

--- a/packages/flutter/lib/src/material/drop_down.dart
+++ b/packages/flutter/lib/src/material/drop_down.dart
@@ -5,6 +5,7 @@
 import 'dart:async';
 import 'dart:math' as math;
 
+import 'package:flutter/scheduler.dart';
 import 'package:flutter/widgets.dart';
 import 'package:meta/meta.dart';
 
@@ -249,7 +250,11 @@ class _DropDownMenuRouteLayout<T> extends SingleChildLayoutDelegate {
     if (route.initialLayout) {
       route.initialLayout = false;
       final double scrollOffset = selectedItemOffset - (buttonTop - top);
-      scrollableKey.currentState.scrollTo(scrollOffset);
+      SchedulerBinding.instance.addPostFrameCallback((Duration timeStamp) {
+        // TODO(ianh): Compute and set this during layout instead of being
+        // lagged by one frame. https://github.com/flutter/flutter/issues/5751
+        scrollableKey.currentState.scrollTo(scrollOffset);
+      });
     }
 
     return new Offset(buttonRect.left, top);

--- a/packages/flutter/lib/src/material/tabs.dart
+++ b/packages/flutter/lib/src/material/tabs.dart
@@ -7,6 +7,7 @@ import 'dart:math' as math;
 
 import 'package:flutter/physics.dart';
 import 'package:flutter/rendering.dart';
+import 'package:flutter/scheduler.dart';
 import 'package:flutter/widgets.dart';
 import 'package:meta/meta.dart';
 
@@ -968,11 +969,18 @@ class _TabBarState<T> extends ScrollableState<TabBar<T>> implements TabBarSelect
   }
 
   void _layoutChanged(Size tabBarSize, List<double> tabWidths) {
-    setState(() {
-      _tabBarSize = tabBarSize;
-      _tabWidths = tabWidths;
-      _indicatorRect = _selection != null ? _tabIndicatorRect(_selection.index) : Rect.zero;
-      _updateScrollBehavior();
+    // This is bad. We should use a LayoutBuilder or CustomMultiChildLayout or some such.
+    // As designed today, tabs are always lagging one frame behind, taking two frames
+    // to handle a layout change.
+    _tabBarSize = tabBarSize;
+    _tabWidths = tabWidths;
+    _indicatorRect = _selection != null ? _tabIndicatorRect(_selection.index) : Rect.zero;
+    _updateScrollBehavior();
+    SchedulerBinding.instance.addPostFrameCallback((Duration timeStamp) {
+      setState(() {
+        // the changes were made at layout time
+        // TODO(ianh): remove this setState: https://github.com/flutter/flutter/issues/5749
+      });
     });
   }
 

--- a/packages/flutter/lib/src/scheduler/debug.dart
+++ b/packages/flutter/lib/src/scheduler/debug.dart
@@ -3,6 +3,18 @@
 // found in the LICENSE file.
 
 /// Print a banner at the beginning of each frame.
+///
+/// Frames triggered by the engine and handler by the scheduler binding will
+/// have a banner saying "Begin Frame" and giving the time stamp of the frame.
+///
+/// Frames triggered eagerly by the widget framework (e.g. when calling
+/// [runApp]) will have a label saying "Begin Warm-Up Frame".
+///
+/// To include a banner at the end of each frame as well, to distinguish
+/// intra-frame output from inter-frame output, set [debugPrintEndFrameBanner]
+/// to true as well.
+///
+/// See [SchedulerBinding.beginFrame].
 bool debugPrintBeginFrameBanner = false;
 
 /// Print a banner at the end of each frame.

--- a/packages/flutter/lib/src/widgets/layout_builder.dart
+++ b/packages/flutter/lib/src/widgets/layout_builder.dart
@@ -176,9 +176,9 @@ class _LayoutBuilderElement extends RenderObjectElement {
   }
 
   void _layout(BoxConstraints constraints) {
-    Widget built;
-    if (widget.builder != null) {
-      owner.lockState(() {
+    owner.buildScope(this, () {
+      Widget built;
+      if (widget.builder != null) {
         try {
           built = widget.builder(this, constraints);
           debugWidgetBuilderValue(widget, built);
@@ -186,13 +186,6 @@ class _LayoutBuilderElement extends RenderObjectElement {
           _debugReportException('building $widget', e, stack);
           built = new ErrorWidget(e);
         }
-      });
-    }
-    owner.lockState(() {
-      if (widget.builder == null) {
-        if (_child != null)
-          _child = updateChild(_child, null, null);
-        return;
       }
       try {
         _child = updateChild(_child, built, null);
@@ -202,7 +195,7 @@ class _LayoutBuilderElement extends RenderObjectElement {
         built = new ErrorWidget(e);
         _child = updateChild(null, built, slot);
       }
-    }, building: true);
+    });
   }
 
   @override

--- a/packages/flutter/lib/src/widgets/lazy_block.dart
+++ b/packages/flutter/lib/src/widgets/lazy_block.dart
@@ -629,11 +629,11 @@ class _LazyBlockElement extends RenderObjectElement {
       while (currentLogicalIndex > 0 && currentLogicalOffset > startLogicalOffset) {
         currentLogicalIndex -= 1;
         Element newElement;
-        owner.lockState(() {
+        owner.buildScope(this, () {
           Widget newWidget = _callBuilder(builder, currentLogicalIndex, requireNonNull: true);
           newWidget = new RepaintBoundary.wrap(newWidget, currentLogicalIndex);
           newElement = inflateWidget(newWidget, null);
-        }, building: true);
+        });
         newChildren.add(newElement);
         RenderBox child = block.firstChild;
         assert(child == newChildren.last.renderObject);
@@ -698,14 +698,14 @@ class _LazyBlockElement extends RenderObjectElement {
       if (physicalIndex >= _children.length) {
         assert(physicalIndex == _children.length);
         Element newElement;
-        owner.lockState(() {
+        owner.buildScope(this, () {
           Widget newWidget = _callBuilder(builder, currentLogicalIndex);
           if (newWidget == null)
             return;
           newWidget = new RepaintBoundary.wrap(newWidget, currentLogicalIndex);
           Element previousChild = _children.isEmpty ? null : _children.last;
           newElement = inflateWidget(newWidget, previousChild);
-        }, building: true);
+        });
         if (newElement == null)
           break;
         _children.add(newElement);

--- a/packages/flutter/lib/src/widgets/scrollable.dart
+++ b/packages/flutter/lib/src/widgets/scrollable.dart
@@ -373,6 +373,7 @@ class ScrollableState<T extends Scrollable> extends State<T> {
   }
 
   void _handleAnimationStatusChanged(AnimationStatus status) {
+    // this is not called when stop() is called on the controller
     setState(() {
       if (!_controller.isAnimating)
         _simulation = null;
@@ -454,7 +455,8 @@ class ScrollableState<T extends Scrollable> extends State<T> {
   /// If there are no in-progress scrolling physics, this function scrolls to
   /// the given offset instead.
   void didUpdateScrollBehavior(double newScrollOffset) {
-    setState(() { /* The scroll behavior is part of our build state. */ });
+    // This does not call setState, because if anything below actually
+    // changes our build, it will itself independently trigger a frame.
     assert(_controller.isAnimating || _simulation == null);
     if (_numberOfInProgressScrolls > 0) {
       if (_simulation != null) {
@@ -583,16 +585,16 @@ class ScrollableState<T extends Scrollable> extends State<T> {
   }
 
   void _handleDragDown(_) {
-    _stop();
+    setState(() {
+      _stop();
+    });
   }
 
   void _stop() {
     assert(mounted);
     assert(_controller.isAnimating || _simulation == null);
-    setState(() {
-      _controller.stop();
-      _simulation = null;
-    });
+    _controller.stop(); // this does not trigger a status notification
+    _simulation = null;
   }
 
   void _handleDragStart(DragStartDetails details) {

--- a/packages/flutter/lib/src/widgets/semantics_debugger.dart
+++ b/packages/flutter/lib/src/widgets/semantics_debugger.dart
@@ -5,6 +5,8 @@
 import 'dart:collection';
 import 'dart:math' as math;
 
+import 'package:flutter/foundation.dart';
+import 'package:flutter/scheduler.dart';
 import 'package:flutter/rendering.dart';
 import 'package:sky_services/semantics/semantics.mojom.dart' as mojom;
 
@@ -53,8 +55,17 @@ class _SemanticsDebuggerState extends State<SemanticsDebugger> {
   }
 
   void _update() {
-    setState(() {
-      // the generation of the _SemanticsDebuggerListener has changed
+    SchedulerBinding.instance.addPostFrameCallback((Duration timeStamp) {
+      // We want the update to take effect next frame, so to make that
+      // explicit we call setState() in a post-frame callback.
+      if (mounted) {
+        // If we got disposed this frame, we will still get an update,
+        // because the inactive list is flushed after the semantics updates
+        // are transmitted to the semantics clients.
+        setState(() {
+          // The generation of the _SemanticsDebuggerListener has changed.
+        });
+      }
     });
   }
 

--- a/packages/flutter/lib/src/widgets/virtual_viewport.dart
+++ b/packages/flutter/lib/src/widgets/virtual_viewport.dart
@@ -175,7 +175,7 @@ abstract class VirtualViewportElement extends RenderObjectElement {
     assert(startOffsetBase != null);
     assert(startOffsetLimit != null);
     _updatePaintOffset();
-    owner.lockState(_materializeChildren, building: true);
+    owner.buildScope(this, _materializeChildren);
   }
 
   void _materializeChildren() {

--- a/packages/flutter/test/widget/independent_widget_layout_test.dart
+++ b/packages/flutter/test/widget/independent_widget_layout_test.dart
@@ -38,7 +38,7 @@ class OffscreenWidgetTree {
   }
 
   void pumpFrame() {
-    buildOwner.buildDirtyElements();
+    buildOwner.buildScope(root);
     pipelineOwner.flushLayout();
     pipelineOwner.flushCompositingBits();
     pipelineOwner.flushPaint();

--- a/packages/flutter/test/widget/layout_builder_and_state_test.dart
+++ b/packages/flutter/test/widget/layout_builder_and_state_test.dart
@@ -1,0 +1,87 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_test/flutter_test.dart' hide TypeMatcher;
+import 'package:flutter/widgets.dart';
+import 'test_widgets.dart';
+
+class StatefulWrapper extends StatefulWidget {
+  StatefulWrapper({
+    Key key,
+    this.child,
+  }) : super(key: key);
+
+  final Widget child;
+
+  @override
+  StatefulWrapperState createState() => new StatefulWrapperState();
+}
+
+class StatefulWrapperState extends State<StatefulWrapper> {
+
+  void trigger() {
+    setState(() { /* no-op setState */ });
+  }
+
+  bool built = false;
+
+  @override
+  Widget build(BuildContext context) {
+    built = true;
+    return config.child;
+  }
+}
+
+class Wrapper extends StatelessWidget {
+  Wrapper({
+    Key key,
+    this.child,
+  }) : super(key: key);
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return child;
+  }
+}
+
+void main() {
+  testWidgets('Calling setState on a widget that moves into a LayoutBuilder in the same frame', (WidgetTester tester) async {
+    StatefulWrapperState statefulWrapper;
+    final Widget inner = new Wrapper(
+      child: new StatefulWrapper(
+        key: new GlobalKey(),
+        child: new Container(),
+      ),
+    );
+    await tester.pumpWidget(new FlipWidget(
+      left: new LayoutBuilder(builder: (BuildContext context, BoxConstraints constraints) {
+        return inner;
+      }),
+      right: inner,
+    ));
+    statefulWrapper = tester.state(find.byType(StatefulWrapper));
+    expect(statefulWrapper.built, true);
+    statefulWrapper.built = false;
+
+    statefulWrapper.trigger();
+    flipStatefulWidget(tester);
+    await tester.pump();
+    expect(statefulWrapper.built, true);
+    statefulWrapper.built = false;
+
+    statefulWrapper.trigger();
+    flipStatefulWidget(tester);
+    await tester.pump();
+    expect(statefulWrapper.built, true);
+    statefulWrapper.built = false;
+
+    statefulWrapper.trigger();
+    flipStatefulWidget(tester);
+    await tester.pump();
+    expect(statefulWrapper.built, true);
+    statefulWrapper.built = false;
+  });
+}


### PR DESCRIPTION
Previously, if a StatefulWidget was marked dirty, then removed from the
build, then reinserted using the exact same widget under a widget under
a LayoutBuilder, it wouldn't rebuild.

This fixes that.

It also introduces an assert that's supposed to catch SizeObserver-like
behaviour. Rather than make this patch even bigger, I papered over two
pre-existing bugs which this assert uncovered (and fixed the other
problems it found):

   https://github.com/flutter/flutter/issues/5751 - DropDown
   https://github.com/flutter/flutter/issues/5749 - Tabs

We should fix those before 1.0 though.
