### PR TITLE
Stop tracking time to first frame because it is unreliable.

### DIFF
--- a/packages/flutter_tools/lib/src/hot.dart
+++ b/packages/flutter_tools/lib/src/hot.dart
@@ -79,42 +79,6 @@ class DartDependencySetBuilder {
   }
 }
 
-
-class FirstFrameTimer {
-  FirstFrameTimer(this.vmService);
-
-  void start() {
-    stopwatch.reset();
-    stopwatch.start();
-    _subscription = vmService.onExtensionEvent.listen(_onExtensionEvent);
-  }
-
-  /// Returns a Future which completes after the first frame event is received.
-  Future<Null> firstFrame() => _completer.future;
-
-  void _onExtensionEvent(ServiceEvent event) {
-    if (event.extensionKind == 'Flutter.FirstFrame')
-      _stop();
-  }
-
-  void _stop() {
-    _subscription?.cancel();
-    _subscription = null;
-    stopwatch.stop();
-    _completer.complete(null);
-  }
-
-  Duration get elapsed {
-    assert(!stopwatch.isRunning);
-    return stopwatch.elapsed;
-  }
-
-  final VMService vmService;
-  final Stopwatch stopwatch = new Stopwatch();
-  final Completer<Null> _completer = new Completer<Null>();
-  StreamSubscription<ServiceEvent> _subscription;
-}
-
 class HotRunner extends ResidentRunner {
   HotRunner(
     Device device, {
@@ -450,31 +414,21 @@ class HotRunner extends ResidentRunner {
   }
 
   Future<OperationResult> _restartFromSources() async {
-    FirstFrameTimer firstFrameTimer = new FirstFrameTimer(vmService);
-    firstFrameTimer.start();
+    Stopwatch restartTimer = new Stopwatch();
+    restartTimer.start();
     bool updatedDevFS = await _updateDevFS();
     if (!updatedDevFS)
       return new OperationResult(1, 'Dart Source Error');
     await _launchFromDevFS(_package, _mainPath);
-    bool waitForFrame =
-        await currentView.uiIsolate.flutterFrameworkPresent();
-    Status restartStatus =
-        logger.startProgress('Waiting for application to start...');
-    if (waitForFrame) {
-      // Wait for the first frame to be rendered.
-      await firstFrameTimer.firstFrame();
-    }
-    restartStatus.stop();
-    if (waitForFrame) {
-      printTrace('Restart performed in '
-                 '${getElapsedAsMilliseconds(firstFrameTimer.elapsed)}.');
-      if (benchmarkMode) {
-        benchmarkData['hotRestartMillisecondsToFrame'] =
-            firstFrameTimer.elapsed.inMilliseconds;
-      }
-      flutterUsage.sendTiming('hot', 'restart', firstFrameTimer.elapsed);
+    restartTimer.stop();
+    printTrace('Restart performed in '
+        '${getElapsedAsMilliseconds(restartTimer.elapsed)}.');
+    if (benchmarkMode) {
+      benchmarkData['hotRestartMillisecondsToFrame'] =
+          restartTimer.elapsed.inMilliseconds;
     }
     flutterUsage.sendEvent('hot', 'restart');
+    flutterUsage.sendTiming('hot', 'restart', restartTimer.elapsed);
     return OperationResult.ok;
   }
 
@@ -520,13 +474,11 @@ class HotRunner extends ResidentRunner {
   Future<OperationResult> _reloadSources({ bool pause: false }) async {
     if (currentView.uiIsolate == null)
       throw 'Application isolate not found';
-    FirstFrameTimer firstFrameTimer = new FirstFrameTimer(vmService);
-    firstFrameTimer.start();
-    if (_devFS != null) {
-      bool updatedDevFS = await _updateDevFS();
-      if (!updatedDevFS)
-        return new OperationResult(1, 'Dart Source Error');
-    }
+    Stopwatch reloadTimer = new Stopwatch();
+    reloadTimer.start();
+    bool updatedDevFS = await _updateDevFS();
+    if (!updatedDevFS)
+      return new OperationResult(1, 'Dart Source Error');
     String reloadMessage;
     try {
       Map<String, dynamic> reloadReport =
@@ -566,9 +518,8 @@ class HotRunner extends ResidentRunner {
     }
     await _evictDirtyAssets();
     printTrace('Reassembling application');
-    bool waitForFrame = true;
     try {
-      waitForFrame = (await currentView.uiIsolate.flutterReassemble() != null);
+      await currentView.uiIsolate.flutterReassemble();
     } catch (_) {
       printError('Reassembling application failed.');
       return new OperationResult(1, 'error reassembling application');
@@ -579,18 +530,14 @@ class HotRunner extends ResidentRunner {
     } catch (_) {
       /* ignore any errors */
     }
-    if (waitForFrame) {
-      // When the framework is present, we can wait for the first frame
-      // event and measure reload time.
-      await firstFrameTimer.firstFrame();
-      printTrace('Hot reload performed in '
-                 '${getElapsedAsMilliseconds(firstFrameTimer.elapsed)}.');
-      if (benchmarkMode) {
-        benchmarkData['hotReloadMillisecondsToFrame'] =
-            firstFrameTimer.elapsed.inMilliseconds;
-      }
-      flutterUsage.sendTiming('hot', 'reload', firstFrameTimer.elapsed);
+    reloadTimer.stop();
+    printTrace('Hot reload performed in '
+               '${getElapsedAsMilliseconds(reloadTimer.elapsed)}.');
+    if (benchmarkMode) {
+      benchmarkData['hotReloadMillisecondsToFrame'] =
+          reloadTimer.elapsed.inMilliseconds;
     }
+    flutterUsage.sendTiming('hot', 'reload', reloadTimer.elapsed);
     return new OperationResult(OperationResult.ok.code, reloadMessage);
   }
 


### PR DESCRIPTION
- [x] Stop tracking time to first frame because it is unreliable.
- [x] Track time to complete reassemble instead.

@Hixie 

Fixes https://github.com/flutter/flutter/issues/6400