### PR TITLE
Persistent bottom sheet should not overlap app bar

### DIFF
--- a/packages/flutter/lib/src/material/scaffold.dart
+++ b/packages/flutter/lib/src/material/scaffold.dart
@@ -120,7 +120,7 @@ class _ScaffoldLayout extends MultiChildLayoutDelegate {
     Size snackBarSize = Size.zero;
 
     if (hasChild(_ScaffoldSlot.bottomSheet)) {
-      bottomSheetSize = layoutChild(_ScaffoldSlot.bottomSheet, fullWidthConstraints);
+      bottomSheetSize = layoutChild(_ScaffoldSlot.bottomSheet, fullWidthConstraints.copyWith(maxHeight: contentBottom - contentTop));
       positionChild(_ScaffoldSlot.bottomSheet, new Offset((size.width - bottomSheetSize.width) / 2.0, bottom - bottomSheetSize.height));
     }
 

--- a/packages/flutter/test/material/scaffold_test.dart
+++ b/packages/flutter/test/material/scaffold_test.dart
@@ -196,4 +196,46 @@ void main() {
     await tester.pump(new Duration(seconds: 1));
     expect(scrollableKey.currentState.scrollOffset, equals(500.0));
   });
+
+  testWidgets('Bottom sheet cannot overlap app bar', (WidgetTester tester) async {
+    Key sheetKey = new UniqueKey();
+
+    await tester.pumpWidget(
+      new MaterialApp(
+        theme: new ThemeData(platform: TargetPlatform.android),
+        home: new Scaffold(
+          appBar: new AppBar(
+            title: new Text('Title')
+          ),
+          body: new Builder(
+            builder: (BuildContext context) {
+              return new GestureDetector(
+                onTap: () {
+                  Scaffold.of(context).showBottomSheet((BuildContext context) {
+                    return new Container(
+                      key: sheetKey,
+                      decoration: new BoxDecoration(backgroundColor: Colors.blue[500])
+                    );
+                  });
+                },
+                child: new Text('X')
+              );
+            }
+          )
+        )
+      )
+    );
+
+    await tester.tap(find.text('X'));
+    await tester.pump(); // start animation
+    await tester.pump(const Duration(seconds: 1));
+
+    RenderBox appBarBox = tester.renderObject(find.byType(AppBar));
+    RenderBox sheetBox = tester.renderObject(find.byKey(sheetKey));
+
+    Point appBarBottomRight = appBarBox.localToGlobal(appBarBox.size.bottomRight(Point.origin));
+    Point sheetTopRight = sheetBox.localToGlobal(sheetBox.size.topRight(Point.origin));
+
+    expect(appBarBottomRight, equals(sheetTopRight));
+  });
 }


### PR DESCRIPTION
The spec forbids persistent bottom sheets from overlapping the app bar. There
are also some fancy scroll-linked effects that we're supposed to do with
persistent bottom sheets, but those will need to wait for another patch.

Fixes #5143
