### PR TITLE
Improve Route lifecycle

### DIFF
--- a/packages/flutter/lib/src/animation/animation_controller.dart
+++ b/packages/flutter/lib/src/animation/animation_controller.dart
@@ -200,7 +200,7 @@ class AnimationController extends Animation<double>
   /// controller's ticker might get muted, in which case the animation
   /// controller's callbacks will no longer fire even though time is continuing
   /// to pass. See [Ticker.muted] and [TickerMode].
-  bool get isAnimating => _ticker.isActive;
+  bool get isAnimating => _ticker != null && _ticker.isActive;
 
   _AnimationDirection _direction;
 
@@ -348,7 +348,17 @@ class AnimationController extends Animation<double>
   /// after this method is called.
   @override
   void dispose() {
+    assert(() {
+      if (_ticker == null) {
+        throw new FlutterError(
+          'AnimationController.dispose() called more than once.\n'
+          'A given AnimationController cannot be disposed more than once.'
+        );
+      }
+      return true;
+    });
     _ticker.dispose();
+    _ticker = null;
     super.dispose();
   }
 
@@ -379,10 +389,10 @@ class AnimationController extends Animation<double>
   @override
   String toStringDetails() {
     String paused = isAnimating ? '' : '; paused';
-    String silenced = _ticker.muted ? '; silenced' : '';
+    String ticker = _ticker == null ? '; DISPOSED' : (_ticker.muted ? '; silenced' : '');
     String label = debugLabel == null ? '' : '; for $debugLabel';
     String more = '${super.toStringDetails()} ${value.toStringAsFixed(3)}';
-    return '$more$paused$silenced$label';
+    return '$more$paused$ticker$label';
   }
 }
 

--- a/packages/flutter/test/animation/animation_controller_test.dart
+++ b/packages/flutter/test/animation/animation_controller_test.dart
@@ -260,4 +260,13 @@ void main() {
 
     controller.stop();
   });
+
+  test('Disposed AnimationController toString works', () {
+    AnimationController controller = new AnimationController(
+      duration: const Duration(milliseconds: 100),
+      vsync: const TestVSync(),
+    );
+    controller.dispose();
+    expect(controller, hasOneLineDescription);
+  });
 }

--- a/packages/flutter/test/material/date_picker_test.dart
+++ b/packages/flutter/test/material/date_picker_test.dart
@@ -142,9 +142,6 @@ void main() {
 
     await tester.pumpUntilNoTransientCallbacks(const Duration(seconds: 1));
     await callback(date);
-
-    // TODO(abarth): Remove this call once https://github.com/flutter/flutter/issues/7457 is fixed.
-    await tester.pumpUntilNoTransientCallbacks(const Duration(seconds: 1));
   }
 
   testWidgets('Initial date is the default', (WidgetTester tester) async {

--- a/packages/flutter/test/material/dialog_test.dart
+++ b/packages/flutter/test/material/dialog_test.dart
@@ -136,9 +136,5 @@ void main() {
     await tester.tap(find.text('First option'));
 
     expect(await result, equals(42));
-
-    // TODO(abarth): Remove once https://github.com/flutter/flutter/issues/7457
-    // is fixed.
-    await tester.pumpUntilNoTransientCallbacks(const Duration(seconds: 1));
   });
 }

--- a/packages/flutter/test/widgets/routes_test.dart
+++ b/packages/flutter/test/widgets/routes_test.dart
@@ -55,7 +55,7 @@ class TestRoute extends LocalHistoryRoute<String> {
     log('didPop $result');
     bool returnValue;
     if (returnValue = super.didPop(result))
-      dispose();
+      navigator.finalizeRoute(this);
     return returnValue;
   }
 


### PR DESCRIPTION
Previously the navigator wouldn't always call Route.dispose when it was
removed from the tree. After this patch, the navigator remembers popped
routes so that it can call dispose on them when it is removed from the
tree.

Also, improve some error messages around calling dispose() more than
once on routes and AnimationControllers.

Fixes #7457