### PR TITLE
Do not reassemble the application after a hot reload if the isolate is paused

### DIFF
--- a/packages/flutter_tools/lib/src/hot.dart
+++ b/packages/flutter_tools/lib/src/hot.dart
@@ -493,6 +493,15 @@ class HotRunner extends ResidentRunner {
       printError('Hot reload failed:\ncode = $errorCode\nmessage = $errorMessage\n$st');
       return false;
     }
+    // Reload the isolate.
+    await currentView.uiIsolate.reload();
+    // Check if the isolate is paused.
+    final ServiceEvent pauseEvent = currentView.uiIsolate.pauseEvent;
+    if ((pauseEvent != null) && (pauseEvent.isPauseEvent)) {
+      // Isolate is paused. Stop here.
+      printTrace('Skipping reassemble because isolate is paused.');
+      return true;
+    }
     await _evictDirtyAssets();
     printTrace('Reassembling application');
     bool waitForFrame = true;
@@ -510,7 +519,7 @@ class HotRunner extends ResidentRunner {
     }
     if (waitForFrame) {
       // When the framework is present, we can wait for the first frame
-      // event and measure reload itme.
+      // event and measure reload time.
       await firstFrameTimer.firstFrame();
       printStatus('Hot reload performed in '
                   '${getElapsedAsMilliseconds(firstFrameTimer.elapsed)}.');

--- a/packages/flutter_tools/lib/src/vmservice.dart
+++ b/packages/flutter_tools/lib/src/vmservice.dart
@@ -332,6 +332,7 @@ class ServiceEvent extends ServiceObject {
   static const String kPauseBreakpoint        = 'PauseBreakpoint';
   static const String kPauseInterrupted       = 'PauseInterrupted';
   static const String kPauseException         = 'PauseException';
+  static const String kPausePostRequest       = 'PausePostRequest';
   static const String kNone                   = 'None';
   static const String kResume                 = 'Resume';
   static const String kBreakpointAdded        = 'BreakpointAdded';
@@ -379,6 +380,7 @@ class ServiceEvent extends ServiceObject {
             kind == kPauseBreakpoint ||
             kind == kPauseInterrupted ||
             kind == kPauseException ||
+            kind == kPausePostRequest ||
             kind == kNone);
   }
 }
@@ -680,6 +682,7 @@ class Isolate extends ServiceObjectOwner {
   Isolate get isolate => this;
 
   DateTime startTime;
+  ServiceEvent pauseEvent;
 
   final Map<String, ServiceObject> _cache = new Map<String, ServiceObject>();
 
@@ -744,8 +747,9 @@ class Isolate extends ServiceObjectOwner {
     int startTimeMillis = map['startTime'];
     startTime = new DateTime.fromMillisecondsSinceEpoch(startTimeMillis);
 
-    // TODO(johnmccutchan): Extract any properties we care about here.
     _upgradeCollection(map, this);
+
+    pauseEvent = map['pauseEvent'];
   }
 
   static final int kIsolateReloadBarred = 1005;


### PR DESCRIPTION
- [x] add `pauseEvent` to `Isolate`.
- [x] add `PausePostRequest` pause kind.
- [x] Do not reassemble the application if the isolate is paused after a reload. 

Now when the isolate is paused after a hot reload, we do not invoke any Dart code in the isolate and leave control in the debug clients. This allows for debug clients to set breakpoints, etc after a reload. 
