### PR TITLE
Make the create command call pub get in online instead of offline mode.

### DIFF
--- a/packages/flutter_tools/lib/src/commands/create.dart
+++ b/packages/flutter_tools/lib/src/commands/create.dart
@@ -32,6 +32,12 @@ class CreateCommand extends FlutterCommand {
       defaultsTo: true,
       help: 'Whether to run "flutter packages get" after the project has been created.'
     );
+    argParser.addFlag('offline',
+      defaultsTo: false,
+      help: 'When "flutter packages get" is run by the create command, this indicates '
+        'whether to run it in offline mode or not. In offline mode, it will need to '
+        'have all dependencies already available in the pub cache to succeed.'
+    );
     argParser.addFlag(
       'with-driver-test',
       negatable: true,
@@ -165,7 +171,7 @@ class CreateCommand extends FlutterCommand {
         await pubGet(
           context: PubContext.createPackage,
           directory: dirPath,
-          offline: true,
+          offline: argResults['offline'],
         );
 
       final String relativePath = fs.path.relative(dirPath);
@@ -187,7 +193,7 @@ class CreateCommand extends FlutterCommand {
         await pubGet(
           context: PubContext.createPlugin,
           directory: dirPath,
-          offline: true,
+          offline: argResults['offline'],
         );
 
       if (android_sdk.androidSdk != null)
@@ -226,7 +232,7 @@ class CreateCommand extends FlutterCommand {
     );
 
     if (argResults['pub']) {
-      await pubGet(context: PubContext.create, directory: appPath, offline: true);
+      await pubGet(context: PubContext.create, directory: appPath, offline: argResults['offline']);
       injectPlugins(directory: appPath);
     }
 

--- a/packages/flutter_tools/test/commands/create_test.dart
+++ b/packages/flutter_tools/test/commands/create_test.dart
@@ -303,7 +303,24 @@ void main() {
       );
     });
 
-    testUsingContext('invokes pub offline', () async {
+    testUsingContext('invokes pub offline when requested', () async {
+      Cache.flutterRoot = '../..';
+
+      final CreateCommand command = new CreateCommand();
+      final CommandRunner<Null> runner = createTestCommandRunner(command);
+
+      await runner.run(<String>['create', '--pub', '--offline', projectDir.path]);
+      final List<String> commands = loggingProcessManager.commands;
+      expect(commands, contains(matches(r'dart-sdk[\\/]bin[\\/]pub')));
+      expect(commands, contains('--offline'));
+    },
+      timeout: allowForCreateFlutterProject,
+      overrides: <Type, Generator>{
+        ProcessManager: () => loggingProcessManager,
+      },
+    );
+
+    testUsingContext('invokes pub online when offline not requested', () async {
       Cache.flutterRoot = '../..';
 
       final CreateCommand command = new CreateCommand();
@@ -312,7 +329,7 @@ void main() {
       await runner.run(<String>['create', '--pub', projectDir.path]);
       final List<String> commands = loggingProcessManager.commands;
       expect(commands, contains(matches(r'dart-sdk[\\/]bin[\\/]pub')));
-      expect(commands, contains('--offline'));
+      expect(commands, isNot(contains('--offline')));
     },
       timeout: allowForCreateFlutterProject,
       overrides: <Type, Generator>{


### PR DESCRIPTION
We thought it would be OK to call the create command offline-only, but it turns out that isn't a great idea because not all of the create template dependencies are cached by running flutter_tool.

This PR makes it go online by default when running pub get after creating a project, and adds an "--offline" flag to the create command so that offline users can use it offline if their cache is warm.