### PR TITLE
Use a package URI in test template import.

### DIFF
--- a/packages/flutter_tools/templates/create/test/widget_test.dart.tmpl
+++ b/packages/flutter_tools/templates/create/test/widget_test.dart.tmpl
@@ -7,7 +7,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import '../lib/main.dart';
+import 'package:{{projectName}}/main.dart';
 
 void main() {
   testWidgets('Counter increments smoke test', (WidgetTester tester) async {


### PR DESCRIPTION
Use a `package:` import when referencing source under test in test template.

This is the prefered style and plays nice w/ automated refactoring.

See: https://github.com/flutter/flutter-intellij/issues/1429

@scheglov @tvolkert 