### PR TITLE
Do not call saveLayer for physical model layers whose bounds are simple rectangles

### DIFF
--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -1364,7 +1364,11 @@ class RenderPhysicalModel extends _RenderCustomClip<RRect> {
           );
         }
         canvas.drawRRect(offsetClipRRect, new Paint()..color = color);
-        canvas.saveLayer(offsetBounds, _defaultPaint);
+        if (offsetClipRRect.isRect) {
+          canvas.save();
+        } else {
+          canvas.saveLayer(offsetBounds, _defaultPaint);
+        }
         canvas.clipRRect(offsetClipRRect);
         super.paint(context, offset);
         canvas.restore();


### PR DESCRIPTION
This is similar to an optimization done in PhysicalModelLayer::Paint in the engine