### PR TITLE
Make these microbenchmarks more holistic.

### DIFF
--- a/dev/benchmarks/microbenchmarks/lib/stocks/build_bench.dart
+++ b/dev/benchmarks/microbenchmarks/lib/stocks/build_bench.dart
@@ -1,4 +1,9 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 import 'dart:async';
+import 'dart:ui' as ui;
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/material.dart';
@@ -14,6 +19,11 @@ Future<Null> main() async {
   assert(false); // don't run this in checked mode! Use --release.
   stock_data.StockDataFetcher.actuallyFetchData = false;
 
+  // This allows us to call onBeginFrame even when the engine didn't request it,
+  // and have it actually do something:
+  LiveTestWidgetsFlutterBinding binding = TestWidgetsFlutterBinding.ensureInitialized();
+  binding.allowAllFrames = true;
+
   final Stopwatch watch = new Stopwatch();
   int iterations = 0;
 
@@ -21,18 +31,20 @@ Future<Null> main() async {
     stocks.main();
     await tester.pump(); // Start startup animation
     await tester.pump(const Duration(seconds: 1)); // Complete startup animation
-    await tester.tapAt(new Point(20.0, 20.0)); // Open drawer
+    await tester.tapAt(new Point(20.0, 40.0)); // Open drawer
     await tester.pump(); // Start drawer animation
     await tester.pump(const Duration(seconds: 1)); // Complete drawer animation
 
-
     final BuildableElement appState = tester.element(find.byType(stocks.StocksApp));
-    final BuildOwner buildOwner = WidgetsBinding.instance.buildOwner;
 
     watch.start();
     while (watch.elapsed < kBenchmarkTime) {
       appState.markNeedsBuild();
-      buildOwner.buildScope(WidgetsBinding.instance.renderViewElement);
+      // We don't use tester.pump() because we're trying to drive it in an
+      // artificially high load to find out how much CPU each frame takes.
+      // This differs from normal benchmarks which might look at how many
+      // frames are missed, etc.
+      ui.window.onBeginFrame(new Duration(milliseconds: iterations * 16));
       iterations += 1;
     }
     watch.stop();

--- a/dev/benchmarks/microbenchmarks/lib/stocks/layout_bench.dart
+++ b/dev/benchmarks/microbenchmarks/lib/stocks/layout_bench.dart
@@ -1,4 +1,9 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 import 'dart:async';
+import 'dart:ui' as ui;
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/material.dart';
@@ -13,6 +18,11 @@ const Duration kBenchmarkTime = const Duration(seconds: 15);
 Future<Null> main() async {
   stock_data.StockDataFetcher.actuallyFetchData = false;
 
+  // This allows us to call onBeginFrame even when the engine didn't request it,
+  // and have it actually do something:
+  LiveTestWidgetsFlutterBinding binding = TestWidgetsFlutterBinding.ensureInitialized();
+  binding.allowAllFrames = true;
+
   final Stopwatch watch = new Stopwatch();
   int iterations = 0;
 
@@ -20,7 +30,7 @@ Future<Null> main() async {
     stocks.main();
     await tester.pump(); // Start startup animation
     await tester.pump(const Duration(seconds: 1)); // Complete startup animation
-    await tester.tapAt(new Point(20.0, 20.0)); // Open drawer
+    await tester.tapAt(new Point(20.0, 40.0)); // Open drawer
     await tester.pump(); // Start drawer animation
     await tester.pump(const Duration(seconds: 1)); // Complete drawer animation
 
@@ -31,7 +41,11 @@ Future<Null> main() async {
     watch.start();
     while (watch.elapsed < kBenchmarkTime) {
       renderView.configuration = (iterations % 2 == 0) ? big : small;
-      RendererBinding.instance.pipelineOwner.flushLayout();
+      // We don't use tester.pump() because we're trying to drive it in an
+      // artificially high load to find out how much CPU each frame takes.
+      // This differs from normal benchmarks which might look at how many
+      // frames are missed, etc.
+      ui.window.onBeginFrame(new Duration(milliseconds: iterations * 16));
       iterations += 1;
     }
     watch.stop();


### PR DESCRIPTION
They previously were very sensitive to widgets like LayoutBuilder.

@yjbanov if this lands, it will represent a break in the benchmarks where we can't compare numbers before and after.