### PR TITLE
Improved ensureDirectoryExists error message

### DIFF
--- a/packages/flutter_tools/lib/src/base/file_system.dart
+++ b/packages/flutter_tools/lib/src/base/file_system.dart
@@ -29,7 +29,7 @@ void ensureDirectoryExists(String filePath) {
   try {
     fs.directory(dirPath).createSync(recursive: true);
   } on FileSystemException catch (e) {
-    throwToolExit('Failed to create directory "$dirPath".\n$e');
+    throwToolExit('Failed to create directory "$dirPath": ${e.osError.message}');
   }
 }
 


### PR DESCRIPTION
On macOS: Failed to create directory "build". Error: Not a directory
On Linux: Failed to create directory "build". Error: Not a directory
On Windows: Failed to create directory "build". Error: Cannot create a file when that file already exists.