### PR TITLE
pass the value of the android sdk

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_sdk.dart
+++ b/packages/flutter_tools/lib/src/android/android_sdk.dart
@@ -67,7 +67,10 @@ class AndroidSdk {
 
   static AndroidSdk locateAndroidSdk() {
     String androidHomeDir;
-    if (platform.environment.containsKey(kAndroidHome)) {
+
+    if (config.containsKey('android-sdk')) {
+      androidHomeDir = config.getValue('android-sdk');
+    } else if (platform.environment.containsKey(kAndroidHome)) {
       androidHomeDir = platform.environment[kAndroidHome];
     } else if (platform.isLinux) {
       if (homeDirPath != null)

--- a/packages/flutter_tools/lib/src/base/config.dart
+++ b/packages/flutter_tools/lib/src/base/config.dart
@@ -24,6 +24,8 @@ class Config {
 
   Iterable<String> get keys => _values.keys;
 
+  bool containsKey(String key) => _values.containsKey(key);
+
   dynamic getValue(String key) => _values[key];
 
   void setValue(String key, String value) {

--- a/packages/flutter_tools/lib/src/commands/config.dart
+++ b/packages/flutter_tools/lib/src/commands/config.dart
@@ -20,6 +20,7 @@ class ConfigCommand extends FlutterCommand {
       negatable: false,
       help: 'Clear the saved development certificate choice used to sign apps for iOS device deployment.');
     argParser.addOption('gradle-dir', help: 'The gradle install directory.');
+    argParser.addOption('android-sdk', help: 'The Android SDK directory.');
     argParser.addOption('android-studio-dir', help: 'The Android Studio install directory.');
     argParser.addFlag('machine',
       negatable: false,
@@ -72,6 +73,9 @@ class ConfigCommand extends FlutterCommand {
 
     if (argResults.wasParsed('gradle-dir'))
       _updateConfig('gradle-dir', argResults['gradle-dir']);
+
+    if (argResults.wasParsed('android-sdk'))
+      _updateConfig('android-sdk', argResults['android-sdk']);
 
     if (argResults.wasParsed('android-studio-dir'))
       _updateConfig('android-studio-dir', argResults['android-studio-dir']);

--- a/packages/flutter_tools/lib/src/commands/config.dart
+++ b/packages/flutter_tools/lib/src/commands/config.dart
@@ -5,6 +5,7 @@
 import 'dart:async';
 import 'dart:convert';
 
+import '../android/android_sdk.dart';
 import '../android/android_studio.dart';
 import '../globals.dart';
 import '../runner/flutter_command.dart';
@@ -37,6 +38,9 @@ class ConfigCommand extends FlutterCommand {
 
   @override
   final List<String> aliases = <String>['configure'];
+
+  @override
+  bool get shouldUpdateCache => true;
 
   @override
   String get usageFooter {
@@ -90,8 +94,11 @@ class ConfigCommand extends FlutterCommand {
     if (results['android-studio-dir'] == null && androidStudio != null) {
       results['android-studio-dir'] = androidStudio.directory;
     }
+    if (results['android-sdk'] == null && androidSdk != null) {
+      results['android-sdk'] = androidSdk.directory;
+    }
 
-    printStatus(JSON.encode(results));
+    printStatus(const JsonEncoder.withIndent('  ').convert(results));
   }
 
   void _updateConfig(String keyName, String keyValue) {

--- a/packages/flutter_tools/lib/src/commands/config.dart
+++ b/packages/flutter_tools/lib/src/commands/config.dart
@@ -40,7 +40,7 @@ class ConfigCommand extends FlutterCommand {
   final List<String> aliases = <String>['configure'];
 
   @override
-  bool get shouldUpdateCache => true;
+  bool get shouldUpdateCache => false;
 
   @override
   String get usageFooter {

--- a/packages/flutter_tools/test/commands/config_test.dart
+++ b/packages/flutter_tools/test/commands/config_test.dart
@@ -1,0 +1,56 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:convert';
+
+import 'package:flutter_tools/src/android/android_sdk.dart';
+import 'package:flutter_tools/src/android/android_studio.dart';
+import 'package:flutter_tools/src/base/context.dart';
+import 'package:flutter_tools/src/base/logger.dart';
+import 'package:flutter_tools/src/commands/config.dart';
+import 'package:mockito/mockito.dart';
+import 'package:test/test.dart';
+
+import '../src/context.dart';
+
+void main() {
+  MockAndroidStudio mockAndroidStudio;
+  MockAndroidSdk mockAndroidSdk;
+
+  setUp(() {
+    mockAndroidStudio = new MockAndroidStudio();
+    mockAndroidSdk = new MockAndroidSdk();
+  });
+
+  group('config', () {
+    testUsingContext('machine flag', () async {
+      final BufferLogger logger = context[Logger];
+      final ConfigCommand command = new ConfigCommand();
+      await command.handleMachine();
+
+      expect(logger.statusText, isNotEmpty);
+      final dynamic json = JSON.decode(logger.statusText);
+      expect(json, isMap);
+
+      expect(json.containsKey('android-studio-dir'), true);
+      expect(json['android-studio-dir'], isNotNull);
+
+      expect(json.containsKey('android-sdk'), true);
+      expect(json['android-sdk'], isNotNull);
+    }, overrides: <Type, Generator>{
+      AndroidStudio: () => mockAndroidStudio,
+      AndroidSdk: () => mockAndroidSdk,
+    });
+  });
+}
+
+class MockAndroidStudio extends Mock implements AndroidStudio, Comparable<AndroidStudio> {
+  @override
+  String get directory => 'path/to/android/stdio';
+}
+
+class MockAndroidSdk extends Mock implements AndroidSdk {
+  @override
+  String get directory => 'path/to/android/sdk';
+}

--- a/packages/flutter_tools/test/config_test.dart
+++ b/packages/flutter_tools/test/config_test.dart
@@ -2,28 +2,17 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:convert';
-
-import 'package:flutter_tools/src/android/android_studio.dart';
 import 'package:flutter_tools/src/base/config.dart';
-import 'package:flutter_tools/src/base/context.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
-import 'package:flutter_tools/src/base/logger.dart';
-import 'package:flutter_tools/src/commands/config.dart';
-import 'package:mockito/mockito.dart';
 import 'package:test/test.dart';
-
-import 'src/context.dart';
 
 void main() {
   Config config;
-  MockAndroidStudio mockAndroidStudio;
 
   setUp(() {
     final Directory tempDirectory = fs.systemTempDirectory.createTempSync('flutter_test');
     final File file = fs.file(fs.path.join(tempDirectory.path, '.settings'));
     config = new Config(file);
-    mockAndroidStudio = new MockAndroidStudio();
   });
 
   group('config', () {
@@ -32,6 +21,12 @@ void main() {
       config.setValue('foo', 'bar');
       expect(config.getValue('foo'), 'bar');
       expect(config.keys, contains('foo'));
+    });
+
+    test('containsKey', () async {
+      expect(config.containsKey('foo'), false);
+      config.setValue('foo', 'bar');
+      expect(config.containsKey('foo'), true);
     });
 
     test('removeValue', () async {
@@ -43,24 +38,5 @@ void main() {
       expect(config.getValue('foo'), null);
       expect(config.keys, isNot(contains('foo')));
     });
-
-    testUsingContext('machine flag', () async {
-      final BufferLogger logger = context[Logger];
-      final ConfigCommand command = new ConfigCommand();
-      await command.handleMachine();
-
-      expect(logger.statusText, isNotEmpty);
-      final dynamic json = JSON.decode(logger.statusText);
-      expect(json, isMap);
-      expect(json.containsKey('android-studio-dir'), true);
-      expect(json['android-studio-dir'], isNotNull);
-    }, overrides: <Type, Generator>{
-      AndroidStudio: () => mockAndroidStudio,
-    });
   });
-}
-
-class MockAndroidStudio extends Mock implements AndroidStudio, Comparable<AndroidStudio> {
-  @override
-  String get directory => 'path/to/android/stdio';
 }


### PR DESCRIPTION
- pass the value of the android sdk in `flutter config --machine`
- mark `flutter config` as one of the commands that doesn't need the cache populated (otherwise, querying for the android sdk location could be a very expensive operation)
- pretty print the returned json

@tvolkert, @pq