### PR TITLE
Refactor sample catalog screenshot production

### DIFF
--- a/dev/devicelab/lib/tasks/sample_catalog_generator.dart
+++ b/dev/devicelab/lib/tasks/sample_catalog_generator.dart
@@ -21,8 +21,8 @@ Future<TaskResult> samplePageCatalogGenerator(String authorizationToken) async {
   await inDirectory(catalogDirectory, () async {
     await flutter('packages', options: <String>['get']);
 
-    final bool isIOSDevice = deviceOperatingSystem == DeviceOperatingSystem.ios;
-    if (isIOSDevice)
+    final bool isIosDevice = deviceOperatingSystem == DeviceOperatingSystem.ios;
+    if (isIosDevice)
       await prepareProvisioningCertificates(catalogDirectory.path);
 
     await dart(<String>['bin/sample_page.dart']);
@@ -38,7 +38,7 @@ Future<TaskResult> samplePageCatalogGenerator(String authorizationToken) async {
       directory: dir('${flutterDirectory.path}/examples/catalog/.generated'),
       commit: await getCurrentFlutterRepoCommit(),
       token: authorizationToken,
-      prefix: isIOSDevice ? 'ios_' : '',
+      prefix: isIosDevice ? 'ios_' : '',
     );
   });
 

--- a/dev/devicelab/lib/tasks/sample_catalog_generator.dart
+++ b/dev/devicelab/lib/tasks/sample_catalog_generator.dart
@@ -9,6 +9,8 @@ import '../framework/adb.dart';
 import '../framework/framework.dart';
 import '../framework/ios.dart';
 import '../framework/utils.dart';
+import 'save_catalog_screenshots.dart' show saveCatalogScreenshots;
+
 
 Future<TaskResult> samplePageCatalogGenerator(String authorizationToken) async {
   final Device device = await devices.workingDevice;
@@ -19,7 +21,8 @@ Future<TaskResult> samplePageCatalogGenerator(String authorizationToken) async {
   await inDirectory(catalogDirectory, () async {
     await flutter('packages', options: <String>['get']);
 
-    if (deviceOperatingSystem == DeviceOperatingSystem.ios)
+    final bool isIOSDevice = deviceOperatingSystem == DeviceOperatingSystem.ios;
+    if (isIOSDevice)
       await prepareProvisioningCertificates(catalogDirectory.path);
 
     await dart(<String>['bin/sample_page.dart']);
@@ -31,11 +34,11 @@ Future<TaskResult> samplePageCatalogGenerator(String authorizationToken) async {
       deviceId,
     ]);
 
-    await dart(<String>[
-      'bin/save_screenshots.dart',
-      await getCurrentFlutterRepoCommit(),
-      authorizationToken,
-    ]);
+    await saveCatalogScreenshots(
+      commit: await getCurrentFlutterRepoCommit(),
+      token: authorizationToken,
+      prefix: isIOSDevice ? 'ios_' : '',
+    );
   });
 
   return new TaskResult.success(null);

--- a/dev/devicelab/lib/tasks/sample_catalog_generator.dart
+++ b/dev/devicelab/lib/tasks/sample_catalog_generator.dart
@@ -35,6 +35,7 @@ Future<TaskResult> samplePageCatalogGenerator(String authorizationToken) async {
     ]);
 
     await saveCatalogScreenshots(
+      directory: dir('${flutterDirectory.path}/examples/catalog/.generated'),
       commit: await getCurrentFlutterRepoCommit(),
       token: authorizationToken,
       prefix: isIOSDevice ? 'ios_' : '',

--- a/dev/devicelab/lib/tasks/save_catalog_screenshots.dart
+++ b/dev/devicelab/lib/tasks/save_catalog_screenshots.dart
@@ -114,15 +114,11 @@ Future<Null> saveScreenshots(List<String> fromPaths, List<String> largeNames, Li
 String screenshotName(String path) => basenameWithoutExtension(path);
 
 Future<Null> saveCatalogScreenshots({
-    @required Directory directory, // Where the *.png screenshots are.
-    @required String commit, // The commit hash to be used as a cloud storage "directory".
-    @required String token, // Cloud storage authorization token.
-    @required String prefix, // Prefix for all file names.
+    Directory directory, // Where the *.png screenshots are.
+    String commit, // The commit hash to be used as a cloud storage "directory".
+    String token, // Cloud storage authorization token.
+    String prefix, // Prefix for all file names.
   }) async {
-  assert(commit != null);
-  assert(token != null);
-  assert(prefix != null);
-
   final List<String> screenshots = <String>[];
   directory.listSync().forEach((FileSystemEntity entity) {
     if (entity is File && entity.path.endsWith('.png')) {

--- a/dev/devicelab/lib/tasks/save_catalog_screenshots.dart
+++ b/dev/devicelab/lib/tasks/save_catalog_screenshots.dart
@@ -1,3 +1,7 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
@@ -56,6 +60,7 @@ class Upload {
 
       final HttpClientResponse response = await request.close().timeout(timeLimit);
       if (response.statusCode == HttpStatus.OK) {
+        logMessage('Saved $name');
         await response.drain<Null>();
       } else {
         // TODO(hansmuller): only retry on 5xx and 429 responses
@@ -96,23 +101,24 @@ Future<Null> saveScreenshots(List<String> fromPaths, List<String> largeNames, Li
   for (int index = 0; index < uploads.length; index += 1)
     uploads[index] = new Upload(fromPaths[index], largeNames[index], smallNames[index]);
 
-  final HttpClient client = new HttpClient();
   while(uploads.any(Upload.isNotComplete)) {
+    final HttpClient client = new HttpClient();
     uploads = uploads.where(Upload.isNotComplete).toList();
     await Future.wait(uploads.map((Upload upload) => upload.run(client)));
+    client.close(force: true);
   }
-  client.close();
 }
 
 
 // If path is lib/foo.png then screenshotName is foo.
 String screenshotName(String path) => basenameWithoutExtension(path);
 
-Future<Null> main(List<String> args) async {
-  if (args.length != 2)
-    throw new UploadError('Usage: dart bin/save_screenshots.dart commit authorization');
+Future<Null> saveCatalogScreenshots({ @required String commit, @required String token, @required String prefix}) async {
+  assert(commit != null);
+  assert(token != null);
+  assert(prefix != null);
 
-  final Directory outputDirectory = new Directory('.generated');
+  final Directory outputDirectory = new Directory('/builds/dev/flutter/examples/catalog/.generated');
   final List<String> screenshots = <String>[];
   outputDirectory.listSync().forEach((FileSystemEntity entity) {
     if (entity is File && entity.path.endsWith('.png')) {
@@ -121,15 +127,14 @@ Future<Null> main(List<String> args) async {
     }
   });
 
-  final String commit = args[0];
   final List<String> largeNames = <String>[]; // Cloud storage names for the full res screenshots.
   final List<String> smallNames = <String>[]; // Likewise for the scaled down screenshots.
   for (String path in screenshots) {
     final String name = screenshotName(path);
-    largeNames.add('$commit/$name.png');
-    smallNames.add('$commit/${name}_small.png');
+    largeNames.add('$commit/$prefix$name.png');
+    smallNames.add('$commit/$prefix${name}_small.png');
   }
 
-  authorizationToken = args[1];
+  authorizationToken = token;
   await saveScreenshots(screenshots, largeNames, smallNames);
 }

--- a/dev/devicelab/lib/tasks/save_catalog_screenshots.dart
+++ b/dev/devicelab/lib/tasks/save_catalog_screenshots.dart
@@ -113,14 +113,18 @@ Future<Null> saveScreenshots(List<String> fromPaths, List<String> largeNames, Li
 // If path is lib/foo.png then screenshotName is foo.
 String screenshotName(String path) => basenameWithoutExtension(path);
 
-Future<Null> saveCatalogScreenshots({ @required String commit, @required String token, @required String prefix}) async {
+Future<Null> saveCatalogScreenshots({
+    @required Directory directory, // Where the *.png screenshots are.
+    @required String commit, // The commit hash to be used as a cloud storage "directory".
+    @required String token, // Cloud storage authorization token.
+    @required String prefix, // Prefix for all file names.
+  }) async {
   assert(commit != null);
   assert(token != null);
   assert(prefix != null);
 
-  final Directory outputDirectory = new Directory('/builds/dev/flutter/examples/catalog/.generated');
   final List<String> screenshots = <String>[];
-  outputDirectory.listSync().forEach((FileSystemEntity entity) {
+  directory.listSync().forEach((FileSystemEntity entity) {
     if (entity is File && entity.path.endsWith('.png')) {
       final File file = entity;
       screenshots.add(file.path);

--- a/dev/devicelab/manifest.yaml
+++ b/dev/devicelab/manifest.yaml
@@ -130,7 +130,7 @@ tasks:
     description: >
       Builds sample catalog markdown pages and Android screenshots
     stage: devicelab
-    required_agent_capabilities: ["linux/android"]
+    required_agent_capabilities: ["has-android-device"]
     flaky: true
 
   # iOS on-device tests

--- a/dev/devicelab/pubspec.yaml
+++ b/dev/devicelab/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 
 dependencies:
   args: ^0.13.4
-  image:
+  image: ^1.1.27
   meta: ^1.0.5
   path: ^1.4.0
   process: 2.0.3

--- a/dev/devicelab/pubspec.yaml
+++ b/dev/devicelab/pubspec.yaml
@@ -9,6 +9,7 @@ environment:
 
 dependencies:
   args: ^0.13.4
+  image:
   meta: ^1.0.5
   path: ^1.4.0
   process: 2.0.3

--- a/examples/catalog/bin/sample_page.dart
+++ b/examples/catalog/bin/sample_page.dart
@@ -180,7 +180,7 @@ void generate() {
     screenshotDriverTemplate,
     <String, String>{
       'paths': samples.map((SampleGenerator sample) {
-        return "'${outputFile('\${prefix}' + sample.sourceName + '.png').path}'";
+        return "'${outputFile(sample.sourceName + '.png').path}'";
       }).toList().join(',\n'),
     },
   );

--- a/examples/catalog/bin/screenshot_test.dart.template
+++ b/examples/catalog/bin/screenshot_test.dart.template
@@ -8,7 +8,6 @@ import 'package:test/test.dart';
 
 void main() {
   group('sample screenshots', () {
-    final String prefix = Platform.isMacOS ? 'ios_' : "";
     FlutterDriver driver;
 
     setUpAll(() async {

--- a/examples/catalog/pubspec.yaml
+++ b/examples/catalog/pubspec.yaml
@@ -3,7 +3,6 @@ description: A collection of Flutter sample apps
 dependencies:
   flutter:
     sdk: flutter
-  image:
   path: ^1.4.0
 
 dev_dependencies:


### PR DESCRIPTION
The (Java) code used to save screenshots has been flaky on Linux. Refactored the code so that screenshot production can run on (just) MacOS.

Also:
- The screenshot uploader is no longer a separate process.
- ... no longer tries to reuse an HTTP client after a timeout.
- ... logs the files that it has saved.
