### PR TITLE
Print ADB output when `adb install` fails

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_device.dart
+++ b/packages/flutter_tools/lib/src/android/android_device.dart
@@ -276,6 +276,7 @@ class AndroidDevice extends Device {
     }
     if (installResult.exitCode != 0) {
       printError('Error: ADB exited with exit code ${installResult.exitCode}');
+      printError('$installResult');
       return false;
     }
 


### PR DESCRIPTION
Fixes #10929