### PR TITLE
Fix gradle plugin test

### DIFF
--- a/dev/devicelab/bin/tasks/gradle_plugin_test.dart
+++ b/dev/devicelab/bin/tasks/gradle_plugin_test.dart
@@ -127,6 +127,7 @@ android {
     buildScript.openWrite(mode: FileMode.APPEND).write('''
 
 android {
+    flavorDimensions "mode"
     productFlavors {
         $name {
             applicationIdSuffix ".$name"


### PR DESCRIPTION
Android Gradle plugin v 3.0.1 requires product flavors to have a dimension (which can be implicit, if there is only one choice).