### PR TITLE
AOT Android: Don't use integer division instructions.

### DIFF
--- a/packages/flutter_tools/lib/src/commands/build_aot.dart
+++ b/packages/flutter_tools/lib/src/commands/build_aot.dart
@@ -233,6 +233,7 @@ Future<String> _buildAotSnapshot(
         '--instructions_blob=$instructionsBlob',
         '--embedder_entry_points_manifest=$vmEntryPointsAndroid',
         '--no-sim-use-hardfp',
+        '--no-use-integer-division',  // Not supported by the Pixel in 32-bit mode.
       ]);
       break;
     case TargetPlatform.ios:


### PR DESCRIPTION
@jason-simmons