### PR TITLE
Add dense layout support to dropdown

### DIFF
--- a/packages/flutter/lib/src/material/drop_down.dart
+++ b/packages/flutter/lib/src/material/drop_down.dart
@@ -406,8 +406,7 @@ class DropdownButtonHideUnderline extends InheritedWidget {
 ///
 ///  * [DropdownButtonHideUnderline], which prevents its descendant drop down buttons
 ///    from displaying their underlines.
-///  * [RaisedButton]
-///  * [FlatButton]
+///  * [RaisedButton], [FlatButton], ordinary buttons that trigger a single action.
 ///  * <https://material.google.com/components/buttons.html#buttons-dropdown-buttons>
 class DropdownButton<T> extends StatefulWidget {
   /// Creates a dropdown button.

--- a/packages/flutter/test/material/drop_down_test.dart
+++ b/packages/flutter/test/material/drop_down_test.dart
@@ -7,33 +7,57 @@ import 'dart:math' as math;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/material.dart';
 
+Widget buildFrame({ Key buttonKey, String value: 'two',  ValueChanged<String> onChanged, bool isDense: false }) {
+  final List<String> items = <String>['one', 'two', 'three', 'four'];
+  return new MaterialApp(
+    home: new Material(
+      child: new Center(
+        child: new DropdownButton<String>(
+          key: buttonKey,
+          value: value,
+          onChanged: onChanged,
+          isDense: isDense,
+          items: items.map((String item) {
+            return new DropdownMenuItem<String>(
+              key: new ValueKey<String>(item),
+              value: item,
+              child: new Text(item, key: new ValueKey<String>(item + "Text")),
+            );
+          }).toList(),
+        ),
+      ),
+    ),
+  );
+}
+
+// When the dropdown's menu is popped up, a RenderParagraph for the selected
+// menu's text item will appear both in the dropdown button and in the menu.
+// The RenderParagraphs should be aligned, i.e. they should have the same
+// size and location.
+void checkSelectedItemTextGeometry(WidgetTester tester, String value) {
+  final List<RenderBox> boxes = tester.renderObjectList(find.byKey(new ValueKey<String>(value + 'Text'))).toList();
+  expect(boxes.length, equals(2));
+  final RenderBox box0 = boxes[0];
+  final RenderBox box1 = boxes[1];
+  expect(box0.localToGlobal(Point.origin), equals(box1.localToGlobal(Point.origin)));
+  expect(box0.size, equals(box1.size));
+}
+
+bool sameGeometry(RenderBox box1, RenderBox box2) {
+  expect(box1.localToGlobal(Point.origin), equals(box2.localToGlobal(Point.origin)));
+  expect(box1.size.height, equals(box2.size.height));
+  return true;
+}
+
+
 void main() {
   testWidgets('Drop down button control test', (WidgetTester tester) async {
-    List<String> items = <String>['one', 'two', 'three', 'four'];
-    String value = items.first;
-
+    String value = 'one';
     void didChangeValue(String newValue) {
       value = newValue;
     }
 
-    Widget build() {
-      return new MaterialApp(
-        home: new Material(
-          child: new Center(
-            child: new DropdownButton<String>(
-              value: value,
-              items: items.map((String item) {
-                return new DropdownMenuItem<String>(
-                  value: item,
-                  child: new Text(item),
-                );
-              }).toList(),
-              onChanged: didChangeValue,
-            ),
-          ),
-        ),
-      );
-    }
+    Widget build() => buildFrame(value: value, onChanged: didChangeValue);
 
     await tester.pumpWidget(build());
 
@@ -67,9 +91,7 @@ void main() {
   });
 
   testWidgets('Drop down button with no app', (WidgetTester tester) async {
-    List<String> items = <String>['one', 'two', 'three', 'four'];
-    String value = items.first;
-
+    String value = 'one';
     void didChangeValue(String newValue) {
       value = newValue;
     }
@@ -82,18 +104,7 @@ void main() {
             settings: settings,
             builder: (BuildContext context) {
               return new Material(
-                child: new Center(
-                  child: new DropdownButton<String>(
-                    value: value,
-                    items: items.map((String item) {
-                      return new DropdownMenuItem<String>(
-                        value: item,
-                        child: new Text(item),
-                      );
-                    }).toList(),
-                    onChanged: didChangeValue,
-                  ),
-                )
+                child: buildFrame(value: 'one', onChanged: didChangeValue),
               );
             },
           );
@@ -186,37 +197,21 @@ void main() {
 
   testWidgets('Drop down button aligns selected menu item', (WidgetTester tester) async {
     Key buttonKey = new UniqueKey();
-    List<String> items = <String>['one', 'two', 'wide three', 'four'];
     String value = 'two';
 
-    Widget build() {
-      return new MaterialApp(
-        home: new Material(
-          child: new Center(
-            child: new DropdownButton<String>(
-              key: buttonKey,
-              value: value,
-              onChanged: (String value) { },
-              items: items.map((String item) {
-                return new DropdownMenuItem<String>(
-                  key: new ValueKey<String>(item),
-                  value: item,
-                  child: new Text(item),
-                );
-              }).toList(),
-            ),
-          ),
-        ),
-      );
-    }
+    Widget build() => buildFrame(buttonKey: buttonKey, value: value);
 
     await tester.pumpWidget(build());
     RenderBox buttonBox = tester.renderObject(find.byKey(buttonKey));
     assert(buttonBox.attached);
+    Point buttonOriginBeforeTap = buttonBox.localToGlobal(Point.origin);
 
     await tester.tap(find.text('two'));
     await tester.pump();
     await tester.pump(const Duration(seconds: 1)); // finish the menu animation
+
+    // Tapping the dropdown button should not cause it to move.
+    expect(buttonBox.localToGlobal(Point.origin), equals(buttonOriginBeforeTap));
 
     // The selected dropdown item is both in menu we just popped up, and in
     // the IndexedStack contained by the dropdown button. Both of them should
@@ -229,34 +224,16 @@ void main() {
       expect(buttonBox.size.height, equals(itemBox.size.height));
     }
 
+    // The two RenderParagraph objects, for the 'two' items' Text children,
+    // should have the same size and location.
+    checkSelectedItemTextGeometry(tester, 'two');
   });
 
   testWidgets('Drop down button with isDense:true aligns selected menu item', (WidgetTester tester) async {
     Key buttonKey = new UniqueKey();
-    List<String> items = <String>['one', 'two', 'three', 'four'];
     String value = 'two';
 
-    Widget build() {
-      return new MaterialApp(
-        home: new Material(
-          child: new Center(
-            child: new DropdownButton<String>(
-              key: buttonKey,
-              value: value,
-              onChanged: (String value) { },
-              isDense: true,
-              items: items.map((String item) {
-                return new DropdownMenuItem<String>(
-                  key: new ValueKey<String>(item),
-                  value: item,
-                  child: new Text(item),
-                );
-              }).toList(),
-            ),
-          ),
-        ),
-      );
-    }
+    Widget build() => buildFrame(buttonKey: buttonKey, value: value, isDense: true);
 
     await tester.pumpWidget(build());
     RenderBox buttonBox = tester.renderObject(find.byKey(buttonKey));
@@ -284,5 +261,8 @@ void main() {
       expect(buttonBoxCenter.y, equals(itemBoxCenter.y));
     }
 
+    // The two RenderParagraph objects, for the 'two' items' Text children,
+    // should have the same size and location.
+    checkSelectedItemTextGeometry(tester, 'two');
   });
 }


### PR DESCRIPTION
Added an isDense flag to DropdownButton to reduce the vertical size of the button. 

By default DropDownButtons have the same height as their menu items, which is 48.0 per the material design spec.  Specifying `isDense: true` causes the button's height to be 24. This is useful for layouts that embed dropdowns in other decorated widgets, like InputContainers.

See #6604


