### PR TITLE
Provide an empty asset manifest if the FLX does not contain any assets

### DIFF
--- a/packages/flutter_tools/lib/src/asset.dart
+++ b/packages/flutter_tools/lib/src/asset.dart
@@ -111,6 +111,7 @@ class AssetBundle {
     }
     if (manifest == null) {
       // No manifest file found for this application.
+      entries.add(new AssetBundleEntry.fromString('AssetManifest.json', '{}'));
       return 0;
     }
     if (manifest != null) {

--- a/packages/flutter_tools/test/asset_bundle_test.dart
+++ b/packages/flutter_tools/test/asset_bundle_test.dart
@@ -61,4 +61,12 @@ void main()  {
       expect(assetContents, UTF8.decode(entry.contentsAsBytes()));
     });
   });
+
+  group('AssetBundle.build', () {
+    test('nonempty', () async {
+      AssetBundle ab = new AssetBundle();
+      expect(await ab.build(), 0);
+      expect(ab.entries.length, greaterThan(0));
+    });
+  });
 }


### PR DESCRIPTION
Without this, an FLX with no assets may be completely empty in AOT mode.
This will result in a warning when the engine's unzip library tries to
parse the FLX.

Fixes https://github.com/flutter/flutter/issues/7060