### PR TITLE
Add support for target file in Gradle builds.

### DIFF
--- a/packages/flutter_tools/gradle/flutter.gradle
+++ b/packages/flutter_tools/gradle/flutter.gradle
@@ -141,6 +141,13 @@ class FlutterPlugin implements Plugin<Project> {
         if (target == null) {
             target = 'lib/main.dart'
         }
+        if (project.hasProperty('target')) {
+            target = project.property('target')
+        }
+        File targetFile = project.file(Paths.get(project.flutter.source, target).toString())
+        if (!targetFile.exists()) {
+            throw new GradleException("Target file $targetFile not found")
+        }
 
         if (project.tasks.findByName('flutterBuildX86Jar')) {
             project.compileDebugJavaWithJavac.dependsOn project.flutterBuildX86Jar
@@ -184,6 +191,7 @@ class FlutterTask extends DefaultTask {
     String buildMode
     String localEngine
     String localEngineSrcPath
+    @Input
     String targetPath
 
     File sourceDir

--- a/packages/flutter_tools/lib/src/android/gradle.dart
+++ b/packages/flutter_tools/lib/src/android/gradle.dart
@@ -102,7 +102,7 @@ Future<String> ensureGradle() async {
   return gradle;
 }
 
-Future<Null> buildGradleProject(BuildMode buildMode) async {
+Future<Null> buildGradleProject(BuildMode buildMode, String target) async {
   // Create android/local.properties.
   File localProperties = fs.file('android/local.properties');
   if (!localProperties.existsSync()) {
@@ -130,7 +130,7 @@ Future<Null> buildGradleProject(BuildMode buildMode) async {
     case FlutterPluginVersion.managed:
       // Fall through. Managed plugin builds the same way as plugin v2.
     case FlutterPluginVersion.v2:
-      return buildGradleProjectV2(gradle, buildModeName);
+      return buildGradleProjectV2(gradle, buildModeName, target);
   }
 }
 
@@ -153,7 +153,7 @@ Future<Null> buildGradleProjectV1(String gradle) async {
   printStatus('Built $gradleAppOutV1 (${getSizeAsMB(apkFile.lengthSync())}).');
 }
 
-Future<Null> buildGradleProjectV2(String gradle, String buildModeName) async {
+Future<Null> buildGradleProjectV2(String gradle, String buildModeName, String target) async {
   String assembleTask = "assemble${toTitleCase(buildModeName)}";
 
   // Run 'gradle assemble<BuildMode>'.
@@ -167,6 +167,9 @@ Future<Null> buildGradleProjectV2(String gradle, String buildModeName) async {
     LocalEngineArtifacts localEngineArtifacts = artifacts;
     printTrace('Using local engine: ${localEngineArtifacts.engineOutPath}');
     command.add('-PlocalEngineOut=${localEngineArtifacts.engineOutPath}');
+  }
+  if (target != null) {
+    command.add('-Ptarget=$target');
   }
   command.add(assembleTask);
   int exitcode = await runCommandAndStreamOutput(

--- a/packages/flutter_tools/lib/src/commands/build_apk.dart
+++ b/packages/flutter_tools/lib/src/commands/build_apk.dart
@@ -589,7 +589,7 @@ Future<Null> buildAndroidWithGradle(
     throwToolExit('Try re-installing or updating your Android SDK.');
   }
 
-  return buildGradleProject(buildMode);
+  return buildGradleProject(buildMode, target);
 }
 
 Future<Null> buildApk(


### PR DESCRIPTION
If a target file is specified on the flutter tools command line, pass it
through to Gradle.

It is still possible to statically specify a target file in the flutter
section of build.gradle, but it is now possible to specify it on the
command line as well. The command line option takes precedence.

Fixes #8175.