### PR TITLE
Remove extraneous gallery demo scrollable keys

### DIFF
--- a/examples/flutter_gallery/lib/demo/cards_demo.dart
+++ b/examples/flutter_gallery/lib/demo/cards_demo.dart
@@ -126,18 +126,15 @@ class TravelDestinationItem extends StatelessWidget {
 }
 
 class CardsDemo extends StatelessWidget {
-  static final GlobalKey<ScrollableState> _scrollableKey = new GlobalKey<ScrollableState>();
   static const String routeName = '/cards';
 
   @override
   Widget build(BuildContext context) {
     return new Scaffold(
-      scrollableKey: _scrollableKey,
       appBar: new AppBar(
         title: new Text('Travel stream')
       ),
       body: new ScrollableList(
-        scrollableKey: _scrollableKey,
         itemExtent: TravelDestinationItem.height,
         padding: const EdgeInsets.only(top: 8.0, left: 8.0, right: 8.0),
         children: destinations.map((TravelDestination destination) {

--- a/examples/flutter_gallery/lib/demo/colors_demo.dart
+++ b/examples/flutter_gallery/lib/demo/colors_demo.dart
@@ -9,7 +9,6 @@ const double kColorItemHeight = 48.0;
 class ColorSwatch {
   ColorSwatch({ this.name, this.colors, this.accentColors, this.threshold: 900});
 
-  final GlobalKey<ScrollableState> scrollableKey = new GlobalKey<ScrollableState>();
   final String name;
   final Map<int, Color> colors;
   final Map<int, Color> accentColors;
@@ -102,7 +101,6 @@ class ColorSwatchTabView extends StatelessWidget {
     }
 
     return new ScrollableList(
-      scrollableKey: swatch.scrollableKey,
       itemExtent: kColorItemHeight,
       children: colorItems
     );
@@ -119,26 +117,11 @@ class ColorsDemo extends StatefulWidget {
 }
 
 class _ColorsDemoState extends State<ColorsDemo> {
-
-  ColorSwatch _selectedSwatch;
-
-  @override
-  void initState() {
-    super.initState();
-    _selectedSwatch = colorSwatches.first;
-  }
-
   @override
   Widget build(BuildContext context) {
     return new TabBarSelection<ColorSwatch>(
       values: colorSwatches,
-      onChanged: (ColorSwatch value) {
-        setState(() {
-          _selectedSwatch = value;
-       });
-      },
       child: new Scaffold(
-        scrollableKey: _selectedSwatch.scrollableKey,
         appBar: new AppBar(
           elevation: 0,
           title: new Text('Colors'),

--- a/examples/flutter_gallery/lib/demo/grid_list_demo.dart
+++ b/examples/flutter_gallery/lib/demo/grid_list_demo.dart
@@ -239,7 +239,6 @@ class GridListDemo extends StatefulWidget {
 }
 
 class GridListDemoState extends State<GridListDemo> {
-  static final GlobalKey<ScrollableState> _scrollableKey = new GlobalKey<ScrollableState>();
   GridDemoTileStyle _tileStyle = GridDemoTileStyle.twoLine;
 
   List<Photo> photos = <Photo>[
@@ -318,7 +317,6 @@ class GridListDemoState extends State<GridListDemo> {
   Widget build(BuildContext context) {
     final Orientation orientation = MediaQuery.of(context).orientation;
     return new Scaffold(
-      scrollableKey: _scrollableKey,
       appBar: new AppBar(
         title: new Text('Grid list'),
         actions: <Widget>[
@@ -345,7 +343,6 @@ class GridListDemoState extends State<GridListDemo> {
         children: <Widget>[
           new Expanded(
             child: new ScrollableGrid(
-              scrollableKey: _scrollableKey,
               delegate: new FixedColumnCountGridDelegate(
                 columnCount: (orientation == Orientation.portrait) ? 2 : 3,
                 rowSpacing: 4.0,

--- a/examples/flutter_gallery/lib/demo/leave_behind_demo.dart
+++ b/examples/flutter_gallery/lib/demo/leave_behind_demo.dart
@@ -39,7 +39,6 @@ class LeaveBehindDemo extends StatefulWidget {
 
 class LeaveBehindDemoState extends State<LeaveBehindDemo> {
   static final GlobalKey<ScaffoldState> _scaffoldKey = new GlobalKey<ScaffoldState>();
-  static final GlobalKey<ScrollableState> _scrollableKey = new GlobalKey<ScrollableState>();
   DismissDirection _dismissDirection = DismissDirection.horizontal;
   List<LeaveBehindItem> leaveBehindItems;
 
@@ -132,7 +131,6 @@ class LeaveBehindDemoState extends State<LeaveBehindDemo> {
   Widget build(BuildContext context) {
     return new Scaffold(
       key: _scaffoldKey,
-      scrollableKey: _scrollableKey,
       appBar: new AppBar(
         title: new Text('Swipe to dismiss'),
         actions: <Widget>[
@@ -164,7 +162,6 @@ class LeaveBehindDemoState extends State<LeaveBehindDemo> {
         ]
       ),
       body: new Block(
-        scrollableKey: _scrollableKey,
         children: leaveBehindItems.map(buildItem).toList()
       )
     );

--- a/examples/flutter_gallery/lib/demo/list_demo.dart
+++ b/examples/flutter_gallery/lib/demo/list_demo.dart
@@ -15,7 +15,6 @@ class ListDemo extends StatefulWidget {
 
 class ListDemoState extends State<ListDemo> {
   static final GlobalKey<ScaffoldState> scaffoldKey = new GlobalKey<ScaffoldState>();
-  static final GlobalKey<ScrollableState> _scrollableKey = new GlobalKey<ScrollableState>();
 
   PersistentBottomSheetController<Null> _bottomSheet;
   MaterialListType _itemType = MaterialListType.threeLine;
@@ -172,7 +171,6 @@ class ListDemoState extends State<ListDemo> {
 
     return new Scaffold(
       key: scaffoldKey,
-      scrollableKey: _scrollableKey,
       appBar: new AppBar(
         title: new Text('Scrolling list\n$itemTypeText$layoutText'),
         actions: <Widget>[
@@ -195,7 +193,6 @@ class ListDemoState extends State<ListDemo> {
       ),
       body: new Scrollbar(
         child: new MaterialList(
-          scrollableKey: _scrollableKey,
           type: _itemType,
           padding: new EdgeInsets.symmetric(vertical: _dense ? 4.0 : 8.0),
           children: listItems

--- a/examples/flutter_gallery/lib/demo/overscroll_demo.dart
+++ b/examples/flutter_gallery/lib/demo/overscroll_demo.dart
@@ -78,7 +78,6 @@ class OverscrollDemoState extends State<OverscrollDemo> {
 
     return new Scaffold(
       key: _scaffoldKey,
-      scrollableKey: _scrollableKey,
       appBar: new AppBar(
         title: new Text('$indicatorTypeText'),
         actions: <Widget>[

--- a/examples/flutter_gallery/lib/demo/shrine/shrine_home.dart
+++ b/examples/flutter_gallery/lib/demo/shrine/shrine_home.dart
@@ -293,7 +293,6 @@ class ShrineHome extends StatefulWidget {
 
 class _ShrineHomeState extends State<ShrineHome> {
   static final GlobalKey<ScaffoldState> scaffoldKey = new GlobalKey<ScaffoldState>(debugLabel: 'Shrine Home');
-  static final GlobalKey<ScrollableState> scrollableKey = new GlobalKey<ScrollableState>();
   static final GridDelegate gridDelegate = new ShrineGridDelegate();
 
   Future<Null> showOrderPage(Product product) async {
@@ -318,11 +317,9 @@ class _ShrineHomeState extends State<ShrineHome> {
     final Product featured = _products.firstWhere((Product product) => product.featureDescription != null);
     return new ShrinePage(
       scaffoldKey: scaffoldKey,
-      scrollableKey: scrollableKey,
       products: _products,
       shoppingCart: _shoppingCart,
       body: new ScrollableViewport(
-        scrollableKey: scrollableKey,
         child: new RepaintBoundary(
           child: new Column(
             children: <Widget>[

--- a/examples/flutter_gallery/lib/demo/shrine/shrine_order.dart
+++ b/examples/flutter_gallery/lib/demo/shrine/shrine_order.dart
@@ -135,7 +135,6 @@ class OrderPage extends StatefulWidget {
 /// order to the shopping cart.
 class _OrderPageState extends State<OrderPage> {
   static final GlobalKey<ScaffoldState> scaffoldKey = new GlobalKey<ScaffoldState>(debugLabel: 'Shrine Order');
-  static final GlobalKey<ScrollableState> scrollableKey = new GlobalKey<ScrollableState>();
 
   Order get currentOrder => ShrineOrderRoute.of(context).order;
 
@@ -161,7 +160,6 @@ class _OrderPageState extends State<OrderPage> {
   Widget build(BuildContext context) {
     return new ShrinePage(
       scaffoldKey: scaffoldKey,
-      scrollableKey: scrollableKey,
       products: config.products,
       shoppingCart: config.shoppingCart,
       floatingActionButton: new FloatingActionButton(
@@ -180,7 +178,6 @@ class _OrderPageState extends State<OrderPage> {
         )
       ),
       body: new Block(
-        scrollableKey: scrollableKey,
         children: <Widget>[
           new OrderItem(
             product: config.order.product,
@@ -211,7 +208,6 @@ class _OrderPageState extends State<OrderPage> {
         ]
       )
     );
-
   }
 }
 

--- a/examples/flutter_gallery/lib/demo/shrine/shrine_page.dart
+++ b/examples/flutter_gallery/lib/demo/shrine/shrine_page.dart
@@ -17,7 +17,6 @@ class ShrinePage extends StatefulWidget {
   ShrinePage({
     Key key,
     this.scaffoldKey,
-    this.scrollableKey,
     this.body,
     this.floatingActionButton,
     this.products,
@@ -28,7 +27,6 @@ class ShrinePage extends StatefulWidget {
   }
 
   final GlobalKey<ScaffoldState> scaffoldKey;
-  final GlobalKey<ScrollableState> scrollableKey;
   final Widget body;
   final Widget floatingActionButton;
   final List<Product> products;
@@ -88,7 +86,6 @@ class ShrinePageState extends State<ShrinePage> {
     final ShrineTheme theme = ShrineTheme.of(context);
     return new Scaffold(
       key: config.scaffoldKey,
-      scrollableKey: config.scrollableKey,
       appBar: new AppBar(
         elevation: _appBarElevation,
         backgroundColor: theme.appBarBackgroundColor,

--- a/examples/flutter_gallery/lib/demo/tabs_demo.dart
+++ b/examples/flutter_gallery/lib/demo/tabs_demo.dart
@@ -9,7 +9,6 @@ import 'package:flutter/material.dart';
 
 class _Page {
   _Page({ this.label });
-  final GlobalKey<ScrollableState> scrollableKey = new GlobalKey<ScrollableState>();
   final String label;
   String get id => label[0];
 }
@@ -140,7 +139,6 @@ class _TabsDemoState extends State<TabsDemo> {
        });
       },
       child: new Scaffold(
-        scrollableKey: _selectedPage.scrollableKey,
         appBar: new AppBar(
           title: new Text('Tabs and scrolling'),
           bottom: new TabBar<_Page>(
@@ -152,7 +150,6 @@ class _TabsDemoState extends State<TabsDemo> {
         body: new TabBarView<_Page>(
           children: _allPages.keys.map((_Page page) {
             return new ScrollableList(
-              scrollableKey: page.scrollableKey,
               padding: const EdgeInsets.symmetric(vertical: 8.0, horizontal: 16.0),
               itemExtent: _CardDataItem.height,
               children: _allPages[page].map((_CardData data) {

--- a/examples/flutter_gallery/lib/demo/tabs_demo.dart
+++ b/examples/flutter_gallery/lib/demo/tabs_demo.dart
@@ -121,23 +121,10 @@ class TabsDemo extends StatefulWidget {
 }
 
 class _TabsDemoState extends State<TabsDemo> {
-  _Page _selectedPage;
-
-  @override
-  void initState() {
-    super.initState();
-    _selectedPage = _allPages.keys.first;
-  }
-
   @override
   Widget build(BuildContext context) {
     return new TabBarSelection<_Page>(
       values: _allPages.keys.toList(),
-      onChanged: (_Page value) {
-        setState(() {
-          _selectedPage = value;
-       });
-      },
       child: new Scaffold(
         appBar: new AppBar(
           title: new Text('Tabs and scrolling'),


### PR DESCRIPTION
Many of the gallery demos needlessly configure their Scaffold with a scrollableKey. A scrollable key is only needed by apps with a flexible app bar.

