### PR TITLE
Run 'pod install' before building iOS app.

### DIFF
--- a/packages/flutter_tools/lib/src/base/process.dart
+++ b/packages/flutter_tools/lib/src/base/process.dart
@@ -211,6 +211,7 @@ String runCheckedSync(List<String> cmd, {
   String workingDirectory,
   bool allowReentrantFlutter: false,
   bool hideStdout: false,
+  Map<String, String> environment,
 }) {
   return _runWithLoggingSync(
     cmd,
@@ -219,6 +220,7 @@ String runCheckedSync(List<String> cmd, {
     hideStdout: hideStdout,
     checked: true,
     noisyErrors: true,
+    environment: environment,
   );
 }
 
@@ -259,12 +261,13 @@ String _runWithLoggingSync(List<String> cmd, {
   String workingDirectory,
   bool allowReentrantFlutter: false,
   bool hideStdout: false,
+  Map<String, String> environment,
 }) {
   _traceCommand(cmd, workingDirectory: workingDirectory);
   final ProcessResult results = processManager.runSync(
     cmd,
     workingDirectory: workingDirectory,
-    environment: _environment(allowReentrantFlutter),
+    environment: _environment(allowReentrantFlutter, environment),
   );
 
   printTrace('Exit code ${results.exitCode} from: ${cmd.join(' ')}');

--- a/packages/flutter_tools/lib/src/ios/ios_workflow.dart
+++ b/packages/flutter_tools/lib/src/ios/ios_workflow.dart
@@ -41,6 +41,10 @@ class IOSWorkflow extends DoctorValidator implements Workflow {
 
   bool get hasPythonSixModule => exitsHappy(<String>['python', '-c', 'import six']);
 
+  bool get hasCocoaPods => exitsHappy(<String>['pod', '--version']);
+
+  String get cocoaPodsVersionText => runSync(<String>['pod', '--version']).trim();
+
   bool get _iosDeployIsInstalledAndMeetsVersionCheck {
     if (!hasIosDeploy)
       return false;
@@ -58,6 +62,7 @@ class IOSWorkflow extends DoctorValidator implements Workflow {
     ValidationType xcodeStatus = ValidationType.missing;
     ValidationType pythonStatus = ValidationType.missing;
     ValidationType brewStatus = ValidationType.missing;
+    ValidationType podStatus = ValidationType.missing;
     String xcodeVersionInfo;
 
     if (xcode.isInstalled) {
@@ -160,8 +165,19 @@ class IOSWorkflow extends DoctorValidator implements Workflow {
       ));
     }
 
+    if (hasCocoaPods) {
+      podStatus = ValidationType.installed;
+      messages.add(new ValidationMessage('CocoaPods version $cocoaPodsVersionText'));
+    } else {
+      podStatus = ValidationType.missing;
+      messages.add(new ValidationMessage.error(
+        'CocoaPods not installed; this is used for iOS development.\n'
+        'Install by running: \'sudo gem install cocoapods\''
+      ));
+    }
+
     return new ValidationResult(
-      <ValidationType>[xcodeStatus, pythonStatus, brewStatus].reduce(_mergeValidationTypes),
+      <ValidationType>[xcodeStatus, pythonStatus, brewStatus, podStatus].reduce(_mergeValidationTypes),
       messages,
       statusInfo: xcodeVersionInfo
     );

--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -123,8 +123,10 @@ Future<XcodeBuildResult> buildXcodeProject({
 
   // Before the build, all service definitions must be updated and the dylibs
   // copied over to a location that is suitable for Xcodebuild to find them.
+  final Directory appDirectory = fs.directory(app.appDirectory);
+  await _addServicesToBundle(appDirectory);
 
-  await _addServicesToBundle(fs.directory(app.appDirectory));
+  _installCocoaPods(appDirectory, flutterFrameworkDir(mode));
 
   final List<String> commands = <String>[
     '/usr/bin/env',
@@ -313,6 +315,16 @@ bool _checkXcodeVersion() {
     return false;
   }
   return true;
+}
+
+void _installCocoaPods(Directory bundle, String engineDirectory)  {
+  if (fs.file(fs.path.join(bundle.path, 'Podfile')).existsSync()) {
+    runCheckedSync(
+        <String>['pod', 'install'],
+        workingDirectory: bundle.path,
+        environment: <String, String>{'FLUTTER_FRAMEWORK_DIR': engineDirectory},
+    );
+  }
 }
 
 Future<Null> _addServicesToBundle(Directory bundle) async {

--- a/packages/flutter_tools/lib/src/ios/xcodeproj.dart
+++ b/packages/flutter_tools/lib/src/ios/xcodeproj.dart
@@ -12,6 +12,10 @@ import '../globals.dart';
 final RegExp _settingExpr = new RegExp(r'(\w+)\s*=\s*(\S+)');
 final RegExp _varExpr = new RegExp(r'\$\((.*)\)');
 
+String flutterFrameworkDir(BuildMode mode) {
+  return fs.path.normalize(fs.path.dirname(artifacts.getArtifactPath(Artifact.flutterFramework, TargetPlatform.ios, mode)));
+}
+
 void updateXcodeGeneratedProperties(String projectPath, BuildMode mode, String target) {
   final StringBuffer localsBuffer = new StringBuffer();
 
@@ -34,8 +38,7 @@ void updateXcodeGeneratedProperties(String projectPath, BuildMode mode, String t
 
   localsBuffer.writeln('SYMROOT=\${SOURCE_ROOT}/../${getIosBuildDirectory()}');
 
-  final String flutterFrameworkDir = fs.path.normalize(fs.path.dirname(artifacts.getArtifactPath(Artifact.flutterFramework, TargetPlatform.ios, mode)));
-  localsBuffer.writeln('FLUTTER_FRAMEWORK_DIR=$flutterFrameworkDir');
+  localsBuffer.writeln('FLUTTER_FRAMEWORK_DIR=${flutterFrameworkDir(mode)}');
 
   if (artifacts is LocalEngineArtifacts) {
     final LocalEngineArtifacts localEngineArtifacts = artifacts;


### PR DESCRIPTION
Since iOS builds are CocoaPods enabled by default, we should make sure to run `pod install` to get pods wired up before building the app.

Also added a check to `flutter doctor` to verify CocoaPods is installed.

I'm passing FLUTTER_FRAMEWORK_DIR to the `pod install` command, so we can have the app's Podfile link in Flutter.framework as a pod instead of having to copy it over in xcode_backend.sh.

Fixes #8526