### PR TITLE
Generate Android framework config

### DIFF
--- a/packages/flutter_tools/templates/create/projectName.iml.tmpl
+++ b/packages/flutter_tools/templates/create/projectName.iml.tmpl
@@ -3,6 +3,7 @@
   <component name="NewModuleRootManager" inherit-compiler-output="true">
     <exclude-output />
     <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$/gen" isTestSource="false" generated="true" />
       <excludeFolder url="file://$MODULE_DIR$/.idea" />
       <excludeFolder url="file://$MODULE_DIR$/.pub" />
       <excludeFolder url="file://$MODULE_DIR$/build" />

--- a/packages/flutter_tools/templates/package/projectName.iml.tmpl
+++ b/packages/flutter_tools/templates/package/projectName.iml.tmpl
@@ -1,13 +1,28 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <module type="WEB_MODULE" version="4">
+  <component name="FacetManager">
+    <facet type="android" name="Android">
+      <configuration>
+        <option name="GEN_FOLDER_RELATIVE_PATH_APT" value="/../../{{projectName}}/gen" />
+        <option name="GEN_FOLDER_RELATIVE_PATH_AIDL" value="/../../{{projectName}}/gen" />
+        <option name="MANIFEST_FILE_RELATIVE_PATH" value="/../../{{projectName}}/AndroidManifest.xml" />
+        <option name="RES_FOLDER_RELATIVE_PATH" value="/../../{{projectName}}/res" />
+        <option name="ASSETS_FOLDER_RELATIVE_PATH" value="/../../{{projectName}}/assets" />
+        <option name="LIBS_FOLDER_RELATIVE_PATH" value="/../../{{projectName}}/libs" />
+        <option name="PROGUARD_LOGS_FOLDER_RELATIVE_PATH" value="/../../{{projectName}}/proguard_logs" />
+      </configuration>
+    </facet>
+  </component>
   <component name="NewModuleRootManager" inherit-compiler-output="true">
     <exclude-output />
     <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$/gen" isTestSource="false" generated="true" />
       <excludeFolder url="file://$MODULE_DIR$/.idea" />
       <excludeFolder url="file://$MODULE_DIR$/.pub" />
       <excludeFolder url="file://$MODULE_DIR$/build" />
       <excludeFolder url="file://$MODULE_DIR$/packages" />
     </content>
+    <orderEntry type="jdk" jdkName="Android API {{androidSdkVersion}} Platform" jdkType="Android SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="library" name="Dart Packages" level="project" />
     <orderEntry type="library" name="Dart SDK" level="project" />

--- a/packages/flutter_tools/templates/plugin/projectName.iml.tmpl
+++ b/packages/flutter_tools/templates/plugin/projectName.iml.tmpl
@@ -1,5 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <module type="WEB_MODULE" version="4">
+  <component name="FacetManager">
+    <facet type="android" name="Android">
+      <configuration>
+        <option name="GEN_FOLDER_RELATIVE_PATH_APT" value="/../../{{projectName}}/gen" />
+        <option name="GEN_FOLDER_RELATIVE_PATH_AIDL" value="/../../{{projectName}}/gen" />
+        <option name="MANIFEST_FILE_RELATIVE_PATH" value="/../../{{projectName}}/AndroidManifest.xml" />
+        <option name="RES_FOLDER_RELATIVE_PATH" value="/../../{{projectName}}/res" />
+        <option name="ASSETS_FOLDER_RELATIVE_PATH" value="/../../{{projectName}}/assets" />
+        <option name="LIBS_FOLDER_RELATIVE_PATH" value="/../../{{projectName}}/libs" />
+        <option name="PROGUARD_LOGS_FOLDER_RELATIVE_PATH" value="/../../{{projectName}}/proguard_logs" />
+      </configuration>
+    </facet>
+  </component>
   <component name="NewModuleRootManager" inherit-compiler-output="true">
     <exclude-output />
     <content url="file://$MODULE_DIR$">
@@ -8,6 +21,7 @@
       <excludeFolder url="file://$MODULE_DIR$/build" />
       <excludeFolder url="file://$MODULE_DIR$/packages" />
     </content>
+    <orderEntry type="jdk" jdkName="Android API {{androidSdkVersion}} Platform" jdkType="Android SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="library" name="Dart Packages" level="project" />
     <orderEntry type="library" name="Dart SDK" level="project" />

--- a/packages/flutter_tools/test/commands/create_test.dart
+++ b/packages/flutter_tools/test/commands/create_test.dart
@@ -46,7 +46,8 @@ void main() {
           'ios/Runner/AppDelegate.m',
           'ios/Runner/main.m',
           'lib/main.dart',
-          'test/widget_test.dart'
+          'test/widget_test.dart',
+          'flutter_project.iml',
         ],
       );
     }, timeout: const Timeout.factor(2.0));
@@ -111,6 +112,7 @@ void main() {
           'example/ios/Runner/AppDelegate.m',
           'example/ios/Runner/main.m',
           'example/lib/main.dart',
+          'flutter_project.iml',
         ],
         plugin: true,
       );


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter-intellij/issues/1347 which is blocking release of the Android Studio plugin.

This patch modifies the generated IntelliJ configuration files to add the Android facet, define the Android SDK, and configure the test directory. 

The tests pass on the build bot and when run from the top level flutter dir. There's a flakey test when run via:
```
cd packages/flutter_tools
pub run test -j1
```
It complains 
```
The following assertion was thrown running a test:
  Who lives, who dies, who tells your story?
```
But sometimes it works.

@devoncarew @mit-mit 