### PR TITLE
Teach flutter upgrade to switch to master

### DIFF
--- a/packages/flutter_tools/lib/src/commands/upgrade.dart
+++ b/packages/flutter_tools/lib/src/commands/upgrade.dart
@@ -33,6 +33,14 @@ class UpgradeCommand extends FlutterCommand {
       return 1;
     }
 
+    FlutterVersion version = new FlutterVersion(Cache.flutterRoot);
+    if (version.channel == 'alpha') {
+      // The alpha branch is deprecated. Rather than trying to pull the alpha
+      // branch, we should switch upstream to master.
+      printStatus('Switching to from alpha to master...');
+      runSync(<String>['git', 'branch', '--set-upstream-to=origin/master']);
+    }
+
     printStatus('Upgrading Flutter from ${Cache.flutterRoot}...');
 
     int code = await runCommandAndStreamOutput(


### PR DESCRIPTION
To avoid orphaning people on the deprecated alpha branch, this patch teaches
`flutter upgrade` to switch to the master branch.
