### PR TITLE
Delete a duplicate EditableText test

### DIFF
--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -250,43 +250,4 @@ void main() {
       }),
     ]);
   });
-
-  testWidgets('Fires onChanged when text changes via TextSelectionOverlay', (WidgetTester tester) async {
-    final GlobalKey<EditableTextState> editableTextKey = new GlobalKey<EditableTextState>();
-
-    String changedValue;
-    final Widget widget = new MaterialApp(
-      home: new EditableText(
-        key: editableTextKey,
-        controller: new TextEditingController(),
-        focusNode: new FocusNode(),
-        style: new Typography(platform: TargetPlatform.android).black.subhead,
-        cursorColor: Colors.blue,
-        selectionControls: materialTextSelectionControls,
-        keyboardType: TextInputType.text,
-        onChanged: (String value) {
-          changedValue = value;
-        },
-      ),
-    );
-    await tester.pumpWidget(widget);
-
-    // Populate a fake clipboard.
-    const String clipboardContent = 'Dobunezumi mitai ni utsukushiku naritai';
-    SystemChannels.platform.setMockMethodCallHandler((MethodCall methodCall) async {
-      if (methodCall.method == 'Clipboard.getData')
-        return const <String, dynamic>{ 'text': clipboardContent };
-      return null;
-    });
-
-    // Long-press to bring up the text editing controls.
-    final Finder textFinder = find.byKey(editableTextKey);
-    await tester.longPress(textFinder);
-    await tester.pump();
-
-    await tester.tap(find.text('PASTE'));
-    await tester.pump();
-
-    expect(changedValue, clipboardContent);
-  });
 }


### PR DESCRIPTION
In 85c425ac88, a test was added to ensure that widget.onChanged was
fired when the contents of an EditableText changed via system paste
events (e.g. triggered from a TextSelectionOverlay). Due to a long stack
of rebases and (less-than-perfect) manual merge conflict merge
resolution, it was inadvertently added twice.