### PR TITLE
Fix Gallery example code display initialization

### DIFF
--- a/examples/flutter_gallery/lib/gallery/demo.dart
+++ b/examples/flutter_gallery/lib/gallery/demo.dart
@@ -115,14 +115,13 @@ class FullScreenCodeDialogState extends State<FullScreenCodeDialog> {
   String _exampleCode;
 
   @override
-  void initState() {
-    super.initState();
-
+  void dependenciesChanged() {
     getExampleCode(config.exampleCodeTag, DefaultAssetBundle.of(context)).then((String code) {
       setState(() {
         _exampleCode = code;
       });
     });
+    super.dependenciesChanged();
   }
 
   @override

--- a/examples/flutter_gallery/lib/gallery/example_code_parser.dart
+++ b/examples/flutter_gallery/lib/gallery/example_code_parser.dart
@@ -18,7 +18,8 @@ Future<String> getExampleCode(String tag, AssetBundle bundle) async {
 }
 
 Future<Null> _parseExampleCode(AssetBundle bundle) async {
-  final String code = await bundle.loadString('lib/gallery/example_code.dart');
+  final String code = await bundle.loadString('lib/gallery/example_code.dart') ??
+    '// lib/gallery/example_code.dart not found\n';
   _exampleCode = <String, String>{};
 
   final List<String> lines = code.split('\n');

--- a/examples/flutter_gallery/test/example_code_display_test.dart
+++ b/examples/flutter_gallery/test/example_code_display_test.dart
@@ -1,0 +1,53 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_gallery/gallery/app.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+Finder byTooltip(WidgetTester tester, String message) {
+  return find.byWidgetPredicate((Widget widget) {
+    return widget is Tooltip && widget.message == message;
+  });
+}
+
+void main() {
+  TestWidgetsFlutterBinding binding = TestWidgetsFlutterBinding.ensureInitialized();
+  if (binding is LiveTestWidgetsFlutterBinding)
+    binding.allowAllFrames = true;
+
+  testWidgets('Flutter gallery button example code displays', (WidgetTester tester) async {
+    // Regression test for https://github.com/flutter/flutter/issues/6147
+
+    await tester.pumpWidget(new GalleryApp());
+    await tester.pump(); // see https://github.com/flutter/flutter/issues/1865
+    await tester.pump(); // triggers a frame
+
+
+    // Scroll the Buttons demo into view so that a tap will succeed
+    final Point allDemosOrigin = tester.getTopRight(find.text('Demos'));
+    final Point buttonsDemoOrigin = tester.getTopRight(find.text('Buttons'));
+    final double scrollDelta  = buttonsDemoOrigin.y - allDemosOrigin.y;
+    await tester.scrollAt(allDemosOrigin, new Offset(0.0, -scrollDelta));
+    await tester.pump(); // start the scroll
+    await tester.pump(const Duration(seconds: 1));
+
+    // Launch the buttons demo and then prove that showing the example
+    // code dialog does not crash.
+
+    await tester.tap(find.text('Buttons'));
+    await tester.pump(); // start animation
+    await tester.pump(const Duration(seconds: 1)); // end animation
+
+    await tester.tap(find.text('RAISED'));
+    await tester.pump(); // start animation
+    await tester.pump(const Duration(seconds: 1)); // end animation
+
+    await tester.tap(byTooltip(tester, 'Show example code'));
+    await tester.pump(); // start animation
+    await tester.pump(const Duration(seconds: 1)); // end animation
+
+    expect(find.text('Example code'), findsOneWidget);
+  });
+}

--- a/packages/flutter_markdown/lib/src/markdown_raw.dart
+++ b/packages/flutter_markdown/lib/src/markdown_raw.dart
@@ -130,9 +130,9 @@ class MarkdownBodyRaw extends StatefulWidget {
 class _MarkdownBodyRawState extends State<MarkdownBodyRaw> {
 
   @override
-  void initState() {
-    super.initState();
+  void dependenciesChanged() {
     _buildMarkdownCache();
+    super.dependenciesChanged();
   }
 
   @override


### PR DESCRIPTION
The example code dialog now displays a "// Can't find ...' comment when it can't
find the example code. This enables testing the dialog initialization code path
even though the test framework doesn't pick up the asset bundle that contains the
example code sources. The sample code parser is aleady separately tested, see
examples/flutter_gallery/test/example_code_parser_test.dart.

Fixes #6147
