### PR TITLE
Rename SliverPadding.child to SliverPadding.sliver

### DIFF
--- a/examples/flutter_gallery/lib/demo/pesto_demo.dart
+++ b/examples/flutter_gallery/lib/demo/pesto_demo.dart
@@ -139,7 +139,7 @@ class _RecipeGridPageState extends State<RecipeGridPage> {
     final EdgeInsets padding = const EdgeInsets.all(8.0);
     return new SliverPadding(
       padding: padding,
-      child: new SliverGrid(
+      sliver: new SliverGrid(
         gridDelegate: const SliverGridDelegateWithMaxCrossAxisExtent(
           maxCrossAxisExtent: _kRecipePageMaxWidth,
           crossAxisSpacing: 8.0,

--- a/examples/flutter_gallery/lib/demo/shrine/shrine_home.dart
+++ b/examples/flutter_gallery/lib/demo/shrine/shrine_home.dart
@@ -381,7 +381,7 @@ class _ShrineHomeState extends State<ShrineHome> {
           ),
           new SliverPadding(
             padding: const EdgeInsets.all(16.0),
-            child: new SliverGrid(
+            sliver: new SliverGrid(
               gridDelegate: gridDelegate,
               delegate: new SliverChildListDelegate(
                 _products.map((Product product) {

--- a/examples/flutter_gallery/lib/demo/shrine/shrine_order.dart
+++ b/examples/flutter_gallery/lib/demo/shrine/shrine_order.dart
@@ -197,7 +197,7 @@ class _OrderPageState extends State<OrderPage> {
           ),
           new SliverPadding(
             padding: const EdgeInsets.all(8.0),
-            child: new SliverGrid(
+            sliver: new SliverGrid(
               gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
                 crossAxisCount: 2,
                 mainAxisSpacing: 8.0,

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -1492,8 +1492,8 @@ class SliverPadding extends SingleChildRenderObjectWidget {
   SliverPadding({
     Key key,
     @required this.padding,
-    Widget child,
-  }) : super(key: key, child: child) {
+    Widget sliver,
+  }) : super(key: key, child: sliver) {
     assert(padding != null);
   }
 

--- a/packages/flutter/lib/src/widgets/scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/scroll_view.dart
@@ -172,7 +172,7 @@ abstract class BoxScrollView extends ScrollView {
   List<Widget> buildSlivers(BuildContext context) {
     Widget sliver = buildChildLayout(context);
     if (padding != null)
-      sliver = new SliverPadding(padding: padding, child: sliver);
+      sliver = new SliverPadding(padding: padding, sliver: sliver);
     return <Widget>[ sliver ];
   }
 

--- a/packages/flutter/test/material/scaffold_test.dart
+++ b/packages/flutter/test/material/scaffold_test.dart
@@ -145,7 +145,7 @@ void main() {
               ),
               new SliverPadding(
                 padding: const EdgeInsets.only(top: appBarHeight),
-                child: new SliverList(
+                sliver: new SliverList(
                   delegate: new SliverChildListDelegate(new List<Widget>.generate(
                     10, (int index) => new SizedBox(height: 100.0, child: new Text('B$index')),
                   )),

--- a/packages/flutter/test/widgets/slivers_evil_test.dart
+++ b/packages/flutter/test/widgets/slivers_evil_test.dart
@@ -93,7 +93,7 @@ void main() {
                   new SliverToBoxAdapter(child: new Container(height: 520.0)),
                   new SliverPadding(
                     padding: const EdgeInsets.all(50.0),
-                    child: new SliverToBoxAdapter(child: new Container(height: 520.0)),
+                    sliver: new SliverToBoxAdapter(child: new Container(height: 520.0)),
                   ),
                   new SliverToBoxAdapter(child: new Container(height: 520.0)),
                   new SliverPersistentHeader(delegate: new TestSliverPersistentHeaderDelegate(150.0), floating: true),
@@ -105,7 +105,7 @@ void main() {
                   new SliverToBoxAdapter(child: new Container(height: 520.0)),
                   new SliverPadding(
                     padding: const EdgeInsets.all(50.0),
-                    child: new SliverPersistentHeader(delegate: new TestSliverPersistentHeaderDelegate(250.0), pinned: true),
+                    sliver: new SliverPersistentHeader(delegate: new TestSliverPersistentHeaderDelegate(250.0), pinned: true),
                   ),
                   new SliverToBoxAdapter(child: new Container(height: 520.0)),
                   new SliverPersistentHeader(delegate: new TestSliverPersistentHeaderDelegate(250.0), pinned: true),
@@ -146,7 +146,7 @@ void main() {
                   new SliverPersistentHeader(delegate: new TestSliverPersistentHeaderDelegate(250.0)),
                   new SliverPadding(
                     padding: const EdgeInsets.symmetric(horizontal: 50.0),
-                    child: new SliverToBoxAdapter(child: new Container(height: 520.0)),
+                    sliver: new SliverToBoxAdapter(child: new Container(height: 520.0)),
                   ),
                   new SliverToBoxAdapter(child: new Container(height: 520.0)),
                   new SliverToBoxAdapter(child: new Container(height: 520.0)),

--- a/packages/flutter/test/widgets/slivers_padding_test.dart
+++ b/packages/flutter/test/widgets/slivers_padding_test.dart
@@ -14,7 +14,7 @@ Future<Null> test(WidgetTester tester, double offset, EdgeInsets padding, AxisDi
       new SliverToBoxAdapter(child: new SizedBox(width: 400.0, height: 400.0, child: new Text('before'))),
       new SliverPadding(
         padding: padding,
-        child: new SliverToBoxAdapter(child: new SizedBox(width: 400.0, height: 400.0, child: new Text('padded'))),
+        sliver: new SliverToBoxAdapter(child: new SizedBox(width: 400.0, height: 400.0, child: new Text('padded'))),
       ),
       new SliverToBoxAdapter(child: new SizedBox(width: 400.0, height: 400.0, child: new Text('after'))),
     ],


### PR DESCRIPTION
The new name follows the pattern of the name suggesting which layout
protocol the parent expects the child to speak.

Fixes #8664