### PR TITLE
flutter create: enable Java support in IDEA

### DIFF
--- a/packages/flutter_tools/lib/src/commands/create.dart
+++ b/packages/flutter_tools/lib/src/commands/create.dart
@@ -106,6 +106,8 @@ class CreateCommand extends FlutterCommand {
         flutterPackagesDirectory, renderDriverTest: argResults['with-driver-test'],
         withPluginHook: generatePlugin,
     );
+    templateContext['flutterJar'] =
+      "$flutterRoot/bin/cache/artifacts/engine/android-arm/flutter.jar";
 
     printStatus('Creating project ${fs.path.relative(dirPath)}...');
     int generatedCount = 0;

--- a/packages/flutter_tools/lib/src/commands/create.dart
+++ b/packages/flutter_tools/lib/src/commands/create.dart
@@ -205,7 +205,7 @@ Host platform code is in the android/ and ios/ directories under $relativePlugin
       'iosIdentifier': _createUTIIdentifier(projectName),
       'description': projectDescription,
       'dartSdk': '$flutterRoot/bin/cache/dart-sdk',
-      'flutterPackagesDirectory': '$flutterRoot/packages',
+      'flutterPackagesDirectory': fs.path.join(flutterRoot, 'packages'),
       'androidMinApiLevel': android.minApiLevel,
       'androidSdkVersion': android_sdk.minimumAndroidSdkVersion,
       'androidFlutterJar': "$flutterRoot/bin/cache/artifacts/engine/android-arm/flutter.jar",

--- a/packages/flutter_tools/lib/src/commands/create.dart
+++ b/packages/flutter_tools/lib/src/commands/create.dart
@@ -5,6 +5,7 @@
 import 'dart:async';
 
 import '../android/android.dart' as android;
+import '../android/android_sdk.dart' as android_sdk;
 import '../base/common.dart';
 import '../base/file_system.dart';
 import '../base/utils.dart';
@@ -103,11 +104,9 @@ class CreateCommand extends FlutterCommand {
 
     final Map<String, dynamic> templateContext = _templateContext(
         projectName, argResults['description'], dirPath,
-        flutterPackagesDirectory, renderDriverTest: argResults['with-driver-test'],
+        flutterRoot, renderDriverTest: argResults['with-driver-test'],
         withPluginHook: generatePlugin,
     );
-    templateContext['flutterJar'] =
-      "$flutterRoot/bin/cache/artifacts/engine/android-arm/flutter.jar";
 
     printStatus('Creating project ${fs.path.relative(dirPath)}...');
     int generatedCount = 0;
@@ -190,10 +189,10 @@ Host platform code is in the android/ and ios/ directories under $relativePlugin
   }
 
   Map<String, dynamic> _templateContext(String projectName,
-      String projectDescription, String dirPath, String flutterPackagesDirectory,
+      String projectDescription, String dirPath, String flutterRoot,
       { bool renderDriverTest: false, bool withPluginHook: false }) {
-    flutterPackagesDirectory = fs.path.normalize(flutterPackagesDirectory);
-    flutterPackagesDirectory = _relativePath(from: dirPath, to: flutterPackagesDirectory);
+    flutterRoot = fs.path.normalize(flutterRoot);
+    flutterRoot = _relativePath(from: dirPath, to: flutterRoot);
 
     final String pluginDartClass = _createPluginClassName(projectName);
     final String pluginClass = pluginDartClass.endsWith('Plugin')
@@ -205,8 +204,11 @@ Host platform code is in the android/ and ios/ directories under $relativePlugin
       'androidIdentifier': _createAndroidIdentifier(projectName),
       'iosIdentifier': _createUTIIdentifier(projectName),
       'description': projectDescription,
-      'flutterPackagesDirectory': flutterPackagesDirectory,
+      'dartSdk': '$flutterRoot/bin/cache/dart-sdk',
+      'flutterPackagesDirectory': '$flutterRoot/packages',
       'androidMinApiLevel': android.minApiLevel,
+      'androidSdkVersion': android_sdk.minimumAndroidSdkVersion,
+      'androidFlutterJar': "$flutterRoot/bin/cache/artifacts/engine/android-arm/flutter.jar",
       'withDriverTest': renderDriverTest,
       'pluginClass': pluginClass,
       'pluginDartClass': pluginDartClass,

--- a/packages/flutter_tools/templates/create/.idea/libraries/Dart_SDK.xml.tmpl
+++ b/packages/flutter_tools/templates/create/.idea/libraries/Dart_SDK.xml.tmpl
@@ -1,0 +1,25 @@
+<component name="libraryTable">
+  <library name="Dart SDK">
+    <CLASSES>
+      <root url="file://{{dartSdk}}/lib/async" />
+      <root url="file://{{dartSdk}}/lib/collection" />
+      <root url="file://{{dartSdk}}/lib/convert" />
+      <root url="file://{{dartSdk}}/lib/core" />
+      <root url="file://{{dartSdk}}/lib/developer" />
+      <root url="file://{{dartSdk}}/lib/html" />
+      <root url="file://{{dartSdk}}/lib/indexed_db" />
+      <root url="file://{{dartSdk}}/lib/io" />
+      <root url="file://{{dartSdk}}/lib/isolate" />
+      <root url="file://{{dartSdk}}/lib/js" />
+      <root url="file://{{dartSdk}}/lib/js_util" />
+      <root url="file://{{dartSdk}}/lib/math" />
+      <root url="file://{{dartSdk}}/lib/mirrors" />
+      <root url="file://{{dartSdk}}/lib/svg" />
+      <root url="file://{{dartSdk}}/lib/typed_data" />
+      <root url="file://{{dartSdk}}/lib/web_audio" />
+      <root url="file://{{dartSdk}}/lib/web_gl" />
+      <root url="file://{{dartSdk}}/lib/web_sql" />
+    </CLASSES>
+    <SOURCES />
+  </library>
+</component>

--- a/packages/flutter_tools/templates/create/.idea/libraries/flutter_for_android.xml.tmpl
+++ b/packages/flutter_tools/templates/create/.idea/libraries/flutter_for_android.xml.tmpl
@@ -1,5 +1,5 @@
 <component name="libraryTable">
-  <library name="flutter for android">
+  <library name="Flutter for Android">
     <CLASSES>
       <root url="jar://{{flutterJar}}!/" />
     </CLASSES>

--- a/packages/flutter_tools/templates/create/.idea/libraries/flutter_for_android.xml.tmpl
+++ b/packages/flutter_tools/templates/create/.idea/libraries/flutter_for_android.xml.tmpl
@@ -1,7 +1,7 @@
 <component name="libraryTable">
   <library name="Flutter for Android">
     <CLASSES>
-      <root url="jar://{{flutterJar}}!/" />
+      <root url="jar://{{androidFlutterJar}}!/" />
     </CLASSES>
     <JAVADOC />
     <SOURCES />

--- a/packages/flutter_tools/templates/create/.idea/libraries/flutter_for_android.xml.tmpl
+++ b/packages/flutter_tools/templates/create/.idea/libraries/flutter_for_android.xml.tmpl
@@ -1,0 +1,9 @@
+<component name="libraryTable">
+  <library name="flutter for android">
+    <CLASSES>
+      <root url="jar://{{flutterJar}}!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES />
+  </library>
+</component>

--- a/packages/flutter_tools/templates/create/.idea/modules.xml.tmpl
+++ b/packages/flutter_tools/templates/create/.idea/modules.xml.tmpl
@@ -3,6 +3,7 @@
   <component name="ProjectModuleManager">
     <modules>
       <module fileurl="file://$PROJECT_DIR$/{{projectName}}.iml" filepath="$PROJECT_DIR$/{{projectName}}.iml" />
+      <module fileurl="file://$PROJECT_DIR$/android.iml" filepath="$PROJECT_DIR$/android.iml" />
     </modules>
   </component>
 </project>

--- a/packages/flutter_tools/templates/create/android.iml.tmpl
+++ b/packages/flutter_tools/templates/create/android.iml.tmpl
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$/android">
+      <sourceFolder url="file://$MODULE_DIR$/android/app/src/main/java" isTestSource="false" />
+    </content>
+    <orderEntry type="jdk" jdkName="Android API 25 Platform" jdkType="Android SDK" />
+    <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="library" name="flutter for android" level="project" />
+  </component>
+</module>

--- a/packages/flutter_tools/templates/create/android.iml.tmpl
+++ b/packages/flutter_tools/templates/create/android.iml.tmpl
@@ -5,7 +5,7 @@
     <content url="file://$MODULE_DIR$/android">
       <sourceFolder url="file://$MODULE_DIR$/android/app/src/main/java" isTestSource="false" />
     </content>
-    <orderEntry type="jdk" jdkName="Android API 25 Platform" jdkType="Android SDK" />
+    <orderEntry type="jdk" jdkName="Android API {{androidSdkVersion}} Platform" jdkType="Android SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="library" name="Flutter for Android" level="project" />
   </component>

--- a/packages/flutter_tools/templates/create/android.iml.tmpl
+++ b/packages/flutter_tools/templates/create/android.iml.tmpl
@@ -7,6 +7,6 @@
     </content>
     <orderEntry type="jdk" jdkName="Android API 25 Platform" jdkType="Android SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
-    <orderEntry type="library" name="flutter for android" level="project" />
+    <orderEntry type="library" name="Flutter for Android" level="project" />
   </component>
 </module>


### PR DESCRIPTION
Generates an android.iml file and a package-level library for flutter.jar.

Does not set up an Android SDK in IDEA; this isn't possible with a
template-based approach. But there will be a clear error for the missing
reference to the SDK and the user can set this up.

(Also, we can fix up the SDK afterwards when "flutter create" is launched
from the Flutter plugin.)