### PR TITLE
RTL, alternative approach (not for checkin)

### DIFF
--- a/packages/flutter/lib/src/painting/basic_types.dart
+++ b/packages/flutter/lib/src/painting/basic_types.dart
@@ -90,3 +90,28 @@ enum RenderComparison {
   /// change in a render object.
   layout,
 }
+
+/// The two cardinal directions in two dimensions.
+///
+/// The axis is always relative to the current coordinate space. This means, for
+/// example, that a [horizontal] axis might actually be diagonally from top
+/// right to bottom left, due to some local [Transform] applied to the scene.
+///
+/// See also:
+///
+///  * [AxisDirection], which is a directional version of this enum (with values
+///    light left and right, rather than just horizontal).
+///  * [TextDirection], which disambiguates between left-to-right horizontal
+///    content and right-to-left horizontal content.
+enum Axis {
+  /// Left and right.
+  ///
+  /// See also:
+  ///
+  ///  * [TextDirection], which disambiguates between left-to-right horizontal
+  ///    content and right-to-left horizontal content.
+  horizontal,
+
+  /// Up and down.
+  vertical,
+}

--- a/packages/flutter/lib/src/painting/edge_insets.dart
+++ b/packages/flutter/lib/src/painting/edge_insets.dart
@@ -8,13 +8,188 @@ import 'package:flutter/foundation.dart';
 
 import 'basic_types.dart';
 
-/// The two cardinal directions in two dimensions.
-enum Axis {
-  /// Left and right
-  horizontal,
+/// Base class for [EdgeInsets] that allows for text-direction aware
+/// resolution.
+///
+/// A property or argument of this type accepts classes created either with [new
+/// EdgeInsets.fromLTRB] and its variants, or [new EdgeInsetsDirectional].
+///
+/// To convert a [EdgeInsetsGeometry] object of indeterminate type into a
+/// [EdgeInsets] object, call the [resolve] method.
+///
+/// See also:
+///
+///  * [Padding], a widget that describes margins using [EdgeInsetsGeometry].
+abstract class EdgeInsetsGeometry {
+  /// Abstract const constructor. This constructor enables subclasses to provide
+  /// const constructors so that they can be used in const expressions.
+  const EdgeInsetsGeometry();
 
-  /// Up and down
-  vertical,
+  double get _bottom;
+  double get _end;
+  double get _left;
+  double get _right;
+  double get _start;
+  double get _top;
+
+  /// Whether every dimension is non-negative.
+  bool get isNonNegative {
+    return _left >= 0.0
+        && _right >= 0.0
+        && _start >= 0.0
+        && _end >= 0.0
+        && _top >= 0.0
+        && _bottom >= 0.0;
+  }
+
+  /// The total offset in the vertical direction.
+  double get horizontal => _left + _right + _start + _end;
+
+  /// The total offset in the horizontal direction.
+  double get vertical => _top + _bottom;
+
+  /// The total offset in the given direction.
+  double along(Axis axis) {
+    assert(axis != null);
+    switch (axis) {
+      case Axis.horizontal:
+        return horizontal;
+      case Axis.vertical:
+        return vertical;
+    }
+    return null;
+  }
+
+  /// The size that this [EdgeInsets] would occupy with an empty interior.
+  Size get collapsedSize => new Size(horizontal, vertical);
+
+  /// An [EdgeInsetsGeometry] with top and bottom, left and right, and start and end flipped.
+  EdgeInsetsGeometry get flipped => new _MixedEdgeInsets.fromLRSETB(_right, _left, _end, _start, _bottom, _top);
+
+  /// Returns a new size that is bigger than the given size by the amount of
+  /// inset in the horizontal and vertical directions.
+  ///
+  /// See also:
+  ///
+  ///  * [EdgeInsets.inflateRect], to inflate a [Rect] rather than a [Size] (for
+  ///    [EdgeInsetsDirectional], requires first calling [resolve] to establish
+  ///    how the start and and map to the left or right).
+  ///  * [deflateSize], to deflate a [Size] rather than inflating it.
+  Size inflateSize(Size size) {
+    return new Size(size.width + horizontal, size.height + vertical);
+  }
+
+  /// Returns a new size that is smaller than the given size by the amount of
+  /// inset in the horizontal and vertical directions.
+  ///
+  /// If the argument is smaller than [collapsedSize], then the resulting size
+  /// will have negative dimensions.
+  ///
+  /// See also:
+  ///
+  ///  * [EdgeInsets.deflateRect], to deflate a [Rect] rather than a [Size]. (for
+  ///    [EdgeInsetsDirectional], requires first calling [resolve] to establish
+  ///    how the start and and map to the left or right).
+  ///  * [inflateSize], to inflate a [Size] rather than deflating it.
+  Size deflateSize(Size size) {
+    return new Size(size.width - horizontal, size.height - vertical);
+  }
+
+  /// Returns the difference between two [EdgeInsetsGeometry] objects.
+  EdgeInsetsGeometry operator -(EdgeInsetsGeometry other) {
+    return new _MixedEdgeInsets.fromLRSETB(
+      _left - other._left,
+      _right - other._right,
+      _start - other._start,
+      _end - other._end,
+      _top - other._top,
+      _bottom - other._bottom,
+    );
+  }
+
+  /// Returns the sum of two [EdgeInsetsGeometry] objects.
+  EdgeInsetsGeometry operator +(EdgeInsetsGeometry other) {
+    return new _MixedEdgeInsets.fromLRSETB(
+      _left + other._left,
+      _right + other._right,
+      _start + other._start,
+      _end + other._end,
+      _top + other._top,
+      _bottom + other._bottom,
+    );
+  }
+
+  /// Scales the [EdgeInsetsGeometry] object in each dimension by the given factor.
+  EdgeInsetsGeometry operator *(double other);
+
+  /// Divides the [EdgeInsetsGeometry] object in each dimension by the given factor.
+  EdgeInsetsGeometry operator /(double other);
+
+  /// Integer divides the [EdgeInsetsGeometry] object in each dimension by the given factor.
+  EdgeInsetsGeometry operator ~/(double other);
+
+  /// Computes the remainder in each dimension by the given factor.
+  EdgeInsetsGeometry operator %(double other);
+
+  /// Linearly interpolate between two [EdgeInsetsGeometry].
+  ///
+  /// If either is null, this function interpolates from [EdgeInsetsGeometry.zero].
+  static EdgeInsetsGeometry lerp(EdgeInsetsGeometry a, EdgeInsetsGeometry b, double t) {
+    if (a == null && b == null)
+      return null;
+    if (a == null)
+      return b * t;
+    if (b == null)
+      return a * (1.0 - t);
+    return new _MixedEdgeInsets.fromLRSETB(
+      ui.lerpDouble(a._left, b._left, t),
+      ui.lerpDouble(a._right, b._right, t),
+      ui.lerpDouble(a._start, b._start, t),
+      ui.lerpDouble(a._end, b._end, t),
+      ui.lerpDouble(a._top, b._top, t),
+      ui.lerpDouble(a._bottom, b._bottom, t)
+    );
+  }
+
+  /// Convert this instance into a [EdgeInsets], which uses literal coordinates
+  /// (i.e. the `left` coordinate being explicitly a distance from the left, and
+  /// the `right` coordinate being explicitly a distance from the right).
+  ///
+  /// See also:
+  ///
+  ///  * [EdgeInsets], for which this is a no-op (returns itself).
+  ///  * [EdgeInsetsDirectional], which flips the horizontal direction
+  ///    based on the `direction` argument.
+  EdgeInsets resolve(TextDirection direction);
+
+  @override
+  String toString() {
+    if (_start == 0.0 && _end == 0.0) {
+      if (_left == 0.0 && _right == 0.0 && _top == 0.0 && _bottom == 0.0)
+        return 'EdgeInsets.zero';
+      if (_left == _right && _right == _top && _top == _bottom)
+        return 'EdgeInsets.all(${_left.toStringAsFixed(1)})';
+      return 'EdgeInsets(${_left.toStringAsFixed(1)}, '
+                        '${_top.toStringAsFixed(1)}, '
+                        '${_right.toStringAsFixed(1)}, '
+                        '${_bottom.toStringAsFixed(1)})';
+    }
+    if (_left == 0.0 && _right == 0.0) {
+      return 'EdgeInsetsDirectional(${_start.toStringAsFixed(1)}, '
+                                   '${_top.toStringAsFixed(1)}, '
+                                   '${_end.toStringAsFixed(1)}, '
+                                   '${_bottom.toStringAsFixed(1)})';
+    }
+    return 'EdgeInsets(${_left.toStringAsFixed(1)}, '
+                      '${_top.toStringAsFixed(1)}, '
+                      '${_right.toStringAsFixed(1)}, '
+                      '${_bottom.toStringAsFixed(1)})'
+           ' + '
+           'EdgeInsetsDirectional(${_start.toStringAsFixed(1)}, '
+                                 '0.0, '
+                                 '${_end.toStringAsFixed(1)}, '
+                                 '0.0)';
+  }
 }
 
 /// An immutable set of offsets in each of the four cardinal directions.
@@ -46,13 +221,16 @@ enum Axis {
 ///
 /// See also:
 ///
-///  * [Padding], a widget that describes margins using [EdgeInsets].
+///  * [Padding], a widget that accepts [EdgeInsets] to describe its margins.
+///  * [EdgeInsetsDirectional], which (for properties and arguments that accept
+///    the type [EdgeInsetsGeometry]) allows the horizontal insets to be
+///    specified in a [TextDirection]-aware manner.
 @immutable
-class EdgeInsets {
+class EdgeInsets extends EdgeInsetsGeometry {
   /// Creates insets from offsets from the left, top, right, and bottom.
   const EdgeInsets.fromLTRB(this.left, this.top, this.right, this.bottom);
 
-  /// Creates insets where all the offsets are value.
+  /// Creates insets where all the offsets are `value`.
   ///
   /// ## Sample code
   ///
@@ -108,14 +286,32 @@ class EdgeInsets {
   /// The offset from the left.
   final double left;
 
+  @override
+  double get _left => left;
+
   /// The offset from the top.
   final double top;
+
+  @override
+  double get _top => top;
 
   /// The offset from the right.
   final double right;
 
+  @override
+  double get _right => right;
+
   /// The offset from the bottom.
   final double bottom;
+
+  @override
+  double get _bottom => bottom;
+
+  @override
+  double get _start => 0.0;
+
+  @override
+  double get _end => 0.0;
 
   /// An Offset describing the vector from the top left of a rectangle to the
   /// top left of that rectangle inset by this object.
@@ -133,31 +329,8 @@ class EdgeInsets {
   /// bottom right of that rectangle inset by this object.
   Offset get bottomRight => new Offset(-right, -bottom);
 
-  /// Whether every dimension is non-negative.
-  bool get isNonNegative => left >= 0.0 && top >= 0.0 && right >= 0.0 && bottom >= 0.0;
-
-  /// The total offset in the vertical direction.
-  double get horizontal => left + right;
-
-  /// The total offset in the horizontal direction.
-  double get vertical => top + bottom;
-
-  /// The total offset in the given direction.
-  double along(Axis axis) {
-    assert(axis != null);
-    switch (axis) {
-      case Axis.horizontal:
-        return horizontal;
-      case Axis.vertical:
-        return vertical;
-    }
-    return null;
-  }
-
-  /// The size that this EdgeInsets would occupy with an empty interior.
-  Size get collapsedSize => new Size(horizontal, vertical);
-
-  /// An EdgeInsets with top and bottom as well as left and right flipped.
+  /// An [EdgeInsets] with top and bottom as well as left and right flipped.
+  @override
   EdgeInsets get flipped => new EdgeInsets.fromLTRB(right, bottom, left, top);
 
   /// Returns a new rect that is bigger than the given rect in each direction by
@@ -191,52 +364,36 @@ class EdgeInsets {
     return new Rect.fromLTRB(rect.left + left, rect.top + top, rect.right - right, rect.bottom - bottom);
   }
 
-  /// Returns a new size that is bigger than the given size by the amount of
-  /// inset in the horizontal and vertical directions.
-  ///
-  /// See also:
-  ///
-  ///  * [inflateRect], to inflate a [Rect] rather than a [Size].
-  ///  * [deflateSize], to deflate a [Size] rather than inflating it.
-  Size inflateSize(Size size) {
-    return new Size(size.width + horizontal, size.height + vertical);
+  /// Returns the difference between two [EdgeInsets].
+  @override
+  EdgeInsetsGeometry operator -(EdgeInsetsGeometry other) {
+    if (other is EdgeInsets) {
+      return new EdgeInsets.fromLTRB(
+        left - other.left,
+        top - other.top,
+        right - other.right,
+        bottom - other.bottom
+      );
+    }
+    return super - other;
   }
 
-  /// Returns a new size that is smaller than the given size by the amount of
-  /// inset in the horizontal and vertical directions.
-  ///
-  /// If the argument is smaller than [collapsedSize], then the resulting size
-  /// will have negative dimensions.
-  ///
-  /// See also:
-  ///
-  ///  * [deflateRect], to deflate a [Rect] rather than a [Size].
-  ///  * [inflateSize], to inflate a [Size] rather than deflating it.
-  Size deflateSize(Size size) {
-    return new Size(size.width - horizontal, size.height - vertical);
+  /// Returns the sum of two [EdgeInsets].
+  @override
+  EdgeInsetsGeometry operator +(EdgeInsetsGeometry other) {
+    if (other is EdgeInsets) {
+      return new EdgeInsets.fromLTRB(
+        left + other.left,
+        top + other.top,
+        right + other.right,
+        bottom + other.bottom
+      );
+    }
+    return super + other;
   }
 
-  /// Returns the difference between two EdgeInsets.
-  EdgeInsets operator -(EdgeInsets other) {
-    return new EdgeInsets.fromLTRB(
-      left - other.left,
-      top - other.top,
-      right - other.right,
-      bottom - other.bottom
-    );
-  }
-
-  /// Returns the sum of two EdgeInsets.
-  EdgeInsets operator +(EdgeInsets other) {
-    return new EdgeInsets.fromLTRB(
-      left + other.left,
-      top + other.top,
-      right + other.right,
-      bottom + other.bottom
-    );
-  }
-
-  /// Scales the EdgeInsets in each dimension by the given factor.
+  /// Scales the [EdgeInsets] in each dimension by the given factor.
+  @override
   EdgeInsets operator *(double other) {
     return new EdgeInsets.fromLTRB(
       left * other,
@@ -246,7 +403,8 @@ class EdgeInsets {
     );
   }
 
-  /// Divides the EdgeInsets in each dimension by the given factor.
+  /// Divides the [EdgeInsets] in each dimension by the given factor.
+  @override
   EdgeInsets operator /(double other) {
     return new EdgeInsets.fromLTRB(
       left / other,
@@ -256,7 +414,8 @@ class EdgeInsets {
     );
   }
 
-  /// Integer divides the EdgeInsets in each dimension by the given factor.
+  /// Integer divides the [EdgeInsets] in each dimension by the given factor.
+  @override
   EdgeInsets operator ~/(double other) {
     return new EdgeInsets.fromLTRB(
       (left ~/ other).toDouble(),
@@ -267,6 +426,7 @@ class EdgeInsets {
   }
 
   /// Computes the remainder in each dimension by the given factor.
+  @override
   EdgeInsets operator %(double other) {
     return new EdgeInsets.fromLTRB(
       left % other,
@@ -276,7 +436,7 @@ class EdgeInsets {
     );
   }
 
-  /// Linearly interpolate between two EdgeInsets.
+  /// Linearly interpolate between two [EdgeInsets].
   ///
   /// If either is null, this function interpolates from [EdgeInsets.zero].
   static EdgeInsets lerp(EdgeInsets a, EdgeInsets b, double t) {
@@ -294,14 +454,17 @@ class EdgeInsets {
     );
   }
 
-  /// An EdgeInsets with zero offsets in each direction.
+  /// An [EdgeInsets] with zero offsets in each direction.
   static const EdgeInsets zero = const EdgeInsets.all(0.0);
+
+  @override
+  EdgeInsets resolve(TextDirection direction) => this;
 
   @override
   bool operator ==(dynamic other) {
     if (identical(this, other))
       return true;
-    if (other is! EdgeInsets)
+    if (other.runtimeType != runtimeType)
       return false;
     final EdgeInsets typedOther = other;
     return left == typedOther.left &&
@@ -312,7 +475,260 @@ class EdgeInsets {
 
   @override
   int get hashCode => hashValues(left, top, right, bottom);
+}
+
+/// An immutable set of offsets in each of the four cardinal directions, but
+/// whose horizontal components are dependent on the writing direction.
+///
+/// This can be used to indicate padding from the left in [TextDirection.ltr]
+/// text and padding from the right in [TextDirection.rtl] text without having
+/// to be aware of the current text direction.
+class EdgeInsetsDirectional extends EdgeInsetsGeometry {
+  /// Creates insets from offsets from the start, top, end, and bottom.
+  const EdgeInsetsDirectional.fromSTEB(this.start, this.top, this.end, this.bottom);
+
+  /// Creates insets with only the given values non-zero.
+  ///
+  /// ## Sample code
+  ///
+  /// A margin indent of 40 pixels on the leading side:
+  ///
+  /// ```dart
+  /// const EdgeInsetsDirectional.only(start: 40.0)
+  /// ```
+  const EdgeInsetsDirectional.only({
+    this.start: 0.0,
+    this.top: 0.0,
+    this.end: 0.0,
+    this.bottom: 0.0
+  });
+
+  /// The offset from the start side, the side from which the user will start
+  /// reading text.
+  ///
+  /// This value is normalized into an [EdgeInsets.left] or [EdgeInsets.right]
+  /// value by the [resolve] method.
+  final double start;
 
   @override
-  String toString() => "EdgeInsets($left, $top, $right, $bottom)";
+  double get _start => start;
+
+  /// The offset from the top.
+  ///
+  /// This value is passed through to [EdgeInsets.top] unmodified by the
+  /// [resolve] method.
+  final double top;
+
+  @override
+  double get _top => top;
+
+  /// The offset from the end side, the side on which the user ends reading
+  /// text.
+  ///
+  /// This value is normalized into an [EdgeInsets.left] or [EdgeInsets.right]
+  /// value by the [resolve] method.
+  final double end;
+
+  @override
+  double get _end => end;
+
+  /// The offset from the bottom.
+  ///
+  /// This value is passed through to [EdgeInsets.bottom] unmodified by the
+  /// [resolve] method.
+  final double bottom;
+
+  @override
+  double get _bottom => bottom;
+
+  @override
+  double get _left => 0.0;
+
+  @override
+  double get _right => 0.0;
+
+  @override
+  bool get isNonNegative => start >= 0.0 && top >= 0.0 && end >= 0.0 && bottom >= 0.0;
+
+  /// An [EdgeInsetsDirectional] with [top] and [bottom] as well as [start] and [end] flipped.
+  @override
+  EdgeInsetsDirectional get flipped => new EdgeInsetsDirectional.fromSTEB(end, bottom, start, top);
+
+  /// Scales the [EdgeInsetsDirectional] in each dimension by the given factor.
+  @override
+  EdgeInsetsDirectional operator *(double other) {
+    return new EdgeInsetsDirectional.fromSTEB(
+      start * other,
+      top * other,
+      end * other,
+      bottom * other
+    );
+  }
+
+  /// Divides the [EdgeInsetsDirectional] in each dimension by the given factor.
+  @override
+  EdgeInsetsDirectional operator /(double other) {
+    return new EdgeInsetsDirectional.fromSTEB(
+      start / other,
+      top / other,
+      end / other,
+      bottom / other
+    );
+  }
+
+  /// Integer divides the [EdgeInsetsDirectional] in each dimension by the given factor.
+  @override
+  EdgeInsetsDirectional operator ~/(double other) {
+    return new EdgeInsetsDirectional.fromSTEB(
+      (start ~/ other).toDouble(),
+      (top ~/ other).toDouble(),
+      (end ~/ other).toDouble(),
+      (bottom ~/ other).toDouble()
+    );
+  }
+
+  /// Computes the remainder in each dimension by the given factor.
+  @override
+  EdgeInsetsDirectional operator %(double other) {
+    return new EdgeInsetsDirectional.fromSTEB(
+      start % other,
+      top % other,
+      end % other,
+      bottom % other
+    );
+  }
+
+  @override
+  EdgeInsets resolve(TextDirection direction) {
+    assert(direction != null);
+    switch (direction) {
+      case TextDirection.ltr:
+        return new EdgeInsets.fromLTRB(start, top, end, bottom);
+      case TextDirection.rtl:
+        return new EdgeInsets.fromLTRB(end, top, start, bottom);
+    }
+    return null;
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    if (other.runtimeType != runtimeType)
+      return false;
+    final EdgeInsetsDirectional typedOther = other;
+    return start == typedOther.start &&
+           top == typedOther.top &&
+           end == typedOther.end &&
+           bottom == typedOther.bottom;
+  }
+
+  @override
+  int get hashCode => hashValues(start, top, end, bottom);
+}
+
+class _MixedEdgeInsets extends EdgeInsetsGeometry {
+  const _MixedEdgeInsets.fromLRSETB(this._left, this._right, this._start, this._end, this._top, this._bottom);
+
+  @override
+  final double _left;
+
+  @override
+  final double _right;
+
+  @override
+  final double _start;
+
+  @override
+  final double _end;
+
+  @override
+  final double _top;
+
+  @override
+  final double _bottom;
+
+  @override
+  bool get isNonNegative {
+    return _left >= 0.0
+        && _right >= 0.0
+        && _start >= 0.0
+        && _end >= 0.0
+        && _top >= 0.0
+        && _bottom >= 0.0;
+  }
+
+  @override
+  _MixedEdgeInsets operator *(double other) {
+    return new _MixedEdgeInsets.fromLRSETB(
+      _left * other,
+      _right * other,
+      _start * other,
+      _end * other,
+      _top * other,
+      _bottom * other
+    );
+  }
+
+  @override
+  _MixedEdgeInsets operator /(double other) {
+    return new _MixedEdgeInsets.fromLRSETB(
+      _left / other,
+      _right / other,
+      _start / other,
+      _end / other,
+      _top / other,
+      _bottom / other
+    );
+  }
+
+  @override
+  _MixedEdgeInsets operator ~/(double other) {
+    return new _MixedEdgeInsets.fromLRSETB(
+      (_left ~/ other).toDouble(),
+      (_right ~/ other).toDouble(),
+      (_start ~/ other).toDouble(),
+      (_end ~/ other).toDouble(),
+      (_top ~/ other).toDouble(),
+      (_bottom ~/ other).toDouble(),
+    );
+  }
+
+  @override
+  _MixedEdgeInsets operator %(double other) {
+    return new _MixedEdgeInsets.fromLRSETB(
+      _left % other,
+      _right % other,
+      _start % other,
+      _end % other,
+      _top % other,
+      _bottom % other
+    );
+  }
+
+  @override
+  EdgeInsets resolve(TextDirection direction) {
+    assert(direction != null);
+    switch (direction) {
+      case TextDirection.ltr:
+        return new EdgeInsets.fromLTRB(_start + _left, _top, _end + _right, _bottom);
+      case TextDirection.rtl:
+        return new EdgeInsets.fromLTRB(_end + _left, _top, _start + _left, _bottom);
+    }
+    return null;
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    if (other.runtimeType != runtimeType)
+      return false;
+    final _MixedEdgeInsets typedOther = other;
+    return _left == typedOther._left &&
+           _right == typedOther._right &&
+           _start == typedOther._start &&
+           _end == typedOther._end &&
+           _top == typedOther._top &&
+           _bottom == typedOther._bottom;
+  }
+
+  @override
+  int get hashCode => hashValues(_left, _right, _start, _end, _top, _bottom);
 }

--- a/packages/flutter/lib/src/rendering/node.dart
+++ b/packages/flutter/lib/src/rendering/node.dart
@@ -43,7 +43,7 @@ class AbstractNode {
   int get depth => _depth;
   int _depth = 0;
 
-  /// Adjust the [depth] of the given [child] to be greated than this node's own
+  /// Adjust the [depth] of the given [child] to be greater than this node's own
   /// [depth].
   ///
   /// Only call this method from overrides of [redepthChildren].

--- a/packages/flutter/lib/src/rendering/shifted_box.dart
+++ b/packages/flutter/lib/src/rendering/shifted_box.dart
@@ -91,29 +91,58 @@ class RenderPadding extends RenderShiftedBox {
   ///
   /// The [padding] argument must not be null and must have non-negative insets.
   RenderPadding({
-    @required EdgeInsets padding,
-    RenderBox child
+    @required EdgeInsetsGeometry padding,
+    TextDirection textDirection,
+    RenderBox child,
   }) : assert(padding != null),
        assert(padding.isNonNegative),
+       _textDirection = textDirection,
        _padding = padding,
-       super(child);
+       super(child) {
+    _applyUpdate();
+  }
+
+  // The resolved absolute insets.
+  EdgeInsets _resolvedPadding;
+
+  void _applyUpdate() {
+    final EdgeInsets resolvedPadding = padding.resolve(textDirection);
+    assert(resolvedPadding.isNonNegative);
+    if (resolvedPadding != _resolvedPadding) {
+      _resolvedPadding = resolvedPadding;
+      markNeedsLayout();
+    }
+  }
 
   /// The amount to pad the child in each dimension.
-  EdgeInsets get padding => _padding;
-  EdgeInsets _padding;
-  set padding(EdgeInsets value) {
+  ///
+  /// If this is set to an [EdgeInsetsDirectional] object, then [textDirection]
+  /// must be non-null.
+  EdgeInsetsGeometry get padding => _padding;
+  EdgeInsetsGeometry _padding;
+  set padding(EdgeInsetsGeometry value) {
     assert(value != null);
     assert(value.isNonNegative);
     if (_padding == value)
       return;
     _padding = value;
-    markNeedsLayout();
+    _applyUpdate();
+  }
+
+  /// The text direction with which to resolve [padding].
+  TextDirection get textDirection => _textDirection;
+  TextDirection _textDirection;
+  set textDirection(TextDirection value) {
+    if (_textDirection == value)
+      return;
+    _textDirection = value;
+    _applyUpdate();
   }
 
   @override
   double computeMinIntrinsicWidth(double height) {
-    final double totalHorizontalPadding = padding.left + padding.right;
-    final double totalVerticalPadding = padding.top + padding.bottom;
+    final double totalHorizontalPadding = _resolvedPadding.left + _resolvedPadding.right;
+    final double totalVerticalPadding = _resolvedPadding.top + _resolvedPadding.bottom;
     if (child != null) // next line relies on double.INFINITY absorption
       return child.getMinIntrinsicWidth(math.max(0.0, height - totalVerticalPadding)) + totalHorizontalPadding;
     return totalHorizontalPadding;
@@ -121,8 +150,8 @@ class RenderPadding extends RenderShiftedBox {
 
   @override
   double computeMaxIntrinsicWidth(double height) {
-    final double totalHorizontalPadding = padding.left + padding.right;
-    final double totalVerticalPadding = padding.top + padding.bottom;
+    final double totalHorizontalPadding = _resolvedPadding.left + _resolvedPadding.right;
+    final double totalVerticalPadding = _resolvedPadding.top + _resolvedPadding.bottom;
     if (child != null) // next line relies on double.INFINITY absorption
       return child.getMaxIntrinsicWidth(math.max(0.0, height - totalVerticalPadding)) + totalHorizontalPadding;
     return totalHorizontalPadding;
@@ -130,8 +159,8 @@ class RenderPadding extends RenderShiftedBox {
 
   @override
   double computeMinIntrinsicHeight(double width) {
-    final double totalHorizontalPadding = padding.left + padding.right;
-    final double totalVerticalPadding = padding.top + padding.bottom;
+    final double totalHorizontalPadding = _resolvedPadding.left + _resolvedPadding.right;
+    final double totalVerticalPadding = _resolvedPadding.top + _resolvedPadding.bottom;
     if (child != null) // next line relies on double.INFINITY absorption
       return child.getMinIntrinsicHeight(math.max(0.0, width - totalHorizontalPadding)) + totalVerticalPadding;
     return totalVerticalPadding;
@@ -139,8 +168,8 @@ class RenderPadding extends RenderShiftedBox {
 
   @override
   double computeMaxIntrinsicHeight(double width) {
-    final double totalHorizontalPadding = padding.left + padding.right;
-    final double totalVerticalPadding = padding.top + padding.bottom;
+    final double totalHorizontalPadding = _resolvedPadding.left + _resolvedPadding.right;
+    final double totalVerticalPadding = _resolvedPadding.top + _resolvedPadding.bottom;
     if (child != null) // next line relies on double.INFINITY absorption
       return child.getMaxIntrinsicHeight(math.max(0.0, width - totalHorizontalPadding)) + totalVerticalPadding;
     return totalVerticalPadding;
@@ -148,21 +177,21 @@ class RenderPadding extends RenderShiftedBox {
 
   @override
   void performLayout() {
-    assert(padding != null);
+    assert(_resolvedPadding != null);
     if (child == null) {
       size = constraints.constrain(new Size(
-        padding.left + padding.right,
-        padding.top + padding.bottom
+        _resolvedPadding.left + _resolvedPadding.right,
+        _resolvedPadding.top + _resolvedPadding.bottom
       ));
       return;
     }
-    final BoxConstraints innerConstraints = constraints.deflate(padding);
+    final BoxConstraints innerConstraints = constraints.deflate(_resolvedPadding);
     child.layout(innerConstraints, parentUsesSize: true);
     final BoxParentData childParentData = child.parentData;
-    childParentData.offset = new Offset(padding.left, padding.top);
+    childParentData.offset = new Offset(_resolvedPadding.left, _resolvedPadding.top);
     size = constraints.constrain(new Size(
-      padding.left + child.size.width + padding.right,
-      padding.top + child.size.height + padding.bottom
+      _resolvedPadding.left + child.size.width + _resolvedPadding.right,
+      _resolvedPadding.top + child.size.height + _resolvedPadding.bottom
     ));
   }
 
@@ -171,7 +200,7 @@ class RenderPadding extends RenderShiftedBox {
     super.debugPaintSize(context, offset);
     assert(() {
       final Rect outerRect = offset & size;
-      debugPaintPadding(context.canvas, outerRect, child != null ? padding.deflateRect(outerRect) : null);
+      debugPaintPadding(context.canvas, outerRect, child != null ? _resolvedPadding.deflateRect(outerRect) : null);
       return true;
     });
   }
@@ -179,7 +208,8 @@ class RenderPadding extends RenderShiftedBox {
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder description) {
     super.debugFillProperties(description);
-    description.add(new DiagnosticsProperty<EdgeInsets>('padding', padding));
+    description.add(new DiagnosticsProperty<EdgeInsetsGeometry>('padding', padding));
+    description.add(new EnumProperty<TextDirection>('textDirection', textDirection));
   }
 }
 

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -55,6 +55,50 @@ export 'package:flutter/rendering.dart' show
   WrapAlignment,
   WrapCrossAlignment;
 
+// BIDIRECTIONAL TEXT SUPPORT
+
+/// A widget that determines the ambient directionality of text and
+/// text-direction-sensitive render objects.
+///
+/// For example, [Padding] depends on the [Directionality] to resolve
+/// [EdgeInsetsDirectional] objects into absolute [EdgeInsets] objects.
+class Directionality extends InheritedWidget {
+  /// Creates a widget that determines the directionality of text and
+  /// text-direction-sensitive render objects.
+  ///
+  /// The [textDirection] and [child] arguments must not be null.
+  const Directionality({
+    Key key,
+    @required this.textDirection,
+    @required Widget child
+  }) : assert(textDirection != null),
+       assert(child != null),
+       super(key: key, child: child);
+
+  /// The text direction for this subtree.
+  final TextDirection textDirection;
+
+  /// The text direction from the closest instance of this class that encloses
+  /// the given context.
+  ///
+  /// If there is no [Directionality] ancestor widget in the tree at the given
+  /// context, then this will return null.
+  ///
+  /// Typical usage is as follows:
+  ///
+  /// ```dart
+  /// TextDirection textDirection = Directionality.of(context);
+  /// ```
+  static TextDirection of(BuildContext context) {
+    final Directionality widget = context.inheritFromWidgetOfExactType(Directionality);
+    return widget?.textDirection;
+  }
+
+  @override
+  bool updateShouldNotify(Directionality old) => textDirection != old.textDirection;
+}
+
+
 // PAINTING NODES
 
 /// A widget that makes its child partially transparent.
@@ -1066,14 +1110,21 @@ class Padding extends SingleChildRenderObjectWidget {
        super(key: key, child: child);
 
   /// The amount of space by which to inset the child.
-  final EdgeInsets padding;
+  final EdgeInsetsGeometry padding;
 
   @override
-  RenderPadding createRenderObject(BuildContext context) => new RenderPadding(padding: padding);
+  RenderPadding createRenderObject(BuildContext context) {
+    return new RenderPadding(
+      padding: padding,
+      textDirection: Directionality.of(context),
+    );
+  }
 
   @override
   void updateRenderObject(BuildContext context, RenderPadding renderObject) {
-    renderObject.padding = padding;
+    renderObject
+      ..padding = padding
+      ..textDirection = Directionality.of(context);
   }
 
   @override
@@ -2007,6 +2058,8 @@ class SliverPadding extends SingleChildRenderObjectWidget {
 
   /// The amount of space by which to inset the child sliver.
   final EdgeInsets padding;
+
+  // TODO(ianh): RTL
 
   @override
   RenderSliverPadding createRenderObject(BuildContext context) => new RenderSliverPadding(padding: padding);

--- a/packages/flutter/lib/src/widgets/container.dart
+++ b/packages/flutter/lib/src/widgets/container.dart
@@ -282,7 +282,7 @@ class Container extends StatelessWidget {
 
   /// Empty space to inscribe inside the [decoration]. The [child], if any, is
   /// placed inside this padding.
-  final EdgeInsets padding;
+  final EdgeInsetsGeometry padding;
 
   /// The decoration to paint behind the [child].
   ///
@@ -303,15 +303,15 @@ class Container extends StatelessWidget {
   final BoxConstraints constraints;
 
   /// Empty space to surround the [decoration] and [child].
-  final EdgeInsets margin;
+  final EdgeInsetsGeometry margin;
 
   /// The transformation matrix to apply before painting the container.
   final Matrix4 transform;
 
-  EdgeInsets get _paddingIncludingDecoration {
+  EdgeInsetsGeometry _getPaddingIncludingDecoration(BuildContext context) {
     if (decoration == null || decoration.padding == null)
       return padding;
-    final EdgeInsets decorationPadding = decoration.padding;
+    final EdgeInsetsGeometry decorationPadding = decoration.padding;
     if (padding == null)
       return decorationPadding;
     return padding + decorationPadding;
@@ -332,7 +332,7 @@ class Container extends StatelessWidget {
     if (alignment != null)
       current = new Align(alignment: alignment, child: current);
 
-    final EdgeInsets effectivePadding = _paddingIncludingDecoration;
+    final EdgeInsetsGeometry effectivePadding = _getPaddingIncludingDecoration(context);
     if (effectivePadding != null)
       current = new Padding(padding: effectivePadding, child: current);
 
@@ -363,11 +363,11 @@ class Container extends StatelessWidget {
   void debugFillProperties(DiagnosticPropertiesBuilder description) {
     super.debugFillProperties(description);
     description.add(new DiagnosticsProperty<FractionalOffset>('alignment', alignment, showName: false, defaultValue: null));
-    description.add(new DiagnosticsProperty<EdgeInsets>('padding', padding, defaultValue: null));
+    description.add(new DiagnosticsProperty<EdgeInsetsGeometry>('padding', padding, defaultValue: null));
     description.add(new DiagnosticsProperty<Decoration>('bg', decoration, defaultValue: null));
     description.add(new DiagnosticsProperty<Decoration>('fg', foregroundDecoration, defaultValue: null));
     description.add(new DiagnosticsProperty<BoxConstraints>('constraints', constraints, defaultValue: null));
-    description.add(new DiagnosticsProperty<EdgeInsets>('margin', margin, defaultValue: null));
+    description.add(new DiagnosticsProperty<EdgeInsetsGeometry>('margin', margin, defaultValue: null));
     description.add(new ObjectFlagProperty<Matrix4>.has('transform', transform));
   }
 }

--- a/packages/flutter/test/painting/edge_insets_test.dart
+++ b/packages/flutter/test/painting/edge_insets_test.dart
@@ -50,4 +50,25 @@ void main() {
     expect(EdgeInsets.lerp(null, b, 0.25), equals(b * 0.25));
     expect(EdgeInsets.lerp(a, null, 0.25), equals(a * 0.75));
   });
+
+  test('EdgeInsets.resolve()', () {
+    expect(new EdgeInsetsDirectional.fromSTEB(10.0, 20.0, 30.0, 40.0).resolve(TextDirection.ltr), const EdgeInsets.fromLTRB(10.0, 20.0, 30.0, 40.0));
+    expect(new EdgeInsetsDirectional.fromSTEB(99.0, 98.0, 97.0, 96.0).resolve(TextDirection.rtl), const EdgeInsets.fromLTRB(97.0, 98.0, 99.0, 96.0));
+    expect(new EdgeInsetsDirectional.only(start: 963.25).resolve(TextDirection.ltr), const EdgeInsets.fromLTRB(963.25, 0.0, 0.0, 0.0));
+    expect(new EdgeInsetsDirectional.only(top: 963.25).resolve(TextDirection.ltr), const EdgeInsets.fromLTRB(0.0, 963.25, 0.0, 0.0));
+    expect(new EdgeInsetsDirectional.only(end: 963.25).resolve(TextDirection.ltr), const EdgeInsets.fromLTRB(0.0, 0.0, 963.25, 0.0));
+    expect(new EdgeInsetsDirectional.only(bottom: 963.25).resolve(TextDirection.ltr), const EdgeInsets.fromLTRB(0.0, 0.0, 0.0, 963.25));
+    expect(new EdgeInsetsDirectional.only(start: 963.25).resolve(TextDirection.rtl), const EdgeInsets.fromLTRB(0.0, 0.0, 963.25, 0.0));
+    expect(new EdgeInsetsDirectional.only(top: 963.25).resolve(TextDirection.rtl), const EdgeInsets.fromLTRB(0.0, 963.25, 0.0, 0.0));
+    expect(new EdgeInsetsDirectional.only(end: 963.25).resolve(TextDirection.rtl), const EdgeInsets.fromLTRB(963.25, 0.0, 0.0, 0.0));
+    expect(new EdgeInsetsDirectional.only(bottom: 963.25).resolve(TextDirection.rtl), const EdgeInsets.fromLTRB(0.0, 0.0, 0.0, 963.25));
+    expect(new EdgeInsetsDirectional.only(), new EdgeInsetsDirectional.only());
+    expect(new EdgeInsetsDirectional.only(top: 1.0).hashCode, isNot(new EdgeInsetsDirectional.only(bottom: 1.0)));
+    expect(new EdgeInsetsDirectional.fromSTEB(10.0, 20.0, 30.0, 40.0).resolve(TextDirection.ltr),
+           new EdgeInsetsDirectional.fromSTEB(30.0, 20.0, 10.0, 40.0).resolve(TextDirection.rtl));
+    expect(new EdgeInsetsDirectional.fromSTEB(10.0, 20.0, 30.0, 40.0).resolve(TextDirection.ltr),
+     isNot(new EdgeInsetsDirectional.fromSTEB(30.0, 20.0, 10.0, 40.0).resolve(TextDirection.ltr)));
+    expect(new EdgeInsetsDirectional.fromSTEB(10.0, 20.0, 30.0, 40.0).resolve(TextDirection.ltr),
+     isNot(new EdgeInsetsDirectional.fromSTEB(10.0, 20.0, 30.0, 40.0).resolve(TextDirection.rtl)));
+  });
 }

--- a/packages/flutter/test/painting/fractional_offset_test.dart
+++ b/packages/flutter/test/painting/fractional_offset_test.dart
@@ -36,4 +36,27 @@ void main() {
     final FractionalOffset a = new FractionalOffset.fromOffsetAndRect(const Offset(150.0, 120.0), new Rect.fromLTWH(50.0, 20.0, 200.0, 400.0));
     expect(a, const FractionalOffset(0.5, 0.25));
   });
+
+  test('FractionalOffsetGeometry.resolve()', () {
+    expect(new FractionalOffsetDirectional(0.25, 0.3).resolve(TextDirection.ltr), const FractionalOffset(0.25, 0.3));
+    expect(new FractionalOffsetDirectional(0.25, 0.3).resolve(TextDirection.rtl), const FractionalOffset(0.75, 0.3));
+    expect(new FractionalOffsetDirectional(-0.25, 0.3).resolve(TextDirection.ltr), const FractionalOffset(-0.25, 0.3));
+    expect(new FractionalOffsetDirectional(-0.25, 0.3).resolve(TextDirection.rtl), const FractionalOffset(1.25, 0.3));
+    expect(new FractionalOffsetDirectional(1.25, 0.3).resolve(TextDirection.ltr), const FractionalOffset(1.25, 0.3));
+    expect(new FractionalOffsetDirectional(1.25, 0.3).resolve(TextDirection.rtl), const FractionalOffset(-0.25, 0.3));
+    expect(new FractionalOffsetDirectional(0.5, -0.3).resolve(TextDirection.ltr), const FractionalOffset(0.5, -0.3));
+    expect(new FractionalOffsetDirectional(0.5, -0.3).resolve(TextDirection.rtl), const FractionalOffset(0.5, -0.3));
+    expect(new FractionalOffsetDirectional(0.0, 0.0).resolve(TextDirection.ltr), const FractionalOffset(0.0, 0.0));
+    expect(new FractionalOffsetDirectional(0.0, 0.0).resolve(TextDirection.rtl), const FractionalOffset(1.0, 0.0));
+    expect(new FractionalOffsetDirectional(1.0, 1.0).resolve(TextDirection.ltr), const FractionalOffset(1.0, 1.0));
+    expect(new FractionalOffsetDirectional(1.0, 1.0).resolve(TextDirection.rtl), const FractionalOffset(0.0, 1.0));
+    expect(new FractionalOffsetDirectional(1.0, 2.0), new FractionalOffsetDirectional(1.0, 2.0));
+    expect(new FractionalOffsetDirectional(1.0, 2.0).hashCode, isNot(new FractionalOffsetDirectional(2.0, 1.0)));
+    expect(new FractionalOffsetDirectional(0.0, 0.0).resolve(TextDirection.ltr),
+           new FractionalOffsetDirectional(1.0, 0.0).resolve(TextDirection.rtl));
+    expect(new FractionalOffsetDirectional(0.0, 0.0).resolve(TextDirection.ltr),
+     isNot(new FractionalOffsetDirectional(1.0, 0.0).resolve(TextDirection.ltr)));
+    expect(new FractionalOffsetDirectional(1.0, 0.0).resolve(TextDirection.ltr),
+     isNot(new FractionalOffsetDirectional(1.0, 0.0).resolve(TextDirection.rtl)));
+  });
 }

--- a/packages/flutter/test/widgets/rtl_test.dart
+++ b/packages/flutter/test/widgets/rtl_test.dart
@@ -1,0 +1,70 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter/widgets.dart';
+
+void main() {
+  testWidgets('Padding RTL', (WidgetTester tester) async {
+    final Widget child = new Padding(
+      padding: new EdgeInsetsDirectional.only(start: 10.0),
+      child: new Placeholder(),
+    );
+    await tester.pumpWidget(new Directionality(
+      textDirection: TextDirection.ltr,
+      child: child,
+    ));
+    expect(tester.getTopLeft(find.byType(Placeholder)), const Offset(10.0, 0.0));
+    await tester.pumpWidget(new Directionality(
+      textDirection: TextDirection.rtl,
+      child: child,
+    ));
+    expect(tester.getTopLeft(find.byType(Placeholder)), const Offset(0.0, 0.0));
+  });
+
+  testWidgets('Container padding/margin RTL', (WidgetTester tester) async {
+    final Widget child = new Container(
+      padding: new EdgeInsetsDirectional.only(start: 6.0),
+      margin: new EdgeInsetsDirectional.only(end: 20.0, start: 4.0),
+      child: new Placeholder(),
+    );
+    await tester.pumpWidget(new Directionality(
+      textDirection: TextDirection.ltr,
+      child: child,
+    ));
+    expect(tester.getTopLeft(find.byType(Placeholder)), const Offset(10.0, 0.0));
+    expect(tester.getTopRight(find.byType(Placeholder)), const Offset(780.0, 0.0));
+    await tester.pumpWidget(new Directionality(
+      textDirection: TextDirection.rtl,
+      child: child,
+    ));
+    expect(tester.getTopLeft(find.byType(Placeholder)), const Offset(20.0, 0.0));
+    expect(tester.getTopRight(find.byType(Placeholder)), const Offset(790.0, 0.0));
+  });
+
+  testWidgets('Container padding/margin mixed RTL/absolute', (WidgetTester tester) async {
+    final Widget child = new Container(
+      padding: new EdgeInsets.only(left: 6.0),
+      margin: new EdgeInsetsDirectional.only(end: 20.0, start: 4.0),
+      child: new Placeholder(),
+    );
+    await tester.pumpWidget(new Directionality(
+      textDirection: TextDirection.ltr,
+      child: child,
+    ));
+    expect(tester.getTopLeft(find.byType(Placeholder)), const Offset(10.0, 0.0));
+    expect(tester.getTopRight(find.byType(Placeholder)), const Offset(780.0, 0.0));
+    await tester.pumpWidget(new Directionality(
+      textDirection: TextDirection.rtl,
+      child: child,
+    ));
+    expect(tester.getTopLeft(find.byType(Placeholder)), const Offset(26.0, 0.0));
+    expect(tester.getTopRight(find.byType(Placeholder)), const Offset(796.0, 0.0));
+  });
+
+  testWidgets('EdgeInsetsDirectional without Directionality', (WidgetTester tester) async {
+    await tester.pumpWidget(new Padding(padding: new EdgeInsetsDirectional.only()));
+    expect(tester.takeException(), isAssertionError);
+  });
+}


### PR DESCRIPTION
This makes it possible to configure Padding (including
Container.padding and Container.margin) using a
directionality-agnostic EdgeInsets variant.

It also introduces a Directionality inherited widget which sets the
ambient LTR vs RTL mode, defaulting to null, which means you cannot
use directionality-influenced padding.