### PR TITLE
Export DecorationPosition, use it in ListItem

### DIFF
--- a/packages/flutter/lib/src/material/list_item.dart
+++ b/packages/flutter/lib/src/material/list_item.dart
@@ -157,6 +157,7 @@ class ListItem extends StatelessWidget {
     Widget item = iterator.current;
     while (iterator.moveNext()) {
       yield new DecoratedBox(
+        position: DecorationPosition.foreground,
         decoration: new BoxDecoration(
           border: new Border(
             bottom: new BorderSide(color: dividerColor),

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -20,6 +20,7 @@ export 'package:flutter/rendering.dart' show
   CrossAxisAlignment,
   CustomClipper,
   CustomPainter,
+  DecorationPosition,
   FlexFit,
   FlowDelegate,
   FlowPaintingContext,


### PR DESCRIPTION
Borders added with ListItem.divideItems() wouldn't show up if the list items were completely opaque because DecoratedBox draws in the "background" by default.
