### PR TITLE
Update IDEA project files

### DIFF
--- a/packages/flutter_tools/templates/create/.idea/workspace.xml.tmpl
+++ b/packages/flutter_tools/templates/create/.idea/workspace.xml.tmpl
@@ -20,10 +20,17 @@
     </layout>
   </component>
   <component name="ProjectView">
+    <navigator currentView="ProjectPane" proportions="" version="1">
+    </navigator>
     <panes>
       <pane id="ProjectPane">
         <option name="show-excluded-files" value="false" />
       </pane>
     </panes>
+  </component>
+  <component name="PropertiesComponent">
+    <property name="last_opened_file_path" value="$PROJECT_DIR$" />
+    <property name="dart.analysis.tool.window.force.activate" value="true" />
+    <property name="show.migrate.to.gradle.popup" value="false" />
   </component>
 </project>

--- a/packages/flutter_tools/templates/create/projectName.iml.tmpl
+++ b/packages/flutter_tools/templates/create/projectName.iml.tmpl
@@ -3,6 +3,7 @@
   <component name="NewModuleRootManager" inherit-compiler-output="true">
     <exclude-output />
     <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$/gen" isTestSource="false" generated="true" />
       <excludeFolder url="file://$MODULE_DIR$/.idea" />
       <excludeFolder url="file://$MODULE_DIR$/.pub" />
       <excludeFolder url="file://$MODULE_DIR$/build" />

--- a/packages/flutter_tools/templates/create/projectName.iml.tmpl
+++ b/packages/flutter_tools/templates/create/projectName.iml.tmpl
@@ -3,14 +3,17 @@
   <component name="NewModuleRootManager" inherit-compiler-output="true">
     <exclude-output />
     <content url="file://$MODULE_DIR$">
-      <sourceFolder url="file://$MODULE_DIR$/gen" isTestSource="false" generated="true" />
+      <sourceFolder url="file://$MODULE_DIR$/lib" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/test" isTestSource="true" />
       <excludeFolder url="file://$MODULE_DIR$/.idea" />
       <excludeFolder url="file://$MODULE_DIR$/.pub" />
       <excludeFolder url="file://$MODULE_DIR$/build" />
       <excludeFolder url="file://$MODULE_DIR$/packages" />
+      <excludeFolder url="file://$MODULE_DIR$/test/packages" />
     </content>
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="library" name="Dart Packages" level="project" />
     <orderEntry type="library" name="Dart SDK" level="project" />
+    <orderEntry type="library" name="Flutter Plugins" level="project" />
   </component>
 </module>

--- a/packages/flutter_tools/templates/create/projectName_android.iml.tmpl
+++ b/packages/flutter_tools/templates/create/projectName_android.iml.tmpl
@@ -1,5 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <module type="JAVA_MODULE" version="4">
+  <component name="FacetManager">
+    <facet type="android" name="Android">
+      <configuration>
+        <option name="GEN_FOLDER_RELATIVE_PATH_APT" value="/../../{{projectName}}/gen" />
+        <option name="GEN_FOLDER_RELATIVE_PATH_AIDL" value="/../../{{projectName}}/gen" />
+        <option name="MANIFEST_FILE_RELATIVE_PATH" value="/../../{{projectName}}/AndroidManifest.xml" />
+        <option name="RES_FOLDER_RELATIVE_PATH" value="/../../{{projectName}}/res" />
+        <option name="ASSETS_FOLDER_RELATIVE_PATH" value="/../../{{projectName}}/assets" />
+        <option name="LIBS_FOLDER_RELATIVE_PATH" value="/../../{{projectName}}/libs" />
+        <option name="PROGUARD_LOGS_FOLDER_RELATIVE_PATH" value="/../../{{projectName}}/proguard_logs" />
+      </configuration>
+    </facet>
+  </component>
   <component name="NewModuleRootManager" inherit-compiler-output="true">
     <exclude-output />
     <content url="file://$MODULE_DIR$/android">

--- a/packages/flutter_tools/templates/create/projectName_android.iml.tmpl
+++ b/packages/flutter_tools/templates/create/projectName_android.iml.tmpl
@@ -3,13 +3,13 @@
   <component name="FacetManager">
     <facet type="android" name="Android">
       <configuration>
-        <option name="GEN_FOLDER_RELATIVE_PATH_APT" value="/../../{{projectName}}/gen" />
-        <option name="GEN_FOLDER_RELATIVE_PATH_AIDL" value="/../../{{projectName}}/gen" />
-        <option name="MANIFEST_FILE_RELATIVE_PATH" value="/../../{{projectName}}/AndroidManifest.xml" />
-        <option name="RES_FOLDER_RELATIVE_PATH" value="/../../{{projectName}}/res" />
-        <option name="ASSETS_FOLDER_RELATIVE_PATH" value="/../../{{projectName}}/assets" />
-        <option name="LIBS_FOLDER_RELATIVE_PATH" value="/../../{{projectName}}/libs" />
-        <option name="PROGUARD_LOGS_FOLDER_RELATIVE_PATH" value="/../../{{projectName}}/proguard_logs" />
+        <option name="GEN_FOLDER_RELATIVE_PATH_APT" value="/android/gen" />
+        <option name="GEN_FOLDER_RELATIVE_PATH_AIDL" value="/android/gen" />
+        <option name="MANIFEST_FILE_RELATIVE_PATH" value="/android/AndroidManifest.xml" />
+        <option name="RES_FOLDER_RELATIVE_PATH" value="/android/res" />
+        <option name="ASSETS_FOLDER_RELATIVE_PATH" value="/android/assets" />
+        <option name="LIBS_FOLDER_RELATIVE_PATH" value="/android/libs" />
+        <option name="PROGUARD_LOGS_FOLDER_RELATIVE_PATH" value="/android/proguard_logs" />
       </configuration>
     </facet>
   </component>
@@ -17,6 +17,7 @@
     <exclude-output />
     <content url="file://$MODULE_DIR$/android">
       <sourceFolder url="file://$MODULE_DIR$/android/app/src/main/java" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/android/gen" isTestSource="false" generated="true" />
     </content>
     <orderEntry type="jdk" jdkName="Android API {{androidSdkVersion}} Platform" jdkType="Android SDK" />
     <orderEntry type="sourceFolder" forTests="false" />

--- a/packages/flutter_tools/templates/package/.idea/modules.xml.tmpl
+++ b/packages/flutter_tools/templates/package/.idea/modules.xml.tmpl
@@ -3,7 +3,6 @@
   <component name="ProjectModuleManager">
     <modules>
       <module fileurl="file://$PROJECT_DIR$/{{projectName}}.iml" filepath="$PROJECT_DIR$/{{projectName}}.iml" />
-      <module fileurl="file://$PROJECT_DIR$/{{projectName}}_android.iml" filepath="$PROJECT_DIR$/{{projectName}}_android.iml" />
     </modules>
   </component>
 </project>

--- a/packages/flutter_tools/templates/package/.idea/workspace.xml.tmpl
+++ b/packages/flutter_tools/templates/package/.idea/workspace.xml.tmpl
@@ -20,10 +20,17 @@
     </layout>
   </component>
   <component name="ProjectView">
+    <navigator currentView="ProjectPane" proportions="" version="1">
+    </navigator>
     <panes>
       <pane id="ProjectPane">
         <option name="show-excluded-files" value="false" />
       </pane>
     </panes>
+  </component>
+  <component name="PropertiesComponent">
+    <property name="last_opened_file_path" value="$PROJECT_DIR$" />
+    <property name="dart.analysis.tool.window.force.activate" value="true" />
+    <property name="show.migrate.to.gradle.popup" value="false" />
   </component>
 </project>

--- a/packages/flutter_tools/templates/package/projectName.iml.tmpl
+++ b/packages/flutter_tools/templates/package/projectName.iml.tmpl
@@ -1,22 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <module type="WEB_MODULE" version="4">
-  <component name="FacetManager">
-    <facet type="android" name="Android">
-      <configuration>
-        <option name="GEN_FOLDER_RELATIVE_PATH_APT" value="/../../{{projectName}}/gen" />
-        <option name="GEN_FOLDER_RELATIVE_PATH_AIDL" value="/../../{{projectName}}/gen" />
-        <option name="MANIFEST_FILE_RELATIVE_PATH" value="/../../{{projectName}}/AndroidManifest.xml" />
-        <option name="RES_FOLDER_RELATIVE_PATH" value="/../../{{projectName}}/res" />
-        <option name="ASSETS_FOLDER_RELATIVE_PATH" value="/../../{{projectName}}/assets" />
-        <option name="LIBS_FOLDER_RELATIVE_PATH" value="/../../{{projectName}}/libs" />
-        <option name="PROGUARD_LOGS_FOLDER_RELATIVE_PATH" value="/../../{{projectName}}/proguard_logs" />
-      </configuration>
-    </facet>
-  </component>
   <component name="NewModuleRootManager" inherit-compiler-output="true">
     <exclude-output />
     <content url="file://$MODULE_DIR$">
-      <sourceFolder url="file://$MODULE_DIR$/gen" isTestSource="false" generated="true" />
+      <sourceFolder url="file://$MODULE_DIR$/lib" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/test" isTestSource="true" />
       <excludeFolder url="file://$MODULE_DIR$/.idea" />
       <excludeFolder url="file://$MODULE_DIR$/.pub" />
       <excludeFolder url="file://$MODULE_DIR$/build" />
@@ -26,5 +14,6 @@
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="library" name="Dart Packages" level="project" />
     <orderEntry type="library" name="Dart SDK" level="project" />
+    <orderEntry type="library" name="Flutter Plugins" level="project" />
   </component>
 </module>

--- a/packages/flutter_tools/templates/package/projectName.iml.tmpl
+++ b/packages/flutter_tools/templates/package/projectName.iml.tmpl
@@ -1,13 +1,28 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <module type="WEB_MODULE" version="4">
+  <component name="FacetManager">
+    <facet type="android" name="Android">
+      <configuration>
+        <option name="GEN_FOLDER_RELATIVE_PATH_APT" value="/../../{{projectName}}/gen" />
+        <option name="GEN_FOLDER_RELATIVE_PATH_AIDL" value="/../../{{projectName}}/gen" />
+        <option name="MANIFEST_FILE_RELATIVE_PATH" value="/../../{{projectName}}/AndroidManifest.xml" />
+        <option name="RES_FOLDER_RELATIVE_PATH" value="/../../{{projectName}}/res" />
+        <option name="ASSETS_FOLDER_RELATIVE_PATH" value="/../../{{projectName}}/assets" />
+        <option name="LIBS_FOLDER_RELATIVE_PATH" value="/../../{{projectName}}/libs" />
+        <option name="PROGUARD_LOGS_FOLDER_RELATIVE_PATH" value="/../../{{projectName}}/proguard_logs" />
+      </configuration>
+    </facet>
+  </component>
   <component name="NewModuleRootManager" inherit-compiler-output="true">
     <exclude-output />
     <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$/gen" isTestSource="false" generated="true" />
       <excludeFolder url="file://$MODULE_DIR$/.idea" />
       <excludeFolder url="file://$MODULE_DIR$/.pub" />
       <excludeFolder url="file://$MODULE_DIR$/build" />
       <excludeFolder url="file://$MODULE_DIR$/packages" />
     </content>
+    <orderEntry type="jdk" jdkName="Android API {{androidSdkVersion}} Platform" jdkType="Android SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="library" name="Dart Packages" level="project" />
     <orderEntry type="library" name="Dart SDK" level="project" />

--- a/packages/flutter_tools/templates/plugin/.idea/workspace.xml.tmpl
+++ b/packages/flutter_tools/templates/plugin/.idea/workspace.xml.tmpl
@@ -2,7 +2,7 @@
 <project version="4">
   <component name="FileEditorManager">
     <leaf>
-      <file leaf-file-name="main.dart" pinned="false" current-in-tab="true">
+      <file leaf-file-name="{{projectName}}.dart" pinned="false" current-in-tab="true">
         <entry file="file://$PROJECT_DIR$/lib/{{projectName}}.dart">
           <provider selected="true" editor-type-id="text-editor">
             <state relative-caret-position="0">
@@ -11,7 +11,7 @@
           </provider>
         </entry>
       </file>
-      <file leaf-file-name="main.dart" pinned="false" current-in-tab="true">
+      <file leaf-file-name="main.dart" pinned="false" current-in-tab="false">
         <entry file="file://$PROJECT_DIR$/example/lib/main.dart">
           <provider selected="true" editor-type-id="text-editor">
             <state relative-caret-position="0">
@@ -25,14 +25,21 @@
   <component name="ToolWindowManager">
     <editor active="true" />
     <layout>
-      <window_info id="Project" active="false" anchor="left" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="true" show_stripe_button="true" weight="0.25" sideWeight="0.5" order="0" side_tool="false" content_ui="combo" />
+      <window_info id="Project" active="true" anchor="left" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="true" show_stripe_button="true" weight="0.25" sideWeight="0.5" order="0" side_tool="false" content_ui="combo" />
     </layout>
   </component>
   <component name="ProjectView">
+    <navigator currentView="ProjectPane" proportions="" version="1">
+    </navigator>
     <panes>
       <pane id="ProjectPane">
         <option name="show-excluded-files" value="false" />
       </pane>
     </panes>
+  </component>
+  <component name="PropertiesComponent">
+    <property name="last_opened_file_path" value="$PROJECT_DIR$" />
+    <property name="dart.analysis.tool.window.force.activate" value="true" />
+    <property name="show.migrate.to.gradle.popup" value="false" />
   </component>
 </project>

--- a/packages/flutter_tools/templates/plugin/projectName.iml.tmpl
+++ b/packages/flutter_tools/templates/plugin/projectName.iml.tmpl
@@ -1,5 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <module type="WEB_MODULE" version="4">
+  <component name="FacetManager">
+    <facet type="android" name="Android">
+      <configuration>
+        <option name="GEN_FOLDER_RELATIVE_PATH_APT" value="/../../{{projectName}}/gen" />
+        <option name="GEN_FOLDER_RELATIVE_PATH_AIDL" value="/../../{{projectName}}/gen" />
+        <option name="MANIFEST_FILE_RELATIVE_PATH" value="/../../{{projectName}}/AndroidManifest.xml" />
+        <option name="RES_FOLDER_RELATIVE_PATH" value="/../../{{projectName}}/res" />
+        <option name="ASSETS_FOLDER_RELATIVE_PATH" value="/../../{{projectName}}/assets" />
+        <option name="LIBS_FOLDER_RELATIVE_PATH" value="/../../{{projectName}}/libs" />
+        <option name="PROGUARD_LOGS_FOLDER_RELATIVE_PATH" value="/../../{{projectName}}/proguard_logs" />
+      </configuration>
+    </facet>
+  </component>
   <component name="NewModuleRootManager" inherit-compiler-output="true">
     <exclude-output />
     <content url="file://$MODULE_DIR$">
@@ -8,6 +21,7 @@
       <excludeFolder url="file://$MODULE_DIR$/build" />
       <excludeFolder url="file://$MODULE_DIR$/packages" />
     </content>
+    <orderEntry type="jdk" jdkName="Android API {{androidSdkVersion}} Platform" jdkType="Android SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="library" name="Dart Packages" level="project" />
     <orderEntry type="library" name="Dart SDK" level="project" />

--- a/packages/flutter_tools/templates/plugin/projectName.iml.tmpl
+++ b/packages/flutter_tools/templates/plugin/projectName.iml.tmpl
@@ -1,18 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <module type="WEB_MODULE" version="4">
-  <component name="FacetManager">
-    <facet type="android" name="Android">
-      <configuration>
-        <option name="GEN_FOLDER_RELATIVE_PATH_APT" value="/../../{{projectName}}/gen" />
-        <option name="GEN_FOLDER_RELATIVE_PATH_AIDL" value="/../../{{projectName}}/gen" />
-        <option name="MANIFEST_FILE_RELATIVE_PATH" value="/../../{{projectName}}/AndroidManifest.xml" />
-        <option name="RES_FOLDER_RELATIVE_PATH" value="/../../{{projectName}}/res" />
-        <option name="ASSETS_FOLDER_RELATIVE_PATH" value="/../../{{projectName}}/assets" />
-        <option name="LIBS_FOLDER_RELATIVE_PATH" value="/../../{{projectName}}/libs" />
-        <option name="PROGUARD_LOGS_FOLDER_RELATIVE_PATH" value="/../../{{projectName}}/proguard_logs" />
-      </configuration>
-    </facet>
-  </component>
   <component name="NewModuleRootManager" inherit-compiler-output="true">
     <exclude-output />
     <content url="file://$MODULE_DIR$">
@@ -21,7 +8,6 @@
       <excludeFolder url="file://$MODULE_DIR$/build" />
       <excludeFolder url="file://$MODULE_DIR$/packages" />
     </content>
-    <orderEntry type="jdk" jdkName="Android API {{androidSdkVersion}} Platform" jdkType="Android SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="library" name="Dart Packages" level="project" />
     <orderEntry type="library" name="Dart SDK" level="project" />

--- a/packages/flutter_tools/templates/plugin/projectName.iml.tmpl
+++ b/packages/flutter_tools/templates/plugin/projectName.iml.tmpl
@@ -3,13 +3,18 @@
   <component name="NewModuleRootManager" inherit-compiler-output="true">
     <exclude-output />
     <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$/lib" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/test" isTestSource="true" />
       <excludeFolder url="file://$MODULE_DIR$/.idea" />
       <excludeFolder url="file://$MODULE_DIR$/.pub" />
       <excludeFolder url="file://$MODULE_DIR$/build" />
       <excludeFolder url="file://$MODULE_DIR$/packages" />
+      <excludeFolder url="file://$MODULE_DIR$/example/.pub" />
+      <excludeFolder url="file://$MODULE_DIR$/example/build" />
     </content>
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="library" name="Dart Packages" level="project" />
     <orderEntry type="library" name="Dart SDK" level="project" />
+    <orderEntry type="library" name="Flutter Plugins" level="project" />
   </component>
 </module>

--- a/packages/flutter_tools/templates/plugin/projectName.iml.tmpl
+++ b/packages/flutter_tools/templates/plugin/projectName.iml.tmpl
@@ -4,7 +4,6 @@
     <exclude-output />
     <content url="file://$MODULE_DIR$">
       <sourceFolder url="file://$MODULE_DIR$/lib" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/test" isTestSource="true" />
       <excludeFolder url="file://$MODULE_DIR$/.idea" />
       <excludeFolder url="file://$MODULE_DIR$/.pub" />
       <excludeFolder url="file://$MODULE_DIR$/build" />

--- a/packages/flutter_tools/templates/plugin/projectName_android.iml.tmpl
+++ b/packages/flutter_tools/templates/plugin/projectName_android.iml.tmpl
@@ -3,20 +3,24 @@
   <component name="FacetManager">
     <facet type="android" name="Android">
       <configuration>
-        <option name="GEN_FOLDER_RELATIVE_PATH_APT" value="/../../{{projectName}}/gen" />
-        <option name="GEN_FOLDER_RELATIVE_PATH_AIDL" value="/../../{{projectName}}/gen" />
-        <option name="MANIFEST_FILE_RELATIVE_PATH" value="/../../{{projectName}}/AndroidManifest.xml" />
-        <option name="RES_FOLDER_RELATIVE_PATH" value="/../../{{projectName}}/res" />
-        <option name="ASSETS_FOLDER_RELATIVE_PATH" value="/../../{{projectName}}/assets" />
-        <option name="LIBS_FOLDER_RELATIVE_PATH" value="/../../{{projectName}}/libs" />
-        <option name="PROGUARD_LOGS_FOLDER_RELATIVE_PATH" value="/../../{{projectName}}/proguard_logs" />
+        <option name="GEN_FOLDER_RELATIVE_PATH_APT" value="/android/gen" />
+        <option name="GEN_FOLDER_RELATIVE_PATH_AIDL" value="/android/gen" />
+        <option name="MANIFEST_FILE_RELATIVE_PATH" value="/android/AndroidManifest.xml" />
+        <option name="RES_FOLDER_RELATIVE_PATH" value="/android/res" />
+        <option name="ASSETS_FOLDER_RELATIVE_PATH" value="/android/assets" />
+        <option name="LIBS_FOLDER_RELATIVE_PATH" value="/android/libs" />
+        <option name="PROGUARD_LOGS_FOLDER_RELATIVE_PATH" value="/android/proguard_logs" />
       </configuration>
     </facet>
   </component>
   <component name="NewModuleRootManager" inherit-compiler-output="true">
     <exclude-output />
     <content url="file://$MODULE_DIR$/android">
-      <sourceFolder url="file://$MODULE_DIR$/android/app/src/main/java" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/android/src/main/java" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/android/gen" isTestSource="false" generated="true" />
+    </content>
+    <content url="file://$MODULE_DIR$/example/android">
+      <sourceFolder url="file://$MODULE_DIR$/example/android/app/src/main/java" isTestSource="false" />
     </content>
     <orderEntry type="jdk" jdkName="Android API {{androidSdkVersion}} Platform" jdkType="Android SDK" />
     <orderEntry type="sourceFolder" forTests="false" />

--- a/packages/flutter_tools/templates/plugin/projectName_android.iml.tmpl
+++ b/packages/flutter_tools/templates/plugin/projectName_android.iml.tmpl
@@ -1,5 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <module type="JAVA_MODULE" version="4">
+  <component name="FacetManager">
+    <facet type="android" name="Android">
+      <configuration>
+        <option name="GEN_FOLDER_RELATIVE_PATH_APT" value="/../../{{projectName}}/gen" />
+        <option name="GEN_FOLDER_RELATIVE_PATH_AIDL" value="/../../{{projectName}}/gen" />
+        <option name="MANIFEST_FILE_RELATIVE_PATH" value="/../../{{projectName}}/AndroidManifest.xml" />
+        <option name="RES_FOLDER_RELATIVE_PATH" value="/../../{{projectName}}/res" />
+        <option name="ASSETS_FOLDER_RELATIVE_PATH" value="/../../{{projectName}}/assets" />
+        <option name="LIBS_FOLDER_RELATIVE_PATH" value="/../../{{projectName}}/libs" />
+        <option name="PROGUARD_LOGS_FOLDER_RELATIVE_PATH" value="/../../{{projectName}}/proguard_logs" />
+      </configuration>
+    </facet>
+  </component>
   <component name="NewModuleRootManager" inherit-compiler-output="true">
     <exclude-output />
     <content url="file://$MODULE_DIR$/android">

--- a/packages/flutter_tools/test/commands/create_test.dart
+++ b/packages/flutter_tools/test/commands/create_test.dart
@@ -46,7 +46,8 @@ void main() {
           'ios/Runner/AppDelegate.m',
           'ios/Runner/main.m',
           'lib/main.dart',
-          'test/widget_test.dart'
+          'test/widget_test.dart',
+          'flutter_project.iml',
         ],
       );
     }, timeout: const Timeout.factor(2.0));
@@ -111,6 +112,7 @@ void main() {
           'example/ios/Runner/AppDelegate.m',
           'example/ios/Runner/main.m',
           'example/lib/main.dart',
+          'flutter_project.iml',
         ],
         plugin: true,
       );


### PR DESCRIPTION
@devoncarew @pq 

Updates project files for IntelliJ and Android Studio that are generated by 'flutter create'. For all three project types:
 * Open the Project view (not Android, which is default for AS)
 * Mark special directories
 * Do not generate any balloons when opening the project
 * Add the Android facet if needed
 * Define the project SDK if needed
