### PR TITLE
Suppress pub warning of expected analyzer override (#5921).

### DIFF
--- a/bin/flutter
+++ b/bin/flutter
@@ -41,7 +41,25 @@ DART="$DART_SDK_PATH/bin/dart"
 
     echo Building flutter tool...
     FLUTTER_DIR="$FLUTTER_ROOT/packages/flutter"
-    (cd "$FLUTTER_TOOLS_DIR"; "../../bin/cache/dart-sdk/bin/pub" get --verbosity=warning)
+
+    # Capture pub output for filtering expected analyzer dependency warning.
+    PUB_OUT=`({(cd "$FLUTTER_TOOLS_DIR"; "../../bin/cache/dart-sdk/bin/pub" get --verbosity=warning)} 2>&1)`
+    ISSUE_COUNT=`(grep -o "Warning:\|Error:" <<< $PUB_OUT | wc -l)`
+    if [ $ISSUE_COUNT -gt 0 ]; then
+      # Filter out expected analyzer warning.
+      if [ $ISSUE_COUNT -eq 1 ]; then
+        if grep -q "dart-sdk/lib/analyzer" <<< $PUB_OUT; then
+          # But only of overridden dependencies.
+          if grep -q -v "overridden dependencies" <<< $PUB_OUT; then
+            echo $PUB_OUT
+          fi
+        # If there's more than one issue, display them all.  
+        else
+          echo $PUB_OUT
+        fi
+      fi
+    fi
+
     "$DART" --snapshot="$SNAPSHOT_PATH" --packages="$FLUTTER_TOOLS_DIR/.packages" "$SCRIPT_PATH"
     echo $REVISION > "$STAMP_PATH"
   fi


### PR DESCRIPTION
Captures `pub get` output and filters out expected warning about overridden `analyzer` dependency.

For reference, here's the format of the warning this suppresses:

``` shell
Warning: You are using these overridden dependencies: ! analyzer 0.29.0-alpha.0 from path ../../bin/cache/dart-sdk/lib/analyzer
```

I tried to be careful to _only_ suppress that warning and I'm sure this could be done in a cleverer way; if you see something neater, suggestions welcome! 👍 

Fixes https://github.com/flutter/flutter/issues/5921.

/cc @abarth @Hixie @danrubel 
