### PR TITLE
Update IntelliJ project files for latest plugin

### DIFF
--- a/dev/bots/bots.iml
+++ b/dev/bots/bots.iml
@@ -5,7 +5,6 @@
     <content url="file://$MODULE_DIR$">
       <excludeFolder url="file://$MODULE_DIR$/.pub" />
       <excludeFolder url="file://$MODULE_DIR$/build" />
-      <excludeFolder url="file://$MODULE_DIR$/packages" />
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />

--- a/dev/devicelab/devicelab.iml
+++ b/dev/devicelab/devicelab.iml
@@ -4,10 +4,7 @@
     <exclude-output />
     <content url="file://$MODULE_DIR$">
       <excludeFolder url="file://$MODULE_DIR$/.pub" />
-      <excludeFolder url="file://$MODULE_DIR$/bin/packages" />
       <excludeFolder url="file://$MODULE_DIR$/build" />
-      <excludeFolder url="file://$MODULE_DIR$/packages" />
-      <excludeFolder url="file://$MODULE_DIR$/test/packages" />
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />

--- a/examples/flutter_gallery/flutter_gallery.iml
+++ b/examples/flutter_gallery/flutter_gallery.iml
@@ -1,14 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module type="FLUTTER_MODULE_TYPE" version="4">
+<module type="WEB_MODULE" version="4">
   <component name="NewModuleRootManager" inherit-compiler-output="true">
     <exclude-output />
     <content url="file://$MODULE_DIR$">
       <excludeFolder url="file://$MODULE_DIR$/.idea" />
       <excludeFolder url="file://$MODULE_DIR$/.pub" />
       <excludeFolder url="file://$MODULE_DIR$/build" />
-      <excludeFolder url="file://$MODULE_DIR$/packages" />
-      <excludeFolder url="file://$MODULE_DIR$/test/calculator/packages" />
-      <excludeFolder url="file://$MODULE_DIR$/test/packages" />
     </content>
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="library" name="Dart Packages" level="project" />

--- a/examples/hello_world/hello_world.iml
+++ b/examples/hello_world/hello_world.iml
@@ -1,13 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module type="FLUTTER_MODULE_TYPE" version="4">
+<module type="WEB_MODULE" version="4">
   <component name="NewModuleRootManager" inherit-compiler-output="true">
     <exclude-output />
     <content url="file://$MODULE_DIR$">
       <excludeFolder url="file://$MODULE_DIR$/.idea" />
       <excludeFolder url="file://$MODULE_DIR$/.pub" />
       <excludeFolder url="file://$MODULE_DIR$/build" />
-      <excludeFolder url="file://$MODULE_DIR$/packages" />
-      <excludeFolder url="file://$MODULE_DIR$/test/packages" />
     </content>
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="library" name="Dart Packages" level="project" />

--- a/packages/flutter/flutter.iml
+++ b/packages/flutter/flutter.iml
@@ -5,23 +5,6 @@
     <content url="file://$MODULE_DIR$">
       <excludeFolder url="file://$MODULE_DIR$/.pub" />
       <excludeFolder url="file://$MODULE_DIR$/build" />
-      <excludeFolder url="file://$MODULE_DIR$/packages" />
-      <excludeFolder url="file://$MODULE_DIR$/test/animation/packages" />
-      <excludeFolder url="file://$MODULE_DIR$/test/cupertino/packages" />
-      <excludeFolder url="file://$MODULE_DIR$/test/engine/packages" />
-      <excludeFolder url="file://$MODULE_DIR$/test/examples/packages" />
-      <excludeFolder url="file://$MODULE_DIR$/test/foundation/packages" />
-      <excludeFolder url="file://$MODULE_DIR$/test/gestures/packages" />
-      <excludeFolder url="file://$MODULE_DIR$/test/harness/packages" />
-      <excludeFolder url="file://$MODULE_DIR$/test/material/packages" />
-      <excludeFolder url="file://$MODULE_DIR$/test/packages" />
-      <excludeFolder url="file://$MODULE_DIR$/test/painting/packages" />
-      <excludeFolder url="file://$MODULE_DIR$/test/physics/packages" />
-      <excludeFolder url="file://$MODULE_DIR$/test/rendering/packages" />
-      <excludeFolder url="file://$MODULE_DIR$/test/scheduler/packages" />
-      <excludeFolder url="file://$MODULE_DIR$/test/services/packages" />
-      <excludeFolder url="file://$MODULE_DIR$/test/ui/packages" />
-      <excludeFolder url="file://$MODULE_DIR$/test/widgets/packages" />
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />

--- a/packages/flutter_driver/flutter_driver.iml
+++ b/packages/flutter_driver/flutter_driver.iml
@@ -5,9 +5,6 @@
     <content url="file://$MODULE_DIR$">
       <excludeFolder url="file://$MODULE_DIR$/.pub" />
       <excludeFolder url="file://$MODULE_DIR$/build" />
-      <excludeFolder url="file://$MODULE_DIR$/packages" />
-      <excludeFolder url="file://$MODULE_DIR$/test/packages" />
-      <excludeFolder url="file://$MODULE_DIR$/test/src/packages" />
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />

--- a/packages/flutter_test/flutter_test.iml
+++ b/packages/flutter_test/flutter_test.iml
@@ -5,8 +5,6 @@
     <content url="file://$MODULE_DIR$">
       <excludeFolder url="file://$MODULE_DIR$/.pub" />
       <excludeFolder url="file://$MODULE_DIR$/build" />
-      <excludeFolder url="file://$MODULE_DIR$/packages" />
-      <excludeFolder url="file://$MODULE_DIR$/test/packages" />
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />

--- a/packages/flutter_tools/flutter_tools.iml
+++ b/packages/flutter_tools/flutter_tools.iml
@@ -4,44 +4,19 @@
     <exclude-output />
     <content url="file://$MODULE_DIR$">
       <excludeFolder url="file://$MODULE_DIR$/.pub" />
-      <excludeFolder url="file://$MODULE_DIR$/bin/packages" />
       <excludeFolder url="file://$MODULE_DIR$/build" />
-      <excludeFolder url="file://$MODULE_DIR$/packages" />
-      <excludeFolder url="file://$MODULE_DIR$/test/android/packages" />
-      <excludeFolder url="file://$MODULE_DIR$/test/base/packages" />
-      <excludeFolder url="file://$MODULE_DIR$/test/commands/packages" />
       <excludeFolder url="file://$MODULE_DIR$/test/data/dart_dependencies_test/asci_casing/.pub" />
       <excludeFolder url="file://$MODULE_DIR$/test/data/dart_dependencies_test/asci_casing/build" />
-      <excludeFolder url="file://$MODULE_DIR$/test/data/dart_dependencies_test/asci_casing/packages" />
       <excludeFolder url="file://$MODULE_DIR$/test/data/dart_dependencies_test/bad_package/.pub" />
       <excludeFolder url="file://$MODULE_DIR$/test/data/dart_dependencies_test/bad_package/build" />
-      <excludeFolder url="file://$MODULE_DIR$/test/data/dart_dependencies_test/bad_package/packages" />
       <excludeFolder url="file://$MODULE_DIR$/test/data/dart_dependencies_test/bad_path/.pub" />
       <excludeFolder url="file://$MODULE_DIR$/test/data/dart_dependencies_test/bad_path/build" />
-      <excludeFolder url="file://$MODULE_DIR$/test/data/dart_dependencies_test/bad_path/packages" />
       <excludeFolder url="file://$MODULE_DIR$/test/data/dart_dependencies_test/changed_sdk_location/.pub" />
       <excludeFolder url="file://$MODULE_DIR$/test/data/dart_dependencies_test/changed_sdk_location/build" />
-      <excludeFolder url="file://$MODULE_DIR$/test/data/dart_dependencies_test/changed_sdk_location/lib/packages" />
-      <excludeFolder url="file://$MODULE_DIR$/test/data/dart_dependencies_test/changed_sdk_location/packages" />
       <excludeFolder url="file://$MODULE_DIR$/test/data/dart_dependencies_test/good/.pub" />
       <excludeFolder url="file://$MODULE_DIR$/test/data/dart_dependencies_test/good/build" />
-      <excludeFolder url="file://$MODULE_DIR$/test/data/dart_dependencies_test/good/lib/packages" />
-      <excludeFolder url="file://$MODULE_DIR$/test/data/dart_dependencies_test/good/packages" />
-      <excludeFolder url="file://$MODULE_DIR$/test/data/dart_dependencies_test/packages" />
       <excludeFolder url="file://$MODULE_DIR$/test/data/dart_dependencies_test/syntax_error/.pub" />
       <excludeFolder url="file://$MODULE_DIR$/test/data/dart_dependencies_test/syntax_error/build" />
-      <excludeFolder url="file://$MODULE_DIR$/test/data/dart_dependencies_test/syntax_error/packages" />
-      <excludeFolder url="file://$MODULE_DIR$/test/data/intellij/packages" />
-      <excludeFolder url="file://$MODULE_DIR$/test/data/intellij/plugins/Dart/lib/packages" />
-      <excludeFolder url="file://$MODULE_DIR$/test/data/intellij/plugins/Dart/packages" />
-      <excludeFolder url="file://$MODULE_DIR$/test/data/intellij/plugins/packages" />
-      <excludeFolder url="file://$MODULE_DIR$/test/data/packages" />
-      <excludeFolder url="file://$MODULE_DIR$/test/ios/packages" />
-      <excludeFolder url="file://$MODULE_DIR$/test/packages" />
-      <excludeFolder url="file://$MODULE_DIR$/test/replay/packages" />
-      <excludeFolder url="file://$MODULE_DIR$/test/runner/packages" />
-      <excludeFolder url="file://$MODULE_DIR$/test/src/packages" />
-      <excludeFolder url="file://$MODULE_DIR$/tool/packages" />
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />


### PR DESCRIPTION
The most recent Flutter IntelliJ plugin replaces FLUTTER_MODULE with
WEB_MODULE and eliminates the exclusion of packages/ directories.
Use of the packages/ directory was turned off by default months ago, and
is replaced by the .packages file.