### PR TITLE
Remove extraneous uses of scrollableKey from tests

### DIFF
--- a/packages/flutter/test/material/scaffold_test.dart
+++ b/packages/flutter/test/material/scaffold_test.dart
@@ -156,11 +156,12 @@ void main() {
       )
     );
 
-    expect(scrollableKey.currentState.scrollOffset, equals(500.0));
+    final ScrollableState scrollable = tester.state(find.byType(Scrollable));
+    expect(scrollable.scrollOffset, equals(500.0));
     await tester.tapAt(const Point(100.0, 10.0));
     await tester.pump();
     await tester.pump(const Duration(seconds: 1));
-    expect(scrollableKey.currentState.scrollOffset, equals(0.0));
+    expect(scrollable.scrollOffset, equals(0.0));
   });
 
   testWidgets('Tapping the status bar does not scroll to top on Android', (WidgetTester tester) async {
@@ -190,11 +191,12 @@ void main() {
       )
     );
 
-    expect(scrollableKey.currentState.scrollOffset, equals(500.0));
+    final ScrollableState scrollable = tester.state(find.byType(Scrollable));
+    expect(scrollable.scrollOffset, equals(500.0));
     await tester.tapAt(const Point(100.0, 10.0));
     await tester.pump();
     await tester.pump(const Duration(seconds: 1));
-    expect(scrollableKey.currentState.scrollOffset, equals(500.0));
+    expect(scrollable.scrollOffset, equals(500.0));
   });
 
   testWidgets('Bottom sheet cannot overlap app bar', (WidgetTester tester) async {

--- a/packages/flutter/test/widgets/clamp_overscrolls_test.dart
+++ b/packages/flutter/test/widgets/clamp_overscrolls_test.dart
@@ -15,7 +15,7 @@ Widget buildFrame(ScrollableEdge clampedEdge) {
   return new ClampOverscrolls(
     edge: clampedEdge,
     child: new ScrollableViewport(
-      scrollableKey: new UniqueKey(),
+      key: new UniqueKey(),
       child: new SizedBox(
         height: 650.0,
         child: new Column(

--- a/packages/flutter/test/widgets/scroll_behavior_test.dart
+++ b/packages/flutter/test/widgets/scroll_behavior_test.dart
@@ -58,7 +58,7 @@ void main() {
   });
 
   testWidgets('Inherited ScrollConfiguration changed', (WidgetTester tester) async {
-    final GlobalKey scrollableKey = new GlobalKey(debugLabel: 'scrollable');
+    final GlobalKey key = new GlobalKey(debugLabel: 'scrollable');
     TestScrollConfigurationDelegate delegate;
     ExtentScrollBehavior behavior;
 
@@ -66,7 +66,7 @@ void main() {
       new ScrollConfiguration(
         delegate: new TestScrollConfigurationDelegate(true),
         child: new ScrollableViewport(
-          scrollableKey: scrollableKey,
+          key: key,
           child: new Builder(
             builder: (BuildContext context) {
               delegate = ScrollConfiguration.of(context);
@@ -89,7 +89,7 @@ void main() {
       new ScrollConfiguration(
         delegate: new TestScrollConfigurationDelegate(false),
         child: new ScrollableViewport(
-          scrollableKey: scrollableKey,
+          key: key,
           child: new Builder(
             builder: (BuildContext context) {
               delegate = ScrollConfiguration.of(context);

--- a/packages/flutter/test/widgets/scroll_events_test.dart
+++ b/packages/flutter/test/widgets/scroll_events_test.dart
@@ -7,9 +7,8 @@ import 'dart:async';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/widgets.dart';
 
-Widget _buildScroller({Key key, List<String> log}) {
+Widget _buildScroller({ List<String> log }) {
   return new ScrollableViewport(
-    scrollableKey: key,
     onScrollStart: (double scrollOffset) {
       log.add('scrollstart');
     },
@@ -24,11 +23,10 @@ Widget _buildScroller({Key key, List<String> log}) {
 }
 
 void main() {
-  GlobalKey<ScrollableState<Scrollable>> scrollKey;
-
-  Completer<Null> scrollTo(double newScrollOffset, { Duration duration }) {
+  Completer<Null> scrollTo(WidgetTester tester, double newScrollOffset, { Duration duration }) {
     Completer<Null> completer = new Completer<Null>();
-    scrollKey.currentState.scrollTo(newScrollOffset, duration: duration).whenComplete(completer.complete);
+    final ScrollableState scrollable = tester.state(find.byType(Scrollable));
+    scrollable.scrollTo(newScrollOffset, duration: duration).whenComplete(completer.complete);
     return completer;
   }
 
@@ -52,12 +50,11 @@ void main() {
   });
 
   testWidgets('Scroll scrollTo animation', (WidgetTester tester) async {
-    scrollKey = new GlobalKey<ScrollableState<Scrollable>>();
     List<String> log = <String>[];
-    await tester.pumpWidget(_buildScroller(key: scrollKey, log: log));
+    await tester.pumpWidget(_buildScroller(log: log));
 
     expect(log, equals(<String>[]));
-    Completer<Null> completer = scrollTo(100.0, duration: const Duration(seconds: 1));
+    Completer<Null> completer = scrollTo(tester, 100.0, duration: const Duration(seconds: 1));
     expect(completer.isCompleted, isFalse);
     expect(log, equals(<String>['scrollstart']));
     await tester.pump(const Duration(milliseconds: 100));
@@ -70,12 +67,11 @@ void main() {
   });
 
   testWidgets('Scroll scrollTo no animation', (WidgetTester tester) async {
-    scrollKey = new GlobalKey<ScrollableState<Scrollable>>();
     List<String> log = <String>[];
-    await tester.pumpWidget(_buildScroller(key: scrollKey, log: log));
+    await tester.pumpWidget(_buildScroller(log: log));
 
     expect(log, equals(<String>[]));
-    Completer<Null> completer = scrollTo(100.0);
+    Completer<Null> completer = scrollTo(tester, 100.0);
     expect(completer.isCompleted, isFalse);
     expect(log, equals(<String>['scrollstart', 'scroll', 'scrollend']));
     await tester.pump();
@@ -83,12 +79,11 @@ void main() {
   });
 
   testWidgets('Scroll during animation', (WidgetTester tester) async {
-    scrollKey = new GlobalKey<ScrollableState<Scrollable>>();
     List<String> log = <String>[];
-    await tester.pumpWidget(_buildScroller(key: scrollKey, log: log));
+    await tester.pumpWidget(_buildScroller(log: log));
 
     expect(log, equals(<String>[]));
-    Completer<Null> completer = scrollTo(100.0, duration: const Duration(seconds: 1));
+    Completer<Null> completer = scrollTo(tester, 100.0, duration: const Duration(seconds: 1));
     expect(completer.isCompleted, isFalse);
     expect(log, equals(<String>['scrollstart']));
     await tester.pump(const Duration(milliseconds: 100));
@@ -97,7 +92,7 @@ void main() {
     expect(log, equals(<String>['scrollstart', 'scroll']));
     expect(completer.isCompleted, isFalse);
 
-    completer = scrollTo(100.0);
+    completer = scrollTo(tester, 100.0);
     expect(completer.isCompleted, isFalse);
     expect(log, equals(<String>['scrollstart', 'scroll', 'scroll']));
     await tester.pump(const Duration(milliseconds: 100));
@@ -108,12 +103,11 @@ void main() {
   });
 
   testWidgets('Scroll during animation', (WidgetTester tester) async {
-    scrollKey = new GlobalKey<ScrollableState<Scrollable>>();
     List<String> log = <String>[];
-    await tester.pumpWidget(_buildScroller(key: scrollKey, log: log));
+    await tester.pumpWidget(_buildScroller(log: log));
 
     expect(log, equals(<String>[]));
-    Completer<Null> completer = scrollTo(100.0, duration: const Duration(seconds: 1));
+    Completer<Null> completer = scrollTo(tester, 100.0, duration: const Duration(seconds: 1));
     expect(completer.isCompleted, isFalse);
     expect(log, equals(<String>['scrollstart']));
     await tester.pump(const Duration(milliseconds: 100));
@@ -122,7 +116,7 @@ void main() {
     expect(log, equals(<String>['scrollstart', 'scroll']));
     expect(completer.isCompleted, isFalse);
 
-    completer = scrollTo(100.0, duration: const Duration(seconds: 1));
+    completer = scrollTo(tester, 100.0, duration: const Duration(seconds: 1));
     expect(completer.isCompleted, isFalse);
     expect(log, equals(<String>['scrollstart', 'scroll']));
     await tester.pump(const Duration(milliseconds: 100));
@@ -133,9 +127,8 @@ void main() {
   });
 
   testWidgets('fling, fling generates two start/end pairs', (WidgetTester tester) async {
-    scrollKey = new GlobalKey<ScrollableState<Scrollable>>();
     List<String> log = <String>[];
-    await tester.pumpWidget(_buildScroller(key: scrollKey, log: log));
+    await tester.pumpWidget(_buildScroller(log: log));
 
     expect(log, equals(<String>[]));
     await tester.flingFrom(const Point(100.0, 100.0), const Offset(-50.0, -50.0), 500.0);
@@ -152,9 +145,8 @@ void main() {
   });
 
   testWidgets('fling up ends', (WidgetTester tester) async {
-    scrollKey = new GlobalKey<ScrollableState<Scrollable>>();
     List<String> log = <String>[];
-    await tester.pumpWidget(_buildScroller(key: scrollKey, log: log));
+    await tester.pumpWidget(_buildScroller(log: log));
 
     expect(log, equals(<String>[]));
     await tester.flingFrom(const Point(100.0, 100.0), const Offset(50.0, 50.0), 500.0);
@@ -165,6 +157,6 @@ void main() {
     expect(log.last, equals('scrollend'));
     log.removeWhere((String value) => value == 'scroll');
     expect(log.length, equals(2));
-    expect(scrollKey.currentState.scrollOffset, equals(0.0));
+    expect(tester.state<ScrollableState>(find.byType(Scrollable)).scrollOffset, equals(0.0));
   });
 }

--- a/packages/flutter/test/widgets/scrollable_grid_test.dart
+++ b/packages/flutter/test/widgets/scrollable_grid_test.dart
@@ -15,7 +15,6 @@ void main() {
 
   // Tests https://github.com/flutter/flutter/issues/5522
   testWidgets('ScrollableGrid displays correct children with nonzero padding', (WidgetTester tester) async {
-    GlobalKey<ScrollableState> scrollableKey = new GlobalKey<ScrollableState>();
     final EdgeInsets padding = const EdgeInsets.fromLTRB(0.0, 100.0, 0.0, 0.0);
 
     Widget testWidget = new Align(
@@ -23,7 +22,6 @@ void main() {
         height: 800.0,
         width: 300.0,  // forces the grid children to be 300..300
         child: new ScrollableGrid(
-          scrollableKey: scrollableKey,
           delegate: new FixedColumnCountGridDelegate(
             columnCount: 1,
             padding: padding

--- a/packages/flutter/test/widgets/scrollable_lazy_list_test.dart
+++ b/packages/flutter/test/widgets/scrollable_lazy_list_test.dart
@@ -77,10 +77,8 @@ void main() {
       return result;
     };
 
-    GlobalKey<ScrollableState> scrollableKey = new GlobalKey<ScrollableState>();
     FlipWidget testWidget = new FlipWidget(
       left: new ScrollableLazyList(
-        scrollableKey: scrollableKey,
         itemBuilder: itemBuilder,
         itemExtent: 200.0,
         initialScrollOffset: 300.0
@@ -89,7 +87,8 @@ void main() {
     );
     Completer<Null> scrollTo(double newScrollOffset) {
       Completer<Null> completer = new Completer<Null>();
-      scrollableKey.currentState.scrollTo(newScrollOffset).whenComplete(completer.complete);
+      final ScrollableState scrollable = tester.state(find.byType(Scrollable));
+      scrollable.scrollTo(newScrollOffset).whenComplete(completer.complete);
       return completer;
     }
 
@@ -132,10 +131,8 @@ void main() {
       return result;
     };
 
-    GlobalKey<ScrollableState> scrollableKey = new GlobalKey<ScrollableState>();
     FlipWidget testWidget = new FlipWidget(
       left: new ScrollableLazyList(
-        scrollableKey: scrollableKey,
         itemBuilder: itemBuilder,
         itemExtent: 200.0,
         initialScrollOffset: 300.0,
@@ -145,7 +142,8 @@ void main() {
     );
     Completer<Null> scrollTo(double newScrollOffset) {
       Completer<Null> completer = new Completer<Null>();
-      scrollableKey.currentState.scrollTo(newScrollOffset).whenComplete(completer.complete);
+      final ScrollableState scrollable = tester.state(find.byType(Scrollable));
+      scrollable.scrollTo(newScrollOffset).whenComplete(completer.complete);
       return completer;
     }
 
@@ -183,16 +181,15 @@ void main() {
       return result;
     };
 
-    GlobalKey<ScrollableState> scrollableKey = new GlobalKey<ScrollableState>();
     Widget testWidget = new ScrollableLazyList(
-      scrollableKey: scrollableKey,
       itemBuilder: itemBuilder,
       itemExtent: 300.0,
       itemCount: 10
     );
     Completer<Null> scrollTo(double newScrollOffset) {
       Completer<Null> completer = new Completer<Null>();
-      scrollableKey.currentState.scrollTo(newScrollOffset).whenComplete(completer.complete);
+      ScrollableState scrollable = tester.state(find.byType(Scrollable));
+      scrollable.scrollTo(newScrollOffset).whenComplete(completer.complete);
       return completer;
     }
 

--- a/packages/flutter/test/widgets/scrollable_list_hit_testing_test.dart
+++ b/packages/flutter/test/widgets/scrollable_list_hit_testing_test.dart
@@ -154,14 +154,12 @@ void main() {
 
   testWidgets('Tap immediately following clamped overscroll', (WidgetTester tester) async {
     // Regression test for https://github.com/flutter/flutter/issues/5709
-    GlobalKey<ScrollableState> scrollableKey = new GlobalKey<ScrollableState>();
     List<int> tapped = <int>[];
 
     await tester.pumpWidget(
       new ClampOverscrolls(
         edge: ScrollableEdge.both,
         child: new ScrollableList(
-          scrollableKey: scrollableKey,
           itemExtent: 200.0,
           children: items.map((int item) {
             return new Container(
@@ -176,8 +174,9 @@ void main() {
     );
 
     await tester.fling(find.text('0'), const Offset(0.0, 400.0), 1000.0);
-    expect(scrollableKey.currentState.scrollOffset, equals(0.0));
-    expect(scrollableKey.currentState.virtualScrollOffset, lessThan(0.0));
+    final ScrollableState scrollable = tester.state(find.byType(Scrollable));
+    expect(scrollable.scrollOffset, equals(0.0));
+    expect(scrollable.virtualScrollOffset, lessThan(0.0));
 
     await tester.tapAt(const Point(200.0, 100.0));
     expect(tapped, equals(<int>[0]));

--- a/packages/flutter/test/widgets/slivers_evil_test.dart
+++ b/packages/flutter/test/widgets/slivers_evil_test.dart
@@ -70,12 +70,10 @@ class TestViewportScrollPosition extends AbsoluteScrollPosition
 
 void main() {
   testWidgets('Evil test of sliver features - 1', (WidgetTester tester) async {
-    final GlobalKey<Scrollable2State> scrollableKey = new GlobalKey<Scrollable2State>();
     final GlobalKey centerKey = new GlobalKey();
     await tester.pumpWidget(
       new Scrollbar2(
         child: new ScrollableViewport2(
-          key: scrollableKey,
           axisDirection: AxisDirection.down,
           center: centerKey,
           anchor: 0.25,

--- a/packages/flutter/test/widgets/snap_scrolling_test.dart
+++ b/packages/flutter/test/widgets/snap_scrolling_test.dart
@@ -9,7 +9,6 @@ import 'package:flutter/widgets.dart';
 
 const double itemExtent = 200.0;
 Axis scrollDirection = Axis.vertical;
-GlobalKey scrollableListKey;
 
 Widget buildItem(int item) {
   return new Container(
@@ -39,14 +38,12 @@ class TestScrollConfigurationDelegate extends ScrollConfigurationDelegate {
 }
 
 Widget buildFrame() {
-  scrollableListKey = new GlobalKey();
   return new ScrollConfiguration(
     delegate: const TestScrollConfigurationDelegate(),
     child: new Center(
       child: new Container(
         height: itemExtent * 2.0,
         child: new ScrollableList(
-          scrollableKey: scrollableListKey,
           snapOffsetCallback: snapOffsetCallback,
           scrollDirection: scrollDirection,
           itemExtent: itemExtent,
@@ -57,26 +54,26 @@ Widget buildFrame() {
   );
 }
 
-ScrollableState get scrollableState => scrollableListKey.currentState;
-
-double get scrollOffset =>  scrollableState.scrollOffset;
-set scrollOffset(double value) {
-  scrollableState.scrollTo(value);
-}
-
-Completer<Null> fling(double velocity) {
-  Completer<Null> completer = new Completer<Null>();
-  scrollableState.fling(velocity).whenComplete(completer.complete);
-  return completer;
-}
-
 void main() {
   testWidgets('ScrollableList snap scrolling', (WidgetTester tester) async {
+    ScrollableState getScrollableState() => tester.state(find.byType(Scrollable));
+
+    double getScrollOffset() => getScrollableState().scrollOffset;
+    void setScrollOffset(double value) {
+      getScrollableState().scrollTo(value);
+    }
+
+    Completer<Null> fling(double velocity) {
+      Completer<Null> completer = new Completer<Null>();
+      getScrollableState().fling(velocity).whenComplete(completer.complete);
+      return completer;
+    }
+
     await tester.pumpWidget(buildFrame());
 
-    scrollOffset = 0.0;
+    setScrollOffset(0.0);
     await tester.pump();
-    expect(scrollOffset, 0.0);
+    expect(getScrollOffset(), 0.0);
 
     Duration dt = const Duration(seconds: 2);
 
@@ -84,51 +81,51 @@ void main() {
     expect(completer.isCompleted, isFalse);
     await tester.pump(); // Start the scheduler at 0.0
     await tester.pump(dt);
-    expect(scrollOffset, closeTo(200.0, 1.0));
+    expect(getScrollOffset(), closeTo(200.0, 1.0));
     expect(completer.isCompleted, isTrue);
 
-    scrollOffset = 0.0;
+    setScrollOffset(0.0);
     await tester.pump();
-    expect(scrollOffset, 0.0);
+    expect(getScrollOffset(), 0.0);
 
     completer = fling(2000.0);
     expect(completer.isCompleted, isFalse);
     await tester.pump();
     await tester.pump(dt);
-    expect(scrollOffset, closeTo(400.0, 1.0));
+    expect(getScrollOffset(), closeTo(400.0, 1.0));
     expect(completer.isCompleted, isTrue);
 
-    scrollOffset = 400.0;
+    setScrollOffset(400.0);
     await tester.pump();
-    expect(scrollOffset, 400.0);
+    expect(getScrollOffset(), 400.0);
 
     completer = fling(-800.0);
     expect(completer.isCompleted, isFalse);
     await tester.pump();
     await tester.pump(dt);
-    expect(scrollOffset, closeTo(0.0, 1.0));
+    expect(getScrollOffset(), closeTo(0.0, 1.0));
     expect(completer.isCompleted, isTrue);
 
-    scrollOffset = 800.0;
+    setScrollOffset(800.0);
     await tester.pump();
-    expect(scrollOffset, 800.0);
+    expect(getScrollOffset(), 800.0);
 
     completer = fling(-2000.0);
     expect(completer.isCompleted, isFalse);
     await tester.pump();
     await tester.pump(dt);
-    expect(scrollOffset, closeTo(200.0, 1.0));
+    expect(getScrollOffset(), closeTo(200.0, 1.0));
     expect(completer.isCompleted, isTrue);
 
-    scrollOffset = 800.0;
+    setScrollOffset(800.0);
     await tester.pump();
-    expect(scrollOffset, 800.0);
+    expect(getScrollOffset(), 800.0);
 
     completer = fling(-2000.0);
     expect(completer.isCompleted, isFalse);
     await tester.pump();
     await tester.pump(dt);
     expect(completer.isCompleted, isTrue);
-    expectSync(scrollOffset, closeTo(200.0, 1.0));
+    expectSync(getScrollOffset(), closeTo(200.0, 1.0));
   });
 }


### PR DESCRIPTION
This patch removes unnecessary uses of scrollableKey from tests.
Scrollable2 will likely use a different mechanism for identifying
itself, so we want to focus on the uses of scrollableKey that will need
to be addressed in the new implementation.