### PR TITLE
Support Xcode builds in project dirs with spaces

### DIFF
--- a/packages/flutter_tools/bin/xcode_backend.sh
+++ b/packages/flutter_tools/bin/xcode_backend.sh
@@ -191,7 +191,7 @@ ThinAppFrameworks() {
   local frameworks_dir="${app_path}/Frameworks"
 
   [[ -d "$frameworks_dir" ]] || return 0
-  for framework_dir in $(find "${app_path}" -type d -name "*.framework"); do
+  find "${app_path}" -type d -name "*.framework" | while read framework_dir; do
     ThinFramework "$framework_dir" "$ARCHS"
   done
 }


### PR DESCRIPTION
Use line-based iteration in place of word-based iteration over the
framework directories, to avoid breaking on spaces.