### PR TITLE
Fix localizations so that extract_messages is happy.

### DIFF
--- a/packages/flutter/lib/src/widgets/localizations.dart
+++ b/packages/flutter/lib/src/widgets/localizations.dart
@@ -289,9 +289,9 @@ class Localizations extends StatefulWidget {
     @required this.locale,
     @required this.delegates,
     this.child,
-  }) : assert(locale != null),
-       assert(delegates != null),
-       super(key: key) {
+  }) : super(key: key) {
+    assert(locale != null);
+    assert(delegates != null);
     assert(delegates.any((LocalizationsDelegate<dynamic> delegate) => delegate is LocalizationsDelegate<WidgetsLocalizations>));
   }
 


### PR DESCRIPTION
extract_messages script currently fails to parse this file because of its use of static asserts, super and a ctr body. Since we already have an assert in the body, I think it is also more readable to put all of them together. _LocalizationScope follows the same pattern above.