### PR TITLE
devicelab: fix basic_material_app_ios__size; add microbenchmarks

### DIFF
--- a/dev/devicelab/manifest.yaml
+++ b/dev/devicelab/manifest.yaml
@@ -166,4 +166,10 @@ tasks:
     description: >
       Measures the IPA size of a basic material app.
     stage: devicelab_ios
-    required_agent_capabilities: ["has-android-device"]
+    required_agent_capabilities: ["has-ios-device"]
+
+  microbenchmarks_ios:
+    description: >
+      Runs benchmarks from dev/benchmarks/microbenchmarks on iOS.
+    stage: devicelab_ios
+    required_agent_capabilities: ["has-ios-device"]


### PR DESCRIPTION
- Fix `required_agent_capabilities` in `basic_material_app_ios__size`
- Add `microbenchmarks_ios` so we run microbenchmarks on iOS as well