### PR TITLE
Correct handling for alwaysUse24HourFormat in MediaQuery

### DIFF
--- a/packages/flutter/lib/src/widgets/media_query.dart
+++ b/packages/flutter/lib/src/widgets/media_query.dart
@@ -117,6 +117,7 @@ class MediaQueryData {
     double textScaleFactor,
     EdgeInsets padding,
     EdgeInsets viewInsets,
+    bool alwaysUse24HourFormat,
   }) {
     return new MediaQueryData(
       size: size ?? this.size,
@@ -124,6 +125,7 @@ class MediaQueryData {
       textScaleFactor: textScaleFactor ?? this.textScaleFactor,
       padding: padding ?? this.padding,
       viewInsets: viewInsets ?? this.viewInsets,
+      alwaysUse24HourFormat: alwaysUse24HourFormat ?? this.alwaysUse24HourFormat,
     );
   }
 
@@ -159,6 +161,7 @@ class MediaQueryData {
         bottom: removeBottom ? 0.0 : null,
       ),
       viewInsets: viewInsets,
+      alwaysUse24HourFormat: alwaysUse24HourFormat,
     );
   }
 
@@ -171,16 +174,18 @@ class MediaQueryData {
         && typedOther.devicePixelRatio == devicePixelRatio
         && typedOther.textScaleFactor == textScaleFactor
         && typedOther.padding == padding
-        && typedOther.viewInsets == viewInsets;
+        && typedOther.viewInsets == viewInsets
+        && typedOther.alwaysUse24HourFormat == alwaysUse24HourFormat;
   }
 
   @override
-  int get hashCode => hashValues(size, devicePixelRatio, textScaleFactor, padding, viewInsets);
+  int get hashCode => hashValues(size, devicePixelRatio, textScaleFactor, padding, viewInsets, alwaysUse24HourFormat);
 
   @override
   String toString() {
     return '$runtimeType(size: $size, devicePixelRatio: $devicePixelRatio, '
-           'textScaleFactor: $textScaleFactor, padding: $padding, viewInsets: $viewInsets)';
+           'textScaleFactor: $textScaleFactor, padding: $padding, '
+           'viewInsets: $viewInsets, alwaysUse24HourFormat: $alwaysUse24HourFormat)';
   }
 }
 

--- a/packages/flutter/test/widgets/media_query_test.dart
+++ b/packages/flutter/test/widgets/media_query_test.dart
@@ -78,19 +78,8 @@ void main() {
     const Size size = const Size(2.0, 4.0);
     const double devicePixelRatio = 2.0;
     const double textScaleFactor = 1.2;
-    const EdgeInsets padding = const EdgeInsets.only(
-      top: 1.0,
-      right: 2.0,
-      left: 3.0,
-      bottom: 4.0,
-    );
-    const EdgeInsets viewInsets = const EdgeInsets.only(
-      top: 5.0,
-      right: 6.0,
-      left: 7.0,
-      bottom: 8.0,
-    );
-    const bool alwaysUse24HourFormat = true;
+    const EdgeInsets padding = const EdgeInsets.only(top: 1.0, right: 2.0, left: 3.0, bottom: 4.0);
+    const EdgeInsets viewInsets = const EdgeInsets.only(top: 5.0, right: 6.0, left: 7.0, bottom: 8.0);
 
     MediaQueryData unpadded;
     await tester.pumpWidget(
@@ -101,7 +90,7 @@ void main() {
           textScaleFactor: textScaleFactor,
           padding: padding,
           viewInsets: viewInsets,
-          alwaysUse24HourFormat: alwaysUse24HourFormat,
+          alwaysUse24HourFormat: true,
         ),
         child: new Builder(
           builder: (BuildContext context) {
@@ -127,59 +116,6 @@ void main() {
     expect(unpadded.textScaleFactor, textScaleFactor);
     expect(unpadded.padding, EdgeInsets.zero);
     expect(unpadded.viewInsets, viewInsets);
-    expect(unpadded.alwaysUse24HourFormat, alwaysUse24HourFormat);
-  });
-
-  testWidgets('MediaQuery.removePadding removes specified padding', (WidgetTester tester) async {
-    const Size size = const Size(2.0, 4.0);
-    const double devicePixelRatio = 2.0;
-    const double textScaleFactor = 1.2;
-    const EdgeInsets padding = const EdgeInsets.only(
-      top: 1.0,
-      right: 2.0,
-      left: 3.0,
-      bottom: 4.0,
-    );
-    const EdgeInsets viewInsets = const EdgeInsets.only(
-      top: 5.0,
-      right: 6.0,
-      left: 7.0,
-      bottom: 8.0,
-    );
-
-    MediaQueryData unpadded;
-    await tester.pumpWidget(
-      new MediaQuery(
-        data: const MediaQueryData(
-          size: size,
-          devicePixelRatio: devicePixelRatio,
-          textScaleFactor: textScaleFactor,
-          padding: padding,
-          viewInsets: viewInsets,
-        ),
-        child: new Builder(
-          builder: (BuildContext context) {
-            return new MediaQuery.removePadding(
-              context: context,
-              removeTop: true,
-              removeRight: true,
-              removeLeft: true,
-              removeBottom: true,
-              child: new Builder(
-                builder: (BuildContext context) {
-                  unpadded = MediaQuery.of(context);
-                  return new Container();
-                }
-              ),
-            );
-          }),
-      )
-    );
-
-    expect(unpadded.size, size);
-    expect(unpadded.devicePixelRatio, devicePixelRatio);
-    expect(unpadded.textScaleFactor, textScaleFactor);
-    expect(unpadded.padding, EdgeInsets.zero);
-    expect(unpadded.viewInsets, viewInsets);
+    expect(unpadded.alwaysUse24HourFormat, true);
   });
 }

--- a/packages/flutter/test/widgets/media_query_test.dart
+++ b/packages/flutter/test/widgets/media_query_test.dart
@@ -53,6 +53,7 @@ void main() {
     expect(copied.textScaleFactor, data.textScaleFactor);
     expect(copied.padding, data.padding);
     expect(copied.viewInsets, data.viewInsets);
+    expect(copied.alwaysUse24HourFormat, data.alwaysUse24HourFormat);
   });
 
   testWidgets('MediaQuery.copyWith copies specified values', (WidgetTester tester) async {
@@ -63,12 +64,70 @@ void main() {
       textScaleFactor: 1.62,
       padding: const EdgeInsets.all(9.10938),
       viewInsets: const EdgeInsets.all(1.67262),
+      alwaysUse24HourFormat: true,
     );
     expect(copied.size, const Size(3.14, 2.72));
     expect(copied.devicePixelRatio, 1.41);
     expect(copied.textScaleFactor, 1.62);
     expect(copied.padding, const EdgeInsets.all(9.10938));
     expect(copied.viewInsets, const EdgeInsets.all(1.67262));
+    expect(copied.alwaysUse24HourFormat, true);
+  });
+
+  testWidgets('MediaQuery.removePadding removes specified padding', (WidgetTester tester) async {
+    const Size size = const Size(2.0, 4.0);
+    const double devicePixelRatio = 2.0;
+    const double textScaleFactor = 1.2;
+    const EdgeInsets padding = const EdgeInsets.only(
+      top: 1.0,
+      right: 2.0,
+      left: 3.0,
+      bottom: 4.0,
+    );
+    const EdgeInsets viewInsets = const EdgeInsets.only(
+      top: 5.0,
+      right: 6.0,
+      left: 7.0,
+      bottom: 8.0,
+    );
+    const bool alwaysUse24HourFormat = true;
+
+    MediaQueryData unpadded;
+    await tester.pumpWidget(
+      new MediaQuery(
+        data: const MediaQueryData(
+          size: size,
+          devicePixelRatio: devicePixelRatio,
+          textScaleFactor: textScaleFactor,
+          padding: padding,
+          viewInsets: viewInsets,
+          alwaysUse24HourFormat: alwaysUse24HourFormat,
+        ),
+        child: new Builder(
+          builder: (BuildContext context) {
+            return new MediaQuery.removePadding(
+              context: context,
+              removeTop: true,
+              removeRight: true,
+              removeLeft: true,
+              removeBottom: true,
+              child: new Builder(
+                builder: (BuildContext context) {
+                  unpadded = MediaQuery.of(context);
+                  return new Container();
+                }
+              ),
+            );
+          }),
+      )
+    );
+
+    expect(unpadded.size, size);
+    expect(unpadded.devicePixelRatio, devicePixelRatio);
+    expect(unpadded.textScaleFactor, textScaleFactor);
+    expect(unpadded.padding, EdgeInsets.zero);
+    expect(unpadded.viewInsets, viewInsets);
+    expect(unpadded.alwaysUse24HourFormat, alwaysUse24HourFormat);
   });
 
   testWidgets('MediaQuery.removePadding removes specified padding', (WidgetTester tester) async {


### PR DESCRIPTION
1. Ensure that this value is defaulted to the value associated with the
   context rather than re-defaulted to false.
2. Add this value to operator==, hashCode, toString methods.