### PR TITLE
Remove trailing comma from assert

### DIFF
--- a/packages/flutter/lib/src/cupertino/nav_bar.dart
+++ b/packages/flutter/lib/src/cupertino/nav_bar.dart
@@ -116,7 +116,7 @@ class CupertinoNavigationBar extends StatelessWidget implements PreferredSizeWid
   Widget build(BuildContext context) {
     assert(
       !largeTitle || middle is Text,
-      "largeTitle mode is only possible when 'middle' is a Text widget",
+      "largeTitle mode is only possible when 'middle' is a Text widget"
     );
 
     if (!largeTitle) {


### PR DESCRIPTION
Fix 'red' test - Dart 2.0 Frontend doesn't allow trailing commas, which is more strict than analyzer.