### PR TITLE
Abort a hot reload if we detect an error in flutter.yaml

### DIFF
--- a/packages/flutter_tools/lib/src/asset.dart
+++ b/packages/flutter_tools/lib/src/asset.dart
@@ -75,7 +75,14 @@ class AssetBundle {
   }) async {
     workingDirPath ??= getAssetBuildDirectory();
     packagesPath ??= path.absolute(PackageMap.globalPackagesPath);
-    Object manifest = _loadFlutterYamlManifest(manifestPath);
+    Object manifest;
+    try {
+      manifest = _loadFlutterYamlManifest(manifestPath);
+    } catch (e) {
+      printStatus('Error detected in flutter.yaml:', emphasis: true);
+      printError(e);
+      return 1;
+    }
     if (manifest == null) {
       // No manifest file found for this application.
       return 0;
@@ -449,13 +456,8 @@ Future<int> _validateFlutterYamlManifest(Object manifest) async {
   if (validator.validate(manifest)) {
     return 0;
   } else {
-    if (validator.errors.length == 1) {
-      printError('Error in flutter.yaml: ${validator.errors.first}');
-    } else {
-      printError('Error in flutter.yaml:');
-      printError('  ' + validator.errors.join('\n  '));
-    }
-
+    printStatus('Error detected in flutter.yaml:', emphasis: true);
+    printError(validator.errors.join('\n'));
     return 1;
   }
 }

--- a/packages/flutter_tools/lib/src/hot.dart
+++ b/packages/flutter_tools/lib/src/hot.dart
@@ -387,12 +387,14 @@ class HotRunner extends ResidentRunner {
       // Did not update DevFS because of a Dart source error.
       return false;
     }
-    Status devFSStatus = logger.startProgress('Syncing files to device...');
     final bool rebuildBundle = bundle.needsBuild();
     if (rebuildBundle) {
       printTrace('Updating assets');
-      await bundle.build();
+      int result = await bundle.build();
+      if (result != 0)
+        return false;
     }
+    Status devFSStatus = logger.startProgress('Syncing files to device...');
     await _devFS.update(progressReporter: progressReporter,
                         bundle: bundle,
                         bundleDirty: rebuildBundle,

--- a/packages/flutter_tools/lib/src/services.dart
+++ b/packages/flutter_tools/lib/src/services.dart
@@ -36,7 +36,14 @@ Future<Null> parseServiceConfigs(
     return;
   }
 
-  dynamic manifest = _loadYamlFile(_kFlutterManifestPath);
+  dynamic manifest;
+  try {
+    manifest = _loadYamlFile(_kFlutterManifestPath);
+  } catch (e) {
+    printStatus('Error detected in flutter.yaml:', emphasis: true);
+    printError(e);
+    return;
+  }
   if (manifest == null || manifest['services'] == null) {
     printTrace('No services specified in the manifest');
     return;


### PR DESCRIPTION
- [x] Better handling of Flutter.yaml errors.
- [x] Do not allow a reload to happen with an error in flutter.yaml

Fixes https://github.com/flutter/flutter/issues/6726