### PR TITLE
Update manual_tests to run on Android again

### DIFF
--- a/dev/manual_tests/android/app/build.gradle
+++ b/dev/manual_tests/android/app/build.gradle
@@ -24,9 +24,11 @@ android {
 
     defaultConfig {
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
-
-        // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "io.flutter.examples.manual_tests"
+        minSdkVersion 16
+        targetSdkVersion 25
+        versionCode 1
+        versionName "1.0"
     }
 
     buildTypes {


### PR DESCRIPTION
I've no idea why but without these changes the card_collection demo renders at 1x instead of 3.5x on my device.

cc @jason-simmons 