### PR TITLE
do not forward errors if stream is closed

### DIFF
--- a/packages/flutter_tools/lib/src/commands/analyze_continuously.dart
+++ b/packages/flutter_tools/lib/src/commands/analyze_continuously.dart
@@ -255,7 +255,8 @@ class AnalysisServer {
     // {"event":"analysis.errors","params":{"file":"/Users/.../lib/main.dart","errors":[]}}
     final String file = issueInfo['file'];
     final List<AnalysisError> errors = issueInfo['errors'].map((Map<String, dynamic> json) => new AnalysisError(json)).toList();
-    _errorsController.add(new FileAnalysisErrors(file, errors));
+    if (!_errorsController.isClosed)
+      _errorsController.add(new FileAnalysisErrors(file, errors));
   }
 
   Future<bool> dispose() async {


### PR DESCRIPTION
Made progress with the [first round of fixes](https://github.com/flutter/flutter/commit/8742fb09fa81087662278429432186c9d171bfc9).
This addresses additional flaky tests.

As before, these are not failing for me locally, so this is a test fix.
Let's see what travis says after I create the PR.
@Hixie
