### PR TITLE
Update dartdoc to 0.13.0+1

### DIFF
--- a/dev/bots/docs.sh
+++ b/dev/bots/docs.sh
@@ -8,7 +8,7 @@ set -e
 bin/flutter --version
 
 # Install dartdoc.
-bin/cache/dart-sdk/bin/pub global activate dartdoc 0.12.0
+bin/cache/dart-sdk/bin/pub global activate dartdoc 0.13.0+1
 
 # This script generates a unified doc set, and creates
 # a custom index.html, placing everything into dev/docs/doc.

--- a/dev/tools/dartdoc.dart
+++ b/dev/tools/dartdoc.dart
@@ -35,6 +35,7 @@ Future<Null> main(List<String> args) async {
   // Create the pubspec.yaml file.
   final StringBuffer buf = new StringBuffer('''
 name: Flutter
+homepage: https://flutter.io
 version: $version
 dependencies:
 ''');


### PR DESCRIPTION
Move flutter from 0.12.0 to 0.13.0+1 dartdoc.  The new dartdoc is somewhat faster at doc generation (~15% for flutter) and has a number of bugfixes.  The homepage addition is to enable the fix for dart-lang/dartdoc#1460.

dartdoc release notes: [v0.13.0](https://github.com/dart-lang/dartdoc/releases/tag/v0.13.0), [v0.13.0+1](https://github.com/dart-lang/dartdoc/releases/tag/v0.13.0%2B1)

Browseable flutter docs for old dartdoc version (for apples-to-apples comparison):
http://jcollins1.pdx.corp.google.com:8012/

Browseable flutter docs for new version:
http://jcollins1.pdx.corp.google.com:8013/