### PR TITLE
Remove extraneous gallery demo imports

### DIFF
--- a/examples/flutter_gallery/lib/demo/buttons_demo.dart
+++ b/examples/flutter_gallery/lib/demo/buttons_demo.dart
@@ -146,8 +146,7 @@ class _ButtonsDemoState extends State<ButtonsDemo> {
               value: dropdown1Value,
               onChanged: (String newValue) {
                 setState(() {
-                  if (newValue != null)
-                    dropdown1Value = newValue;
+                  dropdown1Value = newValue;
                 });
               },
               items: <String>[
@@ -172,8 +171,7 @@ class _ButtonsDemoState extends State<ButtonsDemo> {
               value: dropdown2Value,
               onChanged: (String newValue) {
                 setState(() {
-                  if (newValue != null)
-                    dropdown2Value = newValue;
+                  dropdown2Value = newValue;
                 });
               },
               items: <String>['One', 'Two', 'Free', 'Four'].map((String value) {

--- a/examples/flutter_gallery/lib/demo/cards_demo.dart
+++ b/examples/flutter_gallery/lib/demo/cards_demo.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import 'package:flutter/material.dart';
-import 'package:flutter/widgets.dart';
 
 class TravelDestination {
   const TravelDestination({ this.assetName, this.title, this.description });

--- a/examples/flutter_gallery/lib/demo/colors_demo.dart
+++ b/examples/flutter_gallery/lib/demo/colors_demo.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import 'package:flutter/material.dart';
-import 'package:flutter/widgets.dart';
 
 const double kColorItemHeight = 48.0;
 

--- a/examples/flutter_gallery/lib/demo/dialog_demo.dart
+++ b/examples/flutter_gallery/lib/demo/dialog_demo.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import 'package:flutter/material.dart';
-import 'package:flutter/widgets.dart';
 
 import 'full_screen_dialog_demo.dart';
 

--- a/examples/flutter_gallery/lib/demo/full_screen_dialog_demo.dart
+++ b/examples/flutter_gallery/lib/demo/full_screen_dialog_demo.dart
@@ -4,7 +4,6 @@
 
 import 'package:intl/intl.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/widgets.dart';
 
 // This demo is based on
 // https://material.google.com/components/dialogs.html#dialogs-full-screen-dialogs

--- a/examples/flutter_gallery/lib/demo/grid_list_demo.dart
+++ b/examples/flutter_gallery/lib/demo/grid_list_demo.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import 'package:flutter/material.dart';
-import 'package:flutter/widgets.dart';
 
 enum GridDemoTileStyle {
   imageOnly,

--- a/examples/flutter_gallery/lib/demo/snack_bar_demo.dart
+++ b/examples/flutter_gallery/lib/demo/snack_bar_demo.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import 'package:flutter/material.dart';
-import 'package:flutter/widgets.dart';
 
 const String _text1 =
   "Snackbars provide lightweight feedback about an operation by "

--- a/examples/flutter_gallery/lib/demo/typography_demo.dart
+++ b/examples/flutter_gallery/lib/demo/typography_demo.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import 'package:flutter/material.dart';
-import 'package:flutter/widgets.dart';
 
 class TextStyleItem extends StatelessWidget {
   TextStyleItem({ Key key, this.name, this.style, this.text }) : super(key: key) {

--- a/examples/flutter_gallery/lib/gallery/home.dart
+++ b/examples/flutter_gallery/lib/gallery/home.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import 'package:flutter/material.dart';
-import 'package:flutter/widgets.dart';
 
 import 'drawer.dart';
 import 'item.dart';


### PR DESCRIPTION
It's hasn't been necessary to import both widgets.dart and material.dart in a long time.

Dropdowns do not call their onChanged() callback when the user hasn't selected a value; removed the corresponding defensive checks in the buttons demo.
