### PR TITLE
Updating Cupertino Button MinSize to comply with iOS guidelines

### DIFF
--- a/packages/flutter/lib/src/cupertino/button.dart
+++ b/packages/flutter/lib/src/cupertino/button.dart
@@ -135,6 +135,7 @@ class _CupertinoButtonState extends State<CupertinoButton> with SingleTickerProv
   Widget build(BuildContext context) {
     final bool enabled = config.enabled;
     final Color backgroundColor = config.color;
+    
     return new Listener(
       onPointerDown: enabled ? _handleTapDown : null,
       onPointerUp: enabled ? _handleTapUp : null,

--- a/packages/flutter/lib/src/cupertino/button.dart
+++ b/packages/flutter/lib/src/cupertino/button.dart
@@ -77,7 +77,7 @@ class CupertinoButton extends StatefulWidget {
   ///
   /// See also:
   ///
-  /// * <https://developer.apple.com/ios/human-interface-guidelines/ui-controls/buttons/>
+  /// * <https://developer.apple.com/ios/human-interface-guidelines/visual-design/layout/>
   final double minSize;
 
   /// Whether the button is enabled or disabled. Buttons are disabled by default. To

--- a/packages/flutter/lib/src/cupertino/button.dart
+++ b/packages/flutter/lib/src/cupertino/button.dart
@@ -46,6 +46,7 @@ class CupertinoButton extends StatefulWidget {
     @required this.child,
     this.padding,
     this.color,
+    this.minSize: 44.0,
     @required this.onPressed,
   });
 
@@ -68,6 +69,16 @@ class CupertinoButton extends StatefulWidget {
   ///
   /// If this is set to null, the button will be disabled.
   final VoidCallback onPressed;
+
+  /// Minimum size of the button.
+  ///
+  /// Defaults to 44.0 which the iOS Human Interface Guideline recommends as the
+  /// minimum tappable area
+  ///
+  /// See also:
+  ///
+  /// * <https://developer.apple.com/ios/human-interface-guidelines/ui-controls/buttons/>
+  final double minSize;
 
   /// Whether the button is enabled or disabled. Buttons are disabled by default. To
   /// enable a button, set its [onPressed] property to a non-null value.
@@ -124,16 +135,17 @@ class _CupertinoButtonState extends State<CupertinoButton> with SingleTickerProv
   Widget build(BuildContext context) {
     final bool enabled = config.enabled;
     final Color backgroundColor = config.color;
-
     return new Listener(
       onPointerDown: enabled ? _handleTapDown : null,
       onPointerUp: enabled ? _handleTapUp : null,
       onPointerCancel: enabled ? _handleTapCancel : null,
-
       child: new GestureDetector(
         onTap: config.onPressed,
         child: new ConstrainedBox(
-          constraints: const BoxConstraints(minWidth: 48.0, minHeight: 48.0),
+          constraints: new BoxConstraints(
+            minWidth: config.minSize,
+            minHeight: config.minSize,
+          ),
           child: new FadeTransition(
             opacity: new CurvedAnimation(
               parent: _animationController,

--- a/packages/flutter/lib/src/cupertino/button.dart
+++ b/packages/flutter/lib/src/cupertino/button.dart
@@ -135,7 +135,7 @@ class _CupertinoButtonState extends State<CupertinoButton> with SingleTickerProv
   Widget build(BuildContext context) {
     final bool enabled = config.enabled;
     final Color backgroundColor = config.color;
-    
+
     return new Listener(
       onPointerDown: enabled ? _handleTapDown : null,
       onPointerUp: enabled ? _handleTapUp : null,

--- a/packages/flutter/test/cupertino/button_test.dart
+++ b/packages/flutter/test/cupertino/button_test.dart
@@ -23,7 +23,7 @@ void main() {
     final RenderBox buttonBox = tester.renderObject(find.byType(CupertinoButton));
     expect(
       buttonBox.size,
-      // 1 10px character + 16px * 2 is smaller than the default 44dp minimum.
+      // 1 10px character + 16px * 2 is smaller than the default 44px minimum.
       const Size.square(44.0),
     );
   });
@@ -40,7 +40,7 @@ void main() {
     final RenderBox buttonBox = tester.renderObject(find.byType(CupertinoButton));
     expect(
       buttonBox.size,
-      // 1 10px character + 16px * 2 is smaller than defined 60.0dp minimum
+      // 1 10px character + 16px * 2 is smaller than defined 60.0px minimum
       new Size.square(minSize),
     );
   });

--- a/packages/flutter/test/cupertino/button_test.dart
+++ b/packages/flutter/test/cupertino/button_test.dart
@@ -13,7 +13,7 @@ const TextStyle testStyle = const TextStyle(
 );
 
 void main() {
-  testWidgets('Layout minimum size', (WidgetTester tester) async {
+  testWidgets('Default layout minimum size', (WidgetTester tester) async {
     await tester.pumpWidget(
       new Center(child: new CupertinoButton(
         child: new Text('X', style: testStyle),
@@ -23,8 +23,25 @@ void main() {
     final RenderBox buttonBox = tester.renderObject(find.byType(CupertinoButton));
     expect(
       buttonBox.size,
-      // 1 10px character + 16px * 2 is smaller than the 48px minimum.
-      const Size.square(48.0),
+      // 1 10px character + 16px * 2 is smaller than the default 44dp minimum.
+      const Size.square(44.0),
+    );
+  });
+
+  testWidgets('Minimum size parameter', (WidgetTester tester) async {
+    final double minSize = 60.0;
+    await tester.pumpWidget(
+      new Center(child: new CupertinoButton(
+        child: new Text('X', style: testStyle),
+        onPressed: null,
+        minSize: minSize,
+      ))
+    );
+    final RenderBox buttonBox = tester.renderObject(find.byType(CupertinoButton));
+    expect(
+      buttonBox.size,
+      // 1 10px character + 16px * 2 is smaller than defined 60.0dp minimum
+      new Size.square(minSize),
     );
   });
 


### PR DESCRIPTION
The recommended minimum tappable area is actually 44.0pt according to the [iOS Human Interface Guidline](https://developer.apple.com/ios/human-interface-guidelines/visual-design/layout/).

> Provide ample spacing for interactive elements. Try to maintain a minimum tappable area of 44pt x 44pt for all controls.

I've also added an override to allow for flexibility in situations where designers get naughty and have a desire to make everything super small.