### PR TITLE
Renamed constant.

### DIFF
--- a/examples/flutter_gallery/lib/demo/pesto_demo.dart
+++ b/examples/flutter_gallery/lib/demo/pesto_demo.dart
@@ -120,7 +120,7 @@ class _RecipeGridPageState extends State<RecipeGridPage> {
           final Size size = constraints.biggest;
           final double appBarHeight = size.height - statusBarHeight;
           final double extraPadding = new Tween<double>(begin: 10.0, end: 24.0).lerp(
-            ((appBarHeight - kToolBarHeight) / _kAppBarHeight).clamp(0.0, 1.0)
+            ((appBarHeight - kToolbarHeight) / _kAppBarHeight).clamp(0.0, 1.0)
           );
           final double logoHeight = appBarHeight - 1.5 * extraPadding;
           return new Padding(


### PR DESCRIPTION
Due to a synchronization issue, a PR was merged with a green build
that was supposed to be rebuilt and to fail. This commit fixes the
issue by renaming the usage of a constant.
