### PR TITLE
Some fixes for the microbenchmarks

### DIFF
--- a/dev/benchmarks/microbenchmarks/lib/gestures/velocity_tracker_bench.dart
+++ b/dev/benchmarks/microbenchmarks/lib/gestures/velocity_tracker_bench.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:io';
 import 'package:flutter/gestures.dart';
 import 'data/velocity_tracker_data.dart';
 
@@ -33,5 +32,4 @@ void main() {
     name: 'velocity_tracker_iteration',
   );
   printer.printToStdout();
-  exit(0);
 }

--- a/dev/benchmarks/microbenchmarks/lib/stocks/animation_bench.dart
+++ b/dev/benchmarks/microbenchmarks/lib/stocks/animation_bench.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/material.dart';
@@ -102,6 +101,4 @@ Future<Null> main() async {
     name: 'stock_animation_subsequent_frame_average',
   );
   printer.printToStdout();
-
-  exit(0);
 }

--- a/dev/benchmarks/microbenchmarks/lib/stocks/build_bench.dart
+++ b/dev/benchmarks/microbenchmarks/lib/stocks/build_bench.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/material.dart';
@@ -47,5 +46,4 @@ Future<Null> main() async {
     name: 'stock_build_iteration',
   );
   printer.printToStdout();
-  exit(0);
 }

--- a/dev/benchmarks/microbenchmarks/lib/stocks/layout_bench.dart
+++ b/dev/benchmarks/microbenchmarks/lib/stocks/layout_bench.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/material.dart';
@@ -46,5 +45,4 @@ Future<Null> main() async {
     name: 'stock_layout_iteration',
   );
   printer.printToStdout();
-  exit(0);
 }

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -15,6 +15,7 @@ import 'base/io.dart';
 
 import 'asset.dart';
 
+import 'base/common.dart';
 import 'base/logger.dart';
 import 'build_info.dart';
 import 'dart/dependencies.dart';
@@ -172,8 +173,15 @@ abstract class ResidentRunner {
 
     // Refresh the view list.
     await vmService.vm.refreshViews();
+    for (int i = 0; vmService.vm.mainView == null && i < 5; i++) {
+      // If the VM doesn't yet have a view, wait for one to show up.
+      printTrace('Waiting for Flutter view');
+      await new Future<Null>.delayed(new Duration(seconds: 1));
+      await vmService.vm.refreshViews();
+    }
     currentView = vmService.vm.mainView;
-    assert(currentView != null);
+    if (currentView == null)
+      throwToolExit('No Flutter view is available');
 
     // Listen for service protocol connection to close.
     vmService.done.whenComplete(() {

--- a/packages/flutter_tools/lib/src/vmservice.dart
+++ b/packages/flutter_tools/lib/src/vmservice.dart
@@ -686,7 +686,7 @@ class VM extends ServiceObjectOwner {
   }
 
   FlutterView get mainView {
-    return _viewCache.values.first;
+    return _viewCache.values.isEmpty ? null : _viewCache.values.first;
   }
 }
 


### PR DESCRIPTION
* Return null from VM.mainView if no view exists
* Retry in connectToServiceProtocol if a view is not yet available
* Do not explicitly call exit from the benchmarks - it will not cleanly shut down the engine