### PR TITLE
Recommend using AlwaysScrollableScrollPhysics with RefreshIndicator

### DIFF
--- a/packages/flutter/lib/src/material/refresh_indicator.dart
+++ b/packages/flutter/lib/src/material/refresh_indicator.dart
@@ -54,7 +54,20 @@ enum _RefreshIndicatorMode {
 /// scrollable's contents and then complete the [Future] it returns. The refresh
 /// indicator disappears after the callback's [Future] has completed.
 ///
-/// A [RefreshIndicator] can only be used with a vertical scroll view (the xxxxxxx.
+/// If the [Scrollable] might not have enough content to overscroll, consider
+/// settings its `physics` property to [AlwaysScrollableScrollPhysics]:
+///
+/// ```dart
+/// new ListView(
+///   physics: const AlwaysScrollableScrollPhysics(),
+///   children: ...
+//  )
+/// ```
+///
+/// Using [AlwaysScrollableScrollPhysics] will ensure that the scroll view is
+/// always scrollable and, therefore, can trigger the [RefreshIndicator].
+///
+/// A [RefreshIndicator] can only be used with a vertical scroll view.
 ///
 /// See also:
 ///


### PR DESCRIPTION
Using these physics avoids a problem whereby the scroll view isn't scrollable
due to lack of content and therefore cannot trigger the refresh indicator.

Fixes #8432