### PR TITLE
Minor flutter_tools test reorganization

### DIFF
--- a/packages/flutter_tools/test/base/terminal_test.dart
+++ b/packages/flutter_tools/test/base/terminal_test.dart
@@ -7,7 +7,7 @@ import 'dart:async';
 import 'package:flutter_tools/src/base/terminal.dart';
 import 'package:test/test.dart';
 
-import '../context.dart';
+import '../src/context.dart';
 
 
 void main() {

--- a/packages/flutter_tools/test/ios/code_signing_test.dart
+++ b/packages/flutter_tools/test/ios/code_signing_test.dart
@@ -13,7 +13,7 @@ import 'package:flutter_tools/src/ios/code_signing.dart';
 import 'package:process/process.dart';
 import 'package:test/test.dart';
 
-import '../context.dart';
+import '../src/context.dart';
 
 void main() {
   group('Auto signing', () {


### PR DESCRIPTION
Relocates two tests alongside other related tests:
* moved code_signing_test.dart alongside other lib/src/ios tests
* moved terminal_test.dart alongside other lib/src/base tests