### PR TITLE
Add a tile scrolling test to complex_layout app

### DIFF
--- a/dev/benchmarks/complex_layout/lib/main.dart
+++ b/dev/benchmarks/complex_layout/lib/main.dart
@@ -57,23 +57,21 @@ class TileScrollLayout extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final List<Widget> children = <Widget>[];
-    for (int i = 0; i < 200; i++) {
-      children.add(new Padding(
-        padding:const EdgeInsets.all(5.0),
-        child: new Material(
-          elevation: i % 5 + 1,
-          color: Colors.white,
-          child: new IconBar(),
-        ),
-      ));
-    }
-
     return new Scaffold(
       appBar: new AppBar(title: const Text('Tile Scrolling Layout')),
-      body: new ListView(
+      body: new ListView.builder(
         key: const Key('tiles-scroll'),
-        children: children
+        itemCount: 200,
+        itemBuilder: (BuildContext context, int index) {
+          return new Padding(
+            padding:const EdgeInsets.all(5.0),
+            child: new Material(
+              elevation: index % 5 + 1,
+              color: Colors.white,
+              child: new IconBar(),
+            ),
+          );
+        }
       ),
       drawer: const GalleryDrawer(),
     );

--- a/dev/benchmarks/complex_layout/lib/main.dart
+++ b/dev/benchmarks/complex_layout/lib/main.dart
@@ -11,6 +11,8 @@ void main() {
   );
 }
 
+enum ScrollMode {complex, tile}
+
 class ComplexLayoutApp extends StatefulWidget {
   @override
   ComplexLayoutAppState createState() => new ComplexLayoutAppState();
@@ -24,8 +26,7 @@ class ComplexLayoutAppState extends State<ComplexLayoutApp> {
     return new MaterialApp(
       theme: lightTheme ? new ThemeData.light() : new ThemeData.dark(),
       title: 'Advanced Layout',
-      home: const ComplexLayout()
-    );
+      home: scrollMode == ScrollMode.complex ? const ComplexLayout() : const TileScrollLayout());
   }
 
   bool _lightTheme = true;
@@ -36,10 +37,42 @@ class ComplexLayoutAppState extends State<ComplexLayoutApp> {
     });
   }
 
+  ScrollMode _scrollMode = ScrollMode.complex;
+  ScrollMode get scrollMode => _scrollMode;
+  set scrollMode(ScrollMode mode) {
+    setState(() {
+      _scrollMode = mode;
+    });
+  }
+
   void toggleAnimationSpeed() {
     setState(() {
       timeDilation = (timeDilation != 1.0) ? 1.0 : 5.0;
     });
+  }
+}
+
+class TileScrollLayout extends StatelessWidget {
+  const TileScrollLayout({ Key key }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    final List<Widget> children = <Widget>[];
+    for (int i = 0; i < 200; i++) {
+      children.add(new Padding(padding:const EdgeInsets.all(5.0), child: new Material(
+        elevation: i % 5 + 1,
+        color: Colors.white,
+        child: new IconBar(),
+      )));
+    }
+
+    return new Scaffold(
+      appBar: new AppBar(title: new Text('Tile Scrolling Layout')),
+      body: new ListView(
+        key: new Key('tiles-scroll'),
+        children: children),
+      drawer: new GalleryDrawer(),
+    );
   }
 }
 
@@ -73,7 +106,7 @@ class ComplexLayoutState extends State<ComplexLayout> {
         children: <Widget>[
           new Expanded(
             child: new ListView.builder(
-              key: const Key('main-scroll'), // this key is used by the driver test
+              key: const Key('complex-scroll'), // this key is used by the driver test
               itemBuilder: (BuildContext context, int index) {
                 if (index % 2 == 0)
                   return new FancyImageItem(index, key: new ValueKey<int>(index));
@@ -571,12 +604,22 @@ class GalleryDrawer extends StatelessWidget {
     ComplexLayoutApp.of(context).lightTheme = value;
   }
 
+  void _changeScrollMode(BuildContext context, ScrollMode mode) {
+    ComplexLayoutApp.of(context).scrollMode = mode;
+  }
+
   @override
   Widget build(BuildContext context) {
+    final ScrollMode currentMode = ComplexLayoutApp.of(context).scrollMode;
     return new Drawer(
       child: new ListView(
         children: <Widget>[
           new FancyDrawerHeader(),
+          new ListTile(
+            key: new Key('scroll-switcher'),
+            onTap: () { _changeScrollMode(context, currentMode == ScrollMode.complex ? ScrollMode.tile : ScrollMode.complex); },
+            trailing: new Text(currentMode == ScrollMode.complex ? 'Tile' : 'Complex')
+          ),
           new ListTile(
             leading: const Icon(Icons.brightness_5),
             title: const Text('Light'),

--- a/dev/benchmarks/complex_layout/lib/main.dart
+++ b/dev/benchmarks/complex_layout/lib/main.dart
@@ -11,7 +11,7 @@ void main() {
   );
 }
 
-enum ScrollMode {complex, tile}
+enum ScrollMode { complex, tile }
 
 class ComplexLayoutApp extends StatefulWidget {
   @override
@@ -59,19 +59,23 @@ class TileScrollLayout extends StatelessWidget {
   Widget build(BuildContext context) {
     final List<Widget> children = <Widget>[];
     for (int i = 0; i < 200; i++) {
-      children.add(new Padding(padding:const EdgeInsets.all(5.0), child: new Material(
-        elevation: i % 5 + 1,
-        color: Colors.white,
-        child: new IconBar(),
-      )));
+      children.add(new Padding(
+        padding:const EdgeInsets.all(5.0),
+        child: new Material(
+          elevation: i % 5 + 1,
+          color: Colors.white,
+          child: new IconBar(),
+        ),
+      ));
     }
 
     return new Scaffold(
-      appBar: new AppBar(title: new Text('Tile Scrolling Layout')),
+      appBar: new AppBar(title: const Text('Tile Scrolling Layout')),
       body: new ListView(
-        key: new Key('tiles-scroll'),
-        children: children),
-      drawer: new GalleryDrawer(),
+        key: const Key('tiles-scroll'),
+        children: children
+      ),
+      drawer: const GalleryDrawer(),
     );
   }
 }
@@ -616,7 +620,7 @@ class GalleryDrawer extends StatelessWidget {
         children: <Widget>[
           new FancyDrawerHeader(),
           new ListTile(
-            key: new Key('scroll-switcher'),
+            key: const Key('scroll-switcher'),
             onTap: () { _changeScrollMode(context, currentMode == ScrollMode.complex ? ScrollMode.tile : ScrollMode.complex); },
             trailing: new Text(currentMode == ScrollMode.complex ? 'Tile' : 'Complex')
           ),

--- a/dev/benchmarks/complex_layout/test_driver/scroll_perf_test.dart
+++ b/dev/benchmarks/complex_layout/test_driver/scroll_perf_test.dart
@@ -19,28 +19,38 @@ void main() {
         driver.close();
     });
 
-    test('measure', () async {
+    Future<Null> testScrollPerf(String listKey, String summaryName) async {
       final Timeline timeline = await driver.traceAction(() async {
         // Find the scrollable stock list
-        final SerializableFinder stockList = find.byValueKey('main-scroll');
-        expect(stockList, isNotNull);
+        final SerializableFinder list = find.byValueKey(listKey);
+        expect(list, isNotNull);
 
         // Scroll down
         for (int i = 0; i < 5; i++) {
-          await driver.scroll(stockList, 0.0, -300.0, const Duration(milliseconds: 300));
+          await driver.scroll(list, 0.0, -300.0, const Duration(milliseconds: 300));
           await new Future<Null>.delayed(const Duration(milliseconds: 500));
         }
 
         // Scroll up
         for (int i = 0; i < 5; i++) {
-          await driver.scroll(stockList, 0.0, 300.0, const Duration(milliseconds: 300));
+          await driver.scroll(list, 0.0, 300.0, const Duration(milliseconds: 300));
           await new Future<Null>.delayed(const Duration(milliseconds: 500));
         }
       });
 
       final TimelineSummary summary = new TimelineSummary.summarize(timeline);
-      summary.writeSummaryToFile('complex_layout_scroll_perf', pretty: true);
-      summary.writeTimelineToFile('complex_layout_scroll_perf', pretty: true);
+      summary.writeSummaryToFile(summaryName, pretty: true);
+      summary.writeTimelineToFile(summaryName, pretty: true);
+    }
+
+    test('complex_layout_scroll_perf', () async {
+      await testScrollPerf('complex-scroll', 'complex_layout_scroll_perf');
+    });
+
+    test('tiles_scroll_perf', () async {
+      await driver.tap(find.byTooltip('Open navigation menu'));
+      await driver.tap(find.byValueKey('scroll-switcher'));
+      await testScrollPerf('tiles-scroll', 'tiles_scroll_perf');
     });
   });
 }


### PR DESCRIPTION
complex_layout already has a nice scrolling test that contains many elements. I wanted to stress test the scrolling with a bunch of tiles with small images and lots of shadows (tiles are wrapped in Material with varying elevation). This has caused performance problems for Leafy in the past so I figure it would be a good addition to the micro benchmarks.