### PR TITLE
Add testOutputsDirectory to flutter_drive

### DIFF
--- a/packages/flutter_driver/lib/flutter_driver.dart
+++ b/packages/flutter_driver/lib/flutter_driver.dart
@@ -11,6 +11,9 @@
 /// Protractor (Angular), Espresso (Android) or Earl Gray (iOS).
 library flutter_driver;
 
+export 'src/common.dart' show
+  testOutputsDirectory;
+
 export 'src/driver.dart' show
   find,
   CommonFinders,

--- a/packages/flutter_driver/lib/src/common.dart
+++ b/packages/flutter_driver/lib/src/common.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:io' show Platform;
+
 import 'package:file/file.dart';
 import 'package:file/io.dart';
 
@@ -20,3 +22,10 @@ void useMemoryFileSystemForTesting() {
 void restoreFileSystem() {
   fs = new LocalFileSystem();
 }
+
+/// Flutter Driver test ouputs directory.
+///
+/// Tests should write any output files to this directory. Defaults to the path
+/// set in the FLUTTER_TEST_OUTPUTS_DIR environment variable, or `build` if
+/// unset.
+String get testOutputsDirectory => Platform.environment['FLUTTER_TEST_OUTPUTS_DIR'] ?? 'build';

--- a/packages/flutter_driver/lib/src/timeline_summary.dart
+++ b/packages/flutter_driver/lib/src/timeline_summary.dart
@@ -12,7 +12,6 @@ import 'package:path/path.dart' as path;
 import 'common.dart';
 import 'timeline.dart';
 
-const String _kDefaultDirectory = 'build';
 final JsonEncoder _prettyEncoder = new JsonEncoder.withIndent('  ');
 
 /// The maximum amount of time considered safe to spend for a frame's build
@@ -88,7 +87,8 @@ class TimelineSummary {
 
   /// Writes all of the recorded timeline data to a file.
   Future<Null> writeTimelineToFile(String traceName,
-      {String destinationDirectory: _kDefaultDirectory, bool pretty: false}) async {
+      {String destinationDirectory, bool pretty: false}) async {
+    destinationDirectory ??= testOutputsDirectory;
     await fs.directory(destinationDirectory).create(recursive: true);
     File file = fs.file(path.join(destinationDirectory, '$traceName.timeline.json'));
     await file.writeAsString(_encodeJson(_timeline.json, pretty));
@@ -96,7 +96,8 @@ class TimelineSummary {
 
   /// Writes [summaryJson] to a file.
   Future<Null> writeSummaryToFile(String traceName,
-      {String destinationDirectory: _kDefaultDirectory, bool pretty: false}) async {
+      {String destinationDirectory, bool pretty: false}) async {
+    destinationDirectory ??= testOutputsDirectory;
     await fs.directory(destinationDirectory).create(recursive: true);
     File file = fs.file(path.join(destinationDirectory, '$traceName.timeline_summary.json'));
     await file.writeAsString(_encodeJson(summaryJson, pretty));


### PR DESCRIPTION
Declares a top-level getter that returns the outputs directory to which
Flutter Driver tests can write any output files. Timeline data defaults
to this directory.