### PR TITLE
Fix context.dart to properly handle nested zones

### DIFF
--- a/packages/flutter_tools/lib/src/build_info.dart
+++ b/packages/flutter_tools/lib/src/build_info.dart
@@ -121,7 +121,7 @@ HostPlatform getCurrentHostPlatform() {
 String getBuildDirectory() {
   // TODO(johnmccutchan): Stop calling this function as part of setting
   // up command line argument processing.
-  if (context == null)
+  if (context == null || config == null)
     return 'build';
 
   String buildDir = config.getValue('build-dir') ?? 'build';


### PR DESCRIPTION
This fixes an infinite loop in the code that walks the parent
context chain looking for a variable.

This also includes a fix in build_info.dart whereby if the context
is set but the config is not yet set, we were trying to dereference
null.