### PR TITLE
Migrate sample applications off FlutterAppDelegate

### DIFF
--- a/examples/flutter_gallery/ios/Runner.xcodeproj/project.pbxproj
+++ b/examples/flutter_gallery/ios/Runner.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		3BB1DF161E3AC84F00B1AFE2 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 3BB1DF151E3AC84F00B1AFE2 /* AppDelegate.m */; };
 		9705A1C51CF9049000538489 /* app.dylib in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 9740EEB81CF902C7004384FC /* app.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		9705A1C61CF904A100538489 /* Flutter.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9740EEBA1CF902C7004384FC /* Flutter.framework */; };
 		9705A1C71CF904A300538489 /* Flutter.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 9740EEBA1CF902C7004384FC /* Flutter.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -35,6 +36,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		3BB1DF141E3AC84F00B1AFE2 /* AppDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
+		3BB1DF151E3AC84F00B1AFE2 /* AppDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AppDelegate.m; sourceTree = "<group>"; };
 		9740EEB21CF90195004384FC /* Flutter.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Flutter.xcconfig; path = Flutter/Flutter.xcconfig; sourceTree = "<group>"; };
 		9740EEB31CF90195004384FC /* Generated.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Generated.xcconfig; path = Flutter/Generated.xcconfig; sourceTree = "<group>"; };
 		9740EEB71CF902C7004384FC /* app.flx */ = {isa = PBXFileReference; lastKnownFileType = file; name = app.flx; path = Flutter/app.flx; sourceTree = "<group>"; };
@@ -92,6 +95,8 @@
 		97C146F01CF9000F007C117D /* Runner */ = {
 			isa = PBXGroup;
 			children = (
+				3BB1DF141E3AC84F00B1AFE2 /* AppDelegate.h */,
+				3BB1DF151E3AC84F00B1AFE2 /* AppDelegate.m */,
 				97C146FA1CF9000F007C117D /* Main.storyboard */,
 				97C146FD1CF9000F007C117D /* Assets.xcassets */,
 				97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */,
@@ -200,6 +205,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3BB1DF161E3AC84F00B1AFE2 /* AppDelegate.m in Sources */,
 				97C146F31CF9000F007C117D /* main.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/examples/flutter_gallery/ios/Runner/AppDelegate.h
+++ b/examples/flutter_gallery/ios/Runner/AppDelegate.h
@@ -1,0 +1,7 @@
+#import <UIKit/UIKit.h>
+
+@interface AppDelegate : UIResponder <UIApplicationDelegate>
+
+@property (strong, nonatomic) UIWindow *window;
+
+@end

--- a/examples/flutter_gallery/ios/Runner/AppDelegate.m
+++ b/examples/flutter_gallery/ios/Runner/AppDelegate.m
@@ -1,0 +1,6 @@
+#import <Flutter/Flutter.h>
+#include "AppDelegate.h"
+
+@implementation AppDelegate
+
+@end

--- a/examples/flutter_gallery/ios/Runner/main.m
+++ b/examples/flutter_gallery/ios/Runner/main.m
@@ -4,11 +4,12 @@
 
 #import <UIKit/UIKit.h>
 #import <Flutter/Flutter.h>
+#import "AppDelegate.h"
 
 int main(int argc, char * argv[]) {
     FlutterInit(argc, (const char**)argv);
     @autoreleasepool {
         return UIApplicationMain(argc, argv, nil,
-                                 NSStringFromClass([FlutterAppDelegate class]));
+                                 NSStringFromClass([AppDelegate class]));
     }
 }

--- a/examples/hello_world/ios/Runner.xcodeproj/project.pbxproj
+++ b/examples/hello_world/ios/Runner.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		3BB1DF191E3AC95C00B1AFE2 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 3BB1DF181E3AC95C00B1AFE2 /* AppDelegate.m */; };
 		9705A1C51CF9049000538489 /* app.dylib in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 9740EEB81CF902C7004384FC /* app.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		9705A1C61CF904A100538489 /* Flutter.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9740EEBA1CF902C7004384FC /* Flutter.framework */; };
 		9705A1C71CF904A300538489 /* Flutter.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 9740EEBA1CF902C7004384FC /* Flutter.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -35,6 +36,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		3BB1DF171E3AC95C00B1AFE2 /* AppDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
+		3BB1DF181E3AC95C00B1AFE2 /* AppDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AppDelegate.m; sourceTree = "<group>"; };
 		9740EEB21CF90195004384FC /* Flutter.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Flutter.xcconfig; path = Flutter/Flutter.xcconfig; sourceTree = "<group>"; };
 		9740EEB31CF90195004384FC /* Generated.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Generated.xcconfig; path = Flutter/Generated.xcconfig; sourceTree = "<group>"; };
 		9740EEB71CF902C7004384FC /* app.flx */ = {isa = PBXFileReference; lastKnownFileType = file; name = app.flx; path = Flutter/app.flx; sourceTree = "<group>"; };
@@ -92,6 +95,8 @@
 		97C146F01CF9000F007C117D /* Runner */ = {
 			isa = PBXGroup;
 			children = (
+				3BB1DF171E3AC95C00B1AFE2 /* AppDelegate.h */,
+				3BB1DF181E3AC95C00B1AFE2 /* AppDelegate.m */,
 				97C146FA1CF9000F007C117D /* Main.storyboard */,
 				97C146FD1CF9000F007C117D /* Assets.xcassets */,
 				97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */,
@@ -200,6 +205,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3BB1DF191E3AC95C00B1AFE2 /* AppDelegate.m in Sources */,
 				97C146F31CF9000F007C117D /* main.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/examples/hello_world/ios/Runner/AppDelegate.h
+++ b/examples/hello_world/ios/Runner/AppDelegate.h
@@ -1,0 +1,7 @@
+#import <UIKit/UIKit.h>
+
+@interface AppDelegate : UIResponder <UIApplicationDelegate>
+
+@property (strong, nonatomic) UIWindow *window;
+
+@end

--- a/examples/hello_world/ios/Runner/AppDelegate.m
+++ b/examples/hello_world/ios/Runner/AppDelegate.m
@@ -1,0 +1,6 @@
+#import <Flutter/Flutter.h>
+#include "AppDelegate.h"
+
+@implementation AppDelegate
+
+@end

--- a/examples/hello_world/ios/Runner/main.m
+++ b/examples/hello_world/ios/Runner/main.m
@@ -4,11 +4,12 @@
 
 #import <UIKit/UIKit.h>
 #import <Flutter/Flutter.h>
+#import "AppDelegate.h"
 
 int main(int argc, char * argv[]) {
     FlutterInit(argc, (const char**)argv);
     @autoreleasepool {
         return UIApplicationMain(argc, argv, nil,
-                                 NSStringFromClass([FlutterAppDelegate class]));
+                                 NSStringFromClass([AppDelegate class]));
     }
 }

--- a/examples/stocks/ios/Runner.xcodeproj/project.pbxproj
+++ b/examples/stocks/ios/Runner.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		3B71917B1E3ACB3600E8B792 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 3B71917A1E3ACB3600E8B792 /* AppDelegate.m */; };
 		9705A1C51CF9049000538489 /* app.dylib in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 9740EEB81CF902C7004384FC /* app.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		9705A1C61CF904A100538489 /* Flutter.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9740EEBA1CF902C7004384FC /* Flutter.framework */; };
 		9705A1C71CF904A300538489 /* Flutter.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 9740EEBA1CF902C7004384FC /* Flutter.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -35,6 +36,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		3B7191791E3ACB3600E8B792 /* AppDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
+		3B71917A1E3ACB3600E8B792 /* AppDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AppDelegate.m; sourceTree = "<group>"; };
 		9740EEB21CF90195004384FC /* Flutter.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Flutter.xcconfig; path = Flutter/Flutter.xcconfig; sourceTree = "<group>"; };
 		9740EEB31CF90195004384FC /* Generated.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Generated.xcconfig; path = Flutter/Generated.xcconfig; sourceTree = "<group>"; };
 		9740EEB71CF902C7004384FC /* app.flx */ = {isa = PBXFileReference; lastKnownFileType = file; name = app.flx; path = Flutter/app.flx; sourceTree = "<group>"; };
@@ -92,6 +95,8 @@
 		97C146F01CF9000F007C117D /* Runner */ = {
 			isa = PBXGroup;
 			children = (
+				3B7191791E3ACB3600E8B792 /* AppDelegate.h */,
+				3B71917A1E3ACB3600E8B792 /* AppDelegate.m */,
 				97C146FA1CF9000F007C117D /* Main.storyboard */,
 				97C146FD1CF9000F007C117D /* Assets.xcassets */,
 				97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */,
@@ -200,6 +205,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3B71917B1E3ACB3600E8B792 /* AppDelegate.m in Sources */,
 				97C146F31CF9000F007C117D /* main.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/examples/stocks/ios/Runner/AppDelegate.h
+++ b/examples/stocks/ios/Runner/AppDelegate.h
@@ -1,0 +1,7 @@
+#import <UIKit/UIKit.h>
+
+@interface AppDelegate : UIResponder <UIApplicationDelegate>
+
+@property (strong, nonatomic) UIWindow *window;
+
+@end

--- a/examples/stocks/ios/Runner/AppDelegate.m
+++ b/examples/stocks/ios/Runner/AppDelegate.m
@@ -1,0 +1,6 @@
+#import <Flutter/Flutter.h>
+#include "AppDelegate.h"
+
+@implementation AppDelegate
+
+@end

--- a/examples/stocks/ios/Runner/main.m
+++ b/examples/stocks/ios/Runner/main.m
@@ -4,11 +4,12 @@
 
 #import <UIKit/UIKit.h>
 #import <Flutter/Flutter.h>
+#import "AppDelegate.h"
 
 int main(int argc, char * argv[]) {
     FlutterInit(argc, (const char**)argv);
     @autoreleasepool {
         return UIApplicationMain(argc, argv, nil,
-                                 NSStringFromClass([FlutterAppDelegate class]));
+                                 NSStringFromClass([AppDelegate class]));
     }
 }


### PR DESCRIPTION
Almost all real-world apps will want a custom app delegate, and 'flutter
create' code-gens one by default. This brings the samples in line with
our templates and the most common use case.