### PR TITLE
Faster hot reload

### DIFF
--- a/packages/flutter_tools/lib/src/dart/package_map.dart
+++ b/packages/flutter_tools/lib/src/dart/package_map.dart
@@ -40,13 +40,16 @@ class PackageMap {
   Map<String, Uri> _map;
 
   /// Returns the path to [packageUri].
-  String pathForPackage(Uri packageUri) {
+  String pathForPackage(Uri packageUri) => uriForPackage(packageUri).path;
+
+  /// Returns the path to [packageUri] as Uri.
+  Uri uriForPackage(Uri packageUri) {
     assert(packageUri.scheme == 'package');
     final List<String> pathSegments = packageUri.pathSegments.toList();
     final String packageName = pathSegments.removeAt(0);
     final Uri packageBase = map[packageName];
     final String packageRelativePath = fs.path.joinAll(pathSegments);
-    return packageBase.resolve(packageRelativePath).path;
+    return packageBase.resolveUri(fs.path.toUri(packageRelativePath));
   }
 
   String checkValid() {

--- a/packages/flutter_tools/lib/src/dependency_checker.dart
+++ b/packages/flutter_tools/lib/src/dependency_checker.dart
@@ -17,12 +17,6 @@ class DependencyChecker {
   /// if it cannot be determined.
   bool check(DateTime threshold) {
     _dependencies.clear();
-    try {
-      _dependencies.add(builder.packagesFilePath);
-    } catch (e, st) {
-      printTrace('DependencyChecker: could not parse .packages file:\n$e\n$st');
-      return true;
-    }
     // Build the set of Dart dependencies.
     try {
       _dependencies.addAll(builder.build());

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -330,8 +330,7 @@ abstract class ResidentRunner {
 
   bool hasDirtyDependencies() {
     final DartDependencySetBuilder dartDependencySetBuilder =
-        new DartDependencySetBuilder(
-            mainPath, projectRootPath, packagesFilePath);
+        new DartDependencySetBuilder(mainPath, packagesFilePath);
     final DependencyChecker dependencyChecker =
         new DependencyChecker(dartDependencySetBuilder, assetBundle);
     final String path = package.packagePath;

--- a/packages/flutter_tools/lib/src/run_hot.dart
+++ b/packages/flutter_tools/lib/src/run_hot.dart
@@ -99,8 +99,7 @@ class HotRunner extends ResidentRunner {
       return true;
     }
     final DartDependencySetBuilder dartDependencySetBuilder =
-        new DartDependencySetBuilder(
-              mainPath, projectRootPath, packagesFilePath);
+        new DartDependencySetBuilder(mainPath, packagesFilePath);
     try {
       _dartDependencies = new Set<String>.from(dartDependencySetBuilder.build());
     } catch (error) {

--- a/packages/flutter_tools/test/dart_dependencies_test.dart
+++ b/packages/flutter_tools/test/dart_dependencies_test.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:analyzer/analyzer.dart';
 import 'package:flutter_tools/src/dart/dependencies.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/platform.dart';
@@ -17,7 +18,7 @@ void main()  {
       final String mainPath = fs.path.join(testPath, 'main.dart');
       final String packagesPath = fs.path.join(testPath, '.packages');
       final DartDependencySetBuilder builder =
-          new DartDependencySetBuilder(mainPath, testPath, packagesPath);
+          new DartDependencySetBuilder(mainPath, packagesPath);
       final Set<String> dependencies = builder.build();
       expect(dependencies.contains(fs.path.canonicalize(mainPath)), isTrue);
       expect(dependencies.contains(fs.path.canonicalize(fs.path.join(testPath, 'foo.dart'))), isTrue);
@@ -27,13 +28,12 @@ void main()  {
       final String mainPath = fs.path.join(testPath, 'main.dart');
       final String packagesPath = fs.path.join(testPath, '.packages');
       final DartDependencySetBuilder builder =
-          new DartDependencySetBuilder(mainPath, testPath, packagesPath);
+          new DartDependencySetBuilder(mainPath, packagesPath);
       try {
         builder.build();
         fail('expect an assertion to be thrown.');
-      } catch (e) {
-        expect(e, const isInstanceOf<String>());
-        expect(e.contains('unexpected token \'bad\''), isTrue);
+      } on AnalyzerErrorGroup catch (e) {
+        expect(e.toString(), contains('foo.dart: Expected a string literal'));
       }
     });
   });

--- a/packages/flutter_tools/test/data/dart_dependencies_test/syntax_error/foo.dart
+++ b/packages/flutter_tools/test/data/dart_dependencies_test/syntax_error/foo.dart
@@ -2,4 +2,4 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-bad programmer!
+import bad programmer!

--- a/packages/flutter_tools/test/dependency_checker_test.dart
+++ b/packages/flutter_tools/test/dependency_checker_test.dart
@@ -31,7 +31,7 @@ void main()  {
       final String barPath = fs.path.join(testPath, 'lib', 'bar.dart');
       final String packagesPath = fs.path.join(testPath, '.packages');
       final DartDependencySetBuilder builder =
-          new DartDependencySetBuilder(mainPath, testPath, packagesPath);
+          new DartDependencySetBuilder(mainPath, packagesPath);
       final DependencyChecker dependencyChecker =
           new DependencyChecker(builder, null);
 
@@ -63,7 +63,7 @@ void main()  {
       final String packagesPath = fs.path.join(testPath, '.packages');
 
       final DartDependencySetBuilder builder =
-          new DartDependencySetBuilder(mainPath, testPath, packagesPath);
+          new DartDependencySetBuilder(mainPath, packagesPath);
       final DependencyChecker dependencyChecker =
           new DependencyChecker(builder, null);
 


### PR DESCRIPTION
This implements the `DartDependencySetBuilder` completely in Dart instead of calling out to `sky_snapshot` (Linux/Mac) or `gen_snapshot` (Windows) and allows us to use the same code path on all supported host platforms.

It also slightly reduces hot reload times on Linux from ~750ms to ~690ms for the unchanged flutter_gallery app and significantly reduces hot reload times on Windows from almost 1.5s to just slightly slower than on Linux.

This change will also allow us to retire `sky_snapshot` completely in the future.