### PR TITLE
Add support for synchronized scrolling

### DIFF
--- a/packages/flutter/lib/src/widgets/page_view.dart
+++ b/packages/flutter/lib/src/widgets/page_view.dart
@@ -22,7 +22,8 @@ import 'viewport.dart';
 class PageController extends ScrollController {
   PageController({
     this.initialPage: 0,
-  }) {
+    ScrollLeader leader,
+  }) : super(leader: leader) {
     assert(initialPage != null);
   }
 
@@ -61,6 +62,7 @@ class PageController extends ScrollController {
       state: state,
       initialPage: initialPage,
       oldPosition: oldPosition,
+      leader: leader,
     );
   }
 }
@@ -71,11 +73,13 @@ class _PagePosition extends ScrollPosition {
     AbstractScrollState state,
     this.initialPage: 0,
     ScrollPosition oldPosition,
+    ScrollLeader leader,
   }) : super(
     physics: physics,
     state: state,
     initialPixels: null,
     oldPosition: oldPosition,
+    leader: leader,
   ) {
     assert(initialPage != null);
   }

--- a/packages/flutter/lib/src/widgets/scroll_controller.dart
+++ b/packages/flutter/lib/src/widgets/scroll_controller.dart
@@ -12,6 +12,7 @@ import 'scroll_position.dart';
 class ScrollController {
   ScrollController({
     this.initialScrollOffset: 0.0,
+    this.leader,
   }) {
     assert(initialScrollOffset != null);
   }
@@ -21,6 +22,10 @@ class ScrollController {
   /// New [ScrollPosition] objects that are created and attached to this
   /// controller will have their offset initialized to this value.
   final double initialScrollOffset;
+
+  /// Synchronizes the [offset]s of any other ScrollControllers that were
+  /// created with the same leader.
+  final ScrollLeader leader;
 
   final List<ScrollPosition> _positions = <ScrollPosition>[];
 
@@ -126,6 +131,7 @@ class ScrollController {
       state: state,
       initialPixels: initialScrollOffset,
       oldPosition: oldPosition,
+      leader: leader,
     );
   }
 

--- a/packages/flutter/test/widgets/scroll_leader_test.dart
+++ b/packages/flutter/test/widgets/scroll_leader_test.dart
@@ -1,0 +1,81 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter/widgets.dart';
+
+import 'states.dart';
+
+const double kItemHeight = 64.0;
+const Duration kDuration = const Duration(milliseconds: 100);
+
+void main() {
+  testWidgets('ScrollController control test', (WidgetTester tester) async {
+    ScrollLeader leader = new ScrollLeader();
+    final List<ScrollController> controllers = <ScrollController>[
+      new ScrollController(leader: leader),
+      new ScrollController(leader: leader),
+      new ScrollController(leader: leader),
+    ];
+
+    await tester.pumpWidget(new Row(
+      children: controllers.map((ScrollController controller) {
+        return new Flexible(
+          child: new ListView(
+            controller: controller,
+            children: kStates.map<Widget>((String state) {
+              return new Container(
+                height: kItemHeight,
+                child: new Text(state),
+              );
+            }).toList(),
+          ),
+        );
+      }).toList(),
+    ));
+
+    List<double> scrollOffsets() {
+      return tester.stateList<ScrollableState>(find.byType(Scrollable)).map((ScrollableState state) {
+        return state.position.pixels;
+      }).toList();
+    }
+
+    bool allScrollOffsetsEqual() {
+      final List<double> offsets = scrollOffsets();
+      return offsets.every((double offset) => offset == offsets.first);
+    }
+
+    expect(scrollOffsets(), <double>[0.0, 0.0, 0.0]);
+
+    tester.state<ScrollableState>(find.byType(Scrollable).first).position.jumpTo(100.0);
+    await tester.pump();
+    expect(scrollOffsets(), <double>[100.0, 100.0, 100.0]);
+
+    tester.state<ScrollableState>(find.byType(Scrollable).last).position.jumpTo(500.0);
+    await tester.pump();
+    expect(scrollOffsets(), <double>[500.0, 500.0, 500.0]);
+
+    tester.state<ScrollableState>(find.byType(Scrollable).first).position.animateTo(200.0,
+      duration: kDuration,
+      curve: Curves.linear
+    );
+    await tester.pump();
+    await tester.pump(kDuration);
+    expect(scrollOffsets(), <double>[200.0, 200.0, 200.0]);
+
+    tester.state<ScrollableState>(find.byType(Scrollable).last).position.animateTo(600.0,
+      duration: kDuration,
+      curve: Curves.linear
+    );
+    await tester.pump();
+    await tester.pump(kDuration);
+    expect(scrollOffsets(), <double>[600.0, 600.0, 600.0]);
+
+    await tester.fling(find.byType(ListView).first, const Offset(0.0, -200.0), 1000.0);
+    expect(allScrollOffsetsEqual(), isTrue);
+
+    await tester.fling(find.byType(ListView).first, const Offset(0.0, 200.0), 1000.0);
+    expect(allScrollOffsetsEqual(), isTrue);
+  });
+}


### PR DESCRIPTION
Enable connecting the scroll offsets of two or more scrollables. Scrolling one of the scrollables will scroll them all.

The scrollables must be created with ScrollControllers that share a ScrollLeader.
```
    ScrollLeader leader = new ScrollLeader();
    ScrollController leftController = new ScrollController(leader: leader);
    ScrollController rightController = new ScrollController(leader: leader);

    ...

    new ListView(controller: leftController, ...)
    new ListView(controller: rightController, ...)
```

The implementation of this feature is imperfect and limited. Currently all of the scrollable's with a common ScrollLeader must have the same geometry.
