### PR TITLE
Fix finding Android Studio on macOS.

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_studio.dart
+++ b/packages/flutter_tools/lib/src/android/android_studio.dart
@@ -123,6 +123,8 @@ class AndroidStudio implements Comparable<AndroidStudio> {
     List<FileSystemEntity> candidatePaths = <FileSystemEntity>[];
 
     void _checkForStudio(String path) {
+      if (!fs.isDirectorySync(path))
+        return;
       List<Directory> directories = fs
           .directory(path)
           .listSync()


### PR DESCRIPTION
Don't fail if $HOME/Applications doesn't exist.