### PR TITLE
Pass --enable_mirrors=false when building script snapshots for debug mode.

### DIFF
--- a/packages/flutter_tools/lib/src/base/build.dart
+++ b/packages/flutter_tools/lib/src/base/build.dart
@@ -167,6 +167,7 @@ class Snapshotter {
     final List<String> args = <String>[
       '--snapshot_kind=script',
       '--script_snapshot=$snapshotPath',
+      '--enable-mirrors=false',
       mainPath,
     ];
 


### PR DESCRIPTION
The initial loading happens on the host, which was building a script snapshot and allowing imports of dart:mirrors. Hot reload happens on the device, which then notices the imports and issues a compile-time error. This change causes programs with imports of dart:mirrors to be rejected during the initial load.

Fixes https://github.com/flutter/flutter/issues/12440