### PR TITLE
Fix cross-axis padding on reversed ListViews

### DIFF
--- a/packages/flutter/lib/src/rendering/sliver_padding.dart
+++ b/packages/flutter/lib/src/rendering/sliver_padding.dart
@@ -92,54 +92,6 @@ class RenderSliverPadding extends RenderSliver with RenderObjectWithChildMixin<R
     return null;
   }
 
-  /// The padding in the cross-axis direction on the side to the right when
-  /// facing away from the zero scroll offset in the scroll axis direction. (In
-  /// other words, for a vertical downwards-growing list, the padding on the
-  /// left.)
-  ///
-  /// Only valid after layout has started, since before layout the render object
-  /// doesn't know what direction it will be laid out in.
-  double get startPadding {
-    assert(constraints != null);
-    assert(constraints.axisDirection != null);
-    assert(constraints.growthDirection != null);
-    switch (applyGrowthDirectionToAxisDirection(constraints.axisDirection, constraints.growthDirection)) {
-      case AxisDirection.up:
-        return padding.right;
-      case AxisDirection.right:
-        return padding.top;
-      case AxisDirection.down:
-        return padding.left;
-      case AxisDirection.left:
-        return padding.bottom;
-    }
-    return null;
-  }
-
-  /// The padding in the cross-axis direction on the side to the left when
-  /// facing away from the zero scroll offset in the scroll axis direction. (In
-  /// other words, for a vertical downwards-growing list, the padding on the
-  /// right.)
-  ///
-  /// Only valid after layout has started, since before layout the render object
-  /// doesn't know what direction it will be laid out in.
-  double get endPadding {
-    assert(constraints != null);
-    assert(constraints.axisDirection != null);
-    assert(constraints.growthDirection != null);
-    switch (applyGrowthDirectionToAxisDirection(constraints.axisDirection, constraints.growthDirection)) {
-      case AxisDirection.up:
-        return padding.left;
-      case AxisDirection.right:
-        return padding.bottom;
-      case AxisDirection.down:
-        return padding.right;
-      case AxisDirection.left:
-        return padding.top;
-    }
-    return null;
-  }
-
   /// The total padding in the [constraints.axisDirection]. (In other words, for
   /// a vertical downwards-growing list, the sum of the padding on the top and
   /// bottom.)
@@ -149,13 +101,7 @@ class RenderSliverPadding extends RenderSliver with RenderObjectWithChildMixin<R
   double get mainAxisPadding {
     assert(constraints != null);
     assert(constraints.axis != null);
-    switch (constraints.axis) {
-      case Axis.horizontal:
-        return padding.left + padding.right;
-      case Axis.vertical:
-        return padding.top + padding.bottom;
-    }
-    return null;
+    return padding.along(constraints.axis);
   }
 
   /// The total padding in the cross-axis direction. (In other words, for a
@@ -169,9 +115,9 @@ class RenderSliverPadding extends RenderSliver with RenderObjectWithChildMixin<R
     assert(constraints.axis != null);
     switch (constraints.axis) {
       case Axis.horizontal:
-        return padding.top + padding.bottom;
+        return padding.vertical;
       case Axis.vertical:
-        return padding.left + padding.right;
+        return padding.horizontal;
     }
     return null;
   }
@@ -277,7 +223,18 @@ class RenderSliverPadding extends RenderSliver with RenderObjectWithChildMixin<R
   double childCrossAxisPosition(RenderSliver child) {
     assert(child != null);
     assert(child == this.child);
-    return startPadding;
+    assert(constraints != null);
+    assert(constraints.axisDirection != null);
+    assert(constraints.growthDirection != null);
+    switch (applyGrowthDirectionToAxisDirection(constraints.axisDirection, constraints.growthDirection)) {
+      case AxisDirection.up:
+      case AxisDirection.down:
+        return padding.left;
+      case AxisDirection.left:
+      case AxisDirection.right:
+        return padding.top;
+    }
+    return null;
   }
 
   @override

--- a/packages/flutter/test/widgets/scrollable_list_hit_testing_test.dart
+++ b/packages/flutter/test/widgets/scrollable_list_hit_testing_test.dart
@@ -120,33 +120,32 @@ void main() {
     List<int> tapped = <int>[];
 
     await tester.pumpWidget(
-      new ScrollableList(
-        key: new GlobalKey(),
+      new ListView(
         itemExtent: 290.0,
-        scrollAnchor: ViewportAnchor.end,
+        reverse: true,
         padding: const EdgeInsets.fromLTRB(5.0, 20.0, 15.0, 10.0),
         children: items.map((int item) {
           return new Container(
             child: new GestureDetector(
               onTap: () { tapped.add(item); },
-              child: new Text('$item')
-            )
+              child: new Text('$item'),
+            ),
           );
-        })
-      )
+        }).toList(),
+      ),
     );
     await tester.tapAt(const Point(200.0, 600.0 - 9.0));
     expect(tapped, equals(<int>[]));
     await tester.tapAt(const Point(200.0, 600.0 - 11.0));
-    expect(tapped, equals(<int>[5]));
+    expect(tapped, equals(<int>[0]));
     await tester.tapAt(const Point(4.0, 200.0));
-    expect(tapped, equals(<int>[5]));
+    expect(tapped, equals(<int>[0]));
     await tester.tapAt(const Point(6.0, 200.0));
-    expect(tapped, equals(<int>[5, 4]));
+    expect(tapped, equals(<int>[0, 1]));
     await tester.tapAt(const Point(800.0 - 14.0, 200.0));
-    expect(tapped, equals(<int>[5, 4]));
+    expect(tapped, equals(<int>[0, 1]));
     await tester.tapAt(const Point(800.0 - 16.0, 200.0));
-    expect(tapped, equals(<int>[5, 4, 4]));
+    expect(tapped, equals(<int>[0, 1, 1]));
   });
 
   testWidgets('Tap immediately following clamped overscroll', (WidgetTester tester) async {

--- a/packages/flutter/test/widgets/slivers_padding_test.dart
+++ b/packages/flutter/test/widgets/slivers_padding_test.dart
@@ -169,7 +169,6 @@ void main() {
       ],
     ));
     expect(tester.renderObject<RenderBox>(find.text('x')).localToGlobal(Point.origin), const Point(0.0, 200.0));
-    expect(tester.renderObject<RenderSliverPadding>(find.byType(SliverPadding)).endPadding, 100.0);
   });
 
   testWidgets('Viewport2+SliverPadding changing padding', (WidgetTester tester) async {
@@ -182,7 +181,6 @@ void main() {
       ],
     ));
     expect(tester.renderObject<RenderBox>(find.text('x')).localToGlobal(Point.origin), const Point(399.0, 0.0));
-    expect(tester.renderObject<RenderSliverPadding>(find.byType(SliverPadding)).endPadding, 1.0);
     await tester.pumpWidget(new Viewport2(
       axisDirection: AxisDirection.left,
       offset: new ViewportOffset.fixed(0.0),
@@ -192,7 +190,6 @@ void main() {
       ],
     ));
     expect(tester.renderObject<RenderBox>(find.text('x')).localToGlobal(Point.origin), const Point(409.0, 0.0));
-    expect(tester.renderObject<RenderSliverPadding>(find.byType(SliverPadding)).endPadding, 1.0);
   });
 
   testWidgets('Viewport2+SliverPadding changing direction', (WidgetTester tester) async {
@@ -203,7 +200,7 @@ void main() {
         new SliverPadding(padding: const EdgeInsets.fromLTRB(1.0, 2.0, 4.0, 8.0)),
       ],
     ));
-    expect(tester.renderObject<RenderSliverPadding>(find.byType(SliverPadding)).endPadding, 1.0);
+    expect(tester.renderObject<RenderSliverPadding>(find.byType(SliverPadding)).afterPadding, 2.0);
     await tester.pumpWidget(new Viewport2(
       axisDirection: AxisDirection.down,
       offset: new ViewportOffset.fixed(0.0),
@@ -211,7 +208,7 @@ void main() {
         new SliverPadding(padding: const EdgeInsets.fromLTRB(1.0, 2.0, 4.0, 8.0)),
       ],
     ));
-    expect(tester.renderObject<RenderSliverPadding>(find.byType(SliverPadding)).endPadding, 4.0);
+    expect(tester.renderObject<RenderSliverPadding>(find.byType(SliverPadding)).afterPadding, 8.0);
     await tester.pumpWidget(new Viewport2(
       axisDirection: AxisDirection.right,
       offset: new ViewportOffset.fixed(0.0),
@@ -219,7 +216,7 @@ void main() {
         new SliverPadding(padding: const EdgeInsets.fromLTRB(1.0, 2.0, 4.0, 8.0)),
       ],
     ));
-    expect(tester.renderObject<RenderSliverPadding>(find.byType(SliverPadding)).endPadding, 8.0);
+    expect(tester.renderObject<RenderSliverPadding>(find.byType(SliverPadding)).afterPadding, 4.0);
     await tester.pumpWidget(new Viewport2(
       axisDirection: AxisDirection.left,
       offset: new ViewportOffset.fixed(0.0),
@@ -227,7 +224,7 @@ void main() {
         new SliverPadding(padding: const EdgeInsets.fromLTRB(1.0, 2.0, 4.0, 8.0)),
       ],
     ));
-    expect(tester.renderObject<RenderSliverPadding>(find.byType(SliverPadding)).endPadding, 2.0);
+    expect(tester.renderObject<RenderSliverPadding>(find.byType(SliverPadding)).afterPadding, 1.0);
     await tester.pumpWidget(new Viewport2(
       axisDirection: AxisDirection.left,
       offset: new ViewportOffset.fixed(99999.9),
@@ -235,6 +232,6 @@ void main() {
         new SliverPadding(padding: const EdgeInsets.fromLTRB(1.0, 2.0, 4.0, 8.0)),
       ],
     ));
-    expect(tester.renderObject<RenderSliverPadding>(find.byType(SliverPadding)).endPadding, 2.0);
+    expect(tester.renderObject<RenderSliverPadding>(find.byType(SliverPadding)).afterPadding, 1.0);
   });
 }


### PR DESCRIPTION
Previously the "left" padding was applied on the right when a vertical
list view was reversed.