### PR TITLE
Scaffold appBar is-a PreferredSizeWidget, etc

### DIFF
--- a/packages/flutter/lib/src/material/app_bar.dart
+++ b/packages/flutter/lib/src/material/app_bar.dart
@@ -226,8 +226,12 @@ class AppBar extends StatefulWidget implements PreferredSizeWidget {
 
   /// This widget appears across the bottom of the app bar.
   ///
-  /// Typically a [TabBar]. Only widgets that implement [AppBarBottomWidget] can
+  /// Typically a [TabBar]. Only widgets that implement [PreferredSizeWidget] can
   /// be used at the bottom of an app bar.
+  ///
+  /// See also:
+  ///
+  ///  * [PreferredSize], which can be used to give an arbitrary widget a preferred size.
   final PreferredSizeWidget bottom;
 
   /// The z-coordinate at which to place this app bar.
@@ -293,6 +297,8 @@ class AppBar extends StatefulWidget implements PreferredSizeWidget {
 
   /// A size whose height is the sum of [kToolbarHeight] and the [bottom] widget's
   /// preferred height.
+  ///
+  /// [Scaffold] uses this this size to set its app bar's height.
   @override
   final Size preferredSize;
 
@@ -752,8 +758,12 @@ class SliverAppBar extends StatefulWidget {
 
   /// This widget appears across the bottom of the appbar.
   ///
-  /// Typically a [TabBar]. This widget must be a widget that implements the
-  /// [AppBarBottomWidget] interface.
+  /// Typically a [TabBar]. Only widgets that implement [PreferredSizeWidget] can
+  /// be used at the bottom of an app bar.
+  ///
+  /// See also:
+  ///
+  ///  * [PreferredSize], which can be used to give an arbitrary widget a preferred size.
   final PreferredSizeWidget bottom;
 
   /// The z-coordinate at which to place this app bar.

--- a/packages/flutter/lib/src/material/scaffold.dart
+++ b/packages/flutter/lib/src/material/scaffold.dart
@@ -795,21 +795,16 @@ class ScaffoldState extends State<Scaffold> with TickerProviderStateMixin {
 
     if (widget.appBar != null) {
       final double topPadding = widget.primary ? padding.top : 0.0;
-      Widget appBar = widget.appBar;
-      //final double extent = widget.appBar.minExtent + topPadding;
       final double extent = widget.appBar.preferredSize.height + topPadding;
-      // TBD: make sure the extent isn't infinite, is >= 0
-      //if (widget.appBar.flexibleSpace != null) {
-        appBar = FlexibleSpaceBar.createSettings(
-          currentExtent: extent,
-          child: appBar,
-        );
-      //}
+      assert(extent >= 0.0 && extent.isFinite);
       _addIfNonNull(
         children,
         new ConstrainedBox(
           constraints: new BoxConstraints(maxHeight: extent),
-          child: appBar,
+          child: FlexibleSpaceBar.createSettings(
+            currentExtent: extent,
+            child: widget.appBar,
+          ),
         ),
         _ScaffoldSlot.appBar,
       );

--- a/packages/flutter/lib/src/material/scaffold.dart
+++ b/packages/flutter/lib/src/material/scaffold.dart
@@ -292,11 +292,14 @@ class Scaffold extends StatefulWidget {
     this.drawer,
     this.bottomNavigationBar,
     this.backgroundColor,
-    this.resizeToAvoidBottomPadding: true
-  }) : super(key: key);
+    this.resizeToAvoidBottomPadding: true,
+    this.primary: true,
+  }) : super(key: key) {
+    assert(primary != null);
+  }
 
   /// An app bar to display at the top of the scaffold.
-  final AppBar appBar;
+  final PreferredSizeWidget appBar;
 
   /// The primary content of the scaffold.
   ///
@@ -362,6 +365,15 @@ class Scaffold extends StatefulWidget {
   ///
   /// Defaults to true.
   final bool resizeToAvoidBottomPadding;
+
+  /// Whether this scaffold is being displayed at the top of the screen.
+  ///
+  /// If true then the height of the [appBar] will be extended by the height
+  /// of the screen's status bar, i.e. the top padding for [MediaQuery].
+  ///
+  /// The default value of this property, like the default value of
+  /// [AppBar.primary], is true.
+  final bool primary;
 
   /// The state from the closest instance of this class that encloses the given context.
   ///
@@ -782,16 +794,17 @@ class ScaffoldState extends State<Scaffold> with TickerProviderStateMixin {
     _addIfNonNull(children, widget.body, _ScaffoldSlot.body);
 
     if (widget.appBar != null) {
-      assert(widget.appBar.primary || padding.top == 0.0, 'A non-primary AppBar was passed to a Scaffold but the MediaQuery in scope has top padding.');
-      final double topPadding = widget.appBar.primary ? padding.top : 0.0;
+      final double topPadding = widget.primary ? padding.top : 0.0;
       Widget appBar = widget.appBar;
-      final double extent = widget.appBar.minExtent + topPadding;
-      if (widget.appBar.flexibleSpace != null) {
+      //final double extent = widget.appBar.minExtent + topPadding;
+      final double extent = widget.appBar.preferredSize.height + topPadding;
+      // TBD: make sure the extent isn't infinite, is >= 0
+      //if (widget.appBar.flexibleSpace != null) {
         appBar = FlexibleSpaceBar.createSettings(
           currentExtent: extent,
           child: appBar,
         );
-      }
+      //}
       _addIfNonNull(
         children,
         new ConstrainedBox(

--- a/packages/flutter/lib/src/material/scaffold.dart
+++ b/packages/flutter/lib/src/material/scaffold.dart
@@ -283,7 +283,7 @@ class _FloatingActionButtonTransitionState extends State<_FloatingActionButtonTr
 ///  * <https://material.google.com/layout/structure.html>
 class Scaffold extends StatefulWidget {
   /// Creates a visual scaffold for material design widgets.
-  Scaffold({
+  const Scaffold({
     Key key,
     this.appBar,
     this.body,
@@ -294,9 +294,7 @@ class Scaffold extends StatefulWidget {
     this.backgroundColor,
     this.resizeToAvoidBottomPadding: true,
     this.primary: true,
-  }) : super(key: key) {
-    assert(primary != null);
-  }
+  }) : assert(primary != null), super(key: key);
 
   /// An app bar to display at the top of the scaffold.
   final PreferredSizeWidget appBar;

--- a/packages/flutter/lib/src/material/tabs.dart
+++ b/packages/flutter/lib/src/material/tabs.dart
@@ -420,6 +420,9 @@ class TabBar extends StatefulWidget implements PreferredSizeWidget {
   /// is null then the text style of the theme's body2 definition is used.
   final TextStyle unselectedLabelStyle;
 
+  /// A size whose height depends on if the tabs have both icons and text.
+  ///
+  /// [AppBar] uses this this size to compute its own preferred size.
   @override
   Size get preferredSize {
     for (Widget item in tabs) {

--- a/packages/flutter/lib/src/material/tabs.dart
+++ b/packages/flutter/lib/src/material/tabs.dart
@@ -349,7 +349,7 @@ class _DragAnimation extends Animation<double> with AnimationWithParentMixin<dou
 ///
 ///  * [TabBarView], which displays the contents that the tab bar is selecting
 ///    between.
-class TabBar extends StatefulWidget implements AppBarBottomWidget {
+class TabBar extends StatefulWidget implements PreferredSizeWidget {
   /// Creates a material design tab bar.
   ///
   /// The [tabs] argument must not be null and must have more than one widget.
@@ -421,15 +421,15 @@ class TabBar extends StatefulWidget implements AppBarBottomWidget {
   final TextStyle unselectedLabelStyle;
 
   @override
-  double get bottomHeight {
+  Size get preferredSize {
     for (Widget item in tabs) {
       if (item is Tab) {
         final Tab tab = item;
         if (tab.text != null && tab.icon != null)
-          return _kTextAndIconTabHeight + _kTabIndicatorHeight;
+          return const Size.fromHeight(_kTextAndIconTabHeight + _kTabIndicatorHeight);
       }
     }
-    return _kTabHeight + _kTabIndicatorHeight;
+    return const Size.fromHeight(_kTabHeight + _kTabIndicatorHeight);
   }
 
   @override

--- a/packages/flutter/lib/src/widgets/preferred_size.dart
+++ b/packages/flutter/lib/src/widgets/preferred_size.dart
@@ -1,0 +1,47 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/rendering.dart';
+
+import 'basic.dart';
+import 'framework.dart';
+
+/// Return the size this widget would prefer if it were otherwise unconstrained.
+///
+/// There are a few cases, notably [AppBar] and [TabBar], where it would be
+/// undesirable for the widget to constrain its own size but where the widget
+/// needs to expose a preferred or "default" size. For example a primary
+/// [Scaffold] sets its app bar height to the app bar's preferred height
+/// plus the height of the system status bar.
+///
+/// Use [PreferredSize] to give a preferred size to an arbitrary widget.
+abstract class PreferredSizeWidget extends Widget {
+  Size get preferredSize;
+}
+
+/// Give an arbitrary widget a preferred size.
+///
+/// This class does not impose any constraints on its child, it doesn't affect
+/// the child's layout in any way. It just advertises a default size which
+/// can be used by the parent.
+///
+/// See also:
+///
+///  * [AppBar.bottom] and [Scaffold.appBar], which require preferred size widgets.
+class PreferredSize extends StatelessWidget implements PreferredSizeWidget {
+  const PreferredSize({
+    Key key,
+    @required this.child,
+    @required this.preferredSize,
+  }) : super(key: key);
+
+  final Widget child;
+
+  @override
+  final Size preferredSize;
+
+  @override
+  Widget build(BuildContext context) => child;
+}

--- a/packages/flutter/lib/src/widgets/preferred_size.dart
+++ b/packages/flutter/lib/src/widgets/preferred_size.dart
@@ -8,7 +8,8 @@ import 'package:flutter/rendering.dart';
 import 'basic.dart';
 import 'framework.dart';
 
-/// Return the size this widget would prefer if it were otherwise unconstrained.
+/// An interface for widgets that can return the size this widget would prefer
+/// if it were otherwise unconstrained.
 ///
 /// There are a few cases, notably [AppBar] and [TabBar], where it would be
 /// undesirable for the widget to constrain its own size but where the widget
@@ -17,7 +18,14 @@ import 'framework.dart';
 /// plus the height of the system status bar.
 ///
 /// Use [PreferredSize] to give a preferred size to an arbitrary widget.
-abstract class PreferredSizeWidget extends Widget {
+abstract class PreferredSizeWidget implements Widget {
+
+  /// The size this widget would prefer if it were otherwise unconstrained.
+  ///
+  /// In many cases it's only necessary to define one preferred dimension.
+  /// For example the [Scaffold] only depends on its app bar's preferred
+  /// height. In that case implementations of this method can just return
+  /// `new Size.fromHeight(myAppBarHeight)`;
   Size get preferredSize;
 }
 
@@ -30,6 +38,9 @@ abstract class PreferredSizeWidget extends Widget {
 /// See also:
 ///
 ///  * [AppBar.bottom] and [Scaffold.appBar], which require preferred size widgets.
+///  * [PreferredSizeWidget], the interface which this widget implements to expose
+///    its preferred size.
+///  * [AppBar] and [TabBar], which implement PreferredSizeWidget.
 class PreferredSize extends StatelessWidget implements PreferredSizeWidget {
   const PreferredSize({
     Key key,

--- a/packages/flutter/lib/widgets.dart
+++ b/packages/flutter/lib/widgets.dart
@@ -44,6 +44,7 @@ export 'src/widgets/page_view.dart';
 export 'src/widgets/pages.dart';
 export 'src/widgets/performance_overlay.dart';
 export 'src/widgets/placeholder.dart';
+export 'src/widgets/preferred_size.dart';
 export 'src/widgets/primary_scroll_controller.dart';
 export 'src/widgets/raw_keyboard_listener.dart';
 export 'src/widgets/routes.dart';

--- a/packages/flutter/test/material/app_bar_test.dart
+++ b/packages/flutter/test/material/app_bar_test.dart
@@ -637,4 +637,79 @@ void main() {
     expect(appBarTop(tester), lessThanOrEqualTo(0.0));
     expect(appBarBottom(tester), kTextTabBarHeight);
   });
+
+  testWidgets('AppBar dimensions, with and without bottom, primary', (WidgetTester tester) async {
+    const MediaQueryData topPadding100 = const MediaQueryData(padding: const EdgeInsets.only(top: 100.0));
+
+    await tester.pumpWidget(
+      new MediaQuery(
+        data: topPadding100,
+        child: new Scaffold(
+          primary: false,
+          appBar: new AppBar(),
+        ),
+      ),
+    );
+    expect(appBarTop(tester), 0.0);
+    expect(appBarHeight(tester), kToolbarHeight);
+
+    await tester.pumpWidget(
+      new MediaQuery(
+        data: topPadding100,
+        child: new Scaffold(
+          primary: true,
+          appBar: new AppBar(title: const Text('title'))
+        ),
+      ),
+    );
+    expect(appBarTop(tester), 0.0);
+    expect(tester.getTopLeft(find.text('title')).dy, greaterThan(100.0));
+    expect(appBarHeight(tester), kToolbarHeight + 100.0);
+
+    await tester.pumpWidget(
+      new MediaQuery(
+        data: topPadding100,
+        child: new Scaffold(
+          primary: false,
+          appBar: new AppBar(
+            bottom: new PreferredSize(
+              preferredSize: const Size.fromHeight(200.0),
+              child: new Container(),
+            ),
+          ),
+        ),
+      ),
+    );
+    expect(appBarTop(tester), 0.0);
+    expect(appBarHeight(tester), kToolbarHeight + 200.0);
+
+    await tester.pumpWidget(
+      new MediaQuery(
+        data: topPadding100,
+        child: new Scaffold(
+          primary: true,
+          appBar: new AppBar(
+            bottom: new PreferredSize(
+              preferredSize: const Size.fromHeight(200.0),
+              child: new Container(),
+            ),
+          ),
+        ),
+      ),
+    );
+    expect(appBarTop(tester), 0.0);
+    expect(appBarHeight(tester), kToolbarHeight + 100.0 + 200.0);
+
+    await tester.pumpWidget(
+      new MediaQuery(
+        data: topPadding100,
+        child: new AppBar(
+          primary: false,
+          title: const Text('title'),
+        ),
+      ),
+    );
+    expect(appBarTop(tester), 0.0);
+    expect(tester.getTopLeft(find.text('title')).dy, lessThan(100.0));
+  });
 }

--- a/packages/flutter/test/material/floating_action_button_test.dart
+++ b/packages/flutter/test/material/floating_action_button_test.dart
@@ -28,7 +28,7 @@ void main() {
   testWidgets('Floating Action Button tooltip', (WidgetTester tester) async {
     await tester.pumpWidget(
       new MaterialApp(
-        home: new Scaffold(
+        home: const Scaffold(
           floatingActionButton: const FloatingActionButton(
             onPressed: null,
             tooltip: 'Add',

--- a/packages/flutter/test/material/page_test.dart
+++ b/packages/flutter/test/material/page_test.dart
@@ -191,10 +191,10 @@ void main() {
     await tester.pumpWidget(
       new MaterialApp(
         theme: new ThemeData(platform: TargetPlatform.android),
-        home: new Scaffold(body: const Text('Page 1')),
+        home: const Scaffold(body: const Text('Page 1')),
         routes: <String, WidgetBuilder>{
           '/next': (BuildContext context) {
-            return new Scaffold(body: const Text('Page 2'));
+            return const Scaffold(body: const Text('Page 2'));
           },
         },
       )
@@ -222,10 +222,10 @@ void main() {
     await tester.pumpWidget(
       new MaterialApp(
         theme: new ThemeData(platform: TargetPlatform.iOS),
-        home: new Scaffold(body: const Text('Page 1')),
+        home: const Scaffold(body: const Text('Page 1')),
         routes: <String, WidgetBuilder>{
           '/next': (BuildContext context) {
-            return new Scaffold(body: const Text('Page 2'));
+            return const Scaffold(body: const Text('Page 2'));
           },
         },
       )
@@ -264,13 +264,13 @@ void main() {
     await tester.pumpWidget(
       new MaterialApp(
         theme: new ThemeData(platform: TargetPlatform.iOS),
-        home: new Scaffold(body: const Text('Page 1')),
+        home: const Scaffold(body: const Text('Page 1')),
       )
     );
 
     tester.state<NavigatorState>(find.byType(Navigator)).push(new MaterialPageRoute<Null>(
       builder: (BuildContext context) {
-        return new Scaffold(body: const Text('Page 2'));
+        return const Scaffold(body: const Text('Page 2'));
       },
       fullscreenDialog: true,
     ));

--- a/packages/flutter/test/material/scaffold_test.dart
+++ b/packages/flutter/test/material/scaffold_test.dart
@@ -82,7 +82,7 @@ void main() {
   });
 
   testWidgets('Floating action animation', (WidgetTester tester) async {
-    await tester.pumpWidget(new Scaffold(
+    await tester.pumpWidget(const Scaffold(
       floatingActionButton: const FloatingActionButton(
         key: const Key('one'),
         onPressed: null,
@@ -92,7 +92,7 @@ void main() {
 
     expect(tester.binding.transientCallbackCount, 0);
 
-    await tester.pumpWidget(new Scaffold(
+    await tester.pumpWidget(const Scaffold(
       floatingActionButton: const FloatingActionButton(
         key: const Key('two'),
         onPressed: null,
@@ -103,10 +103,10 @@ void main() {
     expect(tester.binding.transientCallbackCount, greaterThan(0));
     await tester.pumpWidget(new Container());
     expect(tester.binding.transientCallbackCount, 0);
-    await tester.pumpWidget(new Scaffold());
+    await tester.pumpWidget(const Scaffold());
     expect(tester.binding.transientCallbackCount, 0);
 
-    await tester.pumpWidget(new Scaffold(
+    await tester.pumpWidget(const Scaffold(
       floatingActionButton: const FloatingActionButton(
         key: const Key('one'),
         onPressed: null,

--- a/packages/flutter/test/material/theme_test.dart
+++ b/packages/flutter/test/material/theme_test.dart
@@ -206,7 +206,7 @@ void main() {
                   onTap: () {
                     showDialog<Null>(
                       context: context,
-                      child: new Scaffold(
+                      child: const Scaffold(
                         body: const SizedBox(
                           width: 200.0,
                           height: 200.0,


### PR DESCRIPTION
Requiring a Scaffold's appBar to be an AppBar widget was at least inconvenient and definitely inconsistent with the overall Flutter API.  Similarly the bottom of an AppBar had to be a widget that implemented AppBarBottomWidget; somewhat less of an obstacle but still odd.

These quirks in the API existed because sometimes it's useful for a widget to advertise its preferred default size without actually constraining its own size.

The PreferredSizeWidget interface can be used for these situations. AppBar and TabBar implement PreferredSizeWidget:
```
abstract class PreferredSizeWidget extends Widget {
  Size get preferredSize;
}
```
In both cases the returned size only limits the height, like `new Size.fromHeight(100.0)`.

Scaffold's `appBar` and AppBar's `bottom` properties are now PreferredSizeWidgets. In the common cases where appBar is an AppBar and bottom is a TabBar, nothing needs to change.

To substitute an abitrary widget for PreferredSizeWidget, use PreferredSize. For example:

```
new Scaffold(
  appBar: new PreferredSize(
    preferredSize: const Size.fromHeight(200.0),
    child: const Text('HELLO WORLD'),
  ),
  body: ...
)

```
Scaffold now has a default-true primary property, like AppBar does. If true then the height of the [appBar] will be extended by the height of the screen's status bar. Apps that set the Scaffold's primary property to false will very likely also want to set the appBar's property to false.

The AppBar `minExtent` property has been replaced by preferredSize.

Fixes: https://github.com/flutter/flutter/issues/8970
Fixes: https://github.com/flutter/flutter/issues/9349
