### PR TITLE
Tiny simplification of launch scripts

### DIFF
--- a/bin/flutter
+++ b/bin/flutter
@@ -72,7 +72,7 @@ fi
     "$FLUTTER_ROOT/bin/internal/update_dart_sdk.sh"
 
     echo Building flutter tool...
-    (cd "$FLUTTER_TOOLS_DIR"; rm -f pubspec.lock; "$PUB" get --verbosity=error --no-packages-dir)
+    (cd "$FLUTTER_TOOLS_DIR"; "$PUB" upgrade --verbosity=error --no-packages-dir)
     "$DART" --snapshot="$SNAPSHOT_PATH" --packages="$FLUTTER_TOOLS_DIR/.packages" "$SCRIPT_PATH"
     echo $REVISION > "$STAMP_PATH"
   fi

--- a/bin/flutter.bat
+++ b/bin/flutter.bat
@@ -74,9 +74,8 @@ GOTO :after_subroutine
     CALL PowerShell.exe -ExecutionPolicy Bypass -Command "& '%FLUTTER_ROOT%/bin/internal/update_dart_sdk.ps1'"
 
     ECHO Updating flutter tool...
-    del "%flutter_tools_dir%\pubspec.lock"
     PUSHD "%flutter_tools_dir%"
-    CALL "%pub%" get --verbosity=error --no-packages-dir
+    CALL "%pub%" upgrade --verbosity=error --no-packages-dir
     POPD
     CALL "%dart%" --snapshot="%snapshot_path%" --packages="%flutter_tools_dir%\.packages" "%script_path%"
     >"%stamp_path%" ECHO %revision%


### PR DESCRIPTION
Call `pub upgrade` instead of manually deleting `pubspec.lock` and then calling `pub get`. `pub upgrade` ignores the `pubspec.lock`, but is otherwise identically to 'pub get' (https://www.dartlang.org/tools/pub/cmd/pub-upgrade).