### PR TITLE
Fix the doctor check for the flutter intellij plugin

### DIFF
--- a/packages/flutter_tools/lib/src/doctor.dart
+++ b/packages/flutter_tools/lib/src/doctor.dart
@@ -269,8 +269,9 @@ abstract class IntelliJValidator extends DoctorValidator {
   Future<ValidationResult> validate() async {
     final List<ValidationMessage> messages = <ValidationMessage>[];
 
-    _validatePackage(messages, 'flutter-intellij', 'Flutter', minVersion: kMinFlutterPluginVersion);
-    _validatePackage(messages, 'Dart', 'Dart');
+    _validatePackage(messages, <String>['flutter-intellij', 'flutter-intellij.jar'],
+        'Flutter', minVersion: kMinFlutterPluginVersion);
+    _validatePackage(messages, <String>['Dart'], 'Dart');
 
     if (_hasIssues(messages)) {
       messages.add(new ValidationMessage(
@@ -308,26 +309,32 @@ abstract class IntelliJValidator extends DoctorValidator {
     }
   }
 
-  void _validatePackage(List<ValidationMessage> messages, String packageName, String title, {
+  void _validatePackage(List<ValidationMessage> messages, List<String> packageNames, String title, {
     Version minVersion
   }) {
-    if (!hasPackage(packageName)) {
-      messages.add(new ValidationMessage.error(
-        '$title plugin not installed; this adds $title specific functionality.'
-      ));
-      return;
-    }
-    final String versionText = _readPackageVersion(packageName);
-    final Version version = new Version.parse(versionText);
-    if (version != null && minVersion != null && version < minVersion) {
+    for (String packageName in packageNames) {
+      if (!hasPackage(packageName)) {
+        continue;
+      }
+
+      final String versionText = _readPackageVersion(packageName);
+      final Version version = new Version.parse(versionText);
+      if (version != null && minVersion != null && version < minVersion) {
         messages.add(new ValidationMessage.error(
           '$title plugin version $versionText - the recommended minimum version is $minVersion'
         ));
-    } else {
-      messages.add(new ValidationMessage(
-        '$title plugin ${version != null ? "version $version" : "installed"}'
-      ));
+      } else {
+        messages.add(new ValidationMessage(
+          '$title plugin ${version != null ? "version $version" : "installed"}'
+        ));
+      }
+
+      return;
     }
+
+    messages.add(new ValidationMessage.error(
+      '$title plugin not installed; this adds $title specific functionality.'
+    ));
   }
 
   String _readPackageVersion(String packageName) {

--- a/packages/flutter_tools/lib/src/doctor.dart
+++ b/packages/flutter_tools/lib/src/doctor.dart
@@ -269,8 +269,7 @@ abstract class IntelliJValidator extends DoctorValidator {
   Future<ValidationResult> validate() async {
     final List<ValidationMessage> messages = <ValidationMessage>[];
 
-    _validatePackage(messages, 'flutter-intellij.jar', 'Flutter',
-        minVersion: kMinFlutterPluginVersion);
+    _validatePackage(messages, 'flutter-intellij', 'Flutter', minVersion: kMinFlutterPluginVersion);
     _validatePackage(messages, 'Dart', 'Dart');
 
     if (_hasIssues(messages)) {


### PR DESCRIPTION
- fix the doctor check for the flutter intellij plugin (fix https://github.com/flutter/flutter/issues/12380)

The change from the single jar to the zip file distribution format is reflected on disk when users install - this PR check both for `flutter-intellij.jar` and `flutter-intellij/`.

@pq @stevemessick 
