### PR TITLE
Fix the gen_snapshot path for a local_engine FLX build in debug mode

### DIFF
--- a/packages/flutter_tools/lib/src/artifacts.dart
+++ b/packages/flutter_tools/lib/src/artifacts.dart
@@ -89,7 +89,6 @@ class CachedArtifacts extends Artifacts {
       case TargetPlatform.darwin_x64:
       case TargetPlatform.linux_x64:
       case TargetPlatform.windows_x64:
-        assert(mode == null, 'Platform $platform does not support different build modes.');
         return _getHostArtifactPath(artifact, platform);
     }
     assert(false, 'Invalid platform $platform.');
@@ -221,7 +220,7 @@ class LocalEngineArtifacts extends Artifacts {
         final String abi = _getAbiDirectory(platform);
         return fs.path.join(engineOutPath, 'gen', 'flutter', 'shell', 'platform', 'android', 'android', fs.path.join('android', 'libs', abi, _artifactToFileName(artifact)));
       case Artifact.genSnapshot:
-        return _genSnapshotPath(platform);
+        return _genSnapshotPath(platform, mode);
       case Artifact.skyShell:
         return _skyShellPath(platform);
       case Artifact.isolateSnapshotData:
@@ -240,9 +239,9 @@ class LocalEngineArtifacts extends Artifacts {
     return fs.path.basename(engineOutPath);
   }
 
-  String _genSnapshotPath(TargetPlatform platform) {
+  String _genSnapshotPath(TargetPlatform platform, BuildMode mode) {
     String clang;
-    if (platform == TargetPlatform.ios) {
+    if (platform == TargetPlatform.ios || mode == BuildMode.debug) {
       clang = 'clang_x64';
     } else {
       clang = getCurrentHostPlatform() == HostPlatform.darwin_x64 ? 'clang_i386' : 'clang_x86';

--- a/packages/flutter_tools/lib/src/flx.dart
+++ b/packages/flutter_tools/lib/src/flx.dart
@@ -36,7 +36,7 @@ Future<int> createSnapshot({
   assert(mainPath != null);
   assert(snapshotPath != null);
   assert(packages != null);
-  final String snapshotterPath = artifacts.getArtifactPath(Artifact.genSnapshot);
+  final String snapshotterPath = artifacts.getArtifactPath(Artifact.genSnapshot, null, BuildMode.debug);
   final String vmSnapshotData = artifacts.getArtifactPath(Artifact.vmSnapshotData);
   final String isolateSnapshotData = artifacts.getArtifactPath(Artifact.isolateSnapshotData);
 


### PR DESCRIPTION
gen_snapshot is now used for both JIT and AOT snapshots.  The JIT version
used in debug mode will be a 64-bit binary.