### PR TITLE
Support for snapping floating app bars

### DIFF
--- a/packages/flutter/lib/src/material/app_bar.dart
+++ b/packages/flutter/lib/src/material/app_bar.dart
@@ -507,23 +507,13 @@ class _FloatingAppBar extends StatefulWidget {
 // A wrapper for the widget created by _SliverAppBarDelegate that starts and
 /// stops the floating appbar's snap-into-view or snap-out-of-view animation.
 class _FloatingAppBarState extends State<_FloatingAppBar> {
-  ScrollableState _scrollable;
   ScrollPosition _position;
 
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
-    _updateScrollable();
-  }
-
-  void _updateScrollable() {
-    _scrollable = Scrollable.of(context);
-    _updateScrollPosition();
-  }
-
-  void _updateScrollPosition() {
     _position?.removeIsScrollingListener(_isScrollingListener);
-    _position = _scrollable?.position;
+    _position = Scrollable.of(context)?.position;
     _position?.addIsScrollingListener(_isScrollingListener);
   }
 
@@ -538,7 +528,7 @@ class _FloatingAppBarState extends State<_FloatingAppBar> {
   }
 
   void _isScrollingListener() {
-    if (_scrollable == null)
+    if (_position == null)
       return;
 
     // When a scroll stops, then maybe snap the appbar into view.
@@ -551,13 +541,7 @@ class _FloatingAppBarState extends State<_FloatingAppBar> {
   }
 
   @override
-  Widget build(BuildContext context) {
-    if (_scrollable == null)
-      _updateScrollable();
-    if (_scrollable.position != _position)
-      _updateScrollPosition();
-    return config.child;
-  }
+  Widget build(BuildContext context) => widget.child;
 }
 
 class _SliverAppBarDelegate extends SliverPersistentHeaderDelegate {
@@ -887,7 +871,7 @@ class _SliverAppBarState extends State<SliverAppBar> with TickerProviderStateMix
   FloatingHeaderSnapConfiguration _snapConfiguration;
 
   void _updateSnapConfiguration() {
-    if (config.snap && config.floating) {
+    if (widget.snap && widget.floating) {
       _snapConfiguration = new FloatingHeaderSnapConfiguration(
         vsync: this,
         curve: Curves.easeOut,
@@ -905,39 +889,39 @@ class _SliverAppBarState extends State<SliverAppBar> with TickerProviderStateMix
   }
 
   @override
-  void didUpdateConfig(SliverAppBar oldConfig) {
-    super.didUpdateConfig(oldConfig);
-    if (config.snap != oldConfig.snap || config.floating != oldConfig.floating)
+  void didUpdateWidget(SliverAppBar oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.snap != oldWidget.snap || widget.floating != oldWidget.floating)
       _updateSnapConfiguration();
   }
 
   @override
   Widget build(BuildContext context) {
-    final double topPadding = config.primary ? MediaQuery.of(context).padding.top : 0.0;
-    final double collapsedHeight = (config.pinned && config.floating && config.bottom != null)
-      ? config.bottom.bottomHeight + topPadding : null;
+    final double topPadding = widget.primary ? MediaQuery.of(context).padding.top : 0.0;
+    final double collapsedHeight = (widget.pinned && widget.floating && widget.bottom != null)
+      ? widget.bottom.bottomHeight + topPadding : null;
 
     return new SliverPersistentHeader(
-      floating: config.floating,
-      pinned: config.pinned,
+      floating: widget.floating,
+      pinned: widget.pinned,
       delegate: new _SliverAppBarDelegate(
-        leading: config.leading,
-        title: config.title,
-        actions: config.actions,
-        flexibleSpace: config.flexibleSpace,
-        bottom: config.bottom,
-        elevation: config.elevation,
-        backgroundColor: config.backgroundColor,
-        brightness: config.brightness,
-        iconTheme: config.iconTheme,
-        textTheme: config.textTheme,
-        primary: config.primary,
-        centerTitle: config.centerTitle,
-        expandedHeight: config.expandedHeight,
+        leading: widget.leading,
+        title: widget.title,
+        actions: widget.actions,
+        flexibleSpace: widget.flexibleSpace,
+        bottom: widget.bottom,
+        elevation: widget.elevation,
+        backgroundColor: widget.backgroundColor,
+        brightness: widget.brightness,
+        iconTheme: widget.iconTheme,
+        textTheme: widget.textTheme,
+        primary: widget.primary,
+        centerTitle: widget.centerTitle,
+        expandedHeight: widget.expandedHeight,
         collapsedHeight: collapsedHeight,
         topPadding: topPadding,
-        floating: config.floating,
-        pinned: config.pinned,
+        floating: widget.floating,
+        pinned: widget.pinned,
         snapConfiguration: _snapConfiguration,
       ),
     );

--- a/packages/flutter/lib/src/material/app_bar.dart
+++ b/packages/flutter/lib/src/material/app_bar.dart
@@ -512,14 +512,17 @@ class _FloatingAppBarState extends State<_FloatingAppBar> {
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
-    _position?.removeIsScrollingListener(_isScrollingListener);
+    if (_position != null)
+      _position.isScrollingNotifier.removeListener(_isScrollingListener);
     _position = Scrollable.of(context)?.position;
-    _position?.addIsScrollingListener(_isScrollingListener);
+    if (_position != null)
+      _position.isScrollingNotifier.addListener(_isScrollingListener);
   }
 
   @override
   void dispose() {
-    _position?.removeIsScrollingListener(_isScrollingListener);
+    if (_position != null)
+      _position.isScrollingNotifier.removeListener(_isScrollingListener);
     super.dispose();
   }
 
@@ -534,7 +537,7 @@ class _FloatingAppBarState extends State<_FloatingAppBar> {
     // When a scroll stops, then maybe snap the appbar into view.
     // Similarly, when a scroll starts, then maybe stop the snap animation.
     final RenderSliverFloatingPersistentHeader header = _headerRenderer();
-    if (_position.isScrolling)
+    if (_position.isScrollingNotifier.value)
       header?.maybeStopSnapAnimation(_position.userScrollDirection);
     else
       header?.maybeStartSnapAnimation(_position.userScrollDirection);

--- a/packages/flutter/lib/src/material/app_bar.dart
+++ b/packages/flutter/lib/src/material/app_bar.dart
@@ -508,25 +508,30 @@ class _FloatingAppBar extends StatefulWidget {
 /// stops the floating appbar's snap-into-view or snap-out-of-view animation.
 class _FloatingAppBarState extends State<_FloatingAppBar> {
   ScrollableState _scrollable;
+  ScrollPosition _position;
   ScrollActivity _activity;
 
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
-    _updateScrollPositionListener();
+    _updateScrollable();
   }
 
   @override
   void dispose() {
-    _scrollable?.position?.removeActivityChangedListener(_scrollPositionListener);
+    _position?.removeActivityChangedListener(_scrollPositionListener);
     super.dispose();
   }
 
-  void _updateScrollPositionListener() {
-    final ScrollableState scrollable = Scrollable.of(context);
-    _scrollable?.position?.removeActivityChangedListener(_scrollPositionListener);
-    _scrollable = scrollable;
-    _scrollable?.position?.addActivityChangedListener(_scrollPositionListener);
+  void _updateScrollable() {
+    _scrollable = Scrollable.of(context);
+    _updateScrollPosition();
+  }
+
+  void _updateScrollPosition() {
+    _position?.removeActivityChangedListener(_scrollPositionListener);
+    _position = _scrollable?.position;
+    _position?.addActivityChangedListener(_scrollPositionListener);
   }
 
   RenderSliverFloatingPersistentHeader _headerRenderer() {
@@ -553,7 +558,9 @@ class _FloatingAppBarState extends State<_FloatingAppBar> {
   @override
   Widget build(BuildContext context) {
     if (_scrollable == null)
-      _updateScrollPositionListener();
+      _updateScrollable();
+    if (_scrollable.position != _position)
+      _updateScrollPosition();
     return config.child;
   }
 }

--- a/packages/flutter/lib/src/material/app_bar.dart
+++ b/packages/flutter/lib/src/material/app_bar.dart
@@ -5,6 +5,7 @@
 import 'dart:math' as math;
 
 import 'package:flutter/foundation.dart';
+import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 
@@ -494,6 +495,69 @@ class _AppBarState extends State<AppBar> {
   }
 }
 
+class _FloatingAppBar extends StatefulWidget {
+  _FloatingAppBar({ Key key, this.child }) : super(key: key);
+
+  final Widget child;
+
+  @override
+  _FloatingAppBarState createState() => new _FloatingAppBarState();
+}
+
+// A wrapper for the widget created by _SliverAppBarDelegate that starts and
+/// stops the floating appbar's snap-into-view or snap-out-of-view animation.
+class _FloatingAppBarState extends State<_FloatingAppBar> {
+  ScrollableState _scrollable;
+  ScrollActivity _activity;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    _updateScrollPositionListener();
+  }
+
+  @override
+  void dispose() {
+    _scrollable?.position?.removeActivityChangedListener(_scrollPositionListener);
+    super.dispose();
+  }
+
+  void _updateScrollPositionListener() {
+    final ScrollableState scrollable = Scrollable.of(context);
+    _scrollable?.position?.removeActivityChangedListener(_scrollPositionListener);
+    _scrollable = scrollable;
+    _scrollable?.position?.addActivityChangedListener(_scrollPositionListener);
+  }
+
+  RenderSliverFloatingPersistentHeader _headerRenderer() {
+    return context.ancestorRenderObjectOfType(const TypeMatcher<RenderSliverFloatingPersistentHeader>());
+  }
+
+  void _scrollPositionListener() {
+    if (_scrollable == null)
+      return;
+
+    // When a scroll stops, then maybe snap the appbar into view.
+    // Similarly, when a scroll starts, then maybe stop the snap animation.
+    final ScrollActivity activity = _scrollable.position.activity;
+    if (_activity is! IdleScrollActivity && activity is IdleScrollActivity) {
+      final RenderSliverFloatingPersistentHeader header = _headerRenderer();
+      header?.maybeStartSnapAnimation(_scrollable.position.userScrollDirection);
+    } else if (_activity is IdleScrollActivity && activity is! IdleScrollActivity) {
+      final RenderSliverFloatingPersistentHeader header = _headerRenderer();
+      header?.maybeStopSnapAnimation(_scrollable.position.userScrollDirection);
+    }
+    _activity = activity;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_scrollable == null)
+      _updateScrollPositionListener();
+    return config.child;
+  }
+}
+
 class _SliverAppBarDelegate extends SliverPersistentHeaderDelegate {
   _SliverAppBarDelegate({
     @required this.leading,
@@ -513,6 +577,7 @@ class _SliverAppBarDelegate extends SliverPersistentHeaderDelegate {
     @required this.topPadding,
     @required this.floating,
     @required this.pinned,
+    @required this.snapConfiguration,
   }) : _bottomHeight = bottom?.bottomHeight ?? 0.0 {
     assert(primary || topPadding == 0.0);
   }
@@ -544,11 +609,14 @@ class _SliverAppBarDelegate extends SliverPersistentHeaderDelegate {
   double get maxExtent => math.max(topPadding + (expandedHeight ?? kToolbarHeight + _bottomHeight), minExtent);
 
   @override
+  final FloatingHeaderSnapConfiguration snapConfiguration;
+
+  @override
   Widget build(BuildContext context, double shrinkOffset, bool overlapsContent) {
     final double visibleMainHeight = maxExtent - shrinkOffset - topPadding;
     final double toolbarOpacity = pinned && !floating ? 1.0
       : ((visibleMainHeight - _bottomHeight) / kToolbarHeight).clamp(0.0, 1.0);
-    return FlexibleSpaceBar.createSettings(
+    final Widget appBar = FlexibleSpaceBar.createSettings(
       minExtent: minExtent,
       maxExtent: maxExtent,
       currentExtent: math.max(minExtent, maxExtent - shrinkOffset),
@@ -570,6 +638,7 @@ class _SliverAppBarDelegate extends SliverPersistentHeaderDelegate {
         bottomOpacity: pinned ? 1.0 : (visibleMainHeight / _bottomHeight).clamp(0.0, 1.0),
       ),
     );
+    return floating ? new _FloatingAppBar(child: appBar) : appBar;
   }
 
   @override
@@ -590,7 +659,8 @@ class _SliverAppBarDelegate extends SliverPersistentHeaderDelegate {
         || expandedHeight != oldDelegate.expandedHeight
         || topPadding != oldDelegate.topPadding
         || pinned != oldDelegate.pinned
-        || floating != oldDelegate.floating;
+        || floating != oldDelegate.floating
+        || snapConfiguration != oldDelegate.snapConfiguration;
   }
 
   @override
@@ -628,7 +698,7 @@ class _SliverAppBarDelegate extends SliverPersistentHeaderDelegate {
 ///  * [FlexibleSpaceBar], which is used with [flexibleSpace] when the app bar
 ///    can expand and collapse.
 ///  * <https://material.google.com/layout/structure.html#structure-toolbars>
-class SliverAppBar extends StatelessWidget {
+class SliverAppBar extends StatefulWidget {
   /// Creates a material design app bar that can be placed in a [CustomScrollView].
   SliverAppBar({
     Key key,
@@ -647,11 +717,13 @@ class SliverAppBar extends StatelessWidget {
     this.expandedHeight,
     this.floating: false,
     this.pinned: false,
+    this.snap: false,
   }) : super(key: key) {
     assert(primary != null);
     assert(floating != null);
     assert(pinned != null);
     assert(pinned && floating ? bottom != null : true);
+    assert(snap != null);
   }
 
   /// A widget to display before the [title].
@@ -776,6 +848,13 @@ class SliverAppBar extends StatelessWidget {
   ///
   /// Otherwise, the user will need to scroll near the top of the scroll view to
   /// reveal the app bar.
+  ///
+  /// See also:
+  ///
+  ///   * If [snap] is true then a scroll that exposes the app bar will trigger
+  ///     an animation that slides the entire app bar into view. Similarly if
+  ///     a scroll dismisses the app bar, the animation will slide it completely
+  ///     out of view.
   final bool floating;
 
   /// Whether the app bar should remain visible at the start of the scroll view.
@@ -784,33 +863,60 @@ class SliverAppBar extends StatelessWidget {
   /// remain visible rather than being scrolled out of view.
   final bool pinned;
 
+  /// If [snap] and [floating] are true then the floating app bar will "snap"
+  /// into view.
+  ///
+  /// If [snap] is true then a scroll that exposes the floating app bar will
+  /// trigger an animation that slides the entire app bar into view. Similarly if
+  /// a scroll dismisses the app bar, the animation will slide the app bar
+  /// completely out of view.
+  ///
+  /// Snapping only applies when the app bar is floating, not when the appbar
+  /// appears at the top of its scroll view.
+  final bool snap;
+
+  @override
+  _SliverAppBarState createState() => new _SliverAppBarState();
+}
+
+class _SliverAppBarState extends State<SliverAppBar> with TickerProviderStateMixin {
   @override
   Widget build(BuildContext context) {
-    final double topPadding = primary ? MediaQuery.of(context).padding.top : 0.0;
-    final double collapsedHeight = (pinned && floating && bottom != null)
-      ? bottom.bottomHeight + topPadding : null;
+    final double topPadding = config.primary ? MediaQuery.of(context).padding.top : 0.0;
+    final double collapsedHeight = (config.pinned && config.floating && config.bottom != null)
+      ? config.bottom.bottomHeight + topPadding : null;
+
+    FloatingHeaderSnapConfiguration snapConfiguration;
+    if (config.snap && config.floating) {
+      snapConfiguration = new FloatingHeaderSnapConfiguration(
+        vsync: this,
+        curve: Curves.easeOut,
+        duration: const Duration(milliseconds: 200),
+      );
+    }
 
     return new SliverPersistentHeader(
-      floating: floating,
-      pinned: pinned,
+      floating: config.floating,
+      pinned: config.pinned,
       delegate: new _SliverAppBarDelegate(
-        leading: leading,
-        title: title,
-        actions: actions,
-        flexibleSpace: flexibleSpace,
-        bottom: bottom,
-        elevation: elevation,
-        backgroundColor: backgroundColor,
-        brightness: brightness,
-        iconTheme: iconTheme,
-        textTheme: textTheme,
-        primary: primary,
-        centerTitle: centerTitle,
-        expandedHeight: expandedHeight,
+        leading: config.leading,
+        title: config.title,
+        actions: config.actions,
+        flexibleSpace: config.flexibleSpace,
+        bottom: config.bottom,
+        elevation: config.elevation,
+        backgroundColor: config.backgroundColor,
+        brightness: config.brightness,
+        iconTheme: config.iconTheme,
+        textTheme: config.textTheme,
+        primary: config.primary,
+        centerTitle: config.centerTitle,
+        expandedHeight: config.expandedHeight,
         collapsedHeight: collapsedHeight,
         topPadding: topPadding,
-        floating: floating,
-        pinned: pinned,
+        floating: config.floating,
+        pinned: config.pinned,
+        snapConfiguration: snapConfiguration,
       ),
     );
   }

--- a/packages/flutter/lib/src/rendering/sliver_persistent_header.dart
+++ b/packages/flutter/lib/src/rendering/sliver_persistent_header.dart
@@ -8,7 +8,6 @@ import 'package:flutter/animation.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/scheduler.dart';
-import 'package:meta/meta.dart';
 import 'package:vector_math/vector_math_64.dart';
 
 import 'binding.dart';
@@ -262,6 +261,8 @@ abstract class RenderSliverPinnedPersistentHeader extends RenderSliverPersistent
 ///  * [RenderSliverFloatingPersistentHeader.maybeStartSnapAnimation] and
 ///    [RenderSliverFloatingPersistentHeader.maybeStopSnapAnimation], which
 ///    start or stop the floating header's animation.
+///  * [SliverAppBar], which creates a header that can be pinned, floating,
+///    and snapped into view via the corresponding parameters.
 class FloatingHeaderSnapConfiguration {
   /// Creates an object that specifies how a floating header is to be "snapped"
   /// (animated) into or out of view.
@@ -304,7 +305,7 @@ abstract class RenderSliverFloatingPersistentHeader extends RenderSliverPersiste
   @override
   void detach() {
     _controller?.dispose();
-    _controller = null;
+    _controller = null; // lazily recreated if we're reattached.
     super.detach();
   }
 
@@ -318,12 +319,15 @@ abstract class RenderSliverFloatingPersistentHeader extends RenderSliverPersiste
   ///  * [RenderSliverFloatingPersistentHeader.maybeStartSnapAnimation] and
   ///    [RenderSliverFloatingPersistentHeader.maybeStopSnapAnimation], which
   ///    start or stop the floating header's animation.
+  ///  * [SliverAppBar], which creates a header that can be pinned, floating,
+  ///    and snapped into view via the corresponding parameters.
   FloatingHeaderSnapConfiguration get snapConfiguration => _snapConfiguration;
   FloatingHeaderSnapConfiguration _snapConfiguration;
   set snapConfiguration(FloatingHeaderSnapConfiguration value) {
+    if (value == _snapConfiguration)
+      return;
     if (value == null) {
       _controller?.dispose();
-      _controller = null;
     } else {
       if (_snapConfiguration != null && value.vsync != _snapConfiguration.vsync)
         _controller?.resync(value.vsync);

--- a/packages/flutter/lib/src/rendering/sliver_persistent_header.dart
+++ b/packages/flutter/lib/src/rendering/sliver_persistent_header.dart
@@ -371,6 +371,8 @@ abstract class RenderSliverFloatingPersistentHeader extends RenderSliverPersiste
         markNeedsLayout();
       });
 
+    // Recreating the animation rather than updating a cached value, only
+    // to avoid the extra complexity of managing the animation's lifetime.
     _animation = new Tween<double>(
       begin: _effectiveScrollOffset,
       end: direction == ScrollDirection.forward ? 0.0 : maxExtent,

--- a/packages/flutter/lib/src/rendering/sliver_persistent_header.dart
+++ b/packages/flutter/lib/src/rendering/sliver_persistent_header.dart
@@ -4,8 +4,11 @@
 
 import 'dart:math' as math;
 
+import 'package:flutter/animation.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
+import 'package:flutter/scheduler.dart';
+import 'package:meta/meta.dart';
 import 'package:vector_math/vector_math_64.dart';
 
 import 'binding.dart';
@@ -251,17 +254,82 @@ abstract class RenderSliverPinnedPersistentHeader extends RenderSliverPersistent
   double childMainAxisPosition(RenderBox child) => 0.0;
 }
 
+/// Specifies how a floating header is to be "snapped" (animated) into or out
+/// of view.
+///
+/// See also:
+///
+///  * [RenderSliverFloatingPersistentHeader.maybeStartSnapAnimation] and
+///    [RenderSliverFloatingPersistentHeader.maybeStopSnapAnimation], which
+///    start or stop the floating header's animation.
+class FloatingHeaderSnapConfiguration {
+  /// Creates an object that specifies how a floating header is to be "snapped"
+  /// (animated) into or out of view.
+  FloatingHeaderSnapConfiguration({
+    @required this.vsync,
+    this.curve: Curves.ease,
+    this.duration: const Duration(milliseconds: 300),
+  }) {
+    assert(vsync != null);
+    assert(curve != null);
+    assert(duration != null);
+  }
+
+  /// The [TickerProvider] for the [AnimationController] that causes a
+  /// floating header to snap in or out of view.
+  final TickerProvider vsync;
+
+  /// The snap animation curve.
+  final Curve curve;
+
+  /// The snap animation's duration.
+  final Duration duration;
+}
+
 abstract class RenderSliverFloatingPersistentHeader extends RenderSliverPersistentHeader {
   RenderSliverFloatingPersistentHeader({
     RenderBox child,
-  }) : super(child: child);
+    FloatingHeaderSnapConfiguration snapConfiguration,
+  }) : _snapConfiguration = snapConfiguration, super(child: child);
 
+  AnimationController _controller;
+  Animation<double> _animation;
   double _lastActualScrollOffset;
   double _effectiveScrollOffset;
 
   // Distance from our leading edge to the child's leading edge, in the axis
   // direction. Negative if we're scrolled off the top.
   double _childPosition;
+
+  @override
+  void detach() {
+    _controller?.dispose();
+    _controller = null;
+    super.detach();
+  }
+
+  /// Defines the parameters used to snap (animate) the floating header in and
+  /// out of view.
+  ///
+  /// If [snapConfiguration] is null then the floating header does not snap.
+  ///
+  /// See also:
+  ///
+  ///  * [RenderSliverFloatingPersistentHeader.maybeStartSnapAnimation] and
+  ///    [RenderSliverFloatingPersistentHeader.maybeStopSnapAnimation], which
+  ///    start or stop the floating header's animation.
+  FloatingHeaderSnapConfiguration get snapConfiguration => _snapConfiguration;
+  FloatingHeaderSnapConfiguration _snapConfiguration;
+  set snapConfiguration(FloatingHeaderSnapConfiguration value) {
+    if (value == null) {
+      _controller?.dispose();
+      _controller = null;
+    } else {
+      if (_snapConfiguration != null && value.vsync != _snapConfiguration.vsync)
+        _controller?.resync(value.vsync);
+    }
+    _snapConfiguration = value;
+  }
 
   // Update [geometry] and return the new value for [childMainAxisPosition].
   @protected
@@ -280,6 +348,40 @@ abstract class RenderSliverFloatingPersistentHeader extends RenderSliverPersiste
     return math.min(0.0, paintExtent - childExtent);
   }
 
+  /// If the header isn't already fully exposed, then scroll it into view.
+  void maybeStartSnapAnimation(ScrollDirection direction) {
+    if (snapConfiguration == null)
+      return;
+    if (direction == ScrollDirection.forward && _effectiveScrollOffset <= 0.0)
+      return;
+    if (direction == ScrollDirection.reverse && _effectiveScrollOffset >= maxExtent)
+      return;
+
+    final TickerProvider vsync = snapConfiguration.vsync;
+    final Duration duration = snapConfiguration.duration;
+    _controller ??= new AnimationController(vsync: vsync, duration: duration)
+      ..addListener(() {
+        if (_effectiveScrollOffset == _animation.value)
+          return;
+        _effectiveScrollOffset = _animation.value;
+        markNeedsLayout();
+      });
+
+    _animation = new Tween<double>(
+      begin: _effectiveScrollOffset,
+      end: direction == ScrollDirection.forward ? 0.0 : maxExtent,
+    ).animate(new CurvedAnimation(
+      parent: _controller,
+      curve: snapConfiguration.curve,
+    ));
+
+    _controller.forward(from: 0.0);
+  }
+
+  /// If a header snap animation is underway then stop it.
+  void maybeStopSnapAnimation(ScrollDirection direction) {
+    _controller?.stop();
+  }
 
   @override
   void performLayout() {
@@ -321,7 +423,8 @@ abstract class RenderSliverFloatingPersistentHeader extends RenderSliverPersiste
 abstract class RenderSliverFloatingPinnedPersistentHeader extends RenderSliverFloatingPersistentHeader {
   RenderSliverFloatingPinnedPersistentHeader({
     RenderBox child,
-  }) : super(child: child);
+    FloatingHeaderSnapConfiguration snapConfiguration,
+  }) : super(child: child, snapConfiguration: snapConfiguration);
 
   @override
   double updateGeometry() {

--- a/packages/flutter/lib/src/widgets/scroll_position.dart
+++ b/packages/flutter/lib/src/widgets/scroll_position.dart
@@ -466,16 +466,19 @@ class ScrollPosition extends ViewportOffset {
   ScrollActivity get activity => _activity;
   ScrollActivity _activity;
 
-  ChangeNotifier _activityChangedNotifier;
+  bool get isScrolling => _activity?.isScrolling ?? false;
 
-  void addActivityChangedListener(VoidCallback listener) {
-    _activityChangedNotifier ??= new ChangeNotifier();
-    _activityChangedNotifier.addListener(listener);
+  ValueNotifier<bool> _isScrollingNotifier;
+
+  void addIsScrollingListener(VoidCallback listener) {
+    _isScrollingNotifier ??= new ValueNotifier<bool>(isScrolling);
+    _isScrollingNotifier.addListener(listener);
   }
 
-  void removeActivityChangedListener(VoidCallback listener) {
-    _activityChangedNotifier?.removeListener(listener);
+  void removeIsScrollingListener(VoidCallback listener) {
+    _isScrollingNotifier?.removeListener(listener);
   }
+
 
   /// Change the current [activity], disposing of the old one and
   /// sending scroll notifications as necessary.
@@ -501,7 +504,8 @@ class ScrollPosition extends ViewportOffset {
     _activity = newActivity;
     if (oldIgnorePointer != shouldIgnorePointer)
       state.setIgnorePointer(shouldIgnorePointer);
-    _activityChangedNotifier?.notifyListeners();
+    if (_isScrollingNotifier != null)
+      _isScrollingNotifier.value = isScrolling;
     if (!activity.isScrolling)
       updateUserScrollDirection(ScrollDirection.idle);
     if (!wasScrolling && activity.isScrolling)

--- a/packages/flutter/lib/src/widgets/scroll_position.dart
+++ b/packages/flutter/lib/src/widgets/scroll_position.dart
@@ -466,6 +466,17 @@ class ScrollPosition extends ViewportOffset {
   ScrollActivity get activity => _activity;
   ScrollActivity _activity;
 
+  ChangeNotifier _activityChangedNotifier;
+
+  void addActivityChangedListener(VoidCallback listener) {
+    _activityChangedNotifier ??= new ChangeNotifier();
+    _activityChangedNotifier.addListener(listener);
+  }
+
+  void removeActivityChangedListener(VoidCallback listener) {
+    _activityChangedNotifier?.removeListener(listener);
+  }
+
   /// Change the current [activity], disposing of the old one and
   /// sending scroll notifications as necessary.
   ///
@@ -490,6 +501,7 @@ class ScrollPosition extends ViewportOffset {
     _activity = newActivity;
     if (oldIgnorePointer != shouldIgnorePointer)
       state.setIgnorePointer(shouldIgnorePointer);
+    _activityChangedNotifier?.notifyListeners();
     if (!activity.isScrolling)
       updateUserScrollDirection(ScrollDirection.idle);
     if (!wasScrolling && activity.isScrolling)

--- a/packages/flutter/lib/src/widgets/scroll_position.dart
+++ b/packages/flutter/lib/src/widgets/scroll_position.dart
@@ -466,19 +466,12 @@ class ScrollPosition extends ViewportOffset {
   ScrollActivity get activity => _activity;
   ScrollActivity _activity;
 
-  bool get isScrolling => _activity?.isScrolling ?? false;
-
-  ValueNotifier<bool> _isScrollingNotifier;
-
-  void addIsScrollingListener(VoidCallback listener) {
-    _isScrollingNotifier ??= new ValueNotifier<bool>(isScrolling);
-    _isScrollingNotifier.addListener(listener);
-  }
-
-  void removeIsScrollingListener(VoidCallback listener) {
-    _isScrollingNotifier?.removeListener(listener);
-  }
-
+  /// This notifier's value is true if a scroll is underway and false if the scroll
+  /// position is idle.
+  ///
+  /// Listeners added by stateful widgets should be in the widget's
+  /// [State.dispose] method.
+  final ValueNotifier<bool> isScrollingNotifier = new ValueNotifier<bool>(false);
 
   /// Change the current [activity], disposing of the old one and
   /// sending scroll notifications as necessary.
@@ -504,8 +497,7 @@ class ScrollPosition extends ViewportOffset {
     _activity = newActivity;
     if (oldIgnorePointer != shouldIgnorePointer)
       state.setIgnorePointer(shouldIgnorePointer);
-    if (_isScrollingNotifier != null)
-      _isScrollingNotifier.value = isScrolling;
+    isScrollingNotifier.value = _activity?.isScrolling ?? false;
     if (!activity.isScrolling)
       updateUserScrollDirection(ScrollDirection.idle);
     if (!wasScrolling && activity.isScrolling)

--- a/packages/flutter/lib/src/widgets/scrollable.dart
+++ b/packages/flutter/lib/src/widgets/scrollable.dart
@@ -103,6 +103,7 @@ class _ScrollableScope extends InheritedWidget {
   _ScrollableScope({
     Key key,
     @required this.scrollable,
+    @required this.position,
     @required Widget child
   }) : super(key: key, child: child) {
     assert(scrollable != null);
@@ -110,9 +111,12 @@ class _ScrollableScope extends InheritedWidget {
   }
 
   final ScrollableState scrollable;
+  final ScrollPosition position;
 
   @override
-  bool updateShouldNotify(_ScrollableScope old) => true;
+  bool updateShouldNotify(_ScrollableScope old) {
+    return position != old.position;
+  }
 }
 
 /// State object for a [Scrollable] widget.
@@ -333,6 +337,7 @@ class ScrollableState extends State<Scrollable> with TickerProviderStateMixin
         ignoring: _shouldIgnorePointer,
         child: new _ScrollableScope(
           scrollable: this,
+          position: position,
           child: widget.viewportBuilder(context, position),
         ),
       ),

--- a/packages/flutter/lib/src/widgets/sliver_persistent_header.dart
+++ b/packages/flutter/lib/src/widgets/sliver_persistent_header.dart
@@ -19,6 +19,13 @@ abstract class SliverPersistentHeaderDelegate {
   double get maxExtent;
 
   bool shouldRebuild(covariant SliverPersistentHeaderDelegate oldDelegate);
+
+  /// Specifies how floating headers should animate in and out of view.
+  ///
+  /// If the value of this property is null, then floating headers will
+  /// not animate into place.
+  @protected
+  FloatingHeaderSnapConfiguration get snapConfiguration => null;
 }
 
 class SliverPersistentHeader extends StatelessWidget {
@@ -224,7 +231,13 @@ class _SliverFloatingPersistentHeader extends _SliverPersistentHeaderRenderObjec
 
   @override
   _RenderSliverPersistentHeaderForWidgetsMixin createRenderObject(BuildContext context) {
-    return new _RenderSliverFloatingPersistentHeaderForWidgets();
+    return new _RenderSliverFloatingPersistentHeaderForWidgets()
+      ..snapConfiguration = delegate.snapConfiguration;
+  }
+
+  @override
+  void updateRenderObject(BuildContext context, _RenderSliverFloatingPersistentHeaderForWidgets renderObject) {
+    renderObject.snapConfiguration = delegate.snapConfiguration;
   }
 }
 
@@ -241,7 +254,13 @@ class _SliverFloatingPinnedPersistentHeader extends _SliverPersistentHeaderRende
 
   @override
   _RenderSliverPersistentHeaderForWidgetsMixin createRenderObject(BuildContext context) {
-    return new _RenderSliverFloatingPinnedPersistentHeaderForWidgets();
+    return new _RenderSliverFloatingPinnedPersistentHeaderForWidgets()
+      ..snapConfiguration = delegate.snapConfiguration;
+  }
+
+  @override
+  void updateRenderObject(BuildContext context, _RenderSliverFloatingPinnedPersistentHeaderForWidgets renderObject) {
+    renderObject.snapConfiguration = delegate.snapConfiguration;
   }
 }
 

--- a/packages/flutter/lib/src/widgets/sliver_persistent_header.dart
+++ b/packages/flutter/lib/src/widgets/sliver_persistent_header.dart
@@ -231,6 +231,8 @@ class _SliverFloatingPersistentHeader extends _SliverPersistentHeaderRenderObjec
 
   @override
   _RenderSliverPersistentHeaderForWidgetsMixin createRenderObject(BuildContext context) {
+    // Not passing this snapConfiguration as a constructor parameter to avoid the
+    // additional layers added due to https://github.com/dart-lang/sdk/issues/15101
     return new _RenderSliverFloatingPersistentHeaderForWidgets()
       ..snapConfiguration = delegate.snapConfiguration;
   }
@@ -254,6 +256,8 @@ class _SliverFloatingPinnedPersistentHeader extends _SliverPersistentHeaderRende
 
   @override
   _RenderSliverPersistentHeaderForWidgetsMixin createRenderObject(BuildContext context) {
+    // Not passing this snapConfiguration as a constructor parameter to avoid the
+    // additional layers added due to https://github.com/dart-lang/sdk/issues/15101
     return new _RenderSliverFloatingPinnedPersistentHeaderForWidgets()
       ..snapConfiguration = delegate.snapConfiguration;
   }

--- a/packages/flutter/test/material/app_bar_test.dart
+++ b/packages/flutter/test/material/app_bar_test.dart
@@ -459,7 +459,7 @@ void main() {
     final double initialAppBarHeight = 128.0;
     final double initialTabBarHeight = tabBarHeight(tester);
 
-    // Scroll the not-pinned appbar, collapsing the expanded height. At this
+    // Scroll the floating-pinned appbar, collapsing the expanded height. At this
     // point only the tabBar is visible.
     controller.jumpTo(600.0);
     await tester.pump();
@@ -468,7 +468,7 @@ void main() {
     expect(appBarHeight(tester), lessThan(initialAppBarHeight));
     expect(appBarHeight(tester), initialTabBarHeight);
 
-    // Scroll the not-pinned appbar back into view
+    // Scroll the floating-pinned appbar back into view
     controller.jumpTo(0.0);
     await tester.pump();
     expect(appBarIsVisible(tester), true);

--- a/packages/flutter/test/widgets/scrollable_of_test.dart
+++ b/packages/flutter/test/widgets/scrollable_of_test.dart
@@ -1,0 +1,85 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter/widgets.dart';
+
+class ScrollPositionListener extends StatefulWidget {
+  ScrollPositionListener({ Key key, this.child, this.log}) : super(key: key);
+
+  final Widget child;
+  final ValueChanged<String> log;
+
+  @override
+  _ScrollPositionListenerState createState() => new _ScrollPositionListenerState();
+}
+
+class _ScrollPositionListenerState extends State<ScrollPositionListener> {
+  ScrollPosition _position;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    _position?.removeListener(listener);
+    _position = Scrollable.of(context)?.position;
+    _position?.addListener(listener);
+    widget.log("didChangeDependencies ${_position?.pixels}");
+  }
+
+  @override
+  void dispose() {
+    _position?.removeListener(listener);
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) => widget.child;
+
+  void listener() {
+    widget.log("listener ${_position?.pixels}");
+  }
+
+}
+
+void main() {
+  testWidgets('Scrollable.of() dependent rebuilds when Scrollable position changes', (WidgetTester tester) async {
+    String logValue;
+    final ScrollController controller = new ScrollController();
+
+    // Changing the SingleChildScrollView's physics causes the
+    // ScrollController's ScrollPosition to be rebuilt.
+
+    Widget buildFrame(ScrollPhysics physics) {
+      return new SingleChildScrollView(
+        controller: controller,
+        physics: physics,
+        child: new ScrollPositionListener(
+          log: (String s) { logValue = s; },
+          child: const SizedBox(height: 400.0),
+        ),
+      );
+    }
+
+    await tester.pumpWidget(buildFrame(null));
+    expect(logValue, "didChangeDependencies 0.0");
+
+    controller.jumpTo(100.0);
+    expect(logValue, "listener 100.0");
+
+    await tester.pumpWidget(buildFrame(const ClampingScrollPhysics()));
+    expect(logValue, "didChangeDependencies 100.0");
+
+    controller.jumpTo(200.0);
+    expect(logValue, "listener 200.0");
+
+    controller.jumpTo(300.0);
+    expect(logValue, "listener 300.0");
+
+    await tester.pumpWidget(buildFrame(const BouncingScrollPhysics()));
+    expect(logValue, "didChangeDependencies 300.0");
+
+    controller.jumpTo(400.0);
+    expect(logValue, "listener 400.0");
+  });
+}


### PR DESCRIPTION
Support for floating appbars that snap open and shut after a short scroll up or down.

A useful additional feature would be support for specifying that only part of the AppBar, often the integral tab bar,  was to appear when a floating (not pinned) appbar snapped open. Similarly, app bars might want to change how they're configured when they're floating.


