### PR TITLE
Remove unnecessary closures

### DIFF
--- a/packages/flutter/lib/src/material/bottom_navigation_bar.dart
+++ b/packages/flutter/lib/src/material/bottom_navigation_bar.dart
@@ -278,10 +278,7 @@ class _BottomNavigationBarState extends State<BottomNavigationBar> with TickerPr
           children.add(
             new Expanded(
               child: new InkResponse(
-                onTap: () {
-                  if (widget.onTap != null)
-                    widget.onTap(i);
-                },
+                onTap: widget.onTap != null ? () { widget.onTap(i); } : null,
                 child: new Stack(
                   alignment: FractionalOffset.center,
                   children: <Widget>[

--- a/packages/flutter/lib/src/material/bottom_navigation_bar.dart
+++ b/packages/flutter/lib/src/material/bottom_navigation_bar.dart
@@ -278,7 +278,10 @@ class _BottomNavigationBarState extends State<BottomNavigationBar> with TickerPr
           children.add(
             new Expanded(
               child: new InkResponse(
-                onTap: widget.onTap != null ? () { widget.onTap(i); } : null,
+                onTap: () {
+                  if (widget.onTap != null)
+                    widget.onTap(i);
+                },
                 child: new Stack(
                   alignment: FractionalOffset.center,
                   children: <Widget>[

--- a/packages/flutter/lib/src/material/bottom_sheet.dart
+++ b/packages/flutter/lib/src/material/bottom_sheet.dart
@@ -179,7 +179,6 @@ class _ModalBottomSheet<T> extends StatefulWidget {
 }
 
 class _ModalBottomSheetState<T> extends State<_ModalBottomSheet<T>> {
-
   void _navigatorPop() {
     Navigator.pop(context);
   }

--- a/packages/flutter/lib/src/material/bottom_sheet.dart
+++ b/packages/flutter/lib/src/material/bottom_sheet.dart
@@ -179,10 +179,15 @@ class _ModalBottomSheet<T> extends StatefulWidget {
 }
 
 class _ModalBottomSheetState<T> extends State<_ModalBottomSheet<T>> {
+
+  void _navigatorPop() {
+    Navigator.pop(context);
+  }
+
   @override
   Widget build(BuildContext context) {
     return new GestureDetector(
-      onTap: () => Navigator.pop(context),
+      onTap: _navigatorPop,
       child: new AnimatedBuilder(
         animation: widget.route.animation,
         builder: (BuildContext context, Widget child) {

--- a/packages/flutter/lib/src/material/date_picker.dart
+++ b/packages/flutter/lib/src/material/date_picker.dart
@@ -735,6 +735,10 @@ class _DatePickerDialogState extends State<_DatePickerDialog> {
     Navigator.pop(context, _selectedDate);
   }
 
+  void _handleMonthHeaderTap() {
+    _handleModeChanged(DatePickerMode.year);
+  }
+
   Widget _buildPicker() {
     assert(_mode != null);
     switch (_mode) {
@@ -746,7 +750,7 @@ class _DatePickerDialogState extends State<_DatePickerDialog> {
           firstDate: widget.firstDate,
           lastDate: widget.lastDate,
           selectableDayPredicate: widget.selectableDayPredicate,
-          onMonthHeaderTap: () { _handleModeChanged(DatePickerMode.year); },
+          onMonthHeaderTap: _handleMonthHeaderTap,
         );
       case DatePickerMode.year:
         return new YearPicker(

--- a/packages/flutter/lib/src/material/ink_well.dart
+++ b/packages/flutter/lib/src/material/ink_well.dart
@@ -265,11 +265,7 @@ class _InkResponseState<T extends InkResponse> extends State<T> with AutomaticKe
           shape: widget.highlightShape,
           borderRadius: widget.borderRadius,
           rectCallback: widget.getRectCallback(referenceBox),
-          onRemoved: () {
-            assert(_lastHighlight != null);
-            _lastHighlight = null;
-            updateKeepAlive();
-          },
+          onRemoved: _handleInkHighlightRemoval,
         );
         updateKeepAlive();
       } else {
@@ -281,6 +277,12 @@ class _InkResponseState<T extends InkResponse> extends State<T> with AutomaticKe
     assert(value == (_lastHighlight != null && _lastHighlight.active));
     if (widget.onHighlightChanged != null)
       widget.onHighlightChanged(value);
+  }
+
+  void _handleInkHighlightRemoval() {
+    assert(_lastHighlight != null);
+    _lastHighlight = null;
+    updateKeepAlive();
   }
 
   void _handleTapDown(TapDownDetails details) {

--- a/packages/flutter/lib/src/material/paginated_data_table.dart
+++ b/packages/flutter/lib/src/material/paginated_data_table.dart
@@ -272,6 +272,14 @@ class PaginatedDataTableState extends State<PaginatedDataTable> {
     return result;
   }
 
+  void _handlePrevious() {
+    pageTo(math.max(_firstRowIndex - widget.rowsPerPage, 0));
+  }
+
+  void _handleNext() {
+    pageTo(_firstRowIndex + widget.rowsPerPage);
+  }
+
   final GlobalKey _tableKey = new GlobalKey();
 
   @override
@@ -346,18 +354,14 @@ class PaginatedDataTableState extends State<PaginatedDataTable> {
         icon: const Icon(Icons.chevron_left),
         padding: EdgeInsets.zero,
         tooltip: 'Previous page',
-        onPressed: _firstRowIndex <= 0 ? null : () {
-          pageTo(math.max(_firstRowIndex - widget.rowsPerPage, 0));
-        }
+        onPressed: _firstRowIndex <= 0 ? null : _handlePrevious
       ),
       new Container(width: 24.0),
       new IconButton(
         icon: const Icon(Icons.chevron_right),
         padding: EdgeInsets.zero,
         tooltip: 'Next page',
-        onPressed: (!_rowCountApproximate && (_firstRowIndex + widget.rowsPerPage >= _rowCount)) ? null : () {
-          pageTo(_firstRowIndex + widget.rowsPerPage);
-        }
+        onPressed: (!_rowCountApproximate && (_firstRowIndex + widget.rowsPerPage >= _rowCount)) ? null : _handleNext
       ),
       new Container(width: 14.0),
     ]);

--- a/packages/flutter/lib/src/material/tooltip.dart
+++ b/packages/flutter/lib/src/material/tooltip.dart
@@ -177,16 +177,18 @@ class _TooltipState extends State<Tooltip> with SingleTickerProviderStateMixin {
     super.dispose();
   }
 
+  void _handleLongPress() {
+    final bool tooltipCreated = ensureTooltipVisible();
+    if (tooltipCreated)
+      Feedback.forLongPress(context);
+  }
+
   @override
   Widget build(BuildContext context) {
     assert(Overlay.of(context, debugRequiredFor: widget) != null);
     return new GestureDetector(
       behavior: HitTestBehavior.opaque,
-      onLongPress: () {
-        final bool tooltipCreated = ensureTooltipVisible();
-        if (tooltipCreated)
-          Feedback.forLongPress(context);
-      },
+      onLongPress: _handleLongPress,
       excludeFromSemantics: true,
       child: new Semantics(
         label: widget.message,

--- a/packages/flutter/lib/src/material/user_accounts_drawer_header.dart
+++ b/packages/flutter/lib/src/material/user_accounts_drawer_header.dart
@@ -183,6 +183,13 @@ class UserAccountsDrawerHeader extends StatefulWidget {
 class _UserAccountsDrawerHeaderState extends State<UserAccountsDrawerHeader> {
   bool _isOpen = false;
 
+  void _handleDetailsPressed() {
+    setState(() {
+      _isOpen = !_isOpen;
+    });
+    widget.onDetailsPressed();
+  }
+
   @override
   Widget build(BuildContext context) {
     assert(debugCheckHasMaterial(context));
@@ -204,12 +211,7 @@ class _UserAccountsDrawerHeaderState extends State<UserAccountsDrawerHeader> {
             accountName: widget.accountName,
             accountEmail: widget.accountEmail,
             isOpen: _isOpen,
-            onTap: widget.onDetailsPressed == null ? null : () {
-              setState(() {
-                _isOpen = !_isOpen;
-              });
-              widget.onDetailsPressed();
-            },
+            onTap: widget.onDetailsPressed == null ? null : _handleDetailsPressed,
           ),
         ],
       ),

--- a/packages/flutter/lib/src/widgets/drag_target.dart
+++ b/packages/flutter/lib/src/widgets/drag_target.dart
@@ -528,11 +528,13 @@ class _DragAvatar<T> extends Drag {
         _enteredTargets.add(target);
         return target.didEnter(this);
       },
-      orElse: () => null
+      orElse: _null
     );
 
     _activeTarget = newTarget;
   }
+
+  static Null _null() => null;
 
   Iterable<_DragTargetState<T>> _getDragTargets(List<HitTestEntry> path) sync* {
     // Look for the RenderBoxes that corresponds to the hit target (the hit target


### PR DESCRIPTION
Some widgets are using closures even if the only values that are
captured are this, context or widget, that can be accessed even from
methods of the State object.