### PR TITLE
Fixed tabs fling velocity threshold

### DIFF
--- a/packages/flutter/lib/src/material/bottom_sheet.dart
+++ b/packages/flutter/lib/src/material/bottom_sheet.dart
@@ -10,7 +10,6 @@ import 'colors.dart';
 import 'material.dart';
 
 const Duration _kBottomSheetDuration = const Duration(milliseconds: 200);
-const double _kMinFlingVelocity = 700.0;
 const double _kCloseProgressThreshold = 0.5;
 const Color _kTransparent = const Color(0x00000000);
 const Color _kBarrierColor = Colors.black54;
@@ -106,7 +105,7 @@ class _BottomSheetState extends State<BottomSheet> {
   void _handleDragEnd(DragEndDetails details) {
     if (_dismissUnderway)
       return;
-    if (details.velocity.pixelsPerSecond.dy > _kMinFlingVelocity) {
+    if (details.velocity.pixelsPerSecond.dy > kPixelScrollTolerance.velocity) {
       double flingVelocity = -details.velocity.pixelsPerSecond.dy / _childHeight;
       if (config.animationController.value > 0.0)
         config.animationController.fling(velocity: flingVelocity);

--- a/packages/flutter/lib/src/material/bottom_sheet.dart
+++ b/packages/flutter/lib/src/material/bottom_sheet.dart
@@ -10,6 +10,7 @@ import 'colors.dart';
 import 'material.dart';
 
 const Duration _kBottomSheetDuration = const Duration(milliseconds: 200);
+const double _kMinFlingVelocity = 700.0;
 const double _kCloseProgressThreshold = 0.5;
 const Color _kTransparent = const Color(0x00000000);
 const Color _kBarrierColor = Colors.black54;
@@ -105,7 +106,7 @@ class _BottomSheetState extends State<BottomSheet> {
   void _handleDragEnd(DragEndDetails details) {
     if (_dismissUnderway)
       return;
-    if (details.velocity.pixelsPerSecond.dy > kPixelScrollTolerance.velocity) {
+    if (details.velocity.pixelsPerSecond.dy > _kMinFlingVelocity) {
       double flingVelocity = -details.velocity.pixelsPerSecond.dy / _childHeight;
       if (config.animationController.value > 0.0)
         config.animationController.fling(velocity: flingVelocity);

--- a/packages/flutter/lib/src/material/tabs.dart
+++ b/packages/flutter/lib/src/material/tabs.dart
@@ -37,10 +37,9 @@ const Duration _kTabBarScroll = const Duration(milliseconds: 200);
 const Curve _kTabIndicatorLeadingCurve = Curves.easeOut;
 const Curve _kTabIndicatorTrailingCurve = Curves.easeIn;
 
-// The scrollOffset (velocity) provided to fling() is pixels/ms, and the
-// tolerance velocity is pixels/sec. The additional factor of 5 is to further
-// increase sensitivity to swipe gestures and was determined "experimentally".
-final double _kMinFlingVelocity = kPixelScrollTolerance.velocity / 5000.0;
+// The additional factor of 5 is to further increase sensitivity to swipe
+// gestures and was determined "experimentally".
+final double _kMinFlingVelocity = kPixelScrollTolerance.velocity / 5.0;
 
 class _TabBarParentData extends ContainerBoxParentDataMixin<RenderBox> { }
 

--- a/packages/flutter/test/material/tabs_test.dart
+++ b/packages/flutter/test/material/tabs_test.dart
@@ -171,7 +171,7 @@ void main() {
 
     // Fling-scroll the TabBar to the left
     expect(tester.getCenter(find.text('HHHHHH')).x, lessThan(700.0));
-    await tester.fling(find.byKey(tabBarKey), const Offset(-20.0, 0.0), 1000.0);
+    await tester.fling(find.byKey(tabBarKey), const Offset(-200.0, 0.0), 10000.0);
     await tester.pump();
     await tester.pump(const Duration(seconds: 1)); // finish the scroll animation
     expect(tester.getCenter(find.text('HHHHHH')).x, lessThan(500.0));
@@ -267,7 +267,7 @@ void main() {
 
     // Fling to the left, switch from the 'LEFT' tab to the 'RIGHT'
     Point flingStart = tester.getCenter(find.text('LEFT CHILD'));
-    await tester.flingFrom(flingStart, new Offset(-200.0, 0.0), 1000.0);
+    await tester.flingFrom(flingStart, new Offset(-200.0, 0.0), 10000.0);
     await tester.pump();
     await tester.pump(const Duration(seconds: 1)); // finish the scroll animation
     expect(selection.value, equals('RIGHT'));
@@ -276,7 +276,7 @@ void main() {
 
     // Fling to the right, switch back to the 'LEFT' tab
     flingStart = tester.getCenter(find.text('RIGHT CHILD'));
-    await tester.flingFrom(flingStart, new Offset(200.0, 0.0), 1000.0);
+    await tester.flingFrom(flingStart, new Offset(200.0, 0.0), 10000.0);
     await tester.pump();
     await tester.pump(const Duration(seconds: 1)); // finish the scroll animation
     expect(selection.value, equals('LEFT'));
@@ -301,7 +301,7 @@ void main() {
     // a change to the selected tab, everything should just settle back to
     // to where it started.
     Point flingStart = tester.getCenter(find.text('LEFT CHILD'));
-    await tester.flingFrom(flingStart, new Offset(-200.0, 0.0), -1000.0);
+    await tester.flingFrom(flingStart, new Offset(-200.0, 0.0), -10000.0);
     await tester.pump();
     await tester.pump(const Duration(seconds: 1)); // finish the scroll animation
     expect(selection.value, equals('LEFT'));


### PR DESCRIPTION
The scrollable tabs fling logic hadn't been updated to reflect the fact that fling velocities are reported in pixels/sec.
