### PR TITLE
Allow Duration.Zero for animateTo without assertion failure

### DIFF
--- a/packages/flutter/lib/src/animation/animation_controller.dart
+++ b/packages/flutter/lib/src/animation/animation_controller.dart
@@ -341,7 +341,10 @@ class AnimationController extends Animation<double>
     }
     stop();
     if (simulationDuration == Duration.ZERO) {
-      assert(value == target);
+      if (value != target) {
+        _value = target.clamp(lowerBound, upperBound);
+        notifyListeners();
+      }
       _status = (_direction == _AnimationDirection.forward) ?
         AnimationStatus.completed :
         AnimationStatus.dismissed;

--- a/packages/flutter/test/animation/animation_controller_test.dart
+++ b/packages/flutter/test/animation/animation_controller_test.dart
@@ -6,6 +6,7 @@ import 'dart:ui' as ui;
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/animation.dart';
+import 'package:flutter/scheduler.dart';
 import 'package:flutter/widgets.dart';
 
 import '../scheduler/scheduler_tester.dart';
@@ -380,5 +381,18 @@ void main() {
     controller.animateTo(currentValue, duration: const Duration(milliseconds: 100));
     expect(statusLog, equals(<AnimationStatus>[ AnimationStatus.reverse, AnimationStatus.dismissed ]));
     expect(controller.value, currentValue);
+  });
+
+  test('animateTo can deal with duration == Duration.ZERO', () {
+    final AnimationController controller = new AnimationController(
+      duration: const Duration(milliseconds: 100),
+      vsync: const TestVSync(),
+    );
+
+    controller.forward(from: 0.2);
+    expect(controller.value, 0.2);
+    controller.animateTo(1.0, duration: Duration.ZERO);
+    expect(SchedulerBinding.instance.transientCallbackCount, equals(0), reason: 'Expected no animation.');
+    expect(controller.value, 1.0);
   });
 }


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/11445

@Hixie @yjbanov @bramvbilsen