### PR TITLE
Correct sample catalog screenshot filename prefix generation

### DIFF
--- a/dev/devicelab/manifest.yaml
+++ b/dev/devicelab/manifest.yaml
@@ -130,7 +130,7 @@ tasks:
     description: >
       Builds sample catalog markdown pages and Android screenshots
     stage: devicelab
-    required_agent_capabilities: ["has-android-device"]
+    required_agent_capabilities: ["linux/android"]
     flaky: true
 
   # iOS on-device tests


### PR DESCRIPTION
Currently the flutter driver test that collections screenshots (see examples/catalog/bin/screenshot_test.dart.template) incorrectly assumes that if it's running on MacOS, it's targeting an iOS device.  Changed the task's manifest entry to make that true.

It would preferable to just ask the FlutterDriver for the target device's deviceId, or OS. This patch will fix things for now.
