### PR TITLE
Make create command use pub in offline mode.

### DIFF
--- a/packages/flutter_tools/lib/src/commands/create.dart
+++ b/packages/flutter_tools/lib/src/commands/create.dart
@@ -162,7 +162,11 @@ class CreateCommand extends FlutterCommand {
       generatedCount += _renderTemplate('package', dirPath, templateContext);
 
       if (argResults['pub'])
-        await pubGet(context: PubContext.createPackage, directory: dirPath);
+        await pubGet(
+          context: PubContext.createPackage,
+          directory: dirPath,
+          offline: true,
+        );
 
       final String relativePath = fs.path.relative(dirPath);
       printStatus('Wrote $generatedCount files.');
@@ -180,7 +184,11 @@ class CreateCommand extends FlutterCommand {
       generatedCount += _renderTemplate('plugin', dirPath, templateContext);
 
       if (argResults['pub'])
-        await pubGet(context: PubContext.createPlugin, directory: dirPath);
+        await pubGet(
+          context: PubContext.createPlugin,
+          directory: dirPath,
+          offline: true,
+        );
 
       if (android_sdk.androidSdk != null)
         gradle.updateLocalProperties(projectPath: dirPath);
@@ -218,7 +226,7 @@ class CreateCommand extends FlutterCommand {
     );
 
     if (argResults['pub']) {
-      await pubGet(context: PubContext.create, directory: appPath);
+      await pubGet(context: PubContext.create, directory: appPath, offline: true);
       injectPlugins(directory: appPath);
     }
 


### PR DESCRIPTION
In order to allow offline usage of the create command we need to be able to tell pub not to try and contact the server to see if new versions are available.  Since all the versions that create could want are pinned, it shouldn't need to check for new versions.