### PR TITLE
Revert "Reenable fade transition for Material page transition (#13048)"

### DIFF
--- a/packages/flutter/lib/src/material/page.dart
+++ b/packages/flutter/lib/src/material/page.dart
@@ -24,14 +24,9 @@ class _MountainViewPageTransition extends StatelessWidget {
          parent: routeAnimation, // The route's linear 0.0 - 1.0 animation.
          curve: Curves.fastOutSlowIn,
        )),
-       _opacityAnimation = new CurvedAnimation(
-         parent: routeAnimation,
-         curve: Curves.easeIn, // Eyeballed from other Material apps.
-       ),
        super(key: key);
 
   final Animation<Offset> _positionAnimation;
-  final Animation<double> _opacityAnimation;
   final Widget child;
 
   @override
@@ -39,10 +34,7 @@ class _MountainViewPageTransition extends StatelessWidget {
     // TODO(ianh): tell the transform to be un-transformed for hit testing
     return new SlideTransition(
       position: _positionAnimation,
-      child: new FadeTransition(
-        opacity: _opacityAnimation,
-        child: child,
-      ),
+      child: child,
     );
   }
 }

--- a/packages/flutter/test/material/page_test.dart
+++ b/packages/flutter/test/material/page_test.dart
@@ -28,8 +28,6 @@ void main() {
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 1));
 
-    Opacity widget2Opacity =
-        tester.element(find.text('Page 2')).ancestorWidgetOfExactType(Opacity);
     Offset widget2TopLeft = tester.getTopLeft(find.text('Page 2'));
     final Size widget2Size = tester.getSize(find.text('Page 2'));
 
@@ -37,10 +35,8 @@ void main() {
     expect(widget1TopLeft.dx == widget2TopLeft.dx, true);
     // Page 1 is above page 2 mid-transition.
     expect(widget1TopLeft.dy < widget2TopLeft.dy, true);
-    // Animation begins 3/4 of the way up the page.
-    expect(widget2TopLeft.dy < widget2Size.height / 4.0, true);
-    // Animation starts with page 2 being near transparent.
-    expect(widget2Opacity.opacity < 0.01, true);
+    // Animation begins from the top of the page.
+    expect(widget2TopLeft.dy < widget2Size.height, true);
 
     await tester.pump(const Duration(milliseconds: 300));
 
@@ -52,14 +48,10 @@ void main() {
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 1));
 
-    widget2Opacity =
-        tester.element(find.text('Page 2')).ancestorWidgetOfExactType(Opacity);
     widget2TopLeft = tester.getTopLeft(find.text('Page 2'));
 
     // Page 2 starts to move down.
     expect(widget1TopLeft.dy < widget2TopLeft.dy, true);
-    // Page 2 starts to lose opacity.
-    expect(widget2Opacity.opacity < 1.0, true);
 
     await tester.pump(const Duration(milliseconds: 300));
 


### PR DESCRIPTION
This reverts commit e73d406106aefb5b1d4d06bb209d19618bd0e6ac.

It caused major performance regressions.