### PR TITLE
Tooltip update can cause assert

### DIFF
--- a/packages/flutter/test/material/tooltip_test.dart
+++ b/packages/flutter/test/material/tooltip_test.dart
@@ -473,4 +473,36 @@ void main() {
 
     semantics.dispose();
   });
+
+  testWidgets('Tooltip overlay does not update', (WidgetTester tester) async {
+    Widget buildApp(String text) {
+      return new MaterialApp(
+        home: new Center(
+          child: new Tooltip(
+            message: text,
+            child: new Container(
+              width: 100.0,
+              height: 100.0,
+              decoration: new BoxDecoration(
+                backgroundColor: Colors.green[500]
+              )
+            )
+          )
+        )
+      );
+    }
+
+    await tester.pumpWidget(buildApp(tooltipText));
+    await tester.longPress(find.byType(Tooltip));
+    expect(find.text(tooltipText), findsOneWidget);
+    await tester.pumpWidget(buildApp('NEW'));
+    expect(find.text(tooltipText), findsOneWidget);
+    await tester.tapAt(const Point(5.0, 5.0));
+    await tester.pump();
+    await tester.pump(const Duration(seconds: 1));
+    expect(find.text(tooltipText), findsNothing);
+    await tester.longPress(find.byType(Tooltip));
+    expect(find.text(tooltipText), findsNothing);
+  });
+
 }

--- a/packages/flutter_test/lib/src/controller.dart
+++ b/packages/flutter_test/lib/src/controller.dart
@@ -267,6 +267,26 @@ class WidgetController {
     });
   }
 
+  /// Dispatch a pointer down / pointer up sequence (with a delay of
+  /// [kLongPressTimeout] + [kPressTimeout] between the two events) at the
+  /// center of the given widget, assuming it is exposed. If the center of the
+  /// widget is not exposed, this might send events to another
+  /// object.
+  Future<Null> longPress(Finder finder, { int pointer: 1 }) {
+    return longPressAt(getCenter(finder), pointer: pointer);
+  }
+
+  /// Dispatch a pointer down / pointer up sequence at the given location with
+  /// a delay of [kLongPressTimeout] + [kPressTimeout] between the two events.
+  Future<Null> longPressAt(Point location, { int pointer: 1 }) {
+    return TestAsyncUtils.guard(() async {
+      TestGesture gesture = await startGesture(location, pointer: pointer);
+      await pump(kLongPressTimeout + kPressTimeout);
+      await gesture.up();
+      return null;
+    });
+  }
+
   /// Attempts a fling gesture starting from the center of the given
   /// widget, moving the given distance, reaching the given velocity.
   ///


### PR DESCRIPTION
We were trying to update the tooltip overlay entry, but that cannot work
because the overlay entry might have already built. Instead, we keep the
old value.

Fixes #7151