### PR TITLE
set the FLUTTER_ROOT env var when invoking pub

### DIFF
--- a/packages/flutter_tools/lib/src/dart/pub.dart
+++ b/packages/flutter_tools/lib/src/dart/pub.dart
@@ -50,7 +50,8 @@ Future<int> pubGet({
     int code = await runCommandAndStreamOutput(
       <String>[sdkBinaryName('pub'), '--verbosity=warning', command, '--no-packages-dir', '--no-precompile'],
       workingDirectory: directory,
-      mapFunction: _filterOverrideWarnings
+      mapFunction: _filterOverrideWarnings,
+      environment: <String, String>{ 'FLUTTER_ROOT': Cache.flutterRoot }
     );
     status.stop(showElapsedTime: true);
     if (code != 0)


### PR DESCRIPTION
- when invoking pub from flutter_tools, set the `FLUTTER_ROOT` env variable

We're already setting this from `//bin/flutter`, but I saw test failures related to this when invoking the tests directly ( from packages/flutter_tools, `dart test/all.dart`).
