### PR TITLE
change a few more places to use the seconds display for log output

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_device.dart
+++ b/packages/flutter_tools/lib/src/android/android_device.dart
@@ -230,7 +230,7 @@ class AndroidDevice extends Device {
     if (!_checkForSupportedAdbVersion() || !_checkForSupportedAndroidVersion())
       return false;
 
-    Status status = logger.startProgress('Installing ${apk.apkPath}...');
+    Status status = logger.startProgress('Installing ${apk.apkPath}...', expectSlowOperation: true);
     String installOut = runCheckedSync(adbCommandForDevice(<String>['install', '-r', apk.apkPath]));
     status.stop();
     RegExp failureExp = new RegExp(r'^Failure.*$', multiLine: true);

--- a/packages/flutter_tools/lib/src/run_hot.dart
+++ b/packages/flutter_tools/lib/src/run_hot.dart
@@ -277,7 +277,8 @@ class HotRunner extends ResidentRunner {
       if (result != 0)
         return false;
     }
-    Status devFSStatus = logger.startProgress('Syncing files to device...');
+    Status devFSStatus = logger.startProgress('Syncing files to device...',
+        expectSlowOperation: true);
     int bytes = await _devFS.update(progressReporter: progressReporter,
                         bundle: assetBundle,
                         bundleDirty: rebuildBundle,


### PR DESCRIPTION
- change a few more places to use the seconds display for log output
- fix https://github.com/flutter/flutter/issues/7992

<img width="432" alt="screen shot 2017-02-08 at 3 12 28 pm" src="https://cloud.githubusercontent.com/assets/1269969/22762025/0f7516cc-ee12-11e6-8b89-b608512d151d.png">
