### PR TITLE
don't run the summary code if the upgrade fails

### DIFF
--- a/packages/flutter_tools/lib/src/commands/upgrade.dart
+++ b/packages/flutter_tools/lib/src/commands/upgrade.dart
@@ -47,10 +47,10 @@ class UpgradeCommand extends FlutterCommand {
       mapFunction: (String line) => matchesGitLine(line) ? null : line
     );
 
-    await buildUnlinkedForPackages(Cache.flutterRoot);
-
     if (code != 0)
       return code;
+
+    await buildUnlinkedForPackages(Cache.flutterRoot);
 
     // Check for and download any engine and pkg/ updates.
     // We run the 'flutter' shell script re-entrantly here


### PR DESCRIPTION
- don't run the summary code if the upgrade fails
- fix https://github.com/flutter/flutter/issues/6349
