### PR TITLE
Fix composited transform bounds calculations

### DIFF
--- a/packages/flutter/lib/src/painting/transforms.dart
+++ b/packages/flutter/lib/src/painting/transforms.dart
@@ -107,13 +107,13 @@ class MatrixUtils {
     return math.max(a, math.max(b, math.max(c, d)));
   }
 
-  /// Returns a rect that bounds the result of applying the given matrix as a
-  /// perspective transform to the given rect.
+  /// Returns a rect that bounds the result of applying the inverse of the given
+  /// matrix as a perspective transform to the given rect.
   ///
   /// This function assumes the given rect is in the plane with z equals 0.0.
   /// The transformed rect is then projected back into the plane with z equals
   /// 0.0 before computing its bounding rect.
-  static Rect transformRect(Rect rect, Matrix4 transform) {
+  static Rect inverseTransformRect(Rect rect, Matrix4 transform) {
     assert(rect != null);
     assert(transform.determinant != 0.0);
     if (isIdentity(transform))

--- a/packages/flutter/lib/src/rendering/layer.dart
+++ b/packages/flutter/lib/src/rendering/layer.dart
@@ -445,17 +445,20 @@ class TransformLayer extends OffsetLayer {
   /// The [transform] property must be non-null before the compositing phase of
   /// the pipeline.
   TransformLayer({
-    Offset offset: Offset.zero,
     this.transform
-  }): super(offset: offset);
+  });
 
   /// The matrix to apply
   Matrix4 transform;
 
   @override
   void addToScene(ui.SceneBuilder builder, Offset layerOffset) {
-    Matrix4 effectiveTransform = new Matrix4.translationValues(offset.dx + layerOffset.dx, offset.dy + layerOffset.dy, 0.0)
-      ..multiply(transform);
+    assert(offset == Offset.zero);
+    Matrix4 effectiveTransform = transform;
+    if (layerOffset != Offset.zero) {
+      effectiveTransform = new Matrix4.translationValues(layerOffset.dx, layerOffset.dy, 0.0)
+        ..multiply(transform);
+    }
     builder.pushTransform(effectiveTransform.storage);
     addChildrenToScene(builder, Offset.zero);
     builder.pop();

--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -1479,7 +1479,7 @@ class RenderFittedBox extends RenderProxyBox {
       final Rect destinationRect = _alignment.inscribe(sizes.destination, Point.origin & size);
       _hasVisualOverflow = sourceRect.width < childSize.width || sourceRect.height < childSize.width;
       _transform = new Matrix4.translationValues(destinationRect.left, destinationRect.top, 0.0)
-        ..scale(scaleX, scaleY)
+        ..scale(scaleX, scaleY, 1.0)
         ..translate(-sourceRect.left, -sourceRect.top);
     }
   }

--- a/packages/flutter/test/widget/transform_test.dart
+++ b/packages/flutter/test/widget/transform_test.dart
@@ -3,7 +3,9 @@
 // found in the LICENSE file.
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
+import 'package:vector_math/vector_math_64.dart';
 
 void main() {
   testWidgets('Transform origin', (WidgetTester tester) async {
@@ -18,9 +20,9 @@ void main() {
               width: 100.0,
               height: 100.0,
               decoration: new BoxDecoration(
-                backgroundColor: new Color(0xFF0000FF)
-              )
-            )
+                backgroundColor: new Color(0xFF0000FF),
+              ),
+            ),
           ),
           new Positioned(
             top: 100.0,
@@ -37,15 +39,15 @@ void main() {
                   },
                   child: new Container(
                     decoration: new BoxDecoration(
-                      backgroundColor: new Color(0xFF00FFFF)
-                    )
-                  )
-                )
-              )
-            )
-          )
-        ]
-      )
+                      backgroundColor: new Color(0xFF00FFFF),
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
     );
 
     expect(didReceiveTap, isFalse);
@@ -67,9 +69,9 @@ void main() {
               width: 100.0,
               height: 100.0,
               decoration: new BoxDecoration(
-                backgroundColor: new Color(0xFF0000FF)
-              )
-            )
+                backgroundColor: new Color(0xFF0000FF),
+              ),
+            ),
           ),
           new Positioned(
             top: 100.0,
@@ -86,15 +88,15 @@ void main() {
                   },
                   child: new Container(
                     decoration: new BoxDecoration(
-                      backgroundColor: new Color(0xFF00FFFF)
-                    )
-                  )
-                )
-              )
-            )
-          )
-        ]
-      )
+                      backgroundColor: new Color(0xFF00FFFF),
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
     );
 
     expect(didReceiveTap, isFalse);
@@ -106,51 +108,81 @@ void main() {
 
   testWidgets('Transform offset + alignment', (WidgetTester tester) async {
     bool didReceiveTap = false;
-    await tester.pumpWidget(
-      new Stack(
-        children: <Widget>[
-          new Positioned(
-            top: 100.0,
-            left: 100.0,
-            child: new Container(
-              width: 100.0,
-              height: 100.0,
-              decoration: new BoxDecoration(
-                backgroundColor: new Color(0xFF0000FF)
-              )
-            )
+    await tester.pumpWidget(new Stack(
+      children: <Widget>[
+        new Positioned(
+          top: 100.0,
+          left: 100.0,
+          child: new Container(
+            width: 100.0,
+            height: 100.0,
+            decoration: new BoxDecoration(
+              backgroundColor: new Color(0xFF0000FF),
+            ),
           ),
-          new Positioned(
-            top: 100.0,
-            left: 100.0,
-            child: new Container(
-              width: 100.0,
-              height: 100.0,
-              child: new Transform(
-                transform: new Matrix4.diagonal3Values(0.5, 0.5, 1.0),
-                origin: new Offset(100.0, 0.0),
-                alignment: new FractionalOffset(0.0, 0.5),
-                child: new GestureDetector(
-                  onTap: () {
-                    didReceiveTap = true;
-                  },
-                  child: new Container(
-                    decoration: new BoxDecoration(
-                      backgroundColor: new Color(0xFF00FFFF)
-                    )
-                  )
-                )
-              )
-            )
-          )
-        ]
-      )
-    );
+        ),
+        new Positioned(
+          top: 100.0,
+          left: 100.0,
+          child: new Container(
+            width: 100.0,
+            height: 100.0,
+            child: new Transform(
+              transform: new Matrix4.diagonal3Values(0.5, 0.5, 1.0),
+              origin: new Offset(100.0, 0.0),
+              alignment: new FractionalOffset(0.0, 0.5),
+              child: new GestureDetector(
+                onTap: () {
+                  didReceiveTap = true;
+                },
+                child: new Container(
+                  decoration: new BoxDecoration(
+                    backgroundColor: new Color(0xFF00FFFF),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ],
+    ));
 
     expect(didReceiveTap, isFalse);
     await tester.tapAt(new Point(110.0, 110.0));
     expect(didReceiveTap, isFalse);
     await tester.tapAt(new Point(190.0, 150.0));
     expect(didReceiveTap, isTrue);
+  });
+
+  testWidgets('Composited transform offset', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      new Center(
+        child: new SizedBox(
+          width: 400.0,
+          height: 300.0,
+          child: new ClipRect(
+            child: new Transform(
+              transform: new Matrix4.diagonal3Values(0.5, 0.5, 1.0),
+              child: new Opacity(
+                opacity: 0.9,
+                child: new Container(
+                  decoration: new BoxDecoration(
+                    backgroundColor: const Color(0xFF00FF00),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    List<Layer> layers = tester.layers
+      ..retainWhere((Layer layer) => layer is TransformLayer);
+    expect(layers.length, 2);
+    // The first transform is from the render view.
+    TransformLayer layer = layers[1];
+    Matrix4 transform = layer.transform;
+    expect(transform.getTranslation(), equals(new Vector3(100.0, 75.0, 0.0)));
   });
 }


### PR DESCRIPTION
We weren't computing the bounds for composited transforms correctly. We
need to conjugate the transform by the offset in order to get the
correct paint bounds for the composited layer. We now also use the same
math in the non-composited case for consistency.

Also, don't scale the z-coordinate in RenderFittedBox.

Fixes #6293
