### PR TITLE
Remove textHeight as a parameter to buildHandle for text selection

### DIFF
--- a/packages/flutter/lib/src/material/text_selection.dart
+++ b/packages/flutter/lib/src/material/text_selection.dart
@@ -164,7 +164,7 @@ class _MaterialTextSelectionControls extends TextSelectionControls {
 
   /// Builder for material-style text selection handles.
   @override
-  Widget buildHandle(BuildContext context, TextSelectionHandleType type, double textHeight) {
+  Widget buildHandle(BuildContext context, TextSelectionHandleType type) {
     final Widget handle = new SizedBox(
       width: _kHandleSize,
       height: _kHandleSize,

--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -75,7 +75,7 @@ abstract class TextSelectionControls {
   ///
   /// The top left corner of this widget is positioned at the bottom of the
   /// selection position.
-  Widget buildHandle(BuildContext context, TextSelectionHandleType type, double textLineHeight);
+  Widget buildHandle(BuildContext context, TextSelectionHandleType type);
 
   /// Builds a toolbar near a text selection.
   ///
@@ -506,11 +506,7 @@ class _TextSelectionHandleOverlayState extends State<_TextSelectionHandleOverlay
             new Positioned(
               left: point.dx,
               top: point.dy,
-              child: widget.selectionControls.buildHandle(
-                context,
-                type,
-                widget.renderObject.size.height / widget.renderObject.maxLines,
-              ),
+              child: widget.selectionControls.buildHandle(context, type),
             ),
           ],
         ),


### PR DESCRIPTION
This fixes #12046 by removing the parameter that was doing a divide-by-null.  The parameter wasn't being used by any implementations (of which there was exactly one) of the abstract interface, so arguably it wasn't necessary.