### PR TITLE
add an assert to validate the RefreshIndicator.onRefresh result

### DIFF
--- a/packages/flutter/lib/src/material/refresh_indicator.dart
+++ b/packages/flutter/lib/src/material/refresh_indicator.dart
@@ -327,7 +327,20 @@ class RefreshIndicatorState extends State<RefreshIndicator> with TickerProviderS
           });
 
           final Future<Null> refreshResult = widget.onRefresh();
-          assert(refreshResult != null, 'RefreshIndicator.onRefresh must return a Future.');
+          assert(() {
+            if (refreshResult == null)
+              FlutterError.reportError(new FlutterErrorDetails(
+                exception: new FlutterError(
+                  'The onRefresh callback returned null.\n'
+                  'The RefreshIndicator onRefresh callback must return a Future.'
+                ),
+                context: 'when calling onRefresh',
+                library: 'material library',
+              ));
+            return true;
+          });
+          if (refreshResult == null)
+            return;
           refreshResult.whenComplete(() {
             if (mounted && _mode == _RefreshIndicatorMode.refresh) {
               completer.complete();

--- a/packages/flutter/lib/src/material/refresh_indicator.dart
+++ b/packages/flutter/lib/src/material/refresh_indicator.dart
@@ -326,7 +326,9 @@ class RefreshIndicatorState extends State<RefreshIndicator> with TickerProviderS
             _mode = _RefreshIndicatorMode.refresh;
           });
 
-          widget.onRefresh().whenComplete(() {
+          final Future<Null> refreshResult = widget.onRefresh();
+          assert(refreshResult != null, 'RefreshIndicator.onRefresh must return a Future.');
+          refreshResult.whenComplete(() {
             if (mounted && _mode == _RefreshIndicatorMode.refresh) {
               completer.complete();
               _dismiss(_RefreshIndicatorMode.done);

--- a/packages/flutter/test/material/refresh_indicator_test.dart
+++ b/packages/flutter/test/material/refresh_indicator_test.dart
@@ -46,7 +46,35 @@ void main() {
     await tester.pump(const Duration(seconds: 1)); // finish the indicator hide animation
     expect(refreshCalled, true);
   });
-  
+
+  testWidgets('RefreshIndicator - onRefresh asserts', (WidgetTester tester) async {
+    refreshCalled = false;
+    await tester.pumpWidget(
+      new MaterialApp(
+        home: new RefreshIndicator(
+          onRefresh: () {
+            refreshCalled = true;
+          },
+          child: new ListView(
+            physics: const AlwaysScrollableScrollPhysics(),
+            children: <String>['A', 'B', 'C', 'D', 'E', 'F'].map((String item) {
+              return new SizedBox(
+                height: 200.0,
+                child: new Text(item),
+              );
+            }).toList(),
+          ),
+        ),
+      ),
+    );
+
+    await tester.fling(find.text('A'), const Offset(0.0, 300.0), 1000.0);
+    await tester.pump();
+    await tester.pump(const Duration(seconds: 1)); // finish the scroll animation
+    expect(refreshCalled, true);
+    expect(tester.takeException(), isAssertionError);
+  });
+
   testWidgets('Refresh Indicator - nested', (WidgetTester tester) async {
     refreshCalled = false;
     await tester.pumpWidget(

--- a/packages/flutter/test/material/refresh_indicator_test.dart
+++ b/packages/flutter/test/material/refresh_indicator_test.dart
@@ -47,34 +47,6 @@ void main() {
     expect(refreshCalled, true);
   });
 
-  testWidgets('RefreshIndicator - onRefresh asserts', (WidgetTester tester) async {
-    refreshCalled = false;
-    await tester.pumpWidget(
-      new MaterialApp(
-        home: new RefreshIndicator(
-          onRefresh: () {
-            refreshCalled = true;
-          },
-          child: new ListView(
-            physics: const AlwaysScrollableScrollPhysics(),
-            children: <String>['A', 'B', 'C', 'D', 'E', 'F'].map((String item) {
-              return new SizedBox(
-                height: 200.0,
-                child: new Text(item),
-              );
-            }).toList(),
-          ),
-        ),
-      ),
-    );
-
-    await tester.fling(find.text('A'), const Offset(0.0, 300.0), 1000.0);
-    await tester.pump();
-    await tester.pump(const Duration(seconds: 1)); // finish the scroll animation
-    expect(refreshCalled, true);
-    expect(tester.takeException(), isAssertionError);
-  });
-
   testWidgets('Refresh Indicator - nested', (WidgetTester tester) async {
     refreshCalled = false;
     await tester.pumpWidget(
@@ -376,5 +348,34 @@ void main() {
     expect(refreshCalled, true);
     expect(completed1, true);
     expect(completed2, true);
+  });
+
+  testWidgets('RefreshIndicator - onRefresh asserts', (WidgetTester tester) async {
+    refreshCalled = false;
+    await tester.pumpWidget(
+      new MaterialApp(
+        home: new RefreshIndicator(
+          onRefresh: () {
+            refreshCalled = true;
+            // Missing a returned Future value here.
+          },
+          child: new ListView(
+            physics: const AlwaysScrollableScrollPhysics(),
+            children: <String>['A', 'B', 'C', 'D', 'E', 'F'].map((String item) {
+              return new SizedBox(
+                height: 200.0,
+                child: new Text(item),
+              );
+            }).toList(),
+          ),
+        ),
+      ),
+    );
+
+    await tester.fling(find.text('A'), const Offset(0.0, 300.0), 1000.0);
+    await tester.pump();
+    await tester.pump(const Duration(seconds: 1)); // finish the scroll animation
+    expect(refreshCalled, true);
+    expect(tester.takeException(), isFlutterError);
   });
 }


### PR DESCRIPTION
This adds an assert to validate the return value of RefreshIndicator.onRefresh; if the user's `onRefresh` closure did work on the refresh - but omitted to return a Future (which I did) - this code would crash with an NPE. Now we instead assert.