### PR TITLE
Don't fail assert when we send an error to the plugin.

### DIFF
--- a/packages/flutter_tools/lib/src/commands/daemon.dart
+++ b/packages/flutter_tools/lib/src/commands/daemon.dart
@@ -417,7 +417,7 @@ class AppDomain extends Domain {
         );
         _sendAppEvent(app, 'stop');
       } catch (error) {
-        _sendAppEvent(app, 'stop', <String, dynamic>{'error': error.toString()});
+        _sendAppEvent(app, 'stop', <String, dynamic>{'error': _toJsonable(error)});
       } finally {
         fs.currentDirectory = cwd;
         _apps.remove(app);
@@ -699,7 +699,13 @@ dynamic _toJsonable(dynamic obj) {
     return obj;
   if (obj is OperationResult)
     return obj;
-  assert(false, 'obj not jsonable');
+  if (obj is ToolExit) {
+    return <String, String>{
+      'type': 'ToolExit',
+      'message': obj.message,
+      'exitCode': '${obj.exitCode}',
+    };
+  }
   return '$obj';
 }
 

--- a/packages/flutter_tools/lib/src/commands/daemon.dart
+++ b/packages/flutter_tools/lib/src/commands/daemon.dart
@@ -699,13 +699,8 @@ dynamic _toJsonable(dynamic obj) {
     return obj;
   if (obj is OperationResult)
     return obj;
-  if (obj is ToolExit) {
-    return <String, String>{
-      'type': 'ToolExit',
-      'message': obj.message,
-      'exitCode': '${obj.exitCode}',
-    };
-  }
+  if (obj is ToolExit)
+    return obj.message;
   return '$obj';
 }
 


### PR DESCRIPTION
Also, encode more semantics structure for `ToolExit`