### PR TITLE
Update tools to use `analyzer` from vended Dart SDK.

### DIFF
--- a/dev/devicelab/pubspec.yaml
+++ b/dev/devicelab/pubspec.yaml
@@ -13,10 +13,15 @@ dependencies:
   path: ^1.3.0
   stack_trace: ^1.4.0
   vm_service_client: '^0.2.0'
-
-  # See packages/flutter_test/pubspec.yaml for why we're pinning this version
-  analyzer: 0.28.2-alpha.0
+  
+  # Pulled in via dependency_override below.
+  analyzer: any
 
 dev_dependencies:
-  # See packages/flutter_test/pubspec.yaml for why we're pinning this version
+  # See packages/flutter_test/pubspec.yaml for why we're pinning this version.
   test: 0.12.15+4
+
+# See packages/flutter_test/pubspec.yaml for why we're using an override.
+dependency_overrides:
+  analyzer:
+    path: ../../bin/cache/dart-sdk/lib/analyzer

--- a/packages/flutter_test/pubspec.yaml
+++ b/packages/flutter_test/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
   # We don't actually depend on 'analyzer', but 'test' and 'flutter_tools' do.
   # Like 'flutter_tools', we use the version of the analyzer in the vended Dart
   # SDK as defined in the `dependency_overrides` below.
-  analyzer: any 
+  analyzer: any
 
   flutter:
     path: ../flutter

--- a/packages/flutter_test/pubspec.yaml
+++ b/packages/flutter_test/pubspec.yaml
@@ -8,9 +8,13 @@ dependencies:
   test: 0.12.15+4
 
   # We don't actually depend on 'analyzer', but 'test' and 'flutter_tools' do.
-  # We pin the version of analyzer we depend on to avoid version skew across our
-  # packages.
-  analyzer: 0.28.2-alpha.0
+  # Like 'flutter_tools', we use the version of the analyzer in the vended Dart
+  # SDK as defined in the `dependency_overrides` below.
+  analyzer: any 
 
   flutter:
     path: ../flutter
+
+dependency_overrides:
+  analyzer:
+    path: ../../bin/cache/dart-sdk/lib/analyzer

--- a/packages/flutter_tools/lib/src/commands/analyze.dart
+++ b/packages/flutter_tools/lib/src/commands/analyze.dart
@@ -188,9 +188,8 @@ class AnalyzeCommand extends FlutterCommand {
               // Ensure that we only add the `analyzer` package defined in the vended SDK (and referred to with a local path directive).
               // Analyzer package versions reached via transitive dependencies (e.g., via `test`) are ignored since they would produce
               // spurious conflicts.
-              if (packageName != 'analyzer' || packagePath.startsWith('..')) {
+              if (packageName != 'analyzer' || packagePath.startsWith('..'))
                 dependencies.add(packageName, path.normalize(path.absolute(directory.path, path.fromUri(packagePath))), dotPackagesPath);
-              }
             }
           });
       }

--- a/packages/flutter_tools/lib/src/commands/analyze.dart
+++ b/packages/flutter_tools/lib/src/commands/analyze.dart
@@ -182,8 +182,16 @@ class AnalyzeCommand extends FlutterCommand {
           .where((String line) => !line.startsWith(new RegExp(r'^ *#')))
           .forEach((String line) {
             int colon = line.indexOf(':');
-            if (colon > 0)
-              dependencies.add(line.substring(0, colon), path.normalize(path.absolute(directory.path, path.fromUri(line.substring(colon+1)))), dotPackagesPath);
+            if (colon > 0) {
+              String packageName = line.substring(0, colon);
+              String packagePath = path.fromUri(line.substring(colon+1));
+              // Ensure that we only add the `analyzer` package defined in the vended SDK (and referred to with a local path directive).
+              // Analyzer package versions reached via transitive dependencies (e.g., via `test`) are ignored since they would produce
+              // spurious conflicts.
+              if (packageName != 'analyzer' || packagePath.startsWith('..')) {
+                dependencies.add(packageName, path.normalize(path.absolute(directory.path, path.fromUri(packagePath))), dotPackagesPath);
+              }
+            }
           });
       }
     }

--- a/packages/flutter_tools/pubspec.yaml
+++ b/packages/flutter_tools/pubspec.yaml
@@ -38,8 +38,8 @@ dependencies:
   # precisely.
   test: 0.12.15+4
 
-  # Pinned in flutter_test as well.
-  analyzer: 0.28.2-alpha.0
+  # Version from the vended Dart SDK as defined in `dependency_overrides`.
+  analyzer: any
 
 dev_dependencies:
   mockito: ^1.0.0
@@ -47,3 +47,7 @@ dev_dependencies:
 # Exclude this package from the hosted API docs.
 dartdoc:
   nodoc: true
+
+dependency_overrides:
+  analyzer:
+    path: ../../bin/cache/dart-sdk/lib/analyzer


### PR DESCRIPTION
An experiment to see if we can decouple ourselves from published `analyzer` packages via `dependency_overrides`.
- updates `flutter_tools` and `flutter_test` to use the SDK-vended `analyzer` package
- tweaks dependency tracking logic to only record the SDK-vended `analyzer` so as not to crash on spurious conflicts (due to transitive dependencies)

Note that this means we will:
1. no longer need to manually publish `analyzer` packages in lock-step with SDK releases
2. no longer need to update `flutter_tools` and `flutter_test` on fresh SDK rolls
3. never have to worry about possible analysis skew between the analyzer (and server) vended in the SDK and the one pulled in via a package dependency in `flutter_tools`

Rolling to a new Dart SDK should become as simple as an update to `bin/cache/dart-sdk-version`.

:metal: 

Still to do, if we go this way, is to suppress this nag from pub when building:

``` shell
Building flutter tool...
Warning: You are using these overridden dependencies:
! analyzer 0.29.0-alpha.0 from path ../../bin/cache/dart-sdk/lib/analyzer
```
