### PR TITLE
getOffsetToReveal deals with pinned slivers

### DIFF
--- a/packages/flutter/lib/src/rendering/sliver.dart
+++ b/packages/flutter/lib/src/rendering/sliver.dart
@@ -486,7 +486,7 @@ class SliverGeometry extends Diagnosticable {
     this.paintOrigin: 0.0,
     double layoutExtent,
     this.maxPaintExtent: 0.0,
-    this.maxPinnedExtent: 0.0,
+    this.maxScrollObstructionExtent: 0.0,
     double hitTestExtent,
     bool visible,
     this.hasVisualOverflow: false,
@@ -562,7 +562,7 @@ class SliverGeometry extends Diagnosticable {
   /// A pinned app bar is an example for a sliver that would use this setting:
   /// When the app bar is pinned to the top, the area in which content can
   /// actually scroll is reduced by the height of the app bar.
-  final double maxPinnedExtent;
+  final double maxScrollObstructionExtent;
 
   /// The distance from where this sliver started painting to the bottom of
   /// where it should accept hits.

--- a/packages/flutter/lib/src/rendering/sliver.dart
+++ b/packages/flutter/lib/src/rendering/sliver.dart
@@ -486,6 +486,7 @@ class SliverGeometry extends Diagnosticable {
     this.paintOrigin: 0.0,
     double layoutExtent,
     this.maxPaintExtent: 0.0,
+    this.maxPinnedExtent: 0.0,
     double hitTestExtent,
     bool visible,
     this.hasVisualOverflow: false,
@@ -552,6 +553,16 @@ class SliverGeometry extends Diagnosticable {
   ///
   /// By definition, this cannot be less than [paintExtent].
   final double maxPaintExtent;
+
+  /// The maximum extent by which this sliver can reduce the area in which
+  /// content can scroll if the sliver were pinned at the edge.
+  ///
+  /// Slivers, that never get pinned at the edge, should return zero.
+  ///
+  /// A pinned app bar is an example for a sliver that would use this setting:
+  /// When the app bar is pinned to the top, the area in which content can
+  /// actually scroll is reduced by the height of the app bar.
+  final double maxPinnedExtent;
 
   /// The distance from where this sliver started painting to the bottom of
   /// where it should accept hits.

--- a/packages/flutter/lib/src/rendering/sliver.dart
+++ b/packages/flutter/lib/src/rendering/sliver.dart
@@ -557,7 +557,7 @@ class SliverGeometry extends Diagnosticable {
   /// The maximum extent by which this sliver can reduce the area in which
   /// content can scroll if the sliver were pinned at the edge.
   ///
-  /// Slivers, that never get pinned at the edge, should return zero.
+  /// Slivers that never get pinned at the edge, should return zero.
   ///
   /// A pinned app bar is an example for a sliver that would use this setting:
   /// When the app bar is pinned to the top, the area in which content can

--- a/packages/flutter/lib/src/rendering/sliver_persistent_header.dart
+++ b/packages/flutter/lib/src/rendering/sliver_persistent_header.dart
@@ -297,6 +297,7 @@ abstract class RenderSliverPinnedPersistentHeader extends RenderSliverPersistent
       paintExtent: math.min(childExtent, constraints.remainingPaintExtent),
       layoutExtent: (maxExtent - constraints.scrollOffset).clamp(0.0, constraints.remainingPaintExtent),
       maxPaintExtent: maxExtent,
+      maxPinnedExtent: minExtent,
       hasVisualOverflow: true, // Conservatively say we do have overflow to avoid complexity.
     );
   }
@@ -410,6 +411,7 @@ abstract class RenderSliverFloatingPersistentHeader extends RenderSliverPersiste
       paintExtent: paintExtent.clamp(0.0, constraints.remainingPaintExtent),
       layoutExtent: layoutExtent.clamp(0.0, constraints.remainingPaintExtent),
       maxPaintExtent: maxExtent,
+      maxPinnedExtent: maxExtent,
       hasVisualOverflow: true, // Conservatively say we do have overflow to avoid complexity.
     );
     return math.min(0.0, paintExtent - childExtent);
@@ -519,6 +521,7 @@ abstract class RenderSliverFloatingPinnedPersistentHeader extends RenderSliverFl
       paintExtent: paintExtent.clamp(minExtent, constraints.remainingPaintExtent),
       layoutExtent: layoutExtent.clamp(0.0, constraints.remainingPaintExtent - minExtent),
       maxPaintExtent: maxExtent,
+      maxPinnedExtent: maxExtent,
       hasVisualOverflow: true, // Conservatively say we do have overflow to avoid complexity.
     );
     return 0.0;

--- a/packages/flutter/lib/src/rendering/sliver_persistent_header.dart
+++ b/packages/flutter/lib/src/rendering/sliver_persistent_header.dart
@@ -297,7 +297,7 @@ abstract class RenderSliverPinnedPersistentHeader extends RenderSliverPersistent
       paintExtent: math.min(childExtent, constraints.remainingPaintExtent),
       layoutExtent: (maxExtent - constraints.scrollOffset).clamp(0.0, constraints.remainingPaintExtent),
       maxPaintExtent: maxExtent,
-      maxPinnedExtent: minExtent,
+      maxScrollObstructionExtent: minExtent,
       hasVisualOverflow: true, // Conservatively say we do have overflow to avoid complexity.
     );
   }
@@ -411,7 +411,7 @@ abstract class RenderSliverFloatingPersistentHeader extends RenderSliverPersiste
       paintExtent: paintExtent.clamp(0.0, constraints.remainingPaintExtent),
       layoutExtent: layoutExtent.clamp(0.0, constraints.remainingPaintExtent),
       maxPaintExtent: maxExtent,
-      maxPinnedExtent: maxExtent,
+      maxScrollObstructionExtent: maxExtent,
       hasVisualOverflow: true, // Conservatively say we do have overflow to avoid complexity.
     );
     return math.min(0.0, paintExtent - childExtent);
@@ -521,7 +521,7 @@ abstract class RenderSliverFloatingPinnedPersistentHeader extends RenderSliverFl
       paintExtent: paintExtent.clamp(minExtent, constraints.remainingPaintExtent),
       layoutExtent: layoutExtent.clamp(0.0, constraints.remainingPaintExtent - minExtent),
       maxPaintExtent: maxExtent,
-      maxPinnedExtent: maxExtent,
+      maxScrollObstructionExtent: maxExtent,
       hasVisualOverflow: true, // Conservatively say we do have overflow to avoid complexity.
     );
     return 0.0;

--- a/packages/flutter/lib/src/rendering/viewport.dart
+++ b/packages/flutter/lib/src/rendering/viewport.dart
@@ -458,7 +458,7 @@ abstract class RenderViewportBase<ParentDataClass extends ContainerParentDataMix
     assert(child.parent == this);
     assert(child is RenderSliver);
     final RenderSliver sliver = child;
-    final double extentOfPinnedSlivers = paintExtentOfSliversPinnedBefore(sliver);
+    final double extentOfPinnedSlivers = maxScrollObstructionExtentBefore(sliver);
     leadingScrollOffset = scrollOffsetOf(sliver, leadingScrollOffset);
     switch (sliver.constraints.growthDirection) {
       case GrowthDirection.forward:
@@ -590,14 +590,14 @@ abstract class RenderViewportBase<ParentDataClass extends ContainerParentDataMix
   @protected
   double scrollOffsetOf(RenderSliver child, double scrollOffsetWithinChild);
 
-  /// Returns the total paint extent of all slivers that are pinned at the edge
+  /// Returns the total scroll obstruction extent of all slivers in theild].
   /// of the viewport before [child].
   ///
-  /// This is the extent to which the actual area in which content can scroll
+  /// This is the extent by which the actual area in which content can scroll
   /// is reduced. For example, an app bar that is pinned at the top will reduce
   /// the are in which content can actually scroll by the height of the app bar.
   @protected
-  double paintExtentOfSliversPinnedBefore(RenderSliver child);
+  double maxScrollObstructionExtentBefore(RenderSliver child);
 
   /// Converts the `parentMainAxisPosition` into the child's coordinate system.
   ///
@@ -1022,7 +1022,7 @@ class RenderViewport extends RenderViewportBase<SliverPhysicalContainerParentDat
   }
 
   @override
-  double paintExtentOfSliversPinnedBefore(RenderSliver child) {
+  double maxScrollObstructionExtentBefore(RenderSliver child) {
     assert(child.parent == this);
     final GrowthDirection growthDirection = child.constraints.growthDirection;
     assert(growthDirection != null);
@@ -1031,7 +1031,7 @@ class RenderViewport extends RenderViewportBase<SliverPhysicalContainerParentDat
         double pinnedExtent = 0.0;
         RenderSliver current = center;
         while (current != child) {
-          pinnedExtent += current.geometry.maxPinnedExtent;
+          pinnedExtent += current.geometry.maxScrollObstructionExtent;
           current = childAfter(current);
         }
         return pinnedExtent;
@@ -1039,7 +1039,7 @@ class RenderViewport extends RenderViewportBase<SliverPhysicalContainerParentDat
         double pinnedExtent = 0.0;
         RenderSliver current = childBefore(center);
         while (current != child) {
-          pinnedExtent += current.geometry.maxPinnedExtent;
+          pinnedExtent += current.geometry.maxScrollObstructionExtent;
           current = childBefore(current);
         }
         return pinnedExtent;
@@ -1331,13 +1331,13 @@ class RenderShrinkWrappingViewport extends RenderViewportBase<SliverLogicalConta
   }
 
   @override
-  double paintExtentOfSliversPinnedBefore(RenderSliver child) {
+  double maxScrollObstructionExtentBefore(RenderSliver child) {
     assert(child.parent == this);
     assert(child.constraints.growthDirection == GrowthDirection.forward);
     double pinnedExtent = 0.0;
     RenderSliver current = firstChild;
     while (current != child) {
-      pinnedExtent += current.geometry.maxPinnedExtent;
+      pinnedExtent += current.geometry.maxScrollObstructionExtent;
       current = childAfter(current);
     }
     return pinnedExtent;

--- a/packages/flutter/lib/src/rendering/viewport.dart
+++ b/packages/flutter/lib/src/rendering/viewport.dart
@@ -458,7 +458,7 @@ abstract class RenderViewportBase<ParentDataClass extends ContainerParentDataMix
     assert(child.parent == this);
     assert(child is RenderSliver);
     final RenderSliver sliver = child;
-    final double extendOfPinnedSlivers = paintExtendOfSliversPinnedBefore(sliver);
+    final double extendOfPinnedSlivers = paintExtentOfSliversPinnedBefore(sliver);
     leadingScrollOffset = scrollOffsetOf(sliver, leadingScrollOffset);
     switch (sliver.constraints.growthDirection) {
       case GrowthDirection.forward:
@@ -597,7 +597,7 @@ abstract class RenderViewportBase<ParentDataClass extends ContainerParentDataMix
   /// is reduced. For example, an app bar that is pinned at the top will reduce
   /// the are in which content can actually scroll by the height of the app bar.
   @protected
-  double paintExtendOfSliversPinnedBefore(RenderSliver child);
+  double paintExtentOfSliversPinnedBefore(RenderSliver child);
 
   /// Converts the `parentMainAxisPosition` into the child's coordinate system.
   ///
@@ -1022,27 +1022,27 @@ class RenderViewport extends RenderViewportBase<SliverPhysicalContainerParentDat
   }
 
   @override
-  double paintExtendOfSliversPinnedBefore(RenderSliver child) {
+  double paintExtentOfSliversPinnedBefore(RenderSliver child) {
     assert(child.parent == this);
     final GrowthDirection growthDirection = child.constraints.growthDirection;
     assert(growthDirection != null);
     switch (growthDirection) {
       case GrowthDirection.forward:
-        double pinnedExtend = 0.0;
+        double pinnedExtent = 0.0;
         RenderSliver current = center;
         while (current != child) {
-          pinnedExtend += current.geometry.maxPinnedExtent;
+          pinnedExtent += current.geometry.maxPinnedExtent;
           current = childAfter(current);
         }
-        return pinnedExtend;
+        return pinnedExtent;
       case GrowthDirection.reverse:
-        double pinnedExtend = 0.0;
+        double pinnedExtent = 0.0;
         RenderSliver current = childBefore(center);
         while (current != child) {
-          pinnedExtend += current.geometry.maxPinnedExtent;
+          pinnedExtent += current.geometry.maxPinnedExtent;
           current = childBefore(current);
         }
-        return pinnedExtend;
+        return pinnedExtent;
     }
     return null;
   }
@@ -1331,16 +1331,16 @@ class RenderShrinkWrappingViewport extends RenderViewportBase<SliverLogicalConta
   }
 
   @override
-  double paintExtendOfSliversPinnedBefore(RenderSliver child) {
+  double paintExtentOfSliversPinnedBefore(RenderSliver child) {
     assert(child.parent == this);
     assert(child.constraints.growthDirection == GrowthDirection.forward);
-    double pinnedExtend = 0.0;
+    double pinnedExtent = 0.0;
     RenderSliver current = firstChild;
     while (current != child) {
-      pinnedExtend += current.geometry.maxPinnedExtent;
+      pinnedExtent += current.geometry.maxPinnedExtent;
       current = childAfter(current);
     }
-    return pinnedExtend;
+    return pinnedExtent;
   }
 
   @override

--- a/packages/flutter/lib/src/rendering/viewport.dart
+++ b/packages/flutter/lib/src/rendering/viewport.dart
@@ -458,11 +458,11 @@ abstract class RenderViewportBase<ParentDataClass extends ContainerParentDataMix
     assert(child.parent == this);
     assert(child is RenderSliver);
     final RenderSliver sliver = child;
-    final double extendOfPinnedSlivers = paintExtentOfSliversPinnedBefore(sliver);
+    final double extentOfPinnedSlivers = paintExtentOfSliversPinnedBefore(sliver);
     leadingScrollOffset = scrollOffsetOf(sliver, leadingScrollOffset);
     switch (sliver.constraints.growthDirection) {
       case GrowthDirection.forward:
-        leadingScrollOffset -= extendOfPinnedSlivers;
+        leadingScrollOffset -= extentOfPinnedSlivers;
         break;
       case GrowthDirection.reverse:
         // Nothing to do.
@@ -472,10 +472,10 @@ abstract class RenderViewportBase<ParentDataClass extends ContainerParentDataMix
     double mainAxisExtent;
     switch (axis) {
       case Axis.horizontal:
-        mainAxisExtent = size.width - extendOfPinnedSlivers;
+        mainAxisExtent = size.width - extentOfPinnedSlivers;
         break;
       case Axis.vertical:
-        mainAxisExtent = size.height - extendOfPinnedSlivers;
+        mainAxisExtent = size.height - extentOfPinnedSlivers;
         break;
     }
 
@@ -590,7 +590,7 @@ abstract class RenderViewportBase<ParentDataClass extends ContainerParentDataMix
   @protected
   double scrollOffsetOf(RenderSliver child, double scrollOffsetWithinChild);
 
-  /// Returns the total paint extend of all slivers that are pinned at the edge
+  /// Returns the total paint extent of all slivers that are pinned at the edge
   /// of the viewport before [child].
   ///
   /// This is the extent to which the actual area in which content can scroll

--- a/packages/flutter/lib/src/rendering/viewport.dart
+++ b/packages/flutter/lib/src/rendering/viewport.dart
@@ -458,7 +458,7 @@ abstract class RenderViewportBase<ParentDataClass extends ContainerParentDataMix
     assert(child.parent == this);
     assert(child is RenderSliver);
     final RenderSliver sliver = child;
-    final double extendOfPinnedSlivers = paintExtendOfSliversPinnedAtEdgeBefore(sliver);
+    final double extendOfPinnedSlivers = paintExtendOfSliversPinnedBefore(sliver);
     leadingScrollOffset = scrollOffsetOf(sliver, leadingScrollOffset);
     switch (sliver.constraints.growthDirection) {
       case GrowthDirection.forward:
@@ -590,14 +590,14 @@ abstract class RenderViewportBase<ParentDataClass extends ContainerParentDataMix
   @protected
   double scrollOffsetOf(RenderSliver child, double scrollOffsetWithinChild);
 
-  /// Returns the total paint extend of all slivers that are pinned before
-  /// [child].
+  /// Returns the total paint extend of all slivers that are pinned at the edge
+  /// of the viewport before [child].
   ///
   /// This is the extent to which the actual area in which content can scroll
   /// is reduced. For example, an app bar that is pinned at the top will reduce
   /// the are in which content can actually scroll by the height of the app bar.
   @protected
-  double paintExtendOfSliversPinnedAtEdgeBefore(RenderSliver child);
+  double paintExtendOfSliversPinnedBefore(RenderSliver child);
 
   /// Converts the `parentMainAxisPosition` into the child's coordinate system.
   ///
@@ -1022,7 +1022,7 @@ class RenderViewport extends RenderViewportBase<SliverPhysicalContainerParentDat
   }
 
   @override
-  double paintExtendOfSliversPinnedAtEdgeBefore(RenderSliver child) {
+  double paintExtendOfSliversPinnedBefore(RenderSliver child) {
     assert(child.parent == this);
     final GrowthDirection growthDirection = child.constraints.growthDirection;
     assert(growthDirection != null);
@@ -1331,7 +1331,7 @@ class RenderShrinkWrappingViewport extends RenderViewportBase<SliverLogicalConta
   }
 
   @override
-  double paintExtendOfSliversPinnedAtEdgeBefore(RenderSliver child) {
+  double paintExtendOfSliversPinnedBefore(RenderSliver child) {
     assert(child.parent == this);
     assert(child.constraints.growthDirection == GrowthDirection.forward);
     double pinnedExtend = 0.0;

--- a/packages/flutter/test/widgets/scrollable_semantics_test.dart
+++ b/packages/flutter/test/widgets/scrollable_semantics_test.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
@@ -61,6 +62,124 @@ void main() {
     await tester.pump(const Duration(seconds: 5));
 
     expect(scrollController.offset, 0.0);
+  });
+
+  testWidgets('showOnScreen works with pinned app bar and sliver list', (WidgetTester tester) async {
+    new SemanticsTester(tester); // enables semantics tree generation
+
+    const double kItemHeight = 100.0;
+    const double kExpandedAppBarHeight = 56.0;
+
+    final List<Widget> containers = <Widget>[];
+    for (int i = 0; i < 80; i++)
+      containers.add(new MergeSemantics(child: new Container(
+        height: kItemHeight,
+        child: new Text('container $i'),
+      )));
+
+    final ScrollController scrollController = new ScrollController(
+      initialScrollOffset: kItemHeight / 2,
+    );
+
+    await tester.pumpWidget(new MediaQuery(
+      data: new MediaQueryData(),
+        child: new Scrollable(
+        controller: scrollController,
+        viewportBuilder: (BuildContext context, ViewportOffset offset) {
+          return new Viewport(
+            offset: offset,
+            slivers: <Widget>[
+              new SliverAppBar(
+                pinned: true,
+                expandedHeight: kExpandedAppBarHeight,
+                flexibleSpace: const FlexibleSpaceBar(
+                  title: const Text('App Bar'),
+                ),
+              ),
+              new SliverList(
+                delegate: new SliverChildListDelegate(containers),
+              )
+            ],
+          );
+        }),
+      ),
+    );
+
+    expect(scrollController.offset, kItemHeight / 2);
+
+    final int firstContainerId = tester.renderObject(find.byWidget(containers.first)).debugSemantics.id;
+    tester.binding.pipelineOwner.semanticsOwner.performAction(firstContainerId, SemanticsAction.showOnScreen);
+    await tester.pump();
+    await tester.pump(const Duration(seconds: 5));
+    expect(tester.getTopLeft(find.byWidget(containers.first)).dy, kExpandedAppBarHeight);
+
+    final int secondContainerId = tester.renderObject(find.byWidget(containers[1])).debugSemantics.id;
+    tester.binding.pipelineOwner.semanticsOwner.performAction(secondContainerId, SemanticsAction.showOnScreen);
+    await tester.pump();
+    await tester.pump(const Duration(seconds: 5));
+    expect(tester.getTopLeft(find.byWidget(containers[1])).dy, kExpandedAppBarHeight);
+  });
+
+  testWidgets('showOnScreen works with pinned app bar and individual slivers', (WidgetTester tester) async {
+    new SemanticsTester(tester); // enables semantics tree generation
+
+    const double kItemHeight = 100.0;
+    const double kExpandedAppBarHeight = 256.0;
+
+
+    final List<Widget> semantics = <Widget>[];
+    final List<Widget> slivers = new List<Widget>.generate(30, (int i) {
+      final Widget child = new MergeSemantics(
+        child: new Container(
+          child: new Text('Item $i'),
+          height: 72.0,
+        ),
+      );
+      semantics.add(child);
+      return new SliverToBoxAdapter(
+        child: child,
+      );
+    });
+
+    final ScrollController scrollController = new ScrollController(
+      initialScrollOffset: kItemHeight / 2,
+    );
+
+    await tester.pumpWidget(new MediaQuery(
+      data: new MediaQueryData(),
+      child: new Scrollable(
+        controller: scrollController,
+        viewportBuilder: (BuildContext context, ViewportOffset offset) {
+          return new Viewport(
+            offset: offset,
+            slivers: <Widget>[
+              new SliverAppBar(
+                pinned: true,
+                expandedHeight: kExpandedAppBarHeight,
+                flexibleSpace: const FlexibleSpaceBar(
+                  title: const Text('App Bar'),
+                ),
+              ),
+            ]..addAll(slivers),
+          );
+        },
+      ),
+    ),
+    );
+
+    expect(scrollController.offset, kItemHeight / 2);
+
+    final int id0 = tester.renderObject(find.byWidget(semantics[0])).debugSemantics.id;
+    tester.binding.pipelineOwner.semanticsOwner.performAction(id0, SemanticsAction.showOnScreen);
+    await tester.pump();
+    await tester.pump(const Duration(seconds: 5));
+    expect(tester.getTopLeft(find.byWidget(semantics[0])).dy, kToolbarHeight);
+
+    final int id1 = tester.renderObject(find.byWidget(semantics[1])).debugSemantics.id;
+    tester.binding.pipelineOwner.semanticsOwner.performAction(id1, SemanticsAction.showOnScreen);
+    await tester.pump();
+    await tester.pump(const Duration(seconds: 5));
+    expect(tester.getTopLeft(find.byWidget(semantics[1])).dy, kToolbarHeight);
   });
 }
 

--- a/packages/flutter/test/widgets/scrollable_semantics_test.dart
+++ b/packages/flutter/test/widgets/scrollable_semantics_test.dart
@@ -81,7 +81,9 @@ void main() {
       initialScrollOffset: kItemHeight / 2,
     );
 
-    await tester.pumpWidget(new MediaQuery(
+    await tester.pumpWidget(new Directionality(
+      textDirection: TextDirection.ltr,
+      child: new MediaQuery(
       data: new MediaQueryData(),
         child: new Scrollable(
         controller: scrollController,
@@ -103,7 +105,7 @@ void main() {
           );
         }),
       ),
-    );
+    ));
 
     expect(scrollController.offset, kItemHeight / 2);
 
@@ -145,27 +147,29 @@ void main() {
       initialScrollOffset: kItemHeight / 2,
     );
 
-    await tester.pumpWidget(new MediaQuery(
-      data: new MediaQueryData(),
-      child: new Scrollable(
-        controller: scrollController,
-        viewportBuilder: (BuildContext context, ViewportOffset offset) {
-          return new Viewport(
-            offset: offset,
-            slivers: <Widget>[
-              const SliverAppBar(
-                pinned: true,
-                expandedHeight: kExpandedAppBarHeight,
-                flexibleSpace: const FlexibleSpaceBar(
-                  title: const Text('App Bar'),
+    await tester.pumpWidget(new Directionality(
+      textDirection: TextDirection.ltr,
+      child:new MediaQuery(
+        data: new MediaQueryData(),
+        child: new Scrollable(
+          controller: scrollController,
+          viewportBuilder: (BuildContext context, ViewportOffset offset) {
+            return new Viewport(
+              offset: offset,
+              slivers: <Widget>[
+                const SliverAppBar(
+                  pinned: true,
+                  expandedHeight: kExpandedAppBarHeight,
+                  flexibleSpace: const FlexibleSpaceBar(
+                    title: const Text('App Bar'),
+                  ),
                 ),
-              ),
-            ]..addAll(slivers),
-          );
-        },
+              ]..addAll(slivers),
+            );
+          },
+        ),
       ),
-    ),
-    );
+    ));
 
     expect(scrollController.offset, kItemHeight / 2);
 

--- a/packages/flutter/test/widgets/scrollable_semantics_test.dart
+++ b/packages/flutter/test/widgets/scrollable_semantics_test.dart
@@ -89,7 +89,7 @@ void main() {
           return new Viewport(
             offset: offset,
             slivers: <Widget>[
-              new SliverAppBar(
+              const SliverAppBar(
                 pinned: true,
                 expandedHeight: kExpandedAppBarHeight,
                 flexibleSpace: const FlexibleSpaceBar(
@@ -153,7 +153,7 @@ void main() {
           return new Viewport(
             offset: offset,
             slivers: <Widget>[
-              new SliverAppBar(
+              const SliverAppBar(
                 pinned: true,
                 expandedHeight: kExpandedAppBarHeight,
                 flexibleSpace: const FlexibleSpaceBar(

--- a/packages/flutter/test/widgets/scrollable_semantics_test.dart
+++ b/packages/flutter/test/widgets/scrollable_semantics_test.dart
@@ -84,7 +84,7 @@ void main() {
     await tester.pumpWidget(new Directionality(
       textDirection: TextDirection.ltr,
       child: new MediaQuery(
-      data: new MediaQueryData(),
+      data: const MediaQueryData(),
         child: new Scrollable(
         controller: scrollController,
         viewportBuilder: (BuildContext context, ViewportOffset offset) {
@@ -150,7 +150,7 @@ void main() {
     await tester.pumpWidget(new Directionality(
       textDirection: TextDirection.ltr,
       child:new MediaQuery(
-        data: new MediaQueryData(),
+        data: const MediaQueryData(),
         child: new Scrollable(
           controller: scrollController,
           viewportBuilder: (BuildContext context, ViewportOffset offset) {


### PR DESCRIPTION
If a Sliver can potentially be pinned at the edge of a viewport, getOffsetToReveal will take that into account and scroll further up/down to ensure that the object to reveal doesn't end up covered by a pinned sliver.

This is important for accessibility scrolling with app bars.

Since how much a pinned sliver is covering is dynamic (it can change with scroll offset, etc), getOffsetToReveal deals with the worst case and tries to ensure that the object to uncover is visible when the pinned slivers are at their max pinned extent.