### PR TITLE
Move this-referencing asserts to constructor body.

### DIFF
--- a/packages/flutter/lib/src/cupertino/route.dart
+++ b/packages/flutter/lib/src/cupertino/route.dart
@@ -88,8 +88,9 @@ class CupertinoPageRoute<T> extends PageRoute<T> {
        assert(settings != null),
        assert(maintainState != null),
        assert(fullscreenDialog != null),
-       assert(opaque), // PageRoute makes it return true.
-       super(settings: settings, fullscreenDialog: fullscreenDialog);
+       super(settings: settings, fullscreenDialog: fullscreenDialog) {
+    assert(opaque); // PageRoute makes it return true.
+  }
 
   /// Builds the primary contents of the route.
   final WidgetBuilder builder;

--- a/packages/flutter/lib/src/material/page.dart
+++ b/packages/flutter/lib/src/material/page.dart
@@ -70,8 +70,9 @@ class MaterialPageRoute<T> extends PageRoute<T> {
     this.maintainState: true,
     bool fullscreenDialog: false,
   }) : assert(builder != null),
-       assert(opaque),
-       super(settings: settings, fullscreenDialog: fullscreenDialog);
+       super(settings: settings, fullscreenDialog: fullscreenDialog) {
+    assert(opaque);
+  }
 
   /// Builds the primary contents of the route.
   final WidgetBuilder builder;

--- a/packages/flutter/lib/src/widgets/pages.dart
+++ b/packages/flutter/lib/src/widgets/pages.dart
@@ -81,10 +81,11 @@ class PageRouteBuilder<T> extends PageRoute<T> {
     this.maintainState: true,
   }) : assert(pageBuilder != null),
        assert(transitionsBuilder != null),
-       assert(opaque != null),
        assert(barrierDismissible != null),
        assert(maintainState != null),
-       super(settings: settings);
+       super(settings: settings) {
+    assert(opaque != null);
+  }
 
   /// Used build the route's primary contents.
   ///


### PR DESCRIPTION
Dart recently started enforcing the rule that constructor initializer asserts can't reference "this".