### PR TITLE
Deprecate HostMessages

### DIFF
--- a/examples/hello_services/lib/main.dart
+++ b/examples/hello_services/lib/main.dart
@@ -49,7 +49,7 @@ class _HelloServicesState extends State<HelloServices> {
 
   Future<Null> _getLocation() async {
     final Map<String, String> message = <String, String>{'provider': 'network'};
-    final Map<String, dynamic> reply = await HostMessages.sendJSON('getLocation', message);
+    final Map<String, dynamic> reply = await PlatformMessages.sendJSON('getLocation', message);
     // If the widget was removed from the tree while the message was in flight,
     // we want to discard the reply rather than calling setState to update our
     // non-existent appearance.
@@ -65,5 +65,5 @@ class _HelloServicesState extends State<HelloServices> {
 void main() {
   runApp(new HelloServices());
 
-  HostMessages.addJSONMessageHandler('getRandom', handleGetRandom);
+  PlatformMessages.setJSONMessageHandler('getRandom', handleGetRandom);
 }

--- a/packages/flutter/lib/src/services/host_messages.dart
+++ b/packages/flutter/lib/src/services/host_messages.dart
@@ -6,8 +6,8 @@ import 'dart:async';
 
 import 'platform_messages.dart';
 
-/// A service that can be implemented by the host application and the
-/// Flutter framework to exchange application-specific messages.
+/// Deprecated. Use [PlatformMessages] instead.
+@deprecated
 class HostMessages {
   /// Send a message to the host application.
   static Future<String> sendToHost(String channel, [String message = '']) {


### PR DESCRIPTION
This class is just an alias for PlatformMessages. We'll remove it after a short
deprecation period.