### PR TITLE
de-emphasize the footer of the generated docs

### DIFF
--- a/dev/docs/styles.html
+++ b/dev/docs/styles.html
@@ -134,8 +134,17 @@
   }
 
   /* Attempt to de-emphasise the source code section */
-  section.summary.source-code { opacity: 0.3; }
-  section.summary.source-code:hover { opacity: 0.8; }
+  section.summary.source-code {
+    opacity: 0.3;
+  }
+  section.summary.source-code:hover {
+    opacity: 0.8;
+  }
+
+  footer {
+    font-size: 13px;
+    padding: 12px 20px;
+  }
 </style>
 
 <!-- The following rules are from http://google.github.io/material-design-icons/ -->

--- a/dev/tools/dartdoc.dart
+++ b/dev/tools/dartdoc.dart
@@ -139,14 +139,17 @@ dependencies:
 }
 
 void createFooter(String footerPath) {
+  const int kGitRevisionLength = 10;
+
   final ProcessResult gitResult = Process.runSync('git', <String>['rev-parse', 'HEAD']);
-  final String gitHead = (gitResult.exitCode == 0) ? gitResult.stdout.trim() : 'unknown';
+  String gitRevision = (gitResult.exitCode == 0) ? gitResult.stdout.trim() : 'unknown';
+  gitRevision = gitRevision.length > kGitRevisionLength ? gitRevision.substring(0, kGitRevisionLength) : gitRevision;
 
   final String timestamp = new DateFormat('yyyy-MM-dd HH:mm').format(new DateTime.now());
 
   new File(footerPath).writeAsStringSync(
     '• </span class="no-break">$timestamp<span> '
-    '• </span class="no-break">$gitHead</span>'
+    '• </span class="no-break">$gitRevision</span>'
   );
 }
 


### PR DESCRIPTION
This PR:
- makes the footer of the generated API docs slightly smaller
- shortens the git hash for the revision, from 40 chars to 10 (this makes what flutter doctor and --version report)

<img width="442" alt="screen shot 2017-10-12 at 10 57 54 am" src="https://user-images.githubusercontent.com/1269969/31511374-678c0604-af3c-11e7-9d32-2bd46d3e89ed.png">
