### PR TITLE
Include fragment support in Android build to allow use of FragmentActivity in FlutterActivity

### DIFF
--- a/packages/flutter_tools/gradle/flutter.gradle
+++ b/packages/flutter_tools/gradle/flutter.gradle
@@ -137,6 +137,11 @@ class FlutterPlugin implements Plugin<Project> {
             }
         }
 
+        project.dependencies {
+            // FlutterActivity extends FragmentActivity
+            compile 'com.android.support:support-fragment:24.2.0+'
+        }
+
         project.extensions.create("flutter", FlutterExtension)
         project.afterEvaluate this.&addFlutterTask
 


### PR DESCRIPTION
Required to land #3529, on the path to fixing #8581