### PR TITLE
Allow nulls in `Listenable.merge`

### DIFF
--- a/packages/flutter/lib/src/foundation/change_notifier.dart
+++ b/packages/flutter/lib/src/foundation/change_notifier.dart
@@ -18,6 +18,8 @@ abstract class Listenable {
   ///
   /// The list must not be changed after this method has been called. Doing so
   /// will lead to memory leaks or exceptions.
+  ///
+  /// The list may contain `null`s; they are ignored.
   factory Listenable.merge(List<Listenable> listenables) = _MergingListenable;
 
   /// Register a closure to be called when the object notifies its listeners.
@@ -93,7 +95,7 @@ class ChangeNotifier extends Listenable {
 class _MergingListenable extends ChangeNotifier {
   _MergingListenable(this._children) {
     for (Listenable child in _children)
-      child.addListener(notifyListeners);
+      child?.addListener(notifyListeners);
   }
 
   final List<Listenable> _children;
@@ -101,7 +103,7 @@ class _MergingListenable extends ChangeNotifier {
   @override
   void dispose() {
     for (Listenable child in _children)
-      child.removeListener(notifyListeners);
+      child?.removeListener(notifyListeners);
     super.dispose();
   }
 }

--- a/packages/flutter/test/foundation/change_notifier_test.dart
+++ b/packages/flutter/test/foundation/change_notifier_test.dart
@@ -121,20 +121,44 @@ void main() {
     final List<String> log = <String>[];
 
     final Listenable merged = new Listenable.merge(<Listenable>[source1, source2]);
+    final VoidCallback listener1 = () { log.add('listener1'); };
+    final VoidCallback listener2 = () { log.add('listener2'); };
+
+    merged.addListener(listener1);
+    source1.notify();
+    source2.notify();
+    source3.notify();
+    expect(log, <String>['listener1', 'listener1']);
+    log.clear();
+
+    merged.removeListener(listener1);
+    source1.notify();
+    source2.notify();
+    source3.notify();
+    expect(log, isEmpty);
+    log.clear();
+
+    merged.addListener(listener1);
+    merged.addListener(listener2);
+    source1.notify();
+    source2.notify();
+    source3.notify();
+    expect(log, <String>['listener1', 'listener2', 'listener1', 'listener2']);
+    log.clear();
+  });
+
+  testWidgets('Merging change notifiers ignores null', (WidgetTester tester) async {
+    final TestNotifier source1 = new TestNotifier();
+    final TestNotifier source2 = new TestNotifier();
+    final List<String> log = <String>[];
+
+    final Listenable merged = new Listenable.merge(<Listenable>[null, source1, null, source2, null]);
     final VoidCallback listener = () { log.add('listener'); };
 
     merged.addListener(listener);
     source1.notify();
     source2.notify();
-    source3.notify();
     expect(log, <String>['listener', 'listener']);
-    log.clear();
-
-    merged.removeListener(listener);
-    source1.notify();
-    source2.notify();
-    source3.notify();
-    expect(log, isEmpty);
     log.clear();
   });
 }


### PR DESCRIPTION
This lets you use `Listenable.merge` without having to sanitize your
incoming list of change notifiers, in case your semantics are that
they are optional.