### PR TITLE
Apply media padding to snackbar contents

### DIFF
--- a/packages/flutter/lib/src/material/scaffold.dart
+++ b/packages/flutter/lib/src/material/scaffold.dart
@@ -893,7 +893,7 @@ class ScaffoldState extends State<Scaffold> with TickerProviderStateMixin {
         removeLeftPadding: false,
         removeTopPadding: true,
         removeRightPadding: false,
-        removeBottomPadding: widget.resizeToAvoidBottomPadding,
+        removeBottomPadding: false,
       );
     }
 

--- a/packages/flutter/lib/src/material/snack_bar.dart
+++ b/packages/flutter/lib/src/material/snack_bar.dart
@@ -241,9 +241,12 @@ class SnackBar extends StatelessWidget {
                 data: darkTheme,
                 child: new FadeTransition(
                   opacity: fadeAnimation,
-                  child: new Row(
-                    children: children,
-                    crossAxisAlignment: CrossAxisAlignment.center,
+                  child: new SafeArea(
+                    top: false,
+                    child: new Row(
+                      children: children,
+                      crossAxisAlignment: CrossAxisAlignment.center,
+                    ),
                   ),
                 ),
               ),

--- a/packages/flutter/test/material/snack_bar_test.dart
+++ b/packages/flutter/test/material/snack_bar_test.dart
@@ -298,22 +298,32 @@ void main() {
 
   testWidgets('SnackBar button text alignment', (WidgetTester tester) async {
     await tester.pumpWidget(new MaterialApp(
-      home: new Scaffold(
-        body: new Builder(
-          builder: (BuildContext context) {
-            return new GestureDetector(
-              onTap: () {
-                Scaffold.of(context).showSnackBar(new SnackBar(
-                  content: const Text('I am a snack bar.'),
-                  duration: const Duration(seconds: 2),
-                  action: new SnackBarAction(label: 'ACTION', onPressed: () {})
-                ));
-              },
-              child: const Text('X')
-            );
-          }
-        )
-      )
+      home: new MediaQuery(
+        data: const MediaQueryData(
+          padding: const EdgeInsets.only(
+            left: 10.0,
+            top: 20.0,
+            right: 30.0,
+            bottom: 40.0,
+          ),
+        ),
+        child: new Scaffold(
+          body: new Builder(
+            builder: (BuildContext context) {
+              return new GestureDetector(
+                onTap: () {
+                  Scaffold.of(context).showSnackBar(new SnackBar(
+                    content: const Text('I am a snack bar.'),
+                    duration: const Duration(seconds: 2),
+                    action: new SnackBarAction(label: 'ACTION', onPressed: () {})
+                  ));
+                },
+                child: const Text('X')
+              );
+            }
+          ),
+        ),
+      ),
     ));
     await tester.tap(find.text('X'));
     await tester.pump(); // start animation
@@ -330,9 +340,11 @@ void main() {
     final Offset snackBarBottomLeft = snackBarBox.localToGlobal(snackBarBox.size.bottomLeft(Offset.zero));
     final Offset snackBarBottomRight = snackBarBox.localToGlobal(snackBarBox.size.bottomRight(Offset.zero));
 
-    expect(textBottomLeft.dx - snackBarBottomLeft.dx, 24.0);
+    expect(textBottomLeft.dx - snackBarBottomLeft.dx, 24.0 + 10.0); // margin + left padding
+    expect(snackBarBottomLeft.dy - textBottomLeft.dy, 14.0 + 40.0); // margin + bottom padding
     expect(actionTextBottomLeft.dx - textBottomRight.dx, 24.0);
-    expect(snackBarBottomRight.dx - actionTextBottomRight.dx, 24.0);
+    expect(snackBarBottomRight.dx - actionTextBottomRight.dx, 24.0 + 30.0); // margin + right padding
+    expect(snackBarBottomRight.dy - actionTextBottomRight.dy, 14.0 + 40.0); // margin + bottom padding
   });
 
   testWidgets('SnackBarClosedReason', (WidgetTester tester) async {


### PR DESCRIPTION
Applies any additional bottom, left, and right media padding inside the
snackbar, if present. This accounts for the iPhone X home indicator
widget and horizontal padding for the sensor housing notch in landscape
orientation.

Fixes #13595