### PR TITLE
Changing Image.gaplessPlayback to default to true

### DIFF
--- a/packages/flutter/lib/src/widgets/image.dart
+++ b/packages/flutter/lib/src/widgets/image.dart
@@ -70,7 +70,7 @@ class Image extends StatefulWidget {
     this.alignment,
     this.repeat: ImageRepeat.noRepeat,
     this.centerSlice,
-    this.gaplessPlayback: false
+    this.gaplessPlayback: true
   }) : super(key: key) {
     assert(image != null);
   }
@@ -88,7 +88,7 @@ class Image extends StatefulWidget {
     this.alignment,
     this.repeat: ImageRepeat.noRepeat,
     this.centerSlice,
-    this.gaplessPlayback: false
+    this.gaplessPlayback: true
   }) : image = new NetworkImage(src, scale: scale),
        super(key: key);
 
@@ -108,7 +108,7 @@ class Image extends StatefulWidget {
     this.alignment,
     this.repeat: ImageRepeat.noRepeat,
     this.centerSlice,
-    this.gaplessPlayback: false
+    this.gaplessPlayback: true
   }) : image = new FileImage(file, scale: scale),
        super(key: key);
 
@@ -136,7 +136,7 @@ class Image extends StatefulWidget {
     this.alignment,
     this.repeat: ImageRepeat.noRepeat,
     this.centerSlice,
-    this.gaplessPlayback: false
+    this.gaplessPlayback: true
   }) : image = scale != null ? new ExactAssetImage(name, bundle: bundle, scale: scale)
                              : new AssetImage(name, bundle: bundle),
        super(key: key);


### PR DESCRIPTION
Rational:
- I think Flutter's philosophy should be to make it easy to make beautiful apps out of the box. 
- I think the most designers would like to reduce jitter & noise which switching images and gaplessPlayback allows for this.
- Thus, let's have defaults that are "biases" to design best practices.

adding a fellow designer for an opinion: @bkobash