### PR TITLE
update create template intellij metadata

### DIFF
--- a/packages/flutter_tools/templates/create/projectName.iml.tmpl
+++ b/packages/flutter_tools/templates/create/projectName.iml.tmpl
@@ -3,6 +3,8 @@
   <component name="NewModuleRootManager" inherit-compiler-output="true">
     <exclude-output />
     <content url="file://$MODULE_DIR$">
+      <excludeFolder url="file://$MODULE_DIR$/.pub" />
+      <excludeFolder url="file://$MODULE_DIR$/build" />
       <excludeFolder url="file://$MODULE_DIR$/packages" />
     </content>
     <orderEntry type="sourceFolder" forTests="false" />


### PR DESCRIPTION
- update the `flutter create` template intellij metadata (so that opening a new project in IntelliJ doesn't change the files on disk)

@pq