### PR TITLE
Provide a navigatorKey property on MaterialApp and WidgetsApp

### DIFF
--- a/packages/flutter/test/material/app_test.dart
+++ b/packages/flutter/test/material/app_test.dart
@@ -317,4 +317,25 @@ void main() {
     expect(textScaleFactor, isNotNull);
     expect(textScaleFactor, equals(1.0));
   });
+
+  testWidgets('MaterialApp.navigatorKey', (WidgetTester tester) async {
+    final GlobalKey<NavigatorState> key = new GlobalKey<NavigatorState>();
+    await tester.pumpWidget(new MaterialApp(
+      navigatorKey: key,
+      color: const Color(0xFF112233),
+      home: const Placeholder(),
+    ));
+    expect(key.currentState, const isInstanceOf<NavigatorState>());
+    await tester.pumpWidget(new MaterialApp(
+      color: const Color(0xFF112233),
+      home: const Placeholder(),
+    ));
+    expect(key.currentState, isNull);
+    await tester.pumpWidget(new MaterialApp(
+      navigatorKey: key,
+      color: const Color(0xFF112233),
+      home: const Placeholder(),
+    ));
+    expect(key.currentState, const isInstanceOf<NavigatorState>());
+  });
 }

--- a/packages/flutter/test/widgets/app_navigator_key_test.dart
+++ b/packages/flutter/test/widgets/app_navigator_key_test.dart
@@ -1,0 +1,36 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter/widgets.dart';
+
+final RouteFactory generateRoute = (RouteSettings settings) => new PageRouteBuilder<Null>(
+  settings: settings,
+  pageBuilder: (BuildContext context, Animation<double> animation1, Animation<double> animation2) {
+    return const Placeholder();
+  },
+);
+
+void main() {
+  testWidgets('WidgetsApp.navigatorKey', (WidgetTester tester) async {
+    final GlobalKey<NavigatorState> key = new GlobalKey<NavigatorState>();
+    await tester.pumpWidget(new WidgetsApp(
+      navigatorKey: key,
+      color: const Color(0xFF112233),
+      onGenerateRoute: generateRoute,
+    ));
+    expect(key.currentState, const isInstanceOf<NavigatorState>());
+    await tester.pumpWidget(new WidgetsApp(
+      color: const Color(0xFF112233),
+      onGenerateRoute: generateRoute,
+    ));
+    expect(key.currentState, isNull);
+    await tester.pumpWidget(new WidgetsApp(
+      navigatorKey: key,
+      color: const Color(0xFF112233),
+      onGenerateRoute: generateRoute,
+    ));
+    expect(key.currentState, const isInstanceOf<NavigatorState>());
+  });
+}


### PR DESCRIPTION
This lets people poke at navigators without having to get their BuildContext from a build function or State first.