### PR TITLE
Make LayoutCallback generic and other minor changes

### DIFF
--- a/packages/flutter/lib/src/rendering/grid.dart
+++ b/packages/flutter/lib/src/rendering/grid.dart
@@ -520,7 +520,7 @@ class RenderGrid extends RenderVirtualViewport<GridParentData> {
     int virtualChildBase: 0,
     int virtualChildCount,
     Offset paintOffset: Offset.zero,
-    LayoutCallback callback
+    LayoutCallback<BoxConstraints> callback
   }) : _delegate = delegate, _virtualChildBase = virtualChildBase, super(
     virtualChildCount: virtualChildCount,
     paintOffset: paintOffset,
@@ -643,7 +643,7 @@ class RenderGrid extends RenderVirtualViewport<GridParentData> {
     size = constraints.constrain(gridSize);
 
     if (callback != null)
-      invokeLayoutCallback(callback);
+      invokeLayoutCallback/*<BoxConstraints>*/(callback);
 
     double gridTopPadding = 0.0;
     double gridLeftPadding = 0.0;

--- a/packages/flutter/lib/src/rendering/list.dart
+++ b/packages/flutter/lib/src/rendering/list.dart
@@ -33,7 +33,7 @@ class RenderList extends RenderVirtualViewport<ListParentData> {
     Offset paintOffset: Offset.zero,
     Axis mainAxis: Axis.vertical,
     ViewportAnchor anchor: ViewportAnchor.start,
-    LayoutCallback callback
+    LayoutCallback<BoxConstraints> callback
   }) : _itemExtent = itemExtent,
        _padding = padding,
        super(
@@ -153,7 +153,7 @@ class RenderList extends RenderVirtualViewport<ListParentData> {
     }
 
     if (callback != null)
-      invokeLayoutCallback(callback);
+      invokeLayoutCallback/*<BoxConstraints>*/(callback);
 
     double itemWidth;
     double itemHeight;

--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -529,7 +529,7 @@ typedef void RenderObjectVisitor(RenderObject child);
 /// Signature for a function that is called during layout.
 ///
 /// Used by [RenderObject.invokeLayoutCallback].
-typedef void LayoutCallback(Constraints constraints);
+typedef void LayoutCallback<T extends Constraints>(T constraints);
 
 class _SemanticsGeometry {
   _SemanticsGeometry() : transform = new Matrix4.identity();
@@ -1314,9 +1314,8 @@ abstract class RenderObject extends AbstractNode implements HitTestTarget {
       context: 'during $method()',
       renderObject: this,
       informationCollector: (StringBuffer information) {
-        information.writeln('The following RenderObject was being processed when the exception was fired:\n  $this');
-        if (debugCreator != null)
-          information.writeln('This RenderObject had the following creator information:\n  $debugCreator');
+        information.writeln('The following RenderObject was being processed when the exception was fired:');
+        information.writeln('  ${toStringShallow('\n  ')}');
         List<String> descendants = <String>[];
         const int maxDepth = 5;
         int depth = 0;
@@ -1825,7 +1824,7 @@ abstract class RenderObject extends AbstractNode implements HitTestTarget {
   ///
   /// This function can only be called during layout.
   @protected
-  void invokeLayoutCallback(LayoutCallback callback) {
+  void invokeLayoutCallback/*<T extends Constraints>*/(LayoutCallback/*<T>*/ callback) {
     assert(_debugMutationsLocked);
     assert(_debugDoingThisLayout);
     assert(!_doingThisLayoutWithCallback);
@@ -2428,14 +2427,14 @@ abstract class RenderObject extends AbstractNode implements HitTestTarget {
   ///
   /// This includes the same information for this RenderObject as given by
   /// [toStringDeep], but does not recurse to any children.
-  String toStringShallow() {
+  String toStringShallow([String joiner = '; ']) {
     RenderObject debugPreviousActiveLayout = _debugActiveLayout;
     _debugActiveLayout = null;
     StringBuffer result = new StringBuffer();
-    result.write('$this; ');
+    result.write('${this}$joiner'); // TODO(ianh): https://github.com/dart-lang/sdk/issues/28206
     List<String> description = <String>[];
     debugFillDescription(description);
-    result.write(description.join('; '));
+    result.write(description.join(joiner));
     _debugActiveLayout = debugPreviousActiveLayout;
     return result.toString();
   }

--- a/packages/flutter/lib/src/rendering/viewport.dart
+++ b/packages/flutter/lib/src/rendering/viewport.dart
@@ -358,7 +358,7 @@ abstract class RenderVirtualViewport<T extends ContainerBoxParentDataMixin<Rende
   /// The [paintOffset] and [mainAxis] arguments must not be null.
   RenderVirtualViewport({
     int virtualChildCount,
-    LayoutCallback callback,
+    LayoutCallback<BoxConstraints> callback,
     Offset paintOffset: Offset.zero,
     Axis mainAxis: Axis.vertical,
     ViewportAnchor anchor: ViewportAnchor.start
@@ -382,9 +382,9 @@ abstract class RenderVirtualViewport<T extends ContainerBoxParentDataMixin<Rende
   ///
   /// Typically the callback will mutate the child list appropriately, for
   /// example so the child list contains only visible children.
-  LayoutCallback get callback => _callback;
-  LayoutCallback _callback;
-  set callback(LayoutCallback value) {
+  LayoutCallback<BoxConstraints> get callback => _callback;
+  LayoutCallback<BoxConstraints> _callback;
+  set callback(LayoutCallback<BoxConstraints> value) {
     if (value == _callback)
       return;
     _callback = value;

--- a/packages/flutter/lib/src/widgets/layout_builder.dart
+++ b/packages/flutter/lib/src/widgets/layout_builder.dart
@@ -151,12 +151,12 @@ class _LayoutBuilderElement extends RenderObjectElement {
 
 class _RenderLayoutBuilder extends RenderBox with RenderObjectWithChildMixin<RenderBox> {
   _RenderLayoutBuilder({
-    LayoutCallback callback,
+    LayoutCallback<BoxConstraints> callback,
   }) : _callback = callback;
 
-  LayoutCallback get callback => _callback;
-  LayoutCallback _callback;
-  set callback(LayoutCallback value) {
+  LayoutCallback<BoxConstraints> get callback => _callback;
+  LayoutCallback<BoxConstraints> _callback;
+  set callback(LayoutCallback<BoxConstraints> value) {
     if (value == _callback)
       return;
     _callback = value;

--- a/packages/flutter/lib/src/widgets/lazy_block.dart
+++ b/packages/flutter/lib/src/widgets/lazy_block.dart
@@ -397,7 +397,7 @@ class _RenderLazyBlock extends RenderVirtualViewport<_LazyBlockParentData> {
   _RenderLazyBlock({
     Offset paintOffset: Offset.zero,
     Axis mainAxis: Axis.vertical,
-    LayoutCallback callback
+    LayoutCallback<BoxConstraints> callback
   }) : super(
     paintOffset: paintOffset,
     mainAxis: mainAxis,


### PR DESCRIPTION
LayoutCallback passes constraints to the callback, but the constraints
object has a different type for different subclasses. This lets you
call invokeLayoutCallback() with a specific type to verify that
everything is working as expected.

Other changes:

Slightly improve the error reporting in RenderObject.

Allow toStringShallow on RenderObject to have its separator configured.