### PR TITLE
Fix GridTileBar layout

### DIFF
--- a/examples/flutter_gallery/lib/demo/grid_list_demo.dart
+++ b/examples/flutter_gallery/lib/demo/grid_list_demo.dart
@@ -164,10 +164,7 @@ class GridDemoPhotoItem extends StatelessWidget {
           appBar: new AppBar(
             title: new Text(photo.title)
           ),
-          body: new FractionallySizedBox(
-           alignment: FractionalOffset.topLeft,
-            widthFactor: 1.0,
-            heightFactor: 1.0,
+          body: new SizedBox.expand(
             child: new Hero(
               tag: photo.tag,
               child: new GridPhotoViewer(photo: photo),

--- a/examples/flutter_gallery/lib/demo/grid_list_demo.dart
+++ b/examples/flutter_gallery/lib/demo/grid_list_demo.dart
@@ -164,10 +164,15 @@ class GridDemoPhotoItem extends StatelessWidget {
           appBar: new AppBar(
             title: new Text(photo.title)
           ),
-          body: new Hero(
-            tag: photo.tag,
-            child: new GridPhotoViewer(photo: photo),
-          )
+          body: new FractionallySizedBox(
+           alignment: FractionalOffset.topLeft,
+            widthFactor: 1.0,
+            heightFactor: 1.0,
+            child: new Hero(
+              tag: photo.tag,
+              child: new GridPhotoViewer(photo: photo),
+            ),
+          ),
         );
       }
     ));

--- a/packages/flutter/lib/src/material/grid_tile_bar.dart
+++ b/packages/flutter/lib/src/material/grid_tile_bar.dart
@@ -64,13 +64,9 @@ class GridTileBar extends StatelessWidget {
     if (backgroundColor != null)
       decoration = new BoxDecoration(backgroundColor: backgroundColor);
 
-    EdgeInsets padding;
-    if (leading != null && trailing != null)
-      padding = const EdgeInsets.symmetric(vertical: 16.0, horizontal: 8.0);
-    else if (leading != null)
-      padding = const EdgeInsets.only(left: 8.0, right: 16.0, top: 16.0, bottom: 16.0);
-    else // trailing != null || (leading == null && trailing == null)
-      padding = const EdgeInsets.only(left: 16.0, right: 8.0, top: 16.0, bottom: 16.0);
+    EdgeInsets padding = (leading != null)
+      ? const EdgeInsets.only(left: 8.0, right: 16.0)
+      : const EdgeInsets.only(left: 16.0, right: 8.0);
 
     final List<Widget> children = <Widget>[];
 
@@ -87,6 +83,7 @@ class GridTileBar extends StatelessWidget {
       children.add(
         new Flexible(
           child: new Column(
+            mainAxisAlignment: MainAxisAlignment.center,
             crossAxisAlignment: CrossAxisAlignment.start,
             children: <Widget>[
               new DefaultTextStyle(
@@ -124,6 +121,7 @@ class GridTileBar extends StatelessWidget {
     return new Container(
       padding: padding,
       decoration: decoration,
+      height: (title != null && subtitle != null) ? 68.0 : 48.0,
       child: new Theme(
         data: darkTheme,
         child: new IconTheme.merge(

--- a/packages/flutter/lib/src/material/grid_tile_bar.dart
+++ b/packages/flutter/lib/src/material/grid_tile_bar.dart
@@ -64,11 +64,11 @@ class GridTileBar extends StatelessWidget {
     if (backgroundColor != null)
       decoration = new BoxDecoration(backgroundColor: backgroundColor);
 
-    EdgeInsets padding = (leading != null)
-      ? const EdgeInsets.only(left: 8.0, right: 16.0)
-      : const EdgeInsets.only(left: 16.0, right: 8.0);
-
     final List<Widget> children = <Widget>[];
+    final EdgeInsets padding = new EdgeInsets.only(
+      left: leading != null ? 8.0 : 16.0,
+      right: trailing != null ? 8.0 : 16.0
+    );
 
     if (leading != null)
       children.add(new Padding(padding: const EdgeInsets.only(right: 8.0), child: leading));

--- a/packages/flutter/lib/src/material/grid_tile_bar.dart
+++ b/packages/flutter/lib/src/material/grid_tile_bar.dart
@@ -67,7 +67,7 @@ class GridTileBar extends StatelessWidget {
     final List<Widget> children = <Widget>[];
     final EdgeInsets padding = new EdgeInsets.only(
       left: leading != null ? 8.0 : 16.0,
-      right: trailing != null ? 8.0 : 16.0
+      right: trailing != null ? 8.0 : 16.0,
     );
 
     if (leading != null)


### PR DESCRIPTION
Force GridTileBar heights to match the Material spec (https://material.google.com/components/grid-lists.html#grid-lists-specs) and simplify their layout a little.

Correct one more Scaffold body demo layout bug.

Fixes #6836 