### PR TITLE
Dialogs shouldn't scroll their headers or buttons

### DIFF
--- a/examples/flutter_gallery/lib/demo/dialog_demo.dart
+++ b/examples/flutter_gallery/lib/demo/dialog_demo.dart
@@ -33,16 +33,12 @@ class DialogDemoItem extends StatelessWidget {
     return new InkWell(
       onTap: onPressed,
       child: new Padding(
-        padding: const EdgeInsets.symmetric(vertical: 8.0),
+        padding: const EdgeInsets.symmetric(vertical: 8.0, horizontal: 24.0),
         child: new Row(
           mainAxisAlignment: MainAxisAlignment.start,
           crossAxisAlignment: CrossAxisAlignment.center,
           children: <Widget>[
-            new Icon(
-              icon,
-              size: 36.0,
-              color: color
-            ),
+            new Icon(icon, size: 36.0, color: color),
             new Padding(
               padding: const EdgeInsets.only(left: 16.0),
               child: new Text(text)
@@ -156,6 +152,7 @@ class DialogDemoState extends State<DialogDemo> {
                 context: context,
                 dialog: new Dialog(
                   title: new Text('Set backup account'),
+                  contentPadding: const EdgeInsets.only(top: 12.0, bottom: 16.0),
                   content: new Column(
                     children: <Widget>[
                       new DialogDemoItem(

--- a/packages/flutter/lib/src/material/dialog.dart
+++ b/packages/flutter/lib/src/material/dialog.dart
@@ -81,14 +81,11 @@ class Dialog extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    List<Widget> dialogBody = new List<Widget>();
+    final List<Widget> children = new List<Widget>();
 
     if (title != null) {
-      EdgeInsets padding = titlePadding;
-      if (padding == null)
-        padding = new EdgeInsets.fromLTRB(24.0, 24.0, 24.0, content == null ? 20.0 : 0.0);
-      dialogBody.add(new Padding(
-        padding: padding,
+      children.add(new Padding(
+        padding: titlePadding ?? new EdgeInsets.fromLTRB(24.0, 24.0, 24.0, content == null ? 20.0 : 0.0),
         child: new DefaultTextStyle(
           style: Theme.of(context).textTheme.title,
           child: title
@@ -97,20 +94,22 @@ class Dialog extends StatelessWidget {
     }
 
     if (content != null) {
-      EdgeInsets padding = contentPadding;
-      if (padding == null)
-        padding = const EdgeInsets.fromLTRB(24.0, 20.0, 24.0, 24.0);
-      dialogBody.add(new Padding(
-        padding: padding,
-        child: new DefaultTextStyle(
-          style: Theme.of(context).textTheme.subhead,
-          child: content
+      children.add(new Flexible(
+        fit: FlexFit.loose,
+        child: new ScrollableViewport(
+          child: new Padding(
+            padding: contentPadding ?? const EdgeInsets.fromLTRB(24.0, 20.0, 24.0, 24.0),
+            child: new DefaultTextStyle(
+              style: Theme.of(context).textTheme.subhead,
+              child: content
+            )
+          )
         )
       ));
     }
 
     if (actions != null) {
-      dialogBody.add(new ButtonTheme.bar(
+      children.add(new ButtonTheme.bar(
         child: new ButtonBar(
           alignment: MainAxisAlignment.end,
           children: actions
@@ -128,7 +127,11 @@ class Dialog extends StatelessWidget {
             color: _getColor(context),
             type: MaterialType.card,
             child: new IntrinsicWidth(
-              child: new Block(children: dialogBody)
+              child: new Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: children
+              )
             )
           )
         )

--- a/packages/flutter/test/material/dialog_test.dart
+++ b/packages/flutter/test/material/dialog_test.dart
@@ -1,0 +1,58 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('Dialog is scrollable', (WidgetTester tester) async {
+    bool didPressOk = false;
+
+    await tester.pumpWidget(
+      new MaterialApp(
+        home: new Material(
+          child: new Builder(
+            builder: (BuildContext context) {
+              return new Center(
+                child: new RaisedButton(
+                  child: new Text('X'),
+                  onPressed: () {
+                    showDialog(
+                      context: context,
+                      child: new Dialog(
+                        content: new Container(
+                          height: 5000.0,
+                          width: 300.0,
+                          decoration: new BoxDecoration(
+                            backgroundColor: Colors.green[500]
+                          )
+                        ),
+                        actions: <Widget>[
+                          new FlatButton(
+                            onPressed: () {
+                              didPressOk = true;
+                            },
+                            child: new Text('OK')
+                          )
+                        ]
+                      )
+                    );
+                  }
+                )
+              );
+            }
+          )
+        )
+      )
+    );
+
+    await tester.tap(find.text('X'));
+    await tester.pump(); // start animation
+    await tester.pump(const Duration(seconds: 1));
+
+    expect(didPressOk, false);
+    await tester.tap(find.text('OK'));
+    expect(didPressOk, true);
+  });
+}


### PR DESCRIPTION
Rather than scrolling the entire contents of the dialog, we should instead
scroll only the part between the title and the button bar.

Also, polish up the padding in the simple dialog demo.

Fixes #6057
