### PR TITLE
Make consistent use of gradle wrapper

### DIFF
--- a/dev/benchmarks/complex_layout/android/.gitignore
+++ b/dev/benchmarks/complex_layout/android/.gitignore
@@ -8,6 +8,6 @@
 /captures
 GeneratedPluginRegistrant.java
 
-/gradle
+gradle-wrapper.jar
 /gradlew
 /gradlew.bat

--- a/dev/benchmarks/complex_layout/android/app/build.gradle
+++ b/dev/benchmarks/complex_layout/android/app/build.gradle
@@ -23,6 +23,10 @@ android {
     }
 
     defaultConfig {
+        minSdkVersion 16
+        targetSdkVersion 25
+        versionCode 1
+        versionName "0.0.1"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
 

--- a/dev/benchmarks/complex_layout/android/app/src/main/AndroidManifest.xml
+++ b/dev/benchmarks/complex_layout/android/app/src/main/AndroidManifest.xml
@@ -1,9 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.yourcompany.complexLayout"
-    android:versionCode="1"
-    android:versionName="0.0.1">
+    package="com.yourcompany.complexLayout">
 
-    <uses-sdk android:minSdkVersion="16" android:targetSdkVersion="21" />
     <uses-permission android:name="android.permission.INTERNET"/>
 
     <application android:name="io.flutter.app.FlutterApplication" android:label="complex_layout" android:icon="@mipmap/ic_launcher">

--- a/dev/benchmarks/complex_layout/android/build.gradle
+++ b/dev/benchmarks/complex_layout/android/build.gradle
@@ -1,10 +1,13 @@
 buildscript {
     repositories {
         jcenter()
+        maven {
+            url "https://maven.google.com"
+        }
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:2.3.3'
     }
 }
 
@@ -20,12 +23,9 @@ allprojects {
 rootProject.buildDir = '../build'
 subprojects {
     project.buildDir = "${rootProject.buildDir}/${project.name}"
+    project.evaluationDependsOn(':app')
 }
 
 task clean(type: Delete) {
     delete rootProject.buildDir
-}
-
-task wrapper(type: Wrapper) {
-    gradleVersion = '2.14.1'
 }

--- a/dev/benchmarks/complex_layout/android/gradle/wrapper/gradle-wrapper.properties
+++ b/dev/benchmarks/complex_layout/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,0 +1,6 @@
+#Fri Jun 23 08:50:38 CEST 2017
+distributionBase=GRADLE_USER_HOME
+distributionPath=wrapper/dists
+zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip

--- a/dev/benchmarks/microbenchmarks/android/.gitignore
+++ b/dev/benchmarks/microbenchmarks/android/.gitignore
@@ -8,6 +8,6 @@
 /captures
 GeneratedPluginRegistrant.java
 
-/gradle
+gradle-wrapper.jar
 /gradlew
 /gradlew.bat

--- a/dev/benchmarks/microbenchmarks/android/app/build.gradle
+++ b/dev/benchmarks/microbenchmarks/android/app/build.gradle
@@ -23,6 +23,10 @@ android {
     }
 
     defaultConfig {
+        minSdkVersion 16
+        targetSdkVersion 25
+        versionCode 1
+        versionName "0.0.1"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
 

--- a/dev/benchmarks/microbenchmarks/android/app/src/main/AndroidManifest.xml
+++ b/dev/benchmarks/microbenchmarks/android/app/src/main/AndroidManifest.xml
@@ -1,9 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.yourcompany.microbenchmarks"
-    android:versionCode="1"
-    android:versionName="0.0.1">
+    package="com.yourcompany.microbenchmarks">
 
-    <uses-sdk android:minSdkVersion="16" android:targetSdkVersion="21" />
     <uses-permission android:name="android.permission.INTERNET"/>
 
     <application android:name="io.flutter.app.FlutterApplication" android:label="microbenchmarks" android:icon="@mipmap/ic_launcher">

--- a/dev/benchmarks/microbenchmarks/android/build.gradle
+++ b/dev/benchmarks/microbenchmarks/android/build.gradle
@@ -1,10 +1,13 @@
 buildscript {
     repositories {
         jcenter()
+        maven {
+            url "https://maven.google.com"
+        }
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:2.3.3'
     }
 }
 
@@ -20,12 +23,9 @@ allprojects {
 rootProject.buildDir = '../build'
 subprojects {
     project.buildDir = "${rootProject.buildDir}/${project.name}"
+    project.evaluationDependsOn(':app')
 }
 
 task clean(type: Delete) {
     delete rootProject.buildDir
-}
-
-task wrapper(type: Wrapper) {
-    gradleVersion = '2.14.1'
 }

--- a/dev/benchmarks/microbenchmarks/android/gradle/wrapper/gradle-wrapper.properties
+++ b/dev/benchmarks/microbenchmarks/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,0 +1,6 @@
+#Fri Jun 23 08:50:38 CEST 2017
+distributionBase=GRADLE_USER_HOME
+distributionPath=wrapper/dists
+zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip

--- a/dev/integration_tests/channels/android/.gitignore
+++ b/dev/integration_tests/channels/android/.gitignore
@@ -8,6 +8,6 @@
 /captures
 GeneratedPluginRegistrant.java
 
-/gradle
+gradle-wrapper.jar
 /gradlew
 /gradlew.bat

--- a/dev/integration_tests/channels/android/app/build.gradle
+++ b/dev/integration_tests/channels/android/app/build.gradle
@@ -23,6 +23,10 @@ android {
     }
 
     defaultConfig {
+        minSdkVersion 16
+        targetSdkVersion 25
+        versionCode 1
+        versionName "0.0.1"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
 

--- a/dev/integration_tests/channels/android/app/src/main/AndroidManifest.xml
+++ b/dev/integration_tests/channels/android/app/src/main/AndroidManifest.xml
@@ -1,9 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.yourcompany.channels"
-    android:versionCode="1"
-    android:versionName="0.0.1">
-
-    <uses-sdk android:minSdkVersion="16" android:targetSdkVersion="21" />
+    package="com.yourcompany.channels">
 
     <!-- The INTERNET permission is required for development. Specifically,
          flutter needs it to communicate with the running application

--- a/dev/integration_tests/channels/android/build.gradle
+++ b/dev/integration_tests/channels/android/build.gradle
@@ -1,10 +1,13 @@
 buildscript {
     repositories {
         jcenter()
+        maven {
+            url "https://maven.google.com"
+        }
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:2.3.3'
     }
 }
 
@@ -25,8 +28,4 @@ subprojects {
 
 task clean(type: Delete) {
     delete rootProject.buildDir
-}
-
-task wrapper(type: Wrapper) {
-    gradleVersion = '2.14.1'
 }

--- a/dev/integration_tests/channels/android/gradle/wrapper/gradle-wrapper.properties
+++ b/dev/integration_tests/channels/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,0 +1,6 @@
+#Fri Jun 23 08:50:38 CEST 2017
+distributionBase=GRADLE_USER_HOME
+distributionPath=wrapper/dists
+zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip

--- a/dev/integration_tests/ui/android/.gitignore
+++ b/dev/integration_tests/ui/android/.gitignore
@@ -8,6 +8,6 @@
 /captures
 GeneratedPluginRegistrant.java
 
-/gradle
+gradle-wrapper.jar
 /gradlew
 /gradlew.bat

--- a/dev/integration_tests/ui/android/app/build.gradle
+++ b/dev/integration_tests/ui/android/app/build.gradle
@@ -23,6 +23,10 @@ android {
     }
 
     defaultConfig {
+        minSdkVersion 16
+        targetSdkVersion 25
+        versionCode 1
+        versionName "1.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
 

--- a/dev/integration_tests/ui/android/app/src/main/AndroidManifest.xml
+++ b/dev/integration_tests/ui/android/app/src/main/AndroidManifest.xml
@@ -3,11 +3,7 @@
      found in the LICENSE file.
  -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.yourcompany.integration_ui"
-    android:versionCode="1"
-    android:versionName="0.0.1">
-
-    <uses-sdk android:minSdkVersion="16" android:targetSdkVersion="21" />
+    package="com.yourcompany.integration_ui">
 
     <!-- The INTERNET permission is required for development. Specifically,
          flutter needs it to communicate with the running application

--- a/dev/integration_tests/ui/android/build.gradle
+++ b/dev/integration_tests/ui/android/build.gradle
@@ -1,10 +1,13 @@
 buildscript {
     repositories {
         jcenter()
+        maven {
+            url "https://maven.google.com"
+        }
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:2.3.3'
     }
 }
 
@@ -25,8 +28,4 @@ subprojects {
 
 task clean(type: Delete) {
     delete rootProject.buildDir
-}
-
-task wrapper(type: Wrapper) {
-    gradleVersion = '2.14.1'
 }

--- a/dev/integration_tests/ui/android/gradle/wrapper/gradle-wrapper.properties
+++ b/dev/integration_tests/ui/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,0 +1,6 @@
+#Fri Jun 23 08:50:38 CEST 2017
+distributionBase=GRADLE_USER_HOME
+distributionPath=wrapper/dists
+zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip

--- a/dev/manual_tests/android/.gitignore
+++ b/dev/manual_tests/android/.gitignore
@@ -8,6 +8,6 @@
 /captures
 GeneratedPluginRegistrant.java
 
-/gradle
+gradle-wrapper.jar
 /gradlew
 /gradlew.bat

--- a/dev/manual_tests/android/app/src/main/AndroidManifest.xml
+++ b/dev/manual_tests/android/app/src/main/AndroidManifest.xml
@@ -4,11 +4,7 @@
      found in the LICENSE file.
 -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="io.flutter.examples.manual_tests"
-    android:versionCode="1"
-    android:versionName="0.0.1">
-
-    <uses-sdk android:minSdkVersion="16" android:targetSdkVersion="21" />
+    package="io.flutter.examples.manual_tests">
 
     <!-- The INTERNET permission is required for development. Specifically,
          flutter needs it to communicate with the running application

--- a/dev/manual_tests/android/build.gradle
+++ b/dev/manual_tests/android/build.gradle
@@ -1,10 +1,13 @@
 buildscript {
     repositories {
         jcenter()
+        maven {
+            url "https://maven.google.com"
+        }
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:2.3.3'
     }
 }
 
@@ -25,8 +28,4 @@ subprojects {
 
 task clean(type: Delete) {
     delete rootProject.buildDir
-}
-
-task wrapper(type: Wrapper) {
-    gradleVersion = '2.14.1'
 }

--- a/dev/manual_tests/android/gradle/wrapper/gradle-wrapper.properties
+++ b/dev/manual_tests/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,0 +1,6 @@
+#Fri Jun 23 08:50:38 CEST 2017
+distributionBase=GRADLE_USER_HOME
+distributionPath=wrapper/dists
+zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip

--- a/examples/README.md
+++ b/examples/README.md
@@ -44,3 +44,12 @@ Available examples include:
 
 - **Stocks** The [stocks](stocks) demo shows how one might structure
   an application with several screens.
+
+Note on Gradle wrapper files in `.gitignore`:
+
+Gradle wrapper files should normally be checked into source control.
+The example projects don't do that to avoid having several copies of the
+wrapper binary in the Flutter repo. Instead, the Gradle wrapper is
+injected by Flutter tooling, and the wrapper files are .gitignore'd to
+avoid making the Flutter repository dirty as a side effect of running
+the examples.

--- a/examples/catalog/android/.gitignore
+++ b/examples/catalog/android/.gitignore
@@ -8,6 +8,6 @@
 /captures
 GeneratedPluginRegistrant.java
 
-/gradle
+gradle-wrapper.jar
 /gradlew
 /gradlew.bat

--- a/examples/catalog/android/.gitignore
+++ b/examples/catalog/android/.gitignore
@@ -8,6 +8,8 @@
 /captures
 GeneratedPluginRegistrant.java
 
+# Gradle wrapper files should normally be checked into source control.
+# See ../../README.md
 gradle-wrapper.jar
 /gradlew
 /gradlew.bat

--- a/examples/catalog/android/app/build.gradle
+++ b/examples/catalog/android/app/build.gradle
@@ -23,6 +23,11 @@ android {
     }
 
     defaultConfig {
+        applicationId "io.flutter.examples.catalog"
+        minSdkVersion 16
+        targetSdkVersion 25
+        versionCode 1
+        versionName "1.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
 

--- a/examples/catalog/android/app/src/main/AndroidManifest.xml
+++ b/examples/catalog/android/app/src/main/AndroidManifest.xml
@@ -1,9 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.yourcompany.animated_list"
-    android:versionCode="1"
-    android:versionName="0.0.1">
-
-    <uses-sdk android:minSdkVersion="16" android:targetSdkVersion="21" />
+    package="com.yourcompany.animated_list">
 
     <!-- The INTERNET permission is required for development. Specifically,
          flutter needs it to communicate with the running application

--- a/examples/catalog/android/build.gradle
+++ b/examples/catalog/android/build.gradle
@@ -1,10 +1,13 @@
 buildscript {
     repositories {
         jcenter()
+        maven {
+            url "https://maven.google.com"
+        }
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:2.3.3'
     }
 }
 
@@ -25,8 +28,4 @@ subprojects {
 
 task clean(type: Delete) {
     delete rootProject.buildDir
-}
-
-task wrapper(type: Wrapper) {
-    gradleVersion = '2.14.1'
 }

--- a/examples/catalog/android/gradle/wrapper/gradle-wrapper.properties
+++ b/examples/catalog/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,0 +1,6 @@
+#Fri Jun 23 08:50:38 CEST 2017
+distributionBase=GRADLE_USER_HOME
+distributionPath=wrapper/dists
+zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip

--- a/examples/flutter_gallery/android/.gitignore
+++ b/examples/flutter_gallery/android/.gitignore
@@ -8,6 +8,6 @@
 /captures
 GeneratedPluginRegistrant.java
 
-/gradle
+gradle-wrapper.jar
 /gradlew
 /gradlew.bat

--- a/examples/flutter_gallery/android/.gitignore
+++ b/examples/flutter_gallery/android/.gitignore
@@ -8,6 +8,8 @@
 /captures
 GeneratedPluginRegistrant.java
 
+# Gradle wrapper files should normally be checked into source control.
+# See ../../README.md
 gradle-wrapper.jar
 /gradlew
 /gradlew.bat

--- a/examples/flutter_gallery/android/app/build.gradle
+++ b/examples/flutter_gallery/android/app/build.gradle
@@ -23,10 +23,12 @@ android {
     }
 
     defaultConfig {
-        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
-
-        // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "io.flutter.examples.gallery"
+        minSdkVersion 16
+        targetSdkVersion 25
+        versionCode 1
+        versionName "0.0.1"
+        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
 
     buildTypes {

--- a/examples/flutter_gallery/android/app/src/main/AndroidManifest.xml
+++ b/examples/flutter_gallery/android/app/src/main/AndroidManifest.xml
@@ -4,11 +4,7 @@
      found in the LICENSE file.
  -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="io.flutter.examples.gallery"
-    android:versionCode="1"
-    android:versionName="0.0.1">
-
-    <uses-sdk android:minSdkVersion="16" android:targetSdkVersion="21" />
+    package="io.flutter.examples.gallery">
 
     <!-- The INTERNET permission is required for development. Specifically,
          flutter needs it to communicate with the running application

--- a/examples/flutter_gallery/android/build.gradle
+++ b/examples/flutter_gallery/android/build.gradle
@@ -1,10 +1,13 @@
 buildscript {
     repositories {
         jcenter()
+        maven {
+            url "https://maven.google.com"
+        }
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:2.3.3'
     }
 }
 
@@ -25,8 +28,4 @@ subprojects {
 
 task clean(type: Delete) {
     delete rootProject.buildDir
-}
-
-task wrapper(type: Wrapper) {
-    gradleVersion = '2.14.1'
 }

--- a/examples/flutter_gallery/android/gradle/wrapper/gradle-wrapper.properties
+++ b/examples/flutter_gallery/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,0 +1,6 @@
+#Fri Jun 23 08:50:38 CEST 2017
+distributionBase=GRADLE_USER_HOME
+distributionPath=wrapper/dists
+zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip

--- a/examples/flutter_view/android/.gitignore
+++ b/examples/flutter_view/android/.gitignore
@@ -8,6 +8,6 @@
 /captures
 GeneratedPluginRegistrant.java
 
-/gradle
+gradle-wrapper.jar
 /gradlew
 /gradlew.bat

--- a/examples/flutter_view/android/.gitignore
+++ b/examples/flutter_view/android/.gitignore
@@ -8,6 +8,8 @@
 /captures
 GeneratedPluginRegistrant.java
 
+# Gradle wrapper files should normally be checked into source control.
+# See ../../README.md
 gradle-wrapper.jar
 /gradlew
 /gradlew.bat

--- a/examples/flutter_view/android/app/build.gradle
+++ b/examples/flutter_view/android/app/build.gradle
@@ -23,6 +23,11 @@ android {
     }
 
     defaultConfig {
+        applicationId "io.flutter.examples.flutter_view"
+        minSdkVersion 16
+        targetSdkVersion 25
+        versionCode 1
+        versionName "0.0.1"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
 

--- a/examples/flutter_view/android/app/src/main/AndroidManifest.xml
+++ b/examples/flutter_view/android/app/src/main/AndroidManifest.xml
@@ -1,9 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.example.view"
-    android:versionCode="1"
-    android:versionName="0.0.1">
-
-    <uses-sdk android:minSdkVersion="16" android:targetSdkVersion="21" />
+    package="com.example.view">
 
     <!-- The INTERNET permission is required for development. Specifically, flutter needs it to communicate with the running application
          to allow setting breakpoints, to provide hot reload, etc.

--- a/examples/flutter_view/android/build.gradle
+++ b/examples/flutter_view/android/build.gradle
@@ -1,10 +1,13 @@
 buildscript {
     repositories {
         jcenter()
+        maven {
+            url "https://maven.google.com"
+        }
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:2.3.3'
     }
 }
 
@@ -25,8 +28,4 @@ subprojects {
 
 task clean(type: Delete) {
     delete rootProject.buildDir
-}
-
-task wrapper(type: Wrapper) {
-    gradleVersion = '2.14.1'
 }

--- a/examples/flutter_view/android/gradle/wrapper/gradle-wrapper.properties
+++ b/examples/flutter_view/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,0 +1,6 @@
+#Fri Jun 23 08:50:38 CEST 2017
+distributionBase=GRADLE_USER_HOME
+distributionPath=wrapper/dists
+zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip

--- a/examples/hello_world/android/.gitignore
+++ b/examples/hello_world/android/.gitignore
@@ -8,6 +8,6 @@
 /captures
 GeneratedPluginRegistrant.java
 
-/gradle
+gradle-wrapper.jar
 /gradlew
 /gradlew.bat

--- a/examples/hello_world/android/.gitignore
+++ b/examples/hello_world/android/.gitignore
@@ -8,6 +8,8 @@
 /captures
 GeneratedPluginRegistrant.java
 
+# Gradle wrapper files should normally be checked into source control.
+# See ../../README.md
 gradle-wrapper.jar
 /gradlew
 /gradlew.bat

--- a/examples/hello_world/android/app/build.gradle
+++ b/examples/hello_world/android/app/build.gradle
@@ -23,10 +23,12 @@ android {
     }
 
     defaultConfig {
-        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
-
-        // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "io.flutter.examples.hello_world"
+        minSdkVersion 16
+        targetSdkVersion 25
+        versionCode 1
+        versionName "0.0.1"
+        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
 
     buildTypes {

--- a/examples/hello_world/android/app/src/main/AndroidManifest.xml
+++ b/examples/hello_world/android/app/src/main/AndroidManifest.xml
@@ -4,11 +4,7 @@
      found in the LICENSE file.
 -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="io.flutter.examples.hello_world"
-    android:versionCode="1"
-    android:versionName="0.0.1">
-
-    <uses-sdk android:minSdkVersion="16" android:targetSdkVersion="21" />
+    package="io.flutter.examples.hello_world">
 
     <!-- The INTERNET permission is required for development. Specifically,
          flutter needs it to communicate with the running application

--- a/examples/hello_world/android/build.gradle
+++ b/examples/hello_world/android/build.gradle
@@ -1,10 +1,13 @@
 buildscript {
     repositories {
         jcenter()
+        maven {
+            url "https://maven.google.com"
+        }
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:2.3.3'
     }
 }
 
@@ -25,8 +28,4 @@ subprojects {
 
 task clean(type: Delete) {
     delete rootProject.buildDir
-}
-
-task wrapper(type: Wrapper) {
-    gradleVersion = '2.14.1'
 }

--- a/examples/hello_world/android/gradle/wrapper/gradle-wrapper.properties
+++ b/examples/hello_world/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,0 +1,6 @@
+#Fri Jun 23 08:50:38 CEST 2017
+distributionBase=GRADLE_USER_HOME
+distributionPath=wrapper/dists
+zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip

--- a/examples/layers/android/.gitignore
+++ b/examples/layers/android/.gitignore
@@ -8,6 +8,6 @@
 /captures
 GeneratedPluginRegistrant.java
 
-/gradle
+gradle-wrapper.jar
 /gradlew
 /gradlew.bat

--- a/examples/layers/android/.gitignore
+++ b/examples/layers/android/.gitignore
@@ -8,6 +8,8 @@
 /captures
 GeneratedPluginRegistrant.java
 
+# Gradle wrapper files should normally be checked into source control.
+# See ../../README.md
 gradle-wrapper.jar
 /gradlew
 /gradlew.bat

--- a/examples/layers/android/app/build.gradle
+++ b/examples/layers/android/app/build.gradle
@@ -23,6 +23,11 @@ android {
     }
 
     defaultConfig {
+        applicationId "io.flutter.examples.layers"
+        minSdkVersion 16
+        targetSdkVersion 25
+        versionCode 1
+        versionName "0.0.1"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
 

--- a/examples/layers/android/app/src/main/AndroidManifest.xml
+++ b/examples/layers/android/app/src/main/AndroidManifest.xml
@@ -1,9 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="io.flutter.examples.Layers"
-    android:versionCode="1"
-    android:versionName="0.0.1">
-
-    <uses-sdk android:minSdkVersion="16" android:targetSdkVersion="21" />
+    package="io.flutter.examples.Layers">
 
     <!-- The INTERNET permission is required for development. Specifically,
          flutter needs it to communicate with the running application

--- a/examples/layers/android/build.gradle
+++ b/examples/layers/android/build.gradle
@@ -1,10 +1,13 @@
 buildscript {
     repositories {
         jcenter()
+        maven {
+            url "https://maven.google.com"
+        }
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:2.3.3'
     }
 }
 
@@ -20,12 +23,9 @@ allprojects {
 rootProject.buildDir = '../build'
 subprojects {
     project.buildDir = "${rootProject.buildDir}/${project.name}"
+    project.evaluationDependsOn(':app')
 }
 
 task clean(type: Delete) {
     delete rootProject.buildDir
-}
-
-task wrapper(type: Wrapper) {
-    gradleVersion = '2.14.1'
 }

--- a/examples/layers/android/gradle/wrapper/gradle-wrapper.properties
+++ b/examples/layers/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,0 +1,6 @@
+#Fri Jun 23 08:50:38 CEST 2017
+distributionBase=GRADLE_USER_HOME
+distributionPath=wrapper/dists
+zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip

--- a/examples/platform_channel/android/.gitignore
+++ b/examples/platform_channel/android/.gitignore
@@ -8,6 +8,6 @@
 /captures
 GeneratedPluginRegistrant.java
 
-/gradle
+gradle-wrapper.jar
 /gradlew
 /gradlew.bat

--- a/examples/platform_channel/android/.gitignore
+++ b/examples/platform_channel/android/.gitignore
@@ -8,6 +8,8 @@
 /captures
 GeneratedPluginRegistrant.java
 
+# Gradle wrapper files should normally be checked into source control.
+# See ../../README.md
 gradle-wrapper.jar
 /gradlew
 /gradlew.bat

--- a/examples/platform_channel/android/app/build.gradle
+++ b/examples/platform_channel/android/app/build.gradle
@@ -23,8 +23,12 @@ android {
     }
 
     defaultConfig {
+        applicationId "io.flutter.examples.platform_channel"
+        minSdkVersion 16
+        targetSdkVersion 25
+        versionCode 1
+        versionName "0.0.1"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
-        applicationId "com.example.platformchannel"
     }
 
     buildTypes {

--- a/examples/platform_channel/android/app/src/main/AndroidManifest.xml
+++ b/examples/platform_channel/android/app/src/main/AndroidManifest.xml
@@ -1,10 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.example.platformchannel"
-    android:versionCode="1"
-    android:versionName="0.0.1">
-
-    <uses-sdk android:minSdkVersion="16" android:targetSdkVersion="21" />
+    package="com.example.platformchannel">
 
     <!-- The INTERNET permission is required for development. Specifically,
          flutter needs it to communicate with the running application

--- a/examples/platform_channel/android/build.gradle
+++ b/examples/platform_channel/android/build.gradle
@@ -1,10 +1,13 @@
 buildscript {
     repositories {
         jcenter()
+        maven {
+            url "https://maven.google.com"
+        }
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:2.3.3'
     }
 }
 
@@ -25,8 +28,4 @@ subprojects {
 
 task clean(type: Delete) {
     delete rootProject.buildDir
-}
-
-task wrapper(type: Wrapper) {
-    gradleVersion = '2.14.1'
 }

--- a/examples/platform_channel/android/gradle/wrapper/gradle-wrapper.properties
+++ b/examples/platform_channel/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,0 +1,6 @@
+#Fri Jun 23 08:50:38 CEST 2017
+distributionBase=GRADLE_USER_HOME
+distributionPath=wrapper/dists
+zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip

--- a/examples/platform_view/android/.gitignore
+++ b/examples/platform_view/android/.gitignore
@@ -8,6 +8,6 @@
 /captures
 GeneratedPluginRegistrant.java
 
-/gradle
+gradle-wrapper.jar
 /gradlew
 /gradlew.bat

--- a/examples/platform_view/android/.gitignore
+++ b/examples/platform_view/android/.gitignore
@@ -8,6 +8,8 @@
 /captures
 GeneratedPluginRegistrant.java
 
+# Gradle wrapper files should normally be checked into source control.
+# See ../../README.md
 gradle-wrapper.jar
 /gradlew
 /gradlew.bat

--- a/examples/platform_view/android/app/build.gradle
+++ b/examples/platform_view/android/app/build.gradle
@@ -23,10 +23,12 @@ android {
     }
 
     defaultConfig {
-        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
-
-        // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "io.flutter.examples.platform_view"
+        minSdkVersion 16
+        targetSdkVersion 25
+        versionCode 1
+        versionName "0.0.1"
+        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
 
     buildTypes {

--- a/examples/platform_view/android/app/src/main/AndroidManifest.xml
+++ b/examples/platform_view/android/app/src/main/AndroidManifest.xml
@@ -1,11 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="io.flutter.examples.platform_view"
-    android:versionCode="1"
-    android:versionName="0.0.1">
-
-    <uses-sdk
-        android:minSdkVersion="16"
-        android:targetSdkVersion="21" />
+    package="io.flutter.examples.platform_view">
 
     <!-- The INTERNET permission is required for development. Specifically,
          flutter needs it to communicate with the running application

--- a/examples/platform_view/android/build.gradle
+++ b/examples/platform_view/android/build.gradle
@@ -1,10 +1,13 @@
 buildscript {
     repositories {
         jcenter()
+        maven {
+            url "https://maven.google.com"
+        }
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:2.3.3'
     }
 }
 
@@ -25,8 +28,4 @@ subprojects {
 
 task clean(type: Delete) {
     delete rootProject.buildDir
-}
-
-task wrapper(type: Wrapper) {
-    gradleVersion = '2.14.1'
 }

--- a/examples/platform_view/android/gradle/wrapper/gradle-wrapper.properties
+++ b/examples/platform_view/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,0 +1,6 @@
+#Fri Jun 23 08:50:38 CEST 2017
+distributionBase=GRADLE_USER_HOME
+distributionPath=wrapper/dists
+zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip

--- a/examples/stocks/android/.gitignore
+++ b/examples/stocks/android/.gitignore
@@ -8,6 +8,6 @@
 /captures
 GeneratedPluginRegistrant.java
 
-/gradle
+gradle-wrapper.jar
 /gradlew
 /gradlew.bat

--- a/examples/stocks/android/.gitignore
+++ b/examples/stocks/android/.gitignore
@@ -8,6 +8,8 @@
 /captures
 GeneratedPluginRegistrant.java
 
+# Gradle wrapper files should normally be checked into source control.
+# See ../../README.md
 gradle-wrapper.jar
 /gradlew
 /gradlew.bat

--- a/examples/stocks/android/app/build.gradle
+++ b/examples/stocks/android/app/build.gradle
@@ -23,8 +23,12 @@ android {
     }
 
     defaultConfig {
-        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
         applicationId "io.flutter.examples.stocks"
+        minSdkVersion 16
+        targetSdkVersion 25
+        versionCode 1
+        versionName "0.0.1"
+        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
 
     buildTypes {

--- a/examples/stocks/android/app/src/main/AndroidManifest.xml
+++ b/examples/stocks/android/app/src/main/AndroidManifest.xml
@@ -4,11 +4,7 @@
      found in the LICENSE file.
  -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="io.flutter.examples.stocks"
-    android:versionCode="1"
-    android:versionName="0.0.1">
-
-    <uses-sdk android:minSdkVersion="16" android:targetSdkVersion="21" />
+    package="io.flutter.examples.stocks">
 
     <!-- The INTERNET permission is required for development. Specifically,
          flutter needs it to communicate with the running application

--- a/examples/stocks/android/build.gradle
+++ b/examples/stocks/android/build.gradle
@@ -1,10 +1,13 @@
 buildscript {
     repositories {
         jcenter()
+        maven {
+            url "https://maven.google.com"
+        }
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:2.3.3'
     }
 }
 
@@ -25,8 +28,4 @@ subprojects {
 
 task clean(type: Delete) {
     delete rootProject.buildDir
-}
-
-task wrapper(type: Wrapper) {
-    gradleVersion = '2.14.1'
 }

--- a/examples/stocks/android/gradle/wrapper/gradle-wrapper.properties
+++ b/examples/stocks/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,0 +1,6 @@
+#Fri Jun 23 08:50:38 CEST 2017
+distributionBase=GRADLE_USER_HOME
+distributionPath=wrapper/dists
+zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip

--- a/packages/flutter_tools/gradle/flutter.gradle
+++ b/packages/flutter_tools/gradle/flutter.gradle
@@ -21,7 +21,7 @@ buildscript {
     jcenter()
   }
   dependencies {
-    classpath 'com.android.tools.build:gradle:2.3.3'
+    classpath 'com.android.tools.build:gradle:2.2.3'
   }
 }
 

--- a/packages/flutter_tools/gradle/flutter.gradle
+++ b/packages/flutter_tools/gradle/flutter.gradle
@@ -21,7 +21,7 @@ buildscript {
     jcenter()
   }
   dependencies {
-    classpath 'com.android.tools.build:gradle:2.2.3'
+    classpath 'com.android.tools.build:gradle:2.3.3'
   }
 }
 

--- a/packages/flutter_tools/lib/src/android/android_studio.dart
+++ b/packages/flutter_tools/lib/src/android/android_studio.dart
@@ -234,6 +234,7 @@ class AndroidStudio implements Comparable<AndroidStudio> {
         final String javaVersion = versionLines.length >= 2 ? versionLines[1] : versionLines[0];
         _validationMessages.add('Java version $javaVersion');
         _javaPath = javaPath;
+        _isValid = true;
       } else {
         _validationMessages.add('Unable to determine bundled Java version.');
       }

--- a/packages/flutter_tools/lib/src/android/android_studio_validator.dart
+++ b/packages/flutter_tools/lib/src/android/android_studio_validator.dart
@@ -4,10 +4,6 @@
 
 import 'dart:async';
 
-import '../base/file_system.dart';
-import '../base/io.dart';
-import '../base/platform.dart';
-import '../base/process_manager.dart';
 import '../base/version.dart';
 import '../doctor.dart';
 import '../globals.dart';
@@ -26,10 +22,6 @@ class AndroidStudioValidator extends DoctorValidator {
     } else {
       validators.addAll(studios
           .map((AndroidStudio studio) => new AndroidStudioValidator(studio)));
-    }
-    final String cfgGradleDir = config.getValue('gradle-dir');
-    if (cfgGradleDir != null) {
-      validators.add(new ConfiguredGradleValidator(cfgGradleDir));
     }
     return validators;
   }
@@ -82,56 +74,5 @@ class NoAndroidStudioValidator extends DoctorValidator {
 
     return new ValidationResult(ValidationType.missing, messages,
         statusInfo: 'not installed');
-  }
-}
-
-class ConfiguredGradleValidator extends DoctorValidator {
-  final String cfgGradleDir;
-
-  ConfiguredGradleValidator(this.cfgGradleDir) : super('Gradle');
-
-  @override
-  Future<ValidationResult> validate() async {
-    ValidationType type = ValidationType.missing;
-    final List<ValidationMessage> messages = <ValidationMessage>[];
-
-    messages.add(new ValidationMessage('gradle-dir = $cfgGradleDir'));
-
-    String gradleExecutable = cfgGradleDir;
-    if (!fs.isFileSync(cfgGradleDir)) {
-      gradleExecutable = fs.path.join(
-          cfgGradleDir, 'bin', platform.isWindows ? 'gradle.bat' : 'gradle');
-    }
-    String versionString;
-    if (processManager.canRun(gradleExecutable)) {
-      type = ValidationType.partial;
-      final ProcessResult result =
-          processManager.runSync(<String>[gradleExecutable, '--version']);
-      if (result.exitCode == 0) {
-        versionString = result.stdout
-            .toString()
-            .split('\n')
-            .firstWhere((String s) => s.startsWith('Gradle '))
-            .substring('Gradle '.length);
-        final Version version = new Version.parse(versionString) ?? Version.unknown;
-        if (version >= minGradleVersion) {
-          type = ValidationType.installed;
-        } else {
-          messages.add(new ValidationMessage.error(
-              'Gradle version $minGradleVersion required. Found version $versionString.'));
-        }
-      } else {
-        messages
-            .add(new ValidationMessage('Unable to determine Gradle version.'));
-      }
-    } else {
-      messages
-          .add(new ValidationMessage('Gradle not found at $gradleExecutable'));
-    }
-
-    messages.add(new ValidationMessage(
-        'Flutter supports building with Gradle from Android Studio.\n'
-        'Consider removing your gradle-dir setting by running:\nflutter config --gradle-dir='));
-    return new ValidationResult(type, messages, statusInfo: versionString);
   }
 }

--- a/packages/flutter_tools/lib/src/android/gradle.dart
+++ b/packages/flutter_tools/lib/src/android/gradle.dart
@@ -124,20 +124,24 @@ String locateProjectGradlew({ bool ensureExecutable: true }) {
     if (ensureExecutable)
       os.makeExecutable(gradle);
     return gradle.absolute.path;
-  } else {
-    return null;
   }
+  return null;
 }
 
 String ensureGradle() {
   String gradle = locateProjectGradlew();
   if (gradle == null) {
-    gradle = locateSystemGradle();
-    if (gradle == null)
-      throwToolExit('Unable to locate gradle. Please install Android Studio.');
+    _injectGradleWrapper();
+    gradle = locateProjectGradlew();
   }
+  if (gradle == null)
+    throwToolExit('Unable to locate gradle. Please install Android Studio.');
   printTrace('Using gradle from $gradle.');
   return gradle;
+}
+
+void _injectGradleWrapper() {
+  copyDirectorySync(cache.getArtifactDirectory('gradle_wrapper'), fs.directory('android'));
 }
 
 /// Create android/local.properties if needed, and update Flutter settings.
@@ -226,7 +230,7 @@ Future<Null> buildGradleProjectV2(String gradle, String buildModeName, String ta
   final String assembleTask = "assemble${toTitleCase(buildModeName)}";
 
   // Run 'gradle assemble<BuildMode>'.
-  final Status status = logger.startProgress('Running \'gradle $assembleTask\'...', expectSlowOperation: true);
+  final Status status = logger.startProgress('Running \'gradlew $assembleTask\'...', expectSlowOperation: true);
   final String gradlePath = fs.file(gradle).absolute.path;
   final List<String> command = <String>[gradlePath];
   if (!logger.isVerbose) {

--- a/packages/flutter_tools/lib/src/android/gradle.dart
+++ b/packages/flutter_tools/lib/src/android/gradle.dart
@@ -138,7 +138,7 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\\://services.gradle.org/distributions/gradle-${gradleVersion}-all.zip
+distributionUrl=https\\://services.gradle.org/distributions/gradle-$gradleVersion-all.zip
 ''', flush: true,
     );
   }

--- a/packages/flutter_tools/lib/src/android/gradle.dart
+++ b/packages/flutter_tools/lib/src/android/gradle.dart
@@ -115,8 +115,9 @@ String locateProjectGradlew({ bool ensureExecutable: true }) {
     if (ensureExecutable)
       os.makeExecutable(gradle);
     return gradle.absolute.path;
+  } else {
+    return null;
   }
-  return null;
 }
 
 String ensureGradle() {

--- a/packages/flutter_tools/templates/create/android-java.tmpl/app/build.gradle.tmpl
+++ b/packages/flutter_tools/templates/create/android-java.tmpl/app/build.gradle.tmpl
@@ -23,10 +23,13 @@ android {
     }
 
     defaultConfig {
-        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
-
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "{{androidIdentifier}}"
+        minSdkVersion 16
+        targetSdkVersion 25
+        versionCode 1
+        versionName "1.0"
+        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
 
     buildTypes {

--- a/packages/flutter_tools/templates/create/android-java.tmpl/build.gradle
+++ b/packages/flutter_tools/templates/create/android-java.tmpl/build.gradle
@@ -1,6 +1,9 @@
 buildscript {
     repositories {
         jcenter()
+        maven {
+            url "https://maven.google.com"
+        }
     }
 
     dependencies {

--- a/packages/flutter_tools/templates/create/android-kotlin.tmpl/app/build.gradle.tmpl
+++ b/packages/flutter_tools/templates/create/android-kotlin.tmpl/app/build.gradle.tmpl
@@ -28,10 +28,13 @@ android {
     }
 
     defaultConfig {
-        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
-
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "{{androidIdentifier}}"
+        minSdkVersion 16
+        targetSdkVersion 25
+        versionCode 1
+        versionName "1.0"
+        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
 
     buildTypes {

--- a/packages/flutter_tools/templates/create/android-kotlin.tmpl/build.gradle
+++ b/packages/flutter_tools/templates/create/android-kotlin.tmpl/build.gradle
@@ -1,6 +1,9 @@
 buildscript {
     repositories {
         jcenter()
+        maven {
+            url "https://maven.google.com"
+        }
     }
 
     dependencies {

--- a/packages/flutter_tools/templates/create/android.tmpl/app/src/main/AndroidManifest.xml.tmpl
+++ b/packages/flutter_tools/templates/create/android.tmpl/app/src/main/AndroidManifest.xml.tmpl
@@ -1,9 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="{{androidIdentifier}}"
-    android:versionCode="1"
-    android:versionName="0.0.1">
-
-    <uses-sdk android:minSdkVersion="{{androidMinApiLevel}}" android:targetSdkVersion="21" />
+    package="{{androidIdentifier}}">
 
     <!-- The INTERNET permission is required for development. Specifically,
          flutter needs it to communicate with the running application

--- a/packages/flutter_tools/templates/plugin/android-java.tmpl/build.gradle.tmpl
+++ b/packages/flutter_tools/templates/plugin/android-java.tmpl/build.gradle.tmpl
@@ -30,8 +30,6 @@ android {
     buildToolsVersion '25.0.3'
 
     defaultConfig {
-        // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
-        applicationId "{{androidIdentifier}}"
         minSdkVersion 16
         targetSdkVersion 25
         versionCode 1

--- a/packages/flutter_tools/templates/plugin/android-java.tmpl/build.gradle.tmpl
+++ b/packages/flutter_tools/templates/plugin/android-java.tmpl/build.gradle.tmpl
@@ -4,6 +4,9 @@ version '1.0-SNAPSHOT'
 buildscript {
     repositories {
         jcenter()
+        maven {
+            url "https://maven.google.com"
+        }
     }
 
     dependencies {
@@ -27,6 +30,12 @@ android {
     buildToolsVersion '25.0.3'
 
     defaultConfig {
+        // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
+        applicationId "{{androidIdentifier}}"
+        minSdkVersion 16
+        targetSdkVersion 25
+        versionCode 1
+        versionName "1.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
     lintOptions {

--- a/packages/flutter_tools/templates/plugin/android-kotlin.tmpl/build.gradle.tmpl
+++ b/packages/flutter_tools/templates/plugin/android-kotlin.tmpl/build.gradle.tmpl
@@ -4,6 +4,9 @@ version '1.0-SNAPSHOT'
 buildscript {
     repositories {
         jcenter()
+        maven {
+            url "https://maven.google.com"
+        }
     }
 
     dependencies {

--- a/packages/flutter_tools/templates/plugin/android-kotlin.tmpl/build.gradle.tmpl
+++ b/packages/flutter_tools/templates/plugin/android-kotlin.tmpl/build.gradle.tmpl
@@ -34,6 +34,10 @@ android {
         main.java.srcDirs += 'src/main/kotlin'
     }
     defaultConfig {
+        minSdkVersion 16
+        targetSdkVersion 25
+        versionCode 1
+        versionName "1.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
     lintOptions {

--- a/packages/flutter_tools/templates/plugin/android.tmpl/src/main/AndroidManifest.xml.tmpl
+++ b/packages/flutter_tools/templates/plugin/android.tmpl/src/main/AndroidManifest.xml.tmpl
@@ -1,7 +1,3 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="{{androidIdentifier}}"
-  android:versionCode="1"
-  android:versionName="0.0.1">
-
-  <uses-sdk android:minSdkVersion="16" android:targetSdkVersion="21" />
+  package="{{androidIdentifier}}">
 </manifest>


### PR DESCRIPTION
- Flutter tooling now injects Gradle wrapper files into projects that do not have them. This helps prepare active projects for the Android Studio 3.0.0 release where Gradle and Android Gradle plugin versions will be bumped. It also allows us to build `examples/` and `dev/` apps with the Gradle wrapper without committing wrapper scripts and binaries to the Flutter repo.
- Flutter tool implementation no longer retrieves Gradle from user's Android Studio installation, but relies on the Gradle wrapper managed by the Flutter cache instead.
- `examples/` and `dev/` apps have been updated to match new project templates.

Fixes #9765.