### PR TITLE
Remove inactive elements from the semantic tree

### DIFF
--- a/packages/flutter/lib/src/material/drawer.dart
+++ b/packages/flutter/lib/src/material/drawer.dart
@@ -126,6 +126,10 @@ class DrawerController extends StatefulWidget {
   /// Typically a [Drawer].
   final Widget child;
 
+  /// Callback for state change notifications.
+  ///
+  /// Gets called whenever the drawer's state switches from open to closed or
+  /// vice versa.
   final VoidCallback onStateChanged;
 
   @override
@@ -250,6 +254,7 @@ class DrawerControllerState extends State<DrawerController> with SingleTickerPro
     _controller.fling(velocity: -1.0);
   }
 
+  /// Whether the drawer is closed.
   bool get isClosed => _controller.status == AnimationStatus.dismissed;
 
   final ColorTween _color = new ColorTween(begin: Colors.transparent, end: Colors.black54);

--- a/packages/flutter/lib/src/material/drawer.dart
+++ b/packages/flutter/lib/src/material/drawer.dart
@@ -116,7 +116,8 @@ class DrawerController extends StatefulWidget {
   /// The [child] argument must not be null and is typically a [Drawer].
   const DrawerController({
     GlobalKey key,
-    @required this.child
+    this.onStateChanged,
+    @required this.child,
   }) : assert(child != null),
        super(key: key);
 
@@ -124,6 +125,8 @@ class DrawerController extends StatefulWidget {
   ///
   /// Typically a [Drawer].
   final Widget child;
+
+  final VoidCallback onStateChanged;
 
   @override
   DrawerControllerState createState() => new DrawerControllerState();
@@ -178,8 +181,12 @@ class DrawerControllerState extends State<DrawerController> with SingleTickerPro
         _historyEntry = null;
         break;
       case AnimationStatus.dismissed:
+        if (widget.onStateChanged != null)
+          widget.onStateChanged();
         break;
       case AnimationStatus.completed:
+        if (widget.onStateChanged != null)
+          widget.onStateChanged();
         break;
     }
   }
@@ -243,11 +250,13 @@ class DrawerControllerState extends State<DrawerController> with SingleTickerPro
     _controller.fling(velocity: -1.0);
   }
 
+  bool get isClosed => _controller.status == AnimationStatus.dismissed;
+
   final ColorTween _color = new ColorTween(begin: Colors.transparent, end: Colors.black54);
   final GlobalKey _gestureDetectorKey = new GlobalKey();
 
   Widget _buildDrawer(BuildContext context) {
-    if (_controller.status == AnimationStatus.dismissed) {
+    if (isClosed) {
       return new Align(
         alignment: FractionalOffset.centerLeft,
         child: new GestureDetector(

--- a/packages/flutter/lib/src/material/drawer.dart
+++ b/packages/flutter/lib/src/material/drawer.dart
@@ -128,9 +128,9 @@ class DrawerController extends StatefulWidget {
 
   /// Callback for state change notifications.
   ///
-  /// Gets called whenever the drawer's state switches from open to closed or
-  /// vice versa.
-  final VoidCallback onStateChanged;
+  /// Gets called with `true` as argument whenever the drawer's state switched
+  /// to closed and `false` whenever it switched to open.
+  final ValueChanged<bool> onStateChanged;
 
   @override
   DrawerControllerState createState() => new DrawerControllerState();
@@ -186,11 +186,11 @@ class DrawerControllerState extends State<DrawerController> with SingleTickerPro
         break;
       case AnimationStatus.dismissed:
         if (widget.onStateChanged != null)
-          widget.onStateChanged();
+          widget.onStateChanged(isClosed);
         break;
       case AnimationStatus.completed:
         if (widget.onStateChanged != null)
-          widget.onStateChanged();
+          widget.onStateChanged(isClosed);
         break;
     }
   }

--- a/packages/flutter/lib/src/material/scaffold.dart
+++ b/packages/flutter/lib/src/material/scaffold.dart
@@ -891,7 +891,7 @@ class ScaffoldState extends State<Scaffold> with TickerProviderStateMixin {
         new DrawerController(
           key: _drawerKey,
           onStateChanged: () {
-            // Rebuild Scaffold when drawer opens/closed to update semantics tree.
+            // Rebuild Scaffold when drawer opens/closes to update semantics tree.
             setState(() {});
           },
           child: widget.drawer,

--- a/packages/flutter/lib/src/material/scaffold.dart
+++ b/packages/flutter/lib/src/material/scaffold.dart
@@ -762,10 +762,12 @@ class ScaffoldState extends State<Scaffold> with TickerProviderStateMixin {
     super.dispose();
   }
 
-  void _addChild(List<LayoutId> children, Widget child, Object childId, {bool excludeSemantics: false}) {
+  void _addChild(List<LayoutId> children, Widget child, Object childId, { bool excludeSemantics: false }) {
     if (child != null)
       children.add(new LayoutId(child: new ExcludeSemantics(child: child, excluding: excludeSemantics), id: childId));
   }
+
+  bool _drawerIsClosed = true;
 
   @override
   Widget build(BuildContext context) {
@@ -792,7 +794,7 @@ class ScaffoldState extends State<Scaffold> with TickerProviderStateMixin {
 
     final List<LayoutId> children = <LayoutId>[];
 
-    final bool excludeSemantics = !(_drawerKey.currentState?.isClosed ?? true);
+    final bool excludeSemantics = !_drawerIsClosed;
 
     _addChild(children, widget.body, _ScaffoldSlot.body, excludeSemantics: excludeSemantics);
 
@@ -890,9 +892,10 @@ class ScaffoldState extends State<Scaffold> with TickerProviderStateMixin {
         children,
         new DrawerController(
           key: _drawerKey,
-          onStateChanged: () {
-            // Rebuild Scaffold when drawer opens/closes to update semantics tree.
-            setState(() {});
+          onStateChanged: (bool drawerIsClosed) {
+            setState(() {
+              _drawerIsClosed = drawerIsClosed;
+            });
           },
           child: widget.drawer,
         ),

--- a/packages/flutter/lib/src/material/scaffold.dart
+++ b/packages/flutter/lib/src/material/scaffold.dart
@@ -794,7 +794,7 @@ class ScaffoldState extends State<Scaffold> with TickerProviderStateMixin {
 
     final bool excludeSemantics = !(_drawerKey.currentState?.isClosed ?? true);
 
-    _addChild(children, widget.body, _ScaffoldSlot.body);
+    _addChild(children, widget.body, _ScaffoldSlot.body, excludeSemantics: excludeSemantics);
 
     if (widget.appBar != null) {
       final double topPadding = widget.primary ? padding.top : 0.0;

--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -2900,7 +2900,7 @@ class RenderExcludeSemantics extends RenderProxyBox {
   /// Creates a render object that ignores the semantics of its subtree.
   RenderExcludeSemantics({
     RenderBox child,
-    bool excluding : true,
+    bool excluding: true,
   }) : _excluding = excluding, super(child) {
     assert(_excluding != null);
   }
@@ -2918,9 +2918,8 @@ class RenderExcludeSemantics extends RenderProxyBox {
 
   @override
   void visitChildrenForSemantics(RenderObjectVisitor visitor) {
-    if (excluding) {
+    if (excluding)
       return;
-    }
     super.visitChildrenForSemantics(visitor);
   }
 

--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -2895,8 +2895,34 @@ class RenderMergeSemantics extends RenderProxyBox {
 /// to it (e.g. text included only for the visual effect).
 class RenderExcludeSemantics extends RenderProxyBox {
   /// Creates a render object that ignores the semantics of its subtree.
-  RenderExcludeSemantics({ RenderBox child }) : super(child);
+  RenderExcludeSemantics({
+    RenderBox child,
+    bool excluding : true,
+  }) : _excluding = excluding, super(child) {
+    assert(_excluding != null);
+  }
+
+  bool get excluding => _excluding;
+  bool _excluding;
+  set excluding(bool value) {
+    assert(value != null);
+    if (value == _excluding)
+      return;
+    _excluding = value;
+    markNeedsSemanticsUpdate();
+  }
 
   @override
-  void visitChildrenForSemantics(RenderObjectVisitor visitor) { }
+  void visitChildrenForSemantics(RenderObjectVisitor visitor) {
+    if (excluding) {
+      return;
+    }
+    super.visitChildrenForSemantics(visitor);
+  }
+
+  @override
+  void debugFillDescription(List<String> description) {
+    super.debugFillDescription(description);
+    description.add('excluding: $excluding');
+  }
 }

--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -2891,6 +2891,9 @@ class RenderMergeSemantics extends RenderProxyBox {
 
 /// Excludes this subtree from the semantic tree.
 ///
+/// When [excluding] is true, this render object (and its subtree) is excluded
+/// from the semantic tree.
+///
 /// Useful e.g. for hiding text that is redundant with other text next
 /// to it (e.g. text included only for the visual effect).
 class RenderExcludeSemantics extends RenderProxyBox {
@@ -2902,6 +2905,7 @@ class RenderExcludeSemantics extends RenderProxyBox {
     assert(_excluding != null);
   }
 
+  /// Whether this render object is excluded from the semantic tree.
   bool get excluding => _excluding;
   bool _excluding;
   set excluding(bool value) {

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -3272,10 +3272,28 @@ class MergeSemantics extends SingleChildRenderObjectWidget {
 /// redundant with the chip label.
 class ExcludeSemantics extends SingleChildRenderObjectWidget {
   /// Creates a widget that drops all the semantics of its descendants.
-  const ExcludeSemantics({ Key key, Widget child }) : super(key: key, child: child);
+  const ExcludeSemantics({
+    Key key,
+    this.excluding: true,
+    Widget child,
+  }) : assert(excluding != null),
+       super(key: key, child: child);
+
+  final bool excluding;
 
   @override
-  RenderExcludeSemantics createRenderObject(BuildContext context) => new RenderExcludeSemantics();
+  RenderExcludeSemantics createRenderObject(BuildContext context) => new RenderExcludeSemantics(excluding: excluding);
+
+  @override
+  void updateRenderObject(BuildContext context, RenderExcludeSemantics renderObject) {
+    renderObject.excluding = excluding;
+  }
+
+  @override
+  void debugFillDescription(List<String> description) {
+    super.debugFillDescription(description);
+    description.add('excluding: $excluding');
+  }
 }
 
 /// A widget that builds its child.

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -3282,7 +3282,7 @@ class ExcludeSemantics extends SingleChildRenderObjectWidget {
   }) : assert(excluding != null),
        super(key: key, child: child);
 
-  /// Whether this widget is included in the semantics tree.
+  /// Whether this widget is excluded in the semantics tree.
   final bool excluding;
 
   @override

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -3266,6 +3266,9 @@ class MergeSemantics extends SingleChildRenderObjectWidget {
 
 /// A widget that drops all the semantics of its descendants.
 ///
+/// When [excluding] is true, this widget (and its subtree) is excluded from
+/// the semantics tree.
+///
 /// This can be used to hide subwidgets that would otherwise be
 /// reported but that would only be confusing. For example, the
 /// material library's [Chip] widget hides the avatar since it is
@@ -3279,6 +3282,7 @@ class ExcludeSemantics extends SingleChildRenderObjectWidget {
   }) : assert(excluding != null),
        super(key: key, child: child);
 
+  /// Whether this widget is included in the semantics tree.
   final bool excluding;
 
   @override

--- a/packages/flutter/lib/src/widgets/overlay.dart
+++ b/packages/flutter/lib/src/widgets/overlay.dart
@@ -62,7 +62,8 @@ class OverlayEntry {
     @required this.builder,
     bool opaque: false,
     bool maintainState: false,
-  }) : _opaque = opaque, _maintainState = maintainState {
+    bool semanticsBarrier: false,
+  }) : _opaque = opaque, _maintainState = maintainState, _semanticsBarrier = semanticsBarrier {
     assert(builder != null);
     assert(opaque != null);
     assert(maintainState != null);
@@ -113,6 +114,17 @@ class OverlayEntry {
     _maintainState = value;
     assert(_overlay != null);
     _overlay._didChangeEntryOpacity();
+  }
+
+  bool get semanticsBarrier => _semanticsBarrier;
+  bool _semanticsBarrier;
+  set semanticsBarrier(bool value) {
+    assert(_semanticsBarrier != null);
+    if (_semanticsBarrier == value)
+      return;
+    _semanticsBarrier = value;
+    assert(_overlay != null);
+    _overlay._didChangeEntryOpacity(); // TODO(goderbauer): rename?
   }
 
   OverlayState _overlay;
@@ -350,10 +362,16 @@ class OverlayState extends State<Overlay> with TickerProviderStateMixin {
     final List<Widget> onstageChildren = <Widget>[];
     final List<Widget> offstageChildren = <Widget>[];
     bool onstage = true;
+    bool excludeSemantics = false;
     for (int i = _entries.length - 1; i >= 0; i -= 1) {
       final OverlayEntry entry = _entries[i];
       if (onstage) {
-        onstageChildren.add(new _OverlayEntry(entry));
+        onstageChildren.add(new ExcludeSemantics(
+            child: new _OverlayEntry(entry),
+            excluding: excludeSemantics,
+        ));
+        if (entry.semanticsBarrier)
+          excludeSemantics = true;
         if (entry.opaque)
           onstage = false;
       } else if (entry.maintainState) {

--- a/packages/flutter/lib/src/widgets/overlay.dart
+++ b/packages/flutter/lib/src/widgets/overlay.dart
@@ -46,6 +46,10 @@ import 'ticker_provider.dart';
 /// if widgets in an overlay entry with [maintainState] set to true repeatedly
 /// call [State.setState], the user's battery will be drained unnecessarily.
 ///
+/// If this entry is declared to be a [semanticsBarrier], then entries below
+/// this one will not be included in the semantic tree, e.i. those entries will
+/// be unreachable via accessibility means.
+///
 /// See also:
 ///
 ///  * [Overlay].
@@ -116,6 +120,10 @@ class OverlayEntry {
     _overlay._didChangeEntryOpacity();
   }
 
+  /// Whether this entry is a semantics barrier for the entries below it.
+  ///
+  /// If `true`, entries below this entry will not be included in the semantic
+  /// tree. That means they are not reachable via accessibility means.
   bool get semanticsBarrier => _semanticsBarrier;
   bool _semanticsBarrier;
   set semanticsBarrier(bool value) {

--- a/packages/flutter/lib/src/widgets/overlay.dart
+++ b/packages/flutter/lib/src/widgets/overlay.dart
@@ -47,8 +47,8 @@ import 'ticker_provider.dart';
 /// call [State.setState], the user's battery will be drained unnecessarily.
 ///
 /// If this entry is declared to be a [semanticsBarrier], then entries below
-/// this one will not be included in the semantic tree, e.i. those entries will
-/// be unreachable via accessibility means.
+/// this one will not be included in the semantic tree, i.e. those entries will
+/// be unreachable via accessibility user agents.
 ///
 /// See also:
 ///
@@ -71,6 +71,7 @@ class OverlayEntry {
     assert(builder != null);
     assert(opaque != null);
     assert(maintainState != null);
+    assert(semanticsBarrier != null);
   }
 
   /// This entry will include the widget built by this builder in the overlay at
@@ -92,7 +93,7 @@ class OverlayEntry {
       return;
     _opaque = value;
     assert(_overlay != null);
-    _overlay._didChangeEntryOpacity();
+    _overlay._didChangeEntryAttribute();
   }
 
   /// Whether this entry must be included in the tree even if there is a fully
@@ -117,13 +118,14 @@ class OverlayEntry {
       return;
     _maintainState = value;
     assert(_overlay != null);
-    _overlay._didChangeEntryOpacity();
+    _overlay._didChangeEntryAttribute();
   }
 
   /// Whether this entry is a semantics barrier for the entries below it.
   ///
   /// If `true`, entries below this entry will not be included in the semantic
-  /// tree. That means they are not reachable via accessibility means.
+  /// tree. This means, for example, that they are not reachable using
+  /// accessibility tools.
   bool get semanticsBarrier => _semanticsBarrier;
   bool _semanticsBarrier;
   set semanticsBarrier(bool value) {
@@ -132,7 +134,7 @@ class OverlayEntry {
       return;
     _semanticsBarrier = value;
     assert(_overlay != null);
-    _overlay._didChangeEntryOpacity(); // TODO(goderbauer): rename?
+    _overlay._didChangeEntryAttribute();
   }
 
   OverlayState _overlay;
@@ -355,10 +357,10 @@ class OverlayState extends State<Overlay> with TickerProviderStateMixin {
     return result;
   }
 
-  void _didChangeEntryOpacity() {
+  void _didChangeEntryAttribute() {
     setState(() {
-      // We use the opacity of the entry in our build function, which means we
-      // our state has changed.
+      // We use entry attribitues (like opacity and semanticsBarrier) in our
+      // build function, which means our state has changed.
     });
   }
 

--- a/packages/flutter/lib/src/widgets/routes.dart
+++ b/packages/flutter/lib/src/widgets/routes.dart
@@ -945,7 +945,7 @@ abstract class ModalRoute<T> extends TransitionRoute<T> with LocalHistoryRoute<T
 
   @override
   Iterable<OverlayEntry> createOverlayEntries() sync* {
-    yield new OverlayEntry(builder: _buildModalBarrier);
+    yield new OverlayEntry(builder: _buildModalBarrier, semanticsBarrier: true);
     yield new OverlayEntry(builder: _buildModalScope, maintainState: maintainState);
   }
 

--- a/packages/flutter/test/material/dialog_test.dart
+++ b/packages/flutter/test/material/dialog_test.dart
@@ -3,7 +3,12 @@
 // found in the LICENSE file.
 
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
+
+import 'package:matcher/matcher.dart';
+
+import '../widgets/semantics_tester.dart';
 
 void main() {
   testWidgets('Dialog is scrollable', (WidgetTester tester) async {
@@ -191,5 +196,37 @@ void main() {
     await tester.pumpAndSettle(const Duration(seconds: 1));
     expect(find.text('Dialog2'), findsOneWidget);
 
+  });
+
+  testWidgets('Dialog hides underlying semantics tree', (WidgetTester tester) async {
+    final SemanticsTester semantics = new SemanticsTester(tester);
+    const String buttonText = 'A button covered by dialog overlay';
+    await tester.pumpWidget(
+      new MaterialApp(
+        home: const Material(
+          child: const Center(
+            child: const RaisedButton(
+              onPressed: null,
+              child: const Text(buttonText),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(semantics, includesNodeWithLabel(buttonText));
+
+    final BuildContext context = tester.element(find.text(buttonText));
+
+    const String alertText = 'A button in an overlay alert';
+    showDialog<Null>(
+      context: context,
+      child: const AlertDialog(title: const Text(alertText)),
+    );
+
+    await tester.pumpAndSettle(const Duration(seconds: 1));
+
+    expect(semantics, includesNodeWithLabel(alertText));
+    expect(semantics, isNot(includesNodeWithLabel(buttonText)));
   });
 }

--- a/packages/flutter/test/material/dialog_test.dart
+++ b/packages/flutter/test/material/dialog_test.dart
@@ -5,7 +5,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
-
 import 'package:matcher/matcher.dart';
 
 import '../widgets/semantics_tester.dart';
@@ -228,5 +227,7 @@ void main() {
 
     expect(semantics, includesNodeWithLabel(alertText));
     expect(semantics, isNot(includesNodeWithLabel(buttonText)));
+
+    semantics.dispose();
   });
 }

--- a/packages/flutter/test/material/scaffold_test.dart
+++ b/packages/flutter/test/material/scaffold_test.dart
@@ -475,5 +475,7 @@ void main() {
     expect(semantics, isNot(includesNodeWithLabel(bottomNavigationBarLabel)));
     expect(semantics, isNot(includesNodeWithLabel(floatingActionButtonLabel)));
     expect(semantics, includesNodeWithLabel(drawerLabel));
+
+    semantics.dispose();
   });
 }

--- a/packages/flutter/test/material/scaffold_test.dart
+++ b/packages/flutter/test/material/scaffold_test.dart
@@ -6,6 +6,8 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 
+import '../widgets/semantics_tester.dart';
+
 void main() {
   testWidgets('Scaffold control test', (WidgetTester tester) async {
     final Key bodyKey = new UniqueKey();
@@ -439,5 +441,39 @@ void main() {
       expect(tester.element(find.byKey(testKey)).size, const Size(88.0, 36.0));
       expect(tester.renderObject<RenderBox>(find.byKey(testKey)).localToGlobal(Offset.zero), const Offset(0.0, 0.0));
     });
+  });
+
+  testWidgets('Open drawer hides underlying semantics tree', (WidgetTester tester) async {
+    const String bodyLabel = 'I am the body';
+    const String persistentFooterButtonLabel = 'a button on the bottom';
+    const String bottomNavigationBarLabel = 'a bar in an app';
+    const String floatingActionButtonLabel = 'I float in space';
+    const String drawerLabel = 'I am the reason for this test';
+
+    final SemanticsTester semantics = new SemanticsTester(tester);
+    await tester.pumpWidget(new MaterialApp(home: new Scaffold(
+      body: new Semantics(label: bodyLabel, child: new Container()),
+      persistentFooterButtons: <Widget>[new Semantics(label: persistentFooterButtonLabel, child: new Container())],
+      bottomNavigationBar: new Semantics(label: bottomNavigationBarLabel, child: new Container()),
+      floatingActionButton: new Semantics(label: floatingActionButtonLabel, child: new Container()),
+      drawer: new Drawer(child:new Semantics(label: drawerLabel, child: new Container())),
+    )));
+
+    expect(semantics, includesNodeWithLabel(bodyLabel));
+    expect(semantics, includesNodeWithLabel(persistentFooterButtonLabel));
+    expect(semantics, includesNodeWithLabel(bottomNavigationBarLabel));
+    expect(semantics, includesNodeWithLabel(floatingActionButtonLabel));
+    expect(semantics, isNot(includesNodeWithLabel(drawerLabel)));
+
+    final ScaffoldState state = tester.firstState(find.byType(Scaffold));
+    state.openDrawer();
+    await tester.pump();
+    await tester.pump(const Duration(seconds: 1));
+
+    expect(semantics, isNot(includesNodeWithLabel(bodyLabel)));
+    expect(semantics, isNot(includesNodeWithLabel(persistentFooterButtonLabel)));
+    expect(semantics, isNot(includesNodeWithLabel(bottomNavigationBarLabel)));
+    expect(semantics, isNot(includesNodeWithLabel(floatingActionButtonLabel)));
+    expect(semantics, includesNodeWithLabel(drawerLabel));
   });
 }

--- a/packages/flutter/test/widgets/overlay_test.dart
+++ b/packages/flutter/test/widgets/overlay_test.dart
@@ -5,6 +5,8 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/widgets.dart';
 
+import 'semantics_tester.dart';
+
 void main() {
   testWidgets('OverflowEntries context contains Overlay',
       (WidgetTester tester) async {
@@ -25,5 +27,46 @@ void main() {
       ],
     ));
     expect(didBuild, isTrue);
+  });
+
+  testWidgets('semanticsBarrier should hide underlying semantic tree',
+        (WidgetTester tester) async {
+    final SemanticsTester semantics = new SemanticsTester(tester);
+
+    final TestSemantics expectedSemantics = new TestSemantics.root(
+      label: 'included in tree',
+    );
+
+    final Key overlayKey = new UniqueKey();
+    await tester.pumpWidget(new Overlay(
+      key: overlayKey,
+      initialEntries: <OverlayEntry>[
+        new OverlayEntry(
+          builder: (BuildContext context) {
+            return new Container(
+              child: new Semantics(
+                label: 'not included in tree',
+                child: new Container()
+              )
+            );
+          },
+        ),
+        new OverlayEntry(
+          builder: (BuildContext context) {
+            return new Container(
+              child: new Semantics(
+                  label: 'included in tree',
+                  child: new Container()
+              )
+            );
+          },
+          semanticsBarrier: true,
+        )
+      ],
+    ));
+
+    expect(semantics, hasSemantics(expectedSemantics));
+
+    semantics.dispose();
   });
 }


### PR DESCRIPTION
In this PR:
* OverlayEntries can be a semantic barriers meaning that everything below that entry is no longer included in the semantics tree (used for e.g. Dialogs).
* When the Drawer in a Scaffold is open all elements outside of the drawer are no longer part of the semantics tree.
* A new `includesNodeWithLabel` matcher for tests.