### PR TITLE
Update package test to use new strong mode compatible expectAsyncN me…

### DIFF
--- a/dev/benchmarks/complex_layout/pubspec.yaml
+++ b/dev/benchmarks/complex_layout/pubspec.yaml
@@ -23,3 +23,7 @@ flutter:
     - packages/flutter_gallery_assets/ali_connors.png
     - packages/flutter_gallery_assets/ali_connors_sml.png
     - packages/flutter_gallery_assets/top_10_australian_beaches.png
+
+dependency_overrides:
+  test:
+    git: git://github.com/dart-lang/test.git

--- a/dev/devicelab/pubspec.yaml
+++ b/dev/devicelab/pubspec.yaml
@@ -14,6 +14,9 @@ dependencies:
   stack_trace: ^1.4.0
   vm_service_client: '0.2.2+4'
 
+dependency_overrides:
 dev_dependencies:
   # See packages/flutter_test/pubspec.yaml for why we're pinning this version.
-  test: 0.12.18+1
+  test:
+  test: 0.12.18+1  test:
+    git: git://github.com/dart-lang/test.git

--- a/dev/devicelab/pubspec.yaml
+++ b/dev/devicelab/pubspec.yaml
@@ -16,4 +16,4 @@ dependencies:
 
 dev_dependencies:
   # See packages/flutter_test/pubspec.yaml for why we're pinning this version.
-  test: 0.12.15+4
+  test: 0.12.18+1

--- a/dev/devicelab/pubspec.yaml
+++ b/dev/devicelab/pubspec.yaml
@@ -14,9 +14,11 @@ dependencies:
   stack_trace: ^1.4.0
   vm_service_client: '0.2.2+4'
 
-dependency_overrides:
 dev_dependencies:
   # See packages/flutter_test/pubspec.yaml for why we're pinning this version.
+  test: 0.12.18+1
+
+dependency_overrides:
+dev_dependencies:
   test:
-  test: 0.12.18+1  test:
     git: git://github.com/dart-lang/test.git

--- a/examples/flutter_gallery/pubspec.yaml
+++ b/examples/flutter_gallery/pubspec.yaml
@@ -105,3 +105,7 @@ flutter:
     - family: AbrilFatface
       fonts:
         - asset: packages/flutter_gallery_assets/shrine/fonts/abrilfatface/AbrilFatface-Regular.ttf
+
+dependency_overrides:
+  test:
+    git: git://github.com/dart-lang/test.git

--- a/examples/stocks/pubspec.yaml
+++ b/examples/stocks/pubspec.yaml
@@ -12,3 +12,7 @@ dev_dependencies:
 
 flutter:
   uses-material-design: true
+
+dependency_overrides:
+  test:
+    git: git://github.com/dart-lang/test.git

--- a/packages/flutter_driver/pubspec.yaml
+++ b/packages/flutter_driver/pubspec.yaml
@@ -23,3 +23,7 @@ dev_dependencies:
   test: 0.12.18+1
   mockito: ^1.0.0
   quiver: ^0.24.0
+
+dependency_overrides:
+  test:
+    git: git://github.com/dart-lang/test.git

--- a/packages/flutter_driver/pubspec.yaml
+++ b/packages/flutter_driver/pubspec.yaml
@@ -20,6 +20,6 @@ dependencies:
     sdk: flutter
 
 dev_dependencies:
-  test: 0.12.15+4
+  test: 0.12.18+1
   mockito: ^1.0.0
   quiver: ^0.24.0

--- a/packages/flutter_test/lib/src/widget_tester.dart
+++ b/packages/flutter_test/lib/src/widget_tester.dart
@@ -122,7 +122,8 @@ void expect(dynamic actual, dynamic matcher, {
   dynamic formatter
 }) {
   TestAsyncUtils.guardSync();
-  test_package.expect(actual, matcher, reason: reason, verbose: verbose, formatter: formatter);
+  // XXX removed formatter.
+  test_package.expect(actual, matcher, reason: reason, verbose: verbose);
 }
 
 /// Assert that `actual` matches `matcher`.
@@ -139,7 +140,8 @@ void expectSync(dynamic actual, dynamic matcher, {
   bool verbose: false,
   dynamic formatter
 }) {
-  test_package.expect(actual, matcher, reason: reason, verbose: verbose, formatter: formatter);
+  // XXX removed formatter.
+  test_package.expect(actual, matcher, reason: reason, verbose: verbose);
 }
 
 /// Class that programmatically interacts with widgets and the test environment.

--- a/packages/flutter_test/pubspec.yaml
+++ b/packages/flutter_test/pubspec.yaml
@@ -9,3 +9,7 @@ dependencies:
 
   flutter:
     sdk: flutter
+
+dependency_overrides:
+  test:
+    git: git://github.com/dart-lang/test.git

--- a/packages/flutter_test/pubspec.yaml
+++ b/packages/flutter_test/pubspec.yaml
@@ -5,7 +5,7 @@ dependencies:
   # The flutter tools depend on very specific internal implementation
   # details of the 'test' package, which change between versions, so
   # here we pin it precisely to avoid version skew across our packages.
-  test: 0.12.15+4
+  test: 0.12.18+1
 
   flutter:
     sdk: flutter

--- a/packages/flutter_tools/pubspec.yaml
+++ b/packages/flutter_tools/pubspec.yaml
@@ -35,7 +35,7 @@ dependencies:
   # We depend on very specific internal implementation details of the
   # 'test' package, which change between versions, so here we pin it
   # precisely.
-  test: 0.12.15+4
+  test: 0.12.18+1
 
   # Version from the vended Dart SDK as defined in `dependency_overrides`.
   analyzer: any

--- a/packages/flutter_tools/pubspec.yaml
+++ b/packages/flutter_tools/pubspec.yaml
@@ -53,3 +53,5 @@ dependency_overrides:
     path: ../../bin/cache/dart-sdk/lib/analyzer
   front_end:
     path: ../../bin/cache/dart-sdk/lib/front_end
+  test:
+    git: git://github.com/dart-lang/test.git

--- a/packages/flutter_tools/test/drive_test.dart
+++ b/packages/flutter_tools/test/drive_test.dart
@@ -84,7 +84,7 @@ void main() {
 
     testUsingContext('returns 1 when app fails to run', () async {
       withMockDevice();
-      appStarter = expectAsync((DriveCommand command) async => null);
+      appStarter = expectAsync1((DriveCommand command) async => null);
 
       String testApp = '/some/app/test_driver/e2e.dart';
       String testFile = '/some/app/test_driver/e2e_test.dart';
@@ -153,14 +153,14 @@ void main() {
       String testApp = '/some/app/test/e2e.dart';
       String testFile = '/some/app/test_driver/e2e_test.dart';
 
-      appStarter = expectAsync((DriveCommand command) async {
+      appStarter = expectAsync1((DriveCommand command) async {
         return new LaunchResult.succeeded();
       });
-      testRunner = expectAsync((List<String> testArgs, String observatoryUri) async {
+      testRunner = expectAsync2((List<String> testArgs, String observatoryUri) async {
         expect(testArgs, <String>[testFile]);
         return null;
       });
-      appStopper = expectAsync((DriveCommand command) async {
+      appStopper = expectAsync1((DriveCommand command) async {
         return true;
       });
 
@@ -184,13 +184,13 @@ void main() {
       String testApp = '/some/app/test/e2e.dart';
       String testFile = '/some/app/test_driver/e2e_test.dart';
 
-      appStarter = expectAsync((DriveCommand command) async {
+      appStarter = expectAsync1((DriveCommand command) async {
         return new LaunchResult.succeeded();
       });
       testRunner = (List<String> testArgs, String observatoryUri) async {
         throwToolExit(null, exitCode: 123);
       };
-      appStopper = expectAsync((DriveCommand command) async {
+      appStopper = expectAsync1((DriveCommand command) async {
         return true;
       });
 


### PR DESCRIPTION
Does anyone have tips on best practices to debug failing flutter tests. Looks like some changes in package:test between0.12.15+4 and 0.12.18+1 break Flutter test.
