### PR TITLE
change the reload success message to include both the elapsed time and the library count

### DIFF
--- a/packages/flutter_tools/lib/src/base/logger.dart
+++ b/packages/flutter_tools/lib/src/base/logger.dart
@@ -5,11 +5,11 @@
 import 'dart:async';
 import 'dart:convert' show ASCII, LineSplitter;
 
-import 'package:intl/intl.dart';
 import 'package:meta/meta.dart';
 
 import 'io.dart';
 import 'platform.dart';
+import 'utils.dart';
 
 final AnsiTerminal terminal = new AnsiTerminal();
 
@@ -320,8 +320,6 @@ class _AnsiStatus extends Status {
   }
 
   static final List<String> _progress = <String>['-', r'\', '|', r'/', '-', r'\', '|', '/'];
-  static final NumberFormat secondsFormat = new NumberFormat('0.0');
-  static final NumberFormat millisecondsFormat = new NumberFormat.decimalPattern();
 
   final String message;
   final bool expectSlowOperation;
@@ -345,10 +343,9 @@ class _AnsiStatus extends Status {
     live = false;
 
     if (expectSlowOperation) {
-      final double seconds = stopwatch.elapsedMilliseconds / Duration.MILLISECONDS_PER_SECOND;
-      print('\b\b\b\b\b${secondsFormat.format(seconds).padLeft(4)}s');
+      print('\b\b\b\b\b${getElapsedAsSeconds(stopwatch.elapsed).padLeft(5)}');
     } else {
-      print('\b\b\b\b\b${millisecondsFormat.format(stopwatch.elapsedMilliseconds).padLeft(3)}ms');
+      print('\b\b\b\b\b${getElapsedAsMilliseconds(stopwatch.elapsed).padLeft(5)}');
     }
 
     timer.cancel();

--- a/packages/flutter_tools/lib/src/base/utils.dart
+++ b/packages/flutter_tools/lib/src/base/utils.dart
@@ -7,6 +7,7 @@ import 'dart:convert';
 import 'dart:math' show Random;
 
 import 'package:crypto/crypto.dart';
+import 'package:intl/intl.dart';
 
 import 'file_system.dart';
 import 'platform.dart';
@@ -82,7 +83,17 @@ String getSizeAsMB(int bytesLength) {
   return '${(bytesLength / (1024 * 1024)).toStringAsFixed(1)}MB';
 }
 
-String getElapsedAsMilliseconds(Duration duration) => '${duration.inMilliseconds} ms';
+final NumberFormat kSecondsFormat = new NumberFormat('0.0');
+final NumberFormat kMillisecondsFormat = new NumberFormat.decimalPattern();
+
+String getElapsedAsSeconds(Duration duration) {
+  final double seconds = duration.inMilliseconds / Duration.MILLISECONDS_PER_SECOND;
+  return '${kSecondsFormat.format(seconds)}s';
+}
+
+String getElapsedAsMilliseconds(Duration duration) {
+  return '${kMillisecondsFormat.format(duration.inMilliseconds)}ms';
+}
 
 /// Return a relative path if [fullPath] is contained by the cwd, else return an
 /// absolute path.

--- a/packages/flutter_tools/lib/src/run_hot.dart
+++ b/packages/flutter_tools/lib/src/run_hot.dart
@@ -361,24 +361,28 @@ class HotRunner extends ResidentRunner {
     if (fullRestart) {
       final Status status = logger.startProgress('Performing full restart...', progressId: 'hot.restart');
       try {
+        final Stopwatch timer = new Stopwatch()..start();
         await _restartFromSources();
-        status.stop();
-        printStatus('Restart complete.');
+        timer.stop();
+        status.cancel();
+        printStatus('Restarted app in ${getElapsedAsSeconds(timer.elapsed)}.');
         return OperationResult.ok;
       } catch (error) {
-        status.stop();
+        status.cancel();
         rethrow;
       }
     } else {
       final Status status = logger.startProgress('Performing hot reload...', progressId: 'hot.reload');
       try {
+        final Stopwatch timer = new Stopwatch()..start();
         final OperationResult result = await _reloadSources(pause: pauseAfterRestart);
-        status.stop();
+        timer.stop();
+        status.cancel();
         if (result.isOk)
-          printStatus("${result.message}.");
+          printStatus("Reloaded ${result.message} in ${getElapsedAsMilliseconds(timer.elapsed)}.");
         return result;
       } catch (error) {
-        status.stop();
+        status.cancel();
         rethrow;
       }
     }
@@ -434,7 +438,8 @@ class HotRunner extends ResidentRunner {
         flutterUsage.sendEvent('hot', 'reload');
         final int loadedLibraryCount = reloadReport['details']['loadedLibraryCount'];
         final int finalLibraryCount = reloadReport['details']['finalLibraryCount'];
-        reloadMessage = 'Reload done: $loadedLibraryCount of $finalLibraryCount libraries needed reloading';
+        printTrace('reloaded $loadedLibraryCount of $finalLibraryCount libraries');
+        reloadMessage = '$loadedLibraryCount of $finalLibraryCount libraries';
       }
     } catch (error, st) {
       final int errorCode = error['code'];


### PR DESCRIPTION
- change the reload success message to include both the elapsed time and the library count

This will let us remove our separate success / reload timing message in IntelliJ, and have a common (terse) success message.

After these changes:

```
Performing hot reload...                                  
Reloaded 64 of 481 libraries in 847ms.

Performing hot reload...                                  
Reloaded 9 of 535 libraries in 700ms.

Performing hot reload...                                  
Reloaded 0 of 480 libraries in 682ms.

Performing full restart...                                
Restarted app in 1.3s.
```

@johnmccutchan 