### PR TITLE
Bump to test `0.12.20`.

### DIFF
--- a/dev/devicelab/pubspec.yaml
+++ b/dev/devicelab/pubspec.yaml
@@ -16,4 +16,4 @@ dependencies:
 
 dev_dependencies:
   # See packages/flutter_test/pubspec.yaml for why we're pinning this version.
-  test: 0.12.18+2
+  test: 0.12.20

--- a/packages/flutter_driver/pubspec.yaml
+++ b/packages/flutter_driver/pubspec.yaml
@@ -20,6 +20,6 @@ dependencies:
     sdk: flutter
 
 dev_dependencies:
-  test: 0.12.18+2
+  test: 0.12.20
   mockito: ^1.0.0
   quiver: ^0.24.0

--- a/packages/flutter_test/lib/src/stack_manipulation.dart
+++ b/packages/flutter_test/lib/src/stack_manipulation.dart
@@ -13,14 +13,17 @@
 /// with the precise file and line number that called that function.
 int reportExpectCall(StackTrace stack, StringBuffer information) {
   final RegExp line0 = new RegExp(r'^#0 +fail \(.+\)$');
-  final RegExp line1 = new RegExp(r'^#1 +expect \(.+\)$');
+  final RegExp line1 = new RegExp(r'^#1 +_expect \(.+\)$');
   final RegExp line2 = new RegExp(r'^#2 +expect \(.+\)$');
-  final RegExp line3 = new RegExp(r'^#3 +[^(]+ \((.+?):([0-9]+)(?::[0-9]+)?\)$');
+  final RegExp line3 = new RegExp(r'^#3 +expect \(.+\)$');
+  final RegExp line4 = new RegExp(r'^#4 +[^(]+ \((.+?):([0-9]+)(?::[0-9]+)?\)$');
   final List<String> stackLines = stack.toString().split('\n');
   if (line0.firstMatch(stackLines[0]) != null &&
       line1.firstMatch(stackLines[1]) != null &&
-      line2.firstMatch(stackLines[2]) != null) {
-    Match expectMatch = line3.firstMatch(stackLines[3]);
+      line2.firstMatch(stackLines[2]) != null &&
+      line3.firstMatch(stackLines[3]) != null
+      ) {
+    Match expectMatch = line4.firstMatch(stackLines[4]);
     assert(expectMatch != null);
     assert(expectMatch.groupCount == 2);
     information.writeln('This was caught by the test expectation on the following line:');

--- a/packages/flutter_test/lib/src/stack_manipulation.dart
+++ b/packages/flutter_test/lib/src/stack_manipulation.dart
@@ -28,7 +28,7 @@ int reportExpectCall(StackTrace stack, StringBuffer information) {
     assert(expectMatch.groupCount == 2);
     information.writeln('This was caught by the test expectation on the following line:');
     information.writeln('  ${expectMatch.group(1)} line ${expectMatch.group(2)}');
-    return 3;
+    return 4;
   }
   return 0;
 }

--- a/packages/flutter_test/lib/src/widget_tester.dart
+++ b/packages/flutter_test/lib/src/widget_tester.dart
@@ -119,10 +119,9 @@ Future<Null> benchmarkWidgets(WidgetTesterCallback callback) {
 /// that have not yet resolved.
 void expect(dynamic actual, dynamic matcher, {
   String reason,
-  bool verbose: false,
 }) {
   TestAsyncUtils.guardSync();
-  test_package.expect(actual, matcher, reason: reason, verbose: verbose);
+  test_package.expect(actual, matcher, reason: reason);
 }
 
 /// Assert that `actual` matches `matcher`.
@@ -136,9 +135,8 @@ void expect(dynamic actual, dynamic matcher, {
 /// that asynchronous APIs are not being called.
 void expectSync(dynamic actual, dynamic matcher, {
   String reason,
-  bool verbose: false,
 }) {
-  test_package.expect(actual, matcher, reason: reason, verbose: verbose);
+  test_package.expect(actual, matcher, reason: reason);
 }
 
 /// Class that programmatically interacts with widgets and the test environment.

--- a/packages/flutter_test/pubspec.yaml
+++ b/packages/flutter_test/pubspec.yaml
@@ -5,7 +5,7 @@ dependencies:
   # The flutter tools depend on very specific internal implementation
   # details of the 'test' package, which change between versions, so
   # here we pin it precisely to avoid version skew across our packages.
-  test: 0.12.18+2
+  test: 0.12.20
 
   flutter:
     sdk: flutter

--- a/packages/flutter_test/test/stack_manipulation_test.dart
+++ b/packages/flutter_test/test/stack_manipulation_test.dart
@@ -11,7 +11,7 @@ void main() {
       throw 'unexpectedly did not throw';
     } catch (e, stack) {
       StringBuffer information = new StringBuffer();
-      expect(reportExpectCall(stack, information), 3);
+      expect(reportExpectCall(stack, information), 4);
       List<String> lines = information.toString().split('\n');
       expect(lines[0], 'This was caught by the test expectation on the following line:');
       expect(lines[1], matches(r'^  .*stack_manipulation_test.dart line [0-9]+$'));

--- a/packages/flutter_tools/pubspec.yaml
+++ b/packages/flutter_tools/pubspec.yaml
@@ -34,7 +34,7 @@ dependencies:
   # We depend on very specific internal implementation details of the
   # 'test' package, which change between versions, so here we pin it
   # precisely.
-  test: 0.12.18+2
+  test: 0.12.20
 
   # Version from the vended Dart SDK as defined in `dependency_overrides`.
   analyzer: any

--- a/packages/flutter_tools/test/test_test.dart
+++ b/packages/flutter_tools/test/test_test.dart
@@ -82,7 +82,7 @@ Future<Null> _testFile(String testName, int wantedExitCode, String workingDirect
       expect(haveSeenStdErrMarker, isFalse);
       haveSeenStdErrMarker = true;
     }
-    expect(outputLine, matches(expectationLine), verbose: true, reason: 'Full output:\n- - - -----8<----- - - -\n${output.join("\n")}\n- - - -----8<----- - - -');
+    expect(outputLine, matches(expectationLine), reason: 'Full output:\n- - - -----8<----- - - -\n${output.join("\n")}\n- - - -----8<----- - - -');
     expectationLineNumber += 1;
     outputLineNumber += 1;
   }


### PR DESCRIPTION
Some test `0.12.20` highlights:
  * introduces `expectLater()`  that returns a `Future` that completes when the matcher has finished running
  * deprecates the `verbose` parameter to `expect()` and the `formatFailure()` (to be removed in `0.13.0`)

(For more, see the [changelog](https://pub.dartlang.org/packages/test#changelog).)

Otherwise:
  * to keep up w/ the deprecation of `verbose`, removes `widget_tester` API to pass `verbose` flag (alternatively we could suppress the warning for now)

@Hixie, @abarth, @tvolkert : could someone advise on my changes to  `widget_tester`?  Happy to opt for a suppressed warning but I'm leary of more debt! 😉 