### PR TITLE
Fix a few more dartdoc errors

### DIFF
--- a/packages/flutter/lib/src/services/message_codecs.dart
+++ b/packages/flutter/lib/src/services/message_codecs.dart
@@ -181,34 +181,34 @@ class JSONMethodCodec implements MethodCodec {
 /// On Android, messages are represented as follows:
 ///
 ///  * null: null
-///  * [bool]: `java.lang.Boolean`
-///  * [int]: `java.lang.Integer` for values that are representable using 32-bit
+///  * [bool]\: `java.lang.Boolean`
+///  * [int]\: `java.lang.Integer` for values that are representable using 32-bit
 ///    two's complement; otherwise, `java.lang.Long` for values that are
 ///    representable using 64-bit two's complement; otherwise,
 ///    `java.math.BigInteger`.
-///  * [double]: `java.lang.Double`
-///  * [String]: `java.lang.String`
-///  * [Uint8List]: `byte[]`
-///  * [Int32List]: `int[]`
-///  * [Int64List]: `long[]`
-///  * [Float64List]: `double[]`
-///  * [List]: `java.util.ArrayList`
-///  * [Map]: `java.util.HashMap`
+///  * [double]\: `java.lang.Double`
+///  * [String]\: `java.lang.String`
+///  * [Uint8List]\: `byte[]`
+///  * [Int32List]\: `int[]`
+///  * [Int64List]\: `long[]`
+///  * [Float64List]\: `double[]`
+///  * [List]\: `java.util.ArrayList`
+///  * [Map]\: `java.util.HashMap`
 ///
 /// On iOS, messages are represented as follows:
 ///
 ///  * null: nil
-///  * [bool]: `NSNumber numberWithBool:`
-///  * [int]: `NSNumber numberWithInt:` for values that are representable using
+///  * [bool]\: `NSNumber numberWithBool:`
+///  * [int]\: `NSNumber numberWithInt:` for values that are representable using
 ///    32-bit two's complement; otherwise, `NSNumber numberWithLong:` for values
 ///    that are representable using 64-bit two's complement; otherwise,
 ///    `FlutterStandardBigInteger`.
-///  * [double]: `NSNumber numberWithDouble:`
-///  * [String]: `NSString`
-///  * [Uint8List], [Int32List], [Int64List], [Float64List]:
+///  * [double]\: `NSNumber numberWithDouble:`
+///  * [String]\: `NSString`
+///  * [Uint8List], [Int32List], [Int64List], [Float64List]\:
 ///    `FlutterStandardTypedData`
-///  * [List]: `NSArray`
-///  * [Map]: `NSDictionary`
+///  * [List]\: `NSArray`
+///  * [Map]\: `NSDictionary`
 class StandardMessageCodec implements MessageCodec<dynamic> {
   // The codec serializes messages as outlined below. This format must
   // match the Android and iOS counterparts.

--- a/packages/flutter/lib/src/widgets/transitions.dart
+++ b/packages/flutter/lib/src/widgets/transitions.dart
@@ -294,7 +294,7 @@ class FadeTransition extends AnimatedWidget {
 /// An interpolation between two relative rects.
 ///
 /// This class specializes the interpolation of [Tween<RelativeRect>] to
-/// use [RelativeRect.tween].
+/// use [RelativeRect.lerp].
 ///
 /// See [Tween] for a discussion on how to use interpolation objects.
 class RelativeRectTween extends Tween<RelativeRect> {


### PR DESCRIPTION
Turns out that `[]:` means something in markdown, so you have to
escape the `:` with a backslash.