### PR TITLE
Spam EdgeInsetsGeometry to improve RTL support

### DIFF
--- a/packages/flutter/lib/src/material/button.dart
+++ b/packages/flutter/lib/src/material/button.dart
@@ -88,7 +88,7 @@ class ButtonTheme extends InheritedWidget {
   /// The amount of space to surround the child inside the bounds of the button.
   ///
   /// Defaults to 16.0 pixels of horizontal padding.
-  final EdgeInsets padding;
+  final EdgeInsetsGeometry padding;
 
   /// The closest instance of this class that encloses the given context.
   ///
@@ -231,7 +231,7 @@ class MaterialButton extends StatefulWidget {
   /// The amount of space to surround the child inside the bounds of the button.
   ///
   /// Defaults to the value from the current [ButtonTheme].
-  final EdgeInsets padding;
+  final EdgeInsetsGeometry padding;
 
   /// The callback that is called when the button is tapped or otherwise activated.
   ///

--- a/packages/flutter/lib/src/material/dialog.dart
+++ b/packages/flutter/lib/src/material/dialog.dart
@@ -145,7 +145,7 @@ class AlertDialog extends StatelessWidget {
   ///
   /// Uses material design default if none is supplied. If there is no title, no
   /// padding will be provided.
-  final EdgeInsets titlePadding;
+  final EdgeInsetsGeometry titlePadding;
 
   /// The (optional) content of the dialog is displayed in the center of the
   /// dialog in a lighter font.
@@ -158,7 +158,7 @@ class AlertDialog extends StatelessWidget {
   /// Padding around the content.
   ///
   /// Uses material design default if none is supplied.
-  final EdgeInsets contentPadding;
+  final EdgeInsetsGeometry contentPadding;
 
   /// The (optional) set of actions that are displayed at the bottom of the
   /// dialog.
@@ -174,7 +174,7 @@ class AlertDialog extends StatelessWidget {
 
     if (title != null) {
       children.add(new Padding(
-        padding: titlePadding ?? new EdgeInsets.fromLTRB(24.0, 24.0, 24.0, content == null ? 20.0 : 0.0),
+        padding: titlePadding ?? new EdgeInsetsDirectional.fromSTEB(24.0, 24.0, 24.0, content == null ? 20.0 : 0.0),
         child: new DefaultTextStyle(
           style: Theme.of(context).textTheme.title,
           child: title,
@@ -185,7 +185,7 @@ class AlertDialog extends StatelessWidget {
     if (content != null) {
       children.add(new Flexible(
         child: new Padding(
-          padding: contentPadding ?? const EdgeInsets.fromLTRB(24.0, 20.0, 24.0, 24.0),
+          padding: contentPadding ?? const EdgeInsetsDirectional.fromSTEB(24.0, 20.0, 24.0, 24.0),
           child: new DefaultTextStyle(
             style: Theme.of(context).textTheme.subhead,
             child: content,
@@ -352,7 +352,7 @@ class SimpleDialog extends StatelessWidget {
   ///
   /// Uses material design default if none is supplied. If there is no title, no
   /// padding will be provided.
-  final EdgeInsets titlePadding;
+  final EdgeInsetsGeometry titlePadding;
 
   /// The (optional) content of the dialog is displayed in a
   /// [SingleChildScrollView] underneath the title.
@@ -363,7 +363,7 @@ class SimpleDialog extends StatelessWidget {
   /// Padding around the content.
   ///
   /// Uses material design default if none is supplied.
-  final EdgeInsets contentPadding;
+  final EdgeInsetsGeometry contentPadding;
 
   @override
   Widget build(BuildContext context) {
@@ -371,7 +371,7 @@ class SimpleDialog extends StatelessWidget {
 
     if (title != null) {
       body.add(new Padding(
-        padding: titlePadding ?? const EdgeInsets.fromLTRB(24.0, 24.0, 24.0, 0.0),
+        padding: titlePadding ?? const EdgeInsetsDirectional.fromSTEB(24.0, 24.0, 24.0, 0.0),
         child: new DefaultTextStyle(
           style: Theme.of(context).textTheme.title,
           child: title
@@ -382,7 +382,7 @@ class SimpleDialog extends StatelessWidget {
     if (children != null) {
       body.add(new Flexible(
         child: new SingleChildScrollView(
-          padding: contentPadding ?? const EdgeInsets.fromLTRB(0.0, 12.0, 0.0, 16.0),
+          padding: contentPadding ?? const EdgeInsetsDirectional.fromSTEB(0.0, 12.0, 0.0, 16.0),
           child: new ListBody(children: children),
         )
       ));

--- a/packages/flutter/lib/src/material/drawer_header.dart
+++ b/packages/flutter/lib/src/material/drawer_header.dart
@@ -52,10 +52,10 @@ class DrawerHeader extends StatelessWidget {
   /// system status bar.
   ///
   /// If the child is null, the padding has no effect.
-  final EdgeInsets padding;
+  final EdgeInsetsGeometry padding;
 
   /// The margin around the drawer header.
-  final EdgeInsets margin;
+  final EdgeInsetsGeometry margin;
 
   /// The duration for animations of the [decoration].
   final Duration duration;
@@ -82,20 +82,20 @@ class DrawerHeader extends StatelessWidget {
         border: new Border(
           bottom: new BorderSide(
             color: theme.dividerColor,
-            width: 0.0
-          )
-        )
+            width: 0.0,
+          ),
+        ),
       ),
       child: new AnimatedContainer(
-        padding: padding + new EdgeInsets.only(top: statusBarHeight),
+        padding: padding.add(new EdgeInsets.only(top: statusBarHeight)),
         decoration: decoration,
         duration: duration,
         curve: curve,
         child: child == null ? null : new DefaultTextStyle(
           style: theme.textTheme.body2,
-          child: child
-        )
-      )
+          child: child,
+        ),
+      ),
     );
   }
 }

--- a/packages/flutter/lib/src/material/expand_icon.dart
+++ b/packages/flutter/lib/src/material/expand_icon.dart
@@ -52,7 +52,7 @@ class ExpandIcon extends StatefulWidget {
   /// gestures.
   ///
   /// This property must not be null. It defaults to 8.0 padding on all sides.
-  final EdgeInsets padding;
+  final EdgeInsetsGeometry padding;
 
   @override
   _ExpandIconState createState() => new _ExpandIconState();

--- a/packages/flutter/lib/src/material/grid_tile_bar.dart
+++ b/packages/flutter/lib/src/material/grid_tile_bar.dart
@@ -63,13 +63,13 @@ class GridTileBar extends StatelessWidget {
       decoration = new BoxDecoration(color: backgroundColor);
 
     final List<Widget> children = <Widget>[];
-    final EdgeInsets padding = new EdgeInsets.only(
-      left: leading != null ? 8.0 : 16.0,
-      right: trailing != null ? 8.0 : 16.0,
+    final EdgeInsetsDirectional padding = new EdgeInsetsDirectional.only(
+      start: leading != null ? 8.0 : 16.0,
+      end: trailing != null ? 8.0 : 16.0,
     );
 
     if (leading != null)
-      children.add(new Padding(padding: const EdgeInsets.only(right: 8.0), child: leading));
+      children.add(new Padding(padding: const EdgeInsetsDirectional.only(end: 8.0), child: leading));
 
     final ThemeData theme = Theme.of(context);
     final ThemeData darkTheme = new ThemeData(
@@ -114,7 +114,7 @@ class GridTileBar extends StatelessWidget {
     }
 
     if (trailing != null)
-      children.add(new Padding(padding: const EdgeInsets.only(left: 8.0), child: trailing));
+      children.add(new Padding(padding: const EdgeInsetsDirectional.only(start: 8.0), child: trailing));
 
     return new Container(
       padding: padding,

--- a/packages/flutter/lib/src/material/icon_button.dart
+++ b/packages/flutter/lib/src/material/icon_button.dart
@@ -103,12 +103,12 @@ class IconButton extends StatelessWidget {
   /// to input gestures.
   ///
   /// This property must not be null. It defaults to 8.0 padding on all sides.
-  final EdgeInsets padding;
+  final EdgeInsetsGeometry padding;
 
   /// Defines how the icon is positioned within the IconButton.
   ///
   /// This property must not be null. It defaults to [FractionalOffset.center].
-  final FractionalOffset alignment;
+  final FractionalOffsetGeometry alignment;
 
   /// The icon to display inside the button.
   ///

--- a/packages/flutter/lib/src/material/tooltip.dart
+++ b/packages/flutter/lib/src/material/tooltip.dart
@@ -66,7 +66,7 @@ class Tooltip extends StatefulWidget {
   /// The amount of space by which to inset the child.
   ///
   /// Defaults to 16.0 logical pixels in each direction.
-  final EdgeInsets padding;
+  final EdgeInsetsGeometry padding;
 
   /// The amount of vertical distance between the widget and the displayed tooltip.
   final double verticalOffset;
@@ -192,7 +192,7 @@ class _TooltipState extends State<Tooltip> with SingleTickerProviderStateMixin {
       child: new Semantics(
         label: widget.message,
         child: widget.child,
-      )
+      ),
     );
   }
 }
@@ -261,7 +261,7 @@ class _TooltipOverlay extends StatelessWidget {
 
   final String message;
   final double height;
-  final EdgeInsets padding;
+  final EdgeInsetsGeometry padding;
   final Animation<double> animation;
   final Offset target;
   final double verticalOffset;
@@ -281,7 +281,7 @@ class _TooltipOverlay extends StatelessWidget {
           delegate: new _TooltipPositionDelegate(
             target: target,
             verticalOffset: verticalOffset,
-            preferBelow: preferBelow
+            preferBelow: preferBelow,
           ),
           child: new FadeTransition(
             opacity: animation,
@@ -290,19 +290,19 @@ class _TooltipOverlay extends StatelessWidget {
               child: new Container(
                 decoration: new BoxDecoration(
                   color: darkTheme.backgroundColor,
-                  borderRadius: new BorderRadius.circular(2.0)
+                  borderRadius: new BorderRadius.circular(2.0),
                 ),
                 height: height,
                 padding: padding,
                 child: new Center(
                   widthFactor: 1.0,
-                  child: new Text(message, style: darkTheme.textTheme.body1)
-                )
-              )
-            )
-          )
-        )
-      )
+                  child: new Text(message, style: darkTheme.textTheme.body1),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
     );
   }
 }

--- a/packages/flutter/lib/src/material/two_level_list.dart
+++ b/packages/flutter/lib/src/material/two_level_list.dart
@@ -263,7 +263,7 @@ class TwoLevelList extends StatelessWidget {
     Key key,
     this.children: const <Widget>[],
     this.type: MaterialListType.twoLine,
-    this.padding
+    this.padding,
   }) : assert(type != null),
        super(key: key);
 
@@ -276,7 +276,7 @@ class TwoLevelList extends StatelessWidget {
   final MaterialListType type;
 
   /// The amount of space by which to inset the children inside the viewport.
-  final EdgeInsets padding;
+  final EdgeInsetsGeometry padding;
 
   @override
   Widget build(BuildContext context) {

--- a/packages/flutter/lib/src/material/user_accounts_drawer_header.dart
+++ b/packages/flutter/lib/src/material/user_accounts_drawer_header.dart
@@ -153,7 +153,7 @@ class UserAccountsDrawerHeader extends StatefulWidget {
   final Decoration decoration;
 
   /// The margin around the drawer header.
-  final EdgeInsets margin;
+  final EdgeInsetsGeometry margin;
 
   /// A widget placed in the upper-left corner that represents the current
   /// user's account. Normally a [CircleAvatar].

--- a/packages/flutter/lib/src/widgets/animated_list.dart
+++ b/packages/flutter/lib/src/widgets/animated_list.dart
@@ -150,7 +150,7 @@ class AnimatedList extends StatefulWidget {
   final bool shrinkWrap;
 
   /// The amount of space by which to inset the children.
-  final EdgeInsets padding;
+  final EdgeInsetsGeometry padding;
 
   /// The state from the closest instance of this class that encloses the given context.
   ///


### PR DESCRIPTION
Most of the framework widgets should work in terms of EdgeInsetsGeometry
rather than EdgeInsets so that their clients can supply directional
insets.