### PR TITLE
Fixed leading app bar button width constraint

### DIFF
--- a/packages/flutter/lib/src/material/app_bar.dart
+++ b/packages/flutter/lib/src/material/app_bar.dart
@@ -39,7 +39,7 @@ class _ToolBarLayout extends MultiChildLayoutDelegate {
   // space bewteen the leading and actions widgets).
   final bool centerTitle;
 
-  static const double kLeadingWidth = 24.0;
+  static const double kLeadingWidth = 40.0; // Same size as an IconButton
   static const double kTitleLeft = 64.0; // The AppBar pads left and right an additional 8.0.
 
   @override


### PR DESCRIPTION
The width constraint for the leading app bar button should be as big as an icon button (not an icon).
