### PR TITLE
Move host build check until it's actually used.

### DIFF
--- a/packages/flutter_tools/lib/src/compile.dart
+++ b/packages/flutter_tools/lib/src/compile.dart
@@ -20,7 +20,9 @@ String _dartExecutable() {
     Artifact.engineDartSdkPath
   );
   if (!fs.isDirectorySync(engineDartSdkPath)) {
-    throwToolExit('No dart sdk Flutter host engine build found at $engineDartSdkPath.', exitCode: 2);
+    throwToolExit('No dart sdk Flutter host engine build found at $engineDartSdkPath.\n'
+      'Note that corresponding host engine build is required even when targeting particular device platforms.',
+      exitCode: 2);
   }
   return fs.path.join(engineDartSdkPath, 'bin', 'dart');
 }

--- a/packages/flutter_tools/lib/src/compile.dart
+++ b/packages/flutter_tools/lib/src/compile.dart
@@ -5,6 +5,7 @@
 import 'dart:async';
 import 'dart:convert';
 
+import 'package:flutter_tools/src/base/common.dart';
 import 'package:flutter_tools/src/base/process_manager.dart';
 import 'package:usage/uuid/uuid.dart';
 
@@ -18,6 +19,9 @@ String _dartExecutable() {
   final String engineDartSdkPath = artifacts.getArtifactPath(
     Artifact.engineDartSdkPath
   );
+  if (!fs.isDirectorySync(engineDartSdkPath)) {
+    throwToolExit('No dart sdk Flutter host engine build found at $engineDartSdkPath.', exitCode: 2);
+  }
   return fs.path.join(engineDartSdkPath, 'bin', 'dart');
 }
 

--- a/packages/flutter_tools/lib/src/runner/flutter_command_runner.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command_runner.dart
@@ -336,9 +336,6 @@ class FlutterCommandRunner extends CommandRunner<Null> {
 
     final String hostLocalEngine = 'host_' + localEngine.substring(localEngine.indexOf('_') + 1);
     final String engineHostBuildPath = fs.path.normalize(fs.path.join(enginePath, 'out', hostLocalEngine));
-    if (!fs.isDirectorySync(engineHostBuildPath)) {
-      throwToolExit('No Flutter host engine build found at $engineHostBuildPath.', exitCode: 2);
-    }
 
     return new EngineBuildPaths(targetEngine: engineBuildPath, hostEngine: engineHostBuildPath);
   }


### PR DESCRIPTION
host build with dart sdk is used only for debug build with `--preview-dart-2` option. So this PR moves the check whether `host-` build folder exists when using local engine until it actually used, so that if you don't use `--preview-dart-2` option, you don't actually have to have `host-` build done locally.