### PR TITLE
have app loggers log to their parent logger

### DIFF
--- a/packages/flutter_tools/flutter_tools.iml
+++ b/packages/flutter_tools/flutter_tools.iml
@@ -7,6 +7,10 @@
       <excludeFolder url="file://$MODULE_DIR$/bin/packages" />
       <excludeFolder url="file://$MODULE_DIR$/build" />
       <excludeFolder url="file://$MODULE_DIR$/packages" />
+      <excludeFolder url="file://$MODULE_DIR$/test/android/packages" />
+      <excludeFolder url="file://$MODULE_DIR$/test/base/packages" />
+      <excludeFolder url="file://$MODULE_DIR$/test/commands/packages" />
+      <excludeFolder url="file://$MODULE_DIR$/test/data/dart_dependencies_test/asci_casing/packages" />
       <excludeFolder url="file://$MODULE_DIR$/test/data/dart_dependencies_test/bad_package/.pub" />
       <excludeFolder url="file://$MODULE_DIR$/test/data/dart_dependencies_test/bad_package/build" />
       <excludeFolder url="file://$MODULE_DIR$/test/data/dart_dependencies_test/bad_package/packages" />
@@ -30,16 +34,10 @@
       <excludeFolder url="file://$MODULE_DIR$/test/data/intellij/plugins/Dart/packages" />
       <excludeFolder url="file://$MODULE_DIR$/test/data/intellij/plugins/packages" />
       <excludeFolder url="file://$MODULE_DIR$/test/data/packages" />
+      <excludeFolder url="file://$MODULE_DIR$/test/ios/packages" />
       <excludeFolder url="file://$MODULE_DIR$/test/packages" />
-      <excludeFolder url="file://$MODULE_DIR$/test/replay/osx/packages" />
-      <excludeFolder url="file://$MODULE_DIR$/test/replay/osx/simulator_application_binary/file/packages" />
-      <excludeFolder url="file://$MODULE_DIR$/test/replay/osx/simulator_application_binary/packages" />
-      <excludeFolder url="file://$MODULE_DIR$/test/replay/osx/simulator_application_binary/platform/packages" />
-      <excludeFolder url="file://$MODULE_DIR$/test/replay/osx/simulator_application_binary/process/packages" />
-      <excludeFolder url="file://$MODULE_DIR$/test/replay/osx/simulator_application_binary/vmservice/packages" />
       <excludeFolder url="file://$MODULE_DIR$/test/replay/packages" />
-      <excludeFolder url="file://$MODULE_DIR$/test/src/base/packages" />
-      <excludeFolder url="file://$MODULE_DIR$/test/src/ios/packages" />
+      <excludeFolder url="file://$MODULE_DIR$/test/runner/packages" />
       <excludeFolder url="file://$MODULE_DIR$/test/src/packages" />
       <excludeFolder url="file://$MODULE_DIR$/tool/packages" />
     </content>

--- a/packages/flutter_tools/flutter_tools.iml
+++ b/packages/flutter_tools/flutter_tools.iml
@@ -7,10 +7,6 @@
       <excludeFolder url="file://$MODULE_DIR$/bin/packages" />
       <excludeFolder url="file://$MODULE_DIR$/build" />
       <excludeFolder url="file://$MODULE_DIR$/packages" />
-      <excludeFolder url="file://$MODULE_DIR$/test/android/packages" />
-      <excludeFolder url="file://$MODULE_DIR$/test/base/packages" />
-      <excludeFolder url="file://$MODULE_DIR$/test/commands/packages" />
-      <excludeFolder url="file://$MODULE_DIR$/test/data/dart_dependencies_test/asci_casing/packages" />
       <excludeFolder url="file://$MODULE_DIR$/test/data/dart_dependencies_test/bad_package/.pub" />
       <excludeFolder url="file://$MODULE_DIR$/test/data/dart_dependencies_test/bad_package/build" />
       <excludeFolder url="file://$MODULE_DIR$/test/data/dart_dependencies_test/bad_package/packages" />
@@ -34,10 +30,16 @@
       <excludeFolder url="file://$MODULE_DIR$/test/data/intellij/plugins/Dart/packages" />
       <excludeFolder url="file://$MODULE_DIR$/test/data/intellij/plugins/packages" />
       <excludeFolder url="file://$MODULE_DIR$/test/data/packages" />
-      <excludeFolder url="file://$MODULE_DIR$/test/ios/packages" />
       <excludeFolder url="file://$MODULE_DIR$/test/packages" />
+      <excludeFolder url="file://$MODULE_DIR$/test/replay/osx/packages" />
+      <excludeFolder url="file://$MODULE_DIR$/test/replay/osx/simulator_application_binary/file/packages" />
+      <excludeFolder url="file://$MODULE_DIR$/test/replay/osx/simulator_application_binary/packages" />
+      <excludeFolder url="file://$MODULE_DIR$/test/replay/osx/simulator_application_binary/platform/packages" />
+      <excludeFolder url="file://$MODULE_DIR$/test/replay/osx/simulator_application_binary/process/packages" />
+      <excludeFolder url="file://$MODULE_DIR$/test/replay/osx/simulator_application_binary/vmservice/packages" />
       <excludeFolder url="file://$MODULE_DIR$/test/replay/packages" />
-      <excludeFolder url="file://$MODULE_DIR$/test/runner/packages" />
+      <excludeFolder url="file://$MODULE_DIR$/test/src/base/packages" />
+      <excludeFolder url="file://$MODULE_DIR$/test/src/ios/packages" />
       <excludeFolder url="file://$MODULE_DIR$/test/src/packages" />
       <excludeFolder url="file://$MODULE_DIR$/tool/packages" />
     </content>

--- a/packages/flutter_tools/lib/src/commands/daemon.dart
+++ b/packages/flutter_tools/lib/src/commands/daemon.dart
@@ -759,7 +759,7 @@ class AppInstance {
   }
 
   dynamic _runInZone(AppDomain domain, dynamic method()) {
-    _logger ??= new _AppRunLogger(domain, this, logToParent: logToStdout ? logger : null);
+    _logger ??= new _AppRunLogger(domain, this, parent: logToStdout ? logger : null);
 
     final AppContext appContext = new AppContext();
     appContext.setVariable(Logger, _logger);
@@ -769,17 +769,17 @@ class AppInstance {
 
 /// A [Logger] which sends log messages to a listening daemon client.
 class _AppRunLogger extends Logger {
-  _AppRunLogger(this.domain, this.app, { this.logToParent });
+  _AppRunLogger(this.domain, this.app, { this.parent });
 
   AppDomain domain;
   final AppInstance app;
-  final Logger logToParent;
+  final Logger parent;
   int _nextProgressId = 0;
 
   @override
   void printError(String message, { StackTrace stackTrace, bool emphasis: false }) {
-    if (logToParent != null) {
-      logToParent.printError(message, stackTrace: stackTrace, emphasis: emphasis);
+    if (parent != null) {
+      parent.printError(message, stackTrace: stackTrace, emphasis: emphasis);
     } else {
       if (stackTrace != null) {
         _sendLogEvent(<String, dynamic>{
@@ -801,8 +801,8 @@ class _AppRunLogger extends Logger {
     String message, {
     bool emphasis: false, bool newline: true, String ansiAlternative, int indent
   }) {
-    if (logToParent != null) {
-      logToParent.printStatus(message, emphasis: emphasis, newline: newline,
+    if (parent != null) {
+      parent.printStatus(message, emphasis: emphasis, newline: newline,
           ansiAlternative: ansiAlternative, indent: indent);
     } else {
       _sendLogEvent(<String, dynamic>{ 'log': message });
@@ -811,8 +811,8 @@ class _AppRunLogger extends Logger {
 
   @override
   void printTrace(String message) {
-    if (logToParent != null) {
-      logToParent.printTrace(message);
+    if (parent != null) {
+      parent.printTrace(message);
     } else {
       _sendLogEvent(<String, dynamic>{ 'log': message, 'trace': true });
     }

--- a/packages/flutter_tools/lib/src/commands/daemon.dart
+++ b/packages/flutter_tools/lib/src/commands/daemon.dart
@@ -768,6 +768,13 @@ class AppInstance {
 }
 
 /// A [Logger] which sends log messages to a listening daemon client.
+///
+/// This class can either:
+///   1) Send stdout messages and progress events to the client IDE
+///   1) Log messages to stdout and send progress events to the client IDE
+///
+/// TODO(devoncarew): To simplify this code a bit, we could choose to specialize
+/// this class into two, one that covers each of the above use cases.
 class _AppRunLogger extends Logger {
   _AppRunLogger(this.domain, this.app, { this.parent });
 

--- a/packages/flutter_tools/lib/src/commands/daemon.dart
+++ b/packages/flutter_tools/lib/src/commands/daemon.dart
@@ -774,7 +774,7 @@ class AppInstance {
 ///   1) Log messages to stdout and send progress events to the client IDE
 ///
 /// TODO(devoncarew): To simplify this code a bit, we could choose to specialize
-/// this class into two, one that covers each of the above use cases.
+/// this class into two, one for each of the above use cases.
 class _AppRunLogger extends Logger {
   _AppRunLogger(this.domain, this.app, { this.parent });
 


### PR DESCRIPTION
- have app loggers log to their parent logger (instead of directly to stdout). This does the right thing wrt the verbosity level (it respects `-v`)

@tvolkert 