### PR TITLE
Small revision to ScrollableState.fling()

### DIFF
--- a/packages/flutter/lib/src/widgets/scrollable.dart
+++ b/packages/flutter/lib/src/widgets/scrollable.dart
@@ -513,8 +513,8 @@ class ScrollableState<T extends Scrollable> extends State<T> {
 
   /// If [scrollVelocity] is greater than [PixelScrollTolerance.velocity] then
   /// fling the scroll offset with the given velocity in logical pixels/second.
-  /// Otherwise, if this scrollable is overscrolled or a snapOffsetCallback was given,
-  /// animate the scroll offset to its final value with [settleScrollOffset].
+  /// Otherwise, if this scrollable is overscrolled or a [snapOffsetCallback]
+  /// was given, animate the scroll offset to its final value with [settleScrollOffset].
   ///
   /// Calling this function starts a physics-based animation of the scroll
   /// offset with the given value as the initial velocity. The physics

--- a/packages/flutter/lib/src/widgets/scrollable.dart
+++ b/packages/flutter/lib/src/widgets/scrollable.dart
@@ -511,14 +511,24 @@ class ScrollableState<T extends Scrollable> extends State<T> {
     updateGestureDetector();
   }
 
-  /// Fling the scroll offset with the given velocity in logical pixels/second.
+  /// If [scrollVelocity] is greater than [PixelScrollTolerance.velocity] then
+  /// fling the scroll offset with the given velocity in logical pixels/second.
+  /// Otherwise, if this scrollable is overscrolled or a snapOffsetCallback was given,
+  /// then animate the scroll offset to its final value with [settleScrollOffset].
   ///
   /// Calling this function starts a physics-based animation of the scroll
   /// offset with the given value as the initial velocity. The physics
   /// simulation is determined by the scroll behavior.
   Future<Null> fling(double scrollVelocity) {
-    if (scrollVelocity.abs() > kPixelScrollTolerance.velocity || !_controller.isAnimating)
+    if (scrollVelocity.abs() > kPixelScrollTolerance.velocity)
       return _startToEndAnimation(scrollVelocity);
+
+    // If scroll animation isn't underway already and we're overscrolled or we're
+    // going to have to snap the scroll offset, then animate the scroll offset to its
+    // final value.
+    if (!_controller.isAnimating && (shouldSnapScrollOffset || !_scrollOffsetIsInBounds(scrollOffset)))
+      return settleScrollOffset();
+
     return new Future<Null>.value();
   }
 

--- a/packages/flutter/lib/src/widgets/scrollable.dart
+++ b/packages/flutter/lib/src/widgets/scrollable.dart
@@ -514,7 +514,7 @@ class ScrollableState<T extends Scrollable> extends State<T> {
   /// If [scrollVelocity] is greater than [PixelScrollTolerance.velocity] then
   /// fling the scroll offset with the given velocity in logical pixels/second.
   /// Otherwise, if this scrollable is overscrolled or a snapOffsetCallback was given,
-  /// then animate the scroll offset to its final value with [settleScrollOffset].
+  /// animate the scroll offset to its final value with [settleScrollOffset].
   ///
   /// Calling this function starts a physics-based animation of the scroll
   /// offset with the given value as the initial velocity. The physics

--- a/packages/flutter/lib/src/widgets/scrollable.dart
+++ b/packages/flutter/lib/src/widgets/scrollable.dart
@@ -523,7 +523,7 @@ class ScrollableState<T extends Scrollable> extends State<T> {
     if (scrollVelocity.abs() > kPixelScrollTolerance.velocity)
       return _startToEndAnimation(scrollVelocity);
 
-    // If scroll animation isn't underway already and we're overscrolled or we're
+    // If a scroll animation isn't underway already and we're overscrolled or we're
     // going to have to snap the scroll offset, then animate the scroll offset to its
     // final value.
     if (!_controller.isAnimating && (shouldSnapScrollOffset || !_scrollOffsetIsInBounds(scrollOffset)))


### PR DESCRIPTION
If a fling's velocity is below the threshold, do not start a scroll animation. Just settle the scroll offset.

Otherwise, but only if we're overscrolled or snapping, settle the scroll offset.

Fixes #5870
