### PR TITLE
Propagate platform through the subsidiary themes.

### DIFF
--- a/examples/flutter_gallery/lib/demo/calculator/home.dart
+++ b/examples/flutter_gallery/lib/demo/calculator/home.dart
@@ -162,7 +162,8 @@ class KeyPad extends StatelessWidget {
   Widget build(BuildContext context) {
     final ThemeData themeData = new ThemeData(
       primarySwatch: Colors.purple,
-      brightness: Brightness.dark
+      brightness: Brightness.dark,
+      platform: Theme.of(context).platform,
     );
     return new Theme(
       data: themeData,

--- a/examples/flutter_gallery/lib/demo/contacts_demo.dart
+++ b/examples/flutter_gallery/lib/demo/contacts_demo.dart
@@ -99,7 +99,8 @@ class ContactsDemoState extends State<ContactsDemo> {
     return new Theme(
       data: new ThemeData(
         brightness: Brightness.light,
-        primarySwatch: Colors.indigo
+        primarySwatch: Colors.indigo,
+        platform: Theme.of(context).platform,
       ),
       child: new Scaffold(
         key: _scaffoldKey,

--- a/examples/flutter_gallery/lib/demo/pesto_demo.dart
+++ b/examples/flutter_gallery/lib/demo/pesto_demo.dart
@@ -82,7 +82,7 @@ class _RecipeGridPageState extends State<RecipeGridPage> {
   Widget build(BuildContext context) {
     final double statusBarHeight = MediaQuery.of(context).padding.top;
     return new Theme(
-      data: _kTheme,
+      data: _kTheme.copyWith(platform: Theme.of(context).platform),
       child: new Scaffold(
         key: scaffoldKey,
         scrollableKey: config.scrollableKey,
@@ -168,7 +168,7 @@ class _RecipeGridPageState extends State<RecipeGridPage> {
       settings: const RouteSettings(name: "/pesto/recipe"),
       builder: (BuildContext context) {
         return new Theme(
-          data: _kTheme,
+          data: _kTheme.copyWith(platform: Theme.of(context).platform),
           child: new RecipePage(recipe: recipe)
         );
       }

--- a/examples/flutter_gallery/lib/demo/shrine_demo.dart
+++ b/examples/flutter_gallery/lib/demo/shrine_demo.dart
@@ -10,11 +10,12 @@ import 'shrine/shrine_theme.dart' show ShrineTheme;
 // This code would ordinarily be part of the MaterialApp's home. It's being
 // used by the ShrineDemo and by each route pushed from there because this
 // isn't a standalone app with its own main() and MaterialApp.
-Widget buildShrine(Widget child) {
+Widget buildShrine(BuildContext context, Widget child) {
   return new Theme(
     data: new ThemeData(
       primarySwatch: Colors.grey,
-      iconTheme: new IconThemeData(color: const Color(0xFF707070))
+      iconTheme: new IconThemeData(color: const Color(0xFF707070)),
+      platform: Theme.of(context).platform,
     ),
     child: new ShrineTheme(child: child)
   );
@@ -29,7 +30,7 @@ class ShrinePageRoute<T> extends MaterialPageRoute<T> {
 
   @override
   Widget buildPage(BuildContext context, Animation<double> animation, Animation<double> forwardAnimation) {
-    return buildShrine(super.buildPage(context, animation, forwardAnimation));
+    return buildShrine(context, super.buildPage(context, animation, forwardAnimation));
   }
 }
 
@@ -37,5 +38,5 @@ class ShrineDemo extends StatelessWidget {
   static const String routeName = '/shrine'; // Used by the Gallery app.
 
   @override
-  Widget build(BuildContext context) => buildShrine(new ShrineHome());
+  Widget build(BuildContext context) => buildShrine(context, new ShrineHome());
 }


### PR DESCRIPTION
Since we can change the theme's platform, we need to make sure we
propagate that throughout rather than having half the app use the native
platform and half the app use the selected platform.
