### PR TITLE
Fix SizeChangedLayoutNotifier and its test.

### DIFF
--- a/packages/flutter/lib/src/widgets/size_changed_layout_notifier.dart
+++ b/packages/flutter/lib/src/widgets/size_changed_layout_notifier.dart
@@ -9,17 +9,21 @@ import 'package:flutter/widgets.dart';
 /// this notification has changed, and that therefore any assumptions about that
 /// layout are no longer valid.
 ///
-/// See [LayoutChangedNotification].
-class SizeChangedLayoutNotificaion extends LayoutChangedNotification {}
+/// See [LayoutChangedNotification] for additional discussion of layout
+/// notifications such as this one.
+class SizeChangedLayoutNotification extends LayoutChangedNotification { }
 
 /// A widget that automatically dispatches a [SizeChangedLayoutNotifier] when
 /// the layout of its child changes.
 ///
 /// Useful especially when having some complex, layout-changing animation within
 /// [Material] that is also interactive.
+///
+/// The notification is not sent for the initial layout (since the size doesn't
+/// change in that case, it's just established).
 class SizeChangedLayoutNotifier extends SingleChildRenderObjectWidget {
   /// Creates a [SizeChangedLayoutNotifier] that dispatches layout changed
-  /// notifications when [child] changes layout.
+  /// notifications when [child] changes layout size.
   SizeChangedLayoutNotifier({
     Key key,
     Widget child
@@ -29,7 +33,7 @@ class SizeChangedLayoutNotifier extends SingleChildRenderObjectWidget {
   _RenderSizeChangedWithCallback createRenderObject(BuildContext context) {
     return new _RenderSizeChangedWithCallback(
       onLayoutChangedCallback: () {
-        new SizeChangedLayoutNotificaion().dispatch(context);
+        new SizeChangedLayoutNotification().dispatch(context);
       }
     );
   }
@@ -39,15 +43,23 @@ class _RenderSizeChangedWithCallback extends RenderProxyBox {
   _RenderSizeChangedWithCallback({
     RenderBox child,
     this.onLayoutChangedCallback
-  }) : super(child);
+  }) : super(child) {
+    assert(onLayoutChangedCallback != null);
+  }
 
-  VoidCallback onLayoutChangedCallback;
+  // There's a 1:1 relationship between the _RenderSizeChangedWithCallback and
+  // the `context` that is captured by the closure created by createRenderObject
+  // above to assign to onLayoutChangedCallback, and thus we know that the
+  // onLayoutChangedCallback will never change nor need to change.
+
+  final VoidCallback onLayoutChangedCallback;
+
   Size _oldSize;
 
   @override
   void performLayout() {
     super.performLayout();
-    if (onLayoutChangedCallback != null && size != _oldSize)
+    if (_oldSize != null && size != _oldSize)
       onLayoutChangedCallback();
     _oldSize = size;
   }

--- a/packages/flutter/test/widgets/size_changed_layout_notification_test.dart
+++ b/packages/flutter/test/widgets/size_changed_layout_notification_test.dart
@@ -18,33 +18,37 @@ void main() {
     bool notified = false;
 
     await tester.pumpWidget(
-      new NotificationListener<LayoutChangedNotification>(
-        onNotification: (LayoutChangedNotification notification) {
-          notified = true;
-          return true;
-        },
-        child: new SizeChangedLayoutNotifier(
-          child: const SizedBox(
-            width: 100.0,
-            height: 100.0
-          )
-        )
-      )
+      new Center(
+        child: new NotificationListener<LayoutChangedNotification>(
+          onNotification: (LayoutChangedNotification notification) {
+            throw new Exception('Should not reach this point.');
+          },
+          child: new SizeChangedLayoutNotifier(
+            child: const SizedBox(
+              width: 100.0,
+              height: 100.0,
+            ),
+          ),
+        ),
+      ),
     );
 
     await tester.pumpWidget(
-      new NotificationListener<LayoutChangedNotification>(
-        onNotification: (LayoutChangedNotification notification) {
-          notified = true;
-          return true;
-        },
-        child: new SizeChangedLayoutNotifier(
-          child: const SizedBox(
-            width: 200.0,
-            height: 100.0
-          )
-        )
-      )
+      new Center(
+        child: new NotificationListener<LayoutChangedNotification>(
+          onNotification: (LayoutChangedNotification notification) {
+            expect(notification, new isInstanceOf<SizeChangedLayoutNotification>());
+            notified = true;
+            return true;
+          },
+          child: new SizeChangedLayoutNotifier(
+            child: const SizedBox(
+              width: 200.0,
+              height: 100.0,
+            ),
+          ),
+        ),
+      ),
     );
 
     expect(notified, isTrue);


### PR DESCRIPTION
Previously, SizeChangedLayoutNotifier fired a notification even for
the first layout.

Also, previously its test relied on that, and didn't actually change
size at all. This fixes the test as well.

Also, rename SizeChangedLayoutNotificaion to SizeChangedLayoutNotification.