### PR TITLE
Re-enable coverage and docs uploading

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 os:
   - linux
-sudo: false
+sudo: required
 addons:
   apt:
     # sky_shell binary depends on /usr/lib/x86_64-linux-gnu/libstdc++.so.6 version GLIBCXX_3.4.18
@@ -22,8 +22,7 @@ env:
 before_script:
   - ./dev/bots/travis_setup.sh
 script:
-  # TODO(tvolkert): Re-enable `&& ./dev/bots/travis_upload.sh`
-  - (./bin/cache/dart-sdk/bin/dart ./dev/bots/test.dart)
+  - (./bin/cache/dart-sdk/bin/dart ./dev/bots/test.dart && ./dev/bots/travis_upload.sh)
 cache:
   directories:
     - $HOME/.pub-cache

--- a/dev/bots/travis_setup.sh
+++ b/dev/bots/travis_setup.sh
@@ -5,11 +5,10 @@ echo $KEY_FILE | base64 --decode > ../gcloud_key_file.json
 
 set -x
 
-# TODO(tvolkert): Re-enable once this is able to successfully run on Travis
-#if [ -n "$TRAVIS" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
-#  export CLOUDSDK_CORE_DISABLE_PROMPTS=1
-#  curl https://sdk.cloud.google.com | bash
-#fi
+if [ -n "$TRAVIS" ]; then
+  export CLOUDSDK_CORE_DISABLE_PROMPTS=1
+  curl https://sdk.cloud.google.com | bash
+fi
 
 # disable analytics on the bots and download Flutter dependencies
 ./bin/flutter config --no-analytics

--- a/dev/tools/java_and_objc_doc.dart
+++ b/dev/tools/java_and_objc_doc.dart
@@ -23,7 +23,7 @@ Future<Null> main(List<String> args) async {
   final String objcdocUrl =
       'https://storage.googleapis.com/flutter_infra/flutter/$engineVersion/ios-objcdoc.zip';
   generateDocs(
-      objcdocUrl, 'objcdoc', 'objc/Classes/FlutterViewController.html');
+      objcdocUrl, 'objcdoc', 'Classes/FlutterViewController.html');
 }
 
 Future<Null> generateDocs(


### PR DESCRIPTION
This time, do so in Travis' sudo-enabled environment,
which is said to be less prone to networking issues.
It also means we'll run in an env with 7.5GB of RAM
instead of 4GB or RAM (at the cost of about 45 seconds
of extra boot-up time).

https://github.com/flutter/flutter/issues/10940