### PR TITLE
Report why a snackbar was closed

### DIFF
--- a/packages/flutter/lib/src/material/scaffold.dart
+++ b/packages/flutter/lib/src/material/scaffold.dart
@@ -50,40 +50,6 @@ enum AppBarBehavior {
   under,
 }
 
-/// Specify how a [SnackBar] was closed.
-///
-/// The [showSnackBar] function returns a [ScaffoldFeatureController]. The value
-/// of the controller's closed property is a Future that resolves to a
-/// SnackBarClosedReason. Applications that need to now how a snackbar
-/// was closed can use this value.
-///
-/// Example:
-///
-/// ```dart
-/// Scaffold.of(context).showSnackBar(
-///   new SnackBar( ... )
-/// ).closed.then((SnackBarClosedReason reason) {
-///    ...
-/// });
-/// ```
-enum SnackBarClosedReason {
-  /// The snack bar was closed after the user tapped a [SnackBarAction].
-  action,
-
-  /// The snack bar was closed by a user's swipe.
-  swipe,
-
-  /// The snack bar was closed by the [ScaffoldFeatureController] close callback
-  /// or by calling [hideCurrentSnackBar] directly.
-  hide,
-
-  /// The snack bar was closed by an called to [removeCurrentSnackBar].
-  remove,
-
-  /// The snack bar was closed because its timer expired.
-  timeout,
-}
-
 enum _ScaffoldSlot {
   body,
   appBar,

--- a/packages/flutter/lib/src/material/snack_bar.dart
+++ b/packages/flutter/lib/src/material/snack_bar.dart
@@ -77,6 +77,7 @@ class _SnackBarActionState extends State<SnackBarAction> {
       _haveTriggeredAction = true;
     });
     config.onPressed();
+    Scaffold.of(context).hideCurrentSnackBar(reason: SnackBarClosedReason.action);
   }
 
   @override
@@ -201,7 +202,7 @@ class SnackBar extends StatelessWidget {
             direction: DismissDirection.down,
             resizeDuration: null,
             onDismissed: (DismissDirection direction) {
-              Scaffold.of(context).removeCurrentSnackBar();
+              Scaffold.of(context).removeCurrentSnackBar(reason: SnackBarClosedReason.swipe);
             },
             child: new Material(
               elevation: 6,

--- a/packages/flutter/lib/src/material/snack_bar.dart
+++ b/packages/flutter/lib/src/material/snack_bar.dart
@@ -30,6 +30,40 @@ const Duration _kSnackBarDisplayDuration = const Duration(milliseconds: 1500);
 const Curve _snackBarHeightCurve = Curves.fastOutSlowIn;
 const Curve _snackBarFadeCurve = const Interval(0.72, 1.0, curve: Curves.fastOutSlowIn);
 
+/// Specify how a [SnackBar] was closed.
+///
+/// The [showSnackBar] function returns a [ScaffoldFeatureController]. The value
+/// of the controller's closed property is a Future that resolves to a
+/// SnackBarClosedReason. Applications that need to know how a snackbar
+/// was closed can use this value.
+///
+/// Example:
+///
+/// ```dart
+/// Scaffold.of(context).showSnackBar(
+///   new SnackBar( ... )
+/// ).closed.then((SnackBarClosedReason reason) {
+///    ...
+/// });
+/// ```
+enum SnackBarClosedReason {
+  /// The snack bar was closed after the user tapped a [SnackBarAction].
+  action,
+
+  /// The snack bar was closed by a user's swipe.
+  swipe,
+
+  /// The snack bar was closed by the [ScaffoldFeatureController] close callback
+  /// or by calling [hideCurrentSnackBar] directly.
+  hide,
+
+  /// The snack bar was closed by an call to [removeCurrentSnackBar].
+  remove,
+
+  /// The snack bar was closed because its timer expired.
+  timeout,
+}
+
 /// A button for a [SnackBar], known as an "action".
 ///
 /// Snack bar actions are always enabled. If you want to disable a snack bar

--- a/packages/flutter/test/material/snack_bar_test.dart
+++ b/packages/flutter/test/material/snack_bar_test.dart
@@ -130,7 +130,7 @@ void main() {
     int snackBarCount = 0;
     Key tapTarget = new Key('tap-target');
     int time;
-    ScaffoldFeatureController<SnackBar, Null> lastController;
+    ScaffoldFeatureController<SnackBar, SnackBarClosedReason> lastController;
     await tester.pumpWidget(new MaterialApp(
       home: new Scaffold(
         body: new Builder(
@@ -158,7 +158,7 @@ void main() {
     expect(find.text('bar2'), findsNothing);
     time = 1000;
     await tester.tap(find.byKey(tapTarget)); // queue bar1
-    ScaffoldFeatureController<SnackBar, Null> firstController = lastController;
+    ScaffoldFeatureController<SnackBar, SnackBarClosedReason> firstController = lastController;
     time = 2;
     await tester.tap(find.byKey(tapTarget)); // queue bar2
     expect(find.text('bar1'), findsNothing);

--- a/packages/flutter/test/material/snack_bar_test.dart
+++ b/packages/flutter/test/material/snack_bar_test.dart
@@ -371,17 +371,22 @@ void main() {
     await tester.tap(find.text('X'));
     await tester.pump(); // start animation
     await tester.pump(const Duration(milliseconds: 750));
-
     expect(actionPressed, isFalse);
     await tester.tap(find.text('ACTION'));
     expect(actionPressed, isTrue);
-
     await tester.pump(const Duration(seconds: 1));
     expect(closedReason, equals(SnackBarClosedReason.action));
 
+    // Pop up the snack bar and then swipe downwards to dismiss it.
+    await tester.tap(find.text('X'));
+    await tester.pump(const Duration(milliseconds: 750));
+    await tester.pump(const Duration(milliseconds: 750));
+    await tester.scroll(find.text('snack'), new Offset(0.0, 50.0));
+    await tester.pump();
+    expect(closedReason, equals(SnackBarClosedReason.swipe));
+
     // Pop up the snack bar and then remove it.
     await tester.tap(find.text('X'));
-    await tester.pump(); // start animation
     await tester.pump(const Duration(milliseconds: 750));
     scaffoldKey.currentState.removeCurrentSnackBar();
     await tester.pump(const Duration(seconds: 1));
@@ -389,7 +394,6 @@ void main() {
 
     // Pop up the snack bar and then hide it.
     await tester.tap(find.text('X'));
-    await tester.pump(); // start animation
     await tester.pump(const Duration(milliseconds: 750));
     scaffoldKey.currentState.hideCurrentSnackBar();
     await tester.pump(const Duration(seconds: 1));
@@ -397,13 +401,11 @@ void main() {
 
     // Pop up the snack bar and then let it time out.
     await tester.tap(find.text('X'));
-    await tester.pump(); // schedule animation
+    await tester.pump(new Duration(milliseconds: 750));
+    await tester.pump(new Duration(milliseconds: 750));
+    await tester.pump(new Duration(milliseconds: 1500));
     await tester.pump(); // begin animation
-    await tester.pump(new Duration(milliseconds: 750)); // 0.75s // animation last frame; two second timer starts here
-    await tester.pump(new Duration(milliseconds: 750)); // 1.50s
-    await tester.pump(new Duration(milliseconds: 1500)); // timer triggers to dismiss snackbar, reverse animation is scheduled
-    await tester.pump(); // begin animation
-    await tester.pump(new Duration(milliseconds: 750)); // 3.75s // last frame of animation, snackbar removed from build
+    await tester.pump(new Duration(milliseconds: 750));
     expect(closedReason, equals(SnackBarClosedReason.timeout));
   });
 


### PR DESCRIPTION
The value of the ScaffoldFeatureController closed Future returned by showSnackBar(), is now a SnackBarClosedReason.

```
  Scaffold.of(context).showSnackBar(
    new SnackBar(
      content: new Text('snackbar'),
      action: new SnackBarAction(
        label: 'ACTION',
        onPressed: () { print('pressed ACTION'); },
      ),
    ),
  ).closed.then((SnackBarClosedReason reason) {
    print('snackbar closed with $reason');
  });
```
Fixes #6912