### PR TITLE
perform the initial poll for devices quicker

### DIFF
--- a/packages/flutter_tools/lib/src/device.dart
+++ b/packages/flutter_tools/lib/src/device.dart
@@ -106,47 +106,6 @@ abstract class DeviceDiscovery {
   Future<List<Device>> get devices;
 }
 
-// TODO: test the polling class
-
-typedef Future<Null> AsyncCallback();
-
-/// A [Timer] inspired class that:
-///   - has a different initial value for the first callback delay
-///   - waits for a callback to be complete before it starts the next timer
-class Poller {
-  Poller(this.callback, this.pollingInterval, { this.initialDelay: Duration.ZERO }) {
-    new Future<Null>.delayed(initialDelay, _handleCallback);
-  }
-
-  final AsyncCallback callback;
-  final Duration initialDelay;
-  final Duration pollingInterval;
-
-  bool _cancelled = false;
-  Timer _timer;
-
-  Future<Null> _handleCallback() async {
-    if (_cancelled)
-      return;
-
-    try {
-      await callback();
-    } catch (error) {
-      printTrace('Error from poller: $error');
-    }
-
-    if (!_cancelled)
-      _timer = new Timer(pollingInterval, _handleCallback);
-  }
-
-  /// Cancels the poller.
-  void cancel() {
-    _cancelled = true;
-    _timer?.cancel();
-    _timer = null;
-  }
-}
-
 /// A [DeviceDiscovery] implementation that uses polling to discover device adds
 /// and removals.
 abstract class PollingDeviceDiscovery extends DeviceDiscovery {


### PR DESCRIPTION
- when polling for devices, don't delay 4 seconds before we start to poll (in IDEs, the device selector will populate quicker); fix https://github.com/flutter/flutter/issues/8439

