### PR TITLE
Put Gradle output in build/

### DIFF
--- a/packages/flutter_tools/gradle/flutter.gradle
+++ b/packages/flutter_tools/gradle/flutter.gradle
@@ -265,6 +265,7 @@ class FlutterTask extends DefaultTask {
                     args "--local-engine-src-path", localEngineSrcPath
                 }
                 args "build", "aot"
+                args "--quiet"
                 args "--target", targetPath
                 args "--target-platform", "android-arm"
                 args "--output-dir", "${intermediateDir}"

--- a/packages/flutter_tools/lib/src/commands/build_aot.dart
+++ b/packages/flutter_tools/lib/src/commands/build_aot.dart
@@ -33,7 +33,8 @@ class BuildAotCommand extends BuildSubCommand {
         defaultsTo: 'android-arm',
         allowed: <String>['android-arm', 'ios']
       )
-      ..addFlag('interpreter');
+      ..addFlag('interpreter')
+      ..addFlag('quiet', defaultsTo: false);
   }
 
   @override
@@ -51,8 +52,11 @@ class BuildAotCommand extends BuildSubCommand {
       throwToolExit('Unknown platform: $targetPlatform');
 
     final String typeName = artifacts.getEngineType(platform, getBuildMode());
-    final Status status = logger.startProgress('Building AOT snapshot in ${getModeName(getBuildMode())} mode ($typeName)...',
-        expectSlowOperation: true);
+    Status status;
+    if (!argResults['quiet']) {
+      status = logger.startProgress('Building AOT snapshot in ${getModeName(getBuildMode())} mode ($typeName)...',
+          expectSlowOperation: true);
+    }
     final String outputPath = await buildAotSnapshot(
       findMainDartFile(targetFile),
       platform,
@@ -60,12 +64,17 @@ class BuildAotCommand extends BuildSubCommand {
       outputPath: argResults['output-dir'],
       interpreter: argResults['interpreter']
     );
-    status.stop();
+    status?.stop();
 
     if (outputPath == null)
       throwToolExit(null);
 
-    printStatus('Built to $outputPath${fs.path.separator}.');
+    final String builtMessage = 'Built to $outputPath${fs.path.separator}.';
+    if (argResults['quiet']) {
+      printTrace(builtMessage);
+    } else {
+      printStatus(builtMessage);
+    }
   }
 }
 

--- a/packages/flutter_tools/templates/create/android.tmpl/build.gradle
+++ b/packages/flutter_tools/templates/create/android.tmpl/build.gradle
@@ -14,6 +14,11 @@ allprojects {
     }
 }
 
+rootProject.buildDir = '../build'
+subprojects {
+    project.buildDir = "${rootProject.buildDir}/${project.name}"
+}
+
 task clean(type: Delete) {
     delete rootProject.buildDir
 }


### PR DESCRIPTION
Changed the default build output directory in the new project template
to build/, instead of android/build/ and android/app/build/.

Updated tools to ask the Gradle scripts what the build directory is,
since this is configurable in the build scripts, and we need to know
where the build output actually is.

Silenced output from 'flutter build aot' when invoked from Gradle, since
the output was confusing in this case.

Fixes #8723
Fixes #8656
Fixes #8138