### PR TITLE
address unused element issues and new warnings

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_device.dart
+++ b/packages/flutter_tools/lib/src/android/android_device.dart
@@ -26,8 +26,6 @@ import 'adb.dart';
 import 'android.dart';
 import 'android_sdk.dart';
 
-const String _defaultAdbPath = 'adb';
-
 enum _HardwareType { emulator, physical }
 
 /// Map to help our `isLocalEmulator` detection.

--- a/packages/flutter_tools/lib/src/ios/simulators.dart
+++ b/packages/flutter_tools/lib/src/ios/simulators.dart
@@ -24,9 +24,6 @@ import 'mac.dart';
 
 const String _xcrunPath = '/usr/bin/xcrun';
 
-/// Test device created by Flutter when no other device is available.
-const String _kFlutterTestDeviceSuffix = '(Flutter)';
-
 class IOSSimulators extends PollingDeviceDiscovery {
   IOSSimulators() : super('iOS simulators');
 

--- a/packages/flutter_tools/test/android/gradle_test.dart
+++ b/packages/flutter_tools/test/android/gradle_test.dart
@@ -7,9 +7,6 @@ import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/build_info.dart';
 import 'package:test/test.dart';
 
-
-const String _kBuildDirectory = '/build/app/outputs';
-
 void main() {
   group('gradle project', () {
     GradleProject projectFrom(String properties) => new GradleProject.fromAppProperties(properties);

--- a/packages/flutter_tools/test/crash_reporting_test.dart
+++ b/packages/flutter_tools/test/crash_reporting_test.dart
@@ -64,8 +64,14 @@ void main() {
                 return <String>[name, value];
               })
               .where((List<String> pair) => pair != null),
-          key: (List<String> pair) => pair[0],
-          value: (List<String> pair) => pair[1],
+          key: (dynamic key) {
+            final List<String> pair = key;
+            pair[0];
+          },
+          value: (dynamic value) {
+            final List<String> pair = value;
+            return pair[1];
+          }
         );
 
         return new Response(

--- a/packages/flutter_tools/test/crash_reporting_test.dart
+++ b/packages/flutter_tools/test/crash_reporting_test.dart
@@ -66,7 +66,7 @@ void main() {
               .where((List<String> pair) => pair != null),
           key: (dynamic key) {
             final List<String> pair = key;
-            pair[0];
+            return pair[0];
           },
           value: (dynamic value) {
             final List<String> pair = value;

--- a/packages/flutter_tools/test/version_test.dart
+++ b/packages/flutter_tools/test/version_test.dart
@@ -18,7 +18,6 @@ import 'package:flutter_tools/src/version.dart';
 
 import 'src/context.dart';
 
-const JsonEncoder _kPrettyJsonEncoder = const JsonEncoder.withIndent('  ');
 final Clock _testClock = new Clock.fixed(new DateTime(2015, 1, 1));
 final DateTime _upToDateVersion = _testClock.agoBy(FlutterVersion.kVersionAgeConsideredUpToDate ~/ 2);
 final DateTime _outOfDateVersion = _testClock.agoBy(FlutterVersion.kVersionAgeConsideredUpToDate * 2);


### PR DESCRIPTION
Address two types of warnings in flutter_tools from a yet-to-be-rolled-to-flutter sdk:

- some unused element warnings
- an issue where a closure being passed into a param isn't compatible with how the param was defined (`A function of type '(List<String>) → String' can't be assigned to a variable of type '(dynamic) → String'.`)

@tvolkert @yjbanov 
