### PR TITLE
Use ListView in text_field_demo.dart

### DIFF
--- a/examples/flutter_gallery/lib/demo/text_field_demo.dart
+++ b/examples/flutter_gallery/lib/demo/text_field_demo.dart
@@ -110,7 +110,7 @@ class TextFieldDemoState extends State<TextFieldDemo> {
         key: _formKey,
         autovalidate: _autovalidate,
         onWillPop: _warnUserAboutInvalidData,
-        child: new Block(
+        child: new ListView(
           padding: const EdgeInsets.symmetric(horizontal: 16.0),
           children: <Widget>[
             new TextField(


### PR DESCRIPTION
Now that ensureVisible works, we can use ListView instead of Block in
this demo.