### PR TITLE
Pin the test package at version 0.12.20+11

### DIFF
--- a/dev/devicelab/pubspec.yaml
+++ b/dev/devicelab/pubspec.yaml
@@ -20,4 +20,4 @@ dependencies:
 
 dev_dependencies:
   # See packages/flutter_test/pubspec.yaml for why we're pinning this version.
-  test: 0.12.21
+  test: 0.12.20+11

--- a/packages/flutter_driver/pubspec.yaml
+++ b/packages/flutter_driver/pubspec.yaml
@@ -21,6 +21,6 @@ dependencies:
     sdk: flutter
 
 dev_dependencies:
-  test: 0.12.21
+  test: 0.12.20+11
   mockito: ^2.0.2
   quiver: ^0.24.0

--- a/packages/flutter_test/pubspec.yaml
+++ b/packages/flutter_test/pubspec.yaml
@@ -4,7 +4,7 @@ dependencies:
   # The flutter tools depend on very specific internal implementation
   # details of the 'test' package, which change between versions, so
   # here we pin it precisely to avoid version skew across our packages.
-  test: 0.12.21
+  test: 0.12.20+11
 
   # We use FakeAsync and other testing utilities.
   quiver: ^0.24.0

--- a/packages/flutter_tools/pubspec.yaml
+++ b/packages/flutter_tools/pubspec.yaml
@@ -36,7 +36,7 @@ dependencies:
   # We depend on very specific internal implementation details of the
   # 'test' package, which change between versions, so here we pin it
   # precisely.
-  test: 0.12.21
+  test: 0.12.20+11
 
   # Version from the vended Dart SDK as defined in `dependency_overrides`.
   analyzer: any


### PR DESCRIPTION
In a Travis environment, the test package is exiting the process after
completing the tests.
See https://github.com/dart-lang/test/commit/d1057c4d42a760a6b3fdfa145c7aa694c90f1242

The flutter test command calls the test package's main() and then expects to
do other work afterward.  To get proper results on Travis (such as uploading
code coverage data) we need a way to disable the exit.