### PR TITLE
Revert "Revert "Revert "Include fragment support in Android build to allow use of FragmentActivity in FlutterActivity (#9036)"" (#9046)"

### DIFF
--- a/dev/devicelab/lib/framework/framework.dart
+++ b/dev/devicelab/lib/framework/framework.dart
@@ -16,7 +16,7 @@ import 'utils.dart';
 /// Maximum amount of time a single task is allowed to take to run.
 ///
 /// If exceeded the task is considered to have failed.
-const Duration taskTimeout = const Duration(minutes: 15);
+const Duration taskTimeout = const Duration(minutes: 10);
 
 /// Represents a unit of work performed in the CI environment that can
 /// succeed, fail and be retried independently of others.

--- a/packages/flutter_tools/gradle/flutter.gradle
+++ b/packages/flutter_tools/gradle/flutter.gradle
@@ -137,11 +137,6 @@ class FlutterPlugin implements Plugin<Project> {
             }
         }
 
-        project.dependencies {
-            // FlutterActivity extends FragmentActivity
-            compile 'com.android.support:support-fragment:24.2.0+'
-        }
-
         project.extensions.create("flutter", FlutterExtension)
         project.afterEvaluate this.&addFlutterTask
 


### PR DESCRIPTION
Test is still failing with increased timeout.

This reverts commit 864b3c37c65a4294735bbdb041d17b112a2659cc.