### PR TITLE
Use defaultTargetPlatform instead of Platform.operatingSystem for ImageProvider.

### DIFF
--- a/packages/flutter/lib/src/foundation/tree_diagnostics_mixin.dart
+++ b/packages/flutter/lib/src/foundation/tree_diagnostics_mixin.dart
@@ -16,6 +16,7 @@ String shortHash(Object object) {
 String describeIdentity(Object object) =>
     '${object.runtimeType}#${shortHash(object)}';
 
+// This method exists as a workaround for https://github.com/dart-lang/sdk/issues/30021
 /// Returns a short description of an enum value.
 ///
 /// Strips off the enum class name from the `enumEntry.toString()`.

--- a/packages/flutter/lib/src/foundation/tree_diagnostics_mixin.dart
+++ b/packages/flutter/lib/src/foundation/tree_diagnostics_mixin.dart
@@ -16,6 +16,29 @@ String shortHash(Object object) {
 String describeIdentity(Object object) =>
     '${object.runtimeType}#${shortHash(object)}';
 
+/// Returns a short description of an enum value.
+///
+/// Strips off the enum class name from the `enumEntry.toString()`.
+///
+/// For example:
+///
+/// ```dart
+/// enum Day {
+///   monday, tuesday, wednesday, thursday, friday, saturday, sunday
+/// }
+///
+/// main() {
+///   assert(Day.monday.toString() == 'Day.monday');
+///   assert(describeEnum(Day.monday) == 'monday');
+/// }
+/// ```
+String describeEnum(Object enumEntry) {
+  final String description = enumEntry.toString();
+  final int indexOfDot = description.indexOf('.');
+  assert(indexOfDot != -1 && indexOfDot < description.length - 1);
+  return description.substring(indexOfDot + 1);
+}
+
 /// A mixin that helps dump string representations of trees.
 abstract class TreeDiagnosticsMixin {
   // This class is intended to be used as a mixin, and should not be

--- a/packages/flutter/lib/src/services/image_provider.dart
+++ b/packages/flutter/lib/src/services/image_provider.dart
@@ -73,11 +73,11 @@ class ImageConfiguration {
   /// The size at which the image will be rendered.
   final Size size;
 
-  /// A string (same as [Platform.operatingSystem]) that represents the platform
-  /// for which assets should be used. This allows images to be specified in a
-  /// platform-neutral fashion yet use different assets on different platforms,
-  /// to match local conventions e.g. for color matching or shadows.
-  final String platform;
+  /// The [TargetPlatform] for which assets should be used. This allows images
+  /// to be specified in a platform-neutral fashion yet use different assets on
+  /// different platforms, to match local conventions e.g. for color matching or
+  /// shadows.
+  final TargetPlatform platform;
 
   /// An image configuration that provides no additional information.
   ///
@@ -131,7 +131,7 @@ class ImageConfiguration {
     if (platform != null) {
       if (hasArguments)
         result.write(', ');
-      result.write('platform: $platform');
+      result.write('platform: ${describeEnum(platform)}');
       hasArguments = true;
     }
     result.write(')');

--- a/packages/flutter/lib/src/widgets/image.dart
+++ b/packages/flutter/lib/src/widgets/image.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:io' show File, Platform;
+import 'dart:io' show File;
 import 'dart:typed_data';
 
 import 'package:flutter/foundation.dart';
@@ -40,7 +40,7 @@ ImageConfiguration createLocalImageConfiguration(BuildContext context, { Size si
     devicePixelRatio: MediaQuery.of(context, nullOk: true)?.devicePixelRatio ?? 1.0,
     // TODO(ianh): provide the locale
     size: size,
-    platform: Platform.operatingSystem,
+    platform: defaultTargetPlatform,
   );
 }
 


### PR DESCRIPTION
Also add a convenience helper to make it easier to display a short string for enum values.