### PR TITLE
Include main entrypoint in FLX snapshot checksum

### DIFF
--- a/packages/flutter_tools/lib/src/flx.dart
+++ b/packages/flutter_tools/lib/src/flx.dart
@@ -67,6 +67,7 @@ Future<int> _createSnapshot({
         final Checksum oldChecksum = new Checksum.fromJson(json);
         final Set<String> inputPaths = await _readDepfile(depfilePath);
         inputPaths.add(snapshotPath);
+        inputPaths.add(mainPath);
         final Checksum newChecksum = new Checksum.fromFiles(inputPaths);
         if (oldChecksum == newChecksum) {
           printTrace('Skipping snapshot build. Checksums match.');
@@ -87,6 +88,7 @@ Future<int> _createSnapshot({
   try {
     final Set<String> inputPaths = await _readDepfile(depfilePath);
     inputPaths.add(snapshotPath);
+    inputPaths.add(mainPath);
     final Checksum checksum = new Checksum.fromFiles(inputPaths);
     await checksumFile.writeAsString(checksum.toJson());
   } catch (e, s) {


### PR DESCRIPTION
During FLX snapshotting, changes to (or absence of) any of the following
should trigger re-snapshot:

  1. main() entrypoint source
  2. transitive closure of sources reachable from the entrypoint source
  3. the output snapshot