### PR TITLE
Remove Scrollable2.initialScrollOffset

### DIFF
--- a/packages/flutter/lib/src/widgets/scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/scroll_view.dart
@@ -20,14 +20,12 @@ class ScrollView extends StatelessWidget {
     this.scrollDirection: Axis.vertical,
     this.reverse: false,
     this.padding,
-    this.initialScrollOffset: 0.0,
     this.itemExtent,
     this.physics,
     this.shrinkWrap: false,
     this.children: const <Widget>[],
   }) : super(key: key) {
     assert(reverse != null);
-    assert(initialScrollOffset != null);
     assert(shrinkWrap != null);
   }
 
@@ -36,8 +34,6 @@ class ScrollView extends StatelessWidget {
   final bool reverse;
 
   final EdgeInsets padding;
-
-  final double initialScrollOffset;
 
   final double itemExtent;
 
@@ -80,7 +76,6 @@ class ScrollView extends StatelessWidget {
     AxisDirection axisDirection = getDirection(context);
     return new Scrollable2(
       axisDirection: axisDirection,
-      initialScrollOffset: initialScrollOffset,
       physics: physics,
       viewportBuilder: (BuildContext context, ViewportOffset offset) {
         if (shrinkWrap) {
@@ -106,8 +101,6 @@ class ScrollView extends StatelessWidget {
     description.add('$scrollDirection');
     if (padding != null)
       description.add('padding: $padding');
-    if (initialScrollOffset != 0.0)
-      description.add('initialScrollOffset: ${initialScrollOffset.toStringAsFixed(1)}');
     if (itemExtent != null)
       description.add('itemExtent: $itemExtent');
     if (shrinkWrap)
@@ -120,7 +113,6 @@ class ScrollGrid extends ScrollView {
     Key key,
     Axis scrollDirection: Axis.vertical,
     EdgeInsets padding,
-    double initialScrollOffset: 0.0,
     bool shrinkWrap: false,
     this.gridDelegate,
     List<Widget> children: const <Widget>[],
@@ -130,7 +122,6 @@ class ScrollGrid extends ScrollView {
     Key key,
     Axis scrollDirection: Axis.vertical,
     EdgeInsets padding,
-    double initialScrollOffset: 0.0,
     bool shrinkWrap: false,
     @required int crossAxisCount,
     double mainAxisSpacing: 0.0,
@@ -148,7 +139,6 @@ class ScrollGrid extends ScrollView {
     Key key,
     Axis scrollDirection: Axis.vertical,
     EdgeInsets padding,
-    double initialScrollOffset: 0.0,
     bool shrinkWrap: false,
     @required double maxCrossAxisExtent,
     double mainAxisSpacing: 0.0,

--- a/packages/flutter/lib/src/widgets/scrollable.dart
+++ b/packages/flutter/lib/src/widgets/scrollable.dart
@@ -405,18 +405,14 @@ typedef Widget ViewportBuilder(BuildContext context, ViewportOffset position);
 class Scrollable2 extends StatefulWidget {
   Scrollable2({
     Key key,
-    this.initialScrollOffset: 0.0,
     this.axisDirection: AxisDirection.down,
     this.physics,
     this.scrollBehavior,
     @required this.viewportBuilder,
   }) : super (key: key) {
     assert(axisDirection != null);
-    assert(initialScrollOffset != null);
     assert(viewportBuilder != null);
   }
-
-  final double initialScrollOffset;
 
   final AxisDirection axisDirection;
 
@@ -453,8 +449,8 @@ class Scrollable2 extends StatefulWidget {
   void debugFillDescription(List<String> description) {
     super.debugFillDescription(description);
     description.add('$axisDirection');
-    if (initialScrollOffset != 0.0)
-      description.add('initialScrollOffset: ${initialScrollOffset.toStringAsFixed(1)}');
+    if (physics != null)
+      description.add('physics: $physics');
     if (scrollBehavior != null) {
       description.add('scrollBehavior: $scrollBehavior');
     } else {

--- a/packages/flutter/lib/src/widgets/single_child_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/single_child_scroll_view.dart
@@ -22,18 +22,14 @@ class SingleChildScrollView extends StatelessWidget {
     Key key,
     this.scrollDirection: Axis.vertical,
     this.padding,
-    this.initialScrollOffset: 0.0,
     this.child,
   }) : super(key: key) {
     assert(scrollDirection != null);
-    assert(initialScrollOffset != null);
   }
 
   final Axis scrollDirection;
 
   final EdgeInsets padding;
-
-  final double initialScrollOffset;
 
   final Widget child;
 
@@ -56,7 +52,6 @@ class SingleChildScrollView extends StatelessWidget {
       contents = new Padding(padding: padding, child: contents);
     return new Scrollable2(
       axisDirection: axisDirection,
-      initialScrollOffset: initialScrollOffset,
       viewportBuilder: (BuildContext context, ViewportOffset offset) {
         return new _SingleChildViewport(
           key: key,

--- a/packages/flutter/test/widgets/test_widgets.dart
+++ b/packages/flutter/test/widgets/test_widgets.dart
@@ -61,7 +61,6 @@ void flipStatefulWidget(WidgetTester tester) {
 class TestScrollable extends StatelessWidget {
   TestScrollable({
     Key key,
-    this.initialScrollOffset: 0.0,
     this.axisDirection: AxisDirection.down,
     this.physics,
     this.anchor: 0.0,
@@ -71,8 +70,6 @@ class TestScrollable extends StatelessWidget {
   }) {
     assert(slivers != null);
   }
-
-  final double initialScrollOffset;
 
   final AxisDirection axisDirection;
 
@@ -91,7 +88,6 @@ class TestScrollable extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return new Scrollable2(
-      initialScrollOffset: initialScrollOffset,
       axisDirection: axisDirection,
       physics: physics,
       scrollBehavior: scrollBehavior,


### PR DESCRIPTION
This property is wired up to anything and it isn't used. We'll need to find a
better way for clients to control the scroll offset.