### PR TITLE
Update spinning_mixed and fix related bugs

### DIFF
--- a/examples/layers/widgets/spinning_mixed.dart
+++ b/examples/layers/widgets/spinning_mixed.dart
@@ -51,7 +51,7 @@ void attachWidgetTreeToRenderTree(RenderProxyBox container) {
                   new RaisedButton(
                     child: new Row(
                       children: <Widget>[
-                        new Image.network('http://flutter.io/favicon.ico'),
+                        new Image.network('https://flutter.io/images/favicon.png'),
                         new Text('PRESS ME'),
                       ]
                     ),
@@ -83,9 +83,9 @@ void rotate(Duration timeStamp) {
   double delta = (timeStamp - timeBase).inMicroseconds.toDouble() / Duration.MICROSECONDS_PER_SECOND; // radians
 
   transformBox.setIdentity();
-  transformBox.translate(transformBox.size.width / 2.0, transformBox.size.height / 2.0);
   transformBox.rotateZ(delta);
-  transformBox.translate(-transformBox.size.width / 2.0, -transformBox.size.height / 2.0);
+
+  owner.buildScope(element);
 }
 
 void main() {
@@ -98,7 +98,7 @@ void main() {
   flexRoot.add(proxy);
   addFlexChildSolidColor(flexRoot, const Color(0xFF0000FF), flex: 1);
 
-  transformBox = new RenderTransform(child: flexRoot, transform: new Matrix4.identity());
+  transformBox = new RenderTransform(child: flexRoot, transform: new Matrix4.identity(), alignment: FractionalOffset.center);
   RenderPadding root = new RenderPadding(padding: new EdgeInsets.all(80.0), child: transformBox);
 
   binding.renderView.child = root;

--- a/packages/flutter/lib/src/painting/transforms.dart
+++ b/packages/flutter/lib/src/painting/transforms.dart
@@ -90,13 +90,13 @@ class MatrixUtils {
         && a.storage[15] == 1.0;
   }
 
-  /// Applies the given matrix as a perspective transform to the given point.
+  /// Applies the given matrix as a transform to the given point.
   ///
   /// This function assumes the given point has a z-coordinate of 0.0. The
   /// z-coordinate of the result is ignored.
   static Point transformPoint(Matrix4 transform, Point point) {
     Vector3 position3 = new Vector3(point.x, point.y, 0.0);
-    Vector3 transformed3 = transform.perspectiveTransform(position3);
+    Vector3 transformed3 = transform.transform3(position3);
     return new Point(transformed3.x, transformed3.y);
   }
 

--- a/packages/flutter/lib/src/rendering/box.dart
+++ b/packages/flutter/lib/src/rendering/box.dart
@@ -1332,7 +1332,8 @@ abstract class RenderBox extends RenderObject {
   /// function to factor those transforms into the calculation.
   ///
   /// The RenderBox implementation takes care of adjusting the matrix for the
-  /// position of the given child.
+  /// position of the given child as determined during layout and stored on the
+  /// child's [parentData] in the [BoxParentData.offset] field.
   @override
   void applyPaintTransform(RenderObject child, Matrix4 transform) {
     assert(child.parent == this);
@@ -1341,20 +1342,24 @@ abstract class RenderBox extends RenderObject {
     transform.translate(offset.dx, offset.dy);
   }
 
+  Matrix4 _collectPaintTransform() {
+    assert(attached);
+    final List<RenderObject> renderers = <RenderObject>[];
+    for (RenderObject renderer = this; renderer != null; renderer = renderer.parent)
+      renderers.add(renderer);
+    final Matrix4 transform = new Matrix4.identity();
+    for (int index = renderers.length - 1; index > 0; index -= 1)
+      renderers[index].applyPaintTransform(renderers[index - 1], transform);
+    return transform;
+  }
+
   /// Convert the given point from the global coodinate system to the local
   /// coordinate system for this box.
   ///
   /// If the transform from global coordinates to local coordinates is
   /// degenerate, this function returns Point.origin.
   Point globalToLocal(Point point) {
-    assert(attached);
-    Matrix4 transform = new Matrix4.identity();
-    RenderObject renderer = this;
-    while (renderer.parent is RenderObject) {
-      RenderObject rendererParent = renderer.parent;
-      rendererParent.applyPaintTransform(renderer, transform);
-      renderer = rendererParent;
-    }
+    final Matrix4 transform = _collectPaintTransform();
     double det = transform.invert();
     if (det == 0.0)
       return Point.origin;
@@ -1364,13 +1369,7 @@ abstract class RenderBox extends RenderObject {
   /// Convert the given point from the local coordinate system for this box to
   /// the global coordinate system.
   Point localToGlobal(Point point) {
-    List<RenderObject> renderers = <RenderObject>[];
-    for (RenderObject renderer = this; renderer != null; renderer = renderer.parent)
-      renderers.add(renderer);
-    Matrix4 transform = new Matrix4.identity();
-    for (int index = renderers.length - 1; index > 0; index -= 1)
-      renderers[index].applyPaintTransform(renderers[index - 1], transform);
-    return MatrixUtils.transformPoint(transform, point);
+    return MatrixUtils.transformPoint(_collectPaintTransform(), point);
   }
 
   /// Returns a rectangle that contains all the pixels painted by this box.

--- a/packages/flutter/lib/src/rendering/flow.dart
+++ b/packages/flutter/lib/src/rendering/flow.dart
@@ -378,16 +378,14 @@ class RenderFlow extends RenderBox
       final Matrix4 transform = childParentData._transform;
       if (transform == null)
         continue;
-      Matrix4 inverse = new Matrix4.zero();
-      double determinate = inverse.copyInverse(transform);
+      final Matrix4 inverse = new Matrix4.zero();
+      final double determinate = inverse.copyInverse(transform);
       if (determinate == 0.0) {
         // We cannot invert the transform. That means the child doesn't appear
         // on screen and cannot be hit.
         continue;
       }
-      final Vector3 position3 = new Vector3(position.x, position.y, 0.0);
-      final Vector3 transformed3 = inverse.transform3(position3);
-      Point childPosition = new Point(transformed3.x, transformed3.y);
+      final Point childPosition = MatrixUtils.transformPoint(inverse, position);
       if (child.hitTest(result, position: childPosition))
         return true;
     }

--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -6,6 +6,7 @@ import 'dart:ui' as ui show ImageFilter;
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
+import 'package:flutter/painting.dart';
 import 'package:meta/meta.dart';
 import 'package:vector_math/vector_math_64.dart';
 
@@ -1364,9 +1365,7 @@ class RenderTransform extends RenderProxyBox {
         // doesn't appear on screen and cannot be hit.
         return false;
       }
-      Vector3 position3 = new Vector3(position.x, position.y, 0.0);
-      Vector3 transformed3 = inverse.transform3(position3);
-      position = new Point(transformed3.x, transformed3.y);
+      position = MatrixUtils.transformPoint(inverse, position);
     }
     return super.hitTest(result, position: position);
   }
@@ -1512,9 +1511,7 @@ class RenderFittedBox extends RenderProxyBox {
       // doesn't appear on screen and cannot be hit.
       return false;
     }
-    Vector3 position3 = new Vector3(position.x, position.y, 0.0);
-    Vector3 transformed3 = inverse.transform3(position3);
-    position = new Point(transformed3.x, transformed3.y);
+    position = MatrixUtils.transformPoint(inverse, position);
     return super.hitTest(result, position: position);
   }
 

--- a/packages/flutter/lib/src/rendering/rotated_box.dart
+++ b/packages/flutter/lib/src/rendering/rotated_box.dart
@@ -5,6 +5,7 @@
 import 'dart:math' as math;
 
 import 'package:flutter/gestures.dart';
+import 'package:flutter/painting.dart';
 import 'package:vector_math/vector_math_64.dart';
 
 import 'box.dart';
@@ -93,9 +94,7 @@ class RenderRotatedBox extends RenderBox with RenderObjectWithChildMixin<RenderB
     if (child == null || _paintTransform == null)
       return false;
     Matrix4 inverse = new Matrix4.inverted(_paintTransform);
-    Vector3 position3 = new Vector3(position.x, position.y, 0.0);
-    Vector3 transformed3 = inverse.transform3(position3);
-    return child.hitTest(result, position: new Point(transformed3.x, transformed3.y));
+    return child.hitTest(result, position: MatrixUtils.transformPoint(inverse, position));
   }
 
   void _paintChild(PaintingContext context, Offset offset) {

--- a/packages/flutter/lib/src/widgets/binding.dart
+++ b/packages/flutter/lib/src/widgets/binding.dart
@@ -293,7 +293,8 @@ abstract class WidgetsBinding extends BindingBase implements GestureBinding, Ren
       return true;
     });
     try {
-      buildOwner.buildScope(renderViewElement);
+      if (renderViewElement != null)
+        buildOwner.buildScope(renderViewElement);
       super.beginFrame();
       buildOwner.finalizeTree();
     } finally {
@@ -340,7 +341,8 @@ abstract class WidgetsBinding extends BindingBase implements GestureBinding, Ren
   void reassembleApplication() {
     _needToReportFirstFrame = true;
     preventThisFrameFromBeingReportedAsFirstFrame();
-    buildOwner.reassemble(renderViewElement);
+    if (renderViewElement != null)
+      buildOwner.reassemble(renderViewElement);
     super.reassembleApplication();
   }
 }

--- a/packages/flutter/test/painting/text_span_test.dart
+++ b/packages/flutter/test/painting/text_span_test.dart
@@ -7,7 +7,7 @@ import 'package:flutter/painting.dart';
 import 'package:test/test.dart';
 
 void main() {
-  test("TextSpan equals", () {
+  test('TextSpan equals', () {
     TextSpan a1 = new TextSpan(text: 'a');
     TextSpan a2 = new TextSpan(text: 'a');
     TextSpan b1 = new TextSpan(children: <TextSpan>[ a1 ]);
@@ -28,7 +28,7 @@ void main() {
     expect(c1 == b2, isFalse);
   });
 
-  test("TextSpan ", () {
+  test('TextSpan', () {
     final TextSpan test = new TextSpan(
       text: 'a',
       style: new TextStyle(

--- a/packages/flutter/test/rendering/rendering_tester.dart
+++ b/packages/flutter/test/rendering/rendering_tester.dart
@@ -43,13 +43,20 @@ TestRenderingFlutterBinding get renderer {
   return _renderer;
 }
 
-void layout(RenderBox box, { BoxConstraints constraints, EnginePhase phase: EnginePhase.layout }) {
+/// Place the box in the render tree, at the given size and with the given
+/// alignment on the screen.
+void layout(RenderBox box, {
+  BoxConstraints constraints,
+  FractionalOffset alignment: FractionalOffset.center,
+  EnginePhase phase: EnginePhase.layout
+}) {
   assert(box != null); // If you want to just repump the last box, call pumpFrame().
   assert(box.parent == null); // We stick the box in another, so you can't reuse it easily, sorry.
 
   renderer.renderView.child = null;
   if (constraints != null) {
     box = new RenderPositionedBox(
+      alignment: alignment,
       child: new RenderConstrainedBox(
         additionalConstraints: constraints,
         child: box

--- a/packages/flutter/test/rendering/transform_test.dart
+++ b/packages/flutter/test/rendering/transform_test.dart
@@ -1,0 +1,133 @@
+// Copyright 2015 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:math' as math;
+
+import 'package:flutter/rendering.dart';
+import 'package:test/test.dart';
+
+import 'rendering_tester.dart';
+
+Point round(Point value) {
+  return new Point(value.x.roundToDouble(), value.y.roundToDouble());
+}
+
+void main() {
+  test('RenderTransform - identity', () {
+    RenderBox inner;
+    RenderBox sizer = new RenderTransform(
+      transform: new Matrix4.identity(),
+      alignment: FractionalOffset.center,
+      child: inner = new RenderSizedBox(const Size(100.0, 100.0)),
+    );
+    layout(sizer, constraints: new BoxConstraints.tight(new Size(100.0, 100.0)), alignment: FractionalOffset.topLeft);
+    expect(inner.globalToLocal(const Point(0.0, 0.0)), equals(const Point(0.0, 0.0)));
+    expect(inner.globalToLocal(const Point(100.0, 100.0)), equals(const Point(100.0, 100.0)));
+    expect(inner.globalToLocal(const Point(25.0, 75.0)), equals(const Point(25.0, 75.0)));
+    expect(inner.globalToLocal(const Point(50.0, 50.0)), equals(const Point(50.0, 50.0)));
+    expect(inner.localToGlobal(const Point(0.0, 0.0)), equals(const Point(0.0, 0.0)));
+    expect(inner.localToGlobal(const Point(100.0, 100.0)), equals(const Point(100.0, 100.0)));
+    expect(inner.localToGlobal(const Point(25.0, 75.0)), equals(const Point(25.0, 75.0)));
+    expect(inner.localToGlobal(const Point(50.0, 50.0)), equals(const Point(50.0, 50.0)));
+  });
+
+  test('RenderTransform - identity with internal offset', () {
+    RenderBox inner;
+    RenderBox sizer = new RenderTransform(
+      transform: new Matrix4.identity(),
+      alignment: FractionalOffset.center,
+      child: new RenderPadding(
+        padding: new EdgeInsets.only(left: 20.0),
+        child: inner = new RenderSizedBox(const Size(80.0, 100.0)),
+      ),
+    );
+    layout(sizer, constraints: new BoxConstraints.tight(new Size(100.0, 100.0)), alignment: FractionalOffset.topLeft);
+    expect(inner.globalToLocal(const Point(0.0, 0.0)), equals(const Point(-20.0, 0.0)));
+    expect(inner.globalToLocal(const Point(100.0, 100.0)), equals(const Point(80.0, 100.0)));
+    expect(inner.globalToLocal(const Point(25.0, 75.0)), equals(const Point(5.0, 75.0)));
+    expect(inner.globalToLocal(const Point(50.0, 50.0)), equals(const Point(30.0, 50.0)));
+    expect(inner.localToGlobal(const Point(0.0, 0.0)), equals(const Point(20.0, 0.0)));
+    expect(inner.localToGlobal(const Point(100.0, 100.0)), equals(const Point(120.0, 100.0)));
+    expect(inner.localToGlobal(const Point(25.0, 75.0)), equals(const Point(45.0, 75.0)));
+    expect(inner.localToGlobal(const Point(50.0, 50.0)), equals(const Point(70.0, 50.0)));
+  });
+
+  test('RenderTransform - translation', () {
+    RenderBox inner;
+    RenderBox sizer = new RenderTransform(
+      transform: new Matrix4.translationValues(50.0, 200.0, 0.0),
+      alignment: FractionalOffset.center,
+      child: inner = new RenderSizedBox(const Size(100.0, 100.0)),
+    );
+    layout(sizer, constraints: new BoxConstraints.tight(new Size(100.0, 100.0)), alignment: FractionalOffset.topLeft);
+    expect(inner.globalToLocal(const Point(0.0, 0.0)), equals(const Point(-50.0, -200.0)));
+    expect(inner.globalToLocal(const Point(100.0, 100.0)), equals(const Point(50.0, -100.0)));
+    expect(inner.globalToLocal(const Point(25.0, 75.0)), equals(const Point(-25.0, -125.0)));
+    expect(inner.globalToLocal(const Point(50.0, 50.0)), equals(const Point(0.0, -150.0)));
+    expect(inner.localToGlobal(const Point(0.0, 0.0)), equals(const Point(50.0, 200.0)));
+    expect(inner.localToGlobal(const Point(100.0, 100.0)), equals(const Point(150.0, 300.0)));
+    expect(inner.localToGlobal(const Point(25.0, 75.0)), equals(const Point(75.0, 275.0)));
+    expect(inner.localToGlobal(const Point(50.0, 50.0)), equals(const Point(100.0, 250.0)));
+  });
+
+  test('RenderTransform - translation with internal offset', () {
+    RenderBox inner;
+    RenderBox sizer = new RenderTransform(
+      transform: new Matrix4.translationValues(50.0, 200.0, 0.0),
+      alignment: FractionalOffset.center,
+      child: new RenderPadding(
+        padding: new EdgeInsets.only(left: 20.0),
+        child: inner = new RenderSizedBox(const Size(80.0, 100.0)),
+      ),
+    );
+    layout(sizer, constraints: new BoxConstraints.tight(new Size(100.0, 100.0)), alignment: FractionalOffset.topLeft);
+    expect(inner.globalToLocal(const Point(0.0, 0.0)), equals(const Point(-70.0, -200.0)));
+    expect(inner.globalToLocal(const Point(100.0, 100.0)), equals(const Point(30.0, -100.0)));
+    expect(inner.globalToLocal(const Point(25.0, 75.0)), equals(const Point(-45.0, -125.0)));
+    expect(inner.globalToLocal(const Point(50.0, 50.0)), equals(const Point(-20.0, -150.0)));
+    expect(inner.localToGlobal(const Point(0.0, 0.0)), equals(const Point(70.0, 200.0)));
+    expect(inner.localToGlobal(const Point(100.0, 100.0)), equals(const Point(170.0, 300.0)));
+    expect(inner.localToGlobal(const Point(25.0, 75.0)), equals(const Point(95.0, 275.0)));
+    expect(inner.localToGlobal(const Point(50.0, 50.0)), equals(const Point(120.0, 250.0)));
+  });
+
+  test('RenderTransform - rotation', () {
+    RenderBox inner;
+    RenderBox sizer = new RenderTransform(
+      transform: new Matrix4.rotationZ(math.PI),
+      alignment: FractionalOffset.center,
+      child: inner = new RenderSizedBox(const Size(100.0, 100.0)),
+    );
+    layout(sizer, constraints: new BoxConstraints.tight(new Size(100.0, 100.0)), alignment: FractionalOffset.topLeft);
+    expect(round(inner.globalToLocal(const Point(0.0, 0.0))), equals(const Point(100.0, 100.0)));
+    expect(round(inner.globalToLocal(const Point(100.0, 100.0))), equals(const Point(0.0, 0.0)));
+    expect(round(inner.globalToLocal(const Point(25.0, 75.0))), equals(const Point(75.0, 25.0)));
+    expect(round(inner.globalToLocal(const Point(50.0, 50.0))), equals(const Point(50.0, 50.0)));
+    expect(round(inner.localToGlobal(const Point(0.0, 0.0))), equals(const Point(100.0, 100.0)));
+    expect(round(inner.localToGlobal(const Point(100.0, 100.0))), equals(const Point(0.0, 0.0)));
+    expect(round(inner.localToGlobal(const Point(25.0, 75.0))), equals(const Point(75.0, 25.0)));
+    expect(round(inner.localToGlobal(const Point(50.0, 50.0))), equals(const Point(50.0, 50.0)));
+  });
+
+  test('RenderTransform - rotation with internal offset', () {
+    RenderBox inner;
+    RenderBox sizer = new RenderTransform(
+      transform: new Matrix4.rotationZ(math.PI),
+      alignment: FractionalOffset.center,
+      child: new RenderPadding(
+        padding: new EdgeInsets.only(left: 20.0),
+        child: inner = new RenderSizedBox(const Size(80.0, 100.0)),
+      ),
+    );
+    layout(sizer, constraints: new BoxConstraints.tight(new Size(100.0, 100.0)), alignment: FractionalOffset.topLeft);
+    expect(round(inner.globalToLocal(const Point(0.0, 0.0))), equals(const Point(80.0, 100.0)));
+    expect(round(inner.globalToLocal(const Point(100.0, 100.0))), equals(const Point(-20.0, 0.0)));
+    expect(round(inner.globalToLocal(const Point(25.0, 75.0))), equals(const Point(55.0, 25.0)));
+    expect(round(inner.globalToLocal(const Point(50.0, 50.0))), equals(const Point(30.0, 50.0)));
+    expect(round(inner.localToGlobal(const Point(0.0, 0.0))), equals(const Point(80.0, 100.0)));
+    expect(round(inner.localToGlobal(const Point(100.0, 100.0))), equals(const Point(-20.0, 0.0)));
+    expect(round(inner.localToGlobal(const Point(25.0, 75.0))), equals(const Point(55.0, 25.0)));
+    expect(round(inner.localToGlobal(const Point(50.0, 50.0))), equals(const Point(30.0, 50.0)));
+  });
+}

--- a/packages/flutter/test/widget/fitted_box_test.dart
+++ b/packages/flutter/test/widget/fitted_box_test.dart
@@ -38,6 +38,7 @@ void main() {
     Point insidePoint = insideBox.localToGlobal(new Point(100.0, 50.0));
     Point outsidePoint = outsideBox.localToGlobal(new Point(200.0, 100.0));
 
+    expect(outsidePoint, equals(const Point(500.0, 350.0)));
     expect(insidePoint, equals(outsidePoint));
   });
 


### PR DESCRIPTION
- update graphic used by spinning_mixed since the old one went 404
- simplify some of the code in the demo
- fix MatrixUtils.transformPoint to be consistent with how we transform
  points elsewhere
- stop transforming points elsewhere, just use
  MatrixUtils.transformPoint
- make the Widget binding handle not having a root element
- make the spinning_mixed demo update its widget tree.
