### PR TITLE
Make "mergeIntoParent" information available during compile of semantics tree

### DIFF
--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -799,7 +799,7 @@ class _ConcreteSemanticsFragment extends _InterestingSemanticsFragment {
       showOnScreen: renderObjectOwner.showOnScreen,
     );
     final SemanticsNode node = renderObjectOwner._semantics;
-    node.inheritedMergeAllDescendantsIntoThisNode = _mergeIntoParent;
+    node.isMergedIntoParent = _mergeIntoParent;
     if (geometry != null) {
       geometry.applyAncestorChain(_ancestorChain);
       geometry.updateSemanticsNode(rendering: renderObjectOwner, semantics: node, parentSemantics: parentSemantics);
@@ -854,7 +854,7 @@ class _ImplicitSemanticsFragment extends _InterestingSemanticsFragment {
         showOnScreen: renderObjectOwner.showOnScreen,
       );
       node = renderObjectOwner._semantics;
-      node.inheritedMergeAllDescendantsIntoThisNode = _mergeIntoParent;
+      node.isMergedIntoParent = _mergeIntoParent;
     } else {
       renderObjectOwner._semantics = null;
       node = currentSemantics;
@@ -2672,7 +2672,7 @@ abstract class RenderObject extends AbstractNode with DiagnosticableTreeMixin im
     try {
       assert(_needsSemanticsUpdate);
       assert(_semantics != null || parent is! RenderObject);
-      final _SemanticsFragment fragment = _getSemanticsFragment(mergeIntoParent: _semantics?.parent?.shouldMergeAllDescendantsIntoThisNode ?? false);
+      final _SemanticsFragment fragment = _getSemanticsFragment(mergeIntoParent: _semantics?.parent?.isPartOfNodeMerging ?? false);
       assert(fragment is _InterestingSemanticsFragment);
       final SemanticsNode node = fragment.compile(parentSemantics: _semantics?.parent).single;
       assert(node != null);
@@ -2690,10 +2690,9 @@ abstract class RenderObject extends AbstractNode with DiagnosticableTreeMixin im
   /// semantics.
   _SemanticsFragment _getSemanticsFragment({ bool mergeIntoParent: false }) {
     // early-exit if we're not dirty and have our own semantics
-    print('>>> $mergeIntoParent $this');
     if (!_needsSemanticsUpdate && isSemanticBoundary) {
       assert(_semantics != null);
-      if (mergeIntoParent == _semantics.inheritedMergeAllDescendantsIntoThisNode) {
+      if (mergeIntoParent == _semantics.isMergedIntoParent) {
         return new _CleanSemanticsFragment(renderObjectOwner: this, dropSemanticsOfPreviousSiblings: isBlockingSemanticsOfPreviouslyPaintedNodes);
       }
     }

--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -710,7 +710,12 @@ abstract class _InterestingSemanticsFragment extends _SemanticsFragment {
     SemanticsAnnotator annotator,
     Iterable<_SemanticsFragment> children,
     bool dropSemanticsOfPreviousSiblings,
-  }) : super(renderObjectOwner: renderObjectOwner, annotator: annotator, children: children, dropSemanticsOfPreviousSiblings: dropSemanticsOfPreviousSiblings);
+  }) : super(
+         renderObjectOwner: renderObjectOwner,
+         annotator: annotator,
+         children: children,
+         dropSemanticsOfPreviousSiblings: dropSemanticsOfPreviousSiblings,
+       );
 
   @override
   Iterable<SemanticsNode> compile({ _SemanticsGeometry geometry, SemanticsNode currentSemantics, SemanticsNode parentSemantics }) sync* {
@@ -743,7 +748,12 @@ class _RootSemanticsFragment extends _InterestingSemanticsFragment {
     SemanticsAnnotator annotator,
     Iterable<_SemanticsFragment> children,
     bool dropSemanticsOfPreviousSiblings,
-  }) : super(renderObjectOwner: renderObjectOwner, annotator: annotator, children: children, dropSemanticsOfPreviousSiblings: dropSemanticsOfPreviousSiblings);
+  }) : super(
+         renderObjectOwner: renderObjectOwner,
+         annotator: annotator,
+         children: children,
+         dropSemanticsOfPreviousSiblings: dropSemanticsOfPreviousSiblings,
+       );
 
   @override
   SemanticsNode establishSemanticsNode(_SemanticsGeometry geometry, SemanticsNode currentSemantics, SemanticsNode parentSemantics) {
@@ -789,7 +799,14 @@ class _ConcreteSemanticsFragment extends _InterestingSemanticsFragment {
     bool dropSemanticsOfPreviousSiblings,
     bool mergeIntoParent,
     bool mergesAllDescendants,
-  }) : _mergeIntoParent = mergeIntoParent, _mergesAllDescendants = mergesAllDescendants, super(renderObjectOwner: renderObjectOwner, annotator: annotator, children: children, dropSemanticsOfPreviousSiblings: dropSemanticsOfPreviousSiblings);
+  }) : _mergeIntoParent = mergeIntoParent,
+       _mergesAllDescendants = mergesAllDescendants,
+       super(
+         renderObjectOwner: renderObjectOwner,
+         annotator: annotator,
+         children: children,
+         dropSemanticsOfPreviousSiblings: dropSemanticsOfPreviousSiblings,
+       );
 
   final bool _mergeIntoParent;
   final bool _mergesAllDescendants;
@@ -839,7 +856,14 @@ class _ImplicitSemanticsFragment extends _InterestingSemanticsFragment {
     bool dropSemanticsOfPreviousSiblings,
     bool mergeIntoParent,
     bool mergesAllDescendants,
-  }) : _mergeIntoParent = mergeIntoParent, _mergesAllDescendants = mergesAllDescendants, super(renderObjectOwner: renderObjectOwner, annotator: annotator, children: children, dropSemanticsOfPreviousSiblings: dropSemanticsOfPreviousSiblings);
+  }) : _mergeIntoParent = mergeIntoParent,
+       _mergesAllDescendants = mergesAllDescendants,
+       super(
+         renderObjectOwner: renderObjectOwner,
+         annotator: annotator,
+         children: children,
+         dropSemanticsOfPreviousSiblings: dropSemanticsOfPreviousSiblings,
+       );
 
   // If true, this fragment will introduce its own node into the Semantics Tree.
   // If false, a borrowed semantics node from an ancestor is used.
@@ -2529,6 +2553,12 @@ abstract class RenderObject extends AbstractNode with DiagnosticableTreeMixin im
   /// determine if a node is previous to this one.
   bool get isBlockingSemanticsOfPreviouslyPaintedNodes => false;
 
+  /// Whether the semantic information provided by this [RenderObject] and all
+  /// of its descendants should be treated as one logical entity.
+  ///
+  /// If true is returned, the descendants of this [RenderObject]'s
+  /// [SemanticsNode] will merge their semantic information into the
+  /// [SemanticsNode] representing this [RenderObject].
   bool get isMergingSemanticsOfDescendants => false;
 
   /// The bounding box, in the local coordinate system, of this
@@ -2701,7 +2731,10 @@ abstract class RenderObject extends AbstractNode with DiagnosticableTreeMixin im
     if (!_needsSemanticsUpdate && isSemanticBoundary) {
       assert(_semantics != null);
       if (mergeIntoParent == _semantics.isMergedIntoParent) {
-        return new _CleanSemanticsFragment(renderObjectOwner: this, dropSemanticsOfPreviousSiblings: isBlockingSemanticsOfPreviouslyPaintedNodes);
+        return new _CleanSemanticsFragment(
+          renderObjectOwner: this,
+          dropSemanticsOfPreviousSiblings: isBlockingSemanticsOfPreviouslyPaintedNodes,
+        );
       }
     }
     List<_SemanticsFragment> children;
@@ -2738,19 +2771,48 @@ abstract class RenderObject extends AbstractNode with DiagnosticableTreeMixin im
     if (parent is! RenderObject) {
       assert(!mergeIntoParent);
       assert(!isMergingSemanticsOfDescendants);
-      return new _RootSemanticsFragment(renderObjectOwner: this, annotator: annotator, children: children, dropSemanticsOfPreviousSiblings: dropSemanticsOfPreviousSiblings);
+      return new _RootSemanticsFragment(
+        renderObjectOwner: this,
+        annotator: annotator,
+        children: children,
+        dropSemanticsOfPreviousSiblings: dropSemanticsOfPreviousSiblings,
+      );
     }
-    if (isSemanticBoundary)
-      return new _ConcreteSemanticsFragment(renderObjectOwner: this, annotator: annotator, children: children, dropSemanticsOfPreviousSiblings: dropSemanticsOfPreviousSiblings, mergeIntoParent: mergeIntoParent, mergesAllDescendants: isMergingSemanticsOfDescendants);
-    if (annotator != null || isMergingSemanticsOfDescendants)
-      return new _ImplicitSemanticsFragment(renderObjectOwner: this, annotator: annotator, children: children, dropSemanticsOfPreviousSiblings: dropSemanticsOfPreviousSiblings, mergeIntoParent: mergeIntoParent, mergesAllDescendants: isMergingSemanticsOfDescendants);
+    if (isSemanticBoundary) {
+      return new _ConcreteSemanticsFragment(
+        renderObjectOwner: this,
+        annotator: annotator,
+        children: children,
+        dropSemanticsOfPreviousSiblings: dropSemanticsOfPreviousSiblings,
+        mergeIntoParent: mergeIntoParent,
+        mergesAllDescendants: isMergingSemanticsOfDescendants,
+      );
+    }
+     if (annotator != null || isMergingSemanticsOfDescendants) {
+       return new _ImplicitSemanticsFragment(
+         renderObjectOwner: this,
+         annotator: annotator,
+         children: children,
+         dropSemanticsOfPreviousSiblings: dropSemanticsOfPreviousSiblings,
+         mergeIntoParent: mergeIntoParent,
+         mergesAllDescendants: isMergingSemanticsOfDescendants,
+       );
+     }
     _semantics = null;
     if (children == null) {
       // Introduces no semantics and has no descendants that introduce semantics.
-      return new _EmptySemanticsFragment(renderObjectOwner: this, dropSemanticsOfPreviousSiblings: dropSemanticsOfPreviousSiblings);
+      return new _EmptySemanticsFragment(
+        renderObjectOwner: this,
+        dropSemanticsOfPreviousSiblings: dropSemanticsOfPreviousSiblings,
+      );
     }
-    if (children.length > 1)
-      return new _ForkingSemanticsFragment(renderObjectOwner: this, children: children, dropSemanticsOfPreviousSiblings: dropSemanticsOfPreviousSiblings);
+    if (children.length > 1) {
+      return new _ForkingSemanticsFragment(
+        renderObjectOwner: this,
+        children: children,
+        dropSemanticsOfPreviousSiblings: dropSemanticsOfPreviousSiblings,
+      );
+    }
     assert(children.length == 1);
     return children.single..dropSemanticsOfPreviousSiblings = dropSemanticsOfPreviousSiblings;
   }

--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -3259,6 +3259,9 @@ class RenderMergeSemantics extends RenderProxyBox {
   @override
   SemanticsAnnotator get semanticsAnnotator => _annotate;
 
+  @override
+  bool get isMergingSemanticsOfDescendants => true;
+
   void _annotate(SemanticsNode node) {
     node.mergeAllDescendantsIntoThisNode = true;
   }

--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -3001,6 +3001,7 @@ class RenderSemanticsGestureHandler extends RenderProxyBox implements SemanticsA
     _innerNode ??= new SemanticsNode(handler: this, showOnScreen: showOnScreen);
     _innerNode
       ..wasAffectedByClip = node.wasAffectedByClip
+      ..isMergedIntoParent = node.isPartOfNodeMerging
       ..rect = Offset.zero & node.rect.size;
 
     semanticsAnnotator(_innerNode);
@@ -3257,14 +3258,8 @@ class RenderMergeSemantics extends RenderProxyBox {
   RenderMergeSemantics({ RenderBox child }) : super(child);
 
   @override
-  SemanticsAnnotator get semanticsAnnotator => _annotate;
-
-  @override
   bool get isMergingSemanticsOfDescendants => true;
 
-  void _annotate(SemanticsNode node) {
-    node.mergeAllDescendantsIntoThisNode = true;
-  }
 }
 
 /// Excludes this subtree from the semantic tree.

--- a/packages/flutter/lib/src/rendering/semantics.dart
+++ b/packages/flutter/lib/src/rendering/semantics.dart
@@ -330,7 +330,7 @@ class SemanticsNode extends AbstractNode with DiagnosticableTreeMixin {
     return _actionHandler != null && (_actions & action.index) != 0;
   }
 
-  /// Whether all this node and all of its descendants should be treated as one logical entity.
+  /// Whether this node and all of its descendants should be treated as one logical entity.
   bool get mergeAllDescendantsIntoThisNode => _mergeAllDescendantsIntoThisNode;
   bool _mergeAllDescendantsIntoThisNode = false;
   set mergeAllDescendantsIntoThisNode(bool value) {
@@ -341,6 +341,7 @@ class SemanticsNode extends AbstractNode with DiagnosticableTreeMixin {
     _markDirty();
   }
 
+  /// Whether this node merges its semantic information into an ancestor node.
   bool get isMergedIntoParent => _isMergedIntoParent;
   bool _isMergedIntoParent = false;
   set isMergedIntoParent(bool value) {
@@ -351,6 +352,14 @@ class SemanticsNode extends AbstractNode with DiagnosticableTreeMixin {
     _markDirty();
   }
 
+  /// Whether this node is taking part in a merge of semantic information.
+  ///
+  /// This returns true if the node is either merged into an ancestor node or if
+  /// decedent nodes are merged into this node.
+  ///
+  /// See also:
+  ///  * [isMergedIntoParent]
+  ///  * [mergeAllDescendantsIntoThisNode]
   bool get isPartOfNodeMerging => mergeAllDescendantsIntoThisNode || isMergedIntoParent;
 
   int _flags = 0;

--- a/packages/flutter/lib/src/rendering/semantics.dart
+++ b/packages/flutter/lib/src/rendering/semantics.dart
@@ -601,6 +601,7 @@ class SemanticsNode extends AbstractNode with DiagnosticableTreeMixin {
       _dirty = false;
       _markDirty();
     }
+//    print('>>> $id -- $isMergedIntoParent -- ${parent?.isPartOfNodeMerging}');
     assert(isMergedIntoParent == (parent?.isPartOfNodeMerging ?? false));
     if (_children != null) {
       for (SemanticsNode child in _children)

--- a/packages/flutter/lib/src/rendering/semantics.dart
+++ b/packages/flutter/lib/src/rendering/semantics.dart
@@ -601,7 +601,6 @@ class SemanticsNode extends AbstractNode with DiagnosticableTreeMixin {
       _dirty = false;
       _markDirty();
     }
-//    print('>>> $id -- $isMergedIntoParent -- ${parent?.isPartOfNodeMerging}');
     assert(isMergedIntoParent == (parent?.isPartOfNodeMerging ?? false));
     if (_children != null) {
       for (SemanticsNode child in _children)

--- a/packages/flutter/lib/src/rendering/semantics.dart
+++ b/packages/flutter/lib/src/rendering/semantics.dart
@@ -894,6 +894,7 @@ class SemanticsOwner extends ChangeNotifier {
         assert(node.parent == null || !node.parent.isPartOfNodeMerging || node.isMergedIntoParent);
         if (node.isPartOfNodeMerging) {
           assert(node.mergeAllDescendantsIntoThisNode || node.parent != null);
+          // if we're merged into our parent, make sure our parent is added to the dirty list
           if (node.parent != null && node.parent.isPartOfNodeMerging)
             node.parent._markDirty(); // this can add the node to the dirty list
         }

--- a/packages/flutter/lib/src/rendering/semantics.dart
+++ b/packages/flutter/lib/src/rendering/semantics.dart
@@ -341,9 +341,9 @@ class SemanticsNode extends AbstractNode with DiagnosticableTreeMixin {
     _markDirty();
   }
 
-  bool get _inheritedMergeAllDescendantsIntoThisNode => _inheritedMergeAllDescendantsIntoThisNodeValue;
+  bool get inheritedMergeAllDescendantsIntoThisNode => _inheritedMergeAllDescendantsIntoThisNodeValue;
   bool _inheritedMergeAllDescendantsIntoThisNodeValue = false;
-  set _inheritedMergeAllDescendantsIntoThisNode(bool value) {
+  set inheritedMergeAllDescendantsIntoThisNode(bool value) {
     assert(value != null);
     if (_inheritedMergeAllDescendantsIntoThisNodeValue == value)
       return;
@@ -351,7 +351,7 @@ class SemanticsNode extends AbstractNode with DiagnosticableTreeMixin {
     _markDirty();
   }
 
-  bool get _shouldMergeAllDescendantsIntoThisNode => mergeAllDescendantsIntoThisNode || _inheritedMergeAllDescendantsIntoThisNode;
+  bool get shouldMergeAllDescendantsIntoThisNode => mergeAllDescendantsIntoThisNode || inheritedMergeAllDescendantsIntoThisNode;
 
   int _flags = 0;
   void _setFlag(SemanticsFlags flag, bool value) {
@@ -433,7 +433,7 @@ class SemanticsNode extends AbstractNode with DiagnosticableTreeMixin {
 
   /// Restore this node to its default state.
   void reset() {
-    final bool hadInheritedMergeAllDescendantsIntoThisNode = _inheritedMergeAllDescendantsIntoThisNode;
+    final bool hadInheritedMergeAllDescendantsIntoThisNode = inheritedMergeAllDescendantsIntoThisNode;
     _actions = 0;
     _flags = 0;
     if (hadInheritedMergeAllDescendantsIntoThisNode)
@@ -604,7 +604,7 @@ class SemanticsNode extends AbstractNode with DiagnosticableTreeMixin {
       _markDirty();
     }
     if (parent != null)
-      _inheritedMergeAllDescendantsIntoThisNode = parent._shouldMergeAllDescendantsIntoThisNode;
+      inheritedMergeAllDescendantsIntoThisNode = parent.shouldMergeAllDescendantsIntoThisNode;
     if (_children != null) {
       for (SemanticsNode child in _children)
         child.attach(owner);
@@ -759,7 +759,7 @@ class SemanticsNode extends AbstractNode with DiagnosticableTreeMixin {
       hideOwner = inDirtyNodes;
     }
     properties.add(new DiagnosticsProperty<SemanticsOwner>('owner', owner, level: hideOwner ? DiagnosticLevel.hidden : DiagnosticLevel.info));
-    properties.add(new FlagProperty('shouldMergeAllDescendantsIntoThisNode', value: _shouldMergeAllDescendantsIntoThisNode, ifTrue: 'leaf merge'));
+    properties.add(new FlagProperty('shouldMergeAllDescendantsIntoThisNode', value: shouldMergeAllDescendantsIntoThisNode, ifTrue: 'leaf merge'));
     final Offset offset = transform != null ? MatrixUtils.getAsTranslation(transform) : null;
     if (offset != null) {
       properties.add(new DiagnosticsProperty<Rect>('rect', rect.shift(offset), showName: false));
@@ -885,29 +885,29 @@ class SemanticsOwner extends ChangeNotifier {
       visitedNodes.addAll(localDirtyNodes);
       for (SemanticsNode node in localDirtyNodes) {
         assert(node._dirty);
-        assert(node.parent == null || !node.parent._shouldMergeAllDescendantsIntoThisNode || node._inheritedMergeAllDescendantsIntoThisNode);
-        if (node._shouldMergeAllDescendantsIntoThisNode) {
+        assert(node.parent == null || !node.parent.shouldMergeAllDescendantsIntoThisNode || node.inheritedMergeAllDescendantsIntoThisNode);
+        if (node.shouldMergeAllDescendantsIntoThisNode) {
           assert(node.mergeAllDescendantsIntoThisNode || node.parent != null);
           if (node.mergeAllDescendantsIntoThisNode ||
-              node.parent != null && node.parent._shouldMergeAllDescendantsIntoThisNode) {
+              node.parent != null && node.parent.shouldMergeAllDescendantsIntoThisNode) {
             // if we're merged into our parent, make sure our parent is added to the list
-            if (node.parent != null && node.parent._shouldMergeAllDescendantsIntoThisNode)
+            if (node.parent != null && node.parent.shouldMergeAllDescendantsIntoThisNode)
               node.parent._markDirty(); // this can add the node to the dirty list
             // make sure all the descendants are also marked, so that if one gets marked dirty later we know to walk up then too
             if (node._children != null) {
               for (SemanticsNode child in node._children)
-                child._inheritedMergeAllDescendantsIntoThisNode = true; // this can add the node to the dirty list
+                child.inheritedMergeAllDescendantsIntoThisNode = true; // this can add the node to the dirty list
             }
           } else {
             // we previously were being merged but aren't any more
             // update our bits and all our descendants'
-            assert(node._inheritedMergeAllDescendantsIntoThisNode);
+            assert(node.inheritedMergeAllDescendantsIntoThisNode);
             assert(!node.mergeAllDescendantsIntoThisNode);
-            assert(node.parent == null || !node.parent._shouldMergeAllDescendantsIntoThisNode);
-            node._inheritedMergeAllDescendantsIntoThisNode = false;
+            assert(node.parent == null || !node.parent.shouldMergeAllDescendantsIntoThisNode);
+            node.inheritedMergeAllDescendantsIntoThisNode = false;
             if (node._children != null) {
               for (SemanticsNode child in node._children)
-                child._inheritedMergeAllDescendantsIntoThisNode = false; // this can add the node to the dirty list
+                child.inheritedMergeAllDescendantsIntoThisNode = false; // this can add the node to the dirty list
             }
           }
         }
@@ -937,7 +937,7 @@ class SemanticsOwner extends ChangeNotifier {
 
   SemanticsActionHandler _getSemanticsActionHandlerForId(int id, SemanticsAction action) {
     SemanticsNode result = _nodes[id];
-    if (result != null && result._shouldMergeAllDescendantsIntoThisNode && !result._canPerformAction(action)) {
+    if (result != null && result.shouldMergeAllDescendantsIntoThisNode && !result._canPerformAction(action)) {
       result._visitDescendants((SemanticsNode node) {
         if (node._canPerformAction(action)) {
           result = node;

--- a/packages/flutter/lib/src/rendering/semantics.dart
+++ b/packages/flutter/lib/src/rendering/semantics.dart
@@ -433,13 +433,11 @@ class SemanticsNode extends AbstractNode with DiagnosticableTreeMixin {
 
   /// Restore this node to its default state.
   void reset() {
-    final bool hadInheritedMergeAllDescendantsIntoThisNode = inheritedMergeAllDescendantsIntoThisNode;
     _actions = 0;
     _flags = 0;
-    if (hadInheritedMergeAllDescendantsIntoThisNode)
-      _inheritedMergeAllDescendantsIntoThisNodeValue = true;
     _label = '';
     _textDirection = null;
+    _mergeAllDescendantsIntoThisNode = false;
     _tags.clear();
     _markDirty();
   }

--- a/packages/flutter/test/rendering/semantics_test.dart
+++ b/packages/flutter/test/rendering/semantics_test.dart
@@ -177,7 +177,7 @@ void main() {
 
     expect(
       minimalProperties.toStringDeep(minLevel: DiagnosticLevel.hidden),
-      'SemanticsNode#16(owner: null, shouldMergeAllDescendantsIntoThisNode: false, Rect.fromLTRB(0.0, 0.0, 0.0, 0.0), wasAffectedByClip: false, actions: [], tags: [], isSelected: false, label: "", textDirection: null)\n',
+      'SemanticsNode#16(owner: null, isPartOfNodeMerging: false, Rect.fromLTRB(0.0, 0.0, 0.0, 0.0), wasAffectedByClip: false, actions: [], tags: [], isSelected: false, label: "", textDirection: null)\n',
     );
 
     final SemanticsNode allProperties = new SemanticsNode()

--- a/packages/flutter/test/widgets/semantics_merge_test.dart
+++ b/packages/flutter/test/widgets/semantics_merge_test.dart
@@ -45,7 +45,7 @@ void main() {
       ignoreTransform: true,
     ));
 
-    //merged
+    // merged
     await tester.pumpWidget(
       new Directionality(
         textDirection: TextDirection.ltr,

--- a/packages/flutter/test/widgets/semantics_merge_test.dart
+++ b/packages/flutter/test/widgets/semantics_merge_test.dart
@@ -13,7 +13,6 @@ void main() {
   testWidgets('MergeSemantics', (WidgetTester tester) async {
     final SemanticsTester semantics = new SemanticsTester(tester);
 
-    print('>>> not merged');
     // not merged
     await tester.pumpWidget(
       new Directionality(
@@ -46,7 +45,6 @@ void main() {
       ignoreTransform: true,
     ));
 
-    print('>>> merged');
     //merged
     await tester.pumpWidget(
       new Directionality(
@@ -76,7 +74,6 @@ void main() {
       ignoreTransform: true,
     ));
 
-    print('>>> not merged');
     // not merged
     await tester.pumpWidget(
       new Directionality(

--- a/packages/flutter/test/widgets/semantics_merge_test.dart
+++ b/packages/flutter/test/widgets/semantics_merge_test.dart
@@ -1,0 +1,104 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'semantics_tester.dart';
+
+void main() {
+  testWidgets('MergeSemantics', (WidgetTester tester) async {
+    final SemanticsTester semantics = new SemanticsTester(tester);
+
+    print('>>>>> not merged');
+    // not merged
+    await tester.pumpWidget(
+      new Directionality(
+        textDirection: TextDirection.ltr,
+        child: new Row(
+          children: <Widget>[
+            new Semantics(
+                label: 'test1',
+                textDirection: TextDirection.ltr,
+                child: new Container()
+            ),
+            new Semantics(
+                label: 'test2',
+                textDirection: TextDirection.ltr,
+                child: new Container()
+            )
+          ],
+        ),
+      ),
+    );
+
+    expect(semantics, hasSemantics(new TestSemantics.root(
+      children: <TestSemantics>[
+        new TestSemantics.rootChild(id: 1, label: 'test1'),
+        new TestSemantics.rootChild(id: 2, label: 'test2'),
+      ],
+    ), ignoreRect: true, ignoreTransform: true));
+
+    print('>>>>> merged');
+    //merged
+    await tester.pumpWidget(
+      new Directionality(
+        textDirection: TextDirection.ltr,
+        child: new MergeSemantics(
+          child: new Row(
+            children: <Widget>[
+              new Semantics(
+                  label: 'test1',
+                  textDirection: TextDirection.ltr,
+                  child: new Container()
+              ),
+              new Semantics(
+                  label: 'test2',
+                  textDirection: TextDirection.ltr,
+                  child: new Container()
+              )
+            ],
+          ),
+        ),
+      ),
+    );
+
+    expect(semantics, hasSemantics(new TestSemantics.root(label: 'test1\ntest2')));
+
+    print('>>>>> not merged');
+    // not merged
+    await tester.pumpWidget(
+      new Directionality(
+        textDirection: TextDirection.ltr,
+        child: new Row(
+          children: <Widget>[
+            new Semantics(
+                label: 'test1',
+                textDirection: TextDirection.ltr,
+                child: new Container()
+            ),
+            new Semantics(
+                label: 'test2',
+                textDirection: TextDirection.ltr,
+                child: new Container()
+            )
+          ],
+        ),
+      ),
+    );
+
+    debugDumpSemanticsTree(DebugSemanticsDumpOrder.inverseHitTest);
+
+    expect(semantics, hasSemantics(new TestSemantics.root(
+      children: <TestSemantics>[
+        new TestSemantics.rootChild(id: 1, label: 'test1'),
+        new TestSemantics.rootChild(id: 2, label: 'test2'),
+      ],
+    ), ignoreRect: true, ignoreTransform: true));
+
+    semantics.dispose();
+  });
+}

--- a/packages/flutter/test/widgets/semantics_merge_test.dart
+++ b/packages/flutter/test/widgets/semantics_merge_test.dart
@@ -13,7 +13,6 @@ void main() {
   testWidgets('MergeSemantics', (WidgetTester tester) async {
     final SemanticsTester semantics = new SemanticsTester(tester);
 
-    print('>>>>> not merged');
     // not merged
     await tester.pumpWidget(
       new Directionality(
@@ -35,14 +34,17 @@ void main() {
       ),
     );
 
-    expect(semantics, hasSemantics(new TestSemantics.root(
-      children: <TestSemantics>[
-        new TestSemantics.rootChild(id: 1, label: 'test1'),
-        new TestSemantics.rootChild(id: 2, label: 'test2'),
-      ],
-    ), ignoreRect: true, ignoreTransform: true));
+    expect(semantics, hasSemantics(
+      new TestSemantics.root(
+        children: <TestSemantics>[
+          new TestSemantics.rootChild(id: 1, label: 'test1'),
+          new TestSemantics.rootChild(id: 2, label: 'test2'),
+        ],
+      ),
+      ignoreRect: true,
+      ignoreTransform: true,
+    ));
 
-    print('>>>>> merged');
     //merged
     await tester.pumpWidget(
       new Directionality(
@@ -66,9 +68,12 @@ void main() {
       ),
     );
 
-    expect(semantics, hasSemantics(new TestSemantics.root(label: 'test1\ntest2')));
+    expect(semantics, hasSemantics(
+      new TestSemantics.root(label: 'test1\ntest2'),
+      ignoreRect: true,
+      ignoreTransform: true,
+    ));
 
-    print('>>>>> not merged');
     // not merged
     await tester.pumpWidget(
       new Directionality(
@@ -90,14 +95,16 @@ void main() {
       ),
     );
 
-    debugDumpSemanticsTree(DebugSemanticsDumpOrder.inverseHitTest);
-
-    expect(semantics, hasSemantics(new TestSemantics.root(
-      children: <TestSemantics>[
-        new TestSemantics.rootChild(id: 1, label: 'test1'),
-        new TestSemantics.rootChild(id: 2, label: 'test2'),
-      ],
-    ), ignoreRect: true, ignoreTransform: true));
+    expect(semantics, hasSemantics(
+      new TestSemantics.root(
+        children: <TestSemantics>[
+          new TestSemantics.rootChild(id: 5, label: 'test1'),
+          new TestSemantics.rootChild(id: 6, label: 'test2'),
+        ],
+      ),
+      ignoreRect: true,
+      ignoreTransform: true,
+    ));
 
     semantics.dispose();
   });

--- a/packages/flutter/test/widgets/semantics_merge_test.dart
+++ b/packages/flutter/test/widgets/semantics_merge_test.dart
@@ -13,6 +13,7 @@ void main() {
   testWidgets('MergeSemantics', (WidgetTester tester) async {
     final SemanticsTester semantics = new SemanticsTester(tester);
 
+    print('>>> not merged');
     // not merged
     await tester.pumpWidget(
       new Directionality(
@@ -45,6 +46,7 @@ void main() {
       ignoreTransform: true,
     ));
 
+    print('>>> merged');
     //merged
     await tester.pumpWidget(
       new Directionality(
@@ -74,6 +76,7 @@ void main() {
       ignoreTransform: true,
     ));
 
+    print('>>> not merged');
     // not merged
     await tester.pumpWidget(
       new Directionality(


### PR DESCRIPTION
Previously, the information if a node is merged into its parent was only calculated after the shape of the semantics tree had been updated as the very last step before sending the updated tree to the engine. With this change, the information is calculated on-the-fly while the tree is compiled.

We need the information during the tree compile because in combination with the clip rect we can then decide on-the-fly to skip compiling those parts of the tree that will not be visible on screen. This will be implemented in a separate PR.