### PR TITLE
Add widget inheritance links

### DIFF
--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -3097,10 +3097,10 @@ class InheritedElementLinkParent extends ProxyElement {
 
 /// An element that uses a [InheritedWidgetLinkChild] as its configuration.
 class InheritedElementLinkChild extends ProxyElement {
-  InheritedElementLinkChild(InheritedWidgetLinkChild widget) : super(widget);
+  InheritedElementLinkChild(InheritedWidgetLinkChildProxy widget) : super(widget);
 
   @override
-  InheritedWidgetLinkChild get widget => super.widget;
+  InheritedWidgetLinkChildProxy get widget => super.widget;
 
   InheritedElementLinkParent get link => widget.link?._currentElement;
 
@@ -3182,7 +3182,7 @@ class InheritedElementLinkChild extends ProxyElement {
   }
 
   @override
-  void notifyClients(InheritedWidgetLinkChild oldWidget) {
+  void notifyClients(InheritedWidgetLinkChildProxy oldWidget) {
     if (!widget.updateShouldNotify(oldWidget))
       return;
     _updateInheritanceRecursively(this);

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -5,6 +5,7 @@
 import 'dart:async';
 import 'dart:collection';
 import 'dart:developer';
+import 'dart:math' as math;
 
 import 'debug.dart';
 
@@ -1099,6 +1100,32 @@ abstract class InheritedWidget extends ProxyWidget {
   /// object.
   @protected
   bool updateShouldNotify(InheritedWidget oldWidget);
+}
+
+class InheritedWidgetLinkParent extends ProxyWidget {
+  const InheritedWidgetLinkParent({ Key key, Widget child, this.link })
+    : super(key: key, child: child);
+
+  final GlobalKey link;
+
+  @override
+  InheritedElementLinkParent createElement() => new InheritedElementLinkParent(this);
+
+  @protected
+  bool updateShouldNotify(InheritedWidgetLinkParent oldWidget) => link != oldWidget.link;
+}
+
+class InheritedWidgetLinkChild extends ProxyWidget {
+  const InheritedWidgetLinkChild({ Key key, Widget child, this.link })
+    : super(key: key, child: child);
+
+  final GlobalKey link;
+
+  @override
+  InheritedElementLinkChild createElement() => new InheritedElementLinkChild(this);
+
+  @protected
+  bool updateShouldNotify(InheritedWidgetLinkChild oldWidget) => link != oldWidget.link;
 }
 
 /// RenderObjectWidgets provide the configuration for [RenderObjectElement]s,
@@ -3012,17 +3039,131 @@ class InheritedElement extends ProxyElement {
   @protected
   void dispatchDependenciesChanged() {
     for (Element dependent in _dependents) {
-      assert(() {
-        // check that it really is our descendant
-        Element ancestor = dependent._parent;
-        while (ancestor != this && ancestor != null)
-          ancestor = ancestor._parent;
-        return ancestor == this;
-      });
+      assert(dependent._debugIsInScope(this));
       // check that it really deepends on us
       assert(dependent._dependencies.contains(this));
       dependent.dependenciesChanged();
     }
+  }
+}
+
+class InheritedElementLinkParent extends ProxyElement {
+  InheritedElementLinkParent(InheritedWidgetLinkParent widget) : super(widget);
+
+  @override
+  InheritedWidgetLinkParent get widget => super.widget;
+
+  InheritedElementLinkChild get link => widget.link?._currentElement;
+
+  @override
+  void activate() {
+    super.activate(); // clears _dependencies, and sets active to true
+    if (link != null && link._active)
+      link._markLinkChildNeedsBuild();
+  }
+
+  @override
+  void deactivate() {
+    super.deactivate();
+    if (link != null && link._active)
+      link._clearDependenciesRecursively(link);
+  }
+
+  @override
+  void _updateInheritance() {
+    super._updateInheritance();
+    if (link != null && link._active)
+      link._updateInheritanceRecursively(link);
+  }
+
+  @override
+  void notifyClients(InheritedWidgetLinkParent oldWidget) {
+    if (!widget.updateShouldNotify(oldWidget))
+      return;
+
+    InheritedElementLinkChild oldLink = oldWidget.link?._currentElement;
+    oldLink?._clearDependenciesRecursively(oldLink);
+    oldLink?._updateInheritance();
+    link?._updateInheritance();
+  }
+}
+
+class InheritedElementLinkChild extends ProxyElement {
+  InheritedElementLinkChild(InheritedWidgetLinkChild widget) : super(widget);
+
+  @override
+  InheritedWidgetLinkChild get widget => super.widget;
+
+  InheritedElementLinkParent get link => widget.link?._currentElement;
+
+  @override
+  int get depth {
+    if (_depth == null)
+      return null;
+    return math.max(_depth, 1 + (link?.depth ?? 0));
+  }
+
+  @override
+  bool _debugIsInScope(Element target) {
+    return super._debugIsInScope(target) || (link?._debugIsInScope(target) ?? false);
+  }
+
+  void _markLinkChildNeedsBuild() {
+    assert(_debugLifecycleState != _ElementLifecycle.defunct);
+    if (!_active)
+      return;
+    assert(owner != null);
+    assert(_debugLifecycleState == _ElementLifecycle.active);
+    assert(link != null);
+    assert(() {
+      if (link.owner._debugBuilding) {
+        if (link.owner._debugCurrentBuildTarget == null) {
+          // If _debugCurrentBuildTarget is null, we're not actually building a
+          // widget but instead building the root of the tree via runApp.
+          // TODO(abarth): Remove these cases and ensure that we always have
+          // a current build target when we're building.
+          return true;
+        }
+        if (_debugIsInScope(link.owner._debugCurrentBuildTarget))
+          return true;
+      }
+      return true;
+    });
+    if (dirty)
+      return;
+    _dirty = true;
+    owner.scheduleBuildFor(this);
+  }
+
+  @override
+  void _updateInheritance() {
+    if (link != null && link._active)
+      _inheritedWidgets = link._inheritedWidgets;
+    else
+      super._updateInheritance();
+  }
+
+  void _updateInheritanceRecursively(Element element) {
+    element._updateInheritance();
+    element.visitChildren(_updateInheritanceRecursively);
+  }
+
+  // We're going to rebuild this tree. Any element of a dependent list
+  // from an ancestor of the link-parent that points into a link-child
+  // descendant needs to be cleared.
+  void _clearDependenciesRecursively(Element element) {
+    if (element._dependencies != null) {
+      for (InheritedElement dependency in element._dependencies) {
+        dependency._dependents.remove(element);
+      }
+    }
+    element.visitChildren(_clearDependenciesRecursively);
+  }
+
+  @override
+  void notifyClients(InheritedWidgetLinkChild oldWidget) {
+    if (widget.link != oldWidget.link)
+      _updateInheritanceRecursively(this);
   }
 }
 

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -3067,6 +3067,7 @@ class InheritedElement extends ProxyElement {
   }
 }
 
+/// An element that uses a [InheritedWidgetLinkParent] as its configuration.
 class InheritedElementLinkParent extends ProxyElement {
   InheritedElementLinkParent(InheritedWidgetLinkParent widget) : super(widget);
 
@@ -3145,6 +3146,7 @@ class InheritedElementLinkParent extends ProxyElement {
   }
 }
 
+/// An element that uses a [InheritedWidgetLinkChild] as its configuration.
 class InheritedElementLinkChild extends ProxyElement {
   InheritedElementLinkChild(InheritedWidgetLinkChild widget) : super(widget);
 

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -3162,8 +3162,9 @@ class InheritedElementLinkChild extends ProxyElement {
 
   @override
   void notifyClients(InheritedWidgetLinkChild oldWidget) {
-    if (widget.link != oldWidget.link)
-      _updateInheritanceRecursively(this);
+    if (!widget.updateShouldNotify(oldWidget))
+      return;
+    _updateInheritanceRecursively(this);
   }
 }
 

--- a/packages/flutter/lib/src/widgets/inherited_link.dart
+++ b/packages/flutter/lib/src/widgets/inherited_link.dart
@@ -1,0 +1,53 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'debug.dart';
+import 'framework.dart';
+
+
+/// Defines a location in the widget tree that an [InheritedWidgetLinkChild] can
+/// link to. The descendants of the link child inherit from the link parent's
+/// [InheritedWidget] ancestors instead of the link child's inherited widget
+/// ancestors.
+///
+/// This widget must be given its own [GlobalKey] and the value of its [link] must
+/// be a GlobalKey given to its link child. If the link is null then this widget
+/// has no effect on inherited values.
+class InheritedWidgetLinkParent extends ProxyWidget {
+  const InheritedWidgetLinkParent({ GlobalKey key, Widget child, this.link })
+    : super(key: key, child: child);
+
+  /// The value of an [InheritedWidgetLinkChild]'s key or null. The link child's
+  /// descendants will inherit from this widget's  [InheritedWidget] ancestors.
+  /// If [key] or link is null then this link child will have no effect on inheritance.
+  final GlobalKey link;
+
+  @override
+  InheritedElementLinkParent createElement() => new InheritedElementLinkParent(this);
+
+  @protected
+  bool updateShouldNotify(InheritedWidgetLinkParent oldWidget) => link != oldWidget.link;
+}
+
+/// This widget's child inherits values from the [InheritedWidget] ancestors of the
+/// [InheritedWidgetLinkParent] that it's linked to.
+///
+/// This widget must be given its own [GlobalKey] and the value of its [link] must
+/// be a GlobalKey given to its link parent. If the link is null then this widget
+/// has no effect on inherited values.
+class InheritedWidgetLinkChild extends ProxyWidget {
+  const InheritedWidgetLinkChild({ GlobalKey key, Widget child, this.link })
+    : super(key: key, child: child);
+
+  /// The value of an [InheritedWidgetLinkParent]'s key or null. This widget will
+  /// inherit from the link parent's [InheritedWidget] ancestors. If [key] or link
+  /// is null then this link child will have no effect on inheritance.
+  final GlobalKey link;
+
+  @override
+  InheritedElementLinkChild createElement() => new InheritedElementLinkChild(this);
+
+  @protected
+  bool updateShouldNotify(InheritedWidgetLinkChild oldWidget) => link != oldWidget.link;
+}

--- a/packages/flutter/lib/src/widgets/inherited_link.dart
+++ b/packages/flutter/lib/src/widgets/inherited_link.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'debug.dart';
 import 'framework.dart';
 
 
@@ -26,7 +25,6 @@ class InheritedWidgetLinkParent extends ProxyWidget {
   @override
   InheritedElementLinkParent createElement() => new InheritedElementLinkParent(this);
 
-  @protected
   bool updateShouldNotify(InheritedWidgetLinkParent oldWidget) => link != oldWidget.link;
 }
 
@@ -48,6 +46,5 @@ class InheritedWidgetLinkChild extends ProxyWidget {
   @override
   InheritedElementLinkChild createElement() => new InheritedElementLinkChild(this);
 
-  @protected
   bool updateShouldNotify(InheritedWidgetLinkChild oldWidget) => link != oldWidget.link;
 }

--- a/packages/flutter/lib/src/widgets/inherited_link.dart
+++ b/packages/flutter/lib/src/widgets/inherited_link.dart
@@ -3,7 +3,9 @@
 // found in the LICENSE file.
 
 import 'framework.dart';
+import 'layout_builder.dart';
 
+import 'package:flutter/rendering.dart' show BoxConstraints;
 
 /// Defines a location in the widget tree that an [InheritedWidgetLinkChild] can
 /// link to. The descendants of the link child inherit from the link parent's
@@ -11,7 +13,7 @@ import 'framework.dart';
 /// ancestors.
 ///
 /// This widget must be given its own [GlobalKey] and the value of its [link] must
-/// be a GlobalKey given to its link child. If the link is null then this widget
+/// be the GlobalKey given to its link child. If the link is null then this widget
 /// has no effect on inherited values.
 class InheritedWidgetLinkParent extends ProxyWidget {
   const InheritedWidgetLinkParent({ GlobalKey key, Widget child, this.link })
@@ -32,19 +34,34 @@ class InheritedWidgetLinkParent extends ProxyWidget {
 /// [InheritedWidgetLinkParent] that it's linked to.
 ///
 /// This widget must be given its own [GlobalKey] and the value of its [link] must
-/// be a GlobalKey given to its link parent. If the link is null then this widget
+/// be the GlobalKey given to its link parent. If the link is null then this widget
 /// has no effect on inherited values.
-class InheritedWidgetLinkChild extends ProxyWidget {
-  const InheritedWidgetLinkChild({ GlobalKey key, Widget child, this.link })
-    : super(key: key, child: child);
+class InheritedWidgetLinkChild extends StatelessWidget {
+  InheritedWidgetLinkChild({ GlobalKey key, Widget child, GlobalKey link })
+    : _proxy =  new InheritedWidgetLinkChildProxy(key: key, child: child, link: link);
+
+  final InheritedWidgetLinkChildProxy _proxy;
 
   /// The value of an [InheritedWidgetLinkParent]'s key or null. This widget will
-  /// inherit from the link parent's [InheritedWidget] ancestors. If [key] or link
+  /// inherit from the link parent's [InheritedWidget] ancestors. If key or link
   /// is null then this link child will have no effect on inheritance.
+  GlobalKey get link => _proxy?.link;
+
+  Widget _buildProxy(BuildContext context, BoxConstraints constraints) => _proxy;
+
+  @override
+  Widget build(BuildContext context) => new LayoutBuilder(builder: _buildProxy);
+}
+
+
+class InheritedWidgetLinkChildProxy extends ProxyWidget {
+  const InheritedWidgetLinkChildProxy({ GlobalKey key, Widget child, this.link })
+    : super(key: key, child: child);
+
   final GlobalKey link;
 
   @override
   InheritedElementLinkChild createElement() => new InheritedElementLinkChild(this);
 
-  bool updateShouldNotify(InheritedWidgetLinkChild oldWidget) => link != oldWidget.link;
+  bool updateShouldNotify(InheritedWidgetLinkChildProxy oldWidget) => link != oldWidget.link;
 }

--- a/packages/flutter/lib/widgets.dart
+++ b/packages/flutter/lib/widgets.dart
@@ -30,6 +30,7 @@ export 'src/widgets/gridpaper.dart';
 export 'src/widgets/heroes.dart';
 export 'src/widgets/image.dart';
 export 'src/widgets/implicit_animations.dart';
+export 'src/widgets/inherited_link.dart';
 export 'src/widgets/layout_builder.dart';
 export 'src/widgets/lazy_block.dart';
 export 'src/widgets/locale_query.dart';

--- a/packages/flutter/test/widget/inherited_link_test.dart
+++ b/packages/flutter/test/widget/inherited_link_test.dart
@@ -490,14 +490,4 @@ void main() {
     expect(tester.takeException(), isNotNull);
   });
 
-  testWidgets('InheritedWidgetLinkParent invalid key', (WidgetTester tester) async {
-    await tester.pumpWidget(new InheritedWidgetLinkParent(key: new UniqueKey()));
-    expect(tester.takeException(), isNotNull);
-  });
-
-  testWidgets('InheritedWidgetLinkChild invalid key', (WidgetTester tester) async {
-    await tester.pumpWidget(new InheritedWidgetLinkChild(key: new UniqueKey()));
-    expect(tester.takeException(), isNotNull);
-  });
-
 }

--- a/packages/flutter/test/widget/inherited_link_test.dart
+++ b/packages/flutter/test/widget/inherited_link_test.dart
@@ -11,11 +11,18 @@ class InheritedValue extends InheritedWidget {
 
   final double value;
 
+  static double of(BuildContext context) {
+    return context.inheritFromWidgetOfExactType(InheritedValue).value;
+  }
+
   @override
   bool updateShouldNotify(InheritedValue oldWidget) => value != oldWidget.value;
 
   @override
-  String toString() => "InheritedValue(value=$value)";
+  debugFillDescription(List<String> description) {
+    super.debugFillDescription(description);
+    description.add('value: $value');
+  }
 }
 
 void main() {
@@ -37,12 +44,11 @@ void main() {
               value: inheritedValue,
               child: new Builder(
                 builder: (BuildContext context) {
-                  final InheritedValue inheritedValue = context.inheritFromWidgetOfExactType(InheritedValue);
                   return new InheritedWidgetLinkParent(
                     key: linkParentKey,
                     link: linkChildKey,
                     child: new Container(
-                      width: inheritedValue.value
+                      width: InheritedValue.of(context),
                     )
                   );
                 }
@@ -55,10 +61,9 @@ void main() {
                 builder: (BuildContext context) {
                   // The InheritedWidgetLinkChild causes this lookup to redirect to the
                   // ancestors of the InheritedWidgetLinkParent above.
-                  final InheritedValue inheritedValue = context.inheritFromWidgetOfExactType(InheritedValue);
                   return new Container(
                     key: containerKey,
-                    width: inheritedValue.value
+                    width: InheritedValue.of(context),
                   );
                 }
               )
@@ -100,12 +105,11 @@ void main() {
                     value: inheritedValue,
                     child: new Builder(
                       builder: (BuildContext context) {
-                        final InheritedValue inheritedValue = context.inheritFromWidgetOfExactType(InheritedValue);
                         return new InheritedWidgetLinkParent(
                           key: linkParentKey,
                           link: linkChildKey,
                           child: new Container(
-                            width: inheritedValue.value
+                            width: InheritedValue.of(context),
                           )
                         );
                       }
@@ -120,10 +124,9 @@ void main() {
             link: linkParentKey,
             child: new Builder(
               builder: (BuildContext context) {
-                final InheritedValue inheritedValue = context.inheritFromWidgetOfExactType(InheritedValue);
                 return new Container(
                   key: containerKey,
-                  width: inheritedValue.value
+                  width: InheritedValue.of(context),
                 );
               }
             )
@@ -162,12 +165,11 @@ void main() {
                     value: 100.0,
                     child: new Builder(
                       builder: (BuildContext context) {
-                        final InheritedValue inheritedValue = context.inheritFromWidgetOfExactType(InheritedValue);
                         return new InheritedWidgetLinkParent(
                           key: linkParentKey,
                           link: linkChildKey,
                           child: new Container(
-                            width: inheritedValue.value
+                            width: InheritedValue.of(context),
                           )
                         );
                       }
@@ -182,10 +184,9 @@ void main() {
             link: linkParentKey,
             child: new Builder(
               builder: (BuildContext context) {
-                final InheritedValue inheritedValue = context.inheritFromWidgetOfExactType(InheritedValue);
                 return new Container(
                   key: containerKey,
-                  width: inheritedValue.value
+                  width: InheritedValue.of(context),
                 );
               }
             )
@@ -208,12 +209,11 @@ void main() {
             value: 500.0,
             child: new Builder(
               builder: (BuildContext context) {
-                final InheritedValue inheritedValue = context.inheritFromWidgetOfExactType(InheritedValue);
                 return new InheritedWidgetLinkParent(
                   key: linkParentKey,
                   link: linkChildKey,
                   child: new Container(
-                    width: inheritedValue.value
+                    width: InheritedValue.of(context),
                    )
                 );
               }
@@ -225,10 +225,9 @@ void main() {
             child: new Builder(
               builder: (BuildContext context) {
                 rebuilt = true;
-                final InheritedValue inheritedValue = context.inheritFromWidgetOfExactType(InheritedValue);
                 return new Container(
                   key: containerKey,
-                  width: inheritedValue.value
+                  width: InheritedValue.of(context),
                 );
               }
             )
@@ -257,21 +256,19 @@ void main() {
             value: 200.0,
             child: new Builder(
               builder: (BuildContext context) {
-                final InheritedValue inheritedValue = context.inheritFromWidgetOfExactType(InheritedValue);
                 return new InheritedWidgetLinkParent(
                   key: linkParentKey200, // If the child links here, it inherits value=200
                   link: linkChildKey,
                   child: new Container(
-                    width: inheritedValue.value,
+                    width: InheritedValue.of(context),
                     child: new InheritedValue(
                       value: 100.0,
                       child: new Builder(
                         builder: (BuildContext context) {
-                          final InheritedValue inheritedValue = context.inheritFromWidgetOfExactType(InheritedValue);
                           return new InheritedWidgetLinkParent(
                             key: linkParentKey100, // If the child links here, it inherits value=100
                             link: linkChildKey,
-                            child: new Container(width: inheritedValue.value)
+                            child: new Container(width: InheritedValue.of(context)),
                           );
                         }
                       )
@@ -286,10 +283,9 @@ void main() {
             link: linkParentKey, // Initially linkParentKey100, then linkParentKey200
             child: new Builder(
               builder: (BuildContext context) {
-                final InheritedValue inheritedValue = context.inheritFromWidgetOfExactType(InheritedValue);
                 return new Container(
                   key: containerKey,
-                  width: inheritedValue.value
+                  width: InheritedValue.of(context),
                 );
               }
             )
@@ -340,10 +336,9 @@ void main() {
                 link: parentLink, // Initially points to child one, then child two
                 child: new Builder(
                   builder: (BuildContext context) {
-                    final InheritedValue inheritedValue = context.inheritFromWidgetOfExactType(InheritedValue);
                     return new Container(
                       key: parentKey,
-                      width: inheritedValue.value
+                      width: InheritedValue.of(context),
                     );
                   }
                 )
@@ -355,10 +350,9 @@ void main() {
               link: childOneLink, // Initially points to parent, then null
               child: new Builder(
                 builder: (BuildContext context) {
-                  final InheritedValue inheritedValue = context.inheritFromWidgetOfExactType(InheritedValue);
                   return new Container(
                     key: childOneKey,
-                    width: inheritedValue.value,
+                    width: InheritedValue.of(context),
                   );
                 }
               )
@@ -369,10 +363,9 @@ void main() {
               link: childTwoLink, // Initially null, then points to parent
               child: new Builder(
                 builder: (BuildContext context) {
-                  final InheritedValue inheritedValue = context.inheritFromWidgetOfExactType(InheritedValue);
                   return new Container(
                     key: childTwoKey,
-                    width: inheritedValue.value,
+                    width: InheritedValue.of(context),
                   );
                 }
               )
@@ -434,11 +427,10 @@ void main() {
               link: linkParentKey,
               child: new Builder(
                 builder: (BuildContext context) {
-                  final InheritedValue inheritedValue = context.inheritFromWidgetOfExactType(InheritedValue);
                   return new Center(
                     child: new Container(
                       key: containerKey,
-                      width: inheritedValue.value
+                      width: InheritedValue.of(context),
                     )
                   );
                 }
@@ -488,6 +480,75 @@ void main() {
       link: linkParentKey,
     ));
     expect(tester.takeException(), isNotNull);
+  });
+
+  testWidgets('InheritedWidgetLink cross-link', (WidgetTester tester) async {
+    GlobalKey linkParent1Key = new GlobalKey(debugLabel: 'linkParent1Key');
+    GlobalKey linkParent2Key = new GlobalKey(debugLabel: 'linkParent2Key');
+    GlobalKey linkChild1Key = new GlobalKey(debugLabel: 'linkChild1Key');
+    GlobalKey linkChild2Key = new GlobalKey(debugLabel: 'linkChild2Key');
+    Key container1Key = new UniqueKey();
+    Key container2Key = new UniqueKey();
+
+    // The two parent-child links "cross" in the sense that the more deeply
+    // nested of the two children links to the parent that's higher up in
+    // the tree. This test works because the Element.depth of link children
+    // is defined to be the greater of their parent link's depth+1 AND their
+    // actual depth. See InheritedElementLinkChild.depth.
+    Widget buildFrame() {
+      return new Row(
+        children: <Widget>[
+          new InheritedValue(
+            value: 100.0,
+            child: new InheritedWidgetLinkParent(
+              key: linkParent1Key,
+              link: linkChild2Key,
+              child: new InheritedValue(
+                value: 200.0,
+                child: new InheritedWidgetLinkParent(
+                  key: linkParent2Key,
+                  link: linkChild1Key,
+                  child: new Container(width: 300.0),
+                )
+              )
+            )
+          ),
+          new InheritedWidgetLinkChild(
+            key: linkChild1Key,
+            link: linkParent2Key,
+            child: new Builder(
+              builder: (BuildContext context) {
+                return new Container(
+                  key: container1Key,
+                  width: InheritedValue.of(context),
+                  child: new InheritedWidgetLinkChild(
+                    key: linkChild2Key,
+                    link: linkParent1Key,
+                    child: new Builder(
+                      builder: (BuildContext context) {
+                        return new Center(
+                          child: new Container(
+                            key: container2Key,
+                            width: InheritedValue.of(context),
+                          )
+                        );
+                      }
+                    )
+                  )
+                );
+              }
+            )
+          )
+        ]
+      );
+    }
+
+    await tester.pumpWidget(buildFrame());
+    RenderBox box = tester.renderObject(find.byKey(container1Key));
+    expect(box.size.width, equals(200.0));
+
+    box = tester.renderObject(find.byKey(container2Key));
+    expect(box.size.width, equals(100.0));
   });
 
 }

--- a/packages/flutter/test/widget/inherited_link_test.dart
+++ b/packages/flutter/test/widget/inherited_link_test.dart
@@ -1,0 +1,416 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter/widgets.dart';
+
+
+class InheritedValue extends InheritedWidget {
+  InheritedValue({ Key key, Widget child, this.value }) : super(key: key, child: child);
+
+  final double value;
+
+  @override
+  bool updateShouldNotify(InheritedValue oldWidget) => value != oldWidget.value;
+
+  @override
+  String toString() => "InheritedValue(value=$value)";
+}
+
+void main() {
+  testWidgets('InheritedWidgetLink basics', (WidgetTester tester) async {
+    GlobalKey linkParentKey = new GlobalKey();
+    GlobalKey linkChildKey = new GlobalKey();
+    Key containerKey = new UniqueKey();
+    double inheritedValue = 100.0;
+
+    // The first row element's subtree depends on an InheritedValue. The
+    // second row element's subtree links to the leaf Container element
+    // in the first subtree.
+    Widget buildFrame() {
+      return new InheritedValue(
+        value: 500.0, // This value is subverted by the child's link.
+        child: new Row(
+          children: <Widget>[
+            new InheritedValue(
+              value: inheritedValue,
+              child: new Builder(
+                builder: (BuildContext context) {
+                  final InheritedValue inheritedValue = context.inheritFromWidgetOfExactType(InheritedValue);
+                  return new InheritedWidgetLinkParent(
+                    key: linkParentKey,
+                    link: linkChildKey,
+                    child: new Container(
+                      width: inheritedValue.value
+                    )
+                  );
+                }
+              )
+            ),
+            new InheritedWidgetLinkChild(
+              key: linkChildKey,
+              link: linkParentKey,
+              child: new Builder(
+                builder: (BuildContext context) {
+                  // The InheritedWidgetLinkChild causes this lookup to redirect to the
+                  // ancestors of the InheritedWidgetLinkParent above.
+                  final InheritedValue inheritedValue = context.inheritFromWidgetOfExactType(InheritedValue);
+                  return new Container(
+                    key: containerKey,
+                    width: inheritedValue.value
+                  );
+                }
+              )
+            )
+          ]
+        )
+      );
+    }
+
+    await tester.pumpWidget(buildFrame());
+    RenderBox box = tester.renderObject(find.byKey(containerKey));
+    expect(box.size.width, equals(100.0));
+
+    inheritedValue = 200.0;
+    await tester.pumpWidget(buildFrame());
+    expect(box.size.width, equals(200.0));
+
+    linkParentKey = null;
+    await tester.pumpWidget(buildFrame());
+    expect(box.size.width, equals(500.0));
+  });
+
+  testWidgets('InheritedWidgetLink basics, deep target', (WidgetTester tester) async {
+    GlobalKey linkParentKey = new GlobalKey();
+    GlobalKey linkChildKey = new GlobalKey();
+    Key containerKey = new UniqueKey();
+    double inheritedValue = 100.0;
+
+    // In this case, the widget tree depth of the InheritedValue being linked
+    // to is greater than the InheritedWidgetLink's depth.
+    Widget buildFrame() {
+      return new Row(
+        children: <Widget>[
+          new Container(
+            child: new Container(
+              child: new Container(
+                child: new Container(
+                  child: new InheritedValue(
+                    value: inheritedValue,
+                    child: new Builder(
+                      builder: (BuildContext context) {
+                        final InheritedValue inheritedValue = context.inheritFromWidgetOfExactType(InheritedValue);
+                        return new InheritedWidgetLinkParent(
+                          key: linkParentKey,
+                          link: linkChildKey,
+                          child: new Container(
+                            width: inheritedValue.value
+                          )
+                        );
+                      }
+                    )
+                  )
+                )
+              )
+            )
+          ),
+          new InheritedWidgetLinkChild(
+            key: linkChildKey,
+            link: linkParentKey,
+            child: new Builder(
+              builder: (BuildContext context) {
+                final InheritedValue inheritedValue = context.inheritFromWidgetOfExactType(InheritedValue);
+                return new Container(
+                  key: containerKey,
+                  width: inheritedValue.value
+                );
+              }
+            )
+          )
+        ]
+      );
+    }
+
+    await tester.pumpWidget(buildFrame());
+    RenderBox box = tester.renderObject(find.byKey(containerKey));
+    expect(box.size.width, equals(100.0));
+
+    inheritedValue = 200.0;
+    await tester.pumpWidget(buildFrame());
+    expect(box.size.width, equals(200.0));
+  });
+
+  testWidgets('InheritedWidgetLink basics, link target subtree changes', (WidgetTester tester) async {
+    GlobalKey linkParentKey = new GlobalKey(debugLabel: 'linkParentKey');
+    GlobalKey linkChildKey = new GlobalKey(debugLabel: 'linkChildKey');
+    Key containerKey = new UniqueKey();
+
+    // This is the same widget three as in the'InheritedWidgetLink basics,
+    // deep target' test. In the next step the four Container ancestors of
+    // the InheritedWidgetLinkParent will be removed, causing the
+    // InheritedWidgetLinkParent widget to be deactivated and then rebuilt
+    // in its new location.
+    await tester.pumpWidget(
+      new Row(
+        children: <Widget>[
+          new Container(
+            child: new Container(
+              child: new Container(
+                child: new Container(
+                  child: new InheritedValue(
+                    value: 100.0,
+                    child: new Builder(
+                      builder: (BuildContext context) {
+                        final InheritedValue inheritedValue = context.inheritFromWidgetOfExactType(InheritedValue);
+                        return new InheritedWidgetLinkParent(
+                          key: linkParentKey,
+                          link: linkChildKey,
+                          child: new Container(
+                            width: inheritedValue.value
+                          )
+                        );
+                      }
+                    )
+                  )
+                )
+              )
+            )
+          ),
+          new InheritedWidgetLinkChild(
+            key: linkChildKey,
+            link: linkParentKey,
+            child: new Builder(
+              builder: (BuildContext context) {
+                final InheritedValue inheritedValue = context.inheritFromWidgetOfExactType(InheritedValue);
+                return new Container(
+                  key: containerKey,
+                  width: inheritedValue.value
+                );
+              }
+            )
+          )
+        ]
+      )
+    );
+
+    RenderBox box = tester.renderObject(find.byKey(containerKey));
+    expect(box.size.width, equals(100.0));
+
+    // Move the InheritedValue widget subtree up by removing the enclosing
+    // Containers. The width of the Container below the InheritedWidgetLinkChild
+    // should not change but it should be rebuilt.
+    bool rebuilt = false;
+    await tester.pumpWidget(
+      new Row(
+        children: <Widget>[
+          new InheritedValue(
+            value: 500.0,
+            child: new Builder(
+              builder: (BuildContext context) {
+                final InheritedValue inheritedValue = context.inheritFromWidgetOfExactType(InheritedValue);
+                return new InheritedWidgetLinkParent(
+                  key: linkParentKey,
+                  link: linkChildKey,
+                  child: new Container(
+                    width: inheritedValue.value
+                   )
+                );
+              }
+            )
+          ),
+          new InheritedWidgetLinkChild(
+            key: linkChildKey,
+            link: linkParentKey,
+            child: new Builder(
+              builder: (BuildContext context) {
+                rebuilt = true;
+                final InheritedValue inheritedValue = context.inheritFromWidgetOfExactType(InheritedValue);
+                return new Container(
+                  key: containerKey,
+                  width: inheritedValue.value
+                );
+              }
+            )
+          )
+        ]
+      )
+    );
+
+    box = tester.renderObject(find.byKey(containerKey));
+    expect(rebuilt, isTrue);
+    expect(box.size.width, equals(500.0));
+
+  });
+
+  testWidgets('InheritedWidgetLink redirect the child\'s link', (WidgetTester tester) async {
+    GlobalKey linkChildKey = new GlobalKey(debugLabel: 'link child');
+    GlobalKey linkParentKey200 = new GlobalKey(debugLabel: 'InheritedWidgetLinkParent, width: 200.0');
+    GlobalKey linkParentKey100 = new GlobalKey(debugLabel: 'InheritedWidgetLinkChild, width: 100.0');
+    GlobalKey linkParentKey = linkParentKey100;
+    Key containerKey = new UniqueKey();
+
+    Widget buildFrame() {
+      return new Row(
+        children: <Widget>[
+          new InheritedValue(
+            value: 200.0,
+            child: new Builder(
+              builder: (BuildContext context) {
+                final InheritedValue inheritedValue = context.inheritFromWidgetOfExactType(InheritedValue);
+                return new InheritedWidgetLinkParent(
+                  key: linkParentKey200, // If the child links here, it inherits value=200
+                  link: linkChildKey,
+                  child: new Container(
+                    width: inheritedValue.value,
+                    child: new InheritedValue(
+                      value: 100.0,
+                      child: new Builder(
+                        builder: (BuildContext context) {
+                          final InheritedValue inheritedValue = context.inheritFromWidgetOfExactType(InheritedValue);
+                          return new InheritedWidgetLinkParent(
+                            key: linkParentKey100, // If the child links here, it inherits value=100
+                            link: linkChildKey,
+                            child: new Container(width: inheritedValue.value)
+                          );
+                        }
+                      )
+                    )
+                  )
+                );
+              }
+            )
+          ),
+          new InheritedWidgetLinkChild(
+            key: linkChildKey,
+            link: linkParentKey, // Initially linkParentKey100, then linkParentKey200
+            child: new Builder(
+              builder: (BuildContext context) {
+                final InheritedValue inheritedValue = context.inheritFromWidgetOfExactType(InheritedValue);
+                return new Container(
+                  key: containerKey,
+                  width: inheritedValue.value
+                );
+              }
+            )
+          ),
+        ]
+      );
+    }
+
+    await tester.pumpWidget(buildFrame());
+
+    RenderBox box = tester.renderObject(find.byKey(containerKey));
+    expect(box.size.width, equals(100.0));
+
+    // Rebuild the InheritedWidgetLink subtree with the new link value.
+    linkParentKey = linkParentKey200;
+    await tester.pumpWidget(buildFrame());
+    await tester.pump();
+    box = tester.renderObject(find.byKey(containerKey));
+    expect(box.size.width, equals(200.0));
+  });
+
+  testWidgets('InheritedWidgetLink redirect the parent\'s link', (WidgetTester tester) async {
+    // Keys for the Containers whose width is defined an InheritedValue.
+    GlobalKey parentKey = new GlobalKey(debugLabel: 'parent');
+    GlobalKey childOneKey = new GlobalKey(debugLabel: 'childOne');
+    GlobalKey childTwoKey = new GlobalKey(debugLabel: 'childTwo');
+
+    // Keys and link values for the InheritedWidgetLinkParent widget and
+    // the two InheritedWidgetLinkChild widgets. Initially child one is linked
+    // to the parent and child two isn't linked.
+    GlobalKey linkParentKey = new GlobalKey(debugLabel: 'InheritedWidgetLinkParent');
+    GlobalKey linkChildOneKey = new GlobalKey(debugLabel: 'InheritedWidgetLinkChild one');
+    GlobalKey linkChildTwoKey = new GlobalKey(debugLabel: 'InheritedWidgetLinkChild two');
+    GlobalKey parentLink = linkChildOneKey;
+    GlobalKey childOneLink = linkParentKey;
+    GlobalKey childTwoLink;
+
+    Widget buildFrame() {
+      return new InheritedValue(
+        value: 200.0,
+        child: new Row(
+          children: <Widget>[
+            // Parent
+            new InheritedValue(
+              value: 100.0,
+              child: new InheritedWidgetLinkParent(
+                key: linkParentKey,
+                link: parentLink, // Initially points to child one, then child two
+                child: new Builder(
+                  builder: (BuildContext context) {
+                    final InheritedValue inheritedValue = context.inheritFromWidgetOfExactType(InheritedValue);
+                    return new Container(
+                      key: parentKey,
+                      width: inheritedValue.value
+                    );
+                  }
+                )
+              )
+            ),
+            // Child one
+            new InheritedWidgetLinkChild(
+              key: linkChildOneKey,
+              link: childOneLink, // Initially points to parent, then null
+              child: new Builder(
+                builder: (BuildContext context) {
+                  final InheritedValue inheritedValue = context.inheritFromWidgetOfExactType(InheritedValue);
+                  return new Container(
+                    key: childOneKey,
+                    width: inheritedValue.value,
+                  );
+                }
+              )
+            ),
+            // Child two
+            new InheritedWidgetLinkChild(
+              key: linkChildTwoKey,
+              link: childTwoLink, // Initially null, then points to parent
+              child: new Builder(
+                builder: (BuildContext context) {
+                  final InheritedValue inheritedValue = context.inheritFromWidgetOfExactType(InheritedValue);
+                  return new Container(
+                    key: childTwoKey,
+                    width: inheritedValue.value,
+                  );
+                }
+              )
+            ),
+          ]
+        )
+      );
+    }
+
+    // -- Initially the parent and child one are linked.
+    await tester.pumpWidget(buildFrame());
+    RenderBox box = tester.renderObject(find.byKey(parentKey));
+    expect(box.size.width, equals(100.0));
+
+    box = tester.renderObject(find.byKey(childOneKey));
+    expect(box.size.width, equals(100.0));
+
+    // Child two is not actually linked to anything (link is null),
+    // so it inherits via the usual path to the tree's root.
+    box = tester.renderObject(find.byKey(childTwoKey));
+    expect(box.size.width, equals(200.0));
+
+    // -- Make the parent link to child two instead of child one.
+    parentLink = linkChildTwoKey;
+    childOneLink = null;
+    childTwoLink = linkParentKey;
+
+    await tester.pumpWidget(buildFrame());
+    await tester.pump();
+
+    box = tester.renderObject(find.byKey(parentKey));
+    expect(box.size.width, equals(100.0));
+
+    box = tester.renderObject(find.byKey(childOneKey));
+    expect(box.size.width, equals(200.0));
+
+    box = tester.renderObject(find.byKey(childTwoKey));
+    expect(box.size.width, equals(100.0));
+  });
+
+}


### PR DESCRIPTION
Enable a widget to inherit from a widget that's not its parent.

The widget contained by an InheritedWidgetLinkChild inherits from the ancestors of the InheritedWidgetLinkParent that it is linked to.

The link itself is bi-directional and must be defined in terms of global keys. The value of the InheritedWidgetLinkParent's link is the InheritedWidgetLinkChild's global key, and vice versa.

The inheritance link is exlusive: the InheritedWidgetLinkChild only inherits from the InheritedWidgetLinkParent's ancestors, it no longer inherits from its own ancestors.

The value of the link may be null, which restores normal inherited widget behavior.

Fixes #5572
