### PR TITLE
 Don't pad the Input/InputContainer's icon

### DIFF
--- a/examples/flutter_gallery/lib/demo/text_field_demo.dart
+++ b/examples/flutter_gallery/lib/demo/text_field_demo.dart
@@ -87,6 +87,7 @@ class TextFieldDemoState extends State<TextFieldDemo> {
               validator: _validateName,
               builder: (FormFieldState<InputValue> field) {
                 return new Input(
+                  icon: new Icon(Icons.person),
                   hintText: 'What do people call you?',
                   labelText: 'Name',
                   value: field.value,
@@ -96,6 +97,7 @@ class TextFieldDemoState extends State<TextFieldDemo> {
               },
             ),
             new InputFormField(
+              icon: new Icon(Icons.phone),
               hintText: 'Where can we reach you?',
               labelText: 'Phone Number',
               keyboardType: TextInputType.phone,

--- a/packages/flutter/lib/src/material/input.dart
+++ b/packages/flutter/lib/src/material/input.dart
@@ -358,7 +358,7 @@ class _InputContainerState extends State<InputContainer> {
         crossAxisAlignment: CrossAxisAlignment.start,
         children: <Widget>[
           new Container(
-            margin: new EdgeInsets.only(right: 16.0, top: iconTop),
+            margin: new EdgeInsets.only(top: iconTop),
             width: config.isDense ? 40.0 : 48.0,
             child: new IconTheme.merge(
               context: context,

--- a/packages/flutter/test/widgets/input_test.dart
+++ b/packages/flutter/test/widgets/input_test.dart
@@ -810,4 +810,23 @@ void main() {
     newPos = tester.getTopLeft(find.text('Second'));
     expect(newPos.y, lessThan(pos.y));
   });
+
+  testWidgets('No space between Input icon and text', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      new Center(
+        child: new Material(
+          child: new Input(
+            icon: new Icon(Icons.phone),
+            labelText: 'label',
+            value: InputValue.empty,
+          ),
+        ),
+      ),
+    );
+
+    final double iconRight = tester.getTopRight(find.byType(Icon)).x;
+    expect(iconRight, equals(tester.getTopLeft(find.text('label')).x));
+    expect(iconRight, equals(tester.getTopLeft(find.byType(InputField)).x));
+  });
+
 }


### PR DESCRIPTION
Eliminated the 16 pixel right margin on the InputContainer's icon.

Added icons to the gallery text field demo.

Fixes #7272
