### PR TITLE
Fix for issue: Exception in Flutter Gallery / Dialogs Demo #6826

### DIFF
--- a/examples/flutter_gallery/lib/demo/dialog_demo.dart
+++ b/examples/flutter_gallery/lib/demo/dialog_demo.dart
@@ -183,7 +183,7 @@ class DialogDemoState extends State<DialogDemo> {
                 initialTime: _selectedTime
               )
               .then((TimeOfDay value) {
-                if (value != _selectedTime) {
+                if (value != null && value != _selectedTime) {
                   _selectedTime = value;
                   _scaffoldKey.currentState.showSnackBar(new SnackBar(
                     content: new Text('You selected: $value')


### PR DESCRIPTION
https://github.com/flutter/flutter/issues/6826

When `cancel` is pressed in the time selection popup, the value of `value` is null.  In that case, _selectedTime should not be changed.