### PR TITLE
Log checksum validation errors at trace level

### DIFF
--- a/packages/flutter_tools/lib/src/base/build.dart
+++ b/packages/flutter_tools/lib/src/base/build.dart
@@ -248,9 +248,9 @@ class Snapshotter {
         final Checksum newChecksum = new Checksum.fromFiles(type, mainPath, checksumPaths);
         return oldChecksum != newChecksum;
       }
-    } catch (e, s) {
+    } catch (e) {
       // Log exception and continue, this step is a performance improvement only.
-      printTrace('Error during snapshot checksum output: $e\n$s');
+      printTrace('Rebuilding snapshot due to checksum validation error: $e');
     }
     return true;
   }
@@ -263,7 +263,7 @@ class Snapshotter {
       await fs.file(checksumsPath).writeAsString(checksum.toJson());
     } catch (e, s) {
       // Log exception and continue, this step is a performance improvement only.
-      print('Error during snapshot checksum output: $e\n$s');
+      printTrace('Error during snapshot checksum output: $e\n$s');
     }
   }
 }

--- a/packages/flutter_tools/lib/src/commands/build_aot.dart
+++ b/packages/flutter_tools/lib/src/commands/build_aot.dart
@@ -299,12 +299,12 @@ Future<String> _buildAotSnapshot(
         ..addAll(outputPaths);
       final Checksum newChecksum = new Checksum.fromFiles(snapshotType, mainPath, snapshotInputPaths);
       if (oldChecksum == newChecksum) {
-        printStatus('Skipping AOT snapshot build. Checksums match.');
+        printTrace('Skipping AOT snapshot build. Checksums match.');
         return outputPath;
       }
-    } catch (e, s) {
+    } catch (e) {
       // Log exception and continue, this step is a performance improvement only.
-      printStatus('Error during AOT snapshot checksum check: $e\n$s');
+      printTrace('Rebuilding snapshot due to checksum validation error: $e');
     }
   }
 
@@ -379,7 +379,7 @@ Future<String> _buildAotSnapshot(
     await checksumFile.writeAsString(checksum.toJson());
   } catch (e, s) {
     // Log exception and continue, this step is a performance improvement only.
-    printStatus('Error during AOT snapshot checksum output: $e\n$s');
+    printTrace('Error during AOT snapshot checksum output: $e\n$s');
   }
 
   return outputPath;


### PR DESCRIPTION
Checksum validation is intended only as a performance improvement.
Checksum de-serialization errors (typically framework version mismatch) are
expected on framework updates and shouldn't be user-visible except for
informational purposes when --verbose is set.