### PR TITLE
Added enableAssertInitializer: true to analysis_options_user.yaml

### DIFF
--- a/packages/flutter/lib/analysis_options_user.yaml
+++ b/packages/flutter/lib/analysis_options_user.yaml
@@ -23,6 +23,7 @@ analyzer:
   language:
     enableStrictCallChecks: true
     enableSuperMixins: true
+    enableAssertInitializer: true
   strong-mode: true
   errors:
     # treat missing required parameters as a warning (not a hint)


### PR DESCRIPTION
This is an attempt to stop the analyzer from generating inexplicable failures  like this in "user" code:
`error: Invalid constant value. (invalid_constant at [two_level_list] lib/main.dart:1)`