### PR TITLE
update the font used for docs.flutter.io

### DIFF
--- a/dev/docs/styles.html
+++ b/dev/docs/styles.html
@@ -4,17 +4,17 @@
 </style>
 
 <style>
-  header {
-    background-color: #01579b;
-  }
-
   body {
-    font-size: 16px;
+    font-size: 15px;
     line-height: 1.5;
     color: #111;
     background-color: #fdfdfd;
     font-weight: 300;
     -webkit-font-smoothing: auto;
+  }
+
+  header {
+    background-color: #0099e8;
   }
 
   h1, h2 {

--- a/dev/docs/styles.html
+++ b/dev/docs/styles.html
@@ -14,7 +14,7 @@
   }
 
   header {
-    background-color: #0099e8;
+    background-color: #29b6f6;
   }
 
   h1, h2 {

--- a/dev/docs/styles.html
+++ b/dev/docs/styles.html
@@ -14,7 +14,7 @@
   }
 
   header {
-    background-color: #29b6f6;
+    background-color: #01579b;
   }
 
   h1, h2 {

--- a/dev/tools/dartdoc.dart
+++ b/dev/tools/dartdoc.dart
@@ -75,7 +75,6 @@ dependencies:
     '--use-categories'
   ];
 
-
   for (String libraryRef in libraryRefs(diskPath: true)) {
     args.add('--include-external');
     args.add(libraryRef);


### PR DESCRIPTION
- update the font used for docs.flutter.io

This PR updates the font used for docs.flutter.io to be the same as the one for the rest of flutter.io. It also adjusts the color of the page header. I couldn't find an official flutter color, but `#0099e8` is the one of the three colors used in the logo.

@sethladd @LarkAscending (/cc @jcollins-g)

<img width="814" alt="screen shot 2017-04-11 at 3 31 34 pm" src="https://cloud.githubusercontent.com/assets/1269969/24933847/6ee24aa8-1ecd-11e7-91bc-6ab0292a0c15.png">
