### PR TITLE
Simplify project template

### DIFF
--- a/packages/flutter_tools/gradle/flutter.gradle
+++ b/packages/flutter_tools/gradle/flutter.gradle
@@ -74,6 +74,9 @@ class FlutterPlugin implements Plugin<Project> {
         project.android.buildTypes {
             profile {
                 initWith debug
+                if (it.hasProperty('matchingFallbacks')) {
+                    matchingFallbacks = ['debug', 'release']
+                }
             }
         }
 

--- a/packages/flutter_tools/templates/create/android-java.tmpl/app/build.gradle.tmpl
+++ b/packages/flutter_tools/templates/create/android-java.tmpl/app/build.gradle.tmpl
@@ -38,9 +38,6 @@ android {
             // Signing with the debug keys for now, so `flutter run --release` works.
             signingConfig signingConfigs.debug
         }
-        profile {
-            matchingFallbacks = ['debug', 'release']
-        }
     }
 }
 

--- a/packages/flutter_tools/templates/create/android-kotlin.tmpl/app/build.gradle.tmpl
+++ b/packages/flutter_tools/templates/create/android-kotlin.tmpl/app/build.gradle.tmpl
@@ -43,9 +43,6 @@ android {
             // Signing with the debug keys for now, so `flutter run --release` works.
             signingConfig signingConfigs.debug
         }
-        profile {
-            matchingFallbacks = ['debug', 'release']
-        }
     }
 }
 


### PR DESCRIPTION
Relieve Android project templates of config that can be done in `flutter.gradle`.