### PR TITLE
Remove bottom padding in SliverAppBar

### DIFF
--- a/packages/flutter/lib/src/material/app_bar.dart
+++ b/packages/flutter/lib/src/material/app_bar.dart
@@ -954,31 +954,35 @@ class _SliverAppBarState extends State<SliverAppBar> with TickerProviderStateMix
     final double collapsedHeight = (widget.pinned && widget.floating && widget.bottom != null)
       ? widget.bottom.preferredSize.height + topPadding : null;
 
-    return new SliverPersistentHeader(
-      floating: widget.floating,
-      pinned: widget.pinned,
-      delegate: new _SliverAppBarDelegate(
-        leading: widget.leading,
-        automaticallyImplyLeading: widget.automaticallyImplyLeading,
-        title: widget.title,
-        actions: widget.actions,
-        flexibleSpace: widget.flexibleSpace,
-        bottom: widget.bottom,
-        elevation: widget.elevation,
-        forceElevated: widget.forceElevated,
-        backgroundColor: widget.backgroundColor,
-        brightness: widget.brightness,
-        iconTheme: widget.iconTheme,
-        textTheme: widget.textTheme,
-        primary: widget.primary,
-        centerTitle: widget.centerTitle,
-        titleSpacing: widget.titleSpacing,
-        expandedHeight: widget.expandedHeight,
-        collapsedHeight: collapsedHeight,
-        topPadding: topPadding,
+    return new MediaQuery.removePadding(
+      context: context,
+      removeBottom: true,
+      child: new SliverPersistentHeader(
         floating: widget.floating,
         pinned: widget.pinned,
-        snapConfiguration: _snapConfiguration,
+        delegate: new _SliverAppBarDelegate(
+          leading: widget.leading,
+          automaticallyImplyLeading: widget.automaticallyImplyLeading,
+          title: widget.title,
+          actions: widget.actions,
+          flexibleSpace: widget.flexibleSpace,
+          bottom: widget.bottom,
+          elevation: widget.elevation,
+          forceElevated: widget.forceElevated,
+          backgroundColor: widget.backgroundColor,
+          brightness: widget.brightness,
+          iconTheme: widget.iconTheme,
+          textTheme: widget.textTheme,
+          primary: widget.primary,
+          centerTitle: widget.centerTitle,
+          titleSpacing: widget.titleSpacing,
+          expandedHeight: widget.expandedHeight,
+          collapsedHeight: collapsedHeight,
+          topPadding: topPadding,
+          floating: widget.floating,
+          pinned: widget.pinned,
+          snapConfiguration: _snapConfiguration,
+        ),
       ),
     );
   }

--- a/packages/flutter/test/material/app_bar_test.dart
+++ b/packages/flutter/test/material/app_bar_test.dart
@@ -1145,4 +1145,34 @@ void main() {
     expect(tester.getTopLeft(find.byKey(titleKey)), const Offset(420.0, 100.0));
     expect(tester.getTopLeft(find.byKey(trailingKey)), const Offset(4.0, 100.0));
   });
+
+  testWidgets('SliverAppBar positioning of leading and trailing widgets with bottom padding', (WidgetTester tester) async {
+    const MediaQueryData topPadding100 = const MediaQueryData(padding: const EdgeInsets.only(top: 100.0, bottom: 50.0));
+
+    final Key leadingKey = new UniqueKey();
+    final Key titleKey = new UniqueKey();
+    final Key trailingKey = new UniqueKey();
+
+    await tester.pumpWidget(
+      new Directionality(
+        textDirection: TextDirection.rtl,
+        child: new MediaQuery(
+          data: topPadding100,
+          child: new CustomScrollView(
+            primary: true,
+            slivers: <Widget>[
+              new SliverAppBar(
+                leading: new Placeholder(key: leadingKey),
+                title: new Placeholder(key: titleKey),
+                actions: <Widget>[ new Placeholder(key: trailingKey) ],
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+    expect(tester.getRect(find.byType(AppBar)), new Rect.fromLTRB(0.0, 0.0, 800.00, 100.0 + 56.0));
+    expect(tester.getRect(find.byKey(leadingKey)), new Rect.fromLTRB(800.0 - 56.0, 100.0, 800.0, 100.0 + 56.0));
+    expect(tester.getRect(find.byKey(trailingKey)), new Rect.fromLTRB(4.0, 100.0, 400.0 + 4.0, 100.0 + 56.0));
+  });
 }


### PR DESCRIPTION
Removes bottom padding from the child AppBar in SliverAppBar. Scaffold
already does this for its own app bars, but sliver app bars in the body
should also apply the bottom padding removal.

Fixes flutter/flutter#13458