### PR TITLE
Make `new Container()` more cooperative.

### DIFF
--- a/packages/flutter/test/widget/container_test.dart
+++ b/packages/flutter/test/widget/container_test.dart
@@ -1,0 +1,12 @@
+// Copyright 2015 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter/widgets.dart';
+
+void main() {
+  testWidgets('Can be placed in an infinite box', (WidgetTester tester) async {
+    await tester.pumpWidget(new Block(children: <Widget>[new Container()]));
+  });
+}


### PR DESCRIPTION
If a Container with no child is in an infinite space, make it shrink
instead of expanding. Still expand otherwise.
