### PR TITLE
Seems like a lint was renamed.

### DIFF
--- a/packages/flutter/lib/analysis_options_user.yaml
+++ b/packages/flutter/lib/analysis_options_user.yaml
@@ -85,7 +85,7 @@ linter:
     # - type_annotate_public_apis # subset of always_specify_types
     - type_init_formals
     # - unawaited_futures
-    - unnecessary_brace_in_string_interp
+    - unnecessary_brace_in_string_interps
     - unnecessary_getters_setters
 
     # === pub rules ===

--- a/packages/flutter_tools/templates/create/lib/main.dart.tmpl
+++ b/packages/flutter_tools/templates/create/lib/main.dart.tmpl
@@ -108,7 +108,7 @@ class _MyHomePageState extends State<MyHomePage> {
               'You have pushed the button this many times:',
             ),
             new Text(
-              '${_counter}',
+              '$_counter',
               style: Theme.of(context).textTheme.display1,
             ),
           ],


### PR DESCRIPTION
Lint `- unnecessary_brace_in_string_interp` is not in the list here: http://dart-lang.github.io/linter/lints/

In linter [0.1.2](https://github.com/dart-lang/linter/blob/9652dd44b6b32d5c8fc0262f67e037842ef207cc/CHANGELOG.md#012): [unnecessary_brace_in_string_interp](http://dart-lang.github.io/linter/lints/unnecessary_brace_in_string_interp.html)
In linter [0.1.30](https://github.com/dart-lang/linter/blob/9652dd44b6b32d5c8fc0262f67e037842ef207cc/CHANGELOG.md#0130): [unnecessary_brace_in_string_interps](http://dart-lang.github.io/linter/lints/unnecessary_brace_in_string_interps.html)