### PR TITLE
Raise timeout limit for tests that call pub

### DIFF
--- a/packages/flutter_tools/test/commands/packages_test.dart
+++ b/packages/flutter_tools/test/commands/packages_test.dart
@@ -55,7 +55,7 @@ void main() {
       final String projectPath = await runCommand('get');
       expectExists(projectPath, 'lib/main.dart');
       expectExists(projectPath, '.packages');
-    });
+    }, timeout: const Timeout.factor(3.0));
 
     testUsingContext('get --offline', () async {
       final String projectPath = await runCommand('get', args: <String>['--offline']);
@@ -67,7 +67,7 @@ void main() {
       final String projectPath = await runCommand('upgrade');
       expectExists(projectPath, 'lib/main.dart');
       expectExists(projectPath, '.packages');
-    });
+    }, timeout: const Timeout.factor(3.0));
   });
 
   group('packages test/pub', () {


### PR DESCRIPTION
This change aligns the timeouts of `packages_test.dart` with those of `create_test.dart`. It seems that test bots often get timeouts when running tests that invoke `pub`.