### PR TITLE
remove ignore unawaited_future comments

### DIFF
--- a/dev/devicelab/lib/framework/runner.dart
+++ b/dev/devicelab/lib/framework/runner.dart
@@ -34,7 +34,6 @@ Future<Map<String, dynamic>> runTask(String taskName) async {
 
   bool runnerFinished = false;
 
-  // ignore: unawaited_futures
   runner.exitCode.then((_) {
     runnerFinished = true;
   });

--- a/dev/devicelab/lib/framework/utils.dart
+++ b/dev/devicelab/lib/framework/utils.dart
@@ -166,7 +166,6 @@ Future<Process> startProcess(String executable, List<String> arguments,
   ProcessInfo procInfo = new ProcessInfo(command, proc);
   _runningProcesses.add(procInfo);
 
-  // ignore: unawaited_futures
   proc.exitCode.then((_) {
     _runningProcesses.remove(procInfo);
   });


### PR DESCRIPTION
Based upon conversation in https://github.com/flutter/flutter/pull/5947 I want to remove `// ignore: unawaited_future` comments until the [unawaited_future should not warn if .then block is present](https://github.com/dart-lang/sdk/issues/27401) can be resolved.
@Hixie 
