### PR TITLE
fix _debugCheckOwnerBuildTargetExists; sync localizations and tests

### DIFF
--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -3272,27 +3272,28 @@ abstract class Element extends DiagnosticableTree implements BuildContext {
   @mustCallSuper
   void didChangeDependencies() {
     assert(_active); // otherwise markNeedsBuild is a no-op
-    assert(() {
-      _debugCheckOwnerBuildTargetExists('didChangeDependencies');
-      return true;
-    });
+    assert(_debugCheckOwnerBuildTargetExists('didChangeDependencies'));
     markNeedsBuild();
   }
 
-  void _debugCheckOwnerBuildTargetExists(String methodName) {
-    if (owner._debugCurrentBuildTarget == null) {
-      throw new FlutterError(
-        '$methodName for ${widget.runtimeType} was called at an '
-        'inappropriate time.\n'
-        'It may only be called while the widgets are being built. A possible '
-        'cause of this error is when $methodName is called during '
-        'one of:\n'
-        ' * network I/O event\n'
-        ' * file I/O event\n'
-        ' * timer\n'
-        ' * microtask (caused by Future.then, async/await, scheduleMicrotask)'
-      );
-    }
+  bool _debugCheckOwnerBuildTargetExists(String methodName) {
+    assert(() {
+      if (owner._debugCurrentBuildTarget == null) {
+        throw new FlutterError(
+            '$methodName for ${widget.runtimeType} was called at an '
+                'inappropriate time.\n'
+                'It may only be called while the widgets are being built. A possible '
+                'cause of this error is when $methodName is called during '
+                'one of:\n'
+                ' * network I/O event\n'
+                ' * file I/O event\n'
+                ' * timer\n'
+                ' * microtask (caused by Future.then, async/await, scheduleMicrotask)'
+        );
+      }
+      return true;
+    }());
+    return true;
   }
 
   /// Returns a description of what caused this element to be created.
@@ -3940,10 +3941,7 @@ class InheritedElement extends ProxyElement {
   /// by first obtaining their [InheritedElement] using
   /// [BuildContext.ancestorInheritedElementForWidgetOfExactType].
   void dispatchDidChangeDependencies() {
-    assert(() {
-      _debugCheckOwnerBuildTargetExists('dispatchDidChangeDependencies');
-      return true;
-    });
+    assert(_debugCheckOwnerBuildTargetExists('dispatchDidChangeDependencies'));
     for (Element dependent in _dependents) {
       assert(() {
         // check that it really is our descendant

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -3272,29 +3272,27 @@ abstract class Element extends DiagnosticableTree implements BuildContext {
   @mustCallSuper
   void didChangeDependencies() {
     assert(_active); // otherwise markNeedsBuild is a no-op
-    _debugCheckOwnerBuildTargetExists('didChangeDependencies');
+    assert(() {
+      _debugCheckOwnerBuildTargetExists('didChangeDependencies');
+      return true;
+    });
     markNeedsBuild();
   }
 
   void _debugCheckOwnerBuildTargetExists(String methodName) {
-    assert(() {
-      if (owner._debugCurrentBuildTarget == null) {
-        throw new FlutterError(
-          '$methodName for ${widget.runtimeType} was called at an '
-          'inappropriate time.\n'
-          '\n'
-          'It may only be called while the widgets are being built. A possible '
-          'cause of this error is when $methodName is called during '
-          'one of:\n'
-          '\n'
-          ' * network I/O event\n'
-          ' * file I/O event\n'
-          ' * timer\n'
-          ' * microtask (caused by Future.then, async/await, scheduleMicrotask)'
-        );
-      }
-      return true;
-    });
+    if (owner._debugCurrentBuildTarget == null) {
+      throw new FlutterError(
+        '$methodName for ${widget.runtimeType} was called at an '
+        'inappropriate time.\n'
+        'It may only be called while the widgets are being built. A possible '
+        'cause of this error is when $methodName is called during '
+        'one of:\n'
+        ' * network I/O event\n'
+        ' * file I/O event\n'
+        ' * timer\n'
+        ' * microtask (caused by Future.then, async/await, scheduleMicrotask)'
+      );
+    }
   }
 
   /// Returns a description of what caused this element to be created.
@@ -3942,7 +3940,10 @@ class InheritedElement extends ProxyElement {
   /// by first obtaining their [InheritedElement] using
   /// [BuildContext.ancestorInheritedElementForWidgetOfExactType].
   void dispatchDidChangeDependencies() {
-    _debugCheckOwnerBuildTargetExists('dispatchDidChangeDependencies');
+    assert(() {
+      _debugCheckOwnerBuildTargetExists('dispatchDidChangeDependencies');
+      return true;
+    });
     for (Element dependent in _dependents) {
       assert(() {
         // check that it really is our descendant

--- a/packages/flutter/lib/src/widgets/localizations.dart
+++ b/packages/flutter/lib/src/widgets/localizations.dart
@@ -206,23 +206,20 @@ class _LocalizationsScope extends InheritedWidget {
     Key key,
     @required this.locale,
     @required this.localizationsState,
-    @required this.loadGeneration,
+    @required this.typeToResources,
     Widget child,
   }) : super(key: key, child: child) {
     assert(localizationsState != null);
+    assert(typeToResources != null);
   }
 
   final Locale locale;
   final _LocalizationsState localizationsState;
-
-  /// A monotonically increasing number that changes after localizations
-  /// delegates have finished loading new data. When this number changes, it
-  /// triggers inherited widget notifications.
-  final int loadGeneration;
+  final Map<Type, dynamic> typeToResources;
 
   @override
   bool updateShouldNotify(_LocalizationsScope old) {
-    return loadGeneration != old.loadGeneration;
+    return !identical(typeToResources, old.typeToResources);
   }
 }
 
@@ -445,11 +442,6 @@ class _LocalizationsState extends State<Localizations> {
   final GlobalKey _localizedResourcesScopeKey = new GlobalKey();
   Map<Type, dynamic> _typeToResources = <Type, dynamic>{};
 
-  /// A monotonically increasing number that increases after localizations
-  /// delegates have finished loading new data, triggering inherited widget
-  /// notifications.
-  int _loadGeneration = 0;
-
   Locale get locale => _locale;
   Locale _locale;
 
@@ -513,7 +505,6 @@ class _LocalizationsState extends State<Localizations> {
         setState(() {
           _typeToResources = value;
           _locale = locale;
-          _loadGeneration += 1;
         });
       });
     }
@@ -539,7 +530,7 @@ class _LocalizationsState extends State<Localizations> {
       key: _localizedResourcesScopeKey,
       locale: _locale,
       localizationsState: this,
-      loadGeneration: _loadGeneration,
+      typeToResources: _typeToResources,
       child: new Directionality(
         textDirection: _textDirection,
         child: widget.child,

--- a/packages/flutter/lib/src/widgets/localizations.dart
+++ b/packages/flutter/lib/src/widgets/localizations.dart
@@ -219,7 +219,7 @@ class _LocalizationsScope extends InheritedWidget {
 
   @override
   bool updateShouldNotify(_LocalizationsScope old) {
-    return !identical(typeToResources, old.typeToResources);
+    return typeToResources != old.typeToResources;
   }
 }
 

--- a/packages/flutter/test/widgets/localizations_test.dart
+++ b/packages/flutter/test/widgets/localizations_test.dart
@@ -159,6 +159,23 @@ Widget buildFrame({
   );
 }
 
+class SyncLoadTest extends StatefulWidget {
+  const SyncLoadTest();
+
+  @override
+  SyncLoadTestState createState() => new SyncLoadTestState();
+}
+
+class SyncLoadTestState extends State<SyncLoadTest> {
+  @override
+  Widget build(BuildContext context) {
+    return new Text(
+      TestLocalizations.of(context).message,
+      textDirection: TextDirection.rtl,
+    );
+  }
+}
+
 void main() {
   testWidgets('Localizations.localeFor in a WidgetsApp with system locale', (WidgetTester tester) async {
     BuildContext pageContext;
@@ -205,27 +222,27 @@ void main() {
   });
 
   testWidgets('Synchronously loaded localizations in a WidgetsApp', (WidgetTester tester) async {
-    BuildContext pageContext;
-    await tester.pumpWidget(
-      buildFrame(
-        delegates: <LocalizationsDelegate<dynamic>>[
-          new SyncTestLocalizationsDelegate()
-        ],
-        buildContent: (BuildContext context) {
-          pageContext = context;
-          return new Text(TestLocalizations.of(context).message);
-        }
-      )
-    );
+    final List<LocalizationsDelegate<dynamic>> delegates = <LocalizationsDelegate<dynamic>>[
+      new SyncTestLocalizationsDelegate(),
+      const DefaultWidgetsLocalizationsDelegate(),
+    ];
 
-    expect(TestLocalizations.of(pageContext), isNotNull);
+    Future<Null> pumpTest(Locale locale) async {
+      await tester.pumpWidget(new Localizations(
+        locale: locale,
+        delegates: delegates,
+        child: const SyncLoadTest(),
+      ));
+    }
+
+    await pumpTest(const Locale('en', 'US'));
     expect(find.text('en_US'), findsOneWidget);
 
-    await tester.binding.setLocale('en', 'GB');
+    await pumpTest(const Locale('en', 'GB'));
     await tester.pump();
     expect(find.text('en_GB'), findsOneWidget);
 
-    await tester.binding.setLocale('en', 'US');
+    await pumpTest(const Locale('en', 'US'));
     await tester.pump();
     expect(find.text('en_US'), findsOneWidget);
   });

--- a/packages/flutter_tools/lib/src/devfs.dart
+++ b/packages/flutter_tools/lib/src/devfs.dart
@@ -339,16 +339,6 @@ class DevFS {
   Uri _baseUri;
   Uri get baseUri => _baseUri;
 
-  Uri deviceUriToHostUri(Uri deviceUri) {
-    final String deviceUriString = deviceUri.toString();
-    final String baseUriString = baseUri.toString();
-    if (deviceUriString.startsWith(baseUriString)) {
-      final String deviceUriSuffix = deviceUriString.substring(baseUriString.length);
-      return rootDirectory.uri.resolve(deviceUriSuffix);
-    }
-    return deviceUri;
-  }
-
   Future<Uri> create() async {
     printTrace('DevFS: Creating new filesystem on the device ($_baseUri)');
     try {

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -139,26 +139,6 @@ class FlutterDevice {
     return reports;
   }
 
-  // Lists program elements changed in the most recent reload that have not
-  // since executed.
-  Future<List<ProgramElement>> unusedChangesInLastReload() async {
-    final List<Future<List<ProgramElement>>> reports =
-        <Future<List<ProgramElement>>>[];
-    for (FlutterView view in views) {
-      reports.add(view.uiIsolate.getUnusedChangesInLastReload());
-    }
-    final List<ProgramElement> elements = <ProgramElement>[];
-    for (Future<List<ProgramElement>> report in reports) {
-      for (ProgramElement element in await report) {
-        elements.add(new ProgramElement(element.qualifiedName,
-                                        devFS.deviceUriToHostUri(element.uri),
-                                        element.line,
-                                        element.column));
-      }
-    }
-    return elements;
-  }
-
   Future<Null> debugDumpApp() async {
     for (FlutterView view in views)
       await view.uiIsolate.flutterDebugDumpApp();
@@ -825,15 +805,14 @@ abstract class ResidentRunner {
 }
 
 class OperationResult {
-  OperationResult(this.code, this.message, [this.hint]);
+  static final OperationResult ok = new OperationResult(0, '');
+
+  OperationResult(this.code, this.message);
 
   final int code;
   final String message;
-  final String hint;
 
   bool get isOk => code == 0;
-
-  static final OperationResult ok = new OperationResult(0, '');
 }
 
 /// Given the value of the --target option, return the path of the Dart file

--- a/packages/flutter_tools/lib/src/run_hot.dart
+++ b/packages/flutter_tools/lib/src/run_hot.dart
@@ -426,22 +426,12 @@ class HotRunner extends ResidentRunner {
         status.cancel();
         if (result.isOk)
           printStatus("${result.message} in ${getElapsedAsMilliseconds(timer.elapsed)}.");
-        if (result.hint != null)
-          printStatus(result.hint);
         return result;
       } catch (error) {
         status.cancel();
         rethrow;
       }
     }
-  }
-
-  String _uriToRelativePath(Uri uri) {
-    final String path = uri.toString();
-    final String base = new Uri.file(projectRootPath).toString();
-    if (path.startsWith(base))
-      return path.substring(base.length + 1);
-    return path;
   }
 
   Future<OperationResult> _reloadSources({ bool pause: false }) async {
@@ -632,41 +622,9 @@ class HotRunner extends ResidentRunner {
         !reassembleTimedOut &&
         shouldReportReloadTime)
       flutterUsage.sendTiming('hot', 'reload', reloadTimer.elapsed);
-
-    String unusedElementMessage;
-    if (!reassembleAndScheduleErrors && !reassembleTimedOut) {
-      final List<Future<List<ProgramElement>>> unusedReports =
-          <Future<List<ProgramElement>>>[];
-      for (FlutterDevice device in flutterDevices)
-        unusedReports.add(device.unusedChangesInLastReload());
-      final List<ProgramElement> unusedElements = <ProgramElement>[];
-      for (Future<List<ProgramElement>> unusedReport in unusedReports)
-        unusedElements.addAll(await unusedReport);
-
-      if (unusedElements.isNotEmpty) {
-        unusedElementMessage =
-            '\nThe following program elements were changed by the reload, '
-            'but did not run when the view was reassembled. If this code '
-            'only runs at start-up, you will need to restart ("R") for '
-            'the changes to have an effect.';
-        for (ProgramElement unusedElement in unusedElements) {
-          final String name = unusedElement.qualifiedName;
-          final String path = _uriToRelativePath(unusedElement.uri);
-          final int line = unusedElement.line;
-          String elementDescription;
-          if (line == null) {
-            elementDescription = '$name ($path)';
-          } else {
-            elementDescription = '$name ($path:$line)';
-          }
-          unusedElementMessage += '\n - $elementDescription';
-        }
-      }
-    }
-
     return new OperationResult(
       reassembleAndScheduleErrors ? 1 : OperationResult.ok.code,
-      reloadMessage, unusedElementMessage
+      reloadMessage
     );
   }
 

--- a/packages/flutter_tools/lib/src/vmservice.dart
+++ b/packages/flutter_tools/lib/src/vmservice.dart
@@ -897,25 +897,6 @@ class HeapSpace extends ServiceObject {
   }
 }
 
-// A function, field or class along with its source location.
-class ProgramElement {
-  ProgramElement(this.qualifiedName, this.uri, this.line, this.column);
-
-  final String qualifiedName;
-  final Uri uri;
-  final int line;
-  final int column;
-
-  @override
-  String toString() {
-    if (line == null) {
-      return '$qualifiedName ($uri)';
-    } else {
-      return '$qualifiedName ($uri:$line)';
-    }
-  }
-}
-
 /// An isolate running inside the VM. Instances of the Isolate class are always
 /// canonicalized.
 class Isolate extends ServiceObjectOwner {
@@ -1046,58 +1027,6 @@ class Isolate extends ServiceObjectOwner {
         'data': e.data,
       });
     }
-  }
-
-  Future<Map<String, dynamic>> getObject(Map<String, dynamic> objectRef) {
-    return invokeRpcRaw('getObject',
-                        params: <String, dynamic>{'objectId': objectRef['id']});
-  }
-
-  Future<ProgramElement> _describeElement(Map<String, dynamic> elementRef) async {
-    String name = elementRef['name'];
-    Map<String, dynamic> owner = elementRef['owner'];
-    while (owner != null) {
-      final String ownerType = owner['type'];
-      if (ownerType == 'Library' || ownerType == '@Library')
-        break;
-      final String ownerName = owner['name'];
-      name = "$ownerName.$name";
-      owner = owner['owner'];
-    }
-
-    final Map<String, dynamic> fullElement = await getObject(elementRef);
-    final Map<String, dynamic> location = fullElement['location'];
-    final int tokenPos = location['tokenPos'];
-    final Map<String, dynamic> script = await getObject(location['script']);
-
-    // The engine's tag handler doesn't seem to create proper URIs.
-    Uri uri = Uri.parse(script['uri']);
-    if (uri.scheme == '')
-      uri = uri.replace(scheme: 'file');
-
-    // See https://github.com/dart-lang/sdk/blob/master/runtime/vm/service/service.md
-    for (List<int> lineTuple in script['tokenPosTable']) {
-      final int line = lineTuple[0];
-      for (int i = 1; i < lineTuple.length; i += 2) {
-        if (lineTuple[i] == tokenPos) {
-          final int column = lineTuple[i + 1];
-          return new ProgramElement(name, uri, line, column);
-        }
-      }
-    }
-    return new ProgramElement(name, uri, null, null);
-  }
-
-  // Lists program elements changed in the most recent reload that have not
-  // since executed.
-  Future<List<ProgramElement>> getUnusedChangesInLastReload() async {
-    final Map<String, dynamic> response =
-        await invokeRpcRaw('_getUnusedChangesInLastReload');
-    final List<Future<ProgramElement>> unusedElements =
-        <Future<ProgramElement>>[];
-    for (Map<String, dynamic> element in response['unused'])
-      unusedElements.add(_describeElement(element));
-    return Future.wait(unusedElements);
   }
 
   /// Resumes the isolate.


### PR DESCRIPTION
This PR addresses post-submit comments from https://github.com/flutter/flutter/pull/12213, namely:

- Wrap calls to `_debugCheckOwnerBuildTargetExists` in `assert`.
- Replace `loadGeneration` with `typeToResources` in `_LocalizationsScope`, with the side-effect that it fixes synchronous loading of `Localizations` resources
- Fix the test that should have failed due to lack of synchronous load notification.

/cc @Hixie @HansMuller 