### PR TITLE
markNeedsBuild should handle case where the element is in the dirty list

### DIFF
--- a/packages/flutter/lib/src/widgets/app.dart
+++ b/packages/flutter/lib/src/widgets/app.dart
@@ -43,7 +43,7 @@ class WidgetsApp extends StatefulWidget {
     @required this.onGenerateRoute,
     this.title,
     this.textStyle,
-    this.color,
+    @required this.color,
     this.navigatorObserver,
     this.initialRoute,
     this.onLocaleChanged,
@@ -52,6 +52,7 @@ class WidgetsApp extends StatefulWidget {
     this.showSemanticsDebugger: false,
     this.debugShowCheckedModeBanner: true
   }) : super(key: key) {
+    assert(color != null);
     assert(onGenerateRoute != null);
     assert(showPerformanceOverlay != null);
     assert(checkerboardRasterCacheImages != null);


### PR DESCRIPTION
Previously we asserted that the element was not in the dirty list, but there
are scenarios where the element can be in the dirty list already. This patch
makes markNeedsBuild handle those cases by simply resorting the dirty list.

Fixes #6119