### PR TITLE
Fix a problem with the flutter_tools/test/dart/pub_get_test.dart test.

### DIFF
--- a/packages/flutter_tools/test/dart/pub_get_test.dart
+++ b/packages/flutter_tools/test/dart/pub_get_test.dart
@@ -245,7 +245,7 @@ class MockDirectory implements Directory {
   final String path;
 
   @override
-  bool existsSync() => findCache && path.endsWith('flutter/.pub-cache');
+  bool existsSync() => findCache && path.endsWith('.pub-cache');
 
   @override
   dynamic noSuchMethod(Invocation invocation) => null;


### PR DESCRIPTION
It turns out that when a PR build clones the flutter repo, it puts it into a directory called "flutter", and when the "real" build clones the flutter repo, it puts it into a directory called "build".  This allowed the tests to succeed in my PR, but fail when I committed it.

This fixes the test so it doesn't depend on the cloned directory name.