### PR TITLE
expose debugPaintBaselinesEnabled

### DIFF
--- a/packages/flutter/lib/src/rendering/binding.dart
+++ b/packages/flutter/lib/src/rendering/binding.dart
@@ -49,7 +49,7 @@ abstract class RendererBinding extends BindingBase implements SchedulerBinding, 
     super.initServiceExtensions();
 
     assert(() {
-      // this service extension only works in checked mode
+      // these service extensions only works in checked mode
       registerBoolServiceExtension(
         name: 'debugPaint',
         getter: () async => debugPaintSizeEnabled,
@@ -59,6 +59,27 @@ abstract class RendererBinding extends BindingBase implements SchedulerBinding, 
           debugPaintSizeEnabled = value;
           return _forceRepaint();
         }
+      );
+      registerBoolServiceExtension(
+          name: 'debugPaintBaselinesEnabled',
+          getter: () async => debugPaintBaselinesEnabled,
+          setter: (bool value) async {
+            if (debugPaintBaselinesEnabled != value) {
+              debugPaintBaselinesEnabled = value;
+              await _forceRepaint();
+            }
+          }
+      );
+      registerBoolServiceExtension(
+          name: 'repaintRainbow',
+          getter: () async => debugRepaintRainbowEnabled,
+          setter: (bool value) {
+            final bool repaint = debugRepaintRainbowEnabled && !value;
+            debugRepaintRainbowEnabled = value;
+            if (repaint)
+              return _forceRepaint();
+            return new Future<Null>.value();
+          }
       );
       return true;
     });
@@ -77,22 +98,6 @@ abstract class RendererBinding extends BindingBase implements SchedulerBinding, 
       name: 'debugDumpSemanticsTree',
       callback: () { debugDumpSemanticsTree(); return debugPrintDone; }
     );
-
-    assert(() {
-      // this service extension only works in checked mode
-      registerBoolServiceExtension(
-        name: 'repaintRainbow',
-        getter: () async => debugRepaintRainbowEnabled,
-        setter: (bool value) {
-          final bool repaint = debugRepaintRainbowEnabled && !value;
-          debugRepaintRainbowEnabled = value;
-          if (repaint)
-            return _forceRepaint();
-          return new Future<Null>.value();
-        }
-      );
-      return true;
-    });
   }
 
   /// Creates a [RenderView] object to be the root of the

--- a/packages/flutter/lib/src/rendering/binding.dart
+++ b/packages/flutter/lib/src/rendering/binding.dart
@@ -49,7 +49,7 @@ abstract class RendererBinding extends BindingBase implements SchedulerBinding, 
     super.initServiceExtensions();
 
     assert(() {
-      // these service extensions only works in checked mode
+      // these service extensions only work in checked mode
       registerBoolServiceExtension(
         name: 'debugPaint',
         getter: () async => debugPaintSizeEnabled,
@@ -63,12 +63,12 @@ abstract class RendererBinding extends BindingBase implements SchedulerBinding, 
       registerBoolServiceExtension(
           name: 'debugPaintBaselinesEnabled',
           getter: () async => debugPaintBaselinesEnabled,
-          setter: (bool value) async {
-            if (debugPaintBaselinesEnabled != value) {
-              debugPaintBaselinesEnabled = value;
-              await _forceRepaint();
-            }
-          }
+          setter: (bool value) {
+          if (debugPaintBaselinesEnabled == value)
+            return new Future<Null>.value();
+          debugPaintBaselinesEnabled = value;
+          return _forceRepaint();
+        }
       );
       registerBoolServiceExtension(
           name: 'repaintRainbow',

--- a/packages/flutter/test/foundation/service_extensions_test.dart
+++ b/packages/flutter/test/foundation/service_extensions_test.dart
@@ -230,6 +230,48 @@ void main() {
     expect(binding.frameScheduled, isFalse);
   });
 
+  test('Service extensions - debugPaintBaselinesEnabled', () async {
+    Map<String, String> result;
+    Future<Map<String, String>> pendingResult;
+    bool completed;
+
+    expect(binding.frameScheduled, isFalse);
+    expect(debugPaintBaselinesEnabled, false);
+    result = await binding.testExtension('debugPaintBaselinesEnabled', <String, String>{});
+    expect(result, <String, String>{ 'enabled': 'false' });
+    expect(debugPaintBaselinesEnabled, false);
+    expect(binding.frameScheduled, isFalse);
+    pendingResult = binding.testExtension('debugPaintBaselinesEnabled', <String, String>{ 'enabled': 'true' });
+    completed = false;
+    pendingResult.whenComplete(() { completed = true; });
+    await binding.flushMicrotasks();
+    expect(binding.frameScheduled, isTrue);
+    expect(completed, isFalse);
+    await binding.doFrame();
+    await binding.flushMicrotasks();
+    expect(completed, isTrue);
+    expect(binding.frameScheduled, isFalse);
+    result = await pendingResult;
+    expect(result, <String, String>{ 'enabled': 'true' });
+    expect(debugPaintBaselinesEnabled, true);
+    result = await binding.testExtension('debugPaintBaselinesEnabled', <String, String>{});
+    expect(result, <String, String>{ 'enabled': 'true' });
+    expect(debugPaintBaselinesEnabled, true);
+    expect(binding.frameScheduled, isFalse);
+    pendingResult = binding.testExtension('debugPaintBaselinesEnabled', <String, String>{ 'enabled': 'false' });
+    await binding.flushMicrotasks();
+    expect(binding.frameScheduled, isTrue);
+    await binding.doFrame();
+    expect(binding.frameScheduled, isFalse);
+    result = await pendingResult;
+    expect(result, <String, String>{ 'enabled': 'false' });
+    expect(debugPaintBaselinesEnabled, false);
+    result = await binding.testExtension('debugPaintBaselinesEnabled', <String, String>{});
+    expect(result, <String, String>{ 'enabled': 'false' });
+    expect(debugPaintBaselinesEnabled, false);
+    expect(binding.frameScheduled, isFalse);
+  });
+
   test('Service extensions - evict', () async {
     Map<String, String> result;
     bool completed;
@@ -417,7 +459,7 @@ void main() {
   test('Service extensions - posttest', () async {
     // If you add a service extension... TEST IT! :-)
     // ...then increment this number.
-    expect(binding.extensions.length, 14);
+    expect(binding.extensions.length, 15);
 
     expect(console, isEmpty);
     debugPrint = debugPrintThrottled;


### PR DESCRIPTION
- expose `debugPaintBaselinesEnabled` as a service extension
- some work towards https://github.com/flutter/flutter-intellij/issues/1025

Expose `debugPaintBaselinesEnabled` (the primary use case I've heard for this is for designers using Flutter).
