### PR TITLE
tweak the flutter create template to use the function shorthand for main()

### DIFF
--- a/packages/flutter_tools/templates/create/lib/main.dart.tmpl
+++ b/packages/flutter_tools/templates/create/lib/main.dart.tmpl
@@ -7,14 +7,17 @@ import 'package:flutter/services.dart';
 import 'package:{{pluginProjectName}}/{{pluginProjectName}}.dart';
 {{/withPluginHook}}
 
-void main() {
+{{^withDriverTest}}
+void main() => runApp(new MyApp());
+{{/withDriverTest}}
 {{#withDriverTest}}
+void main() {
   // Enable integration testing with the Flutter Driver extension.
   // See https://flutter.io/testing/ for more info.
   enableFlutterDriverExtension();
-{{/withDriverTest}}
   runApp(new MyApp());
 }
+{{/withDriverTest}}
 
 {{^withPluginHook}}
 class MyApp extends StatelessWidget {


### PR DESCRIPTION
- tweak the flutter create template to use `=>` in the main method (some context here: https://github.com/flutter/flutter/issues/12095)

@Hixie @sethladd 

Without a driver test, it's now:

```dart
void main() => runApp(new MyApp());
```
