### PR TITLE
Migrate HostMessages to PlatformMessages

### DIFF
--- a/packages/flutter/lib/src/services/host_messages.dart
+++ b/packages/flutter/lib/src/services/host_messages.dart
@@ -3,76 +3,25 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:convert';
 
-import 'package:mojo/core.dart' as core;
-import 'package:flutter_services/platform/app_messages.dart' as mojom;
-
-import 'shell.dart';
-
-mojom.ApplicationMessagesProxy _initHostAppMessagesProxy() {
-  return shell.connectToViewAssociatedService(mojom.ApplicationMessages.connectToService);
-}
-
-final mojom.ApplicationMessagesProxy _hostAppMessagesProxy = _initHostAppMessagesProxy();
-
-/// Signature for receiving [HostMessages].
-typedef Future<String> HostMessageCallback(String message);
-
-typedef Object _SendStringResponseFactory(String response);
-
-class _ApplicationMessagesImpl extends mojom.ApplicationMessages {
-  final Map<String, HostMessageCallback> handlers = <String, HostMessageCallback>{};
-
-  _ApplicationMessagesImpl() {
-    shell.provideService(mojom.ApplicationMessages.serviceName,
-      (core.MojoMessagePipeEndpoint endpoint) {
-        mojom.ApplicationMessagesStub stub = new mojom.ApplicationMessagesStub.fromEndpoint(endpoint);
-        stub.impl = this;
-      }
-    );
-  }
-
-  @override
-  dynamic sendString(String messageName, String message, [_SendStringResponseFactory responseFactory]) {
-    HostMessageCallback callback = handlers[messageName];
-    if (callback == null)
-      return responseFactory(null);
-
-    return callback(message).then((String s) => responseFactory(s));
-  }
-}
-
-final _ApplicationMessagesImpl _appMessages = new _ApplicationMessagesImpl();
+import 'platform_messages.dart';
 
 /// A service that can be implemented by the host application and the
 /// Flutter framework to exchange application-specific messages.
 class HostMessages {
   /// Send a message to the host application.
-  static Future<String> sendToHost(String messageName, [String message = '']) {
-    Completer<String> completer = new Completer<String>();
-    _hostAppMessagesProxy.sendString(messageName, message, (String reply) {
-      completer.complete(reply);
-    });
-    return completer.future;
-  }
-
-  static dynamic _decode(String message) {
-    return message != null ? JSON.decode(message) : null;
+  static Future<String> sendToHost(String channel, [String message = '']) {
+    return PlatformMessages.sendString(channel, message);
   }
 
   /// Sends a JSON-encoded message to the host application and JSON-decodes the response.
-  static Future<dynamic> sendJSON(String messageName, [dynamic json]) async {
-    Completer<dynamic> completer = new Completer<dynamic>();
-    _hostAppMessagesProxy.sendString(messageName, JSON.encode(json), (String reply) {
-      completer.complete(_decode(reply));
-    });
-    return completer.future;
+  static Future<dynamic> sendJSON(String channel, [dynamic json]) {
+    return PlatformMessages.sendJSON(channel, json);
   }
 
   /// Register a callback for receiving messages from the host application.
-  static void addMessageHandler(String messageName, HostMessageCallback callback) {
-    _appMessages.handlers[messageName] = callback;
+  static void addMessageHandler(String channel, Future<String> callback(String message)) {
+    PlatformMessages.setStringMessageHandler(channel, callback);
   }
 
   /// Register a callback for receiving JSON messages from the host application.
@@ -80,9 +29,7 @@ class HostMessages {
   /// Messages received from the host application are decoded as JSON before
   /// being passed to `callback`. The result of the callback is encoded as JSON
   /// before being returned to the host application.
-  static void addJSONMessageHandler(String messageName, Future<dynamic> callback(dynamic json)) {
-    _appMessages.handlers[messageName] = (String message) async {
-      return JSON.encode(await callback(_decode(message)));
-    };
+  static void addJSONMessageHandler(String channel, Future<dynamic> callback(dynamic json)) {
+    PlatformMessages.setJSONMessageHandler(channel, callback);
   }
 }

--- a/packages/flutter/lib/src/services/platform_messages.dart
+++ b/packages/flutter/lib/src/services/platform_messages.dart
@@ -32,6 +32,8 @@ typedef Future<ByteData> _PlatformMessageHandler(ByteData message);
 
 /// Sends message to and receives messages from the underlying platform.
 class PlatformMessages {
+  PlatformMessages._();
+
   /// Handlers for incoming platform messages.
   static final Map<String, _PlatformMessageHandler> _handlers =
       <String, _PlatformMessageHandler>{};
@@ -143,7 +145,7 @@ class PlatformMessages {
   /// To remove the mock handler, pass `null` as the `handler` argument.
   static void setMockBinaryMessageHandler(String channel, Future<ByteData> handler(ByteData message)) {
     if (handler == null)
-      _mockHandlers.remove(handler);
+      _mockHandlers.remove(channel);
     else
       _mockHandlers[channel] = handler;
   }


### PR DESCRIPTION
We'll eventually remove HostMessages because it's just a pass-through to
PlatformMessages, but that will be a separate step.
