### PR TITLE
Stop ignoring `strong_mode_down_cast_composite`s (#8783)

### DIFF
--- a/.analysis_options
+++ b/.analysis_options
@@ -30,8 +30,6 @@ analyzer:
     missing_return: warning
     # allow overriding fields (if they use super, ideally...)
     strong_mode_invalid_field_override: ignore
-    # allow type narrowing
-    strong_mode_down_cast_composite: ignore
     # allow having TODOs in the code
     todo: ignore
   exclude:

--- a/.analysis_options_repo
+++ b/.analysis_options_repo
@@ -31,8 +31,6 @@ analyzer:
     missing_return: warning    
     # allow overriding fields (if they use super, ideally...)
     strong_mode_invalid_field_override: ignore
-    # allow type narrowing
-    strong_mode_down_cast_composite: ignore
     # allow having TODOs in the code
     todo: ignore
   # `flutter analyze` (without `--watch`) just ignores directories

--- a/packages/flutter/lib/analysis_options_user.yaml
+++ b/packages/flutter/lib/analysis_options_user.yaml
@@ -31,8 +31,6 @@ analyzer:
     missing_return: warning
     # allow overriding fields (if they use super, ideally...)
     strong_mode_invalid_field_override: ignore
-    # allow type narrowing
-    strong_mode_down_cast_composite: ignore
     # allow having TODOs in the code
     todo: ignore
 


### PR DESCRIPTION
Buying down some `ignore` debt!

Thanks to @kasperl , as of `dev-9.0`, `strong_mode_down_cast_composite` is a strong-mode hint and no longer needs to be ignored. 🤘 

Fixes: #8783


@Hixie @abarth @eseidelGoogle 

