### PR TITLE
Don't build ModalBarrier when ModalRoute is opaque

### DIFF
--- a/packages/flutter/lib/src/widgets/routes.dart
+++ b/packages/flutter/lib/src/widgets/routes.dart
@@ -945,7 +945,8 @@ abstract class ModalRoute<T> extends TransitionRoute<T> with LocalHistoryRoute<T
 
   @override
   Iterable<OverlayEntry> createOverlayEntries() sync* {
-    yield new OverlayEntry(builder: _buildModalBarrier);
+    if (!opaque)
+      yield new OverlayEntry(builder: _buildModalBarrier);
     yield new OverlayEntry(builder: _buildModalScope, maintainState: maintainState);
   }
 

--- a/packages/flutter/test/widgets/routes_test.dart
+++ b/packages/flutter/test/widgets/routes_test.dart
@@ -81,6 +81,32 @@ class TestRoute extends LocalHistoryRoute<String> {
 
 }
 
+class TestModalRoute extends ModalRoute<String> {
+
+  TestModalRoute({this.opaque: true});
+
+  @override
+  bool opaque;
+
+  @override
+  bool get barrierDismissible => false;
+
+  @override
+  Color get barrierColor => null;
+
+  @override
+  Duration get transitionDuration => const Duration(microseconds: 1);
+
+  @override
+  bool get maintainState => false;
+
+  @override
+  Widget buildPage(BuildContext context, Animation<double> animation, Animation<double> secondaryAnimation) {
+    return new Container();
+  }
+
+}
+
 Future<Null> runNavigatorTest(
   WidgetTester tester,
   NavigatorState host,
@@ -391,4 +417,22 @@ void main() {
       ]
     );
   });
+
+  group('ModalRoute', () {
+    testWidgets('does not build modal barrier when opaque', (WidgetTester tester) async {
+      await tester.pumpWidget(new Navigator(
+          onGenerateRoute: (_) => new TestModalRoute(opaque: true)
+      ));
+      expect(tester.allWidgets, everyElement((Widget w) => w is! ModalBarrier));
+    });
+
+    testWidgets('does build modal barrier when not opaque', (WidgetTester tester) async {
+      await tester.pumpWidget(new Navigator(
+          onGenerateRoute: (_) => new TestModalRoute(opaque: false)
+      ));
+      expect(tester.allWidgets, anyElement((Widget w) => w is ModalBarrier));
+    });
+  });
+
+
 }


### PR DESCRIPTION
Motivation: clean up the semantic tree. Looks like the ModalBarrier is not needed in the opaque case altogether. That's why I am excluding it entirely instead of just its semantics. 