### PR TITLE
reenable dev/devicelab/test/run_test.dart

### DIFF
--- a/dev/devicelab/test/run_test.dart
+++ b/dev/devicelab/test/run_test.dart
@@ -35,7 +35,7 @@ void main() {
 
     test('Exits with code 1 when fails to connect', () async {
       expect(await runScript(<String>['smoke_test_setup_failure']), 1);
-    }, skip: true); // https://github.com/flutter/flutter/issues/5901
+    });
 
     test('Exits with code 1 when results are mixed', () async {
       expect(


### PR DESCRIPTION
I ran the test 10 times on Linux and Mac and it succeeded
consistently. Let's reenable until there are new reports that it's
flaky.

Fixes #5901 
