### PR TITLE
Revert "Fixes InputDecorator to work with textScaleFactor, fixes Material Design differences. (#12595)"

### DIFF
--- a/dev/manual_tests/lib/card_collection.dart
+++ b/dev/manual_tests/lib/card_collection.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:math';
-
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart' show debugDumpRenderTree;
 
@@ -33,11 +31,6 @@ class CardCollectionState extends State<CardCollection> {
 
   static const double kCardMargins = 8.0;
   static const double kFixedCardHeight = 100.0;
-  static const List<double> _cardHeights = const <double>[
-    48.0, 63.0, 85.0, 146.0, 60.0, 55.0, 84.0, 96.0, 50.0,
-    48.0, 63.0, 85.0, 146.0, 60.0, 55.0, 84.0, 96.0, 50.0,
-    48.0, 63.0, 85.0, 146.0, 60.0, 55.0, 84.0, 96.0, 50.0,
-  ];
 
   MaterialColor _primaryColor = Colors.deepPurple;
   List<CardModel> _cardModels;
@@ -48,22 +41,15 @@ class CardCollectionState extends State<CardCollection> {
   bool _sunshine = false;
   bool _varyFontSizes = false;
 
-  void _updateCardSizes() {
-    if (_fixedSizeCards)
-      return;
-    _cardModels = new List<CardModel>.generate(
-      _cardModels.length,
-      (int i) {
-        _cardModels[i].height = _editable ? max(_cardHeights[i], 60.0) : _cardHeights[i];
-        return _cardModels[i];
-      }
-    );
-  }
-
   void _initVariableSizedCardModels() {
+    final List<double> cardHeights = <double>[
+      48.0, 63.0, 82.0, 146.0, 60.0, 55.0, 84.0, 96.0, 50.0,
+      48.0, 63.0, 82.0, 146.0, 60.0, 55.0, 84.0, 96.0, 50.0,
+      48.0, 63.0, 82.0, 146.0, 60.0, 55.0, 84.0, 96.0, 50.0,
+    ];
     _cardModels = new List<CardModel>.generate(
-      _cardHeights.length,
-      (int i) => new CardModel(i, _editable ? max(_cardHeights[i], 60.0) : _cardHeights[i])
+      cardHeights.length,
+      (int i) => new CardModel(i, cardHeights[i])
     );
   }
 
@@ -140,7 +126,6 @@ class CardCollectionState extends State<CardCollection> {
   void _toggleEditable() {
     setState(() {
       _editable = !_editable;
-      _updateCardSizes();
     });
   }
 

--- a/packages/flutter/lib/src/painting/text_painter.dart
+++ b/packages/flutter/lib/src/painting/text_painter.dart
@@ -134,7 +134,6 @@ class TextPainter {
       return;
     _textScaleFactor = value;
     _paragraph = null;
-    _layoutTemplate = null;
     _needsLayout = true;
   }
 

--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -1964,7 +1964,7 @@ abstract class RenderObject extends AbstractNode with DiagnosticableTreeMixin im
     // yet (that is, our layer might not have been detached yet), because the
     // same node that skipped us in layout is above us in the tree (obviously)
     // and therefore may not have had a chance to paint yet (since the tree
-    // paints in reverse order). In particular this will happen if they have
+    // paints in reverse order). In particular this will happen if they are have
     // a different layer, because there's a repaint boundary between us.
     if (_needsLayout)
       return;

--- a/packages/flutter/test/material/input_decorator_test.dart
+++ b/packages/flutter/test/material/input_decorator_test.dart
@@ -2,343 +2,54 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:flutter/material.dart';
-import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter/material.dart';
 
 void main() {
-  Widget buildInputDecorator({InputDecoration decoration = const InputDecoration(), Widget child = const Text('Test')}) {
-    return new MaterialApp(
-      home: new Material(
-        child: new DefaultTextStyle(
-          style: const TextStyle(fontFamily: 'Ahem', fontSize: 10.0),
-          child: new Center(
-            child: new InputDecorator(
-              decoration: decoration,
-              child: child,
-            ),
-          ),
-        ),
-      ),
-    );
-  }
-
-  Finder findInputDecoratorChildContainer() {
-    return find.byWidgetPredicate(
-            (Widget w) {
-          return w is AnimatedContainer && (w as dynamic).decoration != null;
-        });
-  }
-
-  double getBoxDecorationThickness(WidgetTester tester) {
-    final AnimatedContainer container = tester.widget(findInputDecoratorChildContainer());
-    final BoxDecoration decoration = container.decoration;
-    final Border border = decoration.border;
-    return border.bottom.width;
-  }
-
-  double getDividerY(WidgetTester tester) {
-    final Finder animatedContainerFinder = find.byWidgetPredicate(
-            (Widget w) {
-          return w is AnimatedContainer && (w as dynamic).decoration != null;
-        });
-    return tester.getRect(animatedContainerFinder).bottom;
-  }
-
-  double getDividerWidth(WidgetTester tester) {
-    final Finder animatedContainerFinder = find.byWidgetPredicate(
-            (Widget w) {
-          return w is AnimatedContainer && (w as dynamic).decoration != null;
-        });
-    return tester.getRect(animatedContainerFinder).size.width;
-  }
-
   testWidgets('InputDecorator always expands horizontally', (WidgetTester tester) async {
     final Key key = new UniqueKey();
 
-    await tester.pumpWidget(
-      buildInputDecorator(
-        child: new Container(key: key, width: 50.0, height: 60.0, color: Colors.blue),
-      ),
-    );
-
-    expect(tester.element(find.byKey(key)).size, equals(const Size(800.0, 60.0)));
-
-    await tester.pumpWidget(
-      buildInputDecorator(
-        decoration: const InputDecoration(
-          icon: const Icon(Icons.add_shopping_cart),
-        ),
-        child: new Container(key: key, width: 50.0, height: 60.0, color: Colors.blue),
-      ),
-    );
-
-    expect(tester.element(find.byKey(key)).size, equals(const Size(752.0, 60.0)));
-
-    await tester.pumpWidget(
-      buildInputDecorator(
-        decoration: const InputDecoration.collapsed(
-          hintText: 'Hint text',
-        ),
-        child: new Container(key: key, width: 50.0, height: 60.0, color: Colors.blue),
-      ),
-    );
-
-    expect(tester.element(find.byKey(key)).size, equals(const Size(800.0, 60.0)));
-  });
-
-  testWidgets('InputDecorator draws the underline correctly in the right place.', (WidgetTester tester) async {
-    await tester.pumpWidget(
-      buildInputDecorator(
-        decoration: const InputDecoration(
-          hintText: 'Hint',
-          labelText: 'Label',
-          helperText: 'Helper',
-        ),
-      ),
-    );
-
-    expect(getBoxDecorationThickness(tester), equals(1.0));
-    expect(getDividerY(tester), equals(316.5));
-    expect(getDividerWidth(tester), equals(800.0));
-  });
-
-  testWidgets('InputDecorator draws the underline correctly in the right place for dense layout.', (WidgetTester tester) async {
-    await tester.pumpWidget(
-      buildInputDecorator(
-        decoration: const InputDecoration(
-          hintText: 'Hint',
-          labelText: 'Label',
-          helperText: 'Helper',
-          isDense: true,
-        ),
-      ),
-    );
-
-    expect(getBoxDecorationThickness(tester), equals(1.0));
-    expect(getDividerY(tester), equals(312.5));
-    expect(getDividerWidth(tester), equals(800.0));
-  });
-
-  testWidgets('InputDecorator does not draw the underline when hideDivider is true.', (WidgetTester tester) async {
-    await tester.pumpWidget(
-      buildInputDecorator(
-        decoration: const InputDecoration(
-          hintText: 'Hint',
-          labelText: 'Label',
-          helperText: 'Helper',
-          hideDivider: true,
-        ),
-      ),
-    );
-
-    expect(findInputDecoratorChildContainer(), findsNothing);
-  });
-
-  testWidgets('InputDecorator uses proper padding for dense mode', (WidgetTester tester) async {
-    await tester.pumpWidget(
-      buildInputDecorator(
-        decoration: const InputDecoration(
-          hintText: 'Hint',
-          labelText: 'Label',
-          helperText: 'Helper',
-          isDense: true,
-        ),
-      ),
-    );
-
-    // TODO(#12357): Update this test when the font metric bug is fixed to remove the anyOfs.
-    expect(
-      tester.getRect(find.text('Label')).size,
-      anyOf(<Size>[const Size(60.0, 12.0), const Size(61.0, 12.0)]),
-    );
-    expect(tester.getRect(find.text('Label')).left, equals(0.0));
-    expect(tester.getRect(find.text('Label')).top, equals(278.5));
-    expect(tester.getRect(find.text('Hint')).size, equals(const Size(800.0, 16.0)));
-    expect(tester.getRect(find.text('Hint')).left, equals(0.0));
-    expect(tester.getRect(find.text('Hint')).top, equals(294.5));
-    expect(tester.getRect(find.text('Helper')).size, equals(const Size(800.0, 12.0)));
-    expect(tester.getRect(find.text('Helper')).left, equals(0.0));
-    expect(tester.getRect(find.text('Helper')).top, equals(317.5));
-  });
-
-  testWidgets('InputDecorator uses proper padding', (WidgetTester tester) async {
-    await tester.pumpWidget(
-      buildInputDecorator(
-        decoration: const InputDecoration(
-          hintText: 'Hint',
-          labelText: 'Label',
-          helperText: 'Helper',
-        ),
-      ),
-    );
-
-    // TODO(#12357): Update this test when the font metric bug is fixed to remove the anyOfs.
-    expect(
-        tester.getRect(find.text('Label')).size,
-        anyOf(<Size>[const Size(60.0, 12.0), const Size(61.0, 12.0)]),
-    );
-    expect(tester.getRect(find.text('Label')).left, equals(0.0));
-    expect(tester.getRect(find.text('Label')).top, equals(278.5));
-    expect(tester.getRect(find.text('Hint')).size, equals(const Size(800.0, 16.0)));
-    expect(tester.getRect(find.text('Hint')).left, equals(0.0));
-    expect(tester.getRect(find.text('Hint')).top, equals(298.5));
-    expect(tester.getRect(find.text('Helper')).size, equals(const Size(800.0, 12.0)));
-    expect(tester.getRect(find.text('Helper')).left, equals(0.0));
-    expect(tester.getRect(find.text('Helper')).top, equals(325.5));
-  });
-
-  testWidgets('InputDecorator uses proper padding when error is set', (WidgetTester tester) async {
-    await tester.pumpWidget(
-      buildInputDecorator(
-        decoration: const InputDecoration(
-          hintText: 'Hint',
-          labelText: 'Label',
-          helperText: 'Helper',
-          errorText: 'Error',
-        ),
-      ),
-    );
-
-    // TODO(#12357): Update this test when the font metric bug is fixed to remove the anyOfs.
-    expect(
-      tester.getRect(find.text('Label')).size,
-      anyOf(<Size>[const Size(60.0, 12.0), const Size(61.0, 12.0)]),
-    );
-    expect(tester.getRect(find.text('Label')).left, equals(0.0));
-    expect(tester.getRect(find.text('Label')).top, equals(278.5));
-    expect(tester.getRect(find.text('Hint')).size, equals(const Size(800.0, 16.0)));
-    expect(tester.getRect(find.text('Hint')).left, equals(0.0));
-    expect(tester.getRect(find.text('Hint')).top, equals(298.5));
-    expect(tester.getRect(find.text('Error')).size, equals(const Size(800.0, 12.0)));
-    expect(tester.getRect(find.text('Error')).left, equals(0.0));
-    expect(tester.getRect(find.text('Error')).top, equals(325.5));
-  });
-
-  testWidgets('InputDecorator animates properly', (WidgetTester tester) async {
     await tester.pumpWidget(new MaterialApp(
-      home: const Material(
-        child: const DefaultTextStyle(
-          style: const TextStyle(fontFamily: 'Ahem', fontSize: 10.0),
-          child: const Center(
-            child: const TextField(
-              decoration: const InputDecoration(
-                suffixText: 'S',
-                prefixText: 'P',
-                hintText: 'Hint',
-                labelText: 'Label',
-                helperText: 'Helper',
-              ),
-            ),
+      home: new Material(
+        child: new Center(
+          child: new InputDecorator(
+            decoration: const InputDecoration(),
+            child: new Container(key: key, width: 50.0, height: 60.0, color: Colors.blue),
           ),
         ),
       ),
     ));
 
-    // TODO(#12357): Update this test when the font metric bug is fixed to remove the anyOfs.
-    expect(
-      tester.getRect(find.text('Label')).size,
-      anyOf(<Size>[const Size(80.0, 16.0), const Size(81.0, 16.0)]),
-    );
-    expect(tester.getRect(find.text('Label')).left, equals(0.0));
-    expect(tester.getRect(find.text('Label')).top, equals(295.5));
-    expect(tester.getRect(find.text('Hint')).size, equals(const Size(800.0, 16.0)));
-    expect(tester.getRect(find.text('Hint')).left, equals(0.0));
-    expect(tester.getRect(find.text('Hint')).top, equals(295.5));
-    expect(tester.getRect(find.text('Helper')).size, equals(const Size(800.0, 12.0)));
-    expect(tester.getRect(find.text('Helper')).left, equals(0.0));
-    expect(tester.getRect(find.text('Helper')).top, equals(328.5));
-    expect(find.text('P'), findsNothing);
-    expect(find.text('S'), findsNothing);
+    expect(tester.element(find.byKey(key)).size, equals(const Size(800.0, 60.0)));
 
-    await tester.tap(find.byType(TextField));
-    await tester.pump(const Duration(milliseconds: 100));
+    await tester.pumpWidget(new MaterialApp(
+      home: new Material(
+        child: new Center(
+          child: new InputDecorator(
+            decoration: const InputDecoration(
+              icon: const Icon(Icons.add_shopping_cart),
+            ),
+            child: new Container(key: key, width: 50.0, height: 60.0, color: Colors.blue),
+          ),
+        ),
+      ),
+    ));
 
-    expect(
-      tester.getRect(find.text('Label')).size,
-      anyOf(<Size>[const Size(60.0, 12.0), const Size(61.0, 12.0)]),
-    );
-    expect(tester.getRect(find.text('Label')).left, equals(0.0));
-    expect(tester.getRect(find.text('Label')).top, equals(295.5));
-    expect(tester.getRect(find.text('Hint')).size, equals(const Size(800.0, 16.0)));
-    expect(tester.getRect(find.text('Hint')).left, equals(0.0));
-    expect(tester.getRect(find.text('Hint')).top, equals(295.5));
-    expect(tester.getRect(find.text('Helper')).size, equals(const Size(800.0, 12.0)));
-    expect(tester.getRect(find.text('Helper')).left, equals(0.0));
-    expect(tester.getRect(find.text('Helper')).top, equals(328.5));
-    expect(find.text('P'), findsNothing);
-    expect(find.text('S'), findsNothing);
+    expect(tester.element(find.byKey(key)).size, equals(const Size(752.0, 60.0)));
 
-    await tester.pump(const Duration(seconds: 1));
+    await tester.pumpWidget(new MaterialApp(
+      home: new Material(
+        child: new Center(
+          child: new InputDecorator(
+            decoration: const InputDecoration.collapsed(
+              hintText: 'Hint text',
+            ),
+            child: new Container(key: key, width: 50.0, height: 60.0, color: Colors.blue),
+          ),
+        ),
+      ),
+    ));
 
-    expect(
-      tester.getRect(find.text('Label')).size,
-      anyOf(<Size>[const Size(60.0, 12.0), const Size(61.0, 12.0)]),
-    );
-    expect(tester.getRect(find.text('Label')).left, equals(0.0));
-    expect(tester.getRect(find.text('Label')).top, equals(275.5));
-    expect(tester.getRect(find.text('Hint')).size, equals(const Size(800.0, 16.0)));
-    expect(tester.getRect(find.text('Hint')).left, equals(0.0));
-    expect(tester.getRect(find.text('Hint')).top, equals(295.5));
-    expect(tester.getRect(find.text('Helper')).size, equals(const Size(800.0, 12.0)));
-    expect(tester.getRect(find.text('Helper')).left, equals(0.0));
-    expect(tester.getRect(find.text('Helper')).top, equals(328.5));
-    expect(find.text('P'), findsNothing);
-    expect(find.text('S'), findsNothing);
-
-    await tester.enterText(find.byType(TextField), 'Test');
-    await tester.pump(const Duration(milliseconds: 100));
-
-    expect(
-      tester.getRect(find.text('Label')).size,
-      anyOf(<Size>[const Size(60.0, 12.0), const Size(61.0, 12.0)]),
-    );
-    expect(tester.getRect(find.text('Label')).left, equals(0.0));
-    expect(tester.getRect(find.text('Label')).top, equals(275.5));
-    expect(tester.getRect(find.text('Hint')).size, equals(const Size(800.0, 16.0)));
-    expect(tester.getRect(find.text('Hint')).left, equals(0.0));
-    expect(tester.getRect(find.text('Hint')).top, equals(295.5));
-    expect(tester.getRect(find.text('Helper')).size, equals(const Size(800.0, 12.0)));
-    expect(tester.getRect(find.text('Helper')).left, equals(0.0));
-    expect(tester.getRect(find.text('Helper')).top, equals(328.5));
-    expect(
-      tester.getRect(find.text('P')).size,
-      anyOf(<Size>[const Size(17.0, 16.0), const Size(16.0, 16.0)]),
-    );
-    expect(tester.getRect(find.text('P')).left, equals(0.0));
-    expect(tester.getRect(find.text('P')).top, equals(295.5));
-    expect(
-      tester.getRect(find.text('S')).size,
-      anyOf(<Size>[const Size(17.0, 16.0), const Size(16.0, 16.0)]),
-    );
-    expect(tester.getRect(find.text('S')).left, anyOf(783.0, 784.0));
-    expect(tester.getRect(find.text('S')).top, equals(295.5));
-
-    await tester.pump(const Duration(seconds: 1));
-
-    expect(
-      tester.getRect(find.text('Label')).size,
-      anyOf(<Size>[const Size(60.0, 12.0), const Size(61.0, 12.0)]),
-    );
-    expect(tester.getRect(find.text('Label')).left, equals(0.0));
-    expect(tester.getRect(find.text('Label')).top, equals(275.5));
-    expect(tester.getRect(find.text('Hint')).size, equals(const Size(800.0, 16.0)));
-    expect(tester.getRect(find.text('Hint')).left, equals(0.0));
-    expect(tester.getRect(find.text('Hint')).top, equals(295.5));
-    expect(tester.getRect(find.text('Helper')).size, equals(const Size(800.0, 12.0)));
-    expect(tester.getRect(find.text('Helper')).left, equals(0.0));
-    expect(tester.getRect(find.text('Helper')).top, equals(328.5));
-    expect(
-      tester.getRect(find.text('P')).size,
-      anyOf(<Size>[const Size(17.0, 16.0), const Size(16.0, 16.0)]),
-    );
-    expect(tester.getRect(find.text('P')).left, equals(0.0));
-    expect(tester.getRect(find.text('P')).top, equals(295.5));
-    expect(
-      tester.getRect(find.text('S')).size,
-      anyOf(<Size>[const Size(17.0, 16.0), const Size(16.0, 16.0)]),
-    );
-    expect(tester.getRect(find.text('S')).left, anyOf(783.0, 784.0));
-    expect(tester.getRect(find.text('S')).top, equals(295.5));
+    expect(tester.element(find.byKey(key)).size, equals(const Size(800.0, 60.0)));
   });
 }


### PR DESCRIPTION
This reverts commit 67cf7918cfc9201cfc05f508278a3ab6571bbb8e.

Reverting because this causes Scuba regressions that I'd like to
address in another PR that is pending, but we'd like to roll Flutter.