### PR TITLE
Revert "Gracefully handle !isValid in AndroidStudio.gradleExecutable (#9893)"

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_studio.dart
+++ b/packages/flutter_tools/lib/src/android/android_studio.dart
@@ -100,9 +100,8 @@ class AndroidStudio implements Comparable<AndroidStudio> {
 
   String get gradlePath => _gradlePath;
 
-  String get gradleExecutable => isValid
-      ? fs.path.join(_gradlePath, 'bin', platform.isWindows ? 'gradle.bat' : 'gradle')
-      : null;
+  String get gradleExecutable => fs.path
+      .join(_gradlePath, 'bin', platform.isWindows ? 'gradle.bat' : 'gradle');
 
   String get javaPath => _javaPath;
 


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/9929