### PR TITLE
For consideration: Change Doctor URL for plugin fix

### DIFF
--- a/packages/flutter_tools/lib/src/doctor.dart
+++ b/packages/flutter_tools/lib/src/doctor.dart
@@ -292,8 +292,8 @@ abstract class IntelliJValidator extends DoctorValidator {
 
     if (_hasIssues(messages)) {
       messages.add(new ValidationMessage(
-        'For information about managing plugins, see\n'
-        'https://www.jetbrains.com/help/idea/managing-plugins.html'
+        'For information about installing plugins, see\n'
+        'https://flutter.io/intellij-setup/#installing-the-plugins'
       ));
     }
 


### PR DESCRIPTION
@devoncarew @mit-mit: I'd like you thoughts about this.

I think it would be better if doctor pointed people needing help with the IJ plugins to our page where we could offer them the steps that most people need to do (install the Flutter plugin), and if they are in an advanced case we can send them to the main IJ page on plugins.

It takes quite a bit of time from the link as it currently stands to find the instructions as to how to do a simple install of Flutter, and leaves ambiguity as to whether the user also needs to install Dart etc. etc.

However there may be ramifications here that I'm not aware of. Thoughts?