### PR TITLE
Use snapshot's .d file as source inputs in Gradle build.

### DIFF
--- a/packages/flutter_tools/gradle/flutter.gradle
+++ b/packages/flutter_tools/gradle/flutter.gradle
@@ -216,7 +216,6 @@ class FlutterTask extends DefaultTask {
                 return project.files(depText.split(': ')[1].split())
             } catch (Exception e) {
                 logger.error("Error reading dependency file ${dependenciesFile}: ${e}")
-                // Fall through to use source files.
             }
         }
         return null
@@ -232,12 +231,16 @@ class FlutterTask extends DefaultTask {
         }
         FileCollection sources = readDependencies(dependenciesFile)
         if (sources != null) {
+            // We have a dependencies file. Add a dependency on gen_snapshot as well, since the
+            // snapshots have to be rebuilt if it changes.
             FileCollection snapshotter = readDependencies(project.file("${intermediateDir}/gen_snapshot.d"))
             if (snapshotter != null) {
                 sources = sources.plus(snapshotter)
             }
+            // Finally, add a dependency on pubspec.yaml as well.
             return sources.plus(project.files('pubspec.yaml'))
         }
+        // No dependencies file (or problems parsing it). Fall back to source files.
         return project.fileTree(
                 dir: sourceDir,
                 exclude: ['android', 'ios'],

--- a/packages/flutter_tools/gradle/flutter.gradle
+++ b/packages/flutter_tools/gradle/flutter.gradle
@@ -207,9 +207,42 @@ class FlutterTask extends DefaultTask {
         }
     }
 
+    FileCollection readDependencies(File dependenciesFile) {
+        if (dependenciesFile.exists()) {
+            try {
+                // Dependencies file has Makefile syntax:
+                //   <target> <files>: <source> <files> <separated> <by> <space>
+                String depText = dependenciesFile.text
+                return project.files(depText.split(': ')[1].split())
+            } catch (Exception e) {
+                logger.error("Error reading dependency file ${dependenciesFile}: ${e}")
+                // Fall through to use source files.
+            }
+        }
+        return null
+    }
+
     @InputFiles
     FileCollection getSourceFiles() {
-        return project.fileTree(dir: sourceDir, exclude: ['android', 'ios'], include: ['**/*.dart', 'pubspec.yaml', 'flutter.yaml'])
+        File dependenciesFile
+        if (buildMode != 'debug') {
+            dependenciesFile = project.file("${intermediateDir}/snapshot.d")
+        } else {
+            dependenciesFile = project.file("${intermediateDir}/snapshot_blob.bin.d")
+        }
+        FileCollection sources = readDependencies(dependenciesFile)
+        if (sources != null) {
+            FileCollection snapshotter = readDependencies(project.file("${intermediateDir}/gen_snapshot.d"))
+            if (snapshotter != null) {
+                sources = sources.plus(snapshotter)
+            }
+            return sources.plus(project.files('pubspec.yaml'))
+        }
+        return project.fileTree(
+                dir: sourceDir,
+                exclude: ['android', 'ios'],
+                include: ['**/*.dart', 'pubspec.yaml']
+        )
     }
 
     @TaskAction

--- a/packages/flutter_tools/lib/src/commands/build_aot.dart
+++ b/packages/flutter_tools/lib/src/commands/build_aot.dart
@@ -124,6 +124,7 @@ Future<String> _buildAotSnapshot(
   final String vmSnapshotInstructions = fs.path.join(outputDir.path, 'vm_snapshot_instr');
   final String isolateSnapshotData = fs.path.join(outputDir.path, 'isolate_snapshot_data');
   final String isolateSnapshotInstructions = fs.path.join(outputDir.path, 'isolate_snapshot_instr');
+  final String dependencies = fs.path.join(outputDir.path, 'snapshot.d');
 
   final String vmEntryPoints = artifacts.getArtifactPath(Artifact.dartVmEntryPointsTxt, platform, buildMode);
   final String ioEntryPoints = artifacts.getArtifactPath(Artifact.dartIoEntriesTxt, platform, buildMode);
@@ -198,6 +199,7 @@ Future<String> _buildAotSnapshot(
     '--url_mapping=dart:jni,$jniPath',
     '--url_mapping=dart:vmservice_sky,$vmServicePath',
     '--print_snapshot_sizes',
+    '--dependencies=$dependencies',
   ];
 
   if (!interpreter) {
@@ -248,6 +250,10 @@ Future<String> _buildAotSnapshot(
     printError(results.toString());
     return null;
   }
+
+  // Write path to gen_snapshot, since snapshots have to be re-generated when we roll
+  // the Dart SDK.
+  await outputDir.childFile('gen_snapshot.d').writeAsString('snapshot.d: $genSnapshot\n');
 
   // On iOS, we use Xcode to compile the snapshot into a dynamic library that the
   // end-developer can link into their app.

--- a/packages/flutter_tools/lib/src/flx.dart
+++ b/packages/flutter_tools/lib/src/flx.dart
@@ -50,6 +50,7 @@ Future<int> createSnapshot({
   ];
   if (depfilePath != null) {
     args.add('--dependencies=$depfilePath');
+    fs.file(depfilePath).parent.childFile('gen_snapshot.d').writeAsString('$depfilePath: $snapshotterPath\n');
   }
   args.add(mainPath);
   return runCommandAndStreamOutput(args);


### PR DESCRIPTION
If we don't yet have a .d file (first build), fall back to using the
.dart files in the current directory. This enables us to detect changes
in dependent source files (Flutter framework, packages outside the
source directory, etc.), and re-generate the snapshots as needed.

Unfortunately, Gradle requires knowing the source files before executing
the task, and can't update them after building, so Gradle considers the
second build to be out-of-date (because it has more input files than the
first build). Sub-sequent builds have the correct dependency
information, and will be skipped if the source files haven't changed.

Also added a dependency on gen_snapshot. The snapshot ABI isn't stable,
so we need to re-generate the snapshots when we roll the Dart SDK
dependency.

Fixes #8315
Fixes #8687
Fixes #8607