### PR TITLE
Fix outdated doc

### DIFF
--- a/packages/flutter/lib/src/material/app.dart
+++ b/packages/flutter/lib/src/material/app.dart
@@ -118,7 +118,7 @@ class MaterialApp extends StatefulWidget {
 
   /// The name of the first route to show.
   ///
-  /// Defaults to [Window.defaultRouteName].
+  /// Defaults to [Navigator.defaultRouteName].
   final String initialRoute;
 
   /// The route generator callback used when the app is navigated to a


### PR DESCRIPTION
Material app no longer uses `Window.defaultRouteName` as the default value of `initialRoute`.