### PR TITLE
switch to package:mustache

### DIFF
--- a/packages/flutter_tools/lib/src/commands/create.dart
+++ b/packages/flutter_tools/lib/src/commands/create.dart
@@ -162,8 +162,7 @@ All done! In order to run your application, type:
 
     int fileCount = 0;
 
-    if (renderDriverTest)
-      templateContext['withDriverTest?'] = <String, dynamic>{};
+    templateContext['withDriverTest'] = renderDriverTest;
 
     Template createTemplate = new Template.fromName('create');
     fileCount += createTemplate.render(new Directory(dirPath), templateContext,

--- a/packages/flutter_tools/lib/src/template.dart
+++ b/packages/flutter_tools/lib/src/template.dart
@@ -4,7 +4,7 @@
 
 import 'dart:io';
 
-import 'package:mustache4dart/mustache4dart.dart' as mustache;
+import 'package:mustache/mustache.dart' as mustache;
 import 'package:path/path.dart' as path;
 
 import 'cache.dart';
@@ -109,7 +109,7 @@ class Template {
 
       if (sourceFile.path.endsWith(_kTemplateExtension)) {
         String templateContents = sourceFile.readAsStringSync();
-        String renderedContents = mustache.render(templateContents, context);
+        String renderedContents = new mustache.Template(templateContents).renderString(context);
 
         finalDestinationFile.writeAsStringSync(renderedContents);
 

--- a/packages/flutter_tools/pubspec.yaml
+++ b/packages/flutter_tools/pubspec.yaml
@@ -23,7 +23,7 @@ dependencies:
 
   linter: ^0.1.21
   meta: ^1.0.3
-  mustache4dart: ^1.0.0
+  mustache: ^0.2.5
   package_config: '>=0.1.5 <2.0.0'
   path: ^1.3.0
   pub_semver: ^1.0.0

--- a/packages/flutter_tools/templates/create/lib/main.dart.tmpl
+++ b/packages/flutter_tools/templates/create/lib/main.dart.tmpl
@@ -1,14 +1,14 @@
 import 'package:flutter/material.dart';
-{{#withDriverTest?}}
+{{#withDriverTest}}
 import 'package:flutter_driver/driver_extension.dart';
-{{/withDriverTest?}}
+{{/withDriverTest}}
 
 void main() {
-{{#withDriverTest?}}
+{{#withDriverTest}}
   // Starts the app with Flutter Driver extension enabled to allow Flutter Driver
   // to test the app.
   enableFlutterDriverExtension();
-{{/withDriverTest?}}
+{{/withDriverTest}}
   runApp(
     new MaterialApp(
       title: 'Flutter Demo',

--- a/packages/flutter_tools/templates/create/pubspec.yaml.tmpl
+++ b/packages/flutter_tools/templates/create/pubspec.yaml.tmpl
@@ -3,8 +3,8 @@ description: {{description}}
 dependencies:
   flutter:
     sdk: flutter
-{{#withDriverTest?}}
+{{#withDriverTest}}
 dev_dependencies:
   flutter_driver:
     sdk: flutter
-{{/withDriverTest?}}
+{{/withDriverTest}}


### PR DESCRIPTION
This moves `flutter create` off package:mustache4dart and onto package:mustache which is more current.
Fixes https://github.com/flutter/flutter/issues/6266
@abarth 
