### PR TITLE
Read package ID and activity name from .apk for Gradle-based builds.

### DIFF
--- a/packages/flutter_tools/lib/src/application_package.dart
+++ b/packages/flutter_tools/lib/src/application_package.dart
@@ -82,8 +82,9 @@ class AndroidApk extends ApplicationPackage {
     String apkPath;
 
     if (isProjectUsingGradle()) {
-      manifestPath = gradleManifestPath;
-      apkPath = gradleAppOut;
+      // Grab information from the .apk. The gradle build script might alter the
+      // application Id, so we need to look at what was actually built.
+      return new AndroidApk.fromApk(gradleAppOut);
     } else {
       manifestPath = fs.path.join('android', 'AndroidManifest.xml');
       apkPath = fs.path.join(getAndroidBuildDirectory(), 'app.apk');


### PR DESCRIPTION
The gradle build scripts can be configured to output different
application IDs for different build types, so we need to examine the
built .apk to figure out the name of the package and activity.

Fixes #8327