### PR TITLE
Semantic hit test order for Slivers

### DIFF
--- a/examples/stocks/lib/stock_home.dart
+++ b/examples/stocks/lib/stock_home.dart
@@ -3,7 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:flutter/material.dart';
-import 'package:flutter/rendering.dart' show debugDumpRenderTree, debugDumpLayerTree, debugDumpSemanticsTree;
+import 'package:flutter/rendering.dart' show debugDumpRenderTree, debugDumpLayerTree, debugDumpSemanticsTree, DebugSemanticsDumpOrder;
 import 'package:flutter/scheduler.dart' show timeDilation;
 import 'stock_data.dart';
 import 'stock_list.dart';
@@ -130,7 +130,7 @@ class StockHomeState extends State<StockHome> {
                 debugDumpApp();
                 debugDumpRenderTree();
                 debugDumpLayerTree();
-                debugDumpSemanticsTree();
+                debugDumpSemanticsTree(DebugSemanticsDumpOrder.traversal);
               } catch (e, stack) {
                 debugPrint('Exception while dumping app:\n$e\n$stack');
               }

--- a/packages/flutter/lib/src/rendering/binding.dart
+++ b/packages/flutter/lib/src/rendering/binding.dart
@@ -99,8 +99,13 @@ abstract class RendererBinding extends BindingBase with SchedulerBinding, Servic
     );
 
     registerSignalServiceExtension(
-      name: 'debugDumpSemanticsTree',
-      callback: () { debugDumpSemanticsTree(); return debugPrintDone; }
+      name: 'debugDumpSemanticsTreeInTraversalOrder',
+      callback: () { debugDumpSemanticsTree(DebugSemanticsDumpOrder.traversal); return debugPrintDone; }
+    );
+
+    registerSignalServiceExtension(
+        name: 'debugDumpSemanticsTreeInInverseHitTestOrder',
+        callback: () { debugDumpSemanticsTree(DebugSemanticsDumpOrder.inverseHitTest); return debugPrintDone; }
     );
   }
 
@@ -324,8 +329,8 @@ void debugDumpLayerTree() {
 /// By default, children of a [SemanticsNode] are printed in traversal order.
 /// This can be changed to inverse hit test order by setting
 /// [childrenInInverseHitTestOrder] to `true`.
-void debugDumpSemanticsTree({ bool childrenInInverseHitTestOrder: false }) {
-  debugPrint(RendererBinding.instance?.renderView?.debugSemantics?.toStringDeep(childrenInInverseHitTestOrder: childrenInInverseHitTestOrder) ?? 'Semantics not collected.');
+void debugDumpSemanticsTree(DebugSemanticsDumpOrder childOrder) {
+  debugPrint(RendererBinding.instance?.renderView?.debugSemantics?.toStringDeep(childOrder) ?? 'Semantics not collected.');
 }
 
 /// A concrete binding for applications that use the Rendering framework

--- a/packages/flutter/lib/src/rendering/binding.dart
+++ b/packages/flutter/lib/src/rendering/binding.dart
@@ -326,9 +326,8 @@ void debugDumpLayerTree() {
 /// This will only work if there is a semantics client attached.
 /// Otherwise, a notice that no semantics are available will be printed.
 ///
-/// By default, children of a [SemanticsNode] are printed in traversal order.
-/// This can be changed to inverse hit test order by setting
-/// [childrenInInverseHitTestOrder] to `true`.
+/// The order in which the children of a [SemanticsNode] will be printed can be
+/// controlled with the [childOrder] parameter.
 void debugDumpSemanticsTree(DebugSemanticsDumpOrder childOrder) {
   debugPrint(RendererBinding.instance?.renderView?.debugSemantics?.toStringDeep(childOrder) ?? 'Semantics not collected.');
 }

--- a/packages/flutter/lib/src/rendering/binding.dart
+++ b/packages/flutter/lib/src/rendering/binding.dart
@@ -326,8 +326,8 @@ void debugDumpLayerTree() {
 /// This will only work if there is a semantics client attached.
 /// Otherwise, a notice that no semantics are available will be printed.
 ///
-/// The order in which the children of a [SemanticsNode] will be printed can be
-/// controlled with the [childOrder] parameter.
+/// The order in which the children of a [SemanticsNode] will be printed is
+/// controlled by the [childOrder] parameter.
 void debugDumpSemanticsTree(DebugSemanticsDumpOrder childOrder) {
   debugPrint(RendererBinding.instance?.renderView?.debugSemantics?.toStringDeep(childOrder) ?? 'Semantics not collected.');
 }

--- a/packages/flutter/lib/src/rendering/binding.dart
+++ b/packages/flutter/lib/src/rendering/binding.dart
@@ -319,9 +319,13 @@ void debugDumpLayerTree() {
 
 /// Prints a textual representation of the entire semantics tree.
 /// This will only work if there is a semantics client attached.
-/// Otherwise, the tree is empty and this will print "null".
-void debugDumpSemanticsTree() {
-  debugPrint(RendererBinding.instance?.renderView?.debugSemantics?.toStringDeep() ?? 'Semantics not collected.');
+/// Otherwise, a notice that no semantics are available will be printed.
+///
+/// By default, children of a [SemanticsNode] are printed in traversal order.
+/// This can be changed to inverse hit test order by setting
+/// [childrenInInverseHitTestOrder] to `true`.
+void debugDumpSemanticsTree({ bool childrenInInverseHitTestOrder: false }) {
+  debugPrint(RendererBinding.instance?.renderView?.debugSemantics?.toStringDeep(childrenInInverseHitTestOrder: childrenInInverseHitTestOrder) ?? 'Semantics not collected.');
 }
 
 /// A concrete binding for applications that use the Rendering framework

--- a/packages/flutter/lib/src/rendering/debug.dart
+++ b/packages/flutter/lib/src/rendering/debug.dart
@@ -11,6 +11,16 @@ export 'package:flutter/foundation.dart' show debugPrint;
 // Any changes to this file should be reflected in the debugAssertAllRenderVarsUnset()
 // function below.
 
+/// Used by [debugDumpSemanticsTree] to specify the order in which child nodes
+/// are printed.
+enum DebugSemanticsDumpOrder {
+  /// Print nodes in inverse hit test order.
+  inverseHitTest,
+
+  /// Print nodes in traversal order.
+  traversal,
+}
+
 const HSVColor _kDebugDefaultRepaintColor = const HSVColor.fromAHSV(0.4, 60.0, 1.0, 1.0);
 
 /// Causes each RenderBox to paint a box around its bounds, and some extra

--- a/packages/flutter/lib/src/rendering/debug.dart
+++ b/packages/flutter/lib/src/rendering/debug.dart
@@ -15,9 +15,16 @@ export 'package:flutter/foundation.dart' show debugPrint;
 /// are printed.
 enum DebugSemanticsDumpOrder {
   /// Print nodes in inverse hit test order.
+  ///
+  /// In inverse hit test order, the last child of a [SemanticsNode] will be
+  /// asked first if it wants to respond to a user's interaction, followed by
+  /// the second last, etc. until a taker is found.
   inverseHitTest,
 
   /// Print nodes in traversal order.
+  ///
+  /// Traversal order defines how the user can move the accessibility focus from
+  /// one node to another.
   traversal,
 }
 

--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -2981,7 +2981,7 @@ class RenderSemanticsGestureHandler extends RenderProxyBox implements SemanticsA
       super.assembleSemanticsNode(node, children);
       return;
     }
-    
+
     _innerNode ??= new SemanticsNode(handler: this, showOnScreen: showOnScreen);
     _innerNode
       ..wasAffectedByClip = node.wasAffectedByClip
@@ -2989,7 +2989,7 @@ class RenderSemanticsGestureHandler extends RenderProxyBox implements SemanticsA
 
     semanticsAnnotator(_innerNode);
 
-    final List<SemanticsNode> excluded = <SemanticsNode>[];
+    final List<SemanticsNode> excluded = <SemanticsNode>[_innerNode];
     final List<SemanticsNode> included = <SemanticsNode>[];
     for (SemanticsNode child in children) {
       if (child.hasTag(excludeFromScrolling))
@@ -2997,7 +2997,6 @@ class RenderSemanticsGestureHandler extends RenderProxyBox implements SemanticsA
       else
         included.add(child);
     }
-    excluded.add(_innerNode);
     node.addChildren(excluded);
     _innerNode.addChildren(included);
     _innerNode.finalizeChildren();

--- a/packages/flutter/lib/src/rendering/semantics.dart
+++ b/packages/flutter/lib/src/rendering/semantics.dart
@@ -419,7 +419,7 @@ class SemanticsNode extends AbstractNode {
     });
   }
 
-  /// Contains the children in  inverse hit test order (i.e. paint order).
+  /// Contains the children in inverse hit test order (i.e. paint order).
   List<SemanticsNode> _children;
 
   /// Whether this node has a non-zero number of children.

--- a/packages/flutter/lib/src/rendering/semantics.dart
+++ b/packages/flutter/lib/src/rendering/semantics.dart
@@ -391,13 +391,13 @@ class SemanticsNode extends AbstractNode {
 
   /// Append the given children as children of this node.
   ///
-  /// Children must be added in paint order (i.e. inverse hit test order).
+  /// Children must be added in inverse hit test order (i.e. paint order).
   ///
   /// The [finalizeChildren] method must be called after all children have been
   /// added.
-  void addChildren(Iterable<SemanticsNode> childrenInPaintOrder) {
+  void addChildren(Iterable<SemanticsNode> childrenInInverseHitTestOrder) {
     _newChildren ??= <SemanticsNode>[];
-    _newChildren.addAll(childrenInPaintOrder);
+    _newChildren.addAll(childrenInInverseHitTestOrder);
     // we do the asserts afterwards because children is an Iterable
     // and doing the asserts before would mean the behavior is
     // different in checked mode vs release mode (if you walk an
@@ -419,6 +419,7 @@ class SemanticsNode extends AbstractNode {
     });
   }
 
+  /// Contains the children in  inverse hit test order (i.e. paint order).
   List<SemanticsNode> _children;
 
   /// Whether this node has a non-zero number of children.
@@ -484,6 +485,17 @@ class SemanticsNode extends AbstractNode {
           assert(!child.attached);
           adoptChild(child);
           sawChange = true;
+        }
+      }
+    }
+    if (!sawChange && _children != null) {
+      assert(_newChildren != null);
+      assert(_newChildren.length == _children.length);
+      // Did the order change?
+      for (int i = 0; i < _children.length; i++) {
+        if (_children[i].id != _newChildren[i].id) {
+          sawChange = true;
+          break;
         }
       }
     }

--- a/packages/flutter/lib/src/rendering/semantics.dart
+++ b/packages/flutter/lib/src/rendering/semantics.dart
@@ -701,9 +701,8 @@ class SemanticsNode extends AbstractNode {
 
   /// Returns a string representation of this node and its descendants.
   ///
-  /// By default, children are printed in traversal order. This can be changed
-  /// to inverse hit test order by setting [childrenInInverseHitTestOrder] to
-  /// `true`.
+  /// The order in which the children of the [SemanticsNode] will be printed can
+  /// be controlled with the [childOrder] parameter.
   String toStringDeep(DebugSemanticsDumpOrder childOrder, [
     String prefixLineOne = '',
     String prefixOtherLines = ''

--- a/packages/flutter/lib/src/rendering/semantics.dart
+++ b/packages/flutter/lib/src/rendering/semantics.dart
@@ -701,8 +701,8 @@ class SemanticsNode extends AbstractNode {
 
   /// Returns a string representation of this node and its descendants.
   ///
-  /// The order in which the children of the [SemanticsNode] will be printed can
-  /// be controlled with the [childOrder] parameter.
+  /// The order in which the children of the [SemanticsNode] will be printed is
+  /// controlled by the [childOrder] parameter.
   String toStringDeep(DebugSemanticsDumpOrder childOrder, [
     String prefixLineOne = '',
     String prefixOtherLines = ''
@@ -727,7 +727,7 @@ class SemanticsNode extends AbstractNode {
     assert(childOrder != null);
     switch(childOrder) {
       case DebugSemanticsDumpOrder.traversal:
-        return new List<SemanticsNode>.from(_children)..sort(_nodeComparator);
+        return new List<SemanticsNode>.from(_children)..sort(_geometryComparator);
       case DebugSemanticsDumpOrder.inverseHitTest:
         return _children;
     }
@@ -735,7 +735,7 @@ class SemanticsNode extends AbstractNode {
     return null;
   }
 
-  static int _nodeComparator(SemanticsNode a, SemanticsNode b) {
+  static int _geometryComparator(SemanticsNode a, SemanticsNode b) {
     final Rect rectA = MatrixUtils.transformRect(a.transform, a.rect);
     final Rect rectB = MatrixUtils.transformRect(b.transform, b.rect);
     final int top = rectA.top.compareTo(rectB.top);

--- a/packages/flutter/lib/src/rendering/viewport.dart
+++ b/packages/flutter/lib/src/rendering/viewport.dart
@@ -94,6 +94,14 @@ abstract class RenderViewportBase<ParentDataClass extends ContainerParentDataMix
     node.addTag(RenderSemanticsGestureHandler.useTwoPaneSemantics);
   }
 
+  @override
+  void visitChildrenForSemantics(RenderObjectVisitor visitor) {
+    for (RenderSliver sliver in childrenInPaintOrder) {
+      if (sliver.geometry.paintExtent != 0)
+        visitor(sliver);
+    }
+  }
+
   /// The direction in which the [SliverConstraints.scrollOffset] increases.
   ///
   /// For example, if the [axisDirection] is [AxisDirection.down], a scroll

--- a/packages/flutter/test/foundation/service_extensions_test.dart
+++ b/packages/flutter/test/foundation/service_extensions_test.dart
@@ -178,11 +178,21 @@ void main() {
     console.clear();
   });
 
-  test('Service extensions - debugDumpSemanticsTree', () async {
+  test('Service extensions - debugDumpSemanticsTreeInTraversalOrder', () async {
     Map<String, String> result;
 
     await binding.doFrame();
-    result = await binding.testExtension('debugDumpSemanticsTree', <String, String>{});
+    result = await binding.testExtension('debugDumpSemanticsTreeInTraversalOrder', <String, String>{});
+    expect(result, <String, String>{});
+    expect(console, <String>['Semantics not collected.']);
+    console.clear();
+  });
+
+  test('Service extensions - debugDumpSemanticsTreeInInverseHitTestOrder', () async {
+    Map<String, String> result;
+
+    await binding.doFrame();
+    result = await binding.testExtension('debugDumpSemanticsTreeInInverseHitTestOrder', <String, String>{});
     expect(result, <String, String>{});
     expect(console, <String>['Semantics not collected.']);
     console.clear();
@@ -482,7 +492,7 @@ void main() {
   test('Service extensions - posttest', () async {
     // If you add a service extension... TEST IT! :-)
     // ...then increment this number.
-    expect(binding.extensions.length, 16);
+    expect(binding.extensions.length, 17);
 
     expect(console, isEmpty);
     debugPrint = debugPrintThrottled;

--- a/packages/flutter/test/rendering/semantics_test.dart
+++ b/packages/flutter/test/rendering/semantics_test.dart
@@ -90,8 +90,6 @@ void main() {
 
       expectedActions = SemanticsAction.tap.index | SemanticsAction.longPress.index | SemanticsAction.scrollDown.index | SemanticsAction.scrollRight.index;
       expect(root.debugSemantics.getSemanticsData().actions, expectedActions);
-
-      debugDumpSemanticsTree();
     });
   });
 }

--- a/packages/flutter/test/widgets/semantics_tester.dart
+++ b/packages/flutter/test/widgets/semantics_tester.dart
@@ -199,7 +199,7 @@ class SemanticsTester {
   String toString() => 'SemanticsTester';
 }
 
-const String _matcherHelp = 'Try dumping the semantics with debugDumpSemanticsTree(childrenInInverseHitTestOrder: true) from the package:flutter/rendering.dart library to see what the semantics tree looks like.';
+const String _matcherHelp = 'Try dumping the semantics with debugDumpSemanticsTree(DebugSemanticsDumpOrder.inverseHitTest) from the package:flutter/rendering.dart library to see what the semantics tree looks like.';
 
 class _HasSemantics extends Matcher {
   const _HasSemantics(this._semantics, { this.ignoreRect: false, this.ignoreTransform: false }) : assert(_semantics != null), assert(ignoreRect != null), assert(ignoreTransform != null);

--- a/packages/flutter/test/widgets/semantics_tester.dart
+++ b/packages/flutter/test/widgets/semantics_tester.dart
@@ -199,7 +199,7 @@ class SemanticsTester {
   String toString() => 'SemanticsTester';
 }
 
-const String _matcherHelp = 'Try dumping the semantics with debugDumpSemanticsTree() from the rendering library to see what the semantics tree looks like.';
+const String _matcherHelp = 'Try dumping the semantics with debugDumpSemanticsTree(childrenInInverseHitTestOrder: true) from the package:flutter/rendering.dart library to see what the semantics tree looks like.';
 
 class _HasSemantics extends Matcher {
   const _HasSemantics(this._semantics, { this.ignoreRect: false, this.ignoreTransform: false }) : assert(_semantics != null), assert(ignoreRect != null), assert(ignoreTransform != null);

--- a/packages/flutter/test/widgets/sliver_semantics_test.dart
+++ b/packages/flutter/test/widgets/sliver_semantics_test.dart
@@ -54,15 +54,15 @@ void main() {
                   children: <TestSemantics>[
                     new TestSemantics(
                       id: 2,
-                      label: 'Semantics Test with Slivers',
-                    ),
-                    new TestSemantics(
-                      id: 3,
                       label: 'Item 0',
                     ),
                     new TestSemantics(
-                      id: 4,
+                      id: 3,
                       label: 'Item 1',
+                    ),
+                    new TestSemantics(
+                      id: 4,
+                      label: 'Semantics Test with Slivers',
                     ),
                   ],
                 ),
@@ -87,27 +87,27 @@ void main() {
             tags: <SemanticsTag>[RenderSemanticsGestureHandler.useTwoPaneSemantics],
             children: <TestSemantics>[
               new TestSemantics(
-                id: 6,
-                label: 'Semantics Test with Slivers',
-                tags: <SemanticsTag>[RenderSemanticsGestureHandler.excludeFromScrolling],
-              ),
-              new TestSemantics(
                 id: 5,
                 actions: SemanticsAction.scrollUp.index | SemanticsAction.scrollDown.index,
                 children: <TestSemantics>[
                   new TestSemantics(
-                    id: 3,
+                    id: 2,
                     label: 'Item 0',
                   ),
                   new TestSemantics(
-                    id: 4,
+                    id: 3,
                     label: 'Item 1',
                   ),
                   new TestSemantics(
-                    id: 7,
+                    id: 6,
                     label: 'Item 2',
                   ),
                 ],
+              ),
+              new TestSemantics(
+                id: 7,
+                label: 'Semantics Test with Slivers',
+                tags: <SemanticsTag>[RenderSemanticsGestureHandler.excludeFromScrolling],
               ),
             ],
           )
@@ -134,20 +134,20 @@ void main() {
                 actions: SemanticsAction.scrollUp.index | SemanticsAction.scrollDown.index,
                 children: <TestSemantics>[
                   new TestSemantics(
-                    id: 8,
-                    label: 'Semantics Test with Slivers',
-                  ),
-                  new TestSemantics(
-                    id: 3,
+                    id: 2,
                     label: 'Item 0',
                   ),
                   new TestSemantics(
-                    id: 4,
+                    id: 3,
                     label: 'Item 1',
                   ),
                   new TestSemantics(
-                    id: 7,
+                    id: 6,
                     label: 'Item 2',
+                  ),
+                  new TestSemantics(
+                    id: 8,
+                    label: 'Semantics Test with Slivers',
                   ),
                 ],
               ),
@@ -158,5 +158,127 @@ void main() {
       ignoreRect: true,
       ignoreTransform: true,
     ));
+
+    semantics.dispose();
+  });
+
+  testWidgets('Offscreen sliver are not included in semantics tree', (WidgetTester tester) async {
+    final SemanticsTester semantics = new SemanticsTester(tester);
+
+    const double containerHeight = 200.0;
+
+    final ScrollController scrollController = new ScrollController(
+      initialScrollOffset: containerHeight * 1.5,
+    );
+    final List<Widget> slivers = new List<Widget>.generate(30, (int i) {
+      return new SliverToBoxAdapter(
+        child: new Container(
+          height: containerHeight,
+          child: new Text('Item $i'),
+        ),
+      );
+    });
+    await tester.pumpWidget(
+      new Center(
+        child: new SizedBox(
+          height: containerHeight,
+          child: new CustomScrollView(
+            controller: scrollController,
+            slivers: slivers,
+          ),
+        ),
+      ),
+    );
+
+    expect(semantics, hasSemantics(
+      new TestSemantics.root(
+        children: <TestSemantics>[
+          new TestSemantics.rootChild(
+            id: 9,
+            tags: <SemanticsTag>[RenderSemanticsGestureHandler.useTwoPaneSemantics],
+            children: <TestSemantics>[
+              new TestSemantics(
+                id: 12,
+                actions: SemanticsAction.scrollUp.index | SemanticsAction.scrollDown.index,
+                children: <TestSemantics>[
+                  new TestSemantics(
+                    id: 10,
+                    label: 'Item 2',
+                  ),
+                  new TestSemantics(
+                    id: 11,
+                    label: 'Item 1',
+                  ),
+                ],
+              ),
+            ],
+          )
+        ],
+      ),
+      ignoreRect: true,
+      ignoreTransform: true,
+    ));
+
+    semantics.dispose();
+  });
+
+  testWidgets('SemanticsNodes of Slivers are in paint order', (WidgetTester tester) async {
+    final SemanticsTester semantics = new SemanticsTester(tester);
+
+    final List<Widget> slivers = new List<Widget>.generate(5, (int i) {
+      return new SliverToBoxAdapter(
+        child: new Container(
+          height: 20.0,
+          child: new Text('Item $i'),
+        ),
+      );
+    });
+    await tester.pumpWidget(
+      new CustomScrollView(
+        slivers: slivers,
+      ),
+    );
+    
+    expect(semantics, hasSemantics(
+      new TestSemantics.root(
+        children: <TestSemantics>[
+          new TestSemantics.rootChild(
+            id: 13,
+            tags: <SemanticsTag>[RenderSemanticsGestureHandler.useTwoPaneSemantics],
+            children: <TestSemantics>[
+              new TestSemantics(
+                id: 19,
+                children: <TestSemantics>[
+                  new TestSemantics(
+                    id: 14,
+                    label: 'Item 4',
+                  ),
+                  new TestSemantics(
+                    id: 15,
+                    label: 'Item 3',
+                  ),
+                  new TestSemantics(
+                    id: 16,
+                    label: 'Item 2',
+                  ),
+                  new TestSemantics(
+                    id: 17,
+                    label: 'Item 1',
+                  ),
+                  new TestSemantics(
+                    id: 18,
+                    label: 'Item 0',
+                  ),
+                ],
+              ),
+            ],
+          )
+        ],
+      ),
+      ignoreRect: true,
+      ignoreTransform: true,
+    ));
+
+    semantics.dispose();
   });
 }

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -145,9 +145,14 @@ class FlutterDevice {
       await view.uiIsolate.flutterDebugDumpLayerTree();
   }
 
-  Future<Null> debugDumpSemanticsTree() async {
+  Future<Null> debugDumpSemanticsTreeInTraversalOrder() async {
     for (FlutterView view in views)
-      await view.uiIsolate.flutterDebugDumpSemanticsTree();
+      await view.uiIsolate.flutterDebugDumpSemanticsTreeInTraversalOrder();
+  }
+
+  Future<Null> debugDumpSemanticsTreeInInverseHitTestOrder() async {
+    for (FlutterView view in views)
+      await view.uiIsolate.flutterDebugDumpSemanticsTreeInInverseHitTestOrder();
   }
 
   Future<Null> toggleDebugPaintSizeEnabled() async {
@@ -431,10 +436,16 @@ abstract class ResidentRunner {
       await device.debugDumpLayerTree();
   }
 
-  Future<Null> _debugDumpSemanticsTree() async {
+  Future<Null> _debugDumpSemanticsTreeInTraversalOrder() async {
     await refreshViews();
     for (FlutterDevice device in flutterDevices)
-      await device.debugDumpSemanticsTree();
+      await device.debugDumpSemanticsTreeInTraversalOrder();
+  }
+
+  Future<Null> _debugDumpSemanticsTreeInInverseHitTestOrder() async {
+    await refreshViews();
+    for (FlutterDevice device in flutterDevices)
+      await device.debugDumpSemanticsTreeInInverseHitTestOrder();
   }
 
   Future<Null> _debugToggleDebugPaintSizeEnabled() async {
@@ -607,7 +618,12 @@ abstract class ResidentRunner {
       }
     } else if (character == 'S') {
       if (supportsServiceProtocol) {
-        await _debugDumpSemanticsTree();
+        await _debugDumpSemanticsTreeInTraversalOrder();
+        return true;
+      }
+    } else if (character == 'H') {
+      if (supportsServiceProtocol) {
+        await _debugDumpSemanticsTreeInInverseHitTestOrder();
         return true;
       }
     } else if (character == 'p') {
@@ -743,12 +759,12 @@ abstract class ResidentRunner {
       printStatus('You can dump the widget hierarchy of the app (debugDumpApp) by pressing "w".');
       printStatus('To dump the rendering tree of the app (debugDumpRenderTree), press "t".');
       if (isRunningDebug) {
-        printStatus('For layers (debugDumpLayerTree), use "L"; accessibility (debugDumpSemantics), "S".');
+        printStatus('For layers (debugDumpLayerTree), use "L"; accessibility (debugDumpSemantics), "S" (traversal order) or "H" (inverse hit test order).');
         printStatus('To toggle the widget inspector (WidgetsApp.showWidgetInspectorOverride), press "i".');
         printStatus('To toggle the display of construction lines (debugPaintSizeEnabled), press "p".');
         printStatus('To simulate different operating systems, (defaultTargetPlatform), press "o".');
       } else {
-        printStatus('To dump the accessibility tree (debugDumpSemantics), press "S".');
+        printStatus('To dump the accessibility tree (debugDumpSemantics), press "S" (for traversal order) or "H" (for inverse hit test order).');
       }
       printStatus('To display the performance overlay (WidgetsApp.showPerformanceOverlay), press "P".');
     }

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -621,7 +621,7 @@ abstract class ResidentRunner {
         await _debugDumpSemanticsTreeInTraversalOrder();
         return true;
       }
-    } else if (character == 'H') {
+    } else if (character == 'P') {
       if (supportsServiceProtocol) {
         await _debugDumpSemanticsTreeInInverseHitTestOrder();
         return true;
@@ -759,12 +759,12 @@ abstract class ResidentRunner {
       printStatus('You can dump the widget hierarchy of the app (debugDumpApp) by pressing "w".');
       printStatus('To dump the rendering tree of the app (debugDumpRenderTree), press "t".');
       if (isRunningDebug) {
-        printStatus('For layers (debugDumpLayerTree), use "L"; accessibility (debugDumpSemantics), "S" (traversal order) or "H" (inverse hit test order).');
+        printStatus('For layers (debugDumpLayerTree), use "L"; accessibility (debugDumpSemantics), "S" (traversal order) or "P" (inverse hit test order).');
         printStatus('To toggle the widget inspector (WidgetsApp.showWidgetInspectorOverride), press "i".');
         printStatus('To toggle the display of construction lines (debugPaintSizeEnabled), press "p".');
         printStatus('To simulate different operating systems, (defaultTargetPlatform), press "o".');
       } else {
-        printStatus('To dump the accessibility tree (debugDumpSemantics), press "S" (for traversal order) or "H" (for inverse hit test order).');
+        printStatus('To dump the accessibility tree (debugDumpSemantics), press "S" (for traversal order) or "P" (for inverse hit test order).');
       }
       printStatus('To display the performance overlay (WidgetsApp.showPerformanceOverlay), press "P".');
     }

--- a/packages/flutter_tools/lib/src/vmservice.dart
+++ b/packages/flutter_tools/lib/src/vmservice.dart
@@ -1069,8 +1069,12 @@ class Isolate extends ServiceObjectOwner {
     return invokeFlutterExtensionRpcRaw('ext.flutter.debugDumpLayerTree', timeout: kLongRequestTimeout);
   }
 
-  Future<Map<String, dynamic>> flutterDebugDumpSemanticsTree() {
-    return invokeFlutterExtensionRpcRaw('ext.flutter.debugDumpSemanticsTree', timeout: kLongRequestTimeout);
+  Future<Map<String, dynamic>> flutterDebugDumpSemanticsTreeInTraversalOrder() {
+    return invokeFlutterExtensionRpcRaw('ext.flutter.debugDumpSemanticsTreeInTraversalOrder', timeout: kLongRequestTimeout);
+  }
+
+  Future<Map<String, dynamic>> flutterDebugDumpSemanticsTreeInInverseHitTestOrder() {
+    return invokeFlutterExtensionRpcRaw('ext.flutter.debugDumpSemanticsTreeInInverseHitTestOrder', timeout: kLongRequestTimeout);
   }
 
   Future<Map<String, dynamic>> _flutterToggle(String name) async {


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/11668.

This will mess up the traversal order which I intent to fix on the engine side in a separate PR.

Also in this PR:
* exclude offscreen slivers from semantics tree (fixes https://github.com/flutter/flutter/issues/11780)
* make it configurable in which order children are printed by debugDumpSemanticsTree()