### PR TITLE
Fix race condition in coverage collection

### DIFF
--- a/packages/flutter_tools/lib/src/commands/test.dart
+++ b/packages/flutter_tools/lib/src/commands/test.dart
@@ -89,7 +89,9 @@ class TestCommand extends FlutterCommand {
 
   Future<bool> _collectCoverageData(CoverageCollector collector, { bool mergeCoverageData: false }) async {
     Status status = logger.startProgress('Collecting coverage information...');
-    String coverageData = await collector.finalizeCoverage();
+    String coverageData = await collector.finalizeCoverage(
+      timeout: new Duration(seconds: 30),
+    );
     status.stop();
     if (coverageData == null)
       return false;

--- a/packages/flutter_tools/lib/src/test/coverage_collector.dart
+++ b/packages/flutter_tools/lib/src/test/coverage_collector.dart
@@ -12,26 +12,9 @@ import '../base/io.dart';
 import '../dart/package_map.dart';
 import '../globals.dart';
 
-/// Class that represents a pending task of coverage data collection.
-/// Instances of this class are obtained when a process starts running code
-/// by calling [CoverageCollector.addTask]. Then, when the code has run to
-/// completion (all the coverage data has been recorded), the task is started
-/// to actually collect the coverage data.
-abstract class CoverageCollectionTask {
-  /// Starts the task of collecting coverage. Returns a future that completes
-  /// when coverage has been collected.
-  ///
-  /// This should be called when the code whose coverage data is being
-  /// collected has been run to completion so that all coverage data has been
-  /// recorded.
-  Future<Null> start();
-
-  /// Indicates whether the task has been started or not.
-  bool get isStarted;
-}
-
-/// Singleton class that's used to collect coverage data during tests.
+/// A class that's used to collect coverage data during tests.
 class CoverageCollector {
+  /// The singleton instance of the coverage collector.
   static final CoverageCollector instance = new CoverageCollector._();
 
   CoverageCollector._();
@@ -45,6 +28,9 @@ class CoverageCollector {
   /// begin collecting coverage data until [CoverageCollectionTask.start] is
   /// called.
   ///
+  /// This should be called after a process has been started so that this
+  /// collector knows to wait for the task in [finalizeCoverage].
+  ///
   /// If this collector is not [enabled], the task will still be added to the
   /// pending queue. Only when the task is started will the enabled state of
   /// the collector be consulted.
@@ -53,33 +39,24 @@ class CoverageCollector {
     int port,
     Process processToKill,
   }) {
-    final _Task task = new _Task(this, host, port, processToKill);
-    _tasks.add(task.future);
+    final CoverageCollectionTask task = new CoverageCollectionTask(
+      this,
+      host,
+      port,
+      processToKill,
+    );
+    _tasks.add(task._future);
     return task;
   }
 
   List<Future<Null>> _tasks = <Future<Null>>[];
   Map<String, dynamic> _globalHitmap;
 
-  Future<Null> _startTask(_Task task) async {
-    assert(!task.isStarted);
-    if (!enabled) {
-      task.processToKill.kill();
-      return;
-    }
-
-    int pid = task.processToKill.pid;
-    printTrace('collecting coverage data from pid $pid on port ${task.port}');
-    Map<String, dynamic> data = await collect(task.host, task.port, false, false);
-    printTrace('done collecting coverage data from pid $pid');
-    task.processToKill.kill();
-    Map<String, dynamic> hitmap = createHitmap(data['coverage']);
+  void _addHitmap(Map<String, dynamic> hitmap) {
     if (_globalHitmap == null)
       _globalHitmap = hitmap;
     else
       mergeHitmaps(hitmap, _globalHitmap);
-    printTrace('done merging data from pid $pid into global coverage map');
-    task._completer.complete();
   }
 
   /// Returns a future that completes once all tasks have finished.
@@ -88,20 +65,19 @@ class CoverageCollector {
   /// If [timeout] is specified, the future will timeout (with a
   /// [TimeoutException]) after the specified duration.
   Future<Null> finishPendingTasks({ Duration timeout }) {
-    Future<Null> future = Future.wait(_tasks, eagerError: true);
-    if (timeout != null) {
+    Future<dynamic> future = Future.wait(_tasks, eagerError: true);
+    if (timeout != null)
       future = future.timeout(timeout);
-    }
     return future;
   }
 
   /// Returns a future that will complete with the formatted coverage data
   /// (using [formatter]) once all coverage data has been collected.
   ///
-  /// Note: this will not start any collection tasks. It us up to the caller
-  /// of [addTask] to maintain a reference to the [CoverageCollectionTask]
-  /// and call `start` on the task once the code in question has run. Failure
-  /// to do so will keep this future from completing.
+  /// This will not start any collection tasks. It us up to the caller of
+  /// [addTask] to maintain a reference to the [CoverageCollectionTask] and
+  /// call `start` on the task once the code in question has run. Failure to do
+  /// so will cause this method to wait indefinitely for the task.
   ///
   /// If [timeout] is specified, the future will timeout (with a
   /// [TimeoutException]) after the specified duration.
@@ -126,28 +102,64 @@ class CoverageCollector {
   }
 }
 
-class _Task implements CoverageCollectionTask {
+/// A class that represents a pending task of coverage data collection.
+/// Instances of this class are obtained when a process starts running code
+/// by calling [CoverageCollector.addTask]. Then, when the code has run to
+/// completion (all the coverage data has been recorded), the task is started
+/// to actually collect the coverage data.
+class CoverageCollectionTask {
   final Completer<Null> _completer = new Completer<Null>();
-  final CoverageCollector collector;
-  final String host;
-  final int port;
-  final Process processToKill;
+  final CoverageCollector _collector;
+  final String _host;
+  final int _port;
+  final Process _processToKill;
+
+  CoverageCollectionTask(
+    this._collector,
+    this._host,
+    this._port,
+    this._processToKill,
+  );
 
   bool _started = false;
 
-  _Task(this.collector, this.host, this.port, this.processToKill);
+  Future<Null> get _future => _completer.future;
 
-  @override
-  Future<Null> start() {
-    if (!_started) {
-      _started = true;
-      collector._startTask(this);
+  /// Starts the task of collecting coverage.
+  ///
+  /// This should be called when the code whose coverage data is being collected
+  /// has been run to completion so that all coverage data has been recorded.
+  /// Failure to do so will cause [CoverageCollector.finalizeCoverage] to wait
+  /// indefinitely for the task to complete.
+  ///
+  /// Each task may only be started once.
+  void start() {
+    assert(!_started);
+    _started = true;
+
+    if (!_collector.enabled) {
+      _processToKill.kill();
+      _completer.complete();
+      return;
     }
-    return future;
+
+    int pid = _processToKill.pid;
+    printTrace('collecting coverage data from pid $pid on port $_port');
+    collect(_host, _port, false, false).then(
+      (Map<dynamic, dynamic> data) {
+        printTrace('done collecting coverage data from pid $pid');
+        _processToKill.kill();
+        try {
+          _collector._addHitmap(createHitmap(data['coverage']));
+          printTrace('done merging data from pid $pid into global coverage map');
+          _completer.complete();
+        } catch (error, stackTrace) {
+          _completer.completeError(error, stackTrace);
+        }
+      },
+      onError: (dynamic error, StackTrace stackTrace) {
+        _completer.completeError(error, stackTrace);
+      },
+    );
   }
-
-  @override
-  bool get isStarted => _started;
-
-  Future<Null> get future => _completer.future;
 }

--- a/packages/flutter_tools/lib/src/test/coverage_collector.dart
+++ b/packages/flutter_tools/lib/src/test/coverage_collector.dart
@@ -12,39 +12,70 @@ import '../base/io.dart';
 import '../dart/package_map.dart';
 import '../globals.dart';
 
-class CoverageCollector {
-  static final CoverageCollector instance = new CoverageCollector();
+/// Class that represents a pending task of coverage data collection.
+/// Instances of this class are obtained when a process starts running code
+/// by calling [CoverageCollector.addTask]. Then, when the code has run to
+/// completion (all the coverage data has been recorded), the task is started
+/// to actually collect the coverage data.
+abstract class CoverageCollectionTask {
+  /// Starts the task of collecting coverage. Returns a future that completes
+  /// when coverage has been collected.
+  ///
+  /// This should be called when the code whose coverage data is being
+  /// collected has been run to completion so that all coverage data has been
+  /// recorded.
+  ///
+  /// A task may only be started once.
+  Future<Null> start();
 
+  /// Indicates whether the task has been started or not.
+  bool get isStarted;
+}
+
+/// Singleton class that's used to collect coverage data during tests.
+class CoverageCollector {
+  static final CoverageCollector instance = new CoverageCollector._();
+
+  CoverageCollector._();
+
+  /// By default, coverage collection is not enabled. Set [enabled] to true
+  /// to turn on coverage collection.
   bool enabled = false;
   int observatoryPort;
 
-  void collectCoverage({
+  /// Adds a coverage collection tasks to the pending queue. The task will not
+  /// begin collecting coverage data until [CoverageCollectionTask.start] is
+  /// called or [finalizeCoverage] is called (which implicitly starts all
+  /// pending tasks).
+  ///
+  /// If this collector is not [enabled], the task will still be added to the
+  /// pending queue. Only when the task is started will the enabled state of
+  /// the collector be consulted.
+  CoverageCollectionTask addTask({
     String host,
     int port,
     Process processToKill,
   }) {
-    if (enabled) {
-      assert(_jobs != null);
-      _jobs.add(_startJob(
-        host: host,
-        port: port,
-        processToKill: processToKill,
-      ));
-    } else {
-      processToKill.kill();
-    }
+    _Task task = new _Task(this, host, port, processToKill);
+    _pendingTasks.add(task);
+    return task;
   }
 
-  Future<Null> _startJob({
-    String host,
-    int port,
-    Process processToKill,
-  }) async {
-    int pid = processToKill.pid;
-    printTrace('collecting coverage data from pid $pid on port $port');
-    Map<String, dynamic> data = await collect(host, port, false, false);
+  Set<_Task> _pendingTasks = new Set<_Task>();
+  List<Future<Null>> _activeTasks = <Future<Null>>[];
+  Map<String, dynamic> _globalHitmap;
+
+  Future<Null> _startTask(_Task task) async {
+    if (!enabled) {
+      task.processToKill.kill();
+      return;
+    }
+
+    int pid = task.processToKill.pid;
+    printTrace('collecting coverage data from pid $pid on port ${task.port}');
+    Map<String, dynamic> data = await collect(task.host, task.port, false, false);
     printTrace('done collecting coverage data from pid $pid');
-    processToKill.kill();
+    task.processToKill.kill();
     Map<String, dynamic> hitmap = createHitmap(data['coverage']);
     if (_globalHitmap == null)
       _globalHitmap = hitmap;
@@ -53,16 +84,24 @@ class CoverageCollector {
     printTrace('done merging data from pid $pid into global coverage map');
   }
 
-  Future<Null> finishPendingJobs() async {
-    await Future.wait(_jobs.toList(), eagerError: true);
+  /// Returns a future that completes once all started tasks are finished.
+  /// This will not start any tasks that were not already started.
+  Future<Null> finishActiveTasks() async {
+    await Future.wait(_activeTasks, eagerError: true);
   }
 
-  List<Future<Null>> _jobs = <Future<Null>>[];
-  Map<String, dynamic> _globalHitmap;
-
+  /// Completes all pending collection of coverage data. This will start any
+  /// tasks that have not yet been started. Returns a future that will complete
+  /// with the formatted coverage data (using [formatter]) once all coverage
+  /// data has been collected.
+  ///
+  /// This must only be called if this collector is [enabled].
   Future<String> finalizeCoverage({ Formatter formatter }) async {
     assert(enabled);
-    await finishPendingJobs();
+    while (_pendingTasks.isNotEmpty) {
+      _pendingTasks.first.start();
+    }
+    await finishActiveTasks();
     printTrace('formating coverage data');
     if (_globalHitmap == null)
       return null;
@@ -74,4 +113,25 @@ class CoverageCollector {
     }
     return await formatter.format(_globalHitmap);
   }
+}
+
+class _Task implements CoverageCollectionTask {
+  final CoverageCollector collector;
+  final String host;
+  final int port;
+  final Process processToKill;
+
+  _Task(this.collector, this.host, this.port, this.processToKill);
+
+  @override
+  Future<Null> start() {
+    if (!collector._pendingTasks.remove(this))
+      throw new AssertionError();
+    Future<Null> future = collector._startTask(this);
+    collector._activeTasks.add(future);
+    return future;
+  }
+
+  @override
+  bool get isStarted => !collector._pendingTasks.contains(this);
 }

--- a/packages/flutter_tools/lib/src/test/coverage_collector.dart
+++ b/packages/flutter_tools/lib/src/test/coverage_collector.dart
@@ -14,10 +14,10 @@ import '../globals.dart';
 
 /// A class that's used to collect coverage data during tests.
 class CoverageCollector {
+  CoverageCollector._();
+
   /// The singleton instance of the coverage collector.
   static final CoverageCollector instance = new CoverageCollector._();
-
-  CoverageCollector._();
 
   /// By default, coverage collection is not enabled. Set [enabled] to true
   /// to turn on coverage collection.
@@ -28,8 +28,9 @@ class CoverageCollector {
   /// begin collecting coverage data until [CoverageCollectionTask.start] is
   /// called.
   ///
-  /// This should be called after a process has been started so that this
-  /// collector knows to wait for the task in [finalizeCoverage].
+  /// When a process is spawned to accumulate code coverage data, this method
+  /// should be called before the process terminates so that this collector
+  /// knows to wait for the coverage data in [finalizeCoverage].
   ///
   /// If this collector is not [enabled], the task will still be added to the
   /// pending queue. Only when the task is started will the enabled state of
@@ -39,7 +40,7 @@ class CoverageCollector {
     int port,
     Process processToKill,
   }) {
-    final CoverageCollectionTask task = new CoverageCollectionTask(
+    final CoverageCollectionTask task = new CoverageCollectionTask._(
       this,
       host,
       port,
@@ -114,7 +115,7 @@ class CoverageCollectionTask {
   final int _port;
   final Process _processToKill;
 
-  CoverageCollectionTask(
+  CoverageCollectionTask._(
     this._collector,
     this._host,
     this._port,

--- a/packages/flutter_tools/lib/src/test/flutter_platform.dart
+++ b/packages/flutter_tools/lib/src/test/flutter_platform.dart
@@ -87,7 +87,7 @@ class FlutterPlatform extends PlatformPlugin {
         // TODO(ianh): the random number on the next line is a landmine that will eventually
         // cause a hard-to-find bug...
         observatoryPort = CoverageCollector.instance.observatoryPort ?? new math.Random().nextInt(30000) + 2000;
-        await CoverageCollector.instance.finishPendingJobs();
+        await CoverageCollector.instance.finishActiveTasks();
       }
 
       // Start the engine subprocess.
@@ -108,6 +108,12 @@ class FlutterPlatform extends PlatformPlugin {
           controller.sink.addError(message);
         }
       });
+
+      CoverageCollectionTask coverageTask = CoverageCollector.instance.addTask(
+        host: _kHost.address,
+        port: observatoryPort,
+        processToKill: process, // This kills the subprocess whether coverage is enabled or not.
+      );
 
       // Pipe stdout and stderr from the subprocess to our printStatus console.
       _pipeStandardStreamsToConsole(process);
@@ -181,11 +187,8 @@ class FlutterPlatform extends PlatformPlugin {
           break;
       }
 
-      CoverageCollector.instance.collectCoverage(
-        host: _kHost.address,
-        port: observatoryPort,
-        processToKill: process, // This kills the subprocess whether coverage is enabled or not.
-      );
+      if (!coverageTask.isStarted)
+        coverageTask.start();
       subprocessActive = false;
     } catch (e, stack) {
       if (!controllerSinkClosed) {

--- a/packages/flutter_tools/lib/src/test/flutter_platform.dart
+++ b/packages/flutter_tools/lib/src/test/flutter_platform.dart
@@ -87,7 +87,7 @@ class FlutterPlatform extends PlatformPlugin {
         // TODO(ianh): the random number on the next line is a landmine that will eventually
         // cause a hard-to-find bug...
         observatoryPort = CoverageCollector.instance.observatoryPort ?? new math.Random().nextInt(30000) + 2000;
-        await CoverageCollector.instance.finishActiveTasks();
+        await CoverageCollector.instance.finishPendingTasks();
       }
 
       // Start the engine subprocess.
@@ -187,8 +187,7 @@ class FlutterPlatform extends PlatformPlugin {
           break;
       }
 
-      if (!coverageTask.isStarted)
-        coverageTask.start();
+      coverageTask.start();
       subprocessActive = false;
     } catch (e, stack) {
       if (!controllerSinkClosed) {


### PR DESCRIPTION
Previously, it was possible for the test harness to bail
and the test runner to complete before the platform plugin
triggered the collection of coverage data. This fixes the
race condition such that the pending coverage collection
task is recorded immediately after starting the process.