### PR TITLE
Catch crashes during or before coverage collection.

### DIFF
--- a/packages/flutter_tools/lib/src/commands/test.dart
+++ b/packages/flutter_tools/lib/src/commands/test.dart
@@ -193,7 +193,11 @@ class TestCommand extends FlutterCommand {
     final String shellPath = tools.getHostToolPath(HostTool.SkyShell) ?? platform.environment['SKY_SHELL'];
     if (!fs.isFileSync(shellPath))
       throwToolExit('Cannot find Flutter shell at $shellPath');
-    loader.installHook(shellPath: shellPath, collector: collector, debuggerMode: argResults['start-paused']);
+    loader.installHook(
+      shellPath: shellPath,
+      collector: collector,
+      debuggerMode: argResults['start-paused'],
+    );
 
     Cache.releaseLockEarly();
 


### PR DESCRIPTION
This assumes a fix to https://github.com/dart-lang/test/issues/542

The timeout added in this patch is a workaround for https://github.com/dart-lang/tools/issues/581

Fixes https://github.com/flutter/flutter/issues/8202