### PR TITLE
Remove unnecessary error message when cocopods is not available

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -17,3 +17,4 @@ Vincent Le Quéméner <eu.lequem@gmail.com>
 Mike Hoolehan <mike@hoolehan.com>
 German Saprykin <saprykin.h@gmail.com>
 Stefano Rodriguez <hlsroddy@gmail.com>
+Yusuke Konishi <yahpeycoy0403@gmail.com>

--- a/packages/flutter_tools/lib/src/ios/cocoapods.dart
+++ b/packages/flutter_tools/lib/src/ios/cocoapods.dart
@@ -66,8 +66,6 @@ class CocoaPods {
       } // TODO(xster): Add more logic for handling merge conflicts.
 
       await _runPodInstall(appIosDir, iosEngineDir);
-    } else {
-      throwToolExit('CocoaPods not available for project using Flutter plugins');
     }
   }
 


### PR DESCRIPTION
ref: https://github.com/flutter/flutter/issues/12557

As the original issue says, I thought the error message is not necessary in the case.
I thought it's okay to remove because [this test case](https://github.com/flutter/flutter/blob/master/packages/flutter_tools/test/ios/cocoapods_test.dart#L120) assures. But if it's better to change the error message instead of removing, please tell me.