### PR TITLE
Fix niggling PaginatedDataTable bugs

### DIFF
--- a/examples/flutter_gallery/lib/gallery/item.dart
+++ b/examples/flutter_gallery/lib/gallery/item.dart
@@ -110,6 +110,13 @@ List<GalleryItem> _buildGalleryItems() {
       buildRoute: (BuildContext context) => new ChipDemo(),
     ),
     new GalleryItem(
+      title: 'Data tables',
+      subtitle: 'Data tables',
+      category: 'Material Components',
+      routeName: DataTableDemo.routeName,
+      buildRoute: (BuildContext context) => new DataTableDemo(),
+    ),
+    new GalleryItem(
       title: 'Date and time pickers',
       subtitle: 'Date and time selection widgets',
       category: 'Material Components',

--- a/packages/flutter/lib/src/material/data_table.dart
+++ b/packages/flutter/lib/src/material/data_table.dart
@@ -411,14 +411,15 @@ class DataTable extends StatelessWidget {
       alignment: numeric ? Alignment.centerRight : AlignmentDirectional.centerStart,
       child: new AnimatedDefaultTextStyle(
         style: new TextStyle(
-          // TODO(ianh): font family should be Roboto; see https://github.com/flutter/flutter/issues/3116
+          // TODO(ianh): font family should match Theme; see https://github.com/flutter/flutter/issues/3116
           fontWeight: FontWeight.w500,
           fontSize: _kHeadingFontSize,
-          height: _kHeadingRowHeight / _kHeadingFontSize,
+          height: math.min(1.0, _kHeadingRowHeight / _kHeadingFontSize),
           color: (Theme.of(context).brightness == Brightness.light)
             ? ((onSort != null && sorted) ? Colors.black87 : Colors.black54)
             : ((onSort != null && sorted) ? Colors.white : Colors.white70),
         ),
+        softWrap: false,
         duration: _kSortArrowAnimationDuration,
         child: label,
       ),

--- a/packages/flutter/lib/src/material/material_localizations.dart
+++ b/packages/flutter/lib/src/material/material_localizations.dart
@@ -475,7 +475,7 @@ class DefaultMaterialLocalizations implements MaterialLocalizations {
   }
 
   @override
-  String get rowsPerPageTitle => 'Rows per page';
+  String get rowsPerPageTitle => 'Rows per page:';
 
   @override
   String selectedRowCountTitle(int selectedRowCount) {

--- a/packages/flutter/lib/src/material/paginated_data_table.dart
+++ b/packages/flutter/lib/src/material/paginated_data_table.dart
@@ -324,7 +324,7 @@ class PaginatedDataTableState extends State<PaginatedDataTable> {
     final List<Widget> footerWidgets = <Widget>[];
     if (widget.onRowsPerPageChanged != null) {
       final List<Widget> availableRowsPerPage = widget.availableRowsPerPage
-        .where((int value) => value <= _rowCount)
+        .where((int value) => (value <= _rowCount || value == widget.rowsPerPage))
         .map<DropdownMenuItem<int>>((int value) {
           return new DropdownMenuItem<int>(
             value: value,
@@ -333,15 +333,22 @@ class PaginatedDataTableState extends State<PaginatedDataTable> {
         })
         .toList();
       footerWidgets.addAll(<Widget>[
+        new Container(width: 14.0), // to match trailing padding in case we overflow and end up scrolling
         new Text(localizations.rowsPerPageTitle),
-        new DropdownButtonHideUnderline(
-          child: new DropdownButton<int>(
-            items: availableRowsPerPage,
-            value: widget.rowsPerPage,
-            onChanged: widget.onRowsPerPageChanged,
-            style: footerTextStyle,
-            iconSize: 24.0
-          )
+        new ConstrainedBox(
+          constraints: const BoxConstraints(minWidth: 64.0), // 40.0 for the text, 24.0 for the icon
+          child: new Align(
+            alignment: AlignmentDirectional.centerEnd,
+            child: new DropdownButtonHideUnderline(
+              child: new DropdownButton<int>(
+                items: availableRowsPerPage,
+                value: widget.rowsPerPage,
+                onChanged: widget.onRowsPerPageChanged,
+                style: footerTextStyle,
+                iconSize: 24.0,
+              ),
+            ),
+          ),
         ),
       ]);
     }
@@ -422,15 +429,18 @@ class PaginatedDataTableState extends State<PaginatedDataTable> {
               ),
               child: new Container(
                 height: 56.0,
-                child: new Row(
-                  mainAxisAlignment: MainAxisAlignment.end,
-                  children: footerWidgets
-                )
-              )
-            )
-          )
-        ]
-      )
+                child: new SingleChildScrollView(
+                  scrollDirection: Axis.horizontal,
+                  reverse: true,
+                  child: new Row(
+                    children: footerWidgets,
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
     );
   }
 }

--- a/packages/flutter/lib/src/painting/text_painter.dart
+++ b/packages/flutter/lib/src/painting/text_painter.dart
@@ -407,7 +407,7 @@ class TextPainter {
     final int nextCodeUnit = _text.codeUnitAt(offset);
     if (nextCodeUnit == null)
       return null;
-    // TODO(goderbauer): doesn't handle flag emojis (https://github.com/flutter/flutter/issues/13404).
+    // TODO(goderbauer): doesn't handle extended grapheme clusters with more than one Unicode scalar value (https://github.com/flutter/flutter/issues/13404).
     return _isUtf16Surrogate(nextCodeUnit) ? offset + 2 : offset + 1;
   }
 
@@ -417,7 +417,7 @@ class TextPainter {
     final int prevCodeUnit = _text.codeUnitAt(offset - 1);
     if (prevCodeUnit == null)
       return null;
-    // TODO(goderbauer): doesn't handle flag emojis (https://github.com/flutter/flutter/issues/13404).
+    // TODO(goderbauer): doesn't handle extended grapheme clusters with more than one Unicode scalar value (https://github.com/flutter/flutter/issues/13404).
     return _isUtf16Surrogate(prevCodeUnit) ? offset - 2 : offset - 1;
   }
 

--- a/packages/flutter/lib/src/rendering/table.dart
+++ b/packages/flutter/lib/src/rendering/table.dart
@@ -113,6 +113,9 @@ class IntrinsicColumnWidth extends TableColumnWidth {
 
   @override
   double flex(Iterable<RenderBox> cells) => _flex;
+
+  @override
+  String toString() => '$runtimeType(flex: ${_flex?.toStringAsFixed(1)})';
 }
 
 /// Sizes the column to a specific number of pixels.

--- a/packages/flutter/lib/src/widgets/text.dart
+++ b/packages/flutter/lib/src/widgets/text.dart
@@ -144,6 +144,10 @@ class DefaultTextStyle extends InheritedWidget {
   void debugFillProperties(DiagnosticPropertiesBuilder description) {
     super.debugFillProperties(description);
     style?.debugFillProperties(description);
+    description.add(new EnumProperty<TextAlign>('textAlign', textAlign, defaultValue: null));
+    description.add(new FlagProperty('softWrap', value: softWrap, ifTrue: 'wrapping at box width', ifFalse: 'no wrapping except at line break characters', showName: true));
+    description.add(new EnumProperty<TextOverflow>('overflow', overflow, defaultValue: null));
+    description.add(new IntProperty('maxLines', maxLines, defaultValue: null));
   }
 }
 

--- a/packages/flutter/test/material/data_table_test.dart
+++ b/packages/flutter/test/material/data_table_test.dart
@@ -98,4 +98,116 @@ void main() {
     expect(log, <String>['row-selected: KitKat']);
     log.clear();
   });
+
+  testWidgets('DataTable overflow test - header', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      new MaterialApp(
+        home: new Material(
+          child: new DataTable(
+            columns: <DataColumn>[
+              new DataColumn(
+                label: new Text('X' * 2000),
+              ),
+            ],
+            rows: const <DataRow>[
+              const DataRow(
+                cells: const <DataCell>[
+                  const DataCell(
+                    const Text('X'),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+    expect(tester.renderObject<RenderBox>(find.byType(Text).first).size.width, greaterThan(800.0));
+    expect(tester.renderObject<RenderBox>(find.byType(Row).first).size.width, greaterThan(800.0));
+    expect(tester.takeException(), isNull); // column overflows table, but text doesn't overflow cell
+  });
+
+  testWidgets('DataTable overflow test - header with spaces', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      new MaterialApp(
+        home: new Material(
+          child: new DataTable(
+            columns: <DataColumn>[
+              new DataColumn(
+                label: new Text('X ' * 2000), // has soft wrap points, but they should be ignored
+              ),
+            ],
+            rows: const <DataRow>[
+              const DataRow(
+                cells: const <DataCell>[
+                  const DataCell(
+                    const Text('X'),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+    expect(tester.renderObject<RenderBox>(find.byType(Text).first).size.width, greaterThan(800.0));
+    expect(tester.renderObject<RenderBox>(find.byType(Row).first).size.width, greaterThan(800.0));
+    expect(tester.takeException(), isNull); // column overflows table, but text doesn't overflow cell
+  }, skip: true); // https://github.com/flutter/flutter/issues/13512
+
+  testWidgets('DataTable overflow test', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      new MaterialApp(
+        home: new Material(
+          child: new DataTable(
+            columns: const <DataColumn>[
+              const DataColumn(
+                label: const Text('X'),
+              ),
+            ],
+            rows: <DataRow>[
+              new DataRow(
+                cells: <DataCell>[
+                  new DataCell(
+                    new Text('X' * 2000),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+    expect(tester.renderObject<RenderBox>(find.byType(Text).first).size.width, lessThan(800.0));
+    expect(tester.renderObject<RenderBox>(find.byType(Row).first).size.width, greaterThan(800.0));
+    expect(tester.takeException(), isNull); // cell overflows table, but text doesn't overflow cell
+  });
+
+  testWidgets('DataTable overflow test', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      new MaterialApp(
+        home: new Material(
+          child: new DataTable(
+            columns: const <DataColumn>[
+              const DataColumn(
+                label: const Text('X'),
+              ),
+            ],
+            rows: <DataRow>[
+              new DataRow(
+                cells: <DataCell>[
+                  new DataCell(
+                    new Text('X ' * 2000), // wraps
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+    expect(tester.renderObject<RenderBox>(find.byType(Text).first).size.width, lessThan(800.0));
+    expect(tester.renderObject<RenderBox>(find.byType(Row).first).size.width, lessThan(800.0));
+    expect(tester.takeException(), isNull);
+  });
 }

--- a/packages/flutter/test/rendering/table_test.dart
+++ b/packages/flutter/test/rendering/table_test.dart
@@ -82,7 +82,7 @@ void main() {
         ' │ parentData: offset=Offset(335.0, 185.0) (can use size)\n'
         ' │ constraints: BoxConstraints(0.0<=w<=800.0, 0.0<=h<=600.0)\n'
         ' │ size: Size(130.0, 230.0)\n'
-        ' │ default column width: IntrinsicColumnWidth\n'
+        ' │ default column width: IntrinsicColumnWidth(flex: null)\n'
         ' │ table size: 5×5\n'
         ' │ column offsets: 0.0, 10.0, 30.0, 130.0, 130.0\n'
         ' │ row offsets: 0.0, 30.0, 30.0, 30.0, 30.0, 230.0\n'


### PR DESCRIPTION
Prevent header from thinking it can wrap and then overflowing.

Fix default footer string which lost its colon (localized values are fine).

Make the "rows per page" drop-down include at least one value even when the table lacks many items. (Previously it would assert if your table was too short.)

Make the footer scrollable.

Fix some todos and improve some debug output.

Tests for much of the above.

Fixes https://github.com/flutter/flutter/issues/5011.

(This is not on our priority list but I had a branch with fixes for DataTable as a result of fixing the TableBorder regression recently so I figured I should polish it off and submit it.)