### PR TITLE
Don't attempt to draw invisible overflow indicator

### DIFF
--- a/packages/flutter/lib/src/rendering/flex.dart
+++ b/packages/flutter/lib/src/rendering/flex.dart
@@ -971,6 +971,10 @@ class RenderFlex extends RenderBox with ContainerRenderObjectMixin<RenderBox, Fl
       return;
     }
 
+    // There's no point in drawing the children if we're empty.
+    if (size.isEmpty)
+      return;
+
     // We have overflow. Clip it.
     context.pushClipRect(needsCompositing, offset, Offset.zero & size, defaultPaint);
 

--- a/packages/flutter/test/rendering/flex_overflow_test.dart
+++ b/packages/flutter/test/rendering/flex_overflow_test.dart
@@ -1,0 +1,56 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter/widgets.dart';
+
+import 'mock_canvas.dart';
+
+void main() {
+  testWidgets('Flex overflow indicator', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      new Center(
+        child: new Column(
+          children: <Widget>[
+            const SizedBox(width: 200.0, height: 200.0),
+          ],
+        ),
+      ),
+    );
+
+    expect(find.byType(Column), isNot(paints..rect()));
+
+    await tester.pumpWidget(
+      new Center(
+        child: new SizedBox(
+          height: 100.0,
+          child: new Column(
+            children: <Widget>[
+              const SizedBox(width: 200.0, height: 200.0),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    expect(tester.takeException(), isNotNull);
+
+    expect(find.byType(Column), paints..rect());
+
+    await tester.pumpWidget(
+      new Center(
+        child: new SizedBox(
+          height: 0.0,
+          child: new Column(
+            children: <Widget>[
+              const SizedBox(width: 200.0, height: 200.0),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    expect(find.byType(Column), isNot(paints..rect()));
+  });
+}

--- a/packages/flutter/test/widgets/column_test.dart
+++ b/packages/flutter/test/widgets/column_test.dart
@@ -384,8 +384,6 @@ void main() {
       )
     ));
 
-    expect(tester.takeException(), contains('overflowed'));
-
     final RenderBox renderBox = tester.renderObject(find.byKey(childKey));
     expect(renderBox.size.width, equals(0.0));
     expect(renderBox.size.height, equals(100.0));
@@ -778,8 +776,6 @@ void main() {
         )
       )
     ));
-
-    expect(tester.takeException(), contains('overflowed'));
 
     final RenderBox renderBox = tester.renderObject(find.byKey(childKey));
     expect(renderBox.size.width, equals(0.0));

--- a/packages/flutter/test/widgets/row_test.dart
+++ b/packages/flutter/test/widgets/row_test.dart
@@ -302,8 +302,6 @@ void main() {
       ),
     ));
 
-    expect(tester.takeException(), contains('overflowed'));
-
     final RenderBox renderBox = tester.renderObject(find.byKey(childKey));
     expect(renderBox.size.width, equals(100.0));
     expect(renderBox.size.height, equals(0.0));
@@ -727,8 +725,6 @@ void main() {
       ),
     ));
 
-    expect(tester.takeException(), contains('overflowed'));
-
     final RenderBox renderBox = tester.renderObject(find.byKey(childKey));
     expect(renderBox.size.width, equals(100.0));
     expect(renderBox.size.height, equals(0.0));
@@ -1151,8 +1147,6 @@ void main() {
         ),
       ),
     ));
-
-    expect(tester.takeException(), contains('overflowed'));
 
     final RenderBox renderBox = tester.renderObject(find.byKey(childKey));
     expect(renderBox.size.width, equals(100.0));


### PR DESCRIPTION
If the flex is empty, there's no space in which to draw the overflow indicator,
so we shouldn't bother trying to draw it.

Fixes #12532