### PR TITLE
Fix spelling errors in all the dartdocs.

### DIFF
--- a/dev/devicelab/lib/framework/adb.dart
+++ b/dev/devicelab/lib/framework/adb.dart
@@ -44,7 +44,7 @@ abstract class DeviceDiscovery {
   ///
   /// Returns the same device when called repeatedly (unlike
   /// [chooseWorkingDevice]). This is useful when you need to perform multiple
-  /// perations on one.
+  /// operations on one.
   Future<Device> get workingDevice;
 
   /// Lists all available devices' IDs.

--- a/dev/devicelab/lib/tasks/microbenchmarks.dart
+++ b/dev/devicelab/lib/tasks/microbenchmarks.dart
@@ -13,7 +13,7 @@ import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/framework/ios.dart';
 import 'package:flutter_devicelab/framework/utils.dart';
 
-/// The maximum amount of time a single microbenchmarks is allowed to take.
+/// The maximum amount of time a single microbenchmark is allowed to take.
 const Duration _kBenchmarkTimeout = const Duration(minutes: 6);
 
 /// Creates a device lab task that runs benchmarks in

--- a/examples/flutter_gallery/lib/demo/calculator/logic.dart
+++ b/examples/flutter_gallery/lib/demo/calculator/logic.dart
@@ -246,7 +246,7 @@ class CalcExpression {
   /// Append a minus sign to the current expression and return a new expression
   /// representing the result. Returns null to indicate that it is not legal
   /// to append a minus sign in the current state. Depending on the current
-  /// state the minus sign will be interpretted as either a leading negative
+  /// state the minus sign will be interpreted as either a leading negative
   /// sign or a subtraction operation.
   CalcExpression appendMinus() {
     switch (state) {

--- a/examples/layers/rendering/touch_input.dart
+++ b/examples/layers/rendering/touch_input.dart
@@ -56,7 +56,7 @@ class RenderDots extends RenderBox {
     size = constraints.biggest;
   }
 
-  /// Makes this render object hitable so that it receives pointer events.
+  /// Makes this render object hittable so that it receives pointer events.
   @override
   bool hitTestSelf(Offset position) => true;
 

--- a/examples/layers/rendering/touch_input.dart
+++ b/examples/layers/rendering/touch_input.dart
@@ -48,7 +48,7 @@ class RenderDots extends RenderBox {
   @override
   bool get sizedByParent => true;
 
-  /// By selecting the biggest value permitted by the incomming constraints
+  /// By selecting the biggest value permitted by the incoming constraints
   /// during layout, this function makes this render object as large as
   /// possible (i.e., fills the entire screen).
   @override
@@ -56,7 +56,7 @@ class RenderDots extends RenderBox {
     size = constraints.biggest;
   }
 
-  /// Makes this render object hittable so that it receives pointer events.
+  /// Makes this render object hitable so that it receives pointer events.
   @override
   bool hitTestSelf(Offset position) => true;
 

--- a/packages/flutter/lib/src/animation/animation_controller.dart
+++ b/packages/flutter/lib/src/animation/animation_controller.dart
@@ -85,7 +85,7 @@ const Tolerance _kFlingTolerance = const Tolerance(
 /// }
 /// ```
 ///
-/// ...which asynchnorously runs one animation, then runs another, then changes
+/// ...which asynchronously runs one animation, then runs another, then changes
 /// the state of the widget, without having to verify [State.mounted] is still
 /// true at each step, and without having to chain futures together explicitly.
 /// (This assumes that the controllers are created in [State.initState] and

--- a/packages/flutter/lib/src/animation/animations.dart
+++ b/packages/flutter/lib/src/animation/animations.dart
@@ -156,7 +156,7 @@ abstract class AnimationWithParentMixin<T> {
 ///
 /// A proxy animation is useful because the parent animation can be mutated. For
 /// example, one object can create a proxy animation, hand the proxy to another
-/// object, and then later change the animation from which the proxy receieves
+/// object, and then later change the animation from which the proxy receives
 /// its value.
 class ProxyAnimation extends Animation<double>
   with AnimationLazyListenerMixin, AnimationLocalListenersMixin, AnimationLocalStatusListenersMixin {

--- a/packages/flutter/lib/src/animation/curves.dart
+++ b/packages/flutter/lib/src/animation/curves.dart
@@ -247,7 +247,7 @@ class Cubic extends Curve {
 
 /// A curve that is the reversed inversion of its given curve.
 ///
-/// This curve evalutes the given curve in reverse (i.e., from 1.0 to 0.0 as t
+/// This curve evaluates the given curve in reverse (i.e., from 1.0 to 0.0 as t
 /// increases from 0.0 to 1.0) and returns the inverse of the given curve's value
 /// (i.e., 1.0 minus the given curve's value).
 ///
@@ -534,17 +534,17 @@ class Curves {
   /// ![](https://flutter.github.io/assets-for-api-docs/animation/curve_bounce_in_out.png)
   static const Curve bounceInOut = const _BounceInOutCurve._();
 
-  /// An oscillating curve that grows in magnitude while overshootings its bounds.
+  /// An oscillating curve that grows in magnitude while overshooting its bounds.
   ///
   /// ![](https://flutter.github.io/assets-for-api-docs/animation/curve_elastic_in.png)
   static const ElasticInCurve elasticIn = const ElasticInCurve();
 
-  /// An oscillating curve that shrinks in magnitude while overshootings its bounds.
+  /// An oscillating curve that shrinks in magnitude while overshooting its bounds.
   ///
   /// ![](https://flutter.github.io/assets-for-api-docs/animation/curve_elastic_out.png)
   static const ElasticOutCurve elasticOut = const ElasticOutCurve();
 
-  /// An oscillating curve that grows and then shrinks in magnitude while overshootings its bounds.
+  /// An oscillating curve that grows and then shrinks in magnitude while overshooting its bounds.
   ///
   /// ![](https://flutter.github.io/assets-for-api-docs/animation/curve_elastic_in_out.png)
   static const ElasticInOutCurve elasticInOut = const ElasticInOutCurve();

--- a/packages/flutter/lib/src/cupertino/bottom_tab_bar.dart
+++ b/packages/flutter/lib/src/cupertino/bottom_tab_bar.dart
@@ -187,7 +187,7 @@ class CupertinoTabBar extends StatelessWidget implements PreferredSizeWidget {
   }
 
   /// Create a clone of the current [CupertinoTabBar] but with provided
-  /// parameters overriden.
+  /// parameters overridden.
   CupertinoTabBar copyWith({
     Key key,
     List<BottomNavigationBarItem> items,

--- a/packages/flutter/lib/src/cupertino/route.dart
+++ b/packages/flutter/lib/src/cupertino/route.dart
@@ -200,7 +200,7 @@ class CupertinoPageRoute<T> extends PageRoute<T> {
   /// Begin dismissing this route from a horizontal swipe, if appropriate.
   ///
   /// Swiping will be disabled if the page is a fullscreen dialog or if
-  /// dismissals can be overriden because a [WillPopCallback] was
+  /// dismissals can be overridden because a [WillPopCallback] was
   /// defined for the route.
   ///
   /// When this method decides a pop gesture is appropriate, it returns a

--- a/packages/flutter/lib/src/foundation/change_notifier.dart
+++ b/packages/flutter/lib/src/foundation/change_notifier.dart
@@ -35,7 +35,7 @@ abstract class Listenable {
 /// A class that can be extended or mixed in that provides a change notification
 /// API using [VoidCallback] for notifications.
 ///
-/// [ChangeNotifier] is optimised for small numbers (one or two) of listeners.
+/// [ChangeNotifier] is optimized for small numbers (one or two) of listeners.
 /// It is O(N) for adding and removing listeners and O(N²) for dispatching
 /// notifications (where N is the number of listeners).
 ///

--- a/packages/flutter/lib/src/foundation/diagnostics.dart
+++ b/packages/flutter/lib/src/foundation/diagnostics.dart
@@ -363,7 +363,7 @@ final TextTreeConfiguration sparseTextConfiguration = new TextTreeConfiguration(
 ///
 /// See also:
 ///
-///  * [DiagnosticsTreeStyle.offstage], uses this style for ascii art display.
+///  * [DiagnosticsTreeStyle.offstage], uses this style for ASCII art display.
 final TextTreeConfiguration dashedTextConfiguration = new TextTreeConfiguration(
   prefixLineOne:            '╎╌',
   prefixLastChildLineOne:   '└╌',

--- a/packages/flutter/lib/src/gestures/arena.dart
+++ b/packages/flutter/lib/src/gestures/arena.dart
@@ -60,7 +60,7 @@ class _GestureArena {
   bool hasPendingSweep = false;
 
   /// If a gesture attempts to win while the arena is still open, it becomes the
-  /// "eager winnner". We look for an eager winner when closing the arena to new
+  /// "eager winner". We look for an eager winner when closing the arena to new
   /// participants, and if there is one, we resolve the arena in its favor at
   /// that time.
   GestureArenaMember eagerWinner;

--- a/packages/flutter/lib/src/gestures/events.dart
+++ b/packages/flutter/lib/src/gestures/events.dart
@@ -35,7 +35,7 @@ const int kMiddleMouseButton = 0x04;
 
 /// The bit of [PointerEvent.buttons] that corresponds to the secondary stylus button.
 ///
-/// The secondary stylus button is typically on the end of the stylus fartherest
+/// The secondary stylus button is typically on the end of the stylus farthest
 /// from the tip but can be reconfigured to be a different physical button.
 const int kSecondaryStylusButton = 0x04;
 
@@ -74,7 +74,7 @@ int nthStylusButton(int number) => (kPrimaryStylusButton << (number - 1)) & kMax
 /// logical pixels. Logical pixels approximate a grid with about 38 pixels per
 /// centimeter, or 96 pixels per inch.
 ///
-/// This allows gestures to be recognised independent of the precise hardware
+/// This allows gestures to be recognized independent of the precise hardware
 /// characteristics of the device. In particular, features such as touch slop
 /// (see [kTouchSlop]) can be defined in terms of roughly physical lengths so
 /// that the user can shift their finger by the same distance on a high-density
@@ -241,7 +241,7 @@ abstract class PointerEvent {
   /// in pointer behaviors.
   ///
   /// For instance, on end events, Android always drops any location changes
-  /// that happened between its reporting intervals when emiting the end events.
+  /// that happened between its reporting intervals when emitting the end events.
   ///
   /// On iOS, minor incorrect location changes from the previous move events
   /// can be reported on end events. We synthesize a [PointerEvent] to cover

--- a/packages/flutter/lib/src/gestures/long_press.dart
+++ b/packages/flutter/lib/src/gestures/long_press.dart
@@ -19,7 +19,7 @@ class LongPressGestureRecognizer extends PrimaryPointerGestureRecognizer {
   /// Consider assigning the [onLongPress] callback after creating this object.
   LongPressGestureRecognizer({ Object debugOwner }) : super(deadline: kLongPressTimeout, debugOwner: debugOwner);
 
-  /// Called when a long-press is recongized.
+  /// Called when a long-press is recognized.
   GestureLongPressCallback onLongPress;
 
   @override

--- a/packages/flutter/lib/src/gestures/multidrag.dart
+++ b/packages/flutter/lib/src/gestures/multidrag.dart
@@ -503,7 +503,7 @@ class _DelayedPointerState extends MultiDragPointerState {
 /// Recognizes movement both horizontally and vertically on a per-pointer basis
 /// after a delay.
 ///
-/// In constrast to [ImmediateMultiDragGestureRecognizer],
+/// In contrast to [ImmediateMultiDragGestureRecognizer],
 /// [DelayedMultiDragGestureRecognizer] waits for a [delay] before recognizing
 /// the drag. If the pointer moves more than [kTouchSlop] before the delay
 /// expires, the gesture is not recognized.

--- a/packages/flutter/lib/src/gestures/scale.dart
+++ b/packages/flutter/lib/src/gestures/scale.dart
@@ -102,7 +102,7 @@ bool _isFlingGesture(Velocity velocity) {
 /// Recognizes a scale gesture.
 ///
 /// [ScaleGestureRecognizer] tracks the pointers in contact with the screen and
-/// calculates their focal point and indiciated scale. When a focal pointer is
+/// calculates their focal point and indicated scale. When a focal pointer is
 /// established, the recognizer calls [onStart]. As the focal point and scale
 /// change, the recognizer calls [onUpdate]. When the pointers are no longer in
 /// contact with the screen, the recognizer calls [onEnd].

--- a/packages/flutter/lib/src/material/arc.dart
+++ b/packages/flutter/lib/src/material/arc.dart
@@ -224,7 +224,7 @@ T _maxBy<T>(Iterable<T> input, _KeyFunc<T> keyFunc) {
 ///  * [MaterialRectCenterArcTween], which interpolates a rect along a circular
 ///    arc between the begin and end [Rect]'s centers.
 ///  * [Tween], for a discussion on how to use interpolation objects.
-///  * [MaterialPointArcTween], the analogue for [Offset] interporation.
+///  * [MaterialPointArcTween], the analogue for [Offset] interpolation.
 ///  * [RectTween], which does a linear rectangle interpolation.
 ///  * [Hero.createRectTween], which can be used to specify the tween that defines
 ///    a hero's path.
@@ -340,7 +340,7 @@ class MaterialRectArcTween extends RectTween {
 ///  * [MaterialRectArcTween], A [Tween] that interpolates a [Rect] by having
 ///    its opposite corners follow circular arcs.
 ///  * [Tween], for a discussion on how to use interpolation objects.
-///  * [MaterialPointArcTween], the analogue for [Offset] interporation.
+///  * [MaterialPointArcTween], the analogue for [Offset] interpolation.
 ///  * [RectTween], which does a linear rectangle interpolation.
 ///  * [Hero.createRectTween], which can be used to specify the tween that defines
 ///    a hero's path.

--- a/packages/flutter/lib/src/material/back_button.dart
+++ b/packages/flutter/lib/src/material/back_button.dart
@@ -26,7 +26,7 @@ class BackButtonIcon extends StatelessWidget {
   /// the current platform (as obtained from the [Theme]).
   const BackButtonIcon({ Key key }) : super(key: key);
 
-  /// Returns tha appropriate "back" icon for the given `platform`.
+  /// Returns the appropriate "back" icon for the given `platform`.
   static IconData _getIconData(TargetPlatform platform) {
     switch (platform) {
       case TargetPlatform.android:

--- a/packages/flutter/lib/src/material/expand_icon.dart
+++ b/packages/flutter/lib/src/material/expand_icon.dart
@@ -48,7 +48,7 @@ class ExpandIcon extends StatefulWidget {
   /// If this is set to null, the button will be disabled.
   final ValueChanged<bool> onPressed;
 
-  /// The padding around the icon. The entire padded icon will reactb to input
+  /// The padding around the icon. The entire padded icon will react to input
   /// gestures.
   ///
   /// This property must not be null. It defaults to 8.0 padding on all sides.

--- a/packages/flutter/lib/src/material/icon_button.dart
+++ b/packages/flutter/lib/src/material/icon_button.dart
@@ -113,7 +113,7 @@ class IconButton extends StatelessWidget {
   /// The icon to display inside the button.
   ///
   /// The [Icon.size] and [Icon.color] of the icon is configured automatically
-  /// based on the [iconSize] nad [color] properties of _this_ widget using an
+  /// based on the [iconSize] and [color] properties of _this_ widget using an
   /// [IconTheme] and therefore should not be explicitly given in the icon
   /// widget.
   ///
@@ -149,7 +149,7 @@ class IconButton extends StatelessWidget {
   final Color splashColor;
 
   /// The secondary color of the button when the button is in the down (pressed)
-  /// state. The higlight color is represented as a solid color that is overlaid over the
+  /// state. The highlight color is represented as a solid color that is overlaid over the
   /// button color (if any). If the highlight color has transparency, the button color
   /// will show through. The highlight fades in quickly as the button is held down.
   ///

--- a/packages/flutter/lib/src/material/input_decorator.dart
+++ b/packages/flutter/lib/src/material/input_decorator.dart
@@ -352,7 +352,7 @@ class InputDecoration {
 ///  * [Decoration] and [DecoratedBox], for drawing arbitrary decorations
 ///    around other widgets.
 class InputDecorator extends StatelessWidget {
-  /// Creates a widget that displayes labels and other visual elements similar
+  /// Creates a widget that displays labels and other visual elements similar
   /// to a [TextField].
   ///
   /// The [isFocused] and [isEmpty] arguments must not be null.

--- a/packages/flutter/lib/src/material/material.dart
+++ b/packages/flutter/lib/src/material/material.dart
@@ -432,7 +432,7 @@ abstract class InkFeature {
   /// Override this method to paint the ink feature.
   ///
   /// The transform argument gives the coordinate conversion from the coordinate
-  /// system of the canvas to the coodinate system of the [referenceBox].
+  /// system of the canvas to the coordinate system of the [referenceBox].
   @protected
   void paintFeature(Canvas canvas, Matrix4 transform);
 

--- a/packages/flutter/lib/src/material/material_localizations.dart
+++ b/packages/flutter/lib/src/material/material_localizations.dart
@@ -19,7 +19,7 @@ import 'typography.dart';
 ///  * [GlobalMaterialLocalizations], which provides material localizations for
 ///    many languages.
 abstract class MaterialLocalizations {
-  /// The tooltip for the leading [AppBar] menu (aka 'hamburger') button.
+  /// The tooltip for the leading [AppBar] menu (a.k.a. 'hamburger') button.
   String get openAppDrawerTooltip;
 
   /// The [BackButton]'s tooltip.

--- a/packages/flutter/lib/src/material/paginated_data_table.dart
+++ b/packages/flutter/lib/src/material/paginated_data_table.dart
@@ -23,7 +23,7 @@ import 'theme.dart';
 /// A material design data table that shows data using multiple pages.
 ///
 /// A paginated data table shows [rowsPerPage] rows of data per page and
-/// provies controls for showing other pages.
+/// provides controls for showing other pages.
 ///
 /// Data is read lazily from from a [DataTableSource]. The widget is presented
 /// as a [Card].

--- a/packages/flutter/lib/src/material/progress_indicator.dart
+++ b/packages/flutter/lib/src/material/progress_indicator.dart
@@ -28,7 +28,7 @@ abstract class ProgressIndicator extends StatefulWidget {
   /// Creates a progress indicator.
   ///
   /// The [value] argument can be either null (corresponding to an indeterminate
-  /// progress indcator) or non-null (corresponding to a determinate progress
+  /// progress indicator) or non-null (corresponding to a determinate progress
   /// indicator). See [value] for details.
   const ProgressIndicator({
     Key key,
@@ -156,7 +156,7 @@ class LinearProgressIndicator extends ProgressIndicator {
   /// Creates a linear progress indicator.
   ///
   /// The [value] argument can be either null (corresponding to an indeterminate
-  /// progress indcator) or non-null (corresponding to a determinate progress
+  /// progress indicator) or non-null (corresponding to a determinate progress
   /// indicator). See [value] for details.
   const LinearProgressIndicator({
     Key key,
@@ -315,7 +315,7 @@ class CircularProgressIndicator extends ProgressIndicator {
   /// Creates a circular progress indicator.
   ///
   /// The [value] argument can be either null (corresponding to an indeterminate
-  /// progress indcator) or non-null (corresponding to a determinate progress
+  /// progress indicator) or non-null (corresponding to a determinate progress
   /// indicator). See [value] for details.
   const CircularProgressIndicator({
     Key key,

--- a/packages/flutter/lib/src/material/refresh_indicator.dart
+++ b/packages/flutter/lib/src/material/refresh_indicator.dart
@@ -73,7 +73,7 @@ enum _RefreshIndicatorMode {
 /// See also:
 ///
 ///  * <https://material.google.com/patterns/swipe-to-refresh.html>
-///  * [RefreshIndicatorState], can be used to programatically show the refresh indicator.
+///  * [RefreshIndicatorState], can be used to programmatically show the refresh indicator.
 ///  * [RefreshProgressIndicator].
 class RefreshIndicator extends StatefulWidget {
   /// Creates a refresh indicator.

--- a/packages/flutter/lib/src/material/scaffold.dart
+++ b/packages/flutter/lib/src/material/scaffold.dart
@@ -704,12 +704,12 @@ class ScaffoldState extends State<Scaffold> with TickerProviderStateMixin {
   /// of the app. Modal bottom sheets can be created and displayed with the
   /// [showModalBottomSheet] function.
   ///
-  /// Returns a contoller that can be used to close and otherwise manipulate the
+  /// Returns a controller that can be used to close and otherwise manipulate the
   /// button sheet.
   ///
   /// See also:
   ///
-  ///  * [BottomSheet], which is the widget typicaly returned by the `builder`.
+  ///  * [BottomSheet], which is the widget typically returned by the `builder`.
   ///  * [showModalBottomSheet], which can be used to display a modal bottom
   ///    sheet.
   ///  * [Scaffold.of], for information about how to obtain the [ScaffoldState].

--- a/packages/flutter/lib/src/material/stepper.dart
+++ b/packages/flutter/lib/src/material/stepper.dart
@@ -104,7 +104,7 @@ class Step {
   /// Below the content, every step has a 'continue' and 'cancel' button.
   final Widget content;
 
-  /// The state of the step which determines the styling of its componenents
+  /// The state of the step which determines the styling of its components
   /// and whether steps are interactive.
   final StepState state;
 

--- a/packages/flutter/lib/src/material/tabs.dart
+++ b/packages/flutter/lib/src/material/tabs.dart
@@ -410,7 +410,7 @@ class _TabBarScrollController extends ScrollController {
 /// A material design widget that displays a horizontal row of tabs.
 ///
 /// Typically created as the [AppBar.bottom] part of an [AppBar] and in
-/// conjuction with a [TabBarView].
+/// conjunction with a [TabBarView].
 ///
 /// If a [TabController] is not provided, then there must be a
 /// [DefaultTabController] ancestor. The tab controller's [TabController.length]
@@ -1033,7 +1033,7 @@ class TabPageSelectorIndicator extends StatelessWidget {
 }
 
 /// Displays a row of small circular indicators, one per tab. The selected
-/// tab's indicator is highlighted. Often used in conjuction with a [TabBarView].
+/// tab's indicator is highlighted. Often used in conjunction with a [TabBarView].
 ///
 /// If a [TabController] is not provided, then there must be a [DefaultTabController]
 /// ancestor.
@@ -1056,12 +1056,12 @@ class TabPageSelector extends StatelessWidget {
   /// The indicator circle's diameter (the default value is 12.0).
   final double indicatorSize;
 
-  /// The indicator cicle's fill color for unselected pages.
+  /// The indicator circle's fill color for unselected pages.
   ///
   /// If this parameter is null then the indicator is filled with [Colors.transparent].
   final Color color;
 
-  /// The indicator cicle's fill color for selected pages and border color
+  /// The indicator circle's fill color for selected pages and border color
   /// for all indicator circles.
   ///
   /// If this parameter is null then the indicator is filled with the theme's

--- a/packages/flutter/lib/src/material/time_picker.dart
+++ b/packages/flutter/lib/src/material/time_picker.dart
@@ -158,7 +158,7 @@ class _TimePickerHeaderPiece {
 /// out horizontally. Pieces are laid out horizontally if portrait orientation,
 /// and vertically in landscape orientation.
 ///
-/// One of the pieces is identified as a _centrepiece_. It is a piece that is
+/// One of the pieces is identified as a _centerpiece_. It is a piece that is
 /// positioned in the center of the header, with all other pieces positioned
 /// to the left or right of it.
 class _TimePickerHeaderFormat {

--- a/packages/flutter/lib/src/material/two_level_list.dart
+++ b/packages/flutter/lib/src/material/two_level_list.dart
@@ -107,7 +107,7 @@ class TwoLevelListItem extends StatelessWidget {
 /// This class is deprecated. Please use [ExpansionTile] instead.
 @deprecated
 class TwoLevelSublist extends StatefulWidget {
-  /// Creates an item in a two-level list that can expland and collapse.
+  /// Creates an item in a two-level list that can expand and collapse.
   const TwoLevelSublist({
     Key key,
     this.leading,

--- a/packages/flutter/lib/src/material/typography.dart
+++ b/packages/flutter/lib/src/material/typography.dart
@@ -91,7 +91,7 @@ class TextTheme {
   /// Used for the default text style for [Material].
   final TextStyle body1;
 
-  /// Used for auxillary text associated with images.
+  /// Used for auxiliary text associated with images.
   final TextStyle caption;
 
   /// Used for text on [RaisedButton] and [FlatButton].

--- a/packages/flutter/lib/src/material/user_accounts_drawer_header.dart
+++ b/packages/flutter/lib/src/material/user_accounts_drawer_header.dart
@@ -131,7 +131,7 @@ class _AccountDetails extends StatelessWidget {
 ///
 /// See also:
 ///
-///  * [DrawerHeader], for a drawer header that doesn't show user acounts
+///  * [DrawerHeader], for a drawer header that doesn't show user accounts
 ///  * <https://material.google.com/patterns/navigation-drawer.html>
 class UserAccountsDrawerHeader extends StatefulWidget {
   /// Creates a material design drawer header.

--- a/packages/flutter/lib/src/painting/alignment.dart
+++ b/packages/flutter/lib/src/painting/alignment.dart
@@ -148,7 +148,7 @@ abstract class AlignmentGeometry {
 /// `Alignment(1.0, 1.0)` represents the bottom right of the rectangle.
 ///
 /// `Alignment(0.0, 3.0)` represents a point that is horizontally centered with
-/// respect to the rectangel and vertically below the bottom of the rectangle by
+/// respect to the rectangle and vertically below the bottom of the rectangle by
 /// the height of the rectangle.
 ///
 /// [Alignment] use visual coordinates, which means increasing [x] moves the

--- a/packages/flutter/lib/src/painting/decoration.dart
+++ b/packages/flutter/lib/src/painting/decoration.dart
@@ -126,7 +126,7 @@ abstract class Decoration extends Diagnosticable {
   /// The decoration may be sensitive to the [TextDirection]. The
   /// `textDirection` argument should therefore be provided. If it is known that
   /// the decoration is not affected by the text direction, then the argument
-  /// may be ommitted or set to null.
+  /// may be omitted or set to null.
   bool hitTest(Size size, Offset position, { TextDirection textDirection }) => true;
 
   /// Returns a [BoxPainter] that will paint this decoration.

--- a/packages/flutter/lib/src/painting/gradient.dart
+++ b/packages/flutter/lib/src/painting/gradient.dart
@@ -172,7 +172,7 @@ abstract class Gradient {
 ///  * [BoxDecoration], which can take a [LinearGradient] in its
 ///    [BoxDecoration.gradient] property.
 class LinearGradient extends Gradient {
-  /// Creates a linear graident.
+  /// Creates a linear gradient.
   ///
   /// The [colors] argument must not be null. If [stops] is non-null, it must
   /// have the same length as [colors].

--- a/packages/flutter/lib/src/painting/images.dart
+++ b/packages/flutter/lib/src/painting/images.dart
@@ -23,7 +23,7 @@ enum ImageRepeat {
   /// Repeat the image in the y direction until the box is filled vertically.
   repeatY,
 
-  /// Leave uncovered poritions of the box transparent.
+  /// Leave uncovered portions of the box transparent.
   noRepeat
 }
 

--- a/packages/flutter/lib/src/painting/shape_decoration.dart
+++ b/packages/flutter/lib/src/painting/shape_decoration.dart
@@ -52,7 +52,7 @@ import 'rounded_rectangle_border.dart';
 ///
 ///  * [DecoratedBox] and [Container], widgets that can be configured with
 ///    [ShapeDecoration] objects.
-///  * [BoxDecoration], a similar [Decoration] that is optimised for rectangles
+///  * [BoxDecoration], a similar [Decoration] that is optimized for rectangles
 ///    specifically.
 ///  * [ShapeBorder], the base class for the objects that are used in the
 ///    [shape] property.

--- a/packages/flutter/lib/src/painting/text_painter.dart
+++ b/packages/flutter/lib/src/painting/text_painter.dart
@@ -105,7 +105,7 @@ class TextPainter {
   /// example, if the [text] is an English phrase followed by a Hebrew phrase,
   /// in a [TextDirection.ltr] context the English phrase will be on the left
   /// and the Hebrew phrase to its right, while in a [TextDirection.rtl]
-  /// context, the English phrase will be on the right and the Hebrow phrase on
+  /// context, the English phrase will be on the right and the Hebrew phrase on
   /// its left.
   ///
   /// After this is set, you must call [layout] before the next call to [paint].

--- a/packages/flutter/lib/src/painting/text_span.dart
+++ b/packages/flutter/lib/src/painting/text_span.dart
@@ -178,7 +178,7 @@ class TextSpan extends DiagnosticableTree {
       builder.pop();
   }
 
-  /// Walks this text span and its decendants in pre-order and calls [visitor]
+  /// Walks this text span and its descendants in pre-order and calls [visitor]
   /// for each span that has text.
   bool visitTextSpan(bool visitor(TextSpan span)) {
     if (text != null) {

--- a/packages/flutter/lib/src/painting/text_style.dart
+++ b/packages/flutter/lib/src/painting/text_style.dart
@@ -150,7 +150,7 @@ const String _kDefaultDebugLabel = 'unknown';
 /// relative to the `pubspec.yaml` file. The `weight` property specifies the
 /// weight of the glyph outlines in the file as an integer multiple of 100
 /// between 100 and 900. This corresponds to the [FontWeight] class and can be
-/// used in the [fontWeight] argument. The `style` property specfies whether the
+/// used in the [fontWeight] argument. The `style` property specifies whether the
 /// outlines in the file are `italic` or `normal`. These values correspond to
 /// the [FontStyle] class and can be used in the [fontStyle] argument.
 ///

--- a/packages/flutter/lib/src/physics/clamped_simulation.dart
+++ b/packages/flutter/lib/src/physics/clamped_simulation.dart
@@ -8,7 +8,7 @@ import 'simulation.dart';
 ///
 /// The limits are only applied to the other simulation's outputs. For example,
 /// if a maximum position was applied to a gravity simulation with the
-/// particle's initial velocity being up, and the accerelation being down, and
+/// particle's initial velocity being up, and the acceleration being down, and
 /// the maximum position being between the initial position and the curve's
 /// apogee, then the particle would return to its initial position in the same
 /// amount of time as it would have if the maximum had not been applied; the

--- a/packages/flutter/lib/src/physics/spring_simulation.dart
+++ b/packages/flutter/lib/src/physics/spring_simulation.dart
@@ -22,7 +22,7 @@ class SpringDescription {
   });
 
   /// Creates a spring given the mass (m), stiffness (k), and damping ratio (ζ).
-  /// The damping ratio is especially useful trying to determing the type of
+  /// The damping ratio is especially useful trying to determining the type of
   /// spring to create. A ratio of 1.0 creates a critically damped spring, > 1.0
   /// creates an overdamped spring and < 1.0 an underdamped one.
   ///

--- a/packages/flutter/lib/src/rendering/box.dart
+++ b/packages/flutter/lib/src/rendering/box.dart
@@ -329,7 +329,7 @@ class BoxConstraints extends Constraints {
     return result;
   }
 
-  /// The biggest size that satisifes the constraints.
+  /// The biggest size that satisfies the constraints.
   Size get biggest => new Size(constrainWidth(), constrainHeight());
 
   /// The smallest size that satisfies the constraints.
@@ -341,7 +341,7 @@ class BoxConstraints extends Constraints {
   /// Whether there is exactly one height value that satisfies the constraints.
   bool get hasTightHeight => minHeight >= maxHeight;
 
-  /// Whether there is exactly one size that satifies the constraints.
+  /// Whether there is exactly one size that satisfies the constraints.
   @override
   bool get isTight => hasTightWidth && hasTightHeight;
 
@@ -617,7 +617,7 @@ class _IntrinsicDimensionsCacheEntry {
   int get hashCode => hashValues(dimension, argument);
 }
 
-/// A render object in a 2D cartesian coordinate system.
+/// A render object in a 2D Cartesian coordinate system.
 ///
 /// The [size] of each box is expressed as a width and a height. Each box has
 /// its own coordinate system in which its upper left corner is placed at (0,
@@ -640,7 +640,7 @@ class _IntrinsicDimensionsCacheEntry {
 ///
 /// One would implement a new [RenderBox] subclass to describe a new layout
 /// model, new paint model, new hit-testing model, or new semantics model, while
-/// remaining in the cartesian space defined by the [RenderBox] protocol.
+/// remaining in the Cartesian space defined by the [RenderBox] protocol.
 ///
 /// To create a new protocol, consider subclassing [RenderObject] instead.
 ///
@@ -735,7 +735,7 @@ class _IntrinsicDimensionsCacheEntry {
 /// Children can have additional data owned by the parent but stored on the
 /// child using the [parentData] field. The class used for that data must
 /// inherit from [ParentData]. The [setupParentData] method is used to
-/// initialise the [parentData] field of a child when the child is attached.
+/// initialize the [parentData] field of a child when the child is attached.
 ///
 /// By convention, [RenderBox] objects that have [RenderBox] children use the
 /// [BoxParentData] class, which has a [BoxParentData.offset] field to store the
@@ -1427,7 +1427,7 @@ abstract class RenderBox extends RenderObject {
   ///
   /// The size of a box should be set only during the box's [performLayout] or
   /// [performResize] functions. If you wish to change the size of a box outside
-  /// of those functins, call [markNeedsLayout] instead to schedule a layout of
+  /// of those functions, call [markNeedsLayout] instead to schedule a layout of
   /// the box.
   Size get size {
     assert(hasSize);
@@ -1911,7 +1911,7 @@ abstract class RenderBox extends RenderObject {
     transform.translate(offset.dx, offset.dy);
   }
 
-  /// Convert the given point from the global coodinate system in logical pixels
+  /// Convert the given point from the global coordinate system in logical pixels
   /// to the local coordinate system for this box.
   ///
   /// If the transform from global coordinates to local coordinates is

--- a/packages/flutter/lib/src/rendering/debug.dart
+++ b/packages/flutter/lib/src/rendering/debug.dart
@@ -15,7 +15,7 @@ const HSVColor _kDebugDefaultRepaintColor = const HSVColor.fromAHSV(0.4, 60.0, 1
 /// Causes each RenderBox to paint a box around its bounds, and some extra
 /// boxes, such as [RenderPadding], to draw construction lines.
 ///
-/// The edges of boies are painted as a one-pixel-thick `const Color(0xFF00FFFF)` outline.
+/// The edges of the boxes are painted as a one-pixel-thick `const Color(0xFF00FFFF)` outline.
 ///
 /// Spacing is painted as a solid `const Color(0x90909090)` area.
 ///

--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -193,7 +193,7 @@ class RenderEditable extends RenderBox {
   /// example, if the [text] is an English phrase followed by a Hebrew phrase,
   /// in a [TextDirection.ltr] context the English phrase will be on the left
   /// and the Hebrew phrase to its right, while in a [TextDirection.rtl]
-  /// context, the English phrase will be on the right and the Hebrow phrase on
+  /// context, the English phrase will be on the right and the Hebrew phrase on
   /// its left.
   ///
   /// This must not be null.

--- a/packages/flutter/lib/src/rendering/image.dart
+++ b/packages/flutter/lib/src/rendering/image.dart
@@ -256,7 +256,7 @@ class RenderImage extends RenderBox {
   /// Find a size for the render image within the given constraints.
   ///
   ///  - The dimensions of the RenderImage must fit within the constraints.
-  ///  - The aspect ratio of the RenderImage matches the instrinsic aspect
+  ///  - The aspect ratio of the RenderImage matches the intrinsic aspect
   ///    ratio of the image.
   ///  - The RenderImage's dimension are maximal subject to being smaller than
   ///    the intrinsic size of the image.

--- a/packages/flutter/lib/src/rendering/layer.dart
+++ b/packages/flutter/lib/src/rendering/layer.dart
@@ -443,7 +443,7 @@ class ContainerLayer extends Layer {
   /// before any of the properties have been changed.
   ///
   /// The default implementation does nothing, since [ContainerLayer], by
-  /// default, composits its children at the origin of the [ContainerLayer]
+  /// default, composites its children at the origin of the [ContainerLayer]
   /// itself.
   ///
   /// The `child` argument should generally not be null, since in principle a
@@ -989,7 +989,7 @@ class FollowerLayer extends ContainerLayer {
   /// The transform that was used during the last composition phase.
   ///
   /// If the [link] was not linked to a [LeaderLayer], or if this layer has
-  /// a degerenate matrix applied, then this will be null.
+  /// a degenerate matrix applied, then this will be null.
   ///
   /// This method returns a new [Matrix4] instance each time it is invoked.
   Matrix4 getLastTransform() {

--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -320,7 +320,7 @@ class PaintingContext {
   ///   matches the value of [RenderObject.needsCompositing] for the caller.
   /// * `offset` is the offset from the origin of the canvas' coordinate system
   ///   to the origin of the caller's coordinate system.
-  /// * `clipRect` is rectangle (in the caller's coodinate system) to use to
+  /// * `clipRect` is rectangle (in the caller's coordinate system) to use to
   ///   clip the painting done by [painter].
   /// * `painter` is a callback that will paint with the [clipRect] applied. This
   ///   function calls the [painter] synchronously.
@@ -344,9 +344,9 @@ class PaintingContext {
   ///   matches the value of [RenderObject.needsCompositing] for the caller.
   /// * `offset` is the offset from the origin of the canvas' coordinate system
   ///   to the origin of the caller's coordinate system.
-  /// * `bounds` is the region of the canvas (in the caller's coodinate system)
+  /// * `bounds` is the region of the canvas (in the caller's coordinate system)
   ///   into which `painter` will paint in.
-  /// * `clipRRect` is the rounded-rectangle (in the caller's coodinate system)
+  /// * `clipRRect` is the rounded-rectangle (in the caller's coordinate system)
   ///   to use to clip the painting done by `painter`.
   /// * `painter` is a callback that will paint with the `clipRRect` applied. This
   ///   function calls the `painter` synchronously.
@@ -373,9 +373,9 @@ class PaintingContext {
   ///   matches the value of [RenderObject.needsCompositing] for the caller.
   /// * `offset` is the offset from the origin of the canvas' coordinate system
   ///   to the origin of the caller's coordinate system.
-  /// * `bounds` is the region of the canvas (in the caller's coodinate system)
+  /// * `bounds` is the region of the canvas (in the caller's coordinate system)
   ///   into which `painter` will paint in.
-  /// * `clipPath` is the path (in the coodinate system of the caller) to use to
+  /// * `clipPath` is the path (in the coordinate system of the caller) to use to
   ///   clip the painting done by `painter`.
   /// * `painter` is a callback that will paint with the `clipPath` applied. This
   ///   function calls the `painter` synchronously.
@@ -402,7 +402,7 @@ class PaintingContext {
   ///   matches the value of [RenderObject.needsCompositing] for the caller.
   /// * `offset` is the offset from the origin of the canvas' coordinate system
   ///   to the origin of the caller's coordinate system.
-  /// * `transform` is the matrix to apply to the paiting done by `painter`.
+  /// * `transform` is the matrix to apply to the painting done by `painter`.
   /// * `painter` is a callback that will paint with the `transform` applied. This
   ///   function calls the `painter` synchronously.
   void pushTransform(bool needsCompositing, Offset offset, Matrix4 transform, PaintingContextCallback painter) {
@@ -425,7 +425,7 @@ class PaintingContext {
     }
   }
 
-  /// Blend further paiting with an alpha value.
+  /// Blend further painting with an alpha value.
   ///
   /// * `offset` is the offset from the origin of the canvas' coordinate system
   ///   to the origin of the caller's coordinate system.
@@ -617,7 +617,7 @@ class SemanticsHandle {
 ///    clipping. If a render object has a composited child, its needs to use a
 ///    [Layer] to create the clip in order for the clip to apply to the
 ///    composited child (which will be painted into its own [Layer]).
-/// 3. [flushPaint] visites any render objects that need to paint. During this
+/// 3. [flushPaint] visits any render objects that need to paint. During this
 ///    phase, render objects get a chance to record painting commands into
 ///    [PictureLayer]s and construct other composited [Layer]s.
 /// 4. Finally, if semantics are enabled, [flushSemantics] will compile the
@@ -890,7 +890,7 @@ class PipelineOwner {
 ///
 /// The [RenderObject] class, however, does not define a child model (e.g.
 /// whether a node has zero, one, or more children). It also doesn't define a
-/// coordinate system (e.g. whether children are positioned in cartesian
+/// coordinate system (e.g. whether children are positioned in Cartesian
 /// coordinates, in polar coordinates, etc) or a specific layout protocol (e.g.
 /// whether the layout is width-in-height-out, or constraint-in-size-out, or
 /// whether the parent sets the size and position of the child before or after
@@ -898,13 +898,13 @@ class PipelineOwner {
 /// their parent's [parentData] slot).
 ///
 /// The [RenderBox] subclass introduces the opinion that the layout
-/// system uses cartesian coordinates.
+/// system uses Cartesian coordinates.
 ///
 /// ## Writing a RenderObject subclass
 ///
 /// In most cases, subclassing [RenderObject] itself is overkill, and
 /// [RenderBox] would be a better starting point. However, if a render object
-/// doesn't want to use a cartesian coordinate system, then it should indeed
+/// doesn't want to use a Cartesian coordinate system, then it should indeed
 /// inherit from [RenderObject] directly. This allows it to define its own
 /// layout protocol by using a new subclass of [Constraints] rather than using
 /// [BoxConstraints], and by potentially using an entirely new set of objects
@@ -1314,7 +1314,7 @@ abstract class RenderObject extends AbstractNode with DiagnosticableTreeMixin im
   /// situations in which the parent needs to be notified if the child is
   /// dirtied. Such subclasses override markNeedsLayout and either call
   /// `super.markNeedsLayout()`, in the normal case, or call
-  /// [markParentNeedsLayout], in the case where the parent neds to be laid out
+  /// [markParentNeedsLayout], in the case where the parent needs to be laid out
   /// as well as the child.
   ///
   /// If [sizedByParent] has changed, called

--- a/packages/flutter/lib/src/rendering/paragraph.dart
+++ b/packages/flutter/lib/src/rendering/paragraph.dart
@@ -104,7 +104,7 @@ class RenderParagraph extends RenderBox {
   /// example, if the [text] is an English phrase followed by a Hebrew phrase,
   /// in a [TextDirection.ltr] context the English phrase will be on the left
   /// and the Hebrew phrase to its right, while in a [TextDirection.rtl]
-  /// context, the English phrase will be on the right and the Hebrow phrase on
+  /// context, the English phrase will be on the right and the Hebrew phrase on
   /// its left.
   ///
   /// This must not be null.

--- a/packages/flutter/lib/src/rendering/performance_overlay.dart
+++ b/packages/flutter/lib/src/rendering/performance_overlay.dart
@@ -37,7 +37,7 @@ enum PerformanceOverlayOption {
 
   /// Display the engine frame times as they change over a set period of time
   /// in the form of a graph. The y axis of the graph denotes the total time
-  /// spent by the eninge as a fraction of the total frame slice. When the bar
+  /// spent by the engine as a fraction of the total frame slice. When the bar
   /// turns red, a frame is lost.
   visualizeEngineStatistics,
 }

--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -2223,7 +2223,7 @@ abstract class CustomPainter extends Listenable {
 ///
 /// When asked to paint, [RenderCustomPaint] first asks its [painter] to paint
 /// on the current canvas, then it paints its child, and then, after painting
-/// its child, it asks its [foregroundPainter] to paint. The coodinate system of
+/// its child, it asks its [foregroundPainter] to paint. The coordinate system of
 /// the canvas matches the coordinate system of the [CustomPaint] object. The
 /// painters are expected to paint within a rectangle starting at the origin and
 /// encompassing a region of the given size. (If the painters paint outside
@@ -3789,7 +3789,7 @@ class RenderLeaderLayer extends RenderProxyBox {
   }
 }
 
-/// Transform the child so that its origin is [offset] from the orign of the
+/// Transform the child so that its origin is [offset] from the origin of the
 /// [RenderLeaderLayer] with the same [LayerLink].
 ///
 /// The [RenderLeaderLayer] in question must be earlier in the paint order.

--- a/packages/flutter/lib/src/rendering/shifted_box.dart
+++ b/packages/flutter/lib/src/rendering/shifted_box.dart
@@ -15,7 +15,7 @@ import 'stack.dart' show RelativeRect;
 /// Abstract class for one-child-layout render boxes that provide control over
 /// the child's position.
 abstract class RenderShiftedBox extends RenderBox with RenderObjectWithChildMixin<RenderBox> {
-  /// Initializes the [child] property for sublasses.
+  /// Initializes the [child] property for subclasses.
   RenderShiftedBox(RenderBox child) {
     this.child = child;
   }
@@ -346,7 +346,7 @@ class RenderPositionedBox extends RenderAligningShiftedBox {
        _heightFactor = heightFactor,
        super(child: child, alignment: alignment, textDirection: textDirection);
 
-  /// If non-null, sets its width to the child's width multipled by this factor.
+  /// If non-null, sets its width to the child's width multiplied by this factor.
   ///
   /// Can be both greater and less than 1.0 but must be positive.
   double get widthFactor => _widthFactor;
@@ -359,7 +359,7 @@ class RenderPositionedBox extends RenderAligningShiftedBox {
     markNeedsLayout();
   }
 
-  /// If non-null, sets its height to the child's height multipled by this factor.
+  /// If non-null, sets its height to the child's height multiplied by this factor.
   ///
   /// Can be both greater and less than 1.0 but must be positive.
   double get heightFactor => _heightFactor;
@@ -815,7 +815,7 @@ class RenderFractionallySizedOverflowBox extends RenderAligningShiftedBox {
   /// If non-null, the factor of the incoming width to use.
   ///
   /// If non-null, the child is given a tight width constraint that is the max
-  /// incoming width constraint multipled by this factor.  If null, the child is
+  /// incoming width constraint multiplied by this factor.  If null, the child is
   /// given the incoming width constraints.
   double get widthFactor => _widthFactor;
   double _widthFactor;
@@ -830,7 +830,7 @@ class RenderFractionallySizedOverflowBox extends RenderAligningShiftedBox {
   /// If non-null, the factor of the incoming height to use.
   ///
   /// If non-null, the child is given a tight height constraint that is the max
-  /// incoming width constraint multipled by this factor.  If null, the child is
+  /// incoming width constraint multiplied by this factor.  If null, the child is
   /// given the incoming width constraints.
   double get heightFactor => _heightFactor;
   double _heightFactor;
@@ -967,7 +967,7 @@ abstract class SingleChildLayoutDelegate {
 
   /// The size of this object given the incoming constraints.
   ///
-  /// Defaults to the biggest size that satifies the given constraints.
+  /// Defaults to the biggest size that satisfies the given constraints.
   Size getSize(BoxConstraints constraints) => constraints.biggest;
 
   /// The constraints for the child given the incoming constraints.
@@ -1019,7 +1019,7 @@ abstract class SingleChildLayoutDelegate {
 /// of the parent, but the size of the parent cannot depend on the size of the
 /// child.
 class RenderCustomSingleChildLayoutBox extends RenderShiftedBox {
-  /// Creates a render box that defers its layout to a delgate.
+  /// Creates a render box that defers its layout to a delegate.
   ///
   /// The [delegate] argument must not be null.
   RenderCustomSingleChildLayoutBox({
@@ -1118,7 +1118,7 @@ class RenderCustomSingleChildLayoutBox extends RenderShiftedBox {
 ///
 /// If [baseline] is less than the distance from the top of the child
 /// to the baseline of the child, then the child will overflow the top
-/// of the box. This is typically not desireable, in particular, that
+/// of the box. This is typically not desirable, in particular, that
 /// part of the child will not be found when doing hit tests, so the
 /// user cannot interact with that part of the child.
 ///

--- a/packages/flutter/lib/src/rendering/sliver.dart
+++ b/packages/flutter/lib/src/rendering/sliver.dart
@@ -641,7 +641,7 @@ class SliverHitTestEntry extends HitTestEntry {
 /// Parent data structure used by parents of slivers that position their
 /// children using layout offsets.
 ///
-/// This data structure is optimised for fast layout. It is best used by parents
+/// This data structure is optimized for fast layout. It is best used by parents
 /// that expect to have many children whose relative positions don't change even
 /// when the scroll offset does.
 class SliverLogicalParentData extends ParentData {
@@ -667,7 +667,7 @@ class SliverLogicalContainerParentData extends SliverLogicalParentData with Cont
 ///
 /// For example, used by [RenderViewport].
 ///
-/// This data structure is optimised for fast painting, at the cost of requiring
+/// This data structure is optimized for fast painting, at the cost of requiring
 /// additional work during layout when the children change their offsets. It is
 /// best used by parents that expect to have few children, especially if those
 /// children will themselves be very tall relative to the parent.
@@ -852,7 +852,7 @@ abstract class RenderSliver extends RenderObject {
   ///
   /// The geometry of a sliver should be set only during the sliver's
   /// [performLayout] or [performResize] functions. If you wish to change the
-  /// geometry of a sliver outside of those functins, call [markNeedsLayout]
+  /// geometry of a sliver outside of those functions, call [markNeedsLayout]
   /// instead to schedule a layout of the sliver.
   SliverGeometry get geometry => _geometry;
   SliverGeometry _geometry;
@@ -1300,7 +1300,7 @@ abstract class RenderSliverHelpers implements RenderSliver {
   /// [RenderBox] widgets.
   ///
   /// This function takes care of converting the position from the sliver
-  /// coordinate system to the cartesian coordinate system used by [RenderBox].
+  /// coordinate system to the Cartesian coordinate system used by [RenderBox].
   ///
   /// This function relies on [childMainAxisPosition] to determine the position of
   /// child in question.

--- a/packages/flutter/lib/src/rendering/sliver_grid.dart
+++ b/packages/flutter/lib/src/rendering/sliver_grid.dart
@@ -97,7 +97,7 @@ class SliverGridGeometry {
 ///  * [SliverGridGeometry], which represents the size and position of a single
 ///    tile in a grid.
 ///  * [SliverGridDelegate.getLayout], which returns this object to describe the
-///    delegates's layout.
+///    delegate's layout.
 ///  * [RenderSliverGrid], which uses this class during its
 ///    [RenderSliverGrid.performLayout] method.
 @immutable
@@ -133,11 +133,11 @@ abstract class SliverGridLayout {
 ///
 ///  * [SliverGridDelegateWithFixedCrossAxisCount], which uses this layout.
 ///  * [SliverGridDelegateWithMaxCrossAxisExtent], which uses this layout.
-///  * [SliverGridLayout], which represents an abitrary tile layout.
+///  * [SliverGridLayout], which represents an arbitrary tile layout.
 ///  * [SliverGridGeometry], which represents the size and position of a single
 ///    tile in a grid.
 ///  * [SliverGridDelegate.getLayout], which returns this object to describe the
-///    delegates's layout.
+///    delegate's layout.
 ///  * [RenderSliverGrid], which uses this class during its
 ///    [RenderSliverGrid.performLayout] method.
 class SliverGridRegularTileLayout extends SliverGridLayout {

--- a/packages/flutter/lib/src/rendering/sliver_multi_box_adaptor.dart
+++ b/packages/flutter/lib/src/rendering/sliver_multi_box_adaptor.dart
@@ -136,7 +136,7 @@ class SliverMultiBoxAdaptorParentData extends SliverLogicalParentData with Conta
 /// * Children can be removed except during a layout pass if they have already
 ///   been laid out during that layout pass.
 /// * Children cannot be added except during a call to [childManager], and
-///   then only if there is no child correspending to that index (or the child
+///   then only if there is no child corresponding to that index (or the child
 ///   child corresponding to that index was first removed).
 ///
 /// See also:

--- a/packages/flutter/lib/src/rendering/table.dart
+++ b/packages/flutter/lib/src/rendering/table.dart
@@ -331,7 +331,7 @@ enum TableCellVerticalAlignment {
   /// used is specified by [RenderTable.textBaseline]. It is not valid to use
   /// the baseline value if [RenderTable.textBaseline] is not specified.
   ///
-  /// This vertial alignment is relatively expensive because it causes the table
+  /// This vertical alignment is relatively expensive because it causes the table
   /// to compute the baseline for each cell in the row.
   baseline,
 
@@ -397,7 +397,7 @@ class RenderTable extends RenderBox {
   /// in the table.
   ///
   /// Changing the number of columns is an expensive operation because the table
-  /// needs to rearranage its internal representation.
+  /// needs to rearrange its internal representation.
   int get columns => _columns;
   int _columns;
   set columns(int value) {

--- a/packages/flutter/lib/src/rendering/viewport.dart
+++ b/packages/flutter/lib/src/rendering/viewport.dart
@@ -61,7 +61,7 @@ abstract class RenderAbstractViewport extends RenderObject {
 /// This render object provides the shared code for render objects that host
 /// [RenderSliver] render objects inside a [RenderBox]. The viewport establishes
 /// an [axisDirection], which orients the sliver's coordinate system, which is
-/// based on scroll offsets rather than cartesian coordinates.
+/// based on scroll offsets rather than Cartesian coordinates.
 ///
 /// The viewport also listens to an [offset], which determines the
 /// [SliverConstraints.scrollOffset] input to the sliver layout protocol.
@@ -242,7 +242,7 @@ abstract class RenderViewportBase<ParentDataClass extends ContainerParentDataMix
   /// and stops once `advance` returns null.
   ///
   ///  * `scrollOffset` is the [SliverConstraints.scrollOffset] to pass the
-  ///    first child. The scroll offset is adjsted by
+  ///    first child. The scroll offset is adjusted by
   ///    [SliverGeometry.scrollExtent] for subsequent children.
   ///  * `overlap` is the [SliverConstraints.overlap] to pass the first child.
   ///    The overlay is adjusted by the [SliverGeometry.paintOrigin] and
@@ -613,12 +613,12 @@ abstract class RenderViewportBase<ParentDataClass extends ContainerParentDataMix
   @protected
   double scrollOffsetOf(RenderSliver child, double scrollOffsetWithinChild);
 
-  /// Returns the total scroll obstruction extent of all slivers in theild].
-  /// of the viewport before [child].
+  /// Returns the total scroll obstruction extent of all slivers in the viewport
+  /// before [child].
   ///
   /// This is the extent by which the actual area in which content can scroll
   /// is reduced. For example, an app bar that is pinned at the top will reduce
-  /// the are in which content can actually scroll by the height of the app bar.
+  /// the area in which content can actually scroll by the height of the app bar.
   @protected
   double maxScrollObstructionExtentBefore(RenderSliver child);
 
@@ -706,7 +706,7 @@ abstract class RenderViewportBase<ParentDataClass extends ContainerParentDataMix
 /// example, if the [axisDirection] is [AxisDirection.down], the first sliver
 /// before [center] is placed above the [center]. The slivers that are later in
 /// the child list than [center] are placed in order in the [axisDirection]. For
-/// example, in the preceeding scenario, the first sliver after [center] is
+/// example, in the preceding scenario, the first sliver after [center] is
 /// placed below the [center].
 ///
 /// [RenderViewport] cannot contain [RenderBox] children directly. Instead, use

--- a/packages/flutter/lib/src/rendering/viewport_offset.dart
+++ b/packages/flutter/lib/src/rendering/viewport_offset.dart
@@ -86,7 +86,7 @@ abstract class ViewportOffset extends ChangeNotifier {
   /// For example, if the axis direction is down, then the pixel value
   /// represents the number of logical pixels to move the children _up_ the
   /// screen. Similarly, if the axis direction is left, then the pixels value
-  /// represents the number of logical pixesl to move the children to _right_.
+  /// represents the number of logical pixels to move the children to _right_.
   ///
   /// This object notifies its listeners when this value changes (except when
   /// the value changes due to [correctBy]).
@@ -108,7 +108,7 @@ abstract class ViewportOffset extends ChangeNotifier {
   /// contents, then this will only be called when the viewport recomputes its
   /// size (i.e. when its parent lays out), and not during normal scrolling.
   ///
-  /// If applying the viewport dimentions changes the scroll offset, return
+  /// If applying the viewport dimensions changes the scroll offset, return
   /// false. Otherwise, return true. If you return false, the [RenderViewport]
   /// will be laid out again with the new scroll offset. This is expensive. (The
   /// return value is answering the question "did you accept these viewport

--- a/packages/flutter/lib/src/rendering/wrap.dart
+++ b/packages/flutter/lib/src/rendering/wrap.dart
@@ -153,7 +153,7 @@ class RenderWrap extends RenderBox with ContainerRenderObjectMixin<RenderBox, Wr
   /// How the children within a run should be places in the main axis.
   ///
   /// For example, if [alignment] is [WrapAlignment.center], the children in
-  /// each run are grouped togeter in the center of their run in the main axis.
+  /// each run are grouped together in the center of their run in the main axis.
   ///
   /// Defaults to [WrapAlignment.start].
   ///
@@ -197,7 +197,7 @@ class RenderWrap extends RenderBox with ContainerRenderObjectMixin<RenderBox, Wr
   /// How the runs themselves should be placed in the cross axis.
   ///
   /// For example, if [runAlignment] is [WrapAlignment.center], the runs are
-  /// grouped togeter in the center of the overall [RenderWrap] in the cross
+  /// grouped together in the center of the overall [RenderWrap] in the cross
   /// axis.
   ///
   /// Defaults to [WrapAlignment.start].

--- a/packages/flutter/lib/src/scheduler/binding.dart
+++ b/packages/flutter/lib/src/scheduler/binding.dart
@@ -513,7 +513,7 @@ abstract class SchedulerBinding extends BindingBase {
   Duration _lastRawTimeStamp = Duration.ZERO;
 
   /// Prepares the scheduler for a non-monotonic change to how time stamps are
-  /// calcuated.
+  /// calculated.
   ///
   /// Callbacks received from the scheduler assume that their time stamps are
   /// monotonically increasing. The raw time stamp passed to [handleBeginFrame]

--- a/packages/flutter/lib/src/semantics/semantics.dart
+++ b/packages/flutter/lib/src/semantics/semantics.dart
@@ -144,7 +144,7 @@ class SemanticsData extends Diagnosticable {
   /// The transform from this node's coordinate system to its parent's coordinate system.
   ///
   /// By default, the transform is null, which represents the identity
-  /// transformation (i.e., that this node has the same coorinate system as its
+  /// transformation (i.e., that this node has the same coordinate system as its
   /// parent).
   final Matrix4 transform;
 
@@ -270,7 +270,7 @@ class SemanticsNode extends AbstractNode with DiagnosticableTreeMixin {
   /// The transform from this node's coordinate system to its parent's coordinate system.
   ///
   /// By default, the transform is null, which represents the identity
-  /// transformation (i.e., that this node has the same coorinate system as its
+  /// transformation (i.e., that this node has the same coordinate system as its
   /// parent).
   Matrix4 get transform => _transform;
   Matrix4 _transform;
@@ -429,7 +429,7 @@ class SemanticsNode extends AbstractNode with DiagnosticableTreeMixin {
 
   /// Visits the immediate children of this node.
   ///
-  /// This function calls visitor for each child in a pre-order travseral
+  /// This function calls visitor for each child in a pre-order traversal
   /// until visitor returns false. Returns true if all the visitor calls
   /// returned true, otherwise returns false.
   void visitChildren(SemanticsNodeVisitor visitor) {
@@ -443,7 +443,7 @@ class SemanticsNode extends AbstractNode with DiagnosticableTreeMixin {
 
   /// Visit all the descendants of this node.
   ///
-  /// This function calls visitor for each descendant in a pre-order travseral
+  /// This function calls visitor for each descendant in a pre-order traversal
   /// until visitor returns false. Returns true if all the visitor calls
   /// returned true, otherwise returns false.
   bool _visitDescendants(SemanticsNodeVisitor visitor) {
@@ -541,7 +541,7 @@ class SemanticsNode extends AbstractNode with DiagnosticableTreeMixin {
   /// The [SemanticsTag]s this node is tagged with.
   ///
   /// Tags are used during the construction of the semantics tree. They are not
-  /// transfered to the engine.
+  /// transferred to the engine.
   Set<SemanticsTag> tags;
 
   /// Whether this node is tagged with `tag`.

--- a/packages/flutter/lib/src/services/system_chrome.dart
+++ b/packages/flutter/lib/src/services/system_chrome.dart
@@ -153,7 +153,7 @@ class SystemChrome {
   /// overwrite the pending value, such that only the last specified value takes
   /// effect.
   ///
-  /// Call this API in code whose lifecyle matches that of the desired
+  /// Call this API in code whose lifecycle matches that of the desired
   /// system UI styles. For instance, to change the system UI style on a new
   /// page, consider calling when pushing/popping a new [PageRoute].
   ///

--- a/packages/flutter/lib/src/widgets/animated_list.dart
+++ b/packages/flutter/lib/src/widgets/animated_list.dart
@@ -39,7 +39,7 @@ class _ActiveItem implements Comparable<_ActiveItem> {
 
 /// A scrolling container that animates items when they are inserted or removed.
 ///
-/// This widget's [AnimatedListState] can be used to dynmically insert or remove
+/// This widget's [AnimatedListState] can be used to dynamically insert or remove
 /// items. To refer to the [AnimatedListState] either provide a [GlobalKey] or
 /// use the static [of] method from an item's input callback.
 ///
@@ -66,7 +66,7 @@ class AnimatedList extends StatefulWidget {
   /// List items are only built when they're scrolled into view.
   ///
   /// The [AnimatedListItemBuilder] index parameter indicates the item's
-  /// posiition in the list. The value of the index parameter will be between 0
+  /// position in the list. The value of the index parameter will be between 0
   /// and [initialItemCount] plus the total number of items that have been
   /// inserted with [AnimatedListState.insertItem] and less the total number of
   /// items that have been removed with [AnimatedListState.removeItem].
@@ -77,8 +77,8 @@ class AnimatedList extends StatefulWidget {
 
   /// The number of items the list will start with.
   ///
-  /// The appareance of the initial items is not animated. They
-  /// are created, as needed, by [itemBuilder] with an animation paramter
+  /// The appearance of the initial items is not animated. They
+  /// are created, as needed, by [itemBuilder] with an animation parameter
   /// of [kAlwaysCompleteAnimation].
   final int initialItemCount;
 

--- a/packages/flutter/lib/src/widgets/automatic_keep_alive.dart
+++ b/packages/flutter/lib/src/widgets/automatic_keep_alive.dart
@@ -213,7 +213,7 @@ class _AutomaticKeepAliveState extends State<AutomaticKeepAlive> {
 }
 
 /// Indicates that the subtree through which this notification bubbles must be
-/// kept alive even if it would normally be discarded as an optimisation.
+/// kept alive even if it would normally be discarded as an optimization.
 ///
 /// For example, a focused text field might fire this notification to indicate
 /// that it should not be disposed even if the user scrolls the field off

--- a/packages/flutter/lib/src/widgets/banner.dart
+++ b/packages/flutter/lib/src/widgets/banner.dart
@@ -79,7 +79,7 @@ class BannerPainter extends CustomPainter {
   /// example, if the message is an English phrase followed by a Hebrew phrase,
   /// in a [TextDirection.ltr] context the English phrase will be on the left
   /// and the Hebrew phrase to its right, while in a [TextDirection.rtl]
-  /// context, the English phrase will be on the right and the Hebrow phrase on
+  /// context, the English phrase will be on the right and the Hebrew phrase on
   /// its left.
   ///
   /// See also [layoutDirection], which controls the interpretation of values in
@@ -265,7 +265,7 @@ class Banner extends StatelessWidget {
   /// example, if the message is an English phrase followed by a Hebrew phrase,
   /// in a [TextDirection.ltr] context the English phrase will be on the left
   /// and the Hebrew phrase to its right, while in a [TextDirection.rtl]
-  /// context, the English phrase will be on the right and the Hebrow phrase on
+  /// context, the English phrase will be on the right and the Hebrew phrase on
   /// its left.
   ///
   /// Defaults to the ambient [Directionality], if any.

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -293,7 +293,7 @@ class BackdropFilter extends SingleChildRenderObjectWidget {
 ///
 /// When asked to paint, [CustomPaint] first asks its [painter] to paint on the
 /// current canvas, then it paints its child, and then, after painting its
-/// child, it asks its [foregroundPainter] to paint. The coodinate system of the
+/// child, it asks its [foregroundPainter] to paint. The coordinate system of the
 /// canvas matches the coordinate system of the [CustomPaint] object. The
 /// painters are expected to paint within a rectangle starting at the origin and
 /// encompassing a region of the given size. (If the painters paint outside
@@ -837,7 +837,7 @@ class Transform extends SingleChildRenderObjectWidget {
   }
 }
 
-/// A widget that can be targetted by a [CompositedTransformFollower].
+/// A widget that can be targeted by a [CompositedTransformFollower].
 ///
 /// When this widget is composited during the compositing phase (which comes
 /// after the paint phase, as described in [WidgetsBinding.drawFrame]), it
@@ -1487,7 +1487,7 @@ class CustomMultiChildLayout extends MultiChildRenderObjectWidget {
 ///  * [FractionallySizedBox], a widget that sizes its child to a fraction of
 ///    the total available space.
 ///  * [AspectRatio], a widget that attempts to fit within the parent's
-///    constraints while also sizing its child to match a given sapect ratio.
+///    constraints while also sizing its child to match a given aspect ratio.
 ///  * [FittedBox], which sizes and positions its child widget to fit the parent
 ///    according to a given [BoxFit] discipline.
 ///  * The [catalog of layout widgets](https://flutter.io/widgets/layout/).
@@ -1726,7 +1726,7 @@ class FractionallySizedBox extends SingleChildRenderObjectWidget {
   /// If non-null, the fraction of the incoming width given to the child.
   ///
   /// If non-null, the child is given a tight width constraint that is the max
-  /// incoming width constraint multipled by this factor.
+  /// incoming width constraint multiplied by this factor.
   ///
   /// If null, the incoming width constraints are passed to the child
   /// unmodified.
@@ -1735,7 +1735,7 @@ class FractionallySizedBox extends SingleChildRenderObjectWidget {
   /// If non-null, the fraction of the incoming height given to the child.
   ///
   /// If non-null, the child is given a tight height constraint that is the max
-  /// incoming height constraint multipled by this factor.
+  /// incoming height constraint multiplied by this factor.
   ///
   /// If null, the incoming height constraints are passed to the child
   /// unmodified.
@@ -3768,7 +3768,7 @@ class Wrap extends MultiChildRenderObjectWidget {
   /// How the children within a run should be places in the main axis.
   ///
   /// For example, if [alignment] is [WrapAlignment.center], the children in
-  /// each run are grouped togeter in the center of their run in the main axis.
+  /// each run are grouped together in the center of their run in the main axis.
   ///
   /// Defaults to [WrapAlignment.start].
   ///
@@ -3796,7 +3796,7 @@ class Wrap extends MultiChildRenderObjectWidget {
   /// How the runs themselves should be placed in the cross axis.
   ///
   /// For example, if [runAlignment] is [WrapAlignment.center], the runs are
-  /// grouped togeter in the center of the overall [Wrap] in the cross axis.
+  /// grouped together in the center of the overall [Wrap] in the cross axis.
   ///
   /// Defaults to [WrapAlignment.start].
   ///
@@ -4047,7 +4047,7 @@ class Flow extends MultiChildRenderObjectWidget {
 class RichText extends LeafRenderObjectWidget {
   /// Creates a paragraph of rich text.
   ///
-  /// The [text], [textAlign], [softWrap], [overflow], nad [textScaleFactor]
+  /// The [text], [textAlign], [softWrap], [overflow], and [textScaleFactor]
   /// arguments must not be null.
   ///
   /// The [maxLines] property may be null (and indeed defaults to null), but if
@@ -4087,7 +4087,7 @@ class RichText extends LeafRenderObjectWidget {
   /// example, if the [text] is an English phrase followed by a Hebrew phrase,
   /// in a [TextDirection.ltr] context the English phrase will be on the left
   /// and the Hebrew phrase to its right, while in a [TextDirection.rtl]
-  /// context, the English phrase will be on the right and the Hebrow phrase on
+  /// context, the English phrase will be on the right and the Hebrew phrase on
   /// its left.
   ///
   /// Defaults to the ambient [Directionality], if any. If there is no ambient

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -60,7 +60,7 @@ class TextEditingController extends ValueNotifier<TextEditingValue> {
   TextEditingController({ String text })
     : super(text == null ? TextEditingValue.empty : new TextEditingValue(text: text));
 
-  /// Creates a controller for an editiable text field from an initial [TextEditingValue].
+  /// Creates a controller for an editable text field from an initial [TextEditingValue].
   ///
   /// This constructor treats a null [value] argument as if it were
   /// [TextEditingValue.empty].
@@ -221,7 +221,7 @@ class EditableText extends StatefulWidget {
   /// example, if the text is an English phrase followed by a Hebrew phrase,
   /// in a [TextDirection.ltr] context the English phrase will be on the left
   /// and the Hebrew phrase to its right, while in a [TextDirection.rtl]
-  /// context, the English phrase will be on the right and the Hebrow phrase on
+  /// context, the English phrase will be on the right and the Hebrew phrase on
   /// its left.
   ///
   /// Defaults to the ambient [Directionality], if any.

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -710,7 +710,7 @@ abstract class StatelessWidget extends Widget {
 ///
 /// The second category is widgets that use [State.setState] or depend on
 /// [InheritedWidget]s. These will typically rebuild many times during the
-/// application's lifetime, and it is therefore important to minimise the impact
+/// application's lifetime, and it is therefore important to minimize the impact
 /// of rebuilding such a widget. (They may also use [State.initState] or
 /// [State.didChangeDependencies] and allocate resources, but the important part
 /// is that they rebuild.)
@@ -948,7 +948,7 @@ typedef void StateSetter(VoidCallback fn);
 ///    releasing most resources until the framework calls their [dispose]
 ///    method.
 ///  * If the framework does not reinsert this subtree by the end of the current
-///    animation frame, the framework will call [dispose], which indiciates that
+///    animation frame, the framework will call [dispose], which indicates that
 ///    this [State] object will never build again. Subclasses should override
 ///    this method to release any resources retained by this object (e.g.,
 ///    stop any active animations).
@@ -2682,7 +2682,7 @@ abstract class Element extends DiagnosticableTree implements BuildContext {
   /// or the child that was passed in, if it just had to update the child, or
   /// null, if it removed the child and did not replace it.
   ///
-  /// The following table summarises the above:
+  /// The following table summarizes the above:
   ///
   /// <table>
   /// <tr><th><th>`newWidget == null`<th>`newWidget != null`
@@ -3915,7 +3915,7 @@ class ParentDataElement<T extends RenderObjectWidget> extends ProxyElement {
   ///    descendant).
   ///
   ///  * Paint is currently under way, but the [ParentData] in question does not
-  ///    affect layour or paint, and the value to be applied could not be
+  ///    affect layout or paint, and the value to be applied could not be
   ///    determined before paint (e.g. it depends on the compositing phase).
   ///
   /// In either case, the next build is expected to cause this element to be
@@ -4251,7 +4251,7 @@ abstract class RenderObjectElement extends Element {
   /// checks whether the child is in `forgottenChildren`. If it is, the function
   /// acts as if the child was not in `oldChildren`.
   ///
-  /// This function is a convienence wrapper around [updateChild], which updates
+  /// This function is a convenience wrapper around [updateChild], which updates
   /// each individual child. When calling [updateChild], this function uses the
   /// previous element as the `newSlot` argument.
   @protected

--- a/packages/flutter/lib/src/widgets/grid_paper.dart
+++ b/packages/flutter/lib/src/widgets/grid_paper.dart
@@ -70,7 +70,7 @@ class GridPaper extends StatelessWidget {
 
   /// The color to draw the lines in the grid.
   ///
-  /// Defaults to a light blue commonly seen on traditional gridpaper.
+  /// Defaults to a light blue commonly seen on traditional grid paper.
   final Color color;
 
   /// The distance between the primary lines in the grid, in logical pixels.

--- a/packages/flutter/lib/src/widgets/image.dart
+++ b/packages/flutter/lib/src/widgets/image.dart
@@ -30,7 +30,7 @@ export 'package:flutter/services.dart' show
 ///
 /// If this is not called from a build method, then it should be reinvoked
 /// whenever the dependencies change, e.g. by calling it from
-/// [State.didChangeDependencies], so that any changes in the environement are
+/// [State.didChangeDependencies], so that any changes in the environment are
 /// picked up (e.g. if the device pixel ratio changes).
 ///
 /// See also:

--- a/packages/flutter/lib/src/widgets/navigator.dart
+++ b/packages/flutter/lib/src/widgets/navigator.dart
@@ -157,7 +157,7 @@ abstract class Route<T> {
   /// This route's previous route has changed to the given new route. This is
   /// called on a route whenever the previous route changes for any reason, so
   /// long as it is in the history, except for immediately after the route has
-  /// been pushed (in which wase [didPush] or [didReplace] will be called
+  /// been pushed (in which case [didPush] or [didReplace] will be called
   /// instead). `previousRoute` will be null if there's no previous route.
   @protected
   @mustCallSuper
@@ -207,7 +207,7 @@ abstract class Route<T> {
   ///
   /// If a later route is entirely opaque, then the route will be active but not
   /// rendered. It is even possible for the route to be active but for the stateful
-  /// widgets within the route to not be instatiated. See [ModalRoute.maintainState].
+  /// widgets within the route to not be instantiated. See [ModalRoute.maintainState].
   bool get isActive {
     return _navigator != null && _navigator._history.contains(this);
   }

--- a/packages/flutter/lib/src/widgets/pages.dart
+++ b/packages/flutter/lib/src/widgets/pages.dart
@@ -66,7 +66,7 @@ Widget _defaultTransitionsBuilder(BuildContext context, Animation<double> animat
 /// Callers must define the [pageBuilder] function which creates the route's
 /// primary contents. To add transitions define the [transitionsBuilder] function.
 class PageRouteBuilder<T> extends PageRoute<T> {
-  /// Creates a route that deletates to builder callbacks.
+  /// Creates a route that delegates to builder callbacks.
   ///
   /// The [pageBuilder], [transitionsBuilder], [opaque], [barrierDismissible],
   /// and [maintainState] arguments must not be null.

--- a/packages/flutter/lib/src/widgets/performance_overlay.dart
+++ b/packages/flutter/lib/src/widgets/performance_overlay.dart
@@ -57,7 +57,7 @@ class PerformanceOverlay extends LeafRenderObjectWidget {
   /// is suitable for capturing an SkPicture trace for further analysis.
   ///
   /// For example, if you want a trace of all pictures that could not be
-  /// renderered by the rasterizer within the frame boundary (and hence caused
+  /// rendered by the rasterizer within the frame boundary (and hence caused
   /// jank), specify 1. Specifying 2 will trace all pictures that took more
   /// more than 2 frame intervals to render. Adjust this value to only capture
   /// the particularly expensive pictures while skipping the others. Specifying

--- a/packages/flutter/lib/src/widgets/scroll_activity.dart
+++ b/packages/flutter/lib/src/widgets/scroll_activity.dart
@@ -19,7 +19,7 @@ import 'ticker_provider.dart';
 
 /// A backend for a [ScrollActivity].
 ///
-/// Used by subclases of [ScrollActivity] to manipulate the scroll view that
+/// Used by subclasses of [ScrollActivity] to manipulate the scroll view that
 /// they are acting upon.
 ///
 /// See also:

--- a/packages/flutter/lib/src/widgets/scroll_configuration.dart
+++ b/packages/flutter/lib/src/widgets/scroll_configuration.dart
@@ -81,7 +81,7 @@ class ScrollBehavior {
 /// Controls how [Scrollable] widgets behave in a subtree.
 ///
 /// The scroll configuration determines the [ScrollPhysics] and viewport
-/// decorations used by decendants of [child].
+/// decorations used by descendants of [child].
 class ScrollConfiguration extends InheritedWidget {
   /// Creates a widget that controls how [Scrollable] widgets behave in a subtree.
   ///
@@ -92,7 +92,7 @@ class ScrollConfiguration extends InheritedWidget {
     @required Widget child,
   }) : super(key: key, child: child);
 
-  /// How [Scrollable] widgets that are decendants of [child] should behave.
+  /// How [Scrollable] widgets that are descendants of [child] should behave.
   final ScrollBehavior behavior;
 
   /// The [ScrollBehavior] for [Scrollable] widgets in the given [BuildContext].

--- a/packages/flutter/lib/src/widgets/scroll_context.dart
+++ b/packages/flutter/lib/src/widgets/scroll_context.dart
@@ -49,7 +49,7 @@ abstract class ScrollContext {
   ///
   /// For example, if the scroll position is being driven by an animation, it
   /// might be appropriate to set this value to ignore pointer events to
-  /// prevent the user from accidentially interacting with the contents of the
+  /// prevent the user from accidentally interacting with the contents of the
   /// widget as it animates. The user will still be able to touch the widget,
   /// potentially stopping the animation.
   void setIgnorePointer(bool value);

--- a/packages/flutter/lib/src/widgets/scroll_notification.dart
+++ b/packages/flutter/lib/src/widgets/scroll_notification.dart
@@ -245,7 +245,7 @@ class ScrollEndNotification extends ScrollNotification {
   /// If a drag ends with some residual velocity, a typical [ScrollPhysics] will
   /// start a ballistic scroll, which delays the [ScrollEndNotification] until
   /// the ballistic simulation completes, at which time [dragDetails] will
-  /// be null. If the residtual velocity is too small to trigger ballistic
+  /// be null. If the residual velocity is too small to trigger ballistic
   /// scrolling, then the [ScrollEndNotification] will be dispatched immediately
   /// and [dragDetails] will be non-null.
   final DragEndDetails dragDetails;
@@ -288,7 +288,7 @@ class UserScrollNotification extends ScrollNotification {
 typedef bool ScrollNotificationPredicate(ScrollNotification notification);
 
 /// A [ScrollNotificationPredicate] that checks whether 
-/// `notification.depth == 0`, which means that the notification diid not bubble
+/// `notification.depth == 0`, which means that the notification did not bubble
 /// through any intervening scrolling widgets.
 bool defaultScrollNotificationPredicate(ScrollNotification notification) {
   return notification.depth == 0;

--- a/packages/flutter/lib/src/widgets/scroll_physics.dart
+++ b/packages/flutter/lib/src/widgets/scroll_physics.dart
@@ -130,7 +130,7 @@ class ScrollPhysics {
     return parent.applyBoundaryConditions(position, value);
   }
 
-  /// Returns a simulation for ballisitic scrolling starting from the given
+  /// Returns a simulation for ballistic scrolling starting from the given
   /// position with the given velocity.
   ///
   /// This is used by [ScrollPositionWithSingleContext] in the

--- a/packages/flutter/lib/src/widgets/scroll_position.dart
+++ b/packages/flutter/lib/src/widgets/scroll_position.dart
@@ -374,7 +374,7 @@ abstract class ScrollPosition extends ViewportOffset with ScrollMetrics {
 
   /// Called whenever the scroll position or the dimensions of the scroll view
   /// change to schedule an update of the available semantics actions. The
-  /// actual update will be performed in the nxt frame. If non is pending
+  /// actual update will be performed in the next frame. If non is pending
   /// a frame will be scheduled.
   ///
   /// For example: If the scroll view has been scrolled all the way to the top,

--- a/packages/flutter/lib/src/widgets/scroll_position_with_single_context.dart
+++ b/packages/flutter/lib/src/widgets/scroll_position_with_single_context.dart
@@ -30,7 +30,7 @@ import 'scroll_position.dart';
 /// See also:
 ///
 ///  * [ScrollPosition], which defines the underlying model for a position
-///    within a [Scrollable] but is agnositic as to how that position is
+///    within a [Scrollable] but is agnostic as to how that position is
 ///    changed.
 ///  * [ScrollView] and its subclasses such as [ListView], which use
 ///    [ScrollPositionWithSingleContext] to manage their scroll position.

--- a/packages/flutter/lib/src/widgets/scroll_simulation.dart
+++ b/packages/flutter/lib/src/widgets/scroll_simulation.dart
@@ -72,7 +72,7 @@ class BouncingScrollSimulation extends Simulation {
     assert(_springTime != null);
   }
 
-  /// The maximum velocity that can be transfered from the inertia of a ballistic
+  /// The maximum velocity that can be transferred from the inertia of a ballistic
   /// scroll into overscroll.
   static const double maxSpringTransferVelocity = 5000.0;
 

--- a/packages/flutter/lib/src/widgets/scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/scroll_view.dart
@@ -27,7 +27,7 @@ import 'viewport.dart';
 ///     various scrolling effects, such as lists, grids, and expanding headers.
 ///
 /// [ScrollView] helps orchestrate these pieces by creating the [Scrollable] and
-/// the viewport and defering to its subclass to create the slivers.
+/// the viewport and deferring to its subclass to create the slivers.
 ///
 /// To control the initial scroll offset of the scroll view, provide a
 /// [controller] with its [ScrollController.initialScrollOffset] property set.
@@ -171,7 +171,7 @@ abstract class ScrollView extends StatelessWidget {
   /// concrete [AxisDirection].
   ///
   /// If the [scrollDirection] is [Axis.horizontal], the ambient
-  /// [Directionality] is also consided when selecting the concrete
+  /// [Directionality] is also considered when selecting the concrete
   /// [AxisDirection]. For example, if the ambient [Directionality] is
   /// [TextDirection.rtl], then the non-reversed [AxisDirection] is
   /// [AxisDirection.left] and the reversed [AxisDirection] is

--- a/packages/flutter/lib/src/widgets/sliver.dart
+++ b/packages/flutter/lib/src/widgets/sliver.dart
@@ -382,7 +382,7 @@ abstract class SliverMultiBoxAdaptorWidget extends RenderObjectWidget {
 ///  * [SliverFixedExtentList], which is more efficient for children with
 ///    the same extent in the main axis.
 ///  * [SliverPrototypeExtentList], which is similar to [SliverFixedExtentList]
-///    except that it uses a prototype list item intead a pixel value to define
+///    except that it uses a prototype list item instead of a pixel value to define
 ///    the main axis extent of each item.
 ///  * [SliverGrid], which places its children in arbitrary positions.
 class SliverList extends SliverMultiBoxAdaptorWidget {
@@ -434,7 +434,7 @@ class SliverList extends SliverMultiBoxAdaptorWidget {
 /// See also:
 ///
 ///  * [SliverPrototypeExtentList], which is similar to [SliverFixedExtentList]
-///    except that it uses a prototype list item intead a pixel value to define
+///    except that it uses a prototype list item instead of a pixel value to define
 ///    the main axis extent of each item.
 ///  * [SliverFillViewport], which determines the [itemExtent] based on
 ///    [SliverConstraints.viewportMainAxisExtent].
@@ -505,7 +505,7 @@ class SliverFixedExtentList extends SliverMultiBoxAdaptorWidget {
 ///  * [SliverFixedExtentList], which places its children in a linear
 ///    array with a fixed extent in the main axis.
 ///  * [SliverPrototypeExtentList], which is similar to [SliverFixedExtentList]
-///    except that it uses a prototype list item intead a pixel value to define
+///    except that it uses a prototype list item instead of a pixel value to define
 ///    the main axis extent of each item.
 class SliverGrid extends SliverMultiBoxAdaptorWidget {
   /// Creates a sliver that places multiple box children in a two dimensional
@@ -607,7 +607,7 @@ class SliverGrid extends SliverMultiBoxAdaptorWidget {
 ///  * [SliverFixedExtentList], which has a configurable
 ///    [SliverFixedExtentList.itemExtent].
 ///  * [SliverPrototypeExtentList], which is similar to [SliverFixedExtentList]
-///    except that it uses a prototype list item intead a pixel value to define
+///    except that it uses a prototype list item instead of a pixel value to define
 ///    the main axis extent of each item.
 ///  * [SliverList], which does not require its children to have the same
 ///    extent in the main axis.

--- a/packages/flutter/lib/src/widgets/sliver_prototype_extent_list.dart
+++ b/packages/flutter/lib/src/widgets/sliver_prototype_extent_list.dart
@@ -20,7 +20,7 @@ import 'sliver.dart';
 /// [SliverPrototypeExtentList] is more efficient than [SliverList] because
 /// [SliverPrototypeExtentList] does not need to lay out its children to obtain
 /// their extent along the main axis. It's a little more flexible than
-/// [SliverFixedExtentList] because there's no need to determine the approriate
+/// [SliverFixedExtentList] because there's no need to determine the appropriate
 /// item extent in pixels.
 ///
 /// See also:

--- a/packages/flutter/lib/src/widgets/text.dart
+++ b/packages/flutter/lib/src/widgets/text.dart
@@ -230,7 +230,7 @@ class Text extends StatelessWidget {
   /// example, if the [data] is an English phrase followed by a Hebrew phrase,
   /// in a [TextDirection.ltr] context the English phrase will be on the left
   /// and the Hebrew phrase to its right, while in a [TextDirection.rtl]
-  /// context, the English phrase will be on the right and the Hebrow phrase on
+  /// context, the English phrase will be on the right and the Hebrew phrase on
   /// its left.
   ///
   /// Defaults to the ambient [Directionality], if any.

--- a/packages/flutter/lib/src/widgets/transitions.dart
+++ b/packages/flutter/lib/src/widgets/transitions.dart
@@ -160,7 +160,7 @@ class ScaleTransition extends AnimatedWidget {
   /// painted v times its normal size.
   Animation<double> get scale => listenable;
 
-  /// The alignment of the origin of the coordainte system in which the scale
+  /// The alignment of the origin of the coordinate system in which the scale
   /// takes place, relative to the size of the box.
   ///
   /// For example, to set the origin of the scale to bottom middle, you can use
@@ -498,7 +498,7 @@ typedef Widget TransitionBuilder(BuildContext context, Widget child);
 /// For simple cases without additional state, consider using
 /// [AnimatedWidget].
 ///
-/// ## Performance optimisations
+/// ## Performance optimizations
 ///
 /// If your [builder] function contains a subtree that does not depend on the
 /// animation, it's more efficient to build that subtree once instead of

--- a/packages/flutter/test/rendering/recording_canvas.dart
+++ b/packages/flutter/test/rendering/recording_canvas.dart
@@ -38,7 +38,7 @@ class RecordedInvocation {
 
 /// A [Canvas] for tests that records its method calls.
 ///
-/// This class can be used in conjuction with [TestRecordingPaintingContext]
+/// This class can be used in conjunction with [TestRecordingPaintingContext]
 /// to record the [Canvas] method calls made by a renderer. For example:
 ///
 /// ```dart

--- a/packages/flutter/test/widgets/semantics_tester.dart
+++ b/packages/flutter/test/widgets/semantics_tester.dart
@@ -175,7 +175,7 @@ class TestSemantics {
   /// The transform from this node's coordinate system to its parent's coordinate system.
   ///
   /// By default, the transform is null, which represents the identity
-  /// transformation (i.e., that this node has the same coorinate system as its
+  /// transformation (i.e., that this node has the same coordinate system as its
   /// parent).
   final Matrix4 transform;
 

--- a/packages/flutter_driver/lib/src/common.dart
+++ b/packages/flutter_driver/lib/src/common.dart
@@ -24,7 +24,7 @@ void restoreFileSystem() {
   fs = const LocalFileSystem();
 }
 
-/// Flutter Driver test ouputs directory.
+/// Flutter Driver test output directory.
 ///
 /// Tests should write any output files to this directory. Defaults to the path
 /// set in the FLUTTER_TEST_OUTPUTS_DIR environment variable, or `build` if

--- a/packages/flutter_localizations/lib/src/material_localizations.dart
+++ b/packages/flutter_localizations/lib/src/material_localizations.dart
@@ -45,7 +45,7 @@ import 'widgets_localizations.dart';
 ///   * it - Italian
 ///   * ja - Japanese
 ///   * ps - Pashto
-///   * pt - Portugese
+///   * pt - Portuguese
 ///   * ru - Russian
 ///   * sd - Sindhi
 ///   * ur - Urdu
@@ -369,7 +369,7 @@ class GlobalMaterialLocalizations implements MaterialLocalizations {
   /// A [LocalizationsDelegate] that uses [GlobalMaterialLocalizations.load]
   /// to create an instance of this class.
   ///
-  /// Most internationlized apps will use [GlobalMaterialLocalizations.delegates]
+  /// Most internationalized apps will use [GlobalMaterialLocalizations.delegates]
   /// as the value of [MaterialApp.localizationsDelegates] to include
   /// the localizations for both the material and widget libraries.
   static const LocalizationsDelegate<MaterialLocalizations> delegate = const _MaterialLocalizationsDelegate();

--- a/packages/flutter_test/lib/src/binding.dart
+++ b/packages/flutter_test/lib/src/binding.dart
@@ -103,7 +103,7 @@ abstract class TestWidgetsFlutterBinding extends BindingBase
   /// This can be used to redirect console output from the framework, or to
   /// change the behavior of [debugPrint]. For example,
   /// [AutomatedTestWidgetsFlutterBinding] uses it to make [debugPrint]
-  /// synchronous, disabling its normal throttling behaviour.
+  /// synchronous, disabling its normal throttling behavior.
   @protected
   DebugPrintCallback get debugPrintOverride => debugPrint;
 
@@ -212,13 +212,13 @@ abstract class TestWidgetsFlutterBinding extends BindingBase
     });
   }
 
-  /// Convert the given point from the global coodinate system (as used by
+  /// Convert the given point from the global coordinate system (as used by
   /// pointer events from the device) to the coordinate system used by the
   /// tests (an 800 by 600 window).
   Offset globalToLocal(Offset point) => point;
 
   /// Convert the given point from the coordinate system used by the tests (an
-  /// 800 by 600 window) to the global coodinate system (as used by pointer
+  /// 800 by 600 window) to the global coordinate system (as used by pointer
   /// events from the device).
   Offset localToGlobal(Offset point) => point;
 
@@ -975,7 +975,7 @@ class TestViewConfiguration extends ViewConfiguration {
   /// Provides the transformation matrix that converts coordinates in the test
   /// coordinate space to coordinates in logical pixels on the real display.
   ///
-  /// This is essenitally the same as [toMatrix] but ignoring the device pixel
+  /// This is essentially the same as [toMatrix] but ignoring the device pixel
   /// ratio.
   ///
   /// This is useful because pointers are described in logical pixels, as

--- a/packages/flutter_test/lib/src/controller.dart
+++ b/packages/flutter_test/lib/src/controller.dart
@@ -320,7 +320,7 @@ class WidgetController {
   /// To make tests more realistic, frames may be pumped during this time (using
   /// calls to [pump]). If the total duration is longer than `frameInterval`,
   /// then one frame is pumped each time that amount of time elapses while
-  /// sending events, or each time an event is synthesised, whichever is rarer.
+  /// sending events, or each time an event is synthesized, whichever is rarer.
   ///
   /// A fling is essentially a drag that ends at a particular speed. If you
   /// just want to drag and end without a fling, use [dragFrom].

--- a/packages/flutter_test/lib/src/finders.dart
+++ b/packages/flutter_test/lib/src/finders.dart
@@ -213,7 +213,7 @@ class CommonFinders {
 /// Searches a widget tree and returns nodes that match a particular
 /// pattern.
 abstract class Finder {
-  /// Initialises a Finder. Used by subclasses to initialize the [skipOffstage]
+  /// Initializes a Finder. Used by subclasses to initialize the [skipOffstage]
   /// property.
   Finder({ this.skipOffstage: true });
 
@@ -385,7 +385,7 @@ class _HitTestableFinder extends Finder {
 /// Searches a widget tree and returns nodes that match a particular
 /// pattern.
 abstract class MatchFinder extends Finder {
-  /// Initialises a predicate-based Finder. Used by subclasses to initialize the
+  /// Initializes a predicate-based Finder. Used by subclasses to initialize the
   /// [skipOffstage] property.
   MatchFinder({ bool skipOffstage: true }) : super(skipOffstage: skipOffstage);
 

--- a/packages/flutter_test/lib/src/matchers.dart
+++ b/packages/flutter_test/lib/src/matchers.dart
@@ -449,7 +449,7 @@ class _EqualsIgnoringHashCodes extends Matcher {
 /// Returns true if [c] represents a whitespace code unit.
 bool _isWhitespace(int c) => (c <= 0x000D && c >= 0x0009) || c == 0x0020;
 
-/// Returns true if [c] represents a vertical line unicode line art code unit.
+/// Returns true if [c] represents a vertical line Unicode line art code unit.
 ///
 /// See [https://en.wikipedia.org/wiki/Box-drawing_character]. This method only
 /// specifies vertical line art code units currently used by Flutter line art.

--- a/packages/flutter_tools/lib/src/base/file_system.dart
+++ b/packages/flutter_tools/lib/src/base/file_system.dart
@@ -140,7 +140,7 @@ Directory getReplaySource(String dirname, String basename) {
 
 /// Canonicalizes [path].
 ///
-/// This function implements the behaviour of `canonicalize` from
+/// This function implements the behavior of `canonicalize` from
 /// `package:path`. However, unlike the original, it does not change the ASCII
 /// case of the path. Changing the case can break hot reload in some situations,
 /// for an example see: https://github.com/flutter/flutter/issues/9539.

--- a/packages/flutter_tools/lib/src/base/port_scanner.dart
+++ b/packages/flutter_tools/lib/src/base/port_scanner.dart
@@ -28,7 +28,7 @@ abstract class PortScanner {
   /// Returns an available port as close to [defaultPort] as possible.
   ///
   /// If [defaultPort] is available, this will return it. Otherwise, it will
-  /// search for an avaiable port close to [defaultPort]. If it cannot find one,
+  /// search for an available port close to [defaultPort]. If it cannot find one,
   /// it will return any available port.
   Future<int> findPreferredPort(int defaultPort) async {
     int iterationCount = 0;

--- a/packages/flutter_tools/lib/src/base/terminal.dart
+++ b/packages/flutter_tools/lib/src/base/terminal.dart
@@ -89,7 +89,7 @@ class AnsiTerminal {
     return _broadcastStdInString;
   }
 
-  /// Prompts the user to input a chraracter within the accepted list.
+  /// Prompts the user to input a character within the accepted list.
   /// Reprompts if inputted character is not in the list.
   ///
   /// `prompt` is the text displayed prior to waiting for user input each time.

--- a/packages/flutter_tools/lib/src/base/utils.dart
+++ b/packages/flutter_tools/lib/src/base/utils.dart
@@ -184,15 +184,15 @@ class SettingsFile {
 ///
 ///     f47ac10b-58cc-4372-a567-0e02b2c3d479
 ///
-/// The generated uuids are 128 bit numbers encoded in a specific string format.
+/// The generated UUIDs are 128 bit numbers encoded in a specific string format.
 ///
 /// For more information, see
 /// http://en.wikipedia.org/wiki/Universally_unique_identifier.
 class Uuid {
   final Random _random = new Random();
 
-  /// Generate a version 4 (random) uuid. This is a uuid scheme that only uses
-  /// random numbers as the source of the generated uuid.
+  /// Generate a version 4 (random) UUID. This is a UUID scheme that only uses
+  /// random numbers as the source of the generated UUID.
   String generateV4() {
     // Generate xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx / 8-4-4-4-12.
     final int special = 8 + _random.nextInt(4);

--- a/packages/flutter_tools/lib/src/device.dart
+++ b/packages/flutter_tools/lib/src/device.dart
@@ -389,7 +389,7 @@ abstract class DeviceLogReader {
   @override
   String toString() => name;
 
-  /// Process ID of the app on the deivce.
+  /// Process ID of the app on the device.
   int appPid;
 }
 

--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -95,7 +95,7 @@ class IMobileDevice {
   /// Starts `idevicesyslog` and returns the running process.
   Future<Process> startLogger() => runCommand(<String>['idevicesyslog']);
 
-  /// Captures a screenshot to the specified outputfile.
+  /// Captures a screenshot to the specified outputFile.
   Future<Null> takeScreenshot(File outputFile) {
     return runCheckedAsync(<String>['idevicescreenshot', outputFile.path]);
   }

--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -50,7 +50,7 @@ class FlutterCommandResult {
   /// latency without measuring user interaction time.
   ///
   /// [FlutterCommand] will automatically measure and report the command's
-  /// complete time if not overriden.
+  /// complete time if not overridden.
   final DateTime endTimeOverride;
 }
 

--- a/packages/flutter_tools/lib/src/vmservice.dart
+++ b/packages/flutter_tools/lib/src/vmservice.dart
@@ -533,7 +533,7 @@ class ServiceEvent extends ServiceObject {
 }
 
 /// A ServiceObjectOwner is either a [VM] or an [Isolate]. Owners can cache
-/// and/or canonicalize service objets received over the wire.
+/// and/or canonicalize service objects received over the wire.
 abstract class ServiceObjectOwner extends ServiceObject {
   ServiceObjectOwner._empty(ServiceObjectOwner owner) : super._empty(owner);
 


### PR DESCRIPTION
I got tired of drive-by spelling fixes, so I figured I'd just take care of them all at once.

This only corrects errors in the dartdocs, not regular comments, and I skipped any sample code in the dartdocs.  It doesn't touch any identifiers in the dartdocs either.  No code changes, just comments.