### PR TITLE
Handle missing flutter_test dependency cleanly

### DIFF
--- a/dev/missing_dependency_tests/.gitignore
+++ b/dev/missing_dependency_tests/.gitignore
@@ -1,0 +1,9 @@
+.atom
+.DS_Store
+.buildlog
+.idea
+.packages
+.pub/
+build/
+packages
+pubspec.lock

--- a/dev/missing_dependency_tests/pubspec.yaml
+++ b/dev/missing_dependency_tests/pubspec.yaml
@@ -1,0 +1,4 @@
+name: missing_dependency_tests
+dependencies:
+  flutter:
+    sdk: flutter

--- a/dev/missing_dependency_tests/trivial_expectation.txt
+++ b/dev/missing_dependency_tests/trivial_expectation.txt
@@ -1,0 +1,4 @@
+<<skip until matching line>>
+<<stderr>>
+<<skip until matching line>>
+Failed to load test harness\. +Are you missing a dependency on flutter_test\?

--- a/dev/missing_dependency_tests/trivial_test.dart
+++ b/dev/missing_dependency_tests/trivial_test.dart
@@ -1,0 +1,11 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:test/test.dart';
+
+void main() {
+  test('Trival test', () {
+    expect(42, 42);
+  });
+}


### PR DESCRIPTION
We now produce a more reasonable error message when we're missing the
flutter_test dependency in a test. Also, remove the flutter_tools stack traces
when the engine dies.

Fixes #6187