### PR TITLE
Support chaining await calls on controllers

### DIFF
--- a/packages/flutter/lib/src/animation/animation.dart
+++ b/packages/flutter/lib/src/animation/animation.dart
@@ -81,7 +81,7 @@ abstract class Animation<T> extends Listenable {
 
   @override
   String toString() {
-    return '$runtimeType(${toStringDetails()})';
+    return '$runtimeType#$hashCode(${toStringDetails()})';
   }
 
   /// Provides a string describing the status of this object, but not including

--- a/packages/flutter/lib/src/animation/animation_controller.dart
+++ b/packages/flutter/lib/src/animation/animation_controller.dart
@@ -13,6 +13,8 @@ import 'animation.dart';
 import 'curves.dart';
 import 'listener_helpers.dart';
 
+export 'package:flutter/scheduler.dart' show TickerFuture, TickerCanceled;
+
 /// The direction in which an animation is running.
 enum _AnimationDirection {
   /// The animation is running from beginning to end.
@@ -53,6 +55,35 @@ const Tolerance _kFlingTolerance = const Tolerance(
 /// in the context of tests. In other contexts, you will have to either pass a [TickerProvider] from
 /// a higher level (e.g. indirectly from a [State] that mixes in [TickerProviderStateMixin]), or
 /// create a custom [TickerProvider] subclass.
+///
+/// The methods that start animations return a [TickerFuture] object which
+/// completes when the animation completes successfully, and never throws an
+/// error; if the animation is canceled, the future never completes. This object
+/// also has a [TickerFuture.orCancel] property which returns a future that
+/// completes when the animation completes successfully, and completes with an
+/// error when the animation is aborted.
+///
+/// This can be used to write code such as:
+///
+/// ```dart
+/// Future<Null> fadeOutAndUpdateState() async {
+///   try {
+///     await fadeAnimationController.forward().orCancel;
+///     await sizeAnimationController.forward().orCancel;
+///     setState(() {
+///       dismissed = true;
+///     });
+///   } on TickerCanceled {
+///     // the animation got canceled, probably because we were disposed
+///   }
+/// }
+/// ```
+///
+/// ...which asynchnorously runs one animation, then runs another, then changes
+/// the state of the widget, without having to verify [State.mounted] is still
+/// true at each step, and without having to chain futures together explicitly.
+/// (This assumes that the controllers are created in [State.initState] and
+/// disposed in [State.dispose].)
 class AnimationController extends Animation<double>
   with AnimationEagerListenerMixin, AnimationLocalListenersMixin, AnimationLocalStatusListenersMixin {
 
@@ -171,6 +202,10 @@ class AnimationController extends Animation<double>
   ///
   /// Value listeners are notified even if this does not change the value.
   /// Status listeners are notified if the animation was previously playing.
+  ///
+  /// The most recently returned [TickerFuture], if any, is marked as having been
+  /// canceled, meaning the future never completes and its [TickerFuture.orCancel]
+  /// derivative future completes with a [TickerCanceled] error.
   set value(double newValue) {
     assert(newValue != null);
     stop();
@@ -202,7 +237,8 @@ class AnimationController extends Animation<double>
     }
   }
 
-  /// The amount of time that has passed between the time the animation started and the most recent tick of the animation.
+  /// The amount of time that has passed between the time the animation started
+  /// and the most recent tick of the animation.
   ///
   /// If the controller is not animating, the last elapsed duration is null.
   Duration get lastElapsedDuration => _lastElapsedDuration;
@@ -224,8 +260,12 @@ class AnimationController extends Animation<double>
 
   /// Starts running this animation forwards (towards the end).
   ///
-  /// Returns a [Future] that completes when the animation is complete.
-  Future<Null> forward({ double from }) {
+  /// Returns a [TickerFuture] that completes when the animation is complete.
+  ///
+  /// The most recently returned [TickerFuture], if any, is marked as having been
+  /// canceled, meaning the future never completes and its [TickerFuture.orCancel]
+  /// derivative future completes with a [TickerCanceled] error.
+  TickerFuture forward({ double from }) {
     assert(() {
       if (duration == null) {
         throw new FlutterError(
@@ -244,8 +284,12 @@ class AnimationController extends Animation<double>
 
   /// Starts running this animation in reverse (towards the beginning).
   ///
-  /// Returns a [Future] that completes when the animation is complete.
-  Future<Null> reverse({ double from }) {
+  /// Returns a [TickerFuture] that completes when the animation is dismissed.
+  ///
+  /// The most recently returned [TickerFuture], if any, is marked as having been
+  /// canceled, meaning the future never completes and its [TickerFuture.orCancel]
+  /// derivative future completes with a [TickerCanceled] error.
+  TickerFuture reverse({ double from }) {
     assert(() {
       if (duration == null) {
         throw new FlutterError(
@@ -264,8 +308,12 @@ class AnimationController extends Animation<double>
 
   /// Drives the animation from its current value to target.
   ///
-  /// Returns a [Future] that completes when the animation is complete.
-  Future<Null> animateTo(double target, { Duration duration, Curve curve: Curves.linear }) {
+  /// Returns a [TickerFuture] that completes when the animation is complete.
+  ///
+  /// The most recently returned [TickerFuture], if any, is marked as having been
+  /// canceled, meaning the future never completes and its [TickerFuture.orCancel]
+  /// derivative future completes with a [TickerCanceled] error.
+  TickerFuture animateTo(double target, { Duration duration, Curve curve: Curves.linear }) {
     Duration simulationDuration = duration;
     if (simulationDuration == null) {
       assert(() {
@@ -290,7 +338,7 @@ class AnimationController extends Animation<double>
         AnimationStatus.completed :
         AnimationStatus.dismissed;
       _checkStatusChanged();
-      return new Future<Null>.value();
+      return new TickerFuture.complete();
     }
     assert(simulationDuration > Duration.ZERO);
     assert(!isAnimating);
@@ -301,7 +349,14 @@ class AnimationController extends Animation<double>
   /// restarts the animation when it completes.
   ///
   /// Defaults to repeating between the lower and upper bounds.
-  Future<Null> repeat({ double min, double max, Duration period }) {
+  ///
+  /// Returns a [TickerFuture] that never completes. The [TickerFuture.onCancel] future
+  /// completes with an error when the animation is stopped (e.g. with [stop]).
+  ///
+  /// The most recently returned [TickerFuture], if any, is marked as having been
+  /// canceled, meaning the future never completes and its [TickerFuture.orCancel]
+  /// derivative future completes with a [TickerCanceled] error.
+  TickerFuture repeat({ double min, double max, Duration period }) {
     min ??= lowerBound;
     max ??= upperBound;
     period ??= duration;
@@ -319,10 +374,18 @@ class AnimationController extends Animation<double>
     return animateWith(new _RepeatingSimulation(min, max, period));
   }
 
-  /// Drives the animation with a critically damped spring (within [lowerBound] and [upperBound]) and initial velocity.
+  /// Drives the animation with a critically damped spring (within [lowerBound]
+  /// and [upperBound]) and initial velocity.
   ///
-  /// If velocity is positive, the animation will complete, otherwise it will dismiss.
-  Future<Null> fling({ double velocity: 1.0 }) {
+  /// If velocity is positive, the animation will complete, otherwise it will
+  /// dismiss.
+  ///
+  /// Returns a [TickerFuture] that completes when the animation is complete.
+  ///
+  /// The most recently returned [TickerFuture], if any, is marked as having been
+  /// canceled, meaning the future never completes and its [TickerFuture.orCancel]
+  /// derivative future completes with a [TickerCanceled] error.
+  TickerFuture fling({ double velocity: 1.0 }) {
     _direction = velocity < 0.0 ? _AnimationDirection.reverse : _AnimationDirection.forward;
     final double target = velocity < 0.0 ? lowerBound - _kFlingTolerance.distance
                                          : upperBound + _kFlingTolerance.distance;
@@ -332,12 +395,18 @@ class AnimationController extends Animation<double>
   }
 
   /// Drives the animation according to the given simulation.
-  Future<Null> animateWith(Simulation simulation) {
+  ///
+  /// Returns a [TickerFuture] that completes when the animation is complete.
+  ///
+  /// The most recently returned [TickerFuture], if any, is marked as having been
+  /// canceled, meaning the future never completes and its [TickerFuture.orCancel]
+  /// derivative future completes with a [TickerCanceled] error.
+  TickerFuture animateWith(Simulation simulation) {
     stop();
     return _startSimulation(simulation);
   }
 
-  Future<Null> _startSimulation(Simulation simulation) {
+  TickerFuture _startSimulation(Simulation simulation) {
     assert(simulation != null);
     assert(!isAnimating);
     _simulation = simulation;
@@ -355,21 +424,33 @@ class AnimationController extends Animation<double>
   ///
   /// This does not trigger any notifications. The animation stops in its
   /// current state.
-  void stop() {
+  ///
+  /// By default, the most recently returned [TickerFuture] is marked as having
+  /// been canceled, meaning the future never completes and its
+  /// [TickerFuture.orCancel] derivative future completes with a [TickerCanceled]
+  /// error. By passing the `completed` argument with the value false, this is
+  /// reversed, and the futures complete successfully.
+  void stop({ bool canceled: true }) {
     _simulation = null;
     _lastElapsedDuration = null;
-    _ticker.stop();
+    _ticker.stop(canceled: canceled);
   }
 
   /// Release the resources used by this object. The object is no longer usable
   /// after this method is called.
+  ///
+  /// The most recently returned [TickerFuture], if any, is marked as having been
+  /// canceled, meaning the future never completes and its [TickerFuture.orCancel]
+  /// derivative future completes with a [TickerCanceled] error.
   @override
   void dispose() {
     assert(() {
       if (_ticker == null) {
         throw new FlutterError(
           'AnimationController.dispose() called more than once.\n'
-          'A given AnimationController cannot be disposed more than once.'
+          'A given $runtimeType cannot be disposed more than once.\n'
+          'The following $runtimeType object was disposed multiple times:\n'
+          '  $this'
         );
       }
       return true;
@@ -397,7 +478,7 @@ class AnimationController extends Animation<double>
       _status = (_direction == _AnimationDirection.forward) ?
         AnimationStatus.completed :
         AnimationStatus.dismissed;
-      stop();
+      stop(canceled: false);
     }
     notifyListeners();
     _checkStatusChanged();

--- a/packages/flutter/lib/src/material/refresh_indicator.dart
+++ b/packages/flutter/lib/src/material/refresh_indicator.dart
@@ -309,7 +309,7 @@ class RefreshIndicatorState extends State<RefreshIndicator> with TickerProviderS
     _mode = _RefreshIndicatorMode.snap;
     _positionController
       .animateTo(1.0 / _kDragSizeFactorLimit, duration: _kIndicatorSnapDuration)
-      .whenComplete(() {
+      .then((Null value) {
         if (mounted && _mode == _RefreshIndicatorMode.snap) {
           assert(widget.onRefresh != null);
           setState(() {

--- a/packages/flutter/lib/src/material/scaffold.dart
+++ b/packages/flutter/lib/src/material/scaffold.dart
@@ -189,8 +189,8 @@ class _FloatingActionButtonTransitionState extends State<_FloatingActionButtonTr
 
   @override
   void dispose() {
-    _previousController.stop();
-    _currentController.stop();
+    _previousController.dispose();
+    _currentController.dispose();
     super.dispose();
   }
 
@@ -677,6 +677,7 @@ class ScaffoldState extends State<Scaffold> with TickerProviderStateMixin {
       },
       onDismissed: () {
         if (_dismissedBottomSheets.contains(bottomSheet)) {
+          bottomSheet.animationController.dispose();
           setState(() {
             _dismissedBottomSheets.remove(bottomSheet);
           });
@@ -944,7 +945,7 @@ class _PersistentBottomSheet extends StatefulWidget {
     this.builder
   }) : super(key: key);
 
-  final AnimationController animationController;
+  final AnimationController animationController; // we control it, but it must be disposed by whoever created it
   final VoidCallback onClosing;
   final VoidCallback onDismissed;
   final WidgetBuilder builder;
@@ -954,10 +955,6 @@ class _PersistentBottomSheet extends StatefulWidget {
 }
 
 class _PersistentBottomSheetState extends State<_PersistentBottomSheet> {
-
-  // We take ownership of the animation controller given in the first configuration.
-  // We also share control of that animation with out BottomSheet widget.
-
   @override
   void initState() {
     super.initState();
@@ -969,12 +966,6 @@ class _PersistentBottomSheetState extends State<_PersistentBottomSheet> {
   void didUpdateWidget(_PersistentBottomSheet oldWidget) {
     super.didUpdateWidget(oldWidget);
     assert(widget.animationController == oldWidget.animationController);
-  }
-
-  @override
-  void dispose() {
-    widget.animationController.stop();
-    super.dispose();
   }
 
   void close() {

--- a/packages/flutter/lib/src/material/tab_controller.dart
+++ b/packages/flutter/lib/src/material/tab_controller.dart
@@ -101,16 +101,20 @@ class TabController extends ChangeNotifier {
       _indexIsChangingCount += 1;
       notifyListeners(); // Because the value of indexIsChanging may have changed.
       _animationController
-        ..animateTo(_index.toDouble(), duration: duration, curve: curve).whenComplete(() {
-          _indexIsChangingCount -= 1;
-          notifyListeners();
-        });
+        .animateTo(_index.toDouble(), duration: duration, curve: curve)
+        .orCancel.then<Null>(_indexChanged, onError: _indexChanged);
     } else {
       _indexIsChangingCount += 1;
       _animationController.value = _index.toDouble();
       _indexIsChangingCount -= 1;
       notifyListeners();
     }
+  }
+
+  Null _indexChanged(dynamic value) {
+    _indexIsChangingCount -= 1;
+    notifyListeners();
+    return null;
   }
 
   /// The index of the currently selected tab. Changing the index also updates

--- a/packages/flutter/lib/src/widgets/scroll_position.dart
+++ b/packages/flutter/lib/src/widgets/scroll_position.dart
@@ -694,7 +694,7 @@ class BallisticScrollActivity extends ScrollActivity {
     )
       ..addListener(_tick)
       ..animateWith(simulation)
-       .whenComplete(_end);
+       .whenComplete(_end); // won't trigger if we dispose _controller first
   }
 
   @override
@@ -773,7 +773,7 @@ class DrivenScrollActivity extends ScrollActivity {
     )
       ..addListener(_tick)
       ..animateTo(to, duration: duration, curve: curve)
-       .whenComplete(_end);
+       .whenComplete(_end); // won't trigger if we dispose _controller first
   }
 
   @override

--- a/packages/flutter/test/animation/futures_test.dart
+++ b/packages/flutter/test/animation/futures_test.dart
@@ -1,0 +1,180 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter/animation.dart';
+import 'package:flutter/widgets.dart';
+
+void main() {
+  testWidgets('awaiting animation controllers - using direct future', (WidgetTester tester) async {
+    final AnimationController controller1 = new AnimationController(
+      duration: const Duration(milliseconds: 100),
+      vsync: const TestVSync(),
+    );
+    final AnimationController controller2 = new AnimationController(
+      duration: const Duration(milliseconds: 600),
+      vsync: const TestVSync(),
+    );
+    final AnimationController controller3 = new AnimationController(
+      duration: const Duration(milliseconds: 300),
+      vsync: const TestVSync(),
+    );
+    final List<String> log = <String>[];
+    Future<Null> runTest() async {
+      log.add('a'); // t=0
+      await controller1.forward(); // starts at t=0 again
+      log.add('b'); // wants to end at t=100 but missed frames until t=150
+      await controller2.forward(); // starts at t=200
+      log.add('c'); // wants to end at t=800 but missed frames until t=850
+      await controller3.forward(); // starts at t=1200
+      log.add('d'); // wants to end at t=1500 but missed frames until t=1600
+    }
+    log.add('start');
+    runTest().then((Null value) {
+      log.add('end');
+    });
+    await tester.pump(); // t=0
+    expect(log, <String>['start', 'a']);
+    await tester.pump(); // t=0 again
+    expect(log, <String>['start', 'a']);
+    await tester.pump(const Duration(milliseconds: 50)); // t=50
+    expect(log, <String>['start', 'a']);
+    await tester.pump(const Duration(milliseconds: 100)); // t=150
+    expect(log, <String>['start', 'a', 'b']);
+    await tester.pump(const Duration(milliseconds: 50)); // t=200
+    expect(log, <String>['start', 'a', 'b']);
+    await tester.pump(const Duration(milliseconds: 400)); // t=600
+    expect(log, <String>['start', 'a', 'b']);
+    await tester.pump(const Duration(milliseconds: 199)); // t=799
+    expect(log, <String>['start', 'a', 'b']);
+    await tester.pump(const Duration(milliseconds: 51)); // t=850
+    expect(log, <String>['start', 'a', 'b', 'c']);
+    await tester.pump(const Duration(milliseconds: 400)); // t=1200
+    expect(log, <String>['start', 'a', 'b', 'c']);
+    await tester.pump(const Duration(milliseconds: 400)); // t=1600
+    expect(log, <String>['start', 'a', 'b', 'c', 'd', 'end']);
+  });
+
+  testWidgets('awaiting animation controllers - using orCancel', (WidgetTester tester) async {
+    final AnimationController controller1 = new AnimationController(
+      duration: const Duration(milliseconds: 100),
+      vsync: const TestVSync(),
+    );
+    final AnimationController controller2 = new AnimationController(
+      duration: const Duration(milliseconds: 600),
+      vsync: const TestVSync(),
+    );
+    final AnimationController controller3 = new AnimationController(
+      duration: const Duration(milliseconds: 300),
+      vsync: const TestVSync(),
+    );
+    final List<String> log = <String>[];
+    Future<Null> runTest() async {
+      log.add('a'); // t=0
+      await controller1.forward().orCancel; // starts at t=0 again
+      log.add('b'); // wants to end at t=100 but missed frames until t=150
+      await controller2.forward().orCancel; // starts at t=200
+      log.add('c'); // wants to end at t=800 but missed frames until t=850
+      await controller3.forward().orCancel; // starts at t=1200
+      log.add('d'); // wants to end at t=1500 but missed frames until t=1600
+    }
+    log.add('start');
+    runTest().then((Null value) {
+      log.add('end');
+    });
+    await tester.pump(); // t=0
+    expect(log, <String>['start', 'a']);
+    await tester.pump(); // t=0 again
+    expect(log, <String>['start', 'a']);
+    await tester.pump(const Duration(milliseconds: 50)); // t=50
+    expect(log, <String>['start', 'a']);
+    await tester.pump(const Duration(milliseconds: 100)); // t=150
+    expect(log, <String>['start', 'a', 'b']);
+    await tester.pump(const Duration(milliseconds: 50)); // t=200
+    expect(log, <String>['start', 'a', 'b']);
+    await tester.pump(const Duration(milliseconds: 400)); // t=600
+    expect(log, <String>['start', 'a', 'b']);
+    await tester.pump(const Duration(milliseconds: 199)); // t=799
+    expect(log, <String>['start', 'a', 'b']);
+    await tester.pump(const Duration(milliseconds: 51)); // t=850
+    expect(log, <String>['start', 'a', 'b', 'c']);
+    await tester.pump(const Duration(milliseconds: 400)); // t=1200
+    expect(log, <String>['start', 'a', 'b', 'c']);
+    await tester.pump(const Duration(milliseconds: 400)); // t=1600
+    expect(log, <String>['start', 'a', 'b', 'c', 'd', 'end']);
+  });
+
+  testWidgets('awaiting animation controllers and failing', (WidgetTester tester) async {
+    final AnimationController controller1 = new AnimationController(
+      duration: const Duration(milliseconds: 100),
+      vsync: const TestVSync(),
+    );
+    final List<String> log = <String>[];
+    Future<Null> runTest() async {
+      try {
+        log.add('start');
+        await controller1.forward().orCancel;
+        log.add('fail');
+      } on TickerCanceled {
+        log.add('caught');
+      }
+    }
+    runTest().then((Null value) {
+      log.add('end');
+    });
+    await tester.pump(); // start ticker
+    expect(log, <String>['start']);
+    await tester.pump(const Duration(milliseconds: 50));
+    expect(log, <String>['start']);
+    controller1.dispose();
+    expect(log, <String>['start']);
+    await tester.idle();
+    expect(log, <String>['start', 'caught', 'end']);
+  });
+
+  testWidgets('creating orCancel future later', (WidgetTester tester) async {
+    final AnimationController controller1 = new AnimationController(
+      duration: const Duration(milliseconds: 100),
+      vsync: const TestVSync(),
+    );
+    final TickerFuture f = controller1.forward();
+    await tester.pump(); // start ticker
+    await tester.pump(const Duration(milliseconds: 200)); // end ticker
+    await f; // should be a no-op
+    await f.orCancel; // should create a resolved future
+    expect(true, isTrue); // should reach here
+  });
+
+  testWidgets('creating orCancel future later', (WidgetTester tester) async {
+    final AnimationController controller1 = new AnimationController(
+      duration: const Duration(milliseconds: 100),
+      vsync: const TestVSync(),
+    );
+    final TickerFuture f = controller1.forward();
+    await tester.pump(); // start ticker
+    controller1.stop(); // cancel ticker
+    bool ok = false;
+    try {
+      await f.orCancel; // should create a resolved future
+    } on TickerCanceled {
+      ok = true;
+    }
+    expect(ok, isTrue); // should reach here
+  });
+
+  testWidgets('TickerFuture is a Future', (WidgetTester tester) async {
+    final AnimationController controller1 = new AnimationController(
+      duration: const Duration(milliseconds: 100),
+      vsync: const TestVSync(),
+    );
+    final TickerFuture f = controller1.forward();
+    await tester.pump(); // start ticker
+    await tester.pump(const Duration(milliseconds: 200)); // end ticker
+    expect(await f.asStream().single, isNull);
+    await f.catchError((dynamic e) { throw 'do not reach'; });
+    expect(await f.then<bool>((Null value) => true), isTrue);
+    expect(await f.whenComplete(() => false), isNull);
+    expect(await f.timeout(const Duration(seconds: 5)), isNull);
+  });
+}

--- a/packages/flutter/test/widgets/positioned_test.dart
+++ b/packages/flutter/test/widgets/positioned_test.dart
@@ -123,7 +123,7 @@ void main() {
     expect(sizes, equals(<Size>[const Size(10.0, 10.0), const Size(10.0, 10.0), const Size(10.0, 10.0), const Size(10.0, 10.0), const Size(10.0, 10.0), const Size(10.0, 10.0)]));
     expect(positions, equals(<Offset>[const Offset(10.0, 10.0), const Offset(10.0, 10.0), const Offset(17.0, 17.0), const Offset(24.0, 24.0), const Offset(45.0, 45.0), const Offset(80.0, 80.0)]));
 
-    controller.stop();
+    controller.stop(canceled: false);
     await tester.pump();
     expect(completer.isCompleted, isTrue);
   });


### PR DESCRIPTION
With this patch, you can do:

```dart
   Future<Null> foo() async {
     try {
       await controller.forward().orCancel;
       await controller.reverse().orCancel;
       await controller.forward().orCancel;
     } on TickerCanceled {
       // did not complete
     }
   }
```

...in a State's async method, and so long as you dispose of the
controller properly in your dispose, you'll have a nice way of doing
animations in sequence without leaking the controller. try/finally
works as well, if you need to allocate resources and discard them when
canceled.

Simultaneously, you can do:

```dart
   Future<Null> foo() async {
     await controller.forward().orCancel;
     await controller.reverse().orCancel;
     await controller.forward().orCancel;
   }
```

...and have the same effect, where the method will just silently hang
(and get GC'ed) if the widget is disposed, without leaking anything,
if you don't need to catch the controller being killed.

And all this, without spurious errors for uncaught exceptions on
controllers.