### PR TITLE
PageView ballistics overshoot the page on some devices

### DIFF
--- a/packages/flutter/lib/src/physics/utils.dart
+++ b/packages/flutter/lib/src/physics/utils.dart
@@ -4,14 +4,15 @@
 
 /// Whether two doubles are within a given distance of each other.
 ///
-/// The epsilon argument must be positive.
+/// The `epsilon` argument must be positive and not null.
+/// The `a` and `b` arguments may be null. A null value is only considered
+/// near-equal to another null value.
 bool nearEqual(double a, double b, double epsilon) {
+  assert(epsilon != null);
   assert(epsilon >= 0.0);
-  if (a == null || b == null) {
-  	return (a == b);
-  } else {
-  	return (a > (b - epsilon)) && (a < (b + epsilon));
-  }
+  if (a == null || b == null)
+    return a == b;
+  return (a > (b - epsilon)) && (a < (b + epsilon));
 }
 
 /// Whether a double is within a given distance of zero.

--- a/packages/flutter/lib/src/physics/utils.dart
+++ b/packages/flutter/lib/src/physics/utils.dart
@@ -7,7 +7,11 @@
 /// The epsilon argument must be positive.
 bool nearEqual(double a, double b, double epsilon) {
   assert(epsilon >= 0.0);
-  return (a > (b - epsilon)) && (a < (b + epsilon));
+  if (a == null || b == null) {
+  	return (a == b);
+  } else {
+  	return (a > (b - epsilon)) && (a < (b + epsilon));
+  }
 }
 
 /// Whether a double is within a given distance of zero.

--- a/packages/flutter/lib/src/widgets/scroll_position.dart
+++ b/packages/flutter/lib/src/widgets/scroll_position.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
+import 'package:flutter/physics.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/scheduler.dart';
 
@@ -412,8 +413,8 @@ abstract class ScrollPosition extends ViewportOffset with ScrollMetrics {
 
   @override
   bool applyContentDimensions(double minScrollExtent, double maxScrollExtent) {
-    if (_minScrollExtent != minScrollExtent ||
-        _maxScrollExtent != maxScrollExtent ||
+    if (!nearEqual(_minScrollExtent, minScrollExtent, Tolerance.defaultTolerance.distance) ||
+        !nearEqual(_maxScrollExtent, maxScrollExtent, Tolerance.defaultTolerance.distance) ||
         _didChangeViewportDimension) {
       _minScrollExtent = minScrollExtent;
       _maxScrollExtent = maxScrollExtent;

--- a/packages/flutter/test/physics/near_equal_test.dart
+++ b/packages/flutter/test/physics/near_equal_test.dart
@@ -13,4 +13,10 @@ void main() {
     expect(nearEqual(5.0, 6.0, 0.5), isFalse);
     expect(nearEqual(6.0, 5.0, 0.5), isFalse);
   });
+
+  test('test_null', () {
+    expect(nearEqual(5.0, null, 2.0), isFalse);
+    expect(nearEqual(null, 5.0, 2.0), isFalse);
+    expect(nearEqual(null, null, 2.0), isTrue);
+  });
 }


### PR DESCRIPTION
On some devices, such as Cupertino “Plus”-sized devices, scrolling left on the first page of a PageView will overshoot the first page and land on the second page.  Here is a gif that shows the problem:

![overshoot](https://user-images.githubusercontent.com/103489/32425238-7a8fc38e-c266-11e7-9a97-7adfc5d80c59.gif)

The issue is that applyContentDimensions incorrectly detects a content size change due to a floating point comparison on certain screen sizes (18257.400000000005 vs 18257.4)

To fix this, perform a nearEqual comparison in applyContentDimensions.