### PR TITLE
Make min/max fling velocity and min fling distance ScrollPhysics properties

### DIFF
--- a/packages/flutter/lib/src/gestures/drag.dart
+++ b/packages/flutter/lib/src/gestures/drag.dart
@@ -250,8 +250,24 @@ abstract class DragGestureRecognizer extends OneSequenceGestureRecognizer {
   /// The pointer that previously triggered [onDown] did not complete.
   GestureDragCancelCallback onCancel;
 
-  double minFlingDistance;
-  double minFlingVelocity;
+  /// The minimum distance an input pointer drag must have moved to
+  /// to be considered a scroll fling gesture.
+  ///
+  /// This value is typically compared with the distance traveled along the
+  /// scrolling axis. If null then [kTouchSlop] is used.
+  double get minFlingDistance;
+
+  /// The minimum velocity for an input pointer drag to be considered a
+  /// scroll fling.
+  ///
+  /// This value is typically compared with the magnitude of fling gesture's
+  /// velocity along the scrolling axis. If null then [kMinFlingVelocity]
+  /// is used.
+  double maxFlingVelocity;
+
+  /// Scroll fling velocity magnitudes will be clamped to this value.
+  ///
+  /// If null then [kMaxFlingVelocity] is used.
   double maxFlingVelocity;
 
   _DragState _state = _DragState.ready;

--- a/packages/flutter/lib/src/gestures/drag.dart
+++ b/packages/flutter/lib/src/gestures/drag.dart
@@ -251,21 +251,20 @@ abstract class DragGestureRecognizer extends OneSequenceGestureRecognizer {
   GestureDragCancelCallback onCancel;
 
   /// The minimum distance an input pointer drag must have moved to
-  /// to be considered a scroll fling gesture.
+  /// to be considered a fling gesture.
   ///
   /// This value is typically compared with the distance traveled along the
   /// scrolling axis. If null then [kTouchSlop] is used.
   double get minFlingDistance;
 
-  /// The minimum velocity for an input pointer drag to be considered a
-  /// scroll fling.
+  /// The minimum velocity for an input pointer drag to be considered fling.
   ///
   /// This value is typically compared with the magnitude of fling gesture's
   /// velocity along the scrolling axis. If null then [kMinFlingVelocity]
   /// is used.
   double maxFlingVelocity;
 
-  /// Scroll fling velocity magnitudes will be clamped to this value.
+  /// Fling velocity magnitudes will be clamped to this value.
   ///
   /// If null then [kMaxFlingVelocity] is used.
   double maxFlingVelocity;

--- a/packages/flutter/lib/src/gestures/drag.dart
+++ b/packages/flutter/lib/src/gestures/drag.dart
@@ -20,10 +20,10 @@ enum _DragState {
 ///
 /// See also:
 ///
-/// * [DragGestureRecognizer.onDown], which uses [GestureDragDownCallback].
-/// * [DragStartDetails], the details for [GestureDragStartCallback].
-/// * [DragUpdateDetails], the details for [GestureDragUpdateCallback].
-/// * [DragEndDetails], the details for [GestureDragEndCallback].
+///  * [DragGestureRecognizer.onDown], which uses [GestureDragDownCallback].
+///  * [DragStartDetails], the details for [GestureDragStartCallback].
+///  * [DragUpdateDetails], the details for [GestureDragUpdateCallback].
+///  * [DragEndDetails], the details for [GestureDragEndCallback].
 class DragDownDetails {
   /// Creates details for a [GestureDragDownCallback].
   ///
@@ -53,10 +53,10 @@ typedef void GestureDragDownCallback(DragDownDetails details);
 ///
 /// See also:
 ///
-/// * [DragGestureRecognizer.onStart], which uses [GestureDragStartCallback].
-/// * [DragDownDetails], the details for [GestureDragDownCallback].
-/// * [DragUpdateDetails], the details for [GestureDragUpdateCallback].
-/// * [DragEndDetails], the details for [GestureDragEndCallback].
+///  * [DragGestureRecognizer.onStart], which uses [GestureDragStartCallback].
+///  * [DragDownDetails], the details for [GestureDragDownCallback].
+///  * [DragUpdateDetails], the details for [GestureDragUpdateCallback].
+///  * [DragEndDetails], the details for [GestureDragEndCallback].
 class DragStartDetails {
   /// Creates details for a [GestureDragStartCallback].
   ///
@@ -86,10 +86,10 @@ typedef void GestureDragStartCallback(DragStartDetails details);
 ///
 /// See also:
 ///
-/// * [DragGestureRecognizer.onUpdate], which uses [GestureDragUpdateCallback].
-/// * [DragDownDetails], the details for [GestureDragDownCallback].
-/// * [DragStartDetails], the details for [GestureDragStartCallback].
-/// * [DragEndDetails], the details for [GestureDragEndCallback].
+///  * [DragGestureRecognizer.onUpdate], which uses [GestureDragUpdateCallback].
+///  * [DragDownDetails], the details for [GestureDragDownCallback].
+///  * [DragStartDetails], the details for [GestureDragStartCallback].
+///  * [DragEndDetails], the details for [GestureDragEndCallback].
 class DragUpdateDetails {
   /// Creates details for a [DragUpdateDetails].
   ///
@@ -150,10 +150,10 @@ typedef void GestureDragUpdateCallback(DragUpdateDetails details);
 ///
 /// See also:
 ///
-/// * [DragGestureRecognizer.onEnd], which uses [GestureDragEndCallback].
-/// * [DragDownDetails], the details for [GestureDragDownCallback].
-/// * [DragStartDetails], the details for [GestureDragStartCallback].
-/// * [DragUpdateDetails], the details for [GestureDragUpdateCallback].
+///  * [DragGestureRecognizer.onEnd], which uses [GestureDragEndCallback].
+///  * [DragDownDetails], the details for [GestureDragDownCallback].
+///  * [DragStartDetails], the details for [GestureDragStartCallback].
+///  * [DragUpdateDetails], the details for [GestureDragUpdateCallback].
 class DragEndDetails {
   /// Creates details for a [GestureDragEndCallback].
   ///
@@ -255,14 +255,14 @@ abstract class DragGestureRecognizer extends OneSequenceGestureRecognizer {
   ///
   /// This value is typically compared with the distance traveled along the
   /// scrolling axis. If null then [kTouchSlop] is used.
-  double get minFlingDistance;
+  double minFlingDistance;
 
   /// The minimum velocity for an input pointer drag to be considered fling.
   ///
   /// This value is typically compared with the magnitude of fling gesture's
   /// velocity along the scrolling axis. If null then [kMinFlingVelocity]
   /// is used.
-  double maxFlingVelocity;
+  double minFlingVelocity;
 
   /// Fling velocity magnitudes will be clamped to this value.
   ///

--- a/packages/flutter/lib/src/gestures/velocity_tracker.dart
+++ b/packages/flutter/lib/src/gestures/velocity_tracker.dart
@@ -82,10 +82,11 @@ class Velocity {
 ///
 /// See also:
 ///
-/// * VelocityTracker, which computes [VelocityEstimate]s.
-/// * Velocity, which encapsulates (just) a velocity vector and provides some
-///   useful velocity operations.
+///  * VelocityTracker, which computes [VelocityEstimate]s.
+///  * Velocity, which encapsulates (just) a velocity vector and provides some
+///    useful velocity operations.
 class VelocityEstimate {
+  /// Creates a dimensional velocity estimate.
   const VelocityEstimate({
     this.pixelsPerSecond,
     this.confidence,

--- a/packages/flutter/lib/src/widgets/scroll_physics.dart
+++ b/packages/flutter/lib/src/widgets/scroll_physics.dart
@@ -4,6 +4,7 @@
 
 import 'dart:math' as math;
 
+import 'package:flutter/gestures.dart' show kMinFlingVelocity;
 import 'package:flutter/physics.dart';
 
 import 'overscroll_indicator.dart';
@@ -81,6 +82,12 @@ class BouncingScrollPhysics extends ScrollPhysics {
     }
     return null;
   }
+
+  // The ballistic simulation here decelerates more slowly than the one for
+  // ClampingScrollPhysics so we require a more deliberate input gesture
+  // to trigger a fling.
+  @override
+  double get minFlingVelocity => kMinFlingVelocity * 2.0;
 }
 
 /// Scroll physics for environments that prevent the scroll offset from reaching

--- a/packages/flutter/lib/src/widgets/scroll_physics.dart
+++ b/packages/flutter/lib/src/widgets/scroll_physics.dart
@@ -23,10 +23,10 @@ export 'scroll_position.dart' show ScrollPhysics;
 ///
 /// See also:
 ///
-/// * [ViewportScrollBehavior], which uses this to provide the iOS component of
-///   its scroll behavior.
-/// * [ClampingScrollPhysics], which is the analogous physics for Android's
-///   clamping behavior.
+///  * [ViewportScrollBehavior], which uses this to provide the iOS component of
+///    its scroll behavior.
+///  * [ClampingScrollPhysics], which is the analogous physics for Android's
+///    clamping behavior.
 class BouncingScrollPhysics extends ScrollPhysics {
   /// Creates scroll physics that bounce back from the edge.
   const BouncingScrollPhysics({ ScrollPhysics parent }) : super(parent);
@@ -97,13 +97,13 @@ class BouncingScrollPhysics extends ScrollPhysics {
 ///
 /// See also:
 ///
-/// * [ViewportScrollBehavior], which uses this to provide the Android component
-///   of its scroll behavior.
-/// * [BouncingScrollPhysics], which is the analogous physics for iOS' bouncing
-///   behavior.
-/// * [GlowingOverscrollIndicator], which is used by [ViewportScrollBehavior] to
-///   provide the glowing effect that is usually found with this clamping effect
-///   on Android.
+///  * [ViewportScrollBehavior], which uses this to provide the Android component
+///    of its scroll behavior.
+///  * [BouncingScrollPhysics], which is the analogous physics for iOS' bouncing
+///    behavior.
+///  * [GlowingOverscrollIndicator], which is used by [ViewportScrollBehavior] to
+///    provide the glowing effect that is usually found with this clamping effect
+///    on Android.
 class ClampingScrollPhysics extends ScrollPhysics {
   /// Creates scroll physics that prevent the scroll offset from exceeding the
   /// bounds of the content..
@@ -163,10 +163,10 @@ class ClampingScrollPhysics extends ScrollPhysics {
 ///
 /// See also:
 ///
-/// * [BouncingScrollPhysics], which provides the bouncing overscroll behavior
-///   found on iOS.
-/// * [ClampingScrollPhysics], which provides the clamping overscroll behavior
-///   found on Android.
+///  * [BouncingScrollPhysics], which provides the bouncing overscroll behavior
+///    found on iOS.
+///  * [ClampingScrollPhysics], which provides the clamping overscroll behavior
+///    found on Android.
 class AlwaysScrollableScrollPhysics extends ScrollPhysics {
   /// Creates scroll physics that always lets the user scroll.
   const AlwaysScrollableScrollPhysics({ ScrollPhysics parent }) : super(parent);

--- a/packages/flutter/lib/src/widgets/scroll_position.dart
+++ b/packages/flutter/lib/src/widgets/scroll_position.dart
@@ -106,8 +106,31 @@ abstract class ScrollPhysics {
 
   Tolerance get tolerance => parent?.tolerance ?? _kDefaultTolerance;
 
+  /// The minimum distance an input pointer drag must have moved to
+  /// to be considered a scroll fling gesture.
+  ///
+  /// This value is typically compared with the distance traveled along the
+  /// scrolling axis.
+  ///
+  /// See also:
+  ///
+  /// * [VelocityTracker.getVelocityEstimate], which computes the velocity
+  ///   of a press-drag-release gesture.
   double get minFlingDistance => parent?.minFlingDistance ?? kTouchSlop;
+
+  /// The minimum velocity for an input pointer drag to be considered a
+  /// scroll fling.
+  ///
+  /// This value is typically compared with the magnitude of fling gesture's
+  /// velocity along the scrolling axis.
+  ///
+  /// See also:
+  ///
+  /// * [VelocityTracker.getVelocityEstimate], which computes the velocity
+  ///   of a press-drag-release gesture.
   double get minFlingVelocity => parent?.minFlingVelocity ?? kMinFlingVelocity;
+
+  /// Scroll fling velocity magnitudes will be clamped to this value.
   double get maxFlingVelocity => parent?.maxFlingVelocity ?? kMaxFlingVelocity;
 
   @override

--- a/packages/flutter/lib/src/widgets/scroll_position.dart
+++ b/packages/flutter/lib/src/widgets/scroll_position.dart
@@ -106,6 +106,10 @@ abstract class ScrollPhysics {
 
   Tolerance get tolerance => parent?.tolerance ?? _kDefaultTolerance;
 
+  double get minFlingDistance => parent?.minFlingDistance ?? kTouchSlop;
+  double get minFlingVelocity => parent?.minFlingVelocity ?? kMinFlingVelocity;
+  double get maxFlingVelocity => parent?.maxFlingVelocity ?? kMaxFlingVelocity;
+
   @override
   String toString() {
     if (parent == null)

--- a/packages/flutter/lib/src/widgets/scroll_position.dart
+++ b/packages/flutter/lib/src/widgets/scroll_position.dart
@@ -114,8 +114,8 @@ abstract class ScrollPhysics {
   ///
   /// See also:
   ///
-  /// * [VelocityTracker.getVelocityEstimate], which computes the velocity
-  ///   of a press-drag-release gesture.
+  ///  * [VelocityTracker.getVelocityEstimate], which computes the velocity
+  ///    of a press-drag-release gesture.
   double get minFlingDistance => parent?.minFlingDistance ?? kTouchSlop;
 
   /// The minimum velocity for an input pointer drag to be considered a
@@ -126,8 +126,8 @@ abstract class ScrollPhysics {
   ///
   /// See also:
   ///
-  /// * [VelocityTracker.getVelocityEstimate], which computes the velocity
-  ///   of a press-drag-release gesture.
+  ///  * [VelocityTracker.getVelocityEstimate], which computes the velocity
+  ///    of a press-drag-release gesture.
   double get minFlingVelocity => parent?.minFlingVelocity ?? kMinFlingVelocity;
 
   /// Scroll fling velocity magnitudes will be clamped to this value.

--- a/packages/flutter/lib/src/widgets/scrollable.dart
+++ b/packages/flutter/lib/src/widgets/scrollable.dart
@@ -193,6 +193,7 @@ class ScrollableState extends State<Scrollable> with TickerProviderStateMixin
     if (!canDrag) {
       _gestureRecognizers = const <Type, GestureRecognizerFactory>{};
     } else {
+      final ScrollPhysics physics = _configuration.getScrollPhysics(context);
       switch (config.axis) {
         case Axis.vertical:
           _gestureRecognizers = <Type, GestureRecognizerFactory>{
@@ -201,7 +202,10 @@ class ScrollableState extends State<Scrollable> with TickerProviderStateMixin
                 ..onDown = _handleDragDown
                 ..onStart = _handleDragStart
                 ..onUpdate = _handleDragUpdate
-                ..onEnd = _handleDragEnd;
+                ..onEnd = _handleDragEnd
+                ..minFlingDistance = physics?.minFlingDistance
+                ..minFlingVelocity = physics?.minFlingVelocity
+                ..maxFlingVelocity = physics?.maxFlingVelocity;
             }
           };
           break;
@@ -212,7 +216,10 @@ class ScrollableState extends State<Scrollable> with TickerProviderStateMixin
                 ..onDown = _handleDragDown
                 ..onStart = _handleDragStart
                 ..onUpdate = _handleDragUpdate
-                ..onEnd = _handleDragEnd;
+                ..onEnd = _handleDragEnd
+                ..minFlingDistance = physics?.minFlingDistance
+                ..minFlingVelocity = physics?.minFlingVelocity
+                ..maxFlingVelocity = physics?.maxFlingVelocity;
             }
           };
           break;

--- a/packages/flutter/lib/src/widgets/scrollable.dart
+++ b/packages/flutter/lib/src/widgets/scrollable.dart
@@ -118,13 +118,14 @@ class ScrollableState extends State<Scrollable> with TickerProviderStateMixin
   ScrollPosition _position;
 
   ScrollBehavior _configuration;
+  ScrollPhysics _physics;
 
-  // only call this from places that will definitely trigger a rebuild
+  // Only call this from places that will definitely trigger a rebuild.
   void _updatePosition() {
     _configuration = ScrollConfiguration.of(context);
-    ScrollPhysics physics = _configuration.getScrollPhysics(context);
+    _physics = _configuration.getScrollPhysics(context);
     if (config.physics != null)
-      physics = config.physics.applyTo(physics);
+      _physics = config.physics.applyTo(_physics);
     final ScrollController controller = config.controller;
     final ScrollPosition oldPosition = position;
     if (oldPosition != null) {
@@ -135,8 +136,8 @@ class ScrollableState extends State<Scrollable> with TickerProviderStateMixin
       scheduleMicrotask(oldPosition.dispose);
     }
 
-    _position = controller?.createScrollPosition(physics, this, oldPosition)
-      ?? ScrollController.createDefaultScrollPosition(physics, this, oldPosition);
+    _position = controller?.createScrollPosition(_physics, this, oldPosition)
+      ?? ScrollController.createDefaultScrollPosition(_physics, this, oldPosition);
     assert(position != null);
     controller?.attach(position);
   }
@@ -193,7 +194,6 @@ class ScrollableState extends State<Scrollable> with TickerProviderStateMixin
     if (!canDrag) {
       _gestureRecognizers = const <Type, GestureRecognizerFactory>{};
     } else {
-      final ScrollPhysics physics = _configuration.getScrollPhysics(context);
       switch (config.axis) {
         case Axis.vertical:
           _gestureRecognizers = <Type, GestureRecognizerFactory>{
@@ -203,9 +203,9 @@ class ScrollableState extends State<Scrollable> with TickerProviderStateMixin
                 ..onStart = _handleDragStart
                 ..onUpdate = _handleDragUpdate
                 ..onEnd = _handleDragEnd
-                ..minFlingDistance = physics?.minFlingDistance
-                ..minFlingVelocity = physics?.minFlingVelocity
-                ..maxFlingVelocity = physics?.maxFlingVelocity;
+                ..minFlingDistance = _physics?.minFlingDistance
+                ..minFlingVelocity = _physics?.minFlingVelocity
+                ..maxFlingVelocity = _physics?.maxFlingVelocity;
             }
           };
           break;
@@ -217,9 +217,9 @@ class ScrollableState extends State<Scrollable> with TickerProviderStateMixin
                 ..onStart = _handleDragStart
                 ..onUpdate = _handleDragUpdate
                 ..onEnd = _handleDragEnd
-                ..minFlingDistance = physics?.minFlingDistance
-                ..minFlingVelocity = physics?.minFlingVelocity
-                ..maxFlingVelocity = physics?.maxFlingVelocity;
+                ..minFlingDistance = _physics?.minFlingDistance
+                ..minFlingVelocity = _physics?.minFlingVelocity
+                ..maxFlingVelocity = _physics?.maxFlingVelocity;
             }
           };
           break;

--- a/packages/flutter/test/material/modal_bottom_sheet_test.dart
+++ b/packages/flutter/test/material/modal_bottom_sheet_test.dart
@@ -102,7 +102,7 @@ void main() {
     expect(showBottomSheetThenCalled, isFalse);
     expect(find.text('BottomSheet'), findsOneWidget);
 
-    await tester.fling(find.text('BottomSheet'), const Offset(0.0, 20.0), 1000.0);
+    await tester.fling(find.text('BottomSheet'), const Offset(0.0, 30.0), 1000.0);
     await tester.pump(); // drain the microtask queue (Future completion callback)
 
     expect(showBottomSheetThenCalled, isTrue);


### PR DESCRIPTION
- BouncingScrollPhysics now has a higher min fling velocity to improve iOS fling scrolling fidelity.
- The drag gesture recognizers ignore flings when the samples used to compute the fling's velocity have moved less than minFlingDistance (default is kTouchSlop). This helps with ignoring fat finger rolls.
- Removed the strategy machinery from VelocityTracker, since we unconditionally use the least squares straight line solver.
- Added VelocityTracker.getVelocityEstimate() which reports the motion offset that the estimate was actually based on, as well as the duration and LSQ fit confidence.

Fixes: https://github.com/flutter/flutter/issues/4958
