### PR TITLE
Update Flutter to use the latest dartdoc

### DIFF
--- a/dev/bots/docs.sh
+++ b/dev/bots/docs.sh
@@ -2,9 +2,7 @@
 set -e
 
 # Install dartdoc.
-# Versions after 0.9.7+1 suffer from https://github.com/dart-lang/dartdoc/issues/1236
-# so are we pinned to this old version until that bug is fixed.
-pub global activate dartdoc 0.9.7+1
+pub global activate dartdoc
 
 # This script generates a unified doc set, and creates
 # a custom index.html, placing everything into dev/docs/doc

--- a/dev/tools/dartdoc.dart
+++ b/dev/tools/dartdoc.dart
@@ -62,16 +62,14 @@ dependencies:
     'global', 'run', 'dartdoc',
     '--header', 'styles.html',
     '--header', 'analytics.html',
-    '--dart-sdk', '../../bin/cache/dart-sdk',
     '--exclude', 'temp_doc',
     '--favicon=favicon.ico',
     '--use-categories'
   ];
 
-  for (String libraryRef in libraryRefs()) {
-    String name = path.basename(libraryRef);
+  for (String libraryRef in libraryRefs(diskPath:true)) {
     args.add('--include-external');
-    args.add(name.substring(0, name.length - 5));
+    args.add(libraryRef);
   }
 
   process = await Process.start('pub', args, workingDirectory: 'dev/docs');
@@ -145,6 +143,7 @@ List<String> findPackageNames() {
   return findPackages().map((Directory dir) => path.basename(dir.path)).toList();
 }
 
+/// Finds all packages in the Flutter SDK
 List<Directory> findPackages() {
   return new Directory('packages')
     .listSync()
@@ -158,12 +157,19 @@ List<Directory> findPackages() {
     .toList();
 }
 
-Iterable<String> libraryRefs() sync* {
+/// Returns import or on-disk paths for all libraries in the Flutter SDK.
+///
+/// diskPath toggles between import paths vs. disk paths.
+Iterable<String> libraryRefs({bool diskPath: false}) sync* {
   for (Directory dir in findPackages()) {
     String dirName = path.basename(dir.path);
     for (FileSystemEntity file in new Directory('${dir.path}/lib').listSync()) {
-      if (file is File && file.path.endsWith('.dart'))
-        yield '$dirName/${path.basename(file.path)}';
+      if (file is File && file.path.endsWith('.dart')) {
+        if (diskPath)
+          yield '$dirName/lib/${path.basename(file.path)}';
+        else
+          yield '$dirName/${path.basename(file.path)}';
+      }
     }
   }
 }


### PR DESCRIPTION
Now that https://github.com/dart-lang/dartdoc/issues/1236 is fixed.

This can't be merged until dartdoc does a release.