### PR TITLE
Rename springConstant to stiffness

### DIFF
--- a/packages/flutter/lib/src/animation/animation_controller.dart
+++ b/packages/flutter/lib/src/animation/animation_controller.dart
@@ -29,7 +29,7 @@ enum _AnimationDirection {
 
 final SpringDescription _kFlingSpringDescription = new SpringDescription.withDampingRatio(
   mass: 1.0,
-  springConstant: 500.0,
+  stiffness: 500.0,
   ratio: 1.0,
 );
 

--- a/packages/flutter/lib/src/physics/spring_simulation.dart
+++ b/packages/flutter/lib/src/physics/spring_simulation.dart
@@ -12,36 +12,36 @@ import 'utils.dart';
 ///
 /// Used to configure a [SpringSimulation].
 class SpringDescription {
-  /// Creates a spring given the mass, spring constant and the damping coefficient.
+  /// Creates a spring given the mass, stiffness, and the damping coefficient.
   ///
-  /// See [mass], [springConstant], and [damping] for the units of the arguments.
+  /// See [mass], [stiffness], and [damping] for the units of the arguments.
   const SpringDescription({
     this.mass,
-    this.springConstant,
+    this.stiffness,
     this.damping
   });
 
-  /// Creates a spring given the mass (m), spring constant (k), and damping
-  /// ratio (ζ). The damping ratio is especially useful trying to determing the
-  /// type of spring to create. A ratio of 1.0 creates a critically damped
-  /// spring, > 1.0 creates an overdamped spring and < 1.0 an underdamped one.
+  /// Creates a spring given the mass (m), stiffness (k), and damping ratio (ζ).
+  /// The damping ratio is especially useful trying to determing the type of
+  /// spring to create. A ratio of 1.0 creates a critically damped spring, > 1.0
+  /// creates an overdamped spring and < 1.0 an underdamped one.
   ///
-  /// See [mass] and [springConstant] for the units for those arguments. The
-  /// damping ratio is unitless.
+  /// See [mass] and [stiffness] for the units for those arguments. The damping
+  /// ratio is unitless.
   SpringDescription.withDampingRatio({
     this.mass,
-    this.springConstant,
+    this.stiffness,
     double ratio: 1.0
-  }) : damping = ratio * 2.0 * math.sqrt(mass * springConstant);
+  }) : damping = ratio * 2.0 * math.sqrt(mass * stiffness);
 
   /// The mass of the spring (m). The units are arbitrary, but all springs
   /// within a system should use the same mass units.
   final double mass;
 
-  /// The spring constant (k). The units of the spring constant are M/T², where
-  /// M is the mass unit used for the value of the [mass] property, and T is the
-  /// time unit used for driving the [SpringSimulation].
-  final double springConstant;
+  /// The spring constant (k). The units of stiffness are M/T², where M is the
+  /// mass unit used for the value of the [mass] property, and T is the time
+  /// unit used for driving the [SpringSimulation].
+  final double stiffness;
 
   /// The damping coefficient (c).
   ///
@@ -55,7 +55,7 @@ class SpringDescription {
   final double damping;
 
   @override
-  String toString() => '$runtimeType(mass: ${mass.toStringAsFixed(1)}, springConstant: ${springConstant.toStringAsFixed(1)}, damping: ${damping.toStringAsFixed(1)})';
+  String toString() => '$runtimeType(mass: ${mass.toStringAsFixed(1)}, stiffness: ${stiffness.toStringAsFixed(1)}, damping: ${damping.toStringAsFixed(1)})';
 }
 
 /// The kind of spring solution that the [SpringSimulation] is using to simulate the spring.
@@ -153,11 +153,11 @@ abstract class _SpringSolution {
   ) {
     assert(spring != null);
     assert(spring.mass != null);
-    assert(spring.springConstant != null);
+    assert(spring.stiffness != null);
     assert(spring.damping != null);
     assert(initialPosition != null);
     assert(initialVelocity != null);
-    final double cmk = spring.damping * spring.damping - 4 * spring.mass * spring.springConstant;
+    final double cmk = spring.damping * spring.damping - 4 * spring.mass * spring.stiffness;
     if (cmk == 0.0)
       return new _CriticalSolution(spring, initialPosition, initialVelocity);
     if (cmk > 0.0)
@@ -210,7 +210,7 @@ class _OverdampedSolution implements _SpringSolution {
     double distance,
     double velocity
   ) {
-    final double cmk = spring.damping * spring.damping - 4 * spring.mass * spring.springConstant;
+    final double cmk = spring.damping * spring.damping - 4 * spring.mass * spring.stiffness;
     final double r1 = (-spring.damping - math.sqrt(cmk)) / (2.0 * spring.mass);
     final double r2 = (-spring.damping + math.sqrt(cmk)) / (2.0 * spring.mass);
     final double c2 = (velocity - r1 * distance) / (r2 - r1);
@@ -248,7 +248,7 @@ class _UnderdampedSolution implements _SpringSolution {
     double distance,
     double velocity
   ) {
-    final double w = math.sqrt(4.0 * spring.mass * spring.springConstant -
+    final double w = math.sqrt(4.0 * spring.mass * spring.stiffness -
                      spring.damping * spring.damping) / (2.0 * spring.mass);
     final double r = -(spring.damping / 2.0 * spring.mass);
     final double c1 = distance;

--- a/packages/flutter/lib/src/widgets/scroll_physics.dart
+++ b/packages/flutter/lib/src/widgets/scroll_physics.dart
@@ -150,7 +150,7 @@ class ScrollPhysics {
 
   static final SpringDescription _kDefaultSpring = new SpringDescription.withDampingRatio(
     mass: 0.5,
-    springConstant: 100.0,
+    stiffness: 100.0,
     ratio: 1.1,
   );
 

--- a/packages/flutter/test/material/tabs_test.dart
+++ b/packages/flutter/test/material/tabs_test.dart
@@ -132,18 +132,18 @@ class TabIndicatorRecordingCanvas extends TestRecordingCanvas {
 
 class TestScrollPhysics extends ScrollPhysics {
   const TestScrollPhysics({ ScrollPhysics parent }) : super(parent: parent);
-  
+
   @override
   TestScrollPhysics applyTo(ScrollPhysics ancestor) {
     return new TestScrollPhysics(parent: buildParent(ancestor));
   }
-  
+
   static final SpringDescription _kDefaultSpring = new SpringDescription.withDampingRatio(
     mass: 0.5,
-    springConstant: 500.0,
+    stiffness: 500.0,
     ratio: 1.1,
   );
-  
+
   @override
   SpringDescription get spring => _kDefaultSpring;
 }
@@ -970,7 +970,7 @@ void main() {
       rect: new Rect.fromLTRB(tabLeft + padLeft, height, tabRight - padRight, height + weight)
     ));
   });
-  
+
   testWidgets('correct semantics', (WidgetTester tester) async {
     final SemanticsTester semantics = new SemanticsTester(tester);
 

--- a/packages/flutter/test/physics/newton_test.dart
+++ b/packages/flutter/test/physics/newton_test.dart
@@ -116,31 +116,31 @@ void main() {
 
   test('spring_types', () {
     SpringSimulation crit = new SpringSimulation(new SpringDescription.withDampingRatio(
-        mass: 1.0, springConstant: 100.0), 0.0, 300.0, 0.0);
+        mass: 1.0, stiffness: 100.0), 0.0, 300.0, 0.0);
     expect(crit.type, SpringType.criticallyDamped);
 
     crit = new SpringSimulation(new SpringDescription.withDampingRatio(
-        mass: 1.0, springConstant: 100.0, ratio: 1.0), 0.0, 300.0, 0.0);
+        mass: 1.0, stiffness: 100.0, ratio: 1.0), 0.0, 300.0, 0.0);
     expect(crit.type, SpringType.criticallyDamped);
 
     final SpringSimulation under = new SpringSimulation(new SpringDescription.withDampingRatio(
-        mass: 1.0, springConstant: 100.0, ratio: 0.75), 0.0, 300.0, 0.0);
+        mass: 1.0, stiffness: 100.0, ratio: 0.75), 0.0, 300.0, 0.0);
     expect(under.type, SpringType.underDamped);
 
     final SpringSimulation over = new SpringSimulation(new SpringDescription.withDampingRatio(
-        mass: 1.0, springConstant: 100.0, ratio: 1.25), 0.0, 300.0, 0.0);
+        mass: 1.0, stiffness: 100.0, ratio: 1.25), 0.0, 300.0, 0.0);
     expect(over.type, SpringType.overDamped);
 
     // Just so we don't forget how to create a desc without the ratio.
     final SpringSimulation other = new SpringSimulation(
-        const SpringDescription(mass: 1.0, springConstant: 100.0, damping: 20.0),
+        const SpringDescription(mass: 1.0, stiffness: 100.0, damping: 20.0),
         0.0, 20.0, 20.0);
     expect(other.type, SpringType.criticallyDamped);
   });
 
   test('crit_spring', () {
     final SpringSimulation crit = new SpringSimulation(new SpringDescription.withDampingRatio(
-        mass: 1.0, springConstant: 100.0, ratio: 1.0), 0.0, 500.0, 0.0);
+        mass: 1.0, stiffness: 100.0, ratio: 1.0), 0.0, 500.0, 0.0);
 
     crit.tolerance = const Tolerance(distance: 0.01, velocity: 0.01);
 
@@ -165,7 +165,7 @@ void main() {
 
   test('overdamped_spring', () {
     final SpringSimulation over = new SpringSimulation(new SpringDescription.withDampingRatio(
-        mass: 1.0, springConstant: 100.0, ratio: 1.25), 0.0, 500.0, 0.0);
+        mass: 1.0, stiffness: 100.0, ratio: 1.25), 0.0, 500.0, 0.0);
 
     over.tolerance = const Tolerance(distance: 0.01, velocity: 0.01);
 
@@ -187,7 +187,7 @@ void main() {
 
   test('underdamped_spring', () {
     final SpringSimulation under = new SpringSimulation(new SpringDescription.withDampingRatio(
-        mass: 1.0, springConstant: 100.0, ratio: 0.25), 0.0, 300.0, 0.0);
+        mass: 1.0, stiffness: 100.0, ratio: 0.25), 0.0, 300.0, 0.0);
     expect(under.type, SpringType.underDamped);
 
     expect(under.isDone(0.0), false);
@@ -204,7 +204,7 @@ void main() {
 
   test('test_kinetic_scroll', () {
     final SpringDescription spring = new SpringDescription.withDampingRatio(
-        mass: 1.0, springConstant: 50.0, ratio: 0.5);
+        mass: 1.0, stiffness: 50.0, ratio: 0.5);
 
     final BouncingScrollSimulation scroll = new BouncingScrollSimulation(
       position: 100.0,
@@ -233,7 +233,7 @@ void main() {
 
   test('scroll_with_inf_edge_ends', () {
     final SpringDescription spring = new SpringDescription.withDampingRatio(
-        mass: 1.0, springConstant: 50.0, ratio: 0.5);
+        mass: 1.0, stiffness: 50.0, ratio: 0.5);
 
     final BouncingScrollSimulation scroll = new BouncingScrollSimulation(
       position: 100.0,
@@ -259,7 +259,7 @@ void main() {
   });
 
   test('over/under scroll spring', () {
-    final SpringDescription spring = new SpringDescription.withDampingRatio(mass: 1.0, springConstant: 170.0, ratio: 1.1);
+    final SpringDescription spring = new SpringDescription.withDampingRatio(mass: 1.0, stiffness: 170.0, ratio: 1.1);
     final BouncingScrollSimulation scroll = new BouncingScrollSimulation(
       position: 500.0,
       velocity: -7500.0,


### PR DESCRIPTION
`stiffness` is the name of a spring's `k` input on [iOS](https://developer.apple.com/documentation/quartzcore/caspringanimation), [Android](https://developer.android.com/topic/libraries/support-library/preview/spring-animation.html), and the [Web](https://github.com/skevy/wobble/blob/bbc0f831e234f2d24fb905f2ec278c134d69ed68/src/index.js#L11-L22).  To ensure the API is familiar to and easily understood by developers coming from other platforms, Flutter should follow this convention as well.

This is a minimally-breaking change.  Across [all of GitHub](https://github.com/search?l=Dart&q=springConstant&type=Code&utf8=%E2%9C%93), there are only 2 uses of the `springConstant` API (in Mondrian).  Those can be easily changed to use this name.

Closes #11684