### PR TITLE
add Dart_SDK project library to examples that don't have it

### DIFF
--- a/examples/flutter_view/.idea/libraries/Dart_SDK.xml
+++ b/examples/flutter_view/.idea/libraries/Dart_SDK.xml
@@ -1,0 +1,26 @@
+<component name="libraryTable">
+  <library name="Dart SDK">
+    <CLASSES>
+      <root url="file://$PROJECT_DIR$/../../bin/cache/dart-sdk/lib/async" />
+      <root url="file://$PROJECT_DIR$/../../bin/cache/dart-sdk/lib/collection" />
+      <root url="file://$PROJECT_DIR$/../../bin/cache/dart-sdk/lib/convert" />
+      <root url="file://$PROJECT_DIR$/../../bin/cache/dart-sdk/lib/core" />
+      <root url="file://$PROJECT_DIR$/../../bin/cache/dart-sdk/lib/developer" />
+      <root url="file://$PROJECT_DIR$/../../bin/cache/dart-sdk/lib/html" />
+      <root url="file://$PROJECT_DIR$/../../bin/cache/dart-sdk/lib/indexed_db" />
+      <root url="file://$PROJECT_DIR$/../../bin/cache/dart-sdk/lib/io" />
+      <root url="file://$PROJECT_DIR$/../../bin/cache/dart-sdk/lib/isolate" />
+      <root url="file://$PROJECT_DIR$/../../bin/cache/dart-sdk/lib/js" />
+      <root url="file://$PROJECT_DIR$/../../bin/cache/dart-sdk/lib/js_util" />
+      <root url="file://$PROJECT_DIR$/../../bin/cache/dart-sdk/lib/math" />
+      <root url="file://$PROJECT_DIR$/../../bin/cache/dart-sdk/lib/mirrors" />
+      <root url="file://$PROJECT_DIR$/../../bin/cache/dart-sdk/lib/svg" />
+      <root url="file://$PROJECT_DIR$/../../bin/cache/dart-sdk/lib/typed_data" />
+      <root url="file://$PROJECT_DIR$/../../bin/cache/dart-sdk/lib/web_audio" />
+      <root url="file://$PROJECT_DIR$/../../bin/cache/dart-sdk/lib/web_gl" />
+      <root url="file://$PROJECT_DIR$/../../bin/cache/dart-sdk/lib/web_sql" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES />
+  </library>
+</component>

--- a/examples/hello_world/.idea/libraries/Dart_SDK.xml
+++ b/examples/hello_world/.idea/libraries/Dart_SDK.xml
@@ -1,0 +1,26 @@
+<component name="libraryTable">
+  <library name="Dart SDK">
+    <CLASSES>
+      <root url="file://$PROJECT_DIR$/../../bin/cache/dart-sdk/lib/async" />
+      <root url="file://$PROJECT_DIR$/../../bin/cache/dart-sdk/lib/collection" />
+      <root url="file://$PROJECT_DIR$/../../bin/cache/dart-sdk/lib/convert" />
+      <root url="file://$PROJECT_DIR$/../../bin/cache/dart-sdk/lib/core" />
+      <root url="file://$PROJECT_DIR$/../../bin/cache/dart-sdk/lib/developer" />
+      <root url="file://$PROJECT_DIR$/../../bin/cache/dart-sdk/lib/html" />
+      <root url="file://$PROJECT_DIR$/../../bin/cache/dart-sdk/lib/indexed_db" />
+      <root url="file://$PROJECT_DIR$/../../bin/cache/dart-sdk/lib/io" />
+      <root url="file://$PROJECT_DIR$/../../bin/cache/dart-sdk/lib/isolate" />
+      <root url="file://$PROJECT_DIR$/../../bin/cache/dart-sdk/lib/js" />
+      <root url="file://$PROJECT_DIR$/../../bin/cache/dart-sdk/lib/js_util" />
+      <root url="file://$PROJECT_DIR$/../../bin/cache/dart-sdk/lib/math" />
+      <root url="file://$PROJECT_DIR$/../../bin/cache/dart-sdk/lib/mirrors" />
+      <root url="file://$PROJECT_DIR$/../../bin/cache/dart-sdk/lib/svg" />
+      <root url="file://$PROJECT_DIR$/../../bin/cache/dart-sdk/lib/typed_data" />
+      <root url="file://$PROJECT_DIR$/../../bin/cache/dart-sdk/lib/web_audio" />
+      <root url="file://$PROJECT_DIR$/../../bin/cache/dart-sdk/lib/web_gl" />
+      <root url="file://$PROJECT_DIR$/../../bin/cache/dart-sdk/lib/web_sql" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES />
+  </library>
+</component>

--- a/examples/layers/.idea/libraries/Dart_SDK.xml
+++ b/examples/layers/.idea/libraries/Dart_SDK.xml
@@ -1,0 +1,26 @@
+<component name="libraryTable">
+  <library name="Dart SDK">
+    <CLASSES>
+      <root url="file://$PROJECT_DIR$/../../bin/cache/dart-sdk/lib/async" />
+      <root url="file://$PROJECT_DIR$/../../bin/cache/dart-sdk/lib/collection" />
+      <root url="file://$PROJECT_DIR$/../../bin/cache/dart-sdk/lib/convert" />
+      <root url="file://$PROJECT_DIR$/../../bin/cache/dart-sdk/lib/core" />
+      <root url="file://$PROJECT_DIR$/../../bin/cache/dart-sdk/lib/developer" />
+      <root url="file://$PROJECT_DIR$/../../bin/cache/dart-sdk/lib/html" />
+      <root url="file://$PROJECT_DIR$/../../bin/cache/dart-sdk/lib/indexed_db" />
+      <root url="file://$PROJECT_DIR$/../../bin/cache/dart-sdk/lib/io" />
+      <root url="file://$PROJECT_DIR$/../../bin/cache/dart-sdk/lib/isolate" />
+      <root url="file://$PROJECT_DIR$/../../bin/cache/dart-sdk/lib/js" />
+      <root url="file://$PROJECT_DIR$/../../bin/cache/dart-sdk/lib/js_util" />
+      <root url="file://$PROJECT_DIR$/../../bin/cache/dart-sdk/lib/math" />
+      <root url="file://$PROJECT_DIR$/../../bin/cache/dart-sdk/lib/mirrors" />
+      <root url="file://$PROJECT_DIR$/../../bin/cache/dart-sdk/lib/svg" />
+      <root url="file://$PROJECT_DIR$/../../bin/cache/dart-sdk/lib/typed_data" />
+      <root url="file://$PROJECT_DIR$/../../bin/cache/dart-sdk/lib/web_audio" />
+      <root url="file://$PROJECT_DIR$/../../bin/cache/dart-sdk/lib/web_gl" />
+      <root url="file://$PROJECT_DIR$/../../bin/cache/dart-sdk/lib/web_sql" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES />
+  </library>
+</component>

--- a/examples/platform_channel/.idea/libraries/Dart_SDK.xml
+++ b/examples/platform_channel/.idea/libraries/Dart_SDK.xml
@@ -1,0 +1,26 @@
+<component name="libraryTable">
+  <library name="Dart SDK">
+    <CLASSES>
+      <root url="file://$PROJECT_DIR$/../../bin/cache/dart-sdk/lib/async" />
+      <root url="file://$PROJECT_DIR$/../../bin/cache/dart-sdk/lib/collection" />
+      <root url="file://$PROJECT_DIR$/../../bin/cache/dart-sdk/lib/convert" />
+      <root url="file://$PROJECT_DIR$/../../bin/cache/dart-sdk/lib/core" />
+      <root url="file://$PROJECT_DIR$/../../bin/cache/dart-sdk/lib/developer" />
+      <root url="file://$PROJECT_DIR$/../../bin/cache/dart-sdk/lib/html" />
+      <root url="file://$PROJECT_DIR$/../../bin/cache/dart-sdk/lib/indexed_db" />
+      <root url="file://$PROJECT_DIR$/../../bin/cache/dart-sdk/lib/io" />
+      <root url="file://$PROJECT_DIR$/../../bin/cache/dart-sdk/lib/isolate" />
+      <root url="file://$PROJECT_DIR$/../../bin/cache/dart-sdk/lib/js" />
+      <root url="file://$PROJECT_DIR$/../../bin/cache/dart-sdk/lib/js_util" />
+      <root url="file://$PROJECT_DIR$/../../bin/cache/dart-sdk/lib/math" />
+      <root url="file://$PROJECT_DIR$/../../bin/cache/dart-sdk/lib/mirrors" />
+      <root url="file://$PROJECT_DIR$/../../bin/cache/dart-sdk/lib/svg" />
+      <root url="file://$PROJECT_DIR$/../../bin/cache/dart-sdk/lib/typed_data" />
+      <root url="file://$PROJECT_DIR$/../../bin/cache/dart-sdk/lib/web_audio" />
+      <root url="file://$PROJECT_DIR$/../../bin/cache/dart-sdk/lib/web_gl" />
+      <root url="file://$PROJECT_DIR$/../../bin/cache/dart-sdk/lib/web_sql" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES />
+  </library>
+</component>

--- a/examples/platform_channel_swift/.idea/libraries/Dart_SDK.xml
+++ b/examples/platform_channel_swift/.idea/libraries/Dart_SDK.xml
@@ -1,0 +1,26 @@
+<component name="libraryTable">
+  <library name="Dart SDK">
+    <CLASSES>
+      <root url="file://$PROJECT_DIR$/../../bin/cache/dart-sdk/lib/async" />
+      <root url="file://$PROJECT_DIR$/../../bin/cache/dart-sdk/lib/collection" />
+      <root url="file://$PROJECT_DIR$/../../bin/cache/dart-sdk/lib/convert" />
+      <root url="file://$PROJECT_DIR$/../../bin/cache/dart-sdk/lib/core" />
+      <root url="file://$PROJECT_DIR$/../../bin/cache/dart-sdk/lib/developer" />
+      <root url="file://$PROJECT_DIR$/../../bin/cache/dart-sdk/lib/html" />
+      <root url="file://$PROJECT_DIR$/../../bin/cache/dart-sdk/lib/indexed_db" />
+      <root url="file://$PROJECT_DIR$/../../bin/cache/dart-sdk/lib/io" />
+      <root url="file://$PROJECT_DIR$/../../bin/cache/dart-sdk/lib/isolate" />
+      <root url="file://$PROJECT_DIR$/../../bin/cache/dart-sdk/lib/js" />
+      <root url="file://$PROJECT_DIR$/../../bin/cache/dart-sdk/lib/js_util" />
+      <root url="file://$PROJECT_DIR$/../../bin/cache/dart-sdk/lib/math" />
+      <root url="file://$PROJECT_DIR$/../../bin/cache/dart-sdk/lib/mirrors" />
+      <root url="file://$PROJECT_DIR$/../../bin/cache/dart-sdk/lib/svg" />
+      <root url="file://$PROJECT_DIR$/../../bin/cache/dart-sdk/lib/typed_data" />
+      <root url="file://$PROJECT_DIR$/../../bin/cache/dart-sdk/lib/web_audio" />
+      <root url="file://$PROJECT_DIR$/../../bin/cache/dart-sdk/lib/web_gl" />
+      <root url="file://$PROJECT_DIR$/../../bin/cache/dart-sdk/lib/web_sql" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES />
+  </library>
+</component>

--- a/examples/stocks/.idea/libraries/Dart_SDK.xml
+++ b/examples/stocks/.idea/libraries/Dart_SDK.xml
@@ -1,0 +1,26 @@
+<component name="libraryTable">
+  <library name="Dart SDK">
+    <CLASSES>
+      <root url="file://$PROJECT_DIR$/../../bin/cache/dart-sdk/lib/async" />
+      <root url="file://$PROJECT_DIR$/../../bin/cache/dart-sdk/lib/collection" />
+      <root url="file://$PROJECT_DIR$/../../bin/cache/dart-sdk/lib/convert" />
+      <root url="file://$PROJECT_DIR$/../../bin/cache/dart-sdk/lib/core" />
+      <root url="file://$PROJECT_DIR$/../../bin/cache/dart-sdk/lib/developer" />
+      <root url="file://$PROJECT_DIR$/../../bin/cache/dart-sdk/lib/html" />
+      <root url="file://$PROJECT_DIR$/../../bin/cache/dart-sdk/lib/indexed_db" />
+      <root url="file://$PROJECT_DIR$/../../bin/cache/dart-sdk/lib/io" />
+      <root url="file://$PROJECT_DIR$/../../bin/cache/dart-sdk/lib/isolate" />
+      <root url="file://$PROJECT_DIR$/../../bin/cache/dart-sdk/lib/js" />
+      <root url="file://$PROJECT_DIR$/../../bin/cache/dart-sdk/lib/js_util" />
+      <root url="file://$PROJECT_DIR$/../../bin/cache/dart-sdk/lib/math" />
+      <root url="file://$PROJECT_DIR$/../../bin/cache/dart-sdk/lib/mirrors" />
+      <root url="file://$PROJECT_DIR$/../../bin/cache/dart-sdk/lib/svg" />
+      <root url="file://$PROJECT_DIR$/../../bin/cache/dart-sdk/lib/typed_data" />
+      <root url="file://$PROJECT_DIR$/../../bin/cache/dart-sdk/lib/web_audio" />
+      <root url="file://$PROJECT_DIR$/../../bin/cache/dart-sdk/lib/web_gl" />
+      <root url="file://$PROJECT_DIR$/../../bin/cache/dart-sdk/lib/web_sql" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES />
+  </library>
+</component>


### PR DESCRIPTION
This ensures that when someone opens the project using IDEA,
the Flutter plugin will find the location of the Flutter SDK
and automatically run "flutter packages get".