### PR TITLE
Fix the parameter names for computeMaxIntrinsicHeight and computeMinI…

### DIFF
--- a/packages/flutter/lib/src/rendering/box.dart
+++ b/packages/flutter/lib/src/rendering/box.dart
@@ -1255,7 +1255,7 @@ abstract class RenderBox extends RenderObject {
   ///
   /// See also examples in the definition of [computeMinIntrinsicWidth].
   @protected
-  double computeMinIntrinsicHeight(double height) {
+  double computeMinIntrinsicHeight(double width) {
     return 0.0;
   }
 
@@ -1332,7 +1332,7 @@ abstract class RenderBox extends RenderObject {
   ///
   /// See also examples in the definition of [computeMinIntrinsicWidth].
   @protected
-  double computeMaxIntrinsicHeight(double height) {
+  double computeMaxIntrinsicHeight(double width) {
     return 0.0;
   }
 


### PR DESCRIPTION
…ntrinsicHeight

These parameters are the width, not the height.