### PR TITLE
Lazily initialise Xcode installation status

### DIFF
--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -99,8 +99,6 @@ class Xcode {
       return false;
     if (!xcodeVersionRegex.hasMatch(xcodeVersionText))
       return false;
-    if (!eulaSigned)
-      return false;
     return true;
   }
 

--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -80,54 +80,60 @@ class IMobileDevice {
 }
 
 class Xcode {
-  Xcode() {
-    _eulaSigned = false;
-
-    try {
-      _xcodeSelectPath = runSync(<String>['xcode-select', '--print-path'])?.trim();
-      if (_xcodeSelectPath == null || _xcodeSelectPath.isEmpty) {
-        _isInstalled = false;
-        return;
-      }
-      _isInstalled = true;
-
-      _xcodeVersionText = runSync(<String>['xcodebuild', '-version']).replaceAll('\n', ', ');
-
-      if (!xcodeVersionRegex.hasMatch(_xcodeVersionText)) {
-        _isInstalled = false;
-      } else {
-        try {
-          final ProcessResult result = processManager.runSync(<String>['/usr/bin/xcrun', 'clang']);
-
-          if (result.stdout != null && result.stdout.contains('license'))
-            _eulaSigned = false;
-          else if (result.stderr != null && result.stderr.contains('license'))
-            _eulaSigned = false;
-          else
-            _eulaSigned = true;
-        } catch (error) {
-          _eulaSigned = false;
-        }
-      }
-    } catch (error) {
-      _isInstalled = false;
-    }
-  }
-
   bool get isInstalledAndMeetsVersionCheck => isInstalled && xcodeVersionSatisfactory;
 
   String _xcodeSelectPath;
-  String get xcodeSelectPath => _xcodeSelectPath;
+  String get xcodeSelectPath {
+    if (_xcodeSelectPath == null) {
+      try {
+        _xcodeSelectPath = runSync(<String>['/usr/bin/xcode-select', '--print-path'])?.trim();
+      } on ProcessException {
+        // Ignore: return null below.
+      }
+    }
+    return _xcodeSelectPath;
+  }
 
-  bool _isInstalled;
-  bool get isInstalled => _isInstalled;
+  bool get isInstalled {
+    if (xcodeSelectPath != null && xcodeSelectPath.isNotEmpty)
+      return false;
+    if (!xcodeVersionRegex.hasMatch(xcodeVersionText))
+      return false;
+    if (!eulaSigned)
+      return false;
+    return true;
+  }
 
   bool _eulaSigned;
   /// Has the EULA been signed?
-  bool get eulaSigned => _eulaSigned;
+  bool get eulaSigned {
+    if (_eulaSigned == null) {
+      try {
+        final ProcessResult result = processManager.runSync(<String>['/usr/bin/xcrun', 'clang']);
+        if (result.stdout != null && result.stdout.contains('license'))
+          _eulaSigned = false;
+        else if (result.stderr != null && result.stderr.contains('license'))
+          _eulaSigned = false;
+        else
+          _eulaSigned = true;
+      } on ProcessException {
+        _eulaSigned = false;
+      }
+    }
+    return _eulaSigned;
+  }
 
   String _xcodeVersionText;
-  String get xcodeVersionText => _xcodeVersionText;
+  String get xcodeVersionText {
+    if (_xcodeVersionText != null) {
+      try {
+        _xcodeVersionText = runSync(<String>['/usr/bin/xcodebuild', '-version']).replaceAll('\n', ', ');
+      } on ProcessException {
+        // Ignore: return null below.
+      }
+    }
+    return _xcodeVersionText;
+  }
 
   int _xcodeMajorVersion;
   int get xcodeMajorVersion => _xcodeMajorVersion;

--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -95,7 +95,7 @@ class Xcode {
   }
 
   bool get isInstalled {
-    if (xcodeSelectPath != null && xcodeSelectPath.isNotEmpty)
+    if (xcodeSelectPath == null || xcodeSelectPath.isEmpty)
       return false;
     if (!xcodeVersionRegex.hasMatch(xcodeVersionText))
       return false;


### PR DESCRIPTION
Rather than pre-compute Xcode install path, version, and EULA status,
compute and cache on demand.