### PR TITLE
Improve error message if update cache interrupted during download

### DIFF
--- a/packages/flutter_tools/lib/src/base/net.dart
+++ b/packages/flutter_tools/lib/src/base/net.dart
@@ -27,9 +27,16 @@ Future<List<int>> fetchUrl(Uri url) async {
     );
   }
 
-  BytesBuilder responseBody = new BytesBuilder(copy: false);
-  await for (List<int> chunk in response)
-    responseBody.add(chunk);
+  try {
+    BytesBuilder responseBody = new BytesBuilder(copy: false);
+    await for (List<int> chunk in response)
+        responseBody.add(chunk);
 
-  return responseBody.takeBytes();
+    return responseBody.takeBytes();
+  } on IOException catch (e) {
+    throw new ToolExit(
+      'Download failed: $url\n  $e',
+      exitCode: kNetworkProblemExitCode,
+    );
+  }
 }


### PR DESCRIPTION
Another incremental improvement for https://github.com/flutter/flutter/issues/6148
@devoncarew 