### PR TITLE
Add touchesBegan handler to iOS AppDelegate template

### DIFF
--- a/packages/flutter_tools/templates/create/ios.tmpl/Runner/AppDelegate.m
+++ b/packages/flutter_tools/templates/create/ios.tmpl/Runner/AppDelegate.m
@@ -30,4 +30,16 @@
     // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
 }
 
+- (void) touchesBegan:(NSSet *)touches withEvent:(UIEvent *)event {
+  [super touchesBegan:touches withEvent:event];
+
+  // Support scroll to top on status bar tap. By default, pass status bar taps
+  // to the application's root view controller for handling in Flutter.
+  UIViewController *viewController =
+  [UIApplication sharedApplication].keyWindow.rootViewController;
+  if ([viewController isKindOfClass:[FlutterViewController class]]) {
+    [(FlutterViewController*)viewController handleStatusBarTouches:event];
+  }
+}
+
 @end


### PR DESCRIPTION
By default, pass status bar taps to the root view controller in
generated Flutter apps. Developers should customise as necesary if they
later create one or more alternate FlutterViewControllers that they'd
like to forward these to.