### PR TITLE
Estimate the brightness of the primary color

### DIFF
--- a/packages/flutter/lib/src/painting/colors.dart
+++ b/packages/flutter/lib/src/painting/colors.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:math' as math;
 import 'dart:ui' show Color, lerpDouble, hashValues;
 
 import 'package:flutter/foundation.dart';
@@ -22,6 +23,37 @@ class HSVColor {
         assert(hue != null),
         assert(saturation != null),
         assert(value != null);
+
+  /// Creates an [HSVColor] from an RGB [Color].
+  ///
+  /// This constructor does not necessarily round-trip with [toColor] because
+  /// of floating point imprecision.
+  factory HSVColor.fromColor(Color color) {
+    final double alpha = color.alpha / 0xFF;
+    final double red = color.red / 0xFF;
+    final double green = color.green / 0xFF;
+    final double blue = color.blue / 0xFF;
+
+    final double max = math.max(red, math.max(green, blue));
+    final double min = math.min(red, math.min(green, blue));
+    final double delta = max - min;
+
+    double hue = 0.0;
+
+    if (max == 0.0) {
+      hue = 0.0;
+    } else if (max == red) {
+      hue = 60.0 * (((green - blue) / delta) % 6);
+    } else if (max == green) {
+      hue = 60.0 * (((blue - red) / delta) + 2);
+    } else if (max == blue) {
+      hue = 60.0 * (((red - green) / delta) + 4);
+    }
+
+    final double saturation = max == 0.0 ? 0.0 : delta / max;
+
+    return new HSVColor.fromAHSV(alpha, hue, saturation, max);
+  }
 
   /// Alpha, from 0.0 to 1.0.
   final double alpha;

--- a/packages/flutter/test/material/theme_data_test.dart
+++ b/packages/flutter/test/material/theme_data_test.dart
@@ -89,4 +89,17 @@ void main() {
     expect(themeData.primaryTextTheme.title.fontFamily, equals('Ahem'));
     expect(themeData.accentTextTheme.display4.fontFamily, equals('Ahem'));
   });
+
+  test('Can estimate brightness', () {
+    expect(new ThemeData(primaryColor: Colors.white).primaryColorBrightness, equals(Brightness.light));
+    expect(new ThemeData(primaryColor: Colors.black).primaryColorBrightness, equals(Brightness.dark));
+    expect(new ThemeData(primaryColor: Colors.blue).primaryColorBrightness, equals(Brightness.dark));
+    expect(new ThemeData(primaryColor: Colors.yellow).primaryColorBrightness, equals(Brightness.light));
+    expect(new ThemeData(primaryColor: Colors.deepOrange).primaryColorBrightness, equals(Brightness.dark));
+    expect(new ThemeData(primaryColor: Colors.orange).primaryColorBrightness, equals(Brightness.light));
+    expect(new ThemeData(primaryColor: Colors.lime).primaryColorBrightness, equals(Brightness.light));
+    expect(new ThemeData(primaryColor: Colors.grey).primaryColorBrightness, equals(Brightness.light));
+    expect(new ThemeData(primaryColor: Colors.teal).primaryColorBrightness, equals(Brightness.dark));
+    expect(new ThemeData(primaryColor: Colors.indigo).primaryColorBrightness, equals(Brightness.dark));
+  });
 }

--- a/packages/flutter/test/painting/colors_test.dart
+++ b/packages/flutter/test/painting/colors_test.dart
@@ -26,4 +26,16 @@ void main() {
     expect(result.saturation, lessThan(0.4001));
     expect(result.value, 0.5);
   });
+
+  test('HSVColor.fromColor test', () {
+    final HSVColor black = new HSVColor.fromColor(const Color.fromARGB(0xFF, 0x00, 0x00, 0x00));
+    final HSVColor red = new HSVColor.fromColor(const Color.fromARGB(0xFF, 0xFF, 0x00, 0x00));
+    final HSVColor green = new HSVColor.fromColor(const Color.fromARGB(0xFF, 0x00, 0xFF, 0x00));
+    final HSVColor blue = new HSVColor.fromColor(const Color.fromARGB(0xFF, 0x00, 0x00, 0xFF));
+
+    expect(black.toColor(), equals(const Color.fromARGB(0xFF, 0x00, 0x00, 0x00)));
+    expect(red.toColor(), equals(const Color.fromARGB(0xFF, 0xFF, 0x00, 0x00)));
+    expect(green.toColor(), equals(const Color.fromARGB(0xFF, 0x00, 0xFF, 0x00)));
+    expect(blue.toColor(), equals(const Color.fromARGB(0xFF, 0x00, 0x00, 0xFF)));
+  });
 }


### PR DESCRIPTION
If the caller doesn't explicitly give the brightness of the primary
color, we now estimate it using an algorithm from the Web Content
Accessibility Guidelines.

Also, this patch contains a function that converts RGB colors to
HSVColors. I was originally going to use that, but the WCAG algorithm
ended up seeming like a better choice. The patch still includes this
function because it's generally useful.

Fixes #5718