### PR TITLE
Upgrade node version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,9 @@ addons:
     packages:
       - libstdc++6
       - fonts-droid
+language: node_js
+node_js:
+  - "7"
 install:
   - ./dev/bots/travis_install.sh
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ addons:
       - fonts-droid
 language: node_js
 node_js:
-  - "7"
+  - "6"
 install:
   - ./dev/bots/travis_install.sh
 env:


### PR DESCRIPTION
Another attempts at resolving the firebase problem mentioned in:
https://github.com/flutter/flutter/pull/9548

From the Firebase discussion list, the Firebase team stated that we are currently using a nvm version that is not supported, and recommended upgrading.