### PR TITLE
Support Android Gradle plugin v3.0.1

### DIFF
--- a/packages/flutter_tools/gradle/flutter.gradle
+++ b/packages/flutter_tools/gradle/flutter.gradle
@@ -19,9 +19,12 @@ import org.gradle.api.tasks.bundling.Jar
 buildscript {
     repositories {
         jcenter()
+        maven {
+            url 'https://maven.google.com'
+        }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
     }
 }
 
@@ -101,7 +104,11 @@ class FlutterPlugin implements Plugin<Project> {
             localEngineSrcPath = engineOut.parentFile.parent
 
             project.dependencies {
-                compile project.files(flutterJar)
+                if (project.getConfigurations().findByName("implementation")) {
+                    implementation project.files(flutterJar)
+                } else {
+                    compile project.files(flutterJar)
+                }
             }
         } else {
             Path baseEnginePath = Paths.get(flutterRoot.absolutePath, "bin", "cache", "artifacts", "engine")
@@ -131,10 +138,10 @@ class FlutterPlugin implements Plugin<Project> {
                     into "lib/x86_64"
                 }
             }
-            // Add flutter.jar dependencies to all <buildType>Compile configurations, including custom ones
+            // Add flutter.jar dependencies to all <buildType>Implementation configurations, including custom ones
             // added after applying the Flutter plugin.
-            project.android.buildTypes.each { addFlutterJarCompileDependency(project, it) }
-            project.android.buildTypes.whenObjectAdded { addFlutterJarCompileDependency(project, it) }
+            project.android.buildTypes.each { addFlutterJarImplementationDependency(project, it) }
+            project.android.buildTypes.whenObjectAdded { addFlutterJarImplementationDependency(project, it) }
         }
 
         project.extensions.create("flutter", FlutterExtension)
@@ -147,37 +154,56 @@ class FlutterPlugin implements Plugin<Project> {
             def pluginProject = project.rootProject.findProject(":$name")
             if (pluginProject != null) {
                 project.dependencies {
-                    compile pluginProject
+                    if (project.getConfigurations().findByName("implementation")) {
+                        implementation pluginProject
+                    } else {
+                        compile pluginProject
+                    }
                 }
-                pluginProject.afterEvaluate this.&addFlutterJarProvidedDependency
+                pluginProject.afterEvaluate this.&addFlutterJarCompileOnlyDependency
             } else {
                 project.logger.error("Plugin project :$name not found. Please update settings.gradle.")
             }
         }
     }
 
-    private void addFlutterJarProvidedDependency(Project project) {
+    private void addFlutterJarCompileOnlyDependency(Project project) {
         if (project.state.failure) {
             return
         }
         project.dependencies {
             if (flutterJar != null) {
-                provided project.files(flutterJar)
+                if (project.getConfigurations().findByName("compileOnly")) {
+                    compileOnly project.files(flutterJar)
+                } else {
+                    provided project.files(flutterJar)
+                }
             } else {
-                debugProvided project.files(debugFlutterJar)
-                releaseProvided project.files(releaseFlutterJar)
+                if (project.getConfigurations().findByName("debugCompileOnly")) {
+                    debugCompileOnly project.files(debugFlutterJar)
+                    releaseCompileOnly project.files(releaseFlutterJar)
+                } else {
+                    debugProvided project.files(debugFlutterJar)
+                    releaseProvided project.files(releaseFlutterJar)
+                }
             }
         }
     }
 
     /**
-     * Adds suitable flutter.jar compile dependencies to the specified buildType.
+     * Adds suitable flutter.jar implementation dependencies to the specified buildType.
      *
      * Note: The BuildType DSL type is not public, and is therefore omitted from the signature.
      */
-    private void addFlutterJarCompileDependency(Project project, buildType) {
+    private void addFlutterJarImplementationDependency(Project project, buildType) {
         project.dependencies {
-            add(buildType.name + "Compile", project.files {
+            String configuration;
+            if (project.getConfigurations().findByName("implementation")) {
+                configuration = buildType.name + "Implementation";
+            } else {
+                configuration = buildType.name + "Compile";
+            }
+            add(configuration, project.files {
                 String buildMode = buildModeFor(buildType)
                 if (buildMode == "debug") {
                     [flutterX86Jar, debugFlutterJar]
@@ -244,6 +270,10 @@ class FlutterPlugin implements Plugin<Project> {
             String flutterBuildMode = buildModeFor(variant.buildType)
             if (flutterBuildMode == 'debug' && project.tasks.findByName('flutterBuildX86Jar')) {
                 Task task = project.tasks.findByName("compile${variant.name.capitalize()}JavaWithJavac")
+                if (task) {
+                    task.dependsOn project.flutterBuildX86Jar
+                }
+                task = project.tasks.findByName("compile${variant.name.capitalize()}Kotlin")
                 if (task) {
                     task.dependsOn project.flutterBuildX86Jar
                 }

--- a/packages/flutter_tools/lib/src/android/gradle.dart
+++ b/packages/flutter_tools/lib/src/android/gradle.dart
@@ -23,7 +23,7 @@ import 'android_studio.dart';
 const String gradleManifestPath = 'android/app/src/main/AndroidManifest.xml';
 const String gradleAppOutV1 = 'android/app/build/outputs/apk/app-debug.apk';
 const String gradleAppOutDirV1 = 'android/app/build/outputs/apk';
-const String gradleVersion = '3.3';
+const String gradleVersion = '4.1';
 final RegExp _assembleTaskPattern = new RegExp(r'assemble([^:]+): task ');
 
 GradleProject _cachedGradleProject;

--- a/packages/flutter_tools/lib/src/android/gradle.dart
+++ b/packages/flutter_tools/lib/src/android/gradle.dart
@@ -336,6 +336,13 @@ File _findApkFile(GradleProject project, BuildInfo buildInfo) {
   apkFile = fs.file(fs.path.join(project.apkDirectory, buildInfo.modeName, apkFileName));
   if (apkFile.existsSync())
     return apkFile;
+  if (buildInfo.flavor != null) {
+    // Android Studio Gradle plugin v3 adds flavor to path.
+    apkFile = fs.file(fs.path.join(project.apkDirectory, buildInfo.flavor, buildInfo.modeName, apkFileName));
+    if (apkFile.existsSync()) {
+      return apkFile;
+    }
+  }
   return null;
 }
 

--- a/packages/flutter_tools/lib/src/android/gradle.dart
+++ b/packages/flutter_tools/lib/src/android/gradle.dart
@@ -339,9 +339,8 @@ File _findApkFile(GradleProject project, BuildInfo buildInfo) {
   if (buildInfo.flavor != null) {
     // Android Studio Gradle plugin v3 adds flavor to path.
     apkFile = fs.file(fs.path.join(project.apkDirectory, buildInfo.flavor, buildInfo.modeName, apkFileName));
-    if (apkFile.existsSync()) {
+    if (apkFile.existsSync())
       return apkFile;
-    }
   }
   return null;
 }

--- a/packages/flutter_tools/templates/create/android-java.tmpl/app/build.gradle.tmpl
+++ b/packages/flutter_tools/templates/create/android-java.tmpl/app/build.gradle.tmpl
@@ -15,8 +15,8 @@ apply plugin: 'com.android.application'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion '25.0.3'
+    compileSdkVersion 26
+    buildToolsVersion '26.0.3'
 
     lintOptions {
         disable 'InvalidPackage'
@@ -26,7 +26,7 @@ android {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "{{androidIdentifier}}"
         minSdkVersion 16
-        targetSdkVersion 25
+        targetSdkVersion 26
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
@@ -38,6 +38,9 @@ android {
             // Signing with the debug keys for now, so `flutter run --release` works.
             signingConfig signingConfigs.debug
         }
+        profile {
+            matchingFallbacks = ['debug', 'release']
+        }
     }
 }
 
@@ -46,7 +49,7 @@ flutter {
 }
 
 dependencies {
-    androidTestCompile 'com.android.support:support-annotations:25.4.0'
-    androidTestCompile 'com.android.support.test:runner:0.5'
-    androidTestCompile 'com.android.support.test:rules:0.5'
+    testImplementation 'junit:junit:4.12'
+    androidTestImplementation 'com.android.support.test:runner:1.0.1'
+    androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.1'
 }

--- a/packages/flutter_tools/templates/create/android-java.tmpl/build.gradle
+++ b/packages/flutter_tools/templates/create/android-java.tmpl/build.gradle
@@ -1,22 +1,18 @@
 buildscript {
     repositories {
+        google()
         jcenter()
-        maven {
-            url "https://maven.google.com"
-        }
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
     }
 }
 
 allprojects {
     repositories {
+        google()
         jcenter()
-        maven {
-            url "https://maven.google.com"
-        }
     }
 }
 

--- a/packages/flutter_tools/templates/create/android-kotlin.tmpl/app/build.gradle.tmpl
+++ b/packages/flutter_tools/templates/create/android-kotlin.tmpl/app/build.gradle.tmpl
@@ -16,8 +16,8 @@ apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion '25.0.3'
+    compileSdkVersion 26
+    buildToolsVersion '26.0.3'
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
@@ -31,7 +31,7 @@ android {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "{{androidIdentifier}}"
         minSdkVersion 16
-        targetSdkVersion 25
+        targetSdkVersion 26
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
@@ -43,6 +43,9 @@ android {
             // Signing with the debug keys for now, so `flutter run --release` works.
             signingConfig signingConfigs.debug
         }
+        profile {
+            matchingFallbacks = ['debug', 'release']
+        }
     }
 }
 
@@ -51,8 +54,8 @@ flutter {
 }
 
 dependencies {
-    androidTestCompile 'com.android.support:support-annotations:25.4.0'
-    androidTestCompile 'com.android.support.test:runner:0.5'
-    androidTestCompile 'com.android.support.test:rules:0.5'
-    compile 'org.jetbrains.kotlin:kotlin-stdlib-jre7:1.1.2-4'
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jre7:$kotlin_version"
+    testImplementation 'junit:junit:4.12'
+    androidTestImplementation 'com.android.support.test:runner:1.0.1'
+    androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.1'
 }

--- a/packages/flutter_tools/templates/create/android-kotlin.tmpl/build.gradle
+++ b/packages/flutter_tools/templates/create/android-kotlin.tmpl/build.gradle
@@ -1,23 +1,20 @@
 buildscript {
+    ext.kotlin_version = '1.1.51'
     repositories {
+        google()
         jcenter()
-        maven {
-            url "https://maven.google.com"
-        }
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.3'
-        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.1.2-4'
+        classpath 'com.android.tools.build:gradle:3.0.1'
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
 
 allprojects {
     repositories {
+        google()
         jcenter()
-        maven {
-            url "https://maven.google.com"
-        }
     }
 }
 

--- a/packages/flutter_tools/templates/create/android.tmpl/gradle/wrapper/gradle-wrapper.properties
+++ b/packages/flutter_tools/templates/create/android.tmpl/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/packages/flutter_tools/templates/plugin/android-java.tmpl/build.gradle.tmpl
+++ b/packages/flutter_tools/templates/plugin/android-java.tmpl/build.gradle.tmpl
@@ -3,35 +3,31 @@ version '1.0-SNAPSHOT'
 
 buildscript {
     repositories {
+        google()
         jcenter()
-        maven {
-            url "https://maven.google.com"
-        }
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
     }
 }
 
 rootProject.allprojects {
     repositories {
+        google()
         jcenter()
-        maven {
-            url "https://maven.google.com"
-        }
     }
 }
 
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion '25.0.3'
+    compileSdkVersion 26
+    buildToolsVersion '26.0.3'
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 25
+        targetSdkVersion 26
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"

--- a/packages/flutter_tools/templates/plugin/android-kotlin.tmpl/build.gradle.tmpl
+++ b/packages/flutter_tools/templates/plugin/android-kotlin.tmpl/build.gradle.tmpl
@@ -2,24 +2,22 @@ group '{{androidIdentifier}}'
 version '1.0-SNAPSHOT'
 
 buildscript {
+    ext.kotlin_version = '1.1.51'
     repositories {
+        google()
         jcenter()
-        maven {
-            url "https://maven.google.com"
-        }
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
 
 rootProject.allprojects {
     repositories {
+        google()
         jcenter()
-        maven {
-            url "https://maven.google.com"
-        }
     }
 }
 
@@ -27,15 +25,15 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion '25.0.3'
+    compileSdkVersion 26
+    buildToolsVersion '26.0.3'
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
     }
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 25
+        targetSdkVersion 26
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
@@ -46,5 +44,5 @@ android {
 }
 
 dependencies {
-    compile 'org.jetbrains.kotlin:kotlin-stdlib-jre7:1.1.2-4'
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jre7:$kotlin_version"
 }

--- a/packages/flutter_tools/templates/plugin/android.tmpl/gradle/wrapper/gradle-wrapper.properties
+++ b/packages/flutter_tools/templates/plugin/android.tmpl/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip


### PR DESCRIPTION
Update Android templates to use the new Android Gradle plugin and to match the result of letting Android Studio 3.0.1 create a new project.

Update flutter.gradle script to handle both new and old projects.

Fixes https://github.com/flutter/flutter/issues/10992