### PR TITLE
Manually filter old android device log messages instead of relying on the '-T' option

### DIFF
--- a/packages/flutter_tools/lib/src/hot.dart
+++ b/packages/flutter_tools/lib/src/hot.dart
@@ -249,7 +249,13 @@ class HotRunner extends ResidentRunner {
     }
 
     _observatoryPort = result.observatoryPort;
-    await connectToServiceProtocol(_observatoryPort);
+    try {
+      await connectToServiceProtocol(_observatoryPort);
+    } catch (error) {
+      printError('Error connecting to the service protocol: $error');
+      return 2;
+    }
+
 
     try {
       Uri baseUri = await _initDevFS();


### PR DESCRIPTION
Fixes Galaxy Note 5 (https://github.com/flutter/flutter/issues/6280)