### PR TITLE
Center Shrine demo title with centerTitle

### DIFF
--- a/examples/flutter_gallery/lib/demo/shrine/shrine_page.dart
+++ b/examples/flutter_gallery/lib/demo/shrine/shrine_page.dart
@@ -101,9 +101,8 @@ class ShrinePageState extends State<ShrinePage> {
             )
           )
         ),
-        title: new Center(
-          child: new Text('SHRINE', style: ShrineTheme.of(context).appBarTitleStyle)
-        ),
+        title: new Text('SHRINE', style: ShrineTheme.of(context).appBarTitleStyle),
+        centerTitle: true,
         actions: <Widget>[
           new IconButton(
             icon: const Icon(Icons.shopping_cart),


### PR DESCRIPTION
Rather than use a Center widget, center the title using AppBar's
centerTitle property. This ensures the title is horizontally centred
with respect to the screen rather than centred in the space between the
leading and trailing app bar widgets, which are asymmetrical in Shrine.