### PR TITLE
Give rounded corners to Flat Buttons

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -14,3 +14,4 @@ Michael Beckler <mcbeckler@gmail.com>
 Alexandre Ardhuin <alexandre.ardhuin@gmail.com>
 Luke Freeman <luke@goposse.com>
 Vincent Le Quéméner <eu.lequem@gmail.com>
+Gonzalo Nardini <gonzalo.nardini.dev@gmail.com>

--- a/packages/flutter/lib/src/material/button.dart
+++ b/packages/flutter/lib/src/material/button.dart
@@ -272,21 +272,13 @@ class _MaterialButtonState extends State<MaterialButton> {
         )
       )
     );
-    if (elevation > 0 || config.color != null) {
-      contents = new Material(
-        type: MaterialType.button,
-        color: config.color,
-        elevation: elevation,
-        textStyle: style,
-        child: contents
-      );
-    } else {
-      contents = new AnimatedDefaultTextStyle(
-        style: style,
-        duration: kThemeChangeDuration,
-        child: contents
-      );
-    }
+    contents = new Material(
+      type: MaterialType.button,
+      color: config.color,
+      elevation: elevation,
+      textStyle: style,
+      child: contents
+    );
     return new ConstrainedBox(
       constraints: new BoxConstraints(
         minWidth: config.minWidth ?? buttonTheme.minWidth,


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/7706

The problem is that `FlatButton` has by definition elevation 0, so if a color wasn't set, no `Material` widget was created. That is the case on the Gallery demo. I assume the `Material` widget was not added previously in some cases for performance reasons, but if there was a different one please let me know.

`AnimatedDefaultTextStyle` is added inside the Material widget with the same parameters, so it's not necessary to have it on `Material` with this change.