### PR TITLE
Factor out debugPaintPadding and test it

### DIFF
--- a/packages/flutter/lib/src/painting/basic_types.dart
+++ b/packages/flutter/lib/src/painting/basic_types.dart
@@ -17,6 +17,7 @@ export 'dart:ui' show
   Paint,
   PaintingStyle,
   Path,
+  PathFillType,
   Point,
   Radius,
   RRect,

--- a/packages/flutter/lib/src/rendering/debug.dart
+++ b/packages/flutter/lib/src/rendering/debug.dart
@@ -31,12 +31,22 @@ Color debugPaintSizeColor = _kDebugPaintSizeColor;
 
 /// The color to use when painting some boxes that just add space (e.g. an empty
 /// RenderConstrainedBox or RenderPadding).
+///
+/// Used by, among other methods, [debugPaintPadding], which is called by
+/// [RenderPadding.debugPaintSize] when [debugPaintSizeEnabled] is true.
 Color debugPaintSpacingColor = _kDebugPaintSpacingColor;
 
 /// The color to use when painting RenderPadding edges.
+///
+/// Used by, among other methods, [debugPaintPadding], which is called by
+/// [RenderPadding.debugPaintSize] when [debugPaintSizeEnabled] is true.
 Color debugPaintPaddingColor = _kDebugPaintPaddingColor;
 
-/// The color to use when painting RenderPadding edges.
+/// The color to use when painting RenderPadding edges. This color is painted on
+/// top of [debugPaintPaddingColor].
+///
+/// Used by, among other methods, [debugPaintPadding], which is called by
+/// [RenderPadding.debugPaintSize] when [debugPaintSizeEnabled] is true.
 Color debugPaintPaddingInnerEdgeColor = _kDebugPaintPaddingInnerEdgeColor;
 
 /// The color to use when painting the arrows used to show RenderPositionedBox alignment.
@@ -103,6 +113,35 @@ List<String> debugDescribeTransform(Matrix4 transform) {
   List<String> matrix = transform.toString().split('\n').map((String s) => '  $s').toList();
   matrix.removeLast();
   return matrix;
+}
+
+void _debugDrawDoubleRect(Canvas canvas, Rect outerRect, Rect innerRect, Color color) {
+  final Path path = new Path()
+    ..fillType = PathFillType.evenOdd
+    ..addRect(outerRect)
+    ..addRect(innerRect);
+  final Paint paint = new Paint()
+    ..color = color;
+  canvas.drawPath(path, paint);
+}
+
+/// Paint padding using the [debugPaintPaddingColor],
+/// [debugPaintPaddingInnerEdgeColor], and [debugPaintSpacingColor] colors.
+///
+/// Called by [RenderPadding.debugPaintSize] when [debugPaintSizeEnabled] is
+/// true.
+void debugPaintPadding(Canvas canvas, Rect outerRect, Rect innerRect, { double outlineWidth: 2.0 }) {
+  assert(() {
+    if (innerRect != null && !innerRect.isEmpty) {
+      _debugDrawDoubleRect(canvas, outerRect, innerRect, debugPaintPaddingColor);
+      _debugDrawDoubleRect(canvas, innerRect.inflate(outlineWidth).intersect(outerRect), innerRect, debugPaintPaddingInnerEdgeColor);
+    } else {
+      final Paint paint = new Paint()
+        ..color = debugPaintSpacingColor;
+      canvas.drawRect(outerRect, paint);
+    }
+    return true;
+  });
 }
 
 /// Returns true if none of the rendering library debug variables have been changed.

--- a/packages/flutter/lib/src/rendering/shifted_box.dart
+++ b/packages/flutter/lib/src/rendering/shifted_box.dart
@@ -172,43 +172,8 @@ class RenderPadding extends RenderShiftedBox {
   void debugPaintSize(PaintingContext context, Offset offset) {
     super.debugPaintSize(context, offset);
     assert(() {
-      Paint paint;
-      if (child != null && !child.size.isEmpty) {
-        Path path;
-        paint = new Paint()
-          ..color = debugPaintPaddingColor;
-        path = new Path()
-          ..moveTo(offset.dx, offset.dy)
-          ..lineTo(offset.dx + size.width, offset.dy)
-          ..lineTo(offset.dx + size.width, offset.dy + size.height)
-          ..lineTo(offset.dx, offset.dy + size.height)
-          ..close()
-          ..moveTo(offset.dx + padding.left, offset.dy + padding.top)
-          ..lineTo(offset.dx + padding.left, offset.dy + size.height - padding.bottom)
-          ..lineTo(offset.dx + size.width - padding.right, offset.dy + size.height - padding.bottom)
-          ..lineTo(offset.dx + size.width - padding.right, offset.dy + padding.top)
-          ..close();
-        context.canvas.drawPath(path, paint);
-        paint = new Paint()
-          ..color = debugPaintPaddingInnerEdgeColor;
-        const double kOutline = 2.0;
-        path = new Path()
-          ..moveTo(offset.dx + math.max(padding.left - kOutline, 0.0), offset.dy + math.max(padding.top - kOutline, 0.0))
-          ..lineTo(offset.dx + math.min(size.width - padding.right + kOutline, size.width), offset.dy + math.max(padding.top - kOutline, 0.0))
-          ..lineTo(offset.dx + math.min(size.width - padding.right + kOutline, size.width), offset.dy + math.min(size.height - padding.bottom + kOutline, size.height))
-          ..lineTo(offset.dx + math.max(padding.left - kOutline, 0.0), offset.dy + math.min(size.height - padding.bottom + kOutline, size.height))
-          ..close()
-          ..moveTo(offset.dx + padding.left, offset.dy + padding.top)
-          ..lineTo(offset.dx + padding.left, offset.dy + size.height - padding.bottom)
-          ..lineTo(offset.dx + size.width - padding.right, offset.dy + size.height - padding.bottom)
-          ..lineTo(offset.dx + size.width - padding.right, offset.dy + padding.top)
-          ..close();
-        context.canvas.drawPath(path, paint);
-      } else {
-        paint = new Paint()
-          ..color = debugPaintSpacingColor;
-        context.canvas.drawRect(offset & size, paint);
-      }
+      final Rect outerRect = offset & size;
+      debugPaintPadding(context.canvas, outerRect, child != null ? padding.deflateRect(outerRect) : null);
       return true;
     });
   }

--- a/packages/flutter/test/material/mergeable_material_test.dart
+++ b/packages/flutter/test/material/mergeable_material_test.dart
@@ -203,13 +203,14 @@ void main() {
       )
     );
 
-    RenderBox box = tester.renderObject(find.byType(MergeableMaterial));
-
     final BoxShadow boxShadow = kElevationToShadow[2][0];
     final RRect rrect = kMaterialEdges[MaterialType.card].toRRect(
       new Rect.fromLTRB(0.0, 0.0, 800.0, 100.0)
     );
-    expect(box, paints..rrect(rrect: rrect, color: boxShadow.color, hasMaskFilter: true));
+    expect(
+      find.byType(MergeableMaterial),
+      paints..rrect(rrect: rrect, color: boxShadow.color, hasMaskFilter: true),
+    );
   });
 
   testWidgets('MergeableMaterial merge gap', (WidgetTester tester) async {

--- a/packages/flutter/test/rendering/debug_test.dart
+++ b/packages/flutter/test/rendering/debug_test.dart
@@ -6,8 +6,10 @@ import 'package:flutter/rendering.dart';
 import 'package:test/test.dart';
 import 'package:vector_math/vector_math_64.dart';
 
+import 'mock_canvas.dart';
+
 void main() {
-  test("Describe transform control test", () {
+  test('Describe transform control test', () {
     Matrix4 identity = new Matrix4.identity();
     List<String> description = debugDescribeTransform(identity);
     expect(description, equals(<String>[
@@ -16,5 +18,17 @@ void main() {
       '  [2] 0.0,0.0,1.0,0.0',
       '  [3] 0.0,0.0,0.0,1.0',
     ]));
+  });
+
+  test('debugPaintPadding', () {
+    expect((Canvas canvas) {
+      debugPaintPadding(canvas, new Rect.fromLTRB(10.0, 10.0, 20.0, 20.0), null);
+    }, paints..rect(color: debugPaintSpacingColor));
+    expect((Canvas canvas) {
+      debugPaintPadding(canvas, new Rect.fromLTRB(10.0, 10.0, 20.0, 20.0), new Rect.fromLTRB(11.0, 11.0, 19.0, 19.0));
+    }, paints..path(color: debugPaintPaddingColor)..path(color: debugPaintPaddingInnerEdgeColor));
+    expect((Canvas canvas) {
+      debugPaintPadding(canvas, new Rect.fromLTRB(10.0, 10.0, 20.0, 20.0), new Rect.fromLTRB(15.0, 15.0, 15.0, 15.0));
+    }, paints..rect(rect: new Rect.fromLTRB(10.0, 10.0, 20.0, 20.0), color: debugPaintSpacingColor));
   });
 }


### PR DESCRIPTION
I plan to use this to implement similar logic in SliverPadding.

To make this easier to test I extended the paints matcher to accept a
function that takes a canvas. While I was at it I also made it accept
a Finder, it'll go and find the render object for you.

Also added support for paints..path and fixed some grammar in the
error messages.

Also improved the docs for debugPaint*.