### PR TITLE
Remove a bunch of useless global configuration options.

### DIFF
--- a/packages/flutter/lib/src/rendering/box.dart
+++ b/packages/flutter/lib/src/rendering/box.dart
@@ -2030,7 +2030,7 @@ abstract class RenderBox extends RenderObject {
       final Paint paint = new Paint()
        ..style = PaintingStyle.stroke
        ..strokeWidth = 1.0
-       ..color = debugPaintSizeColor;
+       ..color = const Color(0xFF00FFFF);
       context.canvas.drawRect((offset & size).deflate(0.5), paint);
       return true;
     });
@@ -2049,7 +2049,7 @@ abstract class RenderBox extends RenderObject {
       // ideographic baseline
       final double baselineI = getDistanceToBaseline(TextBaseline.ideographic, onlyReal: true);
       if (baselineI != null) {
-        paint.color = debugPaintIdeographicBaselineColor;
+        paint.color = const Color(0xFFFFD000);
         path = new Path();
         path.moveTo(offset.dx, offset.dy + baselineI);
         path.lineTo(offset.dx + size.width, offset.dy + baselineI);
@@ -2058,7 +2058,7 @@ abstract class RenderBox extends RenderObject {
       // alphabetic baseline
       final double baselineA = getDistanceToBaseline(TextBaseline.alphabetic, onlyReal: true);
       if (baselineA != null) {
-        paint.color = debugPaintAlphabeticBaselineColor;
+        paint.color = const Color(0xFF00FF00);
         path = new Path();
         path.moveTo(offset.dx, offset.dy + baselineA);
         path.lineTo(offset.dx + size.width, offset.dy + baselineA);
@@ -2080,7 +2080,7 @@ abstract class RenderBox extends RenderObject {
     assert(() {
       if (_debugActivePointers > 0) {
         final Paint paint = new Paint()
-         ..color = new Color(debugPaintPointersColorValue | ((0x04000000 * depth) & 0xFF000000));
+         ..color = new Color(0x00BBBB | ((0x04000000 * depth) & 0xFF000000));
         context.canvas.drawRect(offset & size, paint);
       }
       return true;

--- a/packages/flutter/lib/src/rendering/debug.dart
+++ b/packages/flutter/lib/src/rendering/debug.dart
@@ -11,66 +11,24 @@ export 'package:flutter/foundation.dart' show debugPrint;
 // Any changes to this file should be reflected in the debugAssertAllRenderVarsUnset()
 // function below.
 
-const Color _kDebugPaintSizeColor = const Color(0xFF00FFFF);
-const Color _kDebugPaintSpacingColor = const Color(0x90909090);
-const Color _kDebugPaintPaddingColor = const Color(0x900090FF);
-const Color _kDebugPaintPaddingInnerEdgeColor = const Color(0xFF0090FF);
-const Color _kDebugPaintBoxArrowColor = const Color(0xFFFFFF00);
-const Color _kDebugPaintSliverArrowColor = const Color(0xFF33CC33);
-const Color _kDebugPaintAlphabeticBaselineColor = const Color(0xFF00FF00);
-const Color _kDebugPaintIdeographicBaselineColor = const Color(0xFFFFD000);
-const Color _kDebugPaintLayerBordersColor = const Color(0xFFFF9800);
-const int _kDebugPaintPointersColorValue = 0x00BBBB;
-const HSVColor _kDebugCurrentRepaintColor = const HSVColor.fromAHSV(0.4, 60.0, 1.0, 1.0);
-const double _kDebugRepaintRainbowHueIncrement = 2.0;
+const HSVColor _kDebugDefaultRepaintColor = const HSVColor.fromAHSV(0.4, 60.0, 1.0, 1.0);
 
 /// Causes each RenderBox to paint a box around its bounds, and some extra
 /// boxes, such as [RenderPadding], to draw construction lines.
+///
+/// The edges of boies are painted as a one-pixel-thick `const Color(0xFF00FFFF)` outline.
+///
+/// Spacing is painted as a solid `const Color(0x90909090)` area.
+///
+/// Padding is filled in solid `const Color(0x900090FF)`, with the inner edge
+/// outlined in `const Color(0xFF0090FF)`, using [debugPaintPadding].
 bool debugPaintSizeEnabled = false;
-
-/// The color to use when painting RenderObject bounds.
-Color debugPaintSizeColor = _kDebugPaintSizeColor;
-
-/// The color to use when painting some boxes that just add space (e.g. an empty
-/// RenderConstrainedBox or [RenderPadding]).
-///
-/// Used by, among other methods, [debugPaintPadding], which is called by
-/// [RenderPadding.debugPaintSize] when [debugPaintSizeEnabled] is true.
-Color debugPaintSpacingColor = _kDebugPaintSpacingColor;
-
-/// The color to use when painting [RenderPadding] edges.
-///
-/// Used by, among other methods, [debugPaintPadding], which is called by
-/// [RenderPadding.debugPaintSize] when [debugPaintSizeEnabled] is true.
-Color debugPaintPaddingColor = _kDebugPaintPaddingColor;
-
-/// The color to use when painting [RenderPadding] edges. This color is painted on
-/// top of [debugPaintPaddingColor].
-///
-/// Used by, among other methods, [debugPaintPadding], which is called by
-/// [RenderPadding.debugPaintSize] when [debugPaintSizeEnabled] is true.
-Color debugPaintPaddingInnerEdgeColor = _kDebugPaintPaddingInnerEdgeColor;
-
-/// The color to use when painting the arrows used to show [RenderPositionedBox] alignment.
-Color debugPaintBoxArrowColor = _kDebugPaintBoxArrowColor;
-
-/// The color to use when painting the arrows used to show [RenderSliver] alignment.
-Color debugPaintSliverArrowColor = _kDebugPaintSliverArrowColor;
 
 /// Causes each RenderBox to paint a line at each of its baselines.
 bool debugPaintBaselinesEnabled = false;
 
-/// The color to use when painting alphabetic baselines.
-Color debugPaintAlphabeticBaselineColor = _kDebugPaintAlphabeticBaselineColor;
-
-/// The color to use when painting ideographic baselines.
-Color debugPaintIdeographicBaselineColor = _kDebugPaintIdeographicBaselineColor;
-
 /// Causes each Layer to paint a box around its bounds.
 bool debugPaintLayerBordersEnabled = false;
-
-/// The color to use when painting Layer borders.
-Color debugPaintLayerBordersColor = _kDebugPaintLayerBordersColor;
 
 /// Causes objects like [RenderPointerListener] to flash while they are being
 /// tapped. This can be useful to see how large the hit box is, e.g. when
@@ -80,9 +38,6 @@ Color debugPaintLayerBordersColor = _kDebugPaintLayerBordersColor;
 /// [RenderBox.debugHandleEvent].
 bool debugPaintPointersEnabled = false;
 
-/// The color to use when reporting pointers for [debugPaintPointersEnabled].
-int debugPaintPointersColorValue = _kDebugPaintPointersColorValue;
-
 /// Overlay a rotating set of colors when repainting layers in checked mode.
 bool debugRepaintRainbowEnabled = false;
 
@@ -90,10 +45,13 @@ bool debugRepaintRainbowEnabled = false;
 bool debugRepaintTextRainbowEnabled = false;
 
 /// The current color to overlay when repainting a layer.
-HSVColor debugCurrentRepaintColor = _kDebugCurrentRepaintColor;
-
-/// The amount to increment the hue of the current repaint color.
-double debugRepaintRainbowHueIncrement = _kDebugRepaintRainbowHueIncrement;
+///
+/// This is used by painting debug code that implements
+/// [debugRepaintRainbowEnabled] or [debugRepaintTextRainbowEnabled].
+///
+/// The value is incremented by [RenderView.compositeFrame] if either of those
+/// flags is enabled.
+HSVColor debugCurrentRepaintColor = _kDebugDefaultRepaintColor;
 
 /// Log the call stacks that mark render objects as needing layout.
 ///
@@ -205,19 +163,18 @@ void _debugDrawDoubleRect(Canvas canvas, Rect outerRect, Rect innerRect, Color c
   canvas.drawPath(path, paint);
 }
 
-/// Paint padding using the [debugPaintPaddingColor],
-/// [debugPaintPaddingInnerEdgeColor], and [debugPaintSpacingColor] colors.
+/// Paint a diagram showing the given area as padding.
 ///
 /// Called by [RenderPadding.debugPaintSize] when [debugPaintSizeEnabled] is
 /// true.
 void debugPaintPadding(Canvas canvas, Rect outerRect, Rect innerRect, { double outlineWidth: 2.0 }) {
   assert(() {
     if (innerRect != null && !innerRect.isEmpty) {
-      _debugDrawDoubleRect(canvas, outerRect, innerRect, debugPaintPaddingColor);
-      _debugDrawDoubleRect(canvas, innerRect.inflate(outlineWidth).intersect(outerRect), innerRect, debugPaintPaddingInnerEdgeColor);
+      _debugDrawDoubleRect(canvas, outerRect, innerRect, const Color(0x900090FF));
+      _debugDrawDoubleRect(canvas, innerRect.inflate(outlineWidth).intersect(outerRect), innerRect, const Color(0xFF0090FF));
     } else {
       final Paint paint = new Paint()
-        ..color = debugPaintSpacingColor;
+        ..color = const Color(0x90909090);
       canvas.drawRect(outerRect, paint);
     }
     return true;
@@ -243,23 +200,12 @@ bool debugAssertAllRenderVarsUnset(String reason, { bool debugCheckIntrinsicSize
         debugPaintPointersEnabled ||
         debugRepaintRainbowEnabled ||
         debugRepaintTextRainbowEnabled ||
+        debugCurrentRepaintColor != _kDebugDefaultRepaintColor ||
         debugPrintMarkNeedsLayoutStacks ||
         debugPrintMarkNeedsPaintStacks ||
         debugPrintLayouts ||
         debugCheckIntrinsicSizes != debugCheckIntrinsicSizesOverride ||
-        debugProfilePaintsEnabled ||
-        debugPaintSizeColor != _kDebugPaintSizeColor ||
-        debugPaintSpacingColor != _kDebugPaintSpacingColor ||
-        debugPaintPaddingColor != _kDebugPaintPaddingColor ||
-        debugPaintPaddingInnerEdgeColor != _kDebugPaintPaddingInnerEdgeColor ||
-        debugPaintBoxArrowColor != _kDebugPaintBoxArrowColor ||
-        debugPaintSliverArrowColor != _kDebugPaintSliverArrowColor ||
-        debugPaintAlphabeticBaselineColor != _kDebugPaintAlphabeticBaselineColor ||
-        debugPaintIdeographicBaselineColor != _kDebugPaintIdeographicBaselineColor ||
-        debugPaintLayerBordersColor != _kDebugPaintLayerBordersColor ||
-        debugPaintPointersColorValue != _kDebugPaintPointersColorValue ||
-        debugCurrentRepaintColor != _kDebugCurrentRepaintColor ||
-        debugRepaintRainbowHueIncrement != _kDebugRepaintRainbowHueIncrement) {
+        debugProfilePaintsEnabled) {
       throw new FlutterError(reason);
     }
     return true;

--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -232,7 +232,7 @@ class PaintingContext {
         final Paint paint = new Paint()
           ..style = PaintingStyle.stroke
           ..strokeWidth = 1.0
-          ..color = debugPaintLayerBordersColor;
+          ..color = const Color(0xFFFF9800);
         canvas.drawRect(canvasBounds, paint);
       }
       return true;

--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -267,7 +267,7 @@ class RenderConstrainedBox extends RenderProxyBox {
       Paint paint;
       if (child == null || child.size.isEmpty) {
         paint = new Paint()
-          ..color = debugPaintSpacingColor;
+          ..color = const Color(0x90909090);
         context.canvas.drawRect(offset & size, paint);
       }
       return true;

--- a/packages/flutter/lib/src/rendering/shifted_box.dart
+++ b/packages/flutter/lib/src/rendering/shifted_box.dart
@@ -317,7 +317,7 @@ class RenderPositionedBox extends RenderAligningShiftedBox {
         paint = new Paint()
           ..style = PaintingStyle.stroke
           ..strokeWidth = 1.0
-          ..color = debugPaintBoxArrowColor;
+          ..color = const Color(0xFFFFFF00);
         path = new Path();
         final BoxParentData childParentData = child.parentData;
         if (childParentData.offset.dy > 0.0) {
@@ -358,7 +358,7 @@ class RenderPositionedBox extends RenderAligningShiftedBox {
         }
       } else {
         paint = new Paint()
-          ..color = debugPaintSpacingColor;
+          ..color = const Color(0x90909090);
         context.canvas.drawRect(offset & size, paint);
       }
       return true;

--- a/packages/flutter/lib/src/rendering/sliver.dart
+++ b/packages/flutter/lib/src/rendering/sliver.dart
@@ -1246,7 +1246,7 @@ abstract class RenderSliver extends RenderObject {
       if (debugPaintSizeEnabled) {
         final double strokeWidth = math.min(4.0, geometry.paintExtent / 30.0);
         final Paint paint = new Paint()
-          ..color = debugPaintSliverArrowColor
+          ..color = const Color(0xFF33CC33)
           ..strokeWidth = strokeWidth
           ..style = PaintingStyle.stroke
           ..maskFilter = new MaskFilter.blur(BlurStyle.solid, strokeWidth);

--- a/packages/flutter/lib/src/rendering/view.dart
+++ b/packages/flutter/lib/src/rendering/view.dart
@@ -193,7 +193,7 @@ class RenderView extends RenderObject with RenderObjectWithChildMixin<RenderBox>
       scene.dispose();
       assert(() {
         if (debugRepaintRainbowEnabled || debugRepaintTextRainbowEnabled)
-          debugCurrentRepaintColor = debugCurrentRepaintColor.withHue(debugCurrentRepaintColor.hue + debugRepaintRainbowHueIncrement);
+          debugCurrentRepaintColor = debugCurrentRepaintColor.withHue(debugCurrentRepaintColor.hue + 2.0);
         return true;
       });
     } finally {

--- a/packages/flutter/lib/src/widgets/widget_inspector.dart
+++ b/packages/flutter/lib/src/widgets/widget_inspector.dart
@@ -198,7 +198,6 @@ class _WidgetInspectorState extends State<WidgetInspector>
       if (selection != null) {
         // Notify debuggers to open an inspector on the object.
         developer.inspect(selection.current);
-        print(selection.current.toStringDeep());
       }
     }
     setState(() {

--- a/packages/flutter/test/rendering/debug_test.dart
+++ b/packages/flutter/test/rendering/debug_test.dart
@@ -65,13 +65,13 @@ void main() {
   test('debugPaintPadding', () {
     expect((Canvas canvas) {
       debugPaintPadding(canvas, new Rect.fromLTRB(10.0, 10.0, 20.0, 20.0), null);
-    }, paints..rect(color: debugPaintSpacingColor));
+    }, paints..rect(color: const Color(0x90909090)));
     expect((Canvas canvas) {
       debugPaintPadding(canvas, new Rect.fromLTRB(10.0, 10.0, 20.0, 20.0), new Rect.fromLTRB(11.0, 11.0, 19.0, 19.0));
-    }, paints..path(color: debugPaintPaddingColor)..path(color: debugPaintPaddingInnerEdgeColor));
+    }, paints..path(color: const Color(0x900090FF))..path(color: const Color(0xFF0090FF)));
     expect((Canvas canvas) {
       debugPaintPadding(canvas, new Rect.fromLTRB(10.0, 10.0, 20.0, 20.0), new Rect.fromLTRB(15.0, 15.0, 15.0, 15.0));
-    }, paints..rect(rect: new Rect.fromLTRB(10.0, 10.0, 20.0, 20.0), color: debugPaintSpacingColor));
+    }, paints..rect(rect: new Rect.fromLTRB(10.0, 10.0, 20.0, 20.0), color: const Color(0x90909090)));
   });
 
   test('debugPaintPadding from render objects', () {
@@ -92,10 +92,10 @@ void main() {
       ],
     );
     layout(root);
-    expect(b.debugPaint, paints..rect(color: debugPaintSizeColor)..rect(color: debugPaintSpacingColor));
+    expect(b.debugPaint, paints..rect(color: const Color(0xFF00FFFF))..rect(color: const Color(0x90909090)));
     expect(b.debugPaint, isNot(paints..path()));
     expect(s.debugPaint, paints..circle(hasMaskFilter: true)..line(hasMaskFilter: true)..path(hasMaskFilter: true)..path(hasMaskFilter: true)
-                               ..path(color: debugPaintPaddingColor)..path(color: debugPaintPaddingInnerEdgeColor));
+                               ..path(color: const Color(0x900090FF))..path(color: const Color(0xFF0090FF)));
     expect(s.debugPaint, isNot(paints..rect()));
     debugPaintSizeEnabled = false;
   });
@@ -115,11 +115,11 @@ void main() {
       ),
     );
     layout(b);
-    expect(s.debugPaint, paints..rect(color: debugPaintSpacingColor));
+    expect(s.debugPaint, paints..rect(color: const Color(0x90909090)));
     expect(s.debugPaint, isNot(paints..circle(hasMaskFilter: true)..line(hasMaskFilter: true)..path(hasMaskFilter: true)..path(hasMaskFilter: true)
-                                     ..path(color: debugPaintPaddingColor)..path(color: debugPaintPaddingInnerEdgeColor)));
-    expect(b.debugPaint, paints..rect(color: debugPaintSizeColor)..path(color: debugPaintPaddingColor)..path(color: debugPaintPaddingInnerEdgeColor));
-    expect(b.debugPaint, isNot(paints..rect(color: debugPaintSpacingColor)));
+                                     ..path(color: const Color(0x900090FF))..path(color: const Color(0xFF0090FF))));
+    expect(b.debugPaint, paints..rect(color: const Color(0xFF00FFFF))..path(color: const Color(0x900090FF))..path(color: const Color(0xFF0090FF)));
+    expect(b.debugPaint, isNot(paints..rect(color: const Color(0x90909090))));
     debugPaintSizeEnabled = false;
   });
 }


### PR DESCRIPTION
These properties had a high cost in the documentation because they're
all top-level properties, and there's really very little reason for
these values to be configurable in the first place.