### PR TITLE
Increase coverage collection timeout to 2 minutes

### DIFF
--- a/packages/flutter_tools/lib/src/test/coverage_collector.dart
+++ b/packages/flutter_tools/lib/src/test/coverage_collector.dart
@@ -55,9 +55,9 @@ class CoverageCollector extends TestWatcher {
     final Map<String, dynamic> data = await coverage
         .collect(observatoryUri, false, false)
         .timeout(
-          const Duration(seconds: 30),
+          const Duration(minutes: 2),
           onTimeout: () {
-            throw new Exception('Failed to collect coverage, it took more than thirty seconds.');
+            throw new Exception('Timed out while collecting coverage.');
           },
         );
     printTrace(() {


### PR DESCRIPTION
Leafy is hitting the limits of the previous timeout of 30 seconds for tests that touch a lot of code in the app.