### PR TITLE
Bundle assets used in packages

### DIFF
--- a/packages/flutter/lib/src/services/image_provider.dart
+++ b/packages/flutter/lib/src/services/image_provider.dart
@@ -600,7 +600,7 @@ class ExactAssetImage extends AssetBundleImageProvider {
   /// The [assetName] and [scale] arguments must not be null. The [scale] arguments
   /// defaults to 1.0. The [bundle] argument may be null, in which case the
   /// bundle provided in the [ImageConfiguration] passed to the [resolve] call
-  /// will be used instead. The [package] argument should only be non-null when
+  /// will be used instead. The [package] argument should be non-null when
   /// used in a package implementation. It is used to prefix the name in order
   /// to disambiguate assets in an app.
   const ExactAssetImage(this.assetName, {

--- a/packages/flutter/lib/src/services/image_provider.dart
+++ b/packages/flutter/lib/src/services/image_provider.dart
@@ -597,19 +597,24 @@ class MemoryImage extends ImageProvider<MemoryImage> {
 class ExactAssetImage extends AssetBundleImageProvider {
   /// Creates an object that fetches the given image from an asset bundle.
   ///
-  /// The [name] and [scale] arguments must not be null. The [scale] arguments
+  /// The [assetName] and [scale] arguments must not be null. The [scale] arguments
   /// defaults to 1.0. The [bundle] argument may be null, in which case the
   /// bundle provided in the [ImageConfiguration] passed to the [resolve] call
-  /// will be used instead.
-  const ExactAssetImage(this.name, {
+  /// will be used instead. The [package] argument should only be non-null when
+  /// used in a package implementation. It is used to prefix the name in order
+  /// to disambiguate assets in an app.
+  const ExactAssetImage(this.assetName, {
     this.scale: 1.0,
-    this.bundle
-  }) : assert(name != null),
+    this.bundle,
+    this.package
+  }) : assert(assetName != null),
        assert(scale != null);
+
+  final String assetName;
 
   /// The key to use to obtain the resource from the [bundle]. This is the
   /// argument passed to [AssetBundle.load].
-  final String name;
+  String get name => package == null? assetName : 'packages/$package/$assetName';
 
   /// The scale to place in the [ImageInfo] object of the image.
   final double scale;
@@ -623,6 +628,11 @@ class ExactAssetImage extends AssetBundleImageProvider {
   /// The image is obtained by calling [AssetBundle.load] on the given [bundle]
   /// using the key given by [name].
   final AssetBundle bundle;
+
+  /// The name of the package from which the image is included.
+  ///
+  /// This must be null when the image is included by the current app.
+  final String package;
 
   @override
   Future<AssetBundleImageKey> obtainKey(ImageConfiguration configuration) {

--- a/packages/flutter/lib/src/services/image_provider.dart
+++ b/packages/flutter/lib/src/services/image_provider.dart
@@ -688,7 +688,7 @@ class ExactAssetImage extends AssetBundleImageProvider {
   /// that is also null, the [rootBundle] is used.
   ///
   /// The image is obtained by calling [AssetBundle.load] on the given [bundle]
-  /// using the key given by [name].
+  /// using the key given by [keyName].
   final AssetBundle bundle;
 
   /// The name of the package from which the image is included. See the

--- a/packages/flutter/lib/src/services/image_provider.dart
+++ b/packages/flutter/lib/src/services/image_provider.dart
@@ -595,18 +595,17 @@ class MemoryImage extends ImageProvider<MemoryImage> {
 /// uses the configuration to pick an appropriate image based on the device
 /// pixel ratio and size, see [AssetImage].
 ///
-///  ## Fetching assets
+/// ## Fetching assets
 ///
 /// When fetching an image provided by the app itself, use the [assetName]
-/// argument to name the asset to choose. For instance, consider the structure
-/// above. First, the [pubspec.yaml] of the project should specify its assets in
-/// the `flutter` section:
+/// argument to name the asset to choose. For instance, consider a directory
+/// `icons` with an image `heart.png`. First, the [pubspec.yaml] of the project
+/// should specify its assets in the `flutter` section:
 ///
 /// ```yaml
 /// flutter:
 ///   assets:
 ///     - icons/heart.png
-///
 /// ```
 ///
 /// Then, to fetch the image and associate it with scale `1.5`, use
@@ -632,7 +631,7 @@ class MemoryImage extends ImageProvider<MemoryImage> {
 /// is bundled automatically with the app. In particular, assets used by the
 /// package itself must be specified in its [pubspec.yaml].
 ///
-/// A package can also choose to have images in its 'lib/' folder that are not
+/// A package can also choose to have assets in its 'lib/' folder that are not
 /// specified in its [pubspec.yaml]. In this case for those images to be
 /// bundled, the app has to specify which ones to include. For instance a
 /// package named `fancy_backgrounds` could have:

--- a/packages/flutter/lib/src/services/image_provider.dart
+++ b/packages/flutter/lib/src/services/image_provider.dart
@@ -589,32 +589,95 @@ class MemoryImage extends ImageProvider<MemoryImage> {
 
 /// Fetches an image from an [AssetBundle], associating it with the given scale.
 ///
-/// This implementation requires an explicit final [name] and [scale] on
+/// This implementation requires an explicit final [assetName] and [scale] on
 /// construction, and ignores the device pixel ratio and size in the
 /// configuration passed into [resolve]. For a resolution-aware variant that
 /// uses the configuration to pick an appropriate image based on the device
 /// pixel ratio and size, see [AssetImage].
+///
+///  ## Fetching assets
+///
+/// When fetching an image provided by the app itself, use the [assetName]
+/// argument to name the asset to choose. For instance, consider the structure
+/// above. First, the [pubspec.yaml] of the project should specify its assets in
+/// the `flutter` section:
+///
+/// ```yaml
+/// flutter:
+///   assets:
+///     - icons/heart.png
+///
+/// ```
+///
+/// Then, to fetch the image and associate it with scale `1.5`, use
+///
+/// ```dart
+/// new AssetImage('icons/heart.png', scale: 1.5)
+/// ```
+///
+///## Assets in packages
+///
+/// To fetch an asset from a package, the [package] argument must be provided.
+/// For instance, suppose the structure above is inside a package called
+/// `my_icons`. Then to fetch the image, use:
+///
+/// ```dart
+/// new AssetImage('icons/heart.png', scale: 1.5, package: 'my_icons')
+/// ```
+///
+/// Assets used by the package itself should also be fetched using the [package]
+/// argument as above.
+///
+/// If the desired asset is specified in the [pubspec.yaml] of the package, it
+/// is bundled automatically with the app. In particular, assets used by the
+/// package itself must be specified in its [pubspec.yaml].
+///
+/// A package can also choose to have images in its 'lib/' folder that are not
+/// specified in its [pubspec.yaml]. In this case for those images to be
+/// bundled, the app has to specify which ones to include. For instance a
+/// package named `fancy_backgrounds` could have:
+///
+/// ```
+/// lib/backgrounds/background1.png
+/// lib/backgrounds/background2.png
+/// lib/backgrounds/background3.png
+///```
+///
+/// To include, say the first image, the [pubspec.yaml] of the app should specify
+/// it in the `assets` section:
+///
+/// ```yaml
+///  assets:
+///    - packages/fancy_backgrounds/backgrounds/background1.png
+/// ```
+///
+/// Note that the `lib/` is implied, so it should not be included in the asset
+/// path.
+///
 class ExactAssetImage extends AssetBundleImageProvider {
   /// Creates an object that fetches the given image from an asset bundle.
   ///
   /// The [assetName] and [scale] arguments must not be null. The [scale] arguments
   /// defaults to 1.0. The [bundle] argument may be null, in which case the
   /// bundle provided in the [ImageConfiguration] passed to the [resolve] call
-  /// will be used instead. The [package] argument should be non-null when
-  /// used in a package implementation. It is used to prefix the name in order
-  /// to disambiguate assets in an app.
+  /// will be used instead.
+  ///
+  /// The [package] argument must be non-null when fetching an asset that is
+  /// included in a package. See the documentation for the [ExactAssetImage] class
+  /// itself for details.
   const ExactAssetImage(this.assetName, {
     this.scale: 1.0,
     this.bundle,
-    this.package
+    this.package,
   }) : assert(assetName != null),
        assert(scale != null);
 
+  /// The name of the asset.
   final String assetName;
 
   /// The key to use to obtain the resource from the [bundle]. This is the
   /// argument passed to [AssetBundle.load].
-  String get name => package == null? assetName : 'packages/$package/$assetName';
+  String get keyName => package == null ? assetName : 'packages/$package/$assetName';
 
   /// The scale to place in the [ImageInfo] object of the image.
   final double scale;
@@ -629,16 +692,15 @@ class ExactAssetImage extends AssetBundleImageProvider {
   /// using the key given by [name].
   final AssetBundle bundle;
 
-  /// The name of the package from which the image is included.
-  ///
-  /// This must be null when the image is included by the current app.
+  /// The name of the package from which the image is included. See the
+  /// documentation for the [ExactAssetImage] class itself for details.
   final String package;
 
   @override
   Future<AssetBundleImageKey> obtainKey(ImageConfiguration configuration) {
     return new SynchronousFuture<AssetBundleImageKey>(new AssetBundleImageKey(
       bundle: bundle ?? configuration.bundle ?? rootBundle,
-      name: name,
+      name: keyName,
       scale: scale
     ));
   }
@@ -648,14 +710,14 @@ class ExactAssetImage extends AssetBundleImageProvider {
     if (other.runtimeType != runtimeType)
       return false;
     final ExactAssetImage typedOther = other;
-    return name == typedOther.name
+    return keyName == typedOther.keyName
         && scale == typedOther.scale
         && bundle == typedOther.bundle;
   }
 
   @override
-  int get hashCode => hashValues(name, scale, bundle);
+  int get hashCode => hashValues(keyName, scale, bundle);
 
   @override
-  String toString() => '$runtimeType(name: "$name", scale: $scale, bundle: $bundle)';
+  String toString() => '$runtimeType(name: "$keyName", scale: $scale, bundle: $bundle)';
 }

--- a/packages/flutter/lib/src/services/image_resolution.dart
+++ b/packages/flutter/lib/src/services/image_resolution.dart
@@ -58,13 +58,17 @@ const String _kAssetManifestFileName = 'AssetManifest.json';
 class AssetImage extends AssetBundleImageProvider {
   /// Creates an object that fetches an image from an asset bundle.
   ///
-  /// The [name] argument must not be null. It should name the main asset from
-  /// the set of images to chose from.
-  const AssetImage(this.name, { this.bundle }) : assert(name != null);
+  /// The [assetName] argument must not be null. It should name the main asset from
+  /// the set of images to chose from. The [package] argument should only be
+  /// non-null when used in a package implementation. It is used to prefix the
+  /// name in order to disambiguate assets in an app.
+  const AssetImage(this.assetName, { this.bundle, this.package }) : assert(assetName != null);
+
+  final String assetName;
 
   /// The name of the main asset from the set of images to chose from. See the
   /// documentation for the [AssetImage] class itself for details.
-  final String name;
+  String get name => package == null? assetName : 'packages/$package/$assetName';
 
   /// The bundle from which the image will be obtained.
   ///
@@ -75,6 +79,13 @@ class AssetImage extends AssetBundleImageProvider {
   /// The image is obtained by calling [AssetBundle.load] on the given [bundle]
   /// using the key given by [name].
   final AssetBundle bundle;
+
+  /// The name of the package from which the image is included.
+  ///
+  /// This must be null when the image is included by the current app.
+  final String package;
+
+
 
   // We assume the main asset is designed for a device pixel ratio of 1.0
   static const double _naturalResolution = 1.0;

--- a/packages/flutter/lib/src/services/image_resolution.dart
+++ b/packages/flutter/lib/src/services/image_resolution.dart
@@ -259,13 +259,13 @@ class AssetImage extends AssetBundleImageProvider {
     if (other.runtimeType != runtimeType)
       return false;
     final AssetImage typedOther = other;
-    return name == typedOther.name
+    return keyName == typedOther.keyName
         && bundle == typedOther.bundle;
   }
 
   @override
-  int get hashCode => hashValues(name, bundle);
+  int get hashCode => hashValues(keyName, bundle);
 
   @override
-  String toString() => '$runtimeType(bundle: $bundle, name: "$name")';
+  String toString() => '$runtimeType(bundle: $bundle, name: "$keyName")';
 }

--- a/packages/flutter/lib/src/services/image_resolution.dart
+++ b/packages/flutter/lib/src/services/image_resolution.dart
@@ -67,7 +67,6 @@ const String _kAssetManifestFileName = 'AssetManifest.json';
 /// flutter:
 ///   assets:
 ///     - icons/heart.png
-///
 /// ```
 ///
 /// Then, to fetch the image, use
@@ -92,7 +91,7 @@ const String _kAssetManifestFileName = 'AssetManifest.json';
 /// is bundled automatically with the app. In particular, assets used by the
 /// package itself must be specified in its [pubspec.yaml].
 ///
-/// A package can also choose to have images in its 'lib/' folder that are not
+/// A package can also choose to have assets in its 'lib/' folder that are not
 /// specified in its [pubspec.yaml]. In this case for those images to be
 /// bundled, the app has to specify which ones to include. For instance a
 /// package named `fancy_backgrounds` could have:
@@ -132,7 +131,7 @@ class AssetImage extends AssetBundleImageProvider {
 
   /// The name used to generate the key to obtain the asset. For local assets
   /// this is [assetName], and for assets from packages the [assetName] is
-  /// prefixed 'packages/<package_name>'.
+  /// prefixed 'packages/<package_name>/'.
   String get keyName => package == null ? assetName : 'packages/$package/$assetName';
 
   /// The bundle from which the image will be obtained.

--- a/packages/flutter/lib/src/widgets/image.dart
+++ b/packages/flutter/lib/src/widgets/image.dart
@@ -113,7 +113,8 @@ class Image extends StatefulWidget {
     this.alignment,
     this.repeat: ImageRepeat.noRepeat,
     this.centerSlice,
-    this.gaplessPlayback: false
+    this.gaplessPlayback: false,
+    this.package
   }) : assert(image != null),
        super(key: key);
 
@@ -131,7 +132,8 @@ class Image extends StatefulWidget {
     this.alignment,
     this.repeat: ImageRepeat.noRepeat,
     this.centerSlice,
-    this.gaplessPlayback: false
+    this.gaplessPlayback: false,
+    this.package
   }) : image = new NetworkImage(src, scale: scale),
        super(key: key);
 
@@ -152,7 +154,8 @@ class Image extends StatefulWidget {
     this.alignment,
     this.repeat: ImageRepeat.noRepeat,
     this.centerSlice,
-    this.gaplessPlayback: false
+    this.gaplessPlayback: false,
+    this.package
   }) : image = new FileImage(file, scale: scale),
        super(key: key);
 

--- a/packages/flutter/lib/src/widgets/image.dart
+++ b/packages/flutter/lib/src/widgets/image.dart
@@ -157,7 +157,9 @@ class Image extends StatefulWidget {
        super(key: key);
 
   /// Creates a widget that displays an [ImageStream] obtained from an asset
-  /// bundle. The key for the image is given by the `name` argument.
+  /// bundle. The key for the image is given by the `name` argument. If used in
+  /// a package implementation, the `package` argument must be non-null
+  /// otherwise it should be omitted.
   ///
   /// If the `bundle` argument is omitted or null, then the
   /// [DefaultAssetBundle] will be used.
@@ -230,10 +232,12 @@ class Image extends StatefulWidget {
     this.alignment,
     this.repeat: ImageRepeat.noRepeat,
     this.centerSlice,
-    this.gaplessPlayback: false
-  }) : image = scale != null ? new ExactAssetImage(name, bundle: bundle, scale: scale)
-                             : new AssetImage(name, bundle: bundle),
-       super(key: key);
+    this.gaplessPlayback: false,
+    this.package
+  }) : image = scale != null
+      ? new ExactAssetImage(name, bundle: bundle, scale: scale, package: package)
+      : new AssetImage(name, bundle: bundle, package: package),
+        super(key: key);
 
   /// Creates a widget that displays an [ImageStream] obtained from a [Uint8List].
   ///
@@ -309,6 +313,11 @@ class Image extends StatefulWidget {
   /// Whether to continue showing the old image (true), or briefly show nothing
   /// (false), when the image provider changes.
   final bool gaplessPlayback;
+
+  /// The name of the package from which the image is included.
+  ///
+  /// This must be null when the image is included by the current app.
+  final String package;
 
   @override
   _ImageState createState() => new _ImageState();

--- a/packages/flutter/lib/src/widgets/image.dart
+++ b/packages/flutter/lib/src/widgets/image.dart
@@ -114,7 +114,7 @@ class Image extends StatefulWidget {
     this.repeat: ImageRepeat.noRepeat,
     this.centerSlice,
     this.gaplessPlayback: false,
-    this.package
+    this.package,
   }) : assert(image != null),
        super(key: key);
 
@@ -133,7 +133,7 @@ class Image extends StatefulWidget {
     this.repeat: ImageRepeat.noRepeat,
     this.centerSlice,
     this.gaplessPlayback: false,
-    this.package
+    this.package,
   }) : image = new NetworkImage(src, scale: scale),
        super(key: key);
 
@@ -155,14 +155,16 @@ class Image extends StatefulWidget {
     this.repeat: ImageRepeat.noRepeat,
     this.centerSlice,
     this.gaplessPlayback: false,
-    this.package
+    this.package,
   }) : image = new FileImage(file, scale: scale),
        super(key: key);
 
   /// Creates a widget that displays an [ImageStream] obtained from an asset
-  /// bundle. The key for the image is given by the `name` argument. If used in
-  /// a package implementation, the `package` argument must be non-null
-  /// otherwise it should be omitted.
+  /// bundle. The key for the image is given by the `name` argument.
+  ///
+  /// The `package` argument must be non-null when displaying an image from a
+  /// package and null otherwise. See the `Assets in packages` section for
+  /// details.
   ///
   /// If the `bundle` argument is omitted or null, then the
   /// [DefaultAssetBundle] will be used.
@@ -215,6 +217,49 @@ class Image extends StatefulWidget {
   /// be present in the manifest). If it is omitted, then on a device with a 1.0
   /// device pixel ratio, the `images/2x/cat.png` image would be used instead.
   ///
+  ///
+  /// ## Assets in packages
+  ///
+  /// To create the widget with an asset from a package, the [package] argument
+  /// must be provided. For instance, suppose a package called `my_icons` has
+  /// `icons/heart.png` .
+  ///
+  /// Then to display the image, use:
+  ///
+  /// ```dart
+  /// new Image.asset('icons/heart.png', package: 'my_icons')
+  /// ```
+  ///
+  /// Assets used by the package itself should also be displayed using the
+  /// [package] argument as above.
+  ///
+  /// If the desired asset is specified in the [pubspec.yaml] of the package, it
+  /// is bundled automatically with the app. In particular, assets used by the
+  /// package itself must be specified in its [pubspec.yaml].
+  ///
+  /// A package can also choose to have images in its 'lib/' folder that are not
+  /// specified in its [pubspec.yaml]. In this case for those images to be
+  /// bundled, the app has to specify which ones to include. For instance a
+  /// package named `fancy_backgrounds` could have:
+  ///
+  /// ```
+  /// lib/backgrounds/background1.png
+  /// lib/backgrounds/background2.png
+  /// lib/backgrounds/background3.png
+  ///```
+  ///
+  /// To include, say the first image, the [pubspec.yaml] of the app should
+  /// specify it in the assets section:
+  ///
+  /// ```yaml
+  ///  assets:
+  ///    - packages/fancy_backgrounds/backgrounds/background1.png
+  /// ```
+  ///
+  /// Note that the `lib/` is implied, so it should not be included in the asset
+  /// path.
+  ///
+  ///
   /// See also:
   ///
   ///  * [AssetImage], which is used to implement the behavior when the scale is
@@ -236,7 +281,7 @@ class Image extends StatefulWidget {
     this.repeat: ImageRepeat.noRepeat,
     this.centerSlice,
     this.gaplessPlayback: false,
-    this.package
+    this.package,
   }) : image = scale != null
       ? new ExactAssetImage(name, bundle: bundle, scale: scale, package: package)
       : new AssetImage(name, bundle: bundle, package: package),
@@ -256,7 +301,8 @@ class Image extends StatefulWidget {
     this.alignment,
     this.repeat: ImageRepeat.noRepeat,
     this.centerSlice,
-    this.gaplessPlayback: false
+    this.gaplessPlayback: false,
+    this.package,
   }) : image = new MemoryImage(bytes, scale: scale),
        super(key: key);
 
@@ -317,9 +363,8 @@ class Image extends StatefulWidget {
   /// (false), when the image provider changes.
   final bool gaplessPlayback;
 
-  /// The name of the package from which the image is included.
-  ///
-  /// This must be null when the image is included by the current app.
+  /// The name of the package from which the image is included. See the
+  /// documentation for the [Image.asset] constructor for details.
   final String package;
 
   @override

--- a/packages/flutter/lib/src/widgets/image.dart
+++ b/packages/flutter/lib/src/widgets/image.dart
@@ -237,7 +237,7 @@ class Image extends StatefulWidget {
   /// is bundled automatically with the app. In particular, assets used by the
   /// package itself must be specified in its [pubspec.yaml].
   ///
-  /// A package can also choose to have images in its 'lib/' folder that are not
+  /// A package can also choose to have assets in its 'lib/' folder that are not
   /// specified in its [pubspec.yaml]. In this case for those images to be
   /// bundled, the app has to specify which ones to include. For instance a
   /// package named `fancy_backgrounds` could have:

--- a/packages/flutter/test/widgets/image_package_asset_test.dart
+++ b/packages/flutter/test/widgets/image_package_asset_test.dart
@@ -8,7 +8,7 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   test('AssetImage from package', () {
-    final AssetImage image = new AssetImage(
+    final AssetImage image = const AssetImage(
       'assets/image.png',
       package: 'test_package',
     );
@@ -16,7 +16,7 @@ void main() {
   });
 
   test('ExactAssetImage from package', () {
-    final ExactAssetImage image = new ExactAssetImage(
+    final ExactAssetImage image = const ExactAssetImage(
       'assets/image.png',
       scale: 1.5,
       package: 'test_package',

--- a/packages/flutter/test/widgets/image_package_asset_test.dart
+++ b/packages/flutter/test/widgets/image_package_asset_test.dart
@@ -1,0 +1,47 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('AssetImage from package', () {
+    final AssetImage image = new AssetImage(
+      'assets/image.png',
+      package: 'test_package',
+    );
+    expect(image.keyName, 'packages/test_package/assets/image.png');
+  });
+
+  test('ExactAssetImage from package', () {
+    final ExactAssetImage image = new ExactAssetImage(
+      'assets/image.png',
+      scale: 1.5,
+      package: 'test_package',
+    );
+    expect(image.keyName, 'packages/test_package/assets/image.png');
+  });
+
+  test('Image.asset from package', () {
+    final Image imageWidget = new Image.asset(
+      'assets/image.png',
+      package: 'test_package',
+    );
+    assert(imageWidget.image is AssetImage);
+    final AssetImage assetImage = imageWidget.image;
+    expect(assetImage.keyName, 'packages/test_package/assets/image.png');
+  });
+
+  test('Image.asset from package', () {
+    final Image imageWidget = new Image.asset(
+      'assets/image.png',
+      scale: 1.5,
+      package: 'test_package',
+    );
+    assert(imageWidget.image is ExactAssetImage);
+    final ExactAssetImage asssetImage = imageWidget.image;
+    expect(asssetImage.keyName, 'packages/test_package/assets/image.png');
+  });
+}

--- a/packages/flutter_tools/lib/src/asset.dart
+++ b/packages/flutter_tools/lib/src/asset.dart
@@ -361,8 +361,8 @@ DevFSContent _createAssetManifest(Map<_Asset, List<_Asset>> assetVariants) {
   for (_Asset main in assetVariants.keys) {
     final List<String> variants = <String>[];
     for (_Asset variant in assetVariants[main])
-      variants.add(variant.relativePath);
-    json[main.relativePath] = variants;
+      variants.add(variant.assetEntry);
+    json[main.assetEntry] = variants;
   }
   return new DevFSStringContent(JSON.encode(json));
 }

--- a/packages/flutter_tools/lib/src/asset.dart
+++ b/packages/flutter_tools/lib/src/asset.dart
@@ -239,17 +239,19 @@ class _Asset {
     if (other.runtimeType != runtimeType)
       return false;
     final _Asset otherAsset = other;
-    return base == otherAsset.base
-        && assetEntry == otherAsset.assetEntry
-        && relativePath == otherAsset.relativePath
-        && source == otherAsset.source;
+    return otherAsset.base == base
+        && otherAsset.assetEntry == assetEntry
+        && otherAsset.relativePath == relativePath
+        && otherAsset.source == source;
   }
 
   @override
-  int get hashCode => base.hashCode ^
-      assetEntry.hashCode ^
-      relativePath.hashCode ^
-      source.hashCode;
+  int get hashCode {
+    return base.hashCode
+        ^assetEntry.hashCode
+        ^relativePath.hashCode
+        ^ source.hashCode;
+  }
 }
 
 Map<String, dynamic> _readMaterialFontsManifest() {
@@ -491,9 +493,9 @@ _Asset _resolvePackageAsset(
     String asset,
 ) {
   return new _Asset(
-      base: assetBase,
-      assetEntry: 'packages/$packageName/$asset',
-      relativePath: asset,
+    base: assetBase,
+    assetEntry: 'packages/$packageName/$asset',
+    relativePath: asset,
   );
 }
 

--- a/packages/flutter_tools/lib/src/asset.dart
+++ b/packages/flutter_tools/lib/src/asset.dart
@@ -134,10 +134,10 @@ class AssetBundle {
           if (packageManifestDescriptor.containsKey('flutter')) {
             final String packageBasePath = fs.path.dirname(packageManifestPath);
             assetVariants.addAll(_parseAssets(
-                packageMap,
-                packageManifestDescriptor['flutter'],
-                packageBasePath,
-                packageKey: packageName,
+              packageMap,
+              packageManifestDescriptor['flutter'],
+              packageBasePath,
+              packageKey: packageName,
             ));
           }
         }
@@ -236,17 +236,17 @@ class _Asset {
   bool operator ==(dynamic other) {
     if (identical(other, this))
       return true;
-    if (other is! _Asset)
+    if (other.runtimeType != runtimeType)
       return false;
-    return base == other.base &&
-        assetEntry == other.assetEntry &&
-        relativePath == other.relativePath &&
-        source == other.source;
+    final _Asset otherAsset = other;
+    return base == otherAsset.base
+        && assetEntry == otherAsset.assetEntry
+        && relativePath == otherAsset.relativePath
+        && source == otherAsset.source;
   }
 
   @override
-  int get hashCode =>
-      base.hashCode ^
+  int get hashCode => base.hashCode ^
       assetEntry.hashCode ^
       relativePath.hashCode ^
       source.hashCode;
@@ -486,17 +486,21 @@ Map<_Asset, List<_Asset>> _parseAssets(
 }
 
 _Asset _resolvePackageAsset(
-    String assetBase, String packageName, String asset) {
+    String assetBase,
+    String packageName,
+    String asset,
+) {
   return new _Asset(
       base: assetBase,
       assetEntry: 'packages/$packageName/$asset',
-      relativePath: asset);
+      relativePath: asset,
+  );
 }
 
 _Asset _resolveAsset(
   PackageMap packageMap,
   String assetBase,
-  String asset
+  String asset,
 ) {
   if (asset.startsWith('packages/') && !fs.isFileSync(fs.path.join(assetBase, asset))) {
     // Convert packages/flutter_gallery_assets/clouds-0.png to clouds-0.png.

--- a/packages/flutter_tools/test/asset_bundle_package_test.dart
+++ b/packages/flutter_tools/test/asset_bundle_package_test.dart
@@ -114,7 +114,7 @@ $assetsSection
       writePubspecFile('pubspec.yaml', 'test');
       writePackagesFile('test_package:p/p/lib/');
 
-      final List<String> assets = ['a/foo'];
+      final List<String> assets = <String>['a/foo'];
       writePubspecFile(
         'p/p/pubspec.yaml',
         'test_package',

--- a/packages/flutter_tools/test/asset_bundle_package_test.dart
+++ b/packages/flutter_tools/test/asset_bundle_package_test.dart
@@ -1,0 +1,246 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:file/file.dart';
+import 'package:file/memory.dart';
+
+import 'package:flutter_tools/src/asset.dart';
+import 'package:flutter_tools/src/base/file_system.dart';
+import 'package:flutter_tools/src/cache.dart';
+
+import 'package:test/test.dart';
+
+import 'src/common.dart';
+import 'src/context.dart';
+
+void main() {
+  void writePubspecFile(String path, String name, {List<String> assets}) {
+    String assetsSection;
+    if (assets == null) {
+      assetsSection = '';
+    } else {
+      final StringBuffer buffer = new StringBuffer();
+      buffer.write(
+'''
+flutter:
+     assets:
+'''
+      );
+
+      for (String asset in assets) {
+        buffer.write(
+'''
+       - $asset
+''')
+        ;
+      }
+      assetsSection = buffer.toString();
+    }
+
+    fs.file(path)
+      ..createSync(recursive: true)
+      ..writeAsStringSync(
+'''
+name: $name
+dependencies:
+  flutter:
+    sdk: flutter
+$assetsSection
+'''
+      );
+  }
+
+  void writePackagesFile(String packages) {
+    fs.file(".packages")
+      ..createSync()
+      ..writeAsStringSync(packages);
+  }
+
+  Future<Null> buildAndVerifyAssets(
+    List<String> assets,
+    List<String> packages,
+    String expectedAssetManifest,
+  ) async {
+    final AssetBundle bundle = new AssetBundle();
+    await bundle.build(manifestPath: 'pubspec.yaml');
+
+    for (String packageName in packages) {
+      for (String asset in assets) {
+        final String entryKey = 'packages/$packageName/$asset';
+        expect(bundle.entries.containsKey(entryKey), true);
+        expect(
+          UTF8.decode(await bundle.entries[entryKey].contentsAsBytes()),
+          asset,
+        );
+      }
+    }
+
+    expect(
+      UTF8.decode(await bundle.entries['AssetManifest.json'].contentsAsBytes()),
+      expectedAssetManifest,
+    );
+  }
+
+  group('AssetBundle assets from package', () {
+    testUsingContext('One package with no assets', () async {
+      // Setting flutterRoot here so that it picks up the MemoryFileSystem's
+      // path separator.
+      Cache.flutterRoot = getFlutterRoot();
+
+      writePubspecFile('pubspec.yaml', 'test');
+      writePackagesFile('test_package:p/p/lib/');
+      writePubspecFile('p/p/pubspec.yaml', 'test_package');
+
+      final AssetBundle bundle = new AssetBundle();
+      await bundle.build(manifestPath: 'pubspec.yaml');
+      expect(bundle.entries.length, 2); // LICENSE, AssetManifest
+    }, overrides: <Type, Generator>{
+      FileSystem: () => new MemoryFileSystem(),
+    });
+
+    testUsingContext('One package with one asset', () async {
+      // Setting flutterRoot here so that it picks up the MemoryFileSystem's
+      // path separator.
+      Cache.flutterRoot = getFlutterRoot();
+
+      writePubspecFile('pubspec.yaml', 'test');
+      writePackagesFile('test_package:p/p/lib/');
+
+      final String asset = 'a/foo';
+      writePubspecFile(
+        'p/p/pubspec.yaml',
+        'test_package',
+        assets: <String>[asset],
+      );
+
+      fs.file('p/p/$asset')
+        ..createSync(recursive: true)
+        ..writeAsStringSync(asset);
+
+      final String expectedAssetManifest = '{"packages/test_package/a/foo":'
+          '["packages/test_package/a/foo"]}';
+      await buildAndVerifyAssets(
+        <String>[asset],
+        <String>['test_package'],
+        expectedAssetManifest,
+      );
+    }, overrides: <Type, Generator>{
+      FileSystem: () => new MemoryFileSystem(),
+    });
+
+    testUsingContext('One package with asset variants', () async {
+//      // Setting flutterRoot here so that it picks up the MemoryFileSystem's
+//      // path separator.
+      Cache.flutterRoot = getFlutterRoot();
+
+      writePubspecFile('pubspec.yaml', 'test');
+      writePackagesFile('test_package:p/p/lib/');
+      writePubspecFile(
+        'p/p/pubspec.yaml',
+        'test_package',
+        assets: <String>['a/foo'],
+      );
+
+      final List<String> assets = <String>['a/foo', 'a/v/foo'];
+
+      for (String asset in assets) {
+        fs.file('p/p/$asset')
+          ..createSync(recursive: true)
+          ..writeAsStringSync(asset);
+      }
+
+      final String expectedManifest = '{"packages/test_package/a/foo":'
+          '["packages/test_package/a/foo","packages/test_package/a/v/foo"]}';
+
+      await buildAndVerifyAssets(
+        assets,
+        <String>['test_package'],
+        expectedManifest,
+      );
+    }, overrides: <Type, Generator>{
+      FileSystem: () => new MemoryFileSystem(),
+    });
+
+    testUsingContext('One package with two assets', () async {
+      // Setting flutterRoot here so that it picks up the MemoryFileSystem's
+      // path separator.
+      Cache.flutterRoot = getFlutterRoot();
+
+      writePubspecFile('pubspec.yaml', 'test');
+      writePackagesFile('test_package:p/p/lib/');
+
+      final List<String> assets = <String>['a/foo', 'a/bar'];
+      writePubspecFile(
+        'p/p/pubspec.yaml',
+        'test_package',
+        assets: assets,
+      );
+
+      for (String asset in assets) {
+        fs.file('p/p/$asset')
+          ..createSync(recursive: true)
+          ..writeAsStringSync(asset);
+      }
+
+      final String expectedAssetManifest =
+          '{"packages/test_package/a/foo":["packages/test_package/a/foo"],'
+          '"packages/test_package/a/bar":["packages/test_package/a/bar"]}';
+
+      await buildAndVerifyAssets(
+        assets,
+        <String>['test_package'],
+        expectedAssetManifest,
+      );
+    }, overrides: <Type, Generator>{
+      FileSystem: () => new MemoryFileSystem(),
+    });
+
+    testUsingContext('Two packages with assets', () async {
+      // Setting flutterRoot here so that it picks up the MemoryFileSystem's
+      // path separator.
+      Cache.flutterRoot = getFlutterRoot();
+
+      writePubspecFile('pubspec.yaml', 'test');
+      writePackagesFile('test_package:p/p/lib/\ntest_package2:p2/p/lib/');
+      writePubspecFile('p/p/pubspec.yaml', 'test_package',
+          assets: <String>['a/foo']);
+      writePubspecFile(
+        'p2/p/pubspec.yaml',
+        'test_package2',
+        assets: <String>['a/foo'],
+      );
+
+      final List<String> assets = <String>['a/foo', 'a/v/foo'];
+
+      for (String asset in assets) {
+        fs.file('p/p/$asset')
+          ..createSync(recursive: true)
+          ..writeAsStringSync(asset);
+      }
+
+      for (String asset in assets) {
+        fs.file('p2/p/$asset')
+          ..createSync(recursive: true)
+          ..writeAsStringSync(asset);
+      }
+
+      final String expectedAssetManifest =
+          '{"packages/test_package/a/foo":'
+          '["packages/test_package/a/foo","packages/test_package/a/v/foo"],'
+          '"packages/test_package2/a/foo":'
+          '["packages/test_package2/a/foo","packages/test_package2/a/v/foo"]}';
+
+      await buildAndVerifyAssets(
+        assets,
+        <String>['test_package', 'test_package2'],
+        expectedAssetManifest,
+      );
+    }, overrides: <Type, Generator>{
+      FileSystem: () => new MemoryFileSystem(),
+    });
+  });
+}


### PR DESCRIPTION
This PR solves the problem of including package code that makes use of assets. 

1) With this change we add assets from packages to the asset bundle if they are listed in the `pubspec.yaml` of the package.

For instance if a package `my_package` contains a directory with an image: `assets/kitten.png` 

and its `pubspec.yaml` has
```
assets:
  -assets/kitten.png
```
then we add an entry called `packages/my_package/assets/kitten.png` .

2) The image implementation has been changed to take an optional `package` parameter. The idea is that package code should use this extra parameter to specify the name of the package so that it can be used when resolving the image.  

For instance the package code could be: 

```
new Image.asset('assets/kitten.jpg', package: 'my_package')
```

As an alternative to 2) we could require package developers to write 

`new Image.asset('packages/my_package/assets/kitten.jpg')`


I will work on some tests for this but would love some comments on the design.