### PR TITLE
Don't enforce `library_prefixes` lint in users' projects.

### DIFF
--- a/packages/flutter/lib/analysis_options_user.yaml
+++ b/packages/flutter/lib/analysis_options_user.yaml
@@ -69,7 +69,7 @@ linter:
     - empty_constructor_bodies
     - implementation_imports
     - library_names
-    - library_prefixes
+    # - library_prefixes
     - non_constant_identifier_names
     # - one_member_abstracts
     # - only_throw_errors


### PR DESCRIPTION
The lint ensures that the prefix you use in your "import ... as"
directive conforms to lowercase_with_underscores style. However,
generated code often doesn't, since it may use preceding underscores
for collision avoidance, or directly use locale codes in the
prefixes.