### PR TITLE
Document the `reassemble` method as part of the lifetime of a Widget.

### DIFF
--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -924,6 +924,10 @@ typedef void StateSetter(VoidCallback fn);
 ///    [setState] method, which indicates that some of their internal state
 ///    has changed in a way that might impact the user interface in this
 ///    subtree.
+///  * If a hot-reload occurs, such as initiated by the InteliJ IDEA, the 
+///    [State.reassemble] method is called (if overriden). This provides an 
+///    oppportunity to re-initialize any data that was created in the State 
+///    constructor or during [StatefulWidget.createState].
 ///  * During this time, a parent widget might rebuild and request that this
 ///    location in the tree update to display a new widget with the same
 ///    [runtimeType] and [Widget.key]. When this happens, the framework will


### PR DESCRIPTION
I had to ask on reddit how to hook in the hot-reload so I could reload any data already in the system. Incase I was changing the data that was loaded, or how the data is stored. 

I think this method should be listed in the description of the Widget lifetime, so that it will be easier for others to find out  this information as well.