### PR TITLE
Remove superfluous (and wrong) target file check

### DIFF
--- a/packages/flutter_tools/gradle/flutter.gradle
+++ b/packages/flutter_tools/gradle/flutter.gradle
@@ -144,10 +144,6 @@ class FlutterPlugin implements Plugin<Project> {
         if (project.hasProperty('target')) {
             target = project.property('target')
         }
-        File targetFile = project.file(Paths.get(project.flutter.source, target).toString())
-        if (!targetFile.exists()) {
-            throw new GradleException("Target file $targetFile not found")
-        }
 
         if (project.tasks.findByName('flutterBuildX86Jar')) {
             project.compileDebugJavaWithJavac.dependsOn project.flutterBuildX86Jar


### PR DESCRIPTION
The target file is already checked by flutter tools (and again when Gradle recursively calls flutter tools), so there's really no need to check it again. Especially not when the check is wrong, and doesn't take absolute paths into account.