### PR TITLE
Tweaked scroll simulation for iOS platform

### DIFF
--- a/packages/flutter/lib/physics.dart
+++ b/packages/flutter/lib/physics.dart
@@ -11,7 +11,6 @@ library physics;
 export 'src/physics/clamped_simulation.dart';
 export 'src/physics/friction_simulation.dart';
 export 'src/physics/gravity_simulation.dart';
-export 'src/physics/scroll_simulation.dart';
 export 'src/physics/simulation_group.dart';
 export 'src/physics/simulation.dart';
 export 'src/physics/spring_simulation.dart';

--- a/packages/flutter/lib/src/physics/scroll_simulation.dart
+++ b/packages/flutter/lib/src/physics/scroll_simulation.dart
@@ -2,10 +2,105 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:math' as math;
+
+import 'package:flutter/foundation.dart';
+
 import 'friction_simulation.dart';
 import 'simulation_group.dart';
 import 'simulation.dart';
 import 'spring_simulation.dart';
+
+// This class is based on Scroller.java from
+// https://android.googlesource.com/platform/frameworks/base/+/master/core/java/android/widget
+// The "See" comments refer to Scroller methods and values. Some simplifications
+// have been made.
+class _MountainViewSimulation extends Simulation {
+  _MountainViewSimulation({
+    this.position,
+    this.velocity,
+    this.devicePixelRatio: 3.0, // TODO(hansmuller) lookup this value
+    this.friction: 0.015,
+  }) {
+    _scaledFriction = friction * _decelerationForFriction(0.84); // See mPhysicalCoeff
+    _duration = _flingDuration(velocity);
+    _distance = _flingDistance(velocity);
+  }
+
+  final double position;
+  final double velocity;
+  final double devicePixelRatio;
+  final double friction;
+
+  double _scaledFriction;
+  double _duration;
+  double _distance;
+
+  // See DECELERATION_RATE
+  static final double _decelerationRate = math.log(0.78) / math.log(0.9);
+
+  // See computeDeceleration()
+  double _decelerationForFriction(double friction) {
+    return /*devicePixelRatio * */friction * 61774.04968;
+  }
+
+  // See getSplineDeceleration()
+  double _flingDeceleration(double velocity) {
+    return math.log(0.35 * velocity.abs() / _scaledFriction);
+  }
+  // See getSplineFlingDuration()
+  double _flingDuration(double velocity) {
+    return math.exp(_flingDeceleration(velocity) / (_decelerationRate - 1.0));
+  }
+
+  // See getSplineFlingDistance()
+  double _flingDistance(double velocity) {
+    final double rate = _decelerationRate / (_decelerationRate - 1.0) * _flingDeceleration(velocity);
+    return _scaledFriction * math.exp(rate);
+  }
+
+  // This cubic function is based on the SPLINE_POSITION values computed by the
+  // Scroller class. Wolfram Alpha's "cubic fit calculator" was applied to every
+  // fifth value {0.0, 0.141, 0.274, 0.392, 0.495, 0.583, 0.658, 0.721, 0.775,
+  /// 0.820, 0.858, 0.890, 0.916, 0.938, 0.956, 0.971, 0.982, 0.990, 0.995, 1.0}.
+  // That produced: f(x) = 0.000159897 x^3-0.00881705 x^2+0.170734 x-0.162279 with
+  // an R-squared value of 0.9999. It's zero at x=1.00132 and 1.0 at x=19.5036.
+  // The result of substituting t * (19.5036 - 1.00132) + 1.00132 for x is the
+  // cubic function below.
+  double _flingDistancePenetration(double t) {
+    return (1.01278 * t * t * t) - (2.85395 * t * t) + (2.84117 * t);
+  }
+
+  // Based on the deriviate of the _flingPenetration() function,
+  // f(t) = 3.03834 t^2 -5.7079 t + 2.84117, which is zero at
+  // t = .4132643, and 1.0 at t = 0.93912. The result of replacing t with
+  // t * (0.93912 - 0.4132643) + 0.4132643 is the quadratic below.
+  double _flingVelocityPenetration(double t) {
+    return (0.840175 * t * t) - (1.68096 * t) + 1.0012;
+  }
+
+  @override
+  double x(double time) {
+    final double t = (time / _duration).clamp(0.0, 1.0);
+    return position + _distance * _flingDistancePenetration(t) * velocity.sign;
+  }
+
+  @override
+  double dx(double time) {
+    final double t = (time / _duration).clamp(0.0, 1.0);
+    return velocity * _flingVelocityPenetration(t);
+  }
+
+  @override
+  bool isDone(double time) {
+    return time >= _duration;
+  }
+}
+
+class _CupertinoSimulation extends FrictionSimulation {
+  _CupertinoSimulation({ double drag, double position, double velocity })
+    : super(drag, position, velocity);
+}
 
 /// Composite simulation for scrollable interfaces.
 ///
@@ -26,13 +121,23 @@ class ScrollSimulation extends SimulationGroup {
   /// consistent with the other arguments.
   ///
   /// The final argument is the coefficient of friction, which is unitless.
-  ScrollSimulation(
+  ScrollSimulation({
     double position,
     double velocity,
-    this._leadingExtent,
-    this._trailingExtent,
-    this._spring,
-    this._drag) {
+    double leadingExtent,
+    double trailingExtent,
+    SpringDescription spring,
+    double drag,
+    TargetPlatform platform,
+  }) : _leadingExtent = leadingExtent,
+       _trailingExtent = trailingExtent,
+       _spring = spring,
+       _drag = drag,
+       _platform = platform {
+    assert(_leadingExtent != null);
+    assert(_trailingExtent != null);
+    assert(_spring != null);
+    assert(_drag != null);
     _chooseSimulation(position, velocity, 0.0);
   }
 
@@ -40,6 +145,7 @@ class ScrollSimulation extends SimulationGroup {
   final double _trailingExtent;
   final SpringDescription _spring;
   final double _drag;
+  final TargetPlatform _platform;
 
   bool _isSpringing = false;
   Simulation _currentSimulation;
@@ -76,7 +182,25 @@ class ScrollSimulation extends SimulationGroup {
     }
 
     if (_currentSimulation == null) {
-      _currentSimulation = new FrictionSimulation(_drag, position, velocity);
+      switch (_platform) {
+        case TargetPlatform.android:
+        case TargetPlatform.fuchsia:
+          _currentSimulation = new _MountainViewSimulation(
+            position: position,
+            velocity: velocity
+          );
+          break;
+        case TargetPlatform.iOS:
+          _currentSimulation = new _CupertinoSimulation(
+            position: position,
+            velocity: velocity,
+            drag: _drag,
+          );
+          break;
+      }
+      // No platform specified
+      _currentSimulation ??= new FrictionSimulation(_drag, position, velocity);
+
       return true;
     }
 

--- a/packages/flutter/lib/src/physics/scroll_simulation.dart
+++ b/packages/flutter/lib/src/physics/scroll_simulation.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:math' as math;
-
 import 'package:flutter/foundation.dart';
 
 import 'friction_simulation.dart';
@@ -11,95 +9,18 @@ import 'simulation_group.dart';
 import 'simulation.dart';
 import 'spring_simulation.dart';
 
-// This class is based on Scroller.java from
-// https://android.googlesource.com/platform/frameworks/base/+/master/core/java/android/widget
-// The "See" comments refer to Scroller methods and values. Some simplifications
-// have been made.
-class _MountainViewSimulation extends Simulation {
-  _MountainViewSimulation({
-    this.position,
-    this.velocity,
-    this.devicePixelRatio: 3.0, // TODO(hansmuller) lookup this value
-    this.friction: 0.015,
-  }) {
-    _scaledFriction = friction * _decelerationForFriction(0.84); // See mPhysicalCoeff
-    _duration = _flingDuration(velocity);
-    _distance = _flingDistance(velocity);
-  }
+final SpringDescription _kScrollSpring = new SpringDescription.withDampingRatio(mass: 0.5, springConstant: 100.0, ratio: 1.1);
 
-  final double position;
-  final double velocity;
-  final double devicePixelRatio;
-  final double friction;
-
-  double _scaledFriction;
-  double _duration;
-  double _distance;
-
-  // See DECELERATION_RATE
-  static final double _decelerationRate = math.log(0.78) / math.log(0.9);
-
-  // See computeDeceleration()
-  double _decelerationForFriction(double friction) {
-    return /*devicePixelRatio * */friction * 61774.04968;
-  }
-
-  // See getSplineDeceleration()
-  double _flingDeceleration(double velocity) {
-    return math.log(0.35 * velocity.abs() / _scaledFriction);
-  }
-  // See getSplineFlingDuration()
-  double _flingDuration(double velocity) {
-    return math.exp(_flingDeceleration(velocity) / (_decelerationRate - 1.0));
-  }
-
-  // See getSplineFlingDistance()
-  double _flingDistance(double velocity) {
-    final double rate = _decelerationRate / (_decelerationRate - 1.0) * _flingDeceleration(velocity);
-    return _scaledFriction * math.exp(rate);
-  }
-
-  // This cubic function is based on the SPLINE_POSITION values computed by the
-  // Scroller class. Wolfram Alpha's "cubic fit calculator" was applied to every
-  // fifth value {0.0, 0.141, 0.274, 0.392, 0.495, 0.583, 0.658, 0.721, 0.775,
-  /// 0.820, 0.858, 0.890, 0.916, 0.938, 0.956, 0.971, 0.982, 0.990, 0.995, 1.0}.
-  // That produced: f(x) = 0.000159897 x^3-0.00881705 x^2+0.170734 x-0.162279 with
-  // an R-squared value of 0.9999. It's zero at x=1.00132 and 1.0 at x=19.5036.
-  // The result of substituting t * (19.5036 - 1.00132) + 1.00132 for x is the
-  // cubic function below.
-  double _flingDistancePenetration(double t) {
-    return (1.01278 * t * t * t) - (2.85395 * t * t) + (2.84117 * t);
-  }
-
-  // Based on the deriviate of the _flingPenetration() function,
-  // f(t) = 3.03834 t^2 -5.7079 t + 2.84117, which is zero at
-  // t = .4132643, and 1.0 at t = 0.93912. The result of replacing t with
-  // t * (0.93912 - 0.4132643) + 0.4132643 is the quadratic below.
-  double _flingVelocityPenetration(double t) {
-    return (0.840175 * t * t) - (1.68096 * t) + 1.0012;
-  }
-
-  @override
-  double x(double time) {
-    final double t = (time / _duration).clamp(0.0, 1.0);
-    return position + _distance * _flingDistancePenetration(t) * velocity.sign;
-  }
-
-  @override
-  double dx(double time) {
-    final double t = (time / _duration).clamp(0.0, 1.0);
-    return velocity * _flingVelocityPenetration(t);
-  }
-
-  @override
-  bool isDone(double time) {
-    return time >= _duration;
-  }
+class _MountainViewSimulation extends FrictionSimulation {
+  static const double drag = 0.025;
+  _MountainViewSimulation({ double position, double velocity })
+    : super(drag, position, velocity);
 }
 
 class _CupertinoSimulation extends FrictionSimulation {
-  _CupertinoSimulation({ double drag, double position, double velocity })
-    : super(drag, position, velocity);
+  static const double drag = 0.135;
+  _CupertinoSimulation({ double position, double velocity })
+    : super(drag, position, velocity * 0.91);
 }
 
 /// Composite simulation for scrollable interfaces.
@@ -131,13 +52,12 @@ class ScrollSimulation extends SimulationGroup {
     TargetPlatform platform,
   }) : _leadingExtent = leadingExtent,
        _trailingExtent = trailingExtent,
-       _spring = spring,
+       _spring = spring ?? _kScrollSpring,
        _drag = drag,
        _platform = platform {
     assert(_leadingExtent != null);
     assert(_trailingExtent != null);
     assert(_spring != null);
-    assert(_drag != null);
     _chooseSimulation(position, velocity, 0.0);
   }
 
@@ -194,7 +114,6 @@ class ScrollSimulation extends SimulationGroup {
           _currentSimulation = new _CupertinoSimulation(
             position: position,
             velocity: velocity,
-            drag: _drag,
           );
           break;
       }

--- a/packages/flutter/lib/src/widgets/scroll_behavior.dart
+++ b/packages/flutter/lib/src/widgets/scroll_behavior.dart
@@ -8,6 +8,8 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/physics.dart';
 import 'package:meta/meta.dart';
 
+import 'scroll_simulation.dart';
+
 export 'package:flutter/foundation.dart' show TargetPlatform;
 
 Simulation _createSnapScrollSimulation(double startOffset, double endOffset, double startVelocity, double endVelocity) {

--- a/packages/flutter/lib/src/widgets/scroll_behavior.dart
+++ b/packages/flutter/lib/src/widgets/scroll_behavior.dart
@@ -14,10 +14,6 @@ const double _kScrollDragMountainView = 0.025;
 const double _kScrollDragCupertino = 0.125;
 final SpringDescription _kScrollSpring = new SpringDescription.withDampingRatio(mass: 0.5, springConstant: 100.0, ratio: 1.1);
 
-Simulation _createScrollSimulation(double position, double velocity, double minScrollOffset, double maxScrollOffset, double scrollDrag) {
-  return new ScrollSimulation(position, velocity, minScrollOffset, maxScrollOffset, _kScrollSpring, scrollDrag);
-}
-
 Simulation _createSnapScrollSimulation(double startOffset, double endOffset, double startVelocity, double endVelocity) {
   return new FrictionSimulation.through(startOffset, endOffset, startVelocity, endVelocity);
 }
@@ -259,7 +255,15 @@ class OverscrollBehavior extends BoundedBehavior {
 
   @override
   Simulation createScrollSimulation(double position, double velocity) {
-    return _createScrollSimulation(position, velocity, minScrollOffset, maxScrollOffset, scrollDrag);
+    return new ScrollSimulation(
+      position: position,
+      velocity: velocity,
+      leadingExtent: minScrollOffset,
+      trailingExtent: maxScrollOffset,
+      spring: _kScrollSpring,
+      drag: scrollDrag,
+      platform: platform,
+    );
   }
 
   @override

--- a/packages/flutter/lib/src/widgets/scroll_behavior.dart
+++ b/packages/flutter/lib/src/widgets/scroll_behavior.dart
@@ -10,10 +10,6 @@ import 'package:meta/meta.dart';
 
 export 'package:flutter/foundation.dart' show TargetPlatform;
 
-const double _kScrollDragMountainView = 0.025;
-const double _kScrollDragCupertino = 0.125;
-final SpringDescription _kScrollSpring = new SpringDescription.withDampingRatio(mass: 0.5, springConstant: 100.0, ratio: 1.1);
-
 Simulation _createSnapScrollSimulation(double startOffset, double endOffset, double startVelocity, double endVelocity) {
   return new FrictionSimulation.through(startOffset, endOffset, startVelocity, endVelocity);
 }
@@ -64,20 +60,6 @@ abstract class ScrollBehavior<T, U> {
 
   /// Whether this scroll behavior currently permits scrolling.
   bool get isScrollable => true;
-
-  /// The scroll drag constant to use for physics simulations created by this
-  /// ScrollBehavior.
-  double get scrollDrag {
-    assert(platform != null);
-    switch (platform) {
-      case TargetPlatform.android:
-      case TargetPlatform.fuchsia:
-        return _kScrollDragMountainView;
-      case TargetPlatform.iOS:
-        return _kScrollDragCupertino;
-    }
-    return null;
-  }
 
   @override
   String toString() {
@@ -216,8 +198,11 @@ class UnboundedBehavior extends ExtentScrollBehavior {
 
   @override
   Simulation createScrollSimulation(double position, double velocity) {
-    return new BoundedFrictionSimulation(
-      scrollDrag, position, velocity, double.NEGATIVE_INFINITY, double.INFINITY
+    return new ScrollSimulation(
+      position: position,
+      velocity: velocity,
+      leadingExtent: double.NEGATIVE_INFINITY,
+      trailingExtent: double.INFINITY,
     );
   }
 
@@ -260,8 +245,6 @@ class OverscrollBehavior extends BoundedBehavior {
       velocity: velocity,
       leadingExtent: minScrollOffset,
       trailingExtent: maxScrollOffset,
-      spring: _kScrollSpring,
-      drag: scrollDrag,
       platform: platform,
     );
   }

--- a/packages/flutter/lib/src/widgets/scroll_behavior.dart
+++ b/packages/flutter/lib/src/widgets/scroll_behavior.dart
@@ -203,6 +203,7 @@ class UnboundedBehavior extends ExtentScrollBehavior {
       velocity: velocity,
       leadingExtent: double.NEGATIVE_INFINITY,
       trailingExtent: double.INFINITY,
+      platform: platform,
     );
   }
 

--- a/packages/flutter/lib/src/widgets/scroll_simulation.dart
+++ b/packages/flutter/lib/src/widgets/scroll_simulation.dart
@@ -3,11 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:flutter/foundation.dart';
-
-import 'friction_simulation.dart';
-import 'simulation_group.dart';
-import 'simulation.dart';
-import 'spring_simulation.dart';
+import 'package:flutter/physics.dart';
 
 final SpringDescription _kScrollSpring = new SpringDescription.withDampingRatio(mass: 0.5, springConstant: 100.0, ratio: 1.1);
 

--- a/packages/flutter/lib/widgets.dart
+++ b/packages/flutter/lib/widgets.dart
@@ -48,6 +48,7 @@ export 'src/widgets/raw_keyboard_listener.dart';
 export 'src/widgets/routes.dart';
 export 'src/widgets/scroll_behavior.dart';
 export 'src/widgets/scroll_configuration.dart';
+export 'src/widgets/scroll_simulation.dart';
 export 'src/widgets/scrollable.dart';
 export 'src/widgets/scrollable_grid.dart';
 export 'src/widgets/scrollable_list.dart';

--- a/packages/flutter/test/physics/newton_test.dart
+++ b/packages/flutter/test/physics/newton_test.dart
@@ -5,6 +5,7 @@
 import 'package:test/test.dart';
 
 import 'package:flutter/physics.dart';
+import 'package:flutter/widgets.dart';
 
 void main() {
   test('test_friction', () {

--- a/packages/flutter/test/physics/newton_test.dart
+++ b/packages/flutter/test/physics/newton_test.dart
@@ -191,13 +191,27 @@ void main() {
     SpringDescription spring = new SpringDescription.withDampingRatio(
         mass: 1.0, springConstant: 50.0, ratio: 0.5);
 
-    ScrollSimulation scroll = new ScrollSimulation(100.0, 800.0, 0.0, 300.0, spring, 0.3);
+    ScrollSimulation scroll = new ScrollSimulation(
+      position: 100.0,
+      velocity: 800.0,
+      leadingExtent: 0.0,
+      trailingExtent: 300.0,
+      spring: spring,
+      drag: 0.3
+    );
     scroll.tolerance = const Tolerance(velocity: 0.5, distance: 0.1);
     expect(scroll.isDone(0.0), false);
     expect(scroll.isDone(0.5), false); // switch from friction to spring
     expect(scroll.isDone(3.5), true);
 
-    ScrollSimulation scroll2 = new ScrollSimulation(100.0, -800.0, 0.0, 300.0, spring, 0.3);
+    ScrollSimulation scroll2 = new ScrollSimulation(
+      position: 100.0,
+      velocity: -800.0,
+      leadingExtent: 0.0,
+      trailingExtent: 300.0,
+      spring: spring,
+      drag: 0.3
+    );
     scroll2.tolerance = const Tolerance(velocity: 0.5, distance: 0.1);
     expect(scroll2.isDone(0.0), false);
     expect(scroll2.isDone(0.5), false); // switch from friction to spring
@@ -208,8 +222,14 @@ void main() {
     SpringDescription spring = new SpringDescription.withDampingRatio(
         mass: 1.0, springConstant: 50.0, ratio: 0.5);
 
-    ScrollSimulation scroll =
-        new ScrollSimulation(100.0, 400.0, 0.0, double.INFINITY, spring, 0.3);
+    ScrollSimulation scroll = new ScrollSimulation(
+      position: 100.0,
+      velocity: 400.0,
+      leadingExtent: 0.0,
+      trailingExtent: double.INFINITY,
+      spring: spring,
+      drag: 0.3,
+    );
     scroll.tolerance = const Tolerance(velocity: 1.0);
 
     expect(scroll.isDone(0.0), false);
@@ -232,7 +252,14 @@ void main() {
 
   test('over/under scroll spring', () {
     SpringDescription spring = new SpringDescription.withDampingRatio(mass: 1.0, springConstant: 170.0, ratio: 1.1);
-    ScrollSimulation scroll = new ScrollSimulation(500.0, -7500.0, 0.0, 1000.0, spring, 0.025);
+    ScrollSimulation scroll = new ScrollSimulation(
+      position: 500.0,
+      velocity: -7500.0,
+      leadingExtent: 0.0,
+      trailingExtent: 1000.0,
+      spring: spring,
+      drag: 0.025,
+    );
     scroll.tolerance = new Tolerance(velocity: 45.0, distance: 1.5);
 
     expect(scroll.isDone(0.0), false);


### PR DESCRIPTION
I've removed the new Android scroll simulation for the moment.

The platform-specific stuff has moved from the ScrollBehavior classes to the ScrollSimulation class which now uses keyword parameters.
