### PR TITLE
only tap on widgets reachable by hit testing

### DIFF
--- a/dev/devicelab/lib/tasks/integration_ui.dart
+++ b/dev/devicelab/lib/tasks/integration_ui.dart
@@ -27,7 +27,6 @@ Future<TaskResult> runEndToEndTests() async {
     ];
 
     for (final String entryPoint in entryPoints) {
-      await flutter('build', options: <String>['clean']);
       await flutter('drive', options: <String>['--verbose', '-d', deviceId, entryPoint]);
     }
   });

--- a/dev/devicelab/lib/tasks/integration_ui.dart
+++ b/dev/devicelab/lib/tasks/integration_ui.dart
@@ -21,7 +21,15 @@ Future<TaskResult> runEndToEndTests() async {
     if (deviceOperatingSystem == DeviceOperatingSystem.ios)
       await prepareProvisioningCertificates(testDirectory.path);
 
-    await flutter('drive', options: <String>['--verbose', '-d', deviceId, 'lib/keyboard_resize.dart']);
+    const List<String> entryPoints = const <String>[
+      'lib/keyboard_resize.dart',
+      'lib/driver.dart',
+    ];
+
+    for (final String entryPoint in entryPoints) {
+      await flutter('build', options: <String>['clean']);
+      await flutter('drive', options: <String>['--verbose', '-d', deviceId, entryPoint]);
+    }
   });
 
   return new TaskResult.success(<String, dynamic>{});

--- a/dev/integration_tests/ui/lib/driver.dart
+++ b/dev/integration_tests/ui/lib/driver.dart
@@ -23,6 +23,7 @@ class DriverTestApp extends StatefulWidget {
 
 class DriverTestAppState extends State<DriverTestApp> {
   bool present = true;
+  Letter _selectedValue = Letter.a;
 
   @override
   Widget build(BuildContext context) {
@@ -52,9 +53,41 @@ class DriverTestAppState extends State<DriverTestApp> {
                 ),
               ],
             ),
+            new Row(
+              children: <Widget>[
+                new Expanded(
+                  child: const Text('hit testability'),
+                ),
+                new DropdownButton<Letter>(
+                  key: const ValueKey<String>('dropdown'),
+                  value: _selectedValue,
+                  onChanged: (Letter newValue) {
+                    setState(() {
+                      _selectedValue = newValue;
+                    });
+                  },
+                  items: <DropdownMenuItem<Letter>>[
+                    new DropdownMenuItem<Letter>(
+                      value: Letter.a,
+                      child: const Text('Aaa', key: const ValueKey<String>('a')),
+                    ),
+                    new DropdownMenuItem<Letter>(
+                      value: Letter.b,
+                      child: const Text('Bbb', key: const ValueKey<String>('b')),
+                    ),
+                    new DropdownMenuItem<Letter>(
+                      value: Letter.c,
+                      child: const Text('Ccc', key: const ValueKey<String>('c')),
+                    ),
+                  ],
+                ),
+              ],
+            ),
           ],
         ),
       ),
     );
   }
 }
+
+enum Letter { a, b, c }

--- a/dev/integration_tests/ui/lib/driver.dart
+++ b/dev/integration_tests/ui/lib/driver.dart
@@ -55,7 +55,7 @@ class DriverTestAppState extends State<DriverTestApp> {
             ),
             new Row(
               children: <Widget>[
-                new Expanded(
+                const Expanded(
                   child: const Text('hit testability'),
                 ),
                 new DropdownButton<Letter>(
@@ -67,15 +67,15 @@ class DriverTestAppState extends State<DriverTestApp> {
                     });
                   },
                   items: <DropdownMenuItem<Letter>>[
-                    new DropdownMenuItem<Letter>(
+                    const DropdownMenuItem<Letter>(
                       value: Letter.a,
                       child: const Text('Aaa', key: const ValueKey<String>('a')),
                     ),
-                    new DropdownMenuItem<Letter>(
+                    const DropdownMenuItem<Letter>(
                       value: Letter.b,
                       child: const Text('Bbb', key: const ValueKey<String>('b')),
                     ),
-                    new DropdownMenuItem<Letter>(
+                    const DropdownMenuItem<Letter>(
                       value: Letter.c,
                       child: const Text('Ccc', key: const ValueKey<String>('c')),
                     ),

--- a/dev/integration_tests/ui/test_driver/driver_test.dart
+++ b/dev/integration_tests/ui/test_driver/driver_test.dart
@@ -77,5 +77,21 @@ void main() {
     test('waitForAbsent resolves immediately when the element does not exist', () async {
       await driver.waitForAbsent(find.text('that does not exist'));
     });
+
+    test('uses hit test to determine tappable elements', () async {
+      final SerializableFinder a = find.byValueKey('a');
+      final SerializableFinder menu = find.byType('_DropdownMenu<Letter>');
+
+      // Dropdown is closed
+      await driver.waitForAbsent(menu);
+
+      // Open dropdown
+      await driver.tap(a);
+      await driver.waitFor(menu);
+
+      // Close it again
+      await driver.tap(a);
+      await driver.waitForAbsent(menu);
+    });
   });
 }

--- a/packages/flutter_driver/lib/src/extension.dart
+++ b/packages/flutter_driver/lib/src/extension.dart
@@ -260,7 +260,7 @@ class FlutterDriverExtension {
     return constructor(finder);
   }
 
-  Future<TapResult> _tap(Tap command) async {
+  Future<TapResult> _tap(Command command) async {
     final Tap tapCommand = command;
     final Finder computedFinder = await _waitForElement(
       _createFinder(tapCommand.finder).hitTestable(at: const FractionalOffset(0.5, 0.5))

--- a/packages/flutter_driver/lib/src/extension.dart
+++ b/packages/flutter_driver/lib/src/extension.dart
@@ -260,9 +260,11 @@ class FlutterDriverExtension {
     return constructor(finder);
   }
 
-  Future<TapResult> _tap(Command command) async {
+  Future<TapResult> _tap(Tap command) async {
     final Tap tapCommand = command;
-    final Finder computedFinder = await _waitForElement(_createFinder(tapCommand.finder).hitTestable(_prober.getCenter));
+    final Finder computedFinder = await _waitForElement(
+      _createFinder(tapCommand.finder).hitTestable(at: const FractionalOffset(0.5, 0.5))
+    );
     await _prober.tap(computedFinder);
     return new TapResult();
   }

--- a/packages/flutter_driver/lib/src/extension.dart
+++ b/packages/flutter_driver/lib/src/extension.dart
@@ -262,7 +262,8 @@ class FlutterDriverExtension {
 
   Future<TapResult> _tap(Command command) async {
     final Tap tapCommand = command;
-    await _prober.tap(await _waitForElement(_createFinder(tapCommand.finder)));
+    final Finder computedFinder = await _waitForElement(_createFinder(tapCommand.finder).hitTestable(_prober.getCenter));
+    await _prober.tap(computedFinder);
     return new TapResult();
   }
 

--- a/packages/flutter_driver/lib/src/extension.dart
+++ b/packages/flutter_driver/lib/src/extension.dart
@@ -263,7 +263,7 @@ class FlutterDriverExtension {
   Future<TapResult> _tap(Command command) async {
     final Tap tapCommand = command;
     final Finder computedFinder = await _waitForElement(
-      _createFinder(tapCommand.finder).hitTestable(at: const FractionalOffset(0.5, 0.5))
+      _createFinder(tapCommand.finder).hitTestable()
     );
     await _prober.tap(computedFinder);
     return new TapResult();

--- a/packages/flutter_test/lib/src/finders.dart
+++ b/packages/flutter_test/lib/src/finders.dart
@@ -290,7 +290,7 @@ abstract class Finder {
   ///
   /// The [at] parameter specifies the location relative to the size of the
   /// target element where the hit test is performed.
-  Finder hitTestable({@required FractionalOffset at}) => new _HitTestableFinder(this, at);
+  Finder hitTestable({ FractionalOffset at: FractionalOffset.center }) => new _HitTestableFinder(this, at);
 
   @override
   String toString() {
@@ -355,6 +355,7 @@ class _HitTestableFinder extends Finder {
       for (final HitTestEntry entry in hitResult.path) {
         if (entry.target == candidate.renderObject) {
           yield candidate;
+          break;
         }
       }
     }

--- a/packages/flutter_test/test/finders_test.dart
+++ b/packages/flutter_test/test/finders_test.dart
@@ -16,13 +16,13 @@ void main() {
               key: const ValueKey<int>(0),
               behavior: HitTestBehavior.opaque,
               onTap: () {},
-              child: new SizedBox.expand(),
+              child: const SizedBox.expand(),
             ),
             new GestureDetector(
               key: const ValueKey<int>(1),
               behavior: HitTestBehavior.opaque,
-              onTap: () {},
-              child: new SizedBox.expand(),
+              onTap: () { },
+              child: const SizedBox.expand(),
             ),
           ],
         )
@@ -30,7 +30,7 @@ void main() {
       expect(find.byType(GestureDetector), findsNWidgets(2));
       final Finder hitTestable = find.byType(GestureDetector).hitTestable(at: const FractionalOffset(0.5, 0.5));
       expect(hitTestable, findsOneWidget);
-      expect(hitTestable.evaluate().single.widget.key, const ValueKey<int>(0));
+      expect(tester.widget(hitTestable).key, const ValueKey<int>(0));
     });
   });
 }

--- a/packages/flutter_test/test/finders_test.dart
+++ b/packages/flutter_test/test/finders_test.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -9,7 +10,7 @@ void main() {
   group('hitTestable', () {
     testWidgets('excludes non-hit-testable widgets', (WidgetTester tester) async {
       await tester.pumpWidget(
-        new IndexedStack(
+        _boilerplate(new IndexedStack(
           sizing: StackFit.expand,
           children: <Widget>[
             new GestureDetector(
@@ -25,7 +26,7 @@ void main() {
               child: const SizedBox.expand(),
             ),
           ],
-        )
+        )),
       );
       expect(find.byType(GestureDetector), findsNWidgets(2));
       final Finder hitTestable = find.byType(GestureDetector).hitTestable(at: const FractionalOffset(0.5, 0.5));
@@ -33,4 +34,11 @@ void main() {
       expect(tester.widget(hitTestable).key, const ValueKey<int>(0));
     });
   });
+}
+
+Widget _boilerplate(Widget child) {
+  return new Directionality(
+    textDirection: TextDirection.ltr,
+    child: child,
+  );
 }

--- a/packages/flutter_test/test/finders_test.dart
+++ b/packages/flutter_test/test/finders_test.dart
@@ -1,0 +1,36 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('hitTestable', () {
+    testWidgets('excludes non-hit-testable widgets', (WidgetTester tester) async {
+      await tester.pumpWidget(
+          new IndexedStack(
+            sizing: StackFit.expand,
+            children: <Widget>[
+              new GestureDetector(
+                behavior: HitTestBehavior.opaque,
+                onTap: () {},
+                child: new SizedBox.expand(
+                  key: const ValueKey<String>('top'),
+                ),
+              ),
+              new GestureDetector(
+                behavior: HitTestBehavior.opaque,
+                onTap: () {},
+                child: new SizedBox.expand(
+                  key: const ValueKey<String>('top'),
+                ),
+              ),
+            ],
+          )
+      );
+      expect(find.byType(GestureDetector), findsNWidgets(2));
+      expect(find.byType(GestureDetector).hitTestable(at: const FractionalOffset(0.5, 0.5)), findsOneWidget);
+    });
+  });
+}

--- a/packages/flutter_test/test/finders_test.dart
+++ b/packages/flutter_test/test/finders_test.dart
@@ -9,23 +9,23 @@ void main() {
   group('hitTestable', () {
     testWidgets('excludes non-hit-testable widgets', (WidgetTester tester) async {
       await tester.pumpWidget(
-          new IndexedStack(
-            sizing: StackFit.expand,
-            children: <Widget>[
-              new GestureDetector(
-                key: const ValueKey<int>(0),
-                behavior: HitTestBehavior.opaque,
-                onTap: () {},
-                child: new SizedBox.expand(),
-              ),
-              new GestureDetector(
-                key: const ValueKey<int>(1),
-                behavior: HitTestBehavior.opaque,
-                onTap: () {},
-                child: new SizedBox.expand(),
-              ),
-            ],
-          )
+        new IndexedStack(
+          sizing: StackFit.expand,
+          children: <Widget>[
+            new GestureDetector(
+              key: const ValueKey<int>(0),
+              behavior: HitTestBehavior.opaque,
+              onTap: () {},
+              child: new SizedBox.expand(),
+            ),
+            new GestureDetector(
+              key: const ValueKey<int>(1),
+              behavior: HitTestBehavior.opaque,
+              onTap: () {},
+              child: new SizedBox.expand(),
+            ),
+          ],
+        )
       );
       expect(find.byType(GestureDetector), findsNWidgets(2));
       final Finder hitTestable = find.byType(GestureDetector).hitTestable(at: const FractionalOffset(0.5, 0.5));

--- a/packages/flutter_test/test/finders_test.dart
+++ b/packages/flutter_test/test/finders_test.dart
@@ -15,7 +15,7 @@ void main() {
             new GestureDetector(
               key: const ValueKey<int>(0),
               behavior: HitTestBehavior.opaque,
-              onTap: () {},
+              onTap: () { },
               child: const SizedBox.expand(),
             ),
             new GestureDetector(

--- a/packages/flutter_test/test/finders_test.dart
+++ b/packages/flutter_test/test/finders_test.dart
@@ -13,24 +13,24 @@ void main() {
             sizing: StackFit.expand,
             children: <Widget>[
               new GestureDetector(
+                key: const ValueKey<int>(0),
                 behavior: HitTestBehavior.opaque,
                 onTap: () {},
-                child: new SizedBox.expand(
-                  key: const ValueKey<String>('top'),
-                ),
+                child: new SizedBox.expand(),
               ),
               new GestureDetector(
+                key: const ValueKey<int>(1),
                 behavior: HitTestBehavior.opaque,
                 onTap: () {},
-                child: new SizedBox.expand(
-                  key: const ValueKey<String>('top'),
-                ),
+                child: new SizedBox.expand(),
               ),
             ],
           )
       );
       expect(find.byType(GestureDetector), findsNWidgets(2));
-      expect(find.byType(GestureDetector).hitTestable(at: const FractionalOffset(0.5, 0.5)), findsOneWidget);
+      final Finder hitTestable = find.byType(GestureDetector).hitTestable(at: const FractionalOffset(0.5, 0.5));
+      expect(hitTestable, findsOneWidget);
+      expect(hitTestable.evaluate().single.widget.key, const ValueKey<int>(0));
     });
   });
 }


### PR DESCRIPTION
DropdownButton testability fix, take 3: exclude widgets that are not reachable via a hit test.

/cc @Hixie @goderbauer 