### PR TITLE
Improve doctor output when Xcode installation is incomplete

### DIFF
--- a/packages/flutter_tools/lib/src/ios/ios_workflow.dart
+++ b/packages/flutter_tools/lib/src/ios/ios_workflow.dart
@@ -87,10 +87,17 @@ class IOSWorkflow extends DoctorValidator implements Workflow {
       }
     } else {
       xcodeStatus = ValidationType.missing;
-      messages.add(new ValidationMessage.error(
-        'Xcode not installed; this is necessary for iOS development.\n'
-        'Download at https://developer.apple.com/xcode/download/.'
-      ));
+      if (xcode.xcodeSelectPath.isEmpty) {
+        messages.add(new ValidationMessage.error(
+            'Xcode not installed; this is necessary for iOS development.\n'
+            'Download at https://developer.apple.com/xcode/download/.'
+        ));
+      } else {
+        messages.add(new ValidationMessage.error(
+            'Xcode installation is incomplete; a full installation is necessary for iOS development.\n'
+            'Download at https://developer.apple.com/xcode/download/.'
+        ));
+      }
     }
 
     // Python dependencies installed

--- a/packages/flutter_tools/test/src/ios/ios_workflow_test.dart
+++ b/packages/flutter_tools/test/src/ios/ios_workflow_test.dart
@@ -20,6 +20,7 @@ void main() {
 
     testUsingContext('Emit missing status when nothing is installed', () async {
       when(xcode.isInstalled).thenReturn(false);
+      when(xcode.xcodeSelectPath).thenReturn('');
       IOSWorkflowTestTarget workflow = new IOSWorkflowTestTarget()
         ..hasPythonSixModule = false
         ..hasHomebrew = false
@@ -30,6 +31,15 @@ void main() {
 
     testUsingContext('Emits partial status when Xcode is not installed', () async {
       when(xcode.isInstalled).thenReturn(false);
+      when(xcode.xcodeSelectPath).thenReturn('');
+      IOSWorkflowTestTarget workflow = new IOSWorkflowTestTarget();
+      ValidationResult result = await workflow.validate();
+      expect(result.type, ValidationType.partial);
+    }, overrides: <Type, Generator>{ Xcode: () => xcode });
+
+    testUsingContext('Emits partial status when Xcode is partially installed', () async {
+      when(xcode.isInstalled).thenReturn(false);
+      when(xcode.xcodeSelectPath).thenReturn('/Library/Developer/CommandLineTools');
       IOSWorkflowTestTarget workflow = new IOSWorkflowTestTarget();
       ValidationResult result = await workflow.validate();
       expect(result.type, ValidationType.partial);


### PR DESCRIPTION
If the developer has only installed the Xcode command-line tools,
xcode-select and some other tools may be present, but xcodebuild will be
missing. In this case, output a slightly improved message indicating
that the installation is incomplete rather than missing.