### PR TITLE
Don't reinstall the app if the latest build is already installed.

### DIFF
--- a/packages/flutter_tools/lib/src/android/gradle.dart
+++ b/packages/flutter_tools/lib/src/android/gradle.dart
@@ -175,5 +175,10 @@ Future<Null> buildGradleProjectV2(String gradle, String buildModeName) async {
   File apkFile = fs.file('$gradleAppOutDir/$apkFilename');
   // Copy the APK to app.apk, so `flutter run`, `flutter install`, etc. can find it.
   apkFile.copySync('$gradleAppOutDir/app.apk');
+
+  printTrace('calculateSha: $gradleAppOutDir/app.apk');
+  File apkShaFile = fs.file('$gradleAppOutDir/app.apk.sha1');
+  apkShaFile.writeAsStringSync(calculateSha(apkFile));
+
   printStatus('Built $apkFilename (${getSizeAsMB(apkFile.lengthSync())}).');
 }

--- a/packages/flutter_tools/lib/src/device.dart
+++ b/packages/flutter_tools/lib/src/device.dart
@@ -151,6 +151,9 @@ abstract class Device {
   /// Check if a version of the given app is already installed
   bool isAppInstalled(ApplicationPackage app);
 
+  /// Check if the latest build of the [app] is already installed.
+  bool isLatestBuildInstalled(ApplicationPackage app);
+
   /// Install an app package on the current device
   bool installApp(ApplicationPackage app);
 

--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -153,6 +153,9 @@ class IOSDevice extends Device {
   }
 
   @override
+  bool isLatestBuildInstalled(ApplicationPackage app) => false;
+
+  @override
   bool installApp(ApplicationPackage app) {
     IOSApp iosApp = app;
     Directory bundle = fs.directory(iosApp.deviceBundlePath);

--- a/packages/flutter_tools/lib/src/ios/simulators.dart
+++ b/packages/flutter_tools/lib/src/ios/simulators.dart
@@ -341,6 +341,9 @@ class IOSSimulator extends Device {
   }
 
   @override
+  bool isLatestBuildInstalled(ApplicationPackage app) => false;
+
+  @override
   bool installApp(ApplicationPackage app) {
     try {
       IOSApp iosApp = app;


### PR DESCRIPTION
Only implemented for Android devices for now. Compare the installed SHA1
to the latest build. If they match, there's no reason to reinstall the
build.

Fixes #8295