### PR TITLE
Update instructions to add option to install via RubyGems

### DIFF
--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -381,14 +381,22 @@ final String noCocoaPodsConsequence = '''
   For more info, see https://flutter.io/platform-plugins''';
 
 final String cocoaPodsInstallInstructions = '''
-  brew update
-  brew install cocoapods
-  pod setup''';
+  Via RubyGems (if using Ruby version manager):
+    gem install cocoapods
+    pod setup
+  Via Homebrew (if using system Ruby):
+    brew update
+    brew install cocoapods
+    pod setup''';
 
 final String cocoaPodsUpgradeInstructions = '''
-  brew update
-  brew upgrade cocoapods
-  pod setup''';
+  Via RubyGems (if using Ruby version manager):
+    gem update cocoapods
+    pod setup
+  Via Homebrew (if using system Ruby):
+    brew update
+    brew upgrade cocoapods
+    pod setup''';
 
 Future<Null> _runPodInstall(Directory bundle, String engineDirectory) async {
   if (fs.file(fs.path.join(bundle.path, 'Podfile')).existsSync()) {


### PR DESCRIPTION
I ran into an issue with the Homebrew install because I was using a Ruby version manager...

```
❯ pod setup
dyld: lazy symbol binding failed: Symbol not found: _rb_str_new_static
  Referenced from: /Users/jared/.gem/ruby/2.4.1/gems/json-2.1.0/lib/json/ext/generator.bundle
  Expected in: flat namespace

dyld: Symbol not found: _rb_str_new_static
  Referenced from: /Users/jared/.gem/ruby/2.4.1/gems/json-2.1.0/lib/json/ext/generator.bundle
  Expected in: flat namespace

[1]    39800 abort      pod setup
```

Suggesting updating instructions to add installation via RubyGems. This is also the officially recommended way to install CocoaPods.