### PR TITLE
Fix LinearProgressIndicator constructor

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -16,3 +16,4 @@ Luke Freeman <luke@goposse.com>
 Vincent Le Quéméner <eu.lequem@gmail.com>
 Mike Hoolehan <mike@hoolehan.com>
 German Saprykin <saprykin.h@gmail.com>
+Stefano Rodriguez <hlsroddy@gmail.com>

--- a/packages/flutter/lib/src/material/progress_indicator.dart
+++ b/packages/flutter/lib/src/material/progress_indicator.dart
@@ -161,7 +161,9 @@ class LinearProgressIndicator extends ProgressIndicator {
   const LinearProgressIndicator({
     Key key,
     double value,
-  }) : super(key: key, value: value);
+    Color backgroundColor,
+    Animation<Color> valueColor,
+  }) : super(key: key, value: value, backgroundColor: backgroundColor, valueColor: valueColor);
 
   @override
   _LinearProgressIndicatorState createState() => new _LinearProgressIndicatorState();

--- a/packages/flutter/test/material/progress_indicator_test.dart
+++ b/packages/flutter/test/material/progress_indicator_test.dart
@@ -143,6 +143,31 @@ void main() {
     expect(tester.binding.transientCallbackCount, 1);
   });
 
+  testWidgets('LinearProgressIndicator with colors', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const Directionality(
+        textDirection: TextDirection.ltr,
+        child: const Center(
+          child: const SizedBox(
+            width: 200.0,
+            child: const LinearProgressIndicator(
+              value: 0.25,
+              valueColor: const AlwaysStoppedAnimation<Color>(Colors.white),
+              backgroundColor: Colors.black,
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(
+      find.byType(LinearProgressIndicator),
+      paints
+        ..rect(rect: new Rect.fromLTRB(0.0, 0.0, 200.0, 6.0))
+        ..rect(rect: new Rect.fromLTRB(0.0, 0.0, 50.0, 6.0), color: Colors.white)
+    );
+  });
+
   testWidgets('CircularProgressIndicator(value: 0.0) can be constructed', (WidgetTester tester) async {
     await tester.pumpWidget(
       const Center(


### PR DESCRIPTION
This PR adds `backgroundColor` and `valueColor` to the `LinearProgressIndicator` constructor. The value are passed to the super constructor and everything seems to work properly.

Please refer to #11096 