### PR TITLE
FlutterLogoDecoration.lerpFrom/lerpTo with non-logos

### DIFF
--- a/packages/flutter/lib/src/painting/flutter_logo.dart
+++ b/packages/flutter/lib/src/painting/flutter_logo.dart
@@ -165,19 +165,21 @@ class FlutterLogoDecoration extends Decoration {
   @override
   FlutterLogoDecoration lerpFrom(Decoration a, double t) {
     assert(debugAssertIsValid());
-    if (a is! FlutterLogoDecoration)
-      return lerp(null, this, t);
-    assert(a.debugAssertIsValid());
-    return lerp(a, this, t);
+    if (a == null || a is FlutterLogoDecoration) {
+      assert(a == null || a.debugAssertIsValid());
+      return FlutterLogoDecoration.lerp(a, this, t);
+    }
+    return super.lerpFrom(a, t);
   }
 
   @override
   FlutterLogoDecoration lerpTo(Decoration b, double t) {
     assert(debugAssertIsValid());
-    if (b is! FlutterLogoDecoration)
-      return lerp(this, null, t);
-    assert(b.debugAssertIsValid());
-    return lerp(this, b, t);
+    if (b == null || b is FlutterLogoDecoration) {
+      assert(b == null || b.debugAssertIsValid());
+      return FlutterLogoDecoration.lerp(this, b, t);
+    }
+    return super.lerpTo(b, t);
   }
 
   @override

--- a/packages/flutter/test/painting/flutter_logo_test.dart
+++ b/packages/flutter/test/painting/flutter_logo_test.dart
@@ -56,6 +56,11 @@ void main() {
     expect(logo.margin, EdgeInsets.lerp(start.margin, end.margin, 0.5));
   });
 
+  test('FlutterLogoDecorationl.lerpFrom and FlutterLogoDecorationl.lerpTo', () {
+    expect(Decoration.lerp(start, const BoxDecoration(), 1.0), const BoxDecoration());
+    expect(Decoration.lerp(const BoxDecoration(), end, 0.0), end);
+  });
+
   test('FlutterLogoDecoration lerp changes styles at 0.5', () {
     FlutterLogoDecoration logo = FlutterLogoDecoration.lerp(start, end, 0.4);
     expect(logo.style, start.style);


### PR DESCRIPTION
FlutterLogoDecoration should defer to Decoration for what to do when
it doesn't know how to lerp to/from another kind of decoration.