### PR TITLE
One more fix for finding Android Studio on macOS.

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_studio.dart
+++ b/packages/flutter_tools/lib/src/android/android_studio.dart
@@ -125,7 +125,7 @@ class AndroidStudio implements Comparable<AndroidStudio> {
     void _checkForStudio(String path) {
       if (!fs.isDirectorySync(path))
         return;
-      List<Directory> directories = fs
+      Iterable<Directory> directories = fs
           .directory(path)
           .listSync()
           .where((FileSystemEntity e) => e is Directory);


### PR DESCRIPTION
Finally found the command to run tests in checked mode on my system. This one should've been caught by the IDE, but wasn't.