### PR TITLE
Prevent overflow of pagination bar with Ahem font

### DIFF
--- a/packages/flutter/test/material/paginated_data_table_test.dart
+++ b/packages/flutter/test/material/paginated_data_table_test.dart
@@ -32,7 +32,7 @@ class TestDataSource extends DataTableSource {
   }
 
   @override
-  int get rowCount => 500 * kDesserts.length;
+  int get rowCount => 50 * kDesserts.length;
 
   @override
   bool get isRowCountApproximate => false;


### PR DESCRIPTION
Once engine commit d49a6b110bced49fa318b0dd45bf409218df9ee5 rolls into
Flutter rolls in, we get correct font metrics for the Ahem font, used in
headless sky_shell test runs. Ahem has much wider glyphs than the system
font, which causes the PaginatedDataTable bottom bar to be much wider
and overflow the previous and next controls offscreen.

This commit reduces the number of rows such that the prev/next controls
are still just barely onscreen.