### PR TITLE
Remove dangling MediaQuery paddings for non-fullscreen dialogs - 2

### DIFF
--- a/packages/flutter/lib/src/material/bottom_sheet.dart
+++ b/packages/flutter/lib/src/material/bottom_sheet.dart
@@ -234,10 +234,18 @@ class _ModalBottomSheetRoute<T> extends PopupRoute<T> {
 
   @override
   Widget buildPage(BuildContext context, Animation<double> animation, Animation<double> secondaryAnimation) {
-    Widget bottomSheet = new _ModalBottomSheet<T>(route: this);
-    if (theme != null)
-      bottomSheet = new Theme(data: theme, child: bottomSheet);
-    return bottomSheet;
+    return new MediaQuery.removePadding(
+      context: context,
+      removeTop: true,
+      child: new Builder(
+        builder: (BuildContext context) {
+          Widget bottomSheet = new _ModalBottomSheet<T>(route: this);
+          if (theme != null)
+            bottomSheet = new Theme(data: theme, child: bottomSheet);
+          return bottomSheet;
+        },
+      ),
+    );
   }
 }
 

--- a/packages/flutter/lib/src/material/bottom_sheet.dart
+++ b/packages/flutter/lib/src/material/bottom_sheet.dart
@@ -234,18 +234,10 @@ class _ModalBottomSheetRoute<T> extends PopupRoute<T> {
 
   @override
   Widget buildPage(BuildContext context, Animation<double> animation, Animation<double> secondaryAnimation) {
-    return new MediaQuery.removePadding(
-      context: context,
-      removeTop: true,
-      child: new Builder(
-        builder: (BuildContext context) {
-          Widget bottomSheet = new _ModalBottomSheet<T>(route: this);
-          if (theme != null)
-            bottomSheet = new Theme(data: theme, child: bottomSheet);
-          return bottomSheet;
-        },
-      ),
-    );
+    Widget bottomSheet = new _ModalBottomSheet<T>(route: this);
+    if (theme != null)
+      bottomSheet = new Theme(data: theme, child: bottomSheet);
+    return bottomSheet;
   }
 }
 

--- a/packages/flutter/lib/src/material/dialog.dart
+++ b/packages/flutter/lib/src/material/dialog.dart
@@ -427,7 +427,18 @@ class _DialogRoute<T> extends PopupRoute<T> {
 
   @override
   Widget buildPage(BuildContext context, Animation<double> animation, Animation<double> secondaryAnimation) {
-    return theme != null ? new Theme(data: theme, child: child) : child;
+    return new MediaQuery.removePadding(
+      context: context,
+      removeTop: true,
+      removeBottom: true,
+      removeLeft: true,
+      removeRight: true,
+      child: new Builder(
+        builder: (BuildContext context) {
+          return theme != null ? new Theme(data: theme, child: child) : child;
+        }
+      ),
+    );
   }
 
   @override

--- a/packages/flutter/lib/src/material/dropdown.dart
+++ b/packages/flutter/lib/src/material/dropdown.dart
@@ -335,14 +335,25 @@ class _DropdownRoute<T> extends PopupRoute<_DropdownRouteResult<T>> {
     if (theme != null)
       menu = new Theme(data: theme, child: menu);
 
-    return new CustomSingleChildLayout(
-      delegate: new _DropdownMenuRouteLayout<T>(
-        buttonRect: buttonRect,
-        menuTop: menuTop,
-        menuHeight: menuHeight,
-        textDirection: Directionality.of(context),
+    return new MediaQuery.removePadding(
+      context: context,
+      removeTop: true,
+      removeBottom: true,
+      removeLeft: true,
+      removeRight: true,
+      child: new Builder(
+        builder: (BuildContext context) {
+          return new CustomSingleChildLayout(
+            delegate: new _DropdownMenuRouteLayout<T>(
+              buttonRect: buttonRect,
+              menuTop: menuTop,
+              menuHeight: menuHeight,
+              textDirection: Directionality.of(context),
+            ),
+            child: menu,
+          );
+        },
       ),
-      child: menu,
     );
   }
 

--- a/packages/flutter/lib/src/material/popup_menu.dart
+++ b/packages/flutter/lib/src/material/popup_menu.dart
@@ -591,17 +591,24 @@ class _PopupMenuRoute<T> extends PopupRoute<T> {
     if (theme != null)
       menu = new Theme(data: theme, child: menu);
 
-    return new Builder(
-      builder: (BuildContext context) {
-        return new CustomSingleChildLayout(
-          delegate: new _PopupMenuRouteLayout(
-            position,
-            selectedItemOffset,
-            Directionality.of(context),
-          ),
-          child: menu,
-        );
-      },
+    return new MediaQuery.removePadding(
+      context: context,
+      removeTop: true,
+      removeBottom: true,
+      removeLeft: true,
+      removeRight: true,
+      child: new Builder(
+        builder: (BuildContext context) {
+          return new CustomSingleChildLayout(
+            delegate: new _PopupMenuRouteLayout(
+              position,
+              selectedItemOffset,
+              Directionality.of(context),
+            ),
+            child: menu,
+          );
+        },
+      ),
     );
   }
 }

--- a/packages/flutter/test/material/dialog_test.dart
+++ b/packages/flutter/test/material/dialog_test.dart
@@ -229,4 +229,40 @@ void main() {
 
     semantics.dispose();
   });
+
+  testWidgets('Dialogs removes MediaQuery padding', (WidgetTester tester) async {
+    BuildContext scaffoldContext;
+    BuildContext dialogContext;
+
+    await tester.pumpWidget(new MaterialApp(
+      home: new MediaQuery(
+        data: const MediaQueryData(
+          padding: const EdgeInsets.all(50.0),
+        ),
+        child: new Builder(
+          builder: (BuildContext context) {
+            scaffoldContext = context;
+            return new Container();
+          }
+        ),
+      )
+    ));
+
+    await tester.pump();
+
+    showDialog<Null>(
+      context: scaffoldContext,
+      barrierDismissible: false,
+      child: new Builder(
+        builder: (BuildContext context) {
+          dialogContext = context;
+          return new Container();
+        },
+      ),
+    );
+
+    await tester.pump();
+
+    expect(MediaQuery.of(dialogContext).padding, EdgeInsets.zero);
+  });
 }

--- a/packages/flutter/test/material/persistent_bottom_sheet_test.dart
+++ b/packages/flutter/test/material/persistent_bottom_sheet_test.dart
@@ -91,7 +91,7 @@ void main() {
     expect(buildCount, equals(1));
   });
 
-  testWidgets('Bottom sheet removes top MediaQuery padding', (WidgetTester tester) async {
+  testWidgets('Scaffold removes top MediaQuery padding', (WidgetTester tester) async {
     BuildContext scaffoldContext;
     BuildContext bottomSheetContext;
 
@@ -100,11 +100,14 @@ void main() {
         data: const MediaQueryData(
           padding: const EdgeInsets.all(50.0),
         ),
-        child: new Builder(
-          builder: (BuildContext context) {
-            scaffoldContext = context;
-            return new Container();
-          }
+        child: new Scaffold(
+          resizeToAvoidBottomPadding: false,
+          body: new Builder(
+            builder: (BuildContext context) {
+              scaffoldContext = context;
+              return new Container();
+            }
+          ),
         ),
       )
     ));
@@ -119,6 +122,8 @@ void main() {
       },
     );
 
+    await tester.pump();
+
     expect(
       MediaQuery.of(bottomSheetContext).padding,
       const EdgeInsets.only(
@@ -127,7 +132,5 @@ void main() {
         right: 50.0,
       ),
     );
-    // There's the original and a trimmed MediaQuery widget now.
-    expect(find.byType(MediaQuery).evaluate().length, 2);
   });
 }

--- a/packages/flutter/test/material/persistent_bottom_sheet_test.dart
+++ b/packages/flutter/test/material/persistent_bottom_sheet_test.dart
@@ -91,4 +91,43 @@ void main() {
     expect(buildCount, equals(1));
   });
 
+  testWidgets('Bottom sheet removes top MediaQuery padding', (WidgetTester tester) async {
+    BuildContext scaffoldContext;
+    BuildContext bottomSheetContext;
+
+    await tester.pumpWidget(new MaterialApp(
+      home: new MediaQuery(
+        data: const MediaQueryData(
+          padding: const EdgeInsets.all(50.0),
+        ),
+        child: new Builder(
+          builder: (BuildContext context) {
+            scaffoldContext = context;
+            return new Container();
+          }
+        ),
+      )
+    ));
+
+    await tester.pump();
+
+    showBottomSheet<Null>(
+      context: scaffoldContext,
+      builder: (BuildContext context) {
+        bottomSheetContext = context;
+        return new Container();
+      },
+    );
+
+    expect(
+      MediaQuery.of(bottomSheetContext).padding,
+      const EdgeInsets.only(
+        bottom: 50.0,
+        left: 50.0,
+        right: 50.0,
+      ),
+    );
+    // There's the original and a trimmed MediaQuery widget now.
+    expect(find.byType(MediaQuery).evaluate().length, 2);
+  });
 }

--- a/packages/flutter/test/material/popup_menu_test.dart
+++ b/packages/flutter/test/material/popup_menu_test.dart
@@ -315,6 +315,47 @@ void main() {
     await testPositioningDownThenUp(tester, TextDirection.ltr, Alignment.bottomCenter, TextDirection.ltr, new Rect.fromLTWH(350.0, 500.0, 0.0, 0.0));
     await testPositioningDownThenUp(tester, TextDirection.rtl, Alignment.bottomCenter, TextDirection.rtl, new Rect.fromLTWH(450.0, 500.0, 0.0, 0.0));
   });
+
+  testWidgets('PopupMenu removes MediaQuery padding', (WidgetTester tester) async {
+    BuildContext popupContext;
+
+    await tester.pumpWidget(new MaterialApp(
+      home: new MediaQuery(
+        data: const MediaQueryData(
+          padding: const EdgeInsets.all(50.0),
+        ),
+        child: new Material(
+          child: new PopupMenuButton<int>(
+            itemBuilder: (BuildContext context) {
+              popupContext = context;
+              return <PopupMenuItem<int>>[
+                new PopupMenuItem<int>(
+                  value: 1,
+                  child: new Builder(
+                    builder: (BuildContext context) {
+                      popupContext = context;
+                      return const Text('AAA');
+                    },
+                  ),
+                ),
+              ];
+            },
+            child: const SizedBox(
+              height: 100.0,
+              width: 100.0,
+              child: const Text('XXX'),
+            ),
+          ),
+        ),
+      )
+    ));
+
+    await tester.tap(find.text('XXX'));
+
+    await tester.pump();
+
+    expect(MediaQuery.of(popupContext).padding, EdgeInsets.zero);
+  });
 }
 
 class TestApp extends StatefulWidget {


### PR DESCRIPTION
Fixes #13408

Alternate approach to #13436 for customizable edges in case dialogs hug the screen on some sides. 

Removes dangling paddings for sides that don't intersect with the partial obstructions. 