### PR TITLE
Use idevice_id for devicelab iOS device listing

### DIFF
--- a/dev/devicelab/lib/framework/adb.dart
+++ b/dev/devicelab/lib/framework/adb.dart
@@ -307,27 +307,12 @@ class IosDeviceDiscovery implements DeviceDiscovery {
     _workingDevice = allDevices[new math.Random().nextInt(allDevices.length)];
   }
 
-  // Physical device line format to be matched:
-  // My iPhone (10.3.2) [75b90e947c5f429fa67f3e9169fda0d89f0492f1]
-  //
-  // Other formats in output (desktop, simulator) to be ignored:
-  // my-mac-pro [2C10513E-4dA5-405C-8EF5-C44353DB3ADD]
-  // iPhone 6s (9.3) [F6CEE7CF-81EB-4448-81B4-1755288C7C11] (Simulator)
-  static final RegExp _deviceRegex = new RegExp(r'^.* +\(.*\) +\[(.*)\]$');
-
   @override
   Future<List<String>> discoverDevices() async {
-    final List<String> iosDeviceIDs = <String>[];
-    final Iterable<String> deviceLines = (await eval('instruments', <String>['-s', 'devices']))
-        .split('\n')
-        .map((String line) => line.trim());
-    for (String line in deviceLines) {
-      final Match match = _deviceRegex.firstMatch(line);
-      if (match != null) {
-        final String deviceID = match.group(1);
-        iosDeviceIDs.add(deviceID);
-      }
-    }
+    // TODO(yjbanov): use the -k UniqueDeviceID option, which requires much less parsing.
+    final List<String> iosDeviceIDs = grep('UniqueDeviceID', from: await eval('ideviceinfo', <String>[]))
+      .map((String line) => line.split(' ').last).toList();
+
     if (iosDeviceIDs.isEmpty)
       throw 'No connected iOS devices found.';
 


### PR DESCRIPTION
This patch migrates iOS device listing from using Xcode instruments to
using the libimobiledevice tools idevice_id and ideviceinfo.

ideviceinfo was previously incompatible with iOS 11 physical devices;
this has now been fixed.

In 58fe8237d2ec012ea51a673bc228f6545af8bb3c flutter_tools migrated from
libimobiledevice-based device listing on iOS to using Xcode instruments
to work around the lack of support for iOS 11. Using instruments entails
several downsides, including a significantly higher performance hit, and
leaking hung DTServiceHub processes in certain cases when a simulator is
running, necessitating workarounds in which we watched for, and cleaned
up leaked DTServiceHub processes. This patch returns reverts the move to
instruments now that it's no longer necessary.

This reverts commit 58fe8237d2ec012ea51a673bc228f6545af8bb3c.