### PR TITLE
Unconditionally enable Dart profiling on for all devices and platforms.

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_device.dart
+++ b/packages/flutter_tools/lib/src/android/android_device.dart
@@ -327,6 +327,7 @@ class AndroidDevice extends Device {
       '-a', 'android.intent.action.RUN',
       '-f', '0x20000000',  // FLAG_ACTIVITY_SINGLE_TOP
       '--ez', 'enable-background-compilation', 'true',
+      '--ez', 'enable-dart-profiling', 'true',
     ]);
 
     if (traceStartup)

--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -213,7 +213,7 @@ class IOSDevice extends Device {
     }
 
     // Step 3: Attempt to install the application on the device.
-    List<String> launchArguments = <String>[];
+    List<String> launchArguments = <String>["--enable-dart-profiling"];
 
     if (debuggingOptions.startPaused)
       launchArguments.add("--start-paused");

--- a/packages/flutter_tools/lib/src/ios/simulators.dart
+++ b/packages/flutter_tools/lib/src/ios/simulators.dart
@@ -436,7 +436,7 @@ class IOSSimulator extends Device {
                                                    ProtocolDiscovery.kObservatoryService);
 
     // Prepare launch arguments.
-    List<String> args = <String>[];
+    List<String> args = <String>["--enable-dart-profiling"];
 
     if (!prebuiltApplication) {
       args.addAll(<String>[

--- a/packages/flutter_tools/lib/src/test/flutter_platform.dart
+++ b/packages/flutter_tools/lib/src/test/flutter_platform.dart
@@ -64,6 +64,7 @@ Future<Process> _startProcess(String mainPath, { String packages, int observator
     arguments.add('--disable-observatory');
   }
   arguments.addAll(<String>[
+    '--enable-dart-profiling',
     '--non-interactive',
     '--enable-checked-mode',
     '--packages=$packages',


### PR DESCRIPTION
It is not enabled by default in the VM because applications not launched via the tools may try to connect with the debugger. This causes the debugger and the IDE to hang on Mac.

I'll make sure the --ez argument on Android is picked up correctly in an engine patch.