### PR TITLE
Update dart:vmservice_sky to vmservice_io

### DIFF
--- a/packages/flutter_tools/lib/src/commands/build_aot.dart
+++ b/packages/flutter_tools/lib/src/commands/build_aot.dart
@@ -251,7 +251,7 @@ Future<String> _buildAotSnapshot(
     '--isolate_snapshot_data=$isolateSnapshotData',
     '--packages=${packageMap.packagesPath}',
     '--url_mapping=dart:ui,$uiPath',
-    '--url_mapping=dart:vmservice_sky,$vmServicePath',
+    '--url_mapping=dart:vmservice_io,$vmServicePath',
     '--print_snapshot_sizes',
     '--dependencies=$dependencies',
     '--causal_async_stacks',


### PR DESCRIPTION
In the Dart SDK roll landed as part of 77af1e5eec9e91401189bd9d1ecdefb30fca334c, dart:vmservice_sky was renamed to dart:vmservice_io.