### PR TITLE
[devFS] Use URI to represent paths on device

### DIFF
--- a/packages/flutter_tools/lib/src/devfs.dart
+++ b/packages/flutter_tools/lib/src/devfs.dart
@@ -536,7 +536,7 @@ class DevFS {
 
     for (String packageName in packageMap.map.keys) {
       Uri packageUri = packageMap.map[packageName];
-      String packagePath = fs.path.fromUri(packageUri);
+      String packagePath = packageUri.toFilePath();
       Directory packageDirectory = fs.directory(packageUri);
       Uri directoryUriOnDevice = fs.path.toUri(fs.path.join('packages', packageName) + fs.path.separator);
       bool packageExists;

--- a/packages/flutter_tools/lib/src/devfs.dart
+++ b/packages/flutter_tools/lib/src/devfs.dart
@@ -375,7 +375,7 @@ class DevFS {
 
     // Handle deletions.
     printTrace('Scanning for deleted files');
-    String assetBuildDirPrefix = fs.path.toUri(getAssetBuildDirectory()).path + '/';
+    String assetBuildDirPrefix = _asUriPath(getAssetBuildDirectory());
     final List<Uri> toRemove = new List<Uri>();
     _entries.forEach((Uri deviceUri, DevFSContent content) {
       if (!content._exists) {
@@ -464,9 +464,9 @@ class DevFS {
 
   bool _shouldIgnore(Uri deviceUri) {
     List<String> ignoredUriPrefixes = <String>['android/',
-                                            fs.path.toUri(getBuildDirectory()).path + '/',
-                                            'ios/',
-                                            '.pub/'];
+                                               _asUriPath(getBuildDirectory()),
+                                               'ios/',
+                                               '.pub/'];
     for (String ignoredUriPrefix in ignoredUriPrefixes) {
       if (deviceUri.path.startsWith(ignoredUriPrefix))
         return true;
@@ -569,3 +569,5 @@ class DevFS {
     }
   }
 }
+/// Converts a platform-specific file path to a platform-independent Uri path.
+String _asUriPath(String filePath) => fs.path.toUri(filePath).path + '/';

--- a/packages/flutter_tools/lib/src/devfs.dart
+++ b/packages/flutter_tools/lib/src/devfs.dart
@@ -199,7 +199,8 @@ class ServiceProtocolDevFSOperations implements DevFSOperations {
         '_writeDevFSFile',
         params: <String, dynamic> {
           'fsName': fsName,
-          'path': deviceUri.path, // TODO(goderbauer): transfer full Uri when remote end supports it
+          // TODO(goderbauer): transfer real Uri (instead of file path) when remote end supports it
+          'path': deviceUri.toFilePath(windows: false),
           'fileContents': fileContents
         },
       );
@@ -267,9 +268,9 @@ class _DevFSHttpWriter {
       HttpClientRequest request = await _client.putUrl(httpAddress);
       request.headers.removeAll(HttpHeaders.ACCEPT_ENCODING);
       request.headers.add('dev_fs_name', fsName);
-      // TODO(goderbauer): transfer full Uri when remote end supports it
+      // TODO(goderbauer): transfer real Uri (instead of file path) when remote end supports it
       request.headers.add('dev_fs_path_b64',
-                          BASE64.encode(UTF8.encode(deviceUri.path)));
+                          BASE64.encode(UTF8.encode(deviceUri.toFilePath(windows: false))));
       Stream<List<int>> contents = content.contentsAsCompressedStream();
       await request.addStream(contents);
       HttpClientResponse response = await request.close();

--- a/packages/flutter_tools/lib/src/devfs.dart
+++ b/packages/flutter_tools/lib/src/devfs.dart
@@ -160,8 +160,8 @@ class DevFSStringContent extends DevFSByteContent {
 abstract class DevFSOperations {
   Future<Uri> create(String fsName);
   Future<dynamic> destroy(String fsName);
-  Future<dynamic> writeFile(String fsName, String devicePath, DevFSContent content);
-  Future<dynamic> deleteFile(String fsName, String devicePath);
+  Future<dynamic> writeFile(String fsName, Uri devicePath, DevFSContent content);
+  Future<dynamic> deleteFile(String fsName, Uri devicePath);
 }
 
 /// An implementation of [DevFSOperations] that speaks to the
@@ -186,7 +186,7 @@ class ServiceProtocolDevFSOperations implements DevFSOperations {
   }
 
   @override
-  Future<dynamic> writeFile(String fsName, String devicePath, DevFSContent content) async {
+  Future<dynamic> writeFile(String fsName, Uri deviceUri, DevFSContent content) async {
     List<int> bytes;
     try {
       bytes = await content.contentsAsBytes();
@@ -199,17 +199,17 @@ class ServiceProtocolDevFSOperations implements DevFSOperations {
         '_writeDevFSFile',
         params: <String, dynamic> {
           'fsName': fsName,
-          'path': devicePath,
+          'path': deviceUri.path,
           'fileContents': fileContents
         },
       );
     } catch (error) {
-      printTrace('DevFS: Failed to write $devicePath: $error');
+      printTrace('DevFS: Failed to write $deviceUri: $error');
     }
   }
 
   @override
-  Future<dynamic> deleteFile(String fsName, String devicePath) async {
+  Future<dynamic> deleteFile(String fsName, Uri deviceUri) async {
     // TODO(johnmccutchan): Add file deletion to the devFS protocol.
   }
 }
@@ -225,18 +225,18 @@ class _DevFSHttpWriter {
   static const int kMaxRetries = 3;
 
   int _inFlight = 0;
-  Map<String, DevFSContent> _outstanding;
+  Map<Uri, DevFSContent> _outstanding;
   Completer<Null> _completer;
   HttpClient _client;
   int _done;
   int _max;
 
-  Future<Null> write(Map<String, DevFSContent> entries,
+  Future<Null> write(Map<Uri, DevFSContent> entries,
                      {DevFSProgressReporter progressReporter}) async {
     _client = new HttpClient();
     _client.maxConnectionsPerHost = kMaxInFlight;
     _completer = new Completer<Null>();
-    _outstanding = new Map<String, DevFSContent>.from(entries);
+    _outstanding = new Map<Uri, DevFSContent>.from(entries);
     _done = 0;
     _max = _outstanding.length;
     _scheduleWrites(progressReporter);
@@ -250,7 +250,7 @@ class _DevFSHttpWriter {
         // Finished.
         break;
       }
-      String devicePath = _outstanding.keys.first;
+      Uri devicePath = _outstanding.keys.first;
       DevFSContent content = _outstanding.remove(devicePath);
       _scheduleWrite(devicePath, content, progressReporter);
       _inFlight++;
@@ -258,7 +258,7 @@ class _DevFSHttpWriter {
   }
 
   Future<Null> _scheduleWrite(
-    String devicePath,
+    Uri devicePath,
     DevFSContent content,
     DevFSProgressReporter progressReporter, [
     int retry = 0,
@@ -268,7 +268,7 @@ class _DevFSHttpWriter {
       request.headers.removeAll(HttpHeaders.ACCEPT_ENCODING);
       request.headers.add('dev_fs_name', fsName);
       request.headers.add('dev_fs_path_b64',
-                          BASE64.encode(UTF8.encode(devicePath)));
+                          BASE64.encode(UTF8.encode(devicePath.path)));
       Stream<List<int>> contents = content.contentsAsCompressedStream();
       await request.addStream(contents);
       HttpClientResponse response = await request.close();
@@ -324,7 +324,7 @@ class DevFS {
   final String fsName;
   final Directory rootDirectory;
   String _packagesFilePath;
-  final Map<String, DevFSContent> _entries = <String, DevFSContent>{};
+  final Map<Uri, DevFSContent> _entries = <Uri, DevFSContent>{};
   final Set<String> assetPathsToEvict = new Set<String>();
 
   final List<Future<Map<String, dynamic>>> _pendingOperations =
@@ -373,17 +373,17 @@ class DevFS {
 
     // Handle deletions.
     printTrace('Scanning for deleted files');
-    String assetBuildDirPrefix = getAssetBuildDirectory() + fs.path.separator;
-    final List<String> toRemove = new List<String>();
-    _entries.forEach((String devicePath, DevFSContent content) {
+    String assetBuildDirPrefix = fs.path.toUri(getAssetBuildDirectory()).path + '/';
+    final List<Uri> toRemove = new List<Uri>();
+    _entries.forEach((Uri deviceUri, DevFSContent content) {
       if (!content._exists) {
         Future<Map<String, dynamic>> operation =
-            _operations.deleteFile(fsName, devicePath);
+            _operations.deleteFile(fsName, deviceUri);
         if (operation != null)
           _pendingOperations.add(operation);
-        toRemove.add(devicePath);
-        if (devicePath.startsWith(assetBuildDirPrefix)) {
-          String archivePath = devicePath.substring(assetBuildDirPrefix.length);
+        toRemove.add(deviceUri);
+        if (deviceUri.path.startsWith(assetBuildDirPrefix)) {
+          String archivePath = deviceUri.path.substring(assetBuildDirPrefix.length);
           assetPathsToEvict.add(archivePath);
         }
       }
@@ -397,13 +397,13 @@ class DevFS {
 
     // Update modified files
     int numBytes = 0;
-    Map<String, DevFSContent> dirtyEntries = <String, DevFSContent>{};
-    _entries.forEach((String devicePath, DevFSContent content) {
+    Map<Uri, DevFSContent> dirtyEntries = <Uri, DevFSContent>{};
+    _entries.forEach((Uri deviceUri, DevFSContent content) {
       String archivePath;
-      if (devicePath.startsWith(assetBuildDirPrefix))
-        archivePath = devicePath.substring(assetBuildDirPrefix.length);
+      if (deviceUri.path.startsWith(assetBuildDirPrefix))
+        archivePath = deviceUri.path.substring(assetBuildDirPrefix.length);
       if (content.isModified || (bundleDirty && archivePath != null)) {
-        dirtyEntries[devicePath] = content;
+        dirtyEntries[deviceUri] = content;
         numBytes += content.size;
         if (archivePath != null)
           assetPathsToEvict.add(archivePath);
@@ -420,9 +420,9 @@ class DevFS {
         }
       } else {
         // Make service protocol requests for each.
-        dirtyEntries.forEach((String devicePath, DevFSContent content) {
+        dirtyEntries.forEach((Uri deviceUri, DevFSContent content) {
           Future<Map<String, dynamic>> operation =
-              _operations.writeFile(fsName, devicePath, content);
+              _operations.writeFile(fsName, deviceUri, content);
           if (operation != null)
             _pendingOperations.add(operation);
         });
@@ -446,41 +446,44 @@ class DevFS {
     return numBytes;
   }
 
-  void _scanFile(String devicePath, FileSystemEntity file) {
-    DevFSContent content = _entries.putIfAbsent(devicePath, () => new DevFSFileContent(file));
+  void _scanFile(Uri deviceUri, FileSystemEntity file) {
+    DevFSContent content = _entries.putIfAbsent(deviceUri, () => new DevFSFileContent(file));
     content._exists = true;
   }
 
   void _scanBundleEntry(String archivePath, DevFSContent content, bool bundleDirty) {
     // We write the assets into the AssetBundle working dir so that they
     // are in the same location in DevFS and the iOS simulator.
-    final String devicePath = fs.path.join(getAssetBuildDirectory(), archivePath);
+    final Uri devicePath = fs.path.toUri(fs.path.join(getAssetBuildDirectory(), archivePath));
 
     _entries[devicePath] = content;
     content._exists = true;
   }
 
-  bool _shouldIgnore(String devicePath) {
-    List<String> ignoredPrefixes = <String>['android' + fs.path.separator,
-                                            getBuildDirectory(),
-                                            'ios' + fs.path.separator,
-                                            '.pub' + fs.path.separator];
-    for (String ignoredPrefix in ignoredPrefixes) {
-      if (devicePath.startsWith(ignoredPrefix))
+  bool _shouldIgnore(Uri deviceUri) {
+    List<String> ignoredUriPrefixes = <String>['android/',
+                                            fs.path.toUri(getBuildDirectory()).path + '/',
+                                            'ios/',
+                                            '.pub/'];
+    for (String ignoredUriPrefix in ignoredUriPrefixes) {
+      if (deviceUri.path.startsWith(ignoredUriPrefix))
         return true;
     }
     return false;
   }
 
   Future<bool> _scanDirectory(Directory directory,
-                              {String directoryNameOnDevice,
+                              {Uri directoryUriOnDevice,
                                bool recursive: false,
                                bool ignoreDotFiles: true,
                                Set<String> fileFilter}) async {
-    if (directoryNameOnDevice == null) {
-      directoryNameOnDevice = fs.path.relative(directory.path, from: rootDirectory.path);
-      if (directoryNameOnDevice == '.')
-        directoryNameOnDevice = '';
+    if (directoryUriOnDevice == null) {
+      String relativeRootPath = fs.path.relative(directory.path, from: rootDirectory.path);
+      if (relativeRootPath == '.') {
+        directoryUriOnDevice = new Uri();
+      } else {
+        directoryUriOnDevice = fs.path.toUri(relativeRootPath);
+      }
     }
     try {
       Stream<FileSystemEntity> files =
@@ -506,17 +509,17 @@ class DevFS {
         }
         final String relativePath =
             fs.path.relative(file.path, from: directory.path);
-        final String devicePath = fs.path.join(directoryNameOnDevice, relativePath);
+        final Uri deviceUri = directoryUriOnDevice.resolveUri(fs.path.toUri(relativePath));
         if ((fileFilter != null) && !fileFilter.contains(file.absolute.path)) {
           // Skip files that are not included in the filter.
           continue;
         }
-        if (ignoreDotFiles && devicePath.startsWith('.')) {
+        if (ignoreDotFiles && deviceUri.path.startsWith('.')) {
           // Skip directories that start with a dot.
           continue;
         }
-        if (!_shouldIgnore(devicePath))
-          _scanFile(devicePath, file);
+        if (!_shouldIgnore(deviceUri))
+          _scanFile(deviceUri, file);
       }
     } catch (e) {
       // Ignore directory and error.
@@ -533,32 +536,34 @@ class DevFS {
       Uri packageUri = packageMap.map[packageName];
       String packagePath = fs.path.fromUri(packageUri);
       Directory packageDirectory = fs.directory(packageUri);
-      String directoryNameOnDevice = fs.path.join('packages', packageName);
+      Uri directoryUriOnDevice = fs.path.toUri(fs.path.join('packages', packageName) + fs.path.separator);
       bool packageExists;
 
       if (fs.path.isWithin(rootDirectory.path, packagePath)) {
         // We already scanned everything under the root directory.
         packageExists = packageDirectory.existsSync();
-        directoryNameOnDevice = fs.path.relative(packagePath, from: rootDirectory.path);
+        directoryUriOnDevice = fs.path.toUri(
+            fs.path.relative(packagePath, from: rootDirectory.path) + fs.path.separator
+        );
       } else {
         packageExists =
             await _scanDirectory(packageDirectory,
-                                 directoryNameOnDevice: directoryNameOnDevice,
+                                 directoryUriOnDevice: directoryUriOnDevice,
                                  recursive: true,
                                  fileFilter: fileFilter);
       }
       if (packageExists) {
         sb ??= new StringBuffer();
-        sb.writeln('$packageName:$directoryNameOnDevice');
+        sb.writeln('$packageName:$directoryUriOnDevice');
       }
     }
     if (sb != null) {
-      DevFSContent content = _entries['.packages'];
+      DevFSContent content = _entries[fs.path.toUri('.packages')];
       if (content is DevFSStringContent && content.string == sb.toString()) {
         content._exists = true;
         return;
       }
-      _entries['.packages'] = new DevFSStringContent(sb.toString());
+      _entries[fs.path.toUri('.packages')] = new DevFSStringContent(sb.toString());
     }
   }
 }

--- a/packages/flutter_tools/lib/src/run_hot.dart
+++ b/packages/flutter_tools/lib/src/run_hot.dart
@@ -430,17 +430,15 @@ class HotRunner extends ResidentRunner {
     String reloadMessage;
     try {
       String entryPath = fs.path.relative(mainPath, from: projectRootPath);
-      String deviceEntryPath =
-          _devFS.baseUri.resolve(entryPath).toFilePath();
-      String devicePackagesPath =
-          _devFS.baseUri.resolve('.packages').toFilePath();
+      Uri deviceEntryUri = _devFS.baseUri.resolveUri(fs.path.toUri(entryPath));
+      Uri devicePackagesUri = _devFS.baseUri.resolve('.packages');
       if (benchmarkMode)
         vmReloadTimer.start();
       Map<String, dynamic> reloadReport =
           await currentView.uiIsolate.reloadSources(
               pause: pause,
-              rootLibPath: deviceEntryPath,
-              packagesPath: devicePackagesPath);
+              rootLibUri: deviceEntryUri,
+              packagesUri: devicePackagesUri);
       if (!validateReloadReport(reloadReport)) {
         // Reload failed.
         flutterUsage.sendEvent('hot', 'reload-reject');

--- a/packages/flutter_tools/lib/src/vmservice.dart
+++ b/packages/flutter_tools/lib/src/vmservice.dart
@@ -844,11 +844,13 @@ class Isolate extends ServiceObjectOwner {
       Map<String, dynamic> arguments = <String, dynamic>{
         'pause': pause
       };
+      // TODO(goderbauer): Transfer Uri (instead of file path) when remote end supports it.
+      //     Note: Despite the name, `rootLibUri` and `packagesUri` expect file paths.
       if (rootLibUri != null) {
-        arguments['rootLibUri'] = rootLibUri.path;
+        arguments['rootLibUri'] = rootLibUri.toFilePath(windows: false);
       }
       if (packagesUri != null) {
-        arguments['packagesUri'] = packagesUri.path;
+        arguments['packagesUri'] = packagesUri.toFilePath(windows: false);
       }
       Map<String, dynamic> response = await invokeRpcRaw('_reloadSources', params: arguments);
       return response;

--- a/packages/flutter_tools/lib/src/vmservice.dart
+++ b/packages/flutter_tools/lib/src/vmservice.dart
@@ -838,17 +838,17 @@ class Isolate extends ServiceObjectOwner {
 
   Future<Map<String, dynamic>> reloadSources(
       { bool pause: false,
-        String rootLibPath,
-        String packagesPath}) async {
+        Uri rootLibUri,
+        Uri packagesUri}) async {
     try {
       Map<String, dynamic> arguments = <String, dynamic>{
         'pause': pause
       };
-      if (rootLibPath != null) {
-        arguments['rootLibUri'] = rootLibPath;
+      if (rootLibUri != null) {
+        arguments['rootLibUri'] = rootLibUri.path;
       }
-      if (packagesPath != null) {
-        arguments['packagesUri'] = packagesPath;
+      if (packagesUri != null) {
+        arguments['packagesUri'] = packagesUri.path;
       }
       Map<String, dynamic> response = await invokeRpcRaw('_reloadSources', params: arguments);
       return response;

--- a/packages/flutter_tools/test/devfs_test.dart
+++ b/packages/flutter_tools/test/devfs_test.dart
@@ -89,7 +89,7 @@ void main() {
       expect(devFS.assetPathsToEvict, isEmpty);
 
       List<String> packageSpecOnDevice = LineSplitter.split(UTF8.decode(
-          await devFSOperations.devicePathToContent['.packages'].contentsAsBytes()
+          await devFSOperations.devicePathToContent[fs.path.toUri('.packages')].contentsAsBytes()
       )).toList();
       expect(packageSpecOnDevice,
           unorderedEquals(<String>['my_project:lib', 'somepkg:packages/somepkg'])

--- a/packages/flutter_tools/test/devfs_test.dart
+++ b/packages/flutter_tools/test/devfs_test.dart
@@ -4,7 +4,6 @@
 
 import 'dart:async';
 import 'dart:convert';
-import 'dart:io' as io;
 
 import 'package:flutter_tools/src/asset.dart';
 import 'package:flutter_tools/src/base/io.dart';

--- a/packages/flutter_tools/test/src/mocks.dart
+++ b/packages/flutter_tools/test/src/mocks.dart
@@ -95,7 +95,7 @@ class BasicMock {
 }
 
 class MockDevFSOperations extends BasicMock implements DevFSOperations {
-  Map<String, DevFSContent> devicePathToContent = <String, DevFSContent>{};
+  Map<Uri, DevFSContent> devicePathToContent = <Uri, DevFSContent>{};
 
   @override
   Future<Uri> create(String fsName) async {
@@ -109,14 +109,14 @@ class MockDevFSOperations extends BasicMock implements DevFSOperations {
   }
 
   @override
-  Future<dynamic> writeFile(String fsName, String devicePath, DevFSContent content) async {
-    messages.add('writeFile $fsName $devicePath');
-    devicePathToContent[devicePath] = content;
+  Future<dynamic> writeFile(String fsName, Uri deviceUri, DevFSContent content) async {
+    messages.add('writeFile $fsName $deviceUri');
+    devicePathToContent[deviceUri] = content;
   }
 
   @override
-  Future<dynamic> deleteFile(String fsName, String devicePath) async {
-    messages.add('deleteFile $fsName $devicePath');
-    devicePathToContent.remove(devicePath);
+  Future<dynamic> deleteFile(String fsName, Uri deviceUri) async {
+    messages.add('deleteFile $fsName $deviceUri');
+    devicePathToContent.remove(deviceUri);
   }
 }


### PR DESCRIPTION
Previosuly, regular file paths in the format of the host platform were used to represent paths on device. That works when host and device share the same (POSIX) file path format. With a Windows host, this breaks. URIs are the solution as they are platform independent and the VM service on the device already interpreted the file paths as URIs anyways.

/cc @johnmccutchan