### PR TITLE
Use the TextPainter's preferredLineHeight to lay out Cupertino text selection handles

### DIFF
--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -211,6 +211,10 @@ class RenderEditable extends RenderBox {
     markNeedsTextLayout();
   }
 
+  /// The height of a typical line in the text.
+  //  See [TextPainter.preferredLineHeight].
+  double get preferredLineHeight => _textPainter.preferredLineHeight;
+
   /// The color to use when painting the selection.
   Color get selectionColor => _selectionColor;
   Color _selectionColor;

--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -509,7 +509,7 @@ class _TextSelectionHandleOverlayState extends State<_TextSelectionHandleOverlay
               child: widget.selectionControls.buildHandle(
                 context,
                 type,
-                widget.renderObject.size.height / widget.renderObject.maxLines,
+                widget.renderObject.preferredLineHeight,
               ),
             ),
           ],


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/11573