### PR TITLE
rename Android module file to include project name

### DIFF
--- a/packages/flutter_tools/templates/create/.idea/modules.xml.tmpl
+++ b/packages/flutter_tools/templates/create/.idea/modules.xml.tmpl
@@ -3,7 +3,7 @@
   <component name="ProjectModuleManager">
     <modules>
       <module fileurl="file://$PROJECT_DIR$/{{projectName}}.iml" filepath="$PROJECT_DIR$/{{projectName}}.iml" />
-      <module fileurl="file://$PROJECT_DIR$/android.iml" filepath="$PROJECT_DIR$/android.iml" />
+      <module fileurl="file://$PROJECT_DIR$/{{projectName}}_android.iml" filepath="$PROJECT_DIR$/{{projectName}}_android.iml" />
     </modules>
   </component>
 </project>

--- a/packages/flutter_tools/templates/create/projectName_android.iml.tmpl
+++ b/packages/flutter_tools/templates/create/projectName_android.iml.tmpl
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$/android">
+      <sourceFolder url="file://$MODULE_DIR$/android/app/src/main/java" isTestSource="false" />
+    </content>
+    <orderEntry type="jdk" jdkName="Android API {{androidSdkVersion}} Platform" jdkType="Android SDK" />
+    <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="library" name="Flutter for Android" level="project" />
+  </component>
+</module>


### PR DESCRIPTION
IDEA users sometimes want to create multiple Flutter modules
in the same IDEA project. See discussion:
https://github.com/flutter/flutter-intellij/issues/1014

In this case, we will actually have pairs of modules,
one for Flutter and one for Android. Renaming the
android module to make the relationship obvious.

But, don't delete the old file yet to avoid breaking
existing users. We can do that after the next
Flutter plugin release.