### PR TITLE
Relax Android Studio version check.

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_studio_validator.dart
+++ b/packages/flutter_tools/lib/src/android/android_studio_validator.dart
@@ -100,22 +100,23 @@ class ConfiguredGradleValidator extends DoctorValidator {
       gradleExecutable = fs.path.join(
           cfgGradleDir, 'bin', platform.isWindows ? 'gradle.bat' : 'gradle');
     }
-    String version;
+    String versionString;
     if (processManager.canRun(gradleExecutable)) {
       type = ValidationType.partial;
       ProcessResult result =
           processManager.runSync(<String>[gradleExecutable, '--version']);
       if (result.exitCode == 0) {
-        version = result.stdout
+        versionString = result.stdout
             .toString()
             .split('\n')
             .firstWhere((String s) => s.startsWith('Gradle '))
             .substring('Gradle '.length);
-        if (new Version.parse(version) >= minGradleVersion) {
+        Version version = new Version.parse(versionString) ?? Version.unknown;
+        if (version >= minGradleVersion) {
           type = ValidationType.installed;
         } else {
           messages.add(new ValidationMessage.error(
-              'Gradle version $minGradleVersion required. Found version $version.'));
+              'Gradle version $minGradleVersion required. Found version $versionString.'));
         }
       } else {
         messages
@@ -128,6 +129,6 @@ class ConfiguredGradleValidator extends DoctorValidator {
 
     messages.add(new ValidationMessage(
         'Consider removing the gradle-dir setting to use Gradle from Android Studio.'));
-    return new ValidationResult(type, messages, statusInfo: version);
+    return new ValidationResult(type, messages, statusInfo: versionString);
   }
 }

--- a/packages/flutter_tools/lib/src/base/version.dart
+++ b/packages/flutter_tools/lib/src/base/version.dart
@@ -45,7 +45,7 @@ class Version implements Comparable<Version> {
   factory Version.parse(String text) {
     Match match = versionPattern.firstMatch(text);
     if (match == null) {
-      throw new FormatException('Could not parse "$text".');
+      return null;
     }
 
     try {
@@ -54,7 +54,7 @@ class Version implements Comparable<Version> {
       int patch = int.parse(match[5] ?? '0');
       return new Version._(major, minor, patch, text);
     } on FormatException {
-      throw new FormatException('Could not parse "$text".');
+      return null;
     }
   }
 

--- a/packages/flutter_tools/test/utils_test.dart
+++ b/packages/flutter_tools/test/utils_test.dart
@@ -111,6 +111,8 @@ baz=qux
 
       Version v5 = new Version(1, 2, 0, text: 'foo');
       expect(v5, equals(v2));
+
+      expect(new Version.parse('Preview2.2'), isNull);
     });
   });
 }


### PR DESCRIPTION
It's not just $HOME/.AndroidStudio2.2, it might also be
.AndroidStudioPreview2.3, or .AndroidStudioFooBar1.7, or whatever.

Made the Version parser less throw-happy, and relaxed the directory name
checks to allow for the above.

Fixes #8353.