### PR TITLE
Revert "temporarily mark iOS tests as flaky (#9314)"

### DIFF
--- a/dev/devicelab/manifest.yaml
+++ b/dev/devicelab/manifest.yaml
@@ -157,7 +157,6 @@ tasks:
       Runs a driver test on the Platform Channel sample app on iOS.
     stage: devicelab_ios
     required_agent_capabilities: ["has-ios-device"]
-    flaky: true
 
   complex_layout_scroll_perf_ios__timeline_summary:
     description: >
@@ -165,21 +164,18 @@ tasks:
       iOS.
     stage: devicelab_ios
     required_agent_capabilities: ["has-ios-device"]
-    flaky: true
 
   flutter_gallery_ios__start_up:
     description: >
       Measures the startup time of the Flutter Gallery app on iOS.
     stage: devicelab_ios
     required_agent_capabilities: ["has-ios-device"]
-    flaky: true
 
   complex_layout_ios__start_up:
     description: >
       Measures the startup time of the Complex Layout sample app on iOS.
     stage: devicelab_ios
     required_agent_capabilities: ["has-ios-device"]
-    flaky: true
 
   flutter_gallery_ios__transition_perf:
     description: >
@@ -187,14 +183,12 @@ tasks:
       iOS.
     stage: devicelab_ios
     required_agent_capabilities: ["has-ios-device"]
-    flaky: true
 
   basic_material_app_ios__size:
     description: >
       Measures the IPA size of a basic material app.
     stage: devicelab_ios
     required_agent_capabilities: ["has-ios-device"]
-    flaky: true
 
   microbenchmarks_ios:
     description: >
@@ -202,14 +196,12 @@ tasks:
     stage: devicelab_ios
     required_agent_capabilities: ["has-ios-device"]
     timeout_in_minutes: 30
-    flaky: true
 
   flutter_view_ios__start_up:
     description: >
       Verifies that Flutter View can be used from an iOS project.
     stage: devicelab_ios
     required_agent_capabilities: ["has-ios-device"]
-    flaky: true
 
   # Tests running on Windows host
 


### PR DESCRIPTION
This reverts commit ff23a1ebfe5d01af8924761253cc574f23ac5295.

Our iOS lab hardware is back to normal.