### PR TITLE
Revert "Revert "Always evaluate the finder in `driver.waitFor*()`""

### DIFF
--- a/dev/integration_tests/ui/lib/driver.dart
+++ b/dev/integration_tests/ui/lib/driver.dart
@@ -1,0 +1,57 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_driver/driver_extension.dart';
+
+void main() {
+  enableFlutterDriverExtension();
+  runApp(new DriverTestApp());
+}
+
+class DriverTestApp extends StatefulWidget {
+  @override
+  State<StatefulWidget> createState() {
+    return new DriverTestAppState();
+  }
+}
+
+class DriverTestAppState extends State<DriverTestApp> {
+  bool present = true;
+
+  @override
+  Widget build(BuildContext context) {
+    return new MaterialApp(
+      home: new Scaffold(
+        appBar: new AppBar(
+          title: const Text('FlutterDriver test'),
+        ),
+        body: new ListView(
+          padding: const EdgeInsets.all(5.0),
+          children: <Widget>[
+            new Row(
+              children: <Widget>[
+                new Expanded(
+                  child: new Text(present ? 'present' : 'absent'),
+                ),
+                new RaisedButton(
+                  child: const Text(
+                    'toggle',
+                    key: const ValueKey<String>('togglePresent'),
+                  ),
+                  onPressed: () {
+                    setState(() {
+                      present = !present;
+                    });
+                  },
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/dev/integration_tests/ui/test_driver/driver_test.dart
+++ b/dev/integration_tests/ui/test_driver/driver_test.dart
@@ -1,0 +1,81 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:flutter_driver/flutter_driver.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('FlutterDriver', () {
+    final SerializableFinder presentText = find.text('present');
+    FlutterDriver driver;
+
+    setUpAll(() async {
+      driver = await FlutterDriver.connect();
+    });
+
+    tearDownAll(() async {
+      await driver.close();
+    });
+
+    test('waitFor should find text "present"', () async {
+      await driver.waitFor(presentText);
+    });
+
+    test('waitForAbsent should time out waiting for text "present" to disappear', () async {
+      try {
+        await driver.waitForAbsent(presentText, timeout: const Duration(seconds: 1));
+        fail('expected DriverError');
+      } on DriverError catch (error) {
+        expect(error.message, contains('Timeout while executing waitForAbsent'));
+      }
+    });
+
+    test('waitForAbsent should resolve when text "present" disappears', () async {
+      // Begin waiting for it to disappear
+      final Completer<Null> whenWaitForAbsentResolves = new Completer<Null>();
+      driver.waitForAbsent(presentText).then(
+        whenWaitForAbsentResolves.complete,
+        onError: whenWaitForAbsentResolves.completeError,
+      );
+
+      // Wait 1 second then make it disappear
+      await new Future<Null>.delayed(const Duration(seconds: 1));
+      await driver.tap(find.byValueKey('togglePresent'));
+
+      // Ensure waitForAbsent resolves
+      await whenWaitForAbsentResolves.future;
+    });
+
+    test('waitFor times out waiting for "present" to reappear', () async {
+      try {
+        await driver.waitFor(presentText, timeout: const Duration(seconds: 1));
+        fail('expected DriverError');
+      } on DriverError catch (error) {
+        expect(error.message, contains('Timeout while executing waitFor'));
+      }
+    });
+
+    test('waitFor should resolve when text "present" reappears', () async {
+      // Begin waiting for it to reappear
+      final Completer<Null> whenWaitForResolves = new Completer<Null>();
+      driver.waitFor(presentText).then(
+        whenWaitForResolves.complete,
+        onError: whenWaitForResolves.completeError,
+      );
+
+      // Wait 1 second then make it appear
+      await new Future<Null>.delayed(const Duration(seconds: 1));
+      await driver.tap(find.byValueKey('togglePresent'));
+
+      // Ensure waitFor resolves
+      await whenWaitForResolves.future;
+    });
+
+    test('waitForAbsent resolves immediately when the element does not exist', () async {
+      await driver.waitForAbsent(find.text('that does not exist'));
+    });
+  });
+}

--- a/packages/flutter_driver/lib/src/extension.dart
+++ b/packages/flutter_driver/lib/src/extension.dart
@@ -200,7 +200,7 @@ class FlutterDriverExtension {
     if (_frameSync)
       await _waitUntilFrame(() => SchedulerBinding.instance.transientCallbackCount == 0);
 
-    await _waitUntilFrame(() => finder.precache());
+    await _waitUntilFrame(() => finder.evaluate().isNotEmpty);
 
     if (_frameSync)
       await _waitUntilFrame(() => SchedulerBinding.instance.transientCallbackCount == 0);
@@ -213,7 +213,7 @@ class FlutterDriverExtension {
     if (_frameSync)
       await _waitUntilFrame(() => SchedulerBinding.instance.transientCallbackCount == 0);
 
-    await _waitUntilFrame(() => !finder.precache());
+    await _waitUntilFrame(() => finder.evaluate().isEmpty);
 
     if (_frameSync)
       await _waitUntilFrame(() => SchedulerBinding.instance.transientCallbackCount == 0);
@@ -268,10 +268,8 @@ class FlutterDriverExtension {
 
   Future<WaitForResult> _waitFor(Command command) async {
     final WaitFor waitForCommand = command;
-    if ((await _waitForElement(_createFinder(waitForCommand.finder))).evaluate().isNotEmpty)
-      return new WaitForResult();
-    else
-      return null;
+    await _waitForElement(_createFinder(waitForCommand.finder));
+    return new WaitForResult();
   }
 
   Future<WaitForAbsentResult> _waitForAbsent(Command command) async {


### PR DESCRIPTION
Reverts flutter/flutter#11451

This should go back in once we've checked the performance impact of having it reverted.

cc @yjbanov 