### PR TITLE
Default includeRobotoFonts to false

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_device.dart
+++ b/packages/flutter_tools/lib/src/android/android_device.dart
@@ -414,7 +414,6 @@ class AndroidDevice extends Device {
       localBundlePath = await flx.buildFlx(
         mainPath: mainPath,
         precompiledSnapshot: isAotBuildMode(debuggingOptions.buildMode),
-        includeRobotoFonts: false
       );
       if (localBundlePath == null)
         return new LaunchResult.failed();

--- a/packages/flutter_tools/lib/src/asset.dart
+++ b/packages/flutter_tools/lib/src/asset.dart
@@ -69,7 +69,7 @@ class AssetBundle {
     String manifestPath: defaultManifestPath,
     String workingDirPath,
     String packagesPath,
-    bool includeRobotoFonts: true,
+    bool includeRobotoFonts: false,
     bool reportLicensedPackages: false
   }) async {
     workingDirPath ??= getAssetBuildDirectory();

--- a/packages/flutter_tools/lib/src/commands/build_flx.dart
+++ b/packages/flutter_tools/lib/src/commands/build_flx.dart
@@ -22,7 +22,7 @@ class BuildFlxCommand extends BuildSubCommand {
     argParser.addOption('snapshot', defaultsTo: defaultSnapshotPath);
     argParser.addOption('depfile', defaultsTo: defaultDepfilePath);
     argParser.addOption('working-dir', defaultsTo: getAssetBuildDirectory());
-    argParser.addFlag('include-roboto-fonts', defaultsTo: true);
+    argParser.addFlag('include-roboto-fonts', defaultsTo: false);
     argParser.addFlag('report-licensed-packages', help: 'Whether to report the names of all the packages that are included in the application\'s LICENSE file.', defaultsTo: false);
     usesPubOption();
   }

--- a/packages/flutter_tools/lib/src/flx.dart
+++ b/packages/flutter_tools/lib/src/flx.dart
@@ -57,7 +57,7 @@ Future<int> createSnapshot({
 Future<String> buildFlx({
   String mainPath: defaultMainPath,
   bool precompiledSnapshot: false,
-  bool includeRobotoFonts: true
+  bool includeRobotoFonts: false
 }) async {
   int result;
   result = await build(
@@ -81,7 +81,7 @@ Future<int> build({
   String workingDirPath,
   String packagesPath,
   bool precompiledSnapshot: false,
-  bool includeRobotoFonts: true,
+  bool includeRobotoFonts: false,
   bool reportLicensedPackages: false
 }) async {
   snapshotterPath ??= tools.getHostToolPath(HostTool.SkySnapshot);
@@ -131,7 +131,7 @@ Future<int> assemble({
   String privateKeyPath: defaultPrivateKeyPath,
   String workingDirPath,
   String packagesPath,
-  bool includeRobotoFonts: true,
+  bool includeRobotoFonts: false,
   bool reportLicensedPackages: false
 }) async {
   outputPath ??= defaultFlxOutputPath;


### PR DESCRIPTION
As of abcfc42dfca2ab6b4a842daffc28c35d84cb501e, we now default to
platform-specific typography. Developers who wish to use Roboto on iOS
should add the font in flutter.yaml and apply it at the Theme level as
with any other custom font.

Android: previously invoked with explicit false.
iOS: no longer uses Roboto by default.
Fuchsia: previously (and still) invoked with explicit true.