### PR TITLE
Implements WindowsStdoutLogger

### DIFF
--- a/packages/flutter_tools/lib/executable.dart
+++ b/packages/flutter_tools/lib/executable.dart
@@ -105,7 +105,7 @@ Future<Null> main(List<String> args) async {
     context.putIfAbsent(Platform, () => new LocalPlatform());
     context.putIfAbsent(FileSystem, () => new LocalFileSystem());
     context.putIfAbsent(ProcessManager, () => new LocalProcessManager());
-    context.putIfAbsent(Logger, () => new StdoutLogger());
+    context.putIfAbsent(Logger, () => platform.isWindows ? new WindowsStdoutLogger() : new StdoutLogger());
 
     // Order-independent context entries
     context.putIfAbsent(DeviceManager, () => new DeviceManager());

--- a/packages/flutter_tools/lib/src/doctor.dart
+++ b/packages/flutter_tools/lib/src/doctor.dart
@@ -126,7 +126,7 @@ class Doctor {
       for (ValidationMessage message in result.messages) {
         String text = message.message.replaceAll('\n', '\n      ');
         if (message.isError) {
-          printStatus('    x $text', emphasis: true);
+          printStatus('    ✗ $text', emphasis: true);
         } else {
           printStatus('    • $text');
         }


### PR DESCRIPTION
Replaces unprintable characters with alternative symbols.
Workaround for https://github.com/dart-lang/sdk/issues/28571.
Fixes #7714

We will have to add more replacement characters as we encounter them until the real issue is fixed upstream.

`flutter doctor` before this change:
![old_console](https://cloud.githubusercontent.com/assets/1227763/22990408/f1c797c4-f36d-11e6-8b6a-e7e020944527.png)

`flutter doctor` after this change:
![better_console](https://cloud.githubusercontent.com/assets/1227763/22990420/fc528abe-f36d-11e6-961a-697355182f89.png)
