### PR TITLE
Don't collect usage data during Fuchsia build

### DIFF
--- a/packages/flutter_tools/bin/fuchsia_builder.dart
+++ b/packages/flutter_tools/bin/fuchsia_builder.dart
@@ -17,6 +17,7 @@ import '../lib/src/base/os.dart';
 import '../lib/src/base/platform.dart';
 import '../lib/src/base/terminal.dart';
 import '../lib/src/cache.dart';
+import '../lib/src/disabled_usage.dart';
 import '../lib/src/flx.dart';
 import '../lib/src/globals.dart';
 import '../lib/src/usage.dart';
@@ -54,7 +55,7 @@ Future<Null> main(List<String> args) async {
     context.putIfAbsent(Cache, () => new Cache());
     context.putIfAbsent(Config, () => new Config());
     context.putIfAbsent(OperatingSystemUtils, () => new OperatingSystemUtils());
-    context.putIfAbsent(Usage, () => new Usage());
+    context.putIfAbsent(Usage, () => new DisabledUsage());
     return run(args);
   });
 }

--- a/packages/flutter_tools/bin/fuchsia_tester.dart
+++ b/packages/flutter_tools/bin/fuchsia_tester.dart
@@ -20,6 +20,7 @@ import '../lib/src/base/platform.dart';
 import '../lib/src/base/terminal.dart';
 import '../lib/src/cache.dart';
 import '../lib/src/dart/package_map.dart';
+import '../lib/src/disabled_usage.dart';
 import '../lib/src/globals.dart';
 import '../lib/src/test/flutter_platform.dart' as loader;
 import '../lib/src/usage.dart';
@@ -50,7 +51,7 @@ Future<Null> main(List<String> args) async {
     context.putIfAbsent(Cache, () => new Cache());
     context.putIfAbsent(Config, () => new Config());
     context.putIfAbsent(OperatingSystemUtils, () => new OperatingSystemUtils());
-    context.putIfAbsent(Usage, () => new Usage());
+    context.putIfAbsent(Usage, () => new DisabledUsage());
     return run(args);
   });
 }

--- a/packages/flutter_tools/lib/src/disabled_usage.dart
+++ b/packages/flutter_tools/lib/src/disabled_usage.dart
@@ -1,0 +1,48 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+
+import 'usage.dart';
+
+class DisabledUsage implements Usage {
+  @override
+  bool get isFirstRun => false;
+
+  @override
+  bool get suppressAnalytics => true;
+
+  @override
+  set suppressAnalytics(bool value) { }
+
+  @override
+  bool get enabled => false;
+
+  @override
+  set enabled(bool value) { }
+
+  @override
+  String get clientId => null;
+
+  @override
+  void sendCommand(String command, { Map<String, String> parameters }) { }
+
+  @override
+  void sendEvent(String category, String parameter, { Map<String, String> parameters }) { }
+
+  @override
+  void sendTiming(String category, String variableName, Duration duration, { String label }) { }
+
+  @override
+  void sendException(dynamic exception, StackTrace trace) { }
+
+  @override
+  Stream<Map<String, dynamic>> get onSend => null;
+
+  @override
+  Future<Null> ensureAnalyticsSent() => new Future<Null>.value();
+
+  @override
+  void printWelcome() { }
+}

--- a/packages/flutter_tools/lib/src/usage.dart
+++ b/packages/flutter_tools/lib/src/usage.dart
@@ -95,15 +95,15 @@ class Usage {
   }
 
   void sendTiming(
-    String category, 
-    String variableName, 
+    String category,
+    String variableName,
     Duration duration, {
     String label,
     }) {
     if (!suppressAnalytics) {
       _analytics.sendTiming(
-        variableName, 
-        duration.inMilliseconds, 
+        variableName,
+        duration.inMilliseconds,
         category: category,
         label: label,
       );


### PR DESCRIPTION
Previously, the usage analytics would generate a write to the user's
HOME directory during the Fuchsia build. We're tightening down the
environment in which we run the Fuchsia build, and these writes are now
more obvious.

This patch removes the usage analytics during the Fuchsia build,
avoiding the write to the user's HOME directory.