### PR TITLE
Clarifying Divider usage

### DIFF
--- a/packages/flutter/lib/src/material/divider.dart
+++ b/packages/flutter/lib/src/material/divider.dart
@@ -11,9 +11,9 @@ import 'theme.dart';
 ///
 /// In the material design language, this represents a divider.
 ///
-/// Dividers can be used in lists and [Drawer]s to separate content vertically.
-/// To create a one-pixel divider between items in a list, consider using
-/// [ListItem.divideItems], which is optimized for this case.
+/// Dividers can be used in lists, [Drawer]s, and elsewhere to separate content
+/// vertically. To create a one-pixel divider between items in a list, consider
+/// using [ListItem.divideItems], which is optimized for this case.
 ///
 /// The box's total height is controlled by [height]. The appropriate padding is
 /// automatically computed from the height.


### PR DESCRIPTION
Clarifying that Dividers aren't restricted to usage in lists and Drawers. Maybe no one else is confused about this but I didn't realize it until I found them used in the calculator demo (https://github.com/flutter/flutter/blob/8ca4caa4406046a683c0e2d2a5cf6118fa56fef7/examples/flutter_gallery/lib/demo/calculator/home.dart)