### PR TITLE
Drop dependency on http since it doesn't work when building for Fuchsia

### DIFF
--- a/packages/flutter_tools/BUILD.gn
+++ b/packages/flutter_tools/BUILD.gn
@@ -16,7 +16,8 @@ dart_package("flutter_tools") {
     "//third_party/dart-pkg/pub/coverage",
     "//third_party/dart-pkg/pub/crypto",
     "//third_party/dart-pkg/pub/file",
-    "//third_party/dart-pkg/pub/http",
+    # The HTTP dependency is removed because http doesn't work on Fuchsia
+    # because it uses mirrors which Fuchsia's Dart VM doesn't support.
     "//third_party/dart-pkg/pub/json_rpc_2",
     "//third_party/dart-pkg/pub/json_schema",
     "//third_party/dart-pkg/pub/linter",


### PR DESCRIPTION
We're getting rid of the http package from third_party/dart-pkg/