### PR TITLE
Add benchmark score keys to the hot mode test report.

### DIFF
--- a/dev/devicelab/lib/tasks/hot_mode_tests.dart
+++ b/dev/devicelab/lib/tasks/hot_mode_tests.dart
@@ -77,16 +77,29 @@ TaskFunction createHotModeTest({ bool isPreviewDart2: false }) {
     });
     final Map<String, dynamic> twoReloadsData = JSON.decode(
       benchmarkFile.readAsStringSync());
-    return new TaskResult.success(<String, dynamic> {
-      'hotReloadInitialDevFSSyncMilliseconds': twoReloadsData['hotReloadInitialDevFSSyncMilliseconds'][0],
-      'hotRestartMillisecondsToFrame': twoReloadsData['hotRestartMillisecondsToFrame'][0],
-      'hotReloadMillisecondsToFrame' : twoReloadsData['hotReloadMillisecondsToFrame'][0],
-      'hotReloadDevFSSyncMilliseconds': twoReloadsData['hotReloadDevFSSyncMilliseconds'][0],
-      'hotReloadFlutterReassembleMilliseconds': twoReloadsData['hotReloadFlutterReassembleMilliseconds'][0],
-      'hotReloadVMReloadMilliseconds': twoReloadsData['hotReloadVMReloadMilliseconds'][0],
-      'hotReloadDevFSSyncMillisecondsAfterChange': twoReloadsData['hotReloadDevFSSyncMilliseconds'][1],
-      'hotReloadFlutterReassembleMillisecondsAfterChange': twoReloadsData['hotReloadFlutterReassembleMilliseconds'][1],
-      'hotReloadVMReloadMillisecondsAfterChange': twoReloadsData['hotReloadVMReloadMilliseconds'][1]
-    });
+    return new TaskResult.success(
+      <String, dynamic> {
+        'hotReloadInitialDevFSSyncMilliseconds': twoReloadsData['hotReloadInitialDevFSSyncMilliseconds'][0],
+        'hotRestartMillisecondsToFrame': twoReloadsData['hotRestartMillisecondsToFrame'][0],
+        'hotReloadMillisecondsToFrame' : twoReloadsData['hotReloadMillisecondsToFrame'][0],
+        'hotReloadDevFSSyncMilliseconds': twoReloadsData['hotReloadDevFSSyncMilliseconds'][0],
+        'hotReloadFlutterReassembleMilliseconds': twoReloadsData['hotReloadFlutterReassembleMilliseconds'][0],
+        'hotReloadVMReloadMilliseconds': twoReloadsData['hotReloadVMReloadMilliseconds'][0],
+        'hotReloadDevFSSyncMillisecondsAfterChange': twoReloadsData['hotReloadDevFSSyncMilliseconds'][1],
+        'hotReloadFlutterReassembleMillisecondsAfterChange': twoReloadsData['hotReloadFlutterReassembleMilliseconds'][1],
+        'hotReloadVMReloadMillisecondsAfterChange': twoReloadsData['hotReloadVMReloadMilliseconds'][1],
+      },
+      benchmarkScoreKeys: <String>[
+        'hotReloadInitialDevFSSyncMilliseconds',
+        'hotRestartMillisecondsToFrame',
+        'hotReloadMillisecondsToFrame',
+        'hotReloadDevFSSyncMilliseconds',
+        'hotReloadFlutterReassembleMilliseconds',
+        'hotReloadVMReloadMilliseconds',
+        'hotReloadDevFSSyncMillisecondsAfterChange',
+        'hotReloadFlutterReassembleMillisecondsAfterChange',
+        'hotReloadVMReloadMillisecondsAfterChange',
+      ]
+    );
   };
 }


### PR DESCRIPTION
This is follow-up to be1467e0cdb233a528077f1db962c46f28bb5820 as after that change no hot mode scores are reported.