### PR TITLE
Make tests more resilient to timing.

### DIFF
--- a/dev/automated_tests/flutter_test/test_async_utils_guarded_expectation.txt
+++ b/dev/automated_tests/flutter_test/test_async_utils_guarded_expectation.txt
@@ -1,4 +1,4 @@
-.*(this line contains the test framework's output with the clock and so forth)?
+[^═]*(this line contains the test framework's output with the clock and so forth)?
 ══╡ EXCEPTION CAUGHT BY FLUTTER TEST FRAMEWORK ╞════════════════════════════════════════════════════
 The following assertion was thrown running a test:
 Guarded function conflict\. You must use "await" with all Future-returning test APIs\.

--- a/dev/automated_tests/flutter_test/test_async_utils_unguarded_expectation.txt
+++ b/dev/automated_tests/flutter_test/test_async_utils_unguarded_expectation.txt
@@ -1,4 +1,4 @@
-.*(this line contains the test framework's output with the clock and so forth)?
+[^═]*(this line contains the test framework's output with the clock and so forth)?
 ══╡ EXCEPTION CAUGHT BY FLUTTER TEST FRAMEWORK ╞════════════════════════════════════════════════════
 The following assertion was thrown running a test:
 Guarded function conflict\. You must use "await" with all Future-returning test APIs\.


### PR DESCRIPTION
These tests would fail sometimes when run locally. Since they happen
to also be the ones that are flaky on bots, maybe there's some
relationship, even though the failure mode on bots is different. In
any case, this removes a variable.

(The change makes the test accept multiple lines of output
before the expected error message.)