### PR TITLE
Update docs for benchmarks

### DIFF
--- a/dev/benchmarks/microbenchmarks/README.md
+++ b/dev/benchmarks/microbenchmarks/README.md
@@ -1,6 +1,8 @@
 # microbenchmarks
 
-To run these benchmarks on a device:
+To run these benchmarks on a device, first run `flutter logs' in one
+window to see the device logs, then, in a different window, run any of
+these:
 
 ```
 flutter run --release lib/gestures/velocity_tracker_data.dart


### PR DESCRIPTION
We changed how `flutter run --release` works (it quits without showing
logs now, since it can't tell when the app closes).
