### PR TITLE
Fix text selection line height

### DIFF
--- a/packages/flutter/lib/src/material/text_selection.dart
+++ b/packages/flutter/lib/src/material/text_selection.dart
@@ -55,12 +55,15 @@ class _TextSelectionToolbar extends StatelessWidget {
         items.add(new FlatButton(child: const Text('SELECT ALL'), onPressed: handleSelectAll));
     }
 
-    return new Material(
-      elevation: 1.0,
-      child: new Container(
-        height: 44.0,
-        child: new Row(mainAxisSize: MainAxisSize.min, children: items)
-      )
+    return new Padding(
+      padding: const EdgeInsets.only(bottom: 4.0),
+      child: new Material(
+        elevation: 1.0,
+        child: new Container(
+          height: 44.0,
+          child: new Row(mainAxisSize: MainAxisSize.min, children: items)
+        )
+      ),
     );
   }
 }

--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -379,7 +379,9 @@ class RenderEditable extends RenderBox {
   ///
   /// This height is based on properties of the text's style such as
   /// font size etc and could change when those properties change.
-  /// This does not require the layout to be updated.
+  ///
+  /// The [RenderEditable] does not need to be laid out for this property
+  /// to be available.
   ///
   /// Use for defining UI based on the text's height.
   double get preferredLineHeight => _textPainter.preferredLineHeight;

--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -375,7 +375,7 @@ class RenderEditable extends RenderBox {
     return _textPainter.maxIntrinsicWidth;
   }
 
-  // This does not required the layout to be updated.
+  // This does not require the layout to be updated.
   double get preferredLineHeight => _textPainter.preferredLineHeight;
 
   double _preferredHeight(double width) {

--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -375,7 +375,13 @@ class RenderEditable extends RenderBox {
     return _textPainter.maxIntrinsicWidth;
   }
 
-  // This does not require the layout to be updated.
+  /// The height of a typical text line in logical pixels.
+  ///
+  /// This height is based on properties of the text's style such as
+  /// font size etc and could change when those properties change.
+  /// This does not require the layout to be updated.
+  ///
+  /// Use for defining UI based on the text's height.
   double get preferredLineHeight => _textPainter.preferredLineHeight;
 
   double _preferredHeight(double width) {

--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -334,7 +334,7 @@ class RenderEditable extends RenderBox {
     if (selection.isCollapsed) {
       // TODO(mpcomplete): This doesn't work well at an RTL/LTR boundary.
       final Offset caretOffset = _textPainter.getOffsetForCaret(selection.extent, _caretPrototype);
-      final Offset start = new Offset(0.0, _preferredLineHeight) + caretOffset + paintOffset;
+      final Offset start = new Offset(0.0, preferredLineHeight) + caretOffset + paintOffset;
       return <TextSelectionPoint>[new TextSelectionPoint(start, null)];
     } else {
       final List<ui.TextBox> boxes = _textPainter.getBoxesForSelection(selection);
@@ -360,7 +360,7 @@ class RenderEditable extends RenderBox {
     _layoutText(constraints.maxWidth);
     final Offset caretOffset = _textPainter.getOffsetForCaret(caretPosition, _caretPrototype);
     // This rect is the same as _caretPrototype but without the vertical padding.
-    return new Rect.fromLTWH(0.0, 0.0, _kCaretWidth, _preferredLineHeight).shift(caretOffset + _paintOffset);
+    return new Rect.fromLTWH(0.0, 0.0, _kCaretWidth, preferredLineHeight).shift(caretOffset + _paintOffset);
   }
 
   @override
@@ -376,11 +376,11 @@ class RenderEditable extends RenderBox {
   }
 
   // This does not required the layout to be updated.
-  double get _preferredLineHeight => _textPainter.preferredLineHeight;
+  double get preferredLineHeight => _textPainter.preferredLineHeight;
 
   double _preferredHeight(double width) {
     if (maxLines != null)
-      return _preferredLineHeight * maxLines;
+      return preferredLineHeight * maxLines;
     if (width == double.INFINITY) {
       final String text = _textPainter.text.toPlainText();
       int lines = 1;
@@ -388,10 +388,10 @@ class RenderEditable extends RenderBox {
         if (text.codeUnitAt(index) == 0x0A) // count explicit line breaks
           lines += 1;
       }
-      return _preferredLineHeight * lines;
+      return preferredLineHeight * lines;
     }
     _layoutText(width);
-    return math.max(_preferredLineHeight, _textPainter.height);
+    return math.max(preferredLineHeight, _textPainter.height);
   }
 
   @override
@@ -477,7 +477,7 @@ class RenderEditable extends RenderBox {
   @override
   void performLayout() {
     _layoutText(constraints.maxWidth);
-    _caretPrototype = new Rect.fromLTWH(0.0, _kCaretHeightOffset, _kCaretWidth, _preferredLineHeight - 2.0 * _kCaretHeightOffset);
+    _caretPrototype = new Rect.fromLTWH(0.0, _kCaretHeightOffset, _kCaretWidth, preferredLineHeight - 2.0 * _kCaretHeightOffset);
     _selectionRects = null;
     // We grab _textPainter.size here because assigning to `size` on the next
     // line will trigger us to validate our intrinsic sizes, which will change

--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -314,7 +314,7 @@ class TextSelectionOverlay implements TextSelectionDelegate {
       (endpoints.length == 1) ?
         endpoints[0].point.dx :
         (endpoints[0].point.dx + endpoints[1].point.dx) / 2.0,
-      endpoints[0].point.dy - renderObject.size.height,
+      endpoints[0].point.dy - renderObject.preferredLineHeight,
     );
 
     final Rect editingRegion = new Rect.fromPoints(
@@ -479,7 +479,7 @@ class _TextSelectionHandleOverlayState extends State<_TextSelectionHandleOverlay
               child: widget.selectionControls.buildHandle(
                 context,
                 type,
-                widget.renderObject.size.height / widget.renderObject.maxLines,
+                widget.renderObject.preferredLineHeight,
               ),
             ),
           ],

--- a/packages/flutter/test/widgets/text_selection_test.dart
+++ b/packages/flutter/test/widgets/text_selection_test.dart
@@ -1,0 +1,78 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter/widgets.dart';
+import 'package:mockito/mockito.dart';
+
+void main() {
+  testWidgets('build handles', (WidgetTester tester) async {
+    TextSelectionOverlay overlayUnderTest;
+    final MockRenderEditable mockRenderEditable = new MockRenderEditable();
+    final MockTextSelectionControls mockTextSelectionControls =
+        new MockTextSelectionControls();
+    final GlobalKey startingHandleKey = new GlobalKey();
+    final GlobalKey endingHandleKey = new GlobalKey();
+
+    when(mockRenderEditable.getEndpointsForSelection(typed(any)))
+        .thenReturn(<TextSelectionPoint>[
+          const TextSelectionPoint(const Offset(10.0, 0.0), TextDirection.ltr),
+          const TextSelectionPoint(const Offset(30.0, 0.0), TextDirection.ltr),
+        ]);
+    final double renderTextLineHeight = 15.0;
+    when(mockRenderEditable.preferredLineHeight).thenReturn(renderTextLineHeight);
+    when(mockTextSelectionControls.buildHandle(
+      typed(any),
+      typed(any),
+      // Expect the line height passed back.
+      renderTextLineHeight)
+    ).thenAnswer((Invocation invocation) {
+      final TextSelectionHandleType calledHandleType = invocation.positionalArguments[1];
+      if (calledHandleType == TextSelectionHandleType.left)
+        return new Container(key: startingHandleKey);
+      if (calledHandleType == TextSelectionHandleType.right)
+        return new Container(key: endingHandleKey);
+      fail('Unexpected TextSelectionHandleType');
+    });
+
+    BuildContext overlayContext;
+    await tester.pumpWidget(
+      new Overlay(
+        initialEntries: <OverlayEntry>[
+          new OverlayEntry(
+            builder: (BuildContext context) {
+              overlayContext = context;
+              return new Container();
+            }
+          ),
+        ],
+      ),
+    );
+
+    overlayUnderTest = new TextSelectionOverlay(
+      context: overlayContext,
+      value: const TextEditingValue(
+        text: 'blah blah blah',
+        selection: const TextSelection(baseOffset: 2, extentOffset: 7),
+      ),
+      layerLink: new LayerLink(),
+      renderObject: mockRenderEditable,
+      selectionControls: mockTextSelectionControls,
+    );
+
+    overlayUnderTest.showHandles();
+
+    await tester.pump();
+
+    expect(find.byKey(startingHandleKey), findsOneWidget);
+    expect(find.byKey(endingHandleKey), findsOneWidget);
+
+    overlayUnderTest.dispose();
+  });
+}
+
+class MockRenderEditable extends Mock implements RenderEditable {}
+
+class MockTextSelectionControls extends Mock implements TextSelectionControls {}


### PR DESCRIPTION
Fix a bug introduced when calculating the text line height for the text selection overlay https://github.com/flutter/flutter/pull/11224#discussion_r128899459. 
Also fix #11261. 

Expose the preferredLineHeight from RenderEditable because the information is needed for the text UI.