### PR TITLE
update the docs css style so the generated dartdoc matches the new flutter.io

### DIFF
--- a/dev/docs/styles.html
+++ b/dev/docs/styles.html
@@ -1,11 +1,12 @@
 <!-- style overrides for dartdoc -->
 <style>
-@import 'https://fonts.googleapis.com/css?family=Roboto:100i';
+@import 'https://fonts.googleapis.com/css?family=Roboto:500,400italic,300,400,100i';
 </style>
 
 <style>
   body {
     font-size: 15px;
+    font-family: Roboto, sans-serif;
     line-height: 1.5;
     color: #111;
     background-color: #fdfdfd;
@@ -14,7 +15,17 @@
   }
 
   header {
-    background-color: #01579b;
+    background-color: white;
+    color: #424242;
+  }
+
+  nav.navbar {
+    min-height: 57px;
+    padding: 6px 0;
+  }
+
+  nav.nav.navbar-fixed-top {
+    box-shadow: 0 1px 4px 0 rgba(0, 0, 0, 0.37);
   }
 
   h1, h2 {
@@ -36,7 +47,7 @@
 
   h2 {
     color: #111;
-    font-size: 26px;
+    font-size: 24px;
   }
 
   .markdown h2 {
@@ -44,7 +55,7 @@
   }
 
   section.summary h2 {
-    font-size: 32px;
+    font-size: 24px;
     color: inherit;
     border-bottom: none;
   }
@@ -52,10 +63,6 @@
   .sidebar ol,
   .sidebar ol li.section-title {
     font-size: inherit;
-  }
-
-  .sidebar-offcanvas-left {
-    background-color: #fdfdfd;
   }
 
   @media screen and (max-width: 768px) {
@@ -68,31 +75,23 @@
     padding: 0 16px 16px 0;
   }
 
-  .sidebar h5 {
-    display: none;
-  }
-
   .sidebar-offcanvas-left h5 {
-    border-bottom: none;
-    padding: 0 0 16px 0;
-  }
-
-  .sidebar-offcanvas-left h5:last-of-type {
-    padding: 0 0 16px 0;
+    display: none;
   }
 
   pre,
   pre.prettyprint,
   pre > code {
-    font-size: 15px;
+    font-size: 14px;
   }
 
   pre,
   pre.prettyprint {
-    background: inherit;
-    border: none;
+    background: #f5f2f0;
     margin: 0 0 15px 0;
     padding: 8px 12px;
+    border: 1px solid #cccccc;
+    border-radius: 4px;
   }
 
   code {
@@ -103,19 +102,19 @@
     padding-right: 0;
   }
 
+  #search-box {
+    color: #555;
+    background-color: #fff;
+    background-image: none;
+    border: 1px solid #ccc;
+    border-radius: 2px;
+    font-family: inherit;
+    padding: 4px 6px;
+    font-size: 15px;
+  }
+
   dl.dl-horizontal dt {
     color: inherit;
-  }
-
-  footer {
-    border-top: 1px solid #e8e8e8;
-    height: inherit;
-    padding-bottom: 15px;
-    text-transform: lowercase;
-  }
-
-  footer p {
-    color: #828282;
   }
 
   /* Line the material icons up with their labels */

--- a/dev/tools/dartdoc.dart
+++ b/dev/tools/dartdoc.dart
@@ -84,7 +84,7 @@ dependencies:
     'global', 'run', 'dartdoc',
     '--header', 'styles.html',
     '--header', 'analytics.html',
-    '--footer', 'lib/footer.html',
+    '--footer-text', 'lib/footer.html',
     '--exclude', 'temp_doc',
     '--favicon=favicon.ico',
     '--use-categories',
@@ -121,8 +121,8 @@ void createFooter(String footerPath) {
   final String timestamp = new DateFormat('yyyy-MM-dd HH:mm').format(new DateTime.now());
 
   new File(footerPath).writeAsStringSync(
-    '<p class="text-center" style="font-size: 10px">'
-    'Generated on $timestamp - Version $gitHead</p>'
+    '• </span class="no-break">$timestamp<span> '
+    '• </span class="no-break">$gitHead</span>'
   );
 }
 


### PR DESCRIPTION
- update the docs css style so the generated dartdoc matches the new flutter.io
- fix https://github.com/dart-lang/dartdoc/issues/1425

This won't be ready to land until we pub publish the latest dartdoc.

@jcollins-g, @Hixie, @sethladd 

<img width="1395" alt="screen shot 2017-05-17 at 7 14 17 am" src="https://cloud.githubusercontent.com/assets/1269969/26164133/952a0d8e-3ae0-11e7-977d-a19c7881ca75.png">

<img width="1242" alt="screen shot 2017-05-17 at 7 14 36 am" src="https://cloud.githubusercontent.com/assets/1269969/26164136/9c34bdb8-3ae0-11e7-9573-2b4e08b31bf3.png">


