### PR TITLE
Added material string translations for the 6 additional RTL locales we recognize

### DIFF
--- a/packages/flutter/lib/src/material/i18n/localizations.dart
+++ b/packages/flutter/lib/src/material/i18n/localizations.dart
@@ -53,13 +53,6 @@ const Map<String, Map<String, String>> localizations = const <String, Map<String
     "nextMonthTooltip": r"الشهر القادم",
     "previousMonthTooltip": r"الشهر الماضى"
   },
-  "dv": const <String, String>{
-    "openAppDrawerTooltip": r"Open navigation menu",
-    "backButtonTooltip": r"Back",
-    "closeButtonTooltip": r"Close",
-    "nextMonthTooltip": r"Next month",
-    "previousMonthTooltip": r"Previous month"
-  },
   "it": const <String, String>{
     "openAppDrawerTooltip": r"Apri il menu di navigazione",
     "backButtonTooltip": r"Indietro",

--- a/packages/flutter/lib/src/material/i18n/localizations.dart
+++ b/packages/flutter/lib/src/material/i18n/localizations.dart
@@ -11,12 +11,54 @@
 ///
 /// This variable is used by [MaterialLocalizations].
 const Map<String, Map<String, String>> localizations = const <String, Map<String, String>> {
+  "sd": const <String, String>{
+    "openAppDrawerTooltip": r"اوپن جي مينڊيٽ مينيو",
+    "backButtonTooltip": r"پوئتي",
+    "closeButtonTooltip": r"بند ڪريو",
+    "nextMonthTooltip": r"ايندڙ مهيني",
+    "previousMonthTooltip": r"پويون مهينو"
+  },
+  "fa": const <String, String>{
+    "openAppDrawerTooltip": r"منوی ناوبری را باز کنید",
+    "backButtonTooltip": r"بازگشت",
+    "closeButtonTooltip": r"بستن",
+    "nextMonthTooltip": r"ماه بعد",
+    "previousMonthTooltip": r"ماه گذشته"
+  },
+  "ur": const <String, String>{
+    "openAppDrawerTooltip": r"کھولیں نیویگیشن مینو",
+    "backButtonTooltip": r"واپس",
+    "closeButtonTooltip": r"بند کریں",
+    "nextMonthTooltip": r"اگلا مھینہ",
+    "previousMonthTooltip": r"پچھلا مھینہ"
+  },
+  "ps": const <String, String>{
+    "openAppDrawerTooltip": r"د پرانیستی نیینګ مینو",
+    "backButtonTooltip": r"شاته",
+    "closeButtonTooltip": r"بنده",
+    "nextMonthTooltip": r"بله میاشت",
+    "previousMonthTooltip": r"تیره میاشت"
+  },
+  "he": const <String, String>{
+    "openAppDrawerTooltip": r"פתח תפריט ניווט",
+    "backButtonTooltip": r"אחורה",
+    "closeButtonTooltip": r"סגור",
+    "nextMonthTooltip": r"חודש הבא",
+    "previousMonthTooltip": r"חודש שעבר"
+  },
   "ar": const <String, String>{
     "openAppDrawerTooltip": r"افتح قائمة التنقل",
     "backButtonTooltip": r"الى الخلف",
     "closeButtonTooltip": r"إغلا",
     "nextMonthTooltip": r"الشهر القادم",
     "previousMonthTooltip": r"الشهر الماضى"
+  },
+  "dv": const <String, String>{
+    "openAppDrawerTooltip": r"Open navigation menu",
+    "backButtonTooltip": r"Back",
+    "closeButtonTooltip": r"Close",
+    "nextMonthTooltip": r"Next month",
+    "previousMonthTooltip": r"Previous month"
   },
   "it": const <String, String>{
     "openAppDrawerTooltip": r"Apri il menu di navigazione",

--- a/packages/flutter/lib/src/material/i18n/material_ar.arb
+++ b/packages/flutter/lib/src/material/i18n/material_ar.arb
@@ -1,27 +1,7 @@
 {
   "openAppDrawerTooltip": "افتح قائمة التنقل",
-  "@openAppDrawerTooltip": {
-    "description": "The tooltip for the leading AppBar menu (aka 'hamburger') button",
-    "type": "text"
-  },
   "backButtonTooltip": "الى الخلف",
-  "@backButtonTooltip": {
-    "description": "The BackButton's tooltip",
-    "type": "text"
-  },
   "closeButtonTooltip": "إغلا",
-  "@closeButtonTooltip": {
-    "description": "The CloseButton's tooltip",
-    "type": "text"
-  },
   "nextMonthTooltip": "الشهر القادم",
-  "@nextMonthTooltip": {
-    "description": "The tooltip for the MonthPicker's 'next month' button.",
-    "type": "text"
-  },
-  "previousMonthTooltip": "الشهر الماضى",
-  "@previousMonthTooltip": {
-    "description": "The tooltip for the MonthPicker's 'previous month' button.",
-    "type": "text"
-  }
+  "previousMonthTooltip": "الشهر الماضى"
 }

--- a/packages/flutter/lib/src/material/i18n/material_de.arb
+++ b/packages/flutter/lib/src/material/i18n/material_de.arb
@@ -1,27 +1,7 @@
 {
   "openAppDrawerTooltip": "Navigationsmenü öffnen",
-  "@openAppDrawerTooltip": {
-    "description": "The tooltip for the leading AppBar menu (aka 'hamburger') button",
-    "type": "text"
-  },
   "backButtonTooltip": "Zurück",
-  "@backButtonTooltip": {
-    "description": "The BackButton's tooltip",
-    "type": "text"
-  },
   "closeButtonTooltip": "Schließen ",
-  "@closeButtonTooltip": {
-    "description": "The CloseButton's tooltip",
-    "type": "text"
-  },
   "nextMonthTooltip": "Nächster Monat",
-  "@nextMonthTooltip": {
-    "description": "The tooltip for the MonthPicker's 'next month' button.",
-    "type": "text"
-  },
-  "previousMonthTooltip": "Letzter Monat",
-  "@previousMonthTooltip": {
-    "description": "The tooltip for the MonthPicker's 'previous month' button.",
-    "type": "text"
-  }
+  "previousMonthTooltip": "Letzter Monat"
 }

--- a/packages/flutter/lib/src/material/i18n/material_dv.arb
+++ b/packages/flutter/lib/src/material/i18n/material_dv.arb
@@ -1,0 +1,7 @@
+{
+  "openAppDrawerTooltip": "Open navigation menu",
+  "backButtonTooltip": "Back",
+  "closeButtonTooltip": "Close",
+  "nextMonthTooltip": "Next month",
+  "previousMonthTooltip": "Previous month"
+}

--- a/packages/flutter/lib/src/material/i18n/material_dv.arb
+++ b/packages/flutter/lib/src/material/i18n/material_dv.arb
@@ -1,7 +1,0 @@
-{
-  "openAppDrawerTooltip": "Open navigation menu",
-  "backButtonTooltip": "Back",
-  "closeButtonTooltip": "Close",
-  "nextMonthTooltip": "Next month",
-  "previousMonthTooltip": "Previous month"
-}

--- a/packages/flutter/lib/src/material/i18n/material_es.arb
+++ b/packages/flutter/lib/src/material/i18n/material_es.arb
@@ -1,27 +1,7 @@
 {
   "openAppDrawerTooltip": "Abrir el menú de navegación",
-  "@openAppDrawerTooltip": {
-    "description": "The tooltip for the leading AppBar menu (aka 'hamburger') button",
-    "type": "text"
-  },
   "backButtonTooltip": "Espalda",
-  "@backButtonTooltip": {
-    "description": "The BackButton's tooltip",
-    "type": "text"
-  },
   "closeButtonTooltip": "Cerrar",
-  "@closeButtonTooltip": {
-    "description": "The CloseButton's tooltip",
-    "type": "text"
-  },
   "nextMonthTooltip": "Próximo mes",
-  "@nextMonthTooltip": {
-    "description": "The tooltip for the MonthPicker's 'next month' button.",
-    "type": "text"
-  },
-  "previousMonthTooltip": "mes anterior",
-  "@previousMonthTooltip": {
-    "description": "The tooltip for the MonthPicker's 'previous month' button.",
-    "type": "text"
-  }
+  "previousMonthTooltip": "mes anterior"
 }

--- a/packages/flutter/lib/src/material/i18n/material_fa.arb
+++ b/packages/flutter/lib/src/material/i18n/material_fa.arb
@@ -1,0 +1,7 @@
+{
+  "openAppDrawerTooltip": "منوی ناوبری را باز کنید",
+  "backButtonTooltip": "بازگشت",
+  "closeButtonTooltip": "بستن",
+  "nextMonthTooltip": "ماه بعد",
+  "previousMonthTooltip": "ماه گذشته"
+}

--- a/packages/flutter/lib/src/material/i18n/material_fr.arb
+++ b/packages/flutter/lib/src/material/i18n/material_fr.arb
@@ -1,27 +1,7 @@
 {
   "openAppDrawerTooltip": "Ouvrir le menu de navigation",
-  "@openAppDrawerTooltip": {
-    "description": "The tooltip for the leading AppBar menu (aka 'hamburger') button",
-    "type": "text"
-  },
   "backButtonTooltip": "Arrière",
-  "@backButtonTooltip": {
-    "description": "The BackButton's tooltip",
-    "type": "text"
-  },
   "closeButtonTooltip": "Fermer",
-  "@closeButtonTooltip": {
-    "description": "The CloseButton's tooltip",
-    "type": "text"
-  },
   "nextMonthTooltip": "Mois Suivant",
-  "@nextMonthTooltip": {
-    "description": "The tooltip for the MonthPicker's 'next month' button.",
-    "type": "text"
-  },
-  "previousMonthTooltip": "Le mois précédent",
-  "@previousMonthTooltip": {
-    "description": "The tooltip for the MonthPicker's 'previous month' button.",
-    "type": "text"
-  }
+  "previousMonthTooltip": "Le mois précédent"
 }

--- a/packages/flutter/lib/src/material/i18n/material_he.arb
+++ b/packages/flutter/lib/src/material/i18n/material_he.arb
@@ -1,0 +1,7 @@
+{
+  "openAppDrawerTooltip": "פתח תפריט ניווט",
+  "backButtonTooltip": "אחורה",
+  "closeButtonTooltip": "סגור",
+  "nextMonthTooltip": "חודש הבא",
+  "previousMonthTooltip": "חודש שעבר"
+}

--- a/packages/flutter/lib/src/material/i18n/material_it.arb
+++ b/packages/flutter/lib/src/material/i18n/material_it.arb
@@ -1,27 +1,7 @@
 {
   "openAppDrawerTooltip": "Apri il menu di navigazione",
-  "@openAppDrawerTooltip": {
-    "description": "The tooltip for the leading AppBar menu (aka 'hamburger') button",
-    "type": "text"
-  },
   "backButtonTooltip": "Indietro",
-  "@backButtonTooltip": {
-    "description": "The BackButton's tooltip",
-    "type": "text"
-  },
   "closeButtonTooltip": "Chiudi",
-  "@closeButtonTooltip": {
-    "description": "The CloseButton's tooltip",
-    "type": "text"
-  },
   "nextMonthTooltip": "Il prossimo mese",
-  "@nextMonthTooltip": {
-    "description": "The tooltip for the MonthPicker's 'next month' button.",
-    "type": "text"
-  },
-  "previousMonthTooltip": "Il mese scorso",
-  "@previousMonthTooltip": {
-    "description": "The tooltip for the MonthPicker's 'previous month' button.",
-    "type": "text"
-  }
+  "previousMonthTooltip": "Il mese scorso"
 }

--- a/packages/flutter/lib/src/material/i18n/material_ja.arb
+++ b/packages/flutter/lib/src/material/i18n/material_ja.arb
@@ -1,27 +1,7 @@
 {
   "openAppDrawerTooltip": "ナビゲーションメニューを開く",
-  "@openAppDrawerTooltip": {
-    "description": "The tooltip for the leading AppBar menu (aka 'hamburger') button",
-    "type": "text"
-  },
   "backButtonTooltip": "バック",
-  "@backButtonTooltip": {
-    "description": "The BackButton's tooltip",
-    "type": "text"
-  },
   "closeButtonTooltip": "閉じる",
-  "@closeButtonTooltip": {
-    "description": "The CloseButton's tooltip",
-    "type": "text"
-  },
   "nextMonthTooltip": "来月",
-  "@nextMonthTooltip": {
-    "description": "The tooltip for the MonthPicker's 'next month' button.",
-    "type": "text"
-  },
-  "previousMonthTooltip": "前の月",
-  "@previousMonthTooltip": {
-    "description": "The tooltip for the MonthPicker's 'previous month' button.",
-    "type": "text"
-  }
+  "previousMonthTooltip": "前の月"
 }

--- a/packages/flutter/lib/src/material/i18n/material_ps.arb
+++ b/packages/flutter/lib/src/material/i18n/material_ps.arb
@@ -1,0 +1,7 @@
+{
+  "openAppDrawerTooltip": "د پرانیستی نیینګ مینو",
+  "backButtonTooltip": "شاته",
+  "closeButtonTooltip": "بنده",
+  "nextMonthTooltip": "بله میاشت",
+  "previousMonthTooltip": "تیره میاشت"
+}

--- a/packages/flutter/lib/src/material/i18n/material_pt.arb
+++ b/packages/flutter/lib/src/material/i18n/material_pt.arb
@@ -1,27 +1,7 @@
 {
   "openAppDrawerTooltip": "Abrir menu de navegação",
-  "@openAppDrawerTooltip": {
-    "description": "The tooltip for the leading AppBar menu (aka 'hamburger') button",
-    "type": "text"
-  },
   "backButtonTooltip": "Costas",
-  "@backButtonTooltip": {
-    "description": "The BackButton's tooltip",
-    "type": "text"
-  },
   "closeButtonTooltip": "Fechar",
-  "@closeButtonTooltip": {
-    "description": "The CloseButton's tooltip",
-    "type": "text"
-  },
   "nextMonthTooltip": "Próximo mês",
-  "@nextMonthTooltip": {
-    "description": "The tooltip for the MonthPicker's 'next month' button.",
-    "type": "text"
-  },
-  "previousMonthTooltip": "Mês anterior",
-  "@previousMonthTooltip": {
-    "description": "The tooltip for the MonthPicker's 'previous month' button.",
-    "type": "text"
-  }
+  "previousMonthTooltip": "Mês anterior"
 }

--- a/packages/flutter/lib/src/material/i18n/material_ru.arb
+++ b/packages/flutter/lib/src/material/i18n/material_ru.arb
@@ -1,27 +1,7 @@
 {
   "openAppDrawerTooltip": "Открыть меню навигации",
-  "@openAppDrawerTooltip": {
-    "description": "The tooltip for the leading AppBar menu (aka 'hamburger') button",
-    "type": "text"
-  },
   "backButtonTooltip": "назад",
-  "@backButtonTooltip": {
-    "description": "The BackButton's tooltip",
-    "type": "text"
-  },
   "closeButtonTooltip": "Закрыть",
-  "@closeButtonTooltip": {
-    "description": "The CloseButton's tooltip",
-    "type": "text"
-  },
   "nextMonthTooltip": "В следующем месяце",
-  "@nextMonthTooltip": {
-    "description": "The tooltip for the MonthPicker's 'next month' button.",
-    "type": "text"
-  },
-  "previousMonthTooltip": "Предыдущий месяц",
-  "@previousMonthTooltip": {
-    "description": "The tooltip for the MonthPicker's 'previous month' button.",
-    "type": "text"
-  }
+  "previousMonthTooltip": "Предыдущий месяц"
 }

--- a/packages/flutter/lib/src/material/i18n/material_sd.arb
+++ b/packages/flutter/lib/src/material/i18n/material_sd.arb
@@ -1,0 +1,7 @@
+{
+  "openAppDrawerTooltip": "اوپن جي مينڊيٽ مينيو",
+  "backButtonTooltip": "پوئتي",
+  "closeButtonTooltip": "بند ڪريو",
+  "nextMonthTooltip": "ايندڙ مهيني",
+  "previousMonthTooltip": "پويون مهينو"
+}

--- a/packages/flutter/lib/src/material/i18n/material_ur.arb
+++ b/packages/flutter/lib/src/material/i18n/material_ur.arb
@@ -1,0 +1,7 @@
+{
+  "openAppDrawerTooltip": "کھولیں نیویگیشن مینو",
+  "backButtonTooltip": "واپس",
+  "closeButtonTooltip": "بند کریں",
+  "nextMonthTooltip": "اگلا مھینہ",
+  "previousMonthTooltip": "پچھلا مھینہ"
+}

--- a/packages/flutter/lib/src/material/i18n/material_zh.arb
+++ b/packages/flutter/lib/src/material/i18n/material_zh.arb
@@ -1,27 +1,7 @@
 {
   "openAppDrawerTooltip": "打开导航菜单",
-  "@openAppDrawerTooltip": {
-    "description": "The tooltip for the leading AppBar menu (aka 'hamburger') button",
-    "type": "text"
-  },
   "backButtonTooltip": "背部",
-  "@backButtonTooltip": {
-    "description": "The BackButton's tooltip",
-    "type": "text"
-  },
   "closeButtonTooltip": "关",
-  "@closeButtonTooltip": {
-    "description": "The CloseButton's tooltip",
-    "type": "text"
-  },
   "nextMonthTooltip": "-下月就29了。",
-  "@nextMonthTooltip": {
-    "description": "The tooltip for the MonthPicker's 'next month' button.",
-    "type": "text"
-  },
-  "previousMonthTooltip": "前一个月",
-  "@previousMonthTooltip": {
-    "description": "The tooltip for the MonthPicker's 'previous month' button.",
-    "type": "text"
-  }
+  "previousMonthTooltip": "前一个月"
 }

--- a/packages/flutter/lib/src/material/material_localizations.dart
+++ b/packages/flutter/lib/src/material/material_localizations.dart
@@ -13,7 +13,7 @@ import 'i18n/localizations.dart';
 ///
 /// See also:
 ///
-///  * [DefaultMaterialLocalizations], which implements this interface and
+///  * [DefaultMaterialLocalizations], which implements this interface
 ///    and supports a variety of locales.
 abstract class MaterialLocalizations {
   /// The tooltip for the leading [AppBar] menu (aka 'hamburger') button

--- a/packages/flutter/lib/src/widgets/localizations.dart
+++ b/packages/flutter/lib/src/widgets/localizations.dart
@@ -166,7 +166,6 @@ class DefaultWidgetsLocalizations implements WidgetsLocalizations {
   // See http://en.wikipedia.org/wiki/Right-to-left
   static const List<String> _rtlLanguages = const <String>[
     'ar',  // Arabic
-    'dv',  // Dhivehi
     'fa',  // Farsi
     'he',  // Hebrew
     'ps',  // Pashto


### PR DESCRIPTION
All of the translations were generated automatically with the Google Translator Toolkit.

Removed the english language resource descriptions from all of the i18n/*.arb files except the en[glish] one.