### PR TITLE
Add GestureArenaTeam

### DIFF
--- a/packages/flutter/lib/gestures.dart
+++ b/packages/flutter/lib/gestures.dart
@@ -22,4 +22,5 @@ export 'src/gestures/pointer_router.dart';
 export 'src/gestures/recognizer.dart';
 export 'src/gestures/scale.dart';
 export 'src/gestures/tap.dart';
+export 'src/gestures/team.dart';
 export 'src/gestures/velocity_tracker.dart';

--- a/packages/flutter/lib/src/gestures/team.dart
+++ b/packages/flutter/lib/src/gestures/team.dart
@@ -1,0 +1,105 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'arena.dart';
+import 'binding.dart';
+
+class _CombiningGestureArenaEntry implements GestureArenaEntry {
+  _CombiningGestureArenaEntry(this._combiner, this._member);
+
+  final _CombiningGestureArenaMember _combiner;
+  final GestureArenaMember _member;
+
+  @override
+  void resolve(GestureDisposition disposition) {
+    _combiner._resolve(_member, disposition);
+  }
+}
+
+class _CombiningGestureArenaMember extends GestureArenaMember {
+  _CombiningGestureArenaMember(this._owner, this._pointer);
+
+  final GestureArenaTeam _owner;
+  final List<GestureArenaMember> _members = <GestureArenaMember>[];
+  final int _pointer;
+
+  bool _resolved = false;
+  GestureArenaMember _winner;
+  GestureArenaEntry _entry;
+
+  @override
+  void acceptGesture(int pointer) {
+    assert(_pointer == pointer);
+    assert(_winner != null || _members.isNotEmpty);
+    _close();
+    _winner ??= _members.removeAt(0);
+    for (GestureArenaMember member in _members)
+      member.rejectGesture(pointer);
+    _winner.acceptGesture(pointer);
+  }
+
+  @override
+  void rejectGesture(int pointer) {
+    assert(_pointer == pointer);
+    _close();
+    for (GestureArenaMember member in _members)
+      member.rejectGesture(pointer);
+  }
+
+  void _close() {
+    assert(!_resolved);
+    _resolved = true;
+    _CombiningGestureArenaMember combiner = _owner._combiners.remove(_pointer);
+    assert(combiner == this);
+  }
+
+  GestureArenaEntry _add(int pointer, GestureArenaMember member) {
+    assert(!_resolved);
+    assert(_pointer == pointer);
+    _members.add(member);
+    _entry ??= GestureBinding.instance.gestureArena.add(pointer, this);
+    return new _CombiningGestureArenaEntry(this, member);
+  }
+
+  void _resolve(GestureArenaMember member, GestureDisposition disposition) {
+    if (_resolved)
+      return;
+    if (disposition == GestureDisposition.rejected) {
+      _members.remove(member);
+      member.rejectGesture(_pointer);
+      if (_members.isEmpty)
+        _entry.resolve(disposition);
+    } else {
+      assert(disposition == GestureDisposition.accepted);
+      _winner ?? member;
+      _entry.resolve(disposition);
+    }
+  }
+}
+
+/// A group of [GestureArenaMember] objects that are competing as a unit in the [GestureArenaManager].
+///
+/// Normally, a recognizer competes directly in the [GestureArenaManager] to
+/// recognize a sequence of pointer events as a gesture. With a
+/// [GestureArenaTeam], recognizers can compete in the arena in a group with
+/// other recognizers.
+///
+/// To assign a gesture recognizer to a team, see
+/// [OneSequenceGestureRecognizer.team].
+class GestureArenaTeam {
+  final Map<int, _CombiningGestureArenaMember> _combiners = new Map<int, _CombiningGestureArenaMember>();
+
+  /// Adds a new member to the arena on behalf of this team.
+  ///
+  /// Used by [GestureRecognizer] subclasses that wish to compete in the arena
+  /// using this team.
+  ///
+  /// To assign a gesture recognizer to a team, see
+  /// [OneSequenceGestureRecognizer.team].
+  GestureArenaEntry add(int pointer, GestureArenaMember member) {
+    _CombiningGestureArenaMember combiner = _combiners.putIfAbsent(
+        pointer, () => new _CombiningGestureArenaMember(this, pointer));
+    return combiner._add(pointer, member);
+  }
+}

--- a/packages/flutter/test/material/slider_test.dart
+++ b/packages/flutter/test/material/slider_test.dart
@@ -118,4 +118,52 @@ void main() {
     await tester.pumpWidget(buildApp(true));
     expect(getThumbPaint().style, equals(PaintingStyle.stroke));
   });
+
+  testWidgets('Slider can tap in vertical scroller',
+      (WidgetTester tester) async {
+    double value = 0.0;
+    await tester.pumpWidget(new Material(
+      child: new Block(
+        children: <Widget>[
+          new Slider(
+            value: value,
+            onChanged: (double newValue) {
+              value = newValue;
+            },
+          ),
+          new Container(
+            height: 2000.0,
+          ),
+        ],
+      ),
+    ));
+
+    await tester.tap(find.byType(Slider));
+    expect(value, equals(0.5));
+  });
+
+  testWidgets('Slider drags immediately', (WidgetTester tester) async {
+    double value = 0.0;
+    await tester.pumpWidget(new Material(
+      child: new Center(
+        child: new Slider(
+          value: value,
+          onChanged: (double newValue) {
+            value = newValue;
+          },
+        ),
+      ),
+    ));
+
+    Point center = tester.getCenter(find.byType(Slider));
+    TestGesture gesture = await tester.startGesture(center);
+
+    expect(value, equals(0.5));
+
+    await gesture.moveBy(new Offset(1.0, 0.0));
+
+    expect(value, greaterThan(0.5));
+
+    await gesture.up();
+  });
 }


### PR DESCRIPTION
Previously, the Slider used a drag gesture recognizer to move the head
of the slider, but when the slider was in a vertical scroller, the
recognizer would wait until the user moved the pointer by enough pixels
to disambiguate between sliding the slider and scrolling the scroller.

That worked fine for actual drags, but the slider should also move when
the user taps the track. This patch introduces a tap recognizer to
handle that behavior.

To avoid the slider's drag and tap recognizers from competing with each
other in the arena, this patch introduces the notion of a
GestureArenaTeam, which lets several recognizers combine to form one
entry in the arena.  If that entry wins, the team picks the first of its
recognizers as the winner, avoiding latency.

Fixes #7454