### PR TITLE
Simplify and test TransitionRoute.completed

### DIFF
--- a/packages/flutter/lib/src/widgets/routes.dart
+++ b/packages/flutter/lib/src/widgets/routes.dart
@@ -74,24 +74,14 @@ abstract class OverlayRoute<T> extends Route<T> {
 
 /// A route with entrance and exit transitions.
 abstract class TransitionRoute<T> extends OverlayRoute<T> {
-  /// Creates a route with entrance and exit transitions.
-  TransitionRoute({
-    Completer<T> transitionCompleter
-  }) : _transitionCompleter = transitionCompleter;
-
-  /// The same as the default constructor but callable with mixins.
-  TransitionRoute.explicit(
-    Completer<T> transitionCompleter
-  ) : this(transitionCompleter: transitionCompleter);
-
   /// This future completes only once the transition itself has finished, after
   /// the overlay entries have been removed from the navigator's overlay.
   ///
   /// This future completes once the animation has been dismissed. That will be
   /// after [popped], because [popped] completes before the animation even
   /// starts, as soon as the route is popped.
-  Future<T> get completed => _transitionCompleter?.future;
-  final Completer<T> _transitionCompleter;
+  Future<T> get completed => _transitionCompleter.future;
+  final Completer<T> _transitionCompleter = new Completer<T>();
 
   /// The duration the transition lasts.
   Duration get transitionDuration;
@@ -252,7 +242,7 @@ abstract class TransitionRoute<T> extends OverlayRoute<T> {
   @override
   void finished() {
     super.finished();
-    _transitionCompleter?.complete(_result);
+    _transitionCompleter.complete(_result);
   }
 
   @override
@@ -456,7 +446,7 @@ abstract class ModalRoute<T> extends TransitionRoute<T> with LocalHistoryRoute<T
   /// Creates a route that blocks interaction with previous routes.
   ModalRoute({
     this.settings: const RouteSettings()
-  }) : super.explicit(null);
+  });
 
   // The API for general users of this class
 

--- a/packages/flutter/test/widget/page_transitions_test.dart
+++ b/packages/flutter/test/widget/page_transitions_test.dart
@@ -406,4 +406,81 @@ void main() {
     // Sheet called setState and didn't crash.
     expect(sheet.setStateCalled, isTrue);
   });
+
+  testWidgets('Test completed future', (WidgetTester tester) async {
+    final Map<String, WidgetBuilder> routes = <String, WidgetBuilder>{
+      '/': (_) => new Center(child: new Text('home')),
+      '/next': (_) => new Center(child: new Text('next')),
+    };
+
+    await tester.pumpWidget(new MaterialApp(routes: routes));
+
+    PageRoute<Null> route = new MaterialPageRoute<Null>(
+      settings: new RouteSettings(name: '/page'),
+      builder: (BuildContext context) => new Center(child: new Text('page')),
+    );
+
+    int popCount = 0;
+    route.popped.then((_) {
+      ++popCount;
+    });
+
+    int completeCount = 0;
+    route.completed.then((_) {
+      ++completeCount;
+    });
+
+    expect(popCount, 0);
+    expect(completeCount, 0);
+
+    Navigator.push(tester.element(find.text('home')), route);
+
+    expect(popCount, 0);
+    expect(completeCount, 0);
+
+    await tester.pump();
+
+    expect(popCount, 0);
+    expect(completeCount, 0);
+
+    await tester.pump(const Duration(milliseconds: 100));
+
+    expect(popCount, 0);
+    expect(completeCount, 0);
+
+    await tester.pump(const Duration(milliseconds: 100));
+
+    expect(popCount, 0);
+    expect(completeCount, 0);
+
+    await tester.pump(const Duration(seconds: 1));
+
+    expect(popCount, 0);
+    expect(completeCount, 0);
+
+    Navigator.pop(tester.element(find.text('page')));
+
+    expect(popCount, 0);
+    expect(completeCount, 0);
+
+    await tester.pump();
+
+    expect(popCount, 1);
+    expect(completeCount, 0);
+
+    await tester.pump(const Duration(milliseconds: 100));
+
+    expect(popCount, 1);
+    expect(completeCount, 0);
+
+    await tester.pump(const Duration(milliseconds: 100));
+
+    expect(popCount, 1);
+    expect(completeCount, 0);
+
+    await tester.pump(const Duration(seconds: 1));
+
+    expect(popCount, 1);
+    expect(completeCount, 1);
+  });
 }


### PR DESCRIPTION
We now create the Completer inside TransitionRoute, as with the popped
completer. Also, test that this future resolves at the appropriate time.