### PR TITLE
Apply media padding in complex layout benchmark drawer header

### DIFF
--- a/dev/benchmarks/complex_layout/lib/main.dart
+++ b/dev/benchmarks/complex_layout/lib/main.dart
@@ -610,8 +610,12 @@ class GalleryDrawer extends StatelessWidget {
   Widget build(BuildContext context) {
     final ScrollMode currentMode = ComplexLayoutApp.of(context).scrollMode;
     return new Drawer(
+      // Note: for real apps, see the Gallery material Drawer demo. More
+      // typically, a drawer would have a fixed header with a scrolling body
+      // below it.
       child: new ListView(
         key: const PageStorageKey<String>('gallery-drawer'),
+        padding: EdgeInsets.zero,
         children: <Widget>[
           new FancyDrawerHeader(),
           new ListTile(
@@ -664,6 +668,10 @@ class FancyDrawerHeader extends StatelessWidget {
     return new Container(
       color: Colors.purple,
       height: 200.0,
+      child: const SafeArea(
+        bottom: false,
+        child: const Placeholder(),
+      ),
     );
   }
 }


### PR DESCRIPTION
By default BoxScrollView (and hence ListView, which is a subclass)
padding is the media padding along its scroll axis in order to avoid
placing list items within areas where user interaction should be
minimised -- e.g. under the status bar, or in and around the iPhone X
notch in landscape mode.

In cases where a list item should occupy the padding area, developers
should set the ListView padding to EdgeInsets.zero so as not to pick up
the default media padding. For widgets inside the drawer that should
avoid safe areas, developers can add a SafeArea widget.