### PR TITLE
Clarify libimobiledevice doctor check message

### DIFF
--- a/packages/flutter_tools/lib/src/ios/ios_workflow.dart
+++ b/packages/flutter_tools/lib/src/ios/ios_workflow.dart
@@ -152,7 +152,7 @@ class IOSWorkflow extends DoctorValidator implements Workflow {
       if (!await hasWorkingLibimobiledevice) {
         brewStatus = ValidationType.partial;
         messages.add(new ValidationMessage.error(
-            'libimobiledevice is incompatible with the installed Xcode version. To update, run:\n'
+            'libimobiledevice is not installed or requires updating. To update, run:\n'
                 '  brew update\n'
                 '  brew uninstall --ignore-dependencies libimobiledevice\n'
                 '  brew install --HEAD libimobiledevice'


### PR DESCRIPTION
This message will be emitted both when libimobiledevice requires
updating, or when it has not yet been installed.

It's also not specifically the version of Xcode that it's incompatible
with, it's the lockdownd daemon, which is actually more closely tied to
iTunes.