### PR TITLE
Add find.descendant API to support find descendants of an element by passing the current element finder and the finder of descendant.

### DIFF
--- a/packages/flutter_test/lib/src/finders.dart
+++ b/packages/flutter_test/lib/src/finders.dart
@@ -184,13 +184,13 @@ class CommonFinders {
   ///
   /// Example:
   ///
-  ///     expect(tester, hasWidget(find.descedant(
+  ///     expect(tester, hasWidget(find.descendant(
   ///       ancestor: find.widgetWithText(Row, 'label_1'), descendant: find.text('value_1')));
   ///
   /// If the `skipOffstage` argument is true (the default), then this skips
   /// nodes that are [Offstage] or that are from inactive [Route]s.
-  Finder descendant({ Finder ancestor, Finder descendant, bool skipOffstage: true }) {
-    return new _DescendantFinder(ancestor, descendant, skipOffstage: skipOffstage);
+  Finder descendant({ Finder of, Finder matching, bool skipOffstage: true }) {
+    return new _DescendantFinder(of, matching, skipOffstage: skipOffstage);
   }
 }
 
@@ -500,7 +500,6 @@ class _DescendantFinder extends Finder {
 
   @override
   Iterable<Element> get _allElements {
-    assert(ancestor.evaluate().length == 1);
-    return collectAllElementsFrom(ancestor.evaluate().single, skipOffstage: skipOffstage);
+    return ancestor.evaluate().expand((Element element) => collectAllElementsFrom(element, skipOffstage: skipOffstage)).toList();
   }
 }

--- a/packages/flutter_test/lib/src/finders.dart
+++ b/packages/flutter_test/lib/src/finders.dart
@@ -6,6 +6,8 @@ import 'package:flutter/material.dart';
 
 import 'all_elements.dart';
 
+import 'package:meta/meta.dart';
+
 /// Signature for [CommonFinders.byPredicate].
 typedef bool WidgetPredicate(Widget widget);
 

--- a/packages/flutter_test/lib/src/finders.dart
+++ b/packages/flutter_test/lib/src/finders.dart
@@ -185,7 +185,8 @@ class CommonFinders {
   /// Example:
   ///
   ///     expect(find.descendant(
-  ///       ancestor: find.widgetWithText(Row, 'label_1'), descendant: find.text('value_1')), findsOneWidget);
+  ///       of: find.widgetWithText(Row, 'label_1'), matching: find.text('value_1')
+///       ), findsOneWidget);
   ///
   /// If the `skipOffstage` argument is true (the default), then this skips
   /// nodes that are [Offstage] or that are from inactive [Route]s.

--- a/packages/flutter_test/lib/src/finders.dart
+++ b/packages/flutter_test/lib/src/finders.dart
@@ -26,7 +26,7 @@ class CommonFinders {
   ///
   /// Example:
   ///
-  ///     expect(tester, hasWidget(find.text('Back')));
+  ///     expect(find.text('Back'), findsOneWidget);
   ///
   /// If the `skipOffstage` argument is true (the default), then this skips
   /// nodes that are [Offstage] or that are from inactive [Route]s.
@@ -37,7 +37,7 @@ class CommonFinders {
   ///
   /// Example:
   ///
-  ///     expect(tester, hasWidget(find.icon(Icons.chevron_left)));
+  ///     expect(find.icon(Icons.chevron_left), findsOneWidget);
   ///
   /// If the `skipOffstage` argument is true (the default), then this skips
   /// nodes that are [Offstage] or that are from inactive [Route]s.
@@ -66,7 +66,7 @@ class CommonFinders {
   ///
   /// Example:
   ///
-  ///     expect(tester, hasWidget(find.byKey(backKey)));
+  ///     expect(find.byKey(backKey), findsOneWidget);
   ///
   /// If the `skipOffstage` argument is true (the default), then this skips
   /// nodes that are [Offstage] or that are from inactive [Route]s.
@@ -82,7 +82,7 @@ class CommonFinders {
   ///
   /// Example:
   ///
-  ///     expect(tester, hasWidget(find.byType(IconButton)));
+  ///     expect(find.byType(IconButton), findsOneWidget);
   ///
   /// If the `skipOffstage` argument is true (the default), then this skips
   /// nodes that are [Offstage] or that are from inactive [Route]s.
@@ -98,7 +98,7 @@ class CommonFinders {
   ///
   /// Example:
   ///
-  ///     expect(tester, hasWidget(find.byElementType(SingleChildRenderObjectElement)));
+  ///     expect(find.byElementType(SingleChildRenderObjectElement), findsOneWidget);
   ///
   /// If the `skipOffstage` argument is true (the default), then this skips
   /// nodes that are [Offstage] or that are from inactive [Route]s.
@@ -125,10 +125,10 @@ class CommonFinders {
   ///
   /// Example:
   ///
-  ///     expect(tester, hasWidget(find.byWidgetPredicate(
+  ///     expect(find.byWidgetPredicate(
   ///       (Widget widget) => widget is Tooltip && widget.message == 'Back',
   ///       description: 'widget with tooltip "Back"',
-  ///     )));
+  ///     ), findsOneWidget);
   ///
   /// If [description] is provided, then this uses it as the description of the
   /// [Finder] and appears, for example, in the error message when the finder
@@ -145,7 +145,7 @@ class CommonFinders {
   ///
   /// Example:
   ///
-  ///     expect(tester, hasWidget(find.byTooltip('Back')));
+  ///     expect(find.byTooltip('Back'), findsOneWidget);
   ///
   /// If the `skipOffstage` argument is true (the default), then this skips
   /// nodes that are [Offstage] or that are from inactive [Route]s.
@@ -160,13 +160,13 @@ class CommonFinders {
   ///
   /// Example:
   ///
-  ///     expect(tester, hasWidget(find.byElementPredicate(
+  ///     expect(find.byElementPredicate(
   ///       // finds elements of type SingleChildRenderObjectElement, including
   ///       // those that are actually subclasses of that type.
   ///       // (contrast with byElementType, which only returns exact matches)
   ///       (Element element) => element is SingleChildRenderObjectElement,
   ///       description: '$SingleChildRenderObjectElement element',
-  ///     )));
+  ///     ), findsOneWidget);
   ///
   /// If [description] is provided, then this uses it as the description of the
   /// [Finder] and appears, for example, in the error message when the finder
@@ -184,8 +184,8 @@ class CommonFinders {
   ///
   /// Example:
   ///
-  ///     expect(tester, hasWidget(find.descendant(
-  ///       ancestor: find.widgetWithText(Row, 'label_1'), descendant: find.text('value_1')));
+  ///     expect(find.descendant(
+  ///       ancestor: find.widgetWithText(Row, 'label_1'), descendant: find.text('value_1')), findsOneWidget);
   ///
   /// If the `skipOffstage` argument is true (the default), then this skips
   /// nodes that are [Offstage] or that are from inactive [Route]s.
@@ -491,7 +491,7 @@ class _DescendantFinder extends Finder {
   final Finder descendant;
 
   @override
-  String get description => '${ancestor.description} has descendant(s) with ${descendant.description} ';
+  String get description => '${descendant.description} has ancestor(s) with ${ancestor.description} ';
 
   @override
   Iterable<Element> apply(Iterable<Element> candidates) {
@@ -500,6 +500,8 @@ class _DescendantFinder extends Finder {
 
   @override
   Iterable<Element> get _allElements {
-    return ancestor.evaluate().expand((Element element) => collectAllElementsFrom(element, skipOffstage: skipOffstage)).toList();
+    return ancestor.evaluate().expand(
+      (Element element) => collectAllElementsFrom(element, skipOffstage: skipOffstage)
+    ).toSet().toList();
   }
 }

--- a/packages/flutter_test/lib/src/finders.dart
+++ b/packages/flutter_test/lib/src/finders.dart
@@ -222,7 +222,8 @@ abstract class Finder {
   /// [Offstage] widgets, as well as children of inactive [Route]s.
   final bool skipOffstage;
 
-  Iterable<Element> get _allElements {
+  @protected
+  Iterable<Element> get allCandidates {
     return collectAllElementsFrom(
       WidgetsBinding.instance.renderViewElement,
       skipOffstage: skipOffstage
@@ -237,7 +238,7 @@ abstract class Finder {
   ///
   /// Calling this clears the cache from [precache].
   Iterable<Element> evaluate() {
-    final Iterable<Element> result = _cachedResult ?? apply(_allElements);
+    final Iterable<Element> result = _cachedResult ?? apply(allCandidates);
     _cachedResult = null;
     return result;
   }
@@ -249,7 +250,7 @@ abstract class Finder {
   /// If this returns true, you must call [evaluate] before you call [precache] again.
   bool precache() {
     assert(_cachedResult == null);
-    final Iterable<Element> result = apply(_allElements);
+    final Iterable<Element> result = apply(allCandidates);
     if (result.isNotEmpty) {
       _cachedResult = result;
       return true;
@@ -500,7 +501,7 @@ class _DescendantFinder extends Finder {
   }
 
   @override
-  Iterable<Element> get _allElements {
+  Iterable<Element> get allCandidates {
     return ancestor.evaluate().expand(
       (Element element) => collectAllElementsFrom(element, skipOffstage: skipOffstage)
     ).toSet().toList();

--- a/packages/flutter_test/lib/src/finders.dart
+++ b/packages/flutter_test/lib/src/finders.dart
@@ -491,7 +491,7 @@ class _DescendantFinder extends Finder {
   final Finder descendant;
 
   @override
-  String get description => 'find ${descendant.description} in ${ancestor.description}';
+  String get description => '${ancestor.description} has descendant(s) with ${descendant.description} ';
 
   @override
   Iterable<Element> apply(Iterable<Element> candidates) {

--- a/packages/flutter_test/lib/src/finders.dart
+++ b/packages/flutter_test/lib/src/finders.dart
@@ -495,7 +495,7 @@ class _DescendantFinder extends Finder {
   final Finder descendant;
 
   @override
-  String get description => '${descendant.description} has ancestor(s) with ${ancestor.description} ';
+  String get description => '${descendant.description} that has ancestor(s) with ${ancestor.description} ';
 
   @override
   Iterable<Element> apply(Iterable<Element> candidates) {

--- a/packages/flutter_test/test/widget_tester_test.dart
+++ b/packages/flutter_test/test/widget_tester_test.dart
@@ -139,7 +139,7 @@ void main() {
   });
 
   group('find.descendant', () {
-    testWidgets('fails with a descriptive message', (WidgetTester tester) async {
+    testWidgets('finds one descendant', (WidgetTester tester) async {
       await tester.pumpWidget(new Row(children: <Widget>[
         new Column(children: <Text>[new Text('foo'), new Text('bar')])
       ]));
@@ -148,6 +148,18 @@ void main() {
         of:find.widgetWithText(Row, 'foo'),
         matching: find.text('bar')
       ), findsOneWidget);
+    });
+
+    testWidgets('finds two descendants with different ancestors', (WidgetTester tester) async {
+      await tester.pumpWidget(new Row(children: <Widget>[
+        new Column(children: <Text>[new Text('foo'), new Text('bar')]),
+        new Column(children: <Text>[new Text('foo'), new Text('bar')]),
+      ]));
+
+      expect(find.descendant(
+        of:find.widgetWithText(Column, 'foo'),
+        matching: find.text('bar')
+      ), findsNWidgets(2));
     });
 
     testWidgets('fails with a descriptive message', (WidgetTester tester) async {
@@ -169,7 +181,7 @@ void main() {
       expect(failure, isNotNull);
       expect(
           failure.message,
-          contains('Actual: ?:<zero widgets with type Column with text "foo" has descendant(s) with text "bar"')
+          contains('Actual: ?:<zero widgets with text "bar" has ancestor(s) with type Column with text "foo"')
         );
     });
   });

--- a/packages/flutter_test/test/widget_tester_test.dart
+++ b/packages/flutter_test/test/widget_tester_test.dart
@@ -137,4 +137,35 @@ void main() {
       expect(failure.message, contains('Actual: ?:<zero widgets with $customDescription'));
     });
   });
+
+  group('find.descendant', () {
+    testWidgets('fails with a custom description in the message',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(new Row(children: [
+        new Column(children: [new Text('foo')]),
+        new Text('bar')
+      ]));
+
+      TestFailure failure;
+      try {
+        expect(
+            find.descendant(
+                ancestor: find.widgetWithText(Column, 'foo'),
+                descendant: find.text('bar')),
+            findsOneWidget);
+      } catch (e) {
+        failure = e;
+      }
+
+      expect(failure, isNotNull);
+      expect(failure.message,
+          contains('Expected: exactly one matching node in the widget tree\n'));
+      expect(
+          failure.message,
+          contains(
+              'Actual: ?:<zero widgets with find text "bar" in type Column with text "foo" (ignoring offstage widgets)>\n'));
+      expect(failure.message,
+          contains('Which: means none were found but one was expected\n'));
+    });
+  });
 }

--- a/packages/flutter_test/test/widget_tester_test.dart
+++ b/packages/flutter_test/test/widget_tester_test.dart
@@ -140,15 +140,28 @@ void main() {
 
   group('find.descendant', () {
     testWidgets('fails with a descriptive message', (WidgetTester tester) async {
-      await tester.pumpWidget(new Row(children: [
-        new Column(children: [new Text('foo')]),
+      await tester.pumpWidget(new Row(children: <Widget>[
+        new Column(children: <Text>[new Text('foo'), new Text('bar')])
+      ]));
+
+      expect(find.descendant(
+        of:find.widgetWithText(Row, 'foo'),
+        matching: find.text('bar')
+      ), findsOneWidget);
+    });
+
+    testWidgets('fails with a descriptive message', (WidgetTester tester) async {
+      await tester.pumpWidget(new Row(children: <Widget>[
+        new Column(children: <Text>[new Text('foo')]),
         new Text('bar')
       ]));
 
       TestFailure failure;
       try {
-        expect(find.descendant(ancestor: find.widgetWithText(Column, 'foo'),
-                descendant: find.text('bar')), findsOneWidget);
+        expect(find.descendant(
+          of: find.widgetWithText(Column, 'foo'),
+          matching: find.text('bar')
+        ), findsOneWidget);
       } catch (e) {
         failure = e;
       }
@@ -156,7 +169,8 @@ void main() {
       expect(failure, isNotNull);
       expect(
           failure.message,
-          contains('Actual: ?:<zero widgets with type Column with text "foo" has descendant(s) with text "bar"'));
+          contains('Actual: ?:<zero widgets with type Column with text "foo" has descendant(s) with text "bar"')
+        );
     });
   });
 }

--- a/packages/flutter_test/test/widget_tester_test.dart
+++ b/packages/flutter_test/test/widget_tester_test.dart
@@ -181,7 +181,7 @@ void main() {
       expect(failure, isNotNull);
       expect(
           failure.message,
-          contains('Actual: ?:<zero widgets with text "bar" has ancestor(s) with type Column with text "foo"')
+          contains('Actual: ?:<zero widgets with text "bar" that has ancestor(s) with type Column with text "foo"')
         );
     });
   });

--- a/packages/flutter_test/test/widget_tester_test.dart
+++ b/packages/flutter_test/test/widget_tester_test.dart
@@ -145,7 +145,7 @@ void main() {
       ]));
 
       expect(find.descendant(
-        of:find.widgetWithText(Row, 'foo'),
+        of: find.widgetWithText(Row, 'foo'),
         matching: find.text('bar')
       ), findsOneWidget);
     });
@@ -157,7 +157,7 @@ void main() {
       ]));
 
       expect(find.descendant(
-        of:find.widgetWithText(Column, 'foo'),
+        of: find.widgetWithText(Column, 'foo'),
         matching: find.text('bar')
       ), findsNWidgets(2));
     });

--- a/packages/flutter_test/test/widget_tester_test.dart
+++ b/packages/flutter_test/test/widget_tester_test.dart
@@ -139,7 +139,7 @@ void main() {
   });
 
   group('find.descendant', () {
-    testWidgets('fails with a custom description in the message',
+    testWidgets('fails with a descriptive message',
         (WidgetTester tester) async {
       await tester.pumpWidget(new Row(children: [
         new Column(children: [new Text('foo')]),
@@ -148,24 +148,18 @@ void main() {
 
       TestFailure failure;
       try {
-        expect(
-            find.descendant(
+        expect(find.descendant(
                 ancestor: find.widgetWithText(Column, 'foo'),
-                descendant: find.text('bar')),
-            findsOneWidget);
+                descendant: find.text('bar')), findsOneWidget);
       } catch (e) {
         failure = e;
       }
 
       expect(failure, isNotNull);
-      expect(failure.message,
-          contains('Expected: exactly one matching node in the widget tree\n'));
       expect(
           failure.message,
           contains(
-              'Actual: ?:<zero widgets with find text "bar" in type Column with text "foo" (ignoring offstage widgets)>\n'));
-      expect(failure.message,
-          contains('Which: means none were found but one was expected\n'));
+              'Actual: ?:<zero widgets with type Column with text "foo" has descendant(s) with text "bar"'));
     });
   });
 }

--- a/packages/flutter_test/test/widget_tester_test.dart
+++ b/packages/flutter_test/test/widget_tester_test.dart
@@ -139,7 +139,7 @@ void main() {
   });
 
   group('find.descendant', () {
-    testWidgets('fails with a descriptive message',(WidgetTester tester) async {
+    testWidgets('fails with a descriptive message', (WidgetTester tester) async {
       await tester.pumpWidget(new Row(children: [
         new Column(children: [new Text('foo')]),
         new Text('bar')

--- a/packages/flutter_test/test/widget_tester_test.dart
+++ b/packages/flutter_test/test/widget_tester_test.dart
@@ -139,8 +139,7 @@ void main() {
   });
 
   group('find.descendant', () {
-    testWidgets('fails with a descriptive message',
-        (WidgetTester tester) async {
+    testWidgets('fails with a descriptive message',(WidgetTester tester) async {
       await tester.pumpWidget(new Row(children: [
         new Column(children: [new Text('foo')]),
         new Text('bar')
@@ -148,8 +147,7 @@ void main() {
 
       TestFailure failure;
       try {
-        expect(find.descendant(
-                ancestor: find.widgetWithText(Column, 'foo'),
+        expect(find.descendant(ancestor: find.widgetWithText(Column, 'foo'),
                 descendant: find.text('bar')), findsOneWidget);
       } catch (e) {
         failure = e;
@@ -158,8 +156,7 @@ void main() {
       expect(failure, isNotNull);
       expect(
           failure.message,
-          contains(
-              'Actual: ?:<zero widgets with type Column with text "foo" has descendant(s) with text "bar"'));
+          contains('Actual: ?:<zero widgets with type Column with text "foo" has descendant(s) with text "bar"'));
     });
   });
 }


### PR DESCRIPTION
A fix related to https://github.com/flutter/flutter/issues/7643.

I didn't add hasDescendantWidget as Hixie commented because I think find.descendant API should be enough.

Thanks for reviewing.