### PR TITLE
Revert "trace IntelliJ config and install locations on Linux (#6805)"

### DIFF
--- a/packages/flutter_tools/lib/src/doctor.dart
+++ b/packages/flutter_tools/lib/src/doctor.dart
@@ -318,7 +318,6 @@ class IntelliJValidatorOnLinux extends IntelliJValidator {
         String name = path.basename(dir.path);
         IntelliJValidator._idToTitle.forEach((String id, String title) {
           if (name.startsWith('.$id')) {
-            printTrace('Found IntelliJ config: ${dir.path}');
             String version = name.substring(id.length + 1);
             String installPath;
             try {
@@ -327,7 +326,6 @@ class IntelliJValidatorOnLinux extends IntelliJValidator {
               // ignored
             }
             if (installPath != null && FileSystemEntity.isDirectorySync(installPath)) {
-              printTrace('Found IntelliJ installation: $installPath');
               String pluginsPath = path.join(dir.path, 'config', 'plugins');
               validators.add(new IntelliJValidatorOnLinux(title, version, pluginsPath));
             }


### PR DESCRIPTION
The added printTrace statements are causing problems when running tests locally on Linux.
This reverts commit 546cef5277d69eae0c8a6fef31fae7ce94ca8e9e.

TBR @devoncarew 