### PR TITLE
Update gradle wrapper and build-tools version for flutter create.

### DIFF
--- a/packages/flutter_tools/gradle/flutter.gradle
+++ b/packages/flutter_tools/gradle/flutter.gradle
@@ -21,7 +21,7 @@ buildscript {
     jcenter()
   }
   dependencies {
-    classpath 'com.android.tools.build:gradle:2.2.3'
+    classpath 'com.android.tools.build:gradle:2.3.0'
   }
 }
 

--- a/packages/flutter_tools/templates/create/android.tmpl/build.gradle
+++ b/packages/flutter_tools/templates/create/android.tmpl/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:2.3.0'
     }
 }
 
@@ -24,5 +24,5 @@ task clean(type: Delete) {
 }
 
 task wrapper(type: Wrapper) {
-    gradleVersion = '2.14.1'
+    gradleVersion = '3.4.1'
 }


### PR DESCRIPTION
Motivation for this change was driven by:
1. Get the performance improvements of newer gradle(3.+), enabled daemon and incremental java compiler for example. For example: http://tools.android.com/tech-docs/new-build-system/2-5-alpha-gradle-plugin#TOC-What-to-expect-regarding-performance
2. The "Android Studio 2.3" "File->New Project" switched to newer gradle(3.3+) and "com.android.tools.build:gradle" to "2.3.0". 
3. And also many bugfixes: https://developer.android.com/studio/releases/gradle-plugin.html#revisions
Thanks.

Tested manually by "flutter create" with Idea "flutter run" and from android studio "run" android app.