### PR TITLE
Gallery Cupertino Dialog demo toast fix

### DIFF
--- a/examples/flutter_gallery/lib/demo/cupertino/cupertino_dialog_demo.dart
+++ b/examples/flutter_gallery/lib/demo/cupertino/cupertino_dialog_demo.dart
@@ -54,7 +54,7 @@ class _CupertinoDialogDemoState extends State<CupertinoDialogDemo> {
                     new CupertinoDialogAction(
                       child: const Text('Discard'),
                       isDestructive: true,
-                      onPressed: () { Navigator.pop(context, 'OK'); }
+                      onPressed: () { Navigator.pop(context, 'Discard'); }
                     ),
                     new CupertinoDialogAction(
                       child: const Text('Cancel', style: const TextStyle(fontWeight: FontWeight.w600)),


### PR DESCRIPTION
Fixes #9757 
The toast displays a string given by the button. Nothing major.