### PR TITLE
Print "package" instead of "plugin" when creating a package.

### DIFF
--- a/packages/flutter_tools/lib/src/commands/create.dart
+++ b/packages/flutter_tools/lib/src/commands/create.dart
@@ -165,7 +165,7 @@ class CreateCommand extends FlutterCommand {
       final String relativePath = fs.path.relative(dirPath);
       printStatus('Wrote $generatedCount files.');
       printStatus('');
-      printStatus('Your plugin code is in lib/$projectName.dart in the $relativePath directory.');
+      printStatus('Your package code is in lib/$projectName.dart in the $relativePath directory.');
       return;
     }
 


### PR DESCRIPTION
This only affects package projects. App and plugin projects still print the same message.