### PR TITLE
improve the logger ui a bit for elapsed times

### DIFF
--- a/packages/flutter_tools/lib/src/android/gradle.dart
+++ b/packages/flutter_tools/lib/src/android/gradle.dart
@@ -151,7 +151,7 @@ Future<String> ensureGradlew() async {
         ? <String>[gradle, 'wrapper']
         : <String>[gradle, '-q', 'wrapper'];
     try {
-      Status status = logger.startProgress('Running \'gradle wrapper\'...');
+      Status status = logger.startProgress('Running \'gradle wrapper\'...', expectSlowOperation: true);
       int exitcode = await runCommandAndStreamOutput(
           command,
           workingDirectory: 'android',
@@ -204,7 +204,7 @@ Future<Null> buildGradleProject(BuildMode buildMode) async {
 
 Future<Null> buildGradleProjectV1(String gradlew) async {
   // Run 'gradlew build'.
-  Status status = logger.startProgress('Running \'gradlew build\'...');
+  Status status = logger.startProgress('Running \'gradlew build\'...', expectSlowOperation: true);
   int exitcode = await runCommandAndStreamOutput(
     <String>[fs.file(gradlew).absolute.path, 'build'],
     workingDirectory: 'android',
@@ -223,7 +223,7 @@ Future<Null> buildGradleProjectV2(String gradlew, String buildModeName) async {
   String assembleTask = "assemble${toTitleCase(buildModeName)}";
 
   // Run 'gradlew assemble<BuildMode>'.
-  Status status = logger.startProgress('Running \'gradlew $assembleTask\'...');
+  Status status = logger.startProgress('Running \'gradlew $assembleTask\'...', expectSlowOperation: true);
   String gradlewPath = fs.file(gradlew).absolute.path;
   List<String> command = logger.isVerbose
       ? <String>[gradlewPath, assembleTask]

--- a/packages/flutter_tools/lib/src/base/utils.dart
+++ b/packages/flutter_tools/lib/src/base/utils.dart
@@ -54,6 +54,19 @@ String toTitleCase(String str) {
 /// Return the plural of the given word (`cat(s)`).
 String pluralize(String word, int count) => count == 1 ? word : word + 's';
 
+/// Return the value printed with commas every 3 digits.
+String printWithSeparators(int value) {
+  String str = '$value';
+
+  int index = 3;
+  while (index < str.length) {
+    str = str.substring(0, str.length - index) + ',' + str.substring(str.length - index);
+    index += 4;
+  }
+
+  return str;
+}
+
 /// Return the name of an enum item.
 String getEnumName(dynamic enumItem) {
   String name = '$enumItem';

--- a/packages/flutter_tools/lib/src/cache.dart
+++ b/packages/flutter_tools/lib/src/cache.dart
@@ -224,7 +224,7 @@ class MaterialFonts {
   }
 
   Future<Null> download() {
-    Status status = logger.startProgress('Downloading Material fonts...');
+    Status status = logger.startProgress('Downloading Material fonts...', expectSlowOperation: true);
 
     Directory fontsDir = cache.getArtifactDirectory(kName);
     if (fontsDir.existsSync())
@@ -403,7 +403,7 @@ class FlutterEngine {
   }
 
   Future<Null> _downloadItem(String message, String url, Directory dest) {
-    Status status = logger.startProgress(message);
+    Status status = logger.startProgress(message, expectSlowOperation: true);
     return Cache._downloadFileToCache(Uri.parse(url), dest, true).then<Null>((Null value) {
       status.stop();
     }).whenComplete(() {

--- a/packages/flutter_tools/lib/src/commands/build_aot.dart
+++ b/packages/flutter_tools/lib/src/commands/build_aot.dart
@@ -52,7 +52,8 @@ class BuildAotCommand extends BuildSubCommand {
       throwToolExit('Unknown platform: $targetPlatform');
 
     String typeName = path.basename(tools.getEngineArtifactsDirectory(platform, getBuildMode()).path);
-    Status status = logger.startProgress('Building AOT snapshot in ${getModeName(getBuildMode())} mode ($typeName)...');
+    Status status = logger.startProgress('Building AOT snapshot in ${getModeName(getBuildMode())} mode ($typeName)...',
+        expectSlowOperation: true);
     String outputPath = await buildAotSnapshot(
       findMainDartFile(targetFile),
       platform,

--- a/packages/flutter_tools/lib/src/commands/build_apk.dart
+++ b/packages/flutter_tools/lib/src/commands/build_apk.dart
@@ -534,7 +534,8 @@ Future<Null> buildAndroid(
     throwToolExit('Failure building APK: unable to find components.');
 
   String typeName = path.basename(tools.getEngineArtifactsDirectory(platform, buildMode).path);
-  Status status = logger.startProgress('Building APK in ${getModeName(buildMode)} mode ($typeName)...');
+  Status status = logger.startProgress('Building APK in ${getModeName(buildMode)} mode ($typeName)...',
+      expectSlowOperation: true);
 
   if (flxPath != null && flxPath.isNotEmpty) {
     if (!fs.isFileSync(flxPath)) {

--- a/packages/flutter_tools/lib/src/commands/build_ios.dart
+++ b/packages/flutter_tools/lib/src/commands/build_ios.dart
@@ -65,7 +65,8 @@ class BuildIOSCommand extends BuildSubCommand {
     String logTarget = forSimulator ? 'simulator' : 'device';
 
     String typeName = path.basename(tools.getEngineArtifactsDirectory(TargetPlatform.ios, getBuildMode()).path);
-    Status status = logger.startProgress('Building $app for $logTarget ($typeName)...');
+    Status status = logger.startProgress('Building $app for $logTarget ($typeName)...',
+        expectSlowOperation: true);
     XcodeBuildResult result = await buildXcodeProject(
       app: app,
       mode: getBuildMode(),

--- a/packages/flutter_tools/lib/src/commands/daemon.dart
+++ b/packages/flutter_tools/lib/src/commands/daemon.dart
@@ -690,7 +690,7 @@ class NotifyingLogger extends Logger {
   }
 
   @override
-  Status startProgress(String message, { String progressId }) {
+  Status startProgress(String message, { String progressId, bool expectedFastAction: false }) {
     printStatus(message);
     return new Status();
   }
@@ -776,7 +776,7 @@ class _AppRunLogger extends Logger {
   Status _status;
 
   @override
-  Status startProgress(String message, { String progressId }) {
+  Status startProgress(String message, { String progressId, bool expectedFastAction: false }) {
     // Ignore nested progresses; return a no-op status object.
     if (_status != null)
       return new Status();
@@ -820,7 +820,7 @@ class _AppLoggerStatus implements Status {
   final String progressId;
 
   @override
-  void stop({ bool showElapsedTime: true }) {
+  void stop() {
     logger._status = null;
     _sendFinished();
   }

--- a/packages/flutter_tools/lib/src/commands/daemon.dart
+++ b/packages/flutter_tools/lib/src/commands/daemon.dart
@@ -690,7 +690,7 @@ class NotifyingLogger extends Logger {
   }
 
   @override
-  Status startProgress(String message, { String progressId, bool expectedFastAction: false }) {
+  Status startProgress(String message, { String progressId, bool expectSlowOperation: false }) {
     printStatus(message);
     return new Status();
   }
@@ -776,7 +776,7 @@ class _AppRunLogger extends Logger {
   Status _status;
 
   @override
-  Status startProgress(String message, { String progressId, bool expectedFastAction: false }) {
+  Status startProgress(String message, { String progressId, bool expectSlowOperation: false }) {
     // Ignore nested progresses; return a no-op status object.
     if (_status != null)
       return new Status();

--- a/packages/flutter_tools/lib/src/commands/update_packages.dart
+++ b/packages/flutter_tools/lib/src/commands/update_packages.dart
@@ -33,7 +33,7 @@ class UpdatePackagesCommand extends FlutterCommand {
   final bool hidden;
 
   Future<Null> _downloadCoverageData() async {
-    Status status = logger.startProgress("Downloading lcov data for package:flutter...");
+    Status status = logger.startProgress("Downloading lcov data for package:flutter...", expectSlowOperation: true);
     final List<int> data = await fetchUrl(Uri.parse('https://storage.googleapis.com/flutter_infra/flutter/coverage/lcov.info'));
     final String coverageDir = path.join(Cache.flutterRoot, 'packages/flutter/coverage');
     fs.file(path.join(coverageDir, 'lcov.base.info'))

--- a/packages/flutter_tools/lib/src/dart/pub.dart
+++ b/packages/flutter_tools/lib/src/dart/pub.dart
@@ -47,7 +47,8 @@ Future<Null> pubGet({
 
   if (!checkLastModified || _shouldRunPubGet(pubSpecYaml: pubSpecYaml, dotPackages: dotPackages)) {
     String command = upgrade ? 'upgrade' : 'get';
-    Status status = logger.startProgress("Running 'flutter packages $command' in ${path.basename(directory)}...");
+    Status status = logger.startProgress("Running 'flutter packages $command' in ${path.basename(directory)}...",
+        expectSlowOperation: true);
     int code = await runCommandAndStreamOutput(
       <String>[sdkBinaryName('pub'), '--verbosity=warning', command, '--no-packages-dir', '--no-precompile'],
       workingDirectory: directory,

--- a/packages/flutter_tools/lib/src/run_hot.dart
+++ b/packages/flutter_tools/lib/src/run_hot.dart
@@ -277,7 +277,7 @@ class HotRunner extends ResidentRunner {
       if (result != 0)
         return false;
     }
-    Status devFSStatus = logger.startProgress('Syncing files to device...');
+    Status devFSStatus = logger.startProgress('Syncing files to device...', expectedFastAction: true);
     int bytes = await _devFS.update(progressReporter: progressReporter,
                         bundle: assetBundle,
                         bundleDirty: rebuildBundle,
@@ -377,7 +377,8 @@ class HotRunner extends ResidentRunner {
   @override
   Future<OperationResult> restart({ bool fullRestart: false, bool pauseAfterRestart: false }) async {
     if (fullRestart) {
-      Status status = logger.startProgress('Performing full restart...', progressId: 'hot.restart');
+      Status status = logger.startProgress('Performing full restart...',
+          progressId: 'hot.restart', expectedFastAction: true);
       try {
         await _restartFromSources();
         status.stop();
@@ -388,7 +389,8 @@ class HotRunner extends ResidentRunner {
         rethrow;
       }
     } else {
-      Status status = logger.startProgress('Performing hot reload...', progressId: 'hot.reload');
+      Status status = logger.startProgress('Performing hot reload...',
+          progressId: 'hot.reload', expectedFastAction: true);
       try {
         OperationResult result = await _reloadSources(pause: pauseAfterRestart);
         status.stop();

--- a/packages/flutter_tools/lib/src/run_hot.dart
+++ b/packages/flutter_tools/lib/src/run_hot.dart
@@ -277,7 +277,7 @@ class HotRunner extends ResidentRunner {
       if (result != 0)
         return false;
     }
-    Status devFSStatus = logger.startProgress('Syncing files to device...', expectedFastAction: true);
+    Status devFSStatus = logger.startProgress('Syncing files to device...');
     int bytes = await _devFS.update(progressReporter: progressReporter,
                         bundle: assetBundle,
                         bundleDirty: rebuildBundle,
@@ -377,8 +377,7 @@ class HotRunner extends ResidentRunner {
   @override
   Future<OperationResult> restart({ bool fullRestart: false, bool pauseAfterRestart: false }) async {
     if (fullRestart) {
-      Status status = logger.startProgress('Performing full restart...',
-          progressId: 'hot.restart', expectedFastAction: true);
+      Status status = logger.startProgress('Performing full restart...', progressId: 'hot.restart');
       try {
         await _restartFromSources();
         status.stop();
@@ -389,8 +388,7 @@ class HotRunner extends ResidentRunner {
         rethrow;
       }
     } else {
-      Status status = logger.startProgress('Performing hot reload...',
-          progressId: 'hot.reload', expectedFastAction: true);
+      Status status = logger.startProgress('Performing hot reload...', progressId: 'hot.reload');
       try {
         OperationResult result = await _reloadSources(pause: pauseAfterRestart);
         status.stop();

--- a/packages/flutter_tools/test/utils_test.dart
+++ b/packages/flutter_tools/test/utils_test.dart
@@ -6,6 +6,19 @@ import 'package:flutter_tools/src/base/utils.dart';
 import 'package:test/test.dart';
 
 void main() {
+  group('utils', () {
+    test('printWithSeparators', () {
+      expect(printWithSeparators(3), '3');
+      expect(printWithSeparators(33), '33');
+      expect(printWithSeparators(333), '333');
+      expect(printWithSeparators(3333), '3,333');
+      expect(printWithSeparators(33333), '33,333');
+      expect(printWithSeparators(333333), '333,333');
+      expect(printWithSeparators(3333333), '3,333,333');
+      expect(printWithSeparators(33333333), '33,333,333');
+    });
+  });
+
   group('SettingsFile', () {
     test('parse', () {
       SettingsFile file = new SettingsFile.parse('''


### PR DESCRIPTION
Improve the logger ui a bit for elapsed times:
- log most things in seconds (`1.3s`). This works well for things that we expect to take on the order of seconds
- log others in ms (works well for fast things)
- use comma separators when the ms output gets above 1000
- remove a named param (`showElapsedTime`) that was never passed a false value to

This change makes things like the `flutter upgrade` screen print much more nicely.

<img width="438" alt="screen shot 2017-02-07 at 5 45 58 pm" src="https://cloud.githubusercontent.com/assets/1269969/22720325/f3f638bc-ed5e-11e6-9fa8-bd6ceb8f2504.png">

<img width="443" alt="screen shot 2017-02-07 at 5 47 37 pm" src="https://cloud.githubusercontent.com/assets/1269969/22720324/f3f548b2-ed5e-11e6-8973-75d1437a34eb.png">
