### PR TITLE
Simplify AppContext and remove many globals

### DIFF
--- a/packages/flutter_tools/lib/executable.dart
+++ b/packages/flutter_tools/lib/executable.dart
@@ -42,6 +42,8 @@ import 'src/globals.dart';
 import 'src/hot.dart';
 import 'src/runner/flutter_command_runner.dart';
 
+Doctor get doctor => context[Doctor];
+
 /// Main entry point for commands.
 ///
 /// This function is intended to be used from the `flutter` command line tool.

--- a/packages/flutter_tools/lib/src/android/android_device.dart
+++ b/packages/flutter_tools/lib/src/android/android_device.dart
@@ -8,6 +8,7 @@ import 'dart:io';
 
 import '../android/android_sdk.dart';
 import '../application_package.dart';
+import '../base/context.dart';
 import '../base/os.dart';
 import '../base/logger.dart';
 import '../base/process.dart';
@@ -19,6 +20,8 @@ import '../protocol_discovery.dart';
 import 'adb.dart';
 import 'android.dart';
 import 'android_sdk.dart';
+
+AndroidSdk get androidSdk => context[AndroidSdk];
 
 const String _defaultAdbPath = 'adb';
 

--- a/packages/flutter_tools/lib/src/android/android_workflow.dart
+++ b/packages/flutter_tools/lib/src/android/android_workflow.dart
@@ -5,10 +5,13 @@
 import 'dart:async';
 import 'dart:io';
 
+import '../base/context.dart';
 import '../base/os.dart';
 import '../doctor.dart';
 import '../globals.dart';
 import 'android_sdk.dart';
+
+AndroidSdk get androidSdk => context[AndroidSdk];
 
 class AndroidWorkflow extends DoctorValidator implements Workflow {
   AndroidWorkflow() : super('Android toolchain - develop for Android devices');

--- a/packages/flutter_tools/lib/src/android/gradle.dart
+++ b/packages/flutter_tools/lib/src/android/gradle.dart
@@ -8,6 +8,7 @@ import 'dart:io';
 import 'package:path/path.dart' as path;
 
 import '../base/common.dart';
+import '../base/context.dart';
 import '../base/logger.dart';
 import '../base/os.dart';
 import '../base/process.dart';
@@ -16,6 +17,8 @@ import '../build_info.dart';
 import '../cache.dart';
 import '../globals.dart';
 import 'android_sdk.dart';
+
+AndroidSdk get androidSdk => context[AndroidSdk];
 
 const String gradleManifestPath = 'android/app/src/main/AndroidManifest.xml';
 const String gradleAppOut = 'android/app/build/outputs/apk/app-debug.apk';

--- a/packages/flutter_tools/lib/src/commands/create.dart
+++ b/packages/flutter_tools/lib/src/commands/create.dart
@@ -9,12 +9,16 @@ import 'package:path/path.dart' as path;
 
 import '../android/android.dart' as android;
 import '../base/common.dart';
+import '../base/context.dart';
 import '../base/utils.dart';
 import '../cache.dart';
 import '../dart/pub.dart';
+import '../doctor.dart';
 import '../globals.dart';
 import '../runner/flutter_command.dart';
 import '../template.dart';
+
+Doctor get doctor => context[Doctor];
 
 class CreateCommand extends FlutterCommand {
   CreateCommand() {

--- a/packages/flutter_tools/lib/src/commands/devices.dart
+++ b/packages/flutter_tools/lib/src/commands/devices.dart
@@ -5,10 +5,15 @@
 import 'dart:async';
 
 import '../base/common.dart';
+import '../base/context.dart';
 import '../base/utils.dart';
 import '../device.dart';
+import '../doctor.dart';
 import '../globals.dart';
 import '../runner/flutter_command.dart';
+
+DeviceManager get deviceManager => context[DeviceManager];
+Doctor get doctor => context[Doctor];
 
 class DevicesCommand extends FlutterCommand {
   @override

--- a/packages/flutter_tools/lib/src/commands/doctor.dart
+++ b/packages/flutter_tools/lib/src/commands/doctor.dart
@@ -4,8 +4,11 @@
 
 import 'dart:async';
 
-import '../globals.dart';
+import '../base/context.dart';
+import '../doctor.dart';
 import '../runner/flutter_command.dart';
+
+Doctor get doctor => context[Doctor];
 
 class DoctorCommand extends FlutterCommand {
   @override

--- a/packages/flutter_tools/lib/src/commands/drive.dart
+++ b/packages/flutter_tools/lib/src/commands/drive.dart
@@ -10,6 +10,7 @@ import '../android/android_device.dart' show AndroidDevice;
 import '../application_package.dart';
 import '../base/file_system.dart';
 import '../base/common.dart';
+import '../base/context.dart';
 import '../base/os.dart';
 import '../base/process.dart';
 import '../build_info.dart';
@@ -22,6 +23,9 @@ import '../ios/simulators.dart' show SimControl, IOSSimulatorUtils;
 import '../resident_runner.dart';
 import 'build_apk.dart' as build_apk;
 import 'run.dart';
+
+
+DeviceManager get deviceManager => context[DeviceManager];
 
 /// Runs integration (a.k.a. end-to-end) tests.
 ///

--- a/packages/flutter_tools/lib/src/commands/setup.dart
+++ b/packages/flutter_tools/lib/src/commands/setup.dart
@@ -5,10 +5,14 @@
 import 'dart:async';
 
 import '../base/common.dart';
+import '../base/context.dart';
 import '../base/os.dart';
 import '../base/process.dart';
+import '../doctor.dart';
 import '../globals.dart';
 import '../runner/flutter_command.dart';
+
+Doctor get doctor => context[Doctor];
 
 /// This setup command will install dependencies necessary for Flutter development.
 ///

--- a/packages/flutter_tools/lib/src/commands/upgrade.dart
+++ b/packages/flutter_tools/lib/src/commands/upgrade.dart
@@ -5,14 +5,18 @@
 import 'dart:async';
 
 import '../base/common.dart';
+import '../base/context.dart';
 import '../base/os.dart';
 import '../base/process.dart';
 import '../dart/pub.dart';
 import '../dart/summary.dart';
 import '../cache.dart';
+import '../doctor.dart';
 import '../globals.dart';
 import '../runner/flutter_command.dart';
 import '../version.dart';
+
+Doctor get doctor => context[Doctor];
 
 class UpgradeCommand extends FlutterCommand {
   @override

--- a/packages/flutter_tools/lib/src/doctor.dart
+++ b/packages/flutter_tools/lib/src/doctor.dart
@@ -9,10 +9,13 @@ import 'package:path/path.dart' as path;
 
 import 'android/android_workflow.dart';
 import 'base/common.dart';
+import 'base/context.dart';
 import 'device.dart';
 import 'globals.dart';
 import 'ios/ios_workflow.dart';
 import 'version.dart';
+
+DeviceManager get deviceManager => context[DeviceManager];
 
 const Map<String, String> _osNames = const <String, String>{
   'macos': 'Mac OS',

--- a/packages/flutter_tools/lib/src/globals.dart
+++ b/packages/flutter_tools/lib/src/globals.dart
@@ -2,22 +2,17 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'android/android_sdk.dart';
 import 'base/config.dart';
 import 'base/context.dart';
 import 'base/logger.dart';
 import 'cache.dart';
-import 'device.dart';
-import 'doctor.dart';
 import 'toolchain.dart';
 import 'usage.dart';
 
-DeviceManager get deviceManager => context[DeviceManager];
 Logger get logger => context[Logger];
-AndroidSdk get androidSdk => context[AndroidSdk];
+
 Cache get cache => Cache.instance;
 Config get config => Config.instance;
-Doctor get doctor => context[Doctor];
 ToolConfiguration get tools => ToolConfiguration.instance;
 Usage get flutterUsage => Usage.instance;
 

--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -7,13 +7,17 @@ import 'dart:convert';
 import 'dart:io';
 
 import '../application_package.dart';
+import '../base/context.dart';
 import '../base/os.dart';
 import '../base/process.dart';
 import '../build_info.dart';
 import '../device.dart';
+import '../doctor.dart';
 import '../globals.dart';
 import '../protocol_discovery.dart';
 import 'mac.dart';
+
+Doctor get doctor => context[Doctor];
 
 const String _ideviceinstallerInstructions =
     'To work with iOS devices, please install ideviceinstaller.\n'

--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -10,14 +10,19 @@ import 'package:meta/meta.dart';
 
 import '../application_package.dart';
 import '../base/common.dart';
+import '../base/context.dart';
 import '../build_info.dart';
 import '../dart/package_map.dart';
 import '../dart/pub.dart';
 import '../device.dart';
+import '../doctor.dart';
 import '../flx.dart' as flx;
 import '../globals.dart';
 import '../usage.dart';
 import 'flutter_command_runner.dart';
+
+DeviceManager get deviceManager => context[DeviceManager];
+Doctor get doctor => context[Doctor];
 
 typedef void Validator();
 

--- a/packages/flutter_tools/lib/src/runner/flutter_command_runner.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command_runner.dart
@@ -14,10 +14,13 @@ import '../base/context.dart';
 import '../base/logger.dart';
 import '../base/process.dart';
 import '../cache.dart';
+import '../device.dart';
 import '../dart/package_map.dart';
 import '../globals.dart';
 import '../toolchain.dart';
 import '../version.dart';
+
+DeviceManager get deviceManager => context[DeviceManager];
 
 const String kFlutterRootEnvironmentVariableName = 'FLUTTER_ROOT'; // should point to //flutter/ (root of flutter/flutter repo)
 const String kFlutterEngineEnvironmentVariableName = 'FLUTTER_ENGINE'; // should point to //engine/src/ (root of flutter/engine repo)

--- a/packages/flutter_tools/lib/src/services.dart
+++ b/packages/flutter_tools/lib/src/services.dart
@@ -9,6 +9,8 @@ import 'dart:io';
 import 'package:path/path.dart' as path;
 import 'package:yaml/yaml.dart';
 
+import 'android/android_sdk.dart';
+import 'base/context.dart';
 import 'dart/package_map.dart';
 import 'globals.dart';
 
@@ -76,6 +78,7 @@ Future<Null> parseServiceConfigs(
 Future<String> getServiceFromUrl(
   String url, String rootDir, String serviceName, { bool unzip: false }
 ) async {
+  AndroidSdk androidSdk = context[AndroidSdk];
   if (url.startsWith("android-sdk:") && androidSdk != null) {
     // It's something shipped in the standard android SDK.
     return url.replaceAll('android-sdk:', '${androidSdk.directory}/');


### PR DESCRIPTION
- [x] Simplify AppContext by moving the current context out of the Zone.
- [x] Always use the stack trace package zone when running.
- [x] Remove many getters from globals.dart

@devoncarew @tvolkert 