### PR TITLE
Revised the English translation definitions

### DIFF
--- a/packages/flutter_localizations/lib/src/l10n/material_en.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_en.arb
@@ -1,87 +1,80 @@
 {
   "scriptCategory": "English-like",
   "@scriptCategory": {
-    "description": "The name of the language's script category (see https://material.io/guidelines/style/typography.html#typography-language-categories-reference)",
-    "type": "text"
+    "description": "The name of the language's script category (see https://material.io/guidelines/style/typography.html#typography-language-categories-reference)"
   },
 
   "timeOfDayFormat": "h:mm a",
   "@timeOfDayFormat": {
-    "description": "The ICU 'Short Time' pattern, such as 'HH:mm', 'h:mm a', 'H:mm'. See: http://demo.icu-project.org/icu-bin/locexp?d_=en&_=en_US",
-    "type": "text"
+    "description": "The ICU 'Short Time' pattern, such as 'HH:mm', 'h:mm a', 'H:mm'. See: http://demo.icu-project.org/icu-bin/locexp?d_=en&_=en_US"
   },
 
   "openAppDrawerTooltip": "Open navigation menu",
   "@openAppDrawerTooltip": {
-    "description": "The tooltip for the leading AppBar menu (aka 'hamburger') button",
-    "type": "text"
+    "description": "The tooltip for the leading AppBar menu (aka 'hamburger') button"
   },
 
   "backButtonTooltip": "Back",
   "@backButtonTooltip": {
-    "description": "The BackButton's tooltip",
-    "type": "text"
+    "description": "The BackButton's tooltip"
   },
 
   "closeButtonTooltip": "Close",
   "@closeButtonTooltip": {
-    "description": "The CloseButton's tooltip",
-    "type": "text"
+    "description": "The CloseButton's tooltip"
   },
 
   "nextMonthTooltip": "Next month",
   "@nextMonthTooltip": {
-    "description": "The tooltip for the MonthPicker's 'next month' button.",
-    "type": "text"
+    "description": "The tooltip for the MonthPicker's 'next month' button."
   },
 
   "previousMonthTooltip": "Previous month",
   "@previousMonthTooltip": {
-    "description": "The tooltip for the MonthPicker's 'previous month' button.",
-    "type": "text"
+    "description": "The tooltip for the MonthPicker's 'previous month' button."
   },
 
   "nextPageTooltip": "Next page",
-  "@nextMonthTooltip": {
-    "description": "The tooltip for the [PaginatedDataTables]'s 'next page' button.",
-    "type": "text"
+  "@nextPageTooltip": {
+    "description": "The tooltip for the [PaginatedDataTables]'s 'next page' button."
   },
 
   "previousPageTooltip": "Previous page",
-  "@previousMonthTooltip": {
-    "description": "The tooltip for the PaginatedDataTables's 'previous page' button.",
-    "type": "text"
+  "@previousPageTooltip": {
+    "description": "The tooltip for the PaginatedDataTables's 'previous page' button."
   },
 
   "showMenuTooltip": "Show menu",
   "@showMenuTooltip": {
-    "description": "The default PopupMenuButton tooltip",
-    "type": "text"
+    "description": "The default PopupMenuButton tooltip"
   },
 
   "aboutListTileTitle": "About $applicationName",
   "@aboutListTileTitle": {
     "description": "The default title for AboutListTile",
-    "type": "text"
+    "parameters": "applicationName"
   },
 
   "licensesPageTitle": "Licenses",
   "@licensesPageTitle": {
-    "description": "The title for the Flutter licenses page.",
-    "type": "text"
+    "description": "The title for the Flutter licenses page."
   },
 
   "pageRowsInfoTitle": "$firstRow–$lastRow of $rowCount",
-  "pageRowsInfoTitleApproximate": "$firstRow–$lastRow of about $rowCount",
   "@pageRowsInfoTitle": {
-    "description": "Title for the [PaginatedDataTable]'s row info footer",
-    "type": "text"
+    "description": "Title for the [PaginatedDataTable]'s row info footer when the exact overall row count is known",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+
+  "pageRowsInfoTitleApproximate": "$firstRow–$lastRow of about $rowCount",
+  "@pageRowsInfoTitleApproximate": {
+    "description": "Title for the [PaginatedDataTable]'s row info footer when the exact overall row count is unknown",
+    "parameters": "firstRow, lastRow, rowCount"
   },
 
   "rowsPerPageTitle": "Rows per page:",
   "@rowsPerPageTitle": {
-    "description": "Title for the [PaginatedDataTable]'s 'rows per page' footer.",
-    "type": "text"
+    "description": "Title for the [PaginatedDataTable]'s 'rows per page' footer."
   },
 
   "selectedRowCountTitleZero": "No items selected",
@@ -89,72 +82,61 @@
   "selectedRowCountTitleOther": "$selectedRowCount items selected",
   "@selectedRowCountTitle": {
     "description": "Title for the PaginatedDataTable's selected row count header",
-    "type": "text"
+    "plural": "selectedRowCount"
   },
 
   "cancelButtonLabel": "CANCEL",
   "@cancelButtonLabel": {
-    "description": "The label for cancel buttons and menu items.",
-    "type": "text"
+    "description": "The label for cancel buttons and menu items."
   },
 
   "closeButtonLabel": "CLOSE",
   "@closeButtonLabel": {
-    "description": "The label for close buttons and menu items.",
-    "type": "text"
+    "description": "The label for close buttons and menu items."
   },
 
   "continueButtonLabel": "CONTINUE",
   "@continueButtonLabel": {
-    "description": "The label for continue buttons and menu items.",
-    "type": "text"
+    "description": "The label for continue buttons and menu items."
   },
 
   "copyButtonLabel": "COPY",
   "@copyButtonLabel": {
-    "description": "The label for copy buttons and menu items.",
-    "type": "text"
+    "description": "The label for copy buttons and menu items."
   },
 
   "cutButtonLabel": "CUT",
   "@cutButtonLabel": {
-    "description": "The label for cut buttons and menu items",
-    "type": "text"
+    "description": "The label for cut buttons and menu items."
   },
 
   "okButtonLabel": "OK",
   "@okButtonLabel": {
-    "description": "The label for OK buttons and menu items.",
-    "type": "text"
+    "description": "The label for OK buttons and menu items."
   },
 
   "pasteButtonLabel": "PASTE",
   "@pasteButtonLabel": {
-    "description": "The label for paste buttons and menu items.",
-    "type": "text"
+    "description": "The label for paste buttons and menu items."
   },
 
   "selectAllButtonLabel": "SELECT ALL",
-  "@selectButtonLabel": {
-    "description": "The label for select-all buttons and menu items.",
-    "type": "text"
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
   },
 
   "viewLicensesButtonLabel": "VIEW LICENSES",
   "@viewLicensesButtonLabel": {
-    "description": "The label for the about box's view licenses button.",
-    "type": "text"
+    "description": "The label for the about box's view licenses button."
   },
 
   "anteMeridiemAbbreviation": "AM",
   "@anteMeridiemAbbreviation": {
-    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker.",
-    "type": "text"
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker."
   },
 
   "postMeridiemAbbreviation": "PM",
   "@postMeridiemAbbreviation": {
-    "description": "The abbreviation for post meridiem (after noon) shown in the time picker.",
-    "type": "text"
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker."
   }
 }


### PR DESCRIPTION
Updated material_en.arb in the flutter_localizations package to make purals and translation parameters explicit.

The "type" property for @foo meta resources has been removed since we're not using it.

Our one plural translation now identifies itself and names it's integer quantity parameter:
```
  "selectedRowCountTitleZero": "No items selected",
  "selectedRowCountTitleOne": "1 item selected",
  "selectedRowCountTitleOther": "$selectedRowCount items selected",
  "@selectedRowCountTitle": {
    "description": "Title for the PaginatedDataTable's selected row count header",
    "plural": "selectedRowCount"
  },
```

Parameterized translations specify their parameter names. For example:
```
  "pageRowsInfoTitle": "$firstRow–$lastRow of $rowCount",
  "@pageRowsInfoTitle": {
    "description": "Title for the [PaginatedDataTable]'s row info footer when the exact overall row count is known",
    "parameters": "firstRow, lastRow, rowCount"
  },
```


