### PR TITLE
Add slider customizations

### DIFF
--- a/packages/flutter/lib/src/material/slider.dart
+++ b/packages/flutter/lib/src/material/slider.dart
@@ -65,7 +65,6 @@ class Slider extends StatefulWidget {
     this.label,
     this.activeColor,
     this.inactiveColor,
-    this.showThumb: true,
     this.thumbOpenAtMin: false,
   }) : assert(value != null),
        assert(min != null),
@@ -73,7 +72,6 @@ class Slider extends StatefulWidget {
        assert(min <= max),
        assert(value >= min && value <= max),
        assert(divisions == null || divisions > 0),
-       assert(showThumb != null),
        assert(thumbOpenAtMin != null),
        super(key: key);
 
@@ -146,13 +144,6 @@ class Slider extends StatefulWidget {
   /// Defaults to the unselected widget color of the current [Theme].
   final Color inactiveColor;
 
-  /// Whether to show the thumb (circle).
-  ///
-  /// When this property is false, the thumb is hidden.
-  ///
-  /// Defaults to true.
-  final bool showThumb;
-
   /// Whether the thumb should be an open circle when the slider is at its minimum position.
   ///
   /// When this property is false, the thumb does not change when it the slider
@@ -194,7 +185,6 @@ class _SliderState extends State<Slider> with TickerProviderStateMixin {
       label: widget.label,
       activeColor: widget.activeColor ?? theme.accentColor,
       inactiveColor: widget.inactiveColor ?? theme.unselectedWidgetColor,
-      showThumb: widget.showThumb,
       thumbOpenAtMin: widget.thumbOpenAtMin,
       textTheme: theme.accentTextTheme,
       onChanged: (widget.onChanged != null) && (widget.max > widget.min) ? _handleChanged : null,
@@ -211,7 +201,6 @@ class _SliderRenderObjectWidget extends LeafRenderObjectWidget {
     this.label,
     this.activeColor,
     this.inactiveColor,
-    this.showThumb,
     this.thumbOpenAtMin,
     this.textTheme,
     this.onChanged,
@@ -223,7 +212,6 @@ class _SliderRenderObjectWidget extends LeafRenderObjectWidget {
   final String label;
   final Color activeColor;
   final Color inactiveColor;
-  final bool showThumb;
   final bool thumbOpenAtMin;
   final TextTheme textTheme;
   final ValueChanged<double> onChanged;
@@ -237,7 +225,6 @@ class _SliderRenderObjectWidget extends LeafRenderObjectWidget {
       label: label,
       activeColor: activeColor,
       inactiveColor: inactiveColor,
-      showThumb: showThumb,
       thumbOpenAtMin: thumbOpenAtMin,
       textTheme: textTheme,
       onChanged: onChanged,
@@ -253,7 +240,6 @@ class _SliderRenderObjectWidget extends LeafRenderObjectWidget {
       ..label = label
       ..activeColor = activeColor
       ..inactiveColor = inactiveColor
-      ..showThumb = showThumb
       ..thumbOpenAtMin = thumbOpenAtMin
       ..textTheme = textTheme
       ..onChanged = onChanged;
@@ -300,7 +286,6 @@ class _RenderSlider extends RenderBox implements SemanticsActionHandler {
     String label,
     Color activeColor,
     Color inactiveColor,
-    bool showThumb,
     bool thumbOpenAtMin,
     TextTheme textTheme,
     this.onChanged,
@@ -310,7 +295,6 @@ class _RenderSlider extends RenderBox implements SemanticsActionHandler {
        _divisions = divisions,
        _activeColor = activeColor,
        _inactiveColor = inactiveColor,
-       _showThumb = showThumb,
        _thumbOpenAtMin = thumbOpenAtMin,
        _textTheme = textTheme {
     this.label = label;
@@ -405,15 +389,6 @@ class _RenderSlider extends RenderBox implements SemanticsActionHandler {
     if (value == _thumbOpenAtMin)
       return;
     _thumbOpenAtMin = value;
-    markNeedsPaint();
-  }
-
-  bool get showThumb => _showThumb;
-  bool _showThumb;
-  set showThumb(bool value) {
-    if (value == _showThumb)
-      return;
-    _showThumb = value;
     markNeedsPaint();
   }
 
@@ -555,13 +530,9 @@ class _RenderSlider extends RenderBox implements SemanticsActionHandler {
       if (value > 0.0)
         canvas.drawRect(new Rect.fromLTRB(trackLeft, trackTop, trackActive, trackBottom), primaryPaint);
       if (value < 1.0) {
-        if (showThumb) {
-          final bool hasBalloon = _reaction.status != AnimationStatus.dismissed && label != null;
-          final double trackActiveDelta = hasBalloon ? 0.0 : thumbRadius - 1.0;
-          canvas.drawRect(new Rect.fromLTRB(trackActive + trackActiveDelta, trackTop, trackRight, trackBottom), trackPaint);
-        } else {
-          canvas.drawRect(new Rect.fromLTRB(trackActive, trackTop, trackRight, trackBottom), trackPaint);
-        }
+        final bool hasBalloon = _reaction.status != AnimationStatus.dismissed && label != null;
+        final double trackActiveDelta = hasBalloon ? 0.0 : thumbRadius - 1.0;
+        canvas.drawRect(new Rect.fromLTRB(trackActive + trackActiveDelta, trackTop, trackRight, trackBottom), trackPaint);
       }
     } else {
       if (value > 0.0)
@@ -612,19 +583,17 @@ class _RenderSlider extends RenderBox implements SemanticsActionHandler {
       }
     }
 
-    if (showThumb) {
-      Paint thumbPaint = primaryPaint;
-      double thumbRadiusDelta = 0.0;
-      if (value == 0.0 && thumbOpenAtMin) {
-        thumbPaint = trackPaint;
-        // This is destructive to trackPaint.
-        thumbPaint
-          ..style = PaintingStyle.stroke
-          ..strokeWidth = 2.0;
-        thumbRadiusDelta = -1.0;
-      }
-      canvas.drawCircle(thumbCenter, thumbRadius + thumbRadiusDelta, thumbPaint);
+    Paint thumbPaint = primaryPaint;
+    double thumbRadiusDelta = 0.0;
+    if (value == 0.0 && thumbOpenAtMin) {
+      thumbPaint = trackPaint;
+      // This is destructive to trackPaint.
+      thumbPaint
+        ..style = PaintingStyle.stroke
+        ..strokeWidth = 2.0;
+      thumbRadiusDelta = -1.0;
     }
+    canvas.drawCircle(thumbCenter, thumbRadius + thumbRadiusDelta, thumbPaint);
   }
 
   @override

--- a/packages/flutter/test/material/slider_test.dart
+++ b/packages/flutter/test/material/slider_test.dart
@@ -144,9 +144,13 @@ void main() {
 
     expect(sliderBox, paints..rect(color: theme.accentColor)..rect(color: theme.unselectedWidgetColor));
     expect(sliderBox, paints..circle(color: theme.accentColor));
+    expect(sliderBox, isNot(paints..circle(color: customColor)));
+    expect(sliderBox, isNot(paints..circle(color: theme.unselectedWidgetColor)));
     await tester.pumpWidget(buildApp(customColor));
     expect(sliderBox, paints..rect(color: customColor)..rect(color: theme.unselectedWidgetColor));
     expect(sliderBox, paints..circle(color: customColor));
+    expect(sliderBox, isNot(paints..circle(color: theme.accentColor)));
+    expect(sliderBox, isNot(paints..circle(color: theme.unselectedWidgetColor)));
   });
 
   testWidgets('Slider has a customizable inactive color',
@@ -178,33 +182,6 @@ void main() {
     await tester.pumpWidget(buildApp(customColor));
     expect(sliderBox, paints..rect(color: theme.accentColor)..rect(color: customColor));
     expect(sliderBox, paints..circle(color: theme.accentColor));
-  });
-
-  testWidgets('Slider can be drawn with and without a thumb',
-      (WidgetTester tester) async {
-
-    Widget buildApp(bool showThumb) {
-      return new Material(
-        child: new Center(
-          child: new Slider(
-            value: 0.5,
-            showThumb: showThumb,
-            onChanged: (double newValue) {},
-          ),
-        ),
-      );
-    }
-
-    await tester.pumpWidget(buildApp(false));
-
-    final RenderBox sliderBox =
-        tester.firstRenderObject<RenderBox>(find.byType(Slider));
-
-    expect(sliderBox, isNot(paints..circle(style: PaintingStyle.fill)));
-    expect(sliderBox, isNot(paints..circle()..circle()));
-    await tester.pumpWidget(buildApp(true));
-    expect(sliderBox, paints..circle(style: PaintingStyle.fill));
-    expect(sliderBox, isNot(paints..circle()..circle()));
   });
 
   testWidgets('Slider can draw an open thumb at min',

--- a/packages/flutter/test/material/slider_test.dart
+++ b/packages/flutter/test/material/slider_test.dart
@@ -118,6 +118,95 @@ void main() {
     log.clear();
   });
 
+  testWidgets('Slider has a customizable active color',
+      (WidgetTester tester) async {
+    final Color customColor = const Color(0xFF4CD964);
+    final ThemeData theme = new ThemeData(platform: TargetPlatform.android);
+    Widget buildApp(Color activeColor) {
+      return new Material(
+        child: new Center(
+          child: new Theme(
+            data: theme,
+            child: new Slider(
+              value: 0.5,
+              activeColor: activeColor,
+              onChanged: (double newValue) {},
+            ),
+          ),
+        ),
+      );
+    }
+
+    await tester.pumpWidget(buildApp(null));
+
+    final RenderBox sliderBox =
+        tester.firstRenderObject<RenderBox>(find.byType(Slider));
+
+    expect(sliderBox, paints..rect(color: theme.accentColor)..rect(color: theme.unselectedWidgetColor));
+    expect(sliderBox, paints..circle(color: theme.accentColor));
+    await tester.pumpWidget(buildApp(customColor));
+    expect(sliderBox, paints..rect(color: customColor)..rect(color: theme.unselectedWidgetColor));
+    expect(sliderBox, paints..circle(color: customColor));
+  });
+
+  testWidgets('Slider has a customizable inactive color',
+      (WidgetTester tester) async {
+    final Color customColor = const Color(0xFF4CD964);
+    final ThemeData theme = new ThemeData(platform: TargetPlatform.android);
+    Widget buildApp(Color inactiveColor) {
+      return new Material(
+        child: new Center(
+          child: new Theme(
+            data: theme,
+            child: new Slider(
+              value: 0.5,
+              inactiveColor: inactiveColor,
+              onChanged: (double newValue) {},
+            ),
+          ),
+        ),
+      );
+    }
+
+    await tester.pumpWidget(buildApp(null));
+
+    final RenderBox sliderBox =
+        tester.firstRenderObject<RenderBox>(find.byType(Slider));
+
+    expect(sliderBox, paints..rect(color: theme.accentColor)..rect(color: theme.unselectedWidgetColor));
+    expect(sliderBox, paints..circle(color: theme.accentColor));
+    await tester.pumpWidget(buildApp(customColor));
+    expect(sliderBox, paints..rect(color: theme.accentColor)..rect(color: customColor));
+    expect(sliderBox, paints..circle(color: theme.accentColor));
+  });
+
+  testWidgets('Slider can be drawn with and without a thumb',
+      (WidgetTester tester) async {
+
+    Widget buildApp(bool showThumb) {
+      return new Material(
+        child: new Center(
+          child: new Slider(
+            value: 0.5,
+            showThumb: showThumb,
+            onChanged: (double newValue) {},
+          ),
+        ),
+      );
+    }
+
+    await tester.pumpWidget(buildApp(false));
+
+    final RenderBox sliderBox =
+        tester.firstRenderObject<RenderBox>(find.byType(Slider));
+
+    expect(sliderBox, isNot(paints..circle(style: PaintingStyle.fill)));
+    expect(sliderBox, isNot(paints..circle()..circle()));
+    await tester.pumpWidget(buildApp(true));
+    expect(sliderBox, paints..circle(style: PaintingStyle.fill));
+    expect(sliderBox, isNot(paints..circle()..circle()));
+  });
+
   testWidgets('Slider can draw an open thumb at min',
       (WidgetTester tester) async {
     Widget buildApp(bool thumbOpenAtMin) {


### PR DESCRIPTION
When creating a Slider widget, a user can now customize:
- inactiveColor, the color of the not-yet-played portion of the slider (default to theme.unselectedWidgetColor)
- showThumb, whether to show the circle thumb (default to true)