### PR TITLE
Scrollable should restore its viewport dimensions when it reappears

### DIFF
--- a/packages/flutter/lib/src/widgets/scrollable.dart
+++ b/packages/flutter/lib/src/widgets/scrollable.dart
@@ -287,12 +287,11 @@ class ScrollableState<T extends Scrollable> extends State<T> {
   @override
   void dependenciesChanged() {
     _scrollBehavior = createScrollBehavior();
-    final double updatedOffset = _scrollBehavior.updateExtents(
+    didUpdateScrollBehavior(_scrollBehavior.updateExtents(
       contentExtent: _contentExtent,
       containerExtent: _containerExtent,
       scrollOffset: scrollOffset
-    );
-    didUpdateScrollBehavior(updatedOffset);
+    ));
     super.dependenciesChanged();
   }
 

--- a/packages/flutter/lib/src/widgets/scrollable.dart
+++ b/packages/flutter/lib/src/widgets/scrollable.dart
@@ -274,6 +274,8 @@ class ScrollableState<T extends Scrollable> extends State<T> {
 
   Simulation _simulation; // if we're flinging, then this is the animation with which we're doing it
   AnimationController _controller;
+  double _contentExtent;
+  double _containerExtent;
 
   @override
   void dispose() {
@@ -285,7 +287,12 @@ class ScrollableState<T extends Scrollable> extends State<T> {
   @override
   void dependenciesChanged() {
     _scrollBehavior = createScrollBehavior();
-    didUpdateScrollBehavior(scrollOffset);
+    final double updatedOffset = _scrollBehavior.updateExtents(
+      contentExtent: _contentExtent,
+      containerExtent: _containerExtent,
+      scrollOffset: scrollOffset
+    );
+    didUpdateScrollBehavior(updatedOffset);
     super.dependenciesChanged();
   }
 
@@ -495,6 +502,8 @@ class ScrollableState<T extends Scrollable> extends State<T> {
   ///     [didUpdateScrollBehavior].
   ///  3. Updating this object's gesture detector with [updateGestureDetector].
   void handleExtentsChanged(double contentExtent, double containerExtent) {
+    _contentExtent = contentExtent;
+    _containerExtent = containerExtent;
     didUpdateScrollBehavior(scrollBehavior.updateExtents(
       contentExtent: contentExtent,
       containerExtent: containerExtent,

--- a/packages/flutter/test/widget/scroll_behavior_test.dart
+++ b/packages/flutter/test/widget/scroll_behavior_test.dart
@@ -80,6 +80,8 @@ void main() {
     expect(delegate, isNotNull);
     expect(delegate.flag, isTrue);
     expect(behavior, new isInstanceOf<BoundedBehavior>());
+    expect(behavior.containerExtent, equals(600.0));
+    expect(behavior.contentExtent, equals(1000.0));
 
     // Same Scrollable, different ScrollConfiguration
     await tester.pumpWidget(
@@ -101,5 +103,8 @@ void main() {
     expect(delegate, isNotNull);
     expect(delegate.flag, isFalse);
     expect(behavior, new isInstanceOf<UnboundedBehavior>());
+    // Regression test for https://github.com/flutter/flutter/issues/5856
+    expect(behavior.containerExtent, equals(600.0));
+    expect(behavior.contentExtent, equals(1000.0));
   });
 }

--- a/packages/flutter/test/widget/scroll_behavior_test.dart
+++ b/packages/flutter/test/widget/scroll_behavior_test.dart
@@ -80,8 +80,8 @@ void main() {
     expect(delegate, isNotNull);
     expect(delegate.flag, isTrue);
     expect(behavior, new isInstanceOf<BoundedBehavior>());
-    expect(behavior.containerExtent, equals(600.0));
     expect(behavior.contentExtent, equals(1000.0));
+    expect(behavior.containerExtent, equals(600.0));
 
     // Same Scrollable, different ScrollConfiguration
     await tester.pumpWidget(
@@ -104,7 +104,7 @@ void main() {
     expect(delegate.flag, isFalse);
     expect(behavior, new isInstanceOf<UnboundedBehavior>());
     // Regression test for https://github.com/flutter/flutter/issues/5856
-    expect(behavior.containerExtent, equals(600.0));
     expect(behavior.contentExtent, equals(1000.0));
+    expect(behavior.containerExtent, equals(600.0));
   });
 }


### PR DESCRIPTION
When a scrollable is reactivated its dependenciesChanged() method recreates the scroll behavior.

The new scroll behavior needs to be configured with the viewport's current (contentExtent, containerExtent) dimensions.

Fixes #5856
