### PR TITLE
Split TableBorder from Border

### DIFF
--- a/packages/flutter/lib/rendering.dart
+++ b/packages/flutter/lib/rendering.dart
@@ -60,6 +60,7 @@ export 'src/rendering/sliver_padding.dart';
 export 'src/rendering/sliver_persistent_header.dart';
 export 'src/rendering/stack.dart';
 export 'src/rendering/table.dart';
+export 'src/rendering/table_border.dart';
 export 'src/rendering/tweens.dart';
 export 'src/rendering/view.dart';
 export 'src/rendering/viewport.dart';

--- a/packages/flutter/lib/src/painting/box_painter.dart
+++ b/packages/flutter/lib/src/painting/box_painter.dart
@@ -580,7 +580,7 @@ Iterable<Rect> _generateImageTileRects(Rect outputRect, Rect fundamentalRect, Im
   }
 }
 
-/// Paints an image into the given rectangle in the canvas.
+/// Paints an image into the given rectangle on the canvas.
 ///
 ///  * `canvas`: The canvas onto which the image will be painted.
 ///  * `rect`: The region of the canvas into which the image will be painted.
@@ -612,6 +612,12 @@ Iterable<Rect> _generateImageTileRects(Rect outputRect, Rect fundamentalRect, Im
 ///    `alignment` is [FractionalOffset.bottomRight], the image will be as large
 ///    as possible within `rect` and placed with its bottom right corner at the
 ///    bottom right corner of `rect`.
+///
+/// See also:
+///
+///  * [paintBorder], which paints a border around a rectangle on a canvas.
+///  * [DecorationImage], which holds a configuration for calling this function.
+///  * [BoxDecoration], which uses this function to paint a [DecorationImage].
 void paintImage({
   @required Canvas canvas,
   @required Rect rect,

--- a/packages/flutter/lib/src/rendering/table_border.dart
+++ b/packages/flutter/lib/src/rendering/table_border.dart
@@ -1,0 +1,265 @@
+// Copyright 2015 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/painting.dart' hide Border;
+
+/// Border specification for [Table] widgets.
+///
+/// This is like [Border], with the addition of two sides: the inner horizontal
+/// borders between rows and the inner vertical borders between columns.
+///
+/// The sides are represented by [BorderSide] objects.
+@immutable
+class TableBorder {
+  /// Creates a border for a table.
+  ///
+  /// All the sides of the border default to [BorderSide.none].
+  const TableBorder({
+    this.top: BorderSide.none,
+    this.right: BorderSide.none,
+    this.bottom: BorderSide.none,
+    this.left: BorderSide.none,
+    this.horizontalInside: BorderSide.none,
+    this.verticalInside: BorderSide.none,
+  });
+
+  /// A uniform border with all sides the same color and width.
+  ///
+  /// The sides default to black solid borders, one logical pixel wide.
+  factory TableBorder.all({
+    Color color: const Color(0xFF000000),
+    double width: 1.0,
+    BorderStyle style: BorderStyle.solid,
+  }) {
+    final BorderSide side = new BorderSide(color: color, width: width, style: style);
+    return new TableBorder(top: side, right: side, bottom: side, left: side, horizontalInside: side, verticalInside: side);
+  }
+
+  /// Creates a border for a table where all the interior sides use the same
+  /// styling and all the exterior sides use the same styling.
+  factory TableBorder.symmetric({
+    BorderSide inside: BorderSide.none,
+    BorderSide outside: BorderSide.none,
+  }) {
+    return new TableBorder(
+      top: outside,
+      right: outside,
+      bottom: outside,
+      left: outside,
+      horizontalInside: inside,
+      verticalInside: inside,
+    );
+  }
+
+  /// The top side of this border.
+  final BorderSide top;
+
+  /// The right side of this border.
+  final BorderSide right;
+
+  /// The bottom side of this border.
+  final BorderSide bottom;
+
+  /// The left side of this border.
+  final BorderSide left;
+
+  /// The horizontal interior sides of this border.
+  final BorderSide horizontalInside;
+
+  /// The vertical interior sides of this border.
+  final BorderSide verticalInside;
+
+  /// The widths of the sides of this border represented as an [EdgeInsets].
+  ///
+  /// This can be used, for example, with a [Padding] widget to inset a box by
+  /// the size of these borders.
+  EdgeInsets get dimensions {
+    return new EdgeInsets.fromLTRB(left.width, top.width, right.width, bottom.width);
+  }
+
+  /// Whether all four sides of the border are identical. Uniform borders are
+  /// typically more efficient to paint.
+  bool get isUniform {
+    assert(top != null);
+    assert(right != null);
+    assert(bottom != null);
+    assert(left != null);
+    assert(horizontalInside != null);
+    assert(verticalInside != null);
+
+    final Color topColor = top.color;
+    if (right.color != topColor ||
+        bottom.color != topColor ||
+        left.color != topColor ||
+        horizontalInside.color != topColor ||
+        verticalInside.color != topColor)
+      return false;
+
+    final double topWidth = top.width;
+    if (right.width != topWidth ||
+        bottom.width != topWidth ||
+        left.width != topWidth ||
+        horizontalInside.width != topWidth ||
+        verticalInside.width != topWidth)
+      return false;
+
+    final BorderStyle topStyle = top.style;
+    if (right.style != topStyle ||
+        bottom.style != topStyle ||
+        left.style != topStyle ||
+        horizontalInside.style != topStyle ||
+        verticalInside.style != topStyle)
+      return false;
+
+    return true;
+  }
+
+  /// Creates a new border with the widths of this border multiplied by `t`.
+  TableBorder scale(double t) {
+    return new TableBorder(
+      top: top.copyWith(width: t * top.width),
+      right: right.copyWith(width: t * right.width),
+      bottom: bottom.copyWith(width: t * bottom.width),
+      left: left.copyWith(width: t * left.width),
+      horizontalInside: horizontalInside.copyWith(width: t * horizontalInside.width),
+      verticalInside: verticalInside.copyWith(width: t * verticalInside.width)
+    );
+  }
+
+  /// Linearly interpolate between two table borders.
+  ///
+  /// If a border is null, it is treated as having only [BorderSide.none]
+  /// borders.
+  static TableBorder lerp(TableBorder a, TableBorder b, double t) {
+    if (a == null && b == null)
+      return null;
+    if (a == null)
+      return b.scale(t);
+    if (b == null)
+      return a.scale(1.0 - t);
+    return new TableBorder(
+      top: BorderSide.lerp(a.top, b.top, t),
+      right: BorderSide.lerp(a.right, b.right, t),
+      bottom: BorderSide.lerp(a.bottom, b.bottom, t),
+      left: BorderSide.lerp(a.left, b.left, t),
+      horizontalInside: BorderSide.lerp(a.horizontalInside, b.horizontalInside, t),
+      verticalInside: BorderSide.lerp(a.verticalInside, b.verticalInside, t)
+    );
+  }
+
+  /// Paints the border around the given [Rect] on the given [Canvas], with the
+  /// given rows and columns.
+  ///
+  /// Uniform borders are more efficient to paint than more complex borders.
+  ///
+  /// The `rows` argument specifies the vertical positions of the rows,
+  /// specified in terms of the top of each row, in order from top to bottom,
+  /// relative to the given rectangle, with an additional entry for the bottom
+  /// of the last row (so the first entry should be zero and the last entry
+  /// should be `rect.height`).
+  ///
+  /// The `columns` argument has slightly different semantics; it specifies the
+  /// horizontal positions of the columns, specified in terms of the _left_ edge
+  /// of each row, relative to the given rectangle, in left-to-right order (so
+  /// the first entry should be zero). There is no extra entry for the right
+  /// edge of the last column.
+  ///
+  /// There must be at least one row and at least one column, so the `rows` list
+  /// should at a minimum have two values, and the `columns` argument one value.
+  ///
+  /// The [verticalInside] border is only drawn if there are at least columns
+  /// rows. The [horizontalInside] border is only drawn if there are at least
+  /// two rows. The vertical borders are drawn below the horizontal borders.
+  ///
+  /// The outer borders (in the order [top], [right], [bottom], [left], with
+  /// [left] above the others) are painted above the inner borders.
+  ///
+  /// The paint order is particularly notable in the case of
+  /// partially-transparent borders.
+  void paint(Canvas canvas, Rect rect, {
+    @required List<double> rows,
+    @required List<double> columns,
+  }) {
+    // properties can't be null
+    assert(top != null);
+    assert(right != null);
+    assert(bottom != null);
+    assert(left != null);
+    assert(horizontalInside != null);
+    assert(verticalInside != null);
+
+    // arguments can't be null
+    assert(canvas != null);
+    assert(rect != null);
+    assert(rows != null);
+    assert(rows.length >= 2);
+    assert(rows.first == 0.0);
+    assert(rows.last == rect.height);
+    assert(columns != null);
+    assert(columns.length >= 2);
+    assert(columns.first == 0.0);
+    assert(columns.last == rect.width);
+
+    final Paint paint = new Paint();
+    final Path path = new Path();
+
+    switch (verticalInside.style) {
+      case BorderStyle.solid:
+        paint
+          ..color = verticalInside.color
+          ..strokeWidth = verticalInside.width
+          ..style = PaintingStyle.stroke;
+        path.reset();
+        for (int x = 1; x < columns.length; x += 1) {
+          path.moveTo(rect.left + columns[x], rect.top);
+          path.lineTo(rect.left + columns[x], rect.bottom);
+        }
+        canvas.drawPath(path, paint);
+        break;
+      case BorderStyle.none:
+        break;
+    }
+
+    switch (horizontalInside.style) {
+      case BorderStyle.solid:
+        paint
+          ..color = horizontalInside.color
+          ..strokeWidth = horizontalInside.width
+          ..style = PaintingStyle.stroke;
+        path.reset();
+        for (int y = 1; y < rows.length; y += 1) {
+          path.moveTo(rect.left, rect.top + rows[y]);
+          path.lineTo(rect.right, rect.top + rows[y]);
+        }
+        canvas.drawPath(path, paint);
+        break;
+      case BorderStyle.none:
+        break;
+    }
+
+    paintBorder(canvas, rect, top: top, right: right, bottom: bottom, left: left);
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    if (identical(this, other))
+      return true;
+    if (runtimeType != other.runtimeType)
+      return false;
+    final TableBorder typedOther = other;
+    return top == typedOther.top
+        && right == typedOther.right
+        && bottom == typedOther.bottom
+        && left == typedOther.left
+        && horizontalInside == typedOther.horizontalInside
+        && verticalInside == typedOther.verticalInside;
+  }
+
+  @override
+  int get hashCode => hashValues(top, right, bottom, left, horizontalInside, verticalInside);
+
+  @override
+  String toString() => 'TableBorder($top, $right, $bottom, $left, $horizontalInside, $verticalInside)';
+}

--- a/packages/flutter/test/painting/box_painter_test.dart
+++ b/packages/flutter/test/painting/box_painter_test.dart
@@ -70,7 +70,18 @@ void main() {
     expect(
       new Border.all(width: 4.0).toString(),
       equals(
-        'Border(BorderSide(Color(0xff000000), 4.0, BorderStyle.solid), BorderSide(Color(0xff000000), 4.0, BorderStyle.solid), BorderSide(Color(0xff000000), 4.0, BorderStyle.solid), BorderSide(Color(0xff000000), 4.0, BorderStyle.solid))',
+        'Border.all(BorderSide(Color(0xff000000), 4.0, BorderStyle.solid))',
+      ),
+    );
+    expect(
+      const Border(
+        top: const BorderSide(width: 3.0),
+        right: const BorderSide(width: 3.0),
+        bottom: const BorderSide(width: 3.0),
+        left: const BorderSide(width: 3.0),
+      ).toString(),
+      equals(
+        'Border.all(BorderSide(Color(0xff000000), 3.0, BorderStyle.solid))',
       ),
     );
   });

--- a/packages/flutter/test/rendering/mock_canvas.dart
+++ b/packages/flutter/test/rendering/mock_canvas.dart
@@ -138,6 +138,12 @@ abstract class PaintPattern {
   ///
   /// Any calls made between the last matched call (if any) and the
   /// [Canvas.drawRect] call are ignored.
+  ///
+  /// The [Paint]-related arguments (`color`, `strokeWidth`, `hasMaskFilter`,
+  /// `style`) are compared against the state of the [Paint] object after the
+  /// painting has completed, not at the time of the call. If the same [Paint]
+  /// object is reused multiple times, then this may not match the actual
+  /// arguments as they were seen by the method.
   void rect({ Rect rect, Color color, double strokeWidth, bool hasMaskFilter, PaintingStyle style });
 
   /// Indicates that a rounded rectangle clip is expected next.
@@ -162,6 +168,12 @@ abstract class PaintPattern {
   ///
   /// Any calls made between the last matched call (if any) and the
   /// [Canvas.drawRRect] call are ignored.
+  ///
+  /// The [Paint]-related arguments (`color`, `strokeWidth`, `hasMaskFilter`,
+  /// `style`) are compared against the state of the [Paint] object after the
+  /// painting has completed, not at the time of the call. If the same [Paint]
+  /// object is reused multiple times, then this may not match the actual
+  /// arguments as they were seen by the method.
   void rrect({ RRect rrect, Color color, double strokeWidth, bool hasMaskFilter, PaintingStyle style });
 
   /// Indicates that a circle is expected next.
@@ -174,6 +186,12 @@ abstract class PaintPattern {
   ///
   /// Any calls made between the last matched call (if any) and the
   /// [Canvas.drawCircle] call are ignored.
+  ///
+  /// The [Paint]-related arguments (`color`, `strokeWidth`, `hasMaskFilter`,
+  /// `style`) are compared against the state of the [Paint] object after the
+  /// painting has completed, not at the time of the call. If the same [Paint]
+  /// object is reused multiple times, then this may not match the actual
+  /// arguments as they were seen by the method.
   void circle({ double x, double y, double radius, Color color, double strokeWidth, bool hasMaskFilter, PaintingStyle style });
 
   /// Indicates that a path is expected next.
@@ -189,6 +207,12 @@ abstract class PaintPattern {
   ///
   /// Any calls made between the last matched call (if any) and the
   /// [Canvas.drawPath] call are ignored.
+  ///
+  /// The [Paint]-related arguments (`color`, `strokeWidth`, `hasMaskFilter`,
+  /// `style`) are compared against the state of the [Paint] object after the
+  /// painting has completed, not at the time of the call. If the same [Paint]
+  /// object is reused multiple times, then this may not match the actual
+  /// arguments as they were seen by the method.
   void path({ Color color, double strokeWidth, bool hasMaskFilter, PaintingStyle style });
 
   /// Indicates that a line is expected next.
@@ -201,6 +225,12 @@ abstract class PaintPattern {
   ///
   /// Any calls made between the last matched call (if any) and the
   /// [Canvas.drawLine] call are ignored.
+  ///
+  /// The [Paint]-related arguments (`color`, `strokeWidth`, `hasMaskFilter`,
+  /// `style`) are compared against the state of the [Paint] object after the
+  /// painting has completed, not at the time of the call. If the same [Paint]
+  /// object is reused multiple times, then this may not match the actual
+  /// arguments as they were seen by the method.
   void line({ Color color, double strokeWidth, bool hasMaskFilter, PaintingStyle style });
 
   /// Indicates that an arc is expected next.
@@ -213,6 +243,12 @@ abstract class PaintPattern {
   ///
   /// Any calls made between the last matched call (if any) and the
   /// [Canvas.drawArc] call are ignored.
+  ///
+  /// The [Paint]-related arguments (`color`, `strokeWidth`, `hasMaskFilter`,
+  /// `style`) are compared against the state of the [Paint] object after the
+  /// painting has completed, not at the time of the call. If the same [Paint]
+  /// object is reused multiple times, then this may not match the actual
+  /// arguments as they were seen by the method.
   void arc({ Color color, double strokeWidth, bool hasMaskFilter, PaintingStyle style });
 
   /// Indicates that a paragraph is expected next.

--- a/packages/flutter/test/rendering/recording_canvas.dart
+++ b/packages/flutter/test/rendering/recording_canvas.dart
@@ -13,6 +13,12 @@ class RecordedInvocation {
   const RecordedInvocation(this.invocation, { this.stack });
 
   /// The method that was called and its arguments.
+  ///
+  /// The arguments preserve identity, but not value. Thus, if two invocations
+  /// were made with the same [Paint] object, but with that object configured
+  /// differently each time, then they will both have the same object as their
+  /// argument, and inspecting that object will return the object's current
+  /// values (mostly likely those passed to the second call).
   final Invocation invocation;
 
   /// The stack trace at the time of the method call.

--- a/packages/flutter/test/widgets/box_decoration_test.dart
+++ b/packages/flutter/test/widgets/box_decoration_test.dart
@@ -58,19 +58,13 @@ void main() {
 
     await tester.pumpWidget(buildFrame(new Border.all()));
     expect(find.byKey(key), paints
-      ..path(color: black, style: PaintingStyle.fill)
-      ..path(color: black, style: PaintingStyle.fill)
-      ..path(color: black, style: PaintingStyle.fill)
-      ..path(color: black, style: PaintingStyle.fill));
+      ..rect(color: black, style: PaintingStyle.stroke, strokeWidth: 1.0));
 
     await tester.pumpWidget(buildFrame(new Border.all(width: 0.0)));
     expect(find.byKey(key), paints
-      ..path(color: black, style: PaintingStyle.stroke)
-      ..path(color: black, style: PaintingStyle.stroke)
-      ..path(color: black, style: PaintingStyle.stroke)
-      ..path(color: black, style: PaintingStyle.stroke));
+      ..rect(color: black, style: PaintingStyle.stroke, strokeWidth: 0.0));
 
-    final Color green = const Color(0xFF000000);
+    final Color green = const Color(0xFF00FF00);
     final BorderSide greenSide = new BorderSide(color: green, width: 10.0);
 
     await tester.pumpWidget(buildFrame(new Border(top: greenSide)));
@@ -84,6 +78,15 @@ void main() {
 
     await tester.pumpWidget(buildFrame(new Border(bottom: greenSide)));
     expect(find.byKey(key), paints..path(color: green, style: PaintingStyle.fill));
+
+    final Color blue = const Color(0xFF0000FF);
+    final BorderSide blueSide = new BorderSide(color: blue, width: 0.0);
+
+    await tester.pumpWidget(buildFrame(new Border(top: blueSide, right: greenSide, bottom: greenSide)));
+    expect(find.byKey(key), paints
+      ..path() // There's not much point checking the arguments to these calls because paintBorder
+      ..path() // reuses the same Paint object each time, configured differently, and so they will
+      ..path()); // all appear to have the same settings here (that of the last call).
   });
 
 
@@ -95,9 +98,9 @@ void main() {
     Widget buildFrame(Border border) {
       itemsTapped = <int>[];
       return new Center(
-        child: new GestureDetector( 
-            behavior: HitTestBehavior.deferToChild,
-            child: new Container(
+        child: new GestureDetector(
+          behavior: HitTestBehavior.deferToChild,
+          child: new Container(
             key: key,
             width: 100.0,
             height: 50.0,
@@ -121,7 +124,7 @@ void main() {
 
     await tester.tapAt(const Offset(449.0, 324.0));
     expect(itemsTapped, <int>[1,1,1]);
-  
+
   });
 
   testWidgets('Can hit test on BoxDecoration circle', (WidgetTester tester) async {
@@ -132,7 +135,7 @@ void main() {
     Widget buildFrame(Border border) {
       itemsTapped = <int>[];
       return new Center(
-        child: new GestureDetector( 
+        child: new GestureDetector(
             behavior: HitTestBehavior.deferToChild,
             child: new Container(
             key: key,
@@ -161,7 +164,7 @@ void main() {
 
     await tester.tap(find.byKey(key));
     expect(itemsTapped, <int>[1,1]);
-  
+
   });
 
 }


### PR DESCRIPTION
This will enable both to be RTL'ed.

Also, factor out common border painting code into paintBorder.
Also, make Border paint uniform non-rounded borders using drawRect.
Also, add some documentation about an issue that wasted an hour of my life.
Also, factor out all the border painting code into TableBorder.paint.