### PR TITLE
Dismissable should cull and clip background

### DIFF
--- a/packages/flutter/test/widget/clip_test.dart
+++ b/packages/flutter/test/widget/clip_test.dart
@@ -15,7 +15,7 @@ class PathClipper extends CustomClipper<Path> {
       ..addRect(new Rect.fromLTWH(50.0, 50.0, 100.0, 100.0));
   }
   @override
-  bool shouldRepaint(PathClipper oldClipper) => false;
+  bool shouldReclip(PathClipper oldClipper) => false;
 }
 
 class ValueClipper<T> extends CustomClipper<T> {
@@ -31,7 +31,7 @@ class ValueClipper<T> extends CustomClipper<T> {
   }
 
   @override
-  bool shouldRepaint(ValueClipper<T> oldClipper) {
+  bool shouldReclip(ValueClipper<T> oldClipper) {
     return oldClipper.message != message || oldClipper.value != value;
   }
 }

--- a/packages/flutter/test/widget/dismissable_test.dart
+++ b/packages/flutter/test/widget/dismissable_test.dart
@@ -302,7 +302,7 @@ void main() {
     await dismissElement(tester, itemFinder, gestureDirection: DismissDirection.startToEnd);
     await tester.pump();
 
-    expect(find.text('background'), findsNWidgets(5));
+    expect(find.text('background'), findsOneWidget); // The other four have been culled.
     RenderBox backgroundBox = tester.firstRenderObject(find.text('background'));
     expect(backgroundBox.size.height, equals(100.0));
   });


### PR DESCRIPTION
When not dismissing, the Dismissable widget should cull its background.
When a dismiss is in progress, it should clip the background to just the
part that is revealed.

Fixes #6127
