### PR TITLE
Remove Pesto recipe card scaffold leading override

### DIFF
--- a/examples/flutter_gallery/lib/demo/pesto_demo.dart
+++ b/examples/flutter_gallery/lib/demo/pesto_demo.dart
@@ -313,11 +313,6 @@ class _RecipePageState extends State<RecipePage> {
         expandedHeight: _getAppBarHeight(context),
         backgroundColor: Colors.transparent,
         elevation: 0,
-        leading: new IconButton(
-          icon: new Icon(Icons.arrow_back),
-          onPressed: () => Navigator.pop(context),
-          tooltip: 'Back'
-        ),
         actions: <Widget>[
           new PopupMenuButton<String>(
             onSelected: (String item) {},


### PR DESCRIPTION
The current implementation matches the default behaviour of the material
scaffold.
