### PR TITLE
Do not paint a RenderFittedBox with an empty size

### DIFF
--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -1573,6 +1573,8 @@ class RenderFittedBox extends RenderProxyBox {
 
   @override
   void paint(PaintingContext context, Offset offset) {
+    if (size.isEmpty)
+      return;
     _updatePaintData();
     if (child != null) {
       if (_hasVisualOverflow)

--- a/packages/flutter/test/rendering/proxy_box_test.dart
+++ b/packages/flutter/test/rendering/proxy_box_test.dart
@@ -1,0 +1,32 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/rendering.dart';
+import 'package:test/test.dart';
+
+import 'rendering_tester.dart';
+
+void main() {
+  test('RenderFittedBox paint', () {
+    bool painted;
+    RenderFittedBox makeFittedBox() {
+      return new RenderFittedBox(
+        child: new RenderCustomPaint(
+          painter: new TestCallbackPainter(
+            onPaint: () { painted = true; }
+          ),
+        ),
+      );
+    }
+
+    painted = false;
+    layout(makeFittedBox(), phase: EnginePhase.paint);
+    expect(painted, equals(true));
+
+    // The RenderFittedBox should not paint if it is empty.
+    painted = false;
+    layout(makeFittedBox(), constraints: new BoxConstraints.tight(Size.zero), phase: EnginePhase.paint);
+    expect(painted, equals(false));
+  });
+}


### PR DESCRIPTION
If the size is empty, then _updatePaintData will produce an invalid transform
that yields a NaN canvas bounds rectangle

Fixes https://github.com/flutter/flutter/issues/7431