### PR TITLE
Fix a race in runFromSource.

### DIFF
--- a/packages/flutter_tools/lib/src/vmservice.dart
+++ b/packages/flutter_tools/lib/src/vmservice.dart
@@ -1124,7 +1124,8 @@ class FlutterView extends ServiceObject {
       // launch errors.
       if (event.kind == ServiceEvent.kIsolateRunnable) {
         printTrace('Isolate is runnable.');
-        completer.complete(null);
+        if (!completer.isCompleted)
+          completer.complete(null);
       }
     });
     await owner.vm.runInView(viewId,


### PR DESCRIPTION
Fixes #9334

There is a race where we could complete a future based on a stream event
and then before we cancel the stream subscription, we get another event
and try and complete the future again.

@devoncarew 