### PR TITLE
	microbenchmarks: single-line JSON; consolidate #7433 workaround

### DIFF
--- a/dev/benchmarks/microbenchmarks/lib/common.dart
+++ b/dev/benchmarks/microbenchmarks/lib/common.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:convert' show JsonEncoder;
+import 'dart:convert' show JSON;
 
 import 'package:meta/meta.dart';
 
@@ -46,8 +46,8 @@ class BenchmarkResultPrinter {
   }
 
   String _printJson() {
-    const JsonEncoder encoder = const JsonEncoder.withIndent('  ');
-    return encoder.convert(new Map<String, double>.fromIterable(_results,
+    return JSON.encode(new Map<String, double>.fromIterable(
+      _results,
       key: (_BenchmarkResult result) => result.name,
       value: (_BenchmarkResult result) => result.value,
     ));

--- a/dev/benchmarks/microbenchmarks/lib/stocks/build_bench.dart
+++ b/dev/benchmarks/microbenchmarks/lib/stocks/build_bench.dart
@@ -21,7 +21,6 @@ Future<Null> main() async {
   await benchmarkWidgets((WidgetTester tester) async {
     stocks.main();
     await tester.pump(); // Start startup animation
-    new Timer(const Duration(milliseconds: 1100), () { });  // workaround for https://github.com/flutter/flutter/issues/7433
     await tester.pump(const Duration(seconds: 1)); // Complete startup animation
     await tester.tapAt(new Point(20.0, 20.0)); // Open drawer
     await tester.pump(); // Start drawer animation

--- a/dev/benchmarks/microbenchmarks/lib/stocks/layout_bench.dart
+++ b/dev/benchmarks/microbenchmarks/lib/stocks/layout_bench.dart
@@ -20,7 +20,6 @@ Future<Null> main() async {
   await benchmarkWidgets((WidgetTester tester) async {
     stocks.main();
     await tester.pump(); // Start startup animation
-    new Timer(const Duration(milliseconds: 1100), () { });  // workaround for https://github.com/flutter/flutter/issues/7433
     await tester.pump(const Duration(seconds: 1)); // Complete startup animation
     await tester.tapAt(new Point(20.0, 20.0)); // Open drawer
     await tester.pump(); // Start drawer animation

--- a/dev/devicelab/lib/tasks/microbenchmarks.dart
+++ b/dev/devicelab/lib/tasks/microbenchmarks.dart
@@ -41,10 +41,7 @@ TaskFunction createMicrobenchmarkTask() {
     allResults.addAll(await _runMicrobench('lib/stocks/layout_bench.dart'));
     allResults.addAll(await _runMicrobench('lib/stocks/build_bench.dart'));
     allResults.addAll(await _runMicrobench('lib/gestures/velocity_tracker_bench.dart'));
-    if (deviceOperatingSystem == DeviceOperatingSystem.android) {
-      // TODO(yjbanov): Run on iOS when https://github.com/flutter/flutter/issues/7433 is fixed.
-      allResults.addAll(await _runMicrobench('lib/stocks/animation_bench.dart'));
-    }
+    allResults.addAll(await _runMicrobench('lib/stocks/animation_bench.dart'));
 
     return new TaskResult.success(allResults, benchmarkScoreKeys: allResults.keys.toList());
   };

--- a/packages/flutter_test/lib/src/binding.dart
+++ b/packages/flutter_test/lib/src/binding.dart
@@ -632,6 +632,8 @@ class LiveTestWidgetsFlutterBinding extends TestWidgetsFlutterBinding {
       super.handleBeginFrame(rawTimeStamp);
     if (_expectingFrame) {
       assert(_pendingFrame != null);
+      // TODO(yjbanov): workaroud for https://github.com/flutter/flutter/issues/7433
+      Timer.run(() {});  // forces runtime to flush Completer.complete() microtask
       _pendingFrame.complete(); // unlocks the test API
       _pendingFrame = null;
       _expectingFrame = false;


### PR DESCRIPTION
- output single-line JSON because iOS 9.x cannot output more than one line
- move the workaround for #7433 into LiveTestWidgetsFlutterBinding so that it works in all cases (e.g. animation_bench.dart on iOS)

/cc @goderbauer @Hixie 