### PR TITLE
add an intellij module for the dev/devicelab package

### DIFF
--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -2,6 +2,7 @@
 <project version="4">
   <component name="ProjectModuleManager">
     <modules>
+      <module fileurl="file://$PROJECT_DIR$/dev/devicelab/devicelab.iml" filepath="$PROJECT_DIR$/dev/devicelab/devicelab.iml" />
       <module fileurl="file://$PROJECT_DIR$/packages/flutter/flutter.iml" filepath="$PROJECT_DIR$/packages/flutter/flutter.iml" />
       <module fileurl="file://$PROJECT_DIR$/packages/flutter_driver/flutter_driver.iml" filepath="$PROJECT_DIR$/packages/flutter_driver/flutter_driver.iml" />
       <module fileurl="file://$PROJECT_DIR$/examples/flutter_gallery/flutter_gallery.iml" filepath="$PROJECT_DIR$/examples/flutter_gallery/flutter_gallery.iml" />

--- a/dev/devicelab/devicelab.iml
+++ b/dev/devicelab/devicelab.iml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="WEB_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$">
+      <excludeFolder url="file://$MODULE_DIR$/bin/packages" />
+      <excludeFolder url="file://$MODULE_DIR$/packages" />
+      <excludeFolder url="file://$MODULE_DIR$/test/packages" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="library" name="Dart SDK" level="application" />
+    <orderEntry type="library" name="Dart Packages" level="project" />
+  </component>
+</module>


### PR DESCRIPTION
Related to https://github.com/flutter/flutter-intellij/issues/373, add an IntelliJ module for the dev/devicelab package.

@yjbanov 
