### PR TITLE
Make dependenciesChanged fire after initState

### DIFF
--- a/packages/flutter/lib/src/material/tabs.dart
+++ b/packages/flutter/lib/src/material/tabs.dart
@@ -780,16 +780,13 @@ class _TabBarState<T> extends ScrollableState<TabBar<T>> implements TabBarSelect
   }
 
   @override
-  void initState() {
-    super.initState();
-    scrollBehavior.isScrollable = config.isScrollable;
-  }
-
-  @override
   void didUpdateConfig(TabBar<T> oldConfig) {
     super.didUpdateConfig(oldConfig);
-    if (!config.isScrollable)
-      scrollTo(0.0);
+    if (config.isScrollable != oldConfig.isScrollable) {
+      scrollBehavior.isScrollable = config.isScrollable;
+      if (!config.isScrollable)
+        scrollTo(0.0);
+    }
   }
 
   @override
@@ -921,7 +918,10 @@ class _TabBarState<T> extends ScrollableState<TabBar<T>> implements TabBarSelect
   }
 
   @override
-  ScrollBehavior<double, double> createScrollBehavior() => new _TabsScrollBehavior();
+  ScrollBehavior<double, double> createScrollBehavior() {
+    return new _TabsScrollBehavior()
+      ..isScrollable = config.isScrollable;
+  }
 
   @override
   _TabsScrollBehavior get scrollBehavior => super.scrollBehavior;

--- a/packages/flutter/lib/src/widgets/scrollable.dart
+++ b/packages/flutter/lib/src/widgets/scrollable.dart
@@ -348,15 +348,14 @@ class ScrollableState<T extends Scrollable> extends State<T> {
   /// Scroll behaviors control where the boundaries of the scrollable are placed
   /// and how the scrolling physics should behave near those boundaries and
   /// after the user stops directly manipulating the scrollable.
-  ExtentScrollBehavior get scrollBehavior {
-    return _scrollBehavior ??= createScrollBehavior();
-  }
+  ExtentScrollBehavior get scrollBehavior => _scrollBehavior;
   ExtentScrollBehavior _scrollBehavior;
 
   /// Use the value returned by [ScrollConfiguration.createScrollBehavior].
   /// If this widget doesn't have a ScrollConfiguration ancestor,
   /// or its createScrollBehavior callback is null, then return a new instance
   /// of [OverscrollWhenScrollableBehavior].
+  @protected
   ExtentScrollBehavior createScrollBehavior() {
     return ScrollConfiguration.of(context)?.createScrollBehavior();
   }

--- a/packages/flutter/test/widget/image_test.dart
+++ b/packages/flutter/test/widget/image_test.dart
@@ -286,6 +286,18 @@ void main() {
     expect(imageProvider._configuration.devicePixelRatio, 10.0);
   });
 
+  testWidgets('Verify Image stops listening to ImageStream', (WidgetTester tester) async {
+    TestImageProvider imageProvider = new TestImageProvider();
+    await tester.pumpWidget(new Image(image: imageProvider));
+    State<Image> image = tester.state/*State<Image>*/(find.byType(Image));
+    expect(image.toString(), matches(new RegExp(r'_ImageState\([0-9]+; stream: ImageStream\(OneFrameImageStreamCompleter; unresolved; 1 listener\); pixels: null\)')));
+    imageProvider.complete();
+    await tester.pump();
+    expect(image.toString(), matches(new RegExp(r'_ImageState\([0-9]+; stream: ImageStream\(OneFrameImageStreamCompleter; \[100×100\] @ 1\.0x; 1 listener\); pixels: \[100×100\] @ 1\.0x\)')));
+    await tester.pumpWidget(new Container());
+    expect(image.toString(), matches(new RegExp(r'_ImageState\([0-9]+; _StateLifecycle.defunct; not mounted; stream: ImageStream\(OneFrameImageStreamCompleter; \[100×100\] @ 1\.0x; 0 listeners\); pixels: \[100×100\] @ 1\.0x\)')));
+  });
+
 }
 
 class TestImageProvider extends ImageProvider<TestImageProvider> {


### PR DESCRIPTION
This allows us to simplify the logic around inherited widgets e.g. in
the Image widget.

cc @HansMuller 
