### PR TITLE
TextSelectionHandleOverlay: check that maxLines is not null

### DIFF
--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -509,7 +509,10 @@ class _TextSelectionHandleOverlayState extends State<_TextSelectionHandleOverlay
               child: widget.selectionControls.buildHandle(
                 context,
                 type,
-                widget.renderObject.size.height / widget.renderObject.maxLines,
+                widget.renderObject.maxLines != null
+                    ? widget.renderObject.size.height /
+                        widget.renderObject.maxLines
+                    : widget.renderObject.size.height,
               ),
             ),
           ],


### PR DESCRIPTION
Resolves https://github.com/flutter/flutter/issues/12046

I'm not really sure what to do if maxLines is null, so I just set it to widget.renderObject.size.height. I tested it on an app I'm building and it seems to be working fine without crashing.