### PR TITLE
Don't include Roboto fonts in Gradle builds.

### DIFF
--- a/packages/flutter_tools/gradle/flutter.gradle
+++ b/packages/flutter_tools/gradle/flutter.gradle
@@ -222,6 +222,7 @@ class FlutterTask extends DefaultTask {
             args "build", "flx"
             args "--target", targetPath
             args "--output-file", "${intermediateDir}/app.flx"
+            args "--no-include-roboto-fonts"
             if (buildMode != "debug") {
                 args "--precompiled"
             } else {


### PR DESCRIPTION
The "old" APK build did not include Roboto fonts, but the new
Gradle-based build did. This is due to `flutter build flx` defaulting to
include the fonts, where the old `flutter build apk` defaulted to NOT
include them.

So let's change the Gradle build to also not include Roboto fonts.

Fixes #8149