### PR TITLE
Make tests more realistic

### DIFF
--- a/packages/flutter/lib/src/foundation/assertions.dart
+++ b/packages/flutter/lib/src/foundation/assertions.dart
@@ -334,7 +334,11 @@ class FlutterError extends AssertionError {
 ///
 /// The `maxFrames` argument can be given to limit the stack to the given number
 /// of lines. By default, all non-filtered stack lines are shown.
-void debugPrintStack({ int maxFrames }) {
+///
+/// The `label` argument, if present, will be printed before the stack.
+void debugPrintStack({ String label, int maxFrames }) {
+  if (label != null)
+    debugPrint(label);
   List<String> lines = StackTrace.current.toString().trimRight().split('\n');
   if (maxFrames != null)
     lines = lines.take(maxFrames);

--- a/packages/flutter/lib/src/foundation/print.dart
+++ b/packages/flutter/lib/src/foundation/print.dart
@@ -16,7 +16,7 @@ typedef void DebugPrintCallback(String message, { int wrapWidth });
 ///
 /// By default, this function very crudely attempts to throttle the rate at
 /// which messages are sent to avoid data loss on Android. This means that
-/// interleaving calls to this function (directly or indirectly via
+/// interleaving calls to this function (directly or indirectly via, e.g.,
 /// [debugDumpRenderTree] or [debugDumpApp]) and to the Dart [print] method can
 /// result in out-of-order messages in the logs.
 ///

--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -1337,7 +1337,7 @@ abstract class RenderObject extends AbstractNode implements HitTestTarget {
       if (owner != null) {
         assert(() {
           if (debugPrintMarkNeedsLayoutStacks)
-            debugPrintStack();
+            debugPrintStack(label: 'markNeedsLayout() called for $this');
           return true;
         });
         owner._nodesNeedingLayout.add(this);
@@ -1790,7 +1790,7 @@ abstract class RenderObject extends AbstractNode implements HitTestTarget {
     if (isRepaintBoundary) {
       assert(() {
         if (debugPrintMarkNeedsPaintStacks)
-          debugPrintStack();
+          debugPrintStack(label: 'markNeedsPaint() called for $this');
         return true;
       });
       // If we always have our own layer, then we can just repaint

--- a/packages/flutter/lib/src/scheduler/debug.dart
+++ b/packages/flutter/lib/src/scheduler/debug.dart
@@ -5,10 +5,12 @@
 /// Print a banner at the beginning of each frame.
 ///
 /// Frames triggered by the engine and handler by the scheduler binding will
-/// have a banner saying "Begin Frame" and giving the time stamp of the frame.
+/// have a banner giving the frame number and the time stamp of the frame.
 ///
 /// Frames triggered eagerly by the widget framework (e.g. when calling
-/// [runApp]) will have a label saying "Begin Warm-Up Frame".
+/// [runApp]) will have a label saying "warm-up frame" instead of the time stamp
+/// (the time stamp sent to frame callbacks in that case is the time of the last
+/// frame, or 0:00 if it is the first frame).
 ///
 /// To include a banner at the end of each frame as well, to distinguish
 /// intra-frame output from inter-frame output, set [debugPrintEndFrameBanner]

--- a/packages/flutter/lib/src/scheduler/ticker.dart
+++ b/packages/flutter/lib/src/scheduler/ticker.dart
@@ -40,6 +40,8 @@ class Ticker {
     assert(_startTime == null);
     _completer = new Completer<Null>();
     _scheduleTick();
+    if (SchedulerBinding.instance.isProducingFrame)
+      _startTime = SchedulerBinding.instance.currentFrameTimeStamp;
     return _completer.future;
   }
 

--- a/packages/flutter/lib/src/services/image_provider.dart
+++ b/packages/flutter/lib/src/services/image_provider.dart
@@ -99,26 +99,31 @@ class ImageConfiguration {
       if (hasArguments)
         result.write(', ');
       result.write('bundle: $bundle');
+      hasArguments = true;
     }
     if (devicePixelRatio != null) {
       if (hasArguments)
         result.write(', ');
       result.write('devicePixelRatio: $devicePixelRatio');
+      hasArguments = true;
     }
     if (locale != null) {
       if (hasArguments)
         result.write(', ');
       result.write('locale: $locale');
+      hasArguments = true;
     }
     if (size != null) {
       if (hasArguments)
         result.write(', ');
       result.write('size: $size');
+      hasArguments = true;
     }
     if (platform != null) {
       if (hasArguments)
         result.write(', ');
       result.write('platform: $platform');
+      hasArguments = true;
     }
     result.write(')');
     return result.toString();
@@ -219,10 +224,12 @@ abstract class DataPipeImageProvider<T> extends ImageProvider<T> {
   /// const constructors so that they can be used in const expressions.
   const DataPipeImageProvider();
 
+  /// Converts a key into an [ImageStreamCompleter], and begins fetching the
+  /// image using [loadAsync].
   @override
   ImageStreamCompleter load(T key) {
     return new OneFrameImageStreamCompleter(
-      _loadAsync(key),
+      loadAsync(key),
       informationCollector: (StringBuffer information) {
         information.writeln('Image provider: $this');
         information.write('Image key: $key');
@@ -230,7 +237,12 @@ abstract class DataPipeImageProvider<T> extends ImageProvider<T> {
     );
   }
 
-  Future<ImageInfo> _loadAsync(T key) async {
+  /// Fetches the image from the data pipe, decodes it, and returns a
+  /// corresponding [ImageInfo] object.
+  ///
+  /// This function is used by [load].
+  @protected
+  Future<ImageInfo> loadAsync(T key) async {
     final mojo.MojoDataPipeConsumer dataPipe = await loadDataPipe(key);
     if (dataPipe == null)
       throw 'Unable to read data';
@@ -367,7 +379,7 @@ abstract class AssetBundleImageProvider extends DataPipeImageProvider<AssetBundl
   Future<AssetBundleImageKey> obtainKey(ImageConfiguration configuration);
 
   @override
-  Future<mojo.MojoDataPipeConsumer> loadDataPipe(AssetBundleImageKey key) async {
+  Future<mojo.MojoDataPipeConsumer> loadDataPipe(AssetBundleImageKey key) {
     return key.bundle.load(key.name);
   }
 

--- a/packages/flutter/lib/src/services/image_resolution.dart
+++ b/packages/flutter/lib/src/services/image_resolution.dart
@@ -110,7 +110,7 @@ class AssetImage extends AssetBundleImageProvider {
         if (completer != null) {
           // We already returned from this function, which means we are in the
           // asynchronous mode. Pass the value to the completer. The completer's
-          // function is what we returned.
+          // future is what we returned.
           completer.complete(key);
         } else {
           // We haven't yet returned, so we must have been called synchronously

--- a/packages/flutter/lib/src/widgets/debug.dart
+++ b/packages/flutter/lib/src/widgets/debug.dart
@@ -9,7 +9,38 @@ import 'framework.dart';
 import 'table.dart';
 
 /// Log the dirty widgets that are built each frame.
+///
+/// Combined with [debugPrintBuildScope] or [debugPrintBeginFrameBanner], this
+/// allows you to distinguish builds triggered by the initial mounting of a
+/// widget tree (e.g. in a call to [runApp]) from the regular builds triggered
+/// by the pipeline (see [WidgetsBinding.beginFrame].
+///
+/// Combined with [debugPrintScheduleBuildForStacks], this lets you watch a
+/// widget's dirty/clean lifecycle.
 bool debugPrintRebuildDirtyWidgets = false;
+
+/// Log all calls to [BuildOwner.buildScope].
+///
+/// Combined with [debugPrintScheduleBuildForStacks], this allows you to track
+/// when a [State.setState] call gets serviced.
+///
+/// Combined with [debugPrintRebuildDirtyWidgets] or
+/// [debugPrintBeginFrameBanner], this allows you to distinguish builds
+/// triggered by the initial mounting of a widget tree (e.g. in a call to
+/// [runApp]) from the regular builds triggered by the pipeline (see
+/// [WidgetsBinding.beginFrame].
+bool debugPrintBuildScope = false;
+
+/// Log the call stacks that mark widgets as needing to be rebuilt.
+///
+/// This is called whenever [BuildOwner.scheduleBuildFor] adds an element to the
+/// dirty list. Typically this is as a result of [Element.markNeedsBuild] being
+/// called, which itself is usually a result of [State.setState] being called.
+///
+/// To see when a widget is rebuilt, see [debugPrintRebuildDirtyWidgets].
+///
+/// To see when the dirty list is flushed, see [debugPrintBuildDirtyElements].
+bool debugPrintScheduleBuildForStacks = false;
 
 /// Log when widgets with global keys are deactivated and log when they are
 /// reactivated (retaken).

--- a/packages/flutter/test/material/expansion_panels_test.dart
+++ b/packages/flutter/test/material/expansion_panels_test.dart
@@ -40,6 +40,7 @@ void main() {
     box = tester.renderObject(find.byType(ExpansionPanelList));
     expect(box.size.height, equals(oldHeight));
 
+    // now expand the child panel
     await tester.pumpWidget(
       new ScrollableViewport(
         child: new ExpansionPanelList(
@@ -53,13 +54,15 @@ void main() {
                 return new Text(isExpanded ? 'B' : 'A');
               },
               body: new SizedBox(height: 100.0),
-              isExpanded: true
+              isExpanded: true // this is the addition
             )
           ]
         )
       )
     );
+
     await tester.pump(const Duration(milliseconds: 200));
+
 
     expect(find.text('A'), findsNothing);
     expect(find.text('B'), findsOneWidget);

--- a/packages/flutter/test/material/mergeable_material_test.dart
+++ b/packages/flutter/test/material/mergeable_material_test.dart
@@ -597,7 +597,6 @@ void main() {
       )
     );
 
-    await tester.pump();
     expect(box.size.height, equals(300));
 
     matches(getBorderRadius(tester, 0), RadiusType.Round, RadiusType.Round);

--- a/packages/flutter/test/widget/image_resolution_test.dart
+++ b/packages/flutter/test/widget/image_resolution_test.dart
@@ -62,7 +62,7 @@ class TestAssetBundle extends CachingAssetBundle {
         pipe = new TestMojoDataPipeConsumer(4.0);
         break;
     }
-    return (new Completer<mojo.MojoDataPipeConsumer>()..complete(pipe)).future;
+    return new SynchronousFuture<mojo.MojoDataPipeConsumer>(pipe);
   }
 
   @override
@@ -80,8 +80,20 @@ class TestAssetImage extends AssetImage {
   TestAssetImage(String name) : super(name);
 
   @override
+  Future<ImageInfo> loadAsync(AssetBundleImageKey key) {
+    ImageInfo result;
+    key.bundle.load(key.name).then((mojo.MojoDataPipeConsumer dataPipe) {
+      decodeImage(dataPipe).then((ui.Image image) {
+        result = new ImageInfo(image: image, scale: getScale(key));
+      });
+    });
+    assert(result != null);
+    return new SynchronousFuture<ImageInfo>(result);
+  }
+
+  @override
   Future<ui.Image> decodeImage(TestMojoDataPipeConsumer pipe) {
-    return new Future<ui.Image>.value(new TestImage(pipe.scale));
+    return new SynchronousFuture<ui.Image>(new TestImage(pipe.scale));
   }
 }
 

--- a/packages/flutter_test/lib/src/widget_tester.dart
+++ b/packages/flutter_test/lib/src/widget_tester.dart
@@ -164,7 +164,8 @@ class WidgetTester extends WidgetController implements HitTestDispatcher {
     EnginePhase phase = EnginePhase.sendSemanticsTree
   ]) {
     return TestAsyncUtils.guard(() {
-      runApp(widget);
+      binding.attachRootWidget(widget);
+      binding.scheduleFrame();
       return binding.pump(duration, phase);
     });
   }


### PR DESCRIPTION
Previously, pumpWidget() would do a partial pump (it didn't trigger
Ticker callbacks or post-frame callbacks), and pump() would do a full
pump. This patch brings them closer together. It also makes runApp run a
full actual frame, rather than skipping the transient callback part of
the frame logic. Having "half-frames" in the system was confusing and
could lead to bugs where code expecting to run before the next layout
pass didn't because a "half-frame" ran first.

Also, make Tickers start ticking in the frame that they were started in,
if they were started during a frame. This means we no longer spin a
frame for t=0, we jump straight to the first actual frame.

Other changes in this patch:
- rename WidgetsBinding._runApp to WidgetsBinding.attachRootWidget, so
  that tests can use it to more accurately mock out runApp.
- allow loadStructuredData to return synchronously.
- make handleBeginFrame handle not being given a time stamp.
- make DataPipeImageProvider.loadAsync protected (rather than private),
  and document it. There wasn't really a reason for it to be private.
- fix ImageConfiguration.toString.
- introduce debugPrintBuildScope and debugPrintScheduleBuildForStacks,
  which can help debug problems with widgets getting marked as dirty but
  not cleaned.
- make debugPrintRebuildDirtyWidgets say "Building" the first time and
  "Rebuilding" the second, to make it clearer when a widget is first
  created. This makes debugging widget lifecycle issues much easier.
- make debugDumpApp more resilient.
- debugPrintStack now takes a label that is printed before the stack.
- improve the banner shown for debugPrintBeginFrameBanner.
- various and sundry documentation fixes
