### PR TITLE
Rename SliverLogicalParentData.scrollOffset to layoutOffset

### DIFF
--- a/packages/flutter/lib/src/rendering/sliver_fixed_extent_list.dart
+++ b/packages/flutter/lib/src/rendering/sliver_fixed_extent_list.dart
@@ -61,7 +61,7 @@ abstract class RenderSliverFixedExtentBoxAdaptor extends RenderSliverMultiBoxAda
     for (int index = indexOf(firstChild) - 1; index >= firstIndex; --index) {
       final RenderBox child = insertAndLayoutLeadingChild(childConstraints);
       final SliverMultiBoxAdaptorParentData childParentData = child.parentData;
-      childParentData.scrollOffset = indexToScrollOffset(index);
+      childParentData.layoutOffset = indexToScrollOffset(index);
       assert(childParentData.index == index);
       trailingChildWithLayout ??= child;
     }
@@ -87,7 +87,7 @@ abstract class RenderSliverFixedExtentBoxAdaptor extends RenderSliverMultiBoxAda
       trailingChildWithLayout = child;
       assert(child != null);
       final SliverMultiBoxAdaptorParentData childParentData = child.parentData;
-      childParentData.scrollOffset = indexToScrollOffset(childParentData.index);
+      childParentData.layoutOffset = indexToScrollOffset(childParentData.index);
     }
 
     final int lastIndex = indexOf(lastChild);

--- a/packages/flutter/lib/src/rendering/sliver_grid.dart
+++ b/packages/flutter/lib/src/rendering/sliver_grid.dart
@@ -348,7 +348,7 @@ class RenderSliverGrid extends RenderSliverMultiBoxAdaptor {
       final RenderBox child = insertAndLayoutLeadingChild(
           gridGeometry.getBoxConstraints(constraints));
       final SliverGridParentData childParentData = child.parentData;
-      childParentData.scrollOffset = gridGeometry.scrollOffset;
+      childParentData.layoutOffset = gridGeometry.scrollOffset;
       childParentData.crossAxisOffset = gridGeometry.crossAxisOffset;
       assert(childParentData.index == index);
       trailingChildWithLayout ??= child;
@@ -362,7 +362,7 @@ class RenderSliverGrid extends RenderSliverMultiBoxAdaptor {
       firstChild.layout(firstChildGridGeometry.getBoxConstraints(constraints));
       final SliverGridParentData childParentData = firstChild.parentData;
       childParentData.crossAxisOffset = firstChildGridGeometry.crossAxisOffset;
-      assert(childParentData.scrollOffset ==
+      assert(childParentData.layoutOffset ==
           firstChildGridGeometry.scrollOffset);
       trailingChildWithLayout = firstChild;
     }
@@ -386,7 +386,7 @@ class RenderSliverGrid extends RenderSliverMultiBoxAdaptor {
       trailingChildWithLayout = child;
       assert(child != null);
       final SliverGridParentData childParentData = child.parentData;
-      childParentData.scrollOffset = gridGeometry.scrollOffset;
+      childParentData.layoutOffset = gridGeometry.scrollOffset;
       childParentData.crossAxisOffset = gridGeometry.crossAxisOffset;
       assert(childParentData.index == index);
       if (gridGeometry.scrollOffset > trailingScrollOffset)

--- a/packages/flutter/lib/src/rendering/sliver_list.dart
+++ b/packages/flutter/lib/src/rendering/sliver_list.dart
@@ -76,7 +76,7 @@ class RenderSliverList extends RenderSliverMultiBoxAdaptor {
         return;
       }
       final SliverMultiBoxAdaptorParentData childParentData = earliestUsefulChild.parentData;
-      childParentData.scrollOffset = earliestScrollOffset - paintExtentOf(firstChild);
+      childParentData.layoutOffset = earliestScrollOffset - paintExtentOf(firstChild);
       assert(earliestUsefulChild == firstChild);
       leadingChildWithLayout = earliestUsefulChild;
       trailingChildWithLayout ??= earliestUsefulChild;
@@ -136,7 +136,7 @@ class RenderSliverList extends RenderSliverMultiBoxAdaptor {
       }
       assert(child != null);
       final SliverMultiBoxAdaptorParentData childParentData = child.parentData;
-      childParentData.scrollOffset = endScrollOffset;
+      childParentData.layoutOffset = endScrollOffset;
       assert(childParentData.index == index);
       endScrollOffset = childScrollOffset(child) + paintExtentOf(child);
       return true;

--- a/packages/flutter/lib/src/rendering/sliver_multi_box_adaptor.dart
+++ b/packages/flutter/lib/src/rendering/sliver_multi_box_adaptor.dart
@@ -171,7 +171,7 @@ abstract class RenderSliverMultiBoxAdaptor extends RenderSliver
         assert(firstChild == lastChild);
         assert(indexOf(firstChild) == index);
         final SliverMultiBoxAdaptorParentData firstChildParentData = firstChild.parentData;
-        firstChildParentData.scrollOffset = scrollOffset;
+        firstChildParentData.layoutOffset = scrollOffset;
         result = true;
       } else {
         result = false;
@@ -304,8 +304,8 @@ abstract class RenderSliverMultiBoxAdaptor extends RenderSliver
     assert(child != null);
     assert(child.parent == this);
     final SliverMultiBoxAdaptorParentData childParentData = child.parentData;
-    assert(childParentData.scrollOffset != null);
-    return childParentData.scrollOffset;
+    assert(childParentData.layoutOffset != null);
+    return childParentData.layoutOffset;
   }
 
   @override


### PR DESCRIPTION
This quantity is actually the layoutOffset of the child, not its scroll offset.