### PR TITLE
Fix package_test flakiness, init ensure terminal context entry is set

### DIFF
--- a/packages/flutter_tools/lib/src/base/logger.dart
+++ b/packages/flutter_tools/lib/src/base/logger.dart
@@ -178,6 +178,7 @@ class BufferLogger extends Logger {
 
 class VerboseLogger extends Logger {
   VerboseLogger(this.parent) {
+    assert(terminal != null);
     stopwatch.start();
   }
 

--- a/packages/flutter_tools/test/src/context.dart
+++ b/packages/flutter_tools/test/src/context.dart
@@ -12,6 +12,7 @@ import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/os.dart';
 import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/base/port_scanner.dart';
+import 'package:flutter_tools/src/base/terminal.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/devfs.dart';
 import 'package:flutter_tools/src/device.dart';
@@ -40,6 +41,7 @@ typedef void ContextInitializer(AppContext testContext);
 
 void _defaultInitializeContext(AppContext testContext) {
   testContext
+    ..putIfAbsent(AnsiTerminal, () => new AnsiTerminal())
     ..putIfAbsent(DeviceManager, () => new MockDeviceManager())
     ..putIfAbsent(DevFSConfig, () => new DevFSConfig())
     ..putIfAbsent(Doctor, () => new MockDoctor())


### PR DESCRIPTION
The verbose logger depended on the AnsiTerminal context entry, but only if the test happened to run for more than 100ms. The terminal entry wasn't set up by testUsingContext() which is used by all of the package tests.

Fixes https://github.com/flutter/flutter/issues/10283
