### PR TITLE
Re-enable use of instruments for iOS device lookup

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_device.dart
+++ b/packages/flutter_tools/lib/src/android/android_device.dart
@@ -48,7 +48,7 @@ class AndroidDevices extends PollingDeviceDiscovery {
   bool get canListAnything => androidWorkflow.canListDevices;
 
   @override
-  List<Device> pollingGetDevices() => getAdbDevices();
+  Future<List<Device>> pollingGetDevices() async => getAdbDevices();
 }
 
 class AndroidDevice extends Device {

--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -36,11 +36,11 @@ class IOSDevices extends PollingDeviceDiscovery {
   bool get canListAnything => iosWorkflow.canListDevices;
 
   @override
-  List<Device> pollingGetDevices() => IOSDevice.getAttachedDevices();
+  Future<List<Device>> pollingGetDevices() => IOSDevice.getAttachedDevices();
 }
 
 class IOSDevice extends Device {
-  IOSDevice(String id, { this.name }) : super(id) {
+  IOSDevice(String id, { this.name, String sdkVersion }) : _sdkVersion = sdkVersion, super(id) {
     _installerPath = _checkForCommand('ideviceinstaller');
     _iproxyPath = _checkForCommand('iproxy');
     _pusherPath = _checkForCommand(
@@ -54,6 +54,8 @@ class IOSDevice extends Device {
   String _installerPath;
   String _iproxyPath;
   String _pusherPath;
+
+  final String _sdkVersion;
 
   @override
   bool get supportsHotMode => true;
@@ -71,14 +73,30 @@ class IOSDevice extends Device {
   @override
   bool get supportsStartPaused => false;
 
-  static List<IOSDevice> getAttachedDevices() {
-    if (!iMobileDevice.isInstalled)
+  // Physical device line format to be matched:
+  // My iPhone (10.3.2) [75b90e947c5f429fa67f3e9169fda0d89f0492f1]
+  //
+  // Other formats in output (desktop, simulator) to be ignored:
+  // my-mac-pro [2C10513E-4dA5-405C-8EF5-C44353DB3ADD]
+  // iPhone 6s (9.3) [F6CEE7CF-81EB-4448-81B4-1755288C7C11] (Simulator)
+  static final RegExp _deviceRegex = new RegExp(r'^(.*) +\((.*)\) +\[(.*)\]$');
+
+  static Future<List<IOSDevice>> getAttachedDevices() async {
+    if (!xcode.isInstalled)
       return <IOSDevice>[];
 
     final List<IOSDevice> devices = <IOSDevice>[];
-    for (String id in iMobileDevice.getAttachedDeviceIDs()) {
-      final String name = iMobileDevice.getInfoForDevice(id, 'DeviceName');
-      devices.add(new IOSDevice(id, name: name));
+    final Iterable<String> deviceLines = (await xcode.getAvailableDevices())
+        .split('\n')
+        .map((String line) => line.trim());
+    for (String line in deviceLines) {
+      final Match match = _deviceRegex.firstMatch(line);
+      if (match != null) {
+        final String deviceName = match.group(1);
+        final String sdkVersion = match.group(2);
+        final String deviceID = match.group(3);
+        devices.add(new IOSDevice(deviceID, name: deviceName, sdkVersion: sdkVersion));
+      }
     }
     return devices;
   }
@@ -311,11 +329,7 @@ class IOSDevice extends Device {
   Future<TargetPlatform> get targetPlatform async => TargetPlatform.ios;
 
   @override
-  Future<String> get sdkNameAndVersion async => 'iOS $_sdkVersion ($_buildVersion)';
-
-  String get _sdkVersion => iMobileDevice.getInfoForDevice(id, 'ProductVersion');
-
-  String get _buildVersion => iMobileDevice.getInfoForDevice(id, 'BuildVersion');
+  Future<String> get sdkNameAndVersion async => 'iOS $_sdkVersion';
 
   @override
   DeviceLogReader getLogReader({ApplicationPackage app}) {

--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -70,14 +70,6 @@ class IMobileDevice {
     return await exitsHappyAsync(<String>['idevicename']);
   }
 
-  List<String> getAttachedDeviceIDs() {
-    return runSync(<String>['idevice_id', '-l'])
-        .trim()
-        .split('\n')
-        .where((String line) => line.isNotEmpty)
-        .toList();
-  }
-
   /// Returns the value associated with the specified `ideviceinfo` key for a device.
   ///
   /// If either the specified key or device does not exist, returns the empty string.
@@ -164,6 +156,13 @@ class Xcode {
     _xcodeMinorVersion = components.length == 1 ? 0 : int.parse(components[1]);
 
     return _xcodeVersionCheckValid(_xcodeMajorVersion, _xcodeMinorVersion);
+  }
+
+  Future<String> getAvailableDevices() async {
+    final RunResult result = await runAsync(<String>['/usr/bin/instruments', '-s', 'devices']);
+    if (result.exitCode != 0)
+      throw new ToolExit('Failed to invoke /usr/bin/instruments. Is Xcode installed?');
+    return result.stdout;
   }
 }
 

--- a/packages/flutter_tools/lib/src/ios/simulators.dart
+++ b/packages/flutter_tools/lib/src/ios/simulators.dart
@@ -37,7 +37,7 @@ class IOSSimulators extends PollingDeviceDiscovery {
   bool get canListAnything => iosWorkflow.canListDevices;
 
   @override
-  List<Device> pollingGetDevices() => IOSSimulatorUtils.instance.getAttachedDevices();
+  Future<List<Device>> pollingGetDevices() async => IOSSimulatorUtils.instance.getAttachedDevices();
 }
 
 class IOSSimulatorUtils {

--- a/packages/flutter_tools/test/ios/devices_test.dart
+++ b/packages/flutter_tools/test/ios/devices_test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:async';
+
 import 'package:file/file.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/ios/devices.dart';
@@ -14,7 +16,7 @@ import 'package:test/test.dart';
 import '../src/context.dart';
 
 class MockProcessManager extends Mock implements ProcessManager {}
-class MockIMobileDevice extends Mock implements IMobileDevice {}
+class MockXcode extends Mock implements Xcode {}
 class MockFile extends Mock implements File {}
 
 void main() {
@@ -22,46 +24,48 @@ void main() {
   osx.operatingSystem = 'macos';
 
   group('getAttachedDevices', () {
-    MockIMobileDevice mockIMobileDevice;
+    MockXcode mockXcode;
 
     setUp(() {
-      mockIMobileDevice = new MockIMobileDevice();
+      mockXcode = new MockXcode();
     });
 
-    testUsingContext('return no devices if libimobiledevice is not installed', () async {
-      when(mockIMobileDevice.isInstalled).thenReturn(false);
-      expect(IOSDevice.getAttachedDevices(), isEmpty);
+    testUsingContext('return no devices if Xcode is not installed', () async {
+      when(mockXcode.isInstalled).thenReturn(false);
+      expect(await IOSDevice.getAttachedDevices(), isEmpty);
     }, overrides: <Type, Generator>{
-      IMobileDevice: () => mockIMobileDevice,
+      Xcode: () => mockXcode,
     });
 
     testUsingContext('returns no devices if none are attached', () async {
-      when(mockIMobileDevice.isInstalled).thenReturn(true);
-      when(mockIMobileDevice.getAttachedDeviceIDs()).thenReturn(<String>[]);
-      final List<IOSDevice> devices = IOSDevice.getAttachedDevices();
+      when(mockXcode.isInstalled).thenReturn(true);
+      when(mockXcode.getAvailableDevices()).thenReturn(new Future<String>.value(''));
+      final List<IOSDevice> devices = await IOSDevice.getAttachedDevices();
       expect(devices, isEmpty);
     }, overrides: <Type, Generator>{
-      IMobileDevice: () => mockIMobileDevice,
+      Xcode: () => mockXcode,
     });
 
     testUsingContext('returns attached devices', () async {
-      when(mockIMobileDevice.isInstalled).thenReturn(true);
-      when(mockIMobileDevice.getAttachedDeviceIDs()).thenReturn(<String>[
-        '98206e7a4afd4aedaff06e687594e089dede3c44',
-        'f577a7903cc54959be2e34bc4f7f80b7009efcf4',
-      ]);
-      when(mockIMobileDevice.getInfoForDevice('98206e7a4afd4aedaff06e687594e089dede3c44', 'DeviceName'))
-          .thenReturn('La tele me regarde');
-      when(mockIMobileDevice.getInfoForDevice('f577a7903cc54959be2e34bc4f7f80b7009efcf4', 'DeviceName'))
-          .thenReturn('Puits sans fond');
-      final List<IOSDevice> devices = IOSDevice.getAttachedDevices();
+      when(mockXcode.isInstalled).thenReturn(true);
+      when(mockXcode.getAvailableDevices()).thenReturn(new Future<String>.value('''
+Known Devices:
+je-mappelle-horse [ED6552C4-B774-5A4E-8B5A-606710C87C77]
+La tele me regarde (10.3.2) [98206e7a4afd4aedaff06e687594e089dede3c44]
+Puits sans fond (10.3.2) [f577a7903cc54959be2e34bc4f7f80b7009efcf4]
+iPhone 6 Plus (9.3) [FBA880E6-4020-49A5-8083-DCD50CA5FA09] (Simulator)
+iPhone 6s (11.0) [E805F496-FC6A-4EA4-92FF-B7901FF4E7CC] (Simulator)
+iPhone 7 (11.0) + Apple Watch Series 2 - 38mm (4.0) [60027FDD-4A7A-42BF-978F-C2209D27AD61] (Simulator)
+iPhone SE (11.0) [667E8DCD-5DCD-4C80-93A9-60D1D995206F] (Simulator)
+'''));
+      final List<IOSDevice> devices = await IOSDevice.getAttachedDevices();
       expect(devices, hasLength(2));
       expect(devices[0].id, '98206e7a4afd4aedaff06e687594e089dede3c44');
       expect(devices[0].name, 'La tele me regarde');
       expect(devices[1].id, 'f577a7903cc54959be2e34bc4f7f80b7009efcf4');
       expect(devices[1].name, 'Puits sans fond');
     }, overrides: <Type, Generator>{
-      IMobileDevice: () => mockIMobileDevice,
+      Xcode: () => mockXcode,
     });
   });
 

--- a/packages/flutter_tools/test/src/mocks.dart
+++ b/packages/flutter_tools/test/src/mocks.dart
@@ -37,7 +37,7 @@ class MockPollingDeviceDiscovery extends PollingDeviceDiscovery {
   MockPollingDeviceDiscovery() : super('mock');
 
   @override
-  List<Device> pollingGetDevices() => _devices;
+  Future<List<Device>> pollingGetDevices() async => _devices;
 
   @override
   bool get supportsPlatform => true;
@@ -52,7 +52,7 @@ class MockPollingDeviceDiscovery extends PollingDeviceDiscovery {
   }
 
   @override
-  List<Device> get devices => _devices;
+  Future<List<Device>> get devices async => _devices;
 
   @override
   Stream<Device> get onAdded => _onAddedController.stream;


### PR DESCRIPTION
This reverts commit b2909a245a607995ce7ec286585cd1f643124f57.

This resubmits the following patches:

1. Use Xcode instruments to list devices (#10801)
Eliminates the dependency on idevice_id from libimobiledevice. Instead,
uses Xcode built-in functionality.

2. Make device discovery asynchronous (#10803)
Migrates DeviceDiscovery.devices and all device-specific lookup to be
asynchronous.

The above patches were reverted due to incomplete Xcode installs on the
build bots. This has now been remedies.