### PR TITLE
Performance improvements for semantics tree compilation

### DIFF
--- a/examples/flutter_gallery/test_driver/transitions_perf_test.dart
+++ b/examples/flutter_gallery/test_driver/transitions_perf_test.dart
@@ -35,7 +35,7 @@ const List<Demo> demos = const <Demo>[
   // Demos
   const Demo('Shrine', profiled: true),
   const Demo('Contact profile', profiled: true),
-  // const Demo('Animation', profiled: true),
+  const Demo('Animation', profiled: true),
 
   // Material Components
   const Demo('Bottom navigation', profiled: true),

--- a/examples/flutter_gallery/test_driver/transitions_perf_test.dart
+++ b/examples/flutter_gallery/test_driver/transitions_perf_test.dart
@@ -35,7 +35,7 @@ const List<Demo> demos = const <Demo>[
   // Demos
   const Demo('Shrine', profiled: true),
   const Demo('Contact profile', profiled: true),
-  const Demo('Animation', profiled: true),
+  // const Demo('Animation', profiled: true),
 
   // Material Components
   const Demo('Bottom navigation', profiled: true),

--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -859,6 +859,7 @@ class PipelineOwner {
   void flushSemantics() {
     if (_semanticsOwner == null)
       return;
+    clipRectCount = 0;
     Timeline.startSync('Semantics');
     assert(_semanticsOwner != null);
     assert(() { _debugDoingSemantics = true; return true; }());
@@ -875,6 +876,7 @@ class PipelineOwner {
       assert(_nodesNeedingSemantics.isEmpty);
       assert(() { _debugDoingSemantics = false; return true; }());
       Timeline.finishSync();
+      print('Clip rect: $clipRectCount');
     }
   }
 }
@@ -2318,12 +2320,12 @@ abstract class RenderObject extends AbstractNode with DiagnosticableTreeMixin im
           continue;
         if (!config.isCompatibleWith(fragment.config))
           toBeMarkedExplicit.add(fragment);
-//        for (_InterestingSemanticsFragment siblingFragment in fragments.sublist(0, fragments.length - 1)) {
-//          if (!fragment.config.isCompatibleWith(siblingFragment.config)) {
-//            toBeMarkedExplicit.add(fragment);
-//            toBeMarkedExplicit.add(siblingFragment);
-//          }
-//        }
+        for (_InterestingSemanticsFragment siblingFragment in fragments.sublist(0, fragments.length - 1)) {
+          if (!fragment.config.isCompatibleWith(siblingFragment.config)) {
+            toBeMarkedExplicit.add(fragment);
+            toBeMarkedExplicit.add(siblingFragment);
+          }
+        }
       }
     });
 
@@ -3221,6 +3223,7 @@ class _SemanticsGeometry {
   bool _isClipRectValid = false;
 
   Rect _computeClipRect() {
+    clipRectCount++;
     if (_owner.parent is! RenderObject)
       return null;
     final RenderObject parent = _owner.parent;
@@ -3301,3 +3304,5 @@ class _SemanticsGeometry {
     return clipRect != null && clipRect.isEmpty || rect.isEmpty;
   }
 }
+
+int clipRectCount = 0;

--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -2318,12 +2318,12 @@ abstract class RenderObject extends AbstractNode with DiagnosticableTreeMixin im
           continue;
         if (!config.isCompatibleWith(fragment.config))
           toBeMarkedExplicit.add(fragment);
-        for (_InterestingSemanticsFragment siblingFragment in fragments.sublist(0, fragments.length - 1)) {
-          if (!fragment.config.isCompatibleWith(siblingFragment.config)) {
-            toBeMarkedExplicit.add(fragment);
-            toBeMarkedExplicit.add(siblingFragment);
-          }
-        }
+//        for (_InterestingSemanticsFragment siblingFragment in fragments.sublist(0, fragments.length - 1)) {
+//          if (!fragment.config.isCompatibleWith(siblingFragment.config)) {
+//            toBeMarkedExplicit.add(fragment);
+//            toBeMarkedExplicit.add(siblingFragment);
+//          }
+//        }
       }
     });
 

--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -3032,6 +3032,14 @@ abstract class _InterestingSemanticsFragment extends _SemanticsFragment {
     _tagsForChildren.addAll(tags);
   }
 
+  /// Adds the geometric information of `ancestor` to this object.
+  ///
+  /// Those information are required to properly compute the value for
+  /// [SemanticsNode.transform], [SemanticsNode.clipRect], and
+  /// [SemanticsNode.rect].
+  ///
+  /// Ancestors have to be added in order from [owner] up until the next
+  /// [RenderObject] that owns a [SemanticsNode] is reached.
   void addAncestor(RenderObject ancestor) {
     _ancestorChain.add(ancestor);
   }
@@ -3206,7 +3214,12 @@ class _SwitchableSemanticsFragment extends _InterestingSemanticsFragment {
 /// [SemanticsNode.rect] and [SemanticsNode.transform].
 class _SemanticsGeometry {
 
-  /// `parentClippingRect` may be null if no clip is to be applied.
+  /// The `parentClippingRect` may be null if no clip is to be applied.
+  ///
+  /// The `ancestors` list has to include all [RenderObject] in order that are
+  /// located between the [SemanticsNode] whose geometry is represented here
+  /// (first [RenderObject] in the list) and its closest ancestor [RenderObject]
+  /// that also owns its own [SemanticsNode] (last [RenderObject] in the list).
   _SemanticsGeometry({
     @required Rect parentClipRect,
     @required List<RenderObject> ancestors,
@@ -3218,8 +3231,13 @@ class _SemanticsGeometry {
   Matrix4 _transform;
   Rect _rect;
 
+  /// Value for [SemanticsNode.transform].
   Matrix4 get transform => _transform;
+
+  /// Value for [SemanticsNode.parentClipRect].
   Rect get clipRect => _clipRect;
+
+  /// Value for [SemanticsNode.rect].
   Rect get rect => _rect;
 
   void _computeValues(Rect parentClipRect, List<RenderObject> ancestors) {

--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -3086,7 +3086,6 @@ class RenderSemanticsGestureHandler extends RenderProxyBox {
 
     _innerNode ??= new SemanticsNode(showOnScreen: showOnScreen);
     _innerNode
-      ..wasAffectedByClip = node.wasAffectedByClip
       ..isMergedIntoParent = node.isPartOfNodeMerging
       ..rect = Offset.zero & node.rect.size;
     _annotatedNode = _innerNode;

--- a/packages/flutter/lib/src/rendering/semantics.dart
+++ b/packages/flutter/lib/src/rendering/semantics.dart
@@ -253,12 +253,11 @@ class SemanticsNode extends AbstractNode with DiagnosticableTreeMixin {
     }
   }
 
-  /// Whether [rect] was affected by a clip from an ancestors.
+  /// The clip rect from an ancestor that was applied to this node.
   ///
-  /// If this is true it means that an ancestor imposed a clip on this
-  /// [SemanticsNode]. However, it does not mean that the clip had any effect
-  /// on the [rect] whatsoever.
-  bool wasAffectedByClip = false;
+  /// Expressed in the coordinate system of the node. May be null if no clip has
+  /// been applied.
+  Rect parentClipRect;
 
   /// Whether the node is invisible.
   ///
@@ -672,7 +671,6 @@ class SemanticsNode extends AbstractNode with DiagnosticableTreeMixin {
       }
       properties.add(new DiagnosticsProperty<Rect>('rect', rect, description: description, showName: false));
     }
-    properties.add(new FlagProperty('wasAffectedByClip', value: wasAffectedByClip, ifTrue: 'clipped'));
     final List<String> actions = _actions.keys.map((SemanticsAction action) => describeEnum(action)).toList()..sort();
     properties.add(new IterableProperty<String>('actions', actions, ifEmpty: null));
     if (_hasFlag(SemanticsFlags.hasCheckedState))
@@ -1107,7 +1105,7 @@ class SemanticsConfiguration {
       return;
 
     _actions.addAll(other._actions);
-    _actionsAsBits != other._actionsAsBits;
+    _actionsAsBits |= other._actionsAsBits;
     _flags |= other._flags;
 
     textDirection ??= other.textDirection;

--- a/packages/flutter/test/material/card_test.dart
+++ b/packages/flutter/test/material/card_test.dart
@@ -40,12 +40,12 @@ void main() {
       new TestSemantics.root(
         children: <TestSemantics>[
           new TestSemantics.rootChild(
-            id: 2,
+            id: 1,
             label: 'I am text!\nMoar text!!1',
             textDirection: TextDirection.ltr,
             children: <TestSemantics>[
               new TestSemantics(
-                id: 1,
+                id: 2,
                 label: 'Button',
                 textDirection: TextDirection.ltr,
                 actions: SemanticsAction.tap.index,

--- a/packages/flutter/test/material/control_list_tile_test.dart
+++ b/packages/flutter/test/material/control_list_tile_test.dart
@@ -95,7 +95,7 @@ void main() {
     expect(semantics, hasSemantics(new TestSemantics.root(
       children: <TestSemantics>[
         new TestSemantics.rootChild(
-          id: 7,
+          id: 1,
           rect: new Rect.fromLTWH(0.0, 0.0, 800.0, 56.0),
           transform: null,
           flags: SemanticsFlags.hasCheckedState.index | SemanticsFlags.isChecked.index,
@@ -103,7 +103,7 @@ void main() {
           label: 'aaa\nAAA',
         ),
         new TestSemantics.rootChild(
-          id: 8,
+          id: 4,
           rect: new Rect.fromLTWH(0.0, 0.0, 800.0, 56.0),
           transform: new Matrix4.translationValues(0.0, 56.0, 0.0),
           flags: SemanticsFlags.hasCheckedState.index | SemanticsFlags.isChecked.index,
@@ -111,7 +111,7 @@ void main() {
           label: 'bbb\nBBB',
         ),
         new TestSemantics.rootChild(
-          id: 9,
+          id: 7,
           rect: new Rect.fromLTWH(0.0, 0.0, 800.0, 56.0),
           transform: new Matrix4.translationValues(0.0, 112.0, 0.0),
           flags: SemanticsFlags.hasCheckedState.index,

--- a/packages/flutter/test/material/tabs_test.dart
+++ b/packages/flutter/test/material/tabs_test.dart
@@ -1011,11 +1011,11 @@ void main() {
     final TestSemantics expectedSemantics = new TestSemantics.root(
       children: <TestSemantics>[
         new TestSemantics.rootChild(
-          id: 3,
+          id: 1,
           rect: TestSemantics.fullScreen,
           children: <TestSemantics>[
             new TestSemantics(
-              id: 1,
+              id: 2,
               actions: SemanticsAction.tap.index,
               flags: SemanticsFlags.isSelected.index,
               label: 'TAB #0\nTab 1 of 2',
@@ -1023,7 +1023,7 @@ void main() {
               transform: new Matrix4.translationValues(0.0, 276.0, 0.0),
             ),
             new TestSemantics(
-              id: 2,
+              id: 3,
               actions: SemanticsAction.tap.index,
               label: 'TAB #1\nTab 2 of 2',
               rect: new Rect.fromLTRB(0.0, 0.0, 108.0, kTextTabBarHeight),
@@ -1261,11 +1261,11 @@ void main() {
     final TestSemantics expectedSemantics = new TestSemantics.root(
       children: <TestSemantics>[
         new TestSemantics.rootChild(
-          id: 25,
+          id: 23,
           rect: TestSemantics.fullScreen,
           children: <TestSemantics>[
             new TestSemantics(
-              id: 23,
+              id: 24,
               actions: SemanticsAction.tap.index,
               flags: SemanticsFlags.isSelected.index,
               label: 'Semantics override 0\nTab 1 of 2',
@@ -1273,7 +1273,7 @@ void main() {
               transform: new Matrix4.translationValues(0.0, 276.0, 0.0),
             ),
             new TestSemantics(
-              id: 24,
+              id: 25,
               actions: SemanticsAction.tap.index,
               label: 'Semantics override 1\nTab 2 of 2',
               rect: new Rect.fromLTRB(0.0, 0.0, 108.0, kTextTabBarHeight),

--- a/packages/flutter/test/rendering/semantics_test.dart
+++ b/packages/flutter/test/rendering/semantics_test.dart
@@ -198,7 +198,7 @@ void main() {
 
     expect(
       minimalProperties.toStringDeep(minLevel: DiagnosticLevel.hidden),
-      'SemanticsNode#16(owner: null, isPartOfNodeMerging: false, Rect.fromLTRB(0.0, 0.0, 0.0, 0.0), wasAffectedByClip: false, actions: [], isSelected: false, label: "", isButton: false, textDirection: null)\n',
+      'SemanticsNode#16(owner: null, isPartOfNodeMerging: false, Rect.fromLTRB(0.0, 0.0, 0.0, 0.0), actions: [], isSelected: false, label: "", isButton: false, textDirection: null)\n',
     );
 
     final SemanticsConfiguration config = new SemanticsConfiguration()
@@ -214,11 +214,10 @@ void main() {
     final SemanticsNode allProperties = new SemanticsNode()
       ..rect = new Rect.fromLTWH(50.0, 10.0, 20.0, 30.0)
       ..transform = new Matrix4.translation(new Vector3(10.0, 10.0, 0.0))
-      ..wasAffectedByClip = true
       ..updateWith(config: config, childrenInInversePaintOrder: null);
     expect(
       allProperties.toStringDeep(),
-      'SemanticsNode#17(STALE, owner: null, leaf merge, Rect.fromLTRB(60.0, 20.0, 80.0, 50.0), clipped, actions: [longPress, scrollUp, showOnScreen], unchecked, selected, label: "Use all the properties", button, textDirection: rtl)\n',
+      'SemanticsNode#17(STALE, owner: null, leaf merge, Rect.fromLTRB(60.0, 20.0, 80.0, 50.0), actions: [longPress, scrollUp, showOnScreen], unchecked, selected, label: "Use all the properties", button, textDirection: rtl)\n',
     );
     expect(
       allProperties.getSemanticsData().toString(),

--- a/packages/flutter/test/widgets/implicit_semantics_test.dart
+++ b/packages/flutter/test/widgets/implicit_semantics_test.dart
@@ -229,20 +229,20 @@ void main() {
         new TestSemantics.root(
           children: <TestSemantics>[
             new TestSemantics.rootChild(
-              id: 8,
+              id: 5,
               children: <TestSemantics>[
                 new TestSemantics(
-                  id: 5,
+                  id: 6,
                   flags: SemanticsFlags.isSelected.index,
                   label: 'node 1',
                 ),
                 new TestSemantics(
-                  id: 6,
+                  id: 7,
                   flags: SemanticsFlags.isSelected.index,
                   label: 'node 2',
                 ),
                 new TestSemantics(
-                  id: 7,
+                  id: 8,
                   flags: SemanticsFlags.isSelected.index,
                   label: 'node 3',
                 ),

--- a/packages/flutter/test/widgets/modal_barrier_test.dart
+++ b/packages/flutter/test/widgets/modal_barrier_test.dart
@@ -104,11 +104,11 @@ void main() {
     final TestSemantics expectedSemantics = new TestSemantics.root(
       children: <TestSemantics>[
         new TestSemantics.rootChild(
-          id: 2,
+          id: 1,
           rect: TestSemantics.fullScreen,
           children: <TestSemantics>[
             new TestSemantics(
-              id: 1,
+              id: 2,
               rect: TestSemantics.fullScreen,
               actions: SemanticsAction.tap.index,
             ),

--- a/packages/flutter/test/widgets/semantics_2_test.dart
+++ b/packages/flutter/test/widgets/semantics_2_test.dart
@@ -53,17 +53,17 @@ void main() {
     expect(semantics, hasSemantics(new TestSemantics.root(
       children: <TestSemantics>[
         new TestSemantics.rootChild(
-          id: 3,
+          id: 1,
           rect: TestSemantics.fullScreen,
           children: <TestSemantics>[
             new TestSemantics(
-              id: 1,
+              id: 2,
               label: 'child1',
               rect: new Rect.fromLTRB(0.0, 0.0, 800.0, 10.0),
               flags: SemanticsFlags.isSelected.index,
             ),
             new TestSemantics(
-              id: 2,
+              id: 3,
               label: 'child2',
               rect: new Rect.fromLTRB(0.0, 0.0, 800.0, 10.0),
               flags: SemanticsFlags.isSelected.index,
@@ -107,7 +107,7 @@ void main() {
     expect(semantics, hasSemantics(new TestSemantics.root(
       children: <TestSemantics>[
         new TestSemantics.rootChild(
-          id: 3,
+          id: 1,
           label: 'child1',
           rect: TestSemantics.fullScreen,
           flags: SemanticsFlags.isSelected.index,
@@ -149,7 +149,7 @@ void main() {
     expect(semantics, hasSemantics(new TestSemantics.root(
       children: <TestSemantics>[
         new TestSemantics.rootChild(
-          id: 3,
+          id: 1,
           rect: TestSemantics.fullScreen,
           children: <TestSemantics>[
             new TestSemantics(
@@ -159,7 +159,7 @@ void main() {
               flags: SemanticsFlags.isSelected.index,
             ),
             new TestSemantics(
-              id: 2,
+              id: 3,
               label: 'child2',
               rect: new Rect.fromLTRB(0.0, 0.0, 800.0, 10.0),
               flags: SemanticsFlags.isSelected.index,

--- a/packages/flutter/test/widgets/semantics_4_test.dart
+++ b/packages/flutter/test/widgets/semantics_4_test.dart
@@ -53,22 +53,22 @@ void main() {
       new TestSemantics.root(
         children: <TestSemantics>[
           new TestSemantics.rootChild(
-            id: 3,
+            id: 1,
             label: 'L1',
             rect: TestSemantics.fullScreen,
           ),
           new TestSemantics.rootChild(
-            id: 4,
+            id: 2,
             label: 'L2',
             rect: TestSemantics.fullScreen,
             children: <TestSemantics>[
               new TestSemantics(
-                id: 1,
+                id: 3,
                 flags: SemanticsFlags.hasCheckedState.index | SemanticsFlags.isChecked.index,
                 rect: TestSemantics.fullScreen,
               ),
               new TestSemantics(
-                id: 2,
+                id: 4,
                 flags: SemanticsFlags.hasCheckedState.index,
                 rect: TestSemantics.fullScreen,
               ),
@@ -113,12 +113,12 @@ void main() {
       new TestSemantics.root(
         children: <TestSemantics>[
           new TestSemantics.rootChild(
-            id: 3,
+            id: 1,
             label: 'L1',
             rect: TestSemantics.fullScreen,
           ),
           new TestSemantics.rootChild(
-            id: 4,
+            id: 2,
             label: 'L2',
             flags: SemanticsFlags.hasCheckedState.index | SemanticsFlags.isChecked.index,
             rect: TestSemantics.fullScreen,
@@ -158,7 +158,7 @@ void main() {
       new TestSemantics.root(
         children: <TestSemantics>[
           new TestSemantics.rootChild(
-            id: 4,
+            id: 2,
             label: 'L2',
             flags: SemanticsFlags.hasCheckedState.index | SemanticsFlags.isChecked.index,
             rect: TestSemantics.fullScreen,

--- a/packages/flutter/test/widgets/semantics_7_test.dart
+++ b/packages/flutter/test/widgets/semantics_7_test.dart
@@ -55,7 +55,7 @@ void main() {
       new TestSemantics.root(
         children: <TestSemantics>[
           new TestSemantics.rootChild(
-            id: 3,
+            id: 1,
             flags: SemanticsFlags.hasCheckedState.index | SemanticsFlags.isChecked.index,
             label: label,
             rect: TestSemantics.fullScreen,
@@ -111,7 +111,7 @@ void main() {
       new TestSemantics.root(
         children: <TestSemantics>[
           new TestSemantics.rootChild(
-            id: 3,
+            id: 1,
             flags: SemanticsFlags.hasCheckedState.index | SemanticsFlags.isChecked.index,
             label: label,
             rect: TestSemantics.fullScreen,

--- a/packages/flutter/test/widgets/semantics_8_test.dart
+++ b/packages/flutter/test/widgets/semantics_8_test.dart
@@ -41,7 +41,7 @@ void main() {
       new TestSemantics.root(
         children: <TestSemantics>[
           new TestSemantics.rootChild(
-            id: 3,
+            id: 1,
             flags: SemanticsFlags.hasCheckedState.index | SemanticsFlags.isChecked.index,
             label: 'label',
             textDirection: TextDirection.ltr,
@@ -79,7 +79,7 @@ void main() {
       new TestSemantics.root(
         children: <TestSemantics>[
           new TestSemantics.rootChild(
-            id: 3,
+            id: 1,
             flags: SemanticsFlags.hasCheckedState.index | SemanticsFlags.isChecked.index,
             label: 'label',
             textDirection: TextDirection.ltr,

--- a/packages/flutter/test/widgets/semantics_clipping_test.dart
+++ b/packages/flutter/test/widgets/semantics_clipping_test.dart
@@ -60,12 +60,6 @@ void main() {
       ignoreTransform: true,
     ));
 
-    final SemanticsNode node1 = tester.renderObject(find.byWidget(const Text('1'))).debugSemantics;
-    final SemanticsNode node2 = tester.renderObject(find.byWidget(const Text('2'))).debugSemantics;
-
-    expect(node1.wasAffectedByClip, false);
-    expect(node2.wasAffectedByClip, true);
-
     semantics.dispose();
   });
 

--- a/packages/flutter/test/widgets/sliver_semantics_test.dart
+++ b/packages/flutter/test/widgets/sliver_semantics_test.dart
@@ -50,7 +50,7 @@ void main() {
       new TestSemantics.root(
         children: <TestSemantics>[
           new TestSemantics.rootChild(
-            id: 4,
+            id: 1,
             tags: <SemanticsTag>[RenderSemanticsGestureHandler.useTwoPaneSemantics],
             children: <TestSemantics>[
               new TestSemantics(
@@ -58,15 +58,15 @@ void main() {
                 actions: SemanticsAction.scrollUp.index,
                 children: <TestSemantics>[
                   new TestSemantics(
-                    id: 1,
+                    id: 2,
                     label: 'Item 0',
                   ),
                   new TestSemantics(
-                    id: 2,
+                    id: 3,
                     label: 'Item 1',
                   ),
                   new TestSemantics(
-                    id: 3,
+                    id: 4,
                     label: 'Semantics Test with Slivers',
                   ),
                 ],
@@ -88,7 +88,7 @@ void main() {
       new TestSemantics.root(
         children: <TestSemantics>[
           new TestSemantics.rootChild(
-            id: 4,
+            id: 1,
             tags: <SemanticsTag>[RenderSemanticsGestureHandler.useTwoPaneSemantics],
             children: <TestSemantics>[
               new TestSemantics(
@@ -96,11 +96,11 @@ void main() {
                 actions: SemanticsAction.scrollUp.index | SemanticsAction.scrollDown.index,
                 children: <TestSemantics>[
                   new TestSemantics(
-                    id: 1,
+                    id: 2,
                     label: 'Item 0',
                   ),
                   new TestSemantics(
-                    id: 2,
+                    id: 3,
                     label: 'Item 1',
                   ),
                   new TestSemantics(
@@ -110,7 +110,7 @@ void main() {
                 ],
               ),
               new TestSemantics(
-                id: 3,
+                id: 4,
                 label: 'Semantics Test with Slivers',
                 tags: <SemanticsTag>[RenderSemanticsGestureHandler.excludeFromScrolling],
               ),
@@ -131,7 +131,7 @@ void main() {
       new TestSemantics.root(
         children: <TestSemantics>[
           new TestSemantics.rootChild(
-            id: 4,
+            id: 1,
             tags: <SemanticsTag>[RenderSemanticsGestureHandler.useTwoPaneSemantics],
             children: <TestSemantics>[
               new TestSemantics(
@@ -139,11 +139,11 @@ void main() {
                 actions: SemanticsAction.scrollUp.index | SemanticsAction.scrollDown.index,
                 children: <TestSemantics>[
                   new TestSemantics(
-                    id: 1,
+                    id: 2,
                     label: 'Item 0',
                   ),
                   new TestSemantics(
-                    id: 2,
+                    id: 3,
                     label: 'Item 1',
                   ),
                   new TestSemantics(
@@ -151,7 +151,7 @@ void main() {
                     label: 'Item 2',
                   ),
                   new TestSemantics(
-                    id: 3,
+                    id: 4,
                     label: 'Semantics Test with Slivers',
                   ),
                 ],
@@ -202,7 +202,7 @@ void main() {
       new TestSemantics.root(
         children: <TestSemantics>[
           new TestSemantics.rootChild(
-            id: 9,
+            id: 7,
             tags: <SemanticsTag>[RenderSemanticsGestureHandler.useTwoPaneSemantics],
             children: <TestSemantics>[
               new TestSemantics(
@@ -210,12 +210,12 @@ void main() {
                 actions: SemanticsAction.scrollUp.index | SemanticsAction.scrollDown.index,
                 children: <TestSemantics>[
                   new TestSemantics(
-                    id: 7,
+                    id: 8,
                     label: 'Item 2',
                     textDirection: TextDirection.ltr,
                   ),
                   new TestSemantics(
-                    id: 8,
+                    id: 9,
                     label: 'Item 1',
                     textDirection: TextDirection.ltr,
                   ),
@@ -256,34 +256,34 @@ void main() {
       new TestSemantics.root(
         children: <TestSemantics>[
           new TestSemantics.rootChild(
-            id: 16,
+            id: 11,
             tags: <SemanticsTag>[RenderSemanticsGestureHandler.useTwoPaneSemantics],
             children: <TestSemantics>[
               new TestSemantics(
                 id: 17,
                 children: <TestSemantics>[
                   new TestSemantics(
-                    id: 11,
+                    id: 12,
                     label: 'Item 4',
                     textDirection: TextDirection.ltr,
                   ),
                   new TestSemantics(
-                    id: 12,
+                    id: 13,
                     label: 'Item 3',
                     textDirection: TextDirection.ltr,
                   ),
                   new TestSemantics(
-                    id: 13,
+                    id: 14,
                     label: 'Item 2',
                     textDirection: TextDirection.ltr,
                   ),
                   new TestSemantics(
-                    id: 14,
+                    id: 15,
                     label: 'Item 1',
                     textDirection: TextDirection.ltr,
                   ),
                   new TestSemantics(
-                    id: 15,
+                    id: 16,
                     label: 'Item 0',
                     textDirection: TextDirection.ltr,
                   ),
@@ -337,7 +337,7 @@ void main() {
       new TestSemantics.root(
         children: <TestSemantics>[
           new TestSemantics.rootChild(
-            id: 22,
+            id: 18,
             rect: TestSemantics.fullScreen,
             tags: <SemanticsTag>[RenderSemanticsGestureHandler.useTwoPaneSemantics],
             children: <TestSemantics>[
@@ -348,20 +348,20 @@ void main() {
                 children: <TestSemantics>[
                   // Item 0 is missing because its covered by the app bar.
                   new TestSemantics(
-                    id: 18,
+                    id: 19,
                     rect: new Rect.fromLTRB(0.0, 0.0, 800.0, 200.0),
                     // Item 1 starts 20.0dp below edge, so there would be room for Item 0.
                     transform: new Matrix4.translation(new Vector3(0.0, 20.0, 0.0)),
                     label: 'Item 1',
                   ),
                   new TestSemantics(
-                    id: 19,
+                    id: 20,
                     rect: new Rect.fromLTRB(0.0, 0.0, 800.0, 200.0),
                     transform: new Matrix4.translation(new Vector3(0.0, 220.0, 0.0)),
                     label: 'Item 2',
                   ),
                   new TestSemantics(
-                    id: 20,
+                    id: 21,
                     rect: new Rect.fromLTRB(0.0, 0.0, 800.0, 200.0),
                     transform: new Matrix4.translation(new Vector3(0.0, 420.0, 0.0)),
                     label: 'Item 3',
@@ -369,7 +369,7 @@ void main() {
                 ],
               ),
               new TestSemantics(
-                id: 21,
+                id: 22,
                 rect: new Rect.fromLTRB(0.0, 0.0, 120.0, 20.0),
                 tags: <SemanticsTag>[RenderSemanticsGestureHandler.excludeFromScrolling],
                 label: 'AppBar',
@@ -420,7 +420,7 @@ void main() {
       new TestSemantics.root(
         children: <TestSemantics>[
           new TestSemantics.rootChild(
-            id: 28,
+            id: 24,
             rect: TestSemantics.fullScreen,
             tags: <SemanticsTag>[RenderSemanticsGestureHandler.useTwoPaneSemantics],
             children: <TestSemantics>[
@@ -430,19 +430,19 @@ void main() {
                 rect: TestSemantics.fullScreen,
                 children: <TestSemantics>[
                   new TestSemantics(
-                    id: 24,
+                    id: 25,
                     rect: new Rect.fromLTRB(0.0, 0.0, 800.0, 200.0),
                     transform: new Matrix4.translation(new Vector3(0.0, 420.0, 0.0)),
                     label: 'Item 3',
                   ),
                   new TestSemantics(
-                    id: 25,
+                    id: 26,
                     rect: new Rect.fromLTRB(0.0, 0.0, 800.0, 200.0),
                     transform: new Matrix4.translation(new Vector3(0.0, 220.0, 0.0)),
                     label: 'Item 2',
                   ),
                   new TestSemantics(
-                    id: 26,
+                    id: 27,
                     rect: new Rect.fromLTRB(0.0, 0.0, 800.0, 200.0),
                     // Item 1 starts 20.0dp below edge, so there would be room for Item 0.
                     transform: new Matrix4.translation(new Vector3(0.0, 20.0, 0.0)),
@@ -452,7 +452,7 @@ void main() {
                 ],
               ),
               new TestSemantics(
-                id: 27,
+                id: 28,
                 rect: new Rect.fromLTRB(0.0, 0.0, 120.0, 20.0),
                 tags: <SemanticsTag>[RenderSemanticsGestureHandler.excludeFromScrolling],
                 label: 'AppBar'
@@ -505,7 +505,7 @@ void main() {
       new TestSemantics.root(
         children: <TestSemantics>[
           new TestSemantics.rootChild(
-            id: 34,
+            id: 30,
             rect: TestSemantics.fullScreen,
             tags: <SemanticsTag>[RenderSemanticsGestureHandler.useTwoPaneSemantics],
             children: <TestSemantics>[
@@ -516,20 +516,20 @@ void main() {
                 children: <TestSemantics>[
                   // Item 0 is missing because its covered by the app bar.
                   new TestSemantics(
-                    id: 30,
+                    id: 31,
                     // Item 1 ends at 580dp, so there would be 20dp space for Item 0.
                     rect: new Rect.fromLTRB(0.0, 0.0, 800.0, 200.0),
                     transform: new Matrix4.translation(new Vector3(0.0, 380.0, 0.0)),
                     label: 'Item 1',
                   ),
                   new TestSemantics(
-                    id: 31,
+                    id: 32,
                     rect: new Rect.fromLTRB(0.0, 0.0, 800.0, 200.0),
                     transform: new Matrix4.translation(new Vector3(0.0, 180.0, 0.0)),
                     label: 'Item 2',
                   ),
                   new TestSemantics(
-                    id: 32,
+                    id: 33,
                     rect: new Rect.fromLTRB(0.0, 0.0, 800.0, 200.0),
                     transform: new Matrix4.translation(new Vector3(0.0, -20.0, 0.0)),
                     label: 'Item 3',
@@ -537,7 +537,7 @@ void main() {
                 ],
               ),
               new TestSemantics(
-                id: 33,
+                id: 34,
                 rect: new Rect.fromLTRB(0.0, 0.0, 120.0, 20.0),
                 transform: new Matrix4.translation(new Vector3(0.0, 544.0, 0.0)),
                 tags: <SemanticsTag>[RenderSemanticsGestureHandler.excludeFromScrolling],
@@ -590,7 +590,7 @@ void main() {
       new TestSemantics.root(
         children: <TestSemantics>[
           new TestSemantics.rootChild(
-            id: 40,
+            id: 36,
             rect: TestSemantics.fullScreen,
             tags: <SemanticsTag>[RenderSemanticsGestureHandler.useTwoPaneSemantics],
             children: <TestSemantics>[
@@ -600,19 +600,19 @@ void main() {
                 rect: TestSemantics.fullScreen,
                 children: <TestSemantics>[
                   new TestSemantics(
-                    id: 36,
+                    id: 37,
                     rect: new Rect.fromLTRB(0.0, 0.0, 800.0, 200.0),
                     transform: new Matrix4.translation(new Vector3(0.0, -20.0, 0.0)),
                     label: 'Item 3',
                   ),
                   new TestSemantics(
-                    id: 37,
+                    id: 38,
                     rect: new Rect.fromLTRB(0.0, 0.0, 800.0, 200.0),
                     transform: new Matrix4.translation(new Vector3(0.0, 180.0, 0.0)),
                     label: 'Item 2',
                   ),
                   new TestSemantics(
-                    id: 38,
+                    id: 39,
                     rect: new Rect.fromLTRB(0.0, 0.0, 800.0, 200.0),
                     // Item 1 ends at 580dp, so there would be 20dp space for Item 0.
                     transform: new Matrix4.translation(new Vector3(0.0, 380.0, 0.0)),
@@ -622,7 +622,7 @@ void main() {
                 ],
               ),
               new TestSemantics(
-                id: 39,
+                id: 40,
                 rect: new Rect.fromLTRB(0.0, 0.0, 120.0, 20.0),
                 transform: new Matrix4.translation(new Vector3(0.0, 544.0, 0.0)),
                 tags: <SemanticsTag>[RenderSemanticsGestureHandler.excludeFromScrolling],


### PR DESCRIPTION
In local testing it shaves about `0.71ms` off the flutter_gallery__transition_perf_with_semantics benchmark (`2.16ms -> 1.45ms`).

Changes:
* return to a two pass algorithm: geometrics is calculated in the second pass after the tree shape has been established (pro: only the absolutely necessary geometrics are calculated, con: doing work for nodes that will not end up in the tree: according to our benchmarks avoiding geo work is more important)
* remove `wasAffectedByClip` from SemanticsNode (very easy to misunderstand, wasn't used for anything)
* use bit mask to represent valid actions for slight performance boost