### PR TITLE
some updates to the launch verbiage

### DIFF
--- a/packages/flutter_tools/lib/src/commands/daemon.dart
+++ b/packages/flutter_tools/lib/src/commands/daemon.dart
@@ -337,6 +337,9 @@ class AppDomain extends Domain {
         throw 'unhandle build mode: $buildMode';
     }
 
+    if (device.isLocalEmulator && !isEmulatorBuildMode(buildMode))
+      throw '${toTitleCase(getModeName(buildMode))} mode is not supported for emulators.';
+
     // We change the current working directory for the duration of the `start` command.
     Directory cwd = Directory.current;
     Directory.current = new Directory(projectDirectory);

--- a/packages/flutter_tools/lib/src/commands/run.dart
+++ b/packages/flutter_tools/lib/src/commands/run.dart
@@ -171,9 +171,14 @@ class RunCommand extends RunCommandBase {
     if (argResults['machine']) {
       Daemon daemon = new Daemon(stdinCommandStream, stdoutCommandResponse,
           notifyingLogger: new NotifyingLogger(), logToStdout: true);
-      AppInstance app = daemon.appDomain.startApp(
-        device, Directory.current.path, targetFile, route,
-        getBuildMode(), argResults['start-paused'], hotMode);
+      AppInstance app;
+      try {
+        app = daemon.appDomain.startApp(
+          device, Directory.current.path, targetFile, route,
+          getBuildMode(), argResults['start-paused'], hotMode);
+      } catch (error) {
+        throwToolExit(error.toString());
+      }
       int result = await app.runner.waitForAppToFinish();
       if (result != 0)
         throwToolExit(null, exitCode: result);

--- a/packages/flutter_tools/lib/src/hot.dart
+++ b/packages/flutter_tools/lib/src/hot.dart
@@ -196,7 +196,8 @@ class HotRunner extends ResidentRunner {
 
     await startEchoingDeviceLog(_package);
 
-    printStatus('Launching ${getDisplayPath(_mainPath)} on ${device.name}...');
+    String modeName = getModeName(debuggingOptions.buildMode);
+    printStatus('Launching ${getDisplayPath(_mainPath)} on ${device.name} in $modeName mode...');
 
     // Start the application.
     Future<LaunchResult> futureResult = device.startApp(

--- a/packages/flutter_tools/lib/src/run.dart
+++ b/packages/flutter_tools/lib/src/run.dart
@@ -10,6 +10,7 @@ import 'package:stack_trace/stack_trace.dart';
 
 import 'application_package.dart';
 import 'base/utils.dart';
+import 'build_info.dart';
 import 'commands/trace.dart';
 import 'device.dart';
 import 'globals.dart';
@@ -94,11 +95,13 @@ class RunAndStayResident extends ResidentRunner {
       platformArgs = <String, dynamic>{ 'trace-startup': traceStartup };
 
     await startEchoingDeviceLog(_package);
+
+    String modeName = getModeName(debuggingOptions.buildMode);
     if (_mainPath == null) {
       assert(prebuiltMode);
-      printStatus('Running ${_package.displayName} on ${device.name}');
+      printStatus('Launching ${_package.displayName} on ${device.name} in $modeName mode...');
     } else {
-      printStatus('Running ${getDisplayPath(_mainPath)} on ${device.name}...');
+      printStatus('Launching ${getDisplayPath(_mainPath)} on ${device.name} in $modeName mode...');
     }
 
     _result = await device.startApp(


### PR DESCRIPTION
- add a check that we don't try and launch in `--profile` mode on an emulator
- if starting an app throw an exception, pass that exception on to the caller (using `throwToolExit` means that we exit the process and write the error to stderr, instead of assuming the tool crashed and creating a bug report)
- unify the verbiage for what we print out when an app starts, and add information about the mode (debug / profile / release)

```
Launching lib/main.dart on iPhone 6 in debug mode...
```
