### PR TITLE
Add support for baseline alignment to TextField (RenderEditable)

### DIFF
--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -456,12 +456,6 @@ class RenderEditable extends RenderBox {
     return _textPainter.maxIntrinsicWidth;
   }
 
-  @override
-  double computeDistanceToActualBaseline(TextBaseline baseline) {
-    _layoutText(double.INFINITY);
-    return _textPainter.computeDistanceToActualBaseline(baseline);
-  }
-
   /// An estimate of the height of a line in the text. See [TextPainter.preferredLineHeight].
   /// This does not required the layout to be updated.
   double get preferredLineHeight => _textPainter.preferredLineHeight;
@@ -490,6 +484,12 @@ class RenderEditable extends RenderBox {
   @override
   double computeMaxIntrinsicHeight(double width) {
     return _preferredHeight(width);
+  }
+
+  @override
+  double computeDistanceToActualBaseline(TextBaseline baseline) {
+    _layoutText(constraints.maxWidth);
+    return _textPainter.computeDistanceToActualBaseline(baseline);
   }
 
   @override

--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -456,6 +456,12 @@ class RenderEditable extends RenderBox {
     return _textPainter.maxIntrinsicWidth;
   }
 
+  @override
+  double computeDistanceToActualBaseline(TextBaseline baseline) {
+    _layoutText(double.INFINITY);
+    return _textPainter.computeDistanceToActualBaseline(baseline);
+  }
+
   /// An estimate of the height of a line in the text. See [TextPainter.preferredLineHeight].
   /// This does not required the layout to be updated.
   double get preferredLineHeight => _textPainter.preferredLineHeight;

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -1690,4 +1690,56 @@ void main() {
     // Confirm that the selection was updated.
     expect(controller.selection.baseOffset, 0);
   });
+
+  testWidgets('TextField baseline alignment', (WidgetTester tester) async {
+    final TextEditingController controllerA = new TextEditingController(text: 'A');
+    final TextEditingController controllerB = new TextEditingController(text: 'B');
+    final Key keyA = new UniqueKey();
+    final Key keyB = new UniqueKey();
+
+    await tester.pumpWidget(
+      overlay(
+        child: new Row(
+          crossAxisAlignment: CrossAxisAlignment.baseline,
+          textBaseline: TextBaseline.alphabetic,
+          children: <Widget>[
+            new Expanded(
+              child: new TextField(
+                key: keyA,
+                decoration: null,
+                controller: controllerA,
+                style: const TextStyle(fontSize: 10.0),
+              )
+            ),
+            const Text(
+              'abc',
+              style: const TextStyle(fontSize: 20.0),
+            ),
+            new Expanded(
+              child: new TextField(
+                key: keyB,
+                decoration: null,
+                controller: controllerB,
+                style: const TextStyle(fontSize: 30.0),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+
+    // The Ahem font extends 0.2 * fontSize below the baseline.
+    // So the three row elements line up like this:
+    //
+    //  A  abc  B
+    //  ---------   baseline
+    //  2  4    6   space below the baseline = 0.2 * fontSize
+    //  ---------   rowBottomY
+
+    final double rowBottomY = tester.getBottomLeft(find.byType(Row)).dy;
+    expect(tester.getBottomLeft(find.byKey(keyA)).dy, rowBottomY - 4.0);
+    expect(tester.getBottomLeft(find.text('abc')).dy, rowBottomY - 2.0);
+    expect(tester.getBottomLeft(find.byKey(keyB)).dy, rowBottomY);
+  });
+
 }


### PR DESCRIPTION
RenderEditable lacks a `computeDistanceToActualBaseline` override.

Fixes https://github.com/flutter/flutter/issues/13004
