### PR TITLE
Refactor Xcode instance lookup

### DIFF
--- a/packages/flutter_tools/lib/src/commands/run.dart
+++ b/packages/flutter_tools/lib/src/commands/run.dart
@@ -177,7 +177,7 @@ class RunCommand extends RunCommandBase {
   void printNoConnectedDevices() {
     super.printNoConnectedDevices();
     if (getCurrentHostPlatform() == HostPlatform.darwin_x64 &&
-        Xcode.instance.isInstalledAndMeetsVersionCheck) {
+        xcode.isInstalledAndMeetsVersionCheck) {
       printStatus('');
       printStatus('To run on a simulator, launch it first: open -a Simulator.app');
       printStatus('');

--- a/packages/flutter_tools/lib/src/ios/ios_workflow.dart
+++ b/packages/flutter_tools/lib/src/ios/ios_workflow.dart
@@ -16,8 +16,6 @@ import 'mac.dart';
 
 IOSWorkflow get iosWorkflow => context.putIfAbsent(IOSWorkflow, () => new IOSWorkflow());
 
-Xcode get xcode => Xcode.instance;
-
 class IOSWorkflow extends DoctorValidator implements Workflow {
   IOSWorkflow() : super('iOS toolchain - develop for iOS devices');
 

--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -35,6 +35,8 @@ const PythonModule kPythonSix = const PythonModule('six');
 
 IMobileDevice get iMobileDevice => context.putIfAbsent(IMobileDevice, () => const IMobileDevice());
 
+Xcode get xcode => context.putIfAbsent(Xcode, () => new Xcode());
+
 class PythonModule {
   const PythonModule(this.name);
 
@@ -119,9 +121,6 @@ class Xcode {
       _isInstalled = false;
     }
   }
-
-  /// Returns [Xcode] active in the current app context.
-  static Xcode get instance => context.putIfAbsent(Xcode, () => new Xcode());
 
   bool get isInstalledAndMeetsVersionCheck => isInstalled && xcodeVersionSatisfactory;
 

--- a/packages/flutter_tools/lib/src/ios/simulators.dart
+++ b/packages/flutter_tools/lib/src/ios/simulators.dart
@@ -45,7 +45,7 @@ class IOSSimulatorUtils {
   static IOSSimulatorUtils get instance => context[IOSSimulatorUtils];
 
   List<IOSSimulator> getAttachedDevices() {
-    if (!Xcode.instance.isInstalledAndMeetsVersionCheck)
+    if (!xcode.isInstalledAndMeetsVersionCheck)
       return <IOSSimulator>[];
 
     return SimControl.instance.getConnectedDevices().map((SimDevice device) {
@@ -587,8 +587,7 @@ class IOSSimulator extends Device {
   }
 
   bool get _xcodeVersionSupportsScreenshot {
-    return Xcode.instance.xcodeMajorVersion > 8 ||
-        (Xcode.instance.xcodeMajorVersion == 8 && Xcode.instance.xcodeMinorVersion >= 2);
+    return xcode.xcodeMajorVersion > 8 || (xcode.xcodeMajorVersion == 8 && xcode.xcodeMinorVersion >= 2);
   }
 
   @override


### PR DESCRIPTION
Use a top-level getter in mac.dart rather than a static instance getter
and a top-level getter in ios_workflow.dart. Makes this code consistent
with how we do context lookups elsewhere.