### PR TITLE
Use the phrase "must not be null" everywhere instead of "cannot be null"

### DIFF
--- a/packages/flutter/lib/src/animation/animation_controller.dart
+++ b/packages/flutter/lib/src/animation/animation_controller.dart
@@ -112,7 +112,7 @@ class AnimationController extends Animation<double>
   ///   null.
   ///
   /// * `vsync` is the [TickerProvider] for the current context. It can be
-  ///   changed by calling [resync]. It is required and cannot be null. See
+  ///   changed by calling [resync]. It is required and must not be null. See
   ///   [TickerProvider] for advice on obtaining a ticker provider.
   AnimationController({
     double value,
@@ -140,7 +140,7 @@ class AnimationController extends Animation<double>
   ///   debugging (used by [toString]).
   ///
   /// * `vsync` is the [TickerProvider] for the current context. It can be
-  ///   changed by calling [resync]. It is required and cannot be null. See
+  ///   changed by calling [resync]. It is required and must not be null. See
   ///   [TickerProvider] for advice on obtaining a ticker provider.
   ///
   /// This constructor is most useful for animations that will be driven using a

--- a/packages/flutter/lib/src/material/data_table.dart
+++ b/packages/flutter/lib/src/material/data_table.dart
@@ -233,7 +233,7 @@ class DataTable extends StatelessWidget {
   /// The [columns] argument must be a list of as many [DataColumn]
   /// objects as the table is to have columns, ignoring the leading
   /// checkbox column if any. The [columns] argument must have a
-  /// length greater than zero and cannot be null.
+  /// length greater than zero and must not be null.
   ///
   /// The [rows] argument must be a list of as many [DataRow] objects
   /// as the table is to have rows, ignoring the leading heading row

--- a/packages/flutter/lib/src/material/date_picker.dart
+++ b/packages/flutter/lib/src/material/date_picker.dart
@@ -851,7 +851,7 @@ typedef bool SelectableDayPredicate(DateTime day);
 ///
 /// An optional [initialDatePickerMode] argument can be used to display the
 /// date picker initially in the year or month+day picker mode. It defaults
-/// to month+day, but cannot be null.
+/// to month+day, but must not be null.
 ///
 /// See also:
 ///
@@ -872,7 +872,7 @@ Future<DateTime> showDatePicker({
     selectableDayPredicate == null || selectableDayPredicate(initialDate),
     'Provided initialDate must satisfy provided selectableDayPredicate'
   );
-  assert(initialDatePickerMode != null, 'initialDatePickerMode cannot be null');
+  assert(initialDatePickerMode != null, 'initialDatePickerMode must not be null');
   return await showDialog(
     context: context,
     child: new _DatePickerDialog(

--- a/packages/flutter/lib/src/material/tab_controller.dart
+++ b/packages/flutter/lib/src/material/tab_controller.dart
@@ -73,10 +73,10 @@ import 'constants.dart';
 class TabController extends ChangeNotifier {
   /// Creates an object that manages the state required by [TabBar] and a [TabBarView].
   ///
-  /// The [length] cannot be null or negative. Typically its a value greater than one, i.e.
+  /// The [length] must not be null or negative. Typically its a value greater than one, i.e.
   /// typically there are two or more tabs.
   ///
-  /// The `initialIndex` must be valid given [length] and cannot be null. If [length] is
+  /// The `initialIndex` must be valid given [length] and must not be null. If [length] is
   /// zero, then `initialIndex` must be 0 (the default).
   TabController({ int initialIndex: 0, @required this.length, @required TickerProvider vsync })
     : assert(length != null && length >= 0),

--- a/packages/flutter/lib/src/material/tabs.dart
+++ b/packages/flutter/lib/src/material/tabs.dart
@@ -402,15 +402,15 @@ class _TabBarScrollController extends ScrollController {
 class TabBar extends StatefulWidget implements PreferredSizeWidget {
   /// Creates a material design tab bar.
   ///
-  /// The [tabs] argument cannot be null and its length must match the [controller]'s
+  /// The [tabs] argument must not be null and its length must match the [controller]'s
   /// [TabController.length].
   ///
   /// If a [TabController] is not provided, then there must be a
   /// [DefaultTabController] ancestor.
   ///
-  /// The [indicatorWeight] parameter defaults to 2, and cannot be null.
+  /// The [indicatorWeight] parameter defaults to 2, and must not be null.
   ///
-  /// The [indicatorPadding] parameter defaults to [EdgeInsets.zero], and cannot be null.
+  /// The [indicatorPadding] parameter defaults to [EdgeInsets.zero], and must not be null.
   TabBar({
     Key key,
     @required this.tabs,
@@ -980,7 +980,7 @@ class _TabBarViewState extends State<TabBarView> {
 class TabPageSelectorIndicator extends StatelessWidget {
   /// Creates an indicator used by [TabPageSelector].
   ///
-  /// The [backgroundColor], [borderColor], and [size] parameters cannot be null.
+  /// The [backgroundColor], [borderColor], and [size] parameters must not be null.
   const TabPageSelectorIndicator({
     Key key,
     @required this.backgroundColor,

--- a/packages/flutter/lib/src/material/tooltip.dart
+++ b/packages/flutter/lib/src/material/tooltip.dart
@@ -41,7 +41,7 @@ class Tooltip extends StatefulWidget {
   /// By default, tooltips prefer to appear below the [child] widget when the
   /// user long presses on the widget.
   ///
-  /// The [message] argument cannot be null.
+  /// The [message] argument must not be null.
   const Tooltip({
     Key key,
     @required this.message,

--- a/packages/flutter/lib/src/services/image_cache.dart
+++ b/packages/flutter/lib/src/services/image_cache.dart
@@ -67,7 +67,7 @@ class ImageCache {
   /// if not, calls the given callback to obtain it first. In either case, the
   /// key is moved to the "most recently used" position.
   ///
-  /// The arguments cannot be null. The `loader` cannot return null.
+  /// The arguments must not be null. The `loader` cannot return null.
   ImageStreamCompleter putIfAbsent(Object key, ImageStreamCompleter loader()) {
     assert(key != null);
     assert(loader != null);

--- a/packages/flutter/lib/src/widgets/transitions.dart
+++ b/packages/flutter/lib/src/widgets/transitions.dart
@@ -403,7 +403,7 @@ class DecoratedBoxTransition extends AnimatedWidget {
   /// Creates an animated [DecoratedBox] whose [Decoration] animation updates
   /// the widget.
   ///
-  /// The [decoration] and [position] cannot be null.
+  /// The [decoration] and [position] must not be null.
   ///
   /// See also:
   ///

--- a/packages/flutter/lib/src/widgets/unique_widget.dart
+++ b/packages/flutter/lib/src/widgets/unique_widget.dart
@@ -22,7 +22,7 @@ import 'framework.dart';
 abstract class UniqueWidget<T extends State<StatefulWidget>> extends StatefulWidget {
   /// Creates a widget that has exactly one inflated instance in the tree.
   ///
-  /// The [key] argument cannot be null because it identifies the unique
+  /// The [key] argument must not be null because it identifies the unique
   /// inflated instance of this widget.
   const UniqueWidget({
     @required GlobalKey<T> key,


### PR DESCRIPTION
when describing non-nullable method arguments.