### PR TITLE
use less granular progress

### DIFF
--- a/packages/flutter_tools/lib/src/hot.dart
+++ b/packages/flutter_tools/lib/src/hot.dart
@@ -18,12 +18,12 @@ import 'cache.dart';
 import 'commands/build_apk.dart';
 import 'commands/install.dart';
 import 'dart/package_map.dart';
+import 'devfs.dart';
 import 'device.dart';
 import 'globals.dart';
-import 'devfs.dart';
-import 'vmservice.dart';
 import 'resident_runner.dart';
 import 'toolchain.dart';
+import 'vmservice.dart';
 
 const bool kHotReloadDefault = true;
 
@@ -272,7 +272,7 @@ class HotRunner extends ResidentRunner {
     }
 
     await vmService.vm.refreshViews();
-    printStatus('Connected to view \'${vmService.vm.mainView}\'.');
+    printStatus('Connected to ${vmService.vm.mainView}.');
 
     printStatus('Running ${getDisplayPath(_mainPath)} on ${device.name}...');
     _loaderShowMessage('Launching...');
@@ -284,7 +284,7 @@ class HotRunner extends ResidentRunner {
 
     registerSignalHandlers();
 
-    printStatus('Finishing file synchronization...');
+    printTrace('Finishing file synchronization');
     // Finish the file sync now.
     await _updateDevFS();
 
@@ -347,13 +347,12 @@ class HotRunner extends ResidentRunner {
   }
 
   Future<bool> _updateDevFS({ DevFSProgressReporter progressReporter }) async {
+    Status devFSStatus = logger.startProgress('Syncing files to device...');
     final bool rebuildBundle = bundle.needsBuild();
     if (rebuildBundle) {
-      Status bundleStatus = logger.startProgress('Updating assets...');
+      printTrace('Updating assets');
       await bundle.build();
-      bundleStatus.stop(showElapsedTime: true);
     }
-    Status devFSStatus = logger.startProgress('Syncing files to device...');
     await _devFS.update(progressReporter: progressReporter,
                         bundle: bundle,
                         bundleDirty: rebuildBundle,
@@ -495,17 +494,14 @@ class HotRunner extends ResidentRunner {
       return false;
     }
     await _evictDirtyAssets();
-    Status reassembleStatus =
-        logger.startProgress('Reassembling application...');
+    printTrace('Reassembling application');
     bool waitForFrame = true;
     try {
       waitForFrame = (await currentView.uiIsolate.flutterReassemble() != null);
     } catch (_) {
-      reassembleStatus.stop(showElapsedTime: true);
       printError('Reassembling application failed.');
       return false;
     }
-    reassembleStatus.stop(showElapsedTime: true);
     try {
       /* ensure that a frame is scheduled */
       await currentView.uiIsolate.uiWindowScheduleFrame();
@@ -516,8 +512,8 @@ class HotRunner extends ResidentRunner {
       // When the framework is present, we can wait for the first frame
       // event and measure reload itme.
       await firstFrameTimer.firstFrame();
-      printStatus('Hot reload time: '
-                  '${getElapsedAsMilliseconds(firstFrameTimer.elapsed)}');
+      printStatus('Hot reload performed in '
+                  '${getElapsedAsMilliseconds(firstFrameTimer.elapsed)}.');
       if (benchmarkMode) {
         benchmarkData['hotReloadMillisecondsToFrame'] =
             firstFrameTimer.elapsed.inMilliseconds;

--- a/packages/flutter_tools/lib/src/hot.dart
+++ b/packages/flutter_tools/lib/src/hot.dart
@@ -425,8 +425,8 @@ class HotRunner extends ResidentRunner {
     }
     restartStatus.stop(showElapsedTime: true);
     if (waitForFrame) {
-      printStatus('Restart time: '
-                  '${getElapsedAsMilliseconds(firstFrameTimer.elapsed)}');
+      printStatus('Restart performed in '
+                  '${getElapsedAsMilliseconds(firstFrameTimer.elapsed)}.');
       if (benchmarkMode) {
         benchmarkData['hotRestartMillisecondsToFrame'] =
             firstFrameTimer.elapsed.inMilliseconds;

--- a/packages/flutter_tools/lib/src/run.dart
+++ b/packages/flutter_tools/lib/src/run.dart
@@ -202,7 +202,7 @@ class RunAndStayResident extends ResidentRunner {
 
     if (vmService != null) {
       await vmService.vm.refreshViews();
-      printStatus('Connected to view \'${vmService.vm.mainView}\'.');
+      printStatus('Connected to ${vmService.vm.mainView}\.');
     }
 
     if (vmService != null && traceStartup) {


### PR DESCRIPTION
Use a few larger progress displays rather than many smaller ones (also, don't nest progress displays).

From the cli:

```
Syncing files to device...                           0.2s
Performing hot reload...                             1.1s
Reloaded 230 of 499 libraries.
Hot reload performed in 2018 ms.
```

More importantly, this works better in IDEs. It's nicer to be able to show one progress message for a few hundred milliseconds, instead of flashing 4-5 smaller ones.
