### PR TITLE
tweak the device description for emulators

### DIFF
--- a/packages/flutter_tools/lib/src/device.dart
+++ b/packages/flutter_tools/lib/src/device.dart
@@ -249,8 +249,10 @@ abstract class Device {
 
     return devices.map((Device device) {
       String supportIndicator = device.isSupported() ? '' : ' (unsupported)';
-      if (device.isLocalEmulator)
-        supportIndicator += ' • simulator';
+      if (device.isLocalEmulator) {
+        String type = device.platform == TargetPlatform.ios ? 'simulator' : 'emulator';
+        supportIndicator += ' ($type)';
+      }
       return '${device.name.padRight(nameWidth)} • '
              '${device.id.padRight(idWidth)} • '
              '${getNameForTargetPlatform(device.platform)}$supportIndicator';


### PR DESCRIPTION
- tweak the device description for emulators (use `simulator` for the iOS simulator and `emulator` for other devices)

```
1 connected device:

iPhone 6s Plus • 5CE9B176-0962-4C15-BFCA-E2B55B56830C • ios (simulator)
```

@danrubel 
