### PR TITLE
add a profile() method

### DIFF
--- a/packages/flutter/lib/foundation.dart
+++ b/packages/flutter/lib/foundation.dart
@@ -40,6 +40,7 @@ export 'src/foundation/licenses.dart';
 export 'src/foundation/observer_list.dart';
 export 'src/foundation/platform.dart';
 export 'src/foundation/print.dart';
+export 'src/foundation/profile.dart';
 export 'src/foundation/serialization.dart';
 export 'src/foundation/synchronous_future.dart';
 export 'src/foundation/tree_diagnostics_mixin.dart';

--- a/packages/flutter/lib/src/foundation/profile.dart
+++ b/packages/flutter/lib/src/foundation/profile.dart
@@ -1,0 +1,18 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:ui';
+
+/// Whether we've been built in release mode.
+const bool _kReleaseMode = const bool.fromEnvironment("dart.vm.product");
+
+/// When running in profile mode (or debug mode), invoke the given function.
+///
+/// In release mode, the function is not invoked.
+// TODO(devoncarew): Going forward, we'll want the call to profile() to be tree-shaken out.
+void profile(VoidCallback function) {
+  if (_kReleaseMode)
+    return;
+  function();
+}

--- a/packages/flutter/test/foundation/profile_test.dart
+++ b/packages/flutter/test/foundation/profile_test.dart
@@ -5,9 +5,12 @@
 import 'package:flutter/foundation.dart';
 import 'package:test/test.dart';
 
+// We run our tests in debug mode, to this will always evaluate to false...
 const bool isReleaseMode = const bool.fromEnvironment("dart.vm.product");
 
 void main() {
+  // TODO(devoncarew): This test - while very nice - isn't testing what we really want to know:
+  // that the code in the `profile` closure is omitted in release mode.
   test("profile invokes its closure in debug or profile mode", () {
     int count = 0;
     profile(() {

--- a/packages/flutter/test/foundation/profile_test.dart
+++ b/packages/flutter/test/foundation/profile_test.dart
@@ -1,0 +1,18 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/foundation.dart';
+import 'package:test/test.dart';
+
+const bool isReleaseMode = const bool.fromEnvironment("dart.vm.product");
+
+void main() {
+  test("profile invokes its closure in debug or profile mode", () {
+    int count = 0;
+    profile(() {
+      count++;
+    });
+    expect(count, isReleaseMode ? 0 : 1);
+  });
+}


### PR DESCRIPTION
- add a `profile()` method - it will only execute the given function in debug or profile modes
- re-land parts of https://github.com/flutter/flutter/pull/10966
