### PR TITLE
Revert "Work around to fix appveyor build"

### DIFF
--- a/bin/internal/update_dart_sdk.ps1
+++ b/bin/internal/update_dart_sdk.ps1
@@ -40,13 +40,8 @@ if (Test-Path $dartSdkPath) {
 }
 New-Item $dartSdkPath -force -type directory | Out-Null
 $dartSdkZip = "$cachePath\dart-sdk.zip"
-# TODO(goderbauer): remove (slow and backwards-incompatible) appveyor work around
-if (Test-Path Env:\APPVEYOR) {
-    curl $dartSdkUrl -OutFile $dartSdkZip
-} else {
-    Import-Module BitsTransfer
-    Start-BitsTransfer -Source $dartSdkUrl -Destination $dartSdkZip
-}
+Import-Module BitsTransfer
+Start-BitsTransfer -Source $dartSdkUrl -Destination $dartSdkZip
 
 Write-Host "Unzipping Dart SDK..."
 If (Get-Command 7z -errorAction SilentlyContinue) {


### PR DESCRIPTION
Reverts https://github.com/flutter/flutter/pull/11295.

Looks like the issue is resolved on Appveyor's end. The Dart SDK downloads just fine as it is supposed to.