### PR TITLE
Add EBADF errno to list of ignorable errors in terminal.dart

### DIFF
--- a/packages/flutter_tools/lib/src/base/terminal.dart
+++ b/packages/flutter_tools/lib/src/base/terminal.dart
@@ -25,6 +25,7 @@ class AnsiTerminal {
   static const String _reset = '\u001B[0m';
   static const String _clear = '\u001B[2J\u001B[H';
 
+  static const int _EBADF = 9;
   static const int _ENXIO = 6;
   static const int _ENOTTY = 25;
   static const int _ENETRESET = 102;
@@ -33,6 +34,7 @@ class AnsiTerminal {
   /// Setting the line mode can throw for some terminals (with "Operation not
   /// supported on socket"), but the error can be safely ignored.
   static const List<int> _lineModeIgnorableErrors = const <int>[
+    _EBADF,
     _ENXIO,
     _ENOTTY,
     _ENETRESET,


### PR DESCRIPTION
I get this error when piping an `echo` string to the stdin of
the flutter tool.

https://github.com/dart-lang/sdk/issues/29083