### PR TITLE
Use greater of viewInsets, padding for Scaffold bottom padding

### DIFF
--- a/packages/flutter/lib/src/material/scaffold.dart
+++ b/packages/flutter/lib/src/material/scaffold.dart
@@ -834,6 +834,7 @@ class ScaffoldState extends State<Scaffold> with TickerProviderStateMixin {
     assert(debugCheckHasMediaQuery(context));
     assert(debugCheckHasDirectionality(context));
     final EdgeInsets padding = MediaQuery.of(context).padding;
+    final EdgeInsets viewInsets = MediaQuery.of(context).viewInsets;
     final ThemeData themeData = Theme.of(context);
     final TextDirection textDirection = Directionality.of(context);
 
@@ -1038,7 +1039,7 @@ class ScaffoldState extends State<Scaffold> with TickerProviderStateMixin {
             children: children,
             delegate: new _ScaffoldLayout(
               statusBarHeight: padding.top,
-              bottomPadding: widget.resizeToAvoidBottomPadding ? padding.bottom : 0.0,
+              bottomPadding: widget.resizeToAvoidBottomPadding ? math.max(padding.bottom, viewInsets.bottom) : 0.0,
               endPadding: endPadding,
               textDirection: textDirection,
             ),

--- a/packages/flutter/test/material/scaffold_test.dart
+++ b/packages/flutter/test/material/scaffold_test.dart
@@ -59,6 +59,41 @@ void main() {
     expect(bodyBox.size, equals(const Size(800.0, 544.0)));
   });
 
+  testWidgets('Scaffold bottom padding is the greater of window padding or view inset', (WidgetTester tester) async {
+    final Key bodyKey = new UniqueKey();
+    await tester.pumpWidget(new Directionality(
+      textDirection: TextDirection.ltr,
+      child: new MediaQuery(
+        data: const MediaQueryData(
+          padding: const EdgeInsets.only(bottom: 50.0),
+          viewInsets: const EdgeInsets.only(bottom: 100.0),
+        ),
+        child: new Scaffold(
+          body: new Container(key: bodyKey),
+        ),
+      ),
+    ));
+
+    final RenderBox bodyBox = tester.renderObject(find.byKey(bodyKey));
+    expect(bodyBox.size, equals(const Size(800.0, 500.0)));
+
+    await tester.pumpWidget(new Directionality(
+      textDirection: TextDirection.ltr,
+      child: new MediaQuery(
+        data: const MediaQueryData(
+          padding: const EdgeInsets.only(bottom: 200.0),
+          viewInsets: const EdgeInsets.only(bottom: 100.0),
+        ),
+        child: new Scaffold(
+          body: new Container(key: bodyKey),
+        ),
+      ),
+    ));
+
+    expect(bodyBox.size, equals(const Size(800.0, 400.0)));
+  });
+
+
   testWidgets('Scaffold large bottom padding test', (WidgetTester tester) async {
     final Key bodyKey = new UniqueKey();
     await tester.pumpWidget(new Directionality(


### PR DESCRIPTION
Scaffold bottom padding now applies the maximum of window
viewInsets.bottom (typically used for iOS safe areas) and padding.bottom
(typically used for keyboard height).