### PR TITLE
Fix issues when correcting the scroll offset

### DIFF
--- a/packages/flutter/lib/src/rendering/sliver.dart
+++ b/packages/flutter/lib/src/rendering/sliver.dart
@@ -481,7 +481,6 @@ class SliverGeometry {
     assert(visible != null);
     assert(hasVisualOverflow != null);
     assert(scrollOffsetCorrection != null);
-    assert(scrollOffsetCorrection == 0.0);
     return true;
   }
 

--- a/packages/flutter/lib/src/rendering/sliver_list.dart
+++ b/packages/flutter/lib/src/rendering/sliver_list.dart
@@ -73,8 +73,10 @@ class RenderSliverList extends RenderSliverMultiBoxAdaptor {
         // We must inform our parent that this sliver cannot fulfill
         // its contract and that we need a scroll offset correction.
         geometry = new SliverGeometry(
-          scrollOffsetCorrection: -childScrollOffset(firstChild),
+          scrollOffsetCorrection: -scrollOffset,
         );
+        final SliverMultiBoxAdaptorParentData childParentData = firstChild.parentData;
+        childParentData.layoutOffset = 0.0;
         return;
       }
       final SliverMultiBoxAdaptorParentData childParentData = earliestUsefulChild.parentData;

--- a/packages/flutter/test/widgets/list_view_correction_test.dart
+++ b/packages/flutter/test/widgets/list_view_correction_test.dart
@@ -1,0 +1,56 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter/material.dart';
+
+void main() {
+  testWidgets('ListView can handle shrinking top elements', (WidgetTester tester) async {
+    final ScrollController controller = new ScrollController();
+    await tester.pumpWidget(new ListView(
+      controller: controller,
+      children: <Widget>[
+        new Container(height: 400.0, child: new Text('1')),
+        new Container(height: 400.0, child: new Text('2')),
+        new Container(height: 400.0, child: new Text('3')),
+        new Container(height: 400.0, child: new Text('4')),
+        new Container(height: 400.0, child: new Text('5')),
+        new Container(height: 400.0, child: new Text('6')),
+      ],
+    ));
+
+    controller.jumpTo(1000.0);
+    await tester.pump();
+
+    expect(tester.getTopLeft(find.text('4')).y, equals(200.0));
+
+    await tester.pumpWidget(new ListView(
+      controller: controller,
+      children: <Widget>[
+        new Container(height: 200.0, child: new Text('1')),
+        new Container(height: 400.0, child: new Text('2')),
+        new Container(height: 400.0, child: new Text('3')),
+        new Container(height: 400.0, child: new Text('4')),
+        new Container(height: 400.0, child: new Text('5')),
+        new Container(height: 400.0, child: new Text('6')),
+      ],
+    ));
+
+    expect(controller.offset, equals(1000.0));
+    expect(tester.getTopLeft(find.text('4')).y, equals(200.0));
+
+    controller.jumpTo(300.0);
+    await tester.pump();
+
+    expect(tester.getTopLeft(find.text('2')).y, equals(100.0));
+
+    controller.jumpTo(50.0);
+
+    await tester.pump();
+
+    expect(controller.offset, equals(0.0));
+    expect(tester.getTopLeft(find.text('2')).y, equals(200.0));
+  });
+
+}


### PR DESCRIPTION
Previously, the scroll correction code path was untested. This patch
introduces a test for the code path and fixes two issues with it.
There's likely more work we'll need to do in this area to nail down all
the cases.

Fixes #8155