### PR TITLE
Center all strings in SemanticDebugger

### DIFF
--- a/packages/flutter/lib/src/widgets/semantics_debugger.dart
+++ b/packages/flutter/lib/src/widgets/semantics_debugger.dart
@@ -252,6 +252,7 @@ void _paintMessage(Canvas canvas, SemanticsNode node) {
   canvas.clipRect(rect);
   final TextPainter textPainter = new TextPainter()
     ..text = new TextSpan(style: _messageStyle, text: message)
+    ..textAlign = TextAlign.center
     ..layout(maxWidth: rect.width);
 
   textPainter.paint(canvas, FractionalOffset.center.inscribe(textPainter.size, rect).topLeft);


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/4647