### PR TITLE
Make it easier to run local engine tests using the Travis test script.

### DIFF
--- a/dev/bots/test.sh
+++ b/dev/bots/test.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
 
+# When you call this, you can set FLUTTER_TEST_ARGS to pass custom
+# arguments to flutter test. For example, you might want to call this
+# script using FLUTTER_TEST_ARGS=--local-engine=host_debug_unopt to
+# use your own build of the engine.
+#
+# On Travis, this script additionally collects coverage and uploads
+# the coverage and the generated documentation to the cloud.
+
 export PATH="$PWD/bin:$PWD/bin/cache/dart-sdk/bin:$PATH"
 
 trap detect_error_on_exit EXIT HUP INT QUIT TERM
@@ -20,12 +28,12 @@ set -ex
 flutter analyze --flutter-repo
 
 # verify that the tests actually return failure on failure and success on success
-(cd dev/automated_tests; ! flutter test test_smoke_test/fail_test.dart > /dev/null)
-(cd dev/automated_tests; flutter test test_smoke_test/pass_test.dart > /dev/null)
-(cd dev/automated_tests; ! flutter test test_smoke_test/crash1_test.dart > /dev/null)
-(cd dev/automated_tests; ! flutter test test_smoke_test/crash2_test.dart > /dev/null)
-(cd dev/automated_tests; ! flutter test test_smoke_test/syntax_error_test.broken_dart > /dev/null)
-(cd dev/automated_tests; ! flutter test test_smoke_test/missing_import_test.broken_dart > /dev/null)
+(cd dev/automated_tests; ! flutter test $FLUTTER_TEST_ARGS test_smoke_test/fail_test.dart > /dev/null)
+(cd dev/automated_tests; flutter test $FLUTTER_TEST_ARGS test_smoke_test/pass_test.dart > /dev/null)
+(cd dev/automated_tests; ! flutter test $FLUTTER_TEST_ARGS test_smoke_test/crash1_test.dart > /dev/null)
+(cd dev/automated_tests; ! flutter test $FLUTTER_TEST_ARGS test_smoke_test/crash2_test.dart > /dev/null)
+(cd dev/automated_tests; ! flutter test $FLUTTER_TEST_ARGS test_smoke_test/syntax_error_test.broken_dart > /dev/null)
+(cd dev/automated_tests; ! flutter test $FLUTTER_TEST_ARGS test_smoke_test/missing_import_test.broken_dart > /dev/null)
 (cd packages/flutter_driver; ! flutter drive --use-existing-app -t test_driver/failure.dart >/dev/null 2>&1)
 
 COVERAGE_FLAG=
@@ -36,7 +44,7 @@ fi
 SRC_ROOT=$PWD
 
 # run tests
-(cd packages/flutter; flutter test $COVERAGE_FLAG)
+(cd packages/flutter; flutter test $FLUTTER_TEST_ARGS $COVERAGE_FLAG)
 (cd packages/flutter_driver; dart -c test/all.dart)
 (cd packages/flutter_test; flutter test)
 (cd packages/flutter_tools; FLUTTER_ROOT=$SRC_ROOT dart -c test/all.dart)


### PR DESCRIPTION
Our test script is getting complicated enough that doing your own testing with a custom engine has become tedious. Now you can just do:

```bash
(cd ~/dev/flutter/; FLUTTER_TEST_ARGS=--local-engine=host_debug_unopt dev/bots/test.sh)
```

...to run all your tests (assuming your flutter repo is in `~/dev/flutter` and your engine in `~/dev/engine`).