### PR TITLE
Support automaticallyImplyLeading param in AppBar

### DIFF
--- a/packages/flutter/lib/src/material/app_bar.dart
+++ b/packages/flutter/lib/src/material/app_bar.dart
@@ -128,6 +128,9 @@ class _ToolbarContainerLayout extends SingleChildLayoutDelegate {
 class AppBar extends StatefulWidget implements PreferredSizeWidget {
   /// Creates a material design app bar.
   ///
+  /// Arguments [elevation], [primary], [toolbarOpacity], [bottomOpacity],
+  /// [automaticallyImplyLeading], must not be null.
+  /// 
   /// Typically used in the [Scaffold.appBar] property.
   AppBar({
     Key key,
@@ -150,16 +153,18 @@ class AppBar extends StatefulWidget implements PreferredSizeWidget {
        assert(primary != null),
        assert(toolbarOpacity != null),
        assert(bottomOpacity != null),
+       assert(automaticallyImplyLeading != null),
        preferredSize = new Size.fromHeight(kToolbarHeight + (bottom?.preferredSize?.height ?? 0.0)),
        super(key: key);
 
   /// A widget to display before the [title].
   ///
-  /// If this is null, the [AppBar] will imply an appropriate widget. For
-  /// example, if the [AppBar] is in a [Scaffold] that also has a [Drawer], the
-  /// [Scaffold] will fill this widget with an [IconButton] that opens the
-  /// drawer. If there's no [Drawer] and the parent [Navigator] can go back, the
-  /// [AppBar] will use a [BackButton] that calls [Navigator.maybePop].
+  /// If this is null and automaticallyImplyLeading is set to true, the [AppBar] will
+  /// imply an appropriate widget. For example, if the [AppBar] is in a [Scaffold]
+  /// that also has a [Drawer], the [Scaffold] will fill this widget with an
+  /// [IconButton] that opens the drawer. If there's no [Drawer] and the parent
+  /// [Navigator] can go back, the [AppBar] will use a [BackButton] that calls
+  /// [Navigator.maybePop].
   final Widget leading;
 
   /// Controls whether we should try to imply the leading widget if null.
@@ -509,6 +514,7 @@ class _FloatingAppBarState extends State<_FloatingAppBar> {
 class _SliverAppBarDelegate extends SliverPersistentHeaderDelegate {
   _SliverAppBarDelegate({
     @required this.leading,
+    @required this.automaticallyImplyLeading,
     @required this.title,
     @required this.actions,
     @required this.flexibleSpace,
@@ -531,6 +537,7 @@ class _SliverAppBarDelegate extends SliverPersistentHeaderDelegate {
        _bottomHeight = bottom?.preferredSize?.height ?? 0.0;
 
   final Widget leading;
+  final bool automaticallyImplyLeading;
   final Widget title;
   final List<Widget> actions;
   final Widget flexibleSpace;
@@ -572,6 +579,7 @@ class _SliverAppBarDelegate extends SliverPersistentHeaderDelegate {
       toolbarOpacity: toolbarOpacity,
       child: new AppBar(
         leading: leading,
+        automaticallyImplyLeading: automaticallyImplyLeading,
         title: title,
         actions: actions,
         flexibleSpace: flexibleSpace,
@@ -593,6 +601,7 @@ class _SliverAppBarDelegate extends SliverPersistentHeaderDelegate {
   @override
   bool shouldRebuild(covariant _SliverAppBarDelegate oldDelegate) {
     return leading != oldDelegate.leading
+        || automaticallyImplyLeading != oldDelegate.automaticallyImplyLeading
         || title != oldDelegate.title
         || actions != oldDelegate.actions
         || flexibleSpace != oldDelegate.flexibleSpace
@@ -673,6 +682,7 @@ class SliverAppBar extends StatefulWidget {
   const SliverAppBar({
     Key key,
     this.leading,
+    this.automaticallyImplyLeading: true,
     this.title,
     this.actions,
     this.flexibleSpace,
@@ -696,16 +706,25 @@ class SliverAppBar extends StatefulWidget {
        assert(!pinned || !floating || bottom != null, 'A pinned and floating app bar must have a bottom widget.'),
        assert(snap != null),
        assert(floating || !snap, 'The "snap" argument only makes sense for floating app bars.'),
+       assert(automaticallyImplyLeading != null),
        super(key: key);
 
   /// A widget to display before the [title].
   ///
-  /// If this is null, the [AppBar] will imply an appropriate widget. For
-  /// example, if the [AppBar] is in a [Scaffold] that also has a [Drawer], the
-  /// [Scaffold] will fill this widget with an [IconButton] that opens the
-  /// drawer. If there's no [Drawer] and the parent [Navigator] can go back, the
-  /// [AppBar] will use an [IconButton] that calls [Navigator.pop].
+  /// If this is null and automaticallyImplyLeading is set to true, the [AppBar] will
+  /// imply an appropriate widget. For example, if the [AppBar] is in a [Scaffold]
+  /// that also has a [Drawer], the [Scaffold] will fill this widget with an
+  /// [IconButton] that opens the drawer. If there's no [Drawer] and the parent
+  /// [Navigator] can go back, the [AppBar] will use a [BackButton] that calls
+  /// [Navigator.maybePop].
   final Widget leading;
+
+  /// Controls whether we should try to imply the leading widget if null.
+  ///
+  /// If true and leading is null, automatically try to deduce what the leading
+  /// widget should be. If false and leading is null, leading space is given to title.
+  /// If leading widget is not null, this parameter has no effect.
+  final bool automaticallyImplyLeading;
 
   /// The primary widget displayed in the appbar.
   ///
@@ -903,6 +922,7 @@ class _SliverAppBarState extends State<SliverAppBar> with TickerProviderStateMix
       pinned: widget.pinned,
       delegate: new _SliverAppBarDelegate(
         leading: widget.leading,
+        automaticallyImplyLeading: widget.automaticallyImplyLeading,
         title: widget.title,
         actions: widget.actions,
         flexibleSpace: widget.flexibleSpace,

--- a/packages/flutter/lib/src/material/app_bar.dart
+++ b/packages/flutter/lib/src/material/app_bar.dart
@@ -128,9 +128,9 @@ class _ToolbarContainerLayout extends SingleChildLayoutDelegate {
 class AppBar extends StatefulWidget implements PreferredSizeWidget {
   /// Creates a material design app bar.
   ///
-  /// Arguments [elevation], [primary], [toolbarOpacity], [bottomOpacity],
-  /// [automaticallyImplyLeading], must not be null.
-  /// 
+  /// The arguments [elevation], [primary], [toolbarOpacity], [bottomOpacity]
+  /// and [automaticallyImplyLeading] must not be null.
+  ///
   /// Typically used in the [Scaffold.appBar] property.
   AppBar({
     Key key,
@@ -149,17 +149,17 @@ class AppBar extends StatefulWidget implements PreferredSizeWidget {
     this.centerTitle,
     this.toolbarOpacity: 1.0,
     this.bottomOpacity: 1.0,
-  }) : assert(elevation != null),
+  }) : assert(automaticallyImplyLeading != null),
+       assert(elevation != null),
        assert(primary != null),
        assert(toolbarOpacity != null),
        assert(bottomOpacity != null),
-       assert(automaticallyImplyLeading != null),
        preferredSize = new Size.fromHeight(kToolbarHeight + (bottom?.preferredSize?.height ?? 0.0)),
        super(key: key);
 
   /// A widget to display before the [title].
   ///
-  /// If this is null and automaticallyImplyLeading is set to true, the [AppBar] will
+  /// If this is null and [automaticallyImplyLeading] is set to true, the [AppBar] will
   /// imply an appropriate widget. For example, if the [AppBar] is in a [Scaffold]
   /// that also has a [Drawer], the [Scaffold] will fill this widget with an
   /// [IconButton] that opens the drawer. If there's no [Drawer] and the parent
@@ -169,8 +169,8 @@ class AppBar extends StatefulWidget implements PreferredSizeWidget {
 
   /// Controls whether we should try to imply the leading widget if null.
   ///
-  /// If true and leading is null, automatically try to deduce what the leading
-  /// widget should be. If false and leading is null, leading space is given to title.
+  /// If true and [leading] is null, automatically try to deduce what the leading
+  /// widget should be. If false and [leading] is null, leading space is given to [title].
   /// If leading widget is not null, this parameter has no effect.
   final bool automaticallyImplyLeading;
 
@@ -679,6 +679,9 @@ class _SliverAppBarDelegate extends SliverPersistentHeaderDelegate {
 ///  * <https://material.google.com/layout/structure.html#structure-toolbars>
 class SliverAppBar extends StatefulWidget {
   /// Creates a material design app bar that can be placed in a [CustomScrollView].
+  ///
+  /// The arguments [forceElevated], [primary], [floating], [pinned], [snap]
+  /// and [automaticallyImplyLeading] must not be null.
   const SliverAppBar({
     Key key,
     this.leading,
@@ -699,19 +702,19 @@ class SliverAppBar extends StatefulWidget {
     this.floating: false,
     this.pinned: false,
     this.snap: false,
-  }) : assert(forceElevated != null),
+  }) : assert(automaticallyImplyLeading != null),
+       assert(forceElevated != null),
        assert(primary != null),
        assert(floating != null),
        assert(pinned != null),
        assert(!pinned || !floating || bottom != null, 'A pinned and floating app bar must have a bottom widget.'),
        assert(snap != null),
        assert(floating || !snap, 'The "snap" argument only makes sense for floating app bars.'),
-       assert(automaticallyImplyLeading != null),
        super(key: key);
 
   /// A widget to display before the [title].
   ///
-  /// If this is null and automaticallyImplyLeading is set to true, the [AppBar] will
+  /// If this is null and [automaticallyImplyLeading] is set to true, the [AppBar] will
   /// imply an appropriate widget. For example, if the [AppBar] is in a [Scaffold]
   /// that also has a [Drawer], the [Scaffold] will fill this widget with an
   /// [IconButton] that opens the drawer. If there's no [Drawer] and the parent
@@ -721,8 +724,8 @@ class SliverAppBar extends StatefulWidget {
 
   /// Controls whether we should try to imply the leading widget if null.
   ///
-  /// If true and leading is null, automatically try to deduce what the leading
-  /// widget should be. If false and leading is null, leading space is given to title.
+  /// If true and [leading] is null, automatically try to deduce what the leading
+  /// widget should be. If false and [leading] is null, leading space is given to [title].
   /// If leading widget is not null, this parameter has no effect.
   final bool automaticallyImplyLeading;
 

--- a/packages/flutter/lib/src/material/app_bar.dart
+++ b/packages/flutter/lib/src/material/app_bar.dart
@@ -84,7 +84,9 @@ class _ToolbarContainerLayout extends SingleChildLayoutDelegate {
 /// If the [leading] widget is omitted, but the [AppBar] is in a [Scaffold] with
 /// a [Drawer], then a button will be inserted to open the drawer. Otherwise, if
 /// the nearest [Navigator] has any previous routes, a [BackButton] is inserted
-/// instead.
+/// instead. This behavior can be turned off by setting the [automaticallyImplyLeading]
+/// to false. In that case a null leading widget will result in the middle/title widget
+/// stretching to start.
 ///
 /// ## Sample code
 ///
@@ -130,6 +132,7 @@ class AppBar extends StatefulWidget implements PreferredSizeWidget {
   AppBar({
     Key key,
     this.leading,
+    this.automaticallyImplyLeading: true,
     this.title,
     this.actions,
     this.flexibleSpace,
@@ -158,6 +161,13 @@ class AppBar extends StatefulWidget implements PreferredSizeWidget {
   /// drawer. If there's no [Drawer] and the parent [Navigator] can go back, the
   /// [AppBar] will use a [BackButton] that calls [Navigator.maybePop].
   final Widget leading;
+
+  /// Controls whether we should try to imply the leading widget if null.
+  ///
+  /// If true and leading is null, automatically try to deduce what the leading
+  /// widget should be. If false and leading is null, leading space is given to title.
+  /// If leading widget is not null, this parameter has no effect.
+  final bool automaticallyImplyLeading;
 
   /// The primary widget displayed in the appbar.
   ///
@@ -332,7 +342,7 @@ class _AppBarState extends State<AppBar> {
     }
 
     Widget leading = widget.leading;
-    if (leading == null) {
+    if (leading == null && widget.automaticallyImplyLeading) {
       if (hasDrawer) {
         leading = new IconButton(
           icon: const Icon(Icons.menu),

--- a/packages/flutter/test/material/app_bar_test.dart
+++ b/packages/flutter/test/material/app_bar_test.dart
@@ -790,6 +790,18 @@ void main() {
     expect(find.byIcon(Icons.menu), findsOneWidget);
   });
 
+  testWidgets('AppBar does not draw menu for drawer if automaticallyImplyLeading is false', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      new MaterialApp(
+        home: new Scaffold(
+          drawer: const Drawer(),
+          appBar: new AppBar(automaticallyImplyLeading: false),
+        ),
+      ),
+    );
+    expect(find.byIcon(Icons.menu), findsNothing);
+  });
+
   testWidgets('AppBar handles loose children 0', (WidgetTester tester) async {
     final GlobalKey key = new GlobalKey();
     await tester.pumpWidget(


### PR DESCRIPTION
If automaticallyImplyLeading is true (by default), then we try to derive back or menu icon. If false, we do not.