### PR TITLE
Remove now-default enableAssertInitializer from analysis config

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -25,7 +25,6 @@ analyzer:
   language:
     enableStrictCallChecks: true
     enableSuperMixins: true
-    enableAssertInitializer: true
   strong-mode:
     implicit-dynamic: false
   errors:

--- a/analysis_options_repo.yaml
+++ b/analysis_options_repo.yaml
@@ -22,7 +22,6 @@ analyzer:
   language:
     enableStrictCallChecks: true
     enableSuperMixins: true
-    enableAssertInitializer: true
   strong-mode:
     implicit-dynamic: false
   errors:


### PR DESCRIPTION
As discussed in email: This is now on-by-default in Dart, so no reason to include this in our set of language options.