### PR TITLE
Do not upload anything when tests fail on travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,10 +13,7 @@ install:
 before_script:
   - ./dev/bots/travis_setup.sh
 script:
-  - ./bin/cache/dart-sdk/bin/dart ./dev/bots/test.dart
-  - ./dev/bots/travis_upload.sh
-after_success:
-  - (cd packages/flutter && coveralls-lcov coverage/lcov.info)
+  - (./bin/cache/dart-sdk/bin/dart ./dev/bots/test.dart && ./dev/bots/travis_upload.sh)
 cache:
   directories:
     - $HOME/.pub-cache

--- a/dev/bots/travis_upload.sh
+++ b/dev/bots/travis_upload.sh
@@ -17,3 +17,5 @@ fi
 
 # generate the API docs, upload them
 ./dev/bots/docs.sh
+
+(cd packages/flutter && coveralls-lcov coverage/lcov.info)


### PR DESCRIPTION
This used to be the logic before I made the tests portable.