### PR TITLE
pass through the ws debugging uri

### DIFF
--- a/packages/flutter_tools/lib/src/commands/daemon.dart
+++ b/packages/flutter_tools/lib/src/commands/daemon.dart
@@ -358,7 +358,10 @@ class AppDomain extends Domain {
     if (options.debuggingEnabled) {
       connectionInfoCompleter = new Completer<DebugConnectionInfo>();
       connectionInfoCompleter.future.then((DebugConnectionInfo info) {
-        Map<String, dynamic> params = <String, dynamic>{ 'port': info.port };
+        Map<String, dynamic> params = <String, dynamic>{
+          'port': info.port,
+          'wsUri': info.wsUri
+        };
         if (info.baseUri != null)
           params['baseUri'] = info.baseUri;
         _sendAppEvent(app, 'debugPort', params);

--- a/packages/flutter_tools/lib/src/hot.dart
+++ b/packages/flutter_tools/lib/src/hot.dart
@@ -237,7 +237,11 @@ class HotRunner extends ResidentRunner {
       Uri baseUri = await _initDevFS();
       if (connectionInfoCompleter != null) {
         connectionInfoCompleter.complete(
-          new DebugConnectionInfo(_observatoryPort, baseUri: baseUri.toString())
+          new DebugConnectionInfo(
+            port: _observatoryPort,
+            wsUri: 'ws://localhost:$_observatoryPort/ws',
+            baseUri: baseUri.toString()
+          )
         );
       }
     } catch (error) {

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -271,8 +271,9 @@ String getMissingPackageHintForPlatform(TargetPlatform platform) {
 }
 
 class DebugConnectionInfo {
-  DebugConnectionInfo(this.port, { this.baseUri });
+  DebugConnectionInfo({ this.port, this.wsUri, this.baseUri });
 
   final int port;
+  final String wsUri;
   final String baseUri;
 }

--- a/packages/flutter_tools/lib/src/run.dart
+++ b/packages/flutter_tools/lib/src/run.dart
@@ -119,8 +119,13 @@ class RunAndStayResident extends ResidentRunner {
 
     startTime.stop();
 
-    if (_result.hasObservatory)
-      connectionInfoCompleter?.complete(new DebugConnectionInfo(_result.observatoryPort));
+    if (_result.hasObservatory) {
+      int port = _result.observatoryPort;
+      connectionInfoCompleter?.complete(new DebugConnectionInfo(
+        port: port,
+        wsUri: 'ws://localhost:$port/ws'
+      ));
+    }
 
     // Connect to observatory.
     if (debuggingOptions.debuggingEnabled) {


### PR DESCRIPTION
@danrubel, this passes the ws: debugging url through the daemon protocol; it maintains the port info as well so that clients have a grace period to adapt.