### PR TITLE
Show Android tombstone during native crash

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_device.dart
+++ b/packages/flutter_tools/lib/src/android/android_device.dart
@@ -676,8 +676,22 @@ class _AdbLogReader extends DeviceLogReader {
     new RegExp(r'^[F]\/[\S^:]+:\s+')
   ];
 
+  // 'F/libc(pid): Fatal signal 11'
+  static final RegExp _fatalLog = new RegExp(r'^F\/libc\s*\(\s*\d+\):\sFatal signal (\d+)');
+
+  // 'I/DEBUG(pid): ...'
+  static final RegExp _tombstoneLine = new RegExp(r'^I\/DEBUG\s*\(\s*\d+\):\s(.+)$');
+
+  // 'I/DEBUG(pid): Tombstone written to: '
+  static final RegExp _tombstoneTerminator = new RegExp(r'^Tombstone written to:\s');
+
   // we default to true in case none of the log lines match
   bool _acceptedLastLine = true;
+
+  // Whether a fatal crash is happening or not.
+  // During a fatal crash only lines from the crash are accepted, the rest are
+  // dropped.
+  bool _fatalCrash = false;
 
   // The format of the line is controlled by the '-v' parameter passed to
   // adb logcat. We are currently passing 'time', which has the format:
@@ -703,12 +717,35 @@ class _AdbLogReader extends DeviceLogReader {
     final Match logMatch = _logFormat.firstMatch(line);
     if (logMatch != null) {
       bool acceptLine = false;
-      if (appPid != null && int.parse(logMatch.group(1)) == appPid) {
+
+      if (_fatalCrash) {
+        // While a fatal crash is going on, only accept lines from the crash
+        // Otherwise the crash log in the console may get interrupted
+
+        final Match fatalMatch = _tombstoneLine.firstMatch(line);
+
+        if (fatalMatch != null) {
+          acceptLine = true;
+
+          line = fatalMatch[1];
+
+          if (_tombstoneTerminator.hasMatch(fatalMatch[1])) {
+            // Hit crash terminator, stop logging the crash info
+            _fatalCrash = false;
+          }
+        }
+      } else if (appPid != null && int.parse(logMatch.group(1)) == appPid) {
         acceptLine = true;
+
+        if (_fatalLog.hasMatch(line)) {
+          // Hit fatal signal, app is now crashing
+          _fatalCrash = true;
+        }
       } else {
         // Filter on approved names and levels.
         acceptLine = _whitelistedTags.any((RegExp re) => re.hasMatch(line));
       }
+
       if (acceptLine) {
         _acceptedLastLine = true;
         _linesController.add(line);

--- a/packages/flutter_tools/lib/src/android/android_device.dart
+++ b/packages/flutter_tools/lib/src/android/android_device.dart
@@ -680,7 +680,7 @@ class _AdbLogReader extends DeviceLogReader {
   static final RegExp _fatalLog = new RegExp(r'^F\/libc\s*\(\s*\d+\):\sFatal signal (\d+)');
 
   // 'I/DEBUG(pid): ...'
-  static final RegExp _tombstoneLine = new RegExp(r'^I\/DEBUG\s*\(\s*\d+\):\s(.+)$');
+  static final RegExp _tombstoneLine = new RegExp(r'^[IF]\/DEBUG\s*\(\s*\d+\):\s(.+)$');
 
   // 'I/DEBUG(pid): Tombstone written to: '
   static final RegExp _tombstoneTerminator = new RegExp(r'^Tombstone written to:\s');


### PR DESCRIPTION
Related issue: #6530

Engine crashes show up in the log like this:

```
F/libc    (27775): Fatal signal 11 (SIGSEGV), code 1, fault addr 0x0 in tid 27793 (Thread-6300)
*** *** *** *** *** *** *** *** *** *** *** *** *** *** *** ***
Build fingerprint: 'motorola/ghost_verizon/ghost:5.1/LPAS23.12-39.7-1/1:user/release-keys'
Revision: 'p300'
ABI: 'arm'
pid: 27775, tid: 27793, name: Thread-6300  >>> com.endrift.mgba.flutter <<<
signal 11 (SIGSEGV), code 1 (SEGV_MAPERR), fault addr 0x0
    r0 00000000  r1 bef34c20  r2 a435dead  r3 00000000
    r4 b4894e30  r5 9e144600  r6 cccccccd  r7 afc4f2ec
    r8 a24205e0  r9 b4a4eb78  sl a3c62b60  fp b4a4eb78
    ip a4fe2c20  sp a3c62ad8  lr a433941d  pc a433e2c2  cpsr 80000030
backtrace:
    #00 pc 000872c2  /data/app/com.endrift.mgba.flutter-1/lib/arm/libflutter.so
    #01 pc 00082419  /data/app/com.endrift.mgba.flutter-1/lib/arm/libflutter.so
    #02 pc 000a6eb5  /data/app/com.endrift.mgba.flutter-1/lib/arm/libflutter.so
    #03 pc 0008858d  /data/app/com.endrift.mgba.flutter-1/lib/arm/libflutter.so
    #04 pc 0008ac25  /data/app/com.endrift.mgba.flutter-1/lib/arm/libflutter.so
    #05 pc 00011a27  /system/lib/libutils.so (android::SimpleLooperCallback::handleEvent(int, int, void*)+10)
    #06 pc 00012685  /system/lib/libutils.so (android::Looper::pollInner(int)+484)
    #07 pc 0001272d  /system/lib/libutils.so (android::Looper::pollOnce(int, int*, int*, void**)+92)
    #08 pc 00008db1  /system/lib/libandroid.so (ALooper_pollOnce+64)
    #09 pc 0008abdf  /data/app/com.endrift.mgba.flutter-1/lib/arm/libflutter.so
    #10 pc 0008861d  /data/app/com.endrift.mgba.flutter-1/lib/arm/libflutter.so
    #11 pc 000899dd  /data/app/com.endrift.mgba.flutter-1/lib/arm/libflutter.so
    #12 pc 000171ab  /system/lib/libc.so (__pthread_start(void*)+30)
    #13 pc 000150d7  /system/lib/libc.so (__start_thread+6)
Tombstone written to: /data/tombstones/tombstone_09
```

The tombstone doesn't get written to a file, unfortunately, but the ndk-stack does accept the output format.