### PR TITLE
Fix icon color in dark theme of gallery

### DIFF
--- a/examples/flutter_gallery/lib/demo/tooltip_demo.dart
+++ b/examples/flutter_gallery/lib/demo/tooltip_demo.dart
@@ -33,7 +33,7 @@ class TooltipDemo extends StatelessWidget {
                     child: new Icon(
                       Icons.call,
                       size: 18.0,
-                      color: theme.primaryColor
+                      color: theme.iconTheme.color
                     )
                   ),
                   new Text(' icon.', style: theme.textTheme.subhead)
@@ -43,7 +43,7 @@ class TooltipDemo extends StatelessWidget {
                 child: new IconButton(
                   size: 48.0,
                   icon: new Icon(Icons.call),
-                  color: theme.primaryColor,
+                  color: theme.iconTheme.color,
                   tooltip: 'Place a phone call',
                   onPressed: () {
                     Scaffold.of(context).showSnackBar(new SnackBar(


### PR DESCRIPTION
Previously, the icon in the tooltip demo was black on black background
in the dark theme. Now it is white on black background in the dark theme
and black on white background in the light theme.

fixes #7018

#easyFix