### PR TITLE
Update CocoaPods install instructions to use Homebrew

### DIFF
--- a/packages/flutter_tools/lib/src/ios/ios_workflow.dart
+++ b/packages/flutter_tools/lib/src/ios/ios_workflow.dart
@@ -172,7 +172,7 @@ class IOSWorkflow extends DoctorValidator implements Workflow {
       podStatus = ValidationType.missing;
       messages.add(new ValidationMessage.error(
         'CocoaPods not installed; this is used for iOS development.\n'
-        'Install by running: \'sudo gem install cocoapods\''
+        'Install by running: \'brew install cocoapods\''
       ));
     }
 


### PR DESCRIPTION
This is consistent with the rest of the iOS toolchain.