### PR TITLE
[flutter_tools] Run and reload multiple devices with -d all

### DIFF
--- a/packages/flutter_tools/lib/src/commands/daemon.dart
+++ b/packages/flutter_tools/lib/src/commands/daemon.dart
@@ -353,11 +353,13 @@ class AppDomain extends Domain {
     final Directory cwd = fs.currentDirectory;
     fs.currentDirectory = fs.directory(projectDirectory);
 
+    final FlutterDevice flutterDevice = new FlutterDevice(device);
+
     ResidentRunner runner;
 
     if (enableHotReload) {
       runner = new HotRunner(
-        device,
+        <FlutterDevice>[flutterDevice],
         target: target,
         debuggingOptions: options,
         usesTerminalUI: false,
@@ -368,7 +370,7 @@ class AppDomain extends Domain {
       );
     } else {
       runner = new ColdRunner(
-        device,
+        <FlutterDevice>[flutterDevice],
         target: target,
         debuggingOptions: options,
         usesTerminalUI: false,
@@ -448,7 +450,7 @@ class AppDomain extends Domain {
     if (app == null)
       throw "app '$appId' not found";
 
-    final Isolate isolate = app.runner.currentView.uiIsolate;
+    final Isolate isolate = app.runner.flutterDevices.first.views.first.uiIsolate;
     final Map<String, dynamic> result = await isolate.invokeFlutterExtensionRpcRaw(methodName, params: params);
     if (result == null)
       return new OperationResult(1, 'method not available: $methodName');

--- a/packages/flutter_tools/lib/src/device.dart
+++ b/packages/flutter_tools/lib/src/device.dart
@@ -32,10 +32,25 @@ class DeviceManager {
 
   final List<DeviceDiscovery> _deviceDiscoverers = <DeviceDiscovery>[];
 
-  /// A user-specified device ID.
-  String specifiedDeviceId;
+  String _specifiedDeviceId;
 
+  /// A user-specified device ID.
+  String get specifiedDeviceId {
+    if (_specifiedDeviceId == null || _specifiedDeviceId == 'all')
+      return null;
+    return _specifiedDeviceId;
+  }
+
+  set specifiedDeviceId(String id) {
+    _specifiedDeviceId = id;
+  }
+
+  /// True when the user has specified a single specific device.
   bool get hasSpecifiedDeviceId => specifiedDeviceId != null;
+
+  /// True when the user has specified all devices by setting
+  /// specifiedDeviceId = 'all'.
+  bool get hasSpecifiedAllDevices => _specifiedDeviceId == 'all';
 
   Stream<Device> getDevicesById(String deviceId) async* {
     final Stream<Device> devices = getAllConnectedDevices();

--- a/packages/flutter_tools/test/src/context.dart
+++ b/packages/flutter_tools/test/src/context.dart
@@ -127,11 +127,27 @@ class MockPortScanner extends PortScanner {
 class MockDeviceManager implements DeviceManager {
   List<Device> devices = <Device>[];
 
+  String _specifiedDeviceId;
+
   @override
-  String specifiedDeviceId;
+  String get specifiedDeviceId {
+    if (_specifiedDeviceId == null || _specifiedDeviceId == 'all')
+      return null;
+    return _specifiedDeviceId;
+  }
+
+  @override
+  set specifiedDeviceId(String id) {
+    _specifiedDeviceId = id;
+  }
 
   @override
   bool get hasSpecifiedDeviceId => specifiedDeviceId != null;
+
+  @override
+  bool get hasSpecifiedAllDevices {
+    return _specifiedDeviceId != null && _specifiedDeviceId == 'all';
+  }
 
   @override
   Stream<Device> getAllConnectedDevices() => new Stream<Device>.fromIterable(devices);


### PR DESCRIPTION
This CL adds a class RunningDevice in resident_runner.dart that aggregates information that we have about a running device, i.e. Device, Observatory URIs, VM Service connections, DevFS, and ApplicationPackage. When -d all is specified for the run command, instead of accepting only a single device, the HotRunner and ColdRunner accept a list of RunningDevices.