### PR TITLE
Adds support for custom fonts for icons

### DIFF
--- a/packages/flutter/lib/src/material/icon.dart
+++ b/packages/flutter/lib/src/material/icon.dart
@@ -114,7 +114,7 @@ class Icon extends StatelessWidget {
                 inherit: false,
                 color: iconColor,
                 fontSize: iconSize,
-                fontFamily: 'MaterialIcons'
+                fontFamily: icon.fontFamily
               )
             )
           )

--- a/packages/flutter/lib/src/material/icons.dart
+++ b/packages/flutter/lib/src/material/icons.dart
@@ -10,10 +10,13 @@ class IconData {
   ///
   /// Rarely used directly. Instead, consider using one of the predefined icons
   /// from the [Icons] collection.
-  const IconData(this.codePoint);
+  const IconData(this.codePoint, {
+    this.fontFamily: 'MaterialIcons'
+  });
 
   /// The unicode code point at which this icon is stored in the icon font.
   final int codePoint;
+  final String fontFamily;
 
   @override
   bool operator ==(dynamic other) {


### PR DESCRIPTION
This update adds support for custom fonts in icons. As an example, it can be used with the icon-set from https://materialdesignicons.com 

I made an example for how to use the icons here: https://github.com/vlidholt/flutter_mdi_icons This should probably be turned into a dart package, I think many would find that very useful.

This addresses issue #4494 and #3199