### PR TITLE
Remove default horizontal padding for Input.

### DIFF
--- a/examples/flutter_gallery/lib/demo/expansion_panels_demo.dart
+++ b/examples/flutter_gallery/lib/demo/expansion_panels_demo.dart
@@ -192,12 +192,15 @@ class _ExpansionPanelsDemoState extends State<ExpasionPanelsDemo> {
           return new CollapsibleBody(
             margin: const EdgeInsets.symmetric(horizontal: 16.0),
             child: new Form(
-              child: new Input(
-                hintText: item.hint,
-                labelText: item.name,
-                value: new InputValue(text: item.value),
-                formField: new FormField<String>(
-                  setter: (String val) { item.value = val; }
+              child: new Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 16.0),
+                child: new Input(
+                  hintText: item.hint,
+                  labelText: item.name,
+                  value: new InputValue(text: item.value),
+                  formField: new FormField<String>(
+                    setter: (String val) { item.value = val; }
+                  ),
                 ),
               ),
             ),

--- a/examples/flutter_gallery/lib/demo/text_field_demo.dart
+++ b/examples/flutter_gallery/lib/demo/text_field_demo.dart
@@ -74,7 +74,7 @@ class TextFieldDemoState extends State<TextFieldDemo> {
       ),
       body: new Form(
         child: new Block(
-          padding: const EdgeInsets.all(8.0),
+          padding: const EdgeInsets.symmetric(horizontal: 16.0),
           children: <Widget>[
             new Input(
               hintText: 'What do people call you?',
@@ -113,6 +113,7 @@ class TextFieldDemoState extends State<TextFieldDemo> {
                     )
                   )
                 ),
+                new SizedBox(width: 16.0),
                 new Flexible(
                   child: new Input(
                     hintText: 'How do you log in?',

--- a/packages/flutter/lib/src/material/input.dart
+++ b/packages/flutter/lib/src/material/input.dart
@@ -306,10 +306,7 @@ class _InputState extends State<Input> {
       child: new GestureDetector(
         behavior: HitTestBehavior.opaque,
         onTap: () => _rawInputKey.currentState?.requestKeyboard(),
-        child: new Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 16.0),
-          child: child
-        )
+        child: child
       )
     );
   }


### PR DESCRIPTION
This partially reverts https://github.com/flutter/flutter/issues/626 ,
but horizontal padding is not in the spec, so we still match the spec.
