### PR TITLE
Recognize fast flicks' velocity

### DIFF
--- a/packages/flutter/lib/src/gestures/monodrag.dart
+++ b/packages/flutter/lib/src/gestures/monodrag.dart
@@ -127,11 +127,14 @@ abstract class DragGestureRecognizer extends OneSequenceGestureRecognizer {
   @override
   void handleEvent(PointerEvent event) {
     assert(_state != _DragState.ready);
-    if (event is PointerMoveEvent) {
+    if (!event.synthesized
+        && (event is PointerDownEvent || event is PointerMoveEvent)) {
       final VelocityTracker tracker = _velocityTrackers[event.pointer];
       assert(tracker != null);
-      if (!event.synthesized)
-        tracker.addPosition(event.timeStamp, event.position);
+      tracker.addPosition(event.timeStamp, event.position);
+    }
+
+    if (event is PointerMoveEvent) {
       final Offset delta = event.delta;
       if (_state == _DragState.accepted) {
         if (onUpdate != null) {

--- a/packages/flutter/test/gestures/drag_test.dart
+++ b/packages/flutter/test/gestures/drag_test.dart
@@ -261,7 +261,32 @@ void main() {
       timeStamp: const Duration(milliseconds: 60),
       synthesized: true,
     ));
-    tester.route(pointer.up(timeStamp: const Duration(milliseconds: 20)));
+    tester.route(pointer.up(timeStamp: const Duration(milliseconds: 70)));
+    expect(velocity.pixelsPerSecond.dx, moreOrLessEquals(1000.0));
+    expect(velocity.pixelsPerSecond.dy, moreOrLessEquals(0.0));
+
+    drag.dispose();
+  });
+
+  /// Checks that quick flick gestures with 1 down, 2 move and 1 up pointer
+  /// events still have a velocity
+  testGesture('Quick flicks have velocity', (GestureTester tester) {
+    final HorizontalDragGestureRecognizer drag = new HorizontalDragGestureRecognizer();
+
+    Velocity velocity;
+    drag.onEnd = (DragEndDetails details) {
+      velocity = details.velocity;
+    };
+
+    final TestPointer pointer = new TestPointer(1);
+    final PointerDownEvent down = pointer.down(const Offset(10.0, 25.0), timeStamp: const Duration(milliseconds: 10));
+    drag.addPointer(down);
+    tester.closeArena(1);
+    tester.route(down);
+    tester.route(pointer.move(const Offset(20.0, 25.0), timeStamp: const Duration(milliseconds: 20)));
+    tester.route(pointer.move(const Offset(30.0, 25.0), timeStamp: const Duration(milliseconds: 30)));
+    tester.route(pointer.up(timeStamp: const Duration(milliseconds: 40)));
+    // 3 events moving by 10px every 10ms = 1000px/s.
     expect(velocity.pixelsPerSecond.dx, moreOrLessEquals(1000.0));
     expect(velocity.pixelsPerSecond.dy, moreOrLessEquals(0.0));
 


### PR DESCRIPTION
Fixes #11592 

On both Android and iOS, the pointer down event provides valid spacial and time information vs the first pointer move event. Include its usage in the velocity calculation which will make very quick down+move+move+up gestures recognizable.  