### PR TITLE
fix miscellaneous typos in dartdocs

### DIFF
--- a/packages/flutter/lib/src/material/grid_tile_bar.dart
+++ b/packages/flutter/lib/src/material/grid_tile_bar.dart
@@ -12,7 +12,7 @@ import 'theme.dart';
 /// Typically used to add a one or two line header or footer on a [GridTile].
 ///
 /// For a one-line header, include a [title] widget. To add a second line, also
-/// include a [subtitle] wiget. Use [leading] or [trailing] to add an icon.
+/// include a [subtitle] widget. Use [leading] or [trailing] to add an icon.
 ///
 /// See also:
 ///

--- a/packages/flutter/lib/src/rendering/viewport.dart
+++ b/packages/flutter/lib/src/rendering/viewport.dart
@@ -599,7 +599,7 @@ abstract class RenderViewportBase<ParentDataClass extends ContainerParentDataMix
   /// `child`.
   ///
   /// See also [computeAbsolutePaintOffset], which computes the paint offset
-  /// from an explict layout offset and growth direction instead of using the
+  /// from an explicit layout offset and growth direction instead of using the
   /// values computed for the child during layout.
   @protected
   Offset paintOffsetOf(RenderSliver child);

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -3796,7 +3796,7 @@ class StatefulElement extends ComponentElement {
   }
 }
 
-/// An [Element] that uses a [ProxyElement] as its configuration.
+/// An [Element] that uses a [ProxyWidget] as its configuration.
 abstract class ProxyElement extends ComponentElement {
   /// Initializes fields for subclasses.
   ProxyElement(ProxyWidget widget) : super(widget);

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -77,7 +77,7 @@ abstract class LocalKey extends Key {
 ///
 /// See also the discussion at [Widget.key].
 class ValueKey<T> extends LocalKey {
-  /// Creates a key that delgates its [operator==] to the given value.
+  /// Creates a key that delegates its [operator==] to the given value.
   const ValueKey(this.value);
 
   /// The value to which this key delegates its [operator==]
@@ -302,7 +302,7 @@ abstract class GlobalKey<T extends State<StatefulWidget>> extends Key {
   ///
   /// The current state is null if (1) there is no widget in the tree that
   /// matches this global key, (2) that widget is not a [StatefulWidget], or the
-  /// assoicated [State] object is not a subtype of `T`.
+  /// associated [State] object is not a subtype of `T`.
   T get currentState {
     final Element element = _currentElement;
     if (element is StatefulElement) {
@@ -930,7 +930,7 @@ typedef void StateSetter(VoidCallback fn);
 ///    update the [widget] property to refer to the new widget and then call the
 ///    [didUpdateWidget] method with the previous widget as an argument. [State]
 ///    objects should override [didUpdateWidget] to respond to changes in their
-///    associated wiget (e.g., to start implicit animations). The framework
+///    associated widget (e.g., to start implicit animations). The framework
 ///    always calls [build] after calling [didUpdateWidget], which means any
 ///    calls to [setState] in [didUpdateWidget] are redundant.
 ///  * If the subtree containing the [State] object is removed from the tree
@@ -3819,7 +3819,7 @@ abstract class ProxyElement extends ComponentElement {
     rebuild();
   }
 
-  /// Notify other objects that the wiget associated with this element has changed.
+  /// Notify other objects that the widget associated with this element has changed.
   ///
   /// Called during [update] after changing the widget associated with this
   /// element but before rebuilding this element.

--- a/packages/flutter/lib/src/widgets/scroll_position.dart
+++ b/packages/flutter/lib/src/widgets/scroll_position.dart
@@ -557,7 +557,7 @@ abstract class ScrollPosition extends ViewportOffset with ScrollMetrics {
   /// If the argument is null, this method has no effect. This is convenient for
   /// cases where the new activity is obtained from another method, and that
   /// method might return null, since it means the caller does not have to
-  /// explictly null-check the argument.
+  /// explicitly null-check the argument.
   void beginActivity(ScrollActivity newActivity) {
     if (newActivity == null)
       return;

--- a/packages/flutter/lib/src/widgets/scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/scroll_view.dart
@@ -335,7 +335,7 @@ class CustomScrollView extends ScrollView {
   List<Widget> buildSlivers(BuildContext context) => slivers;
 }
 
-/// A [ScrollView] uses a single child layout model.
+/// A [ScrollView] that uses a single child layout model.
 ///
 /// See also:
 ///
@@ -402,7 +402,7 @@ abstract class BoxScrollView extends ScrollView {
 ///
 /// There are three options for constructing a [ListView]:
 ///
-///  1. The default constuctor takes an explict [List<Widget>] of children. This
+///  1. The default constructor takes an explicit [List<Widget>] of children. This
 ///     constructor is appropriate for list views with a small number of
 ///     children because constructing the [List] requires doing work for every
 ///     child that could possibly be displayed in the list view instead of just

--- a/packages/flutter/lib/src/widgets/sliver.dart
+++ b/packages/flutter/lib/src/widgets/sliver.dart
@@ -25,7 +25,7 @@ export 'package:flutter/rendering.dart' show
 ///
 /// It's uncommon to subclass [SliverChildDelegate]. Instead, consider using one
 /// of the existing subclasses that provide adaptors to builder callbacks or
-/// explict child lists.
+/// explicit child lists.
 ///
 /// See also:
 ///


### PR DESCRIPTION
Also wondering why this misspelling is so common in "explicit" but not in "implicit" :)