### PR TITLE
Use const for const constructor

### DIFF
--- a/packages/flutter/lib/src/material/bottom_navigation_bar.dart
+++ b/packages/flutter/lib/src/material/bottom_navigation_bar.dart
@@ -452,7 +452,7 @@ class _BottomNavigationBarState extends State<BottomNavigationBar> with TickerPr
           ),
         ),
         new ConstrainedBox(
-          constraints: new BoxConstraints(minHeight: kBottomNavigationBarHeight),
+          constraints: const BoxConstraints(minHeight: kBottomNavigationBarHeight),
           child: new Stack(
             children: <Widget>[
               new Positioned.fill(


### PR DESCRIPTION
This fixes analyzer lint warning https://flutter-dashboard.appspot.com/api/get-log?ownerKey=ahNzfmZsdXR0ZXItZGFzaGJvYXJkclgLEglDaGVja2xpc3QiOGZsdXR0ZXIvZmx1dHRlci80ZTQ4YTczN2ViNGUwZTY4OWU1MjY3OGE1MGQ1ZjE1ZWUyNmM1YjBmDAsSBFRhc2sYgICAgICAkAgM.

It's not clear why it started to fail after https://github.com/flutter/flutter/commit/4e48a737eb4e0e689e52678a50d5f15ee26c5b0f as that PR seems to have not much to do with flagged code.