### PR TITLE
Fix flakiness of commands_test

### DIFF
--- a/dev/devicelab/bin/tasks/commands_test.dart
+++ b/dev/devicelab/bin/tasks/commands_test.dart
@@ -77,15 +77,21 @@ void main() {
       await driver.drive('none');
       final Future<String> reloadStartingText =
         stdout.stream.firstWhere((String line) => line.endsWith('hot reload...'));
+      final Future<String> reloadEndingText =
+        stdout.stream.firstWhere((String line) => line.contains('Hot reload performed in '));
       print('test: pressing "r" to perform a hot reload...');
       run.stdin.write('r');
       await reloadStartingText;
+      await reloadEndingText;
       await driver.drive('none');
       final Future<String> restartStartingText =
         stdout.stream.firstWhere((String line) => line.endsWith('full restart...'));
+      final Future<String> restartEndingText =
+        stdout.stream.firstWhere((String line) => line.contains('Restart performed in '));
       print('test: pressing "R" to perform a full reload...');
       run.stdin.write('R');
       await restartStartingText;
+      await restartEndingText;
       await driver.drive('none');
       run.stdin.write('q');
       final int result = await run.exitCode;

--- a/dev/devicelab/manifest.yaml
+++ b/dev/devicelab/manifest.yaml
@@ -125,7 +125,6 @@ tasks:
       Runs tests of flutter run commands.
     stage: devicelab
     required_agent_capabilities: ["has-android-device"]
-    flaky: true
 
   android_sample_catalog_generator:
     description: >

--- a/packages/flutter_driver/lib/src/driver.dart
+++ b/packages/flutter_driver/lib/src/driver.dart
@@ -7,8 +7,8 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:file/file.dart' as f;
-import 'package:json_rpc_2/json_rpc_2.dart' as rpc;
 import 'package:json_rpc_2/error_code.dart' as error_code;
+import 'package:json_rpc_2/json_rpc_2.dart' as rpc;
 import 'package:meta/meta.dart';
 import 'package:path/path.dart' as p;
 import 'package:vm_service_client/vm_service_client.dart';
@@ -270,7 +270,7 @@ class FlutterDriver {
       );
     }
 
-    // Invoked checkHealth and try to fix dalays in the registration of Service
+    // Invoked checkHealth and try to fix delays in the registration of Service
     // extensions
     Future<Health> checkHealth() async {
       try {


### PR DESCRIPTION
- Wait for completion of Hot Reload
- Wait for completion of Restart
- Fallback if checkHealth throws METHOD_NOT_FOUND.
  We try to wait for the service extensions to be registered and retry.