### PR TITLE
Two becomes one

### DIFF
--- a/dev/manual_tests/overlay_geometry.dart
+++ b/dev/manual_tests/overlay_geometry.dart
@@ -151,7 +151,7 @@ class OverlayGeometryAppState extends State<OverlayGeometryApp> {
     });
   }
 
-  bool handleScrollNotification(ScrollNotification2 notification) {
+  bool handleScrollNotification(ScrollNotification notification) {
     if (notification is ScrollUpdateNotification && notification.depth == 1) {
       setState(() {
         double dy = markersScrollOffset - notification.metrics.extentBefore;
@@ -172,7 +172,7 @@ class OverlayGeometryAppState extends State<OverlayGeometryApp> {
       markers[MarkerType.topLeft] = box.localToGlobal(new Point(0.0, 0.0));
       final Size size = box.size;
       markers[MarkerType.bottomRight] = box.localToGlobal(new Point(size.width, size.height));
-      final Scrollable2State scrollable = Scrollable2.of(target.currentContext);
+      final ScrollableState scrollable = Scrollable.of(target.currentContext);
       markersScrollOffset = scrollable.position.pixels;
     });
   }
@@ -184,7 +184,7 @@ class OverlayGeometryAppState extends State<OverlayGeometryApp> {
         appBar: new AppBar(title: new Text('Tap a Card')),
         body: new Container(
           padding: const EdgeInsets.symmetric(vertical: 12.0, horizontal: 8.0),
-          child: new NotificationListener<ScrollNotification2>(
+          child: new NotificationListener<ScrollNotification>(
             onNotification: handleScrollNotification,
             child: new ListView.custom(
               childrenDelegate: new CardBuilder(

--- a/examples/flutter_gallery/lib/demo/shrine/shrine_page.dart
+++ b/examples/flutter_gallery/lib/demo/shrine/shrine_page.dart
@@ -40,7 +40,7 @@ class ShrinePage extends StatefulWidget {
 class ShrinePageState extends State<ShrinePage> {
   int _appBarElevation = 0;
 
-  bool _handleScrollNotification(ScrollNotification2 notification) {
+  bool _handleScrollNotification(ScrollNotification notification) {
     int elevation = notification.metrics.extentBefore <= 0.0 ? 0 : 1;
     if (elevation != _appBarElevation) {
       setState(() {
@@ -144,7 +144,7 @@ class ShrinePageState extends State<ShrinePage> {
         ]
       ),
       floatingActionButton: config.floatingActionButton,
-      body: new NotificationListener<ScrollNotification2>(
+      body: new NotificationListener<ScrollNotification>(
         onNotification: _handleScrollNotification,
         child: config.body
       )

--- a/examples/flutter_gallery/test/smoke_test.dart
+++ b/examples/flutter_gallery/test/smoke_test.dart
@@ -126,7 +126,7 @@ Future<Null> runSmokeTest(WidgetTester tester) async {
 
   for (String routeName in routeNames) {
     Finder finder = findGalleryItemByRouteName(tester, routeName);
-    Scrollable2.ensureVisible(tester.element(finder), alignment: 0.5);
+    Scrollable.ensureVisible(tester.element(finder), alignment: 0.5);
     await tester.pump();
     await tester.pumpUntilNoTransientCallbacks();
     await smokeDemo(tester, routeName);

--- a/packages/flutter/lib/src/material/app.dart
+++ b/packages/flutter/lib/src/material/app.dart
@@ -167,7 +167,7 @@ class MaterialApp extends StatefulWidget {
   _MaterialAppState createState() => new _MaterialAppState();
 }
 
-class _MaterialScrollBehavior extends ScrollBehavior2 {
+class _MaterialScrollBehavior extends ScrollBehavior {
   @override
   TargetPlatform getPlatform(BuildContext context) {
     return Theme.of(context).platform;
@@ -245,7 +245,7 @@ class _MaterialAppState extends State<MaterialApp> {
       return true;
     });
 
-    return new ScrollConfiguration2(
+    return new ScrollConfiguration(
       behavior: new _MaterialScrollBehavior(),
       child: result
     );

--- a/packages/flutter/lib/src/material/dropdown.dart
+++ b/packages/flutter/lib/src/material/dropdown.dart
@@ -79,7 +79,7 @@ class _DropdownMenuPainter extends CustomPainter {
 
 // Do not use the platform-specific default scroll configuration.
 // Dropdown menus should never overscroll or display an overscroll indicator.
-class _DropdownScrollBehavior extends ScrollBehavior2 {
+class _DropdownScrollBehavior extends ScrollBehavior {
   const _DropdownScrollBehavior();
 
   @override
@@ -176,7 +176,7 @@ class _DropdownMenuState<T> extends State<_DropdownMenu<T>> {
         child: new Material(
           type: MaterialType.transparency,
           textStyle: route.style,
-          child: new ScrollConfiguration2(
+          child: new ScrollConfiguration(
             behavior: const _DropdownScrollBehavior(),
             child: new Scrollbar(
               child: new ListView(

--- a/packages/flutter/lib/src/material/progress_indicator.dart
+++ b/packages/flutter/lib/src/material/progress_indicator.dart
@@ -432,7 +432,7 @@ class _RefreshProgressIndicatorPainter extends _CircularProgressIndicatorPainter
 /// An indicator for the progress of refreshing the contents of a widget.
 ///
 /// Typically used for swipe-to-refresh interactions. See [RefreshIndicator] for
-/// a complete implementation of swipe-to-refresh driven by a [Scrollable2]
+/// a complete implementation of swipe-to-refresh driven by a [Scrollable]
 /// widget.
 ///
 /// See also:
@@ -442,7 +442,7 @@ class RefreshProgressIndicator extends CircularProgressIndicator {
   /// Creates a refresh progress indicator.
   ///
   /// Rather than creating a refresh progress indicator directly, consider using
-  /// a [RefreshIndicator] together with a [Scrollable2] widget.
+  /// a [RefreshIndicator] together with a [Scrollable] widget.
   RefreshProgressIndicator({
     Key key,
     double value,

--- a/packages/flutter/lib/src/material/refresh_indicator.dart
+++ b/packages/flutter/lib/src/material/refresh_indicator.dart
@@ -47,7 +47,7 @@ enum _RefreshIndicatorMode {
 
 /// A widget that supports the Material "swipe to refresh" idiom.
 ///
-/// When the child's [Scrollable2] descendant overscrolls, an animated circular
+/// When the child's [Scrollable] descendant overscrolls, an animated circular
 /// progress indicator is faded into view. When the scroll ends, if the
 /// indicator has been dragged far enough for it to become completely opaque,
 /// the [onRefresh] callback is called. The callback is expected to update the
@@ -160,7 +160,7 @@ class RefreshIndicatorState extends State<RefreshIndicator> with TickerProviderS
     super.dispose();
   }
 
-  bool _handleScrollNotification(ScrollNotification2 notification) {
+  bool _handleScrollNotification(ScrollNotification notification) {
     if (notification.depth != 0)
       return false;
     if (notification is ScrollStartNotification && notification.metrics.extentBefore == 0.0 &&
@@ -343,7 +343,7 @@ class RefreshIndicatorState extends State<RefreshIndicator> with TickerProviderS
 
   @override
   Widget build(BuildContext context) {
-    Widget child = new NotificationListener<ScrollNotification2>(
+    Widget child = new NotificationListener<ScrollNotification>(
       key: _key,
       onNotification: _handleScrollNotification,
       child: new NotificationListener<OverscrollIndicatorNotification>(

--- a/packages/flutter/lib/src/material/scrollbar.dart
+++ b/packages/flutter/lib/src/material/scrollbar.dart
@@ -17,7 +17,7 @@ class Scrollbar extends StatefulWidget {
   }) : super(key: key);
 
   /// The subtree to place inside the [Scrollbar]. This should include
-  /// a source of [ScrollNotification2] notifications, typically a [Scrollable2]
+  /// a source of [ScrollNotification] notifications, typically a [Scrollable]
   /// widget.
   final Widget child;
 
@@ -35,7 +35,7 @@ class _ScrollbarState extends State<Scrollbar> with TickerProviderStateMixin {
     _controller.color = Theme.of(context).highlightColor;
   }
 
-  bool _handleScrollNotification(ScrollNotification2 notification) {
+  bool _handleScrollNotification(ScrollNotification notification) {
     if (notification is ScrollUpdateNotification ||
         notification is OverscrollNotification)
       _controller.update(notification.metrics, notification.axisDirection);
@@ -50,7 +50,7 @@ class _ScrollbarState extends State<Scrollbar> with TickerProviderStateMixin {
 
   @override
   Widget build(BuildContext context) {
-    return new NotificationListener<ScrollNotification2>(
+    return new NotificationListener<ScrollNotification>(
       onNotification: _handleScrollNotification,
       // TODO(ianh): Maybe we should try to collapse out these repaint
       // boundaries when the scroll bars are invisible.

--- a/packages/flutter/lib/src/material/stepper.dart
+++ b/packages/flutter/lib/src/material/stepper.dart
@@ -525,7 +525,7 @@ class _StepperState extends State<Stepper> with TickerProviderStateMixin {
               onTap: config.steps[i].state != StepState.disabled ? () {
                 // In the vertical case we need to scroll to the newly tapped
                 // step.
-                Scrollable2.ensureVisible(
+                Scrollable.ensureVisible(
                   _keys[i].currentContext,
                   curve: Curves.fastOutSlowIn,
                   duration: kThemeAnimationDuration,

--- a/packages/flutter/lib/src/material/tabs.dart
+++ b/packages/flutter/lib/src/material/tabs.dart
@@ -722,7 +722,7 @@ class _TabBarViewState extends State<TabBarView> {
   }
 
   // Called when the PageView scrolls
-  bool _handleScrollNotification(ScrollNotification2 notification) {
+  bool _handleScrollNotification(ScrollNotification notification) {
     if (_warpUnderwayCount > 0)
       return false;
 
@@ -760,7 +760,7 @@ class _TabBarViewState extends State<TabBarView> {
 
   @override
   Widget build(BuildContext context) {
-    return new NotificationListener<ScrollNotification2>(
+    return new NotificationListener<ScrollNotification>(
       onNotification: _handleScrollNotification,
       child: new PageView(
         controller: _pageController,

--- a/packages/flutter/lib/src/rendering/sliver.dart
+++ b/packages/flutter/lib/src/rendering/sliver.dart
@@ -574,7 +574,7 @@ class SliverLogicalParentData extends ParentData {
 class SliverLogicalContainerParentData extends SliverLogicalParentData with ContainerParentDataMixin<RenderSliver> { }
 
 /// Parent data structure used by parents of slivers that position their
-/// children using absolute coordinates. For example, used by [RenderViewport2].
+/// children using absolute coordinates. For example, used by [RenderViewport].
 ///
 /// This data structure is optimised for fast painting, at the cost of requiring
 /// additional work during layout when the children change their offsets. It is
@@ -715,12 +715,12 @@ abstract class RenderSliver extends RenderObject {
   /// that this sliver can cover.
   ///
   /// For example, if an [AxisDirection.down] viewport with an
-  /// [RenderViewport2.anchor] of 0.5 has a single sliver with a height of 100.0
+  /// [RenderViewport.anchor] of 0.5 has a single sliver with a height of 100.0
   /// and its [centerOffsetAdjustment] returns 50.0, then the sliver will be
   /// centered in the viewport when the scroll offset is 0.0.
   ///
   /// The distance here is in the opposite direction of the
-  /// [RenderViewport2.axisDirection], so values will typically be positive.
+  /// [RenderViewport.axisDirection], so values will typically be positive.
   double get centerOffsetAdjustment => 0.0;
 
   /// Determines the set of render objects located at the given position.
@@ -1126,10 +1126,10 @@ abstract class RenderAbstractViewport implements RenderObject {
 // /// - [RenderBox], which explains more about the Box protocol.
 // /// - [RenderSliverToBoxAdapter], which allows a [RenderBox] object to be
 // ///   placed inside a [RenderSliver] (the opposite of this class).
-abstract class RenderViewportBase2<ParentDataClass extends ContainerParentDataMixin<RenderSliver>>
+abstract class RenderViewportBase<ParentDataClass extends ContainerParentDataMixin<RenderSliver>>
     extends RenderBox with ContainerRenderObjectMixin<RenderSliver, ParentDataClass>
     implements RenderAbstractViewport {
-  RenderViewportBase2({
+  RenderViewportBase({
     AxisDirection axisDirection: AxisDirection.down,
     @required ViewportOffset offset,
   }) : _axisDirection = axisDirection,
@@ -1528,9 +1528,9 @@ abstract class RenderViewportBase2<ParentDataClass extends ContainerParentDataMi
 // /// - [RenderBox], which explains more about the Box protocol.
 // /// - [RenderSliverToBoxAdapter], which allows a [RenderBox] object to be
 // ///   placed inside a [RenderSliver] (the opposite of this class).
-// /// - [RenderShrinkWrappingViewport], a variant of [RenderViewport2] that
+// /// - [RenderShrinkWrappingViewport], a variant of [RenderViewport] that
 // ///   shrink-wraps its contents along the main axis.
-class RenderViewport2 extends RenderViewportBase2<SliverPhysicalContainerParentData> {
+class RenderViewport extends RenderViewportBase<SliverPhysicalContainerParentData> {
   /// Creates a viewport for [RenderSliver] objects.
   ///
   /// If the [center] is not specified, then the first child in the `children`
@@ -1538,7 +1538,7 @@ class RenderViewport2 extends RenderViewportBase2<SliverPhysicalContainerParentD
   ///
   /// The [offset] must be specified. For testing purposes, consider passing a
   /// [new ViewportOffset.zero] or [new ViewportOffset.fixed].
-  RenderViewport2({
+  RenderViewport({
     AxisDirection axisDirection: AxisDirection.down,
     @required ViewportOffset offset,
     double anchor: 0.0,
@@ -1653,14 +1653,14 @@ class RenderViewport2 extends RenderViewportBase2<SliverPhysicalContainerParentD
       if (count >= _kMaxLayoutCycles) {
         assert(count != 1);
         throw new FlutterError(
-          'A RenderViewport2 exceeded its maximum number of layout cycles.\n'
-          'RenderViewport2 render objects, during layout, can retry if either their '
+          'A RenderViewport exceeded its maximum number of layout cycles.\n'
+          'RenderViewport render objects, during layout, can retry if either their '
           'slivers or their ViewportOffset decide that the offset should be corrected '
           'to take into account information collected during that layout.\n'
-          'In the case of this RenderViewport2 object, however, this happened $count '
+          'In the case of this RenderViewport object, however, this happened $count '
           'times and still there was no consensus on the scroll offset. This usually '
           'indicates a bug. Specifically, it means that one of the following three '
-          'problems is being experienced by the RenderViewport2 object:\n'
+          'problems is being experienced by the RenderViewport object:\n'
           ' * One of the RenderSliver children or the ViewportOffset have a bug such'
           ' that they always think that they need to correct the offset regardless.\n'
           ' * Some combination of the RenderSliver children and the ViewportOffset'
@@ -1685,7 +1685,7 @@ class RenderViewport2 extends RenderViewportBase2<SliverPhysicalContainerParentD
     _maxScrollExtent = 0.0;
     _hasVisualOverflow = false;
 
-    // centerOffset is the offset from the leading edge of the RenderViewport2
+    // centerOffset is the offset from the leading edge of the RenderViewport
     // to the zero scroll offset (the line between the forward slivers and the
     // reverse slivers). The other two are that, but clamped to the visible
     // region of the viewport.
@@ -1865,12 +1865,12 @@ class RenderViewport2 extends RenderViewportBase2<SliverPhysicalContainerParentD
 // ///
 // /// See also:
 // ///
-// /// - [RenderViewport2], a viewport that does not shrink-wrap its contents
+// /// - [RenderViewport], a viewport that does not shrink-wrap its contents
 // /// - [RenderSliver], which explains more about the Sliver protocol.
 // /// - [RenderBox], which explains more about the Box protocol.
 // /// - [RenderSliverToBoxAdapter], which allows a [RenderBox] object to be
 // ///   placed inside a [RenderSliver] (the opposite of this class).
-class RenderShrinkWrappingViewport extends RenderViewportBase2<SliverLogicalContainerParentData> {
+class RenderShrinkWrappingViewport extends RenderViewportBase<SliverLogicalContainerParentData> {
   /// Creates a viewport (for [RenderSliver] objects) that shrink-wraps its
   /// contents.
   ///
@@ -2084,7 +2084,7 @@ class RenderShrinkWrappingViewport extends RenderViewportBase2<SliverLogicalCont
 ///
 /// - [RenderSliver], which explains more about the Sliver protocol.
 /// - [RenderBox], which explains more about the Box protocol.
-/// - [RenderViewport2], which allows [RenderSliver] objects to be placed inside
+/// - [RenderViewport], which allows [RenderSliver] objects to be placed inside
 ///   a [RenderBox] (the opposite of this class).
 class RenderSliverToBoxAdapter extends RenderSliver with RenderObjectWithChildMixin<RenderBox>, RenderSliverHelpers {
   /// Creates a [RenderSliver] that wraps a [RenderBox].

--- a/packages/flutter/lib/src/rendering/viewport_offset.dart
+++ b/packages/flutter/lib/src/rendering/viewport_offset.dart
@@ -48,11 +48,11 @@ abstract class ViewportOffset extends ChangeNotifier {
 
   /// Called when the viewport's extents are established.
   ///
-  /// The argument is the dimension of the [RenderViewport2] in the main axis
+  /// The argument is the dimension of the [RenderViewport] in the main axis
   /// (e.g. the height, for a vertical viewport).
   ///
   /// This may be called redundantly, with the same value, each frame. This is
-  /// called during layout for the [RenderViewport2]. If the viewport is
+  /// called during layout for the [RenderViewport]. If the viewport is
   /// configured to shrink-wrap its contents, it may be called several times,
   /// since the layout is repeated each time the scroll offset is corrected.
   ///
@@ -63,7 +63,7 @@ abstract class ViewportOffset extends ChangeNotifier {
   /// size (i.e. when its parent lays out), and not during normal scrolling.
   ///
   /// If applying the viewport dimentions changes the scroll offset, return
-  /// false. Otherwise, return true. If you return false, the [RenderViewport2]
+  /// false. Otherwise, return true. If you return false, the [RenderViewport]
   /// will be laid out again with the new scroll offset. This is expensive. (The
   /// return value is answering the question "did you accept these viewport
   /// dimensions unconditionally?"; if the new dimensions change the
@@ -84,14 +84,14 @@ abstract class ViewportOffset extends ChangeNotifier {
   /// because there's only 20.0 pixels of actual scroll slack.
   ///
   /// If applying the content dimensions changes the scroll offset, return
-  /// false. Otherwise, return true. If you return false, the [RenderViewport2]
+  /// false. Otherwise, return true. If you return false, the [RenderViewport]
   /// will be laid out again with the new scroll offset. This is expensive. (The
   /// return value is answering the question "did you accept these content
   /// dimensions unconditionally?"; if the new dimensions change the
   /// [ViewportOffset]'s actual [pixels] value, then the viewport will need to
   /// be laid out again.)
   ///
-  /// This is called at least once each time the [RenderViewport2] is laid out,
+  /// This is called at least once each time the [RenderViewport] is laid out,
   /// even if the values have not changed. It may be called many times if the
   /// scroll offset is corrected (if this returns false). This is always called
   /// after [applyViewportDimension], if that method is called.
@@ -101,13 +101,13 @@ abstract class ViewportOffset extends ChangeNotifier {
   ///
   /// This method should change the [pixels] value by `correction`, but without
   /// calling [notifyListeners]. It is called during layout by the
-  /// [RenderViewport2], before [applyContentDimensions]. After this method is
+  /// [RenderViewport], before [applyContentDimensions]. After this method is
   /// called, the layout will be recomputed and that may result in this method
   /// being called again, though this should be very rare.
   void correctBy(double correction);
 
   /// The direction in which the user is trying to change [pixels], relative to
-  /// the viewport's [RenderViewport2.axisDirection].
+  /// the viewport's [RenderViewport.axisDirection].
   ///
   /// This is used by some slivers to determine how to react to a change in
   /// scroll offset. For example, [RenderSliverFloatingPersistentHeader] will

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -423,7 +423,7 @@ class EditableTextState extends State<EditableText> implements TextInputClient {
       }
     }
 
-    return new Scrollable2(
+    return new Scrollable(
       axisDirection: _isMultiline ? AxisDirection.down : AxisDirection.right,
       controller: _scrollController,
       physics: const ClampingScrollPhysics(),

--- a/packages/flutter/lib/src/widgets/focus.dart
+++ b/packages/flutter/lib/src/widgets/focus.dart
@@ -192,7 +192,7 @@ class Focus extends StatefulWidget {
     _FocusScope focusScope = key.currentContext.ancestorWidgetOfExactType(_FocusScope);
     if (focusScope != null) {
       focusScope.focusState._setFocusedWidget(key);
-      Scrollable2.ensureVisible(focusedContext);
+      Scrollable.ensureVisible(focusedContext);
     }
   }
 
@@ -359,7 +359,7 @@ class _FocusState extends State<Focus> {
     BuildContext focusedContext = _focusedWidget?.currentContext;
     if (focusedContext == null)
       return;
-    Scrollable2.ensureVisible(focusedContext);
+    Scrollable.ensureVisible(focusedContext);
   }
 
   @override

--- a/packages/flutter/lib/src/widgets/notification_listener.dart
+++ b/packages/flutter/lib/src/widgets/notification_listener.dart
@@ -123,7 +123,7 @@ class NotificationListener<T extends Notification> extends StatelessWidget {
 /// Useful if, for instance, you're trying to align multiple descendants.
 ///
 /// In the widgets library, only the [SizeChangedLayoutNotifier] class and
-/// [Scrollable2] classes dispatch this notification (specifically, they dispatch
+/// [Scrollable] classes dispatch this notification (specifically, they dispatch
 /// [SizeChangedLayoutNotification]s and [ScrollNotification]s respectively).
 /// Transitions, in particular, do not. Changing one's layout in one's build
 /// function does not cause this notification to be dispatched automatically. If

--- a/packages/flutter/lib/src/widgets/overscroll_indicator.dart
+++ b/packages/flutter/lib/src/widgets/overscroll_indicator.dart
@@ -49,7 +49,7 @@ class GlowingOverscrollIndicator extends StatefulWidget {
   final bool showTrailing;
 
   /// The direction of positive scroll offsets in the viewport of the
-  /// [Scrollable2] whose overscrolls are to be visualized.
+  /// [Scrollable] whose overscrolls are to be visualized.
   final AxisDirection axisDirection;
 
   Axis get axis => axisDirectionToAxis(axisDirection);
@@ -58,11 +58,11 @@ class GlowingOverscrollIndicator extends StatefulWidget {
   final Color color;
 
   /// The subtree to place inside the overscroll indicator. This should include
-  /// a source of [ScrollNotification2] notifications, typically a [Scrollable2]
+  /// a source of [ScrollNotification] notifications, typically a [Scrollable]
   /// widget.
   ///
   /// Typically a [GlowingOverscrollIndicator] is created by a
-  /// [ScrollBehavior2.buildViewportChrome] method, in which case
+  /// [ScrollBehavior.buildViewportChrome] method, in which case
   /// the child is usually the one provided as an argument to that method.
   final Widget child;
 
@@ -110,7 +110,7 @@ class _GlowingOverscrollIndicatorState extends State<GlowingOverscrollIndicator>
   Type _lastNotificationType;
   final Map<bool, bool> _accepted = <bool, bool>{false: true, true: true};
 
-  bool _handleScrollNotification(ScrollNotification2 notification) {
+  bool _handleScrollNotification(ScrollNotification notification) {
     if (notification.depth != 0)
       return false;
     if (notification is OverscrollNotification) {
@@ -173,7 +173,7 @@ class _GlowingOverscrollIndicatorState extends State<GlowingOverscrollIndicator>
 
   @override
   Widget build(BuildContext context) {
-    return new NotificationListener<ScrollNotification2>(
+    return new NotificationListener<ScrollNotification>(
       onNotification: _handleScrollNotification,
       child: new RepaintBoundary(
         child: new CustomPaint(

--- a/packages/flutter/lib/src/widgets/page_view.dart
+++ b/packages/flutter/lib/src/widgets/page_view.dart
@@ -186,8 +186,8 @@ class PageView extends BoxScrollView {
   @override
   Widget build(BuildContext context) {
     final Widget scrollable = super.build(context);
-    return new NotificationListener<ScrollNotification2>(
-      onNotification: (ScrollNotification2 notification) {
+    return new NotificationListener<ScrollNotification>(
+      onNotification: (ScrollNotification notification) {
         if (notification.depth == 0 && onPageChanged != null && notification is ScrollEndNotification) {
           final ScrollMetrics metrics = notification.metrics;
           onPageChanged(metrics.extentBefore ~/ metrics.viewportDimension);

--- a/packages/flutter/lib/src/widgets/scroll_configuration.dart
+++ b/packages/flutter/lib/src/widgets/scroll_configuration.dart
@@ -9,8 +9,8 @@ import 'framework.dart';
 import 'scroll_physics.dart';
 import 'overscroll_indicator.dart';
 
-class ScrollBehavior2 {
-  const ScrollBehavior2();
+class ScrollBehavior {
+  const ScrollBehavior();
 
   /// The platform whose scroll physics should be implemented.
   ///
@@ -53,25 +53,25 @@ class ScrollBehavior2 {
     return null;
   }
 
-  bool shouldNotify(@checked ScrollBehavior2 oldDelegate) => false;
+  bool shouldNotify(@checked ScrollBehavior oldDelegate) => false;
 }
 
-class ScrollConfiguration2 extends InheritedWidget {
-  const ScrollConfiguration2({
+class ScrollConfiguration extends InheritedWidget {
+  const ScrollConfiguration({
     Key key,
     @required this.behavior,
     @required Widget child,
   }) : super(key: key, child: child);
 
-  final ScrollBehavior2 behavior;
+  final ScrollBehavior behavior;
 
-  static ScrollBehavior2 of(BuildContext context) {
-    final ScrollConfiguration2 configuration = context.inheritFromWidgetOfExactType(ScrollConfiguration2);
-    return configuration?.behavior ?? const ScrollBehavior2();
+  static ScrollBehavior of(BuildContext context) {
+    final ScrollConfiguration configuration = context.inheritFromWidgetOfExactType(ScrollConfiguration);
+    return configuration?.behavior ?? const ScrollBehavior();
   }
 
   @override
-  bool updateShouldNotify(ScrollConfiguration2 old) {
+  bool updateShouldNotify(ScrollConfiguration old) {
     assert(behavior != null);
     return behavior.runtimeType != old.behavior.runtimeType
         || behavior.shouldNotify(old.behavior);

--- a/packages/flutter/lib/src/widgets/scroll_notification.dart
+++ b/packages/flutter/lib/src/widgets/scroll_notification.dart
@@ -9,9 +9,9 @@ import 'package:flutter/rendering.dart';
 import 'framework.dart';
 import 'basic.dart';
 import 'notification_listener.dart';
-import 'scrollable.dart' show Scrollable2, Scrollable2State;
+import 'scrollable.dart' show Scrollable, ScrollableState;
 
-/// A description of a [Scrollable2]'s contents, useful for modelling the state
+/// A description of a [Scrollable]'s contents, useful for modelling the state
 /// of the viewport, for example by a [Scrollbar].
 ///
 /// The units used by the [extentBefore], [extentInside], and [extentAfter] are
@@ -19,7 +19,7 @@ import 'scrollable.dart' show Scrollable2, Scrollable2State;
 /// or in percentages, or in units of the [extentInside] (in the latter case,
 /// [extentInside] would always be 1.0).
 class ScrollMetrics {
-  /// Create a description of the metrics of a [Scrollable2]'s contents.
+  /// Create a description of the metrics of a [Scrollable]'s contents.
   ///
   /// The three arguments must be present, non-null, finite, and non-negative.
   const ScrollMetrics({
@@ -57,7 +57,7 @@ class ScrollMetrics {
 /// Mixin for [Notification]s that track how many [RenderAbstractViewport] they
 /// have bubbled through.
 ///
-/// This is used by [ScrollNotification2] and [OverscrollIndicatorNotification].
+/// This is used by [ScrollNotification] and [OverscrollIndicatorNotification].
 abstract class ViewportNotificationMixin extends Notification {
   /// The number of viewports that this notification has bubbled through.
   ///
@@ -83,10 +83,10 @@ abstract class ViewportNotificationMixin extends Notification {
   }
 }
 
-abstract class ScrollNotification2 extends LayoutChangedNotification with ViewportNotificationMixin {
+abstract class ScrollNotification extends LayoutChangedNotification with ViewportNotificationMixin {
   /// Creates a notification about scrolling.
-  ScrollNotification2({
-    @required Scrollable2State scrollable,
+  ScrollNotification({
+    @required ScrollableState scrollable,
   }) : axisDirection = scrollable.config.axisDirection,
        metrics = scrollable.position.getMetrics(),
        context = scrollable.context;
@@ -98,7 +98,7 @@ abstract class ScrollNotification2 extends LayoutChangedNotification with Viewpo
 
   final ScrollMetrics metrics;
 
-  /// The build context of the [Scrollable2] that fired this notification.
+  /// The build context of the [Scrollable] that fired this notification.
   ///
   /// This can be used to find the scrollable's render objects to determine the
   /// size of the viewport, for instance.
@@ -112,9 +112,9 @@ abstract class ScrollNotification2 extends LayoutChangedNotification with Viewpo
   }
 }
 
-class ScrollStartNotification extends ScrollNotification2 {
+class ScrollStartNotification extends ScrollNotification {
   ScrollStartNotification({
-    @required Scrollable2State scrollable,
+    @required ScrollableState scrollable,
     this.dragDetails,
   }) : super(scrollable: scrollable);
 
@@ -128,16 +128,16 @@ class ScrollStartNotification extends ScrollNotification2 {
   }
 }
 
-class ScrollUpdateNotification extends ScrollNotification2 {
+class ScrollUpdateNotification extends ScrollNotification {
   ScrollUpdateNotification({
-    @required Scrollable2State scrollable,
+    @required ScrollableState scrollable,
     this.dragDetails,
     this.scrollDelta,
   }) : super(scrollable: scrollable);
 
   final DragUpdateDetails dragDetails;
 
-  /// The distance by which the [Scrollable2] was scrolled, in logical pixels.
+  /// The distance by which the [Scrollable] was scrolled, in logical pixels.
   final double scrollDelta;
 
   @override
@@ -149,9 +149,9 @@ class ScrollUpdateNotification extends ScrollNotification2 {
   }
 }
 
-class OverscrollNotification extends ScrollNotification2 {
+class OverscrollNotification extends ScrollNotification {
   OverscrollNotification({
-    @required Scrollable2State scrollable,
+    @required ScrollableState scrollable,
     this.dragDetails,
     @required this.overscroll,
     this.velocity: 0.0,
@@ -164,7 +164,7 @@ class OverscrollNotification extends ScrollNotification2 {
 
   final DragUpdateDetails dragDetails;
 
-  /// The number of logical pixels that the [Scrollable2] avoided scrolling.
+  /// The number of logical pixels that the [Scrollable] avoided scrolling.
   ///
   /// This will be negative for overscroll on the "start" side and positive for
   /// overscroll on the "end" side.
@@ -188,9 +188,9 @@ class OverscrollNotification extends ScrollNotification2 {
   }
 }
 
-class ScrollEndNotification extends ScrollNotification2 {
+class ScrollEndNotification extends ScrollNotification {
   ScrollEndNotification({
-    @required Scrollable2State scrollable,
+    @required ScrollableState scrollable,
     this.dragDetails,
   }) : super(scrollable: scrollable);
 
@@ -204,9 +204,9 @@ class ScrollEndNotification extends ScrollNotification2 {
   }
 }
 
-class UserScrollNotification extends ScrollNotification2 {
+class UserScrollNotification extends ScrollNotification {
   UserScrollNotification({
-    @required Scrollable2State scrollable,
+    @required ScrollableState scrollable,
     this.direction,
   }) : super(scrollable: scrollable);
 

--- a/packages/flutter/lib/src/widgets/scroll_position.dart
+++ b/packages/flutter/lib/src/widgets/scroll_position.dart
@@ -219,7 +219,7 @@ class ScrollPosition extends ViewportOffset {
     beginBallisticActivity(0.0);
   }
 
-  /// Returns a description of the [Scrollable2].
+  /// Returns a description of the [Scrollable].
   ///
   /// Accurately describing the metrics typicaly requires using information
   /// provided by the viewport to the [applyViewportDimension] and

--- a/packages/flutter/lib/src/widgets/scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/scroll_view.dart
@@ -64,7 +64,7 @@ abstract class ScrollView extends StatelessWidget {
   Widget build(BuildContext context) {
     List<Widget> slivers = buildSlivers(context);
     AxisDirection axisDirection = getDirection(context);
-    return new Scrollable2(
+    return new Scrollable(
       axisDirection: axisDirection,
       controller: controller ?? (primary ? PrimaryScrollController.of(context) : null),
       physics: physics,
@@ -76,7 +76,7 @@ abstract class ScrollView extends StatelessWidget {
             slivers: slivers,
           );
         } else {
-          return new Viewport2(
+          return new Viewport(
             axisDirection: axisDirection,
             offset: offset,
             slivers: slivers,

--- a/packages/flutter/lib/src/widgets/scrollable.dart
+++ b/packages/flutter/lib/src/widgets/scrollable.dart
@@ -24,8 +24,8 @@ export 'package:flutter/physics.dart' show Tolerance;
 
 typedef Widget ViewportBuilder(BuildContext context, ViewportOffset position);
 
-class Scrollable2 extends StatefulWidget {
-  Scrollable2({
+class Scrollable extends StatefulWidget {
+  Scrollable({
     Key key,
     this.axisDirection: AxisDirection.down,
     this.controller,
@@ -47,7 +47,7 @@ class Scrollable2 extends StatefulWidget {
   Axis get axis => axisDirectionToAxis(axisDirection);
 
   @override
-  Scrollable2State createState() => new Scrollable2State();
+  ScrollableState createState() => new ScrollableState();
 
   @override
   void debugFillDescription(List<String> description) {
@@ -62,10 +62,10 @@ class Scrollable2 extends StatefulWidget {
   /// Typical usage is as follows:
   ///
   /// ```dart
-  /// Scrollable2State scrollable = Scrollable2.of(context);
+  /// ScrollableState scrollable = Scrollable.of(context);
   /// ```
-  static Scrollable2State of(BuildContext context) {
-    return context.ancestorStateOfType(const TypeMatcher<Scrollable2State>());
+  static ScrollableState of(BuildContext context) {
+    return context.ancestorStateOfType(const TypeMatcher<ScrollableState>());
   }
 
   /// Scrolls the closest enclosing scrollable to make the given context visible.
@@ -76,7 +76,7 @@ class Scrollable2 extends StatefulWidget {
   }) {
     final List<Future<Null>> futures = <Future<Null>>[];
 
-    Scrollable2State scrollable = Scrollable2.of(context);
+    ScrollableState scrollable = Scrollable.of(context);
     while (scrollable != null) {
       futures.add(scrollable.position.ensureVisible(
         context.findRenderObject(),
@@ -85,7 +85,7 @@ class Scrollable2 extends StatefulWidget {
         curve: curve,
       ));
       context = scrollable.context;
-      scrollable = Scrollable2.of(context);
+      scrollable = Scrollable.of(context);
     }
 
     if (futures.isEmpty || duration == Duration.ZERO)
@@ -96,32 +96,32 @@ class Scrollable2 extends StatefulWidget {
   }
 }
 
-/// State object for a [Scrollable2] widget.
+/// State object for a [Scrollable] widget.
 ///
-/// To manipulate a [Scrollable2] widget's scroll position, use the object
+/// To manipulate a [Scrollable] widget's scroll position, use the object
 /// obtained from the [position] property.
 ///
-/// To be informed of when a [Scrollable2] widget is scrolling, use a
-/// [NotificationListener] to listen for [ScrollNotification2] notifications.
+/// To be informed of when a [Scrollable] widget is scrolling, use a
+/// [NotificationListener] to listen for [ScrollNotification] notifications.
 ///
 /// This class is not intended to be subclassed. To specialize the behavior of a
-/// [Scrollable2], provide it with a [ScrollPhysics].
-class Scrollable2State extends State<Scrollable2> with TickerProviderStateMixin
+/// [Scrollable], provide it with a [ScrollPhysics].
+class ScrollableState extends State<Scrollable> with TickerProviderStateMixin
     implements AbstractScrollState {
-  /// The controller for this [Scrollable2] widget's viewport position.
+  /// The controller for this [Scrollable] widget's viewport position.
   ///
-  /// To control what kind of [ScrollPosition] is created for a [Scrollable2],
+  /// To control what kind of [ScrollPosition] is created for a [Scrollable],
   /// provide it with custom [ScrollPhysics] that creates the appropriate
   /// [ScrollPosition] controller in its [ScrollPhysics.createScrollPosition]
   /// method.
   ScrollPosition get position => _position;
   ScrollPosition _position;
 
-  ScrollBehavior2 _configuration;
+  ScrollBehavior _configuration;
 
   // only call this from places that will definitely trigger a rebuild
   void _updatePosition() {
-    _configuration = ScrollConfiguration2.of(context);
+    _configuration = ScrollConfiguration.of(context);
     ScrollPhysics physics = _configuration.getScrollPhysics(context);
     if (config.physics != null)
       physics = config.physics.applyTo(physics);
@@ -147,13 +147,13 @@ class Scrollable2State extends State<Scrollable2> with TickerProviderStateMixin
     _updatePosition();
   }
 
-  bool _shouldUpdatePosition(Scrollable2 oldConfig) {
+  bool _shouldUpdatePosition(Scrollable oldConfig) {
     return config.physics?.runtimeType != oldConfig.physics?.runtimeType
         || config.controller?.runtimeType != oldConfig.controller?.runtimeType;
   }
 
   @override
-  void didUpdateConfig(Scrollable2 oldConfig) {
+  void didUpdateConfig(Scrollable oldConfig) {
     super.didUpdateConfig(oldConfig);
 
     if (config.controller != oldConfig.controller) {

--- a/packages/flutter/lib/src/widgets/single_child_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/single_child_scroll_view.dart
@@ -35,7 +35,7 @@ import 'scrollable.dart';
 /// * [ListView], which handles multiple children in a scrolling list.
 /// * [GridView], which handles multiple children in a scrolling grid.
 /// * [PageView], for a scrollable that works page by page.
-/// * [Scrollable2], which handles arbitrary scrolling effects.
+/// * [Scrollable], which handles arbitrary scrolling effects.
 class SingleChildScrollView extends StatelessWidget {
   SingleChildScrollView({
     Key key,
@@ -78,7 +78,7 @@ class SingleChildScrollView extends StatelessWidget {
     Widget contents = child;
     if (padding != null)
       contents = new Padding(padding: padding, child: contents);
-    return new Scrollable2(
+    return new Scrollable(
       axisDirection: axisDirection,
       controller: controller,
       physics: physics,

--- a/packages/flutter/lib/src/widgets/viewport.dart
+++ b/packages/flutter/lib/src/widgets/viewport.dart
@@ -11,8 +11,8 @@ export 'package:flutter/rendering.dart' show
   AxisDirection,
   GrowthDirection;
 
-class Viewport2 extends MultiChildRenderObjectWidget {
-  Viewport2({
+class Viewport extends MultiChildRenderObjectWidget {
+  Viewport({
     Key key,
     this.axisDirection: AxisDirection.down,
     this.anchor: 0.0,
@@ -30,8 +30,8 @@ class Viewport2 extends MultiChildRenderObjectWidget {
   final Key center;
 
   @override
-  RenderViewport2 createRenderObject(BuildContext context) {
-    return new RenderViewport2(
+  RenderViewport createRenderObject(BuildContext context) {
+    return new RenderViewport(
       axisDirection: axisDirection,
       anchor: anchor,
       offset: offset,
@@ -39,14 +39,14 @@ class Viewport2 extends MultiChildRenderObjectWidget {
   }
 
   @override
-  void updateRenderObject(BuildContext context, RenderViewport2 renderObject) {
+  void updateRenderObject(BuildContext context, RenderViewport renderObject) {
     renderObject.axisDirection = axisDirection;
     renderObject.anchor = anchor;
     renderObject.offset = offset;
   }
 
   @override
-  Viewport2Element createElement() => new Viewport2Element(this);
+  ViewportElement createElement() => new ViewportElement(this);
 
   @override
   void debugFillDescription(List<String> description) {
@@ -62,15 +62,15 @@ class Viewport2 extends MultiChildRenderObjectWidget {
   }
 }
 
-class Viewport2Element extends MultiChildRenderObjectElement {
+class ViewportElement extends MultiChildRenderObjectElement {
   /// Creates an element that uses the given widget as its configuration.
-  Viewport2Element(Viewport2 widget) : super(widget);
+  ViewportElement(Viewport widget) : super(widget);
 
   @override
-  Viewport2 get widget => super.widget;
+  Viewport get widget => super.widget;
 
   @override
-  RenderViewport2 get renderObject => super.renderObject;
+  RenderViewport get renderObject => super.renderObject;
 
   @override
   void mount(Element parent, dynamic newSlot) {

--- a/packages/flutter/test/material/scaffold_test.dart
+++ b/packages/flutter/test/material/scaffold_test.dart
@@ -161,7 +161,7 @@ void main() {
 
   testWidgets('Tapping the status bar scrolls to top on iOS', (WidgetTester tester) async {
     await tester.pumpWidget(_buildStatusBarTestApp(TargetPlatform.iOS));
-    final Scrollable2State scrollable = tester.state(find.byType(Scrollable2));
+    final ScrollableState scrollable = tester.state(find.byType(Scrollable));
     scrollable.position.jumpTo(500.0);
     expect(scrollable.position.pixels, equals(500.0));
     await tester.tapAt(const Point(100.0, 10.0));
@@ -172,7 +172,7 @@ void main() {
 
   testWidgets('Tapping the status bar does not scroll to top on Android', (WidgetTester tester) async {
     await tester.pumpWidget(_buildStatusBarTestApp(TargetPlatform.android));
-    final Scrollable2State scrollable = tester.state(find.byType(Scrollable2));
+    final ScrollableState scrollable = tester.state(find.byType(Scrollable));
     scrollable.position.jumpTo(500.0);
     expect(scrollable.position.pixels, equals(500.0));
     await tester.tapAt(const Point(100.0, 10.0));

--- a/packages/flutter/test/material/scrollbar_paint_test.dart
+++ b/packages/flutter/test/material/scrollbar_paint_test.dart
@@ -8,7 +8,7 @@ import 'package:flutter/material.dart';
 import '../rendering/mock_canvas.dart';
 
 void main() {
-  testWidgets('Viewport2 basic test', (WidgetTester tester) async {
+  testWidgets('Viewport basic test', (WidgetTester tester) async {
     await tester.pumpWidget(new Scrollbar(
       child: new SingleChildScrollView(
         child: const SizedBox(width: 4000.0, height: 4000.0),

--- a/packages/flutter/test/material/stepper_test.dart
+++ b/packages/flutter/test/material/stepper_test.dart
@@ -276,7 +276,7 @@ void main() {
       )
     );
 
-    Scrollable2State scrollableState = tester.firstState(find.byType(Scrollable2));
+    ScrollableState scrollableState = tester.firstState(find.byType(Scrollable));
     expect(scrollableState.position.pixels, 0.0);
 
     await tester.tap(find.text('Step 3'));

--- a/packages/flutter/test/rendering/debug_test.dart
+++ b/packages/flutter/test/rendering/debug_test.dart
@@ -37,7 +37,7 @@ void main() {
     debugPaintSizeEnabled = true;
     RenderSliver s;
     RenderBox b;
-    RenderViewport2 root = new RenderViewport2(
+    RenderViewport root = new RenderViewport(
       offset: new ViewportOffset.zero(),
       children: <RenderSliver>[
         s = new RenderSliverPadding(
@@ -64,7 +64,7 @@ void main() {
     RenderSliver s;
     RenderBox b = new RenderPadding(
       padding: const EdgeInsets.all(10.0),
-      child: new RenderViewport2(
+      child: new RenderViewport(
         offset: new ViewportOffset.zero(),
         children: <RenderSliver>[
           s = new RenderSliverPadding(

--- a/packages/flutter/test/rendering/slivers_block_test.dart
+++ b/packages/flutter/test/rendering/slivers_block_test.dart
@@ -77,7 +77,7 @@ void main() {
         e = new RenderSizedBox(const Size(100.0, 400.0)),
       ],
     );
-    RenderViewport2 root = new RenderViewport2(
+    RenderViewport root = new RenderViewport(
       axisDirection: AxisDirection.down,
       offset: new ViewportOffset.zero(),
       children: <RenderSliver>[
@@ -151,7 +151,7 @@ void main() {
         e = new RenderSizedBox(const Size(100.0, 400.0)),
       ],
     );
-    RenderViewport2 root = new RenderViewport2(
+    RenderViewport root = new RenderViewport(
       axisDirection: AxisDirection.up,
       offset: new ViewportOffset.zero(),
       children: <RenderSliver>[

--- a/packages/flutter/test/rendering/slivers_layout_test.dart
+++ b/packages/flutter/test/rendering/slivers_layout_test.dart
@@ -19,12 +19,12 @@ class RenderLayoutWatcher extends RenderProxyBox {
 }
 
 void main() {
-  test('RenderViewport2 basic test - impact of layout', () {
+  test('RenderViewport basic test - impact of layout', () {
     RenderSliverToBoxAdapter sliver;
-    RenderViewport2 viewport;
+    RenderViewport viewport;
     RenderBox box;
     RenderObject root = new RenderLayoutWatcher(
-      viewport = new RenderViewport2(
+      viewport = new RenderViewport(
         offset: new ViewportOffset.zero(),
         children: <RenderSliver>[
           sliver = new RenderSliverToBoxAdapter(child: box = new RenderSizedBox(const Size(100.0, 400.0))),

--- a/packages/flutter/test/rendering/slivers_test.dart
+++ b/packages/flutter/test/rendering/slivers_test.dart
@@ -8,8 +8,8 @@ import 'package:test/test.dart';
 import 'rendering_tester.dart';
 
 void main() {
-  test('RenderViewport2 basic test - no children', () {
-    RenderViewport2 root = new RenderViewport2(
+  test('RenderViewport basic test - no children', () {
+    RenderViewport root = new RenderViewport(
       offset: new ViewportOffset.zero(),
     );
     layout(root);
@@ -17,9 +17,9 @@ void main() {
     pumpFrame();
   });
 
-  test('RenderViewport2 basic test - down', () {
+  test('RenderViewport basic test - down', () {
     RenderBox a, b, c, d, e;
-    RenderViewport2 root = new RenderViewport2(
+    RenderViewport root = new RenderViewport(
       offset: new ViewportOffset.zero(),
       children: <RenderSliver>[
         new RenderSliverToBoxAdapter(child: a = new RenderSizedBox(const Size(100.0, 400.0))),
@@ -75,9 +75,9 @@ void main() {
     expect(result.path.first.target, equals(c));
   });
 
-  test('RenderViewport2 basic test - up', () {
+  test('RenderViewport basic test - up', () {
     RenderBox a, b, c, d, e;
-    RenderViewport2 root = new RenderViewport2(
+    RenderViewport root = new RenderViewport(
       axisDirection: AxisDirection.up,
       offset: new ViewportOffset.zero(),
       children: <RenderSliver>[
@@ -128,9 +128,9 @@ void main() {
     expect(result.path.first.target, equals(c));
   });
 
-  test('RenderViewport2 basic test - right', () {
+  test('RenderViewport basic test - right', () {
     RenderBox a, b, c, d, e;
-    RenderViewport2 root = new RenderViewport2(
+    RenderViewport root = new RenderViewport(
       axisDirection: AxisDirection.right,
       offset: new ViewportOffset.zero(),
       children: <RenderSliver>[
@@ -181,9 +181,9 @@ void main() {
     expect(result.path.first.target, equals(c));
   });
 
-  test('RenderViewport2 basic test - left', () {
+  test('RenderViewport basic test - left', () {
     RenderBox a, b, c, d, e;
-    RenderViewport2 root = new RenderViewport2(
+    RenderViewport root = new RenderViewport(
       axisDirection: AxisDirection.left,
       offset: new ViewportOffset.zero(),
       children: <RenderSliver>[

--- a/packages/flutter/test/widgets/clamp_overscrolls_test.dart
+++ b/packages/flutter/test/widgets/clamp_overscrolls_test.dart
@@ -62,7 +62,7 @@ void main() {
     // BouncingScrollPhysics
 
     await tester.pumpWidget(buildFrame(const BouncingScrollPhysics()));
-    Scrollable2State scrollable = tester.state(find.byType(Scrollable2));
+    ScrollableState scrollable = tester.state(find.byType(Scrollable));
 
     await tester.scrollAt(tester.getTopLeft(find.text('top')), const Offset(0.0, 400.0));
     await tester.pump();
@@ -77,7 +77,7 @@ void main() {
     // ClampingScrollPhysics
 
     await tester.pumpWidget(buildFrame(const ClampingScrollPhysics()));
-    scrollable = scrollable = tester.state(find.byType(Scrollable2));
+    scrollable = scrollable = tester.state(find.byType(Scrollable));
 
     await tester.scrollAt(tester.getTopLeft(find.text('top')), const Offset(0.0, 400.0));
     await tester.pump();

--- a/packages/flutter/test/widgets/ensure_visible_test.dart
+++ b/packages/flutter/test/widgets/ensure_visible_test.dart
@@ -66,23 +66,23 @@ void main() {
 
       await tester.pumpWidget(buildSingleChildScrollView(Axis.vertical));
 
-      Scrollable2.ensureVisible(findContext(3));
+      Scrollable.ensureVisible(findContext(3));
       await tester.pump();
       expect(tester.getTopLeft(findKey(3)).y, equals(100.0));
 
-      Scrollable2.ensureVisible(findContext(6));
+      Scrollable.ensureVisible(findContext(6));
       await tester.pump();
       expect(tester.getTopLeft(findKey(6)).y, equals(300.0));
 
-      Scrollable2.ensureVisible(findContext(4), alignment: 1.0);
+      Scrollable.ensureVisible(findContext(4), alignment: 1.0);
       await tester.pump();
       expect(tester.getBottomRight(findKey(4)).y, equals(500.0));
 
-      Scrollable2.ensureVisible(findContext(0), alignment: 1.0);
+      Scrollable.ensureVisible(findContext(0), alignment: 1.0);
       await tester.pump();
       expect(tester.getTopLeft(findKey(0)).y, equals(100.0));
 
-      Scrollable2.ensureVisible(findContext(3), duration: const Duration(seconds: 1));
+      Scrollable.ensureVisible(findContext(3), duration: const Duration(seconds: 1));
       await tester.pump();
       await tester.pump(const Duration(milliseconds: 1020));
       expect(tester.getTopLeft(findKey(3)).y, equals(100.0));
@@ -93,23 +93,23 @@ void main() {
 
       await tester.pumpWidget(buildSingleChildScrollView(Axis.horizontal));
 
-      Scrollable2.ensureVisible(findContext(3));
+      Scrollable.ensureVisible(findContext(3));
       await tester.pump();
       expect(tester.getTopLeft(findKey(3)).x, equals(100.0));
 
-      Scrollable2.ensureVisible(findContext(6));
+      Scrollable.ensureVisible(findContext(6));
       await tester.pump();
       expect(tester.getTopLeft(findKey(6)).x, equals(500.0));
 
-      Scrollable2.ensureVisible(findContext(4), alignment: 1.0);
+      Scrollable.ensureVisible(findContext(4), alignment: 1.0);
       await tester.pump();
       expect(tester.getBottomRight(findKey(4)).x, equals(700.0));
 
-      Scrollable2.ensureVisible(findContext(0), alignment: 1.0);
+      Scrollable.ensureVisible(findContext(0), alignment: 1.0);
       await tester.pump();
       expect(tester.getTopLeft(findKey(0)).x, equals(100.0));
 
-      Scrollable2.ensureVisible(findContext(3), duration: const Duration(seconds: 1));
+      Scrollable.ensureVisible(findContext(3), duration: const Duration(seconds: 1));
       await tester.pump();
       await tester.pump(const Duration(milliseconds: 1020));
       expect(tester.getTopLeft(findKey(3)).x, equals(100.0));
@@ -120,23 +120,23 @@ void main() {
 
       await tester.pumpWidget(buildSingleChildScrollView(Axis.vertical, reverse: true));
 
-      Scrollable2.ensureVisible(findContext(3));
+      Scrollable.ensureVisible(findContext(3));
       await tester.pump();
       expect(tester.getBottomRight(findKey(3)).y, equals(500.0));
 
-      Scrollable2.ensureVisible(findContext(0));
+      Scrollable.ensureVisible(findContext(0));
       await tester.pump();
       expect(tester.getBottomRight(findKey(0)).y, equals(300.0));
 
-      Scrollable2.ensureVisible(findContext(2), alignment: 1.0);
+      Scrollable.ensureVisible(findContext(2), alignment: 1.0);
       await tester.pump();
       expect(tester.getTopLeft(findKey(2)).y, equals(100.0));
 
-      Scrollable2.ensureVisible(findContext(6), alignment: 1.0);
+      Scrollable.ensureVisible(findContext(6), alignment: 1.0);
       await tester.pump();
       expect(tester.getBottomRight(findKey(6)).y, equals(500.0));
 
-      Scrollable2.ensureVisible(findContext(3), duration: const Duration(seconds: 1));
+      Scrollable.ensureVisible(findContext(3), duration: const Duration(seconds: 1));
       await tester.pump();
       await tester.pump(const Duration(milliseconds: 1020));
       expect(tester.getBottomRight(findKey(3)).y, equals(500.0));
@@ -147,23 +147,23 @@ void main() {
 
       await tester.pumpWidget(buildSingleChildScrollView(Axis.horizontal, reverse: true));
 
-      Scrollable2.ensureVisible(findContext(3));
+      Scrollable.ensureVisible(findContext(3));
       await tester.pump();
       expect(tester.getBottomRight(findKey(3)).x, equals(700.0));
 
-      Scrollable2.ensureVisible(findContext(0));
+      Scrollable.ensureVisible(findContext(0));
       await tester.pump();
       expect(tester.getBottomRight(findKey(0)).x, equals(300.0));
 
-      Scrollable2.ensureVisible(findContext(2), alignment: 1.0);
+      Scrollable.ensureVisible(findContext(2), alignment: 1.0);
       await tester.pump();
       expect(tester.getTopLeft(findKey(2)).x, equals(100.0));
 
-      Scrollable2.ensureVisible(findContext(6), alignment: 1.0);
+      Scrollable.ensureVisible(findContext(6), alignment: 1.0);
       await tester.pump();
       expect(tester.getBottomRight(findKey(6)).x, equals(700.0));
 
-      Scrollable2.ensureVisible(findContext(3), duration: const Duration(seconds: 1));
+      Scrollable.ensureVisible(findContext(3), duration: const Duration(seconds: 1));
       await tester.pump();
       await tester.pump(const Duration(milliseconds: 1020));
       expect(tester.getBottomRight(findKey(3)).x, equals(700.0));
@@ -209,11 +209,11 @@ void main() {
         )
       );
 
-      Scrollable2.ensureVisible(findContext(0));
+      Scrollable.ensureVisible(findContext(0));
       await tester.pump();
       expect(tester.getBottomRight(findKey(0)).y, closeTo(100.0, 0.1));
 
-      Scrollable2.ensureVisible(findContext(0), alignment: 1.0);
+      Scrollable.ensureVisible(findContext(0), alignment: 1.0);
       await tester.pump();
       expect(tester.getTopLeft(findKey(0)).y, closeTo(500.0, 0.1));
     });
@@ -223,34 +223,34 @@ void main() {
     testWidgets('ListView ensureVisible Axis.vertical', (WidgetTester tester) async {
       BuildContext findContext(int i) => tester.element(findKey(i));
       Future<Null> prepare(double offset) async {
-        tester.state<Scrollable2State>(find.byType(Scrollable2)).position.jumpTo(offset);
+        tester.state<ScrollableState>(find.byType(Scrollable)).position.jumpTo(offset);
         await tester.pump();
       }
 
       await tester.pumpWidget(buildListView(Axis.vertical));
 
       await prepare(480.0);
-      Scrollable2.ensureVisible(findContext(3));
+      Scrollable.ensureVisible(findContext(3));
       await tester.pump();
       expect(tester.getTopLeft(findKey(3)).y, equals(100.0));
 
       await prepare(1083.0);
-      Scrollable2.ensureVisible(findContext(6));
+      Scrollable.ensureVisible(findContext(6));
       await tester.pump();
       expect(tester.getTopLeft(findKey(6)).y, equals(300.0));
 
       await prepare(735.0);
-      Scrollable2.ensureVisible(findContext(4), alignment: 1.0);
+      Scrollable.ensureVisible(findContext(4), alignment: 1.0);
       await tester.pump();
       expect(tester.getBottomRight(findKey(4)).y, equals(500.0));
 
       await prepare(123.0);
-      Scrollable2.ensureVisible(findContext(0), alignment: 1.0);
+      Scrollable.ensureVisible(findContext(0), alignment: 1.0);
       await tester.pump();
       expect(tester.getTopLeft(findKey(0)).y, equals(100.0));
 
       await prepare(523.0);
-      Scrollable2.ensureVisible(findContext(3), duration: const Duration(seconds: 1));
+      Scrollable.ensureVisible(findContext(3), duration: const Duration(seconds: 1));
       await tester.pump();
       await tester.pump(const Duration(milliseconds: 1020));
       expect(tester.getTopLeft(findKey(3)).y, equals(100.0));
@@ -259,34 +259,34 @@ void main() {
     testWidgets('ListView ensureVisible Axis.horizontal', (WidgetTester tester) async {
       BuildContext findContext(int i) => tester.element(findKey(i));
       Future<Null> prepare(double offset) async {
-        tester.state<Scrollable2State>(find.byType(Scrollable2)).position.jumpTo(offset);
+        tester.state<ScrollableState>(find.byType(Scrollable)).position.jumpTo(offset);
         await tester.pump();
       }
 
       await tester.pumpWidget(buildListView(Axis.horizontal));
 
       await prepare(23.0);
-      Scrollable2.ensureVisible(findContext(3));
+      Scrollable.ensureVisible(findContext(3));
       await tester.pump();
       expect(tester.getTopLeft(findKey(3)).x, equals(100.0));
 
       await prepare(843.0);
-      Scrollable2.ensureVisible(findContext(6));
+      Scrollable.ensureVisible(findContext(6));
       await tester.pump();
       expect(tester.getTopLeft(findKey(6)).x, equals(500.0));
 
       await prepare(415.0);
-      Scrollable2.ensureVisible(findContext(4), alignment: 1.0);
+      Scrollable.ensureVisible(findContext(4), alignment: 1.0);
       await tester.pump();
       expect(tester.getBottomRight(findKey(4)).x, equals(700.0));
 
       await prepare(46.0);
-      Scrollable2.ensureVisible(findContext(0), alignment: 1.0);
+      Scrollable.ensureVisible(findContext(0), alignment: 1.0);
       await tester.pump();
       expect(tester.getTopLeft(findKey(0)).x, equals(100.0));
 
       await prepare(211.0);
-      Scrollable2.ensureVisible(findContext(3), duration: const Duration(seconds: 1));
+      Scrollable.ensureVisible(findContext(3), duration: const Duration(seconds: 1));
       await tester.pump();
       await tester.pump(const Duration(milliseconds: 1020));
       expect(tester.getTopLeft(findKey(3)).x, equals(100.0));
@@ -295,34 +295,34 @@ void main() {
     testWidgets('ListView ensureVisible Axis.vertical reverse', (WidgetTester tester) async {
       BuildContext findContext(int i) => tester.element(findKey(i));
       Future<Null> prepare(double offset) async {
-        tester.state<Scrollable2State>(find.byType(Scrollable2)).position.jumpTo(offset);
+        tester.state<ScrollableState>(find.byType(Scrollable)).position.jumpTo(offset);
         await tester.pump();
       }
 
       await tester.pumpWidget(buildListView(Axis.vertical, reverse: true));
 
       await prepare(211.0);
-      Scrollable2.ensureVisible(findContext(3));
+      Scrollable.ensureVisible(findContext(3));
       await tester.pump();
       expect(tester.getBottomRight(findKey(3)).y, equals(500.0));
 
       await prepare(23.0);
-      Scrollable2.ensureVisible(findContext(0));
+      Scrollable.ensureVisible(findContext(0));
       await tester.pump();
       expect(tester.getBottomRight(findKey(0)).y, equals(500.0));
 
       await prepare(230.0);
-      Scrollable2.ensureVisible(findContext(2), alignment: 1.0);
+      Scrollable.ensureVisible(findContext(2), alignment: 1.0);
       await tester.pump();
       expect(tester.getTopLeft(findKey(2)).y, equals(100.0));
 
       await prepare(1083.0);
-      Scrollable2.ensureVisible(findContext(6), alignment: 1.0);
+      Scrollable.ensureVisible(findContext(6), alignment: 1.0);
       await tester.pump();
       expect(tester.getBottomRight(findKey(6)).y, equals(300.0));
 
       await prepare(345.0);
-      Scrollable2.ensureVisible(findContext(3), duration: const Duration(seconds: 1));
+      Scrollable.ensureVisible(findContext(3), duration: const Duration(seconds: 1));
       await tester.pump();
       await tester.pump(const Duration(milliseconds: 1020));
       expect(tester.getBottomRight(findKey(3)).y, equals(500.0));
@@ -331,34 +331,34 @@ void main() {
     testWidgets('ListView ensureVisible Axis.horizontal reverse', (WidgetTester tester) async {
       BuildContext findContext(int i) => tester.element(findKey(i));
       Future<Null> prepare(double offset) async {
-        tester.state<Scrollable2State>(find.byType(Scrollable2)).position.jumpTo(offset);
+        tester.state<ScrollableState>(find.byType(Scrollable)).position.jumpTo(offset);
         await tester.pump();
       }
 
       await tester.pumpWidget(buildListView(Axis.horizontal, reverse: true));
 
       await prepare(211.0);
-      Scrollable2.ensureVisible(findContext(3));
+      Scrollable.ensureVisible(findContext(3));
       await tester.pump();
       expect(tester.getBottomRight(findKey(3)).x, equals(700.0));
 
       await prepare(23.0);
-      Scrollable2.ensureVisible(findContext(0));
+      Scrollable.ensureVisible(findContext(0));
       await tester.pump();
       expect(tester.getBottomRight(findKey(0)).x, equals(700.0));
 
       await prepare(230.0);
-      Scrollable2.ensureVisible(findContext(2), alignment: 1.0);
+      Scrollable.ensureVisible(findContext(2), alignment: 1.0);
       await tester.pump();
       expect(tester.getTopLeft(findKey(2)).x, equals(100.0));
 
       await prepare(1083.0);
-      Scrollable2.ensureVisible(findContext(6), alignment: 1.0);
+      Scrollable.ensureVisible(findContext(6), alignment: 1.0);
       await tester.pump();
       expect(tester.getBottomRight(findKey(6)).x, equals(300.0));
 
       await prepare(345.0);
-      Scrollable2.ensureVisible(findContext(3), duration: const Duration(seconds: 1));
+      Scrollable.ensureVisible(findContext(3), duration: const Duration(seconds: 1));
       await tester.pump();
       await tester.pump(const Duration(milliseconds: 1020));
       expect(tester.getBottomRight(findKey(3)).x, equals(700.0));
@@ -368,12 +368,12 @@ void main() {
     testWidgets('ListView ensureVisible negative child', (WidgetTester tester) async {
       BuildContext findContext(int i) => tester.element(findKey(i));
       Future<Null> prepare(double offset) async {
-        tester.state<Scrollable2State>(find.byType(Scrollable2)).position.jumpTo(offset);
+        tester.state<ScrollableState>(find.byType(Scrollable)).position.jumpTo(offset);
         await tester.pump();
       }
 
       double getOffset() {
-        return tester.state<Scrollable2State>(find.byType(Scrollable2)).position.pixels;
+        return tester.state<ScrollableState>(find.byType(Scrollable)).position.pixels;
       }
 
       Widget buildSliver(int i) {
@@ -387,9 +387,9 @@ void main() {
         child: new SizedBox(
           width: 600.0,
           height: 400.0,
-          child: new Scrollable2(
+          child: new Scrollable(
             viewportBuilder: (BuildContext context, ViewportOffset offset) {
-              return new Viewport2(
+              return new Viewport(
                 offset: offset,
                 center: const ValueKey<int>(4),
                 slivers: <Widget>[
@@ -408,12 +408,12 @@ void main() {
       ));
 
       await prepare(-125.0);
-      Scrollable2.ensureVisible(findContext(3));
+      Scrollable.ensureVisible(findContext(3));
       await tester.pump();
       expect(getOffset(), equals(-200.0));
 
       await prepare(-225.0);
-      Scrollable2.ensureVisible(findContext(2));
+      Scrollable.ensureVisible(findContext(2));
       await tester.pump();
       expect(getOffset(), equals(-400.0));
     }, skip: true);
@@ -421,7 +421,7 @@ void main() {
     testWidgets('ListView ensureVisible rotated child', (WidgetTester tester) async {
       BuildContext findContext(int i) => tester.element(findKey(i));
       Future<Null> prepare(double offset) async {
-        tester.state<Scrollable2State>(find.byType(Scrollable2)).position.jumpTo(offset);
+        tester.state<ScrollableState>(find.byType(Scrollable)).position.jumpTo(offset);
         await tester.pump();
       }
 
@@ -461,11 +461,11 @@ void main() {
       );
 
       await prepare(321.0);
-      Scrollable2.ensureVisible(findContext(0));
+      Scrollable.ensureVisible(findContext(0));
       await tester.pump();
       expect(tester.getBottomRight(findKey(0)).y, closeTo(100.0, 0.1));
 
-      Scrollable2.ensureVisible(findContext(0), alignment: 1.0);
+      Scrollable.ensureVisible(findContext(0), alignment: 1.0);
       await tester.pump();
       expect(tester.getTopLeft(findKey(0)).y, closeTo(500.0, 0.1));
     });
@@ -475,34 +475,34 @@ void main() {
     testWidgets('ListView ensureVisible Axis.vertical', (WidgetTester tester) async {
       BuildContext findContext(int i) => tester.element(findKey(i));
       Future<Null> prepare(double offset) async {
-        tester.state<Scrollable2State>(find.byType(Scrollable2)).position.jumpTo(offset);
+        tester.state<ScrollableState>(find.byType(Scrollable)).position.jumpTo(offset);
         await tester.pump();
       }
 
       await tester.pumpWidget(buildListView(Axis.vertical, shrinkWrap: true));
 
       await prepare(480.0);
-      Scrollable2.ensureVisible(findContext(3));
+      Scrollable.ensureVisible(findContext(3));
       await tester.pump();
       expect(tester.getTopLeft(findKey(3)).y, equals(100.0));
 
       await prepare(1083.0);
-      Scrollable2.ensureVisible(findContext(6));
+      Scrollable.ensureVisible(findContext(6));
       await tester.pump();
       expect(tester.getTopLeft(findKey(6)).y, equals(300.0));
 
       await prepare(735.0);
-      Scrollable2.ensureVisible(findContext(4), alignment: 1.0);
+      Scrollable.ensureVisible(findContext(4), alignment: 1.0);
       await tester.pump();
       expect(tester.getBottomRight(findKey(4)).y, equals(500.0));
 
       await prepare(123.0);
-      Scrollable2.ensureVisible(findContext(0), alignment: 1.0);
+      Scrollable.ensureVisible(findContext(0), alignment: 1.0);
       await tester.pump();
       expect(tester.getTopLeft(findKey(0)).y, equals(100.0));
 
       await prepare(523.0);
-      Scrollable2.ensureVisible(findContext(3), duration: const Duration(seconds: 1));
+      Scrollable.ensureVisible(findContext(3), duration: const Duration(seconds: 1));
       await tester.pump();
       await tester.pump(const Duration(milliseconds: 1020));
       expect(tester.getTopLeft(findKey(3)).y, equals(100.0));
@@ -511,34 +511,34 @@ void main() {
     testWidgets('ListView ensureVisible Axis.horizontal', (WidgetTester tester) async {
       BuildContext findContext(int i) => tester.element(findKey(i));
       Future<Null> prepare(double offset) async {
-        tester.state<Scrollable2State>(find.byType(Scrollable2)).position.jumpTo(offset);
+        tester.state<ScrollableState>(find.byType(Scrollable)).position.jumpTo(offset);
         await tester.pump();
       }
 
       await tester.pumpWidget(buildListView(Axis.horizontal, shrinkWrap: true));
 
       await prepare(23.0);
-      Scrollable2.ensureVisible(findContext(3));
+      Scrollable.ensureVisible(findContext(3));
       await tester.pump();
       expect(tester.getTopLeft(findKey(3)).x, equals(100.0));
 
       await prepare(843.0);
-      Scrollable2.ensureVisible(findContext(6));
+      Scrollable.ensureVisible(findContext(6));
       await tester.pump();
       expect(tester.getTopLeft(findKey(6)).x, equals(500.0));
 
       await prepare(415.0);
-      Scrollable2.ensureVisible(findContext(4), alignment: 1.0);
+      Scrollable.ensureVisible(findContext(4), alignment: 1.0);
       await tester.pump();
       expect(tester.getBottomRight(findKey(4)).x, equals(700.0));
 
       await prepare(46.0);
-      Scrollable2.ensureVisible(findContext(0), alignment: 1.0);
+      Scrollable.ensureVisible(findContext(0), alignment: 1.0);
       await tester.pump();
       expect(tester.getTopLeft(findKey(0)).x, equals(100.0));
 
       await prepare(211.0);
-      Scrollable2.ensureVisible(findContext(3), duration: const Duration(seconds: 1));
+      Scrollable.ensureVisible(findContext(3), duration: const Duration(seconds: 1));
       await tester.pump();
       await tester.pump(const Duration(milliseconds: 1020));
       expect(tester.getTopLeft(findKey(3)).x, equals(100.0));
@@ -547,34 +547,34 @@ void main() {
     testWidgets('ListView ensureVisible Axis.vertical reverse', (WidgetTester tester) async {
       BuildContext findContext(int i) => tester.element(findKey(i));
       Future<Null> prepare(double offset) async {
-        tester.state<Scrollable2State>(find.byType(Scrollable2)).position.jumpTo(offset);
+        tester.state<ScrollableState>(find.byType(Scrollable)).position.jumpTo(offset);
         await tester.pump();
       }
 
       await tester.pumpWidget(buildListView(Axis.vertical, reverse: true, shrinkWrap: true));
 
       await prepare(211.0);
-      Scrollable2.ensureVisible(findContext(3));
+      Scrollable.ensureVisible(findContext(3));
       await tester.pump();
       expect(tester.getBottomRight(findKey(3)).y, equals(500.0));
 
       await prepare(23.0);
-      Scrollable2.ensureVisible(findContext(0));
+      Scrollable.ensureVisible(findContext(0));
       await tester.pump();
       expect(tester.getBottomRight(findKey(0)).y, equals(500.0));
 
       await prepare(230.0);
-      Scrollable2.ensureVisible(findContext(2), alignment: 1.0);
+      Scrollable.ensureVisible(findContext(2), alignment: 1.0);
       await tester.pump();
       expect(tester.getTopLeft(findKey(2)).y, equals(100.0));
 
       await prepare(1083.0);
-      Scrollable2.ensureVisible(findContext(6), alignment: 1.0);
+      Scrollable.ensureVisible(findContext(6), alignment: 1.0);
       await tester.pump();
       expect(tester.getBottomRight(findKey(6)).y, equals(300.0));
 
       await prepare(345.0);
-      Scrollable2.ensureVisible(findContext(3), duration: const Duration(seconds: 1));
+      Scrollable.ensureVisible(findContext(3), duration: const Duration(seconds: 1));
       await tester.pump();
       await tester.pump(const Duration(milliseconds: 1020));
       expect(tester.getBottomRight(findKey(3)).y, equals(500.0));
@@ -583,34 +583,34 @@ void main() {
     testWidgets('ListView ensureVisible Axis.horizontal reverse', (WidgetTester tester) async {
       BuildContext findContext(int i) => tester.element(findKey(i));
       Future<Null> prepare(double offset) async {
-        tester.state<Scrollable2State>(find.byType(Scrollable2)).position.jumpTo(offset);
+        tester.state<ScrollableState>(find.byType(Scrollable)).position.jumpTo(offset);
         await tester.pump();
       }
 
       await tester.pumpWidget(buildListView(Axis.horizontal, reverse: true, shrinkWrap: true));
 
       await prepare(211.0);
-      Scrollable2.ensureVisible(findContext(3));
+      Scrollable.ensureVisible(findContext(3));
       await tester.pump();
       expect(tester.getBottomRight(findKey(3)).x, equals(700.0));
 
       await prepare(23.0);
-      Scrollable2.ensureVisible(findContext(0));
+      Scrollable.ensureVisible(findContext(0));
       await tester.pump();
       expect(tester.getBottomRight(findKey(0)).x, equals(700.0));
 
       await prepare(230.0);
-      Scrollable2.ensureVisible(findContext(2), alignment: 1.0);
+      Scrollable.ensureVisible(findContext(2), alignment: 1.0);
       await tester.pump();
       expect(tester.getTopLeft(findKey(2)).x, equals(100.0));
 
       await prepare(1083.0);
-      Scrollable2.ensureVisible(findContext(6), alignment: 1.0);
+      Scrollable.ensureVisible(findContext(6), alignment: 1.0);
       await tester.pump();
       expect(tester.getBottomRight(findKey(6)).x, equals(300.0));
 
       await prepare(345.0);
-      Scrollable2.ensureVisible(findContext(3), duration: const Duration(seconds: 1));
+      Scrollable.ensureVisible(findContext(3), duration: const Duration(seconds: 1));
       await tester.pump();
       await tester.pump(const Duration(milliseconds: 1020));
       expect(tester.getBottomRight(findKey(3)).x, equals(700.0));

--- a/packages/flutter/test/widgets/grid_view_test.dart
+++ b/packages/flutter/test/widgets/grid_view_test.dart
@@ -158,7 +158,7 @@ void main() {
     log.clear();
 
 
-    Scrollable2State state = tester.state(find.byType(Scrollable2));
+    ScrollableState state = tester.state(find.byType(Scrollable));
     ScrollPosition position = state.position;
     position.jumpTo(3025.0);
 

--- a/packages/flutter/test/widgets/list_view_builder_test.dart
+++ b/packages/flutter/test/widgets/list_view_builder_test.dart
@@ -79,7 +79,7 @@ void main() {
     }
 
     void jumpTo(double newScrollOffset) {
-      final Scrollable2State scrollable = tester.state(find.byType(Scrollable2));
+      final ScrollableState scrollable = tester.state(find.byType(Scrollable));
       scrollable.position.jumpTo(newScrollOffset);
     }
 
@@ -140,7 +140,7 @@ void main() {
     }
 
     void jumpTo(double newScrollOffset) {
-      final Scrollable2State scrollable = tester.state(find.byType(Scrollable2));
+      final ScrollableState scrollable = tester.state(find.byType(Scrollable));
       scrollable.position.jumpTo(newScrollOffset);
     }
 
@@ -191,7 +191,7 @@ void main() {
     );
 
     void jumpTo(double newScrollOffset) {
-      final Scrollable2State scrollable = tester.state(find.byType(Scrollable2));
+      final ScrollableState scrollable = tester.state(find.byType(Scrollable));
       scrollable.position.jumpTo(newScrollOffset);
     }
 

--- a/packages/flutter/test/widgets/list_view_fling_test.dart
+++ b/packages/flutter/test/widgets/list_view_fling_test.dart
@@ -17,7 +17,7 @@ void main() {
     ));
 
     double getCurrentOffset() {
-      return tester.state<Scrollable2State>(find.byType(Scrollable2)).position.pixels;
+      return tester.state<ScrollableState>(find.byType(Scrollable)).position.pixels;
     }
 
     await tester.fling(find.byType(ListView), const Offset(0.0, -kFlingOffset), 1000.0);

--- a/packages/flutter/test/widgets/list_view_relayout_test.dart
+++ b/packages/flutter/test/widgets/list_view_relayout_test.dart
@@ -141,7 +141,7 @@ void main() {
       ],
     ));
 
-    Scrollable2State scrollable = tester.state(find.byType(Scrollable2));
+    ScrollableState scrollable = tester.state(find.byType(Scrollable));
     expect(scrollable.position.maxScrollExtent, 0.0);
 
     await tester.pumpWidget(new ListView(

--- a/packages/flutter/test/widgets/list_view_test.dart
+++ b/packages/flutter/test/widgets/list_view_test.dart
@@ -75,7 +75,7 @@ void main() {
     expect(log, equals(<int>[0, 1, 2]));
     log.clear();
 
-    Scrollable2State state = tester.state(find.byType(Scrollable2));
+    ScrollableState state = tester.state(find.byType(Scrollable));
     ScrollPosition position = state.position;
     position.jumpTo(2025.0);
 

--- a/packages/flutter/test/widgets/list_view_viewporting_test.dart
+++ b/packages/flutter/test/widgets/list_view_viewporting_test.dart
@@ -83,7 +83,7 @@ void main() {
     expect(callbackTracker, equals(<int>[0, 1, 2, 3, 4]));
     callbackTracker.clear();
 
-    Scrollable2State scrollable = tester.state(find.byType(Scrollable2));
+    ScrollableState scrollable = tester.state(find.byType(Scrollable));
     scrollable.position.jumpTo(400.0); // now only 3 should fit, numbered 2-4.
 
     await tester.pumpWidget(builder());
@@ -134,7 +134,7 @@ void main() {
 
     callbackTracker.clear();
 
-    Scrollable2State scrollable = tester.state(find.byType(Scrollable2));
+    ScrollableState scrollable = tester.state(find.byType(Scrollable));
     scrollable.position.jumpTo(400.0); // now only 4 should fit, numbered 2-5.
 
     await tester.pumpWidget(builder());
@@ -278,7 +278,7 @@ void main() {
     expect(list.childScrollOffset(list.firstChild), equals(0.0));
     expect(list.geometry.scrollExtent, equals(300.0));
 
-    ScrollPosition position = tester.state<Scrollable2State>(find.byType(Scrollable2)).position;
+    ScrollPosition position = tester.state<ScrollableState>(find.byType(Scrollable)).position;
 
     expect(position.viewportDimension, equals(600.0));
     expect(position.minScrollExtent, equals(0.0));

--- a/packages/flutter/test/widgets/overscroll_indicator_test.dart
+++ b/packages/flutter/test/widgets/overscroll_indicator_test.dart
@@ -35,7 +35,7 @@ void main() {
     expect(painter, doesNotOverscroll);
 
     // the scroll gesture from tester.scroll happens in zero time, so nothing should appear:
-    await tester.scroll(find.byType(Scrollable2), const Offset(0.0, 100.0));
+    await tester.scroll(find.byType(Scrollable), const Offset(0.0, 100.0));
     expect(painter, doesNotOverscroll);
     await tester.pump(); // allow the ticker to register itself
     expect(painter, doesNotOverscroll);
@@ -224,7 +224,7 @@ void main() {
     RenderObject painter;
 
     await tester.pumpWidget(
-      new ScrollConfiguration2(
+      new ScrollConfiguration(
         behavior: new TestScrollBehavior1(),
         child: new CustomScrollView(
           scrollDirection: Axis.horizontal,
@@ -242,7 +242,7 @@ void main() {
 
     await tester.pumpUntilNoTransientCallbacks(const Duration(seconds: 1));
     await tester.pumpWidget(
-      new ScrollConfiguration2(
+      new ScrollConfiguration(
         behavior: new TestScrollBehavior2(),
         child: new CustomScrollView(
           scrollDirection: Axis.horizontal,
@@ -259,14 +259,14 @@ void main() {
   });
 }
 
-class TestScrollBehavior1 extends ScrollBehavior2 {
+class TestScrollBehavior1 extends ScrollBehavior {
   @override
   Color getGlowColor(BuildContext context) {
     return const Color(0xFF00FF00);
   }
 }
 
-class TestScrollBehavior2 extends ScrollBehavior2 {
+class TestScrollBehavior2 extends ScrollBehavior {
   @override
   Color getGlowColor(BuildContext context) {
     return const Color(0xFF0000FF);

--- a/packages/flutter/test/widgets/remember_scroll_position_test.dart
+++ b/packages/flutter/test/widgets/remember_scroll_position_test.dart
@@ -58,7 +58,7 @@ void main() {
     expect(find.text('10'), findsNothing);
     expect(find.text('100'), findsNothing);
 
-    tester.state<Scrollable2State>(find.byType(Scrollable2)).position.jumpTo(1000.0);
+    tester.state<ScrollableState>(find.byType(Scrollable)).position.jumpTo(1000.0);
     await tester.pump(const Duration(seconds: 1));
 
     // we're 600 pixels high, each item is 100 pixels high, scroll position is
@@ -96,7 +96,7 @@ void main() {
 
     // Ensure we don't clamp the scroll offset even during the navigation.
     // https://github.com/flutter/flutter/issues/4883
-    Scrollable2State state = tester.state(find.byType(Scrollable2).first);
+    ScrollableState state = tester.state(find.byType(Scrollable).first);
     expect(state.position.pixels, equals(1000.0));
 
     await tester.pump(const Duration(seconds: 1));

--- a/packages/flutter/test/widgets/scroll_behavior_test.dart
+++ b/packages/flutter/test/widgets/scroll_behavior_test.dart
@@ -5,7 +5,7 @@
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-class TestScrollBehavior extends ScrollBehavior2 {
+class TestScrollBehavior extends ScrollBehavior {
   TestScrollBehavior(this.flag);
 
   final bool flag;
@@ -31,15 +31,15 @@ void main() {
       key: key,
       child: new Builder(
         builder: (BuildContext context) {
-          behavior = ScrollConfiguration2.of(context);
-          position = Scrollable2.of(context).position;
+          behavior = ScrollConfiguration.of(context);
+          position = Scrollable.of(context).position;
           return new Container(height: 1000.0);
         },
       ),
     );
 
     await tester.pumpWidget(
-      new ScrollConfiguration2(
+      new ScrollConfiguration(
         behavior: new TestScrollBehavior(true),
         child: scrollView,
       ),
@@ -54,7 +54,7 @@ void main() {
 
     // Same Scrollable, different ScrollConfiguration
     await tester.pumpWidget(
-      new ScrollConfiguration2(
+      new ScrollConfiguration(
         behavior: new TestScrollBehavior(false),
         child: scrollView,
       ),

--- a/packages/flutter/test/widgets/scroll_controller_test.dart
+++ b/packages/flutter/test/widgets/scroll_controller_test.dart
@@ -22,7 +22,7 @@ void main() {
     ));
 
     double realOffset() {
-      return tester.state<Scrollable2State>(find.byType(Scrollable2)).position.pixels;
+      return tester.state<ScrollableState>(find.byType(Scrollable)).position.pixels;
     }
 
     expect(controller.offset, equals(0.0));
@@ -121,7 +121,7 @@ void main() {
     ));
 
     double realOffset() {
-      return tester.state<Scrollable2State>(find.byType(Scrollable2)).position.pixels;
+      return tester.state<ScrollableState>(find.byType(Scrollable)).position.pixels;
     }
 
     expect(controller.offset, equals(209.0));

--- a/packages/flutter/test/widgets/scroll_events_test.dart
+++ b/packages/flutter/test/widgets/scroll_events_test.dart
@@ -9,8 +9,8 @@ import 'package:flutter/widgets.dart';
 import 'package:meta/meta.dart';
 
 Widget _buildScroller({ List<String> log }) {
-  return new NotificationListener<ScrollNotification2>(
-    onNotification: (ScrollNotification2 notification) {
+  return new NotificationListener<ScrollNotification>(
+    onNotification: (ScrollNotification notification) {
       if (notification is ScrollStartNotification) {
         log.add('scroll-start');
       } else if (notification is ScrollUpdateNotification) {
@@ -29,13 +29,13 @@ Widget _buildScroller({ List<String> log }) {
 void main() {
   Completer<Null> animateTo(WidgetTester tester, double newScrollOffset, { @required Duration duration }) {
     Completer<Null> completer = new Completer<Null>();
-    final Scrollable2State scrollable = tester.state(find.byType(Scrollable2));
+    final ScrollableState scrollable = tester.state(find.byType(Scrollable));
     scrollable.position.animateTo(newScrollOffset, duration: duration, curve: Curves.linear).whenComplete(completer.complete);
     return completer;
   }
 
   void jumpTo(WidgetTester tester, double newScrollOffset) {
-    final Scrollable2State scrollable = tester.state(find.byType(Scrollable2));
+    final ScrollableState scrollable = tester.state(find.byType(Scrollable));
     scrollable.position.jumpTo(newScrollOffset);
   }
 
@@ -166,6 +166,6 @@ void main() {
     expect(log.last, equals('scroll-end'));
     log.removeWhere((String value) => value == 'scroll-update');
     expect(log.length, equals(2));
-    expect(tester.state<Scrollable2State>(find.byType(Scrollable2)).position.pixels, equals(0.0));
+    expect(tester.state<ScrollableState>(find.byType(Scrollable)).position.pixels, equals(0.0));
   });
 }

--- a/packages/flutter/test/widgets/scroll_interaction_test.dart
+++ b/packages/flutter/test/widgets/scroll_interaction_test.dart
@@ -13,8 +13,8 @@ void main() {
       ]
     ));
 
-    Scrollable2State scrollable =
-      tester.state<Scrollable2State>(find.byType(Scrollable2));
+    ScrollableState scrollable =
+      tester.state<ScrollableState>(find.byType(Scrollable));
 
     expect(scrollable.position.pixels, equals(0.0));
 

--- a/packages/flutter/test/widgets/scroll_notification_test.dart
+++ b/packages/flutter/test/widgets/scroll_notification_test.dart
@@ -7,10 +7,10 @@ import 'package:flutter/widgets.dart';
 
 void main() {
   testWidgets('Scroll notification basics', (WidgetTester tester) async {
-    ScrollNotification2 notification;
+    ScrollNotification notification;
 
-    await tester.pumpWidget(new NotificationListener<ScrollNotification2>(
-      onNotification: (ScrollNotification2 value) {
+    await tester.pumpWidget(new NotificationListener<ScrollNotification>(
+      onNotification: (ScrollNotification value) {
         if (value is ScrollStartNotification || value is ScrollUpdateNotification || value is ScrollEndNotification)
           notification = value;
         return false;
@@ -52,8 +52,8 @@ void main() {
     final List<int> depth0Values = <int>[];
     final List<int> depth1Values = <int>[];
 
-    await tester.pumpWidget(new NotificationListener<ScrollNotification2>(
-      onNotification: (ScrollNotification2 value) {
+    await tester.pumpWidget(new NotificationListener<ScrollNotification>(
+      onNotification: (ScrollNotification value) {
         depth1Types.add(value.runtimeType);
         depth1Values.add(value.depth);
         return false;
@@ -61,8 +61,8 @@ void main() {
       child: new SingleChildScrollView(
         child: new SizedBox(
           height: 1200.0,
-          child: new NotificationListener<ScrollNotification2>(
-            onNotification: (ScrollNotification2 value) {
+          child: new NotificationListener<ScrollNotification>(
+            onNotification: (ScrollNotification value) {
               depth0Types.add(value.runtimeType);
               depth0Values.add(value.depth);
               return false;

--- a/packages/flutter/test/widgets/scroll_view_test.dart
+++ b/packages/flutter/test/widgets/scroll_view_test.dart
@@ -69,7 +69,7 @@ void main() {
     await tester.pump(const Duration(milliseconds: 10));
     await tester.pumpUntilNoTransientCallbacks(const Duration(milliseconds: 100));
 
-    Viewport2 viewport = tester.widget(find.byType(Viewport2));
+    Viewport viewport = tester.widget(find.byType(Viewport));
     expect(viewport.offset.pixels, equals(2400.0));
   });
 

--- a/packages/flutter/test/widgets/scrollable_custom_scroll_behavior_test.dart
+++ b/packages/flutter/test/widgets/scrollable_custom_scroll_behavior_test.dart
@@ -93,7 +93,7 @@ class TestScrollController extends ScrollController {
   }
 }
 
-class TestScrollBehavior extends ScrollBehavior2 {
+class TestScrollBehavior extends ScrollBehavior {
   TestScrollBehavior(this.extentMultiplier);
 
   final double extentMultiplier;
@@ -116,7 +116,7 @@ class TestScrollBehavior extends ScrollBehavior2 {
 
 void main() {
   testWidgets('Changing the scroll behavior dynamically', (WidgetTester tester) async {
-    await tester.pumpWidget(new ScrollConfiguration2(
+    await tester.pumpWidget(new ScrollConfiguration(
       behavior: new TestScrollBehavior(1.0),
       child: new CustomScrollView(
         controller: new TestScrollController(),
@@ -125,10 +125,10 @@ void main() {
         ],
       ),
     ));
-    Scrollable2State state = tester.state(find.byType(Scrollable2));
+    ScrollableState state = tester.state(find.byType(Scrollable));
 
     expect(state.position.getMetrics().extentInside, 1.0);
-    await tester.pumpWidget(new ScrollConfiguration2(
+    await tester.pumpWidget(new ScrollConfiguration(
       behavior: new TestScrollBehavior(2.0),
       child: new CustomScrollView(
         controller: new TestScrollController(),

--- a/packages/flutter/test/widgets/scrollable_fling_test.dart
+++ b/packages/flutter/test/widgets/scrollable_fling_test.dart
@@ -27,7 +27,7 @@ const double dragOffset = 213.82;
 void main() {
   testWidgets('Flings on different platforms', (WidgetTester tester) async {
     double getCurrentOffset() {
-      return tester.state<Scrollable2State>(find.byType(Scrollable2)).position.pixels;
+      return tester.state<ScrollableState>(find.byType(Scrollable)).position.pixels;
     }
 
     await pumpTest(tester, TargetPlatform.android);
@@ -58,16 +58,16 @@ void main() {
     await tester.pumpWidget(new ListView(children: textWidgets));
 
     expect(log, equals(<String>[]));
-    await tester.tap(find.byType(Scrollable2));
+    await tester.tap(find.byType(Scrollable));
     await tester.pump(const Duration(milliseconds: 50));
     expect(log, equals(<String>['tap 18']));
-    await tester.fling(find.byType(Scrollable2), const Offset(0.0, -200.0), 1000.0);
+    await tester.fling(find.byType(Scrollable), const Offset(0.0, -200.0), 1000.0);
     await tester.pump(const Duration(milliseconds: 50));
     expect(log, equals(<String>['tap 18']));
-    await tester.tap(find.byType(Scrollable2));
+    await tester.tap(find.byType(Scrollable));
     await tester.pump(const Duration(milliseconds: 50));
     expect(log, equals(<String>['tap 18']));
-    await tester.tap(find.byType(Scrollable2));
+    await tester.tap(find.byType(Scrollable));
     await tester.pump(const Duration(milliseconds: 50));
     expect(log, equals(<String>['tap 18', 'tap 31']));
   }, skip: Platform.isMacOS); // Skip due to https://github.com/flutter/flutter/issues/6961
@@ -81,15 +81,15 @@ void main() {
     await tester.pumpWidget(new ListView(children: textWidgets));
 
     expect(log, equals(<String>[]));
-    await tester.tap(find.byType(Scrollable2));
+    await tester.tap(find.byType(Scrollable));
     await tester.pump(const Duration(milliseconds: 50));
     expect(log, equals(<String>['tap 18']));
-    await tester.fling(find.byType(Scrollable2), const Offset(0.0, -200.0), 1000.0);
+    await tester.fling(find.byType(Scrollable), const Offset(0.0, -200.0), 1000.0);
     await tester.pump(const Duration(milliseconds: 50));
     expect(log, equals(<String>['tap 18']));
     await tester.pump(const Duration(seconds: 50));
     expect(log, equals(<String>['tap 18']));
-    await tester.tap(find.byType(Scrollable2));
+    await tester.tap(find.byType(Scrollable));
     await tester.pump(const Duration(milliseconds: 50));
     expect(log, equals(<String>['tap 18', 'tap 43']));
   }, skip: Platform.isMacOS); // Skip due to https://github.com/flutter/flutter/issues/6961

--- a/packages/flutter/test/widgets/scrollable_list_hit_testing_test.dart
+++ b/packages/flutter/test/widgets/scrollable_list_hit_testing_test.dart
@@ -167,7 +167,7 @@ void main() {
     );
 
     await tester.fling(find.text('0'), const Offset(0.0, 400.0), 1000.0);
-    final Scrollable2State scrollable = tester.state(find.byType(Scrollable2));
+    final ScrollableState scrollable = tester.state(find.byType(Scrollable));
     expect(scrollable.position.pixels, equals(0.0));
 
     await tester.tapAt(const Point(200.0, 100.0));

--- a/packages/flutter/test/widgets/scrollable_test.dart
+++ b/packages/flutter/test/widgets/scrollable_test.dart
@@ -24,12 +24,12 @@ Future<Null> pumpTest(WidgetTester tester, TargetPlatform platform) async {
 const double dragOffset = 200.0;
 
 double getScrollOffset(WidgetTester tester) {
-  RenderViewport2 viewport = tester.renderObject(find.byType(Viewport2));
+  RenderViewport viewport = tester.renderObject(find.byType(Viewport));
   return viewport.offset.pixels;
 }
 
 void resetScrollOffset(WidgetTester tester) {
-  RenderViewport2 viewport = tester.renderObject(find.byType(Viewport2));
+  RenderViewport viewport = tester.renderObject(find.byType(Viewport));
   ScrollPosition position = viewport.offset;
   position.jumpTo(0.0);
 }
@@ -37,7 +37,7 @@ void resetScrollOffset(WidgetTester tester) {
 void main() {
   testWidgets('Flings on different platforms', (WidgetTester tester) async {
     await pumpTest(tester, TargetPlatform.android);
-    await tester.fling(find.byType(Viewport2), const Offset(0.0, -dragOffset), 1000.0);
+    await tester.fling(find.byType(Viewport), const Offset(0.0, -dragOffset), 1000.0);
     expect(getScrollOffset(tester), dragOffset);
     await tester.pump(); // trigger fling
     expect(getScrollOffset(tester), dragOffset);
@@ -47,7 +47,7 @@ void main() {
     resetScrollOffset(tester);
 
     await pumpTest(tester, TargetPlatform.iOS);
-    await tester.fling(find.byType(Viewport2), const Offset(0.0, -dragOffset), 1000.0);
+    await tester.fling(find.byType(Viewport), const Offset(0.0, -dragOffset), 1000.0);
     expect(getScrollOffset(tester), dragOffset);
     await tester.pump(); // trigger fling
     expect(getScrollOffset(tester), dragOffset);
@@ -59,7 +59,7 @@ void main() {
 
   testWidgets('Flings on different platforms', (WidgetTester tester) async {
     await pumpTest(tester, TargetPlatform.iOS);
-    await tester.fling(find.byType(Viewport2), const Offset(0.0, -dragOffset), 1000.0);
+    await tester.fling(find.byType(Viewport), const Offset(0.0, -dragOffset), 1000.0);
     expect(getScrollOffset(tester), dragOffset);
     await tester.pump(); // trigger fling
     expect(getScrollOffset(tester), dragOffset);
@@ -69,7 +69,7 @@ void main() {
     resetScrollOffset(tester);
 
     await pumpTest(tester, TargetPlatform.android);
-    await tester.fling(find.byType(Viewport2), const Offset(0.0, -dragOffset), 1000.0);
+    await tester.fling(find.byType(Viewport), const Offset(0.0, -dragOffset), 1000.0);
     expect(getScrollOffset(tester), dragOffset);
     await tester.pump(); // trigger fling
     expect(getScrollOffset(tester), dragOffset);

--- a/packages/flutter/test/widgets/single_child_scroll_view_test.dart
+++ b/packages/flutter/test/widgets/single_child_scroll_view_test.dart
@@ -72,7 +72,7 @@ void main() {
       ),
     ));
 
-    Scrollable2State scrollable = tester.state(find.byType(Scrollable2));
+    ScrollableState scrollable = tester.state(find.byType(Scrollable));
     expect(scrollable.position, const isInstanceOf<TestScrollPosition>());
   });
 

--- a/packages/flutter/test/widgets/sliver_fill_remaining_test.dart
+++ b/packages/flutter/test/widgets/sliver_fill_remaining_test.dart
@@ -28,7 +28,7 @@ void main() {
     expect(find.text('1'), findsNothing);
     expect(find.text('2'), findsNothing);
 
-    await tester.scroll(find.byType(Scrollable2), const Offset(0.0, -700.0));
+    await tester.scroll(find.byType(Scrollable), const Offset(0.0, -700.0));
     await tester.pump();
 
     expect(find.text('0'), findsNothing);
@@ -37,7 +37,7 @@ void main() {
     expect(find.text('3'), findsNothing);
     expect(find.text('4'), findsNothing);
 
-    await tester.scroll(find.byType(Scrollable2), const Offset(0.0, 200.0));
+    await tester.scroll(find.byType(Scrollable), const Offset(0.0, 200.0));
     await tester.pump();
 
     expect(find.text('0'), findsOneWidget);

--- a/packages/flutter/test/widgets/slivers_appbar_floating_test.dart
+++ b/packages/flutter/test/widgets/slivers_appbar_floating_test.dart
@@ -8,7 +8,7 @@ import 'package:flutter/widgets.dart';
 
 void verifyPaintPosition(GlobalKey key, Offset ideal, bool visible) {
   RenderSliver target = key.currentContext.findRenderObject();
-  expect(target.parent, const isInstanceOf<RenderViewport2>());
+  expect(target.parent, const isInstanceOf<RenderViewport>());
   SliverPhysicalParentData parentData = target.parentData;
   Offset actual = parentData.paintOffset;
   expect(actual, ideal);
@@ -34,7 +34,7 @@ void main() {
         ],
       ),
     );
-    ScrollPosition position = tester.state<Scrollable2State>(find.byType(Scrollable2)).position;
+    ScrollPosition position = tester.state<ScrollableState>(find.byType(Scrollable)).position;
     final double max = bigHeight * 2.0 + new TestDelegate().maxExtent - 600.0; // 600 is the height of the test viewport
     assert(max < 10000.0);
     expect(max, 1600.0);
@@ -61,7 +61,7 @@ void main() {
         ],
       ),
     );
-    ScrollPosition position = tester.state<Scrollable2State>(find.byType(Scrollable2)).position;
+    ScrollPosition position = tester.state<ScrollableState>(find.byType(Scrollable)).position;
 
     verifyPaintPosition(key1, const Offset(0.0, 0.0), true);
     verifyPaintPosition(key2, const Offset(0.0, 600.0), false);
@@ -130,7 +130,7 @@ void main() {
         ],
       ),
     );
-    ScrollPosition position = tester.state<Scrollable2State>(find.byType(Scrollable2)).position;
+    ScrollPosition position = tester.state<ScrollableState>(find.byType(Scrollable)).position;
 
     verifyPaintPosition(key1, const Offset(0.0, 0.0), true);
     verifyPaintPosition(key2, const Offset(0.0, 600.0), false);
@@ -162,7 +162,7 @@ void main() {
         ],
       ),
     );
-    ScrollPosition position = tester.state<Scrollable2State>(find.byType(Scrollable2)).position;
+    ScrollPosition position = tester.state<ScrollableState>(find.byType(Scrollable)).position;
 
     verifyPaintPosition(key1, const Offset(0.0, 0.0), true);
     verifyPaintPosition(key2, const Offset(0.0, 600.0), false);

--- a/packages/flutter/test/widgets/slivers_appbar_pinned_test.dart
+++ b/packages/flutter/test/widgets/slivers_appbar_pinned_test.dart
@@ -8,7 +8,7 @@ import 'package:flutter/widgets.dart';
 
 void verifyPaintPosition(GlobalKey key, Offset ideal, bool visible) {
   RenderSliver target = key.currentContext.findRenderObject();
-  expect(target.parent, const isInstanceOf<RenderViewport2>());
+  expect(target.parent, const isInstanceOf<RenderViewport>());
   SliverPhysicalParentData parentData = target.parentData;
   Offset actual = parentData.paintOffset;
   expect(actual, ideal);
@@ -37,7 +37,7 @@ void main() {
         ],
       ),
     );
-    ScrollPosition position = tester.state<Scrollable2State>(find.byType(Scrollable2)).position;
+    ScrollPosition position = tester.state<ScrollableState>(find.byType(Scrollable)).position;
     final double max = bigHeight * 3.0 + new TestDelegate().maxExtent * 2.0 - 600.0; // 600 is the height of the test viewport
     assert(max < 10000.0);
     expect(max, 1450.0);
@@ -70,7 +70,7 @@ void main() {
         ],
       ),
     );
-    ScrollPosition position = tester.state<Scrollable2State>(find.byType(Scrollable2)).position;
+    ScrollPosition position = tester.state<ScrollableState>(find.byType(Scrollable)).position;
     verifyPaintPosition(key1, const Offset(0.0, 0.0), true);
     verifyPaintPosition(key2, const Offset(0.0, 550.0), true);
     verifyPaintPosition(key3, const Offset(0.0, 600.0), false);
@@ -159,7 +159,7 @@ void main() {
         ],
       ),
     );
-    ScrollPosition position = tester.state<Scrollable2State>(find.byType(Scrollable2)).position;
+    ScrollPosition position = tester.state<ScrollableState>(find.byType(Scrollable)).position;
     final double max = bigHeight * 3.0 + new TestDelegate().maxExtent * 2.0 - 600.0; // 600 is the height of the test viewport
     assert(max < 10000.0);
     expect(max, 1750.0);

--- a/packages/flutter/test/widgets/slivers_appbar_scrolling_test.dart
+++ b/packages/flutter/test/widgets/slivers_appbar_scrolling_test.dart
@@ -8,7 +8,7 @@ import 'package:flutter/widgets.dart';
 
 void verifyPaintPosition(GlobalKey key, Offset ideal) {
   RenderObject target = key.currentContext.findRenderObject();
-  expect(target.parent, const isInstanceOf<RenderViewport2>());
+  expect(target.parent, const isInstanceOf<RenderViewport>());
   SliverPhysicalParentData parentData = target.parentData;
   Offset actual = parentData.paintOffset;
   expect(actual, ideal);
@@ -28,7 +28,7 @@ void main() {
         ],
       ),
     );
-    ScrollPosition position = tester.state<Scrollable2State>(find.byType(Scrollable2)).position;
+    ScrollPosition position = tester.state<ScrollableState>(find.byType(Scrollable)).position;
     final double max = RenderBigSliver.height * 3.0 + new TestDelegate().maxExtent * 2.0 - 600.0; // 600 is the height of the test viewport
     assert(max < 10000.0);
     expect(max, 1450.0);
@@ -60,7 +60,7 @@ void main() {
         ],
       ),
     );
-    ScrollPosition position = tester.state<Scrollable2State>(find.byType(Scrollable2)).position;
+    ScrollPosition position = tester.state<ScrollableState>(find.byType(Scrollable)).position;
     position.animateTo(RenderBigSliver.height + delegate.maxExtent - 5.0, curve: Curves.linear, duration: const Duration(minutes: 1));
     await tester.pumpUntilNoTransientCallbacks(const Duration(milliseconds: 1000));
     RenderBox box = tester.renderObject<RenderBox>(find.byType(Container));

--- a/packages/flutter/test/widgets/slivers_block_global_key_test.dart
+++ b/packages/flutter/test/widgets/slivers_block_global_key_test.dart
@@ -24,7 +24,7 @@ class _GenerationTextState extends State<GenerationText> {
 
 Future<Null> test(WidgetTester tester, double offset, List<int> keys) {
   globalGeneration += 1;
-  return tester.pumpWidget(new Viewport2(
+  return tester.pumpWidget(new Viewport(
     offset: new ViewportOffset.fixed(offset),
     slivers: <Widget>[
       new SliverList(
@@ -49,7 +49,7 @@ void verify(WidgetTester tester, List<Point> answerKey, String text) {
 }
 
 void main() {
-  testWidgets('Viewport2+SliverBlock with GlobalKey reparenting', (WidgetTester tester) async {
+  testWidgets('Viewport+SliverBlock with GlobalKey reparenting', (WidgetTester tester) async {
     await test(tester, 0.0, <int>[1,2,3,4,5,6,7,8,9]);
     verify(tester, <Point>[
       const Point(0.0, 0.0),

--- a/packages/flutter/test/widgets/slivers_block_test.dart
+++ b/packages/flutter/test/widgets/slivers_block_test.dart
@@ -9,7 +9,7 @@ import 'package:flutter/widgets.dart';
 import '../rendering/mock_canvas.dart';
 
 Future<Null> test(WidgetTester tester, double offset) {
-  return tester.pumpWidget(new Viewport2(
+  return tester.pumpWidget(new Viewport(
     offset: new ViewportOffset.fixed(offset),
     slivers: <Widget>[
       new SliverList(
@@ -38,9 +38,9 @@ void verify(WidgetTester tester, List<Point> answerKey, String text) {
 }
 
 void main() {
-  testWidgets('Viewport2+SliverBlock basic test', (WidgetTester tester) async {
+  testWidgets('Viewport+SliverBlock basic test', (WidgetTester tester) async {
     await test(tester, 0.0);
-    expect(tester.renderObject<RenderBox>(find.byType(Viewport2)).size, equals(const Size(800.0, 600.0)));
+    expect(tester.renderObject<RenderBox>(find.byType(Viewport)).size, equals(const Size(800.0, 600.0)));
     verify(tester, <Point>[
       const Point(0.0, 0.0),
       const Point(0.0, 400.0),
@@ -71,10 +71,10 @@ void main() {
     ], 'ab');
   });
 
-  testWidgets('Viewport2 with GlobalKey reparenting', (WidgetTester tester) async {
+  testWidgets('Viewport with GlobalKey reparenting', (WidgetTester tester) async {
     Key key1 = new GlobalKey();
     ViewportOffset offset = new ViewportOffset.zero();
-    await tester.pumpWidget(new Viewport2(
+    await tester.pumpWidget(new Viewport(
       offset: offset,
       slivers: <Widget>[
         new SliverList(
@@ -91,7 +91,7 @@ void main() {
       const Point(0.0, 251.0),
       const Point(0.0, 503.0),
     ], 'abc');
-    await tester.pumpWidget(new Viewport2(
+    await tester.pumpWidget(new Viewport(
       offset: offset,
       slivers: <Widget>[
         new SliverList(
@@ -108,7 +108,7 @@ void main() {
       const Point(0.0, 253.0),
       const Point(0.0, 504.0),
     ], 'cab');
-    await tester.pumpWidget(new Viewport2(
+    await tester.pumpWidget(new Viewport(
       offset: offset,
       slivers: <Widget>[
         new SliverList(
@@ -125,7 +125,7 @@ void main() {
       const Point(0.0, 251.0),
       const Point(0.0, 504.0),
     ], 'acb');
-    await tester.pumpWidget(new Viewport2(
+    await tester.pumpWidget(new Viewport(
       offset: offset,
       slivers: <Widget>[
         new SliverList(
@@ -140,7 +140,7 @@ void main() {
       const Point(0.0, 0.0),
       const Point(0.0, 251.0),
     ], 'ab');
-    await tester.pumpWidget(new Viewport2(
+    await tester.pumpWidget(new Viewport(
       offset: offset,
       slivers: <Widget>[
         new SliverList(
@@ -159,8 +159,8 @@ void main() {
     ], 'acb');
   });
 
-  testWidgets('Viewport2 overflow clipping of SliverToBoxAdapter', (WidgetTester tester) async {
-    await tester.pumpWidget(new Viewport2(
+  testWidgets('Viewport overflow clipping of SliverToBoxAdapter', (WidgetTester tester) async {
+    await tester.pumpWidget(new Viewport(
       offset: new ViewportOffset.zero(),
       slivers: <Widget>[
         new SliverToBoxAdapter(
@@ -169,9 +169,9 @@ void main() {
       ],
     ));
 
-    expect(find.byType(Viewport2), isNot(paints..clipRect()));
+    expect(find.byType(Viewport), isNot(paints..clipRect()));
 
-    await tester.pumpWidget(new Viewport2(
+    await tester.pumpWidget(new Viewport(
       offset: new ViewportOffset.fixed(100.0),
       slivers: <Widget>[
         new SliverToBoxAdapter(
@@ -180,9 +180,9 @@ void main() {
       ],
     ));
 
-    expect(find.byType(Viewport2), paints..clipRect());
+    expect(find.byType(Viewport), paints..clipRect());
 
-    await tester.pumpWidget(new Viewport2(
+    await tester.pumpWidget(new Viewport(
       offset: new ViewportOffset.fixed(100.0),
       slivers: <Widget>[
         new SliverToBoxAdapter(
@@ -191,9 +191,9 @@ void main() {
       ],
     ));
 
-    expect(find.byType(Viewport2), paints..clipRect());
+    expect(find.byType(Viewport), paints..clipRect());
 
-    await tester.pumpWidget(new Viewport2(
+    await tester.pumpWidget(new Viewport(
       offset: new ViewportOffset.zero(),
       slivers: <Widget>[
         new SliverToBoxAdapter(
@@ -202,11 +202,11 @@ void main() {
       ],
     ));
 
-    expect(find.byType(Viewport2), paints..clipRect());
+    expect(find.byType(Viewport), paints..clipRect());
   });
 
-  testWidgets('Viewport2 overflow clipping of SliverBlock', (WidgetTester tester) async {
-    await tester.pumpWidget(new Viewport2(
+  testWidgets('Viewport overflow clipping of SliverBlock', (WidgetTester tester) async {
+    await tester.pumpWidget(new Viewport(
       offset: new ViewportOffset.zero(),
       slivers: <Widget>[
         new SliverList(
@@ -217,9 +217,9 @@ void main() {
       ],
     ));
 
-    expect(find.byType(Viewport2), isNot(paints..clipRect()));
+    expect(find.byType(Viewport), isNot(paints..clipRect()));
 
-    await tester.pumpWidget(new Viewport2(
+    await tester.pumpWidget(new Viewport(
       offset: new ViewportOffset.fixed(100.0),
       slivers: <Widget>[
         new SliverList(
@@ -230,9 +230,9 @@ void main() {
       ],
     ));
 
-    expect(find.byType(Viewport2), paints..clipRect());
+    expect(find.byType(Viewport), paints..clipRect());
 
-    await tester.pumpWidget(new Viewport2(
+    await tester.pumpWidget(new Viewport(
       offset: new ViewportOffset.fixed(100.0),
       slivers: <Widget>[
         new SliverList(
@@ -243,9 +243,9 @@ void main() {
       ],
     ));
 
-    expect(find.byType(Viewport2), paints..clipRect());
+    expect(find.byType(Viewport), paints..clipRect());
 
-    await tester.pumpWidget(new Viewport2(
+    await tester.pumpWidget(new Viewport(
       offset: new ViewportOffset.zero(),
       slivers: <Widget>[
         new SliverList(
@@ -256,6 +256,6 @@ void main() {
       ],
     ));
 
-    expect(find.byType(Viewport2), paints..clipRect());
+    expect(find.byType(Viewport), paints..clipRect());
   });
 }

--- a/packages/flutter/test/widgets/slivers_evil_test.dart
+++ b/packages/flutter/test/widgets/slivers_evil_test.dart
@@ -32,7 +32,7 @@ class TestSliverPersistentHeaderDelegate extends SliverPersistentHeaderDelegate 
   bool shouldRebuild(TestSliverPersistentHeaderDelegate oldDelegate) => false;
 }
 
-class TestBehavior extends ScrollBehavior2 {
+class TestBehavior extends ScrollBehavior {
   @override
   Widget buildViewportChrome(BuildContext context, Widget child, AxisDirection axisDirection) {
     return new GlowingOverscrollIndicator(
@@ -72,14 +72,14 @@ void main() {
   testWidgets('Evil test of sliver features - 1', (WidgetTester tester) async {
     final GlobalKey centerKey = new GlobalKey();
     await tester.pumpWidget(
-      new ScrollConfiguration2(
+      new ScrollConfiguration(
         behavior: new TestBehavior(),
         child: new Scrollbar(
-          child: new Scrollable2(
+          child: new Scrollable(
             axisDirection: AxisDirection.down,
             physics: const TestScrollPhysics(),
             viewportBuilder: (BuildContext context, ViewportOffset offset) {
-              return new Viewport2(
+              return new Viewport(
                 axisDirection: AxisDirection.down,
                 anchor: 0.25,
                 offset: offset,
@@ -158,7 +158,7 @@ void main() {
         ),
       ),
     );
-    ScrollPosition position = tester.state<Scrollable2State>(find.byType(Scrollable2)).position;
+    ScrollPosition position = tester.state<ScrollableState>(find.byType(Scrollable)).position;
 
     position.animateTo(10000.0, curve: Curves.linear, duration: const Duration(minutes: 1));
     await tester.pump(const Duration(milliseconds: 10));

--- a/packages/flutter/test/widgets/slivers_padding_test.dart
+++ b/packages/flutter/test/widgets/slivers_padding_test.dart
@@ -7,7 +7,7 @@ import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 
 Future<Null> test(WidgetTester tester, double offset, EdgeInsets padding, AxisDirection axisDirection) {
-  return tester.pumpWidget(new Viewport2(
+  return tester.pumpWidget(new Viewport(
     offset: new ViewportOffset.fixed(offset),
     axisDirection: axisDirection,
     slivers: <Widget>[
@@ -33,10 +33,10 @@ void verify(WidgetTester tester, List<Rect> answerKey) {
 }
 
 void main() {
-  testWidgets('Viewport2+SliverPadding basic test', (WidgetTester tester) async {
+  testWidgets('Viewport+SliverPadding basic test', (WidgetTester tester) async {
     EdgeInsets padding = const EdgeInsets.fromLTRB(25.0, 20.0, 15.0, 35.0);
     await test(tester, 0.0, padding, AxisDirection.down);
-    expect(tester.renderObject<RenderBox>(find.byType(Viewport2)).size, equals(const Size(800.0, 600.0)));
+    expect(tester.renderObject<RenderBox>(find.byType(Viewport)).size, equals(const Size(800.0, 600.0)));
     verify(tester, <Rect>[
       new Rect.fromLTWH(0.0, 0.0, 800.0, 400.0),
       new Rect.fromLTWH(25.0, 420.0, 760.0, 400.0),
@@ -72,10 +72,10 @@ void main() {
     ]);
   });
 
-  testWidgets('Viewport2+SliverPadding hit testing', (WidgetTester tester) async {
+  testWidgets('Viewport+SliverPadding hit testing', (WidgetTester tester) async {
     EdgeInsets padding = const EdgeInsets.all(30.0);
     await test(tester, 350.0, padding, AxisDirection.down);
-    expect(tester.renderObject<RenderBox>(find.byType(Viewport2)).size, equals(const Size(800.0, 600.0)));
+    expect(tester.renderObject<RenderBox>(find.byType(Viewport)).size, equals(const Size(800.0, 600.0)));
     verify(tester, <Rect>[
       new Rect.fromLTWH(0.0, -350.0, 800.0, 400.0),
       new Rect.fromLTWH(30.0, 80.0, 740.0, 400.0),
@@ -94,10 +94,10 @@ void main() {
     expect(result.path.first.target, tester.renderObjectList<RenderObject>(find.byType(Text)).last);
   });
 
-  testWidgets('Viewport2+SliverPadding hit testing up', (WidgetTester tester) async {
+  testWidgets('Viewport+SliverPadding hit testing up', (WidgetTester tester) async {
     EdgeInsets padding = const EdgeInsets.all(30.0);
     await test(tester, 350.0, padding, AxisDirection.up);
-    expect(tester.renderObject<RenderBox>(find.byType(Viewport2)).size, equals(const Size(800.0, 600.0)));
+    expect(tester.renderObject<RenderBox>(find.byType(Viewport)).size, equals(const Size(800.0, 600.0)));
     verify(tester, <Rect>[
       new Rect.fromLTWH(0.0, 600.0+350.0-400.0, 800.0, 400.0),
       new Rect.fromLTWH(30.0, 600.0-80.0-400.0, 740.0, 400.0),
@@ -116,10 +116,10 @@ void main() {
     expect(result.path.first.target, tester.renderObjectList<RenderObject>(find.byType(Text)).last);
   });
 
-  testWidgets('Viewport2+SliverPadding hit testing left', (WidgetTester tester) async {
+  testWidgets('Viewport+SliverPadding hit testing left', (WidgetTester tester) async {
     EdgeInsets padding = const EdgeInsets.all(30.0);
     await test(tester, 350.0, padding, AxisDirection.left);
-    expect(tester.renderObject<RenderBox>(find.byType(Viewport2)).size, equals(const Size(800.0, 600.0)));
+    expect(tester.renderObject<RenderBox>(find.byType(Viewport)).size, equals(const Size(800.0, 600.0)));
     verify(tester, <Rect>[
       new Rect.fromLTWH(800.0+350.0-400.0, 0.0, 400.0, 600.0),
       new Rect.fromLTWH(800.0-80.0-400.0, 30.0, 400.0, 540.0),
@@ -138,10 +138,10 @@ void main() {
     expect(result.path.first.target, tester.renderObjectList<RenderObject>(find.byType(Text)).last);
   });
 
-  testWidgets('Viewport2+SliverPadding hit testing right', (WidgetTester tester) async {
+  testWidgets('Viewport+SliverPadding hit testing right', (WidgetTester tester) async {
     EdgeInsets padding = const EdgeInsets.all(30.0);
     await test(tester, 350.0, padding, AxisDirection.right);
-    expect(tester.renderObject<RenderBox>(find.byType(Viewport2)).size, equals(const Size(800.0, 600.0)));
+    expect(tester.renderObject<RenderBox>(find.byType(Viewport)).size, equals(const Size(800.0, 600.0)));
     verify(tester, <Rect>[
       new Rect.fromLTWH(-350.0, 0.0, 400.0, 600.0),
       new Rect.fromLTWH(80.0, 30.0, 400.0, 540.0),
@@ -160,8 +160,8 @@ void main() {
     expect(result.path.first.target, tester.renderObjectList<RenderObject>(find.byType(Text)).last);
   });
 
-  testWidgets('Viewport2+SliverPadding no child', (WidgetTester tester) async {
-    await tester.pumpWidget(new Viewport2(
+  testWidgets('Viewport+SliverPadding no child', (WidgetTester tester) async {
+    await tester.pumpWidget(new Viewport(
       offset: new ViewportOffset.fixed(0.0),
       slivers: <Widget>[
         new SliverPadding(padding: const EdgeInsets.all(100.0)),
@@ -171,8 +171,8 @@ void main() {
     expect(tester.renderObject<RenderBox>(find.text('x')).localToGlobal(Point.origin), const Point(0.0, 200.0));
   });
 
-  testWidgets('Viewport2+SliverPadding changing padding', (WidgetTester tester) async {
-    await tester.pumpWidget(new Viewport2(
+  testWidgets('Viewport+SliverPadding changing padding', (WidgetTester tester) async {
+    await tester.pumpWidget(new Viewport(
       axisDirection: AxisDirection.left,
       offset: new ViewportOffset.fixed(0.0),
       slivers: <Widget>[
@@ -181,7 +181,7 @@ void main() {
       ],
     ));
     expect(tester.renderObject<RenderBox>(find.text('x')).localToGlobal(Point.origin), const Point(399.0, 0.0));
-    await tester.pumpWidget(new Viewport2(
+    await tester.pumpWidget(new Viewport(
       axisDirection: AxisDirection.left,
       offset: new ViewportOffset.fixed(0.0),
       slivers: <Widget>[
@@ -192,8 +192,8 @@ void main() {
     expect(tester.renderObject<RenderBox>(find.text('x')).localToGlobal(Point.origin), const Point(409.0, 0.0));
   });
 
-  testWidgets('Viewport2+SliverPadding changing direction', (WidgetTester tester) async {
-    await tester.pumpWidget(new Viewport2(
+  testWidgets('Viewport+SliverPadding changing direction', (WidgetTester tester) async {
+    await tester.pumpWidget(new Viewport(
       axisDirection: AxisDirection.up,
       offset: new ViewportOffset.fixed(0.0),
       slivers: <Widget>[
@@ -201,7 +201,7 @@ void main() {
       ],
     ));
     expect(tester.renderObject<RenderSliverPadding>(find.byType(SliverPadding)).afterPadding, 2.0);
-    await tester.pumpWidget(new Viewport2(
+    await tester.pumpWidget(new Viewport(
       axisDirection: AxisDirection.down,
       offset: new ViewportOffset.fixed(0.0),
       slivers: <Widget>[
@@ -209,7 +209,7 @@ void main() {
       ],
     ));
     expect(tester.renderObject<RenderSliverPadding>(find.byType(SliverPadding)).afterPadding, 8.0);
-    await tester.pumpWidget(new Viewport2(
+    await tester.pumpWidget(new Viewport(
       axisDirection: AxisDirection.right,
       offset: new ViewportOffset.fixed(0.0),
       slivers: <Widget>[
@@ -217,7 +217,7 @@ void main() {
       ],
     ));
     expect(tester.renderObject<RenderSliverPadding>(find.byType(SliverPadding)).afterPadding, 4.0);
-    await tester.pumpWidget(new Viewport2(
+    await tester.pumpWidget(new Viewport(
       axisDirection: AxisDirection.left,
       offset: new ViewportOffset.fixed(0.0),
       slivers: <Widget>[
@@ -225,7 +225,7 @@ void main() {
       ],
     ));
     expect(tester.renderObject<RenderSliverPadding>(find.byType(SliverPadding)).afterPadding, 1.0);
-    await tester.pumpWidget(new Viewport2(
+    await tester.pumpWidget(new Viewport(
       axisDirection: AxisDirection.left,
       offset: new ViewportOffset.fixed(99999.9),
       slivers: <Widget>[

--- a/packages/flutter/test/widgets/slivers_protocol_test.dart
+++ b/packages/flutter/test/widgets/slivers_protocol_test.dart
@@ -10,7 +10,7 @@ import 'package:flutter/widgets.dart';
 
 void verifyPaintPosition(GlobalKey key, Offset ideal) {
   RenderObject target = key.currentContext.findRenderObject();
-  expect(target.parent, const isInstanceOf<RenderViewport2>());
+  expect(target.parent, const isInstanceOf<RenderViewport>());
   SliverPhysicalParentData parentData = target.parentData;
   Offset actual = parentData.paintOffset;
   expect(actual, ideal);
@@ -30,7 +30,7 @@ void main() {
         ],
       ),
     );
-    ScrollPosition position = tester.state<Scrollable2State>(find.byType(Scrollable2)).position;
+    ScrollPosition position = tester.state<ScrollableState>(find.byType(Scrollable)).position;
     final double max = RenderBigSliver.height * 3.0 + (RenderOverlappingSliver.totalHeight) * 2.0 - 600.0; // 600 is the height of the test viewport
     assert(max < 10000.0);
     expect(max, 1450.0);

--- a/packages/flutter/test/widgets/slivers_test.dart
+++ b/packages/flutter/test/widgets/slivers_test.dart
@@ -7,7 +7,7 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter/rendering.dart';
 
 Future<Null> test(WidgetTester tester, double offset, { double anchor: 0.0 }) {
-  return tester.pumpWidget(new Viewport2(
+  return tester.pumpWidget(new Viewport(
     anchor: anchor / 600.0,
     offset: new ViewportOffset.fixed(offset),
     slivers: <Widget>[
@@ -32,9 +32,9 @@ void verify(WidgetTester tester, List<Point> idealPositions, List<bool> idealVis
 }
 
 void main() {
-  testWidgets('Viewport2 basic test', (WidgetTester tester) async {
+  testWidgets('Viewport basic test', (WidgetTester tester) async {
     await test(tester, 0.0);
-    expect(tester.renderObject<RenderBox>(find.byType(Viewport2)).size, equals(const Size(800.0, 600.0)));
+    expect(tester.renderObject<RenderBox>(find.byType(Viewport)).size, equals(const Size(800.0, 600.0)));
     verify(tester, <Point>[
       const Point(0.0, 0.0),
       const Point(0.0, 400.0),
@@ -71,9 +71,9 @@ void main() {
     ], <bool>[false, false, true, true, false]);
   });
 
-  testWidgets('Viewport2 anchor test', (WidgetTester tester) async {
+  testWidgets('Viewport anchor test', (WidgetTester tester) async {
     await test(tester, 0.0, anchor: 100.0);
-    expect(tester.renderObject<RenderBox>(find.byType(Viewport2)).size, equals(const Size(800.0, 600.0)));
+    expect(tester.renderObject<RenderBox>(find.byType(Viewport)).size, equals(const Size(800.0, 600.0)));
     verify(tester, <Point>[
       const Point(0.0, 100.0),
       const Point(0.0, 500.0),

--- a/packages/flutter/test/widgets/state_setting_in_scrollables_test.dart
+++ b/packages/flutter/test/widgets/state_setting_in_scrollables_test.dart
@@ -17,7 +17,7 @@ class FooState extends State<Foo> {
   Widget build(BuildContext context) {
     return new LayoutBuilder(
       builder: (BuildContext context, BoxConstraints constraints) {
-        return new ScrollConfiguration2(
+        return new ScrollConfiguration(
           behavior: new FooScrollBehavior(),
           child: new ListView(
             controller: scrollController,
@@ -72,7 +72,7 @@ class FooState extends State<Foo> {
   }
 }
 
-class FooScrollBehavior extends ScrollBehavior2 {
+class FooScrollBehavior extends ScrollBehavior {
   @override
   bool shouldNotify(FooScrollBehavior old) => true;
 }
@@ -80,10 +80,10 @@ class FooScrollBehavior extends ScrollBehavior2 {
 void main() {
   testWidgets('Can animate scroll after setState', (WidgetTester tester) async {
     await tester.pumpWidget(new Foo());
-    expect(tester.state<Scrollable2State>(find.byType(Scrollable2)).position.pixels, 0.0);
+    expect(tester.state<ScrollableState>(find.byType(Scrollable)).position.pixels, 0.0);
     await tester.tap(find.byType(GestureDetector).first);
     await tester.pump();
     await tester.pump(const Duration(seconds: 1));
-    expect(tester.state<Scrollable2State>(find.byType(Scrollable2)).position.pixels, 200.0);
+    expect(tester.state<ScrollableState>(find.byType(Scrollable)).position.pixels, 200.0);
   });
 }

--- a/packages/flutter_driver/lib/src/extension.dart
+++ b/packages/flutter_driver/lib/src/extension.dart
@@ -248,7 +248,7 @@ class _FlutterDriverExtension {
   Future<ScrollResult> _scrollIntoView(Command command) async {
     ScrollIntoView scrollIntoViewCommand = command;
     Finder target = await _waitForElement(_createFinder(scrollIntoViewCommand.finder));
-    await Scrollable2.ensureVisible(target.evaluate().single, duration: const Duration(milliseconds: 100), alignment: scrollIntoViewCommand.alignment ?? 0.0);
+    await Scrollable.ensureVisible(target.evaluate().single, duration: const Duration(milliseconds: 100), alignment: scrollIntoViewCommand.alignment ?? 0.0);
     return new ScrollResult();
   }
 


### PR DESCRIPTION
Rename all the "2" classes related to scrolling to remove the "2". Now that the
old scrolling code is gone, we don't need to use the suffix.