### PR TITLE
Restore Flutter gallery license page scrolling

### DIFF
--- a/examples/flutter_gallery/README.md
+++ b/examples/flutter_gallery/README.md
@@ -20,6 +20,11 @@ the [Flutter Setup](https://flutter.io/setup/) guide.
 
 The `flutter run --release` command both builds and installs the Flutter app.
 
+## Prerelease checklist
+
+* Verify that the About box's license page scrolls and reveals its long
+long stream of license texts.
+
 ## Icon
 
 Android launcher icons were generated using Android Asset Studio:

--- a/packages/flutter/lib/src/widgets/lazy_block.dart
+++ b/packages/flutter/lib/src/widgets/lazy_block.dart
@@ -272,6 +272,7 @@ class LazyBlock extends StatelessWidget {
           minScrollOffset: minScrollOffset,
           scrollOffset: state.scrollOffset
         ));
+        state.updateGestureDetector();
       },
       delegate: delegate
     );

--- a/packages/flutter/test/widget/lazy_block_test.dart
+++ b/packages/flutter/test/widget/lazy_block_test.dart
@@ -53,7 +53,7 @@ void main() {
   });
 
 
-  testWidgets('Underflowing LazyBlock contentExtent should track additional children ', (WidgetTester tester) async {
+  testWidgets('Underflowing LazyBlock contentExtent should track additional children', (WidgetTester tester) async {
     await tester.pumpWidget(new LazyBlock(
       delegate: new LazyBlockChildren(
         children: <Widget>[
@@ -154,5 +154,38 @@ void main() {
     OverscrollWhenScrollableBehavior scrollBehavior = scrollable.scrollBehavior;
     expect(scrollBehavior.contentExtent, equals(700.0));
   });
+
+  testWidgets('Overflowing LazyBlock should become scrollable', (WidgetTester tester) async {
+    // Regression test for https://github.com/flutter/flutter/issues/5920
+    // When a LazyBlock's viewport hasn't overflowed, scrolling is disabled.
+    // When children are added that cause it to overflow, scrolling should
+    // be enabled.
+
+    await tester.pumpWidget(new LazyBlock(
+      delegate: new LazyBlockChildren(
+        children: <Widget>[
+          new SizedBox(height: 100.0, child: new Text('100')),
+        ]
+      )
+    ));
+
+    StatefulElement statefulElement = tester.element(find.byType(Scrollable));
+    ScrollableState scrollable = statefulElement.state;
+    OverscrollWhenScrollableBehavior scrollBehavior = scrollable.scrollBehavior;
+    expect(scrollBehavior.isScrollable, isFalse);
+
+    await tester.pumpWidget(new LazyBlock(
+      delegate: new LazyBlockChildren(
+        children: <Widget>[
+          new SizedBox(height: 100.0, child: new Text('100')),
+          new SizedBox(height: 200.0, child: new Text('200')),
+          new SizedBox(height: 400.0, child: new Text('400')),
+        ]
+      )
+    ));
+
+    expect(scrollBehavior.isScrollable, isTrue);
+  });
+
 
 }


### PR DESCRIPTION
LazyBlock wasn't updating its scrollable's gesture detector when the length of its contents changed.

A regression test isn't included because the flutter license registry isn't populated for tests.  I've started a prerelease checklist for things that will need to be verified manually.

Fixes #5920
