### PR TITLE
AnimatedCrossFade layout customisation

### DIFF
--- a/packages/flutter/lib/src/widgets/animated_cross_fade.dart
+++ b/packages/flutter/lib/src/widgets/animated_cross_fade.dart
@@ -24,6 +24,42 @@ enum CrossFadeState {
   showSecond,
 }
 
+/// Signature for the [AnimatedCrossFade.layoutBuilder] callback.
+///
+/// The `topChild` is the child fading in, which is normally drawn on top. The
+/// `bottomChild` is the child fading out, normally drawn on the bottom.
+///
+/// For good performance, the returned widget tree should contain both the
+/// `topChild` and the `bottomChild`; the depth of the tree, and the types of
+/// the widgets in the tree, from the returned widget to each of the children
+/// should be the same; and where there is a widget with multiple children, the
+/// top child and the bottom child should be keyed using the provided
+/// `topChildKey` and `bottomChildKey` keys respectively.
+///
+/// ## Sample code
+///
+/// ```dart
+/// Widget defaultLayoutBuilder(Widget topChild, Key topChildKey, Widget bottomChild, Key bottomChildKey) {
+///   return new Stack(
+///     fit: StackFit.loose,
+///     children: <Widget>[
+///       new Positioned(
+///         key: bottomChildKey,
+///         left: 0.0,
+///         top: 0.0,
+///         right: 0.0,
+///         child: bottomChild,
+///       ),
+///       new Positioned(
+///         key: topChildKey,
+///         child: topChild,
+///       )
+///     ],
+///   );
+/// }
+/// ```
+typedef Widget AnimatedCrossFadeBuilder(Widget topChild, Key topChildKey, Widget bottomChild, Key bottomChildKey);
+
 /// A widget that cross-fades between two given children and animates itself
 /// between their sizes.
 ///
@@ -70,6 +106,8 @@ class AnimatedCrossFade extends StatefulWidget {
   /// The [duration] of the animation is the same for all components (fade in,
   /// fade out, and size), and you can pass [Interval]s instead of [Curve]s in
   /// order to have finer control, e.g., creating an overlap between the fades.
+  ///
+  /// All the arguments other than [key] must be non-null.
   const AnimatedCrossFade({
     Key key,
     @required this.firstChild,
@@ -79,10 +117,17 @@ class AnimatedCrossFade extends StatefulWidget {
     this.sizeCurve: Curves.linear,
     this.alignment: FractionalOffset.topCenter,
     @required this.crossFadeState,
-    @required this.duration
-  }) : assert(firstCurve != null),
+    @required this.duration,
+    this.layoutBuilder: defaultLayoutBuilder,
+  }) : assert(firstChild != null),
+       assert(secondChild != null),
+       assert(firstCurve != null),
        assert(secondCurve != null),
        assert(sizeCurve != null),
+       assert(alignment != null),
+       assert(crossFadeState != null),
+       assert(duration != null),
+       assert(layoutBuilder != null),
        super(key: key);
 
   /// The child that is visible when [crossFadeState] is
@@ -122,6 +167,49 @@ class AnimatedCrossFade extends StatefulWidget {
   ///
   /// Defaults to [FractionalOffset.topCenter].
   final FractionalOffset alignment;
+
+  /// A builder that positions the [firstChild] and [secondChild] widgets.
+  ///
+  /// The widget returned by this method is wrapped in an [AnimatedSize].
+  ///
+  /// By default, this uses [AnimatedCrossFade.defaultLayoutBuilder], which uses
+  /// a [Stack] and aligns the `bottomChild` to the top of the stack while
+  /// providing the `topChild` as the non-positioned child to fill the provided
+  /// constraints. This works well when the [AnimatedCrossFade] is in a position
+  /// to change size and when the children are not flexible. However, if the
+  /// children are less fussy about their sizes (for example a
+  /// [CircularProgressIndicator] inside a [Center]), or if the
+  /// [AnimatedCrossFade] is being forced to a particular size, then it can
+  /// result in the widgets jumping about when the cross-fade state is changed.
+  final AnimatedCrossFadeBuilder layoutBuilder;
+
+  /// The default layout algorithm used by [AnimatedCrossFade].
+  ///
+  /// The top child is placed in a stack that sizes itself to match the top
+  /// child. The bottom child is positioned at the top of the same stack, sized
+  /// to fit its width but without forcing the height. The stack is then
+  /// clipped.
+  ///
+  /// This is the default value for [layoutBuilder]. It implements
+  /// [AnimatedCrossFadeBuilder].
+  static Widget defaultLayoutBuilder(Widget topChild, Key topChildKey, Widget bottomChild, Key bottomChildKey) {
+    return new Stack(
+      overflow: Overflow.visible,
+      children: <Widget>[
+        new Positioned(
+          key: bottomChildKey,
+          left: 0.0,
+          top: 0.0,
+          right: 0.0,
+          child: bottomChild,
+        ),
+        new Positioned(
+          key: topChildKey,
+          child: topChild,
+        )
+      ],
+    );
+  }
 
   @override
   _AnimatedCrossFadeState createState() => new _AnimatedCrossFadeState();
@@ -203,7 +291,8 @@ class _AnimatedCrossFadeState extends State<AnimatedCrossFade> with TickerProvid
   /// Whether we're in the middle of cross-fading this frame.
   bool get _isTransitioning => _controller.status == AnimationStatus.forward || _controller.status == AnimationStatus.reverse;
 
-  List<Widget> _buildCrossFadedChildren() {
+  @override
+  Widget build(BuildContext context) {
     const Key kFirstChildKey = const ValueKey<CrossFadeState>(CrossFadeState.showFirst);
     const Key kSecondChildKey = const ValueKey<CrossFadeState>(CrossFadeState.showSecond);
     final bool transitioningForwards = _controller.status == AnimationStatus.completed || _controller.status == AnimationStatus.forward;
@@ -230,54 +319,35 @@ class _AnimatedCrossFadeState extends State<AnimatedCrossFade> with TickerProvid
       bottomAnimation = _secondAnimation;
     }
 
-    return <Widget>[
-      new TickerMode(
-        key: bottomKey,
-        enabled: _isTransitioning,
-        child: new Positioned(
-          // TODO(dragostis): Add a way to crop from top right for
-          // right-to-left languages.
-          left: 0.0,
-          top: 0.0,
-          right: 0.0,
-          child: new ExcludeSemantics(
-            excluding: true,  // always exclude the semantics of the widget that's fading out
-            child: new FadeTransition(
-              opacity: bottomAnimation,
-              child: bottomChild,
-            ),
-          ),
+    bottomChild = new TickerMode(
+      key: bottomKey,
+      enabled: _isTransitioning,
+      child: new ExcludeSemantics(
+        excluding: true, // Always exclude the semantics of the widget that's fading out.
+        child: new FadeTransition(
+          opacity: bottomAnimation,
+          child: bottomChild,
         ),
       ),
-      new TickerMode(
-        key: topKey,
-        enabled: true,  // top widget always has its animations enabled
-        child: new Positioned(
-          child: new ExcludeSemantics(
-            excluding: false,  // always publish semantics for the widget that's fading in
-            child: new FadeTransition(
-              opacity: topAnimation,
-              child: topChild,
-            ),
-          ),
+    );
+    topChild = new TickerMode(
+      key: topKey,
+      enabled: true, // Top widget always has its animations enabled.
+      child: new ExcludeSemantics(
+        excluding: false, // Always publish semantics for the widget that's fading in.
+        child: new FadeTransition(
+          opacity: topAnimation,
+          child: topChild,
         ),
       ),
-    ];
-  }
-
-  @override
-  Widget build(BuildContext context) {
+    );
     return new ClipRect(
       child: new AnimatedSize(
-        key: new ValueKey<Key>(widget.key),
         alignment: widget.alignment,
         duration: widget.duration,
         curve: widget.sizeCurve,
         vsync: this,
-        child: new Stack(
-          overflow: Overflow.visible,
-          children: _buildCrossFadedChildren(),
-        ),
+        child: widget.layoutBuilder(topChild, topKey, bottomChild, bottomKey),
       ),
     );
   }

--- a/packages/flutter/test/widgets/animated_cross_fade_test.dart
+++ b/packages/flutter/test/widgets/animated_cross_fade_test.dart
@@ -21,7 +21,7 @@ void main() {
             height: 200.0
           ),
           duration: const Duration(milliseconds: 200),
-          crossFadeState: CrossFadeState.showFirst
+          crossFadeState: CrossFadeState.showFirst,
         )
       )
     );
@@ -43,7 +43,7 @@ void main() {
             height: 200.0
           ),
           duration: const Duration(milliseconds: 200),
-          crossFadeState: CrossFadeState.showSecond
+          crossFadeState: CrossFadeState.showSecond,
         )
       )
     );
@@ -69,7 +69,7 @@ void main() {
             height: 200.0
           ),
           duration: const Duration(milliseconds: 200),
-          crossFadeState: CrossFadeState.showSecond
+          crossFadeState: CrossFadeState.showSecond,
         )
       )
     );
@@ -182,6 +182,35 @@ void main() {
     await tester.pump(const Duration(milliseconds: 25));
     expect(state.ticker.muted, true);
     expect(findSemantics().excluding, true);
+  });
+
+  testWidgets('AnimatedCrossFade.layoutBuilder', (WidgetTester tester) async {
+    await tester.pumpWidget(const AnimatedCrossFade(
+      firstChild: const Text('AAA'),
+      secondChild: const Text('BBB'),
+      crossFadeState: CrossFadeState.showFirst,
+      duration: const Duration(milliseconds: 50),
+    ));
+    expect(find.text('AAA'), findsOneWidget);
+    expect(find.text('BBB'), findsOneWidget);
+    await tester.pumpWidget(new AnimatedCrossFade(
+      firstChild: const Text('AAA'),
+      secondChild: const Text('BBB'),
+      crossFadeState: CrossFadeState.showFirst,
+      duration: const Duration(milliseconds: 50),
+      layoutBuilder: (Widget a, Key aKey, Widget b, Key bKey) => a,
+    ));
+    expect(find.text('AAA'), findsOneWidget);
+    expect(find.text('BBB'), findsNothing);
+    await tester.pumpWidget(new AnimatedCrossFade(
+      firstChild: const Text('AAA'),
+      secondChild: const Text('BBB'),
+      crossFadeState: CrossFadeState.showSecond,
+      duration: const Duration(milliseconds: 50),
+      layoutBuilder: (Widget a, Key aKey, Widget b, Key bKey) => a,
+    ));
+    expect(find.text('BBB'), findsOneWidget);
+    expect(find.text('AAA'), findsNothing);
   });
 }
 


### PR DESCRIPTION
* Optimise AnimatedSize for the tight case.
* Remove `default` from a switch statement over enum (so that analyzer will complain if we add enum values).
* Adopt the Size since we use it after the child may have changed (which would throw normally).
* AnimatedCrossFade.layoutBuilder