### PR TITLE
iOS: fail build wth error if Python six missing

### DIFF
--- a/packages/flutter_tools/lib/src/ios/ios_workflow.dart
+++ b/packages/flutter_tools/lib/src/ios/ios_workflow.dart
@@ -41,7 +41,7 @@ class IOSWorkflow extends DoctorValidator implements Workflow {
 
   bool get hasHomebrew => os.which('brew') != null;
 
-  bool get hasPythonSixModule => exitsHappy(<String>['python', '-c', 'import six']);
+  bool get hasPythonSixModule => kPythonSix.isInstalled;
 
   bool get hasCocoaPods => exitsHappy(<String>['pod', '--version']);
 
@@ -124,10 +124,7 @@ class IOSWorkflow extends DoctorValidator implements Workflow {
       pythonStatus = ValidationType.installed;
     } else {
       pythonStatus = ValidationType.missing;
-      messages.add(new ValidationMessage.error(
-        'Python installation missing module "six".\n'
-        'Install via \'pip install six\' or \'sudo easy_install six\'.'
-      ));
+      messages.add(new ValidationMessage.error(kPythonSix.errorMessage));
     }
 
     // brew installed


### PR DESCRIPTION
Xcode builds depend on the Python 'six' module. If not present, exit
immediately with a useful error message.

The six module is included in the system default Python installation. We
perform this check in case a custom Python install has higher priority
on $PATH; e.g., due to a Homebrew or MacPorts installation.

This extracts an existing doctor check to use it during the build step
as well.