### PR TITLE
AssetImage.obtainKey handles devicePixelRatio == null

### DIFF
--- a/packages/flutter/lib/src/services/image_resolution.dart
+++ b/packages/flutter/lib/src/services/image_resolution.dart
@@ -218,7 +218,7 @@ class AssetImage extends AssetBundleImageProvider {
   }
 
   String _chooseVariant(String main, ImageConfiguration config, List<String> candidates) {
-    if (candidates == null || candidates.isEmpty)
+    if (config.devicePixelRatio == null || candidates == null || candidates.isEmpty)
       return main;
     // TODO(ianh): Consider moving this parsing logic into _manifestParser.
     final SplayTreeMap<double, String> mapping = new SplayTreeMap<double, String>();

--- a/packages/flutter/test/services/asset_bundle_test.dart
+++ b/packages/flutter/test/services/asset_bundle_test.dart
@@ -16,7 +16,7 @@ class TestAssetBundle extends CachingAssetBundle {
   @override
   Future<ByteData> load(String key) async {
     if (key == 'AssetManifest.json')
-      return new ByteData.view(new Uint8List.fromList(new Utf8Encoder().convert('{"one": ["one"]}')).buffer);
+      return new ByteData.view(new Uint8List.fromList(const Utf8Encoder().convert('{"one": ["one"]}')).buffer);
 
     loadCallCount[key] = loadCallCount[key] ?? 0 + 1;
     if (key == 'one')
@@ -51,7 +51,7 @@ void main() {
   test('AssetImage.obtainKey succeeds with ImageConfiguration.empty', () async {
     // This is a regression test for https://github.com/flutter/flutter/issues/12392
     final AssetImage assetImage = new AssetImage('one', bundle: new TestAssetBundle());
-    AssetBundleImageKey key = await assetImage.obtainKey(ImageConfiguration.empty);
+    final AssetBundleImageKey key = await assetImage.obtainKey(ImageConfiguration.empty);
     expect(key.name, 'one');
     expect(key.scale, 1.0);
   });

--- a/packages/flutter/test/services/asset_bundle_test.dart
+++ b/packages/flutter/test/services/asset_bundle_test.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:convert';
 import 'dart:typed_data';
 
 import 'package:flutter/foundation.dart';
@@ -14,6 +15,9 @@ class TestAssetBundle extends CachingAssetBundle {
 
   @override
   Future<ByteData> load(String key) async {
+    if (key == 'AssetManifest.json')
+      return new ByteData.view(new Uint8List.fromList(new Utf8Encoder().convert('{"one": ["one"]}')).buffer);
+
     loadCallCount[key] = loadCallCount[key] ?? 0 + 1;
     if (key == 'one')
       return new ByteData(1)..setInt8(0, 49);
@@ -42,5 +46,13 @@ void main() {
       loadException = e;
     }
     expect(loadException, isFlutterError);
+  });
+
+  test('AssetImage.obtainKey succeeds with ImageConfiguration.empty', () async {
+    // This is a regression test for https://github.com/flutter/flutter/issues/12392
+    final AssetImage assetImage = new AssetImage('one', bundle: new TestAssetBundle());
+    AssetBundleImageKey key = await assetImage.obtainKey(ImageConfiguration.empty);
+    expect(key.name, 'one');
+    expect(key.scale, 1.0);
   });
 }


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/12392
