### PR TITLE
Keep CircleAvatar from scaling the text with textScaleFactor

### DIFF
--- a/packages/flutter/lib/src/material/circle_avatar.dart
+++ b/packages/flutter/lib/src/material/circle_avatar.dart
@@ -117,9 +117,14 @@ class CircleAvatar extends StatelessWidget {
         shape: BoxShape.circle,
       ),
       child: child != null ? new Center(
-        child: new DefaultTextStyle(
-          style: textStyle.copyWith(color: foregroundColor),
-          child: child,
+        child: new MediaQuery(
+          // Need to reset the textScaleFactor here so that the
+          // text doesn't escape the avatar when the textScaleFactor is large.
+          data: const MediaQueryData(textScaleFactor: 1.0),
+          child: new DefaultTextStyle(
+            style: textStyle.copyWith(color: foregroundColor),
+            child: child,
+          ),
         )
       ) : null,
     );

--- a/packages/flutter/test/material/circle_avatar_test.dart
+++ b/packages/flutter/test/material/circle_avatar_test.dart
@@ -101,6 +101,33 @@ void main() {
     final RenderParagraph paragraph = tester.renderObject(find.text('Z'));
     expect(paragraph.text.style.color, equals(theme.primaryTextTheme.title.color));
   });
+
+  testWidgets('CircleAvatar text does not expand with textScaleFactor', (WidgetTester tester) async {
+    final Color foregroundColor = Colors.red.shade100;
+    await tester.pumpWidget(
+      wrap(
+        child: new CircleAvatar(
+          foregroundColor: foregroundColor,
+          child: const Text('Z'),
+        ),
+      ),
+    );
+
+    expect(tester.getSize(find.text('Z')), equals(const Size(20.0, 20.0)));
+
+    await tester.pumpWidget(
+      wrap(
+        child: new MediaQuery(
+          data: const MediaQueryData(textScaleFactor: 2.0),
+          child: new CircleAvatar(
+            foregroundColor: foregroundColor,
+            child: const Text('Z'),
+          ),
+        ),
+      ),
+    );
+    expect(tester.getSize(find.text('Z')), equals(const Size(20.0, 20.0)));
+  });
 }
 
 Widget wrap({ Widget child }) {


### PR DESCRIPTION
When the textScaleFactor is large, the text inside of a circle avatar (usually just a character or two) can escape the circle.  Since we don't want to scale up the avatars, this PR prevents that from happening.

Fixes #12483