### PR TITLE
Add missing onDragCompleted to LongPressDraggable

### DIFF
--- a/packages/flutter/lib/src/widgets/drag_target.dart
+++ b/packages/flutter/lib/src/widgets/drag_target.dart
@@ -228,7 +228,8 @@ class LongPressDraggable<T> extends Draggable<T> {
     DragAnchor dragAnchor: DragAnchor.child,
     int maxSimultaneousDrags,
     VoidCallback onDragStarted,
-    DraggableCanceledCallback onDraggableCanceled
+    DraggableCanceledCallback onDraggableCanceled,
+    VoidCallback onDragCompleted
   }) : super(
     key: key,
     child: child,
@@ -239,7 +240,8 @@ class LongPressDraggable<T> extends Draggable<T> {
     dragAnchor: dragAnchor,
     maxSimultaneousDrags: maxSimultaneousDrags,
     onDragStarted: onDragStarted,
-    onDraggableCanceled: onDraggableCanceled
+    onDraggableCanceled: onDraggableCanceled,
+    onDragCompleted: onDragCompleted
   );
 
   @override


### PR DESCRIPTION
When switching from `Draggable` to `LongPressDraggable` I discovered a missing callback (`onDragCompleted`) which can't be registered.