### PR TITLE
Suggest simulator when no devices

### DIFF
--- a/packages/flutter_tools/lib/src/commands/run.dart
+++ b/packages/flutter_tools/lib/src/commands/run.dart
@@ -13,6 +13,7 @@ import '../cache.dart';
 import '../device.dart';
 import '../globals.dart';
 import '../hot.dart';
+import '../ios/mac.dart';
 import '../vmservice.dart';
 import '../resident_runner.dart';
 import '../run.dart';
@@ -96,6 +97,18 @@ class RunCommand extends RunCommandBase {
 
     // Return 'run/ios'.
     return '$command/${getNameForTargetPlatform(device.platform)}';
+  }
+
+  @override
+  void printNoConnectedDevices() {
+    super.printNoConnectedDevices();
+    if (getCurrentHostPlatform() == HostPlatform.darwin_x64 &&
+        XCode.instance.isInstalledAndMeetsVersionCheck) {
+      printStatus('');
+      printStatus('To run on a simulator, launch it first:');
+      printStatus('open -a Simulator.app');
+      printStatus('');
+    }
   }
 
   @override

--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -141,7 +141,7 @@ abstract class FlutterCommand extends Command {
             "matching '${deviceManager.specifiedDeviceId}'");
         return 1;
       } else if (devices.isEmpty) {
-        printStatus('No connected devices.');
+        printNoConnectedDevices();
         return 1;
       }
 
@@ -190,6 +190,10 @@ abstract class FlutterCommand extends Command {
       flutterUsage.sendCommand(usagePath);
 
     return await runInProject();
+  }
+
+  void printNoConnectedDevices() {
+    printStatus('No connected devices.');
   }
 
   // This is a field so that you can modify the value for testing.


### PR DESCRIPTION
When flutter run is used on a Mac and no devices are specified or attached,
suggest launching a simulator first.
Fixes https://github.com/flutter/flutter/issues/5674
@pq 
