### PR TITLE
Shut off semantics at element level; fix DropdownButton

### DIFF
--- a/packages/flutter/lib/src/material/dropdown.dart
+++ b/packages/flutter/lib/src/material/dropdown.dart
@@ -500,7 +500,9 @@ class _DropdownButtonState<T> extends State<DropdownButton<T>> with WidgetsBindi
   // Defined by WidgetsBindingObserver
   @override
   void didChangeMetrics() {
-    _removeDropdownRoute();
+    setState(() {
+      _removeDropdownRoute();
+    });
   }
 
   void _removeDropdownRoute() {
@@ -532,18 +534,22 @@ class _DropdownButtonState<T> extends State<DropdownButton<T>> with WidgetsBindi
     final RenderBox itemBox = context.findRenderObject();
     final Rect itemRect = itemBox.localToGlobal(Offset.zero) & itemBox.size;
 
-    assert(_dropdownRoute == null);
-    _dropdownRoute = new _DropdownRoute<T>(
-      items: widget.items,
-      buttonRect: _kMenuHorizontalPadding.inflateRect(itemRect),
-      selectedIndex: _selectedIndex ?? 0,
-      elevation: widget.elevation,
-      theme: Theme.of(context, shadowThemeOnly: true),
-      style: _textStyle,
-    );
+    setState(() {
+      assert(_dropdownRoute == null);
+      _dropdownRoute = new _DropdownRoute<T>(
+        items: widget.items,
+        buttonRect: _kMenuHorizontalPadding.inflateRect(itemRect),
+        selectedIndex: _selectedIndex ?? 0,
+        elevation: widget.elevation,
+        theme: Theme.of(context, shadowThemeOnly: true),
+        style: _textStyle,
+      );
+    });
 
     Navigator.push(context, _dropdownRoute).then<Null>((_DropdownRouteResult<T> newValue) {
-      _dropdownRoute = null;
+      setState(() {
+        _dropdownRoute = null;
+      });
       if (!mounted || newValue == null)
         return null;
       if (widget.onChanged != null)
@@ -581,23 +587,26 @@ class _DropdownButtonState<T> extends State<DropdownButton<T>> with WidgetsBindi
       style: _textStyle,
       child: new SizedBox(
         height: widget.isDense ? _denseButtonHeight : null,
-        child: new Row(
-          mainAxisAlignment: MainAxisAlignment.spaceBetween,
-          mainAxisSize: MainAxisSize.min,
-          children: <Widget>[
-            // If value is null (then _selectedIndex is null) then we display
-            // the hint or nothing at all.
-            new IndexedStack(
-              index: _selectedIndex ?? hintIndex,
-              alignment: FractionalOffset.centerLeft,
-              children: items,
-            ),
-            new Icon(Icons.arrow_drop_down,
-              size: widget.iconSize,
-              // These colors are not defined in the Material Design spec.
-              color: Theme.of(context).brightness == Brightness.light ? Colors.grey.shade700 : Colors.white70
-            ),
-          ],
+        child: new ExcludeSemantics(
+          excluding: _dropdownRoute != null,
+          child: new Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            mainAxisSize: MainAxisSize.min,
+            children: <Widget>[
+              // If value is null (then _selectedIndex is null) then we display
+              // the hint or nothing at all.
+              new IndexedStack(
+                index: _selectedIndex ?? hintIndex,
+                alignment: FractionalOffset.centerLeft,
+                children: items,
+              ),
+              new Icon(Icons.arrow_drop_down,
+                  size: widget.iconSize,
+                  // These colors are not defined in the Material Design spec.
+                  color: Theme.of(context).brightness == Brightness.light ? Colors.grey.shade700 : Colors.white70
+              ),
+            ],
+          ),
         ),
       ),
     );

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -3964,6 +3964,9 @@ class ExcludeSemantics extends SingleChildRenderObjectWidget {
   final bool excluding;
 
   @override
+  SingleChildRenderObjectElement createElement() => new _ExcludeSemanticsElement(this);
+
+  @override
   RenderExcludeSemantics createRenderObject(BuildContext context) => new RenderExcludeSemantics(excluding: excluding);
 
   @override
@@ -3975,6 +3978,20 @@ class ExcludeSemantics extends SingleChildRenderObjectWidget {
   void debugFillProperties(DiagnosticPropertiesBuilder description) {
     super.debugFillProperties(description);
     description.add(new DiagnosticsProperty<bool>('excluding', excluding));
+  }
+}
+
+class _ExcludeSemanticsElement extends SingleChildRenderObjectElement {
+  _ExcludeSemanticsElement(ExcludeSemantics widget) : super(widget);
+
+  @override
+  ExcludeSemantics get widget => super.widget;
+
+  @override
+  void visitChildrenForSemantics(ElementVisitor visitor) {
+    if (widget.excluding)
+      return;
+    super.visitChildrenForSemantics(visitor);
   }
 }
 

--- a/packages/flutter/test/material/dropdown_test.dart
+++ b/packages/flutter/test/material/dropdown_test.dart
@@ -13,19 +13,19 @@ import '../widgets/semantics_tester.dart';
 const List<String> menuItems = const <String>['one', 'two', 'three', 'four'];
 
 final Type dropdownButtonType = new DropdownButton<String>(
-  onChanged: (_){ },
-  items: const <DropdownMenuItem<String>>[]
+    onChanged: (_){ },
+    items: const <DropdownMenuItem<String>>[]
 ).runtimeType;
 
 Widget buildFrame({
-    Key buttonKey,
-    String value: 'two',
-    ValueChanged<String> onChanged,
-    bool isDense: false,
-    Widget hint,
-    List<String> items: menuItems,
-    FractionalOffset alignment: FractionalOffset.center,
-  }) {
+  Key buttonKey,
+  String value: 'two',
+  ValueChanged<String> onChanged,
+  bool isDense: false,
+  Widget hint,
+  List<String> items: menuItems,
+  FractionalOffset alignment: FractionalOffset.center,
+}) {
   return new MaterialApp(
     home: new Material(
       child: new Align(
@@ -54,7 +54,7 @@ Widget buildFrame({
 // The RenderParagraphs should be aligned, i.e. they should have the same
 // size and location.
 void checkSelectedItemTextGeometry(WidgetTester tester, String value) {
-  final List<RenderBox> boxes = tester.renderObjectList(find.byKey(new ValueKey<String>(value + 'Text'))).toList();
+  final List<RenderBox> boxes = tester.renderObjectList(find.byKey(new ValueKey<String>(value + 'Text'), skipOffstage: false)).toList();
   expect(boxes.length, equals(2));
   final RenderBox box0 = boxes[0];
   final RenderBox box1 = boxes[1];
@@ -85,7 +85,7 @@ void main() {
 
     expect(value, equals('one'));
 
-    await tester.tap(find.text('three').last);
+    await tester.tap(find.text('three'));
 
     await tester.pump();
     await tester.pump(const Duration(seconds: 1)); // finish the menu animation
@@ -100,7 +100,7 @@ void main() {
 
     await tester.pumpWidget(build());
 
-    await tester.tap(find.text('two').last);
+    await tester.tap(find.text('two'));
 
     await tester.pump();
     await tester.pump(const Duration(seconds: 1)); // finish the menu animation
@@ -116,17 +116,17 @@ void main() {
 
     Widget build() {
       return new Navigator(
-        initialRoute: '/',
-        onGenerateRoute: (RouteSettings settings) {
-          return new MaterialPageRoute<Null>(
-            settings: settings,
-            builder: (BuildContext context) {
-              return new Material(
-                child: buildFrame(value: 'one', onChanged: didChangeValue),
-              );
-            },
-          );
-        }
+          initialRoute: '/',
+          onGenerateRoute: (RouteSettings settings) {
+            return new MaterialPageRoute<Null>(
+              settings: settings,
+              builder: (BuildContext context) {
+                return new Material(
+                  child: buildFrame(value: 'one', onChanged: didChangeValue),
+                );
+              },
+            );
+          }
       );
     }
 
@@ -138,7 +138,7 @@ void main() {
 
     expect(value, equals('one'));
 
-    await tester.tap(find.text('three').last);
+    await tester.tap(find.text('three'));
 
     await tester.pump();
     await tester.pump(const Duration(seconds: 1)); // finish the menu animation
@@ -153,7 +153,7 @@ void main() {
 
     await tester.pumpWidget(build());
 
-    await tester.tap(find.text('two').last);
+    await tester.tap(find.text('two'));
 
     await tester.pump();
     await tester.pump(const Duration(seconds: 1)); // finish the menu animation
@@ -194,11 +194,11 @@ void main() {
 
     // We should have two copies of item 5, one in the menu and one in the
     // button itself.
-    expect(tester.elementList(find.text('5')), hasLength(2));
+    expect(tester.elementList(find.text('5', skipOffstage: false)), hasLength(2));
 
     // We should only have one copy of item 19, which is in the button itself.
     // The copy in the menu shouldn't be in the tree because it's off-screen.
-    expect(tester.elementList(find.text('19')), hasLength(1));
+    expect(tester.elementList(find.text('19', skipOffstage: false)), hasLength(1));
 
     expect(value, 4);
     await tester.tap(find.byWidget(button));
@@ -234,7 +234,7 @@ void main() {
     // The selected dropdown item is both in menu we just popped up, and in
     // the IndexedStack contained by the dropdown button. Both of them should
     // have the same origin and height as the dropdown button.
-    final List<RenderObject> itemBoxes = tester.renderObjectList(find.byKey(const ValueKey<String>('two'))).toList();
+    final List<RenderObject> itemBoxes = tester.renderObjectList(find.byKey(const ValueKey<String>('two'), skipOffstage: false)).toList();
     expect(itemBoxes.length, equals(2));
     for(RenderBox itemBox in itemBoxes) {
       assert(itemBox.attached);
@@ -264,7 +264,7 @@ void main() {
     // The selected dropdown item is both in menu we just popped up, and in
     // the IndexedStack contained by the dropdown button. Both of them should
     // have the same vertical center as the button.
-    final List<RenderBox> itemBoxes = tester.renderObjectList(find.byKey(const ValueKey<String>('two'))).toList();
+    final List<RenderBox> itemBoxes = tester.renderObjectList(find.byKey(const ValueKey<String>('two'), skipOffstage: false)).toList();
     expect(itemBoxes.length, equals(2));
 
     // When isDense is true, the button's height is reduced. The menu items'
@@ -405,19 +405,19 @@ void main() {
     // so that it fits within the frame.
 
     await popUpAndDown(
-      buildFrame(alignment: FractionalOffset.topLeft, value: menuItems.last)
+        buildFrame(alignment: FractionalOffset.topLeft, value: menuItems.last)
     );
     expect(menuRect.topLeft, Offset.zero);
     expect(menuRect.topRight, new Offset(menuRect.width, 0.0));
 
     await popUpAndDown(
-      buildFrame(alignment: FractionalOffset.topCenter, value: menuItems.last)
+        buildFrame(alignment: FractionalOffset.topCenter, value: menuItems.last)
     );
     expect(menuRect.topLeft, new Offset(buttonRect.left, 0.0));
     expect(menuRect.topRight, new Offset(buttonRect.right, 0.0));
 
     await popUpAndDown(
-      buildFrame(alignment: FractionalOffset.topRight, value: menuItems.last)
+        buildFrame(alignment: FractionalOffset.topRight, value: menuItems.last)
     );
     expect(menuRect.topLeft, new Offset(800.0 - menuRect.width, 0.0));
     expect(menuRect.topRight, const Offset(800.0, 0.0));
@@ -427,19 +427,19 @@ void main() {
     // is selected) and shifted horizontally so that it fits within the frame.
 
     await popUpAndDown(
-      buildFrame(alignment: FractionalOffset.centerLeft, value: menuItems.first)
+        buildFrame(alignment: FractionalOffset.centerLeft, value: menuItems.first)
     );
     expect(menuRect.topLeft, new Offset(0.0, buttonRect.top));
     expect(menuRect.topRight, new Offset(menuRect.width, buttonRect.top));
 
     await popUpAndDown(
-      buildFrame(alignment: FractionalOffset.center, value: menuItems.first)
+        buildFrame(alignment: FractionalOffset.center, value: menuItems.first)
     );
     expect(menuRect.topLeft, buttonRect.topLeft);
     expect(menuRect.topRight, buttonRect.topRight);
 
     await popUpAndDown(
-      buildFrame(alignment: FractionalOffset.centerRight, value: menuItems.first)
+        buildFrame(alignment: FractionalOffset.centerRight, value: menuItems.first)
     );
     expect(menuRect.topLeft, new Offset(800.0 - menuRect.width, buttonRect.top));
     expect(menuRect.topRight, new Offset(800.0, buttonRect.top));
@@ -449,19 +449,19 @@ void main() {
     // so that it fits within the frame.
 
     await popUpAndDown(
-      buildFrame(alignment: FractionalOffset.bottomLeft, value: menuItems.first)
+        buildFrame(alignment: FractionalOffset.bottomLeft, value: menuItems.first)
     );
     expect(menuRect.bottomLeft, const Offset(0.0, 600.0));
     expect(menuRect.bottomRight, new Offset(menuRect.width, 600.0));
 
     await popUpAndDown(
-      buildFrame(alignment: FractionalOffset.bottomCenter, value: menuItems.first)
+        buildFrame(alignment: FractionalOffset.bottomCenter, value: menuItems.first)
     );
     expect(menuRect.bottomLeft, new Offset(buttonRect.left, 600.0));
     expect(menuRect.bottomRight, new Offset(buttonRect.right, 600.0));
 
     await popUpAndDown(
-      buildFrame(alignment: FractionalOffset.bottomRight, value: menuItems.first)
+        buildFrame(alignment: FractionalOffset.bottomRight, value: menuItems.first)
     );
     expect(menuRect.bottomLeft, new Offset(800.0 - menuRect.width, 600.0));
     expect(menuRect.bottomRight, const Offset(800.0, 600.0));
@@ -489,5 +489,29 @@ void main() {
     expect(semantics, isNot(includesNodeWith(label: menuItems[3])));
 
     semantics.dispose();
+  });
+
+  testWidgets('Semantics Tree contains only overlay element', (WidgetTester tester) async {
+    final SemanticsTester semantics = new SemanticsTester(tester);
+    final Finder onstageOne = find.byKey(const ValueKey<String>('oneText'));
+    final Finder allOnes = find.byKey(const ValueKey<String>('oneText'), skipOffstage: false);
+
+    await tester.pumpWidget(buildFrame(value: 'one', items: const <String>['one', 'two']));
+
+    expect(semantics, includesNodeWith(label: 'one', allowDuplicates: false));
+    expect(semantics, isNot(includesNodeWith(label: 'two', allowDuplicates: false)));
+    expect(tester.elementList(onstageOne), hasLength(1));
+    expect(tester.elementList(allOnes), hasLength(1));
+
+    // Expand dropdown
+    await tester.tap(find.text('one'));
+    await tester.pump();
+    await tester.pump(const Duration(seconds: 1)); // finish the menu animation
+
+    // Expect all options, and no duplicates
+    expect(semantics, includesNodeWith(label: 'one', allowDuplicates: false));
+    expect(semantics, includesNodeWith(label: 'two', allowDuplicates: false));
+    expect(tester.elementList(onstageOne), hasLength(1));
+    expect(tester.elementList(allOnes), hasLength(2));
   });
 }

--- a/packages/flutter/test/material/theme_test.dart
+++ b/packages/flutter/test/material/theme_test.dart
@@ -241,7 +241,8 @@ void main() {
       )
     );
 
-    RenderParagraph glyphText = tester.renderObject(find.byType(RichText));
+    final Finder richText = find.byType(RichText, skipOffstage: false);
+    RenderParagraph glyphText = tester.renderObject(richText);
 
     expect(glyphText.text.style.color, Colors.green);
     expect(glyphText.text.style.fontSize, 10.0);
@@ -254,13 +255,13 @@ void main() {
     );
     await tester.pump(const Duration(milliseconds: 100)); // Halfway through the theme transition
 
-    glyphText = tester.renderObject(find.byType(RichText));
+    glyphText = tester.renderObject(find.byType(RichText, skipOffstage: false));
 
     expect(glyphText.text.style.color, Color.lerp(Colors.green, Colors.orange, 0.5));
     expect(glyphText.text.style.fontSize, 15.0);
 
     await tester.pump(const Duration(milliseconds: 100)); // Finish the transition
-    glyphText = tester.renderObject(find.byType(RichText));
+    glyphText = tester.renderObject(richText);
 
     expect(glyphText.text.style.color, Colors.orange);
     expect(glyphText.text.style.fontSize, 20.0);

--- a/packages/flutter/test/widgets/animated_cross_fade_test.dart
+++ b/packages/flutter/test/widgets/animated_cross_fade_test.dart
@@ -7,6 +7,8 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 
+Finder get findFadeTransition => find.all.byType(FadeTransition);
+
 void main() {
   testWidgets('AnimatedCrossFade test', (WidgetTester tester) async {
     await tester.pumpWidget(
@@ -26,7 +28,7 @@ void main() {
       )
     );
 
-    expect(find.byType(FadeTransition), findsNWidgets(2));
+    expect(findFadeTransition, findsNWidgets(2));
     RenderBox box = tester.renderObject(find.byType(AnimatedCrossFade));
     expect(box.size.width, equals(100.0));
     expect(box.size.height, equals(100.0));
@@ -50,7 +52,7 @@ void main() {
 
     await tester.pump(const Duration(milliseconds: 100));
 
-    expect(find.byType(FadeTransition), findsNWidgets(2));
+    expect(findFadeTransition, findsNWidgets(2));
     box = tester.renderObject(find.byType(AnimatedCrossFade));
     expect(box.size.width, equals(150.0));
     expect(box.size.height, equals(150.0));
@@ -74,7 +76,7 @@ void main() {
       )
     );
 
-    expect(find.byType(FadeTransition), findsNWidgets(2));
+    expect(findFadeTransition, findsNWidgets(2));
     final RenderBox box = tester.renderObject(find.byType(AnimatedCrossFade));
     expect(box.size.width, equals(200.0));
     expect(box.size.height, equals(200.0));
@@ -126,8 +128,8 @@ void main() {
 
     await tester.pump(const Duration(milliseconds: 100));
 
-    final RenderBox box1 = tester.renderObject(find.byKey(firstKey));
-    final RenderBox box2 = tester.renderObject(find.byKey(secondKey));
+    final RenderBox box1 = tester.renderObject(find.byKey(firstKey, skipOffstage: false));
+    final RenderBox box2 = tester.renderObject(find.byKey(secondKey, skipOffstage: false));
     expect(box1.localToGlobal(Offset.zero), const Offset(275.0, 175.0));
     expect(box2.localToGlobal(Offset.zero), const Offset(275.0, 175.0));
   });
@@ -144,7 +146,7 @@ void main() {
   testWidgets('AnimatedCrossFade preserves widget state', (WidgetTester tester) async {
     await tester.pumpWidget(crossFadeWithWatcher());
 
-    _TickerWatchingWidgetState findState() => tester.state(find.byType(_TickerWatchingWidget));
+    _TickerWatchingWidgetState findState() => tester.state(find.byType(_TickerWatchingWidget, skipOffstage: false));
     final _TickerWatchingWidgetState state = findState();
 
     await tester.pumpWidget(crossFadeWithWatcher(towardsSecond: true));
@@ -191,8 +193,8 @@ void main() {
       crossFadeState: CrossFadeState.showFirst,
       duration: const Duration(milliseconds: 50),
     ));
-    expect(find.text('AAA'), findsOneWidget);
-    expect(find.text('BBB'), findsOneWidget);
+    expect(find.all.text('AAA'), findsOneWidget);
+    expect(find.all.text('BBB'), findsOneWidget);
     await tester.pumpWidget(new AnimatedCrossFade(
       firstChild: const Text('AAA'),
       secondChild: const Text('BBB'),

--- a/packages/flutter/test/widgets/icon_test.dart
+++ b/packages/flutter/test/widgets/icon_test.dart
@@ -16,7 +16,7 @@ void main() {
         child: const Icon(const IconData(0xd0a0, fontFamily: 'Arial'))
       )
     );
-    final RichText text = tester.widget(find.byType(RichText));
+    final RichText text = tester.widget(find.all.byType(RichText));
     expect(text.text.style.color, const Color(0xFF666666).withOpacity(0.5));
   });
 
@@ -98,7 +98,7 @@ void main() {
       ),
     );
 
-    final RichText richText = tester.firstWidget(find.byType(RichText));
+    final RichText richText = tester.firstWidget(find.all.byType(RichText));
     expect(richText.text.style.fontFamily, equals('Roboto'));
   });
 }

--- a/packages/flutter/test/widgets/semantics_tester.dart
+++ b/packages/flutter/test/widgets/semantics_tester.dart
@@ -36,10 +36,10 @@ class TestSemantics {
     this.transform,
     this.children: const <TestSemantics>[],
   }) : assert(id != null),
-       assert(flags != null),
-       assert(label != null),
-       assert(rect != null),
-       assert(children != null);
+        assert(flags != null),
+        assert(label != null),
+        assert(rect != null),
+        assert(children != null);
 
   /// Creates an object with some test semantics data, with the [id] and [rect]
   /// set to the appropriate values for the root node.
@@ -50,10 +50,10 @@ class TestSemantics {
     this.transform,
     this.children: const <TestSemantics>[],
   }) : id = 0,
-       assert(flags != null),
-       assert(label != null),
-       rect = TestSemantics.rootRect,
-       assert(children != null);
+        assert(flags != null),
+        assert(label != null),
+        rect = TestSemantics.rootRect,
+        assert(children != null);
 
   /// Creates an object with some test semantics data, with the [id] and [rect]
   /// set to the appropriate values for direct children of the root node.
@@ -73,9 +73,9 @@ class TestSemantics {
     Matrix4 transform,
     this.children: const <TestSemantics>[],
   }) : assert(flags != null),
-       assert(label != null),
-       transform = _applyRootChildScale(transform),
-       assert(children != null);
+        assert(label != null),
+        transform = _applyRootChildScale(transform),
+        assert(children != null);
 
   /// The unique identifier for this node.
   ///
@@ -244,17 +244,22 @@ class _IncludesNodeWith extends Matcher {
   const _IncludesNodeWith({
     this.label,
     this.actions,
-}) : assert(label != null || actions != null);
+    this.allowDuplicates: true,
+  }) : assert(label != null || actions != null),
+        assert(allowDuplicates != null);
 
   final String label;
   final List<SemanticsAction> actions;
+  final bool allowDuplicates;
 
   @override
   bool matches(covariant SemanticsTester item, Map<dynamic, dynamic> matchState) {
     bool result = false;
+    int count = 0;
     SemanticsNodeVisitor visitor;
     visitor = (SemanticsNode node) {
       if (checkNode(node)) {
+        count += 1;
         result = true;
       } else {
         node.visitChildren(visitor);
@@ -263,7 +268,7 @@ class _IncludesNodeWith extends Matcher {
     };
     final SemanticsNode root = item.tester.binding.pipelineOwner.semanticsOwner.rootSemanticsNode;
     visitor(root);
-    return result;
+    return result && (allowDuplicates || count <= 1);
   }
 
   bool checkNode(SemanticsNode node) {
@@ -280,12 +285,15 @@ class _IncludesNodeWith extends Matcher {
 
   @override
   Description describe(Description description) {
-    return description.add('includes node with $_configAsString');
+    final String expectedCount = allowDuplicates
+        ? 'at least one'
+        : 'exactly one';
+    return description.add('includes $expectedCount node with $_configAsString');
   }
 
   @override
   Description describeMismatch(dynamic item, Description mismatchDescription, Map<dynamic, dynamic> matchState, bool verbose) {
-    return mismatchDescription.add('could not find node with $_configAsString.\n$_matcherHelp');
+    return mismatchDescription.add('incorrect number of nodes with $_configAsString.\n$_matcherHelp');
   }
 
   String get _configAsString {
@@ -305,4 +313,4 @@ class _IncludesNodeWith extends Matcher {
 /// Asserts that a node in the semantics tree of [SemanticsTester] has [label] and [actions].
 ///
 /// If `null` is provided for either argument it will match against any value.
-Matcher includesNodeWith({ String label, List<SemanticsAction> actions }) => new _IncludesNodeWith(label: label, actions: actions);
+Matcher includesNodeWith({ String label, bool allowDuplicates: true, List<SemanticsAction> actions }) => new _IncludesNodeWith(label: label, allowDuplicates: allowDuplicates, actions: actions);

--- a/packages/flutter_test/lib/src/finders.dart
+++ b/packages/flutter_test/lib/src/finders.dart
@@ -20,7 +20,14 @@ final CommonFinders find = const CommonFinders._();
 ///
 /// This class is instantiated once, as [find].
 class CommonFinders {
-  const CommonFinders._();
+  const CommonFinders._({bool skipOffstage: true})
+      : assert(skipOffstage != null),
+        _skipOffstage = skipOffstage;
+
+  final bool _skipOffstage;
+
+  /// Finds all widgets, including the offstage ones.
+  CommonFinders get all => new CommonFinders._(skipOffstage: false);
 
   /// Finds [Text] widgets containing string equal to the `text`
   /// argument.
@@ -31,7 +38,7 @@ class CommonFinders {
   ///
   /// If the `skipOffstage` argument is true (the default), then this skips
   /// nodes that are [Offstage] or that are from inactive [Route]s.
-  Finder text(String text, { bool skipOffstage: true }) => new _TextFinder(text, skipOffstage: skipOffstage);
+  Finder text(String text, { bool skipOffstage }) => new _TextFinder(text, skipOffstage: skipOffstage ?? _skipOffstage);
 
   /// Finds [Icon] widgets containing icon data equal to the `icon`
   /// argument.
@@ -42,7 +49,7 @@ class CommonFinders {
   ///
   /// If the `skipOffstage` argument is true (the default), then this skips
   /// nodes that are [Offstage] or that are from inactive [Route]s.
-  Finder icon(IconData icon, { bool skipOffstage: true }) => new _IconFinder(icon, skipOffstage: skipOffstage);
+  Finder icon(IconData icon, { bool skipOffstage }) => new _IconFinder(icon, skipOffstage: skipOffstage ?? _skipOffstage);
 
   /// Looks for widgets that contain a [Text] descendant with `text`
   /// in it.
@@ -59,8 +66,8 @@ class CommonFinders {
   ///
   /// If the `skipOffstage` argument is true (the default), then this skips
   /// nodes that are [Offstage] or that are from inactive [Route]s.
-  Finder widgetWithText(Type widgetType, String text, { bool skipOffstage: true }) {
-    return new _WidgetWithTextFinder(widgetType, text, skipOffstage: skipOffstage);
+  Finder widgetWithText(Type widgetType, String text, { bool skipOffstage }) {
+    return new _WidgetWithTextFinder(widgetType, text, skipOffstage: skipOffstage ?? _skipOffstage);
   }
 
   /// Finds widgets by searching for one with a particular [Key].
@@ -71,7 +78,7 @@ class CommonFinders {
   ///
   /// If the `skipOffstage` argument is true (the default), then this skips
   /// nodes that are [Offstage] or that are from inactive [Route]s.
-  Finder byKey(Key key, { bool skipOffstage: true }) => new _KeyFinder(key, skipOffstage: skipOffstage);
+  Finder byKey(Key key, { bool skipOffstage }) => new _KeyFinder(key, skipOffstage: skipOffstage ?? _skipOffstage);
 
   /// Finds widgets by searching for widgets with a particular type.
   ///
@@ -87,7 +94,7 @@ class CommonFinders {
   ///
   /// If the `skipOffstage` argument is true (the default), then this skips
   /// nodes that are [Offstage] or that are from inactive [Route]s.
-  Finder byType(Type type, { bool skipOffstage: true }) => new _WidgetTypeFinder(type, skipOffstage: skipOffstage);
+  Finder byType(Type type, { bool skipOffstage }) => new _WidgetTypeFinder(type, skipOffstage: skipOffstage ?? _skipOffstage);
 
   /// Finds widgets by searching for widgets with a particular icon data.
   ///
@@ -97,7 +104,7 @@ class CommonFinders {
   ///
   /// If the `skipOffstage` argument is true (the default), then this skips
   /// nodes that are [Offstage] or that are from inactive [Route]s.
-  Finder byIcon(IconData icon, { bool skipOffstage: true }) => new _WidgetIconFinder(icon, skipOffstage: skipOffstage);
+  Finder byIcon(IconData icon, { bool skipOffstage }) => new _WidgetIconFinder(icon, skipOffstage: skipOffstage ?? _skipOffstage);
 
   /// Finds widgets by searching for elements with a particular type.
   ///
@@ -113,7 +120,7 @@ class CommonFinders {
   ///
   /// If the `skipOffstage` argument is true (the default), then this skips
   /// nodes that are [Offstage] or that are from inactive [Route]s.
-  Finder byElementType(Type type, { bool skipOffstage: true }) => new _ElementTypeFinder(type, skipOffstage: skipOffstage);
+  Finder byElementType(Type type, { bool skipOffstage }) => new _ElementTypeFinder(type, skipOffstage: skipOffstage ?? _skipOffstage);
 
   /// Finds widgets whose current widget is the instance given by the
   /// argument.
@@ -130,7 +137,7 @@ class CommonFinders {
   ///
   /// If the `skipOffstage` argument is true (the default), then this skips
   /// nodes that are [Offstage] or that are from inactive [Route]s.
-  Finder byWidget(Widget widget, { bool skipOffstage: true }) => new _WidgetFinder(widget, skipOffstage: skipOffstage);
+  Finder byWidget(Widget widget, { bool skipOffstage }) => new _WidgetFinder(widget, skipOffstage: skipOffstage ?? _skipOffstage);
 
   /// Finds widgets using a widget [predicate].
   ///
@@ -148,8 +155,8 @@ class CommonFinders {
   ///
   /// If the `skipOffstage` argument is true (the default), then this skips
   /// nodes that are [Offstage] or that are from inactive [Route]s.
-  Finder byWidgetPredicate(WidgetPredicate predicate, { String description, bool skipOffstage: true }) {
-    return new _WidgetPredicateFinder(predicate, description: description, skipOffstage: skipOffstage);
+  Finder byWidgetPredicate(WidgetPredicate predicate, { String description, bool skipOffstage }) {
+    return new _WidgetPredicateFinder(predicate, description: description, skipOffstage: skipOffstage ?? _skipOffstage);
   }
 
   /// Finds Tooltip widgets with the given message.
@@ -160,10 +167,10 @@ class CommonFinders {
   ///
   /// If the `skipOffstage` argument is true (the default), then this skips
   /// nodes that are [Offstage] or that are from inactive [Route]s.
-  Finder byTooltip(String message, { bool skipOffstage: true }) {
+  Finder byTooltip(String message, { bool skipOffstage }) {
     return byWidgetPredicate(
       (Widget widget) => widget is Tooltip && widget.message == message,
-      skipOffstage: skipOffstage,
+      skipOffstage: skipOffstage ?? _skipOffstage,
     );
   }
 
@@ -186,8 +193,8 @@ class CommonFinders {
   ///
   /// If the `skipOffstage` argument is true (the default), then this skips
   /// nodes that are [Offstage] or that are from inactive [Route]s.
-  Finder byElementPredicate(ElementPredicate predicate, { String description, bool skipOffstage: true }) {
-    return new _ElementPredicateFinder(predicate, description: description, skipOffstage: skipOffstage);
+  Finder byElementPredicate(ElementPredicate predicate, { String description, bool skipOffstage }) {
+    return new _ElementPredicateFinder(predicate, description: description, skipOffstage: skipOffstage ?? _skipOffstage);
   }
 
   /// Finds widgets that are descendants of the [of] parameter and that match
@@ -204,8 +211,8 @@ class CommonFinders {
   ///
   /// If the [skipOffstage] argument is true (the default), then nodes that are
   /// [Offstage] or that are from inactive [Route]s are skipped.
-  Finder descendant({ Finder of, Finder matching, bool matchRoot: false, bool skipOffstage: true }) {
-    return new _DescendantFinder(of, matching, matchRoot: matchRoot, skipOffstage: skipOffstage);
+  Finder descendant({ Finder of, Finder matching, bool matchRoot: false, bool skipOffstage }) {
+    return new _DescendantFinder(of, matching, matchRoot: matchRoot, skipOffstage: skipOffstage ?? _skipOffstage);
   }
 }
 
@@ -332,7 +339,7 @@ class _LastFinder extends Finder {
 abstract class MatchFinder extends Finder {
   /// Initialises a predicate-based Finder. Used by subclasses to initialize the
   /// [skipOffstage] property.
-  MatchFinder({ bool skipOffstage: true }) : super(skipOffstage: skipOffstage);
+  MatchFinder({ bool skipOffstage }) : super(skipOffstage: skipOffstage);
 
   /// Returns true if the given element matches the pattern.
   ///
@@ -346,7 +353,7 @@ abstract class MatchFinder extends Finder {
 }
 
 class _TextFinder extends MatchFinder {
-  _TextFinder(this.text, { bool skipOffstage: true }) : super(skipOffstage: skipOffstage);
+  _TextFinder(this.text, { bool skipOffstage }) : super(skipOffstage: skipOffstage);
 
   final String text;
 
@@ -363,7 +370,7 @@ class _TextFinder extends MatchFinder {
 }
 
 class _IconFinder extends MatchFinder {
-  _IconFinder(this.icon, { bool skipOffstage: true }) : super(skipOffstage: skipOffstage);
+  _IconFinder(this.icon, { bool skipOffstage }) : super(skipOffstage: skipOffstage);
 
   final IconData icon;
 
@@ -380,7 +387,7 @@ class _IconFinder extends MatchFinder {
 }
 
 class _WidgetWithTextFinder extends Finder {
-  _WidgetWithTextFinder(this.widgetType, this.text, { bool skipOffstage: true }) : super(skipOffstage: skipOffstage);
+  _WidgetWithTextFinder(this.widgetType, this.text, { bool skipOffstage }) : super(skipOffstage: skipOffstage);
 
   final Type widgetType;
   final String text;
@@ -414,7 +421,7 @@ class _WidgetWithTextFinder extends Finder {
 }
 
 class _KeyFinder extends MatchFinder {
-  _KeyFinder(this.key, { bool skipOffstage: true }) : super(skipOffstage: skipOffstage);
+  _KeyFinder(this.key, { bool skipOffstage }) : super(skipOffstage: skipOffstage);
 
   final Key key;
 
@@ -428,7 +435,7 @@ class _KeyFinder extends MatchFinder {
 }
 
 class _WidgetTypeFinder extends MatchFinder {
-  _WidgetTypeFinder(this.widgetType, { bool skipOffstage: true }) : super(skipOffstage: skipOffstage);
+  _WidgetTypeFinder(this.widgetType, { bool skipOffstage }) : super(skipOffstage: skipOffstage);
 
   final Type widgetType;
 
@@ -442,7 +449,7 @@ class _WidgetTypeFinder extends MatchFinder {
 }
 
 class _WidgetIconFinder extends MatchFinder {
-  _WidgetIconFinder(this.icon, { bool skipOffstage: true }) : super(skipOffstage: skipOffstage);
+  _WidgetIconFinder(this.icon, { bool skipOffstage }) : super(skipOffstage: skipOffstage);
 
   final IconData icon;
 
@@ -457,7 +464,7 @@ class _WidgetIconFinder extends MatchFinder {
 }
 
 class _ElementTypeFinder extends MatchFinder {
-  _ElementTypeFinder(this.elementType, { bool skipOffstage: true }) : super(skipOffstage: skipOffstage);
+  _ElementTypeFinder(this.elementType, { bool skipOffstage }) : super(skipOffstage: skipOffstage);
 
   final Type elementType;
 
@@ -471,7 +478,7 @@ class _ElementTypeFinder extends MatchFinder {
 }
 
 class _WidgetFinder extends MatchFinder {
-  _WidgetFinder(this.widget, { bool skipOffstage: true }) : super(skipOffstage: skipOffstage);
+  _WidgetFinder(this.widget, { bool skipOffstage }) : super(skipOffstage: skipOffstage);
 
   final Widget widget;
 
@@ -485,7 +492,7 @@ class _WidgetFinder extends MatchFinder {
 }
 
 class _WidgetPredicateFinder extends MatchFinder {
-  _WidgetPredicateFinder(this.predicate, { String description, bool skipOffstage: true })
+  _WidgetPredicateFinder(this.predicate, { String description, bool skipOffstage })
       : _description = description,
         super(skipOffstage: skipOffstage);
 
@@ -502,7 +509,7 @@ class _WidgetPredicateFinder extends MatchFinder {
 }
 
 class _ElementPredicateFinder extends MatchFinder {
-  _ElementPredicateFinder(this.predicate, { String description, bool skipOffstage: true })
+  _ElementPredicateFinder(this.predicate, { String description, bool skipOffstage })
       : _description = description,
         super(skipOffstage: skipOffstage);
 


### PR DESCRIPTION
DropdownButton testability fix, take 2: simply have ExcludeSemantics consider Element.visitChildrenForSemantics.

/cc @Hixie @goderbauer 