### PR TITLE
Create a CupertinoPageRoute

### DIFF
--- a/packages/flutter/lib/cupertino.dart
+++ b/packages/flutter/lib/cupertino.dart
@@ -18,3 +18,4 @@ export 'src/cupertino/scaffold.dart';
 export 'src/cupertino/slider.dart';
 export 'src/cupertino/switch.dart';
 export 'src/cupertino/thumb_painter.dart';
+export 'widgets.dart';

--- a/packages/flutter/lib/src/cupertino/page.dart
+++ b/packages/flutter/lib/src/cupertino/page.dart
@@ -88,10 +88,11 @@ class CupertinoPageRoute<T> extends PageRoute<T> {
 
   CupertinoBackGestureController _backGestureController;
 
-  /// Support for dismissing this route with a horizontal swipe is enabled
-  /// for [TargetPlatform.iOS]. If attempts to dismiss this route might be
-  /// vetoed because a [WillPopCallback] was defined for the route then the
-  /// platform-specific back gesture is disabled.
+  /// Support for dismissing this route with a horizontal swipe.
+  ///
+  /// Swiping will be disabled if the page is a fullscreen dialog or if
+  /// dismissals can be overriden because a [WillPopCallback] was
+  /// defined for the route.
   ///
   /// See also:
   ///
@@ -99,8 +100,8 @@ class CupertinoPageRoute<T> extends PageRoute<T> {
   ///    is defined for this route.
   @override
   NavigationGestureController startPopGesture() {
-    // If attempts to dismiss this route might be vetoed, then do not
-    // allow the user to dismiss the route with a swipe.
+    // If attempts to dismiss this route might be vetoed such as in a page
+    // with forms, then do not allow the user to dismiss the route with a swipe.
     if (hasScopedWillPopCallback)
       return null;
     // Fullscreen dialogs aren't dismissable by back swipe.
@@ -143,27 +144,20 @@ class CupertinoPageRoute<T> extends PageRoute<T> {
 
   @override
   Widget buildTransitions(BuildContext context, Animation<double> animation, Animation<double> secondaryAnimation, Widget child) {
-    if (Theme.of(context).platform == TargetPlatform.iOS) {
-      if (fullscreenDialog)
-        return new CupertinoFullscreenDialogTransition(
-          animation: animation,
-          child: child,
-        );
-      else
-        return new CupertinoPageTransition(
-          primaryRouteAnimation: animation,
-          secondaryRouteAnimation: secondaryAnimation,
-          child: child,
-          // In the middle of a back gesture drag, let the transition be linear to match finger
-          // motions.
-          linearTransition: _backGestureController != null,
-        );
-    } else {
-      return new _MountainViewPageTransition(
-        routeAnimation: animation,
-        child: child
+    if (fullscreenDialog)
+      return new CupertinoFullscreenDialogTransition(
+        animation: animation,
+        child: child,
       );
-    }
+    else
+      return new CupertinoPageTransition(
+        primaryRouteAnimation: animation,
+        secondaryRouteAnimation: secondaryAnimation,
+        child: child,
+        // In the middle of a back gesture drag, let the transition be linear to match finger
+        // motions.
+        linearTransition: _backGestureController != null,
+      );
   }
 
   @override

--- a/packages/flutter/lib/src/cupertino/page.dart
+++ b/packages/flutter/lib/src/cupertino/page.dart
@@ -55,13 +55,34 @@ class CupertinoPageRoute<T> extends PageRoute<T> {
     bool fullscreenDialog: false,
   }) : assert(builder != null),
        assert(opaque),
+       _hostPageRoute = null,
        super(settings: settings, fullscreenDialog: fullscreenDialog);
+
+  CupertinoPageRoute.delegate({
+    @required PageRoute<T> hostPageRoute,
+    bool fullscreenDialog,
+  }) : assert(hostPageRoute != null),
+       _hostPageRoute = hostPageRoute,
+       builder = null,
+       maintainState = null,
+       super(fullscreenDialog: fullscreenDialog);
 
   /// Builds the primary contents of the route.
   final WidgetBuilder builder;
 
+  final PageRoute<T> _hostPageRoute;
+
   @override
   final bool maintainState;
+
+  @override
+  NavigatorState get navigator => _hostPageRoute?.navigator ?? super.navigator;
+
+  @override
+  AnimationController get controller => _hostPageRoute?.controller ?? super.controller;
+
+  @override
+  bool get hasScopedWillPopCallback => _hostPageRoute?.hasScopedWillPopCallback ?? super.hasScopedWillPopCallback;
 
   @override
   Duration get transitionDuration => const Duration(milliseconds: 300);
@@ -83,7 +104,8 @@ class CupertinoPageRoute<T> extends PageRoute<T> {
   @override
   void dispose() {
     _backGestureController?.dispose();
-    super.dispose();
+    if (_hostPageRoute == null)
+      super.dispose();
   }
 
   CupertinoBackGestureController _backGestureController;

--- a/packages/flutter/lib/src/material/page.dart
+++ b/packages/flutter/lib/src/material/page.dart
@@ -70,11 +70,11 @@ class MaterialPageRoute<T> extends PageRoute<T> {
 
   /// A delegate PageRoute to which iOS themed page operations are delegated to.
   /// It's lazily created on first use.
-  CupertinoPageRoute<Null> _cupertinoPageRoute;
-  CupertinoPageRoute<Null> get cupertinoPageRoute {
+  CupertinoPageRoute<T> _cupertinoPageRoute;
+  CupertinoPageRoute<T> get cupertinoPageRoute {
     if (_cupertinoPageRoute == null) {
-      _cupertinoPageRoute = new CupertinoPageRoute<Null>(
-        builder: builder, // Should be never used.
+      _cupertinoPageRoute = new CupertinoPageRoute<T>.delegate(
+        hostPageRoute: this,
         fullscreenDialog: fullscreenDialog,
       );
     }

--- a/packages/flutter/lib/src/material/page.dart
+++ b/packages/flutter/lib/src/material/page.dart
@@ -54,6 +54,10 @@ class _MountainViewPageTransition extends StatelessWidget {
 ///
 /// Specify whether the incoming page is a fullscreen modal dialog. On iOS, those
 /// pages animate bottom->up rather than right->left.
+///
+/// See also:
+///
+///  * [CupertinoPageRoute], that this [PageRoute] delegates transition animations to for iOS.
 class MaterialPageRoute<T> extends PageRoute<T> {
   /// Creates a page route for use in a material design app.
   MaterialPageRoute({
@@ -73,8 +77,8 @@ class MaterialPageRoute<T> extends PageRoute<T> {
   CupertinoPageRoute<T> _cupertinoPageRoute;
   CupertinoPageRoute<T> get cupertinoPageRoute {
     if (_cupertinoPageRoute == null) {
-      _cupertinoPageRoute = new CupertinoPageRoute<T>.delegate(
-        hostPageRoute: this,
+      _cupertinoPageRoute = new CupertinoPageRoute<T>(
+        builder: builder, // Not used.
         fullscreenDialog: fullscreenDialog,
       );
     }
@@ -115,12 +119,13 @@ class MaterialPageRoute<T> extends PageRoute<T> {
   ///
   /// See also:
   ///
+  ///  * [CupertinoPageRoute] that backs the gesture for iOS.
   ///  * [hasScopedWillPopCallback], which is true if a `willPop` callback
   ///    is defined for this route.
   @override
   NavigationGestureController startPopGesture() {
     return Theme.of(navigator.context).platform == TargetPlatform.iOS
-        ? cupertinoPageRoute.startPopGesture()
+        ? cupertinoPageRoute.startPopGestureForRoute(this)
         : null;
   }
 

--- a/packages/flutter/lib/src/material/page.dart
+++ b/packages/flutter/lib/src/material/page.dart
@@ -74,15 +74,15 @@ class MaterialPageRoute<T> extends PageRoute<T> {
 
   /// A delegate PageRoute to which iOS themed page operations are delegated to.
   /// It's lazily created on first use.
-  CupertinoPageRoute<T> _cupertinoPageRoute;
-  CupertinoPageRoute<T> get cupertinoPageRoute {
-    if (_cupertinoPageRoute == null) {
-      _cupertinoPageRoute = new CupertinoPageRoute<T>(
+  CupertinoPageRoute<T> _internalCupertinoPageRoute;
+  CupertinoPageRoute<T> get _cupertinoPageRoute {
+    if (_internalCupertinoPageRoute == null) {
+      _internalCupertinoPageRoute = new CupertinoPageRoute<T>(
         builder: builder, // Not used.
         fullscreenDialog: fullscreenDialog,
       );
     }
-    return _cupertinoPageRoute;
+    return _internalCupertinoPageRoute;
   }
 
   @override
@@ -108,7 +108,7 @@ class MaterialPageRoute<T> extends PageRoute<T> {
 
   @override
   void dispose() {
-    _cupertinoPageRoute?.dispose();
+    _internalCupertinoPageRoute?.dispose();
     super.dispose();
   }
 
@@ -125,7 +125,7 @@ class MaterialPageRoute<T> extends PageRoute<T> {
   @override
   NavigationGestureController startPopGesture() {
     return Theme.of(navigator.context).platform == TargetPlatform.iOS
-        ? cupertinoPageRoute.startPopGestureForRoute(this)
+        ? _cupertinoPageRoute.startPopGestureForRoute(this)
         : null;
   }
 
@@ -147,7 +147,7 @@ class MaterialPageRoute<T> extends PageRoute<T> {
   @override
   Widget buildTransitions(BuildContext context, Animation<double> animation, Animation<double> secondaryAnimation, Widget child) {
     if (Theme.of(context).platform == TargetPlatform.iOS) {
-      return cupertinoPageRoute.buildTransitions(context, animation, secondaryAnimation, child);
+      return _cupertinoPageRoute.buildTransitions(context, animation, secondaryAnimation, child);
     } else {
       return new _MountainViewPageTransition(
         routeAnimation: animation,

--- a/packages/flutter/lib/src/material/page.dart
+++ b/packages/flutter/lib/src/material/page.dart
@@ -60,19 +60,13 @@ class MaterialPageRoute<T> extends PageRoute<T> {
     @required this.builder,
     RouteSettings settings: const RouteSettings(),
     this.maintainState: true,
-    this.fullscreenDialog: false,
+    bool fullscreenDialog: false,
   }) : assert(builder != null),
        assert(opaque),
-       super(settings: settings);
+       super(settings: settings, fullscreenDialog: fullscreenDialog);
 
   /// Builds the primary contents of the route.
   final WidgetBuilder builder;
-
-  /// Whether this route is a full-screen dialog.
-  ///
-  /// Prevents [startPopGesture] from poping the route using an edge swipe on
-  /// iOS.
-  final bool fullscreenDialog;
 
   @override
   final bool maintainState;

--- a/packages/flutter/lib/src/material/page.dart
+++ b/packages/flutter/lib/src/material/page.dart
@@ -76,12 +76,10 @@ class MaterialPageRoute<T> extends PageRoute<T> {
   /// It's lazily created on first use.
   CupertinoPageRoute<T> _internalCupertinoPageRoute;
   CupertinoPageRoute<T> get _cupertinoPageRoute {
-    if (_internalCupertinoPageRoute == null) {
-      _internalCupertinoPageRoute = new CupertinoPageRoute<T>(
-        builder: builder, // Not used.
-        fullscreenDialog: fullscreenDialog,
-      );
-    }
+    _internalCupertinoPageRoute ??= new CupertinoPageRoute<T>(
+      builder: builder, // Not used.
+      fullscreenDialog: fullscreenDialog,
+    );
     return _internalCupertinoPageRoute;
   }
 

--- a/packages/flutter/lib/src/widgets/pages.dart
+++ b/packages/flutter/lib/src/widgets/pages.dart
@@ -13,8 +13,17 @@ import 'routes.dart';
 abstract class PageRoute<T> extends ModalRoute<T> {
   /// Creates a modal route that replaces the entire screen.
   PageRoute({
-    RouteSettings settings: const RouteSettings()
+    RouteSettings settings: const RouteSettings(),
+    this.fullscreenDialog: false,
   }) : super(settings: settings);
+
+  /// Whether this page route is a full-screen dialog.
+  ///
+  /// In Material and Cupertino, being fullscreen has the effects of making
+  /// the app bars have a close button instead of a back button. On
+  /// iOS, dialogs transitions animate differently and are also not closeable
+  /// with the back swipe gesture.
+  final bool fullscreenDialog;
 
   @override
   bool get opaque => true;

--- a/packages/flutter/test/cupertino/activity_indicator_test.dart
+++ b/packages/flutter/test/cupertino/activity_indicator_test.dart
@@ -4,7 +4,6 @@
 
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/scheduler.dart';
-import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {

--- a/packages/flutter/test/cupertino/bottom_tab_bar_test.dart
+++ b/packages/flutter/test/cupertino/bottom_tab_bar_test.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import 'package:flutter/cupertino.dart';
-import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import '../services/mocks_for_image_cache.dart';

--- a/packages/flutter/test/cupertino/button_test.dart
+++ b/packages/flutter/test/cupertino/button_test.dart
@@ -4,7 +4,6 @@
 
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/scheduler.dart';
-import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 const TextStyle testStyle = const TextStyle(

--- a/packages/flutter/test/cupertino/nav_bar_test.dart
+++ b/packages/flutter/test/cupertino/nav_bar_test.dart
@@ -4,7 +4,6 @@
 
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/rendering.dart';
-import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {

--- a/packages/flutter/test/cupertino/page_test.dart
+++ b/packages/flutter/test/cupertino/page_test.dart
@@ -1,0 +1,144 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/cupertino.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('test iOS page transition', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      new WidgetsApp(
+        color: const Color(0xFFFFFFFF),
+        onGenerateRoute: (RouteSettings settings) {
+          return new CupertinoPageRoute<Null>(
+            settings: settings,
+            builder: (BuildContext context) {
+              final String pageNumber = settings.name == '/' ? "1" : "2";
+              return new Center(child: new Text('Page $pageNumber'));
+            }
+          );
+        },
+      ),
+    );
+
+    final Offset widget1InitialTopLeft = tester.getTopLeft(find.text('Page 1'));
+
+    tester.state<NavigatorState>(find.byType(Navigator)).pushNamed('/next');
+
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 150));
+
+    Offset widget1TransientTopLeft = tester.getTopLeft(find.text('Page 1'));
+    Offset widget2TopLeft = tester.getTopLeft(find.text('Page 2'));
+
+    // Page 1 is moving to the left.
+    expect(widget1TransientTopLeft.dx < widget1InitialTopLeft.dx, true);
+    // Page 1 isn't moving vertically.
+    expect(widget1TransientTopLeft.dy == widget1InitialTopLeft.dy, true);
+    // iOS transition is horizontal only.
+    expect(widget1InitialTopLeft.dy == widget2TopLeft.dy, true);
+    // Page 2 is coming in from the right.
+    expect(widget2TopLeft.dx > widget1InitialTopLeft.dx, true);
+
+    await tester.pumpAndSettle();
+
+    // Page 2 covers page 1.
+    expect(find.text('Page 1'), findsNothing);
+    expect(find.text('Page 2'), isOnstage);
+
+    tester.state<NavigatorState>(find.byType(Navigator)).pop();
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 100));
+
+    widget1TransientTopLeft = tester.getTopLeft(find.text('Page 1'));
+    widget2TopLeft = tester.getTopLeft(find.text('Page 2'));
+
+    // Page 1 is coming back from the left.
+    expect(widget1TransientTopLeft.dx < widget1InitialTopLeft.dx, true);
+    // Page 1 isn't moving vertically.
+    expect(widget1TransientTopLeft.dy == widget1InitialTopLeft.dy, true);
+    // iOS transition is horizontal only.
+    expect(widget1InitialTopLeft.dy == widget2TopLeft.dy, true);
+    // Page 2 is leaving towards the right.
+    expect(widget2TopLeft.dx > widget1InitialTopLeft.dx, true);
+
+    await tester.pumpAndSettle();
+
+    expect(find.text('Page 1'), isOnstage);
+    expect(find.text('Page 2'), findsNothing);
+
+    widget1TransientTopLeft = tester.getTopLeft(find.text('Page 1'));
+
+    // Page 1 is back where it started.
+    expect(widget1InitialTopLeft == widget1TransientTopLeft, true);
+  });
+
+  testWidgets('test iOS fullscreen dialog transition', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      new WidgetsApp(
+        color: const Color(0xFFFFFFFF),
+        onGenerateRoute: (RouteSettings settings) {
+          return new CupertinoPageRoute<Null>(
+            settings: settings,
+            builder: (BuildContext context) {
+              return const Center(child: const Text('Page 1'));
+            }
+          );
+        },
+      ),
+    );
+
+    final Offset widget1InitialTopLeft = tester.getTopLeft(find.text('Page 1'));
+
+    tester.state<NavigatorState>(find.byType(Navigator)).push(new CupertinoPageRoute<Null>(
+      builder: (BuildContext context) {
+        return const Center(child: const Text('Page 2'));
+      },
+      fullscreenDialog: true,
+    ));
+
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 100));
+
+    Offset widget1TransientTopLeft = tester.getTopLeft(find.text('Page 1'));
+    Offset widget2TopLeft = tester.getTopLeft(find.text('Page 2'));
+
+    // Page 1 doesn't move.
+    expect(widget1TransientTopLeft == widget1InitialTopLeft, true);
+    // Fullscreen dialogs transitions vertically only.
+    expect(widget1InitialTopLeft.dx == widget2TopLeft.dx, true);
+    // Page 2 is coming in from the bottom.
+    expect(widget2TopLeft.dy > widget1InitialTopLeft.dy, true);
+
+    await tester.pumpAndSettle();
+
+    // Page 2 covers page 1.
+    expect(find.text('Page 1'), findsNothing);
+    expect(find.text('Page 2'), isOnstage);
+
+    tester.state<NavigatorState>(find.byType(Navigator)).pop();
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 100));
+
+    widget1TransientTopLeft = tester.getTopLeft(find.text('Page 1'));
+    widget2TopLeft = tester.getTopLeft(find.text('Page 2'));
+
+    // Page 1 doesn't move.
+    expect(widget1TransientTopLeft == widget1InitialTopLeft, true);
+    // Fullscreen dialogs transitions vertically only.
+    expect(widget1InitialTopLeft.dx == widget2TopLeft.dx, true);
+    // Page 2 is leaving towards the bottom.
+    expect(widget2TopLeft.dy > widget1InitialTopLeft.dy, true);
+
+    await tester.pumpAndSettle();
+
+    expect(find.text('Page 1'), isOnstage);
+    expect(find.text('Page 2'), findsNothing);
+
+    widget1TransientTopLeft = tester.getTopLeft(find.text('Page 1'));
+
+    // Page 1 is back where it started.
+    expect(widget1InitialTopLeft == widget1TransientTopLeft, true);
+  });
+}

--- a/packages/flutter/test/cupertino/scaffold_test.dart
+++ b/packages/flutter/test/cupertino/scaffold_test.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import 'package:flutter/cupertino.dart';
-import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import '../rendering/rendering_tester.dart';

--- a/packages/flutter/test/cupertino/switch_test.dart
+++ b/packages/flutter/test/cupertino/switch_test.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import 'package:flutter/cupertino.dart';
-import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {


### PR DESCRIPTION
#10468

Mainly extracted components out of the MaterialPageRoute so pages can be pushed and referred to by the CupertinoScaffold without references to material. 