### PR TITLE
Ensure packages up-to-date on iOS build

### DIFF
--- a/packages/flutter_tools/lib/src/commands/build_ios.dart
+++ b/packages/flutter_tools/lib/src/commands/build_ios.dart
@@ -16,6 +16,7 @@ import 'build.dart';
 class BuildIOSCommand extends BuildSubCommand {
   BuildIOSCommand() {
     usesTargetOption();
+    usesPubOption();
     argParser.addFlag('debug',
       negatable: false,
       help: 'Build a debug version of your app (default mode for iOS simulator builds).');


### PR DESCRIPTION
iOS builds rely on package dependencies and associated build artifacts
(pubspec.lock, .packages files) to be up-to-date.