### PR TITLE
Do not attempt to merge non-fat frameworks in Xcode build

### DIFF
--- a/packages/flutter_tools/bin/xcode_backend.sh
+++ b/packages/flutter_tools/bin/xcode_backend.sh
@@ -163,12 +163,12 @@ LipoExecutable() {
     fi
   done
 
+  # Generate a merged binary from the architecture-specific executables.
+  # Skip this step for non-fat executables.
   if [[ ${#all_executables[@]} > 0 ]]; then
-    # Merge desired architectures.
     local merged="${executable}_merged"
     lipo -output "${merged}" -create "${all_executables[@]}"
 
-    # Replace the original executable with the thinned one and clean up.
     cp -f -- "${merged}" "${executable}" > /dev/null
     rm -f -- "${merged}" "${all_executables[@]}"
   fi

--- a/packages/flutter_tools/bin/xcode_backend.sh
+++ b/packages/flutter_tools/bin/xcode_backend.sh
@@ -163,13 +163,15 @@ LipoExecutable() {
     fi
   done
 
-  # Merge desired architectures.
-  local merged="${executable}_merged"
-  lipo -output "${merged}" -create "${all_executables[@]}"
+  if [[ ${#all_executables[@]} > 0 ]]; then
+    # Merge desired architectures.
+    local merged="${executable}_merged"
+    lipo -output "${merged}" -create "${all_executables[@]}"
 
-  # Replace the original executable with the thinned one and clean up.
-  cp -f -- "${merged}" "${executable}" > /dev/null
-  rm -f -- "${merged}" "${all_executables[@]}"
+    # Replace the original executable with the thinned one and clean up.
+    cp -f -- "${merged}" "${executable}" > /dev/null
+    rm -f -- "${merged}" "${all_executables[@]}"
+  fi
 }
 
 # Destructively thins the specified framework to include only the specified


### PR DESCRIPTION
During the Xcode build, we strip code irrelevant to the target
architecture in frameworks used by the application. In the case of
non-fat executables, no stripping occurs, so the frameworks can be used
as-is. No merge & replace step is necessary.