### PR TITLE
Add doctor check for Python 'six' module

### DIFF
--- a/packages/flutter_tools/lib/src/ios/ios_workflow.dart
+++ b/packages/flutter_tools/lib/src/ios/ios_workflow.dart
@@ -100,7 +100,7 @@ class IOSWorkflow extends DoctorValidator implements Workflow {
       pythonStatus = ValidationType.missing;
       messages.add(new ValidationMessage.error(
         'Python installation missing module "six".\n'
-        'Install via \'sudo easy_install six\'.'
+        'Install via \'pip install six\' or \'sudo easy_install six\'.'
       ));
     }
 

--- a/packages/flutter_tools/lib/src/ios/ios_workflow.dart
+++ b/packages/flutter_tools/lib/src/ios/ios_workflow.dart
@@ -40,6 +40,8 @@ class IOSWorkflow extends DoctorValidator implements Workflow {
 
   bool get hasHomebrew => os.which('brew') != null;
 
+  bool get hasPythonSixModule => exitsHappy(<String>['python', '-c', 'import six']);
+
   bool get _iosDeployIsInstalledAndMeetsVersionCheck {
     if (!hasIosDeploy)
       return false;
@@ -55,6 +57,7 @@ class IOSWorkflow extends DoctorValidator implements Workflow {
   Future<ValidationResult> validate() async {
     List<ValidationMessage> messages = <ValidationMessage>[];
     ValidationType xcodeStatus = ValidationType.missing;
+    ValidationType pythonStatus = ValidationType.missing;
     ValidationType brewStatus = ValidationType.missing;
     String xcodeVersionInfo;
 
@@ -87,6 +90,17 @@ class IOSWorkflow extends DoctorValidator implements Workflow {
       messages.add(new ValidationMessage.error(
         'Xcode not installed; this is necessary for iOS development.\n'
         'Download at https://developer.apple.com/xcode/download/.'
+      ));
+    }
+
+    // Python dependencies installed
+    if (hasPythonSixModule) {
+      pythonStatus = ValidationType.installed;
+    } else {
+      pythonStatus = ValidationType.missing;
+      messages.add(new ValidationMessage.error(
+        'Python installation missing module "six".\n'
+        'Install via \'sudo easy_install six\'.'
       ));
     }
 
@@ -134,7 +148,7 @@ class IOSWorkflow extends DoctorValidator implements Workflow {
     }
 
     return new ValidationResult(
-      <ValidationType>[xcodeStatus, brewStatus].reduce(_mergeValidationTypes),
+      <ValidationType>[xcodeStatus, pythonStatus, brewStatus].reduce(_mergeValidationTypes),
       messages,
       statusInfo: xcodeVersionInfo
     );

--- a/packages/flutter_tools/test/src/ios/ios_workflow_test.dart
+++ b/packages/flutter_tools/test/src/ios/ios_workflow_test.dart
@@ -21,6 +21,7 @@ void main() {
     testUsingContext('Emit missing status when nothing is installed', () async {
       when(xcode.isInstalled).thenReturn(false);
       IOSWorkflowTestTarget workflow = new IOSWorkflowTestTarget()
+        ..hasPythonSixModule = false
         ..hasHomebrew = false
         ..hasIosDeploy = false;
       ValidationResult result = await workflow.validate();
@@ -52,6 +53,18 @@ void main() {
       when(xcode.isInstalledAndMeetsVersionCheck).thenReturn(true);
       when(xcode.eulaSigned).thenReturn(false);
       IOSWorkflowTestTarget workflow = new IOSWorkflowTestTarget();
+      ValidationResult result = await workflow.validate();
+      expect(result.type, ValidationType.partial);
+    }, overrides: <Type, Generator>{ Xcode: () => xcode });
+
+    testUsingContext('Emits partial status when python six not installed', () async {
+      when(xcode.isInstalled).thenReturn(true);
+      when(xcode.xcodeVersionText)
+          .thenReturn('Xcode 8.2.1\nBuild version 8C1002\n');
+      when(xcode.isInstalledAndMeetsVersionCheck).thenReturn(true);
+      when(xcode.eulaSigned).thenReturn(true);
+      IOSWorkflowTestTarget workflow = new IOSWorkflowTestTarget()
+        ..hasPythonSixModule = false;
       ValidationResult result = await workflow.validate();
       expect(result.type, ValidationType.partial);
     }, overrides: <Type, Generator>{ Xcode: () => xcode });
@@ -107,6 +120,9 @@ void main() {
 class MockXcode extends Mock implements Xcode {}
 
 class IOSWorkflowTestTarget extends IOSWorkflow {
+  @override
+  bool hasPythonSixModule = true;
+
   @override
   bool hasHomebrew = true;
 


### PR DESCRIPTION
Required as part of Xcode lldb module. In all likelihood, if we
encounter this situation, the developer is using a custom Python install
(e.g., via MacPorts or Homebrew).