### PR TITLE
re-enable devicelab tests that are no longer flaky

### DIFF
--- a/dev/devicelab/manifest.yaml
+++ b/dev/devicelab/manifest.yaml
@@ -83,7 +83,6 @@ tasks:
       Android.
     stage: devicelab
     required_agent_capabilities: ["has-android-device"]
-    flaky: true
 
   channels_integration_test:
     description: >
@@ -115,7 +114,6 @@ tasks:
       Android.
     stage: devicelab
     required_agent_capabilities: ["has-android-device"]
-    flaky: true
 
   hot_mode_dev_cycle__benchmark:
     description: >
@@ -167,7 +165,6 @@ tasks:
       Checks that platform channels work on iOS.
     stage: devicelab_ios
     required_agent_capabilities: ["has-ios-device"]
-    flaky: true
 
   platform_channel_sample_test_ios:
     description: >
@@ -231,7 +228,6 @@ tasks:
       Checks that platform channels work when app is launched from Windows.
     stage: devicelab_win
     required_agent_capabilities: ["windows"]
-    flaky: true
 
   flutter_gallery_win__build:
     description: >
@@ -239,11 +235,9 @@ tasks:
       Gallery on Windows.
     stage: devicelab_win
     required_agent_capabilities: ["windows"]
-    flaky: true
 
   hot_mode_dev_cycle_win__benchmark:
     description: >
       Measures the performance of Dart VM hot patching feature on Windows.
     stage: devicelab_win
     required_agent_capabilities: ["windows"]
-    flaky: true


### PR DESCRIPTION
They've been green for 20 runs straight.