### PR TITLE
Avoid building x86 jar for profile and release modes

### DIFF
--- a/packages/flutter_tools/gradle/flutter.gradle
+++ b/packages/flutter_tools/gradle/flutter.gradle
@@ -222,14 +222,14 @@ class FlutterPlugin implements Plugin<Project> {
         }
 
         project.android.applicationVariants.all { variant ->
-            if (project.tasks.findByName('flutterBuildX86Jar')) {
+            String flutterBuildMode = buildModeFor(variant.buildType)
+            if (flutterBuildMode == 'debug' && project.tasks.findByName('flutterBuildX86Jar')) {
                 Task task = project.tasks.findByName("compile${variant.name.capitalize()}JavaWithJavac")
                 if (task) {
                     task.dependsOn project.flutterBuildX86Jar
                 }
             }
 
-            String flutterBuildMode = buildModeFor(variant.buildType)
             GenerateDependencies dependenciesTask = project.tasks.create(name: "flutterDependencies${variant.name.capitalize()}", type: GenerateDependencies) {
                 flutterRoot this.flutterRoot
                 flutterExecutable this.flutterExecutable


### PR DESCRIPTION
Fix of regression in build performance on Android: x86 jar was built also for profile and release where it is not needed.

Cf https://github.com/flutter/flutter/pull/11354#issuecomment-319503922