### PR TITLE
Set Linux distro to Ubuntu Trusty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
-os:
-  - linux
+os: linux
+dist: trusty
 sudo: false
 addons:
   apt:


### PR DESCRIPTION
Workaround for Rubygems issue with Travis CI on 2017-05-02 (default is
Precise).