### PR TITLE
Added support for a pinned floating SliverAppBar

### DIFF
--- a/packages/flutter/lib/src/material/app_bar.dart
+++ b/packages/flutter/lib/src/material/app_bar.dart
@@ -93,6 +93,32 @@ class _ToolbarLayout extends MultiChildLayoutDelegate {
   bool shouldRelayout(_ToolbarLayout oldDelegate) => centerTitle != oldDelegate.centerTitle;
 }
 
+// Bottom justify the kToolbarHeight child which may overflow the top.
+class _ToolbarContainerLayout extends SingleChildLayoutDelegate {
+  @override
+  BoxConstraints getConstraintsForChild(BoxConstraints constraints) {
+    return new BoxConstraints(
+      minWidth: constraints.minWidth,
+      maxWidth: constraints.maxWidth,
+      minHeight: kToolbarHeight,
+      maxHeight: kToolbarHeight,
+    );
+  }
+
+  @override
+  Size getSize(BoxConstraints constraints) {
+    return constraints.tighten(height: kToolbarHeight).biggest;
+  }
+
+  @override
+  Offset getPositionForChild(Size size, Size childSize) {
+    return new Offset(0.0, size.height - childSize.height);
+  }
+
+  @override
+  bool shouldRelayout(_ToolbarContainerLayout oldDelegate) => false;
+}
+
 // TODO(eseidel) Toolbar needs to change size based on orientation:
 // http://material.google.com/layout/structure.html#structure-app-bar
 // Mobile Landscape: 48dp
@@ -422,24 +448,32 @@ class _AppBarState extends State<AppBar> {
       ),
     );
 
-    Widget appBar = new SizedBox(
-      height: kToolbarHeight,
-      child: new IconTheme.merge(
-        context: context,
-        data: appBarIconTheme,
-        child: new DefaultTextStyle(
-          style: sideStyle,
-          child: toolbar,
+    // If the toolbar is allocated less than kToolbarHeight make it
+    // appear to scroll upwards within its shrinking container.
+    Widget appBar = new ClipRect(
+      child: new CustomSingleChildLayout(
+        delegate: new _ToolbarContainerLayout(),
+        child: new IconTheme.merge(
+          context: context,
+          data: appBarIconTheme,
+          child: new DefaultTextStyle(
+            style: sideStyle,
+            child: toolbar,
+          ),
         ),
       ),
     );
-
 
     if (config.bottom != null) {
       appBar = new Column(
         mainAxisAlignment: MainAxisAlignment.spaceBetween,
         children: <Widget>[
-          appBar,
+          new Flexible(
+            child: new ConstrainedBox(
+              constraints: new BoxConstraints(maxHeight: kToolbarHeight),
+              child: appBar,
+            ),
+          ),
           config.bottomOpacity == 1.0 ? config.bottom : new Opacity(
             opacity: const Interval(0.25, 1.0, curve: Curves.fastOutSlowIn).transform(config.bottomOpacity),
             child: config.bottom,
@@ -491,7 +525,9 @@ class _SliverAppBarDelegate extends SliverPersistentHeaderDelegate {
     @required this.primary,
     @required this.centerTitle,
     @required this.expandedHeight,
+    @required this.collapsedHeight,
     @required this.topPadding,
+    @required this.floating,
     @required this.pinned,
   }) : bottom = bottom,
       _bottomHeight = bottom?.bottomHeight ?? 0.0 {
@@ -511,21 +547,24 @@ class _SliverAppBarDelegate extends SliverPersistentHeaderDelegate {
   final bool primary;
   final bool centerTitle;
   final double expandedHeight;
+  final double collapsedHeight;
   final double topPadding;
+  final bool floating;
   final bool pinned;
 
   final double _bottomHeight;
 
   @override
-  double get minExtent => topPadding + kToolbarHeight + _bottomHeight;
+  double get minExtent => collapsedHeight ?? (topPadding + kToolbarHeight + _bottomHeight);
 
   @override
-  double get maxExtent => math.max(topPadding + (expandedHeight ?? kToolbarHeight), minExtent);
+  double get maxExtent => math.max(topPadding + (expandedHeight ?? kToolbarHeight + _bottomHeight), minExtent);
 
   @override
   Widget build(BuildContext context, double shrinkOffset, bool overlapsContent) {
-    double visibleMainHeight = maxExtent - shrinkOffset - topPadding;
-    double toolbarOpacity = pinned ? 1.0 : ((visibleMainHeight - _bottomHeight) / kToolbarHeight).clamp(0.0, 1.0);
+    final double visibleMainHeight = maxExtent - shrinkOffset - topPadding;
+    final double toolbarOpacity = pinned && !floating ? 1.0
+      : ((visibleMainHeight - _bottomHeight) / kToolbarHeight).clamp(0.0, 1.0);
     return FlexibleSpaceBar.createSettings(
       minExtent: minExtent,
       maxExtent: maxExtent,
@@ -566,7 +605,9 @@ class _SliverAppBarDelegate extends SliverPersistentHeaderDelegate {
         || primary != oldDelegate.primary
         || centerTitle != oldDelegate.centerTitle
         || expandedHeight != oldDelegate.expandedHeight
-        || topPadding != oldDelegate.topPadding;
+        || topPadding != oldDelegate.topPadding
+        || pinned != oldDelegate.pinned
+        || floating != oldDelegate.floating;
   }
 
   @override
@@ -627,7 +668,7 @@ class SliverAppBar extends StatelessWidget {
     assert(primary != null);
     assert(floating != null);
     assert(pinned != null);
-    assert(!floating || !pinned);
+    assert(pinned && floating ? bottom != null : true);
   }
 
   /// A widget to display before the [title].
@@ -760,6 +801,10 @@ class SliverAppBar extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final double topPadding = primary ? MediaQuery.of(context).padding.top : 0.0;
+    final double collapsedHeight = (pinned && floating && bottom != null)
+      ? bottom.bottomHeight + topPadding : null;
+
     return new SliverPersistentHeader(
       floating: floating,
       pinned: pinned,
@@ -777,7 +822,9 @@ class SliverAppBar extends StatelessWidget {
         primary: primary,
         centerTitle: centerTitle,
         expandedHeight: expandedHeight,
-        topPadding: primary ? MediaQuery.of(context).padding.top : 0.0,
+        collapsedHeight: collapsedHeight,
+        topPadding: topPadding,
+        floating: floating,
         pinned: pinned,
       ),
     );

--- a/packages/flutter/lib/src/material/app_bar.dart
+++ b/packages/flutter/lib/src/material/app_bar.dart
@@ -95,19 +95,16 @@ class _ToolbarLayout extends MultiChildLayoutDelegate {
 
 // Bottom justify the kToolbarHeight child which may overflow the top.
 class _ToolbarContainerLayout extends SingleChildLayoutDelegate {
+  const _ToolbarContainerLayout();
+
   @override
   BoxConstraints getConstraintsForChild(BoxConstraints constraints) {
-    return new BoxConstraints(
-      minWidth: constraints.minWidth,
-      maxWidth: constraints.maxWidth,
-      minHeight: kToolbarHeight,
-      maxHeight: kToolbarHeight,
-    );
+    return constraints.tighten(height: kToolbarHeight);
   }
 
   @override
   Size getSize(BoxConstraints constraints) {
-    return constraints.tighten(height: kToolbarHeight).biggest;
+    return new Size(constraints.maxWidth, kToolbarHeight);
   }
 
   @override
@@ -452,7 +449,7 @@ class _AppBarState extends State<AppBar> {
     // appear to scroll upwards within its shrinking container.
     Widget appBar = new ClipRect(
       child: new CustomSingleChildLayout(
-        delegate: new _ToolbarContainerLayout(),
+        delegate: const _ToolbarContainerLayout(),
         child: new IconTheme.merge(
           context: context,
           data: appBarIconTheme,

--- a/packages/flutter/lib/src/rendering/shifted_box.dart
+++ b/packages/flutter/lib/src/rendering/shifted_box.dart
@@ -700,6 +700,10 @@ class RenderFractionallySizedOverflowBox extends RenderAligningShiftedBox {
 
 /// A delegate for computing the layout of a render object with a single child.
 abstract class SingleChildLayoutDelegate {
+  /// Abstract const constructor. This constructor enables subclasses to provide
+  /// const constructors so that they can be used in const expressions.
+  const SingleChildLayoutDelegate();
+
   // TODO(abarth): This class should take a Listenable to drive relayout.
 
   /// The size of this object given the incoming constraints.

--- a/packages/flutter/lib/src/rendering/sliver_persistent_header.dart
+++ b/packages/flutter/lib/src/rendering/sliver_persistent_header.dart
@@ -265,8 +265,9 @@ abstract class RenderSliverFloatingPersistentHeader extends RenderSliverPersiste
   // direction. Negative if we're scrolled off the top.
   double _childPosition;
 
+  // Update [geometry] and return the new value for [childMainAxisPosition].
   @protected
-  void _updateGeometry() {
+  double updateGeometry() {
     final double maxExtent = this.maxExtent;
     final double paintExtent = maxExtent - _effectiveScrollOffset;
     final double layoutExtent = maxExtent - constraints.scrollOffset;
@@ -277,7 +278,7 @@ abstract class RenderSliverFloatingPersistentHeader extends RenderSliverPersiste
       maxPaintExtent: maxExtent,
       hasVisualOverflow: true, // Conservatively say we do have overflow to avoid complexity.
     );
-    _childPosition = math.min(0.0, paintExtent - childExtent);
+    return math.min(0.0, paintExtent - childExtent);
   }
 
 
@@ -301,7 +302,7 @@ abstract class RenderSliverFloatingPersistentHeader extends RenderSliverPersiste
       _effectiveScrollOffset = constraints.scrollOffset;
     }
     layoutChild(_effectiveScrollOffset, maxExtent, overlapsContent: _effectiveScrollOffset < constraints.scrollOffset);
-    _updateGeometry();
+    _childPosition = updateGeometry();
     _lastActualScrollOffset = constraints.scrollOffset;
   }
 
@@ -324,7 +325,7 @@ abstract class RenderSliverFloatingPinnedPersistentHeader extends RenderSliverFl
   }) : super(child: child);
 
   @override
-  void _updateGeometry() {
+  double updateGeometry() {
     final double minExtent = this.maxExtent;
     final double maxExtent = this.maxExtent;
     final double paintExtent = (maxExtent - _effectiveScrollOffset);
@@ -336,6 +337,6 @@ abstract class RenderSliverFloatingPinnedPersistentHeader extends RenderSliverFl
       maxPaintExtent: maxExtent,
       hasVisualOverflow: true, // Conservatively say we do have overflow to avoid complexity.
     );
-    _childPosition = 0.0;
+    return 0.0;
   }
 }

--- a/packages/flutter/lib/src/widgets/sliver_persistent_header.dart
+++ b/packages/flutter/lib/src/widgets/sliver_persistent_header.dart
@@ -31,7 +31,6 @@ class SliverPersistentHeader extends StatelessWidget {
     assert(delegate != null);
     assert(pinned != null);
     assert(floating != null);
-    assert(!pinned || !floating);
   }
 
   final SliverPersistentHeaderDelegate delegate;
@@ -42,6 +41,8 @@ class SliverPersistentHeader extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    if (floating && pinned)
+      return new _SliverFloatingPinnedPersistentHeader(delegate: delegate);
     if (pinned)
       return new _SliverPinnedPersistentHeader(delegate: delegate);
     if (floating)
@@ -224,6 +225,23 @@ class _SliverFloatingPersistentHeader extends _SliverPersistentHeaderRenderObjec
   @override
   _RenderSliverPersistentHeaderForWidgetsMixin createRenderObject(BuildContext context) {
     return new _RenderSliverFloatingPersistentHeaderForWidgets();
+  }
+}
+
+// This class exists to work around https://github.com/dart-lang/sdk/issues/15101
+abstract class _RenderSliverFloatingPinnedPersistentHeader extends RenderSliverFloatingPinnedPersistentHeader { }
+
+class _RenderSliverFloatingPinnedPersistentHeaderForWidgets extends _RenderSliverFloatingPinnedPersistentHeader with _RenderSliverPersistentHeaderForWidgetsMixin { }
+
+class _SliverFloatingPinnedPersistentHeader extends _SliverPersistentHeaderRenderObjectWidget {
+  _SliverFloatingPinnedPersistentHeader({
+    Key key,
+    @required SliverPersistentHeaderDelegate delegate,
+  }) : super(key: key, delegate: delegate);
+
+  @override
+  _RenderSliverPersistentHeaderForWidgetsMixin createRenderObject(BuildContext context) {
+    return new _RenderSliverFloatingPinnedPersistentHeaderForWidgets();
   }
 }
 


### PR DESCRIPTION
If SliverAppbar's pinned and floating parameters are true, then when scrolling upwards the appbar shrinks until only the it's bottom widget is visible. After that the bottom widget remains pinned.

Fixes https://github.com/flutter/flutter/issues/8157.
