### PR TITLE
modernize corners & borders in animation demo

### DIFF
--- a/examples/flutter_gallery/lib/demo/animation/home.dart
+++ b/examples/flutter_gallery/lib/demo/animation/home.dart
@@ -216,12 +216,8 @@ class _AllSectionsLayout extends MultiChildLayoutDelegate {
       final Rect cardRect = _interpolateRect(columnCardRect, rowCardRect).shift(offset);
       final String cardId = 'card$index';
       if (hasChild(cardId)) {
-        // Add a small horizontal gap between the cards.
-        final Rect insetRect = new Rect.fromLTWH(
-          cardRect.left + 0.5, cardRect.top, cardRect.width - 1.0, cardRect.height
-        );
-        layoutChild(cardId, new BoxConstraints.tight(insetRect.size));
-        positionChild(cardId, insetRect.topLeft);
+        layoutChild(cardId, new BoxConstraints.tight(cardRect.size));
+        positionChild(cardId, cardRect.topLeft);
       }
 
       // Layout the title for index.
@@ -549,7 +545,7 @@ class _AnimationDemoHomeState extends State<AnimationDemoHome> {
     final double screenHeight = mediaQueryData.size.height;
     final double appBarMaxHeight = screenHeight - statusBarHeight;
 
-    // The scrolloffset that reveals the appBarMidHeight appbar.
+    // The scroll offset that reveals the appBarMidHeight appbar.
     final double appBarMidScrollOffset = statusBarHeight + appBarMaxHeight - _kAppBarMidHeight;
 
     return new SizedBox.expand(

--- a/examples/flutter_gallery/lib/demo/animation/widgets.dart
+++ b/examples/flutter_gallery/lib/demo/animation/widgets.dart
@@ -19,27 +19,23 @@ class SectionCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return new Padding(
-      padding: const EdgeInsets.only(bottom: 1.0),
-      child: new DecoratedBox(
-        decoration: new BoxDecoration(
-          borderRadius: new BorderRadius.circular(4.0),
-          gradient: new LinearGradient(
-            begin: Alignment.centerLeft,
-            end: Alignment.centerRight,
-            colors: <Color>[
-              section.leftColor,
-              section.rightColor,
-            ],
-          ),
+    return new DecoratedBox(
+      decoration: new BoxDecoration(
+        gradient: new LinearGradient(
+          begin: Alignment.centerLeft,
+          end: Alignment.centerRight,
+          colors: <Color>[
+            section.leftColor,
+            section.rightColor,
+          ],
         ),
-        child: new Image.asset(
-          section.backgroundAsset,
-          package: section.backgroundAssetPackage,
-          color: const Color.fromRGBO(255, 255, 255, 0.075),
-          colorBlendMode: BlendMode.modulate,
-          fit: BoxFit.cover,
-        ),
+      ),
+      child: new Image.asset(
+        section.backgroundAsset,
+        package: section.backgroundAssetPackage,
+        color: const Color.fromRGBO(255, 255, 255, 0.075),
+        colorBlendMode: BlendMode.modulate,
+        fit: BoxFit.cover,
       ),
     );
   }


### PR DESCRIPTION
Remove rounded corners in the header section cards; they don't go well with the non-rounded main section. Remove layout padding that created dark borders around the header and between the cards; they caused a difference in width between the header and the content, and the extra borders are not necessary because of the different in background colors between the header and the content section.

Before:

![before](https://user-images.githubusercontent.com/211513/33617674-2f4df2ce-d995-11e7-8eb1-b99eec49cfca.jpg)

After:

![after](https://user-images.githubusercontent.com/211513/33617684-3428ac08-d995-11e7-89ce-5ade07d5461c.jpg)

Final:

![flutter_01](https://user-images.githubusercontent.com/211513/33617713-594066ca-d995-11e7-9412-11c04f1ae276.png)

![flutter_02](https://user-images.githubusercontent.com/211513/33617719-5cb829a0-d995-11e7-9dc8-e64a49c92ee3.png)

![flutter_03](https://user-images.githubusercontent.com/211513/33617727-5ff29808-d995-11e7-94ee-590c029f0bdf.png)
