### PR TITLE
Pin args to [0.13.7-1.0.0) to avoid version conflict

### DIFF
--- a/dev/automated_tests/pubspec.yaml
+++ b/dev/automated_tests/pubspec.yaml
@@ -1,5 +1,6 @@
 name: flutter_automated_tests
 dependencies:
+  args: ^0.13.7
   flutter:
     sdk: flutter
   flutter_test:

--- a/dev/benchmarks/complex_layout/pubspec.yaml
+++ b/dev/benchmarks/complex_layout/pubspec.yaml
@@ -2,6 +2,7 @@ name: complex_layout
 description: A benchmark of a relatively complex layout.
 
 dependencies:
+  args: ^0.13.7
   flutter:
     sdk: flutter
   flutter_driver:

--- a/dev/integration_tests/flavors/pubspec.yaml
+++ b/dev/integration_tests/flavors/pubspec.yaml
@@ -2,6 +2,7 @@ name: flavors
 description: Integration test for build flavors.
 
 dependencies:
+  args: ^0.13.7
   flutter:
     sdk: flutter
   flutter_driver:

--- a/dev/integration_tests/platform_interaction/pubspec.yaml
+++ b/dev/integration_tests/platform_interaction/pubspec.yaml
@@ -2,6 +2,7 @@ name: platform_interaction
 description: Integration test for platform interactions.
 
 dependencies:
+  args: ^0.13.7
   flutter:
     sdk: flutter
   flutter_driver:

--- a/dev/integration_tests/ui/pubspec.yaml
+++ b/dev/integration_tests/ui/pubspec.yaml
@@ -2,6 +2,7 @@ name: integration_ui
 description: Flutter non-plugin UI integration tests.
 
 dependencies:
+  args: ^0.13.7
   flutter:
     sdk: flutter
   flutter_driver:

--- a/examples/catalog/pubspec.yaml
+++ b/examples/catalog/pubspec.yaml
@@ -1,6 +1,7 @@
 name: sample_catalog
 description: A collection of Flutter sample apps
 dependencies:
+  args: ^0.13.7
   flutter:
     sdk: flutter
   path: ^1.4.0

--- a/examples/flutter_gallery/pubspec.yaml
+++ b/examples/flutter_gallery/pubspec.yaml
@@ -1,5 +1,6 @@
 name: flutter_gallery
 dependencies:
+  args: ^0.13.7
   collection: '>=1.9.1 <2.0.0'
   intl: '>=0.14.0 <0.16.0'
   string_scanner: ^1.0.0

--- a/examples/hello_world/pubspec.yaml
+++ b/examples/hello_world/pubspec.yaml
@@ -1,6 +1,7 @@
 name: hello_world
 
 dependencies:
+  args: ^0.13.7
   flutter:
     sdk: flutter
 

--- a/examples/platform_channel/pubspec.yaml
+++ b/examples/platform_channel/pubspec.yaml
@@ -1,6 +1,7 @@
 name: platform_channel
 
 dependencies:
+  args: ^0.13.7
   flutter:
     sdk: flutter
 

--- a/packages/flutter/pubspec.yaml
+++ b/packages/flutter/pubspec.yaml
@@ -5,6 +5,7 @@ description: A framework for writing Flutter applications
 homepage: http://flutter.io
 
 dependencies:
+  args: ^0.13.7
   collection: '>=1.9.1 <2.0.0'
   http: '>=0.11.3+12'
   intl: '>=0.14.0 <0.16.0'

--- a/packages/flutter_test/pubspec.yaml
+++ b/packages/flutter_test/pubspec.yaml
@@ -1,6 +1,7 @@
 name: flutter_test
 version: 0.0.14-dev
 dependencies:
+  args: ^0.13.7
   # The flutter tools depend on very specific internal implementation
   # details of the 'test' package, which change between versions, so
   # here we pin it precisely to avoid version skew across our


### PR DESCRIPTION
This should fix build breakage too https://flutter-dashboard.appspot.com/build.html