### PR TITLE
Verify EditableText fires update on replaced controller

### DIFF
--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -178,7 +178,7 @@ void main() {
                   cursorColor: Colors.blue,
                   selectionControls: materialTextSelectionControls,
                   keyboardType: TextInputType.text,
-                  onChanged: (String value) {},
+                  onChanged: (String value) { },
                 ),
               ),
             ),
@@ -199,10 +199,16 @@ void main() {
     });
     await tester.pump();
 
-    final MethodCall setStateCall = log.firstWhere((MethodCall methodCall) {
-      return methodCall.method == 'TextInput.setEditingState';
-    });
-    final Map<String, dynamic> arguments = setStateCall.arguments;
-    expect(arguments['text'], equals('Wobble'));
+    expect(log, <MethodCall>[
+      const MethodCall('TextInput.setEditingState', const <String, dynamic>{
+        'text': 'Wobble',
+        'selectionBase': -1,
+        'selectionExtent': -1,
+        'selectionAffinity': 'TextAffinity.downstream',
+        'selectionIsDirectional': false,
+        'composingBase': -1,
+        'composingExtent': -1,
+      }),
+    ]);
   });
 }


### PR DESCRIPTION
Adds a test that verifies that EditableText sends a
TextInput.setEditingState message to the engine when the associated
TextEditingController is replaced.