### PR TITLE
Disable the coverage shard in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,11 @@ install:
 env:
   - SHARD=analyze
   - SHARD=tests
-  - SHARD=coverage
+  # Temporarily disable the coverage shard.  The test package is exiting
+  # the process after tests run, preventing the flutter test command from
+  # writing coverage results.
+  # TODO(jsimmons): reenable coverage when a new test package is available.
+  # - SHARD=coverage
   - SHARD=docs
 before_script:
   - ./dev/bots/travis_setup.sh


### PR DESCRIPTION
In a Travis environment, the test package is exiting the process after
completing the tests.
See dart-lang/test@d1057c4

The flutter test command calls the test package's main() and then expects to
do other work afterward.  The exit prevents flutter test from writing the
new coverage results, causing the coveralls tool to run against an old
lcov.info file.