### PR TITLE
Make Pageable itemCount public

### DIFF
--- a/packages/flutter/lib/src/widgets/pageable_list.dart
+++ b/packages/flutter/lib/src/widgets/pageable_list.dart
@@ -89,7 +89,8 @@ abstract class Pageable extends Scrollable {
   /// The animation curve to use when animating to a given page.
   final Curve curve;
 
-  int get _itemCount;
+  /// The number of items, one per page, to display.
+  int get itemCount;
 }
 
 /// A widget that pages through an iterable list of children.
@@ -142,7 +143,7 @@ class PageableList extends Pageable {
   final Iterable<Widget> children;
 
   @override
-  int get _itemCount => children?.length ?? 0;
+  int get itemCount => children?.length ?? 0;
 
   @override
   PageableListState<PageableList> createState() => new PageableListState<PageableList>();
@@ -175,7 +176,7 @@ class PageableLazyList extends Pageable {
     ValueChanged<int> onPageChanged,
     Duration duration: const Duration(milliseconds: 200),
     Curve curve: Curves.ease,
-    this.itemCount,
+    this.itemCount: 0,
     this.itemBuilder
   }) : super(
     key: key,
@@ -194,13 +195,11 @@ class PageableLazyList extends Pageable {
   );
 
   /// The total number of list items.
+  @override
   final int itemCount;
 
   /// A function that returns the pages themselves.
   final ItemListBuilder itemBuilder;
-
-  @override
-  int get _itemCount => itemCount ?? 0;
 
   @override
   _PageableLazyListState createState() => new _PageableLazyListState();
@@ -212,7 +211,7 @@ class PageableLazyList extends Pageable {
 ///
 /// Subclasses typically override [buildContent] to build viewports.
 abstract class PageableState<T extends Pageable> extends ScrollableState<T> {
-  int get _itemCount => config._itemCount;
+  int get _itemCount => config.itemCount;
   int _previousItemCount;
 
   double get _pixelsPerScrollUnit {

--- a/packages/flutter/lib/src/widgets/pageable_list.dart
+++ b/packages/flutter/lib/src/widgets/pageable_list.dart
@@ -214,7 +214,8 @@ abstract class PageableState<T extends Pageable> extends ScrollableState<T> {
   int get _itemCount => config.itemCount;
   int _previousItemCount;
 
-  double get _pixelsPerScrollUnit {
+  /// Convert from the item based scroll units to logical pixels.
+  double get pixelsPerScrollUnit {
     final RenderBox box = context.findRenderObject();
     if (box == null || !box.hasSize)
       return 0.0;
@@ -230,13 +231,13 @@ abstract class PageableState<T extends Pageable> extends ScrollableState<T> {
 
   @override
   double pixelOffsetToScrollOffset(double pixelOffset) {
-    final double pixelsPerScrollUnit = _pixelsPerScrollUnit;
-    return super.pixelOffsetToScrollOffset(pixelsPerScrollUnit == 0.0 ? 0.0 : pixelOffset / pixelsPerScrollUnit);
+    final double unit = pixelsPerScrollUnit;
+    return super.pixelOffsetToScrollOffset(unit == 0.0 ? 0.0 : pixelOffset / unit);
   }
 
   @override
   double scrollOffsetToPixelOffset(double scrollOffset) {
-    return super.scrollOffsetToPixelOffset(scrollOffset * _pixelsPerScrollUnit);
+    return super.scrollOffsetToPixelOffset(scrollOffset * pixelsPerScrollUnit);
   }
 
   int _scrollOffsetToPageIndex(double scrollOffset) {


### PR DESCRIPTION
PageableState depended on an abstract getter Pageable._itemCount. The fact that the method was private got in the way of creating pair of Pageable, PageableState subclasses outside of widgets pageable_list.dart.

Also exposing PageableState's pixelToScrollUnit getter. An override of this method makes it possible for the subclass to support items that effectively overlap.
