### PR TITLE
Allow unmerging of SemanticsNodes

### DIFF
--- a/packages/flutter/lib/src/rendering/semantics.dart
+++ b/packages/flutter/lib/src/rendering/semantics.dart
@@ -433,13 +433,11 @@ class SemanticsNode extends AbstractNode with DiagnosticableTreeMixin {
 
   /// Restore this node to its default state.
   void reset() {
-    final bool hadInheritedMergeAllDescendantsIntoThisNode = _inheritedMergeAllDescendantsIntoThisNode;
     _actions = 0;
     _flags = 0;
-    if (hadInheritedMergeAllDescendantsIntoThisNode)
-      _inheritedMergeAllDescendantsIntoThisNodeValue = true;
     _label = '';
     _textDirection = null;
+    _mergeAllDescendantsIntoThisNode = false;
     _tags.clear();
     _markDirty();
   }

--- a/packages/flutter/test/widgets/semantics_merge_test.dart
+++ b/packages/flutter/test/widgets/semantics_merge_test.dart
@@ -1,0 +1,111 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'semantics_tester.dart';
+
+void main() {
+  testWidgets('MergeSemantics', (WidgetTester tester) async {
+    final SemanticsTester semantics = new SemanticsTester(tester);
+
+    // not merged
+    await tester.pumpWidget(
+      new Directionality(
+        textDirection: TextDirection.ltr,
+        child: new Row(
+          children: <Widget>[
+            new Semantics(
+                label: 'test1',
+                textDirection: TextDirection.ltr,
+                child: new Container()
+            ),
+            new Semantics(
+                label: 'test2',
+                textDirection: TextDirection.ltr,
+                child: new Container()
+            )
+          ],
+        ),
+      ),
+    );
+
+    expect(semantics, hasSemantics(
+      new TestSemantics.root(
+        children: <TestSemantics>[
+          new TestSemantics.rootChild(id: 1, label: 'test1'),
+          new TestSemantics.rootChild(id: 2, label: 'test2'),
+        ],
+      ),
+      ignoreRect: true,
+      ignoreTransform: true,
+    ));
+
+    //merged
+    await tester.pumpWidget(
+      new Directionality(
+        textDirection: TextDirection.ltr,
+        child: new MergeSemantics(
+          child: new Row(
+            children: <Widget>[
+              new Semantics(
+                  label: 'test1',
+                  textDirection: TextDirection.ltr,
+                  child: new Container()
+              ),
+              new Semantics(
+                  label: 'test2',
+                  textDirection: TextDirection.ltr,
+                  child: new Container()
+              )
+            ],
+          ),
+        ),
+      ),
+    );
+
+    expect(semantics, hasSemantics(
+      new TestSemantics.root(label: 'test1\ntest2'),
+      ignoreRect: true,
+      ignoreTransform: true,
+    ));
+
+    // not merged
+    await tester.pumpWidget(
+      new Directionality(
+        textDirection: TextDirection.ltr,
+        child: new Row(
+          children: <Widget>[
+            new Semantics(
+                label: 'test1',
+                textDirection: TextDirection.ltr,
+                child: new Container()
+            ),
+            new Semantics(
+                label: 'test2',
+                textDirection: TextDirection.ltr,
+                child: new Container()
+            )
+          ],
+        ),
+      ),
+    );
+
+    expect(semantics, hasSemantics(
+      new TestSemantics.root(
+        children: <TestSemantics>[
+          new TestSemantics.rootChild(id: 5, label: 'test1'),
+          new TestSemantics.rootChild(id: 6, label: 'test2'),
+        ],
+      ),
+      ignoreRect: true,
+      ignoreTransform: true,
+    ));
+
+    semantics.dispose();
+  });
+}


### PR DESCRIPTION
Brings the SemanticsTree into a correct state again after a `MergeSemantics` widget has been removed.

Fixes https://github.com/flutter/flutter/issues/12323.