### PR TITLE
Update path to built .apk.

### DIFF
--- a/dev/devicelab/lib/tasks/size_tests.dart
+++ b/dev/devicelab/lib/tasks/size_tests.dart
@@ -36,7 +36,7 @@ TaskFunction createBasicMaterialAppSizeTest() {
           releaseSizeInBytes = await file('${sampleDir.path}/build/app.ipa').length();
         } else {
           await flutter('build', options: <String>['apk', '--release']);
-          releaseSizeInBytes = await file('${sampleDir.path}/build/app.apk').length();
+          releaseSizeInBytes = await file('${sampleDir.path}/android/app/build/outputs/apk/app.apk').length();
         }
       });
     });


### PR DESCRIPTION
After switching the new project template to be Gradle-based, the .apk output is in android/app/build/outputs/apk. Update the basic_material_app__size test to look there.