### PR TITLE
Add hashCode to RenderObject.toString()

### DIFF
--- a/packages/flutter/lib/src/material/material.dart
+++ b/packages/flutter/lib/src/material/material.dart
@@ -405,5 +405,5 @@ abstract class InkFeature {
   void paintFeature(Canvas canvas, Matrix4 transform);
 
   @override
-  String toString() => '$runtimeType@$hashCode';
+  String toString() => '$runtimeType#$hashCode';
 }

--- a/packages/flutter/lib/src/rendering/box.dart
+++ b/packages/flutter/lib/src/rendering/box.dart
@@ -512,7 +512,7 @@ class BoxHitTestEntry extends HitTestEntry {
   final Point localPosition;
 
   @override
-  String toString() => '${target.runtimeType}@$localPosition';
+  String toString() => '${target.runtimeType}(${target.hashCode})@$localPosition';
 }
 
 /// Parent data used by [RenderBox] and its subclasses.

--- a/packages/flutter/lib/src/rendering/box.dart
+++ b/packages/flutter/lib/src/rendering/box.dart
@@ -512,7 +512,7 @@ class BoxHitTestEntry extends HitTestEntry {
   final Point localPosition;
 
   @override
-  String toString() => '${target.runtimeType}(${target.hashCode})@$localPosition';
+  String toString() => '${target.runtimeType}#${target.hashCode}@$localPosition';
 }
 
 /// Parent data used by [RenderBox] and its subclasses.

--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -620,7 +620,7 @@ abstract class _SemanticsFragment {
   Iterable<SemanticsNode> compile({ _SemanticsGeometry geometry, SemanticsNode currentSemantics, SemanticsNode parentSemantics });
 
   @override
-  String toString() => '$runtimeType($hashCode)';
+  String toString() => '$runtimeType#$hashCode';
 }
 
 /// Represents a subtree that doesn't need updating, it already has a
@@ -2396,7 +2396,7 @@ abstract class RenderObject extends AbstractNode implements HitTestTarget {
   /// Returns a human understandable name.
   @override
   String toString() {
-    String header = '$runtimeType($hashCode)';
+    String header = '$runtimeType#$hashCode';
     if (_relayoutBoundary != null && _relayoutBoundary != this) {
       int count = 1;
       RenderObject target = parent;

--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -2396,7 +2396,7 @@ abstract class RenderObject extends AbstractNode implements HitTestTarget {
   /// Returns a human understandable name.
   @override
   String toString() {
-    String header = '$runtimeType';
+    String header = '$runtimeType($hashCode)';
     if (_relayoutBoundary != null && _relayoutBoundary != this) {
       int count = 1;
       RenderObject target = parent;

--- a/packages/flutter/lib/src/rendering/semantics.dart
+++ b/packages/flutter/lib/src/rendering/semantics.dart
@@ -760,5 +760,5 @@ class SemanticsOwner extends ChangeNotifier {
   }
 
   @override
-  String toString() => '$runtimeType@$hashCode';
+  String toString() => '$runtimeType#$hashCode';
 }

--- a/packages/flutter/lib/src/services/asset_bundle.dart
+++ b/packages/flutter/lib/src/services/asset_bundle.dart
@@ -74,7 +74,7 @@ abstract class AssetBundle {
   void evict(String key) { }
 
   @override
-  String toString() => '$runtimeType@$hashCode()';
+  String toString() => '$runtimeType#$hashCode()';
 }
 
 /// An [AssetBundle] that loads resources over the network.
@@ -120,7 +120,7 @@ class NetworkAssetBundle extends AssetBundle {
   // should implement evict().
 
   @override
-  String toString() => '$runtimeType@$hashCode($_baseUrl)';
+  String toString() => '$runtimeType#$hashCode($_baseUrl)';
 }
 
 /// An [AssetBundle] that permanently caches string and structured resources

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -95,7 +95,7 @@ class UniqueKey extends LocalKey {
   UniqueKey();
 
   @override
-  String toString() => '[$hashCode]';
+  String toString() => '[#$hashCode]';
 }
 
 /// A key that takes its identity from the object used as its value.
@@ -123,8 +123,8 @@ class ObjectKey extends LocalKey {
   @override
   String toString() {
     if (runtimeType == ObjectKey)
-      return '[${value.runtimeType}@${value.hashCode}]';
-    return '[$runtimeType ${value.runtimeType}@${value.hashCode}]';
+      return '[${value.runtimeType}#${value.hashCode}]';
+    return '[$runtimeType ${value.runtimeType}#${value.hashCode}]';
   }
 }
 
@@ -310,8 +310,8 @@ class LabeledGlobalKey<T extends State<StatefulWidget>> extends GlobalKey<T> {
   @override
   String toString() {
     if (this.runtimeType == LabeledGlobalKey)
-      return '[GlobalKey ${_debugLabel ?? hashCode}]';
-    return '[$runtimeType ${_debugLabel ?? hashCode}]';
+      return '[GlobalKey#${_debugLabel ?? hashCode}]';
+    return '[$runtimeType#${_debugLabel ?? hashCode}]';
   }
 }
 
@@ -341,7 +341,7 @@ class GlobalObjectKey<T extends State<StatefulWidget>> extends GlobalKey<T> {
   int get hashCode => identityHashCode(value);
 
   @override
-  String toString() => '[$runtimeType ${value.runtimeType}@${value.hashCode}]';
+  String toString() => '[$runtimeType ${value.runtimeType}#${value.hashCode}]';
 }
 
 /// This class is a work-around for the "is" operator not accepting a variable value as its right operand
@@ -1040,7 +1040,7 @@ abstract class State<T extends StatefulWidget> {
   String toString() {
     final List<String> data = <String>[];
     debugFillDescription(data);
-    return '$runtimeType(${data.join("; ")})';
+    return '$runtimeType#$hashCode(${data.join("; ")})';
   }
 
   /// Add additional information to the given description for use by [toString].
@@ -1055,7 +1055,6 @@ abstract class State<T extends StatefulWidget> {
   @protected
   @mustCallSuper
   void debugFillDescription(List<String> description) {
-    description.add('$hashCode');
     assert(() {
       if (_debugLifecycleState != _StateLifecycle.ready)
         description.add('$_debugLifecycleState');

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -309,9 +309,10 @@ class LabeledGlobalKey<T extends State<StatefulWidget>> extends GlobalKey<T> {
 
   @override
   String toString() {
+    String tag = _debugLabel != null ? ' $_debugLabel' : '#$hashCode';
     if (this.runtimeType == LabeledGlobalKey)
-      return '[GlobalKey#${_debugLabel ?? hashCode}]';
-    return '[$runtimeType#${_debugLabel ?? hashCode}]';
+      return '[GlobalKey$tag]';
+    return '[$runtimeType$tag]';
   }
 }
 

--- a/packages/flutter/lib/src/widgets/overlay.dart
+++ b/packages/flutter/lib/src/widgets/overlay.dart
@@ -150,7 +150,7 @@ class OverlayEntry {
   }
 
   @override
-  String toString() => '$runtimeType@$hashCode(opaque: $opaque; maintainState: $maintainState)';
+  String toString() => '$runtimeType#$hashCode(opaque: $opaque; maintainState: $maintainState)';
 }
 
 class _OverlayEntry extends StatefulWidget {

--- a/packages/flutter/test/foundation/service_extensions_test.dart
+++ b/packages/flutter/test/foundation/service_extensions_test.dart
@@ -124,13 +124,15 @@ void main() {
 
     result = await binding.testExtension('debugDumpRenderTree', <String, String>{});
     expect(result, <String, String>{});
-    expect(console, <String>[
-      'RenderView\n'
-      '   debug mode enabled - ${Platform.operatingSystem}\n'
-      '   window size: Size(800.0, 600.0) (in physical pixels)\n'
-      '   device pixel ratio: 1.0 (physical pixels per logical pixel)\n'
-      '   configuration: Size(800.0, 600.0) at 1.0x (in logical pixels)\n'
-      '\n'
+    expect(console, <Matcher>[
+      matches(
+        'RenderView\\([0-9]+\\)\n'
+        '   debug mode enabled - ${Platform.operatingSystem}\n'
+        '   window size: Size\\(800.0, 600.0\\) \\(in physical pixels\\)\n'
+        '   device pixel ratio: 1.0 \\(physical pixels per logical pixel\\)\n'
+        '   configuration: Size\\(800.0, 600.0\\) at 1.0x \\(in logical pixels\\)\n'
+        '\n'
+      ),
     ]);
     console.clear();
   });

--- a/packages/flutter/test/foundation/service_extensions_test.dart
+++ b/packages/flutter/test/foundation/service_extensions_test.dart
@@ -126,12 +126,12 @@ void main() {
     expect(result, <String, String>{});
     expect(console, <Matcher>[
       matches(
-        'RenderView\\([0-9]+\\)\n'
-        '   debug mode enabled - ${Platform.operatingSystem}\n'
-        '   window size: Size\\(800.0, 600.0\\) \\(in physical pixels\\)\n'
-        '   device pixel ratio: 1.0 \\(physical pixels per logical pixel\\)\n'
-        '   configuration: Size\\(800.0, 600.0\\) at 1.0x \\(in logical pixels\\)\n'
-        '\n'
+        r'RenderView#[0-9]+\n'
+        r'   debug mode enabled - [a-zA-Z]+\n'
+        r'   window size: Size\(800\.0, 600\.0\) \(in physical pixels\)\n'
+        r'   device pixel ratio: 1\.0 \(physical pixels per logical pixel\)\n'
+        r'   configuration: Size\(800\.0, 600\.0\) at 1\.0x \(in logical pixels\)\n'
+        r'\n'
       ),
     ]);
     console.clear();

--- a/packages/flutter/test/foundation/service_extensions_test.dart
+++ b/packages/flutter/test/foundation/service_extensions_test.dart
@@ -4,7 +4,6 @@
 
 import 'dart:async';
 import 'dart:convert';
-import 'dart:io' show Platform;
 import 'dart:typed_data';
 import 'dart:ui' as ui;
 

--- a/packages/flutter/test/painting/decoration_test.dart
+++ b/packages/flutter/test/painting/decoration_test.dart
@@ -75,7 +75,7 @@ class BackgroundImageProvider extends ImageProvider<BackgroundImageProvider> {
   }
 
   @override
-  String toString() => '$runtimeType#$hashCode';
+  String toString() => '$runtimeType#$hashCode()';
 }
 
 class TestImage extends ui.Image {

--- a/packages/flutter/test/painting/decoration_test.dart
+++ b/packages/flutter/test/painting/decoration_test.dart
@@ -75,7 +75,7 @@ class BackgroundImageProvider extends ImageProvider<BackgroundImageProvider> {
   }
 
   @override
-  String toString() => '$runtimeType($hashCode)';
+  String toString() => '$runtimeType#$hashCode';
 }
 
 class TestImage extends ui.Image {

--- a/packages/flutter/test/widgets/image_resolution_test.dart
+++ b/packages/flutter/test/widgets/image_resolution_test.dart
@@ -78,7 +78,7 @@ class TestAssetBundle extends CachingAssetBundle {
   }
 
   @override
-  String toString() => '$runtimeType@$hashCode()';
+  String toString() => '$runtimeType#$hashCode()';
 }
 
 class TestAssetImage extends AssetImage {

--- a/packages/flutter/test/widgets/image_test.dart
+++ b/packages/flutter/test/widgets/image_test.dart
@@ -324,7 +324,7 @@ class TestImageProvider extends ImageProvider<TestImageProvider> {
   }
 
   @override
-  String toString() => '$runtimeType#$hashCode';
+  String toString() => '$runtimeType#$hashCode()';
 }
 
 class TestImage extends ui.Image {

--- a/packages/flutter/test/widgets/image_test.dart
+++ b/packages/flutter/test/widgets/image_test.dart
@@ -291,12 +291,12 @@ void main() {
     TestImageProvider imageProvider = new TestImageProvider();
     await tester.pumpWidget(new Image(image: imageProvider));
     State<Image> image = tester.state/*State<Image>*/(find.byType(Image));
-    expect(image.toString(), matches(new RegExp(r'_ImageState\([0-9]+; stream: ImageStream\(OneFrameImageStreamCompleter; unresolved; 1 listener\); pixels: null\)')));
+    expect(image.toString(), matches(new RegExp(r'_ImageState#[0-9]+\(stream: ImageStream\(OneFrameImageStreamCompleter; unresolved; 1 listener\); pixels: null\)')));
     imageProvider.complete();
     await tester.pump();
-    expect(image.toString(), matches(new RegExp(r'_ImageState\([0-9]+; stream: ImageStream\(OneFrameImageStreamCompleter; \[100×100\] @ 1\.0x; 1 listener\); pixels: \[100×100\] @ 1\.0x\)')));
+    expect(image.toString(), matches(new RegExp(r'_ImageState#[0-9]+\(stream: ImageStream\(OneFrameImageStreamCompleter; \[100×100\] @ 1\.0x; 1 listener\); pixels: \[100×100\] @ 1\.0x\)')));
     await tester.pumpWidget(new Container());
-    expect(image.toString(), matches(new RegExp(r'_ImageState\([0-9]+; _StateLifecycle.defunct; not mounted; stream: ImageStream\(OneFrameImageStreamCompleter; \[100×100\] @ 1\.0x; 0 listeners\); pixels: \[100×100\] @ 1\.0x\)')));
+    expect(image.toString(), matches(new RegExp(r'_ImageState#[0-9]+\(_StateLifecycle.defunct; not mounted; stream: ImageStream\(OneFrameImageStreamCompleter; \[100×100\] @ 1\.0x; 0 listeners\); pixels: \[100×100\] @ 1\.0x\)')));
   });
 
 }
@@ -324,7 +324,7 @@ class TestImageProvider extends ImageProvider<TestImageProvider> {
   }
 
   @override
-  String toString() => '$runtimeType($hashCode)';
+  String toString() => '$runtimeType#$hashCode';
 }
 
 class TestImage extends ui.Image {


### PR DESCRIPTION
When dumping the render tree, it allows you to search the
output in a text editor for specific render objects that you
printed for debug purposes, thus greatly speeding up your
debugging.