### PR TITLE
remove engineEnterTimestampMicros from benchmark list; not useful

### DIFF
--- a/dev/devicelab/lib/tasks/perf_tests.dart
+++ b/dev/devicelab/lib/tasks/perf_tests.dart
@@ -71,7 +71,6 @@ class StartupTest {
       ]).timeout(_startupTimeout);
       Map<String, dynamic> data = JSON.decode(file('$testDirectory/build/start_up_info.json').readAsStringSync());
       return new TaskResult.success(data, benchmarkScoreKeys: <String>[
-        'engineEnterTimestampMicros',
         'timeToFirstFrameMicros',
       ]);
     });


### PR DESCRIPTION
`engineEnterTimestampMicros` is not a useful number to track as a benchmark result. It's just an arbitrary timestamp.

/cc @cbracken 
