### PR TITLE
Add more checks to scheduleWarmUpFrame

### DIFF
--- a/packages/flutter/lib/src/scheduler/binding.dart
+++ b/packages/flutter/lib/src/scheduler/binding.dart
@@ -669,9 +669,14 @@ abstract class SchedulerBinding extends BindingBase with ServicesBinding {
   /// If a frame has already been scheduled with [scheduleFrame] or
   /// [scheduleForcedFrame], this call may delay that frame.
   ///
+  /// If any scheduled frame has already begun or if another
+  /// [scheduleWarmUpFrame] was already called, this call will be ignored.
+  ///
   /// Prefer [scheduleFrame] to update the display in normal operation.
   void scheduleWarmUpFrame() {
-    assert(!_warmUpFrame);
+    if (_warmUpFrame && !(schedulerPhase == SchedulerPhase.idle))
+      return;
+
     final bool hadScheduledFrame = _hasScheduledFrame;
     _warmUpFrame = true;
     // We use timers here to ensure that microtasks flush in between.

--- a/packages/flutter/lib/src/scheduler/binding.dart
+++ b/packages/flutter/lib/src/scheduler/binding.dart
@@ -674,7 +674,7 @@ abstract class SchedulerBinding extends BindingBase with ServicesBinding {
   ///
   /// Prefer [scheduleFrame] to update the display in normal operation.
   void scheduleWarmUpFrame() {
-    if (_warmUpFrame && !(schedulerPhase == SchedulerPhase.idle))
+    if (_warmUpFrame || schedulerPhase != SchedulerPhase.idle)
       return;
 
     final bool hadScheduledFrame = _hasScheduledFrame;


### PR DESCRIPTION
Prevents crash from calling runApp twice. 

I'm not sure how to test it since AutomatedTestWidgetsFlutterBinding overrides it.