### PR TITLE
Revert "Revert "Include fragment support in Android build to allow use of FragmentActivity in FlutterActivity (#9036)""

### DIFF
--- a/dev/devicelab/lib/framework/framework.dart
+++ b/dev/devicelab/lib/framework/framework.dart
@@ -16,7 +16,7 @@ import 'utils.dart';
 /// Maximum amount of time a single task is allowed to take to run.
 ///
 /// If exceeded the task is considered to have failed.
-const Duration taskTimeout = const Duration(minutes: 10);
+const Duration taskTimeout = const Duration(minutes: 15);
 
 /// Represents a unit of work performed in the CI environment that can
 /// succeed, fail and be retried independently of others.

--- a/packages/flutter_tools/gradle/flutter.gradle
+++ b/packages/flutter_tools/gradle/flutter.gradle
@@ -137,6 +137,11 @@ class FlutterPlugin implements Plugin<Project> {
             }
         }
 
+        project.dependencies {
+            // FlutterActivity extends FragmentActivity
+            compile 'com.android.support:support-fragment:24.2.0+'
+        }
+
         project.extensions.create("flutter", FlutterExtension)
         project.afterEvaluate this.&addFlutterTask
 


### PR DESCRIPTION
Increased the time limit slightly to allow the microbenchmark test time to finish.