### PR TITLE
Isolate Mozart dependencies

### DIFF
--- a/packages/flutter/lib/src/rendering/child_view.dart
+++ b/packages/flutter/lib/src/rendering/child_view.dart
@@ -20,6 +20,7 @@ import 'package:mojo/mojo/service_provider.mojom.dart' as mojom;
 
 import 'box.dart';
 import 'object.dart';
+import 'layer.dart';
 
 mojom.ViewProxy _initViewProxy() {
   int viewHandle = ui.MojoServices.takeView();
@@ -308,8 +309,15 @@ class RenderChildView extends RenderBox {
   @override
   void paint(PaintingContext context, Offset offset) {
     assert(needsCompositing);
-    if (_child?._viewInfo != null)
-      context.pushChildScene(offset, scale, _physicalWidth, _physicalHeight, _child._viewInfo.sceneToken);
+    if (_child?._viewInfo != null) {
+      context.addLayer(new ChildSceneLayer(
+        offset: offset,
+        devicePixelRatio: scale,
+        physicalWidth: _physicalWidth,
+        physicalHeight: _physicalHeight,
+        sceneToken: _child._viewInfo.sceneToken.value
+      ));
+    }
     assert(() {
       if (_view == null) {
         context.canvas.drawRect(offset & size, new Paint()..color = const Color(0xFF0000FF));

--- a/packages/flutter/lib/src/rendering/layer.dart
+++ b/packages/flutter/lib/src/rendering/layer.dart
@@ -8,7 +8,6 @@ import 'dart:ui' show Offset;
 import 'package:flutter/painting.dart';
 import 'package:vector_math/vector_math_64.dart';
 import 'package:meta/meta.dart';
-import 'package:flutter_services/mojo/gfx/composition/scene_token.dart' as mojom;
 
 import 'debug.dart';
 
@@ -161,7 +160,7 @@ class ChildSceneLayer extends Layer {
   int physicalHeight;
 
   /// The composited scene that will contain the content rendered by the child.
-  mojom.SceneToken sceneToken;
+  int sceneToken;
 
   @override
   void addToScene(ui.SceneBuilder builder, Offset layerOffset) {
@@ -170,7 +169,7 @@ class ChildSceneLayer extends Layer {
       devicePixelRatio,
       physicalWidth,
       physicalHeight,
-      sceneToken.value
+      sceneToken
     );
   }
 
@@ -180,7 +179,7 @@ class ChildSceneLayer extends Layer {
     description.add('offset: $offset');
     description.add('physicalWidth: $physicalWidth');
     description.add('physicalHeight: $physicalHeight');
-    description.add('sceneToken.value: ${sceneToken.value}');
+    description.add('sceneToken: $sceneToken');
   }
 }
 

--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -10,7 +10,6 @@ import 'package:flutter/gestures.dart';
 import 'package:flutter/painting.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:meta/meta.dart';
-import 'package:flutter_services/mojo/gfx/composition/scene_token.dart' as mojom;
 import 'package:vector_math/vector_math_64.dart';
 
 import 'debug.dart';
@@ -217,39 +216,18 @@ class PaintingContext {
     _currentLayer?.willChangeHint = true;
   }
 
-  /// Adds a performance overlay to the scene.
+  /// Adds a composited layer to the recording.
   ///
-  /// * `offset` is the offset from the origin of the canvas' coordinate system
-  ///   to the origin of the caller's coordinate system.
-  /// * `optionsMask` is a mask is created by shifting 1 by the index of the
-  ///   specific [PerformanceOverlayOption] to enable.
-  /// * `rasterizerThreshold` is an integer specifying the number of frame
-  ///   intervals that the rasterizer must miss before it decides that the frame
-  ///   is suitable for capturing an SkPicture trace for further analysis.
-  /// * `size` is the size of the overlay to draw. The upper left corner of the
-  ///   overlay will be placed at the origin of the caller's coodinate system.
+  /// After calling this function, the [canvas] property will change to refer to
+  /// a new [Canvas] that draws on top of the given layer.
   ///
-  /// Performance overlays are always composited because they display data that
-  /// isn't available until the compositing phase.
-  void pushPerformanceOverlay(Offset offset, int optionsMask, int rasterizerThreshold, Size size) {
+  /// A [RenderObject] that uses this function is very likely to require its
+  /// [RenderObject.needsCompositing] property to return true. That informs
+  /// ancestor render objects that this render object will include a composited
+  /// layer, which causes them to use composited clips, for example.
+  void addLayer(Layer layer) {
     _stopRecordingIfNeeded();
-    _appendLayer(new PerformanceOverlayLayer(
-      overlayRect: new Rect.fromLTWH(offset.dx, offset.dy, size.width, size.height),
-      optionsMask: optionsMask,
-      rasterizerThreshold: rasterizerThreshold
-    ));
-  }
-
-  /// (mojo-only) Draws content from another process.
-  void pushChildScene(Offset offset, double devicePixelRatio, int physicalWidth, int physicalHeight, mojom.SceneToken sceneToken) {
-    _stopRecordingIfNeeded();
-    _appendLayer(new ChildSceneLayer(
-      offset: offset,
-      devicePixelRatio: devicePixelRatio,
-      physicalWidth: physicalWidth,
-      physicalHeight: physicalHeight,
-      sceneToken: sceneToken
-    ));
+    _appendLayer(layer);
   }
 
   /// Clip further painting using a rectangle.

--- a/packages/flutter/lib/src/rendering/performance_overlay.dart
+++ b/packages/flutter/lib/src/rendering/performance_overlay.dart
@@ -4,6 +4,7 @@
 
 import 'box.dart';
 import 'object.dart';
+import 'layer.dart';
 
 /// The options that control whether the performance overlay displays certain
 /// aspects of the compositor.
@@ -136,6 +137,10 @@ class RenderPerformanceOverlay extends RenderBox {
   @override
   void paint(PaintingContext context, Offset offset) {
     assert(needsCompositing);
-    context.pushPerformanceOverlay(offset, optionsMask, rasterizerThreshold, size);
+    context.addLayer(new PerformanceOverlayLayer(
+      overlayRect: new Rect.fromLTWH(offset.dx, offset.dy, size.width, size.height),
+      optionsMask: optionsMask,
+      rasterizerThreshold: rasterizerThreshold
+    ));
   }
 }


### PR DESCRIPTION
This patch removes the Mozart dependencies from object.dart and
layer.dart, which will make it easier for us to move the Mozart
dependencies purely into the Fuchsia tree.
