### PR TITLE
Apply T, L, R media padding in Cupertino nav bar

### DIFF
--- a/packages/flutter/lib/src/cupertino/nav_bar.dart
+++ b/packages/flutter/lib/src/cupertino/nav_bar.dart
@@ -395,15 +395,13 @@ class _CupertinoPersistentNavigationBar extends StatelessWidget implements Prefe
           color: actionsForegroundColor,
           size: 22.0,
         ),
-        child: new Padding(
-          padding: new EdgeInsetsDirectional.only(
-            top: MediaQuery.of(context).padding.top,
-            start: useBackButton ? _kNavBarBackButtonPadding : _kNavBarEdgePadding,
-            end: _kNavBarEdgePadding,
-          ),
-          child: new MediaQuery.removePadding(
-            context: context,
-            removeTop: true,
+        child: new SafeArea(
+          bottom: false,
+          child: new Padding(
+            padding: new EdgeInsetsDirectional.only(
+              start: useBackButton ? _kNavBarBackButtonPadding : _kNavBarEdgePadding,
+              end: _kNavBarEdgePadding,
+            ),
             child: new NavigationToolbar(
               leading: styledLeading ?? backOrCloseButton,
               middle: animatedStyledMiddle,

--- a/packages/flutter/test/cupertino/nav_bar_test.dart
+++ b/packages/flutter/test/cupertino/nav_bar_test.dart
@@ -118,7 +118,9 @@ void main() {
 
   testWidgets('Media padding is applied to CupertinoSliverNavigationBar', (WidgetTester tester) async {
     final ScrollController scrollController = new ScrollController();
+    final Key leadingKey = new GlobalKey();
     final Key middleKey = new GlobalKey();
+    final Key trailingKey = new GlobalKey();
     final Key titleKey = new GlobalKey();
     await tester.pumpWidget(
       new WidgetsApp(
@@ -141,8 +143,10 @@ void main() {
                     controller: scrollController,
                     slivers: <Widget>[
                       new CupertinoSliverNavigationBar(
-                        middle: new Text('Not-large Title', key: middleKey),
+                        leading: new Placeholder(key: leadingKey),
+                        middle: new Placeholder(key: middleKey),
                         largeTitle: new Text('Large Title', key: titleKey),
+                        trailing: new Placeholder(key: trailingKey),
                       ),
                       new SliverToBoxAdapter(
                         child: new Container(
@@ -159,8 +163,10 @@ void main() {
       ),
     );
 
-    // Top padding is applied to middle.
-    expect(tester.getTopLeft(find.byKey(middleKey)), const Offset(277.5, 13.5 + 10.0));
+    // Media padding applied to leading (T,L), middle (T), trailing (T, R).
+    expect(tester.getTopLeft(find.byKey(leadingKey)), const Offset(16.0 + 20.0, 10.0));
+    expect(tester.getRect(find.byKey(middleKey)).top, 10.0);
+    expect(tester.getTopRight(find.byKey(trailingKey)), const Offset(800.0 - 16.0 - 40.0, 10.0));
 
     // Top and left padding is applied to large title.
     expect(tester.getTopLeft(find.byKey(titleKey)), const Offset(16.0 + 20.0, 58.0 + 10.0));


### PR DESCRIPTION
Applies top, left, right media padding for iOS safe area insets. This is
a follow-up to the media padding applied to large titles in
flutter/flutter#13550.