### PR TITLE
increase vmservice timeout; log stderr in microbenchmarks

### DIFF
--- a/packages/flutter_tools/lib/src/vmservice.dart
+++ b/packages/flutter_tools/lib/src/vmservice.dart
@@ -28,7 +28,7 @@ StreamChannel<String> _defaultOpenChannel(Uri uri) =>
     new IOWebSocketChannel.connect(uri.toString()).cast();
 
 /// The default VM service request timeout.
-const Duration kDefaultRequestTimeout = const Duration(seconds: 10);
+const Duration kDefaultRequestTimeout = const Duration(seconds: 30);
 
 /// Used for RPC requests that may take a long time.
 const Duration kLongRequestTimeout = const Duration(minutes: 1);


### PR DESCRIPTION
The timeout is too short, causing flakiness in microbenchmarks

/cc @jason-simmons @collinjackson 