### PR TITLE
fix a race in tap gesture in the driver extension

### DIFF
--- a/packages/flutter_driver/lib/src/extension.dart
+++ b/packages/flutter_driver/lib/src/extension.dart
@@ -181,7 +181,7 @@ class FlutterDriverExtension {
 
   Future<TapResult> _tap(Command command) async {
     Tap tapCommand = command;
-    prober.tap(await _waitForElement(_createFinder(tapCommand.finder)));
+    await prober.tap(await _waitForElement(_createFinder(tapCommand.finder)));
     return new TapResult();
   }
 


### PR DESCRIPTION
The missing `await` causes the extension to return before the tap is completed causing the order of any subsequent action to be non-deterministic.

/cc @HansMuller 
