### PR TITLE
apply upcoming rule: unnecessary_lambdas

### DIFF
--- a/dev/benchmarks/complex_layout/lib/main.dart
+++ b/dev/benchmarks/complex_layout/lib/main.dart
@@ -611,7 +611,7 @@ class GalleryDrawer extends StatelessWidget {
           new DrawerItem(
             icon: new Icon(Icons.hourglass_empty),
             selected: timeDilation != 1.0,
-            onPressed: () { ComplexLayoutApp.of(context).toggleAnimationSpeed(); },
+            onPressed: ComplexLayoutApp.of(context).toggleAnimationSpeed,
             child: new Row(
               children: <Widget>[
                 new Expanded(child: new Text('Animate Slowly')),

--- a/examples/flutter_gallery/lib/demo/calculator/home.dart
+++ b/examples/flutter_gallery/lib/demo/calculator/home.dart
@@ -106,9 +106,7 @@ class _CalculatorState extends State<Calculator> {
   }
 
   void handleDelTap() {
-    setState(() {
-      popCalcExpression();
-    });
+    setState(popCalcExpression);
   }
 
   @override

--- a/examples/flutter_gallery/lib/demo/material/drawer_demo.dart
+++ b/examples/flutter_gallery/lib/demo/material/drawer_demo.dart
@@ -155,9 +155,7 @@ class _DrawerDemoState extends State<DrawerDemo> with TickerProviderStateMixin {
       ),
       body: new Center(
         child: new InkWell(
-          onTap: () {
-            _scaffoldKey.currentState.openDrawer();
-          },
+          onTap: _scaffoldKey.currentState.openDrawer,
           child: new Column(
             mainAxisSize: MainAxisSize.min,
             children: <Widget>[

--- a/examples/flutter_gallery/lib/demo/material/overscroll_demo.dart
+++ b/examples/flutter_gallery/lib/demo/material/overscroll_demo.dart
@@ -32,9 +32,7 @@ class OverscrollDemoState extends State<OverscrollDemo> {
          content: new Text("Refresh complete"),
          action: new SnackBarAction(
            label: 'RETRY',
-           onPressed: () {
-             _refreshIndicatorKey.currentState.show();
-           }
+           onPressed: _refreshIndicatorKey.currentState.show
          )
        ));
     });
@@ -50,9 +48,7 @@ class OverscrollDemoState extends State<OverscrollDemo> {
           new IconButton(
             icon: new Icon(Icons.refresh),
             tooltip: 'Refresh',
-            onPressed: () {
-              _refreshIndicatorKey.currentState.show();
-            }
+            onPressed: _refreshIndicatorKey.currentState.show
           ),
         ]
       ),

--- a/examples/flutter_gallery/lib/demo/shrine/shrine_page.dart
+++ b/examples/flutter_gallery/lib/demo/shrine/shrine_page.dart
@@ -108,9 +108,7 @@ class ShrinePageState extends State<ShrinePage> {
           new IconButton(
             icon: new Icon(Icons.shopping_cart),
             tooltip: 'Shopping cart',
-            onPressed: () {
-              _showShoppingCart();
-            }
+            onPressed: _showShoppingCart
           ),
           new PopupMenuButton<ShrineAction>(
             itemBuilder: (BuildContext context) => <PopupMenuItem<ShrineAction>>[

--- a/examples/stocks/lib/stock_home.dart
+++ b/examples/stocks/lib/stock_home.dart
@@ -24,7 +24,7 @@ class _NotImplementedDialog extends StatelessWidget {
       content: new Text('This feature has not yet been implemented.'),
       actions: <Widget>[
         new FlatButton(
-          onPressed: () { debugDumpApp(); },
+          onPressed: debugDumpApp,
           child: new Row(
             children: <Widget>[
               new Icon(

--- a/examples/stocks/lib/stock_settings.dart
+++ b/examples/stocks/lib/stock_settings.dart
@@ -105,7 +105,7 @@ class StockSettingsState extends State<StockSettings> {
     final List<Widget> rows = <Widget>[
       new DrawerItem(
         icon: new Icon(Icons.thumb_up),
-        onPressed: () => _confirmOptimismChange(),
+        onPressed: _confirmOptimismChange,
         child: new Row(
           children: <Widget>[
             new Expanded(child: new Text('Everything is awesome')),

--- a/packages/flutter/lib/src/gestures/multitap.dart
+++ b/packages/flutter/lib/src/gestures/multitap.dart
@@ -207,7 +207,7 @@ class DoubleTapGestureRecognizer extends GestureRecognizer {
   }
 
   void _startDoubleTapTimer() {
-    _doubleTapTimer ??= new Timer(kDoubleTapTimeout, () => _reset());
+    _doubleTapTimer ??= new Timer(kDoubleTapTimeout, _reset);
   }
 
   void _stopDoubleTapTimer() {

--- a/packages/flutter/lib/src/material/back_button.dart
+++ b/packages/flutter/lib/src/material/back_button.dart
@@ -52,9 +52,7 @@ class BackButton extends StatelessWidget {
     return new IconButton(
       icon: new Icon(getIconData(Theme.of(context).platform)),
       tooltip: 'Back', // TODO(ianh): Figure out how to localize this string
-      onPressed: () {
-        Navigator.of(context).maybePop();
-      },
+      onPressed: Navigator.of(context).maybePop,
     );
   }
 }

--- a/packages/flutter/lib/src/material/date_picker.dart
+++ b/packages/flutter/lib/src/material/date_picker.dart
@@ -392,9 +392,7 @@ class _MonthPickerState extends State<MonthPicker> {
     if (_timer != null)
       _timer.cancel();
     _timer = new Timer(timeUntilTomorrow, () {
-      setState(() {
-        _updateCurrentDate();
-      });
+      setState(_updateCurrentDate);
     });
   }
 

--- a/packages/flutter/lib/src/material/input.dart
+++ b/packages/flutter/lib/src/material/input.dart
@@ -127,9 +127,7 @@ class _InputFieldState extends State<InputField> {
       new GestureDetector(
         key: focusKey == _focusKey ? _focusKey : null,
         behavior: HitTestBehavior.opaque,
-        onTap: () {
-          requestKeyboard();
-        },
+        onTap: requestKeyboard,
         // Since the focusKey may have been created here, defer building the
         // EditableText until the focusKey's context has been set. This is
         // necessary because the EditableText will check the focus, like

--- a/packages/flutter/lib/src/material/scaffold.dart
+++ b/packages/flutter/lib/src/material/scaffold.dart
@@ -561,9 +561,7 @@ class ScaffoldState extends State<Scaffold> with TickerProviderStateMixin {
     switch (status) {
       case AnimationStatus.dismissed:
         assert(_snackBars.isNotEmpty);
-        setState(() {
-          _snackBars.removeFirst();
-        });
+        setState(_snackBars.removeFirst);
         if (_snackBars.isNotEmpty)
           _snackBarController.forward();
         break;

--- a/packages/flutter/lib/src/widgets/dismissable.dart
+++ b/packages/flutter/lib/src/widgets/dismissable.dart
@@ -226,9 +226,7 @@ class _DismissableState extends State<Dismissable> with TickerProviderStateMixin
       _dragExtent = 0.0;
       _moveController.value = 0.0;
     }
-    setState(() {
-      _updateMoveAnimation();
-    });
+    setState(_updateMoveAnimation);
   }
 
   void _handleDragUpdate(DragUpdateDetails details) {
@@ -256,9 +254,7 @@ class _DismissableState extends State<Dismissable> with TickerProviderStateMixin
         break;
     }
     if (oldDragExtent.sign != _dragExtent.sign) {
-      setState(() {
-        _updateMoveAnimation();
-      });
+      setState(_updateMoveAnimation);
     }
     if (!_moveController.isAnimating) {
       _moveController.value = _dragExtent.abs() / _overallDragAxisExtent;

--- a/packages/flutter/lib/src/widgets/form.dart
+++ b/packages/flutter/lib/src/widgets/form.dart
@@ -255,9 +255,7 @@ class FormFieldState<T> extends State<FormField<T>> {
   /// Calls [FormField.validator] to set the [errorText]. Returns true if there
   /// were no errors.
   bool validate() {
-    setState(() {
-      _validate();
-    });
+    setState(_validate);
     return !hasError;
   }
 

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -1859,9 +1859,7 @@ class BuildOwner {
   void finalizeTree() {
     Timeline.startSync('Finalize tree');
     try {
-      lockState(() {
-        _inactiveElements._unmountAll();
-      });
+      lockState(_inactiveElements._unmountAll);
       assert(GlobalKey._debugCheckForDuplicates);
       scheduleMicrotask(GlobalKey._notifyListeners);
     } catch (e, stack) {

--- a/packages/flutter/test/foundation/change_notifier_test.dart
+++ b/packages/flutter/test/foundation/change_notifier_test.dart
@@ -187,8 +187,8 @@ void main() {
     source.dispose();
     expect(() { source.addListener(null); }, throwsFlutterError);
     expect(() { source.removeListener(null); }, throwsFlutterError);
-    expect(() { source.dispose(); }, throwsFlutterError);
-    expect(() { source.notify(); }, throwsFlutterError);
+    expect(source.dispose, throwsFlutterError);
+    expect(source.notify, throwsFlutterError);
   });
 
   test('Value notifier', () {

--- a/packages/flutter/test/foundation/service_extensions_test.dart
+++ b/packages/flutter/test/foundation/service_extensions_test.dart
@@ -58,9 +58,7 @@ class TestServiceExtensionsBinding extends BindingBase
 
   Future<Null> flushMicrotasks() {
     final Completer<Null> completer = new Completer<Null>();
-    new Timer(const Duration(), () {
-      completer.complete();
-    });
+    new Timer(const Duration(), completer.complete);
     return completer.future;
   }
 }

--- a/packages/flutter_driver/lib/src/extension.dart
+++ b/packages/flutter_driver/lib/src/extension.dart
@@ -171,7 +171,7 @@ class FlutterDriverExtension {
     if (_frameSync)
       await _waitUntilFrame(() => SchedulerBinding.instance.transientCallbackCount == 0);
 
-    await _waitUntilFrame(() => finder.precache());
+    await _waitUntilFrame(finder.precache);
 
     if (_frameSync)
       await _waitUntilFrame(() => SchedulerBinding.instance.transientCallbackCount == 0);

--- a/packages/flutter_test/lib/src/widget_tester.dart
+++ b/packages/flutter_test/lib/src/widget_tester.dart
@@ -351,7 +351,7 @@ class WidgetTester extends WidgetController implements HitTestDispatcher, Ticker
   /// Does not run timers. May result in an infinite loop or run out of memory
   /// if microtasks continue to recursively schedule new microtasks.
   Future<Null> idle() {
-    return TestAsyncUtils.guard(() => binding.idle());
+    return TestAsyncUtils.guard(binding.idle);
   }
 
   Set<Ticker> _tickers;

--- a/packages/flutter_tools/lib/executable.dart
+++ b/packages/flutter_tools/lib/executable.dart
@@ -281,7 +281,7 @@ Future<String> _doctorText() async {
 
     appContext.setVariable(Logger, logger);
 
-    await appContext.runInZone(() => doctor.diagnose());
+    await appContext.runInZone(doctor.diagnose);
 
     return logger.statusText;
   } catch (error, trace) {

--- a/packages/flutter_tools/lib/src/cache.dart
+++ b/packages/flutter_tools/lib/src/cache.dart
@@ -231,9 +231,7 @@ class MaterialFonts {
     ).then<Null>((Null value) {
       cache.setStampFor(kName, cache.getVersionFor(kName));
       status.stop();
-    }).whenComplete(() {
-      status.cancel();
-    });
+    }).whenComplete(status.cancel);
   }
 }
 
@@ -376,8 +374,6 @@ class FlutterEngine {
     final Status status = logger.startProgress(message, expectSlowOperation: true);
     return Cache._downloadFileToCache(Uri.parse(url), dest, true).then<Null>((Null value) {
       status.stop();
-    }).whenComplete(() {
-      status.cancel();
-    });
+    }).whenComplete(status.cancel);
   }
 }

--- a/packages/flutter_tools/lib/src/commands/daemon.dart
+++ b/packages/flutter_tools/lib/src/commands/daemon.dart
@@ -264,7 +264,7 @@ class DaemonDomain extends Domain {
   }
 
   Future<Null> shutdown(Map<String, dynamic> args) {
-    Timer.run(() => daemon.shutdown());
+    Timer.run(daemon.shutdown);
     return new Future<Null>.value();
   }
 

--- a/packages/flutter_tools/lib/src/crash_reporting.dart
+++ b/packages/flutter_tools/lib/src/crash_reporting.dart
@@ -385,7 +385,7 @@ Future<Null> writeStreamToSink<O, I extends O>(Stream<I> stream, EventSink<O> si
   final Completer<Null> completer = new Completer<Null>();
   stream.listen(sink.add,
       onError: sink.addError,
-      onDone: () => completer.complete());
+      onDone: completer.complete);
   return completer.future;
 }
 

--- a/packages/flutter_tools/lib/src/ios/simulators.dart
+++ b/packages/flutter_tools/lib/src/ios/simulators.dart
@@ -609,9 +609,7 @@ class _IOSSimulatorLogReader extends DeviceLogReader {
 
   _IOSSimulatorLogReader(this.device, ApplicationPackage app) {
     _linesController = new StreamController<String>.broadcast(
-      onListen: () {
-        _start();
-      },
+      onListen: _start,
       onCancel: _stop
     );
     _appName = app == null ? null : app.name.replaceAll('.app', '');

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -228,9 +228,7 @@ abstract class ResidentRunner {
       throwToolExit('No Flutter view is available');
 
     // Listen for service protocol connection to close.
-    vmService.done.whenComplete(() {
-      appFinished();
-    });
+    vmService.done.whenComplete(appFinished);
   }
 
   /// Returns [true] if the input has been handled by this function.

--- a/packages/flutter_tools/lib/src/runner/flutter_command_runner.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command_runner.dart
@@ -250,7 +250,7 @@ class FlutterCommandRunner extends CommandRunner<Null> {
     }
 
     // The Android SDK could already have been set by tests.
-    context.putIfAbsent(AndroidSdk, () => AndroidSdk.locateAndroidSdk());
+    context.putIfAbsent(AndroidSdk, AndroidSdk.locateAndroidSdk);
 
     if (globalResults['version']) {
       flutterUsage.sendCommand('version');

--- a/packages/flutter_tools/lib/src/test/flutter_platform.dart
+++ b/packages/flutter_tools/lib/src/test/flutter_platform.dart
@@ -222,7 +222,7 @@ class _FlutterPlatform extends PlatformPlugin {
           processObservatoryPort = detectedPort;
         },
         startTimeoutTimer: () {
-          new Future<_InitialResult>.delayed(_kTestStartupTimeout, () => timeout.complete());
+          new Future<_InitialResult>.delayed(_kTestStartupTimeout, timeout.complete);
         },
       );
 
@@ -265,7 +265,7 @@ class _FlutterPlatform extends PlatformPlugin {
           final Completer<Null> harnessDone = new Completer<Null>();
           final StreamSubscription<dynamic> harnessToTest = controller.stream.listen(
             (dynamic event) { testSocket.add(JSON.encode(event)); },
-            onDone: () { harnessDone.complete(); },
+            onDone: harnessDone.complete,
             onError: (dynamic error, dynamic stack) {
               // If you reach here, it's unlikely we're going to be able to really handle this well.
               printError('test harness controller stream experienced an unexpected error\ntest: $testPath\nerror: $error');
@@ -285,7 +285,7 @@ class _FlutterPlatform extends PlatformPlugin {
               assert(encodedEvent is String); // we shouldn't ever get binary messages
               controller.sink.add(JSON.decode(encodedEvent));
             },
-            onDone: () { testDone.complete(); },
+            onDone: testDone.complete,
             onError: (dynamic error, dynamic stack) {
               // If you reach here, it's unlikely we're going to be able to really handle this well.
               printError('test socket stream experienced an unexpected error\ntest: $testPath\nerror: $error');

--- a/packages/flutter_tools/lib/src/vmservice_record_replay.dart
+++ b/packages/flutter_tools/lib/src/vmservice_record_replay.dart
@@ -161,9 +161,7 @@ class _RecordingStream {
         // We currently don't support recording of errors.
         _controller.addError(error, stackTrace);
       },
-      onDone: () {
-        _controller.close();
-      },
+      onDone: _controller.close,
     );
   }
 

--- a/packages/flutter_tools/test/drive_test.dart
+++ b/packages/flutter_tools/test/drive_test.dart
@@ -243,7 +243,7 @@ void main() {
         expect(device.name, 'mock-simulator');
       }, overrides: <Type, Generator>{
         FileSystem: () => fs,
-        Platform: () => macOsPlatform(),
+        Platform: macOsPlatform,
       });
 
       testUsingContext('uses existing Android device if and there are no simulators', () async {
@@ -256,7 +256,7 @@ void main() {
         expect(device.name, 'mock-android-device');
       }, overrides: <Type, Generator>{
         FileSystem: () => fs,
-        Platform: () => macOsPlatform(),
+        Platform: macOsPlatform,
       });
 
       testUsingContext('launches emulator', () async {
@@ -270,7 +270,7 @@ void main() {
         expect(device.name, 'new-simulator');
       }, overrides: <Type, Generator>{
         FileSystem: () => fs,
-        Platform: () => macOsPlatform(),
+        Platform: macOsPlatform,
       });
     });
 
@@ -283,7 +283,7 @@ void main() {
         expect(await findTargetDevice(), isNull);
       }, overrides: <Type, Generator>{
         FileSystem: () => fs,
-        Platform: () => platform(),
+        Platform: platform,
       });
 
       testUsingContext('uses existing Android device', () async {
@@ -295,7 +295,7 @@ void main() {
         expect(device.name, 'mock-android-device');
       }, overrides: <Type, Generator>{
         FileSystem: () => fs,
-        Platform: () => platform(),
+        Platform: platform,
       });
     }
 


### PR DESCRIPTION
[DON’T create a lambda when a tear-off will do.](https://www.dartlang.org/guides/language/effective-dart/usage#dont-create-a-lambda-when-a-tear-off-will-do)

(not sure this improves the readability of `setState` functions) 