### PR TITLE
Revert "Add delay between writing file and modifying it"

### DIFF
--- a/packages/flutter_tools/test/devfs_test.dart
+++ b/packages/flutter_tools/test/devfs_test.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import 'dart:io';
-import 'dart:async';
 
 import 'package:flutter_tools/src/asset.dart';
 import 'package:flutter_tools/src/build_info.dart';
@@ -40,21 +39,18 @@ void main() {
       await devFS.update();
       expect(devFSOperations.contains('writeFile test bar/foo.txt'), isTrue);
     });
+    testUsingContext('modify existing file on local file system', () async {
+      File file = new File(path.join(basePath, filePath));
+      file.writeAsBytesSync(<int>[1, 2, 3, 4, 5, 6]);
+      await devFS.update();
+      expect(devFSOperations.contains('writeFile test bar/foo.txt'), isTrue);
+    });
     testUsingContext('add new file to local file system', () async {
       File file = new File(path.join(basePath, filePath2));
       await file.parent.create(recursive: true);
       file.writeAsBytesSync(<int>[1, 2, 3, 4, 5, 6, 7]);
       await devFS.update();
       expect(devFSOperations.contains('writeFile test foo/bar.txt'), isTrue);
-      // Need to delay between when we first write to a file and when
-      // we modify it.
-      await new Future<Null>.delayed(new Duration(seconds: 1));
-    });
-    testUsingContext('modify existing file on local file system', () async {
-      File file = new File(path.join(basePath, filePath));
-      await file.writeAsBytes(<int>[1, 2, 3, 4, 5, 6]);
-      await devFS.update();
-      expect(devFSOperations.contains('writeFile test bar/foo.txt'), isTrue);
     });
     testUsingContext('delete a file from the local file system', () async {
       File file = new File(path.join(basePath, filePath));


### PR DESCRIPTION
Reverts flutter/flutter#6968

Adding a sleep statement to the tests isn't reasonable. We need the tests to run as fast as possible.

cc @lukechurch 