### PR TITLE
refactor app.* daemon events

### DIFF
--- a/packages/flutter_tools/lib/src/commands/daemon.dart
+++ b/packages/flutter_tools/lib/src/commands/daemon.dart
@@ -344,7 +344,7 @@ class AppDomain extends Domain {
 
     AppInstance app = new AppInstance(_getNewAppId(), runner);
     _apps.add(app);
-    _sendAppEvent(app, 'starting', <String, dynamic>{
+    _sendAppEvent(app, 'start', <String, dynamic>{
       'deviceId': device.id,
       'directory': projectDirectory,
       'supportsRestart': isRestartSupported(enableHotReload, device)
@@ -373,9 +373,9 @@ class AppDomain extends Domain {
           appStartedCompleter: appStartedCompleter,
           route: route,
         );
-        _sendAppEvent(app, 'stopped');
+        _sendAppEvent(app, 'stop');
       } catch (error) {
-        _sendAppEvent(app, 'stopped', <String, dynamic>{'error': error.toString()});
+        _sendAppEvent(app, 'stop', <String, dynamic>{'error': error.toString()});
       } finally {
         Directory.current = cwd;
         _apps.remove(app);

--- a/packages/flutter_tools/lib/src/hot.dart
+++ b/packages/flutter_tools/lib/src/hot.dart
@@ -144,6 +144,7 @@ class HotRunner extends ResidentRunner {
   @override
   Future<int> run({
     Completer<DebugConnectionInfo> connectionInfoCompleter,
+    Completer<Null> appStartedCompleter,
     String route,
     bool shouldBuild: true
   }) {
@@ -151,6 +152,7 @@ class HotRunner extends ResidentRunner {
     return Chain.capture(() {
       return _run(
         connectionInfoCompleter: connectionInfoCompleter,
+        appStartedCompleter: appStartedCompleter,
         route: route,
         shouldBuild: shouldBuild
       );
@@ -161,6 +163,7 @@ class HotRunner extends ResidentRunner {
 
   Future<int> _run({
     Completer<DebugConnectionInfo> connectionInfoCompleter,
+    Completer<Null> appStartedCompleter,
     String route,
     bool shouldBuild: true
   }) async {
@@ -298,6 +301,8 @@ class HotRunner extends ResidentRunner {
     printTrace('Finishing file synchronization');
     // Finish the file sync now.
     await _updateDevFS();
+
+    appStartedCompleter?.complete();
 
     if (benchmarkMode) {
       // We are running in benchmark mode.

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -40,6 +40,7 @@ abstract class ResidentRunner {
   /// Start the app and keep the process running during its lifetime.
   Future<int> run({
     Completer<DebugConnectionInfo> connectionInfoCompleter,
+    Completer<Null> appStartedCompleter,
     String route,
     bool shouldBuild: true
   });

--- a/packages/flutter_tools/lib/src/run.dart
+++ b/packages/flutter_tools/lib/src/run.dart
@@ -45,6 +45,7 @@ class RunAndStayResident extends ResidentRunner {
   @override
   Future<int> run({
     Completer<DebugConnectionInfo> connectionInfoCompleter,
+    Completer<Null> appStartedCompleter,
     String route,
     bool shouldBuild: true
   }) {
@@ -55,6 +56,7 @@ class RunAndStayResident extends ResidentRunner {
         traceStartup: traceStartup,
         benchmark: benchmark,
         connectionInfoCompleter: connectionInfoCompleter,
+        appStartedCompleter: appStartedCompleter,
         route: route,
         shouldBuild: shouldBuild
       );
@@ -101,6 +103,7 @@ class RunAndStayResident extends ResidentRunner {
     bool traceStartup: false,
     bool benchmark: false,
     Completer<DebugConnectionInfo> connectionInfoCompleter,
+    Completer<Null> appStartedCompleter,
     String route,
     bool shouldBuild: true
   }) async {
@@ -185,8 +188,8 @@ class RunAndStayResident extends ResidentRunner {
 
     startTime.stop();
 
-    if (connectionInfoCompleter != null && _result.hasObservatory)
-      connectionInfoCompleter.complete(new DebugConnectionInfo(_result.observatoryPort));
+    if (_result.hasObservatory)
+      connectionInfoCompleter?.complete(new DebugConnectionInfo(_result.observatoryPort));
 
     // Connect to observatory.
     if (debuggingOptions.debuggingEnabled) {
@@ -217,6 +220,8 @@ class RunAndStayResident extends ResidentRunner {
       setupTerminal();
       registerSignalHandlers();
     }
+
+    appStartedCompleter?.complete();
 
     if (benchmark) {
       await new Future<Null>.delayed(new Duration(seconds: 4));


### PR DESCRIPTION
This changes the following `flutter daemon` events:
* ~~`app.start` event becomes `app.starting` event with same params~~
* new `app.started` event with no params sent once the application launch process is complete and the app is either paused before `main()` if `startPaused` is true or `main()` has begun running.
* ~~`app.stop` event becomes `app.stopped` event with same params~~

Fixes https://github.com/flutter/flutter/issues/6665
@devoncarew 

I noticed exceptions from the Flutter IJ plugin when testing this... see https://github.com/flutter/flutter-intellij/issues/413.
I don't think that issue blocks this PR.
