### PR TITLE
Always evaluate the finder in `driver.waitFor*()`

### DIFF
--- a/packages/flutter_driver/lib/src/extension.dart
+++ b/packages/flutter_driver/lib/src/extension.dart
@@ -200,7 +200,7 @@ class FlutterDriverExtension {
     if (_frameSync)
       await _waitUntilFrame(() => SchedulerBinding.instance.transientCallbackCount == 0);
 
-    await _waitUntilFrame(() => finder.precache());
+    await _waitUntilFrame(() => finder.evaluate().isNotEmpty);
 
     if (_frameSync)
       await _waitUntilFrame(() => SchedulerBinding.instance.transientCallbackCount == 0);
@@ -213,7 +213,7 @@ class FlutterDriverExtension {
     if (_frameSync)
       await _waitUntilFrame(() => SchedulerBinding.instance.transientCallbackCount == 0);
 
-    await _waitUntilFrame(() => !finder.precache());
+    await _waitUntilFrame(() => finder.evaluate().isEmpty);
 
     if (_frameSync)
       await _waitUntilFrame(() => SchedulerBinding.instance.transientCallbackCount == 0);
@@ -268,10 +268,8 @@ class FlutterDriverExtension {
 
   Future<WaitForResult> _waitFor(Command command) async {
     final WaitFor waitForCommand = command;
-    if ((await _waitForElement(_createFinder(waitForCommand.finder))).evaluate().isNotEmpty)
-      return new WaitForResult();
-    else
-      return null;
+    await _waitForElement(_createFinder(waitForCommand.finder));
+    return new WaitForResult();
   }
 
   Future<WaitForAbsentResult> _waitForAbsent(Command command) async {


### PR DESCRIPTION
Fixes #11327