### PR TITLE
[Flutter Tool] Only uninstall Android app when the initial install fails

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_device.dart
+++ b/packages/flutter_tools/lib/src/android/android_device.dart
@@ -263,18 +263,28 @@ class AndroidDevice extends Device {
   }
 
   bool _installLatestApp(ApplicationPackage package) {
-    if (isAppInstalled(package)) {
+    final bool wasInstalled = isAppInstalled(package);
+    if (wasInstalled) {
       if (isLatestBuildInstalled(package)) {
-        printStatus('Latest build already installed.');
+        printTrace('Latest build already installed.');
         return true;
       }
-      printStatus('Uninstalling old version...');
-      if (!uninstallApp(package))
-        printError('Warning: uninstalling old version failed');
     }
     printTrace('Installing APK.');
     if (!installApp(package)) {
-      printTrace('Error: Failed to install APK.');
+      printTrace('Warning: Failed to install APK.');
+      if (wasInstalled) {
+        printStatus('Uninstalling old version...');
+        if (!uninstallApp(package)) {
+          printError('Error: Uninstalling old version failed.');
+          return false;
+        }
+        if (!installApp(package)) {
+          printError('Error: Failed to install APK again.');
+          return false;
+        }
+        return true;
+      }
       return false;
     }
     return true;


### PR DESCRIPTION
Uninstalling the app removes the data and cache directories, so this allows application data to persist across multiple flutter run invocations.

This also handles the edge case where the app fails to install due to an error in installation (e.g. debug keystore changes, switching from a release keystore to a debug keystore, etc.).