### PR TITLE
Fix missing animated gif in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,6 @@ without losing state, on
 emulators, simulators, and hardware for iOS
 and Android.
 
-<img src="https://flutter.io/images/intellij/hot-reload.gif" alt="Make a change in your code, and your app is changed instantly.">
-
 ## Expressive, beautiful UIs
 
 Delight your users with Flutter's built-in

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ without losing state, on
 emulators, simulators, and hardware for iOS
 and Android.
 
+<img src="https://user-images.githubusercontent.com/919717/28131204-0f8c3cda-66ee-11e7-9428-6a0513eac75d.gif" alt="Make a change in your code, and your app is changed instantly.">
+
 ## Expressive, beautiful UIs
 
 Delight your users with Flutter's built-in


### PR DESCRIPTION
Github makes own copies of images referenced in README, and that fails for large image sizes. The gif has 6MB and so is over the threshold.

Instead of using an off-GitHub image, use the same image uploaded to user-images.githubusercontent.com. This makes GitHub show the image even when it's very large.

This reverses https://github.com/flutter/flutter/pull/11170 and finalizes https://github.com/flutter/flutter/pull/11158.