### PR TITLE
Use SDK sources to refer to our own packages

### DIFF
--- a/dev/automated_tests/pubspec.yaml
+++ b/dev/automated_tests/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_automated_tests
 dependencies:
   flutter:
-    path: ../../packages/flutter
+    sdk: flutter
   flutter_test:
-    path: ../../packages/flutter_test
+    sdk: flutter

--- a/dev/benchmarks/complex_layout/pubspec.yaml
+++ b/dev/benchmarks/complex_layout/pubspec.yaml
@@ -3,10 +3,11 @@ description: A new flutter project.
 
 dependencies:
   flutter:
-    path: ../../../packages/flutter
+    sdk: flutter
   flutter_driver:
-    path: ../../../packages/flutter_driver
-  # Also update examples/flutter_gallery/pubspec.yaml
+    sdk: flutter
+
+  # Also examples/flutter_gallery/pubspec.yaml
   flutter_gallery_assets:
     git:
       url: https://flutter.googlesource.com/gallery-assets
@@ -14,4 +15,4 @@ dependencies:
 
 dev_dependencies:
   flutter_test:
-    path: ../../../packages/flutter_test
+    sdk: flutter

--- a/dev/benchmarks/microbenchmarks/pubspec.yaml
+++ b/dev/benchmarks/microbenchmarks/pubspec.yaml
@@ -2,8 +2,8 @@ name: microbenchmarks
 description: A new flutter project.
 dependencies:
   flutter:
-    path: ../../../packages/flutter
+    sdk: flutter
   flutter_test:
-    path: ../../../packages/flutter_test
+    sdk: flutter
   stocks:
     path: ../../../examples/stocks

--- a/dev/bots/docs.sh
+++ b/dev/bots/docs.sh
@@ -10,7 +10,7 @@ pub global activate dartdoc 0.9.7+1
 
 # This script generates a unified doc set, and creates
 # a custom index.html, placing everything into dev/docs/doc
-dart dev/tools/dartdoc.dart
+FLUTTER_ROOT=$PWD dart dev/tools/dartdoc.dart
 
 # Ensure google webmaster tools can verify our site.
 cp dev/docs/google2ed1af765c529f57.html dev/docs/doc

--- a/dev/bots/test.sh
+++ b/dev/bots/test.sh
@@ -28,11 +28,13 @@ if [ -n "$TRAVIS" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
   COVERAGE_FLAG=--coverage
 fi
 
+SRC_ROOT=$PWD
+
 # run tests
 (cd packages/flutter; flutter test $COVERAGE_FLAG)
 (cd packages/flutter_driver; dart -c test/all.dart)
 (cd packages/flutter_test; flutter test)
-(cd packages/flutter_tools; dart -c test/all.dart)
+(cd packages/flutter_tools; FLUTTER_ROOT=$SRC_ROOT dart -c test/all.dart)
 
 (cd dev/devicelab; dart -c test/all.dart)
 (cd dev/manual_tests; flutter test)

--- a/dev/manual_tests/flutter.yaml
+++ b/dev/manual_tests/flutter.yaml
@@ -1,14 +1,1 @@
 uses-material-design: true
-assets:
-  - packages/flutter_gallery_assets/weather_demo/sun.png
-  - packages/flutter_gallery_assets/weather_demo/clouds-0.png
-  - packages/flutter_gallery_assets/weather_demo/clouds-1.png
-  - packages/flutter_gallery_assets/weather_demo/ray.png
-  - packages/flutter_gallery_assets/weather_demo/sun.png
-  - packages/flutter_gallery_assets/weather_demo/weathersprites.json
-  - packages/flutter_gallery_assets/weather_demo/weathersprites.png
-  - packages/flutter_gallery_assets/weather_demo/icon-sun.png
-  - packages/flutter_gallery_assets/weather_demo/icon-rain.png
-  - packages/flutter_gallery_assets/weather_demo/icon-snow.png
-  - packages/flutter_gallery_assets/fitness_demo/jumpingjack.json
-  - packages/flutter_gallery_assets/fitness_demo/jumpingjack.png

--- a/dev/manual_tests/pubspec.yaml
+++ b/dev/manual_tests/pubspec.yaml
@@ -1,9 +1,9 @@
 name: flutter_manual_tests
+
 dependencies:
   flutter:
-    path: ../../packages/flutter
+    sdk: flutter
 
 dev_dependencies:
-  test: any # flutter_test provides the version constraints
   flutter_test:
-    path: ../../packages/flutter_test
+    sdk: flutter

--- a/dev/tools/dartdoc.dart
+++ b/dev/tools/dartdoc.dart
@@ -30,7 +30,7 @@ dependencies:
 ''');
   for (String package in findPackageNames()) {
     buf.writeln('  $package:');
-    buf.writeln('    path: ../../packages/$package');
+    buf.writeln('    sdk: flutter');
   }
   new File('dev/docs/pubspec.yaml').writeAsStringSync(buf.toString());
 
@@ -45,7 +45,12 @@ dependencies:
   new File('dev/docs/lib/temp_doc.dart').writeAsStringSync(contents.toString());
 
   // Run pub.
-  Process process = await Process.start('pub', <String>['get'], workingDirectory: 'dev/docs');
+  Process process = await Process.start('pub', <String>['get'],
+    workingDirectory: 'dev/docs',
+    environment: <String, String>{
+      'FLUTTER_ROOT': Directory.current.path
+    }
+  );
   printStream(process.stdout);
   printStream(process.stderr);
   int code = await process.exitCode;

--- a/examples/flutter_gallery/pubspec.yaml
+++ b/examples/flutter_gallery/pubspec.yaml
@@ -5,9 +5,10 @@ dependencies:
   string_scanner: ^1.0.0
 
   flutter:
-    path: ../../packages/flutter
+    sdk: flutter
   flutter_markdown:
-    path: ../../packages/flutter_markdown
+    sdk: flutter
+
   # Also update dev/benchmarks/complex_layout/pubspec.yaml
   flutter_gallery_assets:
     git:
@@ -15,8 +16,7 @@ dependencies:
       ref: ef928550119411358b8b25e16aecde6ace513526
 
 dev_dependencies:
-  test: any # flutter_test provides the version constraints
   flutter_test:
-    path: ../../packages/flutter_test
+    sdk: flutter
   flutter_driver:
-    path: ../../packages/flutter_driver
+    sdk: flutter

--- a/examples/hello_services/pubspec.yaml
+++ b/examples/hello_services/pubspec.yaml
@@ -1,8 +1,9 @@
 name: hello_services
+
 dependencies:
   flutter:
-    path: ../../packages/flutter
+    sdk: flutter
+
 dev_dependencies:
-  test: any # flutter_test provides the version constraints
   flutter_test:
-    path: ../../packages/flutter_test
+    sdk: flutter

--- a/examples/hello_world/pubspec.yaml
+++ b/examples/hello_world/pubspec.yaml
@@ -1,8 +1,9 @@
 name: hello_world
+
 dependencies:
   flutter:
-    path: ../../packages/flutter
+    sdk: flutter
+
 dev_dependencies:
-  test: any # flutter_test provides the version constraints
   flutter_test:
-    path: ../../packages/flutter_test
+    sdk: flutter

--- a/examples/layers/pubspec.yaml
+++ b/examples/layers/pubspec.yaml
@@ -1,8 +1,8 @@
 name: flutter_examples_layers
 dependencies:
   flutter:
-    path: ../../packages/flutter
+    sdk: flutter
+
 dev_dependencies:
-  test: any # flutter_test provides the version constraints
   flutter_test:
-    path: ../../packages/flutter_test
+    sdk: flutter

--- a/examples/stocks/pubspec.yaml
+++ b/examples/stocks/pubspec.yaml
@@ -1,11 +1,11 @@
 name: stocks
 dependencies:
   flutter:
-    path: ../../packages/flutter
+    sdk: flutter
   intl: '>=0.14.0 <0.15.0'
 
 dev_dependencies:
   flutter_test:
-    path: ../../packages/flutter_test
+    sdk: flutter
   flutter_driver:
-    path: ../../packages/flutter_driver
+    sdk: flutter

--- a/packages/flutter/pubspec.yaml
+++ b/packages/flutter/pubspec.yaml
@@ -22,7 +22,7 @@ dependencies:
 
 dev_dependencies:
   flutter_test:
-    path: ../flutter_test
+    sdk: flutter
 
 environment:
   sdk: '>=1.19.0 <2.0.0'

--- a/packages/flutter_driver/pubspec.yaml
+++ b/packages/flutter_driver/pubspec.yaml
@@ -15,9 +15,9 @@ dependencies:
   web_socket_channel: '^1.0.0'
   vm_service_client: '^0.2.0'
   flutter:
-    path: '../flutter'
+    sdk: flutter
   flutter_test:
-    path: '../flutter_test'
+    sdk: flutter
 
 dev_dependencies:
   test: 0.12.15+4

--- a/packages/flutter_markdown/pubspec.yaml
+++ b/packages/flutter_markdown/pubspec.yaml
@@ -6,10 +6,10 @@ homepage: http://flutter.io
 
 dependencies:
   flutter:
-    path: ../flutter
+    sdk: flutter
   markdown: '^0.9.0'
   string_scanner: ^1.0.0
 
 dev_dependencies:
   flutter_test:
-    path: ../flutter_test
+    sdk: flutter

--- a/packages/flutter_test/pubspec.yaml
+++ b/packages/flutter_test/pubspec.yaml
@@ -8,4 +8,4 @@ dependencies:
   test: 0.12.15+4
 
   flutter:
-    path: ../flutter
+    sdk: flutter

--- a/packages/flutter_tools/templates/create/pubspec.yaml.tmpl
+++ b/packages/flutter_tools/templates/create/pubspec.yaml.tmpl
@@ -2,9 +2,9 @@ name: {{projectName}}
 description: {{description}}
 dependencies:
   flutter:
-    path: {{flutterPackagesDirectory}}/flutter
+    sdk: flutter
 {{#withDriverTest?}}
 dev_dependencies:
   flutter_driver:
-    path: {{flutterPackagesDirectory}}/flutter_driver
+    sdk: flutter
 {{/withDriverTest?}}


### PR DESCRIPTION
Switch our pubspec.yamls to using SDK sources so that we can have consistent
source types when we depend on these packages from external packages using SDK
sources.
