### PR TITLE
Only run pod install if CocoaPods v1.0.0 or greater is installed.

### DIFF
--- a/packages/flutter_tools/lib/src/ios/ios_workflow.dart
+++ b/packages/flutter_tools/lib/src/ios/ios_workflow.dart
@@ -60,7 +60,7 @@ class IOSWorkflow extends DoctorValidator implements Workflow {
     }
   }
 
-  bool get _cocoaPodsInstalledAndMeetsVersionCheck {
+  bool get cocoaPodsInstalledAndMeetsVersionCheck {
     if (!hasCocoaPods)
       return false;
     try {

--- a/packages/flutter_tools/lib/src/ios/ios_workflow.dart
+++ b/packages/flutter_tools/lib/src/ios/ios_workflow.dart
@@ -178,7 +178,7 @@ class IOSWorkflow extends DoctorValidator implements Workflow {
           ));
         }
       }
-      if (_cocoaPodsInstalledAndMeetsVersionCheck) {
+      if (cocoaPodsInstalledAndMeetsVersionCheck) {
         messages.add(new ValidationMessage('CocoaPods version $cocoaPodsVersionText'));
       } else {
         if (!hasCocoaPods) {

--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -321,8 +321,9 @@ bool _checkXcodeVersion() {
 
 void _runPodInstall(Directory bundle, String engineDirectory)  {
   if (fs.file(fs.path.join(bundle.path, 'Podfile')).existsSync()) {
-    if (!doctor.iosWorkflow.hasCocoaPods) {
-      printError('Warning: CocoaPods not installed. Not running pod install.');
+    if (!doctor.iosWorkflow.cocoaPodsInstalledAndMeetsVersionCheck) {
+      final String minimumVersion = doctor.iosWorkflow.cocoaPodsMinimumVersion;
+      printError('Warning: CocoaPods version $minimumVersion or greater not installed. Skipping pod install.');
       return;
     }
     try {


### PR DESCRIPTION
Avoid issues with older versions of CocoaPods breaking the build. Users who genuinely use older versions of CocoaPods will have to run pod install manually when required.