### PR TITLE
Navigator.push and Navigator.pushNamed should return Futures

### DIFF
--- a/examples/flutter_gallery/lib/demo/shrine/shrine_home.dart
+++ b/examples/flutter_gallery/lib/demo/shrine/shrine_home.dart
@@ -296,18 +296,10 @@ class _ShrineHomeState extends State<ShrineHome> {
   static final GlobalKey<ScrollableState> scrollableKey = new GlobalKey<ScrollableState>();
   static final GridDelegate gridDelegate = new ShrineGridDelegate();
 
-  void handleCompletedOrder(Order completedOrder) {
-    assert(completedOrder.product != null);
-    if (completedOrder.quantity == 0)
-      _shoppingCart.remove(completedOrder.product);
-  }
-
-  void showOrderPage(Product product) {
+  Future<Null> showOrderPage(Product product) async {
     final Order order = _shoppingCart[product] ?? new Order(product: product);
-    final Completer<Order> completer = new Completer<Order>();
-    Navigator.push(context, new ShrineOrderRoute(
+    final Order completedOrder = await Navigator.push(context, new ShrineOrderRoute(
       order: order,
-      completer: completer,
       builder: (BuildContext context) {
         return new OrderPage(
           order: order,
@@ -316,7 +308,9 @@ class _ShrineHomeState extends State<ShrineHome> {
         );
       }
     ));
-    completer.future.then(handleCompletedOrder);
+    assert(completedOrder.product != null);
+    if (completedOrder.quantity == 0)
+      _shoppingCart.remove(completedOrder.product);
   }
 
   @override

--- a/examples/flutter_gallery/lib/demo/shrine/shrine_order.dart
+++ b/examples/flutter_gallery/lib/demo/shrine/shrine_order.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:async';
-
 import 'package:flutter/material.dart';
 
 import '../shrine_demo.dart' show ShrinePageRoute;
@@ -226,9 +224,8 @@ class ShrineOrderRoute extends ShrinePageRoute<Order> {
   ShrineOrderRoute({
     this.order,
     WidgetBuilder builder,
-    Completer<Order> completer,
     RouteSettings settings: const RouteSettings()
-  }) : super(builder: builder, completer: completer, settings: settings) {
+  }) : super(builder: builder, settings: settings) {
     assert(order != null);
   }
 

--- a/examples/flutter_gallery/lib/demo/shrine_demo.dart
+++ b/examples/flutter_gallery/lib/demo/shrine_demo.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:async';
-
 import 'package:flutter/material.dart';
 
 import 'shrine/shrine_home.dart' show ShrineHome;
@@ -26,9 +24,8 @@ Widget buildShrine(Widget child) {
 class ShrinePageRoute<T> extends MaterialPageRoute<T> {
   ShrinePageRoute({
     WidgetBuilder builder,
-    Completer<T> completer,
     RouteSettings settings: const RouteSettings()
-  }) : super(builder: builder, completer: completer, settings: settings);
+  }) : super(builder: builder, settings: settings);
 
   @override
   Widget buildPage(BuildContext context, Animation<double> animation, Animation<double> forwardAnimation) {

--- a/packages/flutter/lib/src/material/bottom_sheet.dart
+++ b/packages/flutter/lib/src/material/bottom_sheet.dart
@@ -204,10 +204,9 @@ class _ModalBottomSheetState<T> extends State<_ModalBottomSheet<T>> {
 
 class _ModalBottomSheetRoute<T> extends PopupRoute<T> {
   _ModalBottomSheetRoute({
-    Completer<T> completer,
     this.builder,
     this.theme,
-  }) : super(completer: completer);
+  });
 
   final WidgetBuilder builder;
   final ThemeData theme;
@@ -260,11 +259,8 @@ class _ModalBottomSheetRoute<T> extends PopupRoute<T> {
 Future<dynamic/*=T*/> showModalBottomSheet/*<T>*/({ BuildContext context, WidgetBuilder builder }) {
   assert(context != null);
   assert(builder != null);
-  final Completer<dynamic/*=T*/> completer = new Completer<dynamic/*=T*/>();
-  Navigator.push(context, new _ModalBottomSheetRoute<dynamic/*=T*/>(
-    completer: completer,
+  return Navigator.push(context, new _ModalBottomSheetRoute<dynamic/*=T*/>(
     builder: builder,
     theme: Theme.of(context, shadowThemeOnly: true),
   ));
-  return completer.future;
 }

--- a/packages/flutter/lib/src/material/dialog.dart
+++ b/packages/flutter/lib/src/material/dialog.dart
@@ -278,10 +278,9 @@ class SimpleDialog extends StatelessWidget {
 
 class _DialogRoute<T> extends PopupRoute<T> {
   _DialogRoute({
-    Completer<T> completer,
     this.child,
     this.theme,
-  }) : super(completer: completer);
+  });
 
   final Widget child;
   final ThemeData theme;
@@ -324,11 +323,8 @@ class _DialogRoute<T> extends PopupRoute<T> {
 ///  * [Dialog]
 ///  * <https://www.google.com/design/spec/components/dialogs.html>
 Future<dynamic/*=T*/> showDialog/*<T>*/({ BuildContext context, Widget child }) {
-  Completer<dynamic/*=T*/> completer = new Completer<dynamic/*=T*/>();
-  Navigator.push(context, new _DialogRoute<dynamic/*=T*/>(
-    completer: completer,
+  return Navigator.push(context, new _DialogRoute<dynamic/*=T*/>(
     child: child,
     theme: Theme.of(context, shadowThemeOnly: true),
   ));
-  return completer.future;
 }

--- a/packages/flutter/lib/src/material/drop_down.dart
+++ b/packages/flutter/lib/src/material/drop_down.dart
@@ -288,14 +288,13 @@ class _DropdownRouteResult<T> {
 
 class _DropdownRoute<T> extends PopupRoute<_DropdownRouteResult<T>> {
   _DropdownRoute({
-    Completer<_DropdownRouteResult<T>> completer,
     this.items,
     this.buttonRect,
     this.selectedIndex,
     this.elevation: 8,
     this.theme,
     TextStyle style,
-  }) : _style = style, super(completer: completer) {
+  }) : _style = style {
     assert(style != null);
   }
 
@@ -502,7 +501,6 @@ class _DropdownButtonState<T> extends State<DropdownButton<T>> {
     final Rect itemRect = itemBox.localToGlobal(Point.origin) & itemBox.size;
     final Completer<_DropdownRouteResult<T>> completer = new Completer<_DropdownRouteResult<T>>();
     _currentRoute = new _DropdownRoute<T>(
-      completer: completer,
       items: config.items,
       buttonRect: _kMenuHorizontalPadding.inflateRect(itemRect),
       selectedIndex: _selectedIndex,

--- a/packages/flutter/lib/src/material/page.dart
+++ b/packages/flutter/lib/src/material/page.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:async';
-
 import 'package:flutter/widgets.dart';
 import 'material.dart';
 import 'theme.dart';
@@ -167,10 +165,9 @@ class MaterialPageRoute<T> extends PageRoute<T> {
   /// Creates a page route for use in a material design app.
   MaterialPageRoute({
     this.builder,
-    Completer<T> completer,
     RouteSettings settings: const RouteSettings(),
     this.maintainState: true,
-  }) : super(completer: completer, settings: settings) {
+  }) : super(settings: settings) {
     assert(builder != null);
     assert(opaque);
   }

--- a/packages/flutter/lib/src/material/popup_menu.dart
+++ b/packages/flutter/lib/src/material/popup_menu.dart
@@ -370,13 +370,12 @@ class _PopupMenuRouteLayout extends SingleChildLayoutDelegate {
 
 class _PopupMenuRoute<T> extends PopupRoute<T> {
   _PopupMenuRoute({
-    Completer<T> completer,
     this.position,
     this.items,
     this.initialValue,
     this.elevation,
     this.theme
-  }) : super(completer: completer);
+  });
 
   final RelativeRect position;
   final List<PopupMenuEntry<T>> items;
@@ -439,16 +438,13 @@ Future<dynamic/*=T*/> showMenu/*<T>*/({
 }) {
   assert(context != null);
   assert(items != null && items.length > 0);
-  Completer<dynamic/*=T*/> completer = new Completer<dynamic/*=T*/>();
-  Navigator.push(context, new _PopupMenuRoute<dynamic/*=T*/>(
-    completer: completer,
+  return Navigator.push(context, new _PopupMenuRoute<dynamic/*=T*/>(
     position: position,
     items: items,
     initialValue: initialValue,
     elevation: elevation,
     theme: Theme.of(context, shadowThemeOnly: true),
   ));
-  return completer.future;
 }
 
 /// A callback that is passed the value of the PopupMenuItem that caused

--- a/packages/flutter/lib/src/widgets/pages.dart
+++ b/packages/flutter/lib/src/widgets/pages.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:async';
-
 import 'basic.dart';
 import 'navigator.dart';
 import 'overlay.dart';
@@ -13,9 +11,8 @@ import 'routes.dart';
 abstract class PageRoute<T> extends ModalRoute<T> {
   /// Creates a modal route that replaces the entire screen.
   PageRoute({
-    Completer<T> completer,
     RouteSettings settings: const RouteSettings()
-  }) : super(completer: completer, settings: settings);
+  }) : super(settings: settings);
 
   @override
   bool get opaque => true;

--- a/packages/flutter/test/widget/routes_test.dart
+++ b/packages/flutter/test/widget/routes_test.dart
@@ -35,16 +35,19 @@ class TestRoute extends LocalHistoryRoute<String> {
     _entries.add(entry);
     navigator.overlay?.insert(entry, above: insertionPoint);
     routes.add(this);
+    super.install(insertionPoint);
   }
 
   @override
   void didPush() {
     log('didPush');
+    super.didPush();
   }
 
   @override
   void didReplace(@checked TestRoute oldRoute) {
     log('didReplace ${oldRoute.name}');
+    super.didReplace(oldRoute);
   }
 
   @override
@@ -59,11 +62,13 @@ class TestRoute extends LocalHistoryRoute<String> {
   @override
   void didPopNext(@checked TestRoute nextRoute) {
     log('didPopNext ${nextRoute.name}');
+    super.didPopNext(nextRoute);
   }
 
   @override
   void didChangeNext(@checked TestRoute nextRoute) {
     log('didChangeNext ${nextRoute?.name}');
+    super.didChangeNext(nextRoute);
   }
 
   @override
@@ -72,6 +77,7 @@ class TestRoute extends LocalHistoryRoute<String> {
     _entries.forEach((OverlayEntry entry) { entry.remove(); });
     _entries.clear();
     routes.remove(this);
+    super.dispose();
   }
 
 }


### PR DESCRIPTION
These futures complete when the route is popped off the navigator. This
generalizes and simplifies a mechanism already in place for dialogs and
menus.

Fixes #5283
