### PR TITLE
Change few devicelab tests to support testing against local engine

### DIFF
--- a/dev/devicelab/lib/framework/utils.dart
+++ b/dev/devicelab/lib/framework/utils.dart
@@ -510,7 +510,9 @@ void setLocalEngineOptionIfNecessary(List<String> options, [String flavor]) {
       // for flags that specify the engine flavor (--release, --profile or
       // --debug). Default flavor to debug if no flags were found.
       const Map<String, String> optionToFlavor = const <String, String>{
-        '--release': 'release', '--debug': 'debug', '--profile': 'profile'
+        '--release': 'release',
+        '--debug': 'debug',
+        '--profile': 'profile',
       };
 
       for (String option in options) {

--- a/dev/devicelab/lib/framework/utils.dart
+++ b/dev/devicelab/lib/framework/utils.dart
@@ -13,6 +13,8 @@ import 'package:path/path.dart' as path;
 import 'package:process/process.dart';
 import 'package:stack_trace/stack_trace.dart';
 
+import 'adb.dart';
+
 /// Virtual current working directory, which affect functions, such as [exec].
 String cwd = Directory.current.path;
 
@@ -497,4 +499,35 @@ bool lineContainsServicePort(String line) => line.contains(_kObservatoryRegExp);
 int parseServicePort(String line) {
   final Match match = _kObservatoryRegExp.firstMatch(line);
   return match == null ? null : int.parse(match.group(2));
+}
+
+/// If FLUTTER_ENGINE environment variable is set then we need to pass
+/// correct --local-engine setting too.
+setLocalEngineOptionIfNecessary(List<String> options, [String flavor]) {
+  if (Platform.environment['FLUTTER_ENGINE'] != null) {
+    if (flavor == null) {
+      // If engine flavor was not specified explicitly then scan options looking
+      // for flags that specify the engine flavor (--release, --profile or
+      // --debug). Default flavor to debug if no flags were found.
+      const Map<String, String> optionToFlavor = const <String, String>{
+        '--release': 'release', '--debug': 'debug', '--profile': 'profile'
+      };
+
+      for (var option in options) {
+        flavor = optionToFlavor[option];
+        if (flavor != null) {
+          break;
+        }
+      }
+
+      flavor ??= 'debug';
+    }
+
+    const Map<DeviceOperatingSystem, String> osNames = const <DeviceOperatingSystem, String>{
+      DeviceOperatingSystem.ios: 'ios',
+      DeviceOperatingSystem.android: 'android',
+    };
+
+    options.add('--local-engine=${osNames[deviceOperatingSystem]}_${flavor}');
+  }
 }

--- a/dev/devicelab/lib/framework/utils.dart
+++ b/dev/devicelab/lib/framework/utils.dart
@@ -503,7 +503,7 @@ int parseServicePort(String line) {
 
 /// If FLUTTER_ENGINE environment variable is set then we need to pass
 /// correct --local-engine setting too.
-setLocalEngineOptionIfNecessary(List<String> options, [String flavor]) {
+void setLocalEngineOptionIfNecessary(List<String> options, [String flavor]) {
   if (Platform.environment['FLUTTER_ENGINE'] != null) {
     if (flavor == null) {
       // If engine flavor was not specified explicitly then scan options looking
@@ -513,7 +513,7 @@ setLocalEngineOptionIfNecessary(List<String> options, [String flavor]) {
         '--release': 'release', '--debug': 'debug', '--profile': 'profile'
       };
 
-      for (var option in options) {
+      for (String option in options) {
         flavor = optionToFlavor[option];
         if (flavor != null) {
           break;
@@ -528,6 +528,6 @@ setLocalEngineOptionIfNecessary(List<String> options, [String flavor]) {
       DeviceOperatingSystem.android: 'android',
     };
 
-    options.add('--local-engine=${osNames[deviceOperatingSystem]}_${flavor}');
+    options.add('--local-engine=${osNames[deviceOperatingSystem]}_$flavor');
   }
 }

--- a/dev/devicelab/lib/tasks/hot_mode_tests.dart
+++ b/dev/devicelab/lib/tasks/hot_mode_tests.dart
@@ -26,6 +26,7 @@ TaskFunction createHotModeTest({ bool isPreviewDart2: false }) {
     ];
     if (isPreviewDart2)
       options.add('--preview-dart-2');
+    setLocalEngineOptionIfNecessary(options);
     int hotReloadCount = 0;
     await inDirectory(flutterDirectory, () async {
       rmTree(_editedFlutterGalleryDir);

--- a/dev/devicelab/lib/tasks/microbenchmarks.dart
+++ b/dev/devicelab/lib/tasks/microbenchmarks.dart
@@ -40,6 +40,7 @@ TaskFunction createMicrobenchmarkTask() {
           ];
           if (previewDart2)
             options.add('--preview-dart-2');
+          setLocalEngineOptionIfNecessary(options);
           options.add(benchmarkPath);
           return await _startFlutter(
             options: options,

--- a/dev/devicelab/lib/tasks/perf_tests.dart
+++ b/dev/devicelab/lib/tasks/perf_tests.dart
@@ -235,6 +235,7 @@ class CompileTest {
     }
     if (previewDart2)
       options.add('--preview-dart-2');
+    setLocalEngineOptionIfNecessary(options);
     final String compileLog = await evalFlutter('build', options: options);
     watch.stop();
 
@@ -256,6 +257,7 @@ class CompileTest {
     final List<String> options = <String>['--release'];
     if (previewDart2)
       options.add('--preview-dart-2');
+    setLocalEngineOptionIfNecessary(options);
     switch (deviceOperatingSystem) {
       case DeviceOperatingSystem.ios:
         options.insert(0, 'ios');
@@ -288,6 +290,7 @@ class CompileTest {
     final List<String> options = <String>['--debug'];
     if (previewDart2)
       options.add('--preview-dart-2');
+    setLocalEngineOptionIfNecessary(options);
     switch (deviceOperatingSystem) {
       case DeviceOperatingSystem.ios:
         options.insert(0, 'ios');


### PR DESCRIPTION
We can already configure flutter tools to use local engine by setting
FLUTTER_ENGINE environment variable. However when this variable is set
this also requires setting --local-engine to specify which flavor of
engine to use.

This change changes tests in dev/devicelab to pass a sensible default for
--local-engine, e.g. when testing hot reload on Android we pass android_debug
and when testing release AOT build for IOS we pass ios_release.