### PR TITLE
Improve Gradle error output in Flutter commands

### DIFF
--- a/dev/devicelab/bin/tasks/gradle_plugin_test.dart
+++ b/dev/devicelab/bin/tasks/gradle_plugin_test.dart
@@ -43,24 +43,24 @@ void main() {
       {
         final ProcessResult result = await project.resultOfGradleTask('assembleRelease');
         if (result.exitCode == 0)
-          return processFailure('Gradle did not exit with error as expected', result);
+          return _failure('Gradle did not exit with error as expected', result);
         final String output = result.stdout + '\n' + result.stderr;
         if (output.contains('GradleException') || output.contains('Failed to notify') || output.contains('at org.gradle'))
-          return processFailure('Gradle output should not contain stacktrace', result);
+          return _failure('Gradle output should not contain stacktrace', result);
         if (!output.contains('Build failed') || !output.contains('builTypes'))
-          return processFailure('Gradle output should contain a readable error message', result);
+          return _failure('Gradle output should contain a readable error message', result);
       }
 
       section('flutter build apk on build script with error');
       {
         final ProcessResult result = await project.resultOfFlutterCommand('build', <String>['apk']);
         if (result.exitCode == 0)
-          return processFailure('flutter build apk should fail when Gradle does', result);
+          return _failure('flutter build apk should fail when Gradle does', result);
         final String output = result.stdout + '\n' + result.stderr;
         if (!output.contains('Build failed') || !output.contains('builTypes'))
-          return processFailure('flutter build apk output should contain a readable Gradle error message', result);
+          return _failure('flutter build apk output should contain a readable Gradle error message', result);
         if (_hasMultipleOccurrences(output, 'builTypes'))
-          return processFailure('flutter build apk should not invoke Gradle repeatedly on error', result);
+          return _failure('flutter build apk should not invoke Gradle repeatedly on error', result);
       }
 
       return new TaskResult.success(null);
@@ -72,7 +72,7 @@ void main() {
   });
 }
 
-TaskResult processFailure(String message, ProcessResult result) {
+TaskResult _failure(String message, ProcessResult result) {
   print('Unexpected process result:');
   print('Exit code: ${result.exitCode}');
   print('Std out  :\n${result.stdout}');

--- a/dev/devicelab/bin/tasks/gradle_plugin_test.dart
+++ b/dev/devicelab/bin/tasks/gradle_plugin_test.dart
@@ -15,29 +15,45 @@ void main() {
     final Directory tmp = await Directory.systemTemp.createTemp('gradle');
     final FlutterProject project = await FlutterProject.create(tmp, 'hello');
 
-    section('gradlew assembleDebug');
-    await project.runGradleTask('assembleDebug');
+    try {
+      section('gradlew assembleDebug');
+      await project.runGradleTask('assembleDebug');
 
-    section('gradlew assembleProfile');
-    await project.runGradleTask('assembleProfile');
+      section('gradlew assembleProfile');
+      await project.runGradleTask('assembleProfile');
 
-    section('gradlew assembleRelease');
-    await project.runGradleTask('assembleRelease');
+      section('gradlew assembleRelease');
+      await project.runGradleTask('assembleRelease');
 
-    section('gradlew assembleLocal (custom debug build)');
-    await project.addCustomBuildType('local', initWith: 'debug');
-    await project.runGradleTask('assembleLocal');
+      section('gradlew assembleLocal (custom debug build)');
+      await project.addCustomBuildType('local', initWith: 'debug');
+      await project.runGradleTask('assembleLocal');
 
-    section('gradlew assembleBeta (custom release build)');
-    await project.addCustomBuildType('beta', initWith: 'release');
-    await project.runGradleTask('assembleBeta');
+      section('gradlew assembleBeta (custom release build)');
+      await project.addCustomBuildType('beta', initWith: 'release');
+      await project.runGradleTask('assembleBeta');
 
-    section('gradlew assembleFreeDebug (product flavor)');
-    await project.addProductFlavor('free');
-    await project.runGradleTask('assembleFreeDebug');
+      section('gradlew assembleFreeDebug (product flavor)');
+      await project.addProductFlavor('free');
+      await project.runGradleTask('assembleFreeDebug');
 
-    await project.parent.delete(recursive: true);
-    return new TaskResult.success(null);
+      section('gradlew on script with error');
+      await project.introduceError();
+      final ProcessResult result = await project.resultOfGradleTask('assembleRelease');
+      if (result.exitCode == 0)
+        return new TaskResult.failure('Gradle did not exit with error as expected');
+      final String output = result.stdout + '\n' + result.stderr;
+      if (output.contains('GradleException') || output.contains('Failed to notify') || output.contains('at org.gradle'))
+        return new TaskResult.failure('Gradle output should not contain stacktrace');
+      if (!output.contains('Build failed') || !output.contains('builTypes'))
+        return new TaskResult.failure('Gradle output should contain a readable error message');
+
+      return new TaskResult.success(null);
+    } catch(e) {
+      return new TaskResult.failure(e.toString());
+    } finally {
+      project.parent.deleteSync(recursive: true);
+    }
   });
 }
 
@@ -90,18 +106,30 @@ android {
     ''');
   }
 
-  Future<Null> runGradleTask(String task) async {
-    final ProcessResult result = await Process.run(
-      './gradlew',
-      <String>['-q', 'app:$task'],
-      workingDirectory: androidPath,
+  Future<Null> introduceError() async {
+    final File buildScript = new File(
+      path.join(androidPath, 'app', 'build.gradle'),
     );
+    await buildScript.writeAsString((await buildScript.readAsString()).replaceAll('buildTypes', 'builTypes'));
+  }
+
+  Future<Null> runGradleTask(String task) async {
+    final ProcessResult result = await resultOfGradleTask(task);
     if (result.exitCode != 0) {
       print('stdout:');
       print(result.stdout);
       print('stderr:');
       print(result.stderr);
     }
-    assert(result.exitCode == 0);
+    if (result.exitCode != 0)
+      throw 'Gradle exited with error';
+  }
+
+  Future<ProcessResult> resultOfGradleTask(String task) async {
+    return await Process.run(
+      './gradlew',
+      <String>['app:$task'],
+      workingDirectory: androidPath,
+    );
   }
 }

--- a/dev/devicelab/bin/tasks/gradle_plugin_test.dart
+++ b/dev/devicelab/bin/tasks/gradle_plugin_test.dart
@@ -37,16 +37,31 @@ void main() {
       await project.addProductFlavor('free');
       await project.runGradleTask('assembleFreeDebug');
 
-      section('gradlew on script with error');
       await project.introduceError();
-      final ProcessResult result = await project.resultOfGradleTask('assembleRelease');
-      if (result.exitCode == 0)
-        return new TaskResult.failure('Gradle did not exit with error as expected');
-      final String output = result.stdout + '\n' + result.stderr;
-      if (output.contains('GradleException') || output.contains('Failed to notify') || output.contains('at org.gradle'))
-        return new TaskResult.failure('Gradle output should not contain stacktrace');
-      if (!output.contains('Build failed') || !output.contains('builTypes'))
-        return new TaskResult.failure('Gradle output should contain a readable error message');
+
+      section('gradlew on build script with error');
+      {
+        final ProcessResult result = await project.resultOfGradleTask('assembleRelease');
+        if (result.exitCode == 0)
+          return processFailure('Gradle did not exit with error as expected', result);
+        final String output = result.stdout + '\n' + result.stderr;
+        if (output.contains('GradleException') || output.contains('Failed to notify') || output.contains('at org.gradle'))
+          return processFailure('Gradle output should not contain stacktrace', result);
+        if (!output.contains('Build failed') || !output.contains('builTypes'))
+          return processFailure('Gradle output should contain a readable error message', result);
+      }
+
+      section('flutter build apk on build script with error');
+      {
+        final ProcessResult result = await project.resultOfFlutterCommand('build', <String>['apk']);
+        if (result.exitCode == 0)
+          return processFailure('flutter build apk should fail when Gradle does', result);
+        final String output = result.stdout + '\n' + result.stderr;
+        if (!output.contains('Build failed') || !output.contains('builTypes'))
+          return processFailure('flutter build apk output should contain a readable Gradle error message', result);
+        if (_hasMultipleOccurrences(output, 'builTypes'))
+          return processFailure('flutter build apk should not invoke Gradle repeatedly on error', result);
+      }
 
       return new TaskResult.success(null);
     } catch(e) {
@@ -55,6 +70,18 @@ void main() {
       project.parent.deleteSync(recursive: true);
     }
   });
+}
+
+TaskResult processFailure(String message, ProcessResult result) {
+  print('Unexpected process result:');
+  print('Exit code: ${result.exitCode}');
+  print('Std out  :\n${result.stdout}');
+  print('Std err  :\n${result.stderr}');
+  return new TaskResult.failure(message);
+}
+
+bool _hasMultipleOccurrences(String text, Pattern pattern) {
+  return text.indexOf(pattern) != text.lastIndexOf(pattern);
 }
 
 class FlutterProject {
@@ -125,11 +152,19 @@ android {
       throw 'Gradle exited with error';
   }
 
-  Future<ProcessResult> resultOfGradleTask(String task) async {
-    return await Process.run(
+  Future<ProcessResult> resultOfGradleTask(String task) {
+    return Process.run(
       './gradlew',
       <String>['app:$task'],
       workingDirectory: androidPath,
+    );
+  }
+
+  Future<ProcessResult> resultOfFlutterCommand(String command, List<String> options) {
+    return Process.run(
+      path.join(flutterDirectory.path, 'bin', 'flutter'),
+      <String>[command]..addAll(options),
+      workingDirectory: rootPath,
     );
   }
 }

--- a/packages/flutter_tools/gradle/flutter.gradle
+++ b/packages/flutter_tools/gradle/flutter.gradle
@@ -157,8 +157,9 @@ class FlutterPlugin implements Plugin<Project> {
     }
 
     private void addFlutterJarProvidedDependency(Project project) {
-        if (project.state.failure)
+        if (project.state.failure) {
             return
+        }
         project.dependencies {
             if (flutterJar != null) {
                 provided project.files(flutterJar)
@@ -206,8 +207,9 @@ class FlutterPlugin implements Plugin<Project> {
     }
 
     private void addFlutterTask(Project project) {
-        if (project.state.failure)
+        if (project.state.failure) {
             return
+        }
         if (project.flutter.source == null) {
             throw new GradleException("Must provide Flutter source directory")
         }

--- a/packages/flutter_tools/gradle/flutter.gradle
+++ b/packages/flutter_tools/gradle/flutter.gradle
@@ -157,6 +157,8 @@ class FlutterPlugin implements Plugin<Project> {
     }
 
     private void addFlutterJarProvidedDependency(Project project) {
+        if (project.state.failure)
+            return
         project.dependencies {
             if (flutterJar != null) {
                 provided project.files(flutterJar)
@@ -204,6 +206,8 @@ class FlutterPlugin implements Plugin<Project> {
     }
 
     private void addFlutterTask(Project project) {
+        if (project.state.failure)
+            return
         if (project.flutter.source == null) {
             throw new GradleException("Must provide Flutter source directory")
         }

--- a/packages/flutter_tools/lib/src/android/gradle.dart
+++ b/packages/flutter_tools/lib/src/android/gradle.dart
@@ -97,8 +97,12 @@ Future<GradleProject> _readGradleProject() async {
     status.stop();
     return project;
   } catch (e) {
-    printError('Error running gradle: $e');
-    throwToolExit('Please review your Gradle project setup in the android/ folder.');
+    if (flutterPluginVersion == FlutterPluginVersion.managed) {
+      printError('Error running Gradle:\n$e\n');
+      throwToolExit(
+        'Please review your Gradle project setup in the android/ folder.',
+      );
+    }
   }
   // Fall back to the default
   return new GradleProject(<String>['debug', 'profile', 'release'], <String>[], gradleAppOutDirV1);

--- a/packages/flutter_tools/lib/src/android/gradle.dart
+++ b/packages/flutter_tools/lib/src/android/gradle.dart
@@ -98,6 +98,7 @@ Future<GradleProject> _readGradleProject() async {
     return project;
   } catch (e) {
     printError('Error running gradle: $e');
+    throwToolExit('Please review your Gradle project setup in the android/ folder.');
   }
   // Fall back to the default
   return new GradleProject(<String>['debug', 'profile', 'release'], <String>[], gradleAppOutDirV1);


### PR DESCRIPTION
Avoid executing code in `afterEvaluate` when the project is already in an error state.
Avoid repeated gradlew invocations on error.

Fixes #11677