### PR TITLE
Port AppBar to Scrollable2

### DIFF
--- a/examples/flutter_gallery/lib/demo/contacts_demo.dart
+++ b/examples/flutter_gallery/lib/demo/contacts_demo.dart
@@ -87,15 +87,16 @@ class ContactsDemo extends StatefulWidget {
   ContactsDemoState createState() => new ContactsDemoState();
 }
 
+enum AppBarBehavior { normal, pinned, floating }
+
 class ContactsDemoState extends State<ContactsDemo> {
   static final GlobalKey<ScaffoldState> _scaffoldKey = new GlobalKey<ScaffoldState>();
-  static final GlobalKey<ScrollableState> _scrollableKey = new GlobalKey<ScrollableState>();
   final double _appBarHeight = 256.0;
-  AppBarBehavior _appBarBehavior = AppBarBehavior.under;
+
+  AppBarBehavior _appBarBehavior;
 
   @override
   Widget build(BuildContext context) {
-    final double statusBarHeight = MediaQuery.of(context).padding.top;
     return new Theme(
       data: new ThemeData(
         brightness: Brightness.light,
@@ -104,220 +105,226 @@ class ContactsDemoState extends State<ContactsDemo> {
       ),
       child: new Scaffold(
         key: _scaffoldKey,
-        scrollableKey: _scrollableKey,
-        appBarBehavior: _appBarBehavior,
-        appBar: new AppBar(
-          expandedHeight: _appBarHeight,
-          actions: <Widget>[
-            new IconButton(
-              icon: new Icon(Icons.create),
-              tooltip: 'Edit',
-              onPressed: () {
-                _scaffoldKey.currentState.showSnackBar(new SnackBar(
-                  content: new Text('This is actually just a demo. Editing isn\'t supported.')
-                ));
-              }
-            ),
-            new PopupMenuButton<AppBarBehavior>(
-              onSelected: (AppBarBehavior value) {
-                setState(() {
-                  _appBarBehavior = value;
-                });
-              },
-              itemBuilder: (BuildContext context) => <PopupMenuItem<AppBarBehavior>>[
-                new PopupMenuItem<AppBarBehavior>(
-                  value: AppBarBehavior.scroll,
-                  child: new Text('App bar scrolls away')
+        body: new CustomScrollView(
+          slivers: <Widget>[
+            new SliverAppBar(
+              expandedHeight: _appBarHeight,
+              pinned: _appBarBehavior == AppBarBehavior.pinned,
+              floating: _appBarBehavior == AppBarBehavior.floating,
+              actions: <Widget>[
+                new IconButton(
+                  icon: new Icon(Icons.create),
+                  tooltip: 'Edit',
+                  onPressed: () {
+                    _scaffoldKey.currentState.showSnackBar(new SnackBar(
+                      content: new Text('This is actually just a demo. Editing isn\'t supported.')
+                    ));
+                  },
                 ),
-                new PopupMenuItem<AppBarBehavior>(
-                  value: AppBarBehavior.under,
-                  child: new Text('App bar stays put')
-                )
-              ]
-            )
+                new PopupMenuButton<AppBarBehavior>(
+                  onSelected: (AppBarBehavior value) {
+                    setState(() {
+                      _appBarBehavior = value;
+                    });
+                  },
+                  itemBuilder: (BuildContext context) => <PopupMenuItem<AppBarBehavior>>[
+                    new PopupMenuItem<AppBarBehavior>(
+                      value: AppBarBehavior.normal,
+                      child: new Text('App bar scrolls away')
+                    ),
+                    new PopupMenuItem<AppBarBehavior>(
+                      value: AppBarBehavior.pinned,
+                      child: new Text('App bar stays put')
+                    ),
+                    new PopupMenuItem<AppBarBehavior>(
+                      value: AppBarBehavior.floating,
+                      child: new Text('App bar floats')
+                    ),
+                  ],
+                ),
+              ],
+              flexibleSpace: new FlexibleSpaceBar(
+                title: new Text('Ali Connors'),
+                background: new Stack(
+                  children: <Widget>[
+                    new Image.asset(
+                      'packages/flutter_gallery_assets/ali_connors.jpg',
+                      fit: ImageFit.cover,
+                      height: _appBarHeight,
+                    ),
+                    // This gradient ensures that the toolbar icons are distinct
+                    // against the background image.
+                    new DecoratedBox(
+                      decoration: const BoxDecoration(
+                        gradient: const LinearGradient(
+                          begin: const FractionalOffset(0.5, 0.0),
+                          end: const FractionalOffset(0.5, 0.30),
+                          colors: const <Color>[const Color(0x60000000), const Color(0x00000000)],
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+            new SliverList(
+              delegate: new SliverChildListDelegate(<Widget>[
+                new _ContactCategory(
+                  icon: Icons.call,
+                  children: <Widget>[
+                    new _ContactItem(
+                      icon: Icons.message,
+                      tooltip: 'Send message',
+                      onPressed: () {
+                        _scaffoldKey.currentState.showSnackBar(new SnackBar(
+                          content: new Text('Pretend that this opened your SMS application.')
+                        ));
+                      },
+                      lines: <String>[
+                        '(650) 555-1234',
+                        'Mobile',
+                      ],
+                    ),
+                    new _ContactItem(
+                      icon: Icons.message,
+                      tooltip: 'Send message',
+                      onPressed: () {
+                        _scaffoldKey.currentState.showSnackBar(new SnackBar(
+                          content: new Text('In this demo, this button doesn\'t do anything.')
+                        ));
+                      },
+                      lines: <String>[
+                        '(323) 555-6789',
+                        'Work',
+                      ],
+                    ),
+                    new _ContactItem(
+                      icon: Icons.message,
+                      tooltip: 'Send message',
+                      onPressed: () {
+                        _scaffoldKey.currentState.showSnackBar(new SnackBar(
+                          content: new Text('Imagine if you will, a messaging application.')
+                        ));
+                      },
+                      lines: <String>[
+                        '(650) 555-6789',
+                        'Home',
+                      ],
+                    ),
+                  ],
+                ),
+                new _ContactCategory(
+                  icon: Icons.contact_mail,
+                  children: <Widget>[
+                    new _ContactItem(
+                      icon: Icons.email,
+                      tooltip: 'Send personal e-mail',
+                      onPressed: () {
+                        _scaffoldKey.currentState.showSnackBar(new SnackBar(
+                          content: new Text('Here, your e-mail application would open.')
+                        ));
+                      },
+                      lines: <String>[
+                        'ali_connors@example.com',
+                        'Personal',
+                      ],
+                    ),
+                    new _ContactItem(
+                      icon: Icons.email,
+                      tooltip: 'Send work e-mail',
+                      onPressed: () {
+                        _scaffoldKey.currentState.showSnackBar(new SnackBar(
+                          content: new Text('This is a demo, so this button does not actually work.')
+                        ));
+                      },
+                      lines: <String>[
+                        'aliconnors@example.com',
+                        'Work',
+                      ],
+                    ),
+                  ],
+                ),
+                new _ContactCategory(
+                  icon: Icons.location_on,
+                  children: <Widget>[
+                    new _ContactItem(
+                      icon: Icons.map,
+                      tooltip: 'Open map',
+                      onPressed: () {
+                        _scaffoldKey.currentState.showSnackBar(new SnackBar(
+                          content: new Text('This would show a map of San Francisco.')
+                        ));
+                      },
+                      lines: <String>[
+                        '2000 Main Street',
+                        'San Francisco, CA',
+                        'Home',
+                      ],
+                    ),
+                    new _ContactItem(
+                      icon: Icons.map,
+                      tooltip: 'Open map',
+                      onPressed: () {
+                        _scaffoldKey.currentState.showSnackBar(new SnackBar(
+                          content: new Text('This would show a map of Mountain View.')
+                        ));
+                      },
+                      lines: <String>[
+                        '1600 Amphitheater Parkway',
+                        'Mountain View, CA',
+                        'Work',
+                      ],
+                    ),
+                    new _ContactItem(
+                      icon: Icons.map,
+                      tooltip: 'Open map',
+                      onPressed: () {
+                        _scaffoldKey.currentState.showSnackBar(new SnackBar(
+                          content: new Text('This would also show a map, if this was not a demo.')
+                        ));
+                      },
+                      lines: <String>[
+                        '126 Severyns Ave',
+                        'Mountain View, CA',
+                        'Jet Travel',
+                      ],
+                    ),
+                  ],
+                ),
+                new _ContactCategory(
+                  icon: Icons.today,
+                  children: <Widget>[
+                    new _ContactItem(
+                      lines: <String>[
+                        'Birthday',
+                        'January 9th, 1989',
+                      ],
+                    ),
+                    new _ContactItem(
+                      lines: <String>[
+                        'Wedding anniversary',
+                        'June 21st, 2014',
+                      ],
+                    ),
+                    new _ContactItem(
+                      lines: <String>[
+                        'First day in office',
+                        'January 20th, 2015',
+                      ],
+                    ),
+                    new _ContactItem(
+                      lines: <String>[
+                        'Last day in office',
+                        'August 9th, 2015',
+                      ],
+                    ),
+                  ],
+                ),
+              ]),
+            ),
           ],
-          flexibleSpace: new FlexibleSpaceBar(
-            title : new Text('Ali Connors'),
-            background: new Stack(
-              children: <Widget>[
-                new Image.asset(
-                  'packages/flutter_gallery_assets/ali_connors.jpg',
-                  fit: ImageFit.cover,
-                  height: _appBarHeight
-                ),
-                // This gradient ensures that the toolbar icons are distinct
-                // against the background image.
-                new DecoratedBox(
-                  decoration: new BoxDecoration(
-                    gradient: new LinearGradient(
-                      begin: const FractionalOffset(0.5, 0.0),
-                      end: const FractionalOffset(0.5, 0.30),
-                      colors: <Color>[const Color(0x60000000), const Color(0x00000000)]
-                    )
-                  )
-                )
-              ]
-            )
-          )
         ),
-        body: new Block(
-          padding: new EdgeInsets.only(top: _appBarHeight + statusBarHeight),
-          scrollableKey: _scrollableKey,
-          children: <Widget>[
-            new _ContactCategory(
-              icon: Icons.call,
-              children: <Widget>[
-                new _ContactItem(
-                  icon: Icons.message,
-                  tooltip: 'Send message',
-                  onPressed: () {
-                    _scaffoldKey.currentState.showSnackBar(new SnackBar(
-                      content: new Text('Pretend that this opened your SMS application.')
-                    ));
-                  },
-                  lines: <String>[
-                    '(650) 555-1234',
-                    'Mobile'
-                  ]
-                ),
-                new _ContactItem(
-                  icon: Icons.message,
-                  tooltip: 'Send message',
-                  onPressed: () {
-                    _scaffoldKey.currentState.showSnackBar(new SnackBar(
-                      content: new Text('In this demo, this button doesn\'t do anything.')
-                    ));
-                  },
-                  lines: <String>[
-                    '(323) 555-6789',
-                    'Work'
-                  ]
-                ),
-                new _ContactItem(
-                  icon: Icons.message,
-                  tooltip: 'Send message',
-                  onPressed: () {
-                    _scaffoldKey.currentState.showSnackBar(new SnackBar(
-                      content: new Text('Imagine if you will, a messaging application.')
-                    ));
-                  },
-                  lines: <String>[
-                    '(650) 555-6789',
-                    'Home'
-                  ]
-                ),
-              ]
-            ),
-            new _ContactCategory(
-              icon: Icons.contact_mail,
-              children: <Widget>[
-                new _ContactItem(
-                  icon: Icons.email,
-                  tooltip: 'Send personal e-mail',
-                  onPressed: () {
-                    _scaffoldKey.currentState.showSnackBar(new SnackBar(
-                      content: new Text('Here, your e-mail application would open.')
-                    ));
-                  },
-                  lines: <String>[
-                    'ali_connors@example.com',
-                    'Personal'
-                  ]
-                ),
-                new _ContactItem(
-                  icon: Icons.email,
-                  tooltip: 'Send work e-mail',
-                  onPressed: () {
-                    _scaffoldKey.currentState.showSnackBar(new SnackBar(
-                      content: new Text('This is a demo, so this button does not actually work.')
-                    ));
-                  },
-                  lines: <String>[
-                    'aliconnors@example.com',
-                    'Work'
-                  ]
-                )
-              ]
-            ),
-            new _ContactCategory(
-              icon: Icons.location_on,
-              children: <Widget>[
-                new _ContactItem(
-                  icon: Icons.map,
-                  tooltip: 'Open map',
-                  onPressed: () {
-                    _scaffoldKey.currentState.showSnackBar(new SnackBar(
-                      content: new Text('This would show a map of San Francisco.')
-                    ));
-                  },
-                  lines: <String>[
-                    '2000 Main Street',
-                    'San Francisco, CA',
-                    'Home'
-                  ]
-                ),
-                new _ContactItem(
-                  icon: Icons.map,
-                  tooltip: 'Open map',
-                  onPressed: () {
-                    _scaffoldKey.currentState.showSnackBar(new SnackBar(
-                      content: new Text('This would show a map of Mountain View.')
-                    ));
-                  },
-                  lines: <String>[
-                    '1600 Amphitheater Parkway',
-                    'Mountain View, CA',
-                    'Work'
-                  ]
-                ),
-                new _ContactItem(
-                  icon: Icons.map,
-                  tooltip: 'Open map',
-                  onPressed: () {
-                    _scaffoldKey.currentState.showSnackBar(new SnackBar(
-                      content: new Text('This would also show a map, if this was not a demo.')
-                    ));
-                  },
-                  lines: <String>[
-                    '126 Severyns Ave',
-                    'Mountain View, CA',
-                    'Jet Travel'
-                  ]
-                )
-              ]
-            ),
-            new _ContactCategory(
-              icon: Icons.today,
-              children: <Widget>[
-                new _ContactItem(
-                  lines: <String>[
-                    'Birthday',
-                    'January 9th, 1989'
-                  ]
-                ),
-                new _ContactItem(
-                  lines: <String>[
-                    'Wedding anniversary',
-                    'June 21st, 2014'
-                  ]
-                ),
-                new _ContactItem(
-                  lines: <String>[
-                    'First day in office',
-                    'January 20th, 2015'
-                  ]
-                ),
-                new _ContactItem(
-                  lines: <String>[
-                    'Last day in office',
-                    'August 9th, 2015'
-                  ]
-                )
-              ]
-            )
-          ]
-        )
-      )
+      ),
     );
   }
 }

--- a/examples/flutter_gallery/lib/demo/shrine/shrine_page.dart
+++ b/examples/flutter_gallery/lib/demo/shrine/shrine_page.dart
@@ -40,8 +40,8 @@ class ShrinePage extends StatefulWidget {
 class ShrinePageState extends State<ShrinePage> {
   int _appBarElevation = 0;
 
-  bool _handleScrollNotification(ScrollNotification notification) {
-    int elevation = notification.scrollable.scrollOffset <= 0.0 ? 0 : 1;
+  bool _handleScrollNotification(ScrollNotification2 notification) {
+    int elevation = notification.metrics.extentBefore <= 0.0 ? 0 : 1;
     if (elevation != _appBarElevation) {
       setState(() {
         _appBarElevation = elevation;
@@ -141,7 +141,7 @@ class ShrinePageState extends State<ShrinePage> {
         ]
       ),
       floatingActionButton: config.floatingActionButton,
-      body: new NotificationListener<ScrollNotification>(
+      body: new NotificationListener<ScrollNotification2>(
         onNotification: _handleScrollNotification,
         child: config.body
       )

--- a/examples/flutter_gallery/lib/gallery/home.dart
+++ b/examples/flutter_gallery/lib/gallery/home.dart
@@ -41,16 +41,13 @@ class _AppBarBackground extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    // TODO(abarth): Wire up to the parallax of the FlexibleSpaceBar in a way
-    // that doesn't pop during hero transition.
-    Animation<double> effectiveAnimation = kAlwaysDismissedAnimation;
     return new AnimatedBuilder(
-      animation: effectiveAnimation,
+      animation: animation,
       builder: (BuildContext context, Widget child) {
         return new Stack(
           children: _kBackgroundLayers.map((_BackgroundLayer layer) {
             return new Positioned(
-              top: -layer.parallaxTween.evaluate(effectiveAnimation),
+              top: -layer.parallaxTween.evaluate(animation),
               left: 0.0,
               right: 0.0,
               bottom: 0.0,
@@ -107,7 +104,6 @@ class GalleryHome extends StatefulWidget {
 
 class GalleryHomeState extends State<GalleryHome> with SingleTickerProviderStateMixin {
   static final GlobalKey<ScaffoldState> _scaffoldKey = new GlobalKey<ScaffoldState>();
-  static final GlobalKey<ScrollableState> _scrollableKey = new GlobalKey<ScrollableState>();
 
   AnimationController _controller;
 
@@ -153,10 +149,8 @@ class GalleryHomeState extends State<GalleryHome> with SingleTickerProviderState
 
   @override
   Widget build(BuildContext context) {
-    final double statusBarHeight = MediaQuery.of(context).padding.top;
     Widget home = new Scaffold(
       key: _scaffoldKey,
-      scrollableKey: _scrollableKey,
       drawer: new GalleryDrawer(
         useLightTheme: config.useLightTheme,
         onThemeChanged: config.onThemeChanged,
@@ -169,27 +163,19 @@ class GalleryHomeState extends State<GalleryHome> with SingleTickerProviderState
         onPlatformChanged: config.onPlatformChanged,
         onSendFeedback: config.onSendFeedback,
       ),
-      appBar: new AppBar(
-        expandedHeight: _kFlexibleSpaceMaxHeight,
-        flexibleSpace: new FlexibleSpaceBar(
-          title: new Text('Flutter Gallery'),
-          background: new Builder(
-            builder: (BuildContext context) {
-              return new _AppBarBackground(
-                animation: _scaffoldKey.currentState.appBarAnimation
-              );
-            }
-          )
-        )
-      ),
-      appBarBehavior: AppBarBehavior.under,
-      // The block's padding just exists to occupy the space behind the flexible app bar.
-      // As the block's padded region is scrolled upwards, the app bar's height will
-      // shrink keep it above the block content's and over the padded region.
-      body: new Block(
-       scrollableKey: _scrollableKey,
-       padding: new EdgeInsets.only(top: _kFlexibleSpaceMaxHeight + statusBarHeight),
-       children: _galleryListItems()
+      body: new CustomScrollView(
+        slivers: <Widget>[
+          new SliverAppBar(
+            pinned: true,
+            expandedHeight: _kFlexibleSpaceMaxHeight,
+            flexibleSpace: new FlexibleSpaceBar(
+              title: new Text('Flutter Gallery'),
+              // TODO(abarth): Wire up to the parallax in a way that doesn't pop during hero transition.
+              background: new _AppBarBackground(animation: kAlwaysDismissedAnimation),
+            ),
+          ),
+          new SliverList(delegate: new SliverChildListDelegate(_galleryListItems())),
+        ],
       )
     );
 

--- a/examples/flutter_gallery/test/example_code_display_test.dart
+++ b/examples/flutter_gallery/test/example_code_display_test.dart
@@ -21,11 +21,12 @@ void main() {
 
     // Scroll the Buttons demo into view so that a tap will succeed
     final Point allDemosOrigin = tester.getTopRight(find.text('Demos'));
-    final Point buttonsDemoOrigin = tester.getTopRight(find.text('Buttons'));
-    final double scrollDelta  = buttonsDemoOrigin.y - allDemosOrigin.y;
-    await tester.scrollAt(allDemosOrigin, new Offset(0.0, -scrollDelta));
-    await tester.pump(); // start the scroll
-    await tester.pump(const Duration(seconds: 1));
+    final Finder button = find.text('Buttons');
+    while (button.evaluate().isEmpty) {
+      await tester.scrollAt(allDemosOrigin, new Offset(0.0, -100.0));
+      await tester.pump(); // start the scroll
+      await tester.pump(const Duration(seconds: 1));
+    }
 
     // Launch the buttons demo and then prove that showing the example
     // code dialog does not crash.

--- a/examples/flutter_gallery/test/smoke_test.dart
+++ b/examples/flutter_gallery/test/smoke_test.dart
@@ -38,6 +38,7 @@ Future<Null> smokeDemo(WidgetTester tester, String routeName) async {
   await tester.pump(const Duration(seconds: 1)); // Wait until the demo has opened.
 
   expect(find.text(kCaption), findsNothing);
+  await tester.pump(const Duration(seconds: 1)); // Leave the demo on the screen briefly for manual testing.
 
   // Go back
   Finder backButton = find.byTooltip('Back');
@@ -61,22 +62,12 @@ Future<Null> runSmokeTest(WidgetTester tester) async {
 
   expect(find.text(kCaption), findsOneWidget);
 
-  final List<double> scrollDeltas = new List<double>();
-  double previousY = tester.getTopRight(find.text(demoCategories[0])).y;
   for (String routeName in routeNames) {
-    final double y = tester.getTopRight(findGalleryItemByRouteName(tester, routeName)).y;
-    scrollDeltas.add(previousY - y);
-    previousY = y;
-  }
-
-  // Launch each demo and then scroll that item out of the way.
-  for (int i = 0; i < routeNames.length; i += 1) {
-    final String routeName = routeNames[i];
+    Finder finder = findGalleryItemByRouteName(tester, routeName);
+    Scrollable2.ensureVisible(tester.element(finder), alignment: 0.5);
+    await tester.pump();
+    await tester.pumpUntilNoTransientCallbacks();
     await smokeDemo(tester, routeName);
-    await tester.scroll(findGalleryItemByRouteName(tester, routeName), new Offset(0.0, scrollDeltas[i]));
-    await tester.pump(); // start the scroll
-    await tester.pump(const Duration(milliseconds: 500)); // wait for overscroll to timeout, if necessary
-    await tester.pump(const Duration(seconds: 3)); // wait for overscroll to fade away, if necessary
     tester.binding.debugAssertNoTransientCallbacks('A transient callback was still active after leaving route $routeName');
   }
 

--- a/packages/flutter/lib/src/widgets/app.dart
+++ b/packages/flutter/lib/src/widgets/app.dart
@@ -155,9 +155,7 @@ class _WidgetsAppState extends State<WidgetsApp> implements WidgetsBindingObserv
     assert(mounted);
     NavigatorState navigator = _navigator.currentState;
     assert(navigator != null);
-    if (!await navigator.willPop())
-      return true;
-    return mounted && navigator.pop();
+    return await navigator.maybePop();
   }
 
   @override

--- a/packages/flutter/lib/src/widgets/primary_scroll_controller.dart
+++ b/packages/flutter/lib/src/widgets/primary_scroll_controller.dart
@@ -1,0 +1,34 @@
+// Copyright 2015 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/foundation.dart';
+
+import 'framework.dart';
+import 'scroll_controller.dart';
+
+class PrimaryScrollController extends InheritedWidget {
+  PrimaryScrollController({
+    Key key,
+    @required this.controller,
+    @required Widget child
+  }) : super(key: key, child: child) {
+    assert(controller != null);
+  }
+
+  final ScrollController controller;
+
+  static ScrollController of(BuildContext context) {
+    PrimaryScrollController result = context.inheritFromWidgetOfExactType(PrimaryScrollController);
+    return result?.controller;
+  }
+
+  @override
+  bool updateShouldNotify(PrimaryScrollController old) => controller != old.controller;
+
+  @override
+  void debugFillDescription(List<String> description) {
+    super.debugFillDescription(description);
+    description.add('$controller');
+  }
+}

--- a/packages/flutter/lib/src/widgets/scroll_controller.dart
+++ b/packages/flutter/lib/src/widgets/scroll_controller.dart
@@ -22,6 +22,14 @@ class ScrollController {
 
   final List<ScrollPosition> _positions = <ScrollPosition>[];
 
+  /// Whether any [ScrollPosition] objects have attached themselves to the
+  /// [ScrollController] using the [attach] method.
+  ///
+  /// If this is false, then members that interact with the [ScrollPosition],
+  /// such as [position], [offset], [animateTo], and [jumpTo], must not be
+  /// called.
+  bool get hasClients => _positions.isNotEmpty;
+
   ScrollPosition get position {
     assert(_positions.isNotEmpty, 'ScrollController not attached to any scroll views.');
     assert(_positions.length == 1, 'ScrollController attached to multiple scroll views.');

--- a/packages/flutter/lib/src/widgets/scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/scroll_view.dart
@@ -5,8 +5,9 @@
 import 'package:flutter/rendering.dart';
 import 'package:meta/meta.dart';
 
-import 'framework.dart';
 import 'basic.dart';
+import 'framework.dart';
+import 'primary_scroll_controller.dart';
 import 'scroll_controller.dart';
 import 'scroll_physics.dart';
 import 'scroll_position.dart';
@@ -20,11 +21,16 @@ abstract class ScrollView extends StatelessWidget {
     this.scrollDirection: Axis.vertical,
     this.reverse: false,
     this.controller,
+    this.primary: false,
     this.physics,
     this.shrinkWrap: false,
   }) : super(key: key) {
     assert(reverse != null);
     assert(shrinkWrap != null);
+    assert(primary != null);
+    assert(controller == null || !primary,
+           'Primary ScrollViews obtain their ScrollController via inheritance from a PrimaryScrollController widget. '
+           'You cannot both set primary to true and pass an explicit controller.');
   }
 
   final Axis scrollDirection;
@@ -32,6 +38,8 @@ abstract class ScrollView extends StatelessWidget {
   final bool reverse;
 
   final ScrollController controller;
+
+  final bool primary;
 
   final ScrollPhysics physics;
 
@@ -58,7 +66,7 @@ abstract class ScrollView extends StatelessWidget {
     AxisDirection axisDirection = getDirection(context);
     return new Scrollable2(
       axisDirection: axisDirection,
-      controller: controller,
+      controller: controller ?? (primary ? PrimaryScrollController.of(context) : null),
       physics: physics,
       viewportBuilder: (BuildContext context, ViewportOffset offset) {
         if (shrinkWrap) {
@@ -82,6 +90,14 @@ abstract class ScrollView extends StatelessWidget {
   void debugFillDescription(List<String> description) {
     super.debugFillDescription(description);
     description.add('$scrollDirection');
+    if (reverse)
+      description.add('reversed');
+    if (controller != null)
+      description.add('$controller');
+    if (primary)
+      description.add('using primary controller');
+    if (physics != null)
+      description.add('$physics');
     if (shrinkWrap)
       description.add('shrink-wrapping');
   }
@@ -93,6 +109,7 @@ class CustomScrollView extends ScrollView {
     Axis scrollDirection: Axis.vertical,
     bool reverse: false,
     ScrollController controller,
+    bool primary: false,
     ScrollPhysics physics,
     bool shrinkWrap: false,
     this.slivers: const <Widget>[],
@@ -101,6 +118,7 @@ class CustomScrollView extends ScrollView {
     scrollDirection: scrollDirection,
     reverse: reverse,
     controller: controller,
+    primary: primary,
     physics: physics,
     shrinkWrap: shrinkWrap,
   );
@@ -117,6 +135,7 @@ abstract class BoxScrollView extends ScrollView {
     Axis scrollDirection: Axis.vertical,
     bool reverse: false,
     ScrollController controller,
+    bool primary: false,
     ScrollPhysics physics,
     bool shrinkWrap: false,
     this.padding,
@@ -125,6 +144,7 @@ abstract class BoxScrollView extends ScrollView {
     scrollDirection: scrollDirection,
     reverse: reverse,
     controller: controller,
+    primary: primary,
     physics: physics,
     shrinkWrap: shrinkWrap,
   );
@@ -164,6 +184,7 @@ class ListView extends BoxScrollView {
     Axis scrollDirection: Axis.vertical,
     bool reverse: false,
     ScrollController controller,
+    bool primary: false,
     ScrollPhysics physics,
     bool shrinkWrap: false,
     EdgeInsets padding,
@@ -174,6 +195,7 @@ class ListView extends BoxScrollView {
     scrollDirection: scrollDirection,
     reverse: reverse,
     controller: controller,
+    primary: primary,
     physics: physics,
     shrinkWrap: shrinkWrap,
     padding: padding,
@@ -184,6 +206,7 @@ class ListView extends BoxScrollView {
     Axis scrollDirection: Axis.vertical,
     bool reverse: false,
     ScrollController controller,
+    bool primary: false,
     ScrollPhysics physics,
     bool shrinkWrap: false,
     EdgeInsets padding,
@@ -195,6 +218,7 @@ class ListView extends BoxScrollView {
     scrollDirection: scrollDirection,
     reverse: reverse,
     controller: controller,
+    primary: primary,
     physics: physics,
     shrinkWrap: shrinkWrap,
     padding: padding,
@@ -205,6 +229,7 @@ class ListView extends BoxScrollView {
     Axis scrollDirection: Axis.vertical,
     bool reverse: false,
     ScrollController controller,
+    bool primary: false,
     ScrollPhysics physics,
     bool shrinkWrap: false,
     EdgeInsets padding,
@@ -215,6 +240,7 @@ class ListView extends BoxScrollView {
     scrollDirection: scrollDirection,
     reverse: reverse,
     controller: controller,
+    primary: primary,
     physics: physics,
     shrinkWrap: shrinkWrap,
     padding: padding,
@@ -259,6 +285,7 @@ class GridView extends BoxScrollView {
     Axis scrollDirection: Axis.vertical,
     bool reverse: false,
     ScrollController controller,
+    bool primary: false,
     ScrollPhysics physics,
     bool shrinkWrap: false,
     EdgeInsets padding,
@@ -269,6 +296,7 @@ class GridView extends BoxScrollView {
     scrollDirection: scrollDirection,
     reverse: reverse,
     controller: controller,
+    primary: primary,
     physics: physics,
     shrinkWrap: shrinkWrap,
     padding: padding,
@@ -281,6 +309,7 @@ class GridView extends BoxScrollView {
     Axis scrollDirection: Axis.vertical,
     bool reverse: false,
     ScrollController controller,
+    bool primary: false,
     ScrollPhysics physics,
     bool shrinkWrap: false,
     EdgeInsets padding,
@@ -291,6 +320,7 @@ class GridView extends BoxScrollView {
     scrollDirection: scrollDirection,
     reverse: reverse,
     controller: controller,
+    primary: primary,
     physics: physics,
     shrinkWrap: shrinkWrap,
     padding: padding,
@@ -304,6 +334,7 @@ class GridView extends BoxScrollView {
     Axis scrollDirection: Axis.vertical,
     bool reverse: false,
     ScrollController controller,
+    bool primary: false,
     ScrollPhysics physics,
     bool shrinkWrap: false,
     EdgeInsets padding,
@@ -323,6 +354,7 @@ class GridView extends BoxScrollView {
     scrollDirection: scrollDirection,
     reverse: reverse,
     controller: controller,
+    primary: primary,
     physics: physics,
     shrinkWrap: shrinkWrap,
     padding: padding,
@@ -333,6 +365,7 @@ class GridView extends BoxScrollView {
     Axis scrollDirection: Axis.vertical,
     bool reverse: false,
     ScrollController controller,
+    bool primary: false,
     ScrollPhysics physics,
     bool shrinkWrap: false,
     EdgeInsets padding,
@@ -352,6 +385,7 @@ class GridView extends BoxScrollView {
     scrollDirection: scrollDirection,
     reverse: reverse,
     controller: controller,
+    primary: primary,
     physics: physics,
     shrinkWrap: shrinkWrap,
     padding: padding,

--- a/packages/flutter/lib/src/widgets/scrollable.dart
+++ b/packages/flutter/lib/src/widgets/scrollable.dart
@@ -86,7 +86,12 @@ class Scrollable2 extends StatefulWidget {
 
     Scrollable2State scrollable = Scrollable2.of(context);
     while (scrollable != null) {
-      futures.add(scrollable.position.ensureVisible(context.findRenderObject(), alignment: alignment));
+      futures.add(scrollable.position.ensureVisible(
+        context.findRenderObject(),
+        alignment: alignment,
+        duration: duration,
+        curve: curve,
+      ));
       context = scrollable.context;
       scrollable = Scrollable2.of(context);
     }

--- a/packages/flutter/lib/src/widgets/sliver_persistent_header.dart
+++ b/packages/flutter/lib/src/widgets/sliver_persistent_header.dart
@@ -12,7 +12,9 @@ abstract class SliverPersistentHeaderDelegate {
   /// const constructors so that they can be used in const expressions.
   const SliverPersistentHeaderDelegate();
 
-  Widget build(BuildContext context, double shrinkOffset);
+  Widget build(BuildContext context, double shrinkOffset, bool overlapsContent);
+
+  double get minExtent;
 
   double get maxExtent;
 
@@ -101,9 +103,9 @@ class _SliverPersistentHeaderElement extends RenderObjectElement {
 
   Element child;
 
-  void _build(double shrinkOffset) {
+  void _build(double shrinkOffset, bool overlapsContent) {
     owner.buildScope(this, () {
-      child = updateChild(child, widget.delegate.build(this, shrinkOffset), null);
+      child = updateChild(child, widget.delegate.build(this, shrinkOffset, overlapsContent), null);
     });
   }
 
@@ -161,17 +163,20 @@ abstract class _RenderSliverPersistentHeaderForWidgetsMixin implements RenderSli
   _SliverPersistentHeaderElement _element;
 
   @override
+  double get minExtent => _element.widget.delegate.minExtent;
+
+  @override
   double get maxExtent => _element.widget.delegate.maxExtent;
 
   @override
-  void updateChild(double shrinkOffset) {
+  void updateChild(double shrinkOffset, bool overlapsContent) {
     assert(_element != null);
-    _element._build(shrinkOffset);
+    _element._build(shrinkOffset, overlapsContent);
   }
 
   @protected
   void triggerRebuild() {
-    markNeedsUpdate();
+    markNeedsLayout();
   }
 }
 

--- a/packages/flutter/lib/widgets.dart
+++ b/packages/flutter/lib/widgets.dart
@@ -43,6 +43,7 @@ export 'src/widgets/page_view.dart';
 export 'src/widgets/pages.dart';
 export 'src/widgets/performance_overlay.dart';
 export 'src/widgets/placeholder.dart';
+export 'src/widgets/primary_scroll_controller.dart';
 export 'src/widgets/raw_keyboard_listener.dart';
 export 'src/widgets/routes.dart';
 export 'src/widgets/scroll_behavior.dart';

--- a/packages/flutter/test/material/will_pop_test.dart
+++ b/packages/flutter/test/material/will_pop_test.dart
@@ -13,12 +13,22 @@ class SamplePage extends StatefulWidget {
 }
 
 class SamplePageState extends State<SamplePage> {
+  ModalRoute<Null> _route;
+
+  Future<bool> _callback() async => willPopValue;
+
   @override
   void dependenciesChanged() {
     super.dependenciesChanged();
-    final ModalRoute<Null> route = ModalRoute.of(context);
-    if (route.isCurrent)
-      route.addScopedWillPopCallback(() async => willPopValue);
+    _route?.removeScopedWillPopCallback(_callback);
+    _route = ModalRoute.of(context);
+    _route?.addScopedWillPopCallback(_callback);
+  }
+
+  @override
+  void dispose() {
+    super.dispose();
+    _route?.removeScopedWillPopCallback(_callback);
   }
 
   @override
@@ -86,6 +96,9 @@ void main() {
         ),
       ),
     );
+
+    expect(find.byTooltip('Back'), findsNothing);
+    expect(find.text('Sample Page'), findsNothing);
 
     await tester.tap(find.text('X'));
     await tester.pump();

--- a/packages/flutter/test/widgets/slivers_appbar_floating_test.dart
+++ b/packages/flutter/test/widgets/slivers_appbar_floating_test.dart
@@ -189,8 +189,11 @@ class TestDelegate extends SliverPersistentHeaderDelegate {
   double get maxExtent => 200.0;
 
   @override
-  Widget build(BuildContext context, double shrinkOffset) {
-    return new Container(constraints: new BoxConstraints(minHeight: maxExtent / 2.0, maxHeight: maxExtent));
+  double get minExtent => 100.0;
+
+  @override
+  Widget build(BuildContext context, double shrinkOffset, bool overlapsContent) {
+    return new Container(constraints: new BoxConstraints(minHeight: minExtent, maxHeight: maxExtent));
   }
 
   @override

--- a/packages/flutter/test/widgets/slivers_appbar_pinned_test.dart
+++ b/packages/flutter/test/widgets/slivers_appbar_pinned_test.dart
@@ -184,8 +184,11 @@ class TestDelegate extends SliverPersistentHeaderDelegate {
   double get maxExtent => 200.0;
 
   @override
-  Widget build(BuildContext context, double shrinkOffset) {
-    return new Container(constraints: new BoxConstraints(minHeight: maxExtent / 2.0, maxHeight: maxExtent));
+  double get minExtent => 100.0;
+
+  @override
+  Widget build(BuildContext context, double shrinkOffset, bool overlapsContent) {
+    return new Container(constraints: new BoxConstraints(minHeight: minExtent, maxHeight: maxExtent));
   }
 
   @override

--- a/packages/flutter/test/widgets/slivers_appbar_scrolling_test.dart
+++ b/packages/flutter/test/widgets/slivers_appbar_scrolling_test.dart
@@ -74,7 +74,10 @@ class TestDelegate extends SliverPersistentHeaderDelegate {
   double get maxExtent => 200.0;
 
   @override
-  Widget build(BuildContext context, double shrinkOffset) {
+  double get minExtent => 200.0;
+
+  @override
+  Widget build(BuildContext context, double shrinkOffset, bool overlapsContent) {
     return new Container(height: maxExtent);
   }
 

--- a/packages/flutter/test/widgets/slivers_evil_test.dart
+++ b/packages/flutter/test/widgets/slivers_evil_test.dart
@@ -16,10 +16,13 @@ class TestSliverPersistentHeaderDelegate extends SliverPersistentHeaderDelegate 
   double get maxExtent => _maxExtent;
 
   @override
-  Widget build(BuildContext context, double shrinkOffset) {
+  double get minExtent => 16.0;
+
+  @override
+  Widget build(BuildContext context, double shrinkOffset, bool overlapsContent) {
     return new Column(
       children: <Widget>[
-        new Container(height: 16.0),
+        new Container(height: minExtent),
         new Expanded(child: new Container()),
       ],
     );


### PR DESCRIPTION
Move the back button and drawer opening logic into the app bar.

Move the tap-status-bar-to-scroll-to-top logic to using
ScrollControllers. Provide a PrimaryScrollController and a `primary`
flag on scroll views.

Make it possible to track when a route becomes or stops being poppable.