### PR TITLE
IntelliJ and Flutter plugin version checks

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_studio.dart
+++ b/packages/flutter_tools/lib/src/android/android_studio.dart
@@ -291,7 +291,7 @@ class AndroidStudio implements Comparable<AndroidStudio> {
       if (result.exitCode == 0) {
         final List<String> versionLines = result.stderr.split('\n');
         final String javaVersion = versionLines.length >= 2 ? versionLines[1] : versionLines[0];
-        _validationMessages.add('Java version: $javaVersion');
+        _validationMessages.add('Java version $javaVersion');
         _javaPath = javaPath;
       } else {
         _validationMessages.add('Unable to determine bundled Java version.');

--- a/packages/flutter_tools/lib/src/android/android_studio_validator.dart
+++ b/packages/flutter_tools/lib/src/android/android_studio_validator.dart
@@ -38,7 +38,9 @@ class AndroidStudioValidator extends DoctorValidator {
   Future<ValidationResult> validate() async {
     final List<ValidationMessage> messages = <ValidationMessage>[];
     ValidationType type = ValidationType.missing;
-    final String studioVersionText = 'version ${_studio.version}';
+    final String studioVersionText = Version.unknown == _studio.version
+        ? null
+        : 'version ${_studio.version}';
     messages
         .add(new ValidationMessage('Android Studio at ${_studio.directory}'));
     if (_studio.isValid) {

--- a/packages/flutter_tools/lib/src/android/android_studio_validator.dart
+++ b/packages/flutter_tools/lib/src/android/android_studio_validator.dart
@@ -38,7 +38,7 @@ class AndroidStudioValidator extends DoctorValidator {
   Future<ValidationResult> validate() async {
     final List<ValidationMessage> messages = <ValidationMessage>[];
     ValidationType type = ValidationType.missing;
-    final String studioVersionText = Version.unknown == _studio.version
+    final String studioVersionText = _studio.version == Version.unknown
         ? null
         : 'version ${_studio.version}';
     messages

--- a/packages/flutter_tools/lib/src/android/android_workflow.dart
+++ b/packages/flutter_tools/lib/src/android/android_workflow.dart
@@ -83,11 +83,10 @@ class AndroidWorkflow extends DoctorValidator implements Workflow {
       messages.add(new ValidationMessage.error('Could not determine java version'));
       return false;
     }
-    messages.add(new ValidationMessage('Java version: $javaVersion'));
+    messages.add(new ValidationMessage('Java version $javaVersion'));
     // TODO(johnmccutchan): Validate version.
     return true;
   }
-
 
   @override
   Future<ValidationResult> validate() async {

--- a/packages/flutter_tools/lib/src/base/version.dart
+++ b/packages/flutter_tools/lib/src/base/version.dart
@@ -45,7 +45,7 @@ class Version implements Comparable<Version> {
 
   /// Creates a new [Version] by parsing [text].
   factory Version.parse(String text) {
-    final Match match = versionPattern.firstMatch(text);
+    final Match match = versionPattern.firstMatch(text ?? '');
     if (match == null) {
       return null;
     }

--- a/packages/flutter_tools/lib/src/doctor.dart
+++ b/packages/flutter_tools/lib/src/doctor.dart
@@ -16,6 +16,7 @@ import 'base/file_system.dart';
 import 'base/os.dart';
 import 'base/platform.dart';
 import 'base/process_manager.dart';
+import 'base/version.dart';
 import 'cache.dart';
 import 'device.dart';
 import 'globals.dart';
@@ -261,6 +262,10 @@ abstract class IntelliJValidator extends DoctorValidator {
     'WebStorm': 'WebStorm',
   };
 
+  static final Version kMinIdeaVersion = new Version(2017, 1, 0);
+  static final Version kMinWebStormVersion = new Version(2017, 1, 0);
+  static final Version kMinFlutterPluginVersion = new Version(14, 0, 0);
+
   static Iterable<DoctorValidator> get installedValidators {
     if (platform.isLinux || platform.isWindows)
       return IntelliJValidatorOnLinuxAndWindows.installed;
@@ -273,46 +278,73 @@ abstract class IntelliJValidator extends DoctorValidator {
   Future<ValidationResult> validate() async {
     final List<ValidationMessage> messages = <ValidationMessage>[];
 
-    int installCount = 0;
+    _validatePackage(messages, 'flutter-intellij.jar', 'Flutter',
+        minVersion: kMinFlutterPluginVersion);
 
-    if (isWebStorm) {
-      // Dart is bundled with WebStorm.
-      installCount++;
-    } else {
-      if (_validateHasPackage(messages, 'Dart', 'Dart'))
-        installCount++;
+    // Dart is bundled with WebStorm.
+    if (!isWebStorm) {
+      _validatePackage(messages, 'Dart', 'Dart');
     }
 
-    if (_validateHasPackage(messages, 'flutter-intellij.jar', 'Flutter'))
-      installCount++;
-
-    if (installCount < 2) {
+    if (_hasIssues(messages)) {
       messages.add(new ValidationMessage(
-          'For information about managing plugins, see\n'
-          'https://www.jetbrains.com/help/idea/managing-plugins.html'
+        'For information about managing plugins, see\n'
+        'https://www.jetbrains.com/help/idea/managing-plugins.html'
       ));
     }
 
+    _validateIntelliJVersion(messages, isWebStorm ? kMinWebStormVersion : kMinIdeaVersion);
+
     return new ValidationResult(
-        installCount == 2 ? ValidationType.installed : ValidationType.partial,
-        messages,
-        statusInfo: 'version $version'
+      _hasIssues(messages) ? ValidationType.partial : ValidationType.installed,
+      messages,
+      statusInfo: 'version $version'
     );
+  }
+
+  bool _hasIssues(List<ValidationMessage> messages) {
+    return messages.any((ValidationMessage message) => message.isError);
   }
 
   bool get isWebStorm => title == 'WebStorm';
 
-  bool _validateHasPackage(List<ValidationMessage> messages, String packageName, String title) {
+  void _validateIntelliJVersion(List<ValidationMessage> messages, Version minVersion) {
+    // Ignore unknown versions.
+    if (minVersion == Version.unknown)
+      return;
+
+    final Version installedVersion = new Version.parse(version);
+    if (installedVersion == null)
+      return;
+
+    if (installedVersion < minVersion) {
+      messages.add(new ValidationMessage.error(
+        'This install is older than the minimum recommended version of $minVersion.'
+      ));
+    }
+  }
+
+  void _validatePackage(List<ValidationMessage> messages, String packageName, String title, {
+    Version minVersion
+  }) {
     if (!hasPackage(packageName)) {
-      messages.add(new ValidationMessage(
+      messages.add(new ValidationMessage.error(
         '$title plugin not installed; this adds $title specific functionality.'
       ));
-      return false;
+      return;
     }
-    final String version = _readPackageVersion(packageName);
-    messages.add(new ValidationMessage('$title plugin '
-        '${version != null ? "version $version" : "installed"}'));
-    return true;
+    final String versionText = _readPackageVersion(packageName);
+    final Version version = new Version.parse(versionText);
+    if (version != null && minVersion != null && version < minVersion) {
+        messages.add(new ValidationMessage.error(
+          '$title plugin ${version != null ? "version $versionText" : "installed"}'
+          ' - the recommended minimum version is $minVersion'
+        ));
+    } else {
+      messages.add(new ValidationMessage(
+        '$title plugin ${version != null ? "version $version" : "installed"}'
+      ));
+    }
   }
 
   String _readPackageVersion(String packageName) {

--- a/packages/flutter_tools/lib/src/doctor.dart
+++ b/packages/flutter_tools/lib/src/doctor.dart
@@ -337,8 +337,7 @@ abstract class IntelliJValidator extends DoctorValidator {
     final Version version = new Version.parse(versionText);
     if (version != null && minVersion != null && version < minVersion) {
         messages.add(new ValidationMessage.error(
-          '$title plugin ${version != null ? "version $versionText" : "installed"}'
-          ' - the recommended minimum version is $minVersion'
+          '$title plugin version $versionText - the recommended minimum version is $minVersion'
         ));
     } else {
       messages.add(new ValidationMessage(

--- a/packages/flutter_tools/test/commands/doctor_test.dart
+++ b/packages/flutter_tools/test/commands/doctor_test.dart
@@ -12,9 +12,9 @@ void main() {
   group('doctor', () {
     testUsingContext('intellij validator', () async {
       final ValidationResult result = await new IntelliJValidatorTestTarget('Test').validate();
-      expect(result.type, ValidationType.installed);
+      expect(result.type, ValidationType.partial);
       expect(result.statusInfo, 'version test.test.test');
-      expect(result.messages, hasLength(2));
+      expect(result.messages, hasLength(3));
 
       ValidationMessage message = result.messages
           .firstWhere((ValidationMessage m) => m.message.startsWith('Dart '));
@@ -22,7 +22,8 @@ void main() {
 
       message = result.messages
           .firstWhere((ValidationMessage m) => m.message.startsWith('Flutter '));
-      expect(message.message, 'Flutter plugin version 0.1.3');
+      expect(message.message, contains('Flutter plugin version 0.1.3'));
+      expect(message.message, contains('recommended minimum version'));
     });
   });
 }


### PR DESCRIPTION
- validate the installed versions of IntelliJ and the flutter plugin (fix https://github.com/flutter/flutter-intellij/issues/1054)
- instead of printing `version unknown` when we don't discover a version for android studio, just don't print a version
- some tweaks to our other version text for consistency


