### PR TITLE
TabBarView scroll handling should factor in scroll physics tolerance

### DIFF
--- a/packages/flutter/lib/src/material/tabs.dart
+++ b/packages/flutter/lib/src/material/tabs.dart
@@ -830,7 +830,10 @@ class _TabBarViewState extends State<TabBarView> {
       }
       _controller.offset = (_pageController.page - _controller.index).clamp(-1.0, 1.0);
     } else if (notification is ScrollEndNotification) {
-      _controller.index = _pageController.page.floor();
+      final ScrollPosition position = _pageController.position;
+      final double pageTolerance = position.physics.tolerance.distance
+          / (position.viewportDimension * _pageController.viewportFraction);
+      _controller.index = (_pageController.page + pageTolerance).floor();
       _currentIndex = _controller.index;
     }
     _warpUnderwayCount -= 1;


### PR DESCRIPTION
If a TabBarView scroll ends within the scroll physics' distance tolerance of a new page boundary, then its TabController should move to the new page.

Fixes: https://github.com/flutter/flutter/issues/9375
