### PR TITLE
Fix table formatting in MultiFrameImageStreamCompleter doc.

### DIFF
--- a/packages/flutter/lib/src/services/image_stream.dart
+++ b/packages/flutter/lib/src/services/image_stream.dart
@@ -312,14 +312,14 @@ class OneFrameImageStreamCompleter extends ImageStreamCompleter {
 ///
 /// See the following timeline example:
 ///
-/// | Time | Event                                      | Comment                   |
-/// |------|--------------------------------------------|---------------------------|
-/// | t1   | App frame scheduled (image frame A posted) |                           |
-/// | t2   | App frame scheduled                        |                           |
-/// | t3   | App frame scheduled                        |                           |
-/// | t4   | Image frame B decoded                      |                           |
-/// | t5   | App frame scheduled                        | t5 - t1 < frameB_duration | 
-/// | t6   | App frame scheduled (image frame B posted) | t6 - t1 > frameB_duration |
+///   | Time | Event                                      | Comment                   |
+///   |------|--------------------------------------------|---------------------------|
+///   | t1   | App frame scheduled (image frame A posted) |                           |
+///   | t2   | App frame scheduled                        |                           |
+///   | t3   | App frame scheduled                        |                           |
+///   | t4   | Image frame B decoded                      |                           |
+///   | t5   | App frame scheduled                        | t5 - t1 < frameB_duration | 
+///   | t6   | App frame scheduled (image frame B posted) | t6 - t1 > frameB_duration |
 ///
 class MultiFrameImageStreamCompleter extends ImageStreamCompleter {
   /// Creates a image stream completer.


### PR DESCRIPTION
Dart doc currently don't support table markdown - https://github.com/dart-lang/dartdoc/issues/1453

For now, just show the table as pre-formatted text.