### PR TITLE
flutter devices/doctor report Android (and iOS) version

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_device.dart
+++ b/packages/flutter_tools/lib/src/android/android_device.dart
@@ -115,6 +115,13 @@ class AndroidDevice extends Device {
     return _platform;
   }
 
+  @override
+  String get sdkNameAndVersion => 'Android $_sdkVersion (API $_apiVersion)';
+
+  String get _sdkVersion => _getProperty('ro.build.version.release');
+
+  String get _apiVersion => _getProperty('ro.build.version.sdk');
+
   _AdbLogReader _logReader;
   _AndroidDevicePortForwarder _portForwarder;
 

--- a/packages/flutter_tools/lib/src/device.dart
+++ b/packages/flutter_tools/lib/src/device.dart
@@ -239,24 +239,35 @@ abstract class Device {
   String toString() => name;
 
   static Iterable<String> descriptions(List<Device> devices) {
-    int nameWidth = 0;
-    int idWidth = 0;
+    if (devices.isEmpty)
+      return <String>[];
 
+    // Extract device information
+    List<List<String>> table = <List<String>>[];
     for (Device device in devices) {
-      nameWidth = math.max(nameWidth, device.name.length);
-      idWidth = math.max(idWidth, device.id.length);
-    }
-
-    return devices.map((Device device) {
       String supportIndicator = device.isSupported() ? '' : ' (unsupported)';
       if (device.isLocalEmulator) {
         String type = device.platform == TargetPlatform.ios ? 'simulator' : 'emulator';
         supportIndicator += ' ($type)';
       }
-      return '${device.name.padRight(nameWidth)} • '
-             '${device.id.padRight(idWidth)} • '
-             '${getNameForTargetPlatform(device.platform)}$supportIndicator';
-    });
+      table.add(<String>[
+        device.name,
+        device.id,
+        '${getNameForTargetPlatform(device.platform)}$supportIndicator',
+      ]);
+    }
+
+    // Calculate column widths
+    List<int> indices = new List.generate(table[0].length - 1, (int i) => i);
+    List<int> widths = indices.map((int i) => 0).toList();
+    for (List<String> row in table) {
+      widths = indices.map((int i) => math.max(widths[i], row[i].length)).toList();
+    }
+
+    // Join columns into lines of text
+    return table.map((List<String> row) =>
+        indices.map((int i) => row[i].padRight(widths[i])).join(' • ') +
+        ' • ${row.last}');
   }
 
   static void printDevices(List<Device> devices) {

--- a/packages/flutter_tools/lib/src/device.dart
+++ b/packages/flutter_tools/lib/src/device.dart
@@ -163,6 +163,8 @@ abstract class Device {
 
   TargetPlatform get platform;
 
+  String get sdkNameAndVersion;
+
   /// Get the log reader for this device.
   DeviceLogReader get logReader;
 
@@ -253,12 +255,13 @@ abstract class Device {
       table.add(<String>[
         device.name,
         device.id,
-        '${getNameForTargetPlatform(device.platform)}$supportIndicator',
+        '${getNameForTargetPlatform(device.platform)}',
+        '${device.sdkNameAndVersion}$supportIndicator',
       ]);
     }
 
     // Calculate column widths
-    List<int> indices = new List.generate(table[0].length - 1, (int i) => i);
+    List<int> indices = new List<int>.generate(table[0].length - 1, (int i) => i);
     List<int> widths = indices.map((int i) => 0).toList();
     for (List<String> row in table) {
       widths = indices.map((int i) => math.max(widths[i], row[i].length)).toList();

--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -89,7 +89,7 @@ class IOSDevice extends Device {
 
     List<IOSDevice> devices = <IOSDevice>[];
     for (String id in _getAttachedDeviceIDs(mockIOS)) {
-      String name = _getDeviceName(id, mockIOS);
+      String name = IOSDevice._getDeviceInfo(id, 'DeviceName', mockIOS);
       devices.add(new IOSDevice(id, name: name));
     }
     return devices;
@@ -105,11 +105,11 @@ class IOSDevice extends Device {
     }
   }
 
-  static String _getDeviceName(String deviceID, [IOSDevice mockIOS]) {
+  static String _getDeviceInfo(String deviceID, String infoKey, [IOSDevice mockIOS]) {
     String informerPath = (mockIOS != null)
         ? mockIOS.informerPath
         : _checkForCommand('ideviceinfo');
-    return runSync(<String>[informerPath, '-k', 'DeviceName', '-u', deviceID]).trim();
+    return runSync(<String>[informerPath, '-k', infoKey, '-u', deviceID]).trim();
   }
 
   static final Map<String, String> _commandMap = <String, String>{};
@@ -368,6 +368,13 @@ class IOSDevice extends Device {
 
   @override
   TargetPlatform get platform => TargetPlatform.ios;
+
+  @override
+  String get sdkNameAndVersion => 'iOS $_sdkVersion ($_buildVersion)';
+
+  String get _sdkVersion => _getDeviceInfo(id, 'ProductVersion');
+
+  String get _buildVersion => _getDeviceInfo(id, 'BuildVersion');
 
   @override
   DeviceLogReader get logReader {

--- a/packages/flutter_tools/lib/src/ios/simulators.dart
+++ b/packages/flutter_tools/lib/src/ios/simulators.dart
@@ -46,7 +46,7 @@ class IOSSimulatorUtils {
       return <IOSSimulator>[];
 
     return SimControl.instance.getConnectedDevices().map((SimDevice device) {
-      return new IOSSimulator(device.udid, name: device.name);
+      return new IOSSimulator(device.udid, name: device.name, category: device.category);
     }).toList();
   }
 }
@@ -302,10 +302,12 @@ class SimDevice {
 }
 
 class IOSSimulator extends Device {
-  IOSSimulator(String id, { this.name }) : super(id);
+  IOSSimulator(String id, { this.name, this.category }) : super(id);
 
   @override
   final String name;
+
+  final String category;
 
   @override
   bool get isLocalEmulator => true;
@@ -556,6 +558,9 @@ class IOSSimulator extends Device {
 
   @override
   TargetPlatform get platform => TargetPlatform.ios;
+
+  @override
+  String get sdkNameAndVersion => category;
 
   @override
   DeviceLogReader get logReader {


### PR DESCRIPTION
This updates the `flutter devices` and `flutter doctor` commands to include the Android and iOS version information.
Sample output:

```
$ flutter devices
3 connected devices:

Nexus 5X       • 00f4f73e1f8b3daa                         • android-arm • Android 7.0 (API 24)
New iPod touch • 82564b38861a9a5ac42de313e5a18f2e11d299f8 • ios         • iOS 10.0.2 (14A456)
iPhone SE      • 0B466210-6B90-4260-964A-F066B4294BF2     • ios         • iOS 10.0 (simulator)
```

Fixes https://github.com/flutter/flutter/issues/6369
@Hixie @devoncarew 
