### PR TITLE
Changed BottomNavigationBar background.

### DIFF
--- a/packages/flutter/lib/src/material/bottom_navigation_bar.dart
+++ b/packages/flutter/lib/src/material/bottom_navigation_bar.dart
@@ -446,7 +446,7 @@ class BottomNavigationBarState extends State<BottomNavigationBar> {
         new Positioned.fill(
           child: new Material( // Casts shadow.
             elevation: 8,
-            color: _backgroundColor
+            color: config.type == BottomNavigationBarType.shifting ? _backgroundColor : null
           )
         ),
         new SizedBox(


### PR DESCRIPTION
When switching from shifting to fixed, the BottomNavigationBar no
longer displays the old color of the background.
