### PR TITLE
Update minimum ios-deploy version to 1.9.2

### DIFF
--- a/packages/flutter_tools/lib/src/ios/ios_workflow.dart
+++ b/packages/flutter_tools/lib/src/ios/ios_workflow.dart
@@ -34,7 +34,7 @@ class IOSWorkflow extends DoctorValidator implements Workflow {
 
   Future<bool> get hasIosDeploy => exitsHappyAsync(<String>['ios-deploy', '--version']);
 
-  String get iosDeployMinimumVersion => '1.9.0';
+  String get iosDeployMinimumVersion => '1.9.2';
 
   Future<String> get iosDeployVersionText async => (await runAsync(<String>['ios-deploy', '--version'])).processResult.stdout.replaceAll('\n', '');
 

--- a/packages/flutter_tools/test/ios/ios_workflow_test.dart
+++ b/packages/flutter_tools/test/ios/ios_workflow_test.dart
@@ -296,7 +296,7 @@ class IOSWorkflowTestTarget extends IOSWorkflow {
     this.hasPythonSixModule: true,
     this.hasHomebrew: true,
     bool hasIosDeploy: true,
-    String iosDeployVersionText: '1.9.0',
+    String iosDeployVersionText: '1.9.2',
     bool hasIDeviceInstaller: true,
     String macDevMode: 'Developer mode is already enabled.',
   }) : hasIosDeploy = new Future<bool>.value(hasIosDeploy),


### PR DESCRIPTION
ios-deploy 1.9.2 includes fixes for a common source of Xcode breakage
(flutter/flutter#4326) with Xcode 8.3.3 + iOS 10.3.3, and is required to
to support Xcode 9 (flutter/flutter#11875).