### PR TITLE
Text Handler/Controls do not scroll inside a scroll view

### DIFF
--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -520,9 +520,15 @@ class EditableTextState extends State<EditableText> implements TextInputClient {
     _updateOrDisposeSelectionOverlayIfNeeded();
   }
 
+  void _handleScrollChange() {
+    _selectionOverlay?.hide();
+  }
+
   @override
   Widget build(BuildContext context) {
     FocusScope.of(context).reparentIfNeeded(widget.focusNode);
+    Scrollable.of(context)?.widget?.controller?.removeListener(_handleScrollChange);
+    Scrollable.of(context)?.widget?.controller?.addListener(_handleScrollChange);
     return new Scrollable(
       axisDirection: _isMultiline ? AxisDirection.down : AxisDirection.right,
       controller: _scrollController,


### PR DESCRIPTION
Text selection handle/controls do not scroll when the text field is inside a scroll view.
Hide then as soon as scroll starts.