### PR TITLE
Fix dependency inheritance

### DIFF
--- a/examples/flutter_gallery/lib/gallery/demo.dart
+++ b/examples/flutter_gallery/lib/gallery/demo.dart
@@ -109,7 +109,7 @@ class FullScreenCodeDialogState extends State<FullScreenCodeDialog> {
   String _exampleCode;
 
   @override
-  void didChangeDependencies() {
+  void didDependenciesChanged() {
     getExampleCode(widget.exampleCodeTag, DefaultAssetBundle.of(context)).then<Null>((String code) {
       if (mounted) {
         setState(() {
@@ -117,7 +117,7 @@ class FullScreenCodeDialogState extends State<FullScreenCodeDialog> {
         });
       }
     });
-    super.didChangeDependencies();
+    super.didDependenciesChanged();
   }
 
   @override

--- a/packages/flutter/lib/src/material/app_bar.dart
+++ b/packages/flutter/lib/src/material/app_bar.dart
@@ -485,8 +485,8 @@ class _FloatingAppBarState extends State<_FloatingAppBar> {
   ScrollPosition _position;
 
   @override
-  void didChangeDependencies() {
-    super.didChangeDependencies();
+  void didDependenciesChanged() {
+    super.didDependenciesChanged();
     if (_position != null)
       _position.isScrollingNotifier.removeListener(_isScrollingListener);
     _position = Scrollable.of(context)?.position;

--- a/packages/flutter/lib/src/material/refresh_indicator.dart
+++ b/packages/flutter/lib/src/material/refresh_indicator.dart
@@ -154,7 +154,7 @@ class RefreshIndicatorState extends State<RefreshIndicator> with TickerProviderS
   }
 
   @override
-  void didChangeDependencies() {
+  void didDependenciesChanged() {
     final ThemeData theme = Theme.of(context);
     _valueColor = new ColorTween(
       begin: (widget.color ?? theme.accentColor).withOpacity(0.0),
@@ -163,7 +163,7 @@ class RefreshIndicatorState extends State<RefreshIndicator> with TickerProviderS
       parent: _positionController,
       curve: const Interval(0.0, 1.0 / _kDragSizeFactorLimit)
     ));
-    super.didChangeDependencies();
+    super.didDependenciesChanged();
   }
 
   @override

--- a/packages/flutter/lib/src/material/scrollbar.dart
+++ b/packages/flutter/lib/src/material/scrollbar.dart
@@ -46,8 +46,8 @@ class _ScrollbarState extends State<Scrollbar> with TickerProviderStateMixin {
   _ScrollbarPainter _painter;
 
   @override
-  void didChangeDependencies() {
-    super.didChangeDependencies();
+  void didDependenciesChanged() {
+    super.didDependenciesChanged();
     _painter ??= new _ScrollbarPainter(this);
     _painter
       ..color = Theme.of(context).highlightColor

--- a/packages/flutter/lib/src/material/tabs.dart
+++ b/packages/flutter/lib/src/material/tabs.dart
@@ -582,8 +582,8 @@ class _TabBarState extends State<TabBar> {
   }
 
   @override
-  void didChangeDependencies() {
-    super.didChangeDependencies();
+  void didDependenciesChanged() {
+    super.didDependenciesChanged();
     _updateTabController();
   }
 
@@ -883,8 +883,8 @@ class _TabBarViewState extends State<TabBarView> {
   }
 
   @override
-  void didChangeDependencies() {
-    super.didChangeDependencies();
+  void didDependenciesChanged() {
+    super.didDependenciesChanged();
     _updateTabController();
     _currentIndex = _controller?.index;
     _pageController = new PageController(initialPage: _currentIndex ?? 0);

--- a/packages/flutter/lib/src/services/image_provider.dart
+++ b/packages/flutter/lib/src/services/image_provider.dart
@@ -195,8 +195,8 @@ class ImageConfiguration {
 ///   ImageInfo _imageInfo;
 ///
 ///   @override
-///   void didChangeDependencies() {
-///     super.didChangeDependencies();
+///   void didDependenciesChanged() {
+///     super.didDependenciesChanged();
 ///     // We call _getImage here because createLocalImageConfiguration() needs to
 ///     // be called again if the dependencies changed, in case the changes relate
 ///     // to the DefaultAssetBundle, MediaQuery, etc, which that method uses.

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -324,8 +324,8 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
   }
 
   @override
-  void didChangeDependencies() {
-    super.didChangeDependencies();
+  void didDependenciesChanged() {
+    super.didDependenciesChanged();
     if (!_didAutoFocus && widget.autofocus) {
       FocusScope.of(context).autofocus(widget.focusNode);
       _didAutoFocus = true;

--- a/packages/flutter/lib/src/widgets/fade_in_image.dart
+++ b/packages/flutter/lib/src/widgets/fade_in_image.dart
@@ -375,9 +375,9 @@ class _FadeInImageState extends State<FadeInImage> with TickerProviderStateMixin
   }
 
   @override
-  void didChangeDependencies() {
+  void didDependenciesChanged() {
     _resolveImage();
-    super.didChangeDependencies();
+    super.didDependenciesChanged();
   }
 
   @override

--- a/packages/flutter/lib/src/widgets/focus_scope.dart
+++ b/packages/flutter/lib/src/widgets/focus_scope.dart
@@ -86,8 +86,8 @@ class _FocusScopeState extends State<FocusScope> {
   bool _didAutofocus = false;
 
   @override
-  void didChangeDependencies() {
-    super.didChangeDependencies();
+  void didDependenciesChanged() {
+    super.didDependenciesChanged();
     if (!_didAutofocus && widget.autofocus) {
       FocusScope.of(context).setFirstFocus(widget.node);
       _didAutofocus = true;

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -712,7 +712,7 @@ abstract class StatelessWidget extends Widget {
 /// [InheritedWidget]s. These will typically rebuild many times during the
 /// application's lifetime, and it is therefore important to minimise the impact
 /// of rebuilding such a widget. (They may also use [State.initState] or
-/// [State.didChangeDependencies] and allocate resources, but the important part
+/// [State.didDependenciesChanged] and allocate resources, but the important part
 /// is that they rebuild.)
 ///
 /// There are several techniques one can use to minimize the impact of
@@ -866,7 +866,7 @@ enum _StateLifecycle {
   created,
 
   /// The [State.initState] method has been called but the [State] object is
-  /// not yet ready to build. [State.didChangeDependencies] is called at this time.
+  /// not yet ready to build. [State.didDependenciesChanged] is called at this time.
   initialized,
 
   /// The [State] object is ready to build and [State.dispose] has not yet been
@@ -912,10 +912,10 @@ typedef void StateSetter(VoidCallback fn);
 ///    [BuildContext] or the widget, which are available as the [context] and
 ///    [widget] properties, respectively, when the [initState] method is
 ///    called.
-///  * The framework calls [didChangeDependencies]. Subclasses of [State] should
-///    override [didChangeDependencies] to perform initialization involving
+///  * The framework calls [didDependenciesChanged]. Subclasses of [State] should
+///    override [didDependenciesChanged] to perform initialization involving
 ///    [InheritedWidget]s. If [BuildContext.inheritFromWidgetOfExactType] is
-///    called, the [didChangeDependencies] method will be called again if the
+///    called, the [didDependenciesChanged] method will be called again if the
 ///    inherited widgets subsequently change or if the widget moves in the tree.
 ///  * At this point, the [State] object is fully initialized and the framework
 ///    might call its [build] method any number of times to obtain a
@@ -1031,7 +1031,7 @@ abstract class State<T extends StatefulWidget> extends Diagnosticable {
   /// [didUpdateWidget], and then unsubscribe from the object in [dispose].
   ///
   /// You cannot use [BuildContext.inheritFromWidgetOfExactType] from this
-  /// method. However, [didChangeDependencies] will be called immediately
+  /// method. However, [didDependenciesChanged] will be called immediately
   /// following this method, and [BuildContext.inheritFromWidgetOfExactType] can
   /// be used there.
   ///
@@ -1350,7 +1350,7 @@ abstract class State<T extends StatefulWidget> extends Diagnosticable {
   /// expensive to do for every build.
   @protected
   @mustCallSuper
-  void didChangeDependencies() { }
+  void didDependenciesChanged() { }
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder description) {
@@ -1912,12 +1912,12 @@ abstract class BuildContext {
   /// again if the inherited value were to change. To ensure that the widget
   /// correctly updates itself when the inherited value changes, only call this
   /// (directly or indirectly) from build methods, layout and paint callbacks, or
-  /// from [State.didChangeDependencies].
+  /// from [State.didDependenciesChanged].
   ///
   /// This method should not be called from [State.deactivate] or [State.dispose]
   /// because the element tree is no longer stable at that time. To refer to
   /// an ancestor from one of those methods, save a reference to the ancestor
-  /// in [State.didChangeDependencies].
+  /// in [State.didDependenciesChanged].
   ///
   /// It is also possible to call this from interaction event handlers (e.g.
   /// gesture callbacks) or timers, to obtain a value once, if that value is not
@@ -1927,7 +1927,7 @@ abstract class BuildContext {
   /// the widget being rebuilt more often.
   ///
   /// Once a widget registers a dependency on a particular type by calling this
-  /// method, it will be rebuilt, and [State.didChangeDependencies] will be
+  /// method, it will be rebuilt, and [State.didDependenciesChanged] will be
   /// called, whenever changes occur relating to that widget until the next time
   /// the widget or one of its ancestors is moved (for example, because an
   /// ancestor is added or removed).
@@ -1941,13 +1941,13 @@ abstract class BuildContext {
   /// This method does not establish a relationship with the target in the way
   /// that [inheritFromWidgetOfExactType] does. It is normally used by such
   /// widgets to obtain their corresponding [InheritedElement] object so that they
-  /// can call [InheritedElement.dispatchDidChangeDependencies] to actually
+  /// can call [InheritedElement.dispatchDidDependenciesChanged] to actually
   /// notify the widgets that _did_ register such a relationship.
   ///
   /// This method should not be called from [State.deactivate] or [State.dispose]
   /// because the element tree is no longer stable at that time. To refer to
   /// an ancestor from one of those methods, save a reference to the ancestor
-  /// by calling [inheritFromWidgetOfExactType] in [State.didChangeDependencies].
+  /// by calling [inheritFromWidgetOfExactType] in [State.didDependenciesChanged].
   InheritedElement ancestorInheritedElementForWidgetOfExactType(Type targetType);
 
   /// Returns the nearest ancestor widget of the given type, which must be the
@@ -1966,7 +1966,7 @@ abstract class BuildContext {
   /// This method should not be called from [State.deactivate] or [State.dispose]
   /// because the widget tree is no longer stable at that time. To refer to
   /// an ancestor from one of those methods, save a reference to the ancestor
-  /// by calling [inheritFromWidgetOfExactType] in [State.didChangeDependencies].
+  /// by calling [inheritFromWidgetOfExactType] in [State.didDependenciesChanged].
   Widget ancestorWidgetOfExactType(Type targetType);
 
   /// Returns the [State] object of the nearest ancestor [StatefulWidget] widget
@@ -1992,7 +1992,7 @@ abstract class BuildContext {
   /// This method should not be called from [State.deactivate] or [State.dispose]
   /// because the widget tree is no longer stable at that time. To refer to
   /// an ancestor from one of those methods, save a reference to the ancestor
-  /// by calling [inheritFromWidgetOfExactType] in [State.didChangeDependencies].
+  /// by calling [inheritFromWidgetOfExactType] in [State.didDependenciesChanged].
   ///
   /// Example:
   ///
@@ -2026,7 +2026,7 @@ abstract class BuildContext {
   /// This method should not be called from [State.deactivate] or [State.dispose]
   /// because the widget tree is no longer stable at that time. To refer to
   /// an ancestor from one of those methods, save a reference to the ancestor
-  /// by calling [inheritFromWidgetOfExactType] in [State.didChangeDependencies].
+  /// by calling [inheritFromWidgetOfExactType] in [State.didDependenciesChanged].
   ///
   /// Calling this method is relatively expensive (O(N) in the depth of the
   /// tree). Only call this method if the distance from this widget to the
@@ -2046,7 +2046,7 @@ abstract class BuildContext {
   /// This method should not be called from [State.deactivate] or [State.dispose]
   /// because the element tree is no longer stable at that time. To refer to
   /// an ancestor from one of those methods, save a reference to the ancestor
-  /// by calling [inheritFromWidgetOfExactType] in [State.didChangeDependencies].
+  /// by calling [inheritFromWidgetOfExactType] in [State.didDependenciesChanged].
   void visitAncestorElements(bool visitor(Element element));
 
   /// Walks the children of this widget.
@@ -3278,7 +3278,7 @@ abstract class Element extends DiagnosticableTree implements BuildContext {
           'At this point the state of the widget\'s element tree is no longer '
           'stable. To safely refer to a widget\'s ancestor in its dispose() method, '
           'save a reference to the ancestor by calling inheritFromWidgetOfExactType() '
-          'in the widget\'s didChangeDependencies() method.\n'
+          'in the widget\'s didDependenciesChanged() method.\n'
         );
       }
       return true;
@@ -3376,7 +3376,7 @@ abstract class Element extends DiagnosticableTree implements BuildContext {
 
   void _checkDependenciesChanged() {
     if (_dependenciesChanged) {
-      didChangeDependencies();
+      didDependenciesChanged();
       _dependenciesChanged = false;
     }
   }
@@ -3393,9 +3393,9 @@ abstract class Element extends DiagnosticableTree implements BuildContext {
   /// not be called if this element is unmounted later in this frame.
   @protected
   @mustCallSuper
-  void didChangeDependencies() {
+  void didDependenciesChanged() {
     assert(_active && _debugLifecycleState == _ElementLifecycle.active);
-    assert(_debugCheckOwnerBuildTargetExists('didChangeDependencies'));
+    assert(_debugCheckOwnerBuildTargetExists('didDependenciesChanged'));
     assert(owner._debugCurrentBuildTarget == this);
   }
 
@@ -3769,7 +3769,7 @@ class StatefulElement extends ComponentElement {
       _debugSetAllowIgnoredCallsToMarkNeedsBuild(false);
     }
     assert(() { _state._debugLifecycleState = _StateLifecycle.initialized; return true; }());
-    _state.didChangeDependencies();
+    _state.didDependenciesChanged();
     assert(() { _state._debugLifecycleState = _StateLifecycle.ready; return true; }());
     super._firstBuild();
   }
@@ -3838,7 +3838,7 @@ class StatefulElement extends ComponentElement {
           'then the rebuilt dependent widget will not reflect the changes in the '
           'inherited widget.\n'
           'Typically references to to inherited widgets should occur in widget build() methods. Alternatively, '
-          'initialization based on inherited widgets can be placed in the didChangeDependencies method, which '
+          'initialization based on inherited widgets can be placed in the didDependenciesChanged method, which '
           'is called after initState and whenever the dependencies change thereafter.'
         );
       }
@@ -3868,9 +3868,9 @@ class StatefulElement extends ComponentElement {
   }
 
   @override
-  void didChangeDependencies() {
-    super.didChangeDependencies();
-    _state.didChangeDependencies();
+  void didDependenciesChanged() {
+    super.didDependenciesChanged();
+    _state.didDependenciesChanged();
   }
 
   @override
@@ -4047,7 +4047,7 @@ abstract class InheritedElement extends ProxyElement {
   void notifyClients(InheritedWidget oldWidget) {
     if (!widget.updateShouldNotify(oldWidget))
       return;
-    dispatchDidChangeDependencies();
+    dispatchDidDependenciesChanged();
   }
 
   /// Notifies all dependent elements that this inherited widget has changed.
@@ -4058,7 +4058,7 @@ abstract class InheritedElement extends ProxyElement {
   /// the build phase. [InheritedWidget] subclasses can also call this directly
   /// by first obtaining their [InheritedElement] using
   /// [BuildContext.ancestorInheritedElementForWidgetOfExactType].
-  void dispatchDidChangeDependencies() {
+  void dispatchDidDependenciesChanged() {
     for (Element dependent in dependents) {
       assert(() {
         // check that it really is our descendant

--- a/packages/flutter/lib/src/widgets/image.dart
+++ b/packages/flutter/lib/src/widgets/image.dart
@@ -30,7 +30,7 @@ export 'package:flutter/services.dart' show
 ///
 /// If this is not called from a build method, then it should be reinvoked
 /// whenever the dependencies change, e.g. by calling it from
-/// [State.didChangeDependencies], so that any changes in the environement are
+/// [State.didDependenciesChanged], so that any changes in the environement are
 /// picked up (e.g. if the device pixel ratio changes).
 ///
 /// See also:
@@ -445,9 +445,9 @@ class _ImageState extends State<Image> {
   ImageInfo _imageInfo;
 
   @override
-  void didChangeDependencies() {
+  void didDependenciesChanged() {
     _resolveImage();
-    super.didChangeDependencies();
+    super.didDependenciesChanged();
   }
 
   @override

--- a/packages/flutter/lib/src/widgets/nested_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/nested_scroll_view.dart
@@ -130,8 +130,8 @@ class _NestedScrollViewState extends State<NestedScrollView> {
   }
 
   @override
-  void didChangeDependencies() {
-    super.didChangeDependencies();
+  void didDependenciesChanged() {
+    super.didDependenciesChanged();
     _coordinator.updateParent();
   }
 

--- a/packages/flutter/lib/src/widgets/routes.dart
+++ b/packages/flutter/lib/src/widgets/routes.dart
@@ -872,14 +872,14 @@ abstract class ModalRoute<T> extends TransitionRoute<T> with LocalHistoryRoute<T
   /// case, use the [Form.onWillPop] property to register the callback.
   ///
   /// To register a callback manually, look up the enclosing [ModalRoute] in a
-  /// [State.didChangeDependencies] callback:
+  /// [State.didDependenciesChanged] callback:
   ///
   /// ```dart
   /// ModalRoute<dynamic> _route;
   ///
   /// @override
-  /// void didChangeDependencies() {
-  ///  super.didChangeDependencies();
+  /// void didDependenciesChanged() {
+  ///  super.didDependenciesChanged();
   ///  _route?.removeScopedWillPopCallback(askTheUserIfTheyAreSure);
   ///  _route = ModalRoute.of(context);
   ///  _route?.addScopedWillPopCallback(askTheUserIfTheyAreSure);
@@ -1066,8 +1066,8 @@ abstract class PopupRoute<T> extends ModalRoute<T> {
 /// class RouteAwareWidgetState extends State<RouteAwareWidget> with RouteAware {
 ///
 ///   @override
-///   void didChangeDependencies() {
-///     super.didChangeDependencies();
+///   void didDependenciesChanged() {
+///     super.didDependenciesChanged();
 ///     routeObserver.subscribe(this, ModalRoute.of(context));
 ///   }
 ///

--- a/packages/flutter/lib/src/widgets/scrollable.dart
+++ b/packages/flutter/lib/src/widgets/scrollable.dart
@@ -293,8 +293,8 @@ class ScrollableState extends State<Scrollable> with TickerProviderStateMixin
   }
 
   @override
-  void didChangeDependencies() {
-    super.didChangeDependencies();
+  void didDependenciesChanged() {
+    super.didDependenciesChanged();
     _updatePosition();
   }
 

--- a/packages/flutter/lib/src/widgets/ticker_provider.dart
+++ b/packages/flutter/lib/src/widgets/ticker_provider.dart
@@ -120,10 +120,10 @@ abstract class SingleTickerProviderStateMixin extends State<dynamic> implements 
   }
 
   @override
-  void didChangeDependencies() {
+  void didDependenciesChanged() {
     if (_ticker != null)
       _ticker.muted = !TickerMode.of(context);
-    super.didChangeDependencies();
+    super.didDependenciesChanged();
   }
 
   @override
@@ -200,13 +200,13 @@ abstract class TickerProviderStateMixin extends State<dynamic> implements Ticker
   }
 
   @override
-  void didChangeDependencies() {
+  void didDependenciesChanged() {
     final bool muted = !TickerMode.of(context);
     if (_tickers != null) {
       for (Ticker ticker in _tickers)
         ticker.muted = muted;
     }
-    super.didChangeDependencies();
+    super.didDependenciesChanged();
   }
 
   @override

--- a/packages/flutter/lib/src/widgets/will_pop_scope.dart
+++ b/packages/flutter/lib/src/widgets/will_pop_scope.dart
@@ -44,8 +44,8 @@ class _WillPopScopeState extends State<WillPopScope> {
   ModalRoute<dynamic> _route;
 
   @override
-  void didChangeDependencies() {
-    super.didChangeDependencies();
+  void didDependenciesChanged() {
+    super.didDependenciesChanged();
     if (widget.onWillPop != null)
       _route?.removeScopedWillPopCallback(widget.onWillPop);
     _route = ModalRoute.of(context);

--- a/packages/flutter/test/material/will_pop_test.dart
+++ b/packages/flutter/test/material/will_pop_test.dart
@@ -18,8 +18,8 @@ class SamplePageState extends State<SamplePage> {
   Future<bool> _callback() async => willPopValue;
 
   @override
-  void didChangeDependencies() {
-    super.didChangeDependencies();
+  void didDependenciesChanged() {
+    super.didDependenciesChanged();
     _route?.removeScopedWillPopCallback(_callback);
     _route = ModalRoute.of(context);
     _route?.addScopedWillPopCallback(_callback);
@@ -247,8 +247,8 @@ void main() {
     expect(find.text('Sample Form'), findsOneWidget);
 
     // Do it again. Note that each time the Alert is shown and dismissed
-    // the FormState's didChangeDependencies() method runs. We're making sure
-    // that the didChangeDependencies() method doesn't add an extra willPop
+    // the FormState's didDependenciesChanged() method runs. We're making sure
+    // that the didDependenciesChanged() method doesn't add an extra willPop
     // callback.
     await tester.tap(find.byTooltip('Back'));
     await tester.pump(); // Start the pop "back" operation.

--- a/packages/flutter/test/widgets/focus_test.dart
+++ b/packages/flutter/test/widgets/focus_test.dart
@@ -26,8 +26,8 @@ class TestFocusableState extends State<TestFocusable> {
   bool _didAutofocus = false;
 
   @override
-  void didChangeDependencies() {
-    super.didChangeDependencies();
+  void didDependenciesChanged() {
+    super.didDependenciesChanged();
     if (!_didAutofocus && widget.autofocus) {
       _didAutofocus = true;
       FocusScope.of(context).autofocus(focusNode);

--- a/packages/flutter/test/widgets/inherited_dependencies_test.dart
+++ b/packages/flutter/test/widgets/inherited_dependencies_test.dart
@@ -49,9 +49,9 @@ class ConditionalTextElement extends StatefulElement {
   ConditionalText get widget => super.widget;
 
   @override
-  void didChangeDependencies() {
-    super.didChangeDependencies();
-    widget.logger('Element.didChangeDependencies');
+  void didDependenciesChanged() {
+    super.didDependenciesChanged();
+    widget.logger('Element.didDependenciesChanged');
   }
 }
 
@@ -68,9 +68,9 @@ class ConditionalTextState extends State<ConditionalText> {
   }
 
   @override
-  void didChangeDependencies() {
-    super.didChangeDependencies();
-    widget.logger('State.didChangeDependencies');
+  void didDependenciesChanged() {
+    super.didDependenciesChanged();
+    widget.logger('State.didDependenciesChanged');
   }
 }
 
@@ -98,16 +98,16 @@ Widget buildHierarchicalInheritedWidgetTree({bool condition, String text, Widget
 }
 
 void main() {
-  testWidgets('State.didChangeDependencies is called before first build', (WidgetTester tester) async {
+  testWidgets('State.didDependenciesChanged is called before first build', (WidgetTester tester) async {
     final List<String> log = <String>[];
 
-    await tester.pumpWidget(new ConditionalText(logger: newLogger(log, excludes: <String>['Element.didChangeDependencies'])));
-    expect(log, <String>['State.didChangeDependencies', 'build']);
+    await tester.pumpWidget(new ConditionalText(logger: newLogger(log, excludes: <String>['Element.didDependenciesChanged'])));
+    expect(log, <String>['State.didDependenciesChanged', 'build']);
   });
 
-  testWidgets('State.didChangeDependencies is not called for elements about to unmount', (WidgetTester tester) async {
+  testWidgets('State.didDependenciesChanged is not called for elements about to unmount', (WidgetTester tester) async {
     final List<String> log = <String>[];
-    final Widget widget = new ConditionalText(logger: newLogger(log, excludes: <String>['Element.didChangeDependencies']));
+    final Widget widget = new ConditionalText(logger: newLogger(log, excludes: <String>['Element.didDependenciesChanged']));
 
     await tester.pumpWidget(buildHierarchicalInheritedWidgetTree(
         condition: true,
@@ -124,9 +124,9 @@ void main() {
     expect(log, <String>[]);
   });
 
-  testWidgets('State.didChangeDependencies is called only once if multiple dependencies changed', (WidgetTester tester) async {
+  testWidgets('State.didDependenciesChanged is called only once if multiple dependencies changed', (WidgetTester tester) async {
     final List<String> log = <String>[];
-    final Widget widget = new ConditionalText(logger: newLogger(log, excludes: <String>['Element.didChangeDependencies']));
+    final Widget widget = new ConditionalText(logger: newLogger(log, excludes: <String>['Element.didDependenciesChanged']));
 
     await tester.pumpWidget(buildHierarchicalInheritedWidgetTree(
         condition: true,
@@ -140,19 +140,19 @@ void main() {
         text: 'Bar',
         child: widget,
     ));
-    expect(log, <String>['State.didChangeDependencies', 'build']);
+    expect(log, <String>['State.didDependenciesChanged', 'build']);
   });
 
-  testWidgets('Element.didChangeDependencies is not called in first build', (WidgetTester tester) async {
+  testWidgets('Element.didDependenciesChanged is not called in first build', (WidgetTester tester) async {
     final List<String> log = <String>[];
 
-    await tester.pumpWidget(new ConditionalText(logger: newLogger(log, excludes: <String>['State.didChangeDependencies'])));
+    await tester.pumpWidget(new ConditionalText(logger: newLogger(log, excludes: <String>['State.didDependenciesChanged'])));
     expect(log, <String>['build']);
   });
 
-  testWidgets('Element.didChangeDependencies is not called for elements about to unmount', (WidgetTester tester) async {
+  testWidgets('Element.didDependenciesChanged is not called for elements about to unmount', (WidgetTester tester) async {
     final List<String> log = <String>[];
-    final Widget widget = new ConditionalText(logger: newLogger(log, excludes: <String>['State.didChangeDependencies']));
+    final Widget widget = new ConditionalText(logger: newLogger(log, excludes: <String>['State.didDependenciesChanged']));
 
     await tester.pumpWidget(buildHierarchicalInheritedWidgetTree(
       condition: true,
@@ -169,9 +169,9 @@ void main() {
     expect(log, <String>[]);
   });
 
-  testWidgets('Element.didChangeDependencies is called only once if multiple dependencies changed', (WidgetTester tester) async {
+  testWidgets('Element.didDependenciesChanged is called only once if multiple dependencies changed', (WidgetTester tester) async {
     final List<String> log = <String>[];
-    final Widget widget = new ConditionalText(logger: newLogger(log, excludes: <String>['State.didChangeDependencies']));
+    final Widget widget = new ConditionalText(logger: newLogger(log, excludes: <String>['State.didDependenciesChanged']));
 
     await tester.pumpWidget(buildHierarchicalInheritedWidgetTree(
       condition: true,
@@ -185,10 +185,10 @@ void main() {
       text: 'Bar',
       child: widget,
     ));
-    expect(log, <String>['Element.didChangeDependencies', 'build']);
+    expect(log, <String>['Element.didDependenciesChanged', 'build']);
   });
 
-  testWidgets('didChangeDependencies is not called due to outdated dependency change', (WidgetTester tester) async {
+  testWidgets('didDependenciesChanged is not called due to outdated dependency change', (WidgetTester tester) async {
     final List<String> log = <String>[];
     final Widget widget = new ConditionalText(logger: newLogger(log));
 
@@ -213,7 +213,7 @@ void main() {
     expect(log, <String>[]);
   });
 
-  testWidgets('InheritedElement.dispatchDidChangeDependencies is allowed to call outside build phase', (WidgetTester tester) async {
+  testWidgets('InheritedElement.dispatchDidDependenciesChanged is allowed to call outside build phase', (WidgetTester tester) async {
     InheritedElement inheritedElement;
     bool rebuild;
 
@@ -231,7 +231,7 @@ void main() {
     ));
 
     rebuild = false;
-    inheritedElement.dispatchDidChangeDependencies();
+    inheritedElement.dispatchDidDependenciesChanged();
     await tester.pump();
     expect(rebuild, true);
   });

--- a/packages/flutter/test/widgets/inherited_dependencies_test.dart
+++ b/packages/flutter/test/widgets/inherited_dependencies_test.dart
@@ -1,0 +1,238 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter/widgets.dart';
+
+class ConditionInherited extends InheritedWidget {
+  const ConditionInherited({this.value, Key key, Widget child}) : super(key: key, child: child);
+
+  final bool value;
+
+  static bool valueOf(BuildContext context) {
+    final ConditionInherited widget = context.inheritFromWidgetOfExactType(ConditionInherited);
+    return widget?.value ?? true;
+  }
+
+  @override
+  bool updateShouldNotify(ConditionInherited oldWidget) => value != oldWidget.value;
+}
+
+class StringInherited extends InheritedWidget {
+  const StringInherited({this. value, Key key, Widget child}) : super(key: key, child: child);
+
+  final String value;
+
+  static String valueOf(BuildContext context) {
+    final StringInherited widget = context.inheritFromWidgetOfExactType(StringInherited);
+    return widget?.value ?? 'Missing string value';
+  }
+
+  @override
+  bool updateShouldNotify(StringInherited oldWidget) => value != oldWidget.value;
+}
+
+class ConditionalText extends StatefulWidget {
+  const ConditionalText({this.textKey, this.logger, Key key}) : super(key: key);
+
+  final Key textKey;
+  final Logger logger;
+
+  @override
+  ConditionalTextElement createElement() => new ConditionalTextElement(this);
+
+  @override
+  ConditionalTextState createState() => new ConditionalTextState();
+}
+
+class ConditionalTextElement extends StatefulElement {
+  ConditionalTextElement(ConditionalText widget) : super(widget);
+
+  @override
+  ConditionalText get widget => super.widget;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    widget.logger('Element.didChangeDependencies');
+  }
+}
+
+class ConditionalTextState extends State<ConditionalText> {
+  @override
+  Widget build(BuildContext context) {
+    widget.logger('build');
+    final bool condition = ConditionInherited.valueOf(context);
+    if (condition) {
+      final String string = StringInherited.valueOf(context);
+      return new Text(string, key: widget.textKey, textDirection: TextDirection.ltr);
+    }
+    return new Text('No Text', key: widget.textKey, textDirection: TextDirection.ltr);
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    widget.logger('State.didChangeDependencies');
+  }
+}
+
+typedef void Logger(String s);
+
+Logger newLogger(List<String> log, {String prefix = '', List<String> excludes = const <String>[]}) {
+  if (prefix != '')
+    prefix = prefix + ' ';
+  return (String s) {
+    if (excludes.contains(s)) {
+      return;
+    }
+    log.add(prefix + s);
+  };
+}
+
+Widget buildHierarchicalInheritedWidgetTree({bool condition, String text, Widget child}) {
+  return new StringInherited(
+      value: text,
+      child: new ConditionInherited(
+        value: condition,
+        child: child,
+      )
+  );
+}
+
+void main() {
+  testWidgets('State.didChangeDependencies is called before first build', (WidgetTester tester) async {
+    final List<String> log = <String>[];
+
+    await tester.pumpWidget(new ConditionalText(logger: newLogger(log, excludes: <String>['Element.didChangeDependencies'])));
+    expect(log, <String>['State.didChangeDependencies', 'build']);
+  });
+
+  testWidgets('State.didChangeDependencies is not called for elements about to unmount', (WidgetTester tester) async {
+    final List<String> log = <String>[];
+    final Widget widget = new ConditionalText(logger: newLogger(log, excludes: <String>['Element.didChangeDependencies']));
+
+    await tester.pumpWidget(buildHierarchicalInheritedWidgetTree(
+        condition: true,
+        text: 'Foo',
+        child: widget,
+    ));
+
+    log.clear();
+    await tester.pumpWidget(buildHierarchicalInheritedWidgetTree(
+        condition: false,
+        text: 'Bar',
+        child: const Text('text', textDirection: TextDirection.ltr),
+    ));
+    expect(log, <String>[]);
+  });
+
+  testWidgets('State.didChangeDependencies is called only once if multiple dependencies changed', (WidgetTester tester) async {
+    final List<String> log = <String>[];
+    final Widget widget = new ConditionalText(logger: newLogger(log, excludes: <String>['Element.didChangeDependencies']));
+
+    await tester.pumpWidget(buildHierarchicalInheritedWidgetTree(
+        condition: true,
+        text: 'Foo',
+        child: widget,
+    ));
+
+    log.clear();
+    await tester.pumpWidget(buildHierarchicalInheritedWidgetTree(
+        condition: false,
+        text: 'Bar',
+        child: widget,
+    ));
+    expect(log, <String>['State.didChangeDependencies', 'build']);
+  });
+
+  testWidgets('Element.didChangeDependencies is not called in first build', (WidgetTester tester) async {
+    final List<String> log = <String>[];
+
+    await tester.pumpWidget(new ConditionalText(logger: newLogger(log, excludes: <String>['State.didChangeDependencies'])));
+    expect(log, <String>['build']);
+  });
+
+  testWidgets('Element.didChangeDependencies is not called for elements about to unmount', (WidgetTester tester) async {
+    final List<String> log = <String>[];
+    final Widget widget = new ConditionalText(logger: newLogger(log, excludes: <String>['State.didChangeDependencies']));
+
+    await tester.pumpWidget(buildHierarchicalInheritedWidgetTree(
+      condition: true,
+      text: 'Foo',
+      child: widget,
+    ));
+
+    log.clear();
+    await tester.pumpWidget(buildHierarchicalInheritedWidgetTree(
+      condition: false,
+      text: 'Bar',
+      child: const Text('text', textDirection: TextDirection.ltr),
+    ));
+    expect(log, <String>[]);
+  });
+
+  testWidgets('Element.didChangeDependencies is called only once if multiple dependencies changed', (WidgetTester tester) async {
+    final List<String> log = <String>[];
+    final Widget widget = new ConditionalText(logger: newLogger(log, excludes: <String>['State.didChangeDependencies']));
+
+    await tester.pumpWidget(buildHierarchicalInheritedWidgetTree(
+      condition: true,
+      text: 'Foo',
+      child: widget,
+    ));
+
+    log.clear();
+    await tester.pumpWidget(buildHierarchicalInheritedWidgetTree(
+      condition: false,
+      text: 'Bar',
+      child: widget,
+    ));
+    expect(log, <String>['Element.didChangeDependencies', 'build']);
+  });
+
+  testWidgets('didChangeDependencies is not called due to outdated dependency change', (WidgetTester tester) async {
+    final List<String> log = <String>[];
+    final Widget widget = new ConditionalText(logger: newLogger(log));
+
+    await tester.pumpWidget(buildHierarchicalInheritedWidgetTree(
+      condition: true,
+      text: 'Foo',
+      child: widget,
+    ));
+
+    await tester.pumpWidget(buildHierarchicalInheritedWidgetTree(
+      condition: false,
+      text: 'Bar',
+      child: widget,
+    ));
+
+    log.clear();
+    await tester.pumpWidget(buildHierarchicalInheritedWidgetTree(
+      condition: false,
+      text: 'FooBar',
+      child: widget,
+    ));
+    expect(log, <String>[]);
+  });
+
+  testWidgets('InheritedElement.dispatchDidChangeDependencies is allowed to call outside build phase', (WidgetTester tester) async {
+    InheritedElement inheritedElement;
+    bool rebuild;
+
+    final Widget widget = new Builder(builder: (BuildContext context) {
+      rebuild = true;
+      context.inheritFromWidgetOfExactType(ConditionInherited);
+      inheritedElement = context.ancestorInheritedElementForWidgetOfExactType(ConditionInherited);
+      return const Text('text', textDirection: TextDirection.ltr);
+    });
+
+    await tester.pumpWidget(buildHierarchicalInheritedWidgetTree(
+      condition: true,
+      text: 'Foo',
+      child: widget,
+    ));
+
+    rebuild = false;
+    inheritedElement.dispatchDidChangeDependencies();
+    await tester.pump();
+    expect(rebuild, true);
+  });
+}

--- a/packages/flutter/test/widgets/linked_scroll_view_test.dart
+++ b/packages/flutter/test/widgets/linked_scroll_view_test.dart
@@ -269,8 +269,8 @@ class _TestState extends State<Test> {
   }
 
   @override
-  void didChangeDependencies() {
-    super.didChangeDependencies();
+  void didDependenciesChanged() {
+    super.didDependenciesChanged();
     _beforeController.setParent(PrimaryScrollController.of(context));
     _afterController.setParent(PrimaryScrollController.of(context));
   }

--- a/packages/flutter/test/widgets/scrollable_of_test.dart
+++ b/packages/flutter/test/widgets/scrollable_of_test.dart
@@ -19,12 +19,12 @@ class _ScrollPositionListenerState extends State<ScrollPositionListener> {
   ScrollPosition _position;
 
   @override
-  void didChangeDependencies() {
-    super.didChangeDependencies();
+  void didDependenciesChanged() {
+    super.didDependenciesChanged();
     _position?.removeListener(listener);
     _position = Scrollable.of(context)?.position;
     _position?.addListener(listener);
-    widget.log('didChangeDependencies ${_position?.pixels}');
+    widget.log('didDependenciesChanged ${_position?.pixels}');
   }
 
   @override
@@ -62,13 +62,13 @@ void main() {
     }
 
     await tester.pumpWidget(buildFrame(null));
-    expect(logValue, 'didChangeDependencies 0.0');
+    expect(logValue, 'didDependenciesChanged 0.0');
 
     controller.jumpTo(100.0);
     expect(logValue, 'listener 100.0');
 
     await tester.pumpWidget(buildFrame(const ClampingScrollPhysics()));
-    expect(logValue, 'didChangeDependencies 100.0');
+    expect(logValue, 'didDependenciesChanged 100.0');
 
     controller.jumpTo(200.0);
     expect(logValue, 'listener 200.0');
@@ -77,7 +77,7 @@ void main() {
     expect(logValue, 'listener 300.0');
 
     await tester.pumpWidget(buildFrame(const BouncingScrollPhysics()));
-    expect(logValue, 'didChangeDependencies 300.0');
+    expect(logValue, 'didDependenciesChanged 300.0');
 
     controller.jumpTo(400.0);
     expect(logValue, 'listener 400.0');

--- a/packages/flutter_localizations/test/basics_test.dart
+++ b/packages/flutter_localizations/test/basics_test.dart
@@ -27,8 +27,8 @@ void main() {
     expect(innerTracker.captionFontSize, 13.0);
   });
 
-  testWidgets('Localizations is compatible with ChangeNotifier.dispose() called during didChangeDependencies', (WidgetTester tester) async {
-    // PageView calls ScrollPosition.dispose() during didChangeDependencies.
+  testWidgets('Localizations is compatible with ChangeNotifier.dispose() called during didDependenciesChanged', (WidgetTester tester) async {
+    // PageView calls ScrollPosition.dispose() during didDependenciesChanged.
     await tester.pumpWidget(
       new MaterialApp(
         supportedLocales: const <Locale>[
@@ -50,7 +50,7 @@ void main() {
 }
 
 /// A localizations delegate that does not contain any useful data, and is only
-/// used to trigger didChangeDependencies upon locale change.
+/// used to trigger didDependenciesChanged upon locale change.
 class _DummyLocalizationsDelegate extends LocalizationsDelegate<DummyLocalizations> {
   @override
   Future<DummyLocalizations> load(Locale locale) async => new DummyLocalizations();


### PR DESCRIPTION
This PR solves some issues related to dependency inheritance:
* Widgets got rebuilt due to changes in outdated dependencies.
* InheritedElement.dispatchDidChangeDependencies fails to be called outside build phase, while the document states it can.
* didChangeDependencies is called for element unmounted later.
* didChangeDependencies is called more than once if multiple dependencies changed.
* Subclasses of InheritedElement have no way to trigger rebuild for portion of its dependents.

Some API break changes are introduced:
* InheritedElement is an abstract class now.
* Element.didChangeDependencies is splited to markDependenciesChanged and didDependenciesChanged. Subclasses of InheritedElement use markDependenciesChanged to let framework notify their dependents that their dependencies has changed through didDependenciesChanged. This way markDependenciesChanged and hence InheritedElement.dispatchDidDependenciesChanged can be called outside build phase.
* InheritedElement.dispatchDidChangeDependencies is renamed as InheritedElement.dispatchDidDependenciesChanged.