### PR TITLE
Callback wasn't clear what the type of the function was

### DIFF
--- a/packages/flutter/lib/src/material/app_bar.dart
+++ b/packages/flutter/lib/src/material/app_bar.dart
@@ -686,7 +686,9 @@ class SliverAppBar extends StatelessWidget {
   ///           new IconButton(
   ///             icon: new Icon(Icons.shopping_cart),
   ///             tooltip: 'Open shopping cart',
-  ///             onPressed: _openCart,
+  ///             onPressed: () {
+  ///               // handle the press
+  ///             },
   ///           ),
   ///         ],
   ///       ),


### PR DESCRIPTION
Changing to an inline function, making the type more clear.

(From a UX study)