### PR TITLE
Add a pageSnapping parameter to PageView

### DIFF
--- a/packages/flutter/lib/src/widgets/page_view.dart
+++ b/packages/flutter/lib/src/widgets/page_view.dart
@@ -307,7 +307,6 @@ class PageScrollPhysics extends ScrollPhysics {
 // control the scroll positions, everything should be fine.
 final PageController _defaultPageController = new PageController();
 const PageScrollPhysics _kPagePhysics = const PageScrollPhysics();
-const ScrollPhysics _kNonSnappingPhysics = const ScrollPhysics();
 
 /// A scrollable list that works page by page.
 ///
@@ -470,12 +469,9 @@ class _PageViewState extends State<PageView> {
   @override
   Widget build(BuildContext context) {
     final AxisDirection axisDirection = _getDirection(context);
-    ScrollPhysics physics = widget.physics;
-    if (physics == null) {
-      physics = widget.pageSnapping ? _kPagePhysics : _kNonSnappingPhysics;
-    } else if (widget.pageSnapping) {
-      physics = _kPagePhysics.applyTo(physics);
-    }
+    final ScrollPhysics physics = widget.pageSnapping
+        ? _kPagePhysics.applyTo(widget.physics)
+        : widget.physics;
 
     return new NotificationListener<ScrollNotification>(
       onNotification: (ScrollNotification notification) {
@@ -516,6 +512,6 @@ class _PageViewState extends State<PageView> {
     description.add(new FlagProperty('reverse', value: widget.reverse, ifTrue: 'reversed'));
     description.add(new DiagnosticsProperty<PageController>('controller', widget.controller, showName: false));
     description.add(new DiagnosticsProperty<ScrollPhysics>('physics', widget.physics, showName: false));
-    description.add(new FlagProperty('pageSnapping', value: widget.pageSnapping, ifFalse: 'noSnapping'));
+    description.add(new FlagProperty('pageSnapping', value: widget.pageSnapping, ifFalse: 'snapping disabled'));
   }
 }

--- a/packages/flutter/test/widgets/page_view_test.dart
+++ b/packages/flutter/test/widgets/page_view_test.dart
@@ -368,6 +368,70 @@ void main() {
     expect(tester.getTopLeft(find.text('Idaho')), const Offset(790.0, 0.0));
   });
 
+  testWidgets('Page snapping disable and reenable',
+      (WidgetTester tester) async {
+    final List<int> log = <int>[];
+
+    Widget build({bool pageSnapping}) {
+      return new Directionality(
+        textDirection: TextDirection.ltr,
+        child: new PageView(
+          pageSnapping: pageSnapping,
+          onPageChanged: log.add,
+          children:
+              kStates.map<Widget>((String state) => new Text(state)).toList(),
+        ),
+      );
+    }
+
+    await tester.pumpWidget(build(pageSnapping: true));
+    expect(log, isEmpty);
+
+    // Drag more than halfway to the next page, to confirm the default behavior.
+    TestGesture gesture = await tester.startGesture(const Offset(100.0, 100.0));
+    // The page view is 800.0 wide, so this move is just beyond halfway.
+    await gesture.moveBy(const Offset(-420.0, 0.0));
+
+    expect(log, equals(const <int>[1]));
+    log.clear();
+
+    // Release the gesture, confirm that the page settles on the next.
+    await gesture.up();
+    await tester.pumpAndSettle();
+
+    expect(find.text('Alabama'), findsNothing);
+    expect(find.text('Alaska'), findsOneWidget);
+
+    // Disable page snapping, and try moving halfway. Confirm it doesn't snap.
+    await tester.pumpWidget(build(pageSnapping: false));
+    gesture = await tester.startGesture(const Offset(100.0, 100.0));
+    // Move just beyond halfway, again.
+    await gesture.moveBy(const Offset(-420.0, 0.0));
+
+    // Page notifications still get sent.
+    expect(log, equals(const <int>[2]));
+    log.clear();
+
+    // Release the gesture, confirm that both pages are visible.
+    await gesture.up();
+    await tester.pumpAndSettle();
+
+    expect(find.text('Alabama'), findsNothing);
+    expect(find.text('Alaska'), findsOneWidget);
+    expect(find.text('Arizona'), findsOneWidget);
+    expect(find.text('California'), findsNothing);
+
+    // Now re-enable snapping, confirm that we've settled on a page.
+    await tester.pumpWidget(build(pageSnapping: true));
+    await tester.pumpAndSettle();
+
+    expect(log, isEmpty);
+
+    expect(find.text('Alaska'), findsNothing);
+    expect(find.text('Arizona'), findsOneWidget);
+    expect(find.text('California'), findsNothing);
+  });
+
   testWidgets('PageView small viewportFraction', (WidgetTester tester) async {
     final PageController controller = new PageController(viewportFraction: 1/8);
 

--- a/packages/flutter/test/widgets/page_view_test.dart
+++ b/packages/flutter/test/widgets/page_view_test.dart
@@ -368,11 +368,10 @@ void main() {
     expect(tester.getTopLeft(find.text('Idaho')), const Offset(790.0, 0.0));
   });
 
-  testWidgets('Page snapping disable and reenable',
-      (WidgetTester tester) async {
+  testWidgets('Page snapping disable and reenable', (WidgetTester tester) async {
     final List<int> log = <int>[];
 
-    Widget build({bool pageSnapping}) {
+    Widget build({ bool pageSnapping }) {
       return new Directionality(
         textDirection: TextDirection.ltr,
         child: new PageView(
@@ -419,7 +418,7 @@ void main() {
     expect(find.text('Alabama'), findsNothing);
     expect(find.text('Alaska'), findsOneWidget);
     expect(find.text('Arizona'), findsOneWidget);
-    expect(find.text('California'), findsNothing);
+    expect(find.text('Arkansas'), findsNothing);
 
     // Now re-enable snapping, confirm that we've settled on a page.
     await tester.pumpWidget(build(pageSnapping: true));
@@ -429,7 +428,7 @@ void main() {
 
     expect(find.text('Alaska'), findsNothing);
     expect(find.text('Arizona'), findsOneWidget);
-    expect(find.text('California'), findsNothing);
+    expect(find.text('Arkansas'), findsNothing);
   });
 
   testWidgets('PageView small viewportFraction', (WidgetTester tester) async {


### PR DESCRIPTION
This is a change I made to flutter for my application, which enabled me to create a custom scroll bar by introducing a `pageSnapping` property on `PageView`.

When my scroll bar is being dragged, I disable pageSnapping to precisely control the position of the scroll view, and on release I re-enable snapping which results in the nearest page snapping into alignment.

This change includes a test to validate the functionality; let me know if there is anything additional required.