### PR TITLE
Do not print stack traces for DevFS write request failures

### DIFF
--- a/packages/flutter_tools/lib/src/devfs.dart
+++ b/packages/flutter_tools/lib/src/devfs.dart
@@ -255,8 +255,8 @@ class _DevFSHttpWriter {
       await request.addStream(contents);
       HttpClientResponse response = await request.close();
       await response.drain();
-    } catch (e, stackTrace) {
-      printError('Error writing "${entry.devicePath}" to DevFS: $e\n$stackTrace');
+    } catch (e) {
+      printError('Error writing "${entry.devicePath}" to DevFS: $e');
     }
     if (progressReporter != null) {
       _done++;


### PR DESCRIPTION
Each stack trace will yield many async task stacks for every write request
that is in flight.  If the device side is unresponsive and all writes are
failing, then this can generate an overwhelming amount of logs.