### PR TITLE
Bugfix in build test: ensure prev snapshot exists

### DIFF
--- a/packages/flutter_tools/test/base/build_test.dart
+++ b/packages/flutter_tools/test/base/build_test.dart
@@ -340,6 +340,7 @@ void main() {
 
       await fs.file('main.dart').writeAsString('void main() {}');
       await fs.file('other.dart').writeAsString('void main() { print("Kanpai ima kimi wa jinsei no ookina ookina butai ni tachi"); }');
+      await fs.file('output.snapshot').create();
       await fs.file('output.snapshot.d').writeAsString('output.snapshot : main.dart');
       await fs.file('output.snapshot.d.checksums').writeAsString(JSON.encode(<String, dynamic>{
         'version': '$kVersion',


### PR DESCRIPTION
Fix a test for build invalidation due to a change in main entry point.
Previously this test's build was always invalidated to the the lack of a
previous snapshot (as well as the change in checksums). This change
ensures that the build is invalidated only due to the change in
checksums.