### PR TITLE
Remove top MediaQuery padding from modal bottom sheets' child

### DIFF
--- a/packages/flutter/lib/src/material/bottom_sheet.dart
+++ b/packages/flutter/lib/src/material/bottom_sheet.dart
@@ -234,7 +234,13 @@ class _ModalBottomSheetRoute<T> extends PopupRoute<T> {
 
   @override
   Widget buildPage(BuildContext context, Animation<double> animation, Animation<double> secondaryAnimation) {
-    Widget bottomSheet = new _ModalBottomSheet<T>(route: this);
+    // By definition, the bottom sheet is aligned to the bottom of the page
+    // and isn't exposed to the top padding of the MediaQuery.
+    Widget bottomSheet = new MediaQuery.removePadding(
+      context: context,
+      removeTop: true,
+      child: new _ModalBottomSheet<T>(route: this),
+    );
     if (theme != null)
       bottomSheet = new Theme(data: theme, child: bottomSheet);
     return bottomSheet;

--- a/packages/flutter/test/material/dialog_test.dart
+++ b/packages/flutter/test/material/dialog_test.dart
@@ -231,27 +231,30 @@ void main() {
   });
 
   testWidgets('Dialogs removes MediaQuery padding', (WidgetTester tester) async {
-    BuildContext scaffoldContext;
+    BuildContext outerContext;
     BuildContext dialogContext;
 
-    await tester.pumpWidget(new MaterialApp(
-      home: new MediaQuery(
+    await tester.pumpWidget(new Directionality(
+      textDirection: TextDirection.ltr,
+      child: new MediaQuery(
         data: const MediaQueryData(
           padding: const EdgeInsets.all(50.0),
         ),
-        child: new Builder(
-          builder: (BuildContext context) {
-            scaffoldContext = context;
-            return new Container();
-          }
+        child: new Navigator(
+          onGenerateRoute: (_) {
+            return new PageRouteBuilder<Null>(
+              pageBuilder: (BuildContext context, Animation<double> animation, Animation<double> secondaryAnimation) {
+                outerContext = context;
+                return new Container();
+              },
+            );
+          },
         ),
-      )
+      ),
     ));
 
-    await tester.pump();
-
     showDialog<Null>(
-      context: scaffoldContext,
+      context: outerContext,
       barrierDismissible: false,
       child: new Builder(
         builder: (BuildContext context) {
@@ -263,6 +266,7 @@ void main() {
 
     await tester.pump();
 
+    expect(MediaQuery.of(outerContext).padding, const EdgeInsets.all(50.0));
     expect(MediaQuery.of(dialogContext).padding, EdgeInsets.zero);
   });
 }

--- a/packages/flutter/test/material/modal_bottom_sheet_test.dart
+++ b/packages/flutter/test/material/modal_bottom_sheet_test.dart
@@ -153,4 +153,47 @@ void main() {
 
     expect(find.text('BottomSheet'), findsNothing);
   });
+
+  testWidgets('modal BottomSheet has no top MediaQuery', (WidgetTester tester) async {
+    BuildContext outerContext;
+    BuildContext innerContext;
+
+    await tester.pumpWidget(new Directionality(
+      textDirection: TextDirection.ltr,
+      child: new MediaQuery(
+        data: const MediaQueryData(
+          padding: const EdgeInsets.all(50.0),
+        ),
+        child: new Navigator(
+          onGenerateRoute: (_) {
+            return new PageRouteBuilder<Null>(
+              pageBuilder: (BuildContext context, Animation<double> animation, Animation<double> secondaryAnimation) {
+                outerContext = context;
+                return new Container();
+              },
+            );
+          },
+        ),
+      ),
+    ));
+
+    showModalBottomSheet<Null>(
+      context: outerContext,
+      builder: (BuildContext context) {
+        innerContext = context;
+        return new Container();
+      },
+    );
+    await tester.pump();
+    await tester.pump(const Duration(seconds: 1));
+
+    expect(
+      MediaQuery.of(outerContext).padding,
+      const EdgeInsets.all(50.0),
+    );
+    expect(
+      MediaQuery.of(innerContext).padding,
+      const EdgeInsets.only(left: 50.0, right: 50.0, bottom: 50.0),
+    );
+  });
 }


### PR DESCRIPTION
Missed one from #13438. For #13408.

Also fix dialog_test. It wasn't really testing anything before. 