### PR TITLE
Workaround a connection issue on iOS 11.0.x

### DIFF
--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -83,7 +83,7 @@ class IMobileDevice {
 
   Future<String> getInfoForDevice(String deviceID, String key) async {
     try {
-      final ProcessResult result = await processManager.run(<String>['ideviceinfo', '-u', deviceID, '-k', key,]);
+      final ProcessResult result = await processManager.run(<String>['ideviceinfo', '-u', deviceID, '-k', key, '--simple']);
       if (result.exitCode != 0)
         throw new ToolExit('idevice_id returned an error:\n${result.stderr}');
       return result.stdout.trim();


### PR DESCRIPTION
On iOS 11.0.x ideviceinfo fails with the following message
ERROR: Could not connect to lockdownd, error code -3

This workaround should also work for #12330