### PR TITLE
Create and use a STILL_RECORDING shutdown stage

### DIFF
--- a/packages/flutter_tools/lib/src/application_package.dart
+++ b/packages/flutter_tools/lib/src/application_package.dart
@@ -147,7 +147,9 @@ abstract class IOSApp extends ApplicationPackage {
     Directory bundleDir;
     try {
       final Directory tempDir = fs.systemTempDirectory.createTempSync('flutter_app_');
-      addShutdownHook(() async => await tempDir.delete(recursive: true));
+      addShutdownHook(() async {
+        await tempDir.delete(recursive: true);
+      }, ShutdownStage.STILL_RECORDING);
       os.unzip(fs.file(applicationBinary), tempDir);
       final Directory payloadDir = fs.directory(fs.path.join(tempDir.path, 'Payload'));
       bundleDir = payloadDir.listSync().singleWhere(_isBundleDirectory);

--- a/packages/flutter_tools/lib/src/base/process.dart
+++ b/packages/flutter_tools/lib/src/base/process.dart
@@ -26,17 +26,21 @@ class ShutdownStage implements Comparable<ShutdownStage> {
   /// The stage priority. Smaller values will be run before larger values.
   final int _priority;
 
+  /// The stage before the invocation recording (if one exists) is serialized
+  /// to disk. Tasks performed during this stage *will* be recorded.
+  static const ShutdownStage STILL_RECORDING = const ShutdownStage._(1);
+
   /// The stage during which the invocation recording (if one exists) will be
   /// serialized to disk. Invocations performed after this stage will not be
   /// recorded.
-  static const ShutdownStage SERIALIZE_RECORDING = const ShutdownStage._(1);
+  static const ShutdownStage SERIALIZE_RECORDING = const ShutdownStage._(2);
 
   /// The stage during which a serialized recording will be refined (e.g.
   /// cleansed for tests, zipped up for bug reporting purposes, etc.).
-  static const ShutdownStage POST_PROCESS_RECORDING = const ShutdownStage._(2);
+  static const ShutdownStage POST_PROCESS_RECORDING = const ShutdownStage._(3);
 
   /// The stage during which temporary files and directories will be deleted.
-  static const ShutdownStage CLEANUP = const ShutdownStage._(3);
+  static const ShutdownStage CLEANUP = const ShutdownStage._(4);
 
   @override
   int compareTo(ShutdownStage other) => _priority.compareTo(other._priority);


### PR DESCRIPTION
This unblocks work being done towards record/replay tests.