### PR TITLE
diagnose XCode signing errors and offer suggestions

### DIFF
--- a/packages/flutter_tools/lib/src/commands/build_ios.dart
+++ b/packages/flutter_tools/lib/src/commands/build_ios.dart
@@ -82,6 +82,8 @@ class BuildIOSCommand extends BuildSubCommand {
 
     if (!result.success) {
       printError('Encountered error while building for $logTarget.');
+      diagnoseXcodeBuildFailure(result);
+      printError('');
       return 1;
     }
 

--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -191,6 +191,8 @@ class IOSDevice extends Device {
     XcodeBuildResult buildResult = await buildXcodeProject(app: app, mode: mode, target: mainPath, buildForDevice: true);
     if (!buildResult.success) {
       printError('Could not build the precompiled application for the device.');
+      diagnoseXcodeBuildFailure(buildResult);
+      printError('');
       return new LaunchResult.failed();
     }
 
@@ -281,6 +283,9 @@ class IOSDevice extends Device {
 
     if (installationResult != 0) {
       printError('Could not install ${bundle.path} on $id.');
+      printError("Try launching XCode and selecting 'Product > Run' to fix the problem:");
+      printError("  open ios/Runner.xcodeproj");
+      printError('');
       return new LaunchResult.failed();
     }
 

--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -181,7 +181,7 @@ void diagnoseXcodeBuildFailure(XcodeBuildResult result) {
     String plistContent = plistFile.readAsStringSync();
     if (plistContent.contains('com.yourcompany')) {
       printError('');
-      printError('It appears that your application still contains the default identifier.');
+      printError('It appears that your application still contains the default signing identifier.');
       printError("Try replacing 'com.yourcompany' with your signing id");
       printError('in ${plistFile.absolute.path}');
       return;


### PR DESCRIPTION
This functionality examines output from a failed build or run on iOS, and offers suggestions if it detects a code signing error.

If it detects that the generated project still contains the default bundle identifier, it suggests...

```
It appears that your application still contains the default signing identifier.
Try replacing 'com.yourcompany' with your signing id
in ios/Runner/Info.plist
```

If it detects a code signing problem excluding the above case, it suggests...

```
It appears that there was a problem signing your application prior to installation on the device.

Verify that the CFBundleIdentifier in the Info.plist file is your signing id
  ios/Runner/Info.plist

Try launching XCode and selecting 'Product > Build' to fix the problem:
  open ios/Runner.xcodeproj
```
