### PR TITLE
Rename RawInput to EditableText

### DIFF
--- a/packages/flutter/lib/src/material/input.dart
+++ b/packages/flutter/lib/src/material/input.dart
@@ -38,7 +38,7 @@ const Curve _kTransitionCurve = Curves.fastOutSlowIn;
 ///
 /// * [Input], which adds a label, a divider below the text field, and support for
 ///   an error message.
-/// * [RawInput], a text field that does not require [Material] design.
+/// * [EditableText], a text field that does not require [Material] design.
 class InputField extends StatefulWidget {
   InputField({
     Key key,
@@ -96,13 +96,13 @@ class InputField extends StatefulWidget {
 }
 
 class _InputFieldState extends State<InputField> {
-  GlobalKey<RawInputState> _rawInputKey = new GlobalKey<RawInputState>();
-  GlobalKey<RawInputState> _focusKey = new GlobalKey(debugLabel: "_InputFieldState _focusKey");
+  GlobalKey<EditableTextState> _editableTextKey = new GlobalKey<EditableTextState>();
+  GlobalKey<EditableTextState> _focusKey = new GlobalKey(debugLabel: "_InputFieldState _focusKey");
 
   GlobalKey get focusKey => config.focusKey ?? (config.key is GlobalKey ? config.key : _focusKey);
 
   void requestKeyboard() {
-    _rawInputKey.currentState?.requestKeyboard();
+    _editableTextKey.currentState?.requestKeyboard();
   }
 
   @override
@@ -120,13 +120,13 @@ class _InputFieldState extends State<InputField> {
           requestKeyboard();
         },
         // Since the focusKey may have been created here, defer building the
-        // RawInput until the focusKey's context has been set. This is necessary
-        // because the RawInput will check the focus, like Focus.at(focusContext),
-        // when it builds.
+        // EditableText until the focusKey's context has been set. This is
+        // necessary because the EditableText will check the focus, like
+        // Focus.at(focusContext), when it builds.
         child: new Builder(
           builder: (BuildContext context) {
-            return new RawInput(
-              key: _rawInputKey,
+            return new EditableText(
+              key: _editableTextKey,
               value: value,
               focusKey: focusKey,
               style: textStyle,

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -50,7 +50,7 @@ TextEditingState _getTextEditingStateFromInputValue(InputValue value) {
   );
 }
 
-/// Configuration information for an input field.
+/// Configuration information for a text input field.
 ///
 /// An [InputValue] contains the text for the input field as well as the
 /// selection extent and the composing range.
@@ -118,15 +118,28 @@ class InputValue {
   }
 }
 
-/// A basic text input control.
+/// A basic text input field.
 ///
-/// This control is not intended to be used directly. Instead, consider using
-/// [Input], which provides focus management and material design.
-class RawInput extends Scrollable {
+/// This widget interacts with the [TextInput] service to let the user edit the
+/// text it contains. It also provides scrolling, selection, and cursor
+/// movement. This widget does not provide any focus management (e.g.,
+/// tap-to-focus).
+///
+/// Rather than using this widget directly, consider using [InputField], which
+/// adds tap-to-focus and cut, copy, and paste commands, or [TextField], which
+/// is a full-featured, material-design text input field with placeholder text,
+/// labels, and [Form] integration.
+///
+/// See also:
+///
+///  * [InputField], which adds tap-to-focus and cut, copy, and paste commands.
+///  * [TextField], which is a full-featured, material-design text input field
+///    with placeholder text, labels, and [Form] integration.
+class EditableText extends Scrollable {
   /// Creates a basic text input control.
   ///
   /// The [value] argument must not be null.
-  RawInput({
+  EditableText({
     Key key,
     @required this.value,
     this.focusKey,
@@ -205,11 +218,11 @@ class RawInput extends Scrollable {
   final ValueChanged<InputValue> onSubmitted;
 
   @override
-  RawInputState createState() => new RawInputState();
+  EditableTextState createState() => new EditableTextState();
 }
 
-/// State for a [RawInput].
-class RawInputState extends ScrollableState<RawInput> implements TextInputClient {
+/// State for a [EditableText].
+class EditableTextState extends ScrollableState<EditableText> implements TextInputClient {
   Timer _cursorTimer;
   bool _showCursor = false;
 
@@ -230,7 +243,7 @@ class RawInputState extends ScrollableState<RawInput> implements TextInputClient
   }
 
   @override
-  void didUpdateConfig(RawInput oldConfig) {
+  void didUpdateConfig(EditableText oldConfig) {
     if (_currentValue != config.value) {
       _currentValue = config.value;
       if (_isAttachedToKeyboard)
@@ -280,7 +293,7 @@ class RawInputState extends ScrollableState<RawInput> implements TextInputClient
   }
 
   // True if the focus was explicitly requested last frame. This ensures we
-  // don't show the keyboard when focus defaults back to the RawInput.
+  // don't show the keyboard when focus defaults back to the EditableText.
   bool _requestingFocus = false;
 
   void _attachOrDetachKeyboard(bool focused) {

--- a/packages/flutter/lib/src/widgets/raw_keyboard_listener.dart
+++ b/packages/flutter/lib/src/widgets/raw_keyboard_listener.dart
@@ -14,17 +14,17 @@ import 'framework.dart';
 /// hardware buttons that are represented as keys. Typically used by games and
 /// other apps that use keyboards for purposes other than text entry.
 ///
-/// For text entry, consider using a [RawInput], which integrates with
+/// For text entry, consider using a [EditableText], which integrates with
 /// on-screen keyboards and input method editors (IMEs).
 ///
 /// See also:
 ///
-///  * [RawInput], which should be used instead of this widget for text
+///  * [EditableText], which should be used instead of this widget for text
 ///    entry.
 class RawKeyboardListener extends StatefulWidget {
   /// Creates a widget that receives raw keyboard events.
   ///
-  /// For text entry, consider using a [RawInput], which integrates with
+  /// For text entry, consider using a [EditableText], which integrates with
   /// on-screen keyboards and input method editors (IMEs).
   RawKeyboardListener({
     Key key,

--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -8,7 +8,7 @@ import 'package:flutter/scheduler.dart';
 
 import 'basic.dart';
 import 'container.dart';
-import 'editable.dart';
+import 'editable_text.dart';
 import 'framework.dart';
 import 'gesture_detector.dart';
 import 'overlay.dart';

--- a/packages/flutter/lib/widgets.dart
+++ b/packages/flutter/lib/widgets.dart
@@ -18,7 +18,7 @@ export 'src/widgets/container.dart';
 export 'src/widgets/debug.dart';
 export 'src/widgets/dismissable.dart';
 export 'src/widgets/drag_target.dart';
-export 'src/widgets/editable.dart';
+export 'src/widgets/editable_text.dart';
 export 'src/widgets/focus.dart';
 export 'src/widgets/form.dart';
 export 'src/widgets/framework.dart';

--- a/packages/flutter/test/widgets/form_test.dart
+++ b/packages/flutter/test/widgets/form_test.dart
@@ -15,7 +15,7 @@ void main() {
   }
 
   Future<Null> showKeyboard(WidgetTester tester) async {
-    RawInputState editable = tester.state(find.byType(RawInput).first);
+    EditableTextState editable = tester.state(find.byType(EditableText).first);
     editable.requestKeyboard();
     await tester.pump();
   }
@@ -207,7 +207,7 @@ void main() {
     expect(mockTextInput.editingState['text'], equals(initialValue));
 
     // initial value should also be visible in the raw input line
-    RawInputState editableText = tester.state(find.byType(RawInput));
+    EditableTextState editableText = tester.state(find.byType(EditableText));
     expect(editableText.config.value.text, equals(initialValue));
 
     // sanity check, make sure we can still edit the text and everything updates

--- a/packages/flutter/test/widgets/input_test.dart
+++ b/packages/flutter/test/widgets/input_test.dart
@@ -62,14 +62,14 @@ void main() {
   }
 
   Future<Null> showKeyboard(WidgetTester tester) async {
-    RawInputState editable = tester.state(find.byType(RawInput).first);
+    EditableTextState editable = tester.state(find.byType(EditableText).first);
     editable.requestKeyboard();
     await tester.pump();
   }
 
   // Returns the first RenderEditable.
   RenderEditable findRenderEditable(WidgetTester tester) {
-    RenderObject root = tester.renderObject(find.byType(RawInput));
+    RenderObject root = tester.renderObject(find.byType(EditableText));
     expect(root, isNotNull);
 
     RenderEditable renderEditable;
@@ -154,7 +154,7 @@ void main() {
     await tester.pumpWidget(builder());
     await showKeyboard(tester);
 
-    RawInputState editableText = tester.state(find.byType(RawInput));
+    EditableTextState editableText = tester.state(find.byType(EditableText));
 
     // Check that the cursor visibility toggles after each blink interval.
     Future<Null> checkCursorToggle() async {


### PR DESCRIPTION
This patch is part of a series to rationalize our text input classes.

See #7031