### PR TITLE
Cleanup common port forwarding code

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_device.dart
+++ b/packages/flutter_tools/lib/src/android/android_device.dart
@@ -349,14 +349,13 @@ class AndroidDevice extends Device {
         Uri observatoryDeviceUri, diagnosticDeviceUri;
 
         if (debuggingOptions.buildMode == BuildMode.debug) {
-          Future<List<Uri>> scrapeServiceUris = Future.wait(
+          List<Uri> deviceUris = await Future.wait(
               <Future<Uri>>[observatoryDiscovery.nextUri(), diagnosticDiscovery.nextUri()]
           );
-          List<Uri> deviceUris = await scrapeServiceUris.timeout(new Duration(seconds: 20));
           observatoryDeviceUri = deviceUris[0];
           diagnosticDeviceUri = deviceUris[1];
         } else if (debuggingOptions.buildMode == BuildMode.profile) {
-          observatoryDeviceUri = await observatoryDiscovery.nextUri().timeout(new Duration(seconds: 20));
+          observatoryDeviceUri = await observatoryDiscovery.nextUri();
         }
 
         printTrace('Observatory Uri on device: $observatoryDeviceUri');
@@ -379,10 +378,7 @@ class AndroidDevice extends Device {
             diagnosticUri: diagnosticHostUri,
         );
       } catch (error) {
-        if (error is TimeoutException)
-          printError('Timed out while waiting for a debug connection.');
-        else
-          printError('Error waiting for a debug connection: $error');
+        printError('Error waiting for a debug connection: $error');
         return new LaunchResult.failed();
       } finally {
         observatoryDiscovery.cancel();

--- a/packages/flutter_tools/lib/src/android/android_device.dart
+++ b/packages/flutter_tools/lib/src/android/android_device.dart
@@ -8,7 +8,6 @@ import 'dart:io';
 
 import '../android/android_sdk.dart';
 import '../application_package.dart';
-import '../base/common.dart';
 import '../base/os.dart';
 import '../base/logger.dart';
 import '../base/process.dart';
@@ -261,17 +260,6 @@ class AndroidDevice extends Device {
     return true;
   }
 
-  Future<int> _forwardPort(int devicePort, {int hostPort}) async {
-    try {
-      hostPort = await portForwarder.forward(devicePort, hostPort: hostPort);
-      printTrace('Forwarded host port $hostPort to device port $devicePort');
-      return hostPort;
-    } catch (e) {
-      throw new ToolExit(
-          'Unable to forward host port $hostPort to device port $devicePort: $e');
-    }
-  }
-
   @override
   Future<LaunchResult> startApp(
     ApplicationPackage package,
@@ -374,14 +362,14 @@ class AndroidDevice extends Device {
         printTrace('Observatory Uri on device: $observatoryDeviceUri');
         // TODO(devoncarew): Remember the forwarding information (so we can later remove the
         // port forwarding).
-        int observatoryHostPort = await _forwardPort(observatoryDeviceUri.port,
+        int observatoryHostPort = await forwardPort(observatoryDeviceUri.port,
             hostPort: await debuggingOptions.findBestObservatoryPort());
         Uri observatoryHostUri = observatoryDeviceUri.replace(port: observatoryHostPort);
 
         Uri diagnosticHostUri;
         if (diagnosticDeviceUri != null) {
           printTrace('Diagnostic Server Uri on device: $diagnosticDeviceUri');
-          int diagnosticHostPort = await _forwardPort(diagnosticDeviceUri.port,
+          int diagnosticHostPort = await forwardPort(diagnosticDeviceUri.port,
               hostPort: await debuggingOptions.findBestDiagnosticPort());
           diagnosticHostUri = diagnosticDeviceUri.replace(port: diagnosticHostPort);
         }

--- a/packages/flutter_tools/lib/src/android/android_device.dart
+++ b/packages/flutter_tools/lib/src/android/android_device.dart
@@ -307,18 +307,10 @@ class AndroidDevice extends Device {
     if (debuggingOptions.debuggingEnabled) {
       // TODO(devoncarew): Remember the forwarding information (so we can later remove the
       // port forwarding).
-      observatoryDiscovery = new ProtocolDiscovery(
-        getLogReader(),
-        ProtocolDiscovery.kObservatoryService,
-        portForwarder: portForwarder,
-        hostPort: debuggingOptions.observatoryPort,
-        defaultHostPort: kDefaultObservatoryPort);
-      diagnosticDiscovery = new ProtocolDiscovery(
-        getLogReader(),
-        ProtocolDiscovery.kDiagnosticService,
-        portForwarder: portForwarder,
-        hostPort: debuggingOptions.diagnosticPort,
-        defaultHostPort: kDefaultDiagnosticPort);
+      observatoryDiscovery = new ProtocolDiscovery.observatory(
+        getLogReader(), portForwarder: portForwarder, hostPort: debuggingOptions.observatoryPort);
+      diagnosticDiscovery = new ProtocolDiscovery.diagnosticService(
+        getLogReader(), portForwarder: portForwarder, hostPort: debuggingOptions.diagnosticPort);
     }
 
     List<String> cmd;

--- a/packages/flutter_tools/lib/src/android/android_device.dart
+++ b/packages/flutter_tools/lib/src/android/android_device.dart
@@ -8,7 +8,6 @@ import 'dart:io';
 
 import '../android/android_sdk.dart';
 import '../application_package.dart';
-import '../base/common.dart';
 import '../base/os.dart';
 import '../base/logger.dart';
 import '../base/process.dart';

--- a/packages/flutter_tools/lib/src/android/android_device.dart
+++ b/packages/flutter_tools/lib/src/android/android_device.dart
@@ -261,7 +261,7 @@ class AndroidDevice extends Device {
     return true;
   }
 
-  Future<int> _forwardPort(int hostPort, int devicePort) async {
+  Future<int> _forwardPort(int devicePort, {int hostPort}) async {
     try {
       hostPort = await portForwarder.forward(devicePort, hostPort: hostPort);
       printTrace('Forwarded host port $hostPort to device port $devicePort');
@@ -372,23 +372,23 @@ class AndroidDevice extends Device {
         }
 
         printTrace('Observatory Uri on device: $observatoryDeviceUri');
-        int observatoryLocalPort = await debuggingOptions.findBestObservatoryPort();
         // TODO(devoncarew): Remember the forwarding information (so we can later remove the
         // port forwarding).
-        observatoryLocalPort = await _forwardPort(observatoryLocalPort, observatoryDeviceUri.port);
-        Uri observatoryLocalUri = observatoryDeviceUri.replace(port: observatoryLocalPort);
+        int observatoryHostPort = await _forwardPort(observatoryDeviceUri.port,
+            hostPort: await debuggingOptions.findBestObservatoryPort());
+        Uri observatoryHostUri = observatoryDeviceUri.replace(port: observatoryHostPort);
 
-        Uri diagnosticLocalUri;
+        Uri diagnosticHostUri;
         if (diagnosticDeviceUri != null) {
           printTrace('Diagnostic Server Uri on device: $diagnosticDeviceUri');
-          int diagnosticLocalPort = await debuggingOptions.findBestDiagnosticPort();
-          diagnosticLocalPort = await _forwardPort(diagnosticLocalPort, diagnosticDeviceUri.port);
-          diagnosticLocalUri = diagnosticDeviceUri.replace(port: diagnosticLocalPort);
+          int diagnosticHostPort = await _forwardPort(diagnosticDeviceUri.port,
+              hostPort: await debuggingOptions.findBestDiagnosticPort());
+          diagnosticHostUri = diagnosticDeviceUri.replace(port: diagnosticHostPort);
         }
 
         return new LaunchResult.succeeded(
-            observatoryUri: observatoryLocalUri,
-            diagnosticUri: diagnosticLocalUri,
+            observatoryUri: observatoryHostUri,
+            diagnosticUri: diagnosticHostUri,
         );
       } catch (error) {
         if (error is TimeoutException)

--- a/packages/flutter_tools/lib/src/android/android_device.dart
+++ b/packages/flutter_tools/lib/src/android/android_device.dart
@@ -348,6 +348,8 @@ class AndroidDevice extends Device {
     // device has printed "Observatory is listening on...".
     printTrace('Waiting for observatory port to be available...');
 
+    // TODO(danrubel) Waiting for observatory and diagnostic services
+    // can be made common across all devices.
     try {
       Uri observatoryUri, diagnosticUri;
 

--- a/packages/flutter_tools/lib/src/device.dart
+++ b/packages/flutter_tools/lib/src/device.dart
@@ -175,6 +175,22 @@ abstract class Device {
   /// Get the port forwarder for this device.
   DevicePortForwarder get portForwarder;
 
+  Future<int> forwardPort(int devicePort, {int hostPort}) async {
+    try {
+      hostPort = await portForwarder
+          .forward(devicePort, hostPort: hostPort)
+          .timeout(const Duration(seconds: 60), onTimeout: () {
+            throw new ToolExit(
+                'Timeout while atempting to foward device port $devicePort');
+          });
+      printTrace('Forwarded host port $hostPort to device port $devicePort');
+      return hostPort;
+    } catch (e) {
+      throw new ToolExit(
+          'Unable to forward host port $hostPort to device port $devicePort: $e');
+    }
+  }
+
   /// Clear the device's logs.
   void clearLogs();
 

--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -459,7 +459,7 @@ class _IOSDevicePortForwarder extends DevicePortForwarder {
 
     _forwardedPorts.add(forwardedPort);
 
-    return 1;
+    return hostPort;
   }
 
   @override

--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -261,18 +261,10 @@ class IOSDevice extends Device {
 
       // TODO(danrubel): The Android device class does something similar to this code below.
       // The various Device subclasses should be refactored and common code moved into the superclass.
-      ProtocolDiscovery observatoryDiscovery = new ProtocolDiscovery(
-        getLogReader(app: app),
-        ProtocolDiscovery.kObservatoryService,
-        portForwarder: portForwarder,
-        hostPort: debuggingOptions.observatoryPort,
-        defaultHostPort: kDefaultObservatoryPort);
-      ProtocolDiscovery diagnosticDiscovery = new ProtocolDiscovery(
-        getLogReader(app: app),
-        ProtocolDiscovery.kDiagnosticService,
-        portForwarder: portForwarder,
-        hostPort: debuggingOptions.diagnosticPort,
-        defaultHostPort: kDefaultDiagnosticPort);
+      ProtocolDiscovery observatoryDiscovery = new ProtocolDiscovery.observatory(
+        getLogReader(app: app), portForwarder: portForwarder, hostPort: debuggingOptions.observatoryPort);
+      ProtocolDiscovery diagnosticDiscovery = new ProtocolDiscovery.diagnosticService(
+        getLogReader(app: app), portForwarder: portForwarder, hostPort: debuggingOptions.diagnosticPort);
 
       Future<Uri> forwardObsUri = observatoryDiscovery.nextUri();
       Future<Uri> forwardDiagUri;

--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -287,13 +287,7 @@ class IOSDevice extends Device {
         }
 
         printTrace("Application launched on the device. Attempting to forward ports.");
-        return await Future.wait(<Future<Uri>>[forwardObsUri, forwardDiagUri])
-            .timeout(
-                kPortForwardTimeout,
-                onTimeout: () {
-                  throw new TimeoutException('Timeout while waiting to acquire and forward ports.');
-                },
-            );
+        return await Future.wait(<Future<Uri>>[forwardObsUri, forwardDiagUri]);
       });
 
       printTrace("Observatory Uri on device: ${uris[0]}");
@@ -318,20 +312,8 @@ class IOSDevice extends Device {
       ApplicationPackage app,
       String serviceName,
       int localPort) async {
-    Duration stepTimeout = const Duration(seconds: 60);
 
-    Future<Uri> remote = new ProtocolDiscovery(getLogReader(app: app), serviceName).nextUri();
-
-    Uri remoteUri = await remote.timeout(stepTimeout,
-        onTimeout: () {
-      printTrace("Timeout while attempting to retrieve remote Uri for $serviceName");
-      return null;
-    });
-
-    if (remoteUri == null) {
-      printTrace("Could not read Uri on device for $serviceName");
-      return null;
-    }
+    Uri remoteUri = await new ProtocolDiscovery(getLogReader(app: app), serviceName).nextUri();
 
     if ((localPort == null) || (localPort == 0)) {
       localPort = await findAvailablePort();

--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -338,17 +338,7 @@ class IOSDevice extends Device {
       printTrace("Auto selected local port to $localPort");
     }
 
-    int forwardResult = await portForwarder
-      .forward(remoteUri.port, hostPort: localPort)
-      .timeout(stepTimeout, onTimeout: () {
-        printTrace("Timeout while atempting to foward port for $serviceName");
-        return null;
-      });
-
-    if (forwardResult == null) {
-      printTrace("Could not foward remote $serviceName port $remoteUri to local port $localPort");
-      return null;
-    }
+    int forwardResult = await forwardPort(remoteUri.port, hostPort: localPort);
 
     Uri forwardUri = remoteUri.replace(port: forwardResult);
 

--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -7,7 +7,6 @@ import 'dart:convert';
 import 'dart:io';
 
 import '../application_package.dart';
-import '../base/common.dart';
 import '../base/os.dart';
 import '../base/process.dart';
 import '../base/process_manager.dart';

--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -294,6 +294,9 @@ class IOSDevice extends Device {
 
         printTrace("Application launched on the device. Attempting to forward ports.");
         return await Future.wait(<Future<Uri>>[forwardObsUri, forwardDiagUri]);
+      }).whenComplete(() {
+        observatoryDiscovery.cancel();
+        diagnosticDiscovery.cancel();
       });
 
       localObsUri = uris[0];

--- a/packages/flutter_tools/lib/src/ios/simulators.dart
+++ b/packages/flutter_tools/lib/src/ios/simulators.dart
@@ -461,25 +461,23 @@ class IOSSimulator extends Device {
 
     if (!debuggingOptions.debuggingEnabled) {
       return new LaunchResult.succeeded();
-    } else {
-      // Wait for the service protocol port here. This will complete once the
-      // device has printed "Observatory is listening on..."
-      printTrace('Waiting for observatory port to be available...');
+    }
 
-      ProtocolDiscovery observatoryDiscovery = new ProtocolDiscovery(
-          getLogReader(app: app), ProtocolDiscovery.kObservatoryService);
+    // Wait for the service protocol port here. This will complete once the
+    // device has printed "Observatory is listening on..."
+    printTrace('Waiting for observatory port to be available...');
 
-      try {
-        Uri deviceUri = await observatoryDiscovery.nextUri();
-        printTrace('Observatory Uri on simulator: $deviceUri');
-        printStatus('Observatory listening on $deviceUri');
-        return new LaunchResult.succeeded(observatoryUri: deviceUri);
-      } catch (error) {
-        printError('Error waiting for a debug connection: $error');
-        return new LaunchResult.failed();
-      } finally {
-        observatoryDiscovery.cancel();
-      }
+    ProtocolDiscovery observatoryDiscovery = new ProtocolDiscovery(
+        getLogReader(app: app), ProtocolDiscovery.kObservatoryService);
+
+    try {
+      Uri deviceUri = await observatoryDiscovery.nextUri();
+      return new LaunchResult.succeeded(observatoryUri: deviceUri);
+    } catch (error) {
+      printError('Error waiting for a debug connection: $error');
+      return new LaunchResult.failed();
+    } finally {
+      observatoryDiscovery.cancel();
     }
   }
 

--- a/packages/flutter_tools/lib/src/ios/simulators.dart
+++ b/packages/flutter_tools/lib/src/ios/simulators.dart
@@ -467,9 +467,7 @@ class IOSSimulator extends Device {
     // device has printed "Observatory is listening on..."
     printTrace('Waiting for observatory port to be available...');
 
-    ProtocolDiscovery observatoryDiscovery = new ProtocolDiscovery(
-        getLogReader(app: app), ProtocolDiscovery.kObservatoryService);
-
+    ProtocolDiscovery observatoryDiscovery = new ProtocolDiscovery.observatory(getLogReader(app: app));
     try {
       Uri deviceUri = await observatoryDiscovery.nextUri();
       return new LaunchResult.succeeded(observatoryUri: deviceUri);

--- a/packages/flutter_tools/lib/src/ios/simulators.dart
+++ b/packages/flutter_tools/lib/src/ios/simulators.dart
@@ -430,12 +430,6 @@ class IOSSimulator extends Device {
         return new LaunchResult.failed();
     }
 
-    ProtocolDiscovery observatoryDiscovery;
-
-    if (debuggingOptions.debuggingEnabled)
-      observatoryDiscovery = new ProtocolDiscovery(getLogReader(app: app),
-                                                   ProtocolDiscovery.kObservatoryService);
-
     // Prepare launch arguments.
     List<String> args = <String>[];
 
@@ -472,18 +466,16 @@ class IOSSimulator extends Device {
       // device has printed "Observatory is listening on..."
       printTrace('Waiting for observatory port to be available...');
 
+      ProtocolDiscovery observatoryDiscovery = new ProtocolDiscovery(
+          getLogReader(app: app), ProtocolDiscovery.kObservatoryService);
+
       try {
-        Uri deviceUri = await observatoryDiscovery
-          .nextUri()
-          .timeout(new Duration(seconds: 20));
+        Uri deviceUri = await observatoryDiscovery.nextUri();
         printTrace('Observatory Uri on simulator: $deviceUri');
         printStatus('Observatory listening on $deviceUri');
         return new LaunchResult.succeeded(observatoryUri: deviceUri);
       } catch (error) {
-        if (error is TimeoutException)
-          printError('Timed out while waiting for a debug connection.');
-        else
-          printError('Error waiting for a debug connection: $error');
+        printError('Error waiting for a debug connection: $error');
         return new LaunchResult.failed();
       } finally {
         observatoryDiscovery.cancel();

--- a/packages/flutter_tools/lib/src/protocol_discovery.dart
+++ b/packages/flutter_tools/lib/src/protocol_discovery.dart
@@ -21,6 +21,20 @@ class ProtocolDiscovery {
     assert(portForwarder == null || defaultHostPort != null);
   }
 
+  factory ProtocolDiscovery.observatory(DeviceLogReader logReader,
+          {DevicePortForwarder portForwarder, int hostPort}) =>
+      new ProtocolDiscovery(logReader, kObservatoryService,
+          portForwarder: portForwarder,
+          hostPort: hostPort,
+          defaultHostPort: kDefaultObservatoryPort);
+
+  factory ProtocolDiscovery.diagnosticService(DeviceLogReader logReader,
+          {DevicePortForwarder portForwarder, int hostPort}) =>
+      new ProtocolDiscovery(logReader, kDiagnosticService,
+          portForwarder: portForwarder,
+          hostPort: hostPort,
+          defaultHostPort: kDefaultDiagnosticPort);
+
   static const String kObservatoryService = 'Observatory';
   static const String kDiagnosticService = 'Diagnostic server';
 

--- a/packages/flutter_tools/lib/src/protocol_discovery.dart
+++ b/packages/flutter_tools/lib/src/protocol_discovery.dart
@@ -4,6 +4,7 @@
 
 import 'dart:async';
 
+import 'base/common.dart';
 import 'device.dart';
 
 /// Discover service protocol ports on devices.
@@ -26,7 +27,11 @@ class ProtocolDiscovery {
 
   /// The [Future] returned by this function will complete when the next service
   /// Uri is found.
-  Future<Uri> nextUri() => _completer.future;
+  Future<Uri> nextUri() => _completer.future.timeout(
+      const Duration(seconds: 60), onTimeout: () {
+        throwToolExit('Timeout while attempting to retrieve Uri for $_serviceName');
+      }
+  );
 
   void cancel() {
     _subscription.cancel();

--- a/packages/flutter_tools/lib/src/protocol_discovery.dart
+++ b/packages/flutter_tools/lib/src/protocol_discovery.dart
@@ -5,15 +5,20 @@
 import 'dart:async';
 
 import 'base/common.dart';
+import 'base/os.dart';
 import 'device.dart';
+import 'globals.dart';
 
-/// Discover service protocol ports on devices.
+/// Discover service protocol on a device
+/// and forward the service protocol device port to the host.
 class ProtocolDiscovery {
   /// [logReader] - a [DeviceLogReader] to look for service messages in.
-  ProtocolDiscovery(DeviceLogReader logReader, String serviceName)
+  ProtocolDiscovery(DeviceLogReader logReader, String serviceName,
+      {this.portForwarder, this.hostPort, this.defaultHostPort})
       : _logReader = logReader, _serviceName = serviceName {
     assert(_logReader != null);
     _subscription = _logReader.logLines.listen(_onLine);
+    assert(portForwarder == null || defaultHostPort != null);
   }
 
   static const String kObservatoryService = 'Observatory';
@@ -21,17 +26,39 @@ class ProtocolDiscovery {
 
   final DeviceLogReader _logReader;
   final String _serviceName;
+  final DevicePortForwarder portForwarder;
+  int hostPort;
+  final int defaultHostPort;
 
   Completer<Uri> _completer = new Completer<Uri>();
   StreamSubscription<String> _subscription;
 
   /// The [Future] returned by this function will complete when the next service
   /// Uri is found.
-  Future<Uri> nextUri() => _completer.future.timeout(
+  Future<Uri> nextUri() async {
+    Uri deviceUri = await _completer.future.timeout(
       const Duration(seconds: 60), onTimeout: () {
         throwToolExit('Timeout while attempting to retrieve Uri for $_serviceName');
       }
-  );
+    );
+    printTrace('$_serviceName Uri on device: $deviceUri');
+    Uri hostUri;
+    if (portForwarder != null) {
+      int devicePort = deviceUri.port;
+      hostPort ??= await findPreferredPort(defaultHostPort);
+      hostPort = await portForwarder
+          .forward(devicePort, hostPort: hostPort)
+          .timeout(const Duration(seconds: 60), onTimeout: () {
+            throwToolExit('Timeout while atempting to foward device port $devicePort');
+          });
+      printTrace('Forwarded host port $hostPort to device port $devicePort');
+      hostUri = deviceUri.replace(port: hostPort);
+    } else {
+      hostUri = deviceUri;
+    }
+    printStatus('$_serviceName listening on $hostUri');
+    return hostUri;
+  }
 
   void cancel() {
     _subscription.cancel();

--- a/packages/flutter_tools/test/protocol_discovery_test.dart
+++ b/packages/flutter_tools/test/protocol_discovery_test.dart
@@ -4,14 +4,16 @@
 
 import 'dart:async';
 
+import 'package:flutter_tools/src/device.dart';
 import 'package:flutter_tools/src/protocol_discovery.dart';
 import 'package:test/test.dart';
 
+import 'src/context.dart';
 import 'src/mocks.dart';
 
 void main() {
-  group('service_protocol', () {
-    test('Discovery Heartbeat', () async {
+  group('service_protocol discovery', () {
+    testUsingContext('no port forwarding', () async {
       MockDeviceLogReader logReader = new MockDeviceLogReader();
       ProtocolDiscovery discoverer =
           new ProtocolDiscovery(logReader, ProtocolDiscovery.kObservatoryService);
@@ -68,5 +70,60 @@ void main() {
       discoverer.cancel();
       logReader.dispose();
     });
+
+    testUsingContext('port forwarding - default port', () async {
+      MockDeviceLogReader logReader = new MockDeviceLogReader();
+      ProtocolDiscovery discoverer = new ProtocolDiscovery(
+          logReader,
+          ProtocolDiscovery.kObservatoryService,
+          portForwarder: new MockPortForwarder(99),
+          defaultHostPort: 54777);
+
+      // Get next port future.
+      Future<Uri> nextUri = discoverer.nextUri();
+      logReader.addLine('I/flutter : Observatory listening on http://somehost:54804/PTwjm8Ii8qg=/');
+      Uri uri = await nextUri;
+      expect(uri.port, 54777);
+      expect('$uri', 'http://somehost:54777/PTwjm8Ii8qg=/');
+
+      discoverer.cancel();
+      logReader.dispose();
+    });
+
+    testUsingContext('port forwarding - specified port', () async {
+      MockDeviceLogReader logReader = new MockDeviceLogReader();
+      ProtocolDiscovery discoverer = new ProtocolDiscovery(
+          logReader,
+          ProtocolDiscovery.kObservatoryService,
+          portForwarder: new MockPortForwarder(99),
+          hostPort: 1243,
+          defaultHostPort: 192);
+
+      // Get next port future.
+      Future<Uri> nextUri = discoverer.nextUri();
+      logReader.addLine('I/flutter : Observatory listening on http://somehost:54804/PTwjm8Ii8qg=/');
+      Uri uri = await nextUri;
+      expect(uri.port, 1243);
+      expect('$uri', 'http://somehost:1243/PTwjm8Ii8qg=/');
+
+      discoverer.cancel();
+      logReader.dispose();
+    });
   });
+}
+
+class MockPortForwarder extends DevicePortForwarder {
+  final int availablePort;
+  MockPortForwarder([this.availablePort]);
+
+  @override
+  Future<int> forward(int devicePort, {int hostPort}) async => hostPort ?? availablePort;
+
+  @override
+  List<ForwardedPort> get forwardedPorts => throw 'not implemented';
+
+  @override
+  Future<Null> unforward(ForwardedPort forwardedPort) {
+    throw 'not implemented';
+  }
 }


### PR DESCRIPTION
This moves the various copies of port forwarding code in the Device subclasses into the `ProtocolDiscovery` class.

* move port forwarding to a common location
* throw exception if protocol Uri is not discovered or port forwarding fails
* cancel discovery protocol subscriptions on iOS launches (wasn't happening before)
* fix iOS port forwarding to match other implementations
* add tests

@johnmccutchan 