### PR TITLE
Simplify ChangeNotifier toString and handle nulls

### DIFF
--- a/packages/flutter/lib/src/foundation/change_notifier.dart
+++ b/packages/flutter/lib/src/foundation/change_notifier.dart
@@ -161,15 +161,7 @@ class _MergingListenable extends ChangeNotifier {
 
   @override
   String toString() {
-    final StringBuffer buffer = new StringBuffer();
-    buffer.write('Listenable.merge([');
-    for (int i = 0; i < _children.length; ++i) {
-      buffer.write(_children[i].toString());
-      if (i < _children.length - 1)
-        buffer.write(', ');
-    }
-    buffer.write('])');
-    return buffer.toString();
+    return 'Listenable.merge([${_children.join(", ")}])';
   }
 }
 

--- a/packages/flutter/test/foundation/change_notifier_test.dart
+++ b/packages/flutter/test/foundation/change_notifier_test.dart
@@ -206,4 +206,33 @@ void main() {
     notifier.value = 3.0;
     expect(log, isEmpty);
   });
+
+  test('Listenable.merge toString', () {
+    final TestNotifier source1 = new TestNotifier();
+    final TestNotifier source2 = new TestNotifier();
+
+    ChangeNotifier listenableUnderTest = new Listenable.merge(<Listenable>[]);
+    expect(listenableUnderTest.toString(), 'Listenable.merge([])');
+
+    listenableUnderTest = new Listenable.merge(<Listenable>[null]);
+    expect(listenableUnderTest.toString(), 'Listenable.merge([null])');
+
+    listenableUnderTest = new Listenable.merge(<Listenable>[source1]);
+    expect(
+      listenableUnderTest.toString(), 
+      "Listenable.merge([Instance of 'TestNotifier'])",
+    );
+
+    listenableUnderTest = new Listenable.merge(<Listenable>[source1, source2]);
+    expect(
+      listenableUnderTest.toString(), 
+      "Listenable.merge([Instance of 'TestNotifier', Instance of 'TestNotifier'])",
+    );
+
+    listenableUnderTest = new Listenable.merge(<Listenable>[null, source2]);
+    expect(
+      listenableUnderTest.toString(), 
+      "Listenable.merge([null, Instance of 'TestNotifier'])",
+    );
+  });
 }


### PR DESCRIPTION
Pulled out of #9350 to handle nulls. Probably useful anyway.