### PR TITLE
Update flutter_tools test utils to prepare for record/replay tests

### DIFF
--- a/packages/flutter_tools/test/src/common.dart
+++ b/packages/flutter_tools/test/src/common.dart
@@ -7,6 +7,7 @@ import 'package:test/test.dart';
 
 import 'package:flutter_tools/src/base/common.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
+import 'package:flutter_tools/src/base/process.dart';
 import 'package:flutter_tools/src/runner/flutter_command.dart';
 import 'package:flutter_tools/src/runner/flutter_command_runner.dart';
 
@@ -25,7 +26,7 @@ void updateFileModificationTime(String path,
   fs.file(path).setLastModifiedSync(modificationTime);
 }
 
-/// Matcher for functions that throw ToolExit.
+/// Matcher for functions that throw [ToolExit].
 Matcher throwsToolExit([int exitCode]) {
   return exitCode == null
     ? throwsA(isToolExit)
@@ -34,3 +35,13 @@ Matcher throwsToolExit([int exitCode]) {
 
 /// Matcher for [ToolExit]s.
 const Matcher isToolExit = const isInstanceOf<ToolExit>();
+
+/// Matcher for functions that throw [ProcessExit].
+Matcher throwsProcessExit([dynamic exitCode]) {
+  return exitCode == null
+      ? throwsA(isProcessExit)
+      : throwsA(allOf(isProcessExit, (ProcessExit e) => e.exitCode == exitCode));
+}
+
+/// Matcher for [ProcessExit]s.
+const Matcher isProcessExit = const isInstanceOf<ProcessExit>();

--- a/packages/flutter_tools/test/src/context.dart
+++ b/packages/flutter_tools/test/src/context.dart
@@ -106,15 +106,15 @@ String getFlutterRoot() {
   String toolsPath;
   switch (platform.script.scheme) {
     case 'file':
-      List<String> parts = fs.path.split(fs.path.fromUri(platform.script));
-      int toolsIndex = parts.indexOf('flutter_tools');
+      final List<String> parts = fs.path.split(fs.path.fromUri(platform.script));
+      final int toolsIndex = parts.indexOf('flutter_tools');
       if (toolsIndex == -1)
         throw invalidScript();
       toolsPath = fs.path.joinAll(parts.sublist(0, toolsIndex + 1));
       break;
     case 'data':
-      RegExp flutterTools = new RegExp(r'(file://[^%]*[/\\]flutter_tools)');
-      Match match = flutterTools.firstMatch(platform.script.path);
+      final RegExp flutterTools = new RegExp(r'(file://[^%]*[/\\]flutter_tools)');
+      final Match match = flutterTools.firstMatch(platform.script.path);
       if (match == null)
         throw invalidScript();
       toolsPath = Uri.parse(match.group(1)).path;


### PR DESCRIPTION
1. Add matchers for the `ProcessExit` exception class
2. Add ability to control the setup of the `AppContext` we use in
   `testUsingContext()`
3. Clean up the code that figures out the location of `Cache.flutterRoot`
   such that it works with `pub run test`. It previously only worked
   when the tests were invoked with standalone `dart`

`#3` above will also help unblock #7941