### PR TITLE
Make artifacts URLs configurable.

### DIFF
--- a/bin/internal/gradle_wrapper.version
+++ b/bin/internal/gradle_wrapper.version
@@ -1,1 +1,1 @@
-https://storage.googleapis.com/flutter_infra/gradle-wrapper/fd5c1f2c013565a3bea56ada6df9d2b8e96d56aa/gradle-wrapper.tgz
+${FLUTTER_STORAGE_BASE_URL}/flutter_infra/gradle-wrapper/fd5c1f2c013565a3bea56ada6df9d2b8e96d56aa/gradle-wrapper.tgz

--- a/bin/internal/gradle_wrapper.version
+++ b/bin/internal/gradle_wrapper.version
@@ -1,1 +1,1 @@
-${FLUTTER_STORAGE_BASE_URL}/flutter_infra/gradle-wrapper/fd5c1f2c013565a3bea56ada6df9d2b8e96d56aa/gradle-wrapper.tgz
+flutter_infra/gradle-wrapper/fd5c1f2c013565a3bea56ada6df9d2b8e96d56aa/gradle-wrapper.tgz

--- a/bin/internal/material_fonts.version
+++ b/bin/internal/material_fonts.version
@@ -1,1 +1,1 @@
-https://storage.googleapis.com/flutter_infra/flutter/fonts/13ac995daa9dda0a6ba0a45f1fccc541e616a74c/fonts.zip
+${FLUTTER_STORAGE_BASE_URL}/flutter_infra/flutter/fonts/13ac995daa9dda0a6ba0a45f1fccc541e616a74c/fonts.zip

--- a/bin/internal/material_fonts.version
+++ b/bin/internal/material_fonts.version
@@ -1,1 +1,1 @@
-${FLUTTER_STORAGE_BASE_URL}/flutter_infra/flutter/fonts/13ac995daa9dda0a6ba0a45f1fccc541e616a74c/fonts.zip
+flutter_infra/flutter/fonts/13ac995daa9dda0a6ba0a45f1fccc541e616a74c/fonts.zip

--- a/bin/internal/update_dart_sdk.ps1
+++ b/bin/internal/update_dart_sdk.ps1
@@ -28,9 +28,13 @@ if ((Test-Path $dartSdkStampPath) -and ($dartSdkVersion -eq (Get-Content $dartSd
 }
 
 Write-Host "Downloading Dart SDK $dartSdkVersion..."
+$dartSdkBaseUrl = $Env:FLUTTER_STORAGE_BASE_URL
+if (-not $dartSdkBaseUrl) {
+    $dartSdkBaseUrl = "https://storage.googleapis.com"
+}
 $dartZipName = "dartsdk-windows-x64-release.zip"
 $dartChannel = if ($dartSdkVersion.Contains("-dev.")) {"dev"} else {if ($dartSdkVersion.Contains("hash/")) {"be"} else {"stable"}}
-$dartSdkUrl = "https://storage.googleapis.com/dart-archive/channels/$dartChannel/raw/$dartSdkVersion/sdk/$dartZipName"
+$dartSdkUrl = "$dartSdkBaseUrl/dart-archive/channels/$dartChannel/raw/$dartSdkVersion/sdk/$dartZipName"
 
 if (Test-Path $dartSdkPath) {
     # Move old SDK to a new location instead of deleting it in case it is still in use (e.g. by IntelliJ).

--- a/bin/internal/update_dart_sdk.sh
+++ b/bin/internal/update_dart_sdk.sh
@@ -47,7 +47,8 @@ if [ ! -f "$DART_SDK_STAMP_PATH" ] || [ "$DART_SDK_VERSION" != `cat "$DART_SDK_S
     DART_CHANNEL="be"
   fi
 
-  DART_SDK_URL="https://storage.googleapis.com/dart-archive/channels/$DART_CHANNEL/raw/$DART_SDK_VERSION/sdk/$DART_ZIP_NAME"
+  DART_SDK_BASE_URL="${FLUTTER_STORAGE_BASE_URL:-https://storage.googleapis.com}"
+  DART_SDK_URL="$DART_SDK_BASE_URL/dart-archive/channels/$DART_CHANNEL/raw/$DART_SDK_VERSION/sdk/$DART_ZIP_NAME"
 
   # if the sdk path exists, copy it to a temporary location
   if [ -d "$DART_SDK_PATH" ]; then

--- a/dev/tools/repackage_gradle_wrapper.sh
+++ b/dev/tools/repackage_gradle_wrapper.sh
@@ -70,7 +70,7 @@ echo "Uploading repackaged gradle wrapper..."
 echo "Content hash: $STAMP"
 gsutil.py cp -n "$WRAPPER_TEMP_DIR/gradle-wrapper.tgz" "gs://flutter_infra/gradle-wrapper/$STAMP/gradle-wrapper.tgz"
 
-echo "https://storage.googleapis.com/flutter_infra/gradle-wrapper/$STAMP/gradle-wrapper.tgz" > "$WRAPPER_VERSION_PATH"
+echo "flutter_infra/gradle-wrapper/$STAMP/gradle-wrapper.tgz" > "$WRAPPER_VERSION_PATH"
 
 rm -rf "$WRAPPER_TEMP_DIR"
 echo

--- a/packages/flutter_tools/lib/src/cache.dart
+++ b/packages/flutter_tools/lib/src/cache.dart
@@ -270,8 +270,10 @@ bool _hasWarnedAboutStorageOverride = false;
 void _maybeWarnAboutStorageOverride(String overrideUrl) {
   if (_hasWarnedAboutStorageOverride)
     return;
-  logger.printStatus('Flutter assets will be downloaded from $overrideUrl. '
-      'Make sure you trust this source!', emphasis: true);
+  logger.printStatus(
+    'Flutter assets will be downloaded from $overrideUrl. Make sure you trust this source!',
+    emphasis: true,
+  );
   _hasWarnedAboutStorageOverride = true;
 }
 

--- a/packages/flutter_tools/lib/src/commands/update_packages.dart
+++ b/packages/flutter_tools/lib/src/commands/update_packages.dart
@@ -11,6 +11,7 @@ import 'package:meta/meta.dart';
 import '../base/file_system.dart';
 import '../base/logger.dart';
 import '../base/net.dart';
+import '../base/platform.dart';
 import '../cache.dart';
 import '../dart/pub.dart';
 import '../globals.dart';
@@ -72,7 +73,8 @@ class UpdatePackagesCommand extends FlutterCommand {
 
   Future<Null> _downloadCoverageData() async {
     final Status status = logger.startProgress('Downloading lcov data for package:flutter...', expectSlowOperation: true);
-    final List<int> data = await fetchUrl(Uri.parse('https://storage.googleapis.com/flutter_infra/flutter/coverage/lcov.info'));
+    final String urlBase = platform.environment['FLUTTER_STORAGE_BASE_URL'] ?? 'https://storage.googleapis.com';
+    final List<int> data = await fetchUrl(Uri.parse('$urlBase/flutter_infra/flutter/coverage/lcov.info'));
     final String coverageDir = fs.path.join(Cache.flutterRoot, 'packages/flutter/coverage');
     fs.file(fs.path.join(coverageDir, 'lcov.base.info'))
       ..createSync(recursive: true)


### PR DESCRIPTION
Add support for configuring the base storage URL for Flutter's
artifacts. If FLUTTER_STORAGE_BASE_URL is set, use it instead of
storage.googleapis.com.

Also pass PUB_HOSTED_URL from the parent environment when Flutter Tools
runs pub, so it can be overridden if necessary.

Addresses #11681.