### PR TITLE
Make the fire red on black-and-white terminals

### DIFF
--- a/packages/flutter_tools/lib/src/commands/daemon.dart
+++ b/packages/flutter_tools/lib/src/commands/daemon.dart
@@ -624,7 +624,7 @@ class NotifyingLogger extends Logger {
   }
 
   @override
-  void printStatus(String message, { bool emphasis: false, bool newline: true }) {
+  void printStatus(String message, { bool emphasis: false, bool newline: true, String ansiAlternative }) {
     _messageController.add(new LogMessage('status', message));
   }
 
@@ -698,7 +698,7 @@ class _AppRunLogger extends Logger {
   }
 
   @override
-  void printStatus(String message, { bool emphasis: false, bool newline: true }) {
+  void printStatus(String message, { bool emphasis: false, bool newline: true, String ansiAlternative }) {
     _sendLogEvent(<String, dynamic>{ 'log': message });
   }
 

--- a/packages/flutter_tools/lib/src/globals.dart
+++ b/packages/flutter_tools/lib/src/globals.dart
@@ -27,8 +27,15 @@ void printError(String message, [StackTrace stackTrace]) => logger.printError(me
 
 /// Display normal output of the command. This should be used for things like
 /// progress messages, success messages, or just normal command output.
-void printStatus(String message, { bool emphasis: false, bool newline: true }) {
-  logger.printStatus(message, emphasis: emphasis, newline: newline);
+///
+/// Set `emphasis` to true to make the output bold if it's supported.
+///
+/// Set `newline` to false to skip the trailing linefeed.
+///
+/// If `ansiAlternative` is provided, and the terminal supports color, that
+/// string will be printed instead of the message.
+void printStatus(String message, { bool emphasis: false, bool newline: true, String ansiAlternative }) {
+  logger.printStatus(message, emphasis: emphasis, newline: newline, ansiAlternative: ansiAlternative);
 }
 
 /// Use this for verbose tracing output. Users can turn this output on in order

--- a/packages/flutter_tools/lib/src/hot.dart
+++ b/packages/flutter_tools/lib/src/hot.dart
@@ -594,7 +594,15 @@ class HotRunner extends ResidentRunner {
 
   @override
   void printHelp({ @required bool details }) {
-    printStatus('🔥  To hot reload your app on the fly, press "r" or F5. To restart the app entirely, press "R".', emphasis: true);
+    const String fire = '🔥';
+    const String redOnBlack = '\u001B[31;40m';
+    const String bold = '\u001B[0;1m';
+    const String reset = '\u001B[0m';
+    printStatus(
+      '$fire  To hot reload your app on the fly, press "r" or F5. To restart the app entirely, press "R".',
+      ansiAlternative: '$redOnBlack$fire$bold  To ${redOnBlack}hot reload$bold your app on the fly, '
+                       'press "r" or F5. To restart the app entirely, press "R".$reset'
+    );
     printStatus('The Observatory debugger and profiler is available at: http://127.0.0.1:$_observatoryPort/');
     if (details) {
       printStatus('To dump the widget hierarchy of the app (debugDumpApp), press "w".');


### PR DESCRIPTION
The fire emoji, on some variants of Ubuntu, with some terminals, with some fonts, when bold, looks less like a flame than we would like. This attempts to resolve this.

cc @johnmccutchan for review