### PR TITLE
Text Selection Handler/Controls Scroll Problem

### DIFF
--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -523,6 +523,9 @@ class EditableTextState extends State<EditableText> implements TextInputClient {
   @override
   Widget build(BuildContext context) {
     FocusScope.of(context).reparentIfNeeded(widget.focusNode);
+    Scrollable.of(context).widget.controller.addListener((){
+      _selectionOverlay?.hide();
+    });
     return new Scrollable(
       axisDirection: _isMultiline ? AxisDirection.down : AxisDirection.right,
       controller: _scrollController,


### PR DESCRIPTION
Text selection handle/controls do not scroll when the text field is inside a scroll view.
Hide then as soon as scroll starts.