### PR TITLE
Update Xcode projects to 8.2.0

### DIFF
--- a/packages/flutter_tools/templates/create/ios.tmpl/Pods/Pods.xcodeproj/project.pbxproj
+++ b/packages/flutter_tools/templates/create/ios.tmpl/Pods/Pods.xcodeproj/project.pbxproj
@@ -118,8 +118,8 @@
 		D41D8CD98F00B204E9800998ECF8427E /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastSwiftUpdateCheck = 0730;
-				LastUpgradeCheck = 0700;
+				LastSwiftUpdateCheck = 0820;
+				LastUpgradeCheck = 0820;
 			};
 			buildConfigurationList = 2D8E8EC45A3A1A1D94AE762CB5028504 /* Build configuration list for PBXProject "Pods" */;
 			compatibilityVersion = "Xcode 3.2";

--- a/packages/flutter_tools/templates/create/ios.tmpl/Pods/Pods.xcodeproj/xcshareddata/xcschemes/Pods-Runner.xcscheme
+++ b/packages/flutter_tools/templates/create/ios.tmpl/Pods/Pods.xcodeproj/xcshareddata/xcschemes/Pods-Runner.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0730"
+   LastUpgradeVersion = "0820"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/packages/flutter_tools/templates/create/ios.tmpl/Runner.xcodeproj/project.pbxproj.tmpl
+++ b/packages/flutter_tools/templates/create/ios.tmpl/Runner.xcodeproj/project.pbxproj.tmpl
@@ -168,7 +168,7 @@
 		97C146E61CF9000F007C117D /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0800;
+				LastUpgradeCheck = 0820;
 				ORGANIZATIONNAME = "The Chromium Authors";
 				TargetAttributes = {
 					97C146ED1CF9000F007C117D = {

--- a/packages/flutter_tools/templates/create/ios.tmpl/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/packages/flutter_tools/templates/create/ios.tmpl/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0730"
+   LastUpgradeVersion = "0820"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"


### PR DESCRIPTION
This prevents project re-validation on initial Xcode launch.