### PR TITLE
Revert "Remove flutter_view_ios__start_up.dart"

### DIFF
--- a/dev/devicelab/bin/tasks/flutter_view_ios__start_up.dart
+++ b/dev/devicelab/bin/tasks/flutter_view_ios__start_up.dart
@@ -1,0 +1,14 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:flutter_devicelab/tasks/perf_tests.dart';
+import 'package:flutter_devicelab/framework/adb.dart';
+import 'package:flutter_devicelab/framework/framework.dart';
+
+Future<Null> main() async {
+  deviceOperatingSystem = DeviceOperatingSystem.ios;
+  await task(createFlutterViewStartupTest());
+}

--- a/dev/devicelab/manifest.yaml
+++ b/dev/devicelab/manifest.yaml
@@ -196,6 +196,12 @@ tasks:
     stage: devicelab_ios
     required_agent_capabilities: ["has-ios-device"]
 
+  flutter_view_ios__start_up:
+    description: >
+      Verifies that Flutter View can be used from an iOS project.
+    stage: devicelab_ios
+    required_agent_capabilities: ["has-ios-device"]
+
   # Tests running on Windows host
 
   flutter_gallery_win__build:


### PR DESCRIPTION
Re-adding the test, since the devicelab has been updated with CocoaPods.