### PR TITLE
Remove broken image in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,6 @@ without losing state, on
 emulators, simulators, and hardware for iOS
 and Android.
 
-<img src="https://flutter.io/images/intellij/hot-reload.gif" alt="Make a change in your code, and your app is changed instantly.">
-
 ## Expressive, beautiful UIs
 
 Delight your users with Flutter's built-in


### PR DESCRIPTION
Github makes copies of images referenced in README, and it fails for large image sizes. The gif has 6MB and so is over the threshold.

This removes the image until I can figure out how to reinsert it so that it shows.