### PR TITLE
preview of prefer_asserts_in_initializer_list lint

### DIFF
--- a/packages/flutter/lib/src/widgets/animated_list.dart
+++ b/packages/flutter/lib/src/widgets/animated_list.dart
@@ -57,10 +57,9 @@ class AnimatedList extends StatefulWidget {
     this.physics,
     this.shrinkWrap: false,
     this.padding,
-  }) : super(key: key) {
-    assert(itemBuilder != null);
-    assert(initialItemCount != null && initialItemCount >= 0);
-  }
+  }) : assert(itemBuilder != null),
+       assert(initialItemCount != null && initialItemCount >= 0),
+       super(key: key);
 
   /// Called, as needed, to build list item widgets.
   ///

--- a/packages/flutter/lib/src/widgets/banner.dart
+++ b/packages/flutter/lib/src/widgets/banner.dart
@@ -47,12 +47,10 @@ class BannerPainter extends CustomPainter {
     @required this.location,
     this.color: _kColor,
     this.textStyle: _kTextStyle,
-  }) {
-    assert(message != null);
-    assert(location != null);
-    assert(color != null);
-    assert(textStyle != null);
-  }
+  }) : assert(message != null),
+       assert(location != null),
+       assert(color != null),
+       assert(textStyle != null);
 
   /// The message to show in the banner.
   final String message;

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -1202,9 +1202,8 @@ class ConstrainedBox extends SingleChildRenderObjectWidget {
     @required this.constraints,
     Widget child
   }) : assert(constraints != null),
-       super(key: key, child: child) {
-    assert(constraints.debugAssertIsValid());
-  }
+       assert(constraints.debugAssertIsValid()),
+       super(key: key, child: child);
 
   /// The additional constraints to impose on the child.
   final BoxConstraints constraints;
@@ -2222,9 +2221,8 @@ class Flex extends MultiChildRenderObjectWidget {
        assert(mainAxisAlignment != null),
        assert(mainAxisSize != null),
        assert(crossAxisAlignment != null),
-       super(key: key, children: children) {
-    assert(crossAxisAlignment != CrossAxisAlignment.baseline || textBaseline != null); // https://github.com/dart-lang/sdk/issues/29278
-  }
+       assert(crossAxisAlignment != CrossAxisAlignment.baseline || textBaseline != null),// https://github.com/dart-lang/sdk/issues/29278
+       super(key: key, children: children);
 
   /// The direction to use as the main axis.
   ///
@@ -2900,9 +2898,8 @@ class Flow extends MultiChildRenderObjectWidget {
     Key key,
     @required this.delegate,
     List<Widget> children: const <Widget>[],
-  }) : super(key: key, children: children) {
-    assert(delegate != null);
-  }
+  }) : assert(delegate != null),
+       super(key: key, children: children);
 
   /// The delegate that controls the transformation matrices of the children.
   final FlowDelegate delegate;

--- a/packages/flutter/lib/src/widgets/container.dart
+++ b/packages/flutter/lib/src/widgets/container.dart
@@ -198,22 +198,21 @@ class Container extends StatelessWidget {
     this.margin,
     this.transform,
     this.child,
-  }) : decoration = decoration ?? (color != null ? new BoxDecoration(color: color) : null),
+  }) : assert(margin == null || margin.isNonNegative),
+       assert(padding == null || padding.isNonNegative),
+       assert(decoration == null || decoration.debugAssertIsValid()),
+       assert(constraints == null || constraints.debugAssertIsValid()),
+       assert(color == null || decoration == null,
+         'Cannot provide both a color and a decoration\n'
+         'The color argument is just a shorthand for "decoration: new BoxDecoration(color: color)".'
+       ),
+       decoration = decoration ?? (color != null ? new BoxDecoration(color: color) : null),
        constraints =
         (width != null || height != null)
           ? constraints?.tighten(width: width, height: height)
             ?? new BoxConstraints.tightFor(width: width, height: height)
           : constraints,
-       super(key: key) {
-    assert(margin == null || margin.isNonNegative);
-    assert(padding == null || padding.isNonNegative);
-    assert(decoration == null || decoration.debugAssertIsValid());
-    assert(constraints == null || constraints.debugAssertIsValid());
-    assert(color == null || decoration == null,
-      'Cannot provide both a color and a decoration\n'
-      'The color argument is just a shorthand for "decoration: new BoxDecoration(color: color)".'
-    );
-  }
+       super(key: key);
 
   /// The [child] contained by the container.
   ///

--- a/packages/flutter/lib/src/widgets/dismissible.dart
+++ b/packages/flutter/lib/src/widgets/dismissible.dart
@@ -129,10 +129,9 @@ class _DismissibleClipper extends CustomClipper<Rect> {
   _DismissibleClipper({
     @required this.axis,
     @required this.moveAnimation
-  }) : super(reclip: moveAnimation) {
-    assert(axis != null);
-    assert(moveAnimation != null);
-  }
+  }) : assert(axis != null),
+       assert(moveAnimation != null),
+       super(reclip: moveAnimation);
 
   final Axis axis;
   final Animation<FractionalOffset> moveAnimation;

--- a/packages/flutter/lib/src/widgets/drag_target.dart
+++ b/packages/flutter/lib/src/widgets/drag_target.dart
@@ -444,10 +444,9 @@ class _DragAvatar<T> extends Drag {
     this.feedback,
     this.feedbackOffset: Offset.zero,
     this.onDragEnd
-  }) {
-    assert(overlayState != null);
-    assert(dragStartPoint != null);
-    assert(feedbackOffset != null);
+  }) : assert(overlayState != null),
+       assert(dragStartPoint != null),
+       assert(feedbackOffset != null) {
     _entry = new OverlayEntry(builder: _build);
     overlayState.insert(_entry);
     _position = initialPosition;

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -1573,9 +1573,8 @@ abstract class MultiChildRenderObjectWidget extends RenderObjectWidget {
   /// objects.
   MultiChildRenderObjectWidget({ Key key, this.children: const <Widget>[] })
     : assert(children != null),
-      super(key: key) {
-    assert(!children.any((Widget child) => child == null)); // https://github.com/dart-lang/sdk/issues/29276
-  }
+      assert(!children.any((Widget child) => child == null)), // https://github.com/dart-lang/sdk/issues/29276
+      super(key: key);
 
   /// The widgets below this widget in the tree.
   ///
@@ -2375,9 +2374,9 @@ abstract class Element implements BuildContext {
   /// Creates an element that uses the given widget as its configuration.
   ///
   /// Typically called by an override of [Widget.createElement].
-  Element(Widget widget) : _widget = widget {
-    assert(widget != null);
-  }
+  Element(Widget widget)
+    : assert(widget != null),
+      _widget = widget;
 
   Element _parent;
 
@@ -4363,9 +4362,9 @@ class SingleChildRenderObjectElement extends RenderObjectElement {
 /// are expected to inherit from [MultiChildRenderObjectWidget].
 class MultiChildRenderObjectElement extends RenderObjectElement {
   /// Creates an element that uses the given widget as its configuration.
-  MultiChildRenderObjectElement(MultiChildRenderObjectWidget widget) : super(widget) {
-    assert(!debugChildrenHaveDuplicateKeys(widget, widget.children));
-  }
+  MultiChildRenderObjectElement(MultiChildRenderObjectWidget widget)
+    : assert(!debugChildrenHaveDuplicateKeys(widget, widget.children)),
+      super(widget);
 
   @override
   MultiChildRenderObjectWidget get widget => super.widget;

--- a/packages/flutter/lib/src/widgets/gesture_detector.dart
+++ b/packages/flutter/lib/src/widgets/gesture_detector.dart
@@ -98,32 +98,31 @@ class GestureDetector extends StatelessWidget {
     this.onScaleEnd,
     this.behavior,
     this.excludeFromSemantics: false
-  }) : super(key: key) {
-    assert(excludeFromSemantics != null);
-    assert(() {
-      final bool haveVerticalDrag = onVerticalDragStart != null || onVerticalDragUpdate != null || onVerticalDragEnd != null;
-      final bool haveHorizontalDrag = onHorizontalDragStart != null || onHorizontalDragUpdate != null || onHorizontalDragEnd != null;
-      final bool havePan = onPanStart != null || onPanUpdate != null || onPanEnd != null;
-      final bool haveScale = onScaleStart != null || onScaleUpdate != null || onScaleEnd != null;
-      if (havePan || haveScale) {
-        if (havePan && haveScale) {
-          throw new FlutterError(
-            'Incorrect GestureDetector arguments.\n'
-            'Having both a pan gesture recognizer and a scale gesture recognizer is redundant; scale is a superset of pan. Just use the scale gesture recognizer.'
-          );
-        }
-        final String recognizer = havePan ? 'pan' : 'scale';
-        if (haveVerticalDrag && haveHorizontalDrag) {
-          throw new FlutterError(
-            'Incorrect GestureDetector arguments.\n'
-            'Simultaneously having a vertical drag gesture recognizer, a horizontal drag gesture recognizer, and a $recognizer gesture recognizer '
-            'will result in the $recognizer gesture recognizer being ignored, since the other two will catch all drags.'
-          );
-        }
-      }
-      return true;
-    });
-  }
+  }) : assert(excludeFromSemantics != null),
+       assert(() {
+         final bool haveVerticalDrag = onVerticalDragStart != null || onVerticalDragUpdate != null || onVerticalDragEnd != null;
+         final bool haveHorizontalDrag = onHorizontalDragStart != null || onHorizontalDragUpdate != null || onHorizontalDragEnd != null;
+         final bool havePan = onPanStart != null || onPanUpdate != null || onPanEnd != null;
+         final bool haveScale = onScaleStart != null || onScaleUpdate != null || onScaleEnd != null;
+         if (havePan || haveScale) {
+           if (havePan && haveScale) {
+             throw new FlutterError(
+               'Incorrect GestureDetector arguments.\n'
+               'Having both a pan gesture recognizer and a scale gesture recognizer is redundant; scale is a superset of pan. Just use the scale gesture recognizer.'
+             );
+           }
+           final String recognizer = havePan ? 'pan' : 'scale';
+           if (haveVerticalDrag && haveHorizontalDrag) {
+             throw new FlutterError(
+               'Incorrect GestureDetector arguments.\n'
+               'Simultaneously having a vertical drag gesture recognizer, a horizontal drag gesture recognizer, and a $recognizer gesture recognizer '
+               'will result in the $recognizer gesture recognizer being ignored, since the other two will catch all drags.'
+             );
+           }
+         }
+         return true;
+       }),
+       super(key: key);
 
   /// The widget below this widget in the tree.
   final Widget child;

--- a/packages/flutter/lib/src/widgets/heroes.dart
+++ b/packages/flutter/lib/src/widgets/heroes.dart
@@ -180,9 +180,7 @@ class _HeroFlightManifest {
     @required this.fromHero,
     @required this.toHero,
     @required this.createRectTween,
-  }) {
-    assert(fromHero.widget.tag == toHero.widget.tag);
-  }
+  }) : assert(fromHero.widget.tag == toHero.widget.tag);
 
   final _HeroFlightType type;
   final OverlayState overlay;

--- a/packages/flutter/lib/src/widgets/implicit_animations.dart
+++ b/packages/flutter/lib/src/widgets/implicit_animations.dart
@@ -318,22 +318,21 @@ class AnimatedContainer extends ImplicitlyAnimatedWidget {
     this.child,
     Curve curve: Curves.linear,
     @required Duration duration,
-  }) : decoration = decoration ?? (color != null ? new BoxDecoration(color: color) : null),
+  }) : assert(margin == null || margin.isNonNegative),
+       assert(padding == null || padding.isNonNegative),
+       assert(decoration == null || decoration.debugAssertIsValid()),
+       assert(constraints == null || constraints.debugAssertIsValid()),
+       assert(color == null || decoration == null,
+         'Cannot provide both a color and a decoration\n'
+         'The color argument is just a shorthand for "decoration: new BoxDecoration(backgroundColor: color)".'
+       ),
+       decoration = decoration ?? (color != null ? new BoxDecoration(color: color) : null),
        constraints =
         (width != null || height != null)
           ? constraints?.tighten(width: width, height: height)
             ?? new BoxConstraints.tightFor(width: width, height: height)
           : constraints,
-       super(key: key, curve: curve, duration: duration) {
-    assert(margin == null || margin.isNonNegative);
-    assert(padding == null || padding.isNonNegative);
-    assert(decoration == null || decoration.debugAssertIsValid());
-    assert(constraints == null || constraints.debugAssertIsValid());
-    assert(color == null || decoration == null,
-      'Cannot provide both a color and a decoration\n'
-      'The color argument is just a shorthand for "decoration: new BoxDecoration(backgroundColor: color)".'
-    );
-  }
+       super(key: key, curve: curve, duration: duration);
 
   /// The [child] contained by the container.
   ///

--- a/packages/flutter/lib/src/widgets/navigator.dart
+++ b/packages/flutter/lib/src/widgets/navigator.dart
@@ -256,8 +256,8 @@ class NavigatorObserver {
 abstract class NavigationGestureController {
   /// Configures the NavigationGestureController and tells the given [Navigator] that
   /// a gesture has started.
-  NavigationGestureController(this._navigator) {
-    assert(_navigator != null);
+  NavigationGestureController(this._navigator)
+    : assert(_navigator != null) {
     // Disable Hero transitions until the gesture is complete.
     _navigator.didStartUserGesture();
   }

--- a/packages/flutter/lib/src/widgets/nested_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/nested_scroll_view.dart
@@ -38,12 +38,11 @@ class NestedScrollView extends StatefulWidget {
     this.physics,
     @required this.headerSliverBuilder,
     @required this.body,
-  }) : super(key: key) {
-    assert(scrollDirection != null);
-    assert(reverse != null);
-    assert(headerSliverBuilder != null);
-    assert(body != null);
-  }
+  }) : assert(scrollDirection != null),
+       assert(reverse != null),
+       assert(headerSliverBuilder != null),
+       assert(body != null),
+       super(key: key);
 
   // TODO(ianh): we should expose a controller so you can call animateTo, etc.
 
@@ -782,10 +781,9 @@ class _NestedOuterBallisticScrollActivity extends BallisticScrollActivity {
     this.metrics,
     Simulation simulation,
     TickerProvider vsync,
-  ) : super(position, simulation, vsync) {
-    assert(metrics.minRange != metrics.maxRange);
-    assert(metrics.maxRange > metrics.minRange);
-  }
+  ) : assert(metrics.minRange != metrics.maxRange),
+      assert(metrics.maxRange > metrics.minRange),
+      super(position, simulation, vsync);
 
   final _NestedScrollCoordinator coordinator;
   final _NestedScrollMetrics metrics;

--- a/packages/flutter/lib/src/widgets/overlay.dart
+++ b/packages/flutter/lib/src/widgets/overlay.dart
@@ -62,11 +62,11 @@ class OverlayEntry {
     @required this.builder,
     bool opaque: false,
     bool maintainState: false,
-  }) : _opaque = opaque, _maintainState = maintainState {
-    assert(builder != null);
-    assert(opaque != null);
-    assert(maintainState != null);
-  }
+  }) : assert(builder != null),
+       assert(opaque != null),
+       assert(maintainState != null),
+       _opaque = opaque,
+       _maintainState = maintainState;
 
   /// This entry will include the widget built by this builder in the overlay at
   /// the entry's position.
@@ -154,9 +154,9 @@ class OverlayEntry {
 }
 
 class _OverlayEntry extends StatefulWidget {
-  _OverlayEntry(this.entry) : super(key: entry._key) {
-    assert(entry != null);
-  }
+  _OverlayEntry(this.entry)
+    : assert(entry != null),
+      super(key: entry._key);
 
   final OverlayEntry entry;
 
@@ -388,10 +388,8 @@ class _Theatre extends RenderObjectWidget {
   _Theatre({
     this.onstage,
     @required this.offstage,
-  }) {
-    assert(offstage != null);
-    assert(!offstage.any((Widget child) => child == null));
-  }
+  }) : assert(offstage != null),
+       assert(!offstage.any((Widget child) => child == null));
 
   final Stack onstage;
 
@@ -405,9 +403,9 @@ class _Theatre extends RenderObjectWidget {
 }
 
 class _TheatreElement extends RenderObjectElement {
-  _TheatreElement(_Theatre widget) : super(widget) {
-    assert(!debugChildrenHaveDuplicateKeys(widget, widget.offstage));
-  }
+  _TheatreElement(_Theatre widget)
+    : assert(!debugChildrenHaveDuplicateKeys(widget, widget.offstage)),
+      super(widget);
 
   @override
   _Theatre get widget => super.widget;

--- a/packages/flutter/lib/src/widgets/overscroll_indicator.dart
+++ b/packages/flutter/lib/src/widgets/overscroll_indicator.dart
@@ -225,11 +225,11 @@ class _GlowController extends ChangeNotifier {
     @required TickerProvider vsync,
     @required Color color,
     @required Axis axis,
-  }) : _color = color,
+  }) : assert(vsync != null),
+       assert(color != null),
+       assert(axis != null),
+       _color = color,
        _axis = axis {
-    assert(vsync != null);
-    assert(color != null);
-    assert(axis != null);
     _glowController = new AnimationController(vsync: vsync)
       ..addStatusListener(_changePhase);
     final Animation<double> decelerator = new CurvedAnimation(

--- a/packages/flutter/lib/src/widgets/page_view.dart
+++ b/packages/flutter/lib/src/widgets/page_view.dart
@@ -42,11 +42,9 @@ class PageController extends ScrollController {
   PageController({
     this.initialPage: 0,
     this.viewportFraction: 1.0,
-  }) {
-    assert(initialPage != null);
-    assert(viewportFraction != null);
-    assert(viewportFraction > 0.0);
-  }
+  }) : assert(initialPage != null),
+       assert(viewportFraction != null),
+       assert(viewportFraction > 0.0);
 
   /// The page to show when first creating the [PageView].
   final int initialPage;
@@ -154,18 +152,17 @@ class _PagePosition extends ScrollPositionWithSingleContext {
     this.initialPage: 0,
     double viewportFraction: 1.0,
     ScrollPosition oldPosition,
-  }) : _viewportFraction = viewportFraction,
+  }) : assert(initialPage != null),
+       assert(viewportFraction != null),
+       assert(viewportFraction > 0.0),
+       _viewportFraction = viewportFraction,
        _pageToUseOnStartup = initialPage.toDouble(),
        super(
-    physics: physics,
-    context: context,
-    initialPixels: null,
-    oldPosition: oldPosition,
-  ) {
-    assert(initialPage != null);
-    assert(viewportFraction != null);
-    assert(viewportFraction > 0.0);
-  }
+         physics: physics,
+         context: context,
+         initialPixels: null,
+         oldPosition: oldPosition,
+       );
 
   final int initialPage;
   double _pageToUseOnStartup;
@@ -358,9 +355,9 @@ class PageView extends StatefulWidget {
     this.physics,
     this.onPageChanged,
     @required this.childrenDelegate,
-  }) : controller = controller ?? _defaultPageController, super(key: key) {
-    assert(childrenDelegate != null);
-  }
+  }) : assert(childrenDelegate != null),
+       controller = controller ?? _defaultPageController,
+       super(key: key);
 
   /// The axis along which the page view scrolls.
   ///

--- a/packages/flutter/lib/src/widgets/pages.dart
+++ b/packages/flutter/lib/src/widgets/pages.dart
@@ -76,13 +76,12 @@ class PageRouteBuilder<T> extends PageRoute<T> {
     this.barrierDismissible: false,
     this.barrierColor: null,
     this.maintainState: true,
-  }) : super(settings: settings) {
-    assert(pageBuilder != null);
-    assert(transitionsBuilder != null);
-    assert(opaque != null);
-    assert(barrierDismissible != null);
-    assert(maintainState != null);
-  }
+  }) : assert(pageBuilder != null),
+       assert(transitionsBuilder != null),
+       assert(opaque != null),
+       assert(barrierDismissible != null),
+       assert(maintainState != null),
+       super(settings: settings);
 
   /// Used build the route's primary contents.
   ///

--- a/packages/flutter/lib/src/widgets/scroll_activity.dart
+++ b/packages/flutter/lib/src/widgets/scroll_activity.dart
@@ -215,10 +215,10 @@ class ScrollDragController implements Drag {
     @required ScrollActivityDelegate delegate,
     @required DragStartDetails details,
     this.onDragCanceled,
-  }) : _delegate = delegate, _lastDetails = details {
-    assert(delegate != null);
-    assert(details != null);
-  }
+  }) : assert(delegate != null),
+       assert(details != null),
+       _delegate = delegate,
+       _lastDetails = details;
 
   /// The object that will actuate the scroll view as the user drags.
   ScrollActivityDelegate get delegate => _delegate;
@@ -466,12 +466,12 @@ class DrivenScrollActivity extends ScrollActivity {
     @required Duration duration,
     @required Curve curve,
     @required TickerProvider vsync,
-  }) : super(delegate) {
-    assert(from != null);
-    assert(to != null);
-    assert(duration != null);
-    assert(duration > Duration.ZERO);
-    assert(curve != null);
+  }) : assert(from != null),
+       assert(to != null),
+       assert(duration != null),
+       assert(duration > Duration.ZERO),
+       assert(curve != null),
+       super(delegate) {
     _completer = new Completer<Null>();
     _controller = new AnimationController.unbounded(
       value: from,

--- a/packages/flutter/lib/src/widgets/scroll_controller.dart
+++ b/packages/flutter/lib/src/widgets/scroll_controller.dart
@@ -43,9 +43,7 @@ class ScrollController extends ChangeNotifier {
   ScrollController({
     this.initialScrollOffset: 0.0,
     this.debugLabel,
-  }) {
-    assert(initialScrollOffset != null);
-  }
+  }) : assert(initialScrollOffset != null);
 
   /// The initial value to use for [offset].
   ///

--- a/packages/flutter/lib/src/widgets/scroll_notification.dart
+++ b/packages/flutter/lib/src/widgets/scroll_notification.dart
@@ -171,12 +171,11 @@ class OverscrollNotification extends ScrollNotification {
     this.dragDetails,
     @required this.overscroll,
     this.velocity: 0.0,
-  }) : super(metrics: metrics, context: context) {
-    assert(overscroll != null);
-    assert(overscroll.isFinite);
-    assert(overscroll != 0.0);
-    assert(velocity != null);
-  }
+  }) : assert(overscroll != null),
+       assert(overscroll.isFinite),
+       assert(overscroll != 0.0),
+       assert(velocity != null),
+       super(metrics: metrics, context: context);
 
   /// If the [Scrollable] overscrolled because of a drag, the details about that
   /// drag update.

--- a/packages/flutter/lib/src/widgets/scroll_position.dart
+++ b/packages/flutter/lib/src/widgets/scroll_position.dart
@@ -66,10 +66,9 @@ abstract class ScrollPosition extends ViewportOffset with ScrollMetrics {
     @required this.context,
     ScrollPosition oldPosition,
     this.debugLabel,
-  }) {
-    assert(physics != null);
-    assert(context != null);
-    assert(context.vsync != null);
+  }) : assert(physics != null),
+       assert(context != null),
+       assert(context.vsync != null) {
     if (oldPosition != null)
       absorb(oldPosition);
     restoreScrollOffset();

--- a/packages/flutter/lib/src/widgets/scroll_simulation.dart
+++ b/packages/flutter/lib/src/widgets/scroll_simulation.dart
@@ -35,14 +35,13 @@ class BouncingScrollSimulation extends Simulation {
     @required this.trailingExtent,
     @required this.spring,
     Tolerance tolerance: Tolerance.defaultTolerance,
-  }) : super(tolerance: tolerance) {
-    assert(position != null);
-    assert(velocity != null);
-    assert(leadingExtent != null);
-    assert(trailingExtent != null);
-    assert(leadingExtent <= trailingExtent);
-    assert(spring != null);
-
+  }) : assert(position != null),
+       assert(velocity != null),
+       assert(leadingExtent != null),
+       assert(trailingExtent != null),
+       assert(leadingExtent <= trailingExtent),
+       assert(spring != null),
+       super(tolerance: tolerance) {
     if (position < leadingExtent) {
       _springSimulation = _underscrollSimulation(position, velocity);
       _springTime = double.NEGATIVE_INFINITY;

--- a/packages/flutter/lib/src/widgets/scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/scroll_view.dart
@@ -51,17 +51,15 @@ abstract class ScrollView extends StatelessWidget {
     bool primary,
     ScrollPhysics physics,
     this.shrinkWrap: false,
-  }) : primary = primary ?? controller == null && scrollDirection == Axis.vertical,
-       physics = physics ?? (primary == true || (primary == null && controller == null && scrollDirection == Axis.vertical) ? const AlwaysScrollableScrollPhysics() : null),
-       super(key: key) {
-    assert(reverse != null);
-    assert(shrinkWrap != null);
-    assert(this.primary != null);
-    assert(controller == null || !this.primary,
+  }) : assert(reverse != null),
+       assert(shrinkWrap != null),
+       assert(!(controller != null && primary == true),
            'Primary ScrollViews obtain their ScrollController via inheritance from a PrimaryScrollController widget. '
            'You cannot both set primary to true and pass an explicit controller.'
-    );
-  }
+       ),
+       primary = primary ?? controller == null && scrollDirection == Axis.vertical,
+       physics = physics ?? (primary == true || (primary == null && controller == null && scrollDirection == Axis.vertical) ? const AlwaysScrollableScrollPhysics() : null),
+       super(key: key);
 
   /// The axis along which the scroll view scrolls.
   ///
@@ -511,18 +509,17 @@ class ListView extends BoxScrollView {
     EdgeInsets padding,
     this.itemExtent,
     @required this.childrenDelegate,
-  }) : super(
-    key: key,
-    scrollDirection: scrollDirection,
-    reverse: reverse,
-    controller: controller,
-    primary: primary,
-    physics: physics,
-    shrinkWrap: shrinkWrap,
-    padding: padding,
-  ) {
-    assert(childrenDelegate != null);
-  }
+  }) : assert(childrenDelegate != null),
+       super(
+         key: key,
+         scrollDirection: scrollDirection,
+         reverse: reverse,
+         controller: controller,
+         primary: primary,
+         physics: physics,
+         shrinkWrap: shrinkWrap,
+         padding: padding,
+       );
 
   /// If non-null, forces the children to have the given extent in the scroll
   /// direction.
@@ -607,18 +604,18 @@ class GridView extends BoxScrollView {
     EdgeInsets padding,
     @required this.gridDelegate,
     List<Widget> children: const <Widget>[],
-  }) : childrenDelegate = new SliverChildListDelegate(children), super(
-    key: key,
-    scrollDirection: scrollDirection,
-    reverse: reverse,
-    controller: controller,
-    primary: primary,
-    physics: physics,
-    shrinkWrap: shrinkWrap,
-    padding: padding,
-  ) {
-    assert(gridDelegate != null);
-  }
+  }) : assert(gridDelegate != null),
+       childrenDelegate = new SliverChildListDelegate(children),
+       super(
+         key: key,
+         scrollDirection: scrollDirection,
+         reverse: reverse,
+         controller: controller,
+         primary: primary,
+         physics: physics,
+         shrinkWrap: shrinkWrap,
+         padding: padding,
+       );
 
   /// Creates a scrollable, 2D array of widgets that are created on demand.
   ///
@@ -645,18 +642,18 @@ class GridView extends BoxScrollView {
     @required this.gridDelegate,
     @required IndexedWidgetBuilder itemBuilder,
     int itemCount,
-  }) : childrenDelegate = new SliverChildBuilderDelegate(itemBuilder, childCount: itemCount), super(
-    key: key,
-    scrollDirection: scrollDirection,
-    reverse: reverse,
-    controller: controller,
-    primary: primary,
-    physics: physics,
-    shrinkWrap: shrinkWrap,
-    padding: padding,
-  ) {
-    assert(gridDelegate != null);
-  }
+  }) : assert(gridDelegate != null),
+       childrenDelegate = new SliverChildBuilderDelegate(itemBuilder, childCount: itemCount),
+       super(
+         key: key,
+         scrollDirection: scrollDirection,
+         reverse: reverse,
+         controller: controller,
+         primary: primary,
+         physics: physics,
+         shrinkWrap: shrinkWrap,
+         padding: padding,
+       );
 
   /// Creates a scrollable, 2D array of widgets with both a custom
   /// [SliverGridDelegate] and a custom [SliverChildDelegate].
@@ -676,19 +673,18 @@ class GridView extends BoxScrollView {
     EdgeInsets padding,
     @required this.gridDelegate,
     @required this.childrenDelegate,
-  }) : super(
-    key: key,
-    scrollDirection: scrollDirection,
-    reverse: reverse,
-    controller: controller,
-    primary: primary,
-    physics: physics,
-    shrinkWrap: shrinkWrap,
-    padding: padding,
-  ) {
-    assert(gridDelegate != null);
-    assert(childrenDelegate != null);
-  }
+  }) : assert(gridDelegate != null),
+       assert(childrenDelegate != null),
+       super(
+         key: key,
+         scrollDirection: scrollDirection,
+         reverse: reverse,
+         controller: controller,
+         primary: primary,
+         physics: physics,
+         shrinkWrap: shrinkWrap,
+         padding: padding,
+       );
 
   /// Creates a scrollable, 2D array of widgets with a fixed number of tiles in
   /// the cross axis.

--- a/packages/flutter/lib/src/widgets/single_child_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/single_child_scroll_view.dart
@@ -49,15 +49,13 @@ class SingleChildScrollView extends StatelessWidget {
     this.physics,
     this.controller,
     this.child,
-  }) : primary = primary ?? controller == null && scrollDirection == Axis.vertical,
-       super(key: key) {
-    assert(scrollDirection != null);
-    assert(this.primary != null);
-    assert(controller == null || !this.primary,
-       'Primary ScrollViews obtain their ScrollController via inheritance from a PrimaryScrollController widget. '
-       'You cannot both set primary to true and pass an explicit controller.'
-    );
-  }
+  }) : assert(scrollDirection != null),
+       assert(!(controller != null && primary == true),
+          'Primary ScrollViews obtain their ScrollController via inheritance from a PrimaryScrollController widget. '
+          'You cannot both set primary to true and pass an explicit controller.'
+       ),
+       primary = primary ?? controller == null && scrollDirection == Axis.vertical,
+       super(key: key);
 
   /// The axis along which the scroll view scrolls.
   ///
@@ -180,10 +178,10 @@ class _RenderSingleChildViewport extends RenderBox with RenderObjectWithChildMix
     AxisDirection axisDirection: AxisDirection.down,
     @required ViewportOffset offset,
     RenderBox child,
-  }) : _axisDirection = axisDirection,
+  }) : assert(axisDirection != null),
+       assert(offset != null),
+       _axisDirection = axisDirection,
        _offset = offset {
-    assert(axisDirection != null);
-    assert(offset != null);
     this.child = child;
   }
 

--- a/packages/flutter/lib/src/widgets/size_changed_layout_notifier.dart
+++ b/packages/flutter/lib/src/widgets/size_changed_layout_notifier.dart
@@ -58,9 +58,8 @@ class _RenderSizeChangedWithCallback extends RenderProxyBox {
   _RenderSizeChangedWithCallback({
     RenderBox child,
     @required this.onLayoutChangedCallback
-  }) : super(child) {
-    assert(onLayoutChangedCallback != null);
-  }
+  }) : assert(onLayoutChangedCallback != null),
+       super(child);
 
   // There's a 1:1 relationship between the _RenderSizeChangedWithCallback and
   // the `context` that is captured by the closure created by createRenderObject

--- a/packages/flutter/lib/src/widgets/table.dart
+++ b/packages/flutter/lib/src/widgets/table.dart
@@ -100,22 +100,44 @@ class Table extends RenderObjectWidget {
     this.border,
     this.defaultVerticalAlignment: TableCellVerticalAlignment.top,
     this.textBaseline
-  }) : _rowDecorations = children.any((TableRow row) => row.decoration != null)
-                         ? children.map<Decoration>((TableRow row) => row.decoration).toList(growable: false)
-                         : null,
+  }) : assert(children != null),
+       assert(defaultColumnWidth != null),
+       assert(defaultVerticalAlignment != null),
+       assert(() {
+         if (children.any((TableRow row) => row.children.any((Widget cell) => cell == null))) {
+           throw new FlutterError(
+             'One of the children of one of the rows of the table was null.\n'
+             'The children of a TableRow must not be null.'
+           );
+         }
+         return true;
+       }),
+       assert(() {
+         if (children.any((TableRow row1) => row1.key != null && children.any((TableRow row2) => row1 != row2 && row1.key == row2.key))) {
+           throw new FlutterError(
+             'Two or more TableRow children of this Table had the same key.\n'
+             'All the keyed TableRow children of a Table must have different Keys.'
+           );
+         }
+         return true;
+       }),
+       assert(() {
+         if (children.isNotEmpty) {
+           final int cellCount = children.first.children.length;
+           if (children.any((TableRow row) => row.children.length != cellCount)) {
+             throw new FlutterError(
+               'Table contains irregular row lengths.\n'
+               'Every TableRow in a Table must have the same number of children, so that every cell is filled. '
+               'Otherwise, the table will contain holes.'
+             );
+           }
+         }
+         return true;
+       }),
+       _rowDecorations = children.any((TableRow row) => row.decoration != null)
+                              ? children.map<Decoration>((TableRow row) => row.decoration).toList(growable: false)
+                              : null,
        super(key: key) {
-    assert(children != null);
-    assert(defaultColumnWidth != null);
-    assert(defaultVerticalAlignment != null);
-    assert(() {
-      if (children.any((TableRow row) => row.children.any((Widget cell) => cell == null))) {
-        throw new FlutterError(
-          'One of the children of one of the rows of the table was null.\n'
-          'The children of a TableRow must not be null.'
-        );
-      }
-      return true;
-    });
     assert(() {
       final List<Widget> flatChildren = children.expand((TableRow row) => row.children).toList(growable: false);
       if (debugChildrenHaveDuplicateKeys(this, flatChildren)) {
@@ -125,28 +147,6 @@ class Table extends RenderObjectWidget {
           'flattened out for processing, so separate cells cannot have duplicate keys even if they are in '
           'different rows.'
         );
-      }
-      return true;
-    });
-    assert(() {
-      if (children.any((TableRow row1) => row1.key != null && children.any((TableRow row2) => row1 != row2 && row1.key == row2.key))) {
-        throw new FlutterError(
-          'Two or more TableRow children of this Table had the same key.\n'
-          'All the keyed TableRow children of a Table must have different Keys.'
-        );
-      }
-      return true;
-    });
-    assert(() {
-      if (children.isNotEmpty) {
-        final int cellCount = children.first.children.length;
-        if (children.any((TableRow row) => row.children.length != cellCount)) {
-          throw new FlutterError(
-            'Table contains irregular row lengths.\n'
-            'Every TableRow in a Table must have the same number of children, so that every cell is filled. '
-            'Otherwise, the table will contain holes.'
-          );
-        }
       }
       return true;
     });

--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -95,9 +95,9 @@ class TextSelectionOverlay implements TextSelectionDelegate {
     this.renderObject,
     this.onSelectionOverlayChanged,
     this.selectionControls,
-  }): _value  = value {
-    assert(value != null);
-    assert(context != null);
+  }): assert(value != null),
+      assert(context != null),
+      _value = value {
     final OverlayState overlay = Overlay.of(context);
     assert(overlay != null);
     _handleController = new AnimationController(duration: _kFadeDuration, vsync: overlay);

--- a/packages/flutter/lib/src/widgets/title.dart
+++ b/packages/flutter/lib/src/widgets/title.dart
@@ -14,9 +14,8 @@ class Title extends StatelessWidget {
     this.title,
     this.color,
     @required this.child,
-  }) : super(key: key) {
-    assert(color == null || color.alpha == 0xFF);
-  }
+  }) : assert(color == null || color.alpha == 0xFF),
+       super(key: key);
 
   /// A one-line description of this app for use in the window manager.
   final String title;

--- a/packages/flutter/lib/src/widgets/viewport.dart
+++ b/packages/flutter/lib/src/widgets/viewport.dart
@@ -56,10 +56,9 @@ class Viewport extends MultiChildRenderObjectWidget {
     @required this.offset,
     this.center,
     List<Widget> slivers: const <Widget>[],
-  }) : super(key: key, children: slivers) {
-    assert(offset != null);
-    assert(center == null || children.where((Widget child) => child.key == center).length == 1);
-  }
+  }) : assert(offset != null),
+       assert(center == null || children.where((Widget child) => child.key == center).length == 1),
+       super(key: key, children: slivers);
 
   /// The direction in which the [offset]'s [ViewportOffset.pixels] increases.
   ///
@@ -203,9 +202,8 @@ class ShrinkWrappingViewport extends MultiChildRenderObjectWidget {
     this.axisDirection: AxisDirection.down,
     @required this.offset,
     List<Widget> slivers: const <Widget>[],
-  }) : super(key: key, children: slivers) {
-    assert(offset != null);
-  }
+  }) : assert(offset != null),
+       super(key: key, children: slivers);
 
   /// The direction in which the [offset]'s [ViewportOffset.pixels] increases.
   ///

--- a/packages/flutter/lib/src/widgets/viewport.dart
+++ b/packages/flutter/lib/src/widgets/viewport.dart
@@ -57,7 +57,8 @@ class Viewport extends MultiChildRenderObjectWidget {
     this.center,
     List<Widget> slivers: const <Widget>[],
   }) : assert(offset != null),
-       assert(center == null || children.where((Widget child) => child.key == center).length == 1),
+       assert(slivers != null),
+       assert(center == null || slivers.where((Widget child) => child.key == center).length == 1),
        super(key: key, children: slivers);
 
   /// The direction in which the [offset]'s [ViewportOffset.pixels] increases.


### PR DESCRIPTION
2 new lints are coming in linter (`prefer_asserts_in_initializer_list` and `prefer_const_constructors_in_immutables` - names might change).

The first one lints `assert`s in contructor that can be move to initializer list. It allows to show that the asserts are done on parameters. It also improves the probabilty that the `prefer_const_constructors_in_immutables` rule lints the constructor to become a const constructor.

Is it something that is interessing to enable in flutter ? wdyt ?

(note: I use something similar to detect what immutable class could be const)