### PR TITLE
Split ScrollableViewport2 from Scrolllable2

### DIFF
--- a/packages/flutter/lib/src/widgets/block.dart
+++ b/packages/flutter/lib/src/widgets/block.dart
@@ -19,7 +19,6 @@ class ScrollView extends StatelessWidget {
     this.scrollDirection: Axis.vertical,
     this.anchor: 0.0,
     this.initialScrollOffset: 0.0,
-    this.scrollBehavior,
     this.center,
     this.children,
   }) : super(key: key);
@@ -31,8 +30,6 @@ class ScrollView extends StatelessWidget {
   final double anchor;
 
   final double initialScrollOffset;
-
-  final ScrollBehavior2 scrollBehavior;
 
   final Key center;
 
@@ -56,13 +53,12 @@ class ScrollView extends StatelessWidget {
     if (padding != null)
       sliver = new SliverPadding(padding: padding, child: sliver);
 
-    return new Scrollable2(
+    return new ScrollableViewport2(
       axisDirection: _getDirection(context),
       anchor: anchor,
       initialScrollOffset: initialScrollOffset,
-      scrollBehavior: scrollBehavior,
       center: center,
-      children: <Widget>[ sliver ],
+      slivers: <Widget>[ sliver ],
     );
   }
 }

--- a/packages/flutter/lib/src/widgets/scroll_absolute.dart
+++ b/packages/flutter/lib/src/widgets/scroll_absolute.dart
@@ -79,25 +79,6 @@ class ViewportScrollBehavior extends ScrollBehavior2 {
   }
 
   @override
-  Widget createViewport({
-    Key key,
-    AxisDirection axisDirection: AxisDirection.down,
-    double anchor: 0.0,
-    ViewportOffset offset,
-    Key center,
-    List<Widget> children: const <Widget>[],
-  }) {
-    return new Viewport2(
-      key: key,
-      axisDirection: axisDirection,
-      anchor: anchor,
-      offset: offset,
-      center: center,
-      children: children,
-    );
-  }
-
-  @override
   ScrollPosition createScrollPosition(BuildContext context, Scrollable2State state, ScrollPosition oldPosition) {
     switch (getPlatform(context)) {
       case TargetPlatform.iOS:

--- a/packages/flutter/lib/src/widgets/single_child_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/single_child_scroll_view.dart
@@ -40,38 +40,18 @@ class SingleChildScrollView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final ScrollBehavior2 scrollBehavior = new _SingleChildScrollViewBehavior(
-      Scrollable2.getScrollBehavior(context)
-    );
+    final AxisDirection axisDirection = _getDirection(context);
     return new Scrollable2(
-      axisDirection: _getDirection(context),
-      initialScrollOffset: initialScrollOffset,
-      scrollBehavior: scrollBehavior,
-      children: child == null ? const <Widget>[] : <Widget>[ child ],
-    );
-  }
-}
-
-class _SingleChildScrollViewBehavior extends ScrollBehavior2Proxy {
-  _SingleChildScrollViewBehavior(ScrollBehavior2 parent) : super(parent);
-
-  @override
-  Widget createViewport({
-    Key key,
-    AxisDirection axisDirection: AxisDirection.down,
-    double anchor: 0.0,
-    ViewportOffset offset,
-    Key center,
-    List<Widget> children: const <Widget>[],
-  }) {
-    assert(anchor == 0.0);
-    assert(center == null);
-    assert(children.length <= 1);
-    return new _SingleChildViewport(
-      key: key,
       axisDirection: axisDirection,
-      offset: offset,
-      child: children.isEmpty ? null : children[0],
+      initialScrollOffset: initialScrollOffset,
+      viewportBuilder: (BuildContext context, ViewportOffset offset) {
+        return new _SingleChildViewport(
+          key: key,
+          axisDirection: axisDirection,
+          offset: offset,
+          child: child,
+        );
+      },
     );
   }
 }

--- a/packages/flutter/lib/src/widgets/viewport.dart
+++ b/packages/flutter/lib/src/widgets/viewport.dart
@@ -18,8 +18,8 @@ class Viewport2 extends MultiChildRenderObjectWidget {
     this.anchor: 0.0,
     @required this.offset,
     this.center,
-    List<Widget> children: const <Widget>[],
-  }) : super(key: key, children: children) {
+    List<Widget> slivers: const <Widget>[],
+  }) : super(key: key, children: slivers) {
     assert(offset != null);
     assert(center == null || children.where((Widget child) => child.key == center).length == 1);
   }

--- a/packages/flutter/test/widgets/overscroll_indicator_test.dart
+++ b/packages/flutter/test/widgets/overscroll_indicator_test.dart
@@ -24,8 +24,8 @@ Future<Null> slowDrag(WidgetTester tester, Point start, Offset offset) async {
 void main() {
   testWidgets('Overscroll indicator color', (WidgetTester tester) async {
     await tester.pumpWidget(
-      new Scrollable2(
-        children: <Widget>[
+      new ScrollableViewport2(
+        slivers: <Widget>[
           new SliverToBoxAdapter(child: new SizedBox(height: 2000.0)),
         ],
       ),
@@ -57,8 +57,8 @@ void main() {
 
   testWidgets('Overscroll indicator changes side when you drag on the other side', (WidgetTester tester) async {
     await tester.pumpWidget(
-      new Scrollable2(
-        children: <Widget>[
+      new ScrollableViewport2(
+        slivers: <Widget>[
           new SliverToBoxAdapter(child: new SizedBox(height: 2000.0)),
         ],
       ),
@@ -92,8 +92,8 @@ void main() {
 
   testWidgets('Overscroll indicator changes side when you shift sides', (WidgetTester tester) async {
     await tester.pumpWidget(
-      new Scrollable2(
-        children: <Widget>[
+      new ScrollableViewport2(
+        slivers: <Widget>[
           new SliverToBoxAdapter(child: new SizedBox(height: 2000.0)),
         ],
       ),
@@ -125,9 +125,9 @@ void main() {
   group('Flipping direction of scrollable doesn\'t change overscroll behavior', () {
     testWidgets('down', (WidgetTester tester) async {
       await tester.pumpWidget(
-        new Scrollable2(
+        new ScrollableViewport2(
           axisDirection: AxisDirection.down,
-          children: <Widget>[
+          slivers: <Widget>[
             new SliverToBoxAdapter(child: new SizedBox(height: 20.0)),
           ],
         ),
@@ -142,9 +142,9 @@ void main() {
 
     testWidgets('up', (WidgetTester tester) async {
       await tester.pumpWidget(
-        new Scrollable2(
+        new ScrollableViewport2(
           axisDirection: AxisDirection.up,
-          children: <Widget>[
+          slivers: <Widget>[
             new SliverToBoxAdapter(child: new SizedBox(height: 20.0)),
           ],
         ),
@@ -160,9 +160,9 @@ void main() {
 
   testWidgets('Overscroll in both directions', (WidgetTester tester) async {
     await tester.pumpWidget(
-      new Scrollable2(
+      new ScrollableViewport2(
         axisDirection: AxisDirection.down,
-        children: <Widget>[
+        slivers: <Widget>[
           new SliverToBoxAdapter(child: new SizedBox(height: 20.0)),
         ],
       ),
@@ -180,9 +180,9 @@ void main() {
 
   testWidgets('Overscroll horizontally', (WidgetTester tester) async {
     await tester.pumpWidget(
-      new Scrollable2(
+      new ScrollableViewport2(
         axisDirection: AxisDirection.right,
-        children: <Widget>[
+        slivers: <Widget>[
           new SliverToBoxAdapter(child: new SizedBox(height: 20.0)),
         ],
       ),
@@ -203,10 +203,10 @@ void main() {
     RenderObject painter;
 
     await tester.pumpWidget(
-      new Scrollable2(
+      new ScrollableViewport2(
         axisDirection: AxisDirection.left,
         scrollBehavior: new TestScrollBehavior1(),
-        children: <Widget>[
+        slivers: <Widget>[
           new SliverToBoxAdapter(child: new SizedBox(height: 20.0)),
         ],
       ),
@@ -218,10 +218,10 @@ void main() {
 
     await tester.pumpUntilNoTransientCallbacks(const Duration(seconds: 1));
     await tester.pumpWidget(
-      new Scrollable2(
+      new ScrollableViewport2(
         axisDirection: AxisDirection.right,
         scrollBehavior: new TestScrollBehavior2(),
-        children: <Widget>[
+        slivers: <Widget>[
           new SliverToBoxAdapter(child: new SizedBox(height: 20.0)),
         ],
       ),

--- a/packages/flutter/test/widgets/scrollable_custom_scroll_behavior_test.dart
+++ b/packages/flutter/test/widgets/scrollable_custom_scroll_behavior_test.dart
@@ -76,25 +76,6 @@ class TestScrollBehavior extends ScrollBehavior2 {
   Widget wrap(BuildContext context, Widget child, AxisDirection axisDirection) => child;
 
   @override
-  Widget createViewport({
-    Key key,
-    AxisDirection axisDirection: AxisDirection.down,
-    double anchor: 0.0,
-    ViewportOffset offset,
-    Key center,
-    List<Widget> children: const <Widget>[],
-  }) {
-    return new Viewport2(
-      key: key,
-      axisDirection: axisDirection,
-      anchor: anchor,
-      offset: offset,
-      center: center,
-      children: children,
-    );
-  }
-
-  @override
   ScrollPosition createScrollPosition(BuildContext context, Scrollable2State state, ScrollPosition oldPosition) {
     return new TestScrollPosition(extentMultiplier, state, ViewportScrollBehavior.defaultScrollTolerances, oldPosition);
   }
@@ -107,22 +88,21 @@ class TestScrollBehavior extends ScrollBehavior2 {
 
 void main() {
   testWidgets('Changing the scroll behavior dynamically', (WidgetTester tester) async {
-    GlobalKey<Scrollable2State> key = new GlobalKey<Scrollable2State>();
-    await tester.pumpWidget(new Scrollable2(
-      key: key,
+    await tester.pumpWidget(new ScrollableViewport2(
       scrollBehavior: new TestScrollBehavior(1.0),
-      children: <Widget>[
+      slivers: <Widget>[
         new SliverToBoxAdapter(child: new SizedBox(height: 2000.0)),
       ],
     ));
-    expect(key.currentState.position.getMetrics().extentInside, 1.0);
-    await tester.pumpWidget(new Scrollable2(
-      key: key,
+    Scrollable2State state = tester.state(find.byType(Scrollable2));
+
+    expect(state.position.getMetrics().extentInside, 1.0);
+    await tester.pumpWidget(new ScrollableViewport2(
       scrollBehavior: new TestScrollBehavior(2.0),
-      children: <Widget>[
+      slivers: <Widget>[
         new SliverToBoxAdapter(child: new SizedBox(height: 2000.0)),
       ],
     ));
-    expect(key.currentState.position.getMetrics().extentInside, 2.0);
+    expect(state.position.getMetrics().extentInside, 2.0);
   });
 }

--- a/packages/flutter/test/widgets/scrollable_test.dart
+++ b/packages/flutter/test/widgets/scrollable_test.dart
@@ -11,8 +11,8 @@ Future<Null> pumpTest(WidgetTester tester, TargetPlatform platform) async {
     theme: new ThemeData(
       platform: platform,
     ),
-    home: new Scrollable2(
-      children: <Widget>[
+    home: new ScrollableViewport2(
+      slivers: <Widget>[
         new SliverToBoxAdapter(child: new SizedBox(height: 2000.0)),
       ],
     ),

--- a/packages/flutter/test/widgets/slivers_appbar_floating_test.dart
+++ b/packages/flutter/test/widgets/slivers_appbar_floating_test.dart
@@ -24,20 +24,18 @@ void verifyActualBoxPosition(WidgetTester tester, Finder finder, int index, Rect
 
 void main() {
   testWidgets('Sliver appbars - floating - scroll offset doesn\'t change', (WidgetTester tester) async {
-    final GlobalKey<Scrollable2State> scrollableKey = new GlobalKey<Scrollable2State>();
     const double bigHeight = 1000.0;
     await tester.pumpWidget(
-      new Scrollable2(
-        key: scrollableKey,
+      new ScrollableViewport2(
         axisDirection: AxisDirection.down,
-        children: <Widget>[
+        slivers: <Widget>[
           new BigSliver(height: bigHeight),
           new SliverAppBar(delegate: new TestDelegate(), floating: true),
           new BigSliver(height: bigHeight),
         ],
       ),
     );
-    AbsoluteScrollPosition position = scrollableKey.currentState.position;
+    AbsoluteScrollPosition position = tester.state<Scrollable2State>(find.byType(Scrollable2)).position;
     final double max = bigHeight * 2.0 + new TestDelegate().maxExtent - 600.0; // 600 is the height of the test viewport
     assert(max < 10000.0);
     expect(max, 1600.0);
@@ -52,22 +50,20 @@ void main() {
   });
 
   testWidgets('Sliver appbars - floating - normal behavior works', (WidgetTester tester) async {
-    final GlobalKey<Scrollable2State> scrollableKey = new GlobalKey<Scrollable2State>();
     final TestDelegate delegate = new TestDelegate();
     const double bigHeight = 1000.0;
     GlobalKey key1, key2, key3;
     await tester.pumpWidget(
-      new Scrollable2(
-        key: scrollableKey,
+      new ScrollableViewport2(
         axisDirection: AxisDirection.down,
-        children: <Widget>[
+        slivers: <Widget>[
           new BigSliver(key: key1 = new GlobalKey(), height: bigHeight),
           new SliverAppBar(key: key2 = new GlobalKey(), delegate: delegate, floating: true),
           new BigSliver(key: key3 = new GlobalKey(), height: bigHeight),
         ],
       ),
     );
-    AbsoluteScrollPosition position = scrollableKey.currentState.position;
+    AbsoluteScrollPosition position = tester.state<Scrollable2State>(find.byType(Scrollable2)).position;
 
     verifyPaintPosition(key1, new Offset(0.0, 0.0), true);
     verifyPaintPosition(key2, new Offset(0.0, 600.0), false);
@@ -124,22 +120,20 @@ void main() {
   });
 
   testWidgets('Sliver appbars - floating - no floating behavior when animating', (WidgetTester tester) async {
-    final GlobalKey<Scrollable2State> scrollableKey = new GlobalKey<Scrollable2State>();
     final TestDelegate delegate = new TestDelegate();
     const double bigHeight = 1000.0;
     GlobalKey key1, key2, key3;
     await tester.pumpWidget(
-      new Scrollable2(
-        key: scrollableKey,
+      new ScrollableViewport2(
         axisDirection: AxisDirection.down,
-        children: <Widget>[
+        slivers: <Widget>[
           new BigSliver(key: key1 = new GlobalKey(), height: bigHeight),
           new SliverAppBar(key: key2 = new GlobalKey(), delegate: delegate, floating: true),
           new BigSliver(key: key3 = new GlobalKey(), height: bigHeight),
         ],
       ),
     );
-    AbsoluteScrollPosition position = scrollableKey.currentState.position;
+    AbsoluteScrollPosition position = tester.state<Scrollable2State>(find.byType(Scrollable2)).position;
 
     verifyPaintPosition(key1, new Offset(0.0, 0.0), true);
     verifyPaintPosition(key2, new Offset(0.0, 600.0), false);
@@ -159,22 +153,20 @@ void main() {
   });
 
   testWidgets('Sliver appbars - floating - floating behavior when dragging down', (WidgetTester tester) async {
-    final GlobalKey<Scrollable2State> scrollableKey = new GlobalKey<Scrollable2State>();
     final TestDelegate delegate = new TestDelegate();
     const double bigHeight = 1000.0;
     GlobalKey key1, key2, key3;
     await tester.pumpWidget(
-      new Scrollable2(
-        key: scrollableKey,
+      new ScrollableViewport2(
         axisDirection: AxisDirection.down,
-        children: <Widget>[
+        slivers: <Widget>[
           new BigSliver(key: key1 = new GlobalKey(), height: bigHeight),
           new SliverAppBar(key: key2 = new GlobalKey(), delegate: delegate, floating: true),
           new BigSliver(key: key3 = new GlobalKey(), height: bigHeight),
         ],
       ),
     );
-    AbsoluteScrollPosition position = scrollableKey.currentState.position;
+    AbsoluteScrollPosition position = tester.state<Scrollable2State>(find.byType(Scrollable2)).position;
 
     verifyPaintPosition(key1, new Offset(0.0, 0.0), true);
     verifyPaintPosition(key2, new Offset(0.0, 600.0), false);

--- a/packages/flutter/test/widgets/slivers_appbar_pinned_test.dart
+++ b/packages/flutter/test/widgets/slivers_appbar_pinned_test.dart
@@ -24,14 +24,12 @@ void verifyActualBoxPosition(WidgetTester tester, Finder finder, int index, Rect
 
 void main() {
   testWidgets('Sliver appbars - pinned', (WidgetTester tester) async {
-    final GlobalKey<Scrollable2State> scrollableKey = new GlobalKey<Scrollable2State>();
     const double bigHeight = 550.0;
     GlobalKey key1, key2, key3, key4, key5;
     await tester.pumpWidget(
-      new Scrollable2(
-        key: scrollableKey,
+      new ScrollableViewport2(
         axisDirection: AxisDirection.down,
-        children: <Widget>[
+        slivers: <Widget>[
           new BigSliver(key: key1 = new GlobalKey(), height: bigHeight),
           new SliverAppBar(key: key2 = new GlobalKey(), delegate: new TestDelegate(), pinned: true),
           new SliverAppBar(key: key3 = new GlobalKey(), delegate: new TestDelegate(), pinned: true),
@@ -40,7 +38,7 @@ void main() {
         ],
       ),
     );
-    AbsoluteScrollPosition position = scrollableKey.currentState.position;
+    AbsoluteScrollPosition position = tester.state<Scrollable2State>(find.byType(Scrollable2)).position;
     final double max = bigHeight * 3.0 + new TestDelegate().maxExtent * 2.0 - 600.0; // 600 is the height of the test viewport
     assert(max < 10000.0);
     expect(max, 1450.0);
@@ -60,14 +58,12 @@ void main() {
   });
 
   testWidgets('Sliver appbars - pinned with slow scroll', (WidgetTester tester) async {
-    final GlobalKey<Scrollable2State> scrollableKey = new GlobalKey<Scrollable2State>();
     const double bigHeight = 550.0;
     GlobalKey key1, key2, key3, key4, key5;
     await tester.pumpWidget(
-      new Scrollable2(
-        key: scrollableKey,
+      new ScrollableViewport2(
         axisDirection: AxisDirection.down,
-        children: <Widget>[
+        slivers: <Widget>[
           new BigSliver(key: key1 = new GlobalKey(), height: bigHeight),
           new SliverAppBar(key: key2 = new GlobalKey(), delegate: new TestDelegate(), pinned: true),
           new SliverAppBar(key: key3 = new GlobalKey(), delegate: new TestDelegate(), pinned: true),
@@ -76,7 +72,7 @@ void main() {
         ],
       ),
     );
-    AbsoluteScrollPosition position = scrollableKey.currentState.position;
+    AbsoluteScrollPosition position = tester.state<Scrollable2State>(find.byType(Scrollable2)).position;
     verifyPaintPosition(key1, new Offset(0.0, 0.0), true);
     verifyPaintPosition(key2, new Offset(0.0, 550.0), true);
     verifyPaintPosition(key3, new Offset(0.0, 600.0), false);
@@ -152,14 +148,12 @@ void main() {
   });
 
   testWidgets('Sliver appbars - pinned with less overlap', (WidgetTester tester) async {
-    final GlobalKey<Scrollable2State> scrollableKey = new GlobalKey<Scrollable2State>();
     const double bigHeight = 650.0;
     GlobalKey key1, key2, key3, key4, key5;
     await tester.pumpWidget(
-      new Scrollable2(
-        key: scrollableKey,
+      new ScrollableViewport2(
         axisDirection: AxisDirection.down,
-        children: <Widget>[
+        slivers: <Widget>[
           new BigSliver(key: key1 = new GlobalKey(), height: bigHeight),
           new SliverAppBar(key: key2 = new GlobalKey(), delegate: new TestDelegate(), pinned: true),
           new SliverAppBar(key: key3 = new GlobalKey(), delegate: new TestDelegate(), pinned: true),
@@ -168,7 +162,7 @@ void main() {
         ],
       ),
     );
-    AbsoluteScrollPosition position = scrollableKey.currentState.position;
+    AbsoluteScrollPosition position = tester.state<Scrollable2State>(find.byType(Scrollable2)).position;
     final double max = bigHeight * 3.0 + new TestDelegate().maxExtent * 2.0 - 600.0; // 600 is the height of the test viewport
     assert(max < 10000.0);
     expect(max, 1750.0);

--- a/packages/flutter/test/widgets/slivers_appbar_scrolling_test.dart
+++ b/packages/flutter/test/widgets/slivers_appbar_scrolling_test.dart
@@ -16,13 +16,11 @@ void verifyPaintPosition(GlobalKey key, Offset ideal) {
 
 void main() {
   testWidgets('Sliver appbars - scrolling', (WidgetTester tester) async {
-    final GlobalKey<Scrollable2State> scrollableKey = new GlobalKey<Scrollable2State>();
     GlobalKey key1, key2, key3, key4, key5;
     await tester.pumpWidget(
-      new Scrollable2(
-        key: scrollableKey,
+      new ScrollableViewport2(
         axisDirection: AxisDirection.down,
-        children: <Widget>[
+        slivers: <Widget>[
           new BigSliver(key: key1 = new GlobalKey()),
           new SliverAppBar(key: key2 = new GlobalKey(), delegate: new TestDelegate()),
           new SliverAppBar(key: key3 = new GlobalKey(), delegate: new TestDelegate()),
@@ -31,7 +29,7 @@ void main() {
         ],
       ),
     );
-    AbsoluteScrollPosition position = scrollableKey.currentState.position;
+    AbsoluteScrollPosition position = tester.state<Scrollable2State>(find.byType(Scrollable2)).position;
     final double max = RenderBigSliver.height * 3.0 + new TestDelegate().maxExtent * 2.0 - 600.0; // 600 is the height of the test viewport
     assert(max < 10000.0);
     expect(max, 1450.0);
@@ -51,14 +49,12 @@ void main() {
   });
 
   testWidgets('Sliver appbars - scrolling off screen', (WidgetTester tester) async {
-    final GlobalKey<Scrollable2State> scrollableKey = new GlobalKey<Scrollable2State>();
     GlobalKey key = new GlobalKey();
     TestDelegate delegate = new TestDelegate();
     await tester.pumpWidget(
-      new Scrollable2(
-        key: scrollableKey,
+      new ScrollableViewport2(
         axisDirection: AxisDirection.down,
-        children: <Widget>[
+        slivers: <Widget>[
           new BigSliver(),
           new SliverAppBar(key: key, delegate: delegate),
           new BigSliver(),
@@ -66,7 +62,7 @@ void main() {
         ],
       ),
     );
-    AbsoluteScrollPosition position = scrollableKey.currentState.position;
+    AbsoluteScrollPosition position = tester.state<Scrollable2State>(find.byType(Scrollable2)).position;
     position.animate(to: RenderBigSliver.height + delegate.maxExtent - 5.0, curve: Curves.linear, duration: const Duration(minutes: 1));
     await tester.pumpUntilNoTransientCallbacks(const Duration(milliseconds: 1000));
     RenderBox box = tester.renderObject/*<RenderBox>*/(find.byType(Container));

--- a/packages/flutter/test/widgets/slivers_block_global_key_test.dart
+++ b/packages/flutter/test/widgets/slivers_block_global_key_test.dart
@@ -26,7 +26,7 @@ Future<Null> test(WidgetTester tester, double offset, List<int> keys) {
   globalGeneration += 1;
   return tester.pumpWidget(new Viewport2(
     offset: new ViewportOffset.fixed(offset),
-    children: <Widget>[
+    slivers: <Widget>[
       new SliverBlock(
         delegate: new SliverBlockChildListDelegate(keys.map((int key) {
           return new SizedBox(key: new GlobalObjectKey(key), height: 100.0, child: new GenerationText(key));

--- a/packages/flutter/test/widgets/slivers_block_test.dart
+++ b/packages/flutter/test/widgets/slivers_block_test.dart
@@ -11,7 +11,7 @@ import '../rendering/mock_canvas.dart';
 Future<Null> test(WidgetTester tester, double offset) {
   return tester.pumpWidget(new Viewport2(
     offset: new ViewportOffset.fixed(offset),
-    children: <Widget>[
+    slivers: <Widget>[
       new SliverBlock(
         delegate: new SliverBlockChildListDelegate(<Widget>[
           new SizedBox(height: 400.0, child: new Text('a')),
@@ -76,7 +76,7 @@ void main() {
     ViewportOffset offset = new ViewportOffset.zero();
     await tester.pumpWidget(new Viewport2(
       offset: offset,
-      children: <Widget>[
+      slivers: <Widget>[
         new SliverBlock(
           delegate: new SliverBlockChildListDelegate(<Widget>[
             new SizedBox(height: 251.0, child: new Text('a')),
@@ -93,7 +93,7 @@ void main() {
     ], 'abc');
     await tester.pumpWidget(new Viewport2(
       offset: offset,
-      children: <Widget>[
+      slivers: <Widget>[
         new SliverBlock(
           delegate: new SliverBlockChildListDelegate(<Widget>[
             new SizedBox(key: key1, height: 253.0, child: new Text('c')),
@@ -110,7 +110,7 @@ void main() {
     ], 'cab');
     await tester.pumpWidget(new Viewport2(
       offset: offset,
-      children: <Widget>[
+      slivers: <Widget>[
         new SliverBlock(
           delegate: new SliverBlockChildListDelegate(<Widget>[
             new SizedBox(height: 251.0, child: new Text('a')),
@@ -127,7 +127,7 @@ void main() {
     ], 'acb');
     await tester.pumpWidget(new Viewport2(
       offset: offset,
-      children: <Widget>[
+      slivers: <Widget>[
         new SliverBlock(
           delegate: new SliverBlockChildListDelegate(<Widget>[
             new SizedBox(height: 251.0, child: new Text('a')),
@@ -142,7 +142,7 @@ void main() {
     ], 'ab');
     await tester.pumpWidget(new Viewport2(
       offset: offset,
-      children: <Widget>[
+      slivers: <Widget>[
         new SliverBlock(
           delegate: new SliverBlockChildListDelegate(<Widget>[
             new SizedBox(height: 251.0, child: new Text('a')),
@@ -162,7 +162,7 @@ void main() {
   testWidgets('Viewport2 overflow clipping of SliverToBoxAdapter', (WidgetTester tester) async {
     await tester.pumpWidget(new Viewport2(
       offset: new ViewportOffset.zero(),
-      children: <Widget>[
+      slivers: <Widget>[
         new SliverToBoxAdapter(
           child: new SizedBox(height: 400.0, child: new Text('a')),
         ),
@@ -173,7 +173,7 @@ void main() {
 
     await tester.pumpWidget(new Viewport2(
       offset: new ViewportOffset.fixed(100.0),
-      children: <Widget>[
+      slivers: <Widget>[
         new SliverToBoxAdapter(
           child: new SizedBox(height: 400.0, child: new Text('a')),
         ),
@@ -184,7 +184,7 @@ void main() {
 
     await tester.pumpWidget(new Viewport2(
       offset: new ViewportOffset.fixed(100.0),
-      children: <Widget>[
+      slivers: <Widget>[
         new SliverToBoxAdapter(
           child: new SizedBox(height: 4000.0, child: new Text('a')),
         ),
@@ -195,7 +195,7 @@ void main() {
 
     await tester.pumpWidget(new Viewport2(
       offset: new ViewportOffset.zero(),
-      children: <Widget>[
+      slivers: <Widget>[
         new SliverToBoxAdapter(
           child: new SizedBox(height: 4000.0, child: new Text('a')),
         ),
@@ -208,7 +208,7 @@ void main() {
   testWidgets('Viewport2 overflow clipping of SliverBlock', (WidgetTester tester) async {
     await tester.pumpWidget(new Viewport2(
       offset: new ViewportOffset.zero(),
-      children: <Widget>[
+      slivers: <Widget>[
         new SliverBlock(
           delegate: new SliverBlockChildListDelegate(<Widget>[
             new SizedBox(height: 400.0, child: new Text('a')),
@@ -221,7 +221,7 @@ void main() {
 
     await tester.pumpWidget(new Viewport2(
       offset: new ViewportOffset.fixed(100.0),
-      children: <Widget>[
+      slivers: <Widget>[
         new SliverBlock(
           delegate: new SliverBlockChildListDelegate(<Widget>[
             new SizedBox(height: 400.0, child: new Text('a')),
@@ -234,7 +234,7 @@ void main() {
 
     await tester.pumpWidget(new Viewport2(
       offset: new ViewportOffset.fixed(100.0),
-      children: <Widget>[
+      slivers: <Widget>[
         new SliverBlock(
           delegate: new SliverBlockChildListDelegate(<Widget>[
             new SizedBox(height: 4000.0, child: new Text('a')),
@@ -247,7 +247,7 @@ void main() {
 
     await tester.pumpWidget(new Viewport2(
       offset: new ViewportOffset.zero(),
-      children: <Widget>[
+      slivers: <Widget>[
         new SliverBlock(
           delegate: new SliverBlockChildListDelegate(<Widget>[
             new SizedBox(height: 4000.0, child: new Text('a')),

--- a/packages/flutter/test/widgets/slivers_padding_test.dart
+++ b/packages/flutter/test/widgets/slivers_padding_test.dart
@@ -10,7 +10,7 @@ Future<Null> test(WidgetTester tester, double offset, EdgeInsets padding, AxisDi
   return tester.pumpWidget(new Viewport2(
     offset: new ViewportOffset.fixed(offset),
     axisDirection: axisDirection,
-    children: <Widget>[
+    slivers: <Widget>[
       new SliverToBoxAdapter(child: new SizedBox(width: 400.0, height: 400.0, child: new Text('before'))),
       new SliverPadding(
         padding: padding,
@@ -163,7 +163,7 @@ void main() {
   testWidgets('Viewport2+SliverPadding no child', (WidgetTester tester) async {
     await tester.pumpWidget(new Viewport2(
       offset: new ViewportOffset.fixed(0.0),
-      children: <Widget>[
+      slivers: <Widget>[
         new SliverPadding(padding: new EdgeInsets.all(100.0)),
         new SliverToBoxAdapter(child: new SizedBox(width: 400.0, height: 400.0, child: new Text('x'))),
       ],
@@ -176,7 +176,7 @@ void main() {
     await tester.pumpWidget(new Viewport2(
       axisDirection: AxisDirection.left,
       offset: new ViewportOffset.fixed(0.0),
-      children: <Widget>[
+      slivers: <Widget>[
         new SliverPadding(padding: new EdgeInsets.fromLTRB(90.0, 1.0, 110.0, 2.0)),
         new SliverToBoxAdapter(child: new SizedBox(width: 201.0, child: new Text('x'))),
       ],
@@ -186,7 +186,7 @@ void main() {
     await tester.pumpWidget(new Viewport2(
       axisDirection: AxisDirection.left,
       offset: new ViewportOffset.fixed(0.0),
-      children: <Widget>[
+      slivers: <Widget>[
         new SliverPadding(padding: new EdgeInsets.fromLTRB(110.0, 1.0, 80.0, 2.0)),
         new SliverToBoxAdapter(child: new SizedBox(width: 201.0, child: new Text('x'))),
       ],
@@ -199,7 +199,7 @@ void main() {
     await tester.pumpWidget(new Viewport2(
       axisDirection: AxisDirection.up,
       offset: new ViewportOffset.fixed(0.0),
-      children: <Widget>[
+      slivers: <Widget>[
         new SliverPadding(padding: new EdgeInsets.fromLTRB(1.0, 2.0, 4.0, 8.0)),
       ],
     ));
@@ -207,7 +207,7 @@ void main() {
     await tester.pumpWidget(new Viewport2(
       axisDirection: AxisDirection.down,
       offset: new ViewportOffset.fixed(0.0),
-      children: <Widget>[
+      slivers: <Widget>[
         new SliverPadding(padding: new EdgeInsets.fromLTRB(1.0, 2.0, 4.0, 8.0)),
       ],
     ));
@@ -215,7 +215,7 @@ void main() {
     await tester.pumpWidget(new Viewport2(
       axisDirection: AxisDirection.right,
       offset: new ViewportOffset.fixed(0.0),
-      children: <Widget>[
+      slivers: <Widget>[
         new SliverPadding(padding: new EdgeInsets.fromLTRB(1.0, 2.0, 4.0, 8.0)),
       ],
     ));
@@ -223,7 +223,7 @@ void main() {
     await tester.pumpWidget(new Viewport2(
       axisDirection: AxisDirection.left,
       offset: new ViewportOffset.fixed(0.0),
-      children: <Widget>[
+      slivers: <Widget>[
         new SliverPadding(padding: new EdgeInsets.fromLTRB(1.0, 2.0, 4.0, 8.0)),
       ],
     ));
@@ -231,7 +231,7 @@ void main() {
     await tester.pumpWidget(new Viewport2(
       axisDirection: AxisDirection.left,
       offset: new ViewportOffset.fixed(99999.9),
-      children: <Widget>[
+      slivers: <Widget>[
         new SliverPadding(padding: new EdgeInsets.fromLTRB(1.0, 2.0, 4.0, 8.0)),
       ],
     ));

--- a/packages/flutter/test/widgets/slivers_protocol_test.dart
+++ b/packages/flutter/test/widgets/slivers_protocol_test.dart
@@ -18,13 +18,11 @@ void verifyPaintPosition(GlobalKey key, Offset ideal) {
 
 void main() {
   testWidgets('Sliver protocol', (WidgetTester tester) async {
-    final GlobalKey<Scrollable2State> scrollableKey = new GlobalKey<Scrollable2State>();
     GlobalKey key1, key2, key3, key4, key5;
     await tester.pumpWidget(
-      new Scrollable2(
-        key: scrollableKey,
+      new ScrollableViewport2(
         axisDirection: AxisDirection.down,
-        children: <Widget>[
+        slivers: <Widget>[
           new BigSliver(key: key1 = new GlobalKey()),
           new OverlappingSliver(key: key2 = new GlobalKey()),
           new OverlappingSliver(key: key3 = new GlobalKey()),
@@ -33,7 +31,7 @@ void main() {
         ],
       ),
     );
-    AbsoluteScrollPosition position = scrollableKey.currentState.position;
+    AbsoluteScrollPosition position = tester.state<Scrollable2State>(find.byType(Scrollable2)).position;
     final double max = RenderBigSliver.height * 3.0 + (RenderOverlappingSliver.totalHeight) * 2.0 - 600.0; // 600 is the height of the test viewport
     assert(max < 10000.0);
     expect(max, 1450.0);

--- a/packages/flutter/test/widgets/slivers_test.dart
+++ b/packages/flutter/test/widgets/slivers_test.dart
@@ -10,7 +10,7 @@ Future<Null> test(WidgetTester tester, double offset, { double anchor: 0.0 }) {
   return tester.pumpWidget(new Viewport2(
     anchor: anchor / 600.0,
     offset: new ViewportOffset.fixed(offset),
-    children: <Widget>[
+    slivers: <Widget>[
       new SliverToBoxAdapter(child: new SizedBox(height: 400.0)),
       new SliverToBoxAdapter(child: new SizedBox(height: 400.0)),
       new SliverToBoxAdapter(child: new SizedBox(height: 400.0)),


### PR DESCRIPTION
This structure makes it easier to customize the viewport used in a Scrollable.
Now Scrollable2 doesn't commit to using slivers.