### PR TITLE
Update scroll tests to use pumpUntilNoTransientCallbacks

### DIFF
--- a/packages/flutter/test/material/scaffold_test.dart
+++ b/packages/flutter/test/material/scaffold_test.dart
@@ -206,7 +206,7 @@ void main() {
     expect(scrollable.position.pixels, equals(500.0));
     await tester.tapAt(const Point(100.0, 10.0));
     await tester.pump();
-    await tester.pump(const Duration(seconds: 1));
+    await tester.pumpUntilNoTransientCallbacks();
     expect(scrollable.position.pixels, equals(0.0));
   });
 

--- a/packages/flutter/test/material/tabs_test.dart
+++ b/packages/flutter/test/material/tabs_test.dart
@@ -152,17 +152,17 @@ void main() {
 
     await tester.tap(find.text('C'));
     await tester.pump();
-    await tester.pump(const Duration(seconds: 1));
+    await tester.pumpUntilNoTransientCallbacks();
     expect(controller.index, 2);
 
     await tester.tap(find.text('B'));
     await tester.pump();
-    await tester.pump(const Duration(seconds: 1));
+    await tester.pumpUntilNoTransientCallbacks();
     expect(controller.index, 1);
 
     await tester.tap(find.text('A'));
     await tester.pump();
-    await tester.pump(const Duration(seconds: 1));
+    await tester.pumpUntilNoTransientCallbacks();
     expect(controller.index, 0);
   });
 
@@ -180,7 +180,7 @@ void main() {
 
     await tester.tap(find.text('FFFFFF'));
     await tester.pump();
-    await tester.pump(const Duration(seconds: 1)); // finish the scroll animation
+    await tester.pumpUntilNoTransientCallbacks();
     expect(controller.index, 5);
     // The center of the FFFFFF item is now at the TabBar's center
     expect(tester.getCenter(find.text('FFFFFF')).x, closeTo(400.0, 1.0));

--- a/packages/flutter/test/widgets/state_setting_in_scrollables_test.dart
+++ b/packages/flutter/test/widgets/state_setting_in_scrollables_test.dart
@@ -83,7 +83,7 @@ void main() {
     expect(tester.state<ScrollableState>(find.byType(Scrollable)).position.pixels, 0.0);
     await tester.tap(find.byType(GestureDetector).first);
     await tester.pump();
-    await tester.pump(const Duration(seconds: 1));
+    await tester.pumpUntilNoTransientCallbacks();
     expect(tester.state<ScrollableState>(find.byType(Scrollable)).position.pixels, 200.0);
   });
 }


### PR DESCRIPTION
This ensures that both timer/microtask queues are cleared out rather
than assuming that all work is completed in a specified amount of time.