### PR TITLE
Construct the accessibility channel's events by SemanticsEvent.

### DIFF
--- a/packages/flutter/lib/src/rendering/semantics.dart
+++ b/packages/flutter/lib/src/rendering/semantics.dart
@@ -643,12 +643,7 @@ class SemanticsNode extends AbstractNode with DiagnosticableTreeMixin {
   void sendEvent(SemanticsEvent event) {
     if (!attached)
       return;
-    final Map<String, dynamic> annotatedEvent = <String, dynamic>{
-      'nodeId': id,
-      'type': event.type,
-      'data': event.toMap(),
-    };
-    SystemChannels.accessibility.send(annotatedEvent);
+    SystemChannels.accessibility.send(event.toMap(nodeId: id));
   }
 
   @override

--- a/packages/flutter/lib/src/rendering/semantics_event.dart
+++ b/packages/flutter/lib/src/rendering/semantics_event.dart
@@ -25,18 +25,21 @@ abstract class SemanticsEvent {
 
   /// Converts this event to a Map that can be encoded with
   /// [StandardMessageCodec].
-  Map<String, dynamic> toMap({int nodeId}) {
+  ///
+  /// [nodeId] is the unique identifier of the semantics node associated with
+  /// the event, or null if the event is not associated with a semantics node.
+  Map<String, dynamic> toMap({ int nodeId }) {
     final Map<String, dynamic> event = <String, dynamic>{
       'type': type,
       'data': getDataMap(),
     };
-    if (nodeId != null) {
+    if (nodeId != null)
       event['nodeId'] = nodeId;
-    }
+
     return event;
   }
 
-  // Returns the event's data object.
+  /// Returns the event's data object.
   Map<String, dynamic> getDataMap();
 
   @override

--- a/packages/flutter/lib/src/rendering/semantics_event.dart
+++ b/packages/flutter/lib/src/rendering/semantics_event.dart
@@ -25,15 +25,27 @@ abstract class SemanticsEvent {
 
   /// Converts this event to a Map that can be encoded with
   /// [StandardMessageCodec].
-  Map<String, dynamic> toMap();
+  Map<String, dynamic> toMap({int nodeId}) {
+    final Map<String, dynamic> event = <String, dynamic>{
+      'type': type,
+      'data': getDataMap(),
+    };
+    if (nodeId != null) {
+      event['nodeId'] = nodeId;
+    }
+    return event;
+  }
+
+  // Returns the event's data object.
+  Map<String, dynamic> getDataMap();
 
   @override
   String toString() {
     final List<String> pairs = <String>[];
-    final Map<String, dynamic> map = toMap();
-    final List<String> sortedKeys = map.keys.toList()..sort();
+    final Map<String, dynamic> dataMap = getDataMap();
+    final List<String> sortedKeys = dataMap.keys.toList()..sort();
     for (String key in sortedKeys)
-      pairs.add('$key: ${map[key]}');
+      pairs.add('$key: ${dataMap[key]}');
     return '$runtimeType(${pairs.join(', ')})';
   }
 }
@@ -87,7 +99,7 @@ class ScrollCompletedSemanticsEvent extends SemanticsEvent {
   final double maxScrollExtent;
 
   @override
-  Map<String, dynamic> toMap() {
+  Map<String, dynamic> getDataMap() {
     final Map<String, dynamic> map = <String, dynamic>{
       'pixels': pixels.clamp(minScrollExtent, maxScrollExtent),
       'minScrollExtent': minScrollExtent,

--- a/packages/flutter/lib/src/services/system_channels.dart
+++ b/packages/flutter/lib/src/services/system_channels.dart
@@ -58,7 +58,7 @@ class SystemChannels {
   ///
   /// See also:
   ///
-  /// * [SemanticsEvents] and its subclasses for a list of valid accessibility
+  /// * [SemanticsEvent] and its subclasses for a list of valid accessibility
   ///   events that can be sent over this channel.
   static const BasicMessageChannel<dynamic> accessibility = const BasicMessageChannel<dynamic>(
     'flutter/accessibility',

--- a/packages/flutter/test/widgets/semantics_event_test.dart
+++ b/packages/flutter/test/widgets/semantics_event_test.dart
@@ -24,6 +24,29 @@ void main() {
       'TestSemanticsEvent(number: 10, text: hello)',
     );
   });
+  test('SemanticsEvent.toMap', () {
+    expect(
+      new TestSemanticsEvent(text: 'hi', number: 11).toMap(),
+      <String, dynamic> {
+        'type': 'TestEvent',
+        'data': <String, dynamic> {
+          'text': 'hi',
+          'number': 11
+        }
+      }
+    );
+    expect(
+      new TestSemanticsEvent(text: 'hi', number: 11).toMap(nodeId: 123),
+      <String, dynamic> {
+        'type': 'TestEvent',
+        'nodeId': 123,
+        'data': <String, dynamic> {
+          'text': 'hi',
+          'number': 11
+        }
+      }
+    );
+  });
 }
 
 class TestSemanticsEvent extends SemanticsEvent {
@@ -33,7 +56,7 @@ class TestSemanticsEvent extends SemanticsEvent {
   final int number;
 
   @override
-  Map<String, dynamic> toMap() {
+  Map<String, dynamic> getDataMap() {
     final Map<String, dynamic> result = <String, dynamic>{};
     if (text != null)
       result['text'] = text;


### PR DESCRIPTION
This refactoring allows us to have SemanticsEvent object for events that are not
associated with an accessibility node id.
And allow https://github.com/flutter/flutter/pull/12594 to be a bit
cleaner with a single place for accessibility channel documentation (the
SemanticsEvent classes documentation).