### PR TITLE
Fixing assumption that baseStyle is a complete style.

### DIFF
--- a/packages/flutter/lib/src/material/input_decorator.dart
+++ b/packages/flutter/lib/src/material/input_decorator.dart
@@ -472,15 +472,13 @@ class InputDecorator extends StatelessWidget {
 
     final Color activeColor = _getActiveColor(themeData);
 
-    final TextStyle baseStyle = this.baseStyle ?? themeData.textTheme.subhead;
+    final TextStyle baseStyle = themeData.textTheme.subhead.merge(this.baseStyle);
     final TextStyle hintStyle = decoration.hintStyle ?? baseStyle.copyWith(color: themeData.hintColor);
     final TextStyle helperStyle = decoration.helperStyle ?? themeData.textTheme.caption.copyWith(color: themeData.hintColor);
     final TextStyle counterStyle = decoration.counterStyle ?? helperStyle;
     final TextStyle subtextStyle = errorText != null
       ? decoration.errorStyle ?? themeData.textTheme.caption.copyWith(color: themeData.errorColor)
       : helperStyle;
-
-    final double entryTextHeight = baseStyle.fontSize * textScaleFactor;
 
     double topPadding = isCollapsed ? 0.0 : (isDense ?  _kDenseTopPadding : _kNormalTopPadding);
 
@@ -645,6 +643,7 @@ class InputDecorator extends StatelessWidget {
     if (decoration.icon != null) {
       assert(!isCollapsed);
       final double iconSize = isDense ? 18.0 : 24.0;
+      final double entryTextHeight = baseStyle.fontSize * textScaleFactor;
       final double iconTop = topPadding + (entryTextHeight - iconSize) / 2.0;
       return new Row(
         crossAxisAlignment: CrossAxisAlignment.start,

--- a/packages/flutter/lib/src/material/input_decorator.dart
+++ b/packages/flutter/lib/src/material/input_decorator.dart
@@ -473,11 +473,11 @@ class InputDecorator extends StatelessWidget {
     final Color activeColor = _getActiveColor(themeData);
 
     final TextStyle baseStyle = themeData.textTheme.subhead.merge(this.baseStyle);
-    final TextStyle hintStyle = decoration.hintStyle ?? baseStyle.copyWith(color: themeData.hintColor);
-    final TextStyle helperStyle = decoration.helperStyle ?? themeData.textTheme.caption.copyWith(color: themeData.hintColor);
-    final TextStyle counterStyle = decoration.counterStyle ?? helperStyle;
+    final TextStyle hintStyle = baseStyle.copyWith(color: themeData.hintColor).merge(decoration.hintStyle);
+    final TextStyle helperStyle = themeData.textTheme.caption.copyWith(color: themeData.hintColor).merge(decoration.helperStyle);
+    final TextStyle counterStyle = helperStyle.merge(decoration.counterStyle);
     final TextStyle subtextStyle = errorText != null
-      ? decoration.errorStyle ?? themeData.textTheme.caption.copyWith(color: themeData.errorColor)
+      ? themeData.textTheme.caption.copyWith(color: themeData.errorColor).merge(decoration.errorStyle)
       : helperStyle;
 
     double topPadding = isCollapsed ? 0.0 : (isDense ?  _kDenseTopPadding : _kNormalTopPadding);
@@ -486,7 +486,7 @@ class InputDecorator extends StatelessWidget {
 
     if (labelText != null) {
       assert(!isCollapsed);
-      final TextStyle floatingLabelStyle = decoration.labelStyle ?? themeData.textTheme.caption.copyWith(color: activeColor);
+      final TextStyle floatingLabelStyle = themeData.textTheme.caption.copyWith(color: activeColor).merge(decoration.labelStyle);
       final TextStyle labelStyle = hasInlineLabel ? hintStyle : floatingLabelStyle;
       final double labelTextHeight = floatingLabelStyle.fontSize * textScaleFactor;
 

--- a/packages/flutter/test/material/input_decorator_test.dart
+++ b/packages/flutter/test/material/input_decorator_test.dart
@@ -436,4 +436,79 @@ void main() {
       'InputDecorator-[<\'key\'>](decoration: InputDecoration(), baseStyle: TextStyle(<all styles inherited>), isFocused: false, isEmpty: false)',
     );
   });
+
+  testWidgets('InputDecorator works with partially specified styles', (WidgetTester tester) async {
+    await tester.pumpWidget(new MaterialApp(
+      home: const Material(
+        child: const DefaultTextStyle(
+          style: const TextStyle(fontFamily: 'Ahem', fontSize: 10.0),
+          child: const Center(
+            child: const TextField(
+              decoration: const InputDecoration(
+                labelText: 'label',
+                labelStyle: const TextStyle(),
+                helperText: 'helper',
+                helperStyle: const TextStyle(),
+                hintText: 'hint',
+                hintStyle: const TextStyle(),
+                errorText: 'error',
+                errorStyle: const TextStyle(),
+                prefixText: 'prefix',
+                prefixStyle: const TextStyle(),
+                suffixText: 'suffix',
+                suffixStyle: const TextStyle(),
+                counterText: 'counter',
+                counterStyle: const TextStyle(),
+              ),
+            ),
+          ),
+        ),
+      ),
+    ));
+
+    expect(find.text('label'), findsOneWidget);
+
+    // Tap to make the hint show up.
+    await tester.tap(find.byType(TextField));
+    await tester.pump(const Duration(milliseconds: 100));
+
+    expect(find.text('hint'), findsOneWidget);
+
+    // Enter text to make the text style get used.
+    await tester.enterText(find.byType(TextField), 'Test');
+    await tester.pump(const Duration(milliseconds: 100));
+
+    expect(find.text('prefix'), findsOneWidget);
+    expect(find.text('suffix'), findsOneWidget);
+
+    // Test again without error, so helper style gets used.
+    await tester.pumpWidget(new MaterialApp(
+      home: const Material(
+        child: const DefaultTextStyle(
+          style: const TextStyle(),
+          child: const Center(
+            child: const TextField(
+              decoration: const InputDecoration(
+                labelText: 'label',
+                labelStyle: const TextStyle(),
+                helperText: 'helper',
+                helperStyle: const TextStyle(),
+                hintText: 'hint',
+                hintStyle: const TextStyle(),
+                prefixText: 'prefix',
+                prefixStyle: const TextStyle(),
+                suffixText: 'suffix',
+                suffixStyle: const TextStyle(),
+                counterText: 'counter',
+                counterStyle: const TextStyle(),
+              ),
+            ),
+          ),
+        ),
+      ),
+    ));
+
+    expect(find.text('label'), findsOneWidget);
+    expect(find.text('helper'), findsOneWidget);
+  });
 }

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -817,6 +817,7 @@ void main() {
 
   testWidgets('TextField with specified helperStyle', (WidgetTester tester) async {
     final TextStyle style = new TextStyle(
+      inherit: false,
       color: Colors.pink[500],
       fontSize: 10.0,
     );
@@ -865,6 +866,7 @@ void main() {
 
   testWidgets('TextField with specified hintStyle', (WidgetTester tester) async {
     final TextStyle hintStyle = new TextStyle(
+      inherit: false,
       color: Colors.pink[500],
       fontSize: 10.0,
     );
@@ -886,6 +888,7 @@ void main() {
 
   testWidgets('TextField with specified prefixStyle', (WidgetTester tester) async {
     final TextStyle prefixStyle = new TextStyle(
+      inherit: false,
       color: Colors.pink[500],
       fontSize: 10.0,
     );
@@ -973,6 +976,7 @@ void main() {
   testWidgets('TextField prefix and suffix appear correctly with hint text',
           (WidgetTester tester) async {
     final TextStyle hintStyle = new TextStyle(
+      inherit: false,
       color: Colors.pink[500],
       fontSize: 10.0,
     );


### PR DESCRIPTION
This fixes the assumption that InputDecorator had where it expected baseStyle to be a complete style.  Now it merges the baseStyle with the subhead style instead of substituting it entirely.

This fixes #12832.