### PR TITLE
Adds support for custom fonts for icons

### DIFF
--- a/packages/flutter/lib/src/material/icon.dart
+++ b/packages/flutter/lib/src/material/icon.dart
@@ -114,7 +114,7 @@ class Icon extends StatelessWidget {
                 inherit: false,
                 color: iconColor,
                 fontSize: iconSize,
-                fontFamily: 'MaterialIcons'
+                fontFamily: icon.fontFamily
               )
             )
           )

--- a/packages/flutter/lib/src/material/icons.dart
+++ b/packages/flutter/lib/src/material/icons.dart
@@ -10,10 +10,15 @@ class IconData {
   ///
   /// Rarely used directly. Instead, consider using one of the predefined icons
   /// from the [Icons] collection.
-  const IconData(this.codePoint);
+  const IconData(this.codePoint, {
+    this.fontFamily: 'MaterialIcons'
+  });
 
   /// The unicode code point at which this icon is stored in the icon font.
   final int codePoint;
+
+  /// The font family from which the glyph for the [codePoint] will be selected.
+  final String fontFamily;
 
   @override
   bool operator ==(dynamic other) {

--- a/packages/flutter/test/material/icon_test.dart
+++ b/packages/flutter/test/material/icon_test.dart
@@ -11,8 +11,8 @@ void main() {
   testWidgets('Icon sizing - no theme, default size', (WidgetTester tester) async {
     await tester.pumpWidget(
       new Center(
-        child: const Icon(null)
-      )
+        child: const Icon(null),
+      ),
     );
 
     final RenderBox renderObject = tester.renderObject(find.byType(Icon));
@@ -24,9 +24,9 @@ void main() {
       new Center(
         child: const Icon(
           null,
-          size: 96.0
-        )
-      )
+          size: 96.0,
+        ),
+      ),
     );
 
     final RenderBox renderObject = tester.renderObject(find.byType(Icon));
@@ -38,9 +38,9 @@ void main() {
       new Center(
         child: new IconTheme(
           data: const IconThemeData(size: 36.0),
-          child: const Icon(null)
-        )
-      )
+          child: const Icon(null),
+        ),
+      ),
     );
 
     final RenderBox renderObject = tester.renderObject(find.byType(Icon));
@@ -54,9 +54,9 @@ void main() {
           data: const IconThemeData(size: 36.0),
           child: const Icon(
             null,
-            size: 48.0
-          )
-        )
+            size: 48.0,
+          ),
+        ),
       )
     );
 
@@ -69,12 +69,24 @@ void main() {
       new Center(
         child: new IconTheme(
           data: const IconThemeData(),
-          child: const Icon(null)
-        )
-      )
+          child: const Icon(null),
+        ),
+      ),
     );
 
     final RenderBox renderObject = tester.renderObject(find.byType(Icon));
     expect(renderObject.size, equals(const Size.square(24.0)));
+  });
+
+
+  testWidgets('Icon with custom font', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      new Center(
+        child: const Icon(const IconData(0x41, fontFamily: 'Roboto')),
+      ),
+    );
+
+    final RichText richText = tester.firstWidget(find.byType(RichText));
+    expect(richText.text.style.fontFamily, equals('Roboto'));
   });
 }


### PR DESCRIPTION
This update adds support for custom fonts in icons. As an example, it
can be used with the icon-set from https://materialdesignicons.com

Thanks to @vlidholt for the original patch.

Fixes #4494
Fixes #3199