### PR TITLE
Revert "reenable dev/devicelab/test/run_test.dart (#6364)"

### DIFF
--- a/dev/devicelab/test/run_test.dart
+++ b/dev/devicelab/test/run_test.dart
@@ -35,7 +35,7 @@ void main() {
 
     test('Exits with code 1 when fails to connect', () async {
       expect(await runScript(<String>['smoke_test_setup_failure']), 1);
-    });
+    }, skip: true); // https://github.com/flutter/flutter/issues/5901
 
     test('Exits with code 1 when results are mixed', () async {
       expect(


### PR DESCRIPTION
This reverts commit 8f273e49dea9233aa2958744a2c513e23b4f3fe6.

See https://github.com/flutter/flutter/issues/5901#issuecomment-254625981

/cc @Hixie 
