### PR TITLE
Support for vetoing an attempt to pop the current route

### DIFF
--- a/examples/flutter_gallery/lib/demo/text_field_demo.dart
+++ b/examples/flutter_gallery/lib/demo/text_field_demo.dart
@@ -80,7 +80,7 @@ class TextFieldDemoState extends State<TextFieldDemo> {
     if (!_formWasEdited || form.validate())
       return new Future<bool>.value(true);
 
-    return showDialog(
+    return showDialog/*<bool>*/(
       context: context,
       child: new AlertDialog(
         title: new Text('This form has errors'),

--- a/examples/flutter_gallery/test/smoke_test.dart
+++ b/examples/flutter_gallery/test/smoke_test.dart
@@ -43,9 +43,7 @@ Future<Null> smokeDemo(WidgetTester tester, String routeName) async {
   Finder backButton = find.byTooltip('Back');
   expect(backButton, findsOneWidget);
   await tester.tap(backButton);
-  await tester.pump(); // Start the pop "back" operation.
-  await tester.pump();
-  await tester.pump(const Duration(seconds: 1)); // Wait until it has finished.
+  await tester.pumpUntilNoTransientCallbacks(const Duration(seconds: 1));
   return null;
 }
 

--- a/examples/flutter_gallery/test/smoke_test.dart
+++ b/examples/flutter_gallery/test/smoke_test.dart
@@ -44,6 +44,7 @@ Future<Null> smokeDemo(WidgetTester tester, String routeName) async {
   expect(backButton, findsOneWidget);
   await tester.tap(backButton);
   await tester.pump(); // Start the pop "back" operation.
+  await tester.pump();
   await tester.pump(const Duration(seconds: 1)); // Wait until it has finished.
   return null;
 }

--- a/examples/flutter_gallery/test/smoke_test.dart
+++ b/examples/flutter_gallery/test/smoke_test.dart
@@ -43,7 +43,9 @@ Future<Null> smokeDemo(WidgetTester tester, String routeName) async {
   Finder backButton = find.byTooltip('Back');
   expect(backButton, findsOneWidget);
   await tester.tap(backButton);
-  await tester.pumpUntilNoTransientCallbacks(const Duration(seconds: 1));
+  await tester.pump(); // Start the pop "back" operation.
+  await tester.pump(); // Complete the willPop() Future.
+  await tester.pump(const Duration(seconds: 1)); // Wait until it has finished.
   return null;
 }
 

--- a/examples/flutter_gallery/test/update_test.dart
+++ b/examples/flutter_gallery/test/update_test.dart
@@ -32,9 +32,7 @@ void main() {
     Finder backButton = find.byTooltip('Back');
     expect(backButton, findsOneWidget);
     await tester.tap(backButton);
-    await tester.pump(); // Start the pop "back" operation.
-    await tester.pump();
-    await tester.pump(const Duration(seconds: 1)); // transition is complete
+    await tester.pumpUntilNoTransientCallbacks(const Duration(seconds: 1));
 
     expect(find.text('UPDATE'), findsNothing);
   });

--- a/examples/flutter_gallery/test/update_test.dart
+++ b/examples/flutter_gallery/test/update_test.dart
@@ -33,6 +33,7 @@ void main() {
     expect(backButton, findsOneWidget);
     await tester.tap(backButton);
     await tester.pump(); // Start the pop "back" operation.
+    await tester.pump();
     await tester.pump(const Duration(seconds: 1)); // transition is complete
 
     expect(find.text('UPDATE'), findsNothing);

--- a/examples/flutter_gallery/test/update_test.dart
+++ b/examples/flutter_gallery/test/update_test.dart
@@ -32,7 +32,10 @@ void main() {
     Finder backButton = find.byTooltip('Back');
     expect(backButton, findsOneWidget);
     await tester.tap(backButton);
-    await tester.pumpUntilNoTransientCallbacks(const Duration(seconds: 1));
+    await tester.pump(); // Start the pop "back" operation.
+    await tester.pump(); // Complete the willPop() Future.
+    await tester.pump(const Duration(seconds: 1)); // transition is complete
+    //await tester.pumpUntilNoTransientCallbacks(const Duration(seconds: 1));
 
     expect(find.text('UPDATE'), findsNothing);
   });

--- a/packages/flutter/lib/src/material/page.dart
+++ b/packages/flutter/lib/src/material/page.dart
@@ -200,6 +200,15 @@ class MaterialPageRoute<T> extends PageRoute<T> {
 
   _CupertinoBackGestureController _backGestureController;
 
+  /// Support for dismissing this route with a horizontal swipe is enabled
+  /// for [TargetPlatform.iOS]. If attempts to dismiss this route might be
+  /// vetoed because a [WillPopCallback] was defined for the route then the
+  /// platform-specific back gesture is disabled.
+  ///
+  /// See also:
+  ///
+  ///  * [hasScopedWillPopCallback], which is true if a `willPop` callback
+  ///    is defined for this route.
   @override
   NavigationGestureController startPopGesture(NavigatorState navigator) {
     // If attempts to dismiss this route might be vetoed, then do not

--- a/packages/flutter/lib/src/material/page.dart
+++ b/packages/flutter/lib/src/material/page.dart
@@ -202,6 +202,10 @@ class MaterialPageRoute<T> extends PageRoute<T> {
 
   @override
   NavigationGestureController startPopGesture(NavigatorState navigator) {
+    // If attempts to dismiss this route might be vetoed, then do not
+    // allow the user to dismiss the route with a swipe.
+    if (scopedWillPopCallback != null)
+      return null;
     if (controller.status != AnimationStatus.completed)
       return null;
     assert(_backGestureController == null);

--- a/packages/flutter/lib/src/material/page.dart
+++ b/packages/flutter/lib/src/material/page.dart
@@ -204,7 +204,7 @@ class MaterialPageRoute<T> extends PageRoute<T> {
   NavigationGestureController startPopGesture(NavigatorState navigator) {
     // If attempts to dismiss this route might be vetoed, then do not
     // allow the user to dismiss the route with a swipe.
-    if (scopedWillPopCallback != null)
+    if (hasScopedWillPopCallback)
       return null;
     if (controller.status != AnimationStatus.completed)
       return null;

--- a/packages/flutter/lib/src/material/scaffold.dart
+++ b/packages/flutter/lib/src/material/scaffold.dart
@@ -770,6 +770,11 @@ class ScaffoldState extends State<Scaffold> with TickerProviderStateMixin {
 
   bool _shouldShowBackArrow;
 
+  Future<Null> _back() async {
+    if (await Navigator.willPop(context) && mounted)
+      Navigator.pop(context);
+  }
+
   Widget _getModifiedAppBar({ EdgeInsets padding, int elevation}) {
     AppBar appBar = config.appBar;
     if (appBar == null)
@@ -800,7 +805,7 @@ class ScaffoldState extends State<Scaffold> with TickerProviderStateMixin {
           leading = new IconButton(
             icon: new Icon(backIcon),
             alignment: FractionalOffset.centerLeft,
-            onPressed: () => Navigator.pop(context),
+            onPressed: _back,
             tooltip: 'Back' // TODO(ianh): Figure out how to localize this string
           );
         }

--- a/packages/flutter/lib/src/widgets/app.dart
+++ b/packages/flutter/lib/src/widgets/app.dart
@@ -148,8 +148,8 @@ class _WidgetsAppState extends State<WidgetsApp> implements WidgetsBindingObserv
     NavigatorState navigator = _navigator.currentState;
     assert(navigator != null);
     if (!await navigator.willPop())
-      return new Future<bool>.value(true);
-    return new Future<bool>.value(mounted && navigator.pop());
+      return true;
+    return mounted && navigator.pop();
   }
 
   @override

--- a/packages/flutter/lib/src/widgets/app.dart
+++ b/packages/flutter/lib/src/widgets/app.dart
@@ -141,12 +141,15 @@ class _WidgetsAppState extends State<WidgetsApp> implements WidgetsBindingObserv
     super.dispose();
   }
 
+  // On Android: the user has pressed the back button.
   @override
-  bool didPopRoute() {
+  Future<bool> didPopRoute() async {
     assert(mounted);
     NavigatorState navigator = _navigator.currentState;
     assert(navigator != null);
-    return navigator.pop();
+    if (!await navigator.willPop())
+      return new Future<bool>.value(true);
+    return new Future<bool>.value(mounted && navigator.pop());
   }
 
   @override

--- a/packages/flutter/lib/src/widgets/binding.dart
+++ b/packages/flutter/lib/src/widgets/binding.dart
@@ -34,7 +34,7 @@ abstract class WidgetsBindingObserver {
   /// box, and false otherwise. The [WidgetsApp] widget uses this
   /// mechanism to notify the [Navigator] widget that it should pop
   /// its current route if possible.
-  bool didPopRoute() => false;
+  Future<bool> didPopRoute() => new Future<bool>.value(false);
 
   /// Called when the application's dimensions change. For example,
   /// when a phone is rotated.
@@ -158,9 +158,9 @@ abstract class WidgetsBinding extends BindingBase implements GestureBinding, Ren
   /// [WidgetsApp] uses this in conjunction with a [Navigator] to
   /// cause the back button to close dialog boxes, return from modal
   /// pages, and so forth.
-  void handlePopRoute() {
+  Future<Null> handlePopRoute() async {
     for (WidgetsBindingObserver observer in _observers) {
-      if (observer.didPopRoute())
+      if (await observer.didPopRoute())
         return;
     }
     SystemNavigator.pop();

--- a/packages/flutter/lib/src/widgets/binding.dart
+++ b/packages/flutter/lib/src/widgets/binding.dart
@@ -159,7 +159,7 @@ abstract class WidgetsBinding extends BindingBase implements GestureBinding, Ren
   /// cause the back button to close dialog boxes, return from modal
   /// pages, and so forth.
   Future<Null> handlePopRoute() async {
-    for (WidgetsBindingObserver observer in _observers) {
+    for (WidgetsBindingObserver observer in  new List<WidgetsBindingObserver>.from(_observers)) {
       if (await observer.didPopRoute())
         return;
     }

--- a/packages/flutter/lib/src/widgets/form.dart
+++ b/packages/flutter/lib/src/widgets/form.dart
@@ -71,7 +71,6 @@ class FormState extends State<Form> {
     final ModalRoute<dynamic> route = ModalRoute.of(context);
     if (route != null && config.onWillPop != null) {
       // Avoid adding our callback twice by removing it first.
-      //route.removeScopedWillPopCallback(config.onWillPop);
       route.removeScopedWillPopCallback(config.onWillPop);
       route.addScopedWillPopCallback(config.onWillPop);
     }

--- a/packages/flutter/lib/src/widgets/form.dart
+++ b/packages/flutter/lib/src/widgets/form.dart
@@ -69,12 +69,11 @@ class FormState extends State<Form> {
   void dependenciesChanged() {
     super.dependenciesChanged();
     final ModalRoute<dynamic> route = ModalRoute.of(context);
-    if (route != null && route.isCurrent) {
-      // If it's the same ModalRoute, avoid adding our callback twice.
-      if (config.onWillPop != null) {
-        route.removeScopedWillPopCallback(config.onWillPop);
-        route.addScopedWillPopCallback(config.onWillPop);
-      }
+    if (route != null && config.onWillPop != null) {
+      // Avoid adding our callback twice by removing it first.
+      //route.removeScopedWillPopCallback(config.onWillPop);
+      route.removeScopedWillPopCallback(config.onWillPop);
+      route.addScopedWillPopCallback(config.onWillPop);
     }
   }
 
@@ -82,7 +81,8 @@ class FormState extends State<Form> {
   void didUpdateConfig(Form oldConfig) {
     final ModalRoute<dynamic> route = ModalRoute.of(context);
     if (config.onWillPop != oldConfig.onWillPop && route != null) {
-      route.removeScopedWillPopCallback(oldConfig.onWillPop);
+      if (oldConfig.onWillPop != null)
+        route.removeScopedWillPopCallback(oldConfig.onWillPop);
       if (config.onWillPop != null)
         route.addScopedWillPopCallback(config.onWillPop);
     }

--- a/packages/flutter/lib/src/widgets/form.dart
+++ b/packages/flutter/lib/src/widgets/form.dart
@@ -54,7 +54,7 @@ class Form extends StatefulWidget {
   /// that contains the form.
   ///
   /// If the callback returns a Future that resolves to false, the form's route
-  /// will not be dimissed.
+  /// will not be popped.
   WillPopCallback onWillPop;
 
   @override
@@ -68,16 +68,24 @@ class FormState extends State<Form> {
   @override
   void dependenciesChanged() {
     super.dependenciesChanged();
-    final ModalRoute<Null> route = ModalRoute.of(context);
-    if (route != null && route.isCurrent)
-      route.scopedWillPopCallback = config.onWillPop;
+    final ModalRoute<dynamic> route = ModalRoute.of(context);
+    if (route != null && route.isCurrent) {
+      // If it's the same ModalRoute, avoid adding our callback twice.
+      if (config.onWillPop != null) {
+        route.removeScopedWillPopCallback(config.onWillPop);
+        route.addScopedWillPopCallback(config.onWillPop);
+      }
+    }
   }
 
   @override
   void didUpdateConfig(Form oldConfig) {
-    final ModalRoute<Null> route = ModalRoute.of(context);
-    if (config.onWillPop != oldConfig.onWillPop && route != null && route.isCurrent)
-      route.scopedWillPopCallback = config.onWillPop;
+    final ModalRoute<dynamic> route = ModalRoute.of(context);
+    if (config.onWillPop != oldConfig.onWillPop && route != null) {
+      route.removeScopedWillPopCallback(oldConfig.onWillPop);
+      if (config.onWillPop != null)
+        route.addScopedWillPopCallback(config.onWillPop);
+    }
   }
 
   // Called when a form field has changed. This will cause all form fields

--- a/packages/flutter/lib/src/widgets/navigator.dart
+++ b/packages/flutter/lib/src/widgets/navigator.dart
@@ -73,9 +73,7 @@ abstract class Route<T> {
   /// See also:
   ///
   /// * [Form], which provides an `onWillPop` callback that uses this mechanism.
-  Future<bool> willPop() {
-    return new Future<bool>.value(true);
-  }
+  Future<bool> willPop() async => true;
 
   /// A request was made to pop this route. If the route can handle it
   /// internally (e.g. because it has its own stack of internal state) then
@@ -776,16 +774,13 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin {
   ///
   /// * [Form], which provides an `onWillPop` callback that enables the form
   ///   to veto a [pop] initiated by the app's back button.
-  /// * [ModalRoute], which provides a `scopedWillPopCallback` that can be used
-  ///   to define the route's `willPop` method.
+  /// * [ModalRoute], which has as a `willPop` method that can be defined
+  ///   by a list of [WillPopCallback]s.
   Future<bool> willPop() async {
     final Route<dynamic> route = _history.last;
     assert(route._navigator == this);
-    if (!await route.willPop() && route.isCurrent)
-      return new Future<bool>.value(false);
-    return new Future<bool>.value(true);
+    return route.willPop();
   }
-
 
   /// Removes the top route in the [Navigator]'s history.
   ///

--- a/packages/flutter/lib/src/widgets/navigator.dart
+++ b/packages/flutter/lib/src/widgets/navigator.dart
@@ -118,6 +118,11 @@ abstract class Route<T> {
   /// back gesture), this should return a controller object that can be used to
   /// control the transition animation's progress. Otherwise, it should return
   /// null.
+  ///
+  /// If attempts to dismiss this route might be vetoed, for example because
+  /// a [WillPopCallback] was defined for the route, then it may make sense
+  /// to disable the pop gesture. For example, the iOS back gesture is disabled
+  /// when [ModalRoute.hasScopedWillCallback] is true.
   NavigationGestureController startPopGesture(NavigatorState navigator) {
     return null;
   }

--- a/packages/flutter/test/material/will_pop_test.dart
+++ b/packages/flutter/test/material/will_pop_test.dart
@@ -32,7 +32,9 @@ class SamplePageState extends State<SamplePage> {
 int willPopCount = 0;
 
 class SampleForm extends StatelessWidget {
-  SampleForm({ Key key }) : super(key: key);
+  SampleForm({ Key key, this.callback }) : super(key: key);
+
+  final WillPopCallback callback;
 
   @override
   Widget build(BuildContext context) {
@@ -42,7 +44,7 @@ class SampleForm extends StatelessWidget {
         child: new Form(
           onWillPop: () {
             willPopCount += 1;
-            return new Future<bool>.value(willPopValue);
+            return callback();
           },
           child: new InputFormField(),
         ),
@@ -109,7 +111,11 @@ void main() {
                   child: new Text('X'),
                   onPressed: () {
                     Navigator.of(context).push(new MaterialPageRoute<Null>(
-                      builder: (BuildContext context) => new SampleForm(),
+                      builder: (BuildContext context) {
+                        return new SampleForm(
+                          callback: () => new Future<bool>.value(willPopValue),
+                        );
+                      }
                     ));
                   },
                 ),
@@ -146,4 +152,95 @@ void main() {
     expect(find.text('Sample Form'), findsNothing);
     expect(willPopCount, 1);
   });
+
+  testWidgets('Form.willPop callbacks do not accumulate', (WidgetTester tester) async {
+    Future<bool> showYesNoAlert(BuildContext context) {
+      return showDialog/*<bool>*/(
+        context: context,
+        child: new AlertDialog(
+          actions: <Widget> [
+            new FlatButton(
+              child: new Text('YES'),
+              onPressed: () { Navigator.of(context).pop(true); },
+            ),
+            new FlatButton(
+              child: new Text('NO'),
+              onPressed: () { Navigator.of(context).pop(false); },
+            ),
+          ],
+        ),
+      );
+    }
+
+    Widget buildFrame() {
+      return new MaterialApp(
+        home: new Scaffold(
+          appBar: new AppBar(title: new Text('Home')),
+          body: new Builder(
+            builder: (BuildContext context) {
+              return new Center(
+                child: new FlatButton(
+                  child: new Text('X'),
+                  onPressed: () {
+                    Navigator.of(context).push(new MaterialPageRoute<Null>(
+                      builder: (BuildContext context) {
+                        return new SampleForm(
+                          callback: () => showYesNoAlert(context),
+                        );
+                      }
+                    ));
+                  },
+                ),
+              );
+            },
+          ),
+        ),
+      );
+    }
+
+    await tester.pumpWidget(buildFrame());
+
+    await tester.tap(find.text('X'));
+    await tester.pump();
+    await tester.pump(const Duration(seconds: 1));
+
+    expect(find.text('Sample Form'), findsOneWidget);
+
+    // Press the Scaffold's back button. This causes the willPop callback
+    // to run, which shows the YES/NO Alert Dialog. Veto the back operation
+    // by pressing the Alert's NO button.
+    await tester.tap(find.byTooltip('Back'));
+    await tester.pump(); // Start the pop "back" operation.
+    await tester.pump(); // Call willPop which will show an Alert.
+    await tester.tap(find.text('NO'));
+    await tester.pump(); // Start the dismiss animation.
+    await tester.pump(); // Resolve the willPop callback.
+    await tester.pump(const Duration(seconds: 1)); // Wait until it has finished.
+    expect(find.text('Sample Form'), findsOneWidget);
+
+    // Do it again. Note that each time the Alert is shown and dismissed
+    // the FormState's dependenciesChanged() method runs. We're making sure
+    // that the dependenciesChanged() method doesn't add an extra willPop
+    // callback.
+    await tester.tap(find.byTooltip('Back'));
+    await tester.pump(); // Start the pop "back" operation.
+    await tester.pump(); // Call willPop which will show an Alert.
+    await tester.tap(find.text('NO'));
+    await tester.pump(); // Start the dismiss animation.
+    await tester.pump(); // Resolve the willPop callback.
+    await tester.pump(const Duration(seconds: 1)); // Wait until it has finished.
+    expect(find.text('Sample Form'), findsOneWidget);
+
+    // This time really dismiss the SampleForm by pressing the Alert's
+    // YES button.
+    await tester.tap(find.byTooltip('Back'));
+    await tester.pump(); // Start the pop "back" operation.
+    await tester.pump(); // Call willPop which will show an Alert.
+    await tester.tap(find.text('YES'));
+    await tester.pump(); // Start the dismiss animation.
+    await tester.pump(); // Resolve the willPop callback.
+    await tester.pump(const Duration(seconds: 1)); // Wait until it has finished.
+    expect(find.text('Sample Form'), findsNothing);
+  });
+
 }

--- a/packages/flutter/test/material/will_pop_test.dart
+++ b/packages/flutter/test/material/will_pop_test.dart
@@ -1,0 +1,141 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter/material.dart';
+
+bool willPopValue = false;
+
+class SamplePage extends StatefulWidget {
+  @override
+  SamplePageState createState() => new SamplePageState();
+}
+
+class SamplePageState extends State<SamplePage> {
+  @override
+  void dependenciesChanged() {
+    super.dependenciesChanged();
+    final ModalRoute<Null> route = ModalRoute.of(context);
+    if (route.isCurrent) {
+      route.scopedWillPopCallback = () {
+        return new Future<bool>.value(willPopValue);
+      };
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return new Scaffold(
+      appBar: new AppBar(title: new Text('Sample Page')),
+    );
+  }
+}
+
+class SampleForm extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return new Scaffold(
+      appBar: new AppBar(title: new Text('Sample Form')),
+      body: new SizedBox.expand(
+        child: new Form(
+          onWillPop: () {
+            return new Future<bool>.value(willPopValue);
+          },
+          child: new InputFormField(),
+        ),
+      ),
+    );
+  }
+}
+
+void main() {
+  testWidgets('ModalRoute.scopedWillPopupCallback can inhibit back button', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      new MaterialApp(
+        home: new Scaffold(
+          appBar: new AppBar(title: new Text('Home')),
+          body: new Builder(
+            builder: (BuildContext context) {
+              return new Center(
+                child: new FlatButton(
+                  child: new Text('X'),
+                  onPressed: () {
+                    showDialog(
+                      context: context,
+                      child: new SamplePage(),
+                    );
+                  },
+                ),
+              );
+            },
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('X'));
+    await tester.pump();
+    await tester.pump(const Duration(seconds: 1));
+
+    expect(find.text('Sample Page'), findsOneWidget);
+
+    willPopValue = false;
+    await tester.tap(find.byTooltip('Back'));
+    await tester.pump();
+    await tester.pump();
+    await tester.pump(const Duration(seconds: 1));
+    expect(find.text('Sample Page'), findsOneWidget);
+
+    willPopValue = true;
+    await tester.tap(find.byTooltip('Back'));
+    await tester.pump();
+    await tester.pump();
+    await tester.pump(const Duration(seconds: 1));
+    expect(find.text('Sample Page'), findsNothing);
+  });
+
+  testWidgets('Form.willPop can inhibit back button', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      new MaterialApp(
+        home: new Scaffold(
+          appBar: new AppBar(title: new Text('Home')),
+          body: new Builder(
+            builder: (BuildContext context) {
+              return new Center(
+                child: new FlatButton(
+                  child: new Text('X'),
+                  onPressed: () {
+                    Navigator.of(context).push(new MaterialPageRoute<Null>(
+                      builder: (BuildContext context) => new SampleForm(),
+                    ));
+                  },
+                ),
+              );
+            },
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('X'));
+    await tester.pump();
+    await tester.pump(const Duration(seconds: 1));
+
+    expect(find.text('Sample Form'), findsOneWidget);
+
+    willPopValue = false;
+    await tester.tap(find.byTooltip('Back'));
+    await tester.pump();
+    await tester.pump();
+    await tester.pump(const Duration(seconds: 1));
+    expect(find.text('Sample Form'), findsOneWidget);
+
+    willPopValue = true;
+    await tester.tap(find.byTooltip('Back'));
+    await tester.pump();
+    await tester.pump();
+    await tester.pump(const Duration(seconds: 1));
+    expect(find.text('Sample Form'), findsNothing);
+  });
+}

--- a/packages/flutter/test/material/will_pop_test.dart
+++ b/packages/flutter/test/material/will_pop_test.dart
@@ -17,11 +17,8 @@ class SamplePageState extends State<SamplePage> {
   void dependenciesChanged() {
     super.dependenciesChanged();
     final ModalRoute<Null> route = ModalRoute.of(context);
-    if (route.isCurrent) {
-      route.scopedWillPopCallback = () {
-        return new Future<bool>.value(willPopValue);
-      };
-    }
+    if (route.isCurrent)
+      route.addScopedWillPopCallback(() async => willPopValue);
   }
 
   @override
@@ -50,7 +47,7 @@ class SampleForm extends StatelessWidget {
 }
 
 void main() {
-  testWidgets('ModalRoute.scopedWillPopupCallback can inhibit back button', (WidgetTester tester) async {
+  testWidgets('ModalRoute scopedWillPopupCallback can inhibit back button', (WidgetTester tester) async {
     await tester.pumpWidget(
       new MaterialApp(
         home: new Scaffold(
@@ -126,16 +123,12 @@ void main() {
 
     willPopValue = false;
     await tester.tap(find.byTooltip('Back'));
-    await tester.pump();
-    await tester.pump();
-    await tester.pump(const Duration(seconds: 1));
+    await tester.pumpUntilNoTransientCallbacks(const Duration(seconds: 1));
     expect(find.text('Sample Form'), findsOneWidget);
 
     willPopValue = true;
     await tester.tap(find.byTooltip('Back'));
-    await tester.pump();
-    await tester.pump();
-    await tester.pump(const Duration(seconds: 1));
+    await tester.pumpUntilNoTransientCallbacks(const Duration(seconds: 1));
     expect(find.text('Sample Form'), findsNothing);
   });
 }


### PR DESCRIPTION
It's often useful for a Form widget to warn or even block the user if they attempt to back out of an invalid or unsaved modal form.

The Form `willPop` callback is called before a Navigator.pop() triggered by the Scaffold's back button or Android's system back button. The value of the callback is a `Future<bool>`. The enclosing modal route will only be popped if willPop returns true. A simple application of willPop would be to show an alert that asks the user to confirm:

```
new Form(
  onWillPop: () {
    return showDialog(
      context: context,
      child: new AlertDialog(
        title: new Text('This form has errors'),
        content: new Text('Really leave this form?'),
        actions: <Widget> [
          new FlatButton(
            child: new Text('YES'),
            onPressed: () { Navigator.of(context).pop(true); },
          ),
          new FlatButton(
            child: new Text('NO'),
            onPressed: () { Navigator.of(context).pop(false); },
          ),
        ],
      ),
    );
  },
  // ...
)
```

In this example `showDialog` returns true or false depending on the Navigator.pop() value it was dismissed with.

The Route class now has a willPop method with just returns `Future<bool>.value(true)` by default.

The ModalRoute class overrides willPop and delegates to its _ModalScope. This makes it possible to define willPop from a stateful descendant of a ModalRoute. Typically apps don't define ModalRoute subclasses directly, they just use higher level primitives that create ModalRoutes, like showDialog() or MaterialPageRoute.  The ModalRoute `scopedWillPopCallback` makes it possible for a ModalRoute's stateful descendant, like showDialog's child, to define the value of `willPop`.

```
@override
void dependenciesChanged() {
 super.dependenciesChanged();
 final ModalRoute<Null> route = ModalRoute.of(context);
 if (route.isCurrent)
   route.scopedWillPopCallback = askTheUserIfTheyAreSure;
}
```

Navigator.willPop() now delegates to the current route's willPop method. The Scaffold's back button and the binding for the Android system back button now check Navigator.willPop() before actually popping the current route.

Fixes #6331
