### PR TITLE
Fix --preview-dart2 option handling for ios profile/release.

### DIFF
--- a/packages/flutter_tools/lib/src/commands/build_ios.dart
+++ b/packages/flutter_tools/lib/src/commands/build_ios.dart
@@ -73,7 +73,6 @@ class BuildIOSCommand extends BuildSubCommand {
       target: targetFile,
       buildForDevice: !forSimulator,
       codesign: shouldCodesign,
-      previewDart2 : argResults['preview-dart-2'],
     );
 
     if (!result.success) {

--- a/packages/flutter_tools/lib/src/fuchsia/fuchsia_device.dart
+++ b/packages/flutter_tools/lib/src/fuchsia/fuchsia_device.dart
@@ -65,7 +65,6 @@ class FuchsiaDevice extends Device {
     DebuggingOptions debuggingOptions,
     Map<String, dynamic> platformArgs,
     bool prebuiltApplication: false,
-    bool previewDart2: false,
     bool applicationNeedsRebuild: false,
     bool usesTerminalUi: false,
     bool ipv6: false,

--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -154,7 +154,6 @@ class IOSDevice extends Device {
     DebuggingOptions debuggingOptions,
     Map<String, dynamic> platformArgs,
     bool prebuiltApplication: false,
-    bool previewDart2: false,
     bool applicationNeedsRebuild: false,
     bool usesTerminalUi: true,
     bool ipv6: false,

--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -205,7 +205,6 @@ Future<XcodeBuildResult> buildXcodeProject({
   bool buildForDevice,
   bool codesign: true,
   bool usesTerminalUi: true,
-  bool previewDart2: false,
 }) async {
   if (!_checkXcodeVersion())
     return new XcodeBuildResult(success: false);
@@ -266,7 +265,7 @@ Future<XcodeBuildResult> buildXcodeProject({
     buildInfo: buildInfo,
     target: target,
     hasPlugins: hasFlutterPlugins,
-    previewDart2: previewDart2,
+    previewDart2: buildInfo.previewDart2,
   );
 
   final List<String> commands = <String>[

--- a/packages/flutter_tools/lib/src/ios/simulators.dart
+++ b/packages/flutter_tools/lib/src/ios/simulators.dart
@@ -297,7 +297,6 @@ class IOSSimulator extends Device {
     String route,
     DebuggingOptions debuggingOptions,
     Map<String, dynamic> platformArgs,
-    bool previewDart2: false,
     bool prebuiltApplication: false,
     bool applicationNeedsRebuild: false,
     bool usesTerminalUi: true,


### PR DESCRIPTION
We don't need to explicitly pass `previewDart2` option - it is part of `BuildInfo` which is populated based on `--preview-dart-2` option passed. We need to use it from `BuildInfo` so it works correctly for `build run --preview-dart-2 --profile/--release`.