### PR TITLE
Refactor 'flutter drive' to get the observatory port from the logs

### DIFF
--- a/dev/devicelab/lib/tasks/perf_tests.dart
+++ b/dev/devicelab/lib/tasks/perf_tests.dart
@@ -254,10 +254,8 @@ class MemoryTest {
           testTarget,
           '-d',
           deviceId,
-          '--use-existing-app',
-        ], environment: <String, String> {
-          'VM_SERVICE_URL': 'http://localhost:$observatoryPort'
-        });
+          '--use-existing-app=http://localhost:$observatoryPort',
+        ]);
 
         Map<String, dynamic> endData = await device.getMemoryStats(packageName);
         data['end_total_kb'] = endData['total_kb'];

--- a/packages/flutter_driver/lib/src/driver.dart
+++ b/packages/flutter_driver/lib/src/driver.dart
@@ -116,7 +116,7 @@ class FlutterDriver {
   ///
   /// [dartVmServiceUrl] is the URL to Dart observatory (a.k.a. VM service). If
   /// not specified, the URL specified by the `VM_SERVICE_URL` environment
-  /// variable is used, or 'http://localhost:8183'.
+  /// variable is used. One or the other must be specified.
   ///
   /// [printCommunication] determines whether the command communication between
   /// the test and the app should be printed to stdout.
@@ -127,7 +127,14 @@ class FlutterDriver {
                                          bool printCommunication: false,
                                          bool logCommunicationToFile: true }) async {
     dartVmServiceUrl ??= Platform.environment['VM_SERVICE_URL'];
-    dartVmServiceUrl ??= 'http://localhost:8183';
+
+    if (dartVmServiceUrl == null) {
+      throw new DriverError(
+        'Could not determine URL to connect to application.\n'
+        'Either the VM_SERVICE_URL environment variable should be set, or an explicit\n'
+        'URL should be provided to the FlutterDriver.connect() method.'
+      );
+    }
 
     // Connect to Dart VM servcies
     _log.info('Connecting to Flutter application at $dartVmServiceUrl');

--- a/packages/flutter_driver/test/flutter_driver_test.dart
+++ b/packages/flutter_driver/test/flutter_driver_test.dart
@@ -53,7 +53,7 @@ void main() {
       when(mockIsolate.resume()).thenReturn(new Future<Null>.value());
       when(mockIsolate.onExtensionAdded).thenReturn(new Stream<String>.fromIterable(<String>['ext.flutter.driver']));
 
-      FlutterDriver driver = await FlutterDriver.connect();
+      FlutterDriver driver = await FlutterDriver.connect(dartVmServiceUrl: '');
       expect(driver, isNotNull);
       expectLogContains('Isolate is paused at start');
     });
@@ -62,7 +62,7 @@ void main() {
       when(mockIsolate.pauseEvent).thenReturn(new MockVMPauseBreakpointEvent());
       when(mockIsolate.resume()).thenReturn(new Future<Null>.value());
 
-      FlutterDriver driver = await FlutterDriver.connect();
+      FlutterDriver driver = await FlutterDriver.connect(dartVmServiceUrl: '');
       expect(driver, isNotNull);
       expectLogContains('Isolate is paused mid-flight');
     });
@@ -79,14 +79,14 @@ void main() {
         return new Future<Null>.error(new rpc.RpcException(101, ''));
       });
 
-      FlutterDriver driver = await FlutterDriver.connect();
+      FlutterDriver driver = await FlutterDriver.connect(dartVmServiceUrl: '');
       expect(driver, isNotNull);
       expectLogContains('Attempted to resume an already resumed isolate');
     });
 
     test('connects to unpaused isolate', () async {
       when(mockIsolate.pauseEvent).thenReturn(new MockVMResumeEvent());
-      FlutterDriver driver = await FlutterDriver.connect();
+      FlutterDriver driver = await FlutterDriver.connect(dartVmServiceUrl: '');
       expect(driver, isNotNull);
       expectLogContains('Isolate is not paused. Assuming application is ready.');
     });

--- a/packages/flutter_tools/test/drive_test.dart
+++ b/packages/flutter_tools/test/drive_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:async';
-
 import 'package:file/memory.dart';
 import 'package:flutter_tools/src/android/android_device.dart';
 import 'package:flutter_tools/src/base/common.dart';
@@ -50,7 +48,7 @@ void main() {
       appStarter = (DriveCommand command) {
         throw 'Unexpected call to appStarter';
       };
-      testRunner = (List<String> testArgs) {
+      testRunner = (List<String> testArgs, String observatoryUri) {
         throw 'Unexpected call to testRunner';
       };
       appStopper = (DriveCommand command) {
@@ -86,7 +84,7 @@ void main() {
 
     testUsingContext('returns 1 when app fails to run', () async {
       withMockDevice();
-      appStarter = expectAsync((DriveCommand command) async => 1);
+      appStarter = expectAsync((DriveCommand command) async => null);
 
       String testApp = '/some/app/test_driver/e2e.dart';
       String testFile = '/some/app/test_driver/e2e_test.dart';
@@ -104,7 +102,7 @@ void main() {
         fail('Expect exception');
       } on ToolExit catch (e) {
         expect(e.exitCode, 1);
-        expect(e.message, contains('Application failed to start (1). Will not run test. Quitting.'));
+        expect(e.message, contains('Application failed to start. Will not run test. Quitting.'));
       }
     }, overrides: <Type, Generator>{
       FileSystem: () => memoryFileSystem,
@@ -155,15 +153,15 @@ void main() {
       String testApp = '/some/app/test/e2e.dart';
       String testFile = '/some/app/test_driver/e2e_test.dart';
 
-      appStarter = expectAsync((DriveCommand command) {
-        return new Future<int>.value(0);
+      appStarter = expectAsync((DriveCommand command) async {
+        return new LaunchResult.succeeded();
       });
-      testRunner = expectAsync((List<String> testArgs) {
+      testRunner = expectAsync((List<String> testArgs, String observatoryUri) async {
         expect(testArgs, <String>[testFile]);
-        return new Future<int>.value(0);
+        return null;
       });
-      appStopper = expectAsync((DriveCommand command) {
-        return new Future<int>.value(0);
+      appStopper = expectAsync((DriveCommand command) async {
+        return true;
       });
 
       MemoryFileSystem memFs = memoryFileSystem;
@@ -186,14 +184,14 @@ void main() {
       String testApp = '/some/app/test/e2e.dart';
       String testFile = '/some/app/test_driver/e2e_test.dart';
 
-      appStarter = expectAsync((DriveCommand command) {
-        return new Future<int>.value(0);
+      appStarter = expectAsync((DriveCommand command) async {
+        return new LaunchResult.succeeded();
       });
-      testRunner = (List<String> testArgs) {
+      testRunner = (List<String> testArgs, String observatoryUri) async {
         throwToolExit(null, exitCode: 123);
       };
-      appStopper = expectAsync((DriveCommand command) {
-        return new Future<int>.value(0);
+      appStopper = expectAsync((DriveCommand command) async {
+        return true;
       });
 
       MemoryFileSystem memFs = memoryFileSystem;


### PR DESCRIPTION
This remove a very brittle aspect of flutter drive, whereby it would
assume a known port instead of explicitly finding out what it was.

Fixes #7692 and hopefully fixes the devicelab tests.