### PR TITLE
Eliminate direct invocations of idevice_id for iOS

### DIFF
--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -42,7 +42,6 @@ class IOSDevices extends PollingDeviceDiscovery {
 class IOSDevice extends Device {
   IOSDevice(String id, { this.name }) : super(id) {
     _installerPath = _checkForCommand('ideviceinstaller');
-    _listerPath = _checkForCommand('idevice_id');
     _iproxyPath = _checkForCommand('iproxy');
     _debuggerPath = _checkForCommand('idevicedebug');
     _loggerPath = _checkForCommand('idevicesyslog');

--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -57,9 +57,6 @@ class IOSDevice extends Device {
   String _installerPath;
   String get installerPath => _installerPath;
 
-  String _listerPath;
-  String get listerPath => _listerPath;
-
   String _iproxyPath;
   String get iproxyPath => _iproxyPath;
 

--- a/packages/flutter_tools/lib/src/ios/ios_workflow.dart
+++ b/packages/flutter_tools/lib/src/ios/ios_workflow.dart
@@ -22,7 +22,7 @@ class IOSWorkflow extends DoctorValidator implements Workflow {
   @override
   bool get appliesToHostPlatform => platform.isMacOS;
 
-  // We need xcode (+simctl) to list simulator devices, and idevice_id to list real devices.
+  // We need xcode (+simctl) to list simulator devices, and libimobiledevice to list real devices.
   @override
   bool get canListDevices => xcode.isInstalledAndMeetsVersionCheck;
 

--- a/packages/flutter_tools/test/ios/ios_workflow_test.dart
+++ b/packages/flutter_tools/test/ios/ios_workflow_test.dart
@@ -201,11 +201,6 @@ void main() {
       when(xcode.isInstalledAndMeetsVersionCheck).thenReturn(true);
       when(xcode.eulaSigned).thenReturn(true);
 
-      when(processManager.runSync(argThat(contains('idevice_id'))))
-          .thenReturn(exitsHappy);
-      when(processManager.run(argThat(contains('idevice_id')), workingDirectory: any, environment: any))
-          .thenReturn(exitsHappy);
-
       final ValidationResult result = await new IOSWorkflowTestTarget().validate();
       expect(result.type, ValidationType.partial);
     }, overrides: <Type, Generator>{
@@ -221,11 +216,6 @@ void main() {
           .thenReturn('Xcode 8.2.1\nBuild version 8C1002\n');
       when(xcode.isInstalledAndMeetsVersionCheck).thenReturn(true);
       when(xcode.eulaSigned).thenReturn(true);
-
-      when(processManager.runSync(argThat(contains('idevice_id'))))
-          .thenReturn(exitsHappy);
-      when(processManager.run(argThat(contains('idevice_id')), workingDirectory: any, environment: any))
-          .thenReturn(exitsHappy);
 
       ensureDirectoryExists(fs.path.join(homeDirPath, '.cocoapods', 'repos', 'master', 'README.md'));
 


### PR DESCRIPTION
All invocations should go via the IMobileDevice class in mac.dart.