### PR TITLE
improve progress display when running apps; speed up startup

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_device.dart
+++ b/packages/flutter_tools/lib/src/android/android_device.dart
@@ -242,8 +242,9 @@ class AndroidDevice extends Device {
       return false;
     }
 
-    await runCheckedAsync(adbCommandForDevice(
-      <String>['shell', 'echo', '-n', _getSourceSha1(app), '>', _getDeviceSha1Path(app)]));
+    await runCheckedAsync(adbCommandForDevice(<String>[
+      'shell', 'echo', '-n', _getSourceSha1(app), '>', _getDeviceSha1Path(app)
+    ]));
     return true;
   }
 

--- a/packages/flutter_tools/lib/src/android/gradle.dart
+++ b/packages/flutter_tools/lib/src/android/gradle.dart
@@ -23,6 +23,8 @@ const String gradleManifestPath = 'android/app/src/main/AndroidManifest.xml';
 const String gradleAppOutV1 = 'android/app/build/outputs/apk/app-debug.apk';
 const String gradleAppOutDirV1 = 'android/app/build/outputs/apk';
 
+String _cachedGradleAppOutDirV2;
+
 enum FlutterPluginVersion {
   none,
   v1,
@@ -54,7 +56,7 @@ FlutterPluginVersion get flutterPluginVersion {
   return FlutterPluginVersion.none;
 }
 
-String get gradleAppOut {
+String getGradleAppOut() {
   switch (flutterPluginVersion) {
     case FlutterPluginVersion.none:
       // Fall through. Pretend we're v1, and just go with it.
@@ -63,12 +65,19 @@ String get gradleAppOut {
     case FlutterPluginVersion.managed:
       // Fall through. The managed plugin matches plugin v2 for now.
     case FlutterPluginVersion.v2:
-      return '$gradleAppOutDirV2/app.apk';
+      return '${getGradleAppOutDirV2()}/app.apk';
   }
   return null;
 }
 
-String get gradleAppOutDirV2 {
+String getGradleAppOutDirV2() {
+  if (_cachedGradleAppOutDirV2 == null)
+    _cachedGradleAppOutDirV2 = _calculateGradleAppOutDirV2();
+  return _cachedGradleAppOutDirV2;
+}
+
+// Note: this call takes about a second to complete.
+String _calculateGradleAppOutDirV2() {
   final String gradle = ensureGradle();
   ensureLocalProperties();
   try {
@@ -224,7 +233,7 @@ Future<Null> buildGradleProjectV2(String gradle, String buildModeName, String ta
   if (exitcode != 0)
     throwToolExit('Gradle build failed: $exitcode', exitCode: exitcode);
 
-  final String buildDirectory = gradleAppOutDirV2;
+  final String buildDirectory = getGradleAppOutDirV2();
   final String apkFilename = 'app-$buildModeName.apk';
   final File apkFile = fs.file('$buildDirectory/$apkFilename');
   // Copy the APK to app.apk, so `flutter run`, `flutter install`, etc. can find it.

--- a/packages/flutter_tools/lib/src/android/gradle.dart
+++ b/packages/flutter_tools/lib/src/android/gradle.dart
@@ -71,8 +71,7 @@ String getGradleAppOut() {
 }
 
 String getGradleAppOutDirV2() {
-  if (_cachedGradleAppOutDirV2 == null)
-    _cachedGradleAppOutDirV2 = _calculateGradleAppOutDirV2();
+  _cachedGradleAppOutDirV2 ??= _calculateGradleAppOutDirV2();
   return _cachedGradleAppOutDirV2;
 }
 

--- a/packages/flutter_tools/lib/src/application_package.dart
+++ b/packages/flutter_tools/lib/src/application_package.dart
@@ -83,16 +83,16 @@ class AndroidApk extends ApplicationPackage {
     String apkPath;
 
     if (isProjectUsingGradle()) {
-      if (fs.file(gradleAppOut).existsSync()) {
+      if (fs.file(getGradleAppOut()).existsSync()) {
         // Grab information from the .apk. The gradle build script might alter
         // the application Id, so we need to look at what was actually built.
-        return new AndroidApk.fromApk(gradleAppOut);
+        return new AndroidApk.fromApk(getGradleAppOut());
       }
       // The .apk hasn't been built yet, so we work with what we have. The run
       // command will grab a new AndroidApk after building, to get the updated
       // IDs.
       manifestPath = gradleManifestPath;
-      apkPath = gradleAppOut;
+      apkPath = getGradleAppOut();
     } else {
       manifestPath = fs.path.join('android', 'AndroidManifest.xml');
       apkPath = fs.path.join(getAndroidBuildDirectory(), 'app.apk');

--- a/packages/flutter_tools/lib/src/commands/install.dart
+++ b/packages/flutter_tools/lib/src/commands/install.dart
@@ -37,12 +37,12 @@ class InstallCommand extends FlutterCommand {
 
     printStatus('Installing $package to $device...');
 
-    if (!installApp(device, package))
+    if (!await installApp(device, package))
       throwToolExit('Install failed');
   }
 }
 
-bool installApp(Device device, ApplicationPackage package, { bool uninstall: true }) {
+Future<bool> installApp(Device device, ApplicationPackage package, { bool uninstall: true }) async {
   if (package == null)
     return false;
 

--- a/packages/flutter_tools/lib/src/device.dart
+++ b/packages/flutter_tools/lib/src/device.dart
@@ -150,7 +150,7 @@ abstract class Device {
   bool isLatestBuildInstalled(ApplicationPackage app);
 
   /// Install an app package on the current device
-  bool installApp(ApplicationPackage app);
+  Future<bool> installApp(ApplicationPackage app);
 
   /// Uninstall an app package from the current device
   bool uninstallApp(ApplicationPackage app);

--- a/packages/flutter_tools/lib/src/fuchsia/fuchsia_device.dart
+++ b/packages/flutter_tools/lib/src/fuchsia/fuchsia_device.dart
@@ -49,7 +49,7 @@ class FuchsiaDevice extends Device {
   bool isLatestBuildInstalled(ApplicationPackage app) => false;
 
   @override
-  bool installApp(ApplicationPackage app) => false;
+  Future<bool> installApp(ApplicationPackage app) => new Future<bool>.value(false);
 
   @override
   bool uninstallApp(ApplicationPackage app) => false;

--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -155,7 +155,7 @@ class IOSDevice extends Device {
   bool isLatestBuildInstalled(ApplicationPackage app) => false;
 
   @override
-  bool installApp(ApplicationPackage app) {
+  Future<bool> installApp(ApplicationPackage app) async {
     final IOSApp iosApp = app;
     final Directory bundle = fs.directory(iosApp.deviceBundlePath);
     if (!bundle.existsSync()) {
@@ -197,8 +197,7 @@ class IOSDevice extends Device {
     bool applicationNeedsRebuild: false,
   }) async {
     if (!prebuiltApplication) {
-      // TODO(chinmaygarde): Use checked, mainPath, route.
-      // TODO(devoncarew): Handle startPaused, debugPort.
+      // TODO(chinmaygarde): Use mainPath, route.
       printTrace('Building ${app.name} for $id');
 
       // Step 1: Build the precompiled/DBC application if necessary.
@@ -210,7 +209,7 @@ class IOSDevice extends Device {
         return new LaunchResult.failed();
       }
     } else {
-      if (!installApp(app))
+      if (!await installApp(app))
         return new LaunchResult.failed();
     }
 

--- a/packages/flutter_tools/lib/src/ios/simulators.dart
+++ b/packages/flutter_tools/lib/src/ios/simulators.dart
@@ -343,7 +343,7 @@ class IOSSimulator extends Device {
   bool isLatestBuildInstalled(ApplicationPackage app) => false;
 
   @override
-  bool installApp(ApplicationPackage app) {
+  Future<bool> installApp(ApplicationPackage app) async {
     try {
       final IOSApp iosApp = app;
       SimControl.instance.install(id, iosApp.simulatorBundlePath);
@@ -435,7 +435,7 @@ class IOSSimulator extends Device {
         return new LaunchResult.failed();
       }
     } else {
-      if (!installApp(app))
+      if (!await installApp(app))
         return new LaunchResult.failed();
     }
 

--- a/packages/flutter_tools/lib/src/run_cold.dart
+++ b/packages/flutter_tools/lib/src/run_cold.dart
@@ -53,6 +53,14 @@ class ColdRunner extends ResidentRunner {
       }
     }
 
+    final String modeName = getModeName(debuggingOptions.buildMode);
+    if (mainPath == null) {
+      assert(prebuiltMode);
+      printStatus('Launching ${package.displayName} on ${device.name} in $modeName mode...');
+    } else {
+      printStatus('Launching ${getDisplayPath(mainPath)} on ${device.name} in $modeName mode...');
+    }
+
     package = getApplicationPackageForPlatform(device.targetPlatform, applicationBinary: applicationBinary);
 
     if (package == null) {
@@ -71,14 +79,6 @@ class ColdRunner extends ResidentRunner {
       platformArgs = <String, dynamic>{ 'trace-startup': traceStartup };
 
     await startEchoingDeviceLog(package);
-
-    final String modeName = getModeName(debuggingOptions.buildMode);
-    if (mainPath == null) {
-      assert(prebuiltMode);
-      printStatus('Launching ${package.displayName} on ${device.name} in $modeName mode...');
-    } else {
-      printStatus('Launching ${getDisplayPath(mainPath)} on ${device.name} in $modeName mode...');
-    }
 
     _result = await device.startApp(
       package,
@@ -158,7 +158,7 @@ class ColdRunner extends ResidentRunner {
   void printHelp({ @required bool details }) {
     bool haveDetails = false;
     if (_result.hasObservatory)
-      printStatus('The Observatory debugger and profiler is available at: ${_result.observatoryUri}');
+      printStatus('The Observatory debugger and profiler is available at: ${_result.observatoryUri}.');
     if (supportsServiceProtocol) {
       haveDetails = true;
       if (details)

--- a/packages/flutter_tools/lib/src/run_cold.dart
+++ b/packages/flutter_tools/lib/src/run_cold.dart
@@ -158,7 +158,7 @@ class ColdRunner extends ResidentRunner {
   void printHelp({ @required bool details }) {
     bool haveDetails = false;
     if (_result.hasObservatory)
-      printStatus('The Observatory debugger and profiler is available at: ${_result.observatoryUri}.');
+      printStatus('The Observatory debugger and profiler is available at: ${_result.observatoryUri}');
     if (supportsServiceProtocol) {
       haveDetails = true;
       if (details)

--- a/packages/flutter_tools/lib/src/run_hot.dart
+++ b/packages/flutter_tools/lib/src/run_hot.dart
@@ -578,7 +578,7 @@ class HotRunner extends ResidentRunner {
       ansiAlternative: '$red$fire$bold  To hot reload your app on the fly, '
                        'press "r". To restart the app entirely, press "R".$reset'
     );
-    printStatus('The Observatory debugger and profiler is available at: $_observatoryUri.');
+    printStatus('The Observatory debugger and profiler is available at: $_observatoryUri');
     if (details) {
       printHelpDetails();
       printStatus('To repeat this help message, press "h". To quit, press "q".');

--- a/packages/flutter_tools/lib/src/run_hot.dart
+++ b/packages/flutter_tools/lib/src/run_hot.dart
@@ -174,6 +174,9 @@ class HotRunner extends ResidentRunner {
       return 1;
     }
 
+    final String modeName = getModeName(debuggingOptions.buildMode);
+    printStatus('Launching ${getDisplayPath(mainPath)} on ${device.name} in $modeName mode...');
+
     package = getApplicationPackageForPlatform(device.targetPlatform, applicationBinary: applicationBinary);
 
     if (package == null) {
@@ -194,9 +197,6 @@ class HotRunner extends ResidentRunner {
     final Map<String, dynamic> platformArgs = <String, dynamic>{};
 
     await startEchoingDeviceLog(package);
-
-    final String modeName = getModeName(debuggingOptions.buildMode);
-    printStatus('Launching ${getDisplayPath(mainPath)} on ${device.name} in $modeName mode...');
 
     // Start the application.
     final Future<LaunchResult> futureResult = device.startApp(
@@ -578,7 +578,7 @@ class HotRunner extends ResidentRunner {
       ansiAlternative: '$red$fire$bold  To hot reload your app on the fly, '
                        'press "r". To restart the app entirely, press "R".$reset'
     );
-    printStatus('The Observatory debugger and profiler is available at: $_observatoryUri');
+    printStatus('The Observatory debugger and profiler is available at: $_observatoryUri.');
     if (details) {
       printHelpDetails();
       printStatus('To repeat this help message, press "h". To quit, press "q".');


### PR DESCRIPTION
- fix https://github.com/flutter/flutter/issues/9435; speed-up app startup and move our initial message to before we do a lot of work
- cache the result of calculating GradleAppOutDirV2; this call takes about a second, and is called 4-5 times
- move the `Launching...` message before we do a lot of android/gradle work
- change the `installApp()` call to be async, so we can use async methods within, so the spinner for the `Installing build/app/outputs/apk/app.apk... ` message doesn't appear frozen

Start-up text after the PR:

```
Launching lib/main.dart on Nexus 5X in debug mode...
Running 'gradle assembleDebug'...                     7.9s
Built build/app/outputs/apk/app-debug.apk (27.9MB).
Installing build/app/outputs/apk/app.apk...           6.9s
Syncing files to device...                            3.4s

🔥  To hot reload your app on the fly, press "r". To restart the app entirely, press "R".
The Observatory debugger and profiler is available at: http://127.0.0.1:8104/.
For a more detailed help message, press "h". To quit, press "q".
```



