### PR TITLE
A bunch of error detection for iOS onboarding flow

### DIFF
--- a/packages/flutter_tools/lib/src/ios/code_signing.dart
+++ b/packages/flutter_tools/lib/src/ios/code_signing.dart
@@ -41,6 +41,9 @@ You can create a new Provisioning Profile for your project in Xcode for your
 team by:
 $fixWithDevelopmentTeamInstruction
 
+It's also possible that a previously installed app with the same Bundle Identifier was
+signed with a different certificate.
+
 For more information, please visit:
   https://flutter.io/setup/#deploy-to-ios-devices
 
@@ -65,8 +68,11 @@ const String fixWithDevelopmentTeamInstruction = '''
        open ios/Runner.xcworkspace
   2- Select the 'Runner' project in the navigator then the 'Runner' target
      in the project settings
-  3- In the 'General' tab, make sure a 'Development Team' is selected. You may need to add
-     your Apple ID first.
+  3- In the 'General' tab, make sure a 'Development Team' is selected. You may need to
+         - Log in with your Apple ID in Xcode first
+         - Ensure you have a valid unique Bundle ID
+         - Register your device with your Apple Developer Account
+         - Let Xcode automatically provision a profile for your app
   4- Build or run your project again''';
 
 final RegExp _securityFindIdentityDeveloperIdentityExtractionPattern =

--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -354,11 +354,9 @@ Future<XcodeBuildResult> buildXcodeProject({
 Future<Null> diagnoseXcodeBuildFailure(XcodeBuildResult result, BuildableIOSApp app) async {
   if (result.xcodeBuildExecution != null &&
       result.xcodeBuildExecution.buildForPhysicalDevice &&
-      ((result.stdout?.contains('BCEROR') == true &&
-          // May need updating if Xcode changes its outputs.
-          result.stdout?.contains('Xcode couldn\'t find a provisioning profile matching') == true)
-          // Error message from ios-deploy for missing provisioning profile.
-          || result.stdout?.contains('0xe8008015') == true)) {
+      result.stdout?.contains('BCEROR') == true &&
+      // May need updating if Xcode changes its outputs.
+      result.stdout?.contains('Xcode couldn\'t find a provisioning profile matching') == true) {
     printError(noProvisioningProfileInstruction, emphasis: true);
     return;
   }

--- a/packages/flutter_tools/test/ios/mac_test.dart
+++ b/packages/flutter_tools/test/ios/mac_test.dart
@@ -326,33 +326,6 @@ Error launching application on iPhone.''',
       );
     });
 
-    testUsingContext('No ios-deploy provisioning profile shows message', () async {
-      final XcodeBuildResult buildResult = new XcodeBuildResult(
-        success: false,
-        stdout: '''
-Launching lib/main.dart on iPhone in debug mode...
-Signing iOS app for device deployment using developer identity: "iPhone Developer: test@flutter.io (1122334455)"
-Running Xcode build...                                1.3s
-Installing on iPhone...
-
-ios-deploy[75050:1892997] [ !! ] Error 0xe8008015: A valid provisioning profile for this executable was not found. AMDeviceSecureInstallApplication(0, device, url, options, install_callback, 0)
-Could not install build/ios/iphoneos/Runner.app on 7233072bb988fb4c64429a4d9a092295f9423892.
-
-Error launching application on iPhone.''',
-        xcodeBuildExecution: new XcodeBuildExecution(
-          <String>['xcrun', 'xcodebuild', 'blah'],
-          '/blah/blah',
-          buildForPhysicalDevice: true
-        ),
-      );
-
-      await diagnoseXcodeBuildFailure(buildResult, app);
-      expect(
-        testLogger.errorText,
-        contains('No Provisioning Profile was found for your project\'s Bundle Identifier or your device.'),
-      );
-    });
-
     testUsingContext('No development team shows message', () async {
       final XcodeBuildResult buildResult = new XcodeBuildResult(
         success: false,


### PR DESCRIPTION
Fixes #10886
Fixes #12892

Partly reverts and moves #12911 because it was in the wrong place.

- Check for locked phone
- Check for incompatible Xcode
- Check for unregistered phone
- Check for conflicting certificates

Unfortunately tests needs a much bigger refactor in the installation flow. 