### PR TITLE
Enable ANSI codes in PowerShell

### DIFF
--- a/bin/flutter.ps1
+++ b/bin/flutter.ps1
@@ -1,0 +1,29 @@
+# Copyright 2017 The Chromium Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+# This is a wrapper arround flutter.bat, which checks if the terminal supports
+# ANSI codes to work around https://github.com/dart-lang/sdk/issues/28614.
+
+Add-Type -MemberDefinition @"
+[DllImport("kernel32.dll", SetLastError=true)]
+public static extern bool SetConsoleMode(IntPtr hConsoleHandle, int mode);
+[DllImport("kernel32.dll", SetLastError=true)]
+public static extern IntPtr GetStdHandle(int handle);
+[DllImport("kernel32.dll", SetLastError=true)]
+public static extern bool GetConsoleMode(IntPtr handle, out int mode);
+"@ -Namespace Win32 -Name NativeMethods
+
+If (Test-Path Env:\FLUTTER_ANSI_TERMINAL) { Remove-Item Env:\FLUTTER_ANSI_TERMINAL }
+$stdout = [Win32.NativeMethods]::GetStdHandle(-11) # STD_OUTPUT_HANDLE
+If ($stdout -ne -1) {
+    $mode = 0
+    $result = [Win32.NativeMethods]::GetConsoleMode($stdout, [ref]$mode)
+    If ($result) {
+        $mode = $mode -bor 4 # ENABLE_VIRTUAL_TERMINAL_PROCESSING
+        $env:FLUTTER_ANSI_TERMINAL = [Win32.NativeMethods]::SetConsoleMode($stdout, $mode)
+    }
+}
+
+flutter.bat $args
+exit $LastExitCode

--- a/packages/flutter_tools/lib/src/base/logger.dart
+++ b/packages/flutter_tools/lib/src/base/logger.dart
@@ -243,9 +243,10 @@ enum _LogType {
 
 class AnsiTerminal {
   AnsiTerminal() {
-    // TODO(devoncarew): This detection does not work for Windows (https://github.com/dart-lang/sdk/issues/28614).
     String term = platform.environment['TERM'];
-    supportsColor = term != null && term != 'dumb';
+    // FLUTTER_ANSI_TERMINAL is a work-around for https://github.com/dart-lang/sdk/issues/28614
+    String flutterAnsiTerm =  platform.environment['FLUTTER_ANSI_TERMINAL'];
+    supportsColor = (term != null && term != 'dumb') || (flutterAnsiTerm != null);
   }
 
   static const String KEY_F1  = '\u001BOP';


### PR DESCRIPTION
Enable ANSI codes when `flutter` is executed in a PowerShell. This is a work-around for https://github.com/dart-lang/sdk/issues/28614.

The regular Cmd prompt also supports ANSI codes, but there is currently no way of checking from Batch or Dart (https://github.com/dart-lang/sdk/issues/28614) if that support is enabled. :(

Hence, we should recommend PowerShell to our users on Windows for the prettiest output.

Note: `flutter.ps1` is only used when the user invokes `flutter` from a PowerShell, where we incur no cost for running a PowerShell script. If a user launches `flutter` from a regular Cmd prompt, `flutter.bat` is invoked directly. 

Partial fix for https://github.com/flutter/flutter/issues/7824.