### PR TITLE
temporarily disable broken driver test in integration_ui

### DIFF
--- a/dev/devicelab/lib/tasks/integration_ui.dart
+++ b/dev/devicelab/lib/tasks/integration_ui.dart
@@ -22,7 +22,6 @@ Future<TaskResult> runEndToEndTests() async {
       await prepareProvisioningCertificates(testDirectory.path);
 
     await flutter('drive', options: <String>['--verbose', '-d', deviceId, 'lib/keyboard_resize.dart']);
-    await flutter('drive', options: <String>['--verbose', '-d', deviceId, 'lib/driver.dart']);
   });
 
   return new TaskResult.success(<String, dynamic>{});


### PR DESCRIPTION
I'll fix it and reenable asap.

@Hixie 