### PR TITLE
create a bot to canary the dart sdk roll

### DIFF
--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -2,6 +2,7 @@
 <project version="4">
   <component name="ProjectModuleManager">
     <modules>
+      <module fileurl="file://$PROJECT_DIR$/dev/bots/bots.iml" filepath="$PROJECT_DIR$/dev/bots/bots.iml" />
       <module fileurl="file://$PROJECT_DIR$/dev/devicelab/devicelab.iml" filepath="$PROJECT_DIR$/dev/devicelab/devicelab.iml" />
       <module fileurl="file://$PROJECT_DIR$/packages/flutter/flutter.iml" filepath="$PROJECT_DIR$/packages/flutter/flutter.iml" />
       <module fileurl="file://$PROJECT_DIR$/packages/flutter_driver/flutter_driver.iml" filepath="$PROJECT_DIR$/packages/flutter_driver/flutter_driver.iml" />

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,10 @@ before_script:
   - ./dev/bots/setup.sh
 script:
   - ./dev/bots/entry.sh
+env:
+  - MAIN_BOT=true
+  - DART_SDK_CANARY=true
+  - BUILD_DOCS=true
 cache:
   directories:
     - $HOME/.pub-cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,7 @@ install:
 before_script:
   - ./dev/bots/setup.sh
 script:
-  - ./dev/bots/test.sh
-after_success:
-  - (cd packages/flutter && coveralls-lcov coverage/lcov.info)
+  - ./dev/bots/entry.sh
 cache:
   directories:
     - $HOME/.pub-cache

--- a/dev/bots/bots.iml
+++ b/dev/bots/bots.iml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="WEB_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/dev/bots/docs.sh
+++ b/dev/bots/docs.sh
@@ -1,11 +1,14 @@
 #!/bin/bash
 set -e
 
+# analyze all the Dart code in the repo
+flutter analyze --flutter-repo
+
 # Install dartdoc.
 pub global activate dartdoc 0.9.9
 
-# This script generates a unified doc set, and creates
-# a custom index.html, placing everything into dev/docs/doc
+# This script generates a unified doc set, and creates a custom index.html,
+# placing everything into dev/docs/doc
 (cd dev/tools; pub get)
 FLUTTER_ROOT=$PWD dart dev/tools/dartdoc.dart
 

--- a/dev/bots/entry.sh
+++ b/dev/bots/entry.sh
@@ -10,5 +10,5 @@ else if [ "$DART_SDK_CANARY" = "true" ]; then
   dev/bots/sdk_canary.sh
 else
   # run tests
-  dev/bots/docs.sh
+  dev/bots/test.sh
 fi

--- a/dev/bots/entry.sh
+++ b/dev/bots/entry.sh
@@ -5,10 +5,21 @@
 if [ "$BUILD_DOCS" = "true" ]; then
   # generate docs
   dev/bots/docs.sh
-else if [ "$DART_SDK_CANARY" = "true" ]; then
+elif [ "$DART_SDK_CANARY" = "true" ]; then
   # switch flutter to the latest dev sdk and run tests
   dev/bots/sdk_canary.sh
 else
   # run tests
   dev/bots/test.sh
+
+  if [ -n "$COVERAGE_FLAG" ]; then
+    GSUTIL=$HOME/google-cloud-sdk/bin/gsutil
+    GCLOUD=$HOME/google-cloud-sdk/bin/gcloud
+
+    $GCLOUD auth activate-service-account --key-file ../gcloud_key_file.json
+    STORAGE_URL=gs://flutter_infra/flutter/coverage/lcov.info
+    $GSUTIL cp packages/flutter/coverage/lcov.info $STORAGE_URL
+  fi
+
+  (cd packages/flutter && coveralls-lcov coverage/lcov.info)
 fi

--- a/dev/bots/entry.sh
+++ b/dev/bots/entry.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# the bot entry-point - delegate to the correct script
+
+if [ "$BUILD_DOCS" = "true" ]; then
+  # generate docs
+  dev/bots/docs.sh
+else if [ "$DART_SDK_CANARY" = "true" ]; then
+  # switch flutter to the latest dev sdk and run tests
+  dev/bots/sdk_canary.sh
+else
+  # run tests
+  dev/bots/docs.sh
+fi

--- a/dev/bots/sdk_canary.sh
+++ b/dev/bots/sdk_canary.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# switch flutter to the latest dev sdk
+wget \
+  https://storage.googleapis.com/dart-archive/channels/dev/release/latest/sdk/dartsdk-linux-ia32-release.zip
+  -O \
+  /tmp/dartsdk-linux-ia32-release.zip
+unzip /tmp/dartsdk-linux-ia32-release.zip
+
+echo testing against sdk version `cat /tmp/dart-sdk/version`
+cat /tmp/dart-sdk/version > bin/internal/dart-sdk.version
+./bin/internal/update_dart_sdk.sh
+
+./bin/flutter update-packages
+
+# run tests
+dev/bots/docs.sh

--- a/dev/bots/test.sh
+++ b/dev/bots/test.sh
@@ -51,14 +51,3 @@ SRC_ROOT=$PWD
 # generate and analyze our large sample app
 dart dev/tools/mega_gallery.dart
 (cd dev/benchmarks/mega_gallery; flutter analyze --watch --benchmark)
-
-if [ -n "$COVERAGE_FLAG" ]; then
-  GSUTIL=$HOME/google-cloud-sdk/bin/gsutil
-  GCLOUD=$HOME/google-cloud-sdk/bin/gcloud
-
-  $GCLOUD auth activate-service-account --key-file ../gcloud_key_file.json
-  STORAGE_URL=gs://flutter_infra/flutter/coverage/lcov.info
-  $GSUTIL cp packages/flutter/coverage/lcov.info $STORAGE_URL
-fi
-
-(cd packages/flutter && coveralls-lcov coverage/lcov.info)

--- a/dev/bots/test.sh
+++ b/dev/bots/test.sh
@@ -61,5 +61,4 @@ if [ -n "$COVERAGE_FLAG" ]; then
   $GSUTIL cp packages/flutter/coverage/lcov.info $STORAGE_URL
 fi
 
-# generate the API docs, upload them
-dev/bots/docs.sh
+(cd packages/flutter && coveralls-lcov coverage/lcov.info)


### PR DESCRIPTION
Create a bot to canary the dart sdk roll:
- one bot runs the tests (`test.sh`)
- move the doc gen to a separate bot (`docs.sh`) - this will speed up the regular test bot
- create another bot which forces the dart sdk to the latest dev version and runs the tests against that (`sdk_canary.sh`).

This will give us early warning of issues w/ rolling to the next dev sdk release. It does mean that people's PRs will turn red when there are no issues w/ those specific PRs. Not sure what the best recourse there is; having people TBR the canary bot off? Moving the canary to only run when called from a travis cron job?
