### PR TITLE
Add a PhysicalShape widget and a render object for it.

### DIFF
--- a/packages/flutter/lib/src/rendering/layer.dart
+++ b/packages/flutter/lib/src/rendering/layer.dart
@@ -801,66 +801,6 @@ class PhysicalModelLayer extends ContainerLayer {
   }
 }
 
-/// A composited layer that uses a physical model to produce lighting effects.
-///
-/// For example, the layer casts a shadow according to its geometry and the
-/// relative position of lights and other physically modelled objects in the
-/// scene.
-///
-/// This class class allows layers of arbitrary shapes; prefer using
-/// [PhysicalModelLayer] for cases where the shape can be expressed as a rounded
-/// rectangle (including ovals) as it is better optimized.
-class PhysicalShapeLayer extends ContainerLayer {
-  /// Creates a composited layer that uses a physical model to produce
-  /// lighting effects.
-  ///
-  /// The [clipPath], [elevation], and [color] arguments must not be null.
-  PhysicalShapeLayer({
-    @required this.clipPath,
-    @required this.elevation,
-    @required this.color,
-  }) : assert(clipPath != null),
-       assert(elevation != null),
-       assert(color != null);
-
-  /// The path to clip in the parent's coordinate system.
-  ///
-  /// The scene must be explicitly recomposited after this property is changed
-  /// (as described at [Layer]).
-  Path clipPath;
-
-  /// The z-coordinate at which to place this physical object.
-  ///
-  /// The scene must be explicitly recomposited after this property is changed
-  /// (as described at [Layer]).
-  double elevation;
-
-  /// The background color.
-  ///
-  /// The scene must be explicitly recomposited after this property is changed
-  /// (as described at [Layer]).
-  Color color;
-
-  @override
-  void addToScene(ui.SceneBuilder builder, Offset layerOffset) {
-    builder.pushPhysicalShape(
-      path: clipPath.shift(layerOffset),
-      elevation: elevation,
-      color: color,
-    );
-    addChildrenToScene(builder, layerOffset);
-    builder.pop();
-  }
-
-  @override
-  void debugFillProperties(DiagnosticPropertiesBuilder description) {
-    super.debugFillProperties(description);
-    description.add(new DiagnosticsProperty<Path>('clipPath', clipPath));
-    description.add(new DoubleProperty('elevation', elevation));
-    description.add(new DiagnosticsProperty<Color>('color', color));
-  }
-}
-
 /// An object that a [LeaderLayer] can register with.
 ///
 /// An instance of this class should be provided as the [LeaderLayer.link] and

--- a/packages/flutter/lib/src/rendering/layer.dart
+++ b/packages/flutter/lib/src/rendering/layer.dart
@@ -801,6 +801,66 @@ class PhysicalModelLayer extends ContainerLayer {
   }
 }
 
+/// A composited layer that uses a physical model to produce lighting effects.
+///
+/// For example, the layer casts a shadow according to its geometry and the
+/// relative position of lights and other physically modelled objects in the
+/// scene.
+///
+/// This class class allows layers of arbitrary shapes, prefer using
+/// [PhysicalModelLayer] if the shape can be expressed as a rounded rectangle
+/// (including ovals) as it is better optimized.
+class PhysicalShapeLayer extends ContainerLayer {
+  /// Creates a composited layer that uses a physical model to produce
+  /// lighting effects.
+  ///
+  /// The [clipPath], [elevation], and [color] arguments must not be null.
+  PhysicalShapeLayer({
+    @required this.clipPath,
+    @required this.elevation,
+    @required this.color,
+  }) : assert(clipPath != null),
+       assert(elevation != null),
+       assert(color != null);
+
+  /// The path to clip in the parent's coordinate system.
+  ///
+  /// The scene must be explicitly recomposited after this property is changed
+  /// (as described at [Layer]).
+  Path clipPath;
+
+  /// The z-coordinate at which to place this physical object.
+  ///
+  /// The scene must be explicitly recomposited after this property is changed
+  /// (as described at [Layer]).
+  double elevation;
+
+  /// The background color.
+  ///
+  /// The scene must be explicitly recomposited after this property is changed
+  /// (as described at [Layer]).
+  Color color;
+
+  @override
+  void addToScene(ui.SceneBuilder builder, Offset layerOffset) {
+    builder.pushPhysicalShape(
+      path: clipPath.shift(layerOffset),
+      elevation: elevation,
+      color: color,
+    );
+    addChildrenToScene(builder, layerOffset);
+    builder.pop();
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder description) {
+    super.debugFillProperties(description);
+    description.add(new DiagnosticsProperty<Path>('clipPath', clipPath));
+    description.add(new DoubleProperty('elevation', elevation));
+    description.add(new DiagnosticsProperty<Color>('color', color));
+  }
+}
+
 /// An object that a [LeaderLayer] can register with.
 ///
 /// An instance of this class should be provided as the [LeaderLayer.link] and

--- a/packages/flutter/lib/src/rendering/layer.dart
+++ b/packages/flutter/lib/src/rendering/layer.dart
@@ -807,9 +807,9 @@ class PhysicalModelLayer extends ContainerLayer {
 /// relative position of lights and other physically modelled objects in the
 /// scene.
 ///
-/// This class class allows layers of arbitrary shapes, prefer using
-/// [PhysicalModelLayer] if the shape can be expressed as a rounded rectangle
-/// (including ovals) as it is better optimized.
+/// This class class allows layers of arbitrary shapes; prefer using
+/// [PhysicalModelLayer] for cases where the shape can be expressed as a rounded
+/// rectangle (including ovals) as it is better optimized.
 class PhysicalShapeLayer extends ContainerLayer {
   /// Creates a composited layer that uses a physical model to produce
   /// lighting effects.

--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -1292,7 +1292,7 @@ class RenderClipPath extends _RenderCustomClip<Path> {
   }
 }
 
-/// Creates a physical model layer that clips its children to a rounded
+/// Creates a physical model layer that clips its child to a rounded
 /// rectangle.
 ///
 /// A physical model layer casts a shadow based on its [elevation].
@@ -1438,9 +1438,9 @@ class RenderPhysicalModel extends _RenderPhysicalModelBase<RRect> {
   }
 }
 
-/// Creates a physical model layer that clips its children to a [ShapeBorder].
+/// Creates a physical shape layer that clips its child to a [ShapeBorder].
 ///
-/// A physical model layer casts a shadow based on its [elevation].
+/// A physical shape layer casts a shadow based on its [elevation].
 ///
 /// See also:
 ///
@@ -1451,7 +1451,7 @@ class RenderPhysicalShape extends _RenderPhysicalModelBase<Path> {
   ///
   /// The [color], [shape], and [textDirection] are required.
   ///
-  /// The [shape], [elevation], [color], [textDirection] and [shadowColor] must
+  /// The [shape], [elevation], [color] and [shadowColor] must
   /// not be null.
   RenderPhysicalShape({
     RenderBox child,
@@ -1464,7 +1464,6 @@ class RenderPhysicalShape extends _RenderPhysicalModelBase<Path> {
        assert(elevation != null),
        assert(color != null),
        assert(shadowColor != null),
-       assert(textDirection != null),
        _shape = shape,
        _textDirection = textDirection,
        super(
@@ -1486,10 +1485,12 @@ class RenderPhysicalShape extends _RenderPhysicalModelBase<Path> {
   }
 
   /// The text direction to use for getting the outer path for [shape].
+  ///
+  /// [ShapeBorder]s can depend on the text direction (e.g having a "dent"
+  /// towards the start of the shape).
   TextDirection get textDirection => _textDirection;
   TextDirection _textDirection;
   set textDirection(TextDirection value) {
-    assert(value != null);
     if (textDirection == value)
       return;
     _textDirection = value;
@@ -1549,7 +1550,7 @@ class RenderPhysicalShape extends _RenderPhysicalModelBase<Path> {
 /// A physical model layer casts a shadow based on its [elevation].
 ///
 /// The concrete implementations [RenderPhysicalModel] and [RenderPhysicalShape]
-/// determines the actual shape of the physical model.
+/// determine the actual shape of the physical model.
 abstract class _RenderPhysicalModelBase<T> extends _RenderCustomClip<T> {
   /// The [shape], [elevation], [color], and [shadowColor] must not be null.
   _RenderPhysicalModelBase({

--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -1440,17 +1440,6 @@ class RenderPhysicalModel extends _RenderPhysicalModelBase<RRect> {
   }
 
   @override
-  bool hitTest(HitTestResult result, { Offset position }) {
-    if (_clipper != null) {
-      _updateClip();
-      assert(_clip != null);
-      if (!_clip.contains(position))
-        return false;
-    }
-    return super.hitTest(result, position: position);
-  }
-
-  @override
   void debugFillProperties(DiagnosticPropertiesBuilder description) {
     super.debugFillProperties(description);
     description.add(new DiagnosticsProperty<BoxShape>('shape', shape));
@@ -1622,6 +1611,17 @@ abstract class _RenderPhysicalModelBase<T> extends _RenderCustomClip<T> {
   // for physical model layers with non-zero elevation.
   @override
   bool get alwaysNeedsCompositing => _elevation != 0.0 && defaultTargetPlatform == TargetPlatform.fuchsia;
+
+  @override
+  bool hitTest(HitTestResult result, { Offset position }) {
+    if (_clipper != null) {
+      _updateClip();
+      assert(_clip != null);
+      if (!_clip.contains(position))
+        return false;
+    }
+    return super.hitTest(result, position: position);
+  }
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder description) {

--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -980,8 +980,9 @@ class ShapeBorderClipper extends CustomClipper<Path> {
 
   /// Returns the outer path of [shapeBorder] as the clip.
   @override
-  Path getClip(Size size)
-    => shapeBorder.getOuterPath(Offset.zero & size, textDirection: textDirection);
+  Path getClip(Size size) {
+    return shapeBorder.getOuterPath(Offset.zero & size, textDirection: textDirection);
+  }
 
   @override
   bool shouldReclip(covariant ShapeBorderClipper oldClipper) {
@@ -1599,12 +1600,12 @@ class RenderPhysicalShape extends _RenderPhysicalModelBase<Path> {
       final Rect offsetBounds = offset & size;
       final Path offsetPath = _clip.shift(offset);
       if (needsCompositing) {
-        final PhysicalShapeLayer physicalShape = new PhysicalShapeLayer(
+        final PhysicalModelLayer physicalModel = new PhysicalModelLayer(
           clipPath: offsetPath,
           elevation: elevation,
           color: color,
         );
-        context.pushLayer(physicalShape, super.paint, offset, childPaintBounds: offsetBounds);
+        context.pushLayer(physicalModel, super.paint, offset, childPaintBounds: offsetBounds);
       } else {
         final Canvas canvas = context.canvas;
         if (elevation != 0.0) {

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -642,6 +642,9 @@ class ClipPath extends SingleChildRenderObjectWidget {
 /// Physical layers cast shadows based on an [elevation] which is nominally in
 /// logical pixels, coming vertically out of the rendering surface.
 ///
+/// For shapes that cannot be expressed as a rectangle with rounded corners use
+/// [PhysicalShape].
+///
 /// See also:
 ///
 ///  * [DecoratedBox], which can apply more arbitrary shadow effects.
@@ -717,6 +720,13 @@ class PhysicalModel extends SingleChildRenderObjectWidget {
   }
 }
 
+/// A widget representing a physical layer that clips its children to a shape.
+///
+/// Physical layers cast shadows based on an [elevation] which is nominally in
+/// logical pixels, coming vertically out of the rendering surface.
+///
+/// [PhysicalModel] does the same but only supports shapes that can be expressed
+/// as rectangles with rounded corners.
 class PhysicalShape extends SingleChildRenderObjectWidget {
   /// Creates a physical model with an arbitrary shape clip.
   ///

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -720,7 +720,7 @@ class PhysicalModel extends SingleChildRenderObjectWidget {
   }
 }
 
-/// A widget representing a physical layer that clips its children to a shape.
+/// A widget representing a physical layer that clips its children to a path.
 ///
 /// Physical layers cast shadows based on an [elevation] which is nominally in
 /// logical pixels, coming vertically out of the rendering surface.
@@ -732,7 +732,7 @@ class PhysicalShape extends SingleChildRenderObjectWidget {
   ///
   /// The [color] is required; physical things have a color.
   ///
-  /// The [shape], [elevation], [color], and [shadowColor] must not be null.
+  /// The [clipper], [elevation], [color], and [shadowColor] must not be null.
   const PhysicalShape({
     Key key,
     @required this.clipper,
@@ -740,7 +740,6 @@ class PhysicalShape extends SingleChildRenderObjectWidget {
     @required this.color,
     this.shadowColor: const Color(0xFF000000),
     Widget child,
-    this.textDirection,
   }) : assert(clipper != null),
        assert(elevation != null),
        assert(color != null),
@@ -759,22 +758,13 @@ class PhysicalShape extends SingleChildRenderObjectWidget {
   /// The shadow color.
   final Color shadowColor;
 
-  /// The directionality of text.
-  ///
-  /// This affects how [shape]'s outer path is computed.
-  ///
-  /// Defaults to the ambient [Directionality], if any. If there is no ambient
-  /// [Directionality], then this must not be null.
-  final TextDirection textDirection;
-
   @override
   RenderPhysicalShape createRenderObject(BuildContext context) {
     return new RenderPhysicalShape(
       clipper: clipper,
       elevation: elevation,
       color: color,
-      shadowColor: shadowColor,
-      textDirection: textDirection ?? Directionality.of(context),
+      shadowColor: shadowColor
     );
   }
 
@@ -784,8 +774,7 @@ class PhysicalShape extends SingleChildRenderObjectWidget {
       ..clipper = clipper
       ..elevation = elevation
       ..color = color
-      ..shadowColor = shadowColor
-      ..textDirection = textDirection;
+      ..shadowColor = shadowColor;
   }
 
   @override
@@ -795,7 +784,6 @@ class PhysicalShape extends SingleChildRenderObjectWidget {
     description.add(new DoubleProperty('elevation', elevation));
     description.add(new DiagnosticsProperty<Color>('color', color));
     description.add(new DiagnosticsProperty<Color>('shadowColor', shadowColor));
-    description.add(new DiagnosticsProperty<TextDirection>('textDirection', textDirection));
   }
 }
 

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -725,19 +725,20 @@ class PhysicalShape extends SingleChildRenderObjectWidget {
   /// The [shape], [elevation], [color], and [shadowColor] must not be null.
   const PhysicalShape({
     Key key,
-    @required this.shape,
+    @required this.clipper,
     this.elevation: 0.0,
     @required this.color,
     this.shadowColor: const Color(0xFF000000),
     Widget child,
     this.textDirection,
-  }) : assert(shape != null),
+  }) : assert(clipper != null),
        assert(elevation != null),
        assert(color != null),
        assert(shadowColor != null),
        super(key: key, child: child);
 
-  final ShapeBorder shape;
+  /// Determines which clip to use.
+  final CustomClipper<Path> clipper;
 
   /// The z-coordinate at which to place this physical object.
   final double elevation;
@@ -759,7 +760,7 @@ class PhysicalShape extends SingleChildRenderObjectWidget {
   @override
   RenderPhysicalShape createRenderObject(BuildContext context) {
     return new RenderPhysicalShape(
-      shape: shape,
+      clipper: clipper,
       elevation: elevation,
       color: color,
       shadowColor: shadowColor,
@@ -770,7 +771,7 @@ class PhysicalShape extends SingleChildRenderObjectWidget {
   @override
   void updateRenderObject(BuildContext context, RenderPhysicalShape renderObject) {
     renderObject
-      ..shape = shape
+      ..clipper = clipper
       ..elevation = elevation
       ..color = color
       ..shadowColor = shadowColor
@@ -780,7 +781,7 @@ class PhysicalShape extends SingleChildRenderObjectWidget {
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder description) {
     super.debugFillProperties(description);
-    description.add(new EnumProperty<ShapeBorder>('shape', shape));
+    description.add(new EnumProperty<CustomClipper<Path>>('clipper', clipper));
     description.add(new DoubleProperty('elevation', elevation));
     description.add(new DiagnosticsProperty<Color>('color', color));
     description.add(new DiagnosticsProperty<Color>('shadowColor', shadowColor));

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -755,7 +755,7 @@ class PhysicalShape extends SingleChildRenderObjectWidget {
   /// The background color.
   final Color color;
 
-  /// The shadow color.
+  /// When elevation is non zero the color to use for the shadow color.
   final Color shadowColor;
 
   @override

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -718,7 +718,7 @@ class PhysicalModel extends SingleChildRenderObjectWidget {
 }
 
 class PhysicalShape extends SingleChildRenderObjectWidget {
-  /// Creates a physical model with a rounded-rectangular clip.
+  /// Creates a physical model with an arbitrary shape clip.
   ///
   /// The [color] is required; physical things have a color.
   ///
@@ -745,6 +745,7 @@ class PhysicalShape extends SingleChildRenderObjectWidget {
   /// The background color.
   final Color color;
 
+  /// The shadow color.
   final Color shadowColor;
 
   /// The directionality of text.

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -717,6 +717,76 @@ class PhysicalModel extends SingleChildRenderObjectWidget {
   }
 }
 
+class PhysicalShape extends SingleChildRenderObjectWidget {
+  /// Creates a physical model with a rounded-rectangular clip.
+  ///
+  /// The [color] is required; physical things have a color.
+  ///
+  /// The [shape], [elevation], [color], and [shadowColor] must not be null.
+  const PhysicalShape({
+    Key key,
+    @required this.shape,
+    this.elevation: 0.0,
+    @required this.color,
+    this.shadowColor: const Color(0xFF000000),
+    Widget child,
+    this.textDirection,
+  }) : assert(shape != null),
+       assert(elevation != null),
+       assert(color != null),
+       assert(shadowColor != null),
+       super(key: key, child: child);
+
+  final ShapeBorder shape;
+
+  /// The z-coordinate at which to place this physical object.
+  final double elevation;
+
+  /// The background color.
+  final Color color;
+
+  final Color shadowColor;
+
+  /// The directionality of text.
+  ///
+  /// This affects how [shape]'s outer path is computed.
+  ///
+  /// Defaults to the ambient [Directionality], if any. If there is no ambient
+  /// [Directionality], then this must not be null.
+  final TextDirection textDirection;
+
+  @override
+  RenderPhysicalShape createRenderObject(BuildContext context) {
+    return new RenderPhysicalShape(
+      shape: shape,
+      elevation: elevation,
+      color: color,
+      shadowColor: shadowColor,
+      textDirection: textDirection ?? Directionality.of(context),
+    );
+  }
+
+  @override
+  void updateRenderObject(BuildContext context, RenderPhysicalShape renderObject) {
+    renderObject
+      ..shape = shape
+      ..elevation = elevation
+      ..color = color
+      ..shadowColor = shadowColor
+      ..textDirection = textDirection;
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder description) {
+    super.debugFillProperties(description);
+    description.add(new EnumProperty<ShapeBorder>('shape', shape));
+    description.add(new DoubleProperty('elevation', elevation));
+    description.add(new DiagnosticsProperty<Color>('color', color));
+    description.add(new DiagnosticsProperty<Color>('shadowColor', shadowColor));
+    description.add(new DiagnosticsProperty<TextDirection>('textDirection', textDirection));
+  }
+}
+
 // POSITIONING AND SIZING NODES
 
 /// A widget that applies a transformation before painting its child.

--- a/packages/flutter/test/rendering/proxy_box_test.dart
+++ b/packages/flutter/test/rendering/proxy_box_test.dart
@@ -91,4 +91,67 @@ void main() {
     expect(config.getActionHandler(SemanticsAction.scrollLeft), isNotNull);
     expect(config.getActionHandler(SemanticsAction.scrollRight), isNull);
   });
+
+  group('RenderPhysicalShape', () {
+    setUp(() {
+      debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+    });
+
+    test('shape change triggers repaint', () {
+      final RenderPhysicalShape root = new RenderPhysicalShape(
+        color: const Color(0xffff00ff),
+        shape: const CircleBorder(),
+        textDirection: TextDirection.ltr,
+      );
+      layout(root, phase: EnginePhase.composite);
+      expect(root.debugNeedsPaint, isFalse);
+
+      // Same shape, no repaint.
+      root.shape = const CircleBorder();
+      expect(root.debugNeedsPaint, isFalse);
+
+      // Different shape triggers repaint.
+      root.shape = const StadiumBorder();
+      expect(root.debugNeedsPaint, isTrue);
+    });
+
+    test('text direction change triggers repaint', () {
+      final RenderPhysicalShape root = new RenderPhysicalShape(
+        color: const Color(0xffff00ff),
+        shape: const CircleBorder(),
+        textDirection: TextDirection.ltr,
+      );
+      layout(root, phase: EnginePhase.composite);
+      expect(root.debugNeedsPaint, isFalse);
+
+      // Same direction, no repaint.
+      root.textDirection = TextDirection.ltr;
+      expect(root.debugNeedsPaint, isFalse);
+
+      // Different direction triggers repaint.
+      root.textDirection = TextDirection.rtl;
+      expect(root.debugNeedsPaint, isTrue);
+    });
+
+    test('compositing on non-Fuchsia', () {
+      final RenderPhysicalShape root = new RenderPhysicalShape(
+        color: const Color(0xffff00ff),
+        shape: const CircleBorder(),
+        textDirection: TextDirection.ltr,
+      );
+      layout(root, phase: EnginePhase.composite);
+      expect(root.needsCompositing, isFalse);
+
+      // On non-Fuchsia platforms, Flutter draws its own shadows.
+      root.elevation = 1.0;
+      pumpFrame(phase: EnginePhase.composite);
+      expect(root.needsCompositing, isFalse);
+
+      root.elevation = 0.0;
+      pumpFrame(phase: EnginePhase.composite);
+      expect(root.needsCompositing, isFalse);
+
+      debugDefaultTargetPlatformOverride = null;
+    });
+  });
 }

--- a/packages/flutter/test/rendering/proxy_box_test.dart
+++ b/packages/flutter/test/rendering/proxy_box_test.dart
@@ -100,25 +100,25 @@ void main() {
     test('shape change triggers repaint', () {
       final RenderPhysicalShape root = new RenderPhysicalShape(
         color: const Color(0xffff00ff),
-        shape: const CircleBorder(),
+        clipper: const ShapeBorderClipper(shapeBorder: const CircleBorder()),
         textDirection: TextDirection.ltr,
       );
       layout(root, phase: EnginePhase.composite);
       expect(root.debugNeedsPaint, isFalse);
 
       // Same shape, no repaint.
-      root.shape = const CircleBorder();
+      root.clipper = const ShapeBorderClipper(shapeBorder: const CircleBorder());
       expect(root.debugNeedsPaint, isFalse);
 
       // Different shape triggers repaint.
-      root.shape = const StadiumBorder();
+      root.clipper = const ShapeBorderClipper(shapeBorder: const StadiumBorder());
       expect(root.debugNeedsPaint, isTrue);
     });
 
     test('text direction change triggers repaint', () {
       final RenderPhysicalShape root = new RenderPhysicalShape(
         color: const Color(0xffff00ff),
-        shape: const CircleBorder(),
+        clipper: const ShapeBorderClipper(shapeBorder: const CircleBorder()),
         textDirection: TextDirection.ltr,
       );
       layout(root, phase: EnginePhase.composite);
@@ -136,7 +136,7 @@ void main() {
     test('compositing on non-Fuchsia', () {
       final RenderPhysicalShape root = new RenderPhysicalShape(
         color: const Color(0xffff00ff),
-        shape: const CircleBorder(),
+        clipper: const ShapeBorderClipper(shapeBorder: const CircleBorder()),
         textDirection: TextDirection.ltr,
       );
       layout(root, phase: EnginePhase.composite);

--- a/packages/flutter/test/rendering/proxy_box_test.dart
+++ b/packages/flutter/test/rendering/proxy_box_test.dart
@@ -101,7 +101,6 @@ void main() {
       final RenderPhysicalShape root = new RenderPhysicalShape(
         color: const Color(0xffff00ff),
         clipper: const ShapeBorderClipper(shapeBorder: const CircleBorder()),
-        textDirection: TextDirection.ltr,
       );
       layout(root, phase: EnginePhase.composite);
       expect(root.debugNeedsPaint, isFalse);
@@ -115,29 +114,10 @@ void main() {
       expect(root.debugNeedsPaint, isTrue);
     });
 
-    test('text direction change triggers repaint', () {
-      final RenderPhysicalShape root = new RenderPhysicalShape(
-        color: const Color(0xffff00ff),
-        clipper: const ShapeBorderClipper(shapeBorder: const CircleBorder()),
-        textDirection: TextDirection.ltr,
-      );
-      layout(root, phase: EnginePhase.composite);
-      expect(root.debugNeedsPaint, isFalse);
-
-      // Same direction, no repaint.
-      root.textDirection = TextDirection.ltr;
-      expect(root.debugNeedsPaint, isFalse);
-
-      // Different direction triggers repaint.
-      root.textDirection = TextDirection.rtl;
-      expect(root.debugNeedsPaint, isTrue);
-    });
-
     test('compositing on non-Fuchsia', () {
       final RenderPhysicalShape root = new RenderPhysicalShape(
         color: const Color(0xffff00ff),
         clipper: const ShapeBorderClipper(shapeBorder: const CircleBorder()),
-        textDirection: TextDirection.ltr,
       );
       layout(root, phase: EnginePhase.composite);
       expect(root.needsCompositing, isFalse);

--- a/packages/flutter/test/widgets/basic_test.dart
+++ b/packages/flutter/test/widgets/basic_test.dart
@@ -16,7 +16,6 @@ void main() {
           elevation: 2.0,
           color: const Color(0xFF0000FF),
           shadowColor: const Color(0xFF00FF00),
-          textDirection: TextDirection.ltr,
         )
       );
       final RenderPhysicalShape renderObject = tester.renderObject(find.byType(PhysicalShape));
@@ -24,36 +23,6 @@ void main() {
       expect(renderObject.color, const Color(0xFF0000FF));
       expect(renderObject.shadowColor, const Color(0xFF00FF00));
       expect(renderObject.elevation, 2.0);
-      expect(renderObject.textDirection, TextDirection.ltr);
-    });
-
-    testWidgets('overrides directionality', (WidgetTester tester) async {
-      await tester.pumpWidget(
-        const Directionality(
-          textDirection: TextDirection.rtl,
-          child: const PhysicalShape(
-            clipper: const ShapeBorderClipper(shapeBorder: const CircleBorder()),
-            color: const Color(0xFF0000FF),
-            textDirection: TextDirection.ltr,
-          ),
-        ),
-      );
-      final RenderPhysicalShape renderObject = tester.renderObject(find.byType(PhysicalShape));
-      expect(renderObject.textDirection, TextDirection.ltr);
-    });
-
-    testWidgets('inherits directionality', (WidgetTester tester) async {
-      await tester.pumpWidget(
-        const Directionality(
-          textDirection: TextDirection.rtl,
-          child: const PhysicalShape(
-            clipper: const ShapeBorderClipper(shapeBorder: const CircleBorder()),
-            color: const Color(0xFF0000FF),
-          ),
-        ),
-      );
-      final RenderPhysicalShape renderObject = tester.renderObject(find.byType(PhysicalShape));
-      expect(renderObject.textDirection, TextDirection.rtl);
     });
 
     testWidgets('hit test', (WidgetTester tester) async {
@@ -77,10 +46,10 @@ void main() {
       // We test by sampling a few points around the left-most point of the
       // circle (100, 300).
 
-      expect(tester.hitTestOnBinding(const Offset(99.0, 300.0)), doesntHit(renderPhysicalShape));
+      expect(tester.hitTestOnBinding(const Offset(99.0, 300.0)), doesNotHit(renderPhysicalShape));
       expect(tester.hitTestOnBinding(const Offset(100.0, 300.0)), hits(renderPhysicalShape));
-      expect(tester.hitTestOnBinding(const Offset(100.0, 299.0)), doesntHit(renderPhysicalShape));
-      expect(tester.hitTestOnBinding(const Offset(100.0, 301.0)), doesntHit(renderPhysicalShape));
+      expect(tester.hitTestOnBinding(const Offset(100.0, 299.0)), doesNotHit(renderPhysicalShape));
+      expect(tester.hitTestOnBinding(const Offset(100.0, 301.0)), doesNotHit(renderPhysicalShape));
     });
 
   });
@@ -107,10 +76,10 @@ class HitsRenderBox extends Matcher {
   }
 }
 
-DoesntHitRenderBox doesntHit(RenderBox renderBox) => new DoesntHitRenderBox(renderBox);
+DoesNotHitRenderBox doesNotHit(RenderBox renderBox) => new DoesNotHitRenderBox(renderBox);
 
-class DoesntHitRenderBox extends Matcher {
-  const DoesntHitRenderBox(this.renderBox);
+class DoesNotHitRenderBox extends Matcher {
+  const DoesNotHitRenderBox(this.renderBox);
 
   final RenderBox renderBox;
 

--- a/packages/flutter/test/widgets/basic_test.dart
+++ b/packages/flutter/test/widgets/basic_test.dart
@@ -1,0 +1,60 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter/rendering.dart';
+
+
+void main() {
+  group('PhysicalShape', () {
+    testWidgets('properties', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        const PhysicalShape(
+          shape: const CircleBorder(),
+          elevation: 2.0,
+          color: const Color(0xFF0000FF),
+          shadowColor: const Color(0xFF00FF00),
+          textDirection: TextDirection.ltr,
+        )
+      );
+      final RenderPhysicalShape renderObject = tester.renderObject(find.byType(PhysicalShape));
+      expect(renderObject.shape, const CircleBorder());
+      expect(renderObject.color, const Color(0xFF0000FF));
+      expect(renderObject.shadowColor, const Color(0xFF00FF00));
+      expect(renderObject.elevation, 2.0);
+      expect(renderObject.textDirection, TextDirection.ltr);
+    });
+
+    testWidgets('overrides directionality', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        const Directionality(
+          textDirection: TextDirection.rtl,
+          child: const PhysicalShape(
+            shape: const CircleBorder(),
+            color: const Color(0xFF0000FF),
+            textDirection: TextDirection.ltr,
+          ),
+        ),
+      );
+      final RenderPhysicalShape renderObject = tester.renderObject(find.byType(PhysicalShape));
+      expect(renderObject.textDirection, TextDirection.ltr);
+    });
+
+    testWidgets('inherits directionality', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        const Directionality(
+          textDirection: TextDirection.rtl,
+          child: const PhysicalShape(
+            shape: const CircleBorder(),
+            color: const Color(0xFF0000FF),
+          ),
+        ),
+      );
+      final RenderPhysicalShape renderObject = tester.renderObject(find.byType(PhysicalShape));
+      expect(renderObject.textDirection, TextDirection.rtl);
+    });
+  });
+
+}

--- a/packages/flutter/test/widgets/basic_test.dart
+++ b/packages/flutter/test/widgets/basic_test.dart
@@ -67,7 +67,7 @@ void main() {
         )
       );
 
-      RenderPhysicalShape renderPhysicalShape =
+      final RenderPhysicalShape renderPhysicalShape =
         tester.renderObject(find.byType(PhysicalShape));
 
       // The viewport is 800x600, the CircleBorder is centered and fits

--- a/packages/flutter/test/widgets/basic_test.dart
+++ b/packages/flutter/test/widgets/basic_test.dart
@@ -12,7 +12,7 @@ void main() {
     testWidgets('properties', (WidgetTester tester) async {
       await tester.pumpWidget(
         const PhysicalShape(
-          shape: const CircleBorder(),
+          clipper: const ShapeBorderClipper(shapeBorder: const CircleBorder()),
           elevation: 2.0,
           color: const Color(0xFF0000FF),
           shadowColor: const Color(0xFF00FF00),
@@ -20,7 +20,7 @@ void main() {
         )
       );
       final RenderPhysicalShape renderObject = tester.renderObject(find.byType(PhysicalShape));
-      expect(renderObject.shape, const CircleBorder());
+      expect(renderObject.clipper, const ShapeBorderClipper(shapeBorder: const CircleBorder()));
       expect(renderObject.color, const Color(0xFF0000FF));
       expect(renderObject.shadowColor, const Color(0xFF00FF00));
       expect(renderObject.elevation, 2.0);
@@ -32,7 +32,7 @@ void main() {
         const Directionality(
           textDirection: TextDirection.rtl,
           child: const PhysicalShape(
-            shape: const CircleBorder(),
+            clipper: const ShapeBorderClipper(shapeBorder: const CircleBorder()),
             color: const Color(0xFF0000FF),
             textDirection: TextDirection.ltr,
           ),
@@ -47,7 +47,7 @@ void main() {
         const Directionality(
           textDirection: TextDirection.rtl,
           child: const PhysicalShape(
-            shape: const CircleBorder(),
+            clipper: const ShapeBorderClipper(shapeBorder: const CircleBorder()),
             color: const Color(0xFF0000FF),
           ),
         ),

--- a/packages/flutter/test/widgets/basic_test.dart
+++ b/packages/flutter/test/widgets/basic_test.dart
@@ -55,6 +55,74 @@ void main() {
       final RenderPhysicalShape renderObject = tester.renderObject(find.byType(PhysicalShape));
       expect(renderObject.textDirection, TextDirection.rtl);
     });
+
+    testWidgets('hit test', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        new PhysicalShape(
+          clipper: const ShapeBorderClipper(shapeBorder: const CircleBorder()),
+          elevation: 2.0,
+          color: const Color(0xFF0000FF),
+          shadowColor: const Color(0xFF00FF00),
+          child: new Container(color: const Color(0xFF0000FF)),
+        )
+      );
+
+      RenderPhysicalShape renderPhysicalShape =
+        tester.renderObject(find.byType(PhysicalShape));
+
+      // The viewport is 800x600, the CircleBorder is centered and fits
+      // the shortest edge, so we get a circle of radius 300, centered at
+      // (400, 300).
+      //
+      // We test by sampling a few points around the left-most point of the
+      // circle (100, 300).
+
+      expect(tester.hitTestOnBinding(const Offset(99.0, 300.0)), doesntHit(renderPhysicalShape));
+      expect(tester.hitTestOnBinding(const Offset(100.0, 300.0)), hits(renderPhysicalShape));
+      expect(tester.hitTestOnBinding(const Offset(100.0, 299.0)), doesntHit(renderPhysicalShape));
+      expect(tester.hitTestOnBinding(const Offset(100.0, 301.0)), doesntHit(renderPhysicalShape));
+    });
+
   });
 
+}
+
+HitsRenderBox hits(RenderBox renderBox) => new HitsRenderBox(renderBox);
+
+class HitsRenderBox extends Matcher {
+  const HitsRenderBox(this.renderBox);
+
+  final RenderBox renderBox;
+
+  @override
+  Description describe(Description description) =>
+    description.add('hit test result contains ').addDescriptionOf(renderBox);
+
+  @override
+  bool matches(dynamic item, Map<dynamic, dynamic> matchState) {
+    final HitTestResult hitTestResult = item;
+    return hitTestResult.path.where(
+      (HitTestEntry entry) => entry.target == renderBox
+    ).isNotEmpty;
+  }
+}
+
+DoesntHitRenderBox doesntHit(RenderBox renderBox) => new DoesntHitRenderBox(renderBox);
+
+class DoesntHitRenderBox extends Matcher {
+  const DoesntHitRenderBox(this.renderBox);
+
+  final RenderBox renderBox;
+
+  @override
+  Description describe(Description description) =>
+    description.add('hit test result doesn\'t contain ').addDescriptionOf(renderBox);
+
+  @override
+  bool matches(dynamic item, Map<dynamic, dynamic> matchState) {
+    final HitTestResult hitTestResult = item;
+    return hitTestResult.path.where(
+      (HitTestEntry entry) => entry.target == renderBox
+    ).isEmpty;
+  }
 }


### PR DESCRIPTION
This CL also refactors common logic for RenderPhysicalModel and
RenderPhysicalShape into a base class _RenderPhysicalModelBase.

This is based on Ian's work from:
https://github.com/Hixie/flutter/commit/26489315d9646d42152a638ce31cfbd67c98b021