### PR TITLE
Scaffold resizeToAvoidBottomPadding uses view insets

### DIFF
--- a/packages/flutter/lib/src/material/scaffold.dart
+++ b/packages/flutter/lib/src/material/scaffold.dart
@@ -810,7 +810,7 @@ class ScaffoldState extends State<Scaffold> with TickerProviderStateMixin {
     @required bool removeLeftPadding,
     @required bool removeTopPadding,
     @required bool removeRightPadding,
-    bool removeBottomPadding, // defaults to widget.resizeToAvoidBottomPadding
+    @required bool removeBottomPadding,
   }) {
     if (child != null) {
       children.add(
@@ -821,7 +821,7 @@ class ScaffoldState extends State<Scaffold> with TickerProviderStateMixin {
             removeLeft: removeLeftPadding,
             removeTop: removeTopPadding,
             removeRight: removeRightPadding,
-            removeBottom: removeBottomPadding ?? widget.resizeToAvoidBottomPadding,
+            removeBottom: removeBottomPadding,
             child: child,
           ),
         ),
@@ -861,6 +861,7 @@ class ScaffoldState extends State<Scaffold> with TickerProviderStateMixin {
       removeLeftPadding: false,
       removeTopPadding: widget.appBar != null,
       removeRightPadding: false,
+      removeBottomPadding: widget.bottomNavigationBar != null,
     );
 
     if (widget.appBar != null) {
@@ -892,6 +893,7 @@ class ScaffoldState extends State<Scaffold> with TickerProviderStateMixin {
         removeLeftPadding: false,
         removeTopPadding: true,
         removeRightPadding: false,
+        removeBottomPadding: widget.resizeToAvoidBottomPadding,
       );
     }
 
@@ -918,6 +920,7 @@ class ScaffoldState extends State<Scaffold> with TickerProviderStateMixin {
         removeLeftPadding: false,
         removeTopPadding: true,
         removeRightPadding: false,
+        removeBottomPadding: widget.resizeToAvoidBottomPadding,
       );
     }
 
@@ -929,6 +932,7 @@ class ScaffoldState extends State<Scaffold> with TickerProviderStateMixin {
         removeLeftPadding: false,
         removeTopPadding: true,
         removeRightPadding: false,
+        removeBottomPadding: false,
       );
     }
 
@@ -949,6 +953,7 @@ class ScaffoldState extends State<Scaffold> with TickerProviderStateMixin {
         removeLeftPadding: false,
         removeTopPadding: true,
         removeRightPadding: false,
+        removeBottomPadding: widget.resizeToAvoidBottomPadding,
       );
     }
 
@@ -1038,10 +1043,7 @@ class ScaffoldState extends State<Scaffold> with TickerProviderStateMixin {
             children: children,
             delegate: new _ScaffoldLayout(
               statusBarHeight: mediaQuery.padding.top,
-              // TODO(cbracken): this should use viewInsets.bottom only.
-              bottomPadding: widget.resizeToAvoidBottomPadding
-                ? math.max(mediaQuery.padding.bottom, mediaQuery.viewInsets.bottom)
-                : 0.0,
+              bottomPadding: widget.resizeToAvoidBottomPadding ? mediaQuery.viewInsets.bottom : 0.0,
               endPadding: endPadding,
               textDirection: textDirection,
             ),

--- a/packages/flutter/lib/src/material/scaffold.dart
+++ b/packages/flutter/lib/src/material/scaffold.dart
@@ -39,13 +39,13 @@ enum _ScaffoldSlot {
 class _ScaffoldLayout extends MultiChildLayoutDelegate {
   _ScaffoldLayout({
     @required this.statusBarHeight,
-    @required this.bottomPadding,
+    @required this.bottomViewInset,
     @required this.endPadding, // for floating action button
     @required this.textDirection,
   });
 
   final double statusBarHeight;
-  final double bottomPadding;
+  final double bottomViewInset;
   final double endPadding;
   final TextDirection textDirection;
 
@@ -59,7 +59,7 @@ class _ScaffoldLayout extends MultiChildLayoutDelegate {
     // so the app bar's shadow is drawn on top of the body.
 
     final BoxConstraints fullWidthConstraints = looseConstraints.tighten(width: size.width);
-    final double bottom = math.max(0.0, size.height - bottomPadding);
+    final double bottom = math.max(0.0, size.height - bottomViewInset);
     double contentTop = 0.0;
     double contentBottom = bottom;
 
@@ -161,7 +161,7 @@ class _ScaffoldLayout extends MultiChildLayoutDelegate {
   @override
   bool shouldRelayout(_ScaffoldLayout oldDelegate) {
     return oldDelegate.statusBarHeight != statusBarHeight
-        || oldDelegate.bottomPadding != bottomPadding
+        || oldDelegate.bottomViewInset != bottomViewInset
         || oldDelegate.endPadding != endPadding
         || oldDelegate.textDirection != textDirection;
   }
@@ -1043,7 +1043,7 @@ class ScaffoldState extends State<Scaffold> with TickerProviderStateMixin {
             children: children,
             delegate: new _ScaffoldLayout(
               statusBarHeight: mediaQuery.padding.top,
-              bottomPadding: widget.resizeToAvoidBottomPadding ? mediaQuery.viewInsets.bottom : 0.0,
+              bottomViewInset: widget.resizeToAvoidBottomPadding ? mediaQuery.viewInsets.bottom : 0.0,
               endPadding: endPadding,
               textDirection: textDirection,
             ),

--- a/packages/flutter/test/material/scaffold_test.dart
+++ b/packages/flutter/test/material/scaffold_test.dart
@@ -32,7 +32,7 @@ void main() {
     await tester.pumpWidget(new Directionality(
       textDirection: TextDirection.ltr,
       child: new MediaQuery(
-        data: const MediaQueryData(padding: const EdgeInsets.only(bottom: 100.0)),
+        data: const MediaQueryData(viewInsets: const EdgeInsets.only(bottom: 100.0)),
         child: new Scaffold(
           appBar: new AppBar(title: const Text('Title')),
           body: new Container(key: bodyKey),
@@ -46,7 +46,7 @@ void main() {
     await tester.pumpWidget(new Directionality(
       textDirection: TextDirection.ltr,
       child: new MediaQuery(
-        data: const MediaQueryData(padding: const EdgeInsets.only(bottom: 100.0)),
+        data: const MediaQueryData(viewInsets: const EdgeInsets.only(bottom: 100.0)),
         child: new Scaffold(
           appBar: new AppBar(title: const Text('Title')),
           body: new Container(key: bodyKey),
@@ -59,48 +59,13 @@ void main() {
     expect(bodyBox.size, equals(const Size(800.0, 544.0)));
   });
 
-  testWidgets('Scaffold bottom padding is the greater of window padding or view inset', (WidgetTester tester) async {
-    final Key bodyKey = new UniqueKey();
-    await tester.pumpWidget(new Directionality(
-      textDirection: TextDirection.ltr,
-      child: new MediaQuery(
-        data: const MediaQueryData(
-          padding: const EdgeInsets.only(bottom: 50.0),
-          viewInsets: const EdgeInsets.only(bottom: 100.0),
-        ),
-        child: new Scaffold(
-          body: new Container(key: bodyKey),
-        ),
-      ),
-    ));
-
-    final RenderBox bodyBox = tester.renderObject(find.byKey(bodyKey));
-    expect(bodyBox.size, equals(const Size(800.0, 500.0)));
-
-    await tester.pumpWidget(new Directionality(
-      textDirection: TextDirection.ltr,
-      child: new MediaQuery(
-        data: const MediaQueryData(
-          padding: const EdgeInsets.only(bottom: 200.0),
-          viewInsets: const EdgeInsets.only(bottom: 100.0),
-        ),
-        child: new Scaffold(
-          body: new Container(key: bodyKey),
-        ),
-      ),
-    ));
-
-    expect(bodyBox.size, equals(const Size(800.0, 400.0)));
-  });
-
-
   testWidgets('Scaffold large bottom padding test', (WidgetTester tester) async {
     final Key bodyKey = new UniqueKey();
     await tester.pumpWidget(new Directionality(
       textDirection: TextDirection.ltr,
       child: new MediaQuery(
         data: const MediaQueryData(
-          padding: const EdgeInsets.only(bottom: 700.0),
+          viewInsets: const EdgeInsets.only(bottom: 700.0),
         ),
         child: new Scaffold(
           body: new Container(key: bodyKey),
@@ -115,7 +80,7 @@ void main() {
       textDirection: TextDirection.ltr,
       child: new MediaQuery(
         data: const MediaQueryData(
-          padding: const EdgeInsets.only(bottom: 500.0),
+          viewInsets: const EdgeInsets.only(bottom: 500.0),
         ),
         child: new Scaffold(
           body: new Container(key: bodyKey),
@@ -129,7 +94,7 @@ void main() {
       textDirection: TextDirection.ltr,
       child: new MediaQuery(
         data: const MediaQueryData(
-          padding: const EdgeInsets.only(bottom: 580.0),
+          viewInsets: const EdgeInsets.only(bottom: 580.0),
         ),
         child: new Scaffold(
           appBar: new AppBar(
@@ -185,7 +150,7 @@ void main() {
         textDirection: textDirection,
         child: const MediaQuery(
           data: const MediaQueryData(
-            padding: const EdgeInsets.only(bottom: 200.0),
+            viewInsets: const EdgeInsets.only(bottom: 200.0),
           ),
           child: const Scaffold(
             floatingActionButton: const FloatingActionButton(
@@ -585,8 +550,9 @@ void main() {
               left: 20.0,
               top: 30.0,
               right: 50.0,
-              bottom: 70.0,
+              bottom: 60.0,
             ),
+            viewInsets: const EdgeInsets.only(bottom: 70.0),
           ),
           child: new Scaffold(
             appBar: new PreferredSize(
@@ -655,8 +621,8 @@ void main() {
     expect(tester.getRect(find.byKey(insideBody)), new Rect.fromLTRB(20.0, 43.0, 750.0, 338.0));
     expect(tester.getRect(find.byKey(insideFloatingActionButton)), new Rect.fromLTRB(36.0, 245.0, 113.0, 322.0));
     expect(tester.getRect(find.byKey(insidePersistentFooterButton)), new Rect.fromLTRB(28.0, 347.0, 128.0, 437.0));
-    expect(tester.getRect(find.byKey(insideDrawer)), new Rect.fromLTRB(596.0, 30.0, 750.0, 530.0));
-    expect(tester.getRect(find.byKey(insideBottomNavigationBar)), new Rect.fromLTRB(20.0, 445.0, 750.0, 530.0));
+    expect(tester.getRect(find.byKey(insideDrawer)), new Rect.fromLTRB(596.0, 30.0, 750.0, 540.0));
+    expect(tester.getRect(find.byKey(insideBottomNavigationBar)), new Rect.fromLTRB(20.0, 445.0, 750.0, 470.0));
   });
 
   testWidgets('Simultaneous drawers on either side', (WidgetTester tester) async {


### PR DESCRIPTION
Now that keyboard height is modeled as a (bottom) view inset, migrate
scaffold bottom resizing to use view insets instead of bottom padding,
which, after an engine roll, will only be used for safe areas.

Until the aforementioned engine roll, the keyboard height is still
included in both bottom padding and view insets. As such
resizeToAvoidBottomPadding still drives bottom padding removal until
that roll lands.