### PR TITLE
Hide the Scaffold's scroll-to-top button from accessibility

### DIFF
--- a/packages/flutter/lib/src/material/scaffold.dart
+++ b/packages/flutter/lib/src/material/scaffold.dart
@@ -867,6 +867,8 @@ class ScaffoldState extends State<Scaffold> with TickerProviderStateMixin {
         child: new GestureDetector(
           behavior: HitTestBehavior.opaque,
           onTap: _handleStatusBarTap,
+          // iOS accessibility automatically adds scroll-to-top to the clock in the status bar
+          excludeFromSemantics: true,
         )
       ));
     }


### PR DESCRIPTION
It's redundant as iOS accessibility automatically includes this action on the clock in the status bar.