### PR TITLE
Make a couple methods generic so that types flow through properly.

### DIFF
--- a/dev/devicelab/lib/framework/utils.dart
+++ b/dev/devicelab/lib/framework/utils.dart
@@ -274,7 +274,7 @@ String get dartBin =>
 
 Future<int> dart(List<String> args) => exec(dartBin, args);
 
-Future<dynamic> inDirectory(dynamic directory, Future<dynamic> action()) async {
+Future<T> inDirectory<T>(dynamic directory, Future<T> action()) async {
   String previousCwd = cwd;
   try {
     cd(directory);
@@ -328,11 +328,11 @@ Future<Null> getFlutter(String revision) async {
     rmTree(flutterDirectory);
   }
 
-  await inDirectory(flutterDirectory.parent, () async {
+  await inDirectory<Null>(flutterDirectory.parent, () async {
     await exec('git', <String>['clone', 'https://github.com/flutter/flutter.git']);
   });
 
-  await inDirectory(flutterDirectory, () async {
+  await inDirectory<Null>(flutterDirectory, () async {
     await exec('git', <String>['checkout', revision]);
   });
 

--- a/dev/devicelab/lib/tasks/analysis.dart
+++ b/dev/devicelab/lib/tasks/analysis.dart
@@ -67,7 +67,7 @@ class FlutterAnalyzeBenchmark extends Benchmark {
   @override
   Future<num> run() async {
     rm(benchmarkFile);
-    await inDirectory(flutterDirectory, () async {
+    await inDirectory<Null>(flutterDirectory, () async {
       await flutter('analyze', options: <String>[
         '--flutter-repo',
         '--benchmark',
@@ -104,7 +104,7 @@ class FlutterAnalyzeAppBenchmark extends Benchmark {
   @override
   Future<num> run() async {
     rm(benchmarkFile);
-    await inDirectory(megaDir, () async {
+    await inDirectory<Null>(megaDir, () async {
       await flutter('analyze', options: <String>[
         '--watch',
         '--benchmark',

--- a/dev/devicelab/lib/tasks/gallery.dart
+++ b/dev/devicelab/lib/tasks/gallery.dart
@@ -23,7 +23,7 @@ class GalleryTransitionTest {
     String deviceId = device.deviceId;
     Directory galleryDirectory =
         dir('${flutterDirectory.path}/examples/flutter_gallery');
-    await inDirectory(galleryDirectory, () async {
+    await inDirectory<Null>(galleryDirectory, () async {
       await flutter('packages', options: <String>['get']);
 
       if (deviceOperatingSystem == DeviceOperatingSystem.ios) {

--- a/dev/devicelab/lib/tasks/size_tests.dart
+++ b/dev/devicelab/lib/tasks/size_tests.dart
@@ -19,13 +19,13 @@ TaskFunction createBasicMaterialAppSizeTest() {
 
     int releaseSizeInBytes;
 
-    await inDirectory(Directory.systemTemp, () async {
+    await inDirectory<Null>(Directory.systemTemp, () async {
       await flutter('create', options: <String>[sampleAppName]);
 
       if (!(await sampleDir.exists()))
         throw 'Failed to create sample Flutter app in ${sampleDir.path}';
 
-      await inDirectory(sampleDir, () async {
+      await inDirectory<Null>(sampleDir, () async {
         await flutter('packages', options: <String>['get']);
         await flutter('build', options: <String>['clean']);
 

--- a/examples/flutter_gallery/lib/demo/grid_list_demo.dart
+++ b/examples/flutter_gallery/lib/demo/grid_list_demo.dart
@@ -157,7 +157,7 @@ class GridDemoPhotoItem extends StatelessWidget {
   final BannerTapCallback onBannerTap; // User taps on the photo's header or footer.
 
   void showPhoto(BuildContext context) {
-    Navigator.push(context, new MaterialPageRoute<Null>(
+    Navigator.push<Null>(context, new MaterialPageRoute<Null>(
       builder: (BuildContext context) {
         return new Scaffold(
           appBar: new AppBar(

--- a/examples/flutter_gallery/lib/demo/pesto_demo.dart
+++ b/examples/flutter_gallery/lib/demo/pesto_demo.dart
@@ -158,14 +158,14 @@ class _RecipeGridPageState extends State<RecipeGridPage> {
   }
 
   void showFavoritesPage(BuildContext context) {
-    Navigator.push(context, new MaterialPageRoute<Null>(
+    Navigator.push<Null>(context, new MaterialPageRoute<Null>(
       settings: const RouteSettings(name: "/pesto/favorites"),
       builder: (BuildContext context) => new PestoFavorites(),
     ));
   }
 
   void showRecipePage(BuildContext context, Recipe recipe) {
-    Navigator.push(context, new MaterialPageRoute<Null>(
+    Navigator.push<Null>(context, new MaterialPageRoute<Null>(
       settings: const RouteSettings(name: "/pesto/recipe"),
       builder: (BuildContext context) {
         return new Theme(

--- a/packages/flutter/lib/src/material/about.dart
+++ b/packages/flutter/lib/src/material/about.dart
@@ -181,7 +181,7 @@ void showLicensePage({
 }) {
   // TODO(ianh): remove pop once https://github.com/flutter/flutter/issues/4667 is fixed
   Navigator.pop(context);
-  Navigator.push(context, new MaterialPageRoute<Null>(
+  Navigator.push<Null>(context, new MaterialPageRoute<Null>(
     builder: (BuildContext context) => new LicensePage(
       applicationName: applicationName,
       applicationVersion: applicationVersion,

--- a/packages/flutter/lib/src/widgets/navigator.dart
+++ b/packages/flutter/lib/src/widgets/navigator.dart
@@ -502,7 +502,7 @@ class Navigator extends StatefulWidget {
   ///
   /// Returns a [Future] that completes to the `result` value passed to [pop]
   /// when the pushed route is popped off the navigator.
-  static Future<dynamic> push(BuildContext context, Route<dynamic> route) {
+  static Future<T> push<T>(BuildContext context, Route<T> route) {
     return Navigator.of(context).push(route);
   }
 
@@ -670,7 +670,7 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin {
     super.initState();
     assert(config.observer == null || config.observer.navigator == null);
     config.observer?._navigator = this;
-    push(config.onGenerateRoute(new RouteSettings(
+    push<dynamic>(config.onGenerateRoute(new RouteSettings(
       name: config.initialRoute ?? Navigator.defaultRouteName,
       isInitialRoute: true
     )));
@@ -739,7 +739,7 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin {
   /// Navigator.of(context).pushNamed('/nyc/1776');
   /// ```
   Future<dynamic> pushNamed(String name) {
-    return push(_routeNamed(name));
+    return push<dynamic>(_routeNamed(name));
   }
 
   /// Adds the given route to the navigator's history, and transitions to it.
@@ -754,7 +754,7 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin {
   ///
   /// Returns a [Future] that completes to the `result` value passed to [pop]
   /// when the pushed route is popped off the navigator.
-  Future<dynamic> push(Route<dynamic> route) {
+  Future<T> push<T>(Route<T> route) {
     assert(!_debugLocked);
     assert(() { _debugLocked = true; return true; });
     assert(route != null);

--- a/packages/flutter/test/material/will_pop_test.dart
+++ b/packages/flutter/test/material/will_pop_test.dart
@@ -110,7 +110,7 @@ void main() {
                 child: new FlatButton(
                   child: new Text('X'),
                   onPressed: () {
-                    Navigator.of(context).push(new MaterialPageRoute<Null>(
+                    Navigator.of(context).push<Null>(new MaterialPageRoute<Null>(
                       builder: (BuildContext context) {
                         return new SampleForm(
                           callback: () => new Future<bool>.value(willPopValue),
@@ -182,7 +182,7 @@ void main() {
                 child: new FlatButton(
                   child: new Text('X'),
                   onPressed: () {
-                    Navigator.of(context).push(new MaterialPageRoute<Null>(
+                    Navigator.of(context).push<Null>(new MaterialPageRoute<Null>(
                       builder: (BuildContext context) {
                         return new SampleForm(
                           callback: () => showYesNoAlert(context),

--- a/packages/flutter/test/widgets/heroes_test.dart
+++ b/packages/flutter/test/widgets/heroes_test.dart
@@ -26,7 +26,7 @@ final Map<String, WidgetBuilder> routes = <String, WidgetBuilder>{
         new Container(height: 150.0, width: 150.0),
         new Card(child: new Hero(tag: 'a', child: new Container(height: 150.0, width: 150.0, key: secondKey))),
         new Container(height: 150.0, width: 150.0),
-        new FlatButton(child: new Text('three'), onPressed: () => Navigator.push(context, new ThreeRoute())),
+        new FlatButton(child: new Text('three'), onPressed: () => Navigator.push<Null>(context, new ThreeRoute())),
       ]
     )
   ),
@@ -172,7 +172,7 @@ void main() {
           children: <Widget>[
             new Hero(tag: 'a', child: new Text('foo')),
             new Builder(builder: (BuildContext context) {
-              return new FlatButton(child: new Text('two'), onPressed: () => Navigator.push(context, route));
+              return new FlatButton(child: new Text('two'), onPressed: () => Navigator.push<Null>(context, route));
             })
           ]
         )

--- a/packages/flutter/test/widgets/page_transitions_test.dart
+++ b/packages/flutter/test/widgets/page_transitions_test.dart
@@ -82,7 +82,7 @@ void main() {
     expect(find.text('Settings'), isOnstage);
     expect(find.text('Overlay'), findsNothing);
 
-    Navigator.push(containerKey2.currentContext, new TestOverlayRoute());
+    Navigator.push<Null>(containerKey2.currentContext, new TestOverlayRoute());
 
     await tester.pump();
 
@@ -433,7 +433,7 @@ void main() {
     expect(popCount, 0);
     expect(completeCount, 0);
 
-    Navigator.push(tester.element(find.text('home')), route);
+    Navigator.push<Null>(tester.element(find.text('home')), route);
 
     expect(popCount, 0);
     expect(completeCount, 0);


### PR DESCRIPTION
This ended up being ugly due to the Flutter rule that generic arguments 
have to be explicitly set. Maybe there is a way to use annotations to
indicate that omitting the generic for this method is fine? Adding <Null>
for calls to the method where the return type is ignored adds no value.  
Note that there are also a few cases where inference does work correctly
and types now flow through as desired fixing strong mode errors.
For example see: dev/devicelab/lib/framework/utils.dart

@munificent do you have any ideas how we can make the strong mode experience better for this case?