### PR TITLE
Support IPv6-only hosts in vmservice_test.dart.

### DIFF
--- a/packages/flutter_tools/lib/src/base/port_scanner.dart
+++ b/packages/flutter_tools/lib/src/base/port_scanner.dart
@@ -61,7 +61,12 @@ class HostPortScanner extends PortScanner {
 
   @override
   Future<int> findAvailablePort() async {
-    final ServerSocket socket = await ServerSocket.bind(InternetAddress.LOOPBACK_IP_V4, 0);
+    ServerSocket socket;
+    try {
+      socket = await ServerSocket.bind(InternetAddress.LOOPBACK_IP_V4, 0);
+    } on SocketException {
+      socket = await ServerSocket.bind(InternetAddress.LOOPBACK_IP_V6, 0, v6Only: true);
+    }
     final int port = socket.port;
     await socket.close();
     return port;


### PR DESCRIPTION
If we fail to bind to IPv4 loopback, try IPv6. Some hosts only support IPv6,
causing the test in vmservice_test.dart to fail, since it couldn't find an
available port.