### PR TITLE
Remove underscores from Android identifier during `flutter create`

### DIFF
--- a/packages/flutter_tools/lib/src/commands/create.dart
+++ b/packages/flutter_tools/lib/src/commands/create.dart
@@ -275,7 +275,7 @@ To edit platform code in an IDE see https://flutter.io/platform-plugins/#edit-co
 }
 
 String _createAndroidIdentifier(String organization, String name) {
-  return '$organization.$name';
+  return '$organization.$name'.replaceAll('_', '');
 }
 
 String _createPluginClassName(String name) {


### PR DESCRIPTION
Fixes #10077