### PR TITLE
Keep incremental compiler state through full restart.

### DIFF
--- a/packages/flutter_tools/lib/src/devfs.dart
+++ b/packages/flutter_tools/lib/src/devfs.dart
@@ -446,6 +446,8 @@ class DevFS {
       // that isModified does not reset last check timestamp because we
       // want to report all modified files to incremental compiler next time
       // user does hot reload.
+      // TODO(aam): Remove this logic once we switch to using incremental
+      // compiler for full application compilation when doing full restart.
       if (fullRestart && generator != null && content is DevFSFileContent) {
         content = DevFSFileContent.clone(content);
       }

--- a/packages/flutter_tools/lib/src/devfs.dart
+++ b/packages/flutter_tools/lib/src/devfs.dart
@@ -53,6 +53,13 @@ abstract class DevFSContent {
 class DevFSFileContent extends DevFSContent {
   DevFSFileContent(this.file);
 
+  static DevFSFileContent clone(DevFSFileContent fsFileContent) {
+    final DevFSFileContent newFsFileContent = new DevFSFileContent(fsFileContent.file);
+    newFsFileContent._linkTarget = fsFileContent._linkTarget;
+    newFsFileContent._fileStat = fsFileContent._fileStat;
+    return newFsFileContent;
+  }
+
   final FileSystemEntity file;
   FileSystemEntity _linkTarget;
   FileStat _fileStat;
@@ -435,6 +442,13 @@ class DevFS {
       String archivePath;
       if (deviceUri.path.startsWith(assetBuildDirPrefix))
         archivePath = deviceUri.path.substring(assetBuildDirPrefix.length);
+      // When doing full restart in preview-dart-2 mode, copy content so
+      // that isModified does not reset last check timestamp because we
+      // want to report all modified files to incremental compiler next time
+      // user does hot reload.
+      if (fullRestart && generator != null && content is DevFSFileContent) {
+        content = DevFSFileContent.clone(content);
+      }
       if (content.isModified || (bundleDirty && archivePath != null)) {
         dirtyEntries[deviceUri] = content;
         numBytes += content.size;

--- a/packages/flutter_tools/lib/src/run_hot.dart
+++ b/packages/flutter_tools/lib/src/run_hot.dart
@@ -335,6 +335,8 @@ class HotRunner extends ResidentRunner {
     }
 
     final Stopwatch restartTimer = new Stopwatch()..start();
+    // TODO(aam): Add generator reset logic once we switch to using incremental
+    // compiler for full application recompilation on restart.
     final bool updatedDevFS = await _updateDevFS(fullRestart: true);
     if (!updatedDevFS)
       return new OperationResult(1, 'DevFS synchronization failed');

--- a/packages/flutter_tools/lib/src/run_hot.dart
+++ b/packages/flutter_tools/lib/src/run_hot.dart
@@ -335,14 +335,6 @@ class HotRunner extends ResidentRunner {
     }
 
     final Stopwatch restartTimer = new Stopwatch()..start();
-    if (previewDart2) {
-      for (FlutterDevice device in flutterDevices) {
-        // Reset generator so that full kernel file is produced for VM to
-        // restart from.
-        if (device.generator != null)
-          device.generator.reset();
-      }
-    }
     final bool updatedDevFS = await _updateDevFS(fullRestart: true);
     if (!updatedDevFS)
       return new OperationResult(1, 'DevFS synchronization failed');
@@ -574,6 +566,7 @@ class HotRunner extends ResidentRunner {
       printTrace('Skipping reassemble because all isolates are paused.');
       return new OperationResult(OperationResult.ok.code, reloadMessage);
     }
+    printTrace('Evicting dirty assets');
     await _evictDirtyAssets();
     printTrace('Reassembling application');
     bool reassembleAndScheduleErrors = false;


### PR DESCRIPTION
Resetting incremental compiler state is needed when it is used for restarts as well as reloads. But since we are currently use batch compiler for restarts, no need to reset incremental compiler at this point.