### PR TITLE
Exclude modal barrier from semantics on Android

### DIFF
--- a/packages/flutter/lib/src/material/drawer.dart
+++ b/packages/flutter/lib/src/material/drawer.dart
@@ -272,6 +272,8 @@ class DrawerControllerState extends State<DrawerController> with SingleTickerPro
             children: <Widget>[
               new BlockSemantics(
                 child: new GestureDetector(
+                  // On Android, the back button is used to dismiss a modal.
+                  excludeFromSemantics: defaultTargetPlatform == TargetPlatform.android,
                   onTap: close,
                   child: new Container(
                     color: _color.evaluate(_controller)

--- a/packages/flutter/lib/src/widgets/modal_barrier.dart
+++ b/packages/flutter/lib/src/widgets/modal_barrier.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:flutter/foundation.dart';
+
 import 'basic.dart';
 import 'container.dart';
 import 'framework.dart';
@@ -28,7 +30,8 @@ class ModalBarrier extends StatelessWidget {
   Widget build(BuildContext context) {
     return new BlockSemantics(
       child: new ExcludeSemantics(
-        excluding: !dismissible,
+        // On Android, the back button is used to dismiss a modal.
+        excluding: !dismissible || defaultTargetPlatform == TargetPlatform.android,
         child: new Semantics(
           container: true,
           child: new GestureDetector(

--- a/packages/flutter/test/material/dialog_test.dart
+++ b/packages/flutter/test/material/dialog_test.dart
@@ -212,7 +212,7 @@ void main() {
       ),
     );
 
-    expect(semantics, includesNodeWithLabel(buttonText));
+    expect(semantics, includesNodeWith(label: buttonText));
 
     final BuildContext context = tester.element(find.text(buttonText));
 
@@ -224,8 +224,8 @@ void main() {
 
     await tester.pumpAndSettle(const Duration(seconds: 1));
 
-    expect(semantics, includesNodeWithLabel(alertText));
-    expect(semantics, isNot(includesNodeWithLabel(buttonText)));
+    expect(semantics, includesNodeWith(label: alertText));
+    expect(semantics, isNot(includesNodeWith(label: buttonText)));
 
     semantics.dispose();
   });

--- a/packages/flutter/test/material/scaffold_test.dart
+++ b/packages/flutter/test/material/scaffold_test.dart
@@ -459,22 +459,22 @@ void main() {
       drawer: new Drawer(child:new Semantics(label: drawerLabel, child: new Container())),
     )));
 
-    expect(semantics, includesNodeWithLabel(bodyLabel));
-    expect(semantics, includesNodeWithLabel(persistentFooterButtonLabel));
-    expect(semantics, includesNodeWithLabel(bottomNavigationBarLabel));
-    expect(semantics, includesNodeWithLabel(floatingActionButtonLabel));
-    expect(semantics, isNot(includesNodeWithLabel(drawerLabel)));
+    expect(semantics, includesNodeWith(label: bodyLabel));
+    expect(semantics, includesNodeWith(label: persistentFooterButtonLabel));
+    expect(semantics, includesNodeWith(label: bottomNavigationBarLabel));
+    expect(semantics, includesNodeWith(label: floatingActionButtonLabel));
+    expect(semantics, isNot(includesNodeWith(label: drawerLabel)));
 
     final ScaffoldState state = tester.firstState(find.byType(Scaffold));
     state.openDrawer();
     await tester.pump();
     await tester.pump(const Duration(seconds: 1));
 
-    expect(semantics, isNot(includesNodeWithLabel(bodyLabel)));
-    expect(semantics, isNot(includesNodeWithLabel(persistentFooterButtonLabel)));
-    expect(semantics, isNot(includesNodeWithLabel(bottomNavigationBarLabel)));
-    expect(semantics, isNot(includesNodeWithLabel(floatingActionButtonLabel)));
-    expect(semantics, includesNodeWithLabel(drawerLabel));
+    expect(semantics, isNot(includesNodeWith(label: bodyLabel)));
+    expect(semantics, isNot(includesNodeWith(label: persistentFooterButtonLabel)));
+    expect(semantics, isNot(includesNodeWith(label: bottomNavigationBarLabel)));
+    expect(semantics, isNot(includesNodeWith(label: floatingActionButtonLabel)));
+    expect(semantics, includesNodeWith(label: drawerLabel));
 
     semantics.dispose();
   });

--- a/packages/flutter/test/widgets/drawer_test.dart
+++ b/packages/flutter/test/widgets/drawer_test.dart
@@ -3,8 +3,12 @@
 // found in the LICENSE file.
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
+
+import 'semantics_tester.dart';
 
 void main() {
 
@@ -172,4 +176,60 @@ void main() {
     expect(buttonPressed, equals(true));
   });
 
+  testWidgets('Dismissible ModalBarrier includes button in semantic tree on iOS', (WidgetTester tester) async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+
+    final SemanticsTester semantics = new SemanticsTester(tester);
+    final GlobalKey<ScaffoldState> scaffoldKey = new GlobalKey<ScaffoldState>();
+
+    await tester.pumpWidget(
+        new MaterialApp(
+            home: new Builder(
+                builder: (BuildContext context) {
+                  return new Scaffold(
+                      key: scaffoldKey,
+                      drawer: const Drawer(),
+                  );
+                }
+            )
+        )
+    );
+
+    // Open the drawer.
+    scaffoldKey.currentState.openDrawer();
+    await tester.pump(const Duration(milliseconds: 100));
+
+    expect(semantics, includesNodeWith(actions: <SemanticsAction>[SemanticsAction.tap]));
+
+    semantics.dispose();
+
+    debugDefaultTargetPlatformOverride = null;
+  });
+
+  testWidgets('Dismissible ModalBarrier is hidden on Android (back button is used to dismiss)', (WidgetTester tester) async {
+    final SemanticsTester semantics = new SemanticsTester(tester);
+    final GlobalKey<ScaffoldState> scaffoldKey = new GlobalKey<ScaffoldState>();
+
+    await tester.pumpWidget(
+        new MaterialApp(
+            home: new Builder(
+                builder: (BuildContext context) {
+                  return new Scaffold(
+                      key: scaffoldKey,
+                      drawer: const Drawer(),
+                      body: new Container()
+                  );
+                }
+            )
+        )
+    );
+
+    // Open the drawer.
+    scaffoldKey.currentState.openDrawer();
+    await tester.pump(const Duration(milliseconds: 100));
+
+    expect(semantics, isNot(includesNodeWith(actions: <SemanticsAction>[SemanticsAction.tap])));
+
+    semantics.dispose();
+  });
 }

--- a/packages/flutter/test/widgets/modal_barrier_test.dart
+++ b/packages/flutter/test/widgets/modal_barrier_test.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
@@ -92,7 +93,9 @@ void main() {
     semantics.dispose();
   });
 
-  testWidgets('Dismissible ModalBarrier includes button in semantic tree', (WidgetTester tester) async {
+  testWidgets('Dismissible ModalBarrier includes button in semantic tree on iOS', (WidgetTester tester) async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+
     final SemanticsTester semantics = new SemanticsTester(tester);
     await tester.pumpWidget(const ModalBarrier(dismissible: true));
 
@@ -111,6 +114,17 @@ void main() {
         ),
       ]
     );
+    expect(semantics, hasSemantics(expectedSemantics));
+
+    semantics.dispose();
+    debugDefaultTargetPlatformOverride = null;
+  });
+
+  testWidgets('Dismissible ModalBarrier is hidden on Android (back button is used to dismiss)', (WidgetTester tester) async {
+    final SemanticsTester semantics = new SemanticsTester(tester);
+    await tester.pumpWidget(const ModalBarrier(dismissible: true));
+
+    final TestSemantics expectedSemantics = new TestSemantics.root();
     expect(semantics, hasSemantics(expectedSemantics));
 
     semantics.dispose();

--- a/packages/flutter/test/widgets/semantics_9_test.dart
+++ b/packages/flutter/test/widgets/semantics_9_test.dart
@@ -28,7 +28,7 @@ void main() {
         ],
       ));
 
-      expect(semantics, isNot(includesNodeWithLabel('layer#1')));
+      expect(semantics, isNot(includesNodeWith(label: 'layer#1')));
 
       await tester.pumpWidget(new Stack(
         children: <Widget>[
@@ -39,7 +39,7 @@ void main() {
         ],
       ));
 
-      expect(semantics, includesNodeWithLabel('layer#1'));
+      expect(semantics, includesNodeWith(label: 'layer#1'));
 
       semantics.dispose();
     });
@@ -86,13 +86,13 @@ void main() {
         ],
       ));
 
-      expect(semantics, includesNodeWithLabel('#1'));
-      expect(semantics, includesNodeWithLabel('#2'));
-      expect(semantics, isNot(includesNodeWithLabel('NOT#2.1')));
-      expect(semantics, includesNodeWithLabel('#2.2'));
-      expect(semantics, includesNodeWithLabel('#2.2.1'));
-      expect(semantics, includesNodeWithLabel('#2.3'));
-      expect(semantics, includesNodeWithLabel('#3'));
+      expect(semantics, includesNodeWith(label: '#1'));
+      expect(semantics, includesNodeWith(label: '#2'));
+      expect(semantics, isNot(includesNodeWith(label:'NOT#2.1')));
+      expect(semantics, includesNodeWith(label: '#2.2'));
+      expect(semantics, includesNodeWith(label: '#2.2.1'));
+      expect(semantics, includesNodeWith(label: '#2.3'));
+      expect(semantics, includesNodeWith(label: '#3'));
 
       semantics.dispose();
     });
@@ -121,9 +121,9 @@ void main() {
         ],
       ));
 
-      expect(semantics, isNot(includesNodeWithLabel('NOT#1')));
-      expect(semantics, includesNodeWithLabel('#2.1'));
-      expect(semantics, includesNodeWithLabel('#3'));
+      expect(semantics, isNot(includesNodeWith(label: 'NOT#1')));
+      expect(semantics, includesNodeWith(label: '#2.1'));
+      expect(semantics, includesNodeWith(label: '#3'));
 
       semantics.dispose();
     });


### PR DESCRIPTION
On Android, the back button is used to dismiss a modal in accessibility mode. According to the Android accessibility folks, allowing interactions with the modal barrier is confusing to accessibility users.

With this change, Flutter matches the behavior of native modal barriers on Android.

Fixes https://github.com/flutter/flutter/issues/1715.