### PR TITLE
Revert "Simplify path handling logic in dependency checker and devFS (#8414)"

### DIFF
--- a/bin/internal/engine.version
+++ b/bin/internal/engine.version
@@ -1,1 +1,1 @@
-0edcbb7db427e4fcaff23308ea95f9aec0ebb432
+eaacbf5f6f8f7f0be4cec64babc777816c68dd44

--- a/packages/flutter_tools/lib/src/dart/dependencies.dart
+++ b/packages/flutter_tools/lib/src/dart/dependencies.dart
@@ -5,6 +5,7 @@
 import 'dart:convert';
 
 import '../artifacts.dart';
+import '../base/file_system.dart';
 import '../base/process.dart';
 
 class DartDependencySetBuilder {
@@ -29,6 +30,16 @@ class DartDependencySetBuilder {
 
     String output = runSyncAndThrowStdErrOnError(args);
 
-    return new Set<String>.from(LineSplitter.split(output));
+    final List<String> lines = LineSplitter.split(output).toList();
+    final Set<String> minimalDependencies = new Set<String>();
+    for (String line in lines) {
+      if (!line.startsWith('package:')) {
+        // We convert the uris so that they are relative to the project
+        // root.
+        line = fs.path.relative(line, from: projectRootPath);
+      }
+      minimalDependencies.add(line);
+    }
+    return minimalDependencies;
   }
 }

--- a/packages/flutter_tools/lib/src/run_hot.dart
+++ b/packages/flutter_tools/lib/src/run_hot.dart
@@ -98,7 +98,18 @@ class HotRunner extends ResidentRunner {
         new DartDependencySetBuilder(
               mainPath, projectRootPath, packagesFilePath);
     try {
-      _dartDependencies = new Set<String>.from(dartDependencySetBuilder.build());
+      Set<String> dependencies = dartDependencySetBuilder.build();
+      _dartDependencies = new Set<String>();
+      for (String path in dependencies) {
+        // We need to tweak package: uris so that they reflect their devFS
+        // location.
+        if (path.startsWith('package:')) {
+          // Swap out package: for packages/ because we place all package
+          // sources under packages/.
+          path = path.replaceFirst('package:', 'packages/');
+        }
+        _dartDependencies.add(path);
+      }
     } catch (error) {
       printStatus('Error detected in application source code:', emphasis: true);
       printError('$error');

--- a/packages/flutter_tools/test/dart_dependencies_test.dart
+++ b/packages/flutter_tools/test/dart_dependencies_test.dart
@@ -21,8 +21,8 @@ void main()  {
       DartDependencySetBuilder builder =
           new DartDependencySetBuilder(mainPath, testPath, packagesPath);
       Set<String> dependencies = builder.build();
-      expect(dependencies.contains(mainPath), isTrue);
-      expect(dependencies.contains(fs.path.join(testPath, 'foo.dart')), isTrue);
+      expect(dependencies.contains('main.dart'), isTrue);
+      expect(dependencies.contains('foo.dart'), isTrue);
     });
     testUsingContext('syntax_error', () {
       final String testPath = fs.path.join(dataPath, 'syntax_error');


### PR DESCRIPTION
This reverts commit e7bde11cc3a68b27c17ef8b18258cd384d043fb8.

Reason: broke hot reload when using "package:" style imports for sources
within the same project.

Fixes https://github.com/flutter/flutter/issues/8451