### PR TITLE
Avoid duplicate exceptions on VM Service mock failure

### DIFF
--- a/packages/flutter_tools/test/devfs_test.dart
+++ b/packages/flutter_tools/test/devfs_test.dart
@@ -380,7 +380,7 @@ class MockVMService extends BasicMock implements VMService {
   }
 
   Future<Null> tearDown() async {
-    await _server.close();
+    await _server?.close();
   }
 
   @override


### PR DESCRIPTION
On failure to configure a mock VM service, we get a useful exception in
setUpAll(). This change prevents an additional failure in tearDownAll()
that provides no additional useful diagnostic info.