### PR TITLE
Text selection handles track scrolled text fields

### DIFF
--- a/packages/flutter/lib/src/foundation/tree_diagnostics_mixin.dart
+++ b/packages/flutter/lib/src/foundation/tree_diagnostics_mixin.dart
@@ -4,23 +4,71 @@
 
 import 'package:meta/meta.dart';
 
+import 'print.dart';
+
 /// A mixin that helps dump string representations of trees.
 abstract class TreeDiagnosticsMixin {
   // This class is intended to be used as a mixin, and should not be
   // extended directly.
   factory TreeDiagnosticsMixin._() => null;
 
+  /// A brief description of this object, usually just the [runtimeType] and the
+  /// [hashCode].
+  ///
+  /// See also:
+  ///
+  ///  * [toStringShallow], for a detailed description of the object.
+  ///  * [toStringDeep], for a description of the subtree rooted at this object.
   @override
   String toString() => '$runtimeType#$hashCode';
 
+  /// Returns a one-line detailed description of the object.
+  ///
+  /// This description includes everything from [debugFillDescription], but does
+  /// not recurse to any children.
+  ///
+  /// The [toStringShallow] method can take an argument, which is the string to
+  /// place between each part obtained from [debugFillDescription]. Passing a
+  /// string such as `'\n '` will result in a multiline string that indents the
+  /// properties of the object below its name (as per [toString]).
+  ///
+  /// See also:
+  ///
+  ///  * [toString], for a brief description of the object.
+  ///  * [toStringDeep], for a description of the subtree rooted at this object.
+  String toStringShallow([String joiner = '; ']) {
+    final StringBuffer result = new StringBuffer();
+    result.write(toString());
+    result.write(joiner);
+    final List<String> description = <String>[];
+    debugFillDescription(description);
+    result.write(description.join(joiner));
+    return result.toString();
+  }
+
   /// Returns a string representation of this node and its descendants.
+  ///
+  /// This includes the information from [debugFillDescription], and then
+  /// recurses into the children using [debugDescribeChildren].
+  ///
+  /// The [toStringDeep] method takes arguments, but those are intended for
+  /// internal use when recursing to the descendants, and so can be ignored.
+  ///
+  /// See also:
+  ///
+  ///  * [toString], for a brief description of the object but not its children.
+  ///  * [toStringShallow], for a detailed description of the object but not its
+  ///    children.
   String toStringDeep([String prefixLineOne = '', String prefixOtherLines = '']) {
     String result = '$prefixLineOne$this\n';
     final String childrenDescription = debugDescribeChildren(prefixOtherLines);
     final String descriptionPrefix = childrenDescription != '' ? '$prefixOtherLines \u2502 ' : '$prefixOtherLines   ';
     final List<String> description = <String>[];
     debugFillDescription(description);
-    result += description.map((String description) => '$descriptionPrefix$description\n').join();
+    result += description
+      .expand((String description) => debugWordWrap(description, 65, wrapIndent: '  '))
+      .map<String>((String line) => "$descriptionPrefix$line\n")
+      .join();
     if (childrenDescription == '') {
       final String prefix = prefixOtherLines.trimRight();
       if (prefix != '')
@@ -31,7 +79,8 @@ abstract class TreeDiagnosticsMixin {
     return result;
   }
 
-  /// Add additional information to the given description for use by [toStringDeep].
+  /// Add additional information to the given description for use by
+  /// [toStringDeep] and [toStringShallow].
   @protected
   @mustCallSuper
   void debugFillDescription(List<String> description) { }

--- a/packages/flutter/lib/src/rendering/box.dart
+++ b/packages/flutter/lib/src/rendering/box.dart
@@ -1829,7 +1829,7 @@ abstract class RenderBox extends RenderObject {
   /// Subclasses that apply transforms during painting should override this
   /// function to factor those transforms into the calculation.
   ///
-  /// The RenderBox implementation takes care of adjusting the matrix for the
+  /// The [RenderBox] implementation takes care of adjusting the matrix for the
   /// position of the given child as determined during layout and stored on the
   /// child's [parentData] in the [BoxParentData.offset] field.
   @override

--- a/packages/flutter/lib/src/rendering/debug.dart
+++ b/packages/flutter/lib/src/rendering/debug.dart
@@ -123,8 +123,13 @@ bool debugCheckIntrinsicSizes = false;
 bool debugProfilePaintsEnabled = false;
 
 
-/// Returns a list of strings representing the given transform in a format useful for [RenderObject.debugFillDescription].
+/// Returns a list of strings representing the given transform in a format
+/// useful for [RenderObject.debugFillDescription].
+///
+/// If the argument is null, returns a list with the single string "null".
 List<String> debugDescribeTransform(Matrix4 transform) {
+  if (transform == null)
+    return const <String>['null'];
   final List<String> matrix = transform.toString().split('\n').map((String s) => '  $s').toList();
   matrix.removeLast();
   return matrix;

--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -30,8 +30,9 @@ typedef void SelectionChangedHandler(TextSelection selection, RenderEditable ren
 /// Used by [RenderEditable.onCaretChanged].
 typedef void CaretChangedHandler(Rect caretRect);
 
-/// Represents a global screen coordinate of the point in a selection, and the
-/// text direction at that point.
+/// Represents the coordinates of the point in a selection, and the text
+/// direction at that point, relative to top left of the [RenderEditable] that
+/// holds the selection.
 @immutable
 class TextSelectionPoint {
   /// Creates a description of a point in a text selection.
@@ -40,7 +41,8 @@ class TextSelectionPoint {
   const TextSelectionPoint(this.point, this.direction)
       : assert(point != null);
 
-  /// Screen coordinates of the lower left or lower right corner of the selection.
+  /// Coordinates of the lower left or lower right corner of the selection,
+  /// relative to the top left of the [RenderEditable] object.
   final Offset point;
 
   /// Direction of the text at this edge of the selection.
@@ -316,7 +318,7 @@ class RenderEditable extends RenderBox {
 
   bool _hasVisualOverflow = false;
 
-  /// Returns the global coordinates of the endpoints of the given selection.
+  /// Returns the local coordinates of the endpoints of the given selection.
   ///
   /// If the selection is collapsed (and therefore occupies a single point), the
   /// returned list is of length one. Otherwise, the selection is not collapsed
@@ -333,14 +335,14 @@ class RenderEditable extends RenderBox {
       // TODO(mpcomplete): This doesn't work well at an RTL/LTR boundary.
       final Offset caretOffset = _textPainter.getOffsetForCaret(selection.extent, _caretPrototype);
       final Offset start = new Offset(0.0, _preferredLineHeight) + caretOffset + paintOffset;
-      return <TextSelectionPoint>[new TextSelectionPoint(localToGlobal(start), null)];
+      return <TextSelectionPoint>[new TextSelectionPoint(start, null)];
     } else {
       final List<ui.TextBox> boxes = _textPainter.getBoxesForSelection(selection);
       final Offset start = new Offset(boxes.first.start, boxes.first.bottom) + paintOffset;
       final Offset end = new Offset(boxes.last.end, boxes.last.bottom) + paintOffset;
       return <TextSelectionPoint>[
-        new TextSelectionPoint(localToGlobal(start), boxes.first.direction),
-        new TextSelectionPoint(localToGlobal(end), boxes.last.direction),
+        new TextSelectionPoint(start, boxes.first.direction),
+        new TextSelectionPoint(end, boxes.last.direction),
       ];
     }
   }

--- a/packages/flutter/lib/src/rendering/layer.dart
+++ b/packages/flutter/lib/src/rendering/layer.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:collection';
 import 'dart:ui' as ui show ImageFilter, Picture, SceneBuilder;
 import 'dart:ui' show Offset;
 
@@ -90,7 +91,7 @@ abstract class Layer extends AbstractNode with TreeDiagnosticsMixin {
 
   /// Override this method to upload this layer to the engine.
   ///
-  /// The layerOffset is the accumulated offset of this layer's parent from the
+  /// The `layerOffset` is the accumulated offset of this layer's parent from the
   /// origin of the builder's coordinate system.
   void addToScene(ui.SceneBuilder builder, Offset layerOffset);
 
@@ -117,6 +118,16 @@ abstract class Layer extends AbstractNode with TreeDiagnosticsMixin {
 ///
 /// Picture layers are always leaves in the layer tree.
 class PictureLayer extends Layer {
+  PictureLayer(this.canvasBounds);
+
+  /// The bounds that were used for the canvas that drew this layer's [picture].
+  ///
+  /// This is purely advisory. It is included in the information dumped with
+  /// [dumpLayerTree] (which can be triggered by pressing "L" when using
+  /// "flutter run" at the console), which can help debug why certain drawing
+  /// commands are being culled.
+  final Rect canvasBounds;
+
   /// The picture recorded for this layer.
   ///
   /// The picture's coodinate system matches this layer's coodinate system.
@@ -149,6 +160,12 @@ class PictureLayer extends Layer {
   @override
   void addToScene(ui.SceneBuilder builder, Offset layerOffset) {
     builder.addPicture(layerOffset, picture, isComplexHint: isComplexHint, willChangeHint: willChangeHint);
+  }
+
+  @override
+  void debugFillDescription(List<String> description) {
+    super.debugFillDescription(description);
+    description.add('paint bounds: $canvasBounds');
   }
 }
 
@@ -357,6 +374,44 @@ class ContainerLayer extends Layer {
     }
   }
 
+  /// Applies the transform that would be applied when compositing the given
+  /// child to the given matrix.
+  ///
+  /// Specifically, this should apply the transform that is applied to child's
+  /// _origin_. When using [applyTransform] with a chain of layers, results will
+  /// be unreliable unless the deepest layer in the chain collapses the
+  /// `layerOffset` in [addToScene] to zero, meaning that it passes
+  /// [Offset.zero] to its children, and bakes any incoming `layerOffset` into
+  /// the [SceneBuilder] as (for instance) a transform (which is then also
+  /// included in the transformation applied by [applyTransform]).
+  ///
+  /// For example, if [addToScene] applies the `layerOffset` and then
+  /// passes [Offset.zero] to the children, then it should be included in the
+  /// transform applied here, whereas if [addToScene] just passes the
+  /// `layerOffset` to the child, then it should not be included in the
+  /// transform applied here.
+  ///
+  /// This method is only valid immediately after [addToScene] has been called,
+  /// before any of the properties have been changed.
+  ///
+  /// The default implementation does nothing, since [ContainerLayer], by
+  /// default, composits its children at the origin of the [ContainerLayer]
+  /// itself.
+  ///
+  /// The `child` argument should generally not be null, since in principle a
+  /// layer could transform each child independently. However, certain layers
+  /// may explicitly allow null as a value, for example if they know that they
+  /// transform all their children identically.
+  ///
+  /// The `transform` argument must not be null.
+  ///
+  /// Used by [FollowerLayer] to transform its child to a [LeaderLayer]'s
+  /// position.
+  void applyTransform(Layer child, Matrix4 transform) {
+    assert(child != null);
+    assert(transform != null);
+  }
+
   @override
   String debugDescribeChildren(String prefix) {
     if (firstChild == null)
@@ -391,13 +446,17 @@ class ContainerLayer extends Layer {
 class OffsetLayer extends ContainerLayer {
   /// Creates an offset layer.
   ///
-  /// By default, [offset] is zero.
+  /// By default, [offset] is zero. It must be non-null before the compositing
+  /// phase of the pipeline.
   OffsetLayer({ this.offset: Offset.zero });
 
   /// Offset from parent in the parent's coordinate system.
   ///
   /// The scene must be explicitly recomposited after this property is changed
   /// (as described at [Layer]).
+  ///
+  /// The [offset] property must be non-null before the compositing phase of the
+  /// pipeline.
   Offset offset;
 
   @override
@@ -411,7 +470,6 @@ class OffsetLayer extends ContainerLayer {
     description.add('offset: $offset');
   }
 }
-
 
 /// A composite layer that clips its children using a rectangle.
 class ClipRectLayer extends ContainerLayer {
@@ -497,33 +555,49 @@ class ClipPathLayer extends ContainerLayer {
   }
 }
 
-/// A composited layer that applies a transformation matrix to its children.
+/// A composited layer that applies a given transformation matrix to its
+/// children.
+///
+/// This class inherits from [OffsetLayer] to make it one of the layers that
+/// can be used at the root of a [RenderObject] hierarchy.
 class TransformLayer extends OffsetLayer {
   /// Creates a transform layer.
   ///
-  /// The [transform] property must be non-null before the compositing phase of
-  /// the pipeline.
-  TransformLayer({
-    this.transform
-  });
+  /// The [transform] and [offset] properties must be non-null before the
+  /// compositing phase of the pipeline.
+  TransformLayer({ this.transform, Offset offset: Offset.zero }) : super(offset: offset);
 
   /// The matrix to apply.
   ///
   /// The scene must be explicitly recomposited after this property is changed
   /// (as described at [Layer]).
+  ///
+  /// This transform is applied before [offset], if both are set.
+  ///
+  /// The [transform] property must be non-null before the compositing phase of
+  /// the pipeline.
   Matrix4 transform;
+
+  Matrix4 _lastEffectiveTransform;
 
   @override
   void addToScene(ui.SceneBuilder builder, Offset layerOffset) {
-    assert(offset == Offset.zero);
-    Matrix4 effectiveTransform = transform;
-    if (layerOffset != Offset.zero) {
-      effectiveTransform = new Matrix4.translationValues(layerOffset.dx, layerOffset.dy, 0.0)
-        ..multiply(transform);
+    _lastEffectiveTransform = transform;
+    final Offset totalOffset = offset + layerOffset;
+    if (totalOffset != Offset.zero) {
+      _lastEffectiveTransform = new Matrix4.translationValues(totalOffset.dx, totalOffset.dy, 0.0)
+        ..multiply(_lastEffectiveTransform);
     }
-    builder.pushTransform(effectiveTransform.storage);
+    builder.pushTransform(_lastEffectiveTransform.storage);
     addChildrenToScene(builder, Offset.zero);
     builder.pop();
+  }
+
+  @override
+  void applyTransform(Layer child, Matrix4 transform) {
+    assert(child != null);
+    assert(transform != null);
+    transform.multiply(_lastEffectiveTransform);
   }
 
   @override
@@ -565,7 +639,7 @@ class OpacityLayer extends ContainerLayer {
   }
 }
 
-/// A composited layer that applies a shader to hits children.
+/// A composited layer that applies a shader to its children.
 class ShaderMaskLayer extends ContainerLayer {
   /// Creates a shader mask layer.
   ///
@@ -680,5 +754,305 @@ class PhysicalModelLayer extends ContainerLayer {
   void debugFillDescription(List<String> description) {
     super.debugFillDescription(description);
     description.add('clipRRect: $clipRRect');
+  }
+}
+
+/// An object that a [LeaderLayer] can register with.
+///
+/// An instance of this class should be provided as the [LeaderLayer.link] and
+/// the [FollowerLayer.link] properties to cause the [FollowerLayer] to follow
+/// the [LeaderLayer].
+///
+/// See also:
+///
+///  * [CompositedTransformTarget], the widget that creates a [LeaderLayer].
+///  * [CompositedTransformFollower], the widget that creates a [FollowerLayer].
+///  * [RenderLeaderLayer] and [RenderFollowerLayer], the corresponding
+///    render objects.
+class LayerLink {
+  /// The currently-registered [LeaderLayer], if any.
+  LeaderLayer get leader => _leader;
+  LeaderLayer _leader;
+
+  @override
+  String toString() => '$runtimeType#$hashCode(${ _leader != null ? "<linked>" : "<dangling>" })';
+}
+
+/// A composited layer that can be followed by a [FollowerLayer].
+///
+/// This layer collapses the accumulated offset into a transform and passes
+/// [Offset.zero] to its child layers in the [addToScene]/[addChildrenToScene]
+/// methods, so that [applyTransform] will work reliably.
+class LeaderLayer extends ContainerLayer {
+  /// Creates a leader layer.
+  ///
+  /// The [link] property must not be null, and must not have been provided to
+  /// any other [LeaderLayer] layers that are [attached] to the layer tree at
+  /// the same time.
+  ///
+  /// The [offset] property must be non-null before the compositing phase of the
+  /// pipeline.
+  LeaderLayer({ @required this.link, this.offset: Offset.zero }) : assert(link != null);
+
+  /// The object with which this layer should register.
+  ///
+  /// The link will be established when this layer is [attach]ed, and will be
+  /// cleared when this layer is [detach]ed.
+  final LayerLink link;
+
+  /// Offset from parent in the parent's coordinate system.
+  ///
+  /// The scene must be explicitly recomposited after this property is changed
+  /// (as described at [Layer]).
+  ///
+  /// The [offset] property must be non-null before the compositing phase of the
+  /// pipeline.
+  Offset offset;
+
+  @override
+  void attach(Object owner) {
+    super.attach(owner);
+    assert(link.leader == null);
+    _lastOffset = null;
+    link._leader = this;
+  }
+
+  @override
+  void detach() {
+    assert(link.leader == this);
+    link._leader = null;
+    _lastOffset = null;
+    super.detach();
+  }
+
+  /// The offset the last time this layer was composited.
+  ///
+  /// This is reset to null when the layer is attached or detached, to help
+  /// catch cases where the follower layer ends up before the leader layer, but
+  /// not every case can be detected.
+  Offset _lastOffset;
+
+  @override
+  void addToScene(ui.SceneBuilder builder, Offset layerOffset) {
+    assert(offset != null);
+    _lastOffset = offset + layerOffset;
+    if (_lastOffset != Offset.zero)
+      builder.pushTransform(new Matrix4.translationValues(_lastOffset.dx, _lastOffset.dy, 0.0).storage);
+    addChildrenToScene(builder, Offset.zero);
+    if (_lastOffset != Offset.zero)
+      builder.pop();
+  }
+
+  /// Applies the transform that would be applied when compositing the given
+  /// child to the given matrix.
+  ///
+  /// See [ContainerLayer.applyTransform] for details.
+  ///
+  /// The `child` argument may be null, as the same transform is applied to all
+  /// children.
+  @override
+  void applyTransform(Layer child, Matrix4 transform) {
+    assert(_lastOffset != null);
+    if (_lastOffset != Offset.zero)
+      transform.translate(_lastOffset.dx, _lastOffset.dy);
+  }
+
+  @override
+  void debugFillDescription(List<String> description) {
+    super.debugFillDescription(description);
+    description.add('offset: $offset');
+    description.add('link: $link');
+  }
+}
+
+/// A composited layer that applies a transformation matrix to its children such
+/// that they are positioned to match a [LeaderLayer].
+///
+/// If any of the ancestors of this layer have a degenerate matrix (e.g. scaling
+/// by zero), then the [FollowerLayer] will not be able to transform its child
+/// to the coordinate space of the [Leader].
+///
+/// A [linkedOffset] property can be provided to further offset the child layer
+/// from the leader layer, for example if the child is to follow the linked
+/// layer at a distance rather than directly overlapping it.
+class FollowerLayer extends ContainerLayer {
+  /// Creates a follower layer.
+  ///
+  /// The [link] property must not be null.
+  ///
+  /// The [unlinkedOffset], [linkedOffset], and [showWhenUnlinked] properties
+  /// must be non-null before the compositing phase of the pipeline.
+  FollowerLayer({
+    @required this.link,
+    this.showWhenUnlinked: true,
+    this.unlinkedOffset: Offset.zero,
+    this.linkedOffset: Offset.zero,
+  }) : assert(link != null);
+
+  /// The link to the [LeaderLayer].
+  ///
+  /// The same object should be provided to a [LeaderLayer] that is earlier in
+  /// the layer tree. When this layer is composited, it will apply a transform
+  /// that moves its children to match the position of the [LeaderLayer].
+  final LayerLink link;
+
+  /// Whether to show the layer's contents when the [link] does not point to a
+  /// [LeaderLayer].
+  ///
+  /// When the layer is linked, children layers are positioned such that they
+  /// have the same global position as the linked [LeaderLayer].
+  ///
+  /// When the layer is not linked, then: if [showWhenUnlinked] is true,
+  /// children are positioned as if the [FollowerLayer] was a [ContainerLayer];
+  /// if it is false, then children are hidden.
+  ///
+  /// The [showWhenUnlinked] property must be non-null before the compositing
+  /// phase of the pipeline.
+  bool showWhenUnlinked;
+
+  /// Offset from parent in the parent's coordinate system, used when the layer
+  /// is not linked to a [LeaderLayer].
+  ///
+  /// The scene must be explicitly recomposited after this property is changed
+  /// (as described at [Layer]).
+  ///
+  /// The [unlinkedOffset] property must be non-null before the compositing
+  /// phase of the pipeline.
+  ///
+  /// See also:
+  ///
+  ///  * [linkedOffset], for when the layers are linked.
+  Offset unlinkedOffset;
+
+  /// Offset from the origin of the leader layer to the origin of the child
+  /// layers, used when the layer is linked to a [LeaderLayer].
+  ///
+  /// The scene must be explicitly recomposited after this property is changed
+  /// (as described at [Layer]).
+  ///
+  /// The [linkedOffset] property must be non-null before the compositing phase
+  /// of the pipeline.
+  ///
+  /// See also:
+  ///
+  ///  * [unlinkedOffset], for when the layer is not linked.
+  Offset linkedOffset;
+
+  Offset _lastOffset;
+  Matrix4 _lastTransform;
+
+  /// The transform that was used during the last composition phase.
+  ///
+  /// If the [link] was not linked to a [LeaderLayer], or if this layer has
+  /// a degerenate matrix applied, then this will be null.
+  ///
+  /// This method returns a new [Matrix4] instance each time it is invoked.
+  Matrix4 getLastTransform() {
+    if (_lastTransform == null)
+      return null;
+    final Matrix4 result = new Matrix4.translationValues(-_lastOffset.dx, -_lastOffset.dy, 0.0);
+    result.multiply(_lastTransform);
+    return result;
+  }
+
+  /// Call [applyTransform] for each layer in the provided list.
+  ///
+  /// The list is in reverse order (deepest first). The first layer will be
+  /// treated as the child of the second, and so forth. The first layer in the
+  /// list won't have [applyTransform] called on it. The first layer may be
+  /// null.
+  Matrix4 _collectTransformForLayerChain(List<ContainerLayer> layers) {
+    // Initialize our result matrix.
+    final Matrix4 result = new Matrix4.identity();
+    // Apply each layer to the matrix in turn, starting from the last layer,
+    // and providing the previous layer as the child.
+    for (int index = layers.length - 1; index > 0; index -= 1)
+      layers[index].applyTransform(layers[index - 1], result);
+    return result;
+  }
+
+  /// Populate [_lastTransform] given the current state of the tree.
+  void _establishTransform() {
+    assert(link != null);
+    _lastTransform = null;
+    // Check to see if we are linked.
+    if (link.leader == null)
+      return;
+    // If we're linked, check the link is valid.
+    assert(link.leader.owner == owner, 'Linked LeaderLayer anchor is not in the same layer tree as the FollowerLayer.');
+    assert(link.leader._lastOffset != null, 'LeaderLayer anchor must come before FollowerLayer in paint order, but the reverse was true.');
+    // Collect all our ancestors into a Set so we can recognize them.
+    final Set<Layer> ancestors = new HashSet<Layer>();
+    Layer ancestor = parent;
+    while (ancestor != null) {
+      ancestors.add(ancestor);
+      ancestor = ancestor.parent;
+    }
+    // Collect all the layers from a hypothetical child (null) of the target
+    // layer up to the common ancestor layer.
+    ContainerLayer layer = link.leader;
+    final List<ContainerLayer> forwardLayers = <ContainerLayer>[null, layer];
+    do {
+      layer = layer.parent;
+      forwardLayers.add(layer);
+    } while (!ancestors.contains(layer));
+    ancestor = layer;
+    // Collect all the layers from this layer up to the common ancestor layer.
+    layer = this;
+    final List<ContainerLayer> inverseLayers = <ContainerLayer>[layer];
+    do {
+      layer = layer.parent;
+      inverseLayers.add(layer);
+    } while (layer != ancestor);
+    // Establish the forward and backward matrices given these lists of layers.
+    final Matrix4 forwardTransform = _collectTransformForLayerChain(forwardLayers);
+    final Matrix4 inverseTransform = _collectTransformForLayerChain(inverseLayers);
+    if (inverseTransform.invert() == 0.0) {
+      // We are in a degenerate transform, so there's not much we can do.
+      return;
+    }
+    // Combine the matrices and store the result.
+    inverseTransform.multiply(forwardTransform);
+    inverseTransform.translate(linkedOffset.dx, linkedOffset.dy);
+    _lastTransform = inverseTransform;
+  }
+
+  @override
+  void addToScene(ui.SceneBuilder builder, Offset layerOffset) {
+    assert(link != null);
+    assert(showWhenUnlinked != null);
+    if (link.leader == null && !showWhenUnlinked) {
+      _lastTransform = null;
+      _lastOffset = null;
+      return;
+    }
+    _establishTransform();
+    if (_lastTransform != null) {
+      builder.pushTransform(_lastTransform.storage);
+      addChildrenToScene(builder, Offset.zero);
+      builder.pop();
+      _lastOffset = unlinkedOffset + layerOffset;
+    } else {
+      _lastOffset = null;
+      addChildrenToScene(builder, unlinkedOffset + layerOffset);
+    }
+  }
+
+  @override
+  void applyTransform(Layer child, Matrix4 transform) {
+    assert(child != null);
+    assert(transform != null);
+    if (_lastTransform != null)
+      transform.multiply(_lastTransform);
+  }
+
+  @override
+  void debugFillDescription(List<String> description) {
+    super.debugFillDescription(description);
+    description.add('link: $link');
+    if (_lastTransform != null) {
+      description.add('transform:');
+      description.addAll(debugDescribeTransform(getLastTransform()));
+    }
   }
 }

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -263,6 +263,7 @@ class EditableTextState extends State<EditableText> implements TextInputClient {
   TextSelectionOverlay _selectionOverlay;
 
   final ScrollController _scrollController = new ScrollController();
+  final LayerLink _layerLink = new LayerLink();
   bool _didAutoFocus = false;
 
   // State lifecycle:
@@ -272,6 +273,7 @@ class EditableTextState extends State<EditableText> implements TextInputClient {
     super.initState();
     widget.controller.addListener(_didChangeTextEditingValue);
     widget.focusNode.addListener(_handleFocusChanged);
+    _scrollController.addListener(() { _selectionOverlay?.updateForScroll(); });
   }
 
   @override
@@ -436,6 +438,7 @@ class EditableTextState extends State<EditableText> implements TextInputClient {
         context: context,
         value: _value,
         debugRequiredFor: widget,
+        layerLink: _layerLink,
         renderObject: renderObject,
         onSelectionOverlayChanged: _handleSelectionOverlayChanged,
         selectionControls: widget.selectionControls,
@@ -538,19 +541,22 @@ class EditableTextState extends State<EditableText> implements TextInputClient {
       controller: _scrollController,
       physics: const ClampingScrollPhysics(),
       viewportBuilder: (BuildContext context, ViewportOffset offset) {
-        return new _Editable(
-          value: _value,
-          style: widget.style,
-          cursorColor: widget.cursorColor,
-          showCursor: _showCursor,
-          maxLines: widget.maxLines,
-          selectionColor: widget.selectionColor,
-          textScaleFactor: widget.textScaleFactor ?? MediaQuery.of(context, nullOk: true)?.textScaleFactor ?? 1.0,
-          textAlign: widget.textAlign,
-          obscureText: widget.obscureText,
-          offset: offset,
-          onSelectionChanged: _handleSelectionChanged,
-          onCaretChanged: _handleCaretChanged,
+        return new CompositedTransformTarget(
+          link: _layerLink,
+          child: new _Editable(
+            value: _value,
+            style: widget.style,
+            cursorColor: widget.cursorColor,
+            showCursor: _showCursor,
+            maxLines: widget.maxLines,
+            selectionColor: widget.selectionColor,
+            textScaleFactor: widget.textScaleFactor ?? MediaQuery.of(context, nullOk: true)?.textScaleFactor ?? 1.0,
+            textAlign: widget.textAlign,
+            obscureText: widget.obscureText,
+            offset: offset,
+            onSelectionChanged: _handleSelectionChanged,
+            onCaretChanged: _handleCaretChanged,
+          ),
         );
       },
     );

--- a/packages/flutter/lib/src/widgets/scroll_controller.dart
+++ b/packages/flutter/lib/src/widgets/scroll_controller.dart
@@ -24,6 +24,10 @@ import 'scroll_position_with_single_context.dart';
 /// to an individual [Scrollable] widget. To use a custom [ScrollPosition],
 /// subclass [ScrollController] and override [createScrollPosition].
 ///
+/// A [ScrollController] is a [Listenable]. It notifies its listeners whenever
+/// any of the attached [ScrollPosition]s notify _their_ listeners (i.e.
+/// whenever any of them scroll).
+///
 /// Typically used with [ListView], [GridView], [CustomScrollView].
 ///
 /// See also:

--- a/packages/flutter/test/widgets/composited_transform_test.dart
+++ b/packages/flutter/test/widgets/composited_transform_test.dart
@@ -1,0 +1,166 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter/widgets.dart';
+
+void main() {
+  testWidgets('Composited transforms - only offsets', (WidgetTester tester) async {
+    final LayerLink link = new LayerLink();
+    final GlobalKey key = new GlobalKey();
+    await tester.pumpWidget(
+      new Stack(
+        children: <Widget>[
+          new Positioned(
+            left: 123.0,
+            top: 456.0,
+            child: new CompositedTransformTarget(
+              link: link,
+              child: new Container(height: 10.0, width: 10.0),
+            ),
+          ),
+          new Positioned(
+            left: 787.0,
+            top: 343.0,
+            child: new CompositedTransformFollower(
+              link: link,
+              child: new Container(key: key, height: 10.0, width: 10.0),
+            ),
+          ),
+        ],
+      ),
+    );
+    final RenderBox box = key.currentContext.findRenderObject();
+    expect(box.localToGlobal(Offset.zero), const Offset(123.0, 456.0));
+  });
+
+  testWidgets('Composited transforms - with rotations', (WidgetTester tester) async {
+    final LayerLink link = new LayerLink();
+    final GlobalKey key1 = new GlobalKey();
+    final GlobalKey key2 = new GlobalKey();
+    await tester.pumpWidget(
+      new Stack(
+        children: <Widget>[
+          new Positioned(
+            top: 123.0,
+            left: 456.0,
+            child: new Transform.rotate(
+              angle: 1.0, // radians
+              child: new CompositedTransformTarget(
+                link: link,
+                child: new Container(key: key1, height: 10.0, width: 10.0),
+              ),
+            ),
+          ),
+          new Positioned(
+            top: 787.0,
+            left: 343.0,
+            child: new Transform.rotate(
+              angle: -0.3, // radians
+              child: new CompositedTransformFollower(
+                link: link,
+                child: new Container(key: key2, height: 10.0, width: 10.0),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+    final RenderBox box1 = key1.currentContext.findRenderObject();
+    final RenderBox box2 = key2.currentContext.findRenderObject();
+    final Offset position1 = box1.localToGlobal(Offset.zero);
+    final Offset position2 = box2.localToGlobal(Offset.zero);
+    expect(position1.dx, moreOrLessEquals(position2.dx));
+    expect(position1.dy, moreOrLessEquals(position2.dy));
+  });
+
+  testWidgets('Composited transforms - nested', (WidgetTester tester) async {
+    final LayerLink link = new LayerLink();
+    final GlobalKey key1 = new GlobalKey();
+    final GlobalKey key2 = new GlobalKey();
+    await tester.pumpWidget(
+      new Stack(
+        children: <Widget>[
+          new Positioned(
+            top: 123.0,
+            left: 456.0,
+            child: new Transform.rotate(
+              angle: 1.0, // radians
+              child: new CompositedTransformTarget(
+                link: link,
+                child: new Container(key: key1, height: 10.0, width: 10.0),
+              ),
+            ),
+          ),
+          new Positioned(
+            top: 787.0,
+            left: 343.0,
+            child: new Transform.rotate(
+              angle: -0.3, // radians
+              child: new Padding(
+                padding: const EdgeInsets.all(20.0),
+                child: new CompositedTransformFollower(
+                  link: new LayerLink(),
+                  child: new Transform(
+                    transform: new Matrix4.skew(0.9, 1.1),
+                    child: new Padding(
+                      padding: const EdgeInsets.all(20.0),
+                      child: new CompositedTransformFollower(
+                        link: link,
+                        child: new Container(key: key2, height: 10.0, width: 10.0),
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+    final RenderBox box1 = key1.currentContext.findRenderObject();
+    final RenderBox box2 = key2.currentContext.findRenderObject();
+    final Offset position1 = box1.localToGlobal(Offset.zero);
+    final Offset position2 = box2.localToGlobal(Offset.zero);
+    expect(position1.dx, moreOrLessEquals(position2.dx));
+    expect(position1.dy, moreOrLessEquals(position2.dy));
+  });
+
+  testWidgets('Composited transforms - hit testing', (WidgetTester tester) async {
+    final LayerLink link = new LayerLink();
+    final GlobalKey key1 = new GlobalKey();
+    final GlobalKey key2 = new GlobalKey();
+    final GlobalKey key3 = new GlobalKey();
+    bool _tapped = false;
+    await tester.pumpWidget(
+      new Stack(
+        children: <Widget>[
+          new Positioned(
+            left: 123.0,
+            top: 456.0,
+            child: new CompositedTransformTarget(
+              link: link,
+              child: new Container(key: key1, height: 10.0, width: 10.0),
+            ),
+          ),
+          new CompositedTransformFollower(
+            link: link,
+            child: new GestureDetector(
+              key: key2,
+              behavior: HitTestBehavior.opaque,
+              onTap: () { _tapped = true; },
+              child: new Container(key: key3, height: 10.0, width: 10.0),
+            ),
+          ),
+        ],
+      ),
+    );
+    final RenderBox box2 = key2.currentContext.findRenderObject();
+    expect(box2.size, const Size(10.0, 10.0));
+    expect(_tapped, isFalse);
+    await tester.tap(find.byKey(key1));
+    expect(_tapped, isTrue);
+  });
+}


### PR DESCRIPTION
Introduce CompositedTransformTarget and CompositedTransformFollower
widgets, corresponding render objects, and corresponding layers.

Adjust the way text fields work to use this.

Various changes I needed to debug the issues that came up.

Fixes https://github.com/flutter/flutter/issues/3861

cc @abarth 