### PR TITLE
Scale card demo titles if they will not fit

### DIFF
--- a/examples/flutter_gallery/lib/demo/cards_demo.dart
+++ b/examples/flutter_gallery/lib/demo/cards_demo.dart
@@ -70,12 +70,15 @@ class TravelDestinationItem extends StatelessWidget {
                   new Positioned(
                     bottom: 16.0,
                     left: 16.0,
-                    child: new Text(destination.title,
-                      style: titleStyle,
-                      softWrap: false,
-                      overflow: TextOverflow.ellipsis
-                    )
-                  )
+                    right: 16.0,
+                    child: new FittedBox(
+                      fit: ImageFit.scaleDown,
+                      alignment: FractionalOffset.centerLeft,
+                      child: new Text(destination.title,
+                        style: titleStyle,
+                      ),
+                    ),
+                  ),
                 ]
               )
             ),


### PR DESCRIPTION
In this demo, if the title is just a little too wide, it's better to scale it to fit instead of displaying the ellipsis.

Note also: previously the demo hadn't been setting the right margin for card titles.

Fixes #6447
