### PR TITLE
Performance fixes for hot reload when using a prebuilt loader

### DIFF
--- a/packages/flutter_tools/lib/executable.dart
+++ b/packages/flutter_tools/lib/executable.dart
@@ -39,6 +39,7 @@ import 'src/devfs.dart';
 import 'src/device.dart';
 import 'src/doctor.dart';
 import 'src/globals.dart';
+import 'src/hot.dart';
 import 'src/runner/flutter_command_runner.dart';
 
 /// Main entry point for commands.
@@ -90,6 +91,8 @@ Future<Null> main(List<String> args) async {
       context[DevFSConfig] = new DevFSConfig();
     if (context[Doctor] == null)
       context[Doctor] = new Doctor();
+    if (context[HotRunnerConfig] == null)
+      context[HotRunnerConfig] = new HotRunnerConfig();
 
     dynamic result = await runner.run(args);
     _exit(result is int ? result : 1);

--- a/packages/flutter_tools/lib/src/devfs.dart
+++ b/packages/flutter_tools/lib/src/devfs.dart
@@ -20,6 +20,8 @@ typedef void DevFSProgressReporter(int progress, int max);
 class DevFSConfig {
   /// Should DevFS assume that symlink targets are stable?
   bool cacheSymlinks = false;
+  /// Should DevFS assume that there are no symlinks to directories?
+  bool noDirectorySymlinks = false;
 }
 
 DevFSConfig get devFSConfig => context[DevFSConfig];
@@ -521,12 +523,12 @@ class DevFS {
       Stream<FileSystemEntity> files =
           directory.list(recursive: recursive, followLinks: false);
       await for (FileSystemEntity file in files) {
-        if (file is Link) {
+        if (!devFSConfig.noDirectorySymlinks && (file is Link)) {
+          // Check if this is a symlink to a directory and skip it.
           final String linkPath = file.resolveSymbolicLinksSync();
           final FileSystemEntityType linkType =
               FileStat.statSync(linkPath).type;
           if (linkType == FileSystemEntityType.DIRECTORY) {
-            // Skip links to directories.
             continue;
           }
         }

--- a/packages/flutter_tools/test/src/context.dart
+++ b/packages/flutter_tools/test/src/context.dart
@@ -9,10 +9,13 @@ import 'package:flutter_tools/src/base/context.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/os.dart';
 import 'package:flutter_tools/src/device.dart';
+import 'package:flutter_tools/src/devfs.dart';
 import 'package:flutter_tools/src/doctor.dart';
+import 'package:flutter_tools/src/hot.dart';
 import 'package:flutter_tools/src/ios/mac.dart';
 import 'package:flutter_tools/src/ios/simulators.dart';
 import 'package:flutter_tools/src/usage.dart';
+
 import 'package:mockito/mockito.dart';
 import 'package:test/test.dart';
 
@@ -52,6 +55,14 @@ void testUsingContext(String description, dynamic testMethod(), {
       MockOperatingSystemUtils os = new MockOperatingSystemUtils();
       when(os.isWindows).thenReturn(false);
       testContext[OperatingSystemUtils] = os;
+    }
+
+    if (!overrides.containsKey(DevFSConfig)) {
+      testContext[DevFSConfig] = new DevFSConfig();
+    }
+
+    if (!overrides.containsKey(HotRunnerConfig)) {
+      testContext[HotRunnerConfig] = new HotRunnerConfig();
     }
 
     if (!overrides.containsKey(IOSSimulatorUtils)) {


### PR DESCRIPTION
- [x] Extend DevFSConfig with a parameter indicating if we need to handle symlink to directories.
- [x] Add a HotRunnerConfig class which configures whether or not the snapshotter is invoked to compute the minimal Dart dependencies.

@tvolkert 