### PR TITLE
Update DevToolsSecurity doctor message

### DIFF
--- a/packages/flutter_tools/lib/src/ios/ios_workflow.dart
+++ b/packages/flutter_tools/lib/src/ios/ios_workflow.dart
@@ -91,7 +91,7 @@ class IOSWorkflow extends DoctorValidator implements Workflow {
         xcodeStatus = ValidationType.partial;
         messages.add(new ValidationMessage.error(
           'Your Mac needs to enabled for developer mode before using Xcode for the first time.\n'
-          'Run \'sudo DevToolsSecurity -enable\' or open Xcode'
+          'Run \'sudo DevToolsSecurity -enable\' to enable developer mode.'
         ));
       }
 


### PR DESCRIPTION
Opening Xcode is no longer sufficient to enable develop mode in Xcode 9.
Update the message to run the command-line tool. Alternatively users can
launch an app in the Xcode debugger to do this.