### PR TITLE
Revert "Flutter analyze watch improvements (#11143)"

### DIFF
--- a/packages/flutter_tools/lib/src/commands/analyze_base.dart
+++ b/packages/flutter_tools/lib/src/commands/analyze_base.dart
@@ -39,25 +39,6 @@ abstract class AnalyzeBase {
     }
   }
 
-  List<String> flutterRootComponents;
-  bool isFlutterLibrary(String filename) {
-    flutterRootComponents ??= fs.path.normalize(fs.path.absolute(Cache.flutterRoot)).split(fs.path.separator);
-    final List<String> filenameComponents = fs.path.normalize(fs.path.absolute(filename)).split(fs.path.separator);
-    if (filenameComponents.length < flutterRootComponents.length + 4) // the 4: 'packages', package_name, 'lib', file_name
-      return false;
-    for (int index = 0; index < flutterRootComponents.length; index += 1) {
-      if (flutterRootComponents[index] != filenameComponents[index])
-        return false;
-    }
-    if (filenameComponents[flutterRootComponents.length] != 'packages')
-      return false;
-    if (filenameComponents[flutterRootComponents.length + 1] == 'flutter_tools')
-      return false;
-    if (filenameComponents[flutterRootComponents.length + 2] != 'lib')
-      return false;
-    return true;
-  }
-
   void writeBenchmark(Stopwatch stopwatch, int errorCount, int membersMissingDocumentation) {
     final String benchmarkOut = 'analysis_benchmark.json';
     final Map<String, dynamic> data = <String, dynamic>{

--- a/packages/flutter_tools/lib/src/commands/analyze_once.dart
+++ b/packages/flutter_tools/lib/src/commands/analyze_once.dart
@@ -245,6 +245,25 @@ class AnalyzeOnce extends AnalyzeBase {
     return dir;
   }
 
+  List<String> flutterRootComponents;
+  bool isFlutterLibrary(String filename) {
+    flutterRootComponents ??= fs.path.normalize(fs.path.absolute(Cache.flutterRoot)).split(fs.path.separator);
+    final List<String> filenameComponents = fs.path.normalize(fs.path.absolute(filename)).split(fs.path.separator);
+    if (filenameComponents.length < flutterRootComponents.length + 4) // the 4: 'packages', package_name, 'lib', file_name
+      return false;
+    for (int index = 0; index < flutterRootComponents.length; index += 1) {
+      if (flutterRootComponents[index] != filenameComponents[index])
+        return false;
+    }
+    if (filenameComponents[flutterRootComponents.length] != 'packages')
+      return false;
+    if (filenameComponents[flutterRootComponents.length + 1] == 'flutter_tools')
+      return false;
+    if (filenameComponents[flutterRootComponents.length + 2] != 'lib')
+      return false;
+    return true;
+  }
+
   List<File> _collectDartFiles(Directory dir, List<File> collected) {
     // Bail out in case of a .dartignore.
     if (fs.isFileSync(fs.path.join(dir.path, '.dartignore')))

--- a/packages/flutter_tools/test/commands/analyze_continuously_test.dart
+++ b/packages/flutter_tools/test/commands/analyze_continuously_test.dart
@@ -23,55 +23,51 @@ void main() {
     tempDir = fs.systemTempDirectory.createTempSync('analysis_test');
   });
 
-  Future<AnalysisServer> analyzeWithServer({ bool brokenCode: false, bool flutterRepo: false, int expectedErrorCount: 0 }) async {
-    _createSampleProject(tempDir, brokenCode: brokenCode);
-
-    await pubGet(directory: tempDir.path);
-
-    server = new AnalysisServer(dartSdkPath, <String>[tempDir.path], flutterRepo: flutterRepo);
-
-    final Future<bool> onDone = server.onAnalyzing.where((bool analyzing) => analyzing == false).first;
-    final List<AnalysisError> errors = <AnalysisError>[];
-    server.onErrors.listen((FileAnalysisErrors fileErrors) {
-      errors.addAll(fileErrors.errors);
-    });
-
-    await server.start();
-    await onDone;
-
-    expect(errors, hasLength(expectedErrorCount));
-    return server;
-  }
-
   tearDown(() {
     tempDir?.deleteSync(recursive: true);
     return server?.dispose();
   });
 
   group('analyze --watch', () {
+    testUsingContext('AnalysisServer success', () async {
+      _createSampleProject(tempDir);
+
+      await pubGet(directory: tempDir.path);
+
+      server = new AnalysisServer(dartSdkPath, <String>[tempDir.path]);
+
+      int errorCount = 0;
+      final Future<bool> onDone = server.onAnalyzing.where((bool analyzing) => analyzing == false).first;
+      server.onErrors.listen((FileAnalysisErrors errors) => errorCount += errors.errors.length);
+
+      await server.start();
+      await onDone;
+
+      expect(errorCount, 0);
+    }, overrides: <Type, Generator>{
+      OperatingSystemUtils: () => os
+    });
   });
 
-  group('AnalysisServer', () {
-    testUsingContext('success', () async {
-      server = await analyzeWithServer();
-    }, overrides: <Type, Generator>{
-      OperatingSystemUtils: () => os
+  testUsingContext('AnalysisServer errors', () async {
+    _createSampleProject(tempDir, brokenCode: true);
+
+    await pubGet(directory: tempDir.path);
+
+    server = new AnalysisServer(dartSdkPath, <String>[tempDir.path]);
+
+    int errorCount = 0;
+    final Future<bool> onDone = server.onAnalyzing.where((bool analyzing) => analyzing == false).first;
+    server.onErrors.listen((FileAnalysisErrors errors) {
+      errorCount += errors.errors.length;
     });
 
-    testUsingContext('errors', () async {
-      server = await analyzeWithServer(brokenCode: true, expectedErrorCount: 1);
-    }, overrides: <Type, Generator>{
-      OperatingSystemUtils: () => os
-    });
+    await server.start();
+    await onDone;
 
-    testUsingContext('--flutter-repo', () async {
-      // When a Dart SDK containing support for the --flutter-repo startup flag
-      // https://github.com/dart-lang/sdk/commit/def1ee6604c4b3385b567cb9832af0dbbaf32e0d
-      // is rolled into Flutter, then the expectedErrorCount should be set to 1.
-      server = await analyzeWithServer(flutterRepo: true, expectedErrorCount: 0);
-    }, overrides: <Type, Generator>{
-      OperatingSystemUtils: () => os
-    });
+    expect(errorCount, greaterThan(0));
+  }, overrides: <Type, Generator>{
+    OperatingSystemUtils: () => os
   });
 }
 
@@ -81,13 +77,6 @@ void _createSampleProject(Directory directory, { bool brokenCode: false }) {
 name: foo_project
 ''');
 
-  final File analysisOptionsFile = fs.file(fs.path.join(directory.path, 'analysis_options.yaml'));
-  analysisOptionsFile.writeAsStringSync('''
-linter:
-  rules:
-    - hash_and_equals
-''');
-
   final File dartFile = fs.file(fs.path.join(directory.path, 'lib', 'main.dart'));
   dartFile.parent.createSync();
   dartFile.writeAsStringSync('''
@@ -95,7 +84,5 @@ void main() {
   print('hello world');
   ${brokenCode ? 'prints("hello world");' : ''}
 }
-
-class SomeClassWithoutDartDoc { }
 ''');
 }


### PR DESCRIPTION
This reverts commit e13e7806e37a28cfef766b72a6987593063b8d34.

Turns out that with this patch, we aren't actually catching all
errors. For example, `flutter analyze --flutter-repo --watch` didn't
report errors in `dev/devicelab/test/adb_test.dart`.