### PR TITLE
Upgrade dartdoc to 0.11.0 for flutter.

### DIFF
--- a/dev/bots/docs.sh
+++ b/dev/bots/docs.sh
@@ -2,7 +2,7 @@
 set -e
 
 # Install dartdoc.
-pub global activate dartdoc 0.9.11
+pub global activate dartdoc 0.11.0
 
 # This script generates a unified doc set, and creates
 # a custom index.html, placing everything into dev/docs/doc

--- a/dev/tools/dartdoc.dart
+++ b/dev/tools/dartdoc.dart
@@ -77,7 +77,9 @@ dependencies:
     '--footer', 'lib/footer.html',
     '--exclude', 'temp_doc',
     '--favicon=favicon.ico',
-    '--use-categories'
+    '--use-categories',
+    '--category-order',
+    'flutter,Dart Core,flutter_markdown,flutter_test,flutter_driver',
   ];
 
   for (String libraryRef in libraryRefs(diskPath: true)) {


### PR DESCRIPTION
@Hixie @devoncarew @sethladd -- I think dartdoc is finally ready to be upgraded for flutter.  While this change is tiny, implications are large.  To make this somewhat easier to review:

http://jcollins1.pdx.corp.google.com:8000/  -- flutter docs by 0.11.0 (new version), serving:  [flutter0110demo.tar.gz](https://drive.google.com/open?id=0B1OzuuJ9qy6SOXFuR0IwdEJOR00).

http://jcollins1.pdx.corp.google.com:8001/  -- flutter docs by 0.9.11 (old version), serving:
[flutter0911demo.tar.gz](https://drive.google.com/open?id=0B1OzuuJ9qy6SN3doenF6bXVGZVk).   This is the same as http://docs.flutter.io, but generated from the exact same flutter rev as the one, above.

Text diff between the two: [flutter-0.11.0-doc.diff.gz](https://drive.google.com/open?id=0B1OzuuJ9qy6ST3NBbEdWMGdmWUU)

And, of course, the dartdoc [CHANGELOG](https://github.com/dart-lang/dartdoc/blob/v0.11.0/CHANGELOG.md).

There are many warnings printed by dartdoc now which you will likely see in the [bot output](https://travis-ci.org/flutter/flutter/jobs/228869215).  I believe these were all problems before, but are now visible and deduped.   While it of course does not fix every bug ever, please approve if you think that this is a step forward for flutter's dartdocs.