### PR TITLE
Remove build phase restriction on Element.didChangeDependencies and InheritedElement.dispatchDidChangeDependencies

### DIFF
--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -1587,7 +1587,7 @@ abstract class InheritedWidget extends ProxyWidget {
     : super(key: key, child: child);
 
   @override
-  InheritedElement createElement() => new InheritedElement(this);
+  InheritedElement createElement() => new DefaultInheritedElement(this);
 
   /// Whether the framework should notify widgets that inherit from this widget.
   ///
@@ -3023,7 +3023,7 @@ abstract class Element extends DiagnosticableTree implements BuildContext {
     assert(_active);
     if (_dependencies != null && _dependencies.isNotEmpty) {
       for (InheritedElement dependency in _dependencies)
-        dependency._dependents.remove(this);
+        dependency.removeDependent(this);
       // For expediency, we don't actually clear the list here, even though it's
       // no longer representative of what we are registered with. If we never
       // get re-used, it doesn't matter. If we do, then we'll clear the list in
@@ -3212,8 +3212,9 @@ abstract class Element extends DiagnosticableTree implements BuildContext {
     if (ancestor != null) {
       assert(ancestor is InheritedElement);
       _dependencies ??= new HashSet<InheritedElement>();
-      _dependencies.add(ancestor);
-      ancestor._dependents.add(this);
+      if (_dependencies.add(ancestor)) {
+        ancestor.addDependent(this);
+      }
       return ancestor.widget;
     }
     _hadUnsatisfiedDependencies = true;
@@ -3902,14 +3903,21 @@ class ParentDataElement<T extends RenderObjectWidget> extends ProxyElement {
 }
 
 /// An [Element] that uses a [InheritedWidget] as its configuration.
-class InheritedElement extends ProxyElement {
+abstract class InheritedElement extends ProxyElement {
   /// Creates an element that uses the given widget as its configuration.
   InheritedElement(InheritedWidget widget) : super(widget);
 
   @override
   InheritedWidget get widget => super.widget;
 
-  final Set<Element> _dependents = new HashSet<Element>();
+  @protected
+  Iterable<Element> get dependents;
+
+  void addDependent(Element element);
+
+  void removeDependent(Element element);
+
+  bool containsDependent(Element element);
 
   @override
   void _updateInheritance() {
@@ -3925,7 +3933,7 @@ class InheritedElement extends ProxyElement {
   @override
   void debugDeactivated() {
     assert(() {
-      assert(_dependents.isEmpty);
+      assert(dependents.isEmpty);
       return true;
     }());
     super.debugDeactivated();
@@ -3947,7 +3955,7 @@ class InheritedElement extends ProxyElement {
   /// by first obtaining their [InheritedElement] using
   /// [BuildContext.ancestorInheritedElementForWidgetOfExactType].
   void dispatchDidChangeDependencies() {
-    for (Element dependent in _dependents) {
+    for (Element dependent in dependents) {
       assert(() {
         // check that it really is our descendant
         Element ancestor = dependent._parent;
@@ -3959,6 +3967,31 @@ class InheritedElement extends ProxyElement {
       assert(dependent._dependencies.contains(this));
       dependent.didChangeDependencies();
     }
+  }
+}
+
+/// Default implementation for [InheritedElement].
+class DefaultInheritedElement extends InheritedElement {
+  DefaultInheritedElement(InheritedWidget widget) : super(widget);
+
+  final Set<Element> _dependents = new HashSet<Element>();
+
+  @override
+  Iterable<Element> get dependents => _dependents;
+
+  @override
+  void addDependent(Element element) {
+    _dependents.add(element);
+  }
+
+  @override
+  void removeDependent(Element element) {
+    _dependents.remove(element);
+  }
+
+  @override
+  bool containsDependent(Element element) {
+    return _dependents.contains(element);
   }
 }
 

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -3298,29 +3298,8 @@ abstract class Element extends DiagnosticableTree implements BuildContext {
   /// this function to notify this element of the change.
   @mustCallSuper
   void didChangeDependencies() {
-    assert(_active); // otherwise markNeedsBuild is a no-op
-    assert(_debugCheckOwnerBuildTargetExists('didChangeDependencies'));
+    assert(_active); // otherwise dependencies should be unlinked in deactivate().
     markNeedsBuild();
-  }
-
-  bool _debugCheckOwnerBuildTargetExists(String methodName) {
-    assert(() {
-      if (owner._debugCurrentBuildTarget == null) {
-        throw new FlutterError(
-            '$methodName for ${widget.runtimeType} was called at an '
-                'inappropriate time.\n'
-                'It may only be called while the widgets are being built. A possible '
-                'cause of this error is when $methodName is called during '
-                'one of:\n'
-                ' * network I/O event\n'
-                ' * file I/O event\n'
-                ' * timer\n'
-                ' * microtask (caused by Future.then, async/await, scheduleMicrotask)'
-        );
-      }
-      return true;
-    }());
-    return true;
   }
 
   /// Returns a description of what caused this element to be created.
@@ -3968,7 +3947,6 @@ class InheritedElement extends ProxyElement {
   /// by first obtaining their [InheritedElement] using
   /// [BuildContext.ancestorInheritedElementForWidgetOfExactType].
   void dispatchDidChangeDependencies() {
-    assert(_debugCheckOwnerBuildTargetExists('dispatchDidChangeDependencies'));
     for (Element dependent in _dependents) {
       assert(() {
         // check that it really is our descendant

--- a/packages/flutter/test/widgets/inherited_test.dart
+++ b/packages/flutter/test/widgets/inherited_test.dart
@@ -461,6 +461,28 @@ void main() {
     expect(buildCount, equals(2));
   });
 
+  testWidgets('InheritedElement.dispatchDidChangeDependencies is allowed to call outside build phase', (WidgetTester tester) async {
+    int buildCount = 0;
+    InheritedElement inheritedElement;
+
+    await tester.pumpWidget(new TestInherited(
+      shouldNotify: false,
+      child: new Builder(
+        builder: (BuildContext context) {
+          context.inheritFromWidgetOfExactType(TestInherited);
+          buildCount += 1;
+          inheritedElement = context.ancestorInheritedElementForWidgetOfExactType(TestInherited);
+          return new Container();
+        },
+      ),
+    ));
+    expect(buildCount, equals(1));
+
+    inheritedElement.dispatchDidChangeDependencies();
+    await tester.pump();
+    expect(buildCount, equals(2));
+  });
+
   testWidgets('initState() dependency on Inherited asserts', (WidgetTester tester) async {
     // This is a regression test for https://github.com/flutter/flutter/issues/5491
     bool exceptionCaught = false;


### PR DESCRIPTION
Document of InheritedElement.dispatchDidChangeDependencies states that:

> Subclasses of [InheritedElement] might wish to call this function at other times if their inherited information changes outside of the build phase.

While commit 8c3d5838dd539fec52731bdce3dc73bcc11c4f7c(#12213) applies build phase restriction on Element.didChangeDependencies and InheritedElement.dispatchDidChangeDependencies.

This PR adds test to comply with the documentation and removes that restriction.