### PR TITLE
Minor fixes in tools:

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_device.dart
+++ b/packages/flutter_tools/lib/src/android/android_device.dart
@@ -242,8 +242,13 @@ class AndroidDevice extends Device {
   @override
   Future<bool> isAppInstalled(ApplicationPackage app) async {
     // This call takes 400ms - 600ms.
-    final RunResult listOut = await runCheckedAsync(adbCommandForDevice(<String>['shell', 'pm', 'list', 'packages', app.id]));
-    return LineSplitter.split(listOut.stdout).contains("package:${app.id}");
+    try {
+      final RunResult listOut = await runCheckedAsync(adbCommandForDevice(<String>['shell', 'pm', 'list', 'packages', app.id]));
+      return LineSplitter.split(listOut.stdout).contains("package:${app.id}");
+    } catch (error) {
+      printTrace('$error');
+      return false;
+    }
   }
 
   @override

--- a/packages/flutter_tools/lib/src/android/android_device.dart
+++ b/packages/flutter_tools/lib/src/android/android_device.dart
@@ -244,7 +244,7 @@ class AndroidDevice extends Device {
     // This call takes 400ms - 600ms.
     try {
       final RunResult listOut = await runCheckedAsync(adbCommandForDevice(<String>['shell', 'pm', 'list', 'packages', app.id]));
-      return LineSplitter.split(listOut.stdout).contains("package:${app.id}");
+      return LineSplitter.split(listOut.stdout).contains('package:${app.id}');
     } catch (error) {
       printTrace('$error');
       return false;

--- a/packages/flutter_tools/lib/src/base/process.dart
+++ b/packages/flutter_tools/lib/src/base/process.dart
@@ -211,7 +211,7 @@ Future<RunResult> runCheckedAsync(List<String> cmd, {
       environment: environment
   );
   if (result.exitCode != 0)
-    throw 'Exit code ${result.exitCode} from: ${cmd.join(' ')}';
+    throw 'Exit code ${result.exitCode} from: ${cmd.join(' ')}:\n$result';
   return result;
 }
 

--- a/packages/flutter_tools/lib/src/crash_reporting.dart
+++ b/packages/flutter_tools/lib/src/crash_reporting.dart
@@ -90,6 +90,8 @@ class CrashReportSender {
       req.fields['osVersion'] = os.name;  // this actually includes version
       req.fields['type'] = _kDartTypeId;
       req.fields['error_runtime_type'] = '${error.runtimeType}';
+      // TODO(tvolkert): Uncomment this (flutter/flutter/11008)
+      //req.fields['error_message'] = '$error';
 
       final String stackTraceWithRelativePaths = new Chain.parse(stackTrace.toString()).terse.toString();
       req.files.add(new http.MultipartFile.fromString(

--- a/packages/flutter_tools/lib/src/crash_reporting.dart
+++ b/packages/flutter_tools/lib/src/crash_reporting.dart
@@ -90,8 +90,6 @@ class CrashReportSender {
       req.fields['osVersion'] = os.name;  // this actually includes version
       req.fields['type'] = _kDartTypeId;
       req.fields['error_runtime_type'] = '${error.runtimeType}';
-      // TODO(tvolkert): Uncomment this (https://github.com/flutter/flutter/issues/11008)
-      //req.fields['error_message'] = '$error';
 
       final String stackTraceWithRelativePaths = new Chain.parse(stackTrace.toString()).terse.toString();
       req.files.add(new http.MultipartFile.fromString(

--- a/packages/flutter_tools/lib/src/crash_reporting.dart
+++ b/packages/flutter_tools/lib/src/crash_reporting.dart
@@ -90,7 +90,7 @@ class CrashReportSender {
       req.fields['osVersion'] = os.name;  // this actually includes version
       req.fields['type'] = _kDartTypeId;
       req.fields['error_runtime_type'] = '${error.runtimeType}';
-      // TODO(tvolkert): Uncomment this (flutter/flutter/11008)
+      // TODO(tvolkert): Uncomment this (https://github.com/flutter/flutter/issues/11008)
       //req.fields['error_message'] = '$error';
 
       final String stackTraceWithRelativePaths = new Chain.parse(stackTrace.toString()).terse.toString();


### PR DESCRIPTION
* Include the process' `stdout` and `stderr` when it returns a
  non-zero exit code in `runCheckedAsync()`
* Defensively catch errors in `AndroidDevice.isAppInstalled()`
  and return false
* Prepare for including the error message in crash reports - to
  be uncommented when https://github.com/flutter/flutter/wiki/Flutter-CLI-crash-reporting
  has been live for sufficient time for users to see it and have
  a chance to respond.