### PR TITLE
PageView shouldn't crash in zero-size container

### DIFF
--- a/packages/flutter/lib/src/rendering/sliver_fixed_extent_list.dart
+++ b/packages/flutter/lib/src/rendering/sliver_fixed_extent_list.dart
@@ -37,8 +37,8 @@ abstract class RenderSliverFixedExtentBoxAdaptor extends RenderSliverMultiBoxAda
       maxExtent: itemExtent,
     );
 
-    final int firstIndex = math.max(0, scrollOffset ~/ itemExtent);
-    final int targetLastIndex = math.max(0, (targetEndScrollOffset / itemExtent).ceil() - 1);
+    final int firstIndex = itemExtent > 0.0 ? math.max(0, scrollOffset ~/ itemExtent) : 0;
+    final int targetLastIndex = itemExtent > 0.0 ? math.max(0, (targetEndScrollOffset / itemExtent).ceil() - 1) : 0;
 
     if (firstChild != null) {
       final int oldFirstIndex = indexOf(firstChild);

--- a/packages/flutter/test/widgets/page_view_test.dart
+++ b/packages/flutter/test/widgets/page_view_test.dart
@@ -191,4 +191,18 @@ void main() {
 
     expect(find.text('Arizona'), findsOneWidget);
   });
+
+  testWidgets('PageView in zero-size container', (WidgetTester tester) async {
+    await tester.pumpWidget(new Center(
+      child: new SizedBox(
+        width: 0.0,
+        height: 0.0,
+        child: new PageView(
+          children: kStates.map<Widget>((String state) => new Text(state)).toList(),
+        ),
+      ),
+    ));
+
+    expect(find.text('Alabama'), findsOneWidget);
+  });
 }


### PR DESCRIPTION
Previously, we were dividing by zero.

Fixes #8281