### PR TITLE
Adding Reference to Text Input guide in Input API Documentation

### DIFF
--- a/packages/flutter/lib/src/material/input.dart
+++ b/packages/flutter/lib/src/material/input.dart
@@ -24,7 +24,7 @@ export 'package:flutter_services/editing.dart' show KeyboardType;
 ///
 ///  * <https://www.google.com/design/spec/components/text-fields.html>
 ///
-/// For detailed a guide on using the input widget, see:
+/// For a detailed guide on using the input widget, see:
 ///
 /// * <https://flutter.io/text-input/>
 class Input extends StatefulWidget {

--- a/packages/flutter/lib/src/material/input.dart
+++ b/packages/flutter/lib/src/material/input.dart
@@ -24,7 +24,7 @@ export 'package:flutter_services/editing.dart' show KeyboardType;
 ///
 ///  * <https://www.google.com/design/spec/components/text-fields.html>
 ///
-/// For detailed guide on using the input widget, see:
+/// For detailed a guide on using the input widget, see:
 ///
 /// * <https://flutter.io/text-input/>
 class Input extends StatefulWidget {

--- a/packages/flutter/lib/src/material/input.dart
+++ b/packages/flutter/lib/src/material/input.dart
@@ -23,6 +23,10 @@ export 'package:flutter_services/editing.dart' show KeyboardType;
 /// See also:
 ///
 ///  * <https://www.google.com/design/spec/components/text-fields.html>
+///
+/// For detailed guide on using the input widget, see:
+///
+/// * <https://flutter.io/text-input/>
 class Input extends StatefulWidget {
   /// Creates a text input field.
   ///


### PR DESCRIPTION
Adding reference to [Flutter Text Input Guide](https://flutter.io/text-input/) in API docs for `Input`.

Addressing issue #5987.

@abarth @sethladd 
