### PR TITLE
Add operator== and hashCode to TextTheme

### DIFF
--- a/packages/flutter/lib/src/material/typography.dart
+++ b/packages/flutter/lib/src/material/typography.dart
@@ -277,6 +277,43 @@ class TextTheme {
       button: TextStyle.lerp(begin.button, end.button, t)
     );
   }
+
+  @override
+  bool operator ==(dynamic other) {
+    if (identical(this, other))
+      return true;
+    if (other is! TextTheme)
+      return false;
+    final TextTheme typedOther = other;
+    return display4 == typedOther.display4 &&
+           display3 == typedOther.display3 &&
+           display2 == typedOther.display2 &&
+           display1 == typedOther.display1 &&
+           headline == typedOther.headline &&
+           title == typedOther.title &&
+           subhead == typedOther.subhead &&
+           body2 == typedOther.body2 &&
+           body1 == typedOther.body1 &&
+           caption == typedOther.caption &&
+           button == typedOther.button;
+  }
+
+  @override
+  int get hashCode {
+    return hashValues(
+      display4,
+      display3,
+      display2,
+      display1,
+      headline,
+      title,
+      subhead,
+      body2,
+      body1,
+      caption,
+      button,
+    );
+  }
 }
 
 /// The two material design text themes.

--- a/packages/flutter/test/material/theme_test.dart
+++ b/packages/flutter/test/material/theme_test.dart
@@ -6,6 +6,13 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
+  test('ThemeDataTween control test', () {
+    ThemeData light = new ThemeData.light();
+    ThemeData dark = new ThemeData.light();
+    ThemeDataTween tween = new ThemeDataTween(begin: light, end: dark);
+    expect(tween.lerp(0.25), equals(ThemeData.lerp(light, dark, 0.25)));
+  });
+
   testWidgets('PopupMenu inherits app theme', (WidgetTester tester) async {
     final Key popupMenuButtonKey = new UniqueKey();
     await tester.pumpWidget(

--- a/packages/flutter/test/material/typography_test.dart
+++ b/packages/flutter/test/material/typography_test.dart
@@ -6,6 +6,14 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
+  test('TextTheme control test', () {
+    Typography typography = new Typography(platform: TargetPlatform.android);
+    expect(typography.black, equals(typography.black.copyWith()));
+    expect(typography.black, equals(typography.black.apply()));
+    expect(typography.black.hashCode, equals(typography.black.copyWith().hashCode));
+    expect(typography.black, isNot(equals(typography.white)));
+  });
+
   test('Typography is defined for all target platforms', () {
     for (TargetPlatform platform in TargetPlatform.values) {
       Typography typography = new Typography(platform: platform);

--- a/packages/flutter/test/widgets/animated_container_test.dart
+++ b/packages/flutter/test/widgets/animated_container_test.dart
@@ -7,6 +7,23 @@ import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 
 void main() {
+  testWidgets('AnimatedContainer.debugFillDescription', (WidgetTester tester) async {
+    AnimatedContainer container = new AnimatedContainer(
+      constraints: const BoxConstraints.tightFor(width: 17.0, height: 23.0),
+      decoration: const BoxDecoration(backgroundColor: const Color(0xFF00FF00)),
+      foregroundDecoration: const BoxDecoration(backgroundColor: const Color(0x7F0000FF)),
+      margin: const EdgeInsets.all(10.0),
+      padding: const EdgeInsets.all(7.0),
+      transform: new Matrix4.translationValues(4.0, 3.0, 0.0),
+      width: 50.0,
+      height: 75.0,
+      curve: Curves.ease,
+      duration: const Duration(milliseconds: 200),
+    );
+
+    expect(container, hasOneLineDescription);
+  });
+
   testWidgets('AnimatedContainer control test', (WidgetTester tester) async {
     GlobalKey key = new GlobalKey();
 

--- a/packages/flutter/test/widgets/animated_positioned_test.dart
+++ b/packages/flutter/test/widgets/animated_positioned_test.dart
@@ -7,6 +7,19 @@ import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 
 void main() {
+  testWidgets('AnimatedPositioned.fromRect control test', (WidgetTester tester) async {
+    AnimatedPositioned positioned = new AnimatedPositioned.fromRect(
+      rect: new Rect.fromLTWH(7.0, 5.0, 12.0, 16.0),
+      duration: const Duration(milliseconds: 200),
+    );
+
+    expect(positioned.left, equals(7.0));
+    expect(positioned.top, equals(5.0));
+    expect(positioned.width, equals(12.0));
+    expect(positioned.height, equals(16.0));
+    expect(positioned, hasOneLineDescription);
+  });
+
   testWidgets('AnimatedPositioned - basics', (WidgetTester tester) async {
     GlobalKey key = new GlobalKey();
 

--- a/packages/flutter/test/widgets/container_test.dart
+++ b/packages/flutter/test/widgets/container_test.dart
@@ -5,7 +5,50 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/widgets.dart';
 
+import '../rendering/mock_canvas.dart';
+
 void main() {
+  testWidgets('Container control test', (WidgetTester tester) async {
+    Container container = new Container(
+      alignment: FractionalOffset.bottomRight,
+      padding: const EdgeInsets.all(7.0),
+      decoration: const BoxDecoration(backgroundColor: const Color(0xFF00FF00)),
+      foregroundDecoration: const BoxDecoration(backgroundColor: const Color(0x7F0000FF)),
+      width: 53.0,
+      height: 76.0,
+      constraints: const BoxConstraints(
+        minWidth: 50.0,
+        maxWidth: 55.0,
+        minHeight: 78.0,
+        maxHeight: 82.0,
+      ),
+      margin: const EdgeInsets.all(5.0),
+      child: new SizedBox(
+        width: 25.0,
+        height: 33.0,
+        child: new DecoratedBox(
+          decoration: const BoxDecoration(backgroundColor: const Color(0xFFFFFF00)),
+        ),
+      ),
+    );
+
+    expect(container, hasOneLineDescription);
+
+    await tester.pumpWidget(new Align(
+      alignment: FractionalOffset.topLeft,
+      child: container
+    ));
+
+    RenderBox box = tester.renderObject(find.byType(Container));
+    expect(box, isNotNull);
+
+    expect(box, paints
+      ..rect(rect: new Rect.fromLTWH(5.0, 5.0, 53.0, 78.0), color: const Color(0xFF00FF00))
+      ..rect(rect: new Rect.fromLTWH(26.0, 43.0, 25.0, 33.0), color: const Color(0xFFFFFF00))
+      ..rect(rect: new Rect.fromLTWH(5.0, 5.0, 53.0, 78.0), color: const Color(0x7F0000FF))
+    );
+  });
+
   testWidgets('Can be placed in an infinite box', (WidgetTester tester) async {
     await tester.pumpWidget(new Block(children: <Widget>[new Container()]));
   });

--- a/packages/flutter/test/widgets/locale_query_test.dart
+++ b/packages/flutter/test/widgets/locale_query_test.dart
@@ -1,0 +1,32 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter/widgets.dart';
+
+class TestLocaleQueryData extends LocaleQueryData {
+  @override
+  String toString() => 'Test data';
+}
+
+void main() {
+  testWidgets('LocaleQuery control test', (WidgetTester tester) async {
+    await tester.pumpWidget(new Container());
+
+    expect(LocaleQuery.of(tester.element(find.byType(Container))), isNull);
+
+    LocaleQueryData data = new TestLocaleQueryData();
+    Widget widget = new LocaleQuery(
+      data: data,
+      child: new Container(),
+    );
+
+    expect(widget, hasOneLineDescription);
+    expect(widget.toString(), contains('Test data'));
+
+    await tester.pumpWidget(widget);
+
+    expect(LocaleQuery.of(tester.element(find.byType(Container))), equals(data));
+  });
+}


### PR DESCRIPTION
Teach `paints` matches about `drawRect` and how to `paintChild`.

Also, improve test coverage.