### PR TITLE
Rename Container.align to alignment

### DIFF
--- a/dev/manual_tests/card_collection.dart
+++ b/dev/manual_tests/card_collection.dart
@@ -284,7 +284,7 @@ class CardCollectionState extends State<CardCollection> {
       flexibleSpace: new Container(
         padding: const EdgeInsets.only(left: 72.0),
         height: 128.0,
-        align: const FractionalOffset(0.0, 0.75),
+        alignment: const FractionalOffset(0.0, 0.75),
         child: new Text('Swipe Away: ${_cardModels.length}', style: Theme.of(context).primaryTextTheme.title)
       )
     );

--- a/examples/flutter_gallery/lib/demo/full_screen_dialog_demo.dart
+++ b/examples/flutter_gallery/lib/demo/full_screen_dialog_demo.dart
@@ -166,7 +166,7 @@ class FullScreenDialogDemoState extends State<FullScreenDialogDemo> {
             decoration: new BoxDecoration(
               border: new Border(bottom: new BorderSide(color: theme.dividerColor))
             ),
-            align: FractionalOffset.bottomLeft,
+            alignment: FractionalOffset.bottomLeft,
             child: new Text('Event name', style: theme.textTheme.display2)
           ),
           new Container(
@@ -174,7 +174,7 @@ class FullScreenDialogDemoState extends State<FullScreenDialogDemo> {
             decoration: new BoxDecoration(
               border: new Border(bottom: new BorderSide(color: theme.dividerColor))
             ),
-            align: FractionalOffset.bottomLeft,
+            alignment: FractionalOffset.bottomLeft,
             child: new Text('Location', style: theme.textTheme.title.copyWith(color: Colors.black54))
           ),
           new Column(

--- a/examples/flutter_gallery/lib/demo/text_field_demo.dart
+++ b/examples/flutter_gallery/lib/demo/text_field_demo.dart
@@ -121,7 +121,7 @@ class TextFieldDemoState extends State<TextFieldDemo> {
             ),
             new Container(
               padding: const EdgeInsets.all(20.0),
-              align: const FractionalOffset(0.5, 0.5),
+              alignment: const FractionalOffset(0.5, 0.5),
               child: new RaisedButton(
                 child: new Text('SUBMIT'),
                 onPressed: _handleSubmitted,

--- a/examples/flutter_gallery/lib/gallery/home.dart
+++ b/examples/flutter_gallery/lib/gallery/home.dart
@@ -130,7 +130,7 @@ class GalleryHomeState extends State<GalleryHome> with SingleTickerProviderState
           new Container(
             height: 48.0,
             padding: const EdgeInsets.only(left: 16.0),
-            align: FractionalOffset.centerLeft,
+            alignment: FractionalOffset.centerLeft,
             child: new Text(galleryItem.category, style: headerStyle)
           )
         );

--- a/packages/flutter/lib/src/material/data_table.dart
+++ b/packages/flutter/lib/src/material/data_table.dart
@@ -406,7 +406,7 @@ class DataTable extends StatelessWidget {
     label = new Container(
       padding: padding,
       height: _kHeadingRowHeight,
-      align: new FractionalOffset(numeric ? 1.0 : 0.0, 0.5), // TODO(ianh): RTL for non-numeric
+      alignment: new FractionalOffset(numeric ? 1.0 : 0.0, 0.5), // TODO(ianh): RTL for non-numeric
       child: new AnimatedDefaultTextStyle(
         style: new TextStyle(
           // TODO(ianh): font family should be Roboto; see https://github.com/flutter/flutter/issues/3116
@@ -456,7 +456,7 @@ class DataTable extends StatelessWidget {
     label = new Container(
       padding: padding,
       height: _kDataRowHeight,
-      align: new FractionalOffset(numeric ? 1.0 : 0.0, 0.5), // TODO(ianh): RTL for non-numeric
+      alignment: new FractionalOffset(numeric ? 1.0 : 0.0, 0.5), // TODO(ianh): RTL for non-numeric
       child: new DefaultTextStyle(
         style: new TextStyle(
           // TODO(ianh): font family should be Roboto; see https://github.com/flutter/flutter/issues/3116

--- a/packages/flutter/lib/src/material/drop_down.dart
+++ b/packages/flutter/lib/src/material/drop_down.dart
@@ -366,7 +366,7 @@ class DropdownMenuItem<T> extends StatelessWidget {
   Widget build(BuildContext context) {
     return new Container(
       height: _kMenuItemHeight,
-      align: FractionalOffset.centerLeft,
+      alignment: FractionalOffset.centerLeft,
       child: child
     );
   }

--- a/packages/flutter/lib/src/material/list_item.dart
+++ b/packages/flutter/lib/src/material/list_item.dart
@@ -154,7 +154,7 @@ class ListItem extends StatelessWidget {
       children.add(new Container(
         margin: const EdgeInsets.only(right: 16.0),
         width: 40.0,
-        align: FractionalOffset.centerLeft,
+        alignment: FractionalOffset.centerLeft,
         child: leading
       ));
     }
@@ -186,7 +186,7 @@ class ListItem extends StatelessWidget {
     if (trailing != null) {
       children.add(new Container(
         margin: const EdgeInsets.only(left: 16.0),
-        align: FractionalOffset.centerRight,
+        alignment: FractionalOffset.centerRight,
         child: trailing
       ));
     }

--- a/packages/flutter/lib/src/material/refresh_indicator.dart
+++ b/packages/flutter/lib/src/material/refresh_indicator.dart
@@ -381,7 +381,7 @@ class RefreshIndicatorState extends State<RefreshIndicator> with TickerProviderS
                 padding: _isIndicatorAtTop
                   ? new EdgeInsets.only(top: config.displacement)
                   : new EdgeInsets.only(bottom: config.displacement),
-                align: _isIndicatorAtTop
+                alignment: _isIndicatorAtTop
                   ? FractionalOffset.bottomCenter
                   : FractionalOffset.topCenter,
                 child: new ScaleTransition(

--- a/packages/flutter/lib/src/widgets/container.dart
+++ b/packages/flutter/lib/src/widgets/container.dart
@@ -76,7 +76,7 @@ class Container extends StatelessWidget {
   /// The `height` and `width` values include the padding.
   Container({
     Key key,
-    this.align,
+    this.alignment,
     this.padding,
     this.decoration,
     this.foregroundDecoration,
@@ -107,7 +107,7 @@ class Container extends StatelessWidget {
   ///
   /// If non-null, the container will expand to fill its parent and position its
   /// child within itself according to the given value.
-  final FractionalOffset align;
+  final FractionalOffset alignment;
 
   /// Empty space to inscribe inside the decoration.
   final EdgeInsets padding;
@@ -145,8 +145,8 @@ class Container extends StatelessWidget {
     if (child == null && (constraints == null || !constraints.isTight))
       current = new ConstrainedBox(constraints: const BoxConstraints.expand());
 
-    if (align != null)
-      current = new Align(alignment: align, child: current);
+    if (alignment != null)
+      current = new Align(alignment: alignment, child: current);
 
     EdgeInsets effectivePadding = _paddingIncludingDecoration;
     if (effectivePadding != null)


### PR DESCRIPTION
To match the Align widget (and several other widgets).

Fixes #6101
