### PR TITLE
Add a `.bat` entry point for flutter tools

### DIFF
--- a/bin/flutter.bat
+++ b/bin/flutter.bat
@@ -1,0 +1,1 @@
+@PowerShell.exe -ExecutionPolicy Bypass -Command "& '%~dpn0.ps1' %*"


### PR DESCRIPTION
Currently, this only calls out to the PowerShell Script, which is kind of slow. In the future, we will transfer more logic from PowerShell to cmd for faster starup time.

https://github.com/flutter/flutter/issues/7654