### PR TITLE
Don't delete old Dart SDK if it is in use on Windows

### DIFF
--- a/bin/internal/update_dart_sdk.ps1
+++ b/bin/internal/update_dart_sdk.ps1
@@ -14,11 +14,14 @@
 $ErrorActionPreference = "Stop"
 
 $progName = Split-Path -parent $MyInvocation.MyCommand.Definition
-$flutterRoot = (Get-Item $progName ).parent.parent.FullName
+$flutterRoot = (Get-Item $progName).parent.parent.FullName
 
-$dartSdkPath = "$flutterRoot\bin\cache\dart-sdk"
-$dartSdkStampPath = "$flutterRoot\bin\cache\dart-sdk.stamp"
+$cachePath = "$flutterRoot\bin\cache"
+$dartSdkPath = "$cachePath\dart-sdk"
+$dartSdkStampPath = "$cachePath\dart-sdk.stamp"
 $dartSdkVersion = (Get-Content "$flutterRoot\bin\internal\dart-sdk.version")
+
+$oldDartSdkPrefix = "dart-sdk.old"
 
 if ((Test-Path $dartSdkStampPath) -and ($dartSdkVersion -eq (Get-Content $dartSdkStampPath))) {
     return
@@ -29,12 +32,20 @@ $dartZipName = "dartsdk-windows-x64-release.zip"
 $dartChannel = if ($dartSdkVersion.Contains("-dev.")) {"dev"} else {"stable"}
 $dartSdkUrl = "https://storage.googleapis.com/dart-archive/channels/$dartChannel/raw/$dartSdkVersion/sdk/$dartZipName"
 
-if (Test-Path $dartSdkPath) { Remove-Item $dartSdkPath -Recurse }
+if (Test-Path $dartSdkPath) {
+    # Move old SDK to a new location instead of deleting it in case it is still in use (e.g. by IntelliJ).
+    $oldDartSdkSuffix = 1
+    while (Test-Path "$cachePath\$oldDartSdkPrefix$oldDartSdkSuffix") { $oldDartSdkSuffix++ }
+    Rename-Item $dartSdkPath "$oldDartSdkPrefix$oldDartSdkSuffix"
+}
 New-Item $dartSdkPath -force -type directory | Out-Null
-$dartSdkZip = "$flutterRoot\bin\cache\dart-sdk.zip"
+$dartSdkZip = "$cachePath\dart-sdk.zip"
 
 Start-BitsTransfer -Source $dartSdkUrl -Destination $dartSdkZip
 Add-Type -assembly "system.io.compression.filesystem"
-[io.compression.zipfile]::ExtractToDirectory($dartSdkZip, "$flutterRoot\bin\cache")
+[io.compression.zipfile]::ExtractToDirectory($dartSdkZip, $cachePath)
 Remove-Item $dartSdkZip
 $dartSdkVersion | Out-File $dartSdkStampPath -Encoding ASCII
+
+# Try to delete all old SDKs.
+Get-ChildItem -Path $cachePath | Where {$_.BaseName.StartsWith($oldDartSdkPrefix)} | Remove-Item -Recurse -ErrorAction SilentlyContinue


### PR DESCRIPTION
If the Dart SDK is still in use, everything blows up when you try to delete it.

fixes https://github.com/flutter/flutter/issues/7762