### PR TITLE
Update Process.exitCode setter to not use @override

### DIFF
--- a/packages/flutter_tools/lib/src/base/process_manager.dart
+++ b/packages/flutter_tools/lib/src/base/process_manager.dart
@@ -491,7 +491,9 @@ class _RecordingProcess implements Process {
   @override
   Future<int> get exitCode => delegate.exitCode;
 
-  // ignore: annotate_overridden_members
+  // TODO(tvolkert): Remove this once the dart sdk in both the target and
+  // the host have picked up dart-lang/sdk@e5a16b1
+  @override // ignore: OVERRIDE_ON_NON_OVERRIDING_SETTER
   set exitCode(Future<int> exitCode) => throw new UnsupportedError('set exitCode');
 
   @override
@@ -827,7 +829,9 @@ class _ReplayProcess implements Process {
   @override
   Future<int> get exitCode => _exitCodeCompleter.future;
 
-  // ignore: annotate_overridden_members
+  // TODO(tvolkert): Remove this once the dart sdk in both the target and
+  // the host have picked up dart-lang/sdk@e5a16b1
+  @override // ignore: OVERRIDE_ON_NON_OVERRIDING_SETTER
   set exitCode(Future<int> exitCode) => throw new UnsupportedError('set exitCode');
 
   @override

--- a/packages/flutter_tools/lib/src/base/process_manager.dart
+++ b/packages/flutter_tools/lib/src/base/process_manager.dart
@@ -491,6 +491,8 @@ class _RecordingProcess implements Process {
   @override
   Future<int> get exitCode => delegate.exitCode;
 
+  set exitCode(Future<int> exitCode) => throw new UnsupportedError('set exitCode');
+
   @override
   Stream<List<int>> get stdout {
     assert(_started);
@@ -823,6 +825,8 @@ class _ReplayProcess implements Process {
 
   @override
   Future<int> get exitCode => _exitCodeCompleter.future;
+
+  set exitCode(Future<int> exitCode) => throw new UnsupportedError('set exitCode');
 
   @override
   IOSink get stdin => throw new UnimplementedError();

--- a/packages/flutter_tools/lib/src/base/process_manager.dart
+++ b/packages/flutter_tools/lib/src/base/process_manager.dart
@@ -491,6 +491,7 @@ class _RecordingProcess implements Process {
   @override
   Future<int> get exitCode => delegate.exitCode;
 
+  // ignore: annotate_overridden_members
   set exitCode(Future<int> exitCode) => throw new UnsupportedError('set exitCode');
 
   @override
@@ -826,6 +827,7 @@ class _ReplayProcess implements Process {
   @override
   Future<int> get exitCode => _exitCodeCompleter.future;
 
+  // ignore: annotate_overridden_members
   set exitCode(Future<int> exitCode) => throw new UnsupportedError('set exitCode');
 
   @override

--- a/packages/flutter_tools/lib/src/base/process_manager.dart
+++ b/packages/flutter_tools/lib/src/base/process_manager.dart
@@ -492,9 +492,6 @@ class _RecordingProcess implements Process {
   Future<int> get exitCode => delegate.exitCode;
 
   @override
-  set exitCode(Future<int> exitCode) => delegate.exitCode = exitCode;
-
-  @override
   Stream<List<int>> get stdout {
     assert(_started);
     return _stdoutController.stream;
@@ -826,9 +823,6 @@ class _ReplayProcess implements Process {
 
   @override
   Future<int> get exitCode => _exitCodeCompleter.future;
-
-  @override
-  set exitCode(Future<int> exitCode) => throw new UnsupportedError('set exitCode');
 
   @override
   IOSink get stdin => throw new UnimplementedError();


### PR DESCRIPTION
As of Dart SDK 1.22.0-dev.5.0 (which has rolled into Flutter),
it no longer is mutable (we picked up the fix to
https://github.com/dart-lang/sdk/issues/27950)