### PR TITLE
Fixes InputDecorator to work with textScaleFactor, fixes Material Design differences.

### DIFF
--- a/dev/manual_tests/lib/card_collection.dart
+++ b/dev/manual_tests/lib/card_collection.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:math';
+
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart' show debugDumpRenderTree;
 
@@ -31,6 +33,11 @@ class CardCollectionState extends State<CardCollection> {
 
   static const double kCardMargins = 8.0;
   static const double kFixedCardHeight = 100.0;
+  static const List<double> _cardHeights = const <double>[
+    48.0, 63.0, 85.0, 146.0, 60.0, 55.0, 84.0, 96.0, 50.0,
+    48.0, 63.0, 85.0, 146.0, 60.0, 55.0, 84.0, 96.0, 50.0,
+    48.0, 63.0, 85.0, 146.0, 60.0, 55.0, 84.0, 96.0, 50.0,
+  ];
 
   MaterialColor _primaryColor = Colors.deepPurple;
   List<CardModel> _cardModels;
@@ -41,15 +48,22 @@ class CardCollectionState extends State<CardCollection> {
   bool _sunshine = false;
   bool _varyFontSizes = false;
 
-  void _initVariableSizedCardModels() {
-    final List<double> cardHeights = <double>[
-      48.0, 63.0, 82.0, 146.0, 60.0, 55.0, 84.0, 96.0, 50.0,
-      48.0, 63.0, 82.0, 146.0, 60.0, 55.0, 84.0, 96.0, 50.0,
-      48.0, 63.0, 82.0, 146.0, 60.0, 55.0, 84.0, 96.0, 50.0,
-    ];
+  void _updateCardSizes() {
+    if (_fixedSizeCards)
+      return;
     _cardModels = new List<CardModel>.generate(
-      cardHeights.length,
-      (int i) => new CardModel(i, cardHeights[i])
+      _cardModels.length,
+      (int i) {
+        _cardModels[i].height = _editable ? max(_cardHeights[i], 60.0) : _cardHeights[i];
+        return _cardModels[i];
+      }
+    );
+  }
+
+  void _initVariableSizedCardModels() {
+    _cardModels = new List<CardModel>.generate(
+      _cardHeights.length,
+      (int i) => new CardModel(i, _editable ? max(_cardHeights[i], 60.0) : _cardHeights[i])
     );
   }
 
@@ -126,6 +140,7 @@ class CardCollectionState extends State<CardCollection> {
   void _toggleEditable() {
     setState(() {
       _editable = !_editable;
+      _updateCardSizes();
     });
   }
 

--- a/packages/flutter/lib/src/material/input_decorator.dart
+++ b/packages/flutter/lib/src/material/input_decorator.dart
@@ -374,6 +374,8 @@ class InputDecorator extends StatelessWidget {
   static const double _kBottomBorderHeight = 1.0;
   static const double _kDensePadding = 4.0;
   static const double _kNormalPadding = 8.0;
+  static const double _kDenseTopPadding = 8.0;
+  static const double _kNormalTopPadding = 16.0;
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder description) {
@@ -451,7 +453,7 @@ class InputDecorator extends StatelessWidget {
     final double entryTextHeight = baseStyle.fontSize * textScaleFactor;
     final double subTextHeight = subtextStyle.fontSize * textScaleFactor;
 
-    double topPadding = isCollapsed ? 0.0 : 2.0 * (isDense ?  _kDensePadding : _kNormalPadding);
+    double topPadding = isCollapsed ? 0.0 : (isDense ?  _kDenseTopPadding : _kNormalTopPadding);
 
     final List<Widget> stackChildren = <Widget>[];
 
@@ -461,7 +463,7 @@ class InputDecorator extends StatelessWidget {
       final TextStyle labelStyle = hasInlineLabel ? hintStyle : floatingLabelStyle;
       final double labelTextHeight = floatingLabelStyle.fontSize * textScaleFactor;
 
-      final double topPaddingIncrement = labelTextHeight + (isDense ? _kDensePadding : _kNormalPadding) - 4.0;
+      final double topPaddingIncrement = labelTextHeight + (isDense ? _kDensePadding : _kNormalPadding);
       stackChildren.add(
         new AnimatedPositionedDirectional(
           start: 0.0,
@@ -548,7 +550,7 @@ class InputDecorator extends StatelessWidget {
 
     if (errorText != null || helperText != null) {
       assert(!isCollapsed);
-      final double linePadding = _kBottomBorderHeight + (isDense ? _kDensePadding : _kNormalPadding) - 4.0;
+      final double linePadding = _kBottomBorderHeight + (isDense ? _kDensePadding : _kNormalPadding);
       columnChildren.add(
         new AnimatedContainer(
           padding: new EdgeInsets.only(top: linePadding),

--- a/packages/flutter/lib/src/material/input_decorator.dart
+++ b/packages/flutter/lib/src/material/input_decorator.dart
@@ -368,8 +368,12 @@ class InputDecorator extends StatelessWidget {
   /// Defaults to false.
   final bool isEmpty;
 
-  /// The widget below this widget in the tree.
+  /// The widget below this widget in the tree.  Typically, this is an [EditableText] widget.
   final Widget child;
+
+  static const double _kBottomBorderHeight = 1.0;
+  static const double _kDensePadding = 4.0;
+  static const double _kNormalPadding = 8.0;
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder description) {
@@ -392,24 +396,20 @@ class InputDecorator extends StatelessWidget {
     return themeData.hintColor;
   }
 
-  Widget _buildContent(Color borderColor, double topPadding, bool isDense, Widget inputChild) {
-    final double bottomPadding = isDense ? 8.0 : 1.0;
-    const double bottomBorder = 2.0;
-    final double bottomHeight = isDense ? 14.0 : 18.0;
-
-    final EdgeInsets padding = new EdgeInsets.only(top: topPadding, bottom: bottomPadding);
-    final EdgeInsets margin = new EdgeInsets.only(bottom: bottomHeight - (bottomPadding + bottomBorder));
+  Widget _buildContent(Color borderColor, double topPadding, bool isDense, Widget inputChild, double subTextHeight) {
+    final double bottomHeight = subTextHeight + (isDense ? _kDensePadding : _kNormalPadding) + _kBottomBorderHeight;
+    final EdgeInsets padding = new EdgeInsets.only(top: topPadding, bottom: _kNormalPadding - _kBottomBorderHeight);
 
     if (decoration.hideDivider) {
       return new Container(
-        margin: margin + const EdgeInsets.only(bottom: bottomBorder),
+        margin: new EdgeInsets.only(bottom: bottomHeight),
         padding: padding,
         child: inputChild,
       );
     }
 
     return new AnimatedContainer(
-      margin: margin,
+      margin: new EdgeInsets.only(bottom: bottomHeight - _kBottomBorderHeight),
       padding: padding,
       duration: _kTransitionDuration,
       curve: _kTransitionCurve,
@@ -417,7 +417,7 @@ class InputDecorator extends StatelessWidget {
         border: new Border(
           bottom: new BorderSide(
             color: borderColor,
-            width: bottomBorder,
+            width: _kBottomBorderHeight,
           ),
         ),
       ),
@@ -429,6 +429,7 @@ class InputDecorator extends StatelessWidget {
   Widget build(BuildContext context) {
     assert(debugCheckHasMaterial(context));
     final ThemeData themeData = Theme.of(context);
+    final double textScaleFactor = MediaQuery.of(context, nullOk: true)?.textScaleFactor ?? 1.0;
 
     final bool isDense = decoration.isDense;
     final bool isCollapsed = decoration.isCollapsed;
@@ -439,34 +440,37 @@ class InputDecorator extends StatelessWidget {
     final String hintText = decoration.hintText;
     final String errorText = decoration.errorText;
 
-    final TextStyle baseStyle = this.baseStyle ?? themeData.textTheme.subhead;
-    final TextStyle hintStyle = decoration.hintStyle ?? baseStyle.copyWith(color: themeData.hintColor);
-
-    final Color activeColor = _getActiveColor(themeData);
-
-    double topPadding = isCollapsed ? 0.0 : (isDense ? 12.0 : 16.0);
-
-    final List<Widget> stackChildren = <Widget>[];
-
     // If we're not focused, there's no value, and labelText was provided,
     // then the label appears where the hint would. And we will not show
     // the hintText.
     final bool hasInlineLabel = !isFocused && labelText != null && isEmpty;
 
+    final Color activeColor = _getActiveColor(themeData);
+
+    final TextStyle baseStyle = this.baseStyle ?? themeData.textTheme.subhead;
+    final TextStyle hintStyle = decoration.hintStyle ?? baseStyle.copyWith(color: themeData.hintColor);
+    final TextStyle subtextStyle = errorText != null
+      ? decoration.errorStyle ?? themeData.textTheme.caption.copyWith(color: themeData.errorColor)
+      : decoration.helperStyle ?? themeData.textTheme.caption.copyWith(color: themeData.hintColor);
+
+    final double entryTextHeight = baseStyle.fontSize * textScaleFactor;
+    final double subTextHeight = subtextStyle.fontSize * textScaleFactor;
+
+    double topPadding = isCollapsed ? 0.0 : 2.0 * (isDense ?  _kDensePadding : _kNormalPadding);
+
+    final List<Widget> stackChildren = <Widget>[];
+
     if (labelText != null) {
       assert(!isCollapsed);
-      final TextStyle labelStyle = hasInlineLabel ?
-        hintStyle : (decoration.labelStyle ?? themeData.textTheme.caption.copyWith(color: activeColor));
+      final TextStyle floatingLabelStyle = decoration.labelStyle ?? themeData.textTheme.caption.copyWith(color: activeColor);
+      final TextStyle labelStyle = hasInlineLabel ? hintStyle : floatingLabelStyle;
+      final double labelTextHeight = floatingLabelStyle.fontSize * textScaleFactor;
 
-      final double topPaddingIncrement = themeData.textTheme.caption.fontSize + (isDense ? 4.0 : 8.0);
-      double top = topPadding;
-      if (hasInlineLabel)
-        top += topPaddingIncrement + baseStyle.fontSize - labelStyle.fontSize;
-
+      final double topPaddingIncrement = labelTextHeight + (isDense ? _kDensePadding : _kNormalPadding) - 4.0;
       stackChildren.add(
         new AnimatedPositionedDirectional(
           start: 0.0,
-          top: top,
+          top: topPadding + (hasInlineLabel ? topPaddingIncrement : 0.0),
           duration: _kTransitionDuration,
           curve: _kTransitionCurve,
           child: new _AnimatedLabel(
@@ -483,10 +487,12 @@ class InputDecorator extends StatelessWidget {
 
     if (hintText != null) {
       stackChildren.add(
-        new Positioned(
-          left: 0.0,
-          right: 0.0,
-          top: topPadding + baseStyle.fontSize - hintStyle.fontSize,
+        new AnimatedPositionedDirectional(
+          start: 0.0,
+          end: 0.0,
+          top: topPadding,
+          duration: _kTransitionDuration,
+          curve: _kTransitionCurve,
           child: new AnimatedOpacity(
             opacity: (isEmpty && !hasInlineLabel) ? 1.0 : 0.0,
             duration: _kTransitionDuration,
@@ -538,27 +544,27 @@ class InputDecorator extends StatelessWidget {
       stackChildren.add(inputChild);
     } else {
       final Color borderColor = errorText == null ? activeColor : themeData.errorColor;
-      stackChildren.add(_buildContent(borderColor, topPadding, isDense, inputChild));
+      stackChildren.add(_buildContent(borderColor, topPadding, isDense, inputChild, subTextHeight));
     }
 
-    if (!isDense && (errorText != null || helperText != null)) {
+    if (errorText != null || helperText != null) {
       assert(!isCollapsed);
-      final TextStyle captionStyle = themeData.textTheme.caption;
-      final TextStyle subtextStyle = errorText != null
-        ? decoration.errorStyle ?? captionStyle.copyWith(color: themeData.errorColor)
-        : decoration.helperStyle ?? captionStyle.copyWith(color: themeData.hintColor);
-
-      stackChildren.add(new Positioned(
-        left: 0.0,
-        right: 0.0,
-        bottom: 0.0,
-        child: new Text(
-          errorText ?? helperText,
-          style: subtextStyle,
-          textAlign: textAlign,
-          overflow: TextOverflow.ellipsis,
+      final double linePadding = _kBottomBorderHeight + _kNormalPadding + (isDense ? _kDensePadding : _kNormalPadding);
+      stackChildren.add(
+        new AnimatedPositionedDirectional(
+          start: 0.0,
+          end: 0.0,
+          top: topPadding + entryTextHeight + linePadding,
+          duration: _kTransitionDuration,
+          curve: _kTransitionCurve,
+          child: new Text(
+            errorText ?? helperText,
+            style: subtextStyle,
+            textAlign: textAlign,
+            overflow: TextOverflow.ellipsis,
+          ),
         ),
-      ));
+      );
     }
 
     final Widget stack = new Stack(
@@ -569,7 +575,7 @@ class InputDecorator extends StatelessWidget {
     if (decoration.icon != null) {
       assert(!isCollapsed);
       final double iconSize = isDense ? 18.0 : 24.0;
-      final double iconTop = topPadding + (baseStyle.fontSize - iconSize) / 2.0;
+      final double iconTop = topPadding + (entryTextHeight - iconSize) / 2.0;
       return new Row(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: <Widget>[
@@ -605,11 +611,15 @@ class _AnimatedLabel extends ImplicitlyAnimatedWidget {
     @required this.style,
     Curve curve: Curves.linear,
     @required Duration duration,
+    this.textAlign,
+    this.overflow,
   }) : assert(style != null),
        super(key: key, curve: curve, duration: duration);
 
   final String text;
   final TextStyle style;
+  final TextAlign textAlign;
+  final TextOverflow overflow;
 
   @override
   _AnimatedLabelState createState() => new _AnimatedLabelState();
@@ -646,6 +656,8 @@ class _AnimatedLabelState extends AnimatedWidgetBaseState<_AnimatedLabel> {
       child: new Text(
         widget.text,
         style: style,
+        textAlign: widget.textAlign,
+        overflow: widget.overflow,
       ),
     );
   }

--- a/packages/flutter/lib/src/material/input_decorator.dart
+++ b/packages/flutter/lib/src/material/input_decorator.dart
@@ -368,7 +368,7 @@ class InputDecorator extends StatelessWidget {
   /// Defaults to false.
   final bool isEmpty;
 
-  /// The widget below this widget in the tree.  Typically, this is an [EditableText] widget.
+  /// The widget below this widget in the tree.
   final Widget child;
 
   static const double _kBottomBorderHeight = 1.0;

--- a/packages/flutter/lib/src/painting/text_painter.dart
+++ b/packages/flutter/lib/src/painting/text_painter.dart
@@ -134,6 +134,7 @@ class TextPainter {
       return;
     _textScaleFactor = value;
     _paragraph = null;
+    _layoutTemplate = null;
     _needsLayout = true;
   }
 

--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -2377,7 +2377,7 @@ abstract class RenderObject extends AbstractNode with DiagnosticableTreeMixin im
     // yet (that is, our layer might not have been detached yet), because the
     // same node that skipped us in layout is above us in the tree (obviously)
     // and therefore may not have had a chance to paint yet (since the tree
-    // paints in reverse order). In particular this will happen if they are have
+    // paints in reverse order). In particular this will happen if they have
     // a different layer, because there's a repaint boundary between us.
     if (_needsLayout)
       return;

--- a/packages/flutter/test/material/input_decorator_test.dart
+++ b/packages/flutter/test/material/input_decorator_test.dart
@@ -54,6 +54,26 @@ void main() {
     expect(tester.element(find.byKey(key)).size, equals(const Size(800.0, 60.0)));
   });
 
+  testWidgets('InputDecorator draws the underline in the right place.', (WidgetTester tester) async {
+    final TextStyle style = const TextStyle(fontFamily: 'Ahem', fontSize: 10.0);
+    await tester.pumpWidget(new MaterialApp(
+      home: new Material(
+        child: new DefaultTextStyle(
+          style: style,
+          child: const Center(
+            child: const InputDecorator(
+              decoration: const InputDecoration(
+                hintText: 'Hint', labelText: 'Label', helperText: 'Helper'),
+              child: const Text('Test'),
+            ),
+          ),
+        ),
+      ),
+    ));
+
+    expect(tester.renderObject(finder), paints
+  });
+
   testWidgets('InputDecorator uses proper padding', (WidgetTester tester) async {
     final TextStyle style = const TextStyle(fontFamily: 'Ahem', fontSize: 10.0);
     await tester.pumpWidget(new MaterialApp(
@@ -76,13 +96,13 @@ void main() {
         anyOf(<Size>[const Size(60.0, 12.0), const Size(61.0, 12.0)]),
     );
     expect(tester.getRect(find.text('Label')).left, equals(0.0));
-    expect(tester.getRect(find.text('Label')).top, equals(282.5));
+    expect(tester.getRect(find.text('Label')).top, equals(278.5));
     expect(tester.getRect(find.text('Hint')).size, equals(const Size(800.0, 16.0)));
     expect(tester.getRect(find.text('Hint')).left, equals(0.0));
     expect(tester.getRect(find.text('Hint')).top, equals(298.5));
     expect(tester.getRect(find.text('Helper')).size, equals(const Size(800.0, 12.0)));
     expect(tester.getRect(find.text('Helper')).left, equals(0.0));
-    expect(tester.getRect(find.text('Helper')).top, equals(321.5));
+    expect(tester.getRect(find.text('Helper')).top, equals(325.5));
 
     await tester.pumpWidget(new MaterialApp(
       home: new Material(
@@ -103,13 +123,13 @@ void main() {
       anyOf(<Size>[const Size(60.0, 12.0), const Size(61.0, 12.0)]),
     );
     expect(tester.getRect(find.text('Label')).left, equals(0.0));
-    expect(tester.getRect(find.text('Label')).top, equals(282.5));
+    expect(tester.getRect(find.text('Label')).top, equals(278.5));
     expect(tester.getRect(find.text('Hint')).size, equals(const Size(800.0, 16.0)));
     expect(tester.getRect(find.text('Hint')).left, equals(0.0));
     expect(tester.getRect(find.text('Hint')).top, equals(298.5));
     expect(tester.getRect(find.text('Error')).size, equals(const Size(800.0, 12.0)));
     expect(tester.getRect(find.text('Error')).left, equals(0.0));
-    expect(tester.getRect(find.text('Error')).top, equals(321.5));
+    expect(tester.getRect(find.text('Error')).top, equals(325.5));
   });
 
   testWidgets('InputDecorator animates properly', (WidgetTester tester) async {
@@ -145,7 +165,7 @@ void main() {
     expect(tester.getRect(find.text('Hint')).top, equals(295.5));
     expect(tester.getRect(find.text('Helper')).size, equals(const Size(800.0, 12.0)));
     expect(tester.getRect(find.text('Helper')).left, equals(0.0));
-    expect(tester.getRect(find.text('Helper')).top, equals(324.5));
+    expect(tester.getRect(find.text('Helper')).top, equals(328.5));
     expect(find.text('P'), findsNothing);
     expect(find.text('S'), findsNothing);
 
@@ -163,7 +183,7 @@ void main() {
     expect(tester.getRect(find.text('Hint')).top, equals(295.5));
     expect(tester.getRect(find.text('Helper')).size, equals(const Size(800.0, 12.0)));
     expect(tester.getRect(find.text('Helper')).left, equals(0.0));
-    expect(tester.getRect(find.text('Helper')).top, equals(324.5));
+    expect(tester.getRect(find.text('Helper')).top, equals(328.5));
     expect(find.text('P'), findsNothing);
     expect(find.text('S'), findsNothing);
 
@@ -174,13 +194,13 @@ void main() {
       anyOf(<Size>[const Size(60.0, 12.0), const Size(61.0, 12.0)]),
     );
     expect(tester.getRect(find.text('Label')).left, equals(0.0));
-    expect(tester.getRect(find.text('Label')).top, equals(279.5));
+    expect(tester.getRect(find.text('Label')).top, equals(275.5));
     expect(tester.getRect(find.text('Hint')).size, equals(const Size(800.0, 16.0)));
     expect(tester.getRect(find.text('Hint')).left, equals(0.0));
     expect(tester.getRect(find.text('Hint')).top, equals(295.5));
     expect(tester.getRect(find.text('Helper')).size, equals(const Size(800.0, 12.0)));
     expect(tester.getRect(find.text('Helper')).left, equals(0.0));
-    expect(tester.getRect(find.text('Helper')).top, equals(324.5));
+    expect(tester.getRect(find.text('Helper')).top, equals(328.5));
     expect(find.text('P'), findsNothing);
     expect(find.text('S'), findsNothing);
 
@@ -192,13 +212,13 @@ void main() {
       anyOf(<Size>[const Size(60.0, 12.0), const Size(61.0, 12.0)]),
     );
     expect(tester.getRect(find.text('Label')).left, equals(0.0));
-    expect(tester.getRect(find.text('Label')).top, equals(279.5));
+    expect(tester.getRect(find.text('Label')).top, equals(275.5));
     expect(tester.getRect(find.text('Hint')).size, equals(const Size(800.0, 16.0)));
     expect(tester.getRect(find.text('Hint')).left, equals(0.0));
     expect(tester.getRect(find.text('Hint')).top, equals(295.5));
     expect(tester.getRect(find.text('Helper')).size, equals(const Size(800.0, 12.0)));
     expect(tester.getRect(find.text('Helper')).left, equals(0.0));
-    expect(tester.getRect(find.text('Helper')).top, equals(324.5));
+    expect(tester.getRect(find.text('Helper')).top, equals(328.5));
     expect(
       tester.getRect(find.text('P')).size,
       anyOf(<Size>[const Size(17.0, 16.0), const Size(16.0, 16.0)]),
@@ -219,13 +239,13 @@ void main() {
       anyOf(<Size>[const Size(60.0, 12.0), const Size(61.0, 12.0)]),
     );
     expect(tester.getRect(find.text('Label')).left, equals(0.0));
-    expect(tester.getRect(find.text('Label')).top, equals(279.5));
+    expect(tester.getRect(find.text('Label')).top, equals(275.5));
     expect(tester.getRect(find.text('Hint')).size, equals(const Size(800.0, 16.0)));
     expect(tester.getRect(find.text('Hint')).left, equals(0.0));
     expect(tester.getRect(find.text('Hint')).top, equals(295.5));
     expect(tester.getRect(find.text('Helper')).size, equals(const Size(800.0, 12.0)));
     expect(tester.getRect(find.text('Helper')).left, equals(0.0));
-    expect(tester.getRect(find.text('Helper')).top, equals(324.5));
+    expect(tester.getRect(find.text('Helper')).top, equals(328.5));
     expect(
       tester.getRect(find.text('P')).size,
       anyOf(<Size>[const Size(17.0, 16.0), const Size(16.0, 16.0)]),

--- a/packages/flutter/test/material/input_decorator_test.dart
+++ b/packages/flutter/test/material/input_decorator_test.dart
@@ -72,14 +72,17 @@ void main() {
 
     // TODO(#12357): Update this test when the font metric bug is fixed to remove the anyOfs.
     expect(
-        tester.getRect(find.text('Label')),
-        anyOf(<Rect>[
-          new Rect.fromLTWH(0.0, 281.0, 60.0, 12.0),
-          new Rect.fromLTWH(0.0, 281.0, 61.0, 12.0),
-        ])
+        tester.getRect(find.text('Label')).size,
+        anyOf(<Size>[const Size(60.0, 12.0), const Size(61.0, 12.0)]),
     );
-    expect(tester.getRect(find.text('Hint')), equals(new Rect.fromLTWH(0.0, 297.0, 800.0, 16.0)));
-    expect(tester.getRect(find.text('Helper')), equals(new Rect.fromLTWH(0.0, 330.0, 800.0, 12.0)));
+    expect(tester.getRect(find.text('Label')).left, equals(0.0));
+    expect(tester.getRect(find.text('Label')).top, equals(282.5));
+    expect(tester.getRect(find.text('Hint')).size, equals(const Size(800.0, 16.0)));
+    expect(tester.getRect(find.text('Hint')).left, equals(0.0));
+    expect(tester.getRect(find.text('Hint')).top, equals(298.5));
+    expect(tester.getRect(find.text('Helper')).size, equals(const Size(800.0, 12.0)));
+    expect(tester.getRect(find.text('Helper')).left, equals(0.0));
+    expect(tester.getRect(find.text('Helper')).top, equals(321.5));
 
     await tester.pumpWidget(new MaterialApp(
       home: new Material(
@@ -96,14 +99,17 @@ void main() {
     ));
 
     expect(
-        tester.getRect(find.text('Label')),
-        anyOf(<Rect>[
-          new Rect.fromLTWH(0.0, 281.0, 60.0, 12.0),
-          new Rect.fromLTWH(0.0, 281.0, 61.0, 12.0),
-        ]),
+      tester.getRect(find.text('Label')).size,
+      anyOf(<Size>[const Size(60.0, 12.0), const Size(61.0, 12.0)]),
     );
-    expect(tester.getRect(find.text('Hint')), equals(new Rect.fromLTWH(0.0, 297.0, 800.0, 16.0)));
-    expect(tester.getRect(find.text('Error')), equals(new Rect.fromLTWH(0.0, 330.0, 800.0, 12.0)));
+    expect(tester.getRect(find.text('Label')).left, equals(0.0));
+    expect(tester.getRect(find.text('Label')).top, equals(282.5));
+    expect(tester.getRect(find.text('Hint')).size, equals(const Size(800.0, 16.0)));
+    expect(tester.getRect(find.text('Hint')).left, equals(0.0));
+    expect(tester.getRect(find.text('Hint')).top, equals(298.5));
+    expect(tester.getRect(find.text('Error')).size, equals(const Size(800.0, 12.0)));
+    expect(tester.getRect(find.text('Error')).left, equals(0.0));
+    expect(tester.getRect(find.text('Error')).top, equals(321.5));
   });
 
   testWidgets('InputDecorator animates properly', (WidgetTester tester) async {
@@ -129,14 +135,17 @@ void main() {
 
     // TODO(#12357): Update this test when the font metric bug is fixed to remove the anyOfs.
     expect(
-      tester.getRect(find.text('Label')),
-      anyOf(<Rect>[
-        new Rect.fromLTWH(0.0, 294.0, 80.0, 16.0),
-        new Rect.fromLTWH(0.0, 294.0, 81.0, 16.0),
-      ]),
+      tester.getRect(find.text('Label')).size,
+      anyOf(<Size>[const Size(80.0, 16.0), const Size(81.0, 16.0)]),
     );
-    expect(tester.getRect(find.text('Hint')), equals(new Rect.fromLTWH(0.0, 294.0, 800.0, 16.0)));
-    expect(tester.getRect(find.text('Helper')), equals(new Rect.fromLTWH(0.0, 327.0, 800.0, 12.0)));
+    expect(tester.getRect(find.text('Label')).left, equals(0.0));
+    expect(tester.getRect(find.text('Label')).top, equals(295.5));
+    expect(tester.getRect(find.text('Hint')).size, equals(const Size(800.0, 16.0)));
+    expect(tester.getRect(find.text('Hint')).left, equals(0.0));
+    expect(tester.getRect(find.text('Hint')).top, equals(295.5));
+    expect(tester.getRect(find.text('Helper')).size, equals(const Size(800.0, 12.0)));
+    expect(tester.getRect(find.text('Helper')).left, equals(0.0));
+    expect(tester.getRect(find.text('Helper')).top, equals(324.5));
     expect(find.text('P'), findsNothing);
     expect(find.text('S'), findsNothing);
 
@@ -144,28 +153,34 @@ void main() {
     await tester.pump(const Duration(milliseconds: 100));
 
     expect(
-      tester.getRect(find.text('Label')),
-      anyOf(<Rect>[
-        new Rect.fromLTWH(0.0, 294.0, 60.0, 12.0),
-        new Rect.fromLTWH(0.0, 294.0, 61.0, 12.0),
-      ]),
+      tester.getRect(find.text('Label')).size,
+      anyOf(<Size>[const Size(60.0, 12.0), const Size(61.0, 12.0)]),
     );
-    expect(tester.getRect(find.text('Hint')), equals(new Rect.fromLTWH(0.0, 294.0, 800.0, 16.0)));
-    expect(tester.getRect(find.text('Helper')), equals(new Rect.fromLTWH(0.0, 327.0, 800.0, 12.0)));
+    expect(tester.getRect(find.text('Label')).left, equals(0.0));
+    expect(tester.getRect(find.text('Label')).top, equals(295.5));
+    expect(tester.getRect(find.text('Hint')).size, equals(const Size(800.0, 16.0)));
+    expect(tester.getRect(find.text('Hint')).left, equals(0.0));
+    expect(tester.getRect(find.text('Hint')).top, equals(295.5));
+    expect(tester.getRect(find.text('Helper')).size, equals(const Size(800.0, 12.0)));
+    expect(tester.getRect(find.text('Helper')).left, equals(0.0));
+    expect(tester.getRect(find.text('Helper')).top, equals(324.5));
     expect(find.text('P'), findsNothing);
     expect(find.text('S'), findsNothing);
 
     await tester.pump(const Duration(seconds: 1));
 
     expect(
-      tester.getRect(find.text('Label')),
-      anyOf(<Rect>[
-        new Rect.fromLTWH(0.0, 278.0, 60.0, 12.0),
-        new Rect.fromLTWH(0.0, 278.0, 61.0, 12.0),
-      ]),
+      tester.getRect(find.text('Label')).size,
+      anyOf(<Size>[const Size(60.0, 12.0), const Size(61.0, 12.0)]),
     );
-    expect(tester.getRect(find.text('Hint')), equals(new Rect.fromLTWH(0.0, 294.0, 800.0, 16.0)));
-    expect(tester.getRect(find.text('Helper')), equals(new Rect.fromLTWH(0.0, 327.0, 800.0, 12.0)));
+    expect(tester.getRect(find.text('Label')).left, equals(0.0));
+    expect(tester.getRect(find.text('Label')).top, equals(279.5));
+    expect(tester.getRect(find.text('Hint')).size, equals(const Size(800.0, 16.0)));
+    expect(tester.getRect(find.text('Hint')).left, equals(0.0));
+    expect(tester.getRect(find.text('Hint')).top, equals(295.5));
+    expect(tester.getRect(find.text('Helper')).size, equals(const Size(800.0, 12.0)));
+    expect(tester.getRect(find.text('Helper')).left, equals(0.0));
+    expect(tester.getRect(find.text('Helper')).top, equals(324.5));
     expect(find.text('P'), findsNothing);
     expect(find.text('S'), findsNothing);
 
@@ -173,53 +188,55 @@ void main() {
     await tester.pump(const Duration(milliseconds: 100));
 
     expect(
-      tester.getRect(find.text('Label')),
-      anyOf(<Rect>[
-        new Rect.fromLTWH(0.0, 278.0, 60.0, 12.0),
-        new Rect.fromLTWH(0.0, 278.0, 61.0, 12.0),
-      ]),
+      tester.getRect(find.text('Label')).size,
+      anyOf(<Size>[const Size(60.0, 12.0), const Size(61.0, 12.0)]),
     );
-    expect(tester.getRect(find.text('Hint')), equals(new Rect.fromLTWH(0.0, 294.0, 800.0, 16.0)));
-    expect(tester.getRect(find.text('Helper')), equals(new Rect.fromLTWH(0.0, 327.0, 800.0, 12.0)));
+    expect(tester.getRect(find.text('Label')).left, equals(0.0));
+    expect(tester.getRect(find.text('Label')).top, equals(279.5));
+    expect(tester.getRect(find.text('Hint')).size, equals(const Size(800.0, 16.0)));
+    expect(tester.getRect(find.text('Hint')).left, equals(0.0));
+    expect(tester.getRect(find.text('Hint')).top, equals(295.5));
+    expect(tester.getRect(find.text('Helper')).size, equals(const Size(800.0, 12.0)));
+    expect(tester.getRect(find.text('Helper')).left, equals(0.0));
+    expect(tester.getRect(find.text('Helper')).top, equals(324.5));
     expect(
-      tester.getRect(find.text('P')),
-      anyOf(<Rect>[
-        new Rect.fromLTWH(0.0, 294.0, 16.0, 16.0),
-        new Rect.fromLTWH(0.0, 294.0, 17.0, 16.0),
-      ]),
+      tester.getRect(find.text('P')).size,
+      anyOf(<Size>[const Size(17.0, 16.0), const Size(16.0, 16.0)]),
     );
+    expect(tester.getRect(find.text('P')).left, equals(0.0));
+    expect(tester.getRect(find.text('P')).top, equals(295.5));
     expect(
-      tester.getRect(find.text('S')),
-      anyOf(<Rect>[
-        new Rect.fromLTWH(784.0, 294.0, 16.0, 16.0),
-        new Rect.fromLTWH(783.0, 294.0, 17.0, 16.0),
-      ]),
+      tester.getRect(find.text('S')).size,
+      anyOf(<Size>[const Size(17.0, 16.0), const Size(16.0, 16.0)]),
     );
+    expect(tester.getRect(find.text('S')).left, anyOf(783.0, 784.0));
+    expect(tester.getRect(find.text('S')).top, equals(295.5));
 
     await tester.pump(const Duration(seconds: 1));
 
     expect(
-      tester.getRect(find.text('Label')),
-      anyOf(<Rect>[
-        new Rect.fromLTWH(0.0, 278.0, 60.0, 12.0),
-        new Rect.fromLTWH(0.0, 278.0, 61.0, 12.0),
-      ]),
+      tester.getRect(find.text('Label')).size,
+      anyOf(<Size>[const Size(60.0, 12.0), const Size(61.0, 12.0)]),
     );
-    expect(tester.getRect(find.text('Hint')), equals(new Rect.fromLTWH(0.0, 294.0, 800.0, 16.0)));
-    expect(tester.getRect(find.text('Helper')), equals(new Rect.fromLTWH(0.0, 327.0, 800.0, 12.0)));
+    expect(tester.getRect(find.text('Label')).left, equals(0.0));
+    expect(tester.getRect(find.text('Label')).top, equals(279.5));
+    expect(tester.getRect(find.text('Hint')).size, equals(const Size(800.0, 16.0)));
+    expect(tester.getRect(find.text('Hint')).left, equals(0.0));
+    expect(tester.getRect(find.text('Hint')).top, equals(295.5));
+    expect(tester.getRect(find.text('Helper')).size, equals(const Size(800.0, 12.0)));
+    expect(tester.getRect(find.text('Helper')).left, equals(0.0));
+    expect(tester.getRect(find.text('Helper')).top, equals(324.5));
     expect(
-      tester.getRect(find.text('P')),
-      anyOf(<Rect>[
-        new Rect.fromLTWH(0.0, 294.0, 16.0, 16.0),
-        new Rect.fromLTWH(0.0, 294.0, 17.0, 16.0),
-      ]),
+      tester.getRect(find.text('P')).size,
+      anyOf(<Size>[const Size(17.0, 16.0), const Size(16.0, 16.0)]),
     );
+    expect(tester.getRect(find.text('P')).left, equals(0.0));
+    expect(tester.getRect(find.text('P')).top, equals(295.5));
     expect(
-      tester.getRect(find.text('S')),
-      anyOf(<Rect>[
-        new Rect.fromLTWH(784.0, 294.0, 16.0, 16.0),
-        new Rect.fromLTWH(783.0, 294.0, 17.0, 16.0),
-      ]),
+      tester.getRect(find.text('S')).size,
+      anyOf(<Size>[const Size(17.0, 16.0), const Size(16.0, 16.0)]),
     );
+    expect(tester.getRect(find.text('S')).left, anyOf(783.0, 784.0));
+    expect(tester.getRect(find.text('S')).top, equals(295.5));
   });
 }

--- a/packages/flutter/test/material/input_decorator_test.dart
+++ b/packages/flutter/test/material/input_decorator_test.dart
@@ -2,8 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   testWidgets('InputDecorator always expands horizontally', (WidgetTester tester) async {
@@ -51,5 +52,174 @@ void main() {
     ));
 
     expect(tester.element(find.byKey(key)).size, equals(const Size(800.0, 60.0)));
+  });
+
+  testWidgets('InputDecorator uses proper padding', (WidgetTester tester) async {
+    final TextStyle style = const TextStyle(fontFamily: 'Ahem', fontSize: 10.0);
+    await tester.pumpWidget(new MaterialApp(
+      home: new Material(
+        child: new DefaultTextStyle(
+          style: style,
+          child: const Center(
+            child: const InputDecorator(
+              decoration: const InputDecoration(hintText: 'Hint', labelText: 'Label', helperText: 'Helper'),
+              child: const Text('Test'),
+            ),
+          ),
+        ),
+      ),
+    ));
+
+    // TODO(#12357): Update this test when the font metric bug is fixed to remove the anyOfs.
+    expect(
+        tester.getRect(find.text('Label')),
+        anyOf(<Rect>[
+          new Rect.fromLTWH(0.0, 281.0, 60.0, 12.0),
+          new Rect.fromLTWH(0.0, 281.0, 61.0, 12.0),
+        ])
+    );
+    expect(tester.getRect(find.text('Hint')), equals(new Rect.fromLTWH(0.0, 297.0, 800.0, 16.0)));
+    expect(tester.getRect(find.text('Helper')), equals(new Rect.fromLTWH(0.0, 330.0, 800.0, 12.0)));
+
+    await tester.pumpWidget(new MaterialApp(
+      home: new Material(
+        child: new DefaultTextStyle(
+          style: style,
+          child: const Center(
+            child: const InputDecorator(
+              decoration: const InputDecoration(hintText: 'Hint', labelText: 'Label', errorText: 'Error'),
+              child: const Text('Test'),
+            ),
+          ),
+        ),
+      ),
+    ));
+
+    expect(
+        tester.getRect(find.text('Label')),
+        anyOf(<Rect>[
+          new Rect.fromLTWH(0.0, 281.0, 60.0, 12.0),
+          new Rect.fromLTWH(0.0, 281.0, 61.0, 12.0),
+        ]),
+    );
+    expect(tester.getRect(find.text('Hint')), equals(new Rect.fromLTWH(0.0, 297.0, 800.0, 16.0)));
+    expect(tester.getRect(find.text('Error')), equals(new Rect.fromLTWH(0.0, 330.0, 800.0, 12.0)));
+  });
+
+  testWidgets('InputDecorator animates properly', (WidgetTester tester) async {
+    final TextStyle style = const TextStyle(fontFamily: 'Ahem', fontSize: 10.0);
+    await tester.pumpWidget(new MaterialApp(
+      home: new Material(
+        child: new DefaultTextStyle(
+          style: style,
+          child: const Center(
+            child: const TextField(
+              decoration: const InputDecoration(
+                suffixText: 'S',
+                prefixText: 'P',
+                hintText: 'Hint',
+                labelText: 'Label',
+                helperText: 'Helper',
+              ),
+            ),
+          ),
+        ),
+      ),
+    ));
+
+    // TODO(#12357): Update this test when the font metric bug is fixed to remove the anyOfs.
+    expect(
+      tester.getRect(find.text('Label')),
+      anyOf(<Rect>[
+        new Rect.fromLTWH(0.0, 294.0, 80.0, 16.0),
+        new Rect.fromLTWH(0.0, 294.0, 81.0, 16.0),
+      ]),
+    );
+    expect(tester.getRect(find.text('Hint')), equals(new Rect.fromLTWH(0.0, 294.0, 800.0, 16.0)));
+    expect(tester.getRect(find.text('Helper')), equals(new Rect.fromLTWH(0.0, 327.0, 800.0, 12.0)));
+    expect(find.text('P'), findsNothing);
+    expect(find.text('S'), findsNothing);
+
+    await tester.tap(find.byType(TextField));
+    await tester.pump(const Duration(milliseconds: 100));
+
+    expect(
+      tester.getRect(find.text('Label')),
+      anyOf(<Rect>[
+        new Rect.fromLTWH(0.0, 294.0, 60.0, 12.0),
+        new Rect.fromLTWH(0.0, 294.0, 61.0, 12.0),
+      ]),
+    );
+    expect(tester.getRect(find.text('Hint')), equals(new Rect.fromLTWH(0.0, 294.0, 800.0, 16.0)));
+    expect(tester.getRect(find.text('Helper')), equals(new Rect.fromLTWH(0.0, 327.0, 800.0, 12.0)));
+    expect(find.text('P'), findsNothing);
+    expect(find.text('S'), findsNothing);
+
+    await tester.pump(const Duration(seconds: 1));
+
+    expect(
+      tester.getRect(find.text('Label')),
+      anyOf(<Rect>[
+        new Rect.fromLTWH(0.0, 278.0, 60.0, 12.0),
+        new Rect.fromLTWH(0.0, 278.0, 61.0, 12.0),
+      ]),
+    );
+    expect(tester.getRect(find.text('Hint')), equals(new Rect.fromLTWH(0.0, 294.0, 800.0, 16.0)));
+    expect(tester.getRect(find.text('Helper')), equals(new Rect.fromLTWH(0.0, 327.0, 800.0, 12.0)));
+    expect(find.text('P'), findsNothing);
+    expect(find.text('S'), findsNothing);
+
+    await tester.enterText(find.byType(TextField), 'Test');
+    await tester.pump(const Duration(milliseconds: 100));
+
+    expect(
+      tester.getRect(find.text('Label')),
+      anyOf(<Rect>[
+        new Rect.fromLTWH(0.0, 278.0, 60.0, 12.0),
+        new Rect.fromLTWH(0.0, 278.0, 61.0, 12.0),
+      ]),
+    );
+    expect(tester.getRect(find.text('Hint')), equals(new Rect.fromLTWH(0.0, 294.0, 800.0, 16.0)));
+    expect(tester.getRect(find.text('Helper')), equals(new Rect.fromLTWH(0.0, 327.0, 800.0, 12.0)));
+    expect(
+      tester.getRect(find.text('P')),
+      anyOf(<Rect>[
+        new Rect.fromLTWH(0.0, 294.0, 16.0, 16.0),
+        new Rect.fromLTWH(0.0, 294.0, 17.0, 16.0),
+      ]),
+    );
+    expect(
+      tester.getRect(find.text('S')),
+      anyOf(<Rect>[
+        new Rect.fromLTWH(784.0, 294.0, 16.0, 16.0),
+        new Rect.fromLTWH(783.0, 294.0, 17.0, 16.0),
+      ]),
+    );
+
+    await tester.pump(const Duration(seconds: 1));
+
+    expect(
+      tester.getRect(find.text('Label')),
+      anyOf(<Rect>[
+        new Rect.fromLTWH(0.0, 278.0, 60.0, 12.0),
+        new Rect.fromLTWH(0.0, 278.0, 61.0, 12.0),
+      ]),
+    );
+    expect(tester.getRect(find.text('Hint')), equals(new Rect.fromLTWH(0.0, 294.0, 800.0, 16.0)));
+    expect(tester.getRect(find.text('Helper')), equals(new Rect.fromLTWH(0.0, 327.0, 800.0, 12.0)));
+    expect(
+      tester.getRect(find.text('P')),
+      anyOf(<Rect>[
+        new Rect.fromLTWH(0.0, 294.0, 16.0, 16.0),
+        new Rect.fromLTWH(0.0, 294.0, 17.0, 16.0),
+      ]),
+    );
+    expect(
+      tester.getRect(find.text('S')),
+      anyOf(<Rect>[
+        new Rect.fromLTWH(784.0, 294.0, 16.0, 16.0),
+        new Rect.fromLTWH(783.0, 294.0, 17.0, 16.0),
+      ]),
+    );
   });
 }

--- a/packages/flutter/test/material/input_decorator_test.dart
+++ b/packages/flutter/test/material/input_decorator_test.dart
@@ -7,88 +7,171 @@ import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
+  Widget buildInputDecorator({InputDecoration decoration = const InputDecoration(), Widget child = const Text('Test')}) {
+    return new MaterialApp(
+      home: new Material(
+        child: new DefaultTextStyle(
+          style: const TextStyle(fontFamily: 'Ahem', fontSize: 10.0),
+          child: new Center(
+            child: new InputDecorator(
+              decoration: decoration,
+              child: child,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Finder findInputDecoratorChildContainer() {
+    return find.byWidgetPredicate(
+            (Widget w) {
+          return w is AnimatedContainer && (w as dynamic).decoration != null;
+        });
+  }
+
+  double getBoxDecorationThickness(WidgetTester tester) {
+    final AnimatedContainer container = tester.widget(findInputDecoratorChildContainer());
+    final BoxDecoration decoration = container.decoration;
+    final Border border = decoration.border;
+    return border.bottom.width;
+  }
+
+  double getDividerY(WidgetTester tester) {
+    final Finder animatedContainerFinder = find.byWidgetPredicate(
+            (Widget w) {
+          return w is AnimatedContainer && (w as dynamic).decoration != null;
+        });
+    return tester.getRect(animatedContainerFinder).bottom;
+  }
+
+  double getDividerWidth(WidgetTester tester) {
+    final Finder animatedContainerFinder = find.byWidgetPredicate(
+            (Widget w) {
+          return w is AnimatedContainer && (w as dynamic).decoration != null;
+        });
+    return tester.getRect(animatedContainerFinder).size.width;
+  }
+
   testWidgets('InputDecorator always expands horizontally', (WidgetTester tester) async {
     final Key key = new UniqueKey();
 
-    await tester.pumpWidget(new MaterialApp(
-      home: new Material(
-        child: new Center(
-          child: new InputDecorator(
-            decoration: const InputDecoration(),
-            child: new Container(key: key, width: 50.0, height: 60.0, color: Colors.blue),
-          ),
-        ),
+    await tester.pumpWidget(
+      buildInputDecorator(
+        child: new Container(key: key, width: 50.0, height: 60.0, color: Colors.blue),
       ),
-    ));
+    );
 
     expect(tester.element(find.byKey(key)).size, equals(const Size(800.0, 60.0)));
 
-    await tester.pumpWidget(new MaterialApp(
-      home: new Material(
-        child: new Center(
-          child: new InputDecorator(
-            decoration: const InputDecoration(
-              icon: const Icon(Icons.add_shopping_cart),
-            ),
-            child: new Container(key: key, width: 50.0, height: 60.0, color: Colors.blue),
-          ),
+    await tester.pumpWidget(
+      buildInputDecorator(
+        decoration: const InputDecoration(
+          icon: const Icon(Icons.add_shopping_cart),
         ),
+        child: new Container(key: key, width: 50.0, height: 60.0, color: Colors.blue),
       ),
-    ));
+    );
 
     expect(tester.element(find.byKey(key)).size, equals(const Size(752.0, 60.0)));
 
-    await tester.pumpWidget(new MaterialApp(
-      home: new Material(
-        child: new Center(
-          child: new InputDecorator(
-            decoration: const InputDecoration.collapsed(
-              hintText: 'Hint text',
-            ),
-            child: new Container(key: key, width: 50.0, height: 60.0, color: Colors.blue),
-          ),
+    await tester.pumpWidget(
+      buildInputDecorator(
+        decoration: const InputDecoration.collapsed(
+          hintText: 'Hint text',
         ),
+        child: new Container(key: key, width: 50.0, height: 60.0, color: Colors.blue),
       ),
-    ));
+    );
 
     expect(tester.element(find.byKey(key)).size, equals(const Size(800.0, 60.0)));
   });
 
-  testWidgets('InputDecorator draws the underline in the right place.', (WidgetTester tester) async {
-    final TextStyle style = const TextStyle(fontFamily: 'Ahem', fontSize: 10.0);
-    await tester.pumpWidget(new MaterialApp(
-      home: new Material(
-        child: new DefaultTextStyle(
-          style: style,
-          child: const Center(
-            child: const InputDecorator(
-              decoration: const InputDecoration(
-                hintText: 'Hint', labelText: 'Label', helperText: 'Helper'),
-              child: const Text('Test'),
-            ),
-          ),
+  testWidgets('InputDecorator draws the underline correctly in the right place.', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      buildInputDecorator(
+        decoration: const InputDecoration(
+          hintText: 'Hint',
+          labelText: 'Label',
+          helperText: 'Helper',
         ),
       ),
-    ));
+    );
 
-    expect(tester.renderObject(finder), paints
+    expect(getBoxDecorationThickness(tester), equals(1.0));
+    expect(getDividerY(tester), equals(316.5));
+    expect(getDividerWidth(tester), equals(800.0));
+  });
+
+  testWidgets('InputDecorator draws the underline correctly in the right place for dense layout.', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      buildInputDecorator(
+        decoration: const InputDecoration(
+          hintText: 'Hint',
+          labelText: 'Label',
+          helperText: 'Helper',
+          isDense: true,
+        ),
+      ),
+    );
+
+    expect(getBoxDecorationThickness(tester), equals(1.0));
+    expect(getDividerY(tester), equals(312.5));
+    expect(getDividerWidth(tester), equals(800.0));
+  });
+
+  testWidgets('InputDecorator does not draw the underline when hideDivider is true.', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      buildInputDecorator(
+        decoration: const InputDecoration(
+          hintText: 'Hint',
+          labelText: 'Label',
+          helperText: 'Helper',
+          hideDivider: true,
+        ),
+      ),
+    );
+
+    expect(findInputDecoratorChildContainer(), findsNothing);
+  });
+
+  testWidgets('InputDecorator uses proper padding for dense mode', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      buildInputDecorator(
+        decoration: const InputDecoration(
+          hintText: 'Hint',
+          labelText: 'Label',
+          helperText: 'Helper',
+          isDense: true,
+        ),
+      ),
+    );
+
+    // TODO(#12357): Update this test when the font metric bug is fixed to remove the anyOfs.
+    expect(
+      tester.getRect(find.text('Label')).size,
+      anyOf(<Size>[const Size(60.0, 12.0), const Size(61.0, 12.0)]),
+    );
+    expect(tester.getRect(find.text('Label')).left, equals(0.0));
+    expect(tester.getRect(find.text('Label')).top, equals(278.5));
+    expect(tester.getRect(find.text('Hint')).size, equals(const Size(800.0, 16.0)));
+    expect(tester.getRect(find.text('Hint')).left, equals(0.0));
+    expect(tester.getRect(find.text('Hint')).top, equals(294.5));
+    expect(tester.getRect(find.text('Helper')).size, equals(const Size(800.0, 12.0)));
+    expect(tester.getRect(find.text('Helper')).left, equals(0.0));
+    expect(tester.getRect(find.text('Helper')).top, equals(317.5));
   });
 
   testWidgets('InputDecorator uses proper padding', (WidgetTester tester) async {
-    final TextStyle style = const TextStyle(fontFamily: 'Ahem', fontSize: 10.0);
-    await tester.pumpWidget(new MaterialApp(
-      home: new Material(
-        child: new DefaultTextStyle(
-          style: style,
-          child: const Center(
-            child: const InputDecorator(
-              decoration: const InputDecoration(hintText: 'Hint', labelText: 'Label', helperText: 'Helper'),
-              child: const Text('Test'),
-            ),
-          ),
+    await tester.pumpWidget(
+      buildInputDecorator(
+        decoration: const InputDecoration(
+          hintText: 'Hint',
+          labelText: 'Label',
+          helperText: 'Helper',
         ),
       ),
-    ));
+    );
 
     // TODO(#12357): Update this test when the font metric bug is fixed to remove the anyOfs.
     expect(
@@ -103,21 +186,21 @@ void main() {
     expect(tester.getRect(find.text('Helper')).size, equals(const Size(800.0, 12.0)));
     expect(tester.getRect(find.text('Helper')).left, equals(0.0));
     expect(tester.getRect(find.text('Helper')).top, equals(325.5));
+  });
 
-    await tester.pumpWidget(new MaterialApp(
-      home: new Material(
-        child: new DefaultTextStyle(
-          style: style,
-          child: const Center(
-            child: const InputDecorator(
-              decoration: const InputDecoration(hintText: 'Hint', labelText: 'Label', errorText: 'Error'),
-              child: const Text('Test'),
-            ),
-          ),
+  testWidgets('InputDecorator uses proper padding when error is set', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      buildInputDecorator(
+        decoration: const InputDecoration(
+          hintText: 'Hint',
+          labelText: 'Label',
+          helperText: 'Helper',
+          errorText: 'Error',
         ),
       ),
-    ));
+    );
 
+    // TODO(#12357): Update this test when the font metric bug is fixed to remove the anyOfs.
     expect(
       tester.getRect(find.text('Label')).size,
       anyOf(<Size>[const Size(60.0, 12.0), const Size(61.0, 12.0)]),
@@ -133,11 +216,10 @@ void main() {
   });
 
   testWidgets('InputDecorator animates properly', (WidgetTester tester) async {
-    final TextStyle style = const TextStyle(fontFamily: 'Ahem', fontSize: 10.0);
     await tester.pumpWidget(new MaterialApp(
-      home: new Material(
-        child: new DefaultTextStyle(
-          style: style,
+      home: const Material(
+        child: const DefaultTextStyle(
+          style: const TextStyle(fontFamily: 'Ahem', fontSize: 10.0),
           child: const Center(
             child: const TextField(
               decoration: const InputDecoration(


### PR DESCRIPTION
There were a number of differences with the Material Design spec, including
several different padding values and underline thickness.  This corrects
that so that the decorator is in line with the Material Design spec now.

Also, the decorator properly handles changes to the textScaleFactor, where
before it would not re-layout when needed, painting the cursor and
underline incorrectly.

The decorator also now properly animates helper, error, and hint text when
the textScaleFactor or input decoration properties change.

Helper text is now properly displayed in dense mode, as the spec shows.
Before this change, it was never displayed in dense mode.

Fixes #12485