### PR TITLE
Run flutter_tools tests serially

### DIFF
--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -118,7 +118,7 @@ Future<Null> _pubRunTest(
   String workingDirectory, {
   String testPath,
 }) {
-  final List<String> args = <String>['run', 'test', '-rexpanded'];
+  final List<String> args = <String>['run', 'test', '-j1', '-rexpanded'];
   if (testPath != null)
     args.add(testPath);
   return _runCommand(pub, args, workingDirectory: workingDirectory);


### PR DESCRIPTION
We suspect maybe recent failures are caused by race conditions from
running flutter_tools tests in parallel.