### PR TITLE
Signal an error in the dependency checker if an import URI is invalid

### DIFF
--- a/packages/flutter_tools/lib/src/dart/dependencies.dart
+++ b/packages/flutter_tools/lib/src/dart/dependencies.dart
@@ -65,7 +65,13 @@ class DartDependencySetBuilder {
           uriAsString = uriBasedDirective.uri.stringValue;
         }
 
-        Uri resolvedUri = analyzer.resolveRelativeUri(currentUri, Uri.parse(uriAsString));
+        Uri uri;
+        try {
+          uri = Uri.parse(uriAsString);
+        } on FormatException {
+          throw new DartDependencyException('Unable to parse URI: $uriAsString');
+        }
+        Uri resolvedUri = analyzer.resolveRelativeUri(currentUri, uri);
         if (resolvedUri.scheme.startsWith('dart'))
           continue;
         if (resolvedUri.scheme == 'package') {

--- a/packages/flutter_tools/test/dart_dependencies_test.dart
+++ b/packages/flutter_tools/test/dart_dependencies_test.dart
@@ -82,5 +82,19 @@ void main()  {
       final Set<String> deps = builder.build();
       expect(deps, contains(endsWith('This_Import_Has_fuNNy_casING.dart')));
     });
+
+    testUsingContext('bad_import', () {
+      final String testPath = fs.path.join(dataPath, 'bad_import');
+      final String mainPath = fs.path.join(testPath, 'main.dart');
+      final String packagesPath = fs.path.join(testPath, '.packages');
+      final DartDependencySetBuilder builder =
+          new DartDependencySetBuilder(mainPath, packagesPath);
+      try {
+        builder.build();
+        fail('expect an exception to be thrown.');
+      } on DartDependencyException catch (error) {
+        expect(error.toString(), contains('Unable to parse URI'));
+      }
+    });
   });
 }

--- a/packages/flutter_tools/test/data/dart_dependencies_test/bad_import/.analysis_options
+++ b/packages/flutter_tools/test/data/dart_dependencies_test/bad_import/.analysis_options
@@ -1,0 +1,3 @@
+analyzer:
+  exclude:
+    - '**'

--- a/packages/flutter_tools/test/data/dart_dependencies_test/bad_import/main.dart
+++ b/packages/flutter_tools/test/data/dart_dependencies_test/bad_import/main.dart
@@ -1,0 +1,5 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import '[object Object].dart';

--- a/packages/flutter_tools/test/data/dart_dependencies_test/bad_import/pubspec.yaml
+++ b/packages/flutter_tools/test/data/dart_dependencies_test/bad_import/pubspec.yaml
@@ -1,0 +1,1 @@
+name: self


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/11539