### PR TITLE
More AppContext cleanups

### DIFF
--- a/packages/flutter_tools/bin/fuchsia_builder.dart
+++ b/packages/flutter_tools/bin/fuchsia_builder.dart
@@ -8,11 +8,14 @@ import 'dart:io';
 import 'package:args/args.dart';
 
 import '../lib/src/base/common.dart';
+import '../lib/src/base/config.dart';
 import '../lib/src/base/context.dart';
 import '../lib/src/base/logger.dart';
+import '../lib/src/base/os.dart';
 import '../lib/src/cache.dart';
 import '../lib/src/flx.dart';
 import '../lib/src/globals.dart';
+import '../lib/src/usage.dart';
 
 const String _kOptionPackages = 'packages';
 const String _kOptionOutput = 'output-file';
@@ -28,10 +31,16 @@ const List<String> _kRequiredOptions = const <String>[
   _kOptionWorking,
 ];
 
-void main(List<String> args) async {
+Future<Null> main(List<String> args) async {
   AppContext executableContext = new AppContext();
+  executableContext.setVariable(Logger, new StdoutLogger());
   executableContext.runInZone(() {
-    context[Logger] = new StdoutLogger();
+    // Initialize the context with some defaults.
+    context.putIfAbsent(Logger, () => new StdoutLogger());
+    context.putIfAbsent(Cache, () => new Cache());
+    context.putIfAbsent(Config, () => new Config());
+    context.putIfAbsent(OperatingSystemUtils, () => new OperatingSystemUtils());
+    context.putIfAbsent(Usage, () => new Usage());
     return run(args);
   });
 }

--- a/packages/flutter_tools/lib/executable.dart
+++ b/packages/flutter_tools/lib/executable.dart
@@ -9,10 +9,13 @@ import 'package:args/command_runner.dart';
 import 'package:stack_trace/stack_trace.dart';
 
 import 'src/base/common.dart';
+import 'src/base/config.dart';
 import 'src/base/context.dart';
 import 'src/base/logger.dart';
+import 'src/base/os.dart';
 import 'src/base/process.dart';
 import 'src/base/utils.dart';
+import 'src/cache.dart';
 import 'src/commands/analyze.dart';
 import 'src/commands/build.dart';
 import 'src/commands/channel.dart';
@@ -40,8 +43,12 @@ import 'src/device.dart';
 import 'src/doctor.dart';
 import 'src/globals.dart';
 import 'src/hot.dart';
-import 'src/usage.dart';
+import 'src/ios/mac.dart';
+import 'src/ios/simulators.dart';
 import 'src/runner/flutter_command_runner.dart';
+import 'src/toolchain.dart';
+import 'src/usage.dart';
+
 
 /// Main entry point for commands.
 ///
@@ -88,16 +95,19 @@ Future<Null> main(List<String> args) async {
   // Make the context current.
   _executableContext.runInZone(() {
     // Initialize the context with some defaults.
-    if (context[Logger] == null)
-      context[Logger] = new StdoutLogger();
-    if (context[DeviceManager] == null)
-      context[DeviceManager] = new DeviceManager();
-    if (context[DevFSConfig] == null)
-      context[DevFSConfig] = new DevFSConfig();
-    if (context[Doctor] == null)
-      context[Doctor] = new Doctor();
-    if (context[HotRunnerConfig] == null)
-      context[HotRunnerConfig] = new HotRunnerConfig();
+    context.putIfAbsent(Logger, () => new StdoutLogger());
+    context.putIfAbsent(DeviceManager, () => new DeviceManager());
+    context.putIfAbsent(DevFSConfig, () => new DevFSConfig());
+    context.putIfAbsent(Doctor, () => new Doctor());
+    context.putIfAbsent(HotRunnerConfig, () => new HotRunnerConfig());
+    context.putIfAbsent(Cache, () => new Cache());
+    context.putIfAbsent(ToolConfiguration, () => new ToolConfiguration());
+    context.putIfAbsent(Config, () => new Config());
+    context.putIfAbsent(OperatingSystemUtils, () => new OperatingSystemUtils());
+    context.putIfAbsent(XCode, () => new XCode());
+    context.putIfAbsent(IOSSimulatorUtils, () => new IOSSimulatorUtils());
+    context.putIfAbsent(SimControl, () => new SimControl());
+    context.putIfAbsent(Usage, () => new Usage());
 
     return Chain.capture/*<Future<Null>>*/(() async {
       await runner.run(args);
@@ -192,7 +202,7 @@ Future<String> _doctorText() async {
     BufferLogger logger = new BufferLogger();
     AppContext appContext = new AppContext();
 
-    appContext[Logger] = logger;
+    appContext.setVariable(Logger, logger);
 
     await appContext.runInZone(() => doctor.diagnose());
 

--- a/packages/flutter_tools/lib/src/base/config.dart
+++ b/packages/flutter_tools/lib/src/base/config.dart
@@ -16,7 +16,7 @@ class Config {
       _values = JSON.decode(_configFile.readAsStringSync());
   }
 
-  static Config get instance => context[Config] ?? (context[Config] = new Config());
+  static Config get instance => context[Config];
 
   File _configFile;
   String get configPath => _configFile.path;

--- a/packages/flutter_tools/lib/src/base/context.dart
+++ b/packages/flutter_tools/lib/src/base/context.dart
@@ -36,7 +36,15 @@ class AppContext {
 
   dynamic operator[](Type type) => getVariable(type);
 
-  void operator[]=(Type type, dynamic instance) => setVariable(type, instance);
+  dynamic putIfAbsent(Type type, dynamic ifAbsent()) {
+    dynamic value = getVariable(type);
+    if (value != null) {
+      return value;
+    }
+    value = ifAbsent();
+    setVariable(type, value);
+    return value;
+  }
 
   AppContext _calcParent(Zone zone) {
     Zone parentZone = zone.parent;

--- a/packages/flutter_tools/lib/src/base/os.dart
+++ b/packages/flutter_tools/lib/src/base/os.dart
@@ -12,9 +12,7 @@ import 'context.dart';
 import 'process.dart';
 
 /// Returns [OperatingSystemUtils] active in the current app context (i.e. zone).
-OperatingSystemUtils get os {
-  return context[OperatingSystemUtils] ?? (context[OperatingSystemUtils] = new OperatingSystemUtils());
-}
+OperatingSystemUtils get os => context[OperatingSystemUtils];
 
 abstract class OperatingSystemUtils {
   factory OperatingSystemUtils() {

--- a/packages/flutter_tools/lib/src/cache.dart
+++ b/packages/flutter_tools/lib/src/cache.dart
@@ -99,7 +99,7 @@ class Cache {
     return _engineRevision;
   }
 
-  static Cache get instance => context[Cache] ?? (context[Cache] = new Cache());
+  static Cache get instance => context[Cache];
 
   /// Return the top-level directory in the cache; this is `bin/cache`.
   Directory getRoot() {

--- a/packages/flutter_tools/lib/src/commands/daemon.dart
+++ b/packages/flutter_tools/lib/src/commands/daemon.dart
@@ -48,7 +48,7 @@ class DaemonCommand extends FlutterCommand {
 
     AppContext appContext = new AppContext();
     NotifyingLogger notifyingLogger = new NotifyingLogger();
-    appContext[Logger] = notifyingLogger;
+    appContext.setVariable(Logger, notifyingLogger);
 
     Cache.releaseLockEarly();
 
@@ -674,7 +674,7 @@ class AppInstance {
       _logger = new _AppRunLogger(domain, this);
 
     AppContext appContext = new AppContext();
-    appContext[Logger] = _logger;
+    appContext.setVariable(Logger, _logger);
     return appContext.runInZone(method);
   }
 }

--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -56,7 +56,7 @@ class XCode {
   }
 
   /// Returns [XCode] active in the current app context.
-  static XCode get instance => context[XCode] ?? (context[XCode] = new XCode());
+  static XCode get instance => context[XCode];
 
   bool get isInstalledAndMeetsVersionCheck => isInstalled && xcodeVersionSatisfactory;
 

--- a/packages/flutter_tools/lib/src/ios/simulators.dart
+++ b/packages/flutter_tools/lib/src/ios/simulators.dart
@@ -37,9 +37,7 @@ class IOSSimulators extends PollingDeviceDiscovery {
 
 class IOSSimulatorUtils {
   /// Returns [IOSSimulatorUtils] active in the current app context (i.e. zone).
-  static IOSSimulatorUtils get instance {
-    return context[IOSSimulatorUtils] ?? (context[IOSSimulatorUtils] = new IOSSimulatorUtils());
-  }
+  static IOSSimulatorUtils get instance => context[IOSSimulatorUtils];
 
   List<IOSSimulator> getAttachedDevices() {
     if (!XCode.instance.isInstalledAndMeetsVersionCheck)
@@ -54,7 +52,7 @@ class IOSSimulatorUtils {
 /// A wrapper around the `simctl` command line tool.
 class SimControl {
   /// Returns [SimControl] active in the current app context (i.e. zone).
-  static SimControl get instance => context[SimControl] ?? (context[SimControl] = new SimControl());
+  static SimControl get instance => context[SimControl];
 
   Future<bool> boot({ String deviceName }) async {
     if (_isAnyConnected())

--- a/packages/flutter_tools/lib/src/runner/flutter_command_runner.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command_runner.dart
@@ -137,8 +137,10 @@ class FlutterCommandRunner extends CommandRunner<Null> {
   @override
   Future<Null> runCommand(ArgResults globalResults) async {
     // Check for verbose.
-    if (globalResults['verbose'])
-      context[Logger] = new VerboseLogger();
+    if (globalResults['verbose']) {
+      // Override the logger.
+      context.setVariable(Logger, new VerboseLogger());
+    }
 
     logger.quiet = globalResults['quiet'];
 
@@ -171,8 +173,7 @@ class FlutterCommandRunner extends CommandRunner<Null> {
     }
 
     // The Android SDK could already have been set by tests.
-    if (!context.isSet(AndroidSdk))
-      context[AndroidSdk] = AndroidSdk.locateAndroidSdk();
+    context.putIfAbsent(AndroidSdk, () => AndroidSdk.locateAndroidSdk());
 
     if (globalResults['version']) {
       flutterUsage.sendCommand('version');

--- a/packages/flutter_tools/lib/src/toolchain.dart
+++ b/packages/flutter_tools/lib/src/toolchain.dart
@@ -25,18 +25,11 @@ const Map<HostTool, String> _kHostToolFileName = const <HostTool, String>{
 /// and the engine artifact directory for a given target platform. It is configurable
 /// via command-line arguments in order to support local engine builds.
 class ToolConfiguration {
-  /// [overrideCache] is configurable for testing.
-  ToolConfiguration({ Cache overrideCache }) {
-    _cache = overrideCache ?? cache;
-  }
+  ToolConfiguration();
 
-  Cache _cache;
+  Cache get cache => context[Cache];
 
-  static ToolConfiguration get instance {
-    if (context[ToolConfiguration] == null)
-      context[ToolConfiguration] = new ToolConfiguration();
-    return context[ToolConfiguration];
-  }
+  static ToolConfiguration get instance => context[ToolConfiguration];
 
   /// Override using the artifacts from the cache directory (--engine-src-path).
   String engineSrcPath;
@@ -63,14 +56,14 @@ class ToolConfiguration {
 
       // Create something like `android-arm` or `android-arm-release`.
       String dirName = getNameForTargetPlatform(platform) + suffix;
-      Directory engineDir = _cache.getArtifactDirectory('engine');
+      Directory engineDir = cache.getArtifactDirectory('engine');
       return new Directory(path.join(engineDir.path, dirName));
     }
   }
 
   String getHostToolPath(HostTool tool) {
     if (engineBuildPath == null) {
-      return path.join(_cache.getArtifactDirectory('engine').path,
+      return path.join(cache.getArtifactDirectory('engine').path,
                        getNameForHostPlatform(getCurrentHostPlatform()),
                        _kHostToolFileName[tool]);
     }

--- a/packages/flutter_tools/lib/src/usage.dart
+++ b/packages/flutter_tools/lib/src/usage.dart
@@ -39,7 +39,7 @@ class Usage {
   }
 
   /// Returns [Usage] active in the current app context.
-  static Usage get instance => context[Usage] ?? (context[Usage] = new Usage());
+  static Usage get instance => context[Usage];
 
   Analytics _analytics;
 

--- a/packages/flutter_tools/test/context_test.dart
+++ b/packages/flutter_tools/test/context_test.dart
@@ -12,7 +12,7 @@ void main() {
     test('error', () async {
       AppContext context = new AppContext();
       BufferLogger mockLogger = new BufferLogger();
-      context[Logger] = mockLogger;
+      context.setVariable(Logger, mockLogger);
 
       await context.runInZone(() {
         printError('foo bar');
@@ -26,7 +26,7 @@ void main() {
     test('status', () async {
       AppContext context = new AppContext();
       BufferLogger mockLogger = new BufferLogger();
-      context[Logger] = mockLogger;
+      context.setVariable(Logger, mockLogger);
 
       await context.runInZone(() {
         printStatus('foo bar');
@@ -40,7 +40,7 @@ void main() {
     test('trace', () async {
       AppContext context = new AppContext();
       BufferLogger mockLogger = new BufferLogger();
-      context[Logger] = mockLogger;
+      context.setVariable(Logger, mockLogger);
 
       await context.runInZone(() {
         printTrace('foo bar');

--- a/packages/flutter_tools/test/daemon_test.dart
+++ b/packages/flutter_tools/test/daemon_test.dart
@@ -32,11 +32,11 @@ void main() {
     setUp(() {
       appContext = new AppContext();
       notifyingLogger = new NotifyingLogger();
-      appContext[Logger] = notifyingLogger;
-      appContext[Doctor] = new Doctor();
+      appContext.setVariable(Logger, notifyingLogger);
+      appContext.setVariable(Doctor, new Doctor());
       if (Platform.isMacOS)
-        appContext[XCode] = new XCode();
-      appContext[DeviceManager] = new MockDeviceManager();
+        appContext.setVariable(XCode, new XCode());
+      appContext.setVariable(DeviceManager, new MockDeviceManager());
     });
 
     tearDown(() {

--- a/packages/flutter_tools/test/toolchain_test.dart
+++ b/packages/flutter_tools/test/toolchain_test.dart
@@ -14,19 +14,10 @@ import 'src/context.dart';
 void main() {
   group('ToolConfiguration', () {
     Directory tempDir;
-
-    setUp(() {
-      tempDir = Directory.systemTemp.createTempSync('flutter_temp');
-    });
-
-    tearDown(() {
-      tempDir.deleteSync(recursive: true);
-    });
+    tempDir = Directory.systemTemp.createTempSync('flutter_temp');
 
     testUsingContext('using cache', () {
-      ToolConfiguration toolConfig = new ToolConfiguration(
-        overrideCache: new Cache(rootOverride: tempDir)
-      );
+      ToolConfiguration toolConfig = new ToolConfiguration();
 
       expect(
         toolConfig.getEngineArtifactsDirectory(TargetPlatform.android_arm, BuildMode.debug).path,
@@ -36,6 +27,10 @@ void main() {
         toolConfig.getEngineArtifactsDirectory(TargetPlatform.android_arm, BuildMode.release).path,
         endsWith('cache/artifacts/engine/android-arm-release')
       );
+      expect(tempDir, isNotNull);
+      tempDir.deleteSync(recursive: true);
+    }, overrides: <Type, dynamic> {
+      Cache: new Cache(rootOverride: tempDir)
     });
 
     testUsingContext('using enginePath', () {


### PR DESCRIPTION
- [x] Remove getters that mutate the context
- [x] Add utility method `putIfAbsent` to context
- [x] Explicitly initialize the context in the executable entry point and the test context.

@devoncarew @tvolkert 