### PR TITLE
ignore exceptions from stdin.lineMode

### DIFF
--- a/packages/flutter_tools/lib/src/base/logger.dart
+++ b/packages/flutter_tools/lib/src/base/logger.dart
@@ -221,7 +221,11 @@ class AnsiTerminal {
   String clearScreen() => supportsColor ? _clear : '\n\n';
 
   set singleCharMode(bool value) {
-    stdin.lineMode = !value;
+    try {
+      stdin.lineMode = !value;
+    } catch (error) {
+      // This can throw for some terminals; we ignore the error.
+    }
   }
 
   /// Return keystrokes from the console.

--- a/packages/flutter_tools/lib/src/base/logger.dart
+++ b/packages/flutter_tools/lib/src/base/logger.dart
@@ -223,7 +223,7 @@ class AnsiTerminal {
   set singleCharMode(bool value) {
     try {
       stdin.lineMode = !value;
-    } catch (error) {
+    } on IOException {
       // This can throw for some terminals; we ignore the error.
     }
   }


### PR DESCRIPTION
- ignore exceptions from stdin.lineMode

`'StdinException: Error setting terminal line mode, OS Error: Inappropriate ioctl for device, errno = 25'`

@pq, I think this was the issue with your SDK roll yesterday.
