### PR TITLE
update .analysis_options

### DIFF
--- a/.analysis_options
+++ b/.analysis_options
@@ -21,7 +21,6 @@ analyzer:
     # allow overriding fields (if they use super, ideally...)
     strong_mode_invalid_field_override: ignore
     # allow type narrowing
-    strong_mode_static_type_error: ignore
     strong_mode_down_cast_composite: ignore
     # allow having TODOs in the code
     todo: ignore

--- a/.analysis_options_repo
+++ b/.analysis_options_repo
@@ -22,7 +22,6 @@ analyzer:
     # allow overriding fields (if they use super, ideally...)
     strong_mode_invalid_field_override: ignore
     # allow type narrowing
-    strong_mode_static_type_error: ignore
     strong_mode_down_cast_composite: ignore
     # allow having TODOs in the code
     todo: ignore

--- a/.analysis_options_user
+++ b/.analysis_options_user
@@ -23,7 +23,6 @@ analyzer:
     # allow overriding fields (if they use super, ideally...)
     strong_mode_invalid_field_override: ignore
     # allow type narrowing
-    strong_mode_static_type_error: ignore
     strong_mode_down_cast_composite: ignore
     # allow having TODOs in the code
     todo: ignore


### PR DESCRIPTION
`strong_mode_static_type_error` looks unused, and running analysis locally, I don't see any warnings that it's suppressing.

@danrubel @pq @Hixie 