### PR TITLE
[flutter_tools][plugins] generated registerWith guards against re-regitration

### DIFF
--- a/packages/flutter_tools/lib/src/plugins.dart
+++ b/packages/flutter_tools/lib/src/plugins.dart
@@ -102,9 +102,21 @@ import {{package}}.{{class}};
  */
 public final class GeneratedPluginRegistrant {
   public static void registerWith(PluginRegistry registry) {
+    if (alreadyRegisteredWith(registry)) {
+      return;
+    }
 {{#plugins}}
     {{class}}.registerWith(registry.registrarFor("{{package}}.{{class}}"));
 {{/plugins}}
+  }
+
+  private static boolean alreadyRegisteredWith(PluginRegistry registry) {
+    final String key = GeneratedPluginRegistrant.class.getCanonicalName();
+    if (registry.hasPlugin(key)) {
+      return true;
+    }
+    registry.registrarFor(key);
+    return false;
   }
 }
 ''';


### PR DESCRIPTION
This is for handling the case where the PluginRegistry was kept alive by a background service, and is now being used again for a new foreground activity.