### PR TITLE
Disallow back gestures during a page transition.

### DIFF
--- a/packages/flutter/lib/src/material/page.dart
+++ b/packages/flutter/lib/src/material/page.dart
@@ -202,6 +202,8 @@ class MaterialPageRoute<T> extends PageRoute<T> {
 
   @override
   NavigationGestureController startPopGesture(NavigatorState navigator) {
+    if (controller.status != AnimationStatus.completed)
+      return null;
     assert(_backGestureController == null);
     _backGestureController = new _CupertinoBackGestureController(
       navigator: navigator,


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/5973
