### PR TITLE
Size of a childless container's implicit DecoratedBox descendants

### DIFF
--- a/packages/flutter/lib/src/widgets/container.dart
+++ b/packages/flutter/lib/src/widgets/container.dart
@@ -166,12 +166,14 @@ class Container extends StatelessWidget {
       );
     }
 
-    if (alignment != null)
-      current = new Align(alignment: alignment, child: current);
-
     EdgeInsets effectivePadding = _paddingIncludingDecoration;
     if (effectivePadding != null)
       current = new Padding(padding: effectivePadding, child: current);
+
+    // If a child was specified then align it - but not the implicit
+    // DecoratedBox descendants - within this container.
+    if (alignment != null && child != null)
+      current = new Align(alignment: alignment, child: current);
 
     if (decoration != null)
       current = new DecoratedBox(decoration: decoration, child: current);
@@ -192,6 +194,11 @@ class Container extends StatelessWidget {
 
     if (transform != null)
       current = new Transform(transform: transform, child: current);
+
+    // If no child was specified then align the implicit DecoratedBox
+    // descendants, if any.
+    if (alignment != null && child == null)
+      current = new Align(alignment: alignment, child: current);
 
     return current;
   }

--- a/packages/flutter/test/widget/container_test.dart
+++ b/packages/flutter/test/widget/container_test.dart
@@ -11,12 +11,11 @@ void main() {
   });
 
   testWidgets('Size of a container within an align', (WidgetTester tester) async {
-    GlobalKey innerContainerKey = new GlobalKey(debugLabel: "50x100");
+    GlobalKey innerContainerKey = new GlobalKey();
 
     await tester.pumpWidget(
       new Center(
         child: new SizedBox(
-          key: new ValueKey("300x400"),
           width: 300.0,
           height: 400.0,
           child: new Align(
@@ -126,7 +125,7 @@ void main() {
     RenderBox containerBox = innerContainerKey.currentContext.findRenderObject();
     List<RenderObject> renderers = tester.renderObjectList(find.byType(DecoratedBox)).toList();
     expect(renderers.length, equals(2));
-    for (var renderer in renderers) {
+    for (RenderObject renderer in renderers) {
       RenderBox decoratedBox = renderer;
       expect(decoratedBox.size.width, equals(50.0));
       expect(decoratedBox.size.height, equals(100.0));
@@ -165,7 +164,7 @@ void main() {
     RenderBox containerBox = innerContainerKey.currentContext.findRenderObject();
     List<RenderObject> renderers = tester.renderObjectList(find.byType(DecoratedBox)).toList();
     expect(renderers.length, equals(2));
-    for (var renderer in renderers) {
+    for (RenderObject renderer in renderers) {
       RenderBox decoratedBox = renderer;
       expect(decoratedBox.size.width, equals(50.0));
       expect(decoratedBox.size.height, equals(100.0));

--- a/packages/flutter/test/widget/container_test.dart
+++ b/packages/flutter/test/widget/container_test.dart
@@ -9,4 +9,171 @@ void main() {
   testWidgets('Can be placed in an infinite box', (WidgetTester tester) async {
     await tester.pumpWidget(new Block(children: <Widget>[new Container()]));
   });
+
+  testWidgets('Size of a container within an align', (WidgetTester tester) async {
+    GlobalKey innerContainerKey = new GlobalKey(debugLabel: "50x100");
+
+    await tester.pumpWidget(
+      new Center(
+        child: new SizedBox(
+          key: new ValueKey("300x400"),
+          width: 300.0,
+          height: 400.0,
+          child: new Align(
+            alignment:FractionalOffset.topLeft,
+            child: new Container(
+              key: innerContainerKey,
+              width: 50.0,
+              height: 100.0,
+            ),
+          ),
+        ),
+      ),
+    );
+
+    final Size size = innerContainerKey.currentContext.size;
+    expect(size.width, equals(50.0));
+    expect(size.height, equals(100.0));
+  });
+
+  testWidgets('Size of an aligned container\'s implicit child', (WidgetTester tester) async {
+    GlobalKey innerContainerKey = new GlobalKey();
+
+    await tester.pumpWidget(
+      new Center(
+        child: new SizedBox(
+          width: 300.0,
+          height: 400.0,
+          child: new Container(
+            key: innerContainerKey,
+            width: 50.0,
+            height: 100.0,
+            alignment:FractionalOffset.topLeft,
+            decoration: new BoxDecoration(backgroundColor: const Color(0xFF00FF00)),
+          ),
+        ),
+      ),
+    );
+
+    final Size size = innerContainerKey.currentContext.size;
+    expect(size.width, equals(300.0));
+    expect(size.height, equals(400.0));
+
+    RenderBox box = tester.renderObject(find.byType(DecoratedBox));
+    expect(box.size.width, equals(50.0));
+    expect(box.size.height, equals(100.0));
+  });
+
+  testWidgets('Position of an aligned and transformed container\'s implicit child', (WidgetTester tester) async {
+    GlobalKey innerContainerKey = new GlobalKey();
+
+    await tester.pumpWidget(
+      new Center(
+        child: new SizedBox(
+          width: 300.0,
+          height: 400.0,
+          child: new Container(
+            key: innerContainerKey,
+            width: 50.0,
+            height: 100.0,
+            alignment:FractionalOffset.topLeft,
+            decoration: new BoxDecoration(backgroundColor: const Color(0xFF00FF00)),
+            transform: new Matrix4.identity()..translate(100.0, 200.0),
+          ),
+        ),
+      ),
+    );
+
+    final Size size = innerContainerKey.currentContext.size;
+    expect(size.width, equals(300.0));
+    expect(size.height, equals(400.0));
+
+    RenderBox decoratedBox = tester.renderObject(find.byType(DecoratedBox));
+    expect(decoratedBox.size.width, equals(50.0));
+    expect(decoratedBox.size.height, equals(100.0));
+
+    RenderBox containerBox = innerContainerKey.currentContext.findRenderObject();
+    Point decoratedBoxOrigin = containerBox.globalToLocal(decoratedBox.localToGlobal(Point.origin));
+    expect(decoratedBoxOrigin.x, equals(100.0));
+    expect(decoratedBoxOrigin.y, equals(200.0));
+  });
+
+  testWidgets('Position of an aligned and transformed container\'s implicit children', (WidgetTester tester) async {
+    GlobalKey innerContainerKey = new GlobalKey();
+
+    await tester.pumpWidget(
+      new Center(
+        child: new SizedBox(
+          width: 300.0,
+          height: 400.0,
+          child: new Container(
+            key: innerContainerKey,
+            width: 50.0,
+            height: 100.0,
+            alignment:FractionalOffset.topLeft,
+            decoration: new BoxDecoration(backgroundColor: const Color(0xFF00FF00)),
+            foregroundDecoration: new BoxDecoration(backgroundColor: const Color(0xFFFF0000)),
+            transform: new Matrix4.identity()..translate(100.0, 200.0),
+          ),
+        ),
+      ),
+    );
+
+    final Size size = innerContainerKey.currentContext.size;
+    expect(size.width, equals(300.0));
+    expect(size.height, equals(400.0));
+
+    RenderBox containerBox = innerContainerKey.currentContext.findRenderObject();
+    List<RenderObject> renderers = tester.renderObjectList(find.byType(DecoratedBox)).toList();
+    expect(renderers.length, equals(2));
+    for (var renderer in renderers) {
+      RenderBox decoratedBox = renderer;
+      expect(decoratedBox.size.width, equals(50.0));
+      expect(decoratedBox.size.height, equals(100.0));
+
+      Point decoratedBoxOrigin = containerBox.globalToLocal(decoratedBox.localToGlobal(Point.origin));
+      expect(decoratedBoxOrigin.x, equals(100.0));
+      expect(decoratedBoxOrigin.y, equals(200.0));
+    }
+  });
+
+  testWidgets('Position of an aligned container\'s implicit children with margins', (WidgetTester tester) async {
+    GlobalKey innerContainerKey = new GlobalKey();
+
+    await tester.pumpWidget(
+      new Center(
+        child: new SizedBox(
+          width: 300.0,
+          height: 400.0,
+          child: new Container(
+            key: innerContainerKey,
+            width: 50.0,
+            height: 100.0,
+            alignment:FractionalOffset.topLeft,
+            decoration: new BoxDecoration(backgroundColor: const Color(0xFF00FF00)),
+            foregroundDecoration: new BoxDecoration(backgroundColor: const Color(0xFFFF0000)),
+            margin: const EdgeInsets.only(left: 25.0, top: 75.0),
+          ),
+        ),
+      ),
+    );
+
+    final Size size = innerContainerKey.currentContext.size;
+    expect(size.width, equals(300.0));
+    expect(size.height, equals(400.0));
+
+    RenderBox containerBox = innerContainerKey.currentContext.findRenderObject();
+    List<RenderObject> renderers = tester.renderObjectList(find.byType(DecoratedBox)).toList();
+    expect(renderers.length, equals(2));
+    for (var renderer in renderers) {
+      RenderBox decoratedBox = renderer;
+      expect(decoratedBox.size.width, equals(50.0));
+      expect(decoratedBox.size.height, equals(100.0));
+
+      Point decoratedBoxOrigin = containerBox.globalToLocal(decoratedBox.localToGlobal(Point.origin));
+      expect(decoratedBoxOrigin.x, equals(25.0));
+      expect(decoratedBoxOrigin.y, equals(75.0));
+    }
+  });
+
 }


### PR DESCRIPTION
If a container doesn't specify a child then its alignment should define the size of its implicit DecoratedBox children, if any.

Fixes #6608