### PR TITLE
Small doc clarification to HapticFeedback.vibrate

### DIFF
--- a/packages/flutter/lib/src/services/haptic_feedback.dart
+++ b/packages/flutter/lib/src/services/haptic_feedback.dart
@@ -15,8 +15,8 @@ class HapticFeedback {
 
   /// Provides haptic feedback to the user for a short duration.
   ///
-  /// On iOS, this uses the platform "sound" for vibration (via
-  /// `AudioServicesPlaySystemSound`).
+  /// On iOS devices that support haptic feedback, this uses the default system
+  /// vibration value (`kSystemSoundID_Vibrate`).
   ///
   /// On Android, this uses the platform haptic feedback API to simulates a
   /// short tap on a virtual keyboard.


### PR DESCRIPTION
Eliminate the implementation detail of which function is called to
trigger vibration on iOS, instead report the vibration constant.

Also note that not all iOS devices support haptic feedback (e.g., older
iPod touch devices).