### PR TITLE
cleanup test logger usage

### DIFF
--- a/packages/flutter_tools/test/android_device_test.dart
+++ b/packages/flutter_tools/test/android_device_test.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import 'package:flutter_tools/src/android/android_device.dart';
-import 'package:flutter_tools/src/base/logger.dart';
 import 'package:test/test.dart';
 
 import 'src/context.dart';
@@ -49,7 +48,6 @@ ZX1G22JJWR             device usb:3-3 product:shamu model:Nexus_6 device:shamu f
       expect(devices.first.name, 'Nexus 6');
     });
 
-    BufferLogger logger = new BufferLogger();
     testUsingContext('adb error message', () {
       List<AndroidDevice> devices = getAdbDevices(mockAdbOutput: '''
 It appears you do not have 'Android SDK Platform-tools' installed.
@@ -57,9 +55,7 @@ Use the 'android' tool to install them:
     android update sdk --no-ui --filter 'platform-tools'
 ''');
       expect(devices, hasLength(0));
-      expect(logger.errorText, contains('you do not have'));
-    }, overrides: <Type, dynamic>{
-      Logger : logger,
+      expect(testLogger.errorText, contains('you do not have'));
     });
   });
 

--- a/packages/flutter_tools/test/create_test.dart
+++ b/packages/flutter_tools/test/create_test.dart
@@ -7,7 +7,6 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:args/command_runner.dart';
-import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/commands/create.dart';
 import 'package:flutter_tools/src/dart/sdk.dart';
@@ -84,7 +83,6 @@ void main() {
     });
 
     // Verify that we help the user correct an option ordering issue
-    BufferLogger logger = new BufferLogger();
     testUsingContext('produces sensible error message', () async {
       Cache.flutterRoot = '../..';
 
@@ -93,9 +91,7 @@ void main() {
 
       int code = await runner.run(<String>['create', temp.path, '--pub']);
       expect(code, 2);
-      expect(logger.errorText, contains('Try moving --pub'));
-    }, overrides:  <Type, dynamic>{
-      Logger: logger,
+      expect(testLogger.errorText, contains('Try moving --pub'));
     });
 
     // Verify that we fail with an error code when the file exists.


### PR DESCRIPTION
This replaces unnecessary creation of `BufferLogger` during tests with `testLogger`.
Fixes https://github.com/flutter/flutter/pull/6521
@devoncarew 
