### PR TITLE
Forms provide more control over when they validate.

### DIFF
--- a/examples/flutter_gallery/lib/demo/text_field_demo.dart
+++ b/examples/flutter_gallery/lib/demo/text_field_demo.dart
@@ -35,8 +35,8 @@ class TextFieldDemoState extends State<TextFieldDemo> {
   GlobalKey<FormFieldState<InputValue>> _passwordFieldKey = new GlobalKey<FormFieldState<InputValue>>();
   void _handleSubmitted() {
     FormState form = _formKey.currentState;
-    _autovalidate = true;  // Start validating on every change.
     if (!form.validate()) {
+      _autovalidate = true;  // Start validating on every change.
       showInSnackBar('Please fix the errors in red before submitting.');
     } else {
       form.save();

--- a/examples/flutter_gallery/lib/demo/text_field_demo.dart
+++ b/examples/flutter_gallery/lib/demo/text_field_demo.dart
@@ -30,11 +30,13 @@ class TextFieldDemoState extends State<TextFieldDemo> {
     ));
   }
 
+  bool _autovalidate = false;
   GlobalKey<FormState> _formKey = new GlobalKey<FormState>();
   GlobalKey<FormFieldState<InputValue>> _passwordFieldKey = new GlobalKey<FormFieldState<InputValue>>();
   void _handleSubmitted() {
     FormState form = _formKey.currentState;
-    if (form.hasErrors) {
+    _autovalidate = true;  // Start validating on every change.
+    if (!form.validate()) {
       showInSnackBar('Please fix the errors in red before submitting.');
     } else {
       form.save();
@@ -76,6 +78,7 @@ class TextFieldDemoState extends State<TextFieldDemo> {
       ),
       body: new Form(
         key: _formKey,
+        autovalidate: _autovalidate,
         child: new Block(
           padding: const EdgeInsets.symmetric(horizontal: 16.0),
           children: <Widget>[


### PR DESCRIPTION
Callers can manually validate by calling validate(), or tell the Form to
validate on every change by setting the `autovalidate` parameter.

Fixes https://github.com/flutter/flutter/issues/7219