### PR TITLE
Automatically wire dependencies for native plugins

### DIFF
--- a/packages/flutter_tools/gradle/flutter.gradle
+++ b/packages/flutter_tools/gradle/flutter.gradle
@@ -140,7 +140,7 @@ class FlutterPlugin implements Plugin<Project> {
         project.extensions.create("flutter", FlutterExtension)
         project.afterEvaluate this.&addFlutterTask
 
-        File pluginsFile = new File(project.rootProject.projectDir.parentFile, 'flutter-plugins.properties')
+        File pluginsFile = new File(project.rootProject.projectDir.parentFile, '.flutter-plugins')
         Properties plugins = readPropertiesIfExist(pluginsFile)
 
         plugins.each { name, _ ->

--- a/packages/flutter_tools/gradle/flutter.gradle
+++ b/packages/flutter_tools/gradle/flutter.gradle
@@ -144,11 +144,15 @@ class FlutterPlugin implements Plugin<Project> {
         Properties plugins = readPropertiesIfExist(pluginsFile)
 
         plugins.each { name, _ ->
-            def pluginProject = project.rootProject.project(":$name")
-            project.dependencies {
-                compile pluginProject
+            def pluginProject = project.rootProject.findProject(":$name")
+            if (pluginProject != null) {
+                project.dependencies {
+                    compile pluginProject
+                }
+                pluginProject.afterEvaluate this.&addFlutterJarDependency
+            } else {
+                project.logger.error("Plugin project :$name not found. Please update settings.gradle.")
             }
-            pluginProject.afterEvaluate this.&addFlutterJarDependency
         }
     }
 

--- a/packages/flutter_tools/gradle/flutter.gradle
+++ b/packages/flutter_tools/gradle/flutter.gradle
@@ -34,13 +34,22 @@ class FlutterPlugin implements Plugin<Project> {
     private String localEngineSrcPath
     private Properties localProperties
 
+    private File flutterJar
+    private File debugFlutterJar
+    private File profileFlutterJar
+    private File releaseFlutterJar
+
+    private Properties readPropertiesIfExist(File propertiesFile) {
+        Properties result = new Properties()
+        if (propertiesFile.exists()) {
+            propertiesFile.withInputStream { stream -> result.load(stream) }
+        }
+        return result
+    }
+
     private String resolveProperty(Project project, String name, String defaultValue) {
         if (localProperties == null) {
-            localProperties = new Properties()
-            def localPropertiesFile = project.rootProject.file("local.properties")
-            if (localPropertiesFile.exists()) {
-                localProperties.load(localPropertiesFile.newDataInputStream())
-            }
+            localProperties = readPropertiesIfExist(project.rootProject.file("local.properties"))
         }
         String result
         if (project.hasProperty(name)) {
@@ -82,7 +91,7 @@ class FlutterPlugin implements Plugin<Project> {
             if (!engineOut.isDirectory()) {
                 throw new GradleException('localEngineOut must point to a local engine build')
             }
-            File flutterJar = Paths.get(engineOut.absolutePath, "flutter.jar").toFile()
+            flutterJar = Paths.get(engineOut.absolutePath, "flutter.jar").toFile()
             if (!flutterJar.isFile()) {
                 throw new GradleException('Local engine build does not contain flutter.jar')
             }
@@ -95,9 +104,9 @@ class FlutterPlugin implements Plugin<Project> {
             }
         } else {
             Path baseEnginePath = Paths.get(flutterRoot.absolutePath, "bin", "cache", "artifacts", "engine")
-            File debugFlutterJar = baseEnginePath.resolve("android-arm").resolve("flutter.jar").toFile()
-            File profileFlutterJar = baseEnginePath.resolve("android-arm-profile").resolve("flutter.jar").toFile()
-            File releaseFlutterJar = baseEnginePath.resolve("android-arm-release").resolve("flutter.jar").toFile()
+            debugFlutterJar = baseEnginePath.resolve("android-arm").resolve("flutter.jar").toFile()
+            profileFlutterJar = baseEnginePath.resolve("android-arm-profile").resolve("flutter.jar").toFile()
+            releaseFlutterJar = baseEnginePath.resolve("android-arm-release").resolve("flutter.jar").toFile()
             if (!debugFlutterJar.isFile()) {
                 project.exec {
                     executable flutterExecutable.absolutePath
@@ -130,6 +139,28 @@ class FlutterPlugin implements Plugin<Project> {
 
         project.extensions.create("flutter", FlutterExtension)
         project.afterEvaluate this.&addFlutterTask
+
+        File pluginsFile = new File(project.rootProject.projectDir.parentFile, 'flutter-plugins.properties')
+        Properties plugins = readPropertiesIfExist(pluginsFile)
+
+        plugins.each { name, _ ->
+            def pluginProject = project.rootProject.project(":$name")
+            project.dependencies {
+                compile pluginProject
+            }
+            pluginProject.afterEvaluate this.&addFlutterJarDependency
+        }
+    }
+
+    private void addFlutterJarDependency(Project project) {
+        project.dependencies {
+            if (flutterJar != null) {
+                provided project.files(flutterJar)
+            } else {
+                debugProvided project.files(debugFlutterJar)
+                releaseProvided project.files(releaseFlutterJar)
+            }
+        }
     }
 
     private void addFlutterTask(Project project) {

--- a/packages/flutter_tools/lib/src/android/gradle.dart
+++ b/packages/flutter_tools/lib/src/android/gradle.dart
@@ -15,6 +15,7 @@ import '../base/utils.dart';
 import '../build_info.dart';
 import '../cache.dart';
 import '../globals.dart';
+import '../plugins.dart';
 import 'android_sdk.dart';
 import 'android_studio.dart';
 
@@ -151,6 +152,8 @@ Future<Null> buildGradleProject(BuildMode buildMode, String target, String kerne
   final SettingsFile settings = new SettingsFile.parseFromFile(localProperties);
   settings.values['flutter.buildMode'] = buildModeName;
   settings.writeContents(localProperties);
+
+  writeFlutterPluginsList();
 
   final String gradle = ensureGradle();
 

--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -19,6 +19,7 @@ import '../build_info.dart';
 import '../doctor.dart';
 import '../flx.dart' as flx;
 import '../globals.dart';
+import '../plugins.dart';
 import '../services.dart';
 import 'xcodeproj.dart';
 
@@ -127,6 +128,7 @@ Future<XcodeBuildResult> buildXcodeProject({
   // copied over to a location that is suitable for Xcodebuild to find them.
   final Directory appDirectory = fs.directory(app.appDirectory);
   await _addServicesToBundle(appDirectory);
+  writeFlutterPluginsList();
 
   _runPodInstall(appDirectory, flutterFrameworkDir(mode));
 

--- a/packages/flutter_tools/lib/src/plugins.dart
+++ b/packages/flutter_tools/lib/src/plugins.dart
@@ -9,7 +9,6 @@ import 'dart/package_map.dart';
 import 'globals.dart';
 
 dynamic _loadYamlFile(String path) {
-  printTrace("Looking for YAML at '$path'");
   if (!fs.isFileSync(path))
     return null;
   final String manifestString = fs.file(path).readAsStringSync();
@@ -31,8 +30,8 @@ String _generatePluginManifest() {
     if (packageConfig != null) {
       final dynamic flutterConfig = packageConfig['flutter'];
       if (flutterConfig != null && flutterConfig.containsKey('plugin')) {
-        printTrace('Found plugin $name at $packageRoot');
-        plugins.add('$name=$packageRoot');
+        printTrace('Found plugin $name at ${packageRoot.path}');
+        plugins.add('$name=${packageRoot.path}');
       }
     }
   });
@@ -40,7 +39,7 @@ String _generatePluginManifest() {
 }
 
 void writeFlutterPluginsList() {
-  final File pluginsProperties = fs.file('flutter-plugins.properties');
+  final File pluginsProperties = fs.file('.flutter-plugins');
 
   final String pluginManifest = _generatePluginManifest();
   if (pluginManifest.isNotEmpty) {

--- a/packages/flutter_tools/lib/src/plugins.dart
+++ b/packages/flutter_tools/lib/src/plugins.dart
@@ -1,0 +1,53 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:yaml/yaml.dart';
+
+import 'base/file_system.dart';
+import 'dart/package_map.dart';
+import 'globals.dart';
+
+dynamic _loadYamlFile(String path) {
+  printTrace("Looking for YAML at '$path'");
+  if (!fs.isFileSync(path))
+    return null;
+  final String manifestString = fs.file(path).readAsStringSync();
+  return loadYaml(manifestString);
+}
+
+String _generatePluginManifest() {
+  Map<String, Uri> packages;
+  try {
+    packages = new PackageMap(PackageMap.globalPackagesPath).map;
+  } on FormatException catch(e) {
+    printTrace('Invalid .packages file: $e');
+    return '';
+  }
+  final List<String> plugins = <String>[];
+  packages.forEach((String name, Uri uri) {
+    final Uri packageRoot = uri.resolve('..');
+    final dynamic packageConfig = _loadYamlFile(packageRoot.resolve('pubspec.yaml').path);
+    if (packageConfig != null) {
+      final dynamic flutterConfig = packageConfig['flutter'];
+      if (flutterConfig != null && flutterConfig.containsKey('plugin')) {
+        printTrace('Found plugin $name at $packageRoot');
+        plugins.add('$name=$packageRoot');
+      }
+    }
+  });
+  return plugins.join('\n');
+}
+
+void writeFlutterPluginsList() {
+  final File pluginsProperties = fs.file('flutter-plugins.properties');
+
+  final String pluginManifest = _generatePluginManifest();
+  if (pluginManifest.isNotEmpty) {
+    pluginsProperties.writeAsStringSync('$pluginManifest\n');
+  } else {
+    if (pluginsProperties.existsSync()) {
+      pluginsProperties.deleteSync();
+    }
+  }
+}

--- a/packages/flutter_tools/templates/create/.gitignore.tmpl
+++ b/packages/flutter_tools/templates/create/.gitignore.tmpl
@@ -7,3 +7,4 @@ build/
 ios/.generated/
 packages
 pubspec.lock
+.flutter-plugins

--- a/packages/flutter_tools/templates/create/android.tmpl/settings.gradle
+++ b/packages/flutter_tools/templates/create/android.tmpl/settings.gradle
@@ -3,7 +3,7 @@ include ':app'
 def flutterProjectRoot = rootProject.projectDir.parentFile.toPath()
 
 def plugins = new Properties()
-def pluginsFile = new File(flutterProjectRoot.toFile(), 'flutter-plugins.properties')
+def pluginsFile = new File(flutterProjectRoot.toFile(), '.flutter-plugins')
 if (pluginsFile.exists()) {
     pluginsFile.withInputStream { stream -> plugins.load(stream) }
 }

--- a/packages/flutter_tools/templates/create/android.tmpl/settings.gradle
+++ b/packages/flutter_tools/templates/create/android.tmpl/settings.gradle
@@ -1,1 +1,15 @@
 include ':app'
+
+def flutterProjectRoot = rootProject.projectDir.parentFile.toPath()
+
+def plugins = new Properties()
+def pluginsFile = new File(flutterProjectRoot.toFile(), 'flutter-plugins.properties')
+if (pluginsFile.exists()) {
+    pluginsFile.withInputStream { stream -> plugins.load(stream) }
+}
+
+plugins.each { name, path ->
+    def pluginDirectory = flutterProjectRoot.resolve(path).resolve('android').toFile()
+    include ":$name"
+    project(":$name").projectDir = pluginDirectory
+}

--- a/packages/flutter_tools/templates/create/ios.tmpl/Podfile
+++ b/packages/flutter_tools/templates/create/ios.tmpl/Podfile
@@ -13,9 +13,9 @@ target 'Runner' do
   # Flutter Pods
   pod 'Flutter', :path => ENV['FLUTTER_FRAMEWORK_DIR']
 
-  if File.exists? '../flutter-plugins.properties'
+  if File.exists? '../.flutter-plugins'
     flutter_root = File.expand_path('..')
-    File.foreach('../flutter-plugins.properties') { |line|
+    File.foreach('../.flutter-plugins') { |line|
       plugin = line.split(pattern='=')
       if plugin.length == 2
         name = plugin[0].strip()

--- a/packages/flutter_tools/templates/create/ios.tmpl/Podfile
+++ b/packages/flutter_tools/templates/create/ios.tmpl/Podfile
@@ -1,10 +1,38 @@
 # Uncomment this line to define a global platform for your project
 # platform :ios, '9.0'
 
+if ENV['FLUTTER_FRAMEWORK_DIR'] == nil
+  abort('Please set FLUTTER_FRAMEWORK_DIR to the directory containing Flutter.framework')
+end
+
 target 'Runner' do
-  # Uncomment this line if you're using Swift or would like to use dynamic frameworks
-  # use_frameworks!
+  use_frameworks!
 
   # Pods for Runner
 
+  # Flutter Pods
+  pod 'Flutter', :path => ENV['FLUTTER_FRAMEWORK_DIR']
+
+  if File.exists? '../flutter-plugins.properties'
+    flutter_root = File.expand_path('..')
+    File.foreach('../flutter-plugins.properties') { |line|
+      plugin = line.split(pattern='=')
+      if plugin.length == 2
+        name = plugin[0].strip()
+        path = plugin[1].strip()
+        resolved_path = File.expand_path("#{path}/ios", flutter_root)
+        pod name, :path => resolved_path
+      else
+        puts "Invalid plugin specification: #{line}"
+      end
+    }
+  end
+end
+
+post_install do |installer|
+  installer.pods_project.targets.each do |target|
+    target.build_configurations.each do |config|
+      config.build_settings['ENABLE_BITCODE'] = 'NO'
+    end
+  end
 end


### PR DESCRIPTION
Go through all packages brought in by pub, and write the name and path of every package that is a flutter plugin into flutter-plugins.properties. A package is a plugin if the `pubspec.yaml` file has a `flutter:` section containing a `plugin:` section:

```
flutter:
  plugin:
```

The plugin section is currently empty. The `flutter-plugins.properties` file is updated on every build.

Updated Gradle and Podspec in the new project template to read in flutter-plugins.properties and automatically add dependencies on their native code.