### PR TITLE
Upgrade firebase tools version

### DIFF
--- a/dev/bots/travis_install.sh
+++ b/dev/bots/travis_install.sh
@@ -3,5 +3,5 @@ set -ex
 
 if [ -n "$TRAVIS" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
   gem install coveralls-lcov
-  npm install -g firebase-tools@">=3.0.4 <3.1.0"
+  npm install -g firebase-tools@">=3.6.1 <3.7.0"
 fi


### PR DESCRIPTION
Attempting to resolve current travis failure in the docs shard:

```
Docs ready to go!
Extracing javadoc to dev/docs/doc/javadoc
TypeError: Not an integer
    at Object.fs.writeSync (fs.js:540:18)
    at Function.writeFileSync [as sync] (/home/travis/.nvm/v0.10.36/lib/node_modules/firebase-tools/node_modules/configstore/node_modules/write-file-atomic/index.js:114:10)
    at Object.create.all.set (/home/travis/.nvm/v0.10.36/lib/node_modules/firebase-tools/node_modules/configstore/index.js:62:21)
    at Object.Configstore (/home/travis/.nvm/v0.10.36/lib/node_modules/firebase-tools/node_modules/configstore/index.js:27:11)
    at new UpdateNotifier (/home/travis/.nvm/v0.10.36/lib/node_modules/firebase-tools/node_modules/update-notifier/index.js:34:17)
    at module.exports (/home/travis/.nvm/v0.10.36/lib/node_modules/firebase-tools/node_modules/update-notifier/index.js:123:23)
    at Object.<anonymous> (/home/travis/.nvm/v0.10.36/lib/node_modules/firebase-tools/bin/firebase:5:48)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
The command "(./bin/cache/dart-sdk/bin/dart ./dev/bots/test.dart && ./dev/bots/travis_upload.sh)" exited with 8.
cache.2
store build cache
0.01s
13.71schange detected (content changed, file is created, or file is deleted):
/home/travis/.pub-cache/global_packages/dartdoc/bin/dartdoc.dart.snapshot
/home/travis/.pub-cache/global_packages/dartdoc/.packages
changes detected, packing new archive
.
uploading archive
Done. Your build exited with 1.
```