### PR TITLE
Handle reassemble timeouts gracefully.

### DIFF
--- a/packages/flutter_tools/lib/src/vmservice.dart
+++ b/packages/flutter_tools/lib/src/vmservice.dart
@@ -35,6 +35,9 @@ const Duration kDefaultRequestTimeout = const Duration(seconds: 30);
 /// Used for RPC requests that may take a long time.
 const Duration kLongRequestTimeout = const Duration(minutes: 1);
 
+/// Used for RPC requests that should never take a long time.
+const Duration kShortRequestTimeout = const Duration(seconds: 5);
+
 /// A connection to the Dart VM Service.
 class VMService {
   VMService._(this._peer, this.httpAddress, this.wsAddress, this._requestTimeout) {
@@ -1005,8 +1008,8 @@ class Isolate extends ServiceObjectOwner {
   Future<Map<String, dynamic>> flutterReassemble() async {
     return await invokeFlutterExtensionRpcRaw(
       'ext.flutter.reassemble',
-      timeout: kLongRequestTimeout,
-      timeoutFatal: false,
+      timeout: kShortRequestTimeout,
+      timeoutFatal: true,
     );
   }
 


### PR DESCRIPTION
- [x] Switch the reassemble timeout to 5 seconds.
- [x] Print a status message if reassemble fails:

```
Performing hot reload...
Reassembling app.flx$main took too long. Hot reload may have failed.
Reloaded 0 of 418 libraries in 5,322ms.
```

Fixes #9316
Fixes #8861
Fixes #8857
Fixes #8856