### PR TITLE
Bump `intl` to 0.15.1

### DIFF
--- a/dev/devicelab/pubspec.yaml
+++ b/dev/devicelab/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   image: ^1.1.27
   meta: ^1.0.5
   path: ^1.4.0
-  process: 2.0.3
+  process: 2.0.4
   stack_trace: ^1.4.0
   vm_service_client: '0.2.2+4'
 

--- a/dev/tools/pubspec.yaml
+++ b/dev/tools/pubspec.yaml
@@ -5,6 +5,6 @@ dependencies:
   archive: ^1.0.20
   args: ^0.13.4
   http: ^0.11.3+12
-  intl: ^0.14.0
+  intl: '>=0.14.0 <0.16.0'
   meta: ^1.0.5
   path: ^1.4.0

--- a/examples/flutter_gallery/pubspec.yaml
+++ b/examples/flutter_gallery/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flutter_gallery
 dependencies:
   collection: '>=1.9.1 <2.0.0'
-  intl: '>=0.14.0 <0.15.0'
+  intl: '>=0.14.0 <0.16.0'
   string_scanner: ^1.0.0
 
   flutter:

--- a/examples/stocks/pubspec.yaml
+++ b/examples/stocks/pubspec.yaml
@@ -2,8 +2,8 @@ name: stocks
 dependencies:
   flutter:
     sdk: flutter
-  intl: '>=0.14.0 <0.15.0'
-  intl_translation: '>=0.14.0 <0.15.0'
+  intl: '>=0.14.0 <0.16.0'
+  intl_translation: '>=0.14.0 <0.16.0'
   http: '>=0.11.3+12'
   isolate: '>=1.0.0'
 

--- a/packages/flutter/pubspec.yaml
+++ b/packages/flutter/pubspec.yaml
@@ -7,7 +7,7 @@ homepage: http://flutter.io
 dependencies:
   collection: '>=1.9.1 <2.0.0'
   http: '>=0.11.3+12'
-  intl: '>=0.14.0 <0.15.0'
+  intl: '>=0.14.0 <0.16.0'
   meta: ^1.0.5
   typed_data: ^1.1.3
   vector_math: '>=2.0.3 <3.0.0'

--- a/packages/flutter_tools/pubspec.yaml
+++ b/packages/flutter_tools/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   crypto: '>=1.1.1 <3.0.0'
   file: 2.3.3
   http: ^0.11.3+12
-  intl: '>=0.14.0 <0.15.0'
+  intl: '>=0.14.0 <0.16.0'
   json_rpc_2: ^2.0.0
   json_schema: 1.0.6
   linter: 0.1.31
@@ -21,7 +21,7 @@ dependencies:
   mustache: ^0.2.5
   package_config: '>=0.1.5 <2.0.0'
   platform: 2.1.0
-  process: 2.0.3
+  process: 2.0.4
   quiver: ^0.24.0
   stack_trace: ^1.4.0
   usage: ^3.2.0+1


### PR DESCRIPTION
* requires bumping `process` to a version that has
  relaxed version restrictions on `intl`

https://github.com/flutter/flutter/issues/10650