### PR TITLE
Change `Flexible`'s default `FlexFit`

### DIFF
--- a/packages/flutter/lib/src/material/date_picker.dart
+++ b/packages/flutter/lib/src/material/date_picker.dart
@@ -263,7 +263,6 @@ class DayPicker extends StatelessWidget {
             )
           ),
           new Flexible(
-            fit: FlexFit.loose,
             child: new CustomGrid(
               delegate: _kDayPickerGridDelegate,
               children: labels
@@ -594,7 +593,6 @@ class _DatePickerDialogState extends State<_DatePickerDialog> {
   @override
   Widget build(BuildContext context) {
     Widget picker = new Flexible(
-      fit: FlexFit.loose,
       child: new SizedBox(
         height: _kMaxDayPickerHeight,
         child: _buildPicker(),
@@ -644,7 +642,6 @@ class _DatePickerDialogState extends State<_DatePickerDialog> {
                   children: <Widget>[
                     header,
                     new Flexible(
-                      fit: FlexFit.loose,
                       child: new SizedBox(
                         width: _kMonthPickerLandscapeWidth,
                         child: new Column(

--- a/packages/flutter/lib/src/material/dialog.dart
+++ b/packages/flutter/lib/src/material/dialog.dart
@@ -144,7 +144,6 @@ class AlertDialog extends StatelessWidget {
 
     if (content != null) {
       children.add(new Flexible(
-        fit: FlexFit.loose,
         child: new Padding(
           padding: contentPadding ?? const EdgeInsets.fromLTRB(24.0, 20.0, 24.0, 24.0),
           child: new DefaultTextStyle(
@@ -244,7 +243,6 @@ class SimpleDialog extends StatelessWidget {
 
     if (children != null) {
       body.add(new Flexible(
-        fit: FlexFit.loose,
         child: new Block(
           padding: contentPadding ?? const EdgeInsets.fromLTRB(0.0, 12.0, 0.0, 16.0),
           children: children

--- a/packages/flutter/lib/src/material/tabs.dart
+++ b/packages/flutter/lib/src/material/tabs.dart
@@ -545,7 +545,7 @@ class _TabBarState extends State<TabBar> {
         child: wrappedTabs[index],
       );
       if (!config.isScrollable)
-        wrappedTabs[index] = new Flexible(child: wrappedTabs[index]);
+        wrappedTabs[index] = new Expanded(child: wrappedTabs[index]);
     }
 
     Widget tabBar = new CustomPaint(

--- a/packages/flutter/lib/src/material/time_picker.dart
+++ b/packages/flutter/lib/src/material/time_picker.dart
@@ -732,7 +732,6 @@ class _TimePickerDialogState extends State<_TimePickerDialog> {
                   children: <Widget>[
                     header,
                     new Flexible(
-                      fit: FlexFit.loose,
                       child: new Column(
                         children: <Widget>[
                           new Expanded(child: picker),

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -2229,17 +2229,27 @@ class Column extends Flex {
 
 /// A widget that controls how a child of a [Row], [Column], or [Flex] flexes.
 ///
+/// Using a [Flexible] widget gives a child of a [Row], [Column], or [Flex]
+/// the flexibility to expand to fill the available space in the main axis
+/// (e.g., horizontally for a [Row] or vertically for a [Column]), but, unlike
+/// [Expanded], [Flexible] does not require the child to fill the available
+/// space.
+///
 /// A [Flexible] widget must be a descendant of a [Row], [Column], or [Flex],
 /// and the path from the [Flexible] widget to its enclosing [Row], [Column], or
 /// [Flex] must contain only [StatelessWidget]s or [StatefulWidget]s (not other
 /// kinds of widgets, like [RenderObjectWidget]s).
+///
+/// See also:
+///
+///  * [Expanded], which forces the child to expand to fill the available space.
 class Flexible extends ParentDataWidget<Flex> {
   /// Creates a widget that controls how a child of a [Row], [Column], or [Flex]
   /// flexes.
   Flexible({
     Key key,
     this.flex: 1,
-    this.fit: FlexFit.tight,
+    this.fit: FlexFit.loose,
     @required Widget child,
   }) : super(key: key, child: child);
 
@@ -2292,15 +2302,19 @@ class Flexible extends ParentDataWidget<Flex> {
 
 /// A widget that expands a child of a [Row], [Column], or [Flex].
 ///
-/// Using an [Expanded] widget to make a child of a [Row], [Column], or [Flex]
+/// Using an [Expanded] widget makes a child of a [Row], [Column], or [Flex]
 /// expand to fill the available space in the main axis (e.g., horizontally for
 /// a [Row] or vertically for a [Column]). If multiple children are expanded,
 /// the available space is divided amoung them according to the [flex] factor.
 ///
 /// An [Expanded] widget must be a descendant of a [Row], [Column], or [Flex],
-/// and the path from the [Flexible] widget to its enclosing [Row], [Column], or
+/// and the path from the [Expanded] widget to its enclosing [Row], [Column], or
 /// [Flex] must contain only [StatelessWidget]s or [StatefulWidget]s (not other
 /// kinds of widgets, like [RenderObjectWidget]s).
+///
+/// See also:
+///
+///  * [Flexible], which does not force the child to fill the available space.
 class Expanded extends Flexible {
   /// Creates a widget that expands a child of a [Row], [Column], or [Flex]
   /// expand to fill the available space in the main axis.

--- a/packages/flutter/test/widgets/flex_test.dart
+++ b/packages/flutter/test/widgets/flex_test.dart
@@ -48,6 +48,19 @@ void main() {
     expect(didReceiveTap, isTrue);
   });
 
+  testWidgets('Flexible defaults to loose', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      new Row(
+        children: <Widget>[
+          new Flexible(child: new SizedBox(width: 100.0, height: 200.0)),
+        ],
+      ),
+    );
+
+    RenderBox box = tester.renderObject(find.byType(SizedBox));
+    expect(box.size.width, 100.0);
+  });
+
   testWidgets('Can pass null for flex', (WidgetTester tester) async {
     await tester.pumpWidget(
       new Row(


### PR DESCRIPTION
Previously, `Flexible` defaulted to `FlexFit.tight`, which forced the child to
expand to fill the available space. Now, `Flexible` defaults to
`FlexFit.loose`, which does not force the child to expand to fill the available
space.

If you want the child to expand to fill the available space, consider using
`Expanded` instead.

Fixes #5169