### PR TITLE
Stop building unlinked summaries for packages.

### DIFF
--- a/packages/flutter_tools/lib/src/commands/upgrade.dart
+++ b/packages/flutter_tools/lib/src/commands/upgrade.dart
@@ -9,7 +9,6 @@ import '../base/os.dart';
 import '../base/process.dart';
 import '../cache.dart';
 import '../dart/pub.dart';
-import '../dart/summary.dart';
 import '../doctor.dart';
 import '../globals.dart';
 import '../runner/flutter_command.dart';
@@ -50,8 +49,6 @@ class UpgradeCommand extends FlutterCommand {
 
     if (code != 0)
       throwToolExit(null, exitCode: code);
-
-    await buildUnlinkedForPackages(Cache.flutterRoot);
 
     // Check for and download any engine and pkg/ updates.
     // We run the 'flutter' shell script re-entrantly here

--- a/packages/flutter_tools/lib/src/dart/summary.dart
+++ b/packages/flutter_tools/lib/src/dart/summary.dart
@@ -1,5 +1,3 @@
-import 'dart:async';
-
 import 'package:analyzer/file_system/file_system.dart';
 import 'package:analyzer/file_system/physical_file_system.dart';
 import 'package:analyzer/src/context/builder.dart'; // ignore: implementation_imports
@@ -7,15 +5,11 @@ import 'package:analyzer/src/dart/sdk/sdk.dart'; // ignore: implementation_impor
 import 'package:analyzer/src/generated/engine.dart'; // ignore: implementation_imports
 import 'package:analyzer/src/generated/source.dart'; // ignore: implementation_imports
 import 'package:analyzer/src/summary/summary_file_builder.dart'; // ignore: implementation_imports
-import 'package:analyzer/src/summary/pub_summary.dart'; // ignore: implementation_imports
-import 'package:flutter_tools/src/base/logger.dart';
-import 'package:flutter_tools/src/dart/pub.dart';
 import 'package:flutter_tools/src/globals.dart';
 import 'package:path/path.dart' as pathos;
 import 'package:yaml/src/yaml_node.dart'; // ignore: implementation_imports
 
 import '../base/file_system.dart' as file;
-import '../base/io.dart';
 
 /// Given the [skyEnginePath], locate corresponding `_embedder.yaml` and compose
 /// the full embedded Dart SDK, and build the [outBundleName] file with its
@@ -49,54 +43,4 @@ void buildSkyEngineSdkSummary(String skyEnginePath, String outBundleName, bool s
   List<int> bytes = new SummaryBuilder(sources, sdk.context, strong).build();
   String outputPath = pathos.join(skyEnginePath, outBundleName);
   file.fs.file(outputPath).writeAsBytesSync(bytes);
-}
-
-Future<Null> buildUnlinkedForPackages(String flutterPath) async {
-  PhysicalResourceProvider provider = PhysicalResourceProvider.INSTANCE;
-  PubSummaryManager manager =
-      new PubSummaryManager(provider, '__unlinked_$pid.ds');
-
-  Folder flutterFolder = provider.getFolder(flutterPath);
-
-  // Build in packages/.
-  Folder packagesFolder = flutterFolder.getChildAssumingFolder('packages');
-  await _buildUnlinkedForDirectChildren(manager, packagesFolder);
-
-  // Build in bin/cache/pkg/.
-  Folder pkgFolder = flutterFolder
-      .getChildAssumingFolder('bin')
-      .getChildAssumingFolder('cache')
-      .getChildAssumingFolder('pkg');
-  await _buildUnlinkedForDirectChildren(manager, pkgFolder);
-}
-
-Future<Null> _buildUnlinkedForDirectChildren(
-  PubSummaryManager manager,
-  Folder packagesFolder
-) async {
-  for (Resource child in packagesFolder.getChildren()) {
-    if (child is Folder)
-      await _buildUnlinkedForPackage(manager, child);
-  }
-}
-
-Future<Null> _buildUnlinkedForPackage(
-  PubSummaryManager manager,
-  Folder packageFolder
-) async {
-  if (packageFolder.exists) {
-    String name = packageFolder.shortName;
-    File pubspecFile = packageFolder.getChildAssumingFile('pubspec.yaml');
-    Folder libFolder = packageFolder.getChildAssumingFolder('lib');
-    if (pubspecFile.exists && libFolder.exists) {
-      await pubGet(directory: packageFolder.path);
-      Status status =
-          logger.startProgress('Building unlinked bundles for $name...');
-      try {
-        await manager.computeUnlinkedForFolder(name, libFolder);
-      } finally {
-        status.stop();
-      }
-    }
-  }
 }


### PR DESCRIPTION
Stop building (**_unused_**) unlinked summaries for packages.

Improves update speed considerably (for `n` packages it saves us `n` needless calls to `pub get`). 🤘 

(Essentially reverts: https://github.com/flutter/flutter/commit/0774a6748e0d1829512d551e375eb46940d3c35f.)

@scheglov @Hixie @devoncarew 

FYI: @danrubel 