### PR TITLE
Add missing IntelliJ metadata files to platform_services

### DIFF
--- a/examples/platform_services/.idea/modules.xml
+++ b/examples/platform_services/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/platform_services.iml" filepath="$PROJECT_DIR$/platform_services.iml" />
+    </modules>
+  </component>
+</project>

--- a/examples/platform_services/.idea/runConfiguration/platform_services.xml
+++ b/examples/platform_services/.idea/runConfiguration/platform_services.xml
@@ -1,0 +1,6 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="platform_services" type="FlutterRunConfigurationType" factoryName="Flutter">
+    <option name="filePath" value="$PROJECT_DIR$/lib/main.dart" />
+    <method />
+  </configuration>
+</component>

--- a/examples/platform_services/platform_services.iml
+++ b/examples/platform_services/platform_services.iml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="FLUTTER_MODULE_TYPE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$">
+      <excludeFolder url="file://$MODULE_DIR$/.idea" />
+      <excludeFolder url="file://$MODULE_DIR$/.pub" />
+      <excludeFolder url="file://$MODULE_DIR$/build" />
+      <excludeFolder url="file://$MODULE_DIR$/packages" />
+    </content>
+    <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="library" name="Dart SDK" level="application" />
+    <orderEntry type="library" name="Dart Packages" level="project" />
+  </component>
+</module>


### PR DESCRIPTION
The new platform_services sample is missing required metadata files to enable opening in IntelliJ.