### PR TITLE
new --kernel option for flutter run to use precompiled kernel code

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_device.dart
+++ b/packages/flutter_tools/lib/src/android/android_device.dart
@@ -15,6 +15,7 @@ import '../base/process.dart';
 import '../base/process_manager.dart';
 import '../build_info.dart';
 import '../commands/build_apk.dart';
+import '../devfs.dart';
 import '../device.dart';
 import '../globals.dart';
 import '../protocol_discovery.dart';
@@ -268,6 +269,7 @@ class AndroidDevice extends Device {
     String route,
     DebuggingOptions debuggingOptions,
     Map<String, dynamic> platformArgs,
+    DevFSContent kernelContent,
     bool prebuiltApplication: false,
     bool applicationNeedsRebuild: false,
   }) async {
@@ -287,6 +289,7 @@ class AndroidDevice extends Device {
       await buildApk(platform,
           target: mainPath,
           buildMode: debuggingOptions.buildMode,
+          kernelContent: kernelContent,
           applicationNeedsRebuild: applicationNeedsRebuild
       );
     }

--- a/packages/flutter_tools/lib/src/commands/build_apk.dart
+++ b/packages/flutter_tools/lib/src/commands/build_apk.dart
@@ -15,6 +15,7 @@ import '../base/process.dart';
 import '../base/process_manager.dart';
 import '../base/utils.dart';
 import '../build_info.dart';
+import '../devfs.dart';
 import '../flx.dart' as flx;
 import '../globals.dart';
 import '../resident_runner.dart';
@@ -481,6 +482,7 @@ Future<Null> buildAndroid(
   String target,
   String flxPath,
   String aotPath,
+  DevFSContent kernelContent,
   ApkKeystoreInfo keystore,
   bool applicationNeedsRebuild: false
 }) async {
@@ -545,6 +547,7 @@ Future<Null> buildAndroid(
     // Build the FLX.
     flxPath = await flx.buildFlx(
       mainPath: findMainDartFile(target),
+      kernelContent: kernelContent,
       precompiledSnapshot: isAotBuildMode(buildMode),
       includeRobotoFonts: false);
 
@@ -614,6 +617,7 @@ Future<Null> buildApk(
   TargetPlatform platform, {
   String target,
   BuildMode buildMode: BuildMode.debug,
+  DevFSContent kernelContent,
   bool applicationNeedsRebuild: false,
 }) async {
   if (isProjectUsingGradle()) {
@@ -632,6 +636,7 @@ Future<Null> buildApk(
       buildMode,
       force: false,
       target: target,
+      kernelContent: kernelContent,
       applicationNeedsRebuild: applicationNeedsRebuild,
     );
   }

--- a/packages/flutter_tools/lib/src/commands/run.dart
+++ b/packages/flutter_tools/lib/src/commands/run.dart
@@ -96,7 +96,9 @@ class RunCommand extends RunCommandBase {
         help: 'Specify a pre-built application binary to use when running.');
     argParser.addOption('kernel',
         hide: !verboseHelp,
-        help: 'Path to a pre-built kernel blob to use when running.');
+        help: 'Path to a pre-built kernel blob to use when running.\n'
+              'This option only exists for testing new kernel code execution on devices\n'
+              'and is not needed during normal application development.');
     argParser.addOption('snapshotter',
         hide: !verboseHelp,
         help: 'Specify the path to the sky_snapshot binary.');

--- a/packages/flutter_tools/lib/src/commands/run.dart
+++ b/packages/flutter_tools/lib/src/commands/run.dart
@@ -94,6 +94,9 @@ class RunCommand extends RunCommandBase {
     argParser.addOption('use-application-binary',
         hide: !verboseHelp,
         help: 'Specify a pre-built application binary to use when running.');
+    argParser.addOption('kernel',
+        hide: !verboseHelp,
+        help: 'Path to a pre-built kernel blob to use when running.');
     argParser.addOption('snapshotter',
         hide: !verboseHelp,
         help: 'Specify the path to the sky_snapshot binary.');
@@ -259,6 +262,7 @@ class RunCommand extends RunCommandBase {
         debuggingOptions: options,
         benchmarkMode: argResults['benchmark'],
         applicationBinary: argResults['use-application-binary'],
+        kernelFilePath: argResults['kernel'],
         projectRootPath: argResults['project-root'],
         packagesFilePath: argResults['packages'],
         projectAssets: argResults['project-assets'],

--- a/packages/flutter_tools/lib/src/device.dart
+++ b/packages/flutter_tools/lib/src/device.dart
@@ -13,6 +13,7 @@ import 'base/file_system.dart';
 import 'base/os.dart';
 import 'base/utils.dart';
 import 'build_info.dart';
+import 'devfs.dart';
 import 'globals.dart';
 import 'ios/devices.dart';
 import 'ios/simulators.dart';
@@ -207,6 +208,7 @@ abstract class Device {
     String route,
     DebuggingOptions debuggingOptions,
     Map<String, dynamic> platformArgs,
+    DevFSContent kernelContent,
     bool prebuiltApplication: false,
     bool applicationNeedsRebuild: false
   });

--- a/packages/flutter_tools/lib/src/flx.dart
+++ b/packages/flutter_tools/lib/src/flx.dart
@@ -21,8 +21,10 @@ const String defaultManifestPath = 'pubspec.yaml';
 String get defaultFlxOutputPath => fs.path.join(getBuildDirectory(), 'app.flx');
 String get defaultSnapshotPath => fs.path.join(getBuildDirectory(), 'snapshot_blob.bin');
 String get defaultDepfilePath => fs.path.join(getBuildDirectory(), 'snapshot_blob.bin.d');
+String get defaultKernelPath => fs.path.join(getBuildDirectory(), 'kernel_blob.bin');
 const String defaultPrivateKeyPath = 'privatekey.der';
 
+const String _kKernelKey = 'kernel_blob.bin';
 const String _kSnapshotKey = 'snapshot_blob.bin';
 
 Future<int> createSnapshot({
@@ -55,6 +57,7 @@ Future<int> createSnapshot({
 /// Return `null` on failure.
 Future<String> buildFlx({
   String mainPath: defaultMainPath,
+  DevFSContent kernelContent,
   bool precompiledSnapshot: false,
   bool includeRobotoFonts: true
 }) async {
@@ -62,6 +65,7 @@ Future<String> buildFlx({
     snapshotPath: defaultSnapshotPath,
     outputPath: defaultFlxOutputPath,
     mainPath: mainPath,
+    kernelContent: kernelContent,
     precompiledSnapshot: precompiledSnapshot,
     includeRobotoFonts: includeRobotoFonts
   );
@@ -78,18 +82,29 @@ Future<Null> build({
   String privateKeyPath: defaultPrivateKeyPath,
   String workingDirPath,
   String packagesPath,
+  String kernelPath,
+  DevFSContent kernelContent,
   bool precompiledSnapshot: false,
   bool includeRobotoFonts: true,
   bool reportLicensedPackages: false
 }) async {
   snapshotterPath ??= tools.getHostToolPath(HostTool.SkySnapshot);
   outputPath ??= defaultFlxOutputPath;
+  kernelPath ??= defaultKernelPath;
   snapshotPath ??= defaultSnapshotPath;
   depfilePath ??= defaultDepfilePath;
   workingDirPath ??= getAssetBuildDirectory();
   packagesPath ??= fs.path.absolute(PackageMap.globalPackagesPath);
   File snapshotFile;
 
+  File kernelFile;
+  if (kernelContent != null) {
+    // TODO(danrubel) in the future, call the VM to generate this file
+    kernelFile = fs.file(kernelPath);
+    IOSink sink = kernelFile.openWrite();
+    await sink.addStream(kernelContent.contentsAsStream());
+    sink.close();
+  }
   if (!precompiledSnapshot) {
     ensureDirectoryExists(snapshotPath);
 
@@ -110,6 +125,7 @@ Future<Null> build({
 
   return assemble(
     manifestPath: manifestPath,
+    kernelFile: kernelFile,
     snapshotFile: snapshotFile,
     outputPath: outputPath,
     privateKeyPath: privateKeyPath,
@@ -122,6 +138,7 @@ Future<Null> build({
 
 Future<Null> assemble({
   String manifestPath,
+  File kernelFile,
   File snapshotFile,
   String outputPath,
   String privateKeyPath: defaultPrivateKeyPath,
@@ -154,6 +171,8 @@ Future<Null> assemble({
   // Add all entries from the asset bundle.
   zipBuilder.entries.addAll(assetBundle.entries);
 
+  if (kernelFile != null)
+    zipBuilder.entries[_kKernelKey] = new DevFSFileContent(kernelFile);
   if (snapshotFile != null)
     zipBuilder.entries[_kSnapshotKey] = new DevFSFileContent(snapshotFile);
 

--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -13,6 +13,7 @@ import '../base/platform.dart' as p;
 import '../base/process.dart';
 import '../base/process_manager.dart';
 import '../build_info.dart';
+import '../devfs.dart';
 import '../device.dart';
 import '../doctor.dart';
 import '../globals.dart';
@@ -188,6 +189,7 @@ class IOSDevice extends Device {
     DebuggingOptions debuggingOptions,
     Map<String, dynamic> platformArgs,
     bool prebuiltApplication: false,
+    DevFSContent kernelContent,
     bool applicationNeedsRebuild: false,
   }) async {
     if (!prebuiltApplication) {

--- a/packages/flutter_tools/lib/src/ios/simulators.dart
+++ b/packages/flutter_tools/lib/src/ios/simulators.dart
@@ -15,6 +15,7 @@ import '../base/platform.dart' as p;
 import '../base/process.dart';
 import '../base/process_manager.dart';
 import '../build_info.dart';
+import '../devfs.dart';
 import '../device.dart';
 import '../flx.dart' as flx;
 import '../globals.dart';
@@ -414,6 +415,7 @@ class IOSSimulator extends Device {
     String route,
     DebuggingOptions debuggingOptions,
     Map<String, dynamic> platformArgs,
+    DevFSContent kernelContent,
     bool prebuiltApplication: false,
     bool applicationNeedsRebuild: false,
   }) async {

--- a/packages/flutter_tools/lib/src/run_hot.dart
+++ b/packages/flutter_tools/lib/src/run_hot.dart
@@ -42,6 +42,7 @@ class HotRunner extends ResidentRunner {
     bool usesTerminalUI: true,
     this.benchmarkMode: false,
     this.applicationBinary,
+    this.kernelFilePath,
     String projectRootPath,
     String packagesFilePath,
     String projectAssets,
@@ -64,6 +65,7 @@ class HotRunner extends ResidentRunner {
   final Map<String, int> benchmarkData = new Map<String, int>();
   // The initial launch is from a snapshot.
   bool _runningFromSnapshot = true;
+  String kernelFilePath;
 
   @override
   Future<int> run({
@@ -156,6 +158,11 @@ class HotRunner extends ResidentRunner {
     String modeName = getModeName(debuggingOptions.buildMode);
     printStatus('Launching ${getDisplayPath(mainPath)} on ${device.name} in $modeName mode...');
 
+    // Include kernel code
+    DevFSContent kernelContent;
+    if (kernelFilePath != null)
+      kernelContent = new DevFSFileContent(fs.file(kernelFilePath));
+
     // Start the application.
     Future<LaunchResult> futureResult = device.startApp(
       package,
@@ -165,6 +172,7 @@ class HotRunner extends ResidentRunner {
       platformArgs: platformArgs,
       route: route,
       prebuiltApplication: prebuiltMode,
+      kernelContent: kernelContent,
       applicationNeedsRebuild: shouldBuild || hasDirtyDependencies()
     );
 


### PR DESCRIPTION
This is the corresponding change for https://github.com/flutter/engine/pull/3369 but on the flutter tools side. With this, devs can precompile a flutter app into kernel code with some external process and use
```
flutter run --kernel=/path/to/kernel/blob
```
to run that kernel code on the device.