### PR TITLE
fix some call sites of printError

### DIFF
--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -468,7 +468,7 @@ abstract class ResidentRunner {
             await view.uiIsolate.flutterDebugAllowBanner(false);
         } catch (error) {
           status.stop();
-          printError(error);
+          printError('Error communicating with Flutter on the device: $error');
         }
       }
       try {
@@ -480,7 +480,7 @@ abstract class ResidentRunner {
               await view.uiIsolate.flutterDebugAllowBanner(true);
           } catch (error) {
             status.stop();
-            printError(error);
+            printError('Error communicating with Flutter on the device: $error');
           }
         }
       }

--- a/packages/flutter_tools/lib/src/run_cold.dart
+++ b/packages/flutter_tools/lib/src/run_cold.dart
@@ -88,7 +88,7 @@ class ColdRunner extends ResidentRunner {
         try {
           await downloadStartupTrace(device.vmServices.first);
         } catch (error) {
-          printError(error);
+          printError('Error downloading startup trace: $error');
           return 2;
         }
       }

--- a/packages/flutter_tools/lib/src/services.dart
+++ b/packages/flutter_tools/lib/src/services.dart
@@ -42,7 +42,7 @@ Future<Null> parseServiceConfigs(
     manifest = manifest['flutter'];
   } catch (e) {
     printStatus('Error detected in pubspec.yaml:', emphasis: true);
-    printError(e);
+    printError('$e');
     return;
   }
   if (manifest == null || manifest['services'] == null) {

--- a/packages/flutter_tools/lib/src/services.dart
+++ b/packages/flutter_tools/lib/src/services.dart
@@ -31,8 +31,8 @@ Future<Null> parseServiceConfigs(
   Map<String, Uri> packageMap;
   try {
     packageMap = new PackageMap(PackageMap.globalPackagesPath).map;
-  } on FormatException catch(e) {
-    printTrace('Invalid ".packages" file while parsing service configs:\n$e');
+  } on FormatException catch (error) {
+    printTrace('Invalid ".packages" file while parsing service configs:\n$error');
     return;
   }
 
@@ -40,9 +40,9 @@ Future<Null> parseServiceConfigs(
   try {
     manifest = _loadYamlFile(_kFlutterManifestPath);
     manifest = manifest['flutter'];
-  } catch (e) {
+  } catch (error) {
     printStatus('Error detected in pubspec.yaml:', emphasis: true);
-    printError('$e');
+    printError('$error');
     return;
   }
   if (manifest == null || manifest['services'] == null) {


### PR DESCRIPTION
- fix some call sites of `printError` - printError takes a String; these call sites were passing in a `dynamic`, which generally was an exception object, like `TimeoutException`