### PR TITLE
Make SingleTickerProviderStateMixin more resilient

### DIFF
--- a/packages/flutter/lib/src/widgets/ticker_provider.dart
+++ b/packages/flutter/lib/src/widgets/ticker_provider.dart
@@ -92,6 +92,10 @@ abstract class SingleTickerProviderStateMixin implements State<dynamic>, TickerP
       );
     });
     _ticker = new Ticker(onTick, debugLabel: 'created by $this');
+    // We assume that this is called from initState, build, or some sort of
+    // event handler, and that thus TickerMode.of(context) would return true. We
+    // can't actually check that here because if we're in initState then we're
+    // not allowed to do inheritance checks yet.
     return _ticker;
   }
 
@@ -115,7 +119,8 @@ abstract class SingleTickerProviderStateMixin implements State<dynamic>, TickerP
 
   @override
   void dependenciesChanged() {
-    _ticker.muted = !TickerMode.of(context);
+    if (_ticker != null)
+      _ticker.muted = !TickerMode.of(context);
     super.dependenciesChanged();
   }
 

--- a/packages/flutter/test/widgets/ticker_provider_test.dart
+++ b/packages/flutter/test/widgets/ticker_provider_test.dart
@@ -50,4 +50,20 @@ void main() {
     await tester.pump(const Duration(seconds: 5));
     expect(tester.binding.transientCallbackCount, 1);
   });
+
+  testWidgets('SingleTickerProviderStateMixin can handle not being used', (WidgetTester tester) async {
+    await tester.pumpWidget(new BoringTickerTest());
+    await tester.pumpWidget(new Container());
+    // the test is that this doesn't crash, like it used to...
+  });
+}
+
+class BoringTickerTest extends StatefulWidget {
+  @override
+  _BoringTickerTestState createState() => new _BoringTickerTestState();
+}
+
+class _BoringTickerTestState extends State<BoringTickerTest> with SingleTickerProviderStateMixin {
+  @override
+  Widget build(BuildContext context) => new Container();
 }


### PR DESCRIPTION
It used to crash when the State never actually used the TickerProvider
interface.