### PR TITLE
Provide user feedback on slow Gradle operations

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_device.dart
+++ b/packages/flutter_tools/lib/src/android/android_device.dart
@@ -360,7 +360,7 @@ class AndroidDevice extends Device {
       );
       // Package has been built, so we can get the updated application ID and
       // activity name from the .apk.
-      package = new AndroidApk.fromCurrentDirectory();
+      package = await AndroidApk.fromCurrentDirectory();
     }
 
     printTrace("Stopping app '${package.name}' on $name.");

--- a/packages/flutter_tools/lib/src/application_package.dart
+++ b/packages/flutter_tools/lib/src/application_package.dart
@@ -85,16 +85,16 @@ class AndroidApk extends ApplicationPackage {
     String apkPath;
 
     if (isProjectUsingGradle()) {
-      if (fs.file(await getGradleAppOut()).existsSync()) {
+      final String apkPath = await getGradleAppOut();
+      if (fs.file(apkPath).existsSync()) {
         // Grab information from the .apk. The gradle build script might alter
         // the application Id, so we need to look at what was actually built.
-        return new AndroidApk.fromApk(await getGradleAppOut());
+        return new AndroidApk.fromApk(apkPath);
       }
       // The .apk hasn't been built yet, so we work with what we have. The run
       // command will grab a new AndroidApk after building, to get the updated
       // IDs.
       manifestPath = gradleManifestPath;
-      apkPath = await getGradleAppOut();
     } else {
       manifestPath = fs.path.join('android', 'AndroidManifest.xml');
       apkPath = fs.path.join(getAndroidBuildDirectory(), 'app.apk');

--- a/packages/flutter_tools/lib/src/commands/build_ios.dart
+++ b/packages/flutter_tools/lib/src/commands/build_ios.dart
@@ -45,7 +45,7 @@ class BuildIOSCommand extends BuildSubCommand {
     if (getCurrentHostPlatform() != HostPlatform.darwin_x64)
       throwToolExit('Building for iOS is only supported on the Mac.');
 
-    final BuildableIOSApp app = applicationPackages.getPackageForPlatform(TargetPlatform.ios);
+    final BuildableIOSApp app = await applicationPackages.getPackageForPlatform(TargetPlatform.ios);
 
     if (app == null)
       throwToolExit('Application not configured for iOS');

--- a/packages/flutter_tools/lib/src/commands/drive.dart
+++ b/packages/flutter_tools/lib/src/commands/drive.dart
@@ -229,7 +229,7 @@ Future<LaunchResult> _startApp(DriveCommand command) async {
   await appStopper(command);
 
   printTrace('Installing application package.');
-  final ApplicationPackage package = command.applicationPackages
+  final ApplicationPackage package = await command.applicationPackages
       .getPackageForPlatform(await command.device.targetPlatform);
   if (await command.device.isAppInstalled(package))
     await command.device.uninstallApp(package);
@@ -304,7 +304,7 @@ void restoreAppStopper() {
 
 Future<bool> _stopApp(DriveCommand command) async {
   printTrace('Stopping application.');
-  final ApplicationPackage package = command.applicationPackages.getPackageForPlatform(await command.device.targetPlatform);
+  final ApplicationPackage package = await command.applicationPackages.getPackageForPlatform(await command.device.targetPlatform);
   final bool stopped = await command.device.stopApp(package);
   await command._deviceLogSubscription?.cancel();
   return stopped;

--- a/packages/flutter_tools/lib/src/commands/install.dart
+++ b/packages/flutter_tools/lib/src/commands/install.dart
@@ -31,7 +31,7 @@ class InstallCommand extends FlutterCommand {
 
   @override
   Future<Null> runCommand() async {
-    final ApplicationPackage package = applicationPackages.getPackageForPlatform(await device.targetPlatform);
+    final ApplicationPackage package = await applicationPackages.getPackageForPlatform(await device.targetPlatform);
 
     Cache.releaseLockEarly();
 

--- a/packages/flutter_tools/lib/src/commands/stop.dart
+++ b/packages/flutter_tools/lib/src/commands/stop.dart
@@ -32,7 +32,7 @@ class StopCommand extends FlutterCommand {
   @override
   Future<Null> runCommand() async {
     final TargetPlatform targetPlatform = await device.targetPlatform;
-    final ApplicationPackage app = applicationPackages.getPackageForPlatform(targetPlatform);
+    final ApplicationPackage app = await applicationPackages.getPackageForPlatform(targetPlatform);
     if (app == null) {
       final String platformName = getNameForTargetPlatform(targetPlatform);
       throwToolExit('No Flutter application for $platformName found in the current directory.');

--- a/packages/flutter_tools/lib/src/plugins.dart
+++ b/packages/flutter_tools/lib/src/plugins.dart
@@ -179,7 +179,7 @@ void _writeIOSPluginRegistry(String directory, List<Plugin> plugins) {
 }
 
 /// Finds Flutter plugins in the pubspec.yaml, creates platform injection
-/// registries classes and add them to the build depedencies.
+/// registries classes and add them to the build dependencies.
 ///
 /// Returns whether any Flutter plugins are added.
 bool injectPlugins({String directory}) {

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -210,7 +210,7 @@ class FlutterDevice {
     printStatus('Launching ${getDisplayPath(hotRunner.mainPath)} on ${device.name} in $modeName mode...');
 
     final TargetPlatform targetPlatform = await device.targetPlatform;
-    package = getApplicationPackageForPlatform(
+    package = await getApplicationPackageForPlatform(
       targetPlatform,
       applicationBinary: hotRunner.applicationBinary
     );
@@ -261,7 +261,7 @@ class FlutterDevice {
     bool shouldBuild: true,
   }) async {
     final TargetPlatform targetPlatform = await device.targetPlatform;
-    package = getApplicationPackageForPlatform(
+    package = await getApplicationPackageForPlatform(
       targetPlatform,
       applicationBinary: coldRunner.applicationBinary
     );


### PR DESCRIPTION
Bootstrapping Gradle via the Gradle Wrapper may involve downloading and unpacking a Gradle installation. Took 8 seconds last I tried.

Invoking Gradle afterwards (just to learn where it wants to put the apk) involves resolving dependencies, which may in turn involve downloading the internet. Took >30 seconds last I tried.

These processes are now executed by async functions and using a slow-op status logger to provide a reasonable UX.

Fixes #10994.