### PR TITLE
Deploy `@checked`

### DIFF
--- a/.analysis_options
+++ b/.analysis_options
@@ -21,7 +21,6 @@ analyzer:
     # allow overriding fields (if they use super, ideally...)
     strong_mode_invalid_field_override: ignore
     # allow type narrowing
-    strong_mode_invalid_method_override: ignore
     strong_mode_static_type_error: ignore
     strong_mode_down_cast_composite: ignore
     # allow having TODOs in the code

--- a/.analysis_options_repo
+++ b/.analysis_options_repo
@@ -22,7 +22,6 @@ analyzer:
     # allow overriding fields (if they use super, ideally...)
     strong_mode_invalid_field_override: ignore
     # allow type narrowing
-    strong_mode_invalid_method_override: ignore
     strong_mode_static_type_error: ignore
     strong_mode_down_cast_composite: ignore
     # allow having TODOs in the code

--- a/.analysis_options_user
+++ b/.analysis_options_user
@@ -23,7 +23,6 @@ analyzer:
     # allow overriding fields (if they use super, ideally...)
     strong_mode_invalid_field_override: ignore
     # allow type narrowing
-    strong_mode_invalid_method_override: ignore
     strong_mode_static_type_error: ignore
     strong_mode_down_cast_composite: ignore
     # allow having TODOs in the code

--- a/packages/flutter/lib/src/material/tabs.dart
+++ b/packages/flutter/lib/src/material/tabs.dart
@@ -925,7 +925,7 @@ class _TabBarState<T> extends ScrollableState<TabBar<T>> implements TabBarSelect
   }
 
   @override
-  ScrollBehavior<double, double> createScrollBehavior() {
+  ExtentScrollBehavior createScrollBehavior() {
     return new _TabsScrollBehavior()
       ..isScrollable = config.isScrollable;
   }

--- a/packages/flutter/lib/src/rendering/auto_layout.dart
+++ b/packages/flutter/lib/src/rendering/auto_layout.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:flutter/cassowary.dart' as al; // "auto layout"
+import 'package:meta/meta.dart';
 
 import 'box.dart';
 import 'object.dart';
@@ -144,7 +145,7 @@ abstract class AutoLayoutDelegate {
   List<al.Constraint> getConstraints(AutoLayoutRect parent);
 
   /// Override this method to return true when new constraints need to be generated.
-  bool shouldUpdateConstraints(AutoLayoutDelegate oldDelegate);
+  bool shouldUpdateConstraints(@checked AutoLayoutDelegate oldDelegate);
 }
 
 /// A render object that uses the cassowary constraint solver to automatically size and position children.

--- a/packages/flutter/lib/src/rendering/binding.dart
+++ b/packages/flutter/lib/src/rendering/binding.dart
@@ -223,7 +223,7 @@ abstract class RendererBinding extends BindingBase implements SchedulerBinding, 
     assert(renderView != null);
     renderView.hitTest(result, position: position);
     // This super call is safe since it will be bound to a mixed-in declaration.
-    super.hitTest(result, position); //ignore: abstract_super_member_reference
+    super.hitTest(result, position); // ignore: abstract_super_member_reference
   }
 
   void _forceRepaint() {
@@ -289,7 +289,7 @@ class SemanticsServer extends mojom.SemanticsServer {
   }
 
   @override
-  void addSemanticsListener(mojom.SemanticsListenerProxy listener) {
+  void addSemanticsListener(@checked mojom.SemanticsListenerProxy listener) {
     _listeners.add(listener);
   }
 

--- a/packages/flutter/lib/src/rendering/custom_layout.dart
+++ b/packages/flutter/lib/src/rendering/custom_layout.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:meta/meta.dart';
+
 import 'box.dart';
 import 'object.dart';
 
@@ -186,7 +188,7 @@ abstract class MultiChildLayoutDelegate {
   /// laid out. This should compare the fields of the current delegate
   /// and the given oldDelegate and return true if the fields are such
   /// that the layout would be different.
-  bool shouldRelayout(MultiChildLayoutDelegate oldDelegate);
+  bool shouldRelayout(@checked MultiChildLayoutDelegate oldDelegate);
 
   /// Override this method to include additional information in the
   /// debugging data printed by [debugDumpRenderTree] and friends.

--- a/packages/flutter/lib/src/rendering/flow.dart
+++ b/packages/flutter/lib/src/rendering/flow.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:flutter/foundation.dart';
+import 'package:meta/meta.dart';
 import 'package:vector_math/vector_math_64.dart';
 
 import 'box.dart';
@@ -107,7 +108,7 @@ abstract class FlowDelegate {
   /// This should compare the fields of the current delegate and the given
   /// oldDelegate and return true if the fields are such that the layout would
   /// be different.
-  bool shouldRelayout(FlowDelegate oldDelegate) => false;
+  bool shouldRelayout(@checked FlowDelegate oldDelegate) => false;
 
   /// Override this method to return true when the children need to be
   /// repainted. This should compare the fields of the current delegate and the
@@ -122,7 +123,7 @@ abstract class FlowDelegate {
   /// The flow container might repaint even if this function returns false, for
   /// example if layout triggers painting (e.g., if [shouldRelayout] returns
   /// true).
-  bool shouldRepaint(FlowDelegate oldDelegate);
+  bool shouldRepaint(@checked FlowDelegate oldDelegate);
 
   /// Override this method to include additional information in the
   /// debugging data printed by [debugDumpRenderTree] and friends.

--- a/packages/flutter/lib/src/rendering/grid.dart
+++ b/packages/flutter/lib/src/rendering/grid.dart
@@ -196,10 +196,10 @@ abstract class GridDelegate {
   /// [placementData] associated with that child as context. The returned
   /// [GridChildPlacement] is then used to determine the size and position of
   /// that child within the grid.
-  GridChildPlacement getChildPlacement(GridSpecification specification, int index, Object placementData);
+  GridChildPlacement getChildPlacement(GridSpecification specification, int index, @checked Object placementData);
 
   /// Override this method to return true when the children need to be laid out.
-  bool shouldRelayout(GridDelegate oldDelegate) => true;
+  bool shouldRelayout(@checked GridDelegate oldDelegate) => true;
 
   Size _getGridSize(BoxConstraints constraints, int childCount) {
     return getGridSpecification(constraints, childCount).gridSize;

--- a/packages/flutter/lib/src/rendering/node.dart
+++ b/packages/flutter/lib/src/rendering/node.dart
@@ -80,7 +80,7 @@ class AbstractNode {
   /// Subclasses with children should attach all their children to the same
   /// [owner] whenever this method is called.
   @mustCallSuper
-  void attach(Object owner) {
+  void attach(@checked Object owner) {
     assert(owner != null);
     assert(_owner == null);
     _owner = owner;
@@ -106,7 +106,7 @@ class AbstractNode {
   /// Subclasses should call this function when they acquire a new child.
   @protected
   @mustCallSuper
-  void adoptChild(AbstractNode child) {
+  void adoptChild(@checked AbstractNode child) {
     assert(child != null);
     assert(child._parent == null);
     assert(() {
@@ -125,7 +125,7 @@ class AbstractNode {
   /// Subclasses should call this function when they lose a child.
   @protected
   @mustCallSuper
-  void dropChild(AbstractNode child) {
+  void dropChild(@checked AbstractNode child) {
     assert(child != null);
     assert(child._parent == this);
     assert(child.attached == attached);

--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -1074,7 +1074,7 @@ abstract class RenderObject extends AbstractNode implements HitTestTarget {
   ///
   /// You can call this function to set up the parent data for child before the
   /// child is added to the parent's child list.
-  void setupParentData(RenderObject child) {
+  void setupParentData(@checked RenderObject child) {
     assert(_debugCanPerformMutations);
     if (child.parentData is! ParentData)
       child.parentData = new ParentData();
@@ -1931,7 +1931,7 @@ abstract class RenderObject extends AbstractNode implements HitTestTarget {
   ///
   /// Used by coordinate conversion functions to translate coordinates local to
   /// one render object into coordinates local to another render object.
-  void applyPaintTransform(RenderObject child, Matrix4 transform) {
+  void applyPaintTransform(@checked RenderObject child, Matrix4 transform) {
     assert(child.parent == this);
   }
 
@@ -1943,7 +1943,7 @@ abstract class RenderObject extends AbstractNode implements HitTestTarget {
   ///
   /// This is used in the semantics phase to avoid including children
   /// that are not physically visible.
-  Rect describeApproximatePaintClip(RenderObject child) => null;
+  Rect describeApproximatePaintClip(@checked RenderObject child) => null;
 
 
   // SEMANTICS
@@ -2174,7 +2174,7 @@ abstract class RenderObject extends AbstractNode implements HitTestTarget {
 
   /// Override this method to handle pointer events that hit this render object.
   @override
-  void handleEvent(PointerEvent event, HitTestEntry entry) { }
+  void handleEvent(PointerEvent event, @checked HitTestEntry entry) { }
 
 
   // HIT TESTING

--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -873,7 +873,7 @@ abstract class CustomClipper<T> {
 
   /// Returns `true` if the new instance will result in a different clip
   /// than the oldClipper instance.
-  bool shouldRepaint(CustomClipper<T> oldClipper);
+  bool shouldRepaint(@checked CustomClipper<T> oldClipper);
 }
 
 abstract class _RenderCustomClip<T> extends RenderProxyBox {
@@ -1679,7 +1679,7 @@ abstract class CustomPainter {
   /// repaints should be avoided as much as possible, a [RepaintBoundary] or
   /// [RenderRepaintBoundary] (or other render object with [isRepaintBoundary]
   /// set to `true`) might be helpful.
-  bool shouldRepaint(CustomPainter oldDelegate);
+  bool shouldRepaint(@checked CustomPainter oldDelegate);
 
   /// Called whenever a hit test is being performed on an object that is using
   /// this custom paint delegate.

--- a/packages/flutter/lib/src/rendering/shifted_box.dart
+++ b/packages/flutter/lib/src/rendering/shifted_box.dart
@@ -4,6 +4,8 @@
 
 import 'dart:math' as math;
 
+import 'package:meta/meta.dart';
+
 import 'box.dart';
 import 'debug.dart';
 import 'object.dart';
@@ -745,7 +747,7 @@ class SingleChildLayoutDelegate {
   Offset getPositionForChild(Size size, Size childSize) => Offset.zero;
 
   /// Override this method to return true when the child needs to be laid out.
-  bool shouldRelayout(SingleChildLayoutDelegate oldDelegate) => true;
+  bool shouldRelayout(@checked SingleChildLayoutDelegate oldDelegate) => true;
 }
 
 /// Defers the layout of its single child to a delegate.

--- a/packages/flutter/lib/src/services/asset_bundle.dart
+++ b/packages/flutter/lib/src/services/asset_bundle.dart
@@ -58,7 +58,7 @@ abstract class AssetBundle {
   ///
   /// Implementations may cache the result, so a particular key should only be
   /// used with one parser for the lifetime of the asset bundle.
-  Future<dynamic> loadStructuredData(String key, dynamic parser(String value));
+  Future<dynamic> loadStructuredData(String key, Future<dynamic> parser(String value));
 
   /// If this is a caching asset bundle, and the given key describes a cached
   /// asset, then evict the asset from the cache so that the next time it is

--- a/packages/flutter/lib/src/widgets/editable.dart
+++ b/packages/flutter/lib/src/widgets/editable.dart
@@ -247,7 +247,7 @@ class RawInputLineState extends ScrollableState<RawInputLine> {
   TextSelectionOverlay _selectionOverlay;
 
   @override
-  ScrollBehavior<double, double> createScrollBehavior() => new BoundedBehavior(platform: config.platform);
+  ExtentScrollBehavior createScrollBehavior() => new BoundedBehavior(platform: config.platform);
 
   @override
   BoundedBehavior get scrollBehavior => super.scrollBehavior;

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -744,7 +744,7 @@ abstract class State<T extends StatefulWidget> {
   /// super.didUpdateConfig(oldConfig).
   // TODO(abarth): Add @mustCallSuper.
   @protected
-  void didUpdateConfig(T oldConfig) { }
+  void didUpdateConfig(@checked T oldConfig) { }
 
   /// Called whenever the application is reassembled during debugging.
   ///
@@ -1098,7 +1098,7 @@ abstract class InheritedWidget extends ProxyWidget {
   /// The given widget is guaranteed to have the same [runtimeType] as this
   /// object.
   @protected
-  bool updateShouldNotify(InheritedWidget oldWidget);
+  bool updateShouldNotify(@checked InheritedWidget oldWidget);
 }
 
 /// RenderObjectWidgets provide the configuration for [RenderObjectElement]s,
@@ -1123,13 +1123,13 @@ abstract class RenderObjectWidget extends Widget {
   /// given [RenderObject], which will be of the same type as returned by this
   /// object's [createRenderObject].
   @protected
-  void updateRenderObject(BuildContext context, RenderObject renderObject) { }
+  void updateRenderObject(BuildContext context, @checked RenderObject renderObject) { }
 
   /// A render object previously associated with this widget has been removed
   /// from the tree. The given [RenderObject] will be of the same type as
   /// returned by this object's [createRenderObject].
   @protected
-  void didUnmountRenderObject(RenderObject renderObject) { }
+  void didUnmountRenderObject(@checked RenderObject renderObject) { }
 }
 
 /// A superclass for RenderObjectWidgets that configure RenderObject subclasses
@@ -2010,7 +2010,7 @@ abstract class Element implements BuildContext {
   ///
   /// This function is called only during the "active" lifecycle state.
   @mustCallSuper
-  void update(Widget newWidget) {
+  void update(@checked Widget newWidget) {
     assert(_debugLifecycleState == _ElementLifecycle.active);
     assert(widget != null);
     assert(newWidget != null);
@@ -2910,7 +2910,7 @@ abstract class ProxyElement extends ComponentElement {
   /// Called during [update] after changing the widget associated with this
   /// element but before rebuilding this element.
   @protected
-  void notifyClients(ProxyWidget oldWidget);
+  void notifyClients(@checked ProxyWidget oldWidget);
 }
 
 /// An element that uses a [ParentDataWidget] as its configuration.
@@ -3318,7 +3318,7 @@ abstract class RenderObjectElement extends BuildableElement {
   /// element has a list of children, the previous sibling is a convenient value
   /// for the slot.
   @protected
-  void insertChildRenderObject(RenderObject child, dynamic slot);
+  void insertChildRenderObject(@checked RenderObject child, @checked dynamic slot);
 
   /// Move the given child to the given slot.
   ///
@@ -3329,13 +3329,13 @@ abstract class RenderObjectElement extends BuildableElement {
   /// element has a list of children, the previous sibling is a convenient value
   /// for the slot.
   @protected
-  void moveChildRenderObject(RenderObject child, dynamic slot);
+  void moveChildRenderObject(@checked RenderObject child, @checked dynamic slot);
 
   /// Remove the given child from [renderObject].
   ///
   /// The given child is guaranteed to have [renderObject] as its parent.
   @protected
-  void removeChildRenderObject(RenderObject child);
+  void removeChildRenderObject(@checked RenderObject child);
 
   @override
   void debugFillDescription(List<String> description) {

--- a/packages/flutter/lib/src/widgets/lazy_block.dart
+++ b/packages/flutter/lib/src/widgets/lazy_block.dart
@@ -48,7 +48,7 @@ abstract class LazyBlockDelegate {
   ///
   /// When calling this function, [LazyBlock] will always pass an argument that
   /// matches the runtimeType of the receiver.
-  bool shouldRebuild(LazyBlockDelegate oldDelegate);
+  bool shouldRebuild(@checked LazyBlockDelegate oldDelegate);
 
   /// Returns the estimated total height of the children, in pixels.
   ///

--- a/packages/flutter/lib/src/widgets/scroll_configuration.dart
+++ b/packages/flutter/lib/src/widgets/scroll_configuration.dart
@@ -33,7 +33,7 @@ abstract class ScrollConfigurationDelegate {
   /// Overrides should return true if this ScrollConfigurationDelegate differs
   /// from the provided old delegate in a way that requires rebuilding its
   /// scrolling container descendants.
-  bool updateShouldNotify(ScrollConfigurationDelegate old);
+  bool updateShouldNotify(@checked ScrollConfigurationDelegate old);
 }
 
 class _DefaultScrollConfigurationDelegate extends ScrollConfigurationDelegate {

--- a/packages/flutter/lib/src/widgets/unique_widget.dart
+++ b/packages/flutter/lib/src/widgets/unique_widget.dart
@@ -7,7 +7,7 @@ import 'package:meta/meta.dart';
 import 'framework.dart';
 
 /// A widget that has exactly one inflated instance in the tree.
-abstract class UniqueWidget<T extends State> extends StatefulWidget {
+abstract class UniqueWidget<T extends State<StatefulWidget>> extends StatefulWidget {
   /// Creates a widget that has exactly one inflated instance in the tree.
   ///
   /// The [key] argument cannot be null because it identifies the unique

--- a/packages/flutter/lib/src/widgets/virtual_viewport.dart
+++ b/packages/flutter/lib/src/widgets/virtual_viewport.dart
@@ -29,7 +29,7 @@ abstract class VirtualViewport extends RenderObjectWidget {
 }
 
 abstract class _WidgetProvider {
-  void didUpdateWidget(VirtualViewport oldWidget, VirtualViewport newWidget);
+  void didUpdateWidget(@checked VirtualViewport oldWidget, @checked VirtualViewport newWidget);
   int get virtualChildCount;
   void prepareChildren(VirtualViewportElement context, int base, int count);
   Widget getChild(int i);
@@ -146,7 +146,7 @@ abstract class VirtualViewportElement extends RenderObjectElement {
   /// Copies the configuration described by [widget] to this element's [renderObject].
   @protected
   @mustCallSuper
-  void updateRenderObject(VirtualViewport oldWidget) {
+  void updateRenderObject(@checked VirtualViewport oldWidget) {
     renderObject.virtualChildCount = _widgetProvider.virtualChildCount;
 
     if (startOffsetBase != null) {

--- a/packages/flutter/test/foundation/covariant_templates_test.dart
+++ b/packages/flutter/test/foundation/covariant_templates_test.dart
@@ -1,0 +1,23 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:test/test.dart';
+
+class X {}
+
+class Y extends X {}
+
+class A<U extends X> {
+  U u;
+}
+
+void main() {
+  test('Assignment through a covariant template throws exception', () {
+    A<Y> ay = new A<Y>();
+    A<X> ayAsAx = ay;
+    expect(() {
+      ayAsAx.u = new X();
+    }, throws);
+  });
+}

--- a/packages/flutter/test/widget/form_test.dart
+++ b/packages/flutter/test/widget/form_test.dart
@@ -5,6 +5,7 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_services/editing.dart' as mojom;
+import 'package:meta/meta.dart';
 
 class MockKeyboard extends mojom.KeyboardProxy {
   MockKeyboard() : super.unbound();
@@ -13,7 +14,7 @@ class MockKeyboard extends mojom.KeyboardProxy {
   mojom.EditingState currentState;
 
   @override
-  void setClient(mojom.KeyboardClientStub client, mojom.KeyboardConfiguration configuraiton) {
+  void setClient(@checked mojom.KeyboardClientStub client, mojom.KeyboardConfiguration configuraiton) {
     this.client = client.impl;
   }
 

--- a/packages/flutter/test/widget/image_resolution_test.dart
+++ b/packages/flutter/test/widget/image_resolution_test.dart
@@ -9,6 +9,7 @@ import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:meta/meta.dart';
 import 'package:mojo/core.dart' as mojo;
 
 class TestImage extends ui.Image {
@@ -92,7 +93,7 @@ class TestAssetImage extends AssetImage {
   }
 
   @override
-  Future<ui.Image> decodeImage(TestMojoDataPipeConsumer pipe) {
+  Future<ui.Image> decodeImage(@checked TestMojoDataPipeConsumer pipe) {
     return new SynchronousFuture<ui.Image>(new TestImage(pipe.scale));
   }
 }

--- a/packages/flutter/test/widget/input_test.dart
+++ b/packages/flutter/test/widget/input_test.dart
@@ -8,6 +8,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter_services/editing.dart' as mojom;
+import 'package:meta/meta.dart';
 
 class MockKeyboard extends mojom.KeyboardProxy {
   MockKeyboard() : super.unbound();
@@ -15,7 +16,7 @@ class MockKeyboard extends mojom.KeyboardProxy {
   mojom.KeyboardClient client;
 
   @override
-  void setClient(mojom.KeyboardClientStub client, mojom.KeyboardConfiguration configuraiton) {
+  void setClient(@checked mojom.KeyboardClientStub client, mojom.KeyboardConfiguration configuraiton) {
     this.client = client.impl;
   }
 

--- a/packages/flutter/test/widget/routes_test.dart
+++ b/packages/flutter/test/widget/routes_test.dart
@@ -6,6 +6,7 @@ import 'dart:collection';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/widgets.dart';
+import 'package:meta/meta.dart';
 
 final List<String> results = <String>[];
 
@@ -42,7 +43,7 @@ class TestRoute extends LocalHistoryRoute<String> {
   }
 
   @override
-  void didReplace(TestRoute oldRoute) {
+  void didReplace(@checked TestRoute oldRoute) {
     log('didReplace ${oldRoute.name}');
   }
 
@@ -56,12 +57,12 @@ class TestRoute extends LocalHistoryRoute<String> {
   }
 
   @override
-  void didPopNext(TestRoute nextRoute) {
+  void didPopNext(@checked TestRoute nextRoute) {
     log('didPopNext ${nextRoute.name}');
   }
 
   @override
-  void didChangeNext(TestRoute nextRoute) {
+  void didChangeNext(@checked TestRoute nextRoute) {
     log('didChangeNext ${nextRoute?.name}');
   }
 

--- a/packages/flutter/test/widget/scroll_behavior_test.dart
+++ b/packages/flutter/test/widget/scroll_behavior_test.dart
@@ -21,7 +21,7 @@ class TestScrollConfigurationDelegate extends ScrollConfigurationDelegate {
   }
 
   @override
-  bool updateShouldNotify(TestScrollConfigurationDelegate old)  => flag != old.flag;
+  bool updateShouldNotify(TestScrollConfigurationDelegate old) => flag != old.flag;
 }
 
 void main() {

--- a/packages/flutter_markdown/lib/src/markdown_raw.dart
+++ b/packages/flutter_markdown/lib/src/markdown_raw.dart
@@ -3,8 +3,10 @@
 // found in the LICENSE file.
 
 import 'package:markdown/markdown.dart' as md;
+import 'package:meta/meta.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter/gestures.dart';
+
 import 'markdown_style_raw.dart';
 
 typedef void MarkdownLinkCallback(String href);
@@ -65,7 +67,7 @@ class MarkdownRaw extends StatelessWidget {
 
   MarkdownBodyRaw createMarkdownBody({
     String data,
-    MarkdownStyleRaw markdownStyle,
+    @checked MarkdownStyleRaw markdownStyle,
     SyntaxHighlighter syntaxHighlighter,
     MarkdownLinkCallback onTapLink
   }) {

--- a/packages/flutter_test/lib/src/binding.dart
+++ b/packages/flutter_test/lib/src/binding.dart
@@ -13,6 +13,7 @@ import 'package:flutter/rendering.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
+import 'package:meta/meta.dart';
 import 'package:quiver/testing/async.dart';
 import 'package:quiver/time.dart';
 import 'package:test/test.dart' as test_package;
@@ -803,7 +804,7 @@ class _LiveTestRenderView extends RenderView {
   @override
   TestViewConfiguration get configuration => super.configuration;
   @override
-  set configuration(TestViewConfiguration value) { super.configuration = value; }
+  set configuration(@checked TestViewConfiguration value) { super.configuration = value; }
 
   final Map<int, _LiveTestPointerRecord> _pointers = <int, _LiveTestPointerRecord>{};
 

--- a/packages/flutter_test/lib/src/matchers.dart
+++ b/packages/flutter_test/lib/src/matchers.dart
@@ -4,6 +4,7 @@
 
 import 'package:flutter/material.dart';
 import 'package:test/test.dart';
+import 'package:meta/meta.dart';
 
 import 'finders.dart';
 
@@ -72,7 +73,7 @@ class _FindsWidgetMatcher extends Matcher {
   final int max;
 
   @override
-  bool matches(Finder finder, Map<dynamic, dynamic> matchState) {
+  bool matches(@checked Finder finder, Map<dynamic, dynamic> matchState) {
     assert(min != null || max != null);
     assert(min == null || max == null || min <= max);
     matchState[Finder] = finder;
@@ -166,7 +167,7 @@ class _IsOffstage extends Matcher {
   const _IsOffstage();
 
   @override
-  bool matches(Finder finder, Map<dynamic, dynamic> matchState) {
+  bool matches(@checked Finder finder, Map<dynamic, dynamic> matchState) {
     return _hasAncestorMatching(finder, (Widget widget) {
       if (widget is Offstage)
         return widget.offstage;
@@ -182,7 +183,7 @@ class _IsOnstage extends Matcher {
   const _IsOnstage();
 
   @override
-  bool matches(Finder finder, Map<dynamic, dynamic> matchState) {
+  bool matches(@checked Finder finder, Map<dynamic, dynamic> matchState) {
     Iterable<Element> nodes = finder.evaluate();
     if (nodes.length != 1)
       return false;
@@ -206,7 +207,7 @@ class _IsInCard extends Matcher {
   const _IsInCard();
 
   @override
-  bool matches(Finder finder, Map<dynamic, dynamic> matchState) => _hasAncestorOfType(finder, Card);
+  bool matches(@checked Finder finder, Map<dynamic, dynamic> matchState) => _hasAncestorOfType(finder, Card);
 
   @override
   Description describe(Description description) => description.add('in card');
@@ -216,7 +217,7 @@ class _IsNotInCard extends Matcher {
   const _IsNotInCard();
 
   @override
-  bool matches(Finder finder, Map<dynamic, dynamic> matchState) => !_hasAncestorOfType(finder, Card);
+  bool matches(@checked Finder finder, Map<dynamic, dynamic> matchState) => !_hasAncestorOfType(finder, Card);
 
   @override
   Description describe(Description description) => description.add('not in card');

--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -333,7 +333,8 @@ class IOSDevice extends Device {
     ApplicationPackage package,
     LaunchResult result, {
     String mainPath,
-    VMService observatory
+    VMService observatory,
+    bool prebuiltApplication: false
   }) async {
     throw 'unsupported';
   }

--- a/packages/flutter_tools/lib/src/vmservice.dart
+++ b/packages/flutter_tools/lib/src/vmservice.dart
@@ -868,15 +868,15 @@ class ServiceMap extends ServiceObject implements Map<String, dynamic> {
   @override
   bool containsValue(dynamic v) => _map.containsValue(v);
   @override
-  bool containsKey(String k) => _map.containsKey(k);
+  bool containsKey(Object k) => _map.containsKey(k);
   @override
   void forEach(Function f) => _map.forEach(f);
   @override
   dynamic putIfAbsent(String key, Function ifAbsent) => _map.putIfAbsent(key, ifAbsent);
   @override
-  void remove(String key) => _map.remove(key);
+  void remove(Object key) => _map.remove(key);
   @override
-  dynamic operator [](String k) => _map[k];
+  dynamic operator [](Object k) => _map[k];
   @override
   void operator []=(String k, dynamic v) => _map[k] = v;
   @override


### PR DESCRIPTION
This patch adds `@checked` everywhere is needed to remove the
`strong_mode_invalid_method_override` strong mode error.  There's still
one place where we're still ignoring
`strong_mode_invalid_method_override`, but I think that case might be a
bug in the analyzer.
