### PR TITLE
upgrade package:usage to get clientId fix

### DIFF
--- a/packages/flutter_tools/pubspec.yaml
+++ b/packages/flutter_tools/pubspec.yaml
@@ -24,7 +24,7 @@ dependencies:
   process: 2.0.3
   quiver: ^0.24.0
   stack_trace: ^1.4.0
-  usage: ^3.0.1
+  usage: ^3.1.1
   vm_service_client: '0.2.2+4'
   web_socket_channel: ^1.0.4
   xml: ^2.4.1


### PR DESCRIPTION
The upstream fix was: https://github.com/dart-lang/usage/commit/021664efd35d563ee21eadbed40af6b5e8e23b2e

Absence of `clientId` caused crash reporting to not function in the rare situation when `$HOME/.flutter` has not been initialized yet.