### PR TITLE
Positioned.fromRelativeRect

### DIFF
--- a/packages/flutter/lib/src/rendering/stack.dart
+++ b/packages/flutter/lib/src/rendering/stack.dart
@@ -68,12 +68,12 @@ class RelativeRect {
 
   /// Returns a new rectangle object translated by the given offset.
   RelativeRect shift(Offset offset) {
-    return new RelativeRect.fromLTRB(left + offset.dx, top + offset.dy, right + offset.dx, bottom + offset.dy);
+    return new RelativeRect.fromLTRB(left + offset.dx, top + offset.dy, right - offset.dx, bottom - offset.dy);
   }
 
   /// Returns a new rectangle with edges moved outwards by the given delta.
   RelativeRect inflate(double delta) {
-    return new RelativeRect.fromLTRB(left - delta, top - delta, right + delta, bottom + delta);
+    return new RelativeRect.fromLTRB(left - delta, top - delta, right - delta, bottom - delta);
   }
 
   /// Returns a new rectangle with edges moved inwards by the given delta.
@@ -91,7 +91,7 @@ class RelativeRect {
     );
   }
 
-  /// Convert this RelativeRect to a Rect, in the coordinate space of the container.
+  /// Convert this [RelativeRect] to a [Rect], in the coordinate space of the container.
   Rect toRect(Rect container) {
     return new Rect.fromLTRB(left, top, container.width - right, container.height - bottom);
   }

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -1658,8 +1658,8 @@ class Positioned extends ParentDataWidget<Stack> {
   /// set to null.
   Positioned.fromRect({
     Key key,
-    Widget child,
-    Rect rect
+    Rect rect,
+    @required Widget child,
   }) : left = rect.left,
        top = rect.top,
        width = rect.width,
@@ -1668,15 +1668,31 @@ class Positioned extends ParentDataWidget<Stack> {
        bottom = null,
        super(key: key, child: child);
 
+  /// Creates a Positioned object with the values from the given [RelativeRect].
+  ///
+  /// This sets the [left], [top], [right], and [bottom] properties from the
+  /// given [RelativeRect]. The [height] and [width] properties are set to null.
+  Positioned.fromRelativeRect({
+    Key key,
+    RelativeRect rect,
+    @required Widget child,
+  }) : left = rect.left,
+       top = rect.top,
+       right = rect.right,
+       bottom = rect.bottom,
+       width = null,
+       height = null,
+       super(key: key, child: child);
+
   /// Creates a Positioned object with [left], [top], [right], and [bottom] set
   /// to 0.0 unless a value for them is passed.
   Positioned.fill({
     Key key,
-    Widget child,
     this.left: 0.0,
     this.top: 0.0,
     this.right: 0.0,
-    this.bottom: 0.0
+    this.bottom: 0.0,
+    @required Widget child,
   }) : width = null,
        height = null,
        super(key: key, child: child);

--- a/packages/flutter/lib/src/widgets/transitions.dart
+++ b/packages/flutter/lib/src/widgets/transitions.dart
@@ -321,11 +321,8 @@ class PositionedTransition extends AnimatedWidget {
 
   @override
   Widget build(BuildContext context) {
-    return new Positioned(
-      top: rect.value.top,
-      right: rect.value.right,
-      bottom: rect.value.bottom,
-      left: rect.value.left,
+    return new Positioned.fromRelativeRect(
+      rect: rect.value,
       child: child,
     );
   }

--- a/packages/flutter/test/rendering/relative_rect_test.dart
+++ b/packages/flutter/test/rendering/relative_rect_test.dart
@@ -1,0 +1,47 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/rendering.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('RelativeRect.==', () {
+    RelativeRect r = const RelativeRect.fromLTRB(10.0, 20.0, 30.0, 40.0);
+    expect(r, new RelativeRect.fromSize(new Rect.fromLTWH(10.0, 20.0, 0.0, 0.0), const Size(40.0, 60.0)));
+  });
+  test('RelativeRect.shift', () {
+    RelativeRect r1 = const RelativeRect.fromLTRB(10.0, 20.0, 30.0, 40.0);
+    RelativeRect r2 = r1.shift(const Offset(5.0, 50.0));
+    expect(r2, const RelativeRect.fromLTRB(15.0, 70.0, 25.0, -10.0));
+  });
+  test('RelativeRect.inflate', () {
+    RelativeRect r1 = const RelativeRect.fromLTRB(10.0, 20.0, 30.0, 40.0);
+    RelativeRect r2 = r1.inflate(5.0);
+    expect(r2, const RelativeRect.fromLTRB(5.0, 15.0, 25.0, 35.0));
+  });
+  test('RelativeRect.deflate', () {
+    RelativeRect r1 = const RelativeRect.fromLTRB(10.0, 20.0, 30.0, 40.0);
+    RelativeRect r2 = r1.deflate(5.0);
+    expect(r2, const RelativeRect.fromLTRB(15.0, 25.0, 35.0, 45.0));
+  });
+  test('RelativeRect.intersect', () {
+    RelativeRect r1 = const RelativeRect.fromLTRB(10.0, 20.0, 30.0, 40.0);
+    RelativeRect r2 = const RelativeRect.fromLTRB(0.0, 30.0, 60.0, 0.0);
+    RelativeRect r3 = r1.intersect(r2);
+    RelativeRect r4 = r2.intersect(r1);
+    expect(r3, r4);
+    expect(r3, const RelativeRect.fromLTRB(10.0, 30.0, 60.0, 40.0));
+  });
+  test('RelativeRect.toRect', () {
+    RelativeRect r1 = const RelativeRect.fromLTRB(10.0, 20.0, 30.0, 40.0);
+    Rect r2 = r1.toRect(new Rect.fromLTRB(10.0, 20.0, 90.0, 180.0));
+    expect(r2, new Rect.fromLTRB(10.0, 20.0, 50.0, 120.0));
+  });
+  test('RelativeRect.lerp', () {
+    RelativeRect r1 = RelativeRect.fill;
+    RelativeRect r2 = const RelativeRect.fromLTRB(10.0, 20.0, 30.0, 40.0);
+    RelativeRect r3 = RelativeRect.lerp(r1, r2, 0.5);
+    expect(r3, const RelativeRect.fromLTRB(5.0, 10.0, 15.0, 20.0));
+  });
+}

--- a/packages/flutter/test/widgets/positioned_test.dart
+++ b/packages/flutter/test/widgets/positioned_test.dart
@@ -9,9 +9,54 @@ import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 
 void main() {
+  testWidgets('Positioned constructors', (WidgetTester tester) async {
+    Widget child = new Container();
+    Positioned a = new Positioned(
+      left: 101.0,
+      right: 201.0,
+      top: 301.0,
+      bottom: 401.0,
+      child: child,
+    );
+    expect(a.left, 101.0);
+    expect(a.right, 201.0);
+    expect(a.top, 301.0);
+    expect(a.bottom, 401.0);
+    expect(a.width, null);
+    expect(a.height, null);
+    Positioned b = new Positioned.fromRect(
+      rect: new Rect.fromLTRB(
+        102.0,
+        302.0,
+        202.0,
+        502.0,
+      ),
+      child: child,
+    );
+    expect(b.left, 102.0);
+    expect(b.right, null);
+    expect(b.top, 302.0);
+    expect(b.bottom, null);
+    expect(b.width, 100.0);
+    expect(b.height, 200.0);
+    Positioned c = new Positioned.fromRelativeRect(
+      rect: new RelativeRect.fromLTRB(
+        103.0,
+        303.0,
+        203.0,
+        403.0,
+      ),
+      child: child,
+    );
+    expect(c.left, 103.0);
+    expect(c.right, 203.0);
+    expect(c.top, 303.0);
+    expect(c.bottom, 403.0);
+    expect(c.width, null);
+    expect(c.height, null);
+  });
 
   testWidgets('Can animate position data', (WidgetTester tester) async {
-
     final RelativeRectTween rect = new RelativeRectTween(
       begin: new RelativeRect.fromRect(
         new Rect.fromLTRB(10.0, 20.0, 20.0, 30.0),
@@ -82,5 +127,4 @@ void main() {
     await tester.pump();
     expect(completer.isCompleted, isTrue);
   });
-
 }


### PR DESCRIPTION
Since RelativeRect's whole purpose in life is to make work with Stack
easier, it's silly that you can't directly use it with Positioned.

Also, tests for RelativeRect.
And fixes for the bugs that found...