### PR TITLE
Fix getDevicesById()

### DIFF
--- a/packages/flutter_tools/lib/src/device.dart
+++ b/packages/flutter_tools/lib/src/device.dart
@@ -62,7 +62,7 @@ class DeviceManager {
         device.id.toLowerCase().startsWith(deviceId) ||
         device.name.toLowerCase().startsWith(deviceId);
 
-    final Device exactMatch = await devices.firstWhere(
+    final Device exactMatch = devices.firstWhere(
         exactlyMatchesDeviceId, orElse: () => null);
     if (exactMatch != null) {
       yield exactMatch;

--- a/packages/flutter_tools/lib/src/device.dart
+++ b/packages/flutter_tools/lib/src/device.dart
@@ -53,7 +53,7 @@ class DeviceManager {
   bool get hasSpecifiedAllDevices => _specifiedDeviceId == 'all';
 
   Stream<Device> getDevicesById(String deviceId) async* {
-    final Stream<Device> devices = getAllConnectedDevices();
+    final List<Device> devices = await getAllConnectedDevices().toList();
     deviceId = deviceId.toLowerCase();
     bool exactlyMatchesDeviceId(Device device) =>
         device.id.toLowerCase() == deviceId ||
@@ -63,14 +63,14 @@ class DeviceManager {
         device.name.toLowerCase().startsWith(deviceId);
 
     final Device exactMatch = await devices.firstWhere(
-        exactlyMatchesDeviceId, defaultValue: () => null);
+        exactlyMatchesDeviceId, orElse: () => null);
     if (exactMatch != null) {
       yield exactMatch;
       return;
     }
 
     // Match on a id or name starting with [deviceId].
-    await for (Device device in devices.where(startsWithDeviceId))
+    for (Device device in devices.where(startsWithDeviceId))
       yield device;
   }
 


### PR DESCRIPTION
If the user specified a non-exact device id, it was producing
an exception whereby we were trying to listen to the
`getAllConnectedDevies()` stream twice.