### PR TITLE
Workaround for TextPainter.computeDistanceToActualBaseline when the text is empty

### DIFF
--- a/packages/flutter/lib/src/painting/text_painter.dart
+++ b/packages/flutter/lib/src/painting/text_painter.dart
@@ -285,6 +285,11 @@ class TextPainter {
     return new Size(width, height);
   }
 
+  // Workaround for https://github.com/flutter/flutter/issues/13303
+  double _workaroundBaselineBug(double value) {
+    return value >= 0.0 ? value : preferredLineHeight;
+  }
+
   /// Returns the distance from the top of the text to the first baseline of the
   /// given type.
   ///
@@ -294,9 +299,9 @@ class TextPainter {
     assert(baseline != null);
     switch (baseline) {
       case TextBaseline.alphabetic:
-        return _paragraph.alphabeticBaseline;
+        return _workaroundBaselineBug(_paragraph.alphabeticBaseline);
       case TextBaseline.ideographic:
-        return _paragraph.ideographicBaseline;
+        return _workaroundBaselineBug(_paragraph.ideographicBaseline);
     }
     return null;
   }

--- a/packages/flutter/lib/src/painting/text_painter.dart
+++ b/packages/flutter/lib/src/painting/text_painter.dart
@@ -286,8 +286,26 @@ class TextPainter {
   }
 
   // Workaround for https://github.com/flutter/flutter/issues/13303
-  double _workaroundBaselineBug(double value) {
-    return value >= 0.0 ? value : preferredLineHeight;
+  double _workaroundBaselineBug(double value, TextBaseline baseline) {
+    if (value >= 0.0)
+      return value;
+
+    final ui.ParagraphBuilder builder = new ui.ParagraphBuilder(
+      _createParagraphStyle(TextDirection.ltr),
+    );
+    if (text?.style != null)
+      builder.pushStyle(text.style.getTextStyle(textScaleFactor: textScaleFactor));
+    builder.addText(_kZeroWidthSpace);
+    final ui.Paragraph paragraph = builder.build()
+      ..layout(new ui.ParagraphConstraints(width: double.INFINITY));
+
+    switch (baseline) {
+      case TextBaseline.alphabetic:
+        return paragraph.alphabeticBaseline;
+      case TextBaseline.ideographic:
+       return paragraph.ideographicBaseline;
+    }
+    return null;
   }
 
   /// Returns the distance from the top of the text to the first baseline of the
@@ -299,9 +317,9 @@ class TextPainter {
     assert(baseline != null);
     switch (baseline) {
       case TextBaseline.alphabetic:
-        return _workaroundBaselineBug(_paragraph.alphabeticBaseline);
+        return _workaroundBaselineBug(_paragraph.alphabeticBaseline, baseline);
       case TextBaseline.ideographic:
-        return _workaroundBaselineBug(_paragraph.ideographicBaseline);
+       return _workaroundBaselineBug(_paragraph.ideographicBaseline, baseline);
     }
     return null;
   }

--- a/packages/flutter/test/painting/text_painter_rtl_test.dart
+++ b/packages/flutter/test/painting/text_painter_rtl_test.dart
@@ -658,6 +658,21 @@ void main() {
       skip: skipExpectsWithKnownBugs,
     );
   }, skip: skipTestsWithKnownBugs);
+
+  test('TextPainter - empty text baseline', () {
+    final TextPainter painter = new TextPainter()
+      ..textDirection = TextDirection.ltr;
+    painter.text = const TextSpan(
+      text: '',
+      style: const TextStyle(fontFamily: 'Ahem', fontSize: 100.0, height: 1.0),
+    );
+    painter.layout();
+    expect(
+      // Returns -1
+      painter.computeDistanceToActualBaseline(TextBaseline.alphabetic), 80.0,
+      skip: skipExpectsWithKnownBugs,
+    );
+  }, skip: skipTestsWithKnownBugs);
 }
 
 


### PR DESCRIPTION
This is a workaround for TextPainter.computeDistanceToActualBaseline when the text is empty, #13303

This problem crops up when Flutter tries to baseline-align a TextField before the user has input anything.