### PR TITLE
Remove redundant "with" from documentation

### DIFF
--- a/packages/flutter/lib/src/material/icons.dart
+++ b/packages/flutter/lib/src/material/icons.dart
@@ -6,7 +6,7 @@ import 'package:flutter/widgets.dart';
 
 /// Identifiers for the supported material design icons.
 ///
-/// Use with with the [Icon] class to show specific icons.
+/// Use with the [Icon] class to show specific icons.
 ///
 /// Icons are identified by their name as listed below.
 ///


### PR DESCRIPTION
Just a little "with" in the way.