### PR TITLE
Remove dangling MediaQuery paddings for non-fullscreen dialogs

### DIFF
--- a/packages/flutter/lib/src/widgets/pages.dart
+++ b/packages/flutter/lib/src/widgets/pages.dart
@@ -28,7 +28,10 @@ abstract class PageRoute<T> extends ModalRoute<T> {
   bool get opaque => true;
 
   @override
-  bool get barrierDismissible => false;
+  bool get fullscreen => true;
+
+  @override
+  bool get barrierDismissible => true;
 
   @override
   bool canTransitionTo(TransitionRoute<dynamic> nextRoute) => nextRoute is PageRoute;


### PR DESCRIPTION
Fixes #13408

A bit over-generalized but it was a bit strange too that the concept of fullscreen routes weren't explicit. 

Added a fullscreen flag and automatically remove paddings for non-fullscreen routes' inner contents. 