### PR TITLE
Don't use `runBinaryGuarded`.

### DIFF
--- a/packages/flutter_test/lib/src/binding.dart
+++ b/packages/flutter_test/lib/src/binding.dart
@@ -439,7 +439,7 @@ abstract class TestWidgetsFlutterBinding extends BindingBase
     );
     _parentZone = Zone.current;
     final Zone testZone = _parentZone.fork(specification: errorHandlingZoneSpecification);
-    testZone.runBinaryGuarded(_runTestBody, testBody, invariantTester)
+    testZone.runBinary(_runTestBody, testBody, invariantTester)
       .whenComplete(_testCompletionHandler);
     asyncBarrier(); // When using AutomatedTestWidgetsFlutterBinding, this flushes the microtasks.
     return _currentTestCompleter.future;


### PR DESCRIPTION
Since the called function can't throw, there is no need for the "guarded".
Since the function returns something, running in guarded mode doesn't really work. The `uncaught` handler wouldn't know what to return (except for `null`).