### PR TITLE
Correct instructions for libimobiledevice install

### DIFF
--- a/packages/flutter_tools/lib/src/ios/ios_workflow.dart
+++ b/packages/flutter_tools/lib/src/ios/ios_workflow.dart
@@ -124,7 +124,9 @@ class IOSWorkflow extends DoctorValidator implements Workflow {
         brewStatus = ValidationType.partial;
         messages.add(new ValidationMessage.error(
           'ideviceinstaller not available; this is used to discover connected iOS devices.\n'
-          'Install via \'brew install ideviceinstaller\'.'
+          'To install, run:\n'
+          'brew install --HEAD libimobiledevice\n'
+          'brew install ideviceinstaller'
         ));
       }
 

--- a/packages/flutter_tools/lib/src/ios/ios_workflow.dart
+++ b/packages/flutter_tools/lib/src/ios/ios_workflow.dart
@@ -124,7 +124,7 @@ class IOSWorkflow extends DoctorValidator implements Workflow {
         brewStatus = ValidationType.partial;
         messages.add(new ValidationMessage.error(
           'ideviceinstaller not available; this is used to discover connected iOS devices.\n'
-          'Install via \'brew install ideviceinstaller\'.'
+          'Install via \'brew install --HEAD ideviceinstaller\'.'
         ));
       }
 
@@ -152,7 +152,7 @@ class IOSWorkflow extends DoctorValidator implements Workflow {
           brewStatus = ValidationType.partial;
           messages.add(new ValidationMessage.error(
             'libimobiledevice is incompatible with the installed Xcode version. To update, run:\n'
-            'brew uninstall libimobiledevice\n'
+            'brew uninstall --ignore-dependencies libimobiledevice\n'
             'brew install --HEAD libimobiledevice'
           ));
         }

--- a/packages/flutter_tools/lib/src/ios/ios_workflow.dart
+++ b/packages/flutter_tools/lib/src/ios/ios_workflow.dart
@@ -124,7 +124,7 @@ class IOSWorkflow extends DoctorValidator implements Workflow {
         brewStatus = ValidationType.partial;
         messages.add(new ValidationMessage.error(
           'ideviceinstaller not available; this is used to discover connected iOS devices.\n'
-          'Install via \'brew install --HEAD ideviceinstaller\'.'
+          'Install via \'brew install ideviceinstaller\'.'
         ));
       }
 


### PR DESCRIPTION
As of the latest Xcode versions, the latest published libimobiledevice
is out-of-date and build from HEAD is required.

This fixes two bugs:
1. Update initial install instructions to add --HEAD flag.
2. Update uninstall, reinstall instructions to include
   --ignore-dependencies flag, since other brew formulae depend on
   libimobiledevice.