### PR TITLE
Create flutter_driver key finders using parameterized ValueKey types

### DIFF
--- a/dev/benchmarks/complex_layout/lib/main.dart
+++ b/dev/benchmarks/complex_layout/lib/main.dart
@@ -92,6 +92,7 @@ class ComplexLayoutState extends State<ComplexLayout> {
         children: <Widget>[
           new Expanded(
             child: new LazyBlock(
+              key: new Key('main-scroll'),
               delegate: new FancyItemDelegate(),
             )
           ),

--- a/packages/flutter_driver/lib/src/extension.dart
+++ b/packages/flutter_driver/lib/src/extension.dart
@@ -187,8 +187,15 @@ class _FlutterDriverExtension {
     }, description: 'widget with text tooltip "${arguments.text}"');
   }
 
-  Finder _createByValueKeyFinder(ByValueKey arguments) {
-    return find.byKey(new ValueKey<dynamic>(arguments.keyValue));
+  Finder _createByValueKeyFinder(ByValueKey<dynamic> arguments) {
+    switch (arguments.keyValueType) {
+      case 'int':
+        return find.byKey(new ValueKey<int>(arguments.keyValue));
+      case 'String':
+        return find.byKey(new ValueKey<String>(arguments.keyValue));
+      default:
+        throw 'Unsupported ByValueKey type: ${arguments.keyValueType}';
+    }
   }
 
   Finder _createFinder(SerializableFinder finder) {


### PR DESCRIPTION
The finder will only match the widget's ValueKey if both have identical
runtime types