### PR TITLE
Fix call to unimplemented application:openURL:options: in iOS template

### DIFF
--- a/packages/flutter_tools/templates/create/ios.tmpl/Runner/AppDelegate.m
+++ b/packages/flutter_tools/templates/create/ios.tmpl/Runner/AppDelegate.m
@@ -36,10 +36,11 @@
   [super applicationWillTerminate:application];
 }
 
-- (BOOL)application:(UIApplication *)application
-            openURL:(NSURL *)url
-            options:(NSDictionary<UIApplicationOpenURLOptionsKey,id> *)options {
+- (BOOL)application:(UIApplication*)application
+            openURL:(NSURL*)url
+  sourceApplication:(NSString*)sourceApplication
+         annotation:(id)annotation {
   // Called when the application is asked to open a resource specified by a URL.
-  return [super application:application openURL:url options:options];
+  return [super application:application openURL:url sourceApplication:sourceApplication annotation:annotation];
 }
 @end


### PR DESCRIPTION
Fixes #10106 

This is intended to land on alpha first and then merge into master.

My understanding is that "git pull --ff-only" will continue to work on both the alpha and master branches and that the commit hashes of master and alpha will match the next time we merge master into alpha.