### PR TITLE
Fix the continue-at flag in the curl command used to download the Dart SDK

### DIFF
--- a/bin/internal/update_dart_sdk.sh
+++ b/bin/internal/update_dart_sdk.sh
@@ -60,7 +60,7 @@ if [ ! -f "$DART_SDK_STAMP_PATH" ] || [ "$DART_SDK_VERSION" != `cat "$DART_SDK_S
   mkdir -p -- "$DART_SDK_PATH"
   DART_SDK_ZIP="$FLUTTER_ROOT/bin/cache/dart-sdk.zip"
 
-  curl -continue-at=- --location --output "$DART_SDK_ZIP" "$DART_SDK_URL" 2>&1
+  curl --continue-at - --location --output "$DART_SDK_ZIP" "$DART_SDK_URL" 2>&1
   unzip -o -q "$DART_SDK_ZIP" -d "$FLUTTER_ROOT/bin/cache" || {
     echo
     echo "It appears that the downloaded file is corrupt; please try the operation again later."


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/11722