### PR TITLE
Clarify libimobiledevice installation status message

### DIFF
--- a/packages/flutter_tools/lib/src/ios/ios_workflow.dart
+++ b/packages/flutter_tools/lib/src/ios/ios_workflow.dart
@@ -125,10 +125,17 @@ class IOSWorkflow extends DoctorValidator implements Workflow {
     if (hasHomebrew) {
       brewStatus = ValidationType.installed;
 
-      if (!await iMobileDevice.isWorking) {
+      if (!iMobileDevice.isInstalled) {
         brewStatus = ValidationType.partial;
         messages.add(new ValidationMessage.error(
-            'libimobiledevice and ideviceinstaller are not installed or require updating. To update, run:\n'
+            'libimobiledevice and ideviceinstaller are not installed. To install, run:\n'
+            '  brew install --HEAD libimobiledevice\n'
+            '  brew install ideviceinstaller'
+        ));
+      } else if (!await iMobileDevice.isWorking) {
+        brewStatus = ValidationType.partial;
+        messages.add(new ValidationMessage.error(
+            'libimobiledevice and ideviceinstaller may require updating. To update, run:\n'
             '  brew uninstall --ignore-dependencies libimobiledevice\n'
             '  brew install --HEAD libimobiledevice\n'
             '  brew install ideviceinstaller'

--- a/packages/flutter_tools/test/ios/ios_workflow_test.dart
+++ b/packages/flutter_tools/test/ios/ios_workflow_test.dart
@@ -162,6 +162,21 @@ void main() {
       final ValidationResult result = await workflow.validate();
       expect(result.type, ValidationType.partial);
     }, overrides: <Type, Generator>{
+      IMobileDevice: () => new MockIMobileDevice(isInstalled: false, isWorking: false),
+      Xcode: () => xcode,
+      CocoaPods: () => cocoaPods,
+    });
+
+    testUsingContext('Emits partial status when libimobiledevice is installed but not working', () async {
+      when(xcode.isInstalled).thenReturn(true);
+      when(xcode.xcodeVersionText)
+          .thenReturn('Xcode 8.2.1\nBuild version 8C1002\n');
+      when(xcode.isInstalledAndMeetsVersionCheck).thenReturn(true);
+      when(xcode.eulaSigned).thenReturn(true);
+      final IOSWorkflowTestTarget workflow = new IOSWorkflowTestTarget();
+      final ValidationResult result = await workflow.validate();
+      expect(result.type, ValidationType.partial);
+    }, overrides: <Type, Generator>{
       IMobileDevice: () => new MockIMobileDevice(isWorking: false),
       Xcode: () => xcode,
       CocoaPods: () => cocoaPods,
@@ -281,7 +296,13 @@ final ProcessResult exitsHappy = new ProcessResult(
 );
 
 class MockIMobileDevice extends IMobileDevice {
-  MockIMobileDevice({bool isWorking: true}) : isWorking = new Future<bool>.value(isWorking);
+  MockIMobileDevice({
+    this.isInstalled: true,
+    bool isWorking: true,
+  }) : isWorking = new Future<bool>.value(isWorking);
+
+  @override
+  final bool isInstalled;
 
   @override
   final Future<bool> isWorking;


### PR DESCRIPTION
Differentiate between 'not installed' and 'not working' and emit a more
targeted message.