### PR TITLE
write flutter sdk location into intellij metadata

### DIFF
--- a/packages/flutter_tools/lib/src/commands/create.dart
+++ b/packages/flutter_tools/lib/src/commands/create.dart
@@ -4,6 +4,8 @@
 
 import 'dart:async';
 
+import 'package:path/path.dart' as path;
+
 import '../android/android.dart' as android;
 import '../base/common.dart';
 import '../base/file_system.dart';
@@ -206,6 +208,7 @@ Host platform code is in the android/ and ios/ directories under $relativePlugin
       'pluginClass': pluginClass,
       'pluginDartClass': pluginDartClass,
       'withPluginHook': withPluginHook,
+      'flutterRootUri': path.toUri(path.absolute(Cache.flutterRoot)).toString(),
     };
   }
 

--- a/packages/flutter_tools/lib/src/commands/create.dart
+++ b/packages/flutter_tools/lib/src/commands/create.dart
@@ -4,8 +4,6 @@
 
 import 'dart:async';
 
-import 'package:path/path.dart' as path;
-
 import '../android/android.dart' as android;
 import '../base/common.dart';
 import '../base/file_system.dart';
@@ -208,7 +206,7 @@ Host platform code is in the android/ and ios/ directories under $relativePlugin
       'pluginClass': pluginClass,
       'pluginDartClass': pluginDartClass,
       'withPluginHook': withPluginHook,
-      'flutterRootUri': path.toUri(path.absolute(Cache.flutterRoot)).toString(),
+      'flutterRootUri': fs.path.toUri(fs.path.absolute(Cache.flutterRoot)).toString(),
     };
   }
 

--- a/packages/flutter_tools/lib/src/template.dart
+++ b/packages/flutter_tools/lib/src/template.dart
@@ -116,7 +116,9 @@ class Template {
 
       if (sourceFile.path.endsWith(_kTemplateExtension)) {
         final String templateContents = sourceFile.readAsStringSync();
-        final String renderedContents = new mustache.Template(templateContents).renderString(context);
+        final mustache.Template mustacheTemplate = new mustache.Template(
+          templateContents, htmlEscapeValues: false);
+        final String renderedContents = mustacheTemplate.renderString(context);
 
         finalDestinationFile.writeAsStringSync(renderedContents);
 

--- a/packages/flutter_tools/templates/create/.idea/libraries/Dart_SDK.xml.tmpl
+++ b/packages/flutter_tools/templates/create/.idea/libraries/Dart_SDK.xml.tmpl
@@ -1,0 +1,9 @@
+<component name="libraryTable">
+  <library name="Dart SDK">
+    <CLASSES>
+      <root url="{{flutterRootUri}}/bin/cache/dart-sdk/lib/core" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES />
+  </library>
+</component>


### PR DESCRIPTION
- when creating a project with `flutter create`, write the flutter root location into the IntelliJ metadata. This helps the project open with a valid flutter sdk when first opened.
- adjust our template lib code to not escape slashes

@mit-mit @cbracken @jakobr-google 