### PR TITLE
Android: Set evaluationDependsOn for plugin subprojects.

### DIFF
--- a/examples/flutter_gallery/android/build.gradle
+++ b/examples/flutter_gallery/android/build.gradle
@@ -14,6 +14,12 @@ allprojects {
     }
 }
 
+rootProject.buildDir = '../build'
+subprojects {
+    project.buildDir = "${rootProject.buildDir}/${project.name}"
+    project.evaluationDependsOn(':app')
+}
+
 task clean(type: Delete) {
     delete rootProject.buildDir
 }

--- a/examples/flutter_gallery/android/settings.gradle
+++ b/examples/flutter_gallery/android/settings.gradle
@@ -1,1 +1,15 @@
 include ':app'
+
+def flutterProjectRoot = rootProject.projectDir.parentFile.toPath()
+
+def plugins = new Properties()
+def pluginsFile = new File(flutterProjectRoot.toFile(), '.flutter-plugins')
+if (pluginsFile.exists()) {
+    pluginsFile.withInputStream { stream -> plugins.load(stream) }
+}
+
+plugins.each { name, path ->
+    def pluginDirectory = flutterProjectRoot.resolve(path).resolve('android').toFile()
+    include ":$name"
+    project(":$name").projectDir = pluginDirectory
+}

--- a/examples/flutter_view/android/build.gradle
+++ b/examples/flutter_view/android/build.gradle
@@ -14,6 +14,12 @@ allprojects {
     }
 }
 
+rootProject.buildDir = '../build'
+subprojects {
+    project.buildDir = "${rootProject.buildDir}/${project.name}"
+    project.evaluationDependsOn(':app')
+}
+
 task clean(type: Delete) {
     delete rootProject.buildDir
 }

--- a/examples/flutter_view/android/settings.gradle
+++ b/examples/flutter_view/android/settings.gradle
@@ -1,1 +1,15 @@
 include ':app'
+
+def flutterProjectRoot = rootProject.projectDir.parentFile.toPath()
+
+def plugins = new Properties()
+def pluginsFile = new File(flutterProjectRoot.toFile(), '.flutter-plugins')
+if (pluginsFile.exists()) {
+    pluginsFile.withInputStream { stream -> plugins.load(stream) }
+}
+
+plugins.each { name, path ->
+    def pluginDirectory = flutterProjectRoot.resolve(path).resolve('android').toFile()
+    include ":$name"
+    project(":$name").projectDir = pluginDirectory
+}

--- a/examples/hello_world/android/build.gradle
+++ b/examples/hello_world/android/build.gradle
@@ -14,6 +14,12 @@ allprojects {
     }
 }
 
+rootProject.buildDir = '../build'
+subprojects {
+    project.buildDir = "${rootProject.buildDir}/${project.name}"
+    project.evaluationDependsOn(':app')
+}
+
 task clean(type: Delete) {
     delete rootProject.buildDir
 }

--- a/examples/hello_world/android/settings.gradle
+++ b/examples/hello_world/android/settings.gradle
@@ -1,1 +1,15 @@
 include ':app'
+
+def flutterProjectRoot = rootProject.projectDir.parentFile.toPath()
+
+def plugins = new Properties()
+def pluginsFile = new File(flutterProjectRoot.toFile(), '.flutter-plugins')
+if (pluginsFile.exists()) {
+    pluginsFile.withInputStream { stream -> plugins.load(stream) }
+}
+
+plugins.each { name, path ->
+    def pluginDirectory = flutterProjectRoot.resolve(path).resolve('android').toFile()
+    include ":$name"
+    project(":$name").projectDir = pluginDirectory
+}

--- a/examples/platform_channel/android/build.gradle
+++ b/examples/platform_channel/android/build.gradle
@@ -14,6 +14,12 @@ allprojects {
     }
 }
 
+rootProject.buildDir = '../build'
+subprojects {
+    project.buildDir = "${rootProject.buildDir}/${project.name}"
+    project.evaluationDependsOn(':app')
+}
+
 task clean(type: Delete) {
     delete rootProject.buildDir
 }

--- a/examples/platform_channel/android/settings.gradle
+++ b/examples/platform_channel/android/settings.gradle
@@ -1,1 +1,15 @@
 include ':app'
+
+def flutterProjectRoot = rootProject.projectDir.parentFile.toPath()
+
+def plugins = new Properties()
+def pluginsFile = new File(flutterProjectRoot.toFile(), '.flutter-plugins')
+if (pluginsFile.exists()) {
+    pluginsFile.withInputStream { stream -> plugins.load(stream) }
+}
+
+plugins.each { name, path ->
+    def pluginDirectory = flutterProjectRoot.resolve(path).resolve('android').toFile()
+    include ":$name"
+    project(":$name").projectDir = pluginDirectory
+}

--- a/examples/stocks/android/build.gradle
+++ b/examples/stocks/android/build.gradle
@@ -14,6 +14,12 @@ allprojects {
     }
 }
 
+rootProject.buildDir = '../build'
+subprojects {
+    project.buildDir = "${rootProject.buildDir}/${project.name}"
+    project.evaluationDependsOn(':app')
+}
+
 task clean(type: Delete) {
     delete rootProject.buildDir
 }

--- a/examples/stocks/android/settings.gradle
+++ b/examples/stocks/android/settings.gradle
@@ -1,1 +1,15 @@
 include ':app'
+
+def flutterProjectRoot = rootProject.projectDir.parentFile.toPath()
+
+def plugins = new Properties()
+def pluginsFile = new File(flutterProjectRoot.toFile(), '.flutter-plugins')
+if (pluginsFile.exists()) {
+    pluginsFile.withInputStream { stream -> plugins.load(stream) }
+}
+
+plugins.each { name, path ->
+    def pluginDirectory = flutterProjectRoot.resolve(path).resolve('android').toFile()
+    include ":$name"
+    project(":$name").projectDir = pluginDirectory
+}

--- a/packages/flutter_tools/templates/create/android.tmpl/build.gradle
+++ b/packages/flutter_tools/templates/create/android.tmpl/build.gradle
@@ -17,6 +17,7 @@ allprojects {
 rootProject.buildDir = '../build'
 subprojects {
     project.buildDir = "${rootProject.buildDir}/${project.name}"
+    project.evaluationDependsOn(':app')
 }
 
 task clean(type: Delete) {

--- a/packages/flutter_tools/templates/plugin/android.tmpl/src/main/java/com/yourcompany/projectName/pluginClass.java.tmpl
+++ b/packages/flutter_tools/templates/plugin/android.tmpl/src/main/java/com/yourcompany/projectName/pluginClass.java.tmpl
@@ -6,9 +6,6 @@ import io.flutter.plugin.common.FlutterMethodChannel.MethodCallHandler;
 import io.flutter.plugin.common.FlutterMethodChannel.Response;
 import io.flutter.plugin.common.MethodCall;
 
-import java.util.HashMap;
-import java.util.Map;
-
 /**
  * {{pluginClass}}
  */


### PR DESCRIPTION
Gradle projects are evaluated in lexicographical order. The plugin projects are at the same level as the :app project, so if a plugin has a name that comes before 'app' (like, for example, any name that starts with a capital letter), the plugin project will be evaluated before :app.

Since :app applies the Flutter Gradle plugin, which tries to modify the dependencies of the plugin projects, we have a problem if the plugin projects have already been evaluated. Adding `evaluationDependsOn(':app')` to the plugin projects fixes this.

Updated example projects to the latest (plugin-enabled) Gradle build files.

Also removed two unused imports in `pluginClass.java.tmpl`.