### PR TITLE
Remove gallery dependency on flutter_markdown

### DIFF
--- a/examples/flutter_gallery/pubspec.yaml
+++ b/examples/flutter_gallery/pubspec.yaml
@@ -6,8 +6,6 @@ dependencies:
 
   flutter:
     sdk: flutter
-  flutter_markdown:
-    sdk: flutter
 
   # Also update dev/benchmarks/complex_layout/pubspec.yaml
   flutter_gallery_assets:


### PR DESCRIPTION
The gallery doesn't actually use `package:flutter_markdown`.