### PR TITLE
Slider shouldn't be open at min

### DIFF
--- a/examples/flutter_gallery/lib/demo/slider_demo.dart
+++ b/examples/flutter_gallery/lib/demo/slider_demo.dart
@@ -30,6 +30,7 @@ class _SliderDemoState extends State<SliderDemo> {
                   value: _value,
                   min: 0.0,
                   max: 100.0,
+                  thumbOpenAtMin: true,
                   onChanged: (double value) {
                     setState(() {
                       _value = value;
@@ -42,7 +43,7 @@ class _SliderDemoState extends State<SliderDemo> {
             new Column(
               mainAxisSize: MainAxisSize.min,
               children: <Widget> [
-                new Slider(value: 0.25, onChanged: null),
+                new Slider(value: 0.25, thumbOpenAtMin: true, onChanged: null),
                 new Text('Disabled'),
               ]
             ),
@@ -55,6 +56,7 @@ class _SliderDemoState extends State<SliderDemo> {
                   max: 100.0,
                   divisions: 5,
                   label: '${_discreteValue.round()}',
+                  thumbOpenAtMin: true,
                   onChanged: (double value) {
                     setState(() {
                       _discreteValue = value;

--- a/packages/flutter/lib/src/cupertino/slider.dart
+++ b/packages/flutter/lib/src/cupertino/slider.dart
@@ -89,7 +89,7 @@ class CupertinoSlider extends StatefulWidget {
   /// ```
   final ValueChanged<double> onChanged;
 
-  /// The minium value the user can select.
+  /// The minimum value the user can select.
   ///
   /// Defaults to 0.0.
   final double min;

--- a/packages/flutter/test/material/mergeable_material_test.dart
+++ b/packages/flutter/test/material/mergeable_material_test.dart
@@ -5,6 +5,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import '../rendering/mock_canvas.dart';
+
 enum RadiusType {
   Sharp,
   Shifting,
@@ -57,27 +59,6 @@ BorderRadius getBorderRadius(WidgetTester tester, int index) {
   BoxDecoration boxDecoration = container.decoration;
 
   return boxDecoration.borderRadius;
-}
-
-class TestCanvas implements Canvas {
-  final List<Invocation> invocations = <Invocation>[];
-
-  @override
-  void noSuchMethod(Invocation invocation) {
-    invocations.add(invocation);
-  }
-}
-
-class TestPaintingContext implements PaintingContext {
-  TestPaintingContext(this.canvas);
-
-  @override
-  final Canvas canvas;
-
-  @override
-  void noSuchMethod(Invocation invocation) {
-
-  }
 }
 
 void main() {
@@ -223,9 +204,9 @@ void main() {
     );
 
     RenderBox box = tester.renderObject(find.byType(MergeableMaterial));
-    TestCanvas canvas = new TestCanvas();
+    MockCanvas canvas = new MockCanvas();
 
-    box.paint(new TestPaintingContext(canvas), Offset.zero);
+    box.paint(new MockPaintingContext(canvas), Offset.zero);
 
     final Invocation drawCommand = canvas.invocations.firstWhere((Invocation invocation) {
       return invocation.memberName == #drawRRect;

--- a/packages/flutter/test/material/slider_test.dart
+++ b/packages/flutter/test/material/slider_test.dart
@@ -6,6 +6,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import '../rendering/mock_canvas.dart';
+
 void main() {
   testWidgets('Slider can move when tapped', (WidgetTester tester) async {
     Key sliderKey = new UniqueKey();
@@ -23,12 +25,12 @@ void main() {
                   setState(() {
                     value = newValue;
                   });
-                }
-              )
-            )
+                },
+              ),
+            ),
           );
-        }
-      )
+        },
+      ),
     );
 
     expect(value, equals(0.0));
@@ -57,12 +59,12 @@ void main() {
                   setState(() {
                     value = newValue;
                   });
-                }
-              )
-            )
+                },
+              ),
+            ),
           );
-        }
-      )
+        },
+      ),
     );
 
     expect(value, equals(0.0));
@@ -81,5 +83,39 @@ void main() {
     await tester.pump(const Duration(milliseconds: 200));
     // Animation complete.
     expect(SchedulerBinding.instance.transientCallbackCount, equals(0));
+  });
+
+  testWidgets('Slider can draw an open thumb at min',
+      (WidgetTester tester) async {
+    Widget buildApp(bool thumbOpenAtMin) {
+      return new Material(
+        child: new Center(
+          child: new Slider(
+            value: 0.0,
+            thumbOpenAtMin: thumbOpenAtMin,
+            onChanged: (double newValue) {},
+          ),
+        ),
+      );
+    }
+
+    await tester.pumpWidget(buildApp(false));
+
+    final RenderBox sliderBox =
+        tester.firstRenderObject<RenderBox>(find.byType(Slider));
+
+    Paint getThumbPaint() {
+      final MockCanvas canvas = new MockCanvas();
+      sliderBox.paint(new MockPaintingContext(canvas), Offset.zero);
+      final Invocation drawCommand =
+          canvas.invocations.where((Invocation invocation) {
+        return invocation.memberName == #drawCircle;
+      }).single;
+      return drawCommand.positionalArguments[2];
+    }
+
+    expect(getThumbPaint().style, equals(PaintingStyle.fill));
+    await tester.pumpWidget(buildApp(true));
+    expect(getThumbPaint().style, equals(PaintingStyle.stroke));
   });
 }

--- a/packages/flutter/test/rendering/mock_canvas.dart
+++ b/packages/flutter/test/rendering/mock_canvas.dart
@@ -1,0 +1,25 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/rendering.dart';
+
+class MockCanvas implements Canvas {
+  final List<Invocation> invocations = <Invocation>[];
+
+  @override
+  void noSuchMethod(Invocation invocation) {
+    invocations.add(invocation);
+  }
+}
+
+class MockPaintingContext implements PaintingContext {
+  MockPaintingContext(this.canvas);
+
+  @override
+  final Canvas canvas;
+
+  @override
+  void noSuchMethod(Invocation invocation) {
+  }
+}


### PR DESCRIPTION
This patch changes the default appearance of Slider to not have the
thumb be an open circle at its minimum position. The `thumbOpenAtMin`
property can enable drawing an open thumb at the min position, which was
the previous behavior.

Fixes #6941