### PR TITLE
a11y and scrolling with slivers

### DIFF
--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -863,6 +863,7 @@ class _ImplicitSemanticsFragment extends _InterestingSemanticsFragment {
       node.finalizeChildren();
       yield node;
     } else {
+      // Transparently forward children to the borrowed node.
       yield* children;
     }
   }

--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -714,9 +714,9 @@ abstract class _InterestingSemanticsFragment extends _SemanticsFragment {
     for (_SemanticsFragment child in _children) {
       assert(child._ancestorChain.last == renderObjectOwner);
       children.addAll(child.compile(
-          geometry: createSemanticsGeometryForChild(geometry),
-          currentSemantics: _children.length > 1 ? null : node,
-          parentSemantics: node
+        geometry: createSemanticsGeometryForChild(geometry),
+        currentSemantics: _children.length > 1 ? null : node,
+        parentSemantics: node,
       ));
     }
     yield* finalizeSemanticsNode(node, children);
@@ -2546,6 +2546,7 @@ abstract class RenderObject extends AbstractNode with DiagnosticableTreeMixin im
   /// Restore the [SemanticsNode]s owned by this render object to its default
   /// state.
   @mustCallSuper
+  @protected
   void resetSemantics() {
     _semantics?.reset();
   }
@@ -2758,7 +2759,9 @@ abstract class RenderObject extends AbstractNode with DiagnosticableTreeMixin im
   /// and add the [children] to it.
   ///
   /// Subclasses can override this method to add additional [SemanticNode]s
-  /// to the tree. If you do that, you also need to override [resetSemantics].
+  /// to the tree. If a subclass adds additional nodes in this method, it also
+  /// needs to override [resetSemantics] to call [SemanticsNodes.reset] on those
+  /// additional [SemanticsNode]s.
   void assembleSemanticsNode(SemanticsNode node, Iterable<SemanticsNode> children) {
     assert(node == _semantics);
     if (semanticsAnnotator != null)

--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -2749,6 +2749,10 @@ abstract class RenderObject extends AbstractNode with DiagnosticableTreeMixin im
   /// [isSemanticBoundary] isn't true, then the associated call to
   /// [markNeedsSemanticsUpdate] must not have `onlyChanges` set, as it is
   /// possible that the node should be entirely removed.
+  ///
+  /// If the annotation should only happen under certain conditions, `null`
+  /// should be returned if those conditions are currently not met to avoid
+  /// the creation of empty [SemanticsNode].
   SemanticsAnnotator get semanticsAnnotator => null;
 
   /// Assemble the [SemanticsNode] for this [RenderObject].

--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -2752,7 +2752,7 @@ abstract class RenderObject extends AbstractNode with DiagnosticableTreeMixin im
   ///
   /// If the annotation should only happen under certain conditions, `null`
   /// should be returned if those conditions are currently not met to avoid
-  /// the creation of empty [SemanticsNode].
+  /// the creation of an empty [SemanticsNode].
   SemanticsAnnotator get semanticsAnnotator => null;
 
   /// Assemble the [SemanticsNode] for this [RenderObject].

--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -2543,6 +2543,13 @@ abstract class RenderObject extends AbstractNode with DiagnosticableTreeMixin im
     });
   }
 
+  /// Restore the [SemanticsNode]s owned by this render object to its default
+  /// state.
+  @mustCallSuper
+  void resetSemantics() {
+    _semantics?.reset();
+  }
+
   /// Mark this node as needing an update to its semantics
   /// description.
   ///
@@ -2602,10 +2609,10 @@ abstract class RenderObject extends AbstractNode with DiagnosticableTreeMixin im
         if (node.parent is! RenderObject)
           break;
         node._needsSemanticsUpdate = true;
-        node._semantics?.reset();
+        node.resetSemantics();
         node = node.parent;
       } while (node._semantics == null);
-      node._semantics?.reset();
+      node.resetSemantics();
       if (node != this && _semantics != null && _needsSemanticsUpdate) {
         // If [this] node has already been added to [owner._nodesNeedingSemantics]
         // remove it as it is no longer guaranteed that its semantics
@@ -2751,7 +2758,7 @@ abstract class RenderObject extends AbstractNode with DiagnosticableTreeMixin im
   /// and add the [children] to it.
   ///
   /// Subclasses can override this method to add additional [SemanticNode]s
-  /// to the tree.
+  /// to the tree. If you do that, you also need to override [resetSemantics].
   void assembleSemanticsNode(SemanticsNode node, Iterable<SemanticsNode> children) {
     assert(node == _semantics);
     if (semanticsAnnotator != null)

--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -2928,6 +2928,12 @@ class RenderSemanticsGestureHandler extends RenderProxyBox implements SemanticsA
     node.finalizeChildren();
   }
 
+  @override
+  void resetSemantics() {
+    _innerNode?.reset();
+    super.resetSemantics();
+  }
+
   void _annotate(SemanticsNode node) {
     List<SemanticsAction> actions = <SemanticsAction>[];
     if (onTap != null)

--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -2786,8 +2786,7 @@ class RenderSemanticsGestureHandler extends RenderProxyBox implements SemanticsA
   /// bar) can tag its [SemanticNode] with [excludeFromScrolling] to indicate
   /// that it should no longer be considered for semantic actions related to
   /// scrolling.
-  static SemanticsTag excludeFromScrolling = new SemanticsTag('RenderSemanticsGestureHandler.excludeFromScrolling');
-
+  static const SemanticsTag excludeFromScrolling = const SemanticsTag('RenderSemanticsGestureHandler.excludeFromScrolling');
 
   /// If the [SemanticsNode] of this [RenderSemanticsGestureHandler] is tagged
   /// with [useTwoPaneSemantics], two semantics nodes will be used to represent
@@ -2803,7 +2802,7 @@ class RenderSemanticsGestureHandler extends RenderProxyBox implements SemanticsA
   /// the semantic scrolling logic enabled. All children that have been
   /// excluded from scrolling with [excludeFromScrolling] are turned into
   /// children of the outer node.
-  static SemanticsTag useTwoPaneSemantics = const SemanticsTag('RenderSemanticsGestureHandler.twoPane');
+  static const SemanticsTag useTwoPaneSemantics = const SemanticsTag('RenderSemanticsGestureHandler.twoPane');
 
   /// If non-null, the set of actions to allow. Other actions will be omitted,
   /// even if their callback is provided.

--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -2777,12 +2777,33 @@ class RenderSemanticsGestureHandler extends RenderProxyBox implements SemanticsA
   /// [SemanticsNode] is tagged with [excludeFromScrolling] it will not be
   /// part of the scrolling area for semantic purposes.
   ///
+  /// This behavior is only active if the [SemanticsNode] of this
+  /// [RenderSemanticsGestureHandler] is tagged with [useTwoPaneSemantics].
+  /// Otherwise, the [excludeFromScrolling] tag is ignored.
+  ///
   /// As an example, a [RenderSliver] that stays on the screen within a
   /// [Scrollable] even though the user has scrolled past it (e.g. a pinned app
   /// bar) can tag its [SemanticNode] with [excludeFromScrolling] to indicate
   /// that it should no longer be considered for semantic actions related to
   /// scrolling.
   static SemanticsTag excludeFromScrolling = new SemanticsTag('RenderSemanticsGestureHandler.excludeFromScrolling');
+
+
+  /// If the [SemanticsNode] of this [RenderSemanticsGestureHandler] is tagged
+  /// with [useTwoPaneSemantics], two semantics nodes will be used to represent
+  /// this render object in the semantics tree.
+  ///
+  /// Two semantics nodes are necessary to exclude certain child nodes (via the
+  /// [excludeFromScrolling] tag) from the scrollable area for semantic
+  /// purposes.
+  ///
+  /// If this tag is used, the first "outer" semantics node is the regular node
+  /// of this object. The second "inner" node is introduces as a child to that
+  /// node. All scrollable children are now a child of the inner node, which has
+  /// the semantic scrolling logic enabled. All children that have been
+  /// excluded from scrolling with [excludeFromScrolling] are turned into
+  /// children of the outer node.
+  static SemanticsTag useTwoPaneSemantics = const SemanticsTag('RenderSemanticsGestureHandler.twoPane');
 
   /// If non-null, the set of actions to allow. Other actions will be omitted,
   /// even if their callback is provided.
@@ -2877,8 +2898,6 @@ class RenderSemanticsGestureHandler extends RenderProxyBox implements SemanticsA
   SemanticsAnnotator get semanticsAnnotator => isSemanticBoundary ? _annotate : null;
 
   SemanticsNode _innerNode;
-
-  static SemanticsTag useTwoPaneSemantics = const SemanticsTag('RenderSemanticsGestureHandler.twoPane');
 
   @override
   void assembleSemanticsNode(SemanticsNode node, Iterable<SemanticsNode> children) {

--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -2878,21 +2878,21 @@ class RenderSemanticsGestureHandler extends RenderProxyBox implements SemanticsA
 
   SemanticsNode _innerNode;
 
+  static SemanticsTag useTwoPaneSemantics = const SemanticsTag('RenderSemanticsGestureHandler.twoPane');
+
   @override
   void assembleSemanticsNode(SemanticsNode node, Iterable<SemanticsNode> children) {
-    if (onHorizontalDragUpdate == null && onVerticalDragUpdate == null) {
+    if (!node.hasTag(useTwoPaneSemantics)) {
       super.assembleSemanticsNode(node, children);
       return;
     }
-    print('$node');
+    
     _innerNode ??= new SemanticsNode(handler: this, showOnScreen: showOnScreen);
     _innerNode
       ..wasAffectedByClip = node.wasAffectedByClip
       ..rect = Offset.zero & node.rect.size;
 
     semanticsAnnotator(_innerNode);
-
-    print(_innerNode);
 
     final List<SemanticsNode> excluded = <SemanticsNode>[];
     final List<SemanticsNode> included = <SemanticsNode>[];

--- a/packages/flutter/lib/src/rendering/semantics.dart
+++ b/packages/flutter/lib/src/rendering/semantics.dart
@@ -50,7 +50,7 @@ typedef bool SemanticsNodeVisitor(SemanticsNode node);
 ///
 /// Tags can be interpreted by the parent of a [SemanticsNode]
 /// and depending on the presence of a tag the parent can for example decide
-/// how to add the tagged note as a child.
+/// how to add the tagged note as a child. Tags are not sent to the engine.
 ///
 /// As an example, the [RenderSemanticsGestureHandler] uses tags to determine
 /// if a child node should be excluded from the scrollable area for semantic
@@ -61,7 +61,6 @@ typedef bool SemanticsNodeVisitor(SemanticsNode node);
 /// two tags created with the same [name] and the `const` operator are always
 /// identical.
 class SemanticsTag {
-
   /// Creates a [SemanticsTag].
   ///
   /// The provided [name] is only used for debugging. Two tags created with the
@@ -359,11 +358,14 @@ class SemanticsNode extends AbstractNode {
   /// [isPresent] is `false` it will ensure that the node is not tagged with
   /// [tag].
   ///
+  /// Tags are not sent to the engine. They can be used by a parent
+  /// [SemanticsNode] to figure out how to add the node as a child.
+  ///
   /// See also:
   ///
   ///  * [SemanticsTag], whose documentation discusses the purposes of tags.
   ///  * [hasTag] to check if the node has a certain tag.
-  void ensureTag(SemanticsTag tag, { bool isPresent: true}) {
+  void ensureTag(SemanticsTag tag, { bool isPresent: true }) {
     if (isPresent)
       _tags.add(tag);
     else

--- a/packages/flutter/lib/src/rendering/semantics.dart
+++ b/packages/flutter/lib/src/rendering/semantics.dart
@@ -97,11 +97,13 @@ class SemanticsData {
     @required this.actions,
     @required this.label,
     @required this.rect,
+    @required this.tags,
     this.transform
   }) : assert(flags != null),
        assert(actions != null),
        assert(label != null),
-       assert(rect != null);
+       assert(rect != null),
+       assert(tags != null);
 
   /// A bit field of [SemanticsFlags] that apply to this node.
   final int flags;
@@ -114,6 +116,8 @@ class SemanticsData {
 
   /// The bounding box for this node in its coordinate system.
   final Rect rect;
+
+  final Set<SemanticsTag> tags;
 
   /// The transform from this node's coordinate system to its parent's coordinate system.
   ///
@@ -157,11 +161,12 @@ class SemanticsData {
         && typedOther.actions == actions
         && typedOther.label == label
         && typedOther.rect == rect
+        && setEquals(typedOther.tags, tags)
         && typedOther.transform == transform;
   }
 
   @override
-  int get hashCode => hashValues(flags, actions, label, rect, transform);
+  int get hashCode => hashValues(flags, actions, label, rect, tags, transform);
 }
 
 /// A node that represents some semantic data.
@@ -375,7 +380,6 @@ class SemanticsNode extends AbstractNode {
 
   /// Restore this node to its default state.
   void reset() {
-    print('reset $this');
     final bool hadInheritedMergeAllDescendantsIntoThisNode = _inheritedMergeAllDescendantsIntoThisNode;
     _actions = 0;
     _flags = 0;
@@ -580,11 +584,13 @@ class SemanticsNode extends AbstractNode {
     int flags = _flags;
     int actions = _actions;
     String label = _label;
+    final Set<SemanticsTag> tags = new Set<SemanticsTag>.from(_tags);
 
     if (mergeAllDescendantsIntoThisNode) {
       _visitDescendants((SemanticsNode node) {
         flags |= node._flags;
         actions |= node._actions;
+        tags.addAll(node._tags);
         if (node.label.isNotEmpty) {
           if (label.isEmpty)
             label = node.label;
@@ -600,7 +606,8 @@ class SemanticsNode extends AbstractNode {
       actions: actions,
       label: label,
       rect: rect,
-      transform: transform
+      transform: transform,
+      tags: tags,
     );
   }
 

--- a/packages/flutter/lib/src/rendering/semantics.dart
+++ b/packages/flutter/lib/src/rendering/semantics.dart
@@ -117,6 +117,7 @@ class SemanticsData {
   /// The bounding box for this node in its coordinate system.
   final Rect rect;
 
+  /// The set of [SemanticsTag]s associated with this node.
   final Set<SemanticsTag> tags;
 
   /// The transform from this node's coordinate system to its parent's coordinate system.

--- a/packages/flutter/lib/src/rendering/semantics.dart
+++ b/packages/flutter/lib/src/rendering/semantics.dart
@@ -55,14 +55,28 @@ typedef bool SemanticsNodeVisitor(SemanticsNode node);
 /// As an example, the [RenderSemanticsGestureHandler] uses tags to determine
 /// if a child node should be excluded from the scrollable area for semantic
 /// purposes.
+///
+/// The provided [name] is only used for debugging. Two tags created with the
+/// same [name] and the `new` operator are not considered identical. However,
+/// two tags created with the same [name] and the `const` operator are always
+/// identical.
 class SemanticsTag {
+
+  /// Creates a [SemanticsTag].
+  ///
+  /// The provided [name] is only used for debugging. Two tags created with the
+  /// same [name] and the `new` operator are not considered identical. However,
+  /// two tags created with the same [name] and the `const` operator are always
+  /// identical.
   const SemanticsTag(this.name);
 
   /// A human-readable name for this tag used for debugging.
+  ///
+  /// This string is not used to determine if two tags are identical.
   final String name;
 
   @override
-  String toString() => 'SemanticsTag($name)';
+  String toString() => '$runtimeType($name)';
 }
 
 /// Summary information about a [SemanticsNode] object.
@@ -334,11 +348,21 @@ class SemanticsNode extends AbstractNode {
   Set<SemanticsTag> _tags = new Set<SemanticsTag>();
 
   /// Tag the [SemanticsNode] with [tag].
+  ///
+  /// See also:
+  ///
+  ///  * [SemanticsTag], whose documentation discusses the purposes of tags.
   void addTag(SemanticsTag tag) {
     _tags.add(tag);
   }
 
   /// Check if the [SemanticsNode] is tagged with [tag].
+  ///
+  /// Tags can be added with [addTag].
+  ///
+  /// See also:
+  ///
+  ///  * [SemanticsTag], whose documentation discusses the purposes of tags.
   bool hasTag(SemanticsTag tag) => _tags.contains(tag);
 
   /// Restore this node to its default state.
@@ -356,7 +380,8 @@ class SemanticsNode extends AbstractNode {
 
   /// Append the given children as children of this node.
   ///
-  /// You need to call [finalizeChildren] after all children have been added.
+  /// The [finalizeChildren] method must be called after all children have been
+  /// added.
   void addChildren(Iterable<SemanticsNode> children) {
     _newChildren ??= <SemanticsNode>[];
     _newChildren.addAll(children);

--- a/packages/flutter/lib/src/rendering/semantics.dart
+++ b/packages/flutter/lib/src/rendering/semantics.dart
@@ -56,7 +56,7 @@ typedef bool SemanticsNodeVisitor(SemanticsNode node);
 /// if a child node should be excluded from the scrollable area for semantic
 /// purposes.
 class SemanticsTag {
-  SemanticsTag(this.name);
+  const SemanticsTag(this.name);
 
   /// A human-readable name for this tag used for debugging.
   final String name;

--- a/packages/flutter/lib/src/rendering/semantics.dart
+++ b/packages/flutter/lib/src/rendering/semantics.dart
@@ -355,6 +355,8 @@ class SemanticsNode extends AbstractNode {
   List<SemanticsNode> _newChildren;
 
   /// Append the given children as children of this node.
+  ///
+  /// You need to call [finalizeChildren] after all children have been added.
   void addChildren(Iterable<SemanticsNode> children) {
     _newChildren ??= <SemanticsNode>[];
     _newChildren.addAll(children);

--- a/packages/flutter/lib/src/rendering/semantics.dart
+++ b/packages/flutter/lib/src/rendering/semantics.dart
@@ -347,18 +347,26 @@ class SemanticsNode extends AbstractNode {
 
   Set<SemanticsTag> _tags = new Set<SemanticsTag>();
 
-  /// Tag the [SemanticsNode] with [tag].
+  /// Ensures that the [SemanticsNode] is or is not tagged with [tag].
+  ///
+  /// If [isPresent] is `true` it will ensure that the tag is present. If
+  /// [isPresent] is `false` it will ensure that the node is not tagged with
+  /// [tag].
   ///
   /// See also:
   ///
   ///  * [SemanticsTag], whose documentation discusses the purposes of tags.
-  void addTag(SemanticsTag tag) {
-    _tags.add(tag);
+  ///  * [hasTag] to check if the node has a certain tag.
+  void ensureTag(SemanticsTag tag, { bool isPresent: true}) {
+    if (isPresent)
+      _tags.add(tag);
+    else
+      _tags.remove(tag);
   }
 
   /// Check if the [SemanticsNode] is tagged with [tag].
   ///
-  /// Tags can be added with [addTag].
+  /// Tags can be added and removed with [ensureTag].
   ///
   /// See also:
   ///
@@ -367,6 +375,7 @@ class SemanticsNode extends AbstractNode {
 
   /// Restore this node to its default state.
   void reset() {
+    print('reset $this');
     final bool hadInheritedMergeAllDescendantsIntoThisNode = _inheritedMergeAllDescendantsIntoThisNode;
     _actions = 0;
     _flags = 0;

--- a/packages/flutter/lib/src/rendering/semantics.dart
+++ b/packages/flutter/lib/src/rendering/semantics.dart
@@ -46,6 +46,25 @@ typedef void SemanticsAnnotator(SemanticsNode semantics);
 /// Used by [SemanticsNode.visitChildren].
 typedef bool SemanticsNodeVisitor(SemanticsNode node);
 
+/// A tag for a [SemanticsNode].
+///
+/// Tags can be interpreted by the parent of a [SemanticsNode]
+/// and depending on the presence of a tag the parent can for example decide
+/// how to add the tagged note as a child.
+///
+/// As an example, the [RenderSemanticsGestureHandler] uses tags to determine
+/// if a child node should be excluded from the scrollable area for semantic
+/// purposes.
+class SemanticsTag {
+  SemanticsTag(this.name);
+
+  /// A human-readable name for this tag used for debugging.
+  final String name;
+
+  @override
+  String toString() => 'SemanticsTag($name)';
+}
+
 /// Summary information about a [SemanticsNode] object.
 ///
 /// A semantics node might [SemanticsNode.mergeAllDescendantsIntoThisNode],
@@ -311,6 +330,16 @@ class SemanticsNode extends AbstractNode {
       _markDirty();
     }
   }
+
+  Set<SemanticsTag> _tags = new Set<SemanticsTag>();
+
+  /// Tag the [SemanticsNode] with [tag].
+  void addTag(SemanticsTag tag) {
+    _tags.add(tag);
+  }
+
+  /// Check if the [SemanticsNode] is tagged with [tag].
+  bool hasTag(SemanticsTag tag) => _tags.contains(tag);
 
   /// Restore this node to its default state.
   void reset() {
@@ -598,6 +627,8 @@ class SemanticsNode extends AbstractNode {
       if ((_actions & action.index) != 0)
         buffer.write('; $action');
     }
+    for (SemanticsTag tag in _tags)
+      buffer.write('; $tag');
     if (hasCheckedState) {
       if (isChecked)
         buffer.write('; checked');

--- a/packages/flutter/lib/src/rendering/sliver.dart
+++ b/packages/flutter/lib/src/rendering/sliver.dart
@@ -6,7 +6,6 @@ import 'dart:math' as math;
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
-import 'package:meta/meta.dart';
 import 'package:vector_math/vector_math_64.dart';
 
 import 'binding.dart';

--- a/packages/flutter/lib/src/rendering/sliver.dart
+++ b/packages/flutter/lib/src/rendering/sliver.dart
@@ -14,7 +14,6 @@ import 'box.dart';
 import 'debug.dart';
 import 'object.dart';
 import 'proxy_box.dart';
-import 'semantics.dart';
 import 'viewport_offset.dart';
 
 // CORE TYPES FOR SLIVERS
@@ -1313,28 +1312,6 @@ abstract class RenderSliver extends RenderObject {
   // This override exists only to change the type of the second argument.
   @override
   void handleEvent(PointerEvent event, SliverHitTestEntry entry) { }
-
-  /// Whether the [SemanticsNode]s associated with this [RenderSliver] should
-  /// be excluded from the semantic scrolling area.
-  ///
-  /// [RenderSliver]s that stay on the screen even though the user has scrolled
-  /// past them (e.g. a pinned app bar) should set this to `true`.
-  @protected
-  bool get excludeFromSemanticsScrolling => _excludeFromSemanticsScrolling;
-  set excludeFromSemanticsScrolling(bool value) {
-    if (_excludeFromSemanticsScrolling == value)
-      return;
-    _excludeFromSemanticsScrolling = value;
-    markNeedsSemanticsUpdate();
-  }
-  bool _excludeFromSemanticsScrolling = false;
-
-  @override
-  SemanticsAnnotator get semanticsAnnotator => _excludeFromSemanticsScrolling ? _annotate : null;
-
-  void _annotate(SemanticsNode node) {
-    node.addTag(RenderSemanticsGestureHandler.excludeFromScrolling);
-  }
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder description) {

--- a/packages/flutter/lib/src/rendering/sliver.dart
+++ b/packages/flutter/lib/src/rendering/sliver.dart
@@ -12,7 +12,6 @@ import 'binding.dart';
 import 'box.dart';
 import 'debug.dart';
 import 'object.dart';
-import 'proxy_box.dart';
 import 'viewport_offset.dart';
 
 // CORE TYPES FOR SLIVERS

--- a/packages/flutter/lib/src/rendering/sliver.dart
+++ b/packages/flutter/lib/src/rendering/sliver.dart
@@ -6,6 +6,7 @@ import 'dart:math' as math;
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
+import 'package:meta/meta.dart';
 import 'package:vector_math/vector_math_64.dart';
 
 import 'binding.dart';
@@ -1318,6 +1319,8 @@ abstract class RenderSliver extends RenderObject {
   ///
   /// [RenderSliver]s that stay on the screen even though the user has scrolled
   /// past them (e.g. a pinned app bar) should set this to `true`.
+  @protected
+  bool get excludeFromSemanticsScrolling => _excludeFromSemanticsScrolling;
   set excludeFromSemanticsScrolling(bool value) {
     if (_excludeFromSemanticsScrolling == value)
       return;

--- a/packages/flutter/lib/src/rendering/sliver.dart
+++ b/packages/flutter/lib/src/rendering/sliver.dart
@@ -12,6 +12,8 @@ import 'binding.dart';
 import 'box.dart';
 import 'debug.dart';
 import 'object.dart';
+import 'proxy_box.dart';
+import 'semantics.dart';
 import 'viewport_offset.dart';
 
 // CORE TYPES FOR SLIVERS
@@ -1310,6 +1312,26 @@ abstract class RenderSliver extends RenderObject {
   // This override exists only to change the type of the second argument.
   @override
   void handleEvent(PointerEvent event, SliverHitTestEntry entry) { }
+
+  /// Whether the [SemanticsNode]s associated with this [RenderSliver] should
+  /// be excluded from the semantic scrolling area.
+  ///
+  /// [RenderSliver]s that stay on the screen even though the user has scrolled
+  /// past them (e.g. a pinned app bar) should set this to `true`.
+  set excludeFromSemanticsScrolling(bool value) {
+    if (_excludeFromSemanticsScrolling == value)
+      return;
+    _excludeFromSemanticsScrolling = value;
+    markNeedsSemanticsUpdate();
+  }
+  bool _excludeFromSemanticsScrolling = false;
+
+  @override
+  SemanticsAnnotator get semanticsAnnotator => _excludeFromSemanticsScrolling ? _annotate : null;
+
+  void _annotate(SemanticsNode node) {
+    node.addTag(RenderSemanticsGestureHandler.excludeFromScrolling);
+  }
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder description) {

--- a/packages/flutter/lib/src/rendering/sliver_persistent_header.dart
+++ b/packages/flutter/lib/src/rendering/sliver_persistent_header.dart
@@ -212,13 +212,13 @@ abstract class RenderSliverPersistentHeader extends RenderSliver with RenderObje
   /// past them (e.g. a pinned app bar) should set this to `true`.
   @protected
   bool get excludeFromSemanticsScrolling => _excludeFromSemanticsScrolling;
+  bool _excludeFromSemanticsScrolling = false;
   set excludeFromSemanticsScrolling(bool value) {
     if (_excludeFromSemanticsScrolling == value)
       return;
     _excludeFromSemanticsScrolling = value;
     markNeedsSemanticsUpdate();
   }
-  bool _excludeFromSemanticsScrolling = false;
 
   @override
   SemanticsAnnotator get semanticsAnnotator => _excludeFromSemanticsScrolling ? _annotate : null;

--- a/packages/flutter/lib/src/rendering/sliver_persistent_header.dart
+++ b/packages/flutter/lib/src/rendering/sliver_persistent_header.dart
@@ -224,7 +224,7 @@ abstract class RenderSliverPersistentHeader extends RenderSliver with RenderObje
   SemanticsAnnotator get semanticsAnnotator => _excludeFromSemanticsScrolling ? _annotate : null;
 
   void _annotate(SemanticsNode node) {
-    node.addTag(RenderSemanticsGestureHandler.excludeFromScrolling);
+    node.ensureTag(RenderSemanticsGestureHandler.excludeFromScrolling);
   }
 
   @override

--- a/packages/flutter/lib/src/rendering/sliver_persistent_header.dart
+++ b/packages/flutter/lib/src/rendering/sliver_persistent_header.dart
@@ -13,6 +13,8 @@ import 'package:vector_math/vector_math_64.dart';
 import 'binding.dart';
 import 'box.dart';
 import 'object.dart';
+import 'proxy_box.dart';
+import 'semantics.dart';
 import 'sliver.dart';
 import 'viewport_offset.dart';
 
@@ -201,6 +203,28 @@ abstract class RenderSliverPersistentHeader extends RenderSliver with RenderObje
       }
       context.paintChild(child, offset);
     }
+  }
+
+  /// Whether the [SemanticsNode]s associated with this [RenderSliver] should
+  /// be excluded from the semantic scrolling area.
+  ///
+  /// [RenderSliver]s that stay on the screen even though the user has scrolled
+  /// past them (e.g. a pinned app bar) should set this to `true`.
+  @protected
+  bool get excludeFromSemanticsScrolling => _excludeFromSemanticsScrolling;
+  set excludeFromSemanticsScrolling(bool value) {
+    if (_excludeFromSemanticsScrolling == value)
+      return;
+    _excludeFromSemanticsScrolling = value;
+    markNeedsSemanticsUpdate();
+  }
+  bool _excludeFromSemanticsScrolling = false;
+
+  @override
+  SemanticsAnnotator get semanticsAnnotator => _excludeFromSemanticsScrolling ? _annotate : null;
+
+  void _annotate(SemanticsNode node) {
+    node.addTag(RenderSemanticsGestureHandler.excludeFromScrolling);
   }
 
   @override

--- a/packages/flutter/lib/src/rendering/sliver_persistent_header.dart
+++ b/packages/flutter/lib/src/rendering/sliver_persistent_header.dart
@@ -264,7 +264,9 @@ abstract class RenderSliverPinnedPersistentHeader extends RenderSliverPersistent
   @override
   void performLayout() {
     final double maxExtent = this.maxExtent;
-    layoutChild(constraints.scrollOffset, maxExtent, overlapsContent: constraints.overlap > 0.0);
+    final bool overlapsContent = constraints.overlap > 0.0;
+    excludeFromSemanticsScrolling = overlapsContent || (constraints.scrollOffset > maxExtent - minExtent);
+    layoutChild(constraints.scrollOffset, maxExtent, overlapsContent: overlapsContent);
     geometry = new SliverGeometry(
       scrollExtent: maxExtent,
       paintOrigin: constraints.overlap,
@@ -445,7 +447,9 @@ abstract class RenderSliverFloatingPersistentHeader extends RenderSliverPersiste
     } else {
       _effectiveScrollOffset = constraints.scrollOffset;
     }
-    layoutChild(_effectiveScrollOffset, maxExtent, overlapsContent: _effectiveScrollOffset < constraints.scrollOffset);
+    final bool overlapsContent = _effectiveScrollOffset < constraints.scrollOffset;
+    excludeFromSemanticsScrolling = overlapsContent;
+    layoutChild(_effectiveScrollOffset, maxExtent, overlapsContent: overlapsContent);
     _childPosition = updateGeometry();
     _lastActualScrollOffset = constraints.scrollOffset;
   }

--- a/packages/flutter/lib/src/rendering/viewport.dart
+++ b/packages/flutter/lib/src/rendering/viewport.dart
@@ -91,7 +91,7 @@ abstract class RenderViewportBase<ParentDataClass extends ContainerParentDataMix
   SemanticsAnnotator get semanticsAnnotator => _annotate;
 
   void _annotate(SemanticsNode node) {
-    node.addTag(RenderSemanticsGestureHandler.useTwoPaneSemantics);
+    node.ensureTag(RenderSemanticsGestureHandler.useTwoPaneSemantics);
   }
 
   /// The direction in which the [SliverConstraints.scrollOffset] increases.

--- a/packages/flutter/lib/src/rendering/viewport.dart
+++ b/packages/flutter/lib/src/rendering/viewport.dart
@@ -11,6 +11,7 @@ import 'package:vector_math/vector_math_64.dart';
 import 'binding.dart';
 import 'box.dart';
 import 'object.dart';
+import 'proxy_box.dart';
 import 'semantics.dart';
 import 'sliver.dart';
 import 'viewport_offset.dart';
@@ -90,8 +91,7 @@ abstract class RenderViewportBase<ParentDataClass extends ContainerParentDataMix
   SemanticsAnnotator get semanticsAnnotator => _annotate;
 
   void _annotate(SemanticsNode node) {
-    print('here');
-    node.addTag(new SemanticsTag('fooo'));
+    node.addTag(RenderSemanticsGestureHandler.useTwoPaneSemantics);
   }
 
   /// The direction in which the [SliverConstraints.scrollOffset] increases.

--- a/packages/flutter/lib/src/rendering/viewport.dart
+++ b/packages/flutter/lib/src/rendering/viewport.dart
@@ -11,6 +11,7 @@ import 'package:vector_math/vector_math_64.dart';
 import 'binding.dart';
 import 'box.dart';
 import 'object.dart';
+import 'semantics.dart';
 import 'sliver.dart';
 import 'viewport_offset.dart';
 
@@ -84,6 +85,14 @@ abstract class RenderViewportBase<ParentDataClass extends ContainerParentDataMix
        assert(offset != null),
        _axisDirection = axisDirection,
        _offset = offset;
+
+  @override
+  SemanticsAnnotator get semanticsAnnotator => _annotate;
+
+  void _annotate(SemanticsNode node) {
+    print('here');
+    node.addTag(new SemanticsTag('fooo'));
+  }
 
   /// The direction in which the [SliverConstraints.scrollOffset] increases.
   ///

--- a/packages/flutter/test/rendering/semantics_test.dart
+++ b/packages/flutter/test/rendering/semantics_test.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:test/test.dart';
 

--- a/packages/flutter/test/rendering/semantics_test.dart
+++ b/packages/flutter/test/rendering/semantics_test.dart
@@ -1,0 +1,71 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+import 'package:test/test.dart';
+
+
+void main() {
+  group('SemanticsNode', () {
+
+    const SemanticsTag tag1 = const SemanticsTag('Tag One');
+    const SemanticsTag tag2 = const SemanticsTag('Tag Two');
+    const SemanticsTag tag3 = const SemanticsTag('Tag Three');
+
+    test('tagging', () {
+      final SemanticsNode node = new SemanticsNode();
+
+      expect(node.hasTag(tag1), isFalse);
+      expect(node.hasTag(tag2), isFalse);
+
+      node.ensureTag(tag1);
+      expect(node.hasTag(tag1), isTrue);
+      expect(node.hasTag(tag2), isFalse);
+
+      node.ensureTag(tag2, isPresent: false);
+      expect(node.hasTag(tag1), isTrue);
+      expect(node.hasTag(tag2), isFalse);
+
+      node.ensureTag(tag2, isPresent: true);
+      expect(node.hasTag(tag1), isTrue);
+      expect(node.hasTag(tag2), isTrue);
+
+      node.ensureTag(tag2, isPresent: true);
+      expect(node.hasTag(tag1), isTrue);
+      expect(node.hasTag(tag2), isTrue);
+
+      node.ensureTag(tag1, isPresent: false);
+      expect(node.hasTag(tag1), isFalse);
+      expect(node.hasTag(tag2), isTrue);
+
+      node.ensureTag(tag2, isPresent: false);
+      expect(node.hasTag(tag1), isFalse);
+      expect(node.hasTag(tag2), isFalse);
+    });
+
+    test('getSemanticsData includes tags', () {
+      final SemanticsNode node = new SemanticsNode()
+        ..ensureTag(tag1)
+        ..ensureTag(tag2);
+
+      final Set<SemanticsTag> expected = new Set<SemanticsTag>()
+        ..add(tag1)
+        ..add(tag2);
+
+      expect(node.getSemanticsData().tags, expected);
+
+      node.mergeAllDescendantsIntoThisNode = true;
+      node.addChildren(<SemanticsNode>[
+        new SemanticsNode()..ensureTag(tag3)
+      ]);
+      node.finalizeChildren();
+
+      expected.add(tag3);
+
+      expect(node.getSemanticsData().tags, expected);
+    });
+  });
+
+}

--- a/packages/flutter/test/widgets/sliver_semantics_test.dart
+++ b/packages/flutter/test/widgets/sliver_semantics_test.dart
@@ -1,0 +1,162 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter/material.dart';
+
+import 'semantics_tester.dart';
+
+void main() {
+  testWidgets('excludeFromScrollable works correctly', (WidgetTester tester) async {
+    final SemanticsTester semantics = new SemanticsTester(tester);
+
+    const double appBarExpandedHeight = 200.0;
+
+    final ScrollController scrollController = new ScrollController();
+    final List<Widget> listChildren = new List<Widget>.generate(30, (int i) {
+      return new Container(
+        height: appBarExpandedHeight,
+        child: new Text('Item $i'),
+      );
+    });
+    await tester.pumpWidget(
+      new MediaQuery(
+        data: const MediaQueryData(),
+        child: new CustomScrollView(
+          controller: scrollController,
+          slivers: <Widget>[
+            new SliverAppBar(
+              pinned: true,
+              expandedHeight: appBarExpandedHeight,
+              title: const Text('Semantics Test with Slivers'),
+            ),
+            new SliverList(
+              delegate: new SliverChildListDelegate(listChildren),
+            ),
+          ],
+        ),
+    ));
+
+    // AppBar is child of node with semantic scroll actions.
+    expect(semantics, hasSemantics(
+        new TestSemantics.root(
+          children: <TestSemantics>[
+            new TestSemantics.rootChild(
+              id: 1,
+              tags: <SemanticsTag>[RenderSemanticsGestureHandler.useTwoPaneSemantics],
+              children: <TestSemantics>[
+                new TestSemantics(
+                  id: 5,
+                  actions: SemanticsAction.scrollUp.index,
+                  children: <TestSemantics>[
+                    new TestSemantics(
+                      id: 2,
+                      label: 'Semantics Test with Slivers',
+                    ),
+                    new TestSemantics(
+                      id: 3,
+                      label: 'Item 0',
+                    ),
+                    new TestSemantics(
+                      id: 4,
+                      label: 'Item 1',
+                    ),
+                  ],
+                ),
+              ],
+            )
+          ],
+        ),
+        ignoreRect: true,
+        ignoreTransform: true,
+    ));
+
+    // Scroll down far enough to reach the pinned state of the app bar.
+    scrollController.jumpTo(appBarExpandedHeight);
+    await tester.pump();
+
+    // App bar is NOT a child of node with semantic scroll actions.
+    expect(semantics, hasSemantics(
+      new TestSemantics.root(
+        children: <TestSemantics>[
+          new TestSemantics.rootChild(
+            id: 1,
+            tags: <SemanticsTag>[RenderSemanticsGestureHandler.useTwoPaneSemantics],
+            children: <TestSemantics>[
+              new TestSemantics(
+                id: 6,
+                label: 'Semantics Test with Slivers',
+                tags: <SemanticsTag>[RenderSemanticsGestureHandler.excludeFromScrolling],
+              ),
+              new TestSemantics(
+                id: 5,
+                actions: SemanticsAction.scrollUp.index | SemanticsAction.scrollDown.index,
+                children: <TestSemantics>[
+                  new TestSemantics(
+                    id: 3,
+                    label: 'Item 0',
+                  ),
+                  new TestSemantics(
+                    id: 4,
+                    label: 'Item 1',
+                  ),
+                  new TestSemantics(
+                    id: 7,
+                    label: 'Item 2',
+                  ),
+                ],
+              ),
+            ],
+          )
+        ],
+      ),
+      ignoreRect: true,
+      ignoreTransform: true,
+    ));
+
+    // Scroll halfway back to the top, app bar is no longer in pinned state.
+    scrollController.jumpTo(appBarExpandedHeight / 2);
+    await tester.pump();
+
+    // AppBar is child of node with semantic scroll actions.
+    expect(semantics, hasSemantics(
+      new TestSemantics.root(
+        children: <TestSemantics>[
+          new TestSemantics.rootChild(
+            id: 1,
+            tags: <SemanticsTag>[RenderSemanticsGestureHandler.useTwoPaneSemantics],
+            children: <TestSemantics>[
+              new TestSemantics(
+                id: 5,
+                actions: SemanticsAction.scrollUp.index | SemanticsAction.scrollDown.index,
+                children: <TestSemantics>[
+                  new TestSemantics(
+                    id: 8,
+                    label: 'Semantics Test with Slivers',
+                  ),
+                  new TestSemantics(
+                    id: 3,
+                    label: 'Item 0',
+                  ),
+                  new TestSemantics(
+                    id: 4,
+                    label: 'Item 1',
+                  ),
+                  new TestSemantics(
+                    id: 7,
+                    label: 'Item 2',
+                  ),
+                ],
+              ),
+            ],
+          )
+        ],
+      ),
+      ignoreRect: true,
+      ignoreTransform: true,
+    ));
+  });
+}


### PR DESCRIPTION
Goal of this PR is to make pinned app bars work properly when scrolling with a11y methods.

This is achieved by splitting the `SemanticsNode` of `RenderSemanticsGestureHandler` into an inner and outer node. The inner node has all scrollable nodes (i.e. the nodes of the actual list behind/under the app bar) as children. The outer node has all non-scrollable nodes (i.e. the pinned app bar) as children and is also the parent to the inner node.

This PR also introduces a new `assembleSemanticsNode` method on `RenderObject`, which allows `RenderObject`s to provide their own  custom `SemanticsNode` hierarchy. This approach should also enable us to make `CustomPainter`s accessible in the future.

Furthermore, the concept of tagging a `SemanticsNode` with `SemanticsTag`s is introduced. `SemanticsTag`s can be used to provide additional information about a `SemanticsNode` to a parent without exposing these to the native (iOS/Android) side.