### PR TITLE
Allowing more flexibility to the active opacity of the Cupertino Button

### DIFF
--- a/packages/flutter/lib/src/cupertino/button.dart
+++ b/packages/flutter/lib/src/cupertino/button.dart
@@ -47,8 +47,11 @@ class CupertinoButton extends StatefulWidget {
     this.padding,
     this.color,
     this.minSize: 44.0,
+    this.activeOpacity: 0.1,
     @required this.onPressed,
-  });
+  }) {
+    assert(activeOpacity >= 0.0 && activeOpacity <= 1.0);
+  }
 
   /// The widget below this widget in the tree.
   ///
@@ -79,6 +82,11 @@ class CupertinoButton extends StatefulWidget {
   ///
   /// * <https://developer.apple.com/ios/human-interface-guidelines/visual-design/layout/>
   final double minSize;
+
+  /// The opacity that the button will fade to when it is active (pressed)
+  ///
+  /// This defaults to 0.1
+  final double activeOpacity;
 
   /// Whether the button is enabled or disabled. Buttons are disabled by default. To
   /// enable a button, set its [onPressed] property to a non-null value.
@@ -120,7 +128,10 @@ class _CupertinoButtonState extends State<CupertinoButton> with SingleTickerProv
   }
 
   void _handleTapDown(PointerDownEvent event) {
-    _animationController.animateTo(0.1, duration: kFadeOutDuration);
+    _animationController.animateTo(
+      config.activeOpacity,
+      duration: kFadeOutDuration,
+    );
   }
 
   void _handleTapUp(PointerUpEvent event) {

--- a/packages/flutter/lib/src/cupertino/button.dart
+++ b/packages/flutter/lib/src/cupertino/button.dart
@@ -107,6 +107,7 @@ class _CupertinoButtonState extends State<CupertinoButton> with SingleTickerProv
   // Eyeballed values. Feel free to tweak.
   static const Duration kFadeOutDuration = const Duration(milliseconds: 10);
   static const Duration kFadeInDuration = const Duration(milliseconds: 350);
+  Tween<double> _opacityTween;
 
   AnimationController _animationController;
 
@@ -115,8 +116,12 @@ class _CupertinoButtonState extends State<CupertinoButton> with SingleTickerProv
     super.initState();
     _animationController = new AnimationController(
       duration: const Duration(milliseconds: 200),
-      value: 1.0,
+      value: 0.0,
       vsync: this,
+    );
+    _opacityTween = new Tween<double>(
+      begin: 1.0,
+      end: config.activeOpacity
     );
   }
 
@@ -127,19 +132,26 @@ class _CupertinoButtonState extends State<CupertinoButton> with SingleTickerProv
     super.dispose();
   }
 
-  void _handleTapDown(PointerDownEvent event) {
-    _animationController.animateTo(
-      config.activeOpacity,
-      duration: kFadeOutDuration,
+  @override
+  void didUpdateConfig(CupertinoButton old) {
+    super.didUpdateConfig(old);
+    _opacityTween = new Tween<double>(
+      begin: 1.0,
+      end: config.activeOpacity
     );
   }
 
+  void _handleTapDown(PointerDownEvent event) {
+
+    _animationController.animateTo(1.0,duration: kFadeOutDuration);
+  }
+
   void _handleTapUp(PointerUpEvent event) {
-    _animationController.animateTo(1.0, duration: kFadeInDuration);
+    _animationController.animateTo(0.0, duration: kFadeInDuration);
   }
 
   void _handleTapCancel(PointerCancelEvent event) {
-    _animationController.animateTo(1.0, duration: kFadeInDuration);
+    _animationController.animateTo(0.0, duration: kFadeInDuration);
   }
 
   @override
@@ -159,10 +171,10 @@ class _CupertinoButtonState extends State<CupertinoButton> with SingleTickerProv
             minHeight: config.minSize,
           ),
           child: new FadeTransition(
-            opacity: new CurvedAnimation(
+            opacity: _opacityTween.animate(new CurvedAnimation(
               parent: _animationController,
               curve: Curves.decelerate,
-            ),
+            )),
             child: new DecoratedBox(
               decoration: new BoxDecoration(
                 borderRadius: const BorderRadius.all(const Radius.circular(8.0)),

--- a/packages/flutter/lib/src/cupertino/button.dart
+++ b/packages/flutter/lib/src/cupertino/button.dart
@@ -47,10 +47,10 @@ class CupertinoButton extends StatefulWidget {
     this.padding,
     this.color,
     this.minSize: 44.0,
-    this.activeOpacity: 0.1,
+    this.pressedOpacity: 0.1,
     @required this.onPressed,
   }) {
-    assert(activeOpacity >= 0.0 && activeOpacity <= 1.0);
+    assert(pressedOpacity >= 0.0 && pressedOpacity <= 1.0);
   }
 
   /// The widget below this widget in the tree.
@@ -83,10 +83,11 @@ class CupertinoButton extends StatefulWidget {
   /// * <https://developer.apple.com/ios/human-interface-guidelines/visual-design/layout/>
   final double minSize;
 
-  /// The opacity that the button will fade to when it is active (pressed)
+  /// The opacity that the button will fade to when it is pressed.
+  /// The button will have an opacity of 1.0 when it is not pressed.
   ///
-  /// This defaults to 0.1
-  final double activeOpacity;
+  /// This defaults to 0.1.
+  final double pressedOpacity;
 
   /// Whether the button is enabled or disabled. Buttons are disabled by default. To
   /// enable a button, set its [onPressed] property to a non-null value.
@@ -111,6 +112,11 @@ class _CupertinoButtonState extends State<CupertinoButton> with SingleTickerProv
 
   AnimationController _animationController;
 
+  Tween<double> get _tween => new Tween<double>(
+    begin: 1.0,
+    end: config.pressedOpacity
+  );
+
   @override
   void initState() {
     super.initState();
@@ -119,10 +125,7 @@ class _CupertinoButtonState extends State<CupertinoButton> with SingleTickerProv
       value: 0.0,
       vsync: this,
     );
-    _opacityTween = new Tween<double>(
-      begin: 1.0,
-      end: config.activeOpacity
-    );
+    _opacityTween = _tween;
   }
 
   @override
@@ -135,15 +138,11 @@ class _CupertinoButtonState extends State<CupertinoButton> with SingleTickerProv
   @override
   void didUpdateConfig(CupertinoButton old) {
     super.didUpdateConfig(old);
-    _opacityTween = new Tween<double>(
-      begin: 1.0,
-      end: config.activeOpacity
-    );
+    _opacityTween = _tween;
   }
 
   void _handleTapDown(PointerDownEvent event) {
-
-    _animationController.animateTo(1.0,duration: kFadeOutDuration);
+    _animationController.animateTo(1.0, duration: kFadeOutDuration);
   }
 
   void _handleTapUp(PointerUpEvent event) {

--- a/packages/flutter/lib/src/cupertino/button.dart
+++ b/packages/flutter/lib/src/cupertino/button.dart
@@ -112,10 +112,12 @@ class _CupertinoButtonState extends State<CupertinoButton> with SingleTickerProv
 
   AnimationController _animationController;
 
-  Tween<double> get _tween => new Tween<double>(
-    begin: 1.0,
-    end: config.pressedOpacity
-  );
+  void _setTween() {
+    _opacityTween = new Tween<double>(
+      begin: 1.0,
+      end: config.pressedOpacity,
+    );
+  }
 
   @override
   void initState() {
@@ -125,7 +127,7 @@ class _CupertinoButtonState extends State<CupertinoButton> with SingleTickerProv
       value: 0.0,
       vsync: this,
     );
-    _opacityTween = _tween;
+    _setTween();
   }
 
   @override
@@ -138,7 +140,7 @@ class _CupertinoButtonState extends State<CupertinoButton> with SingleTickerProv
   @override
   void didUpdateConfig(CupertinoButton old) {
     super.didUpdateConfig(old);
-    _opacityTween = _tween;
+    _setTween();
   }
 
   void _handleTapDown(PointerDownEvent event) {

--- a/packages/flutter/test/cupertino/button_test.dart
+++ b/packages/flutter/test/cupertino/button_test.dart
@@ -126,10 +126,10 @@ void main() {
     expect(SchedulerBinding.instance.transientCallbackCount, equals(0));
   });
 
-  testWidgets('ActiveOpacity defaults to 0.1', (WidgetTester tester) async {
+  testWidgets('pressedOpacity defaults to 0.1', (WidgetTester tester) async {
     await tester.pumpWidget(new Center(child: new CupertinoButton(
       child: new Text('Tap me'),
-      onPressed: () {},
+      onPressed: () { },
     )));
 
     // Keep a "down" gesture on the button
@@ -145,12 +145,12 @@ void main() {
     expect(opacity.opacity, 0.1);
   });
 
-  testWidgets('ActiveOpacity parameter', (WidgetTester tester) async {
-    final double activeOpacity = 0.5;
+  testWidgets('pressedOpacity parameter', (WidgetTester tester) async {
+    final double pressedOpacity = 0.5;
     await tester.pumpWidget(new Center(child: new CupertinoButton(
-      activeOpacity: activeOpacity,
+      pressedOpacity: pressedOpacity,
       child: new Text('Tap me'),
-      onPressed: () {},
+      onPressed: () { },
     )));
 
     // Keep a "down" gesture on the button
@@ -164,6 +164,6 @@ void main() {
       of: find.byType(CupertinoButton),
       matching: find.byType(Opacity),
     ));
-    expect(opacity.opacity, activeOpacity);
+    expect(opacity.opacity, pressedOpacity);
   });
 }

--- a/packages/flutter/test/cupertino/button_test.dart
+++ b/packages/flutter/test/cupertino/button_test.dart
@@ -158,7 +158,6 @@ void main() {
     await tester.startGesture(center);
     await tester.pumpAndSettle();
 
-
     // Check opacity
     final Opacity opacity = tester.widget(find.descendant(
       of: find.byType(CupertinoButton),

--- a/packages/flutter/test/cupertino/button_test.dart
+++ b/packages/flutter/test/cupertino/button_test.dart
@@ -135,9 +135,7 @@ void main() {
     // Keep a "down" gesture on the button
     final Point center = tester.getCenter(find.byType(CupertinoButton));
     await tester.startGesture(center);
-    // Hack(dvdwasibi): The fadeout duration is 10 ms so this ensures that
-    // when we check the opacity, the animation has reached the end
-    await tester.pumpAndSettle(const Duration(milliseconds: 10));
+    await tester.pumpAndSettle();
 
     // Check opacity
     final Opacity opacity = tester.widget(find.descendant(
@@ -158,9 +156,8 @@ void main() {
     // Keep a "down" gesture on the button
     final Point center = tester.getCenter(find.byType(CupertinoButton));
     await tester.startGesture(center);
-    // Hack(dvdwasibi): The fadeout duration is 10 ms so this ensures that
-    // when we check the opacity, the animation has reached the end
-    await tester.pumpAndSettle(const Duration(milliseconds:10));
+    await tester.pumpAndSettle();
+
 
     // Check opacity
     final Opacity opacity = tester.widget(find.descendant(

--- a/packages/flutter/test/cupertino/button_test.dart
+++ b/packages/flutter/test/cupertino/button_test.dart
@@ -149,7 +149,6 @@ void main() {
 
   testWidgets('ActiveOpacity parameter', (WidgetTester tester) async {
     final double activeOpacity = 0.5;
-    await tester.pumpAndSettle(const Duration(seconds:4));
     await tester.pumpWidget(new Center(child: new CupertinoButton(
       activeOpacity: activeOpacity,
       child: new Text('Tap me'),

--- a/packages/flutter/test/cupertino/button_test.dart
+++ b/packages/flutter/test/cupertino/button_test.dart
@@ -125,4 +125,49 @@ void main() {
     // Still doesn't animate.
     expect(SchedulerBinding.instance.transientCallbackCount, equals(0));
   });
+
+  testWidgets('ActiveOpacity defaults to 0.1', (WidgetTester tester) async {
+    await tester.pumpWidget(new Center(child: new CupertinoButton(
+      child: new Text('Tap me'),
+      onPressed: () {},
+    )));
+
+    // Keep a "down" gesture on the button
+    final Point center = tester.getCenter(find.byType(CupertinoButton));
+    await tester.startGesture(center);
+    // Hack(dvdwasibi): The fadeout duration is 10 ms so this ensures that
+    // when we check the opacity, the animation has reached the end
+    await tester.pumpAndSettle(const Duration(milliseconds: 10));
+
+    // Check opacity
+    final Opacity opacity = tester.widget(find.descendant(
+      of: find.byType(CupertinoButton),
+      matching: find.byType(Opacity),
+    ));
+    expect(opacity.opacity, 0.1);
+  });
+
+  testWidgets('ActiveOpacity parameter', (WidgetTester tester) async {
+    final double activeOpacity = 0.5;
+    await tester.pumpAndSettle(const Duration(seconds:4));
+    await tester.pumpWidget(new Center(child: new CupertinoButton(
+      activeOpacity: activeOpacity,
+      child: new Text('Tap me'),
+      onPressed: () {},
+    )));
+
+    // Keep a "down" gesture on the button
+    final Point center = tester.getCenter(find.byType(CupertinoButton));
+    await tester.startGesture(center);
+    // Hack(dvdwasibi): The fadeout duration is 10 ms so this ensures that
+    // when we check the opacity, the animation has reached the end
+    await tester.pumpAndSettle(const Duration(milliseconds:10));
+
+    // Check opacity
+    final Opacity opacity = tester.widget(find.descendant(
+      of: find.byType(CupertinoButton),
+      matching: find.byType(Opacity),
+    ));
+    expect(opacity.opacity, activeOpacity);
+  });
 }


### PR DESCRIPTION
This will give designers more flexibility.

In various iOS apps (such as Spotify) the active opacity/fade of a button is higher than 0.1.

I don't know how to test this sort of interstitial state, so please advise :)

