### PR TITLE
Fix wording of app bar vs toolbar in gallery

### DIFF
--- a/examples/flutter_gallery/lib/demo/contacts_demo.dart
+++ b/examples/flutter_gallery/lib/demo/contacts_demo.dart
@@ -127,11 +127,11 @@ class ContactsDemoState extends State<ContactsDemo> {
               itemBuilder: (BuildContext context) => <PopupMenuItem<AppBarBehavior>>[
                 new PopupMenuItem<AppBarBehavior>(
                   value: AppBarBehavior.scroll,
-                  child: new Text('Toolbar scrolls away')
+                  child: new Text('App bar scrolls away')
                 ),
                 new PopupMenuItem<AppBarBehavior>(
                   value: AppBarBehavior.under,
-                  child: new Text('Toolbar stays put')
+                  child: new Text('App bar stays put')
                 )
               ]
             )


### PR DESCRIPTION
Reverts a change from https://github.com/flutter/flutter/pull/3158.
Fixes https://github.com/flutter/flutter/issues/3161