### PR TITLE
update flutter run --release to launch and exit

### DIFF
--- a/packages/flutter_tools/lib/src/run.dart
+++ b/packages/flutter_tools/lib/src/run.dart
@@ -8,6 +8,7 @@ import 'dart:io';
 import 'application_package.dart';
 import 'base/logger.dart';
 import 'base/utils.dart';
+import 'build_info.dart';
 import 'commands/build_apk.dart';
 import 'commands/install.dart';
 import 'commands/trace.dart';
@@ -184,6 +185,8 @@ class RunAndStayResident extends ResidentRunner {
     }
 
     printStatus('Application running.');
+    if (debuggingOptions.buildMode == BuildMode.release)
+      return 0;
 
     if (vmService != null) {
       await vmService.vm.refreshViews();


### PR DESCRIPTION
The `flutter run --release` command has no connection to the application it launches. 

This change causes the `flutter run --release` command line to exit once the specified application has been successfully launched without waiting for the launched application to terminate.

Fixes https://github.com/flutter/flutter/issues/5825
@Hixie cc @sethladd 
