### PR TITLE
Skip failing input tests

### DIFF
--- a/packages/flutter/test/widgets/input_test.dart
+++ b/packages/flutter/test/widgets/input_test.dart
@@ -591,7 +591,7 @@ void main() {
     await tester.pumpWidget(builder());
     expect(inputValue.selection.isCollapsed, true);
     expect(inputValue.text, cutValue);
-  });
+  }, skip: true); // Skipped due to https://github.com/flutter/flutter/issues/6961
 
   testWidgets('Can scroll multiline input', (WidgetTester tester) async {
     GlobalKey inputKey = new GlobalKey();
@@ -688,7 +688,7 @@ void main() {
     expect(newFirstPos.y, firstPos.y);
     expect(inputBox.hitTest(new HitTestResult(), position: inputBox.globalToLocal(newFirstPos)), isTrue);
     expect(inputBox.hitTest(new HitTestResult(), position: inputBox.globalToLocal(newFourthPos)), isFalse);
-  });
+  }, skip: true); // Skip due to https://github.com/flutter/flutter/issues/6961
 
   testWidgets('InputField smoke test', (WidgetTester tester) async {
     InputValue inputValue = InputValue.empty;

--- a/packages/flutter/test/widgets/input_test.dart
+++ b/packages/flutter/test/widgets/input_test.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/material.dart';
@@ -591,7 +592,8 @@ void main() {
     await tester.pumpWidget(builder());
     expect(inputValue.selection.isCollapsed, true);
     expect(inputValue.text, cutValue);
-  }, skip: true); // Skipped due to https://github.com/flutter/flutter/issues/6961
+  }, skip: Platform.isMacOS); // Skip due to https://github.com/flutter/flutter/issues/6961
+
 
   testWidgets('Can scroll multiline input', (WidgetTester tester) async {
     GlobalKey inputKey = new GlobalKey();
@@ -688,7 +690,7 @@ void main() {
     expect(newFirstPos.y, firstPos.y);
     expect(inputBox.hitTest(new HitTestResult(), position: inputBox.globalToLocal(newFirstPos)), isTrue);
     expect(inputBox.hitTest(new HitTestResult(), position: inputBox.globalToLocal(newFourthPos)), isFalse);
-  }, skip: true); // Skip due to https://github.com/flutter/flutter/issues/6961
+  }, skip: Platform.isMacOS); // Skip due to https://github.com/flutter/flutter/issues/6961
 
   testWidgets('InputField smoke test', (WidgetTester tester) async {
     InputValue inputValue = InputValue.empty;

--- a/packages/flutter/test/widgets/scrollable_fling_test.dart
+++ b/packages/flutter/test/widgets/scrollable_fling_test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:io';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/material.dart';
 
@@ -80,7 +82,7 @@ void main() {
     await tester.tap(find.byType(Scrollable));
     await tester.pump(const Duration(milliseconds: 50));
     expect(log, equals(<String>['tap 18', 'tap 31']));
-  }, skip: true); // Skipped due to https://github.com/flutter/flutter/issues/6961
+  }, skip: Platform.isMacOS); // Skip due to https://github.com/flutter/flutter/issues/6961
 
   testWidgets('fling and wait and tap', (WidgetTester tester) async {
     List<String> log = <String>[];
@@ -102,5 +104,5 @@ void main() {
     await tester.tap(find.byType(Scrollable));
     await tester.pump(const Duration(milliseconds: 50));
     expect(log, equals(<String>['tap 18', 'tap 43']));
-  }, skip: true); // Skipped due to https://github.com/flutter/flutter/issues/6961
+  }, skip: Platform.isMacOS); // Skip due to https://github.com/flutter/flutter/issues/6961
 }

--- a/packages/flutter/test/widgets/scrollable_fling_test.dart
+++ b/packages/flutter/test/widgets/scrollable_fling_test.dart
@@ -80,7 +80,7 @@ void main() {
     await tester.tap(find.byType(Scrollable));
     await tester.pump(const Duration(milliseconds: 50));
     expect(log, equals(<String>['tap 18', 'tap 31']));
-  });
+  }, skip: true); // Skipped due to https://github.com/flutter/flutter/issues/6961
 
   testWidgets('fling and wait and tap', (WidgetTester tester) async {
     List<String> log = <String>[];
@@ -102,5 +102,5 @@ void main() {
     await tester.tap(find.byType(Scrollable));
     await tester.pump(const Duration(milliseconds: 50));
     expect(log, equals(<String>['tap 18', 'tap 43']));
-  });
+  }, skip: true); // Skipped due to https://github.com/flutter/flutter/issues/6961
 }


### PR DESCRIPTION
@Hixie This disables the input tests that are failing on OS X (https://github.com/flutter/flutter/issues/6961).

Disabling other tests in a follow on PR.