### PR TITLE
Scrollable2.ensureVisible for box-based viewports

### DIFF
--- a/packages/flutter/lib/src/rendering/sliver_block.dart
+++ b/packages/flutter/lib/src/rendering/sliver_block.dart
@@ -61,9 +61,9 @@ class RenderSliverBlock extends RenderSliverMultiBoxAdaptor {
 
     // Find the last child that is at or before the scrollOffset.
     RenderBox earliestUsefulChild = firstChild;
-    for (double earliestScrollOffset = offsetOf(earliestUsefulChild);
+    for (double earliestScrollOffset = childScrollOffset(earliestUsefulChild);
          earliestScrollOffset > scrollOffset;
-         earliestScrollOffset = offsetOf(earliestUsefulChild)) {
+         earliestScrollOffset = childScrollOffset(earliestUsefulChild)) {
       // We have to add children before the earliestUsefulChild.
       earliestUsefulChild = insertAndLayoutLeadingChild(childConstraints, parentUsesSize: true);
       if (earliestUsefulChild == null) {
@@ -71,7 +71,7 @@ class RenderSliverBlock extends RenderSliverMultiBoxAdaptor {
         // We must inform our parent that this sliver cannot fulfill
         // its contract and that we need a scroll offset correction.
         geometry = new SliverGeometry(
-          scrollOffsetCorrection: -offsetOf(firstChild),
+          scrollOffsetCorrection: -childScrollOffset(firstChild),
         );
         return;
       }
@@ -90,7 +90,7 @@ class RenderSliverBlock extends RenderSliverMultiBoxAdaptor {
     // scroll offset.
 
     assert(earliestUsefulChild == firstChild);
-    assert(offsetOf(earliestUsefulChild) <= scrollOffset);
+    assert(childScrollOffset(earliestUsefulChild) <= scrollOffset);
 
     // Make sure we've laid out at least one child.
     if (leadingChildWithLayout == null) {
@@ -107,7 +107,7 @@ class RenderSliverBlock extends RenderSliverMultiBoxAdaptor {
     bool inLayoutRange = true;
     RenderBox child = earliestUsefulChild;
     int index = indexOf(child);
-    double endScrollOffset = offsetOf(child) + paintExtentOf(child);
+    double endScrollOffset = childScrollOffset(child) + paintExtentOf(child);
     bool advance() { // returns true if we advanced, false if we have no more children
       // This function is used in two different places below, to avoid code duplication.
       assert(child != null);
@@ -138,7 +138,7 @@ class RenderSliverBlock extends RenderSliverMultiBoxAdaptor {
       final SliverMultiBoxAdaptorParentData childParentData = child.parentData;
       childParentData.scrollOffset = endScrollOffset;
       assert(childParentData.index == index);
-      endScrollOffset = offsetOf(child) + paintExtentOf(child);
+      endScrollOffset = childScrollOffset(child) + paintExtentOf(child);
       return true;
     }
 
@@ -151,7 +151,7 @@ class RenderSliverBlock extends RenderSliverMultiBoxAdaptor {
         // we want to make sure we keep the last child around so we know the end scroll offset
         collectGarbage(leadingGarbage - 1, 0);
         assert(firstChild == lastChild);
-        final double extent = offsetOf(lastChild) + paintExtentOf(lastChild);
+        final double extent = childScrollOffset(lastChild) + paintExtentOf(lastChild);
         geometry = new SliverGeometry(
           scrollExtent: extent,
           paintExtent: 0.0,
@@ -192,14 +192,14 @@ class RenderSliverBlock extends RenderSliverMultiBoxAdaptor {
         constraints,
         firstIndex: indexOf(firstChild),
         lastIndex: indexOf(lastChild),
-        leadingScrollOffset: offsetOf(firstChild),
+        leadingScrollOffset: childScrollOffset(firstChild),
         trailingScrollOffset: endScrollOffset,
       );
-      assert(estimatedMaxScrollOffset >= endScrollOffset - offsetOf(firstChild));
+      assert(estimatedMaxScrollOffset >= endScrollOffset - childScrollOffset(firstChild));
     }
     final double paintedExtent = calculatePaintOffset(
       constraints,
-      from: offsetOf(firstChild),
+      from: childScrollOffset(firstChild),
       to: endScrollOffset,
     );
     geometry = new SliverGeometry(

--- a/packages/flutter/lib/src/rendering/sliver_grid.dart
+++ b/packages/flutter/lib/src/rendering/sliver_grid.dart
@@ -356,7 +356,7 @@ class RenderSliverGrid extends RenderSliverMultiBoxAdaptor {
         trailingScrollOffset = gridGeometry.scrollOffset;
     }
 
-    assert(offsetOf(firstChild) <= scrollOffset);
+    assert(childScrollOffset(firstChild) <= scrollOffset);
 
     if (trailingChildWithLayout == null) {
       firstChild.layout(firstChildGridGeometry.getBoxConstraints(constraints));

--- a/packages/flutter/lib/src/rendering/sliver_list.dart
+++ b/packages/flutter/lib/src/rendering/sliver_list.dart
@@ -66,7 +66,7 @@ abstract class RenderSliverFixedExtentBoxAdaptor extends RenderSliverMultiBoxAda
       trailingChildWithLayout ??= child;
     }
 
-    assert(offsetOf(firstChild) <= scrollOffset);
+    assert(childScrollOffset(firstChild) <= scrollOffset);
 
     if (trailingChildWithLayout == null) {
       firstChild.layout(childConstraints);

--- a/packages/flutter/lib/src/rendering/sliver_multi_box_adaptor.dart
+++ b/packages/flutter/lib/src/rendering/sliver_multi_box_adaptor.dart
@@ -268,15 +268,6 @@ abstract class RenderSliverMultiBoxAdaptor extends RenderSliver
     return childParentData.index;
   }
 
-  /// Returns the scroll offset of the given child, as given by the
-  /// [SliverMultiBoxAdaptorParentData.scrollOffset] field of the child's [parentData].
-  double offsetOf(RenderBox child) {
-    assert(child != null);
-    final SliverMultiBoxAdaptorParentData childParentData = child.parentData;
-    assert(childParentData.scrollOffset != null);
-    return childParentData.scrollOffset;
-  }
-
   /// Returns the dimension of the given child in the main axis, as given by the
   /// child's [RenderBox.size] property. This is only valid after layout.
   @protected
@@ -305,7 +296,16 @@ abstract class RenderSliverMultiBoxAdaptor extends RenderSliver
 
   @override
   double childMainAxisPosition(RenderBox child) {
-    return offsetOf(child) - constraints.scrollOffset;
+    return childScrollOffset(child) - constraints.scrollOffset;
+  }
+
+  @override
+  double childScrollOffset(RenderObject child) {
+    assert(child != null);
+    assert(child.parent == this);
+    final SliverMultiBoxAdaptorParentData childParentData = child.parentData;
+    assert(childParentData.scrollOffset != null);
+    return childParentData.scrollOffset;
   }
 
   @override

--- a/packages/flutter/lib/src/rendering/sliver_padding.dart
+++ b/packages/flutter/lib/src/rendering/sliver_padding.dart
@@ -281,6 +281,12 @@ class RenderSliverPadding extends RenderSliver with RenderObjectWithChildMixin<R
   }
 
   @override
+  double childScrollOffset(RenderObject child) {
+    assert(child.parent == this);
+    return beforePadding;
+  }
+
+  @override
   void applyPaintTransform(RenderObject child, Matrix4 transform) {
     assert(child != null);
     assert(child == this.child);

--- a/packages/flutter/lib/src/widgets/scroll_position.dart
+++ b/packages/flutter/lib/src/widgets/scroll_position.dart
@@ -142,6 +142,28 @@ class ScrollPosition extends ViewportOffset {
   double get pixels => _pixels;
   double _pixels = 0.0;
 
+  Future<Null> ensureVisible(RenderObject object, {
+    double alignment: 0.0,
+    Duration duration: Duration.ZERO,
+    Curve curve: Curves.ease,
+  }) {
+    assert(object.attached);
+    final RenderAbstractViewport viewport = RenderAbstractViewport.of(object);
+    assert(viewport != null);
+
+    final double to = viewport.getOffsetToReveal(object, alignment).clamp(minScrollExtent, maxScrollExtent);
+
+    if (to == pixels)
+      return new Future<Null>.value();
+
+    if (duration == Duration.ZERO) {
+      jumpTo(to);
+      return new Future<Null>.value();
+    }
+
+    return animate(to: to, duration: duration, curve: curve);
+  }
+
   /// Animates the position from its current value to the given value `to`.
   ///
   /// Any active animation is canceled. If the user is currently scrolling, that

--- a/packages/flutter/lib/src/widgets/scrollable.dart
+++ b/packages/flutter/lib/src/widgets/scrollable.dart
@@ -60,6 +60,39 @@ class Scrollable2 extends StatefulWidget {
     if (physics != null)
       description.add('physics: $physics');
   }
+
+  /// The state from the closest instance of this class that encloses the given context.
+  ///
+  /// Typical usage is as follows:
+  ///
+  /// ```dart
+  /// Scrollable2State scrollable = Scrollable2.of(context);
+  /// ```
+  static Scrollable2State of(BuildContext context) {
+    return context.ancestorStateOfType(const TypeMatcher<Scrollable2State>());
+  }
+
+  /// Scrolls the closest enclosing scrollable to make the given context visible.
+  static Future<Null> ensureVisible(BuildContext context, {
+    double alignment: 0.0,
+    Duration duration: Duration.ZERO,
+    Curve curve: Curves.ease,
+  }) {
+    final List<Future<Null>> futures = <Future<Null>>[];
+
+    Scrollable2State scrollable = Scrollable2.of(context);
+    while (scrollable != null) {
+      futures.add(scrollable.position.ensureVisible(context.findRenderObject(), alignment: alignment));
+      context = scrollable.context;
+      scrollable = Scrollable2.of(context);
+    }
+
+    if (futures.isEmpty || duration == Duration.ZERO)
+      return new Future<Null>.value();
+    if (futures.length == 1)
+      return futures.first;
+    return Future.wait<Null>(futures);
+  }
 }
 
 /// State object for a [Scrollable2] widget.

--- a/packages/flutter/test/widgets/ensure_visible_test.dart
+++ b/packages/flutter/test/widgets/ensure_visible_test.dart
@@ -1,0 +1,195 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:math' as math;
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter/widgets.dart';
+
+Finder findKey(int i) => find.byKey(new ValueKey<int>(i));
+
+Widget buildSingleChildScrollView(Axis scrollDirection, { bool reverse: false }) {
+  return new Center(
+    child: new SizedBox(
+      width: 600.0,
+      height: 400.0,
+      child: new SingleChildScrollView(
+        scrollDirection: scrollDirection,
+        reverse: reverse,
+        child: new BlockBody(
+          mainAxis: scrollDirection,
+          children: <Widget>[
+            new Container(key: new ValueKey<int>(0), width: 200.0, height: 200.0),
+            new Container(key: new ValueKey<int>(1), width: 200.0, height: 200.0),
+            new Container(key: new ValueKey<int>(2), width: 200.0, height: 200.0),
+            new Container(key: new ValueKey<int>(3), width: 200.0, height: 200.0),
+            new Container(key: new ValueKey<int>(4), width: 200.0, height: 200.0),
+            new Container(key: new ValueKey<int>(5), width: 200.0, height: 200.0),
+            new Container(key: new ValueKey<int>(6), width: 200.0, height: 200.0),
+          ],
+        ),
+      ),
+    ),
+  );
+}
+
+void main() {
+  testWidgets('SingleChildScollView ensureVisible Axis.vertical', (WidgetTester tester) async {
+    BuildContext findContext(int i) => tester.element(findKey(i));
+
+    await tester.pumpWidget(buildSingleChildScrollView(Axis.vertical));
+
+    Scrollable2.ensureVisible(findContext(3));
+    await tester.pump();
+    expect(tester.getTopLeft(findKey(3)).y, equals(100.0));
+
+    Scrollable2.ensureVisible(findContext(6));
+    await tester.pump();
+    expect(tester.getTopLeft(findKey(6)).y, equals(300.0));
+
+    Scrollable2.ensureVisible(findContext(4), alignment: 1.0);
+    await tester.pump();
+    expect(tester.getBottomRight(findKey(4)).y, equals(500.0));
+
+    Scrollable2.ensureVisible(findContext(0), alignment: 1.0);
+    await tester.pump();
+    expect(tester.getTopLeft(findKey(0)).y, equals(100.0));
+
+    Scrollable2.ensureVisible(findContext(3), duration: const Duration(seconds: 1));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 1020));
+    expect(tester.getTopLeft(findKey(3)).y, equals(100.0));
+  });
+
+  testWidgets('SingleChildScollView ensureVisible Axis.horizontal', (WidgetTester tester) async {
+    BuildContext findContext(int i) => tester.element(findKey(i));
+
+    await tester.pumpWidget(buildSingleChildScrollView(Axis.horizontal));
+
+    Scrollable2.ensureVisible(findContext(3));
+    await tester.pump();
+    expect(tester.getTopLeft(findKey(3)).x, equals(100.0));
+
+    Scrollable2.ensureVisible(findContext(6));
+    await tester.pump();
+    expect(tester.getTopLeft(findKey(6)).x, equals(500.0));
+
+    Scrollable2.ensureVisible(findContext(4), alignment: 1.0);
+    await tester.pump();
+    expect(tester.getBottomRight(findKey(4)).x, equals(700.0));
+
+    Scrollable2.ensureVisible(findContext(0), alignment: 1.0);
+    await tester.pump();
+    expect(tester.getTopLeft(findKey(0)).x, equals(100.0));
+
+    Scrollable2.ensureVisible(findContext(3), duration: const Duration(seconds: 1));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 1020));
+    expect(tester.getTopLeft(findKey(3)).x, equals(100.0));
+  });
+
+  testWidgets('SingleChildScollView ensureVisible Axis.vertical reverse', (WidgetTester tester) async {
+    BuildContext findContext(int i) => tester.element(findKey(i));
+
+    await tester.pumpWidget(buildSingleChildScrollView(Axis.vertical, reverse: true));
+
+    Scrollable2.ensureVisible(findContext(3));
+    await tester.pump();
+    expect(tester.getBottomRight(findKey(3)).y, equals(500.0));
+
+    Scrollable2.ensureVisible(findContext(0));
+    await tester.pump();
+    expect(tester.getBottomRight(findKey(0)).y, equals(300.0));
+
+    Scrollable2.ensureVisible(findContext(2), alignment: 1.0);
+    await tester.pump();
+    expect(tester.getTopLeft(findKey(2)).y, equals(100.0));
+
+    Scrollable2.ensureVisible(findContext(6), alignment: 1.0);
+    await tester.pump();
+    expect(tester.getBottomRight(findKey(6)).y, equals(500.0));
+
+    Scrollable2.ensureVisible(findContext(3), duration: const Duration(seconds: 1));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 1020));
+    expect(tester.getBottomRight(findKey(3)).y, equals(500.0));
+  });
+
+  testWidgets('SingleChildScollView ensureVisible Axis.horizontal', (WidgetTester tester) async {
+    BuildContext findContext(int i) => tester.element(findKey(i));
+
+    await tester.pumpWidget(buildSingleChildScrollView(Axis.horizontal, reverse: true));
+
+    Scrollable2.ensureVisible(findContext(3));
+    await tester.pump();
+    expect(tester.getBottomRight(findKey(3)).x, equals(700.0));
+
+    Scrollable2.ensureVisible(findContext(0));
+    await tester.pump();
+    expect(tester.getBottomRight(findKey(0)).x, equals(300.0));
+
+    Scrollable2.ensureVisible(findContext(2), alignment: 1.0);
+    await tester.pump();
+    expect(tester.getTopLeft(findKey(2)).x, equals(100.0));
+
+    Scrollable2.ensureVisible(findContext(6), alignment: 1.0);
+    await tester.pump();
+    expect(tester.getBottomRight(findKey(6)).x, equals(700.0));
+
+    Scrollable2.ensureVisible(findContext(3), duration: const Duration(seconds: 1));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 1020));
+    expect(tester.getBottomRight(findKey(3)).x, equals(700.0));
+  });
+
+  testWidgets('SingleChildScollView ensureVisible rotated child', (WidgetTester tester) async {
+    BuildContext findContext(int i) => tester.element(findKey(i));
+
+    await tester.pumpWidget(
+      new Center(
+        child: new SizedBox(
+          width: 600.0,
+          height: 400.0,
+          child: new SingleChildScrollView(
+            child: new BlockBody(
+              children: <Widget>[
+                new Container(height: 200.0),
+                new Container(height: 200.0),
+                new Container(height: 200.0),
+                new Container(
+                  height: 200.0,
+                  child: new Center(
+                    child: new Transform(
+                      transform: new Matrix4.rotationZ(math.PI),
+                      child: new Container(
+                        key: new ValueKey<int>(0),
+                        width: 100.0,
+                        height: 100.0,
+                        decoration: const BoxDecoration(
+                          backgroundColor: const Color(0xFFFFFFFF),
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+                new Container(height: 200.0),
+                new Container(height: 200.0),
+                new Container(height: 200.0),
+              ],
+            ),
+          ),
+        ),
+      )
+    );
+
+    Scrollable2.ensureVisible(findContext(0));
+    await tester.pump();
+    expect(tester.getBottomRight(findKey(0)).y, closeTo(100.0, 0.1));
+
+    Scrollable2.ensureVisible(findContext(0), alignment: 1.0);
+    await tester.pump();
+    expect(tester.getTopLeft(findKey(0)).y, closeTo(500.0, 0.1));
+  });
+
+}

--- a/packages/flutter/test/widgets/scrollable_custom_scroll_behavior_test.dart
+++ b/packages/flutter/test/widgets/scrollable_custom_scroll_behavior_test.dart
@@ -68,6 +68,15 @@ class TestScrollPosition extends ScrollPosition {
       );
     }
   }
+
+  @override
+  Future<Null> ensureVisible(RenderObject object, {
+    double alignment: 0.0,
+    Duration duration: Duration.ZERO,
+    Curve curve: Curves.ease,
+  }) {
+    return new Future<Null>.value();
+  }
 }
 
 class TestScrollPhysics extends ScrollPhysics {


### PR DESCRIPTION
This patch makes Scrollable2.ensureVisible with SingleChildScrollView. A future
patch will extend the implementation to work with slivers. (Although the patch
does include some of the infrastructure for that part of the implementation as
well.)