### PR TITLE
Localizations overrides

### DIFF
--- a/dev/tools/gen_localizations.dart
+++ b/dev/tools/gen_localizations.dart
@@ -75,8 +75,9 @@ String generateLocalizationsMap() {
 /// This variable is used by [MaterialLocalizations].
 const Map<String, Map<String, String>> localizations = const <String, Map<String, String>> {''');
 
-  final String lastLocale = localeToResources.keys.last;
-  for (String locale in localeToResources.keys.toList()..sort()) {
+  final List<String> sortedLocales = localeToResources.keys.toList()..sort();
+  final String lastLocale = sortedLocales.last;
+  for (String locale in sortedLocales) {
     output.writeln('  "$locale": const <String, String>{');
 
     final Map<String, String> resources = localeToResources[locale];

--- a/dev/tools/gen_localizations.dart
+++ b/dev/tools/gen_localizations.dart
@@ -75,20 +75,15 @@ String generateLocalizationsMap() {
 /// This variable is used by [MaterialLocalizations].
 const Map<String, Map<String, String>> localizations = const <String, Map<String, String>> {''');
 
-  final List<String> sortedLocales = localeToResources.keys.toList()..sort();
-  final String lastLocale = sortedLocales.last;
-  for (String locale in sortedLocales) {
+  for (String locale in localeToResources.keys.toList()..sort()) {
     output.writeln('  "$locale": const <String, String>{');
 
     final Map<String, String> resources = localeToResources[locale];
-    final String lastName = resources.keys.last;
     for (String name in resources.keys) {
-      final String comma = name == lastName ? "" : ",";
       final String value = generateString(resources[name]);
-      output.writeln('    "$name": $value$comma');
+      output.writeln('    "$name": $value,');
     }
-    final String comma = locale == lastLocale ? "" : ",";
-    output.writeln('  }$comma');
+    output.writeln('  },');
   }
 
   output.writeln('};');

--- a/packages/flutter/lib/src/material/app.dart
+++ b/packages/flutter/lib/src/material/app.dart
@@ -234,6 +234,55 @@ class MaterialApp extends StatefulWidget {
   ///
   /// The delegates collectively define all of the localized resources
   /// for this application's [Localizations] widget.
+  ///
+  /// Delegates that produce [WidgetsLocalizations] and [MaterialLocalizations]
+  /// are included automatically. Apps can provide their own versions of these
+  /// localizations by creating implementations of
+  /// [LocalizationsDelegate<WidgetLocalizations>] or
+  /// [LocalizationsDelegate<MaterialLocalizations>] whose load methods return
+  /// custom versions of [WidgetLocalizations] or [MaterialLocalizations].
+  ///
+  /// For example: to add support to [MaterialLocalizations] for a
+  /// locale it doesn't already support, say `const Locale('foo', 'BR')`,
+  /// one could just extend [DefaultMaterialLocalizations]:
+  /// ```
+  /// class FooLocalizations extends DefaultMaterialLocalizations {
+  ///   FooLocalizations(Locale locale) : super(locale);
+  ///   @override
+  ///   String get okButtonLabel {
+  ///     if (locale == const Locale('foo', 'BR'))
+  ///       return 'foo';
+  ///     return super.okButtonLabel;
+  ///   }
+  /// }
+  ///
+  /// ```
+  ///
+  /// A `FooLocalizationsDelegate` is essentially just a method that constructs
+  /// a `FooLocalizations` object. We return a [SynchronousFuture] here because
+  /// no asynchronous work takes place upon "loading" the localizations object.
+  /// ```
+  /// class FooLocalizationsDelegate extends LocalizationsDelegate<MaterialLocalizations> {
+  ///   const FooLocalizationsDelegate();
+  ///   @override
+  ///   Future<FooLocalizations> load(Locale locale) {
+  ///     return new SynchronousFuture(new FooLocalizations(locale));
+  ///   }
+  ///   @override
+  ///   bool shouldReload(FooLocalizationsDelegate old) => false;
+  /// }
+  /// ```
+  ///
+  /// Constructing a [MaterialApp] with a `FooLocalizationsDelegate` overrides
+  /// the automatically included delegate for [MaterialLocalizations].
+  /// ```
+  /// new MaterialApp(
+  ///   localizationsDelegates: [
+  ///     const FooLocalizationsDelegate(),
+  ///   ],
+  ///   // ...
+  /// )
+  /// ```
   final Iterable<LocalizationsDelegate<dynamic>> localizationsDelegates;
 
   /// This callback is responsible for choosing the app's locale
@@ -379,11 +428,14 @@ class _MaterialAppState extends State<MaterialApp> {
   }
 
   // Combine the Localizations for Material with the ones contributed
-  // by the localizationsDelegates parameter, if any.
+  // by the localizationsDelegates parameter, if any. Only the first delegate
+  // of a particular LocalizationsDelegate.type is loaded so the
+  // localizationsDelegate parameter can be used to override
+  // _MaterialLocalizationsDelegate.
   Iterable<LocalizationsDelegate<dynamic>> get _localizationsDelegates sync* {
-    yield const _MaterialLocalizationsDelegate(); // TODO(ianh): make this configurable
     if (widget.localizationsDelegates != null)
       yield* widget.localizationsDelegates;
+    yield const _MaterialLocalizationsDelegate();
   }
 
   RectTween _createRectTween(Rect begin, Rect end) {

--- a/packages/flutter/lib/src/material/app.dart
+++ b/packages/flutter/lib/src/material/app.dart
@@ -245,7 +245,8 @@ class MaterialApp extends StatefulWidget {
   /// For example: to add support to [MaterialLocalizations] for a
   /// locale it doesn't already support, say `const Locale('foo', 'BR')`,
   /// one could just extend [DefaultMaterialLocalizations]:
-  /// ```
+  ///
+  /// ```dart
   /// class FooLocalizations extends DefaultMaterialLocalizations {
   ///   FooLocalizations(Locale locale) : super(locale);
   ///   @override
@@ -261,7 +262,8 @@ class MaterialApp extends StatefulWidget {
   /// A `FooLocalizationsDelegate` is essentially just a method that constructs
   /// a `FooLocalizations` object. We return a [SynchronousFuture] here because
   /// no asynchronous work takes place upon "loading" the localizations object.
-  /// ```
+  ///
+  /// ```dart
   /// class FooLocalizationsDelegate extends LocalizationsDelegate<MaterialLocalizations> {
   ///   const FooLocalizationsDelegate();
   ///   @override
@@ -275,7 +277,8 @@ class MaterialApp extends StatefulWidget {
   ///
   /// Constructing a [MaterialApp] with a `FooLocalizationsDelegate` overrides
   /// the automatically included delegate for [MaterialLocalizations].
-  /// ```
+  ///
+  /// ```dart
   /// new MaterialApp(
   ///   localizationsDelegates: [
   ///     const FooLocalizationsDelegate(),

--- a/packages/flutter/lib/src/material/app.dart
+++ b/packages/flutter/lib/src/material/app.dart
@@ -276,7 +276,10 @@ class MaterialApp extends StatefulWidget {
   /// ```
   ///
   /// Constructing a [MaterialApp] with a `FooLocalizationsDelegate` overrides
-  /// the automatically included delegate for [MaterialLocalizations].
+  /// the automatically included delegate for [MaterialLocalizations] because
+  /// only the first delegate of each [LocalizationsDelegate.type] is used and
+  /// the automatically included delegates are added to the end of the app's
+  /// [localizationsDelegates] list.
   ///
   /// ```dart
   /// new MaterialApp(

--- a/packages/flutter/lib/src/material/i18n/localizations.dart
+++ b/packages/flutter/lib/src/material/i18n/localizations.dart
@@ -36,7 +36,7 @@ const Map<String, Map<String, String>> localizations = const <String, Map<String
     "selectAllButtonLabel": r"اختر الكل",
     "viewLicensesButtonLabel": r"عرض التراخيص",
     "anteMeridiemAbbreviation": r"ص",
-    "postMeridiemAbbreviation": r"م"
+    "postMeridiemAbbreviation": r"م",
   },
   "de": const <String, String>{
     "timeOfDayFormat": r"HH:mm",
@@ -63,7 +63,7 @@ const Map<String, Map<String, String>> localizations = const <String, Map<String
     "okButtonLabel": r"OK",
     "pasteButtonLabel": r"EINFÜGEN",
     "selectAllButtonLabel": r"ALLES AUSWÄHLEN",
-    "viewLicensesButtonLabel": r"LIZENZEN ANZEIGEN"
+    "viewLicensesButtonLabel": r"LIZENZEN ANZEIGEN",
   },
   "en": const <String, String>{
     "timeOfDayFormat": r"h:mm a",
@@ -92,16 +92,16 @@ const Map<String, Map<String, String>> localizations = const <String, Map<String
     "selectAllButtonLabel": r"SELECT ALL",
     "viewLicensesButtonLabel": r"VIEW LICENSES",
     "anteMeridiemAbbreviation": r"AM",
-    "postMeridiemAbbreviation": r"PM"
+    "postMeridiemAbbreviation": r"PM",
   },
   "en_GB": const <String, String>{
-    "timeOfDayFormat": r"HH:mm"
+    "timeOfDayFormat": r"HH:mm",
   },
   "en_IE": const <String, String>{
-    "timeOfDayFormat": r"HH:mm"
+    "timeOfDayFormat": r"HH:mm",
   },
   "en_ZA": const <String, String>{
-    "timeOfDayFormat": r"HH:mm"
+    "timeOfDayFormat": r"HH:mm",
   },
   "es": const <String, String>{
     "timeOfDayFormat": r"H:mm",
@@ -128,10 +128,10 @@ const Map<String, Map<String, String>> localizations = const <String, Map<String
     "okButtonLabel": r"OK",
     "pasteButtonLabel": r"PEGAR",
     "selectAllButtonLabel": r"SELECCIONAR TODO",
-    "viewLicensesButtonLabel": r"VER LICENCIAS"
+    "viewLicensesButtonLabel": r"VER LICENCIAS",
   },
   "es_US": const <String, String>{
-    "timeOfDayFormat": r"h:mm a"
+    "timeOfDayFormat": r"h:mm a",
   },
   "fa": const <String, String>{
     "timeOfDayFormat": r"H:mm",
@@ -156,7 +156,7 @@ const Map<String, Map<String, String>> localizations = const <String, Map<String
     "okButtonLabel": r"تایید",
     "pasteButtonLabel": r"چسباندن",
     "selectAllButtonLabel": r"انتخاب همه",
-    "viewLicensesButtonLabel": r"مشاهده مجوز"
+    "viewLicensesButtonLabel": r"مشاهده مجوز",
   },
   "fr": const <String, String>{
     "timeOfDayFormat": r"HH:mm",
@@ -183,10 +183,10 @@ const Map<String, Map<String, String>> localizations = const <String, Map<String
     "okButtonLabel": r"OK",
     "pasteButtonLabel": r"COLLER",
     "selectAllButtonLabel": r"TOUT SÉLECTIONNER",
-    "viewLicensesButtonLabel": r"AFFICHER LES LICENCES"
+    "viewLicensesButtonLabel": r"AFFICHER LES LICENCES",
   },
   "fr_CA": const <String, String>{
-    "timeOfDayFormat": r"HH 'h' mm"
+    "timeOfDayFormat": r"HH 'h' mm",
   },
   "he": const <String, String>{
     "timeOfDayFormat": r"H:mm",
@@ -211,7 +211,7 @@ const Map<String, Map<String, String>> localizations = const <String, Map<String
     "okButtonLabel": r"בסדר",
     "pasteButtonLabel": r"הדבק",
     "selectAllButtonLabel": r"בחר הכל",
-    "viewLicensesButtonLabel": r"ראה רישיונות"
+    "viewLicensesButtonLabel": r"ראה רישיונות",
   },
   "it": const <String, String>{
     "timeOfDayFormat": r"HH:mm",
@@ -236,7 +236,7 @@ const Map<String, Map<String, String>> localizations = const <String, Map<String
     "okButtonLabel": r"OK",
     "pasteButtonLabel": r"INCOLLA",
     "selectAllButtonLabel": r"SELEZIONA TUTTO",
-    "viewLicensesButtonLabel": r"VEDI LE LICENZE"
+    "viewLicensesButtonLabel": r"VEDI LE LICENZE",
   },
   "ja": const <String, String>{
     "timeOfDayFormat": r"H:mm",
@@ -261,7 +261,7 @@ const Map<String, Map<String, String>> localizations = const <String, Map<String
     "okButtonLabel": r"OK",
     "pasteButtonLabel": r"貼付け",
     "selectAllButtonLabel": r"全選択",
-    "viewLicensesButtonLabel": r"ライセンス表記"
+    "viewLicensesButtonLabel": r"ライセンス表記",
   },
   "ps": const <String, String>{
     "timeOfDayFormat": r"HH:mm",
@@ -286,7 +286,7 @@ const Map<String, Map<String, String>> localizations = const <String, Map<String
     "okButtonLabel": r"سمه ده",
     "pasteButtonLabel": r"پیټ کړئ",
     "selectAllButtonLabel": r"غوره کړئ",
-    "viewLicensesButtonLabel": r"لیدلس وګورئ"
+    "viewLicensesButtonLabel": r"لیدلس وګورئ",
   },
   "pt": const <String, String>{
     "timeOfDayFormat": r"HH:mm",
@@ -311,7 +311,7 @@ const Map<String, Map<String, String>> localizations = const <String, Map<String
     "okButtonLabel": r"OK",
     "pasteButtonLabel": r"COLAR",
     "selectAllButtonLabel": r"SELECIONAR TUDO",
-    "viewLicensesButtonLabel": r"VER LICENÇAS"
+    "viewLicensesButtonLabel": r"VER LICENÇAS",
   },
   "ru": const <String, String>{
     "timeOfDayFormat": r"H:mm",
@@ -336,7 +336,7 @@ const Map<String, Map<String, String>> localizations = const <String, Map<String
     "okButtonLabel": r"ОК",
     "pasteButtonLabel": r"Паст",
     "selectAllButtonLabel": r"Выбрать все",
-    "viewLicensesButtonLabel": r"ПРОСМОТРЕТЬ ЛИЦЕНЗИИ"
+    "viewLicensesButtonLabel": r"ПРОСМОТРЕТЬ ЛИЦЕНЗИИ",
   },
   "sd": const <String, String>{
     "timeOfDayFormat": r"HH:mm",
@@ -361,7 +361,7 @@ const Map<String, Map<String, String>> localizations = const <String, Map<String
     "okButtonLabel": r"ٺيڪ آهي",
     "pasteButtonLabel": r"پيسٽ ڪريو",
     "selectAllButtonLabel": r"سڀ چونڊيو",
-    "viewLicensesButtonLabel": r"لائسنس ڏسو"
+    "viewLicensesButtonLabel": r"لائسنس ڏسو",
   },
   "ur": const <String, String>{
     "timeOfDayFormat": r"h:mm a",
@@ -388,7 +388,7 @@ const Map<String, Map<String, String>> localizations = const <String, Map<String
     "selectAllButtonLabel": r"تکاپیمام منتخب کریں",
     "viewLicensesButtonLabel": r"لائسنس دیکھیں",
     "anteMeridiemAbbreviation": r"AM",
-    "postMeridiemAbbreviation": r"PM"
+    "postMeridiemAbbreviation": r"PM",
   },
   "zh": const <String, String>{
     "timeOfDayFormat": r"ah:mm",
@@ -415,6 +415,6 @@ const Map<String, Map<String, String>> localizations = const <String, Map<String
     "selectAllButtonLabel": r"全选",
     "viewLicensesButtonLabel": r"查看许可证",
     "anteMeridiemAbbreviation": r"上午",
-    "postMeridiemAbbreviation": r"下午"
-  }
+    "postMeridiemAbbreviation": r"下午",
+  },
 };

--- a/packages/flutter/lib/src/material/i18n/localizations.dart
+++ b/packages/flutter/lib/src/material/i18n/localizations.dart
@@ -4,7 +4,7 @@
 
 // This file has been automatically generated.  Please do not edit it manually.
 // To regenerate the file, use:
-// dart dev/tools/gen_localizations.dart lib/src/material/i18n material
+// dart dev/tools/gen_localizations.dart packages/flutter/lib/src/material/i18n material
 
 /// Maps from [Locale.languageCode] to a map that contains the localized strings
 /// for that locale.
@@ -393,7 +393,7 @@ const Map<String, Map<String, String>> localizations = const <String, Map<String
   "zh": const <String, String>{
     "timeOfDayFormat": r"ah:mm",
     "openAppDrawerTooltip": r"打开导航菜单",
-    "backButtonTooltip": r"背部",
+    "backButtonTooltip": r"返回",
     "closeButtonTooltip": r"关",
     "nextMonthTooltip": r"-下月就29了。",
     "previousMonthTooltip": r"前一个月",
@@ -418,4 +418,3 @@ const Map<String, Map<String, String>> localizations = const <String, Map<String
     "postMeridiemAbbreviation": r"下午"
   }
 };
-

--- a/packages/flutter/lib/src/material/i18n/material_zh.arb
+++ b/packages/flutter/lib/src/material/i18n/material_zh.arb
@@ -22,7 +22,6 @@
   "pasteButtonLabel": "粘贴",
   "selectAllButtonLabel": "全选",
   "viewLicensesButtonLabel": "查看许可证",
-  "backButtonTooltip": "背部",
   "closeButtonTooltip": "关",
   "nextMonthTooltip": "-下月就29了。",
   "previousMonthTooltip": "前一个月",

--- a/packages/flutter/lib/src/material/material_localizations.dart
+++ b/packages/flutter/lib/src/material/material_localizations.dart
@@ -116,24 +116,20 @@ class DefaultMaterialLocalizations implements MaterialLocalizations {
   ///
   /// [LocalizationsDelegate] implementations typically call the static [load]
   /// function, rather than constructing this class directly.
-  factory DefaultMaterialLocalizations(Locale locale) {
+  DefaultMaterialLocalizations(this.locale) {
     assert(locale != null);
 
-    final Map<String, String> result = <String, String>{};
     if (localizations.containsKey(locale.languageCode))
-      result.addAll(localizations[locale.languageCode]);
-    if (localizations.containsKey(locale.toString()))
-      result.addAll(localizations[locale.toString()]);
-    return new DefaultMaterialLocalizations._(locale, result);
+      _nameToValue.addAll(localizations[locale.languageCode]);
+    if (localizations.containsKey(_localeName))
+      _nameToValue.addAll(localizations[_localeName]);
   }
-
-  DefaultMaterialLocalizations._(this.locale, this._nameToValue);
 
   /// The locale for which the values of this class's localized resources
   /// have been translated.
   final Locale locale;
 
-  final Map<String, String> _nameToValue;
+  final Map<String, String> _nameToValue = <String, String>{};
 
   String get _localeName {
     final String localeName = locale.countryCode.isEmpty ? locale.languageCode : locale.toString();

--- a/packages/flutter/lib/src/widgets/app.dart
+++ b/packages/flutter/lib/src/widgets/app.dart
@@ -383,11 +383,14 @@ class _WidgetsAppState extends State<WidgetsApp> implements WidgetsBindingObserv
   }
 
   // Combine the Localizations for Widgets with the ones contributed
-  // by the localizationsDelegates parameter, if any.
+  // by the localizationsDelegates parameter, if any. Only the first delegate
+  // of a particular LocalizationsDelegate.type is loaded so the
+  // localizationsDelegate parameter can be used to override
+  // _WidgetsLocalizationsDelegate.
   Iterable<LocalizationsDelegate<dynamic>> get _localizationsDelegates sync* {
-    yield const _WidgetsLocalizationsDelegate(); // TODO(ianh): make this configurable
     if (widget.localizationsDelegates != null)
       yield* widget.localizationsDelegates;
+    yield const _WidgetsLocalizationsDelegate();
   }
 
   @override

--- a/packages/flutter/lib/src/widgets/localizations.dart
+++ b/packages/flutter/lib/src/widgets/localizations.dart
@@ -326,8 +326,8 @@ class Localizations extends StatefulWidget {
   /// Overrides the inherited [Locale] or [LocalizationsDelegate]s for `child`.
   ///
   /// This factory constructor is used for the - usually rare - situtation where part
-  /// of an app should be localized for a different locale then the one defined
-  /// for the device, or a different list of [LocalizationsDelegate]s then the
+  /// of an app should be localized for a different locale than the one defined
+  /// for the device, or a different list of [LocalizationsDelegate]s than the
   /// list defined by [WidgetsApp.localizationsDelegates].
   ///
   /// For example you could specify that `myWidget` was only to be localized for
@@ -343,7 +343,7 @@ class Localizations extends StatefulWidget {
   /// ```
   ///
   /// The `locale` and `delegates` parameters default to the [Localizations.locale]
-  /// and [Localizations.delegates] values of the nearest [Localizations] ancestor.
+  /// and [Localizations.delegates] values from the nearest [Localizations] ancestor.
   ///
   /// To override the [Localizations.locale] or [Localizations.delegates] for an
   /// entire app, specify [WidgetsApp.locale] or [WidgetsApp.localizationsDelegates]

--- a/packages/flutter/lib/src/widgets/localizations.dart
+++ b/packages/flutter/lib/src/widgets/localizations.dart
@@ -38,9 +38,19 @@ class _Pending {
 // This is more complicated than just applying Future.wait to input
 // because some of the input.values may be SynchronousFutures. We don't want
 // to Future.wait for the synchronous futures.
-Future<Map<Type, dynamic>> _loadAll(Locale locale, Iterable<LocalizationsDelegate<dynamic>> delegates) {
+Future<Map<Type, dynamic>> _loadAll(Locale locale, Iterable<LocalizationsDelegate<dynamic>> allDelegates) {
   final Map<Type, dynamic> output = <Type, dynamic>{};
   List<_Pending> pendingList;
+
+  // Only load the first delegate for each delgate type.
+  final Set<Type> types = new Set<Type>();
+  final List<LocalizationsDelegate<dynamic>> delegates = <LocalizationsDelegate<dynamic>>[];
+  for (LocalizationsDelegate<dynamic> delegate in allDelegates) {
+    if (!types.contains(delegate.type)) {
+      types.add(delegate.type);
+      delegates.add(delegate);
+    }
+  }
 
   for (LocalizationsDelegate<dynamic> delegate in delegates) {
     final Future<dynamic> inputValue = delegate.load(locale);
@@ -227,6 +237,9 @@ class _LocalizationsScope extends InheritedWidget {
 /// class _MyDelegate extends LocalizationsDelegate<MyLocalizations> {
 ///   @override
 ///   Future<MyLocalizations> load(Locale locale) => MyLocalizations.load(locale);
+///
+///  @override
+///  bool shouldReload(MyLocalizationsDelegate old) => false;
 ///}
 /// ```
 ///
@@ -298,8 +311,7 @@ class _LocalizationsScope extends InheritedWidget {
 /// One could choose another approach for loading localized resources and looking them up while
 /// still conforming to the structure of this example.
 class Localizations extends StatefulWidget {
-  /// Create a widget from which ambient localizations (translated strings)
-  /// can be obtained.
+  /// Create a widget from which localizations (like translated strings) can be obtained.
   Localizations({
     Key key,
     @required this.locale,
@@ -309,6 +321,49 @@ class Localizations extends StatefulWidget {
     assert(locale != null);
     assert(delegates != null);
     assert(delegates.any((LocalizationsDelegate<dynamic> delegate) => delegate is LocalizationsDelegate<WidgetsLocalizations>));
+  }
+
+  /// Overrides the inherited [Locale] or [LocalizationsDelegate]s for `child`.
+  ///
+  /// This factory constructor is used for the - usually rare - situtation where part
+  /// of an app should be localized for a different locale then the one defined
+  /// for the device, or a different list of [LocalizationsDelegate]s then the
+  /// list defined by [WidgetsApp.localizationsDelegates].
+  ///
+  /// For example you could specify that `myWidget` was only to be localized for
+  /// the US English locale:
+  /// ```
+  /// Widget build(BuildContext context) {
+  ///   return new Localizations.override(
+  ///     context: context,
+  ///     locale: const Locale('en', 'US'),
+  ///     child: myWidget,
+  ///   );
+  /// }
+  /// ```
+  ///
+  /// The `locale` and `delegates` parameters default to the [Localizations.locale]
+  /// and [Localizations.delegates] values of the nearest [Localizations] ancestor.
+  ///
+  /// To override the [Localizations.locale] or [Localizations.delegates] for an
+  /// entire app, specify [WidgetsApp.locale] or [WidgetsApp.localizationsDelegates]
+  /// (or specify the same parameters for [MateialApp]).
+  factory Localizations.override({
+    Key key,
+    @required BuildContext context,
+    Locale locale,
+    List<LocalizationsDelegate<dynamic>> delegates,
+    Widget child,
+  }) {
+    final List<LocalizationsDelegate<dynamic>> mergedDelegates = Localizations._delegatesOf(context);
+    if (delegates != null)
+      mergedDelegates.insertAll(0, delegates);
+    return new Localizations(
+      key: key,
+      locale: locale ?? Localizations.localeOf(context),
+      delegates: mergedDelegates,
+      child: child,
+    );
   }
 
   /// The resources returned by [Localizations.of] will be specific to this locale.
@@ -326,7 +381,17 @@ class Localizations extends StatefulWidget {
   static Locale localeOf(BuildContext context) {
     assert(context != null);
     final _LocalizationsScope scope = context.inheritFromWidgetOfExactType(_LocalizationsScope);
+    assert(scope != null, 'a Localizations ancestor was not found');
     return scope.localizationsState.locale;
+  }
+
+  // There doesn't appear to be a need to make this public. See the
+  // Localizations.override factory constructor.
+  static List<LocalizationsDelegate<dynamic>> _delegatesOf(BuildContext context) {
+    assert(context != null);
+    final _LocalizationsScope scope = context.inheritFromWidgetOfExactType(_LocalizationsScope);
+    assert(scope != null, 'a Localizations ancestor was not found');
+    return new List<LocalizationsDelegate<dynamic>>.from(scope.localizationsState.widget.delegates);
   }
 
   /// Returns the 'type' localized resources for the widget tree that
@@ -345,6 +410,7 @@ class Localizations extends StatefulWidget {
     assert(context != null);
     assert(type != null);
     final _LocalizationsScope scope = context.inheritFromWidgetOfExactType(_LocalizationsScope);
+    assert(scope != null, 'a Localizations ancestor was not found');
     return scope.localizationsState.resourcesFor<T>(type);
   }
 

--- a/packages/flutter/lib/src/widgets/localizations.dart
+++ b/packages/flutter/lib/src/widgets/localizations.dart
@@ -325,14 +325,16 @@ class Localizations extends StatefulWidget {
 
   /// Overrides the inherited [Locale] or [LocalizationsDelegate]s for `child`.
   ///
-  /// This factory constructor is used for the - usually rare - situtation where part
+  /// This factory constructor is used for the (usually rare) situtation where part
   /// of an app should be localized for a different locale than the one defined
-  /// for the device, or a different list of [LocalizationsDelegate]s than the
-  /// list defined by [WidgetsApp.localizationsDelegates].
+  /// for the device, or if its localizations should come from a different list
+  /// of [LocalizationsDelegate]s than the list defined by
+  /// [WidgetsApp.localizationsDelegates].
   ///
   /// For example you could specify that `myWidget` was only to be localized for
   /// the US English locale:
-  /// ```
+  ///
+  /// ```dart
   /// Widget build(BuildContext context) {
   ///   return new Localizations.override(
   ///     context: context,
@@ -347,7 +349,7 @@ class Localizations extends StatefulWidget {
   ///
   /// To override the [Localizations.locale] or [Localizations.delegates] for an
   /// entire app, specify [WidgetsApp.locale] or [WidgetsApp.localizationsDelegates]
-  /// (or specify the same parameters for [MateialApp]).
+  /// (or specify the same parameters for [MaterialApp]).
   factory Localizations.override({
     Key key,
     @required BuildContext context,


### PR DESCRIPTION
This PR adds a little functionality to Localizations et al:
- Enable apps to override or extend our automatically provided localizations.
- Enable apps to override the locale of a subtree

This PR will enable https://github.com/flutter/flutter/pull/12062 to wire the license page to just english with:
```
new Localizations.override(
  context: context
  locale: const Locale('en', 'US'),
  child: licensePageBody
)
```
