### PR TITLE
Do not buffer logs in the verbose logger

### DIFF
--- a/packages/flutter_tools/lib/executable.dart
+++ b/packages/flutter_tools/lib/executable.dart
@@ -206,9 +206,6 @@ Future<Null> _exit(int code) async {
   // Run shutdown hooks before flushing logs
   await runShutdownHooks();
 
-  // Write any buffered output.
-  logger.flush();
-
   // Give the task / timer queue one cycle through before we hard exit.
   Timer.run(() {
     printTrace('exiting with code $code');

--- a/packages/flutter_tools/lib/src/devfs.dart
+++ b/packages/flutter_tools/lib/src/devfs.dart
@@ -420,9 +420,6 @@ class DevFS {
       await _operations.writeSource(fsName, '.packages', sb.toString());
 
     printTrace('DevFS: Sync finished');
-    // NB: You must call flush after a printTrace if you want to be printed
-    // immediately.
-    logger.flush();
   }
 
   void _scanFile(String devicePath, FileSystemEntity file) {

--- a/packages/flutter_tools/lib/src/runner/flutter_command_runner.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command_runner.dart
@@ -129,11 +129,7 @@ class FlutterCommandRunner extends CommandRunner {
     if (args.length == 1 && args.first == 'build')
       args = <String>['build', '-h'];
 
-    return super.run(args).then((dynamic result) {
-      return result;
-    }).whenComplete(() {
-      logger.flush();
-    });
+    return super.run(args);
   }
 
   @override


### PR DESCRIPTION
With the old policy the most recent log would not be printed until the next
log is produced (which may be indefinitely).  This change prints logs
immediately along with a time delta since the previous log.
