### PR TITLE
Make Flutter plugins usable from a Windows host

### DIFF
--- a/packages/flutter_tools/lib/src/android/gradle.dart
+++ b/packages/flutter_tools/lib/src/android/gradle.dart
@@ -146,8 +146,8 @@ File ensureLocalProperties() {
   final File localProperties = fs.file('android/local.properties');
   if (!localProperties.existsSync()) {
     localProperties.writeAsStringSync(
-        'sdk.dir=${_escapePath(androidSdk.directory)}\n'
-        'flutter.sdk=${_escapePath(Cache.flutterRoot)}\n'
+        'sdk.dir=${escapePath(androidSdk.directory)}\n'
+        'flutter.sdk=${escapePath(Cache.flutterRoot)}\n'
     );
   }
   return localProperties;
@@ -179,8 +179,6 @@ Future<Null> buildGradleProject(BuildMode buildMode, String target, String kerne
       return buildGradleProjectV2(gradle, buildModeName, target, kernelPath);
   }
 }
-
-String _escapePath(String path) => platform.isWindows ? path.replaceAll('\\', '\\\\') : path;
 
 Future<Null> buildGradleProjectV1(String gradle) async {
   // Run 'gradle build'.

--- a/packages/flutter_tools/lib/src/base/file_system.dart
+++ b/packages/flutter_tools/lib/src/base/file_system.dart
@@ -10,6 +10,7 @@ import 'package:file/record_replay.dart';
 
 import 'common.dart' show throwToolExit;
 import 'context.dart';
+import 'platform.dart';
 import 'process.dart';
 
 export 'package:file/file.dart';
@@ -142,3 +143,9 @@ Directory getReplaySource(String dirname, String basename) {
 /// case of the path. Changing the case can break hot reload in some situations,
 /// for an example see: https://github.com/flutter/flutter/issues/9539.
 String canonicalizePath(String path) => fs.path.normalize(fs.path.absolute(path));
+
+/// Escapes [path].
+///
+/// On Windows it replaces all '\' with '\\'. On other platforms, it returns the
+/// path unchanged.
+String escapePath(String path) => platform.isWindows ? path.replaceAll('\\', '\\\\') : path;

--- a/packages/flutter_tools/lib/src/plugins.dart
+++ b/packages/flutter_tools/lib/src/plugins.dart
@@ -29,7 +29,7 @@ class Plugin {
 }
 
 Plugin _pluginFromPubspec(String name, Uri packageRoot) {
-  final String pubspecPath = packageRoot.resolve('pubspec.yaml').path;
+  final String pubspecPath = fs.path.fromUri(packageRoot.resolve('pubspec.yaml'));
   if (!fs.isFileSync(pubspecPath))
     return null;
   final dynamic pubspec = loadYaml(fs.file(pubspecPath).readAsStringSync());
@@ -38,8 +38,9 @@ Plugin _pluginFromPubspec(String name, Uri packageRoot) {
   final dynamic flutterConfig = pubspec['flutter'];
   if (flutterConfig == null || !flutterConfig.containsKey('plugin'))
     return null;
-  printTrace('Found plugin $name at ${packageRoot.path}');
-  return new Plugin.fromYaml(name, packageRoot.path, flutterConfig['plugin']);
+  final String packageRootPath = fs.path.fromUri(packageRoot);
+  printTrace('Found plugin $name at $packageRootPath');
+  return new Plugin.fromYaml(name, packageRootPath, flutterConfig['plugin']);
 }
 
 List<Plugin> _findPlugins(String directory) {
@@ -64,7 +65,7 @@ List<Plugin> _findPlugins(String directory) {
 void _writeFlutterPluginsList(String directory, List<Plugin> plugins) {
   final File pluginsProperties = fs.file(fs.path.join(directory, '.flutter-plugins'));
   final String pluginManifest =
-      plugins.map((Plugin p) => '${p.name}=${p.path}').join('\n');
+    plugins.map((Plugin p) => '${p.name}=${escapePath(p.path)}').join('\n');
   if (pluginManifest.isNotEmpty) {
     pluginsProperties.writeAsStringSync('$pluginManifest\n');
   } else {

--- a/packages/flutter_tools/test/src/base/file_system_test.dart
+++ b/packages/flutter_tools/test/src/base/file_system_test.dart
@@ -4,6 +4,7 @@
 
 import 'package:file/memory.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
+import 'package:platform/platform.dart';
 import 'package:test/test.dart';
 
 import '../common.dart';
@@ -84,5 +85,23 @@ void main() {
       final String expected = fs.path.join(fs.currentDirectory.parent.absolute.path, 'bar', 'Foo');
       expect(canonicalizePath(path), expected);
     }, testOn: 'posix');
+  });
+
+  group('escapePath', () {
+    testUsingContext('on Windows', () {
+      expect(escapePath('C:\\foo\\bar\\cool.dart'), 'C:\\\\foo\\\\bar\\\\cool.dart');
+      expect(escapePath('foo\\bar\\cool.dart'), 'foo\\\\bar\\\\cool.dart');
+      expect(escapePath('C:/foo/bar/cool.dart'), 'C:/foo/bar/cool.dart');
+    }, overrides: <Type, Generator>{
+      Platform: () => new FakePlatform(operatingSystem: 'windows')
+    });
+
+    testUsingContext('on Linux', () {
+      expect(escapePath('/foo/bar/cool.dart'), '/foo/bar/cool.dart');
+      expect(escapePath('foo/bar/cool.dart'), 'foo/bar/cool.dart');
+      expect(escapePath('foo\\cool.dart'), 'foo\\cool.dart');
+    }, overrides: <Type, Generator>{
+      Platform: () => new FakePlatform(operatingSystem: 'linux')
+    });
   });
 }


### PR DESCRIPTION
Note: In a cross-platform context `Uri.path` is not a valid file path. Allways use `fs.path.fromUri` to convert.

Fixes https://github.com/flutter/flutter/issues/9590.