### PR TITLE
Fix Android templates

### DIFF
--- a/packages/flutter_tools/templates/create/android-java.tmpl/build.gradle
+++ b/packages/flutter_tools/templates/create/android-java.tmpl/build.gradle
@@ -19,6 +19,8 @@ allprojects {
 rootProject.buildDir = '../build'
 subprojects {
     project.buildDir = "${rootProject.buildDir}/${project.name}"
+}
+subprojects {
     project.evaluationDependsOn(':app')
 }
 

--- a/packages/flutter_tools/templates/create/android-kotlin.tmpl/build.gradle
+++ b/packages/flutter_tools/templates/create/android-kotlin.tmpl/build.gradle
@@ -21,6 +21,8 @@ allprojects {
 rootProject.buildDir = '../build'
 subprojects {
     project.buildDir = "${rootProject.buildDir}/${project.name}"
+}
+subprojects {
     project.evaluationDependsOn(':app')
 }
 

--- a/packages/flutter_tools/templates/plugin/android.tmpl/gradle/wrapper/gradle-wrapper.properties
+++ b/packages/flutter_tools/templates/plugin/android.tmpl/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,0 @@
-#Fri Jun 23 08:50:38 CEST 2017
-distributionBase=GRADLE_USER_HOME
-distributionPath=wrapper/dists
-zipStoreBase=GRADLE_USER_HOME
-zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip


### PR DESCRIPTION
Remove superfluous Gradle wrapper properties file from plugins template.

Handle change to project eval order in Android Studio Gradle plugin 3.0.1, causing build dir being set incorrectly on plugin projects named lexicographically before "app".