### PR TITLE
Add tasks for Windows bots in device lab

### DIFF
--- a/dev/devicelab/bin/tasks/flutter_gallery_win__build.dart
+++ b/dev/devicelab/bin/tasks/flutter_gallery_win__build.dart
@@ -1,0 +1,11 @@
+// Copyright (c) 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+
+import 'flutter_gallery__build.dart' as flutter_gallery_build;
+
+Future<Null> main() async {
+  await flutter_gallery_build.main();
+}

--- a/dev/devicelab/bin/tasks/hot_mode_dev_cycle_win__benchmark.dart
+++ b/dev/devicelab/bin/tasks/hot_mode_dev_cycle_win__benchmark.dart
@@ -1,0 +1,9 @@
+// Copyright (c) 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'hot_mode_dev_cycle__benchmark.dart' as hot_mode_dev_cycle_benchmark;
+
+void main() {
+  hot_mode_dev_cycle_benchmark.main();
+}

--- a/dev/devicelab/manifest.yaml
+++ b/dev/devicelab/manifest.yaml
@@ -178,3 +178,18 @@ tasks:
       Runs benchmarks from dev/benchmarks/microbenchmarks on iOS.
     stage: devicelab_ios
     required_agent_capabilities: ["has-ios-device"]
+
+  # Tests running on Windows host
+
+  flutter_gallery_win__build:
+    description: >
+      Collects various performance metrics from AOT builds of the Flutter
+      Gallery on Windows.
+    stage: devicelab_win
+    required_agent_capabilities: ["windows"]
+
+  hot_mode_dev_cycle_win__benchmark:
+    description: >
+      Measures the performance of Dart VM hot patching feature on Windows.
+    stage: devicelab_win
+    required_agent_capabilities: ["windows"]


### PR DESCRIPTION
Adds two tasks:
* AOT build gallery on Windows
* Hot-Reload on Windows

/cc @yjbanov 