### PR TITLE
Fix app bar title overflow with centerTitle:true

### DIFF
--- a/packages/flutter/lib/src/material/app_bar.dart
+++ b/packages/flutter/lib/src/material/app_bar.dart
@@ -39,8 +39,8 @@ class _ToolBarLayout extends MultiChildLayoutDelegate {
   // space bewteen the leading and actions widgets).
   final bool centerTitle;
 
-  static const kLeadingWidth = 24.0;
-  static const kTitleLeft = 64.0; // The AppBar pads left and right an additional 8.0.
+  static const double kLeadingWidth = 24.0;
+  static const double kTitleLeft = 64.0; // The AppBar pads left and right an additional 8.0.
 
   @override
   void performLayout(Size size) {

--- a/packages/flutter/lib/src/material/app_bar.dart
+++ b/packages/flutter/lib/src/material/app_bar.dart
@@ -215,6 +215,7 @@ class AppBar extends StatelessWidget {
       iconTheme: iconTheme ?? this.iconTheme,
       textTheme: textTheme ?? this.textTheme,
       padding: padding ?? this.padding,
+      centerTitle: centerTitle ?? this.centerTitle,
       heroTag: heroTag ?? this.heroTag,
       expandedHeight: expandedHeight ?? this._expandedHeight,
       collapsedHeight: collapsedHeight ?? this._collapsedHeight
@@ -308,16 +309,18 @@ class AppBar extends StatelessWidget {
         child: leading
       ));
     }
+
     toolBarRow.add(new Flexible(
-      child: new Align(
-        // TODO(abarth): In RTL this should be aligned to the right.
-        alignment: FractionalOffset.centerLeft,
-        child: new Padding(
-          padding: new EdgeInsets.only(left: 8.0),
-          child: effectiveCenterTitle ? null : centerWidget
+      child: new Padding(
+        padding: new EdgeInsets.symmetric(horizontal: 8.0),
+        child: new Align(
+          // TODO(abarth): In RTL, when !centerTitle, use FractionalOffset.centerRight
+          alignment: effectiveCenterTitle ? FractionalOffset.center : FractionalOffset.centerLeft,
+          child: centerWidget
         )
       )
     ));
+
     if (actions != null)
       toolBarRow.addAll(actions);
 
@@ -325,17 +328,6 @@ class AppBar extends StatelessWidget {
       padding: const EdgeInsets.symmetric(horizontal: 8.0),
       child: new Row(children: toolBarRow)
     );
-
-    if (effectiveCenterTitle && centerWidget != null) {
-      toolBar = new Stack(
-        children: <Widget>[
-          // TODO(abarth): If there isn't enough room, we should move the title
-          // off center rather than overlap the actions.
-          new Center(child: centerWidget),
-          toolBar
-        ]
-      );
-    }
 
     Widget appBar = new SizedBox(
       height: kToolBarHeight,

--- a/packages/flutter/lib/src/material/app_bar.dart
+++ b/packages/flutter/lib/src/material/app_bar.dart
@@ -66,7 +66,7 @@ class _ToolBarLayout extends MultiChildLayoutDelegate {
       double titleX = kTitleLeft;
 
       // If the centered title will not fit between the leading and actions
-      // widgets, then justify it with the wider one.
+      // widgets, then align its left or right edge with the adjacent boundary.
       if (centerTitle) {
         titleX = (size.width - titleSize.width) / 2.0;
         if (titleX + titleSize.width > size.width - actionsWidth)


### PR DESCRIPTION
Simplified AppBar title layout. The title only gets the horizontal space between the app bar's leading widget and the (trailing) action widgets.

Also: AppBar.copyWith() wasn't copying the centerTitle property.

Fixes: #5212
