### PR TITLE
Adding tests for animationStatus

### DIFF
--- a/packages/flutter/lib/src/animation/animation_controller.dart
+++ b/packages/flutter/lib/src/animation/animation_controller.dart
@@ -274,10 +274,6 @@ class AnimationController extends Animation<double>
   /// During the animation, [status] is reported as [AnimationStatus.forward],
   /// which switches to [AnimationStatus.completed] when [upperBound] is
   /// reached at the end of the animation.
-  ///
-  /// You should not call [forward] or [reverse] on the same instance of an
-  /// [AnimationController] on which you also call [animateTo]. If you do mix
-  /// those calls, [status] might not have the expected value.
   TickerFuture forward({ double from }) {
     assert(() {
       if (duration == null) {
@@ -306,10 +302,6 @@ class AnimationController extends Animation<double>
   /// During the animation, [status] is reported as [AnimationStatus.reverse],
   /// which switches to [AnimationStatus.dismissed] when [lowerBound] is
   /// reached at the end of the animation.
-  ///
-  /// You should not call [forward] or [reverse] on the same instance of an
-  /// [AnimationController] on which you also call [animateTo]. If you do mix
-  /// those calls, [status] might not have the expected value.
   TickerFuture reverse({ double from }) {
     assert(() {
       if (duration == null) {
@@ -339,10 +331,6 @@ class AnimationController extends Animation<double>
   /// regardless of whether `target` > [value] or not. At the end of the
   /// animation, when `target` is reached, [status] is reported as
   /// [AnimationStatus.completed].
-  ///
-  /// You should not call [forward] or [reverse] on the same instance of an
-  /// [AnimationController] on which you also call [animateTo]. If you do mix
-  /// those calls, [status] might not have the expected value.
   TickerFuture animateTo(double target, { Duration duration, Curve curve: Curves.linear }) {
     _direction = _AnimationDirection.forward;
     return _animateToInternal(target, duration: duration, curve: curve);

--- a/packages/flutter/lib/src/animation/animation_controller.dart
+++ b/packages/flutter/lib/src/animation/animation_controller.dart
@@ -274,6 +274,10 @@ class AnimationController extends Animation<double>
   /// During the animation, [status] is reported as [AnimationStatus.forward],
   /// which switches to [AnimationStatus.completed] when [upperBound] is
   /// reached at the end of the animation.
+  ///
+  /// You should not call [forward] or [reverse] on the same instance of an
+  /// [AnimationController] on which you also call [animateTo]. If you do mix
+  /// those calls, [status] might not have the expected value.
   TickerFuture forward({ double from }) {
     assert(() {
       if (duration == null) {
@@ -302,6 +306,10 @@ class AnimationController extends Animation<double>
   /// During the animation, [status] is reported as [AnimationStatus.reverse],
   /// which switches to [AnimationStatus.dismissed] when [lowerBound] is
   /// reached at the end of the animation.
+  ///
+  /// You should not call [forward] or [reverse] on the same instance of an
+  /// [AnimationController] on which you also call [animateTo]. If you do mix
+  /// those calls, [status] might not have the expected value.
   TickerFuture reverse({ double from }) {
     assert(() {
       if (duration == null) {
@@ -331,6 +339,10 @@ class AnimationController extends Animation<double>
   /// regardless of whether `target` > [value] or not. At the end of the
   /// animation, when `target` is reached, [status] is reported as
   /// [AnimationStatus.completed].
+  ///
+  /// You should not call [forward] or [reverse] on the same instance of an
+  /// [AnimationController] on which you also call [animateTo]. If you do mix
+  /// those calls, [status] might not have the expected value.
   TickerFuture animateTo(double target, { Duration duration, Curve curve: Curves.linear }) {
     _direction = _AnimationDirection.forward;
     return _animateToInternal(target, duration: duration, curve: curve);

--- a/packages/flutter/lib/src/animation/animation_controller.dart
+++ b/packages/flutter/lib/src/animation/animation_controller.dart
@@ -270,6 +270,10 @@ class AnimationController extends Animation<double>
   /// The most recently returned [TickerFuture], if any, is marked as having been
   /// canceled, meaning the future never completes and its [TickerFuture.orCancel]
   /// derivative future completes with a [TickerCanceled] error.
+  ///
+  /// During the animation, [status] is reported as [AnimationStatus.forward],
+  /// which switches to [AnimationStatus.completed] when [upperBound] is
+  /// reached at the end of the animation.
   TickerFuture forward({ double from }) {
     assert(() {
       if (duration == null) {
@@ -284,7 +288,7 @@ class AnimationController extends Animation<double>
     _direction = _AnimationDirection.forward;
     if (from != null)
       value = from;
-    return animateTo(upperBound);
+    return _animateToInternal(upperBound);
   }
 
   /// Starts running this animation in reverse (towards the beginning).
@@ -294,6 +298,10 @@ class AnimationController extends Animation<double>
   /// The most recently returned [TickerFuture], if any, is marked as having been
   /// canceled, meaning the future never completes and its [TickerFuture.orCancel]
   /// derivative future completes with a [TickerCanceled] error.
+  ///
+  /// During the animation, [status] is reported as [AnimationStatus.reverse],
+  /// which switches to [AnimationStatus.dismissed] when [lowerBound] is
+  /// reached at the end of the animation.
   TickerFuture reverse({ double from }) {
     assert(() {
       if (duration == null) {
@@ -308,7 +316,7 @@ class AnimationController extends Animation<double>
     _direction = _AnimationDirection.reverse;
     if (from != null)
       value = from;
-    return animateTo(lowerBound);
+    return _animateToInternal(lowerBound);
   }
 
   /// Drives the animation from its current value to target.
@@ -318,7 +326,17 @@ class AnimationController extends Animation<double>
   /// The most recently returned [TickerFuture], if any, is marked as having been
   /// canceled, meaning the future never completes and its [TickerFuture.orCancel]
   /// derivative future completes with a [TickerCanceled] error.
+  ///
+  /// During the animation, [status] is reported as [AnimationStatus.forward]
+  /// regardless of whether `target` > [value] or not. At the end of the
+  /// animation, when `target` is reached, [status] is reported as
+  /// [AnimationStatus.completed].
   TickerFuture animateTo(double target, { Duration duration, Curve curve: Curves.linear }) {
+    _direction = _AnimationDirection.forward;
+    return _animateToInternal(target, duration: duration, curve: curve);
+  }
+
+  TickerFuture _animateToInternal(double target, { Duration duration, Curve curve: Curves.linear }) {
     Duration simulationDuration = duration;
     if (simulationDuration == null) {
       assert(() {

--- a/packages/flutter/test/animation/animation_controller_test.dart
+++ b/packages/flutter/test/animation/animation_controller_test.dart
@@ -469,4 +469,60 @@ void main() {
     expect(statusLog, equals(<AnimationStatus>[ AnimationStatus.forward, AnimationStatus.completed ]));
     statusLog.clear();
   });
+
+  test('after a reverse call animateTo sets correct status', () {
+    final List<AnimationStatus> statusLog = <AnimationStatus>[];
+    final AnimationController controller = new AnimationController(
+      duration: const Duration(milliseconds: 100),
+      value: 1.0,
+      lowerBound: 0.0,
+      upperBound: 1.0,
+      vsync: const TestVSync(),
+    )..addStatusListener(statusLog.add);
+
+    expect(controller.value, 1.0);
+    expect(controller.status, AnimationStatus.completed);
+
+    controller.reverse();
+    tick(const Duration(milliseconds: 0));
+    tick(const Duration(milliseconds: 150));
+    expect(controller.value, 0.0);
+    expect(statusLog, equals(<AnimationStatus>[ AnimationStatus.reverse, AnimationStatus.dismissed ]));
+    statusLog.clear();
+
+    controller.animateTo(0.5);
+    tick(const Duration(milliseconds: 0));
+    tick(const Duration(milliseconds: 150));
+    expect(controller.value, 0.5);
+    expect(statusLog, equals(<AnimationStatus>[ AnimationStatus.forward, AnimationStatus.completed ]));
+    statusLog.clear();
+  });
+
+  test('after a forward call animateTo sets correct status', () {
+    final List<AnimationStatus> statusLog = <AnimationStatus>[];
+    final AnimationController controller = new AnimationController(
+      duration: const Duration(milliseconds: 100),
+      value: 0.0,
+      lowerBound: 0.0,
+      upperBound: 1.0,
+      vsync: const TestVSync(),
+    )..addStatusListener(statusLog.add);
+
+    expect(controller.value, 0.0);
+    expect(controller.status, AnimationStatus.dismissed);
+
+    controller.forward();
+    tick(const Duration(milliseconds: 0));
+    tick(const Duration(milliseconds: 150));
+    expect(controller.value, 1.0);
+    expect(statusLog, equals(<AnimationStatus>[ AnimationStatus.forward, AnimationStatus.completed ]));
+    statusLog.clear();
+
+    controller.animateTo(0.5);
+    tick(const Duration(milliseconds: 0));
+    tick(const Duration(milliseconds: 150));
+    expect(controller.value, 0.5);
+    expect(statusLog, equals(<AnimationStatus>[ AnimationStatus.forward, AnimationStatus.completed ]));
+    statusLog.clear();
+  });
 }

--- a/packages/flutter/test/animation/animation_controller_test.dart
+++ b/packages/flutter/test/animation/animation_controller_test.dart
@@ -395,4 +395,78 @@ void main() {
     expect(SchedulerBinding.instance.transientCallbackCount, equals(0), reason: 'Expected no animation.');
     expect(controller.value, 1.0);
   });
+
+  test('setting value directly sets correct status', () {
+    final AnimationController controller = new AnimationController(
+      value: 0.0,
+      lowerBound: 0.0,
+      upperBound: 1.0,
+      vsync: const TestVSync(),
+    );
+
+    expect(controller.value, 0.0);
+    expect(controller.status, AnimationStatus.dismissed);
+
+    controller.value = 0.5;
+    expect(controller.value, 0.5);
+    expect(controller.status, AnimationStatus.forward);
+
+    controller.value = 1.0;
+    expect(controller.value, 1.0);
+    expect(controller.status, AnimationStatus.completed);
+
+    controller.value = 0.5;
+    expect(controller.value, 0.5);
+    expect(controller.status, AnimationStatus.forward); // ???
+
+    controller.value = 0.0;
+    expect(controller.value, 0.0);
+    expect(controller.status, AnimationStatus.dismissed);
+  });
+
+  test('animateTo sets correct status', () {
+    final List<AnimationStatus> statusLog = <AnimationStatus>[];
+    final AnimationController controller = new AnimationController(
+      duration: const Duration(milliseconds: 100),
+      value: 0.0,
+      lowerBound: 0.0,
+      upperBound: 1.0,
+      vsync: const TestVSync(),
+    )..addStatusListener(statusLog.add);
+
+    expect(controller.value, 0.0);
+    expect(controller.status, AnimationStatus.dismissed);
+
+    // Animate from 0.0 to 0.5
+    controller.animateTo(0.5);
+    tick(const Duration(milliseconds: 0));
+    tick(const Duration(milliseconds: 150));
+    expect(controller.value, 0.5);
+    expect(statusLog, equals(<AnimationStatus>[ AnimationStatus.forward, AnimationStatus.completed ]));
+    statusLog.clear();
+
+    // Animate from 0.5 to 1.0
+    controller.animateTo(1.0);
+    tick(const Duration(milliseconds: 0));
+    tick(const Duration(milliseconds: 150));
+    expect(controller.value, 1.0);
+    expect(statusLog, equals(<AnimationStatus>[ AnimationStatus.forward, AnimationStatus.completed ]));
+    statusLog.clear();
+
+    // Animate from 1.0 to 0.5
+    controller.animateTo(0.5);
+    tick(const Duration(milliseconds: 0));
+    tick(const Duration(milliseconds: 150));
+    expect(controller.value, 0.5);
+    expect(statusLog, equals(<AnimationStatus>[ AnimationStatus.forward, AnimationStatus.completed ])); // ???
+    statusLog.clear();
+
+    // Animate from 0.5 to 1.0
+    controller.animateTo(0.0);
+    tick(const Duration(milliseconds: 0));
+    tick(const Duration(milliseconds: 150));
+    expect(controller.value, 0.0);
+    expect(statusLog, equals(<AnimationStatus>[ AnimationStatus.forward, AnimationStatus.completed ])); // ???
+    statusLog.clear();
+  });
 }

--- a/packages/flutter/test/animation/animation_controller_test.dart
+++ b/packages/flutter/test/animation/animation_controller_test.dart
@@ -379,7 +379,7 @@ void main() {
 
     final double currentValue = controller.value;
     controller.animateTo(currentValue, duration: const Duration(milliseconds: 100));
-    expect(statusLog, equals(<AnimationStatus>[ AnimationStatus.reverse, AnimationStatus.dismissed ]));
+    expect(statusLog, equals(<AnimationStatus>[ AnimationStatus.reverse, AnimationStatus.completed ]));
     expect(controller.value, currentValue);
   });
 

--- a/packages/flutter/test/animation/animation_controller_test.dart
+++ b/packages/flutter/test/animation/animation_controller_test.dart
@@ -417,7 +417,7 @@ void main() {
 
     controller.value = 0.5;
     expect(controller.value, 0.5);
-    expect(controller.status, AnimationStatus.forward); // ???
+    expect(controller.status, AnimationStatus.forward);
 
     controller.value = 0.0;
     expect(controller.value, 0.0);
@@ -458,7 +458,7 @@ void main() {
     tick(const Duration(milliseconds: 0));
     tick(const Duration(milliseconds: 150));
     expect(controller.value, 0.5);
-    expect(statusLog, equals(<AnimationStatus>[ AnimationStatus.forward, AnimationStatus.completed ])); // ???
+    expect(statusLog, equals(<AnimationStatus>[ AnimationStatus.forward, AnimationStatus.completed ]));
     statusLog.clear();
 
     // Animate from 0.5 to 1.0
@@ -466,7 +466,7 @@ void main() {
     tick(const Duration(milliseconds: 0));
     tick(const Duration(milliseconds: 150));
     expect(controller.value, 0.0);
-    expect(statusLog, equals(<AnimationStatus>[ AnimationStatus.forward, AnimationStatus.completed ])); // ???
+    expect(statusLog, equals(<AnimationStatus>[ AnimationStatus.forward, AnimationStatus.completed ]));
     statusLog.clear();
   });
 }


### PR DESCRIPTION
* Adds tests for AnimationController.status.
* Minor change to how AnimationStatus is reported for `animateTo` for consistency.
* Adds docs about the expected AnimationStatus for certain operations.