### PR TITLE
Formally deprecate Block and ScrollableViewport

### DIFF
--- a/dev/manual_tests/overlay_geometry.dart
+++ b/dev/manual_tests/overlay_geometry.dart
@@ -136,7 +136,6 @@ class OverlayGeometryAppState extends State<OverlayGeometryApp> {
   List<CardModel> cardModels;
   Map<MarkerType, Point> markers = new Map<MarkerType, Point>();
   double markersScrollOffset = 0.0;
-  ScrollListener scrollListener;
 
   @override
   void initState() {
@@ -173,8 +172,8 @@ class OverlayGeometryAppState extends State<OverlayGeometryApp> {
       markers[MarkerType.topLeft] = box.localToGlobal(new Point(0.0, 0.0));
       final Size size = box.size;
       markers[MarkerType.bottomRight] = box.localToGlobal(new Point(size.width, size.height));
-      final ScrollableState scrollable = Scrollable.of(target.currentContext);
-      markersScrollOffset = scrollable.scrollOffset;
+      final Scrollable2State scrollable = Scrollable2.of(target.currentContext);
+      markersScrollOffset = scrollable.position.pixels;
     });
   }
 

--- a/examples/flutter_gallery/lib/demo/pesto_demo.dart
+++ b/examples/flutter_gallery/lib/demo/pesto_demo.dart
@@ -29,20 +29,16 @@ final ThemeData _kTheme = new ThemeData(
 );
 
 class PestoHome extends StatelessWidget {
-  static final GlobalKey<ScrollableState> scrollableKey = new GlobalKey<ScrollableState>();
-
   @override
   Widget build(BuildContext context) {
-    return new RecipeGridPage(recipes: kPestoRecipes, scrollableKey: scrollableKey);
+    return new RecipeGridPage(recipes: kPestoRecipes);
   }
 }
 
 class PestoFavorites extends StatelessWidget {
-  static final GlobalKey<ScrollableState> scrollableKey = new GlobalKey<ScrollableState>();
-
   @override
   Widget build(BuildContext context) {
-    return new RecipeGridPage(recipes: _favoriteRecipes.toList(), scrollableKey: scrollableKey);
+    return new RecipeGridPage(recipes: _favoriteRecipes.toList());
   }
 }
 
@@ -67,10 +63,9 @@ class PestoStyle extends TextStyle {
 
 // Displays a grid of recipe cards.
 class RecipeGridPage extends StatefulWidget {
-  RecipeGridPage({ Key key, this.recipes, this.scrollableKey }) : super(key: key);
+  RecipeGridPage({ Key key, this.recipes }) : super(key: key);
 
   final List<Recipe> recipes;
-  final GlobalKey<ScrollableState> scrollableKey;
 
   @override
   _RecipeGridPageState createState() => new _RecipeGridPageState();

--- a/packages/flutter/lib/src/material/progress_indicator.dart
+++ b/packages/flutter/lib/src/material/progress_indicator.dart
@@ -432,7 +432,7 @@ class _RefreshProgressIndicatorPainter extends _CircularProgressIndicatorPainter
 /// An indicator for the progress of refreshing the contents of a widget.
 ///
 /// Typically used for swipe-to-refresh interactions. See [RefreshIndicator] for
-/// a complete implementation of swipe-to-refresh driven by a [Scrollable]
+/// a complete implementation of swipe-to-refresh driven by a [Scrollable2]
 /// widget.
 ///
 /// See also:
@@ -442,7 +442,7 @@ class RefreshProgressIndicator extends CircularProgressIndicator {
   /// Creates a refresh progress indicator.
   ///
   /// Rather than creating a refresh progress indicator directly, consider using
-  /// a [RefreshIndicator] together with a [Scrollable] widget.
+  /// a [RefreshIndicator] together with a [Scrollable2] widget.
   RefreshProgressIndicator({
     Key key,
     double value,

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -135,7 +135,7 @@ class InputValue {
 ///  * [InputField], which adds tap-to-focus and cut, copy, and paste commands.
 ///  * [TextField], which is a full-featured, material-design text input field
 ///    with placeholder text, labels, and [Form] integration.
-class EditableText extends Scrollable {
+class EditableText extends Scrollable { // ignore: DEPRECATED_MEMBER_USE
   /// Creates a basic text input control.
   ///
   /// The [value] argument must not be null.
@@ -226,7 +226,7 @@ class EditableText extends Scrollable {
 }
 
 /// State for a [EditableText].
-class EditableTextState extends ScrollableState<EditableText> implements TextInputClient {
+class EditableTextState extends ScrollableState<EditableText> implements TextInputClient { // ignore: DEPRECATED_MEMBER_USE
   Timer _cursorTimer;
   bool _showCursor = false;
 

--- a/packages/flutter/lib/src/widgets/focus.dart
+++ b/packages/flutter/lib/src/widgets/focus.dart
@@ -192,7 +192,7 @@ class Focus extends StatefulWidget {
     _FocusScope focusScope = key.currentContext.ancestorWidgetOfExactType(_FocusScope);
     if (focusScope != null) {
       focusScope.focusState._setFocusedWidget(key);
-      Scrollable.ensureVisible(focusedContext);
+      Scrollable.ensureVisible(focusedContext);  // ignore: DEPRECATED_MEMBER_USE
       Scrollable2.ensureVisible(focusedContext);
     }
   }
@@ -360,7 +360,7 @@ class _FocusState extends State<Focus> {
     BuildContext focusedContext = _focusedWidget?.currentContext;
     if (focusedContext == null)
       return;
-    Scrollable.ensureVisible(focusedContext);
+    Scrollable.ensureVisible(focusedContext);  // ignore: DEPRECATED_MEMBER_USE
     Scrollable2.ensureVisible(focusedContext);
   }
 

--- a/packages/flutter/lib/src/widgets/scroll_position.dart
+++ b/packages/flutter/lib/src/widgets/scroll_position.dart
@@ -219,7 +219,7 @@ class ScrollPosition extends ViewportOffset {
     beginBallisticActivity(0.0);
   }
 
-  /// Returns a description of the [Scrollable].
+  /// Returns a description of the [Scrollable2].
   ///
   /// Accurately describing the metrics typicaly requires using information
   /// provided by the viewport to the [applyViewportDimension] and

--- a/packages/flutter/lib/src/widgets/scrollable.dart
+++ b/packages/flutter/lib/src/widgets/scrollable.dart
@@ -370,16 +370,7 @@ typedef void ScrollListener(double scrollOffset);
 /// Used by [Scrollable.snapOffsetCallback].
 typedef double SnapOffsetCallback(double scrollOffset, Size containerSize);
 
-/// A base class for scrollable widgets.
-///
-/// If you have a list of widgets and want them to be able to scroll if there is
-/// insufficient room, consider using [Block].
-///
-/// Commonly used classes that are based on Scrollable include [ScrollableList]
-/// and [ScrollableViewport].
-///
-/// Widgets that subclass [Scrollable] typically use state objects that subclass
-/// [ScrollableState].
+/// Will be removed soon.
 class Scrollable extends StatefulWidget {
   /// Initializes fields for subclasses.
   ///
@@ -1246,6 +1237,7 @@ class ScrollNotification extends Notification {
 ///  * [ScrollableList], if you have many identically-sized children.
 ///  * [GridView], if your children are in a grid pattern.
 ///  * [LazyBlock], if you have many children of varying sizes.
+@Deprecated('use SingleChildScrollView')
 class ScrollableViewport extends StatelessWidget {
   /// Creates a simple scrolling widget that has a single child.
   ///
@@ -1379,6 +1371,7 @@ class ScrollableViewport extends StatelessWidget {
 ///  * [LazyBlock], if you have many children with varying heights.
 ///  * [ScrollableList], if all your children are the same height.
 ///  * [ScrollableViewport], if you only have one child.
+@Deprecated('use ListView instead')
 class Block extends StatelessWidget {
   /// Creates a scrollable array of children.
   Block({

--- a/packages/flutter/test/material/refresh_indicator_test.dart
+++ b/packages/flutter/test/material/refresh_indicator_test.dart
@@ -28,7 +28,7 @@ void main() {
       new RefreshIndicator(
         scrollableKey: scrollableKey,
         refresh: refresh,
-        child: new Block(
+        child: new Block( // ignore: DEPRECATED_MEMBER_USE
           scrollableKey: scrollableKey,
           children: <String>['A', 'B', 'C', 'D', 'E', 'F'].map((String item) {
             return new SizedBox(
@@ -55,7 +55,7 @@ void main() {
         scrollableKey: scrollableKey,
         refresh: refresh,
         location: RefreshIndicatorLocation.bottom,
-        child: new Block(
+        child: new Block( // ignore: DEPRECATED_MEMBER_USE
           scrollableKey: scrollableKey,
           children: <Widget>[
             new SizedBox(
@@ -81,7 +81,7 @@ void main() {
       new RefreshIndicator(
         scrollableKey: scrollableKey,
         refresh: refresh,
-        child: new Block(
+        child: new Block( // ignore: DEPRECATED_MEMBER_USE
           scrollableKey: scrollableKey,
           children: <Widget>[
             new SizedBox(
@@ -107,7 +107,7 @@ void main() {
       new RefreshIndicator(
         scrollableKey: scrollableKey,
         refresh: holdRefresh, // this one never returns
-        child: new Block(
+        child: new Block( // ignore: DEPRECATED_MEMBER_USE
           scrollableKey: scrollableKey,
           children: <Widget>[
             new SizedBox(
@@ -149,7 +149,7 @@ void main() {
       new RefreshIndicator(
         scrollableKey: scrollableKey,
         refresh: refresh,
-        child: new Block(
+        child: new Block( // ignore: DEPRECATED_MEMBER_USE
           scrollableKey: scrollableKey,
           children: <Widget>[
             new SizedBox(
@@ -192,7 +192,7 @@ void main() {
       new RefreshIndicator(
         scrollableKey: scrollableKey,
         refresh: refresh,
-        child: new Block(
+        child: new Block( // ignore: DEPRECATED_MEMBER_USE
           scrollableKey: scrollableKey,
           children: <Widget>[
             new SizedBox(


### PR DESCRIPTION
The replacements are ListView and SingleChildScrollView, respectively.