### PR TITLE
suppress pub override warning; decouple the analyzer versions

### DIFF
--- a/bin/flutter
+++ b/bin/flutter
@@ -41,7 +41,7 @@ DART="$DART_SDK_PATH/bin/dart"
 
     echo Building flutter tool...
     FLUTTER_DIR="$FLUTTER_ROOT/packages/flutter"
-    (cd "$FLUTTER_TOOLS_DIR"; "../../bin/cache/dart-sdk/bin/pub" get --verbosity=error)
+    (cd "$FLUTTER_TOOLS_DIR"; "../../bin/cache/dart-sdk/bin/pub" get --verbosity=error --no-packages-dir)
     "$DART" --snapshot="$SNAPSHOT_PATH" --packages="$FLUTTER_TOOLS_DIR/.packages" "$SCRIPT_PATH"
     echo $REVISION > "$STAMP_PATH"
   fi

--- a/bin/flutter
+++ b/bin/flutter
@@ -41,7 +41,7 @@ DART="$DART_SDK_PATH/bin/dart"
 
     echo Building flutter tool...
     FLUTTER_DIR="$FLUTTER_ROOT/packages/flutter"
-    (cd "$FLUTTER_TOOLS_DIR"; "../../bin/cache/dart-sdk/bin/pub" get --verbosity=warning)
+    (cd "$FLUTTER_TOOLS_DIR"; "../../bin/cache/dart-sdk/bin/pub" get --verbosity=error)
     "$DART" --snapshot="$SNAPSHOT_PATH" --packages="$FLUTTER_TOOLS_DIR/.packages" "$SCRIPT_PATH"
     echo $REVISION > "$STAMP_PATH"
   fi

--- a/dev/devicelab/pubspec.yaml
+++ b/dev/devicelab/pubspec.yaml
@@ -13,15 +13,7 @@ dependencies:
   path: ^1.3.0
   stack_trace: ^1.4.0
   vm_service_client: '^0.2.0'
-  
-  # Pulled in via dependency_override below.
-  analyzer: any
 
 dev_dependencies:
   # See packages/flutter_test/pubspec.yaml for why we're pinning this version.
   test: 0.12.15+4
-
-# See packages/flutter_test/pubspec.yaml for why we're using an override.
-dependency_overrides:
-  analyzer:
-    path: ../../bin/cache/dart-sdk/lib/analyzer

--- a/packages/flutter_test/pubspec.yaml
+++ b/packages/flutter_test/pubspec.yaml
@@ -7,14 +7,5 @@ dependencies:
   # here we pin it precisely to avoid version skew across our packages.
   test: 0.12.15+4
 
-  # We don't actually depend on 'analyzer', but 'test' and 'flutter_tools' do.
-  # Like 'flutter_tools', we use the version of the analyzer in the vended Dart
-  # SDK as defined in the `dependency_overrides` below.
-  analyzer: any
-
   flutter:
     path: ../flutter
-
-dependency_overrides:
-  analyzer:
-    path: ../../bin/cache/dart-sdk/lib/analyzer

--- a/packages/flutter_tools/lib/src/dart/pub.dart
+++ b/packages/flutter_tools/lib/src/dart/pub.dart
@@ -49,7 +49,8 @@ Future<int> pubGet({
     Status status = logger.startProgress("Running 'pub $command' in ${path.basename(directory)}...");
     int code = await runCommandAndStreamOutput(
       <String>[sdkBinaryName('pub'), '--verbosity=warning', command, '--no-packages-dir', '--no-precompile'],
-      workingDirectory: directory
+      workingDirectory: directory,
+      mapFunction: _filterOverrideWarnings
     );
     status.stop(showElapsedTime: true);
     if (code != 0)
@@ -61,4 +62,16 @@ Future<int> pubGet({
 
   printError('$directory: pubspec.yaml and .packages are in an inconsistent state');
   return 1;
+}
+
+String _filterOverrideWarnings(String str) {
+  // Warning: You are using these overridden dependencies:
+  // ! analyzer 0.29.0-alpha.0 from path ../../bin/cache/dart-sdk/lib/analyzer
+
+  if (str.contains('overridden dependencies:'))
+    return null;
+  if (str.startsWith('! analyzer '))
+    return null;
+
+  return str;
 }


### PR DESCRIPTION
A different attempt at fixing https://github.com/flutter/flutter/pull/5925:
- suppress the pub override warning in `bin/flutter` and in `flutter_tools/lib/src/dart/pub.dart`
- leave the analyzer override in the pubspec for `flutter_tools`; this is the only package we have that uses the analyzer API directly
- let the analyzer version float in `devicelab/pubspec.yaml` and `flutter_test/pubspec.yaml`; we get the version that `package:test` specifies that it needs in its pubspec
- (also pass in `--no-packages-dir` in bin/flutter, to mirror what we do when driving pub from dart code)

I think allowing the analyzer version to be different - that used by flutter_tools, and that used by packages that user code will depend on - is ok. `flutter_tools` is generally just a snapshot that users interact with, not something they're actively importing into their codebase. And this lets us use the exact same version of the analyzer as the SDK tools, which is nice - we won't have any version skew between analysis server based products and `flutter analyze`.

@danrubel @Hixie @abarth @pq
