### PR TITLE
Make it possible to localize an app title

### DIFF
--- a/packages/flutter/lib/src/material/app.dart
+++ b/packages/flutter/lib/src/material/app.dart
@@ -153,6 +153,8 @@ class MaterialApp extends StatefulWidget {
   /// [Localizations] widget so that this callback can be used to produce a
   /// localized title.
   ///
+  /// This callback function must not return null.
+  ///
   /// This value is passed unmodified to [WidgetsApp.onGenerateTitle].
   final GenerateAppTitle onGenerateTitle;
 

--- a/packages/flutter/lib/src/material/app.dart
+++ b/packages/flutter/lib/src/material/app.dart
@@ -85,6 +85,7 @@ class MaterialApp extends StatefulWidget {
   MaterialApp({ // can't be const because the asserts use methods on Map :-(
     Key key,
     this.title: '',
+    this.onGenerateTitle,
     this.color,
     this.theme,
     this.home,
@@ -134,20 +135,26 @@ class MaterialApp extends StatefulWidget {
 
   /// A one-line description used by the device to identify the app for the user.
   ///
+  /// The title is used by the device to identify the app for the user. On
+  /// Android the titles appear above the task manager's app snapshots which are
+  /// displayed when the user presses the "recent apps" button. Similarly, on
+  /// iOS the titles appear in the App Switcher when the user double presses the
+  /// home button.
+  ///
   /// To provide a localized title instead, use [onGenerateTitle].
   ///
-  /// This value is simply passed along to [WidgetsApp.title].
+  /// This value is passed unmodified to [WidgetsApp.title].
   final String title;
 
   /// If non-null this function is called to produce the app's
   /// title string, otherwise [title] is used.
   ///
-  /// The device uses the title string to identify the app for the user. The
-  /// `context` includes the [WidgetApp]'s [Localizations] widget so that this
-  /// callback can be used to produce a localized title.
+  /// The [onGenerateTitle] `context` parameter includes the [WidgetApp]'s
+  /// [Localizations] widget so that this callback can be used to produce a
+  /// localized title.
   ///
-  /// This value is simply passed along to [WidgetsApp.onGenerateTitle].
-  GenerateAppTitle onGenerateTitle;
+  /// This value is passed unmodified to [WidgetsApp.onGenerateTitle].
+  final GenerateAppTitle onGenerateTitle;
 
   /// The colors to use for the application's widgets.
   final ThemeData theme;
@@ -334,7 +341,7 @@ class MaterialApp extends StatefulWidget {
   /// configure this list to match the locales they support.
   ///
   /// This list must not null. It's default value is just
-  /// `[const Locale('en', 'US')]`. It is simply passed along to the
+  /// `[const Locale('en', 'US')]`. It is passed along unmodified to the
   /// [WidgetsApp] built by this widget.
   ///
   /// The order of the list matters. By default, if the device's locale doesn't

--- a/packages/flutter/lib/src/material/app.dart
+++ b/packages/flutter/lib/src/material/app.dart
@@ -135,8 +135,7 @@ class MaterialApp extends StatefulWidget {
 
   /// A one-line description used by the device to identify the app for the user.
   ///
-  /// The title is used by the device to identify the app for the user. On
-  /// Android the titles appear above the task manager's app snapshots which are
+  /// On Android the titles appear above the task manager's app snapshots which are
   /// displayed when the user presses the "recent apps" button. Similarly, on
   /// iOS the titles appear in the App Switcher when the user double presses the
   /// home button.

--- a/packages/flutter/lib/src/material/app.dart
+++ b/packages/flutter/lib/src/material/app.dart
@@ -132,8 +132,22 @@ class MaterialApp extends StatefulWidget {
        ),
        super(key: key);
 
-  /// A one-line description of this app for use in the window manager.
+  /// A one-line description used by the device to identify the app for the user.
+  ///
+  /// To provide a localized title instead, use [onGenerateTitle].
+  ///
+  /// This value is simply passed along to [WidgetsApp.title].
   final String title;
+
+  /// If non-null this function is called to produce the app's
+  /// title string, otherwise [title] is used.
+  ///
+  /// The device uses the title string to identify the app for the user. The
+  /// `context` includes the [WidgetApp]'s [Localizations] widget so that this
+  /// callback can be used to produce a localized title.
+  ///
+  /// This value is simply passed along to [WidgetsApp.onGenerateTitle].
+  GenerateAppTitle onGenerateTitle;
 
   /// The colors to use for the application's widgets.
   final ThemeData theme;
@@ -508,6 +522,7 @@ class _MaterialAppState extends State<MaterialApp> {
       child: new WidgetsApp(
         key: new GlobalObjectKey(this),
         title: widget.title,
+        onGenerateTitle: widget.onGenerateTitle,
         textStyle: _errorTextStyle,
         // blue is the primary color of the default theme
         color: widget.color ?? theme?.primaryColor ?? Colors.blue,

--- a/packages/flutter/lib/src/widgets/app.dart
+++ b/packages/flutter/lib/src/widgets/app.dart
@@ -40,6 +40,8 @@ typedef Locale LocaleResolutionCallback(Locale locale, Iterable<Locale> supporte
 /// to identify the app for the user. The `context` includes the [WidgetApp]'s
 /// [Localizations] widget so that this method can be used to produce a
 /// localized title.
+///
+/// This function must not return null.
 typedef String GenerateAppTitle(BuildContext context);
 
 // Delegate that fetches the default (English) strings.
@@ -125,6 +127,8 @@ class WidgetsApp extends StatefulWidget {
   /// The [onGenerateTitle] `context` parameter includes the [WidgetApp]'s
   /// [Localizations] widget so that this callback can be used to produce a
   /// localized title.
+  ///
+  /// This callback function must not return null.
   final GenerateAppTitle onGenerateTitle;
 
   /// The default text style for [Text] in the application.

--- a/packages/flutter/lib/src/widgets/app.dart
+++ b/packages/flutter/lib/src/widgets/app.dart
@@ -110,14 +110,17 @@ class WidgetsApp extends StatefulWidget {
 
   /// A one-line description used by the device to identify the app for the user.
   ///
+  /// The title is used by the device to identify the app for the user. On
+  /// Android the titles appear above the task manager's app snapshots which are
+  /// displayed when the user presses the "recent apps" button. Similarly, on
+  /// iOS the titles appear in the App Switcher when the user double presses the
+  /// home button.
+  ///
   /// To provide a localized title instead, use [onGenerateTitle].
   final String title;
 
   /// If non-null this callback function is called to produce the app's
   /// title string, otherwise [title] is used.
-  ///
-  /// The title is a one-line description used by the device to identify the
-  /// app for the user.
   ///
   /// The [onGenerateTitle] `context` parameter includes the [WidgetApp]'s
   /// [Localizations] widget so that this callback can be used to produce a
@@ -487,6 +490,9 @@ class _WidgetsAppState extends State<WidgetsApp> implements WidgetsBindingObserv
       child: new Localizations(
         locale: widget.locale ?? _locale,
         delegates: _localizationsDelegates.toList(),
+        // This Builder exists to provide a context below the Localizations widget.
+        // The onGenerateCallback() can refer to Localizations via its context
+        // parameter.
         child: new Builder(
           builder: (BuildContext context) {
             String title = widget.title;

--- a/packages/flutter/lib/src/widgets/app.dart
+++ b/packages/flutter/lib/src/widgets/app.dart
@@ -112,8 +112,7 @@ class WidgetsApp extends StatefulWidget {
 
   /// A one-line description used by the device to identify the app for the user.
   ///
-  /// The title is used by the device to identify the app for the user. On
-  /// Android the titles appear above the task manager's app snapshots which are
+  /// On Android the titles appear above the task manager's app snapshots which are
   /// displayed when the user presses the "recent apps" button. Similarly, on
   /// iOS the titles appear in the App Switcher when the user double presses the
   /// home button.

--- a/packages/flutter/lib/src/widgets/app.dart
+++ b/packages/flutter/lib/src/widgets/app.dart
@@ -34,6 +34,14 @@ export 'dart:ui' show Locale;
 /// parameter is just the value of [WidgetApp.supportedLocales].
 typedef Locale LocaleResolutionCallback(Locale locale, Iterable<Locale> supportedLocales);
 
+/// The signature of [WidgetsApp.onGenerateTitle].
+///
+/// Used to generate a value for the app's [Title.title], which the device uses
+/// to identify the app for the user. The `context` includes the [WidgetApp]'s
+/// [Localizations] widget so that this method can be used to produce a
+/// localized title.
+typedef String GenerateAppTitle(BuildContext context);
+
 // Delegate that fetches the default (English) strings.
 class _WidgetsLocalizationsDelegate extends LocalizationsDelegate<WidgetsLocalizations> {
   const _WidgetsLocalizationsDelegate();
@@ -71,6 +79,7 @@ class WidgetsApp extends StatefulWidget {
     @required this.onGenerateRoute,
     this.onUnknownRoute,
     this.title: '',
+    this.onGenerateTitle,
     this.textStyle,
     @required this.color,
     this.navigatorObservers: const <NavigatorObserver>[],
@@ -99,8 +108,21 @@ class WidgetsApp extends StatefulWidget {
        assert(debugShowWidgetInspector != null),
        super(key: key);
 
-  /// A one-line description of this app for use in the window manager.
+  /// A one-line description used by the device to identify the app for the user.
+  ///
+  /// To provide a localized title instead, use [onGenerateTitle].
   final String title;
+
+  /// If non-null this callback function is called to produce the app's
+  /// title string, otherwise [title] is used.
+  ///
+  /// The title is a one-line description used by the device to identify the
+  /// app for the user.
+  ///
+  /// The [onGenerateTitle] `context` parameter includes the [WidgetApp]'s
+  /// [Localizations] widget so that this callback can be used to produce a
+  /// localized title.
+  final GenerateAppTitle onGenerateTitle;
 
   /// The default text style for [Text] in the application.
   final TextStyle textStyle;
@@ -465,10 +487,19 @@ class _WidgetsAppState extends State<WidgetsApp> implements WidgetsBindingObserv
       child: new Localizations(
         locale: widget.locale ?? _locale,
         delegates: _localizationsDelegates.toList(),
-        child: new Title(
-          title: widget.title,
-          color: widget.color,
-          child: result,
+        child: new Builder(
+          builder: (BuildContext context) {
+            String title = widget.title;
+            if (widget.onGenerateTitle != null) {
+              title = widget.onGenerateTitle(context);
+              assert(title != null, 'onGenerateTitle must return a non-null String');
+            }
+            return new Title(
+              title: title,
+              color: widget.color,
+              child: result,
+            );
+          },
         ),
       ),
     );

--- a/packages/flutter/test/widgets/app_title_test.dart
+++ b/packages/flutter/test/widgets/app_title_test.dart
@@ -1,0 +1,60 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter/widgets.dart';
+
+const Color kTitleColor = const Color(0xFF333333);
+const String kTitleString = 'Hello World';
+
+Future<Null> pumpApp(WidgetTester tester, { GenerateAppTitle onGenerateTitle }) async {
+  await tester.pumpWidget(
+    new WidgetsApp(
+      supportedLocales: <Locale>[
+        const Locale('en', 'US'),
+        const Locale('en', 'GB'),
+      ],
+      title: kTitleString,
+      color: kTitleColor,
+      onGenerateTitle: onGenerateTitle,
+      onGenerateRoute: (RouteSettings settings) {
+        return new PageRouteBuilder<Null>(
+          pageBuilder: (BuildContext context, Animation<double> animation, Animation<double> secondaryAnimation) {
+            return new Container();
+          }
+        );
+      },
+    ),
+  );
+}
+
+void main() {
+  testWidgets('Specified title and color are used to build a Title', (WidgetTester tester) async {
+    await pumpApp(tester);
+    expect(tester.widget(find.byType(Title)).title, kTitleString);
+    expect(tester.widget(find.byType(Title)).color, kTitleColor);
+  });
+
+  testWidgets('onGenerateTitle handles changing locales', (WidgetTester tester) async {
+    String generateTitle(BuildContext context) {
+      return Localizations.localeOf(context).toString();
+    }
+
+    await pumpApp(tester, onGenerateTitle: generateTitle);
+    expect(tester.widget(find.byType(Title)).title, 'en_US');
+    expect(tester.widget(find.byType(Title)).color, kTitleColor);
+
+    await tester.binding.setLocale('en', 'GB');
+    await tester.pump();
+    expect(tester.widget(find.byType(Title)).title, 'en_GB');
+    expect(tester.widget(find.byType(Title)).color, kTitleColor);
+
+    // Not a supported locale, so we switch to supportedLocales[0], en_US
+    await tester.binding.setLocale('fr', 'CA');
+    await tester.pump();
+    expect(tester.widget(find.byType(Title)).title, 'en_US');
+    expect(tester.widget(find.byType(Title)).color, kTitleColor);
+  });
+
+}

--- a/packages/flutter/test/widgets/app_title_test.dart
+++ b/packages/flutter/test/widgets/app_title_test.dart
@@ -32,8 +32,8 @@ Future<Null> pumpApp(WidgetTester tester, { GenerateAppTitle onGenerateTitle }) 
 void main() {
   testWidgets('Specified title and color are used to build a Title', (WidgetTester tester) async {
     await pumpApp(tester);
-    expect(tester.widget(find.byType(Title)).title, kTitleString);
-    expect(tester.widget(find.byType(Title)).color, kTitleColor);
+    expect(tester.widget<Title>(find.byType(Title)).title, kTitleString);
+    expect(tester.widget<Title>(find.byType(Title)).color, kTitleColor);
   });
 
   testWidgets('onGenerateTitle handles changing locales', (WidgetTester tester) async {
@@ -42,19 +42,19 @@ void main() {
     }
 
     await pumpApp(tester, onGenerateTitle: generateTitle);
-    expect(tester.widget(find.byType(Title)).title, 'en_US');
-    expect(tester.widget(find.byType(Title)).color, kTitleColor);
+    expect(tester.widget<Title>(find.byType(Title)).title, 'en_US');
+    expect(tester.widget<Title>(find.byType(Title)).color, kTitleColor);
 
     await tester.binding.setLocale('en', 'GB');
     await tester.pump();
-    expect(tester.widget(find.byType(Title)).title, 'en_GB');
-    expect(tester.widget(find.byType(Title)).color, kTitleColor);
+    expect(tester.widget<Title>(find.byType(Title)).title, 'en_GB');
+    expect(tester.widget<Title>(find.byType(Title)).color, kTitleColor);
 
     // Not a supported locale, so we switch to supportedLocales[0], en_US
     await tester.binding.setLocale('fr', 'CA');
     await tester.pump();
-    expect(tester.widget(find.byType(Title)).title, 'en_US');
-    expect(tester.widget(find.byType(Title)).color, kTitleColor);
+    expect(tester.widget<Title>(find.byType(Title)).title, 'en_US');
+    expect(tester.widget<Title>(find.byType(Title)).color, kTitleColor);
   });
 
 }


### PR DESCRIPTION
The app `onGenerateTitle` callback can be used to lookup a localized title string.

Fixes https://github.com/flutter/flutter/issues/11968