### PR TITLE
Make Cupertino page transition linear during drag

### DIFF
--- a/packages/flutter/lib/src/material/page.dart
+++ b/packages/flutter/lib/src/material/page.dart
@@ -77,8 +77,6 @@ class MaterialPageRoute<T> extends PageRoute<T> {
   final WidgetBuilder builder;
   final bool fullscreenDialog;
 
-  AnimatedWidget _transitionAnimatedWidget;
-
   @override
   final bool maintainState;
 
@@ -164,12 +162,12 @@ class MaterialPageRoute<T> extends PageRoute<T> {
   Widget buildTransitions(BuildContext context, Animation<double> animation, Animation<double> forwardAnimation, Widget child) {
     if (Theme.of(context).platform == TargetPlatform.iOS) {
       if (fullscreenDialog)
-        _transitionAnimatedWidget = new CupertinoFullscreenDialogTransition(
+        return new CupertinoFullscreenDialogTransition(
           animation: animation,
           child: child,
         );
       else
-        _transitionAnimatedWidget = new CupertinoPageTransition(
+        return new CupertinoPageTransition(
           incomingRouteAnimation: animation,
           outgoingRouteAnimation: forwardAnimation,
           child: child,
@@ -178,12 +176,11 @@ class MaterialPageRoute<T> extends PageRoute<T> {
           linearTransition: _backGestureController != null,
         );
     } else {
-      _transitionAnimatedWidget = new _MountainViewPageTransition(
+      return new _MountainViewPageTransition(
         routeAnimation: animation,
         child: child
       );
     }
-    return _transitionAnimatedWidget;
   }
 
   @override

--- a/packages/flutter/lib/src/material/page.dart
+++ b/packages/flutter/lib/src/material/page.dart
@@ -131,7 +131,6 @@ class MaterialPageRoute<T> extends PageRoute<T> {
     _backGestureController = new CupertinoBackGestureController(
       navigator: navigator,
       controller: controller,
-      transitionAnimatedWidget: _transitionAnimatedWidget,
     );
 
     controller.addStatusListener(_handleBackGestureEnded);
@@ -174,6 +173,9 @@ class MaterialPageRoute<T> extends PageRoute<T> {
           incomingRouteAnimation: animation,
           outgoingRouteAnimation: forwardAnimation,
           child: child,
+          // In the middle of a back gesture drag, let the transition be linear to match finger
+          // motions.
+          linearTransition: _backGestureController != null,
         );
     } else {
       _transitionAnimatedWidget = new _MountainViewPageTransition(
@@ -181,7 +183,6 @@ class MaterialPageRoute<T> extends PageRoute<T> {
         child: child
       );
     }
-    print('building transition $_transitionAnimatedWidget');
     return _transitionAnimatedWidget;
   }
 

--- a/packages/flutter/lib/src/material/page.dart
+++ b/packages/flutter/lib/src/material/page.dart
@@ -77,6 +77,8 @@ class MaterialPageRoute<T> extends PageRoute<T> {
   final WidgetBuilder builder;
   final bool fullscreenDialog;
 
+  AnimatedWidget _transitionAnimatedWidget;
+
   @override
   final bool maintainState;
 
@@ -129,6 +131,7 @@ class MaterialPageRoute<T> extends PageRoute<T> {
     _backGestureController = new CupertinoBackGestureController(
       navigator: navigator,
       controller: controller,
+      transitionAnimatedWidget: _transitionAnimatedWidget,
     );
 
     controller.addStatusListener(_handleBackGestureEnded);
@@ -162,22 +165,24 @@ class MaterialPageRoute<T> extends PageRoute<T> {
   Widget buildTransitions(BuildContext context, Animation<double> animation, Animation<double> forwardAnimation, Widget child) {
     if (Theme.of(context).platform == TargetPlatform.iOS) {
       if (fullscreenDialog)
-        return new CupertinoFullscreenDialogTransition(
+        _transitionAnimatedWidget = new CupertinoFullscreenDialogTransition(
           animation: animation,
           child: child,
         );
       else
-        return new CupertinoPageTransition(
+        _transitionAnimatedWidget = new CupertinoPageTransition(
           incomingRouteAnimation: animation,
           outgoingRouteAnimation: forwardAnimation,
           child: child,
         );
     } else {
-      return new _MountainViewPageTransition(
+      _transitionAnimatedWidget = new _MountainViewPageTransition(
         routeAnimation: animation,
         child: child
       );
     }
+    print('building transition $_transitionAnimatedWidget');
+    return _transitionAnimatedWidget;
   }
 
   @override

--- a/packages/flutter/test/material/page_test.dart
+++ b/packages/flutter/test/material/page_test.dart
@@ -209,7 +209,7 @@ void main() {
     // Drag from left edge to invoke the gesture.
     final TestGesture gesture = await tester.startGesture(const Point(5.0, 100.0));
     await gesture.moveBy(const Offset(400.0, 0.0));
-    await tester.pumpAndSettle();
+    await tester.pump();
 
     expect(find.text('Page 1'), findsNothing);
     expect(find.text('Page 2'), isOnstage);
@@ -240,7 +240,7 @@ void main() {
     // Drag from left edge to invoke the gesture.
     final TestGesture gesture = await tester.startGesture(const Point(5.0, 100.0));
     await gesture.moveBy(const Offset(400.0, 0.0));
-    await tester.pumpAndSettle();
+    await tester.pump();
 
     // Page 1 is now visible.
     expect(find.text('Page 1'), isOnstage);
@@ -250,12 +250,12 @@ void main() {
     expect(tester.getTopLeft(find.text('Page 2')), const Point(400.0, 0.0));
 
     await gesture.moveBy(const Offset(-200.0, 0.0));
-    await tester.pumpAndSettle();
+    await tester.pump();
 
     expect(tester.getTopLeft(find.text('Page 2')), const Point(200.0, 0.0));
 
     await gesture.moveBy(const Offset(-100.0, 200.0));
-    await tester.pumpAndSettle();
+    await tester.pump();
 
     expect(tester.getTopLeft(find.text('Page 2')), const Point(100.0, 0.0));
   });
@@ -282,7 +282,7 @@ void main() {
     // Drag from left edge to invoke the gesture.
     final TestGesture gesture = await tester.startGesture(const Point(5.0, 100.0));
     await gesture.moveBy(const Offset(400.0, 0.0));
-    await tester.pumpAndSettle();
+    await tester.pump();
 
     expect(find.text('Page 1'), findsNothing);
     expect(find.text('Page 2'), isOnstage);

--- a/packages/flutter/test/material/page_test.dart
+++ b/packages/flutter/test/material/page_test.dart
@@ -245,6 +245,19 @@ void main() {
     // Page 1 is now visible.
     expect(find.text('Page 1'), isOnstage);
     expect(find.text('Page 2'), isOnstage);
+
+    // The route widget position needs to track the finger position very exactly.
+    expect(tester.getTopLeft(find.text('Page 2')), const Point(400.0, 0.0));
+
+    await gesture.moveBy(const Offset(-200.0, 0.0));
+    await tester.pumpAndSettle();
+
+    expect(tester.getTopLeft(find.text('Page 2')), const Point(200.0, 0.0));
+
+    await gesture.moveBy(const Offset(-100.0, 200.0));
+    await tester.pumpAndSettle();
+
+    expect(tester.getTopLeft(find.text('Page 2')), const Point(100.0, 0.0));
   });
 
   testWidgets('test no back gesture on iOS fullscreen dialogs', (WidgetTester tester) async {


### PR DESCRIPTION
So that the page's edge would track the finger's position very precisely.

#8726