### PR TITLE
Correct handling of assets when no main asset is present

### DIFF
--- a/packages/flutter/lib/src/services/image_resolution.dart
+++ b/packages/flutter/lib/src/services/image_resolution.dart
@@ -150,7 +150,6 @@ class AssetImage extends AssetBundleImageProvider {
     final SplayTreeMap<double, String> mapping = new SplayTreeMap<double, String>();
     for (String candidate in candidates)
       mapping[_parseScale(candidate)] = candidate;
-    mapping[_naturalResolution] = main;
     // TODO(ianh): implement support for config.locale, config.size, config.platform
     // (then document this over in the Image.asset docs)
     return _findNearest(mapping, config.devicePixelRatio);

--- a/packages/flutter_tools/lib/src/asset.dart
+++ b/packages/flutter_tools/lib/src/asset.dart
@@ -98,6 +98,10 @@ class AssetBundle {
 
     final PackageMap packageMap = new PackageMap(packagesPath);
 
+    // The _assetVariants map contains an entry for each asset listed
+    // in the pubspec.yaml file's assets and font and sections. The
+    // value of each image asset is a list of resolution-specific "variants",
+    // see _AssetDirectoryCache.
     final Map<_Asset, List<_Asset>> assetVariants = _parseAssets(
       packageMap,
       manifestDescriptor,
@@ -112,12 +116,20 @@ class AssetBundle {
         manifestDescriptor.containsKey('uses-material-design') &&
         manifestDescriptor['uses-material-design'];
 
+    // Save the contents of each image, image variant, and font
+    // asset in entries.
     for (_Asset asset in assetVariants.keys) {
       if (!asset.assetFileExists && assetVariants[asset].isEmpty) {
         printStatus('Error detected in pubspec.yaml:', emphasis: true);
         printError('No file or variants found for $asset.\n');
         return 1;
       }
+      // The file name for an asset's "main" entry is whatever appears in
+      // the pubspec.yaml file. The main entry will always exist for font
+      // assets. It need not be specified for an image if resolution-specific
+      // variants exist. An image's main entry is treated the same as a "1x"
+      // resolution variant and if both exist then the explicit variant is
+      // preferred.
       if (asset.assetFileExists) {
         assert(!assetVariants[asset].contains(asset));
         assetVariants[asset].insert(0, asset);

--- a/packages/flutter_tools/lib/src/asset.dart
+++ b/packages/flutter_tools/lib/src/asset.dart
@@ -125,11 +125,11 @@ class AssetBundle {
         return 1;
       }
       // The file name for an asset's "main" entry is whatever appears in
-      // the pubspec.yaml file. The main entry will always exist for font
-      // assets. It need not be specified for an image if resolution-specific
-      // variants exist. An image's main entry is treated the same as a "1x"
-      // resolution variant and if both exist then the explicit variant is
-      // preferred.
+      // the pubspec.yaml file. The main entry's file must always exist for
+      // font assets. It need not exist for an image if resolution-specific
+      // variant files exist. An image's main entry is treated the same as a
+      // "1x" resolution variant and if both exist then the explicit 1x
+      // variant is preferred.
       if (asset.assetFileExists) {
         assert(!assetVariants[asset].contains(asset));
         assetVariants[asset].insert(0, asset);

--- a/packages/flutter_tools/lib/src/asset.dart
+++ b/packages/flutter_tools/lib/src/asset.dart
@@ -118,8 +118,10 @@ class AssetBundle {
         printError('No file or variants found for $asset.\n');
         return 1;
       }
-      if (asset.assetFileExists)
-        entries[asset.assetEntry] = new DevFSFileContent(asset.assetFile);
+      if (asset.assetFileExists) {
+        assert(!assetVariants[asset].contains(asset));
+        assetVariants[asset].insert(0, asset);
+      }
       for (_Asset variant in assetVariants[asset]) {
         assert(variant.assetFileExists);
         entries[variant.assetEntry] = new DevFSFileContent(variant.assetFile);


### PR DESCRIPTION
Since https://github.com/flutter/flutter/pull/10901 it's been OK to just provide image variants and unnecessary to provide a "main"  (1x resolution) image.

Change the way we generate manifests a little: now the main image asset is included with the variants explicitly (if it exists).

