### PR TITLE
Make flutter drive await app reinstall

### DIFF
--- a/packages/flutter_tools/lib/src/commands/drive.dart
+++ b/packages/flutter_tools/lib/src/commands/drive.dart
@@ -232,8 +232,8 @@ Future<LaunchResult> _startApp(DriveCommand command) async {
   final ApplicationPackage package = command.applicationPackages
       .getPackageForPlatform(await command.device.targetPlatform);
   if (await command.device.isAppInstalled(package))
-    command.device.uninstallApp(package);
-  command.device.installApp(package);
+    await command.device.uninstallApp(package);
+  await command.device.installApp(package);
 
   final Map<String, dynamic> platformArgs = <String, dynamic>{};
   if (command.traceStartup)


### PR DESCRIPTION
Asynchronicity seems to be responsible for interleaved output (and apk install failure) towards the end of [this test run log](https://flutter-dashboard.appspot.com/api/get-log?ownerKey=ahNzfmZsdXR0ZXItZGFzaGJvYXJkclgLEglDaGVja2xpc3QiOGZsdXR0ZXIvZmx1dHRlci8xNzMxYTE2ZDgxZDM5MjM3MTcxZDQyYTk3OWM3MWIyYWZhYzgyNDA2DAsSBFRhc2sYgICAgIDyqAsM)