### PR TITLE
Don't pollute Travis log with Google Cloud SDK installation

### DIFF
--- a/dev/bots/travis_setup.sh
+++ b/dev/bots/travis_setup.sh
@@ -7,7 +7,8 @@ set -x
 
 if [ -n "$TRAVIS" ]; then
   export CLOUDSDK_CORE_DISABLE_PROMPTS=1
-  curl https://sdk.cloud.google.com | bash
+  echo "Installing Google Cloud SDK..."
+  curl https://sdk.cloud.google.com | bash > /dev/null
 fi
 
 # disable analytics on the bots and download Flutter dependencies

--- a/dev/bots/travis_setup.sh
+++ b/dev/bots/travis_setup.sh
@@ -9,6 +9,7 @@ if [ -n "$TRAVIS" ]; then
   export CLOUDSDK_CORE_DISABLE_PROMPTS=1
   echo "Installing Google Cloud SDK..."
   curl https://sdk.cloud.google.com | bash > /dev/null
+  echo "Google Cloud SDK installation completed."
 fi
 
 # disable analytics on the bots and download Flutter dependencies


### PR DESCRIPTION
This removed ~4200 lines from the log that don't seem that useful, but make the logs harder to navigate and longer to load (sometimes causing travis to truncate the log and make you view the raw log without pretty formatting to see the relevant logs towards the bottom of the file).