### PR TITLE
Report semantics geometry in physical units.

### DIFF
--- a/packages/flutter/lib/src/gestures/binding.dart
+++ b/packages/flutter/lib/src/gestures/binding.dart
@@ -29,6 +29,8 @@ abstract class GestureBinding extends BindingBase implements HitTestable, HitTes
   static GestureBinding _instance;
 
   void _handlePointerDataPacket(ui.PointerDataPacket packet) {
+    // We convert pointer data to logical pixels so that e.g. the touch slop can be
+    // defined in a device-independent manner.
     _pendingPointerEvents.addAll(PointerEventConverter.expand(packet.data, ui.window.devicePixelRatio));
     _flushPointerEventQueue();
   }

--- a/packages/flutter/lib/src/gestures/converter.dart
+++ b/packages/flutter/lib/src/gestures/converter.dart
@@ -32,6 +32,10 @@ class _PointerState {
 }
 
 /// Converts from engine pointer data to framework pointer events.
+///
+/// This takes [PointerDataPacket] objects, as received from the engine via
+/// [dart:ui.Window.onPointerDataPacket], and converts them to [PointerEvent]
+/// objects.
 class PointerEventConverter {
   // Map from platform pointer identifiers to PointerEvent pointer identifiers.
   static final Map<int, _PointerState> _pointers = <int, _PointerState>{};
@@ -44,6 +48,11 @@ class PointerEventConverter {
   }
 
   /// Expand the given packet of pointer data into a sequence of framework pointer events.
+  ///
+  /// The `devicePixelRatio` argument (usually given the value from
+  /// [dart:ui.Window.devicePixelRatio]) is used to convert the incoming data
+  /// from physical coordinates to logical pixels. See the discussion at
+  /// [PointerEvent] for more details on the [PointerEvent] coordinate space.
   static Iterable<PointerEvent> expand(Iterable<ui.PointerData> data, double devicePixelRatio) sync* {
     for (ui.PointerData datum in data) {
       final Offset position = new Offset(datum.physicalX, datum.physicalY) / devicePixelRatio;

--- a/packages/flutter/lib/src/gestures/events.dart
+++ b/packages/flutter/lib/src/gestures/events.dart
@@ -69,6 +69,26 @@ int nthMouseButton(int number) => (kPrimaryMouseButton << (number - 1)) & kMaxUn
 int nthStylusButton(int number) => (kPrimaryStylusButton << (number - 1)) & kMaxUnsignedSMI;
 
 /// Base class for touch, stylus, or mouse events.
+///
+/// Pointer events operate in the coordinate space of the screen, scaled to
+/// logical pixels. Logical pixels approximate a grid with about 38 pixels per
+/// centimeter, or 96 pixels per inch.
+///
+/// This allows gestures to be recognised independent of the precise hardware
+/// characteristics of the device. In particular, features such as touch slop
+/// (see [kTouchSlop]) can be defined in terms of roughly physical lengths so
+/// that the user can shift their finger by the same distance on a high-density
+/// display as on a low-resolution device.
+///
+/// For similar reasons, pointer events are not affected by any transforms in
+/// the rendering layer. This means that deltas may need to be scaled before
+/// being applied to movement within the rendering. For example, if a scrolling
+/// list is shown scaled by 2x, the pointer deltas will have to be scaled by the
+/// inverse amount if the list is to appear to scroll with the user's finger.
+///
+/// See also:
+///
+///  * [Window.devicePixelRatio], which defines the device's current resolution.
 @immutable
 abstract class PointerEvent {
   /// Abstract const constructor. This constructor enables subclasses to provide

--- a/packages/flutter/lib/src/painting/transforms.dart
+++ b/packages/flutter/lib/src/painting/transforms.dart
@@ -13,8 +13,8 @@ import 'basic_types.dart';
 class MatrixUtils {
   MatrixUtils._();
 
-  /// Returns the given [transform] matrix as Offset, if the matrix is nothing
-  /// but a 2D translation.
+  /// Returns the given [transform] matrix as an [Offset], if the matrix is
+  /// nothing but a 2D translation.
   ///
   /// Otherwise, returns null.
   static Offset getAsTranslation(Matrix4 transform) {
@@ -36,6 +36,34 @@ class MatrixUtils {
         values[14] == 0.0 && // bottom of col 4 (values 12 and 13 are the x and y offsets)
         values[15] == 1.0) {
       return new Offset(values[12], values[13]);
+    }
+    return null;
+  }
+
+  /// Returns the given [transform] matrix as a [double] describing a uniform
+  /// scale, if the matrix is nothing but a symmetric 2D scale transform.
+  ///
+  /// Otherwise, returns null.
+  static double getAsScale(Matrix4 transform) {
+    assert(transform != null);
+    final Float64List values = transform.storage;
+    // Values are stored in column-major order.
+    if (values[1] == 0.0 && // col 1 (value 0 is the scale)
+        values[2] == 0.0 &&
+        values[3] == 0.0 &&
+        values[4] == 0.0 && // col 2 (value 5 is the scale)
+        values[6] == 0.0 &&
+        values[7] == 0.0 &&
+        values[8] == 0.0 && // col 3
+        values[9] == 0.0 &&
+        values[10] == 1.0 &&
+        values[11] == 0.0 &&
+        values[12] == 0.0 && // col 4
+        values[13] == 0.0 &&
+        values[14] == 0.0 &&
+        values[15] == 1.0 &&
+        values[0] == values[5]) { // uniform scale
+      return values[0];
     }
     return null;
   }

--- a/packages/flutter/lib/src/rendering/binding.dart
+++ b/packages/flutter/lib/src/rendering/binding.dart
@@ -143,7 +143,7 @@ abstract class RendererBinding extends BindingBase implements SchedulerBinding, 
     final double devicePixelRatio = ui.window.devicePixelRatio;
     return new ViewConfiguration(
       size: ui.window.physicalSize / devicePixelRatio,
-      devicePixelRatio: devicePixelRatio
+      devicePixelRatio: devicePixelRatio,
     );
   }
 

--- a/packages/flutter/lib/src/rendering/view.dart
+++ b/packages/flutter/lib/src/rendering/view.dart
@@ -54,11 +54,14 @@ class RenderView extends RenderObject with RenderObjectWithChildMixin<RenderBox>
   /// Creates the root of the render tree.
   ///
   /// Typically created by the binding (e.g., [RendererBinding]).
+  ///
+  /// The [configuration] must not be null.
   RenderView({
     RenderBox child,
     this.timeForRotation: const Duration(microseconds: 83333),
-    ViewConfiguration configuration
-  }) : _configuration = configuration {
+    @required ViewConfiguration configuration,
+  }) : assert(configuration != null),
+       _configuration = configuration {
     this.child = child;
   }
 
@@ -76,24 +79,42 @@ class RenderView extends RenderObject with RenderObjectWithChildMixin<RenderBox>
   /// The constraints used for the root layout.
   ViewConfiguration get configuration => _configuration;
   ViewConfiguration _configuration;
+  /// The configuration is initially set by the `configuration` argument
+  /// passed to the constructor.
+  ///
+  /// Always call [scheduleInitialFrame] before changing the configuration.
   set configuration(ViewConfiguration value) {
+    assert(value != null);
     if (configuration == value)
       return;
     _configuration = value;
-    final ContainerLayer rootLayer = new TransformLayer(transform: configuration.toMatrix());
-    rootLayer.attach(this);
-    replaceRootLayer(rootLayer);
+    replaceRootLayer(_updateMatricesAndCreateNewRootLayer());
+    assert(_rootTransform != null);
     markNeedsLayout();
   }
 
   /// Bootstrap the rendering pipeline by scheduling the first frame.
+  ///
+  /// This should only be called once, and must be called before changing
+  /// [configuration]. It is typically called immediately after calling the
+  /// constructor.
   void scheduleInitialFrame() {
     assert(owner != null);
+    assert(_rootTransform == null);
     scheduleInitialLayout();
-    final ContainerLayer rootLayer = new TransformLayer(transform: configuration.toMatrix());
-    rootLayer.attach(this);
-    scheduleInitialPaint(rootLayer);
+    scheduleInitialPaint(_updateMatricesAndCreateNewRootLayer());
+    assert(_rootTransform != null);
     owner.requestVisualUpdate();
+  }
+
+  Matrix4 _rootTransform;
+
+  Layer _updateMatricesAndCreateNewRootLayer() {
+    _rootTransform = configuration.toMatrix();
+    final ContainerLayer rootLayer = new TransformLayer(transform: _rootTransform);
+    rootLayer.attach(this);
+    assert(_rootTransform != null);
+    return rootLayer;
   }
 
   // We never call layout() on this class, so this should never get
@@ -108,6 +129,7 @@ class RenderView extends RenderObject with RenderObjectWithChildMixin<RenderBox>
 
   @override
   void performLayout() {
+    assert(_rootTransform != null);
     if (configuration.orientation != _orientation) {
       if (_orientation != null && child != null)
         child.rotate(oldAngle: _orientation, newAngle: configuration.orientation, time: timeForRotation);
@@ -131,7 +153,10 @@ class RenderView extends RenderObject with RenderObjectWithChildMixin<RenderBox>
   /// of its descendants. Adds any render objects that contain the point to the
   /// given hit test result.
   ///
-  /// The [position] argument is in the coordinate system of the render view.
+  /// The [position] argument is in the coordinate system of the render view,
+  /// which is to say, in logical pixels. This is not necessarily the same
+  /// coordinate system as that expected by the root [Layer], which will
+  /// normally be in physical (device) pixels.
   bool hitTest(HitTestResult result, { Offset position }) {
     if (child != null)
       child.hitTest(result, position: position);
@@ -146,6 +171,13 @@ class RenderView extends RenderObject with RenderObjectWithChildMixin<RenderBox>
   void paint(PaintingContext context, Offset offset) {
     if (child != null)
       context.paintChild(child, offset);
+  }
+
+  @override
+  void applyPaintTransform(RenderBox child, Matrix4 transform) {
+    assert(_rootTransform != null);
+    transform.multiply(_rootTransform);
+    super.applyPaintTransform(child, transform);
   }
 
   /// Uploads the composited layer tree to the engine.
@@ -173,7 +205,10 @@ class RenderView extends RenderObject with RenderObjectWithChildMixin<RenderBox>
   Rect get paintBounds => Offset.zero & size;
 
   @override
-  Rect get semanticBounds => Offset.zero & size;
+  Rect get semanticBounds {
+    assert(_rootTransform != null);
+    return MatrixUtils.transformRect(_rootTransform, Offset.zero & size);
+  }
 
   @override
   void debugFillDescription(List<String> description) {

--- a/packages/flutter/test/material/buttons_test.dart
+++ b/packages/flutter/test/material/buttons_test.dart
@@ -25,10 +25,9 @@ void main() {
     );
 
     expect(semantics, hasSemantics(
-      new TestSemantics(
-        id: 0,
+      new TestSemantics.root(
         children: <TestSemantics>[
-          new TestSemantics(
+          new TestSemantics.rootChild(
             id: 1,
             actions: SemanticsAction.tap.index,
             label: 'ABC',

--- a/packages/flutter/test/material/tooltip_test.dart
+++ b/packages/flutter/test/material/tooltip_test.dart
@@ -460,14 +460,14 @@ void main() {
       )
     );
 
-    expect(semantics, hasSemantics(new TestSemantics(id: 0, label: tooltipText)));
+    expect(semantics, hasSemantics(new TestSemantics.root(label: tooltipText)));
 
     // before using "as dynamic" in your code, see note top of file
     (key.currentState as dynamic).ensureTooltipVisible(); // this triggers a rebuild of the semantics because the tree changes
 
     await tester.pump(const Duration(seconds: 2)); // faded in, show timer started (and at 0.0)
 
-    expect(semantics, hasSemantics(new TestSemantics(id: 0, label: tooltipText)));
+    expect(semantics, hasSemantics(new TestSemantics.root(label: tooltipText)));
 
     semantics.dispose();
   });

--- a/packages/flutter/test/widgets/semantics_1_test.dart
+++ b/packages/flutter/test/widgets/semantics_1_test.dart
@@ -23,7 +23,7 @@ void main() {
       )
     );
 
-    expect(semantics, hasSemantics(new TestSemantics(id: 0, label: 'test1')));
+    expect(semantics, hasSemantics(new TestSemantics.root(label: 'test1')));
 
     // control for forking
     await tester.pumpWidget(
@@ -45,7 +45,7 @@ void main() {
       )
     );
 
-    expect(semantics, hasSemantics(new TestSemantics(id: 0, label: 'child1')));
+    expect(semantics, hasSemantics(new TestSemantics.root(label: 'child1')));
 
     // forking semantics
     await tester.pumpWidget(
@@ -68,15 +68,14 @@ void main() {
     );
 
     expect(semantics, hasSemantics(
-      new TestSemantics(
-        id: 0,
+      new TestSemantics.root(
         children: <TestSemantics>[
-          new TestSemantics(
+          new TestSemantics.rootChild(
             id: 1,
             label: 'child1',
             rect: new Rect.fromLTRB(0.0, 0.0, 800.0, 10.0),
           ),
-          new TestSemantics(
+          new TestSemantics.rootChild(
             id: 2,
             label: 'child2',
             rect: new Rect.fromLTRB(0.0, 0.0, 800.0, 10.0),
@@ -106,7 +105,7 @@ void main() {
       )
     );
 
-    expect(semantics, hasSemantics(new TestSemantics(id: 0, label: 'child1')));
+    expect(semantics, hasSemantics(new TestSemantics.root(label: 'child1')));
 
     // toggle a branch back on
     await tester.pumpWidget(
@@ -129,15 +128,14 @@ void main() {
     );
 
     expect(semantics, hasSemantics(
-      new TestSemantics(
-        id: 0,
+      new TestSemantics.root(
         children: <TestSemantics>[
-          new TestSemantics(
+          new TestSemantics.rootChild(
             id: 3,
             label: 'child1',
             rect: new Rect.fromLTRB(0.0, 0.0, 800.0, 10.0),
           ),
-          new TestSemantics(
+          new TestSemantics.rootChild(
             id: 2,
             label: 'child2',
             rect: new Rect.fromLTRB(0.0, 0.0, 800.0, 10.0),

--- a/packages/flutter/test/widgets/semantics_2_test.dart
+++ b/packages/flutter/test/widgets/semantics_2_test.dart
@@ -38,15 +38,14 @@ void main() {
     );
 
     expect(semantics, hasSemantics(
-      new TestSemantics(
-        id: 0,
+      new TestSemantics.root(
         children: <TestSemantics>[
-          new TestSemantics(
+          new TestSemantics.rootChild(
             id: 1,
             label: 'child1',
             rect: new Rect.fromLTRB(0.0, 0.0, 800.0, 10.0),
           ),
-          new TestSemantics(
+          new TestSemantics.rootChild(
             id: 2,
             label: 'child2',
             rect: new Rect.fromLTRB(0.0, 0.0, 800.0, 10.0),
@@ -76,7 +75,7 @@ void main() {
       )
     );
 
-    expect(semantics, hasSemantics(new TestSemantics(id: 0, label: 'child1')));
+    expect(semantics, hasSemantics(new TestSemantics.root(label: 'child1')));
 
     // toggle a branch back on
     await tester.pumpWidget(
@@ -99,15 +98,14 @@ void main() {
     );
 
     expect(semantics, hasSemantics(
-      new TestSemantics(
-        id: 0,
+      new TestSemantics.root(
         children: <TestSemantics>[
-          new TestSemantics(
+          new TestSemantics.rootChild(
             id: 3,
             label: 'child1',
             rect: new Rect.fromLTRB(0.0, 0.0, 800.0, 10.0),
           ),
-          new TestSemantics(
+          new TestSemantics.rootChild(
             id: 2,
             label: 'child2',
             rect: new Rect.fromLTRB(0.0, 0.0, 800.0, 10.0),

--- a/packages/flutter/test/widgets/semantics_3_test.dart
+++ b/packages/flutter/test/widgets/semantics_3_test.dart
@@ -29,8 +29,7 @@ void main() {
     );
 
     expect(semantics, hasSemantics(
-      new TestSemantics(
-        id: 0,
+      new TestSemantics.root(
         flags: SemanticsFlags.hasCheckedState.index | SemanticsFlags.isChecked.index,
         label: 'test',
       )
@@ -48,8 +47,7 @@ void main() {
     );
 
     expect(semantics, hasSemantics(
-      new TestSemantics(
-        id: 0,
+      new TestSemantics.root(
         flags: SemanticsFlags.hasCheckedState.index | SemanticsFlags.isChecked.index,
       )
     ));
@@ -66,8 +64,7 @@ void main() {
     );
 
     expect(semantics, hasSemantics(
-      new TestSemantics(
-        id: 0,
+      new TestSemantics.root(
         label: 'test',
       )
     ));
@@ -87,8 +84,7 @@ void main() {
     );
 
     expect(semantics, hasSemantics(
-      new TestSemantics(
-        id: 0,
+      new TestSemantics.root(
         flags: SemanticsFlags.hasCheckedState.index | SemanticsFlags.isChecked.index,
         label: 'test',
       )

--- a/packages/flutter/test/widgets/semantics_4_test.dart
+++ b/packages/flutter/test/widgets/semantics_4_test.dart
@@ -46,24 +46,27 @@ void main() {
     );
 
     expect(semantics, hasSemantics(
-      new TestSemantics(
-        id: 0,
+      new TestSemantics.root(
         children: <TestSemantics>[
-          new TestSemantics(
+          new TestSemantics.rootChild(
             id: 1,
             label: 'L1',
+            rect: TestSemantics.fullScreen,
           ),
-          new TestSemantics(
+          new TestSemantics.rootChild(
             id: 2,
             label: 'L2',
+            rect: TestSemantics.fullScreen,
             children: <TestSemantics>[
               new TestSemantics(
                 id: 3,
                 flags: SemanticsFlags.hasCheckedState.index | SemanticsFlags.isChecked.index,
+                rect: TestSemantics.fullScreen,
               ),
               new TestSemantics(
                 id: 4,
                 flags: SemanticsFlags.hasCheckedState.index,
+                rect: TestSemantics.fullScreen,
               ),
             ]
           ),
@@ -100,17 +103,18 @@ void main() {
     );
 
     expect(semantics, hasSemantics(
-      new TestSemantics(
-        id: 0,
+      new TestSemantics.root(
         children: <TestSemantics>[
-          new TestSemantics(
+          new TestSemantics.rootChild(
             id: 1,
             label: 'L1',
+            rect: TestSemantics.fullScreen,
           ),
-          new TestSemantics(
+          new TestSemantics.rootChild(
             id: 2,
             label: 'L2',
             flags: SemanticsFlags.hasCheckedState.index | SemanticsFlags.isChecked.index,
+            rect: TestSemantics.fullScreen,
           ),
         ],
       )
@@ -142,8 +146,7 @@ void main() {
     );
 
     expect(semantics, hasSemantics(
-      new TestSemantics(
-        id: 0,
+      new TestSemantics.root(
         label: 'L2',
         flags: SemanticsFlags.hasCheckedState.index | SemanticsFlags.isChecked.index,
       )

--- a/packages/flutter/test/widgets/semantics_5_test.dart
+++ b/packages/flutter/test/widgets/semantics_5_test.dart
@@ -31,15 +31,16 @@ void main() {
     );
 
     expect(semantics, hasSemantics(
-      new TestSemantics(
-        id: 0,
+      new TestSemantics.root(
         children: <TestSemantics>[
-          new TestSemantics(
+          new TestSemantics.rootChild(
             id: 1,
+            rect: TestSemantics.fullScreen,
           ),
-          new TestSemantics(
+          new TestSemantics.rootChild(
             id: 2,
             label: 'label',
+            rect: TestSemantics.fullScreen,
           ),
         ]
       )

--- a/packages/flutter/test/widgets/semantics_7_test.dart
+++ b/packages/flutter/test/widgets/semantics_7_test.dart
@@ -49,19 +49,20 @@ void main() {
     );
 
     expect(semantics, hasSemantics(
-      new TestSemantics(
-        id: 0,
+      new TestSemantics.root(
         children: <TestSemantics>[
-          new TestSemantics(
+          new TestSemantics.rootChild(
             id: 1,
             flags: SemanticsFlags.hasCheckedState.index | SemanticsFlags.isChecked.index,
             label: label,
+            rect: TestSemantics.fullScreen,
           ),
           // IDs 2 and 3 are used up by the nodes that get merged in
-          new TestSemantics(
+          new TestSemantics.rootChild(
             id: 4,
             flags: SemanticsFlags.hasCheckedState.index | SemanticsFlags.isChecked.index,
             label: label,
+            rect: TestSemantics.fullScreen,
           ),
           // IDs 5 and 6 are used up by the nodes that get merged in
         ],
@@ -101,19 +102,20 @@ void main() {
     );
 
     expect(semantics, hasSemantics(
-      new TestSemantics(
-        id: 0,
+      new TestSemantics.root(
         children: <TestSemantics>[
-          new TestSemantics(
+          new TestSemantics.rootChild(
             id: 1,
             flags: SemanticsFlags.hasCheckedState.index | SemanticsFlags.isChecked.index,
             label: label,
+            rect: TestSemantics.fullScreen,
           ),
           // IDs 2 and 3 are used up by the nodes that get merged in
-          new TestSemantics(
+          new TestSemantics.rootChild(
             id: 4,
             flags: SemanticsFlags.hasCheckedState.index | SemanticsFlags.isChecked.index,
             label: label,
+            rect: TestSemantics.fullScreen,
           ),
           // IDs 5 and 6 are used up by the nodes that get merged in
         ],

--- a/packages/flutter/test/widgets/semantics_8_test.dart
+++ b/packages/flutter/test/widgets/semantics_8_test.dart
@@ -36,8 +36,7 @@ void main() {
     );
 
     expect(semantics, hasSemantics(
-      new TestSemantics(
-        id: 0,
+      new TestSemantics.root(
         flags: SemanticsFlags.hasCheckedState.index | SemanticsFlags.isChecked.index,
         label: 'label',
       )
@@ -66,8 +65,7 @@ void main() {
     );
 
     expect(semantics, hasSemantics(
-      new TestSemantics(
-        id: 0,
+      new TestSemantics.root(
         flags: SemanticsFlags.hasCheckedState.index | SemanticsFlags.isChecked.index,
         label: 'label',
       )

--- a/packages/flutter/test/widgets/semantics_test.dart
+++ b/packages/flutter/test/widgets/semantics_test.dart
@@ -12,8 +12,7 @@ void main() {
   testWidgets('Semantics shutdown and restart', (WidgetTester tester) async {
     SemanticsTester semantics = new SemanticsTester(tester);
 
-    final TestSemantics expectedSemantics = new TestSemantics(
-      id: 0,
+    final TestSemantics expectedSemantics = new TestSemantics.root(
       label: 'test1',
     );
 
@@ -59,13 +58,13 @@ void main() {
     );
 
     expect(semantics, hasSemantics(
-      new TestSemantics(
-        id: 0,
+      new TestSemantics.root(
         label: 'test1',
         children: <TestSemantics>[
-          new TestSemantics(
+          new TestSemantics.rootChild(
             id: 1,
             label: 'test2a',
+            rect: TestSemantics.fullScreen,
           )
         ]
       )
@@ -90,17 +89,18 @@ void main() {
     );
 
     expect(semantics, hasSemantics(
-      new TestSemantics(
-        id: 0,
+      new TestSemantics.root(
         label: 'test1',
         children: <TestSemantics>[
-          new TestSemantics(
+          new TestSemantics.rootChild(
             id: 2,
             label: 'middle',
+            rect: TestSemantics.fullScreen,
             children: <TestSemantics>[
               new TestSemantics(
                 id: 1,
                 label: 'test2b',
+                rect: TestSemantics.fullScreen,
               )
             ]
           )


### PR DESCRIPTION
Previously we used logical pixels. This made the accessibility metrics
tiny on modern devices, since the OS works in physical units.

Also add a bit more debugging info and some docs.