### PR TITLE
new flutter repo level analysis options

### DIFF
--- a/.analysis_options
+++ b/.analysis_options
@@ -38,15 +38,15 @@ linter:
     # === error rules ===
     - avoid_empty_else
     # - comment_references # blocked on https://github.com/dart-lang/dartdoc/issues/1153
-    - cancel_subscriptions
-    - close_sinks
+    # - cancel_subscriptions
+    # - close_sinks
     - control_flow_in_finally
     - empty_statements
     - hash_and_equals
-    - invariant_booleans
+    # - invariant_booleans
     # - iterable_contains_unrelated_type
     - list_remove_unrelated_type
-    - literal_only_boolean_expressions
+    # - literal_only_boolean_expressions
     - test_types_in_equals
     - throw_in_finally
     - unrelated_type_equality_checks
@@ -69,7 +69,7 @@ linter:
     - library_prefixes
     - non_constant_identifier_names
     - one_member_abstracts
-    - only_throw_errors
+    # - only_throw_errors
     # - overridden_fields
     - package_api_docs
     - package_prefixed_library_names

--- a/.analysis_options
+++ b/.analysis_options
@@ -38,15 +38,15 @@ linter:
     # === error rules ===
     - avoid_empty_else
     # - comment_references # blocked on https://github.com/dart-lang/dartdoc/issues/1153
-    # - cancel_subscriptions
-    # - close_sinks
+    # - cancel_subscriptions # https://github.com/flutter/flutter/issues/5788
+    # - close_sinks # https://github.com/flutter/flutter/issues/5789
     - control_flow_in_finally
     - empty_statements
     - hash_and_equals
-    # - invariant_booleans
+    # - invariant_booleans # https://github.com/flutter/flutter/issues/5790
     # - iterable_contains_unrelated_type
     - list_remove_unrelated_type
-    # - literal_only_boolean_expressions
+    # - literal_only_boolean_expressions # https://github.com/flutter/flutter/issues/5791
     - test_types_in_equals
     - throw_in_finally
     - unrelated_type_equality_checks
@@ -69,7 +69,7 @@ linter:
     - library_prefixes
     - non_constant_identifier_names
     - one_member_abstracts
-    # - only_throw_errors
+    # - only_throw_errors # https://github.com/flutter/flutter/issues/5792
     # - overridden_fields
     - package_api_docs
     - package_prefixed_library_names
@@ -81,7 +81,7 @@ linter:
     - super_goes_last
     # - type_annotate_public_apis # subset of always_specify_types
     - type_init_formals
-    # - unawaited_futures
+    # - unawaited_futures # https://github.com/flutter/flutter/issues/5793
     - unnecessary_brace_in_string_interp
     - unnecessary_getters_setters
 

--- a/.analysis_options
+++ b/.analysis_options
@@ -38,12 +38,19 @@ linter:
     # === error rules ===
     - avoid_empty_else
     # - comment_references # blocked on https://github.com/dart-lang/dartdoc/issues/1153
+    - cancel_subscriptions
+    - close_sinks
     - control_flow_in_finally
+    - empty_statements
     - hash_and_equals
+    - invariant_booleans
     # - iterable_contains_unrelated_type
+    - list_remove_unrelated_type
+    - literal_only_boolean_expressions
     - test_types_in_equals
     - throw_in_finally
     - unrelated_type_equality_checks
+    - valid_regexps
 
     # === style rules ===
     - always_declare_return_types
@@ -62,6 +69,7 @@ linter:
     - library_prefixes
     - non_constant_identifier_names
     - one_member_abstracts
+    - only_throw_errors
     # - overridden_fields
     - package_api_docs
     - package_prefixed_library_names
@@ -73,6 +81,7 @@ linter:
     - super_goes_last
     # - type_annotate_public_apis # subset of always_specify_types
     - type_init_formals
+    # - unawaited_futures
     - unnecessary_brace_in_string_interp
     - unnecessary_getters_setters
 

--- a/.analysis_options_flutter_analyze
+++ b/.analysis_options_flutter_analyze
@@ -39,15 +39,15 @@ linter:
     # === error rules ===
     - avoid_empty_else
     # - comment_references # blocked on https://github.com/dart-lang/dartdoc/issues/1153
-    # - cancel_subscriptions
-    # - close_sinks
+    # - cancel_subscriptions # https://github.com/flutter/flutter/issues/5788
+    # - close_sinks # https://github.com/flutter/flutter/issues/5789
     - control_flow_in_finally
     - empty_statements
     - hash_and_equals
-    # - invariant_booleans
+    # - invariant_booleans # https://github.com/flutter/flutter/issues/5790
     # - iterable_contains_unrelated_type
     - list_remove_unrelated_type
-    # - literal_only_boolean_expressions
+    # - literal_only_boolean_expressions # https://github.com/flutter/flutter/issues/5791
     - test_types_in_equals
     - throw_in_finally
     - unrelated_type_equality_checks
@@ -70,7 +70,7 @@ linter:
     - library_prefixes
     - non_constant_identifier_names
     - one_member_abstracts
-    # - only_throw_errors
+    # - only_throw_errors # https://github.com/flutter/flutter/issues/5792
     # - overridden_fields
     - package_api_docs
     - package_prefixed_library_names
@@ -82,7 +82,7 @@ linter:
     - super_goes_last
     # - type_annotate_public_apis # subset of always_specify_types
     - type_init_formals
-    # - unawaited_futures
+    # - unawaited_futures # https://github.com/flutter/flutter/issues/5793
     - unnecessary_brace_in_string_interp
     - unnecessary_getters_setters
 

--- a/.analysis_options_flutter_analyze
+++ b/.analysis_options_flutter_analyze
@@ -39,15 +39,15 @@ linter:
     # === error rules ===
     - avoid_empty_else
     # - comment_references # blocked on https://github.com/dart-lang/dartdoc/issues/1153
-    - cancel_subscriptions
-    - close_sinks
+    # - cancel_subscriptions
+    # - close_sinks
     - control_flow_in_finally
     - empty_statements
     - hash_and_equals
-    - invariant_booleans
+    # - invariant_booleans
     # - iterable_contains_unrelated_type
     - list_remove_unrelated_type
-    - literal_only_boolean_expressions
+    # - literal_only_boolean_expressions
     - test_types_in_equals
     - throw_in_finally
     - unrelated_type_equality_checks
@@ -70,7 +70,7 @@ linter:
     - library_prefixes
     - non_constant_identifier_names
     - one_member_abstracts
-    - only_throw_errors
+    # - only_throw_errors
     # - overridden_fields
     - package_api_docs
     - package_prefixed_library_names

--- a/.analysis_options_flutter_analyze
+++ b/.analysis_options_flutter_analyze
@@ -39,12 +39,19 @@ linter:
     # === error rules ===
     - avoid_empty_else
     # - comment_references # blocked on https://github.com/dart-lang/dartdoc/issues/1153
+    - cancel_subscriptions
+    - close_sinks
     - control_flow_in_finally
+    - empty_statements
     - hash_and_equals
+    - invariant_booleans
     # - iterable_contains_unrelated_type
+    - list_remove_unrelated_type
+    - literal_only_boolean_expressions
     - test_types_in_equals
     - throw_in_finally
     - unrelated_type_equality_checks
+    - valid_regexps
 
     # === style rules ===
     - always_declare_return_types
@@ -63,6 +70,7 @@ linter:
     - library_prefixes
     - non_constant_identifier_names
     - one_member_abstracts
+    - only_throw_errors
     # - overridden_fields
     - package_api_docs
     - package_prefixed_library_names
@@ -74,6 +82,7 @@ linter:
     - super_goes_last
     # - type_annotate_public_apis # subset of always_specify_types
     - type_init_formals
+    # - unawaited_futures
     - unnecessary_brace_in_string_interp
     - unnecessary_getters_setters
 


### PR DESCRIPTION
This adds and enables a raft of new analysis options for the flutter repository. This PR is open for comments, but **cannot be landed yet**. For each new option we need to either update the code to address the issues or turn off the associated analysis option.
