### PR TITLE
Revert "Make the text shorter so that it doesn't overflow (#7970)"

### DIFF
--- a/packages/flutter/test/material/data_table_test.dart
+++ b/packages/flutter/test/material/data_table_test.dart
@@ -20,11 +20,11 @@ void main() {
         },
         columns: <DataColumn>[
           new DataColumn(
-            label: new Text('N'),
+            label: new Text('Name'),
             tooltip: 'Name',
           ),
           new DataColumn(
-            label: new Text('Cc'),
+            label: new Text('Calories'),
             tooltip: 'Calories',
             numeric: true,
             onSort: (int columnIndex, bool ascending) {
@@ -64,12 +64,12 @@ void main() {
     expect(log, <String>['select-all: true']);
     log.clear();
 
-    await tester.tap(find.text('C'));
+    await tester.tap(find.text('Cupcake'));
 
-    expect(log, <String>['row-selected: C']);
+    expect(log, <String>['row-selected: Cupcake']);
     log.clear();
 
-    await tester.tap(find.text('Cc'));
+    await tester.tap(find.text('Calories'));
 
     expect(log, <String>['column-sort: 1 true']);
     log.clear();
@@ -78,7 +78,7 @@ void main() {
       home: new Material(child: buildTable(sortColumnIndex: 1))
     ));
     await tester.pumpUntilNoTransientCallbacks(const Duration(milliseconds: 200));
-    await tester.tap(find.text('Cc'));
+    await tester.tap(find.text('Calories'));
 
     expect(log, <String>['column-sort: 1 false']);
     log.clear();
@@ -95,7 +95,7 @@ void main() {
 
     await tester.tap(find.byType(Checkbox).last);
 
-    expect(log, <String>['row-selected: KK']);
+    expect(log, <String>['row-selected: KitKat']);
     log.clear();
   });
 }

--- a/packages/flutter/test/material/data_table_test_utils.dart
+++ b/packages/flutter/test/material/data_table_test_utils.dart
@@ -16,14 +16,14 @@ class Dessert {
 }
 
 final List<Dessert> kDesserts = <Dessert>[
-  new Dessert('FY',  159,  6.0,  24,  4.0,  87, 14,  1),
-  new Dessert('ICS', 237,  9.0,  37,  4.3, 129,  8,  1),
-  new Dessert('E',   262, 16.0,  24,  6.0, 337,  6,  7),
-  new Dessert('C',   305,  3.7,  67,  4.3, 413,  3,  8),
-  new Dessert('G',   356, 16.0,  49,  3.9, 327,  7, 16),
-  new Dessert('JB',  375,  0.0,  94,  0.0,  50,  0,  0),
-  new Dessert('L',   392,  0.2,  98,  0.0,  38,  0,  2),
-  new Dessert('H',   408,  3.2,  87,  6.5, 562,  0, 45),
-  new Dessert('D',   452, 25.0,  51,  4.9, 326,  2, 22),
-  new Dessert('KK',  518, 26.0,  65,  7.0,  54, 12,  6),
+  new Dessert('Frozen yogurt',                        159,  6.0,  24,  4.0,  87, 14,  1),
+  new Dessert('Ice cream sandwich',                   237,  9.0,  37,  4.3, 129,  8,  1),
+  new Dessert('Eclair',                               262, 16.0,  24,  6.0, 337,  6,  7),
+  new Dessert('Cupcake',                              305,  3.7,  67,  4.3, 413,  3,  8),
+  new Dessert('Gingerbread',                          356, 16.0,  49,  3.9, 327,  7, 16),
+  new Dessert('Jelly bean',                           375,  0.0,  94,  0.0,  50,  0,  0),
+  new Dessert('Lollipop',                             392,  0.2,  98,  0.0,  38,  0,  2),
+  new Dessert('Honeycomb',                            408,  3.2,  87,  6.5, 562,  0, 45),
+  new Dessert('Donut',                                452, 25.0,  51,  4.9, 326,  2, 22),
+  new Dessert('KitKat',                               518, 26.0,  65,  7.0,  54, 12,  6),
 ];

--- a/packages/flutter/test/material/paginated_data_table_test.dart
+++ b/packages/flutter/test/material/paginated_data_table_test.dart
@@ -88,8 +88,8 @@ void main() {
       home: buildTable(source),
     ));
 
-    expect(find.text('G (0)'), findsOneWidget);
-    expect(find.text('G (1)'), findsNothing);
+    expect(find.text('Gingerbread (0)'), findsOneWidget);
+    expect(find.text('Gingerbread (1)'), findsNothing);
     expect(find.text('42'), findsNWidgets(10));
 
     source.generation = 43;
@@ -118,9 +118,9 @@ void main() {
 
     await tester.pump();
 
-    expect(find.text('G (0)'), findsNothing);
-    expect(find.text('G (1)'), findsNothing);
-    expect(find.text('G (2)'), findsOneWidget);
+    expect(find.text('Gingerbread (0)'), findsNothing);
+    expect(find.text('Gingerbread (1)'), findsNothing);
+    expect(find.text('Gingerbread (2)'), findsOneWidget);
 
     await tester.tap(find.icon(Icons.adjust));
     expect(log, <String>['action: adjust']);
@@ -147,9 +147,9 @@ void main() {
           log.add('page-changed: $rowIndex');
         },
         columns: <DataColumn>[
-          new DataColumn(label: new Text('N')),
-          new DataColumn(label: new Text('Cc'), numeric: true),
-          new DataColumn(label: new Text('Ggg')),
+          new DataColumn(label: new Text('Name')),
+          new DataColumn(label: new Text('Calories'), numeric: true),
+          new DataColumn(label: new Text('Generation')),
         ],
       )
     ));
@@ -161,9 +161,9 @@ void main() {
 
     await tester.pump();
 
-    expect(find.text('FY (0)'), findsNothing);
-    expect(find.text('E (0)'), findsOneWidget);
-    expect(find.text('G (0)'), findsNothing);
+    expect(find.text('Frozen yogurt (0)'), findsNothing);
+    expect(find.text('Eclair (0)'), findsOneWidget);
+    expect(find.text('Gingerbread (0)'), findsNothing);
 
     await tester.tap(find.icon(Icons.chevron_left));
 
@@ -172,9 +172,9 @@ void main() {
 
     await tester.pump();
 
-    expect(find.text('FY (0)'), findsOneWidget);
-    expect(find.text('E (0)'), findsNothing);
-    expect(find.text('G (0)'), findsNothing);
+    expect(find.text('Frozen yogurt (0)'), findsOneWidget);
+    expect(find.text('Eclair (0)'), findsNothing);
+    expect(find.text('Gingerbread (0)'), findsNothing);
 
     await tester.tap(find.icon(Icons.chevron_left));
 


### PR DESCRIPTION
This reverts commit ea21d0c542d05a7738a8357db48fe9490c25c621 which
didn't resolve the pagination control overflow issue. Commit
7425940d5be153430f98aa5b0735545f4a4fc3e5 replaces this as an alternate
workaround. Once flutter/flutter#7980 is resolved, we should revert
7425940d5be153430f98aa5b0735545f4a4fc3e5 and scroll instead.