### PR TITLE
Encode DevFS filenames so they are safe for http headers

### DIFF
--- a/packages/flutter_tools/lib/src/devfs.dart
+++ b/packages/flutter_tools/lib/src/devfs.dart
@@ -225,7 +225,8 @@ class _DevFSHttpWriter {
     HttpClientRequest request = await _client.putUrl(httpAddress);
     request.headers.removeAll(HttpHeaders.ACCEPT_ENCODING);
     request.headers.add('dev_fs_name', fsName);
-    request.headers.add('dev_fs_path', entry.devicePath);
+    request.headers.add('dev_fs_path_b64',
+                        BASE64.encode(UTF8.encode(entry.devicePath)));
     Stream<List<int>> contents = entry.contentsAsCompressedStream();
     await request.addStream(contents);
     HttpClientResponse response = await request.close();


### PR DESCRIPTION
Fixes #6133
