### PR TITLE
Revert "Run coverage tests verbosely to help diagnose timeouts. (#8198)"

### DIFF
--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -56,10 +56,8 @@ Future<Null> main() async {
   );
 
   List<String> coverageFlags = <String>[];
-  if (Platform.environment['TRAVIS'] != null && Platform.environment['TRAVIS_PULL_REQUEST'] == 'false') {
+  if (Platform.environment['TRAVIS'] != null && Platform.environment['TRAVIS_PULL_REQUEST'] == 'false')
     coverageFlags.add('--coverage');
-    coverageFlags.add('-v');
-  }
 
   // Run tests.
   await _runFlutterTest(p.join(flutterRoot, 'packages', 'flutter'),


### PR DESCRIPTION
This reverts commit fac9efbacd1e65a0a6a4efb20e95d2be5255f796.

The timeout was fixed by 6795c4ab963342f5f35c052e0d6ee8e9b8f4a0e4.