### PR TITLE
Subclass FlutterAppDelegate in iOS examples

### DIFF
--- a/examples/flutter_gallery/ios/Runner/AppDelegate.h
+++ b/examples/flutter_gallery/ios/Runner/AppDelegate.h
@@ -1,7 +1,6 @@
 #import <UIKit/UIKit.h>
+#import <Flutter/Flutter.h>
 
-@interface AppDelegate : UIResponder <UIApplicationDelegate>
-
-@property (strong, nonatomic) UIWindow *window;
+@interface AppDelegate : FlutterAppDelegate
 
 @end

--- a/examples/hello_services/ios/Runner/AppDelegate.h
+++ b/examples/hello_services/ios/Runner/AppDelegate.h
@@ -3,9 +3,8 @@
 // found in the LICENSE file.
 
 #import <UIKit/UIKit.h>
+#import <Flutter/Flutter.h>
 
-@interface AppDelegate : UIResponder <UIApplicationDelegate>
-
-@property(strong, nonatomic) UIWindow *window;
+@interface AppDelegate : FlutterAppDelegate
 
 @end

--- a/examples/hello_world/ios/Runner/AppDelegate.h
+++ b/examples/hello_world/ios/Runner/AppDelegate.h
@@ -1,7 +1,6 @@
 #import <UIKit/UIKit.h>
+#import <Flutter/Flutter.h>
 
-@interface AppDelegate : UIResponder <UIApplicationDelegate>
-
-@property (strong, nonatomic) UIWindow *window;
+@interface AppDelegate : FlutterAppDelegate
 
 @end

--- a/examples/stocks/ios/Runner/AppDelegate.h
+++ b/examples/stocks/ios/Runner/AppDelegate.h
@@ -1,7 +1,6 @@
 #import <UIKit/UIKit.h>
+#import <Flutter/Flutter.h>
 
-@interface AppDelegate : UIResponder <UIApplicationDelegate>
-
-@property (strong, nonatomic) UIWindow *window;
+@interface AppDelegate : FlutterAppDelegate
 
 @end


### PR DESCRIPTION
Subclassing FlutterAppDelegate is not required for real-world apps, but
it's what 'flutter create' generates, and applies the default behaviours
that most real-world apps will want.