### PR TITLE
Make device discovery asynchronous

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_device.dart
+++ b/packages/flutter_tools/lib/src/android/android_device.dart
@@ -48,7 +48,7 @@ class AndroidDevices extends PollingDeviceDiscovery {
   bool get canListAnything => androidWorkflow.canListDevices;
 
   @override
-  List<Device> pollingGetDevices() => getAdbDevices();
+  Future<List<Device>> pollingGetDevices() async => getAdbDevices();
 }
 
 class AndroidDevice extends Device {

--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -36,7 +36,7 @@ class IOSDevices extends PollingDeviceDiscovery {
   bool get canListAnything => iosWorkflow.canListDevices;
 
   @override
-  List<Device> pollingGetDevices() => IOSDevice.getAttachedDevices();
+  Future<List<Device>> pollingGetDevices() => IOSDevice.getAttachedDevices();
 }
 
 class IOSDevice extends Device {
@@ -81,12 +81,12 @@ class IOSDevice extends Device {
   // iPhone 6s (9.3) [F6CEE7CF-81EB-4448-81B4-1755288C7C11] (Simulator)
   static final RegExp _deviceRegex = new RegExp(r'^(.*) +\((.*)\) +\[(.*)\]$');
 
-  static List<IOSDevice> getAttachedDevices() {
+  static Future<List<IOSDevice>> getAttachedDevices() async {
     if (!xcode.isInstalled)
       return <IOSDevice>[];
 
     final List<IOSDevice> devices = <IOSDevice>[];
-    final Iterable<String> deviceLines = xcode.getAvailableDevices()
+    final Iterable<String> deviceLines = (await xcode.getAvailableDevices())
         .split('\n')
         .map((String line) => line.trim());
     for (String line in deviceLines) {

--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -158,7 +158,12 @@ class Xcode {
     return _xcodeVersionCheckValid(_xcodeMajorVersion, _xcodeMinorVersion);
   }
 
-  String getAvailableDevices() => runSync(<String>['/usr/bin/instruments', '-s', 'devices']);
+  Future<String> getAvailableDevices() async {
+    final RunResult result = await runAsync(<String>['/usr/bin/instruments', '-s', 'devices']);
+    if (result.exitCode != 0)
+      throw new ToolExit('Failed to invoke /usr/bin/instruments. Is Xcode installed?');
+    return result.stdout;
+  }
 }
 
 bool _xcodeVersionCheckValid(int major, int minor) {

--- a/packages/flutter_tools/lib/src/ios/simulators.dart
+++ b/packages/flutter_tools/lib/src/ios/simulators.dart
@@ -37,7 +37,7 @@ class IOSSimulators extends PollingDeviceDiscovery {
   bool get canListAnything => iosWorkflow.canListDevices;
 
   @override
-  List<Device> pollingGetDevices() => IOSSimulatorUtils.instance.getAttachedDevices();
+  Future<List<Device>> pollingGetDevices() async => IOSSimulatorUtils.instance.getAttachedDevices();
 }
 
 class IOSSimulatorUtils {

--- a/packages/flutter_tools/test/ios/devices_test.dart
+++ b/packages/flutter_tools/test/ios/devices_test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:async';
+
 import 'package:file/file.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/ios/devices.dart';
@@ -30,15 +32,15 @@ void main() {
 
     testUsingContext('return no devices if Xcode is not installed', () async {
       when(mockXcode.isInstalled).thenReturn(false);
-      expect(IOSDevice.getAttachedDevices(), isEmpty);
+      expect(await IOSDevice.getAttachedDevices(), isEmpty);
     }, overrides: <Type, Generator>{
       Xcode: () => mockXcode,
     });
 
     testUsingContext('returns no devices if none are attached', () async {
       when(mockXcode.isInstalled).thenReturn(true);
-      when(mockXcode.getAvailableDevices()).thenReturn('');
-      final List<IOSDevice> devices = IOSDevice.getAttachedDevices();
+      when(mockXcode.getAvailableDevices()).thenReturn(new Future<String>.value(''));
+      final List<IOSDevice> devices = await IOSDevice.getAttachedDevices();
       expect(devices, isEmpty);
     }, overrides: <Type, Generator>{
       Xcode: () => mockXcode,
@@ -46,7 +48,7 @@ void main() {
 
     testUsingContext('returns attached devices', () async {
       when(mockXcode.isInstalled).thenReturn(true);
-      when(mockXcode.getAvailableDevices()).thenReturn('''
+      when(mockXcode.getAvailableDevices()).thenReturn(new Future<String>.value('''
 Known Devices:
 je-mappelle-horse [ED6552C4-B774-5A4E-8B5A-606710C87C77]
 La tele me regarde (10.3.2) [98206e7a4afd4aedaff06e687594e089dede3c44]
@@ -55,8 +57,8 @@ iPhone 6 Plus (9.3) [FBA880E6-4020-49A5-8083-DCD50CA5FA09] (Simulator)
 iPhone 6s (11.0) [E805F496-FC6A-4EA4-92FF-B7901FF4E7CC] (Simulator)
 iPhone 7 (11.0) + Apple Watch Series 2 - 38mm (4.0) [60027FDD-4A7A-42BF-978F-C2209D27AD61] (Simulator)
 iPhone SE (11.0) [667E8DCD-5DCD-4C80-93A9-60D1D995206F] (Simulator)
-''');
-      final List<IOSDevice> devices = IOSDevice.getAttachedDevices();
+'''));
+      final List<IOSDevice> devices = await IOSDevice.getAttachedDevices();
       expect(devices, hasLength(2));
       expect(devices[0].id, '98206e7a4afd4aedaff06e687594e089dede3c44');
       expect(devices[0].name, 'La tele me regarde');

--- a/packages/flutter_tools/test/src/mocks.dart
+++ b/packages/flutter_tools/test/src/mocks.dart
@@ -37,7 +37,7 @@ class MockPollingDeviceDiscovery extends PollingDeviceDiscovery {
   MockPollingDeviceDiscovery() : super('mock');
 
   @override
-  List<Device> pollingGetDevices() => _devices;
+  Future<List<Device>> pollingGetDevices() async => _devices;
 
   @override
   bool get supportsPlatform => true;
@@ -52,7 +52,7 @@ class MockPollingDeviceDiscovery extends PollingDeviceDiscovery {
   }
 
   @override
-  List<Device> get devices => _devices;
+  Future<List<Device>> get devices async => _devices;
 
   @override
   Stream<Device> get onAdded => _onAddedController.stream;


### PR DESCRIPTION
Migrates DeviceDiscovery.devices and all device-specific lookup to be
asynchronous.

This change only migrates iOS physical device lookup off runAsync().
Other device types will follow in subsequent PRs.