### PR TITLE
return info about whether a device is an emulator

### DIFF
--- a/packages/flutter_tools/lib/src/commands/daemon.dart
+++ b/packages/flutter_tools/lib/src/commands/daemon.dart
@@ -557,11 +557,12 @@ class DeviceDomain extends Domain {
   }
 }
 
-Map<String, String> _deviceToMap(Device device) {
-  return <String, String>{
+Map<String, dynamic> _deviceToMap(Device device) {
+  return <String, dynamic>{
     'id': device.id,
     'name': device.name,
-    'platform': getNameForTargetPlatform(device.platform)
+    'platform': getNameForTargetPlatform(device.platform),
+    'emulator': device.isLocalEmulator
   };
 }
 


### PR DESCRIPTION
Return info about whether a device is an emulator (this is good to know for clients that want to offer to start an ios simulator instance, only if an instance is not already running).

@pq
