### PR TITLE
Improve SliverBlockDelegate.estimateScrollOffsetExtent

### DIFF
--- a/packages/flutter/lib/src/widgets/block.dart
+++ b/packages/flutter/lib/src/widgets/block.dart
@@ -78,7 +78,13 @@ abstract class SliverBlockDelegate {
     double leadingScrollOffset,
     double trailingScrollOffset,
   ) {
-    return childCount * (trailingScrollOffset - leadingScrollOffset) / (lastIndex - firstIndex + 1);
+    final int childCount = this.childCount;
+    if (lastIndex == childCount - 1)
+      return trailingScrollOffset;
+    final int reifiedCount = lastIndex - firstIndex + 1;
+    final double averageExtent = (trailingScrollOffset - leadingScrollOffset) / reifiedCount;
+    final int remainingCount = childCount - lastIndex - 1;
+    return trailingScrollOffset + averageExtent * remainingCount;
   }
 }
 

--- a/packages/flutter/test/widgets/block_test.dart
+++ b/packages/flutter/test/widgets/block_test.dart
@@ -119,4 +119,16 @@ void main() {
     await tester.pumpWidget(buildBlock());
     expect(key.currentState.scrollOffset, 0.0);
   });
+
+  testWidgets('SliverBlockChildListDelegate.estimateScrollOffsetExtent hits end', (WidgetTester tester) async {
+    SliverBlockChildListDelegate delegate = new SliverBlockChildListDelegate(<Widget>[
+      new Container(),
+      new Container(),
+      new Container(),
+      new Container(),
+      new Container(),
+    ]);
+
+    expect(delegate.estimateScrollOffsetExtent(3, 4, 25.0, 26.0), equals(26.0));
+  });
 }


### PR DESCRIPTION
We now report an accurate estimate when the lastIndex is the final index
in the list.

Also, we now project forward from the lastIndex using the extent of the
reified children instead of trying to project forward from index 0.

This new algorithm leads to estimation error as you reach the end of a
list, avoiding some ballistic overscrolls.