### PR TITLE
Mark flutter_gallery__preview_dart_2_bulid unflaky

### DIFF
--- a/dev/devicelab/manifest.yaml
+++ b/dev/devicelab/manifest.yaml
@@ -338,7 +338,6 @@ tasks:
       Gallery under --preview-dart-2 that enables new Dart 2.0 frontend.
     stage: devicelab
     required_agent_capabilities: ["linux/android"]
-    flaky: true
 
   flutter_gallery__start_up:
     description: >


### PR DESCRIPTION
This was fixed in #13150.

That commit rolled the engine to:
  flutter/engine@93b21795971357edbfd646f61b8d7f62388b0dae,

which rolled Dart to:
  dart-lang/sdk@70e5deacb54aea295665215837adaedd3d6a5bfa

which includes:
  dart-lang/sdk@d38c08d97358ebe4ee30e557bfee339dddda9b7a

Which fixes the breakage introduced in #13134.

This reverts commit f5d9c7775dabc9f3e78b87b4ea8679edcae73b36.