### PR TITLE
Do not schedule animation if already at the target value

### DIFF
--- a/packages/flutter/lib/src/animation/animation_controller.dart
+++ b/packages/flutter/lib/src/animation/animation_controller.dart
@@ -38,10 +38,6 @@ const Tolerance _kFlingTolerance = const Tolerance(
   distance: 0.01,
 );
 
-/// Don't start the animation if the target value is within this tolerance of
-/// the current value.
-const Tolerance _kAnimateToTolerance = const Tolerance();
-
 /// A controller for an animation.
 ///
 /// This class lets you perform tasks such as:
@@ -339,14 +335,9 @@ class AnimationController extends Animation<double>
       final double range = upperBound - lowerBound;
       final double remainingFraction = range.isFinite ? (target - _value).abs() / range : 1.0;
       simulationDuration = this.duration * remainingFraction;
-    } else if (target < _value + _kAnimateToTolerance.distance && target > _value - _kAnimateToTolerance.distance) {
-      // We are basically at the target, don't animate.
+    } else if (target == value) {
+      // Already at target, don't animate.
       simulationDuration = Duration.ZERO;
-      if (target != _value) {
-        _internalSetValue(target);
-        notifyListeners();
-        target = _value;
-      }
     }
     stop();
     if (simulationDuration == Duration.ZERO) {

--- a/packages/flutter/lib/src/animation/animation_controller.dart
+++ b/packages/flutter/lib/src/animation/animation_controller.dart
@@ -38,6 +38,10 @@ const Tolerance _kFlingTolerance = const Tolerance(
   distance: 0.01,
 );
 
+/// Don't start the animation if the target value is within this tolerance of
+/// the current value.
+const Tolerance _kAnimateToTolerance = const Tolerance();
+
 /// A controller for an animation.
 ///
 /// This class lets you perform tasks such as:
@@ -335,6 +339,14 @@ class AnimationController extends Animation<double>
       final double range = upperBound - lowerBound;
       final double remainingFraction = range.isFinite ? (target - _value).abs() / range : 1.0;
       simulationDuration = this.duration * remainingFraction;
+    } else if (target < _value + _kAnimateToTolerance.distance && target > _value - _kAnimateToTolerance.distance) {
+      // We are basically at the target, don't animate.
+      simulationDuration = Duration.ZERO;
+      if (target != _value) {
+        _internalSetValue(target);
+        notifyListeners();
+        target = _value;
+      }
     }
     stop();
     if (simulationDuration == Duration.ZERO) {

--- a/packages/flutter/lib/src/cupertino/button.dart
+++ b/packages/flutter/lib/src/cupertino/button.dart
@@ -112,11 +112,10 @@ class CupertinoButton extends StatefulWidget {
 class _CupertinoButtonState extends State<CupertinoButton> with SingleTickerProviderStateMixin {
   // Eyeballed values. Feel free to tweak.
   static const Duration kFadeOutDuration = const Duration(milliseconds: 10);
-  static const Duration kFadeInDuration = const Duration(milliseconds: 350);
+  static const Duration kFadeInDuration = const Duration(milliseconds: 100);
   Tween<double> _opacityTween;
 
   AnimationController _animationController;
-  TickerFuture _lastAnimation;
 
   void _setTween() {
     _opacityTween = new Tween<double>(
@@ -149,19 +148,39 @@ class _CupertinoButtonState extends State<CupertinoButton> with SingleTickerProv
     _setTween();
   }
 
-  Future<Null> _handleTapDown(PointerDownEvent event) async {
-    await _lastAnimation;
-    _lastAnimation = _animationController.animateTo(1.0, duration: kFadeOutDuration);
+  bool _buttonHeldDown = false;
+
+  void _handleTapDown(PointerDownEvent event) {
+    if (!_buttonHeldDown) {
+      _buttonHeldDown = true;
+      _animate();
+    }
   }
 
-  Future<Null> _handleTapUp(PointerUpEvent event) async {
-    await _lastAnimation;
-    _lastAnimation = _animationController.animateTo(0.0, duration: kFadeInDuration);
+  void _handleTapUp(PointerUpEvent event) {
+    if (_buttonHeldDown) {
+      _buttonHeldDown = false;
+      _animate();
+    }
   }
 
-  Future<Null>  _handleTapCancel(PointerCancelEvent event) async {
-    await _lastAnimation;
-    _lastAnimation = _animationController.animateTo(0.0, duration: kFadeInDuration);
+  void _handleTapCancel(PointerCancelEvent event) {
+    if (_buttonHeldDown) {
+      _buttonHeldDown = false;
+      _animate();
+    }
+  }
+
+  Future<Null> _animate() async {
+    if (!_animationController.isAnimating) {
+      final bool wasHeldDown = _buttonHeldDown;
+      if (_buttonHeldDown)
+        await _animationController.animateTo(1.0, duration: kFadeOutDuration);
+      else
+        await _animationController.animateTo(0.0, duration: kFadeInDuration);
+      if (mounted && wasHeldDown != _buttonHeldDown)
+        _animate();
+    }
   }
 
   @override

--- a/packages/flutter/lib/src/cupertino/button.dart
+++ b/packages/flutter/lib/src/cupertino/button.dart
@@ -150,21 +150,21 @@ class _CupertinoButtonState extends State<CupertinoButton> with SingleTickerProv
 
   bool _buttonHeldDown = false;
 
-  void _handleTapDown(PointerDownEvent event) {
+  void _handleTapDown(TapDownDetails event) {
     if (!_buttonHeldDown) {
       _buttonHeldDown = true;
       _animate();
     }
   }
 
-  void _handleTapUp(PointerUpEvent event) {
+  void _handleTapUp(TapUpDetails event) {
     if (_buttonHeldDown) {
       _buttonHeldDown = false;
       _animate();
     }
   }
 
-  void _handleTapCancel(PointerCancelEvent event) {
+  void _handleTapCancel() {
     if (_buttonHeldDown) {
       _buttonHeldDown = false;
       _animate();
@@ -188,46 +188,44 @@ class _CupertinoButtonState extends State<CupertinoButton> with SingleTickerProv
     final bool enabled = widget.enabled;
     final Color backgroundColor = widget.color;
 
-    return new Listener(
-      onPointerDown: enabled ? _handleTapDown : null,
-      onPointerUp: enabled ? _handleTapUp : null,
-      onPointerCancel: enabled ? _handleTapCancel : null,
-      child: new GestureDetector(
-        onTap: widget.onPressed,
-        child: new ConstrainedBox(
-          constraints: widget.minSize == null
-              ? const BoxConstraints()
-              : new BoxConstraints(
-                minWidth: widget.minSize,
-                minHeight: widget.minSize,
-              ),
-          child: new FadeTransition(
-            opacity: _opacityTween.animate(new CurvedAnimation(
-              parent: _animationController,
-              curve: Curves.decelerate,
-            )),
-            child: new DecoratedBox(
-              decoration: new BoxDecoration(
-                borderRadius: widget.borderRadius,
-                color: backgroundColor != null && !enabled
-                    ? _kDisabledBackground
-                    : backgroundColor,
-              ),
-              child: new Padding(
-                padding: widget.padding ?? (backgroundColor != null
-                  ? _kBackgroundButtonPadding
-                  : _kButtonPadding),
-                child: new Center(
-                  widthFactor: 1.0,
-                  heightFactor: 1.0,
-                  child: new DefaultTextStyle(
-                    style: backgroundColor != null
-                        ? _kBackgroundButtonTextStyle
-                        : enabled
-                            ? _kButtonTextStyle
-                            : _kDisabledButtonTextStyle,
-                    child: widget.child,
-                  ),
+    return new GestureDetector(
+      onTapDown: enabled ? _handleTapDown : null,
+      onTapUp: enabled ? _handleTapUp : null,
+      onTapCancel: enabled ? _handleTapCancel : null,
+      onTap: widget.onPressed,
+      child: new ConstrainedBox(
+        constraints: widget.minSize == null
+            ? const BoxConstraints()
+            : new BoxConstraints(
+              minWidth: widget.minSize,
+              minHeight: widget.minSize,
+            ),
+        child: new FadeTransition(
+          opacity: _opacityTween.animate(new CurvedAnimation(
+            parent: _animationController,
+            curve: Curves.decelerate,
+          )),
+          child: new DecoratedBox(
+            decoration: new BoxDecoration(
+              borderRadius: widget.borderRadius,
+              color: backgroundColor != null && !enabled
+                  ? _kDisabledBackground
+                  : backgroundColor,
+            ),
+            child: new Padding(
+              padding: widget.padding ?? (backgroundColor != null
+                ? _kBackgroundButtonPadding
+                : _kButtonPadding),
+              child: new Center(
+                widthFactor: 1.0,
+                heightFactor: 1.0,
+                child: new DefaultTextStyle(
+                  style: backgroundColor != null
+                      ? _kBackgroundButtonTextStyle
+                      : enabled
+                          ? _kButtonTextStyle
+                          : _kDisabledButtonTextStyle,
+                  child: widget.child,
                 ),
               ),
             ),

--- a/packages/flutter/lib/src/cupertino/button.dart
+++ b/packages/flutter/lib/src/cupertino/button.dart
@@ -171,16 +171,17 @@ class _CupertinoButtonState extends State<CupertinoButton> with SingleTickerProv
     }
   }
 
-  Future<Null> _animate() async {
-    if (!_animationController.isAnimating) {
-      final bool wasHeldDown = _buttonHeldDown;
-      if (_buttonHeldDown)
-        await _animationController.animateTo(1.0, duration: kFadeOutDuration);
-      else
-        await _animationController.animateTo(0.0, duration: kFadeInDuration);
+  void _animate() {
+    if (_animationController.isAnimating)
+      return;
+    final bool wasHeldDown = _buttonHeldDown;
+    final Future<Null> ticker = _buttonHeldDown
+        ? _animationController.animateTo(1.0, duration: kFadeOutDuration)
+        : _animationController.animateTo(0.0, duration: kFadeInDuration);
+    ticker.then((Null value) {
       if (mounted && wasHeldDown != _buttonHeldDown)
         _animate();
-    }
+    });
   }
 
   @override

--- a/packages/flutter/lib/src/cupertino/button.dart
+++ b/packages/flutter/lib/src/cupertino/button.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:async';
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 
@@ -114,6 +116,7 @@ class _CupertinoButtonState extends State<CupertinoButton> with SingleTickerProv
   Tween<double> _opacityTween;
 
   AnimationController _animationController;
+  TickerFuture _lastAnimation;
 
   void _setTween() {
     _opacityTween = new Tween<double>(
@@ -146,16 +149,19 @@ class _CupertinoButtonState extends State<CupertinoButton> with SingleTickerProv
     _setTween();
   }
 
-  void _handleTapDown(PointerDownEvent event) {
-    _animationController.animateTo(1.0, duration: kFadeOutDuration);
+  Future<Null> _handleTapDown(PointerDownEvent event) async {
+    await _lastAnimation;
+    _lastAnimation = _animationController.animateTo(1.0, duration: kFadeOutDuration);
   }
 
-  void _handleTapUp(PointerUpEvent event) {
-    _animationController.animateTo(0.0, duration: kFadeInDuration);
+  Future<Null> _handleTapUp(PointerUpEvent event) async {
+    await _lastAnimation;
+    _lastAnimation = _animationController.animateTo(0.0, duration: kFadeInDuration);
   }
 
-  void _handleTapCancel(PointerCancelEvent event) {
-    _animationController.animateTo(0.0, duration: kFadeInDuration);
+  Future<Null>  _handleTapCancel(PointerCancelEvent event) async {
+    await _lastAnimation;
+    _lastAnimation = _animationController.animateTo(0.0, duration: kFadeInDuration);
   }
 
   @override

--- a/packages/flutter/lib/src/widgets/scroll_position_with_single_context.dart
+++ b/packages/flutter/lib/src/widgets/scroll_position_with_single_context.dart
@@ -174,6 +174,12 @@ class ScrollPositionWithSingleContext extends ScrollPosition implements ScrollAc
     @required Duration duration,
     @required Curve curve,
   }) {
+    if (nearEqual(to, pixels, physics.tolerance.distance)) {
+      // Skip the animation, go straight to the position as we are already close.
+      jumpTo(to);
+      return new Future<Null>.value();
+    }
+
     final DrivenScrollActivity activity = new DrivenScrollActivity(
       this,
       from: pixels,

--- a/packages/flutter/test/animation/animation_controller_test.dart
+++ b/packages/flutter/test/animation/animation_controller_test.dart
@@ -292,4 +292,30 @@ void main() {
     expect((){ controller.repeat(period: null); }, throwsFlutterError);
   });
 
+  test('Do not animate if already at target', () {
+    final List<AnimationStatus> statusLog = <AnimationStatus>[];
+
+    final AnimationController controller = new AnimationController(
+      value: 0.5,
+      vsync: const TestVSync(),
+    )..addStatusListener(statusLog.add);
+
+    controller.animateTo(0.5, duration: const Duration(milliseconds: 100),);
+    expect(statusLog, equals(<AnimationStatus>[ AnimationStatus.completed ]));
+    expect(controller.value, equals(0.5));
+  });
+
+  test('Do not animate if already at target within tolerance', () {
+    final List<AnimationStatus> statusLog = <AnimationStatus>[];
+
+    final AnimationController controller = new AnimationController(
+      value: 0.5,
+      vsync: const TestVSync(),
+    )..addStatusListener(statusLog.add);
+
+    controller.animateTo(0.5001, duration: const Duration(milliseconds: 100),);
+    expect(statusLog, equals(<AnimationStatus>[ AnimationStatus.completed ]));
+    expect(controller.value, equals(0.5001));
+  });
+
 }

--- a/packages/flutter/test/animation/animation_controller_test.dart
+++ b/packages/flutter/test/animation/animation_controller_test.dart
@@ -305,17 +305,4 @@ void main() {
     expect(controller.value, equals(0.5));
   });
 
-  test('Do not animate if already at target within tolerance', () {
-    final List<AnimationStatus> statusLog = <AnimationStatus>[];
-
-    final AnimationController controller = new AnimationController(
-      value: 0.5,
-      vsync: const TestVSync(),
-    )..addStatusListener(statusLog.add);
-
-    controller.animateTo(0.5001, duration: const Duration(milliseconds: 100),);
-    expect(statusLog, equals(<AnimationStatus>[ AnimationStatus.completed ]));
-    expect(controller.value, equals(0.5001));
-  });
-
 }

--- a/packages/flutter/test/animation/animation_controller_test.dart
+++ b/packages/flutter/test/animation/animation_controller_test.dart
@@ -354,7 +354,7 @@ void main() {
     expect(controller.value, inInclusiveRange(0.4, 0.6));
     expect(statusLog, equals(<AnimationStatus>[ AnimationStatus.forward ]));
 
-    double currentValue = controller.value;
+    final double currentValue = controller.value;
     controller.animateTo(currentValue, duration: const Duration(milliseconds: 100));
     expect(statusLog, equals(<AnimationStatus>[ AnimationStatus.forward, AnimationStatus.completed ]));
     expect(controller.value, currentValue);
@@ -376,7 +376,7 @@ void main() {
     expect(controller.value, inInclusiveRange(0.4, 0.6));
     expect(statusLog, equals(<AnimationStatus>[ AnimationStatus.reverse ]));
 
-    double currentValue = controller.value;
+    final double currentValue = controller.value;
     controller.animateTo(currentValue, duration: const Duration(milliseconds: 100));
     expect(statusLog, equals(<AnimationStatus>[ AnimationStatus.reverse, AnimationStatus.dismissed ]));
     expect(controller.value, currentValue);

--- a/packages/flutter/test/animation/animation_controller_test.dart
+++ b/packages/flutter/test/animation/animation_controller_test.dart
@@ -311,6 +311,8 @@ void main() {
 
     final AnimationController controller = new AnimationController(
       value: 1.0,
+      upperBound: 1.0,
+      lowerBound: 0.0,
       vsync: const TestVSync(),
     )..addStatusListener(statusLog.add);
 
@@ -325,6 +327,8 @@ void main() {
 
     final AnimationController controller = new AnimationController(
       value: 0.0,
+      upperBound: 1.0,
+      lowerBound: 0.0,
       vsync: const TestVSync(),
     )..addStatusListener(statusLog.add);
 

--- a/packages/flutter/test/widgets/scrollable_animations_test.dart
+++ b/packages/flutter/test/widgets/scrollable_animations_test.dart
@@ -1,0 +1,72 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter/scheduler.dart';
+import 'package:flutter/widgets.dart';
+
+void main() {
+  testWidgets('Does not animate if already at target position', (WidgetTester tester) async {
+    final List<Widget> textWidgets = <Widget>[];
+    for (int i = 0; i < 80; i++)
+      textWidgets.add(new Text('$i'));
+    final ScrollController controller = new ScrollController();
+    await tester.pumpWidget(new ListView(
+      children: textWidgets,
+      controller: controller,
+    ));
+
+    expectNoAnimation();
+    final double currentPosition = controller.position.pixels;
+    controller.position.animateTo(currentPosition, duration: const Duration(seconds: 10), curve: Curves.linear);
+
+    expectNoAnimation();
+    expect(controller.position.pixels, currentPosition);
+  });
+
+  testWidgets('Does not animate if already at target position within tolerance', (WidgetTester tester) async {
+    final List<Widget> textWidgets = <Widget>[];
+    for (int i = 0; i < 80; i++)
+      textWidgets.add(new Text('$i'));
+    final ScrollController controller = new ScrollController();
+    await tester.pumpWidget(new ListView(
+      children: textWidgets,
+      controller: controller,
+    ));
+
+    expectNoAnimation();
+
+    final double halfTolerance = controller.position.physics.tolerance.distance / 2;
+    expect(halfTolerance, isNonZero);
+    final double targetPosition = controller.position.pixels + halfTolerance;
+    controller.position.animateTo(targetPosition, duration: const Duration(seconds: 10), curve: Curves.linear);
+
+    expectNoAnimation();
+    expect(controller.position.pixels, targetPosition);
+  });
+
+  testWidgets('Animates if going to a position outside of tolerance', (WidgetTester tester) async {
+    final List<Widget> textWidgets = <Widget>[];
+    for (int i = 0; i < 80; i++)
+      textWidgets.add(new Text('$i'));
+    final ScrollController controller = new ScrollController();
+    await tester.pumpWidget(new ListView(
+      children: textWidgets,
+      controller: controller,
+    ));
+
+    expectNoAnimation();
+
+    final double doubleTolerance = controller.position.physics.tolerance.distance * 2;
+    expect(doubleTolerance, isNonZero);
+    final double targetPosition = controller.position.pixels + doubleTolerance;
+    controller.position.animateTo(targetPosition, duration: const Duration(seconds: 10), curve: Curves.linear);
+
+    expect(SchedulerBinding.instance.transientCallbackCount, equals(1), reason: 'Expected an animation.');
+  });
+}
+
+void expectNoAnimation() {
+  expect(SchedulerBinding.instance.transientCallbackCount, equals(0), reason: 'Expected no animation.');
+}


### PR DESCRIPTION
* Partially fixes https://github.com/flutter/flutter/issues/11495.
* Also includes a fix for Cupertino button to always run the tap animation even if the finger is immediately lifted from the screen (uncovered by a test failure).