### PR TITLE
Upgrade dartdoc to 0.11.1

### DIFF
--- a/dev/bots/docs.sh
+++ b/dev/bots/docs.sh
@@ -5,7 +5,7 @@ set -e
 # the root of the flutter repository.
 
 # Install dartdoc.
-pub global activate dartdoc 0.11.0
+pub global activate dartdoc 0.11.1
 
 # This script generates a unified doc set, and creates
 # a custom index.html, placing everything into dev/docs/doc.


### PR DESCRIPTION
This is a minor change that fixes dart-lang/dartdoc#1401 and is the last dartdoc binary change for Flutter I'm planning to make before I/O.

Compare new version:  http://jcollins1.pdx.corp.google.com:8000/flutter/widgets/OverlayEntry-class.html

with 0.11.0: http://jcollins1.pdx.corp.google.com:8001/flutter/widgets/OverlayEntry-class.html