### PR TITLE
Increase connection timeout

### DIFF
--- a/dev/devicelab/lib/framework/runner.dart
+++ b/dev/devicelab/lib/framework/runner.dart
@@ -105,7 +105,7 @@ Future<VMIsolateRef> _connectToRunnerIsolate(int vmServicePort) async {
         throw 'not ready yet';
       return isolate;
     } catch (error) {
-      const Duration connectionTimeout = const Duration(seconds: 2);
+      const Duration connectionTimeout = const Duration(seconds: 4);
       if (new DateTime.now().difference(started) > connectionTimeout) {
         throw new TimeoutException(
           'Failed to connect to the task runner process',


### PR DESCRIPTION
This should fix the flutter_view_ios__start_up_test  flakiness.