### PR TITLE
run zero-device test only on bots

### DIFF
--- a/packages/flutter_tools/test/devices_test.dart
+++ b/packages/flutter_tools/test/devices_test.dart
@@ -2,10 +2,15 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:convert';
+import 'dart:io';
+
 import 'package:flutter_tools/src/android/android_sdk.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/commands/devices.dart';
 import 'package:flutter_tools/src/device.dart';
+import 'package:mockito/mockito.dart';
+import 'package:process/process.dart';
 import 'package:test/test.dart';
 
 import 'src/common.dart';
@@ -29,6 +34,22 @@ void main() {
     }, overrides: <Type, Generator>{
       AndroidSdk: () => null,
       DeviceManager: () => new DeviceManager(),
+      ProcessManager: () => new MockProcessManager(),
     });
   });
+}
+
+class MockProcessManager extends Mock implements ProcessManager {
+  @override
+  ProcessResult runSync(
+      List<dynamic> command, {
+        String workingDirectory,
+        Map<String, String> environment,
+        bool includeParentEnvironment: true,
+        bool runInShell: false,
+        Encoding stdoutEncoding: SYSTEM_ENCODING,
+        Encoding stderrEncoding: SYSTEM_ENCODING,
+      }) {
+    return new ProcessResult(0, 0, '', '');
+  }
 }


### PR DESCRIPTION
When running tests locally a developer almost always has some device connected.