### PR TITLE
Flutter style guide: Prefer naming the argument to a setter 'value'

### DIFF
--- a/packages/flutter/lib/src/cupertino/slider.dart
+++ b/packages/flutter/lib/src/cupertino/slider.dart
@@ -225,10 +225,10 @@ class _RenderCupertinoSlider extends RenderConstrainedBox implements SemanticsAc
 
   int get divisions => _divisions;
   int _divisions;
-  set divisions(int newDivisions) {
-    if (newDivisions == _divisions)
+  set divisions(int value) {
+    if (value == _divisions)
       return;
-    _divisions = newDivisions;
+    _divisions = value;
     markNeedsPaint();
   }
 

--- a/packages/flutter/lib/src/material/slider.dart
+++ b/packages/flutter/lib/src/material/slider.dart
@@ -316,27 +316,27 @@ class _RenderSlider extends RenderConstrainedBox implements SemanticsActionHandl
 
   int get divisions => _divisions;
   int _divisions;
-  set divisions(int newDivisions) {
-    if (newDivisions == _divisions)
+  set divisions(int value) {
+    if (value == _divisions)
       return;
-    _divisions = newDivisions;
+    _divisions = value;
     markNeedsPaint();
   }
 
   String get label => _label;
   String _label;
-  set label(String newLabel) {
-    if (newLabel == _label)
+  set label(String value) {
+    if (value == _label)
       return;
-    _label = newLabel;
+    _label = value;
     additionalConstraints = _getAdditionalConstraints(_label);
-    if (newLabel != null) {
+    if (value != null) {
       // TODO(abarth): Handle textScaleFactor.
       // https://github.com/flutter/flutter/issues/5938
       _labelPainter
         ..text = new TextSpan(
           style: _textTheme.body1.copyWith(fontSize: 10.0),
-          text: newLabel
+          text: value
         )
         ..layout();
     } else {

--- a/packages/flutter/lib/src/material/tab_controller.dart
+++ b/packages/flutter/lib/src/material/tab_controller.dart
@@ -148,13 +148,13 @@ class TabController extends ChangeNotifier {
   /// TabBarView has been dragged to the left. Similarly a value between
   /// 0.0 and 1.0 implies that the TabBarView has been dragged to the right.
   double get offset => _animationController.value - _index.toDouble();
-  set offset(double newOffset) {
-    assert(newOffset != null);
-    assert(newOffset >= -1.0 && newOffset <= 1.0);
+  set offset(double value) {
+    assert(value != null);
+    assert(value >= -1.0 && value <= 1.0);
     assert(!indexIsChanging);
-    if (newOffset == offset)
+    if (value == offset)
       return;
-    _animationController.value = newOffset + _index.toDouble();
+    _animationController.value = value + _index.toDouble();
   }
 
   @override

--- a/packages/flutter/lib/src/physics/simulation_group.dart
+++ b/packages/flutter/lib/src/physics/simulation_group.dart
@@ -69,8 +69,8 @@ abstract class SimulationGroup extends Simulation {
   }
 
   @override
-  set tolerance(Tolerance t) {
-    currentSimulation.tolerance = t;
-    super.tolerance = t;
+  set tolerance(Tolerance value) {
+    currentSimulation.tolerance = value;
+    super.tolerance = value;
   }
 }

--- a/packages/flutter/lib/src/rendering/custom_layout.dart
+++ b/packages/flutter/lib/src/rendering/custom_layout.dart
@@ -282,13 +282,13 @@ class RenderCustomMultiChildLayoutBox extends RenderBox
   /// The delegate that controls the layout of the children.
   MultiChildLayoutDelegate get delegate => _delegate;
   MultiChildLayoutDelegate _delegate;
-  set delegate (MultiChildLayoutDelegate newDelegate) {
-    assert(newDelegate != null);
-    if (_delegate == newDelegate)
+  set delegate (MultiChildLayoutDelegate value) {
+    assert(value != null);
+    if (_delegate == value)
       return;
-    if (newDelegate.runtimeType != _delegate.runtimeType || newDelegate.shouldRelayout(_delegate))
+    if (value.runtimeType != _delegate.runtimeType || value.shouldRelayout(_delegate))
       markNeedsLayout();
-    _delegate = newDelegate;
+    _delegate = value;
   }
 
   Size _getSize(BoxConstraints constraints) {

--- a/packages/flutter/lib/src/rendering/performance_overlay.dart
+++ b/packages/flutter/lib/src/rendering/performance_overlay.dart
@@ -77,11 +77,11 @@ class RenderPerformanceOverlay extends RenderBox {
   /// [PerformanceOverlayOption] to enable.
   int get optionsMask => _optionsMask;
   int _optionsMask;
-  set optionsMask(int mask) {
-    assert(mask != null);
-    if (mask == _optionsMask)
+  set optionsMask(int value) {
+    assert(value != null);
+    if (value == _optionsMask)
       return;
-    _optionsMask = mask;
+    _optionsMask = value;
     markNeedsPaint();
   }
 
@@ -90,22 +90,22 @@ class RenderPerformanceOverlay extends RenderBox {
   /// is suitable for capturing an SkPicture trace for further analysis.
   int get rasterizerThreshold => _rasterizerThreshold;
   int _rasterizerThreshold;
-  set rasterizerThreshold (int threshold) {
-    assert(threshold != null);
-    if (threshold == _rasterizerThreshold)
+  set rasterizerThreshold (int value) {
+    assert(value != null);
+    if (value == _rasterizerThreshold)
       return;
-    _rasterizerThreshold = threshold;
+    _rasterizerThreshold = value;
     markNeedsPaint();
   }
 
   /// Whether the raster cache should checkerboard cached entries.
   bool get checkerboardRasterCacheImages => _checkerboardRasterCacheImages;
   bool _checkerboardRasterCacheImages;
-  set checkerboardRasterCacheImages (bool checkerboard) {
-    assert(checkerboard != null);
-    if (checkerboard == _checkerboardRasterCacheImages)
+  set checkerboardRasterCacheImages (bool value) {
+    assert(value != null);
+    if (value == _checkerboardRasterCacheImages)
       return;
-    _checkerboardRasterCacheImages = checkerboard;
+    _checkerboardRasterCacheImages = value;
     markNeedsPaint();
   }
 

--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -206,12 +206,12 @@ class RenderConstrainedBox extends RenderProxyBox {
   /// Additional constraints to apply to [child] during layout
   BoxConstraints get additionalConstraints => _additionalConstraints;
   BoxConstraints _additionalConstraints;
-  set additionalConstraints (BoxConstraints newConstraints) {
-    assert(newConstraints != null);
-    assert(newConstraints.debugAssertIsValid());
-    if (_additionalConstraints == newConstraints)
+  set additionalConstraints (BoxConstraints value) {
+    assert(value != null);
+    assert(value.debugAssertIsValid());
+    if (_additionalConstraints == value)
       return;
-    _additionalConstraints = newConstraints;
+    _additionalConstraints = value;
     markNeedsLayout();
   }
 
@@ -399,13 +399,13 @@ class RenderAspectRatio extends RenderProxyBox {
   /// a 16:9 width:height aspect ratio would have a value of 16.0/9.0.
   double get aspectRatio => _aspectRatio;
   double _aspectRatio;
-  set aspectRatio (double newAspectRatio) {
-    assert(newAspectRatio != null);
-    assert(newAspectRatio > 0.0);
-    assert(newAspectRatio.isFinite);
-    if (_aspectRatio == newAspectRatio)
+  set aspectRatio (double value) {
+    assert(value != null);
+    assert(value > 0.0);
+    assert(value.isFinite);
+    if (_aspectRatio == value)
       return;
-    _aspectRatio = newAspectRatio;
+    _aspectRatio = value;
     markNeedsLayout();
   }
 
@@ -541,20 +541,20 @@ class RenderIntrinsicWidth extends RenderProxyBox {
   /// If non-null, force the child's width to be a multiple of this value.
   double get stepWidth => _stepWidth;
   double _stepWidth;
-  set stepWidth(double newStepWidth) {
-    if (newStepWidth == _stepWidth)
+  set stepWidth(double value) {
+    if (value == _stepWidth)
       return;
-    _stepWidth = newStepWidth;
+    _stepWidth = value;
     markNeedsLayout();
   }
 
   /// If non-null, force the child's height to be a multiple of this value.
   double get stepHeight => _stepHeight;
   double _stepHeight;
-  set stepHeight(double newStepHeight) {
-    if (newStepHeight == _stepHeight)
+  set stepHeight(double value) {
+    if (value == _stepHeight)
       return;
-    _stepHeight = newStepHeight;
+    _stepHeight = value;
     markNeedsLayout();
   }
 
@@ -721,12 +721,12 @@ class RenderOpacity extends RenderProxyBox {
   /// expensive.
   double get opacity => _opacity;
   double _opacity;
-  set opacity (double newOpacity) {
-    assert(newOpacity != null);
-    assert(newOpacity >= 0.0 && newOpacity <= 1.0);
-    if (_opacity == newOpacity)
+  set opacity (double value) {
+    assert(value != null);
+    assert(value >= 0.0 && value <= 1.0);
+    if (_opacity == value)
       return;
-    _opacity = newOpacity;
+    _opacity = value;
     _alpha = _getAlphaFromOpacity(_opacity);
     markNeedsCompositingBitsUpdate();
     markNeedsPaint();
@@ -792,11 +792,11 @@ class RenderShaderMask extends RenderProxyBox {
   // repaints when the ShaderCallback changes identity.
   ShaderCallback get shaderCallback => _shaderCallback;
   ShaderCallback _shaderCallback;
-  set shaderCallback (ShaderCallback newShaderCallback) {
-    assert(newShaderCallback != null);
-    if (_shaderCallback == newShaderCallback)
+  set shaderCallback (ShaderCallback value) {
+    assert(value != null);
+    if (_shaderCallback == value)
       return;
-    _shaderCallback = newShaderCallback;
+    _shaderCallback = value;
     markNeedsPaint();
   }
 
@@ -806,11 +806,11 @@ class RenderShaderMask extends RenderProxyBox {
   /// to the child. Other blend modes can be used to create other effects.
   BlendMode get blendMode => _blendMode;
   BlendMode _blendMode;
-  set blendMode (BlendMode newBlendMode) {
-    assert(newBlendMode != null);
-    if (_blendMode == newBlendMode)
+  set blendMode (BlendMode value) {
+    assert(value != null);
+    if (_blendMode == value)
       return;
-    _blendMode = newBlendMode;
+    _blendMode = value;
     markNeedsPaint();
   }
 
@@ -846,11 +846,11 @@ class RenderBackdropFilter extends RenderProxyBox {
   /// blur effect
   ui.ImageFilter get filter => _filter;
   ui.ImageFilter _filter;
-  set filter (ui.ImageFilter newFilter) {
-    assert(newFilter != null);
-    if (_filter == newFilter)
+  set filter (ui.ImageFilter value) {
+    assert(value != null);
+    if (_filter == value)
       return;
-    _filter = newFilter;
+    _filter = value;
     markNeedsPaint();
   }
 
@@ -1329,24 +1329,24 @@ class RenderDecoratedBox extends RenderProxyBox {
   /// Commonly a [BoxDecoration].
   Decoration get decoration => _decoration;
   Decoration _decoration;
-  set decoration (Decoration newDecoration) {
-    assert(newDecoration != null);
-    if (newDecoration == _decoration)
+  set decoration (Decoration value) {
+    assert(value != null);
+    if (value == _decoration)
       return;
     _painter?.dispose();
     _painter = null;
-    _decoration = newDecoration;
+    _decoration = value;
     markNeedsPaint();
   }
 
   /// Whether to paint the box decoration behind or in front of the child.
   DecorationPosition get position => _position;
   DecorationPosition _position;
-  set position (DecorationPosition newPosition) {
-    assert(newPosition != null);
-    if (newPosition == _position)
+  set position (DecorationPosition value) {
+    assert(value != null);
+    if (value == _position)
       return;
-    _position = newPosition;
+    _position = value;
     markNeedsPaint();
   }
 
@@ -1355,11 +1355,11 @@ class RenderDecoratedBox extends RenderProxyBox {
   /// [BoxPainter.paint].
   ImageConfiguration get configuration => _configuration;
   ImageConfiguration _configuration;
-  set configuration (ImageConfiguration newConfiguration) {
-    assert(newConfiguration != null);
-    if (newConfiguration == _configuration)
+  set configuration (ImageConfiguration value) {
+    assert(value != null);
+    if (value == _configuration)
       return;
-    _configuration = newConfiguration;
+    _configuration = value;
     markNeedsPaint();
   }
 
@@ -1449,10 +1449,10 @@ class RenderTransform extends RenderProxyBox {
   /// translation. This property is provided just for convenience.
   Offset get origin => _origin;
   Offset _origin;
-  set origin (Offset newOrigin) {
-    if (_origin == newOrigin)
+  set origin (Offset value) {
+    if (_origin == value)
       return;
-    _origin = newOrigin;
+    _origin = value;
     markNeedsPaint();
   }
 
@@ -1462,11 +1462,11 @@ class RenderTransform extends RenderProxyBox {
   /// If it is specified at the same time as an offset, both are applied.
   FractionalOffset get alignment => _alignment;
   FractionalOffset _alignment;
-  set alignment (FractionalOffset newAlignment) {
-    assert(newAlignment == null || (newAlignment.dx != null && newAlignment.dy != null));
-    if (_alignment == newAlignment)
+  set alignment (FractionalOffset value) {
+    assert(value == null || (value.dx != null && value.dy != null));
+    if (_alignment == value)
       return;
-    _alignment = newAlignment;
+    _alignment = value;
     markNeedsPaint();
   }
 
@@ -1482,11 +1482,11 @@ class RenderTransform extends RenderProxyBox {
   Matrix4 _transform;
 
   /// The matrix to transform the child by during painting.
-  set transform(Matrix4 newTransform) {
-    assert(newTransform != null);
-    if (_transform == newTransform)
+  set transform(Matrix4 value) {
+    assert(value != null);
+    if (_transform == value)
       return;
-    _transform = new Matrix4.copy(newTransform);
+    _transform = new Matrix4.copy(value);
     markNeedsPaint();
   }
 
@@ -1607,11 +1607,11 @@ class RenderFittedBox extends RenderProxyBox {
   /// How to inscribe the child into the space allocated during layout.
   ImageFit get fit => _fit;
   ImageFit _fit;
-  set fit (ImageFit newFit) {
-    assert(newFit != null);
-    if (_fit == newFit)
+  set fit (ImageFit value) {
+    assert(value != null);
+    if (_fit == value)
       return;
-    _fit = newFit;
+    _fit = value;
     _clearPaintData();
     markNeedsPaint();
   }
@@ -1623,11 +1623,11 @@ class RenderFittedBox extends RenderProxyBox {
   /// of the right edge of its parent's bounds.
   FractionalOffset get alignment => _alignment;
   FractionalOffset _alignment;
-  set alignment (FractionalOffset newAlignment) {
-    assert(newAlignment != null && newAlignment.dx != null && newAlignment.dy != null);
-    if (_alignment == newAlignment)
+  set alignment (FractionalOffset value) {
+    assert(value != null && value.dx != null && value.dy != null);
+    if (_alignment == value)
       return;
-    _alignment = newAlignment;
+    _alignment = value;
     _clearPaintData();
     markNeedsPaint();
   }
@@ -1744,11 +1744,11 @@ class RenderFractionalTranslation extends RenderProxyBox {
   /// The translation to apply to the child, as a multiple of the size.
   FractionalOffset get translation => _translation;
   FractionalOffset _translation;
-  set translation (FractionalOffset newTranslation) {
-    assert(newTranslation == null || (newTranslation.dx != null && newTranslation.dy != null));
-    if (_translation == newTranslation)
+  set translation (FractionalOffset value) {
+    assert(value == null || (value.dx != null && value.dy != null));
+    if (_translation == value)
       return;
-    _translation = newTranslation;
+    _translation = value;
     markNeedsPaint();
   }
 
@@ -1947,11 +1947,11 @@ class RenderCustomPaint extends RenderProxyBox {
   /// delegate will be called.
   ///
   /// If the new value is null, then there is no background custom painter.
-  set painter (CustomPainter newPainter) {
-    if (_painter == newPainter)
+  set painter (CustomPainter value) {
+    if (_painter == value)
       return;
     final CustomPainter oldPainter = _painter;
-    _painter = newPainter;
+    _painter = value;
     _didUpdatePainter(_painter, oldPainter);
   }
 
@@ -1972,11 +1972,11 @@ class RenderCustomPaint extends RenderProxyBox {
   /// delegate will be called.
   ///
   /// If the new value is null, then there is no foreground custom painter.
-  set foregroundPainter (CustomPainter newPainter) {
-    if (_foregroundPainter == newPainter)
+  set foregroundPainter (CustomPainter value) {
+    if (_foregroundPainter == value)
       return;
     final CustomPainter oldPainter = _foregroundPainter;
-    _foregroundPainter = newPainter;
+    _foregroundPainter = value;
     _didUpdatePainter(_foregroundPainter, oldPainter);
   }
 

--- a/packages/flutter/lib/src/rendering/shifted_box.dart
+++ b/packages/flutter/lib/src/rendering/shifted_box.dart
@@ -212,11 +212,11 @@ abstract class RenderAligningShiftedBox extends RenderShiftedBox {
   /// Sets the alignment to a new value, and triggers a layout update.
   ///
   /// The new alignment must not be null or have any null properties.
-  set alignment (FractionalOffset newAlignment) {
-    assert(newAlignment != null && newAlignment.dx != null && newAlignment.dy != null);
-    if (_alignment == newAlignment)
+  set alignment (FractionalOffset value) {
+    assert(value != null && value.dx != null && value.dy != null);
+    if (_alignment == value)
       return;
-    _alignment = newAlignment;
+    _alignment = value;
     markNeedsLayout();
   }
 

--- a/packages/flutter/lib/src/rendering/sliver_fixed_extent_list.dart
+++ b/packages/flutter/lib/src/rendering/sliver_fixed_extent_list.dart
@@ -163,11 +163,11 @@ class RenderSliverFixedExtentList extends RenderSliverFixedExtentBoxAdaptor {
   @override
   double get itemExtent => _itemExtent;
   double _itemExtent;
-  set itemExtent (double newValue) {
-    assert(newValue != null);
-    if (_itemExtent == newValue)
+  set itemExtent (double value) {
+    assert(value != null);
+    if (_itemExtent == value)
       return;
-    _itemExtent = newValue;
+    _itemExtent = value;
     markNeedsLayout();
   }
 }
@@ -186,11 +186,11 @@ class RenderSliverFill extends RenderSliverFixedExtentBoxAdaptor {
 
   double get viewportFraction => _viewportFraction;
   double _viewportFraction;
-  set viewportFraction (double newValue) {
-    assert(newValue != null);
-    if (_viewportFraction == newValue)
+  set viewportFraction (double value) {
+    assert(value != null);
+    if (_viewportFraction == value)
       return;
-    _viewportFraction = newValue;
+    _viewportFraction = value;
     markNeedsLayout();
   }
 

--- a/packages/flutter/lib/src/rendering/sliver_grid.dart
+++ b/packages/flutter/lib/src/rendering/sliver_grid.dart
@@ -426,14 +426,14 @@ class RenderSliverGrid extends RenderSliverMultiBoxAdaptor {
   SliverGridDelegate get gridDelegate => _gridDelegate;
   SliverGridDelegate _gridDelegate;
 
-  set gridDelegate(SliverGridDelegate newDelegate) {
-    assert(newDelegate != null);
-    if (_gridDelegate == newDelegate)
+  set gridDelegate(SliverGridDelegate value) {
+    assert(value != null);
+    if (_gridDelegate == value)
       return;
-    if (newDelegate.runtimeType != _gridDelegate.runtimeType ||
-        newDelegate.shouldRelayout(_gridDelegate))
+    if (value.runtimeType != _gridDelegate.runtimeType ||
+        value.shouldRelayout(_gridDelegate))
       markNeedsLayout();
-    _gridDelegate = newDelegate;
+    _gridDelegate = value;
   }
 
   @override

--- a/packages/flutter/lib/src/widgets/page_view.dart
+++ b/packages/flutter/lib/src/widgets/page_view.dart
@@ -159,11 +159,11 @@ class _PagePosition extends ScrollPosition {
 
   double get viewportFraction => _viewportFraction;
   double _viewportFraction;
-  set viewportFraction(double newValue) {
-    if (_viewportFraction == newValue)
+  set viewportFraction(double value) {
+    if (_viewportFraction == value)
       return;
     final double oldPage = page;
-    _viewportFraction = newValue;
+    _viewportFraction = value;
     if (oldPage != null)
       correctPixels(getPixelsFromPage(oldPage));
   }

--- a/packages/flutter/lib/src/widgets/placeholder.dart
+++ b/packages/flutter/lib/src/widgets/placeholder.dart
@@ -23,11 +23,11 @@ class PlaceholderState extends State<Placeholder> {
   /// Mutating this field will cause this widget to rebuild with the new child.
   Widget get child => _child;
   Widget _child;
-  set child(Widget child) {
-    if (_child == child)
+  set child(Widget value) {
+    if (_child == value)
       return;
     setState(() {
-      _child = child;
+      _child = value;
     });
   }
 

--- a/packages/flutter_markdown/lib/src/markdown_raw.dart
+++ b/packages/flutter_markdown/lib/src/markdown_raw.dart
@@ -356,9 +356,9 @@ class _Block {
   List<_Block> subBlocks;
 
   bool get open => _open;
-  set open(bool open) {
-    _open = open;
-    if (!open && subBlocks.isNotEmpty)
+  set open(bool value) {
+    _open = value;
+    if (!value && subBlocks.isNotEmpty)
       subBlocks.last.isLast = true;
   }
 

--- a/packages/flutter_test/lib/src/binding.dart
+++ b/packages/flutter_test/lib/src/binding.dart
@@ -202,8 +202,8 @@ abstract class TestWidgetsFlutterBinding extends BindingBase
   /// the focus change.
   EditableTextState get focusedEditable => _focusedEditable;
   EditableTextState _focusedEditable;
-  set focusedEditable (EditableTextState editable) {
-    _focusedEditable = editable..requestKeyboard();
+  set focusedEditable (EditableTextState value) {
+    _focusedEditable = value..requestKeyboard();
   }
 
   /// Returns the exception most recently caught by the Flutter framework.

--- a/packages/flutter_tools/lib/src/devfs.dart
+++ b/packages/flutter_tools/lib/src/devfs.dart
@@ -113,8 +113,8 @@ class DevFSByteContent extends DevFSContent {
 
   List<int> get bytes => _bytes;
 
-  set bytes(List<int> newBytes) {
-    _bytes = newBytes;
+  set bytes(List<int> value) {
+    _bytes = value;
     _isModified = true;
   }
 
@@ -145,14 +145,14 @@ class DevFSStringContent extends DevFSByteContent {
 
   String get string => _string;
 
-  set string(String newString) {
-    _string = newString;
+  set string(String value) {
+    _string = value;
     super.bytes = UTF8.encode(_string);
   }
 
   @override
-  set bytes(List<int> newBytes) {
-    string = UTF8.decode(newBytes);
+  set bytes(List<int> value) {
+    string = UTF8.decode(value);
   }
 }
 

--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -77,8 +77,8 @@ abstract class FlutterCommand extends Command<Null> {
       help: 'Build a release version of your app${defaultToRelease ? ' (default mode)' : ''}.');
   }
 
-  set defaultBuildMode(BuildMode buildMode) {
-    _defaultBuildMode = buildMode;
+  set defaultBuildMode(BuildMode value) {
+    _defaultBuildMode = value;
   }
 
   BuildMode getBuildMode() {


### PR DESCRIPTION
According to [Flutter style guide: Prefer naming the argument to a setter `value`](https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#avoid-using-if-chains-on-enum-values).

I haven't change `set value(double newValue)` and the setters with argument `newXxx` and with a body using `oldXxx` variable ( eg https://github.com/flutter/flutter/blob/master/packages/flutter/lib/src/rendering/shifted_box.dart#L803-L815 ).