### PR TITLE
Remove the repaint boundary around the drawer items to fix disappearing shadows.

### DIFF
--- a/packages/flutter/lib/src/material/drawer.dart
+++ b/packages/flutter/lib/src/material/drawer.dart
@@ -275,11 +275,9 @@ class DrawerControllerState extends State<DrawerController> with SingleTickerPro
                 child: new Align(
                   alignment: FractionalOffset.centerRight,
                   widthFactor: _controller.value,
-                  child: new RepaintBoundary(
-                    child: new Focus(
-                      key: _drawerKey,
-                      child: config.child
-                    )
+                  child: new Focus(
+                    key: _drawerKey,
+                    child: config.child
                   )
                 )
               )


### PR DESCRIPTION
I am working on a more complete fix to the way we track the changes in bounds of a picture due to the presence of filters and custom paint operations before the canvas origin. In the meantime, this repaint boundary was causing a raster cache entry that got rid of its shadow. The entry itself did not improve performance as the drawer sub-scene is trivial. There is another repaint boundary that does rasterize the background however. That is still left as is. So the expensive stuff is indeed rasterized.
![screen shot 2016-11-10 at 5 07 04 pm](https://cloud.githubusercontent.com/assets/44085/20200930/2d80991a-a769-11e6-8073-18854edfcb83.png)


Fixes https://github.com/flutter/flutter/issues/5231. But I admit this is not a general fix and I can do better. Feel free to veto the change.