### PR TITLE
Ensure compatibility with older PowerShell versions and better error handling

### DIFF
--- a/bin/flutter.bat
+++ b/bin/flutter.bat
@@ -29,11 +29,11 @@ SET dart=%dart_sdk_path%\bin\dart.exe
 SET pub=%dart_sdk_path%\bin\pub.bat
 
 REM Test if Git is available on the Host
-where /q git || ECHO Error: Unable to find git in your PATH. && EXIT /B 1
+where /q git || ECHO Error: Unable to find git in your PATH. && EXIT 1
 REM  Test if the flutter directory is a git clone, otherwise git rev-parse HEAD would fail
 IF NOT EXIST "%flutter_root%\.git" (
   ECHO Error: The Flutter directory is not a clone of the GitHub project.
-  EXIT /B 1
+  EXIT 1
 )
 
 REM Ensure that bin/cache exists.
@@ -80,6 +80,12 @@ GOTO :after_subroutine
   :do_sdk_update_and_snapshot
     ECHO Checking Dart SDK version...
     CALL PowerShell.exe -ExecutionPolicy Bypass -Command "& '%FLUTTER_ROOT%/bin/internal/update_dart_sdk.ps1'"
+    SET exit_code=%ERRORLEVEL%
+    IF %exit_code% NEQ 0 (
+      ECHO Error: Unable to update Dart SDK.
+      REM Do not use /B here, we want to exit out of the script, not just the subroutine
+      EXIT %exit_code%
+    )
 
   :do_snapshot
     ECHO: > "%cache_dir%\.dartignore"
@@ -105,4 +111,4 @@ IF /I "%exit_code%" EQU "253" (
   SET exit_code=%ERRORLEVEL%
 )
 
-EXIT /B %exit_code%
+EXIT %exit_code%

--- a/bin/flutter.ps1
+++ b/bin/flutter.ps1
@@ -5,6 +5,8 @@
 # This is a wrapper arround flutter.bat, which checks if the terminal supports
 # ANSI codes to work around https://github.com/dart-lang/sdk/issues/28614.
 
+$ErrorActionPreference = "Stop"
+
 Add-Type -MemberDefinition @"
 [DllImport("kernel32.dll", SetLastError=true)]
 public static extern bool SetConsoleMode(IntPtr hConsoleHandle, int mode);
@@ -26,5 +28,7 @@ If ($stdout -ne -1) {
     }
 }
 
-& $PSScriptRoot\flutter.bat $args
+# Cannot use $PSScriptRoot as that requires PowerShell 3 or newer
+$scriptRoot = Split-Path $MyInvocation.MyCommand.Path -Parent
+& $scriptRoot\flutter.bat $args
 exit $LastExitCode

--- a/bin/internal/update_dart_sdk.ps1
+++ b/bin/internal/update_dart_sdk.ps1
@@ -44,7 +44,16 @@ Import-Module BitsTransfer
 Start-BitsTransfer -Source $dartSdkUrl -Destination $dartSdkZip
 
 Write-Host "Unzipping Dart SDK..."
-Expand-Archive $dartSdkZip -DestinationPath $cachePath
+if (Get-Command Expand-Archive -errorAction SilentlyContinue) {
+    # Expand-Archive requires PowerShell 5 or newer
+    Expand-Archive $dartSdkZip -DestinationPath $cachePath
+} else {
+    $shell = New-Object -com shell.application
+    $zip = $shell.NameSpace($dartSdkZip)
+    foreach($item in $zip.items()) {
+        $shell.Namespace($cachePath).copyhere($item)
+    }
+}
 
 Remove-Item $dartSdkZip
 $dartSdkVersion | Out-File $dartSdkStampPath -Encoding ASCII


### PR DESCRIPTION
This should make our scripts compatible with PowerShell 2 or newer. PowerShell 2 was released in October 2009 and shipped with Windows 7 as default. (I suspect the scripts are now also compatible with PowerShell 1, but that's unconfirmed). This fixes #8606.

The PR also introduces better error handling when Flutter fail to download the Dart SDK to fix #8627.