### PR TITLE
Fix issues with flutter doctor

### DIFF
--- a/packages/flutter_tools/lib/src/doctor.dart
+++ b/packages/flutter_tools/lib/src/doctor.dart
@@ -386,6 +386,7 @@ class IntelliJValidatorOnMac extends IntelliJValidator {
 
   static final Map<String, String> _dirNameToId = <String, String>{
     'IntelliJ IDEA.app' : 'IntelliJIdea',
+    'IntelliJ IDEA Ultimate.app' : 'IntelliJIdea',
     'IntelliJ IDEA CE.app' : 'IdeaIC',
   };
 
@@ -403,13 +404,16 @@ class IntelliJValidatorOnMac extends IntelliJValidator {
     }
 
     try {
-      for (FileSystemEntity dir in fs.directory('/Applications').listSync()) {
-        if (dir is Directory) {
-          checkForIntelliJ(dir);
-          if (!dir.path.endsWith('.app')) {
-            for (FileSystemEntity subdir in dir.listSync()) {
-              if (subdir is Directory)
-                checkForIntelliJ(subdir);
+      var checkDirectories = [ '/Applications' , path.join(homeDirPath, 'Applications') ];
+      for (String checkDir in checkDirectories) {
+        for (FileSystemEntity dir in fs.directory(checkDir).listSync()) {
+          if (dir is Directory) {
+            checkForIntelliJ(dir);
+            if (!dir.path.endsWith('.app')) {
+              for (FileSystemEntity subdir in dir.listSync()) {
+                if (subdir is Directory)
+                  checkForIntelliJ(subdir);
+              }
             }
           }
         }

--- a/packages/flutter_tools/lib/src/doctor.dart
+++ b/packages/flutter_tools/lib/src/doctor.dart
@@ -392,6 +392,7 @@ class IntelliJValidatorOnMac extends IntelliJValidator {
 
   static Iterable<DoctorValidator> get installed {
     List<DoctorValidator> validators = <DoctorValidator>[];
+    List<String> installPaths = <String>['/Applications', path.join(homeDirPath, 'Applications')];
 
     void checkForIntelliJ(Directory dir) {
       String name = path.basename(dir.path);
@@ -404,15 +405,17 @@ class IntelliJValidatorOnMac extends IntelliJValidator {
     }
 
     try {
-      var checkDirectories = [ '/Applications' , path.join(homeDirPath, 'Applications') ];
-      for (String checkDir in checkDirectories) {
-        for (FileSystemEntity dir in fs.directory(checkDir).listSync()) {
-          if (dir is Directory) {
-            checkForIntelliJ(dir);
-            if (!dir.path.endsWith('.app')) {
-              for (FileSystemEntity subdir in dir.listSync()) {
-                if (subdir is Directory)
-                  checkForIntelliJ(subdir);
+      Iterable<FileSystemEntity> installDirs = installPaths
+              .map((String installPath) => fs.directory(installPath).listSync())
+              .expand((List<FileSystemEntity> mappedDirs) => mappedDirs)
+              .where((FileSystemEntity mappedDir) => mappedDir is Directory);
+      for (FileSystemEntity dir in installDirs) {
+        if (dir is Directory) {
+          checkForIntelliJ(dir);
+          if (!dir.path.endsWith('.app')) {
+            for (FileSystemEntity subdir in dir.listSync()) {
+              if (subdir is Directory) {
+                checkForIntelliJ(subdir);
               }
             }
           }


### PR DESCRIPTION
Fixes two issues with `flutter doctor`:

- `ios-deploy` is not detected because `ios-deploy -h` does not return with exit code 0. Using `ios-deploy --version` instead.

- the executable for IntelliJ IDEA Ultimate is not detected correctly on MacOS. This could be because it is installed via JetBrains Toolbox (installed to `~/Applications` vs `/Applications`) and/or because it is named incorrectly.