### PR TITLE
Add platform-specific system navigation behavior to BackButton

### DIFF
--- a/packages/flutter/lib/src/material/back_button.dart
+++ b/packages/flutter/lib/src/material/back_button.dart
@@ -88,9 +88,8 @@ class BackButton extends StatelessWidget {
       tooltip: 'Back', // TODO(ianh): Figure out how to localize this string
       onPressed: () {
         Navigator.of(context).maybePop().then((bool didPop) {
-          if (didPop)
-            return;
-          SystemNavigator.pop();
+          if (!didPop)
+            SystemNavigator.pop();
         }).catchError((dynamic error) {});
       }
     );

--- a/packages/flutter/lib/src/material/back_button.dart
+++ b/packages/flutter/lib/src/material/back_button.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:flutter/widgets.dart';
+import 'package:flutter/services.dart';
 
 import 'icon_button.dart';
 import 'icons.dart';
@@ -46,7 +47,9 @@ class BackButtonIcon extends StatelessWidget {
 ///
 /// A [BackButton] is an [IconButton] with a "back" icon appropriate for the
 /// current [TargetPlatform]. When pressed, the back button calls
-/// [Navigator.maybePop] to return to the previous route.
+/// [Navigator.maybePop] to return to the previous route if possible. If not,
+/// the platform-specific system navigator is instructed to back up a level in
+/// the navigation hierarchy.
 ///
 /// When deciding to display a [BackButton], consider using
 /// `ModalRoute.of(context)?.canPop` to check whether the current route can be
@@ -84,7 +87,11 @@ class BackButton extends StatelessWidget {
       color: color,
       tooltip: 'Back', // TODO(ianh): Figure out how to localize this string
       onPressed: () {
-        Navigator.of(context).maybePop();
+        Navigator.of(context).maybePop().then((bool didPop) {
+          if (didPop)
+            return;
+          SystemNavigator.pop();
+        }).catchError((dynamic error) {});
       }
     );
   }

--- a/packages/flutter/lib/src/services/system_navigator.dart
+++ b/packages/flutter/lib/src/services/system_navigator.dart
@@ -13,8 +13,10 @@ class SystemNavigator {
   /// Instructs the system navigator to remove this activity from the stack and
   /// return to the previous activity.
   ///
-  /// On iOS, calls to this method are ignored because Apple's human interface
-  /// guidelines state that applications should not exit themselves.
+  /// On iOS, if the root view is a navigaton controller, it is instructed to
+  /// back up a level in the navigation hierarchy. Otherwise calls to this
+  /// method are ignored because Apple's human interface guidelines state that
+  /// applications should not exit themselves.
   ///
   /// This method should be preferred over calling `dart:io`'s [exit] method, as
   /// the latter may cause the underlying platform to act as if the application

--- a/packages/flutter/test/material/back_button_test.dart
+++ b/packages/flutter/test/material/back_button_test.dart
@@ -56,7 +56,7 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.byType(BackButton), findsOneWidget);
-    expect(log.contains(const MethodCall('SystemNavigator.pop')), true);
+    expect(log, contains(const MethodCall('SystemNavigator.pop')));
   });
 
   testWidgets('BackButton icon', (WidgetTester tester) async {

--- a/packages/flutter/test/material/back_button_test.dart
+++ b/packages/flutter/test/material/back_button_test.dart
@@ -34,7 +34,7 @@ void main() {
     expect(find.text('Home'), findsOneWidget);
   });
 
-  testWidgets('BackButton platform navigation test', (WidgetTester tester) async {
+  testWidgets('BackButton platform navigation', (WidgetTester tester) async {
     final List<MethodCall> log = <MethodCall>[];
 
     SystemChannels.platform.setMockMethodCallHandler((MethodCall methodCall) async {
@@ -42,13 +42,13 @@ void main() {
     });
 
     await tester.pumpWidget(
-        new MaterialApp(
-            home: const Material(
-                child: const Center(
-                  child: const BackButton(),
-                )
-            ),
-        )
+      new MaterialApp(
+        home: const Material(
+          child: const Center(
+            child: const BackButton(),
+          ),
+        ),
+      ),
     );
 
     await tester.tap(find.byType(BackButton));
@@ -58,7 +58,7 @@ void main() {
     expect(find.byType(BackButton), findsOneWidget);
     expect(log.contains(const MethodCall('SystemNavigator.pop')), true);
   });
-  
+
   testWidgets('BackButton icon', (WidgetTester tester) async {
     final Key iOSKey = new UniqueKey();
     final Key androidKey = new UniqueKey();

--- a/packages/flutter/test/material/back_button_test.dart
+++ b/packages/flutter/test/material/back_button_test.dart
@@ -4,6 +4,7 @@
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter/services.dart';
 
 void main() {
   testWidgets('BackButton control test', (WidgetTester tester) async {
@@ -33,6 +34,31 @@ void main() {
     expect(find.text('Home'), findsOneWidget);
   });
 
+  testWidgets('BackButton platform navigation test', (WidgetTester tester) async {
+    final List<MethodCall> log = <MethodCall>[];
+
+    SystemChannels.platform.setMockMethodCallHandler((MethodCall methodCall) async {
+      log.add(methodCall);
+    });
+
+    await tester.pumpWidget(
+        new MaterialApp(
+            home: const Material(
+                child: const Center(
+                  child: const BackButton(),
+                )
+            ),
+        )
+    );
+
+    await tester.tap(find.byType(BackButton));
+
+    await tester.pumpAndSettle();
+
+    expect(find.byType(BackButton), findsOneWidget);
+    expect(log.contains(const MethodCall('SystemNavigator.pop')), true);
+  });
+  
   testWidgets('BackButton icon', (WidgetTester tester) async {
     final Key iOSKey = new UniqueKey();
     final Key androidKey = new UniqueKey();


### PR DESCRIPTION
We want to be able to drive the app navigation from Flutter, also in apps that are partly written in platform-specific code. 

I also updated the doc for `SystemNavigator.pop` to match the updated behavior on iOS from engine PR flutter/engine#3865