### PR TITLE
Emit additional Xcode settings in flutter create

### DIFF
--- a/packages/flutter_tools/lib/src/commands/create.dart
+++ b/packages/flutter_tools/lib/src/commands/create.dart
@@ -8,10 +8,13 @@ import '../android/android.dart' as android;
 import '../base/common.dart';
 import '../base/file_system.dart';
 import '../base/utils.dart';
+import '../build_info.dart';
 import '../cache.dart';
 import '../dart/pub.dart';
 import '../doctor.dart';
+import '../flx.dart' as flx;
 import '../globals.dart';
+import '../ios/xcodeproj.dart';
 import '../runner/flutter_command.dart';
 import '../template.dart';
 
@@ -99,7 +102,8 @@ class CreateCommand extends FlutterCommand {
     );
     printStatus('Wrote $generatedCount files.');
 
-    printStatus('');
+    updateXcodeGeneratedProperties(dirPath, BuildMode.debug, flx.defaultMainPath);
+    printStatus('Wrote Xcode settings.');
 
     if (argResults['pub'])
       await pubGet(directory: dirPath);

--- a/packages/flutter_tools/lib/src/commands/create.dart
+++ b/packages/flutter_tools/lib/src/commands/create.dart
@@ -101,9 +101,9 @@ class CreateCommand extends FlutterCommand {
       renderDriverTest: argResults['with-driver-test']
     );
     printStatus('Wrote $generatedCount files.');
+    printStatus('');
 
     updateXcodeGeneratedProperties(dirPath, BuildMode.debug, flx.defaultMainPath);
-    printStatus('Wrote Xcode settings.');
 
     if (argResults['pub'])
       await pubGet(directory: dirPath);

--- a/packages/flutter_tools/lib/src/ios/xcodeproj.dart
+++ b/packages/flutter_tools/lib/src/ios/xcodeproj.dart
@@ -20,8 +20,7 @@ void updateXcodeGeneratedProperties(String projectPath, BuildMode mode, String t
   localsBuffer.writeln('FLUTTER_ROOT=$flutterRoot');
 
   // This holds because requiresProjectRoot is true for this command
-  String applicationRoot = fs.path.normalize(fs.currentDirectory.path);
-  localsBuffer.writeln('FLUTTER_APPLICATION_PATH=$applicationRoot');
+  localsBuffer.writeln('FLUTTER_APPLICATION_PATH=${fs.path.normalize(projectPath)}');
 
   // Relative to FLUTTER_APPLICATION_PATH, which is [Directory.current].
   localsBuffer.writeln('FLUTTER_TARGET=$target');

--- a/packages/flutter_tools/test/create_test.dart
+++ b/packages/flutter_tools/test/create_test.dart
@@ -66,6 +66,15 @@ void main() {
           expect(original, formatted, reason: file.path);
         }
       }
+
+      // Generated Xcode settings
+      String xcodeConfigPath = fs.path.join('ios', 'Flutter', 'Generated.xcconfig');
+      expectExists(xcodeConfigPath);
+      File xcodeConfigFile = fs.file(fs.path.join(temp.path, xcodeConfigPath));
+      String xcodeConfig = xcodeConfigFile.readAsStringSync();
+      expect(xcodeConfig, contains('FLUTTER_ROOT='));
+      expect(xcodeConfig, contains('FLUTTER_APPLICATION_PATH='));
+      expect(xcodeConfig, contains('FLUTTER_FRAMEWORK_DIR='));
     });
 
     // Verify that we can regenerate over an existing project.


### PR DESCRIPTION
On flutter run, we update ios/Flutter/Generated.xcconfig with various
Flutter-specific settings required by xcode_backend.sh during a build
from Xcode. These settings need to be present at the time the project is
loaded since Xcode doesn't pick up live updates to these files.

Without these settings, Xcode fails to locate xcode_backend.sh itself,
causing the build to fail until the Xcode project has been closed and
re-opened. This also prevents Xcode's project updater from 'helpfully'
suggesting to clean up and delete the Generated.xcconfig file.