### PR TITLE
Add support for NDK discovery and add --prefer-shared-library option

### DIFF
--- a/packages/flutter_tools/gradle/flutter.gradle
+++ b/packages/flutter_tools/gradle/flutter.gradle
@@ -304,7 +304,7 @@ abstract class BaseFlutterTask extends DefaultTask {
     String targetPath
     @Optional @Input
     Boolean previewDart2
-    @Optional
+    @Optional @Input
     Boolean preferSharedLibrary
     File sourceDir
     File intermediateDir
@@ -346,10 +346,10 @@ abstract class BaseFlutterTask extends DefaultTask {
                     args "--preview-dart-2"
                 }
                 if (extraFrontEndOptions != null) {
-                  args "--extra-front-end-options", "${extraFrontEndOptions}"
+                    args "--extra-front-end-options", "${extraFrontEndOptions}"
                 }
                 if (extraGenSnapshotOptions != null) {
-                  args "--extra-gen-snapshot-options", "${extraGenSnapshotOptions}"
+                    args "--extra-gen-snapshot-options", "${extraGenSnapshotOptions}"
                 }
                 if (preferSharedLibrary) {
                     args "--prefer-shared-library"
@@ -403,19 +403,19 @@ class FlutterTask extends BaseFlutterTask {
 
     CopySpec getAssets() {
         return project.copySpec {
-	     from "${intermediateDir}/app.flx"
-	     from "${intermediateDir}/snapshot_blob.bin"
+            from "${intermediateDir}/app.flx"
+            from "${intermediateDir}/snapshot_blob.bin"
             if (buildMode != 'debug') {
-                // Although we have either the *.so file or the other files, we
-                // can still list all of them and only the existing ones will be
-                // copied :-/
+              if (preferSharedLibrary) {
                 from "${intermediateDir}/app.so"
+              } else {
                 from "${intermediateDir}/vm_snapshot_data"
                 from "${intermediateDir}/vm_snapshot_instr"
                 from "${intermediateDir}/isolate_snapshot_data"
                 from "${intermediateDir}/isolate_snapshot_instr"
+              }
             }
-        }
+      }
     }
 
     FileCollection readDependencies(File dependenciesFile) {

--- a/packages/flutter_tools/gradle/flutter.gradle
+++ b/packages/flutter_tools/gradle/flutter.gradle
@@ -235,6 +235,10 @@ class FlutterPlugin implements Plugin<Project> {
         if (project.hasProperty('extra-gen-snapshot-options')) {
             extraGenSnapshotOptionsValue = project.property('extra-gen-snapshot-options')
         }
+        Boolean preferSharedLibraryValue = false
+        if (project.hasProperty('prefer-shared-library')) {
+            preferSharedLibraryValue = project.property('prefer-shared-library')
+        }
 
         project.android.applicationVariants.all { variant ->
             String flutterBuildMode = buildModeFor(variant.buildType)
@@ -253,6 +257,7 @@ class FlutterPlugin implements Plugin<Project> {
                 localEngineSrcPath this.localEngineSrcPath
                 targetPath target
                 previewDart2 previewDart2Value
+                preferSharedLibrary preferSharedLibraryValue
                 sourceDir project.file(project.flutter.source)
                 intermediateDir project.file("${project.buildDir}/${AndroidProject.FD_INTERMEDIATES}/flutter/${variant.name}")
             }
@@ -266,6 +271,7 @@ class FlutterPlugin implements Plugin<Project> {
                 localEngineSrcPath this.localEngineSrcPath
                 targetPath target
                 previewDart2 previewDart2Value
+                preferSharedLibrary preferSharedLibraryValue
                 sourceDir project.file(project.flutter.source)
                 intermediateDir project.file("${project.buildDir}/${AndroidProject.FD_INTERMEDIATES}/flutter/${variant.name}")
                 extraFrontEndOptions extraFrontEndOptionsValue
@@ -298,6 +304,8 @@ abstract class BaseFlutterTask extends DefaultTask {
     String targetPath
     @Optional @Input
     Boolean previewDart2
+    @Optional
+    Boolean preferSharedLibrary
     File sourceDir
     File intermediateDir
     @Optional @Input
@@ -342,6 +350,9 @@ abstract class BaseFlutterTask extends DefaultTask {
                 }
                 if (extraGenSnapshotOptions != null) {
                   args "--extra-gen-snapshot-options", "${extraGenSnapshotOptions}"
+                }
+                if (preferSharedLibrary) {
+                    args "--prefer-shared-library"
                 }
                 args "--${buildMode}"
             }
@@ -395,6 +406,10 @@ class FlutterTask extends BaseFlutterTask {
 	     from "${intermediateDir}/app.flx"
 	     from "${intermediateDir}/snapshot_blob.bin"
             if (buildMode != 'debug') {
+                // Although we have either the *.so file or the other files, we
+                // can still list all of them and only the existing ones will be
+                // copied :-/
+                from "${intermediateDir}/app.so"
                 from "${intermediateDir}/vm_snapshot_data"
                 from "${intermediateDir}/vm_snapshot_instr"
                 from "${intermediateDir}/isolate_snapshot_data"

--- a/packages/flutter_tools/lib/src/android/android_sdk.dart
+++ b/packages/flutter_tools/lib/src/android/android_sdk.dart
@@ -62,10 +62,17 @@ class AndroidSdk {
     _init();
   }
 
+  /// The path to the Android SDK.
   final String directory;
-  final String ndkDirectory;  // Can be `null`.
-  final String ndkCompiler;  // Can be `null`.
-  final List<String> ndkCompilerArgs;  // Can be `null`.
+
+  /// The path to the NDK (can be `null`).
+  final String ndkDirectory;
+
+  /// The path to the NDK compiler (can be `null`).
+  final String ndkCompiler;
+
+  /// The mandatory arguments to the NDK compiler (can be `null`).
+  final List<String> ndkCompilerArgs;
 
   List<AndroidSdkVersion> _sdkVersions;
   AndroidSdkVersion _latestVersion;
@@ -119,7 +126,7 @@ class AndroidSdk {
     }
 
     String findNdk(String androidHomeDir) {
-      final ndkDirectory = fs.path.join(androidHomeDir, 'ndk-bundle');
+      final String ndkDirectory = fs.path.join(androidHomeDir, 'ndk-bundle');
       if (fs.isDirectorySync(ndkDirectory)) {
         return ndkDirectory;
       }
@@ -134,7 +141,7 @@ class AndroidSdk {
         directory = 'darwin-x86_64';
       }
       if (directory != null) {
-        final ndkCompiler = fs.path.join(ndkDirectory,
+        final String ndkCompiler = fs.path.join(ndkDirectory,
             'toolchains', 'arm-linux-androideabi-4.9', 'prebuilt', directory,
             'bin', 'arm-linux-androideabi-gcc');
         if (fs.isFileSync(ndkCompiler)) {
@@ -145,10 +152,10 @@ class AndroidSdk {
     }
 
     List<String> computeNdkCompilerArgs(String ndkDirectory) {
-      final armPlatform = fs.path.join(ndkDirectory, 'platforms', 'android-9',
-          'arch-arm');
+      final String armPlatform = fs.path.join(ndkDirectory, 'platforms',
+          'android-9', 'arch-arm');
       if (fs.isDirectorySync(armPlatform)) {
-        return ['--sysroot', armPlatform];
+        return <String>['--sysroot', armPlatform];
       }
       return null;
     }
@@ -161,14 +168,16 @@ class AndroidSdk {
     }
 
     // Try to find the NDK compiler.  If we can't find it, it's also ok.
-    final ndkDir = findNdk(androidHomeDir);
+    final String ndkDir = findNdk(androidHomeDir);
     String ndkCompiler;
     List<String> ndkCompilerArgs;
     if (ndkDir != null) {
       ndkCompiler = findNdkCompiler(ndkDir);
       if (ndkCompiler != null) {
         ndkCompilerArgs = computeNdkCompilerArgs(ndkDir);
-        if (ndkCompilerArgs == null) ndkCompiler = null;
+        if (ndkCompilerArgs == null) {
+          ndkCompiler = null;
+        }
       }
     }
 

--- a/packages/flutter_tools/lib/src/android/android_sdk.dart
+++ b/packages/flutter_tools/lib/src/android/android_sdk.dart
@@ -114,6 +114,8 @@ class AndroidSdk {
         if (validSdkDirectory(dir))
           return dir;
       }
+
+      return null;
     }
 
     String findNdk(String androidHomeDir) {

--- a/packages/flutter_tools/lib/src/android/android_sdk.dart
+++ b/packages/flutter_tools/lib/src/android/android_sdk.dart
@@ -57,63 +57,120 @@ String getAdbPath([AndroidSdk existingSdk]) {
 }
 
 class AndroidSdk {
-  AndroidSdk(this.directory) {
+  AndroidSdk(this.directory, [this.ndkDirectory, this.ndkCompiler,
+      this.ndkCompilerArgs]) {
     _init();
   }
 
   final String directory;
+  final String ndkDirectory;  // Can be `null`.
+  final String ndkCompiler;  // Can be `null`.
+  final List<String> ndkCompilerArgs;  // Can be `null`.
 
   List<AndroidSdkVersion> _sdkVersions;
   AndroidSdkVersion _latestVersion;
 
   static AndroidSdk locateAndroidSdk() {
-    String androidHomeDir;
+    String findAndroidHomeDir() {
+      String androidHomeDir;
+      if (config.containsKey('android-sdk')) {
+        androidHomeDir = config.getValue('android-sdk');
+      } else if (platform.environment.containsKey(kAndroidHome)) {
+        androidHomeDir = platform.environment[kAndroidHome];
+      } else if (platform.isLinux) {
+        if (homeDirPath != null)
+          androidHomeDir = fs.path.join(homeDirPath, 'Android', 'Sdk');
+      } else if (platform.isMacOS) {
+        if (homeDirPath != null)
+          androidHomeDir = fs.path.join(homeDirPath, 'Library', 'Android', 'sdk');
+      } else if (platform.isWindows) {
+        if (homeDirPath != null)
+          androidHomeDir = fs.path.join(homeDirPath, 'AppData', 'Local', 'Android', 'sdk');
+      }
 
-    if (config.containsKey('android-sdk')) {
-      androidHomeDir = config.getValue('android-sdk');
-    } else if (platform.environment.containsKey(kAndroidHome)) {
-      androidHomeDir = platform.environment[kAndroidHome];
-    } else if (platform.isLinux) {
-      if (homeDirPath != null)
-        androidHomeDir = fs.path.join(homeDirPath, 'Android', 'Sdk');
-    } else if (platform.isMacOS) {
-      if (homeDirPath != null)
-        androidHomeDir = fs.path.join(homeDirPath, 'Library', 'Android', 'sdk');
-    } else if (platform.isWindows) {
-      if (homeDirPath != null)
-        androidHomeDir = fs.path.join(homeDirPath, 'AppData', 'Local', 'Android', 'sdk');
+      if (androidHomeDir != null) {
+        if (validSdkDirectory(androidHomeDir))
+          return androidHomeDir;
+        if (validSdkDirectory(fs.path.join(androidHomeDir, 'sdk')))
+          return fs.path.join(androidHomeDir, 'sdk');
+      }
+
+      // in build-tools/$version/aapt
+      final List<File> aaptBins = os.whichAll('aapt');
+      for (File aaptBin in aaptBins) {
+        // Make sure we're using the aapt from the SDK.
+        aaptBin = fs.file(aaptBin.resolveSymbolicLinksSync());
+        final String dir = aaptBin.parent.parent.parent.path;
+        if (validSdkDirectory(dir))
+          return dir;
+      }
+
+      // in platform-tools/adb
+      final List<File> adbBins = os.whichAll('adb');
+      for (File adbBin in adbBins) {
+        // Make sure we're using the adb from the SDK.
+        adbBin = fs.file(adbBin.resolveSymbolicLinksSync());
+        final String dir = adbBin.parent.parent.path;
+        if (validSdkDirectory(dir))
+          return dir;
+      }
     }
 
-    if (androidHomeDir != null) {
-      if (validSdkDirectory(androidHomeDir))
-        return new AndroidSdk(androidHomeDir);
-      if (validSdkDirectory(fs.path.join(androidHomeDir, 'sdk')))
-        return new AndroidSdk(fs.path.join(androidHomeDir, 'sdk'));
+    String findNdk(String androidHomeDir) {
+      final ndkDirectory = fs.path.join(androidHomeDir, 'ndk-bundle');
+      if (fs.isDirectorySync(ndkDirectory)) {
+        return ndkDirectory;
+      }
+      return null;
     }
 
-    // in build-tools/$version/aapt
-    final List<File> aaptBins = os.whichAll('aapt');
-    for (File aaptBin in aaptBins) {
-      // Make sure we're using the aapt from the SDK.
-      aaptBin = fs.file(aaptBin.resolveSymbolicLinksSync());
-      final String dir = aaptBin.parent.parent.parent.path;
-      if (validSdkDirectory(dir))
-        return new AndroidSdk(dir);
+    String findNdkCompiler(String ndkDirectory) {
+      String directory;
+      if (platform.isLinux) {
+        directory = 'linux-x86_64';
+      } else if (platform.isMacOS) {
+        directory = 'darwin-x86_64';
+      }
+      if (directory != null) {
+        final ndkCompiler = fs.path.join(ndkDirectory,
+            'toolchains', 'arm-linux-androideabi-4.9', 'prebuilt', directory,
+            'bin', 'arm-linux-androideabi-gcc');
+        if (fs.isFileSync(ndkCompiler)) {
+          return ndkCompiler;
+        }
+      }
+      return null;
     }
 
-    // in platform-tools/adb
-    final List<File> adbBins = os.whichAll('adb');
-    for (File adbBin in adbBins) {
-      // Make sure we're using the adb from the SDK.
-      adbBin = fs.file(adbBin.resolveSymbolicLinksSync());
-      final String dir = adbBin.parent.parent.path;
-      if (validSdkDirectory(dir))
-        return new AndroidSdk(dir);
+    List<String> computeNdkCompilerArgs(String ndkDirectory) {
+      final armPlatform = fs.path.join(ndkDirectory, 'platforms', 'android-9',
+          'arch-arm');
+      if (fs.isDirectorySync(armPlatform)) {
+        return ['--sysroot', armPlatform];
+      }
+      return null;
     }
 
-    // No dice.
-    printTrace('Unable to locate an Android SDK.');
-    return null;
+    final String androidHomeDir = findAndroidHomeDir();
+    if (androidHomeDir == null) {
+      // No dice.
+      printTrace('Unable to locate an Android SDK.');
+      return null;
+    }
+
+    // Try to find the NDK compiler.  If we can't find it, it's also ok.
+    final ndkDir = findNdk(androidHomeDir);
+    String ndkCompiler;
+    List<String> ndkCompilerArgs;
+    if (ndkDir != null) {
+      ndkCompiler = findNdkCompiler(ndkDir);
+      if (ndkCompiler != null) {
+        ndkCompilerArgs = computeNdkCompilerArgs(ndkDir);
+        if (ndkCompilerArgs == null) ndkCompiler = null;
+      }
+    }
+
+    return new AndroidSdk(androidHomeDir, ndkDir, ndkCompiler, ndkCompilerArgs);
   }
 
   static bool validSdkDirectory(String dir) {

--- a/packages/flutter_tools/lib/src/android/android_workflow.dart
+++ b/packages/flutter_tools/lib/src/android/android_workflow.dart
@@ -119,6 +119,14 @@ class AndroidWorkflow extends DoctorValidator implements Workflow {
 
     messages.add(new ValidationMessage('Android SDK at ${androidSdk.directory}'));
 
+    messages.add(new ValidationMessage(androidSdk.ndkDirectory == null
+          ? 'Unable to locate Android NDK.\n'
+          : 'Android NDK at ${androidSdk.ndkDirectory}'));
+
+    messages.add(new ValidationMessage(androidSdk.ndkCompiler == null
+          ? 'Unable to locate compiler in Android NDK.\n'
+          : 'Compiler in Android NDK at ${androidSdk.ndkCompiler}'));
+
     String sdkVersionText;
     if (androidSdk.latestVersion != null) {
       sdkVersionText = 'Android SDK ${androidSdk.latestVersion.buildToolsVersionName}';

--- a/packages/flutter_tools/lib/src/android/gradle.dart
+++ b/packages/flutter_tools/lib/src/android/gradle.dart
@@ -4,6 +4,7 @@
 
 import 'dart:async';
 
+import '../android/android_sdk.dart';
 import '../artifacts.dart';
 import '../base/common.dart';
 import '../base/file_system.dart';
@@ -289,12 +290,17 @@ Future<Null> _buildGradleProjectV2(String gradle, BuildInfo buildInfo, String ta
   if (target != null) {
     command.add('-Ptarget=$target');
   }
-  if (buildInfo.previewDart2)
+  if (buildInfo.previewDart2) {
     command.add('-Ppreview-dart-2=true');
   if (buildInfo.extraFrontEndOptions != null)
     command.add('-Pextra-front-end-options=${buildInfo.extraFrontEndOptions}');
   if (buildInfo.extraGenSnapshotOptions != null)
     command.add('-Pextra-gen-snapshot-options=${buildInfo.extraGenSnapshotOptions}');
+  }
+  if (buildInfo.preferSharedLibrary && androidSdk.ndkCompiler != null) {
+    command.add('-Pprefer-shared-library=true');
+  }
+
   command.add(assembleTask);
   final int exitCode = await runCommandAndStreamOutput(
       command,

--- a/packages/flutter_tools/lib/src/build_info.dart
+++ b/packages/flutter_tools/lib/src/build_info.dart
@@ -13,7 +13,8 @@ class BuildInfo {
   const BuildInfo(this.mode, this.flavor,
       {this.previewDart2,
       this.extraFrontEndOptions,
-      this.extraGenSnapshotOptions});
+      this.extraGenSnapshotOptions,
+      this.preferSharedLibrary});
 
   final BuildMode mode;
   /// Represents a custom Android product flavor or an Xcode scheme, null for
@@ -32,6 +33,9 @@ class BuildInfo {
 
   /// Extra command-line options for gen_snapshot.
   final String extraGenSnapshotOptions;
+
+  // Whether to prefer AOT compiling to a *so file.
+  final bool preferSharedLibrary;
 
   static const BuildInfo debug = const BuildInfo(BuildMode.debug, null);
   static const BuildInfo profile = const BuildInfo(BuildMode.profile, null);

--- a/packages/flutter_tools/lib/src/commands/build_apk.dart
+++ b/packages/flutter_tools/lib/src/commands/build_apk.dart
@@ -11,9 +11,13 @@ class BuildApkCommand extends BuildSubCommand {
   BuildApkCommand() {
     usesTargetOption();
     addBuildModeFlags();
-    argParser.addFlag('preview-dart-2', negatable: false);
     usesFlavorOption();
     usesPubOption();
+
+    argParser
+      ..addFlag('preview-dart-2', negatable: false)
+      ..addFlag('prefer-shared-library', negatable: false,
+          help: 'Whether to prefer compiling to a *.so file (android only).');
   }
 
   @override

--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -161,7 +161,10 @@ abstract class FlutterCommand extends Command<Null> {
           : null,
       extraGenSnapshotOptions: argParser.options.containsKey(FlutterOptions.kExtraGenSnapshotOptions)
           ? argResults[FlutterOptions.kExtraGenSnapshotOptions]
-          : null);
+          : null,
+      preferSharedLibrary: argParser.options.containsKey('prefer-shared-library')
+        ? argResults['prefer-shared-library']
+        : false);
   }
 
   void setupApplicationPackages() {

--- a/packages/flutter_tools/test/android/android_sdk_test.dart
+++ b/packages/flutter_tools/test/android/android_sdk_test.dart
@@ -5,6 +5,9 @@
 import 'package:file/memory.dart';
 import 'package:flutter_tools/src/android/android_sdk.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
+import 'package:flutter_tools/src/base/version.dart';
+import 'package:flutter_tools/src/base/platform.dart';
+import 'package:flutter_tools/src/base/config.dart';
 import 'package:test/test.dart';
 
 import '../src/context.dart';
@@ -21,12 +24,14 @@ void main() {
 
     tearDown(() {
       sdkDir?.deleteSync(recursive: true);
+      sdkDir = null;
     });
 
     testUsingContext('parse sdk', () {
       sdkDir = _createSdkDirectory();
-      final AndroidSdk sdk = new AndroidSdk(sdkDir.path);
+      Config.instance.setValue('android-sdk', sdkDir.path);
 
+      final AndroidSdk sdk = AndroidSdk.locateAndroidSdk();
       expect(sdk.latestVersion, isNotNull);
       expect(sdk.latestVersion.sdkLevel, 23);
     }, overrides: <Type, Generator>{
@@ -35,17 +40,69 @@ void main() {
 
     testUsingContext('parse sdk N', () {
       sdkDir = _createSdkDirectory(withAndroidN: true);
-      final AndroidSdk sdk = new AndroidSdk(sdkDir.path);
+      Config.instance.setValue('android-sdk', sdkDir.path);
 
+      final AndroidSdk sdk = AndroidSdk.locateAndroidSdk();
       expect(sdk.latestVersion, isNotNull);
       expect(sdk.latestVersion.sdkLevel, 24);
     }, overrides: <Type, Generator>{
       FileSystem: () => fs,
     });
+
+    group('ndk', () {
+      const <String, String>{
+        'linux': 'linux-x86_64',
+        'macos': 'darwin-x86_64',
+      }.forEach((String os, String osDir) {
+        testUsingContext('detection on $os', () {
+          sdkDir = _createSdkDirectory(
+              withAndroidN: true, withNdkDir: osDir, withNdkSysroot: true);
+          Config.instance.setValue('android-sdk', sdkDir.path);
+
+          final String realSdkDir = sdkDir.path;
+          final String realNdkDir = fs.path.join(realSdkDir, 'ndk-bundle');
+          final String realNdkCompiler = fs.path.join(
+              realNdkDir,
+              'toolchains',
+              'arm-linux-androideabi-4.9',
+              'prebuilt',
+              osDir,
+              'bin',
+              'arm-linux-androideabi-gcc');
+          final String realNdkSysroot =
+              fs.path.join(realNdkDir, 'platforms', 'android-9', 'arch-arm');
+
+          final AndroidSdk sdk = AndroidSdk.locateAndroidSdk();
+          expect(sdk.directory, realSdkDir);
+          expect(sdk.ndkDirectory, realNdkDir);
+          expect(sdk.ndkCompiler, realNdkCompiler);
+          expect(sdk.ndkCompilerArgs, <String>['--sysroot', realNdkSysroot]);
+        }, overrides: <Type, Generator>{
+          Platform: () => new FakePlatform(operatingSystem: os),
+        });
+      });
+
+      for (String os in <String>['linux', 'macos']) {
+        testUsingContext('detection on $os (no ndk available)', () {
+          sdkDir = _createSdkDirectory(withAndroidN: true);
+          Config.instance.setValue('android-sdk', sdkDir.path);
+
+          final String realSdkDir = sdkDir.path;
+          final AndroidSdk sdk = AndroidSdk.locateAndroidSdk();
+          expect(sdk.directory, realSdkDir);
+          expect(sdk.ndkDirectory, null);
+          expect(sdk.ndkCompiler, null);
+          expect(sdk.ndkCompilerArgs, null);
+        }, overrides: <Type, Generator>{
+          Platform: () => new FakePlatform(operatingSystem: os),
+        });
+      }
+    });
   });
 }
 
-Directory _createSdkDirectory({ bool withAndroidN: false }) {
+Directory _createSdkDirectory(
+    {bool withAndroidN: false, String withNdkDir, bool withNdkSysroot: false}) {
   final Directory dir = fs.systemTempDirectory.createTempSync('android-sdk');
 
   _createSdkFile(dir, 'platform-tools/adb');
@@ -63,6 +120,23 @@ Directory _createSdkDirectory({ bool withAndroidN: false }) {
     _createSdkFile(dir, 'platforms/android-N/build.prop', contents: _buildProp);
   }
 
+  if (withNdkDir != null) {
+    final String ndkCompiler = fs.path.join(
+        'ndk-bundle',
+        'toolchains',
+        'arm-linux-androideabi-4.9',
+        'prebuilt',
+        withNdkDir,
+        'bin',
+        'arm-linux-androideabi-gcc');
+    _createSdkFile(dir, ndkCompiler);
+  }
+  if (withNdkSysroot) {
+    final String armPlatform =
+        fs.path.join('ndk-bundle', 'platforms', 'android-9', 'arch-arm');
+    _createDir(dir, armPlatform);
+  }
+
   return dir;
 }
 
@@ -72,6 +146,11 @@ void _createSdkFile(Directory dir, String filePath, { String contents }) {
   if (contents != null) {
     file.writeAsStringSync(contents, flush: true);
   }
+}
+
+void _createDir(Directory dir, String path) {
+  final Directory directory = fs.directory(fs.path.join(dir.path, path));
+  directory.createSync(recursive: true);
 }
 
 const String _buildProp = r'''

--- a/packages/flutter_tools/test/android/android_sdk_test.dart
+++ b/packages/flutter_tools/test/android/android_sdk_test.dart
@@ -5,7 +5,6 @@
 import 'package:file/memory.dart';
 import 'package:flutter_tools/src/android/android_sdk.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
-import 'package:flutter_tools/src/base/version.dart';
 import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/base/config.dart';
 import 'package:test/test.dart';

--- a/packages/flutter_tools/test/android/android_sdk_test.dart
+++ b/packages/flutter_tools/test/android/android_sdk_test.dart
@@ -78,6 +78,7 @@ void main() {
           expect(sdk.ndkCompiler, realNdkCompiler);
           expect(sdk.ndkCompilerArgs, <String>['--sysroot', realNdkSysroot]);
         }, overrides: <Type, Generator>{
+          FileSystem: () => fs,
           Platform: () => new FakePlatform(operatingSystem: os),
         });
       });
@@ -94,6 +95,7 @@ void main() {
           expect(sdk.ndkCompiler, null);
           expect(sdk.ndkCompilerArgs, null);
         }, overrides: <Type, Generator>{
+          FileSystem: () => fs,
           Platform: () => new FakePlatform(operatingSystem: os),
         });
       }


### PR DESCRIPTION
We would like to be able to use native tools (e.g. simpleperf, gdb) with
precompiled flutter apps.  The native tools work much better with *.so
files instead of the custom formats the Dart VM uses by default.

The reason for using blobs / instruction snapshots is that we do not
want to force flutter users to install the Android NDK.

This CL adds a `--prefer-shared-library` flag to e.g. `flutter build
apk` which will use the NDK compiler (if available) to turn the
precompiled app assembly file to an `*.so` file.  If the NDK compiler is
not available it will default to the default behavior.