### PR TITLE
Make an app's supported locales configurable

### DIFF
--- a/examples/stocks/lib/main.dart
+++ b/examples/stocks/lib/main.dart
@@ -121,6 +121,10 @@ class StocksAppState extends State<StocksApp> {
       localizationsDelegates: <_StocksLocalizationsDelegate>[
         new _StocksLocalizationsDelegate(),
       ],
+      supportedLocales: const <Locale>[
+        const Locale('en', 'US'),
+        const Locale('es', 'ES'),
+      ],
       debugShowMaterialGrid: _configuration.debugShowGrid,
       showPerformanceOverlay: _configuration.showPerformanceOverlay,
       showSemanticsDebugger: _configuration.showSemanticsDebugger,

--- a/packages/flutter/lib/src/material/app.dart
+++ b/packages/flutter/lib/src/material/app.dart
@@ -94,7 +94,7 @@ class MaterialApp extends StatefulWidget {
     this.onUnknownRoute,
     this.locale,
     this.localizationsDelegates,
-    this.resolveLocaleCallback,
+    this.localeResolutionCallback,
     this.supportedLocales: const <Locale>[const Locale('en', 'US')],
     this.navigatorObservers: const <NavigatorObserver>[],
     this.debugShowMaterialGrid: false,
@@ -251,12 +251,12 @@ class MaterialApp extends StatefulWidget {
   ///
   /// If the callback is null then the resolved locale is:
   /// - The callback's `locale` parameter if it's equal to a supported locale.
-  /// - The first supported locale with the same [Locale.langaugeCode] as the
+  /// - The first supported locale with the same [Locale.languageCode] as the
   ///   callback's `locale` parameter.
   /// - The first supported locale.
   ///
   /// This callback is passed along to the [WidgetsApp] built by this widget.
-  final ResolveLocaleCallback resolveLocaleCallback;
+  final LocaleResolutionCallback localeResolutionCallback;
 
   /// The list of locales that this app has been localized for.
   ///
@@ -266,6 +266,32 @@ class MaterialApp extends StatefulWidget {
   /// This list must not null. It's default value is just
   /// `[const Locale('en', 'US')]`. It is simply passed along to the
   /// [WidgetsApp] built by this widget.
+  ///
+  /// The order of the list matters. By default, if the device's locale doesn't
+  /// exactly match a locale in [supportedLocales] then the first locale in
+  /// [supportedLocales] with a matching [Locale.languageCode] is used. If that
+  /// fails then the first locale in [supportedLocales] is used. The default
+  /// locale resolution algorithm can be overridden with [localeResolutionCallback].
+  ///
+  /// The material widgets include translations for locales with the following
+  /// language codes:
+  /// ```
+  /// ar - Arabic
+  /// de - German
+  /// en - English
+  /// es - Spanish
+  /// fa - Farsi (Persian)
+  /// fr - French
+  /// he - Hebrew
+  /// it - Italian
+  /// ja - Japanese
+  /// ps - Pashto
+  /// pt - Portugese
+  /// ru - Russian
+  /// sd - Sindhi
+  /// ur - Urdu
+  /// zh - Chinese (simplified)
+  /// ```
   final Iterable<Locale> supportedLocales;
 
   /// Turns on a performance overlay.
@@ -434,7 +460,7 @@ class _MaterialAppState extends State<MaterialApp> {
         onUnknownRoute: _onUnknownRoute,
         locale: widget.locale,
         localizationsDelegates: _localizationsDelegates,
-        resolveLocaleCallback: widget.resolveLocaleCallback,
+        localeResolutionCallback: widget.localeResolutionCallback,
         supportedLocales: widget.supportedLocales,
         showPerformanceOverlay: widget.showPerformanceOverlay,
         checkerboardRasterCacheImages: widget.checkerboardRasterCacheImages,

--- a/packages/flutter/lib/src/material/app.dart
+++ b/packages/flutter/lib/src/material/app.dart
@@ -94,7 +94,7 @@ class MaterialApp extends StatefulWidget {
     this.onUnknownRoute,
     this.locale,
     this.localizationsDelegates,
-    this.onLocaleChanged: defaultLocaleChangedHandler,
+    this.resolveLocaleCallback,
     this.supportedLocales: const <Locale>[const Locale('en', 'US')],
     this.navigatorObservers: const <NavigatorObserver>[],
     this.debugShowMaterialGrid: false,
@@ -240,20 +240,28 @@ class MaterialApp extends StatefulWidget {
   /// device's locale.
   ///
   /// The returned value becomes the locale of this app's [Localizations]
-  /// widget. The `oldLocale` parameter is null when the app starts. The
-  /// `newLocale` is the device's locale when the app started, or the
-  /// device locale the user selected after the app was started.
-  /// The `supportedLocales` parameter is just the value [supportedLocales].
+  /// widget. The callback's `locale` parameter is the device's locale when
+  /// the app started, or the device locale the user selected after the app was
+  /// started. The callback's `supportedLocales` parameter is just the value
+  /// [supportedLocales].
   ///
-  /// This callback must not be null. Its default value is
-  /// [defaultLocaleChangedHandler]. It is simply passed along to the
-  /// [WidgetsApp] built by this widget.
-  final LocaleChangedCallback onLocaleChanged;
+  /// An app could use this callback to substitute locales based on the app's
+  /// intended audience. If the device's OS provides a prioritized
+  /// list of locales, this callback could be used to defer to it.
+  ///
+  /// If the callback is null then the resolved locale is:
+  /// - The callback's `locale` parameter if it's equal to a supported locale.
+  /// - The first supported locale with the same [Locale.langaugeCode] as the
+  ///   callback's `locale` parameter.
+  /// - The first supported locale.
+  ///
+  /// This callback is passed along to the [WidgetsApp] built by this widget.
+  final ResolveLocaleCallback resolveLocaleCallback;
 
   /// The list of locales that this app has been localized for.
   ///
-  /// By default only the English locale is supported. Apps should configure
-  /// this list to match the locales they support.
+  /// By default only the American English locale is supported. Apps should
+  /// configure this list to match the locales they support.
   ///
   /// This list must not null. It's default value is just
   /// `[const Locale('en', 'US')]`. It is simply passed along to the
@@ -426,7 +434,7 @@ class _MaterialAppState extends State<MaterialApp> {
         onUnknownRoute: _onUnknownRoute,
         locale: widget.locale,
         localizationsDelegates: _localizationsDelegates,
-        onLocaleChanged: widget.onLocaleChanged,
+        resolveLocaleCallback: widget.resolveLocaleCallback,
         supportedLocales: widget.supportedLocales,
         showPerformanceOverlay: widget.showPerformanceOverlay,
         checkerboardRasterCacheImages: widget.checkerboardRasterCacheImages,

--- a/packages/flutter/lib/src/material/app.dart
+++ b/packages/flutter/lib/src/material/app.dart
@@ -94,6 +94,8 @@ class MaterialApp extends StatefulWidget {
     this.onUnknownRoute,
     this.locale,
     this.localizationsDelegates,
+    this.onLocaleChanged: defaultLocaleChangedHandler,
+    this.supportedLocales: const <Locale>[const Locale('en', 'US')],
     this.navigatorObservers: const <NavigatorObserver>[],
     this.debugShowMaterialGrid: false,
     this.showPerformanceOverlay: false,
@@ -232,6 +234,31 @@ class MaterialApp extends StatefulWidget {
   /// The delegates collectively define all of the localized resources
   /// for this application's [Localizations] widget.
   final Iterable<LocalizationsDelegate<dynamic>> localizationsDelegates;
+
+  /// This callback is responsible for choosing the app's locale
+  /// when the app is started, and when the user changes the
+  /// device's locale.
+  ///
+  /// The returned value becomes the locale of this app's [Localizations]
+  /// widget. The `oldLocale` parameter is null when the app starts. The
+  /// `newLocale` is the device's locale when the app started, or the
+  /// device locale the user selected after the app was started.
+  /// The `supportedLocales` parameter is just the value [supportedLocales].
+  ///
+  /// This callback must not be null. Its default value is
+  /// [defaultLocaleChangedHandler]. It is simply passed along to the
+  /// [WidgetsApp] built by this widget.
+  final LocaleChangedCallback onLocaleChanged;
+
+  /// The list of locales that this app has been localized for.
+  ///
+  /// By default only the English locale is supported. Apps should configure
+  /// this list to match the locales they support.
+  ///
+  /// This list must not null. It's default value is just
+  /// `[const Locale('en', 'US')]`. It is simply passed along to the
+  /// [WidgetsApp] built by this widget.
+  final Iterable<Locale> supportedLocales;
 
   /// Turns on a performance overlay.
   ///
@@ -399,6 +426,8 @@ class _MaterialAppState extends State<MaterialApp> {
         onUnknownRoute: _onUnknownRoute,
         locale: widget.locale,
         localizationsDelegates: _localizationsDelegates,
+        onLocaleChanged: widget.onLocaleChanged,
+        supportedLocales: widget.supportedLocales,
         showPerformanceOverlay: widget.showPerformanceOverlay,
         checkerboardRasterCacheImages: widget.checkerboardRasterCacheImages,
         checkerboardOffscreenLayers: widget.checkerboardOffscreenLayers,

--- a/packages/flutter/lib/src/widgets/app.dart
+++ b/packages/flutter/lib/src/widgets/app.dart
@@ -84,7 +84,7 @@ class WidgetsApp extends StatefulWidget {
   ///
   /// The `supportedLocales` argument must be a list of one or more elements.
   /// By default supportedLocales is `[const Locale('en', 'US')]`.
-  const WidgetsApp({
+  WidgetsApp({ // can't be const because the asserts use methods on Iterable :-(
     Key key,
     @required this.onGenerateRoute,
     this.onUnknownRoute,
@@ -108,7 +108,7 @@ class WidgetsApp extends StatefulWidget {
        assert(color != null),
        assert(navigatorObservers != null),
        assert(onLocaleChanged != null),
-       assert(supportedLocales != null),
+       assert(supportedLocales != null && supportedLocales.isNotEmpty),
        assert(showPerformanceOverlay != null),
        assert(checkerboardRasterCacheImages != null),
        assert(checkerboardOffscreenLayers != null),
@@ -310,7 +310,6 @@ class _WidgetsAppState extends State<WidgetsApp> implements WidgetsBindingObserv
   void initState() {
     super.initState();
     _navigator = new GlobalObjectKey<NavigatorState>(this);
-    assert(widget.supportedLocales.isNotEmpty);
     _locale = widget.onLocaleChanged(null, ui.window.locale, widget.supportedLocales);
     WidgetsBinding.instance.addObserver(this);
   }

--- a/packages/flutter/lib/src/widgets/app.dart
+++ b/packages/flutter/lib/src/widgets/app.dart
@@ -76,8 +76,14 @@ class WidgetsApp extends StatefulWidget {
   /// Creates a widget that wraps a number of widgets that are commonly
   /// required for an application.
   ///
-  /// The boolean arguments, [color], [navigatorObservers], and
-  /// [onGenerateRoute] must not be null.
+  /// The boolean arguments, `color`, `navigatorObservers`, and
+  /// `onGenerateRoute` must not be null.
+  ///
+  /// The `onLocaleChanged` argument must not be null. Its default value
+  /// is [defaultLocaleChangeHandler].
+  ///
+  /// The `supportedLocales` argument must be a list of one or more elements.
+  /// By default supportedLocales is `[const Locale('en', 'US')]`.
   const WidgetsApp({
     Key key,
     @required this.onGenerateRoute,
@@ -304,6 +310,7 @@ class _WidgetsAppState extends State<WidgetsApp> implements WidgetsBindingObserv
   void initState() {
     super.initState();
     _navigator = new GlobalObjectKey<NavigatorState>(this);
+    assert(widget.supportedLocales.isNotEmpty);
     _locale = widget.onLocaleChanged(null, ui.window.locale, widget.supportedLocales);
     WidgetsBinding.instance.addObserver(this);
   }

--- a/packages/flutter/lib/src/widgets/app.dart
+++ b/packages/flutter/lib/src/widgets/app.dart
@@ -23,16 +23,16 @@ import 'widget_inspector.dart';
 
 export 'dart:ui' show Locale;
 
-/// The signature of [WidgetsApp.resolveLocaleCallback].
+/// The signature of [WidgetsApp.localeResolutionCallback].
 ///
-/// A `ResolveLocaleCallback` is responsible for computing the locale of the app's
+/// A `LocaleResolutionCallback` is responsible for computing the locale of the app's
 /// [Localizations] object when the app starts and when user changes the default
 /// locale for the device.
 ///
 /// The `locale` is the device's locale when the app started, or the device
 /// locale the user selected after the app was started. The `supportedLocales`
 /// parameter is just the value of [WidgetApp.supportedLocales].
-typedef Locale ResolveLocaleCallback(Locale locale, Iterable<Locale> supportedLocales);
+typedef Locale LocaleResolutionCallback(Locale locale, Iterable<Locale> supportedLocales);
 
 // Delegate that fetches the default (English) strings.
 class _WidgetsLocalizationsDelegate extends LocalizationsDelegate<WidgetsLocalizations> {
@@ -77,7 +77,7 @@ class WidgetsApp extends StatefulWidget {
     this.initialRoute,
     this.locale,
     this.localizationsDelegates,
-    this.resolveLocaleCallback,
+    this.localeResolutionCallback,
     this.supportedLocales: const <Locale>[const Locale('en', 'US')],
     this.showPerformanceOverlay: false,
     this.checkerboardRasterCacheImages: false,
@@ -177,6 +177,7 @@ class WidgetsApp extends StatefulWidget {
   /// [supportedLocales].
   ///
   /// If the callback is null or if it returns null then the resolved locale is:
+  ///
   /// - The callback's `locale` parameter if it's equal to a supported locale.
   /// - The first supported locale with the same [Locale.langaugeCode] as the
   ///   callback's `locale` parameter.
@@ -184,9 +185,9 @@ class WidgetsApp extends StatefulWidget {
   ///
   /// See also:
   ///
-  ///  * [MaterialApp.resolveLocaleCallback], which sets the callback of the
+  ///  * [MaterialApp.localeResolutionCallback], which sets the callback of the
   ///    [WidgetsApp] it creates.
-  final ResolveLocaleCallback resolveLocaleCallback;
+  final LocaleResolutionCallback localeResolutionCallback;
 
   /// The list of locales that this app has been localized for.
   ///
@@ -197,17 +198,17 @@ class WidgetsApp extends StatefulWidget {
   /// `[const Locale('en', 'US')]`.
   ///
   /// The order of the list matters. By default, if the device's locale doesn't
-  /// exactly match a supported locale then the first supported locale with a
-  /// matching [Locale.languageCode] is used. If that fails then the first
-  /// supported locale is used. The default locale resolution algorithm can
-  /// be overridden with [resolveLocaleCallback].
+  /// exactly match a locale in [supportedLocales] then the first locale in
+  /// [supportedLocales] with a matching [Locale.languageCode] is used. If that
+  /// fails then the first locale in [supportedLocales] is used. The default
+  /// locale resolution algorithm can be overridden with [localeResolutionCallback].
   ///
   /// See also:
   ///
   ///  * [MaterialApp.supportedLocales], which sets the `supportedLocales`
   ///    of the [WidgetsApp] it creates.
   ///
-  ///  * [resolveLocaleCallback], an app callback that resolves the app's locale
+  ///  * [localeResolutionCallback], an app callback that resolves the app's locale
   ///    when the device's locale changes.
   ///
   ///  * [localizationDelegates], which collectively define all of the localized
@@ -297,8 +298,8 @@ class _WidgetsAppState extends State<WidgetsApp> implements WidgetsBindingObserv
   Locale _locale;
 
   Locale _resolveLocale(Locale newLocale, Iterable<Locale> supportedLocales) {
-    if (widget.resolveLocaleCallback != null) {
-      final Locale locale = widget.resolveLocaleCallback(newLocale, widget.supportedLocales);
+    if (widget.localeResolutionCallback != null) {
+      final Locale locale = widget.localeResolutionCallback(newLocale, widget.supportedLocales);
       if (locale != null)
         return locale;
     }

--- a/packages/flutter/lib/src/widgets/app.dart
+++ b/packages/flutter/lib/src/widgets/app.dart
@@ -180,7 +180,7 @@ class WidgetsApp extends StatefulWidget {
   /// - The callback's `locale` parameter if it's equal to a supported locale.
   /// - The first supported locale with the same [Locale.langaugeCode] as the
   ///   callback's `locale` parameter.
-  /// - The first supported locale.
+  /// - The first locale in [supportedLocales].
   ///
   /// See also:
   ///

--- a/packages/flutter/test/material/localizations_test.dart
+++ b/packages/flutter/test/material/localizations_test.dart
@@ -12,6 +12,10 @@ Widget buildFrame({
   return new MaterialApp(
     color: const Color(0xFFFFFFFF),
     locale: locale,
+    supportedLocales: const <Locale>[
+      const Locale('en', 'US'),
+      const Locale('es', 'es'),
+    ],
     onGenerateRoute: (RouteSettings settings) {
       return new MaterialPageRoute<Null>(
         builder: (BuildContext context) {
@@ -39,15 +43,16 @@ void main() {
 
     expect(tester.widget<Text>(find.byKey(textKey)).data, 'Back');
 
+    // Unrecognized locale falls back to 'en'
+    await tester.binding.setLocale('foo', 'bar');
+    await tester.pump();
+    expect(tester.widget<Text>(find.byKey(textKey)).data, 'Back');
+
     // Spanish Bolivia locale, falls back to just 'es'
     await tester.binding.setLocale('es', 'bo');
     await tester.pump();
     expect(tester.widget<Text>(find.byKey(textKey)).data, 'Espalda');
 
-    // Unrecognized locale falls back to 'en'
-    await tester.binding.setLocale('foo', 'bar');
-    await tester.pump();
-    expect(tester.widget<Text>(find.byKey(textKey)).data, 'Back');
   });
 
   testWidgets('translations exist for all materia/i18n languages', (WidgetTester tester) async {

--- a/packages/flutter/test/widgets/localizations_test.dart
+++ b/packages/flutter/test/widgets/localizations_test.dart
@@ -107,7 +107,7 @@ Widget buildFrame({
   Locale locale,
   Iterable<LocalizationsDelegate<dynamic>> delegates,
   WidgetBuilder buildContent,
-  LocaleChangedCallback onLocaleChanged: defaultLocaleChangedHandler,
+  ResolveLocaleCallback resolveLocaleCallback,
   List<Locale> supportedLocales: const <Locale>[
     const Locale('en', 'US'),
     const Locale('en', 'GB'),
@@ -117,7 +117,7 @@ Widget buildFrame({
     color: const Color(0xFFFFFFFF),
     locale: locale,
     localizationsDelegates: delegates,
-    onLocaleChanged: onLocaleChanged,
+    resolveLocaleCallback: resolveLocaleCallback,
     supportedLocales: supportedLocales,
     onGenerateRoute: (RouteSettings settings) {
       return new PageRouteBuilder<Null>(
@@ -449,10 +449,10 @@ void main() {
     expect(Directionality.of(pageContext), TextDirection.rtl);
   });
 
-  testWidgets('onLocaleChanged override', (WidgetTester tester) async {
+  testWidgets('resolveLocaleCallback override', (WidgetTester tester) async {
     await tester.pumpWidget(
       buildFrame(
-        onLocaleChanged: (Locale oldLocale, Locale newLocale, Iterable<Locale> supportedLocales) {
+        resolveLocaleCallback: (Locale newLocale, Iterable<Locale> supportedLocales) {
           return const Locale('foo', 'BAR');
         },
         buildContent: (BuildContext context) {
@@ -474,7 +474,7 @@ void main() {
     await tester.pumpWidget(
       buildFrame(
         supportedLocales: const <Locale>[
-          const Locale('zh', 'cn'),
+          const Locale('zh', 'CN'),
           const Locale('en', 'GB'),
           const Locale('en', 'CA'),
         ],
@@ -487,7 +487,7 @@ void main() {
     // Startup time. Default test locale is const Locale('', ''), so
     // no supported matches. Use the first locale.
     await tester.pumpAndSettle();
-    expect(find.text('zh_cn'), findsOneWidget);
+    expect(find.text('zh_CN'), findsOneWidget);
 
     // defaultLocaleChangedHandler prefers exact supported locale match
     await tester.binding.setLocale('en', 'CA');
@@ -499,10 +499,10 @@ void main() {
     await tester.pumpAndSettle();
     expect(find.text('en_GB'), findsOneWidget);
 
-    // defaultLocaleChangedHandler: no matching supported locale, so no change
+    // defaultLocaleChangedHandler: no matching supported locale, so use the 1st one
     await tester.binding.setLocale('da', 'DA');
     await tester.pumpAndSettle();
-    expect(find.text('en_GB'), findsOneWidget);
+    expect(find.text('zh_CN'), findsOneWidget);
   });
 }
 

--- a/packages/flutter/test/widgets/localizations_test.dart
+++ b/packages/flutter/test/widgets/localizations_test.dart
@@ -107,11 +107,18 @@ Widget buildFrame({
   Locale locale,
   Iterable<LocalizationsDelegate<dynamic>> delegates,
   WidgetBuilder buildContent,
+  LocaleChangedCallback onLocaleChanged: defaultLocaleChangedHandler,
+  List<Locale> supportedLocales: const <Locale>[
+    const Locale('en', 'US'),
+    const Locale('en', 'GB'),
+  ],
 }) {
   return new WidgetsApp(
     color: const Color(0xFFFFFFFF),
     locale: locale,
     localizationsDelegates: delegates,
+    onLocaleChanged: onLocaleChanged,
+    supportedLocales: supportedLocales,
     onGenerateRoute: (RouteSettings settings) {
       return new PageRouteBuilder<Null>(
         pageBuilder: (BuildContext context, Animation<double> _, Animation<double> __) {
@@ -182,7 +189,7 @@ void main() {
     );
 
     expect(TestLocalizations.of(pageContext), isNotNull);
-    expect(find.text('_'), findsOneWidget); // default test locale is '_'
+    expect(find.text('en_US'), findsOneWidget);
 
     await tester.binding.setLocale('en', 'GB');
     await tester.pump();
@@ -205,25 +212,25 @@ void main() {
       )
     );
     await tester.pump(const Duration(milliseconds: 50)); // TestLocalizations.loadAsync() takes 100ms
-    expect(find.text('_'), findsNothing); // TestLocalizations hasn't been loaded yet
+    expect(find.text('en_US'), findsNothing); // TestLocalizations hasn't been loaded yet
 
     await tester.pump(const Duration(milliseconds: 50)); // TestLocalizations.loadAsync() completes
     await tester.pumpAndSettle();
-    expect(find.text('_'), findsOneWidget); // default test locale is '_'
-
-    await tester.binding.setLocale('en', 'US');
-    await tester.pump(const Duration(milliseconds: 100));
-    await tester.pumpAndSettle();
-    expect(find.text('en_US'), findsOneWidget);
+    expect(find.text('en_US'), findsOneWidget); // default test locale is US english
 
     await tester.binding.setLocale('en', 'GB');
+    await tester.pump(const Duration(milliseconds: 100));
+    await tester.pumpAndSettle();
+    expect(find.text('en_GB'), findsOneWidget);
+
+    await tester.binding.setLocale('en', 'US');
     await tester.pump(const Duration(milliseconds: 50));
     // TestLocalizations.loadAsync() hasn't completed yet so the old text
     // localization is still displayed
-    expect(find.text('en_US'), findsOneWidget);
+    expect(find.text('en_GB'), findsOneWidget);
     await tester.pump(const Duration(milliseconds: 50)); // finish the async load
     await tester.pumpAndSettle();
-    expect(find.text('en_GB'), findsOneWidget);
+    expect(find.text('en_US'), findsOneWidget);
   });
 
   testWidgets('Localizations with multiple sync delegates', (WidgetTester tester) async {
@@ -422,6 +429,10 @@ void main() {
 
     await tester.pumpWidget(
       buildFrame(
+        supportedLocales: const <Locale>[
+          const Locale('en', 'GB'),
+          const Locale('ar', 'EG'),
+        ],
         buildContent: (BuildContext context) {
           pageContext = context;
           return const Text('Hello World');
@@ -436,6 +447,62 @@ void main() {
     await tester.binding.setLocale('ar', 'EG');
     await tester.pump();
     expect(Directionality.of(pageContext), TextDirection.rtl);
+  });
+
+  testWidgets('onLocaleChanged override', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      buildFrame(
+        onLocaleChanged: (Locale oldLocale, Locale newLocale, Iterable<Locale> supportedLocales) {
+          return const Locale('foo', 'BAR');
+        },
+        buildContent: (BuildContext context) {
+          return new Text(Localizations.localeOf(context).toString());
+        }
+      )
+    );
+
+    await tester.pumpAndSettle();
+    expect(find.text('foo_BAR'), findsOneWidget);
+
+    await tester.binding.setLocale('en', 'GB');
+    await tester.pumpAndSettle();
+    expect(find.text('foo_BAR'), findsOneWidget);
+  });
+
+
+  testWidgets('supportedLocales and defaultLocaleChangeHandler', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      buildFrame(
+        supportedLocales: const <Locale>[
+          const Locale('zh', 'cn'),
+          const Locale('en', 'GB'),
+          const Locale('en', 'CA'),
+        ],
+        buildContent: (BuildContext context) {
+          return new Text(Localizations.localeOf(context).toString());
+        }
+      )
+    );
+
+    // Startup time. Default test locale is const Locale('', ''), so
+    // no supported matches. Use the first locale.
+    await tester.pumpAndSettle();
+    expect(find.text('zh_cn'), findsOneWidget);
+
+    // defaultLocaleChangedHandler prefers exact supported locale match
+    await tester.binding.setLocale('en', 'CA');
+    await tester.pumpAndSettle();
+    expect(find.text('en_CA'), findsOneWidget);
+
+    // defaultLocaleChangedHandler chooses 1st matching supported locale.languageCode
+    await tester.binding.setLocale('en', 'US');
+    await tester.pumpAndSettle();
+    expect(find.text('en_GB'), findsOneWidget);
+
+    // defaultLocaleChangedHandler: no matching supported locale, so no change
+    await tester.binding.setLocale('da', 'DA');
+    await tester.pumpAndSettle();
+    expect(find.text('en_GB'), findsOneWidget);
   });
 }
 

--- a/packages/flutter/test/widgets/localizations_test.dart
+++ b/packages/flutter/test/widgets/localizations_test.dart
@@ -107,7 +107,7 @@ Widget buildFrame({
   Locale locale,
   Iterable<LocalizationsDelegate<dynamic>> delegates,
   WidgetBuilder buildContent,
-  ResolveLocaleCallback resolveLocaleCallback,
+  LocaleResolutionCallback localeResolutionCallback,
   List<Locale> supportedLocales: const <Locale>[
     const Locale('en', 'US'),
     const Locale('en', 'GB'),
@@ -117,7 +117,7 @@ Widget buildFrame({
     color: const Color(0xFFFFFFFF),
     locale: locale,
     localizationsDelegates: delegates,
-    resolveLocaleCallback: resolveLocaleCallback,
+    localeResolutionCallback: localeResolutionCallback,
     supportedLocales: supportedLocales,
     onGenerateRoute: (RouteSettings settings) {
       return new PageRouteBuilder<Null>(
@@ -449,10 +449,10 @@ void main() {
     expect(Directionality.of(pageContext), TextDirection.rtl);
   });
 
-  testWidgets('resolveLocaleCallback override', (WidgetTester tester) async {
+  testWidgets('localeResolutionCallback override', (WidgetTester tester) async {
     await tester.pumpWidget(
       buildFrame(
-        resolveLocaleCallback: (Locale newLocale, Iterable<Locale> supportedLocales) {
+        localeResolutionCallback: (Locale newLocale, Iterable<Locale> supportedLocales) {
           return const Locale('foo', 'BAR');
         },
         buildContent: (BuildContext context) {


### PR DESCRIPTION
The WidgetsApp chooses its Localization widget's locale upon startup and when the user changes the device's locale. The locale is selected by the app's onLocaleChanged callback:

```
Locale LocaleChangedCallback(Locale oldLocale, Locale newLocale, Iterable<Locale> supportedLocales);
```

Apps provide a `supportedLocales` list that's passed to the onLocaleChanged callback. The defaultLocaleChangeHandler returns:
- The first supported locale that matches `newLocale` exactly.
- The first supported locale whose language code matches `newLocale.languageCode`.
- The non-null `oldLocale` (`oldLocale` is null at startup)
- The first supported locale

A custom onLocaleChangedCallback can make app-specific tradeoffs vis the device's locale (`newLocale`) and the existing app locale (`oldLocale`).

The default value for `supportedLocales` is `[const Locale('en', 'US')]`.

