### PR TITLE
Escalate `missing_return` hints to warnings (flutter-intellij/808)

### DIFF
--- a/.analysis_options
+++ b/.analysis_options
@@ -26,6 +26,8 @@ analyzer:
   errors:
     # treat missing required parameters as a warning (not a hint)
     missing_required_param: warning
+    # treat missing returns as a warning (not a hint)
+    missing_return: warning
     # allow overriding fields (if they use super, ideally...)
     strong_mode_invalid_field_override: ignore
     # allow type narrowing

--- a/.analysis_options_repo
+++ b/.analysis_options_repo
@@ -27,6 +27,8 @@ analyzer:
   errors:
     # treat missing required parameters as a warning (not a hint)
     missing_required_param: warning
+    # treat missing returns as a warning (not a hint)
+    missing_return: warning    
     # allow overriding fields (if they use super, ideally...)
     strong_mode_invalid_field_override: ignore
     # allow type narrowing

--- a/packages/flutter/lib/analysis_options_user.yaml
+++ b/packages/flutter/lib/analysis_options_user.yaml
@@ -27,6 +27,8 @@ analyzer:
   errors:
     # treat missing required parameters as a warning (not a hint)
     missing_required_param: warning
+    # treat missing returns as a warning (not a hint)
+    missing_return: warning
     # allow overriding fields (if they use super, ideally...)
     strong_mode_invalid_field_override: ignore
     # allow type narrowing


### PR DESCRIPTION
Fixes: https://github.com/flutter/flutter-intellij/issues/808

@Hixie @abarth 

FYI @devoncarew 