### PR TITLE
Apply media padding in ListTile

### DIFF
--- a/examples/flutter_gallery/lib/gallery/home.dart
+++ b/examples/flutter_gallery/lib/gallery/home.dart
@@ -144,7 +144,11 @@ class GalleryHomeState extends State<GalleryHome> with SingleTickerProviderState
               height: 48.0,
               padding: const EdgeInsetsDirectional.only(start: 16.0),
               alignment: AlignmentDirectional.centerStart,
-              child: new Text(galleryItem.category, style: headerStyle)
+              child: new SafeArea(
+                top: false,
+                bottom: false,
+                child: new Text(galleryItem.category, style: headerStyle),
+              ),
             ),
           )
         );

--- a/packages/flutter/lib/src/material/list_tile.dart
+++ b/packages/flutter/lib/src/material/list_tile.dart
@@ -457,7 +457,11 @@ class ListTile extends StatelessWidget {
           padding: const EdgeInsets.symmetric(horizontal: 16.0),
           child: new UnconstrainedBox(
             constrainedAxis: Axis.horizontal,
-            child: new Row(children: children),
+            child: new SafeArea(
+              top: false,
+              bottom: false,
+              child: new Row(children: children),
+            ),
           ),
         )
       ),

--- a/packages/flutter/test/material/control_list_tile_test.dart
+++ b/packages/flutter/test/material/control_list_tile_test.dart
@@ -11,9 +11,12 @@ import 'package:flutter/rendering.dart';
 import '../widgets/semantics_tester.dart';
 
 Widget wrap({ Widget child }) {
-  return new Directionality(
-    textDirection: TextDirection.ltr,
-    child: new Material(child: child),
+  return new MediaQuery(
+    data: const MediaQueryData(),
+    child: new Directionality(
+      textDirection: TextDirection.ltr,
+      child: new Material(child: child),
+    ),
   );
 }
 

--- a/packages/flutter/test/material/list_tile_test.dart
+++ b/packages/flutter/test/material/list_tile_test.dart
@@ -49,11 +49,16 @@ void main() {
     final Key trailingKey = new GlobalKey();
     bool hasSubtitle;
 
+    const double leftPadding = 10.0;
+    const double rightPadding = 20.0;
     Widget buildFrame({ bool dense: false, bool isTwoLine: false, bool isThreeLine: false, double textScaleFactor: 1.0 }) {
       hasSubtitle = isTwoLine || isThreeLine;
       return new MaterialApp(
         home: new MediaQuery(
-          data: new MediaQueryData(textScaleFactor: textScaleFactor),
+          data: new MediaQueryData(
+            padding: const EdgeInsets.only(left: leftPadding, right: rightPadding),
+            textScaleFactor: textScaleFactor,
+          ),
           child: new Material(
             child: new Center(
               child: new ListTile(
@@ -89,13 +94,14 @@ void main() {
 
 
     // 16.0 padding to the left and right of the leading and trailing widgets
+    // plus the media padding.
     void testHorizontalGeometry() {
-      expect(leftKey(leadingKey), 16.0);
-      expect(left('title'), 72.0);
+      expect(leftKey(leadingKey), 16.0 + leftPadding);
+      expect(left('title'), 72.0 + leftPadding);
       if (hasSubtitle)
-        expect(left('subtitle'), 72.0);
+        expect(left('subtitle'), 72.0 + leftPadding);
       expect(left('title'), rightKey(leadingKey) + 32.0);
-      expect(rightKey(trailingKey), 800.0 - 16.0);
+      expect(rightKey(trailingKey), 800.0 - 16.0 - rightPadding);
       expect(widthKey(trailingKey), 24.0);
     }
 
@@ -169,14 +175,21 @@ void main() {
 
 
   testWidgets('ListTile geometry (RTL)', (WidgetTester tester) async {
-    await tester.pumpWidget(const Directionality(
-      textDirection: TextDirection.rtl,
-      child: const Material(
-        child: const Center(
-          child: const ListTile(
-            leading: const Text('leading'),
-            title: const Text('title'),
-            trailing: const Text('trailing'),
+    const double leftPadding = 10.0;
+    const double rightPadding = 20.0;
+    await tester.pumpWidget(const MediaQuery(
+      data: const MediaQueryData(
+        padding: const EdgeInsets.only(left: leftPadding, right: rightPadding),
+      ),
+      child: const Directionality(
+        textDirection: TextDirection.rtl,
+        child: const Material(
+          child: const Center(
+            child: const ListTile(
+              leading: const Text('leading'),
+              title: const Text('title'),
+              trailing: const Text('trailing'),
+            ),
           ),
         ),
       ),
@@ -186,10 +199,10 @@ void main() {
     double right(String text) => tester.getTopRight(find.text(text)).dx;
 
     void testHorizontalGeometry() {
-      expect(right('leading'), 800.0 - 16.0);
-      expect(right('title'), 800.0 - 72.0);
+      expect(right('leading'), 800.0 - 16.0 - rightPadding);
+      expect(right('title'), 800.0 - 72.0 - rightPadding);
       expect(left('leading') - right('title'), 16.0);
-      expect(left('trailing'), 16.0);
+      expect(left('trailing'), 16.0 + leftPadding);
     }
 
     testHorizontalGeometry();


### PR DESCRIPTION
Applies media padding (e.g. iOS safe area insets) around the list tile
children inside the InkWell.

Also adds a safe area around gallery section titles for consistency with the
surrounding list tiles.