### PR TITLE
upgrade to the latest usage package

### DIFF
--- a/packages/flutter_tools/lib/src/usage.dart
+++ b/packages/flutter_tools/lib/src/usage.dart
@@ -4,8 +4,7 @@
 
 import 'dart:async';
 
-import 'package:usage/src/usage_impl_io.dart'; // ignore: implementation_imports
-import 'package:usage/usage.dart';
+import 'package:usage/usage_io.dart';
 
 import 'base/context.dart';
 import 'base/utils.dart';
@@ -85,18 +84,7 @@ class Usage {
 
   void sendException(dynamic exception, StackTrace trace) {
     if (!suppressAnalytics)
-      _analytics.sendException(_shorten('${exception.runtimeType}; ${sanitizeStacktrace(trace)}'));
-  }
-
-  /// Shorten the exception information that is sent to Google Analytics
-  /// to get more information because Google Analytics truncates this to 100 char.
-  String _shorten(String text) {
-    /// TODO(danrubel) Gather more information about https://github.com/flutter/flutter/issues/5137
-    /// remove this code once that issue is resolved.
-    const String prefix = 'FileSystemException; dart:io/file_impl.dart 807 _RandomAccessFile.writeFromSync dart:io/stdio.dart ';
-    if (text.startsWith(prefix))
-      text = 'FSE:807 ' + text.substring(prefix.length);
-    return text;
+      _analytics.sendException('${exception.runtimeType}\n${sanitizeStacktrace(trace)}');
   }
 
   /// Fires whenever analytics data is sent over the network; public for testing.

--- a/packages/flutter_tools/pubspec.yaml
+++ b/packages/flutter_tools/pubspec.yaml
@@ -26,7 +26,7 @@ dependencies:
   process: 1.0.1
   pub_semver: ^1.0.0
   stack_trace: ^1.4.0
-  usage: ^2.2.1
+  usage: ^3.0.0
   vm_service_client: '0.2.2+4'
   web_socket_channel: ^1.0.4
   xml: ^2.4.1


### PR DESCRIPTION
- upgrade to the latest usage package (`3.0.0`)

This captures a fix to correctly record the locale for clients and it sends more information about captured exceptions. (the exception reporting mechanism may well be replaced by a better system going forward, but this allows us to capture a few more lines of an exception today)

@yjbanov 