### PR TITLE
Open the keyboard without explicit tap for autofocused Inputs.

### DIFF
--- a/packages/flutter/lib/src/material/input.dart
+++ b/packages/flutter/lib/src/material/input.dart
@@ -45,6 +45,7 @@ class InputField extends StatefulWidget {
     this.style,
     this.hideText: false,
     this.maxLines: 1,
+    this.autofocus: false,
     this.onChanged,
     this.onSubmitted,
   }) : super(key: key);
@@ -74,6 +75,9 @@ class InputField extends StatefulWidget {
   /// If this is 1 (the default), the text will not wrap, but will scroll
   /// horizontally instead.
   final int maxLines;
+
+  /// Whether this input field should focus itself if nothing else is already focused.
+  final bool autofocus;
 
   /// Called when the text being edited changes.
   ///
@@ -124,6 +128,7 @@ class _InputFieldState extends State<InputField> {
               style: textStyle,
               hideText: config.hideText,
               maxLines: config.maxLines,
+              autofocus: config.autofocus,
               cursorColor: themeData.textSelectionColor,
               selectionColor: themeData.textSelectionColor,
               selectionControls: materialTextSelectionControls,
@@ -448,6 +453,10 @@ class Input extends StatefulWidget {
   final bool isDense;
 
   /// Whether this input field should focus itself if nothing else is already focused.
+  /// If true, the keyboard will open as soon as this input obtains focus. Otherwise,
+  /// the keyboard is only shown after the user taps the text field.
+  // See https://github.com/flutter/flutter/issues/7035 for the rationale for this
+  // keyboard behavior.
   final bool autofocus;
 
   /// The maximum number of lines for the text to span, wrapping if necessary.
@@ -504,6 +513,7 @@ class _InputState extends State<Input> {
               style: config.style,
               hideText: config.hideText,
               maxLines: config.maxLines,
+              autofocus: config.autofocus,
               keyboardType: config.keyboardType,
               onChanged: config.onChanged,
               onSubmitted: config.onSubmitted,

--- a/packages/flutter/lib/src/widgets/editable.dart
+++ b/packages/flutter/lib/src/widgets/editable.dart
@@ -135,6 +135,7 @@ class RawInput extends Scrollable {
     this.cursorColor,
     this.textScaleFactor,
     int maxLines: 1,
+    this.autofocus: false,
     this.selectionColor,
     this.selectionControls,
     @required this.platform,
@@ -176,6 +177,11 @@ class RawInput extends Scrollable {
   /// If this is 1 (the default), the text will not wrap, but will scroll
   /// horizontally instead.
   final int maxLines;
+
+  /// Whether this input field should focus itself if nothing else is already focused.
+  /// If true, the keyboard will open as soon as this input obtains focus. Otherwise,
+  /// the keyboard is only shown after the user taps the text field.
+  final bool autofocus;
 
   /// The color to use when painting the selection.
   final Color selectionColor;
@@ -278,7 +284,7 @@ class RawInputState extends ScrollableState<RawInput> implements TextInputClient
   bool _requestingFocus = false;
 
   void _attachOrDetachKeyboard(bool focused) {
-    if (focused && !_isAttachedToKeyboard && _requestingFocus) {
+    if (focused && !_isAttachedToKeyboard && (_requestingFocus || config.autofocus)) {
       _textInputConnection = TextInput.attach(
           this, new TextInputConfiguration(inputType: config.keyboardType))
         ..setEditingState(_getTextEditingStateFromInputValue(_currentValue))

--- a/packages/flutter/test/widgets/input_test.dart
+++ b/packages/flutter/test/widgets/input_test.dart
@@ -91,6 +91,7 @@ void main() {
       return new Center(
         child: new Material(
           child: new Input(
+            autofocus: true,
             value: inputValue,
             key: inputKey,
             hintText: 'Placeholder',
@@ -101,7 +102,6 @@ void main() {
     }
 
     await tester.pumpWidget(builder());
-    await showKeyboard(tester);
 
     RenderBox findInputBox() => tester.renderObject(find.byKey(inputKey));
 


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/7035