### PR TITLE
Allow transitions_perf_test.dart to be run using package:test

### DIFF
--- a/examples/flutter_gallery/test_driver/transitions_perf_test.dart
+++ b/examples/flutter_gallery/test_driver/transitions_perf_test.dart
@@ -174,7 +174,7 @@ Future<Null> runDemos(Iterable<Demo> demos, FlutterDriver driver) async {
   }
 }
 
-void main(List<String> args) {
+void main([List<String> args = const <String>[]]) {
   group('flutter gallery transitions', () {
     FlutterDriver driver;
     setUpAll(() async {


### PR DESCRIPTION
package:test does not allow main() methods to have required
arguments - changing to an optional positional arguments list
fixes this.