### PR TITLE
Change all ocurrences of '$runtimeType#$hashCode' to use the idAndType method.

### DIFF
--- a/packages/flutter/lib/src/animation/animation.dart
+++ b/packages/flutter/lib/src/animation/animation.dart
@@ -81,7 +81,7 @@ abstract class Animation<T> extends Listenable {
 
   @override
   String toString() {
-    return '$runtimeType#$hashCode(${toStringDetails()})';
+    return '${idAndType(this)}(${toStringDetails()})';
   }
 
   /// Provides a string describing the status of this object, but not including

--- a/packages/flutter/lib/src/animation/animation.dart
+++ b/packages/flutter/lib/src/animation/animation.dart
@@ -81,7 +81,7 @@ abstract class Animation<T> extends Listenable {
 
   @override
   String toString() {
-    return '${idAndType(this)}(${toStringDetails()})';
+    return '${describeIdentity(this)}(${toStringDetails()})';
   }
 
   /// Provides a string describing the status of this object, but not including

--- a/packages/flutter/lib/src/foundation/change_notifier.dart
+++ b/packages/flutter/lib/src/foundation/change_notifier.dart
@@ -7,6 +7,7 @@ import 'package:meta/meta.dart';
 import 'assertions.dart';
 import 'basic_types.dart';
 import 'observer_list.dart';
+import 'print.dart';
 
 /// An object that maintains a list of listeners.
 abstract class Listenable {
@@ -185,5 +186,5 @@ class ValueNotifier<T> extends ChangeNotifier {
   }
 
   @override
-  String toString() => '$runtimeType#$hashCode($value)';
+  String toString() => '${idAndType(this)}($value)';
 }

--- a/packages/flutter/lib/src/foundation/print.dart
+++ b/packages/flutter/lib/src/foundation/print.dart
@@ -172,11 +172,3 @@ Iterable<String> debugWordWrap(String message, int width, { String wrapIndent: '
     }
   }
 }
-
-/// Returns a 5 character long hexadecimal hash code for [object].
-String shortHash(Object object) {
-  return object.hashCode.toUnsigned(20).toRadixString(16).padLeft(5, '0');
-}
-
-/// Returns a summary of [object]'s runtime type and hash code.
-String idAndType(Object object) => '${object.runtimeType}#${shortHash(object)}';

--- a/packages/flutter/lib/src/foundation/print.dart
+++ b/packages/flutter/lib/src/foundation/print.dart
@@ -172,3 +172,11 @@ Iterable<String> debugWordWrap(String message, int width, { String wrapIndent: '
     }
   }
 }
+
+/// Returns a 5 character long hexadecimal hash code for [object].
+String shortHash(Object object) {
+  return object.hashCode.toUnsigned(20).toRadixString(16).padLeft(5, '0');
+}
+
+/// Returns a summary of [object]'s runtime type and hash code.
+String idAndType(Object object) => '${object.runtimeType}#${shortHash(object)}';

--- a/packages/flutter/lib/src/foundation/tree_diagnostics_mixin.dart
+++ b/packages/flutter/lib/src/foundation/tree_diagnostics_mixin.dart
@@ -6,6 +6,14 @@ import 'package:meta/meta.dart';
 
 import 'print.dart';
 
+/// Returns a 5 character long hexadecimal hash code for [object].
+String shortHash(Object object) {
+  return object.hashCode.toUnsigned(20).toRadixString(16).padLeft(5, '0');
+}
+
+/// Returns a summary of [object]'s runtime type and hash code.
+String idAndType(Object object) => '${object.runtimeType}#${shortHash(object)}';
+
 /// A mixin that helps dump string representations of trees.
 abstract class TreeDiagnosticsMixin {
   // This class is intended to be used as a mixin, and should not be

--- a/packages/flutter/lib/src/foundation/tree_diagnostics_mixin.dart
+++ b/packages/flutter/lib/src/foundation/tree_diagnostics_mixin.dart
@@ -12,7 +12,8 @@ String shortHash(Object object) {
 }
 
 /// Returns a summary of [object]'s runtime type and hash code.
-String idAndType(Object object) => '${object.runtimeType}#${shortHash(object)}';
+String describeIdentity(Object object) =>
+    '${object.runtimeType}#${shortHash(object)}';
 
 /// A mixin that helps dump string representations of trees.
 abstract class TreeDiagnosticsMixin {
@@ -28,7 +29,7 @@ abstract class TreeDiagnosticsMixin {
   ///  * [toStringShallow], for a detailed description of the object.
   ///  * [toStringDeep], for a description of the subtree rooted at this object.
   @override
-  String toString() => idAndType(this);
+  String toString() => describeIdentity(this);
 
   /// Returns a one-line detailed description of the object.
   ///

--- a/packages/flutter/lib/src/foundation/tree_diagnostics_mixin.dart
+++ b/packages/flutter/lib/src/foundation/tree_diagnostics_mixin.dart
@@ -20,7 +20,7 @@ abstract class TreeDiagnosticsMixin {
   ///  * [toStringShallow], for a detailed description of the object.
   ///  * [toStringDeep], for a description of the subtree rooted at this object.
   @override
-  String toString() => '$runtimeType#$hashCode';
+  String toString() => idAndType(this);
 
   /// Returns a one-line detailed description of the object.
   ///

--- a/packages/flutter/lib/src/gestures/recognizer.dart
+++ b/packages/flutter/lib/src/gestures/recognizer.dart
@@ -86,7 +86,7 @@ abstract class GestureRecognizer extends GestureArenaMember {
   }
 
   @override
-  String toString() => idAndType(this);
+  String toString() => describeIdentity(this);
 }
 
 /// Base class for gesture recognizers that can only recognize one
@@ -321,5 +321,5 @@ abstract class PrimaryPointerGestureRecognizer extends OneSequenceGestureRecogni
   }
 
   @override
-  String toString() => '${idAndType(this)}($state)';
+  String toString() => '${describeIdentity(this)}($state)';
 }

--- a/packages/flutter/lib/src/gestures/recognizer.dart
+++ b/packages/flutter/lib/src/gestures/recognizer.dart
@@ -86,7 +86,7 @@ abstract class GestureRecognizer extends GestureArenaMember {
   }
 
   @override
-  String toString() => '$runtimeType#$hashCode';
+  String toString() => idAndType(this);
 }
 
 /// Base class for gesture recognizers that can only recognize one
@@ -321,5 +321,5 @@ abstract class PrimaryPointerGestureRecognizer extends OneSequenceGestureRecogni
   }
 
   @override
-  String toString() => '$runtimeType#$hashCode($state)';
+  String toString() => '${idAndType(this)}($state)';
 }

--- a/packages/flutter/lib/src/material/app_bar.dart
+++ b/packages/flutter/lib/src/material/app_bar.dart
@@ -604,7 +604,7 @@ class _SliverAppBarDelegate extends SliverPersistentHeaderDelegate {
 
   @override
   String toString() {
-    return '$runtimeType#$hashCode(topPadding: ${topPadding.toStringAsFixed(1)}, bottomHeight: ${_bottomHeight.toStringAsFixed(1)}, ...)';
+    return '${idAndType(this)}(topPadding: ${topPadding.toStringAsFixed(1)}, bottomHeight: ${_bottomHeight.toStringAsFixed(1)}, ...)';
   }
 }
 

--- a/packages/flutter/lib/src/material/app_bar.dart
+++ b/packages/flutter/lib/src/material/app_bar.dart
@@ -604,7 +604,7 @@ class _SliverAppBarDelegate extends SliverPersistentHeaderDelegate {
 
   @override
   String toString() {
-    return '${idAndType(this)}(topPadding: ${topPadding.toStringAsFixed(1)}, bottomHeight: ${_bottomHeight.toStringAsFixed(1)}, ...)';
+    return '${describeIdentity(this)}(topPadding: ${topPadding.toStringAsFixed(1)}, bottomHeight: ${_bottomHeight.toStringAsFixed(1)}, ...)';
   }
 }
 

--- a/packages/flutter/lib/src/material/material.dart
+++ b/packages/flutter/lib/src/material/material.dart
@@ -425,5 +425,5 @@ abstract class InkFeature {
   void paintFeature(Canvas canvas, Matrix4 transform);
 
   @override
-  String toString() => '$runtimeType#$hashCode';
+  String toString() => idAndType(this);
 }

--- a/packages/flutter/lib/src/material/material.dart
+++ b/packages/flutter/lib/src/material/material.dart
@@ -425,5 +425,5 @@ abstract class InkFeature {
   void paintFeature(Canvas canvas, Matrix4 transform);
 
   @override
-  String toString() => idAndType(this);
+  String toString() => describeIdentity(this);
 }

--- a/packages/flutter/lib/src/rendering/box.dart
+++ b/packages/flutter/lib/src/rendering/box.dart
@@ -572,7 +572,7 @@ class BoxHitTestEntry extends HitTestEntry {
   final Offset localPosition;
 
   @override
-  String toString() => '${target.runtimeType}#${target.hashCode}@$localPosition';
+  String toString() => '${idAndType(target)}@$localPosition';
 }
 
 /// Parent data used by [RenderBox] and its subclasses.

--- a/packages/flutter/lib/src/rendering/box.dart
+++ b/packages/flutter/lib/src/rendering/box.dart
@@ -572,7 +572,7 @@ class BoxHitTestEntry extends HitTestEntry {
   final Offset localPosition;
 
   @override
-  String toString() => '${idAndType(target)}@$localPosition';
+  String toString() => '${describeIdentity(target)}@$localPosition';
 }
 
 /// Parent data used by [RenderBox] and its subclasses.

--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -636,7 +636,7 @@ abstract class _SemanticsFragment {
   Iterable<SemanticsNode> compile({ _SemanticsGeometry geometry, SemanticsNode currentSemantics, SemanticsNode parentSemantics });
 
   @override
-  String toString() => '$runtimeType#$hashCode';
+  String toString() => idAndType(this);
 }
 
 /// A SemanticsFragment that doesn't produce any [SemanticsNode]s when compiled.
@@ -2686,7 +2686,7 @@ abstract class RenderObject extends AbstractNode implements HitTestTarget {
   /// Returns a human understandable name.
   @override
   String toString() {
-    String header = '$runtimeType#$hashCode';
+    String header = idAndType(this);
     if (_relayoutBoundary != null && _relayoutBoundary != this) {
       int count = 1;
       RenderObject target = parent;

--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -636,7 +636,7 @@ abstract class _SemanticsFragment {
   Iterable<SemanticsNode> compile({ _SemanticsGeometry geometry, SemanticsNode currentSemantics, SemanticsNode parentSemantics });
 
   @override
-  String toString() => idAndType(this);
+  String toString() => describeIdentity(this);
 }
 
 /// A SemanticsFragment that doesn't produce any [SemanticsNode]s when compiled.
@@ -2686,7 +2686,7 @@ abstract class RenderObject extends AbstractNode implements HitTestTarget {
   /// Returns a human understandable name.
   @override
   String toString() {
-    String header = idAndType(this);
+    String header = describeIdentity(this);
     if (_relayoutBoundary != null && _relayoutBoundary != this) {
       int count = 1;
       RenderObject target = parent;

--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -2034,7 +2034,7 @@ abstract class CustomPainter extends Listenable {
   bool hitTest(Offset position) => null;
 
   @override
-  String toString() => '${idAndType(this)}(${ _repaint?.toString() ?? "" })';
+  String toString() => '${describeIdentity(this)}(${ _repaint?.toString() ?? "" })';
 }
 
 /// Provides a canvas on which to draw during the paint phase.

--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -2034,7 +2034,7 @@ abstract class CustomPainter extends Listenable {
   bool hitTest(Offset position) => null;
 
   @override
-  String toString() => '$runtimeType#$hashCode(${ _repaint?.toString() ?? "" })';
+  String toString() => '${idAndType(this)}(${ _repaint?.toString() ?? "" })';
 }
 
 /// Provides a canvas on which to draw during the paint phase.

--- a/packages/flutter/lib/src/rendering/semantics.dart
+++ b/packages/flutter/lib/src/rendering/semantics.dart
@@ -781,5 +781,5 @@ class SemanticsOwner extends ChangeNotifier {
   }
 
   @override
-  String toString() => idAndType(this);
+  String toString() => describeIdentity(this);
 }

--- a/packages/flutter/lib/src/rendering/semantics.dart
+++ b/packages/flutter/lib/src/rendering/semantics.dart
@@ -781,5 +781,5 @@ class SemanticsOwner extends ChangeNotifier {
   }
 
   @override
-  String toString() => '$runtimeType#$hashCode';
+  String toString() => idAndType(this);
 }

--- a/packages/flutter/lib/src/rendering/viewport_offset.dart
+++ b/packages/flutter/lib/src/rendering/viewport_offset.dart
@@ -170,7 +170,7 @@ abstract class ViewportOffset extends ChangeNotifier {
   String toString() {
     final List<String> description = <String>[];
     debugFillDescription(description);
-    return '${idAndType(this)}(${description.join(", ")})';
+    return '${describeIdentity(this)}(${description.join(", ")})';
   }
 
   /// Add additional information to the given description for use by [toString].

--- a/packages/flutter/lib/src/rendering/viewport_offset.dart
+++ b/packages/flutter/lib/src/rendering/viewport_offset.dart
@@ -170,7 +170,7 @@ abstract class ViewportOffset extends ChangeNotifier {
   String toString() {
     final List<String> description = <String>[];
     debugFillDescription(description);
-    return '$runtimeType#$hashCode(${description.join(", ")})';
+    return '${idAndType(this)}(${description.join(", ")})';
   }
 
   /// Add additional information to the given description for use by [toString].

--- a/packages/flutter/lib/src/scheduler/ticker.dart
+++ b/packages/flutter/lib/src/scheduler/ticker.dart
@@ -419,7 +419,7 @@ class TickerFuture implements Future<Null> {
   }
 
   @override
-  String toString() => '${idAndType(this)}(${ _completed == null ? "active" : _completed ? "complete" : "canceled" })';
+  String toString() => '${describeIdentity(this)}(${ _completed == null ? "active" : _completed ? "complete" : "canceled" })';
 }
 
 /// Exception thrown by [Ticker] objects on the [TickerFuture.orCancel] future

--- a/packages/flutter/lib/src/scheduler/ticker.dart
+++ b/packages/flutter/lib/src/scheduler/ticker.dart
@@ -419,7 +419,7 @@ class TickerFuture implements Future<Null> {
   }
 
   @override
-  String toString() => '$runtimeType#$hashCode(${ _completed == null ? "active" : _completed ? "complete" : "canceled" })';
+  String toString() => '${idAndType(this)}(${ _completed == null ? "active" : _completed ? "complete" : "canceled" })';
 }
 
 /// Exception thrown by [Ticker] objects on the [TickerFuture.orCancel] future

--- a/packages/flutter/lib/src/services/asset_bundle.dart
+++ b/packages/flutter/lib/src/services/asset_bundle.dart
@@ -79,7 +79,7 @@ abstract class AssetBundle {
   void evict(String key) { }
 
   @override
-  String toString() => '$runtimeType#$hashCode()';
+  String toString() => '${idAndType(this)}()';
 }
 
 /// An [AssetBundle] that loads resources over the network.
@@ -133,7 +133,7 @@ class NetworkAssetBundle extends AssetBundle {
   // should implement evict().
 
   @override
-  String toString() => '$runtimeType#$hashCode($_baseUrl)';
+  String toString() => '${idAndType(this)}($_baseUrl)';
 }
 
 /// An [AssetBundle] that permanently caches string and structured resources

--- a/packages/flutter/lib/src/services/asset_bundle.dart
+++ b/packages/flutter/lib/src/services/asset_bundle.dart
@@ -79,7 +79,7 @@ abstract class AssetBundle {
   void evict(String key) { }
 
   @override
-  String toString() => '${idAndType(this)}()';
+  String toString() => '${describeIdentity(this)}()';
 }
 
 /// An [AssetBundle] that loads resources over the network.
@@ -133,7 +133,7 @@ class NetworkAssetBundle extends AssetBundle {
   // should implement evict().
 
   @override
-  String toString() => '${idAndType(this)}($_baseUrl)';
+  String toString() => '${describeIdentity(this)}($_baseUrl)';
 }
 
 /// An [AssetBundle] that permanently caches string and structured resources

--- a/packages/flutter/lib/src/services/image_provider.dart
+++ b/packages/flutter/lib/src/services/image_provider.dart
@@ -578,7 +578,7 @@ class MemoryImage extends ImageProvider<MemoryImage> {
   int get hashCode => hashValues(bytes.hashCode, scale);
 
   @override
-  String toString() => '$runtimeType(${idAndType(bytes)}, scale: $scale)';
+  String toString() => '$runtimeType(${describeIdentity(bytes)}, scale: $scale)';
 }
 /// Fetches an image from an [AssetBundle], associating it with the given scale.
 ///

--- a/packages/flutter/lib/src/services/image_provider.dart
+++ b/packages/flutter/lib/src/services/image_provider.dart
@@ -578,7 +578,7 @@ class MemoryImage extends ImageProvider<MemoryImage> {
   int get hashCode => hashValues(bytes.hashCode, scale);
 
   @override
-  String toString() => '$runtimeType(${bytes.runtimeType}#${bytes.hashCode}, scale: $scale)';
+  String toString() => '$runtimeType(${idAndType(bytes)}, scale: $scale)';
 }
 /// Fetches an image from an [AssetBundle], associating it with the given scale.
 ///

--- a/packages/flutter/lib/src/widgets/focus_manager.dart
+++ b/packages/flutter/lib/src/widgets/focus_manager.dart
@@ -94,7 +94,7 @@ class FocusNode extends ChangeNotifier {
   }
 
   @override
-  String toString() => '${idAndType(this)}${hasFocus ? '(FOCUSED)' : ''}';
+  String toString() => '${describeIdentity(this)}${hasFocus ? '(FOCUSED)' : ''}';
 }
 
 /// An interior node in the focus tree.
@@ -446,7 +446,7 @@ class FocusManager {
   String toString() {
     final String status = _haveScheduledUpdate ? ' UPDATE SCHEDULED' : '';
     final String indent = '  ';
-    return '${idAndType(this)}$status\n'
+    return '${describeIdentity(this)}$status\n'
       '${indent}currentFocus: $_currentFocus\n'
       '${rootScope.toStringDeep(indent, indent)}';
   }

--- a/packages/flutter/lib/src/widgets/focus_manager.dart
+++ b/packages/flutter/lib/src/widgets/focus_manager.dart
@@ -94,7 +94,7 @@ class FocusNode extends ChangeNotifier {
   }
 
   @override
-  String toString() => '$runtimeType#$hashCode${hasFocus ? '(FOCUSED)' : ''}';
+  String toString() => '${idAndType(this)}${hasFocus ? '(FOCUSED)' : ''}';
 }
 
 /// An interior node in the focus tree.
@@ -446,7 +446,7 @@ class FocusManager {
   String toString() {
     final String status = _haveScheduledUpdate ? ' UPDATE SCHEDULED' : '';
     final String indent = '  ';
-    return '$runtimeType#$hashCode$status\n'
+    return '${idAndType(this)}$status\n'
       '${indent}currentFocus: $_currentFocus\n'
       '${rootScope.toStringDeep(indent, indent)}';
   }

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -112,7 +112,7 @@ class UniqueKey extends LocalKey {
   UniqueKey();
 
   @override
-  String toString() => '[#$hashCode]';
+  String toString() => '[#${shortHash(this)}]';
 }
 
 /// A key that takes its identity from the object used as its value.
@@ -142,8 +142,8 @@ class ObjectKey extends LocalKey {
   @override
   String toString() {
     if (runtimeType == ObjectKey)
-      return '[${value.runtimeType}#${value.hashCode}]';
-    return '[$runtimeType ${value.runtimeType}#${value.hashCode}]';
+      return '[${idAndType(value)}]';
+    return '[$runtimeType ${idAndType(value)}]';
   }
 }
 
@@ -333,8 +333,8 @@ class LabeledGlobalKey<T extends State<StatefulWidget>> extends GlobalKey<T> {
   String toString() {
     final String label = _debugLabel != null ? ' $_debugLabel' : '';
     if (runtimeType == LabeledGlobalKey)
-      return '[GlobalKey#$hashCode$label]';
-    return '[$runtimeType#$hashCode$label]';
+      return '[GlobalKey#${shortHash(this)}$label]';
+    return '[${idAndType(this)}$label]';
   }
 }
 
@@ -364,7 +364,7 @@ class GlobalObjectKey<T extends State<StatefulWidget>> extends GlobalKey<T> {
   int get hashCode => identityHashCode(value);
 
   @override
-  String toString() => '[$runtimeType ${value.runtimeType}#${value.hashCode}]';
+  String toString() => '[$runtimeType ${idAndType(value)}]';
 }
 
 /// This class is a work-around for the "is" operator not accepting a variable value as its right operand
@@ -1247,7 +1247,7 @@ abstract class State<T extends StatefulWidget> {
   String toString() {
     final List<String> data = <String>[];
     debugFillDescription(data);
-    return '$runtimeType#$hashCode(${data.join("; ")})';
+    return '${idAndType(this)}(${data.join("; ")})';
   }
 
   /// Add additional information to the given description for use by [toString].

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -142,8 +142,8 @@ class ObjectKey extends LocalKey {
   @override
   String toString() {
     if (runtimeType == ObjectKey)
-      return '[${idAndType(value)}]';
-    return '[$runtimeType ${idAndType(value)}]';
+      return '[${describeIdentity(value)}]';
+    return '[$runtimeType ${describeIdentity(value)}]';
   }
 }
 
@@ -334,7 +334,7 @@ class LabeledGlobalKey<T extends State<StatefulWidget>> extends GlobalKey<T> {
     final String label = _debugLabel != null ? ' $_debugLabel' : '';
     if (runtimeType == LabeledGlobalKey)
       return '[GlobalKey#${shortHash(this)}$label]';
-    return '[${idAndType(this)}$label]';
+    return '[${describeIdentity(this)}$label]';
   }
 }
 
@@ -364,7 +364,7 @@ class GlobalObjectKey<T extends State<StatefulWidget>> extends GlobalKey<T> {
   int get hashCode => identityHashCode(value);
 
   @override
-  String toString() => '[$runtimeType ${idAndType(value)}]';
+  String toString() => '[$runtimeType ${describeIdentity(value)}]';
 }
 
 /// This class is a work-around for the "is" operator not accepting a variable value as its right operand
@@ -1247,7 +1247,7 @@ abstract class State<T extends StatefulWidget> {
   String toString() {
     final List<String> data = <String>[];
     debugFillDescription(data);
-    return '${idAndType(this)}(${data.join("; ")})';
+    return '${describeIdentity(this)}(${data.join("; ")})';
   }
 
   /// Add additional information to the given description for use by [toString].

--- a/packages/flutter/lib/src/widgets/overlay.dart
+++ b/packages/flutter/lib/src/widgets/overlay.dart
@@ -150,7 +150,7 @@ class OverlayEntry {
   }
 
   @override
-  String toString() => '$runtimeType#$hashCode(opaque: $opaque; maintainState: $maintainState)';
+  String toString() => '${idAndType(this)}(opaque: $opaque; maintainState: $maintainState)';
 }
 
 class _OverlayEntry extends StatefulWidget {

--- a/packages/flutter/lib/src/widgets/overlay.dart
+++ b/packages/flutter/lib/src/widgets/overlay.dart
@@ -150,7 +150,7 @@ class OverlayEntry {
   }
 
   @override
-  String toString() => '${idAndType(this)}(opaque: $opaque; maintainState: $maintainState)';
+  String toString() => '${describeIdentity(this)}(opaque: $opaque; maintainState: $maintainState)';
 }
 
 class _OverlayEntry extends StatefulWidget {

--- a/packages/flutter/lib/src/widgets/scroll_activity.dart
+++ b/packages/flutter/lib/src/widgets/scroll_activity.dart
@@ -125,7 +125,7 @@ abstract class ScrollActivity {
   }
 
   @override
-  String toString() => '$runtimeType#$hashCode';
+  String toString() => idAndType(this);
 }
 
 /// A scroll activity that does nothing.
@@ -282,9 +282,7 @@ class ScrollDragController implements Drag {
   dynamic _lastDetails;
 
   @override
-  String toString() {
-    return '$runtimeType#$hashCode';
-  }
+  String toString() => idAndType(this);
 }
 
 /// The activity a scroll view performs when a the user drags their finger
@@ -350,7 +348,7 @@ class DragScrollActivity extends ScrollActivity {
 
   @override
   String toString() {
-    return '$runtimeType#$hashCode($_controller)';
+    return '${idAndType(this)}($_controller)';
   }
 }
 
@@ -441,7 +439,7 @@ class BallisticScrollActivity extends ScrollActivity {
 
   @override
   String toString() {
-    return '$runtimeType#$hashCode($_controller)';
+    return '${idAndType(this)}($_controller)';
   }
 }
 
@@ -526,6 +524,6 @@ class DrivenScrollActivity extends ScrollActivity {
 
   @override
   String toString() {
-    return '$runtimeType#$hashCode($_controller)';
+    return '${idAndType(this)}($_controller)';
   }
 }

--- a/packages/flutter/lib/src/widgets/scroll_activity.dart
+++ b/packages/flutter/lib/src/widgets/scroll_activity.dart
@@ -125,7 +125,7 @@ abstract class ScrollActivity {
   }
 
   @override
-  String toString() => idAndType(this);
+  String toString() => describeIdentity(this);
 }
 
 /// A scroll activity that does nothing.
@@ -282,7 +282,7 @@ class ScrollDragController implements Drag {
   dynamic _lastDetails;
 
   @override
-  String toString() => idAndType(this);
+  String toString() => describeIdentity(this);
 }
 
 /// The activity a scroll view performs when a the user drags their finger
@@ -348,7 +348,7 @@ class DragScrollActivity extends ScrollActivity {
 
   @override
   String toString() {
-    return '${idAndType(this)}($_controller)';
+    return '${describeIdentity(this)}($_controller)';
   }
 }
 
@@ -439,7 +439,7 @@ class BallisticScrollActivity extends ScrollActivity {
 
   @override
   String toString() {
-    return '${idAndType(this)}($_controller)';
+    return '${describeIdentity(this)}($_controller)';
   }
 }
 
@@ -524,6 +524,6 @@ class DrivenScrollActivity extends ScrollActivity {
 
   @override
   String toString() {
-    return '${idAndType(this)}($_controller)';
+    return '${describeIdentity(this)}($_controller)';
   }
 }

--- a/packages/flutter/lib/src/widgets/scroll_controller.dart
+++ b/packages/flutter/lib/src/widgets/scroll_controller.dart
@@ -238,7 +238,7 @@ class ScrollController extends ChangeNotifier {
   String toString() {
     final List<String> description = <String>[];
     debugFillDescription(description);
-    return '$runtimeType#$hashCode(${description.join(", ")})';
+    return '${idAndType(this)}(${description.join(", ")})';
   }
 
   /// Add additional information to the given description for use by [toString].

--- a/packages/flutter/lib/src/widgets/scroll_controller.dart
+++ b/packages/flutter/lib/src/widgets/scroll_controller.dart
@@ -238,7 +238,7 @@ class ScrollController extends ChangeNotifier {
   String toString() {
     final List<String> description = <String>[];
     debugFillDescription(description);
-    return '${idAndType(this)}(${description.join(", ")})';
+    return '${describeIdentity(this)}(${description.join(", ")})';
   }
 
   /// Add additional information to the given description for use by [toString].

--- a/packages/flutter/lib/src/widgets/sliver.dart
+++ b/packages/flutter/lib/src/widgets/sliver.dart
@@ -94,7 +94,7 @@ abstract class SliverChildDelegate {
   String toString() {
     final List<String> description = <String>[];
     debugFillDescription(description);
-    return '$runtimeType#$hashCode(${description.join(", ")})';
+    return '${idAndType(this)}(${description.join(", ")})';
   }
 
   /// Add additional information to the given description for use by [toString].

--- a/packages/flutter/lib/src/widgets/sliver.dart
+++ b/packages/flutter/lib/src/widgets/sliver.dart
@@ -94,7 +94,7 @@ abstract class SliverChildDelegate {
   String toString() {
     final List<String> description = <String>[];
     debugFillDescription(description);
-    return '${idAndType(this)}(${description.join(", ")})';
+    return '${describeIdentity(this)}(${description.join(", ")})';
   }
 
   /// Add additional information to the given description for use by [toString].

--- a/packages/flutter/test/foundation/service_extensions_test.dart
+++ b/packages/flutter/test/foundation/service_extensions_test.dart
@@ -143,7 +143,7 @@ void main() {
     expect(console, <Matcher>[
       matches(
         r'^'
-        r'RenderView#[0-9]+\n'
+        r'RenderView#[0-9a-f]{5}\n'
         r'   debug mode enabled - [a-zA-Z]+\n'
         r'   window size: Size\(2400\.0, 1800\.0\) \(in physical pixels\)\n'
         r'   device pixel ratio: 3\.0 \(physical pixels per logical pixel\)\n'
@@ -163,8 +163,8 @@ void main() {
     expect(console, <Matcher>[
       matches(
         r'^'
-        r'TransformLayer#[0-9]+\n'
-        r'   owner: RenderView#[0-9]+\n'
+        r'TransformLayer#[0-9a-f]{5}\n'
+        r'   owner: RenderView#[0-9a-f]{5}\n'
         r'   creator: RenderView\n'
         r'   offset: Offset\(0\.0, 0\.0\)\n'
         r'   transform:\n'

--- a/packages/flutter/test/foundation/tree_diagnostics_mixin_test.dart
+++ b/packages/flutter/test/foundation/tree_diagnostics_mixin_test.dart
@@ -41,7 +41,7 @@ void main() {
     );
 
     final String dump =
-        tree.toStringDeep().replaceAll(new RegExp(r'#\d+'), '#000');
+        tree.toStringDeep().replaceAll(new RegExp(r'#[0-9a-z]{5}'), '#000');
     expect(dump, equals('''TestTree#000
  ├─child node A: TestTree#000
  │

--- a/packages/flutter/test/painting/decoration_test.dart
+++ b/packages/flutter/test/painting/decoration_test.dart
@@ -75,7 +75,7 @@ class DelayedImageProvider extends ImageProvider<DelayedImageProvider> {
   }
 
   @override
-  String toString() => '$runtimeType#$hashCode()';
+  String toString() => '${idAndType(this)}}()';
 }
 
 class TestImage extends ui.Image {

--- a/packages/flutter/test/painting/decoration_test.dart
+++ b/packages/flutter/test/painting/decoration_test.dart
@@ -75,7 +75,7 @@ class DelayedImageProvider extends ImageProvider<DelayedImageProvider> {
   }
 
   @override
-  String toString() => '${idAndType(this)}}()';
+  String toString() => '${describeIdentity(this)}}()';
 }
 
 class TestImage extends ui.Image {

--- a/packages/flutter/test/widgets/framework_test.dart
+++ b/packages/flutter/test/widgets/framework_test.dart
@@ -483,7 +483,7 @@ void main() {
     final MultiChildRenderObjectElement element = key0.currentContext;
 
     final String dump =
-        element.toStringDeep().replaceAll(new RegExp(r'#\d+'), '#000');
+        element.toStringDeep().replaceAll(new RegExp(r'#[0-9a-f]{5}'), '#000');
     expect(dump, equals('''Column([GlobalKey#000]; renderObject: RenderFlex#000)
 ├Container()
 │└LimitedBox(maxWidth: 0.0; maxHeight: 0.0; renderObject: RenderLimitedBox#000 relayoutBoundary=up1)

--- a/packages/flutter/test/widgets/global_keys_duplicated_test.dart
+++ b/packages/flutter/test/widgets/global_keys_duplicated_test.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/widgets.dart';
 
@@ -19,7 +20,7 @@ void main() {
     expect(error, isFlutterError);
     expect(error.toString(), startsWith('Duplicate keys found.\n'));
     expect(error.toString(), contains('Row'));
-    expect(error.toString(), contains('[GlobalObjectKey int#${0.hashCode}]'));
+    expect(error.toString(), contains('[GlobalObjectKey ${idAndType(0)}]'));
   });
 
   testWidgets('GlobalKey children of two nodes', (WidgetTester tester) async {
@@ -32,7 +33,7 @@ void main() {
     expect(error.toString(), startsWith('Multiple widgets used the same GlobalKey.\n'));
     expect(error.toString(), contains('different widgets that both had the following description'));
     expect(error.toString(), contains('Container'));
-    expect(error.toString(), contains('[GlobalObjectKey int#${0.hashCode}]'));
+    expect(error.toString(), contains('[GlobalObjectKey ${idAndType(0)}]'));
     expect(error.toString(), endsWith('\nA GlobalKey can only be specified on one widget at a time in the widget tree.'));
   });
 
@@ -47,7 +48,7 @@ void main() {
     expect(error.toString(), isNot(contains('different widgets that both had the following description')));
     expect(error.toString(), contains('Container()'));
     expect(error.toString(), contains('Container([<\'x\'>])'));
-    expect(error.toString(), contains('[GlobalObjectKey int#${0.hashCode}]'));
+    expect(error.toString(), contains('[GlobalObjectKey ${idAndType(0)}]'));
     expect(error.toString(), endsWith('\nA GlobalKey can only be specified on one widget at a time in the widget tree.'));
   });
 
@@ -73,7 +74,7 @@ void main() {
     // The following line is verifying the grammar is correct in this common case.
     // We should probably also verify the three other combinations that can be generated...
     expect(error.toString(), contains('This was determined by noticing that after the widget with the above global key was moved out of its previous parent, that previous parent never updated during this frame, meaning that it either did not update at all or updated before the widget was moved, in either case implying that it still thinks that it should have a child with that global key.'));
-    expect(error.toString(), contains('[GlobalObjectKey int#0]'));
+    expect(error.toString(), contains('[GlobalObjectKey ${idAndType(0)}]'));
     expect(error.toString(), contains('Container()'));
     expect(error.toString(), endsWith('\nA GlobalKey can only be specified on one widget at a time in the widget tree.'));
     expect(error, isFlutterError);

--- a/packages/flutter/test/widgets/global_keys_duplicated_test.dart
+++ b/packages/flutter/test/widgets/global_keys_duplicated_test.dart
@@ -20,7 +20,7 @@ void main() {
     expect(error, isFlutterError);
     expect(error.toString(), startsWith('Duplicate keys found.\n'));
     expect(error.toString(), contains('Row'));
-    expect(error.toString(), contains('[GlobalObjectKey ${idAndType(0)}]'));
+    expect(error.toString(), contains('[GlobalObjectKey ${describeIdentity(0)}]'));
   });
 
   testWidgets('GlobalKey children of two nodes', (WidgetTester tester) async {
@@ -33,7 +33,7 @@ void main() {
     expect(error.toString(), startsWith('Multiple widgets used the same GlobalKey.\n'));
     expect(error.toString(), contains('different widgets that both had the following description'));
     expect(error.toString(), contains('Container'));
-    expect(error.toString(), contains('[GlobalObjectKey ${idAndType(0)}]'));
+    expect(error.toString(), contains('[GlobalObjectKey ${describeIdentity(0)}]'));
     expect(error.toString(), endsWith('\nA GlobalKey can only be specified on one widget at a time in the widget tree.'));
   });
 
@@ -48,7 +48,7 @@ void main() {
     expect(error.toString(), isNot(contains('different widgets that both had the following description')));
     expect(error.toString(), contains('Container()'));
     expect(error.toString(), contains('Container([<\'x\'>])'));
-    expect(error.toString(), contains('[GlobalObjectKey ${idAndType(0)}]'));
+    expect(error.toString(), contains('[GlobalObjectKey ${describeIdentity(0)}]'));
     expect(error.toString(), endsWith('\nA GlobalKey can only be specified on one widget at a time in the widget tree.'));
   });
 
@@ -74,7 +74,7 @@ void main() {
     // The following line is verifying the grammar is correct in this common case.
     // We should probably also verify the three other combinations that can be generated...
     expect(error.toString(), contains('This was determined by noticing that after the widget with the above global key was moved out of its previous parent, that previous parent never updated during this frame, meaning that it either did not update at all or updated before the widget was moved, in either case implying that it still thinks that it should have a child with that global key.'));
-    expect(error.toString(), contains('[GlobalObjectKey ${idAndType(0)}]'));
+    expect(error.toString(), contains('[GlobalObjectKey ${describeIdentity(0)}]'));
     expect(error.toString(), contains('Container()'));
     expect(error.toString(), endsWith('\nA GlobalKey can only be specified on one widget at a time in the widget tree.'));
     expect(error, isFlutterError);

--- a/packages/flutter/test/widgets/image_resolution_test.dart
+++ b/packages/flutter/test/widgets/image_resolution_test.dart
@@ -77,7 +77,7 @@ class TestAssetBundle extends CachingAssetBundle {
   }
 
   @override
-  String toString() => '$runtimeType#$hashCode()';
+  String toString() => '${idAndType(this)}()';
 }
 
 class TestAssetImage extends AssetImage {

--- a/packages/flutter/test/widgets/image_resolution_test.dart
+++ b/packages/flutter/test/widgets/image_resolution_test.dart
@@ -77,7 +77,7 @@ class TestAssetBundle extends CachingAssetBundle {
   }
 
   @override
-  String toString() => '${idAndType(this)}()';
+  String toString() => '${describeIdentity(this)}()';
 }
 
 class TestAssetImage extends AssetImage {

--- a/packages/flutter/test/widgets/image_test.dart
+++ b/packages/flutter/test/widgets/image_test.dart
@@ -294,12 +294,12 @@ void main() {
     final TestImageProvider imageProvider = new TestImageProvider();
     await tester.pumpWidget(new Image(image: imageProvider));
     final State<Image> image = tester.state/*State<Image>*/(find.byType(Image));
-    expect(image.toString(), matches(new RegExp(r'_ImageState#[0-9]+\(stream: ImageStream\(OneFrameImageStreamCompleter; unresolved; 1 listener\); pixels: null\)')));
+    expect(image.toString(), matches(new RegExp(r'_ImageState#[0-9a-f]{5}\(stream: ImageStream\(OneFrameImageStreamCompleter; unresolved; 1 listener\); pixels: null\)')));
     imageProvider.complete();
     await tester.pump();
-    expect(image.toString(), matches(new RegExp(r'_ImageState#[0-9]+\(stream: ImageStream\(OneFrameImageStreamCompleter; \[100×100\] @ 1\.0x; 1 listener\); pixels: \[100×100\] @ 1\.0x\)')));
+    expect(image.toString(), matches(new RegExp(r'_ImageState#[0-9a-f]{5}\(stream: ImageStream\(OneFrameImageStreamCompleter; \[100×100\] @ 1\.0x; 1 listener\); pixels: \[100×100\] @ 1\.0x\)')));
     await tester.pumpWidget(new Container());
-    expect(image.toString(), matches(new RegExp(r'_ImageState#[0-9]+\(_StateLifecycle.defunct; not mounted; stream: ImageStream\(OneFrameImageStreamCompleter; \[100×100\] @ 1\.0x; 0 listeners\); pixels: \[100×100\] @ 1\.0x\)')));
+    expect(image.toString(), matches(new RegExp(r'_ImageState#[0-9a-f]{5}\(_StateLifecycle.defunct; not mounted; stream: ImageStream\(OneFrameImageStreamCompleter; \[100×100\] @ 1\.0x; 0 listeners\); pixels: \[100×100\] @ 1\.0x\)')));
   });
 
   testWidgets('Image.memory control test', (WidgetTester tester) async {
@@ -343,7 +343,7 @@ class TestImageProvider extends ImageProvider<TestImageProvider> {
   }
 
   @override
-  String toString() => '$runtimeType#$hashCode()';
+  String toString() => '${idAndType(this)}()';
 }
 
 class TestImage extends ui.Image {

--- a/packages/flutter/test/widgets/image_test.dart
+++ b/packages/flutter/test/widgets/image_test.dart
@@ -343,7 +343,7 @@ class TestImageProvider extends ImageProvider<TestImageProvider> {
   }
 
   @override
-  String toString() => '${idAndType(this)}()';
+  String toString() => '${describeIdentity(this)}()';
 }
 
 class TestImage extends ui.Image {

--- a/packages/flutter/test/widgets/table_test.dart
+++ b/packages/flutter/test/widgets/table_test.dart
@@ -524,7 +524,7 @@ void main() {
     final RenderObjectElement element = key0.currentContext;
 
     final String dump =
-        element.toStringDeep().replaceAll(new RegExp(r'#\d+'), '#000');
+        element.toStringDeep().replaceAll(new RegExp(r'#[0-9a-f]{5}'), '#000');
     expect(dump, equals('''Table([GlobalKey#000]; renderObject: RenderTable#000)
 ├Text("A")
 │└RichText(renderObject: RenderParagraph#000 relayoutBoundary=up1)


### PR DESCRIPTION
The idAndType method generates a shorter description with a consistent length
consisting of the runtime type and the a 5 hex character long truncated
version of the hash code.

Feel free to suggest a different method name. I'm not happy about idAndType but I couldn't thinking of anything better and figured you would probably have an opinion on what name would fit well with the rest of Flutter.