### PR TITLE
minor tweak to the text output

### DIFF
--- a/packages/flutter_tools/lib/src/commands/run.dart
+++ b/packages/flutter_tools/lib/src/commands/run.dart
@@ -119,8 +119,7 @@ class RunCommand extends RunCommandBase {
     if (getCurrentHostPlatform() == HostPlatform.darwin_x64 &&
         XCode.instance.isInstalledAndMeetsVersionCheck) {
       printStatus('');
-      printStatus('To run on a simulator, launch it first:');
-      printStatus('open -a Simulator.app');
+      printStatus('To run on a simulator, launch it first: open -a Simulator.app');
       printStatus('');
       printStatus('If you expected your device to be detected, please run "flutter doctor" to diagnose');
       printStatus('potential issues, or visit https://flutter.io/setup/ for troubleshooting tips.');


### PR DESCRIPTION
- minor tweak to the text output

```
No connected devices.

To run on a simulator, launch it first:
open -a Simulator.app
```

==>

```
No connected devices.

To run on a simulator, launch it first: open -a Simulator.app
```
