### PR TITLE
Add intrinsic dimensions to RenderEditable

### DIFF
--- a/packages/flutter/lib/src/painting/text_painter.dart
+++ b/packages/flutter/lib/src/painting/text_painter.dart
@@ -136,15 +136,30 @@ class TextPainter {
 
   ui.Paragraph _layoutTemplate;
 
+  ui.ParagraphStyle _createParagraphStyle() {
+    return _text.style?.getParagraphStyle(
+      textAlign: textAlign,
+      textScaleFactor: textScaleFactor,
+      maxLines: _maxLines,
+      ellipsis: _ellipsis,
+    ) ?? new ui.ParagraphStyle(
+      textAlign: textAlign,
+      maxLines: maxLines,
+      ellipsis: ellipsis,
+    );
+  }
+
   /// The height of a zero-width space in [text] in logical pixels.
   ///
   /// Not every line of text in [text] will have this height, but this height
   /// is "typical" for text in [text] and useful for sizing other objects
   /// relative a typical line of text.
+  ///
+  /// Obtaining this value does not require calling [layout].
   double get preferredLineHeight {
     assert(text != null);
     if (_layoutTemplate == null) {
-      final ui.ParagraphBuilder builder = new ui.ParagraphBuilder(new ui.ParagraphStyle());
+      final ui.ParagraphBuilder builder = new ui.ParagraphBuilder(_createParagraphStyle());
       if (text.style != null)
         builder.pushStyle(text.style.getTextStyle(textScaleFactor: textScaleFactor));
       builder.addText(_kZeroWidthSpace);
@@ -165,7 +180,8 @@ class TextPainter {
     return layoutValue.ceilToDouble();
   }
 
-  /// The width at which decreasing the width of the text would prevent it from painting itself completely within its bounds.
+  /// The width at which decreasing the width of the text would prevent it from
+  /// painting itself completely within its bounds.
   ///
   /// Valid only after [layout] has been called.
   double get minIntrinsicWidth {
@@ -251,18 +267,7 @@ class TextPainter {
       return;
     _needsLayout = false;
     if (_paragraph == null) {
-      ui.ParagraphStyle paragraphStyle = _text.style?.getParagraphStyle(
-        textAlign: textAlign,
-        textScaleFactor: textScaleFactor,
-        maxLines: _maxLines,
-        ellipsis: _ellipsis,
-      );
-      paragraphStyle ??= new ui.ParagraphStyle(
-        textAlign: textAlign,
-        maxLines: maxLines,
-        ellipsis: ellipsis,
-      );
-      final ui.ParagraphBuilder builder = new ui.ParagraphBuilder(paragraphStyle);
+      final ui.ParagraphBuilder builder = new ui.ParagraphBuilder(_createParagraphStyle());
       _text.build(builder, textScaleFactor: textScaleFactor);
       _paragraph = builder.build();
     }

--- a/packages/flutter/test/painting/text_painter_test.dart
+++ b/packages/flutter/test/painting/text_painter_test.dart
@@ -48,4 +48,18 @@ void main() {
     painter.layout();
     expect(painter.size, const Size(123.0, 123.0));
   });
+
+  test('TextPainter default text height is 14 pixels', () {
+    final TextPainter painter = new TextPainter(text: const TextSpan(text: 'x'));
+    painter.layout();
+    expect(painter.preferredLineHeight, 14.0);
+    expect(painter.size, const Size(14.0, 14.0));
+  });
+
+  test('TextPainter sets paragraph size from root', () {
+    final TextPainter painter = new TextPainter(text: const TextSpan(text: 'x', style: const TextStyle(fontSize: 100.0)));
+    painter.layout();
+    expect(painter.preferredLineHeight, 100.0);
+    expect(painter.size, const Size(100.0, 100.0));
+  });
 }

--- a/packages/flutter/test/rendering/editable_test.dart
+++ b/packages/flutter/test/rendering/editable_test.dart
@@ -1,0 +1,22 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/rendering.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('editable intrinsics', () {
+    final RenderEditable editable = new RenderEditable(
+      text: const TextSpan(
+        style: const TextStyle(height: 1.0, fontSize: 10.0, fontFamily: 'Ahem'),
+        text: '12345',
+      ),
+      offset: new ViewportOffset.zero(),
+    );
+    expect(editable.getMinIntrinsicWidth(double.INFINITY), 50.0);
+    expect(editable.getMaxIntrinsicWidth(double.INFINITY), 50.0);
+    expect(editable.getMinIntrinsicHeight(double.INFINITY), 10.0);
+    expect(editable.getMaxIntrinsicHeight(double.INFINITY), 10.0);
+  });
+}


### PR DESCRIPTION
Also:

* Make TextPainter.preferredLineHeight honour root fontSize

* Remove bogus docs.

* More aggressively track dirty state for RenderEditable.

* Some tests.