### PR TITLE
Add Material character counter to TextField.

### DIFF
--- a/packages/flutter/lib/src/material/input_decorator.dart
+++ b/packages/flutter/lib/src/material/input_decorator.dart
@@ -195,8 +195,8 @@ class InputDecoration {
 
   /// Optional text to place below the line as a character count.
   ///
-  /// Uses the [counterStyle]. Uses [helperStyle] if [counterStyle] isn't
-  /// specified. Suffix is not returned as part of the input.
+  /// Rendered using [counterStyle]. Uses [helperStyle] if [counterStyle] is
+  /// null.
   final String counterText;
 
   /// The style to use for the [counterText].
@@ -579,7 +579,7 @@ class InputDecorator extends StatelessWidget {
     }
 
     if (errorText != null || helperText != null || counterText != null) {
-      assert(!isCollapsed);  // Collapsed fields can't have any of these set.
+      assert(!isCollapsed, "Collapsed fields can't have errorText, helperText, or counterText set.");
       final EdgeInsets topPadding = new EdgeInsets.only(
         top: _kBottomBorderHeight + (isDense ? _kDensePadding : _kNormalPadding)
       );

--- a/packages/flutter/lib/src/material/input_decorator.dart
+++ b/packages/flutter/lib/src/material/input_decorator.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:math' as math;
-
 import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 

--- a/packages/flutter/lib/src/material/input_decorator.dart
+++ b/packages/flutter/lib/src/material/input_decorator.dart
@@ -474,12 +474,11 @@ class InputDecorator extends StatelessWidget {
 
     final TextStyle baseStyle = this.baseStyle ?? themeData.textTheme.subhead;
     final TextStyle hintStyle = decoration.hintStyle ?? baseStyle.copyWith(color: themeData.hintColor);
-    final TextStyle helperStyle =
-      decoration.helperStyle ?? themeData.textTheme.caption.copyWith(color: themeData.hintColor);
+    final TextStyle helperStyle = decoration.helperStyle ?? themeData.textTheme.caption.copyWith(color: themeData.hintColor);
+    final TextStyle counterStyle = decoration.counterStyle ?? helperStyle;
     final TextStyle subtextStyle = errorText != null
       ? decoration.errorStyle ?? themeData.textTheme.caption.copyWith(color: themeData.errorColor)
       : helperStyle;
-    final TextStyle counterStyle = decoration.counterStyle ?? helperStyle;
 
     final double entryTextHeight = baseStyle.fontSize * textScaleFactor;
 

--- a/packages/flutter/lib/src/material/text_field.dart
+++ b/packages/flutter/lib/src/material/text_field.dart
@@ -186,7 +186,7 @@ class TextField extends StatefulWidget {
   /// null, the value must be greater than zero.
   final int maxLines;
 
-  /// The maximum number of characters to allow in the text field.
+  /// The maximum number of characters (Unicode runes) to allow in the text field.
   ///
   /// If set, a character counter will be displayed below the
   /// field, showing how many characters have been entered and how many are
@@ -204,6 +204,10 @@ class TextField extends StatefulWidget {
   /// If [maxLengthEnforced] is set to false, then more than [maxLength]
   /// characters may be entered, but the error counter and divider will
   /// switch to the [decoration.errorStyle] when the limit is exceeded.
+  ///
+  /// See also:
+  ///  * [LengthLimitingTextInputFormatter] for more information on how it
+  ///    counts characters.
   final int maxLength;
 
   /// If true, prevents the field from allowing more than [maxLength]
@@ -271,8 +275,8 @@ class _TextFieldState extends State<TextField> {
       return widget.decoration;
 
     final InputDecoration effectiveDecoration = widget?.decoration ?? const InputDecoration();
-    final String counterText = '${_effectiveController.value.text.length} / ${widget.maxLength}';
-    if (_effectiveController.value.text.length > widget.maxLength) {
+    final String counterText = '${_effectiveController.value.text.runes.length} / ${widget.maxLength}';
+    if (_effectiveController.value.text.runes.length > widget.maxLength) {
       final ThemeData themeData = Theme.of(context);
       return effectiveDecoration.copyWith(
         errorText: effectiveDecoration.errorText ?? '',

--- a/packages/flutter/lib/src/material/text_field.dart
+++ b/packages/flutter/lib/src/material/text_field.dart
@@ -87,6 +87,11 @@ class TextField extends StatefulWidget {
   ///
   /// The [keyboardType], [textAlign], [autofocus], [obscureText], and
   /// [autocorrect] arguments must not be null.
+  ///
+  /// See also:
+  ///
+  ///  * [maxLength], which discusses the precise meaning of "number of
+  ///    characters" and how it may differ from the intuitive meaning.
   const TextField({
     Key key,
     this.controller,
@@ -186,7 +191,8 @@ class TextField extends StatefulWidget {
   /// null, the value must be greater than zero.
   final int maxLines;
 
-  /// The maximum number of characters (Unicode runes) to allow in the text field.
+  /// The maximum number of characters (Unicode scalar values) to allow in the
+  /// text field.
   ///
   /// If set, a character counter will be displayed below the
   /// field, showing how many characters have been entered and how many are
@@ -205,9 +211,29 @@ class TextField extends StatefulWidget {
   /// characters may be entered, but the error counter and divider will
   /// switch to the [decoration.errorStyle] when the limit is exceeded.
   ///
+  /// The TextField does not currently count Unicode grapheme clusters (i.e.
+  /// characters visible to the user), it counts Unicode scalar values, which
+  /// leaves out a number of useful possible characters (like many emoji and
+  /// composed characters), so this will be inaccurate in the presence of those
+  /// characters. If you expect to encounter these kinds of characters, be
+  /// generous in the maxLength used.
+  ///
+  /// For instance, the character "ö" can be represented as '\u{006F}\u{0308}',
+  /// which is the letter "o" followed by a composed diaeresis "¨", or it can
+  /// be represented as '\u{00F6}', which is the Unicode scalar value "LATIN
+  /// SMALL LETTER O WITH DIAERESIS".  In the first case, the text field will
+  /// count two characters, and the second case will be counted as one
+  /// character, even though the user can see no difference in the input.
+  ///
+  /// Similarly, some emoji are represented by multiple scalar values. The
+  /// Unicode "THUMBS UP SIGN + MEDIUM SKIN TONE MODIFIER", "👍🏽", should be
+  /// counted as a single character, but because it is a combination of two
+  /// Unicode scalar values, '\u{1F44D}\u{1F3FD}', it is counted as two
+  /// characters.
+  ///
   /// See also:
   ///  * [LengthLimitingTextInputFormatter] for more information on how it
-  ///    counts characters.
+  ///    counts characters, and how it may differ from the intuitive meaning.
   final int maxLength;
 
   /// If true, prevents the field from allowing more than [maxLength]
@@ -246,14 +272,7 @@ class TextField extends StatefulWidget {
     description.add(new DiagnosticsProperty<bool>('autocorrect', autocorrect, defaultValue: false));
     description.add(new IntProperty('maxLines', maxLines, defaultValue: 1));
     description.add(new IntProperty('maxLength', maxLength, defaultValue: null));
-    description.add(
-      new FlagProperty(
-        'maxLengthEnforced',
-        value: maxLengthEnforced,
-        ifTrue: 'enforced',
-        ifFalse: 'not enforced',
-      ),
-    );
+    description.add(new FlagProperty('maxLengthEnforced', value: maxLengthEnforced, ifTrue: 'max length enforced'));
   }
 }
 
@@ -282,7 +301,8 @@ class _TextFieldState extends State<TextField> {
         errorText: effectiveDecoration.errorText ?? '',
         counterStyle: effectiveDecoration.errorStyle
           ?? themeData.textTheme.caption.copyWith(color: themeData.errorColor),
-        counterText: counterText);
+        counterText: counterText,
+      );
     }
     return effectiveDecoration.copyWith(counterText: counterText);
   }

--- a/packages/flutter/lib/src/services/text_formatter.dart
+++ b/packages/flutter/lib/src/services/text_formatter.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:math' as math show min;
+
 import 'text_editing.dart';
 import 'text_input.dart';
 
@@ -124,21 +126,34 @@ class BlacklistingTextInputFormatter extends TextInputFormatter {
 ///
 /// Since this formatter only prevents new characters from being added to the text,
 /// it preserves the existing [TextEditingValue.selection].
-class LimitedLengthTextInputFormatter extends TextInputFormatter {
-  /// Creates a formatter that prevents the insertion of more characters than an allowed limit.
+class LengthLimitingTextInputFormatter extends TextInputFormatter {
+  /// Creates a formatter that prevents the insertion of more characters than an allowed
+  /// limit.
   ///
-  /// The [allowedMaxCharacters] must be null or greater than zero.  If it is null, then
-  /// no limit is enforced.
-  LimitedLengthTextInputFormatter(this.allowedMaxCharacters)
-    : assert(allowedMaxCharacters == null || allowedMaxCharacters > 0);
+  /// The [maxLength] must be null or greater than zero.  If it is null, then no limit
+  /// is enforced.
+  LengthLimitingTextInputFormatter(this.maxLength)
+    : assert(maxLength == null || maxLength > 0);
 
   /// A [Pattern] to match and replace incoming [TextEditingValue]s.
-  final int allowedMaxCharacters;
+  final int maxLength;
 
   @override
-  TextEditingValue formatEditUpdate(TextEditingValue oldValue, TextEditingValue newValue) {
-    if (allowedMaxCharacters != null && newValue.text.length > allowedMaxCharacters)
-      return oldValue;
+  TextEditingValue formatEditUpdate(
+    TextEditingValue oldValue, // unused.
+    TextEditingValue newValue,
+  ) {
+    if (maxLength != null && newValue.text.length > maxLength) {
+      final TextSelection newSelection = newValue.selection.copyWith(
+          baseOffset: math.min(newValue.selection.start, maxLength),
+          extentOffset: math.min(newValue.selection.end, maxLength),
+      );
+      return new TextEditingValue(
+        text: newValue.text.substring(0, maxLength),
+        selection: newSelection,
+        composing: TextRange.empty,
+      );
+    }
     return newValue;
   }
 }

--- a/packages/flutter/lib/src/services/text_formatter.dart
+++ b/packages/flutter/lib/src/services/text_formatter.dart
@@ -120,6 +120,29 @@ class BlacklistingTextInputFormatter extends TextInputFormatter {
       = new BlacklistingTextInputFormatter(new RegExp(r'\n'));
 }
 
+/// A [TextInputFormatter] that prevents the insertion of more characters than allowed.
+///
+/// Since this formatter only prevents new characters from being added to the text,
+/// it preserves the existing [TextEditingValue.selection].
+class LimitedLengthTextInputFormatter extends TextInputFormatter {
+  /// Creates a formatter that prevents the insertion of more characters than an allowed limit.
+  ///
+  /// The [allowedMaxCharacters] must be null or greater than zero.  If it is null, then
+  /// no limit is enforced.
+  LimitedLengthTextInputFormatter(this.allowedMaxCharacters)
+    : assert(allowedMaxCharacters == null || allowedMaxCharacters > 0);
+
+  /// A [Pattern] to match and replace incoming [TextEditingValue]s.
+  final int allowedMaxCharacters;
+
+  @override
+  TextEditingValue formatEditUpdate(TextEditingValue oldValue, TextEditingValue newValue) {
+    if (allowedMaxCharacters != null && newValue.text.length > allowedMaxCharacters)
+      return oldValue;
+    return newValue;
+  }
+}
+
 /// A [TextInputFormatter] that allows only the insertion of whitelisted
 /// characters patterns.
 ///

--- a/packages/flutter/lib/src/services/text_formatter.dart
+++ b/packages/flutter/lib/src/services/text_formatter.dart
@@ -127,15 +127,17 @@ class BlacklistingTextInputFormatter extends TextInputFormatter {
 /// Since this formatter only prevents new characters from being added to the text,
 /// it preserves the existing [TextEditingValue.selection].
 class LengthLimitingTextInputFormatter extends TextInputFormatter {
-  /// Creates a formatter that prevents the insertion of more characters than an allowed
-  /// limit.
+  /// Creates a formatter that prevents the insertion of more characters than a limit.
   ///
-  /// The [maxLength] must be null or greater than zero.  If it is null, then no limit
+  /// The [maxLength] must be null or greater than zero. If it is null, then no limit
   /// is enforced.
   LengthLimitingTextInputFormatter(this.maxLength)
     : assert(maxLength == null || maxLength > 0);
 
-  /// A [Pattern] to match and replace incoming [TextEditingValue]s.
+  /// The limit on the number of characters this formatter will allow.
+  ///
+  /// The value must be null or greater than zero. If it is null, then no limit
+  /// is enforced.
   final int maxLength;
 
   @override

--- a/packages/flutter/test/material/input_decorator_test.dart
+++ b/packages/flutter/test/material/input_decorator_test.dart
@@ -87,13 +87,14 @@ void main() {
     expect(tester.element(find.byKey(key)).size, equals(const Size(800.0, 60.0)));
   });
 
-  testWidgets('InputDecorator draws the underline correctly in the right place.', (WidgetTester tester) async {
+  testWidgets('InputDecorator draws the divider correctly in the right place.', (WidgetTester tester) async {
     await tester.pumpWidget(
       buildInputDecorator(
         decoration: const InputDecoration(
           hintText: 'Hint',
           labelText: 'Label',
           helperText: 'Helper',
+          counterText: 'Counter',
         ),
       ),
     );
@@ -103,13 +104,14 @@ void main() {
     expect(getDividerWidth(tester), equals(800.0));
   });
 
-  testWidgets('InputDecorator draws the underline correctly in the right place for dense layout.', (WidgetTester tester) async {
+  testWidgets('InputDecorator draws the divider correctly in the right place for dense layout.', (WidgetTester tester) async {
     await tester.pumpWidget(
       buildInputDecorator(
         decoration: const InputDecoration(
           hintText: 'Hint',
           labelText: 'Label',
           helperText: 'Helper',
+          counterText: 'Counter',
           isDense: true,
         ),
       ),
@@ -127,6 +129,7 @@ void main() {
           hintText: 'Hint',
           labelText: 'Label',
           helperText: 'Helper',
+          counterText: 'Counter',
           hideDivider: true,
         ),
       ),
@@ -142,6 +145,7 @@ void main() {
           hintText: 'Hint',
           labelText: 'Label',
           helperText: 'Helper',
+          counterText: 'Counter',
           isDense: true,
         ),
       ),
@@ -157,9 +161,18 @@ void main() {
     expect(tester.getRect(find.text('Hint')).size, equals(const Size(800.0, 16.0)));
     expect(tester.getRect(find.text('Hint')).left, equals(0.0));
     expect(tester.getRect(find.text('Hint')).top, equals(294.5));
-    expect(tester.getRect(find.text('Helper')).size, equals(const Size(800.0, 12.0)));
+    expect(
+      tester.getRect(find.text('Helper')).size,
+      anyOf(<Size>[const Size(716.0, 12.0), const Size(715.0, 12.0)]),
+    );
     expect(tester.getRect(find.text('Helper')).left, equals(0.0));
     expect(tester.getRect(find.text('Helper')).top, equals(317.5));
+    expect(
+      tester.getRect(find.text('Counter')).size,
+      anyOf(<Size>[const Size(84.0, 12.0), const Size(85.0, 12.0)]),
+    );
+    expect(tester.getRect(find.text('Counter')).left, anyOf(716.0, 715.0));
+    expect(tester.getRect(find.text('Counter')).top, equals(317.5));
   });
 
   testWidgets('InputDecorator uses proper padding', (WidgetTester tester) async {
@@ -169,6 +182,7 @@ void main() {
           hintText: 'Hint',
           labelText: 'Label',
           helperText: 'Helper',
+          counterText: 'Counter',
         ),
       ),
     );
@@ -183,9 +197,15 @@ void main() {
     expect(tester.getRect(find.text('Hint')).size, equals(const Size(800.0, 16.0)));
     expect(tester.getRect(find.text('Hint')).left, equals(0.0));
     expect(tester.getRect(find.text('Hint')).top, equals(298.5));
-    expect(tester.getRect(find.text('Helper')).size, equals(const Size(800.0, 12.0)));
+    expect(
+      tester.getRect(find.text('Helper')).size,
+      anyOf(<Size>[const Size(715.0, 12.0), const Size(716.0, 12.0)]),
+    );
     expect(tester.getRect(find.text('Helper')).left, equals(0.0));
     expect(tester.getRect(find.text('Helper')).top, equals(325.5));
+    expect(tester.getRect(find.text('Counter')).size, equals(const Size(84.0, 12.0)));
+    expect(tester.getRect(find.text('Counter')).left, equals(716.0));
+    expect(tester.getRect(find.text('Counter')).top, equals(325.5));
   });
 
   testWidgets('InputDecorator uses proper padding when error is set', (WidgetTester tester) async {
@@ -196,6 +216,7 @@ void main() {
           labelText: 'Label',
           helperText: 'Helper',
           errorText: 'Error',
+          counterText: 'Counter',
         ),
       ),
     );
@@ -210,9 +231,12 @@ void main() {
     expect(tester.getRect(find.text('Hint')).size, equals(const Size(800.0, 16.0)));
     expect(tester.getRect(find.text('Hint')).left, equals(0.0));
     expect(tester.getRect(find.text('Hint')).top, equals(298.5));
-    expect(tester.getRect(find.text('Error')).size, equals(const Size(800.0, 12.0)));
+    expect(tester.getRect(find.text('Error')).size, equals(const Size(716.0, 12.0)));
     expect(tester.getRect(find.text('Error')).left, equals(0.0));
     expect(tester.getRect(find.text('Error')).top, equals(325.5));
+    expect(tester.getRect(find.text('Counter')).size, equals(const Size(84.0, 12.0)));
+    expect(tester.getRect(find.text('Counter')).left, equals(716.0));
+    expect(tester.getRect(find.text('Counter')).top, equals(325.5));
   });
 
   testWidgets('InputDecorator animates properly', (WidgetTester tester) async {
@@ -228,6 +252,7 @@ void main() {
                 hintText: 'Hint',
                 labelText: 'Label',
                 helperText: 'Helper',
+                counterText: 'Counter',
               ),
             ),
           ),
@@ -245,9 +270,12 @@ void main() {
     expect(tester.getRect(find.text('Hint')).size, equals(const Size(800.0, 16.0)));
     expect(tester.getRect(find.text('Hint')).left, equals(0.0));
     expect(tester.getRect(find.text('Hint')).top, equals(295.5));
-    expect(tester.getRect(find.text('Helper')).size, equals(const Size(800.0, 12.0)));
+    expect(tester.getRect(find.text('Helper')).size, equals(const Size(716.0, 12.0)));
     expect(tester.getRect(find.text('Helper')).left, equals(0.0));
     expect(tester.getRect(find.text('Helper')).top, equals(328.5));
+    expect(tester.getRect(find.text('Counter')).size, equals(const Size(84.0, 12.0)));
+    expect(tester.getRect(find.text('Counter')).left, equals(716.0));
+    expect(tester.getRect(find.text('Counter')).top, equals(328.5));
     expect(find.text('P'), findsNothing);
     expect(find.text('S'), findsNothing);
 
@@ -263,9 +291,12 @@ void main() {
     expect(tester.getRect(find.text('Hint')).size, equals(const Size(800.0, 16.0)));
     expect(tester.getRect(find.text('Hint')).left, equals(0.0));
     expect(tester.getRect(find.text('Hint')).top, equals(295.5));
-    expect(tester.getRect(find.text('Helper')).size, equals(const Size(800.0, 12.0)));
+    expect(tester.getRect(find.text('Helper')).size, equals(const Size(716.0, 12.0)));
     expect(tester.getRect(find.text('Helper')).left, equals(0.0));
     expect(tester.getRect(find.text('Helper')).top, equals(328.5));
+    expect(tester.getRect(find.text('Counter')).size, equals(const Size(84.0, 12.0)));
+    expect(tester.getRect(find.text('Counter')).left, equals(716.0));
+    expect(tester.getRect(find.text('Counter')).top, equals(328.5));
     expect(find.text('P'), findsNothing);
     expect(find.text('S'), findsNothing);
 
@@ -280,9 +311,12 @@ void main() {
     expect(tester.getRect(find.text('Hint')).size, equals(const Size(800.0, 16.0)));
     expect(tester.getRect(find.text('Hint')).left, equals(0.0));
     expect(tester.getRect(find.text('Hint')).top, equals(295.5));
-    expect(tester.getRect(find.text('Helper')).size, equals(const Size(800.0, 12.0)));
+    expect(tester.getRect(find.text('Helper')).size, equals(const Size(716.0, 12.0)));
     expect(tester.getRect(find.text('Helper')).left, equals(0.0));
     expect(tester.getRect(find.text('Helper')).top, equals(328.5));
+    expect(tester.getRect(find.text('Counter')).size, equals(const Size(84.0, 12.0)));
+    expect(tester.getRect(find.text('Counter')).left, equals(716.0));
+    expect(tester.getRect(find.text('Counter')).top, equals(328.5));
     expect(find.text('P'), findsNothing);
     expect(find.text('S'), findsNothing);
 
@@ -298,9 +332,12 @@ void main() {
     expect(tester.getRect(find.text('Hint')).size, equals(const Size(800.0, 16.0)));
     expect(tester.getRect(find.text('Hint')).left, equals(0.0));
     expect(tester.getRect(find.text('Hint')).top, equals(295.5));
-    expect(tester.getRect(find.text('Helper')).size, equals(const Size(800.0, 12.0)));
+    expect(tester.getRect(find.text('Helper')).size, equals(const Size(716.0, 12.0)));
     expect(tester.getRect(find.text('Helper')).left, equals(0.0));
     expect(tester.getRect(find.text('Helper')).top, equals(328.5));
+    expect(tester.getRect(find.text('Counter')).size, equals(const Size(84.0, 12.0)));
+    expect(tester.getRect(find.text('Counter')).left, equals(716.0));
+    expect(tester.getRect(find.text('Counter')).top, equals(328.5));
     expect(
       tester.getRect(find.text('P')).size,
       anyOf(<Size>[const Size(17.0, 16.0), const Size(16.0, 16.0)]),
@@ -325,9 +362,12 @@ void main() {
     expect(tester.getRect(find.text('Hint')).size, equals(const Size(800.0, 16.0)));
     expect(tester.getRect(find.text('Hint')).left, equals(0.0));
     expect(tester.getRect(find.text('Hint')).top, equals(295.5));
-    expect(tester.getRect(find.text('Helper')).size, equals(const Size(800.0, 12.0)));
+    expect(tester.getRect(find.text('Helper')).size, equals(const Size(716.0, 12.0)));
     expect(tester.getRect(find.text('Helper')).left, equals(0.0));
     expect(tester.getRect(find.text('Helper')).top, equals(328.5));
+    expect(tester.getRect(find.text('Counter')).size, equals(const Size(84.0, 12.0)));
+    expect(tester.getRect(find.text('Counter')).left, equals(716.0));
+    expect(tester.getRect(find.text('Counter')).top, equals(328.5));
     expect(
       tester.getRect(find.text('P')).size,
       anyOf(<Size>[const Size(17.0, 16.0), const Size(16.0, 16.0)]),

--- a/packages/flutter/test/material/input_decorator_test.dart
+++ b/packages/flutter/test/material/input_decorator_test.dart
@@ -203,8 +203,11 @@ void main() {
     );
     expect(tester.getRect(find.text('Helper')).left, equals(0.0));
     expect(tester.getRect(find.text('Helper')).top, equals(325.5));
-    expect(tester.getRect(find.text('Counter')).size, equals(const Size(84.0, 12.0)));
-    expect(tester.getRect(find.text('Counter')).left, equals(716.0));
+    expect(
+      tester.getRect(find.text('Counter')).size,
+      anyOf(<Size>[const Size(84.0, 12.0), const Size(85.0, 12.0)]),
+    );
+    expect(tester.getRect(find.text('Counter')).left, anyOf(715.0, 716.0));
     expect(tester.getRect(find.text('Counter')).top, equals(325.5));
   });
 
@@ -231,11 +234,17 @@ void main() {
     expect(tester.getRect(find.text('Hint')).size, equals(const Size(800.0, 16.0)));
     expect(tester.getRect(find.text('Hint')).left, equals(0.0));
     expect(tester.getRect(find.text('Hint')).top, equals(298.5));
-    expect(tester.getRect(find.text('Error')).size, equals(const Size(716.0, 12.0)));
+    expect(
+      tester.getRect(find.text('Error')).size,
+      anyOf(<Size>[const Size(715.0, 12.0), const Size(716.0, 12.0)]),
+    );
     expect(tester.getRect(find.text('Error')).left, equals(0.0));
     expect(tester.getRect(find.text('Error')).top, equals(325.5));
-    expect(tester.getRect(find.text('Counter')).size, equals(const Size(84.0, 12.0)));
-    expect(tester.getRect(find.text('Counter')).left, equals(716.0));
+    expect(
+      tester.getRect(find.text('Counter')).size,
+      anyOf(<Size>[const Size(84.0, 12.0), const Size(85.0, 12.0)]),
+    );
+    expect(tester.getRect(find.text('Counter')).left, anyOf(715.0, 716.0));
     expect(tester.getRect(find.text('Counter')).top, equals(325.5));
   });
 
@@ -270,11 +279,17 @@ void main() {
     expect(tester.getRect(find.text('Hint')).size, equals(const Size(800.0, 16.0)));
     expect(tester.getRect(find.text('Hint')).left, equals(0.0));
     expect(tester.getRect(find.text('Hint')).top, equals(295.5));
-    expect(tester.getRect(find.text('Helper')).size, equals(const Size(716.0, 12.0)));
+    expect(
+      tester.getRect(find.text('Helper')).size,
+      anyOf(<Size>[const Size(715.0, 12.0), const Size(716.0, 12.0)]),
+    );
     expect(tester.getRect(find.text('Helper')).left, equals(0.0));
     expect(tester.getRect(find.text('Helper')).top, equals(328.5));
-    expect(tester.getRect(find.text('Counter')).size, equals(const Size(84.0, 12.0)));
-    expect(tester.getRect(find.text('Counter')).left, equals(716.0));
+    expect(
+      tester.getRect(find.text('Counter')).size,
+      anyOf(<Size>[const Size(84.0, 12.0), const Size(85.0, 12.0)]),
+    );
+    expect(tester.getRect(find.text('Counter')).left, anyOf(715.0, 716.0));
     expect(tester.getRect(find.text('Counter')).top, equals(328.5));
     expect(find.text('P'), findsNothing);
     expect(find.text('S'), findsNothing);
@@ -291,11 +306,17 @@ void main() {
     expect(tester.getRect(find.text('Hint')).size, equals(const Size(800.0, 16.0)));
     expect(tester.getRect(find.text('Hint')).left, equals(0.0));
     expect(tester.getRect(find.text('Hint')).top, equals(295.5));
-    expect(tester.getRect(find.text('Helper')).size, equals(const Size(716.0, 12.0)));
+    expect(
+      tester.getRect(find.text('Helper')).size,
+      anyOf(<Size>[const Size(715.0, 12.0), const Size(716.0, 12.0)]),
+    );
     expect(tester.getRect(find.text('Helper')).left, equals(0.0));
     expect(tester.getRect(find.text('Helper')).top, equals(328.5));
-    expect(tester.getRect(find.text('Counter')).size, equals(const Size(84.0, 12.0)));
-    expect(tester.getRect(find.text('Counter')).left, equals(716.0));
+    expect(
+      tester.getRect(find.text('Counter')).size,
+      anyOf(<Size>[const Size(84.0, 12.0), const Size(85.0, 12.0)]),
+    );
+    expect(tester.getRect(find.text('Counter')).left, anyOf(715.0, 716.0));
     expect(tester.getRect(find.text('Counter')).top, equals(328.5));
     expect(find.text('P'), findsNothing);
     expect(find.text('S'), findsNothing);
@@ -311,11 +332,17 @@ void main() {
     expect(tester.getRect(find.text('Hint')).size, equals(const Size(800.0, 16.0)));
     expect(tester.getRect(find.text('Hint')).left, equals(0.0));
     expect(tester.getRect(find.text('Hint')).top, equals(295.5));
-    expect(tester.getRect(find.text('Helper')).size, equals(const Size(716.0, 12.0)));
+    expect(
+      tester.getRect(find.text('Helper')).size,
+      anyOf(<Size>[const Size(715.0, 12.0), const Size(716.0, 12.0)]),
+    );
     expect(tester.getRect(find.text('Helper')).left, equals(0.0));
     expect(tester.getRect(find.text('Helper')).top, equals(328.5));
-    expect(tester.getRect(find.text('Counter')).size, equals(const Size(84.0, 12.0)));
-    expect(tester.getRect(find.text('Counter')).left, equals(716.0));
+    expect(
+      tester.getRect(find.text('Counter')).size,
+      anyOf(<Size>[const Size(84.0, 12.0), const Size(85.0, 12.0)]),
+    );
+    expect(tester.getRect(find.text('Counter')).left, anyOf(715.0, 716.0));
     expect(tester.getRect(find.text('Counter')).top, equals(328.5));
     expect(find.text('P'), findsNothing);
     expect(find.text('S'), findsNothing);
@@ -332,11 +359,17 @@ void main() {
     expect(tester.getRect(find.text('Hint')).size, equals(const Size(800.0, 16.0)));
     expect(tester.getRect(find.text('Hint')).left, equals(0.0));
     expect(tester.getRect(find.text('Hint')).top, equals(295.5));
-    expect(tester.getRect(find.text('Helper')).size, equals(const Size(716.0, 12.0)));
+    expect(
+      tester.getRect(find.text('Helper')).size,
+      anyOf(<Size>[const Size(715.0, 12.0), const Size(716.0, 12.0)]),
+    );
     expect(tester.getRect(find.text('Helper')).left, equals(0.0));
     expect(tester.getRect(find.text('Helper')).top, equals(328.5));
-    expect(tester.getRect(find.text('Counter')).size, equals(const Size(84.0, 12.0)));
-    expect(tester.getRect(find.text('Counter')).left, equals(716.0));
+    expect(
+      tester.getRect(find.text('Counter')).size,
+      anyOf(<Size>[const Size(84.0, 12.0), const Size(85.0, 12.0)]),
+    );
+    expect(tester.getRect(find.text('Counter')).left, anyOf(715.0, 716.0));
     expect(tester.getRect(find.text('Counter')).top, equals(328.5));
     expect(
       tester.getRect(find.text('P')).size,
@@ -362,11 +395,17 @@ void main() {
     expect(tester.getRect(find.text('Hint')).size, equals(const Size(800.0, 16.0)));
     expect(tester.getRect(find.text('Hint')).left, equals(0.0));
     expect(tester.getRect(find.text('Hint')).top, equals(295.5));
-    expect(tester.getRect(find.text('Helper')).size, equals(const Size(716.0, 12.0)));
+    expect(
+      tester.getRect(find.text('Helper')).size,
+      anyOf(<Size>[const Size(715.0, 12.0), const Size(716.0, 12.0)]),
+    );
     expect(tester.getRect(find.text('Helper')).left, equals(0.0));
     expect(tester.getRect(find.text('Helper')).top, equals(328.5));
-    expect(tester.getRect(find.text('Counter')).size, equals(const Size(84.0, 12.0)));
-    expect(tester.getRect(find.text('Counter')).left, equals(716.0));
+    expect(
+      tester.getRect(find.text('Counter')).size,
+      anyOf(<Size>[const Size(84.0, 12.0), const Size(85.0, 12.0)]),
+    );
+    expect(tester.getRect(find.text('Counter')).left, anyOf(715.0, 716.0));
     expect(tester.getRect(find.text('Counter')).top, equals(328.5));
     expect(
       tester.getRect(find.text('P')).size,

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -1604,8 +1604,16 @@ void main() {
 
     expect(textController.text, '0123456789101112');
     expect(find.text('16 / 10'), findsOneWidget);
-    final Text counterTextWidget = tester.widget(find.text('16 / 10'));
+    Text counterTextWidget = tester.widget(find.text('16 / 10'));
     expect(counterTextWidget.style.color, equals(Colors.deepPurpleAccent));
+
+    await tester.enterText(find.byType(TextField), '0123456789');
+    await tester.pump();
+
+    expect(textController.text, '0123456789');
+    expect(find.text('10 / 10'), findsOneWidget);
+    counterTextWidget = tester.widget(find.text('10 / 10'));
+    expect(counterTextWidget.style.color, isNot(equals(Colors.deepPurpleAccent)));
   });
 
   testWidgets('setting maxLength shows counter', (WidgetTester tester) async {

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -1520,4 +1520,76 @@ void main() {
       controller.selection = const TextSelection.collapsed(offset: 10);
     }, throwsFlutterError);
   });
+
+  testWidgets('maxLength limits input.', (WidgetTester tester) async {
+    final TextEditingController textController = new TextEditingController();
+
+    await tester.pumpWidget(boilerplate(
+      child: new TextField(
+        controller: textController,
+        maxLength: 10,
+      ),
+    ));
+
+    await tester.enterText(find.byType(TextField), '0123456789101112');
+    expect(textController.text, '0123456789');
+  });
+
+  testWidgets('maxLength limits input length even if decoration is null.', (WidgetTester tester) async {
+    final TextEditingController textController = new TextEditingController();
+
+    await tester.pumpWidget(boilerplate(
+      child: new TextField(
+        controller: textController,
+        decoration: null,
+        maxLength: 10,
+      ),
+    ));
+
+    await tester.enterText(find.byType(TextField), '0123456789101112');
+    expect(textController.text, '0123456789');
+  });
+
+  testWidgets('maxLength still works with other formatters.', (WidgetTester tester) async {
+    final TextEditingController textController = new TextEditingController();
+
+    await tester.pumpWidget(boilerplate(
+      child: new TextField(
+        controller: textController,
+        maxLength: 10,
+        inputFormatters: <TextInputFormatter> [
+          new BlacklistingTextInputFormatter(
+            new RegExp(r'[a-z]'),
+            replacementString: '#',
+          ),
+        ],
+      ),
+    ));
+
+    await tester.enterText(find.byType(TextField), 'a一b二c三\nd四e五f六');
+    // The default single line formatter replaces \n with empty string.
+    expect(textController.text, '#一#二#三#四#五');
+  });
+
+  testWidgets('setting maxLength shows counter', (WidgetTester tester) async {
+    await tester.pumpWidget(new MaterialApp(
+      home: const Material(
+        child: const DefaultTextStyle(
+          style: const TextStyle(fontFamily: 'Ahem', fontSize: 10.0),
+          child: const Center(
+            child: const TextField(
+              maxLength: 10,
+            ),
+          ),
+        ),
+      ),
+    ));
+
+    expect(find.text('0 / 10'), findsOneWidget);
+
+    await tester.enterText(find.byType(TextField), '01234');
+    await tester.pump();
+
+    expect(find.text('5 / 10'), findsOneWidget);
+  });
 }

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -1571,6 +1571,39 @@ void main() {
     expect(textController.text, '#一#二#三#四#五');
   });
 
+  testWidgets("maxLength isn't enforced when maxLengthEnforced is false.", (WidgetTester tester) async {
+    final TextEditingController textController = new TextEditingController();
+
+    await tester.pumpWidget(boilerplate(
+      child: new TextField(
+        controller: textController,
+        maxLength: 10,
+        maxLengthEnforced: false,
+      ),
+    ));
+
+    await tester.enterText(find.byType(TextField), '0123456789101112');
+    expect(textController.text, '0123456789101112');
+  });
+
+  testWidgets("maxLength shows warning when maxLengthEnforced is false.", (WidgetTester tester) async {
+    final TextEditingController textController = new TextEditingController();
+
+    await tester.pumpWidget(boilerplate(
+      child: new TextField(
+        controller: textController,
+        maxLength: 10,
+        maxLengthEnforced: false,
+      ),
+    ));
+
+    await tester.enterText(find.byType(TextField), '0123456789101112');
+    await tester.pump();
+
+    expect(textController.text, '0123456789101112');
+    expect(find.text('16 / 10'), findsOneWidget);
+  });
+
   testWidgets('setting maxLength shows counter', (WidgetTester tester) async {
     await tester.pumpWidget(new MaterialApp(
       home: const Material(

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -1586,7 +1586,7 @@ void main() {
     expect(textController.text, '0123456789101112');
   });
 
-  testWidgets("maxLength shows warning when maxLengthEnforced is false.", (WidgetTester tester) async {
+  testWidgets('maxLength shows warning when maxLengthEnforced is false.', (WidgetTester tester) async {
     final TextEditingController textController = new TextEditingController();
     final TextStyle testStyle = const TextStyle(color: Colors.deepPurpleAccent);
 

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -1588,9 +1588,11 @@ void main() {
 
   testWidgets("maxLength shows warning when maxLengthEnforced is false.", (WidgetTester tester) async {
     final TextEditingController textController = new TextEditingController();
+    final TextStyle testStyle = const TextStyle(color: Colors.deepPurpleAccent);
 
     await tester.pumpWidget(boilerplate(
       child: new TextField(
+        decoration: new InputDecoration(errorStyle: testStyle),
         controller: textController,
         maxLength: 10,
         maxLengthEnforced: false,
@@ -1602,6 +1604,8 @@ void main() {
 
     expect(textController.text, '0123456789101112');
     expect(find.text('16 / 10'), findsOneWidget);
+    final Text counterTextWidget = tester.widget(find.text('16 / 10'));
+    expect(counterTextWidget.style.color, equals(Colors.deepPurpleAccent));
   });
 
   testWidgets('setting maxLength shows counter', (WidgetTester tester) async {

--- a/packages/flutter/test/widgets/text_formatter_test.dart
+++ b/packages/flutter/test/widgets/text_formatter_test.dart
@@ -125,6 +125,109 @@ void main() {
       ));
     });
 
+    test('test length limiting formatter with zero-length string', () {
+      testNewValue = const TextEditingValue(
+        text: '',
+        selection: const TextSelection(
+          baseOffset: 0,
+          extentOffset: 0,
+        ),
+      );
+
+      final TextEditingValue actualValue =
+      new LengthLimitingTextInputFormatter(1)
+        .formatEditUpdate(testOldValue, testNewValue);
+
+      // Expecting the empty string.
+      expect(actualValue, const TextEditingValue(
+        text: '',
+        selection: const TextSelection(
+          baseOffset: 0,
+          extentOffset: 0,
+        ),
+      ));
+    });
+
+    test('test length limiting formatter with non-ASCII runes', () {
+      testNewValue = const TextEditingValue(
+        text: '\u{1f984}\u{1f984}\u{1f984}\u{1f984}', // Unicode U+1f984 (UNICORN FACE)
+        selection: const TextSelection(
+          baseOffset: 4,
+          extentOffset: 4,
+        ),
+      );
+
+      final TextEditingValue actualValue =
+      new LengthLimitingTextInputFormatter(2)
+        .formatEditUpdate(testOldValue, testNewValue);
+
+      // Expecting two runes.
+      expect(actualValue, const TextEditingValue(
+        text: '\u{1f984}\u{1f984}',
+        selection: const TextSelection(
+          baseOffset: 2,
+          extentOffset: 2,
+        ),
+      ));
+    });
+
+
+    test('test length limiting formatter with complex Unicode characters', () {
+      // TODO(gspencer): Test additional strings.  We can do this once the
+      // formatter supports Unicode grapheme clusters.
+      // The following should all be treated as single characters:
+      //  - \u{0058}\u{0346}\u{0361}\u{035E}\u{032A}\u{031C}\u{0333}\u{0326}\u{031D}\u{0332}
+      //  - \u{1F3F3}\u{FE0F}\u{200D}\u{1F308}
+      testNewValue = const TextEditingValue(
+        text: '\u{0000}\u{FEFF}',
+        selection: const TextSelection(
+          baseOffset: 1,
+          extentOffset: 1,
+        ),
+      );
+      TextEditingValue actualValue = new LengthLimitingTextInputFormatter(1).formatEditUpdate(testOldValue, testNewValue);
+      expect(actualValue, const TextEditingValue(
+        text: '\u{0000}',
+        selection: const TextSelection(
+          baseOffset: 1,
+          extentOffset: 1,
+        ),
+      ));
+
+      testNewValue = const TextEditingValue(
+        text: '\u{1F984}\u{0020}',
+        selection: const TextSelection(
+          baseOffset: 1,
+          extentOffset: 1,
+        ),
+      );
+      actualValue = new LengthLimitingTextInputFormatter(1).formatEditUpdate(testOldValue, testNewValue);
+      expect(actualValue, const TextEditingValue(
+        text: '\u{1F984}',
+        selection: const TextSelection(
+          baseOffset: 1,
+          extentOffset: 1,
+        ),
+      ));
+
+      testNewValue = const TextEditingValue(
+        text: '\u{0058}\u{0059}',
+        selection: const TextSelection(
+          baseOffset: 1,
+          extentOffset: 1,
+        ),
+      );
+      actualValue = new LengthLimitingTextInputFormatter(1).formatEditUpdate(testOldValue, testNewValue);
+      expect(actualValue, const TextEditingValue(
+        text: '\u{0058}',
+        selection: const TextSelection(
+          baseOffset: 1,
+          extentOffset: 1,
+        ),
+      ));
+    });
+
+
     test('test length limiting formatter when selection is off the end', () {
       final TextEditingValue actualValue =
       new LengthLimitingTextInputFormatter(2)

--- a/packages/flutter/test/widgets/text_formatter_test.dart
+++ b/packages/flutter/test/widgets/text_formatter_test.dart
@@ -33,7 +33,7 @@ void main() {
   group('test provided formatters', () {
     setUp(() {
       // a1b(2c3
-      // d4)e5f6 
+      // d4)e5f6
       // where the parentheses are the selection range.
       testNewValue = const TextEditingValue(
         text: 'a1b2c3\nd4e5f6',
@@ -51,7 +51,7 @@ void main() {
 
       // Expecting
       // 1(23
-      // 4)56 
+      // 4)56
       expect(actualValue, const TextEditingValue(
         text: '123\n456',
         selection: const TextSelection(
@@ -67,7 +67,7 @@ void main() {
               .formatEditUpdate(testOldValue, testNewValue);
 
       // Expecting
-      // a1b(2c3d4)e5f6 
+      // a1b(2c3d4)e5f6
       expect(actualValue, const TextEditingValue(
         text: 'a1b2c3d4e5f6',
         selection: const TextSelection(
@@ -99,7 +99,7 @@ void main() {
               .formatEditUpdate(testOldValue, testNewValue);
 
       // Expecting
-      // 1(234)56 
+      // 1(234)56
       expect(actualValue, const TextEditingValue(
         text: '123456',
         selection: const TextSelection(
@@ -108,5 +108,38 @@ void main() {
         ),
       ));
     });
+
+    test('test length limiting formatter', () {
+      final TextEditingValue actualValue =
+      new LengthLimitingTextInputFormatter(6)
+          .formatEditUpdate(testOldValue, testNewValue);
+
+      // Expecting
+      // a1b(2c3)
+      expect(actualValue, const TextEditingValue(
+        text: 'a1b2c3',
+        selection: const TextSelection(
+          baseOffset: 3,
+          extentOffset: 6,
+        ),
+      ));
+    });
+
+    test('test length limiting formatter when selection is off the end', () {
+      final TextEditingValue actualValue =
+      new LengthLimitingTextInputFormatter(2)
+          .formatEditUpdate(testOldValue, testNewValue);
+
+      // Expecting
+      // a1()
+      expect(actualValue, const TextEditingValue(
+        text: 'a1',
+        selection: const TextSelection(
+          baseOffset: 2,
+          extentOffset: 2,
+        ),
+      ));
+    });
+
   });
 }


### PR DESCRIPTION
This adds an optional character counter and `maxLength` parameter to the `TextField`, as described in the [Material Design Spec](https://material.io/guidelines/components/text-fields.html#text-fields-layout).

The counter text and style in the input decorator may be specified, but will default to the "right thing" if not specified, where the "right thing" is a counter that looks like "3 / 10" (if there are three characters entered into a field where maxLength is set to 10).

To limit the number of characters entered, I created a LengthLimitingTextFormatter that will limit the number of characters (Unicode runes) in the input, which can be used independently.  The formatter is applied after the other formatters supplied (if any). Even if there is no decorator, the text field will limit the number of characters input if maxLength is set.

If maxLengthEnforced is set to false (it defaults to true), then the max length will not be enforced. In that case, if the text exceeds the length, then the counter will turn red, and it will make the divider turn red.