### PR TITLE
Ask users to set ANDROID_HOME if SDK is installed in a non-standard location

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_workflow.dart
+++ b/packages/flutter_tools/lib/src/android/android_workflow.dart
@@ -103,9 +103,11 @@ class AndroidWorkflow extends DoctorValidator implements Workflow {
         ));
       } else {
         messages.add(new ValidationMessage.error(
+          'Unable to locate Android SDK.\n'
           'Install Android Studio from https://developer.android.com/studio/index.html.\n'
           'On first launch it will assist you in installing the Android SDK components.\n'
-          '(or visit https://flutter.io/setup/#android-setup for detailed instructions).'
+          '(or visit https://flutter.io/setup/#android-setup for detailed instructions).\n'
+          'If Android SDK has been installed to a custom location, set \$$kAndroidHome to that location.'
         ));
       }
 


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/9303.