### PR TITLE
change 2 print calls to printStatus

### DIFF
--- a/packages/flutter_tools/lib/src/commands/update_packages.dart
+++ b/packages/flutter_tools/lib/src/commands/update_packages.dart
@@ -179,7 +179,7 @@ class UpdatePackagesCommand extends FlutterCommand {
 
       if (isPrintTransitiveClosure) {
         tree._dependencyTree.forEach((String from, Set<String> to) {
-          print('$from -> $to');
+          printStatus('$from -> $to');
         });
         return;
       }
@@ -256,7 +256,7 @@ class UpdatePackagesCommand extends FlutterCommand {
         if (path != null)
           buf.write(' <- ');
       }
-      print(buf);
+      printStatus(buf.toString());
     }
 
     if (paths.isEmpty) {


### PR DESCRIPTION
- change two `print` calls to `printStatus`

@yjbanov, looking through the commit history, I assume you meant to use `printStatus` here?