### PR TITLE
Keep resident runner connected on iOS when screen locks in debug mode

### DIFF
--- a/examples/flutter_gallery/ios/Runner/AppDelegate.m
+++ b/examples/flutter_gallery/ios/Runner/AppDelegate.m
@@ -3,4 +3,14 @@
 
 @implementation AppDelegate
 
+- (void)applicationDidEnterBackground:(UIApplication *)application {
+  // Use this method to release shared resources, save user data, invalidate timers, and store enough application state information to restore your application to its current state in case it is terminated later.
+  // If your application supports background execution, this method is called instead of applicationWillTerminate: when the user quits.
+  if ([@"debug" isEqualToString:
+       [[NSBundle mainBundle] objectForInfoDictionaryKey:@"FLTBuildMode"]]) {
+    [application beginBackgroundTaskWithName:@"Flutter debug task"
+                           expirationHandler:^{NSLog(@"Flutter debug task expired");}];
+  }
+}
+
 @end

--- a/examples/flutter_gallery/ios/Runner/AppDelegate.m
+++ b/examples/flutter_gallery/ios/Runner/AppDelegate.m
@@ -6,6 +6,10 @@
 - (void)applicationDidEnterBackground:(UIApplication *)application {
   // Use this method to release shared resources, save user data, invalidate timers, and store enough application state information to restore your application to its current state in case it is terminated later.
   // If your application supports background execution, this method is called instead of applicationWillTerminate: when the user quits.
+
+  // The following keeps the Flutter session alive when the device screen locks
+  // in debug mode. It allows continued use of features like hot reload and 
+  // taking screenshots once the device unlocks again.
   if ([@"debug" isEqualToString:
        [[NSBundle mainBundle] objectForInfoDictionaryKey:@"FLTBuildMode"]]) {
     [application beginBackgroundTaskWithName:@"Flutter debug task"

--- a/examples/flutter_gallery/ios/Runner/Info.plist
+++ b/examples/flutter_gallery/ios/Runner/Info.plist
@@ -43,6 +43,8 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>FLTBuildMode</key>
+	<string>$(FLUTTER_BUILD_MODE)</string>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
 </dict>

--- a/packages/flutter_tools/templates/create/ios.tmpl/Runner/AppDelegate.m
+++ b/packages/flutter_tools/templates/create/ios.tmpl/Runner/AppDelegate.m
@@ -14,25 +14,30 @@
 }
 
 - (void)applicationWillResignActive:(UIApplication *)application {
-    // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
-    // Use this method to pause ongoing tasks, disable timers, and throttle down OpenGL ES frame rates. Games should use this method to pause the game.
+  // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
+  // Use this method to pause ongoing tasks, disable timers, and throttle down OpenGL ES frame rates. Games should use this method to pause the game.
 }
 
 - (void)applicationDidEnterBackground:(UIApplication *)application {
-    // Use this method to release shared resources, save user data, invalidate timers, and store enough application state information to restore your application to its current state in case it is terminated later.
-    // If your application supports background execution, this method is called instead of applicationWillTerminate: when the user quits.
+  // Use this method to release shared resources, save user data, invalidate timers, and store enough application state information to restore your application to its current state in case it is terminated later.
+  // If your application supports background execution, this method is called instead of applicationWillTerminate: when the user quits.
+  if ([@"debug" isEqualToString:
+      [[NSBundle mainBundle] objectForInfoDictionaryKey:@"FLTBuildMode"]]) {
+    [application beginBackgroundTaskWithName:@"Flutter debug task"
+                           expirationHandler:^{NSLog(@"Flutter debug task expired");}];
+  }
 }
 
 - (void)applicationWillEnterForeground:(UIApplication *)application {
-    // Called as part of the transition from the background to the inactive state; here you can undo many of the changes made on entering the background.
+  // Called as part of the transition from the background to the inactive state; here you can undo many of the changes made on entering the background.
 }
 
 - (void)applicationDidBecomeActive:(UIApplication *)application {
-    // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
+  // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
 }
 
 - (void)applicationWillTerminate:(UIApplication *)application {
-    // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
+  // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
 }
 
 @end

--- a/packages/flutter_tools/templates/create/ios.tmpl/Runner/AppDelegate.m
+++ b/packages/flutter_tools/templates/create/ios.tmpl/Runner/AppDelegate.m
@@ -21,6 +21,10 @@
 - (void)applicationDidEnterBackground:(UIApplication *)application {
   // Use this method to release shared resources, save user data, invalidate timers, and store enough application state information to restore your application to its current state in case it is terminated later.
   // If your application supports background execution, this method is called instead of applicationWillTerminate: when the user quits.
+
+  // The following keeps the Flutter session alive when the device screen locks
+  // in debug mode. It allows continued use of features like hot reload and 
+  // taking screenshots once the device unlocks again.
   if ([@"debug" isEqualToString:
       [[NSBundle mainBundle] objectForInfoDictionaryKey:@"FLTBuildMode"]]) {
     [application beginBackgroundTaskWithName:@"Flutter debug task"

--- a/packages/flutter_tools/templates/create/ios.tmpl/Runner/Info.plist.tmpl
+++ b/packages/flutter_tools/templates/create/ios.tmpl/Runner/Info.plist.tmpl
@@ -45,5 +45,8 @@
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
+	<key>FLTBuildMode</key>
+	<string>$(FLUTTER_BUILD_MODE)</string>
+
 </dict>
 </plist>


### PR DESCRIPTION
#9351

For debug mode only. We can also do something more conservative and figure out a way to stop the task when USB disconnects or something.