### PR TITLE
Revert "Read package ID and activity name from .apk for Gradle-based builds."

### DIFF
--- a/packages/flutter_tools/lib/src/application_package.dart
+++ b/packages/flutter_tools/lib/src/application_package.dart
@@ -82,9 +82,8 @@ class AndroidApk extends ApplicationPackage {
     String apkPath;
 
     if (isProjectUsingGradle()) {
-      // Grab information from the .apk. The gradle build script might alter the
-      // application Id, so we need to look at what was actually built.
-      return new AndroidApk.fromApk(gradleAppOut);
+      manifestPath = gradleManifestPath;
+      apkPath = gradleAppOut;
     } else {
       manifestPath = fs.path.join('android', 'AndroidManifest.xml');
       apkPath = fs.path.join(getAndroidBuildDirectory(), 'app.apk');


### PR DESCRIPTION
This patch breaks running an app for the first time.

Reverts flutter/flutter#8393
Fixes #8399