### PR TITLE
Add .vscode/ to .gitignore template

### DIFF
--- a/packages/flutter_tools/templates/create/.gitignore.tmpl
+++ b/packages/flutter_tools/templates/create/.gitignore.tmpl
@@ -1,6 +1,7 @@
 .DS_Store
 .atom/
 .idea
+.vscode/
 .packages
 .pub/
 build/


### PR DESCRIPTION
Adds .vscode/ to the .gitignore rules generated on flutter create.