### PR TITLE
Invalidate snapshot when entrypoint changes

### DIFF
--- a/packages/flutter_tools/lib/src/commands/build_aot.dart
+++ b/packages/flutter_tools/lib/src/commands/build_aot.dart
@@ -297,7 +297,7 @@ Future<String> _buildAotSnapshot(
       final Set<String> snapshotInputPaths = await readDepfile(dependencies)
         ..add(mainPath)
         ..addAll(outputPaths);
-      final Checksum newChecksum = new Checksum.fromFiles(snapshotType, snapshotInputPaths);
+      final Checksum newChecksum = new Checksum.fromFiles(snapshotType, mainPath, snapshotInputPaths);
       if (oldChecksum == newChecksum) {
         printStatus('Skipping AOT snapshot build. Checksums match.');
         return outputPath;
@@ -375,7 +375,7 @@ Future<String> _buildAotSnapshot(
     final Set<String> snapshotInputPaths = await readDepfile(dependencies)
       ..add(mainPath)
       ..addAll(outputPaths);
-    final Checksum checksum = new Checksum.fromFiles(snapshotType, snapshotInputPaths);
+    final Checksum checksum = new Checksum.fromFiles(snapshotType, mainPath, snapshotInputPaths);
     await checksumFile.writeAsString(checksum.toJson());
   } catch (e, s) {
     // Log exception and continue, this step is a performance improvement only.


### PR DESCRIPTION
Adds the app entrypoint as a key in the checksum file.

This change eliminates the assumption that checksummed files change when
the main entrypoint changes. In the case where there are two
entrypoints, a.dart and b.dart and a.dart imports b.dart and b.dart
imports a.dart, building the app with entrypoint a.dart followed by a
build of the app with entrypoint b.dart would result in the same
files list and checksums, but should invalidate the build.