### PR TITLE
Wait for the driver test to settle before collecting screenshots

### DIFF
--- a/examples/catalog/bin/screenshot_test.dart.template
+++ b/examples/catalog/bin/screenshot_test.dart.template
@@ -22,6 +22,7 @@ void main() {
       final List<String> paths = <String>[
         @(paths)
       ];
+      await driver.waitUntilNoTransientCallbacks();
       for (String path in paths) {
         final List<int> pixels = await driver.screenshot();
         final File file = new File(path);


### PR DESCRIPTION
Sometimes the driver would tap the screenshot generating test before it was read. This fixes that.
