### PR TITLE
Switching coverage runs from Travis to infrabots.

### DIFF
--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -171,10 +171,8 @@ Future<Null> _runTests() async {
 }
 
 Future<Null> _runCoverage() async {
-  if (Platform.environment['TRAVIS'] == null ||
-      Platform.environment['TRAVIS_PULL_REQUEST'] != 'false' ||
-      Platform.environment['TRAVIS_OS_NAME'] != 'linux') {
-    print('${bold}DONE: test.dart does not run coverage for Travis pull requests or in non-Linux environments');
+  if (Platform.environment['TRAVIS'] != null) {
+    print('${bold}DONE: test.dart does not run coverage in Travis$reset');
     return;
   }
 

--- a/dev/bots/travis_upload.sh
+++ b/dev/bots/travis_upload.sh
@@ -4,23 +4,6 @@ set -ex
 
 export PATH="$PWD/bin:$PWD/bin/cache/dart-sdk/bin:$PATH"
 
-LCOV_FILE=./packages/flutter/coverage/lcov.info
-
-if [ "$TRAVIS_OS_NAME" = "linux" ] && \
-   [ "$SHARD" = "coverage" ] && \
-   [ "$TRAVIS_PULL_REQUEST" = "false" ] && \
-   [ "$TRAVIS_BRANCH" = "master" ] && \
-   [ -f "$LCOV_FILE" ]; then
-  GSUTIL=$HOME/google-cloud-sdk/bin/gsutil
-  GCLOUD=$HOME/google-cloud-sdk/bin/gcloud
-
-  $GCLOUD auth activate-service-account --key-file ../gcloud_key_file.json
-  STORAGE_URL=gs://flutter_infra/flutter/coverage/lcov.info
-  $GSUTIL cp $LCOV_FILE $STORAGE_URL
-
-  (cd packages/flutter && coveralls-lcov coverage/lcov.info)
-fi
-
 if [ "$TRAVIS_OS_NAME" = "linux" ] && \
    [ "$SHARD" = "docs" ]; then
   # generate the API docs, upload them


### PR DESCRIPTION
This switches the bot test so that instead of coverage running on Travis, it runs on the infra bots.

Until this change lands, the infra bots will attempt to run coverage, but will only print that they are done.

After the change lands, then coverage will not run on Travis anymore.