### PR TITLE
Use touch to avoid race condition in file modification test

### DIFF
--- a/packages/flutter_tools/test/devfs_test.dart
+++ b/packages/flutter_tools/test/devfs_test.dart
@@ -46,12 +46,12 @@ void main() {
       file.writeAsBytesSync(<int>[1, 2, 3, 4, 5, 6, 7]);
       await devFS.update();
       expect(devFSOperations.contains('writeFile test foo/bar.txt'), isTrue);
-      // Need to delay between when we first write to a file and when
-      // we modify it.
-      await new Future<Null>.delayed(new Duration(seconds: 1));
     });
     testUsingContext('modify existing file on local file system', () async {
       File file = new File(path.join(basePath, filePath));
+      // Set the last modified time to 5 seconds ago.
+      Process.runSync('touch', <String>['-A', '-05', file.path]);
+      await devFS.update();
       await file.writeAsBytes(<int>[1, 2, 3, 4, 5, 6]);
       await devFS.update();
       expect(devFSOperations.contains('writeFile test bar/foo.txt'), isTrue);

--- a/packages/flutter_tools/test/devfs_test.dart
+++ b/packages/flutter_tools/test/devfs_test.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import 'dart:io';
-import 'dart:async';
 
 import 'package:flutter_tools/src/asset.dart';
 import 'package:flutter_tools/src/build_info.dart';


### PR DESCRIPTION
@Hixie @johnmccutchan 

As discussed here: https://github.com/flutter/flutter/pull/6968

This resolves the race using touch instead of a sleep delay. It is based from master so it also includes: https://github.com/flutter/flutter/pull/7113

I'm currently not able to test on Linux. @johnmccutchan could you check that this works on Linux for me?

Thanks!