### PR TITLE
remove the no longer needed ignore: cancel_subscriptions

### DIFF
--- a/packages/flutter_tools/lib/src/commands/drive.dart
+++ b/packages/flutter_tools/lib/src/commands/drive.dart
@@ -84,7 +84,6 @@ class DriveCommand extends RunCommandBase {
   Device get device => _device;
 
   /// Subscription to log messages printed on the device or simulator.
-  // ignore: cancel_subscriptions
   StreamSubscription<String> _deviceLogSubscription;
 
   int get debugPort => int.parse(argResults['debug-port']);


### PR DESCRIPTION
This has been fixed: https://github.com/dart-lang/sdk/issues/57387

/cc @alexeieleusis @cbracken 
