### PR TITLE
Always build iOS Archive builds in release mode

### DIFF
--- a/packages/flutter_tools/bin/xcode_backend.sh
+++ b/packages/flutter_tools/bin/xcode_backend.sh
@@ -36,6 +36,19 @@ BuildApp() {
     target_path="${FLUTTER_TARGET}"
   fi
 
+  # Archive builds (ACTION=install) should always run in release mode.
+  if [[ "$ACTION" == "install" && "$FLUTTER_BUILD_MODE" != "release" ]]; then
+    EchoError "========================================================================"
+    EchoError "ERROR: Flutter archive builds must be run in Release mode."
+    EchoError ""
+    EchoError "To correct, run:"
+    EchoError "flutter build ios --release"
+    EchoError ""
+    EchoError "then re-run Archive from Xcode."
+    EchoError "========================================================================"
+    exit -1
+  fi
+
   local build_mode="release"
   if [[ -n "$FLUTTER_BUILD_MODE" ]]; then
     build_mode="${FLUTTER_BUILD_MODE}"


### PR DESCRIPTION
Archive builds for upload to iTunes Connect should always be built in
release mode, not doing so results in crash on startup.

Bug: https://github.com/flutter/flutter/issues/12086