### PR TITLE
Allow for application-specific log readers.

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_device.dart
+++ b/packages/flutter_tools/lib/src/android/android_device.dart
@@ -294,6 +294,7 @@ class AndroidDevice extends Device {
     ProtocolDiscovery observatoryDiscovery;
     ProtocolDiscovery diagnosticDiscovery;
 
+    DeviceLogReader logReader = getLogReader();
     if (options.debuggingEnabled) {
       observatoryDiscovery = new ProtocolDiscovery(logReader, ProtocolDiscovery.kObservatoryService);
       diagnosticDiscovery = new ProtocolDiscovery(logReader, ProtocolDiscovery.kDiagnosticService);
@@ -438,14 +439,10 @@ class AndroidDevice extends Device {
     runSync(adbCommandForDevice(<String>['logcat', '-c']));
   }
 
-  // The Android log reader isn't specific to an app.
   @override
-  DeviceLogReader logReaderForApp(_) => logReader;
-
-  @override
-  DeviceLogReader get logReader {
-    if (_logReader == null)
-      _logReader = new _AdbLogReader(this);
+  DeviceLogReader getLogReader({ApplicationPackage app}) {
+    // The Android log reader isn't app-specific.
+    _logReader ??= new _AdbLogReader(this);
     return _logReader;
   }
 
@@ -491,7 +488,7 @@ class AndroidDevice extends Device {
   Future<List<DiscoveredApp>> discoverApps() {
     RegExp discoverExp = new RegExp(r'DISCOVER: (.*)');
     List<DiscoveredApp> result = <DiscoveredApp>[];
-    StreamSubscription<String> logs = logReader.logLines.listen((String line) {
+    StreamSubscription<String> logs = getLogReader().logLines.listen((String line) {
       Match match = discoverExp.firstMatch(line);
       if (match != null) {
         Map<String, dynamic> app = JSON.decode(match.group(1));

--- a/packages/flutter_tools/lib/src/android/android_device.dart
+++ b/packages/flutter_tools/lib/src/android/android_device.dart
@@ -438,6 +438,10 @@ class AndroidDevice extends Device {
     runSync(adbCommandForDevice(<String>['logcat', '-c']));
   }
 
+  // The Android log reader isn't specific to an app.
+  @override
+  DeviceLogReader logReaderForApp(_) => logReader;
+
   @override
   DeviceLogReader get logReader {
     if (_logReader == null)

--- a/packages/flutter_tools/lib/src/commands/drive.dart
+++ b/packages/flutter_tools/lib/src/commands/drive.dart
@@ -303,7 +303,7 @@ Future<int> startApp(DriveCommand command) async {
   // Forward device log messages to the terminal window running the "drive" command.
   command._deviceLogSubscription = command
       .device
-      .logReaderForApp(package)
+      .getLogReader(app: package)
       .logLines
       .listen(printStatus);
 

--- a/packages/flutter_tools/lib/src/commands/drive.dart
+++ b/packages/flutter_tools/lib/src/commands/drive.dart
@@ -301,7 +301,11 @@ Future<int> startApp(DriveCommand command) async {
   printTrace('Starting application.');
 
   // Forward device log messages to the terminal window running the "drive" command.
-  command._deviceLogSubscription = command.device.logReader.logLines.listen(printStatus);
+  command._deviceLogSubscription = command
+      .device
+      .logReaderForApp(package)
+      .logLines
+      .listen(printStatus);
 
   LaunchResult result = await command.device.startApp(
     package,

--- a/packages/flutter_tools/lib/src/commands/logs.dart
+++ b/packages/flutter_tools/lib/src/commands/logs.dart
@@ -41,7 +41,7 @@ class LogsCommand extends FlutterCommand {
     if (argResults['clear'])
       device.clearLogs();
 
-    DeviceLogReader logReader = device.logReader;
+    DeviceLogReader logReader = device.getLogReader();
 
     Cache.releaseLockEarly();
 

--- a/packages/flutter_tools/lib/src/device.dart
+++ b/packages/flutter_tools/lib/src/device.dart
@@ -164,8 +164,11 @@ abstract class Device {
 
   String get sdkNameAndVersion;
 
-  /// Get the log reader for this device.
+  /// Get the global log reader for this device.
   DeviceLogReader get logReader;
+
+  /// Get an app-specifc log reader for this device.
+  DeviceLogReader logReaderForApp(ApplicationPackage app);
 
   /// Get the port forwarder for this device.
   DevicePortForwarder get portForwarder;

--- a/packages/flutter_tools/lib/src/device.dart
+++ b/packages/flutter_tools/lib/src/device.dart
@@ -164,11 +164,10 @@ abstract class Device {
 
   String get sdkNameAndVersion;
 
-  /// Get the global log reader for this device.
-  DeviceLogReader get logReader;
-
-  /// Get an app-specifc log reader for this device.
-  DeviceLogReader logReaderForApp(ApplicationPackage app);
+  /// Get a log reader for this device.
+  /// If [app] is specified, this will return a log reader specific to that
+  /// application. Otherwise, a global log reader will be returned.
+  DeviceLogReader getLogReader({ApplicationPackage app});
 
   /// Get the port forwarder for this device.
   DevicePortForwarder get portForwarder;

--- a/packages/flutter_tools/lib/src/hot.dart
+++ b/packages/flutter_tools/lib/src/hot.dart
@@ -226,7 +226,7 @@ class HotRunner extends ResidentRunner {
 
     Map<String, dynamic> platformArgs = new Map<String, dynamic>();
 
-    await startEchoingDeviceLog();
+    await startEchoingDeviceLog(_package);
 
     printTrace('Launching loader on ${device.name}...');
 

--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -309,7 +309,7 @@ class IOSDevice extends Device {
       int localPort) async {
     Duration stepTimeout = const Duration(seconds: 60);
 
-    Future<int> remote = new ProtocolDiscovery(logReaderForApp(app), serviceName).nextPort();
+    Future<int> remote = new ProtocolDiscovery(getLogReader(app: app), serviceName).nextPort();
 
     int remotePort = await remote.timeout(stepTimeout,
         onTimeout: () {
@@ -378,10 +378,7 @@ class IOSDevice extends Device {
   String get _buildVersion => _getDeviceInfo(id, 'BuildVersion');
 
   @override
-  DeviceLogReader get logReader => logReaderForApp(null);
-
-  @override
-  DeviceLogReader logReaderForApp(ApplicationPackage app) {
+  DeviceLogReader getLogReader({ApplicationPackage app}) {
     _logReaders ??= <ApplicationPackage, _IOSDeviceLogReader>{};
     return _logReaders.putIfAbsent(app, () => new _IOSDeviceLogReader(this, app));
   }

--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:collection';
 import 'dart:convert';
 import 'dart:io';
 
@@ -75,7 +74,7 @@ class IOSDevice extends Device {
   @override
   final String name;
 
-  HashMap<ApplicationPackage, _IOSDeviceLogReader> _logReaders;
+  Map<ApplicationPackage, _IOSDeviceLogReader> _logReaders;
 
   _IOSDevicePortForwarder _portForwarder;
 
@@ -383,7 +382,7 @@ class IOSDevice extends Device {
 
   @override
   DeviceLogReader logReaderForApp(ApplicationPackage app) {
-    _logReaders ??= new HashMap<ApplicationPackage, _IOSDeviceLogReader>();
+    _logReaders ??= <ApplicationPackage, _IOSDeviceLogReader>{};
     return _logReaders.putIfAbsent(app, () => new _IOSDeviceLogReader(this, app));
   }
 
@@ -426,7 +425,7 @@ class _IOSDeviceLogReader extends DeviceLogReader {
     // iOS 9 format:  Runner[297] <Notice>:
     // iOS 10 format: Runner(libsystem_asl.dylib)[297] <Notice>:
     String appName = app == null ? '' : app.name.replaceAll('.app', '');
-    _lineRegex = new RegExp(r'${appName}(\(.*\))?\[[\d]+\] <[A-Za-z]+>: ');
+    _lineRegex = new RegExp(appName + r'(\(.*\))?\[[\d]+\] <[A-Za-z]+>: ');
   }
 
   final IOSDevice device;

--- a/packages/flutter_tools/lib/src/ios/simulators.dart
+++ b/packages/flutter_tools/lib/src/ios/simulators.dart
@@ -431,7 +431,7 @@ class IOSSimulator extends Device {
     ProtocolDiscovery observatoryDiscovery;
 
     if (debuggingOptions.debuggingEnabled)
-      observatoryDiscovery = new ProtocolDiscovery(logReaderForApp(app),
+      observatoryDiscovery = new ProtocolDiscovery(getLogReader(app: app),
                                                    ProtocolDiscovery.kObservatoryService);
 
     // Prepare launch arguments.
@@ -555,10 +555,7 @@ class IOSSimulator extends Device {
   String get sdkNameAndVersion => category;
 
   @override
-  DeviceLogReader get logReader => logReaderForApp(null);
-
-  @override
-  DeviceLogReader logReaderForApp(ApplicationPackage app) {
+  DeviceLogReader getLogReader({ApplicationPackage app}) {
     _logReaders ??= <ApplicationPackage, _IOSSimulatorLogReader>{};
     return _logReaders.putIfAbsent(app, () => new _IOSSimulatorLogReader(this, app));
   }

--- a/packages/flutter_tools/lib/src/ios/simulators.dart
+++ b/packages/flutter_tools/lib/src/ios/simulators.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:collection';
 import 'dart:convert';
 import 'dart:io';
 import 'dart:math' as math;
@@ -316,7 +315,7 @@ class IOSSimulator extends Device {
   @override
   bool get supportsHotMode => true;
 
-  HashMap<ApplicationPackage, _IOSSimulatorLogReader> _logReaders;
+  Map<ApplicationPackage, _IOSSimulatorLogReader> _logReaders;
   _IOSSimulatorDevicePortForwarder _portForwarder;
 
   String get xcrunPath => path.join('/usr', 'bin', 'xcrun');
@@ -560,7 +559,7 @@ class IOSSimulator extends Device {
 
   @override
   DeviceLogReader logReaderForApp(ApplicationPackage app) {
-    _logReaders ??= new HashMap<ApplicationPackage, _IOSSimulatorLogReader>();
+    _logReaders ??= <ApplicationPackage, _IOSSimulatorLogReader>{};
     return _logReaders.putIfAbsent(app, () => new _IOSSimulatorLogReader(this, app));
   }
 

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -8,6 +8,7 @@ import 'dart:io';
 import 'package:meta/meta.dart';
 import 'package:path/path.dart' as path;
 
+import 'application_package.dart';
 import 'base/logger.dart';
 import 'build_info.dart';
 import 'device.dart';

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -96,11 +96,11 @@ abstract class ResidentRunner {
     });
   }
 
-  Future<Null> startEchoingDeviceLog() async {
+  Future<Null> startEchoingDeviceLog(ApplicationPackage app) async {
     if (_loggingSubscription != null) {
       return;
     }
-    _loggingSubscription = device.logReader.logLines.listen((String line) {
+    _loggingSubscription = device.logReaderForApp(app).logLines.listen((String line) {
       if (!line.contains('Observatory listening on http') &&
           !line.contains('Diagnostic server listening on http'))
         printStatus(line);

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -101,7 +101,7 @@ abstract class ResidentRunner {
     if (_loggingSubscription != null) {
       return;
     }
-    _loggingSubscription = device.logReaderForApp(app).logLines.listen((String line) {
+    _loggingSubscription = device.getLogReader(app: app).logLines.listen((String line) {
       if (!line.contains('Observatory listening on http') &&
           !line.contains('Diagnostic server listening on http'))
         printStatus(line);

--- a/packages/flutter_tools/lib/src/run.dart
+++ b/packages/flutter_tools/lib/src/run.dart
@@ -119,7 +119,7 @@ class RunAndStayResident extends ResidentRunner {
     if (traceStartup != null)
       platformArgs = <String, dynamic>{ 'trace-startup': traceStartup };
 
-    await startEchoingDeviceLog();
+    await startEchoingDeviceLog(_package);
     if (_mainPath == null) {
       assert(prebuiltMode);
       printStatus('Running ${_package.displayName} on ${device.name}');


### PR DESCRIPTION
When running with prebuilt application binaries, those applications
aren't guaranteed to be named "Runner" (as it is when we build
the app locally in Flutter tools).