### PR TITLE
Flutter daemon app launch extension

### DIFF
--- a/packages/flutter_tools/lib/src/cache.dart
+++ b/packages/flutter_tools/lib/src/cache.dart
@@ -126,6 +126,13 @@ class Cache {
     return new Directory(path.join(getCacheArtifacts().path, name));
   }
 
+  /// Return a path to the specified tools extension if it exists
+  /// or `null` if it does not.
+  String getToolsExtension(String commandName) {
+    String toolsExtension = path.join(_rootOverride?.path ?? flutterRoot, 'bin', 'tool-extensions', 'flutter-$commandName');
+    return FileSystemEntity.isFileSync(toolsExtension) ? toolsExtension : null;
+  }
+
   String getVersionFor(String artifactName) {
     File versionFile = new File(path.join(_rootOverride?.path ?? flutterRoot, 'bin', 'internal', '$artifactName.version'));
     return versionFile.existsSync() ? versionFile.readAsStringSync().trim() : null;


### PR DESCRIPTION
Different organizations have different requirements for building and launching Flutter applications, but the current Flutter tool does not take this into account. With this PR, customers can create a custom `flutter-run` script in the `flutter/repo/bin/tool-extensions/` directory, and `flutter daemon` will use that script, if it exists, to launch the Flutter application. 

This PR does not augments `flutter run` and only augments the non-debug daemon launch case.

Future
- update Flutter tool daemon debug launch to use this optional extension
- refactor `flutter run` hot and not-hot to have a common code path with this `flutter daemon` code and use this optional extension
- introduce a `flutter-build` extension point similar to this for customers to hook in their own Flutter build process
