### PR TITLE
Set derived dir Flutter.framework directory readonly

### DIFF
--- a/packages/flutter_tools/bin/xcode_backend.sh
+++ b/packages/flutter_tools/bin/xcode_backend.sh
@@ -60,10 +60,12 @@ BuildApp() {
   RunCommand mkdir -p -- "$derived_dir"
   AssertExists "$derived_dir"
 
+  RunCommand chmod -R ug+w "${derived_dir}/Flutter.framework"
   RunCommand rm -rf -- "${derived_dir}/Flutter.framework"
   RunCommand rm -f -- "${derived_dir}/app.dylib"
   RunCommand rm -f -- "${derived_dir}/app.flx"
   RunCommand cp -r -- "${framework_path}/Flutter.framework" "${derived_dir}"
+  RunCommand chmod -R ug-w "${derived_dir}/Flutter.framework"
   RunCommand pushd "${project_path}" > /dev/null
 
   AssertExists "${target_path}"


### PR DESCRIPTION
Provides a strong hint to developers that editing Flutter framework
headers isn't supported.