### PR TITLE
Point from gallery's routing table to stocks'.

### DIFF
--- a/examples/flutter_gallery/lib/gallery/app.dart
+++ b/examples/flutter_gallery/lib/gallery/app.dart
@@ -13,6 +13,9 @@ import 'item.dart';
 import 'updates.dart';
 
 final Map<String, WidgetBuilder> _kRoutes = new Map<String, WidgetBuilder>.fromIterable(
+  // For a different example of how to set up an application routing table,
+  // consider the Stocks example:
+  // https://github.com/flutter/flutter/blob/master/examples/stocks/lib/main.dart
   kAllGalleryItems,
   key: (GalleryItem item) => item.routeName,
   value: (GalleryItem item) => item.buildRoute,


### PR DESCRIPTION
The stocks routing table is a clearer example of how to do this.
People know to look at the gallery, but don't think to look at the
stocks version. This points them from the former to the latter.