### PR TITLE
Adjust the defaults behaviour of scroll views.

### DIFF
--- a/examples/flutter_gallery/lib/demo/material/list_demo.dart
+++ b/examples/flutter_gallery/lib/demo/material/list_demo.dart
@@ -42,6 +42,7 @@ class _ListDemoState extends State<ListDemo> {
         ),
         child: new ListView(
           shrinkWrap: true,
+          primary: false,
           children: <Widget>[
             new ListTile(
               dense: true,

--- a/examples/flutter_gallery/lib/gallery/drawer.dart
+++ b/examples/flutter_gallery/lib/gallery/drawer.dart
@@ -298,6 +298,6 @@ class GalleryDrawer extends StatelessWidget {
       ));
     }
 
-    return new Drawer(child: new ListView(children: allDrawerItems));
+    return new Drawer(child: new ListView(primary: false, children: allDrawerItems));
   }
 }

--- a/packages/flutter/lib/src/widgets/page_view.dart
+++ b/packages/flutter/lib/src/widgets/page_view.dart
@@ -215,7 +215,7 @@ class _PagePosition extends ScrollPositionWithSingleContext {
 /// These physics cause the page view to snap to page boundaries.
 class PageScrollPhysics extends ScrollPhysics {
   /// Creates physics for a [PageView].
-  const PageScrollPhysics({ ScrollPhysics parent }) : super(parent);
+  const PageScrollPhysics({ ScrollPhysics parent }) : super(parent: parent);
 
   @override
   PageScrollPhysics applyTo(ScrollPhysics parent) => new PageScrollPhysics(parent: parent);

--- a/packages/flutter/lib/src/widgets/scroll_metrics.dart
+++ b/packages/flutter/lib/src/widgets/scroll_metrics.dart
@@ -88,14 +88,6 @@ abstract class ScrollMetrics {
   /// of the viewport in the scrollable. This is the content below the content
   /// described by [extentInside].
   double get extentAfter => math.max(maxScrollExtent - pixels, 0.0);
-
-  @protected
-  String superToString() => super.toString();
-
-  @override
-  String toString() {
-    return '$runtimeType(${extentBefore.toStringAsFixed(1)}..[${extentInside.toStringAsFixed(1)}]..${extentAfter.toStringAsFixed(1)})';
-  }
 }
 
 /// An immutable snapshot of values associated with a [Scrollable] viewport.
@@ -134,4 +126,9 @@ class FixedScrollMetrics extends ScrollMetrics {
 
   @override
   final AxisDirection axisDirection;
+
+  @override
+  String toString() {
+    return '$runtimeType(${extentBefore.toStringAsFixed(1)}..[${extentInside.toStringAsFixed(1)}]..${extentAfter.toStringAsFixed(1)})';
+  }
 }

--- a/packages/flutter/lib/src/widgets/scroll_metrics.dart
+++ b/packages/flutter/lib/src/widgets/scroll_metrics.dart
@@ -89,9 +89,12 @@ abstract class ScrollMetrics {
   /// described by [extentInside].
   double get extentAfter => math.max(maxScrollExtent - pixels, 0.0);
 
+  @protected
+  String superToString() => super.toString();
+
   @override
   String toString() {
-    return '$runtimeType(${extentBefore.toStringAsFixed(1)}..[${extentInside.toStringAsFixed(1)}]..${extentAfter.toStringAsFixed(1)}})';
+    return '$runtimeType(${extentBefore.toStringAsFixed(1)}..[${extentInside.toStringAsFixed(1)}]..${extentAfter.toStringAsFixed(1)})';
   }
 }
 

--- a/packages/flutter/lib/src/widgets/scroll_physics.dart
+++ b/packages/flutter/lib/src/widgets/scroll_physics.dart
@@ -16,12 +16,12 @@ import 'scroll_simulation.dart';
 export 'package:flutter/physics.dart' show Tolerance;
 
 @immutable
-abstract class ScrollPhysics {
-  const ScrollPhysics(this.parent);
+class ScrollPhysics {
+  const ScrollPhysics({ this.parent });
 
   final ScrollPhysics parent;
 
-  ScrollPhysics applyTo(ScrollPhysics parent);
+  ScrollPhysics applyTo(ScrollPhysics parent) => new ScrollPhysics(parent: parent);
 
   /// Used by [DragScrollActivity] and other user-driven activities to
   /// convert an offset in logical pixels as provided by the [DragUpdateDetails]
@@ -172,7 +172,7 @@ abstract class ScrollPhysics {
 ///    clamping behavior.
 class BouncingScrollPhysics extends ScrollPhysics {
   /// Creates scroll physics that bounce back from the edge.
-  const BouncingScrollPhysics({ ScrollPhysics parent }) : super(parent);
+  const BouncingScrollPhysics({ ScrollPhysics parent }) : super(parent: parent);
 
   @override
   BouncingScrollPhysics applyTo(ScrollPhysics parent) => new BouncingScrollPhysics(parent: parent);
@@ -251,7 +251,7 @@ class BouncingScrollPhysics extends ScrollPhysics {
 class ClampingScrollPhysics extends ScrollPhysics {
   /// Creates scroll physics that prevent the scroll offset from exceeding the
   /// bounds of the content..
-  const ClampingScrollPhysics({ ScrollPhysics parent }) : super(parent);
+  const ClampingScrollPhysics({ ScrollPhysics parent }) : super(parent: parent);
 
   @override
   ClampingScrollPhysics applyTo(ScrollPhysics parent) => new ClampingScrollPhysics(parent: parent);
@@ -325,35 +325,19 @@ class ClampingScrollPhysics extends ScrollPhysics {
 ///
 /// See also:
 ///
-///  * [DefaultScrollPhysics], which can be used instead of this class when
-///    the default behavior is desired instead.
+///  * [ScrollPhysics], which can be used instead of this class when the default
+///    behavior is desired instead.
 ///  * [BouncingScrollPhysics], which provides the bouncing overscroll behavior
 ///    found on iOS.
 ///  * [ClampingScrollPhysics], which provides the clamping overscroll behavior
 ///    found on Android.
 class AlwaysScrollableScrollPhysics extends ScrollPhysics {
   /// Creates scroll physics that always lets the user scroll.
-  const AlwaysScrollableScrollPhysics({ ScrollPhysics parent }) : super(parent);
+  const AlwaysScrollableScrollPhysics({ ScrollPhysics parent }) : super(parent: parent);
 
   @override
   AlwaysScrollableScrollPhysics applyTo(ScrollPhysics parent) => new AlwaysScrollableScrollPhysics(parent: parent);
 
   @override
   bool shouldAcceptUserOffset(ScrollMetrics position) => true;
-}
-
-/// Scroll physics that only lets the user scroll if there is content to scroll,
-/// and in general has default behavior.
-///
-/// See also:
-///
-///  * [AlwaysScrollableScrollPhysics], which is similar except that the user
-///    can always attempt to scroll, even when there isn't sufficient content.
-class DefaultScrollPhysics extends ScrollPhysics {
-  /// Creates a scroll physics object that does nothing different from the
-  /// default.
-  const DefaultScrollPhysics({ ScrollPhysics parent }) : super(parent);
-
-  @override
-  DefaultScrollPhysics applyTo(ScrollPhysics parent) => new DefaultScrollPhysics(parent: parent);
 }

--- a/packages/flutter/lib/src/widgets/scroll_physics.dart
+++ b/packages/flutter/lib/src/widgets/scroll_physics.dart
@@ -325,6 +325,8 @@ class ClampingScrollPhysics extends ScrollPhysics {
 ///
 /// See also:
 ///
+///  * [DefaultScrollPhysics], which can be used instead of this class when
+///    the default behavior is desired instead.
 ///  * [BouncingScrollPhysics], which provides the bouncing overscroll behavior
 ///    found on iOS.
 ///  * [ClampingScrollPhysics], which provides the clamping overscroll behavior
@@ -338,4 +340,20 @@ class AlwaysScrollableScrollPhysics extends ScrollPhysics {
 
   @override
   bool shouldAcceptUserOffset(ScrollMetrics position) => true;
+}
+
+/// Scroll physics that only lets the user scroll if there is content to scroll,
+/// and in general has default behavior.
+///
+/// See also:
+///
+///  * [AlwaysScrollableScrollPhysics], which is similar except that the user
+///    can always attempt to scroll, even when there isn't sufficient content.
+class DefaultScrollPhysics extends ScrollPhysics {
+  /// Creates a scroll physics object that does nothing different from the
+  /// default.
+  const DefaultScrollPhysics({ ScrollPhysics parent }) : super(parent);
+
+  @override
+  DefaultScrollPhysics applyTo(ScrollPhysics parent) => new DefaultScrollPhysics(parent: parent);
 }

--- a/packages/flutter/lib/src/widgets/scroll_position.dart
+++ b/packages/flutter/lib/src/widgets/scroll_position.dart
@@ -382,9 +382,6 @@ abstract class ScrollPosition extends ViewportOffset with ScrollMetrics {
   }
 
   @override
-  String toString() => super.superToString();
-
-  @override
   void debugFillDescription(List<String> description) {
     if (debugLabel != null)
       description.add(debugLabel);

--- a/packages/flutter/lib/src/widgets/scroll_position.dart
+++ b/packages/flutter/lib/src/widgets/scroll_position.dart
@@ -382,6 +382,9 @@ abstract class ScrollPosition extends ViewportOffset with ScrollMetrics {
   }
 
   @override
+  String toString() => super.superToString();
+
+  @override
   void debugFillDescription(List<String> description) {
     if (debugLabel != null)
       description.add(debugLabel);

--- a/packages/flutter/lib/src/widgets/scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/scroll_view.dart
@@ -114,11 +114,19 @@ abstract class ScrollView extends StatelessWidget {
   /// To force the scroll view to always be scrollable even if there is
   /// insufficient content, as if [primary] was true but without necessarily
   /// setting it to true, provide an [AlwaysScrollableScrollPhysics] physics
-  /// object.
+  /// object, as in:
+  ///
+  /// ```dart
+  ///   physics: const AlwaysScrollableScrollPhysics(),
+  /// ```
   ///
   /// To force the scroll view to use the default platform conventions and not
   /// be scrollable if there is insufficient content, regardless of the value of
-  /// [primary], provide a [DefaultScrollPhysics] object.
+  /// [primary], provide an explicit [ScrollPhysics] object, as in:
+  ///
+  /// ```dart
+  ///   physics: const ScrollPhysics(),
+  /// ```
   final ScrollPhysics physics;
 
   /// Whether the extent of the scroll view in the [scrollDirection] should be

--- a/packages/flutter/lib/src/widgets/scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/scroll_view.dart
@@ -49,9 +49,10 @@ abstract class ScrollView extends StatelessWidget {
     this.reverse: false,
     this.controller,
     bool primary,
-    this.physics,
+    ScrollPhysics physics,
     this.shrinkWrap: false,
   }) : primary = primary ?? controller == null && scrollDirection == Axis.vertical,
+       physics = physics ?? (primary == true || (primary == null && controller == null && scrollDirection == Axis.vertical) ? const AlwaysScrollableScrollPhysics() : null),
        super(key: key) {
     assert(reverse != null);
     assert(shrinkWrap != null);
@@ -90,7 +91,11 @@ abstract class ScrollView extends StatelessWidget {
   /// Whether this is the primary scroll view associated with the parent
   /// [PrimaryScrollController].
   ///
-  /// On iOS, this identifies the scroll view that will scroll to top in
+  /// When this is true, the scroll view is scrollable even if it does not have
+  /// sufficient content to actually scroll. Otherwise, by default the user can
+  /// only scroll the view if it has sufficient content. See [physics].
+  ///
+  /// On iOS, this also identifies the scroll view that will scroll to top in
   /// response to a tap in the status bar.
   ///
   /// Defaults to true when [scrollDirection] is [Axis.vertical] and
@@ -102,7 +107,18 @@ abstract class ScrollView extends StatelessWidget {
   /// For example, determines how the scroll view continues to animate after the
   /// user stops dragging the scroll view.
   ///
-  /// Defaults to matching platform conventions.
+  /// Defaults to matching platform conventions. Furthermore, if [primary] is
+  /// false, then the user cannot scroll if there is insufficient content to
+  /// scroll, while if [primary] is true, they can always attempt to scroll.
+  ///
+  /// To force the scroll view to always be scrollable even if there is
+  /// insufficient content, as if [primary] was true but without necessarily
+  /// setting it to true, provide an [AlwaysScrollableScrollPhysics] physics
+  /// object.
+  ///
+  /// To force the scroll view to use the default platform conventions and not
+  /// be scrollable if there is insufficient content, regardless of the value of
+  /// [primary], provide a [DefaultScrollPhysics] object.
   final ScrollPhysics physics;
 
   /// Whether the extent of the scroll view in the [scrollDirection] should be

--- a/packages/flutter/test/material/persistent_bottom_sheet_test.dart
+++ b/packages/flutter/test/material/persistent_bottom_sheet_test.dart
@@ -48,6 +48,7 @@ void main() {
     scaffoldKey.currentState.showBottomSheet<Null>((BuildContext context) {
       return new ListView(
         shrinkWrap: true,
+        primary: false,
         children: <Widget>[
           new Container(height: 100.0, child: const Text('One')),
           new Container(height: 100.0, child: const Text('Two')),

--- a/packages/flutter/test/widgets/scroll_view_test.dart
+++ b/packages/flutter/test/widgets/scroll_view_test.dart
@@ -278,4 +278,24 @@ void main() {
     );
     expect(innerScrollable.controller, isNull);
   });
+
+  testWidgets('Primary ListViews are always scrollable', (WidgetTester tester) async {
+    final ListView view = new ListView(primary: true);
+    expect(view.physics, const isInstanceOf<AlwaysScrollableScrollPhysics>());
+  });
+
+  testWidgets('Non-primary ListViews are not always scrollable', (WidgetTester tester) async {
+    final ListView view = new ListView(primary: false);
+    expect(view.physics, isNot(const isInstanceOf<AlwaysScrollableScrollPhysics>()));
+  });
+
+  testWidgets('Defaulting-to-primary ListViews are always scrollable', (WidgetTester tester) async {
+    final ListView view = new ListView(scrollDirection: Axis.vertical);
+    expect(view.physics, const isInstanceOf<AlwaysScrollableScrollPhysics>());
+  });
+
+  testWidgets('Defaulting-to-not-primary ListViews are not always scrollable', (WidgetTester tester) async {
+    final ListView view = new ListView(scrollDirection: Axis.horizontal);
+    expect(view.physics, isNot(const isInstanceOf<AlwaysScrollableScrollPhysics>()));
+  });
 }

--- a/packages/flutter/test/widgets/scroll_view_test.dart
+++ b/packages/flutter/test/widgets/scroll_view_test.dart
@@ -298,4 +298,66 @@ void main() {
     final ListView view = new ListView(scrollDirection: Axis.horizontal);
     expect(view.physics, isNot(const isInstanceOf<AlwaysScrollableScrollPhysics>()));
   });
+
+  testWidgets('primary:true leads to scrolling', (WidgetTester tester) async {
+    bool scrolled = false;
+    await tester.pumpWidget(
+      new NotificationListener<OverscrollNotification>(
+        onNotification: (OverscrollNotification message) { scrolled = true; return false; },
+        child: new ListView(
+          primary: true,
+          children: <Widget>[],
+        ),
+      ),
+    );
+    await tester.dragFrom(const Offset(100.0, 100.0), const Offset(0.0, 100.0));
+    expect(scrolled, isTrue);
+  });
+
+  testWidgets('primary:false leads to no scrolling', (WidgetTester tester) async {
+    bool scrolled = false;
+    await tester.pumpWidget(
+      new NotificationListener<OverscrollNotification>(
+        onNotification: (OverscrollNotification message) { scrolled = true; return false; },
+        child: new ListView(
+          primary: false,
+          children: <Widget>[],
+        ),
+      ),
+    );
+    await tester.dragFrom(const Offset(100.0, 100.0), const Offset(0.0, 100.0));
+    expect(scrolled, isFalse);
+  });
+
+  testWidgets('physics:AlwaysScrollableScrollPhysics actually overrides primary:false default behaviour', (WidgetTester tester) async {
+    bool scrolled = false;
+    await tester.pumpWidget(
+      new NotificationListener<OverscrollNotification>(
+        onNotification: (OverscrollNotification message) { scrolled = true; return false; },
+        child: new ListView(
+          primary: false,
+          physics: const AlwaysScrollableScrollPhysics(),
+          children: <Widget>[],
+        ),
+      ),
+    );
+    await tester.dragFrom(const Offset(100.0, 100.0), const Offset(0.0, 100.0));
+    expect(scrolled, isTrue);
+  });
+
+  testWidgets('physics:ScrollPhysics actually overrides primary:true default behaviour', (WidgetTester tester) async {
+    bool scrolled = false;
+    await tester.pumpWidget(
+      new NotificationListener<OverscrollNotification>(
+        onNotification: (OverscrollNotification message) { scrolled = true; return false; },
+        child: new ListView(
+          primary: true,
+          physics: const ScrollPhysics(),
+          children: <Widget>[],
+        ),
+      ),
+    );
+    await tester.dragFrom(const Offset(100.0, 100.0), const Offset(0.0, 100.0));
+    expect(scrolled, isFalse);
+  });
 }


### PR DESCRIPTION
Now, primary scroll views scroll by default. Others only scroll if necessary.

Fixes https://github.com/flutter/flutter/issues/8925