### PR TITLE
Document the buildTransitions() method

### DIFF
--- a/examples/flutter_gallery/lib/demo/shrine_demo.dart
+++ b/examples/flutter_gallery/lib/demo/shrine_demo.dart
@@ -29,8 +29,8 @@ class ShrinePageRoute<T> extends MaterialPageRoute<T> {
   }) : super(builder: builder, settings: settings);
 
   @override
-  Widget buildPage(BuildContext context, Animation<double> animation, Animation<double> forwardAnimation) {
-    return buildShrine(context, super.buildPage(context, animation, forwardAnimation));
+  Widget buildPage(BuildContext context, Animation<double> primaryAnimation, Animation<double> secondaryAnimation) {
+    return buildShrine(context, super.buildPage(context, primaryAnimation, secondaryAnimation));
   }
 }
 

--- a/examples/flutter_gallery/lib/demo/shrine_demo.dart
+++ b/examples/flutter_gallery/lib/demo/shrine_demo.dart
@@ -29,8 +29,8 @@ class ShrinePageRoute<T> extends MaterialPageRoute<T> {
   }) : super(builder: builder, settings: settings);
 
   @override
-  Widget buildPage(BuildContext context, Animation<double> primaryAnimation, Animation<double> secondaryAnimation) {
-    return buildShrine(context, super.buildPage(context, primaryAnimation, secondaryAnimation));
+  Widget buildPage(BuildContext context, Animation<double> animation, Animation<double> secondaryAnimation) {
+    return buildShrine(context, super.buildPage(context, animation, secondaryAnimation));
   }
 }
 

--- a/packages/flutter/lib/src/material/bottom_sheet.dart
+++ b/packages/flutter/lib/src/material/bottom_sheet.dart
@@ -231,7 +231,7 @@ class _ModalBottomSheetRoute<T> extends PopupRoute<T> {
   }
 
   @override
-  Widget buildPage(BuildContext context, Animation<double> animation, Animation<double> forwardAnimation) {
+  Widget buildPage(BuildContext context, Animation<double> primaryAnimation, Animation<double> secondaryAnimation) {
     Widget bottomSheet = new _ModalBottomSheet<T>(route: this);
     if (theme != null)
       bottomSheet = new Theme(data: theme, child: bottomSheet);

--- a/packages/flutter/lib/src/material/bottom_sheet.dart
+++ b/packages/flutter/lib/src/material/bottom_sheet.dart
@@ -231,7 +231,7 @@ class _ModalBottomSheetRoute<T> extends PopupRoute<T> {
   }
 
   @override
-  Widget buildPage(BuildContext context, Animation<double> primaryAnimation, Animation<double> secondaryAnimation) {
+  Widget buildPage(BuildContext context, Animation<double> animation, Animation<double> secondaryAnimation) {
     Widget bottomSheet = new _ModalBottomSheet<T>(route: this);
     if (theme != null)
       bottomSheet = new Theme(data: theme, child: bottomSheet);

--- a/packages/flutter/lib/src/material/dialog.dart
+++ b/packages/flutter/lib/src/material/dialog.dart
@@ -337,15 +337,15 @@ class _DialogRoute<T> extends PopupRoute<T> {
   Color get barrierColor => Colors.black54;
 
   @override
-  Widget buildPage(BuildContext context, Animation<double> primaryAnimation, Animation<double> secondaryAnimation) {
+  Widget buildPage(BuildContext context, Animation<double> animation, Animation<double> secondaryAnimation) {
     return theme != null ? new Theme(data: theme, child: child) : child;
   }
 
   @override
-  Widget buildTransitions(BuildContext context, Animation<double> primaryAnimation, Animation<double> secondaryAnimation, Widget child) {
+  Widget buildTransitions(BuildContext context, Animation<double> animation, Animation<double> secondaryAnimation, Widget child) {
     return new FadeTransition(
       opacity: new CurvedAnimation(
-        parent: primaryAnimation,
+        parent: animation,
         curve: Curves.easeOut
       ),
       child: child

--- a/packages/flutter/lib/src/material/dialog.dart
+++ b/packages/flutter/lib/src/material/dialog.dart
@@ -337,15 +337,15 @@ class _DialogRoute<T> extends PopupRoute<T> {
   Color get barrierColor => Colors.black54;
 
   @override
-  Widget buildPage(BuildContext context, Animation<double> animation, Animation<double> forwardAnimation) {
+  Widget buildPage(BuildContext context, Animation<double> primaryAnimation, Animation<double> secondaryAnimation) {
     return theme != null ? new Theme(data: theme, child: child) : child;
   }
 
   @override
-  Widget buildTransitions(BuildContext context, Animation<double> animation, Animation<double> forwardAnimation, Widget child) {
+  Widget buildTransitions(BuildContext context, Animation<double> primaryAnimation, Animation<double> secondaryAnimation, Widget child) {
     return new FadeTransition(
       opacity: new CurvedAnimation(
-        parent: animation,
+        parent: primaryAnimation,
         curve: Curves.easeOut
       ),
       child: child

--- a/packages/flutter/lib/src/material/dropdown.dart
+++ b/packages/flutter/lib/src/material/dropdown.dart
@@ -313,7 +313,7 @@ class _DropdownRoute<T> extends PopupRoute<_DropdownRouteResult<T>> {
   Color get barrierColor => null;
 
   @override
-  Widget buildPage(BuildContext context, Animation<double> animation, Animation<double> forwardAnimation) {
+  Widget buildPage(BuildContext context, Animation<double> primaryAnimation, Animation<double> secondaryAnimation) {
     Widget menu = new _DropdownMenu<T>(route: this);
     if (theme != null)
       menu = new Theme(data: theme, child: menu);

--- a/packages/flutter/lib/src/material/dropdown.dart
+++ b/packages/flutter/lib/src/material/dropdown.dart
@@ -313,7 +313,7 @@ class _DropdownRoute<T> extends PopupRoute<_DropdownRouteResult<T>> {
   Color get barrierColor => null;
 
   @override
-  Widget buildPage(BuildContext context, Animation<double> primaryAnimation, Animation<double> secondaryAnimation) {
+  Widget buildPage(BuildContext context, Animation<double> animation, Animation<double> secondaryAnimation) {
     Widget menu = new _DropdownMenu<T>(route: this);
     if (theme != null)
       menu = new Theme(data: theme, child: menu);

--- a/packages/flutter/lib/src/material/page.dart
+++ b/packages/flutter/lib/src/material/page.dart
@@ -149,7 +149,7 @@ class MaterialPageRoute<T> extends PageRoute<T> {
   }
 
   @override
-  Widget buildPage(BuildContext context, Animation<double> animation, Animation<double> forwardAnimation) {
+  Widget buildPage(BuildContext context, Animation<double> primaryAnimation, Animation<double> secondaryAnimation) {
     final Widget result = builder(context);
     assert(() {
       if (result == null) {
@@ -164,17 +164,17 @@ class MaterialPageRoute<T> extends PageRoute<T> {
   }
 
   @override
-  Widget buildTransitions(BuildContext context, Animation<double> animation, Animation<double> forwardAnimation, Widget child) {
+  Widget buildTransitions(BuildContext context, Animation<double> primaryAnimation, Animation<double> secondaryAnimation, Widget child) {
     if (Theme.of(context).platform == TargetPlatform.iOS) {
       if (fullscreenDialog)
         return new CupertinoFullscreenDialogTransition(
-          animation: animation,
+          animation: primaryAnimation,
           child: child,
         );
       else
         return new CupertinoPageTransition(
-          incomingRouteAnimation: animation,
-          outgoingRouteAnimation: forwardAnimation,
+          incomingRouteAnimation: primaryAnimation,
+          outgoingRouteAnimation: secondaryAnimation,
           child: child,
           // In the middle of a back gesture drag, let the transition be linear to match finger
           // motions.
@@ -182,7 +182,7 @@ class MaterialPageRoute<T> extends PageRoute<T> {
         );
     } else {
       return new _MountainViewPageTransition(
-        routeAnimation: animation,
+        routeAnimation: primaryAnimation,
         child: child
       );
     }

--- a/packages/flutter/lib/src/material/page.dart
+++ b/packages/flutter/lib/src/material/page.dart
@@ -149,7 +149,7 @@ class MaterialPageRoute<T> extends PageRoute<T> {
   }
 
   @override
-  Widget buildPage(BuildContext context, Animation<double> primaryAnimation, Animation<double> secondaryAnimation) {
+  Widget buildPage(BuildContext context, Animation<double> animation, Animation<double> secondaryAnimation) {
     final Widget result = builder(context);
     assert(() {
       if (result == null) {
@@ -164,16 +164,16 @@ class MaterialPageRoute<T> extends PageRoute<T> {
   }
 
   @override
-  Widget buildTransitions(BuildContext context, Animation<double> primaryAnimation, Animation<double> secondaryAnimation, Widget child) {
+  Widget buildTransitions(BuildContext context, Animation<double> animation, Animation<double> secondaryAnimation, Widget child) {
     if (Theme.of(context).platform == TargetPlatform.iOS) {
       if (fullscreenDialog)
         return new CupertinoFullscreenDialogTransition(
-          animation: primaryAnimation,
+          animation: animation,
           child: child,
         );
       else
         return new CupertinoPageTransition(
-          incomingRouteAnimation: primaryAnimation,
+          incomingRouteAnimation: animation,
           outgoingRouteAnimation: secondaryAnimation,
           child: child,
           // In the middle of a back gesture drag, let the transition be linear to match finger
@@ -182,7 +182,7 @@ class MaterialPageRoute<T> extends PageRoute<T> {
         );
     } else {
       return new _MountainViewPageTransition(
-        routeAnimation: primaryAnimation,
+        routeAnimation: animation,
         child: child
       );
     }

--- a/packages/flutter/lib/src/material/popup_menu.dart
+++ b/packages/flutter/lib/src/material/popup_menu.dart
@@ -402,7 +402,7 @@ class _PopupMenuRoute<T> extends PopupRoute<T> {
   Color get barrierColor => null;
 
   @override
-  Widget buildPage(BuildContext context, Animation<double> animation, Animation<double> forwardAnimation) {
+  Widget buildPage(BuildContext context, Animation<double> primaryAnimation, Animation<double> secondaryAnimation) {
     double selectedItemOffset;
     if (initialValue != null) {
       selectedItemOffset = 0.0;

--- a/packages/flutter/lib/src/material/popup_menu.dart
+++ b/packages/flutter/lib/src/material/popup_menu.dart
@@ -402,7 +402,7 @@ class _PopupMenuRoute<T> extends PopupRoute<T> {
   Color get barrierColor => null;
 
   @override
-  Widget buildPage(BuildContext context, Animation<double> primaryAnimation, Animation<double> secondaryAnimation) {
+  Widget buildPage(BuildContext context, Animation<double> animation, Animation<double> secondaryAnimation) {
     double selectedItemOffset;
     if (initialValue != null) {
       selectedItemOffset = 0.0;

--- a/packages/flutter/lib/src/widgets/pages.dart
+++ b/packages/flutter/lib/src/widgets/pages.dart
@@ -46,15 +46,15 @@ abstract class PageRoute<T> extends ModalRoute<T> {
 /// primary contents.
 ///
 /// See [ModalRoute.buildPage] for complete definition of the parameters.
-typedef Widget RoutePageBuilder(BuildContext context, Animation<double> animation, Animation<double> forwardAnimation);
+typedef Widget RoutePageBuilder(BuildContext context, Animation<double> primaryAnimation, Animation<double> secondaryAnimation);
 
 /// Signature for the [PageRouteBuilder] function that builds the route's
 /// transitions.
 ///
 /// See [ModalRoute.buildTransitions] for complete definition of the parameters.
-typedef Widget RouteTransitionsBuilder(BuildContext context, Animation<double> animation, Animation<double> forwardAnimation, Widget child);
+typedef Widget RouteTransitionsBuilder(BuildContext context, Animation<double> primaryAnimation, Animation<double> secondaryAnimation, Widget child);
 
-Widget _defaultTransitionsBuilder(BuildContext context, Animation<double> animation, Animation<double> forwardAnimation, Widget child) {
+Widget _defaultTransitionsBuilder(BuildContext context, Animation<double> primaryAnimation, Animation<double> secondaryAnimation, Widget child) {
   return child;
 }
 
@@ -110,13 +110,13 @@ class PageRouteBuilder<T> extends PageRoute<T> {
   final bool maintainState;
 
   @override
-  Widget buildPage(BuildContext context, Animation<double> animation, Animation<double> forwardAnimation) {
-    return pageBuilder(context, animation, forwardAnimation);
+  Widget buildPage(BuildContext context, Animation<double> primaryAnimation, Animation<double> secondaryAnimation) {
+    return pageBuilder(context, primaryAnimation, secondaryAnimation);
   }
 
   @override
-  Widget buildTransitions(BuildContext context, Animation<double> animation, Animation<double> forwardAnimation, Widget child) {
-    return transitionsBuilder(context, animation, forwardAnimation, child);
+  Widget buildTransitions(BuildContext context, Animation<double> primaryAnimation, Animation<double> secondaryAnimation, Widget child) {
+    return transitionsBuilder(context, primaryAnimation, secondaryAnimation, child);
   }
 
 }

--- a/packages/flutter/lib/src/widgets/pages.dart
+++ b/packages/flutter/lib/src/widgets/pages.dart
@@ -46,15 +46,15 @@ abstract class PageRoute<T> extends ModalRoute<T> {
 /// primary contents.
 ///
 /// See [ModalRoute.buildPage] for complete definition of the parameters.
-typedef Widget RoutePageBuilder(BuildContext context, Animation<double> primaryAnimation, Animation<double> secondaryAnimation);
+typedef Widget RoutePageBuilder(BuildContext context, Animation<double> animation, Animation<double> secondaryAnimation);
 
 /// Signature for the [PageRouteBuilder] function that builds the route's
 /// transitions.
 ///
 /// See [ModalRoute.buildTransitions] for complete definition of the parameters.
-typedef Widget RouteTransitionsBuilder(BuildContext context, Animation<double> primaryAnimation, Animation<double> secondaryAnimation, Widget child);
+typedef Widget RouteTransitionsBuilder(BuildContext context, Animation<double> animation, Animation<double> secondaryAnimation, Widget child);
 
-Widget _defaultTransitionsBuilder(BuildContext context, Animation<double> primaryAnimation, Animation<double> secondaryAnimation, Widget child) {
+Widget _defaultTransitionsBuilder(BuildContext context, Animation<double> animation, Animation<double> secondaryAnimation, Widget child) {
   return child;
 }
 
@@ -110,13 +110,13 @@ class PageRouteBuilder<T> extends PageRoute<T> {
   final bool maintainState;
 
   @override
-  Widget buildPage(BuildContext context, Animation<double> primaryAnimation, Animation<double> secondaryAnimation) {
-    return pageBuilder(context, primaryAnimation, secondaryAnimation);
+  Widget buildPage(BuildContext context, Animation<double> animation, Animation<double> secondaryAnimation) {
+    return pageBuilder(context, animation, secondaryAnimation);
   }
 
   @override
-  Widget buildTransitions(BuildContext context, Animation<double> primaryAnimation, Animation<double> secondaryAnimation, Widget child) {
-    return transitionsBuilder(context, primaryAnimation, secondaryAnimation, child);
+  Widget buildTransitions(BuildContext context, Animation<double> animation, Animation<double> secondaryAnimation, Widget child) {
+    return transitionsBuilder(context, animation, secondaryAnimation, child);
   }
 
 }

--- a/packages/flutter/lib/src/widgets/routes.dart
+++ b/packages/flutter/lib/src/widgets/routes.dart
@@ -570,7 +570,7 @@ abstract class ModalRoute<T> extends TransitionRoute<T> with LocalHistoryRoute<T
   /// topmost route, e.g. because the use pressed the back button, the
   /// primary animation runs from 1.0 to 0.0.
   ///
-  /// The following example uses the animation to drive a
+  /// The following example uses the primary animation to drive a
   /// [SlideTransition] that translates the top of the new route vertically
   /// from the bottom of the screen when it is pushed on the Navigator's
   /// stack. When the route is popped the SlideTransition translates the

--- a/packages/flutter/lib/src/widgets/routes.dart
+++ b/packages/flutter/lib/src/widgets/routes.dart
@@ -559,7 +559,7 @@ abstract class ModalRoute<T> extends TransitionRoute<T> with LocalHistoryRoute<T
   Widget buildPage(BuildContext context, Animation<double> animation, Animation<double> forwardAnimation);
 
   /// Override this method to wrap the [child] with one or more transition
-  /// widgets that define how the route arrives and leaves the screen.
+  /// widgets that define how the route arrives on and leaves the screen.
   ///
   /// By default, the child is not wrapped in any transition widgets.
   ///

--- a/packages/flutter/lib/src/widgets/routes.dart
+++ b/packages/flutter/lib/src/widgets/routes.dart
@@ -566,11 +566,11 @@ abstract class ModalRoute<T> extends TransitionRoute<T> with LocalHistoryRoute<T
   /// The buildTransitions method is typically used to define transitions
   /// that animate the new topmost route's comings and goings. When the
   /// [Navigator] pushes a route on the top of its stack, the new route's
-  /// [primaryAnimation] runs from 0.0 to 1.0. When the Navigator pops the
+  /// primary [animation] runs from 0.0 to 1.0. When the Navigator pops the
   /// topmost route, e.g. because the use pressed the back button, the
   /// primary animation runs from 1.0 to 0.0.
   ///
-  /// The following example uses the primaryAnimation to drive a
+  /// The following example uses the animation to drive a
   /// [SlideTransition] that translates the top of the new route vertically
   /// from the bottom of the screen when it is pushed on the Navigator's
   /// stack. When the route is popped the SlideTransition translates the
@@ -588,14 +588,14 @@ abstract class ModalRoute<T> extends TransitionRoute<T> with LocalHistoryRoute<T
   ///   },
   ///   transitionsBuilder: (
   ///       BuildContext context,
-  ///       Animation<double> primaryAnimation,
+  ///       Animation<double> animation,
   ///       Animation<double> secondaryAnimation,
   ///       Widget child) {
   ///     return new SlideTransition(
   ///       position: new FractionalOffsetTween(
   ///         begin: FractionalOffset.bottomLeft,
   ///         end: FractionalOffset.topLeft
-  ///       ).animate(primaryAnimation),
+  ///       ).animate(animation),
   ///       child: child, // child is the value returned by pageBuilder
   ///     );
   ///   },
@@ -624,7 +624,7 @@ abstract class ModalRoute<T> extends TransitionRoute<T> with LocalHistoryRoute<T
   /// ```dart
   ///   transitionsBuilder: (
   ///       BuildContext context,
-  ///       Animation<double> primaryAnimation,
+  ///       Animation<double> animation,
   ///       Animation<double> secondaryAnimation,
   ///       Widget child
   ///   ) {
@@ -632,7 +632,7 @@ abstract class ModalRoute<T> extends TransitionRoute<T> with LocalHistoryRoute<T
   ///       position: new FractionalOffsetTween(
   ///         begin: FractionalOffset.bottomLeft,
   ///         end: FractionalOffset.topLeft,
-  ///       ).animate(primaryAnimation),
+  ///       ).animate(animation),
   ///       child: new SlideTransition(
   ///         position: new FractionalOffsetTween(
   ///           begin: FractionalOffset.topLeft,
@@ -644,20 +644,19 @@ abstract class ModalRoute<T> extends TransitionRoute<T> with LocalHistoryRoute<T
   ///   }
   ///```
   ///
-  /// In practice the secondaryAnimation is not used very often because animating
-  /// both the topmost route and the route below it can be more distracting
-  /// than helpful.
+  /// In practice the secondaryAnimation is used pretty rarely.
   ///
-  /// * [context] The context in which the route is being built.
-  /// * [primaryAnimation] The animation for this route's transition. When entering,
-  ///   the animation runs forward from 0.0 to 1.0. When exiting, this animation
-  ///   runs backwards from 1.0 to 0.0.
-  /// * [secondaryAnimation] The animation for the route below the topmost route.
-  ///   This animation lets this route coordinate with the entrance
-  ///   and exit transition of routes pushed on top.
+  ///  * [context] The context in which the route is being built.
+  ///  * [animation] When the [Navigator] pushes a route on the top of its stack,
+  ///    the new route's primary [animation] runs from 0.0 to 1.0. When the Navigator
+  ///    pops the topmost route this animation runs from 1.0 to 0.0.
+  ///  * [secondaryAnimation] When the Navigator pushes a new route
+  ///    on the top of its stack, the old topmost route's secondaryAnimation
+  ///    runs from 1.0 to 0.0.  When the Navigator pops the topmost route, the
+  ///    secondaryAnimation for the route below it runs from 0.0 to 1.0.
   Widget buildTransitions(
       BuildContext context,
-      Animation<double> primaryAnimation,
+      Animation<double> animation,
       Animation<double> secondaryAnimation,
       Widget child,
   ) {

--- a/packages/flutter/lib/src/widgets/routes.dart
+++ b/packages/flutter/lib/src/widgets/routes.dart
@@ -578,7 +578,11 @@ abstract class ModalRoute<T> extends TransitionRoute<T> with LocalHistoryRoute<T
   ///
   /// ```dart
   /// new PageRouteBuilder(
-  ///   pageBuilder: (BuildContext context, _, __) {
+  ///   pageBuilder: (BuildContext context,
+  ///       Animation<double> animation,
+  ///       Animation<double> secondaryAnimation,
+  ///       Widget child,
+  ///   ) {
   ///     return new Scaffold(
   ///       appBar: new AppBar(title: new Text('Hello')),
   ///       body: new Center(
@@ -590,7 +594,8 @@ abstract class ModalRoute<T> extends TransitionRoute<T> with LocalHistoryRoute<T
   ///       BuildContext context,
   ///       Animation<double> animation,
   ///       Animation<double> secondaryAnimation,
-  ///       Widget child) {
+  ///       Widget child,
+  ///    ) {
   ///     return new SlideTransition(
   ///       position: new FractionalOffsetTween(
   ///         begin: FractionalOffset.bottomLeft,
@@ -626,7 +631,7 @@ abstract class ModalRoute<T> extends TransitionRoute<T> with LocalHistoryRoute<T
   ///       BuildContext context,
   ///       Animation<double> animation,
   ///       Animation<double> secondaryAnimation,
-  ///       Widget child
+  ///       Widget child,
   ///   ) {
   ///     return new SlideTransition(
   ///       position: new FractionalOffsetTween(

--- a/packages/flutter/lib/src/widgets/routes.dart
+++ b/packages/flutter/lib/src/widgets/routes.dart
@@ -152,8 +152,8 @@ abstract class TransitionRoute<T> extends OverlayRoute<T> {
   /// The animation for the route being pushed on top of this route. This
   /// animation lets this route coordinate with the entrance and exit transition
   /// of routes pushed on top of this route.
-  Animation<double> get forwardAnimation => _forwardAnimation;
-  final ProxyAnimation _forwardAnimation = new ProxyAnimation(kAlwaysDismissedAnimation);
+  Animation<double> get secondaryAnimation => _secondaryAnimation;
+  final ProxyAnimation _secondaryAnimation = new ProxyAnimation(kAlwaysDismissedAnimation);
 
   @override
   void install(OverlayEntry insertionPoint) {
@@ -187,19 +187,19 @@ abstract class TransitionRoute<T> extends OverlayRoute<T> {
 
   @override
   void didPopNext(Route<dynamic> nextRoute) {
-    _updateForwardAnimation(nextRoute);
+    _updateSecondaryAnimation(nextRoute);
     super.didPopNext(nextRoute);
   }
 
   @override
   void didChangeNext(Route<dynamic> nextRoute) {
-    _updateForwardAnimation(nextRoute);
+    _updateSecondaryAnimation(nextRoute);
     super.didChangeNext(nextRoute);
   }
 
-  void _updateForwardAnimation(Route<dynamic> nextRoute) {
+  void _updateSecondaryAnimation(Route<dynamic> nextRoute) {
     if (nextRoute is TransitionRoute<dynamic> && canTransitionTo(nextRoute) && nextRoute.canTransitionFrom(this)) {
-      final Animation<double> current = _forwardAnimation.parent;
+      final Animation<double> current = _secondaryAnimation.parent;
       if (current != null) {
         if (current is TrainHoppingAnimation) {
           TrainHoppingAnimation newAnimation;
@@ -207,22 +207,22 @@ abstract class TransitionRoute<T> extends OverlayRoute<T> {
             current.currentTrain,
             nextRoute._animation,
             onSwitchedTrain: () {
-              assert(_forwardAnimation.parent == newAnimation);
+              assert(_secondaryAnimation.parent == newAnimation);
               assert(newAnimation.currentTrain == nextRoute._animation);
-              _forwardAnimation.parent = newAnimation.currentTrain;
+              _secondaryAnimation.parent = newAnimation.currentTrain;
               newAnimation.dispose();
             }
           );
-          _forwardAnimation.parent = newAnimation;
+          _secondaryAnimation.parent = newAnimation;
           current.dispose();
         } else {
-          _forwardAnimation.parent = new TrainHoppingAnimation(current, nextRoute._animation);
+          _secondaryAnimation.parent = new TrainHoppingAnimation(current, nextRoute._animation);
         }
       } else {
-        _forwardAnimation.parent = nextRoute._animation;
+        _secondaryAnimation.parent = nextRoute._animation;
       }
     } else {
-      _forwardAnimation.parent = kAlwaysDismissedAnimation;
+      _secondaryAnimation.parent = kAlwaysDismissedAnimation;
     }
   }
 
@@ -413,7 +413,7 @@ class _ModalScopeState extends State<_ModalScope> {
   void initState() {
     super.initState();
     config.route.animation?.addStatusListener(_animationStatusChanged);
-    config.route.forwardAnimation?.addStatusListener(_animationStatusChanged);
+    config.route.secondaryAnimation?.addStatusListener(_animationStatusChanged);
   }
 
   @override
@@ -424,7 +424,7 @@ class _ModalScopeState extends State<_ModalScope> {
   @override
   void dispose() {
     config.route.animation?.removeStatusListener(_animationStatusChanged);
-    config.route.forwardAnimation?.removeStatusListener(_animationStatusChanged);
+    config.route.secondaryAnimation?.removeStatusListener(_animationStatusChanged);
     super.dispose();
   }
 
@@ -459,7 +459,7 @@ class _ModalScopeState extends State<_ModalScope> {
           child: config.route.buildTransitions(
             context,
             config.route.animation,
-            config.route.forwardAnimation,
+            config.route.secondaryAnimation,
             new RepaintBoundary(
               child: new PageStorage(
                 key: config.route._subtreeKey,
@@ -553,10 +553,10 @@ abstract class ModalRoute<T> extends TransitionRoute<T> with LocalHistoryRoute<T
   /// * [animation] The animation for this route's transition. When entering,
   ///   the animation runs forward from 0.0 to 1.0. When exiting, this animation
   ///   runs backwards from 1.0 to 0.0.
-  /// * [forwardAnimation] The animation for the route being pushed on top of
+  /// * [secondaryAnimation] The animation for the route being pushed on top of
   ///   this route. This animation lets this route coordinate with the entrance
   ///   and exit transition of routes pushed on top of this route.
-  Widget buildPage(BuildContext context, Animation<double> animation, Animation<double> forwardAnimation);
+  Widget buildPage(BuildContext context, Animation<double> animation, Animation<double> secondaryAnimation);
 
   /// Override this method to wrap the [child] with one or more transition
   /// widgets that define how the route arrives on and leaves the screen.
@@ -565,13 +565,13 @@ abstract class ModalRoute<T> extends TransitionRoute<T> with LocalHistoryRoute<T
   ///
   /// The buildTransitions method is typically used to define transitions
   /// that animate the new topmost route's comings and goings. When the
-  /// Navigator pushes a route on the top of its stack, the new route's
-  /// primaryAnimation runs from 0.0 to 1.0. When the Navigator pops the
+  /// [Navigator] pushes a route on the top of its stack, the new route's
+  /// [primaryAnimation] runs from 0.0 to 1.0. When the Navigator pops the
   /// topmost route, e.g. because the use pressed the back button, the
   /// primary animation runs from 1.0 to 0.0.
   ///
   /// The following example uses the primaryAnimation to drive a
-  /// SlideTransition that translates the top of the new route vertically
+  /// [SlideTransition] that translates the top of the new route vertically
   /// from the bottom of the screen when it is pushed on the Navigator's
   /// stack. When the route is popped the SlideTransition translates the
   /// route from the top of the screen back to the bottom.
@@ -602,20 +602,20 @@ abstract class ModalRoute<T> extends TransitionRoute<T> with LocalHistoryRoute<T
   /// );
   ///```
   ///
-  /// We've used PageRouteBuilder to demonstrate the buildTransitions method
+  /// We've used [PageRouteBuilder] to demonstrate the buildTransitions method
   /// here. The body of an override of the buildTransitions method would be
   /// defined in the same way.
   ///
   /// When the Navigator pushes a route on the top of its stack, the
-  /// secondaryAnimation can be used to define how route that was on the top
-  /// of the stack leaves the screen. Similarly when the topmost route is
-  /// popped, the secondaryAnimation can be used to define how the route
+  /// [secondaryAnimation] can be used to define how the route that was on
+  /// the top of the stack leaves the screen. Similarly when the topmost route
+  /// is popped, the secondaryAnimation can be used to define how the route
   /// below it reappears on the screen. When the Navigator pushes a new route
   /// on the top of its stack, the old topmost route's secondaryAnimation
   /// runs from 1.0 to 0.0.  When the Navigator pops the topmost route, the
   /// secondaryAnimation for the route below it runs from 0.0 to 1.0.
   ///
-  /// The example below adds an transition that's driven by the
+  /// The example below adds a transition that's driven by the
   /// secondaryAnimation. When this route disappears because a new route has
   /// been pushed on top of it, it translates in the opposite direction of
   /// the new route. Likewise when the route is exposed because the topmost
@@ -626,7 +626,8 @@ abstract class ModalRoute<T> extends TransitionRoute<T> with LocalHistoryRoute<T
   ///       BuildContext context,
   ///       Animation<double> primaryAnimation,
   ///       Animation<double> secondaryAnimation,
-  ///       Widget child) {
+  ///       Widget child
+  ///   ) {
   ///     return new SlideTransition(
   ///       position: new FractionalOffsetTween(
   ///         begin: FractionalOffset.bottomLeft,
@@ -654,7 +655,12 @@ abstract class ModalRoute<T> extends TransitionRoute<T> with LocalHistoryRoute<T
   /// * [secondaryAnimation] The animation for the route below the topmost route.
   ///   This animation lets this route coordinate with the entrance
   ///   and exit transition of routes pushed on top.
-  Widget buildTransitions(BuildContext context, Animation<double> primaryAnimation, Animation<double> secondaryAnimation, Widget child) {
+  Widget buildTransitions(
+      BuildContext context,
+      Animation<double> primaryAnimation,
+      Animation<double> secondaryAnimation,
+      Widget child,
+  ) {
     return child;
   }
 
@@ -665,7 +671,7 @@ abstract class ModalRoute<T> extends TransitionRoute<T> with LocalHistoryRoute<T
   void install(OverlayEntry insertionPoint) {
     super.install(insertionPoint);
     _animationProxy = new ProxyAnimation(super.animation);
-    _forwardAnimationProxy = new ProxyAnimation(super.forwardAnimation);
+    _secondaryAnimationProxy = new ProxyAnimation(super.secondaryAnimation);
   }
 
   @override
@@ -715,7 +721,7 @@ abstract class ModalRoute<T> extends TransitionRoute<T> with LocalHistoryRoute<T
       _offstage = value;
     });
     _animationProxy.parent = _offstage ? kAlwaysCompleteAnimation : super.animation;
-    _forwardAnimationProxy.parent = _offstage ? kAlwaysDismissedAnimation : super.forwardAnimation;
+    _secondaryAnimationProxy.parent = _offstage ? kAlwaysDismissedAnimation : super.secondaryAnimation;
   }
 
   /// The build context for the subtree containing the primary content of this route.
@@ -726,8 +732,8 @@ abstract class ModalRoute<T> extends TransitionRoute<T> with LocalHistoryRoute<T
   ProxyAnimation _animationProxy;
 
   @override
-  Animation<double> get forwardAnimation => _forwardAnimationProxy;
-  ProxyAnimation _forwardAnimationProxy;
+  Animation<double> get secondaryAnimation => _secondaryAnimationProxy;
+  ProxyAnimation _secondaryAnimationProxy;
 
   /// Return the value of the first callback added with
   /// [addScopedWillPopCallback] that returns false. Otherwise return
@@ -903,7 +909,7 @@ abstract class ModalRoute<T> extends TransitionRoute<T> with LocalHistoryRoute<T
     return new _ModalScope(
       key: _scopeKey,
       route: this,
-      page: buildPage(context, animation, forwardAnimation)
+      page: buildPage(context, animation, secondaryAnimation)
       // _ModalScope calls buildTransitions(), defined above
     );
   }

--- a/packages/flutter/lib/src/widgets/routes.dart
+++ b/packages/flutter/lib/src/widgets/routes.dart
@@ -558,21 +558,103 @@ abstract class ModalRoute<T> extends TransitionRoute<T> with LocalHistoryRoute<T
   ///   and exit transition of routes pushed on top of this route.
   Widget buildPage(BuildContext context, Animation<double> animation, Animation<double> forwardAnimation);
 
-  /// Override this method to wrap the route in a number of transition widgets.
-  ///
-  /// For example, to create a fade entrance transition, wrap the given child
-  /// widget in a [FadeTransition] using the given animation as the opacity.
+  /// Override this method to wrap the [child] with one or more transition
+  /// widgets that define how the route arrives and leaves the screen.
   ///
   /// By default, the child is not wrapped in any transition widgets.
   ///
+  /// The buildTransitions method is typically used to define transitions
+  /// that animate the new topmost route's comings and goings. When the
+  /// Navigator pushes a route on the top of its stack, the new route's
+  /// primaryAnimation runs from 0.0 to 1.0. When the Navigator pops the
+  /// topmost route, e.g. because the use pressed the back button, the
+  /// primary animation runs from 1.0 to 0.0.
+  ///
+  /// The following example uses the primaryAnimation to drive a
+  /// SlideTransition that translates the top of the new route vertically
+  /// from the bottom of the screen when it is pushed on the Navigator's
+  /// stack. When the route is popped the SlideTransition translates the
+  /// route from the top of the screen back to the bottom.
+  ///
+  /// ```dart
+  /// new PageRouteBuilder(
+  ///   pageBuilder: (BuildContext context, _, __) {
+  ///     return new Scaffold(
+  ///       appBar: new AppBar(title: new Text('Hello')),
+  ///       body: new Center(
+  ///         child: new Text('Hello World'),
+  ///       ),
+  ///     );
+  ///   },
+  ///   transitionsBuilder: (
+  ///       BuildContext context,
+  ///       Animation<double> primaryAnimation,
+  ///       Animation<double> secondaryAnimation,
+  ///       Widget child) {
+  ///     return new SlideTransition(
+  ///       position: new FractionalOffsetTween(
+  ///         begin: FractionalOffset.bottomLeft,
+  ///         end: FractionalOffset.topLeft
+  ///       ).animate(primaryAnimation),
+  ///       child: child, // child is the value returned by pageBuilder
+  ///     );
+  ///   },
+  /// );
+  ///```
+  ///
+  /// We've used PageRouteBuilder to demonstrate the buildTransitions method
+  /// here. The body of an override of the buildTransitions method would be
+  /// defined in the same way.
+  ///
+  /// When the Navigator pushes a route on the top of its stack, the
+  /// secondaryAnimation can be used to define how route that was on the top
+  /// of the stack leaves the screen. Similarly when the topmost route is
+  /// popped, the secondaryAnimation can be used to define how the route
+  /// below it reappears on the screen. When the Navigator pushes a new route
+  /// on the top of its stack, the old topmost route's secondaryAnimation
+  /// runs from 1.0 to 0.0.  When the Navigator pops the topmost route, the
+  /// secondaryAnimation for the route below it runs from 0.0 to 1.0.
+  ///
+  /// The example below adds an transition that's driven by the
+  /// secondaryAnimation. When this route disappears because a new route has
+  /// been pushed on top of it, it translates in the opposite direction of
+  /// the new route. Likewise when the route is exposed because the topmost
+  /// route has been popped off.
+  ///
+  /// ```dart
+  ///   transitionsBuilder: (
+  ///       BuildContext context,
+  ///       Animation<double> primaryAnimation,
+  ///       Animation<double> secondaryAnimation,
+  ///       Widget child) {
+  ///     return new SlideTransition(
+  ///       position: new FractionalOffsetTween(
+  ///         begin: FractionalOffset.bottomLeft,
+  ///         end: FractionalOffset.topLeft,
+  ///       ).animate(primaryAnimation),
+  ///       child: new SlideTransition(
+  ///         position: new FractionalOffsetTween(
+  ///           begin: FractionalOffset.topLeft,
+  ///           end: FractionalOffset.bottomLeft,
+  ///         ).animate(secondaryAnimation),
+  ///         child: child,
+  ///       ),
+  ///     );
+  ///   }
+  ///```
+  ///
+  /// In practice the secondaryAnimation is not used very often because animating
+  /// both the topmost route and the route below it can be more distracting
+  /// than helpful.
+  ///
   /// * [context] The context in which the route is being built.
-  /// * [animation] The animation for this route's transition. When entering,
+  /// * [primaryAnimation] The animation for this route's transition. When entering,
   ///   the animation runs forward from 0.0 to 1.0. When exiting, this animation
   ///   runs backwards from 1.0 to 0.0.
-  /// * [forwardAnimation] The animation for the route being pushed on top of
-  ///   this route. This animation lets this route coordinate with the entrance
-  ///   and exit transition of routes pushed on top of this route.
-  Widget buildTransitions(BuildContext context, Animation<double> animation, Animation<double> forwardAnimation, Widget child) {
+  /// * [secondaryAnimation] The animation for the route below the topmost route.
+  ///   This animation lets this route coordinate with the entrance
+  ///   and exit transition of routes pushed on top.
+  Widget buildTransitions(BuildContext context, Animation<double> primaryAnimation, Animation<double> secondaryAnimation, Widget child) {
     return child;
   }
 

--- a/packages/flutter/lib/src/widgets/routes.dart
+++ b/packages/flutter/lib/src/widgets/routes.dart
@@ -612,8 +612,8 @@ abstract class ModalRoute<T> extends TransitionRoute<T> with LocalHistoryRoute<T
   /// is popped, the secondaryAnimation can be used to define how the route
   /// below it reappears on the screen. When the Navigator pushes a new route
   /// on the top of its stack, the old topmost route's secondaryAnimation
-  /// runs from 1.0 to 0.0.  When the Navigator pops the topmost route, the
-  /// secondaryAnimation for the route below it runs from 0.0 to 1.0.
+  /// runs from 0.0 to 1.0.  When the Navigator pops the topmost route, the
+  /// secondaryAnimation for the route below it runs from 1.0 to 0.0.
   ///
   /// The example below adds a transition that's driven by the
   /// secondaryAnimation. When this route disappears because a new route has
@@ -652,8 +652,8 @@ abstract class ModalRoute<T> extends TransitionRoute<T> with LocalHistoryRoute<T
   ///    pops the topmost route this animation runs from 1.0 to 0.0.
   ///  * [secondaryAnimation] When the Navigator pushes a new route
   ///    on the top of its stack, the old topmost route's secondaryAnimation
-  ///    runs from 1.0 to 0.0.  When the Navigator pops the topmost route, the
-  ///    secondaryAnimation for the route below it runs from 0.0 to 1.0.
+  ///    runs from 0.0 to 1.0.  When the Navigator pops the topmost route, the
+  ///    secondaryAnimation for the route below it runs from 1.0 to 0.0.
   Widget buildTransitions(
       BuildContext context,
       Animation<double> animation,

--- a/packages/flutter/test/widgets/app_overrides_test.dart
+++ b/packages/flutter/test/widgets/app_overrides_test.dart
@@ -20,7 +20,7 @@ class TestRoute<T> extends PageRoute<T> {
   bool get maintainState => false;
 
   @override
-  Widget buildPage(BuildContext context, Animation<double> animation, Animation<double> forwardAnimation) {
+  Widget buildPage(BuildContext context, Animation<double> primaryAnimation, Animation<double> secondaryAnimation) {
     return child;
   }
 }

--- a/packages/flutter/test/widgets/app_overrides_test.dart
+++ b/packages/flutter/test/widgets/app_overrides_test.dart
@@ -20,7 +20,7 @@ class TestRoute<T> extends PageRoute<T> {
   bool get maintainState => false;
 
   @override
-  Widget buildPage(BuildContext context, Animation<double> primaryAnimation, Animation<double> secondaryAnimation) {
+  Widget buildPage(BuildContext context, Animation<double> animation, Animation<double> secondaryAnimation) {
     return child;
   }
 }

--- a/packages/flutter/test/widgets/page_forward_transitions_test.dart
+++ b/packages/flutter/test/widgets/page_forward_transitions_test.dart
@@ -41,7 +41,7 @@ class TestRoute<T> extends PageRoute<T> {
   bool get maintainState => false;
 
   @override
-  Widget buildPage(BuildContext context, Animation<double> animation, Animation<double> forwardAnimation) {
+  Widget buildPage(BuildContext context, Animation<double> primaryAnimation, Animation<double> secondaryAnimation) {
     return child;
   }
 }
@@ -94,7 +94,7 @@ void main() {
                         new TestTransition(
                           childFirstHalf: new Text('C'),
                           childSecondHalf: new Text('D'),
-                          animation: route.forwardAnimation
+                          animation: route.secondaryAnimation
                         ),
                       ]
                     );

--- a/packages/flutter/test/widgets/page_forward_transitions_test.dart
+++ b/packages/flutter/test/widgets/page_forward_transitions_test.dart
@@ -41,7 +41,7 @@ class TestRoute<T> extends PageRoute<T> {
   bool get maintainState => false;
 
   @override
-  Widget buildPage(BuildContext context, Animation<double> primaryAnimation, Animation<double> secondaryAnimation) {
+  Widget buildPage(BuildContext context, Animation<double> animation, Animation<double> secondaryAnimation) {
     return child;
   }
 }


### PR DESCRIPTION
Clarify the roles of the two buildTransitions() animation parameters. I've renamed them primaryAnimation and secondaryAnimation to make it easier to write about them.

Fixes https://github.com/flutter/flutter/issues/9132