### PR TITLE
Update flutter_tools to use package:file throughout

### DIFF
--- a/packages/flutter_driver/pubspec.yaml
+++ b/packages/flutter_driver/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
   sdk: '>=1.19.0 <2.0.0'
 
 dependencies:
-  file: '^1.0.0'
+  file: '^1.0.1'
   json_rpc_2: '^2.0.0'
   matcher: '>=0.12.0 <1.0.0'
   path: '^1.4.0'

--- a/packages/flutter_tools/bin/fuchsia_builder.dart
+++ b/packages/flutter_tools/bin/fuchsia_builder.dart
@@ -3,13 +3,14 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:io';
+import 'dart:io' as io;
 
 import 'package:args/args.dart';
 
 import '../lib/src/base/common.dart';
 import '../lib/src/base/config.dart';
 import '../lib/src/base/context.dart';
+import '../lib/src/base/file_system.dart';
 import '../lib/src/base/logger.dart';
 import '../lib/src/base/os.dart';
 import '../lib/src/base/process_manager.dart';
@@ -37,6 +38,7 @@ Future<Null> main(List<String> args) async {
   executableContext.setVariable(Logger, new StdoutLogger());
   executableContext.runInZone(() {
     // Initialize the context with some defaults.
+    context.putIfAbsent(FileSystem, () => new LocalFileSystem());
     context.putIfAbsent(ProcessManager, () => new ProcessManager());
     context.putIfAbsent(Logger, () => new StdoutLogger());
     context.putIfAbsent(Cache, () => new Cache());
@@ -61,12 +63,12 @@ Future<Null> run(List<String> args) async {
     printError('Missing option! All options must be specified.');
     exit(1);
   }
-  Cache.flutterRoot = Platform.environment['FLUTTER_ROOT'];
+  Cache.flutterRoot = io.Platform.environment['FLUTTER_ROOT'];
   String outputPath = argResults[_kOptionOutput];
   try {
     await assemble(
       outputPath: outputPath,
-      snapshotFile: new File(argResults[_kOptionSnapshot]),
+      snapshotFile: fs.file(argResults[_kOptionSnapshot]),
       workingDirPath: argResults[_kOptionWorking],
       packagesPath: argResults[_kOptionPackages],
       manifestPath: argResults[_kOptionsManifest] ?? defaultManifestPath,
@@ -85,7 +87,7 @@ Future<Null> run(List<String> args) async {
 
 int _addHeader(String outputPath, String header) {
   try {
-    final File outputFile = new File(outputPath);
+    final File outputFile = fs.file(outputPath);
     final List<int> content = outputFile.readAsBytesSync();
     outputFile.writeAsStringSync('$header\n');
     outputFile.writeAsBytesSync(content, mode: FileMode.APPEND);

--- a/packages/flutter_tools/lib/src/android/android_device.dart
+++ b/packages/flutter_tools/lib/src/android/android_device.dart
@@ -4,12 +4,13 @@
 
 import 'dart:async';
 import 'dart:convert';
-import 'dart:io';
+import 'dart:io' as io;
 
 import '../android/android_sdk.dart';
 import '../application_package.dart';
-import '../base/os.dart';
+import '../base/file_system.dart';
 import '../base/logger.dart';
+import '../base/os.dart';
 import '../base/process.dart';
 import '../base/process_manager.dart';
 import '../build_info.dart';
@@ -60,7 +61,7 @@ class AndroidDevice extends Device {
       try {
         // We pass an encoding of LATIN1 so that we don't try and interpret the
         // `adb shell getprop` result as UTF8.
-        ProcessResult result = processManager.runSync(
+        io.ProcessResult result = processManager.runSync(
           propCommand.first,
           propCommand.sublist(1),
           stdoutEncoding: LATIN1
@@ -201,7 +202,7 @@ class AndroidDevice extends Device {
 
   String _getSourceSha1(ApplicationPackage app) {
     AndroidApk apk = app;
-    File shaFile = new File('${apk.apkPath}.sha1');
+    File shaFile = fs.file('${apk.apkPath}.sha1');
     return shaFile.existsSync() ? shaFile.readAsStringSync() : '';
   }
 
@@ -222,7 +223,7 @@ class AndroidDevice extends Device {
   @override
   bool installApp(ApplicationPackage app) {
     AndroidApk apk = app;
-    if (!FileSystemEntity.isFileSync(apk.apkPath)) {
+    if (!fs.isFileSync(apk.apkPath)) {
       printError('"${apk.apkPath}" does not exist.');
       return false;
     }
@@ -558,7 +559,7 @@ class _AdbLogReader extends DeviceLogReader {
   final AndroidDevice device;
 
   StreamController<String> _linesController;
-  Process _process;
+  io.Process _process;
 
   @override
   Stream<String> get logLines => _linesController.stream;
@@ -584,7 +585,7 @@ class _AdbLogReader extends DeviceLogReader {
         _timeOrigin = _adbTimestampToDateTime(lastTimestamp);
     else
         _timeOrigin = null;
-    runCommand(device.adbCommandForDevice(args)).then((Process process) {
+    runCommand(device.adbCommandForDevice(args)).then((io.Process process) {
       _process = process;
       _process.stdout.transform(UTF8.decoder).transform(const LineSplitter()).listen(_onLine);
       _process.stderr.transform(UTF8.decoder).transform(const LineSplitter()).listen(_onLine);

--- a/packages/flutter_tools/lib/src/application_package.dart
+++ b/packages/flutter_tools/lib/src/application_package.dart
@@ -2,13 +2,12 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:io';
-
 import 'package:path/path.dart' as path;
 import 'package:xml/xml.dart' as xml;
 
 import 'android/android_sdk.dart';
 import 'android/gradle.dart';
+import 'base/file_system.dart';
 import 'base/os.dart' show os;
 import 'base/process.dart';
 import 'build_info.dart';
@@ -89,10 +88,10 @@ class AndroidApk extends ApplicationPackage {
       apkPath = path.join(getAndroidBuildDirectory(), 'app.apk');
     }
 
-    if (!FileSystemEntity.isFileSync(manifestPath))
+    if (!fs.isFileSync(manifestPath))
       return null;
 
-    String manifestString = new File(manifestPath).readAsStringSync();
+    String manifestString = fs.file(manifestPath).readAsStringSync();
     xml.XmlDocument document = xml.parse(manifestString);
 
     Iterable<xml.XmlElement> manifests = document.findElements('manifest');
@@ -135,10 +134,10 @@ abstract class IOSApp extends ApplicationPackage {
   factory IOSApp.fromIpa(String applicationBinary) {
     Directory bundleDir;
     try {
-      Directory tempDir = Directory.systemTemp.createTempSync('flutter_app_');
+      Directory tempDir = fs.systemTempDirectory.createTempSync('flutter_app_');
       addShutdownHook(() async => await tempDir.delete(recursive: true));
-      os.unzip(new File(applicationBinary), tempDir);
-      Directory payloadDir = new Directory(path.join(tempDir.path, 'Payload'));
+      os.unzip(fs.file(applicationBinary), tempDir);
+      Directory payloadDir = fs.directory(path.join(tempDir.path, 'Payload'));
       bundleDir = payloadDir.listSync().singleWhere(_isBundleDirectory);
     } on StateError catch (e, stackTrace) {
       printError('Invalid prebuilt iOS binary: ${e.toString()}', stackTrace);

--- a/packages/flutter_tools/lib/src/asset.dart
+++ b/packages/flutter_tools/lib/src/asset.dart
@@ -281,7 +281,7 @@ Future<AssetBundleEntry> _obtainLicenses(
   for (String packageName in packageMap.map.keys) {
     final Uri package = packageMap.map[packageName];
     if (package != null && package.scheme == 'file') {
-      final File file = fs.file(package.resolve('../LICENSE').toFilePath());
+      final File file = fs.file(package.resolve('../LICENSE'));
       if (file.existsSync()) {
         final List<String> rawLicenses =
             (await file.readAsString()).split(_licenseSeparator);
@@ -460,7 +460,7 @@ _Asset _resolveAsset(
 
     Uri uri = packageMap.map[packageKey];
     if (uri != null && uri.scheme == 'file') {
-      File file = fs.file(uri.toFilePath());
+      File file = fs.file(uri);
       return new _Asset(base: file.path, assetEntry: asset, relativePath: relativeAsset);
     }
   }

--- a/packages/flutter_tools/lib/src/asset.dart
+++ b/packages/flutter_tools/lib/src/asset.dart
@@ -4,12 +4,13 @@
 
 import 'dart:async';
 import 'dart:convert';
-import 'dart:io';
+import 'dart:io' as io;
 
 import 'package:json_schema/json_schema.dart';
 import 'package:path/path.dart' as path;
 import 'package:yaml/yaml.dart';
 
+import 'base/file_system.dart';
 import 'build_info.dart';
 import 'cache.dart';
 import 'dart/package_map.dart';
@@ -74,7 +75,7 @@ class AssetBundle {
       final String assetPath = path.join(projectRoot, asset);
       final String archivePath = asset;
       entries.add(
-          new AssetBundleEntry.fromFile(archivePath, new File(assetPath)));
+          new AssetBundleEntry.fromFile(archivePath, fs.file(assetPath)));
     }
   }
 
@@ -84,7 +85,7 @@ class AssetBundle {
     if (_lastBuildTimestamp == null)
       return true;
 
-    FileStat stat = new File(manifestPath).statSync();
+    FileStat stat = fs.file(manifestPath).statSync();
     if (stat.type == FileSystemEntityType.NOT_FOUND)
       return true;
 
@@ -206,7 +207,7 @@ class _Asset {
   final String source;
 
   File get assetFile {
-    return new File(source != null ? '$base/$source' : '$base/$relativePath');
+    return fs.file(source != null ? '$base/$source' : '$base/$relativePath');
   }
 
   bool get assetFileExists => assetFile.existsSync();
@@ -228,7 +229,7 @@ Map<String, dynamic> _readMaterialFontsManifest() {
   String fontsPath = path.join(path.absolute(Cache.flutterRoot),
       'packages', 'flutter_tools', 'schema', 'material_fonts.yaml');
 
-  return loadYaml(new File(fontsPath).readAsStringSync());
+  return loadYaml(fs.file(fontsPath).readAsStringSync());
 }
 
 final Map<String, dynamic> _materialFontsManifest = _readMaterialFontsManifest();
@@ -280,7 +281,7 @@ Future<AssetBundleEntry> _obtainLicenses(
   for (String packageName in packageMap.map.keys) {
     final Uri package = packageMap.map[packageName];
     if (package != null && package.scheme == 'file') {
-      final File file = new File.fromUri(package.resolve('../LICENSE'));
+      final File file = fs.file(package.resolve('../LICENSE').toFilePath());
       if (file.existsSync()) {
         final List<String> rawLicenses =
             (await file.readAsString()).split(_licenseSeparator);
@@ -377,7 +378,7 @@ Map<_Asset, List<_Asset>> _parseAssets(
     return result;
 
   excludeDirs = excludeDirs.map(
-    (String exclude) => path.absolute(exclude) + Platform.pathSeparator).toList();
+    (String exclude) => path.absolute(exclude) + io.Platform.pathSeparator).toList();
 
   if (manifestDescriptor.containsKey('assets')) {
     for (String asset in manifestDescriptor['assets']) {
@@ -394,12 +395,12 @@ Map<_Asset, List<_Asset>> _parseAssets(
       // Find asset variants
       String assetPath = baseAsset.assetFile.path;
       String assetFilename = path.basename(assetPath);
-      Directory assetDir = new Directory(path.dirname(assetPath));
+      Directory assetDir = fs.directory(path.dirname(assetPath));
 
       List<FileSystemEntity> files = assetDir.listSync(recursive: true);
 
       for (FileSystemEntity entity in files) {
-        if (!FileSystemEntity.isFileSync(entity.path))
+        if (!fs.isFileSync(entity.path))
           continue;
 
         // Exclude any files in the given directories.
@@ -446,7 +447,7 @@ _Asset _resolveAsset(
   String assetBase,
   String asset
 ) {
-  if (asset.startsWith('packages/') && !FileSystemEntity.isFileSync(path.join(assetBase, asset))) {
+  if (asset.startsWith('packages/') && !fs.isFileSync(path.join(assetBase, asset))) {
     // Convert packages/flutter_gallery_assets/clouds-0.png to clouds-0.png.
     String packageKey = asset.substring(9);
     String relativeAsset = asset;
@@ -459,7 +460,7 @@ _Asset _resolveAsset(
 
     Uri uri = packageMap.map[packageKey];
     if (uri != null && uri.scheme == 'file') {
-      File file = new File.fromUri(uri);
+      File file = fs.file(uri.toFilePath());
       return new _Asset(base: file.path, assetEntry: asset, relativePath: relativeAsset);
     }
   }
@@ -468,9 +469,9 @@ _Asset _resolveAsset(
 }
 
 dynamic _loadFlutterYamlManifest(String manifestPath) {
-  if (manifestPath == null || !FileSystemEntity.isFileSync(manifestPath))
+  if (manifestPath == null || !fs.isFileSync(manifestPath))
     return null;
-  String manifestDescriptor = new File(manifestPath).readAsStringSync();
+  String manifestDescriptor = fs.file(manifestPath).readAsStringSync();
   return loadYaml(manifestDescriptor);
 }
 

--- a/packages/flutter_tools/lib/src/base/config.dart
+++ b/packages/flutter_tools/lib/src/base/config.dart
@@ -3,15 +3,16 @@
 // found in the LICENSE file.
 
 import 'dart:convert';
-import 'dart:io';
+import 'dart:io' as io;
 
 import 'package:path/path.dart' as path;
 
 import 'context.dart';
+import 'file_system.dart';
 
 class Config {
   Config([File configFile]) {
-    _configFile = configFile ?? new File(path.join(_userHomeDir(), '.flutter_settings'));
+    _configFile = configFile ?? fs.file(path.join(_userHomeDir(), '.flutter_settings'));
     if (_configFile.existsSync())
       _values = JSON.decode(_configFile.readAsStringSync());
   }
@@ -45,7 +46,7 @@ class Config {
 }
 
 String _userHomeDir() {
-  String envKey = Platform.operatingSystem == 'windows' ? 'APPDATA' : 'HOME';
-  String value = Platform.environment[envKey];
+  String envKey = io.Platform.operatingSystem == 'windows' ? 'APPDATA' : 'HOME';
+  String value = io.Platform.environment[envKey];
   return value == null ? '.' : value;
 }

--- a/packages/flutter_tools/lib/src/base/file_system.dart
+++ b/packages/flutter_tools/lib/src/base/file_system.dart
@@ -2,27 +2,31 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:io' as dart_io;
+import 'dart:io' as io;
 
 import 'package:file/file.dart';
 import 'package:file/local.dart';
 import 'package:file/memory.dart';
 import 'package:path/path.dart' as path;
 
+import 'context.dart';
+
 export 'package:file/file.dart';
 export 'package:file/local.dart';
+
+const FileSystem _kLocalFs = const LocalFileSystem();
 
 /// Currently active implementation of the file system.
 ///
 /// By default it uses local disk-based implementation. Override this in tests
 /// with [MemoryFileSystem].
-FileSystem fs = new LocalFileSystem();
+FileSystem get fs => context == null ? _kLocalFs : context[FileSystem];
 
 /// Exits the process with the given [exitCode].
 typedef void ExitFunction([int exitCode]);
 
 final ExitFunction _defaultExitFunction = ([int exitCode]) {
-  dart_io.exit(exitCode);
+  io.exit(exitCode);
 };
 
 /// Exits the process.
@@ -30,17 +34,19 @@ ExitFunction exit = _defaultExitFunction;
 
 /// Restores [fs] to the default local disk-based implementation.
 void restoreFileSystem() {
-  fs = new LocalFileSystem();
+  //context.setVariable(FileSystem, new LocalFileSystem());
   exit = _defaultExitFunction;
 }
 
 /// Uses in-memory replacments for `dart:io` functionality. Useful in tests.
 void useInMemoryFileSystem({ String cwd: '/', ExitFunction exitFunction }) {
-  fs = new MemoryFileSystem();
+  /*
+  context.setVariable(FileSystem, new MemoryFileSystem());
   if (!fs.directory(cwd).existsSync()) {
     fs.directory(cwd).createSync(recursive: true);
   }
   fs.currentDirectory = cwd;
+  */
   exit = exitFunction ?? ([int exitCode]) {
     throw new Exception('Exited with code $exitCode');
   };
@@ -57,20 +63,20 @@ void ensureDirectoryExists(String filePath) {
 
 /// Recursively copies a folder from `srcPath` to `destPath`
 void copyFolderSync(String srcPath, String destPath) {
-  dart_io.Directory srcDir = new dart_io.Directory(srcPath);
+  Directory srcDir = fs.directory(srcPath);
   if (!srcDir.existsSync())
     throw new Exception('Source directory "${srcDir.path}" does not exist, nothing to copy');
 
-  dart_io.Directory destDir = new dart_io.Directory(destPath);
+  Directory destDir = fs.directory(destPath);
   if (!destDir.existsSync())
     destDir.createSync(recursive: true);
 
-  srcDir.listSync().forEach((dart_io.FileSystemEntity entity) {
+  srcDir.listSync().forEach((FileSystemEntity entity) {
     String newPath = path.join(destDir.path, path.basename(entity.path));
-    if (entity is dart_io.File) {
-      dart_io.File newFile = new dart_io.File(newPath);
+    if (entity is File) {
+      File newFile = fs.file(newPath);
       newFile.writeAsBytesSync(entity.readAsBytesSync());
-    } else if (entity is dart_io.Directory) {
+    } else if (entity is Directory) {
       copyFolderSync(entity.path, newPath);
     } else {
       throw new Exception('${entity.path} is neither File nor Directory');

--- a/packages/flutter_tools/lib/src/base/utils.dart
+++ b/packages/flutter_tools/lib/src/base/utils.dart
@@ -4,19 +4,21 @@
 
 import 'dart:async';
 import 'dart:convert';
-import 'dart:io';
+import 'dart:io' as io;
 import 'dart:math' show Random;
 
 import 'package:crypto/crypto.dart';
 import 'package:path/path.dart' as path;
 
+import 'file_system.dart';
+
 bool get isRunningOnBot {
   // https://docs.travis-ci.com/user/environment-variables/#Default-Environment-Variables
   // CHROME_HEADLESS is one property set on Flutter's Chrome Infra bots.
   return
-    Platform.environment['TRAVIS'] == 'true' ||
-    Platform.environment['CONTINUOUS_INTEGRATION'] == 'true' ||
-    Platform.environment['CHROME_HEADLESS'] == '1';
+    io.Platform.environment['TRAVIS'] == 'true' ||
+    io.Platform.environment['CONTINUOUS_INTEGRATION'] == 'true' ||
+    io.Platform.environment['CHROME_HEADLESS'] == '1';
 }
 
 String hex(List<int> bytes) {
@@ -63,7 +65,7 @@ File getUniqueFile(Directory dir, String baseName, String ext) {
 
   while (true) {
     String name = '${baseName}_${i.toString().padLeft(2, '0')}.$ext';
-    File file = new File(path.join(dir.path, name));
+    File file = fs.file(path.join(dir.path, name));
     if (!file.existsSync())
       return file;
     i++;
@@ -91,7 +93,7 @@ String getElapsedAsMilliseconds(Duration duration) {
 /// Return a relative path if [fullPath] is contained by the cwd, else return an
 /// absolute path.
 String getDisplayPath(String fullPath) {
-  String cwd = Directory.current.path + Platform.pathSeparator;
+  String cwd = fs.currentDirectory.path + io.Platform.pathSeparator;
   return fullPath.startsWith(cwd) ?  fullPath.substring(cwd.length) : fullPath;
 }
 

--- a/packages/flutter_tools/lib/src/commands/analyze.dart
+++ b/packages/flutter_tools/lib/src/commands/analyze.dart
@@ -3,8 +3,8 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:io';
 
+import '../base/file_system.dart';
 import '../runner/flutter_command.dart';
 import 'analyze_continuously.dart';
 import 'analyze_once.dart';
@@ -46,7 +46,7 @@ class AnalyzeCommand extends FlutterCommand {
       return false;
 
     // Or we're not in a project directory.
-    if (!new File('pubspec.yaml').existsSync())
+    if (!fs.file('pubspec.yaml').existsSync())
       return false;
 
     return super.shouldRunPub;

--- a/packages/flutter_tools/lib/src/commands/analyze_base.dart
+++ b/packages/flutter_tools/lib/src/commands/analyze_base.dart
@@ -3,11 +3,12 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:io';
+import 'dart:io' as io;
 
 import 'package:args/args.dart';
 import 'package:path/path.dart' as path;
 
+import '../base/file_system.dart';
 import '../base/utils.dart';
 import '../cache.dart';
 import '../globals.dart';
@@ -25,7 +26,7 @@ abstract class AnalyzeBase {
   void dumpErrors(Iterable<String> errors) {
     if (argResults['write'] != null) {
       try {
-        final RandomAccessFile resultsFile = new File(argResults['write']).openSync(mode: FileMode.WRITE);
+        final RandomAccessFile resultsFile = fs.file(argResults['write']).openSync(mode: FileMode.WRITE);
         try {
           resultsFile.lockSync();
           resultsFile.writeStringSync(errors.join('\n'));
@@ -45,7 +46,7 @@ abstract class AnalyzeBase {
       'issues': errorCount,
       'missingDartDocs': membersMissingDocumentation
     };
-    new File(benchmarkOut).writeAsStringSync(toPrettyJson(data));
+    fs.file(benchmarkOut).writeAsStringSync(toPrettyJson(data));
     printStatus('Analysis benchmark written to $benchmarkOut ($data).');
   }
 
@@ -58,7 +59,7 @@ bool inRepo(List<String> fileList) {
   if (fileList == null || fileList.isEmpty)
     fileList = <String>[path.current];
   String root = path.normalize(path.absolute(Cache.flutterRoot));
-  String prefix = root + Platform.pathSeparator;
+  String prefix = root + io.Platform.pathSeparator;
   for (String file in fileList) {
     file = path.normalize(path.absolute(file));
     if (file == root || file.startsWith(prefix))

--- a/packages/flutter_tools/lib/src/commands/analyze_continuously.dart
+++ b/packages/flutter_tools/lib/src/commands/analyze_continuously.dart
@@ -4,12 +4,13 @@
 
 import 'dart:async';
 import 'dart:convert';
-import 'dart:io';
+import 'dart:io' as io;
 
 import 'package:args/args.dart';
 import 'package:path/path.dart' as path;
 
 import '../base/common.dart';
+import '../base/file_system.dart';
 import '../base/logger.dart';
 import '../base/process_manager.dart';
 import '../base/utils.dart';
@@ -42,8 +43,8 @@ class AnalyzeContinuously extends AnalyzeBase {
       for (String projectPath in directories)
         printTrace('  ${path.relative(projectPath)}');
     } else {
-      directories = <String>[Directory.current.path];
-      analysisTarget = Directory.current.path;
+      directories = <String>[fs.currentDirectory.path];
+      analysisTarget = fs.currentDirectory.path;
     }
 
     AnalysisServer server = new AnalysisServer(dartSdkPath, directories);
@@ -78,7 +79,7 @@ class AnalyzeContinuously extends AnalyzeBase {
       // Remove errors for deleted files, sort, and print errors.
       final List<AnalysisError> errors = <AnalysisError>[];
       for (String path in analysisErrors.keys.toList()) {
-        if (FileSystemEntity.isFileSync(path)) {
+        if (fs.isFileSync(path)) {
           errors.addAll(analysisErrors[path]);
         } else {
           analysisErrors.remove(path);
@@ -149,7 +150,7 @@ class AnalysisServer {
   final String sdk;
   final List<String> directories;
 
-  Process _process;
+  io.Process _process;
   StreamController<bool> _analyzingController = new StreamController<bool>.broadcast();
   StreamController<FileAnalysisErrors> _errorsController = new StreamController<FileAnalysisErrors>.broadcast();
 

--- a/packages/flutter_tools/lib/src/commands/build.dart
+++ b/packages/flutter_tools/lib/src/commands/build.dart
@@ -3,10 +3,11 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:io';
+import 'dart:io' as io;
 
 import 'package:meta/meta.dart';
 
+import '../base/file_system.dart';
 import '../build_info.dart';
 import '../globals.dart';
 import '../runner/flutter_command.dart';
@@ -54,14 +55,14 @@ abstract class BuildSubCommand extends FlutterCommand {
   @mustCallSuper
   Future<Null> runCommand() async {
     if (isRunningOnBot) {
-      File dotPackages = new File('.packages');
+      File dotPackages = fs.file('.packages');
       printStatus('Contents of .packages:');
       if (dotPackages.existsSync())
         printStatus(dotPackages.readAsStringSync());
       else
         printError('File not found: ${dotPackages.absolute.path}');
 
-      File pubspecLock = new File('pubspec.lock');
+      File pubspecLock = fs.file('pubspec.lock');
       printStatus('Contents of pubspec.lock:');
       if (pubspecLock.existsSync())
         printStatus(pubspecLock.readAsStringSync());
@@ -86,8 +87,8 @@ class BuildCleanCommand extends FlutterCommand {
 
   @override
   Future<Null> runCommand() async {
-    Directory buildDir = new Directory(getBuildDirectory());
-    printStatus("Deleting '${buildDir.path}${Platform.pathSeparator}'.");
+    Directory buildDir = fs.directory(getBuildDirectory());
+    printStatus("Deleting '${buildDir.path}${io.Platform.pathSeparator}'.");
 
     if (!buildDir.existsSync())
       return;

--- a/packages/flutter_tools/lib/src/commands/build_aot.dart
+++ b/packages/flutter_tools/lib/src/commands/build_aot.dart
@@ -3,11 +3,12 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:io';
+import 'dart:io' as io;
 
 import 'package:path/path.dart' as path;
 
 import '../base/common.dart';
+import '../base/file_system.dart';
 import '../base/logger.dart';
 import '../base/process.dart';
 import '../base/utils.dart';
@@ -64,7 +65,7 @@ class BuildAotCommand extends BuildSubCommand {
     if (outputPath == null)
       throwToolExit(null);
 
-    printStatus('Built to $outputPath${Platform.pathSeparator}.');
+    printStatus('Built to $outputPath${io.Platform.pathSeparator}.');
   }
 }
 
@@ -142,7 +143,7 @@ Future<String> _buildAotSnapshot(
     }
   }
 
-  Directory outputDir = new Directory(outputPath);
+  Directory outputDir = fs.directory(outputPath);
   outputDir.createSync(recursive: true);
   String vmIsolateSnapshot = path.join(outputDir.path, 'snapshot_aot_vmisolate');
   String isolateSnapshot = path.join(outputDir.path, 'snapshot_aot_isolate');
@@ -201,7 +202,7 @@ Future<String> _buildAotSnapshot(
       assert(false);
   }
 
-  List<String> missingFiles = filePaths.where((String p) => !FileSystemEntity.isFileSync(p)).toList();
+  List<String> missingFiles = filePaths.where((String p) => !fs.isFileSync(p)).toList();
   if (missingFiles.isNotEmpty) {
     printError('Missing files: $missingFiles');
     return null;

--- a/packages/flutter_tools/lib/src/commands/build_apk.dart
+++ b/packages/flutter_tools/lib/src/commands/build_apk.dart
@@ -4,14 +4,13 @@
 
 import 'dart:async';
 import 'dart:convert' show JSON;
-import 'dart:io';
 
 import 'package:path/path.dart' as path;
 
 import '../android/android_sdk.dart';
 import '../android/gradle.dart';
 import '../base/common.dart';
-import '../base/file_system.dart' show ensureDirectoryExists;
+import '../base/file_system.dart';
 import '../base/logger.dart';
 import '../base/os.dart';
 import '../base/process.dart';
@@ -49,7 +48,7 @@ class _AssetBuilder {
   Directory _assetDir;
 
   _AssetBuilder(this.outDir, String assetDirName) {
-    _assetDir = new Directory('${outDir.path}/$assetDirName');
+    _assetDir = fs.directory('${outDir.path}/$assetDirName');
     _assetDir.createSync(recursive:  true);
   }
 
@@ -73,10 +72,10 @@ class _ApkBuilder {
   File _jarsigner;
 
   _ApkBuilder(this.sdk) {
-    _androidJar = new File(sdk.androidJarPath);
-    _aapt = new File(sdk.aaptPath);
-    _dx = new File(sdk.dxPath);
-    _zipalign = new File(sdk.zipalignPath);
+    _androidJar = fs.file(sdk.androidJarPath);
+    _aapt = fs.file(sdk.aaptPath);
+    _dx = fs.file(sdk.dxPath);
+    _zipalign = fs.file(sdk.zipalignPath);
     _jarsigner = os.which('jarsigner');
   }
 
@@ -284,8 +283,8 @@ Future<_ApkComponents> _findApkComponents(
   Map<String, File> extraFiles
 ) async {
   _ApkComponents components = new _ApkComponents();
-  components.manifest = new File(manifest);
-  components.resources = resources == null ? null : new Directory(resources);
+  components.manifest = fs.file(manifest);
+  components.resources = resources == null ? null : fs.directory(resources);
   components.extraFiles = extraFiles != null ? extraFiles : <String, File>{};
 
   if (tools.isLocalEngine) {
@@ -293,21 +292,21 @@ Future<_ApkComponents> _findApkComponents(
     String enginePath = tools.engineSrcPath;
     String buildDir = tools.getEngineArtifactsDirectory(platform, buildMode).path;
 
-    components.icuData = new File('$enginePath/third_party/icu/android/icudtl.dat');
+    components.icuData = fs.file('$enginePath/third_party/icu/android/icudtl.dat');
     components.jars = <File>[
-      new File('$buildDir/gen/flutter/shell/platform/android/android/classes.dex.jar')
+      fs.file('$buildDir/gen/flutter/shell/platform/android/android/classes.dex.jar')
     ];
-    components.libSkyShell = new File('$buildDir/gen/flutter/shell/platform/android/android/android/libs/$abiDir/libsky_shell.so');
-    components.debugKeystore = new File('$enginePath/build/android/ant/chromium-debug.keystore');
+    components.libSkyShell = fs.file('$buildDir/gen/flutter/shell/platform/android/android/android/libs/$abiDir/libsky_shell.so');
+    components.debugKeystore = fs.file('$enginePath/build/android/ant/chromium-debug.keystore');
   } else {
     Directory artifacts = tools.getEngineArtifactsDirectory(platform, buildMode);
 
-    components.icuData = new File(path.join(artifacts.path, 'icudtl.dat'));
+    components.icuData = fs.file(path.join(artifacts.path, 'icudtl.dat'));
     components.jars = <File>[
-      new File(path.join(artifacts.path, 'classes.dex.jar'))
+      fs.file(path.join(artifacts.path, 'classes.dex.jar'))
     ];
-    components.libSkyShell = new File(path.join(artifacts.path, 'libsky_shell.so'));
-    components.debugKeystore = new File(path.join(artifacts.path, 'chromium-debug.keystore'));
+    components.libSkyShell = fs.file(path.join(artifacts.path, 'libsky_shell.so'));
+    components.debugKeystore = fs.file(path.join(artifacts.path, 'chromium-debug.keystore'));
   }
 
   await parseServiceConfigs(components.services, jars: components.jars);
@@ -338,7 +337,7 @@ int _buildApk(
   assert(platform != null);
   assert(buildMode != null);
 
-  Directory tempDir = Directory.systemTemp.createTempSync('flutter_tools');
+  Directory tempDir = fs.systemTempDirectory.createTempSync('flutter_tools');
 
   printTrace('Building APK; buildMode: ${getModeName(buildMode)}.');
 
@@ -350,7 +349,7 @@ int _buildApk(
       return 1;
     }
 
-    File classesDex = new File('${tempDir.path}/classes.dex');
+    File classesDex = fs.file('${tempDir.path}/classes.dex');
     builder.compileClassesDex(classesDex, components.jars);
 
     File servicesConfig =
@@ -358,7 +357,7 @@ int _buildApk(
 
     _AssetBuilder assetBuilder = new _AssetBuilder(tempDir, 'assets');
     assetBuilder.add(components.icuData, 'icudtl.dat');
-    assetBuilder.add(new File(flxPath), 'app.flx');
+    assetBuilder.add(fs.file(flxPath), 'app.flx');
     assetBuilder.add(servicesConfig, 'services.json');
 
     _AssetBuilder artifactBuilder = new _AssetBuilder(tempDir, 'artifacts');
@@ -369,7 +368,7 @@ int _buildApk(
     for (String relativePath in components.extraFiles.keys)
       artifactBuilder.add(components.extraFiles[relativePath], relativePath);
 
-    File unalignedApk = new File('${tempDir.path}/app.apk.unaligned');
+    File unalignedApk = fs.file('${tempDir.path}/app.apk.unaligned');
     builder.package(
       unalignedApk, components.manifest, assetBuilder.directory,
       artifactBuilder.directory, components.resources, buildMode
@@ -379,12 +378,12 @@ int _buildApk(
     if (signResult != 0)
       return signResult;
 
-    File finalApk = new File(outputFile);
+    File finalApk = fs.file(outputFile);
     ensureDirectoryExists(finalApk.path);
     builder.align(unalignedApk, finalApk);
 
     printTrace('calculateSha: $outputFile');
-    File apkShaFile = new File('$outputFile.sha1');
+    File apkShaFile = fs.file('$outputFile.sha1');
     apkShaFile.writeAsStringSync(calculateSha(finalApk));
 
     return 0;
@@ -417,7 +416,7 @@ int _signApk(
     keyAlias = _kDebugKeystoreKeyAlias;
     keyPassword = _kDebugKeystorePassword;
   } else {
-    keystore = new File(keystoreInfo.keystore);
+    keystore = fs.file(keystoreInfo.keystore);
     keystorePassword = keystoreInfo.password ?? '';
     keyAlias = keystoreInfo.keyAlias ?? '';
     if (keystorePassword.isEmpty || keyAlias.isEmpty) {
@@ -442,7 +441,7 @@ bool _needsRebuild(
   BuildMode buildMode,
   Map<String, File> extraFiles
 ) {
-  FileStat apkStat = FileStat.statSync(apkPath);
+  FileStat apkStat = fs.statSync(apkPath);
   // Note: This list of dependencies is imperfect, but will do for now. We
   // purposely don't include the .dart files, because we can load those
   // over the network without needing to rebuild (at least on Android).
@@ -453,7 +452,7 @@ bool _needsRebuild(
   ];
   dependencies.addAll(extraFiles.values.map((File file) => file.path));
   Iterable<FileStat> dependenciesStat =
-    dependencies.map((String path) => FileStat.statSync(path));
+    dependencies.map((String path) => fs.statSync(path));
 
   if (apkStat.type == FileSystemEntityType.NOT_FOUND)
     return true;
@@ -463,11 +462,11 @@ bool _needsRebuild(
       return true;
   }
 
-  if (!FileSystemEntity.isFileSync('$apkPath.sha1'))
+  if (!fs.isFileSync('$apkPath.sha1'))
     return true;
 
   String lastBuildType = _readBuildMeta(path.dirname(apkPath))['targetBuildType'];
-  String targetBuildType = _getTargetBuildTypeToken(platform, buildMode, new File(apkPath));
+  String targetBuildType = _getTargetBuildTypeToken(platform, buildMode, fs.file(apkPath));
   if (lastBuildType != targetBuildType)
     return true;
 
@@ -499,8 +498,8 @@ Future<Null> buildAndroid(
   }
 
   Map<String, File> extraFiles = <String, File>{};
-  if (FileSystemEntity.isDirectorySync(_kDefaultAssetsPath)) {
-    Directory assetsDir = new Directory(_kDefaultAssetsPath);
+  if (fs.isDirectorySync(_kDefaultAssetsPath)) {
+    Directory assetsDir = fs.directory(_kDefaultAssetsPath);
     for (FileSystemEntity entity in assetsDir.listSync(recursive: true)) {
       if (entity is File) {
         String targetPath = entity.path.substring(assetsDir.path.length);
@@ -520,10 +519,10 @@ Future<Null> buildAndroid(
   }
 
   if (resources != null) {
-    if (!FileSystemEntity.isDirectorySync(resources))
+    if (!fs.isDirectorySync(resources))
       throwToolExit('Resources directory "$resources" not found.');
   } else {
-    if (FileSystemEntity.isDirectorySync(_kDefaultResourcesPath))
+    if (fs.isDirectorySync(_kDefaultResourcesPath))
       resources = _kDefaultResourcesPath;
   }
 
@@ -536,7 +535,7 @@ Future<Null> buildAndroid(
   Status status = logger.startProgress('Building APK in ${getModeName(buildMode)} mode ($typeName)...');
 
   if (flxPath != null && flxPath.isNotEmpty) {
-    if (!FileSystemEntity.isFileSync(flxPath)) {
+    if (!fs.isFileSync(flxPath)) {
       throwToolExit('FLX does not exist: $flxPath\n'
         '(Omit the --flx option to build the FLX automatically)');
     }
@@ -561,13 +560,13 @@ Future<Null> buildAndroid(
   if (aotPath != null) {
     if (!isAotBuildMode(buildMode))
       throwToolExit('AOT snapshot can not be used in build mode $buildMode');
-    if (!FileSystemEntity.isDirectorySync(aotPath))
+    if (!fs.isDirectorySync(aotPath))
       throwToolExit('AOT snapshot does not exist: $aotPath');
     for (String aotFilename in kAotSnapshotFiles) {
       String aotFilePath = path.join(aotPath, aotFilename);
-      if (!FileSystemEntity.isFileSync(aotFilePath))
+      if (!fs.isFileSync(aotFilePath))
         throwToolExit('Missing AOT snapshot file: $aotFilePath');
-      components.extraFiles['assets/$aotFilename'] = new File(aotFilePath);
+      components.extraFiles['assets/$aotFilename'] = fs.file(aotFilePath);
     }
   }
 
@@ -577,13 +576,13 @@ Future<Null> buildAndroid(
   if (result != 0)
     throwToolExit('Build APK failed ($result)', exitCode: result);
 
-  File apkFile = new File(outputFile);
+  File apkFile = fs.file(outputFile);
   printTrace('Built $outputFile (${getSizeAsMB(apkFile.lengthSync())}).');
 
   _writeBuildMetaEntry(
     path.dirname(outputFile),
     'targetBuildType',
-    _getTargetBuildTypeToken(platform, buildMode, new File(outputFile))
+    _getTargetBuildTypeToken(platform, buildMode, fs.file(outputFile))
   );
 }
 
@@ -619,7 +618,7 @@ Future<Null> buildApk(
       target: target
     );
   } else {
-    if (!FileSystemEntity.isFileSync(_kDefaultAndroidManifestPath))
+    if (!fs.isFileSync(_kDefaultAndroidManifestPath))
       throwToolExit('Cannot build APK: missing $_kDefaultAndroidManifestPath.');
 
     return await buildAndroid(
@@ -632,7 +631,7 @@ Future<Null> buildApk(
 }
 
 Map<String, dynamic> _readBuildMeta(String buildDirectoryPath) {
-  File buildMetaFile = new File(path.join(buildDirectoryPath, 'build_meta.json'));
+  File buildMetaFile = fs.file(path.join(buildDirectoryPath, 'build_meta.json'));
   if (buildMetaFile.existsSync())
     return JSON.decode(buildMetaFile.readAsStringSync());
   return <String, dynamic>{};
@@ -641,7 +640,7 @@ Map<String, dynamic> _readBuildMeta(String buildDirectoryPath) {
 void _writeBuildMetaEntry(String buildDirectoryPath, String key, dynamic value) {
   Map<String, dynamic> meta = _readBuildMeta(buildDirectoryPath);
   meta[key] = value;
-  File buildMetaFile = new File(path.join(buildDirectoryPath, 'build_meta.json'));
+  File buildMetaFile = fs.file(path.join(buildDirectoryPath, 'build_meta.json'));
   buildMetaFile.writeAsStringSync(toPrettyJson(meta));
 }
 

--- a/packages/flutter_tools/lib/src/commands/create.dart
+++ b/packages/flutter_tools/lib/src/commands/create.dart
@@ -3,12 +3,12 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:io';
 
 import 'package:path/path.dart' as path;
 
 import '../android/android.dart' as android;
 import '../base/common.dart';
+import '../base/file_system.dart';
 import '../base/utils.dart';
 import '../cache.dart';
 import '../dart/pub.dart';
@@ -72,14 +72,14 @@ class CreateCommand extends FlutterCommand {
 
     String flutterPackagesDirectory = path.join(flutterRoot, 'packages');
     String flutterPackagePath = path.join(flutterPackagesDirectory, 'flutter');
-    if (!FileSystemEntity.isFileSync(path.join(flutterPackagePath, 'pubspec.yaml')))
+    if (!fs.isFileSync(path.join(flutterPackagePath, 'pubspec.yaml')))
       throwToolExit('Unable to find package:flutter in $flutterPackagePath', exitCode: 2);
 
     String flutterDriverPackagePath = path.join(flutterRoot, 'packages', 'flutter_driver');
-    if (!FileSystemEntity.isFileSync(path.join(flutterDriverPackagePath, 'pubspec.yaml')))
+    if (!fs.isFileSync(path.join(flutterDriverPackagePath, 'pubspec.yaml')))
       throwToolExit('Unable to find package:flutter_driver in $flutterDriverPackagePath', exitCode: 2);
 
-    Directory projectDir = new Directory(argResults.rest.first);
+    Directory projectDir = fs.directory(argResults.rest.first);
     String dirPath = path.normalize(projectDir.absolute.path);
     String relativePath = path.relative(dirPath);
     String projectName = _normalizeProjectName(path.basename(dirPath));
@@ -139,7 +139,7 @@ Your main program file is lib/main.dart in the $relativePath directory.
 
   int _renderTemplates(String projectName, String projectDescription, String dirPath,
       String flutterPackagesDirectory, { bool renderDriverTest: false }) {
-    new Directory(dirPath).createSync(recursive: true);
+    fs.directory(dirPath).createSync(recursive: true);
 
     flutterPackagesDirectory = path.normalize(flutterPackagesDirectory);
     flutterPackagesDirectory = _relativePath(from: dirPath, to: flutterPackagesDirectory);
@@ -161,14 +161,14 @@ Your main program file is lib/main.dart in the $relativePath directory.
 
     Template createTemplate = new Template.fromName('create');
     fileCount += createTemplate.render(
-      new Directory(dirPath),
+      fs.directory(dirPath),
       templateContext, overwriteExisting: false,
       projectName: projectName
     );
 
     if (renderDriverTest) {
       Template driverTemplate = new Template.fromName('driver');
-      fileCount += driverTemplate.render(new Directory(path.join(dirPath, 'test_driver')),
+      fileCount += driverTemplate.render(fs.directory(path.join(dirPath, 'test_driver')),
           templateContext, overwriteExisting: false);
     }
 
@@ -234,7 +234,7 @@ String _validateProjectDir(String dirPath, { String flutterRoot }) {
       "Target directory '$dirPath' is within the Flutter SDK at '$flutterRoot'.";
   }
 
-  FileSystemEntityType type = FileSystemEntity.typeSync(dirPath);
+  FileSystemEntityType type = fs.typeSync(dirPath);
 
   if (type != FileSystemEntityType.NOT_FOUND) {
     switch(type) {
@@ -253,7 +253,7 @@ String _validateProjectDir(String dirPath, { String flutterRoot }) {
 String _relativePath({ String from, String to }) {
   String result = path.relative(to, from: from);
   // `path.relative()` doesn't always return a correct result: dart-lang/path#12.
-  if (FileSystemEntity.isDirectorySync(path.join(from, result)))
+  if (fs.isDirectorySync(path.join(from, result)))
     return result;
   return to;
 }

--- a/packages/flutter_tools/lib/src/commands/run.dart
+++ b/packages/flutter_tools/lib/src/commands/run.dart
@@ -3,9 +3,10 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:io';
+import 'dart:io' as io;
 
 import '../base/common.dart';
+import '../base/file_system.dart';
 import '../base/utils.dart';
 import '../build_info.dart';
 import '../cache.dart';
@@ -174,7 +175,7 @@ class RunCommand extends RunCommandBase {
       AppInstance app;
       try {
         app = daemon.appDomain.startApp(
-          device, Directory.current.path, targetFile, route,
+          device, fs.currentDirectory.path, targetFile, route,
           getBuildMode(), argResults['start-paused'], hotMode);
       } catch (error) {
         throwToolExit(error.toString());
@@ -217,7 +218,7 @@ class RunCommand extends RunCommandBase {
     String pidFile = argResults['pid-file'];
     if (pidFile != null) {
       // Write our pid to the file.
-      new File(pidFile).writeAsStringSync(pid.toString());
+      fs.file(pidFile).writeAsStringSync(io.pid.toString());
     }
     ResidentRunner runner;
 

--- a/packages/flutter_tools/lib/src/commands/trace.dart
+++ b/packages/flutter_tools/lib/src/commands/trace.dart
@@ -4,11 +4,11 @@
 
 import 'dart:async';
 import 'dart:convert';
-import 'dart:io';
 
 import 'package:path/path.dart' as path;
 
 import '../base/common.dart';
+import '../base/file_system.dart';
 import '../base/utils.dart';
 import '../build_info.dart';
 import '../cache.dart';
@@ -90,9 +90,9 @@ class TraceCommand extends FlutterCommand {
     File localFile;
 
     if (argResults['out'] != null) {
-      localFile = new File(argResults['out']);
+      localFile = fs.file(argResults['out']);
     } else {
-      localFile = getUniqueFile(Directory.current, 'trace', 'json');
+      localFile = getUniqueFile(fs.currentDirectory, 'trace', 'json');
     }
 
     await localFile.writeAsString(JSON.encode(timeline));
@@ -161,7 +161,7 @@ class Tracing {
 /// store it to build/start_up_info.json.
 Future<Null> downloadStartupTrace(VMService observatory) async {
   String traceInfoFilePath = path.join(getBuildDirectory(), 'start_up_info.json');
-  File traceInfoFile = new File(traceInfoFilePath);
+  File traceInfoFile = fs.file(traceInfoFilePath);
 
   // Delete old startup data, if any.
   if (await traceInfoFile.exists())

--- a/packages/flutter_tools/lib/src/commands/update_packages.dart
+++ b/packages/flutter_tools/lib/src/commands/update_packages.dart
@@ -3,10 +3,10 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:io';
 
 import 'package:path/path.dart' as path;
 
+import '../base/file_system.dart';
 import '../base/logger.dart';
 import '../base/net.dart';
 import '../cache.dart';
@@ -36,10 +36,10 @@ class UpdatePackagesCommand extends FlutterCommand {
     Status status = logger.startProgress("Downloading lcov data for package:flutter...");
     final List<int> data = await fetchUrl(Uri.parse('https://storage.googleapis.com/flutter_infra/flutter/coverage/lcov.info'));
     final String coverageDir = path.join(Cache.flutterRoot, 'packages/flutter/coverage');
-    new File(path.join(coverageDir, 'lcov.base.info'))
+    fs.file(path.join(coverageDir, 'lcov.base.info'))
       ..createSync(recursive: true)
       ..writeAsBytesSync(data, flush: true);
-    new File(path.join(coverageDir, 'lcov.info'))
+    fs.file(path.join(coverageDir, 'lcov.info'))
       ..createSync(recursive: true)
       ..writeAsBytesSync(data, flush: true);
     status.stop();

--- a/packages/flutter_tools/lib/src/dart/analysis.dart
+++ b/packages/flutter_tools/lib/src/dart/analysis.dart
@@ -3,7 +3,7 @@
 // found in the LICENSE file.
 
 import 'dart:collection';
-import 'dart:io';
+import 'dart:io' as io;
 
 import 'package:analyzer/error/error.dart';
 import 'package:analyzer/file_system/file_system.dart' as file_system;
@@ -26,6 +26,8 @@ import 'package:package_config/src/packages_impl.dart' show MapPackages; // igno
 import 'package:path/path.dart' as path;
 import 'package:plugin/manager.dart';
 import 'package:plugin/plugin.dart';
+
+import '../base/file_system.dart';
 
 class AnalysisDriver {
   Set<Source> _analyzedSources = new HashSet<Source>();
@@ -97,7 +99,7 @@ class AnalysisDriver {
 
     // Create our list of resolvers.
     List<UriResolver> resolvers = <UriResolver>[];
-    
+
     // Look for an embedder.
     EmbedderYamlLocator locator = new EmbedderYamlLocator(packageMap);
     if (locator.embedderYamls.isNotEmpty) {
@@ -123,7 +125,7 @@ class AnalysisDriver {
     if (options.packageRootPath != null) {
       ContextBuilderOptions builderOptions = new ContextBuilderOptions();
       builderOptions.defaultPackagesDirectoryPath = options.packageRootPath;
-      ContextBuilder builder = new ContextBuilder(resourceProvider, null, null, 
+      ContextBuilder builder = new ContextBuilder(resourceProvider, null, null,
           options: builderOptions);
       PackageMapUriResolver packageUriResolver = new PackageMapUriResolver(resourceProvider,
           builder.convertPackagesToMap(builder.createPackageMap('')));
@@ -183,7 +185,7 @@ class AnalysisDriverException implements Exception {
 }
 
 class AnalysisErrorDescription {
-  static Directory cwd = Directory.current.absolute;
+  static Directory cwd = fs.currentDirectory.absolute;
 
   final AnalysisError error;
   final LineInfo line;
@@ -238,10 +240,10 @@ class DriverOptions extends AnalysisOptionsImpl {
   Map<Object, Object> analysisOptions;
 
   /// Out sink for logging.
-  IOSink outSink = stdout;
+  io.IOSink outSink = io.stdout;
 
   /// Error sink for logging.
-  IOSink errorSink = stderr;
+  io.IOSink errorSink = io.stderr;
 }
 
 class PackageInfo {
@@ -267,8 +269,8 @@ class PackageInfo {
 }
 
 class _StdLogger extends Logger {
-  final IOSink outSink;
-  final IOSink errorSink;
+  final io.IOSink outSink;
+  final io.IOSink errorSink;
   _StdLogger({this.outSink, this.errorSink});
 
   @override

--- a/packages/flutter_tools/lib/src/dart/package_map.dart
+++ b/packages/flutter_tools/lib/src/dart/package_map.dart
@@ -2,15 +2,15 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:io';
-
 import 'package:package_config/packages_file.dart' as packages_file;
 import 'package:path/path.dart' as path;
+
+import '../base/file_system.dart';
 
 const String kPackagesFileName = '.packages';
 
 Map<String, Uri> _parse(String packagesPath) {
-  List<int> source = new File(packagesPath).readAsBytesSync();
+  List<int> source = fs.file(packagesPath).readAsBytesSync();
   return packages_file.parse(source, new Uri.file(packagesPath));
 }
 
@@ -51,11 +51,11 @@ class PackageMap {
   }
 
   String checkValid() {
-    if (FileSystemEntity.isFileSync(packagesPath))
+    if (fs.isFileSync(packagesPath))
       return null;
     String message = '$packagesPath does not exist.';
     String pubspecPath = path.absolute(path.dirname(packagesPath), 'pubspec.yaml');
-    if (FileSystemEntity.isFileSync(pubspecPath))
+    if (fs.isFileSync(pubspecPath))
       message += '\nDid you run "flutter packages get" in this directory?';
     else
       message += '\nDid you run this command from the same directory as your pubspec.yaml file?';

--- a/packages/flutter_tools/lib/src/dart/pub.dart
+++ b/packages/flutter_tools/lib/src/dart/pub.dart
@@ -3,11 +3,11 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:io';
 
 import 'package:path/path.dart' as path;
 
 import '../base/common.dart';
+import '../base/file_system.dart';
 import '../base/logger.dart';
 import '../base/process.dart';
 import '../cache.dart';
@@ -21,7 +21,8 @@ bool _shouldRunPubGet({ File pubSpecYaml, File dotPackages }) {
   if (pubSpecYaml.lastModifiedSync().isAfter(dotPackagesLastModified))
     return true;
   File flutterToolsStamp = Cache.instance.getStampFileFor('flutter_tools');
-  if (flutterToolsStamp.lastModifiedSync().isAfter(dotPackagesLastModified))
+  if (flutterToolsStamp.existsSync() &&
+      flutterToolsStamp.lastModifiedSync().isAfter(dotPackagesLastModified))
     return true;
   return false;
 }
@@ -33,10 +34,10 @@ Future<Null> pubGet({
   bool checkLastModified: true
 }) async {
   if (directory == null)
-    directory = Directory.current.path;
+    directory = fs.currentDirectory.path;
 
-  File pubSpecYaml = new File(path.join(directory, 'pubspec.yaml'));
-  File dotPackages = new File(path.join(directory, '.packages'));
+  File pubSpecYaml = fs.file(path.join(directory, 'pubspec.yaml'));
+  File dotPackages = fs.file(path.join(directory, '.packages'));
 
   if (!pubSpecYaml.existsSync()) {
     if (!skipIfAbsent)

--- a/packages/flutter_tools/lib/src/dependency_checker.dart
+++ b/packages/flutter_tools/lib/src/dependency_checker.dart
@@ -2,10 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:io';
-
 import 'globals.dart';
 
+import 'base/file_system.dart';
 import 'dart/dependencies.dart';
 import 'dart/package_map.dart';
 import 'asset.dart';
@@ -51,7 +50,7 @@ class DependencyChecker {
 
     // Check all dependency modification times.
     for (String path in _dependencies) {
-      File file = new File(path);
+      File file = fs.file(path);
       FileStat stat = file.statSync();
       if (stat.type == FileSystemEntityType.NOT_FOUND) {
         printTrace('DependencyChecker: Error stating $path.');

--- a/packages/flutter_tools/lib/src/devfs.dart
+++ b/packages/flutter_tools/lib/src/devfs.dart
@@ -4,11 +4,12 @@
 
 import 'dart:async';
 import 'dart:convert' show BASE64, UTF8;
-import 'dart:io';
+import 'dart:io' as io;
 
 import 'package:path/path.dart' as path;
 
 import 'base/context.dart';
+import 'base/file_system.dart';
 import 'build_info.dart';
 import 'dart/package_map.dart';
 import 'asset.dart';
@@ -89,7 +90,7 @@ class DevFSEntry {
     if (_fileStat.type == FileSystemEntityType.LINK) {
       // Resolve, stat, and maybe cache the symlink target.
       String resolved = file.resolveSymbolicLinksSync();
-      FileSystemEntity linkTarget = new File(resolved);
+      FileSystemEntity linkTarget = fs.file(resolved);
       // Stat the link target.
       _fileStat = linkTarget.statSync();
       if (devFSConfig.cacheSymlinks) {
@@ -104,7 +105,7 @@ class DevFSEntry {
     }
     if (file is Link) {
       // The link target.
-      return new File(file.resolveSymbolicLinksSync());
+      return fs.file(file.resolveSymbolicLinksSync());
     }
     return file;
   }
@@ -126,7 +127,7 @@ class DevFSEntry {
   }
 
   Stream<List<int>> contentsAsCompressedStream() {
-    return contentsAsStream().transform(GZIP.encoder);
+    return contentsAsStream().transform(io.GZIP.encoder);
   }
 }
 
@@ -213,13 +214,13 @@ class _DevFSHttpWriter {
   int _inFlight = 0;
   List<DevFSEntry> _outstanding;
   Completer<Null> _completer;
-  HttpClient _client;
+  io.HttpClient _client;
   int _done;
   int _max;
 
   Future<Null> write(Set<DevFSEntry> entries,
                      {DevFSProgressReporter progressReporter}) async {
-    _client = new HttpClient();
+    _client = new io.HttpClient();
     _client.maxConnectionsPerHost = kMaxInFlight;
     _completer = new Completer<Null>();
     _outstanding = entries.toList();
@@ -245,14 +246,14 @@ class _DevFSHttpWriter {
   Future<Null> _scheduleWrite(DevFSEntry entry,
                               DevFSProgressReporter progressReporter) async {
     try {
-      HttpClientRequest request = await _client.putUrl(httpAddress);
-      request.headers.removeAll(HttpHeaders.ACCEPT_ENCODING);
+      io.HttpClientRequest request = await _client.putUrl(httpAddress);
+      request.headers.removeAll(io.HttpHeaders.ACCEPT_ENCODING);
       request.headers.add('dev_fs_name', fsName);
       request.headers.add('dev_fs_path_b64',
                           BASE64.encode(UTF8.encode(entry.devicePath)));
       Stream<List<int>> contents = entry.contentsAsCompressedStream();
       await request.addStream(contents);
-      HttpClientResponse response = await request.close();
+      io.HttpClientResponse response = await request.close();
       await response.drain();
     } catch (e, stackTrace) {
       printError('Error writing "${entry.devicePath}" to DevFS: $e\n$stackTrace');
@@ -353,7 +354,7 @@ class DevFS {
     printTrace('Scanning package files');
 
     StringBuffer sb;
-    if (FileSystemEntity.isFileSync(_packagesFilePath)) {
+    if (fs.isFileSync(_packagesFilePath)) {
       PackageMap packageMap = new PackageMap(_packagesFilePath);
 
       for (String packageName in packageMap.map.keys) {
@@ -368,7 +369,7 @@ class DevFS {
         // path imports within the project's own code.
         final String packagesDirectoryName =
             isProjectPackage ? 'packages/$packageName' : null;
-        Directory directory = new Directory.fromUri(uri);
+        Directory directory = fs.directory(uri.toFilePath());
         bool packageExists =
             await _scanDirectory(directory,
                                  directoryName: directoryName,
@@ -527,7 +528,7 @@ class DevFS {
           // Check if this is a symlink to a directory and skip it.
           final String linkPath = file.resolveSymbolicLinksSync();
           final FileSystemEntityType linkType =
-              FileStat.statSync(linkPath).type;
+              fs.statSync(linkPath).type;
           if (linkType == FileSystemEntityType.DIRECTORY) {
             continue;
           }

--- a/packages/flutter_tools/lib/src/devfs.dart
+++ b/packages/flutter_tools/lib/src/devfs.dart
@@ -369,7 +369,7 @@ class DevFS {
         // path imports within the project's own code.
         final String packagesDirectoryName =
             isProjectPackage ? 'packages/$packageName' : null;
-        Directory directory = fs.directory(uri.toFilePath());
+        Directory directory = fs.directory(uri);
         bool packageExists =
             await _scanDirectory(directory,
                                  directoryName: directoryName,

--- a/packages/flutter_tools/lib/src/device.dart
+++ b/packages/flutter_tools/lib/src/device.dart
@@ -3,13 +3,13 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:io';
 import 'dart:math' as math;
 
 import 'android/android_device.dart';
 import 'application_package.dart';
 import 'base/common.dart';
 import 'base/context.dart';
+import 'base/file_system.dart';
 import 'base/os.dart';
 import 'base/utils.dart';
 import 'build_info.dart';

--- a/packages/flutter_tools/lib/src/flx.dart
+++ b/packages/flutter_tools/lib/src/flx.dart
@@ -3,13 +3,12 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:io';
 
 import 'package:path/path.dart' as path;
 
 import 'asset.dart';
 import 'base/common.dart';
-import 'base/file_system.dart' show ensureDirectoryExists;
+import 'base/file_system.dart';
 import 'base/process.dart';
 import 'dart/package_map.dart';
 import 'build_info.dart';
@@ -107,7 +106,7 @@ Future<Null> build({
     if (result != 0)
       throwToolExit('Failed to run the Flutter compiler. Exit code: $result', exitCode: result);
 
-    snapshotFile = new File(snapshotPath);
+    snapshotFile = fs.file(snapshotPath);
   }
 
   return assemble(
@@ -162,7 +161,7 @@ Future<Null> assemble({
   ensureDirectoryExists(outputPath);
 
   printTrace('Encoding zip file to $outputPath');
-  zipBuilder.createZip(new File(outputPath), new Directory(workingDirPath));
+  zipBuilder.createZip(fs.file(outputPath), fs.directory(workingDirPath));
 
   printTrace('Built $outputPath.');
 }

--- a/packages/flutter_tools/lib/src/hot.dart
+++ b/packages/flutter_tools/lib/src/hot.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:io';
 
 import 'package:meta/meta.dart';
 import 'package:path/path.dart' as path;
@@ -12,6 +11,7 @@ import 'package:stack_trace/stack_trace.dart';
 import 'application_package.dart';
 import 'asset.dart';
 import 'base/context.dart';
+import 'base/file_system.dart';
 import 'base/logger.dart';
 import 'base/utils.dart';
 import 'build_info.dart';
@@ -51,7 +51,7 @@ class HotRunner extends ResidentRunner {
              target: target,
              debuggingOptions: debuggingOptions,
              usesTerminalUI: usesTerminalUI) {
-    _projectRootPath = projectRootPath ?? Directory.current.path;
+    _projectRootPath = projectRootPath ?? fs.currentDirectory.path;
     _packagesFilePath =
             packagesFilePath ?? path.absolute(PackageMap.globalPackagesPath);
     if (projectAssets != null)
@@ -136,7 +136,7 @@ class HotRunner extends ResidentRunner {
     bool shouldBuild: true
   }) async {
     _mainPath = findMainDartFile(target);
-    if (!FileSystemEntity.isFileSync(_mainPath)) {
+    if (!fs.isFileSync(_mainPath)) {
       String message = 'Tried to run $_mainPath, but that file does not exist.';
       if (target == null)
         message += '\nConsider using the -t option to specify the Dart file to start.';
@@ -241,7 +241,7 @@ class HotRunner extends ResidentRunner {
       await _cleanupDevFS();
       await stopEchoingDeviceLog();
       await stopApp();
-      File benchmarkOutput = new File('hot_benchmark.json');
+      File benchmarkOutput = fs.file('hot_benchmark.json');
       benchmarkOutput.writeAsStringSync(toPrettyJson(benchmarkData));
     }
 
@@ -267,7 +267,7 @@ class HotRunner extends ResidentRunner {
     String fsName = path.basename(_projectRootPath);
     _devFS = new DevFS(vmService,
                        fsName,
-                       new Directory(_projectRootPath),
+                       fs.directory(_projectRootPath),
                        packagesFilePath: _packagesFilePath);
     return _devFS.create();
   }

--- a/packages/flutter_tools/lib/src/ios/plist_utils.dart
+++ b/packages/flutter_tools/lib/src/ios/plist_utils.dart
@@ -2,10 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:io';
-
 import 'package:path/path.dart' as path;
 
+import '../base/file_system.dart';
 import '../base/process.dart';
 
 const String kCFBundleIdentifierKey = "CFBundleIdentifier";
@@ -18,7 +17,7 @@ String getValueFromFile(String plistFilePath, String key) {
   // 'defaults' requires the path to be absolute and without the 'plist'
   // extension.
 
-  if (!FileSystemEntity.isFileSync(plistFilePath))
+  if (!fs.isFileSync(plistFilePath))
     return null;
 
   String normalizedPlistPath = path.withoutExtension(path.absolute(plistFilePath));

--- a/packages/flutter_tools/lib/src/ios/xcodeproj.dart
+++ b/packages/flutter_tools/lib/src/ios/xcodeproj.dart
@@ -2,10 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:io';
-
 import 'package:path/path.dart' as path;
 
+import '../base/file_system.dart';
 import '../base/process.dart';
 import '../build_info.dart';
 import '../cache.dart';
@@ -23,7 +22,7 @@ void updateXcodeGeneratedProperties(String projectPath, BuildMode mode, String t
   localsBuffer.writeln('FLUTTER_ROOT=$flutterRoot');
 
   // This holds because requiresProjectRoot is true for this command
-  String applicationRoot = path.normalize(Directory.current.path);
+  String applicationRoot = path.normalize(fs.currentDirectory.path);
   localsBuffer.writeln('FLUTTER_APPLICATION_PATH=$applicationRoot');
 
   // Relative to FLUTTER_APPLICATION_PATH, which is [Directory.current].
@@ -43,7 +42,7 @@ void updateXcodeGeneratedProperties(String projectPath, BuildMode mode, String t
   if (tools.isLocalEngine)
     localsBuffer.writeln('LOCAL_ENGINE=${tools.engineBuildPath}');
 
-  File localsFile = new File(path.join(projectPath, 'ios', 'Flutter', 'Generated.xcconfig'));
+  File localsFile = fs.file(path.join(projectPath, 'ios', 'Flutter', 'Generated.xcconfig'));
   localsFile.createSync(recursive: true);
   localsFile.writeAsStringSync(localsBuffer.toString());
 }

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -3,12 +3,13 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:io';
+import 'dart:io' as io;
 
 import 'package:meta/meta.dart';
 import 'package:path/path.dart' as path;
 
 import 'application_package.dart';
+import 'base/file_system.dart';
 import 'base/logger.dart';
 import 'build_info.dart';
 import 'device.dart';
@@ -77,12 +78,12 @@ abstract class ResidentRunner {
   }
 
   void registerSignalHandlers() {
-    ProcessSignal.SIGINT.watch().listen((ProcessSignal signal) async {
+    io.ProcessSignal.SIGINT.watch().listen((io.ProcessSignal signal) async {
       _resetTerminal();
       await cleanupAfterSignal();
       exit(0);
     });
-    ProcessSignal.SIGTERM.watch().listen((ProcessSignal signal) async {
+    io.ProcessSignal.SIGTERM.watch().listen((io.ProcessSignal signal) async {
       _resetTerminal();
       await cleanupAfterSignal();
       exit(0);
@@ -91,19 +92,19 @@ abstract class ResidentRunner {
       return;
     if (!supportsRestart)
       return;
-    ProcessSignal.SIGUSR1.watch().listen(_handleSignal);
-    ProcessSignal.SIGUSR2.watch().listen(_handleSignal);
+    io.ProcessSignal.SIGUSR1.watch().listen(_handleSignal);
+    io.ProcessSignal.SIGUSR2.watch().listen(_handleSignal);
   }
 
   bool _processingSignal = false;
-  Future<Null> _handleSignal(ProcessSignal signal) async {
+  Future<Null> _handleSignal(io.ProcessSignal signal) async {
     if (_processingSignal) {
       printTrace('Ignoring signal: "$signal" because we are busy.');
       return;
     }
     _processingSignal = true;
 
-    final bool fullRestart = signal == ProcessSignal.SIGUSR2;
+    final bool fullRestart = signal == io.ProcessSignal.SIGUSR2;
 
     try {
       await restart(fullRestart: fullRestart);
@@ -279,7 +280,7 @@ String findMainDartFile([String target]) {
   if (target == null)
     target = '';
   String targetPath = path.absolute(target);
-  if (FileSystemEntity.isDirectorySync(targetPath))
+  if (fs.isDirectorySync(targetPath))
     return path.join(targetPath, 'lib', 'main.dart');
   else
     return targetPath;

--- a/packages/flutter_tools/lib/src/run.dart
+++ b/packages/flutter_tools/lib/src/run.dart
@@ -3,12 +3,12 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:io';
 
 import 'package:meta/meta.dart';
 import 'package:stack_trace/stack_trace.dart';
 
 import 'application_package.dart';
+import 'base/file_system.dart';
 import 'base/utils.dart';
 import 'build_info.dart';
 import 'commands/trace.dart';
@@ -68,7 +68,7 @@ class RunAndStayResident extends ResidentRunner {
   }) async {
     if (!prebuiltMode) {
       _mainPath = findMainDartFile(target);
-      if (!FileSystemEntity.isFileSync(_mainPath)) {
+      if (!fs.isFileSync(_mainPath)) {
         String message = 'Tried to run $_mainPath, but that file does not exist.';
         if (target == null)
           message += '\nConsider using the -t option to specify the Dart file to start.';

--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -3,13 +3,13 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:io';
 
 import 'package:args/command_runner.dart';
 import 'package:meta/meta.dart';
 
 import '../application_package.dart';
 import '../base/common.dart';
+import '../base/file_system.dart';
 import '../build_info.dart';
 import '../dart/package_map.dart';
 import '../dart/pub.dart';
@@ -207,7 +207,7 @@ abstract class FlutterCommand extends Command<Null> {
   void commonCommandValidator() {
     if (!PackageMap.isUsingCustomPackagesPath) {
       // Don't expect a pubspec.yaml file if the user passed in an explicit .packages file path.
-      if (!FileSystemEntity.isFileSync('pubspec.yaml')) {
+      if (!fs.isFileSync('pubspec.yaml')) {
         throw new ToolExit('Error: No pubspec.yaml file found.\n'
           'This command should be run from the root of your Flutter project.\n'
           'Do not run this command from the root of your git clone of Flutter.');
@@ -216,7 +216,7 @@ abstract class FlutterCommand extends Command<Null> {
 
     if (_usesTargetOption) {
       String targetPath = targetFile;
-      if (!FileSystemEntity.isFileSync(targetPath))
+      if (!fs.isFileSync(targetPath))
         throw new ToolExit('Target file "$targetPath" not found.');
     }
 

--- a/packages/flutter_tools/lib/src/services.dart
+++ b/packages/flutter_tools/lib/src/services.dart
@@ -4,11 +4,11 @@
 
 import 'dart:async';
 import 'dart:convert';
-import 'dart:io';
 
 import 'package:path/path.dart' as path;
 import 'package:yaml/yaml.dart';
 
+import 'base/file_system.dart';
 import 'dart/package_map.dart';
 import 'android/android_sdk.dart';
 import 'globals.dart';
@@ -18,9 +18,9 @@ const String _kFlutterServicesManifestPath = 'flutter_services.yaml';
 
 dynamic _loadYamlFile(String path) {
   printTrace("Looking for YAML at '$path'");
-  if (!FileSystemEntity.isFileSync(path))
+  if (!fs.isFileSync(path))
     return null;
-  String manifestString = new File(path).readAsStringSync();
+  String manifestString = fs.file(path).readAsStringSync();
   return loadYaml(manifestString);
 }
 
@@ -69,7 +69,7 @@ Future<Null> parseServiceConfigs(
 
     if (jars != null && serviceConfig['jars'] is Iterable) {
       for (String jar in serviceConfig['jars'])
-        jars.add(new File(await getServiceFromUrl(jar, serviceRoot, service, unzip: false)));
+        jars.add(fs.file(await getServiceFromUrl(jar, serviceRoot, service, unzip: false)));
     }
   }
 }
@@ -106,7 +106,7 @@ File generateServiceDefinitions(
       }).toList();
 
   Map<String, dynamic> json = <String, dynamic>{ 'services': services };
-  File servicesFile = new File(path.join(dir, 'services.json'));
+  File servicesFile = fs.file(path.join(dir, 'services.json'));
   servicesFile.writeAsStringSync(JSON.encode(json), mode: FileMode.WRITE, flush: true);
   return servicesFile;
 }

--- a/packages/flutter_tools/lib/src/template.dart
+++ b/packages/flutter_tools/lib/src/template.dart
@@ -2,11 +2,10 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:io';
-
 import 'package:mustache/mustache.dart' as mustache;
 import 'package:path/path.dart' as path;
 
+import 'base/file_system.dart';
 import 'cache.dart';
 import 'globals.dart';
 
@@ -78,7 +77,7 @@ class Template {
           .replaceAll(_kTemplateExtension, '');
       if (projectName != null)
         finalDestinationPath = finalDestinationPath.replaceAll('projectName', projectName);
-      File finalDestinationFile = new File(finalDestinationPath);
+      File finalDestinationFile = fs.file(finalDestinationPath);
       String relativePathForLogging = path.relative(finalDestinationFile.path);
 
       // Step 1: Check if the file needs to be overwritten.
@@ -99,7 +98,7 @@ class Template {
       fileCount++;
 
       finalDestinationFile.createSync(recursive: true);
-      File sourceFile = new File(absoluteSrcPath);
+      File sourceFile = fs.file(absoluteSrcPath);
 
       // Step 2: If the absolute paths ends with a 'copy.tmpl', this file does
       //         not need mustache rendering but needs to be directly copied.
@@ -135,5 +134,5 @@ class Template {
 Directory _templateDirectoryInPackage(String name) {
   String templatesDir = path.join(Cache.flutterRoot,
       'packages', 'flutter_tools', 'templates');
-  return new Directory(path.join(templatesDir, name));
+  return fs.directory(path.join(templatesDir, name));
 }

--- a/packages/flutter_tools/lib/src/toolchain.dart
+++ b/packages/flutter_tools/lib/src/toolchain.dart
@@ -2,11 +2,10 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:io';
-
 import 'package:path/path.dart' as path;
 
 import 'base/context.dart';
+import 'base/file_system.dart';
 import 'build_info.dart';
 import 'cache.dart';
 import 'globals.dart';
@@ -50,14 +49,14 @@ class ToolConfiguration {
 
   Directory _getEngineArtifactsDirectory(TargetPlatform platform, BuildMode mode) {
     if (engineBuildPath != null) {
-      return new Directory(engineBuildPath);
+      return fs.directory(engineBuildPath);
     } else {
       String suffix = mode != BuildMode.debug ? '-${getModeName(mode)}' : '';
 
       // Create something like `android-arm` or `android-arm-release`.
       String dirName = getNameForTargetPlatform(platform) + suffix;
       Directory engineDir = cache.getArtifactDirectory('engine');
-      return new Directory(path.join(engineDir.path, dirName));
+      return fs.directory(path.join(engineDir.path, dirName));
     }
   }
 
@@ -70,7 +69,7 @@ class ToolConfiguration {
 
     if (tool == HostTool.SkySnapshot) {
       String clangPath = path.join(engineBuildPath, 'clang_x64', 'sky_snapshot');
-      if (FileSystemEntity.isFileSync(clangPath))
+      if (fs.isFileSync(clangPath))
         return clangPath;
       return path.join(engineBuildPath, 'sky_snapshot');
     } else if (tool == HostTool.SkyShell) {

--- a/packages/flutter_tools/lib/src/zip.dart
+++ b/packages/flutter_tools/lib/src/zip.dart
@@ -2,12 +2,11 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:io';
-
 import 'package:archive/archive.dart';
 import 'package:path/path.dart' as path;
 
 import 'asset.dart';
+import 'base/file_system.dart';
 import 'base/process.dart';
 
 abstract class ZipBuilder {
@@ -66,7 +65,7 @@ class _ZipToolBuilder extends ZipBuilder {
 
     for (AssetBundleEntry entry in entries) {
       List<int> data = entry.contentsAsBytes();
-      File file = new File(path.join(zipBuildDir.path, entry.archivePath));
+      File file = fs.file(path.join(zipBuildDir.path, entry.archivePath));
       file.parent.createSync(recursive: true);
       file.writeAsBytesSync(data);
     }

--- a/packages/flutter_tools/pubspec.yaml
+++ b/packages/flutter_tools/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   args: ^0.13.4
   coverage: ^0.8.0
   crypto: '>=1.1.1 <3.0.0'
-  file: ^1.0.0
+  file: '^1.0.1'
   http: ^0.11.3
   intl: '>=0.14.0 <0.15.0'
   json_rpc_2: ^2.0.0

--- a/packages/flutter_tools/test/analyze_continuously_test.dart
+++ b/packages/flutter_tools/test/analyze_continuously_test.dart
@@ -3,8 +3,8 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:io';
 
+import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/os.dart';
 import 'package:flutter_tools/src/commands/analyze_continuously.dart';
 import 'package:flutter_tools/src/dart/pub.dart';
@@ -21,7 +21,7 @@ void main() {
 
   setUp(() {
     FlutterCommandRunner.initFlutterRoot();
-    tempDir = Directory.systemTemp.createTempSync('analysis_test');
+    tempDir = fs.systemTempDirectory.createTempSync('analysis_test');
   });
 
   tearDown(() {
@@ -71,12 +71,12 @@ void main() {
 }
 
 void _createSampleProject(Directory directory, { bool brokenCode: false }) {
-  File pubspecFile = new File(path.join(directory.path, 'pubspec.yaml'));
+  File pubspecFile = fs.file(path.join(directory.path, 'pubspec.yaml'));
   pubspecFile.writeAsStringSync('''
 name: foo_project
 ''');
 
-  File dartFile = new File(path.join(directory.path, 'lib', 'main.dart'));
+  File dartFile = fs.file(path.join(directory.path, 'lib', 'main.dart'));
   dartFile.parent.createSync();
   dartFile.writeAsStringSync('''
 void main() {

--- a/packages/flutter_tools/test/analyze_duplicate_names_test.dart
+++ b/packages/flutter_tools/test/analyze_duplicate_names_test.dart
@@ -2,8 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:io';
-
+import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/commands/analyze.dart';
 import 'package:path/path.dart' as path;
 import 'package:test/test.dart';
@@ -16,7 +15,7 @@ void main() {
   Directory tempDir;
 
   setUp(() {
-    tempDir = Directory.systemTemp.createTempSync('analysis_duplicate_names_test');
+    tempDir = fs.systemTempDirectory.createTempSync('analysis_duplicate_names_test');
   });
 
   tearDown(() {
@@ -25,10 +24,10 @@ void main() {
 
   group('analyze', () {
     testUsingContext('flutter analyze with two files with the same name', () async {
-      File dartFileA = new File(path.join(tempDir.path, 'a.dart'));
+      File dartFileA = fs.file(path.join(tempDir.path, 'a.dart'));
       dartFileA.parent.createSync();
       dartFileA.writeAsStringSync('library test;');
-      File dartFileB = new File(path.join(tempDir.path, 'b.dart'));
+      File dartFileB = fs.file(path.join(tempDir.path, 'b.dart'));
       dartFileB.writeAsStringSync('library test;');
 
       AnalyzeCommand command = new AnalyzeCommand();

--- a/packages/flutter_tools/test/android_sdk_test.dart
+++ b/packages/flutter_tools/test/android_sdk_test.dart
@@ -2,9 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:io';
-
 import 'package:flutter_tools/src/android/android_sdk.dart';
+import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:path/path.dart' as path;
 import 'package:test/test.dart';
 
@@ -53,7 +52,7 @@ void main() {
 }
 
 Directory _createSdkDirectory({ bool withAndroidN: false }) {
-  Directory dir = Directory.systemTemp.createTempSync('android-sdk');
+  Directory dir = fs.systemTempDirectory.createTempSync('android-sdk');
 
   _createSdkFile(dir, 'platform-tools/adb');
 
@@ -72,6 +71,6 @@ Directory _createSdkDirectory({ bool withAndroidN: false }) {
 }
 
 void _createSdkFile(Directory dir, String filePath) {
-  File file = new File(path.join(dir.path, filePath));
+  File file = fs.file(path.join(dir.path, filePath));
   file.createSync(recursive: true);
 }

--- a/packages/flutter_tools/test/asset_bundle_test.dart
+++ b/packages/flutter_tools/test/asset_bundle_test.dart
@@ -2,19 +2,20 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:io';
 import 'dart:convert';
 import 'package:flutter_tools/src/asset.dart';
+import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:path/path.dart' as path;
 import 'package:test/test.dart';
 
 void main()  {
   // Create a temporary directory and write a single file into it.
-  Directory tempDir = Directory.systemTemp.createTempSync();
+  FileSystem fs = new LocalFileSystem();
+  Directory tempDir = fs.systemTempDirectory.createTempSync();
   String projectRoot = tempDir.path;
   String assetPath = 'banana.txt';
   String assetContents = 'banana';
-  File tempFile = new File(path.join(projectRoot, assetPath));
+  File tempFile = fs.file(path.join(projectRoot, assetPath));
   tempFile.parent.createSync(recursive: true);
   tempFile.writeAsBytesSync(UTF8.encode(assetContents));
 

--- a/packages/flutter_tools/test/config_test.dart
+++ b/packages/flutter_tools/test/config_test.dart
@@ -2,9 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:io';
-
 import 'package:flutter_tools/src/base/config.dart';
+import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:path/path.dart' as path;
 import 'package:test/test.dart';
 
@@ -12,8 +11,8 @@ void main() {
   Config config;
 
   setUp(() {
-    Directory tempDiretory = Directory.systemTemp.createTempSync('flutter_test');
-    File file = new File(path.join(tempDiretory.path, '.settings'));
+    Directory tempDiretory = fs.systemTempDirectory.createTempSync('flutter_test');
+    File file = fs.file(path.join(tempDiretory.path, '.settings'));
     config = new Config(file);
   });
 

--- a/packages/flutter_tools/test/create_test.dart
+++ b/packages/flutter_tools/test/create_test.dart
@@ -4,10 +4,11 @@
 
 import 'dart:async';
 import 'dart:convert';
-import 'dart:io';
+import 'dart:io' as io;
 
 import 'package:args/command_runner.dart';
 import 'package:flutter_tools/src/base/common.dart';
+import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/commands/create.dart';
 import 'package:flutter_tools/src/dart/sdk.dart';
@@ -22,7 +23,7 @@ void main() {
     Directory temp;
 
     setUp(() {
-      temp = Directory.systemTemp.createTempSync('flutter_tools');
+      temp = fs.systemTempDirectory.createTempSync('flutter_tools');
     });
 
     tearDown(() {
@@ -48,14 +49,14 @@ void main() {
       await runner.run(<String>['create', '--no-pub', temp.path]);
 
       void expectExists(String relPath) {
-        expect(FileSystemEntity.isFileSync('${temp.path}/$relPath'), true);
+        expect(fs.isFileSync('${temp.path}/$relPath'), true);
       }
       expectExists('lib/main.dart');
       for (FileSystemEntity file in temp.listSync(recursive: true)) {
         if (file is File && file.path.endsWith('.dart')) {
           String original= file.readAsStringSync();
 
-          Process process = await Process.start(
+          io.Process process = await io.Process.start(
               sdkBinaryName('dartfmt'),
               <String>[file.path],
               workingDirectory: temp.path,
@@ -101,7 +102,7 @@ void main() {
       Cache.flutterRoot = '../..';
       CreateCommand command = new CreateCommand();
       CommandRunner<Null> runner = createTestCommandRunner(command);
-      File existingFile = new File("${temp.path.toString()}/bad");
+      File existingFile = fs.file("${temp.path.toString()}/bad");
       if (!existingFile.existsSync()) existingFile.createSync();
       try {
         await runner.run(<String>['create', existingFile.path]);
@@ -123,9 +124,9 @@ Future<Null> _createAndAnalyzeProject(Directory dir, List<String> createArgs) as
   await runner.run(args);
 
   String mainPath = path.join(dir.path, 'lib', 'main.dart');
-  expect(new File(mainPath).existsSync(), true);
+  expect(fs.file(mainPath).existsSync(), true);
   String flutterToolsPath = path.absolute(path.join('bin', 'flutter_tools.dart'));
-  ProcessResult exec = Process.runSync(
+  io.ProcessResult exec = io.Process.runSync(
     '$dartSdkPath/bin/dart', <String>[flutterToolsPath, 'analyze'],
     workingDirectory: dir.path
   );

--- a/packages/flutter_tools/test/devfs_test.dart
+++ b/packages/flutter_tools/test/devfs_test.dart
@@ -2,11 +2,10 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:io';
-
 import 'package:flutter_tools/src/asset.dart';
 import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/devfs.dart';
+import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:path/path.dart' as path;
 import 'package:test/test.dart';
 
@@ -25,9 +24,9 @@ void main() {
   assetBundle.entries.add(new AssetBundleEntry.fromString('a.txt', ''));
   group('devfs', () {
     testUsingContext('create local file system', () async {
-      tempDir = Directory.systemTemp.createTempSync();
+      tempDir = fs.systemTempDirectory.createTempSync();
       basePath = tempDir.path;
-      File file = new File(path.join(basePath, filePath));
+      File file = fs.file(path.join(basePath, filePath));
       await file.parent.create(recursive: true);
       file.writeAsBytesSync(<int>[1, 2, 3]);
     });
@@ -41,14 +40,14 @@ void main() {
       expect(devFSOperations.contains('writeFile test bar/foo.txt'), isTrue);
     });
     testUsingContext('add new file to local file system', () async {
-      File file = new File(path.join(basePath, filePath2));
+      File file = fs.file(path.join(basePath, filePath2));
       await file.parent.create(recursive: true);
       file.writeAsBytesSync(<int>[1, 2, 3, 4, 5, 6, 7]);
       await devFS.update();
       expect(devFSOperations.contains('writeFile test foo/bar.txt'), isTrue);
     });
     testUsingContext('modify existing file on local file system', () async {
-      File file = new File(path.join(basePath, filePath));
+      File file = fs.file(path.join(basePath, filePath));
       // Set the last modified time to 5 seconds in the past.
       updateFileModificationTime(file.path, new DateTime.now(), -5);
       await devFS.update();
@@ -57,7 +56,7 @@ void main() {
       expect(devFSOperations.contains('writeFile test bar/foo.txt'), isTrue);
     });
     testUsingContext('delete a file from the local file system', () async {
-      File file = new File(path.join(basePath, filePath));
+      File file = fs.file(path.join(basePath, filePath));
       await file.delete();
       await devFS.update();
       expect(devFSOperations.contains('deleteFile test bar/foo.txt'), isTrue);

--- a/packages/flutter_tools/test/drive_test.dart
+++ b/packages/flutter_tools/test/drive_test.dart
@@ -42,7 +42,7 @@ void main() {
       memoryFileSystem.directory('test_driver').createSync();
       memoryFileSystem.file('pubspec.yaml').createSync();
       memoryFileSystem.file('.packages').createSync();
-      useInMemoryFileSystem(); // TODO: rename
+      setExitFunctionForTests();
       targetDeviceFinder = () {
         throw 'Unexpected call to targetDeviceFinder';
       };
@@ -59,7 +59,7 @@ void main() {
 
     tearDown(() {
       command = null;
-      restoreFileSystem(); // TODO: rename
+      restoreExitFunction();
       restoreAppStarter();
       restoreAppStopper();
       restoreTestRunner();

--- a/packages/flutter_tools/test/format_test.dart
+++ b/packages/flutter_tools/test/format_test.dart
@@ -3,9 +3,9 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:io';
 
 import 'package:args/command_runner.dart';
+import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/commands/create.dart';
 import 'package:flutter_tools/src/commands/format.dart';
@@ -21,7 +21,7 @@ void main() {
 
     setUp(() {
       Cache.disableLocking();
-      temp = Directory.systemTemp.createTempSync('flutter_tools');
+      temp = fs.systemTempDirectory.createTempSync('flutter_tools');
     });
 
     tearDown(() {
@@ -38,7 +38,7 @@ void main() {
     testUsingContext('a file', () async {
       await createProject();
 
-      File srcFile = new File(path.join(temp.path, 'lib', 'main.dart'));
+      File srcFile = fs.file(path.join(temp.path, 'lib', 'main.dart'));
       String original = srcFile.readAsStringSync();
       srcFile.writeAsStringSync(original.replaceFirst('main()', 'main(  )'));
 

--- a/packages/flutter_tools/test/os_utils_test.dart
+++ b/packages/flutter_tools/test/os_utils_test.dart
@@ -2,20 +2,21 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:io';
+import 'dart:io' as io;
 
-import 'src/context.dart';
-
+import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/os.dart';
 import 'package:path/path.dart' as path;
 import 'package:test/test.dart';
+
+import 'src/context.dart';
 
 void main() {
   group('OperatingSystemUtils', () {
     Directory temp;
 
     setUp(() {
-      temp = Directory.systemTemp.createTempSync('flutter_tools');
+      temp = fs.systemTempDirectory.createTempSync('flutter_tools');
     });
 
     tearDown(() {
@@ -23,12 +24,12 @@ void main() {
     });
 
     testUsingContext('makeExecutable', () async {
-      File file = new File(path.join(temp.path, 'foo.script'));
+      File file = fs.file(path.join(temp.path, 'foo.script'));
       file.writeAsStringSync('hello world');
       os.makeExecutable(file);
 
       // Skip this test on windows.
-      if (!Platform.isWindows) {
+      if (!io.Platform.isWindows) {
         String mode = file.statSync().modeString();
         // rwxr--r--
         expect(mode.substring(0, 3), endsWith('x'));

--- a/packages/flutter_tools/test/packages_test.dart
+++ b/packages/flutter_tools/test/packages_test.dart
@@ -3,9 +3,9 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:io';
 
 import 'package:args/command_runner.dart';
+import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/commands/create.dart';
 import 'package:flutter_tools/src/commands/packages.dart';
 import 'package:test/test.dart';
@@ -18,7 +18,7 @@ void main() {
     Directory temp;
 
     setUp(() {
-      temp = Directory.systemTemp.createTempSync('flutter_tools');
+      temp = fs.systemTempDirectory.createTempSync('flutter_tools');
     });
 
     tearDown(() {
@@ -42,7 +42,7 @@ void main() {
     }
 
     void expectExists(String relPath) {
-      expect(FileSystemEntity.isFileSync('${temp.path}/$relPath'), true);
+      expect(fs.isFileSync('${temp.path}/$relPath'), true);
     }
 
     // Verify that we create a project that is well-formed.

--- a/packages/flutter_tools/test/src/context.dart
+++ b/packages/flutter_tools/test/src/context.dart
@@ -7,6 +7,7 @@ import 'dart:io';
 
 import 'package:flutter_tools/src/base/config.dart';
 import 'package:flutter_tools/src/base/context.dart';
+import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/os.dart';
 import 'package:flutter_tools/src/base/process_manager.dart';
@@ -41,6 +42,7 @@ void testUsingContext(String description, dynamic testMethod(), {
 
     // Initialize the test context with some default mocks.
     // Seed these context entries first since others depend on them
+    testContext.putIfAbsent(FileSystem, () => new LocalFileSystem());
     testContext.putIfAbsent(ProcessManager, () => new ProcessManager());
     testContext.putIfAbsent(Logger, () => new BufferLogger());
 

--- a/packages/flutter_tools/test/test_test.dart
+++ b/packages/flutter_tools/test/test_test.dart
@@ -3,8 +3,9 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:io';
+import 'dart:io' as io;
 
+import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/dart/sdk.dart';
 import 'package:path/path.dart' as path;
@@ -30,12 +31,12 @@ void main() {
 Future<Null> _testFile(String testName, int wantedExitCode) async {
   final String manualTestsDirectory = path.join('..', '..', 'dev', 'automated_tests');
   final String fullTestName = path.join(manualTestsDirectory, 'flutter_test', '${testName}_test.dart');
-  final File testFile = new File(fullTestName);
+  final File testFile = fs.file(fullTestName);
   expect(testFile.existsSync(), true);
   final String fullTestExpectation = path.join(manualTestsDirectory, 'flutter_test', '${testName}_expectation.txt');
-  final File expectationFile = new File(fullTestExpectation);
+  final File expectationFile = fs.file(fullTestExpectation);
   expect(expectationFile.existsSync(), true);
-  final ProcessResult exec = await Process.run(
+  final io.ProcessResult exec = await io.Process.run(
     path.join(dartSdkPath, 'bin', 'dart'),
     <String>[
       path.absolute(path.join('bin', 'flutter_tools.dart')),
@@ -47,7 +48,7 @@ Future<Null> _testFile(String testName, int wantedExitCode) async {
   );
   expect(exec.exitCode, wantedExitCode);
   final List<String> output = exec.stdout.split('\n');
-  final List<String> expectations = new File(fullTestExpectation).readAsLinesSync();
+  final List<String> expectations = fs.file(fullTestExpectation).readAsLinesSync();
   bool allowSkip = false;
   int expectationLineNumber = 0;
   int outputLineNumber = 0;

--- a/packages/flutter_tools/test/toolchain_test.dart
+++ b/packages/flutter_tools/test/toolchain_test.dart
@@ -2,8 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:io';
-
+import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/toolchain.dart';
@@ -14,7 +13,7 @@ import 'src/context.dart';
 void main() {
   group('ToolConfiguration', () {
     Directory tempDir;
-    tempDir = Directory.systemTemp.createTempSync('flutter_temp');
+    tempDir = fs.systemTempDirectory.createTempSync('flutter_temp');
 
     testUsingContext('using cache', () {
       ToolConfiguration toolConfig = new ToolConfiguration();


### PR DESCRIPTION
This removes direct file access from within flutter_tools
in favor of using `package:file` via a `FileSystem` that's
accessed via the `ApplicationContext`.

This lays the groundwork for us to be able to easily swap
out the underlying file system when running Flutter tools,
which will be used to provide a record/replay file system,
analogous to what we have for process invocations.