### PR TITLE
Fix restart/reload benchmark synchronization

### DIFF
--- a/packages/flutter_tools/lib/src/run_hot.dart
+++ b/packages/flutter_tools/lib/src/run_hot.dart
@@ -153,7 +153,6 @@ class HotRunner extends ResidentRunner {
       // Measure time to perform a hot restart.
       printStatus('Benchmarking hot restart');
       await restart(fullRestart: true);
-      await refreshViews();
       // TODO(johnmccutchan): Modify script entry point.
       printStatus('Benchmarking hot reload');
       // Measure time to perform a hot reload.
@@ -313,6 +312,11 @@ class HotRunner extends ResidentRunner {
                           deviceEntryUri,
                           devicePackagesUri,
                           deviceAssetsDirectoryUri);
+      if (benchmarkMode) {
+        for (FlutterDevice device in flutterDevices)
+          for (FlutterView view in device.views)
+            await view.waitUIThreadIdle();
+      }
     }
   }
 

--- a/packages/flutter_tools/lib/src/run_hot.dart
+++ b/packages/flutter_tools/lib/src/run_hot.dart
@@ -315,7 +315,7 @@ class HotRunner extends ResidentRunner {
       if (benchmarkMode) {
         for (FlutterDevice device in flutterDevices)
           for (FlutterView view in device.views)
-            await view.waitUIThreadIdle();
+            await view.flushUIThreadTasks();
       }
     }
   }

--- a/packages/flutter_tools/lib/src/vmservice.dart
+++ b/packages/flutter_tools/lib/src/vmservice.dart
@@ -1226,6 +1226,10 @@ class FlutterView extends ServiceObject {
 
   bool get hasIsolate => _uiIsolate != null;
 
+  Future<Null> waitUIThreadIdle() async {
+    await owner.vm.invokeRpcRaw('_flutter.waitUIThreadIdle');
+  }
+
   @override
   String toString() => id;
 }

--- a/packages/flutter_tools/lib/src/vmservice.dart
+++ b/packages/flutter_tools/lib/src/vmservice.dart
@@ -1226,8 +1226,8 @@ class FlutterView extends ServiceObject {
 
   bool get hasIsolate => _uiIsolate != null;
 
-  Future<Null> waitUIThreadIdle() async {
-    await owner.vm.invokeRpcRaw('_flutter.waitUIThreadIdle');
+  Future<Null> flushUIThreadTasks() async {
+    await owner.vm.invokeRpcRaw('_flutter.flushUIThreadTasks');
   }
 
   @override


### PR DESCRIPTION
Changes introduced in https://github.com/flutter/engine/commit/8ba522eeae35d8c70ada3c7b8e200ca2274f4f95 has removed from the `_flutter.listViews` the thread synchronization side effect used during benchmarks.

The thread synchronization is restored via the new `_flutter.flushUIThreadTasks` RPC.

Fixes https://github.com/flutter/flutter/issues/11241

Related https://github.com/flutter/engine/pull/3898