### PR TITLE
AutomaticKeepAlive

### DIFF
--- a/packages/flutter/lib/src/widgets/automatic_keep_alive.dart
+++ b/packages/flutter/lib/src/widgets/automatic_keep_alive.dart
@@ -1,0 +1,229 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/scheduler.dart';
+
+import 'framework.dart';
+import 'notification_listener.dart';
+import 'sliver.dart';
+
+/// Allows subtrees to request to be kept alive in lazy lists.
+///
+/// This widget is like [KeepAlive] but instead of being explicitly configured,
+/// it listens to [KeepAliveNotification] messages from the [child] and other
+/// descendants.
+///
+/// The subtree is kept alive whenever there is one or more descendant that has
+/// sent a [KeepAliveNotification] and not yet triggered its
+/// [KeepAliveNotification.handle].
+class AutomaticKeepAlive extends StatefulWidget {
+  /// Creates a widget that listens to [KeepAliveNotification]s and maintains a
+  /// [KeepAlive] widget appropriately.
+  const AutomaticKeepAlive({
+    Key key,
+    this.child,
+  }) : super(key: key);
+
+  /// The widget below this widget in the tree.
+  final Widget child;
+
+  @override
+  _AutomaticKeepAliveState createState() => new _AutomaticKeepAliveState();
+}
+
+class _AutomaticKeepAliveState extends State<AutomaticKeepAlive> {
+  Map<Listenable, VoidCallback> _handles;
+  Widget _child;
+  bool _keepingAlive = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _updateChild();
+  }
+
+  @override
+  void didUpdateWidget(AutomaticKeepAlive oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    _updateChild();
+  }
+
+  void _updateChild() {
+    _child = new NotificationListener<KeepAliveNotification>(
+      onNotification: _addClient,
+      child: widget.child,
+    );
+  }
+
+  @override
+  void dispose() {
+    if (_handles != null) {
+      for (Listenable handle in _handles.keys)
+        handle.removeListener(_handles[handle]);
+    }
+    super.dispose();
+  }
+
+  bool _addClient(KeepAliveNotification notification) {
+    final Listenable handle = notification.handle;
+    _handles ??= <Listenable, VoidCallback>{};
+    assert(!_handles.containsKey(handle));
+    _handles[handle] = _createCallback(handle);
+    handle.addListener(_handles[handle]);
+    if (!_keepingAlive) {
+      _keepingAlive = true;
+      // We use Element.visitChildren rather than context.visitChildElements
+      // because we might be called during build, and context.visitChildElements
+      // verifies that it is not called during build. Element.visitChildren does
+      // not, instead it assumes that the caller will be careful. (See the
+      // documentation for these methods for more details.)
+      //
+      // Here we know it's safe because we just received a notification, which
+      // we wouldn't be able to do if we hadn't built our child and its child --
+      // our build method always builds the same subtree and it always includes
+      // the node we're looking for (KeepAlive) as the parent of the node that
+      // reports the notifications (NotificationListener).
+      //
+      // (We're only going down one level, to get our direct child.)
+      final Element element = context;
+      element.visitChildren((Element child) {
+        assert(child is ParentDataElement<SliverMultiBoxAdaptorWidget>);
+        final ParentDataElement<SliverMultiBoxAdaptorWidget> childElement = child;
+        childElement.applyWidgetOutOfTurn(build(context));
+      });
+    }
+    return false;
+  }
+
+  VoidCallback _createCallback(Listenable handle) {
+    return () {
+      _handles.remove(handle);
+      if (_handles.isEmpty) {
+        if (SchedulerBinding.instance.schedulerPhase.index < SchedulerPhase.persistentCallbacks.index) {
+          // Build/layout haven't started yet so let's just schedule this for
+          // the next frame.
+          setState(() { _keepingAlive = false; });
+        } else {
+          // We were probably notified by a descendant when they were yanked out
+          // of our subtree somehow. We're probably in the middle of build or
+          // layout, so there's really nothing we can do to clean up this mess
+          // short of just scheduling another build to do the cleanup. This is
+          // very unfortunate, and means (for instance) that garbage collection
+          // of these resources won't happen for another 16ms.
+          //
+          // The problem is there's really no way for us to distinguish these
+          // cases:
+          //
+          //  * We haven't built yet (or missed out chance to build), but
+          //    someone above us notified our descendant and our descendant is
+          //    disconnecting from us. If we could mark ourselves dirty we would
+          //    be able to clean everything this frame. (This is a pretty
+          //    unlikely scenario in practice. Usually things change before
+          //    build/layout, not during build/layout.)
+          //
+          //  * Our child changed, and as our old child went away, it notified
+          //    us. We can't setState, since we _just_ built. We can't apply the
+          //    parent data information to our child because we don't _have_ a
+          //    child at this instant. We really want to be able to change our
+          //    mind about how we built, so we can give the KeepAlive widget a
+          //    new value, but it's too late.
+          //
+          //  * A deep descendant in another build scope just got yanked, and in
+          //    the process notified us. We could apply new parent data
+          //    information, but it may or may not get applied this frame,
+          //    depending on whether said child is in the same layout scope.
+          //
+          //  * We're being notified in the paint phase, or even in a post-frame
+          //    callback. Either way it is far too late for us to make our
+          //    parent lay out again this frame, so the garbage won't get
+          //    collected this frame.
+          //
+          // Long story short, we have to schedule a new frame and request a
+          // frame there, but this is generally a bad practice, and you should
+          // avoid it if possible.
+          scheduleMicrotask(() {
+            setState(() { _keepingAlive = false; });
+          });
+        }
+      }
+    };
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    assert(_child != null);
+    return new KeepAlive(
+      keepAlive: _keepingAlive,
+      child: _child,
+    );
+  }
+}
+
+/// Indicates that the subtree through which this notification bubbles must be
+/// kept alive even if it would normally be discarded as an optimisation.
+///
+/// For example, a focused text field might fire this notification to indicate
+/// that it should not be disposed even if the user scrolls the field off
+/// screen.
+///
+/// Each [KeepAliveNotification] is configured with a [handle] that consists of
+/// a [Listenable] that is triggered when the subtree no longer needs to be kept
+/// alive.
+///
+/// The [handle] should be triggered any time the sending widget is removed from
+/// the tree (in [State.deactivate]). If the widget is then rebuilt and still
+/// needs to be kept alive, it should immediately send a new notification
+/// (possible with the very same [Listenable]) during build.
+///
+/// This notification is listened to by the [AutomaticKeepAlive] widget, which
+/// is added to the tree automatically by [SliverList] (and [ListView]) and
+/// [SliverGrid] (and [GridView]) widgets.
+///
+/// Failure to trigger the [handle] in the manner described above will likely
+/// cause the [AutomaticKeepAlive] to lose track of whether the widget should be
+/// kept alive or not, leading to memory leaks or lost data. For example, if the
+/// widget that requested keep-alive is removed from the subtree but doesn't
+/// trigger its [Listenable] on the way out, then the subtree will continue to
+/// be kept alive until the list itself is disposed. Similarly, if the
+/// [Listenable] is triggered while the widget needs to be kept alive, but a new
+/// [KeepAliveNotification] is not immediately sent, then the widget risks being
+/// garbage collected while it wants to be kept alive.
+///
+/// It is an error to use the same [handle] in two [KeepAliveNotification]s
+/// within the same [AutomaticKeepAlive] without triggering that [handle] before
+/// the second notification is sent.
+class KeepAliveNotification extends Notification {
+  /// Creates a notification to indicate that a subtree must be kept alive.
+  ///
+  /// The [handle] must not be null.
+  const KeepAliveNotification(this.handle) : assert(handle != null);
+
+  /// A [Listenable] that will inform its clients when the widget that fired the
+  /// notification no longer needs to be kept alive.
+  ///
+  /// The [Listenable] should be triggered any time the sending widget is
+  /// removed from the tree (in [State.deactivate]). If the widget is then
+  /// rebuilt and still needs to be kept alive, it should immediately send a new
+  /// notification (possible with the very same [Listenable]) during build.
+  ///
+  /// See also:
+  ///
+  ///  * [KeepAliveHandle], a convenience class for use with this property.
+  final Listenable handle;
+}
+
+/// A [Listenable] which can be manually triggered.
+///
+/// Used with [KeepAliveNotification] objects as their
+/// [KeepAliveNotification.handle].
+class KeepAliveHandle extends ChangeNotifier {
+  /// Trigger the listeners to indicate that the widget
+  /// no longer needs to be kept alive.
+  void release() {
+    notifyListeners();
+  }
+}

--- a/packages/flutter/lib/src/widgets/notification_listener.dart
+++ b/packages/flutter/lib/src/widgets/notification_listener.dart
@@ -26,6 +26,8 @@ typedef bool NotificationListenerCallback<T extends Notification>(T notification
 /// widgets with the appropriate type parameters that are ancestors of the given
 /// [BuildContext].
 abstract class Notification {
+  const Notification();
+
   /// Applied to each ancestor of the [dispatch] target.
   ///
   /// The [Notification] class implementation of this method dispatches the
@@ -89,7 +91,7 @@ class NotificationListener<T extends Notification> extends StatelessWidget {
   const NotificationListener({
     Key key,
     @required this.child,
-    this.onNotification
+    this.onNotification,
   }) : super(key: key);
 
   /// The widget below this widget in the tree.

--- a/packages/flutter/lib/src/widgets/sliver.dart
+++ b/packages/flutter/lib/src/widgets/sliver.dart
@@ -875,10 +875,17 @@ class KeepAlive extends ParentDataWidget<SliverMultiBoxAdaptorWidget> {
     if (parentData.keepAlive != keepAlive) {
       parentData.keepAlive = keepAlive;
       final AbstractNode targetParent = renderObject.parent;
-      if (targetParent is RenderObject)
-        targetParent.markNeedsLayout();
+      if (targetParent is RenderObject && !keepAlive)
+        targetParent.markNeedsLayout(); // No need to redo layout if it became true.
     }
   }
+
+  // We only return true if [keepAlive] is true, because turning _off_ keep
+  // alive requires a layout to do the garbage collection (but turning it on
+  // requires nothing, since by definition the widget is already alive and won't
+  // go away _unless_ we do a layout).
+  @override
+  bool debugCanApplyOutOfTurn() => keepAlive;
 
   @override
   void debugFillDescription(List<String> description) {

--- a/packages/flutter/lib/widgets.dart
+++ b/packages/flutter/lib/widgets.dart
@@ -19,6 +19,7 @@ export 'src/widgets/animated_list.dart';
 export 'src/widgets/animated_size.dart';
 export 'src/widgets/app.dart';
 export 'src/widgets/async.dart';
+export 'src/widgets/automatic_keep_alive.dart';
 export 'src/widgets/banner.dart';
 export 'src/widgets/basic.dart';
 export 'src/widgets/binding.dart';

--- a/packages/flutter/test/widgets/automatic_keep_alive_test.dart
+++ b/packages/flutter/test/widgets/automatic_keep_alive_test.dart
@@ -1,0 +1,393 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter/widgets.dart';
+
+class Leaf extends StatefulWidget {
+  Leaf({ Key key, this.child }) : super(key: key);
+  final Widget child;
+  @override
+  _LeafState createState() => new _LeafState();
+}
+
+class _LeafState extends State<Leaf> {
+  bool _keepAlive = false;
+  KeepAliveHandle _handle;
+
+  @override
+  void deactivate() {
+    _handle?.release();
+    _handle = null;
+    super.deactivate();
+  }
+
+  void setKeepAlive(bool value) {
+    _keepAlive = value;
+    if (_keepAlive) {
+      if (_handle == null) {
+        _handle = new KeepAliveHandle();
+        new KeepAliveNotification(_handle).dispatch(context);
+      }
+    } else {
+      _handle?.release();
+      _handle = null;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_keepAlive && _handle == null) {
+      _handle = new KeepAliveHandle();
+      new KeepAliveNotification(_handle).dispatch(context);
+    }
+    return widget.child;
+  }
+}
+
+List<Widget> generateList(Widget child) {
+  return new List<Widget>.generate(
+    100,
+    (int index) => new AutomaticKeepAlive(
+      child: new Leaf(
+        key: new GlobalObjectKey<_LeafState>(index),
+        child: child,
+      ),
+    ),
+    growable: false,
+  );
+}
+
+void main() {
+  testWidgets('AutomaticKeepAlive with ListView with itemExtent', (WidgetTester tester) async {
+    await tester.pumpWidget(new ListView(
+      addRepaintBoundaries: false,
+      itemExtent: 12.3, // about 50 widgets visible
+      children: generateList(const Placeholder()),
+    ));
+    expect(find.byKey(const GlobalObjectKey<_LeafState>(3)), findsOneWidget);
+    expect(find.byKey(const GlobalObjectKey<_LeafState>(30)), findsOneWidget);
+    expect(find.byKey(const GlobalObjectKey<_LeafState>(59)), findsNothing);
+    expect(find.byKey(const GlobalObjectKey<_LeafState>(60)), findsNothing);
+    expect(find.byKey(const GlobalObjectKey<_LeafState>(61)), findsNothing);
+    expect(find.byKey(const GlobalObjectKey<_LeafState>(90)), findsNothing);
+    await tester.drag(find.byType(ListView), const Offset(0.0, -300.0)); // about 25 widgets' worth
+    await tester.pump();
+    expect(find.byKey(const GlobalObjectKey<_LeafState>(3)), findsNothing);
+    expect(find.byKey(const GlobalObjectKey<_LeafState>(30)), findsOneWidget);
+    expect(find.byKey(const GlobalObjectKey<_LeafState>(59)), findsOneWidget);
+    expect(find.byKey(const GlobalObjectKey<_LeafState>(60)), findsOneWidget);
+    expect(find.byKey(const GlobalObjectKey<_LeafState>(61)), findsOneWidget);
+    expect(find.byKey(const GlobalObjectKey<_LeafState>(90)), findsNothing);
+    const GlobalObjectKey<_LeafState>(60).currentState.setKeepAlive(true);
+    await tester.drag(find.byType(ListView), const Offset(0.0, 300.0)); // back to top
+    await tester.pump();
+    expect(find.byKey(const GlobalObjectKey<_LeafState>(3)), findsOneWidget);
+    expect(find.byKey(const GlobalObjectKey<_LeafState>(30)), findsOneWidget);
+    expect(find.byKey(const GlobalObjectKey<_LeafState>(59)), findsNothing);
+    expect(find.byKey(const GlobalObjectKey<_LeafState>(60)), findsOneWidget);
+    expect(find.byKey(const GlobalObjectKey<_LeafState>(61)), findsNothing);
+    expect(find.byKey(const GlobalObjectKey<_LeafState>(90)), findsNothing);
+    const GlobalObjectKey<_LeafState>(60).currentState.setKeepAlive(false);
+    await tester.pump();
+    expect(find.byKey(const GlobalObjectKey<_LeafState>(3)), findsOneWidget);
+    expect(find.byKey(const GlobalObjectKey<_LeafState>(30)), findsOneWidget);
+    expect(find.byKey(const GlobalObjectKey<_LeafState>(59)), findsNothing);
+    expect(find.byKey(const GlobalObjectKey<_LeafState>(60)), findsNothing);
+    expect(find.byKey(const GlobalObjectKey<_LeafState>(61)), findsNothing);
+    expect(find.byKey(const GlobalObjectKey<_LeafState>(90)), findsNothing);
+  });
+
+  testWidgets('AutomaticKeepAlive with ListView without itemExtent', (WidgetTester tester) async {
+    await tester.pumpWidget(new ListView(
+      addRepaintBoundaries: false,
+      children: generateList(new Container(height: 12.3, child: const Placeholder())), // about 50 widgets visible
+    ));
+    expect(find.byKey(const GlobalObjectKey<_LeafState>(3)), findsOneWidget);
+    expect(find.byKey(const GlobalObjectKey<_LeafState>(30)), findsOneWidget);
+    expect(find.byKey(const GlobalObjectKey<_LeafState>(59)), findsNothing);
+    expect(find.byKey(const GlobalObjectKey<_LeafState>(60)), findsNothing);
+    expect(find.byKey(const GlobalObjectKey<_LeafState>(61)), findsNothing);
+    expect(find.byKey(const GlobalObjectKey<_LeafState>(90)), findsNothing);
+    await tester.drag(find.byType(ListView), const Offset(0.0, -300.0)); // about 25 widgets' worth
+    await tester.pump();
+    expect(find.byKey(const GlobalObjectKey<_LeafState>(3)), findsNothing);
+    expect(find.byKey(const GlobalObjectKey<_LeafState>(30)), findsOneWidget);
+    expect(find.byKey(const GlobalObjectKey<_LeafState>(59)), findsOneWidget);
+    expect(find.byKey(const GlobalObjectKey<_LeafState>(60)), findsOneWidget);
+    expect(find.byKey(const GlobalObjectKey<_LeafState>(61)), findsOneWidget);
+    expect(find.byKey(const GlobalObjectKey<_LeafState>(90)), findsNothing);
+    const GlobalObjectKey<_LeafState>(60).currentState.setKeepAlive(true);
+    await tester.drag(find.byType(ListView), const Offset(0.0, 300.0)); // back to top
+    await tester.pump();
+    expect(find.byKey(const GlobalObjectKey<_LeafState>(3)), findsOneWidget);
+    expect(find.byKey(const GlobalObjectKey<_LeafState>(30)), findsOneWidget);
+    expect(find.byKey(const GlobalObjectKey<_LeafState>(59)), findsNothing);
+    expect(find.byKey(const GlobalObjectKey<_LeafState>(60)), findsOneWidget);
+    expect(find.byKey(const GlobalObjectKey<_LeafState>(61)), findsNothing);
+    expect(find.byKey(const GlobalObjectKey<_LeafState>(90)), findsNothing);
+    const GlobalObjectKey<_LeafState>(60).currentState.setKeepAlive(false);
+    await tester.pump();
+    expect(find.byKey(const GlobalObjectKey<_LeafState>(3)), findsOneWidget);
+    expect(find.byKey(const GlobalObjectKey<_LeafState>(30)), findsOneWidget);
+    expect(find.byKey(const GlobalObjectKey<_LeafState>(59)), findsNothing);
+    expect(find.byKey(const GlobalObjectKey<_LeafState>(60)), findsNothing);
+    expect(find.byKey(const GlobalObjectKey<_LeafState>(61)), findsNothing);
+    expect(find.byKey(const GlobalObjectKey<_LeafState>(90)), findsNothing);
+  });
+
+  testWidgets('AutomaticKeepAlive with GridView', (WidgetTester tester) async {
+    await tester.pumpWidget(new GridView.count(
+      addRepaintBoundaries: false,
+      crossAxisCount: 2,
+      childAspectRatio: 400.0 / 24.6, // about 50 widgets visible
+      children: generateList(new Container(child: const Placeholder())),
+    ));
+    expect(find.byKey(const GlobalObjectKey<_LeafState>(3)), findsOneWidget);
+    expect(find.byKey(const GlobalObjectKey<_LeafState>(30)), findsOneWidget);
+    expect(find.byKey(const GlobalObjectKey<_LeafState>(59)), findsNothing);
+    expect(find.byKey(const GlobalObjectKey<_LeafState>(60)), findsNothing);
+    expect(find.byKey(const GlobalObjectKey<_LeafState>(61)), findsNothing);
+    expect(find.byKey(const GlobalObjectKey<_LeafState>(90)), findsNothing);
+    await tester.drag(find.byType(GridView), const Offset(0.0, -300.0)); // about 25 widgets' worth
+    await tester.pump();
+    expect(find.byKey(const GlobalObjectKey<_LeafState>(3)), findsNothing);
+    expect(find.byKey(const GlobalObjectKey<_LeafState>(30)), findsOneWidget);
+    expect(find.byKey(const GlobalObjectKey<_LeafState>(59)), findsOneWidget);
+    expect(find.byKey(const GlobalObjectKey<_LeafState>(60)), findsOneWidget);
+    expect(find.byKey(const GlobalObjectKey<_LeafState>(61)), findsOneWidget);
+    expect(find.byKey(const GlobalObjectKey<_LeafState>(90)), findsNothing);
+    const GlobalObjectKey<_LeafState>(60).currentState.setKeepAlive(true);
+    await tester.drag(find.byType(GridView), const Offset(0.0, 300.0)); // back to top
+    await tester.pump();
+    expect(find.byKey(const GlobalObjectKey<_LeafState>(3)), findsOneWidget);
+    expect(find.byKey(const GlobalObjectKey<_LeafState>(30)), findsOneWidget);
+    expect(find.byKey(const GlobalObjectKey<_LeafState>(59)), findsNothing);
+    expect(find.byKey(const GlobalObjectKey<_LeafState>(60)), findsOneWidget);
+    expect(find.byKey(const GlobalObjectKey<_LeafState>(61)), findsNothing);
+    expect(find.byKey(const GlobalObjectKey<_LeafState>(90)), findsNothing);
+    const GlobalObjectKey<_LeafState>(60).currentState.setKeepAlive(false);
+    await tester.pump();
+    expect(find.byKey(const GlobalObjectKey<_LeafState>(3)), findsOneWidget);
+    expect(find.byKey(const GlobalObjectKey<_LeafState>(30)), findsOneWidget);
+    expect(find.byKey(const GlobalObjectKey<_LeafState>(59)), findsNothing);
+    expect(find.byKey(const GlobalObjectKey<_LeafState>(60)), findsNothing);
+    expect(find.byKey(const GlobalObjectKey<_LeafState>(61)), findsNothing);
+    expect(find.byKey(const GlobalObjectKey<_LeafState>(90)), findsNothing);
+  });
+
+  testWidgets('AutomaticKeepAlive double', (WidgetTester tester) async {
+    await tester.pumpWidget(new ListView(
+      addRepaintBoundaries: false,
+      children: <Widget>[
+        new AutomaticKeepAlive(
+          child: new Container(
+            height: 400.0,
+            child: new Row(children: <Widget>[
+              new Leaf(key: const GlobalObjectKey<_LeafState>(0), child: const Placeholder()),
+              new Leaf(key: const GlobalObjectKey<_LeafState>(1), child: const Placeholder()),
+            ]),
+          ),
+        ),
+        new AutomaticKeepAlive(
+          child: new Container(
+            key: const GlobalObjectKey<_LeafState>(2),
+            height: 400.0,
+          ),
+        ),
+        new AutomaticKeepAlive(
+          child: new Container(
+            key: const GlobalObjectKey<_LeafState>(3),
+            height: 400.0,
+          ),
+        ),
+      ],
+    ));
+    expect(find.byKey(const GlobalObjectKey<_LeafState>(0)), findsOneWidget);
+    expect(find.byKey(const GlobalObjectKey<_LeafState>(1)), findsOneWidget);
+    expect(find.byKey(const GlobalObjectKey<_LeafState>(2)), findsOneWidget);
+    expect(find.byKey(const GlobalObjectKey<_LeafState>(3)), findsNothing);
+    await tester.drag(find.byType(ListView), const Offset(0.0, -1000.0)); // move to bottom
+    await tester.pump();
+    expect(find.byKey(const GlobalObjectKey<_LeafState>(0)), findsNothing);
+    expect(find.byKey(const GlobalObjectKey<_LeafState>(1)), findsNothing);
+    expect(find.byKey(const GlobalObjectKey<_LeafState>(2)), findsOneWidget);
+    expect(find.byKey(const GlobalObjectKey<_LeafState>(3)), findsOneWidget);
+    await tester.drag(find.byType(ListView), const Offset(0.0, 1000.0)); // move to top
+    await tester.pump();
+    expect(find.byKey(const GlobalObjectKey<_LeafState>(0)), findsOneWidget);
+    expect(find.byKey(const GlobalObjectKey<_LeafState>(1)), findsOneWidget);
+    expect(find.byKey(const GlobalObjectKey<_LeafState>(2)), findsOneWidget);
+    expect(find.byKey(const GlobalObjectKey<_LeafState>(3)), findsNothing);
+    const GlobalObjectKey<_LeafState>(0).currentState.setKeepAlive(true);
+    await tester.drag(find.byType(ListView), const Offset(0.0, -1000.0)); // move to bottom
+    await tester.pump();
+    expect(find.byKey(const GlobalObjectKey<_LeafState>(0)), findsOneWidget);
+    expect(find.byKey(const GlobalObjectKey<_LeafState>(1)), findsOneWidget);
+    expect(find.byKey(const GlobalObjectKey<_LeafState>(2)), findsOneWidget);
+    expect(find.byKey(const GlobalObjectKey<_LeafState>(3)), findsOneWidget);
+    const GlobalObjectKey<_LeafState>(1).currentState.setKeepAlive(true);
+    await tester.pump();
+    expect(find.byKey(const GlobalObjectKey<_LeafState>(0)), findsOneWidget);
+    expect(find.byKey(const GlobalObjectKey<_LeafState>(1)), findsOneWidget);
+    expect(find.byKey(const GlobalObjectKey<_LeafState>(2)), findsOneWidget);
+    expect(find.byKey(const GlobalObjectKey<_LeafState>(3)), findsOneWidget);
+    const GlobalObjectKey<_LeafState>(0).currentState.setKeepAlive(false);
+    await tester.pump();
+    expect(find.byKey(const GlobalObjectKey<_LeafState>(0)), findsOneWidget);
+    expect(find.byKey(const GlobalObjectKey<_LeafState>(1)), findsOneWidget);
+    expect(find.byKey(const GlobalObjectKey<_LeafState>(2)), findsOneWidget);
+    expect(find.byKey(const GlobalObjectKey<_LeafState>(3)), findsOneWidget);
+    const GlobalObjectKey<_LeafState>(1).currentState.setKeepAlive(false);
+    await tester.pump();
+    expect(find.byKey(const GlobalObjectKey<_LeafState>(0)), findsNothing);
+    expect(find.byKey(const GlobalObjectKey<_LeafState>(1)), findsNothing);
+    expect(find.byKey(const GlobalObjectKey<_LeafState>(2)), findsOneWidget);
+    expect(find.byKey(const GlobalObjectKey<_LeafState>(3)), findsOneWidget);
+  });
+
+  testWidgets('AutomaticKeepAlive double', (WidgetTester tester) async {
+    await tester.pumpWidget(new ListView(
+      addRepaintBoundaries: false,
+      children: <Widget>[
+        new AutomaticKeepAlive(
+          child: new Container(
+            height: 400.0,
+            child: new Row(children: <Widget>[
+              new Leaf(key: const GlobalObjectKey<_LeafState>(0), child: const Placeholder()),
+              new Leaf(key: const GlobalObjectKey<_LeafState>(1), child: const Placeholder()),
+            ]),
+          ),
+        ),
+        new AutomaticKeepAlive(
+          child: new Container(
+            height: 400.0,
+            child: new Row(children: <Widget>[
+              new Leaf(key: const GlobalObjectKey<_LeafState>(2), child: const Placeholder()),
+              new Leaf(key: const GlobalObjectKey<_LeafState>(3), child: const Placeholder()),
+            ]),
+          ),
+        ),
+        new AutomaticKeepAlive(
+          child: new Container(
+            height: 400.0,
+            child: new Row(children: <Widget>[
+              new Leaf(key: const GlobalObjectKey<_LeafState>(4), child: const Placeholder()),
+              new Leaf(key: const GlobalObjectKey<_LeafState>(5), child: const Placeholder()),
+            ]),
+          ),
+        ),
+      ],
+    ));
+    expect(find.byKey(const GlobalObjectKey<_LeafState>(0)), findsOneWidget);
+    expect(find.byKey(const GlobalObjectKey<_LeafState>(1)), findsOneWidget);
+    expect(find.byKey(const GlobalObjectKey<_LeafState>(2)), findsOneWidget);
+    expect(find.byKey(const GlobalObjectKey<_LeafState>(3)), findsOneWidget);
+    expect(find.byKey(const GlobalObjectKey<_LeafState>(4)), findsNothing);
+    expect(find.byKey(const GlobalObjectKey<_LeafState>(5)), findsNothing);
+    const GlobalObjectKey<_LeafState>(0).currentState.setKeepAlive(true);
+    await tester.drag(find.byType(ListView), const Offset(0.0, -1000.0)); // move to bottom
+    await tester.pump();
+    expect(find.byKey(const GlobalObjectKey<_LeafState>(0)), findsOneWidget);
+    expect(find.byKey(const GlobalObjectKey<_LeafState>(1)), findsOneWidget);
+    expect(find.byKey(const GlobalObjectKey<_LeafState>(2)), findsOneWidget);
+    expect(find.byKey(const GlobalObjectKey<_LeafState>(3)), findsOneWidget);
+    expect(find.byKey(const GlobalObjectKey<_LeafState>(4)), findsOneWidget);
+    expect(find.byKey(const GlobalObjectKey<_LeafState>(5)), findsOneWidget);
+    await tester.pumpWidget(new ListView(
+      addRepaintBoundaries: false,
+      children: <Widget>[
+        new AutomaticKeepAlive(
+          child: new Container(
+            height: 400.0,
+            child: new Row(children: <Widget>[
+              new Leaf(key: const GlobalObjectKey<_LeafState>(1), child: const Placeholder()),
+            ]),
+          ),
+        ),
+        new AutomaticKeepAlive(
+          child: new Container(
+            height: 400.0,
+            child: new Row(children: <Widget>[
+              new Leaf(key: const GlobalObjectKey<_LeafState>(2), child: const Placeholder()),
+              new Leaf(key: const GlobalObjectKey<_LeafState>(3), child: const Placeholder()),
+            ]),
+          ),
+        ),
+        new AutomaticKeepAlive(
+          child: new Container(
+            height: 400.0,
+            child: new Row(children: <Widget>[
+              new Leaf(key: const GlobalObjectKey<_LeafState>(4), child: const Placeholder()),
+              new Leaf(key: const GlobalObjectKey<_LeafState>(5), child: const Placeholder()),
+              new Leaf(key: const GlobalObjectKey<_LeafState>(0), child: const Placeholder()),
+            ]),
+          ),
+        ),
+      ],
+    ));
+    await tester.pump(); // Sometimes AutomaticKeepAlive needs an extra pump to clean things up.
+    expect(find.byKey(const GlobalObjectKey<_LeafState>(1)), findsNothing);
+    expect(find.byKey(const GlobalObjectKey<_LeafState>(2)), findsOneWidget);
+    expect(find.byKey(const GlobalObjectKey<_LeafState>(3)), findsOneWidget);
+    expect(find.byKey(const GlobalObjectKey<_LeafState>(4)), findsOneWidget);
+    expect(find.byKey(const GlobalObjectKey<_LeafState>(5)), findsOneWidget);
+    expect(find.byKey(const GlobalObjectKey<_LeafState>(0)), findsOneWidget);
+    await tester.drag(find.byType(ListView), const Offset(0.0, 1000.0)); // move to top
+    await tester.pump();
+    expect(find.byKey(const GlobalObjectKey<_LeafState>(1)), findsOneWidget);
+    expect(find.byKey(const GlobalObjectKey<_LeafState>(2)), findsOneWidget);
+    expect(find.byKey(const GlobalObjectKey<_LeafState>(3)), findsOneWidget);
+    expect(find.byKey(const GlobalObjectKey<_LeafState>(4)), findsOneWidget);
+    expect(find.byKey(const GlobalObjectKey<_LeafState>(5)), findsOneWidget);
+    expect(find.byKey(const GlobalObjectKey<_LeafState>(0)), findsOneWidget);
+    const GlobalObjectKey<_LeafState>(0).currentState.setKeepAlive(false);
+    await tester.pump();
+    expect(find.byKey(const GlobalObjectKey<_LeafState>(1)), findsOneWidget);
+    expect(find.byKey(const GlobalObjectKey<_LeafState>(2)), findsOneWidget);
+    expect(find.byKey(const GlobalObjectKey<_LeafState>(3)), findsOneWidget);
+    expect(find.byKey(const GlobalObjectKey<_LeafState>(4)), findsNothing);
+    expect(find.byKey(const GlobalObjectKey<_LeafState>(5)), findsNothing);
+    expect(find.byKey(const GlobalObjectKey<_LeafState>(0)), findsNothing);
+    await tester.pumpWidget(new ListView(
+      addRepaintBoundaries: false,
+      children: <Widget>[
+        new AutomaticKeepAlive(
+          child: new Container(
+            height: 400.0,
+            child: new Row(children: <Widget>[
+              new Leaf(key: const GlobalObjectKey<_LeafState>(1), child: const Placeholder()),
+              new Leaf(key: const GlobalObjectKey<_LeafState>(2), child: const Placeholder()),
+            ]),
+          ),
+        ),
+        new AutomaticKeepAlive(
+          child: new Container(
+            height: 400.0,
+            child: new Row(children: <Widget>[
+            ]),
+          ),
+        ),
+        new AutomaticKeepAlive(
+          child: new Container(
+            height: 400.0,
+            child: new Row(children: <Widget>[
+              new Leaf(key: const GlobalObjectKey<_LeafState>(3), child: const Placeholder()),
+              new Leaf(key: const GlobalObjectKey<_LeafState>(4), child: const Placeholder()),
+              new Leaf(key: const GlobalObjectKey<_LeafState>(5), child: const Placeholder()),
+              new Leaf(key: const GlobalObjectKey<_LeafState>(0), child: const Placeholder()),
+            ]),
+          ),
+        ),
+      ],
+    ));
+    await tester.pump(); // Sometimes AutomaticKeepAlive needs an extra pump to clean things up.
+    expect(find.byKey(const GlobalObjectKey<_LeafState>(1)), findsOneWidget);
+    expect(find.byKey(const GlobalObjectKey<_LeafState>(2)), findsOneWidget);
+    expect(find.byKey(const GlobalObjectKey<_LeafState>(3)), findsNothing);
+    expect(find.byKey(const GlobalObjectKey<_LeafState>(4)), findsNothing);
+    expect(find.byKey(const GlobalObjectKey<_LeafState>(5)), findsNothing);
+    expect(find.byKey(const GlobalObjectKey<_LeafState>(0)), findsNothing);
+  });
+}

--- a/packages/flutter/test/widgets/keep_alive_test.dart
+++ b/packages/flutter/test/widgets/keep_alive_test.dart
@@ -8,8 +8,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/widgets.dart';
 
 class Leaf extends StatefulWidget {
-  Leaf({ Key key, this.index, this.child }) : super(key: key);
-  final int index;
+  Leaf({ Key key, this.child }) : super(key: key);
   final Widget child;
   @override
   _LeafState createState() => new _LeafState();
@@ -36,7 +35,6 @@ List<Widget> generateList(Widget child) {
     100,
     (int index) => new Leaf(
       key: new GlobalObjectKey<_LeafState>(index),
-      index: index,
       child: child,
     ),
     growable: false,


### PR DESCRIPTION
A Widget that listens for notifications from widgets that don't want to die.

(Next step is to automatically wrap one of these around each child of a SliverList, the same way we currently wrap repaint boundaries.)

cc @cbracken 