### PR TITLE
Exit with error message if ensureDirectoryExists fails

### DIFF
--- a/packages/flutter_tools/lib/src/base/file_system.dart
+++ b/packages/flutter_tools/lib/src/base/file_system.dart
@@ -7,6 +7,7 @@ import 'package:file/local.dart';
 import 'package:file/memory.dart';
 import 'package:path/path.dart' as path;
 
+import 'common.dart' show throwToolExit;
 import 'context.dart';
 
 export 'package:file/file.dart';
@@ -23,10 +24,13 @@ FileSystem get fs => context == null ? _kLocalFs : context[FileSystem];
 /// Create the ancestor directories of a file path if they do not already exist.
 void ensureDirectoryExists(String filePath) {
   String dirPath = path.dirname(filePath);
-
   if (fs.isDirectorySync(dirPath))
     return;
-  fs.directory(dirPath).createSync(recursive: true);
+  try {
+    fs.directory(dirPath).createSync(recursive: true);
+  } on FileSystemException {
+    throwToolExit('Failed to create directory "$dirPath".');
+  }
 }
 
 /// Recursively copies `srcDir` to `destDir`.

--- a/packages/flutter_tools/lib/src/base/file_system.dart
+++ b/packages/flutter_tools/lib/src/base/file_system.dart
@@ -28,8 +28,8 @@ void ensureDirectoryExists(String filePath) {
     return;
   try {
     fs.directory(dirPath).createSync(recursive: true);
-  } on FileSystemException {
-    throwToolExit('Failed to create directory "$dirPath".');
+  } on FileSystemException catch (e) {
+    throwToolExit('Failed to create directory "$dirPath".\n$e');
   }
 }
 

--- a/packages/flutter_tools/test/src/base/file_system_test.dart
+++ b/packages/flutter_tools/test/src/base/file_system_test.dart
@@ -6,8 +6,29 @@ import 'package:file/memory.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:test/test.dart';
 
+import '../common.dart';
+import '../context.dart';
+
 void main() {
-  group('file_system', () {
+  group('ensureDirectoryExists', () {
+    MemoryFileSystem fs;
+
+    setUp(() {
+      fs = new MemoryFileSystem();
+    });
+
+    testUsingContext('recursively creates a directory if it does not exist', () async {
+      ensureDirectoryExists('foo/bar/baz.flx');
+      expect(fs.isDirectorySync('foo/bar'), true);
+    }, overrides: <Type, Generator>{ FileSystem: () => fs } );
+
+    testUsingContext('throws tool exit on failure to create', () async {
+      fs.file('foo').createSync();
+      expect(() => ensureDirectoryExists('foo/bar.flx'), throwsToolExit());
+    }, overrides: <Type, Generator>{ FileSystem: () => fs } );
+  });
+
+  group('copyDirectorySync', () {
     /// Test file_systems.copyDirectorySync() using MemoryFileSystem.
     /// Copies between 2 instances of file systems which is also supported by copyDirectorySync().
     test('test directory copy', () async {


### PR DESCRIPTION
If ensureDirectoryExists fails -- e.g. because a file file of the same
name as the directory to be created exists, ensure that we exit cleanly
with a useful error message.