### PR TITLE
Turn on concurrency for coverage shard so that it runs in parallel to fix Travis timeouts.

### DIFF
--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -174,7 +174,7 @@ Future<Null> _runCoverage() async {
   if (Platform.environment['TRAVIS'] == null ||
       Platform.environment['TRAVIS_PULL_REQUEST'] != 'false' ||
       Platform.environment['TRAVIS_OS_NAME'] != 'linux') {
-    print('${bold}DONE: test.dart does not run coverage for Travis pull requests or not non-Linux environments');
+    print('${bold}DONE: test.dart does not run coverage for Travis pull requests or in non-Linux environments');
     return;
   }
 

--- a/packages/flutter_tools/lib/src/test/runner.dart
+++ b/packages/flutter_tools/lib/src/test/runner.dart
@@ -34,11 +34,6 @@ Future<int> runTests(
   if (!terminal.supportsColor)
     testArgs.addAll(<String>['--no-color', '-rexpanded']);
 
-  if (enableObservatory) {
-    // (In particular, for collecting code coverage.)
-    testArgs.add('--concurrency=1');
-  }
-
   if (machine) {
     testArgs.addAll(<String>['-r', 'json']);
   }


### PR DESCRIPTION
I ran this locally, and all tests passed, and the new coverage data looks reasonable.

Also, fixed a typo.