### PR TITLE
Draggable should have an affinity that selects an axis

### DIFF
--- a/packages/flutter/test/widget/draggable_test.dart
+++ b/packages/flutter/test/widget/draggable_test.dart
@@ -315,15 +315,17 @@ void main() {
             }
           ),
           new Container(height: 400.0),
-          new HorizontalDraggable<int>(
+          new Draggable<int>(
             data: 1,
             child: new Text('H'),
-            feedback: new Text('Dragging')
+            feedback: new Text('Dragging'),
+            affinity: Axis.horizontal,
           ),
-          new VerticalDraggable<int>(
+          new Draggable<int>(
             data: 2,
             child: new Text('V'),
-            feedback: new Text('Dragging')
+            feedback: new Text('Dragging'),
+            affinity: Axis.vertical,
           ),
           new Container(height: 500.0),
           new Container(height: 500.0),
@@ -420,15 +422,17 @@ void main() {
             }
           ),
           new Container(width: 400.0),
-          new HorizontalDraggable<int>(
+          new Draggable<int>(
             data: 1,
             child: new Text('H'),
-            feedback: new Text('Dragging')
+            feedback: new Text('Dragging'),
+            affinity: Axis.horizontal,
           ),
-          new VerticalDraggable<int>(
+          new Draggable<int>(
             data: 2,
             child: new Text('V'),
-            feedback: new Text('Dragging')
+            feedback: new Text('Dragging'),
+            affinity: Axis.vertical,
           ),
           new Container(width: 500.0),
           new Container(width: 500.0),


### PR DESCRIPTION
This structure for the API is hopefully less confusing that the previous one
(which implied that vertical drags would not trigger horizontally draggable
widgets).

Fixes #1987
