### PR TITLE
Gen localization classes intead of a big map

### DIFF
--- a/dev/tools/gen_localizations.dart
+++ b/dev/tools/gen_localizations.dart
@@ -272,12 +272,12 @@ void main(List<String> rawArgs) {
   final String regenerate = 'dart dev/tools/gen_localizations.dart --overwrite';
   final StringBuffer buffer = new StringBuffer();
   buffer.writeln(outputHeader.replaceFirst('@(regenerate)', regenerate));
-  buffer.writeln(generateTranslationBundles());
+  buffer.write(generateTranslationBundles());
 
   if (options.writeToFile) {
     final File localizationsFile = new File(pathlib.join(directory.path, 'localizations.dart'));
-    localizationsFile.writeAsStringSync('$buffer');
+    localizationsFile.writeAsStringSync(buffer.toString());
   } else {
-    print(buffer);
+    stdout.write(buffer.toString());
   }
 }

--- a/dev/tools/gen_localizations.dart
+++ b/dev/tools/gen_localizations.dart
@@ -91,28 +91,139 @@ String generateString(String s) {
   return output.toString();
 }
 
-String generateLocalizationsMap() {
+String generateTranslationBundles() {
   final StringBuffer output = new StringBuffer();
 
-  output.writeln('''
-/// Maps from [Locale.languageCode] to a map that contains the localized strings
-/// for that locale.
-///
-/// This variable is used by [MaterialLocalizations].
-const Map<String, Map<String, String>> localizations = const <String, Map<String, String>> {''');
-
-  for (String locale in localeToResources.keys.toList()..sort()) {
-    output.writeln("  '$locale': const <String, String>{");
-
-    final Map<String, String> resources = localeToResources[locale];
-    for (String name in resources.keys) {
-      final String value = generateString(resources[name]);
-      output.writeln("    '$name': $value,");
-    }
-    output.writeln('  },');
+  final Map<String, List<String>> languageToLocales = <String, List<String>>{};
+  final Set<String> allResourceIdentifiers = new Set<String>();
+  for(String locale in localeToResources.keys) {
+    final List<String> codes = locale.split('_'); // [language, country]
+    assert(codes.length == 1 || codes.length == 2);
+    languageToLocales[codes[0]] ??= <String>[];
+    languageToLocales[codes[0]].add(locale);
+    allResourceIdentifiers.addAll(localeToResources[locale].keys);
   }
 
-  output.writeln('};');
+  // Generate the TranslationsBundle base class. It contains one getter
+  // per resource identifier found in any of the .arb files.
+  //
+  // class TranslationsBundle {
+  //   const TranslationsBundle(this.parent);
+  //   final TranslationsBundle parent;
+  //   String get scriptCategory => parent?.scriptCategory;
+  //   ...
+  // }
+  output.writeln('''
+// The TranslationBundle subclasses defined here encode all of the translations
+// found in the flutter_localizations/lib/src/l10n/*.arb files.
+//
+// The [MaterialLocalizations] class uses the (generated)
+// translationBundleForLocale() function to look up a const TranslationBundle
+// instance for a locale.
+
+import \'dart:ui\' show Locale;
+
+class TranslationBundle {
+  const TranslationBundle(this.parent);
+  final TranslationBundle parent;''');
+  for (String key in allResourceIdentifiers)
+    output.writeln('  String get $key => parent?.$key;');
+  output.writeln('''
+}''');
+
+  // Generate one private TranslationBundle subclass per supported
+  // language. Each of these classes overrides every resource identifier
+  // getter. For example:
+  //
+  // class _Bundle_en extends TranslationBundle {
+  //   const _Bundle_en() : super(null);
+  //   @override String get scriptCategory => r'English-like';
+  //   ...
+  // }
+  for(String language in languageToLocales.keys) {
+    final Map<String, String> resources = localeToResources[language];
+    output.writeln('''
+
+// ignore: camel_case_types
+class _Bundle_$language extends TranslationBundle {
+  const _Bundle_$language() : super(null);''');
+    for (String key in resources.keys) {
+      final String value = generateString(resources[key]);
+      output.writeln('''
+  @override String get $key => $value;''');
+    }
+   output.writeln('''
+}''');
+  }
+
+  // Generate one private TranslationBundle subclass for each locale
+  // with a country code. The parent of these subclasses is a const
+  // instance of a translation bundle for the same locale, but without
+  // a country code. These subclasses only override getters that
+  // return different value than the parent class, or a resource identifier
+  // that's not defined in the parent class. For example:
+  //
+  // class _Bundle_en_CA extends TranslationBundle {
+  //   const _Bundle_en_CA() : super(const _Bundle_en());
+  //   @override String get licensesPageTitle => r'Licences';
+  //   ...
+  // }
+  for(String language in languageToLocales.keys) {
+    final Map<String, String> languageResources = localeToResources[language];
+    for(String localeName in languageToLocales[language]) {
+      if (localeName == language)
+        continue;
+      final Map<String, String> localeResources = localeToResources[localeName];
+      output.writeln('''
+
+// ignore: camel_case_types
+class _Bundle_$localeName extends TranslationBundle {
+  const _Bundle_$localeName() : super(const _Bundle_$language());''');
+      for (String key in localeResources.keys) {
+        if (languageResources[key] == localeResources[key])
+          continue;
+        final String value = generateString(localeResources[key]);
+        output.writeln('''
+  @override String get $key => $value;''');
+      }
+     output.writeln('''
+}''');
+    }
+  }
+
+  // Generate the translationBundleForLocale function. Given a Locale
+  // it returns the corresponding const TranslationBundle.
+  output.writeln('''
+
+TranslationBundle translationBundleForLocale(Locale locale) {
+  switch(locale.languageCode) {''');
+  for(String language in languageToLocales.keys) {
+    if (languageToLocales[language].length == 1) {
+      output.writeln('''
+    case \'$language\':
+      return const _Bundle_${languageToLocales[language][0]}();''');
+    } else {
+      output.writeln('''
+    case \'$language\': {
+      switch(locale.toString()) {''');
+      for(String localeName in languageToLocales[language]) {
+        if (localeName == language)
+          continue;
+        output.writeln('''
+        case \'$localeName\':
+          return const _Bundle_$localeName();''');
+      }
+      output.writeln('''
+      }
+      return const _Bundle_$language();
+    }''');
+    }
+  }
+  output.writeln('''
+  }
+  return const TranslationBundle(null);
+}''');
+
   return output.toString();
 }
 
@@ -161,7 +272,7 @@ void main(List<String> rawArgs) {
   final String regenerate = 'dart dev/tools/gen_localizations.dart --overwrite';
   final StringBuffer buffer = new StringBuffer();
   buffer.writeln(outputHeader.replaceFirst('@(regenerate)', regenerate));
-  buffer.writeln(generateLocalizationsMap());
+  buffer.writeln(generateTranslationBundles());
 
   if (options.writeToFile) {
     final File localizationsFile = new File(pathlib.join(directory.path, 'localizations.dart'));

--- a/dev/tools/gen_localizations.dart
+++ b/dev/tools/gen_localizations.dart
@@ -96,7 +96,7 @@ String generateTranslationBundles() {
 
   final Map<String, List<String>> languageToLocales = <String, List<String>>{};
   final Set<String> allResourceIdentifiers = new Set<String>();
-  for(String locale in localeToResources.keys) {
+  for(String locale in localeToResources.keys.toList()..sort()) {
     final List<String> codes = locale.split('_'); // [language, country]
     assert(codes.length == 1 || codes.length == 2);
     languageToLocales[codes[0]] ??= <String>[];

--- a/packages/flutter_localizations/lib/src/l10n/localizations.dart
+++ b/packages/flutter_localizations/lib/src/l10n/localizations.dart
@@ -6,1738 +6,1397 @@
 // To regenerate the file, use:
 // dart dev/tools/gen_localizations.dart --overwrite
 
-/// Maps from [Locale.languageCode] to a map that contains the localized strings
-/// for that locale.
-///
-/// This variable is used by [MaterialLocalizations].
-const Map<String, Map<String, String>> localizations = const <String, Map<String, String>> {
-  'ar': const <String, String>{
-    'selectedRowCountTitleOne': r'تم اختيار عنصر واحد',
-    'selectedRowCountTitleZero': r'لم يتم اختيار أي عنصر',
-    'selectedRowCountTitleTwo': r'تم اختيار عنصرين ($selectedRowCount)',
-    'selectedRowCountTitleFew': r'تم اختيار $selectedRowCount عنصر',
-    'selectedRowCountTitleMany': r'تم اختيار $selectedRowCount عنصرًا',
-    'scriptCategory': r'tall',
-    'timeOfDayFormat': r'h:mm a',
-    'openAppDrawerTooltip': r'فتح قائمة التنقل',
-    'backButtonTooltip': r'رجوع',
-    'closeButtonTooltip': r'إغلاق',
-    'deleteButtonTooltip': r'حذف',
-    'nextMonthTooltip': r'الشهر التالي',
-    'previousMonthTooltip': r'الشهر السابق',
-    'nextPageTooltip': r'الصفحة التالية',
-    'previousPageTooltip': r'الصفحة السابقة',
-    'showMenuTooltip': r'عرض القائمة',
-    'aboutListTileTitle': r'حول "$applicationName"',
-    'licensesPageTitle': r'التراخيص',
-    'pageRowsInfoTitle': r'من $firstRow إلى $lastRow من إجمالي $rowCount',
-    'pageRowsInfoTitleApproximate': r'من $firstRow إلى $lastRow من إجمالي $rowCount تقريبًا',
-    'rowsPerPageTitle': r'عدد الصفوف في الصفحة:',
-    'selectedRowCountTitleOther': r'تم اختيار $selectedRowCount عنصر',
-    'cancelButtonLabel': r'إلغاء',
-    'closeButtonLabel': r'إغلاق',
-    'continueButtonLabel': r'متابعة',
-    'copyButtonLabel': r'نسخ',
-    'cutButtonLabel': r'قص',
-    'okButtonLabel': r'حسنًا',
-    'pasteButtonLabel': r'لصق',
-    'selectAllButtonLabel': r'اختيار الكل',
-    'viewLicensesButtonLabel': r'الاطّلاع على التراخيص',
-    'anteMeridiemAbbreviation': r'ص',
-    'postMeridiemAbbreviation': r'م',
-    'timePickerHourModeAnnouncement': r'اختيار الساعات',
-    'timePickerMinuteModeAnnouncement': r'اختيار الدقائق',
-    'modalBarrierDismissLabel': r'تجاهل',
-  },
-  'de': const <String, String>{
-    'scriptCategory': r'English-like',
-    'timeOfDayFormat': r'HH:mm',
-    'openAppDrawerTooltip': r'Navigationsmenü öffnen',
-    'backButtonTooltip': r'Zurück',
-    'closeButtonTooltip': r'Schließen',
-    'deleteButtonTooltip': r'Löschen',
-    'nextMonthTooltip': r'Nächster Monat',
-    'previousMonthTooltip': r'Vorheriger Monat',
-    'nextPageTooltip': r'Nächste Seite',
-    'previousPageTooltip': r'Vorherige Seite',
-    'showMenuTooltip': r'Menü anzeigen',
-    'aboutListTileTitle': r'Über $applicationName',
-    'licensesPageTitle': r'Lizenzen',
-    'pageRowsInfoTitle': r'$firstRow–$lastRow von $rowCount',
-    'pageRowsInfoTitleApproximate': r'$firstRow–$lastRow von etwa $rowCount',
-    'rowsPerPageTitle': r'Zeilen pro Seite:',
-    'selectedRowCountTitleZero': r'Keine Objekte ausgewählt',
-    'selectedRowCountTitleOne': r'1 Element ausgewählt',
-    'selectedRowCountTitleOther': r'$selectedRowCount Elemente ausgewählt',
-    'cancelButtonLabel': r'ABBRECHEN',
-    'closeButtonLabel': r'SCHLIEẞEN',
-    'continueButtonLabel': r'WEITER',
-    'copyButtonLabel': r'KOPIEREN',
-    'cutButtonLabel': r'AUSSCHNEIDEN',
-    'okButtonLabel': r'OK',
-    'pasteButtonLabel': r'EINFÜGEN',
-    'selectAllButtonLabel': r'ALLE AUSWÄHLEN',
-    'viewLicensesButtonLabel': r'LIZENZEN ANZEIGEN',
-    'anteMeridiemAbbreviation': r'VORM.',
-    'postMeridiemAbbreviation': r'NACHM.',
-    'timePickerHourModeAnnouncement': r'Stunden auswählen',
-    'timePickerMinuteModeAnnouncement': r'Minuten auswählen',
-    'modalBarrierDismissLabel': r'Schließen',
-  },
-  'de_CH': const <String, String>{
-    'timePickerMinuteModeAnnouncement': r'Minuten auswählen',
-    'timePickerHourModeAnnouncement': r'Stunden auswählen',
-    'scriptCategory': r'English-like',
-    'timeOfDayFormat': r'HH:mm',
-    'openAppDrawerTooltip': r'Navigationsmenü öffnen',
-    'backButtonTooltip': r'Zurück',
-    'closeButtonTooltip': r'Schliessen',
-    'deleteButtonTooltip': r'Löschen',
-    'nextMonthTooltip': r'Nächster Monat',
-    'previousMonthTooltip': r'Vorheriger Monat',
-    'nextPageTooltip': r'Nächste Seite',
-    'previousPageTooltip': r'Vorherige Seite',
-    'showMenuTooltip': r'Menü anzeigen',
-    'aboutListTileTitle': r'Über $applicationName',
-    'licensesPageTitle': r'Lizenzen',
-    'pageRowsInfoTitle': r'$firstRow–$lastRow von $rowCount',
-    'pageRowsInfoTitleApproximate': r'$firstRow–$lastRow von etwa $rowCount',
-    'rowsPerPageTitle': r'Zeilen pro Seite:',
-    'selectedRowCountTitleOne': r'1 Element ausgewählt',
-    'selectedRowCountTitleOther': r'$selectedRowCount Elemente ausgewählt',
-    'cancelButtonLabel': r'ABBRECHEN',
-    'closeButtonLabel': r'SCHLIEẞEN',
-    'continueButtonLabel': r'WEITER',
-    'copyButtonLabel': r'KOPIEREN',
-    'cutButtonLabel': r'AUSSCHNEIDEN',
-    'okButtonLabel': r'OK',
-    'pasteButtonLabel': r'EINFÜGEN',
-    'selectAllButtonLabel': r'ALLE AUSWÄHLEN',
-    'viewLicensesButtonLabel': r'LIZENZEN ANZEIGEN',
-    'anteMeridiemAbbreviation': r'VORM.',
-    'postMeridiemAbbreviation': r'NACHM.',
-    'modalBarrierDismissLabel': r'Schliessen',
-  },
-  'en': const <String, String>{
-    'scriptCategory': r'English-like',
-    'timeOfDayFormat': r'h:mm a',
-    'openAppDrawerTooltip': r'Open navigation menu',
-    'backButtonTooltip': r'Back',
-    'closeButtonTooltip': r'Close',
-    'deleteButtonTooltip': r'Delete',
-    'nextMonthTooltip': r'Next month',
-    'previousMonthTooltip': r'Previous month',
-    'nextPageTooltip': r'Next page',
-    'previousPageTooltip': r'Previous page',
-    'showMenuTooltip': r'Show menu',
-    'aboutListTileTitle': r'About $applicationName',
-    'licensesPageTitle': r'Licenses',
-    'pageRowsInfoTitle': r'$firstRow–$lastRow of $rowCount',
-    'pageRowsInfoTitleApproximate': r'$firstRow–$lastRow of about $rowCount',
-    'rowsPerPageTitle': r'Rows per page:',
-    'selectedRowCountTitleZero': r'No items selected',
-    'selectedRowCountTitleOne': r'1 item selected',
-    'selectedRowCountTitleOther': r'$selectedRowCount items selected',
-    'cancelButtonLabel': r'CANCEL',
-    'closeButtonLabel': r'CLOSE',
-    'continueButtonLabel': r'CONTINUE',
-    'copyButtonLabel': r'COPY',
-    'cutButtonLabel': r'CUT',
-    'okButtonLabel': r'OK',
-    'pasteButtonLabel': r'PASTE',
-    'selectAllButtonLabel': r'SELECT ALL',
-    'viewLicensesButtonLabel': r'VIEW LICENSES',
-    'anteMeridiemAbbreviation': r'AM',
-    'postMeridiemAbbreviation': r'PM',
-    'timePickerHourModeAnnouncement': r'Select hours',
-    'timePickerMinuteModeAnnouncement': r'Select minutes',
-    'modalBarrierDismissLabel': r'Dismiss',
-  },
-  'en_AU': const <String, String>{
-    'timePickerMinuteModeAnnouncement': r'Select minutes',
-    'timePickerHourModeAnnouncement': r'Select hours',
-    'scriptCategory': r'English-like',
-    'timeOfDayFormat': r'h:mm a',
-    'openAppDrawerTooltip': r'Open navigation menu',
-    'backButtonTooltip': r'Back',
-    'closeButtonTooltip': r'Close',
-    'deleteButtonTooltip': r'Delete',
-    'nextMonthTooltip': r'Next month',
-    'previousMonthTooltip': r'Previous month',
-    'nextPageTooltip': r'Next page',
-    'previousPageTooltip': r'Previous page',
-    'showMenuTooltip': r'Show menu',
-    'aboutListTileTitle': r'About $applicationName',
-    'licensesPageTitle': r'Licences',
-    'pageRowsInfoTitle': r'$firstRow–$lastRow of $rowCount',
-    'pageRowsInfoTitleApproximate': r'$firstRow–$lastRow of about $rowCount',
-    'rowsPerPageTitle': r'Rows per page:',
-    'selectedRowCountTitleOne': r'1 item selected',
-    'selectedRowCountTitleOther': r'$selectedRowCount items selected',
-    'cancelButtonLabel': r'CANCEL',
-    'closeButtonLabel': r'CLOSE',
-    'continueButtonLabel': r'CONTINUE',
-    'copyButtonLabel': r'COPY',
-    'cutButtonLabel': r'CUT',
-    'okButtonLabel': r'OK',
-    'pasteButtonLabel': r'PASTE',
-    'selectAllButtonLabel': r'SELECT ALL',
-    'viewLicensesButtonLabel': r'VIEW LICENCES',
-    'anteMeridiemAbbreviation': r'AM',
-    'postMeridiemAbbreviation': r'PM',
-    'modalBarrierDismissLabel': r'Dismiss',
-  },
-  'en_CA': const <String, String>{
-    'timePickerMinuteModeAnnouncement': r'Select minutes',
-    'timePickerHourModeAnnouncement': r'Select hours',
-    'scriptCategory': r'English-like',
-    'timeOfDayFormat': r'h:mm a',
-    'openAppDrawerTooltip': r'Open navigation menu',
-    'backButtonTooltip': r'Back',
-    'closeButtonTooltip': r'Close',
-    'deleteButtonTooltip': r'Delete',
-    'nextMonthTooltip': r'Next month',
-    'previousMonthTooltip': r'Previous month',
-    'nextPageTooltip': r'Next page',
-    'previousPageTooltip': r'Previous page',
-    'showMenuTooltip': r'Show menu',
-    'aboutListTileTitle': r'About $applicationName',
-    'licensesPageTitle': r'Licences',
-    'pageRowsInfoTitle': r'$firstRow–$lastRow of $rowCount',
-    'pageRowsInfoTitleApproximate': r'$firstRow–$lastRow of about $rowCount',
-    'rowsPerPageTitle': r'Rows per page:',
-    'selectedRowCountTitleOne': r'1 item selected',
-    'selectedRowCountTitleOther': r'$selectedRowCount items selected',
-    'cancelButtonLabel': r'CANCEL',
-    'closeButtonLabel': r'CLOSE',
-    'continueButtonLabel': r'CONTINUE',
-    'copyButtonLabel': r'COPY',
-    'cutButtonLabel': r'CUT',
-    'okButtonLabel': r'OK',
-    'pasteButtonLabel': r'PASTE',
-    'selectAllButtonLabel': r'SELECT ALL',
-    'viewLicensesButtonLabel': r'VIEW LICENCES',
-    'anteMeridiemAbbreviation': r'AM',
-    'postMeridiemAbbreviation': r'PM',
-    'modalBarrierDismissLabel': r'Dismiss',
-  },
-  'en_GB': const <String, String>{
-    'timePickerMinuteModeAnnouncement': r'Select minutes',
-    'timePickerHourModeAnnouncement': r'Select hours',
-    'scriptCategory': r'English-like',
-    'timeOfDayFormat': r'HH:mm',
-    'nextMonthTooltip': r'Next month',
-    'pageRowsInfoTitleApproximate': r'$firstRow–$lastRow of about $rowCount',
-    'copyButtonLabel': r'COPY',
-    'closeButtonTooltip': r'Close',
-    'deleteButtonTooltip': r'Delete',
-    'selectAllButtonLabel': r'SELECT ALL',
-    'viewLicensesButtonLabel': r'VIEW LICENCES',
-    'rowsPerPageTitle': r'Rows per page:',
-    'aboutListTileTitle': r'About $applicationName',
-    'backButtonTooltip': r'Back',
-    'licensesPageTitle': r'Licences',
-    'okButtonLabel': r'OK',
-    'pasteButtonLabel': r'PASTE',
-    'previousMonthTooltip': r'Previous month',
-    'closeButtonLabel': r'CLOSE',
-    'cutButtonLabel': r'CUT',
-    'continueButtonLabel': r'CONTINUE',
-    'nextPageTooltip': r'Next page',
-    'openAppDrawerTooltip': r'Open navigation menu',
-    'previousPageTooltip': r'Previous page',
-    'cancelButtonLabel': r'CANCEL',
-    'pageRowsInfoTitle': r'$firstRow–$lastRow of $rowCount',
-    'selectedRowCountTitleOne': r'1 item selected',
-    'selectedRowCountTitleOther': r'$selectedRowCount items selected',
-    'showMenuTooltip': r'Show menu',
-    'anteMeridiemAbbreviation': r'AM',
-    'postMeridiemAbbreviation': r'PM',
-    'modalBarrierDismissLabel': r'Dismiss',
-  },
-  'en_IE': const <String, String>{
-    'timePickerMinuteModeAnnouncement': r'Select minutes',
-    'timePickerHourModeAnnouncement': r'Select hours',
-    'scriptCategory': r'English-like',
-    'timeOfDayFormat': r'HH:mm',
-    'nextMonthTooltip': r'Next month',
-    'pageRowsInfoTitleApproximate': r'$firstRow–$lastRow of about $rowCount',
-    'copyButtonLabel': r'COPY',
-    'closeButtonTooltip': r'Close',
-    'deleteButtonTooltip': r'Delete',
-    'selectAllButtonLabel': r'SELECT ALL',
-    'viewLicensesButtonLabel': r'VIEW LICENCES',
-    'rowsPerPageTitle': r'Rows per page:',
-    'aboutListTileTitle': r'About $applicationName',
-    'backButtonTooltip': r'Back',
-    'licensesPageTitle': r'Licences',
-    'okButtonLabel': r'OK',
-    'pasteButtonLabel': r'PASTE',
-    'previousMonthTooltip': r'Previous month',
-    'closeButtonLabel': r'CLOSE',
-    'cutButtonLabel': r'CUT',
-    'continueButtonLabel': r'CONTINUE',
-    'nextPageTooltip': r'Next page',
-    'openAppDrawerTooltip': r'Open navigation menu',
-    'previousPageTooltip': r'Previous page',
-    'cancelButtonLabel': r'CANCEL',
-    'pageRowsInfoTitle': r'$firstRow–$lastRow of $rowCount',
-    'selectedRowCountTitleOne': r'1 item selected',
-    'selectedRowCountTitleOther': r'$selectedRowCount items selected',
-    'showMenuTooltip': r'Show menu',
-    'anteMeridiemAbbreviation': r'AM',
-    'postMeridiemAbbreviation': r'PM',
-    'modalBarrierDismissLabel': r'Dismiss',
-  },
-  'en_IN': const <String, String>{
-    'timePickerMinuteModeAnnouncement': r'Select minutes',
-    'timePickerHourModeAnnouncement': r'Select hours',
-    'scriptCategory': r'English-like',
-    'timeOfDayFormat': r'h:mm a',
-    'openAppDrawerTooltip': r'Open navigation menu',
-    'backButtonTooltip': r'Back',
-    'closeButtonTooltip': r'Close',
-    'deleteButtonTooltip': r'Delete',
-    'nextMonthTooltip': r'Next month',
-    'previousMonthTooltip': r'Previous month',
-    'nextPageTooltip': r'Next page',
-    'previousPageTooltip': r'Previous page',
-    'showMenuTooltip': r'Show menu',
-    'aboutListTileTitle': r'About $applicationName',
-    'licensesPageTitle': r'Licences',
-    'pageRowsInfoTitle': r'$firstRow–$lastRow of $rowCount',
-    'pageRowsInfoTitleApproximate': r'$firstRow–$lastRow of about $rowCount',
-    'rowsPerPageTitle': r'Rows per page:',
-    'selectedRowCountTitleOne': r'1 item selected',
-    'selectedRowCountTitleOther': r'$selectedRowCount items selected',
-    'cancelButtonLabel': r'CANCEL',
-    'closeButtonLabel': r'CLOSE',
-    'continueButtonLabel': r'CONTINUE',
-    'copyButtonLabel': r'COPY',
-    'cutButtonLabel': r'CUT',
-    'okButtonLabel': r'OK',
-    'pasteButtonLabel': r'PASTE',
-    'selectAllButtonLabel': r'SELECT ALL',
-    'viewLicensesButtonLabel': r'VIEW LICENCES',
-    'anteMeridiemAbbreviation': r'AM',
-    'postMeridiemAbbreviation': r'PM',
-    'modalBarrierDismissLabel': r'Dismiss',
-  },
-  'en_SG': const <String, String>{
-    'timePickerMinuteModeAnnouncement': r'Select minutes',
-    'timePickerHourModeAnnouncement': r'Select hours',
-    'scriptCategory': r'English-like',
-    'timeOfDayFormat': r'h:mm a',
-    'openAppDrawerTooltip': r'Open navigation menu',
-    'backButtonTooltip': r'Back',
-    'closeButtonTooltip': r'Close',
-    'deleteButtonTooltip': r'Delete',
-    'nextMonthTooltip': r'Next month',
-    'previousMonthTooltip': r'Previous month',
-    'nextPageTooltip': r'Next page',
-    'previousPageTooltip': r'Previous page',
-    'showMenuTooltip': r'Show menu',
-    'aboutListTileTitle': r'About $applicationName',
-    'licensesPageTitle': r'Licences',
-    'pageRowsInfoTitle': r'$firstRow–$lastRow of $rowCount',
-    'pageRowsInfoTitleApproximate': r'$firstRow–$lastRow of about $rowCount',
-    'rowsPerPageTitle': r'Rows per page:',
-    'selectedRowCountTitleOne': r'1 item selected',
-    'selectedRowCountTitleOther': r'$selectedRowCount items selected',
-    'cancelButtonLabel': r'CANCEL',
-    'closeButtonLabel': r'CLOSE',
-    'continueButtonLabel': r'CONTINUE',
-    'copyButtonLabel': r'COPY',
-    'cutButtonLabel': r'CUT',
-    'okButtonLabel': r'OK',
-    'pasteButtonLabel': r'PASTE',
-    'selectAllButtonLabel': r'SELECT ALL',
-    'viewLicensesButtonLabel': r'VIEW LICENCES',
-    'anteMeridiemAbbreviation': r'AM',
-    'postMeridiemAbbreviation': r'PM',
-    'modalBarrierDismissLabel': r'Dismiss',
-  },
-  'en_ZA': const <String, String>{
-    'timePickerMinuteModeAnnouncement': r'Select minutes',
-    'timePickerHourModeAnnouncement': r'Select hours',
-    'scriptCategory': r'English-like',
-    'timeOfDayFormat': r'HH:mm',
-    'nextMonthTooltip': r'Next month',
-    'pageRowsInfoTitleApproximate': r'$firstRow–$lastRow of about $rowCount',
-    'copyButtonLabel': r'COPY',
-    'closeButtonTooltip': r'Close',
-    'deleteButtonTooltip': r'Delete',
-    'selectAllButtonLabel': r'SELECT ALL',
-    'viewLicensesButtonLabel': r'VIEW LICENCES',
-    'rowsPerPageTitle': r'Rows per page:',
-    'aboutListTileTitle': r'About $applicationName',
-    'backButtonTooltip': r'Back',
-    'licensesPageTitle': r'Licences',
-    'okButtonLabel': r'OK',
-    'pasteButtonLabel': r'PASTE',
-    'previousMonthTooltip': r'Previous month',
-    'closeButtonLabel': r'CLOSE',
-    'cutButtonLabel': r'CUT',
-    'continueButtonLabel': r'CONTINUE',
-    'nextPageTooltip': r'Next page',
-    'openAppDrawerTooltip': r'Open navigation menu',
-    'previousPageTooltip': r'Previous page',
-    'cancelButtonLabel': r'CANCEL',
-    'pageRowsInfoTitle': r'$firstRow–$lastRow of $rowCount',
-    'selectedRowCountTitleOne': r'1 item selected',
-    'selectedRowCountTitleOther': r'$selectedRowCount items selected',
-    'showMenuTooltip': r'Show menu',
-    'anteMeridiemAbbreviation': r'AM',
-    'postMeridiemAbbreviation': r'PM',
-    'modalBarrierDismissLabel': r'Dismiss',
-  },
-  'es': const <String, String>{
-    'scriptCategory': r'English-like',
-    'timeOfDayFormat': r'H:mm',
-    'openAppDrawerTooltip': r'Abrir el menú de navegación',
-    'backButtonTooltip': r'Atrás',
-    'closeButtonTooltip': r'Cerrar',
-    'deleteButtonTooltip': r'Eliminar',
-    'nextMonthTooltip': r'Mes siguiente',
-    'previousMonthTooltip': r'Mes anterior',
-    'nextPageTooltip': r'Página siguiente',
-    'previousPageTooltip': r'Página anterior',
-    'showMenuTooltip': r'Mostrar menú',
-    'aboutListTileTitle': r'Sobre $applicationName',
-    'licensesPageTitle': r'Licencias',
-    'pageRowsInfoTitle': r'$firstRow‑$lastRow de $rowCount',
-    'pageRowsInfoTitleApproximate': r'$firstRow‑$lastRow de aproximadamente $rowCount',
-    'rowsPerPageTitle': r'Filas por página:',
-    'selectedRowCountTitleZero': r'No se han seleccionado elementos',
-    'selectedRowCountTitleOne': r'1 elemento seleccionado',
-    'selectedRowCountTitleOther': r'$selectedRowCount elementos seleccionados',
-    'cancelButtonLabel': r'CANCELAR',
-    'closeButtonLabel': r'CERRAR',
-    'continueButtonLabel': r'CONTINUAR',
-    'copyButtonLabel': r'COPIAR',
-    'cutButtonLabel': r'CORTAR',
-    'okButtonLabel': r'ACEPTAR',
-    'pasteButtonLabel': r'PEGAR',
-    'selectAllButtonLabel': r'SELECCIONAR TODO',
-    'viewLicensesButtonLabel': r'VER LICENCIAS',
-    'anteMeridiemAbbreviation': r'A.M.',
-    'postMeridiemAbbreviation': r'P.M.',
-    'timePickerHourModeAnnouncement': r'Seleccionar horas',
-    'timePickerMinuteModeAnnouncement': r'Seleccionar minutos',
-    'modalBarrierDismissLabel': r'Ignorar',
-  },
-  'es_419': const <String, String>{
-    'scriptCategory': r'English-like',
-    'timeOfDayFormat': r'H:mm',
-    'openAppDrawerTooltip': r'Abrir menú de navegación',
-    'backButtonTooltip': r'Atrás',
-    'closeButtonTooltip': r'Cerrar',
-    'deleteButtonTooltip': r'Borrar',
-    'nextMonthTooltip': r'Próximo mes',
-    'previousMonthTooltip': r'Mes anterior',
-    'nextPageTooltip': r'Próxima página',
-    'previousPageTooltip': r'Página anterior',
-    'showMenuTooltip': r'Mostrar menú',
-    'aboutListTileTitle': r'Acerca de $applicationName',
-    'licensesPageTitle': r'Licencias',
-    'pageRowsInfoTitle': r'$firstRow–$lastRow de $rowCount',
-    'pageRowsInfoTitleApproximate': r'$firstRow–$lastRow de aproximadamente $rowCount',
-    'rowsPerPageTitle': r'Filas por página:',
-    'selectedRowCountTitleOne': r'Se seleccionó 1 elemento',
-    'selectedRowCountTitleOther': r'Se seleccionaron $selectedRowCount elementos',
-    'cancelButtonLabel': r'CANCELAR',
-    'closeButtonLabel': r'CERRAR',
-    'continueButtonLabel': r'CONTINUAR',
-    'copyButtonLabel': r'COPIAR',
-    'cutButtonLabel': r'CORTAR',
-    'okButtonLabel': r'ACEPTAR',
-    'pasteButtonLabel': r'PEGAR',
-    'selectAllButtonLabel': r'SELECCIONAR TODO',
-    'viewLicensesButtonLabel': r'VER LICENCIAS',
-    'anteMeridiemAbbreviation': r'a.m.',
-    'postMeridiemAbbreviation': r'p.m.',
-    'timePickerHourModeAnnouncement': r'Seleccionar horas',
-    'timePickerMinuteModeAnnouncement': r'Seleccionar minutos',
-  },
-  'es_AR': const <String, String>{
-    'scriptCategory': r'English-like',
-    'timeOfDayFormat': r'H:mm',
-    'openAppDrawerTooltip': r'Abrir menú de navegación',
-    'backButtonTooltip': r'Atrás',
-    'closeButtonTooltip': r'Cerrar',
-    'deleteButtonTooltip': r'Borrar',
-    'nextMonthTooltip': r'Próximo mes',
-    'previousMonthTooltip': r'Mes anterior',
-    'nextPageTooltip': r'Próxima página',
-    'previousPageTooltip': r'Página anterior',
-    'showMenuTooltip': r'Mostrar menú',
-    'aboutListTileTitle': r'Acerca de $applicationName',
-    'licensesPageTitle': r'Licencias',
-    'pageRowsInfoTitle': r'$firstRow–$lastRow de $rowCount',
-    'pageRowsInfoTitleApproximate': r'$firstRow–$lastRow de aproximadamente $rowCount',
-    'rowsPerPageTitle': r'Filas por página:',
-    'selectedRowCountTitleOne': r'Se seleccionó 1 elemento',
-    'selectedRowCountTitleOther': r'Se seleccionaron $selectedRowCount elementos',
-    'cancelButtonLabel': r'CANCELAR',
-    'closeButtonLabel': r'CERRAR',
-    'continueButtonLabel': r'CONTINUAR',
-    'copyButtonLabel': r'COPIAR',
-    'cutButtonLabel': r'CORTAR',
-    'okButtonLabel': r'ACEPTAR',
-    'pasteButtonLabel': r'PEGAR',
-    'selectAllButtonLabel': r'SELECCIONAR TODO',
-    'viewLicensesButtonLabel': r'VER LICENCIAS',
-    'anteMeridiemAbbreviation': r'a.m.',
-    'postMeridiemAbbreviation': r'p.m.',
-    'timePickerHourModeAnnouncement': r'Seleccionar horas',
-    'timePickerMinuteModeAnnouncement': r'Seleccionar minutos',
-  },
-  'es_BO': const <String, String>{
-    'scriptCategory': r'English-like',
-    'timeOfDayFormat': r'H:mm',
-    'openAppDrawerTooltip': r'Abrir menú de navegación',
-    'backButtonTooltip': r'Atrás',
-    'closeButtonTooltip': r'Cerrar',
-    'deleteButtonTooltip': r'Borrar',
-    'nextMonthTooltip': r'Próximo mes',
-    'previousMonthTooltip': r'Mes anterior',
-    'nextPageTooltip': r'Próxima página',
-    'previousPageTooltip': r'Página anterior',
-    'showMenuTooltip': r'Mostrar menú',
-    'aboutListTileTitle': r'Acerca de $applicationName',
-    'licensesPageTitle': r'Licencias',
-    'pageRowsInfoTitle': r'$firstRow–$lastRow de $rowCount',
-    'pageRowsInfoTitleApproximate': r'$firstRow–$lastRow de aproximadamente $rowCount',
-    'rowsPerPageTitle': r'Filas por página:',
-    'selectedRowCountTitleOne': r'Se seleccionó 1 elemento',
-    'selectedRowCountTitleOther': r'Se seleccionaron $selectedRowCount elementos',
-    'cancelButtonLabel': r'CANCELAR',
-    'closeButtonLabel': r'CERRAR',
-    'continueButtonLabel': r'CONTINUAR',
-    'copyButtonLabel': r'COPIAR',
-    'cutButtonLabel': r'CORTAR',
-    'okButtonLabel': r'ACEPTAR',
-    'pasteButtonLabel': r'PEGAR',
-    'selectAllButtonLabel': r'SELECCIONAR TODO',
-    'viewLicensesButtonLabel': r'VER LICENCIAS',
-    'anteMeridiemAbbreviation': r'a.m.',
-    'postMeridiemAbbreviation': r'p.m.',
-    'timePickerHourModeAnnouncement': r'Seleccionar horas',
-    'timePickerMinuteModeAnnouncement': r'Seleccionar minutos',
-  },
-  'es_CL': const <String, String>{
-    'scriptCategory': r'English-like',
-    'timeOfDayFormat': r'H:mm',
-    'openAppDrawerTooltip': r'Abrir menú de navegación',
-    'backButtonTooltip': r'Atrás',
-    'closeButtonTooltip': r'Cerrar',
-    'deleteButtonTooltip': r'Borrar',
-    'nextMonthTooltip': r'Próximo mes',
-    'previousMonthTooltip': r'Mes anterior',
-    'nextPageTooltip': r'Próxima página',
-    'previousPageTooltip': r'Página anterior',
-    'showMenuTooltip': r'Mostrar menú',
-    'aboutListTileTitle': r'Acerca de $applicationName',
-    'licensesPageTitle': r'Licencias',
-    'pageRowsInfoTitle': r'$firstRow–$lastRow de $rowCount',
-    'pageRowsInfoTitleApproximate': r'$firstRow–$lastRow de aproximadamente $rowCount',
-    'rowsPerPageTitle': r'Filas por página:',
-    'selectedRowCountTitleOne': r'Se seleccionó 1 elemento',
-    'selectedRowCountTitleOther': r'Se seleccionaron $selectedRowCount elementos',
-    'cancelButtonLabel': r'CANCELAR',
-    'closeButtonLabel': r'CERRAR',
-    'continueButtonLabel': r'CONTINUAR',
-    'copyButtonLabel': r'COPIAR',
-    'cutButtonLabel': r'CORTAR',
-    'okButtonLabel': r'ACEPTAR',
-    'pasteButtonLabel': r'PEGAR',
-    'selectAllButtonLabel': r'SELECCIONAR TODO',
-    'viewLicensesButtonLabel': r'VER LICENCIAS',
-    'anteMeridiemAbbreviation': r'a.m.',
-    'postMeridiemAbbreviation': r'p.m.',
-    'timePickerHourModeAnnouncement': r'Seleccionar horas',
-    'timePickerMinuteModeAnnouncement': r'Seleccionar minutos',
-  },
-  'es_CO': const <String, String>{
-    'scriptCategory': r'English-like',
-    'timeOfDayFormat': r'H:mm',
-    'openAppDrawerTooltip': r'Abrir menú de navegación',
-    'backButtonTooltip': r'Atrás',
-    'closeButtonTooltip': r'Cerrar',
-    'deleteButtonTooltip': r'Borrar',
-    'nextMonthTooltip': r'Próximo mes',
-    'previousMonthTooltip': r'Mes anterior',
-    'nextPageTooltip': r'Próxima página',
-    'previousPageTooltip': r'Página anterior',
-    'showMenuTooltip': r'Mostrar menú',
-    'aboutListTileTitle': r'Acerca de $applicationName',
-    'licensesPageTitle': r'Licencias',
-    'pageRowsInfoTitle': r'$firstRow–$lastRow de $rowCount',
-    'pageRowsInfoTitleApproximate': r'$firstRow–$lastRow de aproximadamente $rowCount',
-    'rowsPerPageTitle': r'Filas por página:',
-    'selectedRowCountTitleOne': r'Se seleccionó 1 elemento',
-    'selectedRowCountTitleOther': r'Se seleccionaron $selectedRowCount elementos',
-    'cancelButtonLabel': r'CANCELAR',
-    'closeButtonLabel': r'CERRAR',
-    'continueButtonLabel': r'CONTINUAR',
-    'copyButtonLabel': r'COPIAR',
-    'cutButtonLabel': r'CORTAR',
-    'okButtonLabel': r'ACEPTAR',
-    'pasteButtonLabel': r'PEGAR',
-    'selectAllButtonLabel': r'SELECCIONAR TODO',
-    'viewLicensesButtonLabel': r'VER LICENCIAS',
-    'anteMeridiemAbbreviation': r'a.m.',
-    'postMeridiemAbbreviation': r'p.m.',
-    'timePickerHourModeAnnouncement': r'Seleccionar horas',
-    'timePickerMinuteModeAnnouncement': r'Seleccionar minutos',
-  },
-  'es_CR': const <String, String>{
-    'scriptCategory': r'English-like',
-    'timeOfDayFormat': r'H:mm',
-    'openAppDrawerTooltip': r'Abrir menú de navegación',
-    'backButtonTooltip': r'Atrás',
-    'closeButtonTooltip': r'Cerrar',
-    'deleteButtonTooltip': r'Borrar',
-    'nextMonthTooltip': r'Próximo mes',
-    'previousMonthTooltip': r'Mes anterior',
-    'nextPageTooltip': r'Próxima página',
-    'previousPageTooltip': r'Página anterior',
-    'showMenuTooltip': r'Mostrar menú',
-    'aboutListTileTitle': r'Acerca de $applicationName',
-    'licensesPageTitle': r'Licencias',
-    'pageRowsInfoTitle': r'$firstRow–$lastRow de $rowCount',
-    'pageRowsInfoTitleApproximate': r'$firstRow–$lastRow de aproximadamente $rowCount',
-    'rowsPerPageTitle': r'Filas por página:',
-    'selectedRowCountTitleOne': r'Se seleccionó 1 elemento',
-    'selectedRowCountTitleOther': r'Se seleccionaron $selectedRowCount elementos',
-    'cancelButtonLabel': r'CANCELAR',
-    'closeButtonLabel': r'CERRAR',
-    'continueButtonLabel': r'CONTINUAR',
-    'copyButtonLabel': r'COPIAR',
-    'cutButtonLabel': r'CORTAR',
-    'okButtonLabel': r'ACEPTAR',
-    'pasteButtonLabel': r'PEGAR',
-    'selectAllButtonLabel': r'SELECCIONAR TODO',
-    'viewLicensesButtonLabel': r'VER LICENCIAS',
-    'anteMeridiemAbbreviation': r'a.m.',
-    'postMeridiemAbbreviation': r'p.m.',
-    'timePickerHourModeAnnouncement': r'Seleccionar horas',
-    'timePickerMinuteModeAnnouncement': r'Seleccionar minutos',
-  },
-  'es_DO': const <String, String>{
-    'scriptCategory': r'English-like',
-    'timeOfDayFormat': r'H:mm',
-    'openAppDrawerTooltip': r'Abrir menú de navegación',
-    'backButtonTooltip': r'Atrás',
-    'closeButtonTooltip': r'Cerrar',
-    'deleteButtonTooltip': r'Borrar',
-    'nextMonthTooltip': r'Próximo mes',
-    'previousMonthTooltip': r'Mes anterior',
-    'nextPageTooltip': r'Próxima página',
-    'previousPageTooltip': r'Página anterior',
-    'showMenuTooltip': r'Mostrar menú',
-    'aboutListTileTitle': r'Acerca de $applicationName',
-    'licensesPageTitle': r'Licencias',
-    'pageRowsInfoTitle': r'$firstRow–$lastRow de $rowCount',
-    'pageRowsInfoTitleApproximate': r'$firstRow–$lastRow de aproximadamente $rowCount',
-    'rowsPerPageTitle': r'Filas por página:',
-    'selectedRowCountTitleOne': r'Se seleccionó 1 elemento',
-    'selectedRowCountTitleOther': r'Se seleccionaron $selectedRowCount elementos',
-    'cancelButtonLabel': r'CANCELAR',
-    'closeButtonLabel': r'CERRAR',
-    'continueButtonLabel': r'CONTINUAR',
-    'copyButtonLabel': r'COPIAR',
-    'cutButtonLabel': r'CORTAR',
-    'okButtonLabel': r'ACEPTAR',
-    'pasteButtonLabel': r'PEGAR',
-    'selectAllButtonLabel': r'SELECCIONAR TODO',
-    'viewLicensesButtonLabel': r'VER LICENCIAS',
-    'anteMeridiemAbbreviation': r'a.m.',
-    'postMeridiemAbbreviation': r'p.m.',
-    'timePickerHourModeAnnouncement': r'Seleccionar horas',
-    'timePickerMinuteModeAnnouncement': r'Seleccionar minutos',
-  },
-  'es_EC': const <String, String>{
-    'scriptCategory': r'English-like',
-    'timeOfDayFormat': r'H:mm',
-    'openAppDrawerTooltip': r'Abrir menú de navegación',
-    'backButtonTooltip': r'Atrás',
-    'closeButtonTooltip': r'Cerrar',
-    'deleteButtonTooltip': r'Borrar',
-    'nextMonthTooltip': r'Próximo mes',
-    'previousMonthTooltip': r'Mes anterior',
-    'nextPageTooltip': r'Próxima página',
-    'previousPageTooltip': r'Página anterior',
-    'showMenuTooltip': r'Mostrar menú',
-    'aboutListTileTitle': r'Acerca de $applicationName',
-    'licensesPageTitle': r'Licencias',
-    'pageRowsInfoTitle': r'$firstRow–$lastRow de $rowCount',
-    'pageRowsInfoTitleApproximate': r'$firstRow–$lastRow de aproximadamente $rowCount',
-    'rowsPerPageTitle': r'Filas por página:',
-    'selectedRowCountTitleOne': r'Se seleccionó 1 elemento',
-    'selectedRowCountTitleOther': r'Se seleccionaron $selectedRowCount elementos',
-    'cancelButtonLabel': r'CANCELAR',
-    'closeButtonLabel': r'CERRAR',
-    'continueButtonLabel': r'CONTINUAR',
-    'copyButtonLabel': r'COPIAR',
-    'cutButtonLabel': r'CORTAR',
-    'okButtonLabel': r'ACEPTAR',
-    'pasteButtonLabel': r'PEGAR',
-    'selectAllButtonLabel': r'SELECCIONAR TODO',
-    'viewLicensesButtonLabel': r'VER LICENCIAS',
-    'anteMeridiemAbbreviation': r'a.m.',
-    'postMeridiemAbbreviation': r'p.m.',
-    'timePickerHourModeAnnouncement': r'Seleccionar horas',
-    'timePickerMinuteModeAnnouncement': r'Seleccionar minutos',
-  },
-  'es_GT': const <String, String>{
-    'scriptCategory': r'English-like',
-    'timeOfDayFormat': r'H:mm',
-    'openAppDrawerTooltip': r'Abrir menú de navegación',
-    'backButtonTooltip': r'Atrás',
-    'closeButtonTooltip': r'Cerrar',
-    'deleteButtonTooltip': r'Borrar',
-    'nextMonthTooltip': r'Próximo mes',
-    'previousMonthTooltip': r'Mes anterior',
-    'nextPageTooltip': r'Próxima página',
-    'previousPageTooltip': r'Página anterior',
-    'showMenuTooltip': r'Mostrar menú',
-    'aboutListTileTitle': r'Acerca de $applicationName',
-    'licensesPageTitle': r'Licencias',
-    'pageRowsInfoTitle': r'$firstRow–$lastRow de $rowCount',
-    'pageRowsInfoTitleApproximate': r'$firstRow–$lastRow de aproximadamente $rowCount',
-    'rowsPerPageTitle': r'Filas por página:',
-    'selectedRowCountTitleOne': r'Se seleccionó 1 elemento',
-    'selectedRowCountTitleOther': r'Se seleccionaron $selectedRowCount elementos',
-    'cancelButtonLabel': r'CANCELAR',
-    'closeButtonLabel': r'CERRAR',
-    'continueButtonLabel': r'CONTINUAR',
-    'copyButtonLabel': r'COPIAR',
-    'cutButtonLabel': r'CORTAR',
-    'okButtonLabel': r'ACEPTAR',
-    'pasteButtonLabel': r'PEGAR',
-    'selectAllButtonLabel': r'SELECCIONAR TODO',
-    'viewLicensesButtonLabel': r'VER LICENCIAS',
-    'anteMeridiemAbbreviation': r'a.m.',
-    'postMeridiemAbbreviation': r'p.m.',
-    'timePickerHourModeAnnouncement': r'Seleccionar horas',
-    'timePickerMinuteModeAnnouncement': r'Seleccionar minutos',
-  },
-  'es_HN': const <String, String>{
-    'scriptCategory': r'English-like',
-    'timeOfDayFormat': r'H:mm',
-    'openAppDrawerTooltip': r'Abrir menú de navegación',
-    'backButtonTooltip': r'Atrás',
-    'closeButtonTooltip': r'Cerrar',
-    'deleteButtonTooltip': r'Borrar',
-    'nextMonthTooltip': r'Próximo mes',
-    'previousMonthTooltip': r'Mes anterior',
-    'nextPageTooltip': r'Próxima página',
-    'previousPageTooltip': r'Página anterior',
-    'showMenuTooltip': r'Mostrar menú',
-    'aboutListTileTitle': r'Acerca de $applicationName',
-    'licensesPageTitle': r'Licencias',
-    'pageRowsInfoTitle': r'$firstRow–$lastRow de $rowCount',
-    'pageRowsInfoTitleApproximate': r'$firstRow–$lastRow de aproximadamente $rowCount',
-    'rowsPerPageTitle': r'Filas por página:',
-    'selectedRowCountTitleOne': r'Se seleccionó 1 elemento',
-    'selectedRowCountTitleOther': r'Se seleccionaron $selectedRowCount elementos',
-    'cancelButtonLabel': r'CANCELAR',
-    'closeButtonLabel': r'CERRAR',
-    'continueButtonLabel': r'CONTINUAR',
-    'copyButtonLabel': r'COPIAR',
-    'cutButtonLabel': r'CORTAR',
-    'okButtonLabel': r'ACEPTAR',
-    'pasteButtonLabel': r'PEGAR',
-    'selectAllButtonLabel': r'SELECCIONAR TODO',
-    'viewLicensesButtonLabel': r'VER LICENCIAS',
-    'anteMeridiemAbbreviation': r'a.m.',
-    'postMeridiemAbbreviation': r'p.m.',
-    'timePickerHourModeAnnouncement': r'Seleccionar horas',
-    'timePickerMinuteModeAnnouncement': r'Seleccionar minutos',
-  },
-  'es_MX': const <String, String>{
-    'scriptCategory': r'English-like',
-    'timeOfDayFormat': r'H:mm',
-    'openAppDrawerTooltip': r'Abrir menú de navegación',
-    'backButtonTooltip': r'Atrás',
-    'closeButtonTooltip': r'Cerrar',
-    'deleteButtonTooltip': r'Borrar',
-    'nextMonthTooltip': r'Próximo mes',
-    'previousMonthTooltip': r'Mes anterior',
-    'nextPageTooltip': r'Próxima página',
-    'previousPageTooltip': r'Página anterior',
-    'showMenuTooltip': r'Mostrar menú',
-    'aboutListTileTitle': r'Acerca de $applicationName',
-    'licensesPageTitle': r'Licencias',
-    'pageRowsInfoTitle': r'$firstRow–$lastRow de $rowCount',
-    'pageRowsInfoTitleApproximate': r'$firstRow–$lastRow de aproximadamente $rowCount',
-    'rowsPerPageTitle': r'Filas por página:',
-    'selectedRowCountTitleOne': r'Se seleccionó 1 elemento',
-    'selectedRowCountTitleOther': r'Se seleccionaron $selectedRowCount elementos',
-    'cancelButtonLabel': r'CANCELAR',
-    'closeButtonLabel': r'CERRAR',
-    'continueButtonLabel': r'CONTINUAR',
-    'copyButtonLabel': r'COPIAR',
-    'cutButtonLabel': r'CORTAR',
-    'okButtonLabel': r'ACEPTAR',
-    'pasteButtonLabel': r'PEGAR',
-    'selectAllButtonLabel': r'SELECCIONAR TODO',
-    'viewLicensesButtonLabel': r'VER LICENCIAS',
-    'anteMeridiemAbbreviation': r'a.m.',
-    'postMeridiemAbbreviation': r'p.m.',
-    'timePickerHourModeAnnouncement': r'Seleccionar horas',
-    'timePickerMinuteModeAnnouncement': r'Seleccionar minutos',
-  },
-  'es_NI': const <String, String>{
-    'scriptCategory': r'English-like',
-    'timeOfDayFormat': r'H:mm',
-    'openAppDrawerTooltip': r'Abrir menú de navegación',
-    'backButtonTooltip': r'Atrás',
-    'closeButtonTooltip': r'Cerrar',
-    'deleteButtonTooltip': r'Borrar',
-    'nextMonthTooltip': r'Próximo mes',
-    'previousMonthTooltip': r'Mes anterior',
-    'nextPageTooltip': r'Próxima página',
-    'previousPageTooltip': r'Página anterior',
-    'showMenuTooltip': r'Mostrar menú',
-    'aboutListTileTitle': r'Acerca de $applicationName',
-    'licensesPageTitle': r'Licencias',
-    'pageRowsInfoTitle': r'$firstRow–$lastRow de $rowCount',
-    'pageRowsInfoTitleApproximate': r'$firstRow–$lastRow de aproximadamente $rowCount',
-    'rowsPerPageTitle': r'Filas por página:',
-    'selectedRowCountTitleOne': r'Se seleccionó 1 elemento',
-    'selectedRowCountTitleOther': r'Se seleccionaron $selectedRowCount elementos',
-    'cancelButtonLabel': r'CANCELAR',
-    'closeButtonLabel': r'CERRAR',
-    'continueButtonLabel': r'CONTINUAR',
-    'copyButtonLabel': r'COPIAR',
-    'cutButtonLabel': r'CORTAR',
-    'okButtonLabel': r'ACEPTAR',
-    'pasteButtonLabel': r'PEGAR',
-    'selectAllButtonLabel': r'SELECCIONAR TODO',
-    'viewLicensesButtonLabel': r'VER LICENCIAS',
-    'anteMeridiemAbbreviation': r'a.m.',
-    'postMeridiemAbbreviation': r'p.m.',
-    'timePickerHourModeAnnouncement': r'Seleccionar horas',
-    'timePickerMinuteModeAnnouncement': r'Seleccionar minutos',
-  },
-  'es_PA': const <String, String>{
-    'scriptCategory': r'English-like',
-    'timeOfDayFormat': r'H:mm',
-    'openAppDrawerTooltip': r'Abrir menú de navegación',
-    'backButtonTooltip': r'Atrás',
-    'closeButtonTooltip': r'Cerrar',
-    'deleteButtonTooltip': r'Borrar',
-    'nextMonthTooltip': r'Próximo mes',
-    'previousMonthTooltip': r'Mes anterior',
-    'nextPageTooltip': r'Próxima página',
-    'previousPageTooltip': r'Página anterior',
-    'showMenuTooltip': r'Mostrar menú',
-    'aboutListTileTitle': r'Acerca de $applicationName',
-    'licensesPageTitle': r'Licencias',
-    'pageRowsInfoTitle': r'$firstRow–$lastRow de $rowCount',
-    'pageRowsInfoTitleApproximate': r'$firstRow–$lastRow de aproximadamente $rowCount',
-    'rowsPerPageTitle': r'Filas por página:',
-    'selectedRowCountTitleOne': r'Se seleccionó 1 elemento',
-    'selectedRowCountTitleOther': r'Se seleccionaron $selectedRowCount elementos',
-    'cancelButtonLabel': r'CANCELAR',
-    'closeButtonLabel': r'CERRAR',
-    'continueButtonLabel': r'CONTINUAR',
-    'copyButtonLabel': r'COPIAR',
-    'cutButtonLabel': r'CORTAR',
-    'okButtonLabel': r'ACEPTAR',
-    'pasteButtonLabel': r'PEGAR',
-    'selectAllButtonLabel': r'SELECCIONAR TODO',
-    'viewLicensesButtonLabel': r'VER LICENCIAS',
-    'anteMeridiemAbbreviation': r'a.m.',
-    'postMeridiemAbbreviation': r'p.m.',
-    'timePickerHourModeAnnouncement': r'Seleccionar horas',
-    'timePickerMinuteModeAnnouncement': r'Seleccionar minutos',
-  },
-  'es_PE': const <String, String>{
-    'scriptCategory': r'English-like',
-    'timeOfDayFormat': r'H:mm',
-    'openAppDrawerTooltip': r'Abrir menú de navegación',
-    'backButtonTooltip': r'Atrás',
-    'closeButtonTooltip': r'Cerrar',
-    'deleteButtonTooltip': r'Borrar',
-    'nextMonthTooltip': r'Próximo mes',
-    'previousMonthTooltip': r'Mes anterior',
-    'nextPageTooltip': r'Próxima página',
-    'previousPageTooltip': r'Página anterior',
-    'showMenuTooltip': r'Mostrar menú',
-    'aboutListTileTitle': r'Acerca de $applicationName',
-    'licensesPageTitle': r'Licencias',
-    'pageRowsInfoTitle': r'$firstRow–$lastRow de $rowCount',
-    'pageRowsInfoTitleApproximate': r'$firstRow–$lastRow de aproximadamente $rowCount',
-    'rowsPerPageTitle': r'Filas por página:',
-    'selectedRowCountTitleOne': r'Se seleccionó 1 elemento',
-    'selectedRowCountTitleOther': r'Se seleccionaron $selectedRowCount elementos',
-    'cancelButtonLabel': r'CANCELAR',
-    'closeButtonLabel': r'CERRAR',
-    'continueButtonLabel': r'CONTINUAR',
-    'copyButtonLabel': r'COPIAR',
-    'cutButtonLabel': r'CORTAR',
-    'okButtonLabel': r'ACEPTAR',
-    'pasteButtonLabel': r'PEGAR',
-    'selectAllButtonLabel': r'SELECCIONAR TODO',
-    'viewLicensesButtonLabel': r'VER LICENCIAS',
-    'anteMeridiemAbbreviation': r'a.m.',
-    'postMeridiemAbbreviation': r'p.m.',
-    'timePickerHourModeAnnouncement': r'Seleccionar horas',
-    'timePickerMinuteModeAnnouncement': r'Seleccionar minutos',
-  },
-  'es_PR': const <String, String>{
-    'scriptCategory': r'English-like',
-    'timeOfDayFormat': r'H:mm',
-    'openAppDrawerTooltip': r'Abrir menú de navegación',
-    'backButtonTooltip': r'Atrás',
-    'closeButtonTooltip': r'Cerrar',
-    'deleteButtonTooltip': r'Borrar',
-    'nextMonthTooltip': r'Próximo mes',
-    'previousMonthTooltip': r'Mes anterior',
-    'nextPageTooltip': r'Próxima página',
-    'previousPageTooltip': r'Página anterior',
-    'showMenuTooltip': r'Mostrar menú',
-    'aboutListTileTitle': r'Acerca de $applicationName',
-    'licensesPageTitle': r'Licencias',
-    'pageRowsInfoTitle': r'$firstRow–$lastRow de $rowCount',
-    'pageRowsInfoTitleApproximate': r'$firstRow–$lastRow de aproximadamente $rowCount',
-    'rowsPerPageTitle': r'Filas por página:',
-    'selectedRowCountTitleOne': r'Se seleccionó 1 elemento',
-    'selectedRowCountTitleOther': r'Se seleccionaron $selectedRowCount elementos',
-    'cancelButtonLabel': r'CANCELAR',
-    'closeButtonLabel': r'CERRAR',
-    'continueButtonLabel': r'CONTINUAR',
-    'copyButtonLabel': r'COPIAR',
-    'cutButtonLabel': r'CORTAR',
-    'okButtonLabel': r'ACEPTAR',
-    'pasteButtonLabel': r'PEGAR',
-    'selectAllButtonLabel': r'SELECCIONAR TODO',
-    'viewLicensesButtonLabel': r'VER LICENCIAS',
-    'anteMeridiemAbbreviation': r'a.m.',
-    'postMeridiemAbbreviation': r'p.m.',
-    'timePickerHourModeAnnouncement': r'Seleccionar horas',
-    'timePickerMinuteModeAnnouncement': r'Seleccionar minutos',
-  },
-  'es_PY': const <String, String>{
-    'scriptCategory': r'English-like',
-    'timeOfDayFormat': r'H:mm',
-    'openAppDrawerTooltip': r'Abrir menú de navegación',
-    'backButtonTooltip': r'Atrás',
-    'closeButtonTooltip': r'Cerrar',
-    'deleteButtonTooltip': r'Borrar',
-    'nextMonthTooltip': r'Próximo mes',
-    'previousMonthTooltip': r'Mes anterior',
-    'nextPageTooltip': r'Próxima página',
-    'previousPageTooltip': r'Página anterior',
-    'showMenuTooltip': r'Mostrar menú',
-    'aboutListTileTitle': r'Acerca de $applicationName',
-    'licensesPageTitle': r'Licencias',
-    'pageRowsInfoTitle': r'$firstRow–$lastRow de $rowCount',
-    'pageRowsInfoTitleApproximate': r'$firstRow–$lastRow de aproximadamente $rowCount',
-    'rowsPerPageTitle': r'Filas por página:',
-    'selectedRowCountTitleOne': r'Se seleccionó 1 elemento',
-    'selectedRowCountTitleOther': r'Se seleccionaron $selectedRowCount elementos',
-    'cancelButtonLabel': r'CANCELAR',
-    'closeButtonLabel': r'CERRAR',
-    'continueButtonLabel': r'CONTINUAR',
-    'copyButtonLabel': r'COPIAR',
-    'cutButtonLabel': r'CORTAR',
-    'okButtonLabel': r'ACEPTAR',
-    'pasteButtonLabel': r'PEGAR',
-    'selectAllButtonLabel': r'SELECCIONAR TODO',
-    'viewLicensesButtonLabel': r'VER LICENCIAS',
-    'anteMeridiemAbbreviation': r'a.m.',
-    'postMeridiemAbbreviation': r'p.m.',
-    'timePickerHourModeAnnouncement': r'Seleccionar horas',
-    'timePickerMinuteModeAnnouncement': r'Seleccionar minutos',
-  },
-  'es_SV': const <String, String>{
-    'scriptCategory': r'English-like',
-    'timeOfDayFormat': r'H:mm',
-    'openAppDrawerTooltip': r'Abrir menú de navegación',
-    'backButtonTooltip': r'Atrás',
-    'closeButtonTooltip': r'Cerrar',
-    'deleteButtonTooltip': r'Borrar',
-    'nextMonthTooltip': r'Próximo mes',
-    'previousMonthTooltip': r'Mes anterior',
-    'nextPageTooltip': r'Próxima página',
-    'previousPageTooltip': r'Página anterior',
-    'showMenuTooltip': r'Mostrar menú',
-    'aboutListTileTitle': r'Acerca de $applicationName',
-    'licensesPageTitle': r'Licencias',
-    'pageRowsInfoTitle': r'$firstRow–$lastRow de $rowCount',
-    'pageRowsInfoTitleApproximate': r'$firstRow–$lastRow de aproximadamente $rowCount',
-    'rowsPerPageTitle': r'Filas por página:',
-    'selectedRowCountTitleOne': r'Se seleccionó 1 elemento',
-    'selectedRowCountTitleOther': r'Se seleccionaron $selectedRowCount elementos',
-    'cancelButtonLabel': r'CANCELAR',
-    'closeButtonLabel': r'CERRAR',
-    'continueButtonLabel': r'CONTINUAR',
-    'copyButtonLabel': r'COPIAR',
-    'cutButtonLabel': r'CORTAR',
-    'okButtonLabel': r'ACEPTAR',
-    'pasteButtonLabel': r'PEGAR',
-    'selectAllButtonLabel': r'SELECCIONAR TODO',
-    'viewLicensesButtonLabel': r'VER LICENCIAS',
-    'anteMeridiemAbbreviation': r'a.m.',
-    'postMeridiemAbbreviation': r'p.m.',
-    'timePickerHourModeAnnouncement': r'Seleccionar horas',
-    'timePickerMinuteModeAnnouncement': r'Seleccionar minutos',
-  },
-  'es_US': const <String, String>{
-    'deleteButtonTooltip': r'Borrar',
-    'nextMonthTooltip': r'Próximo mes',
-    'pageRowsInfoTitleApproximate': r'$firstRow–$lastRow de aproximadamente $rowCount',
-    'copyButtonLabel': r'COPIAR',
-    'closeButtonTooltip': r'Cerrar',
-    'selectAllButtonLabel': r'SELECCIONAR TODO',
-    'timePickerMinuteModeAnnouncement': r'Seleccionar minutos',
-    'viewLicensesButtonLabel': r'VER LICENCIAS',
-    'rowsPerPageTitle': r'Filas por página:',
-    'aboutListTileTitle': r'Acerca de $applicationName',
-    'backButtonTooltip': r'Atrás',
-    'licensesPageTitle': r'Licencias',
-    'okButtonLabel': r'ACEPTAR',
-    'pasteButtonLabel': r'PEGAR',
-    'previousMonthTooltip': r'Mes anterior',
-    'closeButtonLabel': r'CERRAR',
-    'cutButtonLabel': r'CORTAR',
-    'continueButtonLabel': r'CONTINUAR',
-    'timePickerHourModeAnnouncement': r'Seleccionar horas',
-    'nextPageTooltip': r'Próxima página',
-    'openAppDrawerTooltip': r'Abrir menú de navegación',
-    'previousPageTooltip': r'Página anterior',
-    'cancelButtonLabel': r'CANCELAR',
-    'pageRowsInfoTitle': r'$firstRow–$lastRow de $rowCount',
-    'selectedRowCountTitleOne': r'Se seleccionó 1 elemento',
-    'selectedRowCountTitleOther': r'Se seleccionaron $selectedRowCount elementos',
-    'showMenuTooltip': r'Mostrar menú',
-    'scriptCategory': r'English-like',
-    'timeOfDayFormat': r'h:mm a',
-    'anteMeridiemAbbreviation': r'a.m.',
-    'postMeridiemAbbreviation': r'p.m.',
-  },
-  'es_UY': const <String, String>{
-    'scriptCategory': r'English-like',
-    'timeOfDayFormat': r'H:mm',
-    'openAppDrawerTooltip': r'Abrir menú de navegación',
-    'backButtonTooltip': r'Atrás',
-    'closeButtonTooltip': r'Cerrar',
-    'deleteButtonTooltip': r'Borrar',
-    'nextMonthTooltip': r'Próximo mes',
-    'previousMonthTooltip': r'Mes anterior',
-    'nextPageTooltip': r'Próxima página',
-    'previousPageTooltip': r'Página anterior',
-    'showMenuTooltip': r'Mostrar menú',
-    'aboutListTileTitle': r'Acerca de $applicationName',
-    'licensesPageTitle': r'Licencias',
-    'pageRowsInfoTitle': r'$firstRow–$lastRow de $rowCount',
-    'pageRowsInfoTitleApproximate': r'$firstRow–$lastRow de aproximadamente $rowCount',
-    'rowsPerPageTitle': r'Filas por página:',
-    'selectedRowCountTitleOne': r'Se seleccionó 1 elemento',
-    'selectedRowCountTitleOther': r'Se seleccionaron $selectedRowCount elementos',
-    'cancelButtonLabel': r'CANCELAR',
-    'closeButtonLabel': r'CERRAR',
-    'continueButtonLabel': r'CONTINUAR',
-    'copyButtonLabel': r'COPIAR',
-    'cutButtonLabel': r'CORTAR',
-    'okButtonLabel': r'ACEPTAR',
-    'pasteButtonLabel': r'PEGAR',
-    'selectAllButtonLabel': r'SELECCIONAR TODO',
-    'viewLicensesButtonLabel': r'VER LICENCIAS',
-    'anteMeridiemAbbreviation': r'a.m.',
-    'postMeridiemAbbreviation': r'p.m.',
-    'timePickerHourModeAnnouncement': r'Seleccionar horas',
-    'timePickerMinuteModeAnnouncement': r'Seleccionar minutos',
-  },
-  'es_VE': const <String, String>{
-    'scriptCategory': r'English-like',
-    'timeOfDayFormat': r'H:mm',
-    'openAppDrawerTooltip': r'Abrir menú de navegación',
-    'backButtonTooltip': r'Atrás',
-    'closeButtonTooltip': r'Cerrar',
-    'deleteButtonTooltip': r'Borrar',
-    'nextMonthTooltip': r'Próximo mes',
-    'previousMonthTooltip': r'Mes anterior',
-    'nextPageTooltip': r'Próxima página',
-    'previousPageTooltip': r'Página anterior',
-    'showMenuTooltip': r'Mostrar menú',
-    'aboutListTileTitle': r'Acerca de $applicationName',
-    'licensesPageTitle': r'Licencias',
-    'pageRowsInfoTitle': r'$firstRow–$lastRow de $rowCount',
-    'pageRowsInfoTitleApproximate': r'$firstRow–$lastRow de aproximadamente $rowCount',
-    'rowsPerPageTitle': r'Filas por página:',
-    'selectedRowCountTitleOne': r'Se seleccionó 1 elemento',
-    'selectedRowCountTitleOther': r'Se seleccionaron $selectedRowCount elementos',
-    'cancelButtonLabel': r'CANCELAR',
-    'closeButtonLabel': r'CERRAR',
-    'continueButtonLabel': r'CONTINUAR',
-    'copyButtonLabel': r'COPIAR',
-    'cutButtonLabel': r'CORTAR',
-    'okButtonLabel': r'ACEPTAR',
-    'pasteButtonLabel': r'PEGAR',
-    'selectAllButtonLabel': r'SELECCIONAR TODO',
-    'viewLicensesButtonLabel': r'VER LICENCIAS',
-    'anteMeridiemAbbreviation': r'a.m.',
-    'postMeridiemAbbreviation': r'p.m.',
-    'timePickerHourModeAnnouncement': r'Seleccionar horas',
-    'timePickerMinuteModeAnnouncement': r'Seleccionar minutos',
-  },
-  'fa': const <String, String>{
-    'scriptCategory': r'tall',
-    'timeOfDayFormat': r'H:mm',
-    'selectedRowCountTitleOne': r'۱ مورد انتخاب شد',
-    'openAppDrawerTooltip': r'باز کردن منوی پیمایش',
-    'backButtonTooltip': r'برگشت',
-    'closeButtonTooltip': r'بستن',
-    'deleteButtonTooltip': r'حذف',
-    'nextMonthTooltip': r'ماه بعد',
-    'previousMonthTooltip': r'ماه قبل',
-    'nextPageTooltip': r'صفحه بعد',
-    'previousPageTooltip': r'صفحه قبل',
-    'showMenuTooltip': r'نمایش منو',
-    'aboutListTileTitle': r'درباره $applicationName',
-    'licensesPageTitle': r'مجوزها',
-    'pageRowsInfoTitle': r'$firstRow–$lastRow از $rowCount',
-    'pageRowsInfoTitleApproximate': r'$firstRow–$lastRow از حدود $rowCount',
-    'rowsPerPageTitle': r'ردیف در هر صفحه:',
-    'selectedRowCountTitleOther': r'$selectedRowCount مورد انتخاب شدند',
-    'cancelButtonLabel': r'لغو',
-    'closeButtonLabel': r'بستن',
-    'continueButtonLabel': r'ادامه',
-    'copyButtonLabel': r'کپی',
-    'cutButtonLabel': r'برش',
-    'okButtonLabel': r'تأیید',
-    'pasteButtonLabel': r'جای‌گذاری',
-    'selectAllButtonLabel': r'انتخاب همه',
-    'viewLicensesButtonLabel': r'مشاهده مجوزها',
-    'anteMeridiemAbbreviation': r'ق.ظ.',
-    'postMeridiemAbbreviation': r'ب.ظ.',
-    'timePickerHourModeAnnouncement': r'انتخاب ساعت',
-    'timePickerMinuteModeAnnouncement': r'انتخاب دقیقه',
-    'modalBarrierDismissLabel': r'رد کردن',
-  },
-  'fr': const <String, String>{
-    'scriptCategory': r'English-like',
-    'timeOfDayFormat': r'HH:mm',
-    'openAppDrawerTooltip': r'Ouvrir le menu de navigation',
-    'backButtonTooltip': r'Retour',
-    'closeButtonTooltip': r'Fermer',
-    'deleteButtonTooltip': r'Supprimer',
-    'nextMonthTooltip': r'Mois suivant',
-    'previousMonthTooltip': r'Mois précédent',
-    'nextPageTooltip': r'Page suivante',
-    'previousPageTooltip': r'Page précédente',
-    'showMenuTooltip': r'Afficher le menu',
-    'aboutListTileTitle': r'À propos de $applicationName',
-    'licensesPageTitle': r'Licences',
-    'pageRowsInfoTitle': r'$firstRow – $lastRow sur $rowCount',
-    'pageRowsInfoTitleApproximate': r'$firstRow – $lastRow sur environ $rowCount',
-    'rowsPerPageTitle': r'Lignes par page :',
-    'selectedRowCountTitleZero': r'Aucun élément sélectionné',
-    'selectedRowCountTitleOne': r'1 élément sélectionné',
-    'selectedRowCountTitleOther': r'$selectedRowCount éléments sélectionnés',
-    'cancelButtonLabel': r'ANNULER',
-    'closeButtonLabel': r'FERMER',
-    'continueButtonLabel': r'CONTINUER',
-    'copyButtonLabel': r'COPIER',
-    'cutButtonLabel': r'COUPER',
-    'okButtonLabel': r'OK',
-    'pasteButtonLabel': r'COLLER',
-    'selectAllButtonLabel': r'TOUT SÉLECTIONNER',
-    'viewLicensesButtonLabel': r'AFFICHER LES LICENCES',
-    'anteMeridiemAbbreviation': r'AM',
-    'postMeridiemAbbreviation': r'PM',
-    'timePickerHourModeAnnouncement': r'Sélectionner une heure',
-    'timePickerMinuteModeAnnouncement': r'Sélectionner des minutes',
-    'modalBarrierDismissLabel': r'Ignorer',
-  },
-  'fr_CA': const <String, String>{
-    'scriptCategory': r'English-like',
-    'timeOfDayFormat': r'HH ' "'" r'h' "'" r' mm',
-  },
-  'gsw': const <String, String>{
-    'timePickerMinuteModeAnnouncement': r'Minuten auswählen',
-    'timePickerHourModeAnnouncement': r'Stunden auswählen',
-    'scriptCategory': r'English-like',
-    'timeOfDayFormat': r'HH:mm',
-    'openAppDrawerTooltip': r'Navigationsmenü öffnen',
-    'backButtonTooltip': r'Zurück',
-    'closeButtonTooltip': r'Schließen',
-    'deleteButtonTooltip': r'Löschen',
-    'nextMonthTooltip': r'Nächster Monat',
-    'previousMonthTooltip': r'Vorheriger Monat',
-    'nextPageTooltip': r'Nächste Seite',
-    'previousPageTooltip': r'Vorherige Seite',
-    'showMenuTooltip': r'Menü anzeigen',
-    'aboutListTileTitle': r'Über $applicationName',
-    'licensesPageTitle': r'Lizenzen',
-    'pageRowsInfoTitle': r'$firstRow–$lastRow von $rowCount',
-    'pageRowsInfoTitleApproximate': r'$firstRow–$lastRow von etwa $rowCount',
-    'rowsPerPageTitle': r'Zeilen pro Seite:',
-    'selectedRowCountTitleOne': r'1 Element ausgewählt',
-    'selectedRowCountTitleOther': r'$selectedRowCount Elemente ausgewählt',
-    'cancelButtonLabel': r'ABBRECHEN',
-    'closeButtonLabel': r'SCHLIEẞEN',
-    'continueButtonLabel': r'WEITER',
-    'copyButtonLabel': r'KOPIEREN',
-    'cutButtonLabel': r'AUSSCHNEIDEN',
-    'okButtonLabel': r'OK',
-    'pasteButtonLabel': r'EINFÜGEN',
-    'selectAllButtonLabel': r'ALLE AUSWÄHLEN',
-    'viewLicensesButtonLabel': r'LIZENZEN ANZEIGEN',
-    'anteMeridiemAbbreviation': r'VORM.',
-    'postMeridiemAbbreviation': r'NACHM.',
-    'modalBarrierDismissLabel': r'Schließen',
-  },
-  'he': const <String, String>{
-    'scriptCategory': r'English-like',
-    'timeOfDayFormat': r'H:mm',
-    'selectedRowCountTitleOne': r'פריט אחד נבחר',
-    'selectedRowCountTitleTwo': r'$selectedRowCount פריטים נבחרו',
-    'selectedRowCountTitleMany': r'$selectedRowCount פריטים נבחרו',
-    'openAppDrawerTooltip': r'פתיחה של תפריט הניווט',
-    'backButtonTooltip': r'הקודם',
-    'closeButtonTooltip': r'סגירה',
-    'deleteButtonTooltip': r'מחיקה',
-    'nextMonthTooltip': r'החודש הבא',
-    'previousMonthTooltip': r'החודש הקודם',
-    'nextPageTooltip': r'הדף הבא',
-    'previousPageTooltip': r'הדף הקודם',
-    'showMenuTooltip': r'הצגת התפריט',
-    'aboutListTileTitle': r'מידע על $applicationName',
-    'licensesPageTitle': r'רישיונות',
-    'pageRowsInfoTitle': r'$lastRow–$firstRow מתוך $rowCount',
-    'pageRowsInfoTitleApproximate': r'$lastRow–$firstRow מתוך כ-$rowCount',
-    'rowsPerPageTitle': r'שורות בכל דף:',
-    'selectedRowCountTitleOther': r'$selectedRowCount פריטים נבחרו',
-    'cancelButtonLabel': r'ביטול',
-    'closeButtonLabel': r'סגירה',
-    'continueButtonLabel': r'המשך',
-    'copyButtonLabel': r'העתקה',
-    'cutButtonLabel': r'גזירה',
-    'okButtonLabel': r'אישור',
-    'pasteButtonLabel': r'הדבקה',
-    'selectAllButtonLabel': r'בחירת הכול',
-    'viewLicensesButtonLabel': r'הצגת הרישיונות',
-    'anteMeridiemAbbreviation': r'AM',
-    'postMeridiemAbbreviation': r'PM',
-    'timePickerHourModeAnnouncement': r'בחירת שעות',
-    'timePickerMinuteModeAnnouncement': r'בחירת דקות',
-    'modalBarrierDismissLabel': r'סגירה',
-  },
-  'it': const <String, String>{
-    'scriptCategory': r'English-like',
-    'timeOfDayFormat': r'HH:mm',
-    'selectedRowCountTitleOne': r'1 elemento selezionato',
-    'openAppDrawerTooltip': r'Apri il menu di navigazione',
-    'backButtonTooltip': r'Indietro',
-    'closeButtonTooltip': r'Chiudi',
-    'deleteButtonTooltip': r'Elimina',
-    'nextMonthTooltip': r'Mese successivo',
-    'previousMonthTooltip': r'Mese precedente',
-    'nextPageTooltip': r'Pagina successiva',
-    'previousPageTooltip': r'Pagina precedente',
-    'showMenuTooltip': r'Mostra il menu',
-    'aboutListTileTitle': r'Informazioni su $applicationName',
-    'licensesPageTitle': r'Licenze',
-    'pageRowsInfoTitle': r'$firstRow-$lastRow di $rowCount',
-    'pageRowsInfoTitleApproximate': r'$firstRow-$lastRow di circa $rowCount',
-    'rowsPerPageTitle': r'Righe per pagina:',
-    'selectedRowCountTitleOther': r'$selectedRowCount elementi selezionati',
-    'cancelButtonLabel': r'ANNULLA',
-    'closeButtonLabel': r'CHIUDI',
-    'continueButtonLabel': r'CONTINUA',
-    'copyButtonLabel': r'COPIA',
-    'cutButtonLabel': r'TAGLIA',
-    'okButtonLabel': r'OK',
-    'pasteButtonLabel': r'INCOLLA',
-    'selectAllButtonLabel': r'SELEZIONA TUTTO',
-    'viewLicensesButtonLabel': r'VISUALIZZA LICENZE',
-    'anteMeridiemAbbreviation': r'AM',
-    'postMeridiemAbbreviation': r'PM',
-    'timePickerHourModeAnnouncement': r'Seleziona le ore',
-    'timePickerMinuteModeAnnouncement': r'Seleziona i minuti',
-    'modalBarrierDismissLabel': r'Ignora',
-  },
-  'ja': const <String, String>{
-    'scriptCategory': r'dense',
-    'timeOfDayFormat': r'H:mm',
-    'selectedRowCountTitleOne': r'1 件のアイテムを選択中',
-    'openAppDrawerTooltip': r'ナビゲーション メニューを開く',
-    'backButtonTooltip': r'戻る',
-    'closeButtonTooltip': r'閉じる',
-    'deleteButtonTooltip': r'削除',
-    'nextMonthTooltip': r'来月',
-    'previousMonthTooltip': r'前月',
-    'nextPageTooltip': r'次のページ',
-    'previousPageTooltip': r'前のページ',
-    'showMenuTooltip': r'メニューを表示',
-    'aboutListTileTitle': r'$applicationName について',
-    'licensesPageTitle': r'ライセンス',
-    'pageRowsInfoTitle': r'$firstRow - $lastRow 行（合計 $rowCount 行）',
-    'pageRowsInfoTitleApproximate': r'$firstRow – $lastRow 行（合計約 $rowCount 行）',
-    'rowsPerPageTitle': r'ページあたりの行数:',
-    'selectedRowCountTitleOther': r'$selectedRowCount 件のアイテムを選択中',
-    'cancelButtonLabel': r'キャンセル',
-    'closeButtonLabel': r'閉じる',
-    'continueButtonLabel': r'続行',
-    'copyButtonLabel': r'コピー',
-    'cutButtonLabel': r'切り取り',
-    'okButtonLabel': r'OK',
-    'pasteButtonLabel': r'貼り付け',
-    'selectAllButtonLabel': r'すべて選択',
-    'viewLicensesButtonLabel': r'ライセンスを表示',
-    'anteMeridiemAbbreviation': r'AM',
-    'postMeridiemAbbreviation': r'PM',
-    'timePickerHourModeAnnouncement': r'時間を選択',
-    'timePickerMinuteModeAnnouncement': r'分を選択',
-    'modalBarrierDismissLabel': r'閉じる',
-  },
-  'ko': const <String, String>{
-    'scriptCategory': r'dense',
-    'timeOfDayFormat': r'a h:mm',
-    'openAppDrawerTooltip': r'탐색 메뉴 열기',
-    'backButtonTooltip': r'뒤로',
-    'closeButtonTooltip': r'닫기',
-    'deleteButtonTooltip': r'삭제',
-    'nextMonthTooltip': r'다음 달',
-    'previousMonthTooltip': r'지난달',
-    'nextPageTooltip': r'다음 페이지',
-    'previousPageTooltip': r'이전 페이지',
-    'showMenuTooltip': r'메뉴 표시',
-    'aboutListTileTitle': r'$applicationName 정보',
-    'licensesPageTitle': r'라이선스',
-    'pageRowsInfoTitle': r'$rowCount행 중 $firstRow~$lastRow행',
-    'pageRowsInfoTitleApproximate': r'약 $rowCount행 중 $firstRow~$lastRow행',
-    'rowsPerPageTitle': r'페이지당 행 수:',
-    'selectedRowCountTitleOne': r'항목 1개 선택됨',
-    'selectedRowCountTitleOther': r'항목 $selectedRowCount개 선택됨',
-    'cancelButtonLabel': r'취소',
-    'closeButtonLabel': r'닫기',
-    'continueButtonLabel': r'계속',
-    'copyButtonLabel': r'복사',
-    'cutButtonLabel': r'잘라내기',
-    'okButtonLabel': r'확인',
-    'pasteButtonLabel': r'붙여넣기',
-    'selectAllButtonLabel': r'전체 선택',
-    'viewLicensesButtonLabel': r'라이선스 보기',
-    'anteMeridiemAbbreviation': r'오전',
-    'postMeridiemAbbreviation': r'오후',
-    'timePickerHourModeAnnouncement': r'시간 선택',
-    'timePickerMinuteModeAnnouncement': r'분 선택',
-    'modalBarrierDismissLabel': r'버리다',
-  },
-  'nl': const <String, String>{
-    'scriptCategory': r'English-like',
-    'timeOfDayFormat': r'HH:mm',
-    'openAppDrawerTooltip': r'Navigatiemenu openen',
-    'backButtonTooltip': r'Terug',
-    'closeButtonTooltip': r'Sluiten',
-    'deleteButtonTooltip': r'Verwijderen',
-    'nextMonthTooltip': r'Volgende maand',
-    'previousMonthTooltip': r'Vorige maand',
-    'nextPageTooltip': r'Volgende pagina',
-    'previousPageTooltip': r'Vorige pagina',
-    'showMenuTooltip': r'Menu weergeven',
-    'aboutListTileTitle': r'Over $applicationName',
-    'licensesPageTitle': r'Licenties',
-    'pageRowsInfoTitle': r'$firstRow-$lastRow van $rowCount',
-    'pageRowsInfoTitleApproximate': r'$firstRow-$lastRow van ongeveer $rowCount',
-    'rowsPerPageTitle': r'Rijen per pagina:',
-    'selectedRowCountTitleOne': r'1 item geselecteerd',
-    'selectedRowCountTitleOther': r'$selectedRowCount items geselecteerd',
-    'cancelButtonLabel': r'ANNULEREN',
-    'closeButtonLabel': r'SLUITEN',
-    'continueButtonLabel': r'DOORGAAN',
-    'copyButtonLabel': r'KOPIËREN',
-    'cutButtonLabel': r'KNIPPEN',
-    'okButtonLabel': r'OK',
-    'pasteButtonLabel': r'PLAKKEN',
-    'selectAllButtonLabel': r'ALLES SELECTEREN',
-    'viewLicensesButtonLabel': r'LICENTIES BEKIJKEN',
-    'anteMeridiemAbbreviation': r'am',
-    'postMeridiemAbbreviation': r'pm',
-    'timePickerHourModeAnnouncement': r'Uren selecteren',
-    'timePickerMinuteModeAnnouncement': r'Minuten selecteren',
-    'modalBarrierDismissLabel': r'ontslaan',
-  },
-  'pl': const <String, String>{
-    'scriptCategory': r'English-like',
-    'timeOfDayFormat': r'HH:mm',
-    'selectedRowCountTitleFew': r'$selectedRowCount wybrane elementy',
-    'selectedRowCountTitleMany': r'$selectedRowCount wybranych elementów',
-    'openAppDrawerTooltip': r'Otwórz menu nawigacyjne',
-    'backButtonTooltip': r'Wstecz',
-    'closeButtonTooltip': r'Zamknij',
-    'deleteButtonTooltip': r'Usuń',
-    'nextMonthTooltip': r'Następny miesiąc',
-    'previousMonthTooltip': r'Poprzedni miesiąc',
-    'nextPageTooltip': r'Następna strona',
-    'previousPageTooltip': r'Poprzednia strona',
-    'showMenuTooltip': r'Pokaż menu',
-    'aboutListTileTitle': r'$applicationName – informacje',
-    'licensesPageTitle': r'Licencje',
-    'pageRowsInfoTitle': r'$firstRow–$lastRow z $rowCount',
-    'pageRowsInfoTitleApproximate': r'$firstRow–$lastRow z około $rowCount',
-    'rowsPerPageTitle': r'Wiersze na stronie:',
-    'selectedRowCountTitleOne': r'1 wybrany element',
-    'selectedRowCountTitleOther': r'$selectedRowCount wybranego elementu',
-    'cancelButtonLabel': r'ANULUJ',
-    'closeButtonLabel': r'ZAMKNIJ',
-    'continueButtonLabel': r'DALEJ',
-    'copyButtonLabel': r'KOPIUJ',
-    'cutButtonLabel': r'WYTNIJ',
-    'okButtonLabel': r'OK',
-    'pasteButtonLabel': r'WKLEJ',
-    'selectAllButtonLabel': r'ZAZNACZ WSZYSTKO',
-    'viewLicensesButtonLabel': r'WYŚWIETL LICENCJE',
-    'anteMeridiemAbbreviation': r'AM',
-    'postMeridiemAbbreviation': r'PM',
-    'timePickerHourModeAnnouncement': r'Wybierz godziny',
-    'timePickerMinuteModeAnnouncement': r'Wybierz minuty',
-    'modalBarrierDismissLabel': r'oddalić',
-  },
-  'ps': const <String, String>{
-    'scriptCategory': r'tall',
-    'timeOfDayFormat': r'HH:mm',
-    'openAppDrawerTooltip': r'د پرانیستی نیینګ مینو',
-    'backButtonTooltip': r'شاته',
-    'closeButtonTooltip': r'بنده',
-    'deleteButtonTooltip': r'',
-    'nextMonthTooltip': r'بله میاشت',
-    'previousMonthTooltip': r'تیره میاشت',
-    'nextPageTooltip': r'بله پاڼه',
-    'previousPageTooltip': r'مخکینی مخ',
-    'showMenuTooltip': r'غورنۍ ښودل',
-    'aboutListTileTitle': r'د $applicationName په اړه',
-    'licensesPageTitle': r'جوازونه',
-    'pageRowsInfoTitle': r'$firstRow–$lastRow د $rowCount',
-    'pageRowsInfoTitleApproximate': r'$firstRow–$lastRow څخه $rowCount د',
-    'rowsPerPageTitle': r'د هرې پاڼې پاڼې:',
-    'selectedRowCountTitleOther': r'$selectedRowCount توکي غوره شوي',
-    'cancelButtonLabel': r'لغوه کول',
-    'closeButtonLabel': r'تړل',
-    'continueButtonLabel': r'منځپانګې',
-    'copyButtonLabel': r'کاپی',
-    'cutButtonLabel': r'کم کړئ',
-    'okButtonLabel': r'سمه ده',
-    'pasteButtonLabel': r'پیټ کړئ',
-    'selectAllButtonLabel': r'غوره کړئ',
-    'viewLicensesButtonLabel': r'لیدلس وګورئ',
-    'timePickerHourModeAnnouncement': r'وختونه وټاکئ',
-    'timePickerMinuteModeAnnouncement': r'منې غوره کړئ',
-    'modalBarrierDismissLabel': r'رد کړه',
-  },
-  'pt': const <String, String>{
-    'anteMeridiemAbbreviation': r'Manhã',
-    'selectedRowCountTitleOne': r'1 item selecionado',
-    'postMeridiemAbbreviation': r'Tarde/noite',
-    'scriptCategory': r'English-like',
-    'timeOfDayFormat': r'HH:mm',
-    'openAppDrawerTooltip': r'Abrir menu de navegação',
-    'backButtonTooltip': r'Voltar',
-    'closeButtonTooltip': r'Fechar',
-    'deleteButtonTooltip': r'Excluir',
-    'nextMonthTooltip': r'Próximo mês',
-    'previousMonthTooltip': r'Mês anterior',
-    'nextPageTooltip': r'Próxima página',
-    'previousPageTooltip': r'Página anterior',
-    'showMenuTooltip': r'Mostrar menu',
-    'aboutListTileTitle': r'Sobre o app $applicationName',
-    'licensesPageTitle': r'Licenças',
-    'pageRowsInfoTitle': r'$firstRow – $lastRow de $rowCount',
-    'pageRowsInfoTitleApproximate': r'$firstRow – $lastRow de aproximadamente $rowCount',
-    'rowsPerPageTitle': r'Linhas por página:',
-    'selectedRowCountTitleOther': r'$selectedRowCount itens selecionados',
-    'cancelButtonLabel': r'CANCELAR',
-    'closeButtonLabel': r'FECHAR',
-    'continueButtonLabel': r'CONTINUAR',
-    'copyButtonLabel': r'COPIAR',
-    'cutButtonLabel': r'RECORTAR',
-    'okButtonLabel': r'Ok',
-    'pasteButtonLabel': r'COLAR',
-    'selectAllButtonLabel': r'SELECIONAR TUDO',
-    'viewLicensesButtonLabel': r'VER LICENÇAS',
-    'timePickerHourModeAnnouncement': r'Selecione as horas',
-    'timePickerMinuteModeAnnouncement': r'Selecione os minutos',
-    'modalBarrierDismissLabel': r'Dispensar',
-  },
-  'pt_PT': const <String, String>{
-    'timePickerMinuteModeAnnouncement': r'Selecionar minutos',
-    'timePickerHourModeAnnouncement': r'Selecionar horas',
-    'scriptCategory': r'English-like',
-    'timeOfDayFormat': r'HH:mm',
-    'openAppDrawerTooltip': r'Abrir menu de navegação',
-    'backButtonTooltip': r'Voltar',
-    'closeButtonTooltip': r'Fechar',
-    'deleteButtonTooltip': r'Eliminar',
-    'nextMonthTooltip': r'Mês seguinte',
-    'previousMonthTooltip': r'Mês anterior',
-    'nextPageTooltip': r'Página seguinte',
-    'previousPageTooltip': r'Página anterior',
-    'showMenuTooltip': r'Mostrar menu',
-    'aboutListTileTitle': r'Acerca de $applicationName',
-    'licensesPageTitle': r'Licenças',
-    'pageRowsInfoTitle': r'$firstRow a $lastRow de $rowCount',
-    'pageRowsInfoTitleApproximate': r'$firstRow a $lastRow de cerca de $rowCount',
-    'rowsPerPageTitle': r'Linhas por página:',
-    'selectedRowCountTitleOne': r'1 item selecionado',
-    'selectedRowCountTitleOther': r'$selectedRowCount itens selecionados',
-    'cancelButtonLabel': r'CANCELAR',
-    'closeButtonLabel': r'FECHAR',
-    'continueButtonLabel': r'CONTINUAR',
-    'copyButtonLabel': r'COPIAR',
-    'cutButtonLabel': r'CORTAR',
-    'okButtonLabel': r'OK',
-    'pasteButtonLabel': r'COLAR',
-    'selectAllButtonLabel': r'SELECIONAR TUDO',
-    'viewLicensesButtonLabel': r'VER LICENÇAS',
-    'anteMeridiemAbbreviation': r'AM',
-    'postMeridiemAbbreviation': r'PM',
-    'modalBarrierDismissLabel': r'Ignorar',
-  },
-  'ru': const <String, String>{
-    'scriptCategory': r'English-like',
-    'timeOfDayFormat': r'H:mm',
-    'selectedRowCountTitleFew': r'Выбрано $selectedRowCount объекта',
-    'selectedRowCountTitleMany': r'Выбрано $selectedRowCount объектов',
-    'openAppDrawerTooltip': r'Открыть меню навигации',
-    'backButtonTooltip': r'Назад',
-    'closeButtonTooltip': r'Закрыть',
-    'deleteButtonTooltip': r'Удалить',
-    'nextMonthTooltip': r'Следующий месяц',
-    'previousMonthTooltip': r'Предыдущий месяц',
-    'nextPageTooltip': r'Следующая страница',
-    'previousPageTooltip': r'Предыдущая страница',
-    'showMenuTooltip': r'Показать меню',
-    'pageRowsInfoTitle': r'$firstRow–$lastRow из $rowCount',
-    'pageRowsInfoTitleApproximate': r'$firstRow–$lastRow из примерно $rowCount',
-    'rowsPerPageTitle': r'Строк на странице:',
-    'aboutListTileTitle': r'$applicationName: сведения',
-    'licensesPageTitle': r'Лицензии',
-    'selectedRowCountTitleZero': r'Строки не выбраны',
-    'selectedRowCountTitleOne': r'Выбран 1 объект',
-    'selectedRowCountTitleOther': r'Выбрано $selectedRowCount объекта',
-    'cancelButtonLabel': r'ОТМЕНА',
-    'closeButtonLabel': r'ЗАКРЫТЬ',
-    'continueButtonLabel': r'ПРОДОЛЖИТЬ',
-    'copyButtonLabel': r'КОПИРОВАТЬ',
-    'cutButtonLabel': r'ВЫРЕЗАТЬ',
-    'okButtonLabel': r'ОК',
-    'pasteButtonLabel': r'ВСТАВИТЬ',
-    'selectAllButtonLabel': r'ВЫБРАТЬ ВСЕ',
-    'viewLicensesButtonLabel': r'ЛИЦЕНЗИИ',
-    'anteMeridiemAbbreviation': r'АМ',
-    'postMeridiemAbbreviation': r'PM',
-    'timePickerHourModeAnnouncement': r'Выберите часы',
-    'timePickerMinuteModeAnnouncement': r'Выберите минуты',
-    'modalBarrierDismissLabel': r'Закрыть',
-  },
-  'th': const <String, String>{
-    'scriptCategory': r'tall',
-    'timeOfDayFormat': r'ah:mm',
-    'openAppDrawerTooltip': r'เปิดเมนูการนำทาง',
-    'backButtonTooltip': r'กลับ',
-    'closeButtonTooltip': r'ปิด',
-    'deleteButtonTooltip': r'ลบ',
-    'nextMonthTooltip': r'เดือนหน้า',
-    'previousMonthTooltip': r'เดือนที่แล้ว',
-    'nextPageTooltip': r'หน้าถัดไป',
-    'previousPageTooltip': r'หน้าก่อน',
-    'showMenuTooltip': r'แสดงเมนู',
-    'aboutListTileTitle': r'เกี่ยวกับ $applicationName',
-    'licensesPageTitle': r'ใบอนุญาต',
-    'pageRowsInfoTitle': r'$firstRow-$lastRow จาก $rowCount',
-    'pageRowsInfoTitleApproximate': r'$firstRow–$lastRow จากประมาณ $rowCount',
-    'rowsPerPageTitle': r'แถวต่อหน้า:',
-    'selectedRowCountTitleOne': r'เลือกแล้ว 1 รายการ',
-    'selectedRowCountTitleOther': r'เลือกแล้ว $selectedRowCount รายการ',
-    'cancelButtonLabel': r'ยกเลิก',
-    'closeButtonLabel': r'ปิด',
-    'continueButtonLabel': r'ต่อไป',
-    'copyButtonLabel': r'คัดลอก',
-    'cutButtonLabel': r'ตัด',
-    'okButtonLabel': r'ตกลง',
-    'pasteButtonLabel': r'วาง',
-    'selectAllButtonLabel': r'เลือกทั้งหมด',
-    'viewLicensesButtonLabel': r'ดูใบอนุญาต',
-    'anteMeridiemAbbreviation': r'AM',
-    'postMeridiemAbbreviation': r'PM',
-    'timePickerHourModeAnnouncement': r'เลือกชั่วโมง',
-    'timePickerMinuteModeAnnouncement': r'เลือกนาที',
-    'modalBarrierDismissLabel': r'ยกเลิก',
-  },
-  'tr': const <String, String>{
-    'scriptCategory': r'English-like',
-    'timeOfDayFormat': r'HH:mm',
-    'openAppDrawerTooltip': r'Gezinme menüsünü aç',
-    'backButtonTooltip': r'Geri',
-    'closeButtonTooltip': r'Kapat',
-    'deleteButtonTooltip': r'Sil',
-    'nextMonthTooltip': r'Gelecek ay',
-    'previousMonthTooltip': r'Önceki ay',
-    'nextPageTooltip': r'Sonraki sayfa',
-    'previousPageTooltip': r'Önceki sayfa',
-    'showMenuTooltip': r'Menüyü göster',
-    'aboutListTileTitle': r'$applicationName Hakkında',
-    'licensesPageTitle': r'Lisanslar',
-    'pageRowsInfoTitle': r'$firstRow-$lastRow / $rowCount',
-    'pageRowsInfoTitleApproximate': r'$firstRow-$lastRow / $rowCount',
-    'rowsPerPageTitle': r'Sayfa başına satır sayısı:',
-    'selectedRowCountTitleOne': r'1 öğe seçildi',
-    'selectedRowCountTitleOther': r'$selectedRowCount öğe seçildi',
-    'cancelButtonLabel': r'İPTAL',
-    'closeButtonLabel': r'KAPAT',
-    'continueButtonLabel': r'DEVAM',
-    'copyButtonLabel': r'KOPYALA',
-    'cutButtonLabel': r'KES',
-    'okButtonLabel': r'Tamam',
-    'pasteButtonLabel': r'YAPIŞTIR',
-    'selectAllButtonLabel': r'TÜMÜNÜ SEÇ',
-    'viewLicensesButtonLabel': r'LİSANLARI GÖSTER',
-    'anteMeridiemAbbreviation': r'ÖÖ',
-    'postMeridiemAbbreviation': r'ÖS',
-    'timePickerHourModeAnnouncement': r'Saati seçin',
-    'timePickerMinuteModeAnnouncement': r'Dakikayı seçin',
-    'modalBarrierDismissLabel': r'Reddet',
-  },
-  'ur': const <String, String>{
-    'scriptCategory': r'tall',
-    'timeOfDayFormat': r'h:mm a',
-    'selectedRowCountTitleOne': r'1 آئٹم منتخب کیا گیا',
-    'openAppDrawerTooltip': r'نیویگیشن مینو کھولیں',
-    'backButtonTooltip': r'پیچھے',
-    'closeButtonTooltip': r'بند کریں',
-    'deleteButtonTooltip': r'حذف کریں',
-    'nextMonthTooltip': r'اگلا مہینہ',
-    'previousMonthTooltip': r'پچھلا مہینہ',
-    'nextPageTooltip': r'اگلا صفحہ',
-    'previousPageTooltip': r'گزشتہ صفحہ',
-    'showMenuTooltip': r'مینو دکھائیں',
-    'aboutListTileTitle': r'$applicationName کے بارے میں',
-    'licensesPageTitle': r'لائسنسز',
-    'pageRowsInfoTitle': r'$firstRow–$lastRow از $rowCount',
-    'pageRowsInfoTitleApproximate': r'$firstRow–$lastRow $rowCount میں سے تقریباً',
-    'rowsPerPageTitle': r'قطاریں فی صفحہ:',
-    'selectedRowCountTitleOther': r'$selectedRowCount آئٹمز منتخب کیے گئے',
-    'cancelButtonLabel': r'منسوخ کریں',
-    'closeButtonLabel': r'بند کریں',
-    'continueButtonLabel': r'جاری رکھیں',
-    'copyButtonLabel': r'کاپی کریں',
-    'cutButtonLabel': r'کٹ کریں',
-    'okButtonLabel': r'ٹھیک ہے',
-    'pasteButtonLabel': r'پیسٹ کریں',
-    'selectAllButtonLabel': r'سبھی منتخب کریں',
-    'viewLicensesButtonLabel': r'لائسنسز دیکھیں',
-    'anteMeridiemAbbreviation': r'AM',
-    'postMeridiemAbbreviation': r'PM',
-    'timePickerHourModeAnnouncement': r'گھنٹے منتخب کریں',
-    'timePickerMinuteModeAnnouncement': r'منٹ منتخب کریں',
-    'modalBarrierDismissLabel': r'برطرف',
-  },
-  'zh': const <String, String>{
-    'scriptCategory': r'dense',
-    'timeOfDayFormat': r'ah:mm',
-    'selectedRowCountTitleOne': r'已选择 1 项内容',
-    'openAppDrawerTooltip': r'打开导航菜单',
-    'backButtonTooltip': r'返回',
-    'nextPageTooltip': r'下一页',
-    'previousPageTooltip': r'上一页',
-    'showMenuTooltip': r'显示菜单',
-    'aboutListTileTitle': r'关于$applicationName',
-    'licensesPageTitle': r'许可',
-    'pageRowsInfoTitle': r'第 $firstRow-$lastRow 行（共 $rowCount 行）',
-    'pageRowsInfoTitleApproximate': r'第 $firstRow-$lastRow 行（共约 $rowCount 行）',
-    'rowsPerPageTitle': r'每页行数：',
-    'selectedRowCountTitleOther': r'已选择 $selectedRowCount 项内容',
-    'cancelButtonLabel': r'取消',
-    'continueButtonLabel': r'继续',
-    'closeButtonLabel': r'关闭',
-    'copyButtonLabel': r'复制',
-    'cutButtonLabel': r'剪切',
-    'okButtonLabel': r'确定',
-    'pasteButtonLabel': r'粘贴',
-    'selectAllButtonLabel': r'全选',
-    'viewLicensesButtonLabel': r'查看许可',
-    'closeButtonTooltip': r'关闭',
-    'deleteButtonTooltip': r'删除',
-    'nextMonthTooltip': r'下个月',
-    'previousMonthTooltip': r'上个月',
-    'anteMeridiemAbbreviation': r'上午',
-    'postMeridiemAbbreviation': r'下午',
-    'timePickerHourModeAnnouncement': r'选择小时',
-    'timePickerMinuteModeAnnouncement': r'选择分钟',
-    'modalBarrierDismissLabel': r'关闭',
-  },
-  'zh_HK': const <String, String>{
-    'scriptCategory': r'dense',
-    'timeOfDayFormat': r'ah:mm',
-    'openAppDrawerTooltip': r'開啟導覽選單',
-    'backButtonTooltip': r'返回',
-    'closeButtonTooltip': r'關閉',
-    'deleteButtonTooltip': r'刪除',
-    'nextMonthTooltip': r'下個月',
-    'previousMonthTooltip': r'上個月',
-    'nextPageTooltip': r'下一頁',
-    'previousPageTooltip': r'上一頁',
-    'showMenuTooltip': r'顯示選單',
-    'aboutListTileTitle': r'關於「$applicationName」',
-    'licensesPageTitle': r'授權',
-    'pageRowsInfoTitle': r'第 $firstRow - $lastRow 列 (總共 $rowCount 列)',
-    'pageRowsInfoTitleApproximate': r'第 $firstRow - $lastRow 列 (總共約 $rowCount 列)',
-    'rowsPerPageTitle': r'每頁列數：',
-    'selectedRowCountTitleOne': r'已選取 1 個項目',
-    'selectedRowCountTitleOther': r'已選取 $selectedRowCount 個項目',
-    'cancelButtonLabel': r'取消',
-    'closeButtonLabel': r'關閉',
-    'continueButtonLabel': r'繼續',
-    'copyButtonLabel': r'複製',
-    'cutButtonLabel': r'剪下',
-    'okButtonLabel': r'確定',
-    'pasteButtonLabel': r'貼上',
-    'selectAllButtonLabel': r'全選',
-    'viewLicensesButtonLabel': r'查看授權',
-    'anteMeridiemAbbreviation': r'上午',
-    'postMeridiemAbbreviation': r'下午',
-    'timePickerHourModeAnnouncement': r'選取小時數',
-    'timePickerMinuteModeAnnouncement': r'選取分鐘數',
-  },
-  'zh_TW': const <String, String>{
-    'scriptCategory': r'dense',
-    'timeOfDayFormat': r'ah:mm',
-    'openAppDrawerTooltip': r'開啟導覽選單',
-    'backButtonTooltip': r'返回',
-    'closeButtonTooltip': r'關閉',
-    'deleteButtonTooltip': r'刪除',
-    'nextMonthTooltip': r'下個月',
-    'previousMonthTooltip': r'上個月',
-    'nextPageTooltip': r'下一頁',
-    'previousPageTooltip': r'上一頁',
-    'showMenuTooltip': r'顯示選單',
-    'aboutListTileTitle': r'關於「$applicationName」',
-    'licensesPageTitle': r'授權',
-    'pageRowsInfoTitle': r'第 $firstRow - $lastRow 列 (總共 $rowCount 列)',
-    'pageRowsInfoTitleApproximate': r'第 $firstRow - $lastRow 列 (總共約 $rowCount 列)',
-    'rowsPerPageTitle': r'每頁列數：',
-    'selectedRowCountTitleOne': r'已選取 1 個項目',
-    'selectedRowCountTitleOther': r'已選取 $selectedRowCount 個項目',
-    'cancelButtonLabel': r'取消',
-    'closeButtonLabel': r'關閉',
-    'continueButtonLabel': r'繼續',
-    'copyButtonLabel': r'複製',
-    'cutButtonLabel': r'剪下',
-    'okButtonLabel': r'確定',
-    'pasteButtonLabel': r'貼上',
-    'selectAllButtonLabel': r'全選',
-    'viewLicensesButtonLabel': r'查看授權',
-    'anteMeridiemAbbreviation': r'上午',
-    'postMeridiemAbbreviation': r'下午',
-    'timePickerHourModeAnnouncement': r'選取小時數',
-    'timePickerMinuteModeAnnouncement': r'選取分鐘數',
-  },
-};
+// The TranslationBundle subclasses defined here encode all of the translations
+// found in the flutter_localizations/lib/src/l10n/*.arb files.
+//
+// The [MaterialLocalizations] class uses the (generated)
+// translationBundleForLocale() function to look up a const TranslationBundle
+// instance for a locale.
+
+import 'dart:ui' show Locale;
+
+class TranslationBundle {
+  const TranslationBundle(this.parent);
+  final TranslationBundle parent;
+  String get scriptCategory => parent?.scriptCategory;
+  String get timeOfDayFormat => parent?.timeOfDayFormat;
+  String get openAppDrawerTooltip => parent?.openAppDrawerTooltip;
+  String get backButtonTooltip => parent?.backButtonTooltip;
+  String get closeButtonTooltip => parent?.closeButtonTooltip;
+  String get deleteButtonTooltip => parent?.deleteButtonTooltip;
+  String get nextMonthTooltip => parent?.nextMonthTooltip;
+  String get previousMonthTooltip => parent?.previousMonthTooltip;
+  String get nextPageTooltip => parent?.nextPageTooltip;
+  String get previousPageTooltip => parent?.previousPageTooltip;
+  String get showMenuTooltip => parent?.showMenuTooltip;
+  String get aboutListTileTitle => parent?.aboutListTileTitle;
+  String get licensesPageTitle => parent?.licensesPageTitle;
+  String get pageRowsInfoTitle => parent?.pageRowsInfoTitle;
+  String get pageRowsInfoTitleApproximate => parent?.pageRowsInfoTitleApproximate;
+  String get rowsPerPageTitle => parent?.rowsPerPageTitle;
+  String get selectedRowCountTitleOne => parent?.selectedRowCountTitleOne;
+  String get selectedRowCountTitleOther => parent?.selectedRowCountTitleOther;
+  String get cancelButtonLabel => parent?.cancelButtonLabel;
+  String get closeButtonLabel => parent?.closeButtonLabel;
+  String get continueButtonLabel => parent?.continueButtonLabel;
+  String get copyButtonLabel => parent?.copyButtonLabel;
+  String get cutButtonLabel => parent?.cutButtonLabel;
+  String get okButtonLabel => parent?.okButtonLabel;
+  String get pasteButtonLabel => parent?.pasteButtonLabel;
+  String get selectAllButtonLabel => parent?.selectAllButtonLabel;
+  String get viewLicensesButtonLabel => parent?.viewLicensesButtonLabel;
+  String get anteMeridiemAbbreviation => parent?.anteMeridiemAbbreviation;
+  String get postMeridiemAbbreviation => parent?.postMeridiemAbbreviation;
+  String get timePickerHourModeAnnouncement => parent?.timePickerHourModeAnnouncement;
+  String get timePickerMinuteModeAnnouncement => parent?.timePickerMinuteModeAnnouncement;
+  String get modalBarrierDismissLabel => parent?.modalBarrierDismissLabel;
+  String get selectedRowCountTitleTwo => parent?.selectedRowCountTitleTwo;
+  String get selectedRowCountTitleMany => parent?.selectedRowCountTitleMany;
+  String get selectedRowCountTitleZero => parent?.selectedRowCountTitleZero;
+  String get selectedRowCountTitleFew => parent?.selectedRowCountTitleFew;
+}
+
+// ignore: camel_case_types
+class _Bundle_es extends TranslationBundle {
+  const _Bundle_es() : super(null);
+  @override String get scriptCategory => r'English-like';
+  @override String get timeOfDayFormat => r'H:mm';
+  @override String get openAppDrawerTooltip => r'Abrir el menú de navegación';
+  @override String get backButtonTooltip => r'Atrás';
+  @override String get closeButtonTooltip => r'Cerrar';
+  @override String get deleteButtonTooltip => r'Eliminar';
+  @override String get nextMonthTooltip => r'Mes siguiente';
+  @override String get previousMonthTooltip => r'Mes anterior';
+  @override String get nextPageTooltip => r'Página siguiente';
+  @override String get previousPageTooltip => r'Página anterior';
+  @override String get showMenuTooltip => r'Mostrar menú';
+  @override String get aboutListTileTitle => r'Sobre $applicationName';
+  @override String get licensesPageTitle => r'Licencias';
+  @override String get pageRowsInfoTitle => r'$firstRow‑$lastRow de $rowCount';
+  @override String get pageRowsInfoTitleApproximate => r'$firstRow‑$lastRow de aproximadamente $rowCount';
+  @override String get rowsPerPageTitle => r'Filas por página:';
+  @override String get selectedRowCountTitleZero => r'No se han seleccionado elementos';
+  @override String get selectedRowCountTitleOne => r'1 elemento seleccionado';
+  @override String get selectedRowCountTitleOther => r'$selectedRowCount elementos seleccionados';
+  @override String get cancelButtonLabel => r'CANCELAR';
+  @override String get closeButtonLabel => r'CERRAR';
+  @override String get continueButtonLabel => r'CONTINUAR';
+  @override String get copyButtonLabel => r'COPIAR';
+  @override String get cutButtonLabel => r'CORTAR';
+  @override String get okButtonLabel => r'ACEPTAR';
+  @override String get pasteButtonLabel => r'PEGAR';
+  @override String get selectAllButtonLabel => r'SELECCIONAR TODO';
+  @override String get viewLicensesButtonLabel => r'VER LICENCIAS';
+  @override String get anteMeridiemAbbreviation => r'A.M.';
+  @override String get postMeridiemAbbreviation => r'P.M.';
+  @override String get timePickerHourModeAnnouncement => r'Seleccionar horas';
+  @override String get timePickerMinuteModeAnnouncement => r'Seleccionar minutos';
+  @override String get modalBarrierDismissLabel => r'Ignorar';
+}
+
+// ignore: camel_case_types
+class _Bundle_fa extends TranslationBundle {
+  const _Bundle_fa() : super(null);
+  @override String get scriptCategory => r'tall';
+  @override String get timeOfDayFormat => r'H:mm';
+  @override String get selectedRowCountTitleOne => r'۱ مورد انتخاب شد';
+  @override String get openAppDrawerTooltip => r'باز کردن منوی پیمایش';
+  @override String get backButtonTooltip => r'برگشت';
+  @override String get closeButtonTooltip => r'بستن';
+  @override String get deleteButtonTooltip => r'حذف';
+  @override String get nextMonthTooltip => r'ماه بعد';
+  @override String get previousMonthTooltip => r'ماه قبل';
+  @override String get nextPageTooltip => r'صفحه بعد';
+  @override String get previousPageTooltip => r'صفحه قبل';
+  @override String get showMenuTooltip => r'نمایش منو';
+  @override String get aboutListTileTitle => r'درباره $applicationName';
+  @override String get licensesPageTitle => r'مجوزها';
+  @override String get pageRowsInfoTitle => r'$firstRow–$lastRow از $rowCount';
+  @override String get pageRowsInfoTitleApproximate => r'$firstRow–$lastRow از حدود $rowCount';
+  @override String get rowsPerPageTitle => r'ردیف در هر صفحه:';
+  @override String get selectedRowCountTitleOther => r'$selectedRowCount مورد انتخاب شدند';
+  @override String get cancelButtonLabel => r'لغو';
+  @override String get closeButtonLabel => r'بستن';
+  @override String get continueButtonLabel => r'ادامه';
+  @override String get copyButtonLabel => r'کپی';
+  @override String get cutButtonLabel => r'برش';
+  @override String get okButtonLabel => r'تأیید';
+  @override String get pasteButtonLabel => r'جای‌گذاری';
+  @override String get selectAllButtonLabel => r'انتخاب همه';
+  @override String get viewLicensesButtonLabel => r'مشاهده مجوزها';
+  @override String get anteMeridiemAbbreviation => r'ق.ظ.';
+  @override String get postMeridiemAbbreviation => r'ب.ظ.';
+  @override String get timePickerHourModeAnnouncement => r'انتخاب ساعت';
+  @override String get timePickerMinuteModeAnnouncement => r'انتخاب دقیقه';
+  @override String get modalBarrierDismissLabel => r'رد کردن';
+}
+
+// ignore: camel_case_types
+class _Bundle_en extends TranslationBundle {
+  const _Bundle_en() : super(null);
+  @override String get scriptCategory => r'English-like';
+  @override String get timeOfDayFormat => r'h:mm a';
+  @override String get openAppDrawerTooltip => r'Open navigation menu';
+  @override String get backButtonTooltip => r'Back';
+  @override String get closeButtonTooltip => r'Close';
+  @override String get deleteButtonTooltip => r'Delete';
+  @override String get nextMonthTooltip => r'Next month';
+  @override String get previousMonthTooltip => r'Previous month';
+  @override String get nextPageTooltip => r'Next page';
+  @override String get previousPageTooltip => r'Previous page';
+  @override String get showMenuTooltip => r'Show menu';
+  @override String get aboutListTileTitle => r'About $applicationName';
+  @override String get licensesPageTitle => r'Licenses';
+  @override String get pageRowsInfoTitle => r'$firstRow–$lastRow of $rowCount';
+  @override String get pageRowsInfoTitleApproximate => r'$firstRow–$lastRow of about $rowCount';
+  @override String get rowsPerPageTitle => r'Rows per page:';
+  @override String get selectedRowCountTitleZero => r'No items selected';
+  @override String get selectedRowCountTitleOne => r'1 item selected';
+  @override String get selectedRowCountTitleOther => r'$selectedRowCount items selected';
+  @override String get cancelButtonLabel => r'CANCEL';
+  @override String get closeButtonLabel => r'CLOSE';
+  @override String get continueButtonLabel => r'CONTINUE';
+  @override String get copyButtonLabel => r'COPY';
+  @override String get cutButtonLabel => r'CUT';
+  @override String get okButtonLabel => r'OK';
+  @override String get pasteButtonLabel => r'PASTE';
+  @override String get selectAllButtonLabel => r'SELECT ALL';
+  @override String get viewLicensesButtonLabel => r'VIEW LICENSES';
+  @override String get anteMeridiemAbbreviation => r'AM';
+  @override String get postMeridiemAbbreviation => r'PM';
+  @override String get timePickerHourModeAnnouncement => r'Select hours';
+  @override String get timePickerMinuteModeAnnouncement => r'Select minutes';
+  @override String get modalBarrierDismissLabel => r'Dismiss';
+}
+
+// ignore: camel_case_types
+class _Bundle_de extends TranslationBundle {
+  const _Bundle_de() : super(null);
+  @override String get scriptCategory => r'English-like';
+  @override String get timeOfDayFormat => r'HH:mm';
+  @override String get openAppDrawerTooltip => r'Navigationsmenü öffnen';
+  @override String get backButtonTooltip => r'Zurück';
+  @override String get closeButtonTooltip => r'Schließen';
+  @override String get deleteButtonTooltip => r'Löschen';
+  @override String get nextMonthTooltip => r'Nächster Monat';
+  @override String get previousMonthTooltip => r'Vorheriger Monat';
+  @override String get nextPageTooltip => r'Nächste Seite';
+  @override String get previousPageTooltip => r'Vorherige Seite';
+  @override String get showMenuTooltip => r'Menü anzeigen';
+  @override String get aboutListTileTitle => r'Über $applicationName';
+  @override String get licensesPageTitle => r'Lizenzen';
+  @override String get pageRowsInfoTitle => r'$firstRow–$lastRow von $rowCount';
+  @override String get pageRowsInfoTitleApproximate => r'$firstRow–$lastRow von etwa $rowCount';
+  @override String get rowsPerPageTitle => r'Zeilen pro Seite:';
+  @override String get selectedRowCountTitleZero => r'Keine Objekte ausgewählt';
+  @override String get selectedRowCountTitleOne => r'1 Element ausgewählt';
+  @override String get selectedRowCountTitleOther => r'$selectedRowCount Elemente ausgewählt';
+  @override String get cancelButtonLabel => r'ABBRECHEN';
+  @override String get closeButtonLabel => r'SCHLIEẞEN';
+  @override String get continueButtonLabel => r'WEITER';
+  @override String get copyButtonLabel => r'KOPIEREN';
+  @override String get cutButtonLabel => r'AUSSCHNEIDEN';
+  @override String get okButtonLabel => r'OK';
+  @override String get pasteButtonLabel => r'EINFÜGEN';
+  @override String get selectAllButtonLabel => r'ALLE AUSWÄHLEN';
+  @override String get viewLicensesButtonLabel => r'LIZENZEN ANZEIGEN';
+  @override String get anteMeridiemAbbreviation => r'VORM.';
+  @override String get postMeridiemAbbreviation => r'NACHM.';
+  @override String get timePickerHourModeAnnouncement => r'Stunden auswählen';
+  @override String get timePickerMinuteModeAnnouncement => r'Minuten auswählen';
+  @override String get modalBarrierDismissLabel => r'Schließen';
+}
+
+// ignore: camel_case_types
+class _Bundle_ur extends TranslationBundle {
+  const _Bundle_ur() : super(null);
+  @override String get scriptCategory => r'tall';
+  @override String get timeOfDayFormat => r'h:mm a';
+  @override String get selectedRowCountTitleOne => r'1 آئٹم منتخب کیا گیا';
+  @override String get openAppDrawerTooltip => r'نیویگیشن مینو کھولیں';
+  @override String get backButtonTooltip => r'پیچھے';
+  @override String get closeButtonTooltip => r'بند کریں';
+  @override String get deleteButtonTooltip => r'حذف کریں';
+  @override String get nextMonthTooltip => r'اگلا مہینہ';
+  @override String get previousMonthTooltip => r'پچھلا مہینہ';
+  @override String get nextPageTooltip => r'اگلا صفحہ';
+  @override String get previousPageTooltip => r'گزشتہ صفحہ';
+  @override String get showMenuTooltip => r'مینو دکھائیں';
+  @override String get aboutListTileTitle => r'$applicationName کے بارے میں';
+  @override String get licensesPageTitle => r'لائسنسز';
+  @override String get pageRowsInfoTitle => r'$firstRow–$lastRow از $rowCount';
+  @override String get pageRowsInfoTitleApproximate => r'$firstRow–$lastRow $rowCount میں سے تقریباً';
+  @override String get rowsPerPageTitle => r'قطاریں فی صفحہ:';
+  @override String get selectedRowCountTitleOther => r'$selectedRowCount آئٹمز منتخب کیے گئے';
+  @override String get cancelButtonLabel => r'منسوخ کریں';
+  @override String get closeButtonLabel => r'بند کریں';
+  @override String get continueButtonLabel => r'جاری رکھیں';
+  @override String get copyButtonLabel => r'کاپی کریں';
+  @override String get cutButtonLabel => r'کٹ کریں';
+  @override String get okButtonLabel => r'ٹھیک ہے';
+  @override String get pasteButtonLabel => r'پیسٹ کریں';
+  @override String get selectAllButtonLabel => r'سبھی منتخب کریں';
+  @override String get viewLicensesButtonLabel => r'لائسنسز دیکھیں';
+  @override String get anteMeridiemAbbreviation => r'AM';
+  @override String get postMeridiemAbbreviation => r'PM';
+  @override String get timePickerHourModeAnnouncement => r'گھنٹے منتخب کریں';
+  @override String get timePickerMinuteModeAnnouncement => r'منٹ منتخب کریں';
+  @override String get modalBarrierDismissLabel => r'برطرف';
+}
+
+// ignore: camel_case_types
+class _Bundle_tr extends TranslationBundle {
+  const _Bundle_tr() : super(null);
+  @override String get scriptCategory => r'English-like';
+  @override String get timeOfDayFormat => r'HH:mm';
+  @override String get openAppDrawerTooltip => r'Gezinme menüsünü aç';
+  @override String get backButtonTooltip => r'Geri';
+  @override String get closeButtonTooltip => r'Kapat';
+  @override String get deleteButtonTooltip => r'Sil';
+  @override String get nextMonthTooltip => r'Gelecek ay';
+  @override String get previousMonthTooltip => r'Önceki ay';
+  @override String get nextPageTooltip => r'Sonraki sayfa';
+  @override String get previousPageTooltip => r'Önceki sayfa';
+  @override String get showMenuTooltip => r'Menüyü göster';
+  @override String get aboutListTileTitle => r'$applicationName Hakkında';
+  @override String get licensesPageTitle => r'Lisanslar';
+  @override String get pageRowsInfoTitle => r'$firstRow-$lastRow / $rowCount';
+  @override String get pageRowsInfoTitleApproximate => r'$firstRow-$lastRow / $rowCount';
+  @override String get rowsPerPageTitle => r'Sayfa başına satır sayısı:';
+  @override String get selectedRowCountTitleOne => r'1 öğe seçildi';
+  @override String get selectedRowCountTitleOther => r'$selectedRowCount öğe seçildi';
+  @override String get cancelButtonLabel => r'İPTAL';
+  @override String get closeButtonLabel => r'KAPAT';
+  @override String get continueButtonLabel => r'DEVAM';
+  @override String get copyButtonLabel => r'KOPYALA';
+  @override String get cutButtonLabel => r'KES';
+  @override String get okButtonLabel => r'Tamam';
+  @override String get pasteButtonLabel => r'YAPIŞTIR';
+  @override String get selectAllButtonLabel => r'TÜMÜNÜ SEÇ';
+  @override String get viewLicensesButtonLabel => r'LİSANLARI GÖSTER';
+  @override String get anteMeridiemAbbreviation => r'ÖÖ';
+  @override String get postMeridiemAbbreviation => r'ÖS';
+  @override String get timePickerHourModeAnnouncement => r'Saati seçin';
+  @override String get timePickerMinuteModeAnnouncement => r'Dakikayı seçin';
+  @override String get modalBarrierDismissLabel => r'Reddet';
+}
+
+// ignore: camel_case_types
+class _Bundle_ps extends TranslationBundle {
+  const _Bundle_ps() : super(null);
+  @override String get scriptCategory => r'tall';
+  @override String get timeOfDayFormat => r'HH:mm';
+  @override String get openAppDrawerTooltip => r'د پرانیستی نیینګ مینو';
+  @override String get backButtonTooltip => r'شاته';
+  @override String get closeButtonTooltip => r'بنده';
+  @override String get deleteButtonTooltip => r'';
+  @override String get nextMonthTooltip => r'بله میاشت';
+  @override String get previousMonthTooltip => r'تیره میاشت';
+  @override String get nextPageTooltip => r'بله پاڼه';
+  @override String get previousPageTooltip => r'مخکینی مخ';
+  @override String get showMenuTooltip => r'غورنۍ ښودل';
+  @override String get aboutListTileTitle => r'د $applicationName په اړه';
+  @override String get licensesPageTitle => r'جوازونه';
+  @override String get pageRowsInfoTitle => r'$firstRow–$lastRow د $rowCount';
+  @override String get pageRowsInfoTitleApproximate => r'$firstRow–$lastRow څخه $rowCount د';
+  @override String get rowsPerPageTitle => r'د هرې پاڼې پاڼې:';
+  @override String get selectedRowCountTitleOther => r'$selectedRowCount توکي غوره شوي';
+  @override String get cancelButtonLabel => r'لغوه کول';
+  @override String get closeButtonLabel => r'تړل';
+  @override String get continueButtonLabel => r'منځپانګې';
+  @override String get copyButtonLabel => r'کاپی';
+  @override String get cutButtonLabel => r'کم کړئ';
+  @override String get okButtonLabel => r'سمه ده';
+  @override String get pasteButtonLabel => r'پیټ کړئ';
+  @override String get selectAllButtonLabel => r'غوره کړئ';
+  @override String get viewLicensesButtonLabel => r'لیدلس وګورئ';
+  @override String get timePickerHourModeAnnouncement => r'وختونه وټاکئ';
+  @override String get timePickerMinuteModeAnnouncement => r'منې غوره کړئ';
+  @override String get modalBarrierDismissLabel => r'رد کړه';
+}
+
+// ignore: camel_case_types
+class _Bundle_he extends TranslationBundle {
+  const _Bundle_he() : super(null);
+  @override String get scriptCategory => r'English-like';
+  @override String get timeOfDayFormat => r'H:mm';
+  @override String get selectedRowCountTitleOne => r'פריט אחד נבחר';
+  @override String get selectedRowCountTitleTwo => r'$selectedRowCount פריטים נבחרו';
+  @override String get selectedRowCountTitleMany => r'$selectedRowCount פריטים נבחרו';
+  @override String get openAppDrawerTooltip => r'פתיחה של תפריט הניווט';
+  @override String get backButtonTooltip => r'הקודם';
+  @override String get closeButtonTooltip => r'סגירה';
+  @override String get deleteButtonTooltip => r'מחיקה';
+  @override String get nextMonthTooltip => r'החודש הבא';
+  @override String get previousMonthTooltip => r'החודש הקודם';
+  @override String get nextPageTooltip => r'הדף הבא';
+  @override String get previousPageTooltip => r'הדף הקודם';
+  @override String get showMenuTooltip => r'הצגת התפריט';
+  @override String get aboutListTileTitle => r'מידע על $applicationName';
+  @override String get licensesPageTitle => r'רישיונות';
+  @override String get pageRowsInfoTitle => r'$lastRow–$firstRow מתוך $rowCount';
+  @override String get pageRowsInfoTitleApproximate => r'$lastRow–$firstRow מתוך כ-$rowCount';
+  @override String get rowsPerPageTitle => r'שורות בכל דף:';
+  @override String get selectedRowCountTitleOther => r'$selectedRowCount פריטים נבחרו';
+  @override String get cancelButtonLabel => r'ביטול';
+  @override String get closeButtonLabel => r'סגירה';
+  @override String get continueButtonLabel => r'המשך';
+  @override String get copyButtonLabel => r'העתקה';
+  @override String get cutButtonLabel => r'גזירה';
+  @override String get okButtonLabel => r'אישור';
+  @override String get pasteButtonLabel => r'הדבקה';
+  @override String get selectAllButtonLabel => r'בחירת הכול';
+  @override String get viewLicensesButtonLabel => r'הצגת הרישיונות';
+  @override String get anteMeridiemAbbreviation => r'AM';
+  @override String get postMeridiemAbbreviation => r'PM';
+  @override String get timePickerHourModeAnnouncement => r'בחירת שעות';
+  @override String get timePickerMinuteModeAnnouncement => r'בחירת דקות';
+  @override String get modalBarrierDismissLabel => r'סגירה';
+}
+
+// ignore: camel_case_types
+class _Bundle_zh extends TranslationBundle {
+  const _Bundle_zh() : super(null);
+  @override String get scriptCategory => r'dense';
+  @override String get timeOfDayFormat => r'ah:mm';
+  @override String get selectedRowCountTitleOne => r'已选择 1 项内容';
+  @override String get openAppDrawerTooltip => r'打开导航菜单';
+  @override String get backButtonTooltip => r'返回';
+  @override String get nextPageTooltip => r'下一页';
+  @override String get previousPageTooltip => r'上一页';
+  @override String get showMenuTooltip => r'显示菜单';
+  @override String get aboutListTileTitle => r'关于$applicationName';
+  @override String get licensesPageTitle => r'许可';
+  @override String get pageRowsInfoTitle => r'第 $firstRow-$lastRow 行（共 $rowCount 行）';
+  @override String get pageRowsInfoTitleApproximate => r'第 $firstRow-$lastRow 行（共约 $rowCount 行）';
+  @override String get rowsPerPageTitle => r'每页行数：';
+  @override String get selectedRowCountTitleOther => r'已选择 $selectedRowCount 项内容';
+  @override String get cancelButtonLabel => r'取消';
+  @override String get continueButtonLabel => r'继续';
+  @override String get closeButtonLabel => r'关闭';
+  @override String get copyButtonLabel => r'复制';
+  @override String get cutButtonLabel => r'剪切';
+  @override String get okButtonLabel => r'确定';
+  @override String get pasteButtonLabel => r'粘贴';
+  @override String get selectAllButtonLabel => r'全选';
+  @override String get viewLicensesButtonLabel => r'查看许可';
+  @override String get closeButtonTooltip => r'关闭';
+  @override String get deleteButtonTooltip => r'删除';
+  @override String get nextMonthTooltip => r'下个月';
+  @override String get previousMonthTooltip => r'上个月';
+  @override String get anteMeridiemAbbreviation => r'上午';
+  @override String get postMeridiemAbbreviation => r'下午';
+  @override String get timePickerHourModeAnnouncement => r'选择小时';
+  @override String get timePickerMinuteModeAnnouncement => r'选择分钟';
+  @override String get modalBarrierDismissLabel => r'关闭';
+}
+
+// ignore: camel_case_types
+class _Bundle_ar extends TranslationBundle {
+  const _Bundle_ar() : super(null);
+  @override String get selectedRowCountTitleOne => r'تم اختيار عنصر واحد';
+  @override String get selectedRowCountTitleZero => r'لم يتم اختيار أي عنصر';
+  @override String get selectedRowCountTitleTwo => r'تم اختيار عنصرين ($selectedRowCount)';
+  @override String get selectedRowCountTitleFew => r'تم اختيار $selectedRowCount عنصر';
+  @override String get selectedRowCountTitleMany => r'تم اختيار $selectedRowCount عنصرًا';
+  @override String get scriptCategory => r'tall';
+  @override String get timeOfDayFormat => r'h:mm a';
+  @override String get openAppDrawerTooltip => r'فتح قائمة التنقل';
+  @override String get backButtonTooltip => r'رجوع';
+  @override String get closeButtonTooltip => r'إغلاق';
+  @override String get deleteButtonTooltip => r'حذف';
+  @override String get nextMonthTooltip => r'الشهر التالي';
+  @override String get previousMonthTooltip => r'الشهر السابق';
+  @override String get nextPageTooltip => r'الصفحة التالية';
+  @override String get previousPageTooltip => r'الصفحة السابقة';
+  @override String get showMenuTooltip => r'عرض القائمة';
+  @override String get aboutListTileTitle => r'حول "$applicationName"';
+  @override String get licensesPageTitle => r'التراخيص';
+  @override String get pageRowsInfoTitle => r'من $firstRow إلى $lastRow من إجمالي $rowCount';
+  @override String get pageRowsInfoTitleApproximate => r'من $firstRow إلى $lastRow من إجمالي $rowCount تقريبًا';
+  @override String get rowsPerPageTitle => r'عدد الصفوف في الصفحة:';
+  @override String get selectedRowCountTitleOther => r'تم اختيار $selectedRowCount عنصر';
+  @override String get cancelButtonLabel => r'إلغاء';
+  @override String get closeButtonLabel => r'إغلاق';
+  @override String get continueButtonLabel => r'متابعة';
+  @override String get copyButtonLabel => r'نسخ';
+  @override String get cutButtonLabel => r'قص';
+  @override String get okButtonLabel => r'حسنًا';
+  @override String get pasteButtonLabel => r'لصق';
+  @override String get selectAllButtonLabel => r'اختيار الكل';
+  @override String get viewLicensesButtonLabel => r'الاطّلاع على التراخيص';
+  @override String get anteMeridiemAbbreviation => r'ص';
+  @override String get postMeridiemAbbreviation => r'م';
+  @override String get timePickerHourModeAnnouncement => r'اختيار الساعات';
+  @override String get timePickerMinuteModeAnnouncement => r'اختيار الدقائق';
+  @override String get modalBarrierDismissLabel => r'تجاهل';
+}
+
+// ignore: camel_case_types
+class _Bundle_nl extends TranslationBundle {
+  const _Bundle_nl() : super(null);
+  @override String get scriptCategory => r'English-like';
+  @override String get timeOfDayFormat => r'HH:mm';
+  @override String get openAppDrawerTooltip => r'Navigatiemenu openen';
+  @override String get backButtonTooltip => r'Terug';
+  @override String get closeButtonTooltip => r'Sluiten';
+  @override String get deleteButtonTooltip => r'Verwijderen';
+  @override String get nextMonthTooltip => r'Volgende maand';
+  @override String get previousMonthTooltip => r'Vorige maand';
+  @override String get nextPageTooltip => r'Volgende pagina';
+  @override String get previousPageTooltip => r'Vorige pagina';
+  @override String get showMenuTooltip => r'Menu weergeven';
+  @override String get aboutListTileTitle => r'Over $applicationName';
+  @override String get licensesPageTitle => r'Licenties';
+  @override String get pageRowsInfoTitle => r'$firstRow-$lastRow van $rowCount';
+  @override String get pageRowsInfoTitleApproximate => r'$firstRow-$lastRow van ongeveer $rowCount';
+  @override String get rowsPerPageTitle => r'Rijen per pagina:';
+  @override String get selectedRowCountTitleOne => r'1 item geselecteerd';
+  @override String get selectedRowCountTitleOther => r'$selectedRowCount items geselecteerd';
+  @override String get cancelButtonLabel => r'ANNULEREN';
+  @override String get closeButtonLabel => r'SLUITEN';
+  @override String get continueButtonLabel => r'DOORGAAN';
+  @override String get copyButtonLabel => r'KOPIËREN';
+  @override String get cutButtonLabel => r'KNIPPEN';
+  @override String get okButtonLabel => r'OK';
+  @override String get pasteButtonLabel => r'PLAKKEN';
+  @override String get selectAllButtonLabel => r'ALLES SELECTEREN';
+  @override String get viewLicensesButtonLabel => r'LICENTIES BEKIJKEN';
+  @override String get anteMeridiemAbbreviation => r'am';
+  @override String get postMeridiemAbbreviation => r'pm';
+  @override String get timePickerHourModeAnnouncement => r'Uren selecteren';
+  @override String get timePickerMinuteModeAnnouncement => r'Minuten selecteren';
+  @override String get modalBarrierDismissLabel => r'ontslaan';
+}
+
+// ignore: camel_case_types
+class _Bundle_pt extends TranslationBundle {
+  const _Bundle_pt() : super(null);
+  @override String get anteMeridiemAbbreviation => r'Manhã';
+  @override String get selectedRowCountTitleOne => r'1 item selecionado';
+  @override String get postMeridiemAbbreviation => r'Tarde/noite';
+  @override String get scriptCategory => r'English-like';
+  @override String get timeOfDayFormat => r'HH:mm';
+  @override String get openAppDrawerTooltip => r'Abrir menu de navegação';
+  @override String get backButtonTooltip => r'Voltar';
+  @override String get closeButtonTooltip => r'Fechar';
+  @override String get deleteButtonTooltip => r'Excluir';
+  @override String get nextMonthTooltip => r'Próximo mês';
+  @override String get previousMonthTooltip => r'Mês anterior';
+  @override String get nextPageTooltip => r'Próxima página';
+  @override String get previousPageTooltip => r'Página anterior';
+  @override String get showMenuTooltip => r'Mostrar menu';
+  @override String get aboutListTileTitle => r'Sobre o app $applicationName';
+  @override String get licensesPageTitle => r'Licenças';
+  @override String get pageRowsInfoTitle => r'$firstRow – $lastRow de $rowCount';
+  @override String get pageRowsInfoTitleApproximate => r'$firstRow – $lastRow de aproximadamente $rowCount';
+  @override String get rowsPerPageTitle => r'Linhas por página:';
+  @override String get selectedRowCountTitleOther => r'$selectedRowCount itens selecionados';
+  @override String get cancelButtonLabel => r'CANCELAR';
+  @override String get closeButtonLabel => r'FECHAR';
+  @override String get continueButtonLabel => r'CONTINUAR';
+  @override String get copyButtonLabel => r'COPIAR';
+  @override String get cutButtonLabel => r'RECORTAR';
+  @override String get okButtonLabel => r'Ok';
+  @override String get pasteButtonLabel => r'COLAR';
+  @override String get selectAllButtonLabel => r'SELECIONAR TUDO';
+  @override String get viewLicensesButtonLabel => r'VER LICENÇAS';
+  @override String get timePickerHourModeAnnouncement => r'Selecione as horas';
+  @override String get timePickerMinuteModeAnnouncement => r'Selecione os minutos';
+  @override String get modalBarrierDismissLabel => r'Dispensar';
+}
+
+// ignore: camel_case_types
+class _Bundle_it extends TranslationBundle {
+  const _Bundle_it() : super(null);
+  @override String get scriptCategory => r'English-like';
+  @override String get timeOfDayFormat => r'HH:mm';
+  @override String get selectedRowCountTitleOne => r'1 elemento selezionato';
+  @override String get openAppDrawerTooltip => r'Apri il menu di navigazione';
+  @override String get backButtonTooltip => r'Indietro';
+  @override String get closeButtonTooltip => r'Chiudi';
+  @override String get deleteButtonTooltip => r'Elimina';
+  @override String get nextMonthTooltip => r'Mese successivo';
+  @override String get previousMonthTooltip => r'Mese precedente';
+  @override String get nextPageTooltip => r'Pagina successiva';
+  @override String get previousPageTooltip => r'Pagina precedente';
+  @override String get showMenuTooltip => r'Mostra il menu';
+  @override String get aboutListTileTitle => r'Informazioni su $applicationName';
+  @override String get licensesPageTitle => r'Licenze';
+  @override String get pageRowsInfoTitle => r'$firstRow-$lastRow di $rowCount';
+  @override String get pageRowsInfoTitleApproximate => r'$firstRow-$lastRow di circa $rowCount';
+  @override String get rowsPerPageTitle => r'Righe per pagina:';
+  @override String get selectedRowCountTitleOther => r'$selectedRowCount elementi selezionati';
+  @override String get cancelButtonLabel => r'ANNULLA';
+  @override String get closeButtonLabel => r'CHIUDI';
+  @override String get continueButtonLabel => r'CONTINUA';
+  @override String get copyButtonLabel => r'COPIA';
+  @override String get cutButtonLabel => r'TAGLIA';
+  @override String get okButtonLabel => r'OK';
+  @override String get pasteButtonLabel => r'INCOLLA';
+  @override String get selectAllButtonLabel => r'SELEZIONA TUTTO';
+  @override String get viewLicensesButtonLabel => r'VISUALIZZA LICENZE';
+  @override String get anteMeridiemAbbreviation => r'AM';
+  @override String get postMeridiemAbbreviation => r'PM';
+  @override String get timePickerHourModeAnnouncement => r'Seleziona le ore';
+  @override String get timePickerMinuteModeAnnouncement => r'Seleziona i minuti';
+  @override String get modalBarrierDismissLabel => r'Ignora';
+}
+
+// ignore: camel_case_types
+class _Bundle_fr extends TranslationBundle {
+  const _Bundle_fr() : super(null);
+  @override String get scriptCategory => r'English-like';
+  @override String get timeOfDayFormat => r'HH:mm';
+  @override String get openAppDrawerTooltip => r'Ouvrir le menu de navigation';
+  @override String get backButtonTooltip => r'Retour';
+  @override String get closeButtonTooltip => r'Fermer';
+  @override String get deleteButtonTooltip => r'Supprimer';
+  @override String get nextMonthTooltip => r'Mois suivant';
+  @override String get previousMonthTooltip => r'Mois précédent';
+  @override String get nextPageTooltip => r'Page suivante';
+  @override String get previousPageTooltip => r'Page précédente';
+  @override String get showMenuTooltip => r'Afficher le menu';
+  @override String get aboutListTileTitle => r'À propos de $applicationName';
+  @override String get licensesPageTitle => r'Licences';
+  @override String get pageRowsInfoTitle => r'$firstRow – $lastRow sur $rowCount';
+  @override String get pageRowsInfoTitleApproximate => r'$firstRow – $lastRow sur environ $rowCount';
+  @override String get rowsPerPageTitle => r'Lignes par page :';
+  @override String get selectedRowCountTitleZero => r'Aucun élément sélectionné';
+  @override String get selectedRowCountTitleOne => r'1 élément sélectionné';
+  @override String get selectedRowCountTitleOther => r'$selectedRowCount éléments sélectionnés';
+  @override String get cancelButtonLabel => r'ANNULER';
+  @override String get closeButtonLabel => r'FERMER';
+  @override String get continueButtonLabel => r'CONTINUER';
+  @override String get copyButtonLabel => r'COPIER';
+  @override String get cutButtonLabel => r'COUPER';
+  @override String get okButtonLabel => r'OK';
+  @override String get pasteButtonLabel => r'COLLER';
+  @override String get selectAllButtonLabel => r'TOUT SÉLECTIONNER';
+  @override String get viewLicensesButtonLabel => r'AFFICHER LES LICENCES';
+  @override String get anteMeridiemAbbreviation => r'AM';
+  @override String get postMeridiemAbbreviation => r'PM';
+  @override String get timePickerHourModeAnnouncement => r'Sélectionner une heure';
+  @override String get timePickerMinuteModeAnnouncement => r'Sélectionner des minutes';
+  @override String get modalBarrierDismissLabel => r'Ignorer';
+}
+
+// ignore: camel_case_types
+class _Bundle_gsw extends TranslationBundle {
+  const _Bundle_gsw() : super(null);
+  @override String get timePickerMinuteModeAnnouncement => r'Minuten auswählen';
+  @override String get timePickerHourModeAnnouncement => r'Stunden auswählen';
+  @override String get scriptCategory => r'English-like';
+  @override String get timeOfDayFormat => r'HH:mm';
+  @override String get openAppDrawerTooltip => r'Navigationsmenü öffnen';
+  @override String get backButtonTooltip => r'Zurück';
+  @override String get closeButtonTooltip => r'Schließen';
+  @override String get deleteButtonTooltip => r'Löschen';
+  @override String get nextMonthTooltip => r'Nächster Monat';
+  @override String get previousMonthTooltip => r'Vorheriger Monat';
+  @override String get nextPageTooltip => r'Nächste Seite';
+  @override String get previousPageTooltip => r'Vorherige Seite';
+  @override String get showMenuTooltip => r'Menü anzeigen';
+  @override String get aboutListTileTitle => r'Über $applicationName';
+  @override String get licensesPageTitle => r'Lizenzen';
+  @override String get pageRowsInfoTitle => r'$firstRow–$lastRow von $rowCount';
+  @override String get pageRowsInfoTitleApproximate => r'$firstRow–$lastRow von etwa $rowCount';
+  @override String get rowsPerPageTitle => r'Zeilen pro Seite:';
+  @override String get selectedRowCountTitleOne => r'1 Element ausgewählt';
+  @override String get selectedRowCountTitleOther => r'$selectedRowCount Elemente ausgewählt';
+  @override String get cancelButtonLabel => r'ABBRECHEN';
+  @override String get closeButtonLabel => r'SCHLIEẞEN';
+  @override String get continueButtonLabel => r'WEITER';
+  @override String get copyButtonLabel => r'KOPIEREN';
+  @override String get cutButtonLabel => r'AUSSCHNEIDEN';
+  @override String get okButtonLabel => r'OK';
+  @override String get pasteButtonLabel => r'EINFÜGEN';
+  @override String get selectAllButtonLabel => r'ALLE AUSWÄHLEN';
+  @override String get viewLicensesButtonLabel => r'LIZENZEN ANZEIGEN';
+  @override String get anteMeridiemAbbreviation => r'VORM.';
+  @override String get postMeridiemAbbreviation => r'NACHM.';
+  @override String get modalBarrierDismissLabel => r'Schließen';
+}
+
+// ignore: camel_case_types
+class _Bundle_ja extends TranslationBundle {
+  const _Bundle_ja() : super(null);
+  @override String get scriptCategory => r'dense';
+  @override String get timeOfDayFormat => r'H:mm';
+  @override String get selectedRowCountTitleOne => r'1 件のアイテムを選択中';
+  @override String get openAppDrawerTooltip => r'ナビゲーション メニューを開く';
+  @override String get backButtonTooltip => r'戻る';
+  @override String get closeButtonTooltip => r'閉じる';
+  @override String get deleteButtonTooltip => r'削除';
+  @override String get nextMonthTooltip => r'来月';
+  @override String get previousMonthTooltip => r'前月';
+  @override String get nextPageTooltip => r'次のページ';
+  @override String get previousPageTooltip => r'前のページ';
+  @override String get showMenuTooltip => r'メニューを表示';
+  @override String get aboutListTileTitle => r'$applicationName について';
+  @override String get licensesPageTitle => r'ライセンス';
+  @override String get pageRowsInfoTitle => r'$firstRow - $lastRow 行（合計 $rowCount 行）';
+  @override String get pageRowsInfoTitleApproximate => r'$firstRow – $lastRow 行（合計約 $rowCount 行）';
+  @override String get rowsPerPageTitle => r'ページあたりの行数:';
+  @override String get selectedRowCountTitleOther => r'$selectedRowCount 件のアイテムを選択中';
+  @override String get cancelButtonLabel => r'キャンセル';
+  @override String get closeButtonLabel => r'閉じる';
+  @override String get continueButtonLabel => r'続行';
+  @override String get copyButtonLabel => r'コピー';
+  @override String get cutButtonLabel => r'切り取り';
+  @override String get okButtonLabel => r'OK';
+  @override String get pasteButtonLabel => r'貼り付け';
+  @override String get selectAllButtonLabel => r'すべて選択';
+  @override String get viewLicensesButtonLabel => r'ライセンスを表示';
+  @override String get anteMeridiemAbbreviation => r'AM';
+  @override String get postMeridiemAbbreviation => r'PM';
+  @override String get timePickerHourModeAnnouncement => r'時間を選択';
+  @override String get timePickerMinuteModeAnnouncement => r'分を選択';
+  @override String get modalBarrierDismissLabel => r'閉じる';
+}
+
+// ignore: camel_case_types
+class _Bundle_th extends TranslationBundle {
+  const _Bundle_th() : super(null);
+  @override String get scriptCategory => r'tall';
+  @override String get timeOfDayFormat => r'ah:mm';
+  @override String get openAppDrawerTooltip => r'เปิดเมนูการนำทาง';
+  @override String get backButtonTooltip => r'กลับ';
+  @override String get closeButtonTooltip => r'ปิด';
+  @override String get deleteButtonTooltip => r'ลบ';
+  @override String get nextMonthTooltip => r'เดือนหน้า';
+  @override String get previousMonthTooltip => r'เดือนที่แล้ว';
+  @override String get nextPageTooltip => r'หน้าถัดไป';
+  @override String get previousPageTooltip => r'หน้าก่อน';
+  @override String get showMenuTooltip => r'แสดงเมนู';
+  @override String get aboutListTileTitle => r'เกี่ยวกับ $applicationName';
+  @override String get licensesPageTitle => r'ใบอนุญาต';
+  @override String get pageRowsInfoTitle => r'$firstRow-$lastRow จาก $rowCount';
+  @override String get pageRowsInfoTitleApproximate => r'$firstRow–$lastRow จากประมาณ $rowCount';
+  @override String get rowsPerPageTitle => r'แถวต่อหน้า:';
+  @override String get selectedRowCountTitleOne => r'เลือกแล้ว 1 รายการ';
+  @override String get selectedRowCountTitleOther => r'เลือกแล้ว $selectedRowCount รายการ';
+  @override String get cancelButtonLabel => r'ยกเลิก';
+  @override String get closeButtonLabel => r'ปิด';
+  @override String get continueButtonLabel => r'ต่อไป';
+  @override String get copyButtonLabel => r'คัดลอก';
+  @override String get cutButtonLabel => r'ตัด';
+  @override String get okButtonLabel => r'ตกลง';
+  @override String get pasteButtonLabel => r'วาง';
+  @override String get selectAllButtonLabel => r'เลือกทั้งหมด';
+  @override String get viewLicensesButtonLabel => r'ดูใบอนุญาต';
+  @override String get anteMeridiemAbbreviation => r'AM';
+  @override String get postMeridiemAbbreviation => r'PM';
+  @override String get timePickerHourModeAnnouncement => r'เลือกชั่วโมง';
+  @override String get timePickerMinuteModeAnnouncement => r'เลือกนาที';
+  @override String get modalBarrierDismissLabel => r'ยกเลิก';
+}
+
+// ignore: camel_case_types
+class _Bundle_ru extends TranslationBundle {
+  const _Bundle_ru() : super(null);
+  @override String get scriptCategory => r'English-like';
+  @override String get timeOfDayFormat => r'H:mm';
+  @override String get selectedRowCountTitleFew => r'Выбрано $selectedRowCount объекта';
+  @override String get selectedRowCountTitleMany => r'Выбрано $selectedRowCount объектов';
+  @override String get openAppDrawerTooltip => r'Открыть меню навигации';
+  @override String get backButtonTooltip => r'Назад';
+  @override String get closeButtonTooltip => r'Закрыть';
+  @override String get deleteButtonTooltip => r'Удалить';
+  @override String get nextMonthTooltip => r'Следующий месяц';
+  @override String get previousMonthTooltip => r'Предыдущий месяц';
+  @override String get nextPageTooltip => r'Следующая страница';
+  @override String get previousPageTooltip => r'Предыдущая страница';
+  @override String get showMenuTooltip => r'Показать меню';
+  @override String get pageRowsInfoTitle => r'$firstRow–$lastRow из $rowCount';
+  @override String get pageRowsInfoTitleApproximate => r'$firstRow–$lastRow из примерно $rowCount';
+  @override String get rowsPerPageTitle => r'Строк на странице:';
+  @override String get aboutListTileTitle => r'$applicationName: сведения';
+  @override String get licensesPageTitle => r'Лицензии';
+  @override String get selectedRowCountTitleZero => r'Строки не выбраны';
+  @override String get selectedRowCountTitleOne => r'Выбран 1 объект';
+  @override String get selectedRowCountTitleOther => r'Выбрано $selectedRowCount объекта';
+  @override String get cancelButtonLabel => r'ОТМЕНА';
+  @override String get closeButtonLabel => r'ЗАКРЫТЬ';
+  @override String get continueButtonLabel => r'ПРОДОЛЖИТЬ';
+  @override String get copyButtonLabel => r'КОПИРОВАТЬ';
+  @override String get cutButtonLabel => r'ВЫРЕЗАТЬ';
+  @override String get okButtonLabel => r'ОК';
+  @override String get pasteButtonLabel => r'ВСТАВИТЬ';
+  @override String get selectAllButtonLabel => r'ВЫБРАТЬ ВСЕ';
+  @override String get viewLicensesButtonLabel => r'ЛИЦЕНЗИИ';
+  @override String get anteMeridiemAbbreviation => r'АМ';
+  @override String get postMeridiemAbbreviation => r'PM';
+  @override String get timePickerHourModeAnnouncement => r'Выберите часы';
+  @override String get timePickerMinuteModeAnnouncement => r'Выберите минуты';
+  @override String get modalBarrierDismissLabel => r'Закрыть';
+}
+
+// ignore: camel_case_types
+class _Bundle_ko extends TranslationBundle {
+  const _Bundle_ko() : super(null);
+  @override String get scriptCategory => r'dense';
+  @override String get timeOfDayFormat => r'a h:mm';
+  @override String get openAppDrawerTooltip => r'탐색 메뉴 열기';
+  @override String get backButtonTooltip => r'뒤로';
+  @override String get closeButtonTooltip => r'닫기';
+  @override String get deleteButtonTooltip => r'삭제';
+  @override String get nextMonthTooltip => r'다음 달';
+  @override String get previousMonthTooltip => r'지난달';
+  @override String get nextPageTooltip => r'다음 페이지';
+  @override String get previousPageTooltip => r'이전 페이지';
+  @override String get showMenuTooltip => r'메뉴 표시';
+  @override String get aboutListTileTitle => r'$applicationName 정보';
+  @override String get licensesPageTitle => r'라이선스';
+  @override String get pageRowsInfoTitle => r'$rowCount행 중 $firstRow~$lastRow행';
+  @override String get pageRowsInfoTitleApproximate => r'약 $rowCount행 중 $firstRow~$lastRow행';
+  @override String get rowsPerPageTitle => r'페이지당 행 수:';
+  @override String get selectedRowCountTitleOne => r'항목 1개 선택됨';
+  @override String get selectedRowCountTitleOther => r'항목 $selectedRowCount개 선택됨';
+  @override String get cancelButtonLabel => r'취소';
+  @override String get closeButtonLabel => r'닫기';
+  @override String get continueButtonLabel => r'계속';
+  @override String get copyButtonLabel => r'복사';
+  @override String get cutButtonLabel => r'잘라내기';
+  @override String get okButtonLabel => r'확인';
+  @override String get pasteButtonLabel => r'붙여넣기';
+  @override String get selectAllButtonLabel => r'전체 선택';
+  @override String get viewLicensesButtonLabel => r'라이선스 보기';
+  @override String get anteMeridiemAbbreviation => r'오전';
+  @override String get postMeridiemAbbreviation => r'오후';
+  @override String get timePickerHourModeAnnouncement => r'시간 선택';
+  @override String get timePickerMinuteModeAnnouncement => r'분 선택';
+  @override String get modalBarrierDismissLabel => r'버리다';
+}
+
+// ignore: camel_case_types
+class _Bundle_pl extends TranslationBundle {
+  const _Bundle_pl() : super(null);
+  @override String get scriptCategory => r'English-like';
+  @override String get timeOfDayFormat => r'HH:mm';
+  @override String get selectedRowCountTitleFew => r'$selectedRowCount wybrane elementy';
+  @override String get selectedRowCountTitleMany => r'$selectedRowCount wybranych elementów';
+  @override String get openAppDrawerTooltip => r'Otwórz menu nawigacyjne';
+  @override String get backButtonTooltip => r'Wstecz';
+  @override String get closeButtonTooltip => r'Zamknij';
+  @override String get deleteButtonTooltip => r'Usuń';
+  @override String get nextMonthTooltip => r'Następny miesiąc';
+  @override String get previousMonthTooltip => r'Poprzedni miesiąc';
+  @override String get nextPageTooltip => r'Następna strona';
+  @override String get previousPageTooltip => r'Poprzednia strona';
+  @override String get showMenuTooltip => r'Pokaż menu';
+  @override String get aboutListTileTitle => r'$applicationName – informacje';
+  @override String get licensesPageTitle => r'Licencje';
+  @override String get pageRowsInfoTitle => r'$firstRow–$lastRow z $rowCount';
+  @override String get pageRowsInfoTitleApproximate => r'$firstRow–$lastRow z około $rowCount';
+  @override String get rowsPerPageTitle => r'Wiersze na stronie:';
+  @override String get selectedRowCountTitleOne => r'1 wybrany element';
+  @override String get selectedRowCountTitleOther => r'$selectedRowCount wybranego elementu';
+  @override String get cancelButtonLabel => r'ANULUJ';
+  @override String get closeButtonLabel => r'ZAMKNIJ';
+  @override String get continueButtonLabel => r'DALEJ';
+  @override String get copyButtonLabel => r'KOPIUJ';
+  @override String get cutButtonLabel => r'WYTNIJ';
+  @override String get okButtonLabel => r'OK';
+  @override String get pasteButtonLabel => r'WKLEJ';
+  @override String get selectAllButtonLabel => r'ZAZNACZ WSZYSTKO';
+  @override String get viewLicensesButtonLabel => r'WYŚWIETL LICENCJE';
+  @override String get anteMeridiemAbbreviation => r'AM';
+  @override String get postMeridiemAbbreviation => r'PM';
+  @override String get timePickerHourModeAnnouncement => r'Wybierz godziny';
+  @override String get timePickerMinuteModeAnnouncement => r'Wybierz minuty';
+  @override String get modalBarrierDismissLabel => r'oddalić';
+}
+
+// ignore: camel_case_types
+class _Bundle_es_UY extends TranslationBundle {
+  const _Bundle_es_UY() : super(const _Bundle_es());
+  @override String get openAppDrawerTooltip => r'Abrir menú de navegación';
+  @override String get deleteButtonTooltip => r'Borrar';
+  @override String get nextMonthTooltip => r'Próximo mes';
+  @override String get nextPageTooltip => r'Próxima página';
+  @override String get aboutListTileTitle => r'Acerca de $applicationName';
+  @override String get pageRowsInfoTitle => r'$firstRow–$lastRow de $rowCount';
+  @override String get pageRowsInfoTitleApproximate => r'$firstRow–$lastRow de aproximadamente $rowCount';
+  @override String get selectedRowCountTitleOne => r'Se seleccionó 1 elemento';
+  @override String get selectedRowCountTitleOther => r'Se seleccionaron $selectedRowCount elementos';
+  @override String get anteMeridiemAbbreviation => r'a.m.';
+  @override String get postMeridiemAbbreviation => r'p.m.';
+}
+
+// ignore: camel_case_types
+class _Bundle_es_CR extends TranslationBundle {
+  const _Bundle_es_CR() : super(const _Bundle_es());
+  @override String get openAppDrawerTooltip => r'Abrir menú de navegación';
+  @override String get deleteButtonTooltip => r'Borrar';
+  @override String get nextMonthTooltip => r'Próximo mes';
+  @override String get nextPageTooltip => r'Próxima página';
+  @override String get aboutListTileTitle => r'Acerca de $applicationName';
+  @override String get pageRowsInfoTitle => r'$firstRow–$lastRow de $rowCount';
+  @override String get pageRowsInfoTitleApproximate => r'$firstRow–$lastRow de aproximadamente $rowCount';
+  @override String get selectedRowCountTitleOne => r'Se seleccionó 1 elemento';
+  @override String get selectedRowCountTitleOther => r'Se seleccionaron $selectedRowCount elementos';
+  @override String get anteMeridiemAbbreviation => r'a.m.';
+  @override String get postMeridiemAbbreviation => r'p.m.';
+}
+
+// ignore: camel_case_types
+class _Bundle_es_US extends TranslationBundle {
+  const _Bundle_es_US() : super(const _Bundle_es());
+  @override String get deleteButtonTooltip => r'Borrar';
+  @override String get nextMonthTooltip => r'Próximo mes';
+  @override String get pageRowsInfoTitleApproximate => r'$firstRow–$lastRow de aproximadamente $rowCount';
+  @override String get aboutListTileTitle => r'Acerca de $applicationName';
+  @override String get nextPageTooltip => r'Próxima página';
+  @override String get openAppDrawerTooltip => r'Abrir menú de navegación';
+  @override String get pageRowsInfoTitle => r'$firstRow–$lastRow de $rowCount';
+  @override String get selectedRowCountTitleOne => r'Se seleccionó 1 elemento';
+  @override String get selectedRowCountTitleOther => r'Se seleccionaron $selectedRowCount elementos';
+  @override String get timeOfDayFormat => r'h:mm a';
+  @override String get anteMeridiemAbbreviation => r'a.m.';
+  @override String get postMeridiemAbbreviation => r'p.m.';
+}
+
+// ignore: camel_case_types
+class _Bundle_es_SV extends TranslationBundle {
+  const _Bundle_es_SV() : super(const _Bundle_es());
+  @override String get openAppDrawerTooltip => r'Abrir menú de navegación';
+  @override String get deleteButtonTooltip => r'Borrar';
+  @override String get nextMonthTooltip => r'Próximo mes';
+  @override String get nextPageTooltip => r'Próxima página';
+  @override String get aboutListTileTitle => r'Acerca de $applicationName';
+  @override String get pageRowsInfoTitle => r'$firstRow–$lastRow de $rowCount';
+  @override String get pageRowsInfoTitleApproximate => r'$firstRow–$lastRow de aproximadamente $rowCount';
+  @override String get selectedRowCountTitleOne => r'Se seleccionó 1 elemento';
+  @override String get selectedRowCountTitleOther => r'Se seleccionaron $selectedRowCount elementos';
+  @override String get anteMeridiemAbbreviation => r'a.m.';
+  @override String get postMeridiemAbbreviation => r'p.m.';
+}
+
+// ignore: camel_case_types
+class _Bundle_es_DO extends TranslationBundle {
+  const _Bundle_es_DO() : super(const _Bundle_es());
+  @override String get openAppDrawerTooltip => r'Abrir menú de navegación';
+  @override String get deleteButtonTooltip => r'Borrar';
+  @override String get nextMonthTooltip => r'Próximo mes';
+  @override String get nextPageTooltip => r'Próxima página';
+  @override String get aboutListTileTitle => r'Acerca de $applicationName';
+  @override String get pageRowsInfoTitle => r'$firstRow–$lastRow de $rowCount';
+  @override String get pageRowsInfoTitleApproximate => r'$firstRow–$lastRow de aproximadamente $rowCount';
+  @override String get selectedRowCountTitleOne => r'Se seleccionó 1 elemento';
+  @override String get selectedRowCountTitleOther => r'Se seleccionaron $selectedRowCount elementos';
+  @override String get anteMeridiemAbbreviation => r'a.m.';
+  @override String get postMeridiemAbbreviation => r'p.m.';
+}
+
+// ignore: camel_case_types
+class _Bundle_es_AR extends TranslationBundle {
+  const _Bundle_es_AR() : super(const _Bundle_es());
+  @override String get openAppDrawerTooltip => r'Abrir menú de navegación';
+  @override String get deleteButtonTooltip => r'Borrar';
+  @override String get nextMonthTooltip => r'Próximo mes';
+  @override String get nextPageTooltip => r'Próxima página';
+  @override String get aboutListTileTitle => r'Acerca de $applicationName';
+  @override String get pageRowsInfoTitle => r'$firstRow–$lastRow de $rowCount';
+  @override String get pageRowsInfoTitleApproximate => r'$firstRow–$lastRow de aproximadamente $rowCount';
+  @override String get selectedRowCountTitleOne => r'Se seleccionó 1 elemento';
+  @override String get selectedRowCountTitleOther => r'Se seleccionaron $selectedRowCount elementos';
+  @override String get anteMeridiemAbbreviation => r'a.m.';
+  @override String get postMeridiemAbbreviation => r'p.m.';
+}
+
+// ignore: camel_case_types
+class _Bundle_es_419 extends TranslationBundle {
+  const _Bundle_es_419() : super(const _Bundle_es());
+  @override String get openAppDrawerTooltip => r'Abrir menú de navegación';
+  @override String get deleteButtonTooltip => r'Borrar';
+  @override String get nextMonthTooltip => r'Próximo mes';
+  @override String get nextPageTooltip => r'Próxima página';
+  @override String get aboutListTileTitle => r'Acerca de $applicationName';
+  @override String get pageRowsInfoTitle => r'$firstRow–$lastRow de $rowCount';
+  @override String get pageRowsInfoTitleApproximate => r'$firstRow–$lastRow de aproximadamente $rowCount';
+  @override String get selectedRowCountTitleOne => r'Se seleccionó 1 elemento';
+  @override String get selectedRowCountTitleOther => r'Se seleccionaron $selectedRowCount elementos';
+  @override String get anteMeridiemAbbreviation => r'a.m.';
+  @override String get postMeridiemAbbreviation => r'p.m.';
+}
+
+// ignore: camel_case_types
+class _Bundle_es_PE extends TranslationBundle {
+  const _Bundle_es_PE() : super(const _Bundle_es());
+  @override String get openAppDrawerTooltip => r'Abrir menú de navegación';
+  @override String get deleteButtonTooltip => r'Borrar';
+  @override String get nextMonthTooltip => r'Próximo mes';
+  @override String get nextPageTooltip => r'Próxima página';
+  @override String get aboutListTileTitle => r'Acerca de $applicationName';
+  @override String get pageRowsInfoTitle => r'$firstRow–$lastRow de $rowCount';
+  @override String get pageRowsInfoTitleApproximate => r'$firstRow–$lastRow de aproximadamente $rowCount';
+  @override String get selectedRowCountTitleOne => r'Se seleccionó 1 elemento';
+  @override String get selectedRowCountTitleOther => r'Se seleccionaron $selectedRowCount elementos';
+  @override String get anteMeridiemAbbreviation => r'a.m.';
+  @override String get postMeridiemAbbreviation => r'p.m.';
+}
+
+// ignore: camel_case_types
+class _Bundle_es_VE extends TranslationBundle {
+  const _Bundle_es_VE() : super(const _Bundle_es());
+  @override String get openAppDrawerTooltip => r'Abrir menú de navegación';
+  @override String get deleteButtonTooltip => r'Borrar';
+  @override String get nextMonthTooltip => r'Próximo mes';
+  @override String get nextPageTooltip => r'Próxima página';
+  @override String get aboutListTileTitle => r'Acerca de $applicationName';
+  @override String get pageRowsInfoTitle => r'$firstRow–$lastRow de $rowCount';
+  @override String get pageRowsInfoTitleApproximate => r'$firstRow–$lastRow de aproximadamente $rowCount';
+  @override String get selectedRowCountTitleOne => r'Se seleccionó 1 elemento';
+  @override String get selectedRowCountTitleOther => r'Se seleccionaron $selectedRowCount elementos';
+  @override String get anteMeridiemAbbreviation => r'a.m.';
+  @override String get postMeridiemAbbreviation => r'p.m.';
+}
+
+// ignore: camel_case_types
+class _Bundle_es_BO extends TranslationBundle {
+  const _Bundle_es_BO() : super(const _Bundle_es());
+  @override String get openAppDrawerTooltip => r'Abrir menú de navegación';
+  @override String get deleteButtonTooltip => r'Borrar';
+  @override String get nextMonthTooltip => r'Próximo mes';
+  @override String get nextPageTooltip => r'Próxima página';
+  @override String get aboutListTileTitle => r'Acerca de $applicationName';
+  @override String get pageRowsInfoTitle => r'$firstRow–$lastRow de $rowCount';
+  @override String get pageRowsInfoTitleApproximate => r'$firstRow–$lastRow de aproximadamente $rowCount';
+  @override String get selectedRowCountTitleOne => r'Se seleccionó 1 elemento';
+  @override String get selectedRowCountTitleOther => r'Se seleccionaron $selectedRowCount elementos';
+  @override String get anteMeridiemAbbreviation => r'a.m.';
+  @override String get postMeridiemAbbreviation => r'p.m.';
+}
+
+// ignore: camel_case_types
+class _Bundle_es_PY extends TranslationBundle {
+  const _Bundle_es_PY() : super(const _Bundle_es());
+  @override String get openAppDrawerTooltip => r'Abrir menú de navegación';
+  @override String get deleteButtonTooltip => r'Borrar';
+  @override String get nextMonthTooltip => r'Próximo mes';
+  @override String get nextPageTooltip => r'Próxima página';
+  @override String get aboutListTileTitle => r'Acerca de $applicationName';
+  @override String get pageRowsInfoTitle => r'$firstRow–$lastRow de $rowCount';
+  @override String get pageRowsInfoTitleApproximate => r'$firstRow–$lastRow de aproximadamente $rowCount';
+  @override String get selectedRowCountTitleOne => r'Se seleccionó 1 elemento';
+  @override String get selectedRowCountTitleOther => r'Se seleccionaron $selectedRowCount elementos';
+  @override String get anteMeridiemAbbreviation => r'a.m.';
+  @override String get postMeridiemAbbreviation => r'p.m.';
+}
+
+// ignore: camel_case_types
+class _Bundle_es_GT extends TranslationBundle {
+  const _Bundle_es_GT() : super(const _Bundle_es());
+  @override String get openAppDrawerTooltip => r'Abrir menú de navegación';
+  @override String get deleteButtonTooltip => r'Borrar';
+  @override String get nextMonthTooltip => r'Próximo mes';
+  @override String get nextPageTooltip => r'Próxima página';
+  @override String get aboutListTileTitle => r'Acerca de $applicationName';
+  @override String get pageRowsInfoTitle => r'$firstRow–$lastRow de $rowCount';
+  @override String get pageRowsInfoTitleApproximate => r'$firstRow–$lastRow de aproximadamente $rowCount';
+  @override String get selectedRowCountTitleOne => r'Se seleccionó 1 elemento';
+  @override String get selectedRowCountTitleOther => r'Se seleccionaron $selectedRowCount elementos';
+  @override String get anteMeridiemAbbreviation => r'a.m.';
+  @override String get postMeridiemAbbreviation => r'p.m.';
+}
+
+// ignore: camel_case_types
+class _Bundle_es_NI extends TranslationBundle {
+  const _Bundle_es_NI() : super(const _Bundle_es());
+  @override String get openAppDrawerTooltip => r'Abrir menú de navegación';
+  @override String get deleteButtonTooltip => r'Borrar';
+  @override String get nextMonthTooltip => r'Próximo mes';
+  @override String get nextPageTooltip => r'Próxima página';
+  @override String get aboutListTileTitle => r'Acerca de $applicationName';
+  @override String get pageRowsInfoTitle => r'$firstRow–$lastRow de $rowCount';
+  @override String get pageRowsInfoTitleApproximate => r'$firstRow–$lastRow de aproximadamente $rowCount';
+  @override String get selectedRowCountTitleOne => r'Se seleccionó 1 elemento';
+  @override String get selectedRowCountTitleOther => r'Se seleccionaron $selectedRowCount elementos';
+  @override String get anteMeridiemAbbreviation => r'a.m.';
+  @override String get postMeridiemAbbreviation => r'p.m.';
+}
+
+// ignore: camel_case_types
+class _Bundle_es_PA extends TranslationBundle {
+  const _Bundle_es_PA() : super(const _Bundle_es());
+  @override String get openAppDrawerTooltip => r'Abrir menú de navegación';
+  @override String get deleteButtonTooltip => r'Borrar';
+  @override String get nextMonthTooltip => r'Próximo mes';
+  @override String get nextPageTooltip => r'Próxima página';
+  @override String get aboutListTileTitle => r'Acerca de $applicationName';
+  @override String get pageRowsInfoTitle => r'$firstRow–$lastRow de $rowCount';
+  @override String get pageRowsInfoTitleApproximate => r'$firstRow–$lastRow de aproximadamente $rowCount';
+  @override String get selectedRowCountTitleOne => r'Se seleccionó 1 elemento';
+  @override String get selectedRowCountTitleOther => r'Se seleccionaron $selectedRowCount elementos';
+  @override String get anteMeridiemAbbreviation => r'a.m.';
+  @override String get postMeridiemAbbreviation => r'p.m.';
+}
+
+// ignore: camel_case_types
+class _Bundle_es_HN extends TranslationBundle {
+  const _Bundle_es_HN() : super(const _Bundle_es());
+  @override String get openAppDrawerTooltip => r'Abrir menú de navegación';
+  @override String get deleteButtonTooltip => r'Borrar';
+  @override String get nextMonthTooltip => r'Próximo mes';
+  @override String get nextPageTooltip => r'Próxima página';
+  @override String get aboutListTileTitle => r'Acerca de $applicationName';
+  @override String get pageRowsInfoTitle => r'$firstRow–$lastRow de $rowCount';
+  @override String get pageRowsInfoTitleApproximate => r'$firstRow–$lastRow de aproximadamente $rowCount';
+  @override String get selectedRowCountTitleOne => r'Se seleccionó 1 elemento';
+  @override String get selectedRowCountTitleOther => r'Se seleccionaron $selectedRowCount elementos';
+  @override String get anteMeridiemAbbreviation => r'a.m.';
+  @override String get postMeridiemAbbreviation => r'p.m.';
+}
+
+// ignore: camel_case_types
+class _Bundle_es_PR extends TranslationBundle {
+  const _Bundle_es_PR() : super(const _Bundle_es());
+  @override String get openAppDrawerTooltip => r'Abrir menú de navegación';
+  @override String get deleteButtonTooltip => r'Borrar';
+  @override String get nextMonthTooltip => r'Próximo mes';
+  @override String get nextPageTooltip => r'Próxima página';
+  @override String get aboutListTileTitle => r'Acerca de $applicationName';
+  @override String get pageRowsInfoTitle => r'$firstRow–$lastRow de $rowCount';
+  @override String get pageRowsInfoTitleApproximate => r'$firstRow–$lastRow de aproximadamente $rowCount';
+  @override String get selectedRowCountTitleOne => r'Se seleccionó 1 elemento';
+  @override String get selectedRowCountTitleOther => r'Se seleccionaron $selectedRowCount elementos';
+  @override String get anteMeridiemAbbreviation => r'a.m.';
+  @override String get postMeridiemAbbreviation => r'p.m.';
+}
+
+// ignore: camel_case_types
+class _Bundle_es_MX extends TranslationBundle {
+  const _Bundle_es_MX() : super(const _Bundle_es());
+  @override String get openAppDrawerTooltip => r'Abrir menú de navegación';
+  @override String get deleteButtonTooltip => r'Borrar';
+  @override String get nextMonthTooltip => r'Próximo mes';
+  @override String get nextPageTooltip => r'Próxima página';
+  @override String get aboutListTileTitle => r'Acerca de $applicationName';
+  @override String get pageRowsInfoTitle => r'$firstRow–$lastRow de $rowCount';
+  @override String get pageRowsInfoTitleApproximate => r'$firstRow–$lastRow de aproximadamente $rowCount';
+  @override String get selectedRowCountTitleOne => r'Se seleccionó 1 elemento';
+  @override String get selectedRowCountTitleOther => r'Se seleccionaron $selectedRowCount elementos';
+  @override String get anteMeridiemAbbreviation => r'a.m.';
+  @override String get postMeridiemAbbreviation => r'p.m.';
+}
+
+// ignore: camel_case_types
+class _Bundle_es_CO extends TranslationBundle {
+  const _Bundle_es_CO() : super(const _Bundle_es());
+  @override String get openAppDrawerTooltip => r'Abrir menú de navegación';
+  @override String get deleteButtonTooltip => r'Borrar';
+  @override String get nextMonthTooltip => r'Próximo mes';
+  @override String get nextPageTooltip => r'Próxima página';
+  @override String get aboutListTileTitle => r'Acerca de $applicationName';
+  @override String get pageRowsInfoTitle => r'$firstRow–$lastRow de $rowCount';
+  @override String get pageRowsInfoTitleApproximate => r'$firstRow–$lastRow de aproximadamente $rowCount';
+  @override String get selectedRowCountTitleOne => r'Se seleccionó 1 elemento';
+  @override String get selectedRowCountTitleOther => r'Se seleccionaron $selectedRowCount elementos';
+  @override String get anteMeridiemAbbreviation => r'a.m.';
+  @override String get postMeridiemAbbreviation => r'p.m.';
+}
+
+// ignore: camel_case_types
+class _Bundle_es_EC extends TranslationBundle {
+  const _Bundle_es_EC() : super(const _Bundle_es());
+  @override String get openAppDrawerTooltip => r'Abrir menú de navegación';
+  @override String get deleteButtonTooltip => r'Borrar';
+  @override String get nextMonthTooltip => r'Próximo mes';
+  @override String get nextPageTooltip => r'Próxima página';
+  @override String get aboutListTileTitle => r'Acerca de $applicationName';
+  @override String get pageRowsInfoTitle => r'$firstRow–$lastRow de $rowCount';
+  @override String get pageRowsInfoTitleApproximate => r'$firstRow–$lastRow de aproximadamente $rowCount';
+  @override String get selectedRowCountTitleOne => r'Se seleccionó 1 elemento';
+  @override String get selectedRowCountTitleOther => r'Se seleccionaron $selectedRowCount elementos';
+  @override String get anteMeridiemAbbreviation => r'a.m.';
+  @override String get postMeridiemAbbreviation => r'p.m.';
+}
+
+// ignore: camel_case_types
+class _Bundle_es_CL extends TranslationBundle {
+  const _Bundle_es_CL() : super(const _Bundle_es());
+  @override String get openAppDrawerTooltip => r'Abrir menú de navegación';
+  @override String get deleteButtonTooltip => r'Borrar';
+  @override String get nextMonthTooltip => r'Próximo mes';
+  @override String get nextPageTooltip => r'Próxima página';
+  @override String get aboutListTileTitle => r'Acerca de $applicationName';
+  @override String get pageRowsInfoTitle => r'$firstRow–$lastRow de $rowCount';
+  @override String get pageRowsInfoTitleApproximate => r'$firstRow–$lastRow de aproximadamente $rowCount';
+  @override String get selectedRowCountTitleOne => r'Se seleccionó 1 elemento';
+  @override String get selectedRowCountTitleOther => r'Se seleccionaron $selectedRowCount elementos';
+  @override String get anteMeridiemAbbreviation => r'a.m.';
+  @override String get postMeridiemAbbreviation => r'p.m.';
+}
+
+// ignore: camel_case_types
+class _Bundle_en_CA extends TranslationBundle {
+  const _Bundle_en_CA() : super(const _Bundle_en());
+  @override String get licensesPageTitle => r'Licences';
+  @override String get viewLicensesButtonLabel => r'VIEW LICENCES';
+}
+
+// ignore: camel_case_types
+class _Bundle_en_ZA extends TranslationBundle {
+  const _Bundle_en_ZA() : super(const _Bundle_en());
+  @override String get timeOfDayFormat => r'HH:mm';
+  @override String get viewLicensesButtonLabel => r'VIEW LICENCES';
+  @override String get licensesPageTitle => r'Licences';
+}
+
+// ignore: camel_case_types
+class _Bundle_en_AU extends TranslationBundle {
+  const _Bundle_en_AU() : super(const _Bundle_en());
+  @override String get licensesPageTitle => r'Licences';
+  @override String get viewLicensesButtonLabel => r'VIEW LICENCES';
+}
+
+// ignore: camel_case_types
+class _Bundle_en_IE extends TranslationBundle {
+  const _Bundle_en_IE() : super(const _Bundle_en());
+  @override String get timeOfDayFormat => r'HH:mm';
+  @override String get viewLicensesButtonLabel => r'VIEW LICENCES';
+  @override String get licensesPageTitle => r'Licences';
+}
+
+// ignore: camel_case_types
+class _Bundle_en_SG extends TranslationBundle {
+  const _Bundle_en_SG() : super(const _Bundle_en());
+  @override String get licensesPageTitle => r'Licences';
+  @override String get viewLicensesButtonLabel => r'VIEW LICENCES';
+}
+
+// ignore: camel_case_types
+class _Bundle_en_GB extends TranslationBundle {
+  const _Bundle_en_GB() : super(const _Bundle_en());
+  @override String get timeOfDayFormat => r'HH:mm';
+  @override String get viewLicensesButtonLabel => r'VIEW LICENCES';
+  @override String get licensesPageTitle => r'Licences';
+}
+
+// ignore: camel_case_types
+class _Bundle_en_IN extends TranslationBundle {
+  const _Bundle_en_IN() : super(const _Bundle_en());
+  @override String get licensesPageTitle => r'Licences';
+  @override String get viewLicensesButtonLabel => r'VIEW LICENCES';
+}
+
+// ignore: camel_case_types
+class _Bundle_de_CH extends TranslationBundle {
+  const _Bundle_de_CH() : super(const _Bundle_de());
+  @override String get closeButtonTooltip => r'Schliessen';
+  @override String get modalBarrierDismissLabel => r'Schliessen';
+}
+
+// ignore: camel_case_types
+class _Bundle_zh_TW extends TranslationBundle {
+  const _Bundle_zh_TW() : super(const _Bundle_zh());
+  @override String get openAppDrawerTooltip => r'開啟導覽選單';
+  @override String get closeButtonTooltip => r'關閉';
+  @override String get deleteButtonTooltip => r'刪除';
+  @override String get nextMonthTooltip => r'下個月';
+  @override String get previousMonthTooltip => r'上個月';
+  @override String get nextPageTooltip => r'下一頁';
+  @override String get previousPageTooltip => r'上一頁';
+  @override String get showMenuTooltip => r'顯示選單';
+  @override String get aboutListTileTitle => r'關於「$applicationName」';
+  @override String get licensesPageTitle => r'授權';
+  @override String get pageRowsInfoTitle => r'第 $firstRow - $lastRow 列 (總共 $rowCount 列)';
+  @override String get pageRowsInfoTitleApproximate => r'第 $firstRow - $lastRow 列 (總共約 $rowCount 列)';
+  @override String get rowsPerPageTitle => r'每頁列數：';
+  @override String get selectedRowCountTitleOne => r'已選取 1 個項目';
+  @override String get selectedRowCountTitleOther => r'已選取 $selectedRowCount 個項目';
+  @override String get closeButtonLabel => r'關閉';
+  @override String get continueButtonLabel => r'繼續';
+  @override String get copyButtonLabel => r'複製';
+  @override String get cutButtonLabel => r'剪下';
+  @override String get okButtonLabel => r'確定';
+  @override String get pasteButtonLabel => r'貼上';
+  @override String get selectAllButtonLabel => r'全選';
+  @override String get viewLicensesButtonLabel => r'查看授權';
+  @override String get timePickerHourModeAnnouncement => r'選取小時數';
+  @override String get timePickerMinuteModeAnnouncement => r'選取分鐘數';
+}
+
+// ignore: camel_case_types
+class _Bundle_zh_HK extends TranslationBundle {
+  const _Bundle_zh_HK() : super(const _Bundle_zh());
+  @override String get openAppDrawerTooltip => r'開啟導覽選單';
+  @override String get closeButtonTooltip => r'關閉';
+  @override String get deleteButtonTooltip => r'刪除';
+  @override String get nextMonthTooltip => r'下個月';
+  @override String get previousMonthTooltip => r'上個月';
+  @override String get nextPageTooltip => r'下一頁';
+  @override String get previousPageTooltip => r'上一頁';
+  @override String get showMenuTooltip => r'顯示選單';
+  @override String get aboutListTileTitle => r'關於「$applicationName」';
+  @override String get licensesPageTitle => r'授權';
+  @override String get pageRowsInfoTitle => r'第 $firstRow - $lastRow 列 (總共 $rowCount 列)';
+  @override String get pageRowsInfoTitleApproximate => r'第 $firstRow - $lastRow 列 (總共約 $rowCount 列)';
+  @override String get rowsPerPageTitle => r'每頁列數：';
+  @override String get selectedRowCountTitleOne => r'已選取 1 個項目';
+  @override String get selectedRowCountTitleOther => r'已選取 $selectedRowCount 個項目';
+  @override String get closeButtonLabel => r'關閉';
+  @override String get continueButtonLabel => r'繼續';
+  @override String get copyButtonLabel => r'複製';
+  @override String get cutButtonLabel => r'剪下';
+  @override String get okButtonLabel => r'確定';
+  @override String get pasteButtonLabel => r'貼上';
+  @override String get selectAllButtonLabel => r'全選';
+  @override String get viewLicensesButtonLabel => r'查看授權';
+  @override String get timePickerHourModeAnnouncement => r'選取小時數';
+  @override String get timePickerMinuteModeAnnouncement => r'選取分鐘數';
+}
+
+// ignore: camel_case_types
+class _Bundle_pt_PT extends TranslationBundle {
+  const _Bundle_pt_PT() : super(const _Bundle_pt());
+  @override String get timePickerMinuteModeAnnouncement => r'Selecionar minutos';
+  @override String get timePickerHourModeAnnouncement => r'Selecionar horas';
+  @override String get deleteButtonTooltip => r'Eliminar';
+  @override String get nextMonthTooltip => r'Mês seguinte';
+  @override String get nextPageTooltip => r'Página seguinte';
+  @override String get aboutListTileTitle => r'Acerca de $applicationName';
+  @override String get pageRowsInfoTitle => r'$firstRow a $lastRow de $rowCount';
+  @override String get pageRowsInfoTitleApproximate => r'$firstRow a $lastRow de cerca de $rowCount';
+  @override String get cutButtonLabel => r'CORTAR';
+  @override String get okButtonLabel => r'OK';
+  @override String get anteMeridiemAbbreviation => r'AM';
+  @override String get postMeridiemAbbreviation => r'PM';
+  @override String get modalBarrierDismissLabel => r'Ignorar';
+}
+
+// ignore: camel_case_types
+class _Bundle_fr_CA extends TranslationBundle {
+  const _Bundle_fr_CA() : super(const _Bundle_fr());
+  @override String get timeOfDayFormat => r'HH ' "'" r'h' "'" r' mm';
+}
+
+TranslationBundle translationBundleForLocale(Locale locale) {
+  switch(locale.languageCode) {
+    case 'es': {
+      switch(locale.toString()) {
+        case 'es_UY':
+          return const _Bundle_es_UY();
+        case 'es_CR':
+          return const _Bundle_es_CR();
+        case 'es_US':
+          return const _Bundle_es_US();
+        case 'es_SV':
+          return const _Bundle_es_SV();
+        case 'es_DO':
+          return const _Bundle_es_DO();
+        case 'es_AR':
+          return const _Bundle_es_AR();
+        case 'es_419':
+          return const _Bundle_es_419();
+        case 'es_PE':
+          return const _Bundle_es_PE();
+        case 'es_VE':
+          return const _Bundle_es_VE();
+        case 'es_BO':
+          return const _Bundle_es_BO();
+        case 'es_PY':
+          return const _Bundle_es_PY();
+        case 'es_GT':
+          return const _Bundle_es_GT();
+        case 'es_NI':
+          return const _Bundle_es_NI();
+        case 'es_PA':
+          return const _Bundle_es_PA();
+        case 'es_HN':
+          return const _Bundle_es_HN();
+        case 'es_PR':
+          return const _Bundle_es_PR();
+        case 'es_MX':
+          return const _Bundle_es_MX();
+        case 'es_CO':
+          return const _Bundle_es_CO();
+        case 'es_EC':
+          return const _Bundle_es_EC();
+        case 'es_CL':
+          return const _Bundle_es_CL();
+      }
+      return const _Bundle_es();
+    }
+    case 'fa':
+      return const _Bundle_fa();
+    case 'en': {
+      switch(locale.toString()) {
+        case 'en_CA':
+          return const _Bundle_en_CA();
+        case 'en_ZA':
+          return const _Bundle_en_ZA();
+        case 'en_AU':
+          return const _Bundle_en_AU();
+        case 'en_IE':
+          return const _Bundle_en_IE();
+        case 'en_SG':
+          return const _Bundle_en_SG();
+        case 'en_GB':
+          return const _Bundle_en_GB();
+        case 'en_IN':
+          return const _Bundle_en_IN();
+      }
+      return const _Bundle_en();
+    }
+    case 'de': {
+      switch(locale.toString()) {
+        case 'de_CH':
+          return const _Bundle_de_CH();
+      }
+      return const _Bundle_de();
+    }
+    case 'ur':
+      return const _Bundle_ur();
+    case 'tr':
+      return const _Bundle_tr();
+    case 'ps':
+      return const _Bundle_ps();
+    case 'he':
+      return const _Bundle_he();
+    case 'zh': {
+      switch(locale.toString()) {
+        case 'zh_TW':
+          return const _Bundle_zh_TW();
+        case 'zh_HK':
+          return const _Bundle_zh_HK();
+      }
+      return const _Bundle_zh();
+    }
+    case 'ar':
+      return const _Bundle_ar();
+    case 'nl':
+      return const _Bundle_nl();
+    case 'pt': {
+      switch(locale.toString()) {
+        case 'pt_PT':
+          return const _Bundle_pt_PT();
+      }
+      return const _Bundle_pt();
+    }
+    case 'it':
+      return const _Bundle_it();
+    case 'fr': {
+      switch(locale.toString()) {
+        case 'fr_CA':
+          return const _Bundle_fr_CA();
+      }
+      return const _Bundle_fr();
+    }
+    case 'gsw':
+      return const _Bundle_gsw();
+    case 'ja':
+      return const _Bundle_ja();
+    case 'th':
+      return const _Bundle_th();
+    case 'ru':
+      return const _Bundle_ru();
+    case 'ko':
+      return const _Bundle_ko();
+    case 'pl':
+      return const _Bundle_pl();
+  }
+  return const TranslationBundle(null);
+}
 

--- a/packages/flutter_localizations/lib/src/l10n/localizations.dart
+++ b/packages/flutter_localizations/lib/src/l10n/localizations.dart
@@ -18,6 +18,11 @@ import 'dart:ui' show Locale;
 class TranslationBundle {
   const TranslationBundle(this.parent);
   final TranslationBundle parent;
+  String get selectedRowCountTitleOne => parent?.selectedRowCountTitleOne;
+  String get selectedRowCountTitleZero => parent?.selectedRowCountTitleZero;
+  String get selectedRowCountTitleTwo => parent?.selectedRowCountTitleTwo;
+  String get selectedRowCountTitleFew => parent?.selectedRowCountTitleFew;
+  String get selectedRowCountTitleMany => parent?.selectedRowCountTitleMany;
   String get scriptCategory => parent?.scriptCategory;
   String get timeOfDayFormat => parent?.timeOfDayFormat;
   String get openAppDrawerTooltip => parent?.openAppDrawerTooltip;
@@ -34,7 +39,6 @@ class TranslationBundle {
   String get pageRowsInfoTitle => parent?.pageRowsInfoTitle;
   String get pageRowsInfoTitleApproximate => parent?.pageRowsInfoTitleApproximate;
   String get rowsPerPageTitle => parent?.rowsPerPageTitle;
-  String get selectedRowCountTitleOne => parent?.selectedRowCountTitleOne;
   String get selectedRowCountTitleOther => parent?.selectedRowCountTitleOther;
   String get cancelButtonLabel => parent?.cancelButtonLabel;
   String get closeButtonLabel => parent?.closeButtonLabel;
@@ -50,10 +54,123 @@ class TranslationBundle {
   String get timePickerHourModeAnnouncement => parent?.timePickerHourModeAnnouncement;
   String get timePickerMinuteModeAnnouncement => parent?.timePickerMinuteModeAnnouncement;
   String get modalBarrierDismissLabel => parent?.modalBarrierDismissLabel;
-  String get selectedRowCountTitleTwo => parent?.selectedRowCountTitleTwo;
-  String get selectedRowCountTitleMany => parent?.selectedRowCountTitleMany;
-  String get selectedRowCountTitleZero => parent?.selectedRowCountTitleZero;
-  String get selectedRowCountTitleFew => parent?.selectedRowCountTitleFew;
+}
+
+// ignore: camel_case_types
+class _Bundle_ar extends TranslationBundle {
+  const _Bundle_ar() : super(null);
+  @override String get selectedRowCountTitleOne => r'تم اختيار عنصر واحد';
+  @override String get selectedRowCountTitleZero => r'لم يتم اختيار أي عنصر';
+  @override String get selectedRowCountTitleTwo => r'تم اختيار عنصرين ($selectedRowCount)';
+  @override String get selectedRowCountTitleFew => r'تم اختيار $selectedRowCount عنصر';
+  @override String get selectedRowCountTitleMany => r'تم اختيار $selectedRowCount عنصرًا';
+  @override String get scriptCategory => r'tall';
+  @override String get timeOfDayFormat => r'h:mm a';
+  @override String get openAppDrawerTooltip => r'فتح قائمة التنقل';
+  @override String get backButtonTooltip => r'رجوع';
+  @override String get closeButtonTooltip => r'إغلاق';
+  @override String get deleteButtonTooltip => r'حذف';
+  @override String get nextMonthTooltip => r'الشهر التالي';
+  @override String get previousMonthTooltip => r'الشهر السابق';
+  @override String get nextPageTooltip => r'الصفحة التالية';
+  @override String get previousPageTooltip => r'الصفحة السابقة';
+  @override String get showMenuTooltip => r'عرض القائمة';
+  @override String get aboutListTileTitle => r'حول "$applicationName"';
+  @override String get licensesPageTitle => r'التراخيص';
+  @override String get pageRowsInfoTitle => r'من $firstRow إلى $lastRow من إجمالي $rowCount';
+  @override String get pageRowsInfoTitleApproximate => r'من $firstRow إلى $lastRow من إجمالي $rowCount تقريبًا';
+  @override String get rowsPerPageTitle => r'عدد الصفوف في الصفحة:';
+  @override String get selectedRowCountTitleOther => r'تم اختيار $selectedRowCount عنصر';
+  @override String get cancelButtonLabel => r'إلغاء';
+  @override String get closeButtonLabel => r'إغلاق';
+  @override String get continueButtonLabel => r'متابعة';
+  @override String get copyButtonLabel => r'نسخ';
+  @override String get cutButtonLabel => r'قص';
+  @override String get okButtonLabel => r'حسنًا';
+  @override String get pasteButtonLabel => r'لصق';
+  @override String get selectAllButtonLabel => r'اختيار الكل';
+  @override String get viewLicensesButtonLabel => r'الاطّلاع على التراخيص';
+  @override String get anteMeridiemAbbreviation => r'ص';
+  @override String get postMeridiemAbbreviation => r'م';
+  @override String get timePickerHourModeAnnouncement => r'اختيار الساعات';
+  @override String get timePickerMinuteModeAnnouncement => r'اختيار الدقائق';
+  @override String get modalBarrierDismissLabel => r'تجاهل';
+}
+
+// ignore: camel_case_types
+class _Bundle_de extends TranslationBundle {
+  const _Bundle_de() : super(null);
+  @override String get scriptCategory => r'English-like';
+  @override String get timeOfDayFormat => r'HH:mm';
+  @override String get openAppDrawerTooltip => r'Navigationsmenü öffnen';
+  @override String get backButtonTooltip => r'Zurück';
+  @override String get closeButtonTooltip => r'Schließen';
+  @override String get deleteButtonTooltip => r'Löschen';
+  @override String get nextMonthTooltip => r'Nächster Monat';
+  @override String get previousMonthTooltip => r'Vorheriger Monat';
+  @override String get nextPageTooltip => r'Nächste Seite';
+  @override String get previousPageTooltip => r'Vorherige Seite';
+  @override String get showMenuTooltip => r'Menü anzeigen';
+  @override String get aboutListTileTitle => r'Über $applicationName';
+  @override String get licensesPageTitle => r'Lizenzen';
+  @override String get pageRowsInfoTitle => r'$firstRow–$lastRow von $rowCount';
+  @override String get pageRowsInfoTitleApproximate => r'$firstRow–$lastRow von etwa $rowCount';
+  @override String get rowsPerPageTitle => r'Zeilen pro Seite:';
+  @override String get selectedRowCountTitleZero => r'Keine Objekte ausgewählt';
+  @override String get selectedRowCountTitleOne => r'1 Element ausgewählt';
+  @override String get selectedRowCountTitleOther => r'$selectedRowCount Elemente ausgewählt';
+  @override String get cancelButtonLabel => r'ABBRECHEN';
+  @override String get closeButtonLabel => r'SCHLIEẞEN';
+  @override String get continueButtonLabel => r'WEITER';
+  @override String get copyButtonLabel => r'KOPIEREN';
+  @override String get cutButtonLabel => r'AUSSCHNEIDEN';
+  @override String get okButtonLabel => r'OK';
+  @override String get pasteButtonLabel => r'EINFÜGEN';
+  @override String get selectAllButtonLabel => r'ALLE AUSWÄHLEN';
+  @override String get viewLicensesButtonLabel => r'LIZENZEN ANZEIGEN';
+  @override String get anteMeridiemAbbreviation => r'VORM.';
+  @override String get postMeridiemAbbreviation => r'NACHM.';
+  @override String get timePickerHourModeAnnouncement => r'Stunden auswählen';
+  @override String get timePickerMinuteModeAnnouncement => r'Minuten auswählen';
+  @override String get modalBarrierDismissLabel => r'Schließen';
+}
+
+// ignore: camel_case_types
+class _Bundle_en extends TranslationBundle {
+  const _Bundle_en() : super(null);
+  @override String get scriptCategory => r'English-like';
+  @override String get timeOfDayFormat => r'h:mm a';
+  @override String get openAppDrawerTooltip => r'Open navigation menu';
+  @override String get backButtonTooltip => r'Back';
+  @override String get closeButtonTooltip => r'Close';
+  @override String get deleteButtonTooltip => r'Delete';
+  @override String get nextMonthTooltip => r'Next month';
+  @override String get previousMonthTooltip => r'Previous month';
+  @override String get nextPageTooltip => r'Next page';
+  @override String get previousPageTooltip => r'Previous page';
+  @override String get showMenuTooltip => r'Show menu';
+  @override String get aboutListTileTitle => r'About $applicationName';
+  @override String get licensesPageTitle => r'Licenses';
+  @override String get pageRowsInfoTitle => r'$firstRow–$lastRow of $rowCount';
+  @override String get pageRowsInfoTitleApproximate => r'$firstRow–$lastRow of about $rowCount';
+  @override String get rowsPerPageTitle => r'Rows per page:';
+  @override String get selectedRowCountTitleZero => r'No items selected';
+  @override String get selectedRowCountTitleOne => r'1 item selected';
+  @override String get selectedRowCountTitleOther => r'$selectedRowCount items selected';
+  @override String get cancelButtonLabel => r'CANCEL';
+  @override String get closeButtonLabel => r'CLOSE';
+  @override String get continueButtonLabel => r'CONTINUE';
+  @override String get copyButtonLabel => r'COPY';
+  @override String get cutButtonLabel => r'CUT';
+  @override String get okButtonLabel => r'OK';
+  @override String get pasteButtonLabel => r'PASTE';
+  @override String get selectAllButtonLabel => r'SELECT ALL';
+  @override String get viewLicensesButtonLabel => r'VIEW LICENSES';
+  @override String get anteMeridiemAbbreviation => r'AM';
+  @override String get postMeridiemAbbreviation => r'PM';
+  @override String get timePickerHourModeAnnouncement => r'Select hours';
+  @override String get timePickerMinuteModeAnnouncement => r'Select minutes';
+  @override String get modalBarrierDismissLabel => r'Dismiss';
 }
 
 // ignore: camel_case_types
@@ -132,418 +249,6 @@ class _Bundle_fa extends TranslationBundle {
 }
 
 // ignore: camel_case_types
-class _Bundle_en extends TranslationBundle {
-  const _Bundle_en() : super(null);
-  @override String get scriptCategory => r'English-like';
-  @override String get timeOfDayFormat => r'h:mm a';
-  @override String get openAppDrawerTooltip => r'Open navigation menu';
-  @override String get backButtonTooltip => r'Back';
-  @override String get closeButtonTooltip => r'Close';
-  @override String get deleteButtonTooltip => r'Delete';
-  @override String get nextMonthTooltip => r'Next month';
-  @override String get previousMonthTooltip => r'Previous month';
-  @override String get nextPageTooltip => r'Next page';
-  @override String get previousPageTooltip => r'Previous page';
-  @override String get showMenuTooltip => r'Show menu';
-  @override String get aboutListTileTitle => r'About $applicationName';
-  @override String get licensesPageTitle => r'Licenses';
-  @override String get pageRowsInfoTitle => r'$firstRow–$lastRow of $rowCount';
-  @override String get pageRowsInfoTitleApproximate => r'$firstRow–$lastRow of about $rowCount';
-  @override String get rowsPerPageTitle => r'Rows per page:';
-  @override String get selectedRowCountTitleZero => r'No items selected';
-  @override String get selectedRowCountTitleOne => r'1 item selected';
-  @override String get selectedRowCountTitleOther => r'$selectedRowCount items selected';
-  @override String get cancelButtonLabel => r'CANCEL';
-  @override String get closeButtonLabel => r'CLOSE';
-  @override String get continueButtonLabel => r'CONTINUE';
-  @override String get copyButtonLabel => r'COPY';
-  @override String get cutButtonLabel => r'CUT';
-  @override String get okButtonLabel => r'OK';
-  @override String get pasteButtonLabel => r'PASTE';
-  @override String get selectAllButtonLabel => r'SELECT ALL';
-  @override String get viewLicensesButtonLabel => r'VIEW LICENSES';
-  @override String get anteMeridiemAbbreviation => r'AM';
-  @override String get postMeridiemAbbreviation => r'PM';
-  @override String get timePickerHourModeAnnouncement => r'Select hours';
-  @override String get timePickerMinuteModeAnnouncement => r'Select minutes';
-  @override String get modalBarrierDismissLabel => r'Dismiss';
-}
-
-// ignore: camel_case_types
-class _Bundle_de extends TranslationBundle {
-  const _Bundle_de() : super(null);
-  @override String get scriptCategory => r'English-like';
-  @override String get timeOfDayFormat => r'HH:mm';
-  @override String get openAppDrawerTooltip => r'Navigationsmenü öffnen';
-  @override String get backButtonTooltip => r'Zurück';
-  @override String get closeButtonTooltip => r'Schließen';
-  @override String get deleteButtonTooltip => r'Löschen';
-  @override String get nextMonthTooltip => r'Nächster Monat';
-  @override String get previousMonthTooltip => r'Vorheriger Monat';
-  @override String get nextPageTooltip => r'Nächste Seite';
-  @override String get previousPageTooltip => r'Vorherige Seite';
-  @override String get showMenuTooltip => r'Menü anzeigen';
-  @override String get aboutListTileTitle => r'Über $applicationName';
-  @override String get licensesPageTitle => r'Lizenzen';
-  @override String get pageRowsInfoTitle => r'$firstRow–$lastRow von $rowCount';
-  @override String get pageRowsInfoTitleApproximate => r'$firstRow–$lastRow von etwa $rowCount';
-  @override String get rowsPerPageTitle => r'Zeilen pro Seite:';
-  @override String get selectedRowCountTitleZero => r'Keine Objekte ausgewählt';
-  @override String get selectedRowCountTitleOne => r'1 Element ausgewählt';
-  @override String get selectedRowCountTitleOther => r'$selectedRowCount Elemente ausgewählt';
-  @override String get cancelButtonLabel => r'ABBRECHEN';
-  @override String get closeButtonLabel => r'SCHLIEẞEN';
-  @override String get continueButtonLabel => r'WEITER';
-  @override String get copyButtonLabel => r'KOPIEREN';
-  @override String get cutButtonLabel => r'AUSSCHNEIDEN';
-  @override String get okButtonLabel => r'OK';
-  @override String get pasteButtonLabel => r'EINFÜGEN';
-  @override String get selectAllButtonLabel => r'ALLE AUSWÄHLEN';
-  @override String get viewLicensesButtonLabel => r'LIZENZEN ANZEIGEN';
-  @override String get anteMeridiemAbbreviation => r'VORM.';
-  @override String get postMeridiemAbbreviation => r'NACHM.';
-  @override String get timePickerHourModeAnnouncement => r'Stunden auswählen';
-  @override String get timePickerMinuteModeAnnouncement => r'Minuten auswählen';
-  @override String get modalBarrierDismissLabel => r'Schließen';
-}
-
-// ignore: camel_case_types
-class _Bundle_ur extends TranslationBundle {
-  const _Bundle_ur() : super(null);
-  @override String get scriptCategory => r'tall';
-  @override String get timeOfDayFormat => r'h:mm a';
-  @override String get selectedRowCountTitleOne => r'1 آئٹم منتخب کیا گیا';
-  @override String get openAppDrawerTooltip => r'نیویگیشن مینو کھولیں';
-  @override String get backButtonTooltip => r'پیچھے';
-  @override String get closeButtonTooltip => r'بند کریں';
-  @override String get deleteButtonTooltip => r'حذف کریں';
-  @override String get nextMonthTooltip => r'اگلا مہینہ';
-  @override String get previousMonthTooltip => r'پچھلا مہینہ';
-  @override String get nextPageTooltip => r'اگلا صفحہ';
-  @override String get previousPageTooltip => r'گزشتہ صفحہ';
-  @override String get showMenuTooltip => r'مینو دکھائیں';
-  @override String get aboutListTileTitle => r'$applicationName کے بارے میں';
-  @override String get licensesPageTitle => r'لائسنسز';
-  @override String get pageRowsInfoTitle => r'$firstRow–$lastRow از $rowCount';
-  @override String get pageRowsInfoTitleApproximate => r'$firstRow–$lastRow $rowCount میں سے تقریباً';
-  @override String get rowsPerPageTitle => r'قطاریں فی صفحہ:';
-  @override String get selectedRowCountTitleOther => r'$selectedRowCount آئٹمز منتخب کیے گئے';
-  @override String get cancelButtonLabel => r'منسوخ کریں';
-  @override String get closeButtonLabel => r'بند کریں';
-  @override String get continueButtonLabel => r'جاری رکھیں';
-  @override String get copyButtonLabel => r'کاپی کریں';
-  @override String get cutButtonLabel => r'کٹ کریں';
-  @override String get okButtonLabel => r'ٹھیک ہے';
-  @override String get pasteButtonLabel => r'پیسٹ کریں';
-  @override String get selectAllButtonLabel => r'سبھی منتخب کریں';
-  @override String get viewLicensesButtonLabel => r'لائسنسز دیکھیں';
-  @override String get anteMeridiemAbbreviation => r'AM';
-  @override String get postMeridiemAbbreviation => r'PM';
-  @override String get timePickerHourModeAnnouncement => r'گھنٹے منتخب کریں';
-  @override String get timePickerMinuteModeAnnouncement => r'منٹ منتخب کریں';
-  @override String get modalBarrierDismissLabel => r'برطرف';
-}
-
-// ignore: camel_case_types
-class _Bundle_tr extends TranslationBundle {
-  const _Bundle_tr() : super(null);
-  @override String get scriptCategory => r'English-like';
-  @override String get timeOfDayFormat => r'HH:mm';
-  @override String get openAppDrawerTooltip => r'Gezinme menüsünü aç';
-  @override String get backButtonTooltip => r'Geri';
-  @override String get closeButtonTooltip => r'Kapat';
-  @override String get deleteButtonTooltip => r'Sil';
-  @override String get nextMonthTooltip => r'Gelecek ay';
-  @override String get previousMonthTooltip => r'Önceki ay';
-  @override String get nextPageTooltip => r'Sonraki sayfa';
-  @override String get previousPageTooltip => r'Önceki sayfa';
-  @override String get showMenuTooltip => r'Menüyü göster';
-  @override String get aboutListTileTitle => r'$applicationName Hakkında';
-  @override String get licensesPageTitle => r'Lisanslar';
-  @override String get pageRowsInfoTitle => r'$firstRow-$lastRow / $rowCount';
-  @override String get pageRowsInfoTitleApproximate => r'$firstRow-$lastRow / $rowCount';
-  @override String get rowsPerPageTitle => r'Sayfa başına satır sayısı:';
-  @override String get selectedRowCountTitleOne => r'1 öğe seçildi';
-  @override String get selectedRowCountTitleOther => r'$selectedRowCount öğe seçildi';
-  @override String get cancelButtonLabel => r'İPTAL';
-  @override String get closeButtonLabel => r'KAPAT';
-  @override String get continueButtonLabel => r'DEVAM';
-  @override String get copyButtonLabel => r'KOPYALA';
-  @override String get cutButtonLabel => r'KES';
-  @override String get okButtonLabel => r'Tamam';
-  @override String get pasteButtonLabel => r'YAPIŞTIR';
-  @override String get selectAllButtonLabel => r'TÜMÜNÜ SEÇ';
-  @override String get viewLicensesButtonLabel => r'LİSANLARI GÖSTER';
-  @override String get anteMeridiemAbbreviation => r'ÖÖ';
-  @override String get postMeridiemAbbreviation => r'ÖS';
-  @override String get timePickerHourModeAnnouncement => r'Saati seçin';
-  @override String get timePickerMinuteModeAnnouncement => r'Dakikayı seçin';
-  @override String get modalBarrierDismissLabel => r'Reddet';
-}
-
-// ignore: camel_case_types
-class _Bundle_ps extends TranslationBundle {
-  const _Bundle_ps() : super(null);
-  @override String get scriptCategory => r'tall';
-  @override String get timeOfDayFormat => r'HH:mm';
-  @override String get openAppDrawerTooltip => r'د پرانیستی نیینګ مینو';
-  @override String get backButtonTooltip => r'شاته';
-  @override String get closeButtonTooltip => r'بنده';
-  @override String get deleteButtonTooltip => r'';
-  @override String get nextMonthTooltip => r'بله میاشت';
-  @override String get previousMonthTooltip => r'تیره میاشت';
-  @override String get nextPageTooltip => r'بله پاڼه';
-  @override String get previousPageTooltip => r'مخکینی مخ';
-  @override String get showMenuTooltip => r'غورنۍ ښودل';
-  @override String get aboutListTileTitle => r'د $applicationName په اړه';
-  @override String get licensesPageTitle => r'جوازونه';
-  @override String get pageRowsInfoTitle => r'$firstRow–$lastRow د $rowCount';
-  @override String get pageRowsInfoTitleApproximate => r'$firstRow–$lastRow څخه $rowCount د';
-  @override String get rowsPerPageTitle => r'د هرې پاڼې پاڼې:';
-  @override String get selectedRowCountTitleOther => r'$selectedRowCount توکي غوره شوي';
-  @override String get cancelButtonLabel => r'لغوه کول';
-  @override String get closeButtonLabel => r'تړل';
-  @override String get continueButtonLabel => r'منځپانګې';
-  @override String get copyButtonLabel => r'کاپی';
-  @override String get cutButtonLabel => r'کم کړئ';
-  @override String get okButtonLabel => r'سمه ده';
-  @override String get pasteButtonLabel => r'پیټ کړئ';
-  @override String get selectAllButtonLabel => r'غوره کړئ';
-  @override String get viewLicensesButtonLabel => r'لیدلس وګورئ';
-  @override String get timePickerHourModeAnnouncement => r'وختونه وټاکئ';
-  @override String get timePickerMinuteModeAnnouncement => r'منې غوره کړئ';
-  @override String get modalBarrierDismissLabel => r'رد کړه';
-}
-
-// ignore: camel_case_types
-class _Bundle_he extends TranslationBundle {
-  const _Bundle_he() : super(null);
-  @override String get scriptCategory => r'English-like';
-  @override String get timeOfDayFormat => r'H:mm';
-  @override String get selectedRowCountTitleOne => r'פריט אחד נבחר';
-  @override String get selectedRowCountTitleTwo => r'$selectedRowCount פריטים נבחרו';
-  @override String get selectedRowCountTitleMany => r'$selectedRowCount פריטים נבחרו';
-  @override String get openAppDrawerTooltip => r'פתיחה של תפריט הניווט';
-  @override String get backButtonTooltip => r'הקודם';
-  @override String get closeButtonTooltip => r'סגירה';
-  @override String get deleteButtonTooltip => r'מחיקה';
-  @override String get nextMonthTooltip => r'החודש הבא';
-  @override String get previousMonthTooltip => r'החודש הקודם';
-  @override String get nextPageTooltip => r'הדף הבא';
-  @override String get previousPageTooltip => r'הדף הקודם';
-  @override String get showMenuTooltip => r'הצגת התפריט';
-  @override String get aboutListTileTitle => r'מידע על $applicationName';
-  @override String get licensesPageTitle => r'רישיונות';
-  @override String get pageRowsInfoTitle => r'$lastRow–$firstRow מתוך $rowCount';
-  @override String get pageRowsInfoTitleApproximate => r'$lastRow–$firstRow מתוך כ-$rowCount';
-  @override String get rowsPerPageTitle => r'שורות בכל דף:';
-  @override String get selectedRowCountTitleOther => r'$selectedRowCount פריטים נבחרו';
-  @override String get cancelButtonLabel => r'ביטול';
-  @override String get closeButtonLabel => r'סגירה';
-  @override String get continueButtonLabel => r'המשך';
-  @override String get copyButtonLabel => r'העתקה';
-  @override String get cutButtonLabel => r'גזירה';
-  @override String get okButtonLabel => r'אישור';
-  @override String get pasteButtonLabel => r'הדבקה';
-  @override String get selectAllButtonLabel => r'בחירת הכול';
-  @override String get viewLicensesButtonLabel => r'הצגת הרישיונות';
-  @override String get anteMeridiemAbbreviation => r'AM';
-  @override String get postMeridiemAbbreviation => r'PM';
-  @override String get timePickerHourModeAnnouncement => r'בחירת שעות';
-  @override String get timePickerMinuteModeAnnouncement => r'בחירת דקות';
-  @override String get modalBarrierDismissLabel => r'סגירה';
-}
-
-// ignore: camel_case_types
-class _Bundle_zh extends TranslationBundle {
-  const _Bundle_zh() : super(null);
-  @override String get scriptCategory => r'dense';
-  @override String get timeOfDayFormat => r'ah:mm';
-  @override String get selectedRowCountTitleOne => r'已选择 1 项内容';
-  @override String get openAppDrawerTooltip => r'打开导航菜单';
-  @override String get backButtonTooltip => r'返回';
-  @override String get nextPageTooltip => r'下一页';
-  @override String get previousPageTooltip => r'上一页';
-  @override String get showMenuTooltip => r'显示菜单';
-  @override String get aboutListTileTitle => r'关于$applicationName';
-  @override String get licensesPageTitle => r'许可';
-  @override String get pageRowsInfoTitle => r'第 $firstRow-$lastRow 行（共 $rowCount 行）';
-  @override String get pageRowsInfoTitleApproximate => r'第 $firstRow-$lastRow 行（共约 $rowCount 行）';
-  @override String get rowsPerPageTitle => r'每页行数：';
-  @override String get selectedRowCountTitleOther => r'已选择 $selectedRowCount 项内容';
-  @override String get cancelButtonLabel => r'取消';
-  @override String get continueButtonLabel => r'继续';
-  @override String get closeButtonLabel => r'关闭';
-  @override String get copyButtonLabel => r'复制';
-  @override String get cutButtonLabel => r'剪切';
-  @override String get okButtonLabel => r'确定';
-  @override String get pasteButtonLabel => r'粘贴';
-  @override String get selectAllButtonLabel => r'全选';
-  @override String get viewLicensesButtonLabel => r'查看许可';
-  @override String get closeButtonTooltip => r'关闭';
-  @override String get deleteButtonTooltip => r'删除';
-  @override String get nextMonthTooltip => r'下个月';
-  @override String get previousMonthTooltip => r'上个月';
-  @override String get anteMeridiemAbbreviation => r'上午';
-  @override String get postMeridiemAbbreviation => r'下午';
-  @override String get timePickerHourModeAnnouncement => r'选择小时';
-  @override String get timePickerMinuteModeAnnouncement => r'选择分钟';
-  @override String get modalBarrierDismissLabel => r'关闭';
-}
-
-// ignore: camel_case_types
-class _Bundle_ar extends TranslationBundle {
-  const _Bundle_ar() : super(null);
-  @override String get selectedRowCountTitleOne => r'تم اختيار عنصر واحد';
-  @override String get selectedRowCountTitleZero => r'لم يتم اختيار أي عنصر';
-  @override String get selectedRowCountTitleTwo => r'تم اختيار عنصرين ($selectedRowCount)';
-  @override String get selectedRowCountTitleFew => r'تم اختيار $selectedRowCount عنصر';
-  @override String get selectedRowCountTitleMany => r'تم اختيار $selectedRowCount عنصرًا';
-  @override String get scriptCategory => r'tall';
-  @override String get timeOfDayFormat => r'h:mm a';
-  @override String get openAppDrawerTooltip => r'فتح قائمة التنقل';
-  @override String get backButtonTooltip => r'رجوع';
-  @override String get closeButtonTooltip => r'إغلاق';
-  @override String get deleteButtonTooltip => r'حذف';
-  @override String get nextMonthTooltip => r'الشهر التالي';
-  @override String get previousMonthTooltip => r'الشهر السابق';
-  @override String get nextPageTooltip => r'الصفحة التالية';
-  @override String get previousPageTooltip => r'الصفحة السابقة';
-  @override String get showMenuTooltip => r'عرض القائمة';
-  @override String get aboutListTileTitle => r'حول "$applicationName"';
-  @override String get licensesPageTitle => r'التراخيص';
-  @override String get pageRowsInfoTitle => r'من $firstRow إلى $lastRow من إجمالي $rowCount';
-  @override String get pageRowsInfoTitleApproximate => r'من $firstRow إلى $lastRow من إجمالي $rowCount تقريبًا';
-  @override String get rowsPerPageTitle => r'عدد الصفوف في الصفحة:';
-  @override String get selectedRowCountTitleOther => r'تم اختيار $selectedRowCount عنصر';
-  @override String get cancelButtonLabel => r'إلغاء';
-  @override String get closeButtonLabel => r'إغلاق';
-  @override String get continueButtonLabel => r'متابعة';
-  @override String get copyButtonLabel => r'نسخ';
-  @override String get cutButtonLabel => r'قص';
-  @override String get okButtonLabel => r'حسنًا';
-  @override String get pasteButtonLabel => r'لصق';
-  @override String get selectAllButtonLabel => r'اختيار الكل';
-  @override String get viewLicensesButtonLabel => r'الاطّلاع على التراخيص';
-  @override String get anteMeridiemAbbreviation => r'ص';
-  @override String get postMeridiemAbbreviation => r'م';
-  @override String get timePickerHourModeAnnouncement => r'اختيار الساعات';
-  @override String get timePickerMinuteModeAnnouncement => r'اختيار الدقائق';
-  @override String get modalBarrierDismissLabel => r'تجاهل';
-}
-
-// ignore: camel_case_types
-class _Bundle_nl extends TranslationBundle {
-  const _Bundle_nl() : super(null);
-  @override String get scriptCategory => r'English-like';
-  @override String get timeOfDayFormat => r'HH:mm';
-  @override String get openAppDrawerTooltip => r'Navigatiemenu openen';
-  @override String get backButtonTooltip => r'Terug';
-  @override String get closeButtonTooltip => r'Sluiten';
-  @override String get deleteButtonTooltip => r'Verwijderen';
-  @override String get nextMonthTooltip => r'Volgende maand';
-  @override String get previousMonthTooltip => r'Vorige maand';
-  @override String get nextPageTooltip => r'Volgende pagina';
-  @override String get previousPageTooltip => r'Vorige pagina';
-  @override String get showMenuTooltip => r'Menu weergeven';
-  @override String get aboutListTileTitle => r'Over $applicationName';
-  @override String get licensesPageTitle => r'Licenties';
-  @override String get pageRowsInfoTitle => r'$firstRow-$lastRow van $rowCount';
-  @override String get pageRowsInfoTitleApproximate => r'$firstRow-$lastRow van ongeveer $rowCount';
-  @override String get rowsPerPageTitle => r'Rijen per pagina:';
-  @override String get selectedRowCountTitleOne => r'1 item geselecteerd';
-  @override String get selectedRowCountTitleOther => r'$selectedRowCount items geselecteerd';
-  @override String get cancelButtonLabel => r'ANNULEREN';
-  @override String get closeButtonLabel => r'SLUITEN';
-  @override String get continueButtonLabel => r'DOORGAAN';
-  @override String get copyButtonLabel => r'KOPIËREN';
-  @override String get cutButtonLabel => r'KNIPPEN';
-  @override String get okButtonLabel => r'OK';
-  @override String get pasteButtonLabel => r'PLAKKEN';
-  @override String get selectAllButtonLabel => r'ALLES SELECTEREN';
-  @override String get viewLicensesButtonLabel => r'LICENTIES BEKIJKEN';
-  @override String get anteMeridiemAbbreviation => r'am';
-  @override String get postMeridiemAbbreviation => r'pm';
-  @override String get timePickerHourModeAnnouncement => r'Uren selecteren';
-  @override String get timePickerMinuteModeAnnouncement => r'Minuten selecteren';
-  @override String get modalBarrierDismissLabel => r'ontslaan';
-}
-
-// ignore: camel_case_types
-class _Bundle_pt extends TranslationBundle {
-  const _Bundle_pt() : super(null);
-  @override String get anteMeridiemAbbreviation => r'Manhã';
-  @override String get selectedRowCountTitleOne => r'1 item selecionado';
-  @override String get postMeridiemAbbreviation => r'Tarde/noite';
-  @override String get scriptCategory => r'English-like';
-  @override String get timeOfDayFormat => r'HH:mm';
-  @override String get openAppDrawerTooltip => r'Abrir menu de navegação';
-  @override String get backButtonTooltip => r'Voltar';
-  @override String get closeButtonTooltip => r'Fechar';
-  @override String get deleteButtonTooltip => r'Excluir';
-  @override String get nextMonthTooltip => r'Próximo mês';
-  @override String get previousMonthTooltip => r'Mês anterior';
-  @override String get nextPageTooltip => r'Próxima página';
-  @override String get previousPageTooltip => r'Página anterior';
-  @override String get showMenuTooltip => r'Mostrar menu';
-  @override String get aboutListTileTitle => r'Sobre o app $applicationName';
-  @override String get licensesPageTitle => r'Licenças';
-  @override String get pageRowsInfoTitle => r'$firstRow – $lastRow de $rowCount';
-  @override String get pageRowsInfoTitleApproximate => r'$firstRow – $lastRow de aproximadamente $rowCount';
-  @override String get rowsPerPageTitle => r'Linhas por página:';
-  @override String get selectedRowCountTitleOther => r'$selectedRowCount itens selecionados';
-  @override String get cancelButtonLabel => r'CANCELAR';
-  @override String get closeButtonLabel => r'FECHAR';
-  @override String get continueButtonLabel => r'CONTINUAR';
-  @override String get copyButtonLabel => r'COPIAR';
-  @override String get cutButtonLabel => r'RECORTAR';
-  @override String get okButtonLabel => r'Ok';
-  @override String get pasteButtonLabel => r'COLAR';
-  @override String get selectAllButtonLabel => r'SELECIONAR TUDO';
-  @override String get viewLicensesButtonLabel => r'VER LICENÇAS';
-  @override String get timePickerHourModeAnnouncement => r'Selecione as horas';
-  @override String get timePickerMinuteModeAnnouncement => r'Selecione os minutos';
-  @override String get modalBarrierDismissLabel => r'Dispensar';
-}
-
-// ignore: camel_case_types
-class _Bundle_it extends TranslationBundle {
-  const _Bundle_it() : super(null);
-  @override String get scriptCategory => r'English-like';
-  @override String get timeOfDayFormat => r'HH:mm';
-  @override String get selectedRowCountTitleOne => r'1 elemento selezionato';
-  @override String get openAppDrawerTooltip => r'Apri il menu di navigazione';
-  @override String get backButtonTooltip => r'Indietro';
-  @override String get closeButtonTooltip => r'Chiudi';
-  @override String get deleteButtonTooltip => r'Elimina';
-  @override String get nextMonthTooltip => r'Mese successivo';
-  @override String get previousMonthTooltip => r'Mese precedente';
-  @override String get nextPageTooltip => r'Pagina successiva';
-  @override String get previousPageTooltip => r'Pagina precedente';
-  @override String get showMenuTooltip => r'Mostra il menu';
-  @override String get aboutListTileTitle => r'Informazioni su $applicationName';
-  @override String get licensesPageTitle => r'Licenze';
-  @override String get pageRowsInfoTitle => r'$firstRow-$lastRow di $rowCount';
-  @override String get pageRowsInfoTitleApproximate => r'$firstRow-$lastRow di circa $rowCount';
-  @override String get rowsPerPageTitle => r'Righe per pagina:';
-  @override String get selectedRowCountTitleOther => r'$selectedRowCount elementi selezionati';
-  @override String get cancelButtonLabel => r'ANNULLA';
-  @override String get closeButtonLabel => r'CHIUDI';
-  @override String get continueButtonLabel => r'CONTINUA';
-  @override String get copyButtonLabel => r'COPIA';
-  @override String get cutButtonLabel => r'TAGLIA';
-  @override String get okButtonLabel => r'OK';
-  @override String get pasteButtonLabel => r'INCOLLA';
-  @override String get selectAllButtonLabel => r'SELEZIONA TUTTO';
-  @override String get viewLicensesButtonLabel => r'VISUALIZZA LICENZE';
-  @override String get anteMeridiemAbbreviation => r'AM';
-  @override String get postMeridiemAbbreviation => r'PM';
-  @override String get timePickerHourModeAnnouncement => r'Seleziona le ore';
-  @override String get timePickerMinuteModeAnnouncement => r'Seleziona i minuti';
-  @override String get modalBarrierDismissLabel => r'Ignora';
-}
-
-// ignore: camel_case_types
 class _Bundle_fr extends TranslationBundle {
   const _Bundle_fr() : super(null);
   @override String get scriptCategory => r'English-like';
@@ -619,6 +324,82 @@ class _Bundle_gsw extends TranslationBundle {
 }
 
 // ignore: camel_case_types
+class _Bundle_he extends TranslationBundle {
+  const _Bundle_he() : super(null);
+  @override String get scriptCategory => r'English-like';
+  @override String get timeOfDayFormat => r'H:mm';
+  @override String get selectedRowCountTitleOne => r'פריט אחד נבחר';
+  @override String get selectedRowCountTitleTwo => r'$selectedRowCount פריטים נבחרו';
+  @override String get selectedRowCountTitleMany => r'$selectedRowCount פריטים נבחרו';
+  @override String get openAppDrawerTooltip => r'פתיחה של תפריט הניווט';
+  @override String get backButtonTooltip => r'הקודם';
+  @override String get closeButtonTooltip => r'סגירה';
+  @override String get deleteButtonTooltip => r'מחיקה';
+  @override String get nextMonthTooltip => r'החודש הבא';
+  @override String get previousMonthTooltip => r'החודש הקודם';
+  @override String get nextPageTooltip => r'הדף הבא';
+  @override String get previousPageTooltip => r'הדף הקודם';
+  @override String get showMenuTooltip => r'הצגת התפריט';
+  @override String get aboutListTileTitle => r'מידע על $applicationName';
+  @override String get licensesPageTitle => r'רישיונות';
+  @override String get pageRowsInfoTitle => r'$lastRow–$firstRow מתוך $rowCount';
+  @override String get pageRowsInfoTitleApproximate => r'$lastRow–$firstRow מתוך כ-$rowCount';
+  @override String get rowsPerPageTitle => r'שורות בכל דף:';
+  @override String get selectedRowCountTitleOther => r'$selectedRowCount פריטים נבחרו';
+  @override String get cancelButtonLabel => r'ביטול';
+  @override String get closeButtonLabel => r'סגירה';
+  @override String get continueButtonLabel => r'המשך';
+  @override String get copyButtonLabel => r'העתקה';
+  @override String get cutButtonLabel => r'גזירה';
+  @override String get okButtonLabel => r'אישור';
+  @override String get pasteButtonLabel => r'הדבקה';
+  @override String get selectAllButtonLabel => r'בחירת הכול';
+  @override String get viewLicensesButtonLabel => r'הצגת הרישיונות';
+  @override String get anteMeridiemAbbreviation => r'AM';
+  @override String get postMeridiemAbbreviation => r'PM';
+  @override String get timePickerHourModeAnnouncement => r'בחירת שעות';
+  @override String get timePickerMinuteModeAnnouncement => r'בחירת דקות';
+  @override String get modalBarrierDismissLabel => r'סגירה';
+}
+
+// ignore: camel_case_types
+class _Bundle_it extends TranslationBundle {
+  const _Bundle_it() : super(null);
+  @override String get scriptCategory => r'English-like';
+  @override String get timeOfDayFormat => r'HH:mm';
+  @override String get selectedRowCountTitleOne => r'1 elemento selezionato';
+  @override String get openAppDrawerTooltip => r'Apri il menu di navigazione';
+  @override String get backButtonTooltip => r'Indietro';
+  @override String get closeButtonTooltip => r'Chiudi';
+  @override String get deleteButtonTooltip => r'Elimina';
+  @override String get nextMonthTooltip => r'Mese successivo';
+  @override String get previousMonthTooltip => r'Mese precedente';
+  @override String get nextPageTooltip => r'Pagina successiva';
+  @override String get previousPageTooltip => r'Pagina precedente';
+  @override String get showMenuTooltip => r'Mostra il menu';
+  @override String get aboutListTileTitle => r'Informazioni su $applicationName';
+  @override String get licensesPageTitle => r'Licenze';
+  @override String get pageRowsInfoTitle => r'$firstRow-$lastRow di $rowCount';
+  @override String get pageRowsInfoTitleApproximate => r'$firstRow-$lastRow di circa $rowCount';
+  @override String get rowsPerPageTitle => r'Righe per pagina:';
+  @override String get selectedRowCountTitleOther => r'$selectedRowCount elementi selezionati';
+  @override String get cancelButtonLabel => r'ANNULLA';
+  @override String get closeButtonLabel => r'CHIUDI';
+  @override String get continueButtonLabel => r'CONTINUA';
+  @override String get copyButtonLabel => r'COPIA';
+  @override String get cutButtonLabel => r'TAGLIA';
+  @override String get okButtonLabel => r'OK';
+  @override String get pasteButtonLabel => r'INCOLLA';
+  @override String get selectAllButtonLabel => r'SELEZIONA TUTTO';
+  @override String get viewLicensesButtonLabel => r'VISUALIZZA LICENZE';
+  @override String get anteMeridiemAbbreviation => r'AM';
+  @override String get postMeridiemAbbreviation => r'PM';
+  @override String get timePickerHourModeAnnouncement => r'Seleziona le ore';
+  @override String get timePickerMinuteModeAnnouncement => r'Seleziona i minuti';
+  @override String get modalBarrierDismissLabel => r'Ignora';
+}
+
+// ignore: camel_case_types
 class _Bundle_ja extends TranslationBundle {
   const _Bundle_ja() : super(null);
   @override String get scriptCategory => r'dense';
@@ -656,40 +437,187 @@ class _Bundle_ja extends TranslationBundle {
 }
 
 // ignore: camel_case_types
-class _Bundle_th extends TranslationBundle {
-  const _Bundle_th() : super(null);
-  @override String get scriptCategory => r'tall';
-  @override String get timeOfDayFormat => r'ah:mm';
-  @override String get openAppDrawerTooltip => r'เปิดเมนูการนำทาง';
-  @override String get backButtonTooltip => r'กลับ';
-  @override String get closeButtonTooltip => r'ปิด';
-  @override String get deleteButtonTooltip => r'ลบ';
-  @override String get nextMonthTooltip => r'เดือนหน้า';
-  @override String get previousMonthTooltip => r'เดือนที่แล้ว';
-  @override String get nextPageTooltip => r'หน้าถัดไป';
-  @override String get previousPageTooltip => r'หน้าก่อน';
-  @override String get showMenuTooltip => r'แสดงเมนู';
-  @override String get aboutListTileTitle => r'เกี่ยวกับ $applicationName';
-  @override String get licensesPageTitle => r'ใบอนุญาต';
-  @override String get pageRowsInfoTitle => r'$firstRow-$lastRow จาก $rowCount';
-  @override String get pageRowsInfoTitleApproximate => r'$firstRow–$lastRow จากประมาณ $rowCount';
-  @override String get rowsPerPageTitle => r'แถวต่อหน้า:';
-  @override String get selectedRowCountTitleOne => r'เลือกแล้ว 1 รายการ';
-  @override String get selectedRowCountTitleOther => r'เลือกแล้ว $selectedRowCount รายการ';
-  @override String get cancelButtonLabel => r'ยกเลิก';
-  @override String get closeButtonLabel => r'ปิด';
-  @override String get continueButtonLabel => r'ต่อไป';
-  @override String get copyButtonLabel => r'คัดลอก';
-  @override String get cutButtonLabel => r'ตัด';
-  @override String get okButtonLabel => r'ตกลง';
-  @override String get pasteButtonLabel => r'วาง';
-  @override String get selectAllButtonLabel => r'เลือกทั้งหมด';
-  @override String get viewLicensesButtonLabel => r'ดูใบอนุญาต';
+class _Bundle_ko extends TranslationBundle {
+  const _Bundle_ko() : super(null);
+  @override String get scriptCategory => r'dense';
+  @override String get timeOfDayFormat => r'a h:mm';
+  @override String get openAppDrawerTooltip => r'탐색 메뉴 열기';
+  @override String get backButtonTooltip => r'뒤로';
+  @override String get closeButtonTooltip => r'닫기';
+  @override String get deleteButtonTooltip => r'삭제';
+  @override String get nextMonthTooltip => r'다음 달';
+  @override String get previousMonthTooltip => r'지난달';
+  @override String get nextPageTooltip => r'다음 페이지';
+  @override String get previousPageTooltip => r'이전 페이지';
+  @override String get showMenuTooltip => r'메뉴 표시';
+  @override String get aboutListTileTitle => r'$applicationName 정보';
+  @override String get licensesPageTitle => r'라이선스';
+  @override String get pageRowsInfoTitle => r'$rowCount행 중 $firstRow~$lastRow행';
+  @override String get pageRowsInfoTitleApproximate => r'약 $rowCount행 중 $firstRow~$lastRow행';
+  @override String get rowsPerPageTitle => r'페이지당 행 수:';
+  @override String get selectedRowCountTitleOne => r'항목 1개 선택됨';
+  @override String get selectedRowCountTitleOther => r'항목 $selectedRowCount개 선택됨';
+  @override String get cancelButtonLabel => r'취소';
+  @override String get closeButtonLabel => r'닫기';
+  @override String get continueButtonLabel => r'계속';
+  @override String get copyButtonLabel => r'복사';
+  @override String get cutButtonLabel => r'잘라내기';
+  @override String get okButtonLabel => r'확인';
+  @override String get pasteButtonLabel => r'붙여넣기';
+  @override String get selectAllButtonLabel => r'전체 선택';
+  @override String get viewLicensesButtonLabel => r'라이선스 보기';
+  @override String get anteMeridiemAbbreviation => r'오전';
+  @override String get postMeridiemAbbreviation => r'오후';
+  @override String get timePickerHourModeAnnouncement => r'시간 선택';
+  @override String get timePickerMinuteModeAnnouncement => r'분 선택';
+  @override String get modalBarrierDismissLabel => r'버리다';
+}
+
+// ignore: camel_case_types
+class _Bundle_nl extends TranslationBundle {
+  const _Bundle_nl() : super(null);
+  @override String get scriptCategory => r'English-like';
+  @override String get timeOfDayFormat => r'HH:mm';
+  @override String get openAppDrawerTooltip => r'Navigatiemenu openen';
+  @override String get backButtonTooltip => r'Terug';
+  @override String get closeButtonTooltip => r'Sluiten';
+  @override String get deleteButtonTooltip => r'Verwijderen';
+  @override String get nextMonthTooltip => r'Volgende maand';
+  @override String get previousMonthTooltip => r'Vorige maand';
+  @override String get nextPageTooltip => r'Volgende pagina';
+  @override String get previousPageTooltip => r'Vorige pagina';
+  @override String get showMenuTooltip => r'Menu weergeven';
+  @override String get aboutListTileTitle => r'Over $applicationName';
+  @override String get licensesPageTitle => r'Licenties';
+  @override String get pageRowsInfoTitle => r'$firstRow-$lastRow van $rowCount';
+  @override String get pageRowsInfoTitleApproximate => r'$firstRow-$lastRow van ongeveer $rowCount';
+  @override String get rowsPerPageTitle => r'Rijen per pagina:';
+  @override String get selectedRowCountTitleOne => r'1 item geselecteerd';
+  @override String get selectedRowCountTitleOther => r'$selectedRowCount items geselecteerd';
+  @override String get cancelButtonLabel => r'ANNULEREN';
+  @override String get closeButtonLabel => r'SLUITEN';
+  @override String get continueButtonLabel => r'DOORGAAN';
+  @override String get copyButtonLabel => r'KOPIËREN';
+  @override String get cutButtonLabel => r'KNIPPEN';
+  @override String get okButtonLabel => r'OK';
+  @override String get pasteButtonLabel => r'PLAKKEN';
+  @override String get selectAllButtonLabel => r'ALLES SELECTEREN';
+  @override String get viewLicensesButtonLabel => r'LICENTIES BEKIJKEN';
+  @override String get anteMeridiemAbbreviation => r'am';
+  @override String get postMeridiemAbbreviation => r'pm';
+  @override String get timePickerHourModeAnnouncement => r'Uren selecteren';
+  @override String get timePickerMinuteModeAnnouncement => r'Minuten selecteren';
+  @override String get modalBarrierDismissLabel => r'ontslaan';
+}
+
+// ignore: camel_case_types
+class _Bundle_pl extends TranslationBundle {
+  const _Bundle_pl() : super(null);
+  @override String get scriptCategory => r'English-like';
+  @override String get timeOfDayFormat => r'HH:mm';
+  @override String get selectedRowCountTitleFew => r'$selectedRowCount wybrane elementy';
+  @override String get selectedRowCountTitleMany => r'$selectedRowCount wybranych elementów';
+  @override String get openAppDrawerTooltip => r'Otwórz menu nawigacyjne';
+  @override String get backButtonTooltip => r'Wstecz';
+  @override String get closeButtonTooltip => r'Zamknij';
+  @override String get deleteButtonTooltip => r'Usuń';
+  @override String get nextMonthTooltip => r'Następny miesiąc';
+  @override String get previousMonthTooltip => r'Poprzedni miesiąc';
+  @override String get nextPageTooltip => r'Następna strona';
+  @override String get previousPageTooltip => r'Poprzednia strona';
+  @override String get showMenuTooltip => r'Pokaż menu';
+  @override String get aboutListTileTitle => r'$applicationName – informacje';
+  @override String get licensesPageTitle => r'Licencje';
+  @override String get pageRowsInfoTitle => r'$firstRow–$lastRow z $rowCount';
+  @override String get pageRowsInfoTitleApproximate => r'$firstRow–$lastRow z około $rowCount';
+  @override String get rowsPerPageTitle => r'Wiersze na stronie:';
+  @override String get selectedRowCountTitleOne => r'1 wybrany element';
+  @override String get selectedRowCountTitleOther => r'$selectedRowCount wybranego elementu';
+  @override String get cancelButtonLabel => r'ANULUJ';
+  @override String get closeButtonLabel => r'ZAMKNIJ';
+  @override String get continueButtonLabel => r'DALEJ';
+  @override String get copyButtonLabel => r'KOPIUJ';
+  @override String get cutButtonLabel => r'WYTNIJ';
+  @override String get okButtonLabel => r'OK';
+  @override String get pasteButtonLabel => r'WKLEJ';
+  @override String get selectAllButtonLabel => r'ZAZNACZ WSZYSTKO';
+  @override String get viewLicensesButtonLabel => r'WYŚWIETL LICENCJE';
   @override String get anteMeridiemAbbreviation => r'AM';
   @override String get postMeridiemAbbreviation => r'PM';
-  @override String get timePickerHourModeAnnouncement => r'เลือกชั่วโมง';
-  @override String get timePickerMinuteModeAnnouncement => r'เลือกนาที';
-  @override String get modalBarrierDismissLabel => r'ยกเลิก';
+  @override String get timePickerHourModeAnnouncement => r'Wybierz godziny';
+  @override String get timePickerMinuteModeAnnouncement => r'Wybierz minuty';
+  @override String get modalBarrierDismissLabel => r'oddalić';
+}
+
+// ignore: camel_case_types
+class _Bundle_ps extends TranslationBundle {
+  const _Bundle_ps() : super(null);
+  @override String get scriptCategory => r'tall';
+  @override String get timeOfDayFormat => r'HH:mm';
+  @override String get openAppDrawerTooltip => r'د پرانیستی نیینګ مینو';
+  @override String get backButtonTooltip => r'شاته';
+  @override String get closeButtonTooltip => r'بنده';
+  @override String get deleteButtonTooltip => r'';
+  @override String get nextMonthTooltip => r'بله میاشت';
+  @override String get previousMonthTooltip => r'تیره میاشت';
+  @override String get nextPageTooltip => r'بله پاڼه';
+  @override String get previousPageTooltip => r'مخکینی مخ';
+  @override String get showMenuTooltip => r'غورنۍ ښودل';
+  @override String get aboutListTileTitle => r'د $applicationName په اړه';
+  @override String get licensesPageTitle => r'جوازونه';
+  @override String get pageRowsInfoTitle => r'$firstRow–$lastRow د $rowCount';
+  @override String get pageRowsInfoTitleApproximate => r'$firstRow–$lastRow څخه $rowCount د';
+  @override String get rowsPerPageTitle => r'د هرې پاڼې پاڼې:';
+  @override String get selectedRowCountTitleOther => r'$selectedRowCount توکي غوره شوي';
+  @override String get cancelButtonLabel => r'لغوه کول';
+  @override String get closeButtonLabel => r'تړل';
+  @override String get continueButtonLabel => r'منځپانګې';
+  @override String get copyButtonLabel => r'کاپی';
+  @override String get cutButtonLabel => r'کم کړئ';
+  @override String get okButtonLabel => r'سمه ده';
+  @override String get pasteButtonLabel => r'پیټ کړئ';
+  @override String get selectAllButtonLabel => r'غوره کړئ';
+  @override String get viewLicensesButtonLabel => r'لیدلس وګورئ';
+  @override String get timePickerHourModeAnnouncement => r'وختونه وټاکئ';
+  @override String get timePickerMinuteModeAnnouncement => r'منې غوره کړئ';
+  @override String get modalBarrierDismissLabel => r'رد کړه';
+}
+
+// ignore: camel_case_types
+class _Bundle_pt extends TranslationBundle {
+  const _Bundle_pt() : super(null);
+  @override String get anteMeridiemAbbreviation => r'Manhã';
+  @override String get selectedRowCountTitleOne => r'1 item selecionado';
+  @override String get postMeridiemAbbreviation => r'Tarde/noite';
+  @override String get scriptCategory => r'English-like';
+  @override String get timeOfDayFormat => r'HH:mm';
+  @override String get openAppDrawerTooltip => r'Abrir menu de navegação';
+  @override String get backButtonTooltip => r'Voltar';
+  @override String get closeButtonTooltip => r'Fechar';
+  @override String get deleteButtonTooltip => r'Excluir';
+  @override String get nextMonthTooltip => r'Próximo mês';
+  @override String get previousMonthTooltip => r'Mês anterior';
+  @override String get nextPageTooltip => r'Próxima página';
+  @override String get previousPageTooltip => r'Página anterior';
+  @override String get showMenuTooltip => r'Mostrar menu';
+  @override String get aboutListTileTitle => r'Sobre o app $applicationName';
+  @override String get licensesPageTitle => r'Licenças';
+  @override String get pageRowsInfoTitle => r'$firstRow – $lastRow de $rowCount';
+  @override String get pageRowsInfoTitleApproximate => r'$firstRow – $lastRow de aproximadamente $rowCount';
+  @override String get rowsPerPageTitle => r'Linhas por página:';
+  @override String get selectedRowCountTitleOther => r'$selectedRowCount itens selecionados';
+  @override String get cancelButtonLabel => r'CANCELAR';
+  @override String get closeButtonLabel => r'FECHAR';
+  @override String get continueButtonLabel => r'CONTINUAR';
+  @override String get copyButtonLabel => r'COPIAR';
+  @override String get cutButtonLabel => r'RECORTAR';
+  @override String get okButtonLabel => r'Ok';
+  @override String get pasteButtonLabel => r'COLAR';
+  @override String get selectAllButtonLabel => r'SELECIONAR TUDO';
+  @override String get viewLicensesButtonLabel => r'VER LICENÇAS';
+  @override String get timePickerHourModeAnnouncement => r'Selecione as horas';
+  @override String get timePickerMinuteModeAnnouncement => r'Selecione os minutos';
+  @override String get modalBarrierDismissLabel => r'Dispensar';
 }
 
 // ignore: camel_case_types
@@ -733,149 +661,215 @@ class _Bundle_ru extends TranslationBundle {
 }
 
 // ignore: camel_case_types
-class _Bundle_ko extends TranslationBundle {
-  const _Bundle_ko() : super(null);
-  @override String get scriptCategory => r'dense';
-  @override String get timeOfDayFormat => r'a h:mm';
-  @override String get openAppDrawerTooltip => r'탐색 메뉴 열기';
-  @override String get backButtonTooltip => r'뒤로';
-  @override String get closeButtonTooltip => r'닫기';
-  @override String get deleteButtonTooltip => r'삭제';
-  @override String get nextMonthTooltip => r'다음 달';
-  @override String get previousMonthTooltip => r'지난달';
-  @override String get nextPageTooltip => r'다음 페이지';
-  @override String get previousPageTooltip => r'이전 페이지';
-  @override String get showMenuTooltip => r'메뉴 표시';
-  @override String get aboutListTileTitle => r'$applicationName 정보';
-  @override String get licensesPageTitle => r'라이선스';
-  @override String get pageRowsInfoTitle => r'$rowCount행 중 $firstRow~$lastRow행';
-  @override String get pageRowsInfoTitleApproximate => r'약 $rowCount행 중 $firstRow~$lastRow행';
-  @override String get rowsPerPageTitle => r'페이지당 행 수:';
-  @override String get selectedRowCountTitleOne => r'항목 1개 선택됨';
-  @override String get selectedRowCountTitleOther => r'항목 $selectedRowCount개 선택됨';
-  @override String get cancelButtonLabel => r'취소';
-  @override String get closeButtonLabel => r'닫기';
-  @override String get continueButtonLabel => r'계속';
-  @override String get copyButtonLabel => r'복사';
-  @override String get cutButtonLabel => r'잘라내기';
-  @override String get okButtonLabel => r'확인';
-  @override String get pasteButtonLabel => r'붙여넣기';
-  @override String get selectAllButtonLabel => r'전체 선택';
-  @override String get viewLicensesButtonLabel => r'라이선스 보기';
-  @override String get anteMeridiemAbbreviation => r'오전';
-  @override String get postMeridiemAbbreviation => r'오후';
-  @override String get timePickerHourModeAnnouncement => r'시간 선택';
-  @override String get timePickerMinuteModeAnnouncement => r'분 선택';
-  @override String get modalBarrierDismissLabel => r'버리다';
-}
-
-// ignore: camel_case_types
-class _Bundle_pl extends TranslationBundle {
-  const _Bundle_pl() : super(null);
-  @override String get scriptCategory => r'English-like';
-  @override String get timeOfDayFormat => r'HH:mm';
-  @override String get selectedRowCountTitleFew => r'$selectedRowCount wybrane elementy';
-  @override String get selectedRowCountTitleMany => r'$selectedRowCount wybranych elementów';
-  @override String get openAppDrawerTooltip => r'Otwórz menu nawigacyjne';
-  @override String get backButtonTooltip => r'Wstecz';
-  @override String get closeButtonTooltip => r'Zamknij';
-  @override String get deleteButtonTooltip => r'Usuń';
-  @override String get nextMonthTooltip => r'Następny miesiąc';
-  @override String get previousMonthTooltip => r'Poprzedni miesiąc';
-  @override String get nextPageTooltip => r'Następna strona';
-  @override String get previousPageTooltip => r'Poprzednia strona';
-  @override String get showMenuTooltip => r'Pokaż menu';
-  @override String get aboutListTileTitle => r'$applicationName – informacje';
-  @override String get licensesPageTitle => r'Licencje';
-  @override String get pageRowsInfoTitle => r'$firstRow–$lastRow z $rowCount';
-  @override String get pageRowsInfoTitleApproximate => r'$firstRow–$lastRow z około $rowCount';
-  @override String get rowsPerPageTitle => r'Wiersze na stronie:';
-  @override String get selectedRowCountTitleOne => r'1 wybrany element';
-  @override String get selectedRowCountTitleOther => r'$selectedRowCount wybranego elementu';
-  @override String get cancelButtonLabel => r'ANULUJ';
-  @override String get closeButtonLabel => r'ZAMKNIJ';
-  @override String get continueButtonLabel => r'DALEJ';
-  @override String get copyButtonLabel => r'KOPIUJ';
-  @override String get cutButtonLabel => r'WYTNIJ';
-  @override String get okButtonLabel => r'OK';
-  @override String get pasteButtonLabel => r'WKLEJ';
-  @override String get selectAllButtonLabel => r'ZAZNACZ WSZYSTKO';
-  @override String get viewLicensesButtonLabel => r'WYŚWIETL LICENCJE';
+class _Bundle_th extends TranslationBundle {
+  const _Bundle_th() : super(null);
+  @override String get scriptCategory => r'tall';
+  @override String get timeOfDayFormat => r'ah:mm';
+  @override String get openAppDrawerTooltip => r'เปิดเมนูการนำทาง';
+  @override String get backButtonTooltip => r'กลับ';
+  @override String get closeButtonTooltip => r'ปิด';
+  @override String get deleteButtonTooltip => r'ลบ';
+  @override String get nextMonthTooltip => r'เดือนหน้า';
+  @override String get previousMonthTooltip => r'เดือนที่แล้ว';
+  @override String get nextPageTooltip => r'หน้าถัดไป';
+  @override String get previousPageTooltip => r'หน้าก่อน';
+  @override String get showMenuTooltip => r'แสดงเมนู';
+  @override String get aboutListTileTitle => r'เกี่ยวกับ $applicationName';
+  @override String get licensesPageTitle => r'ใบอนุญาต';
+  @override String get pageRowsInfoTitle => r'$firstRow-$lastRow จาก $rowCount';
+  @override String get pageRowsInfoTitleApproximate => r'$firstRow–$lastRow จากประมาณ $rowCount';
+  @override String get rowsPerPageTitle => r'แถวต่อหน้า:';
+  @override String get selectedRowCountTitleOne => r'เลือกแล้ว 1 รายการ';
+  @override String get selectedRowCountTitleOther => r'เลือกแล้ว $selectedRowCount รายการ';
+  @override String get cancelButtonLabel => r'ยกเลิก';
+  @override String get closeButtonLabel => r'ปิด';
+  @override String get continueButtonLabel => r'ต่อไป';
+  @override String get copyButtonLabel => r'คัดลอก';
+  @override String get cutButtonLabel => r'ตัด';
+  @override String get okButtonLabel => r'ตกลง';
+  @override String get pasteButtonLabel => r'วาง';
+  @override String get selectAllButtonLabel => r'เลือกทั้งหมด';
+  @override String get viewLicensesButtonLabel => r'ดูใบอนุญาต';
   @override String get anteMeridiemAbbreviation => r'AM';
   @override String get postMeridiemAbbreviation => r'PM';
-  @override String get timePickerHourModeAnnouncement => r'Wybierz godziny';
-  @override String get timePickerMinuteModeAnnouncement => r'Wybierz minuty';
-  @override String get modalBarrierDismissLabel => r'oddalić';
+  @override String get timePickerHourModeAnnouncement => r'เลือกชั่วโมง';
+  @override String get timePickerMinuteModeAnnouncement => r'เลือกนาที';
+  @override String get modalBarrierDismissLabel => r'ยกเลิก';
 }
 
 // ignore: camel_case_types
-class _Bundle_es_UY extends TranslationBundle {
-  const _Bundle_es_UY() : super(const _Bundle_es());
-  @override String get openAppDrawerTooltip => r'Abrir menú de navegación';
-  @override String get deleteButtonTooltip => r'Borrar';
-  @override String get nextMonthTooltip => r'Próximo mes';
-  @override String get nextPageTooltip => r'Próxima página';
-  @override String get aboutListTileTitle => r'Acerca de $applicationName';
-  @override String get pageRowsInfoTitle => r'$firstRow–$lastRow de $rowCount';
-  @override String get pageRowsInfoTitleApproximate => r'$firstRow–$lastRow de aproximadamente $rowCount';
-  @override String get selectedRowCountTitleOne => r'Se seleccionó 1 elemento';
-  @override String get selectedRowCountTitleOther => r'Se seleccionaron $selectedRowCount elementos';
-  @override String get anteMeridiemAbbreviation => r'a.m.';
-  @override String get postMeridiemAbbreviation => r'p.m.';
+class _Bundle_tr extends TranslationBundle {
+  const _Bundle_tr() : super(null);
+  @override String get scriptCategory => r'English-like';
+  @override String get timeOfDayFormat => r'HH:mm';
+  @override String get openAppDrawerTooltip => r'Gezinme menüsünü aç';
+  @override String get backButtonTooltip => r'Geri';
+  @override String get closeButtonTooltip => r'Kapat';
+  @override String get deleteButtonTooltip => r'Sil';
+  @override String get nextMonthTooltip => r'Gelecek ay';
+  @override String get previousMonthTooltip => r'Önceki ay';
+  @override String get nextPageTooltip => r'Sonraki sayfa';
+  @override String get previousPageTooltip => r'Önceki sayfa';
+  @override String get showMenuTooltip => r'Menüyü göster';
+  @override String get aboutListTileTitle => r'$applicationName Hakkında';
+  @override String get licensesPageTitle => r'Lisanslar';
+  @override String get pageRowsInfoTitle => r'$firstRow-$lastRow / $rowCount';
+  @override String get pageRowsInfoTitleApproximate => r'$firstRow-$lastRow / $rowCount';
+  @override String get rowsPerPageTitle => r'Sayfa başına satır sayısı:';
+  @override String get selectedRowCountTitleOne => r'1 öğe seçildi';
+  @override String get selectedRowCountTitleOther => r'$selectedRowCount öğe seçildi';
+  @override String get cancelButtonLabel => r'İPTAL';
+  @override String get closeButtonLabel => r'KAPAT';
+  @override String get continueButtonLabel => r'DEVAM';
+  @override String get copyButtonLabel => r'KOPYALA';
+  @override String get cutButtonLabel => r'KES';
+  @override String get okButtonLabel => r'Tamam';
+  @override String get pasteButtonLabel => r'YAPIŞTIR';
+  @override String get selectAllButtonLabel => r'TÜMÜNÜ SEÇ';
+  @override String get viewLicensesButtonLabel => r'LİSANLARI GÖSTER';
+  @override String get anteMeridiemAbbreviation => r'ÖÖ';
+  @override String get postMeridiemAbbreviation => r'ÖS';
+  @override String get timePickerHourModeAnnouncement => r'Saati seçin';
+  @override String get timePickerMinuteModeAnnouncement => r'Dakikayı seçin';
+  @override String get modalBarrierDismissLabel => r'Reddet';
 }
 
 // ignore: camel_case_types
-class _Bundle_es_CR extends TranslationBundle {
-  const _Bundle_es_CR() : super(const _Bundle_es());
-  @override String get openAppDrawerTooltip => r'Abrir menú de navegación';
-  @override String get deleteButtonTooltip => r'Borrar';
-  @override String get nextMonthTooltip => r'Próximo mes';
-  @override String get nextPageTooltip => r'Próxima página';
-  @override String get aboutListTileTitle => r'Acerca de $applicationName';
-  @override String get pageRowsInfoTitle => r'$firstRow–$lastRow de $rowCount';
-  @override String get pageRowsInfoTitleApproximate => r'$firstRow–$lastRow de aproximadamente $rowCount';
-  @override String get selectedRowCountTitleOne => r'Se seleccionó 1 elemento';
-  @override String get selectedRowCountTitleOther => r'Se seleccionaron $selectedRowCount elementos';
-  @override String get anteMeridiemAbbreviation => r'a.m.';
-  @override String get postMeridiemAbbreviation => r'p.m.';
-}
-
-// ignore: camel_case_types
-class _Bundle_es_US extends TranslationBundle {
-  const _Bundle_es_US() : super(const _Bundle_es());
-  @override String get deleteButtonTooltip => r'Borrar';
-  @override String get nextMonthTooltip => r'Próximo mes';
-  @override String get pageRowsInfoTitleApproximate => r'$firstRow–$lastRow de aproximadamente $rowCount';
-  @override String get aboutListTileTitle => r'Acerca de $applicationName';
-  @override String get nextPageTooltip => r'Próxima página';
-  @override String get openAppDrawerTooltip => r'Abrir menú de navegación';
-  @override String get pageRowsInfoTitle => r'$firstRow–$lastRow de $rowCount';
-  @override String get selectedRowCountTitleOne => r'Se seleccionó 1 elemento';
-  @override String get selectedRowCountTitleOther => r'Se seleccionaron $selectedRowCount elementos';
+class _Bundle_ur extends TranslationBundle {
+  const _Bundle_ur() : super(null);
+  @override String get scriptCategory => r'tall';
   @override String get timeOfDayFormat => r'h:mm a';
-  @override String get anteMeridiemAbbreviation => r'a.m.';
-  @override String get postMeridiemAbbreviation => r'p.m.';
+  @override String get selectedRowCountTitleOne => r'1 آئٹم منتخب کیا گیا';
+  @override String get openAppDrawerTooltip => r'نیویگیشن مینو کھولیں';
+  @override String get backButtonTooltip => r'پیچھے';
+  @override String get closeButtonTooltip => r'بند کریں';
+  @override String get deleteButtonTooltip => r'حذف کریں';
+  @override String get nextMonthTooltip => r'اگلا مہینہ';
+  @override String get previousMonthTooltip => r'پچھلا مہینہ';
+  @override String get nextPageTooltip => r'اگلا صفحہ';
+  @override String get previousPageTooltip => r'گزشتہ صفحہ';
+  @override String get showMenuTooltip => r'مینو دکھائیں';
+  @override String get aboutListTileTitle => r'$applicationName کے بارے میں';
+  @override String get licensesPageTitle => r'لائسنسز';
+  @override String get pageRowsInfoTitle => r'$firstRow–$lastRow از $rowCount';
+  @override String get pageRowsInfoTitleApproximate => r'$firstRow–$lastRow $rowCount میں سے تقریباً';
+  @override String get rowsPerPageTitle => r'قطاریں فی صفحہ:';
+  @override String get selectedRowCountTitleOther => r'$selectedRowCount آئٹمز منتخب کیے گئے';
+  @override String get cancelButtonLabel => r'منسوخ کریں';
+  @override String get closeButtonLabel => r'بند کریں';
+  @override String get continueButtonLabel => r'جاری رکھیں';
+  @override String get copyButtonLabel => r'کاپی کریں';
+  @override String get cutButtonLabel => r'کٹ کریں';
+  @override String get okButtonLabel => r'ٹھیک ہے';
+  @override String get pasteButtonLabel => r'پیسٹ کریں';
+  @override String get selectAllButtonLabel => r'سبھی منتخب کریں';
+  @override String get viewLicensesButtonLabel => r'لائسنسز دیکھیں';
+  @override String get anteMeridiemAbbreviation => r'AM';
+  @override String get postMeridiemAbbreviation => r'PM';
+  @override String get timePickerHourModeAnnouncement => r'گھنٹے منتخب کریں';
+  @override String get timePickerMinuteModeAnnouncement => r'منٹ منتخب کریں';
+  @override String get modalBarrierDismissLabel => r'برطرف';
 }
 
 // ignore: camel_case_types
-class _Bundle_es_SV extends TranslationBundle {
-  const _Bundle_es_SV() : super(const _Bundle_es());
-  @override String get openAppDrawerTooltip => r'Abrir menú de navegación';
-  @override String get deleteButtonTooltip => r'Borrar';
-  @override String get nextMonthTooltip => r'Próximo mes';
-  @override String get nextPageTooltip => r'Próxima página';
-  @override String get aboutListTileTitle => r'Acerca de $applicationName';
-  @override String get pageRowsInfoTitle => r'$firstRow–$lastRow de $rowCount';
-  @override String get pageRowsInfoTitleApproximate => r'$firstRow–$lastRow de aproximadamente $rowCount';
-  @override String get selectedRowCountTitleOne => r'Se seleccionó 1 elemento';
-  @override String get selectedRowCountTitleOther => r'Se seleccionaron $selectedRowCount elementos';
-  @override String get anteMeridiemAbbreviation => r'a.m.';
-  @override String get postMeridiemAbbreviation => r'p.m.';
+class _Bundle_zh extends TranslationBundle {
+  const _Bundle_zh() : super(null);
+  @override String get scriptCategory => r'dense';
+  @override String get timeOfDayFormat => r'ah:mm';
+  @override String get selectedRowCountTitleOne => r'已选择 1 项内容';
+  @override String get openAppDrawerTooltip => r'打开导航菜单';
+  @override String get backButtonTooltip => r'返回';
+  @override String get nextPageTooltip => r'下一页';
+  @override String get previousPageTooltip => r'上一页';
+  @override String get showMenuTooltip => r'显示菜单';
+  @override String get aboutListTileTitle => r'关于$applicationName';
+  @override String get licensesPageTitle => r'许可';
+  @override String get pageRowsInfoTitle => r'第 $firstRow-$lastRow 行（共 $rowCount 行）';
+  @override String get pageRowsInfoTitleApproximate => r'第 $firstRow-$lastRow 行（共约 $rowCount 行）';
+  @override String get rowsPerPageTitle => r'每页行数：';
+  @override String get selectedRowCountTitleOther => r'已选择 $selectedRowCount 项内容';
+  @override String get cancelButtonLabel => r'取消';
+  @override String get continueButtonLabel => r'继续';
+  @override String get closeButtonLabel => r'关闭';
+  @override String get copyButtonLabel => r'复制';
+  @override String get cutButtonLabel => r'剪切';
+  @override String get okButtonLabel => r'确定';
+  @override String get pasteButtonLabel => r'粘贴';
+  @override String get selectAllButtonLabel => r'全选';
+  @override String get viewLicensesButtonLabel => r'查看许可';
+  @override String get closeButtonTooltip => r'关闭';
+  @override String get deleteButtonTooltip => r'删除';
+  @override String get nextMonthTooltip => r'下个月';
+  @override String get previousMonthTooltip => r'上个月';
+  @override String get anteMeridiemAbbreviation => r'上午';
+  @override String get postMeridiemAbbreviation => r'下午';
+  @override String get timePickerHourModeAnnouncement => r'选择小时';
+  @override String get timePickerMinuteModeAnnouncement => r'选择分钟';
+  @override String get modalBarrierDismissLabel => r'关闭';
 }
 
 // ignore: camel_case_types
-class _Bundle_es_DO extends TranslationBundle {
-  const _Bundle_es_DO() : super(const _Bundle_es());
+class _Bundle_de_CH extends TranslationBundle {
+  const _Bundle_de_CH() : super(const _Bundle_de());
+  @override String get closeButtonTooltip => r'Schliessen';
+  @override String get modalBarrierDismissLabel => r'Schliessen';
+}
+
+// ignore: camel_case_types
+class _Bundle_en_AU extends TranslationBundle {
+  const _Bundle_en_AU() : super(const _Bundle_en());
+  @override String get licensesPageTitle => r'Licences';
+  @override String get viewLicensesButtonLabel => r'VIEW LICENCES';
+}
+
+// ignore: camel_case_types
+class _Bundle_en_CA extends TranslationBundle {
+  const _Bundle_en_CA() : super(const _Bundle_en());
+  @override String get licensesPageTitle => r'Licences';
+  @override String get viewLicensesButtonLabel => r'VIEW LICENCES';
+}
+
+// ignore: camel_case_types
+class _Bundle_en_GB extends TranslationBundle {
+  const _Bundle_en_GB() : super(const _Bundle_en());
+  @override String get timeOfDayFormat => r'HH:mm';
+  @override String get viewLicensesButtonLabel => r'VIEW LICENCES';
+  @override String get licensesPageTitle => r'Licences';
+}
+
+// ignore: camel_case_types
+class _Bundle_en_IE extends TranslationBundle {
+  const _Bundle_en_IE() : super(const _Bundle_en());
+  @override String get timeOfDayFormat => r'HH:mm';
+  @override String get viewLicensesButtonLabel => r'VIEW LICENCES';
+  @override String get licensesPageTitle => r'Licences';
+}
+
+// ignore: camel_case_types
+class _Bundle_en_IN extends TranslationBundle {
+  const _Bundle_en_IN() : super(const _Bundle_en());
+  @override String get licensesPageTitle => r'Licences';
+  @override String get viewLicensesButtonLabel => r'VIEW LICENCES';
+}
+
+// ignore: camel_case_types
+class _Bundle_en_SG extends TranslationBundle {
+  const _Bundle_en_SG() : super(const _Bundle_en());
+  @override String get licensesPageTitle => r'Licences';
+  @override String get viewLicensesButtonLabel => r'VIEW LICENCES';
+}
+
+// ignore: camel_case_types
+class _Bundle_en_ZA extends TranslationBundle {
+  const _Bundle_en_ZA() : super(const _Bundle_en());
+  @override String get timeOfDayFormat => r'HH:mm';
+  @override String get viewLicensesButtonLabel => r'VIEW LICENCES';
+  @override String get licensesPageTitle => r'Licences';
+}
+
+// ignore: camel_case_types
+class _Bundle_es_419 extends TranslationBundle {
+  const _Bundle_es_419() : super(const _Bundle_es());
   @override String get openAppDrawerTooltip => r'Abrir menú de navegación';
   @override String get deleteButtonTooltip => r'Borrar';
   @override String get nextMonthTooltip => r'Próximo mes';
@@ -906,54 +900,6 @@ class _Bundle_es_AR extends TranslationBundle {
 }
 
 // ignore: camel_case_types
-class _Bundle_es_419 extends TranslationBundle {
-  const _Bundle_es_419() : super(const _Bundle_es());
-  @override String get openAppDrawerTooltip => r'Abrir menú de navegación';
-  @override String get deleteButtonTooltip => r'Borrar';
-  @override String get nextMonthTooltip => r'Próximo mes';
-  @override String get nextPageTooltip => r'Próxima página';
-  @override String get aboutListTileTitle => r'Acerca de $applicationName';
-  @override String get pageRowsInfoTitle => r'$firstRow–$lastRow de $rowCount';
-  @override String get pageRowsInfoTitleApproximate => r'$firstRow–$lastRow de aproximadamente $rowCount';
-  @override String get selectedRowCountTitleOne => r'Se seleccionó 1 elemento';
-  @override String get selectedRowCountTitleOther => r'Se seleccionaron $selectedRowCount elementos';
-  @override String get anteMeridiemAbbreviation => r'a.m.';
-  @override String get postMeridiemAbbreviation => r'p.m.';
-}
-
-// ignore: camel_case_types
-class _Bundle_es_PE extends TranslationBundle {
-  const _Bundle_es_PE() : super(const _Bundle_es());
-  @override String get openAppDrawerTooltip => r'Abrir menú de navegación';
-  @override String get deleteButtonTooltip => r'Borrar';
-  @override String get nextMonthTooltip => r'Próximo mes';
-  @override String get nextPageTooltip => r'Próxima página';
-  @override String get aboutListTileTitle => r'Acerca de $applicationName';
-  @override String get pageRowsInfoTitle => r'$firstRow–$lastRow de $rowCount';
-  @override String get pageRowsInfoTitleApproximate => r'$firstRow–$lastRow de aproximadamente $rowCount';
-  @override String get selectedRowCountTitleOne => r'Se seleccionó 1 elemento';
-  @override String get selectedRowCountTitleOther => r'Se seleccionaron $selectedRowCount elementos';
-  @override String get anteMeridiemAbbreviation => r'a.m.';
-  @override String get postMeridiemAbbreviation => r'p.m.';
-}
-
-// ignore: camel_case_types
-class _Bundle_es_VE extends TranslationBundle {
-  const _Bundle_es_VE() : super(const _Bundle_es());
-  @override String get openAppDrawerTooltip => r'Abrir menú de navegación';
-  @override String get deleteButtonTooltip => r'Borrar';
-  @override String get nextMonthTooltip => r'Próximo mes';
-  @override String get nextPageTooltip => r'Próxima página';
-  @override String get aboutListTileTitle => r'Acerca de $applicationName';
-  @override String get pageRowsInfoTitle => r'$firstRow–$lastRow de $rowCount';
-  @override String get pageRowsInfoTitleApproximate => r'$firstRow–$lastRow de aproximadamente $rowCount';
-  @override String get selectedRowCountTitleOne => r'Se seleccionó 1 elemento';
-  @override String get selectedRowCountTitleOther => r'Se seleccionaron $selectedRowCount elementos';
-  @override String get anteMeridiemAbbreviation => r'a.m.';
-  @override String get postMeridiemAbbreviation => r'p.m.';
-}
-
-// ignore: camel_case_types
 class _Bundle_es_BO extends TranslationBundle {
   const _Bundle_es_BO() : super(const _Bundle_es());
   @override String get openAppDrawerTooltip => r'Abrir menú de navegación';
@@ -970,8 +916,72 @@ class _Bundle_es_BO extends TranslationBundle {
 }
 
 // ignore: camel_case_types
-class _Bundle_es_PY extends TranslationBundle {
-  const _Bundle_es_PY() : super(const _Bundle_es());
+class _Bundle_es_CL extends TranslationBundle {
+  const _Bundle_es_CL() : super(const _Bundle_es());
+  @override String get openAppDrawerTooltip => r'Abrir menú de navegación';
+  @override String get deleteButtonTooltip => r'Borrar';
+  @override String get nextMonthTooltip => r'Próximo mes';
+  @override String get nextPageTooltip => r'Próxima página';
+  @override String get aboutListTileTitle => r'Acerca de $applicationName';
+  @override String get pageRowsInfoTitle => r'$firstRow–$lastRow de $rowCount';
+  @override String get pageRowsInfoTitleApproximate => r'$firstRow–$lastRow de aproximadamente $rowCount';
+  @override String get selectedRowCountTitleOne => r'Se seleccionó 1 elemento';
+  @override String get selectedRowCountTitleOther => r'Se seleccionaron $selectedRowCount elementos';
+  @override String get anteMeridiemAbbreviation => r'a.m.';
+  @override String get postMeridiemAbbreviation => r'p.m.';
+}
+
+// ignore: camel_case_types
+class _Bundle_es_CO extends TranslationBundle {
+  const _Bundle_es_CO() : super(const _Bundle_es());
+  @override String get openAppDrawerTooltip => r'Abrir menú de navegación';
+  @override String get deleteButtonTooltip => r'Borrar';
+  @override String get nextMonthTooltip => r'Próximo mes';
+  @override String get nextPageTooltip => r'Próxima página';
+  @override String get aboutListTileTitle => r'Acerca de $applicationName';
+  @override String get pageRowsInfoTitle => r'$firstRow–$lastRow de $rowCount';
+  @override String get pageRowsInfoTitleApproximate => r'$firstRow–$lastRow de aproximadamente $rowCount';
+  @override String get selectedRowCountTitleOne => r'Se seleccionó 1 elemento';
+  @override String get selectedRowCountTitleOther => r'Se seleccionaron $selectedRowCount elementos';
+  @override String get anteMeridiemAbbreviation => r'a.m.';
+  @override String get postMeridiemAbbreviation => r'p.m.';
+}
+
+// ignore: camel_case_types
+class _Bundle_es_CR extends TranslationBundle {
+  const _Bundle_es_CR() : super(const _Bundle_es());
+  @override String get openAppDrawerTooltip => r'Abrir menú de navegación';
+  @override String get deleteButtonTooltip => r'Borrar';
+  @override String get nextMonthTooltip => r'Próximo mes';
+  @override String get nextPageTooltip => r'Próxima página';
+  @override String get aboutListTileTitle => r'Acerca de $applicationName';
+  @override String get pageRowsInfoTitle => r'$firstRow–$lastRow de $rowCount';
+  @override String get pageRowsInfoTitleApproximate => r'$firstRow–$lastRow de aproximadamente $rowCount';
+  @override String get selectedRowCountTitleOne => r'Se seleccionó 1 elemento';
+  @override String get selectedRowCountTitleOther => r'Se seleccionaron $selectedRowCount elementos';
+  @override String get anteMeridiemAbbreviation => r'a.m.';
+  @override String get postMeridiemAbbreviation => r'p.m.';
+}
+
+// ignore: camel_case_types
+class _Bundle_es_DO extends TranslationBundle {
+  const _Bundle_es_DO() : super(const _Bundle_es());
+  @override String get openAppDrawerTooltip => r'Abrir menú de navegación';
+  @override String get deleteButtonTooltip => r'Borrar';
+  @override String get nextMonthTooltip => r'Próximo mes';
+  @override String get nextPageTooltip => r'Próxima página';
+  @override String get aboutListTileTitle => r'Acerca de $applicationName';
+  @override String get pageRowsInfoTitle => r'$firstRow–$lastRow de $rowCount';
+  @override String get pageRowsInfoTitleApproximate => r'$firstRow–$lastRow de aproximadamente $rowCount';
+  @override String get selectedRowCountTitleOne => r'Se seleccionó 1 elemento';
+  @override String get selectedRowCountTitleOther => r'Se seleccionaron $selectedRowCount elementos';
+  @override String get anteMeridiemAbbreviation => r'a.m.';
+  @override String get postMeridiemAbbreviation => r'p.m.';
+}
+
+// ignore: camel_case_types
+class _Bundle_es_EC extends TranslationBundle {
+  const _Bundle_es_EC() : super(const _Bundle_es());
   @override String get openAppDrawerTooltip => r'Abrir menú de navegación';
   @override String get deleteButtonTooltip => r'Borrar';
   @override String get nextMonthTooltip => r'Próximo mes';
@@ -988,6 +998,38 @@ class _Bundle_es_PY extends TranslationBundle {
 // ignore: camel_case_types
 class _Bundle_es_GT extends TranslationBundle {
   const _Bundle_es_GT() : super(const _Bundle_es());
+  @override String get openAppDrawerTooltip => r'Abrir menú de navegación';
+  @override String get deleteButtonTooltip => r'Borrar';
+  @override String get nextMonthTooltip => r'Próximo mes';
+  @override String get nextPageTooltip => r'Próxima página';
+  @override String get aboutListTileTitle => r'Acerca de $applicationName';
+  @override String get pageRowsInfoTitle => r'$firstRow–$lastRow de $rowCount';
+  @override String get pageRowsInfoTitleApproximate => r'$firstRow–$lastRow de aproximadamente $rowCount';
+  @override String get selectedRowCountTitleOne => r'Se seleccionó 1 elemento';
+  @override String get selectedRowCountTitleOther => r'Se seleccionaron $selectedRowCount elementos';
+  @override String get anteMeridiemAbbreviation => r'a.m.';
+  @override String get postMeridiemAbbreviation => r'p.m.';
+}
+
+// ignore: camel_case_types
+class _Bundle_es_HN extends TranslationBundle {
+  const _Bundle_es_HN() : super(const _Bundle_es());
+  @override String get openAppDrawerTooltip => r'Abrir menú de navegación';
+  @override String get deleteButtonTooltip => r'Borrar';
+  @override String get nextMonthTooltip => r'Próximo mes';
+  @override String get nextPageTooltip => r'Próxima página';
+  @override String get aboutListTileTitle => r'Acerca de $applicationName';
+  @override String get pageRowsInfoTitle => r'$firstRow–$lastRow de $rowCount';
+  @override String get pageRowsInfoTitleApproximate => r'$firstRow–$lastRow de aproximadamente $rowCount';
+  @override String get selectedRowCountTitleOne => r'Se seleccionó 1 elemento';
+  @override String get selectedRowCountTitleOther => r'Se seleccionaron $selectedRowCount elementos';
+  @override String get anteMeridiemAbbreviation => r'a.m.';
+  @override String get postMeridiemAbbreviation => r'p.m.';
+}
+
+// ignore: camel_case_types
+class _Bundle_es_MX extends TranslationBundle {
+  const _Bundle_es_MX() : super(const _Bundle_es());
   @override String get openAppDrawerTooltip => r'Abrir menú de navegación';
   @override String get deleteButtonTooltip => r'Borrar';
   @override String get nextMonthTooltip => r'Próximo mes';
@@ -1034,8 +1076,8 @@ class _Bundle_es_PA extends TranslationBundle {
 }
 
 // ignore: camel_case_types
-class _Bundle_es_HN extends TranslationBundle {
-  const _Bundle_es_HN() : super(const _Bundle_es());
+class _Bundle_es_PE extends TranslationBundle {
+  const _Bundle_es_PE() : super(const _Bundle_es());
   @override String get openAppDrawerTooltip => r'Abrir menú de navegación';
   @override String get deleteButtonTooltip => r'Borrar';
   @override String get nextMonthTooltip => r'Próximo mes';
@@ -1066,8 +1108,8 @@ class _Bundle_es_PR extends TranslationBundle {
 }
 
 // ignore: camel_case_types
-class _Bundle_es_MX extends TranslationBundle {
-  const _Bundle_es_MX() : super(const _Bundle_es());
+class _Bundle_es_PY extends TranslationBundle {
+  const _Bundle_es_PY() : super(const _Bundle_es());
   @override String get openAppDrawerTooltip => r'Abrir menú de navegación';
   @override String get deleteButtonTooltip => r'Borrar';
   @override String get nextMonthTooltip => r'Próximo mes';
@@ -1082,8 +1124,8 @@ class _Bundle_es_MX extends TranslationBundle {
 }
 
 // ignore: camel_case_types
-class _Bundle_es_CO extends TranslationBundle {
-  const _Bundle_es_CO() : super(const _Bundle_es());
+class _Bundle_es_SV extends TranslationBundle {
+  const _Bundle_es_SV() : super(const _Bundle_es());
   @override String get openAppDrawerTooltip => r'Abrir menú de navegación';
   @override String get deleteButtonTooltip => r'Borrar';
   @override String get nextMonthTooltip => r'Próximo mes';
@@ -1098,8 +1140,25 @@ class _Bundle_es_CO extends TranslationBundle {
 }
 
 // ignore: camel_case_types
-class _Bundle_es_EC extends TranslationBundle {
-  const _Bundle_es_EC() : super(const _Bundle_es());
+class _Bundle_es_US extends TranslationBundle {
+  const _Bundle_es_US() : super(const _Bundle_es());
+  @override String get deleteButtonTooltip => r'Borrar';
+  @override String get nextMonthTooltip => r'Próximo mes';
+  @override String get pageRowsInfoTitleApproximate => r'$firstRow–$lastRow de aproximadamente $rowCount';
+  @override String get aboutListTileTitle => r'Acerca de $applicationName';
+  @override String get nextPageTooltip => r'Próxima página';
+  @override String get openAppDrawerTooltip => r'Abrir menú de navegación';
+  @override String get pageRowsInfoTitle => r'$firstRow–$lastRow de $rowCount';
+  @override String get selectedRowCountTitleOne => r'Se seleccionó 1 elemento';
+  @override String get selectedRowCountTitleOther => r'Se seleccionaron $selectedRowCount elementos';
+  @override String get timeOfDayFormat => r'h:mm a';
+  @override String get anteMeridiemAbbreviation => r'a.m.';
+  @override String get postMeridiemAbbreviation => r'p.m.';
+}
+
+// ignore: camel_case_types
+class _Bundle_es_UY extends TranslationBundle {
+  const _Bundle_es_UY() : super(const _Bundle_es());
   @override String get openAppDrawerTooltip => r'Abrir menú de navegación';
   @override String get deleteButtonTooltip => r'Borrar';
   @override String get nextMonthTooltip => r'Próximo mes';
@@ -1114,8 +1173,8 @@ class _Bundle_es_EC extends TranslationBundle {
 }
 
 // ignore: camel_case_types
-class _Bundle_es_CL extends TranslationBundle {
-  const _Bundle_es_CL() : super(const _Bundle_es());
+class _Bundle_es_VE extends TranslationBundle {
+  const _Bundle_es_VE() : super(const _Bundle_es());
   @override String get openAppDrawerTooltip => r'Abrir menú de navegación';
   @override String get deleteButtonTooltip => r'Borrar';
   @override String get nextMonthTooltip => r'Próximo mes';
@@ -1130,92 +1189,27 @@ class _Bundle_es_CL extends TranslationBundle {
 }
 
 // ignore: camel_case_types
-class _Bundle_en_CA extends TranslationBundle {
-  const _Bundle_en_CA() : super(const _Bundle_en());
-  @override String get licensesPageTitle => r'Licences';
-  @override String get viewLicensesButtonLabel => r'VIEW LICENCES';
+class _Bundle_fr_CA extends TranslationBundle {
+  const _Bundle_fr_CA() : super(const _Bundle_fr());
+  @override String get timeOfDayFormat => r'HH ' "'" r'h' "'" r' mm';
 }
 
 // ignore: camel_case_types
-class _Bundle_en_ZA extends TranslationBundle {
-  const _Bundle_en_ZA() : super(const _Bundle_en());
-  @override String get timeOfDayFormat => r'HH:mm';
-  @override String get viewLicensesButtonLabel => r'VIEW LICENCES';
-  @override String get licensesPageTitle => r'Licences';
-}
-
-// ignore: camel_case_types
-class _Bundle_en_AU extends TranslationBundle {
-  const _Bundle_en_AU() : super(const _Bundle_en());
-  @override String get licensesPageTitle => r'Licences';
-  @override String get viewLicensesButtonLabel => r'VIEW LICENCES';
-}
-
-// ignore: camel_case_types
-class _Bundle_en_IE extends TranslationBundle {
-  const _Bundle_en_IE() : super(const _Bundle_en());
-  @override String get timeOfDayFormat => r'HH:mm';
-  @override String get viewLicensesButtonLabel => r'VIEW LICENCES';
-  @override String get licensesPageTitle => r'Licences';
-}
-
-// ignore: camel_case_types
-class _Bundle_en_SG extends TranslationBundle {
-  const _Bundle_en_SG() : super(const _Bundle_en());
-  @override String get licensesPageTitle => r'Licences';
-  @override String get viewLicensesButtonLabel => r'VIEW LICENCES';
-}
-
-// ignore: camel_case_types
-class _Bundle_en_GB extends TranslationBundle {
-  const _Bundle_en_GB() : super(const _Bundle_en());
-  @override String get timeOfDayFormat => r'HH:mm';
-  @override String get viewLicensesButtonLabel => r'VIEW LICENCES';
-  @override String get licensesPageTitle => r'Licences';
-}
-
-// ignore: camel_case_types
-class _Bundle_en_IN extends TranslationBundle {
-  const _Bundle_en_IN() : super(const _Bundle_en());
-  @override String get licensesPageTitle => r'Licences';
-  @override String get viewLicensesButtonLabel => r'VIEW LICENCES';
-}
-
-// ignore: camel_case_types
-class _Bundle_de_CH extends TranslationBundle {
-  const _Bundle_de_CH() : super(const _Bundle_de());
-  @override String get closeButtonTooltip => r'Schliessen';
-  @override String get modalBarrierDismissLabel => r'Schliessen';
-}
-
-// ignore: camel_case_types
-class _Bundle_zh_TW extends TranslationBundle {
-  const _Bundle_zh_TW() : super(const _Bundle_zh());
-  @override String get openAppDrawerTooltip => r'開啟導覽選單';
-  @override String get closeButtonTooltip => r'關閉';
-  @override String get deleteButtonTooltip => r'刪除';
-  @override String get nextMonthTooltip => r'下個月';
-  @override String get previousMonthTooltip => r'上個月';
-  @override String get nextPageTooltip => r'下一頁';
-  @override String get previousPageTooltip => r'上一頁';
-  @override String get showMenuTooltip => r'顯示選單';
-  @override String get aboutListTileTitle => r'關於「$applicationName」';
-  @override String get licensesPageTitle => r'授權';
-  @override String get pageRowsInfoTitle => r'第 $firstRow - $lastRow 列 (總共 $rowCount 列)';
-  @override String get pageRowsInfoTitleApproximate => r'第 $firstRow - $lastRow 列 (總共約 $rowCount 列)';
-  @override String get rowsPerPageTitle => r'每頁列數：';
-  @override String get selectedRowCountTitleOne => r'已選取 1 個項目';
-  @override String get selectedRowCountTitleOther => r'已選取 $selectedRowCount 個項目';
-  @override String get closeButtonLabel => r'關閉';
-  @override String get continueButtonLabel => r'繼續';
-  @override String get copyButtonLabel => r'複製';
-  @override String get cutButtonLabel => r'剪下';
-  @override String get okButtonLabel => r'確定';
-  @override String get pasteButtonLabel => r'貼上';
-  @override String get selectAllButtonLabel => r'全選';
-  @override String get viewLicensesButtonLabel => r'查看授權';
-  @override String get timePickerHourModeAnnouncement => r'選取小時數';
-  @override String get timePickerMinuteModeAnnouncement => r'選取分鐘數';
+class _Bundle_pt_PT extends TranslationBundle {
+  const _Bundle_pt_PT() : super(const _Bundle_pt());
+  @override String get timePickerMinuteModeAnnouncement => r'Selecionar minutos';
+  @override String get timePickerHourModeAnnouncement => r'Selecionar horas';
+  @override String get deleteButtonTooltip => r'Eliminar';
+  @override String get nextMonthTooltip => r'Mês seguinte';
+  @override String get nextPageTooltip => r'Página seguinte';
+  @override String get aboutListTileTitle => r'Acerca de $applicationName';
+  @override String get pageRowsInfoTitle => r'$firstRow a $lastRow de $rowCount';
+  @override String get pageRowsInfoTitleApproximate => r'$firstRow a $lastRow de cerca de $rowCount';
+  @override String get cutButtonLabel => r'CORTAR';
+  @override String get okButtonLabel => r'OK';
+  @override String get anteMeridiemAbbreviation => r'AM';
+  @override String get postMeridiemAbbreviation => r'PM';
+  @override String get modalBarrierDismissLabel => r'Ignorar';
 }
 
 // ignore: camel_case_types
@@ -1249,97 +1243,39 @@ class _Bundle_zh_HK extends TranslationBundle {
 }
 
 // ignore: camel_case_types
-class _Bundle_pt_PT extends TranslationBundle {
-  const _Bundle_pt_PT() : super(const _Bundle_pt());
-  @override String get timePickerMinuteModeAnnouncement => r'Selecionar minutos';
-  @override String get timePickerHourModeAnnouncement => r'Selecionar horas';
-  @override String get deleteButtonTooltip => r'Eliminar';
-  @override String get nextMonthTooltip => r'Mês seguinte';
-  @override String get nextPageTooltip => r'Página seguinte';
-  @override String get aboutListTileTitle => r'Acerca de $applicationName';
-  @override String get pageRowsInfoTitle => r'$firstRow a $lastRow de $rowCount';
-  @override String get pageRowsInfoTitleApproximate => r'$firstRow a $lastRow de cerca de $rowCount';
-  @override String get cutButtonLabel => r'CORTAR';
-  @override String get okButtonLabel => r'OK';
-  @override String get anteMeridiemAbbreviation => r'AM';
-  @override String get postMeridiemAbbreviation => r'PM';
-  @override String get modalBarrierDismissLabel => r'Ignorar';
-}
-
-// ignore: camel_case_types
-class _Bundle_fr_CA extends TranslationBundle {
-  const _Bundle_fr_CA() : super(const _Bundle_fr());
-  @override String get timeOfDayFormat => r'HH ' "'" r'h' "'" r' mm';
+class _Bundle_zh_TW extends TranslationBundle {
+  const _Bundle_zh_TW() : super(const _Bundle_zh());
+  @override String get openAppDrawerTooltip => r'開啟導覽選單';
+  @override String get closeButtonTooltip => r'關閉';
+  @override String get deleteButtonTooltip => r'刪除';
+  @override String get nextMonthTooltip => r'下個月';
+  @override String get previousMonthTooltip => r'上個月';
+  @override String get nextPageTooltip => r'下一頁';
+  @override String get previousPageTooltip => r'上一頁';
+  @override String get showMenuTooltip => r'顯示選單';
+  @override String get aboutListTileTitle => r'關於「$applicationName」';
+  @override String get licensesPageTitle => r'授權';
+  @override String get pageRowsInfoTitle => r'第 $firstRow - $lastRow 列 (總共 $rowCount 列)';
+  @override String get pageRowsInfoTitleApproximate => r'第 $firstRow - $lastRow 列 (總共約 $rowCount 列)';
+  @override String get rowsPerPageTitle => r'每頁列數：';
+  @override String get selectedRowCountTitleOne => r'已選取 1 個項目';
+  @override String get selectedRowCountTitleOther => r'已選取 $selectedRowCount 個項目';
+  @override String get closeButtonLabel => r'關閉';
+  @override String get continueButtonLabel => r'繼續';
+  @override String get copyButtonLabel => r'複製';
+  @override String get cutButtonLabel => r'剪下';
+  @override String get okButtonLabel => r'確定';
+  @override String get pasteButtonLabel => r'貼上';
+  @override String get selectAllButtonLabel => r'全選';
+  @override String get viewLicensesButtonLabel => r'查看授權';
+  @override String get timePickerHourModeAnnouncement => r'選取小時數';
+  @override String get timePickerMinuteModeAnnouncement => r'選取分鐘數';
 }
 
 TranslationBundle translationBundleForLocale(Locale locale) {
   switch(locale.languageCode) {
-    case 'es': {
-      switch(locale.toString()) {
-        case 'es_UY':
-          return const _Bundle_es_UY();
-        case 'es_CR':
-          return const _Bundle_es_CR();
-        case 'es_US':
-          return const _Bundle_es_US();
-        case 'es_SV':
-          return const _Bundle_es_SV();
-        case 'es_DO':
-          return const _Bundle_es_DO();
-        case 'es_AR':
-          return const _Bundle_es_AR();
-        case 'es_419':
-          return const _Bundle_es_419();
-        case 'es_PE':
-          return const _Bundle_es_PE();
-        case 'es_VE':
-          return const _Bundle_es_VE();
-        case 'es_BO':
-          return const _Bundle_es_BO();
-        case 'es_PY':
-          return const _Bundle_es_PY();
-        case 'es_GT':
-          return const _Bundle_es_GT();
-        case 'es_NI':
-          return const _Bundle_es_NI();
-        case 'es_PA':
-          return const _Bundle_es_PA();
-        case 'es_HN':
-          return const _Bundle_es_HN();
-        case 'es_PR':
-          return const _Bundle_es_PR();
-        case 'es_MX':
-          return const _Bundle_es_MX();
-        case 'es_CO':
-          return const _Bundle_es_CO();
-        case 'es_EC':
-          return const _Bundle_es_EC();
-        case 'es_CL':
-          return const _Bundle_es_CL();
-      }
-      return const _Bundle_es();
-    }
-    case 'fa':
-      return const _Bundle_fa();
-    case 'en': {
-      switch(locale.toString()) {
-        case 'en_CA':
-          return const _Bundle_en_CA();
-        case 'en_ZA':
-          return const _Bundle_en_ZA();
-        case 'en_AU':
-          return const _Bundle_en_AU();
-        case 'en_IE':
-          return const _Bundle_en_IE();
-        case 'en_SG':
-          return const _Bundle_en_SG();
-        case 'en_GB':
-          return const _Bundle_en_GB();
-        case 'en_IN':
-          return const _Bundle_en_IN();
-      }
-      return const _Bundle_en();
-    }
+    case 'ar':
+      return const _Bundle_ar();
     case 'de': {
       switch(locale.toString()) {
         case 'de_CH':
@@ -1347,36 +1283,72 @@ TranslationBundle translationBundleForLocale(Locale locale) {
       }
       return const _Bundle_de();
     }
-    case 'ur':
-      return const _Bundle_ur();
-    case 'tr':
-      return const _Bundle_tr();
-    case 'ps':
-      return const _Bundle_ps();
-    case 'he':
-      return const _Bundle_he();
-    case 'zh': {
+    case 'en': {
       switch(locale.toString()) {
-        case 'zh_TW':
-          return const _Bundle_zh_TW();
-        case 'zh_HK':
-          return const _Bundle_zh_HK();
+        case 'en_AU':
+          return const _Bundle_en_AU();
+        case 'en_CA':
+          return const _Bundle_en_CA();
+        case 'en_GB':
+          return const _Bundle_en_GB();
+        case 'en_IE':
+          return const _Bundle_en_IE();
+        case 'en_IN':
+          return const _Bundle_en_IN();
+        case 'en_SG':
+          return const _Bundle_en_SG();
+        case 'en_ZA':
+          return const _Bundle_en_ZA();
       }
-      return const _Bundle_zh();
+      return const _Bundle_en();
     }
-    case 'ar':
-      return const _Bundle_ar();
-    case 'nl':
-      return const _Bundle_nl();
-    case 'pt': {
+    case 'es': {
       switch(locale.toString()) {
-        case 'pt_PT':
-          return const _Bundle_pt_PT();
+        case 'es_419':
+          return const _Bundle_es_419();
+        case 'es_AR':
+          return const _Bundle_es_AR();
+        case 'es_BO':
+          return const _Bundle_es_BO();
+        case 'es_CL':
+          return const _Bundle_es_CL();
+        case 'es_CO':
+          return const _Bundle_es_CO();
+        case 'es_CR':
+          return const _Bundle_es_CR();
+        case 'es_DO':
+          return const _Bundle_es_DO();
+        case 'es_EC':
+          return const _Bundle_es_EC();
+        case 'es_GT':
+          return const _Bundle_es_GT();
+        case 'es_HN':
+          return const _Bundle_es_HN();
+        case 'es_MX':
+          return const _Bundle_es_MX();
+        case 'es_NI':
+          return const _Bundle_es_NI();
+        case 'es_PA':
+          return const _Bundle_es_PA();
+        case 'es_PE':
+          return const _Bundle_es_PE();
+        case 'es_PR':
+          return const _Bundle_es_PR();
+        case 'es_PY':
+          return const _Bundle_es_PY();
+        case 'es_SV':
+          return const _Bundle_es_SV();
+        case 'es_US':
+          return const _Bundle_es_US();
+        case 'es_UY':
+          return const _Bundle_es_UY();
+        case 'es_VE':
+          return const _Bundle_es_VE();
       }
-      return const _Bundle_pt();
+      return const _Bundle_es();
     }
-    case 'it':
-      return const _Bundle_it();
+    case 'fa':
+      return const _Bundle_fa();
     case 'fr': {
       switch(locale.toString()) {
         case 'fr_CA':
@@ -1386,16 +1358,44 @@ TranslationBundle translationBundleForLocale(Locale locale) {
     }
     case 'gsw':
       return const _Bundle_gsw();
+    case 'he':
+      return const _Bundle_he();
+    case 'it':
+      return const _Bundle_it();
     case 'ja':
       return const _Bundle_ja();
-    case 'th':
-      return const _Bundle_th();
-    case 'ru':
-      return const _Bundle_ru();
     case 'ko':
       return const _Bundle_ko();
+    case 'nl':
+      return const _Bundle_nl();
     case 'pl':
       return const _Bundle_pl();
+    case 'ps':
+      return const _Bundle_ps();
+    case 'pt': {
+      switch(locale.toString()) {
+        case 'pt_PT':
+          return const _Bundle_pt_PT();
+      }
+      return const _Bundle_pt();
+    }
+    case 'ru':
+      return const _Bundle_ru();
+    case 'th':
+      return const _Bundle_th();
+    case 'tr':
+      return const _Bundle_tr();
+    case 'ur':
+      return const _Bundle_ur();
+    case 'zh': {
+      switch(locale.toString()) {
+        case 'zh_HK':
+          return const _Bundle_zh_HK();
+        case 'zh_TW':
+          return const _Bundle_zh_TW();
+      }
+      return const _Bundle_zh();
+    }
   }
   return const TranslationBundle(null);
 }

--- a/packages/flutter_localizations/lib/src/l10n/localizations.dart
+++ b/packages/flutter_localizations/lib/src/l10n/localizations.dart
@@ -1399,4 +1399,3 @@ TranslationBundle translationBundleForLocale(Locale locale) {
   }
   return const TranslationBundle(null);
 }
-

--- a/packages/flutter_localizations/lib/src/material_localizations.dart
+++ b/packages/flutter_localizations/lib/src/material_localizations.dart
@@ -11,7 +11,7 @@ import 'package:intl/date_symbols.dart' as intl;
 import 'package:intl/date_symbol_data_custom.dart' as date_symbol_data_custom;
 import 'l10n/date_localizations.dart' as date_localizations;
 
-import 'l10n/localizations.dart';
+import 'l10n/localizations.dart' show TranslationBundle, translationBundleForLocale;
 import 'widgets_localizations.dart';
 
 /// Localized strings for the material widgets.
@@ -68,13 +68,11 @@ class GlobalMaterialLocalizations implements MaterialLocalizations {
   /// function, rather than constructing this class directly.
   GlobalMaterialLocalizations(this.locale)
       : assert(locale != null),
-        this._localeName = _computeLocaleName(locale) {
+        _localeName = _computeLocaleName(locale) {
     _loadDateIntlDataIfNotLoaded();
 
-    if (localizations.containsKey(locale.languageCode))
-      _nameToValue.addAll(localizations[locale.languageCode]);
-    if (localizations.containsKey(_localeName))
-      _nameToValue.addAll(localizations[_localeName]);
+    _translationBundle = translationBundleForLocale(locale);
+    assert(_translationBundle != null);
 
     const String kMediumDatePattern = 'E, MMM\u00a0d';
     if (intl.DateFormat.localeExists(_localeName)) {
@@ -113,7 +111,7 @@ class GlobalMaterialLocalizations implements MaterialLocalizations {
 
   final String _localeName;
 
-  final Map<String, String> _nameToValue = <String, String>{};
+  TranslationBundle _translationBundle;
 
   intl.NumberFormat _decimalFormat;
 
@@ -130,24 +128,6 @@ class GlobalMaterialLocalizations implements MaterialLocalizations {
   static String _computeLocaleName(Locale locale) {
     final String localeName = locale.countryCode.isEmpty ? locale.languageCode : locale.toString();
     return intl.Intl.canonicalizedLocale(localeName);
-  }
-
-  // TODO(hmuller): the rules for mapping from an integer value to
-  // "one" or "two" etc. are locale specific and an additional "few" category
-  // is needed. See http://cldr.unicode.org/index/cldr-spec/plural-rules
-  String _nameToPluralValue(int count, String key) {
-    String text;
-    if (count == 0)
-      text = _nameToValue['${key}Zero'];
-    else if (count == 1)
-      text = _nameToValue['${key}One'];
-    else if (count == 2)
-      text = _nameToValue['${key}Two'];
-    else if (count > 2)
-      text = _nameToValue['${key}Many'];
-    text ??= _nameToValue['${key}Other'];
-    assert(text != null);
-    return text;
   }
 
   @override
@@ -242,45 +222,45 @@ class GlobalMaterialLocalizations implements MaterialLocalizations {
   }
 
   @override
-  String get openAppDrawerTooltip => _nameToValue['openAppDrawerTooltip'];
+  String get openAppDrawerTooltip => _translationBundle.openAppDrawerTooltip;
 
   @override
-  String get backButtonTooltip => _nameToValue['backButtonTooltip'];
+  String get backButtonTooltip => _translationBundle.backButtonTooltip;
 
   @override
-  String get closeButtonTooltip => _nameToValue['closeButtonTooltip'];
+  String get closeButtonTooltip => _translationBundle.closeButtonTooltip;
 
   @override
-  String get deleteButtonTooltip => _nameToValue['deleteButtonTooltip'];
+  String get deleteButtonTooltip => _translationBundle.deleteButtonTooltip;
 
   @override
-  String get nextMonthTooltip => _nameToValue['nextMonthTooltip'];
+  String get nextMonthTooltip => _translationBundle.nextMonthTooltip;
 
   @override
-  String get previousMonthTooltip => _nameToValue['previousMonthTooltip'];
+  String get previousMonthTooltip => _translationBundle.previousMonthTooltip;
 
   @override
-  String get nextPageTooltip => _nameToValue['nextPageTooltip'];
+  String get nextPageTooltip => _translationBundle.nextPageTooltip;
 
   @override
-  String get previousPageTooltip => _nameToValue['previousPageTooltip'];
+  String get previousPageTooltip => _translationBundle.previousPageTooltip;
 
   @override
-  String get showMenuTooltip => _nameToValue['showMenuTooltip'];
+  String get showMenuTooltip => _translationBundle.showMenuTooltip;
 
   @override
   String aboutListTileTitle(String applicationName) {
-    final String text = _nameToValue['aboutListTileTitle'];
+    final String text = _translationBundle.aboutListTileTitle;
     return text.replaceFirst(r'$applicationName', applicationName);
   }
 
   @override
-  String get licensesPageTitle => _nameToValue['licensesPageTitle'];
+  String get licensesPageTitle => _translationBundle.licensesPageTitle;
 
   @override
   String pageRowsInfoTitle(int firstRow, int lastRow, int rowCount, bool rowCountIsApproximate) {
-    String text = rowCountIsApproximate ? _nameToValue['pageRowsInfoTitleApproximate'] : null;
-    text ??= _nameToValue['pageRowsInfoTitle'];
+    String text = rowCountIsApproximate ? _translationBundle.pageRowsInfoTitleApproximate : null;
+    text ??= _translationBundle.pageRowsInfoTitle;
     assert(text != null, 'A $locale localization was not found for pageRowsInfoTitle or pageRowsInfoTitleApproximate');
     // TODO(hansmuller): this could be more efficient.
     return text
@@ -290,55 +270,69 @@ class GlobalMaterialLocalizations implements MaterialLocalizations {
   }
 
   @override
-  String get rowsPerPageTitle => _nameToValue['rowsPerPageTitle'];
+  String get rowsPerPageTitle => _translationBundle.rowsPerPageTitle;
 
   @override
   String selectedRowCountTitle(int selectedRowCount) {
-    return _nameToPluralValue(selectedRowCount, 'selectedRowCountTitle') // asserts on no match
-      .replaceFirst(r'$selectedRowCount', formatDecimal(selectedRowCount));
+    // TODO(hmuller): the rules for mapping from an integer value to
+    // "one" or "two" etc. are locale specific and an additional "few" category
+    // is needed. See http://cldr.unicode.org/index/cldr-spec/plural-rules
+    String text;
+    if (selectedRowCount == 0)
+      text = _translationBundle.selectedRowCountTitleZero;
+    else if (selectedRowCount == 1)
+      text = _translationBundle.selectedRowCountTitleOne;
+    else if (selectedRowCount == 2)
+      text = _translationBundle.selectedRowCountTitleTwo;
+    else if (selectedRowCount > 2)
+      text = _translationBundle.selectedRowCountTitleMany;
+    text ??= _translationBundle.selectedRowCountTitleOther;
+    assert(text != null);
+
+    return text.replaceFirst(r'$selectedRowCount', formatDecimal(selectedRowCount));
   }
 
   @override
-  String get cancelButtonLabel => _nameToValue['cancelButtonLabel'];
+  String get cancelButtonLabel => _translationBundle.cancelButtonLabel;
 
   @override
-  String get closeButtonLabel => _nameToValue['closeButtonLabel'];
+  String get closeButtonLabel => _translationBundle.closeButtonLabel;
 
   @override
-  String get continueButtonLabel => _nameToValue['continueButtonLabel'];
+  String get continueButtonLabel => _translationBundle.continueButtonLabel;
 
   @override
-  String get copyButtonLabel => _nameToValue['copyButtonLabel'];
+  String get copyButtonLabel => _translationBundle.copyButtonLabel;
 
   @override
-  String get cutButtonLabel => _nameToValue['cutButtonLabel'];
+  String get cutButtonLabel => _translationBundle.cutButtonLabel;
 
   @override
-  String get okButtonLabel => _nameToValue['okButtonLabel'];
+  String get okButtonLabel => _translationBundle.okButtonLabel;
 
   @override
-  String get pasteButtonLabel => _nameToValue['pasteButtonLabel'];
+  String get pasteButtonLabel => _translationBundle.pasteButtonLabel;
 
   @override
-  String get selectAllButtonLabel => _nameToValue['selectAllButtonLabel'];
+  String get selectAllButtonLabel => _translationBundle.selectAllButtonLabel;
 
   @override
-  String get viewLicensesButtonLabel => _nameToValue['viewLicensesButtonLabel'];
+  String get viewLicensesButtonLabel => _translationBundle.viewLicensesButtonLabel;
 
   @override
-  String get anteMeridiemAbbreviation => _nameToValue['anteMeridiemAbbreviation'];
+  String get anteMeridiemAbbreviation => _translationBundle.anteMeridiemAbbreviation;
 
   @override
-  String get postMeridiemAbbreviation => _nameToValue['postMeridiemAbbreviation'];
+  String get postMeridiemAbbreviation => _translationBundle.postMeridiemAbbreviation;
 
   @override
-  String get timePickerHourModeAnnouncement => _nameToValue['timePickerHourModeAnnouncement'];
+  String get timePickerHourModeAnnouncement => _translationBundle.timePickerHourModeAnnouncement;
 
   @override
-  String get timePickerMinuteModeAnnouncement => _nameToValue['timePickerMinuteModeAnnouncement'];
+  String get timePickerMinuteModeAnnouncement => _translationBundle.timePickerMinuteModeAnnouncement;
 
   @override
-  String get modalBarrierDismissLabel => _nameToValue['modalBarrierDismissLabel'];
+  String get modalBarrierDismissLabel => _translationBundle.modalBarrierDismissLabel;
 
   /// The [TimeOfDayFormat] corresponding to one of the following supported
   /// patterns:
@@ -358,7 +352,7 @@ class GlobalMaterialLocalizations implements MaterialLocalizations {
   ///    short time pattern used in locale en_US
   @override
   TimeOfDayFormat timeOfDayFormat({ bool alwaysUse24HourFormat: false }) {
-    final String icuShortTimePattern = _nameToValue['timeOfDayFormat'];
+    final String icuShortTimePattern = _translationBundle.timeOfDayFormat;
 
     assert(() {
       if (!_icuTimeOfDayToEnum.containsKey(icuShortTimePattern)) {
@@ -382,7 +376,7 @@ class GlobalMaterialLocalizations implements MaterialLocalizations {
 
   /// Looks up text geometry defined in [MaterialTextGeometry].
   @override
-  TextTheme get localTextGeometry => MaterialTextGeometry.forScriptCategory(_nameToValue['scriptCategory']);
+  TextTheme get localTextGeometry => MaterialTextGeometry.forScriptCategory(_translationBundle.scriptCategory);
 
   /// Creates an object that provides localized resource values for the
   /// for the widgets of the material library.


### PR DESCRIPTION
An private implementation change for the GlobalMaterialLocalizations class.

Previously `dev/tools/gen_localizations.dart` generated a map for every
locale represented by a package_localizations/lib/src/l10n/*.arb file.
Now it generates a (private) TranslationBundle subclass with a getter
for each (ARB) resource identifier.

For locales with country codes, like en_CA, the subclass delegates to
the language-specific TranslationBundle, like en, for resources whose
values are the same. This makes the resulting code more compact.

GlobalMaterialLocalizations only depends on the generated
TranslationBundle class and translationBundleForLocale() function.
