### PR TITLE
Use a different message on the first reload.

### DIFF
--- a/packages/flutter_tools/lib/src/run_hot.dart
+++ b/packages/flutter_tools/lib/src/run_hot.dart
@@ -373,7 +373,9 @@ class HotRunner extends ResidentRunner {
         rethrow;
       }
     } else {
-      final Status status = logger.startProgress('Performing hot reload...', progressId: 'hot.reload');
+      final bool reloadOnTopOfSnapshot = _runningFromSnapshot;
+      final String progressPrefix = reloadOnTopOfSnapshot ? 'Initializing' : 'Performing';
+      final Status status =  logger.startProgress('$progressPrefix hot reload...', progressId: 'hot.reload');
       try {
         final Stopwatch timer = new Stopwatch()..start();
         final OperationResult result = await _reloadSources(pause: pauseAfterRestart);


### PR DESCRIPTION
The first hot reload does a bunch of work that we used to hide behind the
loader screen. This PR changes the messsage printed to the user on the first
reload from:

'Performing hot reload...'

to:

'Initializing hot reload...'

Subsequent reloads say 'Performing hot reload...'