### PR TITLE
mark Linux tasks as stable

### DIFF
--- a/dev/devicelab/manifest.yaml
+++ b/dev/devicelab/manifest.yaml
@@ -238,21 +238,18 @@ tasks:
       Measures the performance of Dart VM hot patching feature on a Linux host.
     stage: devicelab
     required_agent_capabilities: ["linux/android"]
-    flaky: true
 
   dartdocs:
     description: >
       Tracks how many members are still lacking documentation.
     stage: devicelab
     required_agent_capabilities: ["linux/android"]
-    flaky: true
 
   technical_debt__cost:
     description: >
       Estimates our technical debt (TODOs, analyzer ignores, etc).
     stage: devicelab
     required_agent_capabilities: ["linux/android"]
-    flaky: true
 
   flutter_gallery__build:
     description: >


### PR DESCRIPTION
The linux hosts seem to be working fine. Removing the `flaky` flag.