### PR TITLE
Add option to specify default text style in MaterialApp

### DIFF
--- a/packages/flutter/lib/src/material/app.dart
+++ b/packages/flutter/lib/src/material/app.dart
@@ -68,13 +68,14 @@ class MaterialApp extends StatefulWidget {
   ///
   /// This class creates an instance of [WidgetsApp].
   ///
-  /// The boolean arguments, [routes], and [navigatorObservers], must not be null.
+  /// The boolean arguments, [routes] and [navigatorObservers], must not be null.
   MaterialApp({ // can't be const because the asserts use methods on Map :-(
     Key key,
     this.title: '',
     this.onGenerateTitle,
     this.color,
     this.theme,
+    this.defaultTextStyle,
     this.home,
     this.routes: const <String, WidgetBuilder>{},
     this.initialRoute,
@@ -146,6 +147,17 @@ class MaterialApp extends StatefulWidget {
 
   /// The colors to use for the application's widgets.
   final ThemeData theme;
+
+  /// The top-level default text style to use for the application.
+  ///
+  /// Most subtrees in your application will have a [DefaultTextStyle] set to
+  /// apply to that specific subtree. For those that do not, this text style
+  /// will serve as the top-level default.
+  ///
+  /// If unspecified, this will default to a text style that calls attention to
+  /// the users, to indicate that the application is probably lacking some
+  /// theming somewhere.
+  final TextStyle defaultTextStyle;
 
   /// The widget for the default route of the app ([Navigator.defaultRouteName],
   /// which is `/`).
@@ -517,7 +529,7 @@ class _MaterialAppState extends State<MaterialApp> {
         key: new GlobalObjectKey(this),
         title: widget.title,
         onGenerateTitle: widget.onGenerateTitle,
-        textStyle: _errorTextStyle,
+        textStyle: widget.defaultTextStyle ?? _errorTextStyle,
         // blue is the primary color of the default theme
         color: widget.color ?? theme?.primaryColor ?? Colors.blue,
         navigatorObservers:

--- a/packages/flutter/test/material/app_test.dart
+++ b/packages/flutter/test/material/app_test.dart
@@ -317,4 +317,21 @@ void main() {
     expect(textScaleFactor, isNotNull);
     expect(textScaleFactor, equals(1.0));
   });
+
+  testWidgets('Defaults to error text style if unspecified', (WidgetTester tester) async {
+    await tester.pumpWidget(new MaterialApp(
+      home: new Text('text'),
+    ));
+    TextSpan text = tester.firstWidget(find.byType(RichText)).text;
+    expect(text.style.decoration, TextDecoration.underline);
+  });
+
+  testWidgets('Uses default text style if specified', (WidgetTester tester) async {
+    await tester.pumpWidget(new MaterialApp(
+      home: new Text('text'),
+      defaultTextStyle: const TextStyle(),
+    ));
+    TextSpan text = tester.firstWidget(find.byType(RichText)).text;
+    expect(text.style.decoration, isNull);
+  });
 }


### PR DESCRIPTION
Currently, MaterialApp inserts a `DefaultTextStyle` in its hierarchy
with a style of `_errorTextStyle`. This means that any material app
with a `Text` widget that:
(a) doesn't have another `DefaultTextStyle` widget in its ancestry
    between it and the `MaterialApp`, and
(b) specifies an explicit style with `inherit: true`
... is susceptible to having its styles inherit from the app-level
error styles.  In this case, it's forced to insert a `DefaultTextStyle`
as a *child* of the `MaterialApp`, which is a little counter-intuitive.

This is exacerbated by the change in #12249, which changed the default
platform text themes in `typography.dart` to `inherit: true`. While this
change was correct, it makes apps more susceptible to the behavior above.
Consider the case of an app using a `Text` widget and explicitly setting
a `style` on that widget of a platform default style. In that case, they're
*explicitly* saying "I want this text to have style X" (e.g.
`Typography.white.body1`), and because the default platform text styles
don't specify decorations, those get inherited from the top-level error
text styles.

This change adds the ability to give `MaterialApp` a `defaultTextStyle`,
and only to use `_errorTextStyles` if such a default is unspecified.