### PR TITLE
Move assert into constructor body.

### DIFF
--- a/packages/flutter/lib/src/material/material_localizations.dart
+++ b/packages/flutter/lib/src/material/material_localizations.dart
@@ -146,8 +146,9 @@ class DefaultMaterialLocalizations implements MaterialLocalizations {
   /// [LocalizationsDelegate] implementations typically call the static [load]
   /// function, rather than constructing this class directly.
   DefaultMaterialLocalizations(this.locale)
-      : assert(locale != null),
-        this._localeName = _computeLocaleName(locale) {
+      : this._localeName = _computeLocaleName(locale) {
+    // TODO(tvolkert): Move this assert back to the initializer.
+    assert(locale != null);
     if (localizations.containsKey(locale.languageCode))
       _nameToValue.addAll(localizations[locale.languageCode]);
     if (localizations.containsKey(_localeName))

--- a/packages/flutter/lib/src/material/material_localizations.dart
+++ b/packages/flutter/lib/src/material/material_localizations.dart
@@ -147,7 +147,6 @@ class DefaultMaterialLocalizations implements MaterialLocalizations {
   /// function, rather than constructing this class directly.
   DefaultMaterialLocalizations(this.locale)
       : this._localeName = _computeLocaleName(locale) {
-    // TODO(tvolkert): Move this assert back to the initializer.
     assert(locale != null);
     if (localizations.containsKey(locale.languageCode))
       _nameToValue.addAll(localizations[locale.languageCode]);


### PR DESCRIPTION
Temporary workaround to the fact that the Analyzer API
doesn't have a way to turn on asserts in initializers, coupled
with the fact that this file is being parsed by package:intl
using the Analyzer API.