### PR TITLE
flutter_tools: ensure the context value passed to pub is consistent

### DIFF
--- a/packages/flutter_tools/lib/src/commands/create.dart
+++ b/packages/flutter_tools/lib/src/commands/create.dart
@@ -162,7 +162,7 @@ class CreateCommand extends FlutterCommand {
       generatedCount += _renderTemplate('package', dirPath, templateContext);
 
       if (argResults['pub'])
-        await pubGet(context: 'create_pkg', directory: dirPath);
+        await pubGet(context: PubContext.createPackage, directory: dirPath);
 
       final String relativePath = fs.path.relative(dirPath);
       printStatus('Wrote $generatedCount files.');
@@ -180,7 +180,7 @@ class CreateCommand extends FlutterCommand {
       generatedCount += _renderTemplate('plugin', dirPath, templateContext);
 
       if (argResults['pub'])
-        await pubGet(context: 'create_plugin', directory: dirPath);
+        await pubGet(context: PubContext.createPlugin, directory: dirPath);
 
       if (android_sdk.androidSdk != null)
         gradle.updateLocalProperties(projectPath: dirPath);
@@ -218,7 +218,7 @@ class CreateCommand extends FlutterCommand {
     );
 
     if (argResults['pub']) {
-      await pubGet(context: 'create', directory: appPath);
+      await pubGet(context: PubContext.create, directory: appPath);
       injectPlugins(directory: appPath);
     }
 

--- a/packages/flutter_tools/lib/src/commands/packages.dart
+++ b/packages/flutter_tools/lib/src/commands/packages.dart
@@ -69,7 +69,7 @@ class PackagesGetCommand extends FlutterCommand {
       );
     }
 
-    await pubGet(context: PubContext.get,
+    await pubGet(context: PubContext.pubGet,
       directory: target,
       upgrade: upgrade,
       offline: argResults['offline'],

--- a/packages/flutter_tools/lib/src/commands/packages.dart
+++ b/packages/flutter_tools/lib/src/commands/packages.dart
@@ -69,7 +69,7 @@ class PackagesGetCommand extends FlutterCommand {
       );
     }
 
-    await pubGet(context: 'get',
+    await pubGet(context: PubContext.get,
       directory: target,
       upgrade: upgrade,
       offline: argResults['offline'],
@@ -102,7 +102,7 @@ class PackagesTestCommand extends FlutterCommand {
   }
 
   @override
-  Future<Null> runCommand() => pub(<String>['run', 'test']..addAll(argResults.rest), context: 'run_test', retry: false);
+  Future<Null> runCommand() => pub(<String>['run', 'test']..addAll(argResults.rest), context:  PubContext.runTest, retry: false);
 }
 
 class PackagesPassthroughCommand extends FlutterCommand {

--- a/packages/flutter_tools/lib/src/commands/update_packages.dart
+++ b/packages/flutter_tools/lib/src/commands/update_packages.dart
@@ -146,7 +146,7 @@ class UpdatePackagesCommand extends FlutterCommand {
         fakePackage.createSync();
         fakePackage.writeAsStringSync(_generateFakePubspec(dependencies.values));
         // First we run "pub upgrade" on this generated package:
-        await pubGet(context: 'update_packages', directory: temporaryDirectory.path, upgrade: true, checkLastModified: false);
+        await pubGet(context: PubContext.updatePackages, directory: temporaryDirectory.path, upgrade: true, checkLastModified: false);
         // Then we run "pub deps --style=compact" on the result. We pipe all the
         // output to tree.fill(), which parses it so that it can create a graph
         // of all the dependencies so that we can figure out the transitive
@@ -154,7 +154,7 @@ class UpdatePackagesCommand extends FlutterCommand {
         // each package.
         await pub(
           <String>['deps', '--style=compact'],
-          context: 'update_pkgs',
+          context: PubContext.updatePackages,
           directory: temporaryDirectory.path,
           filter: tree.fill,
           retry: false, // errors here are usually fatal since we're not hitting the network
@@ -211,7 +211,7 @@ class UpdatePackagesCommand extends FlutterCommand {
     int count = 0;
 
     for (Directory dir in packages) {
-      await pubGet(context: 'update_packages', directory: dir.path, checkLastModified: false);
+      await pubGet(context: PubContext.updatePackages, directory: dir.path, checkLastModified: false);
       count += 1;
     }
 

--- a/packages/flutter_tools/lib/src/commands/upgrade.dart
+++ b/packages/flutter_tools/lib/src/commands/upgrade.dart
@@ -68,7 +68,7 @@ class UpgradeCommand extends FlutterCommand {
     final String projRoot = findProjectRoot();
     if (projRoot != null) {
       printStatus('');
-      await pubGet(context: PubContext.upgrade, directory: projRoot, upgrade: true, checkLastModified: false);
+      await pubGet(context: PubContext.pubUpgrade, directory: projRoot, upgrade: true, checkLastModified: false);
     }
 
     // Run a doctor check in case system requirements have changed.

--- a/packages/flutter_tools/lib/src/commands/upgrade.dart
+++ b/packages/flutter_tools/lib/src/commands/upgrade.dart
@@ -68,7 +68,7 @@ class UpgradeCommand extends FlutterCommand {
     final String projRoot = findProjectRoot();
     if (projRoot != null) {
       printStatus('');
-      await pubGet(context: 'upgrade', directory: projRoot, upgrade: true, checkLastModified: false);
+      await pubGet(context: PubContext.upgrade, directory: projRoot, upgrade: true, checkLastModified: false);
     }
 
     // Run a doctor check in case system requirements have changed.

--- a/packages/flutter_tools/lib/src/dart/pub.dart
+++ b/packages/flutter_tools/lib/src/dart/pub.dart
@@ -24,28 +24,33 @@ import 'sdk.dart';
 class PubContext {
   static final RegExp _validContext = new RegExp('[a-z][a-z_]*[a-z]');
 
-  static final PubContext create = new PubContext._('create');
-  static final PubContext createPackage = new PubContext._('create_pkg');
-  static final PubContext createPlugin = new PubContext._('create_plugin');
-  static final PubContext get = new PubContext._('get');
-  static final PubContext interactive = new PubContext._('interactive');
-  static final PubContext runTest = new PubContext._('run_test');
-  static final PubContext upgrade = new PubContext._('upgrade');
-  static final PubContext verify = new PubContext._('verify');
+  static final PubContext create = new PubContext._(<String>['create']);
+  static final PubContext createPackage = new PubContext._(<String>['create_pkg']);
+  static final PubContext createPlugin = new PubContext._(<String>['create_plugin']);
+  static final PubContext get = new PubContext._(<String>['get']);
+  static final PubContext interactive = new PubContext._(<String>['interactive']);
+  static final PubContext runTest = new PubContext._(<String>['run_test']);
+  static final PubContext upgrade = new PubContext._(<String>['upgrade']);
 
-  static final PubContext flutterTests = new PubContext._('flutter_tests');
-  static final PubContext updatePackages = new PubContext._('update_packages');
+  static final PubContext flutterTests = new PubContext._(<String>['flutter_tests']);
+  static final PubContext updatePackages = new PubContext._(<String>['update_packages']);
 
-  final String _value;
+  final List<String> _values;
 
-  PubContext._(this._value) {
-    if (!_validContext.hasMatch(_value)) {
-      throw new ArgumentError.value(_value, 'pubContext', 'Must match RegExp ${_validContext.pattern}');
+  PubContext._(this._values) {
+    for (String item in _values) {
+      if (!_validContext.hasMatch(item)) {
+        throw new ArgumentError.value(
+            _values, 'value', 'Must match RegExp ${_validContext.pattern}');
+      }
     }
   }
 
+  static PubContext getVerifyContext(String commandName) =>
+      new PubContext._(<String>['verify', commandName.replaceAll('-', '_')]);
+
   @override
-  String toString() => 'PubContext: $_value';
+  String toString() => 'PubContext: ${_values.join(':')}';
 }
 
 bool _shouldRunPubGet({ File pubSpecYaml, File dotPackages }) {
@@ -222,8 +227,7 @@ String _getPubEnvironmentValue(PubContext pubContext) {
   }
 
   values.add('flutter_cli');
-
-  values.add('ctx_${pubContext._value}');
+  values.addAll(pubContext._values);
 
   return values.join(':');
 }

--- a/packages/flutter_tools/lib/src/dart/pub.dart
+++ b/packages/flutter_tools/lib/src/dart/pub.dart
@@ -27,10 +27,10 @@ class PubContext {
   static final PubContext create = new PubContext._(<String>['create']);
   static final PubContext createPackage = new PubContext._(<String>['create_pkg']);
   static final PubContext createPlugin = new PubContext._(<String>['create_plugin']);
-  static final PubContext get = new PubContext._(<String>['get']);
   static final PubContext interactive = new PubContext._(<String>['interactive']);
+  static final PubContext pubGet = new PubContext._(<String>['get']);
+  static final PubContext pubUpgrade = new PubContext._(<String>['upgrade']);
   static final PubContext runTest = new PubContext._(<String>['run_test']);
-  static final PubContext upgrade = new PubContext._(<String>['upgrade']);
 
   static final PubContext flutterTests = new PubContext._(<String>['flutter_tests']);
   static final PubContext updatePackages = new PubContext._(<String>['update_packages']);

--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -242,7 +242,7 @@ abstract class FlutterCommand extends Command<Null> {
       await cache.updateAll();
 
     if (shouldRunPub)
-      await pubGet(context: PubContext.verify);
+      await pubGet(context: PubContext.getVerifyContext(name));
 
     setupApplicationPackages();
 

--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -242,7 +242,7 @@ abstract class FlutterCommand extends Command<Null> {
       await cache.updateAll();
 
     if (shouldRunPub)
-      await pubGet(context: 'verify');
+      await pubGet(context: PubContext.verify);
 
     setupApplicationPackages();
 

--- a/packages/flutter_tools/test/commands/analyze_continuously_test.dart
+++ b/packages/flutter_tools/test/commands/analyze_continuously_test.dart
@@ -32,7 +32,7 @@ void main() {
     testUsingContext('AnalysisServer success', () async {
       _createSampleProject(tempDir);
 
-      await pubGet(context: 'flutter_tests', directory: tempDir.path);
+      await pubGet(context: PubContext.flutterTests, directory: tempDir.path);
 
       server = new AnalysisServer(dartSdkPath, <String>[tempDir.path]);
 
@@ -52,7 +52,7 @@ void main() {
   testUsingContext('AnalysisServer errors', () async {
     _createSampleProject(tempDir, brokenCode: true);
 
-    await pubGet(context: 'flutter_tests', directory: tempDir.path);
+    await pubGet(context: PubContext.flutterTests, directory: tempDir.path);
 
     server = new AnalysisServer(dartSdkPath, <String>[tempDir.path]);
 

--- a/packages/flutter_tools/test/dart/pub_get_test.dart
+++ b/packages/flutter_tools/test/dart/pub_get_test.dart
@@ -37,7 +37,7 @@ void main() {
         'Running "flutter packages get" in /...\n'
         'pub get failed (69) -- attempting retry 1 in 1 second...\n'
       );
-      expect(processMock.lastPubEnvironmment, contains('flutter_cli:ctx_flutter_tests'));
+      expect(processMock.lastPubEnvironmment, contains('flutter_cli:flutter_tests'));
       expect(processMock.lastPubCache, isNull);
       time.elapse(const Duration(milliseconds: 500));
       expect(testLogger.statusText,

--- a/packages/flutter_tools/test/dart/pub_get_test.dart
+++ b/packages/flutter_tools/test/dart/pub_get_test.dart
@@ -26,7 +26,7 @@ void main() {
 
     new FakeAsync().run((FakeAsync time) {
       expect(processMock.lastPubEnvironmment, isNull);
-      pubGet(context: 'flutter_tests', checkLastModified: false).then((Null value) {
+      pubGet(context: PubContext.flutterTests, checkLastModified: false).then((Null value) {
         error = 'test completed unexpectedly';
       }, onError: (dynamic thrownError) {
         error = 'test failed unexpectedly: $thrownError';
@@ -96,7 +96,7 @@ void main() {
       MockDirectory.findCache = true;
       expect(processMock.lastPubEnvironmment, isNull);
       expect(processMock.lastPubCache, isNull);
-      pubGet(context: 'flutter_tests', checkLastModified: false).then((Null value) {
+      pubGet(context: PubContext.flutterTests, checkLastModified: false).then((Null value) {
         error = 'test completed unexpectedly';
       }, onError: (dynamic thrownError) {
         error = 'test failed unexpectedly: $thrownError';
@@ -122,7 +122,7 @@ void main() {
       MockDirectory.findCache = false;
       expect(processMock.lastPubEnvironmment, isNull);
       expect(processMock.lastPubCache, isNull);
-      pubGet(context: 'flutter_tests', checkLastModified: false).then((Null value) {
+      pubGet(context: PubContext.flutterTests, checkLastModified: false).then((Null value) {
         error = 'test completed unexpectedly';
       }, onError: (dynamic thrownError) {
         error = 'test failed unexpectedly: $thrownError';


### PR DESCRIPTION
Adds a class `PubContext` with a fixed set of allowed values
Make it clear these values should not be changed casually

Fixed one inconsistency already: update_packages vs update_pkgs