### PR TITLE
Bump up the timeout on port acquisition and forwarding to 60 seconds.

### DIFF
--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -295,7 +295,7 @@ class IOSDevice extends Device {
   }
 
   Future<int> _acquireAndForwardPort(String serviceName, int localPort) async {
-    Duration stepTimeout = const Duration(seconds: 10);
+    Duration stepTimeout = const Duration(seconds: 60);
 
     Future<int> remote = new ProtocolDiscovery(logReader, serviceName).nextPort();
 


### PR DESCRIPTION
It takes a little bit longer that 10 seconds to install, launch and
have the observatory be available on an iPod touch. Depending on the
size of the application, it could be a lot longer to transfer the
bundle over the wire. The 60 seconds is arbitrary.
