### PR TITLE
fix typeahead css

### DIFF
--- a/dev/docs/styles.html
+++ b/dev/docs/styles.html
@@ -113,6 +113,11 @@
     font-size: 15px;
   }
 
+  input.form-control.typeahead {
+    padding: 4px 7px;
+    font-size: 15px;
+  }
+
   dl.dl-horizontal dt {
     color: inherit;
   }


### PR DESCRIPTION
- fix typeahead css (fix https://github.com/flutter/flutter/issues/10314)

<img width="457" alt="screen shot 2017-05-25 at 1 04 04 pm" src="https://cloud.githubusercontent.com/assets/1269969/26468317/d15097a4-414a-11e7-8435-d28fbb05461f.png">