### PR TITLE
We removed markdown a while ago.

### DIFF
--- a/dev/tools/dartdoc.dart
+++ b/dev/tools/dartdoc.dart
@@ -88,8 +88,7 @@ dependencies:
     '--exclude', 'temp_doc',
     '--favicon=favicon.ico',
     '--use-categories',
-    '--category-order',
-    'flutter,Dart Core,flutter_markdown,flutter_test,flutter_driver',
+    '--category-order', 'flutter,Dart Core,flutter_test,flutter_driver',
   ];
 
   for (String libraryRef in libraryRefs(diskPath: true)) {


### PR DESCRIPTION
This will get tested once we turn on fatal errors for dartdocs.
We can't do that yet because of upstream failures.