### PR TITLE
Prevent overlapping hero transitions from starting

### DIFF
--- a/packages/flutter/lib/src/widgets/heroes.dart
+++ b/packages/flutter/lib/src/widgets/heroes.dart
@@ -493,7 +493,7 @@ class HeroController extends NavigatorObserver {
   void didPush(Route<dynamic> route, Route<dynamic> previousRoute) {
     assert(navigator != null);
     assert(route != null);
-    if (route is PageRoute<dynamic>) {
+    if (_questsEnabled && route is PageRoute<dynamic>) {
       assert(route.animation != null);
       if (previousRoute is PageRoute<dynamic>) // could be null
         _from = previousRoute;
@@ -507,7 +507,7 @@ class HeroController extends NavigatorObserver {
   void didPop(Route<dynamic> route, Route<dynamic> previousRoute) {
     assert(navigator != null);
     assert(route != null);
-    if (route is PageRoute<dynamic>) {
+    if (_questsEnabled && route is PageRoute<dynamic>) {
       assert(route.animation != null);
       if (route.animation.status != AnimationStatus.dismissed && previousRoute is PageRoute<dynamic>) {
         _from = route;
@@ -532,9 +532,11 @@ class HeroController extends NavigatorObserver {
   }
 
   void _checkForHeroQuest() {
-    if (_from != null && _to != null && _from != _to && _questsEnabled) {
+    assert(_questsEnabled);
+    if (_from != null && _to != null && _from != _to) {
       assert(_animation != null);
       _to.offstage = _to.animation.status != AnimationStatus.completed;
+      _questsEnabled = false;
       WidgetsBinding.instance.addPostFrameCallback(_updateQuest);
     } else {
       // this isn't a valid quest
@@ -544,6 +546,8 @@ class HeroController extends NavigatorObserver {
 
   void _handleQuestFinished() {
     _removeHeroesFromOverlay();
+    assert(!_questsEnabled);
+    _questsEnabled = true;
   }
 
   Rect _getAnimationArea(BuildContext context) {
@@ -571,6 +575,7 @@ class HeroController extends NavigatorObserver {
   }
 
   void _updateQuest(Duration timeStamp) {
+    assert(!_questsEnabled);
     if (navigator == null) {
       // The navigator was removed before this end-of-frame callback was called.
       _clearPendingHeroQuest();

--- a/packages/flutter/lib/src/widgets/heroes.dart
+++ b/packages/flutter/lib/src/widgets/heroes.dart
@@ -546,8 +546,6 @@ class HeroController extends NavigatorObserver {
 
   void _handleQuestFinished() {
     _removeHeroesFromOverlay();
-    assert(!_questsEnabled);
-    _questsEnabled = true;
   }
 
   Rect _getAnimationArea(BuildContext context) {
@@ -609,6 +607,7 @@ class HeroController extends NavigatorObserver {
       );
     }
 
+    _questsEnabled = true;
     _clearPendingHeroQuest();
   }
 

--- a/packages/flutter/lib/src/widgets/heroes.dart
+++ b/packages/flutter/lib/src/widgets/heroes.dart
@@ -607,7 +607,7 @@ class HeroController extends NavigatorObserver {
       );
     }
 
-    _questsEnabled = true;
+    //_questsEnabled = true;
     _clearPendingHeroQuest();
   }
 
@@ -615,5 +615,6 @@ class HeroController extends NavigatorObserver {
     _from = null;
     _to = null;
     _animation = null;
+    _questsEnabled = true;
   }
 }

--- a/packages/flutter/lib/src/widgets/heroes.dart
+++ b/packages/flutter/lib/src/widgets/heroes.dart
@@ -607,7 +607,6 @@ class HeroController extends NavigatorObserver {
       );
     }
 
-    //_questsEnabled = true;
     _clearPendingHeroQuest();
   }
 

--- a/packages/flutter/test/widgets/navigator_test.dart
+++ b/packages/flutter/test/widgets/navigator_test.dart
@@ -66,6 +66,29 @@ class ThirdWidget extends StatelessWidget {
   }
 }
 
+class OnTapPage extends StatelessWidget {
+  OnTapPage({ Key key, this.id, this.onTap }) : super(key: key);
+
+  final String id;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return new Scaffold(
+      appBar: new AppBar(title: new Text('Page $id')),
+      body: new GestureDetector(
+        onTap: onTap,
+        behavior: HitTestBehavior.opaque,
+        child: new Container(
+          child: new Center(
+            child: new Text(id, style: Theme.of(context).textTheme.display2),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
 void main() {
   testWidgets('Can navigator navigate to and from a stateful widget', (WidgetTester tester) async {
     final Map<String, WidgetBuilder> routes = <String, WidgetBuilder>{
@@ -209,4 +232,32 @@ void main() {
   //   await gesture.up();
   //   expect(log, equals(<String>['left']));
   // });
+
+  testWidgets('popAndPushNamed', (WidgetTester tester) async {
+    final Map<String, WidgetBuilder> routes = <String, WidgetBuilder>{
+       '/': (BuildContext context) => new OnTapPage(id: '/', onTap: () { Navigator.pushNamed(context, '/A'); }),
+      '/A': (BuildContext context) => new OnTapPage(id: 'A', onTap: () { Navigator.popAndPushNamed(context, '/B'); }),
+      '/B': (BuildContext context) => new OnTapPage(id: 'B', onTap: () { Navigator.pop(context); }),
+    };
+
+    await tester.pumpWidget(new MaterialApp(routes: routes));
+    expect(find.text('/'), findsOneWidget);
+    expect(find.text('A', skipOffstage: false), findsNothing);
+    expect(find.text('B', skipOffstage: false), findsNothing);
+
+    await tester.tap(find.text('/'));
+    await tester.pump();
+    await tester.pump(const Duration(seconds: 1));
+    expect(find.text('/'), findsNothing);
+    expect(find.text('A'), findsOneWidget);
+    expect(find.text('B'), findsNothing);
+
+    await tester.tap(find.text('A'));
+    await tester.pump();
+    await tester.pump(const Duration(seconds: 1));
+    expect(find.text('/'), findsNothing);
+    expect(find.text('A'), findsNothing);
+    expect(find.text('B'), findsOneWidget);
+
+  });
 }

--- a/packages/flutter/test/widgets/page_forward_transitions_test.dart
+++ b/packages/flutter/test/widgets/page_forward_transitions_test.dart
@@ -140,10 +140,7 @@ void main() {
     navigator.pushNamed('/3');
     expect(state(), equals('BDE')); // transition 1<-2 is at 0.6
     await tester.pump();
-    // This check depends on route '/3' being move offstage by the HeroController's
-    // NavigatorObserver. Currently we don't support two Hero transitions running at once.
-    // TODO(hansmuller): restore this check.
-    // expect(state(), equals('BDE')); // transition 1<-2 is at 0.6, 1->3 is at 0.0
+    expect(state(), equals('BDE')); // transition 1<-2 is at 0.6, 1->3 is at 0.0
     expect(state(skipOffstage: false), equals('BDEF')); // F is offstage since we're at 0.0
 
     await tester.pump(kFourTenthsOfTheTransitionDuration);
@@ -167,10 +164,7 @@ void main() {
     navigator.pushNamed('/4');
     expect(state(), equals('BCF')); // transition 1<-3 is at 0.2, 1->4 is not yet built
     await tester.pump();
-    // This check depends on route '/4' being move offstage by the HeroController's
-    // NavigatorObserver. Currently we don't support two Hero transitions running at once.
-    // TODO(hansmuller): restore this check.
-    // expect(state(), equals('BCF')); // transition 1<-3 is at 0.2, 1->4 is at 0.0
+    expect(state(), equals('BCF')); // transition 1<-3 is at 0.2, 1->4 is at 0.0
     expect(state(skipOffstage: false), equals('BCFG')); // G is offstage
 
     await tester.pump(kFourTenthsOfTheTransitionDuration);

--- a/packages/flutter/test/widgets/page_forward_transitions_test.dart
+++ b/packages/flutter/test/widgets/page_forward_transitions_test.dart
@@ -142,7 +142,7 @@ void main() {
     await tester.pump();
     // This check depends on route '/3' being move offstage by the HeroController's
     // NavigatorObserver. Currently we don't support two Hero transitions running at once.
-    // TODO(hansmuller) : restore this check.
+    // TODO(hansmuller): restore this check.
     // expect(state(), equals('BDE')); // transition 1<-2 is at 0.6, 1->3 is at 0.0
     expect(state(skipOffstage: false), equals('BDEF')); // F is offstage since we're at 0.0
 
@@ -169,7 +169,7 @@ void main() {
     await tester.pump();
     // This check depends on route '/4' being move offstage by the HeroController's
     // NavigatorObserver. Currently we don't support two Hero transitions running at once.
-    // TODO(hansmuller) : restore this check.
+    // TODO(hansmuller): restore this check.
     // expect(state(), equals('BCF')); // transition 1<-3 is at 0.2, 1->4 is at 0.0
     expect(state(skipOffstage: false), equals('BCFG')); // G is offstage
 

--- a/packages/flutter/test/widgets/page_forward_transitions_test.dart
+++ b/packages/flutter/test/widgets/page_forward_transitions_test.dart
@@ -140,7 +140,10 @@ void main() {
     navigator.pushNamed('/3');
     expect(state(), equals('BDE')); // transition 1<-2 is at 0.6
     await tester.pump();
-    expect(state(), equals('BDE')); // transition 1<-2 is at 0.6, 1->3 is at 0.0
+    // This check depends on route '/3' being move offstage by the HeroController's
+    // NavigatorObserver. Currently we don't support two Hero transitions running at once.
+    // TODO(hansmuller) : restore this check.
+    // expect(state(), equals('BDE')); // transition 1<-2 is at 0.6, 1->3 is at 0.0
     expect(state(skipOffstage: false), equals('BDEF')); // F is offstage since we're at 0.0
 
     await tester.pump(kFourTenthsOfTheTransitionDuration);
@@ -164,7 +167,10 @@ void main() {
     navigator.pushNamed('/4');
     expect(state(), equals('BCF')); // transition 1<-3 is at 0.2, 1->4 is not yet built
     await tester.pump();
-    expect(state(), equals('BCF')); // transition 1<-3 is at 0.2, 1->4 is at 0.0
+    // This check depends on route '/4' being move offstage by the HeroController's
+    // NavigatorObserver. Currently we don't support two Hero transitions running at once.
+    // TODO(hansmuller) : restore this check.
+    // expect(state(), equals('BCF')); // transition 1<-3 is at 0.2, 1->4 is at 0.0
     expect(state(skipOffstage: false), equals('BCFG')); // G is offstage
 
     await tester.pump(kFourTenthsOfTheTransitionDuration);


### PR DESCRIPTION
Currently the HeroController's NavigatorObserver only supports one hero transition at a time.

We do need to enable running multiple overlapping hero transitions. See https://github.com/flutter/flutter/issues/5798.

This provisional change just quietly disables the second and subequent overlapping hero transitions so that Navigator operations like popAndPushNamed() will succeed.

Fixes: https://github.com/flutter/flutter/issues/7203
