### PR TITLE
Remove the flaky tests.

### DIFF
--- a/dev/devicelab/manifest.yaml
+++ b/dev/devicelab/manifest.yaml
@@ -25,7 +25,9 @@
 #
 # * flaky: boolean true or false
 #       whether the task is considered flaky; the result of running a flaky task does not affect
-#       the overall build status.
+#       the overall build status. Tests should be marked flaky when newly added, until they have
+#       been proved for a few cycles. Tests that are actually flaky but not being actively worked
+#       on should be hidden because they just cause confusion otherwise.
 # * timeout_in_minutes: integer
 #       a custom task timeout, specified in minutes.
 
@@ -180,17 +182,19 @@ tasks:
     stage: devicelab_ios
     required_agent_capabilities: ["has-ios-device"]
 
-  flutter_gallery_ios__start_up:
-    description: >
-      Measures the startup time of the Flutter Gallery app on iOS.
-    stage: devicelab_ios
-    required_agent_capabilities: ["has-ios-device"]
+#  flutter_gallery_ios__start_up:
+#    description: >
+#      Measures the startup time of the Flutter Gallery app on iOS.
+#    stage: devicelab_ios
+#    required_agent_capabilities: ["has-ios-device"]
+#    flaky: true    
 
-  complex_layout_ios__start_up:
-    description: >
-      Measures the startup time of the Complex Layout sample app on iOS.
-    stage: devicelab_ios
-    required_agent_capabilities: ["has-ios-device"]
+#  complex_layout_ios__start_up:
+#    description: >
+#      Measures the startup time of the Complex Layout sample app on iOS.
+#    stage: devicelab_ios
+#    required_agent_capabilities: ["has-ios-device"]
+#    flaky: true    
 
   flutter_gallery_ios__transition_perf:
     description: >
@@ -205,19 +209,20 @@ tasks:
     stage: devicelab_ios
     required_agent_capabilities: ["has-ios-device"]
 
-  microbenchmarks_ios:
-    description: >
-      Runs benchmarks from dev/benchmarks/microbenchmarks on iOS.
-    stage: devicelab_ios
-    required_agent_capabilities: ["has-ios-device"]
-    timeout_in_minutes: 30
-    flaky: true
+#  microbenchmarks_ios:
+#    description: >
+#      Runs benchmarks from dev/benchmarks/microbenchmarks on iOS.
+#    stage: devicelab_ios
+#    required_agent_capabilities: ["has-ios-device"]
+#    timeout_in_minutes: 30
+#    flaky: true
 
-  flutter_view_ios__start_up:
-    description: >
-      Verifies that Flutter View can be used from an iOS project.
-    stage: devicelab_ios
-    required_agent_capabilities: ["has-ios-device"]
+#  flutter_view_ios__start_up:
+#    description: >
+#      Verifies that Flutter View can be used from an iOS project.
+#    stage: devicelab_ios
+#    required_agent_capabilities: ["has-ios-device"]
+#    flaky: true    
 
   # Tests running on Windows host
 


### PR DESCRIPTION
They are causing nothing but trouble. We should fix these before turning them back on.

See https://github.com/flutter/flutter/issues/9986 https://github.com/flutter/flutter/issues/9987