### PR TITLE
Revert "nav bar font styles are special, do not inherit (#12578)"

### DIFF
--- a/packages/flutter/lib/src/cupertino/nav_bar.dart
+++ b/packages/flutter/lib/src/cupertino/nav_bar.dart
@@ -330,19 +330,19 @@ class _CupertinoPersistentNavigationBar extends StatelessWidget implements Prefe
       color: actionsForegroundColor,
     );
 
-    final Widget styledLeading = leading == null ? null : new DefaultTextStyle(
+    final Widget styledLeading = leading == null ? null : DefaultTextStyle.merge(
       style: actionsStyle,
       child: leading,
     );
 
-    final Widget styledTrailing = trailing == null ? null : new DefaultTextStyle(
+    final Widget styledTrailing = trailing == null ? null : DefaultTextStyle.merge(
       style: actionsStyle,
       child: trailing,
     );
 
     // Let the middle be black rather than `actionsForegroundColor` in case
     // it's a plain text title.
-    final Widget styledMiddle = middle == null ? null : new DefaultTextStyle(
+    final Widget styledMiddle = middle == null ? null : DefaultTextStyle.merge(
       style: actionsStyle.copyWith(
         fontWeight: FontWeight.w600,
         letterSpacing: -0.72,


### PR DESCRIPTION
This reverts commit 964a138d80e4b0778bdb31f0d0c4d3b34d100f84.

It may (or may not) have caused a performance regression. Hard to say.