### PR TITLE
drive: Support an environment-specified VM service URL

### DIFF
--- a/packages/flutter_driver/lib/src/driver.dart
+++ b/packages/flutter_driver/lib/src/driver.dart
@@ -73,9 +73,13 @@ class FlutterDriver {
   ///
   /// Resumes the application if it is currently paused (e.g. at a breakpoint).
   ///
-  /// [dartVmServiceUrl] is the URL to Dart observatory (a.k.a. VM service). By
-  /// default it connects to `http://localhost:8183`.
-  static Future<FlutterDriver> connect({String dartVmServiceUrl: 'http://localhost:8183'}) async {
+  /// [dartVmServiceUrl] is the URL to Dart observatory (a.k.a. VM service). If
+  /// not specified, the URL specified by the `VM_SERVICE_URL` environment
+  /// variable is used, or 'http://localhost:8183'.
+  static Future<FlutterDriver> connect({String dartVmServiceUrl}) async {
+    dartVmServiceUrl ??= Platform.environment['VM_SERVICE_URL'];
+    dartVmServiceUrl ??= 'http://localhost:8183';
+
     // Connect to Dart VM servcies
     _log.info('Connecting to Flutter application at $dartVmServiceUrl');
     VMServiceClientConnection connection = await vmServiceConnectFunction(dartVmServiceUrl);


### PR DESCRIPTION
If a URL is not explicitly specified by the test author, check for an
environment-specified URL before falling back to the default value.
