### PR TITLE
Fix currently animated widget jumping to top when using the AnimatedCrossFade widget

### DIFF
--- a/packages/flutter/lib/src/widgets/animated_cross_fade.dart
+++ b/packages/flutter/lib/src/widgets/animated_cross_fade.dart
@@ -172,6 +172,7 @@ class _AnimatedCrossFadeState extends State<AnimatedCrossFade> with TickerProvid
           left: 0.0,
           top: 0.0,
           right: 0.0,
+          bottom: 0.0,
           child: new FadeTransition(
             opacity: _firstAnimation,
             child: widget.firstChild,
@@ -190,6 +191,7 @@ class _AnimatedCrossFadeState extends State<AnimatedCrossFade> with TickerProvid
           left: 0.0,
           top: 0.0,
           right: 0.0,
+          bottom: 0.0,
           child: new FadeTransition(
             opacity: _secondAnimation,
             child: widget.secondChild,


### PR DESCRIPTION
The issue & sample project are [here](https://github.com/flutter/flutter/issues/10243).

I was not able to get it working with modifying the Stack's `fit` property as @Hixie originally suggested, but if I understand everything correctly, this should be a proper fix for this. For the sample app, this fixes the issue & doesn't change behavior on some other cases I tested manually.