### PR TITLE
Fixed expansion panels demo alignment.

### DIFF
--- a/examples/flutter_gallery/lib/demo/expansion_panels_demo.dart
+++ b/examples/flutter_gallery/lib/demo/expansion_panels_demo.dart
@@ -229,6 +229,7 @@ class _ExpansionPanelsDemoState extends State<ExpasionPanelsDemo> {
           return new CollapsibleBody(
             child: new Column(
               mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
               children: <Widget>[
                 new Row(
                   mainAxisSize: MainAxisSize.min,


### PR DESCRIPTION
The former horitzontal alignment in the expansion panels demo in
the Gallery was center instead of left. Fixes #6049.

@HansMuller PTAL.
