### PR TITLE
Changed vm_service_client version back to 0.2.2+2

### DIFF
--- a/dev/devicelab/pubspec.yaml
+++ b/dev/devicelab/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   meta: ^1.0.3
   path: ^1.3.0
   stack_trace: ^1.4.0
-  vm_service_client: '0.2.2+2'
+  vm_service_client: '0.2.2+2' // TODO(yegor): use the latest version
 
 dev_dependencies:
   # See packages/flutter_test/pubspec.yaml for why we're pinning this version.

--- a/dev/devicelab/pubspec.yaml
+++ b/dev/devicelab/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   meta: ^1.0.3
   path: ^1.3.0
   stack_trace: ^1.4.0
-  vm_service_client: '0.2.2+2' // TODO(yegor): use the latest version
+  vm_service_client: '0.2.2+2' # TODO(yegor): use the latest version
 
 dev_dependencies:
   # See packages/flutter_test/pubspec.yaml for why we're pinning this version.

--- a/dev/devicelab/pubspec.yaml
+++ b/dev/devicelab/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   meta: ^1.0.3
   path: ^1.3.0
   stack_trace: ^1.4.0
-  vm_service_client: '^0.2.0'
+  vm_service_client: '0.2.2+2'
 
 dev_dependencies:
   # See packages/flutter_test/pubspec.yaml for why we're pinning this version.

--- a/packages/flutter_driver/pubspec.yaml
+++ b/packages/flutter_driver/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   matcher: '>=0.12.0 <1.0.0'
   path: '^1.3.0'
   web_socket_channel: '^1.0.0'
-  vm_service_client: '0.2.2+2'
+  vm_service_client: '0.2.2+2' // TODO(yegor): use the latest version
   flutter:
     sdk: flutter
   flutter_test:

--- a/packages/flutter_driver/pubspec.yaml
+++ b/packages/flutter_driver/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   matcher: '>=0.12.0 <1.0.0'
   path: '^1.3.0'
   web_socket_channel: '^1.0.0'
-  vm_service_client: '^0.2.0'
+  vm_service_client: '0.2.2+2'
   flutter:
     sdk: flutter
   flutter_test:

--- a/packages/flutter_driver/pubspec.yaml
+++ b/packages/flutter_driver/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   matcher: '>=0.12.0 <1.0.0'
   path: '^1.3.0'
   web_socket_channel: '^1.0.0'
-  vm_service_client: '0.2.2+2' // TODO(yegor): use the latest version
+  vm_service_client: '0.2.2+2' # TODO(yegor): use the latest version
   flutter:
     sdk: flutter
   flutter_test:

--- a/packages/flutter_tools/pubspec.yaml
+++ b/packages/flutter_tools/pubspec.yaml
@@ -24,6 +24,7 @@ dependencies:
   pub_semver: ^1.0.0
   stack_trace: ^1.4.0
   usage: ^2.2.1
+  vm_service_client: '0.2.2+2' # TODO(yegor): use the latest version
   web_socket_channel: ^1.0.4
   xml: ^2.4.1
   yaml: ^2.1.3


### PR DESCRIPTION
The latest version, 0.2.2+3, caused travis failures (https://pub.dartlang.org/packages/vm_service_client)

Swan song on Travis was:

```
+cd dev/devicelab
+dart -c test/all.dart
00:00 +0: device isAwake/isAsleep reads Awake
...
00:00 +19: manifest parser missing stage
00:00 +20: run.dart script exits with code 0 when succeeds
00:02 +20 -1: run.dart script exits with code 0 when succeeds
  Expected: <0>
    Actual: <1>

  package:test             expect
  test/run_test.dart 25:7  main.<fn>.<fn>.<async>
  ===== asynchronous gap ===========================
  dart:async               _Completer.completeError
  test/run_test.dart 26:6  main.<fn>.<fn>.<async>
  ===== asynchronous gap ===========================
  dart:async               _asyncThenWrapperHelper
  test/run_test.dart       main.<fn>.<fn>
```
