### PR TITLE
Stop using package:stack_trace and Chain.capture

### DIFF
--- a/packages/flutter_tools/lib/executable.dart
+++ b/packages/flutter_tools/lib/executable.dart
@@ -9,7 +9,6 @@ import 'package:flutter_tools/src/version.dart';
 import 'package:intl/intl_standalone.dart' as intl;
 import 'package:meta/meta.dart';
 import 'package:process/process.dart';
-import 'package:stack_trace/stack_trace.dart';
 
 import 'src/artifacts.dart';
 import 'src/base/common.dart';
@@ -138,17 +137,14 @@ Future<int> run(List<String> args, List<FlutterCommand> subCommands, {
     // Initialize the system locale.
     await intl.findSystemLocale();
 
-    final Completer<int> runCompleter = new Completer<int>();
-    Chain.capture<Future<Null>>(() async {
+    try {
       await runner.run(args);
       await _exit(0);
-      runCompleter.complete(0);
-    }, onError: (dynamic error, Chain chain) {
+    } catch (error, stackTrace) {
       String getVersion() => flutterVersion ?? FlutterVersion.getVersionString();
-      _handleToolError(error, chain, verbose, args, reportCrashes, getVersion)
-          .then(runCompleter.complete, onError: runCompleter.completeError);
-    });
-    return runCompleter.future;
+      return await _handleToolError(error, stackTrace, verbose, args, reportCrashes, getVersion);
+    }
+    return 0;
   });
 }
 
@@ -164,7 +160,7 @@ WriteCallback writelnStderr = stderr.writeln;
 
 Future<int> _handleToolError(
     dynamic error,
-    Chain chain,
+    StackTrace stackTrace,
     bool verbose,
     List<String> args,
     bool reportCrashes,
@@ -184,7 +180,7 @@ Future<int> _handleToolError(
       writelnStderr(error.message);
     if (verbose) {
       writelnStderr();
-      writelnStderr(chain.terse.toString());
+      writelnStderr(stackTrace.toString());
       writelnStderr();
     }
     return _exit(error.exitCode ?? 1);
@@ -203,10 +199,10 @@ Future<int> _handleToolError(
     if (!reportCrashes) {
       // Print the stack trace on the bots - don't write a crash report.
       writelnStderr('$error');
-      writelnStderr(chain.terse.toString());
+      writelnStderr(stackTrace.toString());
       return _exit(1);
     } else {
-      flutterUsage.sendException(error, chain);
+      flutterUsage.sendException(error, stackTrace);
 
       if (error is String)
         writelnStderr('Oops; flutter has exited unexpectedly: "$error".');
@@ -215,11 +211,11 @@ Future<int> _handleToolError(
 
       await CrashReportSender.instance.sendReport(
         error: error,
-        stackTrace: chain,
+        stackTrace: stackTrace,
         getFlutterVersion: getFlutterVersion,
       );
       try {
-        final File file = await _createLocalCrashReport(args, error, chain);
+        final File file = await _createLocalCrashReport(args, error, stackTrace);
         writelnStderr(
             'Crash report written to ${file.path};\n'
                 'please let us know at https://github.com/flutter/flutter/issues.',
@@ -249,7 +245,7 @@ Future<int> _handleToolError(
 FileSystem crashFileSystem = const LocalFileSystem();
 
 /// Saves the crash report to a local file.
-Future<File> _createLocalCrashReport(List<String> args, dynamic error, Chain chain) async {
+Future<File> _createLocalCrashReport(List<String> args, dynamic error, StackTrace stackTrace) async {
   File crashFile = getUniqueFile(crashFileSystem.currentDirectory, 'flutter', 'log');
 
   final StringBuffer buffer = new StringBuffer();
@@ -261,7 +257,7 @@ Future<File> _createLocalCrashReport(List<String> args, dynamic error, Chain cha
 
   buffer.writeln('## exception\n');
   buffer.writeln('${error.runtimeType}: $error\n');
-  buffer.writeln('```\n${chain.terse}```\n');
+  buffer.writeln('```\n$stackTrace```\n');
 
   buffer.writeln('## flutter doctor\n');
   buffer.writeln('```\n${await _doctorText()}```');

--- a/packages/flutter_tools/lib/src/base/logger.dart
+++ b/packages/flutter_tools/lib/src/base/logger.dart
@@ -7,7 +7,6 @@ import 'dart:convert' show ASCII, LineSplitter;
 
 import 'package:intl/intl.dart';
 import 'package:meta/meta.dart';
-import 'package:stack_trace/stack_trace.dart';
 
 import 'io.dart';
 import 'platform.dart';
@@ -67,7 +66,7 @@ class StdoutLogger extends Logger {
 
     stderr.writeln(message);
     if (stackTrace != null)
-      stderr.writeln(new Chain.forTrace(stackTrace).terse.toString());
+      stderr.writeln(stackTrace.toString());
   }
 
   @override
@@ -264,6 +263,7 @@ class AnsiTerminal {
   static const String _reset = '\u001B[0m';
   static const String _clear = '\u001B[2J\u001B[H';
 
+  static const int _ENXIO = 6;
   static const int _ENOTTY = 25;
   static const int _ENETRESET = 102;
   static const int _ERROR_INVALID_PARAMETER = 87;
@@ -271,6 +271,7 @@ class AnsiTerminal {
   /// Setting the line mode can throw for some terminals (with "Operation not
   /// supported on socket"), but the error can be safely ignored.
   static const List<int> _lineModeIgnorableErrors = const <int>[
+    _ENXIO,
     _ENOTTY,
     _ENETRESET,
     _ERROR_INVALID_PARAMETER, // TODO(goderbauer): remove when https://github.com/dart-lang/sdk/issues/28599 is fixed

--- a/packages/flutter_tools/lib/src/crash_reporting.dart
+++ b/packages/flutter_tools/lib/src/crash_reporting.dart
@@ -6,7 +6,6 @@ import 'dart:async';
 
 import 'package:http/http.dart' as http;
 import 'package:meta/meta.dart';
-import 'package:stack_trace/stack_trace.dart';
 
 import 'base/io.dart';
 import 'globals.dart';
@@ -69,7 +68,7 @@ class CrashReportSender {
   /// The report is populated from data in [error] and [stackTrace].
   Future<Null> sendReport({
     @required dynamic error,
-    @required dynamic stackTrace,
+    @required StackTrace stackTrace,
     @required String getFlutterVersion(),
   }) async {
     try {
@@ -98,13 +97,9 @@ class CrashReportSender {
       req.fields['type'] = _kDartTypeId;
       req.fields['error_runtime_type'] = '${error.runtimeType}';
 
-      final Chain chain = stackTrace is StackTrace
-          ? new Chain.forTrace(stackTrace)
-          : new Chain.parse(stackTrace.toString());
-
       req.files.add(new http.MultipartFile.fromString(
         _kStackTraceFileField,
-        '${chain.terse}',
+        stackTrace.toString(),
         filename: _kStackTraceFilename,
       ));
 

--- a/packages/flutter_tools/lib/src/run_cold.dart
+++ b/packages/flutter_tools/lib/src/run_cold.dart
@@ -5,10 +5,8 @@
 import 'dart:async';
 
 import 'package:meta/meta.dart';
-import 'package:stack_trace/stack_trace.dart';
 
 import 'application_package.dart';
-import 'base/common.dart';
 import 'base/file_system.dart';
 import 'base/utils.dart';
 import 'build_info.dart';
@@ -40,30 +38,6 @@ class ColdRunner extends ResidentRunner {
 
   @override
   Future<int> run({
-    Completer<DebugConnectionInfo> connectionInfoCompleter,
-    Completer<Null> appStartedCompleter,
-    String route,
-    bool shouldBuild: true
-  }) {
-    // Don't let uncaught errors kill the process.
-    return Chain.capture(() {
-      return _run(
-        traceStartup: traceStartup,
-        connectionInfoCompleter: connectionInfoCompleter,
-        appStartedCompleter: appStartedCompleter,
-        route: route,
-        shouldBuild: shouldBuild
-      );
-    }, onError: (dynamic error, StackTrace stackTrace) {
-      // Actually exit on ToolExit.
-      if (error is ToolExit)
-        throw error;
-      printError('Exception from flutter run: $error', stackTrace);
-    });
-  }
-
-  Future<int> _run({
-    bool traceStartup: false,
     Completer<DebugConnectionInfo> connectionInfoCompleter,
     Completer<Null> appStartedCompleter,
     String route,


### PR DESCRIPTION
- [x] Don't use package:stack_trace.
- [x] Don't use Chain.capture.
- [x] Fix an instance of aggressive catching of exceptions

Related #8742 

@tvolkert 