### PR TITLE
Adds un/selected text styles to the TabBar widget

### DIFF
--- a/packages/flutter/lib/src/material/tabs.dart
+++ b/packages/flutter/lib/src/material/tabs.dart
@@ -124,7 +124,7 @@ class _TabStyle extends AnimatedWidget {
   @override
   Widget build(BuildContext context) {
     final ThemeData themeData = Theme.of(context);
-    final TextStyle defaultStyle = labelStyle ?? unselectedLabelStyle ?? themeData.primaryTextTheme.body2;
+    final TextStyle defaultStyle = labelStyle ?? themeData.primaryTextTheme.body2;
     final TextStyle defaultUnselectedStyle = unselectedLabelStyle ?? labelStyle ?? themeData.primaryTextTheme.body2;
     final TextStyle textStyle = selected
       ? defaultStyle
@@ -391,7 +391,9 @@ class TabBar extends StatefulWidget implements AppBarBottomWidget {
   /// [labelColor] rendered at 70% opacity.
   final Color unselectedLabelColor;
 
-  /// The text style of the selected tab labels
+  /// The text style of the selected tab labels. If [unselectedLabelStyle] is
+  /// null then this text style will be used for both selected and unselected
+  /// label styles.
   ///
   /// If this property is null then the text style of the theme's body2
   /// definition is used.
@@ -399,8 +401,8 @@ class TabBar extends StatefulWidget implements AppBarBottomWidget {
 
   /// The text style of the unselected tab labels
   ///
-  /// If this property is null then the text style of the theme's body2
-  /// definition is used.
+  /// If this property is null then the [labelStyle] value is used. If [labelStyle]
+  /// is null then the text style of the theme's body2 definition is used.
   final TextStyle unselectedLabelStyle;
 
   @override

--- a/packages/flutter/lib/src/material/tabs.dart
+++ b/packages/flutter/lib/src/material/tabs.dart
@@ -109,9 +109,13 @@ class _TabStyle extends AnimatedWidget {
     this.selected,
     this.labelColor,
     this.unselectedLabelColor,
+    this.labelStyle,
+    this.unselectedLabelStyle,
     @required this.child,
   }) : super(key: key, animation: animation);
 
+  final TextStyle labelStyle;
+  final TextStyle unselectedLabelStyle;
   final bool selected;
   final Color labelColor;
   final Color unselectedLabelColor;
@@ -120,7 +124,11 @@ class _TabStyle extends AnimatedWidget {
   @override
   Widget build(BuildContext context) {
     final ThemeData themeData = Theme.of(context);
-    final TextStyle textStyle = themeData.primaryTextTheme.body2;
+    final TextStyle defaultStyle = labelStyle ?? unselectedLabelStyle ?? themeData.primaryTextTheme.body2;
+    final TextStyle defaultUnselectedStyle = unselectedLabelStyle ?? labelStyle ?? themeData.primaryTextTheme.body2;
+    final TextStyle textStyle = selected
+      ? defaultStyle
+      : defaultUnselectedStyle;
     final Color selectedColor = labelColor ?? themeData.primaryTextTheme.body2.color;
     final Color unselectedColor = unselectedLabelColor ?? selectedColor.withAlpha(0xB2); // 70% alpha
     final Color color = selected
@@ -340,7 +348,9 @@ class TabBar extends StatefulWidget implements AppBarBottomWidget {
     this.isScrollable: false,
     this.indicatorColor,
     this.labelColor,
+    this.labelStyle,
     this.unselectedLabelColor,
+    this.unselectedLabelStyle,
   }) : super(key: key) {
     assert(tabs != null && tabs.length > 1);
     assert(isScrollable != null);
@@ -380,6 +390,18 @@ class TabBar extends StatefulWidget implements AppBarBottomWidget {
   /// If this property is null, Unselected tab labels are rendered with the
   /// [labelColor] rendered at 70% opacity.
   final Color unselectedLabelColor;
+
+  /// The text style of the selected tab labels
+  ///
+  /// If this property is null then the text style of the theme's body2
+  /// definition is used.
+  final TextStyle labelStyle;
+
+  /// The text style of the unselected tab labels
+  ///
+  /// If this property is null then the text style of the theme's body2
+  /// definition is used.
+  final TextStyle unselectedLabelStyle;
 
   @override
   double get bottomHeight {
@@ -542,6 +564,8 @@ class _TabBarState extends State<TabBar> {
           selected: true,
           labelColor: config.labelColor,
           unselectedLabelColor: config.unselectedLabelColor,
+          labelStyle: config.labelStyle,
+          unselectedLabelStyle: config.unselectedLabelStyle,
           child: wrappedTabs[_currentIndex],
         );
         wrappedTabs[previousIndex] = new _TabStyle(
@@ -549,6 +573,8 @@ class _TabBarState extends State<TabBar> {
           selected: false,
           labelColor: config.labelColor,
           unselectedLabelColor: config.unselectedLabelColor,
+          labelStyle: config.labelStyle,
+          unselectedLabelStyle: config.unselectedLabelStyle,
           child: wrappedTabs[previousIndex],
         );
       } else {
@@ -557,6 +583,8 @@ class _TabBarState extends State<TabBar> {
           selected: true,
           labelColor: config.labelColor,
           unselectedLabelColor: config.unselectedLabelColor,
+          labelStyle: config.labelStyle,
+          unselectedLabelStyle: config.unselectedLabelStyle,
           child: wrappedTabs[_currentIndex],
         );
       }
@@ -583,6 +611,8 @@ class _TabBarState extends State<TabBar> {
           selected: false,
           labelColor: config.labelColor,
           unselectedLabelColor: config.unselectedLabelColor,
+          labelStyle: config.labelStyle,
+          unselectedLabelStyle: config.unselectedLabelStyle,
           child: new _TabLabelBar(
             onPerformLayout: _saveTabOffsets,
             children:  wrappedTabs,


### PR DESCRIPTION
Add's the ability to style the selected/unselected text labels of a TabBar. This allows a developer to adjust font weight, size, etc for the labels generally and also depending on the selected state of the tab item. 

The priority of the styles is as such:

```
Unselected ==  tabbar.unselected ?? tabbar.selected ?? theme.body2
Selected == tabbar.selected ?? tabbar.unselected ?? theme.body2
```

Currently, the priorities are as such that if a user defines either style, that will be used as the default before the theme value.

There is one potential issue with scrolling tabs where the size of the tab widget itself could need to expand/contract due to the delta in the styles. This will affect the current scroll offset but I think that should be accepted as the reality of trying to do something like that. If it is a big issue, I'd suggest simplifying the implementation to a single style only.