### PR TITLE
PageView should be able to resize from zero

### DIFF
--- a/packages/flutter/lib/src/widgets/page_view.dart
+++ b/packages/flutter/lib/src/widgets/page_view.dart
@@ -86,7 +86,7 @@ class _PagePosition extends ScrollPosition {
     final double oldViewportDimensions = this.viewportDimension;
     final bool result = super.applyViewportDimension(viewportDimension);
     final double oldPixels = pixels;
-    final double page = oldPixels == null ? initialPage.toDouble() : oldPixels / oldViewportDimensions;
+    final double page = (oldPixels == null || oldViewportDimensions == 0.0) ? initialPage.toDouble() : oldPixels / oldViewportDimensions;
     final double newPixels = page * viewportDimension;
     if (newPixels != oldPixels) {
       correctPixels(newPixels);

--- a/packages/flutter/test/widgets/page_view_test.dart
+++ b/packages/flutter/test/widgets/page_view_test.dart
@@ -204,5 +204,17 @@ void main() {
     ));
 
     expect(find.text('Alabama'), findsOneWidget);
+
+    await tester.pumpWidget(new Center(
+      child: new SizedBox(
+        width: 200.0,
+        height: 200.0,
+        child: new PageView(
+          children: kStates.map<Widget>((String state) => new Text(state)).toList(),
+        ),
+      ),
+    ));
+
+    expect(find.text('Alabama'), findsOneWidget);
   });
 }


### PR DESCRIPTION
When resizing a PageView from 0x0, we weren't sure what the old page
number was because all the pages are collapsed at zero. Now we avoid the
divide by zero and default to the initialPage.

Fixes #8285