### PR TITLE
Pin the test package to 0.12.26

### DIFF
--- a/packages/flutter_tools/lib/src/commands/update_packages.dart
+++ b/packages/flutter_tools/lib/src/commands/update_packages.dart
@@ -26,6 +26,10 @@ import '../runner/flutter_command.dart';
 ///   'linter': '0.1.35', // TODO(yjbanov): https://github.com/dart-lang/linter/issues/824
 /// ```
 const Map<String, String> _kManuallyPinnedDependencies = const <String, String>{
+  // New test package breaks the analyzer, see:
+  // https://github.com/dart-lang/sdk/issues/31442
+  // TODO(amirh): unpin this.
+  'test': '0.12.26',
   // Add pinned packages here.
 };
 


### PR DESCRIPTION
https://github.com/dart-lang/sdk/issues/31442 prevents us from upgrading packages, pinning the test package until it is resolved.

@cbracken 