### PR TITLE
Add border radius to Card

### DIFF
--- a/packages/flutter/lib/src/material/card.dart
+++ b/packages/flutter/lib/src/material/card.dart
@@ -63,6 +63,7 @@ class Card extends StatelessWidget {
     Key key,
     this.color,
     this.elevation: 2.0,
+    this.borderRadius: const BorderRadius.all(const Radius.circular(2.0)),
     this.child,
   }) : super(key: key);
 
@@ -78,6 +79,11 @@ class Card extends StatelessWidget {
   /// Defaults to 2, the appropriate elevation for cards.
   final double elevation;
 
+  /// The border radii that are used for the card.
+  ///
+  /// Defaults to a 2.0 circular radius, the appropriate border radius for cards.
+  final BorderRadius borderRadius;
+
   @override
   Widget build(BuildContext context) {
     return new Semantics(
@@ -88,6 +94,7 @@ class Card extends StatelessWidget {
           color: color,
           type: MaterialType.card,
           elevation: elevation,
+          borderRadius: borderRadius,
           child: child
         )
       ),


### PR DESCRIPTION
This PR adds the border radius to `Card`, so that we can customise the border radius:

![corners](https://user-images.githubusercontent.com/153802/32604001-c750517c-c543-11e7-871b-d2fad327e88b.gif)

This allows us to obtain effects such as those seen in the Google Now feed on Android:

![image](https://user-images.githubusercontent.com/153802/32604077-2e897dd2-c544-11e7-9739-9f98b344645f.png)

Sorry @takhion for doing this before you did but I needed it 💃 
