### PR TITLE
Language-specific LocalizationDelegates

### DIFF
--- a/examples/stocks/lib/main.dart
+++ b/examples/stocks/lib/main.dart
@@ -27,6 +27,9 @@ class _StocksLocalizationsDelegate extends LocalizationsDelegate<StockStrings> {
   Future<StockStrings> load(Locale locale) => StockStrings.load(locale);
 
   @override
+  bool isSupported(Locale locale) => locale.languageCode == 'es' || locale.languageCode == 'en';
+
+  @override
   bool shouldReload(_StocksLocalizationsDelegate old) => false;
 }
 

--- a/packages/flutter/lib/src/material/material_localizations.dart
+++ b/packages/flutter/lib/src/material/material_localizations.dart
@@ -188,6 +188,9 @@ class _MaterialLocalizationsDelegate extends LocalizationsDelegate<MaterialLocal
   const _MaterialLocalizationsDelegate();
 
   @override
+  bool isSupported(Locale locale) => locale.languageCode == 'en';
+
+  @override
   Future<MaterialLocalizations> load(Locale locale) => DefaultMaterialLocalizations.load(locale);
 
   @override

--- a/packages/flutter/lib/src/widgets/localizations.dart
+++ b/packages/flutter/lib/src/widgets/localizations.dart
@@ -42,11 +42,13 @@ Future<Map<Type, dynamic>> _loadAll(Locale locale, Iterable<LocalizationsDelegat
   final Map<Type, dynamic> output = <Type, dynamic>{};
   List<_Pending> pendingList;
 
-  // Only load the first delegate for each delgate type.
+  // Only load the first delegate for each delgate type that supports
+  // locale.languageCode.
+  //
   final Set<Type> types = new Set<Type>();
   final List<LocalizationsDelegate<dynamic>> delegates = <LocalizationsDelegate<dynamic>>[];
   for (LocalizationsDelegate<dynamic> delegate in allDelegates) {
-    if (!types.contains(delegate.type)) {
+    if (delegate.isSupported(locale) && !types.contains(delegate.type)) {
       types.add(delegate.type);
       delegates.add(delegate);
     }
@@ -96,6 +98,12 @@ abstract class LocalizationsDelegate<T> {
   /// Abstract const constructor. This constructor enables subclasses to provide
   /// const constructors so that they can be used in const expressions.
   const LocalizationsDelegate();
+
+  /// Return true if the instance of 'T' loaded by this delegate's [load]
+  /// method supports the given `locale`'s language.
+  bool isSupported(Locale locale) => true;
+  // TODO(hansmuller): remove the default implementation after existing
+  // apps have had a chance to update.
 
   /// Start loading the resources for `locale`. The returned future completes
   /// when the resources have finished loading.
@@ -163,6 +171,11 @@ abstract class WidgetsLocalizations {
 
 class _WidgetsLocalizationsDelegate extends LocalizationsDelegate<WidgetsLocalizations> {
   const _WidgetsLocalizationsDelegate();
+
+  // This is convenient simplification. It would be more correct test if locale's
+  // text-direction is LTR.
+  @override
+  bool isSupported(Locale locale) => true;
 
   @override
   Future<WidgetsLocalizations> load(Locale locale) => DefaultWidgetsLocalizations.load(locale);

--- a/packages/flutter/lib/src/widgets/localizations.dart
+++ b/packages/flutter/lib/src/widgets/localizations.dart
@@ -42,13 +42,12 @@ Future<Map<Type, dynamic>> _loadAll(Locale locale, Iterable<LocalizationsDelegat
   final Map<Type, dynamic> output = <Type, dynamic>{};
   List<_Pending> pendingList;
 
-  // Only load the first delegate for each delgate type that supports
+  // Only load the first delegate for each delegate type that supports
   // locale.languageCode.
-  //
   final Set<Type> types = new Set<Type>();
   final List<LocalizationsDelegate<dynamic>> delegates = <LocalizationsDelegate<dynamic>>[];
   for (LocalizationsDelegate<dynamic> delegate in allDelegates) {
-    if (delegate.isSupported(locale) && !types.contains(delegate.type)) {
+    if (!types.contains(delegate.type) && delegate.isSupported(locale)) {
       types.add(delegate.type);
       delegates.add(delegate);
     }
@@ -99,11 +98,11 @@ abstract class LocalizationsDelegate<T> {
   /// const constructors so that they can be used in const expressions.
   const LocalizationsDelegate();
 
-  /// Return true if the instance of 'T' loaded by this delegate's [load]
+  /// Whether resources for the given locale can be loaded by this delegate.
+  ///
+  /// Return true if the instance of `T` loaded by this delegate's [load]
   /// method supports the given `locale`'s language.
-  bool isSupported(Locale locale) => true;
-  // TODO(hansmuller): remove the default implementation after existing
-  // apps have had a chance to update.
+  bool isSupported(Locale locale);
 
   /// Start loading the resources for `locale`. The returned future completes
   /// when the resources have finished loading.
@@ -172,7 +171,7 @@ abstract class WidgetsLocalizations {
 class _WidgetsLocalizationsDelegate extends LocalizationsDelegate<WidgetsLocalizations> {
   const _WidgetsLocalizationsDelegate();
 
-  // This is convenient simplification. It would be more correct test if locale's
+  // This is convenient simplification. It would be more correct test if the locale's
   // text-direction is LTR.
   @override
   bool isSupported(Locale locale) => true;

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -29,6 +29,9 @@ class MockClipboard {
 
 class MaterialLocalizationsDelegate extends LocalizationsDelegate<MaterialLocalizations> {
   @override
+  bool isSupported(Locale locale) => true;
+
+  @override
   Future<MaterialLocalizations> load(Locale locale) => DefaultMaterialLocalizations.load(locale);
 
   @override
@@ -36,6 +39,9 @@ class MaterialLocalizationsDelegate extends LocalizationsDelegate<MaterialLocali
 }
 
 class WidgetsLocalizationsDelegate extends LocalizationsDelegate<WidgetsLocalizations> {
+  @override
+  bool isSupported(Locale locale) => true;
+
   @override
   Future<WidgetsLocalizations> load(Locale locale) => DefaultWidgetsLocalizations.load(locale);
 

--- a/packages/flutter_localizations/lib/src/material_localizations.dart
+++ b/packages/flutter_localizations/lib/src/material_localizations.dart
@@ -423,6 +423,27 @@ void _loadDateIntlDataIfNotLoaded() {
 class _MaterialLocalizationsDelegate extends LocalizationsDelegate<MaterialLocalizations> {
   const _MaterialLocalizationsDelegate();
 
+  static const List<String> _supportedLanguages = const <String>[
+    'ar',  // Arabic
+    'de',  // German
+    'en',  // English
+    'es',  // Spanish
+    'fa',  // Farsi
+    'fr',  // French
+    'he',  // Hebrew
+    'it',  // Italian
+    'ja',  // Japanese
+    'ps',  // Pashto
+    'pt',  // Portugese
+    'ru',  // Russian
+    'sd',  // Sindhi
+    'ur',  // Urdu
+    'zh',  // Simplified Chinese
+  ];
+
+  @override
+  bool isSupported(Locale locale) => _supportedLanguages.contains(locale.languageCode);
+
   @override
   Future<MaterialLocalizations> load(Locale locale) => GlobalMaterialLocalizations.load(locale);
 

--- a/packages/flutter_localizations/lib/src/widgets_localizations.dart
+++ b/packages/flutter_localizations/lib/src/widgets_localizations.dart
@@ -68,6 +68,9 @@ class _WidgetsLocalizationsDelegate extends LocalizationsDelegate<WidgetsLocaliz
   const _WidgetsLocalizationsDelegate();
 
   @override
+  bool isSupported(Locale locale) => true;
+
+  @override
   Future<WidgetsLocalizations> load(Locale locale) => GlobalWidgetsLocalizations.load(locale);
 
   @override

--- a/packages/flutter_localizations/test/basics_test.dart
+++ b/packages/flutter_localizations/test/basics_test.dart
@@ -56,6 +56,9 @@ class _DummyLocalizationsDelegate extends LocalizationsDelegate<DummyLocalizatio
   Future<DummyLocalizations> load(Locale locale) async => new DummyLocalizations();
 
   @override
+  isSupported(Locale locale) => true;
+
+  @override
   bool shouldReload(_DummyLocalizationsDelegate old) => true;
 }
 

--- a/packages/flutter_localizations/test/basics_test.dart
+++ b/packages/flutter_localizations/test/basics_test.dart
@@ -56,7 +56,7 @@ class _DummyLocalizationsDelegate extends LocalizationsDelegate<DummyLocalizatio
   Future<DummyLocalizations> load(Locale locale) async => new DummyLocalizations();
 
   @override
-  isSupported(Locale locale) => true;
+  bool isSupported(Locale locale) => true;
 
   @override
   bool shouldReload(_DummyLocalizationsDelegate old) => true;

--- a/packages/flutter_localizations/test/widgets_test.dart
+++ b/packages/flutter_localizations/test/widgets_test.dart
@@ -36,6 +36,9 @@ class SyncTestLocalizationsDelegate extends LocalizationsDelegate<TestLocalizati
   final List<bool> shouldReloadValues = <bool>[];
 
   @override
+  bool isSupported(Locale locale) => true;
+
+  @override
   Future<TestLocalizations> load(Locale locale) => TestLocalizations.loadSync(locale, prefix);
 
   @override
@@ -53,6 +56,9 @@ class AsyncTestLocalizationsDelegate extends LocalizationsDelegate<TestLocalizat
 
   final String prefix; // Changing this value triggers a rebuild
   final List<bool> shouldReloadValues = <bool>[];
+
+  @override
+  bool isSupported(Locale locale) => true;
 
   @override
   Future<TestLocalizations> load(Locale locale) => TestLocalizations.loadAsync(locale, prefix);
@@ -93,12 +99,18 @@ class SyncMoreLocalizationsDelegate extends LocalizationsDelegate<MoreLocalizati
   Future<MoreLocalizations> load(Locale locale) => MoreLocalizations.loadSync(locale);
 
   @override
+  bool isSupported(Locale locale) => true;
+
+  @override
   bool shouldReload(SyncMoreLocalizationsDelegate old) => false;
 }
 
 class AsyncMoreLocalizationsDelegate extends LocalizationsDelegate<MoreLocalizations> {
   @override
   Future<MoreLocalizations> load(Locale locale) => MoreLocalizations.loadAsync(locale);
+
+  @override
+  bool isSupported(Locale locale) => true;
 
   @override
   bool shouldReload(AsyncMoreLocalizationsDelegate old) => false;
@@ -111,6 +123,9 @@ class OnlyRTLDefaultWidgetsLocalizations extends DefaultWidgetsLocalizations {
 
 class OnlyRTLDefaultWidgetsLocalizationsDelegate extends LocalizationsDelegate<WidgetsLocalizations> {
   const OnlyRTLDefaultWidgetsLocalizationsDelegate();
+
+  @override
+  bool isSupported(Locale locale) => true;
 
   @override
   Future<WidgetsLocalizations> load(Locale locale) {


### PR DESCRIPTION
Make it easier to add language-specific versions of MaterialLocalizations.

Apps can define their own implementations of MaterialLocalizations that support languages which are not supported by the flutter_localizations package.

When a Flutter app starts or switches locales it will now select the first LocalizationDelegate for each LocalizationDelegate.type that supports the new locale. LocalizationDelegates must override their isSupported(Locale) method.

So to add material library support for a new language an app would define a subclass of MaterialLocalizations, say MyPolishMaterialLocalizations. The new Polish localizations would be loaded by a LocalizationsDelegate defined like this:

```dart
class PolishLocalizationsDelegate extends LocalizationsDelegate<MaterialLocalizations> {
  const PolishLocalizationsDelegate();

  @override
  bool isSupported(Locale locale) => locale.languageCode == 'pl';

  @override
  Future<MaterialLocalizations> load(Locale locale) => MyPolishMaterialLocalizations.load(locale);

  @override
  bool shouldReload(PolishLocalizationsDelegate old) => false;
}
```

A Material app that included the new Polish localizations would be created like this:

```dart
new MaterialApp(
  localizationsDelegates: [
    const PolishLocalizationsDelegate(),
    GlobalMaterialLocalizations.delegate,
    GlobalWidgetsLocalizations.delegate,
  ],
  supportedLocales: [
    const Locale('pl', 'PL'),
    // .. the other supported locales here
  ]
)
```
