### PR TITLE
Explicitly build ios keyboard_resize test

### DIFF
--- a/dev/devicelab/lib/tasks/integration_ui.dart
+++ b/dev/devicelab/lib/tasks/integration_ui.dart
@@ -21,7 +21,7 @@ Future<TaskResult> runEndToEndTests() async {
     if (deviceOperatingSystem == DeviceOperatingSystem.ios) {
       await prepareProvisioningCertificates(testDirectory.path);
       // This causes an Xcode project to be created.
-      await flutter('build', options: <String>['ios']);
+      await flutter('build', options: <String>['ios', 'lib/keyboard_resize.dart']);
     }
 
     await flutter('drive', options: <String>['-d', deviceId, 'lib/keyboard_resize.dart']);


### PR DESCRIPTION
Since lib/main.dart does not exist, update test to explicitly build lib/keyboard_resize.dart.