### PR TITLE
Add a maxLines parameter for multiline Input.

### DIFF
--- a/examples/flutter_gallery/lib/demo/text_field_demo.dart
+++ b/examples/flutter_gallery/lib/demo/text_field_demo.dart
@@ -97,7 +97,7 @@ class TextFieldDemoState extends State<TextFieldDemo> {
             new Input(
               hintText: 'Tell us about yourself (optional)',
               labelText: 'Life story',
-              multiline: true,
+              maxLines: 3,
               formField: new FormField<String>()
             ),
             new Row(

--- a/packages/flutter/lib/src/material/input.dart
+++ b/packages/flutter/lib/src/material/input.dart
@@ -43,7 +43,7 @@ class Input extends StatefulWidget {
     this.hideText: false,
     this.isDense: false,
     this.autofocus: false,
-    this.multiline: false,
+    this.maxLines: 1,
     this.formField,
     this.onChanged,
     this.onSubmitted
@@ -85,9 +85,10 @@ class Input extends StatefulWidget {
   /// Whether this input field should focus itself is nothing else is already focused.
   final bool autofocus;
 
-  /// True if the text should wrap and span multiple lines, false if it should
-  /// stay on a single line and scroll when overflowed.
-  final bool multiline;
+  /// The maximum number of lines for the text to span, wrapping if necessary.
+  /// If this is 1 (the default), the text will not wrap, but will scroll
+  /// horizontally instead.
+  final int maxLines;
 
   /// Form-specific data, required if this Input is part of a Form.
   final FormField<String> formField;
@@ -210,7 +211,7 @@ class _InputState extends State<Input> {
         focusKey: focusKey,
         style: textStyle,
         hideText: config.hideText,
-        multiline: config.multiline,
+        maxLines: config.maxLines,
         cursorColor: themeData.textSelectionColor,
         selectionColor: themeData.textSelectionColor,
         selectionControls: materialTextSelectionControls,

--- a/packages/flutter/lib/src/rendering/editable_line.dart
+++ b/packages/flutter/lib/src/rendering/editable_line.dart
@@ -106,6 +106,16 @@ class RenderEditableLine extends RenderBox {
     markNeedsPaint();
   }
 
+  /// Whether to paint the cursor.
+  int get maxLines => _maxLines;
+  int _maxLines;
+  set maxLines(int value) {
+    if (_maxLines == value)
+      return;
+    _maxLines = value;
+    markNeedsLayout();
+  }
+
   /// The color to use when painting the selection.
   Color get selectionColor => _selectionColor;
   Color _selectionColor;
@@ -216,7 +226,6 @@ class RenderEditableLine extends RenderBox {
     return _layoutTemplate.height;
   }
 
-  int _maxLines;
   double get _maxContentWidth {
     return _maxLines > 1 ?
       constraints.maxWidth - (_kCaretGap + _kCaretWidth) :

--- a/packages/flutter/lib/src/rendering/editable_line.dart
+++ b/packages/flutter/lib/src/rendering/editable_line.dart
@@ -301,7 +301,7 @@ class RenderEditableLine extends RenderBox {
       _textPainter.height.clamp(lineHeight, lineHeight * _maxLines)
     ));
     Size contentSize = new Size(_textPainter.width + _kCaretGap + _kCaretWidth, _textPainter.height);
-    assert(_selection != null);  // valid assumption?
+    assert(_selection != null);
     Offset caretOffset = _textPainter.getOffsetForCaret(_selection.extent, _caretPrototype);
     Rect caretRect = _caretPrototype.shift(caretOffset + _paintOffset);
     if (onPaintOffsetUpdateNeeded != null && (size != oldSize || contentSize != _contentSize || !_withinBounds(caretRect)))

--- a/packages/flutter/lib/src/rendering/editable_line.dart
+++ b/packages/flutter/lib/src/rendering/editable_line.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import 'dart:ui' as ui show Paragraph, ParagraphBuilder, ParagraphConstraints, ParagraphStyle, TextBox;
-import 'dart:math' as math;
 
 import 'package:flutter/gestures.dart';
 

--- a/packages/flutter/lib/src/rendering/editable_line.dart
+++ b/packages/flutter/lib/src/rendering/editable_line.dart
@@ -206,8 +206,10 @@ class RenderEditableLine extends RenderBox {
   /// Returns the Rect in local coordinates for the caret at the given text
   /// position.
   Rect getLocalRectForCaret(TextPosition caretPosition) {
+    double lineHeight = constraints.constrainHeight(_preferredLineHeight);
     Offset caretOffset = _textPainter.getOffsetForCaret(caretPosition, _caretPrototype);
-    return _caretPrototype.shift(caretOffset + _paintOffset);
+    // This rect is the same as _caretPrototype but without the vertical padding.
+    return new Rect.fromLTWH(0.0, 0.0, _kCaretWidth, lineHeight).shift(caretOffset + _paintOffset);
   }
 
   Size _contentSize;
@@ -310,8 +312,7 @@ class RenderEditableLine extends RenderBox {
     ));
     Size contentSize = new Size(_textPainter.width + _kCaretGap + _kCaretWidth, _textPainter.height);
     assert(_selection != null);
-    Offset caretOffset = _textPainter.getOffsetForCaret(_selection.extent, _caretPrototype);
-    Rect caretRect = _caretPrototype.shift(caretOffset + _paintOffset);
+    Rect caretRect = getLocalRectForCaret(_selection.extent);
     if (onPaintOffsetUpdateNeeded != null && (size != oldSize || contentSize != _contentSize || !_withinBounds(caretRect)))
       onPaintOffsetUpdateNeeded(new ViewportDimensions(containerSize: size, contentSize: contentSize), caretRect);
     _contentSize = contentSize;

--- a/packages/flutter/lib/src/rendering/editable_line.dart
+++ b/packages/flutter/lib/src/rendering/editable_line.dart
@@ -298,7 +298,8 @@ class RenderEditableLine extends RenderBox {
     _selectionRects = null;
     _textPainter.layout(maxWidth: _maxContentWidth);
     size = new Size(constraints.maxWidth, constraints.constrainHeight(
-      _textPainter.height.clamp(lineHeight, lineHeight * _maxLines)));
+      _textPainter.height.clamp(lineHeight, lineHeight * _maxLines)
+    ));
     Size contentSize = new Size(_textPainter.width + _kCaretGap + _kCaretWidth, _textPainter.height);
     assert(_selection != null);  // valid assumption?
     Offset caretOffset = _textPainter.getOffsetForCaret(_selection.extent, _caretPrototype);

--- a/packages/flutter/lib/src/widgets/editable.dart
+++ b/packages/flutter/lib/src/widgets/editable.dart
@@ -530,6 +530,7 @@ class _EditableLineWidget extends LeafRenderObjectWidget {
       ..text = _styledTextSpan
       ..cursorColor = cursorColor
       ..showCursor = showCursor
+      ..maxLines = maxLines
       ..selectionColor = selectionColor
       ..textScaleFactor = textScaleFactor
       ..selection = value.selection

--- a/packages/flutter/lib/src/widgets/editable.dart
+++ b/packages/flutter/lib/src/widgets/editable.dart
@@ -4,7 +4,7 @@
 
 import 'dart:async';
 
-import 'package:flutter/rendering.dart' show RenderEditableLine, SelectionChangedHandler;
+import 'package:flutter/rendering.dart' show RenderEditableLine, SelectionChangedHandler, RenderEditableLinePaintOffsetNeededCallback;
 import 'package:flutter/services.dart';
 import 'package:meta/meta.dart';
 import 'package:flutter_services/editing.dart' as mojom;
@@ -170,17 +170,17 @@ class RawInputLine extends Scrollable {
     this.style,
     this.cursorColor,
     this.textScaleFactor,
-    this.multiline,
+    int maxLines: 1,
     this.selectionColor,
     this.selectionControls,
     @required this.platform,
     this.keyboardType,
     this.onChanged,
     this.onSubmitted
-  }) : super(
+  }) : maxLines = maxLines, super(
     key: key,
     initialScrollOffset: 0.0,
-    scrollDirection: Axis.horizontal
+    scrollDirection: maxLines > 1 ? Axis.vertical : Axis.horizontal
   ) {
     assert(value != null);
   }
@@ -208,9 +208,10 @@ class RawInputLine extends Scrollable {
   /// The color to use when painting the cursor.
   final Color cursorColor;
 
-  /// True if the text should wrap and span multiple lines, false if it should
-  /// stay on a single line and scroll when overflowed.
-  final bool multiline;
+  /// The maximum number of lines for the text to span, wrapping if necessary.
+  /// If this is 1 (the default), the text will not wrap, but will scroll
+  /// horizontally instead.
+  final int maxLines;
 
   /// The color to use when painting the selection.
   final Color selectionColor;
@@ -273,28 +274,43 @@ class RawInputLineState extends ScrollableState<RawInputLine> {
 
   bool get _isAttachedToKeyboard => _keyboardHandle != null && _keyboardHandle.attached;
 
-  double _contentWidth = 0.0;
-  double _containerWidth = 0.0;
+  bool get _isMultiline => config.maxLines > 1;
 
-  Offset _handlePaintOffsetUpdateNeeded(ViewportDimensions dimensions) {
+  double _contentExtent = 0.0;
+  double _containerExtent = 0.0;
+
+  Offset _handlePaintOffsetUpdateNeeded(ViewportDimensions dimensions, Rect caretRect) {
     // We make various state changes here but don't have to do so in a
     // setState() callback because we are called during layout and all
     // we're updating is the new offset, which we are providing to the
     // render object via our return value.
-    _containerWidth = dimensions.containerSize.width;
-    _contentWidth = dimensions.contentSize.width;
+    _contentExtent = _isMultiline ?
+      dimensions.contentSize.height :
+      dimensions.contentSize.width;
+    _containerExtent = _isMultiline ?
+      dimensions.containerSize.height :
+      dimensions.containerSize.width;
     didUpdateScrollBehavior(scrollBehavior.updateExtents(
-      contentExtent: _contentWidth,
-      containerExtent: _containerWidth,
-      // Set the scroll offset to match the content width so that the
-      // cursor (which is always at the end of the text) will be
-      // visible.
+      contentExtent: _contentExtent,
+      containerExtent: _containerExtent,
       // TODO(ianh): We should really only do this when text is added,
       // not generally any time the size changes.
-      scrollOffset: pixelOffsetToScrollOffset(-_contentWidth)
+      scrollOffset: _getScrollOffsetForCaret(caretRect, _containerExtent)
     ));
     updateGestureDetector();
     return scrollOffsetToPixelDelta(scrollOffset);
+  }
+
+  // Calculate the new scroll offset so the cursor remains visible.
+  double _getScrollOffsetForCaret(Rect caretRect, double containerExtent) {
+    double caretStart = _isMultiline ? caretRect.top : caretRect.left;
+    double caretEnd = _isMultiline ? caretRect.bottom : caretRect.right;
+    double newScrollOffset = scrollOffset;
+    if (caretStart < 0.0)  // cursor before start of bounds
+      newScrollOffset += pixelOffsetToScrollOffset(-caretStart);
+    else if (caretEnd >= containerExtent)  // cursor after end of bounds
+      newScrollOffset += pixelOffsetToScrollOffset(-(caretEnd - containerExtent));
+    return newScrollOffset;
   }
 
   void _attachOrDetachKeyboard(bool focused) {
@@ -373,10 +389,18 @@ class RawInputLineState extends ScrollableState<RawInputLine> {
     }
   }
 
-  void _handleSelectionOverlayChanged(InputValue newInput) {
+  void _handleSelectionOverlayChanged(InputValue newInput, Rect caretRect) {
     assert(!newInput.composing.isValid);  // composing range must be empty while selecting
     if (config.onChanged != null)
       config.onChanged(newInput);
+
+    didUpdateScrollBehavior(scrollBehavior.updateExtents(
+      // TODO(mpcomplete): should just be able to pass
+      // scrollBehavior.containerExtent here (and remove the member var), but
+      // scrollBehavior gets re-created too often, and is sometimes
+      // uninitialized here. Investigate if this is a bug.
+      scrollOffset: _getScrollOffsetForCaret(caretRect, _containerExtent)
+    ));
   }
 
   /// Whether the blinking cursor is actually visible at this precise moment
@@ -438,18 +462,20 @@ class RawInputLineState extends ScrollableState<RawInputLine> {
       }
     }
 
-    return new _EditableLineWidget(
-      value: _keyboardClient.inputValue,
-      style: config.style,
-      cursorColor: config.cursorColor,
-      showCursor: _showCursor,
-      multiline: config.multiline,
-      selectionColor: config.selectionColor,
-      textScaleFactor: config.textScaleFactor ?? MediaQuery.of(context).textScaleFactor,
-      hideText: config.hideText,
-      onSelectionChanged: _handleSelectionChanged,
-      paintOffset: scrollOffsetToPixelDelta(scrollOffset),
-      onPaintOffsetUpdateNeeded: _handlePaintOffsetUpdateNeeded
+    return new ClipRect(
+      child: new _EditableLineWidget(
+        value: _keyboardClient.inputValue,
+        style: config.style,
+        cursorColor: config.cursorColor,
+        showCursor: _showCursor,
+        maxLines: config.maxLines,
+        selectionColor: config.selectionColor,
+        textScaleFactor: config.textScaleFactor ?? MediaQuery.of(context).textScaleFactor,
+        hideText: config.hideText,
+        onSelectionChanged: _handleSelectionChanged,
+        paintOffset: scrollOffsetToPixelDelta(scrollOffset),
+        onPaintOffsetUpdateNeeded: _handlePaintOffsetUpdateNeeded
+      )
     );
   }
 }
@@ -461,7 +487,7 @@ class _EditableLineWidget extends LeafRenderObjectWidget {
     this.style,
     this.cursorColor,
     this.showCursor,
-    this.multiline,
+    this.maxLines,
     this.selectionColor,
     this.textScaleFactor,
     this.hideText,
@@ -474,13 +500,13 @@ class _EditableLineWidget extends LeafRenderObjectWidget {
   final TextStyle style;
   final Color cursorColor;
   final bool showCursor;
-  final bool multiline;
+  final int maxLines;
   final Color selectionColor;
   final double textScaleFactor;
   final bool hideText;
   final SelectionChangedHandler onSelectionChanged;
   final Offset paintOffset;
-  final ViewportDimensionsChangeCallback onPaintOffsetUpdateNeeded;
+  final RenderEditableLinePaintOffsetNeededCallback onPaintOffsetUpdateNeeded;
 
   @override
   RenderEditableLine createRenderObject(BuildContext context) {
@@ -488,7 +514,7 @@ class _EditableLineWidget extends LeafRenderObjectWidget {
       text: _styledTextSpan,
       cursorColor: cursorColor,
       showCursor: showCursor,
-      multiline: multiline,
+      maxLines: maxLines,
       selectionColor: selectionColor,
       textScaleFactor: textScaleFactor,
       selection: value.selection,

--- a/packages/flutter/lib/src/widgets/scrollable.dart
+++ b/packages/flutter/lib/src/widgets/scrollable.dart
@@ -708,6 +708,8 @@ class ScrollableState<T extends Scrollable> extends State<T> with SingleTickerPr
 
   // Used for state changes that sometimes occur during a build phase. If so,
   // we skip calling setState, as the changes will apply to the next build.
+  // TODO(ianh): This is ugly and hopefully temporary. Ideally this won't be
+  // needed after Scrollable is rewritten.
   void _setStateMaybeDuringBuild(VoidCallback fn) {
     if (SchedulerBinding.instance.schedulerPhase == SchedulerPhase.persistentCallbacks) {
       fn();

--- a/packages/flutter/lib/src/widgets/scrollable.dart
+++ b/packages/flutter/lib/src/widgets/scrollable.dart
@@ -486,9 +486,7 @@ class ScrollableState<T extends Scrollable> extends State<T> with SingleTickerPr
 
     if (duration == null) {
       _stop();
-      // scheduleMicrotask(() {
-        _setScrollOffset(newScrollOffset, details: details);
-      // });
+      _setScrollOffset(newScrollOffset, details: details);
       return new Future<Null>.value();
     }
 

--- a/packages/flutter/test/widget/input_test.dart
+++ b/packages/flutter/test/widget/input_test.dart
@@ -449,7 +449,7 @@ void main() {
             value: inputValue,
             key: inputKey,
             style: const TextStyle(color: Colors.black, fontSize: 34.0),
-            multiline: true,
+            maxLines: 3,
             hintText: 'Placeholder',
             onChanged: (InputValue value) { inputValue = value; }
           )
@@ -490,7 +490,7 @@ void main() {
                     value: inputValue,
                     key: inputKey,
                     style: const TextStyle(color: Colors.black, fontSize: 34.0),
-                    multiline: true,
+                    maxLines: 3,
                     onChanged: (InputValue value) { inputValue = value; }
                   )
                 )

--- a/packages/flutter/test/widget/input_test.dart
+++ b/packages/flutter/test/widget/input_test.dart
@@ -54,6 +54,11 @@ void main() {
   MockClipboard mockClipboard = new MockClipboard();
   serviceMocker.registerMockService(mockClipboard);
 
+  const String kThreeLines =
+    'First line of text is here abcdef ghijkl mnopqrst. ' +
+    'Second line of text goes until abcdef ghijkl mnopq. ' +
+    'Third line of stuff keeps going until abcdef ghijk. ';
+
   void enterText(String testValue) {
     // Simulate entry of text through the keyboard.
     expect(mockKeyboard.client, isNotNull);
@@ -469,11 +474,7 @@ void main() {
     expect(findInputBox(), equals(inputBox));
     expect(inputBox.size, equals(emptyInputSize));
 
-    String threeLines =
-      'First line of text is here abcdef ghijkl mnopqrst. ' +
-      'Second line of text goes until abcdef ghijkl mnopq. ' +
-      'Third line of stuff keeps going until abcdef ghijk. ';
-    enterText(threeLines);
+    enterText(kThreeLines);
     await tester.pumpWidget(builder(3), const Duration(seconds: 1));
     expect(findInputBox(), equals(inputBox));
     expect(inputBox.size, greaterThan(emptyInputSize));
@@ -481,7 +482,7 @@ void main() {
     Size threeLineInputSize = inputBox.size;
 
     // An extra line won't increase the size because we max at 3.
-    String fourLines = threeLines + 'Fourth line of text wraps and will not display.';
+    String fourLines = kThreeLines + 'Fourth line of text wraps and will not display.';
     enterText(fourLines);
     await tester.pumpWidget(builder(3), const Duration(seconds: 2));
     expect(findInputBox(), equals(inputBox));
@@ -522,8 +523,8 @@ void main() {
 
     await tester.pumpWidget(builder());
 
-    String testValue = 'First line of text is here abcdef ghijkl mnopqrst. Second line of text goes until abcdef ghijkl mnopq. Third line of stuff.';
-    String cutValue = 'First line of stuff.';
+    String testValue = kThreeLines;
+    String cutValue = 'First line of stuff keeps going until abcdef ghijk. ';
     enterText(testValue);
 
     await tester.pumpWidget(builder());


### PR DESCRIPTION
If maxLines is 1, it's a single line Input that scrolls horizontally.
Otherwise, overflowed text wraps and scrolls vertically, taking up at
most `maxLines`.

Also fixed scrolling behavior so that the Input scrolls ensuring the
cursor is always visible.

Fixes https://github.com/flutter/flutter/issues/6271
