### PR TITLE
Verify microtasks are flushed with each event loop

### DIFF
--- a/packages/flutter/test/engine/task_order_test.dart
+++ b/packages/flutter/test/engine/task_order_test.dart
@@ -1,0 +1,49 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:test/test.dart';
+
+void main() {
+  test('Message loop flushes microtasks between iterations', () async {
+    final List<int> tasks = <int>[];
+
+    tasks.add(1);
+
+    // Flush 0 microtasks.
+    await new Future<Null>.delayed(Duration.ZERO);
+
+    scheduleMicrotask(() {
+      tasks.add(3);
+    });
+    scheduleMicrotask(() {
+      tasks.add(4);
+    });
+
+    tasks.add(2);
+
+    // Flush 2 microtasks.
+    await new Future<Null>.delayed(Duration.ZERO);
+
+    scheduleMicrotask(() {
+      tasks.add(6);
+    });
+    scheduleMicrotask(() {
+      tasks.add(7);
+    });
+    scheduleMicrotask(() {
+      tasks.add(8);
+    });
+
+    tasks.add(5);
+
+    // Flush 3 microtasks.
+    await new Future<Null>.delayed(Duration.ZERO);
+
+    tasks.add(9);
+
+    expect(tasks, <int>[1, 2, 3, 4, 5, 6, 7, 8, 9]);
+  });
+}


### PR DESCRIPTION
Adds a test that verifies that the microtask queue is flushed between
engine event loop iterations.

Related issue: https://github.com/flutter/flutter/issues/9998