### PR TITLE
Add FlexFit.loose

### DIFF
--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -20,7 +20,7 @@ export 'package:flutter/rendering.dart' show
     CustomClipper,
     CustomPainter,
     FixedColumnCountGridDelegate,
-    Axis,
+    FlexFit,
     FlowDelegate,
     FlowPaintingContext,
     FractionalOffsetTween,
@@ -1949,23 +1949,44 @@ class Flexible extends ParentDataWidget<Flex> {
   Flexible({
     Key key,
     this.flex: 1,
+    this.fit: FlexFit.tight,
     @required Widget child
   }) : super(key: key, child: child);
 
   /// The flex factor to use for this child
   ///
-  /// If null, the child is inflexible and determines its own size. If non-null,
-  /// the child is flexible and its extent in the main axis is determined by
-  /// dividing the free space (after placing the inflexible children)
-  /// according to the flex factors of the flexible children.
+  /// If null or zero, the child is inflexible and determines its own size. If
+  /// non-zero, the amount of space the child's can occupy in the main axis is
+  /// determined by dividing the free space (after placing the inflexible
+  /// children) according to the flex factors of the flexible children.
   final int flex;
+
+  /// How a flexible child is inscribed into the available space.
+  ///
+  /// If [flex] is non-zero, the [fit] determines whether the child fills the
+  /// space the parent makes available during layout. If the fit is
+  /// [FlexFit.tight], the child is required to fill the available space. If the
+  /// fit is [FlexFit.loose], the child can be at most as large as the available
+  /// space (but is allowed to be smaller).
+  final FlexFit fit;
 
   @override
   void applyParentData(RenderObject renderObject) {
     assert(renderObject.parentData is FlexParentData);
     final FlexParentData parentData = renderObject.parentData;
+    bool needsLayout = false;
+
     if (parentData.flex != flex) {
       parentData.flex = flex;
+      needsLayout = true;
+    }
+
+    if (parentData.fit != fit) {
+      parentData.fit = fit;
+      needsLayout = true;
+    }
+
+    if (needsLayout) {
       AbstractNode targetParent = renderObject.parent;
       if (targetParent is RenderObject)
         targetParent.markNeedsLayout();

--- a/packages/flutter/test/rendering/flex_test.dart
+++ b/packages/flutter/test/rendering/flex_test.dart
@@ -166,4 +166,51 @@ void main() {
     expect(getOffset(box3).dy, equals(275.0));
     expect(box3.size.height, equals(100.0));
   });
+
+  test('Fit.loose', () {
+    RenderConstrainedBox box1 = new RenderConstrainedBox(additionalConstraints: new BoxConstraints.tightFor(width: 100.0, height: 100.0));
+    RenderConstrainedBox box2 = new RenderConstrainedBox(additionalConstraints: new BoxConstraints.tightFor(width: 100.0, height: 100.0));
+    RenderConstrainedBox box3 = new RenderConstrainedBox(additionalConstraints: new BoxConstraints.tightFor(width: 100.0, height: 100.0));
+    RenderFlex flex = new RenderFlex(mainAxisAlignment: MainAxisAlignment.spaceBetween);
+    flex.addAll(<RenderBox>[box1, box2, box3]);
+    layout(flex, constraints: const BoxConstraints(
+      minWidth: 0.0, maxWidth: 500.0, minHeight: 0.0, maxHeight: 400.0)
+    );
+    Offset getOffset(RenderBox box) {
+      FlexParentData parentData = box.parentData;
+      return parentData.offset;
+    }
+    expect(getOffset(box1).dx, equals(0.0));
+    expect(box1.size.width, equals(100.0));
+    expect(getOffset(box2).dx, equals(200.0));
+    expect(box2.size.width, equals(100.0));
+    expect(getOffset(box3).dx, equals(400.0));
+    expect(box3.size.width, equals(100.0));
+
+    void setFit(RenderBox box, FlexFit fit) {
+      FlexParentData parentData = box.parentData;
+      parentData.flex = 1;
+      parentData.fit = fit;
+    }
+
+    setFit(box1, FlexFit.loose);
+
+    pumpFrame();
+    expect(getOffset(box1).dx, equals(0.0));
+    expect(box1.size.width, equals(100.0));
+    expect(getOffset(box2).dx, equals(200.0));
+    expect(box2.size.width, equals(100.0));
+    expect(getOffset(box3).dx, equals(400.0));
+    expect(box3.size.width, equals(100.0));
+
+    box1.additionalConstraints = new BoxConstraints.tightFor(width: 1000.0, height: 100.0);
+
+    pumpFrame();
+    expect(getOffset(box1).dx, equals(0.0));
+    expect(box1.size.width, equals(300.0));
+    expect(getOffset(box2).dx, equals(300.0));
+    expect(box2.size.width, equals(100.0));
+    expect(getOffset(box3).dx, equals(400.0));
+    expect(box3.size.width, equals(100.0));
+  });
 }


### PR DESCRIPTION
Previously, flexible children were always required to fill their allocated
space. After this change, they can fit loosely into that space and not fill it.
When that happens, the remaining free space is allocated according to the
maixAxisAlignment.

Fixes #5858
