### PR TITLE
ExpansionTile opened - initial state

### DIFF
--- a/packages/flutter/lib/src/material/expansion_tile.dart
+++ b/packages/flutter/lib/src/material/expansion_tile.dart
@@ -30,7 +30,8 @@ const Duration _kExpand = const Duration(milliseconds: 200);
 ///    <https://material.io/guidelines/components/lists-controls.html>.
 class ExpansionTile extends StatefulWidget {
   /// Creates a single-line [ListTile] with a trailing button that expands or collapses
-  /// the tile to reveal or hide the [children].
+  /// the tile to reveal or hide the [children]. The [initiallyExpanded] property must
+  /// be non-null.
   const ExpansionTile({
     Key key,
     this.leading,
@@ -39,7 +40,9 @@ class ExpansionTile extends StatefulWidget {
     this.onExpansionChanged,
     this.children: const <Widget>[],
     this.trailing,
-  }) : super(key: key);
+    this.initiallyExpanded: false,
+  }) : assert(initiallyExpanded != null),
+       super(key: key);
 
   /// A widget to display before the title.
   ///
@@ -69,6 +72,9 @@ class ExpansionTile extends StatefulWidget {
   /// A widget to display instead of a rotating arrow icon.
   final Widget trailing;
 
+  /// Specifies if the list tile is initially expanded (true) or collapsed (false, the default).
+  final bool initiallyExpanded;
+
   @override
   _ExpansionTileState createState() => new _ExpansionTileState();
 }
@@ -97,7 +103,7 @@ class _ExpansionTileState extends State<ExpansionTile> with SingleTickerProvider
     _iconTurns = new Tween<double>(begin: 0.0, end: 0.5).animate(_easeInAnimation);
     _backgroundColor = new ColorTween();
 
-    _isExpanded = PageStorage.of(context)?.readState(context) ?? false;
+    _isExpanded = PageStorage.of(context)?.readState(context) ?? widget.initiallyExpanded;
     if (_isExpanded)
       _controller.value = 1.0;
   }

--- a/packages/flutter/test/material/expansion_tile_initial_state_test.dart
+++ b/packages/flutter/test/material/expansion_tile_initial_state_test.dart
@@ -1,0 +1,76 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter/material.dart';
+
+void main() {
+  testWidgets('ExpansionTile initial state', (WidgetTester tester) async {
+    final Key topKey = new UniqueKey();
+    final Key expandedKey = const PageStorageKey<String>('expanded');
+    final Key collapsedKey = const PageStorageKey<String>('collapsed');
+    final Key defaultKey = const PageStorageKey<String>('default');
+
+    final Key tileKey = new UniqueKey();
+
+    await tester.pumpWidget(new MaterialApp(
+      home: new Material(
+        child: new SingleChildScrollView(
+          child: new Column(
+            children: <Widget>[
+              new ListTile(title: const Text('Top'), key: topKey),
+              new ExpansionTile(
+                key: expandedKey,
+                initiallyExpanded: true,
+                title: const Text('Expanded'),
+                children: <Widget>[
+                  new ListTile(
+                    key: tileKey,
+                    title: const Text('0')
+                  )
+                ]
+              ),
+              new ExpansionTile(
+                key: collapsedKey,
+                initiallyExpanded: false,
+                title: const Text('Collapsed'),
+                children: <Widget>[
+                  new ListTile(
+                    key: tileKey,
+                    title: const Text('0')
+                  )
+                ]
+              ),
+              new ExpansionTile(
+                key: defaultKey,
+                title: const Text('Default'),
+                children: <Widget>[
+                  const ListTile(title: const Text('0')),
+                ]
+              )
+            ]
+          )
+        )
+      )
+    ));
+
+    double getHeight(Key key) => tester.getSize(find.byKey(key)).height;
+
+    expect(getHeight(topKey), getHeight(expandedKey) - getHeight(tileKey) - 2.0);
+    expect(getHeight(topKey), getHeight(collapsedKey) - 2.0);
+    expect(getHeight(topKey), getHeight(defaultKey) - 2.0);
+
+    await tester.tap(find.text('Expanded'));
+    await tester.tap(find.text('Collapsed'));
+    await tester.tap(find.text('Default'));
+
+    await tester.pump();
+    await tester.pump(const Duration(seconds: 1));
+
+    expect(getHeight(topKey), getHeight(expandedKey) - 2.0);
+    expect(getHeight(topKey), getHeight(collapsedKey) - getHeight(tileKey) - 2.0);
+    expect(getHeight(topKey), getHeight(defaultKey) - getHeight(tileKey) - 2.0);
+  });
+}


### PR DESCRIPTION
Related issue  #13105

Changed the ExpansionTile widget to have an optional value to
initialize the widget as collapsed or expanded.

The widget will be collapsed by default.