### PR TITLE
Clean up crash reporting code

### DIFF
--- a/packages/flutter_tools/lib/src/crash_reporting.dart
+++ b/packages/flutter_tools/lib/src/crash_reporting.dart
@@ -37,18 +37,19 @@ String _kStackTraceFileField = 'DartError';
 /// it must be supplied in the request.
 String _kStackTraceFilename = 'stacktrace_file';
 
+/// We only send crash reports in testing mode.
+///
+/// See [enterTestingMode] and [exitTestingMode].
 bool _testing = false;
 
 /// Sends crash reports to Google.
 class CrashReportSender {
-  static final Uri _defaultBaseUri = new Uri(
+  static final Uri _baseUri = new Uri(
       scheme: 'https',
       host: _kCrashServerHost,
       port: 443,
       path: _kCrashEndpointPath,
   );
-
-  static Uri _baseUri = _defaultBaseUri;
 
   static CrashReportSender _instance;
 
@@ -128,19 +129,15 @@ class CrashReportSender {
   }
 }
 
-/// Overrides [CrashReportSender._baseUri] for testing and enables testing
-/// mode.
+/// Enables testing mode.
 @visibleForTesting
-void overrideBaseCrashUrlForTesting(Uri uri) {
-  CrashReportSender._baseUri = uri;
+void enterTestingMode() {
   _testing = true;
 }
 
-/// Resets [CrashReportSender._baseUri] back to the original value and disables
-/// test mode.
+/// Disables testing mode.
 @visibleForTesting
-void resetBaseCrashUrlForTesting() {
-  CrashReportSender._baseUri = CrashReportSender._defaultBaseUri;
+void exitTestingMode() {
   _testing = false;
 }
 

--- a/packages/flutter_tools/test/crash_reporting_test.dart
+++ b/packages/flutter_tools/test/crash_reporting_test.dart
@@ -15,26 +15,22 @@ import 'package:flutter_tools/executable.dart' as tools;
 import 'package:flutter_tools/src/base/context.dart';
 import 'package:flutter_tools/src/base/io.dart';
 import 'package:flutter_tools/src/base/logger.dart';
-import 'package:flutter_tools/src/base/os.dart' as os;
 import 'package:flutter_tools/src/crash_reporting.dart';
 import 'package:flutter_tools/src/runner/flutter_command.dart';
 import 'src/context.dart';
 
 void main() {
   group('crash reporting', () {
-    int testPort;
-
     setUp(() async {
       tools.crashFileSystem = new MemoryFileSystem();
       setExitFunctionForTests((_) { });
-      testPort = await os.findAvailablePort();
-      overrideBaseCrashUrlForTesting(Uri.parse('http://localhost:$testPort/test-path'));
+      enterTestingMode();
     });
 
     tearDown(() {
       tools.crashFileSystem = new LocalFileSystem();
       restoreExitFunction();
-      resetBaseCrashUrlForTesting();
+      exitTestingMode();
     });
 
     testUsingContext('should send crash reports', () async {
@@ -62,10 +58,10 @@ void main() {
       // Verify that we sent the crash report.
       expect(method, 'POST');
       expect(uri, new Uri(
-        scheme: 'http',
-        host: 'localhost',
-        port: testPort,
-        path: '/test-path',
+        scheme: 'https',
+        host: 'clients2.google.com',
+        port: 443,
+        path: '/cr/staging_report',
         queryParameters: <String, String>{
           'product': 'Flutter_Tools',
           'version' : 'test-version',


### PR DESCRIPTION
Remove the superfluous base URI overloading and port searching since we mock out the HTTP client entirely.
