### PR TITLE
Mark some tests as flaky

### DIFF
--- a/dev/devicelab/manifest.yaml
+++ b/dev/devicelab/manifest.yaml
@@ -107,6 +107,7 @@ tasks:
       Android.
     stage: devicelab
     required_agent_capabilities: ["has-android-device"]
+    flaky: true
 
   hot_mode_dev_cycle__benchmark:
     description: >
@@ -212,9 +213,11 @@ tasks:
       Gallery on Windows.
     stage: devicelab_win
     required_agent_capabilities: ["windows"]
+    flaky: true
 
   hot_mode_dev_cycle_win__benchmark:
     description: >
       Measures the performance of Dart VM hot patching feature on Windows.
     stage: devicelab_win
     required_agent_capabilities: ["windows"]
+    flaky: true


### PR DESCRIPTION
These tests have recently been turning the build red incorrectly. Until they are reliable, let's mark them flaky.