### PR TITLE
Use non-whitespace contents in a button padding test

### DIFF
--- a/packages/flutter/test/cupertino/button_test.dart
+++ b/packages/flutter/test/cupertino/button_test.dart
@@ -75,7 +75,7 @@ void main() {
 
   testWidgets('Custom padding', (WidgetTester tester) async {
     await tester.pumpWidget(boilerplate(child: const CupertinoButton(
-      child: const Text(' ', style: testStyle),
+      child: const Text('X', style: testStyle),
       onPressed: null,
       padding: const EdgeInsets.all(100.0),
     )));


### PR DESCRIPTION
libtxt has different policies than Blink for trimming whitespace.  This change
will make the test results consistent in both text renderers.