### PR TITLE
Only synchronize used Dart sources to DevFS.

### DIFF
--- a/packages/flutter_tools/lib/src/base/process.dart
+++ b/packages/flutter_tools/lib/src/base/process.dart
@@ -164,6 +164,16 @@ String runCheckedSync(List<String> cmd, {
   );
 }
 
+/// Run cmd and return stdout on success.
+///
+/// Throws the standard error output if cmd exits with a non-zero value.
+String runSyncAndThrowStdErrOnError(List<String> cmd) {
+  return _runWithLoggingSync(cmd,
+                             checked: true,
+                             throwStandardErrorOnError: true,
+                             hideStdout: true);
+}
+
 /// Run cmd and return stdout.
 String runSync(List<String> cmd, {
   String workingDirectory,
@@ -187,6 +197,7 @@ void _traceCommand(List<String> args, { String workingDirectory }) {
 String _runWithLoggingSync(List<String> cmd, {
   bool checked: false,
   bool noisyErrors: false,
+  bool throwStandardErrorOnError: false,
   String workingDirectory,
   bool allowReentrantFlutter: false,
   bool hideStdout: false,
@@ -215,6 +226,9 @@ String _runWithLoggingSync(List<String> cmd, {
       else
         printTrace(results.stderr.trim());
     }
+
+    if (throwStandardErrorOnError)
+      throw results.stderr.trim();
 
     if (checked)
       throw 'Exit code ${results.exitCode} from: ${cmd.join(' ')}';


### PR DESCRIPTION
- [x] Remove the second full-sync on startup.
- [x] Always invoke the snapshotter to determine the minimal set of Dart sources used.
- [x] Only synchronize the *used* Dart sources to DevFS.
- [x] Detect syntax / file missing errors on the host and gate reloads / restarts.