### PR TITLE
Add CrossDart links to the generated docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .idea
+crossdart.json

--- a/dev/bots/docs.sh
+++ b/dev/bots/docs.sh
@@ -6,6 +6,8 @@ set -e
 # so are we pinned to this old version until that bug is fixed.
 pub global activate dartdoc 0.9.7+1
 
+pub global activate crossdart
+
 # This script generates a unified doc set, and creates
 # a custom index.html, placing everything into dev/docs/doc
 (cd dev/tools; pub get)

--- a/dev/tools/dartdoc.dart
+++ b/dev/tools/dartdoc.dart
@@ -23,6 +23,23 @@ Future<Null> main(List<String> args) async {
   if (path.basename(Directory.current.path) == 'tools')
     Directory.current = Directory.current.parent.parent;
 
+  // Generate crossdart.json files for all the packages. If fails - ignore
+  // and proceed
+  for (String package in findPackageNames()) {
+    List<String> args = [
+        "global", "run", "crossdart",
+        "--input", path.join(Directory.current.path, "packages", package),
+        "--output", path.join(Directory.current.path, "packages", package),
+        "--hosted-url", "https://www.crossdart.info",
+        "--url-path-prefix", "p",
+        "--output-format", "json",
+        "--dart-sdk", path.join(Directory.current.path, "bin/cache/dart-sdk")];
+    Process crossdartProcess = await Process.start("pub", args);
+    printStream(crossdartProcess.stdout);
+    printStream(crossdartProcess.stderr);
+    await crossdartProcess.exitCode;
+  }
+
   // Create the pubspec.yaml file.
   StringBuffer buf = new StringBuffer('''
 name: Flutter
@@ -65,6 +82,7 @@ dependencies:
     '--dart-sdk', '../../bin/cache/dart-sdk',
     '--exclude', 'temp_doc',
     '--favicon=favicon.ico',
+    '--add-crossdart',
     '--use-categories'
   ];
 


### PR DESCRIPTION
Ticket: https://github.com/flutter/flutter/issues/125819
Depends on: https://github.com/dart-lang/dartdoc/pull/1277

We run `pub global run crossdart` for every flutter package, that puts
`crossdart.json` files to the package roots. Then, we use new version of
dartdoc, and run the doc generation just as before. That new version of
dartdoc will know how to find those `crossdart.json` files in those
package roots, and will augment the docs with the CrossDart links in the
source snippets.