### PR TITLE
Fix 'Animated images' demo name in Gallery's test.

### DIFF
--- a/examples/flutter_gallery/test/live_smoketest.dart
+++ b/examples/flutter_gallery/test/live_smoketest.dart
@@ -101,7 +101,7 @@ const List<Demo> demos = const <Demo>[
   const Demo('Switches'),
 
   // Media
-  const Demo('Animated Images'),
+  const Demo('Animated images'),
 
   // Style
   const Demo('Colors'),

--- a/examples/flutter_gallery/test_driver/transitions_perf_test.dart
+++ b/examples/flutter_gallery/test_driver/transitions_perf_test.dart
@@ -75,7 +75,7 @@ const List<Demo> demos = const <Demo>[
   const Demo('Switches'),
 
   // Media
-  const Demo('Animated Images'),
+  const Demo('Animated images'),
 
   // Style
   const Demo('Colors'),


### PR DESCRIPTION
In https://github.com/flutter/flutter/pull/13141 I updated the demo name
from 'Animated Images' to 'Animated images' before submitted, but did
not update the name in the smoketest and transitions_perf test.