### PR TITLE
Ticker.stop should work when muted

### DIFF
--- a/packages/flutter/lib/src/scheduler/ticker.dart
+++ b/packages/flutter/lib/src/scheduler/ticker.dart
@@ -128,7 +128,7 @@ class Ticker {
   /// (as opposed to the [TickerProvider] which created the ticker).
   Future<Null> start() {
     assert(() {
-      if (isTicking) {
+      if (isActive) {
         throw new FlutterError(
           'A ticker was started twice.\n'
           'A ticker that is already active cannot be started again without first stopping it.\n'
@@ -158,7 +158,7 @@ class Ticker {
   /// By convention, this method is used by the object that receives the ticks
   /// (as opposed to the [TickerProvider] which created the ticker).
   void stop() {
-    if (!isTicking)
+    if (!isActive)
       return;
 
     // We take the _completer into a local variable so that isTicking is false
@@ -167,7 +167,7 @@ class Ticker {
     Completer<Null> localCompleter = _completer;
     _completer = null;
     _startTime = null;
-    assert(!isTicking);
+    assert(!isActive);
 
     unscheduleTick();
     localCompleter.complete();
@@ -246,7 +246,7 @@ class Ticker {
   ///
   /// This ticker must not be active when this method is called.
   void absorbTicker(Ticker originalTicker) {
-    assert(!isTicking);
+    assert(!isActive);
     assert(_completer == null);
     assert(_startTime == null);
     assert(_animationId == null);

--- a/packages/flutter/test/scheduler/ticker_test.dart
+++ b/packages/flutter/test/scheduler/ticker_test.dart
@@ -1,0 +1,69 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/scheduler.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('Ticker mute control test', (WidgetTester tester) async {
+    int tickCount = 0;
+    void handleTick(Duration duration) {
+      ++tickCount;
+    }
+
+    Ticker ticker = new Ticker(handleTick);
+
+    expect(ticker.isTicking, isFalse);
+    expect(ticker.isActive, isFalse);
+
+    ticker.start();
+
+    expect(ticker.isTicking, isTrue);
+    expect(ticker.isActive, isTrue);
+    expect(tickCount, equals(0));
+
+    await tester.pump(const Duration(milliseconds: 10));
+
+    expect(tickCount, equals(1));
+
+    ticker.muted = true;
+    await tester.pump(const Duration(milliseconds: 10));
+
+    expect(tickCount, equals(1));
+    expect(ticker.isTicking, isFalse);
+    expect(ticker.isActive, isTrue);
+
+    ticker.muted = false;
+    await tester.pump(const Duration(milliseconds: 10));
+
+    expect(tickCount, equals(2));
+    expect(ticker.isTicking, isTrue);
+    expect(ticker.isActive, isTrue);
+
+    ticker.muted = true;
+    await tester.pump(const Duration(milliseconds: 10));
+
+    expect(tickCount, equals(2));
+    expect(ticker.isTicking, isFalse);
+    expect(ticker.isActive, isTrue);
+
+    ticker.stop();
+
+    expect(tickCount, equals(2));
+    expect(ticker.isTicking, isFalse);
+    expect(ticker.isActive, isFalse);
+
+    ticker.muted = false;
+
+    expect(tickCount, equals(2));
+    expect(ticker.isTicking, isFalse);
+    expect(ticker.isActive, isFalse);
+
+    await tester.pump(const Duration(milliseconds: 10));
+
+    expect(tickCount, equals(2));
+    expect(ticker.isTicking, isFalse);
+    expect(ticker.isActive, isFalse);
+  });
+}


### PR DESCRIPTION
Previously, the ticker would not stop when it was muted because it thought it
was already not ticking.