### PR TITLE
Bump tools version to `0.0.3`.

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -6,4 +6,4 @@
 # incompatible way, this version number might not change. Instead, the version
 # number for package:flutter will update to reflect that change.
 
-0.0.2
+0.0.3


### PR DESCRIPTION
The IntelliJ plugin will use this as a baseline to ensure that the installed tools support the expected message formats.

To see where this applies, look at https://github.com/flutter/flutter-intellij/pull/426.

The changes we’re checking for were introduced in https://github.com/flutter/flutter/commit/1f1adcaa0e563cb68ec5f0d2f82efc9759be1221.

/cc @abarth @Hixie @danrubel 

FYI @devoncarew 