### PR TITLE
Mark android_sample_catalog_generator flaky

### DIFF
--- a/dev/devicelab/manifest.yaml
+++ b/dev/devicelab/manifest.yaml
@@ -139,6 +139,7 @@ tasks:
       Builds sample catalog markdown pages and Android screenshots
     stage: devicelab
     required_agent_capabilities: ["has-android-device"]
+    flaky: true
 
   complex_layout_semantics_perf:
     description: >


### PR DESCRIPTION
The android_sample_catalog_generator CI task has been intermittently failing for about a week. I've marked it flaky.

Note sure what the problem is (timeout is too short for our slow servers?).  Typical swan song follows.

```
------------ TASK ------------
{
  "Key": "ahNzfmZsdXR0ZXItZGFzaGJvYXJkclgLEglDaGVja2xpc3QiOGZsdXR0ZXIvZmx1dHRlci81NDFhZmFlNDViMTBhNzY0ZTQ2ZDE3NmVhMjQ5YzRkYzEyMmViNTU3DAsSBFRhc2sYgICAgICAkAoM",
  "Task": {
    "ChecklistKey": "ahNzfmZsdXR0ZXItZGFzaGJvYXJkckcLEglDaGVja2xpc3QiOGZsdXR0ZXIvZmx1dHRlci81NDFhZmFlNDViMTBhNzY0ZTQ2ZDE3NmVhMjQ5YzRkYzEyMmViNTU3DA",
    "StageName": "devicelab",
    "Name": "android_sample_catalog_generator",
    "RequiredCapabilities": [
      "has-android-device"
    ],
    "Status": "Failed",
    "Reason": "Task failed on agent",
    "Attempts": 2,
    "ReservedForAgentID": "mac3",
    "CreateTimestamp": 1504190760381,
    "StartTimestamp": 1504191668951,
    "EndTimestamp": 0,
    "Flaky": false,
    "TimeoutInMinutes": 0
  }
}

------------ LOG ------------
Observatory listening on http://127.0.0.1:20000/
Task execution finished

Task failed with the following reason:
Timeout waiting for connection: Failed to connect to the task runner process
Observatory listening on http://127.0.0.1:20000/
Task execution finished

Task failed with the following reason:
Timeout waiting for connection: Failed to connect to the task runner process
```