### PR TITLE
Flutter doctor detect intellij on Linux

### DIFF
--- a/packages/flutter_tools/lib/src/doctor.dart
+++ b/packages/flutter_tools/lib/src/doctor.dart
@@ -127,10 +127,11 @@ class Doctor {
       final String separator = Platform.isWindows ? ' ' : '•';
 
       for (ValidationMessage message in result.messages) {
+        String text = message.message.replaceAll('\n', '\n      ');
         if (message.isError) {
-          printStatus('    x ${message.message.replaceAll('\n', '\n      ')}', emphasis: true);
+          printStatus('    x $text', emphasis: true);
         } else {
-          printStatus('    $separator ${message.message.replaceAll('\n', '\n      ')}');
+          printStatus('    $separator $text');
         }
       }
     }
@@ -176,8 +177,6 @@ class ValidationResult {
   // A short message about the status.
   final String statusInfo;
   final List<ValidationMessage> messages;
-
-  bool get isInstalled => type == ValidationType.installed;
 
   String get leadingBox {
     if (type == ValidationType.missing)

--- a/packages/flutter_tools/lib/src/doctor.dart
+++ b/packages/flutter_tools/lib/src/doctor.dart
@@ -39,7 +39,13 @@ class Doctor {
     if (_iosWorkflow.appliesToHostPlatform)
       _validators.add(_iosWorkflow);
 
-    _validators.add(new AtomValidator());
+    List<DoctorValidator> ideValidators = <DoctorValidator>[];
+    ideValidators.addAll(AtomValidator.installed);
+    if (ideValidators.isNotEmpty)
+      _validators.addAll(ideValidators);
+    else
+      _validators.add(new NoIdeValidator());
+
     _validators.add(new DeviceValidator());
   }
 
@@ -226,8 +232,26 @@ class _FlutterValidator extends DoctorValidator {
   }
 }
 
+class NoIdeValidator extends DoctorValidator {
+  NoIdeValidator() : super('Flutter IDE Support');
+
+  @override
+  Future<ValidationResult> validate() async {
+    // TODO(danrubel) do not show Atom once IntelliJ support is complete
+    return new ValidationResult(ValidationType.missing, <ValidationMessage>[
+      new ValidationMessage('Atom - https://atom.io/'),
+      new ValidationMessage('IntelliJ - https://www.jetbrains.com/idea/'),
+    ], statusInfo: 'No supported IDEs installed');
+  }
+}
+
 class AtomValidator extends DoctorValidator {
   AtomValidator() : super('Atom - a lightweight development environment for Flutter');
+
+  static Iterable<DoctorValidator> get installed {
+    AtomValidator atom = new AtomValidator();
+    return atom.isInstalled ? <DoctorValidator>[atom] : <DoctorValidator>[];
+  }
 
   static File getConfigFile() {
     // ~/.atom/config.cson

--- a/packages/flutter_tools/lib/src/doctor.dart
+++ b/packages/flutter_tools/lib/src/doctor.dart
@@ -243,14 +243,15 @@ class AtomValidator extends DoctorValidator {
       : path.join(env['HOME'], '.atom');
   }
 
+  bool get isInstalled => FileSystemEntity.isDirectorySync(_getAtomHomePath());
+
   @override
   Future<ValidationResult> validate() async {
     List<ValidationMessage> messages = <ValidationMessage>[];
 
     int installCount = 0;
 
-    bool atomDirExists = FileSystemEntity.isDirectorySync(_getAtomHomePath());
-    if (!atomDirExists) {
+    if (!isInstalled) {
       messages.add(new ValidationMessage.error('Atom not installed; download at https://atom.io.'));
     } else {
       installCount++;
@@ -265,7 +266,7 @@ class AtomValidator extends DoctorValidator {
     return new ValidationResult(
       installCount == 3
         ? ValidationType.installed
-        : installCount == 1 ? ValidationType.partial : ValidationType.missing,
+        : installCount > 0 ? ValidationType.partial : ValidationType.missing,
       messages
     );
   }

--- a/packages/flutter_tools/lib/src/doctor.dart
+++ b/packages/flutter_tools/lib/src/doctor.dart
@@ -275,22 +275,14 @@ class AtomValidator extends DoctorValidator {
 
     int installCount = 0;
 
-    if (!isInstalled) {
-      messages.add(new ValidationMessage.error('Atom not installed; download at https://atom.io.'));
-    } else {
+    if (_validateHasPackage(messages, 'flutter', 'Flutter'))
       installCount++;
 
-      if (!_validateHasPackage(messages, 'flutter', 'Flutter'))
-        installCount++;
-
-      if (!_validateHasPackage(messages, 'dartlang', 'Dart'))
-        installCount++;
-    }
+    if (_validateHasPackage(messages, 'dartlang', 'Dart'))
+      installCount++;
 
     return new ValidationResult(
-      installCount == 3
-        ? ValidationType.installed
-        : installCount > 0 ? ValidationType.partial : ValidationType.missing,
+      installCount == 2 ? ValidationType.installed : ValidationType.partial,
       messages
     );
   }
@@ -301,19 +293,18 @@ class AtomValidator extends DoctorValidator {
         '$packageName plugin not installed; this adds $description specific functionality to Atom.\n'
         'Install the plugin from Atom or run \'apm install $packageName\'.'
       ));
-      return true;
-    } else {
-      try {
-        String flutterPluginPath = path.join(_getAtomHomePath(), 'packages', packageName);
-        File packageFile = new File(path.join(flutterPluginPath, 'package.json'));
-        Map<String, dynamic> packageInfo = JSON.decode(packageFile.readAsStringSync());
-        String version = packageInfo['version'];
-        messages.add(new ValidationMessage('$packageName plugin version $version'));
-      } catch (error) {
-        printTrace('Unable to read $packageName plugin version: $error');
-      }
       return false;
     }
+    try {
+      String flutterPluginPath = path.join(_getAtomHomePath(), 'packages', packageName);
+      File packageFile = new File(path.join(flutterPluginPath, 'package.json'));
+      Map<String, dynamic> packageInfo = JSON.decode(packageFile.readAsStringSync());
+      String version = packageInfo['version'];
+      messages.add(new ValidationMessage('$packageName plugin version $version'));
+    } catch (error) {
+      printTrace('Unable to read $packageName plugin version: $error');
+    }
+    return true;
   }
 
   bool hasPackage(String packageName) {

--- a/packages/flutter_tools/lib/src/doctor.dart
+++ b/packages/flutter_tools/lib/src/doctor.dart
@@ -237,7 +237,7 @@ class NoIdeValidator extends DoctorValidator {
 
   @override
   Future<ValidationResult> validate() async {
-    // TODO(danrubel) do not show Atom once IntelliJ support is complete
+    // TODO(danrubel): do not show Atom once IntelliJ support is complete
     return new ValidationResult(ValidationType.missing, <ValidationMessage>[
       new ValidationMessage('Atom - https://atom.io/'),
       new ValidationMessage('IntelliJ - https://www.jetbrains.com/idea/'),
@@ -314,10 +314,10 @@ class AtomValidator extends DoctorValidator {
 }
 
 class IntellijValidator extends DoctorValidator {
+  IntellijValidator(String title, {this.version, this.pluginsPath}) : super(title);
+
   final String version;
   final String pluginsPath;
-
-  IntellijValidator(String title, {this.version, this.pluginsPath}) : super(title);
 
   static Iterable<DoctorValidator> get installed {
     List<DoctorValidator> validators = <DoctorValidator>[];
@@ -353,10 +353,10 @@ class IntellijValidator extends DoctorValidator {
         }
       }
     } else if (Platform.isMacOS) {
-      // TODO(danrubel) add support for Mac
+      // TODO(danrubel): add support for Mac
 
     } else {
-      // TODO(danrubel) add support for Windows
+      // TODO(danrubel): add support for Windows
     }
     return validators;
   }
@@ -373,16 +373,18 @@ class IntellijValidator extends DoctorValidator {
     if (_validateHasPackage(messages, 'Flutter', 'Flutter'))
       installCount++;
 
-    if (installCount < 2)
+    if (installCount < 2) {
       messages.add(new ValidationMessage(
-        'For information about managing plugins, see\n'
-        'https://www.jetbrains.com/help/idea/2016.2/managing-plugins.html'
+          'For information about managing plugins, see\n'
+          'https://www.jetbrains.com/help/idea/2016.2/managing-plugins.html'
       ));
+    }
 
     return new ValidationResult(
         installCount == 2 ? ValidationType.installed : ValidationType.partial,
         messages,
-        statusInfo: 'version $version');
+        statusInfo: 'version $version'
+    );
   }
 
   bool _validateHasPackage(List<ValidationMessage> messages, String packageName, String description) {


### PR DESCRIPTION
This enhances `flutter doctor` on Linux so that it can detect [IntelliJ product installations](https://intellij-support.jetbrains.com/hc/en-us/articles/206544519-Directories-used-by-the-IDE-to-store-settings-caches-plugins-and-logs) and ensure that the needed plugins are installed. 

Future work:
- Detect IntelliJ products on Mac and Windows
- Support alternate [plugin locations](https://www.jetbrains.com/help/idea/2016.2/project-and-ide-settings.html)

For each IntelliJ product installation, you'll see something like this in `flutter doctor` output:

```
[-] IntelliJ IDEA Community Edition (version 2016.2)
    • Dart plugin installed
    • Flutter plugin not installed; this adds Flutter specific functionality.
    • For information about managing plugins, see
      https://www.jetbrains.com/help/idea/2016.2/managing-plugins.html
```

The "managing plugins" will only appear if one or more plugins are missing.

If Atom is installed, you'll also see something like this in the output:

```
[-] Atom - a lightweight development environment for Flutter
    • flutter plugin not installed; this adds Flutter specific functionality to Atom.
      Install the plugin from Atom or run 'apm install flutter'.
    • dartlang plugin version 0.6.34
```

If no supported IDEs are installed, you'll see:

```
[x] Flutter IDE Support (No supported IDEs installed)
    • Atom - https://atom.io/
    • IntelliJ - https://www.jetbrains.com/idea/
```

Partially addresses https://github.com/flutter/flutter/issues/5875
@devoncarew 
