### PR TITLE
fix app launch in intellij

### DIFF
--- a/packages/flutter_tools/lib/src/run_cold.dart
+++ b/packages/flutter_tools/lib/src/run_cold.dart
@@ -24,7 +24,7 @@ class ColdRunner extends ResidentRunner {
     bool usesTerminalUI: true,
     this.traceStartup: false,
     this.applicationBinary,
-    bool stayResident,
+    bool stayResident: true,
   }) : super(device,
              target: target,
              debuggingOptions: debuggingOptions,

--- a/packages/flutter_tools/lib/src/run_hot.dart
+++ b/packages/flutter_tools/lib/src/run_hot.dart
@@ -46,7 +46,7 @@ class HotRunner extends ResidentRunner {
     String projectRootPath,
     String packagesFilePath,
     String projectAssets,
-    bool stayResident,
+    bool stayResident: true,
   }) : super(device,
              target: target,
              debuggingOptions: debuggingOptions,


### PR DESCRIPTION
- fix launching apps in IntelliJ (fix https://github.com/flutter/flutter-intellij/issues/683)
- currently the behavior is that we exit the flutter tools process after the launch is complete, but IntelliJ expects the process to be alive for the life of the app (regressed in https://github.com/flutter/flutter/commit/f888bbed48e36d03bb78cb3e7a6e124b32748356)

@Hixie 

I'll open some issues about getting the daemon run mode under test. I'm thinking of something like:
- an issue to create a integration test that verifies we can run an app, connect, and terminate it
- an issue to create a headless test device based on sky_shell (which you could access through something like `--device test_shell`)
