### PR TITLE
Revert method generics in `packages/flutter/lib/src/http`

### DIFF
--- a/packages/flutter/lib/src/http/http.dart
+++ b/packages/flutter/lib/src/http/http.dart
@@ -161,7 +161,7 @@ Future<String> read(dynamic url, {Map<String, String> headers}) =>
 Future<Uint8List> readBytes(dynamic url, {Map<String, String> headers}) =>
   _withClient((Client client) => client.readBytes(url, headers: headers));
 
-Future/*<T>*/ _withClient/*<T>*/(Future<T> fn(Client client)) async {
+Future/*<T>*/ _withClient/*<T>*/(Future/*<T>*/ fn(Client client)) async {
   Client client = new Client();
   try {
     return await fn(client);

--- a/packages/flutter/lib/src/http/http.dart
+++ b/packages/flutter/lib/src/http/http.dart
@@ -161,7 +161,7 @@ Future<String> read(dynamic url, {Map<String, String> headers}) =>
 Future<Uint8List> readBytes(dynamic url, {Map<String, String> headers}) =>
   _withClient((Client client) => client.readBytes(url, headers: headers));
 
-Future<T> _withClient<T>(Future<T> fn(Client client)) async {
+Future/*<T>*/ _withClient/*<T>*/(Future<T> fn(Client client)) async {
   Client client = new Client();
   try {
     return await fn(client);

--- a/packages/flutter/lib/src/http/io_client.dart
+++ b/packages/flutter/lib/src/http/io_client.dart
@@ -62,7 +62,7 @@ class IOClient extends BaseClient {
       });
 
       return new StreamedResponse(
-          DelegatingStream.typed<List<int>>(response).handleError((dynamic error) =>
+          DelegatingStream.typed/*<List<int>>*/(response).handleError((dynamic error) =>
               throw new ClientException(error.message, error.uri),
               test: (dynamic error) => io.isHttpException(error)),
           response.statusCode,

--- a/packages/flutter/lib/src/http/utils.dart
+++ b/packages/flutter/lib/src/http/utils.dart
@@ -85,7 +85,7 @@ ByteStream toByteStream(Stream<List<int>> stream) {
 /// Calls [onDone] once [stream] (a single-subscription [Stream]) is finished.
 /// The return value, also a single-subscription [Stream] should be used in
 /// place of [stream] after calling this method.
-Stream<T> onDone<T>(Stream<T> stream, void onDone()) =>
+Stream/*<T>*/ onDone/*<T>*/(Stream/*<T>*/ stream, void onDone()) =>
     stream.transform(new StreamTransformer.fromHandlers(handleDone: (EventSink<dynamic> sink) { // ignore: always_specify_types
       sink.close();
       onDone();


### PR DESCRIPTION
We converted all code to use method generics in #7235, but
we shouldn't have touched the `http` folder since this code
is pulled from upstream.