### PR TITLE
Bump `json_schema` version.

### DIFF
--- a/packages/flutter_tools/pubspec.yaml
+++ b/packages/flutter_tools/pubspec.yaml
@@ -15,10 +15,7 @@ dependencies:
   file: ^0.1.0
   http: ^0.11.3
   json_rpc_2: ^2.0.0
-
-  # Versions 1.0.4 and below have duplicate pubspec map entries and will fail the build.
-  json_schema: 1.0.5
-
+  json_schema: 1.0.6
   linter: ^0.1.21
   meta: ^1.0.3
   mustache: ^0.2.5


### PR DESCRIPTION
Fixes the `package:drudge` spam.

\o/

See: #6840

/cc @Hixie @abarth 