### PR TITLE
Allow for customization of hintText style in InputField

### DIFF
--- a/packages/flutter/lib/src/material/input.dart
+++ b/packages/flutter/lib/src/material/input.dart
@@ -47,6 +47,7 @@ class InputField extends StatefulWidget {
     this.keyboardType: TextInputType.text,
     this.hintText,
     this.style,
+    this.hintStyle,
     this.obscureText: false,
     this.maxLines: 1,
     this.autofocus: false,
@@ -68,6 +69,12 @@ class InputField extends StatefulWidget {
 
   /// The style to use for the text being edited.
   final TextStyle style;
+
+  /// The style to use for the hint text.
+  ///
+  /// Defaults to the specified TextStyle in style with the hintColor from
+  /// the ThemeData
+  final TextStyle hintStyle;
 
   /// Whether to hide the text being edited (e.g., for passwords).
   ///
@@ -151,7 +158,8 @@ class _InputFieldState extends State<InputField> {
     ];
 
     if (config.hintText != null && value.text.isEmpty) {
-      TextStyle hintStyle = textStyle.copyWith(color: themeData.hintColor);
+      TextStyle hintStyle = config.hintStyle ??
+        textStyle.copyWith(color: themeData.hintColor);
       stackChildren.add(
         new Positioned(
           left: 0.0,

--- a/packages/flutter/test/widgets/input_test.dart
+++ b/packages/flutter/test/widgets/input_test.dart
@@ -766,6 +766,63 @@ void main() {
     checkText('Hello World');
   });
 
+  testWidgets('InputField with default hintStyle', (WidgetTester tester) async {
+    InputValue inputValue = InputValue.empty;
+    TextStyle textStyle = new TextStyle(
+      color: Colors.pink[500],
+      fontSize: 10.0,
+    );
+    ThemeData themeData = new ThemeData(
+      hintColor: Colors.blue[500],
+    );
+
+    Widget builder() {
+      return new Center(
+        child: new Theme(
+          data: themeData,
+          child: new Material(
+            child: new InputField(
+              value: inputValue,
+              hintText: 'Placeholder',
+              style: textStyle,
+            ),
+          ),
+        ),
+      );
+    }
+
+    await tester.pumpWidget(builder());
+
+    Text hintText = tester.widget(find.text('Placeholder'));
+    expect(hintText.style.color, themeData.hintColor);
+    expect(hintText.style.fontSize, textStyle.fontSize);
+  });
+
+  testWidgets('InputField with specified hintStyle', (WidgetTester tester) async {
+    InputValue inputValue = InputValue.empty;
+    TextStyle hintStyle = new TextStyle(
+      color: Colors.pink[500],
+      fontSize: 10.0,
+    );
+
+    Widget builder() {
+      return new Center(
+        child: new Material(
+          child: new InputField(
+            value: inputValue,
+            hintText: 'Placeholder',
+            hintStyle: hintStyle,
+          ),
+        ),
+      );
+    }
+
+    await tester.pumpWidget(builder());
+
+    Text hintText = tester.widget(find.text('Placeholder'));
+    expect(hintText.style, hintStyle);
+  });
+
   testWidgets('Input label text animates', (WidgetTester tester) async {
     GlobalKey inputKey = new GlobalKey();
     GlobalKey focusKey = new GlobalKey();


### PR DESCRIPTION
Since InputField is an un-opinionated (in terms of decoration) input field, it would be useful to be able to specify the hintText style as well.

Addresses #7850