### PR TITLE
Allow Expanded.flex to be null

### DIFF
--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -2308,9 +2308,7 @@ class Expanded extends Flexible {
     Key key,
     int flex: 1,
     @required Widget child,
-  }) : super(key: key, flex: flex, fit: FlexFit.tight, child: child) {
-    assert(flex > 0);
-  }
+  }) : super(key: key, flex: flex, fit: FlexFit.tight, child: child);
 }
 
 /// A widget that implements the flow layout algorithm.

--- a/packages/flutter/test/widgets/flex_test.dart
+++ b/packages/flutter/test/widgets/flex_test.dart
@@ -7,12 +7,13 @@ import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 
 void main() {
-  testWidgets('Can hit test flex children of stacks', (WidgetTester tester) async {
+  testWidgets('Can hit test flex children of stacks',
+      (WidgetTester tester) async {
     bool didReceiveTap = false;
     await tester.pumpWidget(
       new Container(
         decoration: const BoxDecoration(
-          backgroundColor: const Color(0xFF00FF00)
+          backgroundColor: const Color(0xFF00FF00),
         ),
         child: new Stack(
           children: <Widget>[
@@ -27,24 +28,34 @@ void main() {
                     },
                     child: new Container(
                       decoration: const BoxDecoration(
-                        backgroundColor: const Color(0xFF0000FF)
-                      ),
+                          backgroundColor: const Color(0xFF0000FF)),
                       width: 100.0,
                       height: 100.0,
                       child: new Center(
-                        child: new Text('X')
-                      )
-                    )
-                  )
-                ]
-              )
-            )
-          ]
-        )
-      )
+                        child: new Text('X'),
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
     );
 
     await tester.tap(find.text('X'));
     expect(didReceiveTap, isTrue);
+  });
+
+  testWidgets('Can pass null for flex', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      new Row(
+        children: <Widget>[
+          new Expanded(flex: null, child: new Text('one')),
+          new Flexible(flex: null, child: new Text('two')),
+        ],
+      ),
+    );
   });
 }


### PR DESCRIPTION
Some clients pass null, which was previously allowed by Flexible.

Fixes #7383