### PR TITLE
Add isToolExit, throwsToolExit test matchers

### DIFF
--- a/packages/flutter_tools/test/src/base/common_test.dart
+++ b/packages/flutter_tools/test/src/base/common_test.dart
@@ -1,0 +1,20 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:test/test.dart';
+import 'package:flutter_tools/src/base/common.dart';
+
+import '../common.dart';
+
+void main() {
+  group('throwToolExit', () {
+    test('throws ToolExit', () {
+      expect(() => throwToolExit('message'), throwsToolExit());
+    });
+
+    test('throws ToolExit with exitCode', () {
+      expect(() => throwToolExit('message', exitCode: 42), throwsToolExit(42));
+    });
+  });
+}

--- a/packages/flutter_tools/test/src/common.dart
+++ b/packages/flutter_tools/test/src/common.dart
@@ -4,7 +4,9 @@
 
 import 'package:args/command_runner.dart';
 import 'package:process/process.dart';
+import 'package:test/test.dart';
 
+import 'package:flutter_tools/src/base/common.dart';
 import 'package:flutter_tools/src/base/context.dart';
 import 'package:flutter_tools/src/runner/flutter_command.dart';
 import 'package:flutter_tools/src/runner/flutter_command_runner.dart';
@@ -31,3 +33,13 @@ void updateFileModificationTime(String path,
   ProcessManager processManager = context[ProcessManager];
   processManager.runSync(<String>['touch', '-t', argument, path]);
 }
+
+/// Matcher for functions that throw ToolExit.
+Matcher throwsToolExit([int exitCode]) {
+  return exitCode == null
+    ? const Throws(isToolExit)
+    : new Throws(allOf(isToolExit, (ToolExit e) => e.exitCode == exitCode));
+}
+
+/// Matcher for [ToolExit]s.
+const Matcher isToolExit = const isInstanceOf<ToolExit>();


### PR DESCRIPTION
Allows for better testing of functions that throw ToolExit to bail out.