### PR TITLE
Remove SHA1 check from AndroidDevice.isAppInstalled()

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_device.dart
+++ b/packages/flutter_tools/lib/src/android/android_device.dart
@@ -213,11 +213,7 @@ class AndroidDevice extends Device {
   bool isAppInstalled(ApplicationPackage app) {
     // This call takes 400ms - 600ms.
     String listOut = runCheckedSync(adbCommandForDevice(<String>['shell', 'pm', 'list', 'packages', app.id]));
-    if (!LineSplitter.split(listOut).contains("package:${app.id}"))
-      return false;
-
-    // Check the application SHA.
-    return _getDeviceApkSha1(app) == _getSourceSha1(app);
+    return LineSplitter.split(listOut).contains("package:${app.id}");
   }
 
   @override

--- a/packages/flutter_tools/lib/src/android/android_device.dart
+++ b/packages/flutter_tools/lib/src/android/android_device.dart
@@ -196,10 +196,6 @@ class AndroidDevice extends Device {
     return '/data/local/tmp/sky.${app.id}.sha1';
   }
 
-  String _getDeviceApkSha1(ApplicationPackage app) {
-    return runCheckedSync(adbCommandForDevice(<String>['shell', 'cat', _getDeviceSha1Path(app)]));
-  }
-
   String _getSourceSha1(ApplicationPackage app) {
     AndroidApk apk = app;
     File shaFile = fs.file('${apk.apkPath}.sha1');


### PR DESCRIPTION
The docs for isAppInstalled say 'check if a version of the given app is already installed', however the current code returns true only if it's the latest build that's installed.

This made sense in the past, when the use pattern was:

```dart
  if (!isAppInstalled(...)) installApp(...);
```

but now the usage is:

```dart
  if (isAppInstalled(...)) uninstallApp(...);
  installApp(...);
```

This has the probably unintended consequence that if you run `flutter install` or `flutter run` two times in a row with no source changes, the second invocation will uninstall the app, but the first invocation might not.

Removing the SHA1 check makes us always uninstall the app if it's installed.

Fixes #8172