### PR TITLE
Android plugin registry

### DIFF
--- a/packages/flutter_tools/lib/src/plugins.dart
+++ b/packages/flutter_tools/lib/src/plugins.dart
@@ -130,7 +130,7 @@ const String _iosPluginRegistryHeaderTemplate = '''//
 #import "{{class}}.h"
 {{/plugins}}
 
-@interface PluginRegistry : FlutterPluginRegistry
+@interface PluginRegistry : NSObject
 
 {{#plugins}}
 @property (readonly, nonatomic) {{class}} *{{name}};
@@ -149,7 +149,7 @@ const String _iosPluginRegistryImplementationTemplate = '''//
 
 #import "PluginRegistry.h"
 
-@implementation PluginRegistry : NSObject
+@implementation PluginRegistry
 
 - (instancetype)initWithController:(FlutterViewController *)controller {
   if (self = [super init]) {

--- a/packages/flutter_tools/lib/src/plugins.dart
+++ b/packages/flutter_tools/lib/src/plugins.dart
@@ -149,13 +149,12 @@ const String _iosPluginRegistryImplementationTemplate = '''//
 
 #import "PluginRegistry.h"
 
-@implementation PluginRegistry
+@implementation PluginRegistry : NSObject
 
 - (instancetype)initWithController:(FlutterViewController *)controller {
   if (self = [super init]) {
 {{#plugins}}
     _{{name}} = [[{{class}} alloc] initWithController:controller];
-    [self registerPlugin:_{{name}}];
 {{/plugins}}
   }
   return self;

--- a/packages/flutter_tools/lib/src/plugins.dart
+++ b/packages/flutter_tools/lib/src/plugins.dart
@@ -84,13 +84,12 @@ import {{package}}.{{class}};
 /**
  * Generated file. Do not edit.
  */
-public final class GeneratedPluginRegistry extends PluginRegistry {
-    @Override
-    public void registerPlugins(PluginContext context) {
+public final class GeneratedPluginRegistrant {
+  public static void registerWith(PluginRegistry registry) {
 {{#plugins}}
-        {{class}}.register(context);
+    {{class}}.registerWith(registry.registrarFor("{{package}}.{{class}}"));
 {{/plugins}}
-    }
+  }
 }
 ''';
 
@@ -113,7 +112,7 @@ void _writeAndroidPluginRegistry(String directory, List<Plugin> plugins) {
   final Directory registryDirectory =
       fs.directory(fs.path.join(javaSourcePath, 'io', 'flutter', 'plugin', 'common'));
   registryDirectory.createSync(recursive: true);
-  final File registryFile = registryDirectory.childFile('GeneratedPluginRegistry.java');
+  final File registryFile = registryDirectory.childFile('GeneratedPluginRegistrant.java');
   registryFile.writeAsStringSync(pluginRegistry);
 }
 

--- a/packages/flutter_tools/lib/src/plugins.dart
+++ b/packages/flutter_tools/lib/src/plugins.dart
@@ -75,9 +75,10 @@ void _writeFlutterPluginsList(String directory, List<Plugin> plugins) {
   }
 }
 
-const String _androidPluginRegistryTemplate = '''package io.flutter.plugin.common;
+const String _androidPluginRegistryTemplate = '''package io.flutter.plugins;
 
 {{#plugins}}
+import io.flutter.plugin.common.PluginRegistry;
 import {{package}}.{{class}};
 {{/plugins}}
 
@@ -110,7 +111,7 @@ void _writeAndroidPluginRegistry(String directory, List<Plugin> plugins) {
       new mustache.Template(_androidPluginRegistryTemplate).renderString(context);
   final String javaSourcePath = fs.path.join(directory, 'android', 'app', 'src', 'main', 'java');
   final Directory registryDirectory =
-      fs.directory(fs.path.join(javaSourcePath, 'io', 'flutter', 'plugin', 'common'));
+      fs.directory(fs.path.join(javaSourcePath, 'io', 'flutter', 'plugins'));
   registryDirectory.createSync(recursive: true);
   final File registryFile = registryDirectory.childFile('GeneratedPluginRegistrant.java');
   registryFile.writeAsStringSync(pluginRegistry);

--- a/packages/flutter_tools/templates/create/android.tmpl/.gitignore
+++ b/packages/flutter_tools/templates/create/android.tmpl/.gitignore
@@ -6,7 +6,7 @@
 .DS_Store
 /build
 /captures
-PluginRegistry.java
+GeneratedPluginRegistry.java
 
 /gradle
 /gradlew

--- a/packages/flutter_tools/templates/create/android.tmpl/.gitignore
+++ b/packages/flutter_tools/templates/create/android.tmpl/.gitignore
@@ -6,7 +6,7 @@
 .DS_Store
 /build
 /captures
-GeneratedPluginRegistry.java
+GeneratedPluginRegistrant.java
 
 /gradle
 /gradlew

--- a/packages/flutter_tools/templates/create/android.tmpl/app/src/main/java/com/yourcompany/projectName/MainActivity.java.tmpl
+++ b/packages/flutter_tools/templates/create/android.tmpl/app/src/main/java/com/yourcompany/projectName/MainActivity.java.tmpl
@@ -2,15 +2,10 @@ package {{androidIdentifier}};
 
 import android.os.Bundle;
 import io.flutter.app.FlutterActivity;
-import io.flutter.plugins.PluginRegistry;
+import io.flutter.plugin.common.GeneratedPluginRegistry;
 
 public class MainActivity extends FlutterActivity {
-    PluginRegistry pluginRegistry;
-
-    @Override
-    protected void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-        pluginRegistry = new PluginRegistry();
-        pluginRegistry.registerAll(this);
+    public MainActivity() {
+      super(new GeneratedPluginRegistry());
     }
 }

--- a/packages/flutter_tools/templates/create/android.tmpl/app/src/main/java/com/yourcompany/projectName/MainActivity.java.tmpl
+++ b/packages/flutter_tools/templates/create/android.tmpl/app/src/main/java/com/yourcompany/projectName/MainActivity.java.tmpl
@@ -1,6 +1,5 @@
 package {{androidIdentifier}};
 
-import android.os.Bundle;
 import io.flutter.app.FlutterActivity;
 import io.flutter.plugin.common.GeneratedPluginRegistry;
 

--- a/packages/flutter_tools/templates/create/android.tmpl/app/src/main/java/com/yourcompany/projectName/MainActivity.java.tmpl
+++ b/packages/flutter_tools/templates/create/android.tmpl/app/src/main/java/com/yourcompany/projectName/MainActivity.java.tmpl
@@ -1,10 +1,14 @@
 package {{androidIdentifier}};
 
+import android.os.Bundle;
+
 import io.flutter.app.FlutterActivity;
-import io.flutter.plugin.common.GeneratedPluginRegistry;
+import io.flutter.plugin.common.GeneratedPluginRegistrant;
 
 public class MainActivity extends FlutterActivity {
-    public MainActivity() {
-      super(new GeneratedPluginRegistry());
-    }
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    GeneratedPluginRegistrant.registerWith(this);
+  }
 }

--- a/packages/flutter_tools/templates/plugin/android.tmpl/src/main/java/com/yourcompany/projectName/pluginClass.java.tmpl
+++ b/packages/flutter_tools/templates/plugin/android.tmpl/src/main/java/com/yourcompany/projectName/pluginClass.java.tmpl
@@ -1,24 +1,24 @@
 package {{androidIdentifier}};
 
-import io.flutter.app.FlutterActivity;
 import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
 import io.flutter.plugin.common.MethodChannel.Result;
 import io.flutter.plugin.common.MethodCall;
+import io.flutter.plugin.common.PluginRegistry.PluginContext;
 
 /**
  * {{pluginClass}}
  */
 public class {{pluginClass}} implements MethodCallHandler {
-  private FlutterActivity activity;
+  private final PluginContext context;
 
-  public static {{pluginClass}} register(FlutterActivity activity) {
-    return new {{pluginClass}}(activity);
+  public static void register(PluginContext context) {
+    final {{pluginClass}} instance = new {{pluginClass}}(context);
+    context.newMethodChannel("{{projectName}}").setMethodCallHandler(instance);
   }
 
-  private {{pluginClass}}(FlutterActivity activity) {
-    this.activity = activity;
-    new MethodChannel(activity.getFlutterView(), "{{projectName}}").setMethodCallHandler(this);
+  private {{pluginClass}}(PluginContext context) {
+    this.context = context;
   }
 
   @Override

--- a/packages/flutter_tools/templates/plugin/android.tmpl/src/main/java/com/yourcompany/projectName/pluginClass.java.tmpl
+++ b/packages/flutter_tools/templates/plugin/android.tmpl/src/main/java/com/yourcompany/projectName/pluginClass.java.tmpl
@@ -4,21 +4,18 @@ import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
 import io.flutter.plugin.common.MethodChannel.Result;
 import io.flutter.plugin.common.MethodCall;
-import io.flutter.plugin.common.PluginRegistry.PluginContext;
+import io.flutter.plugin.common.PluginRegistry.Registrar;
 
 /**
  * {{pluginClass}}
  */
 public class {{pluginClass}} implements MethodCallHandler {
-  private final PluginContext context;
-
-  public static void register(PluginContext context) {
-    final {{pluginClass}} instance = new {{pluginClass}}(context);
-    context.newMethodChannel("{{projectName}}").setMethodCallHandler(instance);
-  }
-
-  private {{pluginClass}}(PluginContext context) {
-    this.context = context;
+  /**
+   * Plugin registration.
+   */
+  public static void registerWith(Registrar registrar) {
+    final MethodChannel channel = new MethodChannel(registrar.messenger(), "{{projectName}}");
+    channel.setMethodCallHandler(new {{pluginClass}}());
   }
 
   @Override


### PR DESCRIPTION
Add gearing between plugins and the application context defined by custom Application and Activity classes supplied by the app author. Design constraints/goals:

- Avoid forcing apps to use FlutterApplication/FlutterActivity just to integrate plugins.
- Avoid being in the way of advanced plugin/Activity interaction (use of gearing should not be mandatory).
- Allow consuming simple/common plugins without forcing app author to write Android-specific code.
- Provide convenience for simple and common cases, including plugin-defined callbacks for common Activity lifecycle methods.
- Make the "simple/common cases" an extensible notion without incurring breaking changes when extended.

Android only in this PR. Accompanying flutter/engine PR: https://github.com/flutter/engine/pull/3641.
Partially addresses flutter/flutter#9215