### PR TITLE
Support for overriding tap behavior of feedback drawer item

### DIFF
--- a/examples/flutter_gallery/lib/gallery/app.dart
+++ b/examples/flutter_gallery/lib/gallery/app.dart
@@ -31,6 +31,7 @@ class GalleryApp extends StatefulWidget {
     this.updateUrlFetcher,
     this.enablePerformanceOverlay: true,
     this.checkerboardRasterCacheImages: true,
+    this.onSendFeedback,
     Key key}
   ) : super(key: key);
 
@@ -39,6 +40,8 @@ class GalleryApp extends StatefulWidget {
   final bool enablePerformanceOverlay;
 
   final bool checkerboardRasterCacheImages;
+
+  final VoidCallback onSendFeedback;
 
   @override
   GalleryAppState createState() => new GalleryAppState();
@@ -83,6 +86,7 @@ class GalleryAppState extends State<GalleryApp> {
           timeDilation = value;
         });
       },
+      onSendFeedback: config.onSendFeedback,
     );
 
     if (config.updateUrlFetcher != null) {

--- a/examples/flutter_gallery/lib/gallery/drawer.dart
+++ b/examples/flutter_gallery/lib/gallery/drawer.dart
@@ -97,6 +97,7 @@ class GalleryDrawer extends StatelessWidget {
     this.checkerboardRasterCacheImages,
     this.onCheckerboardRasterCacheImagesChanged,
     this.onPlatformChanged,
+    this.onSendFeedback,
   }) : super(key: key) {
     assert(onThemeChanged != null);
     assert(onTimeDilationChanged != null);
@@ -115,6 +116,8 @@ class GalleryDrawer extends StatelessWidget {
   final ValueChanged<bool> onCheckerboardRasterCacheImagesChanged;
 
   final ValueChanged<TargetPlatform> onPlatformChanged;
+
+  final VoidCallback onSendFeedback;
 
   @override
   Widget build(BuildContext context) {
@@ -203,12 +206,12 @@ class GalleryDrawer extends StatelessWidget {
       )
     );
 
-    final Widget fileAnIssueItem = new DrawerItem(
+    final Widget sendFeedbackItem = new DrawerItem(
       icon: new Icon(Icons.report),
-      onPressed: () {
+      onPressed: onSendFeedback ?? () {
         UrlLauncher.launch('https://github.com/flutter/flutter/issues/new');
       },
-      child: new Text('File an issue')
+      child: new Text('Send feedback'),
     );
 
     final Widget aboutItem = new AboutDrawerItem(
@@ -264,7 +267,7 @@ class GalleryDrawer extends StatelessWidget {
       new Divider(),
       animateSlowlyItem,
       // index 8, optional: Performance Overlay
-      fileAnIssueItem,
+      sendFeedbackItem,
       aboutItem
     ];
 

--- a/examples/flutter_gallery/lib/gallery/home.dart
+++ b/examples/flutter_gallery/lib/gallery/home.dart
@@ -79,6 +79,7 @@ class GalleryHome extends StatefulWidget {
     this.checkerboardRasterCacheImages,
     this.onCheckerboardRasterCacheImagesChanged,
     this.onPlatformChanged,
+    this.onSendFeedback,
   }) : super(key: key) {
     assert(onThemeChanged != null);
     assert(onTimeDilationChanged != null);
@@ -97,6 +98,8 @@ class GalleryHome extends StatefulWidget {
   final ValueChanged<bool> onCheckerboardRasterCacheImagesChanged;
 
   final ValueChanged<TargetPlatform> onPlatformChanged;
+
+  final VoidCallback onSendFeedback;
 
   @override
   GalleryHomeState createState() => new GalleryHomeState();
@@ -164,6 +167,7 @@ class GalleryHomeState extends State<GalleryHome> with SingleTickerProviderState
         checkerboardRasterCacheImages: config.checkerboardRasterCacheImages,
         onCheckerboardRasterCacheImagesChanged: config.onCheckerboardRasterCacheImagesChanged,
         onPlatformChanged: config.onPlatformChanged,
+        onSendFeedback: config.onSendFeedback,
       ),
       appBar: new AppBar(
         expandedHeight: _kFlexibleSpaceMaxHeight,

--- a/examples/flutter_gallery/test/smoke_test.dart
+++ b/examples/flutter_gallery/test/smoke_test.dart
@@ -49,7 +49,12 @@ Future<Null> smokeDemo(WidgetTester tester, String routeName) async {
 }
 
 Future<Null> runSmokeTest(WidgetTester tester) async {
-  await tester.pumpWidget(new GalleryApp());
+  bool hasFeedback = false;
+  void mockOnSendFeedback() {
+    hasFeedback = true;
+  }
+
+  await tester.pumpWidget(new GalleryApp(onSendFeedback: mockOnSendFeedback));
   await tester.pump(); // see https://github.com/flutter/flutter/issues/1865
   await tester.pump(); // triggers a frame
 
@@ -89,6 +94,12 @@ Future<Null> runSmokeTest(WidgetTester tester) async {
   await tester.tap(find.text('Light'));
   await tester.pump();
   await tester.pump(const Duration(seconds: 1)); // Wait until it's changed.
+
+  // send feedback
+  expect(hasFeedback, false);
+  await tester.tap(find.text('Send feedback'));
+  await tester.pump();
+  expect(hasFeedback, true);
 }
 
 void main() {


### PR DESCRIPTION
This will allow us to have the feedback menu item open a Google feedback dialog in first-party builds of Gallery.