### PR TITLE
Popup menus RTL

### DIFF
--- a/packages/flutter/lib/src/material/about.dart
+++ b/packages/flutter/lib/src/material/about.dart
@@ -138,6 +138,9 @@ class AboutListTile extends StatelessWidget {
 ///
 /// The licenses shown on the [LicensePage] are those returned by the
 /// [LicenseRegistry] API, which can be used to add more licenses to the list.
+///
+/// The `context` argument is passed to [showDialog], the documentation for
+/// which discusses how it is used.
 void showAboutDialog({
   @required BuildContext context,
   String applicationName,

--- a/packages/flutter/lib/src/material/bottom_sheet.dart
+++ b/packages/flutter/lib/src/material/bottom_sheet.dart
@@ -252,6 +252,11 @@ class _ModalBottomSheetRoute<T> extends PopupRoute<T> {
 /// preventing the use from interacting with the app. Persistent bottom sheets
 /// can be created and displayed with the [ScaffoldState.showBottomSheet] function.
 ///
+/// The `context` argument is used to look up the [Navigator] and [Theme] for
+/// the bottom sheet. It is only used when the method is called. Its
+/// corresponding widget can be safely removed from the tree before the bottom
+/// sheet is closed.
+///
 /// Returns a `Future` that resolves to the value (if any) that was passed to
 /// [Navigator.pop] when the modal bottom sheet was closed.
 ///

--- a/packages/flutter/lib/src/material/date_picker.dart
+++ b/packages/flutter/lib/src/material/date_picker.dart
@@ -934,6 +934,9 @@ typedef bool SelectableDayPredicate(DateTime day);
 /// provided by [Directionality]. If both [locale] and [textDirection] are not
 /// null, [textDirection] overrides the direction chosen for the [locale].
 ///
+/// The `context` argument is passed to [showDialog], the documentation for
+/// which discusses how it is used.
+///
 /// See also:
 ///
 ///  * [showTimePicker]

--- a/packages/flutter/lib/src/material/dialog.dart
+++ b/packages/flutter/lib/src/material/dialog.dart
@@ -447,6 +447,10 @@ class _DialogRoute<T> extends PopupRoute<T> {
 /// This function typically receives a [Dialog] widget as its child argument.
 /// Content below the dialog is dimmed with a [ModalBarrier].
 ///
+/// The `context` argument is used to look up the [Navigator] and [Theme] for
+/// the dialog. It is only used when the method is called. Its corresponding
+/// widget can be safely removed from the tree before the dialog is closed.
+///
 /// Returns a [Future] that resolves to the value (if any) that was passed to
 /// [Navigator.pop] when the dialog was closed.
 ///

--- a/packages/flutter/lib/src/material/time_picker.dart
+++ b/packages/flutter/lib/src/material/time_picker.dart
@@ -1249,12 +1249,16 @@ class _TimePickerDialogState extends State<_TimePickerDialog> {
 /// closes the dialog. If the user cancels the dialog, null is returned.
 ///
 /// To show a dialog with [initialTime] equal to the current time:
+///
 /// ```dart
 /// showTimePicker(
 ///   initialTime: new TimeOfDay.now(),
-///   context: context
+///   context: context,
 /// );
 /// ```
+///
+/// The `context` argument is passed to [showDialog], the documentation for
+/// which discusses how it is used.
 ///
 /// See also:
 ///

--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -3076,7 +3076,7 @@ abstract class _InterestingSemanticsFragment extends _SemanticsFragment {
   }
 }
 
-/// A [_InterestingSemanticsFragment] that produces the root [SemanticsNode] of
+/// An [_InterestingSemanticsFragment] that produces the root [SemanticsNode] of
 /// the semantics tree.
 ///
 /// The root node is available as only element in the Iterable returned by
@@ -3130,7 +3130,7 @@ class _RootSemanticsFragment extends _InterestingSemanticsFragment {
   }
 }
 
-/// A [_InterstingSemanticsFragment] that can be told to only add explicit
+/// An [_InterestingSemanticsFragment] that can be told to only add explicit
 /// [SemanticsNode]s to the parent.
 ///
 /// If [markAsExplicit] was not called before this fragment is added to

--- a/packages/flutter/lib/src/rendering/stack.dart
+++ b/packages/flutter/lib/src/rendering/stack.dart
@@ -103,8 +103,22 @@ class RelativeRect {
   }
 
   /// Convert this [RelativeRect] to a [Rect], in the coordinate space of the container.
+  ///
+  /// See also:
+  ///
+  ///  * [toSize], which returns the size part of the rect, based on the size of
+  ///    the container.
   Rect toRect(Rect container) {
     return new Rect.fromLTRB(left, top, container.width - right, container.height - bottom);
+  }
+
+  /// Convert this [RelativeRect] to a [Size], assuming a container with the given size.
+  ///
+  /// See also:
+  ///
+  ///  * [toRect], which also computes the position relative to the container.
+  Size toSize(Size container) {
+    return new Size(container.width - left - right, container.height - top - bottom);
   }
 
   /// Linearly interpolate between two RelativeRects.

--- a/packages/flutter/test/rendering/relative_rect_test.dart
+++ b/packages/flutter/test/rendering/relative_rect_test.dart
@@ -38,6 +38,11 @@ void main() {
     final Rect r2 = r1.toRect(new Rect.fromLTRB(10.0, 20.0, 90.0, 180.0));
     expect(r2, new Rect.fromLTRB(10.0, 20.0, 50.0, 120.0));
   });
+  test('RelativeRect.toSize', () {
+    final RelativeRect r1 = const RelativeRect.fromLTRB(10.0, 20.0, 30.0, 40.0);
+    final Size r2 = r1.toSize(const Size(80.0, 160.0));
+    expect(r2, const Size(40.0, 100.0));
+  });
   test('RelativeRect.lerp', () {
     final RelativeRect r1 = RelativeRect.fill;
     final RelativeRect r2 = const RelativeRect.fromLTRB(10.0, 20.0, 30.0, 40.0);


### PR DESCRIPTION
This fixes the popup menu code to do a better job of expanding
smoothly regardless of which side of the screen it's on. It still
results in a bidirection growth when positioned at the bottom of the
screen, so maybe we'll need to animate menus differently, but that's
a problem for another patch.

Also, improve some docs and provide RelativeRect.toSize which I needed
at one point while building this patch (though it didn't survive all
the way to the end).