### PR TITLE
Bump VERSION to `0.0.2`.

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -6,4 +6,4 @@
 # incompatible way, this version number might not change. Instead, the version
 # number for package:flutter will update to reflect that change.
 
-0.0.1
+0.0.2


### PR DESCRIPTION
Sets a minimal baseline version for IDEs to verify a hot-reload supporting SDK.

Fixes: https://github.com/flutter/flutter-intellij/issues/293

/cc @abarth 

FYI @danrubel 
