### PR TITLE
Separate data_table_test util code into its own file.

### DIFF
--- a/packages/flutter/test/material/data_table_test.dart
+++ b/packages/flutter/test/material/data_table_test.dart
@@ -5,31 +5,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-class Dessert {
-  Dessert(this.name, this.calories, this.fat, this.carbs, this.protein, this.sodium, this.calcium, this.iron);
-
-  final String name;
-  final int calories;
-  final double fat;
-  final int carbs;
-  final double protein;
-  final int sodium;
-  final int calcium;
-  final int iron;
-}
-
-final List<Dessert> kDesserts = <Dessert>[
-  new Dessert('Frozen yogurt',                        159,  6.0,  24,  4.0,  87, 14,  1),
-  new Dessert('Ice cream sandwich',                   237,  9.0,  37,  4.3, 129,  8,  1),
-  new Dessert('Eclair',                               262, 16.0,  24,  6.0, 337,  6,  7),
-  new Dessert('Cupcake',                              305,  3.7,  67,  4.3, 413,  3,  8),
-  new Dessert('Gingerbread',                          356, 16.0,  49,  3.9, 327,  7, 16),
-  new Dessert('Jelly bean',                           375,  0.0,  94,  0.0,  50,  0,  0),
-  new Dessert('Lollipop',                             392,  0.2,  98,  0.0,  38,  0,  2),
-  new Dessert('Honeycomb',                            408,  3.2,  87,  6.5, 562,  0, 45),
-  new Dessert('Donut',                                452, 25.0,  51,  4.9, 326,  2, 22),
-  new Dessert('KitKat',                               518, 26.0,  65,  7.0,  54, 12,  6),
-];
+import 'data_table_test_utils.dart';
 
 void main() {
   testWidgets('DataTable control test', (WidgetTester tester) async {

--- a/packages/flutter/test/material/data_table_test_utils.dart
+++ b/packages/flutter/test/material/data_table_test_utils.dart
@@ -1,0 +1,29 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+class Dessert {
+  Dessert(this.name, this.calories, this.fat, this.carbs, this.protein, this.sodium, this.calcium, this.iron);
+
+  final String name;
+  final int calories;
+  final double fat;
+  final int carbs;
+  final double protein;
+  final int sodium;
+  final int calcium;
+  final int iron;
+}
+
+final List<Dessert> kDesserts = <Dessert>[
+  new Dessert('Frozen yogurt',                        159,  6.0,  24,  4.0,  87, 14,  1),
+  new Dessert('Ice cream sandwich',                   237,  9.0,  37,  4.3, 129,  8,  1),
+  new Dessert('Eclair',                               262, 16.0,  24,  6.0, 337,  6,  7),
+  new Dessert('Cupcake',                              305,  3.7,  67,  4.3, 413,  3,  8),
+  new Dessert('Gingerbread',                          356, 16.0,  49,  3.9, 327,  7, 16),
+  new Dessert('Jelly bean',                           375,  0.0,  94,  0.0,  50,  0,  0),
+  new Dessert('Lollipop',                             392,  0.2,  98,  0.0,  38,  0,  2),
+  new Dessert('Honeycomb',                            408,  3.2,  87,  6.5, 562,  0, 45),
+  new Dessert('Donut',                                452, 25.0,  51,  4.9, 326,  2, 22),
+  new Dessert('KitKat',                               518, 26.0,  65,  7.0,  54, 12,  6),
+];

--- a/packages/flutter/test/material/paginated_data_table_test.dart
+++ b/packages/flutter/test/material/paginated_data_table_test.dart
@@ -5,7 +5,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import 'data_table_test.dart' show Dessert, kDesserts;
+import 'data_table_test_utils.dart';
 
 class TestDataSource extends DataTableSource {
   int get generation => _generation;


### PR DESCRIPTION
This yields a cleaner separation between common testing code
and actual tests (a distinction which is important in Google's
internal build system).