### PR TITLE
Don't print stacktraces from ToolExit errors during flutter run

### DIFF
--- a/packages/flutter_tools/lib/src/run_cold.dart
+++ b/packages/flutter_tools/lib/src/run_cold.dart
@@ -54,7 +54,8 @@ class ColdRunner extends ResidentRunner {
         shouldBuild: shouldBuild
       );
     }, onError: (dynamic error, StackTrace stackTrace) {
-      printError('Exception from flutter run: $error', stackTrace);
+      printError('Exception from flutter run: $error',
+          logger.isVerbose ? stackTrace : null);
     });
   }
 

--- a/packages/flutter_tools/lib/src/run_cold.dart
+++ b/packages/flutter_tools/lib/src/run_cold.dart
@@ -8,6 +8,7 @@ import 'package:meta/meta.dart';
 import 'package:stack_trace/stack_trace.dart';
 
 import 'application_package.dart';
+import 'base/common.dart';
 import 'base/file_system.dart';
 import 'base/utils.dart';
 import 'build_info.dart';
@@ -54,8 +55,10 @@ class ColdRunner extends ResidentRunner {
         shouldBuild: shouldBuild
       );
     }, onError: (dynamic error, StackTrace stackTrace) {
-      printError('Exception from flutter run: $error',
-          logger.isVerbose ? stackTrace : null);
+      // Actually exit on ToolExit.
+      if (error is ToolExit)
+        throw error;
+      printError('Exception from flutter run: $error', stackTrace);
     });
   }
 

--- a/packages/flutter_tools/lib/src/run_hot.dart
+++ b/packages/flutter_tools/lib/src/run_hot.dart
@@ -81,7 +81,8 @@ class HotRunner extends ResidentRunner {
         shouldBuild: shouldBuild
       );
     }, onError: (dynamic error, StackTrace stackTrace) {
-      printError('Exception from flutter run: $error', stackTrace);
+      printError('Exception from flutter run: $error',
+          logger.isVerbose ? stackTrace : null);
     });
   }
 

--- a/packages/flutter_tools/lib/src/run_hot.dart
+++ b/packages/flutter_tools/lib/src/run_hot.dart
@@ -8,6 +8,7 @@ import 'package:meta/meta.dart';
 import 'package:stack_trace/stack_trace.dart';
 
 import 'application_package.dart';
+import 'base/common.dart';
 import 'base/context.dart';
 import 'base/file_system.dart';
 import 'base/logger.dart';
@@ -81,8 +82,10 @@ class HotRunner extends ResidentRunner {
         shouldBuild: shouldBuild
       );
     }, onError: (dynamic error, StackTrace stackTrace) {
-      printError('Exception from flutter run: $error',
-          logger.isVerbose ? stackTrace : null);
+      // Actually exit on ToolExit.
+      if (error is ToolExit)
+        throw error;
+      printError('Exception from flutter run: $error', stackTrace);
     });
   }
 


### PR DESCRIPTION
Fixes #8363.