### PR TITLE
Move intrinsics tests to test mode only.

### DIFF
--- a/packages/flutter/lib/src/rendering/box.dart
+++ b/packages/flutter/lib/src/rendering/box.dart
@@ -1587,9 +1587,6 @@ abstract class RenderBox extends RenderObject {
   @override
   BoxConstraints get constraints => super.constraints;
 
-  // We check the intrinsic sizes of each render box once by default.
-  bool _debugNeedsIntrinsicSizeCheck = true;
-
   @override
   void debugAssertDoesMeetConstraints() {
     assert(constraints != null);
@@ -1657,7 +1654,7 @@ abstract class RenderBox extends RenderObject {
           'your fault. Contact support: https://github.com/flutter/flutter/issues/new'
         );
       }
-      if (_debugNeedsIntrinsicSizeCheck || debugCheckIntrinsicSizes) {
+      if (debugCheckIntrinsicSizes) {
         // verify that the intrinsics are sane
         assert(!RenderObject.debugCheckingIntrinsics);
         RenderObject.debugCheckingIntrinsics = true;
@@ -1696,7 +1693,6 @@ abstract class RenderBox extends RenderObject {
         // TODO(ianh): Test that values are internally consistent in more ways than the above.
 
         RenderObject.debugCheckingIntrinsics = false;
-        _debugNeedsIntrinsicSizeCheck = false;
         if (failures.isNotEmpty) {
           assert(failureCount > 0);
           throw new FlutterError(

--- a/packages/flutter/lib/src/rendering/debug.dart
+++ b/packages/flutter/lib/src/rendering/debug.dart
@@ -106,6 +106,9 @@ bool debugPrintMarkNeedsPaintStacks = false;
 bool debugPrintMarkNeedsLayoutStacks = false;
 
 /// Check the intrinsic sizes of each [RenderBox] during layout.
+///
+/// By default this is turned off since these checks are expensive, but it is
+/// enabled by the test framework.
 bool debugCheckIntrinsicSizes = false;
 
 /// Adds [dart:developer.Timeline] events for every [RenderObject] painted.
@@ -161,9 +164,13 @@ void debugPaintPadding(Canvas canvas, Rect outerRect, Rect innerRect, { double o
 /// This function is used by the test framework to ensure that debug variables
 /// haven't been inadvertently changed.
 ///
-/// See [https://docs.flutter.io/flutter/rendering/rendering-library.html] for
+/// See <https://docs.flutter.io/flutter/rendering/rendering-library.html> for
 /// a complete list.
-bool debugAssertAllRenderVarsUnset(String reason) {
+///
+/// The `debugCheckIntrinsicSizesOverride` argument can be provided to override
+/// the expected value for [debugCheckIntrinsicSizes]. (This exists because the
+/// test framework itself overrides this value in some cases.)
+bool debugAssertAllRenderVarsUnset(String reason, { bool debugCheckIntrinsicSizesOverride: false }) {
   assert(() {
     if (debugPaintSizeEnabled ||
         debugPaintBaselinesEnabled ||
@@ -173,7 +180,7 @@ bool debugAssertAllRenderVarsUnset(String reason) {
         debugRepaintTextRainbowEnabled ||
         debugPrintMarkNeedsPaintStacks ||
         debugPrintMarkNeedsLayoutStacks ||
-        debugCheckIntrinsicSizes ||
+        debugCheckIntrinsicSizes != debugCheckIntrinsicSizesOverride ||
         debugProfilePaintsEnabled ||
         debugPaintSizeColor != _kDebugPaintSizeColor ||
         debugPaintSpacingColor != _kDebugPaintSpacingColor ||

--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -477,8 +477,17 @@ class RenderEditable extends RenderBox {
     _layoutText(constraints.maxWidth);
     _caretPrototype = new Rect.fromLTWH(0.0, _kCaretHeightOffset, _kCaretWidth, _preferredLineHeight - 2.0 * _kCaretHeightOffset);
     _selectionRects = null;
+    // We grab _textPainter.size here because assigning to `size` on the next
+    // line will trigger us to validate our intrinsic sizes, which will change
+    // _textPainter's layout because the intrinsic size calculations are
+    // destructive, which would mean we would get different results if we later
+    // used properties on _textPainter in this method.
+    // Other _textPainter state like didExceedMaxLines will also be affected,
+    // though we currently don't use those here.
+    // See also RenderParagraph which has a similar issue.
+    final Size textPainterSize = _textPainter.size;
     size = new Size(constraints.maxWidth, constraints.constrainHeight(_preferredHeight(constraints.maxWidth)));
-    final Size contentSize = new Size(_textPainter.width + _kCaretGap + _kCaretWidth, _textPainter.height);
+    final Size contentSize = new Size(textPainterSize.width + _kCaretGap + _kCaretWidth, textPainterSize.height);
     final double _maxScrollExtent = _getMaxScrollExtent(contentSize);
     _hasVisualOverflow = _maxScrollExtent > 0.0;
     offset.applyViewportDimension(_viewportExtent);

--- a/packages/flutter/lib/src/rendering/paragraph.dart
+++ b/packages/flutter/lib/src/rendering/paragraph.dart
@@ -213,6 +213,7 @@ class RenderParagraph extends RenderBox {
     // us to validate our intrinsic sizes, which will change _textPainter's
     // layout because the intrinsic size calculations are destructive.
     // Other _textPainter state like didExceedMaxLines will also be affected.
+    // See also RenderEditable which has a similar issue.
     final Size textSize = _textPainter.size;
     final bool didOverflowHeight = _textPainter.didExceedMaxLines;
     size = constraints.constrain(textSize);

--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -2862,6 +2862,23 @@ class RenderSemanticsGestureHandler extends RenderProxyBox implements SemanticsA
         break;
     }
   }
+
+  @override
+  void debugFillDescription(List<String> description) {
+    super.debugFillDescription(description);
+    final List<String> gestures = <String>[];
+    if (onTap != null)
+      gestures.add('tap');
+    if (onLongPress != null)
+      gestures.add('long press');
+    if (onHorizontalDragUpdate != null)
+      gestures.add('horizontal scroll');
+    if (onVerticalDragUpdate != null)
+      gestures.add('vertical scroll');
+    if (gestures.isEmpty)
+      gestures.add('<none>');
+    description.add('gestures: ${gestures.join(", ")}');
+  }
 }
 
 /// Add annotations to the [SemanticsNode] for this subtree.

--- a/packages/flutter_test/lib/src/binding.dart
+++ b/packages/flutter_test/lib/src/binding.dart
@@ -95,10 +95,14 @@ abstract class TestWidgetsFlutterBinding extends BindingBase
   /// [debugPrintOverride], which can be overridden by subclasses.
   TestWidgetsFlutterBinding() {
     debugPrint = debugPrintOverride;
+    debugCheckIntrinsicSizes = checkIntrinsicSizes;
   }
 
   @protected
   DebugPrintCallback get debugPrintOverride => debugPrint;
+
+  @protected
+  bool get checkIntrinsicSizes => false;
 
   /// Creates and initializes the binding. This function is
   /// idempotent; calling it a second time will just return the
@@ -460,13 +464,14 @@ abstract class TestWidgetsFlutterBinding extends BindingBase
       debugPrintOverride: debugPrintOverride,
     ));
     assert(debugAssertAllRenderVarsUnset(
-      'The value of a rendering debug variable was changed by the test.'
+      'The value of a rendering debug variable was changed by the test.',
+      debugCheckIntrinsicSizesOverride: checkIntrinsicSizes,
     ));
     assert(debugAssertAllWidgetVarsUnset(
-      'The value of a widget debug variable was changed by the test.'
+      'The value of a widget debug variable was changed by the test.',
     ));
     assert(debugAssertAllSchedulerVarsUnset(
-      'The value of a scheduler debug variable was changed by the test.'
+      'The value of a scheduler debug variable was changed by the test.',
     ));
   }
 
@@ -504,6 +509,9 @@ class AutomatedTestWidgetsFlutterBinding extends TestWidgetsFlutterBinding {
 
   @override
   DebugPrintCallback get debugPrintOverride => debugPrintSynchronously;
+
+  @override
+  bool get checkIntrinsicSizes => true;
 
   @override
   test_package.Timeout get defaultTestTimeout => const test_package.Timeout(const Duration(seconds: 5));


### PR DESCRIPTION
This should improve debug-time performance.