### PR TITLE
FadeInImage: shows a placeholder while loading then fades in

### DIFF
--- a/packages/flutter/lib/src/rendering/image.dart
+++ b/packages/flutter/lib/src/rendering/image.dart
@@ -14,7 +14,7 @@ export 'package:flutter/painting.dart' show
 /// An image in the render tree.
 ///
 /// The render image attempts to find a size for itself that fits in the given
-/// constraints and preserves the image's intrinisc aspect ratio.
+/// constraints and preserves the image's intrinsic aspect ratio.
 ///
 /// The image is painted using [paintImage], which describes the meanings of the
 /// various fields on this class in more detail.

--- a/packages/flutter/lib/src/widgets/fade_in_image.dart
+++ b/packages/flutter/lib/src/widgets/fade_in_image.dart
@@ -1,10 +1,14 @@
-// Copyright 2017, the Flutter project authors.  Please see the AUTHORS file
-// for details. All rights reserved. Use of this source code is governed by a
-// BSD-style license that can be found in the LICENSE file.
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
-import 'package:flutter/widgets.dart';
+
+import 'basic.dart';
+import 'framework.dart';
+import 'image.dart';
+import 'ticker_provider.dart';
 
 /// An image that shows a [placeholder] image while the target [image] is
 /// loading, then fades in the new image when it loads.

--- a/packages/flutter/lib/src/widgets/fade_in_image.dart
+++ b/packages/flutter/lib/src/widgets/fade_in_image.dart
@@ -28,12 +28,12 @@ import 'package:flutter/widgets.dart';
 ///
 /// Example:
 ///
-/// '''dart
+/// ```dart
 /// return new FadeInImage(
 ///   placeholder: new Image.memory(bytes),
 ///   image: new Image.network('https://yourbackend.com/image.png'),
 /// );
-/// '''
+/// ```
 ///
 /// Prefer [placeholder] that's already cached so that it can be displayed in
 /// the frame in which the [FadeInImage] is built.

--- a/packages/flutter/lib/src/widgets/fade_in_image.dart
+++ b/packages/flutter/lib/src/widgets/fade_in_image.dart
@@ -1,0 +1,269 @@
+// Copyright 2017, the Flutter project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
+
+/// An image that shows a [placeholder] image while the target [image] is
+/// loading, then fades in the new image when it loads.
+///
+/// Use this class to display long-loading images, such as [new Image.network],
+/// so that the image appears on screen with a graceful animation rather than a
+/// sudden jerk.
+///
+/// This image ignores the [placeholder]'s and [image]'s `color` and `blendMode`
+/// properties in order to efficiently perform the cross-fade animation.
+///
+/// If the [image]'s [ImageProvider] returns [ImageInfo] synchronously, such as
+/// when the image has been loaded and cached, the [image] is displayed
+/// immediately and the [placeholder] is never displayed.
+///
+/// [fadeOutDuration] and [fadeOutCurve] control the fade-out animation of the
+/// placeholder.
+///
+/// [fadeInDuration] and [fadeInCurve] control the fade-in animation of the
+/// target [image].
+///
+/// Example:
+///
+/// '''dart
+/// return new FadeInImage(
+///   placeholder: new Image.memory(bytes),
+///   image: new Image.network('https://yourbackend.com/image.png'),
+/// );
+/// '''
+///
+/// Prefer [placeholder] that's already cached so that it can be displayed in
+/// the frame in which the [FadeInImage] is built.
+class FadeInImage extends StatefulWidget {
+  const FadeInImage({
+    Key key,
+    @required this.placeholder,
+    @required this.image,
+    this.fadeOutDuration: const Duration(milliseconds: 300),
+    this.fadeOutCurve: Curves.easeOut,
+    this.fadeInDuration: const Duration(milliseconds: 700),
+    this.fadeInCurve: Curves.easeIn,
+  }) : super(key: key);
+
+  /// Image displayed while the target [image] is loading.
+  final Image placeholder;
+
+  /// The target image that is displayed.
+  final Image image;
+
+  /// The duration of the fade-out animation for the [placeholder].
+  final Duration fadeOutDuration;
+
+  /// The curve of the fade-out animation for the [placeholder].
+  final Curve fadeOutCurve;
+
+  /// The duration of the fade-in animation for the [image].
+  final Duration fadeInDuration;
+
+  /// The curve of the fade-in animation for the [image].
+  final Curve fadeInCurve;
+
+  @override
+  State<StatefulWidget> createState() => new _FadeInImageState();
+}
+
+
+/// The phases a [FadeInImage] goes through.
+@visibleForTesting
+enum FadeInImagePhase {
+  /// The initial state.
+  ///
+  /// We do not yet know whether the target image is ready and therefore no
+  /// animation is necessary, or whether we need to use the placeholder and
+  /// wait for the image to load.
+  start,
+
+  /// Waiting for the target image to load.
+  waiting,
+
+  /// Fading out previous image.
+  fadeOut,
+
+  /// Fading in new image.
+  fadeIn,
+
+  /// Fade-in complete.
+  completed,
+}
+
+
+class _FadeInImageState extends State<FadeInImage> with TickerProviderStateMixin {
+  ImageStream _imageStream;
+  ImageInfo _imageInfo;
+  AnimationController _controller;
+  Animation<double> _animation;
+
+  FadeInImagePhase _phase = FadeInImagePhase.start;
+  FadeInImagePhase get phase => _phase;
+
+  @override
+  void initState() {
+    _controller = new AnimationController(
+      value: 1.0,
+      vsync: this,
+    );
+    _controller.addListener(() {
+      setState(() {
+        // Trigger rebuild to update opacity value.
+      });
+    });
+    _controller.addStatusListener((AnimationStatus status) {
+      _updatePhase();
+    });
+    super.initState();
+  }
+
+  @override
+  void didChangeDependencies() {
+    _resolveImage();
+    super.didChangeDependencies();
+  }
+
+  @override
+  void didUpdateWidget(FadeInImage oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.image.image != oldWidget.image.image)
+      _resolveImage();
+  }
+
+  @override
+  void reassemble() {
+    _resolveImage(); // in case the image cache was flushed
+    super.reassemble();
+  }
+
+  void _resolveImage() {
+    final ImageStream oldImageStream = _imageStream;
+    final Image image = widget.image;
+    _imageStream = image.image.resolve(createLocalImageConfiguration(
+        context,
+        size: image.width != null && image.height != null ? new Size(image.width, image.height) : null
+    ));
+    assert(_imageStream != null);
+
+    if (_imageStream.key != oldImageStream?.key) {
+      oldImageStream?.removeListener(_handleImageChanged);
+      if (!image.gaplessPlayback)
+        setState(() { _imageInfo = null; });
+      _imageStream.addListener(_handleImageChanged);
+    }
+
+    if (_phase == FadeInImagePhase.start)
+      _updatePhase();
+  }
+
+  void _handleImageChanged(ImageInfo imageInfo, bool synchronousCall) {
+    setState(() {
+      _imageInfo = imageInfo;
+      _updatePhase();
+    });
+  }
+
+  void _updatePhase() {
+    switch(_phase) {
+      case FadeInImagePhase.start:
+        if (_imageInfo != null)
+          _phase = FadeInImagePhase.completed;
+        else
+          _phase = FadeInImagePhase.waiting;
+        break;
+      case FadeInImagePhase.waiting:
+        if (_imageInfo != null) {
+          // Received image data. Begin placeholder fade-out.
+          _controller.duration = widget.fadeOutDuration;
+          _animation = new CurvedAnimation(
+            parent: _controller,
+            curve: widget.fadeOutCurve,
+          );
+          _phase = FadeInImagePhase.fadeOut;
+          _controller.reverse(from: 1.0);
+        }
+        break;
+      case FadeInImagePhase.fadeOut:
+        if (_controller.status == AnimationStatus.dismissed) {
+          // Done fading out placeholder. Begin target image fade-in.
+          _controller.duration = widget.fadeInDuration;
+          _animation = new CurvedAnimation(
+            parent: _controller,
+            curve: widget.fadeInCurve,
+          );
+          _phase = FadeInImagePhase.fadeIn;
+          _controller.forward(from: 0.0);
+        }
+        break;
+      case FadeInImagePhase.fadeIn:
+        if (_controller.status == AnimationStatus.completed) {
+          // Done finding in new image.
+          _phase = FadeInImagePhase.completed;
+        }
+        break;
+      case FadeInImagePhase.completed:
+      // Nothing to do.
+        break;
+    }
+  }
+
+  @override
+  void dispose() {
+    assert(_imageStream != null);
+    _imageStream.removeListener(_handleImageChanged);
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    assert(_phase != FadeInImagePhase.start);
+    if (_phase == FadeInImagePhase.waiting || _phase == FadeInImagePhase.fadeOut)
+      return _buildPlaceholderImage();
+    else
+      return _buildTargetImage();
+  }
+
+  Image _buildPlaceholderImage() {
+    return new Image(
+      key: widget.placeholder.key,
+      image: widget.placeholder.image,
+      width: widget.placeholder.width,
+      height: widget.placeholder.height,
+      color: new Color.fromRGBO(255, 255, 255, _animation?.value ?? 1.0),
+      colorBlendMode: BlendMode.modulate,
+      fit: widget.placeholder.fit,
+      alignment: widget.placeholder.alignment,
+      repeat: widget.placeholder.repeat,
+      centerSlice: widget.placeholder.centerSlice,
+      gaplessPlayback: widget.placeholder.gaplessPlayback,
+    );
+  }
+
+  RawImage _buildTargetImage() {
+    final Image image = widget.image;
+    return new RawImage(
+      image: _imageInfo?.image,
+      width: image.width,
+      height: image.height,
+      scale: _imageInfo?.scale ?? 1.0,
+      color: new Color.fromRGBO(255, 255, 255, _animation?.value ?? 1.0),
+      colorBlendMode: BlendMode.modulate,
+      fit: image.fit,
+      alignment: image.alignment,
+      repeat: image.repeat,
+      centerSlice: image.centerSlice,
+    );
+  }
+
+  @override
+  void debugFillDescription(List<String> description) {
+    super.debugFillDescription(description);
+    description.add('stream: $_imageStream');
+    description.add('pixels: $_imageInfo');
+  }
+}

--- a/packages/flutter/lib/src/widgets/fade_in_image.dart
+++ b/packages/flutter/lib/src/widgets/fade_in_image.dart
@@ -441,11 +441,11 @@ class _FadeInImageState extends State<FadeInImage> with TickerProviderStateMixin
   }
 
   @override
-  void debugFillDescription(List<String> description) {
-    super.debugFillDescription(description);
-    description.add('phase: $_phase');
-    description.add('pixels: $_imageInfo');
-    description.add('image stream: ${_imageResolver._imageStream}');
-    description.add('placeholder stream: ${_placeholderResolver._imageStream}');
+  void debugFillProperties(List<DiagnosticsNode> description) {
+    super.debugFillProperties(description);
+    description.add(new EnumProperty<FadeInImagePhase>('phase', _phase));
+    description.add(new DiagnosticsProperty<ImageInfo>('pixels', _imageInfo));
+    description.add(new DiagnosticsProperty<ImageStream>('image stream', _imageResolver._imageStream));
+    description.add(new DiagnosticsProperty<ImageStream>('placeholder stream', _placeholderResolver._imageStream));
   }
 }

--- a/packages/flutter/lib/src/widgets/fade_in_image.dart
+++ b/packages/flutter/lib/src/widgets/fade_in_image.dart
@@ -322,7 +322,7 @@ class _FadeInImageState extends State<FadeInImage> with TickerProviderStateMixin
   @override
   void didUpdateWidget(FadeInImage oldWidget) {
     super.didUpdateWidget(oldWidget);
-    if (widget.image != oldWidget.image)
+    if (widget.image != oldWidget.image || widget.placeholder != widget.placeholder)
       _resolveImage();
   }
 

--- a/packages/flutter/lib/src/widgets/image.dart
+++ b/packages/flutter/lib/src/widgets/image.dart
@@ -133,10 +133,11 @@ class Image extends StatefulWidget {
   /// If the `bundle` argument is omitted or null, then the
   /// [DefaultAssetBundle] will be used.
   ///
-  /// By default, the exact asset specified will be used. In addition:
+  /// By default, the pixel-density-aware asset resolution will be attempted. In
+  /// addition:
   ///
-  /// * If the `scale` argument is omitted or null, then pixel-density-aware
-  ///   asset resolution will be attempted.
+  /// * If the `scale` argument is provided and is not null, then the exact
+  /// asset specified will be used.
   //
   // TODO(ianh): Implement the following (see ../services/image_resolution.dart):
   // ///

--- a/packages/flutter/lib/widgets.dart
+++ b/packages/flutter/lib/widgets.dart
@@ -29,6 +29,7 @@ export 'src/widgets/debug.dart';
 export 'src/widgets/dismissible.dart';
 export 'src/widgets/drag_target.dart';
 export 'src/widgets/editable_text.dart';
+export 'src/widgets/fade_in_image.dart';
 export 'src/widgets/focus_manager.dart';
 export 'src/widgets/focus_scope.dart';
 export 'src/widgets/form.dart';

--- a/packages/flutter/test/services/image_test_utils.dart
+++ b/packages/flutter/test/services/image_test_utils.dart
@@ -9,7 +9,7 @@ import 'dart:ui' as ui;
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 
-import '../services/image_data.dart';
+import 'image_data.dart';
 
 class TestImageProvider extends ImageProvider<TestImageProvider> {
   TestImageProvider(this.testImage);

--- a/packages/flutter/test/widgets/fade_in_image_test.dart
+++ b/packages/flutter/test/widgets/fade_in_image_test.dart
@@ -1,6 +1,6 @@
-// Copyright (c) 2017, the Flutter project authors.  Please see the AUTHORS file
-// for details. All rights reserved. Use of this source code is governed by a
-// BSD-style license that can be found in the LICENSE file.
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 import 'dart:async';
 import 'dart:ui' as ui;

--- a/packages/flutter/test/widgets/fade_in_image_test.dart
+++ b/packages/flutter/test/widgets/fade_in_image_test.dart
@@ -10,59 +10,75 @@ import 'package:flutter_test/flutter_test.dart';
 import 'image_test_utils.dart';
 
 Future<Null> main() async {
-  final ui.Image testImage = await createTestImage();  // must run outside test zone to complete
+  // These must run outside test zone to complete
+  final ui.Image targetImage = await createTestImage();
+  final ui.Image placeholderImage = await createTestImage();
 
   group('FadeInImage', () {
     testWidgets('animates uncached image and shows cached image immediately', (WidgetTester tester) async {
       // State type is private, hence using dynamic.
       dynamic state() => tester.state(find.byType(FadeInImage));
 
+      RawImage displayedImage() => tester.widget(find.byType(RawImage));
+
       // The placeholder is expected to be already loaded
-      final TestImageProvider placeholderProvider = new TestImageProvider(testImage);
-      placeholderProvider.complete();
+      final TestImageProvider placeholderProvider = new TestImageProvider(placeholderImage);
 
       // Test case: long loading image
-      final TestImageProvider syncImageProvider = new TestImageProvider(testImage);
+      final TestImageProvider imageProvider = new TestImageProvider(targetImage);
 
       await tester.pumpWidget(new FadeInImage(
-        placeholder: new Image(image: placeholderProvider),
-        image: new Image(image: syncImageProvider),
+        placeholder: placeholderProvider,
+        image: imageProvider,
         fadeOutDuration: const Duration(milliseconds: 50),
         fadeInDuration: const Duration(milliseconds: 50),
       ));
 
+      expect(displayedImage().image, null);  // image providers haven't completed yet
+      placeholderProvider.complete();
+      await tester.pump();
+
+      expect(displayedImage().image, same(placeholderImage));  // placeholder completed
       expect(state().phase, FadeInImagePhase.waiting);
-      syncImageProvider.complete();  // load the image
+
+      imageProvider.complete();  // load the image
       expect(state().phase, FadeInImagePhase.fadeOut);  // fade out placeholder
       for (int i = 0; i < 7; i += 1) {
+        expect(displayedImage().image, same(placeholderImage));
         await tester.pump(const Duration(milliseconds: 10));
       }
+      expect(displayedImage().image, same(targetImage));
       expect(state().phase, FadeInImagePhase.fadeIn);  // fade in image
       for (int i = 0; i < 6; i += 1) {
+        expect(displayedImage().image, same(targetImage));
         await tester.pump(const Duration(milliseconds: 10));
       }
       expect(state().phase, FadeInImagePhase.completed);  // done
+      expect(displayedImage().image, same(targetImage));
 
       // Test case: re-use state object (didUpdateWidget)
       final dynamic stateBeforeDidUpdateWidget = state();
       await tester.pumpWidget(new FadeInImage(
-        placeholder: new Image(image: placeholderProvider),
-        image: new Image(image: syncImageProvider),
+        placeholder: placeholderProvider,
+        image: imageProvider,
       ));
       final dynamic stateAfterDidUpdateWidget = state();
       expect(stateAfterDidUpdateWidget, same(stateBeforeDidUpdateWidget));
       expect(stateAfterDidUpdateWidget.phase, FadeInImagePhase.completed);  // completes immediately
+      expect(displayedImage().image, same(targetImage));
 
       // Test case: new state object but cached image
       final dynamic stateBeforeRecreate = state();
       await tester.pumpWidget(new Container());  // clear widget tree to prevent state reuse
       await tester.pumpWidget(new FadeInImage(
-        placeholder: new Image(image: placeholderProvider),
-        image: new Image(image: syncImageProvider),
+        placeholder: placeholderProvider,
+        image: imageProvider,
       ));
+      expect(displayedImage().image, same(targetImage));
       final dynamic stateAfterRecreate = state();
       expect(stateAfterRecreate, isNot(same(stateBeforeRecreate)));
       expect(stateAfterRecreate.phase, FadeInImagePhase.completed);  // completes immediately
+      expect(displayedImage().image, same(targetImage));
     });
   });
 }

--- a/packages/flutter/test/widgets/fade_in_image_test.dart
+++ b/packages/flutter/test/widgets/fade_in_image_test.dart
@@ -1,0 +1,68 @@
+// Copyright (c) 2017, the Flutter project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:ui' as ui;
+
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'image_test_utils.dart';
+
+Future<Null> main() async {
+  final ui.Image testImage = await createTestImage();  // must run outside test zone to complete
+
+  group('FadeInImage', () {
+    testWidgets('animates uncached image and shows cached image immediately', (WidgetTester tester) async {
+      // State type is private, hence using dynamic.
+      dynamic state() => tester.state(find.byType(FadeInImage));
+
+      // The placeholder is expected to be already loaded
+      final TestImageProvider placeholderProvider = new TestImageProvider(testImage);
+      placeholderProvider.complete();
+
+      // Test case: long loading image
+      final TestImageProvider syncImageProvider = new TestImageProvider(testImage);
+
+      await tester.pumpWidget(new FadeInImage(
+        placeholder: new Image(image: placeholderProvider),
+        image: new Image(image: syncImageProvider),
+        fadeOutDuration: const Duration(milliseconds: 50),
+        fadeInDuration: const Duration(milliseconds: 50),
+      ));
+
+      expect(state().phase, FadeInImagePhase.waiting);
+      syncImageProvider.complete();  // load the image
+      expect(state().phase, FadeInImagePhase.fadeOut);  // fade out placeholder
+      for (int i = 0; i < 7; i += 1) {
+        await tester.pump(const Duration(milliseconds: 10));
+      }
+      expect(state().phase, FadeInImagePhase.fadeIn);  // fade in image
+      for (int i = 0; i < 6; i += 1) {
+        await tester.pump(const Duration(milliseconds: 10));
+      }
+      expect(state().phase, FadeInImagePhase.completed);  // done
+
+      // Test case: re-use state object (didUpdateWidget)
+      final dynamic stateBeforeDidUpdateWidget = state();
+      await tester.pumpWidget(new FadeInImage(
+        placeholder: new Image(image: placeholderProvider),
+        image: new Image(image: syncImageProvider),
+      ));
+      final dynamic stateAfterDidUpdateWidget = state();
+      expect(stateAfterDidUpdateWidget, same(stateBeforeDidUpdateWidget));
+      expect(stateAfterDidUpdateWidget.phase, FadeInImagePhase.completed);  // completes immediately
+
+      // Test case: new state object but cached image
+      final dynamic stateBeforeRecreate = state();
+      await tester.pumpWidget(new Container());  // clear widget tree to prevent state reuse
+      await tester.pumpWidget(new FadeInImage(
+        placeholder: new Image(image: placeholderProvider),
+        image: new Image(image: syncImageProvider),
+      ));
+      final dynamic stateAfterRecreate = state();
+      expect(stateAfterRecreate, isNot(same(stateBeforeRecreate)));
+      expect(stateAfterRecreate.phase, FadeInImagePhase.completed);  // completes immediately
+    });
+  });
+}

--- a/packages/flutter/test/widgets/fade_in_image_test.dart
+++ b/packages/flutter/test/widgets/fade_in_image_test.dart
@@ -7,7 +7,7 @@ import 'dart:ui' as ui;
 
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'image_test_utils.dart';
+import '../services/image_test_utils.dart';
 
 Future<Null> main() async {
   // These must run outside test zone to complete

--- a/packages/flutter/test/widgets/image_test_utils.dart
+++ b/packages/flutter/test/widgets/image_test_utils.dart
@@ -34,8 +34,10 @@ class TestImageProvider extends ImageProvider<TestImageProvider> {
   ImageStreamCompleter load(TestImageProvider key) =>
       new OneFrameImageStreamCompleter(_completer.future);
 
-  void complete() {
-    _completer.complete(new ImageInfo(image: testImage));
+  ImageInfo complete() {
+    final ImageInfo imageInfo = new ImageInfo(image: testImage);
+    _completer.complete(imageInfo);
+    return imageInfo;
   }
 
   @override

--- a/packages/flutter/test/widgets/image_test_utils.dart
+++ b/packages/flutter/test/widgets/image_test_utils.dart
@@ -1,0 +1,49 @@
+// Copyright (c) 2017, the Flutter project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:typed_data';
+import 'dart:ui' as ui;
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+
+import '../services/image_data.dart';
+
+class TestImageProvider extends ImageProvider<TestImageProvider> {
+  TestImageProvider(this.testImage);
+
+  final ui.Image testImage;
+
+  final Completer<ImageInfo> _completer = new Completer<ImageInfo>.sync();
+  ImageConfiguration configuration;
+
+  @override
+  Future<TestImageProvider> obtainKey(ImageConfiguration configuration) {
+    return new SynchronousFuture<TestImageProvider>(this);
+  }
+
+  @override
+  ImageStream resolve(ImageConfiguration config) {
+    configuration = config;
+    return super.resolve(configuration);
+  }
+
+  @override
+  ImageStreamCompleter load(TestImageProvider key) =>
+      new OneFrameImageStreamCompleter(_completer.future);
+
+  void complete() {
+    _completer.complete(new ImageInfo(image: testImage));
+  }
+
+  @override
+  String toString() => '${describeIdentity(this)}()';
+}
+
+Future<ui.Image> createTestImage() {
+  final Completer<ui.Image> uiImage = new Completer<ui.Image>();
+  ui.decodeImageFromList(new Uint8List.fromList(kTransparentImage), uiImage.complete);
+  return uiImage.future;
+}

--- a/packages/flutter/test/widgets/image_test_utils.dart
+++ b/packages/flutter/test/widgets/image_test_utils.dart
@@ -1,6 +1,6 @@
-// Copyright (c) 2017, the Flutter project authors.  Please see the AUTHORS file
-// for details. All rights reserved. Use of this source code is governed by a
-// BSD-style license that can be found in the LICENSE file.
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 import 'dart:async';
 import 'dart:typed_data';


### PR DESCRIPTION
This PR is a copy of https://github.com/flutter/flutter_image/pull/2

A widget for displaying long-loading images using a placeholder and a delightful cross-fade effect.

Fixes https://github.com/flutter/flutter/issues/8984

@Hixie 