### PR TITLE
Left align AppBar title on iOS with multiple actions

### DIFF
--- a/packages/flutter/lib/src/material/app_bar.dart
+++ b/packages/flutter/lib/src/material/app_bar.dart
@@ -311,7 +311,7 @@ class AppBar extends StatefulWidget implements PreferredSizeWidget {
       case TargetPlatform.fuchsia:
         return false;
       case TargetPlatform.iOS:
-        return true;
+        return actions == null || actions.length < 2;
     }
     return null;
   }

--- a/packages/flutter/test/material/app_bar_test.dart
+++ b/packages/flutter/test/material/app_bar_test.dart
@@ -90,6 +90,48 @@ void main() {
     size = tester.getSize(title);
     expect(center.dx, greaterThan(400 - size.width / 2.0));
     expect(center.dx, lessThan(400 + size.width / 2.0));
+
+    // One action is still centered.
+
+    await tester.pumpWidget(
+      new MaterialApp(
+        theme: new ThemeData(platform: TargetPlatform.iOS),
+        home: new Scaffold(
+          appBar: new AppBar(
+            title: const Text('X'),
+            actions: <Widget>[
+              const Icon(Icons.thumb_up),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    center = tester.getCenter(title);
+    size = tester.getSize(title);
+    expect(center.dx, greaterThan(400 - size.width / 2.0));
+    expect(center.dx, lessThan(400 + size.width / 2.0));
+
+    // Two actions is left aligned again.
+
+    await tester.pumpWidget(
+      new MaterialApp(
+        theme: new ThemeData(platform: TargetPlatform.iOS),
+        home: new Scaffold(
+          appBar: new AppBar(
+            title: const Text('X'),
+            actions: <Widget>[
+              const Icon(Icons.thumb_up),
+              const Icon(Icons.thumb_up),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    center = tester.getCenter(title);
+    size = tester.getSize(title);
+    expect(center.dx, lessThan(400 - size.width / 2.0));
   });
 
   testWidgets('AppBar centerTitle:true centers on Android', (WidgetTester tester) async {
@@ -104,7 +146,6 @@ void main() {
         )
       )
     );
-
 
     final Finder title = find.text('X');
     final Offset center = tester.getCenter(title);


### PR DESCRIPTION
If there is more than one action, then the AppBar should align the title to the
left according to
<https://material.io/guidelines/platforms/platform-adaptation.html#platform-adaptation-platform-recommendations>