### PR TITLE
Print locale in flutter doctor

### DIFF
--- a/packages/flutter_tools/lib/src/doctor.dart
+++ b/packages/flutter_tools/lib/src/doctor.dart
@@ -225,7 +225,7 @@ class _FlutterValidator extends DoctorValidator {
     }
 
     return new ValidationResult(valid, messages,
-      statusInfo: 'on ${os.name}, channel ${version.channel}');
+      statusInfo: 'on ${os.name}, locale ${platform.localeName}, channel ${version.channel}');
   }
 }
 

--- a/packages/flutter_tools/pubspec.yaml
+++ b/packages/flutter_tools/pubspec.yaml
@@ -20,7 +20,7 @@ dependencies:
   meta: ^1.0.5
   mustache: ^0.2.5
   package_config: '>=0.1.5 <2.0.0'
-  platform: 2.0.0
+  platform: 2.1.0
   process: 2.0.3
   quiver: ^0.24.0
   stack_trace: ^1.4.0


### PR DESCRIPTION
This helps to debug encoding issues that are believed to only happen for certain locales (see https://github.com/flutter/flutter/issues/10198 for example).

DO NOT SUBMIT until Dart SDK has been bumped (https://github.com/flutter/flutter/pull/10110) as this depends on new API form Dart 1.24.