### PR TITLE
Fixed TrackingScrollController cleaning offset on position's detach

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -15,3 +15,4 @@ Alexandre Ardhuin <alexandre.ardhuin@gmail.com>
 Luke Freeman <luke@goposse.com>
 Vincent Le Quéméner <eu.lequem@gmail.com>
 Mike Hoolehan <mike@hoolehan.com>
+German Saprykin <saprykin.h@gmail.com>

--- a/packages/flutter/lib/src/widgets/scroll_controller.dart
+++ b/packages/flutter/lib/src/widgets/scroll_controller.dart
@@ -323,6 +323,7 @@ class TrackingScrollController extends ScrollController {
 
   final Map<ScrollPosition, VoidCallback> _positionToListener = <ScrollPosition, VoidCallback>{};
   ScrollPosition _lastUpdated;
+  double _lastUpdatedOffset;
 
   /// The last [ScrollPosition] to change. Returns null if there aren't any
   /// attached scroll positions, or there hasn't been any scrolling yet, or the
@@ -336,13 +337,16 @@ class TrackingScrollController extends ScrollController {
   ///
   ///  * [ScrollController.initialScrollOffset], which this overrides.
   @override
-  double get initialScrollOffset => _lastUpdated?.pixels ?? super.initialScrollOffset;
+  double get initialScrollOffset => _lastUpdatedOffset ?? super.initialScrollOffset;
 
   @override
   void attach(ScrollPosition position) {
     super.attach(position);
     assert(!_positionToListener.containsKey(position));
-    _positionToListener[position] = () { _lastUpdated = position; };
+    _positionToListener[position] = () {
+      _lastUpdated = position;
+      _lastUpdatedOffset = position.pixels;
+    };
     position.addListener(_positionToListener[position]);
   }
 
@@ -354,6 +358,8 @@ class TrackingScrollController extends ScrollController {
     _positionToListener.remove(position);
     if (_lastUpdated == position)
       _lastUpdated = null;
+    if (_positionToListener.isEmpty)
+      _lastUpdatedOffset = null;
   }
 
   @override

--- a/packages/flutter/test/widgets/tracking_scroll_controller_test.dart
+++ b/packages/flutter/test/widgets/tracking_scroll_controller_test.dart
@@ -42,8 +42,7 @@ void main() {
     expect(find.text('Page2-Item0'), findsNothing);
     expect(find.text('Page2-Item1'), findsNothing);
 
-    await tester.fling(
-        find.text('Page1-Item1'), const Offset(-100.0, 0.0), 10000.0);
+    await tester.fling(find.text('Page1-Item1'), const Offset(-100.0, 0.0), 10000.0);
     await (tester.pumpAndSettle());
 
     expect(find.text('Page0-Item1'), findsNothing);

--- a/packages/flutter/test/widgets/tracking_scroll_controller_test.dart
+++ b/packages/flutter/test/widgets/tracking_scroll_controller_test.dart
@@ -6,7 +6,8 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  testWidgets('TrackingScrollController saves offset', (WidgetTester tester) async {
+  testWidgets('TrackingScrollController saves offset',
+      (WidgetTester tester) async {
     final TrackingScrollController controller = new TrackingScrollController();
 
     await tester.pumpWidget(
@@ -16,11 +17,8 @@ void main() {
               controller: controller,
               children: new List<Widget>.generate(
                 10,
-                    (int i) =>
-                new Container(
-                  height: 100.0,
-                  child: new Text("Page$index-Item$i"),
-                ),
+                (int i) => new Container(
+                    height: 100.0, child: new Text("Page$index-Item$i")),
               ).toList());
         },
       ),
@@ -34,7 +32,8 @@ void main() {
     controller.jumpTo(110.0);
     await (tester.pumpAndSettle());
 
-    await tester.fling(find.text('Page0-Item1'), const Offset(-100.0, 0.0), 10000.0);
+    await tester.fling(
+        find.text('Page0-Item1'), const Offset(-100.0, 0.0), 10000.0);
     await (tester.pumpAndSettle());
 
     expect(find.text('Page0-Item1'), findsNothing);
@@ -42,7 +41,8 @@ void main() {
     expect(find.text('Page2-Item0'), findsNothing);
     expect(find.text('Page2-Item1'), findsNothing);
 
-    await tester.fling(find.text('Page1-Item1'), const Offset(-100.0, 0.0), 10000.0);
+    await tester.fling(
+        find.text('Page1-Item1'), const Offset(-100.0, 0.0), 10000.0);
     await (tester.pumpAndSettle());
 
     expect(find.text('Page0-Item1'), findsNothing);

--- a/packages/flutter/test/widgets/tracking_scroll_controller_test.dart
+++ b/packages/flutter/test/widgets/tracking_scroll_controller_test.dart
@@ -1,0 +1,58 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('TrackingScrollController saves offset', (WidgetTester tester) async {
+    final TrackingScrollController controller = new TrackingScrollController();
+
+    await tester.pumpWidget(
+      new PageView.builder(
+        itemBuilder: (BuildContext context, int index) {
+          return new ListView(
+              controller: controller,
+              children: new List<Widget>.generate(
+                10,
+                    (int i) =>
+                new Container(
+                  height: 100.0,
+                  child: new Text("Page$index-Item$i"),
+                ),
+              ).toList());
+        },
+      ),
+    );
+
+    expect(find.text('Page0-Item1'), findsOneWidget);
+    expect(find.text('Page1-Item1'), findsNothing);
+    expect(find.text('Page2-Item0'), findsNothing);
+    expect(find.text('Page2-Item1'), findsNothing);
+
+    controller.jumpTo(110.0);
+    await (tester.pumpAndSettle());
+
+    await tester.fling(find.text('Page0-Item1'), const Offset(-100.0, 0.0), 10000.0);
+    await (tester.pumpAndSettle());
+
+    expect(find.text('Page0-Item1'), findsNothing);
+    expect(find.text('Page1-Item1'), findsOneWidget);
+    expect(find.text('Page2-Item0'), findsNothing);
+    expect(find.text('Page2-Item1'), findsNothing);
+
+    await tester.fling(
+        find.text('Page1-Item1'), const Offset(-100.0, 0.0), 10000.0);
+    await (tester.pumpAndSettle());
+
+    expect(find.text('Page0-Item1'), findsNothing);
+    expect(find.text('Page1-Item1'), findsNothing);
+    expect(find.text('Page2-Item0'), findsNothing);
+    expect(find.text('Page2-Item1'), findsOneWidget);
+
+    await tester.pumpWidget(new Text("Another page"));
+
+    expect(controller.initialScrollOffset, 0.0);
+  });
+}


### PR DESCRIPTION
Hi,
I bumped into an issue with `TrackingScrollController`. According to docs [TrackingScrollController](https://docs.flutter.io/flutter/widgets/TrackingScrollController-class.html) should always use last updated position. But in some case `_lastUpdated` position can be [deleted](https://github.com/flutter/flutter/blob/6655074b370d39150d2ed28f67851e3bce7013ab/packages/flutter/lib/src/widgets/scroll_controller.dart#L355) and this resets offset. It's possible in case of "infinite" PageView if you start switching pages without vertical scrolling.

In this PR I added new variable to store offset and clean it only if there aren't any stored positions.

## Steps to Reproduce

* Scroll down on the first page
* Swipe to the second page - offset is non-zero - correct
* Swipe to the third page - offset is zero - bug

Minimal example:

```dart
import 'package:flutter/material.dart';

class Home extends StatelessWidget {
  TrackingScrollController _trackingScrollController =
      new TrackingScrollController();

  @override
  Widget build(BuildContext context) {
    return new Scaffold(
      body: new PageView.builder(
        itemBuilder: (context, index) {
          return new ListView(
            controller: _trackingScrollController,
            children: new List<Widget>.generate(
                100, (int i) => new Text('page $index item $i')).toList(),
          );
        },
      ),
    );
  }
}

void main() {
  runApp(new MaterialApp(
    home: new Home(),
  ));
}
```
## Flutter Doctor

[✓] Flutter (on Mac OS X 10.12.6 16G29, locale en-RU, channel alpha)
    • Flutter at /Users/herman/Projects/github/flutter
    • Framework revision b156a0f054 (2 weeks ago), 2017-08-11 22:01:40 -0700
    • Engine revision fef7d827d6
    • Tools Dart version 1.25.0-dev.9.0

[✓] Android toolchain - develop for Android devices (Android SDK 26.0.0)
    • Android SDK at /Users/herman/Library/Android/sdk
    • Platform android-26, build-tools 26.0.0
    • ANDROID_HOME = /Users/herman/Library/Android/sdk
    • Java binary at: /Applications/Android Studio.app/Contents/jre/jdk/Contents/Home/bin/java
    • Java version OpenJDK Runtime Environment (build 1.8.0_112-release-b06)

[✓] iOS toolchain - develop for iOS devices (Xcode 8.3.3)
    • Xcode at /Applications/Xcode.app/Contents/Developer
    • Xcode 8.3.3, Build version 8E3004b
    • ios-deploy 1.9.1
    • CocoaPods version 1.2.1

[✓] Android Studio
    • Android Studio at /Applications/Android Studio 3.0 Preview.app/Contents
    • Java version OpenJDK Runtime Environment (build 1.8.0_152-release-915-b01)

[✓] Android Studio (version 2.3)
    • Android Studio at /Applications/Android Studio.app/Contents
    • Java version OpenJDK Runtime Environment (build 1.8.0_112-release-b06)

[✓] IntelliJ IDEA Ultimate Edition (version 2017.2.2)
    • Flutter plugin version 16.0
    • Dart plugin version 172.3757.55

[✓] Connected devices
    • Nexus 6P • CVH7N15B14004431 • android-arm • Android 7.1.2 (API 25)