### PR TITLE
Flush microtasks after transient callbacks are run.

### DIFF
--- a/dev/benchmarks/microbenchmarks/lib/stocks/animation_bench.dart
+++ b/dev/benchmarks/microbenchmarks/lib/stocks/animation_bench.dart
@@ -24,6 +24,11 @@ class BenchmarkingBinding extends LiveTestWidgetsFlutterBinding {
   void handleBeginFrame(Duration rawTimeStamp) {
     stopwatch.start();
     super.handleBeginFrame(rawTimeStamp);
+  }
+
+  @override
+  void handleDrawFrame() {
+    super.handleDrawFrame();
     stopwatch.stop();
   }
 }

--- a/packages/flutter/lib/src/scheduler/debug.dart
+++ b/packages/flutter/lib/src/scheduler/debug.dart
@@ -30,6 +30,17 @@ bool debugPrintBeginFrameBanner = false;
 /// determining if code is running during a frame or between frames.
 bool debugPrintEndFrameBanner = false;
 
+/// Log the call stacks that cause a frame to be scheduled.
+///
+/// This is called whenever [Scheduler.scheduleFrame] schedules a frame. This
+/// can happen for various reasons, e.g. when a [Ticker] or
+/// [AnimationController] is started, or when [RenderObject.markNeedsLayout] is
+/// called, or when [State.setState] is called.
+///
+/// To get a stack specifically when widgets are scheduled to be built, see
+/// [debugPrintScheduleBuildForStacks].
+bool debugPrintScheduleFrameStacks = false;
+
 /// Returns true if none of the scheduler library debug variables have been changed.
 ///
 /// This function is used by the test framework to ensure that debug variables

--- a/packages/flutter/lib/src/widgets/debug.dart
+++ b/packages/flutter/lib/src/widgets/debug.dart
@@ -45,6 +45,8 @@ bool debugPrintBuildScope = false;
 /// To see when a widget is rebuilt, see [debugPrintRebuildDirtyWidgets].
 ///
 /// To see when the dirty list is flushed, see [debugPrintBuildDirtyElements].
+///
+/// To see when a frame is scheduled, see [debugPrintScheduleFrameStacks].
 bool debugPrintScheduleBuildForStacks = false;
 
 /// Log when widgets with global keys are deactivated and log when they are

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -210,6 +210,26 @@ class EditableText extends StatefulWidget {
 
   @override
   EditableTextState createState() => new EditableTextState();
+
+  @override
+  void debugFillDescription(List<String> description) {
+    super.debugFillDescription(description);
+    description.add('controller: $controller');
+    description.add('focusNode: $focusNode');
+    if (obscureText != false)
+      description.add('obscureText: $obscureText');
+    description.add('$style');
+    if (textAlign != null)
+      description.add('$textAlign');
+    if (textScaleFactor != null)
+      description.add('textScaleFactor: $textScaleFactor');
+    if (maxLines != 1)
+      description.add('maxLines: $maxLines');
+    if (autofocus != false)
+      description.add('autofocus: $autofocus');
+    if (keyboardType != null)
+      description.add('keyboardType: $keyboardType');
+  }
 }
 
 /// State for a [EditableText].

--- a/packages/flutter/lib/src/widgets/raw_keyboard_listener.dart
+++ b/packages/flutter/lib/src/widgets/raw_keyboard_listener.dart
@@ -48,6 +48,12 @@ class RawKeyboardListener extends StatefulWidget {
 
   @override
   _RawKeyboardListenerState createState() => new _RawKeyboardListenerState();
+
+  @override
+  void debugFillDescription(List<String> description) {
+    super.debugFillDescription(description);
+    description.add('focusNode: $focusNode');
+  }
 }
 
 class _RawKeyboardListenerState extends State<RawKeyboardListener> {

--- a/packages/flutter/test/animation/animation_controller_test.dart
+++ b/packages/flutter/test/animation/animation_controller_test.dart
@@ -2,14 +2,20 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:ui' as ui;
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/animation.dart';
 import 'package:flutter/widgets.dart';
+
+import '../scheduler/scheduler_tester.dart';
 
 void main() {
   setUp(() {
     WidgetsFlutterBinding.ensureInitialized();
     WidgetsBinding.instance.resetEpoch();
+    ui.window.onBeginFrame = null;
+    ui.window.onDrawFrame = null;
   });
 
   test('Can set value during status callback', () {
@@ -34,10 +40,10 @@ void main() {
     controller.forward();
     expect(didComplete, isFalse);
     expect(didDismiss, isFalse);
-    WidgetsBinding.instance.handleBeginFrame(const Duration(seconds: 1));
+    tick(const Duration(seconds: 1));
     expect(didComplete, isFalse);
     expect(didDismiss, isFalse);
-    WidgetsBinding.instance.handleBeginFrame(const Duration(seconds: 2));
+    tick(const Duration(seconds: 2));
     expect(didComplete, isTrue);
     expect(didDismiss, isTrue);
 
@@ -89,16 +95,16 @@ void main() {
     controller.reverse();
     log.clear();
 
-    WidgetsBinding.instance.handleBeginFrame(const Duration(seconds: 10));
+    tick(const Duration(seconds: 10));
     expect(log, equals(<AnimationStatus>[]));
     expect(valueLog, equals(<AnimationStatus>[]));
-    WidgetsBinding.instance.handleBeginFrame(const Duration(seconds: 20));
+    tick(const Duration(seconds: 20));
     expect(log, equals(<AnimationStatus>[]));
     expect(valueLog, equals(<AnimationStatus>[]));
-    WidgetsBinding.instance.handleBeginFrame(const Duration(seconds: 30));
+    tick(const Duration(seconds: 30));
     expect(log, equals(<AnimationStatus>[]));
     expect(valueLog, equals(<AnimationStatus>[]));
-    WidgetsBinding.instance.handleBeginFrame(const Duration(seconds: 40));
+    tick(const Duration(seconds: 40));
     expect(log, equals(<AnimationStatus>[]));
     expect(valueLog, equals(<AnimationStatus>[]));
 
@@ -157,8 +163,8 @@ void main() {
     );
 
     controller.fling();
-    WidgetsBinding.instance.handleBeginFrame(const Duration(seconds: 1));
-    WidgetsBinding.instance.handleBeginFrame(const Duration(seconds: 2));
+    tick(const Duration(seconds: 1));
+    tick(const Duration(seconds: 2));
     expect(controller.value, 1.0);
     controller.stop();
 
@@ -170,12 +176,12 @@ void main() {
     );
 
     largeRangeController.fling();
-    WidgetsBinding.instance.handleBeginFrame(const Duration(seconds: 3));
-    WidgetsBinding.instance.handleBeginFrame(const Duration(seconds: 4));
+    tick(const Duration(seconds: 3));
+    tick(const Duration(seconds: 4));
     expect(largeRangeController.value, 45.0);
     largeRangeController.fling(velocity: -1.0);
-    WidgetsBinding.instance.handleBeginFrame(const Duration(seconds: 5));
-    WidgetsBinding.instance.handleBeginFrame(const Duration(seconds: 6));
+    tick(const Duration(seconds: 5));
+    tick(const Duration(seconds: 6));
     expect(largeRangeController.value, -30.0);
     largeRangeController.stop();
   });
@@ -186,9 +192,9 @@ void main() {
       vsync: const TestVSync(),
     );
     controller.forward();
-    WidgetsBinding.instance.handleBeginFrame(const Duration(milliseconds: 20));
-    WidgetsBinding.instance.handleBeginFrame(const Duration(milliseconds: 30));
-    WidgetsBinding.instance.handleBeginFrame(const Duration(milliseconds: 40));
+    tick(const Duration(milliseconds: 20));
+    tick(const Duration(milliseconds: 30));
+    tick(const Duration(milliseconds: 40));
     expect(controller.lastElapsedDuration, equals(const Duration(milliseconds: 20)));
     controller.stop();
   });
@@ -200,14 +206,14 @@ void main() {
     );
     expect(controller, hasOneLineDescription);
     controller.forward();
-    WidgetsBinding.instance.handleBeginFrame(const Duration(milliseconds: 10));
-    WidgetsBinding.instance.handleBeginFrame(const Duration(milliseconds: 20));
+    tick(const Duration(milliseconds: 10));
+    tick(const Duration(milliseconds: 20));
     expect(controller, hasOneLineDescription);
-    WidgetsBinding.instance.handleBeginFrame(const Duration(milliseconds: 30));
+    tick(const Duration(milliseconds: 30));
     expect(controller, hasOneLineDescription);
     controller.reverse();
-    WidgetsBinding.instance.handleBeginFrame(const Duration(milliseconds: 40));
-    WidgetsBinding.instance.handleBeginFrame(const Duration(milliseconds: 50));
+    tick(const Duration(milliseconds: 40));
+    tick(const Duration(milliseconds: 50));
     expect(controller, hasOneLineDescription);
     controller.stop();
   });
@@ -220,36 +226,36 @@ void main() {
 
     // mid-flight
     controller.forward();
-    WidgetsBinding.instance.handleBeginFrame(const Duration(milliseconds: 0));
-    WidgetsBinding.instance.handleBeginFrame(const Duration(milliseconds: 500));
+    tick(const Duration(milliseconds: 0));
+    tick(const Duration(milliseconds: 500));
     expect(controller.velocity, inInclusiveRange(0.9, 1.1));
 
     // edges
     controller.forward();
     expect(controller.velocity, inInclusiveRange(0.4, 0.6));
-    WidgetsBinding.instance.handleBeginFrame(Duration.ZERO);
+    tick(Duration.ZERO);
     expect(controller.velocity, inInclusiveRange(0.4, 0.6));
-    WidgetsBinding.instance.handleBeginFrame(const Duration(milliseconds: 5));
+    tick(const Duration(milliseconds: 5));
     expect(controller.velocity, inInclusiveRange(0.9, 1.1));
 
     controller.forward(from: 0.5);
     expect(controller.velocity, inInclusiveRange(0.4, 0.6));
-    WidgetsBinding.instance.handleBeginFrame(Duration.ZERO);
+    tick(Duration.ZERO);
     expect(controller.velocity, inInclusiveRange(0.4, 0.6));
-    WidgetsBinding.instance.handleBeginFrame(const Duration(milliseconds: 5));
+    tick(const Duration(milliseconds: 5));
     expect(controller.velocity, inInclusiveRange(0.9, 1.1));
 
     // stopped
     controller.forward(from: 1.0);
     expect(controller.velocity, 0.0);
-    WidgetsBinding.instance.handleBeginFrame(Duration.ZERO);
+    tick(Duration.ZERO);
     expect(controller.velocity, 0.0);
-    WidgetsBinding.instance.handleBeginFrame(const Duration(milliseconds: 500));
+    tick(const Duration(milliseconds: 500));
     expect(controller.velocity, 0.0);
 
     controller.forward();
-    WidgetsBinding.instance.handleBeginFrame(Duration.ZERO);
-    WidgetsBinding.instance.handleBeginFrame(const Duration(milliseconds: 1000));
+    tick(Duration.ZERO);
+    tick(const Duration(milliseconds: 1000));
     expect(controller.velocity, 0.0);
 
     controller.stop();

--- a/packages/flutter/test/animation/futures_test.dart
+++ b/packages/flutter/test/animation/futures_test.dart
@@ -4,6 +4,7 @@
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/animation.dart';
+import 'package:flutter/scheduler.dart';
 import 'package:flutter/widgets.dart';
 
 void main() {
@@ -25,10 +26,10 @@ void main() {
       log.add('a'); // t=0
       await controller1.forward(); // starts at t=0 again
       log.add('b'); // wants to end at t=100 but missed frames until t=150
-      await controller2.forward(); // starts at t=200
-      log.add('c'); // wants to end at t=800 but missed frames until t=850
-      await controller3.forward(); // starts at t=1200
-      log.add('d'); // wants to end at t=1500 but missed frames until t=1600
+      await controller2.forward(); // starts at t=150
+      log.add('c'); // wants to end at t=750 but missed frames until t=799
+      await controller3.forward(); // starts at t=799
+      log.add('d'); // wants to end at t=1099 but missed frames until t=1200
     }
     log.add('start');
     runTest().then((Null value) {
@@ -47,11 +48,11 @@ void main() {
     await tester.pump(const Duration(milliseconds: 400)); // t=600
     expect(log, <String>['start', 'a', 'b']);
     await tester.pump(const Duration(milliseconds: 199)); // t=799
-    expect(log, <String>['start', 'a', 'b']);
+    expect(log, <String>['start', 'a', 'b', 'c']);
     await tester.pump(const Duration(milliseconds: 51)); // t=850
     expect(log, <String>['start', 'a', 'b', 'c']);
     await tester.pump(const Duration(milliseconds: 400)); // t=1200
-    expect(log, <String>['start', 'a', 'b', 'c']);
+    expect(log, <String>['start', 'a', 'b', 'c', 'd', 'end']);
     await tester.pump(const Duration(milliseconds: 400)); // t=1600
     expect(log, <String>['start', 'a', 'b', 'c', 'd', 'end']);
   });
@@ -74,10 +75,10 @@ void main() {
       log.add('a'); // t=0
       await controller1.forward().orCancel; // starts at t=0 again
       log.add('b'); // wants to end at t=100 but missed frames until t=150
-      await controller2.forward().orCancel; // starts at t=200
-      log.add('c'); // wants to end at t=800 but missed frames until t=850
-      await controller3.forward().orCancel; // starts at t=1200
-      log.add('d'); // wants to end at t=1500 but missed frames until t=1600
+      await controller2.forward().orCancel; // starts at t=150
+      log.add('c'); // wants to end at t=750 but missed frames until t=799
+      await controller3.forward().orCancel; // starts at t=799
+      log.add('d'); // wants to end at t=1099 but missed frames until t=1200
     }
     log.add('start');
     runTest().then((Null value) {
@@ -96,11 +97,11 @@ void main() {
     await tester.pump(const Duration(milliseconds: 400)); // t=600
     expect(log, <String>['start', 'a', 'b']);
     await tester.pump(const Duration(milliseconds: 199)); // t=799
-    expect(log, <String>['start', 'a', 'b']);
+    expect(log, <String>['start', 'a', 'b', 'c']);
     await tester.pump(const Duration(milliseconds: 51)); // t=850
     expect(log, <String>['start', 'a', 'b', 'c']);
     await tester.pump(const Duration(milliseconds: 400)); // t=1200
-    expect(log, <String>['start', 'a', 'b', 'c']);
+    expect(log, <String>['start', 'a', 'b', 'c', 'd', 'end']);
     await tester.pump(const Duration(milliseconds: 400)); // t=1600
     expect(log, <String>['start', 'a', 'b', 'c', 'd', 'end']);
   });

--- a/packages/flutter/test/foundation/service_extensions_test.dart
+++ b/packages/flutter/test/foundation/service_extensions_test.dart
@@ -50,10 +50,13 @@ class TestServiceExtensionsBinding extends BindingBase
   void scheduleFrame() {
     frameScheduled = true;
   }
-  void doFrame() {
+  Future<Null> doFrame() async {
     frameScheduled = false;
     if (ui.window.onBeginFrame != null)
       ui.window.onBeginFrame(Duration.ZERO);
+    await flushMicrotasks();
+    if (ui.window.onDrawFrame != null)
+      ui.window.onDrawFrame();
   }
 
   Future<Null> flushMicrotasks() {
@@ -72,7 +75,7 @@ Future<Map<String, String>> hasReassemble(Future<Map<String, String>> pendingRes
   await binding.flushMicrotasks();
   expect(binding.frameScheduled, isTrue);
   expect(completed, isFalse);
-  binding.doFrame();
+  await binding.doFrame();
   await binding.flushMicrotasks();
   expect(completed, isTrue);
   expect(binding.frameScheduled, isFalse);
@@ -85,7 +88,7 @@ void main() {
   test('Service extensions - pretest', () async {
     binding = new TestServiceExtensionsBinding();
     expect(binding.frameScheduled, isTrue);
-    binding.doFrame(); // initial frame scheduled by creating the binding
+    await binding.doFrame(); // initial frame scheduled by creating the binding
     expect(binding.frameScheduled, isFalse);
 
     expect(debugPrint, equals(debugPrintThrottled));
@@ -134,6 +137,7 @@ void main() {
   test('Service extensions - debugDumpRenderTree', () async {
     Map<String, String> result;
 
+    await binding.doFrame();
     result = await binding.testExtension('debugDumpRenderTree', <String, String>{});
     expect(result, <String, String>{});
     expect(console, <Matcher>[
@@ -165,7 +169,7 @@ void main() {
     await binding.flushMicrotasks();
     expect(binding.frameScheduled, isTrue);
     expect(completed, isFalse);
-    binding.doFrame();
+    await binding.doFrame();
     await binding.flushMicrotasks();
     expect(completed, isTrue);
     expect(binding.frameScheduled, isFalse);
@@ -179,7 +183,7 @@ void main() {
     pendingResult = binding.testExtension('debugPaint', <String, String>{ 'enabled': 'false' });
     await binding.flushMicrotasks();
     expect(binding.frameScheduled, isTrue);
-    binding.doFrame();
+    await binding.doFrame();
     expect(binding.frameScheduled, isFalse);
     result = await pendingResult;
     expect(result, <String, String>{ 'enabled': 'false' });
@@ -294,7 +298,7 @@ void main() {
     await binding.flushMicrotasks();
     expect(completed, false);
     expect(binding.frameScheduled, isTrue);
-    binding.doFrame();
+    await binding.doFrame();
     await binding.flushMicrotasks();
     expect(completed, true);
     expect(binding.frameScheduled, isFalse);
@@ -319,7 +323,7 @@ void main() {
     await binding.flushMicrotasks();
     expect(binding.frameScheduled, isTrue);
     expect(completed, false);
-    binding.doFrame();
+    await binding.doFrame();
     await binding.flushMicrotasks();
     expect(completed, true);
     expect(binding.frameScheduled, isFalse);

--- a/packages/flutter/test/rendering/rendering_tester.dart
+++ b/packages/flutter/test/rendering/rendering_tester.dart
@@ -15,7 +15,7 @@ class TestRenderingFlutterBinding extends BindingBase with SchedulerBinding, Ser
   EnginePhase phase = EnginePhase.composite;
 
   @override
-  void beginFrame() {
+  void drawFrame() {
     assert(phase != EnginePhase.build, 'rendering_tester does not support testing the build phase; use flutter_test instead');
     pipelineOwner.flushLayout();
     if (phase == EnginePhase.layout)
@@ -82,7 +82,7 @@ void pumpFrame({ EnginePhase phase: EnginePhase.layout }) {
   assert(renderer.renderView != null);
   assert(renderer.renderView.child != null); // call layout() first!
   renderer.phase = phase;
-  renderer.beginFrame();
+  renderer.drawFrame();
 }
 
 class TestCallbackPainter extends CustomPainter {

--- a/packages/flutter/test/scheduler/animation_test.dart
+++ b/packages/flutter/test/scheduler/animation_test.dart
@@ -6,6 +6,8 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:test/test.dart';
 
+import 'scheduler_tester.dart';
+
 class TestSchedulerBinding extends BindingBase with SchedulerBinding { }
 
 void main() {
@@ -39,7 +41,7 @@ void main() {
     scheduler.scheduleFrameCallback(firstCallback);
     secondId = scheduler.scheduleFrameCallback(secondCallback);
 
-    scheduler.handleBeginFrame(const Duration(milliseconds: 16));
+    tick(const Duration(milliseconds: 16));
 
     expect(firstCallbackRan, isTrue);
     expect(secondCallbackRan, isFalse);
@@ -47,7 +49,7 @@ void main() {
     firstCallbackRan = false;
     secondCallbackRan = false;
 
-    scheduler.handleBeginFrame(const Duration(milliseconds: 32));
+    tick(const Duration(milliseconds: 32));
 
     expect(firstCallbackRan, isFalse);
     expect(secondCallbackRan, isFalse);

--- a/packages/flutter/test/scheduler/scheduler_tester.dart
+++ b/packages/flutter/test/scheduler/scheduler_tester.dart
@@ -1,0 +1,15 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/scheduler.dart';
+
+@Deprecated('animation_tester is not compatible with dart:async')
+class Future { } // so that people can't import us and dart:async
+
+void tick(Duration duration) {
+  // We don't bother running microtasks between these two calls
+  // because we don't use Futures in these tests and so don't care.
+  SchedulerBinding.instance.handleBeginFrame(duration);
+  SchedulerBinding.instance.handleDrawFrame();
+}

--- a/packages/flutter/test/widgets/animated_list_test.dart
+++ b/packages/flutter/test/widgets/animated_list_test.dart
@@ -144,7 +144,7 @@ void main() {
       duration: const Duration(milliseconds: 100),
     );
 
-    // Item's 0, 1, 2 at 0, 100, 200. All heights 100.
+    // Items 0, 1, 2 at 0, 100, 200. All heights 100.
     expect(itemTop(0), 0.0);
     expect(itemBottom(0), 100.0);
     expect(itemTop(1), 100.0);
@@ -154,7 +154,7 @@ void main() {
 
     // Newly removed item 0's height should animate from 100 to 0 over 100ms
 
-    // Item's 0, 1, 2 at 0, 50, 150. Item 0's height is 50.
+    // Items 0, 1, 2 at 0, 50, 150. Item 0's height is 50.
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 50));
     expect(itemTop(0), 0.0);
@@ -164,10 +164,8 @@ void main() {
     expect(itemTop(2), 150.0);
     expect(itemBottom(2), 250.0);
 
-    // Item's 0, 1, 2 at 0, 0, 0. Item 0's height is 0.
+    // Items 1, 2 at 0, 100.
     await tester.pumpAndSettle();
-    expect(itemTop(0), 0.0);
-    expect(itemBottom(0), 0.0);
     expect(itemTop(1), 0.0);
     expect(itemBottom(1), 100.0);
     expect(itemTop(2), 100.0);

--- a/packages/flutter/test/widgets/raw_keyboard_listener_test.dart
+++ b/packages/flutter/test/widgets/raw_keyboard_listener_test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:typed_data';
+
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -10,7 +12,8 @@ void sendFakeKeyEvent(Map<String, dynamic> data) {
   BinaryMessages.handlePlatformMessage(
     SystemChannels.keyEvent.name,
     SystemChannels.keyEvent.codec.encodeMessage(data),
-    (_) {});
+    (ByteData data) { },
+  );
 }
 
 void main() {
@@ -25,13 +28,15 @@ void main() {
     final List<RawKeyEvent> events = <RawKeyEvent>[];
 
     final FocusNode focusNode = new FocusNode();
-    tester.binding.focusManager.rootScope.requestFocus(focusNode);
 
     await tester.pumpWidget(new RawKeyboardListener(
       focusNode: focusNode,
       onKey: events.add,
       child: new Container(),
     ));
+
+    tester.binding.focusManager.rootScope.requestFocus(focusNode);
+    await tester.idle();
 
     sendFakeKeyEvent(<String, dynamic>{
       'type': 'keydown',
@@ -40,7 +45,6 @@ void main() {
       'codePoint': 0x64,
       'modifiers': 0x08,
     });
-
     await tester.idle();
 
     expect(events.length, 1);
@@ -60,13 +64,15 @@ void main() {
     final List<RawKeyEvent> events = <RawKeyEvent>[];
 
     final FocusNode focusNode = new FocusNode();
-    tester.binding.focusManager.rootScope.requestFocus(focusNode);
 
     await tester.pumpWidget(new RawKeyboardListener(
       focusNode: focusNode,
       onKey: events.add,
       child: new Container(),
     ));
+
+    tester.binding.focusManager.rootScope.requestFocus(focusNode);
+    await tester.idle();
 
     sendFakeKeyEvent(<String, dynamic>{
       'type': 'keydown',
@@ -75,7 +81,6 @@ void main() {
       'codePoint': 0x64,
       'modifiers': 0x08,
     });
-
     await tester.idle();
 
     expect(events.length, 1);

--- a/packages/flutter_test/lib/src/widget_tester.dart
+++ b/packages/flutter_test/lib/src/widget_tester.dart
@@ -210,10 +210,9 @@ class WidgetTester extends WidgetController implements HitTestDispatcher, Ticker
   }
 
   /// Repeatedly calls [pump] with the given `duration` until there are no
-  /// longer any transient callbacks scheduled. This will call [pump] at least
-  /// once, even if no transient callbacks are scheduled when the function is
-  /// called, in case there are dirty widgets to rebuild which will themselves
-  /// register new transient callbacks.
+  /// longer any frames scheduled. This will call [pump] at least once, even if
+  /// no frames are scheduled when the function is called, to flush any pending
+  /// microtasks which may themselves schedule a frame.
   ///
   /// This essentially waits for all animations to have completed.
   ///
@@ -251,13 +250,26 @@ class WidgetTester extends WidgetController implements HitTestDispatcher, Ticker
           throw new FlutterError('pumpAndSettle timed out');
         await binding.pump(duration, phase);
         count += 1;
-      } while (hasRunningAnimations);
+      } while (binding.hasScheduledFrame);
     }).then<int>((Null _) => count);
   }
 
-  /// Whether ther are any any transient callbacks scheduled.
+  /// Whether there are any any transient callbacks scheduled.
   ///
   /// This essentially checks whether all animations have completed.
+  ///
+  /// See also:
+  ///
+  ///  * [pumpAndSettle], which essentially calls [pump] until there are no
+  ///    scheduled frames.
+  ///
+  ///  * [SchedulerBinding.transientCallbackCount], which is the value on which
+  ///    this is based.
+  ///
+  ///  * [SchedulerBinding.hasScheduledFrame], which is true whenever a frame is
+  ///    pending. [SchedulerBinding.hasScheduledFrame] is made true when a
+  ///    widget calls [State.setState], even if there are no transient callbacks
+  ///    scheduled. This is what [pumpAndSettle] uses.
   bool get hasRunningAnimations => binding.transientCallbackCount > 0;
 
   @override


### PR DESCRIPTION
This splits the frame pipeline into two, beginFrame and drawFrame.

As part of making this change I added some debugging hooks that helped
debug the issues that came up:

 * I added debugPrintScheduleFrameStacks which prints a stack whenever
   a frame is actually scheduled, so you can see why frames are being
   scheduled.

 * I added some toString output to EditableText and RawKeyboardListener.

 * I added a scheduler_tester.dart library for scheduler library tests.

 * I changed the test framework to flush microtasks before pumping.

 * Some asserts that had the old string literal form were replaced by
   asserts with messages.

I also fixed a few subtle bugs that this uncovered:

 * setState() now calls `ensureVisualUpdate`, rather than
   `scheduleFrame`. This means that calling it from an
   AnimationController callback does not actually schedule an extra
   redundant frame as it used to.

 * I corrected some documentation.