### PR TITLE
flutter doctor - display ANDROID_HOME

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_sdk.dart
+++ b/packages/flutter_tools/lib/src/android/android_sdk.dart
@@ -11,6 +11,8 @@ import '../base/common.dart';
 import '../base/os.dart';
 import '../globals.dart';
 
+const String kAndroidHome = 'ANDROID_HOME';
+
 // Android SDK layout:
 
 // $ANDROID_HOME/platform-tools/adb
@@ -58,8 +60,8 @@ class AndroidSdk {
 
   static AndroidSdk locateAndroidSdk() {
     String androidHomeDir;
-    if (Platform.environment.containsKey('ANDROID_HOME')) {
-      androidHomeDir = Platform.environment['ANDROID_HOME'];
+    if (Platform.environment.containsKey(kAndroidHome)) {
+      androidHomeDir = Platform.environment[kAndroidHome];
     } else if (Platform.isLinux) {
       if (homeDirPath != null)
         androidHomeDir = '$homeDirPath/Android/Sdk';

--- a/packages/flutter_tools/lib/src/android/android_workflow.dart
+++ b/packages/flutter_tools/lib/src/android/android_workflow.dart
@@ -29,10 +29,18 @@ class AndroidWorkflow extends DoctorValidator implements Workflow {
     String sdkVersionText;
 
     if (androidSdk == null) {
-      messages.add(new ValidationMessage.error(
-        'Android Studio / Android SDK not found. Download from https://developer.android.com/sdk/\n'
-        '(or visit https://flutter.io/setup/#android-setup for detailed instructions).'
-      ));
+      if (Platform.environment.containsKey(kAndroidHome)) {
+        String androidHomeDir = Platform.environment[kAndroidHome];
+        messages.add(new ValidationMessage.error(
+          '$kAndroidHome = $androidHomeDir\n'
+          'but Android Studio / Android SDK not found at this location.'
+        ));
+      } else {
+        messages.add(new ValidationMessage.error(
+          'Android Studio / Android SDK not found. Download from https://developer.android.com/sdk/\n'
+          '(or visit https://flutter.io/setup/#android-setup for detailed instructions).'
+        ));
+      }
     } else {
       type = ValidationType.partial;
 
@@ -45,6 +53,11 @@ class AndroidWorkflow extends DoctorValidator implements Workflow {
           'Platform ${androidSdk.latestVersion.platformVersionName}, '
           'build-tools ${androidSdk.latestVersion.buildToolsVersionName}'
         ));
+      }
+
+      if (Platform.environment.containsKey(kAndroidHome)) {
+        String androidHomeDir = Platform.environment[kAndroidHome];
+        messages.add(new ValidationMessage('$kAndroidHome = $androidHomeDir'));
       }
 
       List<String> validationResult = androidSdk.validateSdkWellFormed();


### PR DESCRIPTION
If `ANDROID_HOME` is set, then `flutter doctor` will display it's value.

If it points to an invalid location, then you'll see something like this...

```
[x] Android toolchain - develop for Android devices
    x ANDROID_HOME = foo
      but Android Studio / Android SDK not found at this location.
```

If it points to a valid location, then you'll see something like this...

```
[✓] Android toolchain - develop for Android devices (Android SDK 24.0.3)
    • Android SDK at /path/to/my/Android/sdk
    • Platform android-24, build-tools 24.0.3
    • ANDROID_HOME = /path/to/my/Android/sdk
    • Java(TM) SE Runtime Environment (build 1.8.0_102-b14)
```

Fixes https://github.com/flutter/flutter/issues/6516
@pq 
