### PR TITLE
update our build bot exclusions

### DIFF
--- a/packages/flutter_tools/lib/src/base/utils.dart
+++ b/packages/flutter_tools/lib/src/base/utils.dart
@@ -15,16 +15,20 @@ import 'file_system.dart';
 import 'platform.dart';
 
 bool get isRunningOnBot {
-  // https://docs.travis-ci.com/user/environment-variables/#Default-Environment-Variables
-  // https://www.appveyor.com/docs/environment-variables/
-  // CHROME_HEADLESS is one property set on Flutter's Chrome Infra bots.
   return
-    platform.environment['TRAVIS'] == 'true' ||
     platform.environment['BOT'] == 'true' ||
+
+    // https://docs.travis-ci.com/user/environment-variables/#Default-Environment-Variables
+    platform.environment['TRAVIS'] == 'true' ||
     platform.environment['CONTINUOUS_INTEGRATION'] == 'true' ||
+    platform.environment.containsKey('CI') || // Travis and AppVeyor
+
+    // https://www.appveyor.com/docs/environment-variables/
+    platform.environment.containsKey('APPVEYOR') ||
+
+    // Properties on Flutter's Chrome Infra bots.
     platform.environment['CHROME_HEADLESS'] == '1' ||
-    platform.environment['APPVEYOR'] == 'true' ||
-    platform.environment['CI'] == 'true';
+    platform.environment.containsKey('BUILDBOT_BUILDERNAME');
 }
 
 String hex(List<int> bytes) {


### PR DESCRIPTION
- add one more env var to recognize chrome bots (`BUILDBOT_BUILDERNAME`)
- switch the method we use to recognize bots on windows. We were using env var `==` comparisons, generally to `true`; however the appveyor docs say the value will be `True`. In order to avoid case issues, we now just check for the presence of the key.

@tvolkert @Hixie 