### PR TITLE
Increase timeout to discover Observatory's port on iOS.

### DIFF
--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -295,7 +295,7 @@ class IOSDevice extends Device {
   }
 
   Future<int> _acquireAndForwardPort(String serviceName, int localPort) async {
-    Duration stepTimeout = const Duration(seconds: 10);
+    Duration stepTimeout = const Duration(seconds: 30);
 
     Future<int> remote = new ProtocolDiscovery(logReader, serviceName).nextPort();
 


### PR DESCRIPTION
My iPod Touch was taking ~11 seconds to launch.
