### PR TITLE
Shrink-wrapping Viewport

### DIFF
--- a/examples/flutter_gallery/lib/demo/list_demo.dart
+++ b/examples/flutter_gallery/lib/demo/list_demo.dart
@@ -40,7 +40,8 @@ class ListDemoState extends State<ListDemo> {
         decoration: new BoxDecoration(
           border: new Border(top: new BorderSide(color: Colors.black26))
         ),
-        child: new Block(
+        child: new ScrollView(
+          shrinkWrap: true,
           children: <Widget>[
             new ListItem(
               dense: true,

--- a/packages/flutter/lib/src/material/about.dart
+++ b/packages/flutter/lib/src/material/about.dart
@@ -285,8 +285,8 @@ class AboutDialog extends StatelessWidget {
     if (children != null)
       body.addAll(children);
     return new AlertDialog(
-      content: new Block(
-        children: body
+      content: new SingleChildScrollView(
+        child: new BlockBody(children: body),
       ),
       actions: <Widget>[
         new FlatButton(

--- a/packages/flutter/lib/src/material/dialog.dart
+++ b/packages/flutter/lib/src/material/dialog.dart
@@ -290,9 +290,9 @@ class SimpleDialog extends StatelessWidget {
 
     if (children != null) {
       body.add(new Flexible(
-        child: new Block(
+        child: new SingleChildScrollView(
           padding: contentPadding ?? const EdgeInsets.fromLTRB(0.0, 12.0, 0.0, 16.0),
-          children: children
+          child: new BlockBody(children: children),
         )
       ));
     }

--- a/packages/flutter/lib/src/material/popup_menu.dart
+++ b/packages/flutter/lib/src/material/popup_menu.dart
@@ -292,15 +292,15 @@ class _PopupMenu<T> extends StatelessWidget {
     Widget child = new ConstrainedBox(
       constraints: const BoxConstraints(
         minWidth: _kMenuMinWidth,
-        maxWidth: _kMenuMaxWidth
+        maxWidth: _kMenuMaxWidth,
       ),
       child: new IntrinsicWidth(
         stepWidth: _kMenuWidthStep,
-        child: new Block(
-          children: children,
+        child: new SingleChildScrollView(
           padding: const EdgeInsets.symmetric(
             vertical: _kMenuVerticalPadding
-          )
+          ),
+          child: new BlockBody(children: children),
         )
       )
     );
@@ -317,9 +317,9 @@ class _PopupMenu<T> extends StatelessWidget {
               alignment: FractionalOffset.topRight,
               widthFactor: width.evaluate(route.animation),
               heightFactor: height.evaluate(route.animation),
-              child: child
-            )
-          )
+              child: child,
+            ),
+          ),
         );
       },
       child: child

--- a/packages/flutter/lib/src/material/stepper.dart
+++ b/packages/flutter/lib/src/material/stepper.dart
@@ -542,8 +542,9 @@ class _StepperState extends State<Stepper> with TickerProviderStateMixin {
       );
     }
 
-    return new Block(
-      children: children
+    return new ScrollView(
+      shrinkWrap: true,
+      children: children,
     );
   }
 

--- a/packages/flutter/lib/src/material/two_level_list.dart
+++ b/packages/flutter/lib/src/material/two_level_list.dart
@@ -263,7 +263,6 @@ class TwoLevelList extends StatelessWidget {
   /// The [type] argument must not be null.
   TwoLevelList({
     Key key,
-    this.scrollableKey,
     this.children: const <Widget>[],
     this.type: MaterialListType.twoLine,
     this.padding
@@ -279,18 +278,15 @@ class TwoLevelList extends StatelessWidget {
   /// The kind of [ListItem] contained in this list.
   final MaterialListType type;
 
-  /// The key to use for the underlying scrollable widget.
-  final Key scrollableKey;
-
   /// The amount of space by which to inset the children inside the viewport.
   final EdgeInsets padding;
 
   @override
   Widget build(BuildContext context) {
-    return new Block(
+    return new ScrollView(
       padding: padding,
+      shrinkWrap: true,
       children: KeyedSubtree.ensureUniqueKeysForList(children),
-      scrollableKey: scrollableKey
     );
   }
 }

--- a/packages/flutter/lib/src/rendering/box.dart
+++ b/packages/flutter/lib/src/rendering/box.dart
@@ -198,16 +198,33 @@ class BoxConstraints extends Constraints {
     return height.clamp(minHeight, maxHeight);
   }
 
-  /// Returns the size that both satisfies the constraints and is as close as
-  /// possible to the given size.
-  Size constrain(Size size) {
-    Size result = new Size(constrainWidth(size.width), constrainHeight(size.height));
+  Size _debugPropagateDebugSize(Size size, Size result) {
     assert(() {
       if (size is _DebugSize)
         result = new _DebugSize(result, size._owner, size._canBeUsedByParent);
       return true;
     });
     return result;
+  }
+
+  /// Returns the size that both satisfies the constraints and is as close as
+  /// possible to the given size.
+  ///
+  /// See also [constrainDimensions], which applies the same algorithm to
+  /// separately provided widths and heights.
+  Size constrain(Size size) {
+    Size result = new Size(constrainWidth(size.width), constrainHeight(size.height));
+    assert(() { result = _debugPropagateDebugSize(size, result); return true; });
+    return result;
+  }
+
+  /// Returns the size that both satisfies the constraints and is as close as
+  /// possible to the given width and height.
+  ///
+  /// When you already have a [Size], prefer [constrain], which applies the same
+  /// algorithm to a [Size] directly.
+  Size constrainDimensions(double width, double height) {
+    return new Size(constrainWidth(width), constrainHeight(height));
   }
 
   /// Returns a size that attempts to meet the following conditions, in order:
@@ -218,8 +235,11 @@ class BoxConstraints extends Constraints {
   ///  - The returned size as big as possible while still being equal to or
   ///    smaller than the given size.
   Size constrainSizeAndAttemptToPreserveAspectRatio(Size size) {
-    if (isTight)
-      return smallest;
+    if (isTight) {
+      Size result = smallest;
+      assert(() { result = _debugPropagateDebugSize(size, result); return true; });
+      return result;
+    }
 
     double width = size.width;
     double height = size.height;
@@ -247,7 +267,9 @@ class BoxConstraints extends Constraints {
       width = height * aspectRatio;
     }
 
-    return new Size(constrainWidth(width), constrainHeight(height));
+    Size result = new Size(constrainWidth(width), constrainHeight(height));
+    assert(() { result = _debugPropagateDebugSize(size, result); return true; });
+    return result;
   }
 
   /// The biggest size that satisifes the constraints.

--- a/packages/flutter/lib/src/widgets/scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/scroll_view.dart
@@ -9,136 +9,160 @@ import 'framework.dart';
 import 'basic.dart';
 import 'scrollable.dart';
 import 'sliver.dart';
+import 'viewport.dart';
 
-AxisDirection _getDirection(BuildContext context, Axis scrollDirection) {
-  // TODO(abarth): Consider reading direction.
-  switch (scrollDirection) {
-    case Axis.horizontal:
-      return AxisDirection.right;
-    case Axis.vertical:
-      return AxisDirection.down;
-  }
-  return null;
-}
-
+/// A convenience widget that combines common scrolling-related widgets.
 class ScrollView extends StatelessWidget {
   ScrollView({
     Key key,
-    this.padding,
     this.scrollDirection: Axis.vertical,
+    this.reverse: false,
+    this.padding,
     this.initialScrollOffset: 0.0,
     this.itemExtent,
+    this.shrinkWrap: false,
     this.children: const <Widget>[],
-  }) : super(key: key);
-
-  final EdgeInsets padding;
+  }) : super(key: key) {
+    assert(reverse != null);
+    assert(initialScrollOffset != null);
+    assert(shrinkWrap != null);
+  }
 
   final Axis scrollDirection;
+
+  final bool reverse;
+
+  final EdgeInsets padding;
 
   final double initialScrollOffset;
 
   final double itemExtent;
 
+  final bool shrinkWrap;
+
   final List<Widget> children;
 
-  Widget _buildChildLayout() {
-    final SliverChildListDelegate delegate = new SliverChildListDelegate(children);
+  SliverChildListDelegate get childrenDelegate => new SliverChildListDelegate(children);
 
+  @protected
+  AxisDirection getDirection(BuildContext context) {
+    // TODO(abarth): Consider reading direction.
+    switch (scrollDirection) {
+      case Axis.horizontal:
+        return reverse ? AxisDirection.left : AxisDirection.right;
+      case Axis.vertical:
+        return reverse ? AxisDirection.up : AxisDirection.down;
+    }
+    return null;
+  }
+
+  @protected
+  Widget buildChildLayout(BuildContext context) {
     if (itemExtent != null) {
       return new SliverList(
-        delegate: delegate,
+        delegate: childrenDelegate,
         itemExtent: itemExtent,
       );
     }
-
-    return new SliverBlock(delegate: delegate);
+    return new SliverBlock(delegate: childrenDelegate);
   }
 
   @override
   Widget build(BuildContext context) {
-    Widget sliver = _buildChildLayout();
-
+    Widget sliver = buildChildLayout(context);
     if (padding != null)
       sliver = new SliverPadding(padding: padding, child: sliver);
-
-    return new ScrollableViewport2(
-      axisDirection: _getDirection(context, scrollDirection),
+    AxisDirection axisDirection = getDirection(context);
+    return new Scrollable2(
+      axisDirection: axisDirection,
       initialScrollOffset: initialScrollOffset,
-      slivers: <Widget>[ sliver ],
+      viewportBuilder: (BuildContext context, ViewportOffset offset) {
+        if (shrinkWrap) {
+          return new ShrinkWrappingViewport(
+            axisDirection: axisDirection,
+            offset: offset,
+            slivers: <Widget>[ sliver ],
+          );
+        } else {
+          return new Viewport2(
+            axisDirection: axisDirection,
+            offset: offset,
+            slivers: <Widget>[ sliver ],
+          );
+        }
+      }
     );
+  }
+
+  @override
+  void debugFillDescription(List<String> description) {
+    super.debugFillDescription(description);
+    description.add('$scrollDirection');
+    if (padding != null)
+      description.add('padding: $padding');
+    if (initialScrollOffset != 0.0)
+      description.add('initialScrollOffset: ${initialScrollOffset.toStringAsFixed(1)}');
+    if (itemExtent != null)
+      description.add('itemExtent: $itemExtent');
+    if (shrinkWrap)
+      description.add('shrink-wrapping');
   }
 }
 
-class ScrollGrid extends StatelessWidget {
+class ScrollGrid extends ScrollView {
   ScrollGrid({
     Key key,
-    this.padding,
-    this.scrollDirection: Axis.vertical,
-    this.initialScrollOffset: 0.0,
+    Axis scrollDirection: Axis.vertical,
+    EdgeInsets padding,
+    double initialScrollOffset: 0.0,
+    bool shrinkWrap: false,
     this.gridDelegate,
-    this.children: const <Widget>[],
-  }) : super(key: key);
+    List<Widget> children: const <Widget>[],
+  }) : super(key: key, scrollDirection: scrollDirection, padding: padding, shrinkWrap: shrinkWrap, children: children);
 
   ScrollGrid.count({
     Key key,
-    this.padding,
-    this.scrollDirection: Axis.vertical,
-    this.initialScrollOffset: 0.0,
+    Axis scrollDirection: Axis.vertical,
+    EdgeInsets padding,
+    double initialScrollOffset: 0.0,
+    bool shrinkWrap: false,
     @required int crossAxisCount,
     double mainAxisSpacing: 0.0,
     double crossAxisSpacing: 0.0,
     double childAspectRatio: 1.0,
-    this.children: const <Widget>[],
+    List<Widget> children: const <Widget>[],
   }) : gridDelegate = new SliverGridDelegateWithFixedCrossAxisCount(
     crossAxisCount: crossAxisCount,
     mainAxisSpacing: mainAxisSpacing,
     crossAxisSpacing: crossAxisSpacing,
     childAspectRatio: childAspectRatio,
-  ), super(key: key);
+  ), super(key: key, scrollDirection: scrollDirection, padding: padding, shrinkWrap: shrinkWrap, children: children);
 
   ScrollGrid.extent({
     Key key,
-    this.padding,
-    this.scrollDirection: Axis.vertical,
-    this.initialScrollOffset: 0.0,
+    Axis scrollDirection: Axis.vertical,
+    EdgeInsets padding,
+    double initialScrollOffset: 0.0,
+    bool shrinkWrap: false,
     @required double maxCrossAxisExtent,
     double mainAxisSpacing: 0.0,
     double crossAxisSpacing: 0.0,
     double childAspectRatio: 1.0,
-    this.children: const <Widget>[],
+    List<Widget> children: const <Widget>[],
   }) : gridDelegate = new SliverGridDelegateWithMaxCrossAxisExtent(
     maxCrossAxisExtent: maxCrossAxisExtent,
     mainAxisSpacing: mainAxisSpacing,
     crossAxisSpacing: crossAxisSpacing,
     childAspectRatio: childAspectRatio,
-  ), super(key: key);
-
-  final EdgeInsets padding;
-
-  final Axis scrollDirection;
-
-  final double initialScrollOffset;
+  ), super(key: key, scrollDirection: scrollDirection, padding: padding, shrinkWrap: shrinkWrap, children: children);
 
   final SliverGridDelegate gridDelegate;
 
-  final List<Widget> children;
-
   @override
-  Widget build(BuildContext context) {
-    final SliverChildListDelegate delegate = new SliverChildListDelegate(children);
-
-    Widget sliver = new SliverGrid(
-      delegate: delegate,
+  Widget buildChildLayout(BuildContext context) {
+    return new SliverGrid(
+      delegate: childrenDelegate,
       gridDelegate: gridDelegate,
-    );
-
-    if (padding != null)
-      sliver = new SliverPadding(padding: padding, child: sliver);
-
-    return new ScrollableViewport2(
-      axisDirection: _getDirection(context, scrollDirection),
-      initialScrollOffset: initialScrollOffset,
-      slivers: <Widget>[ sliver ],
     );
   }
 }

--- a/packages/flutter/lib/src/widgets/scrollable.dart
+++ b/packages/flutter/lib/src/widgets/scrollable.dart
@@ -396,64 +396,6 @@ class ScrollConfiguration2 extends InheritedWidget {
   }
 }
 
-class ScrollableViewport2 extends StatelessWidget {
-  ScrollableViewport2({
-    Key key,
-    this.initialScrollOffset: 0.0,
-    this.axisDirection: AxisDirection.down,
-    this.anchor: 0.0,
-    this.center,
-    this.scrollBehavior,
-    this.slivers: const <Widget>[],
-  }) {
-    assert(slivers != null);
-  }
-
-  final double initialScrollOffset;
-
-  final AxisDirection axisDirection;
-
-  final double anchor;
-
-  final Key center;
-
-  final ScrollBehavior2 scrollBehavior;
-
-  final List<Widget> slivers;
-
-  Axis get axis => axisDirectionToAxis(axisDirection);
-
-  @override
-  Widget build(BuildContext context) {
-    return new Scrollable2(
-      initialScrollOffset: initialScrollOffset,
-      axisDirection: axisDirection,
-      scrollBehavior: scrollBehavior,
-      viewportBuilder: (BuildContext context, ViewportOffset offset) {
-        return new Viewport2(
-          axisDirection: axisDirection,
-          anchor: anchor,
-          offset: offset,
-          center: center,
-          slivers: slivers,
-        );
-      }
-    );
-  }
-
-  @override
-  void debugFillDescription(List<String> description) {
-    super.debugFillDescription(description);
-    description.add('$axisDirection');
-    if (anchor != 0.0)
-      description.add('anchor: ${anchor.toStringAsFixed(1)}');
-    if (initialScrollOffset != 0.0)
-      description.add('initialScrollOffset: ${initialScrollOffset.toStringAsFixed(1)}');
-    if (center != null)
-      description.add('center: $center');
-  }
-}
-
 typedef Widget ViewportBuilder(BuildContext context, ViewportOffset position);
 
 class Scrollable2 extends StatefulWidget {

--- a/packages/flutter/lib/src/widgets/single_child_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/single_child_scroll_view.dart
@@ -10,10 +10,18 @@ import 'basic.dart';
 import 'framework.dart';
 import 'scrollable.dart';
 
+// ///
+// /// The viewport will shrink-wrap the child in both axes.
+// ///
+// /// See also:
+// ///  * [ScrollView], which handles multiple children in a scrolling list.
+// ///  * [ScrollGrid], which handles multiple children in a scrolling grid.
+// ///  * [Scrollable2], which handles arbitrary scrolling effects.
 class SingleChildScrollView extends StatelessWidget {
   SingleChildScrollView({
     Key key,
     this.scrollDirection: Axis.vertical,
+    this.padding,
     this.initialScrollOffset: 0.0,
     this.child,
   }) : super(key: key) {
@@ -22,6 +30,8 @@ class SingleChildScrollView extends StatelessWidget {
   }
 
   final Axis scrollDirection;
+
+  final EdgeInsets padding;
 
   final double initialScrollOffset;
 
@@ -41,6 +51,9 @@ class SingleChildScrollView extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final AxisDirection axisDirection = _getDirection(context);
+    Widget contents = child;
+    if (padding != null)
+      contents = new Padding(padding: padding, child: contents);
     return new Scrollable2(
       axisDirection: axisDirection,
       initialScrollOffset: initialScrollOffset,
@@ -49,7 +62,7 @@ class SingleChildScrollView extends StatelessWidget {
           key: key,
           axisDirection: axisDirection,
           offset: offset,
-          child: child,
+          child: contents,
         );
       },
     );

--- a/packages/flutter/lib/src/widgets/viewport.dart
+++ b/packages/flutter/lib/src/widgets/viewport.dart
@@ -98,3 +98,39 @@ class Viewport2Element extends MultiChildRenderObjectElement {
     }
   }
 }
+
+class ShrinkWrappingViewport extends MultiChildRenderObjectWidget {
+  ShrinkWrappingViewport({
+    Key key,
+    this.axisDirection: AxisDirection.down,
+    @required this.offset,
+    List<Widget> slivers: const <Widget>[],
+  }) : super(key: key, children: slivers) {
+    assert(offset != null);
+  }
+
+  final AxisDirection axisDirection;
+  final ViewportOffset offset;
+
+  @override
+  RenderShrinkWrappingViewport createRenderObject(BuildContext context) {
+    return new RenderShrinkWrappingViewport(
+      axisDirection: axisDirection,
+      offset: offset,
+    );
+  }
+
+  @override
+  void updateRenderObject(BuildContext context, RenderShrinkWrappingViewport renderObject) {
+    renderObject
+      ..axisDirection = axisDirection
+      ..offset = offset;
+  }
+
+  @override
+  void debugFillDescription(List<String> description) {
+    super.debugFillDescription(description);
+    description.add('$axisDirection');
+    description.add('offset: $offset');
+  }
+}

--- a/packages/flutter/test/material/stepper_test.dart
+++ b/packages/flutter/test/material/stepper_test.dart
@@ -34,7 +34,6 @@ void main() {
         )
       )
     );
-
     await tester.tap(find.text('Step 2'));
     expect(index, 1);
   });
@@ -277,8 +276,8 @@ void main() {
       )
     );
 
-    ScrollableState scrollableState = tester.firstState(find.byType(Scrollable));
-    expect(scrollableState.scrollOffset, 0.0);
+    Scrollable2State scrollableState = tester.firstState(find.byType(Scrollable2));
+    expect(scrollableState.position.pixels, 0.0);
 
     await tester.tap(find.text('Step 3'));
     await tester.pumpWidget(
@@ -313,8 +312,10 @@ void main() {
     );
 
     await tester.pump(const Duration(milliseconds: 100));
-    expect(scrollableState.scrollOffset, greaterThan(0.0));
-  });
+    expect(scrollableState.position.pixels, greaterThan(0.0));
+  }, skip: Scrollable == Scrollable &&
+           ScrollableViewport == ScrollableViewport &&
+           Block == Block); // TODO(abarth): re-enable when ensureVisible is implemented
 
   testWidgets('Stepper index test', (WidgetTester tester) async {
     await tester.pumpWidget(

--- a/packages/flutter/test/rendering/rendering_tester.dart
+++ b/packages/flutter/test/rendering/rendering_tester.dart
@@ -134,4 +134,7 @@ class RenderSizedBox extends RenderBox {
 
   @override
   void performLayout() { }
+
+  @override
+  bool hitTestSelf(Point position) => true;
 }

--- a/packages/flutter/test/rendering/slivers_test.dart
+++ b/packages/flutter/test/rendering/slivers_test.dart
@@ -40,6 +40,12 @@ void main() {
     expect(d.localToGlobal(const Point(0.0, 0.0)), const Point(0.0, 600.0));
     expect(e.localToGlobal(const Point(0.0, 0.0)), const Point(0.0, 600.0));
 
+    expect(a.localToGlobal(const Point(800.0, 400.0)), const Point(800.0, 400.0));
+    expect(b.localToGlobal(const Point(800.0, 400.0)), const Point(800.0, 800.0));
+    expect(c.localToGlobal(const Point(800.0, 400.0)), const Point(800.0, 1000.0));
+    expect(d.localToGlobal(const Point(800.0, 400.0)), const Point(800.0, 1000.0));
+    expect(e.localToGlobal(const Point(800.0, 400.0)), const Point(800.0, 1000.0));
+
     root.offset = new ViewportOffset.fixed(200.0);
     pumpFrame();
     expect(a.localToGlobal(const Point(0.0, 0.0)), const Point(0.0, -200.0));
@@ -63,6 +69,10 @@ void main() {
     expect(c.localToGlobal(const Point(0.0, 0.0)), const Point(0.0, -100.0));
     expect(d.localToGlobal(const Point(0.0, 0.0)), const Point(0.0, 300.0));
     expect(e.localToGlobal(const Point(0.0, 0.0)), const Point(0.0, 600.0));
+
+    HitTestResult result = new HitTestResult();
+    root.hitTest(result, position: const Point(130.0, 150.0));
+    expect(result.path.first.target, equals(c));
   });
 
   test('RenderViewport2 basic test - up', () {
@@ -112,6 +122,10 @@ void main() {
     expect(c.localToGlobal(const Point(0.0, 0.0)), const Point(0.0, 300.0));
     expect(d.localToGlobal(const Point(0.0, 0.0)), const Point(0.0, -100.0));
     expect(e.localToGlobal(const Point(0.0, 0.0)), const Point(0.0, -400.0));
+
+    HitTestResult result = new HitTestResult();
+    root.hitTest(result, position: const Point(150.0, 350.0));
+    expect(result.path.first.target, equals(c));
   });
 
   test('RenderViewport2 basic test - right', () {
@@ -161,6 +175,10 @@ void main() {
     expect(c.localToGlobal(const Point(0.0, 0.0)), const Point(-100.0, 0.0));
     expect(d.localToGlobal(const Point(0.0, 0.0)), const Point(300.0, 0.0));
     expect(e.localToGlobal(const Point(0.0, 0.0)), const Point(700.0, 0.0));
+
+    HitTestResult result = new HitTestResult();
+    root.hitTest(result, position: const Point(150.0, 450.0));
+    expect(result.path.first.target, equals(c));
   });
 
   test('RenderViewport2 basic test - left', () {
@@ -210,12 +228,278 @@ void main() {
     expect(c.localToGlobal(const Point(0.0, 0.0)), const Point(500.0, 0.0));
     expect(d.localToGlobal(const Point(0.0, 0.0)), const Point(100.0, 0.0));
     expect(e.localToGlobal(const Point(0.0, 0.0)), const Point(-300.0, 0.0));
+
+    HitTestResult result = new HitTestResult();
+    root.hitTest(result, position: const Point(550.0, 150.0));
+    expect(result.path.first.target, equals(c));
   });
 
   // TODO(ianh): test anchor
-  // TODO(ianh): test offset
   // TODO(ianh): test center
-  // TODO(ianh): test hit testing
   // TODO(ianh): test semantics
 
+  test('RenderShrinkWrappingViewport basic test - no children', () {
+    RenderShrinkWrappingViewport root = new RenderShrinkWrappingViewport(
+      offset: new ViewportOffset.zero(),
+    );
+    layout(root);
+    root.offset = new ViewportOffset.fixed(900.0);
+    pumpFrame();
+  });
+
+  test('RenderShrinkWrappingViewport basic test - down', () {
+    RenderBox a, b, c, d, e;
+    RenderShrinkWrappingViewport root = new RenderShrinkWrappingViewport(
+      offset: new ViewportOffset.zero(),
+      children: <RenderSliver>[
+        new RenderSliverToBoxAdapter(child: a = new RenderSizedBox(const Size(100.0, 400.0))),
+        new RenderSliverToBoxAdapter(child: b = new RenderSizedBox(const Size(100.0, 400.0))),
+        new RenderSliverToBoxAdapter(child: c = new RenderSizedBox(const Size(100.0, 400.0))),
+        new RenderSliverToBoxAdapter(child: d = new RenderSizedBox(const Size(100.0, 400.0))),
+        new RenderSliverToBoxAdapter(child: e = new RenderSizedBox(const Size(100.0, 400.0))),
+      ],
+    );
+    layout(root);
+
+    expect(root.size.width, equals(800.0));
+    expect(root.size.height, equals(600.0));
+
+    expect(a.localToGlobal(const Point(0.0, 0.0)), const Point(0.0, 0.0));
+    expect(b.localToGlobal(const Point(0.0, 0.0)), const Point(0.0, 400.0));
+    expect(c.localToGlobal(const Point(0.0, 0.0)), const Point(0.0, 600.0));
+    expect(d.localToGlobal(const Point(0.0, 0.0)), const Point(0.0, 600.0));
+    expect(e.localToGlobal(const Point(0.0, 0.0)), const Point(0.0, 600.0));
+
+    expect(a.localToGlobal(const Point(800.0, 400.0)), const Point(800.0, 400.0));
+    expect(b.localToGlobal(const Point(800.0, 400.0)), const Point(800.0, 800.0));
+    expect(c.localToGlobal(const Point(800.0, 400.0)), const Point(800.0, 1000.0));
+    expect(d.localToGlobal(const Point(800.0, 400.0)), const Point(800.0, 1000.0));
+    expect(e.localToGlobal(const Point(800.0, 400.0)), const Point(800.0, 1000.0));
+
+    root.offset = new ViewportOffset.fixed(200.0);
+    pumpFrame();
+    expect(a.localToGlobal(const Point(0.0, 0.0)), const Point(0.0, -200.0));
+    expect(b.localToGlobal(const Point(0.0, 0.0)), const Point(0.0, 200.0));
+    expect(c.localToGlobal(const Point(0.0, 0.0)), const Point(0.0, 600.0));
+    expect(d.localToGlobal(const Point(0.0, 0.0)), const Point(0.0, 600.0));
+    expect(e.localToGlobal(const Point(0.0, 0.0)), const Point(0.0, 600.0));
+
+    root.offset = new ViewportOffset.fixed(600.0);
+    pumpFrame();
+    expect(a.localToGlobal(const Point(0.0, 0.0)), const Point(0.0, -600.0));
+    expect(b.localToGlobal(const Point(0.0, 0.0)), const Point(0.0, -200.0));
+    expect(c.localToGlobal(const Point(0.0, 0.0)), const Point(0.0, 200.0));
+    expect(d.localToGlobal(const Point(0.0, 0.0)), const Point(0.0, 600.0));
+    expect(e.localToGlobal(const Point(0.0, 0.0)), const Point(0.0, 600.0));
+
+    root.offset = new ViewportOffset.fixed(900.0);
+    pumpFrame();
+    expect(a.localToGlobal(const Point(0.0, 0.0)), const Point(0.0, -900.0));
+    expect(b.localToGlobal(const Point(0.0, 0.0)), const Point(0.0, -500.0));
+    expect(c.localToGlobal(const Point(0.0, 0.0)), const Point(0.0, -100.0));
+    expect(d.localToGlobal(const Point(0.0, 0.0)), const Point(0.0, 300.0));
+    expect(e.localToGlobal(const Point(0.0, 0.0)), const Point(0.0, 600.0));
+
+    HitTestResult result = new HitTestResult();
+    root.hitTest(result, position: const Point(130.0, 150.0));
+    expect(result.path.first.target, equals(c));
+  });
+
+  test('RenderShrinkWrappingViewport basic test - up', () {
+    RenderBox a, b, c, d, e;
+    RenderShrinkWrappingViewport root = new RenderShrinkWrappingViewport(
+      axisDirection: AxisDirection.up,
+      offset: new ViewportOffset.zero(),
+      children: <RenderSliver>[
+        new RenderSliverToBoxAdapter(child: a = new RenderSizedBox(const Size(100.0, 400.0))),
+        new RenderSliverToBoxAdapter(child: b = new RenderSizedBox(const Size(100.0, 400.0))),
+        new RenderSliverToBoxAdapter(child: c = new RenderSizedBox(const Size(100.0, 400.0))),
+        new RenderSliverToBoxAdapter(child: d = new RenderSizedBox(const Size(100.0, 400.0))),
+        new RenderSliverToBoxAdapter(child: e = new RenderSizedBox(const Size(100.0, 400.0))),
+      ],
+    );
+    layout(root);
+
+    expect(root.size.width, equals(800.0));
+    expect(root.size.height, equals(600.0));
+
+    expect(a.localToGlobal(const Point(0.0, 0.0)), const Point(0.0, 200.0));
+    expect(b.localToGlobal(const Point(0.0, 0.0)), const Point(0.0, -200.0));
+    expect(c.localToGlobal(const Point(0.0, 0.0)), const Point(0.0, -400.0));
+    expect(d.localToGlobal(const Point(0.0, 0.0)), const Point(0.0, -400.0));
+    expect(e.localToGlobal(const Point(0.0, 0.0)), const Point(0.0, -400.0));
+
+    root.offset = new ViewportOffset.fixed(200.0);
+    pumpFrame();
+    expect(a.localToGlobal(const Point(0.0, 0.0)), const Point(0.0, 400.0));
+    expect(b.localToGlobal(const Point(0.0, 0.0)), const Point(0.0, 0.0));
+    expect(c.localToGlobal(const Point(0.0, 0.0)), const Point(0.0, -400.0));
+    expect(d.localToGlobal(const Point(0.0, 0.0)), const Point(0.0, -400.0));
+    expect(e.localToGlobal(const Point(0.0, 0.0)), const Point(0.0, -400.0));
+
+    root.offset = new ViewportOffset.fixed(600.0);
+    pumpFrame();
+    expect(a.localToGlobal(const Point(0.0, 0.0)), const Point(0.0, 800.0));
+    expect(b.localToGlobal(const Point(0.0, 0.0)), const Point(0.0, 400.0));
+    expect(c.localToGlobal(const Point(0.0, 0.0)), const Point(0.0, 0.0));
+    expect(d.localToGlobal(const Point(0.0, 0.0)), const Point(0.0, -400.0));
+    expect(e.localToGlobal(const Point(0.0, 0.0)), const Point(0.0, -400.0));
+
+    root.offset = new ViewportOffset.fixed(900.0);
+    pumpFrame();
+    expect(a.localToGlobal(const Point(0.0, 0.0)), const Point(0.0, 1100.0));
+    expect(b.localToGlobal(const Point(0.0, 0.0)), const Point(0.0, 700.0));
+    expect(c.localToGlobal(const Point(0.0, 0.0)), const Point(0.0, 300.0));
+    expect(d.localToGlobal(const Point(0.0, 0.0)), const Point(0.0, -100.0));
+    expect(e.localToGlobal(const Point(0.0, 0.0)), const Point(0.0, -400.0));
+
+    HitTestResult result = new HitTestResult();
+    root.hitTest(result, position: const Point(150.0, 350.0));
+    expect(result.path.first.target, equals(c));
+  });
+
+  test('RenderShrinkWrappingViewport basic test - right', () {
+    RenderBox a, b, c, d, e;
+    RenderShrinkWrappingViewport root = new RenderShrinkWrappingViewport(
+      axisDirection: AxisDirection.right,
+      offset: new ViewportOffset.zero(),
+      children: <RenderSliver>[
+        new RenderSliverToBoxAdapter(child: a = new RenderSizedBox(const Size(400.0, 100.0))),
+        new RenderSliverToBoxAdapter(child: b = new RenderSizedBox(const Size(400.0, 100.0))),
+        new RenderSliverToBoxAdapter(child: c = new RenderSizedBox(const Size(400.0, 100.0))),
+        new RenderSliverToBoxAdapter(child: d = new RenderSizedBox(const Size(400.0, 100.0))),
+        new RenderSliverToBoxAdapter(child: e = new RenderSizedBox(const Size(400.0, 100.0))),
+      ],
+    );
+    layout(root);
+
+    expect(root.size.width, equals(800.0));
+    expect(root.size.height, equals(600.0));
+
+    expect(a.localToGlobal(const Point(0.0, 0.0)), const Point(0.0, 0.0));
+    expect(b.localToGlobal(const Point(0.0, 0.0)), const Point(400.0, 0.0));
+    expect(c.localToGlobal(const Point(0.0, 0.0)), const Point(800.0, 0.0));
+    expect(d.localToGlobal(const Point(0.0, 0.0)), const Point(800.0, 0.0));
+    expect(e.localToGlobal(const Point(0.0, 0.0)), const Point(800.0, 0.0));
+
+    root.offset = new ViewportOffset.fixed(200.0);
+    pumpFrame();
+    expect(a.localToGlobal(const Point(0.0, 0.0)), const Point(-200.0, 0.0));
+    expect(b.localToGlobal(const Point(0.0, 0.0)), const Point(200.0, 0.0));
+    expect(c.localToGlobal(const Point(0.0, 0.0)), const Point(600.0, 0.0));
+    expect(d.localToGlobal(const Point(0.0, 0.0)), const Point(800.0, 0.0));
+    expect(e.localToGlobal(const Point(0.0, 0.0)), const Point(800.0, 0.0));
+
+    root.offset = new ViewportOffset.fixed(600.0);
+    pumpFrame();
+    expect(a.localToGlobal(const Point(0.0, 0.0)), const Point(-600.0, 0.0));
+    expect(b.localToGlobal(const Point(0.0, 0.0)), const Point(-200.0, 0.0));
+    expect(c.localToGlobal(const Point(0.0, 0.0)), const Point(200.0, 0.0));
+    expect(d.localToGlobal(const Point(0.0, 0.0)), const Point(600.0, 0.0));
+    expect(e.localToGlobal(const Point(0.0, 0.0)), const Point(800.0, 0.0));
+
+    root.offset = new ViewportOffset.fixed(900.0);
+    pumpFrame();
+    expect(a.localToGlobal(const Point(0.0, 0.0)), const Point(-900.0, 0.0));
+    expect(b.localToGlobal(const Point(0.0, 0.0)), const Point(-500.0, 0.0));
+    expect(c.localToGlobal(const Point(0.0, 0.0)), const Point(-100.0, 0.0));
+    expect(d.localToGlobal(const Point(0.0, 0.0)), const Point(300.0, 0.0));
+    expect(e.localToGlobal(const Point(0.0, 0.0)), const Point(700.0, 0.0));
+
+    HitTestResult result = new HitTestResult();
+    root.hitTest(result, position: const Point(150.0, 450.0));
+    expect(result.path.first.target, equals(c));
+  });
+
+  test('RenderShrinkWrappingViewport basic test - left', () {
+    RenderBox a, b, c, d, e;
+    RenderShrinkWrappingViewport root = new RenderShrinkWrappingViewport(
+      axisDirection: AxisDirection.left,
+      offset: new ViewportOffset.zero(),
+      children: <RenderSliver>[
+        new RenderSliverToBoxAdapter(child: a = new RenderSizedBox(const Size(400.0, 100.0))),
+        new RenderSliverToBoxAdapter(child: b = new RenderSizedBox(const Size(400.0, 100.0))),
+        new RenderSliverToBoxAdapter(child: c = new RenderSizedBox(const Size(400.0, 100.0))),
+        new RenderSliverToBoxAdapter(child: d = new RenderSizedBox(const Size(400.0, 100.0))),
+        new RenderSliverToBoxAdapter(child: e = new RenderSizedBox(const Size(400.0, 100.0))),
+      ],
+    );
+    layout(root);
+
+    expect(root.size.width, equals(800.0));
+    expect(root.size.height, equals(600.0));
+
+    expect(a.localToGlobal(const Point(0.0, 0.0)), const Point(400.0, 0.0));
+    expect(b.localToGlobal(const Point(0.0, 0.0)), const Point(0.0, 0.0));
+    expect(c.localToGlobal(const Point(0.0, 0.0)), const Point(-400.0, 0.0));
+    expect(d.localToGlobal(const Point(0.0, 0.0)), const Point(-400.0, 0.0));
+    expect(e.localToGlobal(const Point(0.0, 0.0)), const Point(-400.0, 0.0));
+
+    root.offset = new ViewportOffset.fixed(200.0);
+    pumpFrame();
+    expect(a.localToGlobal(const Point(0.0, 0.0)), const Point(600.0, 0.0));
+    expect(b.localToGlobal(const Point(0.0, 0.0)), const Point(200.0, 0.0));
+    expect(c.localToGlobal(const Point(0.0, 0.0)), const Point(-200.0, 0.0));
+    expect(d.localToGlobal(const Point(0.0, 0.0)), const Point(-400.0, 0.0));
+    expect(e.localToGlobal(const Point(0.0, 0.0)), const Point(-400.0, 0.0));
+
+    root.offset = new ViewportOffset.fixed(600.0);
+    pumpFrame();
+    expect(a.localToGlobal(const Point(0.0, 0.0)), const Point(1000.0, 0.0));
+    expect(b.localToGlobal(const Point(0.0, 0.0)), const Point(600.0, 0.0));
+    expect(c.localToGlobal(const Point(0.0, 0.0)), const Point(200.0, 0.0));
+    expect(d.localToGlobal(const Point(0.0, 0.0)), const Point(-200.0, 0.0));
+    expect(e.localToGlobal(const Point(0.0, 0.0)), const Point(-400.0, 0.0));
+
+    root.offset = new ViewportOffset.fixed(900.0);
+    pumpFrame();
+    expect(a.localToGlobal(const Point(0.0, 0.0)), const Point(1300.0, 0.0));
+    expect(b.localToGlobal(const Point(0.0, 0.0)), const Point(900.0, 0.0));
+    expect(c.localToGlobal(const Point(0.0, 0.0)), const Point(500.0, 0.0));
+    expect(d.localToGlobal(const Point(0.0, 0.0)), const Point(100.0, 0.0));
+    expect(e.localToGlobal(const Point(0.0, 0.0)), const Point(-300.0, 0.0));
+
+    HitTestResult result = new HitTestResult();
+    root.hitTest(result, position: const Point(550.0, 150.0));
+    expect(result.path.first.target, equals(c));
+  });
+
+  test('RenderShrinkWrappingViewport shrinkwrap test - 1 child', () {
+    RenderBox child;
+    RenderBox root = new RenderPositionedBox(
+      child: child = new RenderShrinkWrappingViewport(
+        axisDirection: AxisDirection.left,
+        offset: new ViewportOffset.fixed(200.0),
+        children: <RenderSliver>[
+          new RenderSliverToBoxAdapter(child: new RenderSizedBox(const Size(400.0, 100.0))),
+        ],
+      ),
+    );
+    layout(root);
+
+    expect(root.size.width, equals(800.0));
+    expect(root.size.height, equals(600.0));
+    expect(child.size.width, equals(400.0));
+    expect(child.size.height, equals(600.0));
+  });
+
+  test('RenderShrinkWrappingViewport shrinkwrap test - 2 children', () {
+    RenderBox child;
+    RenderBox root = new RenderPositionedBox(
+      child: child = new RenderShrinkWrappingViewport(
+        axisDirection: AxisDirection.right,
+        offset: new ViewportOffset.fixed(200.0),
+        children: <RenderSliver>[
+          new RenderSliverToBoxAdapter(child: new RenderSizedBox(const Size(300.0, 100.0))),
+          new RenderSliverToBoxAdapter(child: new RenderSizedBox(const Size(150.0, 100.0))),
+        ],
+      ),
+    );
+    layout(root);
+
+    expect(root.size.width, equals(800.0));
+    expect(root.size.height, equals(600.0));
+    expect(child.size.width, equals(450.0));
+    expect(child.size.height, equals(600.0));
+  });
 }

--- a/packages/flutter/test/widgets/block_test.dart
+++ b/packages/flutter/test/widgets/block_test.dart
@@ -6,6 +6,8 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 
+import 'test_widgets.dart';
+
 final Key blockKey = new Key('test');
 
 void main() {
@@ -130,7 +132,7 @@ void main() {
       new Container(),
     ]);
 
-    await tester.pumpWidget(new ScrollableViewport2(
+    await tester.pumpWidget(new TestScrollable(
       slivers: <Widget>[
         new SliverBlock(
           delegate: delegate,

--- a/packages/flutter/test/widgets/overscroll_indicator_test.dart
+++ b/packages/flutter/test/widgets/overscroll_indicator_test.dart
@@ -9,6 +9,7 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter/rendering.dart';
 
 import '../rendering/mock_canvas.dart';
+import 'test_widgets.dart';
 
 final Matcher doesNotOverscroll = isNot(paints..circle());
 
@@ -24,7 +25,7 @@ Future<Null> slowDrag(WidgetTester tester, Point start, Offset offset) async {
 void main() {
   testWidgets('Overscroll indicator color', (WidgetTester tester) async {
     await tester.pumpWidget(
-      new ScrollableViewport2(
+      new TestScrollable(
         slivers: <Widget>[
           new SliverToBoxAdapter(child: new SizedBox(height: 2000.0)),
         ],
@@ -57,7 +58,7 @@ void main() {
 
   testWidgets('Overscroll indicator changes side when you drag on the other side', (WidgetTester tester) async {
     await tester.pumpWidget(
-      new ScrollableViewport2(
+      new TestScrollable(
         slivers: <Widget>[
           new SliverToBoxAdapter(child: new SizedBox(height: 2000.0)),
         ],
@@ -92,7 +93,7 @@ void main() {
 
   testWidgets('Overscroll indicator changes side when you shift sides', (WidgetTester tester) async {
     await tester.pumpWidget(
-      new ScrollableViewport2(
+      new TestScrollable(
         slivers: <Widget>[
           new SliverToBoxAdapter(child: new SizedBox(height: 2000.0)),
         ],
@@ -125,7 +126,7 @@ void main() {
   group('Flipping direction of scrollable doesn\'t change overscroll behavior', () {
     testWidgets('down', (WidgetTester tester) async {
       await tester.pumpWidget(
-        new ScrollableViewport2(
+        new TestScrollable(
           axisDirection: AxisDirection.down,
           slivers: <Widget>[
             new SliverToBoxAdapter(child: new SizedBox(height: 20.0)),
@@ -142,7 +143,7 @@ void main() {
 
     testWidgets('up', (WidgetTester tester) async {
       await tester.pumpWidget(
-        new ScrollableViewport2(
+        new TestScrollable(
           axisDirection: AxisDirection.up,
           slivers: <Widget>[
             new SliverToBoxAdapter(child: new SizedBox(height: 20.0)),
@@ -160,7 +161,7 @@ void main() {
 
   testWidgets('Overscroll in both directions', (WidgetTester tester) async {
     await tester.pumpWidget(
-      new ScrollableViewport2(
+      new TestScrollable(
         axisDirection: AxisDirection.down,
         slivers: <Widget>[
           new SliverToBoxAdapter(child: new SizedBox(height: 20.0)),
@@ -180,7 +181,7 @@ void main() {
 
   testWidgets('Overscroll horizontally', (WidgetTester tester) async {
     await tester.pumpWidget(
-      new ScrollableViewport2(
+      new TestScrollable(
         axisDirection: AxisDirection.right,
         slivers: <Widget>[
           new SliverToBoxAdapter(child: new SizedBox(height: 20.0)),
@@ -203,7 +204,7 @@ void main() {
     RenderObject painter;
 
     await tester.pumpWidget(
-      new ScrollableViewport2(
+      new TestScrollable(
         axisDirection: AxisDirection.left,
         scrollBehavior: new TestScrollBehavior1(),
         slivers: <Widget>[
@@ -218,7 +219,7 @@ void main() {
 
     await tester.pumpUntilNoTransientCallbacks(const Duration(seconds: 1));
     await tester.pumpWidget(
-      new ScrollableViewport2(
+      new TestScrollable(
         axisDirection: AxisDirection.right,
         scrollBehavior: new TestScrollBehavior2(),
         slivers: <Widget>[

--- a/packages/flutter/test/widgets/scroll_grid_test.dart
+++ b/packages/flutter/test/widgets/scroll_grid_test.dart
@@ -303,4 +303,7 @@ void main() {
     expect(tester.getSize(find.text('3')), equals(const Size(400.0, 400.0)));
     expect(find.text('4'), findsNothing);
   });
+
+  // TODO(ianh): can you tap a grid cell that is slightly off the bottom of the screen?
+  // (try it with the flutter_gallery Grid demo)
 }

--- a/packages/flutter/test/widgets/scrollable_custom_scroll_behavior_test.dart
+++ b/packages/flutter/test/widgets/scrollable_custom_scroll_behavior_test.dart
@@ -6,6 +6,8 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 
+import 'test_widgets.dart';
+
 class TestScrollPosition extends ScrollPosition {
   TestScrollPosition(
     this.extentMultiplier,
@@ -88,7 +90,7 @@ class TestScrollBehavior extends ScrollBehavior2 {
 
 void main() {
   testWidgets('Changing the scroll behavior dynamically', (WidgetTester tester) async {
-    await tester.pumpWidget(new ScrollableViewport2(
+    await tester.pumpWidget(new TestScrollable(
       scrollBehavior: new TestScrollBehavior(1.0),
       slivers: <Widget>[
         new SliverToBoxAdapter(child: new SizedBox(height: 2000.0)),
@@ -97,7 +99,7 @@ void main() {
     Scrollable2State state = tester.state(find.byType(Scrollable2));
 
     expect(state.position.getMetrics().extentInside, 1.0);
-    await tester.pumpWidget(new ScrollableViewport2(
+    await tester.pumpWidget(new TestScrollable(
       scrollBehavior: new TestScrollBehavior(2.0),
       slivers: <Widget>[
         new SliverToBoxAdapter(child: new SizedBox(height: 2000.0)),

--- a/packages/flutter/test/widgets/scrollable_test.dart
+++ b/packages/flutter/test/widgets/scrollable_test.dart
@@ -6,12 +6,14 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 
+import 'test_widgets.dart';
+
 Future<Null> pumpTest(WidgetTester tester, TargetPlatform platform) async {
   await tester.pumpWidget(new MaterialApp(
     theme: new ThemeData(
       platform: platform,
     ),
-    home: new ScrollableViewport2(
+    home: new TestScrollable(
       slivers: <Widget>[
         new SliverToBoxAdapter(child: new SizedBox(height: 2000.0)),
       ],

--- a/packages/flutter/test/widgets/sliver_fill_remaining_test.dart
+++ b/packages/flutter/test/widgets/sliver_fill_remaining_test.dart
@@ -5,6 +5,8 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/widgets.dart';
 
+import 'test_widgets.dart';
+
 void main() {
   testWidgets('SliverFillRemaining control test', (WidgetTester tester) async {
     List<Widget> children = new List<Widget>.generate(20, (int i) {
@@ -12,7 +14,7 @@ void main() {
     });
 
     await tester.pumpWidget(
-      new ScrollableViewport2(
+      new TestScrollable(
         slivers: <Widget>[
           new SliverFill(
             delegate: new SliverChildListDelegate(children),
@@ -28,7 +30,7 @@ void main() {
     expect(find.text('1'), findsNothing);
     expect(find.text('2'), findsNothing);
 
-    await tester.scroll(find.byType(ScrollableViewport2), const Offset(0.0, -700.0));
+    await tester.scroll(find.byType(Scrollable2), const Offset(0.0, -700.0));
     await tester.pump();
 
     expect(find.text('0'), findsNothing);
@@ -37,7 +39,7 @@ void main() {
     expect(find.text('3'), findsNothing);
     expect(find.text('4'), findsNothing);
 
-    await tester.scroll(find.byType(ScrollableViewport2), const Offset(0.0, 200.0));
+    await tester.scroll(find.byType(Scrollable2), const Offset(0.0, 200.0));
     await tester.pump();
 
     expect(find.text('0'), findsOneWidget);

--- a/packages/flutter/test/widgets/slivers_appbar_floating_test.dart
+++ b/packages/flutter/test/widgets/slivers_appbar_floating_test.dart
@@ -6,6 +6,8 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 
+import 'test_widgets.dart';
+
 void verifyPaintPosition(GlobalKey key, Offset ideal, bool visible) {
   RenderSliver target = key.currentContext.findRenderObject();
   expect(target.parent, new isInstanceOf<RenderViewport2>());
@@ -26,7 +28,7 @@ void main() {
   testWidgets('Sliver appbars - floating - scroll offset doesn\'t change', (WidgetTester tester) async {
     const double bigHeight = 1000.0;
     await tester.pumpWidget(
-      new ScrollableViewport2(
+      new TestScrollable(
         axisDirection: AxisDirection.down,
         slivers: <Widget>[
           new BigSliver(height: bigHeight),
@@ -54,7 +56,7 @@ void main() {
     const double bigHeight = 1000.0;
     GlobalKey key1, key2, key3;
     await tester.pumpWidget(
-      new ScrollableViewport2(
+      new TestScrollable(
         axisDirection: AxisDirection.down,
         slivers: <Widget>[
           new BigSliver(key: key1 = new GlobalKey(), height: bigHeight),
@@ -124,7 +126,7 @@ void main() {
     const double bigHeight = 1000.0;
     GlobalKey key1, key2, key3;
     await tester.pumpWidget(
-      new ScrollableViewport2(
+      new TestScrollable(
         axisDirection: AxisDirection.down,
         slivers: <Widget>[
           new BigSliver(key: key1 = new GlobalKey(), height: bigHeight),
@@ -157,7 +159,7 @@ void main() {
     const double bigHeight = 1000.0;
     GlobalKey key1, key2, key3;
     await tester.pumpWidget(
-      new ScrollableViewport2(
+      new TestScrollable(
         axisDirection: AxisDirection.down,
         slivers: <Widget>[
           new BigSliver(key: key1 = new GlobalKey(), height: bigHeight),

--- a/packages/flutter/test/widgets/slivers_appbar_pinned_test.dart
+++ b/packages/flutter/test/widgets/slivers_appbar_pinned_test.dart
@@ -6,6 +6,8 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 
+import 'test_widgets.dart';
+
 void verifyPaintPosition(GlobalKey key, Offset ideal, bool visible) {
   RenderSliver target = key.currentContext.findRenderObject();
   expect(target.parent, new isInstanceOf<RenderViewport2>());
@@ -17,7 +19,7 @@ void verifyPaintPosition(GlobalKey key, Offset ideal, bool visible) {
 }
 
 void verifyActualBoxPosition(WidgetTester tester, Finder finder, int index, Rect ideal) {
-  RenderBox box = tester.renderObjectList/*<RenderBox>*/(finder).elementAt(index);
+  RenderBox box = tester.renderObjectList<RenderBox>(finder).elementAt(index);
   Rect rect = new Rect.fromPoints(box.localToGlobal(Point.origin), box.localToGlobal(box.size.bottomRight(Point.origin)));
   expect(rect, equals(ideal));
 }
@@ -27,7 +29,7 @@ void main() {
     const double bigHeight = 550.0;
     GlobalKey key1, key2, key3, key4, key5;
     await tester.pumpWidget(
-      new ScrollableViewport2(
+      new TestScrollable(
         axisDirection: AxisDirection.down,
         slivers: <Widget>[
           new BigSliver(key: key1 = new GlobalKey(), height: bigHeight),
@@ -61,7 +63,7 @@ void main() {
     const double bigHeight = 550.0;
     GlobalKey key1, key2, key3, key4, key5;
     await tester.pumpWidget(
-      new ScrollableViewport2(
+      new TestScrollable(
         axisDirection: AxisDirection.down,
         slivers: <Widget>[
           new BigSliver(key: key1 = new GlobalKey(), height: bigHeight),
@@ -151,7 +153,7 @@ void main() {
     const double bigHeight = 650.0;
     GlobalKey key1, key2, key3, key4, key5;
     await tester.pumpWidget(
-      new ScrollableViewport2(
+      new TestScrollable(
         axisDirection: AxisDirection.down,
         slivers: <Widget>[
           new BigSliver(key: key1 = new GlobalKey(), height: bigHeight),

--- a/packages/flutter/test/widgets/slivers_appbar_scrolling_test.dart
+++ b/packages/flutter/test/widgets/slivers_appbar_scrolling_test.dart
@@ -6,6 +6,8 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 
+import 'test_widgets.dart';
+
 void verifyPaintPosition(GlobalKey key, Offset ideal) {
   RenderObject target = key.currentContext.findRenderObject();
   expect(target.parent, new isInstanceOf<RenderViewport2>());
@@ -18,7 +20,7 @@ void main() {
   testWidgets('Sliver appbars - scrolling', (WidgetTester tester) async {
     GlobalKey key1, key2, key3, key4, key5;
     await tester.pumpWidget(
-      new ScrollableViewport2(
+      new TestScrollable(
         axisDirection: AxisDirection.down,
         slivers: <Widget>[
           new BigSliver(key: key1 = new GlobalKey()),
@@ -52,7 +54,7 @@ void main() {
     GlobalKey key = new GlobalKey();
     TestDelegate delegate = new TestDelegate();
     await tester.pumpWidget(
-      new ScrollableViewport2(
+      new TestScrollable(
         axisDirection: AxisDirection.down,
         slivers: <Widget>[
           new BigSliver(),
@@ -65,7 +67,7 @@ void main() {
     AbsoluteScrollPosition position = tester.state<Scrollable2State>(find.byType(Scrollable2)).position;
     position.animate(to: RenderBigSliver.height + delegate.maxExtent - 5.0, curve: Curves.linear, duration: const Duration(minutes: 1));
     await tester.pumpUntilNoTransientCallbacks(const Duration(milliseconds: 1000));
-    RenderBox box = tester.renderObject/*<RenderBox>*/(find.byType(Container));
+    RenderBox box = tester.renderObject<RenderBox>(find.byType(Container));
     Rect rect = new Rect.fromPoints(box.localToGlobal(Point.origin), box.localToGlobal(box.size.bottomRight(Point.origin)));
     expect(rect, equals(new Rect.fromLTWH(0.0, -195.0, 800.0, 200.0)));
   });

--- a/packages/flutter/test/widgets/slivers_evil_test.dart
+++ b/packages/flutter/test/widgets/slivers_evil_test.dart
@@ -7,6 +7,8 @@ import 'package:flutter/rendering.dart';
 import 'package:flutter/physics.dart';
 import 'package:flutter/material.dart';
 
+import 'test_widgets.dart';
+
 class TestSliverAppBarDelegate extends SliverAppBarDelegate {
   TestSliverAppBarDelegate(this._maxExtent);
 
@@ -74,7 +76,7 @@ void main() {
     final GlobalKey centerKey = new GlobalKey();
     await tester.pumpWidget(
       new Scrollbar2(
-        child: new ScrollableViewport2(
+        child: new TestScrollable(
           axisDirection: AxisDirection.down,
           center: centerKey,
           anchor: 0.25,

--- a/packages/flutter/test/widgets/slivers_protocol_test.dart
+++ b/packages/flutter/test/widgets/slivers_protocol_test.dart
@@ -8,6 +8,8 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 
+import 'test_widgets.dart';
+
 void verifyPaintPosition(GlobalKey key, Offset ideal) {
   RenderObject target = key.currentContext.findRenderObject();
   expect(target.parent, new isInstanceOf<RenderViewport2>());
@@ -20,7 +22,7 @@ void main() {
   testWidgets('Sliver protocol', (WidgetTester tester) async {
     GlobalKey key1, key2, key3, key4, key5;
     await tester.pumpWidget(
-      new ScrollableViewport2(
+      new TestScrollable(
         axisDirection: AxisDirection.down,
         slivers: <Widget>[
           new BigSliver(key: key1 = new GlobalKey()),

--- a/packages/flutter/test/widgets/test_widgets.dart
+++ b/packages/flutter/test/widgets/test_widgets.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 
 final BoxDecoration kBoxDecorationA = const BoxDecoration(
@@ -55,4 +56,50 @@ class FlipWidgetState extends State<FlipWidget> {
 
 void flipStatefulWidget(WidgetTester tester) {
   tester.state<FlipWidgetState>(find.byType(FlipWidget)).flip();
+}
+
+class TestScrollable extends StatelessWidget {
+  TestScrollable({
+    Key key,
+    this.initialScrollOffset: 0.0,
+    this.axisDirection: AxisDirection.down,
+    this.anchor: 0.0,
+    this.center,
+    this.scrollBehavior,
+    this.slivers: const <Widget>[],
+  }) {
+    assert(slivers != null);
+  }
+
+  final double initialScrollOffset;
+
+  final AxisDirection axisDirection;
+
+  final double anchor;
+
+  final Key center;
+
+  final ScrollBehavior2 scrollBehavior;
+
+  final List<Widget> slivers;
+
+  Axis get axis => axisDirectionToAxis(axisDirection);
+
+  @override
+  Widget build(BuildContext context) {
+    return new Scrollable2(
+      initialScrollOffset: initialScrollOffset,
+      axisDirection: axisDirection,
+      scrollBehavior: scrollBehavior,
+      viewportBuilder: (BuildContext context, ViewportOffset offset) {
+        return new Viewport2(
+          axisDirection: axisDirection,
+          anchor: anchor,
+          offset: offset,
+          center: center,
+          slivers: slivers,
+        );
+      }
+    );
+  }
 }

--- a/packages/flutter_test/lib/src/binding.dart
+++ b/packages/flutter_test/lib/src/binding.dart
@@ -18,8 +18,8 @@ import 'package:quiver/time.dart';
 import 'package:test/test.dart' as test_package;
 import 'package:vector_math/vector_math_64.dart';
 
-import 'test_async_utils.dart';
 import 'stack_manipulation.dart';
+import 'test_async_utils.dart';
 
 /// Phases that can be reached by [WidgetTester.pumpWidget] and
 /// [TestWidgetsFlutterBinding.pump].


### PR DESCRIPTION
Also:
* ScrollView.shrinkWrap
* Port Block to ScrollView.shrinkWrap where possible
* Port Block to SingleChildScrollView/BlockBody where not
* Remove scrollableKey from twoLevelList
* Remove ScrollableViewport2
* Refactor ScrollGrid to extend ScrollView to avoid code duplication
* Add padding to SingleChildScrollView
* More testing