### PR TITLE
Added Widgets that interact with asynchronous computations

### DIFF
--- a/packages/flutter/lib/src/widgets/async.dart
+++ b/packages/flutter/lib/src/widgets/async.dart
@@ -3,203 +3,97 @@
 // found in the LICENSE file.
 
 /// Widgets that handle interaction with asynchronous computations.
+///
+/// Asynchronous computations are represented by [Future]s and [Stream]s.
 
 import 'package:flutter/widgets.dart';
+import 'package:meta/meta.dart' show required;
 import 'dart:async' show Future, Stream, StreamSubscription;
 
-/// Snapshot of an asynchronous interaction.
-class AsyncSnapshot<T> {
-  /// Current state of connection to the asynchronous computation.
-  final ConnectionState connectionState;
-
-  /// Latest data received. Is null, if [error] is not.
-  final T data;
-
-  /// Latest error object received. Is null, if [data] is not.
-  final dynamic error;
-
-  AsyncSnapshot(this.connectionState, this.data, this.error);
-
-  bool get hasError => error != null;
-  bool get hasData => data != null;
-
-  @override
-  String toString() => 'AsyncSnapshot($connectionState, $data, $error)';
-
-  @override
-  bool operator ==(dynamic o) =>
-      o == this ||
-      o is AsyncSnapshot<T> &&
-          connectionState == o.connectionState &&
-          data == o.data &&
-          error == o.error;
-
-  @override
-  int get hashCode => hashValues(connectionState, data, error);
-}
-
-/// The state of connection to an asynchronous computation.
-enum ConnectionState {
-  /// Not currently connected to any asynchronous computation.
-  none,
-
-  /// Connected to an asynchronous computation and awaiting interaction.
-  waiting,
-
-  /// Connected to an active asynchronous computation.
-  active,
-
-  /// Connected to a terminated asynchronous computation.
-  done
-}
-
-/// Strategy for building a Widget based on asynchronous interaction.
-typedef Widget AsyncWidgetBuilder<T>(
-    BuildContext context, AsyncSnapshot<T> snapshot);
-
-/// Widget that builds itself based on interaction with the specified [future].
+/// Base class for widgets that build themselves based on interaction with
+/// a specified [Stream].
 ///
-/// The building strategy is defined by the given [builder].
+/// A [StreamBuilderBase] is stateful and maintains a summary of the interaction
+/// so far. The type of the summary and how it is updated with each interaction
+/// is defined by sub-classes.
 ///
-/// Behaves identically to [StreamBuilder] configured with [future].asStream()
-/// when [future] is non-null.
-class FutureBuilder<T> extends StatefulWidget {
-  final Future<T> future;
-  final AsyncWidgetBuilder<T> builder;
-
-  FutureBuilder({Key key, this.future, this.builder}) : super(key: key);
-
-  @override
-  State<FutureBuilder<T>> createState() => new _FutureBuilderState<T>();
-}
-
-class _FutureBuilderState<T> extends State<FutureBuilder<T>> {
-  Stream<T> _stream;
-
-  @override
-  void initState() {
-    super.initState();
-    _subscribe();
-  }
-
-  @override
-  void didUpdateConfig(FutureBuilder<T> oldConfig) {
-    if (!identical(oldConfig.future, config.future)) {
-      _unsubscribe();
-      _subscribe();
-    }
-  }
-
-  @override
-  Widget build(BuildContext context) =>
-      new StreamBuilder<T>(stream: _stream, builder: config.builder);
-
-  @override
-  void dispose() {
-    _unsubscribe();
-    super.dispose();
-  }
-
-  void _subscribe() {
-    _stream = config.future?.asStream();
-  }
-
-  void _unsubscribe() {
-    _stream = null;
-  }
-}
-
-/// Widget that builds itself based on the latest snapshot of interaction with
-/// the specified [stream].
+/// Examples of summaries include:
 ///
-/// The building strategy is defined by the given [builder].
-class StreamBuilder<T> extends StreamFold<T, AsyncSnapshot<T>> {
-  final AsyncWidgetBuilder<T> builder;
-
-  StreamBuilder({Key key, Stream<T> stream, this.builder})
-      : super(key: key, stream: stream);
-
-  @override
-  AsyncSnapshot<T> initial() =>
-      new AsyncSnapshot<T>(ConnectionState.none, null, null);
-
-  @override
-  AsyncSnapshot<T> onConnecting(AsyncSnapshot<T> current) =>
-      new AsyncSnapshot<T>(
-          ConnectionState.waiting, current.data, current.error);
-
-  @override
-  AsyncSnapshot<T> onData(AsyncSnapshot<T> current, T data) =>
-      new AsyncSnapshot<T>(ConnectionState.active, data, null);
-
-  @override
-  AsyncSnapshot<T> onError(AsyncSnapshot<T> current, dynamic error) =>
-      new AsyncSnapshot<T>(ConnectionState.active, null, error);
-
-  @override
-  AsyncSnapshot<T> onDone(AsyncSnapshot<T> current) =>
-      new AsyncSnapshot<T>(ConnectionState.done, current.data, current.error);
-
-  @override
-  AsyncSnapshot<T> onDisconnecting(AsyncSnapshot<T> current) =>
-      new AsyncSnapshot<T>(
-          ConnectionState.none, current.data, current.error);
-
-  @override
-  Widget build(BuildContext context, AsyncSnapshot<T> currentSummary) =>
-      builder(context, currentSummary);
-}
-
-/// Base class for Widgets that build themselves based on interaction with
-/// a specified [stream].
+/// * the running average of a stream of integers;
+/// * the current direction and speed based on a stream of geolocation data;
+/// * a graph displaying data points from a stream.
 ///
-/// The widget's state maintains a summary of the interaction so far. The
-/// summary is defined by sub-classes.
+/// In general, the summary is the result of a fold computation over the data
+/// items and errors received from the stream along with pseudo-events
+/// representing termination or change of stream. The initial summary is
+/// specified by sub-classes by overriding [initial]. The summary updates on
+/// receipt of stream data and errors are specified by overriding [onData] and
+/// [onError], respectively. If needed, the summary may be updated on stream
+/// termination by overriding [onDone]. Finally, the summary may be updated
+/// on change of stream by overriding [onConnected] and [onDisconnected].
 ///
-/// [T] type of stream events.
-/// [S] type of summary.
-abstract class StreamFold<T, S> extends StatefulWidget {
+/// [T] is the type of stream events.
+/// [S] is the type of interaction summary.
+///
+/// See also:
+///
+///  * [StreamBuilder], which is specialized to the case where only the most
+///  recent interaction is needed for widget building.
+abstract class StreamBuilderBase<T, S> extends StatefulWidget {
+  /// Creates a [StreamBuilderBase] connected to the specified [stream].
+  StreamBuilderBase({ Key key, this.stream }) : super(key: key);
+
+  /// The asynchronous computation to which this builder is currently connected,
+  /// possibly `null`. When changed, the current summary is updated using
+  /// [onDisconnecting], if the previous stream was not `null`, followed by
+  /// [onConnecting], if the new stream is not `null`.
   final Stream<T> stream;
 
-  StreamFold({Key key, this.stream}) : super(key: key);
-
-  /// Returns the initial summary.
+  /// Returns the initial summary of stream interaction, typically representing
+  /// the fact that no interaction has happened at all.
+  ///
+  /// Sub-classes must override this method to provide the initial value for
+  /// the fold computation.
   S initial();
 
   /// Returns an updated version of the [current] summary reflecting that we
   /// are now connected to a stream.
   ///
   /// The default implementation returns [current] as is.
-  S onConnecting(S current) => current;
+  S afterConnected(S current) => current;
 
-  /// Returns an updated version of the [current] summary following an event.
-  S onData(S current, T data);
+  /// Returns an updated version of the [current] summary following a data event.
+  ///
+  /// Sub-classes must override this method to specify how the current summary
+  /// is combined with the new data item in the fold computation.
+  S afterData(S current, T data);
 
   /// Returns an updated version of the [current] summary following an error.
   ///
   /// The default implementation returns [current] as is.
-  S onError(S current, dynamic error) => current;
+  S afterError(S current, Object error) => current;
 
   /// Returns an updated version of the [current] summary following stream
   /// termination.
   ///
   /// The default implementation returns [current] as is.
-  S onDone(S current) => current;
+  S afterDone(S current) => current;
 
   /// Returns an updated version of the [current] summary reflecting that we
   /// are no longer connected to a stream.
   ///
   /// The default implementation returns [current] as is.
-  S onDisconnecting(S current) => current;
+  S afterDisconnected(S current) => current;
 
   /// Returns a Widget based on the [currentSummary].
   Widget build(BuildContext context, S currentSummary);
 
   @override
-  State<StreamFold<T, S>> createState() => new _StreamFoldState<T, S>();
+  State<StreamBuilderBase<T, S>> createState() => new _StreamBuilderBaseState<T, S>();
 }
 
-class _StreamFoldState<T, S> extends State<StreamFold<T, S>> {
+/// State for [StreamBuilderBase].
+class _StreamBuilderBaseState<T, S> extends State<StreamBuilderBase<T, S>> {
   StreamSubscription<T> _subscription;
   S _summary;
 
@@ -211,9 +105,12 @@ class _StreamFoldState<T, S> extends State<StreamFold<T, S>> {
   }
 
   @override
-  void didUpdateConfig(StreamFold<T, S> oldConfig) {
-    if (!identical(oldConfig.stream, config.stream)) {
-      _unsubscribe();
+  void didUpdateConfig(StreamBuilderBase<T, S> oldConfig) {
+    if (oldConfig.stream != config.stream) {
+      if (_subscription != null) {
+        _unsubscribe();
+        _summary = config.afterDisconnected(_summary);
+      }
       _subscribe();
     }
   }
@@ -231,18 +128,18 @@ class _StreamFoldState<T, S> extends State<StreamFold<T, S>> {
     if (config.stream != null) {
       _subscription = config.stream.listen((T event) {
         setState(() {
-          _summary = config.onData(_summary, event);
+          _summary = config.afterData(_summary, event);
         });
-      }, onError: (dynamic e) {
+      }, onError: (Object e) {
         setState(() {
-          _summary = config.onError(_summary, e);
+          _summary = config.afterError(_summary, e);
         });
       }, onDone: () {
         setState(() {
-          _summary = config.onDone(_summary);
+          _summary = config.afterDone(_summary);
         });
       });
-      _summary = config.onConnecting(_summary);
+      _summary = config.afterConnected(_summary);
     }
   }
 
@@ -250,7 +147,241 @@ class _StreamFoldState<T, S> extends State<StreamFold<T, S>> {
     if (_subscription != null) {
       _subscription.cancel();
       _subscription = null;
-      _summary = config.onDisconnecting(_summary);
     }
+  }
+}
+
+/// The state of connection to an asynchronous computation.
+///
+/// See also:
+///
+/// * [AsyncSnapshot]
+enum ConnectionState {
+  /// Not currently connected to any asynchronous computation.
+  none,
+
+  /// Connected to an asynchronous computation and awaiting interaction.
+  waiting,
+
+  /// Connected to an active asynchronous computation.
+  active,
+
+  /// Connected to a terminated asynchronous computation.
+  done
+}
+
+/// Snapshot of an asynchronous interaction.
+///
+/// Used by widget builders that depend only on the most recent interaction with
+/// an asynchronous computation.
+///
+/// See also:
+///
+/// * [StreamBuilder]
+/// * [FutureBuilder]
+class AsyncSnapshot<T> {
+  /// Creates an [AsyncSnapshot] with the specified [connectionState],
+  /// and optionally either [data] or [error] (but not both).
+  AsyncSnapshot(this.connectionState, this.data, this.error) {
+    assert(connectionState != null);
+    assert(data == null || error == null);
+  }
+
+  /// Creates an [AsyncSnapshot] in [ConnectionState.none] with `null` data and
+  /// `error`.
+  factory AsyncSnapshot.nothing() => new AsyncSnapshot<T>(ConnectionState.none, null, null);
+
+  /// Creates an [AsyncSnapshot] in [ConnectionState.active] with the specified
+  /// [data].
+  factory AsyncSnapshot.activeData(T data) => new AsyncSnapshot<T>(ConnectionState.active, data, null);
+
+  /// Creates an [AsyncSnapshot] in [ConnectionState.active] with the specified
+  /// [error].
+  factory AsyncSnapshot.activeError(Object error) => new AsyncSnapshot<T>(ConnectionState.active, null, error);
+
+  /// Current state of connection to the asynchronous computation.
+  final ConnectionState connectionState;
+
+  /// Latest data received. Is null, if [error] is not.
+  final T data;
+
+  /// Latest error object received. Is null, if [data] is not.
+  final Object error;
+
+  /// Returns a snapshot like this one, but in the specified [state].
+  AsyncSnapshot<T> inState(ConnectionState state) => new AsyncSnapshot<T>(state, data, error);
+
+  /// Returns whether this snapshot contains a non-null data value.
+  bool get hasData => data != null;
+
+  /// Returns whether this snapshot contains a non-null error value.
+  bool get hasError => error != null;
+
+  @override
+  String toString() => 'AsyncSnapshot($connectionState, $data, $error)';
+
+  @override
+  bool operator ==(dynamic other) {
+    if (identical(this, other))
+      return true;
+    if (other is! AsyncSnapshot<T>)
+      return false;
+    final AsyncSnapshot<T> typedOther = other;
+    return connectionState == typedOther.connectionState &&
+      data == typedOther.data &&
+      error == typedOther.error;
+  }
+
+  @override
+  int get hashCode => hashValues(connectionState, data, error);
+}
+
+/// Signature for strategies that build widgets based on asynchronous
+/// interaction.
+///
+/// See also:
+///
+/// * [StreamBuilder]
+/// * [FutureBuilder]
+typedef Widget AsyncWidgetBuilder<T>(BuildContext context, AsyncSnapshot<T> snapshot);
+
+/// Widget that builds itself based on the latest snapshot of interaction with
+/// a [Stream].
+///
+/// Widget rebuilding is scheduled by each interaction, using [State.setState],
+/// but is otherwise decoupled from the timing of the stream. The [build] method
+/// is called at the discretion of the Flutter pipeline, and will thus receive a
+/// timing-dependent sub-sequence of the snapshots that represent the
+/// interaction with the stream
+///
+/// As an example, when interacting with a stream producing the integers
+/// 0 through 9, the [build] method may be called with any ordered sub-sequence
+/// of the following snapshots that includes the last one (the one with
+/// ConnectionState.done):
+///
+/// * `new AsyncSnapshot<int>(ConnectionState.waiting, null, null)`
+/// * `new AsyncSnapshot<int>(ConnectionState.active, 0, null)`
+/// * `new AsyncSnapshot<int>(ConnectionState.active, 1, null)`
+/// * ...
+/// * `new AsyncSnapshot<int>(ConnectionState.active, 9, null)`
+/// * `new AsyncSnapshot<int>(ConnectionState.done, 9, null)`
+///
+/// The actual sequence of invocations of [build] depends on the relative timing
+/// of events produced by the stream and the build rate of the Flutter pipeline.
+///
+/// Changing the [StreamBuilder] configuration to another [Stream] during event
+/// generation introduces snapshot pairs of the form
+///
+/// * `new AsyncSnapshot<int>(ConnectionState.none, 5, null)`
+/// * `new AsyncSnapshot<int>(ConnectionState.waiting, 5, null)`
+///
+/// The latter will be produced only when the new stream is non-null. The former
+/// only when the old stream is non-null.
+///
+/// The stream may produce errors, resulting in snapshots of the form
+///
+/// * `new AsyncSnapshot<int>(ConnectionState.active, null, 'some error')`
+///
+/// The data and error fields of snapshots produced are only changed when the
+/// state is `ConnectionState.active`.
+///
+/// See also:
+///
+/// * [StreamBuilderBase], which supports widget building based on a computation
+/// that spans all interactions made with the stream.
+class StreamBuilder<T> extends StreamBuilderBase<T, AsyncSnapshot<T>> {
+  /// Creates a new [StreamBuilder] that builds itself based on the latest
+  /// snapshot of interaction with the specified [stream] and whose build
+  /// strategy is given by [builder].
+  StreamBuilder({
+    Key key,
+    Stream<T> stream,
+    @required this.builder
+  }) : super(key: key, stream: stream) {
+    assert(builder != null);
+  }
+
+  /// The build strategy currently used by this builder. Cannot be `null`.
+  final AsyncWidgetBuilder<T> builder;
+
+  @override
+  AsyncSnapshot<T> initial() => new AsyncSnapshot<T>.nothing();
+
+  @override
+  AsyncSnapshot<T> afterConnected(AsyncSnapshot<T> current) => current.inState(ConnectionState.waiting);
+
+  @override
+  AsyncSnapshot<T> afterData(AsyncSnapshot<T> current, T data) => new AsyncSnapshot<T>.activeData(data);
+
+  @override
+  AsyncSnapshot<T> afterError(AsyncSnapshot<T> current, Object error) => new AsyncSnapshot<T>.activeError(error);
+
+  @override
+  AsyncSnapshot<T> afterDone(AsyncSnapshot<T> current) => current.inState(ConnectionState.done);
+
+  @override
+  AsyncSnapshot<T> afterDisconnected(AsyncSnapshot<T> current) => current.inState(ConnectionState.none);
+
+  @override
+  Widget build(BuildContext context, AsyncSnapshot<T> currentSummary) => builder(context, currentSummary);
+}
+
+/// Widget that builds itself based on the latest snapshot of interaction with
+/// a [Future].
+///
+/// Behaves identically to [StreamBuilder] configured with `future?.asStream()`.
+class FutureBuilder<T> extends StatefulWidget {
+  FutureBuilder({
+    Key key,
+    this.future,
+    @required this.builder
+  }) : super(key: key) {
+    assert(builder != null);
+  }
+
+  /// The asynchronous computation to which this builder is currently connected,
+  /// possibly `null`.
+  final Future<T> future;
+
+  /// The build strategy currently used by this builder. Cannot be `null`.
+  final AsyncWidgetBuilder<T> builder;
+
+  @override
+  State<FutureBuilder<T>> createState() => new _FutureBuilderState<T>();
+}
+
+/// State for [FutureBuilder].
+class _FutureBuilderState<T> extends State<FutureBuilder<T>> {
+  Stream<T> _stream;
+
+  @override
+  void initState() {
+    super.initState();
+    _subscribe();
+  }
+
+  @override
+  void didUpdateConfig(FutureBuilder<T> oldConfig) {
+    if (oldConfig.future != config.future) {
+      _unsubscribe();
+      _subscribe();
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) => new StreamBuilder<T>(stream: _stream, builder: config.builder);
+
+  @override
+  void dispose() {
+    _unsubscribe();
+    super.dispose();
+  }
+
+  void _subscribe() {
+    _stream = config.future?.asStream();
+  }
+
+  void _unsubscribe() {
+    _stream = null;
   }
 }

--- a/packages/flutter/lib/src/widgets/async.dart
+++ b/packages/flutter/lib/src/widgets/async.dart
@@ -126,13 +126,13 @@ class _StreamBuilderBaseState<T, S> extends State<StreamBuilderBase<T, S>> {
 
   void _subscribe() {
     if (config.stream != null) {
-      _subscription = config.stream.listen((T event) {
+      _subscription = config.stream.listen((T data) {
         setState(() {
-          _summary = config.afterData(_summary, event);
+          _summary = config.afterData(_summary, data);
         });
-      }, onError: (Object e) {
+      }, onError: (Object error) {
         setState(() {
-          _summary = config.afterError(_summary, e);
+          _summary = config.afterError(_summary, error);
         });
       }, onDone: () {
         setState(() {

--- a/packages/flutter/lib/src/widgets/async.dart
+++ b/packages/flutter/lib/src/widgets/async.dart
@@ -27,10 +27,10 @@ import 'dart:async' show Future, Stream, StreamSubscription;
 /// items and errors received from the stream along with pseudo-events
 /// representing termination or change of stream. The initial summary is
 /// specified by sub-classes by overriding [initial]. The summary updates on
-/// receipt of stream data and errors are specified by overriding [onData] and
-/// [onError], respectively. If needed, the summary may be updated on stream
-/// termination by overriding [onDone]. Finally, the summary may be updated
-/// on change of stream by overriding [onConnected] and [onDisconnected].
+/// receipt of stream data and errors are specified by overriding [afterData] and
+/// [afterError], respectively. If needed, the summary may be updated on stream
+/// termination by overriding [afterDone]. Finally, the summary may be updated
+/// on change of stream by overriding [afterConnected] and [afterConnected].
 ///
 /// [T] is the type of stream events.
 /// [S] is the type of interaction summary.
@@ -45,8 +45,8 @@ abstract class StreamBuilderBase<T, S> extends StatefulWidget {
 
   /// The asynchronous computation to which this builder is currently connected,
   /// possibly `null`. When changed, the current summary is updated using
-  /// [onDisconnecting], if the previous stream was not `null`, followed by
-  /// [onConnecting], if the new stream is not `null`.
+  /// [afterDisconnecting], if the previous stream was not `null`, followed by
+  /// [afterConnecting], if the new stream is not `null`.
   final Stream<T> stream;
 
   /// Returns the initial summary of stream interaction, typically representing

--- a/packages/flutter/lib/src/widgets/async.dart
+++ b/packages/flutter/lib/src/widgets/async.dart
@@ -1,0 +1,256 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+/// Widgets that handle interaction with asynchronous computations.
+
+import 'package:flutter/widgets.dart';
+import 'dart:async' show Future, Stream, StreamSubscription;
+
+/// Snapshot of an asynchronous interaction.
+class AsyncSnapshot<T> {
+  /// Current state of connection to the asynchronous computation.
+  final ConnectionState connectionState;
+
+  /// Latest data received. Is null, if [error] is not.
+  final T data;
+
+  /// Latest error object received. Is null, if [data] is not.
+  final dynamic error;
+
+  AsyncSnapshot(this.connectionState, this.data, this.error);
+
+  bool get hasError => error != null;
+  bool get hasData => data != null;
+
+  @override
+  String toString() => 'AsyncSnapshot($connectionState, $data, $error)';
+
+  @override
+  bool operator ==(dynamic o) =>
+      o == this ||
+      o is AsyncSnapshot<T> &&
+          connectionState == o.connectionState &&
+          data == o.data &&
+          error == o.error;
+
+  @override
+  int get hashCode => hashValues(connectionState, data, error);
+}
+
+/// The state of connection to an asynchronous computation.
+enum ConnectionState {
+  /// Not currently connected to any asynchronous computation.
+  none,
+
+  /// Connected to an asynchronous computation and awaiting interaction.
+  waiting,
+
+  /// Connected to an active asynchronous computation.
+  active,
+
+  /// Connected to a terminated asynchronous computation.
+  done
+}
+
+/// Strategy for building a Widget based on asynchronous interaction.
+typedef Widget AsyncWidgetBuilder<T>(
+    BuildContext context, AsyncSnapshot<T> snapshot);
+
+/// Widget that builds itself based on interaction with the specified [future].
+///
+/// The building strategy is defined by the given [builder].
+///
+/// Behaves identically to [StreamBuilder] configured with [future].asStream()
+/// when [future] is non-null.
+class FutureBuilder<T> extends StatefulWidget {
+  final Future<T> future;
+  final AsyncWidgetBuilder<T> builder;
+
+  FutureBuilder({Key key, this.future, this.builder}) : super(key: key);
+
+  @override
+  State<FutureBuilder<T>> createState() => new _FutureBuilderState<T>();
+}
+
+class _FutureBuilderState<T> extends State<FutureBuilder<T>> {
+  Stream<T> _stream;
+
+  @override
+  void initState() {
+    super.initState();
+    _subscribe();
+  }
+
+  @override
+  void didUpdateConfig(FutureBuilder<T> oldConfig) {
+    if (!identical(oldConfig.future, config.future)) {
+      _unsubscribe();
+      _subscribe();
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) =>
+      new StreamBuilder<T>(stream: _stream, builder: config.builder);
+
+  @override
+  void dispose() {
+    _unsubscribe();
+    super.dispose();
+  }
+
+  void _subscribe() {
+    _stream = config.future?.asStream();
+  }
+
+  void _unsubscribe() {
+    _stream = null;
+  }
+}
+
+/// Widget that builds itself based on the latest snapshot of interaction with
+/// the specified [stream].
+///
+/// The building strategy is defined by the given [builder].
+class StreamBuilder<T> extends StreamFold<T, AsyncSnapshot<T>> {
+  final AsyncWidgetBuilder<T> builder;
+
+  StreamBuilder({Key key, Stream<T> stream, this.builder})
+      : super(key: key, stream: stream);
+
+  @override
+  AsyncSnapshot<T> initial() =>
+      new AsyncSnapshot<T>(ConnectionState.none, null, null);
+
+  @override
+  AsyncSnapshot<T> onConnecting(AsyncSnapshot<T> current) =>
+      new AsyncSnapshot<T>(
+          ConnectionState.waiting, current.data, current.error);
+
+  @override
+  AsyncSnapshot<T> onData(AsyncSnapshot<T> current, T data) =>
+      new AsyncSnapshot<T>(ConnectionState.active, data, null);
+
+  @override
+  AsyncSnapshot<T> onError(AsyncSnapshot<T> current, dynamic error) =>
+      new AsyncSnapshot<T>(ConnectionState.active, null, error);
+
+  @override
+  AsyncSnapshot<T> onDone(AsyncSnapshot<T> current) =>
+      new AsyncSnapshot<T>(ConnectionState.done, current.data, current.error);
+
+  @override
+  AsyncSnapshot<T> onDisconnecting(AsyncSnapshot<T> current) =>
+      new AsyncSnapshot<T>(
+          ConnectionState.none, current.data, current.error);
+
+  @override
+  Widget build(BuildContext context, AsyncSnapshot<T> currentSummary) =>
+      builder(context, currentSummary);
+}
+
+/// Base class for Widgets that build themselves based on interaction with
+/// a specified [stream].
+///
+/// The widget's state maintains a summary of the interaction so far. The
+/// summary is defined by sub-classes.
+///
+/// [T] type of stream events.
+/// [S] type of summary.
+abstract class StreamFold<T, S> extends StatefulWidget {
+  final Stream<T> stream;
+
+  StreamFold({Key key, this.stream}) : super(key: key);
+
+  /// Returns the initial summary.
+  S initial();
+
+  /// Returns an updated version of the [current] summary reflecting that we
+  /// are now connected to a stream.
+  ///
+  /// The default implementation returns [current] as is.
+  S onConnecting(S current) => current;
+
+  /// Returns an updated version of the [current] summary following an event.
+  S onData(S current, T data);
+
+  /// Returns an updated version of the [current] summary following an error.
+  ///
+  /// The default implementation returns [current] as is.
+  S onError(S current, dynamic error) => current;
+
+  /// Returns an updated version of the [current] summary following stream
+  /// termination.
+  ///
+  /// The default implementation returns [current] as is.
+  S onDone(S current) => current;
+
+  /// Returns an updated version of the [current] summary reflecting that we
+  /// are no longer connected to a stream.
+  ///
+  /// The default implementation returns [current] as is.
+  S onDisconnecting(S current) => current;
+
+  /// Returns a Widget based on the [currentSummary].
+  Widget build(BuildContext context, S currentSummary);
+
+  @override
+  State<StreamFold<T, S>> createState() => new _StreamFoldState<T, S>();
+}
+
+class _StreamFoldState<T, S> extends State<StreamFold<T, S>> {
+  StreamSubscription<T> _subscription;
+  S _summary;
+
+  @override
+  void initState() {
+    super.initState();
+    _summary = config.initial();
+    _subscribe();
+  }
+
+  @override
+  void didUpdateConfig(StreamFold<T, S> oldConfig) {
+    if (!identical(oldConfig.stream, config.stream)) {
+      _unsubscribe();
+      _subscribe();
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) => config.build(context, _summary);
+
+  @override
+  void dispose() {
+    _unsubscribe();
+    super.dispose();
+  }
+
+  void _subscribe() {
+    if (config.stream != null) {
+      _subscription = config.stream.listen((T event) {
+        setState(() {
+          _summary = config.onData(_summary, event);
+        });
+      }, onError: (dynamic e) {
+        setState(() {
+          _summary = config.onError(_summary, e);
+        });
+      }, onDone: () {
+        setState(() {
+          _summary = config.onDone(_summary);
+        });
+      });
+      _summary = config.onConnecting(_summary);
+    }
+  }
+
+  void _unsubscribe() {
+    if (_subscription != null) {
+      _subscription.cancel();
+      _subscription = null;
+      _summary = config.onDisconnecting(_summary);
+    }
+  }
+}

--- a/packages/flutter/lib/widgets.dart
+++ b/packages/flutter/lib/widgets.dart
@@ -11,6 +11,7 @@ export 'src/widgets/animated_cross_fade.dart';
 export 'src/widgets/animated_size.dart';
 export 'src/widgets/app.dart';
 export 'src/widgets/app_bar.dart';
+export 'src/widgets/async.dart';
 export 'src/widgets/banner.dart';
 export 'src/widgets/basic.dart';
 export 'src/widgets/binding.dart';

--- a/packages/flutter/test/widgets/async_test.dart
+++ b/packages/flutter/test/widgets/async_test.dart
@@ -244,7 +244,7 @@ Future<Null> eventFiring(WidgetTester tester) async {
   await tester.pump(const Duration(milliseconds: 0));
 }
 
-class StringFold extends StreamFold<String, List<String>> {
+class StringFold extends StreamBuilderBase<String, List<String>> {
   StringFold({Key key, Stream<String> stream})
       : super(key: key, stream: stream);
 
@@ -252,21 +252,21 @@ class StringFold extends StreamFold<String, List<String>> {
   List<String> initial() => <String>[];
 
   @override
-  List<String> onConnecting(List<String> current) => current..add('conn');
+  List<String> afterConnected(List<String> current) => current..add('conn');
 
   @override
-  List<String> onData(List<String> current, String data) =>
+  List<String> afterData(List<String> current, String data) =>
       current..add('data:$data');
 
   @override
-  List<String> onError(List<String> current, dynamic error) =>
+  List<String> afterError(List<String> current, dynamic error) =>
       current..add('error:$error');
 
   @override
-  List<String> onDone(List<String> current) => current..add('done');
+  List<String> afterDone(List<String> current) => current..add('done');
 
   @override
-  List<String> onDisconnecting(List<String> current) => current..add('disc');
+  List<String> afterDisconnected(List<String> current) => current..add('disc');
 
   @override
   Widget build(BuildContext context, List<String> currentSummary) =>

--- a/packages/flutter/test/widgets/async_test.dart
+++ b/packages/flutter/test/widgets/async_test.dart
@@ -7,246 +7,238 @@ import 'package:flutter/widgets.dart';
 import 'dart:async';
 
 void main() {
+  Widget snapshotText(BuildContext context, AsyncSnapshot<String> snapshot) { 
+    return new Text(snapshot.toString());
+  }
   group('Async smoke tests', () {
     testWidgets('FutureBuilder', (WidgetTester tester) async {
       await tester.pumpWidget(new FutureBuilder<String>(
-          future: new Future<String>.value('hello'),
-          builder: (BuildContext ctx, AsyncSnapshot<String> snapshot) =>
-              new Text(snapshot.hasData ? snapshot.data : 'Waiting')));
+        future: new Future<String>.value('hello'),
+        builder: snapshotText
+      ));
       await eventFiring(tester);
     });
     testWidgets('StreamBuilder', (WidgetTester tester) async {
       await tester.pumpWidget(new StreamBuilder<String>(
-          stream: new Stream<String>.fromIterable(<String>['hello', 'world']),
-          builder: (BuildContext ctx, AsyncSnapshot<String> snapshot) =>
-              new Text(snapshot.hasData ? snapshot.data : 'Waiting')));
+        stream: new Stream<String>.fromIterable(<String>['hello', 'world']),
+        builder: snapshotText
+      ));
       await eventFiring(tester);
     });
     testWidgets('StreamFold', (WidgetTester tester) async {
-      await tester.pumpWidget(new StringFold(
-          stream: new Stream<String>.fromIterable(<String>['hello', 'world'])));
+      await tester.pumpWidget(new StringCollector(
+        stream: new Stream<String>.fromIterable(<String>['hello', 'world'])
+      ));
       await eventFiring(tester);
     });
   });
   group('FutureBuilder', () {
-    final AsyncWidgetBuilder<String> builder =
-        (BuildContext ctx, AsyncSnapshot<String> snapshot) =>
-            new Text(snapshot.toString());
-    testWidgets('gracefully handles transition from null future',
-        (WidgetTester tester) async {
+    testWidgets('gracefully handles transition from null future', (WidgetTester tester) async {
       final GlobalKey key = new GlobalKey();
-      await tester.pumpWidget(
-          new FutureBuilder<String>(key: key, future: null, builder: builder));
-      expect(find.text('AsyncSnapshot(ConnectionState.none, null, null)'),
-          findsOneWidget);
+      await tester.pumpWidget(new FutureBuilder<String>(
+        key: key, future: null, builder: snapshotText
+      ));
+      expect(find.text('AsyncSnapshot(ConnectionState.none, null, null)'), findsOneWidget);
       final Completer<String> completer = new Completer<String>();
       await tester.pumpWidget(new FutureBuilder<String>(
-          key: key, future: completer.future, builder: builder));
-      expect(find.text('AsyncSnapshot(ConnectionState.waiting, null, null)'),
-          findsOneWidget);
+        key: key, future: completer.future, builder: snapshotText
+      ));
+      expect(find.text('AsyncSnapshot(ConnectionState.waiting, null, null)'), findsOneWidget);
     });
-    testWidgets('gracefully handles transition to null future',
-        (WidgetTester tester) async {
+    testWidgets('gracefully handles transition to null future', (WidgetTester tester) async {
       final GlobalKey key = new GlobalKey();
       final Completer<String> completer = new Completer<String>();
       await tester.pumpWidget(new FutureBuilder<String>(
-          key: key, future: completer.future, builder: builder));
-      expect(find.text('AsyncSnapshot(ConnectionState.waiting, null, null)'),
-          findsOneWidget);
-      await tester.pumpWidget(
-          new FutureBuilder<String>(key: key, future: null, builder: builder));
-      expect(find.text('AsyncSnapshot(ConnectionState.none, null, null)'),
-          findsOneWidget);
+        key: key, future: completer.future, builder: snapshotText
+      ));
+      expect(find.text('AsyncSnapshot(ConnectionState.waiting, null, null)'), findsOneWidget);
+      await tester.pumpWidget(new FutureBuilder<String>(
+          key: key, future: null, builder: snapshotText
+      ));
+      expect(find.text('AsyncSnapshot(ConnectionState.none, null, null)'), findsOneWidget);
       completer.complete('hello');
       await eventFiring(tester);
-      expect(find.text('AsyncSnapshot(ConnectionState.none, null, null)'),
-          findsOneWidget);
+      expect(find.text('AsyncSnapshot(ConnectionState.none, null, null)'), findsOneWidget);
     });
-    testWidgets('gracefully handles transition to other future',
-        (WidgetTester tester) async {
+    testWidgets('gracefully handles transition to other future', (WidgetTester tester) async {
       final GlobalKey key = new GlobalKey();
       final Completer<String> completerA = new Completer<String>();
       final Completer<String> completerB = new Completer<String>();
       await tester.pumpWidget(new FutureBuilder<String>(
-          key: key, future: completerA.future, builder: builder));
-      expect(find.text('AsyncSnapshot(ConnectionState.waiting, null, null)'),
-          findsOneWidget);
+        key: key, future: completerA.future, builder: snapshotText
+      ));
+      expect(find.text('AsyncSnapshot(ConnectionState.waiting, null, null)'), findsOneWidget);
       await tester.pumpWidget(new FutureBuilder<String>(
-          key: key, future: completerB.future, builder: builder));
-      expect(find.text('AsyncSnapshot(ConnectionState.waiting, null, null)'),
-          findsOneWidget);
+        key: key, future: completerB.future, builder: snapshotText
+      ));
+      expect(find.text('AsyncSnapshot(ConnectionState.waiting, null, null)'), findsOneWidget);
       completerB.complete('B');
       completerA.complete('A');
       await eventFiring(tester);
-      expect(find.text('AsyncSnapshot(ConnectionState.done, B, null)'),
-          findsOneWidget);
+      expect(find.text('AsyncSnapshot(ConnectionState.done, B, null)'), findsOneWidget);
     });
-    testWidgets('tracks life-cycle of Future to success',
-        (WidgetTester tester) async {
+    testWidgets('tracks life-cycle of Future to success', (WidgetTester tester) async {
       final Completer<String> completer = new Completer<String>();
       await tester.pumpWidget(new FutureBuilder<String>(
-          future: completer.future, builder: builder));
-      expect(find.text('AsyncSnapshot(ConnectionState.waiting, null, null)'),
-          findsOneWidget);
+        future: completer.future, builder: snapshotText
+      ));
+      expect(find.text('AsyncSnapshot(ConnectionState.waiting, null, null)'), findsOneWidget);
       completer.complete('hello');
       await eventFiring(tester);
-      expect(find.text('AsyncSnapshot(ConnectionState.done, hello, null)'),
-          findsOneWidget);
+      expect(find.text('AsyncSnapshot(ConnectionState.done, hello, null)'), findsOneWidget);
     });
-    testWidgets('tracks life-cycle of Future to error',
-        (WidgetTester tester) async {
+    testWidgets('tracks life-cycle of Future to error', (WidgetTester tester) async {
       final Completer<String> completer = new Completer<String>();
       await tester.pumpWidget(new FutureBuilder<String>(
-          future: completer.future, builder: builder));
-      expect(find.text('AsyncSnapshot(ConnectionState.waiting, null, null)'),
-          findsOneWidget);
+        future: completer.future, builder: snapshotText
+      ));
+      expect(find.text('AsyncSnapshot(ConnectionState.waiting, null, null)'), findsOneWidget);
       completer.completeError('bad');
       await eventFiring(tester);
-      expect(find.text('AsyncSnapshot(ConnectionState.done, null, bad)'),
-          findsOneWidget);
+      expect(find.text('AsyncSnapshot(ConnectionState.done, null, bad)'), findsOneWidget);
     });
   });
   group('StreamBuilder', () {
-    final AsyncWidgetBuilder<String> builder =
-        (BuildContext ctx, AsyncSnapshot<String> snapshot) =>
-            new Text(snapshot.toString());
-    testWidgets('gracefully handles transition from null stream',
-        (WidgetTester tester) async {
+    testWidgets('gracefully handles transition from null stream', (WidgetTester tester) async {
       final GlobalKey key = new GlobalKey();
-      await tester.pumpWidget(
-          new StreamBuilder<String>(key: key, stream: null, builder: builder));
-      expect(find.text('AsyncSnapshot(ConnectionState.none, null, null)'),
-          findsOneWidget);
-      final StreamController<String> controller =
-          new StreamController<String>();
       await tester.pumpWidget(new StreamBuilder<String>(
-          key: key, stream: controller.stream, builder: builder));
-      expect(find.text('AsyncSnapshot(ConnectionState.waiting, null, null)'),
-          findsOneWidget);
+        key: key, stream: null, builder: snapshotText
+      ));
+      expect(find.text('AsyncSnapshot(ConnectionState.none, null, null)'), findsOneWidget);
+      final StreamController<String> controller = new StreamController<String>();
+      await tester.pumpWidget(new StreamBuilder<String>(
+        key: key, stream: controller.stream, builder: snapshotText
+      ));
+      expect(find.text('AsyncSnapshot(ConnectionState.waiting, null, null)'), findsOneWidget);
     });
-    testWidgets('gracefully handles transition to null stream',
-        (WidgetTester tester) async {
+    testWidgets('gracefully handles transition to null stream', (WidgetTester tester) async {
       final GlobalKey key = new GlobalKey();
-      final StreamController<String> controller =
-          new StreamController<String>();
+      final StreamController<String> controller = new StreamController<String>();
       await tester.pumpWidget(new StreamBuilder<String>(
-          key: key, stream: controller.stream, builder: builder));
-      expect(find.text('AsyncSnapshot(ConnectionState.waiting, null, null)'),
-          findsOneWidget);
-      await tester.pumpWidget(
-          new StreamBuilder<String>(key: key, stream: null, builder: builder));
-      expect(find.text('AsyncSnapshot(ConnectionState.none, null, null)'),
-          findsOneWidget);
+        key: key, stream: controller.stream, builder: snapshotText
+      ));
+      expect(find.text('AsyncSnapshot(ConnectionState.waiting, null, null)'), findsOneWidget);
+      await tester.pumpWidget(new StreamBuilder<String>(
+        key: key, stream: null, builder: snapshotText
+      ));
+      expect(find.text('AsyncSnapshot(ConnectionState.none, null, null)'), findsOneWidget);
     });
-    testWidgets('gracefully handles transition to other stream',
-        (WidgetTester tester) async {
+    testWidgets('gracefully handles transition to other stream', (WidgetTester tester) async {
       final GlobalKey key = new GlobalKey();
-      final StreamController<String> controllerA =
-          new StreamController<String>();
-      final StreamController<String> controllerB =
-          new StreamController<String>();
+      final StreamController<String> controllerA = new StreamController<String>();
+      final StreamController<String> controllerB = new StreamController<String>();
       await tester.pumpWidget(new StreamBuilder<String>(
-          key: key, stream: controllerA.stream, builder: builder));
-      expect(find.text('AsyncSnapshot(ConnectionState.waiting, null, null)'),
-          findsOneWidget);
+        key: key, stream: controllerA.stream, builder: snapshotText
+      ));
+      expect(find.text('AsyncSnapshot(ConnectionState.waiting, null, null)'), findsOneWidget);
       await tester.pumpWidget(new StreamBuilder<String>(
-          key: key, stream: controllerB.stream, builder: builder));
+        key: key, stream: controllerB.stream, builder: snapshotText
+      ));
       controllerB.add('B');
       controllerA.add('A');
       await eventFiring(tester);
-      expect(find.text('AsyncSnapshot(ConnectionState.active, B, null)'),
-          findsOneWidget);
+      expect(find.text('AsyncSnapshot(ConnectionState.active, B, null)'), findsOneWidget);
     });
-    testWidgets('tracks events and errors of stream until completion',
-        (WidgetTester tester) async {
+    testWidgets('tracks events and errors of stream until completion', (WidgetTester tester) async {
       final GlobalKey key = new GlobalKey();
-      final StreamController<String> controller =
-          new StreamController<String>();
+      final StreamController<String> controller = new StreamController<String>();
       await tester.pumpWidget(new StreamBuilder<String>(
-          key: key, stream: controller.stream, builder: builder));
-      expect(find.text('AsyncSnapshot(ConnectionState.waiting, null, null)'),
-          findsOneWidget);
+        key: key, stream: controller.stream, builder: snapshotText
+      ));
+      expect(find.text('AsyncSnapshot(ConnectionState.waiting, null, null)'), findsOneWidget);
       controller.add('1');
       controller.add('2');
       await eventFiring(tester);
-      expect(find.text('AsyncSnapshot(ConnectionState.active, 2, null)'),
-          findsOneWidget);
+      expect(find.text('AsyncSnapshot(ConnectionState.active, 2, null)'), findsOneWidget);
       controller.add('3');
       controller.addError('bad');
       await eventFiring(tester);
-      expect(find.text('AsyncSnapshot(ConnectionState.active, null, bad)'),
-          findsOneWidget);
+      expect(find.text('AsyncSnapshot(ConnectionState.active, null, bad)'), findsOneWidget);
       controller.add('4');
       controller.close();
       await eventFiring(tester);
-      expect(find.text('AsyncSnapshot(ConnectionState.done, 4, null)'),
-          findsOneWidget);
+      expect(find.text('AsyncSnapshot(ConnectionState.done, 4, null)'), findsOneWidget);
     });
   });
-  group('StreamFold', () {
-    testWidgets('gracefully handles transition from null stream',
-        (WidgetTester tester) async {
+  group('FutureBuilder and StreamBuilder behave identically on Stream from Future', () {
+    testWidgets('when completing with data', (WidgetTester tester) async {
+      final Completer<String> completer = new Completer<String>();
+      await tester.pumpWidget(new Column(children: <Widget>[
+        new FutureBuilder<String>(future: completer.future, builder: snapshotText),
+        new StreamBuilder<String>(stream: completer.future.asStream(), builder: snapshotText),
+      ]));
+      expect(find.text('AsyncSnapshot(ConnectionState.waiting, null, null)'), findsNWidgets(2));
+      completer.complete('hello');
+      await eventFiring(tester);
+      expect(find.text('AsyncSnapshot(ConnectionState.done, hello, null)'), findsNWidgets(2));
+    });
+    testWidgets('when completing with error', (WidgetTester tester) async {
+      final Completer<String> completer = new Completer<String>();
+      await tester.pumpWidget(new Column(children: <Widget>[
+        new FutureBuilder<String>(future: completer.future, builder: snapshotText),
+        new StreamBuilder<String>(stream: completer.future.asStream(), builder: snapshotText),
+      ]));
+      expect(find.text('AsyncSnapshot(ConnectionState.waiting, null, null)'), findsNWidgets(2));
+      completer.completeError('bad');
+      await eventFiring(tester);
+      expect(find.text('AsyncSnapshot(ConnectionState.done, null, bad)'), findsNWidgets(2));
+    });
+    testWidgets('when Future is null', (WidgetTester tester) async {
+      await tester.pumpWidget(new Column(children: <Widget>[
+        new FutureBuilder<String>(future: null, builder: snapshotText),
+        new StreamBuilder<String>(stream: null, builder: snapshotText),
+      ]));
+      expect(find.text('AsyncSnapshot(ConnectionState.none, null, null)'), findsNWidgets(2));
+    });
+  });
+  group('StreamBuilderBase', () {
+    testWidgets('gracefully handles transition from null stream', (WidgetTester tester) async {
       final GlobalKey key = new GlobalKey();
-      await tester.pumpWidget(new StringFold(key: key, stream: null));
+      await tester.pumpWidget(new StringCollector(key: key, stream: null));
       expect(find.text(''), findsOneWidget);
-      final StreamController<String> controller =
-          new StreamController<String>();
-      await tester
-          .pumpWidget(new StringFold(key: key, stream: controller.stream));
+      final StreamController<String> controller = new StreamController<String>();
+      await tester.pumpWidget(new StringCollector(key: key, stream: controller.stream));
       expect(find.text('conn'), findsOneWidget);
     });
-    testWidgets('gracefully handles transition to null stream',
-        (WidgetTester tester) async {
+    testWidgets('gracefully handles transition to null stream', (WidgetTester tester) async {
       final GlobalKey key = new GlobalKey();
-      final StreamController<String> controller =
-          new StreamController<String>();
-      await tester
-          .pumpWidget(new StringFold(key: key, stream: controller.stream));
+      final StreamController<String> controller = new StreamController<String>();
+      await tester.pumpWidget(new StringCollector(key: key, stream: controller.stream));
       expect(find.text('conn'), findsOneWidget);
-      await tester.pumpWidget(new StringFold(key: key, stream: null));
+      await tester.pumpWidget(new StringCollector(key: key, stream: null));
       expect(find.text('conn, disc'), findsOneWidget);
     });
-    testWidgets('gracefully handles transition to other stream',
-        (WidgetTester tester) async {
+    testWidgets('gracefully handles transition to other stream', (WidgetTester tester) async {
       final GlobalKey key = new GlobalKey();
-      final StreamController<String> controllerA =
-          new StreamController<String>();
-      final StreamController<String> controllerB =
-          new StreamController<String>();
-      await tester
-          .pumpWidget(new StringFold(key: key, stream: controllerA.stream));
-      await tester
-          .pumpWidget(new StringFold(key: key, stream: controllerB.stream));
+      final StreamController<String> controllerA = new StreamController<String>();
+      final StreamController<String> controllerB = new StreamController<String>();
+      await tester.pumpWidget(new StringCollector(key: key, stream: controllerA.stream));
+      await tester.pumpWidget(new StringCollector(key: key, stream: controllerB.stream));
       controllerA.add('A');
       controllerB.add('B');
       await eventFiring(tester);
       expect(find.text('conn, disc, conn, data:B'), findsOneWidget);
     });
-    testWidgets('tracks events and errors until completion',
-        (WidgetTester tester) async {
+    testWidgets('tracks events and errors until completion', (WidgetTester tester) async {
       final GlobalKey key = new GlobalKey();
-      final StreamController<String> controller =
-          new StreamController<String>();
-      await tester
-          .pumpWidget(new StringFold(key: key, stream: controller.stream));
+      final StreamController<String> controller = new StreamController<String>();
+      await tester.pumpWidget(new StringCollector(key: key, stream: controller.stream));
       controller.add('1');
       controller.addError('bad');
       controller.add('2');
       controller.close();
       await eventFiring(tester);
-      expect(
-          find.text('conn, data:1, error:bad, data:2, done'), findsOneWidget);
+      expect(find.text('conn, data:1, error:bad, data:2, done'), findsOneWidget);
     });
   });
 }
 
 Future<Null> eventFiring(WidgetTester tester) async {
-  await tester.pump(const Duration(milliseconds: 0));
+  await tester.pump(const Duration());
 }
 
-class StringFold extends StreamBuilderBase<String, List<String>> {
-  StringFold({Key key, Stream<String> stream})
-      : super(key: key, stream: stream);
+class StringCollector extends StreamBuilderBase<String, List<String>> {
+  StringCollector({ Key key, Stream<String> stream }) : super(key: key, stream: stream);
 
   @override
   List<String> initial() => <String>[];
@@ -255,12 +247,10 @@ class StringFold extends StreamBuilderBase<String, List<String>> {
   List<String> afterConnected(List<String> current) => current..add('conn');
 
   @override
-  List<String> afterData(List<String> current, String data) =>
-      current..add('data:$data');
+  List<String> afterData(List<String> current, String data) => current..add('data:$data');
 
   @override
-  List<String> afterError(List<String> current, dynamic error) =>
-      current..add('error:$error');
+  List<String> afterError(List<String> current, dynamic error) => current..add('error:$error');
 
   @override
   List<String> afterDone(List<String> current) => current..add('done');
@@ -269,6 +259,5 @@ class StringFold extends StreamBuilderBase<String, List<String>> {
   List<String> afterDisconnected(List<String> current) => current..add('disc');
 
   @override
-  Widget build(BuildContext context, List<String> currentSummary) =>
-      new Text(currentSummary.join(', '));
+  Widget build(BuildContext context, List<String> currentSummary) => new Text(currentSummary.join(', '));
 }

--- a/packages/flutter/test/widgets/async_test.dart
+++ b/packages/flutter/test/widgets/async_test.dart
@@ -1,0 +1,274 @@
+// Copyright 2015 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter/widgets.dart';
+import 'dart:async';
+
+void main() {
+  group('Async smoke tests', () {
+    testWidgets('FutureBuilder', (WidgetTester tester) async {
+      await tester.pumpWidget(new FutureBuilder<String>(
+          future: new Future<String>.value('hello'),
+          builder: (BuildContext ctx, AsyncSnapshot<String> snapshot) =>
+              new Text(snapshot.hasData ? snapshot.data : 'Waiting')));
+      await eventFiring(tester);
+    });
+    testWidgets('StreamBuilder', (WidgetTester tester) async {
+      await tester.pumpWidget(new StreamBuilder<String>(
+          stream: new Stream<String>.fromIterable(<String>['hello', 'world']),
+          builder: (BuildContext ctx, AsyncSnapshot<String> snapshot) =>
+              new Text(snapshot.hasData ? snapshot.data : 'Waiting')));
+      await eventFiring(tester);
+    });
+    testWidgets('StreamFold', (WidgetTester tester) async {
+      await tester.pumpWidget(new StringFold(
+          stream: new Stream<String>.fromIterable(<String>['hello', 'world'])));
+      await eventFiring(tester);
+    });
+  });
+  group('FutureBuilder', () {
+    final AsyncWidgetBuilder<String> builder =
+        (BuildContext ctx, AsyncSnapshot<String> snapshot) =>
+            new Text(snapshot.toString());
+    testWidgets('gracefully handles transition from null future',
+        (WidgetTester tester) async {
+      final GlobalKey key = new GlobalKey();
+      await tester.pumpWidget(
+          new FutureBuilder<String>(key: key, future: null, builder: builder));
+      expect(find.text('AsyncSnapshot(ConnectionState.none, null, null)'),
+          findsOneWidget);
+      final Completer<String> completer = new Completer<String>();
+      await tester.pumpWidget(new FutureBuilder<String>(
+          key: key, future: completer.future, builder: builder));
+      expect(find.text('AsyncSnapshot(ConnectionState.waiting, null, null)'),
+          findsOneWidget);
+    });
+    testWidgets('gracefully handles transition to null future',
+        (WidgetTester tester) async {
+      final GlobalKey key = new GlobalKey();
+      final Completer<String> completer = new Completer<String>();
+      await tester.pumpWidget(new FutureBuilder<String>(
+          key: key, future: completer.future, builder: builder));
+      expect(find.text('AsyncSnapshot(ConnectionState.waiting, null, null)'),
+          findsOneWidget);
+      await tester.pumpWidget(
+          new FutureBuilder<String>(key: key, future: null, builder: builder));
+      expect(find.text('AsyncSnapshot(ConnectionState.none, null, null)'),
+          findsOneWidget);
+      completer.complete('hello');
+      await eventFiring(tester);
+      expect(find.text('AsyncSnapshot(ConnectionState.none, null, null)'),
+          findsOneWidget);
+    });
+    testWidgets('gracefully handles transition to other future',
+        (WidgetTester tester) async {
+      final GlobalKey key = new GlobalKey();
+      final Completer<String> completerA = new Completer<String>();
+      final Completer<String> completerB = new Completer<String>();
+      await tester.pumpWidget(new FutureBuilder<String>(
+          key: key, future: completerA.future, builder: builder));
+      expect(find.text('AsyncSnapshot(ConnectionState.waiting, null, null)'),
+          findsOneWidget);
+      await tester.pumpWidget(new FutureBuilder<String>(
+          key: key, future: completerB.future, builder: builder));
+      expect(find.text('AsyncSnapshot(ConnectionState.waiting, null, null)'),
+          findsOneWidget);
+      completerB.complete('B');
+      completerA.complete('A');
+      await eventFiring(tester);
+      expect(find.text('AsyncSnapshot(ConnectionState.done, B, null)'),
+          findsOneWidget);
+    });
+    testWidgets('tracks life-cycle of Future to success',
+        (WidgetTester tester) async {
+      final Completer<String> completer = new Completer<String>();
+      await tester.pumpWidget(new FutureBuilder<String>(
+          future: completer.future, builder: builder));
+      expect(find.text('AsyncSnapshot(ConnectionState.waiting, null, null)'),
+          findsOneWidget);
+      completer.complete('hello');
+      await eventFiring(tester);
+      expect(find.text('AsyncSnapshot(ConnectionState.done, hello, null)'),
+          findsOneWidget);
+    });
+    testWidgets('tracks life-cycle of Future to error',
+        (WidgetTester tester) async {
+      final Completer<String> completer = new Completer<String>();
+      await tester.pumpWidget(new FutureBuilder<String>(
+          future: completer.future, builder: builder));
+      expect(find.text('AsyncSnapshot(ConnectionState.waiting, null, null)'),
+          findsOneWidget);
+      completer.completeError('bad');
+      await eventFiring(tester);
+      expect(find.text('AsyncSnapshot(ConnectionState.done, null, bad)'),
+          findsOneWidget);
+    });
+  });
+  group('StreamBuilder', () {
+    final AsyncWidgetBuilder<String> builder =
+        (BuildContext ctx, AsyncSnapshot<String> snapshot) =>
+            new Text(snapshot.toString());
+    testWidgets('gracefully handles transition from null stream',
+        (WidgetTester tester) async {
+      final GlobalKey key = new GlobalKey();
+      await tester.pumpWidget(
+          new StreamBuilder<String>(key: key, stream: null, builder: builder));
+      expect(find.text('AsyncSnapshot(ConnectionState.none, null, null)'),
+          findsOneWidget);
+      final StreamController<String> controller =
+          new StreamController<String>();
+      await tester.pumpWidget(new StreamBuilder<String>(
+          key: key, stream: controller.stream, builder: builder));
+      expect(find.text('AsyncSnapshot(ConnectionState.waiting, null, null)'),
+          findsOneWidget);
+    });
+    testWidgets('gracefully handles transition to null stream',
+        (WidgetTester tester) async {
+      final GlobalKey key = new GlobalKey();
+      final StreamController<String> controller =
+          new StreamController<String>();
+      await tester.pumpWidget(new StreamBuilder<String>(
+          key: key, stream: controller.stream, builder: builder));
+      expect(find.text('AsyncSnapshot(ConnectionState.waiting, null, null)'),
+          findsOneWidget);
+      await tester.pumpWidget(
+          new StreamBuilder<String>(key: key, stream: null, builder: builder));
+      expect(find.text('AsyncSnapshot(ConnectionState.none, null, null)'),
+          findsOneWidget);
+    });
+    testWidgets('gracefully handles transition to other stream',
+        (WidgetTester tester) async {
+      final GlobalKey key = new GlobalKey();
+      final StreamController<String> controllerA =
+          new StreamController<String>();
+      final StreamController<String> controllerB =
+          new StreamController<String>();
+      await tester.pumpWidget(new StreamBuilder<String>(
+          key: key, stream: controllerA.stream, builder: builder));
+      expect(find.text('AsyncSnapshot(ConnectionState.waiting, null, null)'),
+          findsOneWidget);
+      await tester.pumpWidget(new StreamBuilder<String>(
+          key: key, stream: controllerB.stream, builder: builder));
+      controllerB.add('B');
+      controllerA.add('A');
+      await eventFiring(tester);
+      expect(find.text('AsyncSnapshot(ConnectionState.active, B, null)'),
+          findsOneWidget);
+    });
+    testWidgets('tracks events and errors of stream until completion',
+        (WidgetTester tester) async {
+      final GlobalKey key = new GlobalKey();
+      final StreamController<String> controller =
+          new StreamController<String>();
+      await tester.pumpWidget(new StreamBuilder<String>(
+          key: key, stream: controller.stream, builder: builder));
+      expect(find.text('AsyncSnapshot(ConnectionState.waiting, null, null)'),
+          findsOneWidget);
+      controller.add('1');
+      controller.add('2');
+      await eventFiring(tester);
+      expect(find.text('AsyncSnapshot(ConnectionState.active, 2, null)'),
+          findsOneWidget);
+      controller.add('3');
+      controller.addError('bad');
+      await eventFiring(tester);
+      expect(find.text('AsyncSnapshot(ConnectionState.active, null, bad)'),
+          findsOneWidget);
+      controller.add('4');
+      controller.close();
+      await eventFiring(tester);
+      expect(find.text('AsyncSnapshot(ConnectionState.done, 4, null)'),
+          findsOneWidget);
+    });
+  });
+  group('StreamFold', () {
+    testWidgets('gracefully handles transition from null stream',
+        (WidgetTester tester) async {
+      final GlobalKey key = new GlobalKey();
+      await tester.pumpWidget(new StringFold(key: key, stream: null));
+      expect(find.text(''), findsOneWidget);
+      final StreamController<String> controller =
+          new StreamController<String>();
+      await tester
+          .pumpWidget(new StringFold(key: key, stream: controller.stream));
+      expect(find.text('conn'), findsOneWidget);
+    });
+    testWidgets('gracefully handles transition to null stream',
+        (WidgetTester tester) async {
+      final GlobalKey key = new GlobalKey();
+      final StreamController<String> controller =
+          new StreamController<String>();
+      await tester
+          .pumpWidget(new StringFold(key: key, stream: controller.stream));
+      expect(find.text('conn'), findsOneWidget);
+      await tester.pumpWidget(new StringFold(key: key, stream: null));
+      expect(find.text('conn, disc'), findsOneWidget);
+    });
+    testWidgets('gracefully handles transition to other stream',
+        (WidgetTester tester) async {
+      final GlobalKey key = new GlobalKey();
+      final StreamController<String> controllerA =
+          new StreamController<String>();
+      final StreamController<String> controllerB =
+          new StreamController<String>();
+      await tester
+          .pumpWidget(new StringFold(key: key, stream: controllerA.stream));
+      await tester
+          .pumpWidget(new StringFold(key: key, stream: controllerB.stream));
+      controllerA.add('A');
+      controllerB.add('B');
+      await eventFiring(tester);
+      expect(find.text('conn, disc, conn, data:B'), findsOneWidget);
+    });
+    testWidgets('tracks events and errors until completion',
+        (WidgetTester tester) async {
+      final GlobalKey key = new GlobalKey();
+      final StreamController<String> controller =
+          new StreamController<String>();
+      await tester
+          .pumpWidget(new StringFold(key: key, stream: controller.stream));
+      controller.add('1');
+      controller.addError('bad');
+      controller.add('2');
+      controller.close();
+      await eventFiring(tester);
+      expect(
+          find.text('conn, data:1, error:bad, data:2, done'), findsOneWidget);
+    });
+  });
+}
+
+Future<Null> eventFiring(WidgetTester tester) async {
+  await tester.pump(const Duration(milliseconds: 0));
+}
+
+class StringFold extends StreamFold<String, List<String>> {
+  StringFold({Key key, Stream<String> stream})
+      : super(key: key, stream: stream);
+
+  @override
+  List<String> initial() => <String>[];
+
+  @override
+  List<String> onConnecting(List<String> current) => current..add('conn');
+
+  @override
+  List<String> onData(List<String> current, String data) =>
+      current..add('data:$data');
+
+  @override
+  List<String> onError(List<String> current, dynamic error) =>
+      current..add('error:$error');
+
+  @override
+  List<String> onDone(List<String> current) => current..add('done');
+
+  @override
+  List<String> onDisconnecting(List<String> current) => current..add('disc');
+
+  @override
+  Widget build(BuildContext context, List<String> currentSummary) =>
+      new Text(currentSummary.join(', '));
+}

--- a/packages/flutter/test/widgets/async_test.dart
+++ b/packages/flutter/test/widgets/async_test.dart
@@ -53,7 +53,7 @@ void main() {
       ));
       expect(find.text('AsyncSnapshot(ConnectionState.waiting, null, null)'), findsOneWidget);
       await tester.pumpWidget(new FutureBuilder<String>(
-          key: key, future: null, builder: snapshotText
+        key: key, future: null, builder: snapshotText
       ));
       expect(find.text('AsyncSnapshot(ConnectionState.none, null, null)'), findsOneWidget);
       completer.complete('hello');


### PR DESCRIPTION
Added three new Widget types for building Widget sub-trees based on interaction with asynchronous computations such as Futures and Streams.

These Widgets are intended to be used e.g. with native interop (upcoming pull-requests that expand on the current `hello_services` example) and background computations (later).