### PR TITLE
Don't trigger an assert when markNeedsSemanticsUpdate is called multiple times in edge cases

### DIFF
--- a/examples/flutter_gallery/test/smoke_test.dart
+++ b/examples/flutter_gallery/test/smoke_test.dart
@@ -164,7 +164,7 @@ Future<Null> runSmokeTest(WidgetTester tester) async {
 void main() {
   testWidgets('Flutter Gallery app smoke test', runSmokeTest);
 
-  testWidgets('Flutter Gallery app smoke test', (WidgetTester tester) async {
+  testWidgets('Flutter Gallery app smoke test with semantics', (WidgetTester tester) async {
     RendererBinding.instance.setSemanticsEnabled(true);
     await runSmokeTest(tester);
     RendererBinding.instance.setSemanticsEnabled(false);

--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -2580,7 +2580,7 @@ abstract class RenderObject extends AbstractNode with DiagnosticableTreeMixin im
         node = node.parent;
       } while (node._semantics == null);
       node._semantics?.reset();
-      if (node != this && this._semantics != null && this._needsSemanticsUpdate) {
+      if (node != this && _semantics != null && _needsSemanticsUpdate) {
         // If [this] node has already been added to [owner._nodesNeedingSemantics]
         // remove it as it is no longer guaranteed that its semantics
         // node will continue to be in the tree. If it still is in the tree, the

--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -2572,16 +2572,6 @@ abstract class RenderObject extends AbstractNode with DiagnosticableTreeMixin im
       // and dirty the nearest _semantics-laden ancestor of the
       // affected node to rebuild the tree.
       RenderObject node = this;
-
-      // If the node has already been added to [owner._nodesNeedingSemantics]
-      // remove it as it is now not guaranteed that the [node]'s semantics node
-      // will continue to be in the tree. If it still is in the tree, the node
-      // added to [owner._nodesNeedingSemantics] at the end of this block will
-      // ensure that the semantics of [node] actually get updated.
-      // (See semantics_10_test.dart for an example why this is required).
-      if (node._semantics != null && node._needsSemanticsUpdate)
-        owner._nodesNeedingSemantics.remove(node);
-
       do {
         if (node.parent is! RenderObject)
           break;
@@ -2590,6 +2580,16 @@ abstract class RenderObject extends AbstractNode with DiagnosticableTreeMixin im
         node = node.parent;
       } while (node._semantics == null);
       node._semantics?.reset();
+      if (node != this && this._semantics != null && this._needsSemanticsUpdate) {
+        // If [this] node has already been added to [owner._nodesNeedingSemantics]
+        // remove it as it is no longer guaranteed that its semantics
+        // node will continue to be in the tree. If it still is in the tree, the
+        // ancestor [node] added to [owner._nodesNeedingSemantics] at the end of
+        // this block will ensure that the semantics of [this] node actually get
+        // updated.
+        // (See semantics_10_test.dart for an example why this is required).
+        owner._nodesNeedingSemantics.remove(this);
+      }
       if (!node._needsSemanticsUpdate) {
         node._needsSemanticsUpdate = true;
         if (owner != null) {

--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -1186,7 +1186,7 @@ class PipelineOwner {
   }
 
   bool _debugDoingSemantics = false;
-  final List<RenderObject> _nodesNeedingSemantics = <RenderObject>[];
+  final Set<RenderObject> _nodesNeedingSemantics = new Set<RenderObject>();
 
   /// Update the semantics for render objects marked as needing a semantics
   /// update.
@@ -1206,14 +1206,16 @@ class PipelineOwner {
     assert(_semanticsOwner != null);
     assert(() { _debugDoingSemantics = true; return true; });
     try {
-      _nodesNeedingSemantics.sort((RenderObject a, RenderObject b) => a.depth - b.depth);
-      for (RenderObject node in _nodesNeedingSemantics) {
+      final List<RenderObject> nodesToProcess = _nodesNeedingSemantics.toList()
+        ..sort((RenderObject a, RenderObject b) => a.depth - b.depth);
+      _nodesNeedingSemantics.clear();
+      for (RenderObject node in nodesToProcess) {
         if (node._needsSemanticsUpdate && node.owner == this)
           node._updateSemantics();
       }
       _semanticsOwner.sendSemanticsUpdate();
     } finally {
-      _nodesNeedingSemantics.clear();
+      assert(_nodesNeedingSemantics.isEmpty);
       assert(() { _debugDoingSemantics = false; return true; });
       Timeline.finishSync();
     }

--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -2572,6 +2572,16 @@ abstract class RenderObject extends AbstractNode with DiagnosticableTreeMixin im
       // and dirty the nearest _semantics-laden ancestor of the
       // affected node to rebuild the tree.
       RenderObject node = this;
+
+      // If the node has already been added to [owner._nodesNeedingSemantics]
+      // remove it as it is now not guaranteed that the [node]'s semantics node
+      // will continue to be in the tree. If it still is in the tree, the node
+      // added to [owner._nodesNeedingSemantics] at the end of this block will
+      // ensure that the semantics of [node] actually get updated.
+      // (See semantics_10_test.dart for an example why this is required).
+      if (node._semantics != null && node._needsSemanticsUpdate)
+        owner._nodesNeedingSemantics.remove(node);
+
       do {
         if (node.parent is! RenderObject)
           break;

--- a/packages/flutter/test/widgets/semantics_10_test.dart
+++ b/packages/flutter/test/widgets/semantics_10_test.dart
@@ -35,6 +35,8 @@ void main() {
     );
 
     expect(callLog, <String>['markNeedsSemanticsUpdate(onlyChanges: true)', 'markNeedsSemanticsUpdate(onlyChanges: false)']);
+
+    semantics.dispose();
   });
 }
 

--- a/packages/flutter/test/widgets/semantics_10_test.dart
+++ b/packages/flutter/test/widgets/semantics_10_test.dart
@@ -1,0 +1,58 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:meta/meta.dart';
+
+import 'semantics_tester.dart';
+
+void main() {
+  testWidgets('canDrag update does not trigger assert in semantics', (WidgetTester tester) async {
+    final SemanticsTester semantics = new SemanticsTester(tester);
+
+    await tester.pumpWidget(buildTestWidget(
+      excludeListSemantics: false,
+      listIsDragable: true,
+      numOfListEntries: 100,
+    ));
+
+    // The following should not trigger an assert.
+    await tester.pumpWidget(buildTestWidget(
+      excludeListSemantics: true,
+      listIsDragable: false,
+      numOfListEntries: 2,
+    ));
+
+    semantics.dispose();
+  });
+}
+
+Widget buildTestWidget({
+    @required bool excludeListSemantics,
+    @required bool listIsDragable,
+    @required int numOfListEntries
+}) {
+  final List<Widget> children = new List<Widget>.generate(numOfListEntries, (int i) {
+    return new Container(
+      child: new Semantics(
+        label: 'child$i',
+      ),
+      height: 40.0,
+    );
+  });
+
+  return new Semantics(
+    container: true,
+    label: 'container',
+    child: new ExcludeSemantics(
+      excluding: excludeListSemantics,
+      child: new ListView(
+        physics: listIsDragable ? null : const NeverScrollableScrollPhysics(),
+        children: children,
+      ),
+    ),
+  );
+}

--- a/packages/flutter/test/widgets/semantics_10_test.dart
+++ b/packages/flutter/test/widgets/semantics_10_test.dart
@@ -16,7 +16,7 @@ void main() {
     final SemanticsTester semantics = new SemanticsTester(tester);
 
     await tester.pumpWidget(
-        bildTestWidgets(
+        buildTestWidgets(
           excludeSemantics: false,
           label: 'label',
           isSemanticsBoundary: true,
@@ -27,7 +27,7 @@ void main() {
 
     // The following should not trigger an assert.
     await tester.pumpWidget(
-        bildTestWidgets(
+        buildTestWidgets(
           excludeSemantics: true,
           label: 'label CHANGED',
           isSemanticsBoundary: false,
@@ -40,7 +40,7 @@ void main() {
   });
 }
 
-Widget bildTestWidgets({bool excludeSemantics, String label, bool isSemanticsBoundary}) {
+Widget buildTestWidgets({bool excludeSemantics, String label, bool isSemanticsBoundary}) {
   return new Semantics(
     label: 'container',
     container: true,


### PR DESCRIPTION
This bug was exposed by https://github.com/flutter/flutter/pull/11309, which caused the following assertion to trigger when scrolling in the Animation demo of Flutter Gallery:

```
The following assertion was thrown during _updateSemantics():
'package:flutter/src/rendering/object.dart': Failed assertion: line 2626 pos 16: 'fragment is
_InterestingSemanticsFragment': is not true.
```

A minimal reproduction of the bug can be found in `semantics_10_test.dart`, which has been added to this PR as a regression test for the bug.

The original problem was that `RenderSemanticsGestureHandler` would call `markNeedsSemanticsUpdate` twice - the first time with `onlyChanges: true` and the second time with `onlyChanges: false`. Furthermore, during the second call `RenderSemanticsGestureHandler` would also cease to be either an explicit or implicit semantics boundary. However, the first call to `markNeedsSemanticsUpdate` had added the `RenderSemanticsGestureHandler` to `_nodesNeedingSemantics`, which implies that the node is supposed to produce an `_InterestingSemanticsFragment`. Unfortunately, with the second call to `markNeedsSemanticsUpdate` it ceased to be an explicit or implicit semantics boundary and hence didn't produce an `_InterestingSemanticsFragment` anymore. However, the object wasn't removed from `_nodesNeedingSemantics`, which triggered the assert when the framework tried to calculate the node's SemanticsFragment and something other than an `_InterestingSemanticsFragment` was computed.

In addition to this fix, PR https://github.com/flutter/flutter/pull/11543 refactors the `RenderSemanticsGestureHandler` to call `markNeedsSemanticsUpdate` less frequently.