### PR TITLE
fix devices test; print on test failure

### DIFF
--- a/packages/flutter_tools/test/all.dart
+++ b/packages/flutter_tools/test/all.dart
@@ -24,7 +24,7 @@ import 'create_test.dart' as create_test;
 import 'daemon_test.dart' as daemon_test;
 import 'devfs_test.dart' as devfs_test;
 import 'device_test.dart' as device_test;
-// import 'devices_test.dart' as devices_test;
+import 'devices_test.dart' as devices_test;
 import 'drive_test.dart' as drive_test;
 import 'format_test.dart' as format_test;
 import 'install_test.dart' as install_test;
@@ -58,7 +58,7 @@ void main() {
   daemon_test.main();
   devfs_test.main();
   device_test.main();
-  // devices_test.main(); // https://github.com/flutter/flutter/issues/4480
+  devices_test.main();
   drive_test.main();
   format_test.main();
   install_test.main();

--- a/packages/flutter_tools/test/devices_test.dart
+++ b/packages/flutter_tools/test/devices_test.dart
@@ -14,16 +14,16 @@ void main() {
   group('devices', () {
     testUsingContext('returns 0 when called', () {
       DevicesCommand command = new DevicesCommand();
-      return createTestCommandRunner(command).run(<String>['list']).then((int code) {
+      return createTestCommandRunner(command).run(<String>['devices']).then((int code) {
         expect(code, 0);
       });
     });
 
     testUsingContext('no error when no connected devices', () {
       DevicesCommand command = new DevicesCommand();
-      return createTestCommandRunner(command).run(<String>['list']).then((int code) {
+      return createTestCommandRunner(command).run(<String>['devices']).then((int code) {
         expect(code, 0);
-        expect(testLogger.statusText, contains('No connected devices'));
+        expect(testLogger.statusText, contains('No devices detected'));
       });
     }, overrides: <Type, dynamic>{
       AndroidSdk: null,

--- a/packages/flutter_tools/test/src/context.dart
+++ b/packages/flutter_tools/test/src/context.dart
@@ -26,7 +26,7 @@ void testUsingContext(String description, dynamic testMethod(), {
   Timeout timeout,
   Map<Type, dynamic> overrides: const <Type, dynamic>{}
 }) {
-  test(description, () {
+  test(description, () async {
     AppContext testContext = new AppContext();
 
     overrides.forEach((Type type, dynamic value) {
@@ -65,7 +65,17 @@ void testUsingContext(String description, dynamic testMethod(), {
         testContext[XCode] = new XCode();
     }
 
-    return testContext.runInZone(testMethod);
+    try {
+      return await testContext.runInZone(testMethod);
+    } catch (error) {
+      if (testContext[Logger] is BufferLogger) {
+        BufferLogger bufferLogger = testContext[Logger];
+        if (bufferLogger.errorText.isNotEmpty)
+          print(bufferLogger.errorText);
+      }
+      throw error;
+    }
+
   }, timeout: timeout);
 }
 

--- a/packages/flutter_tools/test/src/context.dart
+++ b/packages/flutter_tools/test/src/context.dart
@@ -111,6 +111,10 @@ class MockDeviceManager implements DeviceManager {
 class MockDoctor extends Doctor {
   // True for testing.
   @override
+  bool get canListAnything => true;
+
+  // True for testing.
+  @override
   bool get canLaunchAnything => true;
 }
 


### PR DESCRIPTION
- fix and re-enable the devices test (fix https://github.com/flutter/flutter/issues/4480)
- on test failure, print any output from `printError()`; this can help diagnose test failures
