### PR TITLE
improve error message for corrupt dart-sdk download

### DIFF
--- a/bin/cache/update_dart_sdk.sh
+++ b/bin/cache/update_dart_sdk.sh
@@ -42,11 +42,11 @@ if [ ! -f "$DART_SDK_STAMP_PATH" ] || [ "$DART_SDK_VERSION" != `cat "$DART_SDK_S
 
   curl --progress-bar -continue-at=- --location --output "$DART_SDK_ZIP" "$DART_SDK_URL"
   unzip -o -q "$DART_SDK_ZIP" -d "$FLUTTER_ROOT/bin/cache" || {
-    echo " "
-    echo "It appears that the downloaded file was corrupted; Please the operation again later."
+    echo
+    echo "It appears that the downloaded file is corrupt; please try the operation again later."
     echo "If this problem persists, please report the problem at"
     echo "https://github.com/flutter/flutter/issues/new"
-    echo " "
+    echo
     rm -f -- "$DART_SDK_ZIP"
     exit 1
   }

--- a/bin/cache/update_dart_sdk.sh
+++ b/bin/cache/update_dart_sdk.sh
@@ -41,7 +41,15 @@ if [ ! -f "$DART_SDK_STAMP_PATH" ] || [ "$DART_SDK_VERSION" != `cat "$DART_SDK_S
   DART_SDK_ZIP="$FLUTTER_ROOT/bin/cache/dart-sdk.zip"
 
   curl --progress-bar -continue-at=- --location --output "$DART_SDK_ZIP" "$DART_SDK_URL"
-  unzip -o -q "$DART_SDK_ZIP" -d "$FLUTTER_ROOT/bin/cache"
+  unzip -o -q "$DART_SDK_ZIP" -d "$FLUTTER_ROOT/bin/cache" || {
+    echo " "
+    echo "It appears that the downloaded file was corrupted; Please the operation again later."
+    echo "If this problem persists, please report the problem at"
+    echo "https://github.com/flutter/flutter/issues/new"
+    echo " "
+    rm -f -- "$DART_SDK_ZIP"
+    exit 1
+  }
   rm -f -- "$DART_SDK_ZIP"
   echo "$DART_SDK_VERSION" > "$DART_SDK_STAMP_PATH"
 fi


### PR DESCRIPTION
This change improves the user facing error message if the download dart-sdk.zip file is corrupted, and **ensures that the corrupt file is deleted** so that the next attempt will download a fresh file.

```
$ ../flutter/bin/cache/update_dart_sdk.sh 
Downloading Dart SDK 1.20.0-dev.10.1...
######################################################################## 100.0%
<some error from unzip here>

It appears that the downloaded file was corrupted; Please the operation again later.
If this problem persists, please report the problem at
https://github.com/flutter/flutter/issues/new
```

Fixes https://github.com/flutter/flutter/issues/6231
@Hixie 
