### PR TITLE
Change the definition of MainAxisSize

### DIFF
--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -1856,15 +1856,16 @@ class Flex extends MultiChildRenderObjectWidget {
   /// How the children should be placed along the main axis.
   final MainAxisAlignment mainAxisAlignment;
 
-  /// The limit that defines how much space is available along the main axis.
+  /// How much space space should be occupied in the main axis.
   ///
-  /// By default the size of this widget will be as big as the incoming
-  /// max constraint. In other words it will become as big as possible
-  /// along its main axis by growing [Flexible] children and inserting
-  /// space between children per the [mainAxisAlignment] parameter.
-  /// If mainAxisSize is [MainAxisSize.min] then this widget's size along
-  /// the main axis will be as small as possible. This version of the layout
-  /// is sometimes referred to as "shrink wrapping".
+  /// After allocating space to children, there might be some remaining free
+  /// space. This value controls whether to maximize or minimize the amount of
+  /// free space, subject to the incoming layout contraints.
+  ///
+  /// If some children have a non-zero flex factors (and none have a fit of
+  /// [FlexFit.loose]), they will expand to consume all the available space and
+  /// there will be no remaining free space to maximize or minimize, making this
+  /// value irrelevant to the final layout.
   final MainAxisSize mainAxisSize;
 
   /// How the children should be placed along the cross axis.

--- a/packages/flutter/test/rendering/flex_test.dart
+++ b/packages/flutter/test/rendering/flex_test.dart
@@ -194,6 +194,7 @@ void main() {
     }
 
     setFit(box1, FlexFit.loose);
+    flex.markNeedsLayout();
 
     pumpFrame();
     expect(getOffset(box1).dx, equals(0.0));
@@ -212,5 +213,60 @@ void main() {
     expect(box2.size.width, equals(100.0));
     expect(getOffset(box3).dx, equals(400.0));
     expect(box3.size.width, equals(100.0));
+  });
+
+  test('Flexible with MainAxisSize.min', () {
+    RenderConstrainedBox box1 = new RenderConstrainedBox(additionalConstraints: new BoxConstraints.tightFor(width: 100.0, height: 100.0));
+    RenderConstrainedBox box2 = new RenderConstrainedBox(additionalConstraints: new BoxConstraints.tightFor(width: 100.0, height: 100.0));
+    RenderConstrainedBox box3 = new RenderConstrainedBox(additionalConstraints: new BoxConstraints.tightFor(width: 100.0, height: 100.0));
+    RenderFlex flex = new RenderFlex(
+      mainAxisSize: MainAxisSize.min,
+      mainAxisAlignment: MainAxisAlignment.spaceBetween
+    );
+    flex.addAll(<RenderBox>[box1, box2, box3]);
+    layout(flex, constraints: const BoxConstraints(
+      minWidth: 0.0, maxWidth: 500.0, minHeight: 0.0, maxHeight: 400.0)
+    );
+    Offset getOffset(RenderBox box) {
+      FlexParentData parentData = box.parentData;
+      return parentData.offset;
+    }
+    expect(getOffset(box1).dx, equals(0.0));
+    expect(box1.size.width, equals(100.0));
+    expect(getOffset(box2).dx, equals(100.0));
+    expect(box2.size.width, equals(100.0));
+    expect(getOffset(box3).dx, equals(200.0));
+    expect(box3.size.width, equals(100.0));
+    expect(flex.size.width, equals(300.0));
+
+    void setFit(RenderBox box, FlexFit fit) {
+      FlexParentData parentData = box.parentData;
+      parentData.flex = 1;
+      parentData.fit = fit;
+    }
+
+    setFit(box1, FlexFit.tight);
+    flex.markNeedsLayout();
+
+    pumpFrame();
+    expect(getOffset(box1).dx, equals(0.0));
+    expect(box1.size.width, equals(300.0));
+    expect(getOffset(box2).dx, equals(300.0));
+    expect(box2.size.width, equals(100.0));
+    expect(getOffset(box3).dx, equals(400.0));
+    expect(box3.size.width, equals(100.0));
+    expect(flex.size.width, equals(500.0));
+
+    setFit(box1, FlexFit.loose);
+    flex.markNeedsLayout();
+
+    pumpFrame();
+    expect(getOffset(box1).dx, equals(0.0));
+    expect(box1.size.width, equals(100.0));
+    expect(getOffset(box2).dx, equals(100.0));
+    expect(box2.size.width, equals(100.0));
+    expect(getOffset(box3).dx, equals(200.0));
+    expect(box3.size.width, equals(100.0));
+    expect(flex.size.width, equals(300.0));
   });
 }


### PR DESCRIPTION
This property now applies only to the free space in the flex layout (i.e.,
minimize or maximize the amount of free space). Previously, the flexible
children were always allocated a size of zero when MainAxisSize was min. Now
they're allocated the same size that would be if the MainAxisSize was max.
