### PR TITLE
add tests to linux hosts

### DIFF
--- a/dev/devicelab/bin/tasks/hot_mode_dev_cycle_linux__benchmark.dart
+++ b/dev/devicelab/bin/tasks/hot_mode_dev_cycle_linux__benchmark.dart
@@ -1,0 +1,9 @@
+// Copyright (c) 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'hot_mode_dev_cycle__benchmark.dart' as hot_mode_dev_cycle_benchmark;
+
+void main() {
+  hot_mode_dev_cycle_benchmark.main();
+}

--- a/dev/devicelab/manifest.yaml
+++ b/dev/devicelab/manifest.yaml
@@ -69,19 +69,6 @@ tasks:
     stage: devicelab
     required_agent_capabilities: ["has-android-device"]
 
-  technical_debt__cost:
-    description: >
-      Estimates our technical debt (TODOs, analyzer ignores, etc).
-    stage: devicelab
-    required_agent_capabilities: ["has-android-device"]
-
-  dartdocs:
-    description: >
-      Tracks how many members are still lacking documentation.
-    stage: devicelab
-    required_agent_capabilities: ["has-android-device"]
-    flaky: true
-
   # Android on-device tests
 
   complex_layout_scroll_perf__timeline_summary:
@@ -274,3 +261,26 @@ tasks:
       Measures the performance of Dart VM hot patching feature on Windows.
     stage: devicelab_win
     required_agent_capabilities: ["windows"]
+
+  # Tests running on Linux hosts
+
+  hot_mode_dev_cycle_linux__benchmark:
+    description: >
+      Measures the performance of Dart VM hot patching feature on a Linux host.
+    stage: devicelab
+    required_agent_capabilities: ["linux/android"]
+    flaky: true
+
+  dartdocs:
+    description: >
+      Tracks how many members are still lacking documentation.
+    stage: devicelab
+    required_agent_capabilities: ["linux/android"]
+    flaky: true
+
+  technical_debt__cost:
+    description: >
+      Estimates our technical debt (TODOs, analyzer ignores, etc).
+    stage: devicelab
+    required_agent_capabilities: ["linux/android"]
+    flaky: true


### PR DESCRIPTION
- Add dev cycle test to the new Linux devicelab agents
- Move `dartdocs` and `technical_debt__cost` to Linux as well (they do not depend on the host platform)
