### PR TITLE
Update GeneratedPluginRegistrant.java to latest version

### DIFF
--- a/examples/flutter_gallery/android/app/src/main/java/io/flutter/plugins/GeneratedPluginRegistrant.java
+++ b/examples/flutter_gallery/android/app/src/main/java/io/flutter/plugins/GeneratedPluginRegistrant.java
@@ -1,13 +1,13 @@
 package io.flutter.plugins;
 
 import io.flutter.plugin.common.PluginRegistry;
-import io.flutter.plugins.urllauncher.UrlLauncherPlugin;
+import io.flutter.plugins.url_launcher.UrlLauncherPlugin;
 
 /**
  * Generated file. Do not edit.
  */
 public final class GeneratedPluginRegistrant {
   public static void registerWith(PluginRegistry registry) {
-    UrlLauncherPlugin.registerWith(registry.registrarFor("io.flutter.plugins.urllauncher.UrlLauncherPlugin"));
+    UrlLauncherPlugin.registerWith(registry.registrarFor("io.flutter.plugins.url_launcher.UrlLauncherPlugin"));
   }
 }


### PR DESCRIPTION
Running the `flutter_gallery` example marks GeneratedPluginRegistrant.java as modified.

Updated GeneratedPluginRegistrant.java to latest version to avoid to mark a clean repository as modified after a `flutter run`.