### PR TITLE
proxy service extension calls through the daemon protocol

### DIFF
--- a/packages/flutter_tools/lib/src/commands/daemon.dart
+++ b/packages/flutter_tools/lib/src/commands/daemon.dart
@@ -22,6 +22,7 @@ import '../ios/simulators.dart';
 import '../resident_runner.dart';
 import '../run.dart';
 import '../runner/flutter_command.dart';
+import '../vmservice.dart';
 
 const String protocolVersion = '0.2.0';
 
@@ -280,6 +281,7 @@ class AppDomain extends Domain {
   AppDomain(Daemon daemon) : super(daemon, 'app') {
     registerHandler('start', start);
     registerHandler('restart', restart);
+    registerHandler('callServiceExtension', callServiceExtension);
     registerHandler('stop', stop);
     registerHandler('discover', discover);
   }
@@ -433,6 +435,26 @@ class AppDomain extends Domain {
     return app._runInZone(this, () {
       return app.restart(fullRestart: fullRestart, pauseAfterRestart: pauseAfterRestart);
     });
+  }
+
+  Future<OperationResult> callServiceExtension(Map<String, dynamic> args) async {
+    String appId = _getStringArg(args, 'appId', required: true);
+    String methodName = _getStringArg(args, 'methodName');
+    Map<String, dynamic> params = args['params'] ?? <String, dynamic>{};
+
+    AppInstance app = _getApp(appId);
+    if (app == null)
+      throw "app '$appId' not found";
+
+    Isolate isolate = app.runner.currentView.uiIsolate;
+    Map<String, dynamic> result = await isolate.invokeFlutterExtensionRpcRaw(methodName, params: params);
+    if (result == null)
+      return new OperationResult(1, 'method not available: $methodName');
+
+    if (result.containsKey('error'))
+      return new OperationResult(1, result['error']);
+    else
+      return OperationResult.ok;
   }
 
   Future<bool> stop(Map<String, dynamic> args) async {

--- a/packages/flutter_tools/lib/src/commands/daemon.dart
+++ b/packages/flutter_tools/lib/src/commands/daemon.dart
@@ -440,7 +440,7 @@ class AppDomain extends Domain {
   Future<OperationResult> callServiceExtension(Map<String, dynamic> args) async {
     String appId = _getStringArg(args, 'appId', required: true);
     String methodName = _getStringArg(args, 'methodName');
-    Map<String, dynamic> params = args['params'] ?? <String, dynamic>{};
+    Map<String, String> params = args['params'] ?? <String, String>{};
 
     AppInstance app = _getApp(appId);
     if (app == null)

--- a/packages/flutter_tools/test/daemon_test.dart
+++ b/packages/flutter_tools/test/daemon_test.dart
@@ -167,6 +167,33 @@ void main() {
       commands.close();
     });
 
+    _testUsingContext('daemon.callServiceExtension', () async {
+      DaemonCommand command = new DaemonCommand();
+      applyMocksToCommand(command);
+
+      StreamController<Map<String, dynamic>> commands = new StreamController<Map<String, dynamic>>();
+      StreamController<Map<String, dynamic>> responses = new StreamController<Map<String, dynamic>>();
+      daemon = new Daemon(
+          commands.stream,
+              (Map<String, dynamic> result) => responses.add(result),
+          daemonCommand: command,
+          notifyingLogger: notifyingLogger
+      );
+
+      commands.add(<String, dynamic>{
+        'id': 0,
+        'method': 'app.callServiceExtension',
+        'params': <String, String> {
+          'methodName': 'ext.flutter.debugPaint'
+        }
+      });
+      Map<String, dynamic> response = await responses.stream.where(_notEvent).first;
+      expect(response['id'], 0);
+      expect(response['error'], contains('appId is required'));
+      responses.close();
+      commands.close();
+    });
+
     _testUsingContext('daemon.stop', () async {
       DaemonCommand command = new DaemonCommand();
       applyMocksToCommand(command);


### PR DESCRIPTION
Allow daemon clients to call service extensions (via `app.callServiceExtension`); this lets clients call things like `ext.flutter.debugPaint`.

@danrubel, @johnmccutchan 
