### PR TITLE
Allow a Nexus 5 to install the gallery from the Play Store

### DIFF
--- a/examples/flutter_gallery/android/AndroidManifest.xml
+++ b/examples/flutter_gallery/android/AndroidManifest.xml
@@ -15,11 +15,13 @@
         <screen android:screenSize="small" android:screenDensity="mdpi" />
         <screen android:screenSize="small" android:screenDensity="hdpi" />
         <screen android:screenSize="small" android:screenDensity="xhdpi" />
+        <screen android:screenSize="small" android:screenDensity="480" />
         <!-- all normal size screens -->
         <screen android:screenSize="normal" android:screenDensity="ldpi" />
         <screen android:screenSize="normal" android:screenDensity="mdpi" />
         <screen android:screenSize="normal" android:screenDensity="hdpi" />
         <screen android:screenSize="normal" android:screenDensity="xhdpi" />
+        <screen android:screenSize="normal" android:screenDensity="480" />
     </compatible-screens>
 
     <application android:icon="@mipmap/ic_launcher" android:label="Gallery" android:name="org.domokit.sky.shell.SkyApplication">


### PR DESCRIPTION
Cargo culted from http://stackoverflow.com/questions/24690739/nexus-5-galaxy-s5-and-some-other-devices-are-showing-not-compatible-in-google
