### PR TITLE
Register tools as a reloadSources service

### DIFF
--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -45,7 +45,12 @@ class FlutterDevice {
   }
 
   /// If the [reloadSources] parameter is not null the 'reloadSources' service
-  /// will be registered
+  /// will be registered.
+  /// The 'reloadSources' service can be used by other Service Protocol clients
+  /// connected to the VM (e.g. Observatory) to request a reload of the source
+  /// code of the running application (a.k.a. HotReload).
+  /// This ensures that the reload process follows the normal orchestration of
+  /// the Flutter Tools and not just the VM internal service.
   void connect({ReloadSources reloadSources}) {
     if (vmServices != null)
       return;

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -44,12 +44,15 @@ class FlutterDevice {
     _viewsCache = null;
   }
 
-  void connect() {
+  /// If the [reloadSources] parameter is not null the 'reloadSources' service
+  /// will be registered
+  void connect({ReloadSources reloadSources}) {
     if (vmServices != null)
       return;
     vmServices = new List<VMService>(observatoryUris.length);
     for (int i = 0; i < observatoryUris.length; i++) {
-      vmServices[i] = VMService.connect(observatoryUris[i]);
+      vmServices[i] = VMService.connect(observatoryUris[i],
+          reloadSources: reloadSources);
       printTrace('Connected to service protocol: ${observatoryUris[i]}');
     }
   }
@@ -528,14 +531,17 @@ abstract class ResidentRunner {
       device.stopEchoingDeviceLog();
   }
 
-  Future<Null> connectToServiceProtocol({String viewFilter}) async {
+  /// If the [reloadSources] parameter is not null the 'reloadSources' service
+  /// will be registered
+  Future<Null> connectToServiceProtocol({String viewFilter,
+      ReloadSources reloadSources}) async {
     if (!debuggingOptions.debuggingEnabled)
       return new Future<Null>.error('Error the service protocol is not enabled.');
 
     bool viewFound = false;
     for (FlutterDevice device in flutterDevices) {
       device.viewFilter = viewFilter;
-      device.connect();
+      device.connect(reloadSources: reloadSources);
       await device.getVMs();
       await device.waitForViews();
       if (device.views == null)

--- a/packages/flutter_tools/lib/src/run_hot.dart
+++ b/packages/flutter_tools/lib/src/run_hot.dart
@@ -17,6 +17,8 @@ import 'device.dart';
 import 'globals.dart';
 import 'resident_runner.dart';
 import 'usage.dart';
+import 'package:json_rpc_2/error_code.dart' as rpc_error_code;
+import 'package:json_rpc_2/json_rpc_2.dart' as rpc;
 import 'vmservice.dart';
 
 class HotRunnerConfig {
@@ -84,10 +86,16 @@ class HotRunner extends ResidentRunner {
     return true;
   }
 
-  Future _reloadSourcesService(String isolateId,
+  Future<Null> _reloadSourcesService(String isolateId,
       { bool force: false, bool pause: false }) async {
     // TODO(cbernaschina): check that isolateId is the id of the UI isolate.
-    return restart(pauseAfterRestart: pause);
+    final OperationResult result = await restart(pauseAfterRestart: pause);
+    if (result != OperationResult.ok) {
+      throw new rpc.RpcException(
+        rpc_error_code.INTERNAL_ERROR,
+        'Unable to reload sources',
+      );
+    };
   }
 
   Future<int> attach({

--- a/packages/flutter_tools/lib/src/run_hot.dart
+++ b/packages/flutter_tools/lib/src/run_hot.dart
@@ -85,8 +85,8 @@ class HotRunner extends ResidentRunner {
   }
 
   Future _reloadSourcesService(String isolateId,
-      {bool force: false, bool pause: false}) async {
-    // TODO(cbernaschina): check that isolateId is the id of the UI isolate
+      { bool force: false, bool pause: false }) async {
+    // TODO(cbernaschina): check that isolateId is the id of the UI isolate.
     return restart(pauseAfterRestart: pause);
   }
 
@@ -511,10 +511,6 @@ class HotRunner extends ResidentRunner {
     _runningFromSnapshot = false;
     // Check if the isolate is paused.
 
-    if (pause) {
-      printTrace('Skipping reassemble because all isolates are paused.');
-      return new OperationResult(OperationResult.ok.code, reloadMessage);
-    }
     final List<FlutterView> reassembleViews = <FlutterView>[];
     for (FlutterDevice device in flutterDevices) {
       for (FlutterView view in device.views) {

--- a/packages/flutter_tools/lib/src/vmservice.dart
+++ b/packages/flutter_tools/lib/src/vmservice.dart
@@ -24,9 +24,9 @@ typedef StreamChannel<String> _OpenChannel(Uri uri);
 
 _OpenChannel _openChannel = _defaultOpenChannel;
 
-/// A function that reacts to the invocation of the 'reloadSources' service
+/// A function that reacts to the invocation of the 'reloadSources' service.
 typedef Future ReloadSources(String isolateId,
-    {bool force, bool pause});
+    { bool force, bool pause });
 
 const String _kRecordingType = 'vmservice';
 
@@ -55,8 +55,8 @@ class VMService {
 
     if (reloadSources != null) {
       _peer.registerMethod('reloadSources', (rpc.Parameters params) async {
-        const kInvalidParams = -32602;
-        const kServerError = -32000;
+        const int kInvalidParams = -32602;
+        const int kServerError = -32000;
 
         final String isolateId = params['isolateId'].value;
         final bool force = params.asMap['force'] ?? false;
@@ -70,8 +70,7 @@ class VMService {
           throw new rpc.RpcException.invalidParams('Invalid \'pause\'');
 
         try {
-          await reloadSources(isolateId, force: force ?? false,
-              pause: pause ?? false);
+          await reloadSources(isolateId, force: force, pause: pause);
           return {'type': 'Success'};
         } on rpc.RpcException {
           rethrow;
@@ -120,11 +119,11 @@ class VMService {
   /// Requests made via the returns [VMService] time out after [requestTimeout]
   /// amount of time, which is [kDefaultRequestTimeout] by default.
   /// If the [reloadSources] parameter is not null the 'reloadSources' service
-  /// will be registered
+  /// will be registered.
   static VMService connect(
     Uri httpUri, {
     Duration requestTimeout: kDefaultRequestTimeout,
-    ReloadSources reloadSources
+    ReloadSources reloadSources,
   }) {
     final Uri wsUri = httpUri.replace(scheme: 'ws', path: fs.path.join(httpUri.path, 'ws'));
     final StreamChannel<String> channel = _openChannel(wsUri);

--- a/packages/flutter_tools/lib/src/vmservice.dart
+++ b/packages/flutter_tools/lib/src/vmservice.dart
@@ -91,7 +91,7 @@ class VMService {
           rethrow;
         } catch (e, st) {
           throw new rpc.RpcException(rpc_error_code.SERVER_ERROR,
-              'Error during Sources Reload: $e$st');
+              'Error during Sources Reload: $e\n$st');
         }
       });
 


### PR DESCRIPTION
In https://github.com/dart-lang/sdk/commit/df8bf384eb815cf38450cb50a0f4b62230fba217 a new functionality of the Dart VM Service Protocol has been introduced.

Clients connected to the Service Protocol are now able to expose services that other clients (e.g. Observatory) can invoke through the Service Protocol itself.


With these changes Flutter Tools register them self as a `reloadSources` (a.k.a. HotReload) capable client.
Observatory is already listening for the clients which expose this functionality and uses by default the service based version of  `reloadSources` when available, so requesting a HotReload from Observatory will trigger the full Flutter HotReload.

Related https://github.com/dart-lang/sdk/issues/30023