### PR TITLE
Add log to understand flakiness of commands_test

### DIFF
--- a/dev/integration_tests/ui/lib/driver.dart
+++ b/dev/integration_tests/ui/lib/driver.dart
@@ -7,7 +7,10 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_driver/driver_extension.dart';
 
 void main() {
-  enableFlutterDriverExtension();
+  enableFlutterDriverExtension(handler: (String message) async {
+    // TODO(cbernaschina) remove when test flakiness is resolved
+    return 'driver';
+  });
   runApp(new DriverTestApp());
 }
 

--- a/dev/integration_tests/ui/lib/keyboard_resize.dart
+++ b/dev/integration_tests/ui/lib/keyboard_resize.dart
@@ -8,7 +8,10 @@ import 'package:flutter_driver/driver_extension.dart';
 import 'keys.dart' as keys;
 
 void main() {
-  enableFlutterDriverExtension();
+  enableFlutterDriverExtension(handler: (String message) async {
+    // TODO(cbernaschina) remove when test flakiness is resolved
+    return 'keyboard_resize';
+  });
   runApp(new MyApp());
 }
 

--- a/packages/flutter_driver/lib/src/extension.dart
+++ b/packages/flutter_driver/lib/src/extension.dart
@@ -324,7 +324,7 @@ class FlutterDriverExtension {
 
   Future<RequestDataResult> _requestData(Command command) async {
     final RequestData requestDataCommand = command;
-    return new RequestDataResult(_requestDataHandler == null ? '' : await _requestDataHandler(requestDataCommand.message));
+    return new RequestDataResult(_requestDataHandler == null ? 'No requestData Extension registered' : await _requestDataHandler(requestDataCommand.message));
   }
 
   Future<SetFrameSyncResult> _setFrameSync(Command command) async {


### PR DESCRIPTION
The flakiness of commands_test is generally visible via:

```
drive:stdout:   Expected: 'log: paint'
drive:stdout:     Actual: ''
drive:stdout:      Which: is different. Both strings start the same, but the actual value is missing the following trailing characters: log: paint ...
```

By returning the name of the test we will be able to understand if
another test is running by reading the `Actual` value