### PR TITLE
Engine artifacts used for snapshots also specified as build inputs

### DIFF
--- a/packages/flutter_tools/gradle/flutter.gradle
+++ b/packages/flutter_tools/gradle/flutter.gradle
@@ -406,6 +406,9 @@ class FlutterTask extends BaseFlutterTask {
             if (snapshotter != null) {
                 sources = sources.plus(snapshotter)
             }
+            if (localEngineSrcPath != null) {
+                sources = sources.plus(project.files("$localEngineSrcPath/$localEngine"))
+            }
             // Finally, add a dependency on pubspec.yaml as well.
             return sources.plus(project.files('pubspec.yaml'))
         }

--- a/packages/flutter_tools/lib/src/base/build.dart
+++ b/packages/flutter_tools/lib/src/base/build.dart
@@ -51,7 +51,6 @@ class GenSnapshot {
       '--dependencies=$depfilePath',
       '--print_snapshot_sizes',
     ]..addAll(additionalArgs);
-
     final String snapshotterPath = artifacts.getArtifactPath(Artifact.genSnapshot, snapshotType.platform, snapshotType.mode);
     return runCommandAndStreamOutput(<String>[snapshotterPath]..addAll(args));
   }
@@ -250,7 +249,7 @@ class Snapshotter {
       await fs.file(fingerprintPath).writeAsString(fingerprint.toJson());
     } catch (e, s) {
       // Log exception and continue, this step is a performance improvement only.
-      print('Error during snapshot fingerprinting: $e\n$s');
+      printStatus('Error during snapshot fingerprinting: $e\n$s');
     }
   }
 
@@ -260,6 +259,9 @@ class Snapshotter {
       'targetPlatform': type.platform?.toString() ?? '',
       'entryPoint': mainPath,
     };
-    return new Fingerprint.fromBuildInputs(properties, inputFilePaths);
+    final List<String> pathsWithSnapshotData = inputFilePaths.toList()
+      ..add(artifacts.getArtifactPath(Artifact.vmSnapshotData))
+      ..add(artifacts.getArtifactPath(Artifact.isolateSnapshotData));
+    return new Fingerprint.fromBuildInputs(properties, pathsWithSnapshotData);
   }
 }

--- a/packages/flutter_tools/test/base/build_test.dart
+++ b/packages/flutter_tools/test/base/build_test.dart
@@ -323,7 +323,7 @@ void main() {
     Snapshotter snapshotter;
     MockArtifacts mockArtifacts;
 
-    setUp(()  {
+    setUp(() {
       fs = new MemoryFileSystem();
       fs.file(kIsolateSnapshotData).writeAsStringSync('snapshot data');
       fs.file(kVmSnapshotData).writeAsStringSync('vm data');


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/11977

Gradle and snapshot rebuild logic did not take change in these artifacts into account and could miss a necessary snapshot rebuild.

Unit test suite cleanup.