### PR TITLE
Fixes issue with TabBar / TabBarController

### DIFF
--- a/packages/flutter/lib/src/material/tabs.dart
+++ b/packages/flutter/lib/src/material/tabs.dart
@@ -478,8 +478,10 @@ class _TabBarState extends State<TabBar> {
 
   @override
   void dispose() {
-    if (_controller != null)
+    if (_controller != null) {
       _controller.animation.removeListener(_handleTabControllerAnimationTick);
+      _controller.removeListener(_handleTabControllerTick);
+    }
     // We don't own the _controller Animation, so it's not disposed here.
     super.dispose();
   }


### PR DESCRIPTION
If adding a TabBarController to a TabBar, then temporarily not building the TabBar or placing it offscreen and later re-adding it to the scene with the same TabBarController, Flutter throws a bunch of exceptions. It seems that the TabBar isn't correctly removing its connections to the TabBarController. This PR fixes that.

Example of exception that was thrown:
══╡ EXCEPTION CAUGHT BY FOUNDATION LIBRARY ╞════════════════════════════════════════════════════════
The following assertion was thrown while dispatching notifications for TabController:
setState() called after dispose(): _TabBarState#877904277(_StateLifecycle.defunct; not mounted)
This error happens if you call setState() on a State object for a widget that no longer appears in
the widget tree (e.g., whose parent widget no longer includes the widget in its build). This error
can occur when code calls setState() from a timer or an animation callback. The preferred solution
is to cancel the timer or stop listening to the animation in the dispose() callback. Another
solution is to check the "mounted" property of this object before calling setState() to ensure the
object is still in the tree.
This error might indicate a memory leak if setState() is being called because another object is
retaining a reference to this State object after it has been removed from the tree. To avoid memory
leaks, consider breaking the reference to this object during dispose().
When the exception was thrown, this was the stack:
#0      State.setState.<anonymous closure> (package:flutter/src/widgets/framework.dart:953:9)
#2      State.setState (package:flutter/src/widgets/framework.dart:951:12)
#3      _TabBarState._handleTabControllerTick (package:flutter/src/material/tabs.dart:540:5)
#4      ChangeNotifier.notifyListeners (package:flutter/src/foundation/change_notifier.dart:129:21)
#5      TabController._changeIndex (package:flutter/src/material/tab_controller.dart:112:7)
#6      TabController.index= (package:flutter/src/material/tab_controller.dart:124:5)
#7      _TabBarViewState._handleScrollNotification (package:flutter/src/material/tabs.dart:807:19)
#8      NotificationListener._dispatch (package:flutter/src/widgets/notification_listener.dart:95:41)
#9      Notification.visitAncestor (package:flutter/src/widgets/notification_listener.dart:33:20)
#10     LayoutChangedNotification&ViewportNotificationMixin.visitAncestor (package:flutter/src/widgets/scroll_notification.dart:84:31)
#11     Element.visitAncestorElements (package:flutter/src/widgets/framework.dart:2846:39)
#12     Notification.dispatch (package:flutter/src/widgets/notification_listener.dart:45:12)
#13     ScrollableState.dispatchNotification (package:flutter/src/widgets/scrollable.dart:253:18)
#14     ScrollPosition.beginActivity (package:flutter/src/widgets/scroll_position.dart:485:15)
#15     ScrollPosition.beginIdleActivity (package:flutter/src/widgets/scroll_position.dart:500:5)
#16     BallisticScrollActivity._end (package:flutter/src/widgets/scroll_position.dart:720:15)
(elided 9 frames from class _AssertionError and package dart:async)
The TabController sending notification was:
  Instance of 'TabController'