### PR TITLE
Selectively apply margin between middle and leading

### DIFF
--- a/packages/flutter/lib/src/widgets/navigation_toolbar.dart
+++ b/packages/flutter/lib/src/widgets/navigation_toolbar.dart
@@ -141,7 +141,7 @@ class _ToolbarLayout extends MultiChildLayoutDelegate {
       final BoxConstraints constraints = new BoxConstraints.loose(size).copyWith(maxWidth: maxWidth);
       final Size middleSize = layoutChild(_ToolbarSlot.middle, constraints);
 
-      final double middleStartMargin = leadingWidth + _kMiddleMargin;
+      final double middleStartMargin = hasChild(_ToolbarSlot.leading) ? leadingWidth + _kMiddleMargin : 0.0;
       double middleStart = middleStartMargin;
       final double middleY = (size.height - middleSize.height) / 2.0;
       // If the centered middle will not fit between the leading and trailing

--- a/packages/flutter/test/material/app_bar_test.dart
+++ b/packages/flutter/test/material/app_bar_test.dart
@@ -157,7 +157,7 @@ void main() {
     expect(center.dx, lessThan(400 + size.width / 2.0));
   });
 
-  testWidgets('AppBar centerTitle:false title start edge is 16.0 (LTR)', (WidgetTester tester) async {
+  testWidgets('AppBar centerTitle:false title start edge is 0.0 (LTR)', (WidgetTester tester) async {
     await tester.pumpWidget(
       new MaterialApp(
         home: new Scaffold(
@@ -169,10 +169,10 @@ void main() {
       ),
     );
 
-    expect(tester.getTopLeft(find.text('X')).dx, 16.0);
+    expect(tester.getTopLeft(find.text('X')).dx, 0.0);
   });
 
-  testWidgets('AppBar centerTitle:false title start edge is 16.0 (RTL)', (WidgetTester tester) async {
+  testWidgets('AppBar centerTitle:false title start edge is 0.0 (RTL)', (WidgetTester tester) async {
     await tester.pumpWidget(
       new MaterialApp(
         home: new Directionality(
@@ -187,7 +187,7 @@ void main() {
       ),
     );
 
-    expect(tester.getTopRight(find.text('X')).dx, 800.0 - 16.0);
+    expect(tester.getTopRight(find.text('X')).dx, 800.0);
   });
 
   testWidgets(


### PR DESCRIPTION
If ToolbarLayout does not have a leading widget, we should not put a margin between leading and middle areas since it ends up being blank space that looks odd. Fixes https://github.com/flutter/flutter/issues/11963