### PR TITLE
RenderFlex with MainAxisSize.min RTL

### DIFF
--- a/packages/flutter/lib/src/rendering/flex.dart
+++ b/packages/flutter/lib/src/rendering/flex.dart
@@ -817,40 +817,22 @@ class RenderFlex extends RenderBox with ContainerRenderObjectMixin<RenderBox, Fl
     }
 
     // Align items along the main axis.
+    final double idealSize = canFlex && mainAxisSize == MainAxisSize.max ? maxMainSize : allocatedSize;
+    double actualSize;
     double actualSizeDelta;
-    double preferredSize;
-    if (canFlex) {
-      final bool isMainAxisSizeMax = mainAxisSize == MainAxisSize.max;
-      preferredSize = isMainAxisSizeMax ? maxMainSize : allocatedSize;
-      switch (_direction) {
-        case Axis.horizontal:
-          size = constraints.constrain(new Size(preferredSize, crossSize));
-          actualSizeDelta = size.width - allocatedSize;
-          crossSize = size.height;
-          assert(isMainAxisSizeMax ? size.width == maxMainSize : size.width >= constraints.minWidth);
-          break;
-        case Axis.vertical:
-          size = constraints.constrain(new Size(crossSize, preferredSize));
-          actualSizeDelta = size.height - allocatedSize;
-          crossSize = size.width;
-          assert(isMainAxisSizeMax ? size.height == maxMainSize : size.height >= constraints.minHeight);
-          break;
-      }
-    } else {
-      switch (_direction) {
-        case Axis.horizontal:
-          size = constraints.constrain(new Size(allocatedSize, crossSize));
-          preferredSize = size.width;
-          crossSize = size.height;
-          break;
-        case Axis.vertical:
-          size = constraints.constrain(new Size(crossSize, allocatedSize));
-          preferredSize = size.height;
-          crossSize = size.width;
-          break;
-      }
-      actualSizeDelta = preferredSize - allocatedSize;
+    switch (_direction) {
+      case Axis.horizontal:
+        size = constraints.constrain(new Size(idealSize, crossSize));
+        actualSize = size.width;
+        crossSize = size.height;
+        break;
+      case Axis.vertical:
+        size = constraints.constrain(new Size(crossSize, idealSize));
+        actualSize = size.height;
+        crossSize = size.width;
+        break;
     }
+    actualSizeDelta = actualSize - allocatedSize;
     _overflow = math.max(0.0, -actualSizeDelta);
 
     final double remainingSpace = math.max(0.0, actualSizeDelta);
@@ -889,7 +871,7 @@ class RenderFlex extends RenderBox with ContainerRenderObjectMixin<RenderBox, Fl
     }
 
     // Position elements
-    double childMainPosition = flipMainAxis ? preferredSize - leadingSpace : leadingSpace;
+    double childMainPosition = flipMainAxis ? actualSize - leadingSpace : leadingSpace;
     child = firstChild;
     while (child != null) {
       final FlexParentData childParentData = child.parentData;

--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -184,7 +184,7 @@ abstract class RenderProxyBoxWithHitTestBehavior extends RenderProxyBox {
 /// as well.
 ///
 /// For example, if you wanted [child] to have a minimum height of 50.0 logical
-/// pixels, you could use `const BoxConstraints(minHeight: 50.0)`` as the
+/// pixels, you could use `const BoxConstraints(minHeight: 50.0)` as the
 /// [additionalConstraints].
 class RenderConstrainedBox extends RenderProxyBox {
   /// Creates a render box that constrains its child.

--- a/packages/flutter/test/rendering/flex_test.dart
+++ b/packages/flutter/test/rendering/flex_test.dart
@@ -391,6 +391,26 @@ void main() {
     expect(exceptions.first, const isInstanceOf<FlutterError>());
   });
 
+  test('MainAxisSize.min inside tightly constrained', () {
+    final BoxConstraints square = const BoxConstraints.tightFor(width: 100.0, height: 100.0);
+    final RenderConstrainedBox box1 = new RenderConstrainedBox(additionalConstraints: square);
+    final RenderConstrainedBox box2 = new RenderConstrainedBox(additionalConstraints: square);
+    final RenderConstrainedBox box3 = new RenderConstrainedBox(additionalConstraints: square);
+    final RenderFlex flex = new RenderFlex(
+      textDirection: TextDirection.rtl,
+      mainAxisSize: MainAxisSize.min,
+    );
+    flex.addAll(<RenderBox>[box1, box2, box3]);
+    layout(flex);
+    expect(flex.constraints.hasTightWidth, isTrue);
+    expect(box1.localToGlobal(const Offset(0.0, 0.0)), const Offset(700.0, 250.0));
+    expect(box2.localToGlobal(const Offset(0.0, 0.0)), const Offset(600.0, 250.0));
+    expect(box3.localToGlobal(const Offset(0.0, 0.0)), const Offset(500.0, 250.0));
+    expect(box1.size, const Size(100.0, 100.0));
+    expect(box2.size, const Size(100.0, 100.0));
+    expect(box3.size, const Size(100.0, 100.0));
+  });
+
   test('Flex RTL', () {
     final BoxConstraints square = const BoxConstraints.tightFor(width: 100.0, height: 100.0);
     final RenderConstrainedBox box1 = new RenderConstrainedBox(additionalConstraints: square);


### PR DESCRIPTION
There was a left-bias when MainAxisSize.min couldn't be honoured.

cc @abarth 