### PR TITLE
Revert "Eliminate CocoaPods install step (#8694)"

### DIFF
--- a/packages/flutter_tools/lib/src/base/process.dart
+++ b/packages/flutter_tools/lib/src/base/process.dart
@@ -211,6 +211,7 @@ String runCheckedSync(List<String> cmd, {
   String workingDirectory,
   bool allowReentrantFlutter: false,
   bool hideStdout: false,
+  Map<String, String> environment,
 }) {
   return _runWithLoggingSync(
     cmd,
@@ -219,6 +220,7 @@ String runCheckedSync(List<String> cmd, {
     hideStdout: hideStdout,
     checked: true,
     noisyErrors: true,
+    environment: environment,
   );
 }
 
@@ -259,12 +261,13 @@ String _runWithLoggingSync(List<String> cmd, {
   String workingDirectory,
   bool allowReentrantFlutter: false,
   bool hideStdout: false,
+  Map<String, String> environment,
 }) {
   _traceCommand(cmd, workingDirectory: workingDirectory);
   final ProcessResult results = processManager.runSync(
     cmd,
     workingDirectory: workingDirectory,
-    environment: _environment(allowReentrantFlutter),
+    environment: _environment(allowReentrantFlutter, environment),
   );
 
   printTrace('Exit code ${results.exitCode} from: ${cmd.join(' ')}');

--- a/packages/flutter_tools/lib/src/doctor.dart
+++ b/packages/flutter_tools/lib/src/doctor.dart
@@ -41,7 +41,6 @@ class Doctor {
   IOSWorkflow _iosWorkflow;
   AndroidWorkflow _androidWorkflow;
 
-  /// This can return null for platforms that don't support developing for iOS.
   IOSWorkflow get iosWorkflow => _iosWorkflow;
 
   AndroidWorkflow get androidWorkflow => _androidWorkflow;

--- a/packages/flutter_tools/lib/src/ios/ios_workflow.dart
+++ b/packages/flutter_tools/lib/src/ios/ios_workflow.dart
@@ -41,6 +41,10 @@ class IOSWorkflow extends DoctorValidator implements Workflow {
 
   bool get hasPythonSixModule => exitsHappy(<String>['python', '-c', 'import six']);
 
+  bool get hasCocoaPods => exitsHappy(<String>['pod', '--version']);
+
+  String get cocoaPodsVersionText => runSync(<String>['pod', '--version']).trim();
+
   bool get _iosDeployIsInstalledAndMeetsVersionCheck {
     if (!hasIosDeploy)
       return false;
@@ -58,6 +62,7 @@ class IOSWorkflow extends DoctorValidator implements Workflow {
     ValidationType xcodeStatus = ValidationType.missing;
     ValidationType pythonStatus = ValidationType.missing;
     ValidationType brewStatus = ValidationType.missing;
+    ValidationType podStatus = ValidationType.missing;
     String xcodeVersionInfo;
 
     if (xcode.isInstalled) {
@@ -167,8 +172,19 @@ class IOSWorkflow extends DoctorValidator implements Workflow {
       ));
     }
 
+    if (hasCocoaPods) {
+      podStatus = ValidationType.installed;
+      messages.add(new ValidationMessage('CocoaPods version $cocoaPodsVersionText'));
+    } else {
+      podStatus = ValidationType.missing;
+      messages.add(new ValidationMessage.error(
+        'CocoaPods not installed; this is used for iOS development.\n'
+        'Install by running: \'brew install cocoapods\''
+      ));
+    }
+
     return new ValidationResult(
-      <ValidationType>[xcodeStatus, pythonStatus, brewStatus].reduce(_mergeValidationTypes),
+      <ValidationType>[xcodeStatus, pythonStatus, brewStatus, podStatus].reduce(_mergeValidationTypes),
       messages,
       statusInfo: xcodeVersionInfo
     );

--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -9,6 +9,7 @@ import 'package:meta/meta.dart';
 
 import '../application_package.dart';
 import '../base/context.dart';
+import '../base/common.dart';
 import '../base/file_system.dart';
 import '../base/io.dart';
 import '../base/platform.dart';
@@ -329,11 +330,15 @@ void _installCocoaPods(Directory bundle, String engineDirectory)  {
       printError('Warning: CocoaPods not installed. Not running pod install.');
       return;
     }
-    runCheckedSync(
-        <String>['pod', 'install'],
-        workingDirectory: bundle.path,
-        environment: <String, String>{'FLUTTER_FRAMEWORK_DIR': engineDirectory},
-    );
+    try {
+      runCheckedSync(
+          <String>['pod', 'install'],
+          workingDirectory: bundle.path,
+          environment: <String, String>{'FLUTTER_FRAMEWORK_DIR': engineDirectory},
+      );
+    } catch (e) {
+      throwToolExit('Error running pod install: $e');
+    }
   }
 }
 

--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -16,6 +16,7 @@ import '../base/platform.dart';
 import '../base/process.dart';
 import '../base/process_manager.dart';
 import '../build_info.dart';
+import '../doctor.dart';
 import '../flx.dart' as flx;
 import '../globals.dart';
 import '../services.dart';
@@ -127,7 +128,7 @@ Future<XcodeBuildResult> buildXcodeProject({
   final Directory appDirectory = fs.directory(app.appDirectory);
   await _addServicesToBundle(appDirectory);
 
-  _installCocoaPods(appDirectory, flutterFrameworkDir(mode));
+  _runPodInstall(appDirectory, flutterFrameworkDir(mode));
 
   final List<String> commands = <String>[
     '/usr/bin/env',
@@ -312,21 +313,15 @@ bool _checkXcodeVersion() {
       return false;
     }
   } catch (e) {
-    printError('Cannot find "xcodebuid". $_xcodeRequirement');
+    printError('Cannot find "xcodebuild". $_xcodeRequirement');
     return false;
   }
   return true;
 }
 
-bool _checkCocoaPodsInstalled() {
-  if (!platform.isMacOS)
-    return false;
-  return exitsHappy(<String>['pod', '--version']);
-}
-
-void _installCocoaPods(Directory bundle, String engineDirectory)  {
+void _runPodInstall(Directory bundle, String engineDirectory)  {
   if (fs.file(fs.path.join(bundle.path, 'Podfile')).existsSync()) {
-    if (!_checkCocoaPodsInstalled()) {
+    if (!doctor.iosWorkflow.hasCocoaPods) {
       printError('Warning: CocoaPods not installed. Not running pod install.');
       return;
     }

--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -123,8 +123,10 @@ Future<XcodeBuildResult> buildXcodeProject({
 
   // Before the build, all service definitions must be updated and the dylibs
   // copied over to a location that is suitable for Xcodebuild to find them.
+  final Directory appDirectory = fs.directory(app.appDirectory);
+  await _addServicesToBundle(appDirectory);
 
-  await _addServicesToBundle(fs.directory(app.appDirectory));
+  _installCocoaPods(appDirectory, flutterFrameworkDir(mode));
 
   final List<String> commands = <String>[
     '/usr/bin/env',
@@ -313,6 +315,26 @@ bool _checkXcodeVersion() {
     return false;
   }
   return true;
+}
+
+bool _checkCocoaPodsInstalled() {
+  if (!platform.isMacOS)
+    return false;
+  return exitsHappy(<String>['pod', '--version']);
+}
+
+void _installCocoaPods(Directory bundle, String engineDirectory)  {
+  if (fs.file(fs.path.join(bundle.path, 'Podfile')).existsSync()) {
+    if (!_checkCocoaPodsInstalled()) {
+      printError('Warning: CocoaPods not installed. Not running pod install.');
+      return;
+    }
+    runCheckedSync(
+        <String>['pod', 'install'],
+        workingDirectory: bundle.path,
+        environment: <String, String>{'FLUTTER_FRAMEWORK_DIR': engineDirectory},
+    );
+  }
 }
 
 Future<Null> _addServicesToBundle(Directory bundle) async {

--- a/packages/flutter_tools/lib/src/ios/xcodeproj.dart
+++ b/packages/flutter_tools/lib/src/ios/xcodeproj.dart
@@ -12,6 +12,10 @@ import '../globals.dart';
 final RegExp _settingExpr = new RegExp(r'(\w+)\s*=\s*(\S+)');
 final RegExp _varExpr = new RegExp(r'\$\((.*)\)');
 
+String flutterFrameworkDir(BuildMode mode) {
+  return fs.path.normalize(fs.path.dirname(artifacts.getArtifactPath(Artifact.flutterFramework, TargetPlatform.ios, mode)));
+}
+
 void updateXcodeGeneratedProperties(String projectPath, BuildMode mode, String target) {
   final StringBuffer localsBuffer = new StringBuffer();
 
@@ -34,8 +38,7 @@ void updateXcodeGeneratedProperties(String projectPath, BuildMode mode, String t
 
   localsBuffer.writeln('SYMROOT=\${SOURCE_ROOT}/../${getIosBuildDirectory()}');
 
-  final String flutterFrameworkDir = fs.path.normalize(fs.path.dirname(artifacts.getArtifactPath(Artifact.flutterFramework, TargetPlatform.ios, mode)));
-  localsBuffer.writeln('FLUTTER_FRAMEWORK_DIR=$flutterFrameworkDir');
+  localsBuffer.writeln('FLUTTER_FRAMEWORK_DIR=${flutterFrameworkDir(mode)}');
 
   if (artifacts is LocalEngineArtifacts) {
     final LocalEngineArtifacts localEngineArtifacts = artifacts;


### PR DESCRIPTION
This reverts commit f4a13bc72b0d0a6f08592a24a61cc92f86e62061.

If the developer is relying on CocoaPods and hasn't done a pod install, we will do it for them. This is needed for a smooth native plugin experience, similar to what Gradle is doing on the Android side.

There's no hard dependency on CocoaPods. We only run pod install if the project uses CocoaPods, so developers are still free to use alternatives if they prefer (and if they don't want to use native plugins).

Fixes #8685 
Fixes #8657 
Fixes #8526 
