### PR TITLE
add a --machine mode to flutter config

### DIFF
--- a/packages/flutter_tools/lib/executable.dart
+++ b/packages/flutter_tools/lib/executable.dart
@@ -68,7 +68,7 @@ Future<Null> main(List<String> args) async {
     new AnalyzeCommand(verboseHelp: verboseHelp),
     new BuildCommand(verboseHelp: verboseHelp),
     new ChannelCommand(),
-    new ConfigCommand(),
+    new ConfigCommand(verboseHelp: verboseHelp),
     new CreateCommand(),
     new DaemonCommand(hidden: !verboseHelp),
     new DevicesCommand(),

--- a/packages/flutter_tools/lib/src/android/android_studio.dart
+++ b/packages/flutter_tools/lib/src/android/android_studio.dart
@@ -128,7 +128,9 @@ class AndroidStudio implements Comparable<AndroidStudio> {
             .listSync()
             .where((FileSystemEntity e) => e is Directory);
         for (Directory directory in directories) {
-          if (directory.basename == 'Android Studio.app') {
+          final String name = directory.basename;
+          // An exact match, or something like 'Android Studio 3.0 Preview.app'.
+          if (name.startsWith('Android Studio') && name.endsWith('.app')) {
             candidatePaths.add(directory);
           } else if (!directory.path.endsWith('.app')) {
             _checkForStudio(directory.path);

--- a/packages/flutter_tools/lib/src/commands/analyze.dart
+++ b/packages/flutter_tools/lib/src/commands/analyze.dart
@@ -23,7 +23,7 @@ class AnalyzeCommand extends FlutterCommand {
     argParser.addOption('dart-sdk', valueHelp: 'path-to-sdk', help: 'The path to the Dart SDK.', hide: !verboseHelp);
 
     // Hidden option to enable a benchmarking mode.
-    argParser.addFlag('benchmark', negatable: false, hide: !verboseHelp, help: 'Also output the analysis time');
+    argParser.addFlag('benchmark', negatable: false, hide: !verboseHelp, help: 'Also output the analysis time.');
 
     usesPubOption();
 

--- a/packages/flutter_tools/lib/src/commands/config.dart
+++ b/packages/flutter_tools/lib/src/commands/config.dart
@@ -27,7 +27,6 @@ class ConfigCommand extends FlutterCommand {
   }
 
   @override
-  @override
   final String name = 'config';
 
   @override
@@ -58,9 +57,8 @@ class ConfigCommand extends FlutterCommand {
 
   @override
   Future<Null> runCommand() async {
-    if (argResults['machine']) {
+    if (argResults['machine'])
       return handleMachine();
-    }
 
     if (argResults.wasParsed('analytics')) {
       final bool value = argResults['analytics'];

--- a/packages/flutter_tools/test/config_test.dart
+++ b/packages/flutter_tools/test/config_test.dart
@@ -2,17 +2,28 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:convert';
+
+import 'package:flutter_tools/src/android/android_studio.dart';
 import 'package:flutter_tools/src/base/config.dart';
+import 'package:flutter_tools/src/base/context.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
+import 'package:flutter_tools/src/base/logger.dart';
+import 'package:flutter_tools/src/commands/config.dart';
+import 'package:mockito/mockito.dart';
 import 'package:test/test.dart';
+
+import 'src/context.dart';
 
 void main() {
   Config config;
+  MockAndroidStudio mockAndroidStudio;
 
   setUp(() {
-    final Directory tempDiretory = fs.systemTempDirectory.createTempSync('flutter_test');
-    final File file = fs.file(fs.path.join(tempDiretory.path, '.settings'));
+    final Directory tempDirectory = fs.systemTempDirectory.createTempSync('flutter_test');
+    final File file = fs.file(fs.path.join(tempDirectory.path, '.settings'));
     config = new Config(file);
+    mockAndroidStudio = new MockAndroidStudio();
   });
 
   group('config', () {
@@ -32,5 +43,24 @@ void main() {
       expect(config.getValue('foo'), null);
       expect(config.keys, isNot(contains('foo')));
     });
+
+    testUsingContext('machine flag', () async {
+      final BufferLogger logger = context[Logger];
+      final ConfigCommand command = new ConfigCommand();
+      await command.handleMachine();
+
+      expect(logger.statusText, isNotEmpty);
+      final dynamic json = JSON.decode(logger.statusText);
+      expect(json, isMap);
+      expect(json.containsKey('android-studio-dir'), true);
+      expect(json['android-studio-dir'], isNotNull);
+    }, overrides: <Type, Generator>{
+      AndroidStudio: () => mockAndroidStudio,
+    });
   });
+}
+
+class MockAndroidStudio extends Mock implements AndroidStudio, Comparable<AndroidStudio> {
+  @override
+  String get directory => 'path/to/android/stdio';
 }


### PR DESCRIPTION
- add a `--machine` mode to `flutter config` (some work towards addressing https://github.com/flutter/flutter-intellij/issues/1150)

This allows IDEs to query flutter_tools for it's settings and tooling information. In particular, it's useful for IntelliJ to know which location flutter tools is using for Android Studio. `flutter config --machine` will dump the explicit user settings, and specific ones that it's inferred, in a json format:

```json
{"android-studio-dir":"/Applications/Android Studio 3.0 Preview.app/Contents"}
```
