### PR TITLE
Force all dart:io usage to go through 'base/io.dart'

### DIFF
--- a/dev/bots/test.sh
+++ b/dev/bots/test.sh
@@ -19,10 +19,17 @@ check_for_dart_io() {
     (
         cd packages/flutter_tools
         for f in $(grep -Erl '^import.*dart:io' lib bin test); do
-            if [[ "$f" != "lib/src/base/io.dart" ]]; then
-                echo -e "\x1B[31mError: $f imports 'dart:io'; import 'lib/src/base/io.dart' instead\x1B[0m"
-                exit 1
+            if [[ "$f" == "lib/src/base/io.dart" ]]; then
+                continue
             fi
+
+            IFS=$'\n' matches=( $(grep -E '^import.*dart:io' $f) )
+            for match in "${matches[@]}"; do
+                if [[ "$match" != *"ignore: dart_io_import"* ]]; then
+                    echo -e "\x1B[31mError: $f imports 'dart:io'; import 'lib/src/base/io.dart' instead\x1B[0m"
+                    exit 1
+                fi
+            done
         done
     )
     set -ex

--- a/packages/flutter_tools/bin/fuchsia_builder.dart
+++ b/packages/flutter_tools/bin/fuchsia_builder.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:io' as io;
 
 import 'package:args/args.dart';
 
@@ -11,6 +10,7 @@ import '../lib/src/base/common.dart';
 import '../lib/src/base/config.dart';
 import '../lib/src/base/context.dart';
 import '../lib/src/base/file_system.dart';
+import '../lib/src/base/io.dart';
 import '../lib/src/base/logger.dart';
 import '../lib/src/base/os.dart';
 import '../lib/src/base/process_manager.dart';
@@ -63,7 +63,7 @@ Future<Null> run(List<String> args) async {
     printError('Missing option! All options must be specified.');
     exit(1);
   }
-  Cache.flutterRoot = io.Platform.environment['FLUTTER_ROOT'];
+  Cache.flutterRoot = Platform.environment['FLUTTER_ROOT'];
   String outputPath = argResults[_kOptionOutput];
   try {
     await assemble(

--- a/packages/flutter_tools/lib/executable.dart
+++ b/packages/flutter_tools/lib/executable.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:io' as io;
 
 import 'package:args/command_runner.dart';
 import 'package:stack_trace/stack_trace.dart';
@@ -12,6 +11,7 @@ import 'src/base/common.dart';
 import 'src/base/config.dart';
 import 'src/base/context.dart';
 import 'src/base/file_system.dart';
+import 'src/base/io.dart';
 import 'src/base/logger.dart';
 import 'src/base/os.dart';
 import 'src/base/process.dart';
@@ -125,9 +125,9 @@ Future<Null> main(List<String> args) async {
       _exit(0);
     }, onError: (dynamic error, Chain chain) {
       if (error is UsageException) {
-        io.stderr.writeln(error.message);
-        io.stderr.writeln();
-        io.stderr.writeln(
+        stderr.writeln(error.message);
+        stderr.writeln();
+        stderr.writeln(
             "Run 'flutter -h' (or 'flutter <command> -h') for available "
                 "flutter commands and options."
         );
@@ -135,11 +135,11 @@ Future<Null> main(List<String> args) async {
         _exit(64);
       } else if (error is ToolExit) {
         if (error.message != null)
-          io.stderr.writeln(error.message);
+          stderr.writeln(error.message);
         if (verbose) {
-          io.stderr.writeln();
-          io.stderr.writeln(chain.terse.toString());
-          io.stderr.writeln();
+          stderr.writeln();
+          stderr.writeln(chain.terse.toString());
+          stderr.writeln();
         }
         _exit(error.exitCode ?? 1);
       } else if (error is ProcessExit) {
@@ -147,23 +147,23 @@ Future<Null> main(List<String> args) async {
         _exit(error.exitCode);
       } else {
         // We've crashed; emit a log report.
-        io.stderr.writeln();
+        stderr.writeln();
 
         flutterUsage.sendException(error, chain);
 
         if (isRunningOnBot) {
           // Print the stack trace on the bots - don't write a crash report.
-          io.stderr.writeln('$error');
-          io.stderr.writeln(chain.terse.toString());
+          stderr.writeln('$error');
+          stderr.writeln(chain.terse.toString());
           _exit(1);
         } else {
           if (error is String)
-            io.stderr.writeln('Oops; flutter has exited unexpectedly: "$error".');
+            stderr.writeln('Oops; flutter has exited unexpectedly: "$error".');
           else
-            io.stderr.writeln('Oops; flutter has exited unexpectedly.');
+            stderr.writeln('Oops; flutter has exited unexpectedly.');
 
           _createCrashReport(args, error, chain).then((File file) {
-            io.stderr.writeln(
+            stderr.writeln(
                 'Crash report written to ${file.path};\n'
                     'please let us know at https://github.com/flutter/flutter/issues.'
             );

--- a/packages/flutter_tools/lib/src/android/adb.dart
+++ b/packages/flutter_tools/lib/src/android/adb.dart
@@ -3,8 +3,8 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:io';
 
+import '../base/io.dart';
 import '../base/process.dart';
 import '../globals.dart';
 

--- a/packages/flutter_tools/lib/src/android/android_device.dart
+++ b/packages/flutter_tools/lib/src/android/android_device.dart
@@ -4,11 +4,11 @@
 
 import 'dart:async';
 import 'dart:convert';
-import 'dart:io' as io;
 
 import '../android/android_sdk.dart';
 import '../application_package.dart';
 import '../base/file_system.dart';
+import '../base/io.dart';
 import '../base/logger.dart';
 import '../base/os.dart';
 import '../base/process.dart';
@@ -61,7 +61,7 @@ class AndroidDevice extends Device {
       try {
         // We pass an encoding of LATIN1 so that we don't try and interpret the
         // `adb shell getprop` result as UTF8.
-        io.ProcessResult result = processManager.runSync(
+        ProcessResult result = processManager.runSync(
           propCommand.first,
           propCommand.sublist(1),
           stdoutEncoding: LATIN1
@@ -559,7 +559,7 @@ class _AdbLogReader extends DeviceLogReader {
   final AndroidDevice device;
 
   StreamController<String> _linesController;
-  io.Process _process;
+  Process _process;
 
   @override
   Stream<String> get logLines => _linesController.stream;
@@ -585,7 +585,7 @@ class _AdbLogReader extends DeviceLogReader {
         _timeOrigin = _adbTimestampToDateTime(lastTimestamp);
     else
         _timeOrigin = null;
-    runCommand(device.adbCommandForDevice(args)).then((io.Process process) {
+    runCommand(device.adbCommandForDevice(args)).then((Process process) {
       _process = process;
       _process.stdout.transform(UTF8.decoder).transform(const LineSplitter()).listen(_onLine);
       _process.stderr.transform(UTF8.decoder).transform(const LineSplitter()).listen(_onLine);

--- a/packages/flutter_tools/lib/src/android/android_sdk.dart
+++ b/packages/flutter_tools/lib/src/android/android_sdk.dart
@@ -2,14 +2,13 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:io' as io;
-
 import 'package:path/path.dart' as path;
 import 'package:pub_semver/pub_semver.dart';
 
 import '../base/common.dart';
 import '../base/context.dart';
 import '../base/file_system.dart';
+import '../base/io.dart';
 import '../base/os.dart';
 import '../globals.dart';
 
@@ -65,12 +64,12 @@ class AndroidSdk {
 
   static AndroidSdk locateAndroidSdk() {
     String androidHomeDir;
-    if (io.Platform.environment.containsKey(kAndroidHome)) {
-      androidHomeDir = io.Platform.environment[kAndroidHome];
-    } else if (io.Platform.isLinux) {
+    if (Platform.environment.containsKey(kAndroidHome)) {
+      androidHomeDir = Platform.environment[kAndroidHome];
+    } else if (Platform.isLinux) {
       if (homeDirPath != null)
         androidHomeDir = '$homeDirPath/Android/Sdk';
-    } else if (io.Platform.isMacOS) {
+    } else if (Platform.isMacOS) {
       if (homeDirPath != null)
         androidHomeDir = '$homeDirPath/Library/Android/sdk';
     }

--- a/packages/flutter_tools/lib/src/android/android_workflow.dart
+++ b/packages/flutter_tools/lib/src/android/android_workflow.dart
@@ -3,8 +3,8 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:io';
 
+import '../base/io.dart';
 import '../base/os.dart';
 import '../base/process_manager.dart';
 import '../doctor.dart';

--- a/packages/flutter_tools/lib/src/asset.dart
+++ b/packages/flutter_tools/lib/src/asset.dart
@@ -4,13 +4,13 @@
 
 import 'dart:async';
 import 'dart:convert';
-import 'dart:io' as io;
 
 import 'package:json_schema/json_schema.dart';
 import 'package:path/path.dart' as path;
 import 'package:yaml/yaml.dart';
 
 import 'base/file_system.dart';
+import 'base/io.dart';
 import 'build_info.dart';
 import 'cache.dart';
 import 'dart/package_map.dart';
@@ -378,7 +378,7 @@ Map<_Asset, List<_Asset>> _parseAssets(
     return result;
 
   excludeDirs = excludeDirs.map(
-    (String exclude) => path.absolute(exclude) + io.Platform.pathSeparator).toList();
+    (String exclude) => path.absolute(exclude) + Platform.pathSeparator).toList();
 
   if (manifestDescriptor.containsKey('assets')) {
     for (String asset in manifestDescriptor['assets']) {

--- a/packages/flutter_tools/lib/src/base/common.dart
+++ b/packages/flutter_tools/lib/src/base/common.dart
@@ -2,9 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:io';
-
 import 'package:path/path.dart' as path;
+
+import 'io.dart';
 
 const int kDefaultObservatoryPort = 8100;
 const int kDefaultDiagnosticPort  = 8101;

--- a/packages/flutter_tools/lib/src/base/config.dart
+++ b/packages/flutter_tools/lib/src/base/config.dart
@@ -3,12 +3,12 @@
 // found in the LICENSE file.
 
 import 'dart:convert';
-import 'dart:io' as io;
 
 import 'package:path/path.dart' as path;
 
 import 'context.dart';
 import 'file_system.dart';
+import 'io.dart';
 
 class Config {
   Config([File configFile]) {
@@ -46,7 +46,7 @@ class Config {
 }
 
 String _userHomeDir() {
-  String envKey = io.Platform.operatingSystem == 'windows' ? 'APPDATA' : 'HOME';
-  String value = io.Platform.environment[envKey];
+  String envKey = Platform.operatingSystem == 'windows' ? 'APPDATA' : 'HOME';
+  String value = Platform.environment[envKey];
   return value == null ? '.' : value;
 }

--- a/packages/flutter_tools/lib/src/base/file_system.dart
+++ b/packages/flutter_tools/lib/src/base/file_system.dart
@@ -2,12 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:io' as io;
-
 import 'package:file/file.dart';
 import 'package:file/local.dart';
 import 'package:file/memory.dart';
-import 'package:meta/meta.dart';
 import 'package:path/path.dart' as path;
 
 import 'context.dart';
@@ -23,41 +20,11 @@ const FileSystem _kLocalFs = const LocalFileSystem();
 /// with [MemoryFileSystem].
 FileSystem get fs => context == null ? _kLocalFs : context[FileSystem];
 
-/// Exits the process with the given [exitCode].
-typedef void ExitFunction([int exitCode]);
-
-final ExitFunction _defaultExitFunction = ([int exitCode]) {
-  io.exit(exitCode);
-};
-
-ExitFunction _exitFunction = _defaultExitFunction;
-
-/// Exits the process.
-///
-/// During tests, this may be set to a testing-friendly value by calling
-/// [setExitFunctionForTests] (and then restored with [restoreExitFunction]).
-ExitFunction get exit => _exitFunction;
-
-/// Sets the [exit] function to a function that throws an exception rather
-/// than exiting the process; intended for testing purposes.
-@visibleForTesting
-void setExitFunctionForTests([ExitFunction exitFunction]) {
-  _exitFunction = exitFunction ?? ([int exitCode]) {
-    throw new Exception('Exited with code $exitCode');
-  };
-}
-
-/// Restores the [exit] function to the `dart:io` implementation.
-@visibleForTesting
-void restoreExitFunction() {
-  _exitFunction = _defaultExitFunction;
-}
-
 /// Create the ancestor directories of a file path if they do not already exist.
 void ensureDirectoryExists(String filePath) {
   String dirPath = path.dirname(filePath);
 
-  if (fs.typeSync(dirPath) == FileSystemEntityType.DIRECTORY)
+  if (fs.isDirectorySync(dirPath))
     return;
   fs.directory(dirPath).createSync(recursive: true);
 }

--- a/packages/flutter_tools/lib/src/base/io.dart
+++ b/packages/flutter_tools/lib/src/base/io.dart
@@ -1,3 +1,26 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+/// This file serves as the single point of entry into the `dart:io` APIs
+/// within Flutter tools.
+///
+/// In order to make Flutter tools more testable, we use the `FileSystem` APIs
+/// in `package:file` rather than using the `dart:io` file APIs directly (see
+/// `file_system.dart`). Doing so allows us to swap out local file system
+/// access with mockable (or in-memory) file systems, making our tests hermetic
+/// vis-a-vis file system access.
+///
+/// To ensure that all file system access within Flutter tools goes through the
+/// proper APIs, we forbid direct imports of `dart:io` (via a test), forcing
+/// all callers to instead import this file, which exports the blessed subset
+/// of `dart:io` that is legal to use in Flutter tools.
+///
+/// Because of the nature of this file, it is important that **no file APIs
+/// be exported from `dart:io` in this file**! Moreover, be careful about any
+/// additional exports that you add to this file, as doing so will increase the
+/// API surface that we have to test in Flutter tools, and the APIs in `dart:io`
+/// can sometimes be hard to use in tests.
 import 'dart:io' as io show exit, exitCode;
 
 import 'package:meta/meta.dart';
@@ -43,12 +66,15 @@ ExitFunction _exitFunction = _defaultExitFunction;
 
 /// Exits the process.
 ///
-/// During tests, this may be set to a testing-friendly value by calling
-/// [setExitFunctionForTests] (and then restored with [restoreExitFunction]).
+/// This is analogous to the `exit` function in `dart:io`, except that this
+/// function may be set to a testing-friendly value by calling
+/// [setExitFunctionForTests] (and then restored to its default implementation
+/// with [restoreExitFunction]). The default implementation delegates to
+/// `dart:io`.
 ExitFunction get exit => _exitFunction;
 
 /// Sets the [exit] function to a function that throws an exception rather
-/// than exiting the process; intended for testing purposes.
+/// than exiting the process; this is intended for testing purposes.
 @visibleForTesting
 void setExitFunctionForTests([ExitFunction exitFunction]) {
   _exitFunction = exitFunction ?? (int exitCode) {

--- a/packages/flutter_tools/lib/src/base/io.dart
+++ b/packages/flutter_tools/lib/src/base/io.dart
@@ -1,0 +1,63 @@
+import 'dart:io' as io show exit, exitCode;
+
+import 'package:meta/meta.dart';
+
+export 'dart:io'
+    show
+        BytesBuilder,
+        exitCode,
+        GZIP,
+        InternetAddress,
+        IOException,
+        IOSink,
+        HttpClient,
+        HttpClientRequest,
+        HttpClientResponse,
+        HttpHeaders,
+        HttpRequest,
+        HttpServer,
+        HttpStatus,
+        pid,
+        Platform,
+        Process,
+        ProcessException,
+        ProcessResult,
+        ProcessSignal,
+        ProcessStartMode,
+        ServerSocket,
+        stderr,
+        stdin,
+        stdout,
+        Socket,
+        SocketException,
+        SYSTEM_ENCODING,
+        WebSocket,
+        WebSocketTransformer;
+
+/// Exits the process with the given [exitCode].
+typedef void ExitFunction(int exitCode);
+
+final ExitFunction _defaultExitFunction = (int exitCode) => io.exit(exitCode);
+
+ExitFunction _exitFunction = _defaultExitFunction;
+
+/// Exits the process.
+///
+/// During tests, this may be set to a testing-friendly value by calling
+/// [setExitFunctionForTests] (and then restored with [restoreExitFunction]).
+ExitFunction get exit => _exitFunction;
+
+/// Sets the [exit] function to a function that throws an exception rather
+/// than exiting the process; intended for testing purposes.
+@visibleForTesting
+void setExitFunctionForTests([ExitFunction exitFunction]) {
+  _exitFunction = exitFunction ?? (int exitCode) {
+    throw new Exception('Exited with code ${io.exitCode}');
+  };
+}
+
+/// Restores the [exit] function to the `dart:io` implementation.
+@visibleForTesting
+void restoreExitFunction() {
+  _exitFunction = _defaultExitFunction;
+}

--- a/packages/flutter_tools/lib/src/base/logger.dart
+++ b/packages/flutter_tools/lib/src/base/logger.dart
@@ -4,9 +4,10 @@
 
 import 'dart:async';
 import 'dart:convert' show ASCII;
-import 'dart:io';
 
 import 'package:stack_trace/stack_trace.dart';
+
+import 'io.dart';
 
 final AnsiTerminal terminal = new AnsiTerminal();
 

--- a/packages/flutter_tools/lib/src/base/net.dart
+++ b/packages/flutter_tools/lib/src/base/net.dart
@@ -3,10 +3,10 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:io';
 
 import '../globals.dart';
 import 'common.dart';
+import 'io.dart';
 
 const int kNetworkProblemExitCode = 50;
 

--- a/packages/flutter_tools/lib/src/base/os.dart
+++ b/packages/flutter_tools/lib/src/base/os.dart
@@ -3,13 +3,13 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:io' as io;
 
 import 'package:archive/archive.dart';
 import 'package:path/path.dart' as path;
 
 import 'context.dart';
 import 'file_system.dart';
+import 'io.dart';
 import 'process.dart';
 import 'process_manager.dart';
 
@@ -18,7 +18,7 @@ OperatingSystemUtils get os => context[OperatingSystemUtils];
 
 abstract class OperatingSystemUtils {
   factory OperatingSystemUtils() {
-    if (io.Platform.isWindows) {
+    if (Platform.isWindows) {
       return new _WindowsUtils();
     } else {
       return new _PosixUtils();
@@ -27,14 +27,14 @@ abstract class OperatingSystemUtils {
 
   OperatingSystemUtils._private();
 
-  String get operatingSystem => io.Platform.operatingSystem;
+  String get operatingSystem => Platform.operatingSystem;
 
   bool get isMacOS => operatingSystem == 'macos';
   bool get isWindows => operatingSystem == 'windows';
   bool get isLinux => operatingSystem == 'linux';
 
   /// Make the given file executable. This may be a no-op on some platforms.
-  io.ProcessResult makeExecutable(File file);
+  ProcessResult makeExecutable(File file);
 
   /// Return the path (with symlinks resolved) to the given executable, or `null`
   /// if `which` was not able to locate the binary.
@@ -50,7 +50,7 @@ class _PosixUtils extends OperatingSystemUtils {
   _PosixUtils() : super._private();
 
   @override
-  io.ProcessResult makeExecutable(File file) {
+  ProcessResult makeExecutable(File file) {
     return processManager.runSync('chmod', <String>['a+x', file.path]);
   }
 
@@ -58,7 +58,7 @@ class _PosixUtils extends OperatingSystemUtils {
   /// to locate the binary.
   @override
   File which(String execName) {
-    io.ProcessResult result = processManager.runSync('which', <String>[execName]);
+    ProcessResult result = processManager.runSync('which', <String>[execName]);
     if (result.exitCode != 0)
       return null;
     String path = result.stdout.trim().split('\n').first.trim();
@@ -83,13 +83,13 @@ class _WindowsUtils extends OperatingSystemUtils {
 
   // This is a no-op.
   @override
-  io.ProcessResult makeExecutable(File file) {
-    return new io.ProcessResult(0, 0, null, null);
+  ProcessResult makeExecutable(File file) {
+    return new ProcessResult(0, 0, null, null);
   }
 
   @override
   File which(String execName) {
-    io.ProcessResult result = processManager.runSync('where', <String>[execName]);
+    ProcessResult result = processManager.runSync('where', <String>[execName]);
     if (result.exitCode != 0)
       return null;
     return fs.file(result.stdout.trim().split('\n').first.trim());
@@ -118,7 +118,7 @@ class _WindowsUtils extends OperatingSystemUtils {
 }
 
 Future<int> findAvailablePort() async {
-  io.ServerSocket socket = await io.ServerSocket.bind(io.InternetAddress.LOOPBACK_IP_V4, 0);
+  ServerSocket socket = await ServerSocket.bind(InternetAddress.LOOPBACK_IP_V4, 0);
   int port = socket.port;
   await socket.close();
   return port;
@@ -143,7 +143,7 @@ Future<int> findPreferredPort(int defaultPort, { int searchStep: 2 }) async {
 
 Future<bool> _isPortAvailable(int port) async {
   try {
-    io.ServerSocket socket = await io.ServerSocket.bind(io.InternetAddress.LOOPBACK_IP_V4, port);
+    ServerSocket socket = await ServerSocket.bind(InternetAddress.LOOPBACK_IP_V4, port);
     await socket.close();
     return true;
   } catch (error) {

--- a/packages/flutter_tools/lib/src/base/process.dart
+++ b/packages/flutter_tools/lib/src/base/process.dart
@@ -4,8 +4,8 @@
 
 import 'dart:async';
 import 'dart:convert';
-import 'dart:io';
 
+import 'io.dart';
 import 'process_manager.dart';
 import '../globals.dart';
 

--- a/packages/flutter_tools/lib/src/base/process_manager.dart
+++ b/packages/flutter_tools/lib/src/base/process_manager.dart
@@ -4,14 +4,14 @@
 
 import 'dart:async';
 import 'dart:convert';
-import 'dart:io' as io;
 
 import 'package:archive/archive.dart';
 import 'package:intl/intl.dart';
 import 'package:path/path.dart' as path;
 
 import 'context.dart';
-import 'file_system.dart';
+import 'file_system.dart' hide IOSink;
+import 'io.dart';
 import 'os.dart';
 import 'process.dart';
 
@@ -32,14 +32,14 @@ bool _areListsEqual/*<T>*/(List<dynamic/*=T*/> list1, List<dynamic/*=T*/> list2)
 /// methods to allow the implementation of these methods to be mocked out or
 /// decorated for testing or debugging purposes.
 class ProcessManager {
-  Future<io.Process> start(
+  Future<Process> start(
     String executable,
     List<String> arguments, {
     String workingDirectory,
     Map<String, String> environment,
-    io.ProcessStartMode mode: io.ProcessStartMode.NORMAL,
+    ProcessStartMode mode: ProcessStartMode.NORMAL,
   }) {
-    return io.Process.start(
+    return Process.start(
       executable,
       arguments,
       workingDirectory: workingDirectory,
@@ -48,15 +48,15 @@ class ProcessManager {
     );
   }
 
-  Future<io.ProcessResult> run(
+  Future<ProcessResult> run(
     String executable,
     List<String> arguments, {
     String workingDirectory,
     Map<String, String> environment,
-    Encoding stdoutEncoding: io.SYSTEM_ENCODING,
-    Encoding stderrEncoding: io.SYSTEM_ENCODING,
+    Encoding stdoutEncoding: SYSTEM_ENCODING,
+    Encoding stderrEncoding: SYSTEM_ENCODING,
   }) {
-    return io.Process.run(
+    return Process.run(
       executable,
       arguments,
       workingDirectory: workingDirectory,
@@ -66,15 +66,15 @@ class ProcessManager {
     );
   }
 
-  io.ProcessResult runSync(
+  ProcessResult runSync(
     String executable,
     List<String> arguments, {
     String workingDirectory,
     Map<String, String> environment,
-    Encoding stdoutEncoding: io.SYSTEM_ENCODING,
-    Encoding stderrEncoding: io.SYSTEM_ENCODING,
+    Encoding stdoutEncoding: SYSTEM_ENCODING,
+    Encoding stderrEncoding: SYSTEM_ENCODING,
   }) {
-    return io.Process.runSync(
+    return Process.runSync(
       executable,
       arguments,
       workingDirectory: workingDirectory,
@@ -84,8 +84,8 @@ class ProcessManager {
     );
   }
 
-  bool killPid(int pid, [io.ProcessSignal signal = io.ProcessSignal.SIGTERM]) {
-    return io.Process.killPid(pid, signal);
+  bool killPid(int pid, [ProcessSignal signal = ProcessSignal.SIGTERM]) {
+    return Process.killPid(pid, signal);
   }
 }
 
@@ -122,14 +122,14 @@ class RecordingProcessManager implements ProcessManager {
   }
 
   @override
-  Future<io.Process> start(
+  Future<Process> start(
     String executable,
     List<String> arguments, {
     String workingDirectory,
     Map<String, String> environment,
-    io.ProcessStartMode mode: io.ProcessStartMode.NORMAL,
+    ProcessStartMode mode: ProcessStartMode.NORMAL,
   }) async {
-    io.Process process = await _delegate.start(
+    Process process = await _delegate.start(
       executable,
       arguments,
       workingDirectory: workingDirectory,
@@ -164,15 +164,15 @@ class RecordingProcessManager implements ProcessManager {
   }
 
   @override
-  Future<io.ProcessResult> run(
+  Future<ProcessResult> run(
     String executable,
     List<String> arguments, {
     String workingDirectory,
     Map<String, String> environment,
-    Encoding stdoutEncoding: io.SYSTEM_ENCODING,
-    Encoding stderrEncoding: io.SYSTEM_ENCODING,
+    Encoding stdoutEncoding: SYSTEM_ENCODING,
+    Encoding stderrEncoding: SYSTEM_ENCODING,
   }) async {
-    io.ProcessResult result = await _delegate.run(
+    ProcessResult result = await _delegate.run(
       executable,
       arguments,
       workingDirectory: workingDirectory,
@@ -216,15 +216,15 @@ class RecordingProcessManager implements ProcessManager {
   }
 
   @override
-  io.ProcessResult runSync(
+  ProcessResult runSync(
     String executable,
     List<String> arguments, {
     String workingDirectory,
     Map<String, String> environment,
-    Encoding stdoutEncoding: io.SYSTEM_ENCODING,
-    Encoding stderrEncoding: io.SYSTEM_ENCODING,
+    Encoding stdoutEncoding: SYSTEM_ENCODING,
+    Encoding stderrEncoding: SYSTEM_ENCODING,
   }) {
-    io.ProcessResult result = _delegate.runSync(
+    ProcessResult result = _delegate.runSync(
       executable,
       arguments,
       workingDirectory: workingDirectory,
@@ -268,7 +268,7 @@ class RecordingProcessManager implements ProcessManager {
   }
 
   @override
-  bool killPid(int pid, [io.ProcessSignal signal = io.ProcessSignal.SIGTERM]) {
+  bool killPid(int pid, [ProcessSignal signal = ProcessSignal.SIGTERM]) {
     return _delegate.killPid(pid, signal);
   }
 
@@ -281,7 +281,7 @@ class RecordingProcessManager implements ProcessManager {
     List<String> arguments,
     String workingDirectory,
     Map<String, String> environment,
-    io.ProcessStartMode mode,
+    ProcessStartMode mode,
     Encoding stdoutEncoding,
     Encoding stderrEncoding,
     int exitCode,
@@ -332,7 +332,7 @@ class RecordingProcessManager implements ProcessManager {
     await _waitForRunningProcessesToExitWithTimeout(
       onTimeout: (int pid, Map<String, dynamic> manifestEntry) {
         manifestEntry['daemon'] = true;
-        io.Process.killPid(pid);
+        Process.killPid(pid);
       });
     // Now that we explicitly signalled the processes that timed out asking
     // them to shutdown, wait one more time for those processes to exit.
@@ -438,8 +438,8 @@ class _ManifestEntryBuilder {
 
 /// A [Process] implementation that records `stdout` and `stderr` stream events
 /// to disk before forwarding them on to the underlying stream listener.
-class _RecordingProcess implements io.Process {
-  final io.Process delegate;
+class _RecordingProcess implements Process {
+  final Process delegate;
   final String basename;
   final RecordingProcessManager manager;
 
@@ -507,7 +507,7 @@ class _RecordingProcess implements io.Process {
   }
 
   @override
-  io.IOSink get stdin {
+  IOSink get stdin {
     // We don't currently support recording `stdin`.
     return delegate.stdin;
   }
@@ -516,7 +516,7 @@ class _RecordingProcess implements io.Process {
   int get pid => delegate.pid;
 
   @override
-  bool kill([io.ProcessSignal signal = io.ProcessSignal.SIGTERM]) => delegate.kill(signal);
+  bool kill([ProcessSignal signal = ProcessSignal.SIGTERM]) => delegate.kill(signal);
 }
 
 /// A [ProcessManager] implementation that mocks out all process invocations
@@ -609,12 +609,12 @@ class ReplayProcessManager implements ProcessManager {
   }
 
   @override
-  Future<io.Process> start(
+  Future<Process> start(
     String executable,
     List<String> arguments, {
     String workingDirectory,
     Map<String, String> environment,
-    io.ProcessStartMode mode: io.ProcessStartMode.NORMAL,
+    ProcessStartMode mode: ProcessStartMode.NORMAL,
   }) async {
     Map<String, dynamic> entry = _popEntry(executable, arguments, mode: mode);
     _ReplayProcessResult result = await _ReplayProcessResult.create(
@@ -623,13 +623,13 @@ class ReplayProcessManager implements ProcessManager {
   }
 
   @override
-  Future<io.ProcessResult> run(
+  Future<ProcessResult> run(
     String executable,
     List<String> arguments, {
     String workingDirectory,
     Map<String, String> environment,
-    Encoding stdoutEncoding: io.SYSTEM_ENCODING,
-    Encoding stderrEncoding: io.SYSTEM_ENCODING,
+    Encoding stdoutEncoding: SYSTEM_ENCODING,
+    Encoding stderrEncoding: SYSTEM_ENCODING,
   }) async {
     Map<String, dynamic> entry = _popEntry(executable, arguments,
         stdoutEncoding: stdoutEncoding, stderrEncoding: stderrEncoding);
@@ -638,13 +638,13 @@ class ReplayProcessManager implements ProcessManager {
   }
 
   @override
-  io.ProcessResult runSync(
+  ProcessResult runSync(
     String executable,
     List<String> arguments, {
     String workingDirectory,
     Map<String, String> environment,
-    Encoding stdoutEncoding: io.SYSTEM_ENCODING,
-    Encoding stderrEncoding: io.SYSTEM_ENCODING,
+    Encoding stdoutEncoding: SYSTEM_ENCODING,
+    Encoding stderrEncoding: SYSTEM_ENCODING,
   }) {
     Map<String, dynamic> entry = _popEntry(executable, arguments,
         stdoutEncoding: stdoutEncoding, stderrEncoding: stderrEncoding);
@@ -656,7 +656,7 @@ class ReplayProcessManager implements ProcessManager {
   /// the specified process arguments. Once found, it marks the manifest entry
   /// as having been invoked and thus not eligible for invocation again.
   Map<String, dynamic> _popEntry(String executable, List<String> arguments, {
-    io.ProcessStartMode mode,
+    ProcessStartMode mode,
     Encoding stdoutEncoding,
     Encoding stderrEncoding,
   }) {
@@ -675,14 +675,14 @@ class ReplayProcessManager implements ProcessManager {
     );
 
     if (entry == null)
-      throw new io.ProcessException(executable, arguments, 'No matching invocation found');
+      throw new ProcessException(executable, arguments, 'No matching invocation found');
 
     entry['invoked'] = true;
     return entry;
   }
 
   @override
-  bool killPid(int pid, [io.ProcessSignal signal = io.ProcessSignal.SIGTERM]) {
+  bool killPid(int pid, [ProcessSignal signal = ProcessSignal.SIGTERM]) {
     throw new UnsupportedError(
         "$runtimeType.killPid() has not been implemented because at the time "
         "of its writing, it wasn't needed. If you're hitting this error, you "
@@ -692,7 +692,7 @@ class ReplayProcessManager implements ProcessManager {
 
 /// A [ProcessResult] implementation that derives its data from a recording
 /// fragment.
-class _ReplayProcessResult implements io.ProcessResult {
+class _ReplayProcessResult implements ProcessResult {
   @override
   final int pid;
 
@@ -722,7 +722,7 @@ class _ReplayProcessResult implements io.ProcessResult {
         stderr: await _getData('$basePath.stderr', entry['stderrEncoding']),
       );
     } catch (e) {
-      throw new io.ProcessException(executable, arguments, e.toString());
+      throw new ProcessException(executable, arguments, e.toString());
     }
   }
 
@@ -748,7 +748,7 @@ class _ReplayProcessResult implements io.ProcessResult {
         stderr: _getDataSync('$basePath.stderr', entry['stderrEncoding']),
       );
     } catch (e) {
-      throw new io.ProcessException(executable, arguments, e.toString());
+      throw new ProcessException(executable, arguments, e.toString());
     }
   }
 
@@ -761,13 +761,13 @@ class _ReplayProcessResult implements io.ProcessResult {
 
   static Encoding _getEncodingByName(String encoding) {
     if (encoding == 'system')
-      return const io.SystemEncoding();
+      return SYSTEM_ENCODING;
     else if (encoding != null)
       return Encoding.getByName(encoding);
     return null;
   }
 
-  io.Process asProcess(bool daemon) {
+  Process asProcess(bool daemon) {
     assert(stdout is List<int>);
     assert(stderr is List<int>);
     return new _ReplayProcess(this, daemon);
@@ -775,7 +775,7 @@ class _ReplayProcessResult implements io.ProcessResult {
 }
 
 /// A [Process] implementation derives its data from a recording fragment.
-class _ReplayProcess implements io.Process {
+class _ReplayProcess implements Process {
   @override
   final int pid;
 
@@ -831,10 +831,10 @@ class _ReplayProcess implements io.Process {
   set exitCode(Future<int> exitCode) => throw new UnsupportedError('set exitCode');
 
   @override
-  io.IOSink get stdin => throw new UnimplementedError();
+  IOSink get stdin => throw new UnimplementedError();
 
   @override
-  bool kill([io.ProcessSignal signal = io.ProcessSignal.SIGTERM]) {
+  bool kill([ProcessSignal signal = ProcessSignal.SIGTERM]) {
     if (!_exitCodeCompleter.isCompleted) {
       _stdoutController.close();
       _stderrController.close();

--- a/packages/flutter_tools/lib/src/base/utils.dart
+++ b/packages/flutter_tools/lib/src/base/utils.dart
@@ -4,21 +4,21 @@
 
 import 'dart:async';
 import 'dart:convert';
-import 'dart:io' as io;
 import 'dart:math' show Random;
 
 import 'package:crypto/crypto.dart';
 import 'package:path/path.dart' as path;
 
 import 'file_system.dart';
+import 'io.dart';
 
 bool get isRunningOnBot {
   // https://docs.travis-ci.com/user/environment-variables/#Default-Environment-Variables
   // CHROME_HEADLESS is one property set on Flutter's Chrome Infra bots.
   return
-    io.Platform.environment['TRAVIS'] == 'true' ||
-    io.Platform.environment['CONTINUOUS_INTEGRATION'] == 'true' ||
-    io.Platform.environment['CHROME_HEADLESS'] == '1';
+    Platform.environment['TRAVIS'] == 'true' ||
+    Platform.environment['CONTINUOUS_INTEGRATION'] == 'true' ||
+    Platform.environment['CHROME_HEADLESS'] == '1';
 }
 
 String hex(List<int> bytes) {
@@ -93,7 +93,7 @@ String getElapsedAsMilliseconds(Duration duration) {
 /// Return a relative path if [fullPath] is contained by the cwd, else return an
 /// absolute path.
 String getDisplayPath(String fullPath) {
-  String cwd = fs.currentDirectory.path + io.Platform.pathSeparator;
+  String cwd = fs.currentDirectory.path + Platform.pathSeparator;
   return fullPath.startsWith(cwd) ?  fullPath.substring(cwd.length) : fullPath;
 }
 

--- a/packages/flutter_tools/lib/src/build_info.dart
+++ b/packages/flutter_tools/lib/src/build_info.dart
@@ -2,11 +2,10 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:io';
-
 import 'package:path/path.dart' as path;
 
 import 'base/context.dart';
+import 'base/io.dart';
 import 'base/utils.dart';
 import 'globals.dart';
 

--- a/packages/flutter_tools/lib/src/cache.dart
+++ b/packages/flutter_tools/lib/src/cache.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:io' as io;
 
 import 'package:flutter_tools/src/dart/pub.dart';
 import 'package:flutter_tools/src/dart/summary.dart';
@@ -11,6 +10,7 @@ import 'package:path/path.dart' as path;
 
 import 'base/context.dart';
 import 'base/file_system.dart';
+import 'base/io.dart';
 import 'base/logger.dart';
 import 'base/net.dart';
 import 'base/os.dart';
@@ -84,7 +84,7 @@ class Cache {
 
   static String get dartSdkVersion {
     if (_dartSdkVersion == null) {
-      _dartSdkVersion = io.Platform.version;
+      _dartSdkVersion = Platform.version;
     }
     return _dartSdkVersion;
   }
@@ -264,9 +264,9 @@ class FlutterEngine {
 
     if (cache.includeAllPlatforms)
       dirs.addAll(<String>['ios', 'ios-profile', 'ios-release', 'linux-x64']);
-    else if (io.Platform.isMacOS)
+    else if (Platform.isMacOS)
       dirs.addAll(<String>['ios', 'ios-profile', 'ios-release']);
-    else if (io.Platform.isLinux)
+    else if (Platform.isLinux)
       dirs.add('linux-x64');
 
     return dirs;
@@ -278,9 +278,9 @@ class FlutterEngine {
       return <List<String>>[]
         ..addAll(_osxToolsDirs)
         ..addAll(_linuxToolsDirs);
-    else if (io.Platform.isMacOS)
+    else if (Platform.isMacOS)
       return _osxToolsDirs;
-    else if (io.Platform.isLinux)
+    else if (Platform.isLinux)
       return _linuxToolsDirs;
     else
       return <List<String>>[];

--- a/packages/flutter_tools/lib/src/commands/analyze_base.dart
+++ b/packages/flutter_tools/lib/src/commands/analyze_base.dart
@@ -3,12 +3,12 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:io' as io;
 
 import 'package:args/args.dart';
 import 'package:path/path.dart' as path;
 
 import '../base/file_system.dart';
+import '../base/io.dart';
 import '../base/utils.dart';
 import '../cache.dart';
 import '../globals.dart';
@@ -59,7 +59,7 @@ bool inRepo(List<String> fileList) {
   if (fileList == null || fileList.isEmpty)
     fileList = <String>[path.current];
   String root = path.normalize(path.absolute(Cache.flutterRoot));
-  String prefix = root + io.Platform.pathSeparator;
+  String prefix = root + Platform.pathSeparator;
   for (String file in fileList) {
     file = path.normalize(path.absolute(file));
     if (file == root || file.startsWith(prefix))

--- a/packages/flutter_tools/lib/src/commands/analyze_continuously.dart
+++ b/packages/flutter_tools/lib/src/commands/analyze_continuously.dart
@@ -4,13 +4,13 @@
 
 import 'dart:async';
 import 'dart:convert';
-import 'dart:io' as io;
 
 import 'package:args/args.dart';
 import 'package:path/path.dart' as path;
 
 import '../base/common.dart';
 import '../base/file_system.dart';
+import '../base/io.dart';
 import '../base/logger.dart';
 import '../base/process_manager.dart';
 import '../base/utils.dart';
@@ -150,7 +150,7 @@ class AnalysisServer {
   final String sdk;
   final List<String> directories;
 
-  io.Process _process;
+  Process _process;
   StreamController<bool> _analyzingController = new StreamController<bool>.broadcast();
   StreamController<FileAnalysisErrors> _errorsController = new StreamController<FileAnalysisErrors>.broadcast();
 

--- a/packages/flutter_tools/lib/src/commands/build.dart
+++ b/packages/flutter_tools/lib/src/commands/build.dart
@@ -3,16 +3,16 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:io' as io;
 
 import 'package:meta/meta.dart';
 
+import '../base/common.dart';
 import '../base/file_system.dart';
+import '../base/io.dart';
+import '../base/utils.dart';
 import '../build_info.dart';
 import '../globals.dart';
 import '../runner/flutter_command.dart';
-import '../base/common.dart';
-import '../base/utils.dart';
 import 'build_apk.dart';
 import 'build_aot.dart';
 import 'build_flx.dart';
@@ -88,7 +88,7 @@ class BuildCleanCommand extends FlutterCommand {
   @override
   Future<Null> runCommand() async {
     Directory buildDir = fs.directory(getBuildDirectory());
-    printStatus("Deleting '${buildDir.path}${io.Platform.pathSeparator}'.");
+    printStatus("Deleting '${buildDir.path}${Platform.pathSeparator}'.");
 
     if (!buildDir.existsSync())
       return;

--- a/packages/flutter_tools/lib/src/commands/build_aot.dart
+++ b/packages/flutter_tools/lib/src/commands/build_aot.dart
@@ -3,12 +3,12 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:io' as io;
 
 import 'package:path/path.dart' as path;
 
 import '../base/common.dart';
 import '../base/file_system.dart';
+import '../base/io.dart';
 import '../base/logger.dart';
 import '../base/process.dart';
 import '../base/utils.dart';
@@ -65,7 +65,7 @@ class BuildAotCommand extends BuildSubCommand {
     if (outputPath == null)
       throwToolExit(null);
 
-    printStatus('Built to $outputPath${io.Platform.pathSeparator}.');
+    printStatus('Built to $outputPath${Platform.pathSeparator}.');
   }
 }
 

--- a/packages/flutter_tools/lib/src/commands/daemon.dart
+++ b/packages/flutter_tools/lib/src/commands/daemon.dart
@@ -4,12 +4,12 @@
 
 import 'dart:async';
 import 'dart:convert';
-import 'dart:io' as io;
 
 import '../android/android_device.dart';
 import '../base/common.dart';
 import '../base/context.dart';
 import '../base/file_system.dart';
+import '../base/io.dart';
 import '../base/logger.dart';
 import '../base/utils.dart';
 import '../build_info.dart';
@@ -120,7 +120,7 @@ class Daemon {
     dynamic id = request['id'];
 
     if (id == null) {
-      io.stderr.writeln('no id for request: $request');
+      stderr.writeln('no id for request: $request');
       return;
     }
 
@@ -235,9 +235,9 @@ class DaemonDomain extends Domain {
           // capture the print output for testing.
           print(message.message);
         } else if (message.level == 'error') {
-          io.stderr.writeln(message.message);
+          stderr.writeln(message.message);
           if (message.stackTrace != null)
-            io.stderr.writeln(message.stackTrace.toString().trimRight());
+            stderr.writeln(message.stackTrace.toString().trimRight());
         }
       } else {
         if (message.stackTrace != null) {
@@ -590,7 +590,7 @@ class DeviceDomain extends Domain {
   }
 }
 
-Stream<Map<String, dynamic>> get stdinCommandStream => io.stdin
+Stream<Map<String, dynamic>> get stdinCommandStream => stdin
   .transform(UTF8.decoder)
   .transform(const LineSplitter())
   .where((String line) => line.startsWith('[{') && line.endsWith('}]'))
@@ -600,7 +600,7 @@ Stream<Map<String, dynamic>> get stdinCommandStream => io.stdin
   });
 
 void stdoutCommandResponse(Map<String, dynamic> command) {
-  io.stdout.writeln('[${JSON.encode(command, toEncodable: _jsonEncodeObject)}]');
+  stdout.writeln('[${JSON.encode(command, toEncodable: _jsonEncodeObject)}]');
 }
 
 dynamic _jsonEncodeObject(dynamic object) {
@@ -710,9 +710,9 @@ class _AppRunLogger extends Logger {
   @override
   void printError(String message, [StackTrace stackTrace]) {
     if (logToStdout) {
-      io.stderr.writeln(message);
+      stderr.writeln(message);
       if (stackTrace != null)
-        io.stderr.writeln(stackTrace.toString().trimRight());
+        stderr.writeln(stackTrace.toString().trimRight());
     } else {
       if (stackTrace != null) {
         _sendLogEvent(<String, dynamic>{

--- a/packages/flutter_tools/lib/src/commands/logs.dart
+++ b/packages/flutter_tools/lib/src/commands/logs.dart
@@ -3,9 +3,9 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:io';
 
 import '../base/common.dart';
+import '../base/io.dart';
 import '../cache.dart';
 import '../device.dart';
 import '../globals.dart';

--- a/packages/flutter_tools/lib/src/commands/run.dart
+++ b/packages/flutter_tools/lib/src/commands/run.dart
@@ -3,10 +3,10 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:io' as io;
 
 import '../base/common.dart';
 import '../base/file_system.dart';
+import '../base/io.dart';
 import '../base/utils.dart';
 import '../build_info.dart';
 import '../cache.dart';
@@ -218,7 +218,7 @@ class RunCommand extends RunCommandBase {
     String pidFile = argResults['pid-file'];
     if (pidFile != null) {
       // Write our pid to the file.
-      fs.file(pidFile).writeAsStringSync(io.pid.toString());
+      fs.file(pidFile).writeAsStringSync(pid.toString());
     }
     ResidentRunner runner;
 

--- a/packages/flutter_tools/lib/src/commands/screenshot.dart
+++ b/packages/flutter_tools/lib/src/commands/screenshot.dart
@@ -3,13 +3,13 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:io' as io;
 
 import 'package:http/http.dart' as http;
 import 'package:path/path.dart' as path;
 
 import '../base/common.dart';
 import '../base/file_system.dart';
+import '../base/io.dart' hide IOSink;
 import '../base/utils.dart';
 import '../device.dart';
 import '../globals.dart';
@@ -106,10 +106,10 @@ class ScreenshotCommand extends FlutterCommand {
     http.StreamedResponse skpResponse;
     try {
       skpResponse = await new http.Request('GET', skpUri).send();
-    } on io.SocketException catch (e) {
+    } on SocketException catch (e) {
       throwToolExit('Skia screenshot failed: $skpUri\n$e\n\n$errorHelpText');
     }
-    if (skpResponse.statusCode != io.HttpStatus.OK) {
+    if (skpResponse.statusCode != HttpStatus.OK) {
       String error = await skpResponse.stream.toStringStream().join();
       throwToolExit('Error: $error\n\n$errorHelpText');
     }
@@ -122,7 +122,7 @@ class ScreenshotCommand extends FlutterCommand {
           'file', skpResponse.stream, skpResponse.contentLength));
 
       http.StreamedResponse postResponse = await postRequest.send();
-      if (postResponse.statusCode != io.HttpStatus.OK)
+      if (postResponse.statusCode != HttpStatus.OK)
         throwToolExit('Failed to post Skia picture to skiaserve.\n\n$errorHelpText');
     } else {
       outputFile ??= getUniqueFile(fs.currentDirectory, 'flutter', 'skp');

--- a/packages/flutter_tools/lib/src/commands/test.dart
+++ b/packages/flutter_tools/lib/src/commands/test.dart
@@ -3,13 +3,13 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:io' as io;
 
 import 'package:path/path.dart' as path;
 import 'package:test/src/executable.dart' as test; // ignore: implementation_imports
 
 import '../base/common.dart';
 import '../base/file_system.dart';
+import '../base/io.dart';
 import '../base/logger.dart';
 import '../base/process_manager.dart';
 import '../base/os.dart';
@@ -80,8 +80,8 @@ class TestCommand extends FlutterCommand {
       printTrace('running test package with arguments: $testArgs');
       await test.main(testArgs);
       // test.main() sets dart:io's exitCode global.
-      printTrace('test package returned with exit code ${io.exitCode}');
-      return io.exitCode;
+      printTrace('test package returned with exit code $exitCode');
+      return exitCode;
     } finally {
       fs.currentDirectory = currentDirectory;
     }
@@ -128,7 +128,7 @@ class TestCommand extends FlutterCommand {
       Directory tempDir = fs.systemTempDirectory.createTempSync('flutter_tools');
       try {
         File sourceFile = coverageFile.copySync(path.join(tempDir.path, 'lcov.source.info'));
-        io.ProcessResult result = processManager.runSync('lcov', <String>[
+        ProcessResult result = processManager.runSync('lcov', <String>[
           '--add-tracefile', baseCoverageData,
           '--add-tracefile', sourceFile.path,
           '--output-file', coverageFile.path,
@@ -165,7 +165,7 @@ class TestCommand extends FlutterCommand {
     if (argResults['coverage'])
       testArgs.insert(0, '--concurrency=1');
 
-    final String shellPath = tools.getHostToolPath(HostTool.SkyShell) ?? io.Platform.environment['SKY_SHELL'];
+    final String shellPath = tools.getHostToolPath(HostTool.SkyShell) ?? Platform.environment['SKY_SHELL'];
     if (!fs.isFileSync(shellPath))
       throwToolExit('Cannot find Flutter shell at $shellPath');
     loader.installHook(shellPath: shellPath);

--- a/packages/flutter_tools/lib/src/dart/analysis.dart
+++ b/packages/flutter_tools/lib/src/dart/analysis.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import 'dart:collection';
-import 'dart:io' as io;
 
 import 'package:analyzer/error/error.dart';
 import 'package:analyzer/file_system/file_system.dart' as file_system;
@@ -27,7 +26,8 @@ import 'package:path/path.dart' as path;
 import 'package:plugin/manager.dart';
 import 'package:plugin/plugin.dart';
 
-import '../base/file_system.dart';
+import '../base/file_system.dart' hide IOSink;
+import '../base/io.dart';
 
 class AnalysisDriver {
   Set<Source> _analyzedSources = new HashSet<Source>();
@@ -240,10 +240,10 @@ class DriverOptions extends AnalysisOptionsImpl {
   Map<Object, Object> analysisOptions;
 
   /// Out sink for logging.
-  io.IOSink outSink = io.stdout;
+  IOSink outSink = stdout;
 
   /// Error sink for logging.
-  io.IOSink errorSink = io.stderr;
+  IOSink errorSink = stderr;
 }
 
 class PackageInfo {
@@ -269,8 +269,8 @@ class PackageInfo {
 }
 
 class _StdLogger extends Logger {
-  final io.IOSink outSink;
-  final io.IOSink errorSink;
+  final IOSink outSink;
+  final IOSink errorSink;
   _StdLogger({this.outSink, this.errorSink});
 
   @override

--- a/packages/flutter_tools/lib/src/dart/sdk.dart
+++ b/packages/flutter_tools/lib/src/dart/sdk.dart
@@ -2,10 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:io';
-
 import 'package:path/path.dart' as path;
 
+import '../base/io.dart';
 import '../cache.dart';
 
 /// Locate the Dart SDK.

--- a/packages/flutter_tools/lib/src/dart/summary.dart
+++ b/packages/flutter_tools/lib/src/dart/summary.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:io' as io;
 
 import 'package:analyzer/file_system/file_system.dart';
 import 'package:analyzer/file_system/physical_file_system.dart';
@@ -14,6 +13,9 @@ import 'package:flutter_tools/src/dart/pub.dart';
 import 'package:flutter_tools/src/globals.dart';
 import 'package:path/path.dart' as pathos;
 import 'package:yaml/src/yaml_node.dart'; // ignore: implementation_imports
+
+import '../base/file_system.dart' as file;
+import '../base/io.dart';
 
 /// Given the [skyEnginePath], locate corresponding `_embedder.yaml` and compose
 /// the full embedded Dart SDK, and build the [outBundleName] file with its
@@ -46,13 +48,13 @@ void buildSkyEngineSdkSummary(String skyEnginePath, String outBundleName) {
   // Build.
   List<int> bytes = new SummaryBuilder(sources, sdk.context, true).build();
   String outputPath = pathos.join(skyEnginePath, outBundleName);
-  new io.File(outputPath).writeAsBytesSync(bytes);
+  file.fs.file(outputPath).writeAsBytesSync(bytes);
 }
 
 Future<Null> buildUnlinkedForPackages(String flutterPath) async {
   PhysicalResourceProvider provider = PhysicalResourceProvider.INSTANCE;
   PubSummaryManager manager =
-      new PubSummaryManager(provider, '__unlinked_${io.pid}.ds');
+      new PubSummaryManager(provider, '__unlinked_$pid.ds');
 
   Folder flutterFolder = provider.getFolder(flutterPath);
 

--- a/packages/flutter_tools/lib/src/devfs.dart
+++ b/packages/flutter_tools/lib/src/devfs.dart
@@ -4,12 +4,12 @@
 
 import 'dart:async';
 import 'dart:convert' show BASE64, UTF8;
-import 'dart:io' as io;
 
 import 'package:path/path.dart' as path;
 
 import 'base/context.dart';
 import 'base/file_system.dart';
+import 'base/io.dart';
 import 'build_info.dart';
 import 'dart/package_map.dart';
 import 'asset.dart';
@@ -127,7 +127,7 @@ class DevFSEntry {
   }
 
   Stream<List<int>> contentsAsCompressedStream() {
-    return contentsAsStream().transform(io.GZIP.encoder);
+    return contentsAsStream().transform(GZIP.encoder);
   }
 }
 
@@ -214,13 +214,13 @@ class _DevFSHttpWriter {
   int _inFlight = 0;
   List<DevFSEntry> _outstanding;
   Completer<Null> _completer;
-  io.HttpClient _client;
+  HttpClient _client;
   int _done;
   int _max;
 
   Future<Null> write(Set<DevFSEntry> entries,
                      {DevFSProgressReporter progressReporter}) async {
-    _client = new io.HttpClient();
+    _client = new HttpClient();
     _client.maxConnectionsPerHost = kMaxInFlight;
     _completer = new Completer<Null>();
     _outstanding = entries.toList();
@@ -246,14 +246,14 @@ class _DevFSHttpWriter {
   Future<Null> _scheduleWrite(DevFSEntry entry,
                               DevFSProgressReporter progressReporter) async {
     try {
-      io.HttpClientRequest request = await _client.putUrl(httpAddress);
-      request.headers.removeAll(io.HttpHeaders.ACCEPT_ENCODING);
+      HttpClientRequest request = await _client.putUrl(httpAddress);
+      request.headers.removeAll(HttpHeaders.ACCEPT_ENCODING);
       request.headers.add('dev_fs_name', fsName);
       request.headers.add('dev_fs_path_b64',
                           BASE64.encode(UTF8.encode(entry.devicePath)));
       Stream<List<int>> contents = entry.contentsAsCompressedStream();
       await request.addStream(contents);
-      io.HttpClientResponse response = await request.close();
+      HttpClientResponse response = await request.close();
       await response.drain();
     } catch (e, stackTrace) {
       printError('Error writing "${entry.devicePath}" to DevFS: $e\n$stackTrace');

--- a/packages/flutter_tools/lib/src/doctor.dart
+++ b/packages/flutter_tools/lib/src/doctor.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:io' as io;
 
 import 'package:archive/archive.dart';
 import 'dart:convert' show UTF8;
@@ -13,6 +12,7 @@ import 'android/android_workflow.dart';
 import 'base/common.dart';
 import 'base/context.dart';
 import 'base/file_system.dart';
+import 'base/io.dart';
 import 'device.dart';
 import 'globals.dart';
 import 'ios/ios_workflow.dart';
@@ -27,7 +27,7 @@ const Map<String, String> _osNames = const <String, String>{
 };
 
 String osName() {
-  String os = io.Platform.operatingSystem;
+  String os = Platform.operatingSystem;
   return _osNames.containsKey(os) ? _osNames[os] : os;
 }
 
@@ -124,7 +124,7 @@ class Doctor {
       else
         printStatus('${result.leadingBox} ${validator.title}');
 
-      final String separator = io.Platform.isWindows ? ' ' : '•';
+      final String separator = Platform.isWindows ? ' ' : '•';
 
       for (ValidationMessage message in result.messages) {
         String text = message.message.replaceAll('\n', '\n      ');
@@ -182,7 +182,7 @@ class ValidationResult {
     if (type == ValidationType.missing)
       return '[x]';
     else if (type == ValidationType.installed)
-      return io.Platform.isWindows ? '[+]' : '[✓]';
+      return Platform.isWindows ? '[+]' : '[✓]';
     else
       return '[-]';
   }
@@ -217,7 +217,7 @@ class _FlutterValidator extends DoctorValidator {
     messages.add(new ValidationMessage('Engine revision ${version.engineRevisionShort}'));
     messages.add(new ValidationMessage('Tools Dart version ${version.dartSdkVersion}'));
 
-    if (io.Platform.isWindows) {
+    if (Platform.isWindows) {
       valid = ValidationType.missing;
 
       messages.add(new ValidationMessage.error(
@@ -254,9 +254,9 @@ abstract class IntelliJValidator extends DoctorValidator {
   };
 
   static Iterable<DoctorValidator> get installedValidators {
-    if (io.Platform.isLinux)
+    if (Platform.isLinux)
       return IntelliJValidatorOnLinux.installed;
-    if (io.Platform.isMacOS)
+    if (Platform.isMacOS)
       return IntelliJValidatorOnMac.installed;
     // TODO(danrubel): add support for Windows
     return <DoctorValidator>[];

--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -4,10 +4,10 @@
 
 import 'dart:async';
 import 'dart:convert';
-import 'dart:io' as io;
 
 import '../application_package.dart';
 import '../base/file_system.dart';
+import '../base/io.dart';
 import '../base/os.dart';
 import '../base/process.dart';
 import '../base/process_manager.dart';
@@ -28,7 +28,7 @@ class IOSDevices extends PollingDeviceDiscovery {
   IOSDevices() : super('IOSDevices');
 
   @override
-  bool get supportsPlatform => io.Platform.isMacOS;
+  bool get supportsPlatform => Platform.isMacOS;
 
   @override
   List<Device> pollingGetDevices() => IOSDevice.getAttachedDevices();
@@ -125,7 +125,7 @@ class IOSDevice extends Device {
       try {
         command = runCheckedSync(<String>['which', command]).trim();
       } catch (e) {
-        if (io.Platform.isMacOS) {
+        if (Platform.isMacOS) {
           printError('$command not found. $macInstructions');
         } else {
           printError('Cannot control iOS devices or simulators. $command is not available on your platform.');
@@ -313,7 +313,7 @@ class IOSDevice extends Device {
   }
 
   Future<bool> pushFile(ApplicationPackage app, String localFile, String targetFile) async {
-    if (io.Platform.isMacOS) {
+    if (Platform.isMacOS) {
       runSync(<String>[
         pusherPath,
         '-t',
@@ -392,7 +392,7 @@ class _IOSDeviceLogReader extends DeviceLogReader {
   final IOSDevice device;
 
   StreamController<String> _linesController;
-  io.Process _process;
+  Process _process;
 
   @override
   Stream<String> get logLines => _linesController.stream;
@@ -401,7 +401,7 @@ class _IOSDeviceLogReader extends DeviceLogReader {
   String get name => device.name;
 
   void _start() {
-    runCommand(<String>[device.loggerPath]).then((io.Process process) {
+    runCommand(<String>[device.loggerPath]).then((Process process) {
       _process = process;
       _process.stdout.transform(UTF8.decoder).transform(const LineSplitter()).listen(_onLine);
       _process.stderr.transform(UTF8.decoder).transform(const LineSplitter()).listen(_onLine);
@@ -445,7 +445,7 @@ class _IOSDevicePortForwarder extends DevicePortForwarder {
     }
 
     // Usage: iproxy LOCAL_TCP_PORT DEVICE_TCP_PORT UDID
-    io.Process process = await runCommand(<String>[
+    Process process = await runCommand(<String>[
       device.iproxyPath,
       hostPort.toString(),
       devicePort.toString(),
@@ -471,7 +471,7 @@ class _IOSDevicePortForwarder extends DevicePortForwarder {
 
     printTrace("Unforwarding port $forwardedPort");
 
-    io.Process process = forwardedPort.context;
+    Process process = forwardedPort.context;
 
     if (process != null) {
       processManager.killPid(process.pid);

--- a/packages/flutter_tools/lib/src/ios/ios_workflow.dart
+++ b/packages/flutter_tools/lib/src/ios/ios_workflow.dart
@@ -3,8 +3,8 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:io';
 
+import '../base/io.dart';
 import '../base/os.dart';
 import '../base/process.dart';
 import '../doctor.dart';

--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -4,13 +4,13 @@
 
 import 'dart:async';
 import 'dart:convert' show JSON;
-import 'dart:io' as io;
 
 import 'package:path/path.dart' as path;
 
 import '../application_package.dart';
 import '../base/context.dart';
 import '../base/file_system.dart';
+import '../base/io.dart';
 import '../base/process.dart';
 import '../base/process_manager.dart';
 import '../build_info.dart';
@@ -41,7 +41,7 @@ class XCode {
       } else {
         try {
           printTrace('xcrun clang');
-          io.ProcessResult result = processManager.runSync('/usr/bin/xcrun', <String>['clang']);
+          ProcessResult result = processManager.runSync('/usr/bin/xcrun', <String>['clang']);
 
           if (result.stdout != null && result.stdout.contains('license'))
             _eulaSigned = false;
@@ -220,7 +220,7 @@ final RegExp _xcodeVersionRegExp = new RegExp(r'Xcode (\d+)\..*');
 final String _xcodeRequirement = 'Xcode 7.0 or greater is required to develop for iOS.';
 
 bool _checkXcodeVersion() {
-  if (!io.Platform.isMacOS)
+  if (!Platform.isMacOS)
     return false;
   try {
     String version = runCheckedSync(<String>['xcodebuild', '-version']);

--- a/packages/flutter_tools/lib/src/ios/simulators.dart
+++ b/packages/flutter_tools/lib/src/ios/simulators.dart
@@ -4,7 +4,6 @@
 
 import 'dart:async';
 import 'dart:convert';
-import 'dart:io' as io;
 import 'dart:math' as math;
 
 import 'package:path/path.dart' as path;
@@ -13,6 +12,7 @@ import '../application_package.dart';
 import '../base/common.dart';
 import '../base/context.dart';
 import '../base/file_system.dart';
+import '../base/io.dart';
 import '../base/process.dart';
 import '../base/process_manager.dart';
 import '../build_info.dart';
@@ -31,7 +31,7 @@ class IOSSimulators extends PollingDeviceDiscovery {
   IOSSimulators() : super('IOSSimulators');
 
   @override
-  bool get supportsPlatform => io.Platform.isMacOS;
+  bool get supportsPlatform => Platform.isMacOS;
 
   @override
   List<Device> pollingGetDevices() => IOSSimulatorUtils.instance.getAttachedDevices();
@@ -192,7 +192,7 @@ class SimControl {
 
     List<String> args = <String>['simctl', 'list', '--json', section.name];
     printTrace('$_xcrunPath ${args.join(' ')}');
-    io.ProcessResult results = processManager.runSync(_xcrunPath, args);
+    ProcessResult results = processManager.runSync(_xcrunPath, args);
     if (results.exitCode != 0) {
       printError('Error executing simctl: ${results.exitCode}\n${results.stderr}');
       return <String, Map<String, dynamic>>{};
@@ -359,7 +359,7 @@ class IOSSimulator extends Device {
 
   @override
   bool isSupported() {
-    if (!io.Platform.isMacOS) {
+    if (!Platform.isMacOS) {
       _supportMessage = "Not supported on a non Mac host";
       return false;
     }
@@ -531,7 +531,7 @@ class IOSSimulator extends Device {
 
   Future<bool> pushFile(
       ApplicationPackage app, String localFile, String targetFile) async {
-    if (io.Platform.isMacOS) {
+    if (Platform.isMacOS) {
       String simulatorHomeDirectory = _getSimulatorAppHomeDirectory(app);
       runCheckedSync(<String>['cp', localFile, path.join(simulatorHomeDirectory, targetFile)]);
       return true;
@@ -640,8 +640,8 @@ class _IOSSimulatorLogReader extends DeviceLogReader {
   StreamController<String> _linesController;
 
   // We log from two files: the device and the system log.
-  io.Process _deviceProcess;
-  io.Process _systemProcess;
+  Process _deviceProcess;
+  Process _systemProcess;
 
   @override
   Stream<String> get logLines => _linesController.stream;

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -3,13 +3,13 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:io' as io;
 
 import 'package:meta/meta.dart';
 import 'package:path/path.dart' as path;
 
 import 'application_package.dart';
 import 'base/file_system.dart';
+import 'base/io.dart';
 import 'base/logger.dart';
 import 'build_info.dart';
 import 'device.dart';
@@ -78,12 +78,12 @@ abstract class ResidentRunner {
   }
 
   void registerSignalHandlers() {
-    io.ProcessSignal.SIGINT.watch().listen((io.ProcessSignal signal) async {
+    ProcessSignal.SIGINT.watch().listen((ProcessSignal signal) async {
       _resetTerminal();
       await cleanupAfterSignal();
       exit(0);
     });
-    io.ProcessSignal.SIGTERM.watch().listen((io.ProcessSignal signal) async {
+    ProcessSignal.SIGTERM.watch().listen((ProcessSignal signal) async {
       _resetTerminal();
       await cleanupAfterSignal();
       exit(0);
@@ -92,19 +92,19 @@ abstract class ResidentRunner {
       return;
     if (!supportsRestart)
       return;
-    io.ProcessSignal.SIGUSR1.watch().listen(_handleSignal);
-    io.ProcessSignal.SIGUSR2.watch().listen(_handleSignal);
+    ProcessSignal.SIGUSR1.watch().listen(_handleSignal);
+    ProcessSignal.SIGUSR2.watch().listen(_handleSignal);
   }
 
   bool _processingSignal = false;
-  Future<Null> _handleSignal(io.ProcessSignal signal) async {
+  Future<Null> _handleSignal(ProcessSignal signal) async {
     if (_processingSignal) {
       printTrace('Ignoring signal: "$signal" because we are busy.');
       return;
     }
     _processingSignal = true;
 
-    final bool fullRestart = signal == io.ProcessSignal.SIGUSR2;
+    final bool fullRestart = signal == ProcessSignal.SIGUSR2;
 
     try {
       await restart(fullRestart: fullRestart);

--- a/packages/flutter_tools/lib/src/runner/flutter_command_runner.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command_runner.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:io' as io;
 
 import 'package:args/args.dart';
 import 'package:args/command_runner.dart';
@@ -13,6 +12,7 @@ import '../android/android_sdk.dart';
 import '../base/common.dart';
 import '../base/context.dart';
 import '../base/file_system.dart';
+import '../base/io.dart';
 import '../base/logger.dart';
 import '../base/process.dart';
 import '../base/process_manager.dart';
@@ -118,12 +118,12 @@ class FlutterCommandRunner extends CommandRunner<Null> {
   }
 
   static String get _defaultFlutterRoot {
-    if (io.Platform.environment.containsKey(kFlutterRootEnvironmentVariableName))
-      return io.Platform.environment[kFlutterRootEnvironmentVariableName];
+    if (Platform.environment.containsKey(kFlutterRootEnvironmentVariableName))
+      return Platform.environment[kFlutterRootEnvironmentVariableName];
     try {
-      if (io.Platform.script.scheme == 'data')
+      if (Platform.script.scheme == 'data')
         return '../..'; // we're running as a test
-      String script = io.Platform.script.toFilePath();
+      String script = Platform.script.toFilePath();
       if (path.basename(script) == kSnapshotFileName)
         return path.dirname(path.dirname(path.dirname(script)));
       if (path.basename(script) == kFlutterToolsScriptFileName)
@@ -192,7 +192,7 @@ class FlutterCommandRunner extends CommandRunner<Null> {
     // enginePath's initialiser uses it).
     Cache.flutterRoot = path.normalize(path.absolute(globalResults['flutter-root']));
 
-    if (io.Platform.environment['FLUTTER_ALREADY_LOCKED'] != 'true')
+    if (Platform.environment['FLUTTER_ALREADY_LOCKED'] != 'true')
       await Cache.lock();
 
     if (globalResults['suppress-analytics'])
@@ -232,7 +232,7 @@ class FlutterCommandRunner extends CommandRunner<Null> {
   }
 
   String _findEnginePath(ArgResults globalResults) {
-    String engineSourcePath = globalResults['local-engine-src-path'] ?? io.Platform.environment[kFlutterEngineEnvironmentVariableName];
+    String engineSourcePath = globalResults['local-engine-src-path'] ?? Platform.environment[kFlutterEngineEnvironmentVariableName];
 
     if (engineSourcePath == null && globalResults['local-engine'] != null) {
       try {

--- a/packages/flutter_tools/lib/src/test/coverage_collector.dart
+++ b/packages/flutter_tools/lib/src/test/coverage_collector.dart
@@ -3,11 +3,12 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:io';
 
 import 'package:coverage/coverage.dart';
 import 'package:path/path.dart' as path;
 
+import '../base/file_system.dart';
+import '../base/io.dart';
 import '../dart/package_map.dart';
 import '../globals.dart';
 
@@ -67,7 +68,7 @@ class CoverageCollector {
       return null;
     if (formatter == null) {
       Resolver resolver = new Resolver(packagesPath: PackageMap.globalPackagesPath);
-      String packagePath = Directory.current.path;
+      String packagePath = fs.currentDirectory.path;
       List<String> reportOn = <String>[path.join(packagePath, 'lib')];
       formatter = new LcovFormatter(resolver, reportOn: reportOn, basePath: packagePath);
     }

--- a/packages/flutter_tools/lib/src/test/flutter_platform.dart
+++ b/packages/flutter_tools/lib/src/test/flutter_platform.dart
@@ -213,8 +213,8 @@ class FlutterPlatform extends PlatformPlugin {
   }) {
     return '''
 import 'dart:convert';
-import '../base/io.dart';
 
+import 'package:flutter_tools/src/base/io.dart';
 import 'package:stream_channel/stream_channel.dart';
 import 'package:test/src/runner/plugin/remote_platform_helpers.dart';
 import 'package:test/src/runner/vm/catch_isolate_errors.dart';

--- a/packages/flutter_tools/lib/src/test/flutter_platform.dart
+++ b/packages/flutter_tools/lib/src/test/flutter_platform.dart
@@ -213,8 +213,8 @@ class FlutterPlatform extends PlatformPlugin {
   }) {
     return '''
 import 'dart:convert';
+import 'dart:io'; // ignore: dart_io_import
 
-import 'package:flutter_tools/src/base/io.dart';
 import 'package:stream_channel/stream_channel.dart';
 import 'package:test/src/runner/plugin/remote_platform_helpers.dart';
 import 'package:test/src/runner/vm/catch_isolate_errors.dart';

--- a/packages/flutter_tools/lib/src/version.dart
+++ b/packages/flutter_tools/lib/src/version.dart
@@ -2,8 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:io';
-
+import 'base/io.dart';
 import 'base/process.dart';
 import 'base/process_manager.dart';
 import 'cache.dart';

--- a/packages/flutter_tools/lib/src/vmservice.dart
+++ b/packages/flutter_tools/lib/src/vmservice.dart
@@ -4,7 +4,6 @@
 
 import 'dart:async';
 import 'dart:convert' show BASE64;
-import 'dart:io';
 
 import 'package:json_rpc_2/json_rpc_2.dart' as rpc;
 import 'package:json_rpc_2/error_code.dart' as rpc_error_code;
@@ -12,6 +11,7 @@ import 'package:path/path.dart' as path;
 import 'package:stream_channel/stream_channel.dart';
 import 'package:web_socket_channel/io.dart';
 
+import 'base/io.dart';
 import 'globals.dart';
 
 /// The default VM service request timeout.

--- a/packages/flutter_tools/test/analytics_test.dart
+++ b/packages/flutter_tools/test/analytics_test.dart
@@ -2,9 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:io';
-
 import 'package:args/command_runner.dart';
+import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/commands/create.dart';
 import 'package:flutter_tools/src/commands/config.dart';
@@ -21,7 +20,7 @@ void main() {
 
     setUp(() {
       Cache.flutterRoot = '../..';
-      temp = Directory.systemTemp.createTempSync('flutter_tools');
+      temp = fs.systemTempDirectory.createTempSync('flutter_tools');
     });
 
     tearDown(() {

--- a/packages/flutter_tools/test/analyze_test.dart
+++ b/packages/flutter_tools/test/analyze_test.dart
@@ -2,8 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:io';
-
+import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/commands/analyze_base.dart';
 import 'package:flutter_tools/src/runner/flutter_command_runner.dart';
@@ -17,7 +16,7 @@ void main() {
 
   setUp(() {
     FlutterCommandRunner.initFlutterRoot();
-    tempDir = Directory.systemTemp.createTempSync('analysis_test');
+    tempDir = fs.systemTempDirectory.createTempSync('analysis_test');
   });
 
   tearDown(() {
@@ -33,16 +32,16 @@ void main() {
       expect(inRepo(<String>[Cache.flutterRoot]), isTrue);
       expect(inRepo(<String>[path.join(Cache.flutterRoot, 'foo')]), isTrue);
       // Relative paths
-      String oldWorkingDirectory = path.current;
+      String oldWorkingDirectory = fs.currentDirectory.path;
       try {
-        Directory.current = Cache.flutterRoot;
+        fs.currentDirectory = Cache.flutterRoot;
         expect(inRepo(<String>['.']), isTrue);
         expect(inRepo(<String>['foo']), isTrue);
-        Directory.current = tempDir.path;
+        fs.currentDirectory = tempDir.path;
         expect(inRepo(<String>['.']), isFalse);
         expect(inRepo(<String>['foo']), isFalse);
       } finally {
-        Directory.current = oldWorkingDirectory;
+        fs.currentDirectory = oldWorkingDirectory;
       }
       // Ensure no exceptions
       inRepo(null);

--- a/packages/flutter_tools/test/create_test.dart
+++ b/packages/flutter_tools/test/create_test.dart
@@ -4,11 +4,11 @@
 
 import 'dart:async';
 import 'dart:convert';
-import 'dart:io' as io;
 
 import 'package:args/command_runner.dart';
 import 'package:flutter_tools/src/base/common.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
+import 'package:flutter_tools/src/base/io.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/commands/create.dart';
 import 'package:flutter_tools/src/dart/sdk.dart';
@@ -56,7 +56,7 @@ void main() {
         if (file is File && file.path.endsWith('.dart')) {
           String original= file.readAsStringSync();
 
-          io.Process process = await io.Process.start(
+          Process process = await Process.start(
               sdkBinaryName('dartfmt'),
               <String>[file.path],
               workingDirectory: temp.path,
@@ -126,7 +126,7 @@ Future<Null> _createAndAnalyzeProject(Directory dir, List<String> createArgs) as
   String mainPath = path.join(dir.path, 'lib', 'main.dart');
   expect(fs.file(mainPath).existsSync(), true);
   String flutterToolsPath = path.absolute(path.join('bin', 'flutter_tools.dart'));
-  io.ProcessResult exec = io.Process.runSync(
+  ProcessResult exec = Process.runSync(
     '$dartSdkPath/bin/dart', <String>[flutterToolsPath, 'analyze'],
     workingDirectory: dir.path
   );

--- a/packages/flutter_tools/test/daemon_test.dart
+++ b/packages/flutter_tools/test/daemon_test.dart
@@ -3,9 +3,9 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:io';
 
 import 'package:flutter_tools/src/base/context.dart';
+import 'package:flutter_tools/src/base/io.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/commands/daemon.dart';
 import 'package:flutter_tools/src/device.dart';

--- a/packages/flutter_tools/test/dart_dependencies_test.dart
+++ b/packages/flutter_tools/test/dart_dependencies_test.dart
@@ -2,8 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:io';
-
+import 'package:flutter_tools/src/base/io.dart';
 import 'package:flutter_tools/src/dart/dependencies.dart';
 import 'package:path/path.dart' as path;
 import 'package:test/test.dart';

--- a/packages/flutter_tools/test/dependency_checker_test.dart
+++ b/packages/flutter_tools/test/dependency_checker_test.dart
@@ -2,8 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:io';
-
+import 'package:flutter_tools/src/base/io.dart';
 import 'package:flutter_tools/src/dart/dependencies.dart';
 import 'package:flutter_tools/src/dependency_checker.dart';
 import 'package:path/path.dart' as path;

--- a/packages/flutter_tools/test/drive_test.dart
+++ b/packages/flutter_tools/test/drive_test.dart
@@ -8,6 +8,7 @@ import 'package:file/memory.dart';
 import 'package:flutter_tools/src/android/android_device.dart';
 import 'package:flutter_tools/src/base/common.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
+import 'package:flutter_tools/src/base/io.dart';
 import 'package:flutter_tools/src/base/os.dart';
 import 'package:flutter_tools/src/commands/drive.dart';
 import 'package:flutter_tools/src/device.dart';

--- a/packages/flutter_tools/test/os_utils_test.dart
+++ b/packages/flutter_tools/test/os_utils_test.dart
@@ -2,9 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:io' as io;
-
 import 'package:flutter_tools/src/base/file_system.dart';
+import 'package:flutter_tools/src/base/io.dart';
 import 'package:flutter_tools/src/base/os.dart';
 import 'package:path/path.dart' as path;
 import 'package:test/test.dart';
@@ -29,7 +28,7 @@ void main() {
       os.makeExecutable(file);
 
       // Skip this test on windows.
-      if (!io.Platform.isWindows) {
+      if (!Platform.isWindows) {
         String mode = file.statSync().modeString();
         // rwxr--r--
         expect(mode.substring(0, 3), endsWith('x'));

--- a/packages/flutter_tools/test/process_manager_test.dart
+++ b/packages/flutter_tools/test/process_manager_test.dart
@@ -4,11 +4,11 @@
 
 import 'dart:async';
 import 'dart:convert';
-import 'dart:io' as io;
 
 import 'package:archive/archive.dart';
 import 'package:flutter_tools/src/base/context.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
+import 'package:flutter_tools/src/base/io.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/os.dart';
 import 'package:flutter_tools/src/base/process.dart';
@@ -42,7 +42,7 @@ void main() {
     });
 
     test('start', () async {
-      io.Process process = await manager.start('echo', <String>['foo']);
+      Process process = await manager.start('echo', <String>['foo']);
       int pid = process.pid;
       int exitCode = await process.exitCode;
       List<int> stdout = await _consume(process.stdout);
@@ -64,7 +64,7 @@ void main() {
     });
 
     test('run', () async {
-      io.ProcessResult result = await manager.run('echo', <String>['bar']);
+      ProcessResult result = await manager.run('echo', <String>['bar']);
       int pid = result.pid;
       int exitCode = result.exitCode;
       String stdout = result.stdout;
@@ -86,7 +86,7 @@ void main() {
     });
 
     test('runSync', () async {
-      io.ProcessResult result = manager.runSync('echo', <String>['baz']);
+      ProcessResult result = manager.runSync('echo', <String>['baz']);
       int pid = result.pid;
       int exitCode = result.exitCode;
       String stdout = result.stdout;
@@ -124,7 +124,7 @@ void main() {
     });
 
     test('start', () async {
-      io.Process process = await manager.start('sing', <String>['ppap']);
+      Process process = await manager.start('sing', <String>['ppap']);
       int exitCode = await process.exitCode;
       List<int> stdout = await _consume(process.stdout);
       List<int> stderr = await _consume(process.stderr);
@@ -135,7 +135,7 @@ void main() {
     });
 
     test('run', () async {
-      io.ProcessResult result = await manager.run('dance', <String>['gangnam-style']);
+      ProcessResult result = await manager.run('dance', <String>['gangnam-style']);
       expect(result.pid, 101);
       expect(result.exitCode, 2);
       expect(result.stdout, '');
@@ -143,7 +143,7 @@ void main() {
     });
 
     test('runSync', () {
-      io.ProcessResult result = manager.runSync('dance', <String>['gangnam-style']);
+      ProcessResult result = manager.runSync('dance', <String>['gangnam-style']);
       expect(result.pid, 101);
       expect(result.exitCode, 2);
       expect(result.stdout, '');
@@ -196,7 +196,7 @@ class _Recording {
     Encoding encoding;
     if (encodingName != null)
       encoding = encodingName == 'system'
-          ? const io.SystemEncoding()
+          ? SYSTEM_ENCODING
           : Encoding.getByName(encodingName);
     return _getFileContent('$basename.$type', encoding);
   }

--- a/packages/flutter_tools/test/src/context.dart
+++ b/packages/flutter_tools/test/src/context.dart
@@ -3,11 +3,11 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:io';
 
 import 'package:flutter_tools/src/base/config.dart';
 import 'package:flutter_tools/src/base/context.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
+import 'package:flutter_tools/src/base/io.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/os.dart';
 import 'package:flutter_tools/src/base/process_manager.dart';

--- a/packages/flutter_tools/test/test_test.dart
+++ b/packages/flutter_tools/test/test_test.dart
@@ -3,9 +3,9 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:io' as io;
 
 import 'package:flutter_tools/src/base/file_system.dart';
+import 'package:flutter_tools/src/base/io.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/dart/sdk.dart';
 import 'package:path/path.dart' as path;
@@ -36,7 +36,7 @@ Future<Null> _testFile(String testName, int wantedExitCode) async {
   final String fullTestExpectation = path.join(manualTestsDirectory, 'flutter_test', '${testName}_expectation.txt');
   final File expectationFile = fs.file(fullTestExpectation);
   expect(expectationFile.existsSync(), true);
-  final io.ProcessResult exec = await io.Process.run(
+  final ProcessResult exec = await Process.run(
     path.join(dartSdkPath, 'bin', 'dart'),
     <String>[
       path.absolute(path.join('bin', 'flutter_tools.dart')),

--- a/packages/flutter_tools/test/upgrade_test.dart
+++ b/packages/flutter_tools/test/upgrade_test.dart
@@ -3,9 +3,9 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:io';
 
 import 'package:args/command_runner.dart';
+import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/os.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/commands/create.dart';
@@ -40,7 +40,7 @@ void main() {
       Directory temp;
 
       setUp(() async {
-        temp = Directory.systemTemp.createTempSync('flutter_tools');
+        temp = fs.systemTempDirectory.createTempSync('flutter_tools');
       });
 
       tearDown(() {

--- a/packages/flutter_tools/tool/daemon_client.dart
+++ b/packages/flutter_tools/tool/daemon_client.dart
@@ -4,7 +4,8 @@
 
 import 'dart:async';
 import 'dart:convert';
-import 'dart:io';
+
+import 'package:flutter_tools/src/base/io.dart';
 
 Process daemon;
 


### PR DESCRIPTION
This ensures that accidental usages of dart:io's
file API don't creep in over time.