### PR TITLE
Read package ID and activity name from .apk for Gradle-based builds.

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_device.dart
+++ b/packages/flutter_tools/lib/src/android/android_device.dart
@@ -283,9 +283,6 @@ class AndroidDevice extends Device {
       return new LaunchResult.failed();
     }
 
-    printTrace("Stopping app '${package.name}' on $name.");
-    await stopApp(package);
-
     if (!prebuiltApplication) {
       printTrace('Building APK');
       await buildApk(platform,
@@ -294,7 +291,13 @@ class AndroidDevice extends Device {
           kernelContent: kernelContent,
           applicationNeedsRebuild: applicationNeedsRebuild
       );
+      // Package has been built, so we can get the updated application ID and
+      // activity name from the .apk.
+      package = new AndroidApk.fromCurrentDirectory();
     }
+
+    printTrace("Stopping app '${package.name}' on $name.");
+    await stopApp(package);
 
     if (isLatestBuildInstalled(package)) {
       printStatus('Latest build already installed.');

--- a/packages/flutter_tools/lib/src/application_package.dart
+++ b/packages/flutter_tools/lib/src/application_package.dart
@@ -82,6 +82,14 @@ class AndroidApk extends ApplicationPackage {
     String apkPath;
 
     if (isProjectUsingGradle()) {
+      if (fs.file(gradleAppOut).existsSync()) {
+        // Grab information from the .apk. The gradle build script might alter
+        // the application Id, so we need to look at what was actually built.
+        return new AndroidApk.fromApk(gradleAppOut);
+      }
+      // The .apk hasn't been built yet, so we work with what we have. The run
+      // command will grab a new AndroidApk after building, to get the updated
+      // IDs.
       manifestPath = gradleManifestPath;
       apkPath = gradleAppOut;
     } else {


### PR DESCRIPTION
The gradle build scripts can be configured to output different
application IDs for different build types, so we need to examine the
built .apk to figure out the name of the package and activity.

Re-landing this change, updated to only get information from the .apk
if it exists.

Since the tools create an AndroidApk instance early, even before we've
actually built an .apk, we have to create a new instance after building,
so we can start the right app/activity.

Fixes #8327.