### PR TITLE
Add Navigator.pushReplacement() and Navigator.pushReplacementNamed()

### DIFF
--- a/packages/flutter/lib/src/widgets/navigator.dart
+++ b/packages/flutter/lib/src/widgets/navigator.dart
@@ -695,6 +695,19 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin {
 
   bool _debugLocked = false; // used to prevent re-entrant calls to push, pop, and friends
 
+  Route<dynamic> _routeNamed(String name) {
+    assert(!_debugLocked);
+    assert(name != null);
+    final RouteSettings settings = new RouteSettings(name: name);
+    Route<dynamic> route = config.onGenerateRoute(settings);
+    if (route == null) {
+      assert(config.onUnknownRoute != null);
+      route = config.onUnknownRoute(settings);
+      assert(route != null);
+    }
+    return route;
+  }
+
   /// Push a named route onto the navigator.
   ///
   /// The route name will be passed to [Navigator.onGenerateRoute]. The returned
@@ -709,16 +722,7 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin {
   /// Navigator.of(context).pushNamed('/nyc/1776');
   /// ```
   Future<dynamic> pushNamed(String name) {
-    assert(!_debugLocked);
-    assert(name != null);
-    RouteSettings settings = new RouteSettings(name: name);
-    Route<dynamic> route = config.onGenerateRoute(settings);
-    if (route == null) {
-      assert(config.onUnknownRoute != null);
-      route = config.onUnknownRoute(settings);
-      assert(route != null);
-    }
-    return push(route);
+    return push(_routeNamed(name));
   }
 
   /// Adds the given route to the navigator's history, and transitions to it.
@@ -777,7 +781,7 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin {
     setState(() {
       int index = _history.length - 1;
       assert(index >= 0);
-      assert(indexOf(oldRoute) == index);
+      assert(_history.indexOf(oldRoute) == index);
       newRoute._navigator = this;
       newRoute.install(oldRoute.overlayEntries.last);
       _history[index] = newRoute;
@@ -844,16 +848,7 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin {
   /// Returns a [Future] that completes to the `result` value passed to [pop]
   /// when the pushed route is popped off the navigator.
   Future<dynamic> pushReplacementNamed(String name, { dynamic result }) {
-    assert(!_debugLocked);
-    assert(name != null);
-    final RouteSettings settings = new RouteSettings(name: name);
-    Route<dynamic> newRoute = config.onGenerateRoute(settings);
-    if (newRoute == null) {
-      assert(config.onUnknownRoute != null);
-      newRoute = config.onUnknownRoute(settings);
-      assert(newRoute != null);
-    }
-    return pushReplacement(newRoute, result: result);
+    return pushReplacement(_routeNamed(name), result: result);
   }
 
   /// Replaces a route that is not currently visible with a new route.

--- a/packages/flutter/lib/src/widgets/navigator.dart
+++ b/packages/flutter/lib/src/widgets/navigator.dart
@@ -779,9 +779,8 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin {
     assert(newRoute.overlayEntries.isEmpty);
     assert(!overlay.debugIsVisible(oldRoute.overlayEntries.last));
     setState(() {
-      int index = _history.length - 1;
+      final int index = _history.indexOf(oldRoute);
       assert(index >= 0);
-      assert(_history.indexOf(oldRoute) == index);
       newRoute._navigator = this;
       newRoute.install(oldRoute.overlayEntries.last);
       _history[index] = newRoute;
@@ -816,8 +815,9 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin {
     assert(newRoute.overlayEntries.isEmpty);
 
     setState(() {
-      final int index = _history.indexOf(oldRoute);
+      int index = _history.length - 1;
       assert(index >= 0);
+      assert(_history.indexOf(oldRoute) == index);
       newRoute._navigator = this;
       newRoute.install(_currentOverlayEntry);
       _history[index] = newRoute;

--- a/packages/flutter/lib/src/widgets/navigator.dart
+++ b/packages/flutter/lib/src/widgets/navigator.dart
@@ -52,7 +52,8 @@ abstract class Route<T> {
   @mustCallSuper
   void install(OverlayEntry insertionPoint) { }
 
-  /// Called after install() when the route is pushed onto the navigator.
+  /// Called after install() when the route is pushed onto the navigator. The
+  /// returned value resolves when the push transition is complete.
   @protected
   Future<Null> didPush() => new Future<Null>.value();
 

--- a/packages/flutter/lib/src/widgets/routes.dart
+++ b/packages/flutter/lib/src/widgets/routes.dart
@@ -164,10 +164,9 @@ abstract class TransitionRoute<T> extends OverlayRoute<T> {
   }
 
   @override
-  void didPush() {
+  Future<Null> didPush() {
     _animation.addStatusListener(_handleStatusChanged);
-    _controller.forward();
-    super.didPush();
+    return _controller.forward();
   }
 
   @override
@@ -559,7 +558,7 @@ abstract class ModalRoute<T> extends TransitionRoute<T> with LocalHistoryRoute<T
   }
 
   @override
-  void didPush() {
+  Future<Null> didPush() {
     if (!settings.isInitialRoute) {
       BuildContext overlayContext = navigator.overlay?.context;
       assert(() {
@@ -574,7 +573,7 @@ abstract class ModalRoute<T> extends TransitionRoute<T> with LocalHistoryRoute<T
       });
       Focus.moveScopeTo(focusKey, context: overlayContext);
     }
-    super.didPush();
+    return super.didPush();
   }
 
   @override

--- a/packages/flutter/test/widgets/navigator_test.dart
+++ b/packages/flutter/test/widgets/navigator_test.dart
@@ -282,8 +282,8 @@ void main() {
 
   testWidgets('replaceNamed', (WidgetTester tester) async {
     final Map<String, WidgetBuilder> routes = <String, WidgetBuilder>{
-       '/': (BuildContext context) => new OnTapPage(id: '/', onTap: () { Navigator.replaceNamed(context, '/A'); }),
-      '/A': (BuildContext context) => new OnTapPage(id: 'A', onTap: () { Navigator.replaceNamed(context, '/B'); }),
+       '/': (BuildContext context) => new OnTapPage(id: '/', onTap: () { Navigator.pushReplacementNamed(context, '/A'); }),
+      '/A': (BuildContext context) => new OnTapPage(id: 'A', onTap: () { Navigator.pushReplacementNamed(context, '/B'); }),
       '/B': (BuildContext context) => new OnTapPage(id: 'B'),
     };
 
@@ -307,7 +307,7 @@ void main() {
 
     final Map<String, WidgetBuilder> routes = <String, WidgetBuilder>{
        '/': (BuildContext context) => new OnTapPage(id: '/', onTap: () { Navigator.pushNamed(context, '/A'); }),
-      '/A': (BuildContext context) => new OnTapPage(id: 'A', onTap: () { value = Navigator.replaceNamed(context, '/B', result: 'B'); }),
+      '/A': (BuildContext context) => new OnTapPage(id: 'A', onTap: () { value = Navigator.pushReplacementNamed(context, '/B', result: 'B'); }),
       '/B': (BuildContext context) => new OnTapPage(id: 'B', onTap: () { Navigator.pop(context, 'B'); }),
     };
 

--- a/packages/flutter/test/widgets/routes_test.dart
+++ b/packages/flutter/test/widgets/routes_test.dart
@@ -39,9 +39,9 @@ class TestRoute extends LocalHistoryRoute<String> {
   }
 
   @override
-  void didPush() {
+  Future<Null> didPush() {
     log('didPush');
-    super.didPush();
+    return super.didPush();
   }
 
   @override


### PR DESCRIPTION
Replace the current route by pushing a new route and disposing the old one.

Route.didPush() now returns a Future that completes when the push operation completes.

Fixes: https://github.com/flutter/flutter/issues/7365
Fixes: https://github.com/flutter/flutter/issues/6544
