### PR TITLE
Prevent event dispatch from happening during reassemble.

### DIFF
--- a/packages/flutter/lib/src/gestures/binding.dart
+++ b/packages/flutter/lib/src/gestures/binding.dart
@@ -28,22 +28,24 @@ abstract class GestureBinding extends BindingBase with HitTestable, HitTestDispa
     ui.window.onPointerDataPacket = _handlePointerDataPacket;
   }
 
+  @override
+  void unlocked() {
+    super.unlocked();
+    _flushPointerEventQueue();
+  }
+
   /// The singleton instance of this object.
   static GestureBinding get instance => _instance;
   static GestureBinding _instance;
+
+  final Queue<PointerEvent> _pendingPointerEvents = new Queue<PointerEvent>();
 
   void _handlePointerDataPacket(ui.PointerDataPacket packet) {
     // We convert pointer data to logical pixels so that e.g. the touch slop can be
     // defined in a device-independent manner.
     _pendingPointerEvents.addAll(PointerEventConverter.expand(packet.data, ui.window.devicePixelRatio));
-    _flushPointerEventQueue();
-  }
-
-  final Queue<PointerEvent> _pendingPointerEvents = new Queue<PointerEvent>();
-
-  void _flushPointerEventQueue() {
-    while (_pendingPointerEvents.isNotEmpty)
-      _handlePointerEvent(_pendingPointerEvents.removeFirst());
+    if (!locked)
+      _flushPointerEventQueue();
   }
 
   /// Dispatch a [PointerCancelEvent] for the given pointer soon.
@@ -51,9 +53,15 @@ abstract class GestureBinding extends BindingBase with HitTestable, HitTestDispa
   /// The pointer event will be dispatch before the next pointer event and
   /// before the end of the microtask but not within this function call.
   void cancelPointer(int pointer) {
-    if (_pendingPointerEvents.isEmpty)
+    if (_pendingPointerEvents.isEmpty && !locked)
       scheduleMicrotask(_flushPointerEventQueue);
     _pendingPointerEvents.addFirst(new PointerCancelEvent(pointer: pointer));
+  }
+
+  void _flushPointerEventQueue() {
+    assert(!locked);
+    while (_pendingPointerEvents.isNotEmpty)
+      _handlePointerEvent(_pendingPointerEvents.removeFirst());
   }
 
   /// A router that routes all pointer events received from the engine.
@@ -70,6 +78,7 @@ abstract class GestureBinding extends BindingBase with HitTestable, HitTestDispa
   final Map<int, HitTestResult> _hitTests = <int, HitTestResult>{};
 
   void _handlePointerEvent(PointerEvent event) {
+    assert(!locked);
     HitTestResult result;
     if (event is PointerDownEvent) {
       assert(!_hitTests.containsKey(event.pointer));
@@ -105,6 +114,7 @@ abstract class GestureBinding extends BindingBase with HitTestable, HitTestDispa
   /// the handlers might throw. The `result` argument must not be null.
   @override // from HitTestDispatcher
   void dispatchEvent(PointerEvent event, HitTestResult result) {
+    assert(!locked);
     assert(result != null);
     for (HitTestEntry entry in result.path) {
       try {

--- a/packages/flutter/lib/src/rendering/binding.dart
+++ b/packages/flutter/lib/src/rendering/binding.dart
@@ -276,8 +276,8 @@ abstract class RendererBinding extends BindingBase with SchedulerBinding, Servic
   }
 
   @override
-  Future<Null> reassembleApplication() async {
-    await super.reassembleApplication();
+  Future<Null> performReassemble() async {
+    await super.performReassemble();
     Timeline.startSync('Dirty Render Tree');
     try {
       renderView.reassemble();

--- a/packages/flutter/lib/src/widgets/binding.dart
+++ b/packages/flutter/lib/src/widgets/binding.dart
@@ -544,12 +544,12 @@ abstract class WidgetsBinding extends BindingBase with GestureBinding, RendererB
   }
 
   @override
-  Future<Null> reassembleApplication() {
+  Future<Null> performReassemble() {
     _needToReportFirstFrame = true;
     preventThisFrameFromBeingReportedAsFirstFrame();
     if (renderViewElement != null)
       buildOwner.reassemble(renderViewElement);
-    return super.reassembleApplication();
+    return super.performReassemble();
   }
 }
 

--- a/packages/flutter/test/foundation/reassemble_test.dart
+++ b/packages/flutter/test/foundation/reassemble_test.dart
@@ -1,0 +1,29 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:test/test.dart';
+
+class TestFoundationFlutterBinding extends BindingBase {
+  bool wasLocked;
+
+  @override
+  Future<Null> performReassemble() async {
+    wasLocked = locked;
+    return super.performReassemble();
+  }
+}
+
+TestFoundationFlutterBinding binding = new TestFoundationFlutterBinding();
+
+void main() {
+  binding ??= new TestFoundationFlutterBinding();
+
+  test('Pointer events are locked during reassemble', () async {
+    await binding.reassembleApplication();
+    expect(binding.wasLocked, isTrue);
+  });
+}

--- a/packages/flutter/test/foundation/service_extensions_test.dart
+++ b/packages/flutter/test/foundation/service_extensions_test.dart
@@ -40,9 +40,9 @@ class TestServiceExtensionsBinding extends BindingBase
 
   int reassembled = 0;
   @override
-  Future<Null> reassembleApplication() {
+  Future<Null> performReassemble() {
     reassembled += 1;
-    return super.reassembleApplication();
+    return super.performReassemble();
   }
 
   bool frameScheduled = false;

--- a/packages/flutter/test/gestures/locking_test.dart
+++ b/packages/flutter/test/gestures/locking_test.dart
@@ -1,0 +1,63 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:ui' as ui;
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/gestures.dart';
+import 'package:test/test.dart';
+
+typedef void HandleEventCallback(PointerEvent event);
+
+class TestGestureFlutterBinding extends BindingBase with GestureBinding {
+  HandleEventCallback callback;
+
+  @override
+  void handleEvent(PointerEvent event, HitTestEntry entry) {
+    if (callback != null)
+      callback(event);
+    super.handleEvent(event, entry);
+  }
+
+  static const ui.PointerDataPacket packet = const ui.PointerDataPacket(
+    data: const <ui.PointerData>[
+      const ui.PointerData(change: ui.PointerChange.down),
+      const ui.PointerData(change: ui.PointerChange.up),
+    ]
+  );
+
+  Future<Null> test(VoidCallback callback) {
+    assert(callback != null);
+    return _binding.lockEvents(() async {
+      ui.window.onPointerDataPacket(packet);
+      callback();
+    });
+  }
+}
+
+TestGestureFlutterBinding _binding = new TestGestureFlutterBinding();
+
+void ensureTestGestureBinding() {
+  _binding ??= new TestGestureFlutterBinding();
+  assert(GestureBinding.instance != null);
+}
+
+void main() {
+  setUp(ensureTestGestureBinding);
+
+  test('Pointer events are locked during reassemble', () async {
+    final List<PointerEvent> events = <PointerEvent>[];
+    _binding.callback = events.add;
+    bool tested = false;
+    await _binding.test(() {
+      expect(events.length, 0);
+      tested = true;
+    });
+    expect(tested, isTrue);
+    expect(events.length, 2);
+    expect(events[0].runtimeType, equals(PointerDownEvent));
+    expect(events[1].runtimeType, equals(PointerUpEvent));
+  });
+}


### PR DESCRIPTION
It was previously possible for event dispatch to occurr during the
brief window where the tree had been marked dirty but before it had
been relaid out by reassemble, which would cause assertions to fire if
someone did a hot reload while touching the device.