### PR TITLE
Add a dependency on sky_engine on Fuchsia.

### DIFF
--- a/packages/flutter/BUILD.gn
+++ b/packages/flutter/BUILD.gn
@@ -17,4 +17,8 @@ dart_package("flutter") {
     "//third_party/dart-pkg/pub/meta",
     "//third_party/dart-pkg/pub/vector_math",
   ]
+
+  if (is_fuchsia) {
+    deps += [ "//flutter/sky/packages/sky_engine:sky_engine_dart" ]
+  }
 }


### PR DESCRIPTION
This allows us to run the analyzer CLI on packages and correctly find dart:ui.