### PR TITLE
Eliminate CocoaPods install step

### DIFF
--- a/packages/flutter_tools/lib/src/base/process.dart
+++ b/packages/flutter_tools/lib/src/base/process.dart
@@ -211,7 +211,6 @@ String runCheckedSync(List<String> cmd, {
   String workingDirectory,
   bool allowReentrantFlutter: false,
   bool hideStdout: false,
-  Map<String, String> environment,
 }) {
   return _runWithLoggingSync(
     cmd,
@@ -220,7 +219,6 @@ String runCheckedSync(List<String> cmd, {
     hideStdout: hideStdout,
     checked: true,
     noisyErrors: true,
-    environment: environment,
   );
 }
 
@@ -261,13 +259,12 @@ String _runWithLoggingSync(List<String> cmd, {
   String workingDirectory,
   bool allowReentrantFlutter: false,
   bool hideStdout: false,
-  Map<String, String> environment,
 }) {
   _traceCommand(cmd, workingDirectory: workingDirectory);
   final ProcessResult results = processManager.runSync(
     cmd,
     workingDirectory: workingDirectory,
-    environment: _environment(allowReentrantFlutter, environment),
+    environment: _environment(allowReentrantFlutter),
   );
 
   printTrace('Exit code ${results.exitCode} from: ${cmd.join(' ')}');

--- a/packages/flutter_tools/lib/src/ios/ios_workflow.dart
+++ b/packages/flutter_tools/lib/src/ios/ios_workflow.dart
@@ -41,10 +41,6 @@ class IOSWorkflow extends DoctorValidator implements Workflow {
 
   bool get hasPythonSixModule => exitsHappy(<String>['python', '-c', 'import six']);
 
-  bool get hasCocoaPods => exitsHappy(<String>['pod', '--version']);
-
-  String get cocoaPodsVersionText => runSync(<String>['pod', '--version']).trim();
-
   bool get _iosDeployIsInstalledAndMeetsVersionCheck {
     if (!hasIosDeploy)
       return false;
@@ -62,7 +58,6 @@ class IOSWorkflow extends DoctorValidator implements Workflow {
     ValidationType xcodeStatus = ValidationType.missing;
     ValidationType pythonStatus = ValidationType.missing;
     ValidationType brewStatus = ValidationType.missing;
-    ValidationType podStatus = ValidationType.missing;
     String xcodeVersionInfo;
 
     if (xcode.isInstalled) {
@@ -167,19 +162,8 @@ class IOSWorkflow extends DoctorValidator implements Workflow {
       ));
     }
 
-    if (hasCocoaPods) {
-      podStatus = ValidationType.installed;
-      messages.add(new ValidationMessage('CocoaPods version $cocoaPodsVersionText'));
-    } else {
-      podStatus = ValidationType.missing;
-      messages.add(new ValidationMessage.error(
-        'CocoaPods not installed; this is used for iOS development.\n'
-        'Install by running: \'brew install cocoapods\''
-      ));
-    }
-
     return new ValidationResult(
-      <ValidationType>[xcodeStatus, pythonStatus, brewStatus, podStatus].reduce(_mergeValidationTypes),
+      <ValidationType>[xcodeStatus, pythonStatus, brewStatus].reduce(_mergeValidationTypes),
       messages,
       statusInfo: xcodeVersionInfo
     );

--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -123,10 +123,8 @@ Future<XcodeBuildResult> buildXcodeProject({
 
   // Before the build, all service definitions must be updated and the dylibs
   // copied over to a location that is suitable for Xcodebuild to find them.
-  final Directory appDirectory = fs.directory(app.appDirectory);
-  await _addServicesToBundle(appDirectory);
 
-  _installCocoaPods(appDirectory, flutterFrameworkDir(mode));
+  await _addServicesToBundle(fs.directory(app.appDirectory));
 
   final List<String> commands = <String>[
     '/usr/bin/env',
@@ -315,26 +313,6 @@ bool _checkXcodeVersion() {
     return false;
   }
   return true;
-}
-
-bool _checkCocoaPodsInstalled() {
-  if (!platform.isMacOS)
-    return false;
-  return exitsHappy(<String>['pod', '--version']);
-}
-
-void _installCocoaPods(Directory bundle, String engineDirectory)  {
-  if (fs.file(fs.path.join(bundle.path, 'Podfile')).existsSync()) {
-    if (!_checkCocoaPodsInstalled()) {
-      printError('Warning: CocoaPods not installed. Not running pod install.');
-      return;
-    }
-    runCheckedSync(
-        <String>['pod', 'install'],
-        workingDirectory: bundle.path,
-        environment: <String, String>{'FLUTTER_FRAMEWORK_DIR': engineDirectory},
-    );
-  }
 }
 
 Future<Null> _addServicesToBundle(Directory bundle) async {

--- a/packages/flutter_tools/lib/src/ios/xcodeproj.dart
+++ b/packages/flutter_tools/lib/src/ios/xcodeproj.dart
@@ -12,10 +12,6 @@ import '../globals.dart';
 final RegExp _settingExpr = new RegExp(r'(\w+)\s*=\s*(\S+)');
 final RegExp _varExpr = new RegExp(r'\$\((.*)\)');
 
-String flutterFrameworkDir(BuildMode mode) {
-  return fs.path.normalize(fs.path.dirname(artifacts.getArtifactPath(Artifact.flutterFramework, TargetPlatform.ios, mode)));
-}
-
 void updateXcodeGeneratedProperties(String projectPath, BuildMode mode, String target) {
   final StringBuffer localsBuffer = new StringBuffer();
 
@@ -38,7 +34,8 @@ void updateXcodeGeneratedProperties(String projectPath, BuildMode mode, String t
 
   localsBuffer.writeln('SYMROOT=\${SOURCE_ROOT}/../${getIosBuildDirectory()}');
 
-  localsBuffer.writeln('FLUTTER_FRAMEWORK_DIR=${flutterFrameworkDir(mode)}');
+  final String flutterFrameworkDir = fs.path.normalize(fs.path.dirname(artifacts.getArtifactPath(Artifact.flutterFramework, TargetPlatform.ios, mode)));
+  localsBuffer.writeln('FLUTTER_FRAMEWORK_DIR=$flutterFrameworkDir');
 
   if (artifacts is LocalEngineArtifacts) {
     final LocalEngineArtifacts localEngineArtifacts = artifacts;


### PR DESCRIPTION
If the developer is relying on CocoaPods and hasn't done a pod install,
they'll get a build failure indicating the issue.

This also avoids a hard dependency on CocoaPods in the tool and allows
developers to customize their Xcode steps to use alternatives such as
Carthage if they prefer.