### PR TITLE
Simplify AbsoluteScrollPosition class structure

### DIFF
--- a/packages/flutter/lib/src/widgets/scrollable.dart
+++ b/packages/flutter/lib/src/widgets/scrollable.dart
@@ -209,14 +209,6 @@ abstract class ScrollPosition extends ViewportOffset {
     return null;
   }
 
-  /// Used by [AbsoluteDragScrollActivity] and other user-driven activities to
-  /// convert an offset in logical pixels as provided by the [DragUpdateDetails]
-  /// into a delta to apply using [setPixels].
-  ///
-  /// This is used by some [ScrollPosition] subclasses to apply friction during
-  /// overscroll situations.
-  double applyPhysicsToUserOffset(double offset) => offset;
-
   // ///
   // /// The velocity should be in logical pixels per second.
   void beginBallisticActivity(double velocity) {

--- a/packages/flutter/test/widgets/slivers_evil_test.dart
+++ b/packages/flutter/test/widgets/slivers_evil_test.dart
@@ -45,6 +45,7 @@ class TestBehavior extends ScrollBehavior2 {
       state,
       new Tolerance(velocity: 20.0, distance: 1.0),
       oldPosition,
+      const ClampingScrollPhysics(),
     );
   }
 
@@ -52,13 +53,13 @@ class TestBehavior extends ScrollBehavior2 {
   bool shouldNotify(TestBehavior oldDelegate) => false;
 }
 
-class TestViewportScrollPosition extends AbsoluteScrollPosition
-  with ClampingAbsoluteScrollPositionMixIn {
+class TestViewportScrollPosition extends AbsoluteScrollPosition {
   TestViewportScrollPosition(
     Scrollable2State state,
     Tolerance scrollTolerances,
     ScrollPosition oldPosition,
-  ) : super(state, scrollTolerances, oldPosition);
+    ScrollPhysics physics,
+  ) : super(state, scrollTolerances, oldPosition, physics);
 
   @override
   bool applyContentDimensions(double minScrollExtent, double maxScrollExtent) {


### PR DESCRIPTION
Instead of using mixins and subclasses, we now use a `ScrollPhysics` delegate
to customize the scrolling phyics for Android and iOS. This change will make it
easier to customize the scroll position for paging.