### PR TITLE
Roll forward #8467

### DIFF
--- a/examples/flutter_gallery/lib/demo/all.dart
+++ b/examples/flutter_gallery/lib/demo/all.dart
@@ -33,6 +33,8 @@ export 'snack_bar_demo.dart';
 export 'tabs_demo.dart';
 export 'tabs_fab_demo.dart';
 export 'text_field_demo.dart';
-export 'tooltip_demo.dart';
 export 'two_level_list_demo.dart';
 export 'typography_demo.dart';
+
+// Intentionally use a self-package URL to make sure we don't break these.
+export 'package:flutter_gallery/demo/tooltip_demo.dart';

--- a/packages/flutter_tools/lib/src/dart/dependencies.dart
+++ b/packages/flutter_tools/lib/src/dart/dependencies.dart
@@ -5,7 +5,6 @@
 import 'dart:convert';
 
 import '../artifacts.dart';
-import '../base/file_system.dart';
 import '../base/process.dart';
 
 class DartDependencySetBuilder {
@@ -30,16 +29,6 @@ class DartDependencySetBuilder {
 
     String output = runSyncAndThrowStdErrOnError(args);
 
-    final List<String> lines = LineSplitter.split(output).toList();
-    final Set<String> minimalDependencies = new Set<String>();
-    for (String line in lines) {
-      if (!line.startsWith('package:')) {
-        // We convert the uris so that they are relative to the project
-        // root.
-        line = fs.path.relative(line, from: projectRootPath);
-      }
-      minimalDependencies.add(line);
-    }
-    return minimalDependencies;
+    return new Set<String>.from(LineSplitter.split(output));
   }
 }

--- a/packages/flutter_tools/lib/src/dependency_checker.dart
+++ b/packages/flutter_tools/lib/src/dependency_checker.dart
@@ -5,7 +5,6 @@
 import 'asset.dart';
 import 'base/file_system.dart';
 import 'dart/dependencies.dart';
-import 'dart/package_map.dart';
 import 'globals.dart';
 
 class DependencyChecker {
@@ -18,10 +17,7 @@ class DependencyChecker {
   /// if it cannot be determined.
   bool check(DateTime threshold) {
     _dependencies.clear();
-    PackageMap packageMap;
-    // Parse the package map.
     try {
-      packageMap = new PackageMap(builder.packagesFilePath)..load();
       _dependencies.add(builder.packagesFilePath);
     } catch (e, st) {
       printTrace('DependencyChecker: could not parse .packages file:\n$e\n$st');
@@ -29,16 +25,7 @@ class DependencyChecker {
     }
     // Build the set of Dart dependencies.
     try {
-      Set<String> dependencies = builder.build();
-      for (String path in dependencies) {
-        // Ensure all paths are absolute.
-        if (path.startsWith('package:')) {
-          path = packageMap.pathForPackage(Uri.parse(path));
-        } else {
-          path = fs.path.join(builder.projectRootPath, path);
-        }
-        _dependencies.add(path);
-      }
+      _dependencies.addAll(builder.build());
     } catch (e, st) {
       printTrace('DependencyChecker: error determining .dart dependencies:\n$e\n$st');
       return true;

--- a/packages/flutter_tools/lib/src/devfs.dart
+++ b/packages/flutter_tools/lib/src/devfs.dart
@@ -461,10 +461,10 @@ class DevFS {
   }
 
   bool _shouldIgnore(String devicePath) {
-    List<String> ignoredPrefixes = <String>['android/',
+    List<String> ignoredPrefixes = <String>['android' + fs.path.separator,
                                             getBuildDirectory(),
-                                            'ios/',
-                                            '.pub/'];
+                                            'ios' + fs.path.separator,
+                                            '.pub' + fs.path.separator];
     for (String ignoredPrefix in ignoredPrefixes) {
       if (devicePath.startsWith(ignoredPrefix))
         return true;
@@ -473,16 +473,14 @@ class DevFS {
   }
 
   Future<bool> _scanDirectory(Directory directory,
-                              {String directoryName,
+                              {String directoryNameOnDevice,
                                bool recursive: false,
                                bool ignoreDotFiles: true,
-                               String packagesDirectoryName,
                                Set<String> fileFilter}) async {
-    String prefix = directoryName;
-    if (prefix == null) {
-      prefix = fs.path.relative(directory.path, from: rootDirectory.path);
-      if (prefix == '.')
-        prefix = '';
+    if (directoryNameOnDevice == null) {
+      directoryNameOnDevice = fs.path.relative(directory.path, from: rootDirectory.path);
+      if (directoryNameOnDevice == '.')
+        directoryNameOnDevice = '';
     }
     try {
       Stream<FileSystemEntity> files =
@@ -508,24 +506,8 @@ class DevFS {
         }
         final String relativePath =
             fs.path.relative(file.path, from: directory.path);
-        final String devicePath = fs.path.join(prefix, relativePath);
-        bool filtered = false;
-        if ((fileFilter != null) &&
-            !fileFilter.contains(devicePath)) {
-          if (packagesDirectoryName != null) {
-            // Double check the filter for packages/packagename/
-            final String packagesDevicePath =
-                fs.path.join(packagesDirectoryName, relativePath);
-            if (!fileFilter.contains(packagesDevicePath)) {
-              // File was not in the filter set.
-              filtered = true;
-            }
-          } else {
-            // File was not in the filter set.
-            filtered = true;
-          }
-        }
-        if (filtered) {
+        final String devicePath = fs.path.join(directoryNameOnDevice, relativePath);
+        if ((fileFilter != null) && !fileFilter.contains(file.absolute.path)) {
           // Skip files that are not included in the filter.
           continue;
         }
@@ -548,27 +530,26 @@ class DevFS {
     PackageMap packageMap = new PackageMap(_packagesFilePath);
 
     for (String packageName in packageMap.map.keys) {
-      Uri uri = packageMap.map[packageName];
-      // This project's own package.
-      final bool isProjectPackage = uri.toString() == 'lib/';
-      final String directoryName =
-          isProjectPackage ? 'lib' : fs.path.join('packages', packageName);
-      // If this is the project's package, we need to pass both
-      // package:<package_name> and lib/ as paths to be checked against
-      // the filter because we must support both package: imports and relative
-      // path imports within the project's own code.
-      final String packagesDirectoryName =
-          isProjectPackage ? fs.path.join('packages', packageName) : null;
-      Directory directory = fs.directory(uri);
-      bool packageExists =
-          await _scanDirectory(directory,
-                               directoryName: directoryName,
-                               recursive: true,
-                               packagesDirectoryName: packagesDirectoryName,
-                               fileFilter: fileFilter);
+      Uri packageUri = packageMap.map[packageName];
+      String packagePath = fs.path.fromUri(packageUri);
+      Directory packageDirectory = fs.directory(packageUri);
+      String directoryNameOnDevice = fs.path.join('packages', packageName);
+      bool packageExists;
+
+      if (fs.path.isWithin(rootDirectory.path, packagePath)) {
+        // We already scanned everything under the root directory.
+        packageExists = packageDirectory.existsSync();
+        directoryNameOnDevice = fs.path.relative(packagePath, from: rootDirectory.path);
+      } else {
+        packageExists =
+            await _scanDirectory(packageDirectory,
+                                 directoryNameOnDevice: directoryNameOnDevice,
+                                 recursive: true,
+                                 fileFilter: fileFilter);
+      }
       if (packageExists) {
         sb ??= new StringBuffer();
-        sb.writeln('$packageName:$directoryName');
+        sb.writeln('$packageName:$directoryNameOnDevice');
       }
     }
     if (sb != null) {

--- a/packages/flutter_tools/lib/src/run_hot.dart
+++ b/packages/flutter_tools/lib/src/run_hot.dart
@@ -98,18 +98,7 @@ class HotRunner extends ResidentRunner {
         new DartDependencySetBuilder(
               mainPath, projectRootPath, packagesFilePath);
     try {
-      Set<String> dependencies = dartDependencySetBuilder.build();
-      _dartDependencies = new Set<String>();
-      for (String path in dependencies) {
-        // We need to tweak package: uris so that they reflect their devFS
-        // location.
-        if (path.startsWith('package:')) {
-          // Swap out package: for packages/ because we place all package
-          // sources under packages/.
-          path = path.replaceFirst('package:', 'packages/');
-        }
-        _dartDependencies.add(path);
-      }
+      _dartDependencies = new Set<String>.from(dartDependencySetBuilder.build());
     } catch (error) {
       printStatus('Error detected in application source code:', emphasis: true);
       printError('$error');

--- a/packages/flutter_tools/test/dart_dependencies_test.dart
+++ b/packages/flutter_tools/test/dart_dependencies_test.dart
@@ -21,8 +21,8 @@ void main()  {
       DartDependencySetBuilder builder =
           new DartDependencySetBuilder(mainPath, testPath, packagesPath);
       Set<String> dependencies = builder.build();
-      expect(dependencies.contains('main.dart'), isTrue);
-      expect(dependencies.contains('foo.dart'), isTrue);
+      expect(dependencies.contains(mainPath), isTrue);
+      expect(dependencies.contains(fs.path.join(testPath, 'foo.dart')), isTrue);
     });
     testUsingContext('syntax_error', () {
       final String testPath = fs.path.join(dataPath, 'syntax_error');

--- a/packages/flutter_tools/test/src/mocks.dart
+++ b/packages/flutter_tools/test/src/mocks.dart
@@ -95,6 +95,8 @@ class BasicMock {
 }
 
 class MockDevFSOperations extends BasicMock implements DevFSOperations {
+  Map<String, DevFSContent> devicePathToContent = <String, DevFSContent>{};
+
   @override
   Future<Uri> create(String fsName) async {
     messages.add('create $fsName');
@@ -109,10 +111,12 @@ class MockDevFSOperations extends BasicMock implements DevFSOperations {
   @override
   Future<dynamic> writeFile(String fsName, String devicePath, DevFSContent content) async {
     messages.add('writeFile $fsName $devicePath');
+    devicePathToContent[devicePath] = content;
   }
 
   @override
   Future<dynamic> deleteFile(String fsName, String devicePath) async {
     messages.add('deleteFile $fsName $devicePath');
+    devicePathToContent.remove(devicePath);
   }
 }


### PR DESCRIPTION
The path issue that caused #8451 has been fixed upstream in the engine.

Additionally, this PR also improves testing of devFS by making sure the path used by self-package imports is covered.

Last, but not least, this PR also introduces a self-package import in our gallery example app to further ensure that we notice breakages in these types of imports as early as possible since our customers seem to be using them quite a bit.

/cc @johnmccutchan 