### PR TITLE
Suppress TimePicker haptic feedback on iOS

### DIFF
--- a/packages/flutter/lib/src/material/time_picker.dart
+++ b/packages/flutter/lib/src/material/time_picker.dart
@@ -645,8 +645,19 @@ class _TimePickerDialogState extends State<_TimePickerDialog> {
   _TimePickerMode _mode = _TimePickerMode.hour;
   TimeOfDay _selectedTime;
 
+  void _vibrate() {
+    switch (Theme.of(context).platform) {
+      case TargetPlatform.android:
+      case TargetPlatform.fuchsia:
+        HapticFeedback.vibrate();
+        break;
+      case TargetPlatform.iOS:
+        break;
+    }
+  }
+
   void _handleModeChanged(_TimePickerMode mode) {
-    HapticFeedback.vibrate();
+    _vibrate();
     setState(() {
       _mode = mode;
     });


### PR DESCRIPTION
State changes are expected to trigger haptic feedback on Android, but
not on iOS time pickers.