### PR TITLE
Workaround for intermittent pub crash on macOS.

### DIFF
--- a/packages/flutter_tools/bin/flutter_tools.dart
+++ b/packages/flutter_tools/bin/flutter_tools.dart
@@ -4,6 +4,14 @@
 
 import 'package:flutter_tools/executable.dart' as executable;
 
+// Temporary workaround for https://github.com/flutter/flutter/issues/9727
+bool get initializeLibNotify {
+  final DateTime date = new DateTime.now();
+  return date.month == 1;
+}
+
 void main(List<String> args) {
+  // ignore: UNUSED_LOCAL_VARIABLE
+  final bool x = initializeLibNotify;
   executable.main(args);
 }


### PR DESCRIPTION
Eagerly initialize libnotify by accessing the current date. See dart-lang/sdk#29539 for details.

This workaround should be removed after the next Dart SDK roll.

Fixes #9727.