### PR TITLE
Apply media padding to Contacts demo

### DIFF
--- a/examples/flutter_gallery/lib/demo/contacts_demo.dart
+++ b/examples/flutter_gallery/lib/demo/contacts_demo.dart
@@ -20,18 +20,22 @@ class _ContactCategory extends StatelessWidget {
       ),
       child: new DefaultTextStyle(
         style: Theme.of(context).textTheme.subhead,
-        child: new Row(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: <Widget>[
-            new Container(
-              padding: const EdgeInsets.symmetric(vertical: 24.0),
-              width: 72.0,
-              child: new Icon(icon, color: themeData.primaryColor)
-            ),
-            new Expanded(child: new Column(children: children))
-          ]
-        )
-      )
+        child: new SafeArea(
+          top: false,
+          bottom: false,
+          child: new Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: <Widget>[
+              new Container(
+                padding: const EdgeInsets.symmetric(vertical: 24.0),
+                width: 72.0,
+                child: new Icon(icon, color: themeData.primaryColor)
+              ),
+              new Expanded(child: new Column(children: children))
+            ],
+          ),
+        ),
+      ),
     );
   }
 }


### PR DESCRIPTION
Applies horizontal safe area insets to the Contacts demo in the Gallery.
This is to support the iPhone X sensor housing notch and other similarly
creative display features when in landscape orientation.