### PR TITLE
Silence new analyzer warnings

### DIFF
--- a/dev/tools/dartdoc.dart
+++ b/dev/tools/dartdoc.dart
@@ -148,11 +148,12 @@ List<String> findPackageNames() {
 List<Directory> findPackages() {
   return new Directory('packages')
     .listSync()
-    .where((FileSystemEntity entity) => entity is Directory)
-    .where((Directory dir) {
-      File pubspec = new File('${dir.path}/pubspec.yaml');
-      bool nodoc = pubspec.readAsStringSync().contains('nodoc: true');
-      return !nodoc;
+    .where((FileSystemEntity entity) {
+      if (entity is! Directory)
+        return false;
+      File pubspec = new File('${entity.path}/pubspec.yaml');
+      // TODO(ianh): Use a real YAML parser here
+      return !pubspec.readAsStringSync().contains('nodoc: true');
     })
     .toList();
 }
@@ -160,7 +161,6 @@ List<Directory> findPackages() {
 Iterable<String> libraryRefs() sync* {
   for (Directory dir in findPackages()) {
     String dirName = path.basename(dir.path);
-
     for (FileSystemEntity file in new Directory('${dir.path}/lib').listSync()) {
       if (file is File && file.path.endsWith('.dart'))
         yield '$dirName/${path.basename(file.path)}';

--- a/packages/flutter/lib/src/gestures/drag.dart
+++ b/packages/flutter/lib/src/gestures/drag.dart
@@ -182,7 +182,7 @@ abstract class DragGestureRecognizer extends OneSequenceGestureRecognizer {
       _initialPosition = event.position;
       _pendingDragOffset = Offset.zero;
       if (onDown != null)
-        invokeCallback/*<Null>*/('onDown', () => onDown(new DragDownDetails(globalPosition: _initialPosition)));
+        invokeCallback/*<Null>*/('onDown', () => onDown(new DragDownDetails(globalPosition: _initialPosition))); // ignore: INVALID_CAST_FUNCTION_EXPR, https://github.com/dart-lang/sdk/issues/27504
     }
   }
 
@@ -196,7 +196,7 @@ abstract class DragGestureRecognizer extends OneSequenceGestureRecognizer {
       Offset delta = event.delta;
       if (_state == _DragState.accepted) {
         if (onUpdate != null) {
-          invokeCallback/*<Null>*/('onUpdate', () => onUpdate(new DragUpdateDetails(
+          invokeCallback/*<Null>*/('onUpdate', () => onUpdate(new DragUpdateDetails( // ignore: INVALID_CAST_FUNCTION_EXPR, https://github.com/dart-lang/sdk/issues/27504
             delta: _getDeltaForDetails(delta),
             primaryDelta: _getPrimaryDeltaForDetails(delta),
             globalPosition: event.position
@@ -218,9 +218,9 @@ abstract class DragGestureRecognizer extends OneSequenceGestureRecognizer {
       Offset delta = _pendingDragOffset;
       _pendingDragOffset = Offset.zero;
       if (onStart != null)
-        invokeCallback/*<Null>*/('onStart', () => onStart(new DragStartDetails(globalPosition: _initialPosition)));
+        invokeCallback/*<Null>*/('onStart', () => onStart(new DragStartDetails(globalPosition: _initialPosition))); // ignore: INVALID_CAST_FUNCTION_EXPR, https://github.com/dart-lang/sdk/issues/27504
       if (delta != Offset.zero && onUpdate != null) {
-        invokeCallback/*<Null>*/('onUpdate', () => onUpdate(new DragUpdateDetails(
+        invokeCallback/*<Null>*/('onUpdate', () => onUpdate(new DragUpdateDetails( // ignore: INVALID_CAST_FUNCTION_EXPR, https://github.com/dart-lang/sdk/issues/27504
           delta: _getDeltaForDetails(delta),
           primaryDelta: _getPrimaryDeltaForDetails(delta)
         )));
@@ -239,7 +239,7 @@ abstract class DragGestureRecognizer extends OneSequenceGestureRecognizer {
       resolve(GestureDisposition.rejected);
       _state = _DragState.ready;
       if (onCancel != null)
-        invokeCallback/*<Null>*/('onCancel', onCancel);
+        invokeCallback/*<Null>*/('onCancel', onCancel); // ignore: INVALID_CAST_FUNCTION_EXPR, https://github.com/dart-lang/sdk/issues/27504
       return;
     }
     bool wasAccepted = (_state == _DragState.accepted);
@@ -253,9 +253,9 @@ abstract class DragGestureRecognizer extends OneSequenceGestureRecognizer {
         final Offset pixelsPerSecond = velocity.pixelsPerSecond;
         if (pixelsPerSecond.distanceSquared > kMaxFlingVelocity * kMaxFlingVelocity)
           velocity = new Velocity(pixelsPerSecond: (pixelsPerSecond / pixelsPerSecond.distance) * kMaxFlingVelocity);
-        invokeCallback/*<Null>*/('onEnd', () => onEnd(new DragEndDetails(velocity: velocity)));
+        invokeCallback/*<Null>*/('onEnd', () => onEnd(new DragEndDetails(velocity: velocity))); // ignore: INVALID_CAST_FUNCTION_EXPR, https://github.com/dart-lang/sdk/issues/27504
       } else {
-        invokeCallback/*<Null>*/('onEnd', () => onEnd(new DragEndDetails(velocity: Velocity.zero)));
+        invokeCallback/*<Null>*/('onEnd', () => onEnd(new DragEndDetails(velocity: Velocity.zero))); // ignore: INVALID_CAST_FUNCTION_EXPR, https://github.com/dart-lang/sdk/issues/27504
       }
     }
     _velocityTrackers.clear();

--- a/packages/flutter/lib/src/gestures/long_press.dart
+++ b/packages/flutter/lib/src/gestures/long_press.dart
@@ -26,7 +26,7 @@ class LongPressGestureRecognizer extends PrimaryPointerGestureRecognizer {
   void didExceedDeadline() {
     resolve(GestureDisposition.accepted);
     if (onLongPress != null)
-      invokeCallback/*<Null>*/('onLongPress', onLongPress);
+      invokeCallback/*<Null>*/('onLongPress', onLongPress); // ignore: INVALID_CAST_FUNCTION_EXPR, https://github.com/dart-lang/sdk/issues/27504
   }
 
   @override

--- a/packages/flutter/lib/src/gestures/multitap.dart
+++ b/packages/flutter/lib/src/gestures/multitap.dart
@@ -191,7 +191,7 @@ class DoubleTapGestureRecognizer extends GestureRecognizer {
     _freezeTracker(tracker);
     _trackers.remove(tracker.pointer);
     if (onDoubleTap != null)
-      invokeCallback/*<Null>*/('onDoubleTap', onDoubleTap);
+      invokeCallback/*<Null>*/('onDoubleTap', onDoubleTap); // ignore: INVALID_CAST_FUNCTION_EXPR, https://github.com/dart-lang/sdk/issues/27504
     _reset();
   }
 
@@ -359,7 +359,7 @@ class MultiTapGestureRecognizer extends GestureRecognizer {
       longTapDelay: longTapDelay
     );
     if (onTapDown != null)
-      invokeCallback/*<Null>*/('onTapDown', () => onTapDown(event.pointer, new TapDownDetails(globalPosition: event.position)));
+      invokeCallback/*<Null>*/('onTapDown', () => onTapDown(event.pointer, new TapDownDetails(globalPosition: event.position))); // ignore: INVALID_CAST_FUNCTION_EXPR, https://github.com/dart-lang/sdk/issues/27504
   }
 
   @override
@@ -380,19 +380,19 @@ class MultiTapGestureRecognizer extends GestureRecognizer {
     _gestureMap.remove(pointer);
     if (resolution == _TapResolution.tap) {
       if (onTapUp != null)
-        invokeCallback/*<Null>*/('onTapUp', () => onTapUp(pointer, new TapUpDetails(globalPosition: globalPosition)));
+        invokeCallback/*<Null>*/('onTapUp', () => onTapUp(pointer, new TapUpDetails(globalPosition: globalPosition))); // ignore: INVALID_CAST_FUNCTION_EXPR, https://github.com/dart-lang/sdk/issues/27504
       if (onTap != null)
-        invokeCallback/*<Null>*/('onTap', () => onTap(pointer));
+        invokeCallback/*<Null>*/('onTap', () => onTap(pointer)); // ignore: INVALID_CAST_FUNCTION_EXPR, https://github.com/dart-lang/sdk/issues/27504
     } else {
       if (onTapCancel != null)
-        invokeCallback/*<Null>*/('onTapCancel', () => onTapCancel(pointer));
+        invokeCallback/*<Null>*/('onTapCancel', () => onTapCancel(pointer)); // ignore: INVALID_CAST_FUNCTION_EXPR, https://github.com/dart-lang/sdk/issues/27504
     }
   }
 
   void _handleLongTap(int pointer, Point lastPosition) {
     assert(_gestureMap.containsKey(pointer));
     if (onLongTapDown != null)
-      invokeCallback/*<Null>*/('onLongTapDown', () => onLongTapDown(pointer, new TapDownDetails(globalPosition: lastPosition)));
+      invokeCallback/*<Null>*/('onLongTapDown', () => onLongTapDown(pointer, new TapDownDetails(globalPosition: lastPosition))); // ignore: INVALID_CAST_FUNCTION_EXPR, https://github.com/dart-lang/sdk/issues/27504
   }
 
   @override

--- a/packages/flutter/lib/src/gestures/scale.dart
+++ b/packages/flutter/lib/src/gestures/scale.dart
@@ -180,9 +180,9 @@ class ScaleGestureRecognizer extends OneSequenceGestureRecognizer {
             final Offset pixelsPerSecond = velocity.pixelsPerSecond;
             if (pixelsPerSecond.distanceSquared > kMaxFlingVelocity * kMaxFlingVelocity)
               velocity = new Velocity(pixelsPerSecond: (pixelsPerSecond / pixelsPerSecond.distance) * kMaxFlingVelocity);
-            invokeCallback/*<Null>*/('onEnd', () => onEnd(new ScaleEndDetails(velocity: velocity)));
+            invokeCallback/*<Null>*/('onEnd', () => onEnd(new ScaleEndDetails(velocity: velocity))); // ignore: INVALID_CAST_FUNCTION_EXPR, https://github.com/dart-lang/sdk/issues/27504
           } else {
-            invokeCallback/*<Null>*/('onEnd', () => onEnd(new ScaleEndDetails(velocity: Velocity.zero)));
+            invokeCallback/*<Null>*/('onEnd', () => onEnd(new ScaleEndDetails(velocity: Velocity.zero))); // ignore: INVALID_CAST_FUNCTION_EXPR, https://github.com/dart-lang/sdk/issues/27504
           }
         }
         _state = ScaleState.accepted;
@@ -200,11 +200,11 @@ class ScaleGestureRecognizer extends OneSequenceGestureRecognizer {
     if (_state == ScaleState.accepted && !configChanged) {
       _state = ScaleState.started;
       if (onStart != null)
-        invokeCallback/*<Null>*/('onStart', () => onStart(new ScaleStartDetails(focalPoint: focalPoint)));
+        invokeCallback/*<Null>*/('onStart', () => onStart(new ScaleStartDetails(focalPoint: focalPoint))); // ignore: INVALID_CAST_FUNCTION_EXPR, https://github.com/dart-lang/sdk/issues/27504
     }
 
     if (_state == ScaleState.started && onUpdate != null)
-      invokeCallback/*<Null>*/('onUpdate', () => onUpdate(new ScaleUpdateDetails(scale: _scaleFactor, focalPoint: focalPoint)));
+      invokeCallback/*<Null>*/('onUpdate', () => onUpdate(new ScaleUpdateDetails(scale: _scaleFactor, focalPoint: focalPoint))); // ignore: INVALID_CAST_FUNCTION_EXPR, https://github.com/dart-lang/sdk/issues/27504
   }
 
   @override

--- a/packages/flutter/lib/src/gestures/tap.dart
+++ b/packages/flutter/lib/src/gestures/tap.dart
@@ -99,7 +99,7 @@ class TapGestureRecognizer extends PrimaryPointerGestureRecognizer {
   void resolve(GestureDisposition disposition) {
     if (_wonArenaForPrimaryPointer && disposition == GestureDisposition.rejected) {
       if (onTapCancel != null)
-        invokeCallback/*<Null>*/('onTapCancel', onTapCancel);
+        invokeCallback/*<Null>*/('onTapCancel', onTapCancel); // ignore: INVALID_CAST_FUNCTION_EXPR, https://github.com/dart-lang/sdk/issues/27504
       _reset();
     }
     super.resolve(disposition);
@@ -126,7 +126,7 @@ class TapGestureRecognizer extends PrimaryPointerGestureRecognizer {
     if (pointer == primaryPointer) {
       assert(state == GestureRecognizerState.defunct);
       if (onTapCancel != null)
-        invokeCallback/*<Null>*/('onTapCancel', onTapCancel);
+        invokeCallback/*<Null>*/('onTapCancel', onTapCancel); // ignore: INVALID_CAST_FUNCTION_EXPR, https://github.com/dart-lang/sdk/issues/27504
       _reset();
     }
   }
@@ -134,7 +134,7 @@ class TapGestureRecognizer extends PrimaryPointerGestureRecognizer {
   void _checkDown() {
     if (!_sentTapDown) {
       if (onTapDown != null)
-        invokeCallback/*<Null>*/('onTapDown', () => onTapDown(new TapDownDetails(globalPosition: initialPosition)));
+        invokeCallback/*<Null>*/('onTapDown', () => onTapDown(new TapDownDetails(globalPosition: initialPosition))); // ignore: INVALID_CAST_FUNCTION_EXPR, https://github.com/dart-lang/sdk/issues/27504
       _sentTapDown = true;
     }
   }
@@ -143,9 +143,9 @@ class TapGestureRecognizer extends PrimaryPointerGestureRecognizer {
     if (_wonArenaForPrimaryPointer && _finalPosition != null) {
       resolve(GestureDisposition.accepted);
       if (onTapUp != null)
-        invokeCallback/*<Null>*/('onTapUp', () => onTapUp(new TapUpDetails(globalPosition: _finalPosition)));
+        invokeCallback/*<Null>*/('onTapUp', () => onTapUp(new TapUpDetails(globalPosition: _finalPosition))); // ignore: INVALID_CAST_FUNCTION_EXPR, https://github.com/dart-lang/sdk/issues/27504
       if (onTap != null)
-        invokeCallback/*<Null>*/('onTap', onTap);
+        invokeCallback/*<Null>*/('onTap', onTap); // ignore: INVALID_CAST_FUNCTION_EXPR, https://github.com/dart-lang/sdk/issues/27504
       _reset();
     }
   }

--- a/packages/flutter/lib/src/http/mock_client.dart
+++ b/packages/flutter/lib/src/http/mock_client.dart
@@ -27,7 +27,7 @@ class MockClient extends BaseClient {
   /// Creates a [MockClient] with a handler that receives [Request]s and sends
   /// [Response]s.
   MockClient(MockClientHandler fn)
-    : this._((Request baseRequest, ByteStream bodyStream) {
+    : this._((BaseRequest baseRequest, ByteStream bodyStream) {
       return bodyStream.toBytes().then((Uint8List bodyBytes) {
         Request request = new Request(baseRequest.method, baseRequest.url)
             ..persistentConnection = baseRequest.persistentConnection
@@ -56,7 +56,7 @@ class MockClient extends BaseClient {
   /// Creates a [MockClient] with a handler that receives [StreamedRequest]s and
   /// sends [StreamedResponse]s.
   MockClient.streaming(MockClientStreamHandler fn)
-    : this._((Request request, ByteStream bodyStream) {
+    : this._((BaseRequest request, ByteStream bodyStream) {
       return fn(request, bodyStream).then((StreamedResponse response) {
         return new StreamedResponse(
             response.stream,
@@ -85,4 +85,4 @@ typedef Future<StreamedResponse> MockClientStreamHandler(
 
 /// A handler function that receives [Request]s and sends [Response]s. Note that
 /// [request] will be finalized.
-typedef Future<Response> MockClientHandler(Request request);
+typedef Future<Response> MockClientHandler(BaseRequest request);

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -1929,7 +1929,10 @@ abstract class Element implements BuildContext {
   int get depth => _depth;
   int _depth;
 
-  static int _sort(BuildableElement a, BuildableElement b) {
+  /// Returns true if the element has been marked as needing rebuilding.
+  bool get dirty => false;
+
+  static int _sort(Element a, Element b) {
     if (a.depth < b.depth)
       return -1;
     if (b.depth < a.depth)
@@ -2667,6 +2670,7 @@ abstract class BuildableElement extends Element {
   BuildableElement(Widget widget) : super(widget);
 
   /// Returns true if the element has been marked as needing rebuilding.
+  @override
   bool get dirty => _dirty;
   bool _dirty = true;
 

--- a/packages/flutter/lib/src/widgets/gesture_detector.dart
+++ b/packages/flutter/lib/src/widgets/gesture_detector.dart
@@ -400,7 +400,7 @@ class RawGestureDetectorState extends State<RawGestureDetector> {
     _syncAll(gestures);
     if (!config.excludeFromSemantics) {
       RenderSemanticsGestureHandler semanticsGestureHandler = context.findRenderObject();
-      context.visitChildElements((RenderObjectElement element) {
+      context.visitChildElements((Element element) {
         _GestureSemantics widget = element.widget;
         widget._updateHandlers(semanticsGestureHandler, _recognizers);
       });

--- a/packages/flutter_test/lib/src/binding.dart
+++ b/packages/flutter_test/lib/src/binding.dart
@@ -342,7 +342,7 @@ abstract class TestWidgetsFlutterBinding extends BindingBase
           stack: stack,
           context: 'running a test',
           library: 'Flutter test framework',
-          stackFilter: (List<String> frames) {
+          stackFilter: (Iterable<String> frames) {
             return FlutterError.defaultStackFilter(frames.skip(stackLinesToOmit));
           },
           informationCollector: (StringBuffer information) {

--- a/packages/flutter_test/lib/src/controller.dart
+++ b/packages/flutter_test/lib/src/controller.dart
@@ -130,7 +130,7 @@ class WidgetController {
     TestAsyncUtils.guardSync();
     return allElements
            .where((Element element) => element is StatefulElement)
-           .map((StatefulElement element) => element.state);
+           .map((StatefulElement element) => element.state); // ignore: INVALID_CAST_FUNCTION_EXPR, https://github.com/dart-lang/sdk/issues/27827
   }
 
   /// The matching state in the widget tree.


### PR DESCRIPTION
See https://github.com/flutter/flutter/pull/6861

This silences all but two of the warnings from https://travis-ci.org/flutter/flutter/builds/176055550

One of the silenced warnings was a genuine code error.

Some of the others were correct but there was no way for the analyzer to know, and I worked around them.

The remainder are problems with the analyzer, specifically https://github.com/dart-lang/sdk/issues/27827 and https://github.com/dart-lang/sdk/issues/27504.