### PR TITLE
generate_from_arb has been moved to intl_translantion library

### DIFF
--- a/examples/stocks/lib/i18n/regenerate.md
+++ b/examples/stocks/lib/i18n/regenerate.md
@@ -1,7 +1,7 @@
 To rebuild the i18n files:
 
 ```
-pub run intl_translantion:generate_from_arb \
+pub run intl_translation:generate_from_arb \
   --output-dir=lib/i18n \
   --generated-file-prefix=stock_ \
   --no-use-deferred-loading \

--- a/examples/stocks/lib/i18n/regenerate.md
+++ b/examples/stocks/lib/i18n/regenerate.md
@@ -1,7 +1,7 @@
 To rebuild the i18n files:
 
 ```
-pub run intl:generate_from_arb \
+pub run intl_translantion:generate_from_arb \
   --output-dir=lib/i18n \
   --generated-file-prefix=stock_ \
   --no-use-deferred-loading \

--- a/examples/stocks/lib/i18n/stock_messages_all.dart
+++ b/examples/stocks/lib/i18n/stock_messages_all.dart
@@ -29,15 +29,24 @@ MessageLookupByLibrary _findExact(localeName) {
 
 /// User programs should call this before using [localeName] for messages.
 Future initializeMessages(String localeName) {
-  initializeInternalMessageLookup(() => new CompositeMessageLookup());
   var lib = _deferredLibraries[Intl.canonicalizedLocale(localeName)];
   var load = lib == null ? new Future.value(false) : lib();
-  return load.then((_) =>
-      messageLookup.addLocale(localeName, _findGeneratedMessagesFor));
+  return load.then((_) {
+    initializeInternalMessageLookup(() => new CompositeMessageLookup());
+    messageLookup.addLocale(localeName, _findGeneratedMessagesFor);
+  });
+}
+
+bool _messagesExistFor(String locale) {
+  var messages;
+  try {
+    messages = _findExact(locale);
+  } catch (e) {}
+  return messages != null;
 }
 
 MessageLookupByLibrary _findGeneratedMessagesFor(locale) {
-  var actualLocale = Intl.verifiedLocale(locale, (x) => _findExact(x) != null,
+  var actualLocale = Intl.verifiedLocale(locale, _messagesExistFor,
       onFailure: (_) => null);
   if (actualLocale == null) return null;
   return _findExact(actualLocale);

--- a/examples/stocks/pubspec.yaml
+++ b/examples/stocks/pubspec.yaml
@@ -3,7 +3,7 @@ dependencies:
   flutter:
     sdk: flutter
   intl: '>=0.14.0 <0.15.0'
-  intl_translation:
+  intl_translation: '>=0.14.0 <0.15.0'
   http: '>=0.11.3+12'
 
 dev_dependencies:

--- a/examples/stocks/pubspec.yaml
+++ b/examples/stocks/pubspec.yaml
@@ -3,6 +3,7 @@ dependencies:
   flutter:
     sdk: flutter
   intl: '>=0.14.0 <0.15.0'
+  intl_translation:
   http: '>=0.11.3+12'
 
 dev_dependencies:

--- a/examples/stocks/pubspec.yaml
+++ b/examples/stocks/pubspec.yaml
@@ -5,6 +5,7 @@ dependencies:
   intl: '>=0.14.0 <0.15.0'
   intl_translation: '>=0.14.0 <0.15.0'
   http: '>=0.11.3+12'
+  isolate: '>=1.0.0'
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Scripts used for generating translation files  has moved from `intl` to `intl_translantion` library.

Updated read me file.