### PR TITLE
Do not print logs whose timestamp is equal to the last timestamp seen

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_device.dart
+++ b/packages/flutter_tools/lib/src/android/android_device.dart
@@ -628,7 +628,7 @@ class _AdbLogReader extends DeviceLogReader {
     if (_timeOrigin != null) {
       final String timestamp = timeMatch.group(0);
       DateTime time = _adbTimestampToDateTime(timestamp);
-      if (time.isBefore(_timeOrigin)) {
+      if (!time.isAfter(_timeOrigin)) {
         // Ignore log messages before the origin.
         return;
       }


### PR DESCRIPTION
If the tool is started immediately after a previous run of the tool, then
the most recent log timestamp may come from the previous run's logs.
The new instance of the tool should not print those logs.

This was happening during runs of the microbenchmark script.