### PR TITLE
Have the scale gesture callbacks use detail objects

### DIFF
--- a/examples/flutter_gallery/lib/demo/grid_list_demo.dart
+++ b/examples/flutter_gallery/lib/demo/grid_list_demo.dart
@@ -78,29 +78,29 @@ class _GridPhotoViewerState extends State<GridPhotoViewer> with SingleTickerProv
     });
   }
 
-  void _handleOnScaleStart(Point focalPoint) {
+  void _handleOnScaleStart(ScaleStartDetails details) {
     setState(() {
       _lastScale = 1.0;
-      _lastFocalPoint = focalPoint;
+      _lastFocalPoint = details.focalPoint;
       // The fling animation stops if an input gesture starts.
       _controller.stop();
     });
   }
 
-  void _handleOnScaleUpdate(double scale, Point focalPoint) {
+  void _handleOnScaleUpdate(ScaleUpdateDetails details) {
     setState(() {
-      _scale = (_scale + (scale - _lastScale)).clamp(1.0, 3.0);
-      _lastScale = scale;
-      _focalPoint = _clampFocalPoint(_focalPoint + (_lastFocalPoint - focalPoint));
-      _lastFocalPoint = focalPoint;
+      _scale = (_scale + (details.scale - _lastScale)).clamp(1.0, 3.0);
+      _lastScale = details.scale;
+      _focalPoint = _clampFocalPoint(_focalPoint + (_lastFocalPoint - details.focalPoint));
+      _lastFocalPoint = details.focalPoint;
     });
   }
 
-  void _handleOnScaleEnd(Velocity flingVelocity) {
-    final double magnitude = flingVelocity.pixelsPerSecond.distance;
+  void _handleOnScaleEnd(ScaleEndDetails details) {
+    final double magnitude = details.velocity.pixelsPerSecond.distance;
     if (magnitude < _kMinFlingVelocity)
       return;
-    final Offset direction = flingVelocity.pixelsPerSecond / magnitude;
+    final Offset direction = details.velocity.pixelsPerSecond / magnitude;
     final RenderBox box = context.findRenderObject();
     final double distance = (Point.origin & box.size).shortestSide;
     _flingAnimation = new Tween<Point>(

--- a/examples/layers/widgets/gestures.dart
+++ b/examples/layers/widgets/gestures.dart
@@ -79,21 +79,21 @@ class _GestureDemoState extends State<GestureDemo> {
   bool _doubleTapEnabled = true;
   bool _longPressEnabled = true;
 
-  void _handleScaleStart(Point focalPoint) {
+  void _handleScaleStart(ScaleStartDetails details) {
     setState(() {
-      _startingFocalPoint = focalPoint;
+      _startingFocalPoint = details.focalPoint;
       _previousOffset = _offset;
       _previousZoom = _zoom;
     });
   }
 
-  void _handleScaleUpdate(double scale, Point focalPoint) {
+  void _handleScaleUpdate(ScaleUpdateDetails details) {
     setState(() {
-      _zoom = (_previousZoom * scale);
+      _zoom = (_previousZoom * details.scale);
 
       // Ensure that item under the focal point stays in the same place despite zooming
       Offset normalizedOffset = (_startingFocalPoint.toOffset() - _previousOffset) / _previousZoom;
-      _offset = focalPoint.toOffset() - normalizedOffset * _zoom;
+      _offset = details.focalPoint.toOffset() - normalizedOffset * _zoom;
     });
   }
 

--- a/packages/flutter/lib/src/widgets/gesture_detector.dart
+++ b/packages/flutter/lib/src/widgets/gesture_detector.dart
@@ -26,6 +26,9 @@ export 'package:flutter/gestures.dart' show
   GestureScaleStartCallback,
   GestureScaleUpdateCallback,
   GestureScaleEndCallback,
+  ScaleStartDetails,
+  ScaleUpdateDetails,
+  ScaleEndDetails,
   TapDownDetails,
   TapUpDetails,
   Velocity;

--- a/packages/flutter/test/gestures/scale_test.dart
+++ b/packages/flutter/test/gestures/scale_test.dart
@@ -16,19 +16,19 @@ void main() {
 
     bool didStartScale = false;
     Point updatedFocalPoint;
-    scale.onStart = (Point focalPoint) {
+    scale.onStart = (ScaleStartDetails details) {
       didStartScale = true;
-      updatedFocalPoint = focalPoint;
+      updatedFocalPoint = details.focalPoint;
     };
 
     double updatedScale;
-    scale.onUpdate = (double scale, Point focalPoint) {
-      updatedScale = scale;
-      updatedFocalPoint = focalPoint;
+    scale.onUpdate = (ScaleUpdateDetails details) {
+      updatedScale = details.scale;
+      updatedFocalPoint = details.focalPoint;
     };
 
     bool didEndScale = false;
-    scale.onEnd = (Velocity flingVelocity) {
+    scale.onEnd = (ScaleEndDetails details) {
       didEndScale = true;
     };
 


### PR DESCRIPTION
Updated the signatures of the scale gesture callbacks to match how we handle drags and taps.

Per https://github.com/flutter/flutter/pull/6185#discussion_r81656099
