### PR TITLE
Support 'be' channel so you can download dart-sdk from the tip.

### DIFF
--- a/bin/internal/README.md
+++ b/bin/internal/README.md
@@ -1,6 +1,10 @@
 Dart SDK dependency
-===
+===================
 
-Dart SDK is downloaded from one of [the supported channels](https://www.dartlang.org/install/archive), cached in `bin/cache/dart-sdk` and is used to run Flutter Dart code.
+The Dart SDK is downloaded from one of [the supported channels](https://www.dartlang.org/install/archive),
+cached in `bin/cache/dart-sdk` and is used to run Flutter Dart code.
 
-File `bin/internal/dart-sdk.version` determines the version of Dart SDK that will be downloaded. Normally it points to the `dev` channel(for example, `1.24.0-dev.6.7`), but it can also point to particular bleeding edge build of Dart(for example, `hash/c0617d20158955d99d6447036237fe2639ba088c`).
+The file `bin/internal/dart-sdk.version` determines the version of Dart SDK
+that will be downloaded. Normally it points to the `dev` channel (for example,
+`1.24.0-dev.6.7`), but it can also point to particular bleeding edge build
+of Dart (for example, `hash/c0617d20158955d99d6447036237fe2639ba088c`).

--- a/bin/internal/README.md
+++ b/bin/internal/README.md
@@ -1,0 +1,6 @@
+Dart SDK dependency
+===
+
+Dart SDK is downloaded from one of [the supported channels](https://www.dartlang.org/install/archive), cached in `bin/cache/dart-sdk` and is used to run Flutter Dart code.
+
+File `bin/internal/dart-sdk.version` determines the version of Dart SDK that will be downloaded. Normally it points to the `dev` channel(for example, `1.24.0-dev.6.7`), but it can also point to particular bleeding edge build of Dart(for example, `hash/c0617d20158955d99d6447036237fe2639ba088c`).

--- a/bin/internal/update_dart_sdk.ps1
+++ b/bin/internal/update_dart_sdk.ps1
@@ -29,7 +29,7 @@ if ((Test-Path $dartSdkStampPath) -and ($dartSdkVersion -eq (Get-Content $dartSd
 
 Write-Host "Downloading Dart SDK $dartSdkVersion..."
 $dartZipName = "dartsdk-windows-x64-release.zip"
-$dartChannel = if ($dartSdkVersion.Contains("-dev.")) {"dev"} else {"stable"}
+$dartChannel = if ($dartSdkVersion.Contains("-dev.")) {"dev"} else {if ($dartSdkVersion.Contains("hash/")) {"be"} else {"stable"}}
 $dartSdkUrl = "https://storage.googleapis.com/dart-archive/channels/$dartChannel/raw/$dartSdkVersion/sdk/$dartZipName"
 
 if (Test-Path $dartSdkPath) {

--- a/bin/internal/update_dart_sdk.sh
+++ b/bin/internal/update_dart_sdk.sh
@@ -41,6 +41,9 @@ if [ ! -f "$DART_SDK_STAMP_PATH" ] || [ "$DART_SDK_VERSION" != `cat "$DART_SDK_S
   if [[ $DART_SDK_VERSION == *"-dev."* ]]
   then
     DART_CHANNEL="dev"
+  elif [[ $DART_SDK_VERSION == "hash/"* ]]
+  then
+    DART_CHANNEL="be"
   fi
 
   DART_SDK_URL="https://storage.googleapis.com/dart-archive/channels/$DART_CHANNEL/raw/$DART_SDK_VERSION/sdk/$DART_ZIP_NAME"


### PR DESCRIPTION
This is triggered when you put 'hash/<build hash>' into dart-sdk.version file.
For example, 'hash/c0617d20158955d99d6447036237fe2639ba088c'.

This allows to easily iterate against dart tip of the tree changes.