### PR TITLE
Gallery animation demo back button update

### DIFF
--- a/examples/flutter_gallery/lib/demo/animation/home.dart
+++ b/examples/flutter_gallery/lib/demo/animation/home.dart
@@ -15,6 +15,8 @@ import 'sections.dart';
 import 'widgets.dart';
 
 const Color _kAppBackgroundColor = const Color(0xFF353662);
+const Duration _kScrollDuration = const Duration(milliseconds: 400);
+const Curve _kScrollCurve = Curves.fastOutSlowIn;
 
 // This app's contents start out at _kHeadingMaxHeight and they function like
 // an appbar. Initially the appbar occupies most of the screen and its section
@@ -449,6 +451,13 @@ class _AnimationDemoHomeState extends State<AnimationDemoHome> {
     );
   }
 
+  void _handleBackButton(double midScrollOffset) {
+    if (_scrollController.offset >= midScrollOffset)
+      _scrollController.animateTo(0.0, curve: _kScrollCurve, duration: _kScrollDuration);
+    else
+      Navigator.of(context).maybePop();
+  }
+
   // Only enable paging for the heading when the user has scrolled to midScrollOffset.
   // Paging is enabled/disabled by setting the heading's PageView scroll physics.
   bool _handleScrollNotification(ScrollNotification notification, double midScrollOffset) {
@@ -466,18 +475,16 @@ class _AnimationDemoHomeState extends State<AnimationDemoHome> {
   }
 
   void _maybeScroll(double midScrollOffset, int pageIndex, double xOffset) {
-    const Duration duration = const Duration(milliseconds: 400);
-    const Curve curve = Curves.fastOutSlowIn;
     if (_scrollController.offset < midScrollOffset) {
       // Scroll the overall list to the point where only one section card shows.
       // At the same time scroll the PageViews to the page at pageIndex.
-      _headingPageController.animateToPage(pageIndex, curve: curve, duration: duration);
-      _scrollController.animateTo(midScrollOffset, curve: curve, duration: duration);
+      _headingPageController.animateToPage(pageIndex, curve: _kScrollCurve, duration: _kScrollDuration);
+      _scrollController.animateTo(midScrollOffset, curve: _kScrollCurve, duration: _kScrollDuration);
     } else {
       // One one section card is showing: scroll one page forward or back.
       final double centerX = _headingPageController.position.viewportDimension / 2.0;
       final int newPageIndex = xOffset > centerX ? pageIndex + 1 : pageIndex - 1;
-      _headingPageController.animateToPage(newPageIndex, curve: curve, duration: duration);
+      _headingPageController.animateToPage(newPageIndex, curve: _kScrollCurve, duration: _kScrollDuration);
     }
   }
 
@@ -605,9 +612,14 @@ class _AnimationDemoHomeState extends State<AnimationDemoHome> {
           new Positioned(
             top: statusBarHeight,
             left: 0.0,
-            child: const IconTheme(
-              data: const IconThemeData(color: Colors.white),
-              child: const BackButton(),
+            child: new IconTheme(
+              data: new IconThemeData(color: Colors.white),
+              child: new IconButton(
+                icon: const BackButtonIcon(),
+                onPressed: () {
+                  _handleBackButton(appBarMidScrollOffset);
+                }
+              ),
             ),
           ),
         ],

--- a/examples/flutter_gallery/lib/demo/animation/home.dart
+++ b/examples/flutter_gallery/lib/demo/animation/home.dart
@@ -613,7 +613,7 @@ class _AnimationDemoHomeState extends State<AnimationDemoHome> {
             top: statusBarHeight,
             left: 0.0,
             child: new IconTheme(
-              data: new IconThemeData(color: Colors.white),
+              data: const IconThemeData(color: Colors.white),
               child: new IconButton(
                 icon: const BackButtonIcon(),
                 onPressed: () {

--- a/examples/flutter_gallery/lib/demo/animation/home.dart
+++ b/examples/flutter_gallery/lib/demo/animation/home.dart
@@ -616,6 +616,7 @@ class _AnimationDemoHomeState extends State<AnimationDemoHome> {
               data: const IconThemeData(color: Colors.white),
               child: new IconButton(
                 icon: const BackButtonIcon(),
+                tooltip: 'Back',
                 onPressed: () {
                   _handleBackButton(appBarMidScrollOffset);
                 }

--- a/packages/flutter/lib/src/material/back_button.dart
+++ b/packages/flutter/lib/src/material/back_button.dart
@@ -9,6 +9,13 @@ import 'icon_button.dart';
 import 'icons.dart';
 import 'theme.dart';
 
+/// Signature for callbacks with a BuildContext parameter.
+///
+/// This type can be useful for widget callbacks. The context passed to the
+/// widget's build method can be passed along to callbacks that may need to look
+/// up an inherited widget or other context-specific resource.
+typedef void BuildContextCallback(BuildContext context);
+
 /// A material design back button.
 ///
 /// A [BackButton] is an [IconButton] with a "back" icon appropriate for the
@@ -20,6 +27,9 @@ import 'theme.dart';
 /// popped. If that value is false (e.g., because the current route is the
 /// initial route), the [BackButton] will not have any effect when pressed,
 /// which could frustrate the user.
+///
+/// The default button pressed behavior can be overridden by specifying
+/// [onPressed].
 ///
 /// Requires one of its ancestors to be a [Material] widget.
 ///
@@ -34,7 +44,12 @@ import 'theme.dart';
 class BackButton extends StatelessWidget {
   /// Creates an [IconButton] with the appropriate "back" icon for the current
   /// target platform.
-  const BackButton({ Key key }) : super(key: key);
+  const BackButton({ Key key, this.onPressed }) : super(key: key);
+
+  /// If this property is non-null it's called when the back button is pressed.
+  /// If it's null then a method that pops that navigator is called:
+  /// `Navigator.of(context).maybePop()`.
+  final BuildContextCallback onPressed;
 
   /// Returns tha appropriate "back" icon for the given `platform`.
   static IconData getIconData(TargetPlatform platform) {
@@ -49,14 +64,18 @@ class BackButton extends StatelessWidget {
     return null;
   }
 
+  void _defaultOnPressed(BuildContext context) {
+    Navigator.of(context).maybePop();
+  }
+
   @override
   Widget build(BuildContext context) {
     return new IconButton(
       icon: new Icon(getIconData(Theme.of(context).platform)),
       tooltip: 'Back', // TODO(ianh): Figure out how to localize this string
       onPressed: () {
-        Navigator.of(context).maybePop();
-      },
+        (onPressed ?? _defaultOnPressed)(context);
+      }
     );
   }
 }
@@ -79,7 +98,16 @@ class BackButton extends StatelessWidget {
 ///  * [IconButton], to create other material design icon buttons.
 class CloseButton extends StatelessWidget {
   /// Creates a Material Design close button.
-  const CloseButton({ Key key }) : super(key: key);
+  const CloseButton({ Key key, this.onPressed }) : super(key: key);
+
+  /// If this property is non-null it's called when the back button is pressed.
+  /// If it's null then a method that pops the navigator is called:
+  /// `Navigator.of(context).maybePop()`.
+  final BuildContextCallback onPressed;
+
+  void _defaultOnPressed(BuildContext context) {
+    Navigator.of(context).maybePop();
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -87,7 +115,7 @@ class CloseButton extends StatelessWidget {
       icon: const Icon(Icons.close),
       tooltip: 'Close', // TODO(ianh): Figure out how to localize this string
       onPressed: () {
-        Navigator.of(context).maybePop();
+        (onPressed ?? _defaultOnPressed)(context);
       },
     );
   }

--- a/packages/flutter/lib/src/material/back_button.dart
+++ b/packages/flutter/lib/src/material/back_button.dart
@@ -13,9 +13,11 @@ import 'theme.dart';
 ///
 /// See also:
 ///
-///  * [BackButton], an [IconButton] with a [BackButtonIcon] that
-///  * [IconButton], which is a more general widget for creating buttons with
-///    icons.
+///  * [BackButton], an [IconButton] with a [BackButtonIcon] that calls
+///    [Navigator.maybePop] to return to the previous route.
+///  * [IconButton], which is a more general widget for creating buttons
+///    with icons.
+///  * [Icon], a material design icon.
 class BackButtonIcon extends StatelessWidget {
   const BackButtonIcon({ Key key }) : super(key: key);
 
@@ -55,7 +57,7 @@ class BackButtonIcon extends StatelessWidget {
 ///  * [AppBar], which automatically uses a [BackButton] in its
 ///    [AppBar.leading] slot when appropriate.
 ///  * [BackButtonIcon], which is useful if you need to create a back button
-///    that responds differently being pressed.
+///    that responds differently to being pressed.
 ///  * [IconButton], which is a more general widget for creating buttons with
 ///    icons.
 ///  * [CloseButton], an alternative which may be more appropriate for leaf

--- a/packages/flutter/lib/src/material/back_button.dart
+++ b/packages/flutter/lib/src/material/back_button.dart
@@ -9,12 +9,32 @@ import 'icon_button.dart';
 import 'icons.dart';
 import 'theme.dart';
 
-/// Signature for callbacks with a BuildContext parameter.
+/// A "back" icon that's appropriate for the current [TargetPlatform].
 ///
-/// This type can be useful for widget callbacks. The context passed to the
-/// widget's build method can be passed along to callbacks that may need to look
-/// up an inherited widget or other context-specific resource.
-typedef void BuildContextCallback(BuildContext context);
+/// See also:
+///
+///  * [BackButton], an [IconButton] with a [BackButtonIcon] that
+///  * [IconButton], which is a more general widget for creating buttons with
+///    icons.
+class BackButtonIcon extends StatelessWidget {
+  const BackButtonIcon({ Key key }) : super(key: key);
+
+  /// Returns tha appropriate "back" icon for the given `platform`.
+  static IconData _getIconData(TargetPlatform platform) {
+    switch (platform) {
+      case TargetPlatform.android:
+      case TargetPlatform.fuchsia:
+        return Icons.arrow_back;
+      case TargetPlatform.iOS:
+        return Icons.arrow_back_ios;
+    }
+    assert(false);
+    return null;
+  }
+
+  @override
+  Widget build(BuildContext context) => new Icon(_getIconData(Theme.of(context).platform));
+}
 
 /// A material design back button.
 ///
@@ -28,15 +48,14 @@ typedef void BuildContextCallback(BuildContext context);
 /// initial route), the [BackButton] will not have any effect when pressed,
 /// which could frustrate the user.
 ///
-/// The default button pressed behavior can be overridden by specifying
-/// [onPressed].
-///
 /// Requires one of its ancestors to be a [Material] widget.
 ///
 /// See also:
 ///
 ///  * [AppBar], which automatically uses a [BackButton] in its
 ///    [AppBar.leading] slot when appropriate.
+///  * [BackButtonIcon], which is useful if you need to create a back button
+///    that responds differently being pressed.
 ///  * [IconButton], which is a more general widget for creating buttons with
 ///    icons.
 ///  * [CloseButton], an alternative which may be more appropriate for leaf
@@ -44,37 +63,15 @@ typedef void BuildContextCallback(BuildContext context);
 class BackButton extends StatelessWidget {
   /// Creates an [IconButton] with the appropriate "back" icon for the current
   /// target platform.
-  const BackButton({ Key key, this.onPressed }) : super(key: key);
-
-  /// If this property is non-null it's called when the back button is pressed.
-  /// If it's null then a method that pops that navigator is called:
-  /// `Navigator.of(context).maybePop()`.
-  final BuildContextCallback onPressed;
-
-  /// Returns tha appropriate "back" icon for the given `platform`.
-  static IconData getIconData(TargetPlatform platform) {
-    switch (platform) {
-      case TargetPlatform.android:
-      case TargetPlatform.fuchsia:
-        return Icons.arrow_back;
-      case TargetPlatform.iOS:
-        return Icons.arrow_back_ios;
-    }
-    assert(false);
-    return null;
-  }
-
-  void _defaultOnPressed(BuildContext context) {
-    Navigator.of(context).maybePop();
-  }
+  const BackButton({ Key key }) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
     return new IconButton(
-      icon: new Icon(getIconData(Theme.of(context).platform)),
+      icon: const BackButtonIcon(),
       tooltip: 'Back', // TODO(ianh): Figure out how to localize this string
       onPressed: () {
-        (onPressed ?? _defaultOnPressed)(context);
+        Navigator.of(context).maybePop();
       }
     );
   }
@@ -98,16 +95,7 @@ class BackButton extends StatelessWidget {
 ///  * [IconButton], to create other material design icon buttons.
 class CloseButton extends StatelessWidget {
   /// Creates a Material Design close button.
-  const CloseButton({ Key key, this.onPressed }) : super(key: key);
-
-  /// If this property is non-null it's called when the back button is pressed.
-  /// If it's null then a method that pops the navigator is called:
-  /// `Navigator.of(context).maybePop()`.
-  final BuildContextCallback onPressed;
-
-  void _defaultOnPressed(BuildContext context) {
-    Navigator.of(context).maybePop();
-  }
+  const CloseButton({ Key key }) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
@@ -115,7 +103,7 @@ class CloseButton extends StatelessWidget {
       icon: const Icon(Icons.close),
       tooltip: 'Close', // TODO(ianh): Figure out how to localize this string
       onPressed: () {
-        (onPressed ?? _defaultOnPressed)(context);
+        Navigator.of(context).maybePop();
       },
     );
   }

--- a/packages/flutter/test/material/back_button_test.dart
+++ b/packages/flutter/test/material/back_button_test.dart
@@ -32,4 +32,31 @@ void main() {
 
     expect(find.text('Home'), findsOneWidget);
   });
+
+  testWidgets('BackButton icon', (WidgetTester tester) async {
+    final Key iOSKey = new UniqueKey();
+    final Key androidKey = new UniqueKey();
+
+
+    await tester.pumpWidget(
+      new MaterialApp(
+        home: new Column(
+          children: <Widget>[
+            new Theme(
+              data: new ThemeData(platform: TargetPlatform.iOS),
+              child: new BackButtonIcon(key: iOSKey),
+            ),
+            new Theme(
+              data: new ThemeData(platform: TargetPlatform.android),
+              child: new BackButtonIcon(key: androidKey),
+            ),
+          ],
+        ),
+      ),
+    );
+
+    final Icon iOSIcon = tester.widget(find.descendant(of: find.byKey(iOSKey), matching: find.byType(Icon)));
+    final Icon androidIcon = tester.widget(find.descendant(of: find.byKey(androidKey), matching: find.byType(Icon)));
+    expect(iOSIcon == androidIcon, false);
+  });
 }


### PR DESCRIPTION
If you tap the app's back button and the animation demo isn't fully expanded, it just expands.

Added BackButtonIcon to trivialize creating IconButtons that look like (platform specific) back buttons but behave differently.

Fixes #9601