### PR TITLE
Fix crash when a RenderObject tree is rooted in a non-RenderObject environment

### DIFF
--- a/dev/devicelab/test/run_test.dart
+++ b/dev/devicelab/test/run_test.dart
@@ -35,7 +35,7 @@ void main() {
 
     test('Exits with code 1 when fails to connect', () async {
       expect(await runScript(<String>['smoke_test_setup_failure']), 1);
-    });
+    }, skip: true); // https://github.com/flutter/flutter/issues/5901
 
     test('Exits with code 1 when results are mixed', () async {
       expect(

--- a/packages/flutter/lib/src/rendering/binding.dart
+++ b/packages/flutter/lib/src/rendering/binding.dart
@@ -26,7 +26,11 @@ abstract class RendererBinding extends BindingBase implements SchedulerBinding, 
   void initInstances() {
     super.initInstances();
     _instance = this;
-    _pipelineOwner = new PipelineOwner(onNeedVisualUpdate: ensureVisualUpdate);
+    _pipelineOwner = new PipelineOwner(
+      onNeedVisualUpdate: ensureVisualUpdate,
+      onScheduleInitialSemantics: _scheduleInitialSemantics,
+      onClearSemantics: _clearSemantics,
+    );
     ui.window.onMetricsChanged = handleMetricsChanged;
     initRenderView();
     initSemantics();
@@ -96,12 +100,12 @@ abstract class RendererBinding extends BindingBase implements SchedulerBinding, 
   PipelineOwner _pipelineOwner;
 
   /// The render tree that's attached to the output surface.
-  RenderView get renderView => _pipelineOwner.rootRenderObject;
+  RenderView get renderView => _pipelineOwner.rootNode;
   /// Sets the given [RenderView] object (which must not be null), and its tree, to
   /// be the new render tree to display. The previous tree, if any, is detached.
   set renderView(RenderView value) {
     assert(value != null);
-    _pipelineOwner.rootRenderObject = value;
+    _pipelineOwner.rootNode = value;
   }
 
   /// Called when the system metrics change.
@@ -210,7 +214,7 @@ abstract class RendererBinding extends BindingBase implements SchedulerBinding, 
   @override
   void reassembleApplication() {
     super.reassembleApplication();
-    pipelineOwner.reassemble();
+    renderView.reassemble();
     handleBeginFrame(null);
   }
 
@@ -228,6 +232,14 @@ abstract class RendererBinding extends BindingBase implements SchedulerBinding, 
       child.visitChildren(visitor);
     };
     instance?.renderView?.visitChildren(visitor);
+  }
+
+  void _scheduleInitialSemantics() {
+    renderView.scheduleInitialSemantics();
+  }
+
+  void _clearSemantics() {
+    renderView.clearSemantics();
   }
 }
 

--- a/packages/flutter/lib/src/rendering/node.dart
+++ b/packages/flutter/lib/src/rendering/node.dart
@@ -76,6 +76,9 @@ class AbstractNode {
   ///
   /// Typically called only from the parent's attach(), and to mark the root of
   /// a tree attached.
+  ///
+  /// Subclasses with children should attach all their children to the same
+  /// [owner] whenever this method is called.
   @mustCallSuper
   void attach(Object owner) {
     assert(owner != null);
@@ -87,6 +90,9 @@ class AbstractNode {
   ///
   /// Typically called only from the parent's detach(), and to mark the root of
   /// a tree detached.
+  ///
+  /// Subclasses with children should detach all their children whenever this
+  /// method is called.
   @mustCallSuper
   void detach() {
     assert(_owner != null);

--- a/packages/flutter/test/rendering/non_render_object_root_test.dart
+++ b/packages/flutter/test/rendering/non_render_object_root_test.dart
@@ -1,0 +1,62 @@
+// Copyright 2015 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+import 'package:test/test.dart';
+
+import 'rendering_tester.dart';
+
+class RealRoot extends AbstractNode {
+  RealRoot(this.child) {
+    if (child != null)
+      adoptChild(child);
+  }
+
+  final RenderObject child;
+
+  @override
+  void redepthChildren() {
+    if (child != null)
+      redepthChild(child);
+  }
+
+  @override
+  void attach(Object owner) {
+    super.attach(owner);
+    child?.attach(owner);
+  }
+
+  @override
+  void detach() {
+    super.detach();
+    child?.detach();
+  }
+
+  @override
+  PipelineOwner get owner => super.owner;
+
+  void layout() {
+    child?.layout(new BoxConstraints.tight(const Size(500.0, 500.0)));
+  }
+}
+
+void main() {
+  test("non-RenderObject roots", () {
+    RenderPositionedBox child;
+    RealRoot root = new RealRoot(
+      child = new RenderPositionedBox(
+        alignment: FractionalOffset.center,
+        child: new RenderSizedBox(new Size(100.0, 100.0))
+      )
+    );
+    root.attach(new PipelineOwner());
+
+    child.scheduleInitialLayout();
+    root.layout();
+
+    child.markNeedsLayout();
+    root.layout();
+  });
+}


### PR DESCRIPTION
This is just a one line fix, in principle, but to write the test I had to refactor PipelineOwner...
