### PR TITLE
Fix flex floating point error causing unnecessary striped warnings

### DIFF
--- a/dev/automated_tests/flutter_test/exception_handling_expectation.txt
+++ b/dev/automated_tests/flutter_test/exception_handling_expectation.txt
@@ -16,6 +16,7 @@ Exception handling in test harness - string
 ════════════════════════════════════════════════════════════════════════════════════════════════════
 .*(this line has more of the test framework's output)?
   Test failed\. See exception logs above\.
+  The test description was: Exception handling in test harness - string
  *
 [^═]*(this line contains the test framework's output with the clock and so forth)?
 ══╡ EXCEPTION CAUGHT BY FLUTTER TEST FRAMEWORK ╞════════════════════════════════════════════════════
@@ -35,6 +36,7 @@ Exception handling in test harness - FlutterError
 ════════════════════════════════════════════════════════════════════════════════════════════════════
 .*(this line has more of the test framework's output)?
   Test failed\. See exception logs above\.
+  The test description was: Exception handling in test harness - FlutterError
  *
 [^═]*(this line contains the test framework's output with the clock and so forth)?
 ══╡ EXCEPTION CAUGHT BY FLUTTER TEST FRAMEWORK ╞════════════════════════════════════════════════════
@@ -54,5 +56,6 @@ Exception handling in test harness - uncaught Future error
 ════════════════════════════════════════════════════════════════════════════════════════════════════
 .*(this line has more of the test framework's output)?
   Test failed\. See exception logs above\.
+  The test description was: Exception handling in test harness - uncaught Future error
  *
 .*..:.. \+0 -3: Some tests failed\. *

--- a/dev/automated_tests/flutter_test/test_async_utils_guarded_expectation.txt
+++ b/dev/automated_tests/flutter_test/test_async_utils_guarded_expectation.txt
@@ -20,5 +20,6 @@ TestAsyncUtils - custom guarded sections
 ════════════════════════════════════════════════════════════════════════════════════════════════════
 .*(this line has more of the test framework's output)?
   Test failed\. See exception logs above\.
+  The test description was: TestAsyncUtils - custom guarded sections
  *
 .*..:.. \+0 -1: Some tests failed\. *

--- a/dev/automated_tests/flutter_test/test_async_utils_unguarded_expectation.txt
+++ b/dev/automated_tests/flutter_test/test_async_utils_unguarded_expectation.txt
@@ -18,6 +18,7 @@ The test description was:
 TestAsyncUtils - handling unguarded async helper functions
 ════════════════════════════════════════════════════════════════════════════════════════════════════
 .*..:.. \+0 -1: - TestAsyncUtils - handling unguarded async helper functions *
-  Test failed. See exception logs above.
+  Test failed\. See exception logs above\.
+  The test description was: TestAsyncUtils - handling unguarded async helper functions
  *
 .*..:.. \+0 -1: Some tests failed\. *

--- a/packages/flutter/lib/src/foundation/assertions.dart
+++ b/packages/flutter/lib/src/foundation/assertions.dart
@@ -200,7 +200,11 @@ class FlutterError extends AssertionError {
     _errorCount = 0;
   }
 
-  static const int _kWrapWidth = 100;
+  /// The width to which [dumpErrorToConsole] will wrap lines.
+  ///
+  /// This can be used to ensure strings will not exceed the length at which
+  /// they will wrap, e.g. when placing ASCII art diagrams in messages.
+  static const int wrapWidth = 100;
 
   /// Prints the given exception details to the console.
   ///
@@ -227,13 +231,13 @@ class FlutterError extends AssertionError {
       return;
     if (_errorCount == 0 || forceReport) {
       final String header = '\u2550\u2550\u2561 EXCEPTION CAUGHT BY ${details.library} \u255E'.toUpperCase();
-      final String footer = '\u2550' * _kWrapWidth;
+      final String footer = '\u2550' * wrapWidth;
       debugPrint('$header${"\u2550" * (footer.length - header.length)}');
       final String verb = 'thrown${ details.context != null ? " ${details.context}" : ""}';
       if (details.exception is NullThrownError) {
-        debugPrint('The null value was $verb.', wrapWidth: _kWrapWidth);
+        debugPrint('The null value was $verb.', wrapWidth: wrapWidth);
       } else if (details.exception is num) {
-        debugPrint('The number ${details.exception} was $verb.', wrapWidth: _kWrapWidth);
+        debugPrint('The number ${details.exception} was $verb.', wrapWidth: wrapWidth);
       } else {
         String errorName;
         if (details.exception is AssertionError) {
@@ -252,7 +256,7 @@ class FlutterError extends AssertionError {
         String message = details.exceptionAsString();
         if (message.startsWith(prefix))
           message = message.substring(prefix.length);
-        debugPrint('The following $errorName was $verb:\n$message', wrapWidth: _kWrapWidth);
+        debugPrint('The following $errorName was $verb:\n$message', wrapWidth: wrapWidth);
       }
       Iterable<String> stackLines = (details.stack != null) ? details.stack.toString().trimRight().split('\n') : null;
       if ((details.exception is AssertionError) && (details.exception is! FlutterError)) {
@@ -276,25 +280,25 @@ class FlutterError extends AssertionError {
         if (ourFault) {
           debugPrint('\nEither the assertion indicates an error in the framework itself, or we should '
                      'provide substantially more information in this error message to help you determine '
-                     'and fix the underlying cause.', wrapWidth: _kWrapWidth);
-          debugPrint('In either case, please report this assertion by filing a bug on GitHub:', wrapWidth: _kWrapWidth);
+                     'and fix the underlying cause.', wrapWidth: wrapWidth);
+          debugPrint('In either case, please report this assertion by filing a bug on GitHub:', wrapWidth: wrapWidth);
           debugPrint('  https://github.com/flutter/flutter/issues/new');
         }
       }
       if (details.stack != null) {
-        debugPrint('\nWhen the exception was thrown, this was the stack:', wrapWidth: _kWrapWidth);
+        debugPrint('\nWhen the exception was thrown, this was the stack:', wrapWidth: wrapWidth);
         if (details.stackFilter != null) {
           stackLines = details.stackFilter(stackLines);
         } else {
           stackLines = defaultStackFilter(stackLines);
         }
         for (String line in stackLines)
-          debugPrint(line, wrapWidth: _kWrapWidth);
+          debugPrint(line, wrapWidth: wrapWidth);
       }
       if (details.informationCollector != null) {
         final StringBuffer information = new StringBuffer();
         details.informationCollector(information);
-        debugPrint('\n${information.toString().trimRight()}', wrapWidth: _kWrapWidth);
+        debugPrint('\n${information.toString().trimRight()}', wrapWidth: wrapWidth);
       }
       debugPrint(footer);
     } else {

--- a/packages/flutter/lib/src/rendering/box.dart
+++ b/packages/flutter/lib/src/rendering/box.dart
@@ -411,11 +411,15 @@ class BoxConstraints extends Constraints {
       return a * (1.0 - t);
     assert(a.debugAssertIsValid());
     assert(b.debugAssertIsValid());
+    assert((a.minWidth.isFinite && b.minWidth.isFinite) || (a.minWidth == double.INFINITY && b.minWidth == double.INFINITY), 'Cannot interpolate between finite constraints and unbounded constraints.');
+    assert((a.maxWidth.isFinite && b.maxWidth.isFinite) || (a.maxWidth == double.INFINITY && b.maxWidth == double.INFINITY), 'Cannot interpolate between finite constraints and unbounded constraints.');
+    assert((a.minHeight.isFinite && b.minHeight.isFinite) || (a.minHeight == double.INFINITY && b.minHeight == double.INFINITY), 'Cannot interpolate between finite constraints and unbounded constraints.');
+    assert((a.maxHeight.isFinite && b.maxHeight.isFinite) || (a.maxHeight == double.INFINITY && b.maxHeight == double.INFINITY), 'Cannot interpolate between finite constraints and unbounded constraints.');
     return new BoxConstraints(
-      minWidth: ui.lerpDouble(a.minWidth, b.minWidth, t),
-      maxWidth: ui.lerpDouble(a.maxWidth, b.maxWidth, t),
-      minHeight: ui.lerpDouble(a.minHeight, b.minHeight, t),
-      maxHeight: ui.lerpDouble(a.maxHeight, b.maxHeight, t)
+      minWidth: a.minWidth.isFinite ? ui.lerpDouble(a.minWidth, b.minWidth, t) : double.INFINITY,
+      maxWidth: a.maxWidth.isFinite ? ui.lerpDouble(a.maxWidth, b.maxWidth, t) : double.INFINITY,
+      minHeight: a.minHeight.isFinite ? ui.lerpDouble(a.minHeight, b.minHeight, t) : double.INFINITY,
+      maxHeight: a.maxHeight.isFinite ? ui.lerpDouble(a.maxHeight, b.maxHeight, t) : double.INFINITY,
     );
   }
 

--- a/packages/flutter/test/material/app_bar_test.dart
+++ b/packages/flutter/test/material/app_bar_test.dart
@@ -971,9 +971,9 @@ void main() {
             leading: new Placeholder(key: key),
             title: const Text('Abc'),
             actions: <Widget>[
-              const Placeholder(),
-              const Placeholder(),
-              const Placeholder(),
+              const Placeholder(fallbackWidth: 10.0),
+              const Placeholder(fallbackWidth: 10.0),
+              const Placeholder(fallbackWidth: 10.0),
             ],
           ),
         ),
@@ -992,9 +992,9 @@ void main() {
             leading: new Placeholder(key: key),
             title: const Text('Abc'),
             actions: <Widget>[
-              const Placeholder(),
-              const Placeholder(),
-              const Placeholder(),
+              const Placeholder(fallbackWidth: 10.0),
+              const Placeholder(fallbackWidth: 10.0),
+              const Placeholder(fallbackWidth: 10.0),
             ],
             flexibleSpace: new DecoratedBox(
               decoration: new BoxDecoration(
@@ -1022,9 +1022,9 @@ void main() {
             leading: new Placeholder(key: key),
             title: const Text('Abc'),
             actions: <Widget>[
-              const Placeholder(),
-              const Placeholder(),
-              const Placeholder(),
+              const Placeholder(fallbackWidth: 10.0),
+              const Placeholder(fallbackWidth: 10.0),
+              const Placeholder(fallbackWidth: 10.0),
             ],
             flexibleSpace: new DecoratedBox(
               decoration: new BoxDecoration(
@@ -1063,9 +1063,9 @@ void main() {
             leading: new Placeholder(key: key),
             title: const Text('Abc'),
             actions: <Widget>[
-              const Placeholder(),
-              const Placeholder(),
-              const Placeholder(),
+              const Placeholder(fallbackWidth: 10.0),
+              const Placeholder(fallbackWidth: 10.0),
+              const Placeholder(fallbackWidth: 10.0),
             ],
             bottom: new PreferredSize(
               preferredSize: const Size(0.0, kToolbarHeight),

--- a/packages/flutter/test/material/paginated_data_table_test.dart
+++ b/packages/flutter/test/material/paginated_data_table_test.dart
@@ -151,6 +151,9 @@ void main() {
       home: buildTable(source),
     ));
 
+    // the column overflows because we're forcing it to 600 pixels high
+    expect(tester.takeException(), contains('A vertical RenderFlex overflowed by'));
+
     expect(find.text('Gingerbread (0)'), findsOneWidget);
     expect(find.text('Gingerbread (1)'), findsNothing);
     expect(find.text('42'), findsNWidgets(10));

--- a/packages/flutter/test/rendering/box_constraints_test.dart
+++ b/packages/flutter/test/rendering/box_constraints_test.dart
@@ -90,6 +90,74 @@ void main() {
     expect(copy.maxHeight, 97.0);
   });
 
+  test('BoxConstraints lerp with unbounded width', () {
+    final BoxConstraints constraints1 = const BoxConstraints(
+      minWidth: double.INFINITY,
+      maxWidth: double.INFINITY,
+      minHeight: 10.0,
+      maxHeight: 20.0,
+    );
+    final BoxConstraints constraints2 = const BoxConstraints(
+      minWidth: double.INFINITY,
+      maxWidth: double.INFINITY,
+      minHeight: 20.0,
+      maxHeight: 30.0,
+    );
+    final BoxConstraints constraints3 = const BoxConstraints(
+      minWidth: double.INFINITY,
+      maxWidth: double.INFINITY,
+      minHeight: 15.0,
+      maxHeight: 25.0,
+    );
+    expect(BoxConstraints.lerp(constraints1, constraints2, 0.5), constraints3);
+  });
+
+  test('BoxConstraints lerp with unbounded height', () {
+    final BoxConstraints constraints1 = const BoxConstraints(
+      minWidth: 10.0,
+      maxWidth: 20.0,
+      minHeight: double.INFINITY,
+      maxHeight: double.INFINITY,
+    );
+    final BoxConstraints constraints2 = const BoxConstraints(
+      minWidth: 20.0,
+      maxWidth: 30.0,
+      minHeight: double.INFINITY,
+      maxHeight: double.INFINITY,
+    );
+    final BoxConstraints constraints3 = const BoxConstraints(
+      minWidth: 15.0,
+      maxWidth: 25.0,
+      minHeight: double.INFINITY,
+      maxHeight: double.INFINITY,
+    );
+    expect(BoxConstraints.lerp(constraints1, constraints2, 0.5), constraints3);
+  });
+
+  test('BoxConstraints lerp from bounded to unbounded', () {
+    final BoxConstraints constraints1 = const BoxConstraints(
+      minWidth: double.INFINITY,
+      maxWidth: double.INFINITY,
+      minHeight: double.INFINITY,
+      maxHeight: double.INFINITY,
+    );
+    final BoxConstraints constraints2 = const BoxConstraints(
+      minWidth: 20.0,
+      maxWidth: 30.0,
+      minHeight: double.INFINITY,
+      maxHeight: double.INFINITY,
+    );
+    final BoxConstraints constraints3 = const BoxConstraints(
+      minWidth: double.INFINITY,
+      maxWidth: double.INFINITY,
+      minHeight: 20.0,
+      maxHeight: 30.0,
+    );
+    expect(() => BoxConstraints.lerp(constraints1, constraints2, 0.5), throwsA(const isInstanceOf<AssertionError>()));
+    expect(() => BoxConstraints.lerp(constraints1, constraints3, 0.5), throwsA(const isInstanceOf<AssertionError>()));
+    expect(() => BoxConstraints.lerp(constraints2, constraints3, 0.5), throwsA(const isInstanceOf<AssertionError>()));
+  });
+
   test('BoxConstraints normalize', () {
     final BoxConstraints constraints = const BoxConstraints(
       minWidth: 3.0,

--- a/packages/flutter/test/widgets/automatic_keep_alive_test.dart
+++ b/packages/flutter/test/widgets/automatic_keep_alive_test.dart
@@ -221,7 +221,7 @@ void main() {
             new AutomaticKeepAlive(
               child: new Container(
                 height: 400.0,
-                child: new Row(children: <Widget>[
+                child: new Stack(children: <Widget>[
                   new Leaf(key: const GlobalObjectKey<_LeafState>(0), child: const Placeholder()),
                   new Leaf(key: const GlobalObjectKey<_LeafState>(1), child: const Placeholder()),
                 ]),
@@ -297,7 +297,7 @@ void main() {
             new AutomaticKeepAlive(
               child: new Container(
                 height: 400.0,
-                child: new Row(children: <Widget>[
+                child: new Stack(children: <Widget>[
                   new Leaf(key: const GlobalObjectKey<_LeafState>(0), child: const Placeholder()),
                   new Leaf(key: const GlobalObjectKey<_LeafState>(1), child: const Placeholder()),
                 ]),
@@ -306,7 +306,7 @@ void main() {
             new AutomaticKeepAlive(
               child: new Container(
                 height: 400.0,
-                child: new Row(children: <Widget>[
+                child: new Stack(children: <Widget>[
                   new Leaf(key: const GlobalObjectKey<_LeafState>(2), child: const Placeholder()),
                   new Leaf(key: const GlobalObjectKey<_LeafState>(3), child: const Placeholder()),
                 ]),
@@ -315,7 +315,7 @@ void main() {
             new AutomaticKeepAlive(
               child: new Container(
                 height: 400.0,
-                child: new Row(children: <Widget>[
+                child: new Stack(children: <Widget>[
                   new Leaf(key: const GlobalObjectKey<_LeafState>(4), child: const Placeholder()),
                   new Leaf(key: const GlobalObjectKey<_LeafState>(5), child: const Placeholder()),
                 ]),
@@ -349,7 +349,7 @@ void main() {
           new AutomaticKeepAlive(
             child: new Container(
               height: 400.0,
-              child: new Row(children: <Widget>[
+              child: new Stack(children: <Widget>[
                 new Leaf(key: const GlobalObjectKey<_LeafState>(1), child: const Placeholder()),
               ]),
             ),
@@ -357,7 +357,7 @@ void main() {
           new AutomaticKeepAlive(
             child: new Container(
               height: 400.0,
-              child: new Row(children: <Widget>[
+              child: new Stack(children: <Widget>[
                 new Leaf(key: const GlobalObjectKey<_LeafState>(2), child: const Placeholder()),
                 new Leaf(key: const GlobalObjectKey<_LeafState>(3), child: const Placeholder()),
               ]),
@@ -366,7 +366,7 @@ void main() {
           new AutomaticKeepAlive(
             child: new Container(
               height: 400.0,
-              child: new Row(children: <Widget>[
+              child: new Stack(children: <Widget>[
                 new Leaf(key: const GlobalObjectKey<_LeafState>(4), child: const Placeholder()),
                 new Leaf(key: const GlobalObjectKey<_LeafState>(5), child: const Placeholder()),
                 new Leaf(key: const GlobalObjectKey<_LeafState>(0), child: const Placeholder()),
@@ -408,7 +408,7 @@ void main() {
           new AutomaticKeepAlive(
             child: new Container(
               height: 400.0,
-              child: new Row(children: <Widget>[
+              child: new Stack(children: <Widget>[
                 new Leaf(key: const GlobalObjectKey<_LeafState>(1), child: const Placeholder()),
                 new Leaf(key: const GlobalObjectKey<_LeafState>(2), child: const Placeholder()),
               ]),
@@ -417,14 +417,14 @@ void main() {
           new AutomaticKeepAlive(
             child: new Container(
               height: 400.0,
-              child: new Row(children: <Widget>[
+              child: new Stack(children: <Widget>[
               ]),
             ),
           ),
           new AutomaticKeepAlive(
             child: new Container(
               height: 400.0,
-              child: new Row(children: <Widget>[
+              child: new Stack(children: <Widget>[
                 new Leaf(key: const GlobalObjectKey<_LeafState>(3), child: const Placeholder()),
                 new Leaf(key: const GlobalObjectKey<_LeafState>(4), child: const Placeholder()),
                 new Leaf(key: const GlobalObjectKey<_LeafState>(5), child: const Placeholder()),

--- a/packages/flutter/test/widgets/column_test.dart
+++ b/packages/flutter/test/widgets/column_test.dart
@@ -384,6 +384,8 @@ void main() {
       )
     ));
 
+    expect(tester.takeException(), contains('overflowed'));
+
     final RenderBox renderBox = tester.renderObject(find.byKey(childKey));
     expect(renderBox.size.width, equals(0.0));
     expect(renderBox.size.height, equals(100.0));
@@ -776,6 +778,8 @@ void main() {
         )
       )
     ));
+
+    expect(tester.takeException(), contains('overflowed'));
 
     final RenderBox renderBox = tester.renderObject(find.byKey(childKey));
     expect(renderBox.size.width, equals(0.0));

--- a/packages/flutter/test/widgets/flex_test.dart
+++ b/packages/flutter/test/widgets/flex_test.dart
@@ -72,4 +72,42 @@ void main() {
       ),
     );
   });
+
+  testWidgets('Doesn\'t overflow because of floating point accumulated error', (WidgetTester tester) async {
+    // both of these cases have failed in the past due to floating point issues
+    await tester.pumpWidget(
+      new Center(
+        child: new Container(
+          height: 400.0,
+          child: new Column(
+            children: <Widget>[
+              new Expanded(child: new Container()),
+              new Expanded(child: new Container()),
+              new Expanded(child: new Container()),
+              new Expanded(child: new Container()),
+              new Expanded(child: new Container()),
+              new Expanded(child: new Container()),
+            ],
+          ),
+        ),
+      ),
+    );
+    await tester.pumpWidget(
+      new Center(
+        child: new Container(
+          height: 199.0,
+          child: new Column(
+            children: <Widget>[
+              new Expanded(child: new Container()),
+              new Expanded(child: new Container()),
+              new Expanded(child: new Container()),
+              new Expanded(child: new Container()),
+              new Expanded(child: new Container()),
+              new Expanded(child: new Container()),
+            ],
+          ),
+        ),
+      ),
+    );
+  });
 }

--- a/packages/flutter/test/widgets/global_keys_duplicated_test.dart
+++ b/packages/flutter/test/widgets/global_keys_duplicated_test.dart
@@ -12,19 +12,19 @@ void main() {
   testWidgets('GlobalKey children of one node', (WidgetTester tester) async {
     // This is actually a test of the regular duplicate key logic, which
     // happens before the duplicate GlobalKey logic.
-    await tester.pumpWidget(new Row(children: <Widget>[
+    await tester.pumpWidget(new Stack(children: <Widget>[
       new Container(key: const GlobalObjectKey(0)),
       new Container(key: const GlobalObjectKey(0)),
     ]));
     final dynamic error = tester.takeException();
     expect(error, isFlutterError);
     expect(error.toString(), startsWith('Duplicate keys found.\n'));
-    expect(error.toString(), contains('Row'));
+    expect(error.toString(), contains('Stack'));
     expect(error.toString(), contains('[GlobalObjectKey ${describeIdentity(0)}]'));
   });
 
   testWidgets('GlobalKey children of two nodes', (WidgetTester tester) async {
-    await tester.pumpWidget(new Row(
+    await tester.pumpWidget(new Stack(
       textDirection: TextDirection.ltr,
       children: <Widget>[
         new Container(child: new Container(key: const GlobalObjectKey(0))),
@@ -41,7 +41,7 @@ void main() {
   });
 
   testWidgets('GlobalKey children of two different nodes', (WidgetTester tester) async {
-    await tester.pumpWidget(new Row(
+    await tester.pumpWidget(new Stack(
       textDirection: TextDirection.ltr,
       children: <Widget>[
         new Container(child: new Container(key: const GlobalObjectKey(0))),
@@ -61,7 +61,7 @@ void main() {
   testWidgets('GlobalKey children of two nodes', (WidgetTester tester) async {
     StateSetter nestedSetState;
     bool flag = false;
-    await tester.pumpWidget(new Row(
+    await tester.pumpWidget(new Stack(
       textDirection: TextDirection.ltr,
       children: <Widget>[
         new Container(child: new Container(key: const GlobalObjectKey(0))),

--- a/packages/flutter/test/widgets/row_test.dart
+++ b/packages/flutter/test/widgets/row_test.dart
@@ -302,6 +302,8 @@ void main() {
       ),
     ));
 
+    expect(tester.takeException(), contains('overflowed'));
+
     final RenderBox renderBox = tester.renderObject(find.byKey(childKey));
     expect(renderBox.size.width, equals(100.0));
     expect(renderBox.size.height, equals(0.0));
@@ -725,6 +727,8 @@ void main() {
       ),
     ));
 
+    expect(tester.takeException(), contains('overflowed'));
+
     final RenderBox renderBox = tester.renderObject(find.byKey(childKey));
     expect(renderBox.size.width, equals(100.0));
     expect(renderBox.size.height, equals(0.0));
@@ -1147,6 +1151,8 @@ void main() {
         ),
       ),
     ));
+
+    expect(tester.takeException(), contains('overflowed'));
 
     final RenderBox renderBox = tester.renderObject(find.byKey(childKey));
     expect(renderBox.size.width, equals(100.0));

--- a/packages/flutter/test/widgets/semantics_clipping_test.dart
+++ b/packages/flutter/test/widgets/semantics_clipping_test.dart
@@ -39,6 +39,8 @@ void main() {
       ),
     ));
 
+    expect(tester.takeException(), contains('overflowed'));
+
     expect(semantics, hasSemantics(
       new TestSemantics.root(
         children: <TestSemantics>[
@@ -108,6 +110,8 @@ void main() {
         ),
       ),
     ));
+
+    expect(tester.takeException(), contains('overflowed'));
 
     expect(semantics, hasSemantics(
       new TestSemantics.root(


### PR DESCRIPTION
Also:

 * Provide a better message when you lerp from infinity to finity
   constraints.

 * Make the striped marker support RTL.

 * By popular demand, dump a warning to the console the first time
   a particular Flex overflows. (Resets on hot reload.)