### PR TITLE
Make pod install a long-running step.

### DIFF
--- a/packages/flutter_tools/lib/src/base/process.dart
+++ b/packages/flutter_tools/lib/src/base/process.dart
@@ -182,17 +182,34 @@ Future<Process> runDetached(List<String> cmd) {
 
 Future<RunResult> runAsync(List<String> cmd, {
   String workingDirectory,
-  bool allowReentrantFlutter: false
+  bool allowReentrantFlutter: false,
+  Map<String, String> environment
 }) async {
   _traceCommand(cmd, workingDirectory: workingDirectory);
   final ProcessResult results = await processManager.run(
     cmd,
     workingDirectory: workingDirectory,
-    environment: _environment(allowReentrantFlutter),
+    environment: _environment(allowReentrantFlutter, environment),
   );
   final RunResult runResults = new RunResult(results);
   printTrace(runResults.toString());
   return runResults;
+}
+
+Future<RunResult> runCheckedAsync(List<String> cmd, {
+  String workingDirectory,
+  bool allowReentrantFlutter: false,
+  Map<String, String> environment
+}) async {
+  final RunResult result = await runAsync(
+      cmd,
+      workingDirectory: workingDirectory,
+      allowReentrantFlutter: allowReentrantFlutter,
+      environment: environment
+  );
+  if (result.exitCode != 0)
+    throw 'Exit code ${result.exitCode} from: ${cmd.join(' ')}';
+  return result;
 }
 
 bool exitsHappy(List<String> cli) {

--- a/packages/flutter_tools/lib/src/commands/build_ios.dart
+++ b/packages/flutter_tools/lib/src/commands/build_ios.dart
@@ -6,7 +6,6 @@ import 'dart:async';
 
 import '../application_package.dart';
 import '../base/common.dart';
-import '../base/logger.dart';
 import '../base/utils.dart';
 import '../build_info.dart';
 import '../globals.dart';
@@ -64,8 +63,7 @@ class BuildIOSCommand extends BuildSubCommand {
     final String logTarget = forSimulator ? 'simulator' : 'device';
 
     final String typeName = artifacts.getEngineType(TargetPlatform.ios, getBuildMode());
-    final Status status = logger.startProgress('Building $app for $logTarget ($typeName)...',
-        expectSlowOperation: true);
+    printStatus('Building $app for $logTarget ($typeName)...');
     final XcodeBuildResult result = await buildXcodeProject(
       app: app,
       mode: getBuildMode(),
@@ -73,7 +71,6 @@ class BuildIOSCommand extends BuildSubCommand {
       buildForDevice: !forSimulator,
       codesign: shouldCodesign
     );
-    status.stop();
 
     if (!result.success) {
       await diagnoseXcodeBuildFailure(result);

--- a/packages/flutter_tools/lib/src/ios/ios_workflow.dart
+++ b/packages/flutter_tools/lib/src/ios/ios_workflow.dart
@@ -185,13 +185,15 @@ class IOSWorkflow extends DoctorValidator implements Workflow {
           messages.add(new ValidationMessage.error(
             'CocoaPods not installed. To install:\n'
             'brew update\n'
-            'brew install cocoapods'
+            'brew install cocoapods\n'
+            'pod setup'
           ));
         } else {
           messages.add(new ValidationMessage.error(
             'CocoaPods out of date ($cocoaPodsMinimumVersion is required). To upgrade:\n'
             'brew update\n'
-            'brew upgrade cocoapods'
+            'brew upgrade cocoapods\n'
+            'pod setup'
           ));
         }
       }


### PR DESCRIPTION
The very first time `pod install` is invoked, CocoaPods downloads the master spec repository, which takes quite a while. Before this change, the build appeared to have stalled. With this change, at least the spinner is moving.

Added `pod setup` to the install instructions for CocoaPods, so the spec repo is downloaded while setting up Flutter, instead of during the first build.