### PR TITLE
Move the discovered Java installation to the front of PATH when running sdkmanager

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_workflow.dart
+++ b/packages/flutter_tools/lib/src/android/android_workflow.dart
@@ -178,7 +178,7 @@ class AndroidWorkflow extends DoctorValidator implements Workflow {
     final String javaBinary = _findJavaBinary();
     if (javaBinary != null) {
       sdkManagerEnv['PATH'] =
-          platform.environment['PATH'] + os.pathVarSeparator + fs.path.dirname(javaBinary);
+          fs.path.dirname(javaBinary) + os.pathVarSeparator + platform.environment['PATH'];
     }
 
     final String sdkManagerPath = fs.path.join(


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/10703