### PR TITLE
Revert use of const asserts in flutter_driver

### DIFF
--- a/packages/flutter_driver/lib/src/health.dart
+++ b/packages/flutter_driver/lib/src/health.dart
@@ -29,8 +29,9 @@ final EnumIndex<HealthStatus> _healthStatusIndex =
 
 class Health extends Result {
   /// Creates a [Health] object with the given [status].
-  Health(this.status)
-    : assert(status != null);
+  Health(this.status) {
+    assert(status != null);
+  }
 
   /// Deserializes the result from JSON.
   static Health fromJson(Map<String, dynamic> json) {


### PR DESCRIPTION
Fixes bot breakage resulting from commit
7d7132636369914402507c7b15d635039193ee46 (#10540).