### PR TITLE
Don't analyze dev/missing_dependency_test

### DIFF
--- a/.analysis_options
+++ b/.analysis_options
@@ -26,6 +26,7 @@ analyzer:
     todo: ignore
   exclude:
     - 'bin/cache/**'
+    - 'dev/missing_dependency_tests/**'
     - 'packages/flutter_tools/test/data/dart_dependencies_test/**'
 
 linter:

--- a/.analysis_options_repo
+++ b/.analysis_options_repo
@@ -27,6 +27,7 @@ analyzer:
     todo: ignore
   exclude:
     - 'bin/cache/**'
+    - 'dev/missing_dependency_tests/**'
     - 'packages/flutter_tools/test/data/dart_dependencies_test/**'
 
 linter:


### PR DESCRIPTION
That test intentionally has analysis errors to check how the tools react
to that situation.