### PR TITLE
Require Xcode 9.0 or later for iOS builds (#13608)

### DIFF
--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -25,7 +25,7 @@ import 'cocoapods.dart';
 import 'code_signing.dart';
 import 'xcodeproj.dart';
 
-const int kXcodeRequiredVersionMajor = 8;
+const int kXcodeRequiredVersionMajor = 9;
 const int kXcodeRequiredVersionMinor = 0;
 
 // The Python `six` module is a dependency for Xcode builds, and installed by

--- a/packages/flutter_tools/test/ios/mac_test.dart
+++ b/packages/flutter_tools/test/ios/mac_test.dart
@@ -187,7 +187,7 @@ void main() {
 
     testUsingContext('xcodeVersionSatisfactory is false when version is less than minimum', () {
       when(mockProcessManager.runSync(<String>['/usr/bin/xcodebuild', '-version']))
-          .thenReturn(new ProcessResult(1, 0, 'Xcode 7.0.1\nBuild version 7A1001', ''));
+          .thenReturn(new ProcessResult(1, 0, 'Xcode 8.3.3\nBuild version 8E3004b', ''));
       expect(xcode.xcodeVersionSatisfactory, isFalse);
     }, overrides: <Type, Generator>{
       ProcessManager: () => mockProcessManager,
@@ -203,7 +203,7 @@ void main() {
 
     testUsingContext('xcodeVersionSatisfactory is true when version meets minimum', () {
       when(mockProcessManager.runSync(<String>['/usr/bin/xcodebuild', '-version']))
-          .thenReturn(new ProcessResult(1, 0, 'Xcode 8.3.3\nBuild version 8E3004b', ''));
+          .thenReturn(new ProcessResult(1, 0, 'Xcode 9.0\nBuild version 9A235', ''));
       expect(xcode.xcodeVersionSatisfactory, isTrue);
     }, overrides: <Type, Generator>{
       ProcessManager: () => mockProcessManager,
@@ -211,7 +211,7 @@ void main() {
 
     testUsingContext('xcodeVersionSatisfactory is true when version exceeds minimum', () {
       when(mockProcessManager.runSync(<String>['/usr/bin/xcodebuild', '-version']))
-          .thenReturn(new ProcessResult(1, 0, 'Xcode 9.0\nBuild version 9M137d', ''));
+          .thenReturn(new ProcessResult(1, 0, 'Xcode 10.0\nBuild version 10A123', ''));
       expect(xcode.xcodeVersionSatisfactory, isTrue);
     }, overrides: <Type, Generator>{
       ProcessManager: () => mockProcessManager,


### PR DESCRIPTION
We now require Xcode 9.0, which ships with the iOS 11 SDK, for iOS
builds. This change does not affect the minimum supported iOS deployment
target, which remains iOS 8.

The iOS 11 SDK adds support for safe area insets, which model the status
bar, iPhone X home indicator, and symmetric horizontal insets to avoid
the iPhone X sensor housing when in landscape mode.

This re-lands flutter/flutter#13608 now that the devicelab Macs have
been updated to Xcode 9.