### PR TITLE
pass additional named params to daemon run

### DIFF
--- a/packages/flutter_tools/lib/src/commands/daemon.dart
+++ b/packages/flutter_tools/lib/src/commands/daemon.dart
@@ -360,7 +360,7 @@ class AppDomain extends Domain {
         applicationBinary: applicationBinary,
         projectRootPath: projectRootPath,
         packagesFilePath: packagesFilePath,
-        projectAssets: projectAssets
+        projectAssets: projectAssets,
       );
     } else {
       runner = new RunAndStayResident(

--- a/packages/flutter_tools/lib/src/commands/daemon.dart
+++ b/packages/flutter_tools/lib/src/commands/daemon.dart
@@ -321,9 +321,13 @@ class AppDomain extends Domain {
   }
 
   AppInstance startApp(
-      Device device, String projectDirectory, String target, String route,
-      BuildMode buildMode, bool startPaused, bool enableHotReload) {
-
+    Device device, String projectDirectory, String target, String route,
+    BuildMode buildMode, bool startPaused, bool enableHotReload, {
+    String applicationBinary,
+    String projectRootPath,
+    String packagesFilePath,
+    String projectAssets,
+  }) {
     DebuggingOptions options;
 
     switch (buildMode) {
@@ -352,14 +356,19 @@ class AppDomain extends Domain {
         device,
         target: target,
         debuggingOptions: options,
-        usesTerminalUI: false
+        usesTerminalUI: false,
+        applicationBinary: applicationBinary,
+        projectRootPath: projectRootPath,
+        packagesFilePath: packagesFilePath,
+        projectAssets: projectAssets
       );
     } else {
       runner = new RunAndStayResident(
         device,
         target: target,
         debuggingOptions: options,
-        usesTerminalUI: false
+        usesTerminalUI: false,
+        applicationBinary: applicationBinary,
       );
     }
 

--- a/packages/flutter_tools/lib/src/commands/run.dart
+++ b/packages/flutter_tools/lib/src/commands/run.dart
@@ -176,7 +176,11 @@ class RunCommand extends RunCommandBase {
       try {
         app = daemon.appDomain.startApp(
           device, fs.currentDirectory.path, targetFile, route,
-          getBuildMode(), argResults['start-paused'], hotMode);
+          getBuildMode(), argResults['start-paused'], hotMode,
+          applicationBinary: argResults['use-application-binary'],
+          projectRootPath: argResults['project-root'],
+          packagesFilePath: argResults['packages'],
+          projectAssets: argResults['project-assets']);
       } catch (error) {
         throwToolExit(error.toString());
       }


### PR DESCRIPTION
- pass additional named params to daemon run

This is necessary for `flutter run --machine`, which is now how IntelliJ launches flutter apps.

@tvolkert @johnmccutchan 