### PR TITLE
Avoid downloading artifacts twice

### DIFF
--- a/packages/flutter_tools/lib/src/commands/precache.dart
+++ b/packages/flutter_tools/lib/src/commands/precache.dart
@@ -20,6 +20,9 @@ class PrecacheCommand extends FlutterCommand {
   final String description = 'Populates the Flutter tool\'s cache of binary artifacts.';
 
   @override
+  bool get shouldUpdateCache => false;
+
+  @override
   Future<Null> runCommand() async {
     if (argResults['all-platforms'])
       cache.includeAllPlatforms = true;

--- a/packages/flutter_tools/lib/src/commands/upgrade.dart
+++ b/packages/flutter_tools/lib/src/commands/upgrade.dart
@@ -23,6 +23,9 @@ class UpgradeCommand extends FlutterCommand {
   final String description = 'Upgrade your copy of Flutter.';
 
   @override
+  bool get shouldUpdateCache => false;
+
+  @override
   Future<Null> runCommand() async {
     try {
       runCheckedSync(<String>[

--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -37,6 +37,8 @@ abstract class FlutterCommand extends Command<Null> {
 
   bool get shouldRunPub => _usesPubOption && argResults['pub'];
 
+  bool get shouldUpdateCache => true;
+
   BuildMode _defaultBuildMode;
 
   void usesTargetOption() {
@@ -134,7 +136,8 @@ abstract class FlutterCommand extends Command<Null> {
   Future<Null> verifyThenRunCommand() async {
     // Populate the cache. We call this before pub get below so that the sky_engine
     // package is available in the flutter cache for pub to find.
-    await cache.updateAll();
+    if (shouldUpdateCache)
+      await cache.updateAll();
 
     if (shouldRunPub)
       await pubGet();

--- a/packages/flutter_tools/test/src/runner/flutter_command_test.dart
+++ b/packages/flutter_tools/test/src/runner/flutter_command_test.dart
@@ -1,0 +1,63 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:flutter_tools/src/cache.dart';
+import 'package:flutter_tools/src/runner/flutter_command.dart';
+import 'package:mockito/mockito.dart';
+import 'package:test/test.dart';
+
+import '../context.dart';
+
+void main() {
+
+  group('Flutter Command', () {
+
+    MockCache cache;
+
+    setUp(() {
+      cache = new MockCache();
+    });
+
+    testUsingContext('honors shouldUpdateCache false', () async {
+      final DummyFlutterCommand flutterCommand = new DummyFlutterCommand(shouldUpdateCache: false);
+      await flutterCommand.run();
+      verifyZeroInteractions(cache);
+    },
+    overrides: <Type, Generator>{
+      Cache: () => cache,
+    });
+
+    testUsingContext('honors shouldUpdateCache true', () async {
+      final DummyFlutterCommand flutterCommand = new DummyFlutterCommand(shouldUpdateCache: true);
+      await flutterCommand.run();
+      verify(cache.updateAll()).called(1);
+    },
+    overrides: <Type, Generator>{
+      Cache: () => cache,
+    });
+  });
+}
+
+class DummyFlutterCommand extends FlutterCommand {
+
+  DummyFlutterCommand({this.shouldUpdateCache});
+
+  @override
+  final bool shouldUpdateCache;
+
+  @override
+  String get description => 'does nothing';
+
+  @override
+  String get name => 'dummy';
+
+  @override
+  Future<Null> runCommand() async {
+    // does nothing.
+  }
+}
+
+class MockCache extends Mock implements Cache {}


### PR DESCRIPTION
* Don't update cache before `flutter upgrade` is executed (`flutter upgrade` might bump the engine version)
* Don't update cache twice during `flutter precache`

Fixes #8249.