### PR TITLE
Remove a misfiring assert in the test framework plugin

### DIFF
--- a/packages/flutter_tools/lib/src/test/flutter_platform.dart
+++ b/packages/flutter_tools/lib/src/test/flutter_platform.dart
@@ -164,7 +164,6 @@ class FlutterPlatform extends PlatformPlugin {
           harnessToTest.cancel();
           testToHarness.cancel();
 
-          assert(!controllerSinkClosed);
           switch (testResult) {
             case _TestResult.crashed:
               int exitCode = await process.exitCode;


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/7351

When a test runs to completion, the test harness closes the stream side of the
StreamChannel, causing the sink side to be closed as well.  So by the time we
receive a test result of completed/harnessBailed, the controller sink has been
closed.