### PR TITLE
fix frame info extraction logic; track frames in gallery test

### DIFF
--- a/dev/devicelab/lib/tasks/gallery.dart
+++ b/dev/devicelab/lib/tasks/gallery.dart
@@ -52,11 +52,22 @@ class GalleryTransitionTest {
     Map<String, dynamic> original = JSON.decode(file(
             '${galleryDirectory.path}/build/transition_durations.timeline.json')
         .readAsStringSync());
-    Map<String, dynamic> clean = new Map<String, dynamic>.fromIterable(
+    Map<String, dynamic> transitions = new Map<String, dynamic>.fromIterable(
         original.keys,
         key: (String key) => key.replaceAll('/', ''),
         value: (String key) => original[key]);
 
-    return new TaskResult.success(clean);
+    Map<String, dynamic> summary = JSON.decode(file('${galleryDirectory.path}/build/transitions.timeline_summary.json').readAsStringSync());
+
+    Map<String, dynamic> data = <String, dynamic>{
+      'transitions': transitions,
+    };
+    data.addAll(summary);
+
+    return new TaskResult.success(data, benchmarkScoreKeys: <String>[
+      'average_frame_build_time_millis',
+      'worst_frame_build_time_millis',
+      'missed_frame_build_budget_count',
+    ]);
   }
 }

--- a/dev/devicelab/lib/tasks/perf_tests.dart
+++ b/dev/devicelab/lib/tasks/perf_tests.dart
@@ -108,6 +108,14 @@ class PerfTest {
         deviceId,
       ]);
       Map<String, dynamic> data = JSON.decode(file('$testDirectory/build/$timelineFileName.timeline_summary.json').readAsStringSync());
+
+      if (data['frame_count'] < 5) {
+        return new TaskResult.failure(
+          'Timeline contains too few frames: ${data['frame_count']}. Possibly '
+          'trace events are not being captured.',
+        );
+      }
+
       return new TaskResult.success(data, benchmarkScoreKeys: <String>[
         'average_frame_build_time_millis',
         'worst_frame_build_time_millis',

--- a/examples/flutter_gallery/test_driver/transitions_perf_test.dart
+++ b/examples/flutter_gallery/test_driver/transitions_perf_test.dart
@@ -138,6 +138,9 @@ void main() {
       // 'Start Transition' event when a demo is launched (see GalleryItem).
       saveDurationsHistogram(timeline.json['traceEvents']);
 
+      TimelineSummary summary = new TimelineSummary.summarize(timeline);
+      summary.writeSummaryToFile('transitions');
+
     }, timeout: new Timeout(new Duration(minutes: 5)));
   });
 }


### PR DESCRIPTION
The reason we started losing frame information was because the timeline event was renamed from "Engine::BeginFrame" to just "Frame" and changed type from "B"/"E" pairs to "X" duration events.

This PR also submits per-frame data for the transitions test (https://github.com/flutter/cocoon/issues/67).

Fixes https://github.com/flutter/cocoon/issues/67
Fixes https://github.com/flutter/flutter/issues/6406
Fixes https://github.com/flutter/cocoon/issues/66

/cc @HansMuller @Hixie 
