### PR TITLE
Rename dependenciesChanged to didChangeDependencies

### DIFF
--- a/examples/flutter_gallery/lib/gallery/demo.dart
+++ b/examples/flutter_gallery/lib/gallery/demo.dart
@@ -109,7 +109,7 @@ class FullScreenCodeDialogState extends State<FullScreenCodeDialog> {
   String _exampleCode;
 
   @override
-  void dependenciesChanged() {
+  void didChangeDependencies() {
     getExampleCode(config.exampleCodeTag, DefaultAssetBundle.of(context)).then<Null>((String code) {
       if (mounted) {
         setState(() {
@@ -117,7 +117,7 @@ class FullScreenCodeDialogState extends State<FullScreenCodeDialog> {
         });
       }
     });
-    super.dependenciesChanged();
+    super.didChangeDependencies();
   }
 
   @override

--- a/packages/flutter/lib/src/material/app_bar.dart
+++ b/packages/flutter/lib/src/material/app_bar.dart
@@ -335,8 +335,8 @@ class _AppBarState extends State<AppBar> {
   bool _canPop = false;
 
   @override
-  void dependenciesChanged() {
-    super.dependenciesChanged();
+  void didChangeDependencies() {
+    super.didChangeDependencies();
     final ScaffoldState scaffold = Scaffold.of(context);
     _hasDrawer = scaffold?.hasDrawer ?? false;
     _canPop = ModalRoute.of(context)?.canPop ?? false;

--- a/packages/flutter/lib/src/material/refresh_indicator.dart
+++ b/packages/flutter/lib/src/material/refresh_indicator.dart
@@ -154,7 +154,7 @@ class RefreshIndicatorState extends State<RefreshIndicator> with TickerProviderS
   }
 
   @override
-  void dependenciesChanged() {
+  void didChangeDependencies() {
     final ThemeData theme = Theme.of(context);
     _valueColor = new ColorTween(
       begin: (config.color ?? theme.accentColor).withOpacity(0.0),
@@ -163,7 +163,7 @@ class RefreshIndicatorState extends State<RefreshIndicator> with TickerProviderS
       parent: _positionController,
       curve: const Interval(0.0, 1.0 / _kDragSizeFactorLimit)
     ));
-    super.dependenciesChanged();
+    super.didChangeDependencies();
   }
 
   @override

--- a/packages/flutter/lib/src/material/scrollbar.dart
+++ b/packages/flutter/lib/src/material/scrollbar.dart
@@ -46,8 +46,8 @@ class _ScrollbarState extends State<Scrollbar> with TickerProviderStateMixin {
   _ScrollbarController _controller;
 
   @override
-  void dependenciesChanged() {
-    super.dependenciesChanged();
+  void didChangeDependencies() {
+    super.didChangeDependencies();
     _controller ??= new _ScrollbarController(this);
     _controller.color = Theme.of(context).highlightColor;
   }

--- a/packages/flutter/lib/src/material/tabs.dart
+++ b/packages/flutter/lib/src/material/tabs.dart
@@ -464,8 +464,8 @@ class _TabBarState extends State<TabBar> {
   }
 
   @override
-  void dependenciesChanged() {
-    super.dependenciesChanged();
+  void didChangeDependencies() {
+    super.didChangeDependencies();
     _updateTabController();
   }
 
@@ -715,8 +715,8 @@ class _TabBarViewState extends State<TabBarView> {
   }
 
   @override
-  void dependenciesChanged() {
-    super.dependenciesChanged();
+  void didChangeDependencies() {
+    super.didChangeDependencies();
     _updateTabController();
     _currentIndex = _controller?.index;
     _pageController = new PageController(initialPage: _currentIndex ?? 0);

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -679,7 +679,7 @@ enum _StateLifecycle {
   created,
 
   /// The [State.initState] method has been called but the [State] object is
-  /// not yet ready to build. [State.dependenciesChanged] is called at this time.
+  /// not yet ready to build. [State.didChangeDependencies] is called at this time.
   initialized,
 
   /// The [State] object is ready to build and [State.dispose] has not yet been
@@ -725,10 +725,10 @@ typedef void StateSetter(VoidCallback fn);
 ///    [BuildContext] or the widget, which are available as the [context] and
 ///    [config] properties, respectively, when the [initState] method is
 ///    called.
-///  * The framework calls [dependenciesChanged]. Subclasses of [State] should
-///    override [dependenciesChanged] to perform initialization involving
+///  * The framework calls [didChangeDependencies]. Subclasses of [State] should
+///    override [didChangeDependencies] to perform initialization involving
 ///    [InheritedWidget]s. If [BuildContext.inheritFromWidgetOfExactType] is
-///    called, the [dependenciesChanged] method will be called again if the
+///    called, the [didChangeDependencies] method will be called again if the
 ///    inherited widgets subsequently change or if the widget moves in the tree.
 ///  * At this point, the [State] object is fully initialized and the framework
 ///    might call its [build] method any number of times to obtain a
@@ -842,7 +842,7 @@ abstract class State<T extends StatefulWidget> {
   /// [didUpdateConfig], and then unsubscribe from the object in [dispose].
   ///
   /// You cannot use [BuildContext.inheritFromWidgetOfExactType] from this
-  /// method. However, [dependenciesChanged] will be called immediately
+  /// method. However, [didChangeDependencies] will be called immediately
   /// following this method, and [BuildContext.inheritFromWidgetOfExactType] can
   /// be used there.
   ///
@@ -1090,7 +1090,7 @@ abstract class State<T extends StatefulWidget> {
   /// expensive to do for every build.
   @protected
   @mustCallSuper
-  void dependenciesChanged() { }
+  void didChangeDependencies() { }
 
   @override
   String toString() {
@@ -1556,7 +1556,7 @@ abstract class BuildContext {
   /// again if the inherited value were to change. To ensure that the widget
   /// correctly updates itself when the inherited value changes, only call this
   /// (directly or indirectly) from build methods, layout and paint callbacks, or
-  /// from [State.dependenciesChanged].
+  /// from [State.didChangeDependencies].
   ///
   /// It is also possible to call this from interaction event handlers (e.g.
   /// gesture callbacks) or timers, to obtain a value once, if that value is not
@@ -1566,7 +1566,7 @@ abstract class BuildContext {
   /// the widget being rebuilt more often.
   ///
   /// Once a widget registers a dependency on a particular type by calling this
-  /// method, it will be rebuilt, and [State.dependenciesChanged] will be
+  /// method, it will be rebuilt, and [State.didChangeDependencies] will be
   /// called, whenever changes occur relating to that widget until the next time
   /// the widget or one of its ancestors is moved (for example, because an
   /// ancestor is added or removed).
@@ -1580,7 +1580,7 @@ abstract class BuildContext {
   /// This method does not establish a relationship with the target in the way
   /// that [inheritFromWidgetOfExactType] does. It is normally used by such
   /// widgets to obtain their corresponding [InheritedElement] object so that they
-  /// can call [InheritedElement.dispatchDependenciesChanged] to actually
+  /// can call [InheritedElement.dispatchDidChangeDependencies] to actually
   /// notify the widgets that _did_ register such a relationship.
   InheritedElement ancestorInheritedElementForWidgetOfExactType(Type targetType);
 
@@ -2787,7 +2787,7 @@ abstract class Element implements BuildContext {
   /// [InheritedWidget.updateShouldNotify] returned true), the framework calls
   /// this function to notify this element of the change.
   @mustCallSuper
-  void dependenciesChanged() { }
+  void didChangeDependencies() { }
 
   /// Returns a description of what caused this element to be created.
   ///
@@ -3011,8 +3011,8 @@ abstract class BuildableElement extends Element {
   void performRebuild();
 
   @override
-  void dependenciesChanged() {
-    super.dependenciesChanged();
+  void didChangeDependencies() {
+    super.didChangeDependencies();
     assert(_active); // otherwise markNeedsBuild is a no-op
     markNeedsBuild();
   }
@@ -3024,7 +3024,7 @@ abstract class BuildableElement extends Element {
     if (_dirty)
       owner.scheduleBuildFor(this);
     if (hadDependencies)
-      dependenciesChanged();
+      didChangeDependencies();
   }
 
   @override
@@ -3208,7 +3208,7 @@ class StatefulElement extends ComponentElement {
       _debugSetAllowIgnoredCallsToMarkNeedsBuild(false);
     }
     assert(() { _state._debugLifecycleState = _StateLifecycle.initialized; return true; });
-    _state.dependenciesChanged();
+    _state.didChangeDependencies();
     assert(() { _state._debugLifecycleState = _StateLifecycle.ready; return true; });
     super._firstBuild();
   }
@@ -3277,7 +3277,7 @@ class StatefulElement extends ComponentElement {
           'then the rebuilt dependent widget will not reflect the changes in the '
           'inherited widget.\n'
           'Typically references to to inherited widgets should occur in widget build() methods. Alternatively, '
-          'initialization based on inherited widgets can be placed in the dependenciesChanged method, which '
+          'initialization based on inherited widgets can be placed in the didChangeDependencies method, which '
           'is called after initState and whenever the dependencies change thereafter.'
         );
       }
@@ -3307,9 +3307,9 @@ class StatefulElement extends ComponentElement {
   }
 
   @override
-  void dependenciesChanged() {
-    super.dependenciesChanged();
-    _state.dependenciesChanged();
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    _state.didChangeDependencies();
   }
 
   @override
@@ -3438,7 +3438,7 @@ class InheritedElement extends ProxyElement {
   void notifyClients(InheritedWidget oldWidget) {
     if (!widget.updateShouldNotify(oldWidget))
       return;
-    dispatchDependenciesChanged();
+    dispatchDidChangeDependencies();
   }
 
   /// Notifies all dependent elements that this inherited widget has changed.
@@ -3449,7 +3449,7 @@ class InheritedElement extends ProxyElement {
   /// the build phase. [InheritedWidget] subclasses can also call this directly
   /// by first obtaining their [InheritedElement] using
   /// [BuildContext.ancestorInheritedElementForWidgetOfExactType].
-  void dispatchDependenciesChanged() {
+  void dispatchDidChangeDependencies() {
     for (Element dependent in _dependents) {
       assert(() {
         // check that it really is our descendant
@@ -3460,7 +3460,7 @@ class InheritedElement extends ProxyElement {
       });
       // check that it really deepends on us
       assert(dependent._dependencies.contains(this));
-      dependent.dependenciesChanged();
+      dependent.didChangeDependencies();
     }
   }
 }

--- a/packages/flutter/lib/src/widgets/image.dart
+++ b/packages/flutter/lib/src/widgets/image.dart
@@ -217,9 +217,9 @@ class _ImageState extends State<Image> {
   ImageInfo _imageInfo;
 
   @override
-  void dependenciesChanged() {
+  void didChangeDependencies() {
     _resolveImage();
-    super.dependenciesChanged();
+    super.didChangeDependencies();
   }
 
   @override

--- a/packages/flutter/lib/src/widgets/routes.dart
+++ b/packages/flutter/lib/src/widgets/routes.dart
@@ -710,14 +710,14 @@ abstract class ModalRoute<T> extends TransitionRoute<T> with LocalHistoryRoute<T
   /// case, use the [Form.onWillPop] property to register the callback.
   ///
   /// To register a callback manually, look up the enclosing [ModalRoute] in a
-  /// [State.dependenciesChanged] callback:
+  /// [State.didChangeDependencies] callback:
   ///
   /// ```dart
   /// ModalRoute<dynamic> _route;
   ///
   /// @override
-  /// void dependenciesChanged() {
-  ///  super.dependenciesChanged();
+  /// void didChangeDependencies() {
+  ///  super.didChangeDependencies();
   ///  _route?.removeScopedWillPopCallback(askTheUserIfTheyAreSure);
   ///  _route = ModalRoute.of(context);
   ///  _route?.addScopedWillPopCallback(askTheUserIfTheyAreSure);

--- a/packages/flutter/lib/src/widgets/scrollable.dart
+++ b/packages/flutter/lib/src/widgets/scrollable.dart
@@ -142,8 +142,8 @@ class ScrollableState extends State<Scrollable> with TickerProviderStateMixin
   }
 
   @override
-  void dependenciesChanged() {
-    super.dependenciesChanged();
+  void didChangeDependencies() {
+    super.didChangeDependencies();
     _updatePosition();
   }
 

--- a/packages/flutter/lib/src/widgets/ticker_provider.dart
+++ b/packages/flutter/lib/src/widgets/ticker_provider.dart
@@ -118,10 +118,10 @@ abstract class SingleTickerProviderStateMixin implements State<dynamic>, TickerP
   }
 
   @override
-  void dependenciesChanged() {
+  void didChangeDependencies() {
     if (_ticker != null)
       _ticker.muted = !TickerMode.of(context);
-    super.dependenciesChanged();
+    super.didChangeDependencies();
   }
 
   @override
@@ -193,13 +193,13 @@ abstract class TickerProviderStateMixin implements State<dynamic>, TickerProvide
   }
 
   @override
-  void dependenciesChanged() {
+  void didChangeDependencies() {
     final bool muted = !TickerMode.of(context);
     if (_tickers != null) {
       for (Ticker ticker in _tickers)
         ticker.muted = muted;
     }
-    super.dependenciesChanged();
+    super.didChangeDependencies();
   }
 
   @override

--- a/packages/flutter/lib/src/widgets/will_pop_scope.dart
+++ b/packages/flutter/lib/src/widgets/will_pop_scope.dart
@@ -44,8 +44,8 @@ class _WillPopScopeState extends State<WillPopScope> {
   ModalRoute<dynamic> _route;
 
   @override
-  void dependenciesChanged() {
-    super.dependenciesChanged();
+  void didChangeDependencies() {
+    super.didChangeDependencies();
     if (config.onWillPop != null)
       _route?.removeScopedWillPopCallback(config.onWillPop);
     _route = ModalRoute.of(context);

--- a/packages/flutter/test/material/will_pop_test.dart
+++ b/packages/flutter/test/material/will_pop_test.dart
@@ -18,8 +18,8 @@ class SamplePageState extends State<SamplePage> {
   Future<bool> _callback() async => willPopValue;
 
   @override
-  void dependenciesChanged() {
-    super.dependenciesChanged();
+  void didChangeDependencies() {
+    super.didChangeDependencies();
     _route?.removeScopedWillPopCallback(_callback);
     _route = ModalRoute.of(context);
     _route?.addScopedWillPopCallback(_callback);
@@ -241,8 +241,8 @@ void main() {
     expect(find.text('Sample Form'), findsOneWidget);
 
     // Do it again. Note that each time the Alert is shown and dismissed
-    // the FormState's dependenciesChanged() method runs. We're making sure
-    // that the dependenciesChanged() method doesn't add an extra willPop
+    // the FormState's didChangeDependencies() method runs. We're making sure
+    // that the didChangeDependencies() method doesn't add an extra willPop
     // callback.
     await tester.tap(find.byTooltip('Back'));
     await tester.pump(); // Start the pop "back" operation.

--- a/packages/flutter_markdown/lib/src/markdown_raw.dart
+++ b/packages/flutter_markdown/lib/src/markdown_raw.dart
@@ -134,9 +134,9 @@ class MarkdownBodyRaw extends StatefulWidget {
 class _MarkdownBodyRawState extends State<MarkdownBodyRaw> {
 
   @override
-  void dependenciesChanged() {
+  void didChangeDependencies() {
     _buildMarkdownCache();
-    super.dependenciesChanged();
+    super.didChangeDependencies();
   }
 
   @override


### PR DESCRIPTION
The new name matches the style guide. (The old name was just old and predated
the style guide.)

Fixes #8000