### PR TITLE
Update Semantics for SingleChildScrollViews

### DIFF
--- a/packages/flutter/lib/src/rendering/viewport_offset.dart
+++ b/packages/flutter/lib/src/rendering/viewport_offset.dart
@@ -143,10 +143,6 @@ abstract class ViewportOffset extends ChangeNotifier {
   /// after [applyViewportDimension], if that method is called.
   bool applyContentDimensions(double minScrollExtent, double maxScrollExtent);
 
-  /// Updates the available semantics actions according to the the current
-  /// scroll position.
-  void updateSemanticActions();
-
   /// Apply a layout-time correction to the scroll offset.
   ///
   /// This method should change the [pixels] value by `correction`, but without
@@ -210,11 +206,6 @@ class _FixedViewportOffset extends ViewportOffset {
 
   @override
   bool applyContentDimensions(double minScrollExtent, double maxScrollExtent) => true;
-
-  @override
-  void updateSemanticActions() {
-    // Do nothing.
-  }
 
   @override
   void correctBy(double correction) {

--- a/packages/flutter/lib/src/rendering/viewport_offset.dart
+++ b/packages/flutter/lib/src/rendering/viewport_offset.dart
@@ -143,6 +143,10 @@ abstract class ViewportOffset extends ChangeNotifier {
   /// after [applyViewportDimension], if that method is called.
   bool applyContentDimensions(double minScrollExtent, double maxScrollExtent);
 
+  /// Updates the available semantics actions according to the the current
+  /// scroll position.
+  void updateSemanticActions();
+
   /// Apply a layout-time correction to the scroll offset.
   ///
   /// This method should change the [pixels] value by `correction`, but without
@@ -206,6 +210,11 @@ class _FixedViewportOffset extends ViewportOffset {
 
   @override
   bool applyContentDimensions(double minScrollExtent, double maxScrollExtent) => true;
+
+  @override
+  void updateSemanticActions() {
+    // Do nothing.
+  }
 
   @override
   void correctBy(double correction) {

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -2145,6 +2145,11 @@ class BuildOwner {
 
   int _debugStateLockLevel = 0;
   bool get _debugStateLocked => _debugStateLockLevel > 0;
+
+  //  Whether this element is currently in the process of getting built.
+  //
+  //  Only valid when asserts are enabled.
+  bool get debugBuilding => _debugBuilding;
   bool _debugBuilding = false;
   Element _debugCurrentBuildTarget;
 

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -2146,9 +2146,9 @@ class BuildOwner {
   int _debugStateLockLevel = 0;
   bool get _debugStateLocked => _debugStateLockLevel > 0;
 
-  //  Whether this element is currently in the process of getting built.
-  //
-  //  Only valid when asserts are enabled.
+  /// Whether this widget tree is in the build phase.
+  ///
+  /// Only valid when asserts are enabled.
   bool get debugBuilding => _debugBuilding;
   bool _debugBuilding = false;
   Element _debugCurrentBuildTarget;

--- a/packages/flutter/lib/src/widgets/gesture_detector.dart
+++ b/packages/flutter/lib/src/widgets/gesture_detector.dart
@@ -535,9 +535,7 @@ class RawGestureDetectorState extends State<RawGestureDetector> {
     }
   }
 
-  /// This method can be called after the build phase, during the layout of the
-  /// nearest descendant [RenderObjectWidget] of the gesture detector, to filter
-  /// the list of available semantic actions.
+  /// This method can be called to filter the list of available semantic actions.
   ///
   /// This is used by [Scrollable] to configure system accessibility tools so
   /// that they know in which direction a particular list can be scrolled.
@@ -546,15 +544,6 @@ class RawGestureDetectorState extends State<RawGestureDetector> {
   /// actions to filter changes, it must be called again (during the layout of
   /// the nearest descendant [RenderObjectWidget] of the gesture detector).
   void replaceSemanticsActions(Set<SemanticsAction> actions) {
-    assert(() {
-      if (!context.findRenderObject().owner.debugDoingLayout) {
-        throw new FlutterError(
-          'Unexpected call to replaceSemanticsActions() method of RawGestureDetectorState.\n'
-          'The replaceSemanticsActions() method can only be called during the layout phase.'
-        );
-      }
-      return true;
-    }());
     if (!widget.excludeFromSemantics) {
       final RenderSemanticsGestureHandler semanticsGestureHandler = context.findRenderObject();
       semanticsGestureHandler.validActions = actions;

--- a/packages/flutter/lib/src/widgets/gesture_detector.dart
+++ b/packages/flutter/lib/src/widgets/gesture_detector.dart
@@ -535,18 +535,28 @@ class RawGestureDetectorState extends State<RawGestureDetector> {
     }
   }
 
-  /// This method can be called to filter the list of available semantic actions.
+  /// This method can be called outside of the build phase to filter the list of
+  /// available semantic actions.
   ///
   /// This is used by [Scrollable] to configure system accessibility tools so
   /// that they know in which direction a particular list can be scrolled.
   ///
   /// If this is never called, then the actions are not filtered. If the list of
-  /// actions to filter changes, it must be called again (during the layout of
-  /// the nearest descendant [RenderObjectWidget] of the gesture detector).
+  /// actions to filter changes, it must be called again.
   void replaceSemanticsActions(Set<SemanticsAction> actions) {
+    assert(() {
+      final Element element = context;
+      if (element.owner.debugBuilding) {
+        throw new FlutterError(
+          'Unexpected call to replaceSemanticsActions() method of RawGestureDetectorState.\n'
+          'The replaceSemanticsActions() method can only be called outside of the build phase.'
+        );
+      }
+      return true;
+    }());
     if (!widget.excludeFromSemantics) {
       final RenderSemanticsGestureHandler semanticsGestureHandler = context.findRenderObject();
-      semanticsGestureHandler.validActions = actions;
+      semanticsGestureHandler.validActions = actions;  // will call _markNeedsSemanticsUpdate(), if required.
     }
   }
 

--- a/packages/flutter/lib/src/widgets/gesture_detector.dart
+++ b/packages/flutter/lib/src/widgets/gesture_detector.dart
@@ -538,6 +538,9 @@ class RawGestureDetectorState extends State<RawGestureDetector> {
   /// This method can be called outside of the build phase to filter the list of
   /// available semantic actions.
   ///
+  /// The actual filtering is happening in the next frame and a frame will be
+  /// scheduled if non is pending.
+  ///
   /// This is used by [Scrollable] to configure system accessibility tools so
   /// that they know in which direction a particular list can be scrolled.
   ///

--- a/packages/flutter/lib/src/widgets/scroll_position.dart
+++ b/packages/flutter/lib/src/widgets/scroll_position.dart
@@ -79,6 +79,7 @@ abstract class ScrollPosition extends ViewportOffset with ScrollMetrics {
       absorb(oldPosition);
     if (keepScrollOffset)
       restoreScrollOffset();
+    addListener(_updateSemanticActions);
   }
 
   /// How the scroll position should respond to user input.
@@ -371,8 +372,7 @@ abstract class ScrollPosition extends ViewportOffset with ScrollMetrics {
 
   Set<SemanticsAction> _semanticActions;
 
-  @override
-  void updateSemanticActions() {
+  void _updateSemanticActions() {
     SemanticsAction forward;
     SemanticsAction backward;
     switch (axis) {
@@ -410,7 +410,6 @@ abstract class ScrollPosition extends ViewportOffset with ScrollMetrics {
       applyNewDimensions();
       _didChangeViewportDimension = false;
     }
-    updateSemanticActions();
     return true;
   }
 
@@ -438,6 +437,7 @@ abstract class ScrollPosition extends ViewportOffset with ScrollMetrics {
   void applyNewDimensions() {
     assert(pixels != null);
     activity.applyNewDimensions();
+    _updateSemanticActions();
   }
 
   /// Animates the position such that the given object is as visible as possible

--- a/packages/flutter/lib/src/widgets/scroll_position.dart
+++ b/packages/flutter/lib/src/widgets/scroll_position.dart
@@ -79,7 +79,6 @@ abstract class ScrollPosition extends ViewportOffset with ScrollMetrics {
       absorb(oldPosition);
     if (keepScrollOffset)
       restoreScrollOffset();
-    addListener(_updateSemanticActions);
   }
 
   /// How the scroll position should respond to user input.
@@ -612,6 +611,12 @@ abstract class ScrollPosition extends ViewportOffset with ScrollMetrics {
     activity?.dispose(); // it will be null if it got absorbed by another ScrollPosition
     _activity = null;
     super.dispose();
+  }
+
+  @override
+  void notifyListeners() {
+    _updateSemanticActions();
+    super.notifyListeners();
   }
 
   @override

--- a/packages/flutter/lib/src/widgets/scroll_position.dart
+++ b/packages/flutter/lib/src/widgets/scroll_position.dart
@@ -371,6 +371,16 @@ abstract class ScrollPosition extends ViewportOffset with ScrollMetrics {
 
   Set<SemanticsAction> _semanticActions;
 
+  /// Called whenever the scroll position or the dimensions of the scroll view
+  /// change to update the available semantics actions.
+  ///
+  /// For example: If the scroll view has been scrolled all the way to the top,
+  /// the action to scroll further up needs to be removed as the scroll view
+  /// cannot be scrolled in that direction anymore.
+  ///
+  /// This method is potentially called twice (if scroll position and scroll
+  /// view dimensions both change) and therefore shouldn't do anything
+  /// expansive.
   void _updateSemanticActions() {
     SemanticsAction forward;
     SemanticsAction backward;
@@ -436,7 +446,7 @@ abstract class ScrollPosition extends ViewportOffset with ScrollMetrics {
   void applyNewDimensions() {
     assert(pixels != null);
     activity.applyNewDimensions();
-    _updateSemanticActions();
+    _updateSemanticActions();  // will potentially request a semantics update.
   }
 
   /// Animates the position such that the given object is as visible as possible
@@ -615,7 +625,7 @@ abstract class ScrollPosition extends ViewportOffset with ScrollMetrics {
 
   @override
   void notifyListeners() {
-    _updateSemanticActions();
+    _updateSemanticActions();  // will potentially request a semantics update.
     super.notifyListeners();
   }
 

--- a/packages/flutter/lib/src/widgets/scroll_position.dart
+++ b/packages/flutter/lib/src/widgets/scroll_position.dart
@@ -371,7 +371,8 @@ abstract class ScrollPosition extends ViewportOffset with ScrollMetrics {
 
   Set<SemanticsAction> _semanticActions;
 
-  void _updateSemanticActions() {
+  @override
+  void updateSemanticActions() {
     SemanticsAction forward;
     SemanticsAction backward;
     switch (axis) {
@@ -409,7 +410,7 @@ abstract class ScrollPosition extends ViewportOffset with ScrollMetrics {
       applyNewDimensions();
       _didChangeViewportDimension = false;
     }
-    _updateSemanticActions();
+    updateSemanticActions();
     return true;
   }
 

--- a/packages/flutter/lib/src/widgets/scroll_position.dart
+++ b/packages/flutter/lib/src/widgets/scroll_position.dart
@@ -372,15 +372,17 @@ abstract class ScrollPosition extends ViewportOffset with ScrollMetrics {
   Set<SemanticsAction> _semanticActions;
 
   /// Called whenever the scroll position or the dimensions of the scroll view
-  /// change to update the available semantics actions.
+  /// change to schedule an update of the available semantics actions. The
+  /// actual update will be performed in the nxt frame. If non is pending
+  /// a frame will be scheduled.
   ///
   /// For example: If the scroll view has been scrolled all the way to the top,
   /// the action to scroll further up needs to be removed as the scroll view
   /// cannot be scrolled in that direction anymore.
   ///
-  /// This method is potentially called twice (if scroll position and scroll
-  /// view dimensions both change) and therefore shouldn't do anything
-  /// expansive.
+  /// This method is potentially called twice per frame (if scroll position and
+  /// scroll view dimensions both change) and therefore shouldn't do anything
+  /// expensive.
   void _updateSemanticActions() {
     SemanticsAction forward;
     SemanticsAction backward;

--- a/packages/flutter/lib/src/widgets/single_child_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/single_child_scroll_view.dart
@@ -215,11 +215,17 @@ class _RenderSingleChildViewport extends RenderBox with RenderObjectWithChildMix
     if (value == _offset)
       return;
     if (attached)
-      _offset.removeListener(markNeedsPaint);
+      _offset.removeListener(_hasScrolled);
     _offset = value;
     if (attached)
-      _offset.addListener(markNeedsPaint);
+      _offset.addListener(_hasScrolled);
     markNeedsLayout();
+  }
+
+  void _hasScrolled() {
+    markNeedsPaint();
+    _offset.updateSemanticActions();
+    markNeedsSemanticsUpdate();
   }
 
   @override
@@ -233,12 +239,12 @@ class _RenderSingleChildViewport extends RenderBox with RenderObjectWithChildMix
   @override
   void attach(PipelineOwner owner) {
     super.attach(owner);
-    _offset.addListener(markNeedsPaint);
+    _offset.addListener(_hasScrolled);
   }
 
   @override
   void detach() {
-    _offset.removeListener(markNeedsPaint);
+    _offset.removeListener(_hasScrolled);
     super.detach();
   }
 

--- a/packages/flutter/lib/src/widgets/single_child_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/single_child_scroll_view.dart
@@ -224,7 +224,6 @@ class _RenderSingleChildViewport extends RenderBox with RenderObjectWithChildMix
 
   void _hasScrolled() {
     markNeedsPaint();
-    _offset.updateSemanticActions();
     markNeedsSemanticsUpdate();
   }
 

--- a/packages/flutter/test/material/tabs_test.dart
+++ b/packages/flutter/test/material/tabs_test.dart
@@ -1038,6 +1038,56 @@ void main() {
     semantics.dispose();
   });
 
+  testWidgets('correct scrolling semantics', (WidgetTester tester) async {
+    final SemanticsTester semantics = new SemanticsTester(tester);
+
+    final List<Tab> tabs = new List<Tab>.generate(20, (int index) {
+      return new Tab(text: 'This is a very wide tab #$index');
+    });
+
+    final TabController controller = new TabController(
+      vsync: const TestVSync(),
+      length: tabs.length,
+      initialIndex: 0,
+    );
+
+    await tester.pumpWidget(
+      boilerplate(
+        child: new Semantics(
+          container: true,
+          child: new TabBar(
+            isScrollable: true,
+            controller: controller,
+            tabs: tabs,
+          ),
+        ),
+      ),
+    );
+
+    expect(semantics, includesNodeWith(actions: <SemanticsAction>[SemanticsAction.scrollLeft]));
+    expect(semantics, isNot(includesNodeWith(label: 'This is a very wide tab #10')));
+
+    controller.index = 10;
+    await tester.pumpAndSettle();
+
+    expect(semantics, isNot(includesNodeWith(label: 'This is a very wide tab #0')));
+    expect(semantics, includesNodeWith(actions: <SemanticsAction>[SemanticsAction.scrollLeft, SemanticsAction.scrollRight]));
+    expect(semantics, includesNodeWith(label: 'This is a very wide tab #10'));
+
+    controller.index = 19;
+    await tester.pumpAndSettle();
+
+    expect(semantics, includesNodeWith(actions: <SemanticsAction>[SemanticsAction.scrollRight]));
+
+    controller.index = 0;
+    await tester.pumpAndSettle();
+
+    expect(semantics, includesNodeWith(actions: <SemanticsAction>[SemanticsAction.scrollLeft]));
+    expect(semantics, includesNodeWith(label: 'This is a very wide tab #0'));
+
+    semantics.dispose();
+  });
+
   testWidgets('TabBar etc with zero tabs', (WidgetTester tester) async {
     final TabController controller = new TabController(
       vsync: const TestVSync(),


### PR DESCRIPTION
For the other scroll views updating the semantics is a side effect of layout. However, the `SingleChildScrollView` is not re-layouted after a scroll action and therefore its semantics weren't updated. This caused two issues:

1. After scrolling the semantics tree still had the semantic information of the state before the scroll.
2. The available semantic scroll actions were not updated after the scroll.

This PR makes updating those two points explicit for the SingleChildScrollView. An alternative approach would have been to make those updates a side-effect of painting (similarly to how they are a side-effect of layout for the other scrollviews). 

Fixes https://github.com/flutter/flutter/issues/12275.