### PR TITLE
AppBar Menu and action button center alignment

### DIFF
--- a/packages/flutter/lib/src/material/app_bar.dart
+++ b/packages/flutter/lib/src/material/app_bar.dart
@@ -55,8 +55,11 @@ class _ToolbarLayout extends MultiChildLayoutDelegate {
 
     if (hasChild(_ToolbarSlot.actions)) {
       final BoxConstraints constraints = new BoxConstraints.loose(size);
-      actionsWidth = layoutChild(_ToolbarSlot.actions, constraints).width;
-      positionChild(_ToolbarSlot.actions, new Offset(size.width - actionsWidth, 0.0));
+      final Size actionsSize = layoutChild(_ToolbarSlot.actions, constraints);
+      final double actionsLeft = size.width - actionsSize.width;
+      final double actionsTop = (size.height - actionsSize.height) / 2.0;
+      actionsWidth = actionsSize.width;
+      positionChild(_ToolbarSlot.actions, new Offset(actionsLeft, actionsTop));
     }
 
     if (hasChild(_ToolbarSlot.title)) {

--- a/packages/flutter/test/material/app_bar_test.dart
+++ b/packages/flutter/test/material/app_bar_test.dart
@@ -197,4 +197,40 @@ void main() {
     Finder title = find.text('X');
     expect(tester.getSize(title).isEmpty, isTrue);
   });
+
+  testWidgets('AppBar actions are vertically centered', (WidgetTester tester) async {
+    UniqueKey appBarKey = new UniqueKey();
+    UniqueKey leadingKey = new UniqueKey();
+    UniqueKey titleKey = new UniqueKey();
+    UniqueKey action0Key = new UniqueKey();
+    UniqueKey action1Key = new UniqueKey();
+
+    await tester.pumpWidget(
+      new MaterialApp(
+        home: new Scaffold(
+          appBar: new AppBar(
+            key: appBarKey,
+            leading: new SizedBox(key: leadingKey, height: 50.0),
+            title: new SizedBox(key: titleKey, height: 40.0),
+            actions: <Widget>[
+              new SizedBox(key: action0Key, height: 20.0),
+              new SizedBox(key: action1Key, height: 30.0),
+            ],
+          ),
+        ),
+      )
+    );
+
+    // The vertical center of the widget with key, in global coordinates.
+    double yCenter(Key key) {
+      RenderBox box = tester.renderObject(find.byKey(appBarKey));
+      return box.localToGlobal(new Point(0.0, box.size.height / 2.0)).y;
+    }
+
+    expect(yCenter(appBarKey), equals(yCenter(leadingKey)));
+    expect(yCenter(appBarKey), equals(yCenter(titleKey)));
+    expect(yCenter(appBarKey), equals(yCenter(action0Key)));
+    expect(yCenter(appBarKey), equals(yCenter(action1Key)));
+  });
+
 }


### PR DESCRIPTION
Vertically enter the toolbar's actions.

Fixes #7185