### PR TITLE
Fire widget.onChanged on EditableText value change

### DIFF
--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -370,8 +370,6 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
     }
     _lastKnownRemoteTextEditingValue = value;
     _formatAndSetValue(value);
-    if (widget.onChanged != null)
-      widget.onChanged(value.text);
   }
 
   @override
@@ -524,6 +522,7 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
   }
 
   void _formatAndSetValue(TextEditingValue value) {
+    final bool textChanged = _value?.text != value?.text;
     if (widget.inputFormatters != null && widget.inputFormatters.isNotEmpty) {
       for (TextInputFormatter formatter in widget.inputFormatters)
         value = formatter.formatEditUpdate(_value, value);
@@ -532,6 +531,8 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
     } else {
       _value = value;
     }
+    if (textChanged && widget.onChanged != null)
+      widget.onChanged(value.text);
   }
 
   /// Whether the blinking cursor is actually visible at this precise moment

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -1,0 +1,49 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('Fires onChanged when text changes via TextSelectionOverlay', (WidgetTester tester) async {
+    final GlobalKey<EditableTextState> editableTextKey = new GlobalKey<EditableTextState>();
+
+    String changedValue;
+    final Widget widget = new MaterialApp(
+      home: new EditableText(
+        key: editableTextKey,
+        controller: new TextEditingController(),
+        focusNode: new FocusNode(),
+        style: new Typography(platform: TargetPlatform.android).black.subhead,
+        cursorColor: Colors.blue,
+        selectionControls: materialTextSelectionControls,
+        keyboardType: TextInputType.text,
+        onChanged: (String value) {
+          changedValue = value;
+        },
+      ),
+    );
+    await tester.pumpWidget(widget);
+
+    // Populate a fake clipboard.
+    const String clipboardContent = 'Dobunezumi mitai ni utsukushiku naritai';
+    SystemChannels.platform.setMockMethodCallHandler((MethodCall methodCall) async {
+      if (methodCall.method == 'Clipboard.getData')
+        return const <String, dynamic>{ 'text': clipboardContent };
+      return null;
+    });
+
+    // Long-press to bring up the text editing controls.
+    final Finder textFinder = find.byKey(editableTextKey);
+    await tester.longPress(textFinder);
+    await tester.pump();
+
+    await tester.tap(find.text('PASTE'));
+    await tester.pump();
+
+    expect(changedValue, clipboardContent);
+  });
+}


### PR DESCRIPTION
The value of an EditableText is composed of the text value as well as
other editing-related data such as selection-related information.

Previously, widget.onChanged() was only called for updates via
updateEditingValue(). For pastes via a TextSelectionOverlay, updates are
signalled via _handleSelectionOverlayChanged(), which only ever
triggered widget.onSelectionChanged(), but not widget.onChanged().

Both updateEditingValue() and _handleSelectionOverlayChanged() perform
the value update via _formatAndSetValue(), which is where this patch
moves the widget.onChanged() call.