### PR TITLE
Retry when pub fails in flutter tool.

### DIFF
--- a/bin/flutter
+++ b/bin/flutter
@@ -87,7 +87,12 @@ FLUTTER_TOOL_ARGS="--assert-initializer $FLUTTER_TOOL_ARGS"
       LOCAL_PUB_ENV="$LOCAL_PUB_ENV:flutter_bot"
     fi
     LOCAL_PUB_ENV="$LOCAL_PUB_ENV:flutter_install"
-    (cd "$FLUTTER_TOOLS_DIR"; PUB_ENVIRONMENT=$LOCAL_PUB_ENV "$PUB" upgrade --verbosity=error --no-packages-dir)
+    while : ; do
+      cd "$FLUTTER_TOOLS_DIR"
+      PUB_ENVIRONMENT="$LOCAL_PUB_ENV" "$PUB" upgrade --verbosity=error --no-packages-dir && break
+      echo Error: Unable to 'pub upgrade' flutter tool. Retrying in five seconds...
+      sleep 5
+    done
     "$DART" --snapshot="$SNAPSHOT_PATH" --packages="$FLUTTER_TOOLS_DIR/.packages" "$SCRIPT_PATH"
     echo $REVISION > "$STAMP_PATH"
   fi

--- a/bin/flutter.bat
+++ b/bin/flutter.bat
@@ -108,7 +108,7 @@ GOTO :after_subroutine
       :retry_pub_upgrade
       CALL "%pub%" upgrade --verbosity=error --no-packages-dir
       IF "%ERRORLEVEL%" NEQ "0" (
-        ECHO Error: Unable to 'pub upgrade' flutter tool. Retrying...
+        ECHO Error: Unable to 'pub upgrade' flutter tool. Retrying in five seconds...
         timeout /t 5 /nobreak
         GOTO :retry_pub_upgrade
       )


### PR DESCRIPTION
This ports the five-second retry interval from flutter.bat to the Bash
version. Failures during "pub get" of the flutter tool are common on
Travis and so this should help Travis reliability if nothing else.