### PR TITLE
brew update is not needed any more

### DIFF
--- a/packages/flutter_tools/lib/src/ios/cocoapods.dart
+++ b/packages/flutter_tools/lib/src/ios/cocoapods.dart
@@ -23,12 +23,10 @@ final String noCocoaPodsConsequence = '''
   For more info, see https://flutter.io/platform-plugins''';
 
 final String cocoaPodsInstallInstructions = '''
-  brew update
   brew install cocoapods
   pod setup''';
 
 final String cocoaPodsUpgradeInstructions = '''
-  brew update
   brew upgrade cocoapods
   pod setup''';
 

--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -21,7 +21,6 @@ import 'mac.dart';
 
 const String _kIdeviceinstallerInstructions =
     'To work with iOS devices, please install ideviceinstaller. To install, run:\n'
-    'brew update\n'
     'brew install ideviceinstaller.';
 
 const Duration kPortForwardTimeout = const Duration(seconds: 10);
@@ -46,7 +45,6 @@ class IOSDevice extends Device {
     _pusherPath = _checkForCommand(
       'ios-deploy',
       'To copy files to iOS devices, please install ios-deploy. To install, run:\n'
-      'brew update\n'
       'brew install ios-deploy'
     );
   }

--- a/packages/flutter_tools/lib/src/ios/ios_workflow.dart
+++ b/packages/flutter_tools/lib/src/ios/ios_workflow.dart
@@ -129,7 +129,6 @@ class IOSWorkflow extends DoctorValidator implements Workflow {
         brewStatus = ValidationType.partial;
         messages.add(new ValidationMessage.error(
             'libimobiledevice and ideviceinstaller are not installed or require updating. To update, run:\n'
-            '  brew update\n'
             '  brew uninstall --ignore-dependencies libimobiledevice\n'
             '  brew install --HEAD libimobiledevice\n'
             '  brew install ideviceinstaller'
@@ -139,7 +138,6 @@ class IOSWorkflow extends DoctorValidator implements Workflow {
         messages.add(new ValidationMessage.error(
           'ideviceinstaller not available; this is used to discover connected iOS devices.\n'
           'To install, run:\n'
-          '  brew update\n'
           '  brew install --HEAD libimobiledevice\n'
           '  brew install ideviceinstaller'
         ));
@@ -154,13 +152,11 @@ class IOSWorkflow extends DoctorValidator implements Workflow {
         if (await hasIosDeploy) {
           messages.add(new ValidationMessage.error(
             'ios-deploy out of date ($iosDeployMinimumVersion is required). To upgrade:\n'
-            '  brew update\n'
             '  brew upgrade ios-deploy'
           ));
         } else {
           messages.add(new ValidationMessage.error(
             'ios-deploy not installed. To install:\n'
-            '  brew update\n'
             '  brew install ios-deploy'
           ));
         }


### PR DESCRIPTION
Starting from August 2016 it's no longer necessary to run `brew update`. Homebrew auto-updates before installs: Homebrew/brew#679

`brew doctor` before:

```
[-] iOS toolchain - develop for iOS devices (Xcode 8.2.1)
    • Xcode at /Applications/Xcode.app/Contents/Developer
    • Xcode 8.2.1, Build version 8C1002
    ✗ ios-deploy not installed. To install:
        brew update
        brew install ios-deploy
    ✗ CocoaPods not installed.
        CocoaPods is used to retrieve the iOS platform side's plugin code that responds to your plugin usage on the Dart side.
        Without resolving iOS dependencies with CocoaPods, plugins will not work on iOS.
        For more info, see https://flutter.io/platform-plugins
      To install:
        brew update
        brew install cocoapods
        pod setup
```

`brew doctor` after:

```
[-] iOS toolchain - develop for iOS devices (Xcode 8.2.1)
    • Xcode at /Applications/Xcode.app/Contents/Developer
    • Xcode 8.2.1, Build version 8C1002
    ✗ Your Mac needs to enabled for developer mode before using Xcode for the first time.
      Run 'sudo DevToolsSecurity -enable' or open Xcode
    ✗ ios-deploy not installed. To install:
        brew install ios-deploy
    ✗ CocoaPods not installed.
        CocoaPods is used to retrieve the iOS platform side's plugin code that responds to your plugin usage on the Dart side.
        Without resolving iOS dependencies with CocoaPods, plugins will not work on iOS.
        For more info, see https://flutter.io/platform-plugins
      To install:
        brew install cocoapods
        pod setup
```