### PR TITLE
Add --preview-dart-2 option support for ios builds

### DIFF
--- a/packages/flutter_tools/bin/xcode_backend.sh
+++ b/packages/flutter_tools/bin/xcode_backend.sh
@@ -88,6 +88,11 @@ BuildApp() {
     local_engine_flag="--local-engine=$LOCAL_ENGINE"
   fi
 
+  local preview_dart_2_flag=""
+  if [[ -n "$PREVIEW_DART_2" ]]; then
+    preview_dart_2_flag="--preview-dart-2"
+  fi
+
   if [[ "$CURRENT_ARCH" != "x86_64" ]]; then
     local aot_flags=""
     if [[ "$build_mode" == "debug" ]]; then
@@ -101,7 +106,8 @@ BuildApp() {
       --target-platform=ios                                                 \
       --target="${target_path}"                                             \
       ${aot_flags}                                                          \
-      ${local_engine_flag}
+      ${local_engine_flag}                                                  \
+      ${preview_dart_2_flag}
 
     if [[ $? -ne 0 ]]; then
       EchoError "Failed to build ${project_path}."
@@ -133,6 +139,7 @@ BuildApp() {
     --working-dir="${build_dir}/flx"                                      \
     ${precompilation_flag}                                                \
     ${local_engine_flag}                                                  \
+    ${preview_dart_2_flag}                                                \
 
   if [[ $? -ne 0 ]]; then
     EchoError "Failed to package ${project_path}."

--- a/packages/flutter_tools/lib/src/commands/build_ios.dart
+++ b/packages/flutter_tools/lib/src/commands/build_ios.dart
@@ -29,6 +29,7 @@ class BuildIOSCommand extends BuildSubCommand {
     argParser.addFlag('simulator', help: 'Build for the iOS simulator instead of the device.');
     argParser.addFlag('codesign', negatable: true, defaultsTo: true,
         help: 'Codesign the application bundle (only available on device builds).');
+    argParser.addFlag('preview-dart-2', negatable: false);
   }
 
   @override
@@ -70,7 +71,8 @@ class BuildIOSCommand extends BuildSubCommand {
       buildInfo: buildInfo,
       target: targetFile,
       buildForDevice: !forSimulator,
-      codesign: shouldCodesign
+      codesign: shouldCodesign,
+      previewDart2 : argResults['preview-dart-2'],
     );
 
     if (!result.success) {

--- a/packages/flutter_tools/lib/src/commands/create.dart
+++ b/packages/flutter_tools/lib/src/commands/create.dart
@@ -214,6 +214,7 @@ class CreateCommand extends FlutterCommand {
       buildInfo: BuildInfo.debug,
       target: flx.defaultMainPath,
       hasPlugins: generatePlugin,
+      previewDart2: false,
     );
 
     if (argResults['pub']) {

--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -205,6 +205,7 @@ Future<XcodeBuildResult> buildXcodeProject({
   bool buildForDevice,
   bool codesign: true,
   bool usesTerminalUi: true,
+  bool previewDart2: false,
 }) async {
   if (!_checkXcodeVersion())
     return new XcodeBuildResult(success: false);
@@ -264,7 +265,8 @@ Future<XcodeBuildResult> buildXcodeProject({
     projectPath: fs.currentDirectory.path,
     buildInfo: buildInfo,
     target: target,
-    hasPlugins: hasFlutterPlugins
+    hasPlugins: hasFlutterPlugins,
+    previewDart2: previewDart2,
   );
 
   final List<String> commands = <String>[

--- a/packages/flutter_tools/lib/src/ios/xcodeproj.dart
+++ b/packages/flutter_tools/lib/src/ios/xcodeproj.dart
@@ -24,6 +24,7 @@ void updateXcodeGeneratedProperties({
   @required BuildInfo buildInfo,
   @required String target,
   @required bool hasPlugins,
+  @required bool previewDart2,
 }) {
   final StringBuffer localsBuffer = new StringBuffer();
 
@@ -51,6 +52,10 @@ void updateXcodeGeneratedProperties({
   if (artifacts is LocalEngineArtifacts) {
     final LocalEngineArtifacts localEngineArtifacts = artifacts;
     localsBuffer.writeln('LOCAL_ENGINE=${localEngineArtifacts.engineOutPath}');
+  }
+
+  if (previewDart2) {
+    localsBuffer.writeln('PREVIEW_DART_2=true');
   }
 
   // Add dependency to CocoaPods' generated project only if plugins are used.


### PR DESCRIPTION
Until this change you are not able to specify `--preview-dart-2` option for `build ios` bulid like so
```
flutter build ios --preview-dart-2 
```