### PR TITLE
Revert "Require Xcode 9.0 or later for iOS builds (#13608)"

### DIFF
--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -25,7 +25,7 @@ import 'cocoapods.dart';
 import 'code_signing.dart';
 import 'xcodeproj.dart';
 
-const int kXcodeRequiredVersionMajor = 9;
+const int kXcodeRequiredVersionMajor = 8;
 const int kXcodeRequiredVersionMinor = 0;
 
 // The Python `six` module is a dependency for Xcode builds, and installed by

--- a/packages/flutter_tools/test/ios/mac_test.dart
+++ b/packages/flutter_tools/test/ios/mac_test.dart
@@ -187,7 +187,7 @@ void main() {
 
     testUsingContext('xcodeVersionSatisfactory is false when version is less than minimum', () {
       when(mockProcessManager.runSync(<String>['/usr/bin/xcodebuild', '-version']))
-          .thenReturn(new ProcessResult(1, 0, 'Xcode 8.3.3\nBuild version 8E3004b', ''));
+          .thenReturn(new ProcessResult(1, 0, 'Xcode 7.0.1\nBuild version 7A1001', ''));
       expect(xcode.xcodeVersionSatisfactory, isFalse);
     }, overrides: <Type, Generator>{
       ProcessManager: () => mockProcessManager,
@@ -203,7 +203,7 @@ void main() {
 
     testUsingContext('xcodeVersionSatisfactory is true when version meets minimum', () {
       when(mockProcessManager.runSync(<String>['/usr/bin/xcodebuild', '-version']))
-          .thenReturn(new ProcessResult(1, 0, 'Xcode 9.0\nBuild version 9A235', ''));
+          .thenReturn(new ProcessResult(1, 0, 'Xcode 8.3.3\nBuild version 8E3004b', ''));
       expect(xcode.xcodeVersionSatisfactory, isTrue);
     }, overrides: <Type, Generator>{
       ProcessManager: () => mockProcessManager,
@@ -211,7 +211,7 @@ void main() {
 
     testUsingContext('xcodeVersionSatisfactory is true when version exceeds minimum', () {
       when(mockProcessManager.runSync(<String>['/usr/bin/xcodebuild', '-version']))
-          .thenReturn(new ProcessResult(1, 0, 'Xcode 10.0\nBuild version 10A123', ''));
+          .thenReturn(new ProcessResult(1, 0, 'Xcode 9.0\nBuild version 9M137d', ''));
       expect(xcode.xcodeVersionSatisfactory, isTrue);
     }, overrides: <Type, Generator>{
       ProcessManager: () => mockProcessManager,


### PR DESCRIPTION
Our devicelab machines have not yet been upgraded to Xcode 9. Once this
has been done, I'll re-land this.

This reverts commit 0fac5f01a2469b2658a64da139884b337de5f9dd.