### PR TITLE
When parts of the program are changed in a hot reload, but not executed during the reassemble, warn that a restart may be needed.

### DIFF
--- a/packages/flutter_tools/lib/src/devfs.dart
+++ b/packages/flutter_tools/lib/src/devfs.dart
@@ -339,6 +339,16 @@ class DevFS {
   Uri _baseUri;
   Uri get baseUri => _baseUri;
 
+  Uri deviceUriToHostUri(Uri deviceUri) {
+    final String deviceUriString = deviceUri.toString();
+    final String baseUriString = baseUri.toString();
+    if (deviceUriString.startsWith(baseUriString)) {
+      final String deviceUriSuffix = deviceUriString.substring(baseUriString.length);
+      return rootDirectory.uri.resolve(deviceUriSuffix);
+    }
+    return deviceUri;
+  }
+
   Future<Uri> create() async {
     printTrace('DevFS: Creating new filesystem on the device ($_baseUri)');
     try {

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -150,8 +150,10 @@ class FlutterDevice {
     final List<ProgramElement> elements = <ProgramElement>[];
     for (Future<List<ProgramElement>> report in reports) {
       for (ProgramElement element in await report) {
-        element.uri = devFS.deviceUriToHostUri(element.uri);
-        elements.add(element);
+        elements.add(new ProgramElement(element.qualifiedName,
+                                        devFS.deviceUriToHostUri(element.uri),
+                                        element.line,
+                                        element.column));
       }
     }
     return elements;
@@ -823,8 +825,6 @@ abstract class ResidentRunner {
 }
 
 class OperationResult {
-  static final OperationResult ok = new OperationResult(0, '');
-
   OperationResult(this.code, this.message, [this.hint]);
 
   final int code;
@@ -832,6 +832,8 @@ class OperationResult {
   final String hint;
 
   bool get isOk => code == 0;
+
+  static final OperationResult ok = new OperationResult(0, '');
 }
 
 /// Given the value of the --target option, return the path of the Dart file

--- a/packages/flutter_tools/lib/src/run_hot.dart
+++ b/packages/flutter_tools/lib/src/run_hot.dart
@@ -439,9 +439,8 @@ class HotRunner extends ResidentRunner {
   String _uriToRelativePath(Uri uri) {
     final String path = uri.toString();
     final String base = new Uri.file(projectRootPath).toString();
-    if (path.startsWith(base)) {
+    if (path.startsWith(base))
       return path.substring(base.length + 1);
-    }
     return path;
   }
 

--- a/packages/flutter_tools/lib/src/run_hot.dart
+++ b/packages/flutter_tools/lib/src/run_hot.dart
@@ -436,6 +436,15 @@ class HotRunner extends ResidentRunner {
     }
   }
 
+  String _uriToRelativePath(Uri uri) {
+    final String path = uri.toString();
+    final String base = new Uri.file(projectRootPath).toString();
+    if (path.startsWith(base)) {
+      return path.substring(base.length + 1);
+    }
+    return path;
+  }
+
   Future<OperationResult> _reloadSources({ bool pause: false }) async {
     for (FlutterDevice device in flutterDevices) {
       for (FlutterView view in device.views) {
@@ -629,22 +638,29 @@ class HotRunner extends ResidentRunner {
     if (!reassembleAndScheduleErrors && !reassembleTimedOut) {
       final List<Future<List<ProgramElement>>> unusedReports =
           <Future<List<ProgramElement>>>[];
-      for (FlutterDevice device in flutterDevices) {
+      for (FlutterDevice device in flutterDevices)
         unusedReports.add(device.unusedChangesInLastReload());
-      }
       final List<ProgramElement> unusedElements = <ProgramElement>[];
-      for (Future<List<ProgramElement>> unusedReport in unusedReports) {
+      for (Future<List<ProgramElement>> unusedReport in unusedReports)
         unusedElements.addAll(await unusedReport);
-      }
 
       if (unusedElements.isNotEmpty) {
         unusedElementMessage =
             '\nThe following program elements were changed by the reload, '
             'but did not run when the view was reassembled. If this code '
             'only runs at start-up, you will need to restart ("R") for '
-            'the changes to have an effect.\n';
+            'the changes to have an effect.';
         for (ProgramElement unusedElement in unusedElements) {
-          unusedElementMessage += " - $unusedElement\n";
+          final String name = unusedElement.qualifiedName;
+          final String path = _uriToRelativePath(unusedElement.uri);
+          final int line = unusedElement.line;
+          String elementDescription;
+          if (line == null) {
+            elementDescription = '$name ($path)';
+          } else {
+            elementDescription = '$name ($path:$line)';
+          }
+          unusedElementMessage += '\n - $elementDescription';
         }
       }
     }

--- a/packages/flutter_tools/lib/src/vmservice.dart
+++ b/packages/flutter_tools/lib/src/vmservice.dart
@@ -897,6 +897,25 @@ class HeapSpace extends ServiceObject {
   }
 }
 
+// A function, field or class along with its source location.
+class ProgramElement {
+  String qualifiedName;
+  Uri uri;
+  int line;
+  int column;
+
+  ProgramElement(this.qualifiedName, this.uri, this.line, this.column);
+
+  @override
+  String toString() {
+    if (line == null) {
+      return "$qualifiedName ($uri)";
+    } else {
+      return "$qualifiedName ($uri:$line)";
+    }
+  }
+}
+
 /// An isolate running inside the VM. Instances of the Isolate class are always
 /// canonicalized.
 class Isolate extends ServiceObjectOwner {
@@ -1027,6 +1046,60 @@ class Isolate extends ServiceObjectOwner {
         'data': e.data,
       });
     }
+  }
+
+  Future<Map<String, dynamic>> getObject(Map<String, dynamic> objectRef) {
+    return invokeRpcRaw('getObject',
+                        params: <String, dynamic>{'objectId': objectRef['id']});
+  }
+
+  Future<ProgramElement> _describeElement(Map<String, dynamic> elementRef) async {
+    String name = elementRef['name'];
+    Map<String, dynamic> owner = elementRef['owner'];
+    while (owner != null) {
+      final String ownerType = owner['type'];
+      if (ownerType == 'Library' || ownerType == '@Library')
+        break;
+      final String ownerName = owner['name'];
+      name = "$ownerName.$name";
+      owner = owner['owner'];
+    }
+
+    final Map<String, dynamic> fullElement = await getObject(elementRef);
+    final Map<String, dynamic> location = fullElement['location'];
+    final int tokenPos = location['tokenPos'];
+    final Map<String, dynamic> script = await getObject(location['script']);
+
+    // The engine's tag handler doesn't seem to create proper URIs.
+    Uri uri = Uri.parse(script['uri']);
+    if (uri.scheme == '') {
+      uri = uri.replace(scheme: 'file');
+    }
+
+    // See //dart/runtime/vm/service/service.md.
+    for (List<int> lineTuple in script['tokenPosTable']) {
+      final int line = lineTuple[0];
+      for (int i = 1; i < lineTuple.length; i += 2) {
+        if (lineTuple[i] == tokenPos) {
+          final int column = lineTuple[i + 1];
+          return new ProgramElement(name, uri, line, column);
+        }
+      }
+    }
+    return new ProgramElement(name, uri, null, null);
+  }
+
+  // Lists program elements changed in the most recent reload that have not
+  // since executed.
+  Future<List<ProgramElement>> getUnusedChangesInLastReload() async {
+    final Map<String, dynamic> response =
+        await invokeRpcRaw('_getUnusedChangesInLastReload');
+    final List<Future<ProgramElement>> unusedElements =
+        <Future<ProgramElement>>[];
+    for (Map<String, dynamic> element in response['unused']) {
+      unusedElements.add(_describeElement(element));
+    }
+    return Future.wait(unusedElements);
   }
 
   /// Resumes the isolate.

--- a/packages/flutter_tools/lib/src/vmservice.dart
+++ b/packages/flutter_tools/lib/src/vmservice.dart
@@ -1095,9 +1095,8 @@ class Isolate extends ServiceObjectOwner {
         await invokeRpcRaw('_getUnusedChangesInLastReload');
     final List<Future<ProgramElement>> unusedElements =
         <Future<ProgramElement>>[];
-    for (Map<String, dynamic> element in response['unused']) {
+    for (Map<String, dynamic> element in response['unused'])
       unusedElements.add(_describeElement(element));
-    }
     return Future.wait(unusedElements);
   }
 

--- a/packages/flutter_tools/lib/src/vmservice.dart
+++ b/packages/flutter_tools/lib/src/vmservice.dart
@@ -899,19 +899,19 @@ class HeapSpace extends ServiceObject {
 
 // A function, field or class along with its source location.
 class ProgramElement {
-  String qualifiedName;
-  Uri uri;
-  int line;
-  int column;
-
   ProgramElement(this.qualifiedName, this.uri, this.line, this.column);
+
+  final String qualifiedName;
+  final Uri uri;
+  final int line;
+  final int column;
 
   @override
   String toString() {
     if (line == null) {
-      return "$qualifiedName ($uri)";
+      return '$qualifiedName ($uri)';
     } else {
-      return "$qualifiedName ($uri:$line)";
+      return '$qualifiedName ($uri:$line)';
     }
   }
 }
@@ -1072,11 +1072,10 @@ class Isolate extends ServiceObjectOwner {
 
     // The engine's tag handler doesn't seem to create proper URIs.
     Uri uri = Uri.parse(script['uri']);
-    if (uri.scheme == '') {
+    if (uri.scheme == '')
       uri = uri.replace(scheme: 'file');
-    }
 
-    // See //dart/runtime/vm/service/service.md.
+    // See https://github.com/dart-lang/sdk/blob/master/runtime/vm/service/service.md
     for (List<int> lineTuple in script['tokenPosTable']) {
       final int line = lineTuple[0];
       for (int i = 1; i < lineTuple.length; i += 2) {


### PR DESCRIPTION
(Do not merge: requires a Dart roll that has not yet landed.)

For example, if one reloads with no change, the message is unchanged:

```
Performing hot reload...                                  
Reloaded 0 of 524 libraries in 899ms.
```
A change in a build method for a widget currently in use, or a const field or helper function used by such a build method, also results in no extra message.

If one reloads with a change to main, the message now warns that main hasn't executed:

```
Performing hot reload...                                  
Reloaded 1 of 524 libraries in 1,951ms.

The following program elements were changed by the reload, but did not run when the view was reassembled. If this code only runs at start-up, you will need to restart ("R") for the changes to have an effect.
 - main (lib/main.dart:12)
```
A similar message will appear for changes to the build method of some widget that isn't currently in use, or a change to code that only runs in response to user input like a touch event.