### PR TITLE
Mark scroll views primary where necessary

### DIFF
--- a/examples/flutter_gallery/lib/demo/cards_demo.dart
+++ b/examples/flutter_gallery/lib/demo/cards_demo.dart
@@ -135,6 +135,7 @@ class CardsDemo extends StatelessWidget {
         title: new Text('Travel stream')
       ),
       body: new ListView(
+        primary: true,
         itemExtent: TravelDestinationItem.height,
         padding: const EdgeInsets.only(top: 8.0, left: 8.0, right: 8.0),
         children: destinations.map((TravelDestination destination) {

--- a/examples/flutter_gallery/lib/demo/chip_demo.dart
+++ b/examples/flutter_gallery/lib/demo/chip_demo.dart
@@ -42,6 +42,7 @@ class _ChipDemoState extends State<ChipDemo> {
     return new Scaffold(
       appBar: new AppBar(title: new Text('Chips')),
       body: new ListView(
+        primary: true,
         children: chips.map((Widget widget) {
           return new Container(
             height: 100.0,

--- a/examples/flutter_gallery/lib/demo/colors_demo.dart
+++ b/examples/flutter_gallery/lib/demo/colors_demo.dart
@@ -99,6 +99,7 @@ class ColorSwatchTabView extends StatelessWidget {
     }
 
     return new ListView(
+      primary: true,
       itemExtent: kColorItemHeight,
       children: colorItems,
     );

--- a/examples/flutter_gallery/lib/demo/contacts_demo.dart
+++ b/examples/flutter_gallery/lib/demo/contacts_demo.dart
@@ -106,6 +106,7 @@ class ContactsDemoState extends State<ContactsDemo> {
       child: new Scaffold(
         key: _scaffoldKey,
         body: new CustomScrollView(
+          primary: true,
           slivers: <Widget>[
             new SliverAppBar(
               expandedHeight: _appBarHeight,

--- a/examples/flutter_gallery/lib/demo/date_and_time_picker_demo.dart
+++ b/examples/flutter_gallery/lib/demo/date_and_time_picker_demo.dart
@@ -130,6 +130,7 @@ class _DateAndTimePickerDemoState extends State<DateAndTimePickerDemo> {
       appBar: new AppBar(title: new Text('Date and time pickers')),
       body: new DropdownButtonHideUnderline(
         child: new ListView(
+          primary: true,
           padding: const EdgeInsets.all(16.0),
           children: <Widget>[
             new TextField(

--- a/examples/flutter_gallery/lib/demo/dialog_demo.dart
+++ b/examples/flutter_gallery/lib/demo/dialog_demo.dart
@@ -90,6 +90,7 @@ class DialogDemoState extends State<DialogDemo> {
         title: new Text('Dialogs')
       ),
       body: new ListView(
+        primary: true,
         padding: const EdgeInsets.symmetric(vertical: 24.0, horizontal: 72.0),
         children: <Widget>[
           new RaisedButton(

--- a/examples/flutter_gallery/lib/demo/expansion_panels_demo.dart
+++ b/examples/flutter_gallery/lib/demo/expansion_panels_demo.dart
@@ -335,6 +335,7 @@ class _ExpansionPanelsDemoState extends State<ExpasionPanelsDemo> {
     return new Scaffold(
       appBar: new AppBar(title: new Text('Expansion panels')),
       body: new SingleChildScrollView(
+        primary: true,
         child: new Container(
           margin: const EdgeInsets.all(24.0),
           child: new ExpansionPanelList(

--- a/examples/flutter_gallery/lib/demo/full_screen_dialog_demo.dart
+++ b/examples/flutter_gallery/lib/demo/full_screen_dialog_demo.dart
@@ -158,6 +158,7 @@ class FullScreenDialogDemoState extends State<FullScreenDialogDemo> {
         ]
       ),
       body: new ListView(
+        primary: true,
         padding: const EdgeInsets.all(16.0),
         children: <Widget>[
           new Container(

--- a/examples/flutter_gallery/lib/demo/grid_list_demo.dart
+++ b/examples/flutter_gallery/lib/demo/grid_list_demo.dart
@@ -340,6 +340,7 @@ class GridListDemoState extends State<GridListDemo> {
         children: <Widget>[
           new Expanded(
             child: new GridView.count(
+              primary: true,
               crossAxisCount: (orientation == Orientation.portrait) ? 2 : 3,
               mainAxisSpacing: 4.0,
               crossAxisSpacing: 4.0,

--- a/examples/flutter_gallery/lib/demo/leave_behind_demo.dart
+++ b/examples/flutter_gallery/lib/demo/leave_behind_demo.dart
@@ -162,6 +162,7 @@ class LeaveBehindDemoState extends State<LeaveBehindDemo> {
         ]
       ),
       body: new ListView(
+        primary: true,
         children: leaveBehindItems.map(buildItem).toList()
       )
     );

--- a/examples/flutter_gallery/lib/demo/list_demo.dart
+++ b/examples/flutter_gallery/lib/demo/list_demo.dart
@@ -204,6 +204,7 @@ class _ListDemoState extends State<ListDemo> {
       ),
       body: new Scrollbar(
         child: new ListView(
+          primary: true,
           padding: new EdgeInsets.symmetric(vertical: _dense ? 4.0 : 8.0),
           children: listItems.toList(),
         ),

--- a/examples/flutter_gallery/lib/demo/menu_demo.dart
+++ b/examples/flutter_gallery/lib/demo/menu_demo.dart
@@ -84,6 +84,7 @@ class MenuDemoState extends State<MenuDemo> {
         ]
       ),
       body: new ListView(
+        primary: true,
         padding: const EdgeInsets.symmetric(vertical: 8.0),
         children: <Widget>[
           // Pressing the PopupMenuButton on the right of this item shows

--- a/examples/flutter_gallery/lib/demo/overscroll_demo.dart
+++ b/examples/flutter_gallery/lib/demo/overscroll_demo.dart
@@ -60,6 +60,7 @@ class OverscrollDemoState extends State<OverscrollDemo> {
         key: _refreshIndicatorKey,
         onRefresh: _handleRefresh,
         child: new ListView.builder(
+          primary: true,
           padding: const EdgeInsets.all(8.0),
           itemCount: _items.length,
           itemBuilder: (BuildContext context, int index) {

--- a/examples/flutter_gallery/lib/demo/pesto_demo.dart
+++ b/examples/flutter_gallery/lib/demo/pesto_demo.dart
@@ -90,6 +90,7 @@ class _RecipeGridPageState extends State<RecipeGridPage> {
           },
         ),
         body: new CustomScrollView(
+          primary: true,
           slivers: <Widget>[
             _buildAppBar(context, statusBarHeight),
             _buildBody(context, statusBarHeight),
@@ -330,6 +331,7 @@ class _RecipePageState extends State<RecipePage> {
             ),
           ),
           new CustomScrollView(
+            primary: true,
             slivers: <Widget>[
               new SliverAppBar(
                 expandedHeight: appBarHeight - _kFabHalfSize,

--- a/examples/flutter_gallery/lib/demo/progress_indicator_demo.dart
+++ b/examples/flutter_gallery/lib/demo/progress_indicator_demo.dart
@@ -102,6 +102,7 @@ class _ProgressIndicatorDemoState extends State<ProgressIndicatorDemo> with Sing
       appBar: new AppBar(title: new Text('Progress indicators')),
       body: new Center(
         child: new SingleChildScrollView(
+          primary: true,
           child: new DefaultTextStyle(
             style: Theme.of(context).textTheme.title,
             child: new GestureDetector(

--- a/examples/flutter_gallery/lib/demo/shrine/shrine_home.dart
+++ b/examples/flutter_gallery/lib/demo/shrine/shrine_home.dart
@@ -375,6 +375,7 @@ class _ShrineHomeState extends State<ShrineHome> {
       products: _products,
       shoppingCart: _shoppingCart,
       body: new CustomScrollView(
+        primary: true,
         slivers: <Widget>[
           new SliverToBoxAdapter(
             child: new FeatureItem(product: featured),

--- a/examples/flutter_gallery/lib/demo/shrine/shrine_order.dart
+++ b/examples/flutter_gallery/lib/demo/shrine/shrine_order.dart
@@ -178,6 +178,7 @@ class _OrderPageState extends State<OrderPage> {
         ),
       ),
       body: new CustomScrollView(
+        primary: true,
         slivers: <Widget>[
           new SliverList(
             delegate: new SliverChildListDelegate(<Widget>[

--- a/examples/flutter_gallery/lib/demo/snack_bar_demo.dart
+++ b/examples/flutter_gallery/lib/demo/snack_bar_demo.dart
@@ -30,6 +30,7 @@ class _SnackBarDemoState extends State<SnackBarDemo> {
 
   Widget buildBody(BuildContext context) {
     return new ListView(
+      primary: true,
       padding: const EdgeInsets.all(24.0),
       children: <Widget>[
         new Text(_text1),

--- a/examples/flutter_gallery/lib/demo/tabs_demo.dart
+++ b/examples/flutter_gallery/lib/demo/tabs_demo.dart
@@ -128,6 +128,7 @@ class TabsDemo extends StatelessWidget {
         body: new TabBarView(
           children: _allPages.keys.map((_Page page) {
             return new ListView(
+              primary: true,
               padding: const EdgeInsets.symmetric(vertical: 8.0, horizontal: 16.0),
               itemExtent: _CardDataItem.height,
               children: _allPages[page].map((_CardData data) {

--- a/examples/flutter_gallery/lib/demo/text_field_demo.dart
+++ b/examples/flutter_gallery/lib/demo/text_field_demo.dart
@@ -111,6 +111,7 @@ class TextFieldDemoState extends State<TextFieldDemo> {
         autovalidate: _autovalidate,
         onWillPop: _warnUserAboutInvalidData,
         child: new ListView(
+          primary: true,
           padding: const EdgeInsets.symmetric(horizontal: 16.0),
           children: <Widget>[
             new TextField(

--- a/examples/flutter_gallery/lib/demo/tooltip_demo.dart
+++ b/examples/flutter_gallery/lib/demo/tooltip_demo.dart
@@ -23,6 +23,7 @@ class TooltipDemo extends StatelessWidget {
       body: new Builder(
         builder: (BuildContext context) {
           return new ListView(
+            primary: true,
             children: <Widget>[
               new Text(_introText, style: theme.textTheme.subhead),
               new Row(

--- a/examples/flutter_gallery/lib/demo/typography_demo.dart
+++ b/examples/flutter_gallery/lib/demo/typography_demo.dart
@@ -66,7 +66,7 @@ class TypographyDemo extends StatelessWidget {
 
     return new Scaffold(
       appBar: new AppBar(title: new Text('Typography')),
-      body: new ListView(children: styleItems)
+      body: new ListView(primary: true, children: styleItems)
     );
   }
 }

--- a/examples/flutter_gallery/lib/gallery/home.dart
+++ b/examples/flutter_gallery/lib/gallery/home.dart
@@ -164,6 +164,7 @@ class GalleryHomeState extends State<GalleryHome> with SingleTickerProviderState
         onSendFeedback: config.onSendFeedback,
       ),
       body: new CustomScrollView(
+        primary: true,
         slivers: <Widget>[
           new SliverAppBar(
             pinned: true,


### PR DESCRIPTION
Ensure that scrollable views are wired up to the primary scroll controller. Among other things, this ensures that status bar taps on iOS automatically scroll the correct view to the top.