### PR TITLE
Improve and document SliverGrid delegate structure

### DIFF
--- a/packages/flutter/lib/src/widgets/sliver.dart
+++ b/packages/flutter/lib/src/widgets/sliver.dart
@@ -209,7 +209,7 @@ class SliverGrid extends SliverMultiBoxAdaptorWidget {
       lastIndex,
       leadingScrollOffset,
       trailingScrollOffset,
-    ) ?? gridDelegate.estimateMaxScrollOffset(constraints, delegate.estimatedChildCount);
+    ) ?? gridDelegate.getLayout(constraints).estimateMaxScrollOffset(delegate.estimatedChildCount);
   }
 }
 


### PR DESCRIPTION
We now create a GridLayout object that memoizes the layout information
for a given SliverConstraints. This approach is both more efficient
(because the delegate no longer needs to re-solve its layout for each
child) and allows for more code sharing between delegates.

The SliverGridRegularTileLayout will also be useful for the date
picker.

Also, document the grid delegates.