### PR TITLE
remove unused constants

### DIFF
--- a/dev/manual_tests/lib/color_testing_demo.dart
+++ b/dev/manual_tests/lib/color_testing_demo.dart
@@ -14,8 +14,6 @@ class ColorTestingDemo extends StatelessWidget {
   Widget build(BuildContext context) => new ColorDemoHome();
 }
 
-const double _kPageMaxWidth = 500.0;
-
 class ColorDemoHome extends StatelessWidget {
   @override
   Widget build(BuildContext context) {

--- a/examples/flutter_gallery/lib/demo/animation/sections.dart
+++ b/examples/flutter_gallery/lib/demo/animation/sections.dart
@@ -10,7 +10,6 @@ const Color _mariner = const Color(0xFF3B5F8F);
 const Color _mediumPurple = const Color(0xFF8266D4);
 const Color _tomato = const Color(0xFFF95B57);
 const Color _mySin = const Color(0xFFF3A646);
-const Color _deepCerise = const Color(0xFFD93F9B);
 
 const String _kGalleryAssetsPackage = 'flutter_gallery_assets';
 

--- a/packages/flutter/lib/src/cupertino/slider.dart
+++ b/packages/flutter/lib/src/cupertino/slider.dart
@@ -179,7 +179,6 @@ class _CupertinoSliderRenderObjectWidget extends LeafRenderObjectWidget {
 }
 
 const double _kPadding = 8.0;
-const double _kTrackHeight = 2.0;
 const Color _kTrackColor = const Color(0xFFB5B5B5);
 const double _kSliderHeight = 2.0 * (CupertinoThumbPainter.radius + _kPadding);
 const double _kSliderWidth = 176.0; // Matches Material Design slider.

--- a/packages/flutter/lib/src/material/bottom_navigation_bar.dart
+++ b/packages/flutter/lib/src/material/bottom_navigation_bar.dart
@@ -16,8 +16,6 @@ import 'material.dart';
 import 'theme.dart';
 import 'typography.dart';
 
-const double _kActiveMaxWidth = 168.0;
-const double _kInactiveMaxWidth = 96.0;
 const double _kActiveFontSize = 14.0;
 const double _kInactiveFontSize = 12.0;
 const double _kTopMargin = 6.0;

--- a/packages/flutter/lib/src/material/bottom_sheet.dart
+++ b/packages/flutter/lib/src/material/bottom_sheet.dart
@@ -14,8 +14,6 @@ import 'theme.dart';
 const Duration _kBottomSheetDuration = const Duration(milliseconds: 200);
 const double _kMinFlingVelocity = 700.0;
 const double _kCloseProgressThreshold = 0.5;
-const Color _kTransparent = const Color(0x00000000);
-const Color _kBarrierColor = Colors.black54;
 
 /// A material design bottom sheet.
 ///

--- a/packages/flutter/lib/src/material/checkbox.dart
+++ b/packages/flutter/lib/src/material/checkbox.dart
@@ -151,7 +151,6 @@ class _CheckboxRenderObjectWidget extends LeafRenderObjectWidget {
   }
 }
 
-const double _kMidpoint = 0.5;
 const double _kEdgeSize = Checkbox.width;
 const Radius _kEdgeRadius = const Radius.circular(1.0);
 const double _kStrokeWidth = 2.0;

--- a/packages/flutter/lib/src/material/material.dart
+++ b/packages/flutter/lib/src/material/material.dart
@@ -277,8 +277,6 @@ class _MaterialState extends State<Material> with TickerProviderStateMixin {
   }
 }
 
-const Duration _kHighlightFadeDuration = const Duration(milliseconds: 200);
-
 class _RenderInkFeatures extends RenderProxyBox implements MaterialInkController {
   _RenderInkFeatures({
     RenderBox child,

--- a/packages/flutter/lib/src/material/snack_bar.dart
+++ b/packages/flutter/lib/src/material/snack_bar.dart
@@ -15,8 +15,6 @@ import 'theme_data.dart';
 // https://material.google.com/components/snackbars-toasts.html#snackbars-toasts-specs
 const double _kSnackBarPadding = 24.0;
 const double _kSingleLineVerticalPadding = 14.0;
-const double _kMultiLineVerticalTopPadding = 24.0;
-const double _kMultiLineVerticalSpaceBetweenTextAndButtons = 10.0;
 const Color _kSnackBackground = const Color(0xFF323232);
 
 // TODO(ianh): We should check if the given text and actions are going to fit on

--- a/packages/flutter/lib/src/material/tabs.dart
+++ b/packages/flutter/lib/src/material/tabs.dart
@@ -22,7 +22,6 @@ import 'theme.dart';
 const double _kTabHeight = 46.0;
 const double _kTextAndIconTabHeight = 72.0;
 const double _kMinTabWidth = 72.0;
-const double _kMaxTabWidth = 264.0;
 
 /// A material design [TabBar] tab. If both [icon] and [text] are
 /// provided, the text is displayed below the icon.

--- a/packages/flutter/lib/src/material/text_field.dart
+++ b/packages/flutter/lib/src/material/text_field.dart
@@ -14,9 +14,6 @@ import 'theme.dart';
 
 export 'package:flutter/services.dart' show TextInputType;
 
-const Duration _kTransitionDuration = const Duration(milliseconds: 200);
-const Curve _kTransitionCurve = Curves.fastOutSlowIn;
-
 /// A material design text field.
 ///
 /// A text field lets the user enter text, either with hardware keyboard or with

--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -18,8 +18,6 @@ const double _kCaretGap = 1.0; // pixels
 const double _kCaretHeightOffset = 2.0; // pixels
 const double _kCaretWidth = 1.0; // pixels
 
-final String _kZeroWidthSpace = new String.fromCharCode(0x200B);
-
 /// Signature for the callback that reports when the user changes the selection
 /// (including the cursor location).
 ///

--- a/packages/flutter_test/lib/src/test_text_input.dart
+++ b/packages/flutter_test/lib/src/test_text_input.dart
@@ -9,8 +9,6 @@ import 'package:flutter/services.dart';
 
 import 'widget_tester.dart';
 
-const String _kTextInputClientChannel = 'flutter/textinputclient';
-
 /// A testing stub for the system's onscreen keyboard.
 ///
 /// Typical app tests will not need to use this class directly.


### PR DESCRIPTION
- remove ~a dozen unused constants in the flutter repo

These were found by the latest analysis server; fixing these addressed about half of the issues in rolling in the latest sdk (https://github.com/flutter/flutter/pull/13180).

If we do want to keep some of these private constants around (like the material ones), we could make them public, or use the `// ignore: ` syntax.