### PR TITLE
Include Semantics Node in debugDumpRenderTree, if available

### DIFF
--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -2680,6 +2680,8 @@ abstract class RenderObject extends AbstractNode implements HitTestTarget {
     description.add('constraints: $constraints');
     if (_layer != null) // don't access it via the "layer" getter since that's only valid when we don't need paint
       description.add('layer: $_layer');
+    if (_semantics != null)
+      description.add('semantics: $_semantics');
   }
 
   /// Returns a string describing the current node's descendants. Each line of


### PR DESCRIPTION
Makes debugging semantics easier (e.g. which RenderObject has semantics, where is a SemanticNode seen in the semantic tree comming from, etc).

It's only printed if accessibility is turned on.