### PR TITLE
Correct handling for nulling TextField controller

### DIFF
--- a/packages/flutter/lib/src/material/text_field.dart
+++ b/packages/flutter/lib/src/material/text_field.dart
@@ -213,7 +213,7 @@ class _TextFieldState extends State<TextField> {
   void didUpdateWidget(TextField oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (widget.controller == null && oldWidget.controller != null)
-      _controller == new TextEditingController.fromValue(oldWidget.controller.value);
+      _controller = new TextEditingController.fromValue(oldWidget.controller.value);
     else if (widget.controller != null && oldWidget.controller == null)
       _controller = null;
   }


### PR DESCRIPTION
Correctly handle the case where the TextEditingController associated
with a TextField is set to null. Due to a typo (= vs ==), previously
this was a no-op and the existing TextEditingController was retained,
rather than copied.