### PR TITLE
SliverChildDelegate should know which children are live

### DIFF
--- a/packages/flutter/lib/src/rendering/sliver_fixed_extent_list.dart
+++ b/packages/flutter/lib/src/rendering/sliver_fixed_extent_list.dart
@@ -103,7 +103,7 @@ abstract class RenderSliverFixedExtentBoxAdaptor extends RenderSliverMultiBoxAda
 
   @override
   void performLayout() {
-    assert(childManager.debugAssertChildListLocked());
+    childManager.didStartLayout();
     childManager.setDidUnderflow(false);
 
     final double itemExtent = this.itemExtent;
@@ -136,6 +136,7 @@ abstract class RenderSliverFixedExtentBoxAdaptor extends RenderSliverMultiBoxAda
       if (!addInitialChild(index: firstIndex, layoutOffset: indexToLayoutOffset(itemExtent, firstIndex))) {
         // There are no children.
         geometry = SliverGeometry.zero;
+        childManager.didFinishLayout();
         return;
       }
     }
@@ -206,7 +207,7 @@ abstract class RenderSliverFixedExtentBoxAdaptor extends RenderSliverMultiBoxAda
         || constraints.scrollOffset > 0.0,
     );
 
-    assert(childManager.debugAssertChildListLocked());
+    childManager.didFinishLayout();
   }
 }
 

--- a/packages/flutter/lib/src/rendering/sliver_grid.dart
+++ b/packages/flutter/lib/src/rendering/sliver_grid.dart
@@ -477,7 +477,7 @@ class RenderSliverGrid extends RenderSliverMultiBoxAdaptor {
 
   @override
   void performLayout() {
-    assert(childManager.debugAssertChildListLocked());
+    childManager.didStartLayout();
     childManager.setDidUnderflow(false);
 
     final double scrollOffset = constraints.scrollOffset;
@@ -510,6 +510,7 @@ class RenderSliverGrid extends RenderSliverMultiBoxAdaptor {
           layoutOffset: firstChildGridGeometry.scrollOffset)) {
         // There are no children.
         geometry = SliverGeometry.zero;
+        childManager.didFinishLayout();
         return;
       }
     }
@@ -587,6 +588,6 @@ class RenderSliverGrid extends RenderSliverMultiBoxAdaptor {
       hasVisualOverflow: true,
     );
 
-    assert(childManager.debugAssertChildListLocked());
+    childManager.didFinishLayout();
   }
 }

--- a/packages/flutter/lib/src/rendering/sliver_list.dart
+++ b/packages/flutter/lib/src/rendering/sliver_list.dart
@@ -44,7 +44,7 @@ class RenderSliverList extends RenderSliverMultiBoxAdaptor {
 
   @override
   void performLayout() {
-    assert(childManager.debugAssertChildListLocked());
+    childManager.didStartLayout();
     childManager.setDidUnderflow(false);
 
     final double scrollOffset = constraints.scrollOffset;
@@ -78,6 +78,7 @@ class RenderSliverList extends RenderSliverMultiBoxAdaptor {
       if (!addInitialChild()) {
         // There are no children.
         geometry = SliverGeometry.zero;
+        childManager.didFinishLayout();
         return;
       }
     }
@@ -242,6 +243,6 @@ class RenderSliverList extends RenderSliverMultiBoxAdaptor {
       hasVisualOverflow: endScrollOffset > targetEndScrollOffset || constraints.scrollOffset > 0.0,
     );
 
-    assert(childManager.debugAssertChildListLocked());
+    childManager.didFinishLayout();
   }
 }

--- a/packages/flutter/lib/src/rendering/sliver_multi_box_adaptor.dart
+++ b/packages/flutter/lib/src/rendering/sliver_multi_box_adaptor.dart
@@ -88,6 +88,13 @@ abstract class RenderSliverBoxChildManager {
   /// affect the visible contents of the [RenderSliverMultiBoxAdaptor].
   void setDidUnderflow(bool value);
 
+  /// Called at the beginning of layout to indicate that layout is about to
+  /// occur.
+  void didStartLayout() { }
+
+  /// Called at the end of layout to indicate that layout is now complete.
+  void didFinishLayout() { }
+
   /// In debug mode, asserts that this manager is not expecting any
   /// modifications to the [RenderSliverMultiBoxAdaptor]'s child list.
   ///

--- a/packages/flutter/lib/src/widgets/sliver.dart
+++ b/packages/flutter/lib/src/widgets/sliver.dart
@@ -31,12 +31,29 @@ abstract class SliverChildDelegate {
   /// be too difficult to estimate the number of children.
   int get estimatedChildCount => null;
 
+  /// Returns an estimate of the max scroll extent for all the children.
+  ///
+  /// Subclasses should override this function if they have additional
+  /// information about their max scroll extent.
+  ///
+  /// The default implementation returns null, which causes the caller to
+  /// extrapolate the max scroll offset from the given parameters.
   double estimateMaxScrollOffset(
     int firstIndex,
     int lastIndex,
     double leadingScrollOffset,
     double trailingScrollOffset,
   ) => null;
+
+  /// Called at the end of layout to indicate that layout is now complete.
+  ///
+  /// The `firstIndex` argument is the index of the first child that was
+  /// included in the current layout. The `lastIndex` argument is the index of
+  /// the last child that was included in the current layout.
+  ///
+  /// Useful for subclasses that which to track which children are included in
+  /// the underlying render tree.
+  void didFinishLayout(int firstIndex, int lastIndex) {}
 
   bool shouldRebuild(covariant SliverChildDelegate oldDelegate);
 
@@ -413,6 +430,19 @@ class SliverMultiBoxAdaptorElement extends RenderObjectElement implements Render
       leadingScrollOffset,
       trailingScrollOffset,
     );
+  }
+
+  @override
+  void didStartLayout() {
+    assert(debugAssertChildListLocked());
+  }
+
+  @override
+  void didFinishLayout() {
+    assert(debugAssertChildListLocked());
+    final int firstIndex = _childElements.firstKey() ?? 0;
+    final int lastIndex = _childElements.lastKey() ?? 0;
+    widget.delegate.didFinishLayout(firstIndex, lastIndex);
   }
 
   int _currentlyUpdatingChildIndex;


### PR DESCRIPTION
This patch adds a notification to SliverChildDelegate that says which
children are alive after each layout. The delegate can use this
information to optimize it's underlying model of the children (e.g., by
discarding models for children that are far outside the live range).

Fixes #9045