### PR TITLE
Fix iOS last up event velocity calculation - version 3

### DIFF
--- a/packages/flutter/lib/src/gestures/converter.dart
+++ b/packages/flutter/lib/src/gestures/converter.dart
@@ -170,7 +170,8 @@ class PointerEventConverter {
               radiusMin: datum.radiusMin,
               radiusMax: datum.radiusMax,
               orientation: datum.orientation,
-              tilt: datum.tilt
+              tilt: datum.tilt,
+              synthesized: true,
             );
             state.lastPosition = position;
           }
@@ -257,7 +258,8 @@ class PointerEventConverter {
               radiusMin: datum.radiusMin,
               radiusMax: datum.radiusMax,
               orientation: datum.orientation,
-              tilt: datum.tilt
+              tilt: datum.tilt,
+              synthesized: true,
             );
             state.lastPosition = position;
           }

--- a/packages/flutter/lib/src/gestures/events.dart
+++ b/packages/flutter/lib/src/gestures/events.dart
@@ -113,7 +113,8 @@ abstract class PointerEvent {
     this.radiusMin: 0.0,
     this.radiusMax: 0.0,
     this.orientation: 0.0,
-    this.tilt: 0.0
+    this.tilt: 0.0,
+    this.synthesized: false,
   });
 
   /// Time of event dispatch, relative to an arbitrary timeline.
@@ -235,6 +236,18 @@ abstract class PointerEvent {
   /// the stylus is flat on that surface).
   final double tilt;
 
+  /// We occasionally synthesize PointerEvents that aren't exact translations
+  /// of [ui.PointerData] from the engine to cover small cross-OS discrepancies
+  /// in pointer behaviours.
+  ///
+  /// For instance, on end events, Android always drops any location changes
+  /// that happened between its reporting intervals when emiting the end events.
+  ///
+  /// On iOS, minor incorrect location changes from the previous move events
+  /// can be reported on end events. We synthesize a [PointerEvent] to cover
+  /// the difference between the 2 events in that case.
+  final bool synthesized;
+
   @override
   String toString() => '$runtimeType($position)';
 
@@ -261,7 +274,8 @@ abstract class PointerEvent {
              'radiusMin: $radiusMin, '
              'radiusMax: $radiusMax, '
              'orientation: $orientation, '
-             'tilt: $tilt'
+             'tilt: $tilt, '
+             'synthesized: $synthesized'
            ')';
   }
 }
@@ -365,7 +379,8 @@ class PointerHoverEvent extends PointerEvent {
     double radiusMin: 0.0,
     double radiusMax: 0.0,
     double orientation: 0.0,
-    double tilt: 0.0
+    double tilt: 0.0,
+    bool synthesized: false,
   }) : super(
     timeStamp: timeStamp,
     kind: kind,
@@ -384,7 +399,8 @@ class PointerHoverEvent extends PointerEvent {
     radiusMin: radiusMin,
     radiusMax: radiusMax,
     orientation: orientation,
-    tilt: tilt
+    tilt: tilt,
+    synthesized: synthesized,
   );
 }
 
@@ -463,7 +479,8 @@ class PointerMoveEvent extends PointerEvent {
     double radiusMin: 0.0,
     double radiusMax: 0.0,
     double orientation: 0.0,
-    double tilt: 0.0
+    double tilt: 0.0,
+    bool synthesized: false,
   }) : super(
     timeStamp: timeStamp,
     pointer: pointer,
@@ -484,7 +501,8 @@ class PointerMoveEvent extends PointerEvent {
     radiusMin: radiusMin,
     radiusMax: radiusMax,
     orientation: orientation,
-    tilt: tilt
+    tilt: tilt,
+    synthesized: synthesized,
   );
 }
 

--- a/packages/flutter/lib/src/gestures/monodrag.dart
+++ b/packages/flutter/lib/src/gestures/monodrag.dart
@@ -130,7 +130,8 @@ abstract class DragGestureRecognizer extends OneSequenceGestureRecognizer {
     if (event is PointerMoveEvent) {
       final VelocityTracker tracker = _velocityTrackers[event.pointer];
       assert(tracker != null);
-      tracker.addPosition(event.timeStamp, event.position);
+      if (!event.synthesized)
+        tracker.addPosition(event.timeStamp, event.position);
       final Offset delta = event.delta;
       if (_state == _DragState.accepted) {
         if (onUpdate != null) {

--- a/packages/flutter/lib/src/gestures/multidrag.dart
+++ b/packages/flutter/lib/src/gestures/multidrag.dart
@@ -62,7 +62,8 @@ abstract class MultiDragPointerState {
 
   void _move(PointerMoveEvent event) {
     assert(_arenaEntry != null);
-    _velocityTracker.addPosition(event.timeStamp, event.position);
+    if (!event.synthesized)
+      _velocityTracker.addPosition(event.timeStamp, event.position);
     if (_client != null) {
       assert(pendingDelta == null);
       // Call client last to avoid reentrancy.

--- a/packages/flutter/lib/src/gestures/scale.dart
+++ b/packages/flutter/lib/src/gestures/scale.dart
@@ -152,7 +152,8 @@ class ScaleGestureRecognizer extends OneSequenceGestureRecognizer {
     if (event is PointerMoveEvent) {
       final VelocityTracker tracker = _velocityTrackers[event.pointer];
       assert(tracker != null);
-      tracker.addPosition(event.timeStamp, event.position);
+      if (!event.synthesized)
+        tracker.addPosition(event.timeStamp, event.position);
       _pointerLocations[event.pointer] = event.position;
       shouldStartIfAccepted = true;
     } else if (event is PointerDownEvent) {


### PR DESCRIPTION
Let framework synthesized pointer events not be used for velocity calculation. 
For #10977. 

Doesn't affect Android.

