### PR TITLE
revert args to 0.13.6

### DIFF
--- a/dev/automated_tests/pubspec.yaml
+++ b/dev/automated_tests/pubspec.yaml
@@ -1,5 +1,11 @@
 name: flutter_automated_tests
 dependencies:
+
+  # version 0.13.6+1 does not return the value from the command
+  # causing flutter tools to always have exit code 0
+  # see https://github.com/flutter/flutter/issues/6766
+  args: 0.13.6
+
   flutter:
     sdk: flutter
   flutter_test:

--- a/dev/benchmarks/complex_layout/pubspec.yaml
+++ b/dev/benchmarks/complex_layout/pubspec.yaml
@@ -2,6 +2,12 @@ name: complex_layout
 description: A new flutter project.
 
 dependencies:
+
+  # version 0.13.6+1 does not return the value from the command
+  # causing flutter tools to always have exit code 0
+  # see https://github.com/flutter/flutter/issues/6766
+  args: 0.13.6
+
   flutter:
     sdk: flutter
   flutter_driver:

--- a/dev/benchmarks/microbenchmarks/pubspec.yaml
+++ b/dev/benchmarks/microbenchmarks/pubspec.yaml
@@ -1,6 +1,12 @@
 name: microbenchmarks
 description: A new flutter project.
 dependencies:
+
+  # version 0.13.6+1 does not return the value from the command
+  # causing flutter tools to always have exit code 0
+  # see https://github.com/flutter/flutter/issues/6766
+  args: 0.13.6
+
   flutter:
     sdk: flutter
   flutter_test:

--- a/dev/devicelab/pubspec.yaml
+++ b/dev/devicelab/pubspec.yaml
@@ -8,7 +8,12 @@ environment:
   sdk: '>=1.12.0 <2.0.0'
 
 dependencies:
-  args: ^0.13.4
+
+  # version 0.13.6+1 does not return the value from the command
+  # causing flutter tools to always have exit code 0
+  # see https://github.com/flutter/flutter/issues/6766
+  args: 0.13.6
+
   meta: ^1.0.3
   path: ^1.3.0
   stack_trace: ^1.4.0

--- a/dev/manual_tests/pubspec.yaml
+++ b/dev/manual_tests/pubspec.yaml
@@ -1,6 +1,12 @@
 name: flutter_manual_tests
 
 dependencies:
+
+  # version 0.13.6+1 does not return the value from the command
+  # causing flutter tools to always have exit code 0
+  # see https://github.com/flutter/flutter/issues/6766
+  args: 0.13.6
+
   flutter:
     sdk: flutter
 

--- a/dev/tools/pubspec.yaml
+++ b/dev/tools/pubspec.yaml
@@ -2,5 +2,10 @@ name: dev_tools
 description: Various repository development tools for flutter.
 
 dependencies:
-  args: ^0.13.4
+
+  # version 0.13.6+1 does not return the value from the command
+  # causing flutter tools to always have exit code 0
+  # see https://github.com/flutter/flutter/issues/6766
+  args: 0.13.6
+
   path: ^1.3.0

--- a/examples/flutter_gallery/pubspec.yaml
+++ b/examples/flutter_gallery/pubspec.yaml
@@ -1,5 +1,11 @@
 name: flutter_gallery
 dependencies:
+
+  # version 0.13.6+1 does not return the value from the command
+  # causing flutter tools to always have exit code 0
+  # see https://github.com/flutter/flutter/issues/6766
+  args: 0.13.6
+
   collection: '>=1.9.1 <2.0.0'
   intl: '>=0.14.0 <0.15.0'
   string_scanner: ^1.0.0

--- a/examples/hello_services/pubspec.yaml
+++ b/examples/hello_services/pubspec.yaml
@@ -1,6 +1,12 @@
 name: hello_services
 
 dependencies:
+
+  # version 0.13.6+1 does not return the value from the command
+  # causing flutter tools to always have exit code 0
+  # see https://github.com/flutter/flutter/issues/6766
+  args: 0.13.6
+
   flutter:
     sdk: flutter
 

--- a/examples/hello_world/pubspec.yaml
+++ b/examples/hello_world/pubspec.yaml
@@ -1,6 +1,12 @@
 name: hello_world
 
 dependencies:
+
+  # version 0.13.6+1 does not return the value from the command
+  # causing flutter tools to always have exit code 0
+  # see https://github.com/flutter/flutter/issues/6766
+  args: 0.13.6
+
   flutter:
     sdk: flutter
 

--- a/examples/layers/pubspec.yaml
+++ b/examples/layers/pubspec.yaml
@@ -1,5 +1,11 @@
 name: flutter_examples_layers
 dependencies:
+
+  # version 0.13.6+1 does not return the value from the command
+  # causing flutter tools to always have exit code 0
+  # see https://github.com/flutter/flutter/issues/6766
+  args: 0.13.6
+
   flutter:
     sdk: flutter
 

--- a/examples/stocks/pubspec.yaml
+++ b/examples/stocks/pubspec.yaml
@@ -1,5 +1,11 @@
 name: stocks
 dependencies:
+
+  # version 0.13.6+1 does not return the value from the command
+  # causing flutter tools to always have exit code 0
+  # see https://github.com/flutter/flutter/issues/6766
+  args: 0.13.6
+
   flutter:
     sdk: flutter
   intl: '>=0.14.0 <0.15.0'

--- a/packages/flutter/pubspec.yaml
+++ b/packages/flutter/pubspec.yaml
@@ -5,6 +5,12 @@ description: A framework for writing Flutter applications
 homepage: http://flutter.io
 
 dependencies:
+
+  # version 0.13.6+1 does not return the value from the command
+  # causing flutter tools to always have exit code 0
+  # see https://github.com/flutter/flutter/issues/6766
+  args: 0.13.6
+
   collection: '>=1.9.1 <2.0.0'
   intl: '>=0.14.0 <0.15.0'
   meta: ^1.0.3

--- a/packages/flutter_driver/pubspec.yaml
+++ b/packages/flutter_driver/pubspec.yaml
@@ -8,6 +8,12 @@ environment:
   sdk: '>=1.19.0 <2.0.0'
 
 dependencies:
+
+  # version 0.13.6+1 does not return the value from the command
+  # causing flutter tools to always have exit code 0
+  # see https://github.com/flutter/flutter/issues/6766
+  args: 0.13.6
+
   file: '^0.1.0'
   json_rpc_2: '^2.0.0'
   matcher: '>=0.12.0 <1.0.0'

--- a/packages/flutter_markdown/pubspec.yaml
+++ b/packages/flutter_markdown/pubspec.yaml
@@ -5,6 +5,12 @@ author: Flutter Authors <flutter-dev@googlegroups.com>
 homepage: http://flutter.io
 
 dependencies:
+
+  # version 0.13.6+1 does not return the value from the command
+  # causing flutter tools to always have exit code 0
+  # see https://github.com/flutter/flutter/issues/6766
+  args: 0.13.6
+
   flutter:
     sdk: flutter
   markdown: '^0.9.0'

--- a/packages/flutter_test/pubspec.yaml
+++ b/packages/flutter_test/pubspec.yaml
@@ -1,5 +1,11 @@
 name: flutter_test
 dependencies:
+
+  # version 0.13.6+1 does not return the value from the command
+  # causing flutter tools to always have exit code 0
+  # see https://github.com/flutter/flutter/issues/6766
+  args: 0.13.6
+
   quiver: ^0.21.4
 
   # The flutter tools depend on very specific internal implementation

--- a/packages/flutter_tools/lib/executable.dart
+++ b/packages/flutter_tools/lib/executable.dart
@@ -86,7 +86,7 @@ Future<Null> main(List<String> args) async {
     Doctor.initGlobal();
 
     dynamic result = await runner.run(args);
-    _exit(result is int ? result : 0);
+    _exit(result is int ? result : 1);
   }, onError: (dynamic error, Chain chain) {
     if (error is UsageException) {
       stderr.writeln(error.message);

--- a/packages/flutter_tools/pubspec.yaml
+++ b/packages/flutter_tools/pubspec.yaml
@@ -12,6 +12,7 @@ dependencies:
 
   # version 0.13.6+1 does not return the value from the command
   # causing flutter tools to always have exit code 0
+  # see https://github.com/flutter/flutter/issues/6766
   args: 0.13.6
 
   coverage: ^0.8.0

--- a/packages/flutter_tools/pubspec.yaml
+++ b/packages/flutter_tools/pubspec.yaml
@@ -9,7 +9,11 @@ environment:
 
 dependencies:
   archive: ^1.0.20
-  args: ^0.13.4
+
+  # version 0.13.6+1 does not return the value from the command
+  # causing flutter tools to always have exit code 0
+  args: 0.13.6
+
   coverage: ^0.8.0
   crypto: '>=1.1.1 <3.0.0'
   file: ^0.1.0


### PR DESCRIPTION
args package v0.13.6+1 breaks flutter tools because the `CommandRunner.runCommand` no longer returns the value from executing `command.run()` (see line 188). This workaround rolls back to using args package v0.13.6 until an appropriate fix is made.