### PR TITLE
Disable Dart analysis in Fuchsia.

### DIFF
--- a/examples/flutter_gallery/BUILD.gn
+++ b/examples/flutter_gallery/BUILD.gn
@@ -9,7 +9,7 @@ assert(is_fuchsia)
 flutter_app("flutter_gallery") {
   main_dart = "lib/main.dart"
 
-  analysis_options = "//lib/flutter/analysis_options.yaml"
+  disable_analysis = true
 
   deps = [
     "//lib/flutter/packages/flutter",

--- a/packages/flutter/BUILD.gn
+++ b/packages/flutter/BUILD.gn
@@ -7,7 +7,7 @@ import("//build/dart/dart_package.gni")
 dart_package("flutter") {
   package_name = "flutter"
 
-  analysis_options = "//lib/flutter/analysis_options.yaml"
+  disable_analysis = true
 
   deps = [
     "//third_party/dart-pkg/pub/async",

--- a/packages/flutter_test/BUILD.gn
+++ b/packages/flutter_test/BUILD.gn
@@ -7,7 +7,7 @@ import("//build/dart/dart_package.gni")
 dart_package("flutter_test") {
   package_name = "flutter_test"
 
-  analysis_options = "//lib/flutter/analysis_options.yaml"
+  disable_analysis = true
 
   deps = [
     "//lib/flutter/packages/flutter",

--- a/packages/flutter_tools/BUILD.gn
+++ b/packages/flutter_tools/BUILD.gn
@@ -8,7 +8,7 @@ import("//build/dart/dart_tool.gni")
 dart_package("flutter_tools") {
   package_name = "flutter_tools"
 
-  analysis_options = "//lib/flutter/analysis_options.yaml"
+  disable_analysis = true
 
   deps = [
     "//dart/pkg/analyzer",
@@ -42,7 +42,7 @@ dart_package("flutter_tools") {
 dart_tool("fuchsia_builder") {
   main_dart = "bin/fuchsia_builder.dart"
 
-  analysis_options = "//lib/flutter/analysis_options.yaml"
+  disable_analysis = true
 
   deps = [
     ":flutter_tools",
@@ -52,7 +52,7 @@ dart_tool("fuchsia_builder") {
 dart_tool("fuchsia_tester") {
   main_dart = "bin/fuchsia_tester.dart"
 
-  analysis_options = "//lib/flutter/analysis_options.yaml"
+  disable_analysis = true
 
   deps = [
     ":flutter_tools",


### PR DESCRIPTION
Fuchsia will soon use a newer version of the Dart analysis server which Flutter code has not been adjusted for yet.