### PR TITLE
Refactor 'flutter drive' to get the observatory port from the logs

### DIFF
--- a/dev/devicelab/lib/tasks/perf_tests.dart
+++ b/dev/devicelab/lib/tasks/perf_tests.dart
@@ -254,10 +254,8 @@ class MemoryTest {
           testTarget,
           '-d',
           deviceId,
-          '--use-existing-app',
-        ], environment: <String, String> {
-          'VM_SERVICE_URL': 'http://localhost:$observatoryPort'
-        });
+          '--use-existing-app=http://localhost:$observatoryPort',
+        ]);
 
         Map<String, dynamic> endData = await device.getMemoryStats(packageName);
         data['end_total_kb'] = endData['total_kb'];

--- a/packages/flutter_driver/lib/src/driver.dart
+++ b/packages/flutter_driver/lib/src/driver.dart
@@ -116,7 +116,7 @@ class FlutterDriver {
   ///
   /// [dartVmServiceUrl] is the URL to Dart observatory (a.k.a. VM service). If
   /// not specified, the URL specified by the `VM_SERVICE_URL` environment
-  /// variable is used, or 'http://localhost:8183'.
+  /// variable is used. One or the other must be specified.
   ///
   /// [printCommunication] determines whether the command communication between
   /// the test and the app should be printed to stdout.
@@ -127,7 +127,14 @@ class FlutterDriver {
                                          bool printCommunication: false,
                                          bool logCommunicationToFile: true }) async {
     dartVmServiceUrl ??= Platform.environment['VM_SERVICE_URL'];
-    dartVmServiceUrl ??= 'http://localhost:8183';
+
+    if (dartVmServiceUrl == null) {
+      throw new DriverError(
+        'Could not determine URL to connect to application.\n'
+        'Either the VM_SERVICE_URL environment variable should be set, or an explicit\n'
+        'URL should be provided to the FlutterDriver.connect() method.'
+      );
+    }
 
     // Connect to Dart VM servcies
     _log.info('Connecting to Flutter application at $dartVmServiceUrl');

--- a/packages/flutter_tools/lib/src/android/android_device.dart
+++ b/packages/flutter_tools/lib/src/android/android_device.dart
@@ -353,21 +353,21 @@ class AndroidDevice extends Device {
     // TODO(danrubel) Waiting for observatory and diagnostic services
     // can be made common across all devices.
     try {
-      Uri observatoryUri, diagnosticUri;
+      Uri observatoryUrl, diagnosticUrl;
 
       if (debuggingOptions.buildMode == BuildMode.debug) {
-        List<Uri> deviceUris = await Future.wait(
-            <Future<Uri>>[observatoryDiscovery.nextUri(), diagnosticDiscovery.nextUri()]
+        List<Uri> deviceUrls = await Future.wait(
+            <Future<Uri>>[observatoryDiscovery.nextUrl(), diagnosticDiscovery.nextUrl()]
         );
-        observatoryUri = deviceUris[0];
-        diagnosticUri = deviceUris[1];
+        observatoryUrl = deviceUrls[0];
+        diagnosticUrl = deviceUrls[1];
       } else if (debuggingOptions.buildMode == BuildMode.profile) {
-        observatoryUri = await observatoryDiscovery.nextUri();
+        observatoryUrl = await observatoryDiscovery.nextUrl();
       }
 
       return new LaunchResult.succeeded(
-          observatoryUri: observatoryUri,
-          diagnosticUri: diagnosticUri,
+          observatoryUrl: observatoryUrl,
+          diagnosticUrl: diagnosticUrl,
       );
     } catch (error) {
       printError('Error waiting for a debug connection: $error');

--- a/packages/flutter_tools/lib/src/commands/daemon.dart
+++ b/packages/flutter_tools/lib/src/commands/daemon.dart
@@ -388,11 +388,11 @@ class AppDomain extends Domain {
       connectionInfoCompleter = new Completer<DebugConnectionInfo>();
       connectionInfoCompleter.future.then<Null>((DebugConnectionInfo info) {
         Map<String, dynamic> params = <String, dynamic>{
-          'port': info.httpUri.port,
-          'wsUri': info.wsUri.toString(),
+          'port': info.httpUrl.port,
+          'wsUri': info.wsUrl.toString(),
         };
-        if (info.baseUri != null)
-          params['baseUri'] = info.baseUri;
+        if (info.baseUrl != null)
+          params['baseUri'] = info.baseUrl;
         _sendAppEvent(app, 'debugPort', params);
       });
     }

--- a/packages/flutter_tools/lib/src/devfs.dart
+++ b/packages/flutter_tools/lib/src/devfs.dart
@@ -318,17 +318,17 @@ class DevFS {
   final List<Future<Map<String, dynamic>>> _pendingOperations =
       new List<Future<Map<String, dynamic>>>();
 
-  Uri _baseUri;
-  Uri get baseUri => _baseUri;
+  Uri _baseUrl;
+  Uri get baseUrl => _baseUrl;
 
   Future<Uri> create() async {
-    _baseUri = await _operations.create(fsName);
-    printTrace('DevFS: Created new filesystem on the device ($_baseUri)');
-    return _baseUri;
+    _baseUrl = await _operations.create(fsName);
+    printTrace('DevFS: Created new filesystem on the device ($_baseUrl)');
+    return _baseUrl;
   }
 
   Future<dynamic> destroy() {
-    printTrace('DevFS: Deleted filesystem on the device ($_baseUri)');
+    printTrace('DevFS: Deleted filesystem on the device ($_baseUrl)');
     return _operations.destroy(fsName);
   }
 
@@ -536,9 +536,9 @@ class DevFS {
     PackageMap packageMap = new PackageMap(_packagesFilePath);
 
     for (String packageName in packageMap.map.keys) {
-      Uri uri = packageMap.map[packageName];
+      Uri url = packageMap.map[packageName];
       // This project's own package.
-      final bool isProjectPackage = uri.toString() == 'lib/';
+      final bool isProjectPackage = url.toString() == 'lib/';
       final String directoryName =
           isProjectPackage ? 'lib' : 'packages/$packageName';
       // If this is the project's package, we need to pass both
@@ -547,7 +547,7 @@ class DevFS {
       // path imports within the project's own code.
       final String packagesDirectoryName =
           isProjectPackage ? 'packages/$packageName' : null;
-      Directory directory = fs.directory(uri);
+      Directory directory = fs.directory(url);
       bool packageExists =
           await _scanDirectory(directory,
                                directoryName: directoryName,

--- a/packages/flutter_tools/lib/src/device.dart
+++ b/packages/flutter_tools/lib/src/device.dart
@@ -320,22 +320,22 @@ class DebuggingOptions {
 }
 
 class LaunchResult {
-  LaunchResult.succeeded({ this.observatoryUri, this.diagnosticUri }) : started = true;
-  LaunchResult.failed() : started = false, observatoryUri = null, diagnosticUri = null;
+  LaunchResult.succeeded({ this.observatoryUrl, this.diagnosticUrl }) : started = true;
+  LaunchResult.failed() : started = false, observatoryUrl = null, diagnosticUrl = null;
 
-  bool get hasObservatory => observatoryUri != null;
+  bool get hasObservatory => observatoryUrl != null;
 
   final bool started;
-  final Uri observatoryUri;
-  final Uri diagnosticUri;
+  final Uri observatoryUrl;
+  final Uri diagnosticUrl;
 
   @override
   String toString() {
     StringBuffer buf = new StringBuffer('started=$started');
-    if (observatoryUri != null)
-      buf.write(', observatory=$observatoryUri');
-    if (diagnosticUri != null)
-      buf.write(', diagnostic=$diagnosticUri');
+    if (observatoryUrl != null)
+      buf.write(', observatory=$observatoryUrl');
+    if (diagnosticUrl != null)
+      buf.write(', diagnostic=$diagnosticUrl');
     return buf.toString();
   }
 }

--- a/packages/flutter_tools/lib/src/hot.dart
+++ b/packages/flutter_tools/lib/src/hot.dart
@@ -57,7 +57,7 @@ class HotRunner extends ResidentRunner {
   final String applicationBinary;
   bool get prebuiltMode => applicationBinary != null;
   Set<String> _dartDependencies;
-  Uri _observatoryUri;
+  Uri _observatoryUrl;
 
   final bool benchmarkMode;
   final Map<String, int> benchmarkData = new Map<String, int>();
@@ -100,7 +100,7 @@ class HotRunner extends ResidentRunner {
       Set<String> dependencies = dartDependencySetBuilder.build();
       _dartDependencies = new Set<String>();
       for (String path in dependencies) {
-        // We need to tweak package: uris so that they reflect their devFS
+        // We need to tweak package: urls so that they reflect their devFS
         // location.
         if (path.startsWith('package:')) {
           // Swap out package: for packages/ because we place all package
@@ -175,22 +175,22 @@ class HotRunner extends ResidentRunner {
       return 2;
     }
 
-    _observatoryUri = result.observatoryUri;
+    _observatoryUrl = result.observatoryUrl;
     try {
-      await connectToServiceProtocol(_observatoryUri);
+      await connectToServiceProtocol(_observatoryUrl);
     } catch (error) {
       printError('Error connecting to the service protocol: $error');
       return 2;
     }
 
     try {
-      Uri baseUri = await _initDevFS();
+      Uri baseUrl = await _initDevFS();
       if (connectionInfoCompleter != null) {
         connectionInfoCompleter.complete(
           new DebugConnectionInfo(
-            httpUri: _observatoryUri,
-            wsUri: vmService.wsAddress,
-            baseUri: baseUri.toString()
+            httpUrl: _observatoryUrl,
+            wsUrl: vmService.wsAddress,
+            baseUrl: baseUrl.toString()
           )
         );
       }
@@ -319,11 +319,11 @@ class HotRunner extends ResidentRunner {
                                 String mainScript) async {
     String entryPath = path.relative(mainScript, from: projectRootPath);
     String deviceEntryPath =
-        _devFS.baseUri.resolve(entryPath).toFilePath();
+        _devFS.baseUrl.resolve(entryPath).toFilePath();
     String devicePackagesPath =
-        _devFS.baseUri.resolve('.packages').toFilePath();
+        _devFS.baseUrl.resolve('.packages').toFilePath();
     String deviceAssetsDirectoryPath =
-        _devFS.baseUri.resolve(getAssetBuildDirectory()).toFilePath();
+        _devFS.baseUrl.resolve(getAssetBuildDirectory()).toFilePath();
     await _launchInView(deviceEntryPath,
                         devicePackagesPath,
                         deviceAssetsDirectoryPath);
@@ -430,9 +430,9 @@ class HotRunner extends ResidentRunner {
     try {
       String entryPath = path.relative(mainPath, from: projectRootPath);
       String deviceEntryPath =
-          _devFS.baseUri.resolve(entryPath).toFilePath();
+          _devFS.baseUrl.resolve(entryPath).toFilePath();
       String devicePackagesPath =
-          _devFS.baseUri.resolve('.packages').toFilePath();
+          _devFS.baseUrl.resolve('.packages').toFilePath();
       if (benchmarkMode)
         vmReloadTimer.start();
       Map<String, dynamic> reloadReport =
@@ -526,7 +526,7 @@ class HotRunner extends ResidentRunner {
       ansiAlternative: '$red$fire$bold  To hot reload your app on the fly, '
                        'press "r" or F5. To restart the app entirely, press "R".$reset'
     );
-    printStatus('The Observatory debugger and profiler is available at: $_observatoryUri');
+    printStatus('The Observatory debugger and profiler is available at: $_observatoryUrl');
     if (details) {
       printHelpDetails();
       printStatus('To repeat this help message, press "h" or F1. To quit, press "q", F10, or Ctrl-C.');

--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -249,8 +249,8 @@ class IOSDevice extends Device {
     }
 
     int installationResult = -1;
-    Uri localObsUri;
-    Uri localDiagUri;
+    Uri localObservatoryUrl;
+    Uri localDiagnosticUrl;
 
     if (!debuggingOptions.debuggingEnabled) {
       // If debugging is not enabled, just launch the application and continue.
@@ -268,17 +268,17 @@ class IOSDevice extends Device {
       ProtocolDiscovery diagnosticDiscovery = new ProtocolDiscovery.diagnosticService(
         getLogReader(app: app), portForwarder: portForwarder, hostPort: debuggingOptions.diagnosticPort);
 
-      Future<Uri> forwardObsUri = observatoryDiscovery.nextUri();
-      Future<Uri> forwardDiagUri;
+      Future<Uri> forwardObservatoryUrl = observatoryDiscovery.nextUrl();
+      Future<Uri> forwardDiagnosticUrl;
       if (debuggingOptions.buildMode == BuildMode.debug) {
-        forwardDiagUri = diagnosticDiscovery.nextUri();
+        forwardDiagnosticUrl = diagnosticDiscovery.nextUrl();
       } else {
-        forwardDiagUri = new Future<Uri>.value(null);
+        forwardDiagnosticUrl = new Future<Uri>.value(null);
       }
 
       Future<int> launch = runCommandAndStreamOutput(launchCommand, trace: true);
 
-      List<Uri> uris = await launch.then((int result) async {
+      List<Uri> urls = await launch.then((int result) async {
         installationResult = result;
 
         if (result != 0) {
@@ -287,14 +287,14 @@ class IOSDevice extends Device {
         }
 
         printTrace("Application launched on the device. Attempting to forward ports.");
-        return await Future.wait(<Future<Uri>>[forwardObsUri, forwardDiagUri]);
+        return await Future.wait(<Future<Uri>>[forwardObservatoryUrl, forwardDiagnosticUrl]);
       }).whenComplete(() {
         observatoryDiscovery.cancel();
         diagnosticDiscovery.cancel();
       });
 
-      localObsUri = uris[0];
-      localDiagUri = uris[1];
+      localObservatoryUrl = urls[0];
+      localDiagnosticUrl = urls[1];
     }
 
     if (installationResult != 0) {
@@ -305,7 +305,7 @@ class IOSDevice extends Device {
       return new LaunchResult.failed();
     }
 
-    return new LaunchResult.succeeded(observatoryUri: localObsUri, diagnosticUri: localDiagUri);
+    return new LaunchResult.succeeded(observatoryUrl: localObservatoryUrl, diagnosticUrl: localDiagnosticUrl);
   }
 
   @override

--- a/packages/flutter_tools/lib/src/ios/simulators.dart
+++ b/packages/flutter_tools/lib/src/ios/simulators.dart
@@ -478,8 +478,8 @@ class IOSSimulator extends Device {
     printTrace('Waiting for observatory port to be available...');
 
     try {
-      Uri deviceUri = await observatoryDiscovery.nextUri();
-      return new LaunchResult.succeeded(observatoryUri: deviceUri);
+      Uri deviceUrl = await observatoryDiscovery.nextUrl();
+      return new LaunchResult.succeeded(observatoryUrl: deviceUrl);
     } catch (error) {
       printError('Error waiting for a debug connection: $error');
       return new LaunchResult.failed();

--- a/packages/flutter_tools/lib/src/protocol_discovery.dart
+++ b/packages/flutter_tools/lib/src/protocol_discovery.dart
@@ -49,16 +49,16 @@ class ProtocolDiscovery {
 
   /// The [Future] returned by this function will complete when the next service
   /// Uri is found.
-  Future<Uri> nextUri() async {
-    Uri deviceUri = await _completer.future.timeout(
+  Future<Uri> nextUrl() async {
+    Uri deviceUrl = await _completer.future.timeout(
       const Duration(seconds: 60), onTimeout: () {
-        throwToolExit('Timeout while attempting to retrieve Uri for $_serviceName');
+        throwToolExit('Timeout while attempting to retrieve URL for $_serviceName');
       }
     );
-    printTrace('$_serviceName Uri on device: $deviceUri');
-    Uri hostUri;
+    printTrace('$_serviceName URL on device: $deviceUrl');
+    Uri hostUrl;
     if (portForwarder != null) {
-      int devicePort = deviceUri.port;
+      int devicePort = deviceUrl.port;
       hostPort ??= await findPreferredPort(defaultHostPort);
       hostPort = await portForwarder
           .forward(devicePort, hostPort: hostPort)
@@ -66,11 +66,11 @@ class ProtocolDiscovery {
             throwToolExit('Timeout while atempting to foward device port $devicePort for $_serviceName');
           });
       printTrace('Forwarded host port $hostPort to device port $devicePort for $_serviceName');
-      hostUri = deviceUri.replace(port: hostPort);
+      hostUrl = deviceUrl.replace(port: hostPort);
     } else {
-      hostUri = deviceUri;
+      hostUrl = deviceUrl;
     }
-    return hostUri;
+    return hostUrl;
   }
 
   void cancel() {
@@ -78,25 +78,25 @@ class ProtocolDiscovery {
   }
 
   void _onLine(String line) {
-    Uri uri;
+    Uri url;
     String prefix = '$_serviceName listening on ';
     int index = line.indexOf(prefix + 'http://');
     if (index >= 0) {
       try {
-        uri = Uri.parse(line.substring(index + prefix.length));
+        url = Uri.parse(line.substring(index + prefix.length));
       } catch (_) {
         // Ignore errors.
       }
     }
-    if (uri != null)
-      _located(uri);
+    if (url != null)
+      _located(url);
   }
 
-  void _located(Uri uri) {
+  void _located(Uri url) {
     assert(_completer != null);
     assert(!_completer.isCompleted);
 
-    _completer.complete(uri);
+    _completer.complete(url);
     _completer = new Completer<Uri>();
   }
 }

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -348,11 +348,11 @@ String getMissingPackageHintForPlatform(TargetPlatform platform) {
 }
 
 class DebugConnectionInfo {
-  DebugConnectionInfo({ this.httpUri, this.wsUri, this.baseUri });
+  DebugConnectionInfo({ this.httpUrl, this.wsUrl, this.baseUrl });
 
-  // TODO(danrubel): the httpUri field should be removed as part of
+  // TODO(danrubel): the httpUrl field should be removed as part of
   // https://github.com/flutter/flutter/issues/7050
-  final Uri httpUri;
-  final Uri wsUri;
-  final String baseUri;
+  final Uri httpUrl;
+  final Uri wsUrl;
+  final String baseUrl;
 }

--- a/packages/flutter_tools/lib/src/run.dart
+++ b/packages/flutter_tools/lib/src/run.dart
@@ -120,14 +120,13 @@ class RunAndStayResident extends ResidentRunner {
     startTime.stop();
 
     // Connect to observatory.
-    if (debuggingOptions.debuggingEnabled) {
-      await connectToServiceProtocol(_result.observatoryUri);
-    }
+    if (debuggingOptions.debuggingEnabled)
+      await connectToServiceProtocol(_result.observatoryUrl);
 
     if (_result.hasObservatory) {
       connectionInfoCompleter?.complete(new DebugConnectionInfo(
-        httpUri: _result.observatoryUri,
-        wsUri: vmService.wsAddress,
+        httpUrl: _result.observatoryUrl,
+        wsUrl: vmService.wsAddress,
       ));
     }
 
@@ -175,7 +174,7 @@ class RunAndStayResident extends ResidentRunner {
   void printHelp({ @required bool details }) {
     bool haveDetails = false;
     if (_result.hasObservatory)
-      printStatus('The Observatory debugger and profiler is available at: ${_result.observatoryUri}');
+      printStatus('The Observatory debugger and profiler is available at: ${_result.observatoryUrl}');
     if (supportsServiceProtocol) {
       haveDetails = true;
       if (details)

--- a/packages/flutter_tools/test/drive_test.dart
+++ b/packages/flutter_tools/test/drive_test.dart
@@ -50,7 +50,7 @@ void main() {
       appStarter = (DriveCommand command) {
         throw 'Unexpected call to appStarter';
       };
-      testRunner = (List<String> testArgs) {
+      testRunner = (List<String> testArgs, String observatoryUrl) {
         throw 'Unexpected call to testRunner';
       };
       appStopper = (DriveCommand command) {
@@ -189,7 +189,7 @@ void main() {
       appStarter = expectAsync((DriveCommand command) {
         return new Future<int>.value(0);
       });
-      testRunner = (List<String> testArgs) {
+      testRunner = (List<String> testArgs, String observatoryUrl) {
         throwToolExit(null, exitCode: 123);
       };
       appStopper = expectAsync((DriveCommand command) {

--- a/packages/flutter_tools/test/protocol_discovery_test.dart
+++ b/packages/flutter_tools/test/protocol_discovery_test.dart
@@ -19,53 +19,53 @@ void main() {
           new ProtocolDiscovery(logReader, ProtocolDiscovery.kObservatoryService);
 
       // Get next port future.
-      Future<Uri> nextUri = discoverer.nextUri();
-      expect(nextUri, isNotNull);
+      Future<Uri> nextUrl = discoverer.nextUrl();
+      expect(nextUrl, isNotNull);
 
       // Inject some lines.
       logReader.addLine('HELLO WORLD');
       logReader.addLine('Observatory listening on http://127.0.0.1:9999');
       // Await the port.
-      Uri uri = await nextUri;
-      expect(uri.port, 9999);
-      expect('$uri', 'http://127.0.0.1:9999');
+      Uri url = await nextUrl;
+      expect(url.port, 9999);
+      expect('$url', 'http://127.0.0.1:9999');
 
       // Get next port future.
-      nextUri = discoverer.nextUri();
+      nextUrl = discoverer.nextUrl();
       logReader.addLine('Observatory listening on http://127.0.0.1:3333');
-      uri = await nextUri;
-      expect(uri.port, 3333);
-      expect('$uri', 'http://127.0.0.1:3333');
+      url = await nextUrl;
+      expect(url.port, 3333);
+      expect('$url', 'http://127.0.0.1:3333');
 
       // Get next port future.
-      nextUri = discoverer.nextUri();
+      nextUrl = discoverer.nextUrl();
       // Inject a bad line.
       logReader.addLine('Observatory listening on http://127.0.0.1:apple');
-      Uri timeoutUri = Uri.parse('http://timeout');
-      Uri actualUri = await nextUri.timeout(
-          const Duration(milliseconds: 100), onTimeout: () => timeoutUri);
-      expect(actualUri, timeoutUri);
+      Uri timeoutUrl = Uri.parse('http://timeout');
+      Uri actualUrl = await nextUrl.timeout(
+          const Duration(milliseconds: 100), onTimeout: () => timeoutUrl);
+      expect(actualUrl, timeoutUrl);
 
       // Get next port future.
-      nextUri = discoverer.nextUri();
+      nextUrl = discoverer.nextUrl();
       logReader.addLine('I/flutter : Observatory listening on http://127.0.0.1:52584');
-      uri = await nextUri;
-      expect(uri.port, 52584);
-      expect('$uri', 'http://127.0.0.1:52584');
+      url = await nextUrl;
+      expect(url.port, 52584);
+      expect('$url', 'http://127.0.0.1:52584');
 
       // Get next port future.
-      nextUri = discoverer.nextUri();
+      nextUrl = discoverer.nextUrl();
       logReader.addLine('I/flutter : Observatory listening on http://127.0.0.1:54804/PTwjm8Ii8qg=/');
-      uri = await nextUri;
-      expect(uri.port, 54804);
-      expect('$uri', 'http://127.0.0.1:54804/PTwjm8Ii8qg=/');
+      url = await nextUrl;
+      expect(url.port, 54804);
+      expect('$url', 'http://127.0.0.1:54804/PTwjm8Ii8qg=/');
 
       // Get next port future.
-      nextUri = discoverer.nextUri();
+      nextUrl = discoverer.nextUrl();
       logReader.addLine('I/flutter : Observatory listening on http://somehost:54804/PTwjm8Ii8qg=/');
-      uri = await nextUri;
-      expect(uri.port, 54804);
-      expect('$uri', 'http://somehost:54804/PTwjm8Ii8qg=/');
+      url = await nextUrl;
+      expect(url.port, 54804);
+      expect('$url', 'http://somehost:54804/PTwjm8Ii8qg=/');
 
       discoverer.cancel();
       logReader.dispose();
@@ -80,11 +80,11 @@ void main() {
           defaultHostPort: 54777);
 
       // Get next port future.
-      Future<Uri> nextUri = discoverer.nextUri();
+      Future<Uri> nextUrl = discoverer.nextUrl();
       logReader.addLine('I/flutter : Observatory listening on http://somehost:54804/PTwjm8Ii8qg=/');
-      Uri uri = await nextUri;
-      expect(uri.port, 54777);
-      expect('$uri', 'http://somehost:54777/PTwjm8Ii8qg=/');
+      Uri url = await nextUrl;
+      expect(url.port, 54777);
+      expect('$url', 'http://somehost:54777/PTwjm8Ii8qg=/');
 
       discoverer.cancel();
       logReader.dispose();
@@ -100,11 +100,11 @@ void main() {
           defaultHostPort: 192);
 
       // Get next port future.
-      Future<Uri> nextUri = discoverer.nextUri();
+      Future<Uri> nextUrl = discoverer.nextUrl();
       logReader.addLine('I/flutter : Observatory listening on http://somehost:54804/PTwjm8Ii8qg=/');
-      Uri uri = await nextUri;
-      expect(uri.port, 1243);
-      expect('$uri', 'http://somehost:1243/PTwjm8Ii8qg=/');
+      Uri url = await nextUrl;
+      expect(url.port, 1243);
+      expect('$url', 'http://somehost:1243/PTwjm8Ii8qg=/');
 
       discoverer.cancel();
       logReader.dispose();


### PR DESCRIPTION
This remove a very brittle aspect of flutter drive, whereby it would
assume a known port instead of explicitly finding out what it was.

Also, I changed one variable name from the obsolete "URI" to the more
standard and conventional "URL" and then tried to fix neighbouring
code and, uh, the transitive closure of that minor change got out of
hand. Sorry about that. Let me know if you want me to separate that
into another PR.

Fixes https://github.com/flutter/flutter/issues/7692 and hopefully fixes the devicelab tests.