### PR TITLE
Remove the timeout on test_test.dart

### DIFF
--- a/packages/flutter_tools/test/test_test.dart
+++ b/packages/flutter_tools/test/test_test.dart
@@ -33,7 +33,7 @@ void main() {
       Cache.flutterRoot = '../..';
       return _testFile('trivial', 1, missingDependencyTests, missingDependencyTests);
     });
-  }, timeout: new Timeout(const Duration(seconds: 5)));
+  });
 }
 
 Future<Null> _testFile(String testName, int wantedExitCode, String workingDirectory, String testDirectory) async {


### PR DESCRIPTION
It was causing the flakiness because it was too short. The default timeout is better.