### PR TITLE
[BREAKING CHANGE] Introduce ImageStyle and DefaultImageStyle

### DIFF
--- a/dev/benchmarks/complex_layout/lib/main.dart
+++ b/dev/benchmarks/complex_layout/lib/main.dart
@@ -353,8 +353,10 @@ class UserHeader extends StatelessWidget {
             padding: const EdgeInsets.only(right: 8.0),
             child: new Image(
               image: new AssetImage('packages/flutter_gallery_assets/ali_connors_sml.png'),
-              width: 32.0,
-              height: 32.0
+              style: const ImageStyle(
+                width: 32.0,
+                height: 32.0
+              )
             )
           ),
           new Expanded(

--- a/examples/flutter_gallery/lib/demo/animation/widgets.dart
+++ b/examples/flutter_gallery/lib/demo/animation/widgets.dart
@@ -35,9 +35,11 @@ class SectionCard extends StatelessWidget {
         ),
         child: new Image.asset(
           section.backgroundAsset,
-          color: const Color.fromRGBO(255, 255, 255, 0.075),
-          colorBlendMode: BlendMode.modulate,
-          fit: BoxFit.cover,
+          style: const ImageStyle(
+            color: const Color.fromRGBO(255, 255, 255, 0.075),
+            colorBlendMode: BlendMode.modulate,
+            fit: BoxFit.cover,
+          ),
         ),
       ),
     );

--- a/examples/flutter_gallery/lib/demo/contacts_demo.dart
+++ b/examples/flutter_gallery/lib/demo/contacts_demo.dart
@@ -155,8 +155,10 @@ class ContactsDemoState extends State<ContactsDemo> {
                   children: <Widget>[
                     new Image.asset(
                       'packages/flutter_gallery_assets/ali_connors.jpg',
-                      fit: BoxFit.cover,
-                      height: _appBarHeight,
+                      style: new ImageStyle(
+                        fit: BoxFit.cover,
+                        height: _appBarHeight,
+                      ),
                     ),
                     // This gradient ensures that the toolbar icons are distinct
                     // against the background image.

--- a/examples/flutter_gallery/lib/demo/material/cards_demo.dart
+++ b/examples/flutter_gallery/lib/demo/material/cards_demo.dart
@@ -65,7 +65,7 @@ class TravelDestinationItem extends StatelessWidget {
                   new Positioned.fill(
                     child: new Image.asset(
                       destination.assetName,
-                      fit: BoxFit.cover,
+                      style: const ImageStyle(fit: BoxFit.cover),
                     ),
                   ),
                   new Positioned(

--- a/examples/flutter_gallery/lib/demo/material/grid_list_demo.dart
+++ b/examples/flutter_gallery/lib/demo/material/grid_list_demo.dart
@@ -130,7 +130,10 @@ class _GridPhotoViewerState extends State<GridPhotoViewer> with SingleTickerProv
           transform: new Matrix4.identity()
             ..translate(_offset.dx, _offset.dy)
             ..scale(_scale),
-          child: new Image.asset(widget.photo.assetName, fit: BoxFit.cover),
+          child: new Image.asset(
+            widget.photo.assetName,
+            style: const ImageStyle(fit: BoxFit.cover),
+          ),
         ),
       ),
     );
@@ -178,7 +181,10 @@ class GridDemoPhotoItem extends StatelessWidget {
       child: new Hero(
         key: new Key(photo.assetName),
         tag: photo.tag,
-        child: new Image.asset(photo.assetName, fit: BoxFit.cover)
+        child: new Image.asset(
+          photo.assetName,
+          style: const ImageStyle(fit: BoxFit.cover),
+        )
       )
     );
 

--- a/examples/flutter_gallery/lib/demo/material/tabs_demo.dart
+++ b/examples/flutter_gallery/lib/demo/material/tabs_demo.dart
@@ -99,7 +99,10 @@ class _CardDataItem extends StatelessWidget {
             new SizedBox(
               width: 144.0,
               height: 144.0,
-              child: new Image.asset(data.imageAsset, fit: BoxFit.contain),
+              child: new Image.asset(
+                data.imageAsset,
+                style: const ImageStyle(fit: BoxFit.contain),
+              ),
             ),
             new Center(
               child: new Text(data.title, style: Theme.of(context).textTheme.title),

--- a/examples/flutter_gallery/lib/demo/pesto_demo.dart
+++ b/examples/flutter_gallery/lib/demo/pesto_demo.dart
@@ -218,7 +218,10 @@ class _PestoLogoState extends State<PestoLogo> {
           children: <Widget>[
             new Positioned.fromRect(
               rect: _imageRectTween.lerp(widget.t),
-              child: new Image.asset(_kSmallLogoImage, fit: BoxFit.contain),
+              child: new Image.asset(
+                _kSmallLogoImage,
+                style: const ImageStyle(fit: BoxFit.contain),
+              ),
             ),
             new Positioned.fromRect(
               rect: _textRectTween.lerp(widget.t),
@@ -254,7 +257,10 @@ class RecipeCard extends StatelessWidget {
           children: <Widget>[
             new Hero(
               tag: recipe.imagePath,
-              child: new Image.asset(recipe.imagePath, fit: BoxFit.contain)
+              child: new Image.asset(
+                recipe.imagePath,
+                style: const ImageStyle(fit: BoxFit.contain),
+              ),
             ),
             new Expanded(
               child: new Row(
@@ -263,8 +269,10 @@ class RecipeCard extends StatelessWidget {
                     padding: const EdgeInsets.all(16.0),
                     child: new Image.asset(
                       recipe.ingredientsImagePath,
-                      width: 48.0,
-                      height: 48.0,
+                      style: const ImageStyle(
+                        width: 48.0,
+                        height: 48.0,
+                      ),
                     ),
                   ),
                   new Expanded(
@@ -325,7 +333,9 @@ class _RecipePageState extends State<RecipePage> {
               tag: widget.recipe.imagePath,
               child: new Image.asset(
                 widget.recipe.imagePath,
-                fit: fullWidth ? BoxFit.fitWidth : BoxFit.cover,
+                style: new ImageStyle(
+                  fit: fullWidth ? BoxFit.fitWidth : BoxFit.cover,
+                ),
               ),
             ),
           ),
@@ -434,10 +444,12 @@ class RecipeSheet extends StatelessWidget {
                   verticalAlignment: TableCellVerticalAlignment.middle,
                   child: new Image.asset(
                     recipe.ingredientsImagePath,
-                    width: 32.0,
-                    height: 32.0,
-                    alignment: FractionalOffset.centerLeft,
-                    fit: BoxFit.scaleDown
+                    style: const ImageStyle(
+                      width: 32.0,
+                      height: 32.0,
+                      alignment: FractionalOffset.centerLeft,
+                      fit: BoxFit.scaleDown,
+                    ),
                   )
                 ),
                 new TableCell(

--- a/examples/flutter_gallery/lib/demo/shrine/shrine_home.dart
+++ b/examples/flutter_gallery/lib/demo/shrine/shrine_home.dart
@@ -132,7 +132,10 @@ class _VendorItem extends StatelessWidget {
             width: 24.0,
             child: new ClipRRect(
               borderRadius: new BorderRadius.circular(12.0),
-              child: new Image.asset(vendor.avatarAsset, fit: BoxFit.cover),
+              child: new Image.asset(
+                vendor.avatarAsset,
+                style: const ImageStyle(fit: BoxFit.cover),
+              ),
             ),
           ),
           const SizedBox(width: 8.0),
@@ -270,7 +273,10 @@ class _Heading extends StatelessWidget {
             ),
             new LayoutId(
               id: _HeadingLayout.image,
-              child: new Image.asset(product.imageAsset, fit: BoxFit.cover),
+              child: new Image.asset(
+                product.imageAsset,
+                style: const ImageStyle(fit: BoxFit.cover),
+              ),
             ),
             new LayoutId(
               id: _HeadingLayout.title,
@@ -318,7 +324,10 @@ class _ProductItem extends StatelessWidget {
                 padding: const EdgeInsets.symmetric(horizontal: 8.0),
                 child: new Hero(
                     tag: product.tag,
-                    child: new Image.asset(product.imageAsset, fit: BoxFit.contain),
+                    child: new Image.asset(
+                      product.imageAsset,
+                      style: const ImageStyle(fit: BoxFit.contain),
+                    ),
                   ),
                 ),
               new Padding(

--- a/examples/flutter_gallery/lib/demo/shrine/shrine_order.dart
+++ b/examples/flutter_gallery/lib/demo/shrine/shrine_order.dart
@@ -174,8 +174,10 @@ class _Heading extends StatelessWidget {
                   tag: product.tag,
                   child: new Image.asset(
                     product.imageAsset,
-                    fit: BoxFit.contain,
-                    alignment: FractionalOffset.center,
+                    style: const ImageStyle(
+                      fit: BoxFit.contain,
+                      alignment: FractionalOffset.center,
+                    ),
                   ),
                 ),
               ),
@@ -305,7 +307,7 @@ class _OrderPageState extends State<OrderPage> {
                       elevation: 1,
                       child: new Image.asset(
                         product.imageAsset,
-                        fit: BoxFit.contain,
+                        style: const ImageStyle(fit: BoxFit.contain),
                       ),
                     );
                   }).toList(),

--- a/examples/flutter_gallery/lib/gallery/example_code.dart
+++ b/examples/flutter_gallery/lib/gallery/example_code.dart
@@ -220,7 +220,7 @@ new GridView.count(
       footer: new GridTileBar(
         title: new Text(url)
       ),
-      child: new Image.network(url, fit: BoxFit.cover)
+      child: new Image.network(url, style: const ImageStyle(fit: BoxFit.cover))
     );
   }).toList(),
 );

--- a/examples/flutter_gallery/lib/gallery/home.dart
+++ b/examples/flutter_gallery/lib/gallery/home.dart
@@ -54,8 +54,10 @@ class _AppBarBackground extends StatelessWidget {
               bottom: 0.0,
               child: new Image.asset(
                 layer.assetName,
-                fit: BoxFit.cover,
-                height: _kFlexibleSpaceMaxHeight
+                style: const ImageStyle(
+                  fit: BoxFit.cover,
+                  height: _kFlexibleSpaceMaxHeight,
+                ),
               )
             );
           }).toList()

--- a/packages/flutter/lib/src/material/image_icon.dart
+++ b/packages/flutter/lib/src/material/image_icon.dart
@@ -68,11 +68,13 @@ class ImageIcon extends StatelessWidget {
 
     return new Image(
       image: image,
-      width: iconSize,
-      height: iconSize,
-      color: iconColor,
-      fit: BoxFit.scaleDown,
-      alignment: FractionalOffset.center
+      style: new ImageStyle(
+        width: iconSize,
+        height: iconSize,
+        color: iconColor,
+        fit: BoxFit.scaleDown,
+        alignment: FractionalOffset.center
+      ),
     );
   }
 

--- a/packages/flutter/lib/src/rendering/image.dart
+++ b/packages/flutter/lib/src/rendering/image.dart
@@ -128,7 +128,7 @@ class RenderImage extends RenderBox {
   set colorBlendMode(BlendMode value) {
     if (value == _colorBlendMode)
       return;
-    _colorBlendMode;
+    _colorBlendMode = value;
     _updateColorFilter();
     markNeedsPaint();
   }

--- a/packages/flutter/lib/src/widgets/image.dart
+++ b/packages/flutter/lib/src/widgets/image.dart
@@ -34,38 +34,14 @@ ImageConfiguration createLocalImageConfiguration(BuildContext context, { Size si
   );
 }
 
-/// A widget that displays an image.
-///
-/// Several constructors are provided for the various ways that an image can be
-/// specified:
-///
-///  * [new Image], for obtaining an image from an [ImageProvider].
-///  * [new Image.asset], for obtaining an image from an [AssetBundle]
-///    using a key.
-///  * [new Image.network], for obtaining an image from a URL.
-///  * [new Image.file], for obtaining an image from a [File].
-///  * [new Image.memory], for obtaining an image from a [Uint8List].
-///
-/// To automatically perform pixel-density-aware asset resolution, specify the
-/// image using an [AssetImage] and make sure that a [MaterialApp], [WidgetsApp],
-/// or [MediaQuery] widget exists above the [Image] widget in the widget tree.
-///
-/// The image is painted using [paintImage], which describes the meanings of the
-/// various fields on this class in more detail.
-///
-/// See also:
-///
-///  * [Icon]
-class Image extends StatefulWidget {
-  /// Creates a widget that displays an image.
+/// An immutable style for [Image] widgets.
+@immutable
+class ImageStyle {
+  /// Creates an image style.
   ///
-  /// To show an image from the network or from an asset bundle, consider using
-  /// [new Image.network] and [new Image.asset] respectively.
-  ///
-  /// The [image] and [repeat] arguments must not be null.
-  const Image({
-    Key key,
-    @required this.image,
+  /// The [repeat] argument must not be null.
+  /// TODO(ds84182): Can [repeat] be null? Maybe.
+  const ImageStyle({
     this.width,
     this.height,
     this.color,
@@ -75,98 +51,7 @@ class Image extends StatefulWidget {
     this.repeat: ImageRepeat.noRepeat,
     this.centerSlice,
     this.gaplessPlayback: false
-  }) : assert(image != null),
-       super(key: key);
-
-  /// Creates a widget that displays an [ImageStream] obtained from the network.
-  ///
-  /// The [src], [scale], and [repeat] arguments must not be null.
-  Image.network(String src, {
-    Key key,
-    double scale: 1.0,
-    this.width,
-    this.height,
-    this.color,
-    this.colorBlendMode,
-    this.fit,
-    this.alignment,
-    this.repeat: ImageRepeat.noRepeat,
-    this.centerSlice,
-    this.gaplessPlayback: false
-  }) : image = new NetworkImage(src, scale: scale),
-       super(key: key);
-
-  /// Creates a widget that displays an [ImageStream] obtained from a [File].
-  ///
-  /// The [file], [scale], and [repeat] arguments must not be null.
-  ///
-  /// On Android, this may require the
-  /// `android.permission.READ_EXTERNAL_STORAGE` permission.
-  Image.file(File file, {
-    Key key,
-    double scale: 1.0,
-    this.width,
-    this.height,
-    this.color,
-    this.colorBlendMode,
-    this.fit,
-    this.alignment,
-    this.repeat: ImageRepeat.noRepeat,
-    this.centerSlice,
-    this.gaplessPlayback: false
-  }) : image = new FileImage(file, scale: scale),
-       super(key: key);
-
-  /// Creates a widget that displays an [ImageStream] obtained from an asset
-  /// bundle. The key for the image is given by the `name` argument.
-  ///
-  /// If the `bundle` argument is omitted or null, then the
-  /// [DefaultAssetBundle] will be used.
-  ///
-  /// If the `scale` argument is omitted or null, then pixel-density-aware asset
-  /// resolution will be attempted.
-  ///
-  /// If [width] and [height] are both specified, and [scale] is not, then
-  /// size-aware asset resolution will be attempted also.
-  ///
-  /// The [name] and [repeat] arguments must not be null.
-  Image.asset(String name, {
-    Key key,
-    AssetBundle bundle,
-    double scale,
-    this.width,
-    this.height,
-    this.color,
-    this.colorBlendMode,
-    this.fit,
-    this.alignment,
-    this.repeat: ImageRepeat.noRepeat,
-    this.centerSlice,
-    this.gaplessPlayback: false
-  }) : image = scale != null ? new ExactAssetImage(name, bundle: bundle, scale: scale)
-                             : new AssetImage(name, bundle: bundle),
-       super(key: key);
-
-  /// Creates a widget that displays an [ImageStream] obtained from a [Uint8List].
-  ///
-  /// The [bytes], [scale], and [repeat] arguments must not be null.
-  Image.memory(Uint8List bytes, {
-    Key key,
-    double scale: 1.0,
-    this.width,
-    this.height,
-    this.color,
-    this.colorBlendMode,
-    this.fit,
-    this.alignment,
-    this.repeat: ImageRepeat.noRepeat,
-    this.centerSlice,
-    this.gaplessPlayback: false
-  }) : image = new MemoryImage(bytes, scale: scale),
-       super(key: key);
-
-  /// The image to display.
-  final ImageProvider image;
+  });
 
   /// If non-null, require the image to have this width.
   ///
@@ -222,6 +107,199 @@ class Image extends StatefulWidget {
   /// (false), when the image provider changes.
   final bool gaplessPlayback;
 
+  ImageStyle copyWith({
+    double width,
+    double height,
+    Color color,
+    BlendMode colorBlendMode,
+    BoxFit fit,
+    FractionalOffset alignment,
+    ImageRepeat repeat,
+    Rect centerSlice,
+    bool gaplessPlayback
+  }) {
+    return new ImageStyle(
+      width: width ?? this.width,
+      height: height ?? this.height,
+      color: color ?? this.color,
+      colorBlendMode: colorBlendMode ?? this.colorBlendMode,
+      fit: fit ?? this.fit,
+      alignment: alignment ?? this.alignment,
+      repeat: repeat ?? this.repeat,
+      centerSlice: centerSlice ?? this.centerSlice,
+      gaplessPlayback: gaplessPlayback ?? this.gaplessPlayback
+    );
+  }
+
+  ImageStyle merge(ImageStyle other) {
+    if (other == null)
+      return this;
+    return copyWith(
+      width: other.width,
+      height: other.height,
+      color: other.color,
+      colorBlendMode: other.colorBlendMode,
+      fit: other.fit,
+      alignment: other.alignment,
+      repeat: other.repeat,
+      centerSlice: other.centerSlice,
+      gaplessPlayback: other.gaplessPlayback
+    );
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    if (identical(this, other))
+      return true;
+    if (other is! ImageStyle)
+      return false;
+    final ImageStyle typedOther = other;
+    return width == typedOther.width &&
+        height == typedOther.height &&
+        color == typedOther.color &&
+        colorBlendMode == typedOther.colorBlendMode &&
+        fit == typedOther.fit &&
+        alignment == typedOther.alignment &&
+        repeat == typedOther.repeat &&
+        centerSlice == typedOther.centerSlice &&
+        gaplessPlayback == typedOther.gaplessPlayback;
+  }
+
+  @override
+  int get hashCode {
+    return hashValues(
+      width,
+      height,
+      color,
+      colorBlendMode,
+      fit,
+      alignment,
+      repeat,
+      centerSlice,
+      gaplessPlayback
+    );
+  }
+
+  @override
+  String toString([String prefix = '']) {
+    final List<String> result = <String>[];
+    if (width != null)
+      result.add('width: $width');
+    if (height != null)
+      result.add('height: $height');
+    if (color != null)
+      result.add('color: $color');
+    if (colorBlendMode != null)
+      result.add('colorBlendMode: $colorBlendMode');
+    if (fit != null)
+      result.add('fit: $fit');
+    if (alignment != null)
+      result.add('alignment: $alignment');
+    if (repeat != ImageRepeat.noRepeat)
+      result.add('repeat: $repeat');
+    if (centerSlice != null)
+      result.add('centerSlice: $centerSlice');
+    return "$prefix${result.join('\n')}";
+  }
+}
+
+/// A widget that displays an image.
+///
+/// Several constructors are provided for the various ways that an image can be
+/// specified:
+///
+///  * [new Image], for obtaining an image from an [ImageProvider].
+///  * [new Image.asset], for obtaining an image from an [AssetBundle]
+///    using a key.
+///  * [new Image.network], for obtaining an image from a URL.
+///  * [new Image.file], for obtaining an image from a [File].
+///  * [new Image.memory], for obtaining an image from a [Uint8List].
+///
+/// To automatically perform pixel-density-aware asset resolution, specify the
+/// image using an [AssetImage] and make sure that a [MaterialApp], [WidgetsApp],
+/// or [MediaQuery] widget exists above the [Image] widget in the widget tree.
+///
+/// The image is painted using [paintImage], which describes the meanings of the
+/// various fields on this class in more detail.
+///
+/// See also:
+///
+///  * [Icon]
+class Image extends StatefulWidget {
+  /// Creates a widget that displays an image.
+  ///
+  /// To show an image from the network or from an asset bundle, consider using
+  /// [new Image.network] and [new Image.asset] respectively.
+  ///
+  /// The [image] and [repeat] arguments must not be null.
+  const Image({
+    Key key,
+    @required this.image,
+    this.style: const ImageStyle()
+  }) : assert(image != null),
+       super(key: key);
+
+  /// Creates a widget that displays an [ImageStream] obtained from the network.
+  ///
+  /// The [src], [scale], and [repeat] arguments must not be null.
+  Image.network(String src, {
+    Key key,
+    double scale: 1.0,
+    this.style: const ImageStyle()
+  }) : image = new NetworkImage(src, scale: scale),
+       super(key: key);
+
+  /// Creates a widget that displays an [ImageStream] obtained from a [File].
+  ///
+  /// The [file], [scale], and [repeat] arguments must not be null.
+  ///
+  /// On Android, this may require the
+  /// `android.permission.READ_EXTERNAL_STORAGE` permission.
+  Image.file(File file, {
+    Key key,
+    double scale: 1.0,
+    this.style: const ImageStyle()
+  }) : image = new FileImage(file, scale: scale),
+       super(key: key);
+
+  /// Creates a widget that displays an [ImageStream] obtained from an asset
+  /// bundle. The key for the image is given by the `name` argument.
+  ///
+  /// If the `bundle` argument is omitted or null, then the
+  /// [DefaultAssetBundle] will be used.
+  ///
+  /// If the `scale` argument is omitted or null, then pixel-density-aware asset
+  /// resolution will be attempted.
+  ///
+  /// If [width] and [height] are both specified, and [scale] is not, then
+  /// size-aware asset resolution will be attempted also.
+  ///
+  /// The [name] and [repeat] arguments must not be null.
+  Image.asset(String name, {
+    Key key,
+    AssetBundle bundle,
+    double scale,
+    this.style: const ImageStyle()
+  }) : image = scale != null ? new ExactAssetImage(name, bundle: bundle, scale: scale)
+                             : new AssetImage(name, bundle: bundle),
+       super(key: key);
+
+  /// Creates a widget that displays an [ImageStream] obtained from a [Uint8List].
+  ///
+  /// The [bytes], [scale], and [repeat] arguments must not be null.
+  Image.memory(Uint8List bytes, {
+    Key key,
+    double scale: 1.0,
+    this.style: const ImageStyle()
+  }) : image = new MemoryImage(bytes, scale: scale),
+       super(key: key);
+
+  /// The image to display.
+  final ImageProvider image;
+
+  /// The style to give to the image.
+  final ImageStyle style;
+
   @override
   _ImageState createState() => new _ImageState();
 
@@ -229,22 +307,7 @@ class Image extends StatefulWidget {
   void debugFillDescription(List<String> description) {
     super.debugFillDescription(description);
     description.add('image: $image');
-    if (width != null)
-      description.add('width: $width');
-    if (height != null)
-      description.add('height: $height');
-    if (color != null)
-      description.add('color: $color');
-    if (colorBlendMode != null)
-      description.add('colorBlendMode: $colorBlendMode');
-    if (fit != null)
-      description.add('fit: $fit');
-    if (alignment != null)
-      description.add('alignment: $alignment');
-    if (repeat != ImageRepeat.noRepeat)
-      description.add('repeat: $repeat');
-    if (centerSlice != null)
-      description.add('centerSlice: $centerSlice');
+    description.add('style: $style');
   }
 }
 
@@ -275,12 +338,14 @@ class _ImageState extends State<Image> {
     final ImageStream oldImageStream = _imageStream;
     _imageStream = widget.image.resolve(createLocalImageConfiguration(
       context,
-      size: widget.width != null && widget.height != null ? new Size(widget.width, widget.height) : null
+      size: widget.style.width != null &&
+          widget.style.height != null ?
+            new Size(widget.style.width, widget.style.height) : null
     ));
     assert(_imageStream != null);
     if (_imageStream.key != oldImageStream?.key) {
       oldImageStream?.removeListener(_handleImageChanged);
-      if (!widget.gaplessPlayback)
+      if (!widget.style.gaplessPlayback)
         setState(() { _imageInfo = null; });
       _imageStream.addListener(_handleImageChanged);
     }
@@ -303,15 +368,15 @@ class _ImageState extends State<Image> {
   Widget build(BuildContext context) {
     return new RawImage(
       image: _imageInfo?.image,
-      width: widget.width,
-      height: widget.height,
+      width: widget.style.width,
+      height: widget.style.height,
       scale: _imageInfo?.scale ?? 1.0,
-      color: widget.color,
-      colorBlendMode: widget.colorBlendMode,
-      fit: widget.fit,
-      alignment: widget.alignment,
-      repeat: widget.repeat,
-      centerSlice: widget.centerSlice
+      color: widget.style.color,
+      colorBlendMode: widget.style.colorBlendMode,
+      fit: widget.style.fit,
+      alignment: widget.style.alignment,
+      repeat: widget.style.repeat,
+      centerSlice: widget.style.centerSlice
     );
   }
 

--- a/packages/flutter/test/material/image_icon_test.dart
+++ b/packages/flutter/test/material/image_icon_test.dart
@@ -37,7 +37,7 @@ void main() {
 
     final Image image = tester.widget(find.byType(Image));
     expect(image, isNotNull);
-    expect(image.color.alpha, equals(128));
+    expect(image.style.color.alpha, equals(128));
   });
 
   testWidgets('ImageIcon sizing - no theme, explicit size', (WidgetTester tester) async {

--- a/packages/flutter/test/widgets/image_resolution_test.dart
+++ b/packages/flutter/test/widgets/image_resolution_test.dart
@@ -122,9 +122,11 @@ Widget buildImageAtRatio(String image, Key key, double ratio, bool inferSize) {
           new Image(
             key: key,
             image: new TestAssetImage(image),
-            height: imageSize,
-            width: imageSize,
-            fit: BoxFit.fill
+            style: const ImageStyle(
+              height: imageSize,
+              width: imageSize,
+              fit: BoxFit.fill
+            )
           )
       )
     )

--- a/packages/flutter/test/widgets/image_test.dart
+++ b/packages/flutter/test/widgets/image_test.dart
@@ -320,6 +320,54 @@ void main() {
     expect(renderer.color, const Color(0xFF00FF00));
     expect(renderer.colorBlendMode, BlendMode.clear);
   });
+
+  testWidgets('Images inherit ImageStyle parameters', (WidgetTester tester) async {
+    await tester.pumpWidget(
+        new Image(
+            image: new TestImageProvider(),
+            style: const ImageStyle(
+                color: const Color(0xFF00FF00)
+            )
+        )
+    );
+    RenderImage renderer = tester.renderObject<RenderImage>(find.byType(Image));
+    expect(renderer.color, const Color(0xFF00FF00));
+    expect(renderer.colorBlendMode, isNull);
+    await tester.pumpWidget(
+        DefaultImageStyle.merge(
+            style: const ImageStyle(
+                color: const Color(0xFFFFFF00),
+                colorBlendMode: BlendMode.clear
+            ),
+            child: new Image(
+                image: new TestImageProvider(),
+                style: const ImageStyle(
+                    color: const Color(0xFF00FF00)
+                )
+            )
+        )
+    );
+    renderer = tester.renderObject<RenderImage>(find.byType(Image));
+    expect(renderer.color, const Color(0xFF00FF00));
+    expect(renderer.colorBlendMode, BlendMode.clear);
+    await tester.pumpWidget(
+        DefaultImageStyle.merge(
+            style: const ImageStyle(
+                color: const Color(0xFFFFFF00),
+                colorBlendMode: BlendMode.lighten
+            ),
+            child: new Image(
+                image: new TestImageProvider(),
+                style: const ImageStyle(
+                    color: const Color(0xFF00FF00)
+                )
+            )
+        )
+    );
+    renderer = tester.renderObject<RenderImage>(find.byType(Image));
+    expect(renderer.color, const Color(0xFF00FF00));
+    expect(renderer.colorBlendMode, BlendMode.lighten);
+  });
 }
 
 class TestImageProvider extends ImageProvider<TestImageProvider> {

--- a/packages/flutter/test/widgets/image_test.dart
+++ b/packages/flutter/test/widgets/image_test.dart
@@ -61,7 +61,7 @@ void main() {
       new Container(
         key: key,
         child: new Image(
-          gaplessPlayback: true,
+          style: const ImageStyle(gaplessPlayback: true),
           image: imageProvider1
         )
       ),
@@ -83,7 +83,7 @@ void main() {
       new Container(
         key: key,
         child: new Image(
-          gaplessPlayback: true,
+          style: const ImageStyle(gaplessPlayback: true),
           image: imageProvider2
         )
       ),
@@ -136,7 +136,7 @@ void main() {
     await tester.pumpWidget(
       new Image(
         key: key,
-        gaplessPlayback: true,
+        style: const ImageStyle(gaplessPlayback: true),
         image: imageProvider1
       ),
       null,
@@ -156,7 +156,7 @@ void main() {
     await tester.pumpWidget(
       new Image(
         key: key,
-        gaplessPlayback: true,
+        style: const ImageStyle(gaplessPlayback: true),
         image: imageProvider2
       ),
       null,
@@ -310,8 +310,10 @@ void main() {
     await tester.pumpWidget(
       new Image(
         image: new TestImageProvider(),
-        color: const Color(0xFF00FF00),
-        colorBlendMode: BlendMode.clear
+        style: const ImageStyle(
+          color: const Color(0xFF00FF00),
+          colorBlendMode: BlendMode.clear
+        )
       )
     );
     final RenderImage renderer = tester.renderObject<RenderImage>(find.byType(Image));

--- a/packages/flutter_markdown/lib/src/builder.dart
+++ b/packages/flutter_markdown/lib/src/builder.dart
@@ -209,7 +209,7 @@ class MarkdownBuilder implements md.NodeVisitor {
       }
     }
 
-    return new Image.network(path, width: width, height: height);
+    return new Image.network(path, style: new ImageStyle(width: width, height: height));
   }
 
   Widget _buildBullet(String listTag) {


### PR DESCRIPTION
**THIS IS A BREAKING CHANGE, STUFF _WILL_ BREAK!!**

This moves all parameters from Image, except for the ImageProvider, into a new class: ImageStyle. ImageStyle, like TextStyle, can be merged with another ImageStyle and can be copied with new values. 

This PR also implements DefaultImageStyle, which, like DefaultTextStyle, allows you to give a subtree a base ImageStyle. The fallback style also contains the default values that RawImage expects (repeat, currently) and a default value for gaplessPlayback (which is false). Also, the difference between `new DefaultImageStyle` and `DefaultImageStyle.merge` is highlighted, and also advises users of `new DefaultImageStyle` to make sure they inherit the values from the default ImageStyle.

I've also provided a unit test for DefaultImageStyle. This also allowed me to find a bug in RenderImage, where the colorBlendMode setter didn't actually update the value. There should probably be a lint for that >_<;

Also, all existing code using Image has been updated (Gallery, Complex Layout, Flutter Markdown).