### PR TITLE
Restore velocity tracker sample window duration

### DIFF
--- a/packages/flutter/lib/src/gestures/velocity_tracker.dart
+++ b/packages/flutter/lib/src/gestures/velocity_tracker.dart
@@ -43,7 +43,14 @@ class _LeastSquaresVelocityTrackerStrategy extends _VelocityTrackerStrategy {
   int _index = 0;
 
   static const int kHistorySize = 20;
+
+  // On iOS we're not necccessarily seeing all of the motion events. See:
+  // https://github.com/flutter/flutter/issues/4737#issuecomment-241076994
   static const int kHorizonMilliseconds = 100;
+
+  // The maximum length of time between two move events to allow
+  // before assuming the pointer stopped.
+  static const int kAssumePointerMoveStoppedMilliseconds = 40;
 
   @override
   void addMovement(Duration timeStamp, Point position) {
@@ -64,6 +71,7 @@ class _LeastSquaresVelocityTrackerStrategy extends _VelocityTrackerStrategy {
     int index = _index;
 
     _Movement newestMovement = _movements[index];
+    _Movement previousMovement = newestMovement;
     if (newestMovement == null)
       return null;
 
@@ -73,7 +81,9 @@ class _LeastSquaresVelocityTrackerStrategy extends _VelocityTrackerStrategy {
         break;
 
       double age = (newestMovement.eventTime - movement.eventTime).inMilliseconds.toDouble();
-      if (age > kHorizonMilliseconds)
+      double delta = (movement.eventTime - previousMovement.eventTime).inMilliseconds.toDouble();
+      previousMovement = movement;
+      if (age > kHorizonMilliseconds || delta > kAssumePointerMoveStoppedMilliseconds)
         break;
 
       Point position = movement.position;

--- a/packages/flutter/lib/src/gestures/velocity_tracker.dart
+++ b/packages/flutter/lib/src/gestures/velocity_tracker.dart
@@ -43,7 +43,7 @@ class _LeastSquaresVelocityTrackerStrategy extends _VelocityTrackerStrategy {
   int _index = 0;
 
   static const int kHistorySize = 20;
-  static const int kHorizonMilliseconds = 40;
+  static const int kHorizonMilliseconds = 100;
 
   @override
   void addMovement(Duration timeStamp, Point position) {

--- a/packages/flutter/lib/src/gestures/velocity_tracker.dart
+++ b/packages/flutter/lib/src/gestures/velocity_tracker.dart
@@ -48,8 +48,8 @@ class _LeastSquaresVelocityTrackerStrategy extends _VelocityTrackerStrategy {
   // https://github.com/flutter/flutter/issues/4737#issuecomment-241076994
   static const int kHorizonMilliseconds = 100;
 
-  // The maximum length of time between two move events to allow
-  // before assuming the pointer stopped.
+  // The maximum length of time between two move events to allow before
+  // assuming the pointer stopped.
   static const int kAssumePointerMoveStoppedMilliseconds = 40;
 
   @override

--- a/packages/flutter/lib/src/gestures/velocity_tracker.dart
+++ b/packages/flutter/lib/src/gestures/velocity_tracker.dart
@@ -34,6 +34,9 @@ class _Movement {
   String toString() => 'Movement($position at $eventTime)';
 }
 
+// TODO: On iOS we're not necccessarily seeing all of the motion events. See:
+// https://github.com/flutter/flutter/issues/4737#issuecomment-241076994
+
 class _LeastSquaresVelocityTrackerStrategy extends _VelocityTrackerStrategy {
   _LeastSquaresVelocityTrackerStrategy(this.degree);
 
@@ -43,9 +46,6 @@ class _LeastSquaresVelocityTrackerStrategy extends _VelocityTrackerStrategy {
   int _index = 0;
 
   static const int kHistorySize = 20;
-
-  // On iOS we're not necccessarily seeing all of the motion events. See:
-  // https://github.com/flutter/flutter/issues/4737#issuecomment-241076994
   static const int kHorizonMilliseconds = 100;
 
   // The maximum length of time between two move events to allow before
@@ -81,7 +81,7 @@ class _LeastSquaresVelocityTrackerStrategy extends _VelocityTrackerStrategy {
         break;
 
       double age = (newestMovement.eventTime - movement.eventTime).inMilliseconds.toDouble();
-      double delta = (movement.eventTime - previousMovement.eventTime).inMilliseconds.toDouble();
+      double delta = (movement.eventTime - previousMovement.eventTime).inMilliseconds.abs().toDouble();
       previousMovement = movement;
       if (age > kHorizonMilliseconds || delta > kAssumePointerMoveStoppedMilliseconds)
         break;

--- a/packages/flutter/test/gestures/velocity_tracker_data.dart
+++ b/packages/flutter/test/gestures/velocity_tracker_data.dart
@@ -1536,3 +1536,72 @@ const List<PointerEvent> velocityEventData = const <PointerEvent>[
     position: const Point(241.14285278320312, 451.4285583496094)
   ),
 ];
+
+const List<PointerEvent> interruptedVelocityEventData = const <PointerEvent>[
+  const PointerDownEvent(
+    timeStamp: const Duration(milliseconds: 216698321),
+    pointer: 13,
+    position: const Point(250.0, 306.0)
+  ),
+
+  const PointerMoveEvent(
+    timeStamp: const Duration(milliseconds: 216698328),
+    pointer: 13,
+    position: const Point(250.0, 306.0)
+  ),
+  const PointerMoveEvent(
+    timeStamp: const Duration(milliseconds: 216698344),
+    pointer: 13,
+    position: const Point(249.14285278320312, 314.0)
+  ),
+  const PointerMoveEvent(
+    timeStamp: const Duration(milliseconds: 216698351),
+    pointer: 13,
+    position: const Point(247.42857360839844, 319.4285583496094)
+  ),
+  const PointerMoveEvent(
+    timeStamp: const Duration(milliseconds: 216698359),
+    pointer: 13,
+    position: const Point(245.14285278320312, 326.8571472167969)
+  ),
+  const PointerMoveEvent(
+    timeStamp: const Duration(milliseconds: 216698366),
+    pointer: 13,
+    position: const Point(241.7142791748047, 339.4285583496094)
+  ),
+
+  // The pointer "stops" here because we've introduced a 40+ms gap
+  // in the move event stream. See kAssumePointerMoveStoppedMilliseconds
+  // in velocity_tracker.dart.
+
+  const PointerMoveEvent(
+    timeStamp: const Duration(milliseconds: 216698374 + 40),
+    pointer: 13,
+    position: const Point(238.57142639160156, 355.71429443359375)
+  ),
+  const PointerMoveEvent(
+    timeStamp: const Duration(milliseconds: 216698382 + 40),
+    pointer: 13,
+    position: const Point(236.2857208251953, 374.28570556640625)
+  ),
+  const PointerMoveEvent(
+    timeStamp: const Duration(milliseconds: 216698390 + 40),
+    pointer: 13,
+    position: const Point(235.14285278320312, 396.5714416503906)
+  ),
+  const PointerMoveEvent(
+    timeStamp: const Duration(milliseconds: 216698398 + 40),
+    pointer: 13,
+    position: const Point(236.57142639160156, 421.4285583496094)
+  ),
+  const PointerMoveEvent(
+    timeStamp: const Duration(milliseconds: 216698406 + 40),
+    pointer: 13,
+    position: const Point(241.14285278320312, 451.4285583496094)
+  ),
+  const PointerUpEvent(
+    timeStamp: const Duration(milliseconds: 216698421 + 40),
+    pointer: 13,
+    position: const Point(241.14285278320312, 451.4285583496094)
+  ),
+];

--- a/packages/flutter/test/gestures/velocity_tracker_test.dart
+++ b/packages/flutter/test/gestures/velocity_tracker_test.dart
@@ -59,4 +59,16 @@ void main() {
     expect(velocity1.hashCode, isNot(equals(velocity2.hashCode)));
     expect(velocity1, hasOneLineDescription);
   });
+
+  test('Interrupted velocity estimation', () {
+    // Regression test for https://github.com/flutter/flutter/pull/7510
+    VelocityTracker tracker = new VelocityTracker();
+    for (PointerEvent event in interruptedVelocityEventData) {
+      if (event is PointerDownEvent || event is PointerMoveEvent)
+        tracker.addPosition(event.timeStamp, event.position);
+      if (event is PointerUpEvent) {
+        _checkVelocity(tracker.getVelocity(), const Offset(649.5, 3890.3));
+      }
+    }
+  });
 }


### PR DESCRIPTION
Pull request https://github.com/flutter/flutter/pull/7363 reduced the kHorizontalMilliseconds constant in velocity_tracker.dart from 100ms to 40ms. On Android, with yours truly as the swipe duration standard, that yielded about 5 sample events and reasonable velocity estimates. On iOS however the result was only 2 or 3 samples. This led to poor (albeit high confidence) velocity estimates.

Fixes #7477