### PR TITLE
ClampOverscrolls clamps Scrollable, not its Viewport

### DIFF
--- a/examples/flutter_gallery/test/smoke_test.dart
+++ b/examples/flutter_gallery/test/smoke_test.dart
@@ -82,7 +82,7 @@ void main() {
       await tester.scroll(findGalleryItemByRouteName(tester, routeName), new Offset(0.0, scrollDeltas[i]));
       await tester.pump(); // start the scroll
       await tester.pump(const Duration(milliseconds: 500)); // wait for overscroll to timeout, if necessary
-      await tester.pump(const Duration(milliseconds: 2000)); // wait for overscroll to fade away, if necessary
+      await tester.pump(const Duration(seconds: 3)); // wait for overscroll to fade away, if necessary
       tester.binding.debugAssertNoTransientCallbacks('A transient callback was still active after leaving route $routeName');
     }
 

--- a/packages/flutter/lib/src/material/overscroll_indicator.dart
+++ b/packages/flutter/lib/src/material/overscroll_indicator.dart
@@ -151,7 +151,7 @@ class _OverscrollIndicatorState extends State<OverscrollIndicator> {
       return;
     final ExtentScrollBehavior scrollBehavior = scrollable.scrollBehavior;
     _scrollDirection = scrollable.config.scrollDirection;
-    _scrollOffset = scrollable.scrollOffset;
+    _scrollOffset = scrollable.virtualScrollOffset;
     _minScrollOffset = scrollBehavior.minScrollOffset;
     _maxScrollOffset = scrollBehavior.maxScrollOffset;
   }
@@ -166,7 +166,7 @@ class _OverscrollIndicatorState extends State<OverscrollIndicator> {
     if (!_scrollUnderway) // The hide timer has run.
       return;
 
-    final double value = scrollable.scrollOffset;
+    final double value = scrollable.virtualScrollOffset;
     if (_isOverscroll(value)) {
       _refreshHideTimer();
       // Hide the indicator as soon as user starts scrolling in the reverse direction of overscroll.

--- a/packages/flutter/lib/src/widgets/clamp_overscrolls.dart
+++ b/packages/flutter/lib/src/widgets/clamp_overscrolls.dart
@@ -83,9 +83,10 @@ class ClampOverscrolls extends InheritedWidget {
   /// constraints are applied.
   final ScrollableEdge edge;
 
-  /// Return the [scrollable]'s scrollOffset clamped  according to [edge].
-  double clampScrollOffset(ScrollableState scrollable) {
-    final double scrollOffset = scrollable.scrollOffset;
+  /// Return the [newScrollOffset] clamped  according to [edge] and [scrollable]'s
+  /// scroll behavior. The value of [newScrollOffset] defaults to `scrollable.scrollOffset`.
+  double clampScrollOffset(ScrollableState scrollable, [double newScrollOffset]) {
+    final double scrollOffset = newScrollOffset ?? scrollable.scrollOffset;
     final double minScrollOffset = scrollable.scrollBehavior.minScrollOffset;
     final double maxScrollOffset = scrollable.scrollBehavior.maxScrollOffset;
     switch (edge) {
@@ -104,29 +105,6 @@ class ClampOverscrolls extends InheritedWidget {
   /// The closest instance of this class that encloses the given context.
   static ClampOverscrolls of(BuildContext context) {
     return context.inheritFromWidgetOfExactType(ClampOverscrolls);
-  }
-
-  /// Clamps the new viewport's scroll offset according to the value of
-  /// `ClampOverscrolls.of(context).edge`.
-  ///
-  /// The clamped overscroll edge is reset to [ScrollableEdge.none] for the viewport's
-  /// descendants.
-  ///
-  /// This utility function is typically used by [Scrollable.builder] callbacks.
-  static Widget buildViewport(BuildContext context, ScrollableState state, ViewportBuilder builder) {
-    // TODO(ianh): minScrollOffset and maxScrollOffset are typically determined
-    // by the container and content size. But we don't know those until we
-    // layout the viewport, which happens after build phase. We need to rethink
-    // this.
-    final ClampOverscrolls clampOverscrolls = ClampOverscrolls.of(context);
-    if (clampOverscrolls == null)
-      return builder(context, state, state.scrollOffset);
-
-    final double clampedScrollOffset = clampOverscrolls.clampScrollOffset(state);
-    Widget viewport = builder(context, state, clampedScrollOffset);
-    if (clampOverscrolls.edge != ScrollableEdge.none)
-      viewport = new ClampOverscrolls(edge: ScrollableEdge.none, child: viewport);
-    return viewport;
   }
 
   @override

--- a/packages/flutter/lib/src/widgets/lazy_block.dart
+++ b/packages/flutter/lib/src/widgets/lazy_block.dart
@@ -8,7 +8,6 @@ import 'package:flutter/rendering.dart';
 import 'package:meta/meta.dart';
 
 import 'basic.dart';
-import 'clamp_overscrolls.dart';
 import 'framework.dart';
 import 'scroll_configuration.dart';
 import 'scrollable.dart';
@@ -259,9 +258,9 @@ class LazyBlock extends StatelessWidget {
   /// See [LazyBlockDelegate] for details.
   final LazyBlockDelegate delegate;
 
-  Widget _buildViewport(BuildContext context, ScrollableState state, double scrollOffset) {
+  Widget _buildViewport(BuildContext context, ScrollableState state) {
     return new LazyBlockViewport(
-      startOffset: scrollOffset,
+      startOffset: state.scrollOffset,
       mainAxis: scrollDirection,
       padding: padding,
       onExtentsChanged: (int firstIndex, int lastIndex, double firstStartOffset, double lastEndOffset, double minScrollOffset, double containerExtent) {
@@ -278,10 +277,6 @@ class LazyBlock extends StatelessWidget {
     );
   }
 
-  Widget _buildContent(BuildContext context, ScrollableState state) {
-    return ClampOverscrolls.buildViewport(context, state, _buildViewport);
-  }
-
   @override
   Widget build(BuildContext context) {
     final Widget result = new Scrollable(
@@ -292,7 +287,7 @@ class LazyBlock extends StatelessWidget {
       onScroll: onScroll,
       onScrollEnd: onScrollEnd,
       snapOffsetCallback: snapOffsetCallback,
-      builder: _buildContent
+      builder: _buildViewport
     );
     return ScrollConfiguration.wrap(context, result);
   }

--- a/packages/flutter/lib/src/widgets/scrollable.dart
+++ b/packages/flutter/lib/src/widgets/scrollable.dart
@@ -422,8 +422,10 @@ class ScrollableState<T extends Scrollable> extends State<T> {
   void _handleAnimationStatusChanged(AnimationStatus status) {
     // this is not called when stop() is called on the controller
     setState(() {
-      if (!_controller.isAnimating)
+      if (!_controller.isAnimating) {
         _simulation = null;
+        _scrollUnderway = false;
+      }
     });
   }
 
@@ -704,8 +706,8 @@ class ScrollableState<T extends Scrollable> extends State<T> {
       _simulation = null;
       if (_scrollUnderway && mounted) {
         // If the scroll hasn't already stopped because we've hit a clamped
-        // edge, then rebuild the Scrollable with the IgnorePointer widget
-        // turned off.
+        // edge or the controller stopped animating, then rebuild the Scrollable
+        // with the IgnorePointer widget turned off.
         setState(() {
           _scrollUnderway = false;
         });

--- a/packages/flutter/lib/src/widgets/scrollable.dart
+++ b/packages/flutter/lib/src/widgets/scrollable.dart
@@ -460,7 +460,7 @@ class ScrollableState<T extends Scrollable> extends State<T> {
     Curve curve: Curves.ease,
     DragUpdateDetails details
   }) {
-    double newScrollOffset = scrollBehavior.applyCurve(_virtualScrollOffset, scrollDelta);
+    double newScrollOffset = scrollBehavior.applyCurve(virtualScrollOffset, scrollDelta);
     return scrollTo(newScrollOffset, duration: duration, curve: curve, details: details);
   }
 
@@ -492,7 +492,7 @@ class ScrollableState<T extends Scrollable> extends State<T> {
 
   Future<Null> _animateTo(double newScrollOffset, Duration duration, Curve curve) {
     _stop();
-    _controller.value = scrollOffset;
+    _controller.value = virtualScrollOffset;
     _startScroll();
     return _controller.animateTo(newScrollOffset, duration: duration, curve: curve).then((Null _) {
       _endScroll();
@@ -612,7 +612,7 @@ class ScrollableState<T extends Scrollable> extends State<T> {
     final double snapVelocity = scrollVelocity.abs() * (snappedScrollOffset - scrollOffset).sign;
     final double endVelocity = pixelOffsetToScrollOffset(kPixelScrollTolerance.velocity).abs() * (scrollVelocity < 0.0 ? -1.0 : 1.0);
     Simulation toSnapSimulation = scrollBehavior.createSnapScrollSimulation(
-      scrollOffset, snappedScrollOffset, snapVelocity, endVelocity
+      virtualScrollOffset, snappedScrollOffset, snapVelocity, endVelocity
     );
     if (toSnapSimulation == null)
       return null;
@@ -623,7 +623,7 @@ class ScrollableState<T extends Scrollable> extends State<T> {
   }
 
   Simulation _createFlingSimulation(double scrollVelocity) {
-    final Simulation simulation = scrollBehavior.createScrollSimulation(scrollOffset, scrollVelocity);
+    final Simulation simulation = scrollBehavior.createScrollSimulation(virtualScrollOffset, scrollVelocity);
     if (simulation != null) {
       final double endVelocity = pixelOffsetToScrollOffset(kPixelScrollTolerance.velocity).abs();
       final double endDistance = pixelOffsetToScrollOffset(kPixelScrollTolerance.distance).abs();

--- a/packages/flutter/lib/src/widgets/scrollable.dart
+++ b/packages/flutter/lib/src/widgets/scrollable.dart
@@ -702,7 +702,7 @@ class ScrollableState<T extends Scrollable> extends State<T> {
     _numberOfInProgressScrolls -= 1;
     if (_numberOfInProgressScrolls == 0) {
       _simulation = null;
-      if (_scrollUnderway) {
+      if (_scrollUnderway && mounted) {
         // If the scroll hasn't already stopped because we've hit a clamped
         // edge, then rebuild the Scrollable with the IgnorePointer widget
         // turned off.

--- a/packages/flutter/lib/src/widgets/scrollable_grid.dart
+++ b/packages/flutter/lib/src/widgets/scrollable_grid.dart
@@ -8,7 +8,6 @@ import 'package:collection/collection.dart' show lowerBound;
 import 'package:flutter/rendering.dart';
 import 'package:meta/meta.dart';
 
-import 'clamp_overscrolls.dart';
 import 'framework.dart';
 import 'scroll_configuration.dart';
 import 'scrollable.dart';
@@ -81,17 +80,13 @@ class ScrollableGrid extends StatelessWidget {
   /// The children that will be placed in the grid.
   final Iterable<Widget> children;
 
-  Widget _buildViewport(BuildContext context, ScrollableState state, double scrollOffset) {
+  Widget _buildViewport(BuildContext context, ScrollableState state) {
     return new GridViewport(
-      scrollOffset: scrollOffset,
+      scrollOffset: state.scrollOffset,
       delegate: delegate,
       onExtentsChanged: state.handleExtentsChanged,
       children: children
     );
-  }
-
-  Widget _buildContent(BuildContext context, ScrollableState state) {
-    return ClampOverscrolls.buildViewport(context, state, _buildViewport);
   }
 
   @override
@@ -107,7 +102,7 @@ class ScrollableGrid extends StatelessWidget {
       onScroll: onScroll,
       onScrollEnd: onScrollEnd,
       snapOffsetCallback: snapOffsetCallback,
-      builder: _buildContent
+      builder: _buildViewport,
     );
     return ScrollConfiguration.wrap(context, result);
   }

--- a/packages/flutter/lib/src/widgets/scrollable_list.dart
+++ b/packages/flutter/lib/src/widgets/scrollable_list.dart
@@ -7,7 +7,6 @@ import 'dart:math' as math;
 import 'package:flutter/rendering.dart';
 import 'package:meta/meta.dart';
 
-import 'clamp_overscrolls.dart';
 import 'framework.dart';
 import 'scroll_configuration.dart';
 import 'scrollable.dart';
@@ -126,12 +125,12 @@ class ScrollableList extends StatelessWidget {
   /// The children, some of which might be materialized.
   final Iterable<Widget> children;
 
-  Widget _buildViewport(BuildContext context, ScrollableState state, double scrollOffset) {
+  Widget _buildViewport(BuildContext context, ScrollableState state) {
     return new ListViewport(
       onExtentsChanged: (double contentExtent, double containerExtent) {
         state.handleExtentsChanged(itemsWrap ? double.INFINITY : contentExtent, containerExtent);
       },
-      scrollOffset: scrollOffset,
+      scrollOffset: state.scrollOffset,
       mainAxis: scrollDirection,
       anchor: scrollAnchor,
       itemExtent: itemExtent,
@@ -139,10 +138,6 @@ class ScrollableList extends StatelessWidget {
       padding: padding,
       children: children
     );
-  }
-
-  Widget _buildContent(BuildContext context, ScrollableState state) {
-    return ClampOverscrolls.buildViewport(context, state, _buildViewport);
   }
 
   @override
@@ -156,7 +151,7 @@ class ScrollableList extends StatelessWidget {
       onScroll: onScroll,
       onScrollEnd: onScrollEnd,
       snapOffsetCallback: snapOffsetCallback,
-      builder: _buildContent
+      builder: _buildViewport
     );
     return ScrollConfiguration.wrap(context, result);
   }
@@ -529,10 +524,10 @@ class ScrollableLazyList extends StatelessWidget {
   /// The amount of space by which to inset the children inside the viewport.
   final EdgeInsets padding;
 
-  Widget _buildViewport(BuildContext context, ScrollableState state, double scrollOffset) {
+  Widget _buildViewport(BuildContext context, ScrollableState state) {
     return new LazyListViewport(
       onExtentsChanged: state.handleExtentsChanged,
-      scrollOffset: scrollOffset,
+      scrollOffset: state.scrollOffset,
       mainAxis: scrollDirection,
       anchor: scrollAnchor,
       itemExtent: itemExtent,
@@ -540,10 +535,6 @@ class ScrollableLazyList extends StatelessWidget {
       itemBuilder: itemBuilder,
       padding: padding
     );
-  }
-
-  Widget _buildContent(BuildContext context, ScrollableState state) {
-    return ClampOverscrolls.buildViewport(context, state, _buildViewport);
   }
 
   @override
@@ -557,7 +548,7 @@ class ScrollableLazyList extends StatelessWidget {
       onScroll: onScroll,
       onScrollEnd: onScrollEnd,
       snapOffsetCallback: snapOffsetCallback,
-      builder: _buildContent
+      builder: _buildViewport
     );
     return ScrollConfiguration.wrap(context, result);
   }

--- a/packages/flutter/test/material/date_picker_test.dart
+++ b/packages/flutter/test/material/date_picker_test.dart
@@ -6,7 +6,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  testWidgets('tap-select an day', (WidgetTester tester) async {
+  testWidgets('tap-select a day', (WidgetTester tester) async {
     Key _datePickerKey = new UniqueKey();
     DateTime _selectedDate = new DateTime(2016, DateTime.JULY, 26);
 

--- a/packages/flutter/test/widget/scrollable_list_hit_testing_test.dart
+++ b/packages/flutter/test/widget/scrollable_list_hit_testing_test.dart
@@ -151,4 +151,35 @@ void main() {
     await tester.tapAt(new Point(800.0 - 16.0, 200.0));
     expect(tapped, equals(<int>[5, 4, 4]));
   });
+
+  testWidgets('Tap immediately following clamped overscroll', (WidgetTester tester) async {
+    // Regression test for https://github.com/flutter/flutter/issues/5709
+    GlobalKey<ScrollableState> scrollableKey = new GlobalKey<ScrollableState>();
+    List<int> tapped = <int>[];
+
+    await tester.pumpWidget(
+      new ClampOverscrolls(
+        edge: ScrollableEdge.both,
+        child: new ScrollableList(
+          scrollableKey: scrollableKey,
+          itemExtent: 200.0,
+          children: items.map((int item) {
+            return new Container(
+              child: new GestureDetector(
+                onTap: () { tapped.add(item); },
+                child: new Text('$item')
+              )
+            );
+          })
+        )
+      )
+    );
+
+    await tester.fling(find.text('0'), const Offset(0.0, 400.0), 1000.0);
+    expect(scrollableKey.currentState.scrollOffset, equals(0.0));
+    expect(scrollableKey.currentState.virtualScrollOffset, lessThan(0.0));
+
+    await tester.tapAt(new Point(200.0, 100.0));
+    expect(tapped, equals(<int>[0]));
+  });
 }


### PR DESCRIPTION
The ClampOverscrolls widget now actually clamps the scrollable's scrollOffset, rather than its viewport's scrollOffset.

Widgets that depend on seeing the overscroll, even when the scroll offset has been clamped, can use the Scrollable's virtualScrollOffset. The virutalScrollOffset is updated unconditionally.

Fixes #5709
