### PR TITLE
Loosen the constraints for Stack non-positioned children.

### DIFF
--- a/packages/flutter/lib/src/material/input_decorator.dart
+++ b/packages/flutter/lib/src/material/input_decorator.dart
@@ -428,7 +428,10 @@ class InputDecorator extends StatelessWidget {
       ));
     }
 
-    final Widget stack = new Stack(children: stackChildren);
+    final Widget stack = new Stack(
+      sizing: StackFit.passthrough,
+      children: stackChildren
+    );
 
     if (decoration.icon != null) {
       assert(!isCollapsed);

--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -2407,7 +2407,7 @@ class RenderOffstage extends RenderProxyBox {
     if (value == _offstage)
       return;
     _offstage = value;
-    markNeedsLayout();
+    markNeedsLayoutForSizedByParentChange();
   }
 
   @override

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -43,6 +43,7 @@ export 'package:flutter/rendering.dart' show
   RelativeRect,
   ShaderCallback,
   SingleChildLayoutDelegate,
+  StackFit,
   TextOverflow,
   ValueChanged,
   ValueGetter,
@@ -1647,6 +1648,7 @@ class Stack extends MultiChildRenderObjectWidget {
   Stack({
     Key key,
     this.alignment: FractionalOffset.topLeft,
+    this.sizing: StackFit.loose,
     this.overflow: Overflow.clip,
     List<Widget> children: const <Widget>[],
   }) : super(key: key, children: children);
@@ -1659,6 +1661,13 @@ class Stack extends MultiChildRenderObjectWidget {
   /// each non-positioned child will be located at the same global coordinate.
   final FractionalOffset alignment;
 
+  /// How to size the non-positioned children in the stack.
+  ///
+  /// The constraints passed into the [Stack] from its parent are either
+  /// loosened ([StackFit.loose]) or tightened to their biggest size
+  /// ([StackFit.expand]).
+  final StackFit sizing;
+
   /// Whether overflowing children should be clipped. See [Overflow].
   ///
   /// Some children in a stack might overflow its box. When this flag is set to
@@ -1669,7 +1678,8 @@ class Stack extends MultiChildRenderObjectWidget {
   RenderStack createRenderObject(BuildContext context) {
     return new RenderStack(
       alignment: alignment,
-      overflow: overflow
+      sizing: sizing,
+      overflow: overflow,
     );
   }
 
@@ -1677,6 +1687,7 @@ class Stack extends MultiChildRenderObjectWidget {
   void updateRenderObject(BuildContext context, RenderStack renderObject) {
     renderObject
       ..alignment = alignment
+      ..sizing = sizing
       ..overflow = overflow;
   }
 }
@@ -1696,9 +1707,10 @@ class IndexedStack extends Stack {
   IndexedStack({
     Key key,
     FractionalOffset alignment: FractionalOffset.topLeft,
+    StackFit sizing: StackFit.loose,
     this.index: 0,
     List<Widget> children: const <Widget>[],
-  }) : super(key: key, alignment: alignment, children: children);
+  }) : super(key: key, alignment: alignment, sizing: sizing, children: children);
 
   /// The index of the child to show.
   final int index;

--- a/packages/flutter/lib/src/widgets/overlay.dart
+++ b/packages/flutter/lib/src/widgets/overlay.dart
@@ -198,9 +198,8 @@ class Overlay extends StatefulWidget {
   /// The initial entries will be inserted into the overlay when its associated
   /// [OverlayState] is initialized.
   ///
-  /// Rather than creating an overlay, consider using the overlay that has
-  /// already been created by the [WidgetsApp] or the [MaterialApp] for this
-  /// application.
+  /// Rather than creating an overlay, consider using the overlay that is
+  /// created by the [WidgetsApp] or the [MaterialApp] for the application.
   const Overlay({
     Key key,
     this.initialEntries: const <OverlayEntry>[]
@@ -362,7 +361,10 @@ class OverlayState extends State<Overlay> with TickerProviderStateMixin {
       }
     }
     return new _Theatre(
-      onstage: new Stack(children: onstageChildren.reversed.toList(growable: false)),
+      onstage: new Stack(
+        sizing: StackFit.expand,
+        children: onstageChildren.reversed.toList(growable: false),
+      ),
       offstage: offstageChildren,
     );
   }

--- a/packages/flutter/test/material/input_decorator_test.dart
+++ b/packages/flutter/test/material/input_decorator_test.dart
@@ -6,7 +6,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/material.dart';
 
 void main() {
-  testWidgets('InputDecorator always expands', (WidgetTester tester) async {
+  testWidgets('InputDecorator always expands horizontally', (WidgetTester tester) async {
     final Key key = new UniqueKey();
 
     await tester.pumpWidget(new Material(

--- a/packages/flutter/test/rendering/stack_test.dart
+++ b/packages/flutter/test/rendering/stack_test.dart
@@ -45,4 +45,6 @@ void main() {
     expect(green.size.width, equals(100.0));
     expect(green.size.height, equals(100.0));
   });
+
+  // More tests in ../widgets/stack_test.dart
 }

--- a/packages/flutter/test/widgets/modal_barrier_test.dart
+++ b/packages/flutter/test/widgets/modal_barrier_test.dart
@@ -76,7 +76,7 @@ void main() {
     await tester.pump(const Duration(seconds: 1));  // end transition
 
     expect(find.byKey(const ValueKey<String>('barrier')), findsNothing,
-      reason: 'because the barrier was dismissed');
+      reason: 'The route should have been dismissed by tapping the barrier.');
   });
 }
 

--- a/packages/flutter/test/widgets/semantics_4_test.dart
+++ b/packages/flutter/test/widgets/semantics_4_test.dart
@@ -22,25 +22,27 @@ void main() {
     //
     await tester.pumpWidget(
       new Stack(
+        sizing: StackFit.expand,
         children: <Widget>[
           const Semantics(
-            label: 'L1'
+            label: 'L1',
           ),
           new Semantics(
             label: 'L2',
             child: new Stack(
+              sizing: StackFit.expand,
               children: <Widget>[
                 const Semantics(
-                  checked: true
+                  checked: true,
                 ),
                 const Semantics(
-                  checked: false
-                )
-              ]
-            )
-          )
-        ]
-      )
+                  checked: false,
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
     );
 
     expect(semantics, hasSemantics(
@@ -76,23 +78,25 @@ void main() {
     //
     await tester.pumpWidget(
       new Stack(
+        sizing: StackFit.expand,
         children: <Widget>[
           const Semantics(
-            label: 'L1'
+            label: 'L1',
           ),
           new Semantics(
             label: 'L2',
             child: new Stack(
+              sizing: StackFit.expand,
               children: <Widget>[
                 const Semantics(
-                  checked: true
+                  checked: true,
                 ),
-                const Semantics()
-              ]
-            )
-          )
-        ]
-      )
+                const Semantics(),
+              ],
+            ),
+          ),
+        ],
+      ),
     );
 
     expect(semantics, hasSemantics(
@@ -118,21 +122,23 @@ void main() {
     //
     await tester.pumpWidget(
       new Stack(
+        sizing: StackFit.expand,
         children: <Widget>[
           const Semantics(),
           new Semantics(
             label: 'L2',
             child: new Stack(
+              sizing: StackFit.expand,
               children: <Widget>[
                 const Semantics(
-                  checked: true
+                  checked: true,
                 ),
-                const Semantics()
-              ]
-            )
-          )
-        ]
-      )
+                const Semantics(),
+              ],
+            ),
+          ),
+        ],
+      ),
     );
 
     expect(semantics, hasSemantics(

--- a/packages/flutter/test/widgets/semantics_5_test.dart
+++ b/packages/flutter/test/widgets/semantics_5_test.dart
@@ -14,16 +14,17 @@ void main() {
 
     await tester.pumpWidget(
       new Stack(
+        sizing: StackFit.expand,
         children: <Widget>[
           const Semantics(
             // this tests that empty nodes disappear
           ),
           const Semantics(
             // this tests whether you can have a container with no other semantics
-            container: true
+            container: true,
           ),
           const Semantics(
-            label: 'label' // (force a fork)
+            label: 'label', // (force a fork)
           ),
         ]
       )

--- a/packages/flutter/test/widgets/semantics_7_test.dart
+++ b/packages/flutter/test/widgets/semantics_7_test.dart
@@ -19,6 +19,7 @@ void main() {
     label = '1';
     await tester.pumpWidget(
       new Stack(
+        sizing: StackFit.expand,
         children: <Widget>[
           new MergeSemantics(
             child: new Semantics(
@@ -26,19 +27,20 @@ void main() {
               container: true,
               child: new Semantics(
                 container: true,
-                label: label
+                label: label,
               )
             )
           ),
           new MergeSemantics(
             child: new Stack(
+              sizing: StackFit.expand,
               children: <Widget>[
                 const Semantics(
-                  checked: true
+                  checked: true,
                 ),
                 new Semantics(
-                  label: label
-                )
+                  label: label,
+                ),
               ]
             )
           ),
@@ -69,6 +71,7 @@ void main() {
     label = '2';
     await tester.pumpWidget(
       new Stack(
+        sizing: StackFit.expand,
         children: <Widget>[
           new MergeSemantics(
             child: new Semantics(
@@ -76,18 +79,19 @@ void main() {
               container: true,
               child: new Semantics(
                 container: true,
-                label: label
+                label: label,
               )
             )
           ),
           new MergeSemantics(
             child: new Stack(
+              sizing: StackFit.expand,
               children: <Widget>[
                 const Semantics(
-                  checked: true
+                  checked: true,
                 ),
                 new Semantics(
-                  label: label
+                  label: label,
                 )
               ]
             )

--- a/packages/flutter/test/widgets/semantics_tester.dart
+++ b/packages/flutter/test/widgets/semantics_tester.dart
@@ -44,6 +44,8 @@ class TestSemantics {
   final String label;
 
   /// The bounding box for this node in its coordinate system.
+  ///
+  /// Defaults to filling the screen.
   final Rect rect;
 
   /// The transform from this node's coordinate system to its parent's coordinate system.
@@ -62,7 +64,7 @@ class TestSemantics {
       actions: actions,
       label: label,
       rect: rect,
-      transform: transform
+      transform: transform,
     );
   }
 

--- a/packages/flutter/test/widgets/stack_test.dart
+++ b/packages/flutter/test/widgets/stack_test.dart
@@ -343,4 +343,70 @@ void main() {
     box.paint(context, Offset.zero);
     expect(context.invocations.first.memberName, equals(#paintChild));
   });
+
+  testWidgets('Stack sizing: default', (WidgetTester tester) async {
+    final List<String> logs = <String>[];
+    await tester.pumpWidget(
+      new Center(
+        child: new ConstrainedBox(
+          constraints: const BoxConstraints(
+            minWidth: 2.0,
+            maxWidth: 3.0,
+            minHeight: 5.0,
+            maxHeight: 7.0,
+          ),
+          child: new Stack(
+            children: <Widget>[
+              new LayoutBuilder(
+                builder: (BuildContext context, BoxConstraints constraints) {
+                  logs.add(constraints.toString());
+                  return const Placeholder();
+                },
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+    expect(logs, <String>['BoxConstraints(0.0<=w<=3.0, 0.0<=h<=7.0)']);
+  });
+
+  testWidgets('Stack sizing: explicit', (WidgetTester tester) async {
+    final List<String> logs = <String>[];
+    Widget buildStack(StackFit sizing) {
+      return new Center(
+        child: new ConstrainedBox(
+          constraints: const BoxConstraints(
+            minWidth: 2.0,
+            maxWidth: 3.0,
+            minHeight: 5.0,
+            maxHeight: 7.0,
+          ),
+          child: new Stack(
+            sizing: sizing,
+            children: <Widget>[
+              new LayoutBuilder(
+                builder: (BuildContext context, BoxConstraints constraints) {
+                  logs.add(constraints.toString());
+                  return const Placeholder();
+                },
+              ),
+            ],
+          ),
+        ),
+      );
+    }
+    await tester.pumpWidget(buildStack(StackFit.loose));
+    logs.add('=1=');
+    await tester.pumpWidget(buildStack(StackFit.expand));
+    logs.add('=2=');
+    await tester.pumpWidget(buildStack(StackFit.passthrough));
+    expect(logs, <String>[
+      'BoxConstraints(0.0<=w<=3.0, 0.0<=h<=7.0)',
+      '=1=',
+      'BoxConstraints(w=3.0, h=7.0)',
+      '=2=',
+      'BoxConstraints(2.0<=w<=3.0, 5.0<=h<=7.0)'
+    ]);
+  });
 }


### PR DESCRIPTION
Also:

 * Add three explicit sizing modes to Stack for non-positioned
   children: loose, expand, and passthrough. (All three are used.)

 * Fix a bug whereby layers would try to paint in the same frame as
   they were removed from layout (but not detached).

 * Fix a bug whereby Offstage wasn't properly marking the parent dirty
   when changing its sizedByParent flag.

 * Explicitly make Overlay expand non-positioned children.

 * Explicitly have InputDecoration pass through the constraints from
   its Row to its Stack children.