### PR TITLE
Be explicit about typed_data deps

### DIFF
--- a/packages/flutter/pubspec.yaml
+++ b/packages/flutter/pubspec.yaml
@@ -9,6 +9,7 @@ dependencies:
   http: '>=0.11.3+11'
   intl: '>=0.14.0 <0.15.0'
   meta: ^1.0.4
+  typed_data: ^1.1.3
   vector_math: '>=2.0.3 <3.0.0'
 
   sky_engine:


### PR DESCRIPTION
It's used [here](https://github.com/flutter/flutter/blob/ddaba8992fbbed0f2f89ad0c099bdd54393c9a12/packages/flutter/lib/src/foundation/serialization.dart#L7), but not declared in our yaml file.