### PR TITLE
Clean up pre-existing DevFS during creation

### DIFF
--- a/packages/flutter_tools/lib/src/commands/fuchsia_reload.dart
+++ b/packages/flutter_tools/lib/src/commands/fuchsia_reload.dart
@@ -143,9 +143,24 @@ class FuchsiaReloadCommand extends FlutterCommand {
     return _vmServiceCache[port];
   }
 
+  Future<bool> _checkPort(int port) async {
+    bool connected = true;
+    Socket s;
+    try {
+      s = await Socket.connect("$_address", port);
+    } catch (_) {
+      connected = false;
+    }
+    if (s != null)
+      await s.close();
+    return connected;
+  }
+
   Future<List<FlutterView>> _getViews(List<int> ports) async {
     final List<FlutterView> views = <FlutterView>[];
     for (int port in ports) {
+      if (!await _checkPort(port))
+        continue;
       final VMService vmService = _getVMService(port);
       await vmService.getVM();
       await vmService.waitForViews();


### PR DESCRIPTION
When connecting to a flaky device, or a device with a flaky network stack, flutter_tool can exit without any opportunity to clean up the DevFS on the device. However, users are expecting reconnections to work. Currently they fail when flutter_tool notices that the target VM already has a DevFS set up.

In this case, this CL cleans up the existing DevFS, and sets up a new one. This CL also avoids trying to connect to a bogus port on a Fuchsia devices.