### PR TITLE
Update to new mojom Dart generation scheme

### DIFF
--- a/dev/manual_tests/raw_keyboard.dart
+++ b/dev/manual_tests/raw_keyboard.dart
@@ -4,7 +4,7 @@
 
 import 'package:flutter/material.dart';
 
-import 'package:sky_services/sky/input_event.mojom.dart' as mojom;
+import 'package:flutter.services.engine/input_event.mojom.dart' as mojom;
 
 GlobalKey _key = new GlobalKey();
 

--- a/examples/hello_world/BUILD.gn
+++ b/examples/hello_world/BUILD.gn
@@ -1,0 +1,15 @@
+# Copyright 2016 The Fuchsia Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+import("//flutter/build/flutter_app.gni")
+
+flutter_app("hello_world") {
+  source_dir = "lib"
+
+  main_dart = "lib/main.dart"
+
+  deps = [
+    "//lib/flutter/packages/flutter",
+  ]
+}

--- a/examples/layers/raw/touch_input.dart
+++ b/examples/layers/raw/touch_input.dart
@@ -8,9 +8,9 @@
 import 'dart:ui' as ui;
 import 'dart:typed_data';
 
+import 'package:flutter.services.pointer/pointer.mojom.dart';
 import 'package:mojo/bindings.dart' as bindings;
 import 'package:mojo/core.dart' as core;
-import 'package:sky_services/pointer/pointer.mojom.dart';
 
 ui.Color color;
 

--- a/examples/layers/services/media_service.dart
+++ b/examples/layers/services/media_service.dart
@@ -4,11 +4,11 @@
 
 import 'dart:async';
 
-import 'package:sky_services/media/media.mojom.dart' as mojom;
+import 'package:flutter.services.media/media.mojom.dart' as mojom;
+import 'package:flutter/http.dart' as http;
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
-import 'package:flutter/http.dart' as http;
 
 // All of these sounds are marked as public domain at soundbible.
 const String chimes = "http://soundbible.com/grab.php?id=2030&type=wav";

--- a/packages/flutter/BUILD.gn
+++ b/packages/flutter/BUILD.gn
@@ -1,0 +1,24 @@
+# Copyright 2016 The Fuchsia Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+import("//build/dart/dart_package.gni")
+
+dart_package("flutter") {
+  package_name = "flutter"
+
+  source_dir = "lib"
+
+  deps = [
+    "//mojo/dart/packages/mojo",
+    "//mojo/services/asset_bundle/interfaces:interfaces_dart",
+    "//mojo/public/interfaces/network:network_dart",
+    "//apps/network/mojo/services/network/interfaces:interfaces_dart",
+    "//flutter/sky/packages/sky_services",
+    "//third_party/dart-pkg/pub/collection",
+    "//third_party/dart-pkg/pub/crypto",
+    "//third_party/dart-pkg/pub/intl",
+    "//third_party/dart-pkg/pub/meta",
+    "//third_party/dart-pkg/pub/vector_math",
+  ]
+}

--- a/packages/flutter/lib/src/gestures/binding.dart
+++ b/packages/flutter/lib/src/gestures/binding.dart
@@ -7,10 +7,10 @@ import 'dart:collection';
 import 'dart:typed_data';
 import 'dart:ui' as ui show window;
 
+import 'package:flutter.services.pointer/pointer.mojom.dart';
 import 'package:flutter/foundation.dart';
 import 'package:mojo/bindings.dart' as mojo_bindings;
 import 'package:mojo/core.dart' as mojo_core;
-import 'package:sky_services/pointer/pointer.mojom.dart';
 
 import 'arena.dart';
 import 'converter.dart';

--- a/packages/flutter/lib/src/gestures/converter.dart
+++ b/packages/flutter/lib/src/gestures/converter.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:sky_services/pointer/pointer.mojom.dart' as mojom;
+import 'package:flutter.services.pointer/pointer.mojom.dart' as mojom;
 
 import 'events.dart';
 

--- a/packages/flutter/lib/src/http/mojo_client.dart
+++ b/packages/flutter/lib/src/http/mojo_client.dart
@@ -6,14 +6,14 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:typed_data';
 
+import 'package:apps.network.mojo.services.network.interfaces/network_service.mojom.dart' as mojom;
+import 'package:apps.network.mojo.services.network.interfaces/url_loader.mojom.dart' as mojom;
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
+import 'package:mojo.public.interfaces.network/http_header.mojom.dart' as mojom;
+import 'package:mojo.public.interfaces.network/url_request.mojom.dart' as mojom;
+import 'package:mojo.public.interfaces.network/url_response.mojom.dart' as mojom;
 import 'package:mojo/core.dart' as mojo;
-import 'package:mojo/mojo/http_header.mojom.dart' as mojom;
-import 'package:mojo/mojo/url_request.mojom.dart' as mojom;
-import 'package:mojo/mojo/url_response.mojom.dart' as mojom;
-import 'package:mojo_services/mojo/network_service.mojom.dart' as mojom;
-import 'package:mojo_services/mojo/url_loader.mojom.dart' as mojom;
 
 import 'response.dart';
 

--- a/packages/flutter/lib/src/material/app_bar.dart
+++ b/packages/flutter/lib/src/material/app_bar.dart
@@ -2,9 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:flutter.services.flutter/platform/system_chrome.mojom.dart' as mojom;
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
-import 'package:sky_services/flutter/platform/system_chrome.mojom.dart' as mojom;
 
 import 'constants.dart';
 import 'icon_theme.dart';

--- a/packages/flutter/lib/src/material/input.dart
+++ b/packages/flutter/lib/src/material/input.dart
@@ -14,7 +14,7 @@ import 'material.dart';
 import 'text_selection.dart';
 import 'theme.dart';
 
-export 'package:sky_services/editing/editing.mojom.dart' show KeyboardType;
+export 'package:flutter.services.editing/editing.mojom.dart' show KeyboardType;
 
 /// A material design text input field.
 ///

--- a/packages/flutter/lib/src/rendering/binding.dart
+++ b/packages/flutter/lib/src/rendering/binding.dart
@@ -4,13 +4,13 @@
 
 import 'dart:ui' as ui show window;
 
+import 'package:flutter.services.semantics/semantics.mojom.dart' as mojom;
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:flutter/services.dart';
 import 'package:meta/meta.dart';
 import 'package:mojo/core.dart' as core;
-import 'package:sky_services/semantics/semantics.mojom.dart' as mojom;
 
 import 'box.dart';
 import 'debug.dart';

--- a/packages/flutter/lib/src/rendering/child_view.dart
+++ b/packages/flutter/lib/src/rendering/child_view.dart
@@ -7,16 +7,16 @@ import 'dart:collection';
 import 'dart:ui' as ui;
 
 import 'package:flutter/services.dart';
-import 'package:mojo_services/mojo/gfx/composition/scene_token.mojom.dart' as mojom;
-import 'package:mojo_services/mojo/ui/view_containers.mojom.dart' as mojom;
-import 'package:mojo_services/mojo/ui/view_provider.mojom.dart' as mojom;
-import 'package:mojo_services/mojo/ui/view_properties.mojom.dart' as mojom;
-import 'package:mojo_services/mojo/ui/view_token.mojom.dart' as mojom;
-import 'package:mojo_services/mojo/ui/views.mojom.dart' as mojom;
-import 'package:mojo_services/mojo/geometry.mojom.dart' as mojom;
+import 'package:mojo.public.interfaces.application/service_provider.mojom.dart' as mojom;
+import 'package:mojo.services.geometry.interfaces/geometry.mojom.dart' as mojom;
+import 'package:mojo.services.gfx.composition.interfaces/scene_token.mojom.dart' as mojom;
+import 'package:mojo.services.ui.views.interfaces/view_containers.mojom.dart' as mojom;
+import 'package:mojo.services.ui.views.interfaces/view_properties.mojom.dart' as mojom;
+import 'package:mojo.services.ui.views.interfaces/view_provider.mojom.dart' as mojom;
+import 'package:mojo.services.ui.views.interfaces/view_token.mojom.dart' as mojom;
+import 'package:mojo.services.ui.views.interfaces/views.mojom.dart' as mojom;
 import 'package:mojo/application.dart';
 import 'package:mojo/core.dart' as core;
-import 'package:mojo/mojo/service_provider.mojom.dart' as mojom;
 
 import 'box.dart';
 import 'object.dart';

--- a/packages/flutter/lib/src/rendering/layer.dart
+++ b/packages/flutter/lib/src/rendering/layer.dart
@@ -6,9 +6,9 @@ import 'dart:ui' as ui show ImageFilter, Picture, SceneBuilder;
 import 'dart:ui' show Offset;
 
 import 'package:flutter/painting.dart';
-import 'package:vector_math/vector_math_64.dart';
 import 'package:meta/meta.dart';
-import 'package:mojo_services/mojo/gfx/composition/scene_token.mojom.dart' as mojom;
+import 'package:mojo.services.gfx.composition.interfaces/scene_token.mojom.dart' as mojom;
+import 'package:vector_math/vector_math_64.dart';
 
 import 'debug.dart';
 

--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -10,7 +10,7 @@ import 'package:flutter/gestures.dart';
 import 'package:flutter/painting.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:meta/meta.dart';
-import 'package:mojo_services/mojo/gfx/composition/scene_token.mojom.dart' as mojom;
+import 'package:mojo.services.gfx.composition.interfaces/scene_token.mojom.dart' as mojom;
 import 'package:vector_math/vector_math_64.dart';
 
 import 'debug.dart';

--- a/packages/flutter/lib/src/rendering/semantics.dart
+++ b/packages/flutter/lib/src/rendering/semantics.dart
@@ -5,10 +5,10 @@
 import 'dart:math' as math;
 import 'dart:ui' show Rect;
 
+import 'package:flutter.services.semantics/semantics.mojom.dart' as mojom;
 import 'package:flutter/foundation.dart';
 import 'package:flutter/painting.dart';
 import 'package:meta/meta.dart';
-import 'package:sky_services/semantics/semantics.mojom.dart' as mojom;
 import 'package:vector_math/vector_math_64.dart';
 
 import 'node.dart';

--- a/packages/flutter/lib/src/services/activity.dart
+++ b/packages/flutter/lib/src/services/activity.dart
@@ -4,11 +4,11 @@
 
 import 'dart:ui';
 
-import 'package:sky_services/activity/activity.mojom.dart';
+import 'package:flutter.services.activity/activity.mojom.dart';
 
 import 'shell.dart';
 
-export 'package:sky_services/activity/activity.mojom.dart' show Activity, Intent, ComponentName, StringExtra;
+export 'package:flutter.services.activity/activity.mojom.dart' show Activity, Intent, ComponentName, StringExtra;
 
 
 // Dart wrapper around Activity mojo service available in Flutter on Android.

--- a/packages/flutter/lib/src/services/asset_bundle.dart
+++ b/packages/flutter/lib/src/services/asset_bundle.dart
@@ -10,8 +10,8 @@ import 'dart:typed_data';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/http.dart' as http;
+import 'package:mojo.services.asset_bundle.interfaces/asset_bundle.mojom.dart' as mojom;
 import 'package:mojo/core.dart' as core;
-import 'package:mojo_services/mojo/asset_bundle/asset_bundle.mojom.dart' as mojom;
 
 import 'shell.dart';
 

--- a/packages/flutter/lib/src/services/clipboard.dart
+++ b/packages/flutter/lib/src/services/clipboard.dart
@@ -4,11 +4,11 @@
 
 import 'dart:async';
 
-import 'package:sky_services/editing/editing.mojom.dart' as mojom;
+import 'package:flutter.services.editing/editing.mojom.dart' as mojom;
 
 import 'shell.dart';
 
-export 'package:sky_services/editing/editing.mojom.dart' show ClipboardData;
+export 'package:flutter.services.editing/editing.mojom.dart' show ClipboardData;
 
 mojom.ClipboardProxy _initClipboardProxy() {
   return shell.connectToApplicationService('mojo:clipboard', mojom.Clipboard.connectToService);

--- a/packages/flutter/lib/src/services/haptic_feedback.dart
+++ b/packages/flutter/lib/src/services/haptic_feedback.dart
@@ -4,7 +4,7 @@
 
 import 'dart:async';
 
-import 'package:sky_services/flutter/platform/haptic_feedback.mojom.dart' as mojom;
+import 'package:flutter.services.platform/haptic_feedback.mojom.dart' as mojom;
 
 import 'shell.dart';
 

--- a/packages/flutter/lib/src/services/host_messages.dart
+++ b/packages/flutter/lib/src/services/host_messages.dart
@@ -5,8 +5,8 @@
 import 'dart:async';
 import 'dart:convert';
 
+import 'package:flutter.services.platform/app_messages.mojom.dart' as mojom;
 import 'package:mojo/core.dart' as core;
-import 'package:sky_services/flutter/platform/app_messages.mojom.dart' as mojom;
 
 import 'shell.dart';
 

--- a/packages/flutter/lib/src/services/keyboard.dart
+++ b/packages/flutter/lib/src/services/keyboard.dart
@@ -4,11 +4,11 @@
 
 import 'dart:async';
 
-import 'package:sky_services/editing/editing.mojom.dart' as mojom;
+import 'package:flutter.services.editing/editing.mojom.dart' as mojom;
 
 import 'shell.dart';
 
-export 'package:sky_services/editing/editing.mojom.dart' show KeyboardType;
+export 'package:flutter.services.editing/editing.mojom.dart' show KeyboardType;
 
 /// An interface to the system's keyboard.
 ///

--- a/packages/flutter/lib/src/services/path_provider.dart
+++ b/packages/flutter/lib/src/services/path_provider.dart
@@ -5,7 +5,7 @@
 import 'dart:async';
 import 'dart:io';
 
-import 'package:sky_services/flutter/platform/path_provider.mojom.dart' as mojom;
+import 'package:flutter.services.platform/path_provider.mojom.dart' as mojom;
 
 import 'shell.dart';
 

--- a/packages/flutter/lib/src/services/shell.dart
+++ b/packages/flutter/lib/src/services/shell.dart
@@ -4,11 +4,11 @@
 
 import 'dart:ui' as ui;
 
+import 'package:mojo.public.interfaces.application/service_provider.mojom.dart' as mojom;
+import 'package:mojo.public.interfaces.application/shell.mojom.dart' as mojom;
 import 'package:mojo/application.dart';
 import 'package:mojo/bindings.dart' as bindings;
 import 'package:mojo/core.dart' as core;
-import 'package:mojo/mojo/service_provider.mojom.dart' as mojom;
-import 'package:mojo/mojo/shell.mojom.dart' as mojom;
 
 /// Signature for connecting to services. The generated mojom.dart code has
 /// static functions that match this signature on the interface objects. For

--- a/packages/flutter/lib/src/services/system_chrome.dart
+++ b/packages/flutter/lib/src/services/system_chrome.dart
@@ -4,13 +4,13 @@
 
 import 'dart:async';
 
-import 'package:sky_services/flutter/platform/system_chrome.mojom.dart' as mojom;
-import 'package:sky_services/flutter/platform/system_chrome.mojom.dart'
+import 'package:flutter.services.platform/system_chrome.mojom.dart' as mojom;
+import 'package:flutter.services.platform/system_chrome.mojom.dart'
     show DeviceOrientation, SystemUiOverlay, SystemUiOverlayStyle;
 
 import 'shell.dart';
 
-export 'package:sky_services/flutter/platform/system_chrome.mojom.dart'
+export 'package:flutter.services.platform/system_chrome.mojom.dart'
     show DeviceOrientation, SystemUiOverlay, SystemUiOverlayStyle;
 
 mojom.SystemChromeProxy _initSystemChromeProxy() {

--- a/packages/flutter/lib/src/services/system_sound.dart
+++ b/packages/flutter/lib/src/services/system_sound.dart
@@ -4,12 +4,12 @@
 
 import 'dart:async';
 
-import 'package:sky_services/flutter/platform/system_sound.mojom.dart' as mojom;
-import 'package:sky_services/flutter/platform/system_sound.mojom.dart' show SystemSoundType;
+import 'package:flutter.services.platform/system_sound.mojom.dart' as mojom;
+import 'package:flutter.services.platform/system_sound.mojom.dart' show SystemSoundType;
 
 import 'shell.dart';
 
-export 'package:sky_services/flutter/platform/system_sound.mojom.dart' show SystemSoundType;
+export 'package:flutter.services.platform/system_sound.mojom.dart' show SystemSoundType;
 
 mojom.SystemSoundProxy _initSystemSoundProxy() {
   return shell.connectToApplicationService('mojo:flutter_platform', mojom.SystemSound.connectToService);

--- a/packages/flutter/lib/src/services/url_launcher.dart
+++ b/packages/flutter/lib/src/services/url_launcher.dart
@@ -4,7 +4,7 @@
 
 import 'dart:async';
 
-import 'package:sky_services/flutter/platform/url_launcher.mojom.dart' as mojom;
+import 'package:flutter.services.platform/url_launcher.mojom.dart' as mojom;
 import 'shell.dart';
 
 mojom.UrlLauncherProxy _initUrlLauncherProxy() {

--- a/packages/flutter/lib/src/widgets/editable.dart
+++ b/packages/flutter/lib/src/widgets/editable.dart
@@ -4,10 +4,10 @@
 
 import 'dart:async';
 
+import 'package:flutter.services.editing/editing.mojom.dart' as mojom;
 import 'package:flutter/rendering.dart' show RenderEditableLine, SelectionChangedHandler;
 import 'package:flutter/services.dart';
 import 'package:meta/meta.dart';
-import 'package:sky_services/editing/editing.mojom.dart' as mojom;
 
 import 'basic.dart';
 import 'framework.dart';
@@ -17,7 +17,7 @@ import 'scroll_behavior.dart';
 import 'text_selection.dart';
 
 export 'package:flutter/painting.dart' show TextSelection;
-export 'package:sky_services/editing/editing.mojom.dart' show KeyboardType;
+export 'package:flutter.services.editing/editing.mojom.dart' show KeyboardType;
 
 const Duration _kCursorBlinkHalfPeriod = const Duration(milliseconds: 500);
 

--- a/packages/flutter/lib/src/widgets/raw_keyboard_listener.dart
+++ b/packages/flutter/lib/src/widgets/raw_keyboard_listener.dart
@@ -2,9 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:flutter.services.engine/input_event.mojom.dart' as mojom;
+import 'package:flutter.services.raw_keyboard/raw_keyboard.mojom.dart' as mojom;
 import 'package:flutter/services.dart';
-import 'package:sky_services/raw_keyboard/raw_keyboard.mojom.dart' as mojom;
-import 'package:sky_services/sky/input_event.mojom.dart' as mojom;
 
 import 'basic.dart';
 import 'framework.dart';

--- a/packages/flutter/lib/src/widgets/semantics_debugger.dart
+++ b/packages/flutter/lib/src/widgets/semantics_debugger.dart
@@ -5,10 +5,10 @@
 import 'dart:collection';
 import 'dart:math' as math;
 
+import 'package:flutter.services.semantics/semantics.mojom.dart' as mojom;
 import 'package:flutter/foundation.dart';
-import 'package:flutter/scheduler.dart';
 import 'package:flutter/rendering.dart';
-import 'package:sky_services/semantics/semantics.mojom.dart' as mojom;
+import 'package:flutter/scheduler.dart';
 
 import 'basic.dart';
 import 'binding.dart';

--- a/packages/flutter/test/gestures/gesture_binding_test.dart
+++ b/packages/flutter/test/gestures/gesture_binding_test.dart
@@ -4,10 +4,10 @@
 
 import 'dart:ui' as ui;
 
+import 'package:flutter.services.pointer/pointer.mojom.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:mojo/bindings.dart' as mojo_bindings;
-import 'package:sky_services/pointer/pointer.mojom.dart';
 import 'package:test/test.dart';
 
 typedef void HandleEventCallback(PointerEvent event);

--- a/packages/flutter/test/rendering/test_semantics_client.dart
+++ b/packages/flutter/test/rendering/test_semantics_client.dart
@@ -3,7 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:flutter/rendering.dart';
-import 'package:sky_services/semantics/semantics.mojom.dart' as mojom;
+import 'package:flutter.services.semantics/semantics.mojom.dart' as mojom;
 
 class TestSemanticsClient {
   TestSemanticsClient(PipelineOwner pipelineOwner) {

--- a/packages/flutter/test/services/system_chrome_test.dart
+++ b/packages/flutter/test/services/system_chrome_test.dart
@@ -4,7 +4,7 @@
 
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:sky_services/flutter/platform/system_chrome.mojom.dart' as mojom;
+import 'package:flutter.services.flutter/platform/system_chrome.mojom.dart' as mojom;
 
 void main() {
   testWidgets('SystemChrome overlay style test', (WidgetTester tester) async {

--- a/packages/flutter/test/widget/buttons_test.dart
+++ b/packages/flutter/test/widget/buttons_test.dart
@@ -2,10 +2,10 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:flutter.services.semantics/semantics.mojom.dart' as mojom;
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:sky_services/semantics/semantics.mojom.dart' as mojom;
 
 import '../rendering/test_semantics_client.dart';
 

--- a/packages/flutter/test/widget/form_test.dart
+++ b/packages/flutter/test/widget/form_test.dart
@@ -2,9 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter.services.editing/editing.mojom.dart' as mojom;
 import 'package:flutter/material.dart';
-import 'package:sky_services/editing/editing.mojom.dart' as mojom;
+import 'package:flutter_test/flutter_test.dart';
 
 class MockKeyboard extends mojom.KeyboardProxy {
   MockKeyboard() : super.unbound();

--- a/packages/flutter/test/widget/input_test.dart
+++ b/packages/flutter/test/widget/input_test.dart
@@ -4,10 +4,10 @@
 
 import 'dart:async';
 
-import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter.services.editing/editing.mojom.dart' as mojom;
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
-import 'package:sky_services/editing/editing.mojom.dart' as mojom;
+import 'package:flutter_test/flutter_test.dart';
 
 class MockKeyboard extends mojom.KeyboardProxy {
   MockKeyboard() : super.unbound();

--- a/packages/flutter/test/widget/semantics_7_test.dart
+++ b/packages/flutter/test/widget/semantics_7_test.dart
@@ -2,10 +2,10 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:flutter.services.semantics/semantics.mojom.dart' as mojom;
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:sky_services/semantics/semantics.mojom.dart' as mojom;
 
 import '../rendering/test_semantics_client.dart';
 

--- a/packages/flutter/test/widget/semantics_test.dart
+++ b/packages/flutter/test/widget/semantics_test.dart
@@ -2,10 +2,10 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:flutter.services.semantics/semantics.mojom.dart' as mojom;
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:sky_services/semantics/semantics.mojom.dart' as mojom;
 
 import '../rendering/test_semantics_client.dart';
 

--- a/packages/flutter_sprites/lib/flutter_sprites.dart
+++ b/packages/flutter_sprites/lib/flutter_sprites.dart
@@ -12,6 +12,7 @@ import 'dart:math' as math;
 import 'dart:typed_data';
 import 'dart:ui' as ui show Image;
 
+import 'package:flutter.services.media/media.mojom.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/scheduler.dart';
@@ -19,7 +20,6 @@ import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 import 'package:meta/meta.dart';
 import 'package:mojo/core.dart';
-import 'package:sky_services/media/media.mojom.dart';
 import 'package:vector_math/vector_math_64.dart';
 
 part 'src/action.dart';


### PR DESCRIPTION
With this, mojom.dart files are generated into one place in the
outdir with the path and package determined by the location of the
mojom target (and not a DartPackage annotation). This means dart
packages need to declare their dependency on the correct mojom rules
and import statements have to match the generated name.
