### PR TITLE
Minor fixes to SDK update PowerShell Script

### DIFF
--- a/bin/internal/update_dart_sdk.ps1
+++ b/bin/internal/update_dart_sdk.ps1
@@ -41,9 +41,9 @@ if (Test-Path $dartSdkPath) {
 New-Item $dartSdkPath -force -type directory | Out-Null
 $dartSdkZip = "$cachePath\dart-sdk.zip"
 
+Import-Module BitsTransfer
 Start-BitsTransfer -Source $dartSdkUrl -Destination $dartSdkZip
-Add-Type -assembly "system.io.compression.filesystem"
-[io.compression.zipfile]::ExtractToDirectory($dartSdkZip, $cachePath)
+Expand-Archive $dartSdkZip -DestinationPath $cachePath
 Remove-Item $dartSdkZip
 $dartSdkVersion | Out-File $dartSdkStampPath -Encoding ASCII
 


### PR DESCRIPTION
* import BitsTransfer before using it
* switch to PowerShell's build-in archive expander (instead of relying on .NET)

Addresses some of the problems in https://github.com/flutter/flutter/issues/8606.