### PR TITLE
Remove the coverage shard from Travis completely.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,6 @@ install:
 env:
   - SHARD=analyze
   - SHARD=tests
-  - SHARD=coverage
   - SHARD=docs
 before_script:
   - ./dev/bots/travis_setup.sh
@@ -33,7 +32,5 @@ matrix:
   exclude:
   - os: osx
     env: SHARD=analyze
-  - os: osx
-    env: SHARD=coverage
   - os: osx
     env: SHARD=docs


### PR DESCRIPTION
Now that we know that coverage runs work on the infrabots, this removes the coverage shard from Travis completely.