### PR TITLE
RTL

### DIFF
--- a/packages/flutter/lib/src/painting/basic_types.dart
+++ b/packages/flutter/lib/src/painting/basic_types.dart
@@ -90,3 +90,28 @@ enum RenderComparison {
   /// change in a render object.
   layout,
 }
+
+/// The two cardinal directions in two dimensions.
+///
+/// The axis is always relative to the current coordinate space. This means, for
+/// example, that a [horizontal] axis might actually be diagonally from top
+/// right to bottom left, due to some local [Transform] applied to the scene.
+///
+/// See also:
+///
+///  * [AxisDirection], which is a directional version of this enum (with values
+///    light left and right, rather than just horizontal).
+///  * [TextDirection], which disambiguates between left-to-right horizontal
+///    content and right-to-left horizontal content.
+enum Axis {
+  /// Left and right.
+  ///
+  /// See also:
+  ///
+  ///  * [TextDirection], which disambiguates between left-to-right horizontal
+  ///    content and right-to-left horizontal content.
+  horizontal,
+
+  /// Up and down.
+  vertical,
+}

--- a/packages/flutter/lib/src/rendering/node.dart
+++ b/packages/flutter/lib/src/rendering/node.dart
@@ -43,7 +43,7 @@ class AbstractNode {
   int get depth => _depth;
   int _depth = 0;
 
-  /// Adjust the [depth] of the given [child] to be greated than this node's own
+  /// Adjust the [depth] of the given [child] to be greater than this node's own
   /// [depth].
   ///
   /// Only call this method from overrides of [redepthChildren].

--- a/packages/flutter/lib/src/rendering/shifted_box.dart
+++ b/packages/flutter/lib/src/rendering/shifted_box.dart
@@ -91,29 +91,58 @@ class RenderPadding extends RenderShiftedBox {
   ///
   /// The [padding] argument must not be null and must have non-negative insets.
   RenderPadding({
-    @required EdgeInsets padding,
-    RenderBox child
+    @required EdgeInsetsGeometry padding,
+    TextDirection textDirection,
+    RenderBox child,
   }) : assert(padding != null),
        assert(padding.isNonNegative),
+       _textDirection = textDirection,
        _padding = padding,
-       super(child);
+       super(child) {
+    _applyUpdate();
+  }
+
+  // The resolved absolute insets.
+  EdgeInsets _resolvedPadding;
+
+  void _applyUpdate() {
+    final EdgeInsets resolvedPadding = padding.resolve(textDirection);
+    assert(resolvedPadding.isNonNegative);
+    if (resolvedPadding != _resolvedPadding) {
+      _resolvedPadding = resolvedPadding;
+      markNeedsLayout();
+    }
+  }
 
   /// The amount to pad the child in each dimension.
-  EdgeInsets get padding => _padding;
-  EdgeInsets _padding;
-  set padding(EdgeInsets value) {
+  ///
+  /// If this is set to an [EdgeInsetsDirectional] object, then [textDirection]
+  /// must be non-null.
+  EdgeInsetsGeometry get padding => _padding;
+  EdgeInsetsGeometry _padding;
+  set padding(EdgeInsetsGeometry value) {
     assert(value != null);
     assert(value.isNonNegative);
     if (_padding == value)
       return;
     _padding = value;
-    markNeedsLayout();
+    _applyUpdate();
+  }
+
+  /// The text direction with which to resolve [padding].
+  TextDirection get textDirection => _textDirection;
+  TextDirection _textDirection;
+  set textDirection(TextDirection value) {
+    if (_textDirection == value)
+      return;
+    _textDirection = value;
+    _applyUpdate();
   }
 
   @override
   double computeMinIntrinsicWidth(double height) {
-    final double totalHorizontalPadding = padding.left + padding.right;
-    final double totalVerticalPadding = padding.top + padding.bottom;
+    final double totalHorizontalPadding = _resolvedPadding.left + _resolvedPadding.right;
+    final double totalVerticalPadding = _resolvedPadding.top + _resolvedPadding.bottom;
     if (child != null) // next line relies on double.INFINITY absorption
       return child.getMinIntrinsicWidth(math.max(0.0, height - totalVerticalPadding)) + totalHorizontalPadding;
     return totalHorizontalPadding;
@@ -121,8 +150,8 @@ class RenderPadding extends RenderShiftedBox {
 
   @override
   double computeMaxIntrinsicWidth(double height) {
-    final double totalHorizontalPadding = padding.left + padding.right;
-    final double totalVerticalPadding = padding.top + padding.bottom;
+    final double totalHorizontalPadding = _resolvedPadding.left + _resolvedPadding.right;
+    final double totalVerticalPadding = _resolvedPadding.top + _resolvedPadding.bottom;
     if (child != null) // next line relies on double.INFINITY absorption
       return child.getMaxIntrinsicWidth(math.max(0.0, height - totalVerticalPadding)) + totalHorizontalPadding;
     return totalHorizontalPadding;
@@ -130,8 +159,8 @@ class RenderPadding extends RenderShiftedBox {
 
   @override
   double computeMinIntrinsicHeight(double width) {
-    final double totalHorizontalPadding = padding.left + padding.right;
-    final double totalVerticalPadding = padding.top + padding.bottom;
+    final double totalHorizontalPadding = _resolvedPadding.left + _resolvedPadding.right;
+    final double totalVerticalPadding = _resolvedPadding.top + _resolvedPadding.bottom;
     if (child != null) // next line relies on double.INFINITY absorption
       return child.getMinIntrinsicHeight(math.max(0.0, width - totalHorizontalPadding)) + totalVerticalPadding;
     return totalVerticalPadding;
@@ -139,8 +168,8 @@ class RenderPadding extends RenderShiftedBox {
 
   @override
   double computeMaxIntrinsicHeight(double width) {
-    final double totalHorizontalPadding = padding.left + padding.right;
-    final double totalVerticalPadding = padding.top + padding.bottom;
+    final double totalHorizontalPadding = _resolvedPadding.left + _resolvedPadding.right;
+    final double totalVerticalPadding = _resolvedPadding.top + _resolvedPadding.bottom;
     if (child != null) // next line relies on double.INFINITY absorption
       return child.getMaxIntrinsicHeight(math.max(0.0, width - totalHorizontalPadding)) + totalVerticalPadding;
     return totalVerticalPadding;
@@ -148,21 +177,21 @@ class RenderPadding extends RenderShiftedBox {
 
   @override
   void performLayout() {
-    assert(padding != null);
+    assert(_resolvedPadding != null);
     if (child == null) {
       size = constraints.constrain(new Size(
-        padding.left + padding.right,
-        padding.top + padding.bottom
+        _resolvedPadding.left + _resolvedPadding.right,
+        _resolvedPadding.top + _resolvedPadding.bottom
       ));
       return;
     }
-    final BoxConstraints innerConstraints = constraints.deflate(padding);
+    final BoxConstraints innerConstraints = constraints.deflate(_resolvedPadding);
     child.layout(innerConstraints, parentUsesSize: true);
     final BoxParentData childParentData = child.parentData;
-    childParentData.offset = new Offset(padding.left, padding.top);
+    childParentData.offset = new Offset(_resolvedPadding.left, _resolvedPadding.top);
     size = constraints.constrain(new Size(
-      padding.left + child.size.width + padding.right,
-      padding.top + child.size.height + padding.bottom
+      _resolvedPadding.left + child.size.width + _resolvedPadding.right,
+      _resolvedPadding.top + child.size.height + _resolvedPadding.bottom
     ));
   }
 
@@ -171,7 +200,7 @@ class RenderPadding extends RenderShiftedBox {
     super.debugPaintSize(context, offset);
     assert(() {
       final Rect outerRect = offset & size;
-      debugPaintPadding(context.canvas, outerRect, child != null ? padding.deflateRect(outerRect) : null);
+      debugPaintPadding(context.canvas, outerRect, child != null ? _resolvedPadding.deflateRect(outerRect) : null);
       return true;
     });
   }
@@ -179,7 +208,8 @@ class RenderPadding extends RenderShiftedBox {
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder description) {
     super.debugFillProperties(description);
-    description.add(new DiagnosticsProperty<EdgeInsets>('padding', padding));
+    description.add(new DiagnosticsProperty<EdgeInsetsGeometry>('padding', padding));
+    description.add(new EnumProperty<TextDirection>('textDirection', textDirection));
   }
 }
 

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -55,6 +55,50 @@ export 'package:flutter/rendering.dart' show
   WrapAlignment,
   WrapCrossAlignment;
 
+// BIDIRECTIONAL TEXT SUPPORT
+
+/// A widget that determines the ambient directionality of text and
+/// text-direction-sensitive render objects.
+///
+/// For example, [Padding] depends on the [Directionality] to resolve
+/// [EdgeInsetsDirectional] objects into absolute [EdgeInsets] objects.
+class Directionality extends InheritedWidget {
+  /// Creates a widget that determines the directionality of text and
+  /// text-direction-sensitive render objects.
+  ///
+  /// The [textDirection] and [child] arguments must not be null.
+  const Directionality({
+    Key key,
+    @required this.textDirection,
+    @required Widget child
+  }) : assert(textDirection != null),
+       assert(child != null),
+       super(key: key, child: child);
+
+  /// The text direction for this subtree.
+  final TextDirection textDirection;
+
+  /// The text direction from the closest instance of this class that encloses
+  /// the given context.
+  ///
+  /// If there is no [Directionality] ancestor widget in the tree at the given
+  /// context, then this will return null.
+  ///
+  /// Typical usage is as follows:
+  ///
+  /// ```dart
+  /// TextDirection textDirection = Directionality.of(context);
+  /// ```
+  static TextDirection of(BuildContext context) {
+    final Directionality widget = context.inheritFromWidgetOfExactType(Directionality);
+    return widget?.textDirection;
+  }
+
+  @override
+  bool updateShouldNotify(Directionality old) => textDirection != old.textDirection;
+}
+
+
 // PAINTING NODES
 
 /// A widget that makes its child partially transparent.
@@ -1066,14 +1110,21 @@ class Padding extends SingleChildRenderObjectWidget {
        super(key: key, child: child);
 
   /// The amount of space by which to inset the child.
-  final EdgeInsets padding;
+  final EdgeInsetsGeometry padding;
 
   @override
-  RenderPadding createRenderObject(BuildContext context) => new RenderPadding(padding: padding);
+  RenderPadding createRenderObject(BuildContext context) {
+    return new RenderPadding(
+      padding: padding,
+      textDirection: Directionality.of(context),
+    );
+  }
 
   @override
   void updateRenderObject(BuildContext context, RenderPadding renderObject) {
-    renderObject.padding = padding;
+    renderObject
+      ..padding = padding
+      ..textDirection = Directionality.of(context);
   }
 
   @override
@@ -2007,6 +2058,8 @@ class SliverPadding extends SingleChildRenderObjectWidget {
 
   /// The amount of space by which to inset the child sliver.
   final EdgeInsets padding;
+
+  // TODO(ianh): RTL
 
   @override
   RenderSliverPadding createRenderObject(BuildContext context) => new RenderSliverPadding(padding: padding);

--- a/packages/flutter/lib/src/widgets/container.dart
+++ b/packages/flutter/lib/src/widgets/container.dart
@@ -282,7 +282,7 @@ class Container extends StatelessWidget {
 
   /// Empty space to inscribe inside the [decoration]. The [child], if any, is
   /// placed inside this padding.
-  final EdgeInsets padding;
+  final EdgeInsetsGeometry padding;
 
   /// The decoration to paint behind the [child].
   ///
@@ -303,18 +303,19 @@ class Container extends StatelessWidget {
   final BoxConstraints constraints;
 
   /// Empty space to surround the [decoration] and [child].
-  final EdgeInsets margin;
+  final EdgeInsetsGeometry margin;
 
   /// The transformation matrix to apply before painting the container.
   final Matrix4 transform;
 
-  EdgeInsets get _paddingIncludingDecoration {
+  EdgeInsetsGeometry _getPaddingIncludingDecoration(BuildContext context) {
     if (decoration == null || decoration.padding == null)
       return padding;
-    final EdgeInsets decorationPadding = decoration.padding;
+    final EdgeInsetsGeometry decorationPadding = decoration.padding;
     if (padding == null)
       return decorationPadding;
-    return padding + decorationPadding;
+    final TextDirection textDirection = Directionality.of(context);
+    return padding.resolve(textDirection) + decorationPadding.resolve(textDirection);
   }
 
   @override
@@ -332,7 +333,7 @@ class Container extends StatelessWidget {
     if (alignment != null)
       current = new Align(alignment: alignment, child: current);
 
-    final EdgeInsets effectivePadding = _paddingIncludingDecoration;
+    final EdgeInsetsGeometry effectivePadding = _getPaddingIncludingDecoration(context);
     if (effectivePadding != null)
       current = new Padding(padding: effectivePadding, child: current);
 
@@ -363,11 +364,11 @@ class Container extends StatelessWidget {
   void debugFillProperties(DiagnosticPropertiesBuilder description) {
     super.debugFillProperties(description);
     description.add(new DiagnosticsProperty<FractionalOffset>('alignment', alignment, showName: false, defaultValue: null));
-    description.add(new DiagnosticsProperty<EdgeInsets>('padding', padding, defaultValue: null));
+    description.add(new DiagnosticsProperty<EdgeInsetsGeometry>('padding', padding, defaultValue: null));
     description.add(new DiagnosticsProperty<Decoration>('bg', decoration, defaultValue: null));
     description.add(new DiagnosticsProperty<Decoration>('fg', foregroundDecoration, defaultValue: null));
     description.add(new DiagnosticsProperty<BoxConstraints>('constraints', constraints, defaultValue: null));
-    description.add(new DiagnosticsProperty<EdgeInsets>('margin', margin, defaultValue: null));
+    description.add(new DiagnosticsProperty<EdgeInsetsGeometry>('margin', margin, defaultValue: null));
     description.add(new ObjectFlagProperty<Matrix4>.has('transform', transform));
   }
 }

--- a/packages/flutter/test/painting/edge_insets_test.dart
+++ b/packages/flutter/test/painting/edge_insets_test.dart
@@ -50,4 +50,25 @@ void main() {
     expect(EdgeInsets.lerp(null, b, 0.25), equals(b * 0.25));
     expect(EdgeInsets.lerp(a, null, 0.25), equals(a * 0.75));
   });
+
+  test('EdgeInsets.resolve()', () {
+    expect(new EdgeInsetsDirectional.fromSTEB(10.0, 20.0, 30.0, 40.0).resolve(TextDirection.ltr), const EdgeInsets.fromLTRB(10.0, 20.0, 30.0, 40.0));
+    expect(new EdgeInsetsDirectional.fromSTEB(99.0, 98.0, 97.0, 96.0).resolve(TextDirection.rtl), const EdgeInsets.fromLTRB(97.0, 98.0, 99.0, 96.0));
+    expect(new EdgeInsetsDirectional.only(start: 963.25).resolve(TextDirection.ltr), const EdgeInsets.fromLTRB(963.25, 0.0, 0.0, 0.0));
+    expect(new EdgeInsetsDirectional.only(top: 963.25).resolve(TextDirection.ltr), const EdgeInsets.fromLTRB(0.0, 963.25, 0.0, 0.0));
+    expect(new EdgeInsetsDirectional.only(end: 963.25).resolve(TextDirection.ltr), const EdgeInsets.fromLTRB(0.0, 0.0, 963.25, 0.0));
+    expect(new EdgeInsetsDirectional.only(bottom: 963.25).resolve(TextDirection.ltr), const EdgeInsets.fromLTRB(0.0, 0.0, 0.0, 963.25));
+    expect(new EdgeInsetsDirectional.only(start: 963.25).resolve(TextDirection.rtl), const EdgeInsets.fromLTRB(0.0, 0.0, 963.25, 0.0));
+    expect(new EdgeInsetsDirectional.only(top: 963.25).resolve(TextDirection.rtl), const EdgeInsets.fromLTRB(0.0, 963.25, 0.0, 0.0));
+    expect(new EdgeInsetsDirectional.only(end: 963.25).resolve(TextDirection.rtl), const EdgeInsets.fromLTRB(963.25, 0.0, 0.0, 0.0));
+    expect(new EdgeInsetsDirectional.only(bottom: 963.25).resolve(TextDirection.rtl), const EdgeInsets.fromLTRB(0.0, 0.0, 0.0, 963.25));
+    expect(new EdgeInsetsDirectional.only(), new EdgeInsetsDirectional.only());
+    expect(new EdgeInsetsDirectional.only(top: 1.0).hashCode, isNot(new EdgeInsetsDirectional.only(bottom: 1.0)));
+    expect(new EdgeInsetsDirectional.fromSTEB(10.0, 20.0, 30.0, 40.0).resolve(TextDirection.ltr),
+           new EdgeInsetsDirectional.fromSTEB(30.0, 20.0, 10.0, 40.0).resolve(TextDirection.rtl));
+    expect(new EdgeInsetsDirectional.fromSTEB(10.0, 20.0, 30.0, 40.0).resolve(TextDirection.ltr),
+     isNot(new EdgeInsetsDirectional.fromSTEB(30.0, 20.0, 10.0, 40.0).resolve(TextDirection.ltr)));
+    expect(new EdgeInsetsDirectional.fromSTEB(10.0, 20.0, 30.0, 40.0).resolve(TextDirection.ltr),
+     isNot(new EdgeInsetsDirectional.fromSTEB(10.0, 20.0, 30.0, 40.0).resolve(TextDirection.rtl)));
+  });
 }

--- a/packages/flutter/test/painting/fractional_offset_test.dart
+++ b/packages/flutter/test/painting/fractional_offset_test.dart
@@ -36,4 +36,27 @@ void main() {
     final FractionalOffset a = new FractionalOffset.fromOffsetAndRect(const Offset(150.0, 120.0), new Rect.fromLTWH(50.0, 20.0, 200.0, 400.0));
     expect(a, const FractionalOffset(0.5, 0.25));
   });
+
+  test('FractionalOffsetGeometry.resolve()', () {
+    expect(new FractionalOffsetDirectional(0.25, 0.3).resolve(TextDirection.ltr), const FractionalOffset(0.25, 0.3));
+    expect(new FractionalOffsetDirectional(0.25, 0.3).resolve(TextDirection.rtl), const FractionalOffset(0.75, 0.3));
+    expect(new FractionalOffsetDirectional(-0.25, 0.3).resolve(TextDirection.ltr), const FractionalOffset(-0.25, 0.3));
+    expect(new FractionalOffsetDirectional(-0.25, 0.3).resolve(TextDirection.rtl), const FractionalOffset(1.25, 0.3));
+    expect(new FractionalOffsetDirectional(1.25, 0.3).resolve(TextDirection.ltr), const FractionalOffset(1.25, 0.3));
+    expect(new FractionalOffsetDirectional(1.25, 0.3).resolve(TextDirection.rtl), const FractionalOffset(-0.25, 0.3));
+    expect(new FractionalOffsetDirectional(0.5, -0.3).resolve(TextDirection.ltr), const FractionalOffset(0.5, -0.3));
+    expect(new FractionalOffsetDirectional(0.5, -0.3).resolve(TextDirection.rtl), const FractionalOffset(0.5, -0.3));
+    expect(new FractionalOffsetDirectional(0.0, 0.0).resolve(TextDirection.ltr), const FractionalOffset(0.0, 0.0));
+    expect(new FractionalOffsetDirectional(0.0, 0.0).resolve(TextDirection.rtl), const FractionalOffset(1.0, 0.0));
+    expect(new FractionalOffsetDirectional(1.0, 1.0).resolve(TextDirection.ltr), const FractionalOffset(1.0, 1.0));
+    expect(new FractionalOffsetDirectional(1.0, 1.0).resolve(TextDirection.rtl), const FractionalOffset(0.0, 1.0));
+    expect(new FractionalOffsetDirectional(1.0, 2.0), new FractionalOffsetDirectional(1.0, 2.0));
+    expect(new FractionalOffsetDirectional(1.0, 2.0).hashCode, isNot(new FractionalOffsetDirectional(2.0, 1.0)));
+    expect(new FractionalOffsetDirectional(0.0, 0.0).resolve(TextDirection.ltr),
+           new FractionalOffsetDirectional(1.0, 0.0).resolve(TextDirection.rtl));
+    expect(new FractionalOffsetDirectional(0.0, 0.0).resolve(TextDirection.ltr),
+     isNot(new FractionalOffsetDirectional(1.0, 0.0).resolve(TextDirection.ltr)));
+    expect(new FractionalOffsetDirectional(1.0, 0.0).resolve(TextDirection.ltr),
+     isNot(new FractionalOffsetDirectional(1.0, 0.0).resolve(TextDirection.rtl)));
+  });
 }

--- a/packages/flutter/test/widgets/rtl_test.dart
+++ b/packages/flutter/test/widgets/rtl_test.dart
@@ -1,0 +1,70 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter/widgets.dart';
+
+void main() {
+  testWidgets('Padding RTL', (WidgetTester tester) async {
+    final Widget child = new Padding(
+      padding: new EdgeInsetsDirectional.only(start: 10.0),
+      child: new Placeholder(),
+    );
+    await tester.pumpWidget(new Directionality(
+      textDirection: TextDirection.ltr,
+      child: child,
+    ));
+    expect(tester.getTopLeft(find.byType(Placeholder)), const Offset(10.0, 0.0));
+    await tester.pumpWidget(new Directionality(
+      textDirection: TextDirection.rtl,
+      child: child,
+    ));
+    expect(tester.getTopLeft(find.byType(Placeholder)), const Offset(0.0, 0.0));
+  });
+
+  testWidgets('Container padding/margin RTL', (WidgetTester tester) async {
+    final Widget child = new Container(
+      padding: new EdgeInsetsDirectional.only(start: 6.0),
+      margin: new EdgeInsetsDirectional.only(end: 20.0, start: 4.0),
+      child: new Placeholder(),
+    );
+    await tester.pumpWidget(new Directionality(
+      textDirection: TextDirection.ltr,
+      child: child,
+    ));
+    expect(tester.getTopLeft(find.byType(Placeholder)), const Offset(10.0, 0.0));
+    expect(tester.getTopRight(find.byType(Placeholder)), const Offset(780.0, 0.0));
+    await tester.pumpWidget(new Directionality(
+      textDirection: TextDirection.rtl,
+      child: child,
+    ));
+    expect(tester.getTopLeft(find.byType(Placeholder)), const Offset(20.0, 0.0));
+    expect(tester.getTopRight(find.byType(Placeholder)), const Offset(790.0, 0.0));
+  });
+
+  testWidgets('Container padding/margin mixed RTL/absolute', (WidgetTester tester) async {
+    final Widget child = new Container(
+      padding: new EdgeInsets.only(left: 6.0),
+      margin: new EdgeInsetsDirectional.only(end: 20.0, start: 4.0),
+      child: new Placeholder(),
+    );
+    await tester.pumpWidget(new Directionality(
+      textDirection: TextDirection.ltr,
+      child: child,
+    ));
+    expect(tester.getTopLeft(find.byType(Placeholder)), const Offset(10.0, 0.0));
+    expect(tester.getTopRight(find.byType(Placeholder)), const Offset(780.0, 0.0));
+    await tester.pumpWidget(new Directionality(
+      textDirection: TextDirection.rtl,
+      child: child,
+    ));
+    expect(tester.getTopLeft(find.byType(Placeholder)), const Offset(26.0, 0.0));
+    expect(tester.getTopRight(find.byType(Placeholder)), const Offset(796.0, 0.0));
+  });
+
+  testWidgets('EdgeInsetsDirectional without Directionality', (WidgetTester tester) async {
+    await tester.pumpWidget(new Padding(padding: new EdgeInsetsDirectional.only()));
+    expect(tester.takeException(), isAssertionError);
+  });
+}


### PR DESCRIPTION
This makes it possible to configure Padding (including
Container.padding and Container.margin) using a
directionality-agnostic EdgeInsets variant.

It also introduces a Directionality inherited widget which sets the
ambient LTR vs RTL mode, defaulting to null, which means you cannot
use directionality-influenced padding.