### PR TITLE
change a printStatus() to a printTrace()

### DIFF
--- a/packages/flutter_tools/lib/src/run_hot.dart
+++ b/packages/flutter_tools/lib/src/run_hot.dart
@@ -375,7 +375,7 @@ class HotRunner extends ResidentRunner {
         await _restartFromSources();
         timer.stop();
         status.cancel();
-        printStatus('Restarted app in ${getElapsedAsSeconds(timer.elapsed)}.');
+        printStatus('Restarted app in ${getElapsedAsMilliseconds(timer.elapsed)}.');
         return OperationResult.ok;
       } catch (error) {
         status.cancel();
@@ -412,7 +412,7 @@ class HotRunner extends ResidentRunner {
     }
 
     if (!_isPaused()) {
-      printStatus('Refreshing active FlutterViews before reloading.');
+      printTrace('Refreshing active FlutterViews before reloading.');
       await refreshViews();
     }
 
@@ -528,8 +528,8 @@ class HotRunner extends ResidentRunner {
         await view.uiIsolate.flutterReassemble();
       } on TimeoutException {
         reassembleTimedOut = true;
-        printTrace("Reassembling ${view.uiIsolate.name} took too long. ");
-        printStatus("Hot reloading ${view.uiIsolate.name} took too long. Hot reload may have failed.");
+        printTrace("Reassembling ${view.uiIsolate.name} took too long.");
+        printStatus("Hot reloading ${view.uiIsolate.name} took too long; the reload may have failed.");
         continue;
       } catch (error) {
         reassembleAndScheduleErrors = true;

--- a/packages/flutter_tools/lib/src/runner/flutter_command_runner.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command_runner.dart
@@ -37,14 +37,13 @@ class FlutterCommandRunner extends CommandRunner<Null> {
     'flutter',
     'Manage your Flutter app development.\n'
       '\n'
-      'Common actions:\n'
+      'Common commands:\n'
       '\n'
       '  flutter create <output directory>\n'
       '    Create a new Flutter project in the specified directory.\n'
       '\n'
       '  flutter run [options]\n'
-      '    Run your Flutter application on an attached device\n'
-      '    or in an emulator.',
+      '    Run your Flutter application on an attached device or in an emulator.',
   ) {
     argParser.addFlag('verbose',
         abbr: 'v',
@@ -72,7 +71,7 @@ class FlutterCommandRunner extends CommandRunner<Null> {
         negatable: false,
         help:
             'Captures a bug report file to submit to the Flutter team '
-            '(contains local paths, device identifiers, and log snippets).');
+            '(contains local paths, device\nidentifiers, and log snippets).');
 
     String packagesHelp;
     if (fs.isFileSync(kPackagesFileName))


### PR DESCRIPTION
Various tweaks the the cli output for flutter_tools:

- change a printStatus() to a printTrace() - this is the important one - we were printing two lines on a hot reload when we just want one output
- measure restart times in ms now instead of seconds
- minor tweaks to `flutter -h` output