### PR TITLE
promote the missing_return issue from a hint to a warning

### DIFF
--- a/.analysis_options
+++ b/.analysis_options
@@ -26,6 +26,8 @@ analyzer:
   errors:
     # treat missing required parameters as a warning (not a hint)
     missing_required_param: warning
+    # treat missing returns as a warning
+    missing_return: warning
     # allow overriding fields (if they use super, ideally...)
     strong_mode_invalid_field_override: ignore
     # allow type narrowing

--- a/.analysis_options_repo
+++ b/.analysis_options_repo
@@ -27,6 +27,8 @@ analyzer:
   errors:
     # treat missing required parameters as a warning (not a hint)
     missing_required_param: warning
+    # treat missing returns as a warning
+    missing_return: warning
     # allow overriding fields (if they use super, ideally...)
     strong_mode_invalid_field_override: ignore
     # allow type narrowing

--- a/packages/flutter/lib/analysis_options_user.yaml
+++ b/packages/flutter/lib/analysis_options_user.yaml
@@ -27,6 +27,8 @@ analyzer:
   errors:
     # treat missing required parameters as a warning (not a hint)
     missing_required_param: warning
+    # treat missing returns as a warning
+    missing_return: warning
     # allow overriding fields (if they use super, ideally...)
     strong_mode_invalid_field_override: ignore
     # allow type narrowing


### PR DESCRIPTION
- promote the `missing_return` issue from a hint to a warning
- fix https://github.com/flutter/flutter-intellij/issues/808

<img width="215" alt="screen shot 2017-03-14 at 2 31 30 pm" src="https://cloud.githubusercontent.com/assets/1269969/23923329/733a618c-08c3-11e7-97eb-b3b063cd275f.png">
