### PR TITLE
Link platform.dill only into app kernel file used for aot build.

### DIFF
--- a/packages/flutter_tools/lib/src/commands/build_aot.dart
+++ b/packages/flutter_tools/lib/src/commands/build_aot.dart
@@ -307,6 +307,7 @@ Future<String> _buildAotSnapshot(
       sdkRoot: artifacts.getArtifactPath(Artifact.flutterPatchedSdkPath),
       mainPath: mainPath,
       extraFrontEndOptions: extraFrontEndOptions,
+      linkPlatformKernelIn : true,
     );
   }
 

--- a/packages/flutter_tools/lib/src/compile.dart
+++ b/packages/flutter_tools/lib/src/compile.dart
@@ -59,6 +59,7 @@ class _StdoutHandler {
 Future<String> compile(
     {String sdkRoot,
     String mainPath,
+    bool linkPlatformKernelIn : false,
     List<String> extraFrontEndOptions}) async {
   final String frontendServer = artifacts.getArtifactPath(
     Artifact.frontendServerSnapshotForEngineDartSdk
@@ -73,6 +74,8 @@ Future<String> compile(
     '--sdk-root',
     sdkRoot,
   ];
+  if (!linkPlatformKernelIn)
+    command.add('--no-link-platform');
   if (extraFrontEndOptions != null)
     command.addAll(extraFrontEndOptions);
   command.add(mainPath);


### PR DESCRIPTION
`gen_snapshot` used for build aot loads all packages from single app kernel file, so `platform.dill` needs to be in there.