### PR TITLE
CupertinoPageRoute cleanup

### DIFF
--- a/packages/flutter/lib/src/material/scaffold.dart
+++ b/packages/flutter/lib/src/material/scaffold.dart
@@ -23,8 +23,6 @@ const double _kFloatingActionButtonMargin = 16.0; // TODO(hmuller): should be de
 const Duration _kFloatingActionButtonSegue = const Duration(milliseconds: 200);
 final Tween<double> _kFloatingActionButtonTurnTween = new Tween<double>(begin: -0.125, end: 0.0);
 
-const double _kBackGestureWidth = 20.0;
-
 enum _ScaffoldSlot {
   body,
   appBar,
@@ -717,40 +715,6 @@ class ScaffoldState extends State<Scaffold> with TickerProviderStateMixin {
     }
   }
 
-  final GlobalKey _backGestureKey = new GlobalKey();
-  NavigationGestureController _backGestureController;
-
-  bool _shouldHandleBackGesture() {
-    assert(mounted);
-    return Theme.of(context).platform == TargetPlatform.iOS && Navigator.canPop(context);
-  }
-
-  void _handleDragStart(DragStartDetails details) {
-    assert(mounted);
-    _backGestureController = Navigator.of(context).startPopGesture();
-  }
-
-  void _handleDragUpdate(DragUpdateDetails details) {
-    assert(mounted);
-    _backGestureController?.dragUpdate(details.primaryDelta / context.size.width);
-  }
-
-  void _handleDragEnd(DragEndDetails details) {
-    assert(mounted);
-    final bool willPop = _backGestureController?.dragEnd(details.velocity.pixelsPerSecond.dx / context.size.width) ?? false;
-    if (willPop)
-      _currentBottomSheet?.close();
-    _backGestureController = null;
-  }
-
-  void _handleDragCancel() {
-    assert(mounted);
-    final bool willPop = _backGestureController?.dragEnd(0.0) ?? false;
-    if (willPop)
-      _currentBottomSheet?.close();
-    _backGestureController = null;
-  }
-
 
   // INTERNALS
 
@@ -885,25 +849,6 @@ class ScaffoldState extends State<Scaffold> with TickerProviderStateMixin {
         child: new DrawerController(
           key: _drawerKey,
           child: widget.drawer,
-        )
-      ));
-    } else if (_shouldHandleBackGesture()) {
-      assert(!hasDrawer);
-      // Add a gesture for navigating back.
-      children.add(new LayoutId(
-        id: _ScaffoldSlot.drawer,
-        child: new Align(
-          alignment: FractionalOffset.centerLeft,
-          child: new GestureDetector(
-            key: _backGestureKey,
-            onHorizontalDragStart: _handleDragStart,
-            onHorizontalDragUpdate: _handleDragUpdate,
-            onHorizontalDragEnd: _handleDragEnd,
-            onHorizontalDragCancel: _handleDragCancel,
-            behavior: HitTestBehavior.translucent,
-            excludeFromSemantics: true,
-            child: new Container(width: _kBackGestureWidth)
-          )
         )
       ));
     }

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -3113,6 +3113,8 @@ abstract class Element extends DiagnosticableTree implements BuildContext {
           'resulting object.\n'
           'The size getter was called for the following element:\n'
           '  $this\n'
+          'The associated render sliver was:\n'
+          '  ${renderObject.toStringShallow("\n  ")}'
         );
       }
       if (renderObject is! RenderBox) {
@@ -3124,10 +3126,12 @@ abstract class Element extends DiagnosticableTree implements BuildContext {
           'and extracting its size manually.\n'
           'The size getter was called for the following element:\n'
           '  $this\n'
+          'The associated render object was:\n'
+          '  ${renderObject.toStringShallow("\n  ")}'
         );
       }
       final RenderBox box = renderObject;
-      if (!box.hasSize || box.debugNeedsLayout) {
+      if (!box.hasSize) {
         throw new FlutterError(
           'Cannot get size from a render object that has not been through layout.\n'
           'The size of this render object has not yet been determined because '
@@ -3137,6 +3141,24 @@ abstract class Element extends DiagnosticableTree implements BuildContext {
           'the size and position of the render objects during layout.\n'
           'The size getter was called for the following element:\n'
           '  $this\n'
+          'The render object from which the size was to be obtained was:\n'
+          '  ${box.toStringShallow("\n  ")}'
+        );
+      }
+      if (box.debugNeedsLayout) {
+        throw new FlutterError(
+          'Cannot get size from a render object that has been marked dirty for layout.\n'
+          'The size of this render object is ambiguous because this render object has '
+          'been modified since it was last laid out, which typically means that the size '
+          'getter was called too early in the pipeline (e.g., during the build phase) '
+          'before the framework has determined the size and position of the render '
+          'objects during layout.\n'
+          'The size getter was called for the following element:\n'
+          '  $this\n'
+          'The render object from which the size was to be obtained was:\n'
+          '  ${box.toStringShallow("\n  ")}\n'
+          'Consider using debugPrintMarkNeedsLayoutStacks to determine why the render '
+          'object in question is dirty, if you did not expect this.'
         );
       }
       return true;

--- a/packages/flutter/lib/src/widgets/pages.dart
+++ b/packages/flutter/lib/src/widgets/pages.dart
@@ -32,10 +32,10 @@ abstract class PageRoute<T> extends ModalRoute<T> {
   bool get barrierDismissible => false;
 
   @override
-  bool canTransitionTo(TransitionRoute<dynamic> nextRoute) => nextRoute is PageRoute<dynamic>;
+  bool canTransitionTo(TransitionRoute<dynamic> nextRoute) => nextRoute is PageRoute;
 
   @override
-  bool canTransitionFrom(TransitionRoute<dynamic> nextRoute) => nextRoute is PageRoute<dynamic>;
+  bool canTransitionFrom(TransitionRoute<dynamic> previousRoute) => previousRoute is PageRoute;
 
   @override
   AnimationController createAnimationController() {

--- a/packages/flutter/test/material/page_test.dart
+++ b/packages/flutter/test/material/page_test.dart
@@ -272,6 +272,73 @@ void main() {
     expect(tester.getTopLeft(find.text('Page 2')), const Offset(100.0, 0.0));
   });
 
+  testWidgets('back gesture while OS changes', (WidgetTester tester) async {
+    final Map<String, WidgetBuilder> routes = <String, WidgetBuilder>{
+      '/': (BuildContext context) => new Material(
+        child: new FlatButton(
+          child: new Text('PUSH'),
+          onPressed: () { Navigator.of(context).pushNamed('/b'); },
+        ),
+      ),
+      '/b': (BuildContext context) => new Container(child: new Text('HELLO')),
+    };
+    await tester.pumpWidget(
+      new MaterialApp(
+        theme: new ThemeData(platform: TargetPlatform.iOS),
+        routes: routes,
+      ),
+    );
+    await tester.tap(find.text('PUSH'));
+    expect(await tester.pumpAndSettle(const Duration(minutes: 1)), 2);
+    expect(find.text('PUSH'), findsNothing);
+    expect(find.text('HELLO'), findsOneWidget);
+    final Offset helloPosition1 = tester.getCenter(find.text('HELLO'));
+    final TestGesture gesture = await tester.startGesture(const Offset(2.5, 300.0));
+    await tester.pump(const Duration(milliseconds: 20));
+    await gesture.moveBy(const Offset(100.0, 0.0));
+    expect(find.text('PUSH'), findsNothing);
+    expect(find.text('HELLO'), findsOneWidget);
+    await tester.pump(const Duration(milliseconds: 20));
+    expect(find.text('PUSH'), findsOneWidget);
+    expect(find.text('HELLO'), findsOneWidget);
+    final Offset helloPosition2 = tester.getCenter(find.text('HELLO'));
+    expect(helloPosition1.dx, lessThan(helloPosition2.dx));
+    expect(helloPosition1.dy, helloPosition2.dy);
+    expect(Theme.of(tester.element(find.text('HELLO'))).platform, TargetPlatform.iOS);
+    await tester.pumpWidget(
+      new MaterialApp(
+        theme: new ThemeData(platform: TargetPlatform.android),
+        routes: routes,
+      ),
+    );
+    // Now we have to let the theme animation run through.
+    // This takes three frames (including the first one above):
+    //  1. Start the Theme animation. It's at t=0 so everything else is identical.
+    //  2. Start any animations that are informed by the Theme, for example, the
+    //     DefaultTextStyle, on the first frame that the theme is not at t=0. In
+    //     this case, it's at t=1.0 of the theme animation, so this is also the
+    //     frame in which the theme animation ends.
+    //  3. End all the other animations.
+    expect(await tester.pumpAndSettle(const Duration(minutes: 1)), 2);
+    expect(Theme.of(tester.element(find.text('HELLO'))).platform, TargetPlatform.android);
+    final Offset helloPosition3 = tester.getCenter(find.text('HELLO'));
+    expect(helloPosition3, helloPosition2);
+    expect(find.text('PUSH'), findsOneWidget);
+    expect(find.text('HELLO'), findsOneWidget);
+    await gesture.moveBy(const Offset(100.0, 0.0));
+    await tester.pump(const Duration(milliseconds: 20));
+    expect(find.text('PUSH'), findsOneWidget);
+    expect(find.text('HELLO'), findsOneWidget);
+    final Offset helloPosition4 = tester.getCenter(find.text('HELLO'));
+    expect(helloPosition3.dx, lessThan(helloPosition4.dx));
+    expect(helloPosition3.dy, helloPosition4.dy);
+    await gesture.moveBy(const Offset(500.0, 0.0));
+    await gesture.up();
+    expect(await tester.pumpAndSettle(const Duration(minutes: 1)), 2);
+    expect(find.text('PUSH'), findsOneWidget);
+    expect(find.text('HELLO'), findsNothing);
+  });
+
   testWidgets('test no back gesture on iOS fullscreen dialogs', (WidgetTester tester) async {
     await tester.pumpWidget(
       new MaterialApp(

--- a/packages/flutter/test/widgets/page_transitions_test.dart
+++ b/packages/flutter/test/widgets/page_transitions_test.dart
@@ -268,24 +268,39 @@ void main() {
     expect(find.text('Home'), findsNothing);
     expect(find.text('Sheet'), isOnstage);
 
+    // Drag from left edge to invoke the gesture. We should go back.
+    TestGesture gesture = await tester.startGesture(const Offset(5.0, 100.0));
+    await gesture.moveBy(const Offset(500.0, 0.0));
+    await gesture.up();
+    await tester.pump();
+    await tester.pump(const Duration(seconds: 1));
+
+    Navigator.pushNamed(containerKey1.currentContext, '/sheet');
+
+    await tester.pump();
+    await tester.pump(const Duration(seconds: 1));
+
+    expect(find.text('Home'), findsNothing);
+    expect(find.text('Sheet'), isOnstage);
+
     // Show the bottom sheet.
     final PersistentBottomSheetTestState sheet = containerKey2.currentState;
     sheet.showBottomSheet();
 
     await tester.pump(const Duration(seconds: 1));
 
-    // Drag from left edge to invoke the gesture.
-    final TestGesture gesture = await tester.startGesture(const Offset(5.0, 100.0));
+    // Drag from left edge to invoke the gesture. Nothing should happen.
+    gesture = await tester.startGesture(const Offset(5.0, 100.0));
     await gesture.moveBy(const Offset(500.0, 0.0));
     await gesture.up();
     await tester.pump();
     await tester.pump(const Duration(seconds: 1));
 
-    expect(find.text('Home'), isOnstage);
-    expect(find.text('Sheet'), findsNothing);
+    expect(find.text('Home'), findsNothing);
+    expect(find.text('Sheet'), isOnstage);
 
-    // Sheet called setState and didn't crash.
-    expect(sheet.setStateCalled, isTrue);
+    // Sheet did not call setState (since the gesture did nothing).
+    expect(sheet.setStateCalled, isFalse);
   });
 
   testWidgets('Test completed future', (WidgetTester tester) async {


### PR DESCRIPTION
This moves the CupertinoPageRoute logic from the Scaffold to the CupertinoPageRoute.
Also cleans up some dubious code like a destructor that didn't call its superclass destructor in some cases.
Also, it makes sure that if you change operating systems during a swipe, we don't switch to the other operating system's conventions for transitions until after the gesture/transition is over.

cc @xster for review