### PR TITLE
Declare cli_util dependency in pubspec

### DIFF
--- a/packages/flutter_tools/pubspec.yaml
+++ b/packages/flutter_tools/pubspec.yaml
@@ -9,6 +9,7 @@ environment:
 dependencies:
   archive: ^1.0.20
   args: ^0.13.4
+  cli_util: ^0.1.2
   coverage: ^0.9.2
   crypto: '>=1.1.1 <3.0.0'
   file: 2.3.4
@@ -21,9 +22,11 @@ dependencies:
   mustache: ^0.2.5
   package_config: '>=0.1.5 <2.0.0'
   platform: 2.1.1
+  plugin: ^0.2.0
   process: 2.0.5
   quiver: ^0.24.0
   stack_trace: ^1.4.0
+  stream_channel: ^1.6.1
   usage: ^3.2.0+1
   vm_service_client: '0.2.2+4'
   web_socket_channel: ^1.0.4


### PR DESCRIPTION
flutter_tools depends on cli_util, but hadn't explicitly declared it as
a dependency.