### PR TITLE
change --machine flag for `flutter test` to report test progress as JSON

### DIFF
--- a/packages/flutter_tools/lib/src/commands/test.dart
+++ b/packages/flutter_tools/lib/src/commands/test.dart
@@ -193,7 +193,8 @@ class TestCommand extends FlutterCommand {
         enableObservatory: collector != null || startPaused,
         startPaused: startPaused,
         ipv6: argResults['ipv6'],
-        json: machine);
+        json: machine,
+        );
 
     if (collector != null) {
       if (!await _collectCoverageData(collector, mergeCoverageData: argResults['merge-coverage']))

--- a/packages/flutter_tools/lib/src/commands/test.dart
+++ b/packages/flutter_tools/lib/src/commands/test.dart
@@ -172,8 +172,8 @@ class TestCommand extends FlutterCommand {
       collector = new CoverageCollector();
     }
 
-    final bool wantEvents = argResults['machine'];
-    if (collector != null && wantEvents) {
+    final bool machine = argResults['machine'];
+    if (collector != null && machine) {
       throwToolExit(
           "The test command doesn't support --machine and coverage together");
     }
@@ -181,7 +181,7 @@ class TestCommand extends FlutterCommand {
     TestWatcher watcher;
     if (collector != null) {
       watcher = collector;
-    } else if (wantEvents) {
+    } else if (machine) {
       watcher = new EventPrinter();
     }
 
@@ -192,7 +192,8 @@ class TestCommand extends FlutterCommand {
         watcher: watcher,
         enableObservatory: collector != null || startPaused,
         startPaused: startPaused,
-        ipv6: argResults['ipv6']);
+        ipv6: argResults['ipv6'],
+        json: machine);
 
     if (collector != null) {
       if (!await _collectCoverageData(collector, mergeCoverageData: argResults['merge-coverage']))

--- a/packages/flutter_tools/lib/src/test/runner.dart
+++ b/packages/flutter_tools/lib/src/test/runner.dart
@@ -24,6 +24,7 @@ Future<int> runTests(
     bool enableObservatory: false,
     bool startPaused: false,
     bool ipv6: false,
+    bool json: false,
     TestWatcher watcher,
     }) async {
   // Compute the command-line arguments for package:test.
@@ -34,6 +35,10 @@ Future<int> runTests(
   if (enableObservatory) {
     // (In particular, for collecting code coverage.)
     testArgs.add('--concurrency=1');
+  }
+
+  if (json) {
+    testArgs.addAll(<String>["-r", "json"]);
   }
 
   testArgs.add('--');

--- a/packages/flutter_tools/lib/src/test/runner.dart
+++ b/packages/flutter_tools/lib/src/test/runner.dart
@@ -38,7 +38,7 @@ Future<int> runTests(
   }
 
   if (json) {
-    testArgs.addAll(<String>["-r", "json"]);
+    testArgs.addAll(<String>['-r', 'json']);
   }
 
   testArgs.add('--');


### PR DESCRIPTION
This is so that the IntelliJ Flutter plugin can report test progress using a nice UI.


