### PR TITLE
Remove terminating semicolons from our android templates using Kotlin

### DIFF
--- a/packages/flutter_tools/templates/create/android-kotlin.tmpl/app/src/main/kotlin/androidIdentifier/MainActivity.kt.tmpl
+++ b/packages/flutter_tools/templates/create/android-kotlin.tmpl/app/src/main/kotlin/androidIdentifier/MainActivity.kt.tmpl
@@ -8,6 +8,6 @@ import io.flutter.plugins.GeneratedPluginRegistrant
 class MainActivity(): FlutterActivity() {
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
-    GeneratedPluginRegistrant.registerWith(this);
+    GeneratedPluginRegistrant.registerWith(this)
   }
 }


### PR DESCRIPTION
Remove terminating semicolons; they are causing an "code inspection warning" in Android Studio:

```
This inspection reports redundant semicolon (';') token which is not required in Kotlin and may be removed.
```