### PR TITLE
Use alwaysUse24HourFormat when formatting time of day

### DIFF
--- a/packages/flutter/lib/src/material/material_localizations.dart
+++ b/packages/flutter/lib/src/material/material_localizations.dart
@@ -132,7 +132,10 @@ abstract class MaterialLocalizations {
   /// Formats [timeOfDay] according to the value of [timeOfDayFormat].
   ///
   /// If [alwaysUse24HourFormat] is true, formats hour using [HourFormat.HH]
-  /// rather than the default for the current locale.
+  /// rather than the default for the current locale. This value is usually
+  /// passed from [MediaQueryData.alwaysUse24HourFormat], and it has platform-
+  /// specific behavior. For more details, see the documentation for
+  /// [MediaQueryData.alwaysUse24HourFormat].
   String formatTimeOfDay(TimeOfDay timeOfDay, { bool alwaysUse24HourFormat: false });
 
   /// Full unabbreviated year format, e.g. 2017 rather than 17.

--- a/packages/flutter/lib/src/material/material_localizations.dart
+++ b/packages/flutter/lib/src/material/material_localizations.dart
@@ -133,9 +133,8 @@ abstract class MaterialLocalizations {
   ///
   /// If [alwaysUse24HourFormat] is true, formats hour using [HourFormat.HH]
   /// rather than the default for the current locale. This value is usually
-  /// passed from [MediaQueryData.alwaysUse24HourFormat], and it has platform-
-  /// specific behavior. For more details, see the documentation for
-  /// [MediaQueryData.alwaysUse24HourFormat].
+  /// passed from [MediaQueryData.alwaysUse24HourFormat], which has platform-
+  /// specific behavior.
   String formatTimeOfDay(TimeOfDay timeOfDay, { bool alwaysUse24HourFormat: false });
 
   /// Full unabbreviated year format, e.g. 2017 rather than 17.
@@ -286,17 +285,19 @@ class DefaultMaterialLocalizations implements MaterialLocalizations {
   String formatHour(TimeOfDay timeOfDay, { bool alwaysUse24HourFormat: false }) {
     if (alwaysUse24HourFormat)
       return _formatTwoDigitZeroPad(timeOfDay.hour);
-    else
-      return formatDecimal(timeOfDay.hourOfPeriod == 0 ? 12 : timeOfDay.hourOfPeriod);
+
+    return formatDecimal(timeOfDay.hourOfPeriod == 0 ? 12 : timeOfDay.hourOfPeriod);
   }
 
   /// Formats [number] using two digits, assuming it's in the 0-99 inclusive
   /// range. Not designed to format values outside this range.
   String _formatTwoDigitZeroPad(int number) {
+    assert(0 <= number && number < 100);
+
     if (number < 10)
       return '0$number';
-    else
-      return '$number';
+
+    return '$number';
   }
 
   @override

--- a/packages/flutter/lib/src/material/material_localizations.dart
+++ b/packages/flutter/lib/src/material/material_localizations.dart
@@ -120,14 +120,20 @@ abstract class MaterialLocalizations {
 
   /// Formats [TimeOfDay.hour] in the given time of day according to the value
   /// of [timeOfDayFormat].
-  String formatHour(TimeOfDay timeOfDay);
+  ///
+  /// If [alwaysUse24HourFormat] is true, formats hour using [HourFormat.HH]
+  /// rather than the default for the current locale.
+  String formatHour(TimeOfDay timeOfDay, { bool alwaysUse24HourFormat: false });
 
   /// Formats [TimeOfDay.minute] in the given time of day according to the value
   /// of [timeOfDayFormat].
   String formatMinute(TimeOfDay timeOfDay);
 
   /// Formats [timeOfDay] according to the value of [timeOfDayFormat].
-  String formatTimeOfDay(TimeOfDay timeOfDay);
+  ///
+  /// If [alwaysUse24HourFormat] is true, formats hour using [HourFormat.HH]
+  /// rather than the default for the current locale.
+  String formatTimeOfDay(TimeOfDay timeOfDay, { bool alwaysUse24HourFormat: false });
 
   /// Full unabbreviated year format, e.g. 2017 rather than 17.
   String formatYear(DateTime date);
@@ -274,9 +280,20 @@ class DefaultMaterialLocalizations implements MaterialLocalizations {
   ];
 
   @override
-  String formatHour(TimeOfDay timeOfDay) {
-    assert(hourFormat(of: timeOfDayFormat) == HourFormat.h);
-    return formatDecimal(timeOfDay.hour);
+  String formatHour(TimeOfDay timeOfDay, { bool alwaysUse24HourFormat: false }) {
+    if (alwaysUse24HourFormat)
+      return _formatTwoDigitZeroPad(timeOfDay.hour);
+    else
+      return formatDecimal(timeOfDay.hourOfPeriod == 0 ? 12 : timeOfDay.hourOfPeriod);
+  }
+
+  /// Formats [number] using two digits, assuming it's in the 0-99 inclusive
+  /// range. Not designed to format values outside this range.
+  String _formatTwoDigitZeroPad(int number) {
+    if (number < 10)
+      return '0$number';
+    else
+      return '$number';
   }
 
   @override
@@ -335,7 +352,7 @@ class DefaultMaterialLocalizations implements MaterialLocalizations {
   }
 
   @override
-  String formatTimeOfDay(TimeOfDay timeOfDay) {
+  String formatTimeOfDay(TimeOfDay timeOfDay, { bool alwaysUse24HourFormat: false }) {
     assert(timeOfDayFormat == TimeOfDayFormat.h_colon_mm_space_a);
     // Not using intl.DateFormat for two reasons:
     //
@@ -345,7 +362,8 @@ class DefaultMaterialLocalizations implements MaterialLocalizations {
     // - DateFormat operates on DateTime, which is sensitive to time eras and
     //   time zones, while here we want to format hour and minute within one day
     //   no matter what date the day falls on.
-    return '${formatHour(timeOfDay)}:${formatMinute(timeOfDay)} ${_formatDayPeriod(timeOfDay)}';
+    final String hour = formatHour(timeOfDay, alwaysUse24HourFormat: alwaysUse24HourFormat);
+    return '$hour:${formatMinute(timeOfDay)} ${_formatDayPeriod(timeOfDay)}';
   }
 
   @override

--- a/packages/flutter/lib/src/material/time.dart
+++ b/packages/flutter/lib/src/material/time.dart
@@ -84,6 +84,7 @@ class TimeOfDay {
   ///
   /// This is a shortcut for [MaterialLocalizations.formatTimeOfDay].
   String format(BuildContext context) {
+    debugCheckHasMediaQuery(context);
     final MaterialLocalizations localizations = MaterialLocalizations.of(context);
     return localizations.formatTimeOfDay(
       this,

--- a/packages/flutter/lib/src/material/time.dart
+++ b/packages/flutter/lib/src/material/time.dart
@@ -85,7 +85,10 @@ class TimeOfDay {
   /// This is a shortcut for [MaterialLocalizations.formatTimeOfDay].
   String format(BuildContext context) {
     final MaterialLocalizations localizations = MaterialLocalizations.of(context);
-    return localizations.formatTimeOfDay(this);
+    return localizations.formatTimeOfDay(
+      this,
+      alwaysUse24HourFormat: MediaQuery.of(context).alwaysUse24HourFormat,
+    );
   }
 
   @override
@@ -181,11 +184,14 @@ enum HourFormat {
 }
 
 /// The [HourFormat] used for the given [TimeOfDayFormat].
-HourFormat hourFormat({ @required TimeOfDayFormat of }) {
+///
+/// If [alwaysUse24HourFormat] is true, returns [HourFormat.HH] for
+/// [TimeOfDayFormat]s that by default use [HourFormat.h].
+HourFormat hourFormat({ @required TimeOfDayFormat of, bool alwaysUse24HourFormat: false }) {
   switch (of) {
     case TimeOfDayFormat.h_colon_mm_space_a:
     case TimeOfDayFormat.a_space_h_colon_mm:
-      return HourFormat.h;
+      return alwaysUse24HourFormat ? HourFormat.HH : HourFormat.h;
     case TimeOfDayFormat.H_colon_mm:
       return HourFormat.H;
     case TimeOfDayFormat.HH_dot_mm:

--- a/packages/flutter/lib/src/material/time.dart
+++ b/packages/flutter/lib/src/material/time.dart
@@ -185,14 +185,11 @@ enum HourFormat {
 }
 
 /// The [HourFormat] used for the given [TimeOfDayFormat].
-///
-/// If [alwaysUse24HourFormat] is true, returns [HourFormat.HH] for
-/// [TimeOfDayFormat]s that by default use [HourFormat.h].
-HourFormat hourFormat({ @required TimeOfDayFormat of, bool alwaysUse24HourFormat: false }) {
+HourFormat hourFormat({ @required TimeOfDayFormat of }) {
   switch (of) {
     case TimeOfDayFormat.h_colon_mm_space_a:
     case TimeOfDayFormat.a_space_h_colon_mm:
-      return alwaysUse24HourFormat ? HourFormat.HH : HourFormat.h;
+      return HourFormat.h;
     case TimeOfDayFormat.H_colon_mm:
       return HourFormat.H;
     case TimeOfDayFormat.HH_dot_mm:

--- a/packages/flutter/lib/src/material/time_picker.dart
+++ b/packages/flutter/lib/src/material/time_picker.dart
@@ -1081,11 +1081,11 @@ class _DialState extends State<_Dial> with SingleTickerProviderStateMixin {
 /// selected [TimeOfDay] if the user taps the "OK" button, or null if the user
 /// taps the "CANCEL" button. The selected time is reported by calling
 /// [Navigator.pop].
-class TimePickerDialog extends StatefulWidget {
+class _TimePickerDialog extends StatefulWidget {
   /// Creates a material time picker.
   ///
   /// [initialTime] must not be null.
-  const TimePickerDialog({
+  const _TimePickerDialog({
     Key key,
     @required this.initialTime
   }) : assert(initialTime != null),
@@ -1098,7 +1098,7 @@ class TimePickerDialog extends StatefulWidget {
   _TimePickerDialogState createState() => new _TimePickerDialogState();
 }
 
-class _TimePickerDialogState extends State<TimePickerDialog> {
+class _TimePickerDialogState extends State<_TimePickerDialog> {
   @override
   void initState() {
     super.initState();
@@ -1268,6 +1268,6 @@ Future<TimeOfDay> showTimePicker({
   assert(initialTime != null);
   return await showDialog<TimeOfDay>(
     context: context,
-    child: new TimePickerDialog(initialTime: initialTime),
+    child: new _TimePickerDialog(initialTime: initialTime),
   );
 }

--- a/packages/flutter/lib/src/material/time_picker.dart
+++ b/packages/flutter/lib/src/material/time_picker.dart
@@ -68,7 +68,6 @@ class _TimePickerFragmentContext {
     @required this.inactiveStyle,
     @required this.onTimeChange,
     @required this.onModeChange,
-    @required this.alwaysUse24HourFormat,
   }) : assert(headerTextTheme != null),
        assert(textDirection != null),
        assert(selectedTime != null),
@@ -78,8 +77,7 @@ class _TimePickerFragmentContext {
        assert(inactiveColor != null),
        assert(inactiveStyle != null),
        assert(onTimeChange != null),
-       assert(onModeChange != null),
-       assert(alwaysUse24HourFormat != null);
+       assert(onModeChange != null);
 
   final TextTheme headerTextTheme;
   final TextDirection textDirection;
@@ -91,7 +89,6 @@ class _TimePickerFragmentContext {
   final TextStyle inactiveStyle;
   final ValueChanged<TimeOfDay> onTimeChange;
   final ValueChanged<_TimePickerMode> onModeChange;
-  final bool alwaysUse24HourFormat;
 }
 
 /// Contains the [widget] and layout properties of an atom of time information,
@@ -292,7 +289,7 @@ class _MinuteControl extends StatelessWidget {
 /// [timeOfDayFormat] passing [context] to each widget in the
 /// configuration.
 ///
-/// The arguments must not be null.
+/// The [timeOfDayFormat] and [context] arguments must not be null.
 _TimePickerHeaderFormat _buildHeaderFormat(TimeOfDayFormat timeOfDayFormat, _TimePickerFragmentContext context) {
   // Creates an hour fragment.
   _TimePickerHeaderFragment hour() {
@@ -577,7 +574,6 @@ class _TimePickerHeader extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final ThemeData themeData = Theme.of(context);
-    final MediaQueryData media = MediaQuery.of(context);
     final TimeOfDayFormat timeOfDayFormat = MaterialLocalizations.of(context).timeOfDayFormat;
 
     EdgeInsets padding;
@@ -632,7 +628,6 @@ class _TimePickerHeader extends StatelessWidget {
       inactiveStyle: baseHeaderStyle.copyWith(color: inactiveColor),
       onTimeChange: onChanged,
       onModeChange: _handleChangeMode,
-      alwaysUse24HourFormat: media.alwaysUse24HourFormat,
     );
 
     final _TimePickerHeaderFormat format = _buildHeaderFormat(timeOfDayFormat, fragmentContext);

--- a/packages/flutter/lib/src/widgets/media_query.dart
+++ b/packages/flutter/lib/src/widgets/media_query.dart
@@ -40,7 +40,8 @@ class MediaQueryData {
     this.size: Size.zero,
     this.devicePixelRatio: 1.0,
     this.textScaleFactor: 1.0,
-    this.padding: EdgeInsets.zero
+    this.padding: EdgeInsets.zero,
+    this.alwaysUse24HourFormat: false,
   });
 
   /// Creates data for a media query based on the given window.
@@ -53,7 +54,8 @@ class MediaQueryData {
     : size = window.physicalSize / window.devicePixelRatio,
       devicePixelRatio = window.devicePixelRatio,
       textScaleFactor = window.textScaleFactor,
-      padding = new EdgeInsets.fromWindowPadding(window.padding, window.devicePixelRatio);
+      padding = new EdgeInsets.fromWindowPadding(window.padding, window.devicePixelRatio),
+      alwaysUse24HourFormat = false;
 
   /// The size of the media in logical pixel (e.g, the size of the screen).
   ///
@@ -76,6 +78,20 @@ class MediaQueryData {
 
   /// The padding around the edges of the media (e.g., the screen).
   final EdgeInsets padding;
+
+  /// Whether to use 24-hour format when formatting time.
+  ///
+  /// ## Advice for widget implementors
+  ///
+  /// The behavior of this flag is different across platforms:
+  ///
+  /// - On Android this flag is reported directly from the user settings called
+  ///   "Use 24-hour format". It applies to any locale used by the application,
+  ///   whether it is the system-wide locale, or the custom locale set by the
+  ///   application.
+  /// - On iOS this flag is set to `true` when the user setting called "24-Hour
+  ///   Time" is set or the system-wide locale's default.
+  final bool alwaysUse24HourFormat;
 
   /// The orientation of the media (e.g., whether the device is in landscape or portrait mode).
   Orientation get orientation {

--- a/packages/flutter/lib/src/widgets/media_query.dart
+++ b/packages/flutter/lib/src/widgets/media_query.dart
@@ -81,8 +81,6 @@ class MediaQueryData {
 
   /// Whether to use 24-hour format when formatting time.
   ///
-  /// ## Advice for widget implementors
-  ///
   /// The behavior of this flag is different across platforms:
   ///
   /// - On Android this flag is reported directly from the user settings called
@@ -90,7 +88,8 @@ class MediaQueryData {
   ///   whether it is the system-wide locale, or the custom locale set by the
   ///   application.
   /// - On iOS this flag is set to `true` when the user setting called "24-Hour
-  ///   Time" is set or the system-wide locale's default.
+  ///   Time" is set or the system-wide locale's default uses 24-hour
+  ///   formatting.
   final bool alwaysUse24HourFormat;
 
   /// The orientation of the media (e.g., whether the device is in landscape or portrait mode).

--- a/packages/flutter/lib/src/widgets/media_query.dart
+++ b/packages/flutter/lib/src/widgets/media_query.dart
@@ -55,7 +55,7 @@ class MediaQueryData {
       devicePixelRatio = window.devicePixelRatio,
       textScaleFactor = window.textScaleFactor,
       padding = new EdgeInsets.fromWindowPadding(window.padding, window.devicePixelRatio),
-      alwaysUse24HourFormat = false;
+      alwaysUse24HourFormat = window.alwaysUse24HourFormat;
 
   /// The size of the media in logical pixel (e.g, the size of the screen).
   ///

--- a/packages/flutter/lib/src/widgets/media_query.dart
+++ b/packages/flutter/lib/src/widgets/media_query.dart
@@ -87,7 +87,7 @@ class MediaQueryData {
   ///   "Use 24-hour format". It applies to any locale used by the application,
   ///   whether it is the system-wide locale, or the custom locale set by the
   ///   application.
-  /// - On iOS this flag is set to `true` when the user setting called "24-Hour
+  /// - On iOS this flag is set to true when the user setting called "24-Hour
   ///   Time" is set or the system-wide locale's default uses 24-hour
   ///   formatting.
   final bool alwaysUse24HourFormat;

--- a/packages/flutter/test/material/time_test.dart
+++ b/packages/flutter/test/material/time_test.dart
@@ -6,10 +6,24 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  group('hourFormat', () {
+  group('TimeOfDay.format', () {
     testWidgets('respects alwaysUse24HourFormat option', (WidgetTester tester) async {
-      expect(hourFormat(of: TimeOfDayFormat.a_space_h_colon_mm), HourFormat.h);
-      expect(hourFormat(of: TimeOfDayFormat.a_space_h_colon_mm, alwaysUse24HourFormat: true), HourFormat.HH);
+      Future<String> pumpTest(bool alwaysUse24HourFormat) async {
+        String formattedValue;
+        await tester.pumpWidget(new MaterialApp(
+          home: new MediaQuery(
+            data: new MediaQueryData(alwaysUse24HourFormat: alwaysUse24HourFormat),
+            child: new Builder(builder: (BuildContext context) {
+              formattedValue = const TimeOfDay(hour: 7, minute: 0).format(context);
+              return new Container();
+            }),
+          ),
+        ));
+        return formattedValue;
+      }
+
+      expect(await pumpTest(false), '7:00 AM');
+      expect(await pumpTest(true), '07:00');
     });
   });
 }

--- a/packages/flutter/test/material/time_test.dart
+++ b/packages/flutter/test/material/time_test.dart
@@ -1,0 +1,15 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('hourFormat', () {
+    testWidgets('respects alwaysUse24HourFormat option', (WidgetTester tester) async {
+      expect(hourFormat(of: TimeOfDayFormat.a_space_h_colon_mm), HourFormat.h);
+      expect(hourFormat(of: TimeOfDayFormat.a_space_h_colon_mm, alwaysUse24HourFormat: true), HourFormat.HH);
+    });
+  });
+}

--- a/packages/flutter_localizations/lib/src/material_localizations.dart
+++ b/packages/flutter_localizations/lib/src/material_localizations.dart
@@ -141,8 +141,8 @@ class GlobalMaterialLocalizations implements MaterialLocalizations {
   }
 
   @override
-  String formatHour(TimeOfDay timeOfDay) {
-    switch (hourFormat(of: timeOfDayFormat)) {
+  String formatHour(TimeOfDay timeOfDay, { bool alwaysUse24HourFormat: false }) {
+    switch (hourFormat(of: timeOfDayFormat, alwaysUse24HourFormat: alwaysUse24HourFormat)) {
       case HourFormat.HH:
         return _twoDigitZeroPaddedFormat.format(timeOfDay.hour);
       case HourFormat.H:
@@ -188,7 +188,7 @@ class GlobalMaterialLocalizations implements MaterialLocalizations {
   }
 
   @override
-  String formatTimeOfDay(TimeOfDay timeOfDay) {
+  String formatTimeOfDay(TimeOfDay timeOfDay, { bool alwaysUse24HourFormat: false }) {
     // Not using intl.DateFormat for two reasons:
     //
     // - DateFormat supports more formats than our material time picker does,
@@ -199,16 +199,16 @@ class GlobalMaterialLocalizations implements MaterialLocalizations {
     //   no matter what date the day falls on.
     switch (timeOfDayFormat) {
       case TimeOfDayFormat.h_colon_mm_space_a:
-        return '${formatHour(timeOfDay)}:${formatMinute(timeOfDay)} ${_formatDayPeriod(timeOfDay)}';
+        return '${formatHour(timeOfDay, alwaysUse24HourFormat: alwaysUse24HourFormat)}:${formatMinute(timeOfDay)} ${_formatDayPeriod(timeOfDay)}';
       case TimeOfDayFormat.H_colon_mm:
       case TimeOfDayFormat.HH_colon_mm:
-        return '${formatHour(timeOfDay)}:${formatMinute(timeOfDay)}';
+        return '${formatHour(timeOfDay, alwaysUse24HourFormat: alwaysUse24HourFormat)}:${formatMinute(timeOfDay)}';
       case TimeOfDayFormat.HH_dot_mm:
-        return '${formatHour(timeOfDay)}.${formatMinute(timeOfDay)}';
+        return '${formatHour(timeOfDay, alwaysUse24HourFormat: alwaysUse24HourFormat)}.${formatMinute(timeOfDay)}';
       case TimeOfDayFormat.a_space_h_colon_mm:
-        return '${_formatDayPeriod(timeOfDay)} ${formatHour(timeOfDay)}:${formatMinute(timeOfDay)}';
+        return '${_formatDayPeriod(timeOfDay)} ${formatHour(timeOfDay, alwaysUse24HourFormat: alwaysUse24HourFormat)}:${formatMinute(timeOfDay)}';
       case TimeOfDayFormat.frenchCanadian:
-        return '${formatHour(timeOfDay)} h ${formatMinute(timeOfDay)}';
+        return '${formatHour(timeOfDay, alwaysUse24HourFormat: alwaysUse24HourFormat)} h ${formatMinute(timeOfDay)}';
     }
 
     return null;

--- a/packages/flutter_localizations/test/date_time_test.dart
+++ b/packages/flutter_localizations/test/date_time_test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -24,40 +26,44 @@ void main() {
     });
 
     group('formatHour', () {
-      test('formats h', () {
-        GlobalMaterialLocalizations localizations;
+      Future<String> formatHour(WidgetTester tester, Locale locale, TimeOfDay timeOfDay) async {
+        final Completer<String> completer = new Completer<String>();
+        await tester.pumpWidget(new MaterialApp(
+          supportedLocales: <Locale>[locale],
+          locale: locale,
+          localizationsDelegates: <LocalizationsDelegate<dynamic>>[
+            GlobalMaterialLocalizations.delegate,
+          ],
+          home: new Builder(builder: (BuildContext context) {
+            completer.complete(MaterialLocalizations.of(context).formatHour(timeOfDay));
+            return new Container();
+          }),
+        ));
+        return completer.future;
+      }
 
-        localizations = new GlobalMaterialLocalizations(const Locale('en', 'US'));
-        expect(localizations.formatHour(const TimeOfDay(hour: 10, minute: 0)), '10');
-        expect(localizations.formatHour(const TimeOfDay(hour: 20, minute: 0)), '8');
+      testWidgets('formats h', (WidgetTester tester) async {
+        expect(await formatHour(tester, const Locale('en', 'US'), const TimeOfDay(hour: 10, minute: 0)), '10');
+        expect(await formatHour(tester, const Locale('en', 'US'), const TimeOfDay(hour: 20, minute: 0)), '8');
 
-        localizations = new GlobalMaterialLocalizations(const Locale('ar', ''));
-        expect(localizations.formatHour(const TimeOfDay(hour: 10, minute: 0)), '١٠');
-        expect(localizations.formatHour(const TimeOfDay(hour: 20, minute: 0)), '٨');
+        expect(await formatHour(tester, const Locale('ar', ''), const TimeOfDay(hour: 10, minute: 0)), '١٠');
+        expect(await formatHour(tester, const Locale('ar', ''), const TimeOfDay(hour: 20, minute: 0)), '٨');
       });
 
-      test('formats HH', () {
-        GlobalMaterialLocalizations localizations;
+      testWidgets('formats HH', (WidgetTester tester) async {
+        expect(await formatHour(tester, const Locale('de', ''), const TimeOfDay(hour: 9, minute: 0)), '09');
+        expect(await formatHour(tester, const Locale('de', ''), const TimeOfDay(hour: 20, minute: 0)), '20');
 
-        localizations = new GlobalMaterialLocalizations(const Locale('de', ''));
-        expect(localizations.formatHour(const TimeOfDay(hour: 9, minute: 0)), '09');
-        expect(localizations.formatHour(const TimeOfDay(hour: 20, minute: 0)), '20');
-
-        localizations = new GlobalMaterialLocalizations(const Locale('en', 'GB'));
-        expect(localizations.formatHour(const TimeOfDay(hour: 9, minute: 0)), '09');
-        expect(localizations.formatHour(const TimeOfDay(hour: 20, minute: 0)), '20');
+        expect(await formatHour(tester, const Locale('en', 'GB'), const TimeOfDay(hour: 9, minute: 0)), '09');
+        expect(await formatHour(tester, const Locale('en', 'GB'), const TimeOfDay(hour: 20, minute: 0)), '20');
       });
 
-      test('formats H', () {
-        GlobalMaterialLocalizations localizations;
+      testWidgets('formats H', (WidgetTester tester) async {
+        expect(await formatHour(tester, const Locale('es', ''), const TimeOfDay(hour: 9, minute: 0)), '9');
+        expect(await formatHour(tester, const Locale('es', ''), const TimeOfDay(hour: 20, minute: 0)), '20');
 
-        localizations = new GlobalMaterialLocalizations(const Locale('es', ''));
-        expect(localizations.formatHour(const TimeOfDay(hour: 9, minute: 0)), '9');
-        expect(localizations.formatHour(const TimeOfDay(hour: 20, minute: 0)), '20');
-
-        localizations = new GlobalMaterialLocalizations(const Locale('fa', ''));
-        expect(localizations.formatHour(const TimeOfDay(hour: 9, minute: 0)), '۹');
-        expect(localizations.formatHour(const TimeOfDay(hour: 20, minute: 0)), '۲۰');
+        expect(await formatHour(tester, const Locale('fa', ''), const TimeOfDay(hour: 9, minute: 0)), '۹');
+        expect(await formatHour(tester, const Locale('fa', ''), const TimeOfDay(hour: 20, minute: 0)), '۲۰');
       });
     });
 
@@ -74,48 +80,49 @@ void main() {
     });
 
     group('formatTimeOfDay', () {
-      test('formats ${TimeOfDayFormat.h_colon_mm_space_a}', () {
-        GlobalMaterialLocalizations localizations;
+      Future<String> formatTimeOfDay(WidgetTester tester, Locale locale, TimeOfDay timeOfDay) async {
+        final Completer<String> completer = new Completer<String>();
+        await tester.pumpWidget(new MaterialApp(
+          supportedLocales: <Locale>[locale],
+          locale: locale,
+          localizationsDelegates: <LocalizationsDelegate<dynamic>>[
+            GlobalMaterialLocalizations.delegate,
+          ],
+          home: new Builder(builder: (BuildContext context) {
+            completer.complete(MaterialLocalizations.of(context).formatTimeOfDay(timeOfDay));
+            return new Container();
+          }),
+        ));
+        return completer.future;
+      }
 
-        localizations = new GlobalMaterialLocalizations(const Locale('ar', ''));
-        expect(localizations.formatTimeOfDay(const TimeOfDay(hour: 9, minute: 32)), '٩:٣٢ ص');
+      testWidgets('formats ${TimeOfDayFormat.h_colon_mm_space_a}', (WidgetTester tester) async {
+        expect(await formatTimeOfDay(tester, const Locale('ar', ''), const TimeOfDay(hour: 9, minute: 32)), '٩:٣٢ ص');
+        expect(await formatTimeOfDay(tester, const Locale('ar', ''), const TimeOfDay(hour: 20, minute: 32)), '٨:٣٢ م');
 
-        localizations = new GlobalMaterialLocalizations(const Locale('en', ''));
-        expect(localizations.formatTimeOfDay(const TimeOfDay(hour: 9, minute: 32)), '9:32 AM');
+        expect(await formatTimeOfDay(tester, const Locale('en', ''), const TimeOfDay(hour: 9, minute: 32)), '9:32 AM');
+        expect(await formatTimeOfDay(tester, const Locale('en', ''), const TimeOfDay(hour: 20, minute: 32)), '8:32 PM');
       });
 
-      test('formats ${TimeOfDayFormat.HH_colon_mm}', () {
-        GlobalMaterialLocalizations localizations;
-
-        localizations = new GlobalMaterialLocalizations(const Locale('de', ''));
-        expect(localizations.formatTimeOfDay(const TimeOfDay(hour: 9, minute: 32)), '09:32');
-
-        localizations = new GlobalMaterialLocalizations(const Locale('en', 'ZA'));
-        expect(localizations.formatTimeOfDay(const TimeOfDay(hour: 9, minute: 32)), '09:32');
+      testWidgets('formats ${TimeOfDayFormat.HH_colon_mm}', (WidgetTester tester) async {
+        expect(await formatTimeOfDay(tester, const Locale('de', ''), const TimeOfDay(hour: 9, minute: 32)), '09:32');
+        expect(await formatTimeOfDay(tester, const Locale('en', 'ZA'), const TimeOfDay(hour: 9, minute: 32)), '09:32');
       });
 
-      test('formats ${TimeOfDayFormat.H_colon_mm}', () {
-        GlobalMaterialLocalizations localizations;
+      testWidgets('formats ${TimeOfDayFormat.H_colon_mm}', (WidgetTester tester) async {
+        expect(await formatTimeOfDay(tester, const Locale('es', ''), const TimeOfDay(hour: 9, minute: 32)), '9:32');
+        expect(await formatTimeOfDay(tester, const Locale('es', ''), const TimeOfDay(hour: 20, minute: 32)), '20:32');
 
-        localizations = new GlobalMaterialLocalizations(const Locale('es', ''));
-        expect(localizations.formatTimeOfDay(const TimeOfDay(hour: 9, minute: 32)), '9:32');
-
-        localizations = new GlobalMaterialLocalizations(const Locale('ja', ''));
-        expect(localizations.formatTimeOfDay(const TimeOfDay(hour: 9, minute: 32)), '9:32');
+        expect(await formatTimeOfDay(tester, const Locale('ja', ''), const TimeOfDay(hour: 9, minute: 32)), '9:32');
+        expect(await formatTimeOfDay(tester, const Locale('ja', ''), const TimeOfDay(hour: 20, minute: 32)), '20:32');
       });
 
-      test('formats ${TimeOfDayFormat.frenchCanadian}', () {
-        GlobalMaterialLocalizations localizations;
-
-        localizations = new GlobalMaterialLocalizations(const Locale('fr', 'CA'));
-        expect(localizations.formatTimeOfDay(const TimeOfDay(hour: 9, minute: 32)), '09 h 32');
+      testWidgets('formats ${TimeOfDayFormat.frenchCanadian}', (WidgetTester tester) async {
+        expect(await formatTimeOfDay(tester, const Locale('fr', 'CA'), const TimeOfDay(hour: 9, minute: 32)), '09 h 32');
       });
 
-      test('formats ${TimeOfDayFormat.a_space_h_colon_mm}', () {
-        GlobalMaterialLocalizations localizations;
-
-        localizations = new GlobalMaterialLocalizations(const Locale('zh', ''));
-        expect(localizations.formatTimeOfDay(const TimeOfDay(hour: 9, minute: 32)), '上午 9:32');
+      testWidgets('formats ${TimeOfDayFormat.a_space_h_colon_mm}', (WidgetTester tester) async {
+        expect(await formatTimeOfDay(tester, const Locale('zh', ''), const TimeOfDay(hour: 9, minute: 32)), '上午 9:32');
       });
     });
   });

--- a/packages/flutter_localizations/test/time_picker_test.dart
+++ b/packages/flutter_localizations/test/time_picker_test.dart
@@ -48,8 +48,7 @@ Future<Offset> startPicker(WidgetTester tester, ValueChanged<TimeOfDay> onChange
 }
 
 Future<Null> finishPicker(WidgetTester tester) async {
-  final Element timePickerElement = tester.element(find.byElementPredicate((Element element) => element.widget.runtimeType.toString() == '_TimePickerDialog'));
-  final MaterialLocalizations materialLocalizations = MaterialLocalizations.of(timePickerElement);
+  final MaterialLocalizations materialLocalizations = MaterialLocalizations.of(tester.element(find.byType(TimePickerDialog)));
   await tester.tap(find.text(materialLocalizations.okButtonLabel));
   await tester.pumpAndSettle(const Duration(seconds: 1));
 }
@@ -58,11 +57,11 @@ void main() {
   testWidgets('can localize the header in all known formats', (WidgetTester tester) async {
     // TODO(yjbanov): also test `HH.mm` (in_ID), `a h:mm` (ko_KR) and `HH:mm น.` (th_TH) when we have .arb files for them
     final Map<Locale, List<String>> locales = <Locale, List<String>>{
-      const Locale('en', 'US'): const <String>['hour h', 'string :', 'minute', 'period'], //'h:mm a'
-      const Locale('en', 'GB'): const <String>['hour HH', 'string :', 'minute'], //'HH:mm'
-      const Locale('es', 'ES'): const <String>['hour H', 'string :', 'minute'], //'H:mm'
-      const Locale('fr', 'CA'): const <String>['hour HH', 'string h', 'minute'], //'HH \'h\' mm'
-      const Locale('zh', 'ZH'): const <String>['period', 'hour h', 'string :', 'minute'], //'ah:mm'
+      const Locale('en', 'US'): const <String>['hour', 'string :', 'minute', 'period'], //'h:mm a'
+      const Locale('en', 'GB'): const <String>['hour', 'string :', 'minute'], //'HH:mm'
+      const Locale('es', 'ES'): const <String>['hour', 'string :', 'minute'], //'H:mm'
+      const Locale('fr', 'CA'): const <String>['hour', 'string h', 'minute'], //'HH \'h\' mm'
+      const Locale('zh', 'ZH'): const <String>['period', 'hour', 'string :', 'minute'], //'ah:mm'
     };
 
     for (Locale locale in locales.keys) {
@@ -77,7 +76,7 @@ void main() {
         } else if (fragmentType == '_DayPeriodControl') {
           actual.add('period');
         } else if (fragmentType == '_HourControl') {
-          actual.add('hour ${widget.hourFormat.toString().split('.').last}');
+          actual.add('hour');
         } else if (fragmentType == '_StringFragment') {
           actual.add('string ${widget.value}');
         } else {
@@ -125,5 +124,57 @@ void main() {
         expect(result, equals(new TimeOfDay(hour: i < 7 ? 12 : 0, minute: 0)));
       }
     }
+  });
+
+  const List<String> labels12To11 = const <String>['12', '1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11'];
+  const List<String> labels12To11TwoDigit = const <String>['12', '01', '02', '03', '04', '05', '06', '07', '08', '09', '10', '11'];
+  const List<String> labels00To23 = const <String>['00', '13', '14', '15', '16', '17', '18', '19', '20', '21', '22', '23'];
+
+  testWidgets('respects MediaQueryData.alwaysUse24HourFormat == false', (WidgetTester tester) async {
+    await tester.pumpWidget(new MaterialApp(
+      localizationsDelegates: GlobalMaterialLocalizations.delegates,
+      home: const MediaQuery(
+        data: const MediaQueryData(alwaysUse24HourFormat: false),
+        child: const TimePickerDialog(initialTime: const TimeOfDay(hour: 7, minute: 0)),
+      ),
+    ));
+
+    final CustomPaint dialPaint = tester.widget(find.descendant(
+      of: find.byWidgetPredicate((Widget w) => '${w.runtimeType}' == '_Dial'),
+      matching: find.byType(CustomPaint),
+    ));
+    final dynamic dialPainter = dialPaint.painter;
+    final List<TextPainter> primaryOuterLabels = dialPainter.primaryOuterLabels;
+    expect(primaryOuterLabels.map((TextPainter tp) => tp.text.text), labels12To11);
+    expect(dialPainter.primaryInnerLabels, null);
+
+    final List<TextPainter> secondaryOuterLabels = dialPainter.secondaryOuterLabels;
+    expect(secondaryOuterLabels.map((TextPainter tp) => tp.text.text), labels12To11);
+    expect(dialPainter.secondaryInnerLabels, null);
+  });
+
+  testWidgets('respects MediaQueryData.alwaysUse24HourFormat == true', (WidgetTester tester) async {
+    await tester.pumpWidget(new MaterialApp(
+      localizationsDelegates: GlobalMaterialLocalizations.delegates,
+      home: const MediaQuery(
+        data: const MediaQueryData(alwaysUse24HourFormat: true),
+        child: const TimePickerDialog(initialTime: const TimeOfDay(hour: 7, minute: 0)),
+      ),
+    ));
+
+    final CustomPaint dialPaint = tester.widget(find.descendant(
+      of: find.byWidgetPredicate((Widget w) => '${w.runtimeType}' == '_Dial'),
+      matching: find.byType(CustomPaint),
+    ));
+    final dynamic dialPainter = dialPaint.painter;
+    final List<TextPainter> primaryOuterLabels = dialPainter.primaryOuterLabels;
+    expect(primaryOuterLabels.map((TextPainter tp) => tp.text.text), labels00To23);
+    final List<TextPainter> primaryInnerLabels = dialPainter.primaryInnerLabels;
+    expect(primaryInnerLabels.map((TextPainter tp) => tp.text.text), labels12To11TwoDigit);
+
+    final List<TextPainter> secondaryOuterLabels = dialPainter.secondaryOuterLabels;
+    expect(secondaryOuterLabels.map((TextPainter tp) => tp.text.text), labels00To23);
+    final List<TextPainter> secondaryInnerLabels = dialPainter.secondaryInnerLabels;
+    expect(secondaryInnerLabels.map((TextPainter tp) => tp.text.text), labels12To11TwoDigit);
   });
 }


### PR DESCRIPTION
Add `alwaysUse24HourFormat` property to `MediaQuery` (currently not wired to `dart:ui`; will do it in a follow-up PR).

Drive-by changes:

- Fixes labels on the 24-hour rings, changing them from 0-11/13-24 to 1-12/13-23 to match Android.
- Makes `TimePickerDialog` public in order to support custom `Localizations` and `MediaQuery` (allows better testing and gives developers more control).

Breaking changes:
- adds an optional `alwaysUse24HourFormat` parameter to some methods of `MaterialLocalizations`. This should only affect _implementations_ of this interface. _Users_ of `MaterialLocalizations` should not be affected.


Fixes https://github.com/flutter/flutter/issues/11994
Fixes #4815
