### PR TITLE
Break long line in flutter create help output

### DIFF
--- a/packages/flutter_tools/lib/src/commands/create.dart
+++ b/packages/flutter_tools/lib/src/commands/create.dart
@@ -45,9 +45,8 @@ class CreateCommand extends FlutterCommand {
       allowedHelp: <String, String>{
         'app': '(default) Generate a Flutter application.',
         'package': 'Generate a shareable Flutter project containing modular Dart code.',
-        'plugin': 'Generate a shareable Flutter project containing an API in Dart '
-            'code with a platform-specific implementation for Android, for '
-            'iOS code, or for both.',
+        'plugin': 'Generate a shareable Flutter project containing an API in Dart code\n'
+            'with a platform-specific implementation for Android, for iOS code, or for both.',
       },
       defaultsTo: 'app',
     );


### PR DESCRIPTION
Current output overflows:

```
Usage: flutter create <output directory>
-t, --template=<type>          Specify the type of project to create.

          [app]                (default) Generate a Flutter application.
          [package]            Generate a shareable Flutter project containing modular Dart code.
          [plugin]             Generate a shareable Flutter project containing an API in Dart code with a platform-specific implementation for Android, for iOS code, or for both.

    --description              The description to use for your new Flutter project. This string ends up in the pubspec.yaml file.
```