### PR TITLE
Disable AAPT cruncher on Windows for channel integration test

### DIFF
--- a/dev/integration_tests/channels/android/app/build.gradle
+++ b/dev/integration_tests/channels/android/app/build.gradle
@@ -33,6 +33,14 @@ android {
             signingConfig signingConfigs.debug
         }
     }
+
+    aaptOptions {
+        // TODO(goderbauer): remove when https://github.com/flutter/flutter/issues/8986 is resolved.
+        if(System.getenv("FLUTTER_CI_WIN")) {
+            println "AAPT cruncher disabled when running on Win CI."
+            cruncherEnabled false
+        }
+    }
 }
 
 flutter {


### PR DESCRIPTION
It causes the test to be flaky, see https://github.com/flutter/flutter/issues/8986.