### PR TITLE
Stop sending cocoapods stats

### DIFF
--- a/packages/flutter_tools/lib/src/ios/cocoapods.dart
+++ b/packages/flutter_tools/lib/src/ios/cocoapods.dart
@@ -119,6 +119,8 @@ class CocoaPods {
       workingDirectory: bundle.path,
       environment: <String, String>{
         'FLUTTER_FRAMEWORK_DIR': engineDirectory,
+        // See https://github.com/flutter/flutter/issues/10873.
+        // CocoaPods analytics adds a lot of latency.
         'COCOAPODS_DISABLE_STATS': 'true',
       },
     );

--- a/packages/flutter_tools/lib/src/ios/cocoapods.dart
+++ b/packages/flutter_tools/lib/src/ios/cocoapods.dart
@@ -117,7 +117,10 @@ class CocoaPods {
     final ProcessResult result = await processManager.run(
       <String>['pod', 'install', '--verbose'],
       workingDirectory: bundle.path,
-      environment: <String, String>{'FLUTTER_FRAMEWORK_DIR': engineDirectory},
+      environment: <String, String>{
+        'FLUTTER_FRAMEWORK_DIR': engineDirectory,
+        'COCOAPODS_DISABLE_STATS': 'true',
+      },
     );
     status.stop();
     if (logger.isVerbose || result.exitCode != 0) {

--- a/packages/flutter_tools/test/ios/cocoapods_test.dart
+++ b/packages/flutter_tools/test/ios/cocoapods_test.dart
@@ -56,7 +56,7 @@ void main() {
       verify(mockProcessManager.run(
         <String>['pod', 'install', '--verbose'],
         workingDirectory: 'project/ios',
-        environment: <String, String>{'FLUTTER_FRAMEWORK_DIR': 'engine/path'},
+        environment: <String, String>{'FLUTTER_FRAMEWORK_DIR': 'engine/path', 'COCOAPODS_DISABLE_STATS': 'true'},
       ));
     },
     overrides: <Type, Generator>{

--- a/packages/flutter_tools/test/ios/cocoapods_test.dart
+++ b/packages/flutter_tools/test/ios/cocoapods_test.dart
@@ -41,7 +41,7 @@ void main() {
     when(mockProcessManager.run(
       <String>['pod', 'install', '--verbose'],
       workingDirectory: 'project/ios',
-      environment: <String, String>{'FLUTTER_FRAMEWORK_DIR': 'engine/path'},
+      environment: <String, String>{'FLUTTER_FRAMEWORK_DIR': 'engine/path', 'COCOAPODS_DISABLE_STATS': 'true'},
     )).thenReturn(exitsHappy);
   });
 
@@ -77,7 +77,7 @@ void main() {
       verify(mockProcessManager.run(
         <String>['pod', 'install', '--verbose'],
         workingDirectory: 'project/ios',
-        environment: <String, String>{'FLUTTER_FRAMEWORK_DIR': 'engine/path'},
+        environment: <String, String>{'FLUTTER_FRAMEWORK_DIR': 'engine/path', 'COCOAPODS_DISABLE_STATS': 'true'},
       ));
     },
     overrides: <Type, Generator>{
@@ -99,7 +99,7 @@ void main() {
       verify(mockProcessManager.run(
         <String>['pod', 'install', '--verbose'],
         workingDirectory: 'project/ios',
-        environment: <String, String>{'FLUTTER_FRAMEWORK_DIR': 'engine/path'},
+        environment: <String, String>{'FLUTTER_FRAMEWORK_DIR': 'engine/path', 'COCOAPODS_DISABLE_STATS': 'true'},
       ));
     },
     overrides: <Type, Generator>{
@@ -122,7 +122,7 @@ void main() {
         verifyNever(mockProcessManager.run(
           <String>['pod', 'install', '--verbose'],
           workingDirectory: 'project/ios',
-          environment: <String, String>{'FLUTTER_FRAMEWORK_DIR': 'engine/path'},
+          environment: <String, String>{'FLUTTER_FRAMEWORK_DIR': 'engine/path', 'COCOAPODS_DISABLE_STATS': 'true'},
         ));
       }
     },


### PR DESCRIPTION
Fixes #10873

Diffbases #11101 (compare with https://github.com/xster/flutter/compare/auto-pods...xster:disable-cocoapods-stats) where the cocoapods logic moved. 

Should improve `pod install` speeds by 50+%