### PR TITLE
Avoid potential ConcurrentModificationError

### DIFF
--- a/packages/flutter/lib/src/widgets/scroll_controller.dart
+++ b/packages/flutter/lib/src/widgets/scroll_controller.dart
@@ -70,7 +70,7 @@ class ScrollController {
     @required Curve curve,
   }) {
     assert(_positions.isNotEmpty, 'ScrollController not attached to any scroll views.');
-    List<Future<Null>> animations = new List<Future<Null>>(_positions.length);
+    final List<Future<Null>> animations = new List<Future<Null>>(_positions.length);
     for (int i = 0; i < _positions.length; i++)
       animations[i] = _positions[i].animateTo(offset, duration: duration, curve: curve);
     return Future.wait<Null>(animations).then((List<Null> _) => null);
@@ -90,8 +90,8 @@ class ScrollController {
   /// value was out of range.
   void jumpTo(double value) {
     assert(_positions.isNotEmpty, 'ScrollController not attached to any scroll views.');
-    for (ScrollPosition p in _positions)
-      p.jumpTo(value);
+    for (ScrollPosition position in new List<ScrollPosition>.from(_positions))
+      position.jumpTo(value);
   }
 
   /// Register the given position with this controller.

--- a/packages/flutter/lib/src/widgets/scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/scroll_view.dart
@@ -72,13 +72,13 @@ abstract class ScrollView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    List<Widget> slivers = buildSlivers(context);
-    AxisDirection axisDirection = getDirection(context);
+    final List<Widget> slivers = buildSlivers(context);
+    final AxisDirection axisDirection = getDirection(context);
 
-    ScrollController scrollController = primary
+    final ScrollController scrollController = primary
         ? PrimaryScrollController.of(context)
         : controller;
-    Scrollable scrollable = new Scrollable(
+    final Scrollable scrollable = new Scrollable(
       axisDirection: axisDirection,
       controller: scrollController,
       physics: physics,

--- a/packages/flutter/lib/src/widgets/single_child_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/single_child_scroll_view.dart
@@ -96,10 +96,10 @@ class SingleChildScrollView extends StatelessWidget {
     Widget contents = child;
     if (padding != null)
       contents = new Padding(padding: padding, child: contents);
-    ScrollController scrollController = primary
+    final ScrollController scrollController = primary
         ? PrimaryScrollController.of(context)
         : controller;
-    Scrollable scrollable = new Scrollable(
+    final Scrollable scrollable = new Scrollable(
       axisDirection: axisDirection,
       controller: scrollController,
       physics: physics,


### PR DESCRIPTION
Also make locals final where possible.

Followup to 527154679466940189a86e24378c2fa4e5db04a3.