### PR TITLE
Apply media bottom padding in BottomNavigationBar

### DIFF
--- a/packages/flutter/lib/src/material/bottom_navigation_bar.dart
+++ b/packages/flutter/lib/src/material/bottom_navigation_bar.dart
@@ -436,6 +436,9 @@ class _BottomNavigationBarState extends State<BottomNavigationBar> with TickerPr
   @override
   Widget build(BuildContext context) {
     assert(debugCheckHasDirectionality(context));
+
+    // Labels apply up to _bottomMargin padding. Remainder is media padding.
+    final double additionalBottomPadding = math.max(MediaQuery.of(context).padding.bottom - _kBottomMargin, 0.0);
     Color backgroundColor;
     switch (widget.type) {
       case BottomNavigationBarType.fixed:
@@ -453,7 +456,7 @@ class _BottomNavigationBarState extends State<BottomNavigationBar> with TickerPr
           ),
         ),
         new ConstrainedBox(
-          constraints: const BoxConstraints(minHeight: kBottomNavigationBarHeight),
+          constraints: new BoxConstraints(minHeight: kBottomNavigationBarHeight + additionalBottomPadding),
           child: new Stack(
             children: <Widget>[
               new Positioned.fill(
@@ -466,7 +469,14 @@ class _BottomNavigationBarState extends State<BottomNavigationBar> with TickerPr
               ),
               new Material( // Splashes.
                 type: MaterialType.transparency,
-                child: _createContainer(_createTiles()),
+                child: new Padding(
+                  padding: new EdgeInsets.only(bottom: additionalBottomPadding),
+                  child: new MediaQuery.removePadding(
+                    context: context,
+                    removeBottom: true,
+                    child: _createContainer(_createTiles()),
+                  ),
+                ),
               ),
             ],
           ),

--- a/packages/flutter/test/material/bottom_navigation_bar_test.dart
+++ b/packages/flutter/test/material/bottom_navigation_bar_test.dart
@@ -65,6 +65,35 @@ void main() {
     expect(find.text('Alarm'), findsOneWidget);
   });
 
+  testWidgets('BottomNavigationBar adds bottom padding to height', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      new MaterialApp(
+        home: new MediaQuery(
+          data: const MediaQueryData(padding: const EdgeInsets.only(bottom: 40.0)),
+          child: new Scaffold(
+            bottomNavigationBar: new BottomNavigationBar(
+              items: <BottomNavigationBarItem>[
+                const BottomNavigationBarItem(
+                  icon: const Icon(Icons.ac_unit),
+                  title: const Text('AC')
+                ),
+                const BottomNavigationBarItem(
+                  icon: const Icon(Icons.access_alarm),
+                  title: const Text('Alarm')
+                )
+              ]
+            )
+          )
+        )
+      )
+    );
+
+    const double labelBottomMargin = 8.0; // _kBottomMargin in implementation.
+    const double additionalPadding = 40.0 - labelBottomMargin;
+    const double expectedHeight = kBottomNavigationBarHeight + additionalPadding;
+    expect(tester.getSize(find.byType(BottomNavigationBar)).height, expectedHeight);
+  });
+
   testWidgets('BottomNavigationBar action size test', (WidgetTester tester) async {
     await tester.pumpWidget(
       new MaterialApp(


### PR DESCRIPTION
Updates scaffold to expose bottom padding to the associated
BottonNavigationBar (if present). BottomNavigationBar is now responsible
for adjusting itself to account for bottom padding.

This change is necessary to support the updated BottomNavigationBar
layout for the iPhone X.

Fixes flutter/flutter#12099 once the associated engine roll lands.