### PR TITLE
Enable call to Keyboard.ClearClient now that it's available in the engine

### DIFF
--- a/packages/flutter/lib/src/services/keyboard.dart
+++ b/packages/flutter/lib/src/services/keyboard.dart
@@ -95,7 +95,7 @@ class KeyboardHandle {
     if (_attached) {
       assert(_keyboard._currentHandle == this);
       _attached = false;
-      //_keyboard.service.clearClient();
+      _keyboard.service.clearClient();
       _keyboard._currentHandle = null;
       _keyboard._scheduleHide();
     }


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/6274
