### PR TITLE
use the intl package

### DIFF
--- a/packages/flutter_tools/lib/executable.dart
+++ b/packages/flutter_tools/lib/executable.dart
@@ -7,6 +7,7 @@ import 'dart:async';
 import 'package:args/command_runner.dart';
 import 'package:process/process.dart';
 import 'package:stack_trace/stack_trace.dart';
+import 'package:intl/intl_standalone.dart' as intl;
 
 import 'src/base/common.dart';
 import 'src/base/config.dart';
@@ -94,7 +95,7 @@ Future<Null> main(List<String> args) async {
   AppContext _executableContext = new AppContext();
 
   // Make the context current.
-  await _executableContext.runInZone(() {
+  await _executableContext.runInZone(() async {
     // Initialize the context with some defaults.
     // NOTE: Similar lists also exist in `bin/fuchsia_builder.dart` and
     // `test/src/context.dart`. If you update this list of defaults, look
@@ -119,6 +120,9 @@ Future<Null> main(List<String> args) async {
     context.putIfAbsent(IOSSimulatorUtils, () => new IOSSimulatorUtils());
     context.putIfAbsent(SimControl, () => new SimControl());
     context.putIfAbsent(Usage, () => new Usage());
+
+    // Initialize the system locale.
+    await intl.findSystemLocale();
 
     return Chain.capture<Future<Null>>(() async {
       await runner.run(args);

--- a/packages/flutter_tools/lib/src/base/logger.dart
+++ b/packages/flutter_tools/lib/src/base/logger.dart
@@ -5,11 +5,11 @@
 import 'dart:async';
 import 'dart:convert' show ASCII, LineSplitter;
 
+import 'package:intl/intl.dart';
 import 'package:stack_trace/stack_trace.dart';
 
 import 'io.dart';
 import 'platform.dart';
-import 'utils.dart';
 
 final AnsiTerminal terminal = new AnsiTerminal();
 
@@ -274,6 +274,8 @@ class _AnsiStatus extends Status {
   }
 
   static final List<String> _progress = <String>['-', r'\', '|', r'/', '-', r'\', '|', '/'];
+  static final NumberFormat secondsFormat = new NumberFormat('0.0');
+  static final NumberFormat millisecondsFormat = new NumberFormat.decimalPattern();
 
   final String message;
   final bool expectSlowOperation;
@@ -298,9 +300,9 @@ class _AnsiStatus extends Status {
 
     if (expectSlowOperation) {
       double seconds = stopwatch.elapsedMilliseconds / Duration.MILLISECONDS_PER_SECOND;
-      print('\b\b\b\b\b${seconds.toStringAsFixed(1).padLeft(4)}s');
+      print('\b\b\b\b\b${secondsFormat.format(seconds).padLeft(4)}s');
     } else {
-      print('\b\b\b\b\b${printWithSeparators(stopwatch.elapsedMilliseconds).toString().padLeft(3)}ms');
+      print('\b\b\b\b\b${millisecondsFormat.format(stopwatch.elapsedMilliseconds).padLeft(3)}ms');
     }
 
     timer.cancel();

--- a/packages/flutter_tools/lib/src/base/utils.dart
+++ b/packages/flutter_tools/lib/src/base/utils.dart
@@ -54,19 +54,6 @@ String toTitleCase(String str) {
 /// Return the plural of the given word (`cat(s)`).
 String pluralize(String word, int count) => count == 1 ? word : word + 's';
 
-/// Return the value printed with commas every 3 digits.
-String printWithSeparators(int value) {
-  String str = '$value';
-
-  int index = 3;
-  while (index < str.length) {
-    str = str.substring(0, str.length - index) + ',' + str.substring(str.length - index);
-    index += 4;
-  }
-
-  return str;
-}
-
 /// Return the name of an enum item.
 String getEnumName(dynamic enumItem) {
   String name = '$enumItem';
@@ -95,14 +82,7 @@ String getSizeAsMB(int bytesLength) {
   return '${(bytesLength / (1024 * 1024)).toStringAsFixed(1)}MB';
 }
 
-String getElapsedAsSeconds(Duration duration) {
-  double seconds = duration.inMilliseconds / Duration.MILLISECONDS_PER_SECOND;
-  return '${seconds.toStringAsFixed(2)} seconds';
-}
-
-String getElapsedAsMilliseconds(Duration duration) {
-  return '${duration.inMilliseconds} ms';
-}
+String getElapsedAsMilliseconds(Duration duration) => '${duration.inMilliseconds} ms';
 
 /// Return a relative path if [fullPath] is contained by the cwd, else return an
 /// absolute path.

--- a/packages/flutter_tools/test/utils_test.dart
+++ b/packages/flutter_tools/test/utils_test.dart
@@ -6,19 +6,6 @@ import 'package:flutter_tools/src/base/utils.dart';
 import 'package:test/test.dart';
 
 void main() {
-  group('utils', () {
-    test('printWithSeparators', () {
-      expect(printWithSeparators(3), '3');
-      expect(printWithSeparators(33), '33');
-      expect(printWithSeparators(333), '333');
-      expect(printWithSeparators(3333), '3,333');
-      expect(printWithSeparators(33333), '33,333');
-      expect(printWithSeparators(333333), '333,333');
-      expect(printWithSeparators(3333333), '3,333,333');
-      expect(printWithSeparators(33333333), '33,333,333');
-    });
-  });
-
   group('SettingsFile', () {
     test('parse', () {
       SettingsFile file = new SettingsFile.parse('''


### PR DESCRIPTION
- use the `intl` package when printing numbers for our elapsed times
- fix https://github.com/flutter/flutter/issues/7967
