### PR TITLE
Avoid known wide gallery title issues

### DIFF
--- a/examples/flutter_gallery/lib/demo/grid_list_demo.dart
+++ b/examples/flutter_gallery/lib/demo/grid_list_demo.dart
@@ -37,6 +37,21 @@ class GridPhotoViewer extends StatefulWidget {
   _GridPhotoViewerState createState() => new _GridPhotoViewerState();
 }
 
+class _GridTitleText extends StatelessWidget {
+  _GridTitleText(this.text);
+
+  final String text;
+
+  @override
+  Widget build(BuildContext context) {
+    return new FittedBox(
+      fit: ImageFit.scaleDown,
+      alignment: FractionalOffset.centerLeft,
+      child: new Text(text),
+    );
+  }
+}
+
 class _GridPhotoViewerState extends State<GridPhotoViewer> with SingleTickerProviderStateMixin {
   AnimationController _controller;
   Animation<Offset> _flingAnimation;
@@ -180,7 +195,7 @@ class GridDemoPhotoItem extends StatelessWidget {
           header: new GestureDetector(
             onTap: () { onBannerTap(photo); },
             child: new GridTileBar(
-              title: new Text(photo.title),
+              title: new _GridTitleText(photo.title),
               backgroundColor: Colors.black45,
               leading: new Icon(
                 icon,
@@ -197,8 +212,8 @@ class GridDemoPhotoItem extends StatelessWidget {
             onTap: () { onBannerTap(photo); },
             child: new GridTileBar(
               backgroundColor: Colors.black45,
-              title: new Text(photo.title),
-              subtitle: new Text(photo.caption),
+              title: new _GridTitleText(photo.title),
+              subtitle: new _GridTitleText(photo.caption),
               trailing: new Icon(
                 icon,
                 color: Colors.white

--- a/examples/flutter_gallery/lib/demo/leave_behind_demo.dart
+++ b/examples/flutter_gallery/lib/demo/leave_behind_demo.dart
@@ -134,7 +134,7 @@ class LeaveBehindDemoState extends State<LeaveBehindDemo> {
       key: _scaffoldKey,
       scrollableKey: _scrollableKey,
       appBar: new AppBar(
-        title: new Text('Swipe items to dismiss'),
+        title: new Text('Swipe to dismiss'),
         actions: <Widget>[
           new PopupMenuButton<LeaveBehindDemoAction>(
             onSelected: handleDemoAction,


### PR DESCRIPTION
The text wrapping problems reported in #6448 #6450 still need to be fixed. However in those cases the titles were intended to fit on a single line. We don't really want an ellipsis to show up. Use FittedBox to avoid the known problems.
