### PR TITLE
Switch many `Device` methods to be async

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_device.dart
+++ b/packages/flutter_tools/lib/src/android/android_device.dart
@@ -108,7 +108,8 @@ class AndroidDevice extends Device {
   }
 
   @override
-  String get sdkNameAndVersion => 'Android $_sdkVersion (API $_apiVersion)';
+  Future<String> get sdkNameAndVersion async =>
+      'Android ${await _sdkVersion} (API ${await _apiVersion})';
 
   Future<String> get _sdkVersion => _getProperty('ro.build.version.release');
 

--- a/packages/flutter_tools/lib/src/base/process.dart
+++ b/packages/flutter_tools/lib/src/base/process.dart
@@ -250,16 +250,6 @@ String runCheckedSync(List<String> cmd, {
   );
 }
 
-/// Run cmd and return stdout on success.
-///
-/// Throws the standard error output if cmd exits with a non-zero value.
-String runSyncAndThrowStdErrOnError(List<String> cmd) {
-  return _runWithLoggingSync(cmd,
-                             checked: true,
-                             throwStandardErrorOnError: true,
-                             hideStdout: true);
-}
-
 /// Run cmd and return stdout.
 String runSync(List<String> cmd, {
   String workingDirectory,

--- a/packages/flutter_tools/lib/src/base/process.dart
+++ b/packages/flutter_tools/lib/src/base/process.dart
@@ -221,6 +221,15 @@ bool exitsHappy(List<String> cli) {
   }
 }
 
+Future<bool> exitsHappyAsync(List<String> cli) async {
+  _traceCommand(cli);
+  try {
+    return (await processManager.run(cli)).exitCode == 0;
+  } catch (error) {
+    return false;
+  }
+}
+
 /// Run cmd and return stdout.
 ///
 /// Throws an error if cmd exits with a non-zero value.

--- a/packages/flutter_tools/lib/src/commands/build_aot.dart
+++ b/packages/flutter_tools/lib/src/commands/build_aot.dart
@@ -273,24 +273,24 @@ Future<String> _buildAotSnapshot(
     final List<String> commonBuildOptions = <String>['-arch', 'arm64', '-miphoneos-version-min=8.0'];
 
     if (interpreter) {
-      runCheckedSync(<String>['mv', vmSnapshotData, fs.path.join(outputDir.path, kVmSnapshotData)]);
-      runCheckedSync(<String>['mv', isolateSnapshotData, fs.path.join(outputDir.path, kIsolateSnapshotData)]);
+      await runCheckedAsync(<String>['mv', vmSnapshotData, fs.path.join(outputDir.path, kVmSnapshotData)]);
+      await runCheckedAsync(<String>['mv', isolateSnapshotData, fs.path.join(outputDir.path, kIsolateSnapshotData)]);
 
-      runCheckedSync(<String>[
+      await runCheckedAsync(<String>[
         'xxd', '--include', kVmSnapshotData, fs.path.basename(kVmSnapshotDataC)
       ], workingDirectory: outputDir.path);
-      runCheckedSync(<String>[
+      await runCheckedAsync(<String>[
         'xxd', '--include', kIsolateSnapshotData, fs.path.basename(kIsolateSnapshotDataC)
       ], workingDirectory: outputDir.path);
 
-      runCheckedSync(<String>['xcrun', 'cc']
+      await runCheckedAsync(<String>['xcrun', 'cc']
         ..addAll(commonBuildOptions)
         ..addAll(<String>['-c', kVmSnapshotDataC, '-o', kVmSnapshotDataO]));
-      runCheckedSync(<String>['xcrun', 'cc']
+      await runCheckedAsync(<String>['xcrun', 'cc']
         ..addAll(commonBuildOptions)
         ..addAll(<String>['-c', kIsolateSnapshotDataC, '-o', kIsolateSnapshotDataO]));
     } else {
-      runCheckedSync(<String>['xcrun', 'cc']
+      await runCheckedAsync(<String>['xcrun', 'cc']
         ..addAll(commonBuildOptions)
         ..addAll(<String>['-c', assembly, '-o', assemblyO]));
     }
@@ -313,7 +313,7 @@ Future<String> _buildAotSnapshot(
     } else {
       linkCommand.add(assemblyO);
     }
-    runCheckedSync(linkCommand);
+    await runCheckedAsync(linkCommand);
   }
 
   return outputPath;

--- a/packages/flutter_tools/lib/src/commands/config.dart
+++ b/packages/flutter_tools/lib/src/commands/config.dart
@@ -44,7 +44,7 @@ class ConfigCommand extends FlutterCommand {
 
   /// Return `null` to disable tracking of the `config` command.
   @override
-  String get usagePath => null;
+  Future<String> get usagePath async => null;
 
   @override
   Future<Null> runCommand() async {

--- a/packages/flutter_tools/lib/src/commands/config.dart
+++ b/packages/flutter_tools/lib/src/commands/config.dart
@@ -44,7 +44,7 @@ class ConfigCommand extends FlutterCommand {
 
   /// Return `null` to disable tracking of the `config` command.
   @override
-  Future<String> get usagePath async => null;
+  Future<String> get usagePath => null;
 
   @override
   Future<Null> runCommand() async {

--- a/packages/flutter_tools/lib/src/commands/devices.dart
+++ b/packages/flutter_tools/lib/src/commands/devices.dart
@@ -27,7 +27,7 @@ class DevicesCommand extends FlutterCommand {
         exitCode: 1);
     }
 
-    final List<Device> devices = await deviceManager.getAllConnectedDevices();
+    final List<Device> devices = await deviceManager.getAllConnectedDevices().toList();
 
     if (devices.isEmpty) {
       printStatus(
@@ -36,7 +36,7 @@ class DevicesCommand extends FlutterCommand {
         'potential issues, or visit https://flutter.io/setup/ for troubleshooting tips.');
     } else {
       printStatus('${devices.length} connected ${pluralize('device', devices.length)}:\n');
-      Device.printDevices(devices);
+      await Device.printDevices(devices);
     }
   }
 }

--- a/packages/flutter_tools/lib/src/commands/install.dart
+++ b/packages/flutter_tools/lib/src/commands/install.dart
@@ -31,7 +31,7 @@ class InstallCommand extends FlutterCommand {
 
   @override
   Future<Null> runCommand() async {
-    final ApplicationPackage package = applicationPackages.getPackageForPlatform(device.targetPlatform);
+    final ApplicationPackage package = applicationPackages.getPackageForPlatform(await device.targetPlatform);
 
     Cache.releaseLockEarly();
 
@@ -46,9 +46,9 @@ Future<bool> installApp(Device device, ApplicationPackage package, { bool uninst
   if (package == null)
     return false;
 
-  if (uninstall && device.isAppInstalled(package)) {
+  if (uninstall && await device.isAppInstalled(package)) {
     printStatus('Uninstalling old version...');
-    if (!device.uninstallApp(package))
+    if (!await device.uninstallApp(package))
       printError('Warning: uninstalling old version failed');
   }
 

--- a/packages/flutter_tools/lib/src/commands/run.dart
+++ b/packages/flutter_tools/lib/src/commands/run.dart
@@ -153,14 +153,14 @@ class RunCommand extends RunCommandBase {
   Device device;
 
   @override
-  String get usagePath {
+  Future<String> get usagePath async {
     final String command = shouldUseHotMode() ? 'hotrun' : name;
 
     if (device == null)
       return command;
 
     // Return 'run/ios'.
-    return '$command/${getNameForTargetPlatform(device.targetPlatform)}';
+    return '$command/${getNameForTargetPlatform(await device.targetPlatform)}';
   }
 
   @override
@@ -249,7 +249,7 @@ class RunCommand extends RunCommandBase {
       return null;
     }
 
-    if (device.isLocalEmulator && !isEmulatorBuildMode(getBuildMode()))
+    if (await device.isLocalEmulator && !isEmulatorBuildMode(getBuildMode()))
       throwToolExit('${toTitleCase(getModeName(getBuildMode()))} mode is not supported for emulators.');
 
     if (hotMode) {

--- a/packages/flutter_tools/lib/src/commands/stop.dart
+++ b/packages/flutter_tools/lib/src/commands/stop.dart
@@ -31,9 +31,10 @@ class StopCommand extends FlutterCommand {
 
   @override
   Future<Null> runCommand() async {
-    final ApplicationPackage app = applicationPackages.getPackageForPlatform(device.targetPlatform);
+    final TargetPlatform targetPlatform = await device.targetPlatform;
+    final ApplicationPackage app = applicationPackages.getPackageForPlatform(targetPlatform);
     if (app == null) {
-      final String platformName = getNameForTargetPlatform(device.targetPlatform);
+      final String platformName = getNameForTargetPlatform(targetPlatform);
       throwToolExit('No Flutter application for $platformName found in the current directory.');
     }
     printStatus('Stopping apps on ${device.name}.');

--- a/packages/flutter_tools/lib/src/commands/upgrade.dart
+++ b/packages/flutter_tools/lib/src/commands/upgrade.dart
@@ -28,7 +28,7 @@ class UpgradeCommand extends FlutterCommand {
   @override
   Future<Null> runCommand() async {
     try {
-      runCheckedSync(<String>[
+      await runCheckedAsync(<String>[
         'git', 'rev-parse', '@{u}'
       ], workingDirectory: Cache.flutterRoot);
     } catch (e) {

--- a/packages/flutter_tools/lib/src/device.dart
+++ b/packages/flutter_tools/lib/src/device.dart
@@ -37,42 +37,40 @@ class DeviceManager {
 
   bool get hasSpecifiedDeviceId => specifiedDeviceId != null;
 
-  /// Return the devices with a name or id matching [deviceId].
-  /// This does a case insentitive compare with [deviceId].
-  Future<List<Device>> getDevicesById(String deviceId) async {
+  Stream<Device> getDevicesById(String deviceId) async* {
+    final Stream<Device> devices = getAllConnectedDevices();
     deviceId = deviceId.toLowerCase();
-    final List<Device> devices = await getAllConnectedDevices();
-    final Device device = devices.firstWhere(
-        (Device device) =>
-            device.id.toLowerCase() == deviceId ||
-            device.name.toLowerCase() == deviceId,
-        orElse: () => null);
+    bool exactlyMatchesDeviceId(Device device) =>
+        device.id.toLowerCase() == deviceId ||
+        device.name.toLowerCase() == deviceId;
+    bool startsWithDeviceId(Device device) =>
+        device.id.toLowerCase().startsWith(deviceId) ||
+        device.name.toLowerCase().startsWith(deviceId);
 
-    if (device != null)
-      return <Device>[device];
+    final Device exactMatch = await devices.firstWhere(
+        exactlyMatchesDeviceId, defaultValue: () => null);
+    if (exactMatch != null) {
+      yield exactMatch;
+      return;
+    }
 
     // Match on a id or name starting with [deviceId].
-    return devices.where((Device device) {
-      return (device.id.toLowerCase().startsWith(deviceId) ||
-        device.name.toLowerCase().startsWith(deviceId));
-    }).toList();
+    await for (Device device in devices.where(startsWithDeviceId))
+      yield device;
   }
 
   /// Return the list of connected devices, filtered by any user-specified device id.
-  Future<List<Device>> getDevices() async {
-    if (specifiedDeviceId == null) {
-      return getAllConnectedDevices();
-    } else {
-      return getDevicesById(specifiedDeviceId);
-    }
+  Stream<Device> getDevices() {
+    return hasSpecifiedDeviceId
+        ? getDevicesById(specifiedDeviceId)
+        : getAllConnectedDevices();
   }
 
   /// Return the list of all connected devices.
-  Future<List<Device>> getAllConnectedDevices() async {
-    return _deviceDiscoverers
+  Stream<Device> getAllConnectedDevices() {
+    return new Stream<Device>.fromIterable(_deviceDiscoverers
       .where((DeviceDiscovery discoverer) => discoverer.supportsPlatform)
-      .expand((DeviceDiscovery discoverer) => discoverer.devices)
-      .toList();
+      .expand((DeviceDiscovery discoverer) => discoverer.devices));
   }
 }
 
@@ -141,19 +139,19 @@ abstract class Device {
   bool get supportsStartPaused => true;
 
   /// Whether it is an emulated device running on localhost.
-  bool get isLocalEmulator;
+  Future<bool> get isLocalEmulator;
 
   /// Check if a version of the given app is already installed
-  bool isAppInstalled(ApplicationPackage app);
+  Future<bool> isAppInstalled(ApplicationPackage app);
 
   /// Check if the latest build of the [app] is already installed.
-  bool isLatestBuildInstalled(ApplicationPackage app);
+  Future<bool> isLatestBuildInstalled(ApplicationPackage app);
 
   /// Install an app package on the current device
   Future<bool> installApp(ApplicationPackage app);
 
   /// Uninstall an app package from the current device
-  bool uninstallApp(ApplicationPackage app);
+  Future<bool> uninstallApp(ApplicationPackage app);
 
   /// Check if the device is supported by Flutter
   bool isSupported();
@@ -162,7 +160,8 @@ abstract class Device {
   // supported by Flutter, and, if not, why.
   String supportMessage() => isSupported() ? "Supported" : "Unsupported";
 
-  TargetPlatform get targetPlatform;
+  /// The device's platform.
+  Future<TargetPlatform> get targetPlatform;
 
   String get sdkNameAndVersion;
 
@@ -238,22 +237,23 @@ abstract class Device {
   @override
   String toString() => name;
 
-  static Iterable<String> descriptions(List<Device> devices) {
+  static Stream<String> descriptions(List<Device> devices) async* {
     if (devices.isEmpty)
-      return <String>[];
+      return;
 
     // Extract device information
     final List<List<String>> table = <List<String>>[];
     for (Device device in devices) {
       String supportIndicator = device.isSupported() ? '' : ' (unsupported)';
-      if (device.isLocalEmulator) {
-        final String type = device.targetPlatform == TargetPlatform.ios ? 'simulator' : 'emulator';
+      final TargetPlatform targetPlatform = await device.targetPlatform;
+      if (await device.isLocalEmulator) {
+        final String type = targetPlatform == TargetPlatform.ios ? 'simulator' : 'emulator';
         supportIndicator += ' ($type)';
       }
       table.add(<String>[
         device.name,
         device.id,
-        '${getNameForTargetPlatform(device.targetPlatform)}',
+        '${getNameForTargetPlatform(targetPlatform)}',
         '${device.sdkNameAndVersion}$supportIndicator',
       ]);
     }
@@ -266,13 +266,13 @@ abstract class Device {
     }
 
     // Join columns into lines of text
-    return table.map((List<String> row) =>
-        indices.map((int i) => row[i].padRight(widths[i])).join(' • ') +
-        ' • ${row.last}');
+    for (List<String> row in table) {
+      yield indices.map((int i) => row[i].padRight(widths[i])).join(' • ') + ' • ${row.last}';
+    }
   }
 
-  static void printDevices(List<Device> devices) {
-    descriptions(devices).forEach(printStatus);
+  static Future<Null> printDevices(List<Device> devices) async {
+    await descriptions(devices).forEach(printStatus);
   }
 }
 

--- a/packages/flutter_tools/lib/src/device.dart
+++ b/packages/flutter_tools/lib/src/device.dart
@@ -163,7 +163,7 @@ abstract class Device {
   /// The device's platform.
   Future<TargetPlatform> get targetPlatform;
 
-  String get sdkNameAndVersion;
+  Future<String> get sdkNameAndVersion;
 
   /// Get a log reader for this device.
   /// If [app] is specified, this will return a log reader specific to that
@@ -254,7 +254,7 @@ abstract class Device {
         device.name,
         device.id,
         '${getNameForTargetPlatform(targetPlatform)}',
-        '${device.sdkNameAndVersion}$supportIndicator',
+        '${await device.sdkNameAndVersion}$supportIndicator',
       ]);
     }
 

--- a/packages/flutter_tools/lib/src/doctor.dart
+++ b/packages/flutter_tools/lib/src/doctor.dart
@@ -486,12 +486,12 @@ class DeviceValidator extends DoctorValidator {
 
   @override
   Future<ValidationResult> validate() async {
-    final List<Device> devices = await deviceManager.getAllConnectedDevices();
+    final List<Device> devices = await deviceManager.getAllConnectedDevices().toList();
     List<ValidationMessage> messages;
     if (devices.isEmpty) {
       messages = <ValidationMessage>[new ValidationMessage('None')];
     } else {
-      messages = Device.descriptions(devices)
+      messages = await Device.descriptions(devices)
           .map((String msg) => new ValidationMessage(msg)).toList();
     }
     return new ValidationResult(ValidationType.installed, messages);

--- a/packages/flutter_tools/lib/src/fuchsia/fuchsia_device.dart
+++ b/packages/flutter_tools/lib/src/fuchsia/fuchsia_device.dart
@@ -80,7 +80,7 @@ class FuchsiaDevice extends Device {
   Future<TargetPlatform> get targetPlatform async => TargetPlatform.fuchsia;
 
   @override
-  String get sdkNameAndVersion => 'Fuchsia';
+  Future<String> get sdkNameAndVersion async => 'Fuchsia';
 
   _FuchsiaLogReader _logReader;
   @override

--- a/packages/flutter_tools/lib/src/fuchsia/fuchsia_device.dart
+++ b/packages/flutter_tools/lib/src/fuchsia/fuchsia_device.dart
@@ -37,22 +37,22 @@ class FuchsiaDevice extends Device {
   final String name;
 
   @override
-  bool get isLocalEmulator => false;
+  Future<bool> get isLocalEmulator async => false;
 
   @override
   bool get supportsStartPaused => false;
 
   @override
-  bool isAppInstalled(ApplicationPackage app) => false;
+  Future<bool> isAppInstalled(ApplicationPackage app) async => false;
 
   @override
-  bool isLatestBuildInstalled(ApplicationPackage app) => false;
+  Future<bool> isLatestBuildInstalled(ApplicationPackage app) async => false;
 
   @override
   Future<bool> installApp(ApplicationPackage app) => new Future<bool>.value(false);
 
   @override
-  bool uninstallApp(ApplicationPackage app) => false;
+  Future<bool> uninstallApp(ApplicationPackage app) async => false;
 
   @override
   bool isSupported() => true;
@@ -77,7 +77,7 @@ class FuchsiaDevice extends Device {
   }
 
   @override
-  TargetPlatform get targetPlatform => TargetPlatform.fuchsia;
+  Future<TargetPlatform> get targetPlatform async => TargetPlatform.fuchsia;
 
   @override
   String get sdkNameAndVersion => 'Fuchsia';

--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -87,7 +87,7 @@ class IOSDevice extends Device {
   _IOSDevicePortForwarder _portForwarder;
 
   @override
-  bool get isLocalEmulator => false;
+  Future<bool> get isLocalEmulator async => false;
 
   @override
   bool get supportsStartPaused => false;
@@ -139,10 +139,10 @@ class IOSDevice extends Device {
   }
 
   @override
-  bool isAppInstalled(ApplicationPackage app) {
+  Future<bool> isAppInstalled(ApplicationPackage app) async {
     try {
-      final String apps = runCheckedSync(<String>[installerPath, '--list-apps']);
-      if (new RegExp(app.id, multiLine: true).hasMatch(apps)) {
+      final RunResult apps = await runCheckedAsync(<String>[installerPath, '--list-apps']);
+      if (new RegExp(app.id, multiLine: true).hasMatch(apps.stdout)) {
         return true;
       }
     } catch (e) {
@@ -152,7 +152,7 @@ class IOSDevice extends Device {
   }
 
   @override
-  bool isLatestBuildInstalled(ApplicationPackage app) => false;
+  Future<bool> isLatestBuildInstalled(ApplicationPackage app) async => false;
 
   @override
   Future<bool> installApp(ApplicationPackage app) async {
@@ -172,9 +172,9 @@ class IOSDevice extends Device {
   }
 
   @override
-  bool uninstallApp(ApplicationPackage app) {
+  Future<bool> uninstallApp(ApplicationPackage app) async {
     try {
-      runCheckedSync(<String>[installerPath, '-U', app.id]);
+      await runCheckedAsync(<String>[installerPath, '-U', app.id]);
       return true;
     } catch (e) {
       return false;
@@ -343,7 +343,7 @@ class IOSDevice extends Device {
   }
 
   @override
-  TargetPlatform get targetPlatform => TargetPlatform.ios;
+  Future<TargetPlatform> get targetPlatform async => TargetPlatform.ios;
 
   @override
   String get sdkNameAndVersion => 'iOS $_sdkVersion ($_buildVersion)';

--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -164,7 +164,7 @@ class IOSDevice extends Device {
     }
 
     try {
-      runCheckedSync(<String>[installerPath, '-i', iosApp.deviceBundlePath]);
+      await runCheckedAsync(<String>[installerPath, '-i', iosApp.deviceBundlePath]);
       return true;
     } catch (e) {
       return false;
@@ -370,8 +370,7 @@ class IOSDevice extends Device {
 
   @override
   Future<Null> takeScreenshot(File outputFile) {
-    runCheckedSync(<String>[screenshotPath, outputFile.path]);
-    return new Future<Null>.value();
+    return runCheckedAsync(<String>[screenshotPath, outputFile.path]);
   }
 }
 

--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -346,7 +346,7 @@ class IOSDevice extends Device {
   Future<TargetPlatform> get targetPlatform async => TargetPlatform.ios;
 
   @override
-  String get sdkNameAndVersion => 'iOS $_sdkVersion ($_buildVersion)';
+  Future<String> get sdkNameAndVersion async => 'iOS $_sdkVersion ($_buildVersion)';
 
   String get _sdkVersion => _getDeviceInfo(id, 'ProductVersion');
 

--- a/packages/flutter_tools/lib/src/ios/ios_workflow.dart
+++ b/packages/flutter_tools/lib/src/ios/ios_workflow.dart
@@ -165,7 +165,7 @@ class IOSWorkflow extends DoctorValidator implements Workflow {
         // Check for compatibility between libimobiledevice and Xcode.
         // TODO(cbracken) remove this check once libimobiledevice > 1.2.0 is released.
         final ProcessResult result = (await runAsync(<String>['idevice_id', '-l'])).processResult;
-        if (result.exitCode == 0 && result.stdout.isNotEmpty && !exitsHappy(<String>['ideviceName'])) {
+        if (result.exitCode == 0 && result.stdout.isNotEmpty && !await exitsHappyAsync(<String>['ideviceName'])) {
           brewStatus = ValidationType.partial;
           messages.add(new ValidationMessage.error(
             'libimobiledevice is incompatible with the installed Xcode version. To update, run:\n'

--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -399,7 +399,7 @@ Future<Null> _copyServiceFrameworks(List<Map<String, String>> services, Director
       continue;
     }
     // Shell out so permissions on the dylib are preserved.
-    runCheckedSync(<String>['/bin/cp', dylib.path, frameworksDirectory.path]);
+    await runCheckedAsync(<String>['/bin/cp', dylib.path, frameworksDirectory.path]);
   }
 }
 

--- a/packages/flutter_tools/lib/src/ios/simulators.dart
+++ b/packages/flutter_tools/lib/src/ios/simulators.dart
@@ -224,8 +224,8 @@ class SimControl {
 
   bool _isAnyConnected() => getConnectedDevices().isNotEmpty;
 
-  bool isInstalled(String appId) {
-    return exitsHappy(<String>[
+  Future<bool> isInstalled(String appId) {
+    return exitsHappyAsync(<String>[
       _xcrunPath,
       'simctl',
       'get_app_container',
@@ -234,23 +234,23 @@ class SimControl {
     ]);
   }
 
-  void install(String deviceId, String appPath) {
-    runCheckedSync(<String>[_xcrunPath, 'simctl', 'install', deviceId, appPath]);
+  Future<Null> install(String deviceId, String appPath) {
+    return runCheckedAsync(<String>[_xcrunPath, 'simctl', 'install', deviceId, appPath]);
   }
 
-  void uninstall(String deviceId, String appId) {
-    runCheckedSync(<String>[_xcrunPath, 'simctl', 'uninstall', deviceId, appId]);
+  Future<Null> uninstall(String deviceId, String appId) {
+    return runCheckedAsync(<String>[_xcrunPath, 'simctl', 'uninstall', deviceId, appId]);
   }
 
-  void launch(String deviceId, String appIdentifier, [List<String> launchArgs]) {
+  Future<Null> launch(String deviceId, String appIdentifier, [List<String> launchArgs]) {
     final List<String> args = <String>[_xcrunPath, 'simctl', 'launch', deviceId, appIdentifier];
     if (launchArgs != null)
       args.addAll(launchArgs);
-    runCheckedSync(args);
+    return runCheckedAsync(args);
   }
 
-  void takeScreenshot(String outputPath) {
-    runCheckedSync(<String>[_xcrunPath, 'simctl', 'io', 'booted', 'screenshot', outputPath]);
+  Future<Null> takeScreenshot(String outputPath) {
+    return runCheckedAsync(<String>[_xcrunPath, 'simctl', 'io', 'booted', 'screenshot', outputPath]);
   }
 }
 
@@ -313,7 +313,7 @@ class IOSSimulator extends Device {
   final String category;
 
   @override
-  bool get isLocalEmulator => true;
+  Future<bool> get isLocalEmulator async => true;
 
   @override
   bool get supportsHotMode => true;
@@ -335,12 +335,12 @@ class IOSSimulator extends Device {
   }
 
   @override
-  bool isAppInstalled(ApplicationPackage app) {
+  Future<bool> isAppInstalled(ApplicationPackage app) {
     return SimControl.instance.isInstalled(app.id);
   }
 
   @override
-  bool isLatestBuildInstalled(ApplicationPackage app) => false;
+  Future<bool> isLatestBuildInstalled(ApplicationPackage app) async => false;
 
   @override
   Future<bool> installApp(ApplicationPackage app) async {
@@ -354,9 +354,9 @@ class IOSSimulator extends Device {
   }
 
   @override
-  bool uninstallApp(ApplicationPackage app) {
+  Future<bool> uninstallApp(ApplicationPackage app) async {
     try {
-      SimControl.instance.uninstall(id, app.id);
+      await SimControl.instance.uninstall(id, app.id);
       return true;
     } catch (e) {
       return false;
@@ -495,21 +495,18 @@ class IOSSimulator extends Device {
     }
   }
 
-  bool _applicationIsInstalledAndRunning(ApplicationPackage app) {
-    final bool isInstalled = isAppInstalled(app);
-
-    final bool isRunning = exitsHappy(<String>[
-      '/usr/bin/killall',
-      'Runner',
+  Future<bool> _applicationIsInstalledAndRunning(ApplicationPackage app) async {
+    final List<bool> criteria = await Future.wait(<Future<bool>>[
+      isAppInstalled(app),
+      exitsHappyAsync(<String>['/usr/bin/killall', 'Runner']),
     ]);
-
-    return isInstalled && isRunning;
+    return criteria.reduce((bool a, bool b) => a && b);
   }
 
   Future<Null> _setupUpdatedApplicationBundle(ApplicationPackage app) async {
     await _sideloadUpdatedAssetsForInstalledApplicationBundle(app);
 
-    if (!_applicationIsInstalledAndRunning(app))
+    if (!await _applicationIsInstalledAndRunning(app))
       return _buildAndInstallApplicationBundle(app);
   }
 
@@ -555,7 +552,7 @@ class IOSSimulator extends Device {
   }
 
   @override
-  TargetPlatform get targetPlatform => TargetPlatform.ios;
+  Future<TargetPlatform> get targetPlatform async => TargetPlatform.ios;
 
   @override
   String get sdkNameAndVersion => category;

--- a/packages/flutter_tools/lib/src/ios/simulators.dart
+++ b/packages/flutter_tools/lib/src/ios/simulators.dart
@@ -592,8 +592,7 @@ class IOSSimulator extends Device {
 
   @override
   Future<Null> takeScreenshot(File outputFile) {
-    SimControl.instance.takeScreenshot(outputFile.path);
-    return new Future<Null>.value();
+    return SimControl.instance.takeScreenshot(outputFile.path);
   }
 }
 

--- a/packages/flutter_tools/lib/src/ios/simulators.dart
+++ b/packages/flutter_tools/lib/src/ios/simulators.dart
@@ -555,7 +555,7 @@ class IOSSimulator extends Device {
   Future<TargetPlatform> get targetPlatform async => TargetPlatform.ios;
 
   @override
-  String get sdkNameAndVersion => category;
+  Future<String> get sdkNameAndVersion async => category;
 
   @override
   DeviceLogReader getLogReader({ApplicationPackage app}) {

--- a/packages/flutter_tools/lib/src/ios/simulators.dart
+++ b/packages/flutter_tools/lib/src/ios/simulators.dart
@@ -541,7 +541,7 @@ class IOSSimulator extends Device {
       ApplicationPackage app, String localFile, String targetFile) async {
     if (platform.isMacOS) {
       final String simulatorHomeDirectory = _getSimulatorAppHomeDirectory(app);
-      runCheckedSync(<String>['cp', localFile, fs.path.join(simulatorHomeDirectory, targetFile)]);
+      await runCheckedAsync(<String>['cp', localFile, fs.path.join(simulatorHomeDirectory, targetFile)]);
       return true;
     }
     return false;

--- a/packages/flutter_tools/lib/src/run_cold.dart
+++ b/packages/flutter_tools/lib/src/run_cold.dart
@@ -65,7 +65,7 @@ class ColdRunner extends ResidentRunner {
     package = getApplicationPackageForPlatform(targetPlatform, applicationBinary: applicationBinary);
 
     if (package == null) {
-      String message = 'No application found for ${targetPlatform}.';
+      String message = 'No application found for $targetPlatform.';
       final String hint = getMissingPackageHintForPlatform(targetPlatform);
       if (hint != null)
         message += '\n$hint';

--- a/packages/flutter_tools/lib/src/run_cold.dart
+++ b/packages/flutter_tools/lib/src/run_cold.dart
@@ -61,11 +61,12 @@ class ColdRunner extends ResidentRunner {
       printStatus('Launching ${getDisplayPath(mainPath)} on ${device.name} in $modeName mode...');
     }
 
-    package = getApplicationPackageForPlatform(device.targetPlatform, applicationBinary: applicationBinary);
+    final TargetPlatform targetPlatform = await device.targetPlatform;
+    package = getApplicationPackageForPlatform(targetPlatform, applicationBinary: applicationBinary);
 
     if (package == null) {
-      String message = 'No application found for ${device.targetPlatform}.';
-      final String hint = getMissingPackageHintForPlatform(device.targetPlatform);
+      String message = 'No application found for ${targetPlatform}.';
+      final String hint = getMissingPackageHintForPlatform(targetPlatform);
       if (hint != null)
         message += '\n$hint';
       printError(message);

--- a/packages/flutter_tools/lib/src/run_hot.dart
+++ b/packages/flutter_tools/lib/src/run_hot.dart
@@ -177,11 +177,12 @@ class HotRunner extends ResidentRunner {
     final String modeName = getModeName(debuggingOptions.buildMode);
     printStatus('Launching ${getDisplayPath(mainPath)} on ${device.name} in $modeName mode...');
 
-    package = getApplicationPackageForPlatform(device.targetPlatform, applicationBinary: applicationBinary);
+    final TargetPlatform targetPlatform = await device.targetPlatform;
+    package = getApplicationPackageForPlatform(targetPlatform, applicationBinary: applicationBinary);
 
     if (package == null) {
-      String message = 'No application found for ${device.targetPlatform}.';
-      final String hint = getMissingPackageHintForPlatform(device.targetPlatform);
+      String message = 'No application found for ${targetPlatform}.';
+      final String hint = getMissingPackageHintForPlatform(targetPlatform);
       if (hint != null)
         message += '\n$hint';
       printError(message);

--- a/packages/flutter_tools/lib/src/run_hot.dart
+++ b/packages/flutter_tools/lib/src/run_hot.dart
@@ -181,7 +181,7 @@ class HotRunner extends ResidentRunner {
     package = getApplicationPackageForPlatform(targetPlatform, applicationBinary: applicationBinary);
 
     if (package == null) {
-      String message = 'No application found for ${targetPlatform}.';
+      String message = 'No application found for $targetPlatform.';
       final String hint = getMissingPackageHintForPlatform(targetPlatform);
       if (hint != null)
         message += '\n$hint';

--- a/packages/flutter_tools/lib/src/usage.dart
+++ b/packages/flutter_tools/lib/src/usage.dart
@@ -4,6 +4,7 @@
 
 import 'dart:async';
 
+import 'package:meta/meta.dart';
 import 'package:usage/usage_io.dart';
 
 import 'base/context.dart';
@@ -96,7 +97,8 @@ class Usage {
       _analytics.sendException('${exception.runtimeType}\n${sanitizeStacktrace(trace)}');
   }
 
-  /// Fires whenever analytics data is sent over the network; public for testing.
+  /// Fires whenever analytics data is sent over the network.
+  @visibleForTesting
   Stream<Map<String, dynamic>> get onSend => _analytics.onSend;
 
   /// Returns when the last analytics event has been sent, or after a fixed

--- a/packages/flutter_tools/lib/src/zip.dart
+++ b/packages/flutter_tools/lib/src/zip.dart
@@ -86,7 +86,7 @@ class _ZipToolBuilder extends ZipBuilder {
 
     final Iterable<String> compressedNames = _getCompressedNames();
     if (compressedNames.isNotEmpty) {
-      runCheckedSync(
+      await runCheckedAsync(
         <String>['zip', '-q', outFile.absolute.path]..addAll(compressedNames),
         workingDirectory: zipBuildDir.path
       );
@@ -94,7 +94,7 @@ class _ZipToolBuilder extends ZipBuilder {
 
     final Iterable<String> storedNames = _getStoredNames();
     if (storedNames.isNotEmpty) {
-      runCheckedSync(
+      await runCheckedAsync(
         <String>['zip', '-q', '-0', outFile.absolute.path]..addAll(storedNames),
         workingDirectory: zipBuildDir.path
       );

--- a/packages/flutter_tools/test/analytics_test.dart
+++ b/packages/flutter_tools/test/analytics_test.dart
@@ -56,7 +56,7 @@ void main() {
       Usage: () => new Usage(),
     });
 
-    // Ensure we con't send for the 'flutter config' command.
+    // Ensure we don't send for the 'flutter config' command.
     testUsingContext('config doesn\'t send', () async {
       int count = 0;
       flutterUsage.onSend.listen((Map<String, dynamic> data) => count++);

--- a/packages/flutter_tools/test/device_test.dart
+++ b/packages/flutter_tools/test/device_test.dart
@@ -14,7 +14,7 @@ void main() {
     testUsingContext('getDevices', () async {
       // Test that DeviceManager.getDevices() doesn't throw.
       final DeviceManager deviceManager = new DeviceManager();
-      final List<Device> devices = await deviceManager.getDevices();
+      final List<Device> devices = await deviceManager.getDevices().toList();
       expect(devices, isList);
     });
 
@@ -26,7 +26,7 @@ void main() {
       final DeviceManager deviceManager = new TestDeviceManager(devices);
 
       Future<Null> expectDevice(String id, List<Device> expected) async {
-        expect(await deviceManager.getDevicesById(id), expected);
+        expect(await deviceManager.getDevicesById(id).toList(), expected);
       }
       expectDevice('01abfc49119c410e', <Device>[device2]);
       expectDevice('Nexus 5X', <Device>[device2]);
@@ -44,8 +44,8 @@ class TestDeviceManager extends DeviceManager {
   TestDeviceManager(this.allDevices);
 
   @override
-  Future<List<Device>> getAllConnectedDevices() async {
-    return allDevices;
+  Stream<Device> getAllConnectedDevices() {
+    return new Stream<Device>.fromIterable(allDevices);
   }
 }
 

--- a/packages/flutter_tools/test/src/context.dart
+++ b/packages/flutter_tools/test/src/context.dart
@@ -134,20 +134,19 @@ class MockDeviceManager implements DeviceManager {
   bool get hasSpecifiedDeviceId => specifiedDeviceId != null;
 
   @override
-  Future<List<Device>> getAllConnectedDevices() => new Future<List<Device>>.value(devices);
+  Stream<Device> getAllConnectedDevices() => new Stream<Device>.fromIterable(devices);
 
   @override
-  Future<List<Device>> getDevicesById(String deviceId) async {
-    return devices.where((Device device) => device.id == deviceId).toList();
+  Stream<Device> getDevicesById(String deviceId) {
+    return new Stream<Device>.fromIterable(
+        devices.where((Device device) => device.id == deviceId));
   }
 
   @override
-  Future<List<Device>> getDevices() async {
-    if (specifiedDeviceId == null) {
-      return getAllConnectedDevices();
-    } else {
-      return getDevicesById(specifiedDeviceId);
-    }
+  Stream<Device> getDevices() {
+    return hasSpecifiedDeviceId
+        ? getDevicesById(specifiedDeviceId)
+        : getAllConnectedDevices();
   }
 
   void addDevice(Device device) => devices.add(device);

--- a/packages/flutter_tools/test/src/ios/devices_test.dart
+++ b/packages/flutter_tools/test/src/ios/devices_test.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:async';
 import 'dart:io' show ProcessResult;
 
 import 'package:file/file.dart';
@@ -38,23 +39,23 @@ void main() {
         // Let everything else return exit code 0 so process.dart doesn't crash.
         // The matcher order is important.
         when(
-          mockProcessManager.runSync(any, environment: null, workingDirectory:  null)
+          mockProcessManager.run(any, environment: null, workingDirectory:  null)
         ).thenReturn(
-          new ProcessResult(2, 0, '', null)
+          new Future<ProcessResult>.value(new ProcessResult(2, 0, '', ''))
         );
         // Let `which idevicescreenshot` fail with exit code 1.
         when(
           mockProcessManager.runSync(
             <String>['which', 'idevicescreenshot'], environment: null, workingDirectory: null)
         ).thenReturn(
-          new ProcessResult(1, 1, '', null)
+          new ProcessResult(1, 1, '', '')
         );
 
         iosDeviceUnderTest = new IOSDevice('1234');
-        iosDeviceUnderTest.takeScreenshot(mockOutputFile);
+        await iosDeviceUnderTest.takeScreenshot(mockOutputFile);
         verify(mockProcessManager.runSync(
           <String>['which', 'idevicescreenshot'], environment: null, workingDirectory: null));
-        verifyNever(mockProcessManager.runSync(
+        verifyNever(mockProcessManager.run(
           <String>['idevicescreenshot', fs.path.join('some', 'test', 'path', 'image.png')],
           environment: null,
           workingDirectory: null
@@ -74,23 +75,23 @@ void main() {
         // Let everything else return exit code 0.
         // The matcher order is important.
         when(
-          mockProcessManager.runSync(any, environment: null, workingDirectory:  null)
+          mockProcessManager.run(any, environment: null, workingDirectory:  null)
         ).thenReturn(
-          new ProcessResult(4, 0, '', null)
+          new Future<ProcessResult>.value(new ProcessResult(4, 0, '', ''))
         );
         // Let there be idevicescreenshot in the PATH.
         when(
           mockProcessManager.runSync(
             <String>['which', 'idevicescreenshot'], environment: null, workingDirectory: null)
         ).thenReturn(
-          new ProcessResult(3, 0, fs.path.join('some', 'path', 'to', 'iscreenshot'), null)
+          new ProcessResult(3, 0, fs.path.join('some', 'path', 'to', 'iscreenshot'), '')
         );
 
         iosDeviceUnderTest = new IOSDevice('1234');
-        iosDeviceUnderTest.takeScreenshot(mockOutputFile);
+        await iosDeviceUnderTest.takeScreenshot(mockOutputFile);
         verify(mockProcessManager.runSync(
           <String>['which', 'idevicescreenshot'], environment: null, workingDirectory: null));
-        verify(mockProcessManager.runSync(
+        verify(mockProcessManager.run(
           <String>[
             fs.path.join('some', 'path', 'to', 'iscreenshot'),
             fs.path.join('some', 'test', 'path', 'image.png')

--- a/packages/flutter_tools/test/src/ios/simulators_test.dart
+++ b/packages/flutter_tools/test/src/ios/simulators_test.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:io' show ProcessResult;
 
 import 'package:file/file.dart';
@@ -128,9 +129,9 @@ void main() {
       mockProcessManager = new MockProcessManager();
       // Let everything else return exit code 0 so process.dart doesn't crash.
       when(
-        mockProcessManager.runSync(any, environment: null, workingDirectory:  null)
+        mockProcessManager.run(any, environment: null, workingDirectory:  null)
       ).thenReturn(
-        new ProcessResult(2, 0, '', null)
+        new Future<ProcessResult>.value(new ProcessResult(2, 0, '', ''))
       );
       // Doesn't matter what the device is.
       deviceUnderTest = new IOSSimulator('x', name: 'iPhone SE');
@@ -148,14 +149,14 @@ void main() {
 
     testUsingContext(
       'Xcode 8.2+ supports screenshots',
-      () {
+      () async {
         when(mockXcode.xcodeMajorVersion).thenReturn(8);
         when(mockXcode.xcodeMinorVersion).thenReturn(2);
         expect(deviceUnderTest.supportsScreenshot, true);
         final MockFile mockFile = new MockFile();
         when(mockFile.path).thenReturn(fs.path.join('some', 'path', 'to', 'screenshot.png'));
-        deviceUnderTest.takeScreenshot(mockFile);
-        verify(mockProcessManager.runSync(
+        await deviceUnderTest.takeScreenshot(mockFile);
+        verify(mockProcessManager.run(
           <String>[
               '/usr/bin/xcrun',
               'simctl',

--- a/packages/flutter_tools/test/src/mocks.dart
+++ b/packages/flutter_tools/test/src/mocks.dart
@@ -31,7 +31,7 @@ class MockApplicationPackageStore extends ApplicationPackageStore {
 
 class MockAndroidDevice extends Mock implements AndroidDevice {
   @override
-  TargetPlatform get targetPlatform => TargetPlatform.android_arm;
+  Future<TargetPlatform> get targetPlatform async => TargetPlatform.android_arm;
 
   @override
   bool isSupported() => true;
@@ -39,7 +39,7 @@ class MockAndroidDevice extends Mock implements AndroidDevice {
 
 class MockIOSDevice extends Mock implements IOSDevice {
   @override
-  TargetPlatform get targetPlatform => TargetPlatform.ios;
+  Future<TargetPlatform> get targetPlatform async => TargetPlatform.ios;
 
   @override
   bool isSupported() => true;
@@ -47,7 +47,7 @@ class MockIOSDevice extends Mock implements IOSDevice {
 
 class MockIOSSimulator extends Mock implements IOSSimulator {
   @override
-  TargetPlatform get targetPlatform => TargetPlatform.ios;
+  Future<TargetPlatform> get targetPlatform async => TargetPlatform.ios;
 
   @override
   bool isSupported() => true;


### PR DESCRIPTION
`adb` can sometimes hang, which will in turn hang the Dart isolate if
we're using `Process.runSync()`. This changes many of the `Device` methods
to return `Future<T>` in order to allow them to use the async process
methods. A future change will add timeouts to the associated calls so
that we can properly alert the user to the hung `adb` process.

This is work towards #7102, #9567