### PR TITLE
Make plugins add their repos to projects in the consuming app

### DIFF
--- a/packages/flutter_tools/templates/plugin/android-java.tmpl/build.gradle.tmpl
+++ b/packages/flutter_tools/templates/plugin/android-java.tmpl/build.gradle.tmpl
@@ -14,11 +14,13 @@ buildscript {
     }
 }
 
-allprojects {
-    repositories {
-        jcenter()
-        maven {
-            url "https://maven.google.com"
+[rootProject, this].each {
+    it.allprojects {
+        repositories {
+            jcenter()
+            maven {
+                url "https://maven.google.com"
+            }
         }
     }
 }

--- a/packages/flutter_tools/templates/plugin/android-java.tmpl/build.gradle.tmpl
+++ b/packages/flutter_tools/templates/plugin/android-java.tmpl/build.gradle.tmpl
@@ -14,13 +14,11 @@ buildscript {
     }
 }
 
-[rootProject, this].each {
-    it.allprojects {
-        repositories {
-            jcenter()
-            maven {
-                url "https://maven.google.com"
-            }
+rootProject.allprojects {
+    repositories {
+        jcenter()
+        maven {
+            url "https://maven.google.com"
         }
     }
 }

--- a/packages/flutter_tools/templates/plugin/android-kotlin.tmpl/build.gradle.tmpl
+++ b/packages/flutter_tools/templates/plugin/android-kotlin.tmpl/build.gradle.tmpl
@@ -14,11 +14,13 @@ buildscript {
     }
 }
 
-allprojects {
-    repositories {
-        jcenter()
-        maven {
-            url "https://maven.google.com"
+[rootProject, this].each {
+    it.allprojects {
+        repositories {
+            jcenter()
+            maven {
+                url "https://maven.google.com"
+            }
         }
     }
 }

--- a/packages/flutter_tools/templates/plugin/android-kotlin.tmpl/build.gradle.tmpl
+++ b/packages/flutter_tools/templates/plugin/android-kotlin.tmpl/build.gradle.tmpl
@@ -14,13 +14,11 @@ buildscript {
     }
 }
 
-[rootProject, this].each {
-    it.allprojects {
-        repositories {
-            jcenter()
-            maven {
-                url "https://maven.google.com"
-            }
+rootProject.allprojects {
+    repositories {
+        jcenter()
+        maven {
+            url "https://maven.google.com"
         }
     }
 }


### PR DESCRIPTION
Avoids manual work when consuming a plugin that uses a non-standard repository (e.g. image_picker).

Fixes https://github.com/flutter/flutter/issues/9881