### PR TITLE
Add BuildContext.size as a convenience getter

### DIFF
--- a/examples/flutter_gallery/lib/demo/grid_list_demo.dart
+++ b/examples/flutter_gallery/lib/demo/grid_list_demo.dart
@@ -62,11 +62,11 @@ class _GridPhotoViewerState extends State<GridPhotoViewer> with SingleTickerProv
   // renderer's box is w,h then the maximum value of the focal point is
   // (w * _scale - w)/_scale, (h * _scale - h)/_scale.
   Point _clampFocalPoint(Point point) {
-    final RenderBox box = context.findRenderObject();
+    final Size size = context.size;
     final double inverseScale = (_scale - 1.0) / _scale;
     final Point bottomRight = new Point(
-      box.size.width * inverseScale,
-      box.size.height * inverseScale
+      size.width * inverseScale,
+      size.height * inverseScale,
     );
      return new Point(point.x.clamp(0.0, bottomRight.x), point.y.clamp(0.0, bottomRight.y));
   }
@@ -101,8 +101,7 @@ class _GridPhotoViewerState extends State<GridPhotoViewer> with SingleTickerProv
     if (magnitude < _kMinFlingVelocity)
       return;
     final Offset direction = details.velocity.pixelsPerSecond / magnitude;
-    final RenderBox box = context.findRenderObject();
-    final double distance = (Point.origin & box.size).shortestSide;
+    final double distance = (Point.origin & context.size).shortestSide;
     _flingAnimation = new Tween<Point>(
       begin: _focalPoint,
       end: _clampFocalPoint(_focalPoint + direction * -distance)

--- a/packages/flutter/lib/src/material/scaffold.dart
+++ b/packages/flutter/lib/src/material/scaffold.dart
@@ -745,13 +745,11 @@ class ScaffoldState extends State<Scaffold> with TickerProviderStateMixin {
   }
 
   void _handleDragUpdate(DragUpdateDetails details) {
-    final RenderBox box = context.findRenderObject();
-    _backGestureController?.dragUpdate(details.primaryDelta / box.size.width);
+    _backGestureController?.dragUpdate(details.primaryDelta / context.size.width);
   }
 
   void _handleDragEnd(DragEndDetails details) {
-    final RenderBox box = context.findRenderObject();
-    _backGestureController?.dragEnd(details.velocity.pixelsPerSecond.dx / box.size.width);
+    _backGestureController?.dragEnd(details.velocity.pixelsPerSecond.dx / context.size.width);
     _backGestureController = null;
   }
 

--- a/packages/flutter/lib/src/widgets/dismissable.dart
+++ b/packages/flutter/lib/src/widgets/dismissable.dart
@@ -197,10 +197,7 @@ class _DismissableState extends State<Dismissable> with TickerProviderStateMixin
   }
 
   double get _overallDragAxisExtent {
-    final RenderBox box = context.findRenderObject();
-    assert(box != null);
-    assert(box.hasSize);
-    final Size size = box.size;
+    final Size size = context.size;
     return _directionIsXAxis ? size.width : size.height;
   }
 
@@ -324,8 +321,7 @@ class _DismissableState extends State<Dismissable> with TickerProviderStateMixin
         ..addListener(_handleResizeProgressChanged);
       _resizeController.forward();
       setState(() {
-        RenderBox box = context.findRenderObject();
-        _sizePriorToCollapse = box.size;
+        _sizePriorToCollapse = context.size;
         _resizeAnimation = new Tween<double>(
           begin: 1.0,
           end: 0.0

--- a/packages/flutter/lib/src/widgets/mimic.dart
+++ b/packages/flutter/lib/src/widgets/mimic.dart
@@ -197,12 +197,8 @@ class MimicableState extends State<Mimicable> {
       }
       return true;
     });
-    RenderBox box = context.findRenderObject();
-    assert(box != null);
-    assert(box.hasSize);
-    assert(!box.needsLayout);
     setState(() {
-      _placeholderSize = box.size;
+      _placeholderSize = context.size;
     });
     return new MimicableHandle._(this);
   }

--- a/packages/flutter/lib/src/widgets/scrollable.dart
+++ b/packages/flutter/lib/src/widgets/scrollable.dart
@@ -595,8 +595,7 @@ class ScrollableState<T extends Scrollable> extends State<T> with SingleTickerPr
 
   /// Returns the snapped offset closest to the given scroll offset.
   double snapScrollOffset(double scrollOffset) {
-    RenderBox box = context.findRenderObject();
-    return config.snapOffsetCallback == null ? scrollOffset : config.snapOffsetCallback(scrollOffset, box.size);
+    return config.snapOffsetCallback == null ? scrollOffset : config.snapOffsetCallback(scrollOffset, context.size);
   }
 
   Simulation _createSnapSimulation(double scrollVelocity) {

--- a/packages/flutter/test/widget/align_test.dart
+++ b/packages/flutter/test/widget/align_test.dart
@@ -38,8 +38,8 @@ void main() {
       )
     );
 
-    RenderBox box = alignKey.currentContext.findRenderObject();
-    expect(box.size.width, equals(800.0));
-    expect(box.size.height, equals(10.0));
+    final Size size = alignKey.currentContext.size;
+    expect(size.width, equals(800.0));
+    expect(size.height, equals(10.0));
   });
 }

--- a/packages/flutter/test/widget/pageable_list_test.dart
+++ b/packages/flutter/test/widget/pageable_list_test.dart
@@ -217,9 +217,9 @@ void main() {
     await pageRight(tester);
     expect(currentPage, equals(5));
 
-    RenderBox box = globalKeys[5].currentContext.findRenderObject();
-    expect(box.size.width, equals(pageSize.width));
-    expect(box.size.height, equals(pageSize.height));
+    Size boxSize = globalKeys[5].currentContext.size;
+    expect(boxSize.width, equals(pageSize.width));
+    expect(boxSize.height, equals(pageSize.height));
 
     pageSize = new Size(pageSize.height, pageSize.width);
     await tester.pumpWidget(buildFrame(itemsWrap: true));
@@ -231,8 +231,8 @@ void main() {
     expect(find.text('4'), findsNothing);
     expect(find.text('5'), findsOneWidget);
 
-    box = globalKeys[5].currentContext.findRenderObject();
-    expect(box.size.width, equals(pageSize.width));
-    expect(box.size.height, equals(pageSize.height));
+    boxSize = globalKeys[5].currentContext.size;
+    expect(boxSize.width, equals(pageSize.width));
+    expect(boxSize.height, equals(pageSize.height));
   });
 }


### PR DESCRIPTION
Developers need to get the size of the BuildContext sufficiently often
that we should provide a convenient getter for the value. Having this
getter is also an opportunity to catch common mistakes and provide
useful error messages that guide developers towards better patterns.

Fixes #2321
