### PR TITLE
Add `@protected` to AnimatedWidget build function

### DIFF
--- a/packages/flutter/lib/src/widgets/transitions.dart
+++ b/packages/flutter/lib/src/widgets/transitions.dart
@@ -35,6 +35,7 @@ abstract class AnimatedWidget extends StatefulWidget {
 
   /// Override this method to build widgets that depend on the current value
   /// of the animation.
+  @protected
   Widget build(BuildContext context);
 
   /// Subclasses typically do not override this method.


### PR DESCRIPTION
We use `@protected` in this way in StatelessWidget to avoid developers calling
this function directly.
