### PR TITLE
Debug location

### DIFF
--- a/examples/flutter_gallery/lib/demo/animation/home.dart
+++ b/examples/flutter_gallery/lib/demo/animation/home.dart
@@ -76,12 +76,12 @@ class _RenderStatusBarPaddingSliver extends RenderSliver {
 
 class _StatusBarPaddingSliver extends SingleChildRenderObjectWidget {
   const _StatusBarPaddingSliver({
-    Key key,
+    Object debugLocation, Key key,
     @required this.maxHeight,
     this.scrollFactor: 5.0,
   }) : assert(maxHeight != null && maxHeight >= 0.0),
        assert(scrollFactor != null && scrollFactor >= 1.0),
-       super(key: key);
+       super(debugLocation: debugLocation, key: key);
 
   final double maxHeight;
   final double scrollFactor;
@@ -259,7 +259,7 @@ class _AllSectionsLayout extends MultiChildLayoutDelegate {
 
 class _AllSectionsView extends AnimatedWidget {
   _AllSectionsView({
-    Key key,
+    Object debugLocation, Key key,
     this.sectionIndex,
     @required this.sections,
     @required this.selectedIndex,
@@ -273,7 +273,7 @@ class _AllSectionsView extends AnimatedWidget {
        assert(sectionIndex >= 0 && sectionIndex < sections.length),
        assert(selectedIndex != null),
        assert(selectedIndex.value >= 0.0 && selectedIndex.value < sections.length.toDouble()),
-       super(key: key, listenable: selectedIndex);
+       super(debugLocation: debugLocation, key: key, listenable: selectedIndex);
 
   final int sectionIndex;
   final List<Section> sections;
@@ -421,7 +421,7 @@ class _SnappingScrollPhysics extends ClampingScrollPhysics {
 }
 
 class AnimationDemoHome extends StatefulWidget {
-  const AnimationDemoHome({ Key key }) : super(key: key);
+  const AnimationDemoHome({ Object debugLocation, Key key }) : super(debugLocation: debugLocation, key: key);
 
   static const String routeName = '/animation';
 

--- a/examples/flutter_gallery/lib/demo/animation/widgets.dart
+++ b/examples/flutter_gallery/lib/demo/animation/widgets.dart
@@ -11,9 +11,9 @@ const double kSectionIndicatorWidth = 32.0;
 
 // The card for a single section. Displays the section's gradient and background image.
 class SectionCard extends StatelessWidget {
-  const SectionCard({ Key key, @required this.section })
+  const SectionCard({ Object debugLocation, Key key, @required this.section })
     : assert(section != null),
-      super(key: key);
+      super(debugLocation: debugLocation, key: key);
 
   final Section section;
 
@@ -58,14 +58,14 @@ class SectionTitle extends StatelessWidget {
   );
 
   const SectionTitle({
-    Key key,
+    Object debugLocation, Key key,
     @required this.section,
     @required this.scale,
     @required this.opacity,
   }) : assert(section != null),
        assert(scale != null),
        assert(opacity != null && opacity >= 0.0 && opacity <= 1.0),
-       super(key: key);
+       super(debugLocation: debugLocation, key: key);
 
   final Section section;
   final double scale;
@@ -96,7 +96,7 @@ class SectionTitle extends StatelessWidget {
 
 // Small horizontal bar that indicates the selected section.
 class SectionIndicator extends StatelessWidget {
-  const SectionIndicator({ Key key, this.opacity: 1.0 }) : super(key: key);
+  const SectionIndicator({ Object debugLocation, Key key, this.opacity: 1.0 }) : super(debugLocation: debugLocation, key: key);
 
   final double opacity;
 
@@ -114,10 +114,10 @@ class SectionIndicator extends StatelessWidget {
 
 // Display a single SectionDetail.
 class SectionDetailView extends StatelessWidget {
-  SectionDetailView({ Key key, @required this.detail })
+  SectionDetailView({ Object debugLocation, Key key, @required this.detail })
     : assert(detail != null && detail.imageAsset != null),
       assert((detail.imageAsset ?? detail.title) != null),
-      super(key: key);
+      super(debugLocation: debugLocation, key: key);
 
   final SectionDetail detail;
 

--- a/examples/flutter_gallery/lib/demo/animation_demo.dart
+++ b/examples/flutter_gallery/lib/demo/animation_demo.dart
@@ -7,7 +7,7 @@ import 'package:flutter/material.dart';
 import 'animation/home.dart';
 
 class AnimationDemo extends StatelessWidget {
-  const AnimationDemo({Key key}) : super(key: key);
+  const AnimationDemo({Object debugLocation, Key key}) : super(debugLocation: debugLocation, key: key);
 
   static const String routeName = '/animation';
 

--- a/examples/flutter_gallery/lib/demo/calculator/home.dart
+++ b/examples/flutter_gallery/lib/demo/calculator/home.dart
@@ -7,7 +7,7 @@ import 'package:flutter/material.dart';
 import 'logic.dart';
 
 class Calculator extends StatefulWidget {
-  const Calculator({Key key}) : super(key: key);
+  const Calculator({Object debugLocation, Key key}) : super(debugLocation: debugLocation, key: key);
 
   @override
   _CalculatorState createState() => new _CalculatorState();

--- a/examples/flutter_gallery/lib/demo/calculator_demo.dart
+++ b/examples/flutter_gallery/lib/demo/calculator_demo.dart
@@ -7,7 +7,7 @@ import 'package:flutter/material.dart';
 import 'calculator/home.dart';
 
 class CalculatorDemo extends StatelessWidget {
-  const CalculatorDemo({Key key}) : super(key: key);
+  const CalculatorDemo({Object debugLocation, Key key}) : super(debugLocation: debugLocation, key: key);
 
   static const String routeName = '/calculator';
 

--- a/examples/flutter_gallery/lib/demo/colors_demo.dart
+++ b/examples/flutter_gallery/lib/demo/colors_demo.dart
@@ -43,14 +43,14 @@ final List<Palette> allPalettes = <Palette>[
 
 class ColorItem extends StatelessWidget {
   const ColorItem({
-    Key key,
+    Object debugLocation, Key key,
     @required this.index,
     @required this.color,
     this.prefix: '',
   }) : assert(index != null),
        assert(color != null),
        assert(prefix != null),
-       super(key: key);
+       super(debugLocation: debugLocation, key: key);
 
   final int index;
   final Color color;
@@ -81,10 +81,10 @@ class PaletteTabView extends StatelessWidget {
   static const List<int> accentKeys = const <int>[100, 200, 400, 700];
 
   PaletteTabView({
-    Key key,
+    Object debugLocation, Key key,
     @required this.colors,
   }) : assert(colors != null && colors.isValid),
-       super(key: key);
+       super(debugLocation: debugLocation, key: key);
 
   final Palette colors;
 

--- a/examples/flutter_gallery/lib/demo/contacts_demo.dart
+++ b/examples/flutter_gallery/lib/demo/contacts_demo.dart
@@ -5,7 +5,7 @@
 import 'package:flutter/material.dart';
 
 class _ContactCategory extends StatelessWidget {
-  const _ContactCategory({ Key key, this.icon, this.children }) : super(key: key);
+  const _ContactCategory({ Object debugLocation, Key key, this.icon, this.children }) : super(debugLocation: debugLocation, key: key);
 
   final IconData icon;
   final List<Widget> children;
@@ -37,9 +37,9 @@ class _ContactCategory extends StatelessWidget {
 }
 
 class _ContactItem extends StatelessWidget {
-  _ContactItem({ Key key, this.icon, this.lines, this.tooltip, this.onPressed })
+  _ContactItem({ Object debugLocation, Key key, this.icon, this.lines, this.tooltip, this.onPressed })
     : assert(lines.length > 1),
-      super(key: key);
+      super(debugLocation: debugLocation, key: key);
 
   final IconData icon;
   final List<String> lines;

--- a/examples/flutter_gallery/lib/demo/material/cards_demo.dart
+++ b/examples/flutter_gallery/lib/demo/material/cards_demo.dart
@@ -47,9 +47,9 @@ final List<TravelDestination> destinations = <TravelDestination>[
 ];
 
 class TravelDestinationItem extends StatelessWidget {
-  TravelDestinationItem({ Key key, @required this.destination })
+  TravelDestinationItem({ Object debugLocation, Key key, @required this.destination })
     : assert(destination != null && destination.isValid),
-      super(key: key);
+      super(debugLocation: debugLocation, key: key);
 
   static final double height = 366.0;
   final TravelDestination destination;

--- a/examples/flutter_gallery/lib/demo/material/date_and_time_picker_demo.dart
+++ b/examples/flutter_gallery/lib/demo/material/date_and_time_picker_demo.dart
@@ -9,12 +9,12 @@ import 'package:intl/intl.dart';
 
 class _InputDropdown extends StatelessWidget {
   const _InputDropdown({
-    Key key,
+    Object debugLocation, Key key,
     this.child,
     this.labelText,
     this.valueText,
     this.valueStyle,
-    this.onPressed }) : super(key: key);
+    this.onPressed }) : super(debugLocation: debugLocation, key: key);
 
   final String labelText;
   final String valueText;
@@ -48,13 +48,13 @@ class _InputDropdown extends StatelessWidget {
 
 class _DateTimePicker extends StatelessWidget {
   const _DateTimePicker({
-    Key key,
+    Object debugLocation, Key key,
     this.labelText,
     this.selectedDate,
     this.selectedTime,
     this.selectDate,
     this.selectTime
-  }) : super(key: key);
+  }) : super(debugLocation: debugLocation, key: key);
 
   final String labelText;
   final DateTime selectedDate;

--- a/examples/flutter_gallery/lib/demo/material/dialog_demo.dart
+++ b/examples/flutter_gallery/lib/demo/material/dialog_demo.dart
@@ -20,7 +20,7 @@ const String _alertWithTitleText =
   'data to Google, even when no apps are running.';
 
 class DialogDemoItem extends StatelessWidget {
-  const DialogDemoItem({ Key key, this.icon, this.color, this.text, this.onPressed }) : super(key: key);
+  const DialogDemoItem({ Object debugLocation, Key key, this.icon, this.color, this.text, this.onPressed }) : super(debugLocation: debugLocation, key: key);
 
   final IconData icon;
   final Color color;

--- a/examples/flutter_gallery/lib/demo/material/full_screen_dialog_demo.dart
+++ b/examples/flutter_gallery/lib/demo/material/full_screen_dialog_demo.dart
@@ -18,11 +18,11 @@ enum DismissDialogAction {
 }
 
 class DateTimeItem extends StatelessWidget {
-  DateTimeItem({ Key key, DateTime dateTime, @required this.onChanged })
+  DateTimeItem({ Object debugLocation, Key key, DateTime dateTime, @required this.onChanged })
     : assert(onChanged != null),
       date = new DateTime(dateTime.year, dateTime.month, dateTime.day),
       time = new TimeOfDay(hour: dateTime.hour, minute: dateTime.minute),
-      super(key: key);
+      super(debugLocation: debugLocation, key: key);
 
   final DateTime date;
   final TimeOfDay time;

--- a/examples/flutter_gallery/lib/demo/material/grid_list_demo.dart
+++ b/examples/flutter_gallery/lib/demo/material/grid_list_demo.dart
@@ -37,7 +37,7 @@ class Photo {
 }
 
 class GridPhotoViewer extends StatefulWidget {
-  const GridPhotoViewer({ Key key, this.photo }) : super(key: key);
+  const GridPhotoViewer({ Object debugLocation, Key key, this.photo }) : super(debugLocation: debugLocation, key: key);
 
   final Photo photo;
 
@@ -151,14 +151,14 @@ class _GridPhotoViewerState extends State<GridPhotoViewer> with SingleTickerProv
 
 class GridDemoPhotoItem extends StatelessWidget {
   GridDemoPhotoItem({
-    Key key,
+    Object debugLocation, Key key,
     @required this.photo,
     @required this.tileStyle,
     @required this.onBannerTap
   }) : assert(photo != null && photo.isValid),
        assert(tileStyle != null),
        assert(onBannerTap != null),
-       super(key: key);
+       super(debugLocation: debugLocation, key: key);
 
   final Photo photo;
   final GridDemoTileStyle tileStyle;
@@ -242,7 +242,7 @@ class GridDemoPhotoItem extends StatelessWidget {
 }
 
 class GridListDemo extends StatefulWidget {
-  const GridListDemo({ Key key }) : super(key: key);
+  const GridListDemo({ Object debugLocation, Key key }) : super(debugLocation: debugLocation, key: key);
 
   static const String routeName = '/material/grid-list';
 

--- a/examples/flutter_gallery/lib/demo/material/leave_behind_demo.dart
+++ b/examples/flutter_gallery/lib/demo/material/leave_behind_demo.dart
@@ -29,7 +29,7 @@ class LeaveBehindItem implements Comparable<LeaveBehindItem> {
 }
 
 class LeaveBehindDemo extends StatefulWidget {
-  const LeaveBehindDemo({ Key key }) : super(key: key);
+  const LeaveBehindDemo({ Object debugLocation, Key key }) : super(debugLocation: debugLocation, key: key);
 
   static const String routeName = '/material/leave-behind';
 

--- a/examples/flutter_gallery/lib/demo/material/list_demo.dart
+++ b/examples/flutter_gallery/lib/demo/material/list_demo.dart
@@ -19,7 +19,7 @@ enum _MaterialListType {
 }
 
 class ListDemo extends StatefulWidget {
-  const ListDemo({ Key key }) : super(key: key);
+  const ListDemo({ Object debugLocation, Key key }) : super(debugLocation: debugLocation, key: key);
 
   static const String routeName = '/material/list';
 

--- a/examples/flutter_gallery/lib/demo/material/menu_demo.dart
+++ b/examples/flutter_gallery/lib/demo/material/menu_demo.dart
@@ -5,7 +5,7 @@
 import 'package:flutter/material.dart';
 
 class MenuDemo extends StatefulWidget {
-  const MenuDemo({ Key key }) : super(key: key);
+  const MenuDemo({ Object debugLocation, Key key }) : super(debugLocation: debugLocation, key: key);
 
   static const String routeName = '/material/menu';
 

--- a/examples/flutter_gallery/lib/demo/material/overscroll_demo.dart
+++ b/examples/flutter_gallery/lib/demo/material/overscroll_demo.dart
@@ -9,7 +9,7 @@ import 'package:flutter/material.dart';
 enum IndicatorType { overscroll, refresh }
 
 class OverscrollDemo extends StatefulWidget {
-  const OverscrollDemo({ Key key }) : super(key: key);
+  const OverscrollDemo({ Object debugLocation, Key key }) : super(debugLocation: debugLocation, key: key);
 
   static const String routeName = '/material/overscroll';
 

--- a/examples/flutter_gallery/lib/demo/material/snack_bar_demo.dart
+++ b/examples/flutter_gallery/lib/demo/material/snack_bar_demo.dart
@@ -17,7 +17,7 @@ const String _text3 =
   'By default snackbars automatically disappear after a few seconds ';
 
 class SnackBarDemo extends StatefulWidget {
-  const SnackBarDemo({ Key key }) : super(key: key);
+  const SnackBarDemo({ Object debugLocation, Key key }) : super(debugLocation: debugLocation, key: key);
 
   static const String routeName = '/material/snack-bar';
 

--- a/examples/flutter_gallery/lib/demo/material/text_form_field_demo.dart
+++ b/examples/flutter_gallery/lib/demo/material/text_form_field_demo.dart
@@ -8,7 +8,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
 class TextFormFieldDemo extends StatefulWidget {
-  const TextFormFieldDemo({ Key key }) : super(key: key);
+  const TextFormFieldDemo({ Object debugLocation, Key key }) : super(debugLocation: debugLocation, key: key);
 
   static const String routeName = '/material/text-form-field';
 

--- a/examples/flutter_gallery/lib/demo/pesto_demo.dart
+++ b/examples/flutter_gallery/lib/demo/pesto_demo.dart
@@ -6,7 +6,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 
 class PestoDemo extends StatelessWidget {
-  const PestoDemo({ Key key }) : super(key: key);
+  const PestoDemo({ Object debugLocation, Key key }) : super(debugLocation: debugLocation, key: key);
 
   static const String routeName = '/pesto';
 
@@ -64,7 +64,7 @@ class PestoStyle extends TextStyle {
 
 // Displays a grid of recipe cards.
 class RecipeGridPage extends StatefulWidget {
-  const RecipeGridPage({ Key key, this.recipes }) : super(key: key);
+  const RecipeGridPage({ Object debugLocation, Key key, this.recipes }) : super(debugLocation: debugLocation, key: key);
 
   final List<Recipe> recipes;
 
@@ -244,7 +244,7 @@ class RecipeCard extends StatelessWidget {
   final TextStyle titleStyle = const PestoStyle(fontSize: 24.0, fontWeight: FontWeight.w600);
   final TextStyle authorStyle = const PestoStyle(fontWeight: FontWeight.w500, color: Colors.black54);
 
-  const RecipeCard({ Key key, this.recipe, this.onTap }) : super(key: key);
+  const RecipeCard({ Object debugLocation, Key key, this.recipe, this.onTap }) : super(debugLocation: debugLocation, key: key);
 
   final Recipe recipe;
   final VoidCallback onTap;
@@ -299,7 +299,7 @@ class RecipeCard extends StatelessWidget {
 
 // Displays one recipe. Includes the recipe sheet with a background image.
 class RecipePage extends StatefulWidget {
-  const RecipePage({ Key key, this.recipe }) : super(key: key);
+  const RecipePage({ Object debugLocation, Key key, this.recipe }) : super(debugLocation: debugLocation, key: key);
 
   final Recipe recipe;
 
@@ -425,7 +425,7 @@ class RecipeSheet extends StatelessWidget {
   final TextStyle itemAmountStyle = new PestoStyle(fontSize: 15.0, color: _kTheme.primaryColor, height: 24.0/15.0);
   final TextStyle headingStyle = const PestoStyle(fontSize: 16.0, fontWeight: FontWeight.bold, height: 24.0/15.0);
 
-  RecipeSheet({ Key key, this.recipe }) : super(key: key);
+  RecipeSheet({ Object debugLocation, Key key, this.recipe }) : super(debugLocation: debugLocation, key: key);
 
   final Recipe recipe;
 

--- a/examples/flutter_gallery/lib/demo/shrine/shrine_home.dart
+++ b/examples/flutter_gallery/lib/demo/shrine/shrine_home.dart
@@ -116,9 +116,9 @@ class _ShrineGridDelegate extends SliverGridDelegate {
 
 // Displays the Vendor's name and avatar.
 class _VendorItem extends StatelessWidget {
-  const _VendorItem({ Key key, @required this.vendor })
+  const _VendorItem({ Object debugLocation, Key key, @required this.vendor })
     : assert(vendor != null),
-      super(key: key);
+      super(debugLocation: debugLocation, key: key);
 
   final Vendor vendor;
 
@@ -152,9 +152,9 @@ class _VendorItem extends StatelessWidget {
 // Displays the product's price. If the product is in the shopping cart then the
 // background is highlighted.
 abstract class _PriceItem extends StatelessWidget {
-  const _PriceItem({ Key key, @required this.product })
+  const _PriceItem({ Object debugLocation, Key key, @required this.product })
       : assert(product != null),
-        super(key: key);
+        super(debugLocation: debugLocation, key: key);
 
   final Product product;
 
@@ -172,7 +172,7 @@ abstract class _PriceItem extends StatelessWidget {
 }
 
 class _ProductPriceItem extends _PriceItem {
-  const _ProductPriceItem({ Key key, Product product }) : super(key: key, product: product);
+  const _ProductPriceItem({ Object debugLocation, Key key, Product product }) : super(debugLocation: debugLocation, key: key, product: product);
 
   @override
   Widget build(BuildContext context) {
@@ -185,7 +185,7 @@ class _ProductPriceItem extends _PriceItem {
 }
 
 class _FeaturePriceItem extends _PriceItem {
-  const _FeaturePriceItem({ Key key, Product product }) : super(key: key, product: product);
+  const _FeaturePriceItem({ Object debugLocation, Key key, Product product }) : super(debugLocation: debugLocation, key: key, product: product);
 
   @override
   Widget build(BuildContext context) {
@@ -244,11 +244,11 @@ class _HeadingLayout extends MultiChildLayoutDelegate {
 
 // A card that highlights the "featured" catalog item.
 class _Heading extends StatelessWidget {
-  _Heading({ Key key, @required this.product })
+  _Heading({ Object debugLocation, Key key, @required this.product })
     : assert(product != null),
       assert(product.featureTitle != null),
       assert(product.featureDescription != null),
-      super(key: key);
+      super(debugLocation: debugLocation, key: key);
 
   final Product product;
 
@@ -304,9 +304,9 @@ class _Heading extends StatelessWidget {
 // A card that displays a product's image, price, and vendor. The _ProductItem
 // cards appear in a grid below the heading.
 class _ProductItem extends StatelessWidget {
-  const _ProductItem({ Key key, @required this.product, this.onPressed })
+  const _ProductItem({ Object debugLocation, Key key, @required this.product, this.onPressed })
     : assert(product != null),
-      super(key: key);
+      super(debugLocation: debugLocation, key: key);
 
   final Product product;
   final VoidCallback onPressed;

--- a/examples/flutter_gallery/lib/demo/shrine/shrine_order.dart
+++ b/examples/flutter_gallery/lib/demo/shrine/shrine_order.dart
@@ -13,14 +13,14 @@ import 'shrine_types.dart';
 // Displays the product title's, description, and order quantity dropdown.
 class _ProductItem extends StatelessWidget {
   const _ProductItem({
-    Key key,
+    Object debugLocation, Key key,
     @required this.product,
     @required this.quantity,
     @required this.onChanged,
   }) : assert(product != null),
        assert(quantity != null),
        assert(onChanged != null),
-       super(key: key);
+       super(debugLocation: debugLocation, key: key);
 
   final Product product;
   final int quantity;
@@ -69,9 +69,9 @@ class _ProductItem extends StatelessWidget {
 
 // Vendor name and description
 class _VendorItem extends StatelessWidget {
-  const _VendorItem({ Key key, @required this.vendor })
+  const _VendorItem({ Object debugLocation, Key key, @required this.vendor })
     : assert(vendor != null),
-      super(key: key);
+      super(debugLocation: debugLocation, key: key);
 
   final Vendor vendor;
 
@@ -141,13 +141,13 @@ class _HeadingLayout extends MultiChildLayoutDelegate {
 // a order quantity (0-5). Appears at the top of the OrderPage.
 class _Heading extends StatelessWidget {
   const _Heading({
-    Key key,
+    Object debugLocation, Key key,
     @required this.product,
     @required this.quantity,
     this.quantityChanged,
   }) : assert(product != null),
        assert(quantity != null && quantity >= 0 && quantity <= 5),
-       super(key: key);
+       super(debugLocation: debugLocation, key: key);
 
   final Product product;
   final int quantity;
@@ -208,14 +208,14 @@ class _Heading extends StatelessWidget {
 
 class OrderPage extends StatefulWidget {
   OrderPage({
-    Key key,
+    Object debugLocation, Key key,
     @required this.order,
     @required this.products,
     @required this.shoppingCart,
   }) : assert(order != null),
        assert(products != null && products.isNotEmpty),
        assert(shoppingCart != null),
-       super(key: key);
+       super(debugLocation: debugLocation, key: key);
 
   final Order order;
   final List<Product> products;

--- a/examples/flutter_gallery/lib/demo/shrine/shrine_page.dart
+++ b/examples/flutter_gallery/lib/demo/shrine/shrine_page.dart
@@ -16,7 +16,7 @@ enum ShrineAction {
 
 class ShrinePage extends StatefulWidget {
   const ShrinePage({
-    Key key,
+    Object debugLocation, Key key,
     @required this.scaffoldKey,
     @required this.body,
     this.floatingActionButton,
@@ -24,7 +24,7 @@ class ShrinePage extends StatefulWidget {
     this.shoppingCart
   }) : assert(body != null),
        assert(scaffoldKey != null),
-       super(key: key);
+       super(debugLocation: debugLocation, key: key);
 
   final GlobalKey<ScaffoldState> scaffoldKey;
   final Widget body;

--- a/examples/flutter_gallery/lib/demo/shrine/shrine_theme.dart
+++ b/examples/flutter_gallery/lib/demo/shrine/shrine_theme.dart
@@ -27,9 +27,9 @@ TextStyle abrilFatfaceRegular34(Color color) => new ShrineStyle.abrilFatface(34.
 /// InheritedWidget is shared by all of the routes and widgets created for
 /// the Shrine app.
 class ShrineTheme extends InheritedWidget {
-  ShrineTheme({ Key key, @required Widget child })
+  ShrineTheme({ Object debugLocation, Key key, @required Widget child })
     : assert(child != null),
-      super(key: key, child: child);
+      super(debugLocation: debugLocation, key: key, child: child);
 
   final Color cardBackgroundColor = Colors.white;
   final Color appBarBackgroundColor = Colors.white;

--- a/examples/flutter_gallery/lib/demo/typography_demo.dart
+++ b/examples/flutter_gallery/lib/demo/typography_demo.dart
@@ -7,14 +7,14 @@ import 'package:flutter/material.dart';
 
 class TextStyleItem extends StatelessWidget {
   const TextStyleItem({
-    Key key,
+    Object debugLocation, Key key,
     @required this.name,
     @required this.style,
     @required this.text,
   }) : assert(name != null),
        assert(style != null),
        assert(text != null),
-       super(key: key);
+       super(debugLocation: debugLocation, key: key);
 
   final String name;
   final TextStyle style;

--- a/examples/flutter_gallery/lib/demo/video_demo.dart
+++ b/examples/flutter_gallery/lib/demo/video_demo.dart
@@ -21,8 +21,8 @@ class VideoCard extends StatelessWidget {
   final String title;
   final String subtitle;
 
-  const VideoCard({Key key, this.controller, this.title, this.subtitle})
-      : super(key: key);
+  const VideoCard({Object debugLocation, Key key, this.controller, this.title, this.subtitle})
+      : super(debugLocation: debugLocation, key: key);
 
   Widget _buildInlineVideo() {
     return new Padding(
@@ -342,7 +342,7 @@ class _ConnectivityOverlayState extends State<ConnectivityOverlay> {
 }
 
 class VideoDemo extends StatefulWidget {
-  const VideoDemo({Key key}) : super(key: key);
+  const VideoDemo({Object debugLocation, Key key}) : super(debugLocation: debugLocation, key: key);
 
   static const String routeName = '/video';
 

--- a/examples/flutter_gallery/lib/gallery/app.dart
+++ b/examples/flutter_gallery/lib/gallery/app.dart
@@ -29,8 +29,8 @@ class GalleryApp extends StatefulWidget {
     this.checkerboardRasterCacheImages: true,
     this.checkerboardOffscreenLayers: true,
     this.onSendFeedback,
-    Key key}
-  ) : super(key: key);
+    Object debugLocation, Key key}
+  ) : super(debugLocation: debugLocation, key: key);
 
   final UpdateUrlFetcher updateUrlFetcher;
 

--- a/examples/flutter_gallery/lib/gallery/drawer.dart
+++ b/examples/flutter_gallery/lib/gallery/drawer.dart
@@ -35,7 +35,7 @@ class LinkTextSpan extends TextSpan {
 }
 
 class GalleryDrawerHeader extends StatefulWidget {
-  const GalleryDrawerHeader({ Key key, this.light }) : super(key: key);
+  const GalleryDrawerHeader({ Object debugLocation, Key key, this.light }) : super(debugLocation: debugLocation, key: key);
 
   final bool light;
 
@@ -103,7 +103,7 @@ class _GalleryDrawerHeaderState extends State<GalleryDrawerHeader> {
 
 class GalleryDrawer extends StatelessWidget {
   const GalleryDrawer({
-    Key key,
+    Object debugLocation, Key key,
     this.useLightTheme,
     @required this.onThemeChanged,
     this.timeDilation,
@@ -120,7 +120,7 @@ class GalleryDrawer extends StatelessWidget {
     this.onSendFeedback,
   }) : assert(onThemeChanged != null),
        assert(onTimeDilationChanged != null),
-       super(key: key);
+       super(debugLocation: debugLocation, key: key);
 
   final bool useLightTheme;
   final ValueChanged<bool> onThemeChanged;

--- a/examples/flutter_gallery/lib/gallery/home.dart
+++ b/examples/flutter_gallery/lib/gallery/home.dart
@@ -31,7 +31,7 @@ final List<_BackgroundLayer> _kBackgroundLayers = <_BackgroundLayer>[
 ];
 
 class _AppBarBackground extends StatelessWidget {
-  const _AppBarBackground({ Key key, this.animation }) : super(key: key);
+  const _AppBarBackground({ Object debugLocation, Key key, this.animation }) : super(debugLocation: debugLocation, key: key);
 
   final Animation<double> animation;
 
@@ -63,7 +63,7 @@ class _AppBarBackground extends StatelessWidget {
 
 class GalleryHome extends StatefulWidget {
   const GalleryHome({
-    Key key,
+    Object debugLocation, Key key,
     this.useLightTheme,
     @required this.onThemeChanged,
     this.timeDilation,
@@ -80,7 +80,7 @@ class GalleryHome extends StatefulWidget {
     this.onSendFeedback,
   }) : assert(onThemeChanged != null),
        assert(onTimeDilationChanged != null),
-       super(key: key);
+       super(debugLocation: debugLocation, key: key);
 
   final bool useLightTheme;
   final ValueChanged<bool> onThemeChanged;

--- a/examples/flutter_gallery/lib/gallery/updates.dart
+++ b/examples/flutter_gallery/lib/gallery/updates.dart
@@ -12,9 +12,9 @@ import 'package:url_launcher/url_launcher.dart';
 typedef Future<String> UpdateUrlFetcher();
 
 class Updater extends StatefulWidget {
-  const Updater({ @required this.updateUrlFetcher, this.child, Key key })
+  const Updater({ @required this.updateUrlFetcher, this.child, Object debugLocation, Key key })
     : assert(updateUrlFetcher != null),
-      super(key: key);
+      super(debugLocation: debugLocation, key: key);
 
   final UpdateUrlFetcher updateUrlFetcher;
   final Widget child;

--- a/examples/flutter_gallery/pubspec.yaml
+++ b/examples/flutter_gallery/pubspec.yaml
@@ -64,7 +64,13 @@ dev_dependencies:
   vector_math: 2.0.5 # TRANSITIVE DEPENDENCY
   vm_service_client: 0.2.3 # TRANSITIVE DEPENDENCY
   web_socket_channel: 1.0.6 # TRANSITIVE DEPENDENCY
-  yaml: 2.1.13 # TRANSITIVE DEPENDENCY
+  yaml: 2.1.13 # TRANSITIVE DEPENDENCYZ
+
+dependency_overrides:
+  sky_engine:
+    path: /usr/local/google/home/jacobr/git/engine/src/out/host_debug_unopt_x64/gen/dart-pkg/sky_engine
+  sky_services:
+    path: /usr/local/google/home/jacobr/git/engine/src/out/host_debug_unopt_x64/gen/dart-pkg/sky_services
 
 flutter:
   uses-material-design: true

--- a/packages/flutter/lib/src/cupertino/activity_indicator.dart
+++ b/packages/flutter/lib/src/cupertino/activity_indicator.dart
@@ -16,10 +16,10 @@ import 'colors.dart';
 class CupertinoActivityIndicator extends StatefulWidget {
   /// Creates an iOS-style activity indicator.
   const CupertinoActivityIndicator({
-    Key key,
+    Object debugLocation, Key key,
     this.animating: true,
   }) : assert(animating != null),
-       super(key: key);
+       super(debugLocation: debugLocation, key: key);
 
   /// Whether the activity indicator is running its animation.
   ///

--- a/packages/flutter/lib/src/cupertino/bottom_tab_bar.dart
+++ b/packages/flutter/lib/src/cupertino/bottom_tab_bar.dart
@@ -37,7 +37,7 @@ const Color _kDefaultTabBarBorderColor = const Color(0x4C000000);
 class CupertinoTabBar extends StatelessWidget implements PreferredSizeWidget {
   /// Creates a tab bar in the iOS style.
   CupertinoTabBar({
-    Key key,
+    Object debugLocation, Key key,
     @required this.items,
     this.onTap,
     this.currentIndex: 0,
@@ -49,7 +49,7 @@ class CupertinoTabBar extends StatelessWidget implements PreferredSizeWidget {
        assert(items.length >= 2),
        assert(0 <= currentIndex && currentIndex < items.length),
        assert(iconSize != null),
-       super(key: key);
+       super(debugLocation: debugLocation, key: key);
 
   /// The interactive items laid out within the bottom navigation bar.
   final List<BottomNavigationBarItem> items;
@@ -193,7 +193,7 @@ class CupertinoTabBar extends StatelessWidget implements PreferredSizeWidget {
   /// Create a clone of the current [CupertinoTabBar] but with provided
   /// parameters overridden.
   CupertinoTabBar copyWith({
-    Key key,
+    Object debugLocation, Key key,
     List<BottomNavigationBarItem> items,
     Color backgroundColor,
     Color activeColor,

--- a/packages/flutter/lib/src/cupertino/dialog.dart
+++ b/packages/flutter/lib/src/cupertino/dialog.dart
@@ -64,9 +64,9 @@ const BoxDecoration _kCupertinoDialogBackFill = const BoxDecoration(
 class CupertinoDialog extends StatelessWidget {
   /// Creates an iOS-style dialog.
   const CupertinoDialog({
-    Key key,
+    Object debugLocation, Key key,
     this.child,
-  }) : super(key: key);
+  }) : super(debugLocation: debugLocation, key: key);
 
   /// The widget below this widget in the tree.
   final Widget child;
@@ -112,11 +112,11 @@ class CupertinoDialog extends StatelessWidget {
 class CupertinoAlertDialog extends StatelessWidget {
   /// Creates an iOS-style alert dialog.
   const CupertinoAlertDialog({
-    Key key,
+    Object debugLocation, Key key,
     this.title,
     this.content,
     this.actions,
-  }) : super(key: key);
+  }) : super(debugLocation: debugLocation, key: key);
 
   /// The (optional) title of the dialog is displayed in a large font at the top
   /// of the dialog.
@@ -259,9 +259,9 @@ const Color _kButtonDividerColor = const Color(0xFFD5D5D5);
 
 class _CupertinoButtonBar extends StatelessWidget {
   const _CupertinoButtonBar({
-    Key key,
+    Object debugLocation, Key key,
     this.children,
-  }) : super(key: key);
+  }) : super(debugLocation: debugLocation, key: key);
 
   final List<Widget> children;
 

--- a/packages/flutter/lib/src/cupertino/nav_bar.dart
+++ b/packages/flutter/lib/src/cupertino/nav_bar.dart
@@ -72,7 +72,7 @@ const TextStyle _kLargeTitleTextStyle = const TextStyle(
 class CupertinoNavigationBar extends StatelessWidget implements ObstructingPreferredSizeWidget {
   /// Creates a navigation bar in the iOS style.
   const CupertinoNavigationBar({
-    Key key,
+    Object debugLocation, Key key,
     this.leading,
     this.automaticallyImplyLeading: true,
     this.middle,
@@ -80,7 +80,7 @@ class CupertinoNavigationBar extends StatelessWidget implements ObstructingPrefe
     this.backgroundColor: _kDefaultNavBarBackgroundColor,
     this.actionsForegroundColor: CupertinoColors.activeBlue,
   }) : assert(automaticallyImplyLeading != null),
-       super(key: key);
+       super(debugLocation: debugLocation, key: key);
 
   /// Widget to place at the start of the navigation bar. Normally a back button
   /// for a normal page or a cancel button for full page dialogs.
@@ -174,7 +174,7 @@ class CupertinoSliverNavigationBar extends StatelessWidget {
   ///
   /// The [largeTitle] argument is required and must not be null.
   const CupertinoSliverNavigationBar({
-    Key key,
+    Object debugLocation, Key key,
     @required this.largeTitle,
     this.leading,
     this.automaticallyImplyLeading: true,
@@ -184,7 +184,7 @@ class CupertinoSliverNavigationBar extends StatelessWidget {
     this.actionsForegroundColor: CupertinoColors.activeBlue,
   }) : assert(largeTitle != null),
        assert(automaticallyImplyLeading != null),
-       super(key: key);
+       super(debugLocation: debugLocation, key: key);
 
   /// The navigation bar's title.
   ///
@@ -302,14 +302,14 @@ Widget _wrapWithBackground({Color backgroundColor, Widget child}) {
 /// doesn't scroll.
 class _CupertinoPersistentNavigationBar extends StatelessWidget implements PreferredSizeWidget {
   const _CupertinoPersistentNavigationBar({
-    Key key,
+    Object debugLocation, Key key,
     this.leading,
     this.automaticallyImplyLeading,
     this.middle,
     this.trailing,
     this.actionsForegroundColor,
     this.middleVisible,
-  }) : super(key: key);
+  }) : super(debugLocation: debugLocation, key: key);
 
   final Widget leading;
 

--- a/packages/flutter/lib/src/cupertino/page_scaffold.dart
+++ b/packages/flutter/lib/src/cupertino/page_scaffold.dart
@@ -20,11 +20,11 @@ import 'colors.dart';
 class CupertinoPageScaffold extends StatelessWidget {
   /// Creates a layout for pages with a navigation bar at the top.
   const CupertinoPageScaffold({
-    Key key,
+    Object debugLocation, Key key,
     this.navigationBar,
     @required this.child,
   }) : assert(child != null),
-       super(key: key);
+       super(debugLocation: debugLocation, key: key);
 
   /// The [navigationBar], typically a [CupertinoNavigationBar], is drawn at the
   /// top of the screen.

--- a/packages/flutter/lib/src/cupertino/route.dart
+++ b/packages/flutter/lib/src/cupertino/route.dart
@@ -289,7 +289,7 @@ class CupertinoPageTransition extends StatelessWidget {
   ///  * `linearTransition` is whether to perform primary transition linearly.
   ///    Used to precisely track back gesture drags.
   CupertinoPageTransition({
-    Key key,
+    Object debugLocation, Key key,
     @required Animation<double> primaryRouteAnimation,
     @required Animation<double> secondaryRouteAnimation,
     @required this.child,
@@ -317,7 +317,7 @@ class CupertinoPageTransition extends StatelessWidget {
            curve: Curves.easeOut,
          )
        ),
-       super(key: key);
+       super(debugLocation: debugLocation, key: key);
 
   // When this page is coming in to cover another page.
   final Animation<Offset> _primaryPositionAnimation;
@@ -356,7 +356,7 @@ class CupertinoPageTransition extends StatelessWidget {
 class CupertinoFullscreenDialogTransition extends StatelessWidget {
   /// Creates an iOS-style transition used for summoning fullscreen dialogs.
   CupertinoFullscreenDialogTransition({
-    Key key,
+    Object debugLocation, Key key,
     @required Animation<double> animation,
     @required this.child,
   }) : _positionAnimation = _kBottomUpTween.animate(
@@ -365,7 +365,7 @@ class CupertinoFullscreenDialogTransition extends StatelessWidget {
            curve: Curves.easeInOut,
          )
        ),
-       super(key: key);
+       super(debugLocation: debugLocation, key: key);
 
   final Animation<Offset> _positionAnimation;
 
@@ -391,14 +391,14 @@ class CupertinoFullscreenDialogTransition extends StatelessWidget {
 /// coordinates by this widget.
 class _CupertinoBackGestureDetector extends StatefulWidget {
   const _CupertinoBackGestureDetector({
-    Key key,
+    Object debugLocation, Key key,
     @required this.enabledCallback,
     @required this.onStartPopGesture,
     @required this.child,
   }) : assert(enabledCallback != null),
        assert(onStartPopGesture != null),
        assert(child != null),
-       super(key: key);
+       super(debugLocation: debugLocation, key: key);
 
   final Widget child;
 

--- a/packages/flutter/lib/src/cupertino/slider.dart
+++ b/packages/flutter/lib/src/cupertino/slider.dart
@@ -43,7 +43,7 @@ class CupertinoSlider extends StatefulWidget {
   /// * [value] determines currently selected value for this slider.
   /// * [onChanged] is called when the user selects a new value for the slider.
   const CupertinoSlider({
-    Key key,
+    Object debugLocation, Key key,
     @required this.value,
     @required this.onChanged,
     this.min: 0.0,
@@ -55,7 +55,7 @@ class CupertinoSlider extends StatefulWidget {
        assert(max != null),
        assert(value >= min && value <= max),
        assert(divisions == null || divisions > 0),
-       super(key: key);
+       super(debugLocation: debugLocation, key: key);
 
   /// The currently selected value for this slider.
   ///
@@ -139,13 +139,13 @@ class _CupertinoSliderState extends State<CupertinoSlider> with TickerProviderSt
 
 class _CupertinoSliderRenderObjectWidget extends LeafRenderObjectWidget {
   const _CupertinoSliderRenderObjectWidget({
-    Key key,
+    Object debugLocation, Key key,
     this.value,
     this.divisions,
     this.activeColor,
     this.onChanged,
     this.vsync,
-  }) : super(key: key);
+  }) : super(debugLocation: debugLocation, key: key);
 
   final double value;
   final int divisions;

--- a/packages/flutter/lib/src/cupertino/switch.dart
+++ b/packages/flutter/lib/src/cupertino/switch.dart
@@ -48,11 +48,11 @@ import 'thumb_painter.dart';
 class CupertinoSwitch extends StatefulWidget {
   /// Creates an iOS-style switch.
   const CupertinoSwitch({
-    Key key,
+    Object debugLocation, Key key,
     @required this.value,
     @required this.onChanged,
     this.activeColor: CupertinoColors.activeGreen,
-  }) : super(key: key);
+  }) : super(debugLocation: debugLocation, key: key);
 
   /// Whether this switch is on or off.
   final bool value;
@@ -109,12 +109,12 @@ class _CupertinoSwitchState extends State<CupertinoSwitch> with TickerProviderSt
 
 class _CupertinoSwitchRenderObjectWidget extends LeafRenderObjectWidget {
   const _CupertinoSwitchRenderObjectWidget({
-    Key key,
+    Object debugLocation, Key key,
     this.value,
     this.activeColor,
     this.onChanged,
     this.vsync,
-  }) : super(key: key);
+  }) : super(debugLocation: debugLocation, key: key);
 
   final bool value;
   final Color activeColor;

--- a/packages/flutter/lib/src/cupertino/tab_scaffold.dart
+++ b/packages/flutter/lib/src/cupertino/tab_scaffold.dart
@@ -85,12 +85,12 @@ class CupertinoTabScaffold extends StatefulWidget {
   ///
   /// The [tabBar] and [tabBuilder] arguments must not be null.
   const CupertinoTabScaffold({
-    Key key,
+    Object debugLocation, Key key,
     @required this.tabBar,
     @required this.tabBuilder,
   }) : assert(tabBar != null),
        assert(tabBuilder != null),
-       super(key: key);
+       super(debugLocation: debugLocation, key: key);
 
   /// The [tabBar] is a [CupertinoTabBar] drawn at the bottom of the screen
   /// that lets the user switch between different tabs in the main content area

--- a/packages/flutter/lib/src/cupertino/tab_view.dart
+++ b/packages/flutter/lib/src/cupertino/tab_view.dart
@@ -37,14 +37,14 @@ import 'route.dart';
 class CupertinoTabView extends StatelessWidget {
   /// Creates the content area for a tab in a [CupertinoTabScaffold].
   const CupertinoTabView({
-    Key key,
+    Object debugLocation, Key key,
     this.builder,
     this.routes,
     this.onGenerateRoute,
     this.onUnknownRoute,
     this.navigatorObservers: const <NavigatorObserver>[],
   }) : assert(navigatorObservers != null),
-       super(key: key);
+       super(debugLocation: debugLocation, key: key);
 
   /// The widget builder for the default route of the tab view
   /// ([Navigator.defaultRouteName], which is `/`).

--- a/packages/flutter/lib/src/cupertino/text_selection.dart
+++ b/packages/flutter/lib/src/cupertino/text_selection.dart
@@ -58,13 +58,13 @@ class _TextSelectionToolbarNotchPainter extends CustomPainter {
 /// Manages a copy/paste text selection toolbar.
 class _TextSelectionToolbar extends StatelessWidget {
   const _TextSelectionToolbar({
-    Key key,
+    Object debugLocation, Key key,
     this.delegate,
     this.handleCut,
     this.handleCopy,
     this.handlePaste,
     this.handleSelectAll,
-  }) : super(key: key);
+  }) : super(debugLocation: debugLocation, key: key);
 
   final TextSelectionDelegate delegate;
   TextEditingValue get value => delegate.textEditingValue;

--- a/packages/flutter/lib/src/material/about.dart
+++ b/packages/flutter/lib/src/material/about.dart
@@ -38,7 +38,7 @@ class AboutListTile extends StatelessWidget {
   /// derived from the nearest [Title] widget. The version, icon, and legalese
   /// values default to the empty string.
   const AboutListTile({
-    Key key,
+    Object debugLocation, Key key,
     this.icon: const Icon(null),
     this.child,
     this.applicationName,
@@ -46,7 +46,7 @@ class AboutListTile extends StatelessWidget {
     this.applicationIcon,
     this.applicationLegalese,
     this.aboutBoxChildren
-  }) : super(key: key);
+  }) : super(debugLocation: debugLocation, key: key);
 
   /// The icon to show for this drawer item.
   ///
@@ -213,13 +213,13 @@ class AboutDialog extends StatelessWidget {
   /// derived from the nearest [Title] widget. The version, icon, and legalese
   /// values default to the empty string.
   const AboutDialog({
-    Key key,
+    Object debugLocation, Key key,
     this.applicationName,
     this.applicationVersion,
     this.applicationIcon,
     this.applicationLegalese,
     this.children,
-  }) : super(key: key);
+  }) : super(debugLocation: debugLocation, key: key);
 
   /// The name of the application.
   ///
@@ -333,11 +333,11 @@ class LicensePage extends StatefulWidget {
   /// The licenses shown on the [LicensePage] are those returned by the
   /// [LicenseRegistry] API, which can be used to add more licenses to the list.
   const LicensePage({
-    Key key,
+    Object debugLocation, Key key,
     this.applicationName,
     this.applicationVersion,
     this.applicationLegalese
-  }) : super(key: key);
+  }) : super(debugLocation: debugLocation, key: key);
 
   /// The name of the application.
   ///

--- a/packages/flutter/lib/src/material/app.dart
+++ b/packages/flutter/lib/src/material/app.dart
@@ -78,7 +78,7 @@ class MaterialApp extends StatefulWidget {
   ///
   /// The boolean arguments, [routes], and [navigatorObservers], must not be null.
   MaterialApp({ // can't be const because the asserts use methods on Map :-(
-    Key key,
+    Object debugLocation, Key key,
     this.title: '',
     this.onGenerateTitle,
     this.color,
@@ -126,7 +126,7 @@ class MaterialApp extends StatefulWidget {
          'because otherwise there is nothing to fall back on if the '
          'app is started with an intent that specifies an unknown route.'
        ),
-       super(key: key);
+       super(debugLocation: debugLocation, key: key);
 
   /// A one-line description used by the device to identify the app for the user.
   ///

--- a/packages/flutter/lib/src/material/app_bar.dart
+++ b/packages/flutter/lib/src/material/app_bar.dart
@@ -134,7 +134,7 @@ class AppBar extends StatefulWidget implements PreferredSizeWidget {
   ///
   /// Typically used in the [Scaffold.appBar] property.
   AppBar({
-    Key key,
+    Object debugLocation, Key key,
     this.leading,
     this.automaticallyImplyLeading: true,
     this.title,
@@ -158,7 +158,7 @@ class AppBar extends StatefulWidget implements PreferredSizeWidget {
        assert(toolbarOpacity != null),
        assert(bottomOpacity != null),
        preferredSize = new Size.fromHeight(kToolbarHeight + (bottom?.preferredSize?.height ?? 0.0)),
-       super(key: key);
+       super(debugLocation: debugLocation, key: key);
 
   /// A widget to display before the [title].
   ///
@@ -482,7 +482,7 @@ class _AppBarState extends State<AppBar> {
 }
 
 class _FloatingAppBar extends StatefulWidget {
-  const _FloatingAppBar({ Key key, this.child }) : super(key: key);
+  const _FloatingAppBar({ Object debugLocation, Key key, this.child }) : super(debugLocation: debugLocation, key: key);
 
   final Widget child;
 
@@ -709,7 +709,7 @@ class SliverAppBar extends StatefulWidget {
   /// The arguments [forceElevated], [primary], [floating], [pinned], [snap]
   /// and [automaticallyImplyLeading] must not be null.
   const SliverAppBar({
-    Key key,
+    Object debugLocation, Key key,
     this.leading,
     this.automaticallyImplyLeading: true,
     this.title,
@@ -737,7 +737,7 @@ class SliverAppBar extends StatefulWidget {
        assert(pinned != null),
        assert(snap != null),
        assert(floating || !snap, 'The "snap" argument only makes sense for floating app bars.'),
-       super(key: key);
+       super(debugLocation: debugLocation, key: key);
 
   /// A widget to display before the [title].
   ///

--- a/packages/flutter/lib/src/material/back_button.dart
+++ b/packages/flutter/lib/src/material/back_button.dart
@@ -24,7 +24,7 @@ import 'theme.dart';
 class BackButtonIcon extends StatelessWidget {
   /// Creates an icon that shows the appropriate "back" image for
   /// the current platform (as obtained from the [Theme]).
-  const BackButtonIcon({ Key key }) : super(key: key);
+  const BackButtonIcon({ Object debugLocation, Key key }) : super(debugLocation: debugLocation, key: key);
 
   /// Returns the appropriate "back" icon for the given `platform`.
   static IconData _getIconData(TargetPlatform platform) {
@@ -71,7 +71,7 @@ class BackButtonIcon extends StatelessWidget {
 class BackButton extends StatelessWidget {
   /// Creates an [IconButton] with the appropriate "back" icon for the current
   /// target platform.
-  const BackButton({ Key key, this.color }) : super(key: key);
+  const BackButton({ Object debugLocation, Key key, this.color }) : super(debugLocation: debugLocation, key: key);
 
   /// The color to use for the icon.
   ///
@@ -110,7 +110,7 @@ class BackButton extends StatelessWidget {
 ///  * [IconButton], to create other material design icon buttons.
 class CloseButton extends StatelessWidget {
   /// Creates a Material Design close button.
-  const CloseButton({ Key key }) : super(key: key);
+  const CloseButton({ Object debugLocation, Key key }) : super(debugLocation: debugLocation, key: key);
 
   @override
   Widget build(BuildContext context) {

--- a/packages/flutter/lib/src/material/bottom_navigation_bar.dart
+++ b/packages/flutter/lib/src/material/bottom_navigation_bar.dart
@@ -70,7 +70,7 @@ class BottomNavigationBar extends StatefulWidget {
   /// color. The [fixedColor] field will be ignored if the [BottomNavigationBar.type] is
   /// not [BottomNavigationBarType.fixed].
   BottomNavigationBar({
-    Key key,
+    Object debugLocation, Key key,
     @required this.items,
     this.onTap,
     this.currentIndex: 0,
@@ -82,7 +82,7 @@ class BottomNavigationBar extends StatefulWidget {
        assert(0 <= currentIndex && currentIndex < items.length),
        assert(iconSize != null),
        type = type ?? (items.length <= 3 ? BottomNavigationBarType.fixed : BottomNavigationBarType.shifting),
-       super(key: key);
+       super(debugLocation: debugLocation, key: key);
 
   /// The interactive items laid out within the bottom navigation bar.
   final List<BottomNavigationBarItem> items;

--- a/packages/flutter/lib/src/material/bottom_sheet.dart
+++ b/packages/flutter/lib/src/material/bottom_sheet.dart
@@ -47,13 +47,13 @@ class BottomSheet extends StatefulWidget {
   /// [ScaffoldState.showBottomSheet], for persistent bottom sheets, or by
   /// [showModalBottomSheet], for modal bottom sheets.
   const BottomSheet({
-    Key key,
+    Object debugLocation, Key key,
     this.animationController,
     @required this.onClosing,
     @required this.builder
   }) : assert(onClosing != null),
        assert(builder != null),
-       super(key: key);
+       super(debugLocation: debugLocation, key: key);
 
   /// The animation that controls the bottom sheet's position.
   ///
@@ -169,7 +169,7 @@ class _ModalBottomSheetLayout extends SingleChildLayoutDelegate {
 }
 
 class _ModalBottomSheet<T> extends StatefulWidget {
-  const _ModalBottomSheet({ Key key, this.route }) : super(key: key);
+  const _ModalBottomSheet({ Object debugLocation, Key key, this.route }) : super(debugLocation: debugLocation, key: key);
 
   final _ModalBottomSheetRoute<T> route;
 

--- a/packages/flutter/lib/src/material/button.dart
+++ b/packages/flutter/lib/src/material/button.dart
@@ -43,13 +43,13 @@ class ButtonTheme extends InheritedWidget {
   ///
   /// The child argument is required.
   const ButtonTheme({
-    Key key,
+    Object debugLocation, Key key,
     this.textTheme: ButtonTextTheme.normal,
     this.minWidth: 88.0,
     this.height: 36.0,
     this.padding: const EdgeInsets.symmetric(horizontal: 16.0),
     Widget child
-  }) : super(key: key, child: child);
+  }) : super(debugLocation: debugLocation, key: key, child: child);
 
   /// Creates a button theme that is appropriate for button bars, as used in
   /// dialog footers and in the headers of data tables.
@@ -66,13 +66,13 @@ class ButtonTheme extends InheritedWidget {
   /// For example, buttons at the bottom of [Dialog] or [Card] widgets use this
   /// button theme.
   const ButtonTheme.bar({
-    Key key,
+    Object debugLocation, Key key,
     this.textTheme: ButtonTextTheme.accent,
     this.minWidth: 64.0,
     this.height: 36.0,
     this.padding: const EdgeInsets.symmetric(horizontal: 8.0),
     Widget child
-  }) : super(key: key, child: child);
+  }) : super(debugLocation: debugLocation, key: key, child: child);
 
   /// The button color that this subtree should use.
   final ButtonTextTheme textTheme;
@@ -136,7 +136,7 @@ class MaterialButton extends StatefulWidget {
   /// Rather than creating a material button directly, consider using
   /// [FlatButton] or [RaisedButton].
   const MaterialButton({
-    Key key,
+    Object debugLocation, Key key,
     this.colorBrightness,
     this.textTheme,
     this.textColor,
@@ -150,7 +150,7 @@ class MaterialButton extends StatefulWidget {
     this.padding,
     @required this.onPressed,
     this.child
-  }) : super(key: key);
+  }) : super(debugLocation: debugLocation, key: key);
 
   /// The theme brightness to use for this button.
   ///

--- a/packages/flutter/lib/src/material/button_bar.dart
+++ b/packages/flutter/lib/src/material/button_bar.dart
@@ -28,11 +28,11 @@ class ButtonBar extends StatelessWidget {
   ///
   /// The alignment argument defaults to [MainAxisAlignment.end].
   const ButtonBar({
-    Key key,
+    Object debugLocation, Key key,
     this.alignment: MainAxisAlignment.end,
     this.mainAxisSize: MainAxisSize.max,
     this.children: const <Widget>[],
-  }) : super(key: key);
+  }) : super(debugLocation: debugLocation, key: key);
 
   /// How the children should be placed along the horizontal axis.
   final MainAxisAlignment alignment;

--- a/packages/flutter/lib/src/material/card.dart
+++ b/packages/flutter/lib/src/material/card.dart
@@ -60,11 +60,11 @@ import 'material.dart';
 class Card extends StatelessWidget {
   /// Creates a material design card.
   const Card({
-    Key key,
+    Object debugLocation, Key key,
     this.color,
     this.elevation: 2.0,
     this.child,
-  }) : super(key: key);
+  }) : super(debugLocation: debugLocation, key: key);
 
   /// The widget below this widget in the tree.
   final Widget child;

--- a/packages/flutter/lib/src/material/checkbox.dart
+++ b/packages/flutter/lib/src/material/checkbox.dart
@@ -48,12 +48,12 @@ class Checkbox extends StatefulWidget {
   /// * [onChanged], which is called when the value of the checkbox should
   ///   change. It can be set to null to disable the checkbox.
   const Checkbox({
-    Key key,
+    Object debugLocation, Key key,
     @required this.value,
     @required this.onChanged,
     this.activeColor,
   }) : assert(value != null),
-       super(key: key);
+       super(debugLocation: debugLocation, key: key);
 
   /// Whether this checkbox is checked.
   ///
@@ -113,7 +113,7 @@ class _CheckboxState extends State<Checkbox> with TickerProviderStateMixin {
 
 class _CheckboxRenderObjectWidget extends LeafRenderObjectWidget {
   const _CheckboxRenderObjectWidget({
-    Key key,
+    Object debugLocation, Key key,
     @required this.value,
     @required this.activeColor,
     @required this.inactiveColor,
@@ -123,7 +123,7 @@ class _CheckboxRenderObjectWidget extends LeafRenderObjectWidget {
        assert(activeColor != null),
        assert(inactiveColor != null),
        assert(vsync != null),
-       super(key: key);
+       super(debugLocation: debugLocation, key: key);
 
   final bool value;
   final Color activeColor;

--- a/packages/flutter/lib/src/material/checkbox_list_tile.dart
+++ b/packages/flutter/lib/src/material/checkbox_list_tile.dart
@@ -77,7 +77,7 @@ class CheckboxListTile extends StatelessWidget {
   /// * [onChanged], which is called when the value of the checkbox should
   ///   change. It can be set to null to disable the checkbox.
   const CheckboxListTile({
-    Key key,
+    Object debugLocation, Key key,
     @required this.value,
     @required this.onChanged,
     this.activeColor,
@@ -93,7 +93,7 @@ class CheckboxListTile extends StatelessWidget {
        assert(!isThreeLine || subtitle != null),
        assert(selected != null),
        assert(controlAffinity != null),
-       super(key: key);
+       super(debugLocation: debugLocation, key: key);
 
   /// Whether this checkbox is checked.
   ///

--- a/packages/flutter/lib/src/material/chip.dart
+++ b/packages/flutter/lib/src/material/chip.dart
@@ -45,7 +45,7 @@ class Chip extends StatelessWidget {
   ///  * [onDeleted] determines whether the chip has a delete button. This
   ///    callback runs when the delete button is pressed.
   const Chip({
-    Key key,
+    Object debugLocation, Key key,
     this.avatar,
     @required this.label,
     this.onDeleted,
@@ -57,7 +57,7 @@ class Chip extends StatelessWidget {
   }) : assert(label != null),
        assert(border != null),
        labelStyle = labelStyle ?? _defaultLabelStyle,
-       super(key: key);
+       super(debugLocation: debugLocation, key: key);
 
   static const TextStyle _defaultLabelStyle = const TextStyle(
     inherit: false,

--- a/packages/flutter/lib/src/material/circle_avatar.dart
+++ b/packages/flutter/lib/src/material/circle_avatar.dart
@@ -50,13 +50,13 @@ import 'theme_data.dart';
 class CircleAvatar extends StatelessWidget {
   /// Creates a circle that represents a user.
   const CircleAvatar({
-    Key key,
+    Object debugLocation, Key key,
     this.child,
     this.backgroundColor,
     this.backgroundImage,
     this.foregroundColor,
     this.radius: 20.0,
-  }) : super(key: key);
+  }) : super(debugLocation: debugLocation, key: key);
 
   /// The widget below this widget in the tree.
   ///

--- a/packages/flutter/lib/src/material/data_table.dart
+++ b/packages/flutter/lib/src/material/data_table.dart
@@ -253,7 +253,7 @@ class DataTable extends StatelessWidget {
   /// the sort order is ascending, this should be true (the default),
   /// otherwise it should be false.
   DataTable({
-    Key key,
+    Object debugLocation, Key key,
     @required this.columns,
     this.sortColumnIndex,
     this.sortAscending: true,
@@ -266,7 +266,7 @@ class DataTable extends StatelessWidget {
        assert(rows != null),
        assert(!rows.any((DataRow row) => row.cells.length != columns.length)),
        _onlyTextColumn = _initOnlyTextColumn(columns),
-       super(key: key);
+       super(debugLocation: debugLocation, key: key);
 
   /// The configuration and labels for the columns in the table.
   final List<DataColumn> columns;
@@ -606,7 +606,7 @@ class DataTable extends StatelessWidget {
 class TableRowInkWell extends InkResponse {
   /// Creates an ink well for a table row.
   const TableRowInkWell({
-    Key key,
+    Object debugLocation, Key key,
     Widget child,
     GestureTapCallback onTap,
     GestureTapCallback onDoubleTap,
@@ -660,11 +660,11 @@ class TableRowInkWell extends InkResponse {
 
 class _SortArrow extends StatefulWidget {
   const _SortArrow({
-    Key key,
+    Object debugLocation, Key key,
     this.visible,
     this.down,
     this.duration,
-  }) : super(key: key);
+  }) : super(debugLocation: debugLocation, key: key);
 
   final bool visible;
 

--- a/packages/flutter/lib/src/material/date_picker.dart
+++ b/packages/flutter/lib/src/material/date_picker.dart
@@ -59,7 +59,7 @@ const double _kDatePickerLandscapeHeight = _kMaxDayPickerHeight + _kDialogAction
 // Shows the selected date in large font and toggles between year and day mode
 class _DatePickerHeader extends StatelessWidget {
   const _DatePickerHeader({
-    Key key,
+    Object debugLocation, Key key,
     @required this.selectedDate,
     @required this.mode,
     @required this.onModeChanged,
@@ -67,7 +67,7 @@ class _DatePickerHeader extends StatelessWidget {
   }) : assert(selectedDate != null),
        assert(mode != null),
        assert(orientation != null),
-       super(key: key);
+       super(debugLocation: debugLocation, key: key);
 
   final DateTime selectedDate;
   final DatePickerMode mode;
@@ -159,11 +159,11 @@ class _DatePickerHeader extends StatelessWidget {
 
 class _DateHeaderButton extends StatelessWidget {
   const _DateHeaderButton({
-    Key key,
+    Object debugLocation, Key key,
     this.onTap,
     this.color,
     this.child,
-  }) : super(key: key);
+  }) : super(debugLocation: debugLocation, key: key);
 
   final VoidCallback onTap;
   final Color color;
@@ -231,7 +231,7 @@ class DayPicker extends StatelessWidget {
   ///
   /// Rarely used directly. Instead, typically used as part of a [MonthPicker].
   DayPicker({
-    Key key,
+    Object debugLocation, Key key,
     @required this.selectedDate,
     @required this.currentDate,
     @required this.onChanged,
@@ -246,7 +246,7 @@ class DayPicker extends StatelessWidget {
        assert(displayedMonth != null),
        assert(!firstDate.isAfter(lastDate)),
        assert(selectedDate.isAfter(firstDate) || selectedDate.isAtSameMomentAs(firstDate)),
-       super(key: key);
+       super(debugLocation: debugLocation, key: key);
 
   /// The currently selected date.
   ///
@@ -472,7 +472,7 @@ class MonthPicker extends StatefulWidget {
   /// Rarely used directly. Instead, typically used as part of the dialog shown
   /// by [showDatePicker].
   MonthPicker({
-    Key key,
+    Object debugLocation, Key key,
     @required this.selectedDate,
     @required this.onChanged,
     @required this.firstDate,
@@ -483,7 +483,7 @@ class MonthPicker extends StatefulWidget {
        assert(onChanged != null),
        assert(!firstDate.isAfter(lastDate)),
        assert(selectedDate.isAfter(firstDate) || selectedDate.isAtSameMomentAs(firstDate)),
-       super(key: key);
+       super(debugLocation: debugLocation, key: key);
 
   /// The currently selected date.
   ///
@@ -666,7 +666,7 @@ class YearPicker extends StatefulWidget {
   /// Rarely used directly. Instead, typically used as part of the dialog shown
   /// by [showDatePicker].
   YearPicker({
-    Key key,
+    Object debugLocation, Key key,
     @required this.selectedDate,
     @required this.onChanged,
     @required this.firstDate,
@@ -674,7 +674,7 @@ class YearPicker extends StatefulWidget {
   }) : assert(selectedDate != null),
        assert(onChanged != null),
        assert(!firstDate.isAfter(lastDate)),
-       super(key: key);
+       super(debugLocation: debugLocation, key: key);
 
   /// The currently selected date.
   ///
@@ -736,13 +736,13 @@ class _YearPickerState extends State<YearPicker> {
 
 class _DatePickerDialog extends StatefulWidget {
   const _DatePickerDialog({
-    Key key,
+    Object debugLocation, Key key,
     this.initialDate,
     this.firstDate,
     this.lastDate,
     this.selectableDayPredicate,
     this.initialDatePickerMode,
-  }) : super(key: key);
+  }) : super(debugLocation: debugLocation, key: key);
 
   final DateTime initialDate;
   final DateTime firstDate;

--- a/packages/flutter/lib/src/material/dialog.dart
+++ b/packages/flutter/lib/src/material/dialog.dart
@@ -35,9 +35,9 @@ class Dialog extends StatelessWidget {
   ///
   /// Typically used in conjunction with [showDialog].
   const Dialog({
-    Key key,
+    Object debugLocation, Key key,
     this.child,
-  }) : super(key: key);
+  }) : super(debugLocation: debugLocation, key: key);
 
   /// The widget below this widget in the tree.
   final Widget child;
@@ -127,13 +127,13 @@ class AlertDialog extends StatelessWidget {
   ///
   /// Typically used in conjunction with [showDialog].
   const AlertDialog({
-    Key key,
+    Object debugLocation, Key key,
     this.title,
     this.titlePadding,
     this.content,
     this.contentPadding,
     this.actions
-  }) : super(key: key);
+  }) : super(debugLocation: debugLocation, key: key);
 
   /// The (optional) title of the dialog is displayed in a large font at the top
   /// of the dialog.
@@ -240,10 +240,10 @@ class AlertDialog extends StatelessWidget {
 class SimpleDialogOption extends StatelessWidget {
   /// Creates an option for a [SimpleDialog].
   const SimpleDialogOption({
-    Key key,
+    Object debugLocation, Key key,
     this.onPressed,
     this.child,
-  }) : super(key: key);
+  }) : super(debugLocation: debugLocation, key: key);
 
   /// The callback that is called when this option is selected.
   ///
@@ -335,12 +335,12 @@ class SimpleDialog extends StatelessWidget {
   ///
   /// Typically used in conjunction with [showDialog].
   const SimpleDialog({
-    Key key,
+    Object debugLocation, Key key,
     this.title,
     this.titlePadding,
     this.children,
     this.contentPadding,
-  }) : super(key: key);
+  }) : super(debugLocation: debugLocation, key: key);
 
   /// The (optional) title of the dialog is displayed in a large font at the top
   /// of the dialog.

--- a/packages/flutter/lib/src/material/divider.dart
+++ b/packages/flutter/lib/src/material/divider.dart
@@ -28,12 +28,12 @@ class Divider extends StatelessWidget {
   ///
   /// The height must be positive.
   const Divider({
-    Key key,
+    Object debugLocation, Key key,
     this.height: 16.0,
     this.indent: 0.0,
     this.color
   }) : assert(height >= 0.0),
-       super(key: key);
+       super(debugLocation: debugLocation, key: key);
 
   /// The divider's vertical extent.
   ///

--- a/packages/flutter/lib/src/material/drawer.dart
+++ b/packages/flutter/lib/src/material/drawer.dart
@@ -82,10 +82,10 @@ class Drawer extends StatelessWidget {
   ///
   /// Typically used in the [Scaffold.drawer] property.
   const Drawer({
-    Key key,
+    Object debugLocation, Key key,
     this.elevation: 16.0,
     this.child,
-  }) : super(key: key);
+  }) : super(debugLocation: debugLocation, key: key);
 
   /// The z-coordinate at which to place this drawer. This controls the size of
   /// the shadow below the drawer.
@@ -131,12 +131,12 @@ class DrawerController extends StatefulWidget {
   ///
   /// The [child] argument must not be null and is typically a [Drawer].
   const DrawerController({
-    GlobalKey key,
+    Object debugLocation, GlobalKey key,
     @required this.child,
     @required this.alignment,
   }) : assert(child != null),
        assert(alignment != null),
-       super(key: key);
+       super(debugLocation: debugLocation, key: key);
 
   /// The widget below this widget in the tree.
   ///

--- a/packages/flutter/lib/src/material/drawer_header.dart
+++ b/packages/flutter/lib/src/material/drawer_header.dart
@@ -29,14 +29,14 @@ class DrawerHeader extends StatelessWidget {
   ///
   /// Requires one of its ancestors to be a [Material] widget.
   const DrawerHeader({
-    Key key,
+    Object debugLocation, Key key,
     this.decoration,
     this.margin: const EdgeInsets.only(bottom: 8.0),
     this.padding: const EdgeInsets.fromLTRB(16.0, 16.0, 16.0, 8.0),
     this.duration: const Duration(milliseconds: 250),
     this.curve: Curves.fastOutSlowIn,
     @required this.child,
-  }) : super(key: key);
+  }) : super(debugLocation: debugLocation, key: key);
 
   /// Decoration for the main drawer header [Container]; useful for applying
   /// backgrounds.

--- a/packages/flutter/lib/src/material/dropdown.dart
+++ b/packages/flutter/lib/src/material/dropdown.dart
@@ -89,9 +89,9 @@ class _DropdownScrollBehavior extends ScrollBehavior {
 
 class _DropdownMenu<T> extends StatefulWidget {
   const _DropdownMenu({
-    Key key,
+    Object debugLocation, Key key,
     this.route,
-  }) : super(key: key);
+  }) : super(debugLocation: debugLocation, key: key);
 
   final _DropdownRoute<T> route;
 
@@ -371,11 +371,11 @@ class DropdownMenuItem<T> extends StatelessWidget {
   ///
   /// The [child] argument is required.
   const DropdownMenuItem({
-    Key key,
+    Object debugLocation, Key key,
     this.value,
     @required this.child,
   }) : assert(child != null),
-       super(key: key);
+       super(debugLocation: debugLocation, key: key);
 
   /// The widget below this widget in the tree.
   ///
@@ -407,10 +407,10 @@ class DropdownButtonHideUnderline extends InheritedWidget {
   /// Creates a [DropdownButtonHideUnderline]. A non-null [child] must
   /// be given.
   const DropdownButtonHideUnderline({
-    Key key,
+    Object debugLocation, Key key,
     @required Widget child,
   }) : assert(child != null),
-       super(key: key, child: child);
+       super(debugLocation: debugLocation, key: key, child: child);
 
   /// Returns whether the underline of [DropdownButton] widgets should
   /// be hidden.
@@ -450,7 +450,7 @@ class DropdownButton<T> extends StatefulWidget {
   /// The [elevation] and [iconSize] arguments must not be null (they both have
   /// defaults, so do not need to be specified).
   DropdownButton({
-    Key key,
+    Object debugLocation, Key key,
     @required this.items,
     this.value,
     this.hint,
@@ -461,7 +461,7 @@ class DropdownButton<T> extends StatefulWidget {
     this.isDense: false,
   }) : assert(items != null),
        assert(value == null || items.where((DropdownMenuItem<T> item) => item.value == value).length == 1),
-      super(key: key);
+      super(debugLocation: debugLocation, key: key);
 
   /// The list of possible items to select among.
   final List<DropdownMenuItem<T>> items;

--- a/packages/flutter/lib/src/material/expand_icon.dart
+++ b/packages/flutter/lib/src/material/expand_icon.dart
@@ -21,7 +21,7 @@ class ExpandIcon extends StatefulWidget {
   /// Creates an [ExpandIcon] with the given padding, and a callback that is
   /// triggered when the icon is pressed.
   const ExpandIcon({
-    Key key,
+    Object debugLocation, Key key,
     this.isExpanded: false,
     this.size: 24.0,
     @required this.onPressed,
@@ -29,7 +29,7 @@ class ExpandIcon extends StatefulWidget {
   }) : assert(isExpanded != null),
        assert(size != null),
        assert(padding != null),
-       super(key: key);
+       super(debugLocation: debugLocation, key: key);
 
   /// Whether the icon is in an expanded state.
   ///

--- a/packages/flutter/lib/src/material/expansion_panel.dart
+++ b/packages/flutter/lib/src/material/expansion_panel.dart
@@ -98,13 +98,13 @@ class ExpansionPanelList extends StatelessWidget {
   /// Creates an expansion panel list widget. The [expansionCallback] is
   /// triggered when an expansion panel expand/collapse button is pushed.
   const ExpansionPanelList({
-    Key key,
+    Object debugLocation, Key key,
     this.children: const <ExpansionPanel>[],
     this.expansionCallback,
     this.animationDuration: kThemeAnimationDuration
   }) : assert(children != null),
        assert(animationDuration != null),
-       super(key: key);
+       super(debugLocation: debugLocation, key: key);
 
   /// The children of the expansion panel list. They are laid out in a similar
   /// fashion to [ListBody].

--- a/packages/flutter/lib/src/material/expansion_tile.dart
+++ b/packages/flutter/lib/src/material/expansion_tile.dart
@@ -33,7 +33,7 @@ class ExpansionTile extends StatefulWidget {
   /// the tile to reveal or hide the [children]. The [initiallyExpanded] property must
   /// be non-null.
   const ExpansionTile({
-    Key key,
+    Object debugLocation, Key key,
     this.leading,
     @required this.title,
     this.backgroundColor,
@@ -42,7 +42,7 @@ class ExpansionTile extends StatefulWidget {
     this.trailing,
     this.initiallyExpanded: false,
   }) : assert(initiallyExpanded != null),
-       super(key: key);
+       super(debugLocation: debugLocation, key: key);
 
   /// A widget to display before the title.
   ///

--- a/packages/flutter/lib/src/material/flat_button.dart
+++ b/packages/flutter/lib/src/material/flat_button.dart
@@ -51,7 +51,7 @@ class FlatButton extends StatelessWidget {
   /// The [child] argument is required and is typically a [Text] widget in all
   /// caps.
   const FlatButton({
-    Key key,
+    Object debugLocation, Key key,
     @required this.onPressed,
     this.textColor,
     this.disabledTextColor,
@@ -63,7 +63,7 @@ class FlatButton extends StatelessWidget {
     this.colorBrightness,
     @required this.child
   }) : assert(child != null),
-       super(key: key);
+       super(debugLocation: debugLocation, key: key);
 
   /// The callback that is called when the button is tapped or otherwise
   /// activated.

--- a/packages/flutter/lib/src/material/flexible_space_bar.dart
+++ b/packages/flutter/lib/src/material/flexible_space_bar.dart
@@ -31,11 +31,11 @@ class FlexibleSpaceBar extends StatefulWidget {
   ///
   /// Most commonly used in the [AppBar.flexibleSpace] field.
   const FlexibleSpaceBar({
-    Key key,
+    Object debugLocation, Key key,
     this.title,
     this.background,
     this.centerTitle
-  }) : super(key: key);
+  }) : super(debugLocation: debugLocation, key: key);
 
   /// The primary contents of the flexible space bar when expanded.
   ///
@@ -176,13 +176,13 @@ class _FlexibleSpaceBarState extends State<FlexibleSpaceBar> {
 
 class _FlexibleSpaceBarSettings extends InheritedWidget {
   const _FlexibleSpaceBarSettings({
-    Key key,
+    Object debugLocation, Key key,
     this.toolbarOpacity,
     this.minExtent,
     this.maxExtent,
     this.currentExtent,
     Widget child,
-  }) : super(key: key, child: child);
+  }) : super(debugLocation: debugLocation, key: key, child: child);
 
   final double toolbarOpacity;
   final double minExtent;

--- a/packages/flutter/lib/src/material/floating_action_button.dart
+++ b/packages/flutter/lib/src/material/floating_action_button.dart
@@ -46,7 +46,7 @@ class FloatingActionButton extends StatefulWidget {
   ///
   /// Most commonly used in the [Scaffold.floatingActionButton] field.
   const FloatingActionButton({
-    Key key,
+    Object debugLocation, Key key,
     this.child,
     this.tooltip,
     this.backgroundColor,
@@ -55,7 +55,7 @@ class FloatingActionButton extends StatefulWidget {
     this.highlightElevation: 12.0,
     @required this.onPressed,
     this.mini: false
-  }) : super(key: key);
+  }) : super(debugLocation: debugLocation, key: key);
 
   /// The widget below this widget in the tree.
   final Widget child;

--- a/packages/flutter/lib/src/material/flutter_logo.dart
+++ b/packages/flutter/lib/src/material/flutter_logo.dart
@@ -18,14 +18,14 @@ class FlutterLogo extends StatelessWidget {
   ///
   /// The [size] defaults to the value given by the current [IconTheme].
   const FlutterLogo({
-    Key key,
+    Object debugLocation, Key key,
     this.size,
     this.colors,
     this.textColor: const Color(0xFF616161),
     this.style: FlutterLogoStyle.markOnly,
     this.duration: const Duration(milliseconds: 750),
     this.curve: Curves.fastOutSlowIn,
-  }) : super(key: key);
+  }) : super(debugLocation: debugLocation, key: key);
 
   /// The size of the logo in logical pixels.
   ///

--- a/packages/flutter/lib/src/material/grid_tile.dart
+++ b/packages/flutter/lib/src/material/grid_tile.dart
@@ -22,12 +22,12 @@ class GridTile extends StatelessWidget {
   ///
   /// Must have a child. Does not typically have both a header and a footer.
   const GridTile({
-    Key key,
+    Object debugLocation, Key key,
     this.header,
     this.footer,
     @required this.child,
   }) : assert(child != null),
-       super(key: key);
+       super(debugLocation: debugLocation, key: key);
 
   /// The widget to show over the top of this grid tile.
   ///

--- a/packages/flutter/lib/src/material/grid_tile_bar.dart
+++ b/packages/flutter/lib/src/material/grid_tile_bar.dart
@@ -23,13 +23,13 @@ class GridTileBar extends StatelessWidget {
   ///
   /// Typically used to with [GridTile].
   const GridTileBar({
-    Key key,
+    Object debugLocation, Key key,
     this.backgroundColor,
     this.leading,
     this.title,
     this.subtitle,
     this.trailing
-  }) : super(key: key);
+  }) : super(debugLocation: debugLocation, key: key);
 
   /// The color to paint behind the child widgets.
   ///

--- a/packages/flutter/lib/src/material/icon_button.dart
+++ b/packages/flutter/lib/src/material/icon_button.dart
@@ -70,7 +70,7 @@ class IconButton extends StatelessWidget {
   /// The [icon] argument must be specified, and is typically either an [Icon]
   /// or an [ImageIcon].
   const IconButton({
-    Key key,
+    Object debugLocation, Key key,
     this.iconSize: 24.0,
     this.padding: const EdgeInsets.all(8.0),
     this.alignment: Alignment.center,
@@ -85,7 +85,7 @@ class IconButton extends StatelessWidget {
        assert(padding != null),
        assert(alignment != null),
        assert(icon != null),
-       super(key: key);
+       super(debugLocation: debugLocation, key: key);
 
   /// The size of the icon inside the button.
   ///

--- a/packages/flutter/lib/src/material/ink_well.dart
+++ b/packages/flutter/lib/src/material/ink_well.dart
@@ -83,7 +83,7 @@ class InkResponse extends StatefulWidget {
   ///
   /// Must have an ancestor [Material] widget in which to cause ink reactions.
   const InkResponse({
-    Key key,
+    Object debugLocation, Key key,
     this.child,
     this.onTap,
     this.onDoubleTap,
@@ -96,7 +96,7 @@ class InkResponse extends StatefulWidget {
     this.highlightColor,
     this.splashColor,
     this.enableFeedback: true,
-  }) : assert(enableFeedback != null), super(key: key);
+  }) : assert(enableFeedback != null), super(debugLocation: debugLocation, key: key);
 
   /// The widget below this widget in the tree.
   final Widget child;
@@ -415,7 +415,7 @@ class InkWell extends InkResponse {
   ///
   /// Must have an ancestor [Material] widget in which to cause ink reactions.
   const InkWell({
-    Key key,
+    Object debugLocation, Key key,
     Widget child,
     GestureTapCallback onTap,
     GestureTapCallback onDoubleTap,

--- a/packages/flutter/lib/src/material/input_decorator.dart
+++ b/packages/flutter/lib/src/material/input_decorator.dart
@@ -357,7 +357,7 @@ class InputDecorator extends StatelessWidget {
   ///
   /// The [isFocused] and [isEmpty] arguments must not be null.
   const InputDecorator({
-    Key key,
+    Object debugLocation, Key key,
     @required this.decoration,
     this.baseStyle,
     this.textAlign,
@@ -366,7 +366,7 @@ class InputDecorator extends StatelessWidget {
     this.child,
   }) : assert(isFocused != null),
        assert(isEmpty != null),
-       super(key: key);
+       super(debugLocation: debugLocation, key: key);
 
   /// The text and styles to use when decorating the child.
   final InputDecoration decoration;
@@ -677,7 +677,7 @@ class InputDecorator extends StatelessWidget {
 // transitions between inline and caption.
 class _AnimatedLabel extends ImplicitlyAnimatedWidget {
   const _AnimatedLabel({
-    Key key,
+    Object debugLocation, Key key,
     this.text,
     @required this.style,
     Curve curve: Curves.linear,
@@ -685,7 +685,7 @@ class _AnimatedLabel extends ImplicitlyAnimatedWidget {
     this.textAlign,
     this.overflow,
   }) : assert(style != null),
-       super(key: key, curve: curve, duration: duration);
+       super(debugLocation: debugLocation, key: key, curve: curve, duration: duration);
 
   final String text;
   final TextStyle style;

--- a/packages/flutter/lib/src/material/list_tile.dart
+++ b/packages/flutter/lib/src/material/list_tile.dart
@@ -36,21 +36,21 @@ class ListTileTheme extends InheritedWidget {
   /// Creates a list tile theme that controls the color and style parameters for
   /// [ListTile]s.
   const ListTileTheme({
-    Key key,
+    Object debugLocation, Key key,
     this.dense: false,
     this.style: ListTileStyle.list,
     this.selectedColor,
     this.iconColor,
     this.textColor,
     Widget child,
-  }) : super(key: key, child: child);
+  }) : super(debugLocation: debugLocation, key: key, child: child);
 
   /// Creates a list tile theme that controls the color and style parameters for
   /// [ListTile]s, and merges in the current list tile theme, if any.
   ///
   /// The [child] argument must not be null.
   static Widget merge({
-    Key key,
+    Object debugLocation, Key key,
     bool dense,
     ListTileStyle style,
     Color selectedColor,
@@ -203,7 +203,7 @@ class ListTile extends StatelessWidget {
   ///
   /// Requires one of its ancestors to be a [Material] widget.
   const ListTile({
-    Key key,
+    Object debugLocation, Key key,
     this.leading,
     this.title,
     this.subtitle,
@@ -218,7 +218,7 @@ class ListTile extends StatelessWidget {
        assert(enabled != null),
        assert(selected != null),
        assert(!isThreeLine || subtitle != null),
-       super(key: key);
+       super(debugLocation: debugLocation, key: key);
 
   /// A widget to display before the title.
   ///

--- a/packages/flutter/lib/src/material/material.dart
+++ b/packages/flutter/lib/src/material/material.dart
@@ -110,7 +110,7 @@ class Material extends StatefulWidget {
   ///
   /// The [type], [elevation] and [shadowColor] arguments must not be null.
   const Material({
-    Key key,
+    Object debugLocation, Key key,
     this.type: MaterialType.canvas,
     this.elevation: 0.0,
     this.color,
@@ -122,7 +122,7 @@ class Material extends StatefulWidget {
        assert(elevation != null),
        assert(shadowColor != null),
        assert(!(identical(type, MaterialType.circle) && borderRadius != null)),
-       super(key: key);
+       super(debugLocation: debugLocation, key: key);
 
   /// The widget below this widget in the tree.
   final Widget child;
@@ -340,11 +340,11 @@ class _RenderInkFeatures extends RenderProxyBox implements MaterialInkController
 
 class _InkFeatures extends SingleChildRenderObjectWidget {
   const _InkFeatures({
-    Key key,
+    Object debugLocation, Key key,
     this.color,
     @required this.vsync,
     Widget child,
-  }) : super(key: key, child: child);
+  }) : super(debugLocation: debugLocation, key: key, child: child);
 
   // This widget must be owned by a MaterialState, which must be provided as the vsync.
   // This relationship must be 1:1 and cannot change for the lifetime of the MaterialState.

--- a/packages/flutter/lib/src/material/mergeable_material.dart
+++ b/packages/flutter/lib/src/material/mergeable_material.dart
@@ -98,12 +98,12 @@ class MaterialGap extends MergeableMaterialItem {
 class MergeableMaterial extends StatefulWidget {
   /// Creates a mergeable Material list of items.
   const MergeableMaterial({
-    Key key,
+    Object debugLocation, Key key,
     this.mainAxis: Axis.vertical,
     this.elevation: 2,
     this.hasDividers: false,
     this.children: const <MergeableMaterialItem>[]
-  }) : super(key: key);
+  }) : super(debugLocation: debugLocation, key: key);
 
   /// The children of the [MergeableMaterial].
   final List<MergeableMaterialItem> children;

--- a/packages/flutter/lib/src/material/page.dart
+++ b/packages/flutter/lib/src/material/page.dart
@@ -17,14 +17,14 @@ final Tween<Offset> _kBottomUpTween = new Tween<Offset>(
 // Used for Android and Fuchsia.
 class _MountainViewPageTransition extends StatelessWidget {
   _MountainViewPageTransition({
-    Key key,
+    Object debugLocation, Key key,
     @required Animation<double> routeAnimation,
     @required this.child,
   }) : _positionAnimation = _kBottomUpTween.animate(new CurvedAnimation(
          parent: routeAnimation, // The route's linear 0.0 - 1.0 animation.
          curve: Curves.fastOutSlowIn,
        )),
-       super(key: key);
+       super(debugLocation: debugLocation, key: key);
 
   final Animation<Offset> _positionAnimation;
   final Widget child;

--- a/packages/flutter/lib/src/material/paginated_data_table.dart
+++ b/packages/flutter/lib/src/material/paginated_data_table.dart
@@ -61,7 +61,7 @@ class PaginatedDataTable extends StatefulWidget {
   /// The [rowsPerPage] and [availableRowsPerPage] must not be null (they
   /// both have defaults, though, so don't have to be specified).
   PaginatedDataTable({
-    Key key,
+    Object debugLocation, Key key,
     @required this.header,
     this.actions,
     @required this.columns,
@@ -87,7 +87,7 @@ class PaginatedDataTable extends StatefulWidget {
          return true;
        }()),
        assert(source != null),
-       super(key: key);
+       super(debugLocation: debugLocation, key: key);
 
   /// The table card's header.
   ///

--- a/packages/flutter/lib/src/material/popup_menu.dart
+++ b/packages/flutter/lib/src/material/popup_menu.dart
@@ -57,7 +57,7 @@ const double _kMenuScreenPadding = 8.0;
 abstract class PopupMenuEntry<T> extends StatefulWidget {
   /// Abstract const constructor. This constructor enables subclasses to provide
   /// const constructors so that they can be used in const expressions.
-  const PopupMenuEntry({ Key key }) : super(key: key);
+  const PopupMenuEntry({ Object debugLocation, Key key }) : super(debugLocation: debugLocation, key: key);
 
   /// The amount of vertical space occupied by this entry.
   ///
@@ -96,7 +96,7 @@ class PopupMenuDivider extends PopupMenuEntry<Null> {
   /// Creates a horizontal divider for a popup menu.
   ///
   /// By default, the divider has a height of 16 logical pixels.
-  const PopupMenuDivider({ Key key, this.height: _kMenuDividerHeight }) : super(key: key);
+  const PopupMenuDivider({ Object debugLocation, Key key, this.height: _kMenuDividerHeight }) : super(debugLocation: debugLocation, key: key);
 
   /// The height of the divider entry.
   ///
@@ -161,14 +161,14 @@ class PopupMenuItem<T> extends PopupMenuEntry<T> {
   ///
   /// The `height` and `enabled` arguments must not be null.
   const PopupMenuItem({
-    Key key,
+    Object debugLocation, Key key,
     this.value,
     this.enabled: true,
     this.height: _kMenuItemHeight,
     @required this.child,
   }) : assert(enabled != null),
        assert(height != null),
-       super(key: key);
+       super(debugLocation: debugLocation, key: key);
 
   /// The value that will be returned by [showMenu] if this entry is selected.
   final T value;
@@ -312,7 +312,7 @@ class CheckedPopupMenuItem<T> extends PopupMenuItem<T> {
   ///
   /// The `checked` and `enabled` arguments must not be null.
   const CheckedPopupMenuItem({
-    Key key,
+    Object debugLocation, Key key,
     T value,
     this.checked: false,
     bool enabled: true,
@@ -387,9 +387,9 @@ class _CheckedPopupMenuItemState<T> extends _PopupMenuItemState<CheckedPopupMenu
 
 class _PopupMenu<T> extends StatelessWidget {
   const _PopupMenu({
-    Key key,
+    Object debugLocation, Key key,
     this.route
-  }) : super(key: key);
+  }) : super(debugLocation: debugLocation, key: key);
 
   final _PopupMenuRoute<T> route;
 
@@ -741,7 +741,7 @@ class PopupMenuButton<T> extends StatefulWidget {
   ///
   /// The [itemBuilder] argument must not be null.
   const PopupMenuButton({
-    Key key,
+    Object debugLocation, Key key,
     @required this.itemBuilder,
     this.initialValue,
     this.onSelected,
@@ -752,7 +752,7 @@ class PopupMenuButton<T> extends StatefulWidget {
     this.icon,
   }) : assert(itemBuilder != null),
        assert(!(child != null && icon != null)), // fails if passed both parameters
-       super(key: key);
+       super(debugLocation: debugLocation, key: key);
 
   /// Called when the button is pressed to create the items to show in the menu.
   final PopupMenuItemBuilder<T> itemBuilder;

--- a/packages/flutter/lib/src/material/progress_indicator.dart
+++ b/packages/flutter/lib/src/material/progress_indicator.dart
@@ -31,11 +31,11 @@ abstract class ProgressIndicator extends StatefulWidget {
   /// progress indicator) or non-null (corresponding to a determinate progress
   /// indicator). See [value] for details.
   const ProgressIndicator({
-    Key key,
+    Object debugLocation, Key key,
     this.value,
     this.backgroundColor,
     this.valueColor,
-  }) : super(key: key);
+  }) : super(debugLocation: debugLocation, key: key);
 
   /// If non-null, the value of this progress indicator with 0.0 corresponding
   /// to no progress having been made and 1.0 corresponding to all the progress
@@ -159,11 +159,11 @@ class LinearProgressIndicator extends ProgressIndicator {
   /// progress indicator) or non-null (corresponding to a determinate progress
   /// indicator). See [value] for details.
   const LinearProgressIndicator({
-    Key key,
+    Object debugLocation, Key key,
     double value,
     Color backgroundColor,
     Animation<Color> valueColor,
-  }) : super(key: key, value: value, backgroundColor: backgroundColor, valueColor: valueColor);
+  }) : super(debugLocation: debugLocation, key: key, value: value, backgroundColor: backgroundColor, valueColor: valueColor);
 
   @override
   _LinearProgressIndicatorState createState() => new _LinearProgressIndicatorState();
@@ -318,12 +318,12 @@ class CircularProgressIndicator extends ProgressIndicator {
   /// progress indicator) or non-null (corresponding to a determinate progress
   /// indicator). See [value] for details.
   const CircularProgressIndicator({
-    Key key,
+    Object debugLocation, Key key,
     double value,
     Color backgroundColor,
     Animation<Color> valueColor,
     this.strokeWidth: 4.0,
-  }) : super(key: key, value: value, backgroundColor: backgroundColor, valueColor: valueColor);
+  }) : super(debugLocation: debugLocation, key: key, value: value, backgroundColor: backgroundColor, valueColor: valueColor);
 
   /// The width of the line used to draw the circle.
   final double strokeWidth;
@@ -482,7 +482,7 @@ class RefreshProgressIndicator extends CircularProgressIndicator {
   /// Rather than creating a refresh progress indicator directly, consider using
   /// a [RefreshIndicator] together with a [Scrollable] widget.
   const RefreshProgressIndicator({
-    Key key,
+    Object debugLocation, Key key,
     double value,
     Color backgroundColor,
     Animation<Color> valueColor,

--- a/packages/flutter/lib/src/material/radio.dart
+++ b/packages/flutter/lib/src/material/radio.dart
@@ -52,12 +52,12 @@ class Radio<T> extends StatefulWidget {
   ///   selected.
   /// * [onChanged] is called when the user selects this radio button.
   const Radio({
-    Key key,
+    Object debugLocation, Key key,
     @required this.value,
     @required this.groupValue,
     @required this.onChanged,
     this.activeColor
-  }) : super(key: key);
+  }) : super(debugLocation: debugLocation, key: key);
 
   /// The value represented by this radio button.
   final T value;
@@ -133,7 +133,7 @@ class _RadioState<T> extends State<Radio<T>> with TickerProviderStateMixin {
 
 class _RadioRenderObjectWidget extends LeafRenderObjectWidget {
   const _RadioRenderObjectWidget({
-    Key key,
+    Object debugLocation, Key key,
     @required this.selected,
     @required this.activeColor,
     @required this.inactiveColor,
@@ -143,7 +143,7 @@ class _RadioRenderObjectWidget extends LeafRenderObjectWidget {
        assert(activeColor != null),
        assert(inactiveColor != null),
        assert(vsync != null),
-       super(key: key);
+       super(debugLocation: debugLocation, key: key);
 
   final bool selected;
   final Color inactiveColor;

--- a/packages/flutter/lib/src/material/radio_list_tile.dart
+++ b/packages/flutter/lib/src/material/radio_list_tile.dart
@@ -90,7 +90,7 @@ class RadioListTile<T> extends StatelessWidget {
   ///   selected.
   /// * [onChanged] is called when the user selects this radio button.
   const RadioListTile({
-    Key key,
+    Object debugLocation, Key key,
     @required this.value,
     @required this.groupValue,
     @required this.onChanged,
@@ -106,7 +106,7 @@ class RadioListTile<T> extends StatelessWidget {
        assert(!isThreeLine || subtitle != null),
        assert(selected != null),
        assert(controlAffinity != null),
-       super(key: key);
+       super(debugLocation: debugLocation, key: key);
 
   /// The value represented by this radio button.
   final T value;

--- a/packages/flutter/lib/src/material/raised_button.dart
+++ b/packages/flutter/lib/src/material/raised_button.dart
@@ -44,7 +44,7 @@ class RaisedButton extends StatelessWidget {
   /// The [child] argument is required and is typically a [Text] widget in all
   /// caps.
   const RaisedButton({
-    Key key,
+    Object debugLocation, Key key,
     @required this.onPressed,
     this.color,
     this.highlightColor,
@@ -55,7 +55,7 @@ class RaisedButton extends StatelessWidget {
     this.disabledElevation: 0.0,
     this.colorBrightness,
     this.child
-  }) : super(key: key);
+  }) : super(debugLocation: debugLocation, key: key);
 
   /// The callback that is called when the button is tapped or otherwise
   /// activated.

--- a/packages/flutter/lib/src/material/refresh_indicator.dart
+++ b/packages/flutter/lib/src/material/refresh_indicator.dart
@@ -82,7 +82,7 @@ class RefreshIndicator extends StatefulWidget {
   /// non-null. The default
   /// [displacement] is 40.0 logical pixels.
   const RefreshIndicator({
-    Key key,
+    Object debugLocation, Key key,
     @required this.child,
     this.displacement: 40.0,
     @required this.onRefresh,
@@ -92,7 +92,7 @@ class RefreshIndicator extends StatefulWidget {
   }) : assert(child != null),
        assert(onRefresh != null),
        assert(notificationPredicate != null),
-       super(key: key);
+       super(debugLocation: debugLocation, key: key);
 
   /// The refresh indicator will be stacked on top of this child. The indicator
   /// will appear when child's Scrollable descendant is over-scrolled.

--- a/packages/flutter/lib/src/material/scaffold.dart
+++ b/packages/flutter/lib/src/material/scaffold.dart
@@ -169,9 +169,9 @@ class _ScaffoldLayout extends MultiChildLayoutDelegate {
 
 class _FloatingActionButtonTransition extends StatefulWidget {
   const _FloatingActionButtonTransition({
-    Key key,
+    Object debugLocation, Key key,
     this.child,
-  }) : super(key: key);
+  }) : super(debugLocation: debugLocation, key: key);
 
   final Widget child;
 
@@ -312,7 +312,7 @@ class _FloatingActionButtonTransitionState extends State<_FloatingActionButtonTr
 class Scaffold extends StatefulWidget {
   /// Creates a visual scaffold for material design widgets.
   const Scaffold({
-    Key key,
+    Object debugLocation, Key key,
     this.appBar,
     this.body,
     this.floatingActionButton,
@@ -323,7 +323,7 @@ class Scaffold extends StatefulWidget {
     this.backgroundColor,
     this.resizeToAvoidBottomPadding: true,
     this.primary: true,
-  }) : assert(primary != null), super(key: key);
+  }) : assert(primary != null), super(debugLocation: debugLocation, key: key);
 
   /// An app bar to display at the top of the scaffold.
   final PreferredSizeWidget appBar;
@@ -1074,12 +1074,12 @@ class ScaffoldFeatureController<T extends Widget, U> {
 
 class _PersistentBottomSheet extends StatefulWidget {
   const _PersistentBottomSheet({
-    Key key,
+    Object debugLocation, Key key,
     this.animationController,
     this.onClosing,
     this.onDismissed,
     this.builder
-  }) : super(key: key);
+  }) : super(debugLocation: debugLocation, key: key);
 
   final AnimationController animationController; // we control it, but it must be disposed by whoever created it
   final VoidCallback onClosing;
@@ -1151,10 +1151,11 @@ class PersistentBottomSheetController<T> extends ScaffoldFeatureController<_Pers
 
 class _ScaffoldScope extends InheritedWidget {
   const _ScaffoldScope({
+    Object debugLocation,
     @required this.hasDrawer,
     @required Widget child,
   }) : assert(hasDrawer != null),
-       super(child: child);
+       super(debugLocation: debugLocation, child: child);
 
   final bool hasDrawer;
 

--- a/packages/flutter/lib/src/material/scrollbar.dart
+++ b/packages/flutter/lib/src/material/scrollbar.dart
@@ -29,9 +29,9 @@ class Scrollbar extends StatefulWidget {
   /// The [child] should be a source of [ScrollNotification] notifications,
   /// typically a [Scrollable] widget.
   const Scrollbar({
-    Key key,
+    Object debugLocation, Key key,
     @required this.child,
-  }) : super(key: key);
+  }) : super(debugLocation: debugLocation, key: key);
 
   /// The subtree to place inside the [Scrollbar].
   ///

--- a/packages/flutter/lib/src/material/slider.dart
+++ b/packages/flutter/lib/src/material/slider.dart
@@ -56,7 +56,7 @@ class Slider extends StatefulWidget {
   /// * [value] determines currently selected value for this slider.
   /// * [onChanged] is called when the user selects a new value for the slider.
   const Slider({
-    Key key,
+    Object debugLocation, Key key,
     @required this.value,
     @required this.onChanged,
     this.min: 0.0,
@@ -73,7 +73,7 @@ class Slider extends StatefulWidget {
        assert(value >= min && value <= max),
        assert(divisions == null || divisions > 0),
        assert(thumbOpenAtMin != null),
-       super(key: key);
+       super(debugLocation: debugLocation, key: key);
 
   /// The currently selected value for this slider.
   ///
@@ -214,7 +214,7 @@ class _SliderState extends State<Slider> with TickerProviderStateMixin {
 
 class _SliderRenderObjectWidget extends LeafRenderObjectWidget {
   const _SliderRenderObjectWidget({
-    Key key,
+    Object debugLocation, Key key,
     this.value,
     this.divisions,
     this.label,
@@ -226,7 +226,7 @@ class _SliderRenderObjectWidget extends LeafRenderObjectWidget {
     this.onChanged,
     this.vsync,
     this.reactionController,
-  }) : super(key: key);
+  }) : super(debugLocation: debugLocation, key: key);
 
   final double value;
   final int divisions;

--- a/packages/flutter/lib/src/material/snack_bar.dart
+++ b/packages/flutter/lib/src/material/snack_bar.dart
@@ -78,12 +78,12 @@ class SnackBarAction extends StatefulWidget {
   ///
   /// The [label] and [onPressed] arguments must be non-null.
   const SnackBarAction({
-    Key key,
+    Object debugLocation, Key key,
     @required this.label,
     @required this.onPressed,
   }) : assert(label != null),
        assert(onPressed != null),
-       super(key: key);
+       super(debugLocation: debugLocation, key: key);
 
   /// The button label.
   final String label;
@@ -143,14 +143,14 @@ class SnackBar extends StatelessWidget {
   ///
   /// The [content] argument must be non-null.
   const SnackBar({
-    Key key,
+    Object debugLocation, Key key,
     @required this.content,
     this.backgroundColor,
     this.action,
     this.duration: _kSnackBarDisplayDuration,
     this.animation,
   }) : assert(content != null),
-       super(key: key);
+       super(debugLocation: debugLocation, key: key);
 
   /// The primary content of the snack bar.
   ///

--- a/packages/flutter/lib/src/material/stepper.dart
+++ b/packages/flutter/lib/src/material/stepper.dart
@@ -134,7 +134,7 @@ class Stepper extends StatefulWidget {
   ///
   /// The [steps], [type], and [currentStep] arguments must not be null.
   Stepper({
-    Key key,
+    Object debugLocation, Key key,
     @required this.steps,
     this.type: StepperType.vertical,
     this.currentStep: 0,
@@ -145,7 +145,7 @@ class Stepper extends StatefulWidget {
        assert(type != null),
        assert(currentStep != null),
        assert(0 <= currentStep && currentStep < steps.length),
-       super(key: key);
+       super(debugLocation: debugLocation, key: key);
 
   /// The steps of the stepper whose titles, subtitles, icons always get shown.
   ///

--- a/packages/flutter/lib/src/material/switch.dart
+++ b/packages/flutter/lib/src/material/switch.dart
@@ -46,7 +46,7 @@ class Switch extends StatefulWidget {
   /// * [value] determines whether this switch is on or off.
   /// * [onChanged] is called when the user toggles the switch on or off.
   const Switch({
-    Key key,
+    Object debugLocation, Key key,
     @required this.value,
     @required this.onChanged,
     this.activeColor,
@@ -55,7 +55,7 @@ class Switch extends StatefulWidget {
     this.inactiveTrackColor,
     this.activeThumbImage,
     this.inactiveThumbImage
-  }) : super(key: key);
+  }) : super(debugLocation: debugLocation, key: key);
 
   /// Whether this switch is on or off.
   ///
@@ -160,7 +160,7 @@ class _SwitchState extends State<Switch> with TickerProviderStateMixin {
 
 class _SwitchRenderObjectWidget extends LeafRenderObjectWidget {
   const _SwitchRenderObjectWidget({
-    Key key,
+    Object debugLocation, Key key,
     this.value,
     this.activeColor,
     this.inactiveColor,
@@ -171,7 +171,7 @@ class _SwitchRenderObjectWidget extends LeafRenderObjectWidget {
     this.configuration,
     this.onChanged,
     this.vsync,
-  }) : super(key: key);
+  }) : super(debugLocation: debugLocation, key: key);
 
   final bool value;
   final Color activeColor;

--- a/packages/flutter/lib/src/material/switch_list_tile.dart
+++ b/packages/flutter/lib/src/material/switch_list_tile.dart
@@ -70,7 +70,7 @@ class SwitchListTile extends StatelessWidget {
   /// * [value] determines whether this switch is on or off.
   /// * [onChanged] is called when the user toggles the switch on or off.
   const SwitchListTile({
-    Key key,
+    Object debugLocation, Key key,
     @required this.value,
     @required this.onChanged,
     this.activeColor,
@@ -86,7 +86,7 @@ class SwitchListTile extends StatelessWidget {
        assert(isThreeLine != null),
        assert(!isThreeLine || subtitle != null),
        assert(selected != null),
-       super(key: key);
+       super(debugLocation: debugLocation, key: key);
 
   /// Whether this switch is checked.
   ///

--- a/packages/flutter/lib/src/material/tab_controller.dart
+++ b/packages/flutter/lib/src/material/tab_controller.dart
@@ -26,7 +26,7 @@ import 'constants.dart';
 ///
 /// ```dart
 /// class MyTabbedPage extends StatefulWidget {
-///   const MyTabbedPage({ Key key }) : super(key: key);
+///   const MyTabbedPage({ Object debugLocation, Key key }) : super(debugLocation: debugLocation, key: key);
 ///   @override
 ///   _MyTabbedPageState createState() => new _MyTabbedPageState();
 /// }
@@ -190,11 +190,11 @@ class TabController extends ChangeNotifier {
 
 class _TabControllerScope extends InheritedWidget {
   const _TabControllerScope({
-    Key key,
+    Object debugLocation, Key key,
     this.controller,
     this.enabled,
     Widget child
-  }) : super(key: key, child: child);
+  }) : super(debugLocation: debugLocation, key: key, child: child);
 
   final TabController controller;
   final bool enabled;
@@ -247,12 +247,12 @@ class DefaultTabController extends StatefulWidget {
   ///
   /// The [initialIndex] argument must not be null.
   const DefaultTabController({
-    Key key,
+    Object debugLocation, Key key,
     @required this.length,
     this.initialIndex: 0,
     @required this.child,
   }) : assert(initialIndex != null),
-       super(key: key);
+       super(debugLocation: debugLocation, key: key);
 
   /// The total number of tabs. Typically greater than one.
   final int length;

--- a/packages/flutter/lib/src/material/tabs.dart
+++ b/packages/flutter/lib/src/material/tabs.dart
@@ -37,13 +37,13 @@ class Tab extends StatelessWidget {
   /// and [child] must be non-null. The [text] and [child] arguments must not be
   /// used at the same time.
   const Tab({
-    Key key,
+    Object debugLocation, Key key,
     this.text,
     this.icon,
     this.child,
   }) : assert(text != null || child != null || icon != null),
        assert(!(text != null && null != child)), // TODO(goderbauer): https://github.com/dart-lang/sdk/issues/31140
-       super(key: key);
+       super(debugLocation: debugLocation, key: key);
 
   /// The text to display as the tab's label.
   ///
@@ -109,7 +109,7 @@ class Tab extends StatelessWidget {
 
 class _TabStyle extends AnimatedWidget {
   const _TabStyle({
-    Key key,
+    Object debugLocation, Key key,
     Animation<double> animation,
     this.selected,
     this.labelColor,
@@ -117,7 +117,7 @@ class _TabStyle extends AnimatedWidget {
     this.labelStyle,
     this.unselectedLabelStyle,
     @required this.child,
-  }) : super(key: key, listenable: animation);
+  }) : super(debugLocation: debugLocation, key: key, listenable: animation);
 
   final TextStyle labelStyle;
   final TextStyle unselectedLabelStyle;
@@ -213,7 +213,7 @@ class _TabLabelBarRenderer extends RenderFlex {
 // or in response to input.
 class _TabLabelBar extends Flex {
   _TabLabelBar({
-    Key key,
+    Object debugLocation, Key key,
     List<Widget> children: const <Widget>[],
     this.onPerformLayout,
   }) : super(
@@ -480,7 +480,7 @@ class TabBar extends StatefulWidget implements PreferredSizeWidget {
   ///
   /// The [indicatorPadding] parameter defaults to [EdgeInsets.zero], and must not be null.
   const TabBar({
-    Key key,
+    Object debugLocation, Key key,
     @required this.tabs,
     this.controller,
     this.isScrollable: false,
@@ -495,7 +495,7 @@ class TabBar extends StatefulWidget implements PreferredSizeWidget {
        assert(isScrollable != null),
        assert(indicatorWeight != null && indicatorWeight > 0.0),
        assert(indicatorPadding != null),
-       super(key: key);
+       super(debugLocation: debugLocation, key: key);
 
   /// Typically a list of two or more [Tab] widgets.
   ///
@@ -861,11 +861,11 @@ class TabBarView extends StatefulWidget {
   ///
   /// The length of [children] must be the same as the [controller]'s length.
   const TabBarView({
-    Key key,
+    Object debugLocation, Key key,
     @required this.children,
     this.controller,
     this.physics,
-  }) : assert(children != null), super(key: key);
+  }) : assert(children != null), super(debugLocation: debugLocation, key: key);
 
   /// This widget's selection and animation state.
   ///
@@ -1050,11 +1050,11 @@ class TabPageSelectorIndicator extends StatelessWidget {
   ///
   /// The [backgroundColor], [borderColor], and [size] parameters must not be null.
   const TabPageSelectorIndicator({
-    Key key,
+    Object debugLocation, Key key,
     @required this.backgroundColor,
     @required this.borderColor,
     @required this.size,
-  }) : assert(backgroundColor != null), assert(borderColor != null), assert(size != null), super(key: key);
+  }) : assert(backgroundColor != null), assert(borderColor != null), assert(size != null), super(debugLocation: debugLocation, key: key);
 
   /// The indicator circle's background color.
   final Color backgroundColor;
@@ -1088,12 +1088,12 @@ class TabPageSelectorIndicator extends StatelessWidget {
 class TabPageSelector extends StatelessWidget {
   /// Creates a compact widget that indicates which tab has been selected.
   const TabPageSelector({
-    Key key,
+    Object debugLocation, Key key,
     this.controller,
     this.indicatorSize: 12.0,
     this.color,
     this.selectedColor,
-  }) : assert(indicatorSize != null && indicatorSize > 0.0), super(key: key);
+  }) : assert(indicatorSize != null && indicatorSize > 0.0), super(debugLocation: debugLocation, key: key);
 
   /// This widget's selection and animation state.
   ///

--- a/packages/flutter/lib/src/material/text_field.dart
+++ b/packages/flutter/lib/src/material/text_field.dart
@@ -90,7 +90,7 @@ class TextField extends StatefulWidget {
   ///  * [maxLength], which discusses the precise meaning of "number of
   ///    characters" and how it may differ from the intuitive meaning.
   const TextField({
-    Key key,
+    Object debugLocation, Key key,
     this.controller,
     this.focusNode,
     this.decoration: const InputDecoration(),
@@ -115,7 +115,7 @@ class TextField extends StatefulWidget {
        assert(maxLines == null || maxLines > 0),
        assert(maxLength == null || maxLength > 0),
        keyboardType = maxLines == 1 ? keyboardType : TextInputType.multiline,
-       super(key: key);
+       super(debugLocation: debugLocation, key: key);
 
   /// Controls the text being edited.
   ///

--- a/packages/flutter/lib/src/material/text_form_field.dart
+++ b/packages/flutter/lib/src/material/text_form_field.dart
@@ -41,7 +41,7 @@ class TextFormField extends FormField<String> {
   /// For documentation about the various parameters, see the [TextField] class
   /// and [new TextField], the constructor.
   TextFormField({
-    Key key,
+    Object debugLocation, Key key,
     this.controller,
     String initialValue: '',
     FocusNode focusNode,

--- a/packages/flutter/lib/src/material/text_selection.dart
+++ b/packages/flutter/lib/src/material/text_selection.dart
@@ -21,13 +21,13 @@ const double _kToolbarScreenPadding = 8.0;
 /// Manages a copy/paste text selection toolbar.
 class _TextSelectionToolbar extends StatelessWidget {
   const _TextSelectionToolbar({
-    Key key,
+    Object debugLocation, Key key,
     this.delegate,
     this.handleCut,
     this.handleCopy,
     this.handlePaste,
     this.handleSelectAll,
-  }) : super(key: key);
+  }) : super(debugLocation: debugLocation, key: key);
 
   final TextSelectionDelegate delegate;
   TextEditingValue get value => delegate.textEditingValue;

--- a/packages/flutter/lib/src/material/theme.dart
+++ b/packages/flutter/lib/src/material/theme.dart
@@ -37,13 +37,13 @@ class Theme extends StatelessWidget {
   ///
   /// The [data] and [child] arguments must not be null.
   const Theme({
-    Key key,
+    Object debugLocation, Key key,
     @required this.data,
     this.isMaterialAppTheme: false,
     @required this.child,
   }) : assert(child != null),
        assert(data != null),
-       super(key: key);
+       super(debugLocation: debugLocation, key: key);
 
   /// Specifies the color and typography values for descendant widgets.
   final ThemeData data;
@@ -156,11 +156,11 @@ class Theme extends StatelessWidget {
 
 class _InheritedTheme extends InheritedWidget {
   const _InheritedTheme({
-    Key key,
+    Object debugLocation, Key key,
     @required this.theme,
     @required Widget child
   }) : assert(theme != null),
-       super(key: key, child: child);
+       super(debugLocation: debugLocation, key: key, child: child);
 
   final Theme theme;
 
@@ -202,7 +202,7 @@ class AnimatedTheme extends ImplicitlyAnimatedWidget {
   /// By default, the theme transition uses a linear curve. The [data] and
   /// [child] arguments must not be null.
   const AnimatedTheme({
-    Key key,
+    Object debugLocation, Key key,
     @required this.data,
     this.isMaterialAppTheme: false,
     Curve curve: Curves.linear,
@@ -210,7 +210,7 @@ class AnimatedTheme extends ImplicitlyAnimatedWidget {
     @required this.child,
   }) : assert(child != null),
        assert(data != null),
-       super(key: key, curve: curve, duration: duration);
+       super(debugLocation: debugLocation, key: key, curve: curve, duration: duration);
 
   /// Specifies the color and typography values for descendant widgets.
   final ThemeData data;

--- a/packages/flutter/lib/src/material/time_picker.dart
+++ b/packages/flutter/lib/src/material/time_picker.dart
@@ -1345,10 +1345,10 @@ class _TimePickerDialog extends StatefulWidget {
   ///
   /// [initialTime] must not be null.
   const _TimePickerDialog({
-    Key key,
+    Object debugLocation, Key key,
     @required this.initialTime
   }) : assert(initialTime != null),
-       super(key: key);
+       super(debugLocation: debugLocation, key: key);
 
   /// The time initially selected when the dialog is shown.
   final TimeOfDay initialTime;

--- a/packages/flutter/lib/src/material/tooltip.dart
+++ b/packages/flutter/lib/src/material/tooltip.dart
@@ -42,7 +42,7 @@ class Tooltip extends StatefulWidget {
   ///
   /// The [message] argument must not be null.
   const Tooltip({
-    Key key,
+    Object debugLocation, Key key,
     @required this.message,
     this.height: 32.0,
     this.padding: const EdgeInsets.symmetric(horizontal: 16.0),
@@ -54,7 +54,7 @@ class Tooltip extends StatefulWidget {
        assert(padding != null),
        assert(verticalOffset != null),
        assert(preferBelow != null),
-       super(key: key);
+       super(debugLocation: debugLocation, key: key);
 
   /// The text to display in the tooltip.
   final String message;
@@ -248,7 +248,7 @@ class _TooltipPositionDelegate extends SingleChildLayoutDelegate {
 
 class _TooltipOverlay extends StatelessWidget {
   const _TooltipOverlay({
-    Key key,
+    Object debugLocation, Key key,
     this.message,
     this.height,
     this.padding,
@@ -256,7 +256,7 @@ class _TooltipOverlay extends StatelessWidget {
     this.target,
     this.verticalOffset,
     this.preferBelow,
-  }) : super(key: key);
+  }) : super(debugLocation: debugLocation, key: key);
 
   final String message;
   final double height;

--- a/packages/flutter/lib/src/material/two_level_list.dart
+++ b/packages/flutter/lib/src/material/two_level_list.dart
@@ -43,7 +43,7 @@ const Duration _kExpand = const Duration(milliseconds: 200);
 class TwoLevelListItem extends StatelessWidget {
   /// Creates an item in a two-level list.
   const TwoLevelListItem({
-    Key key,
+    Object debugLocation, Key key,
     this.leading,
     @required this.title,
     this.trailing,
@@ -51,7 +51,7 @@ class TwoLevelListItem extends StatelessWidget {
     this.onTap,
     this.onLongPress
   }) : assert(title != null),
-       super(key: key);
+       super(debugLocation: debugLocation, key: key);
 
   /// A widget to display before the title.
   ///
@@ -109,13 +109,13 @@ class TwoLevelListItem extends StatelessWidget {
 class TwoLevelSublist extends StatefulWidget {
   /// Creates an item in a two-level list that can expand and collapse.
   const TwoLevelSublist({
-    Key key,
+    Object debugLocation, Key key,
     this.leading,
     @required this.title,
     this.backgroundColor,
     this.onOpenChanged,
     this.children: const <Widget>[],
-  }) : super(key: key);
+  }) : super(debugLocation: debugLocation, key: key);
 
   /// A widget to display before the title.
   ///
@@ -260,12 +260,12 @@ class TwoLevelList extends StatelessWidget {
   ///
   /// The [type] argument must not be null.
   const TwoLevelList({
-    Key key,
+    Object debugLocation, Key key,
     this.children: const <Widget>[],
     this.type: MaterialListType.twoLine,
     this.padding,
   }) : assert(type != null),
-       super(key: key);
+       super(debugLocation: debugLocation, key: key);
 
   /// The widgets to display in this list.
   ///

--- a/packages/flutter/lib/src/material/user_accounts_drawer_header.dart
+++ b/packages/flutter/lib/src/material/user_accounts_drawer_header.dart
@@ -14,10 +14,10 @@ import 'theme.dart';
 
 class _AccountPictures extends StatelessWidget {
   const _AccountPictures({
-    Key key,
+    Object debugLocation, Key key,
     this.currentAccountPicture,
     this.otherAccountsPictures,
-  }) : super(key: key);
+  }) : super(debugLocation: debugLocation, key: key);
 
   final Widget currentAccountPicture;
   final List<Widget> otherAccountsPictures;
@@ -55,12 +55,12 @@ class _AccountPictures extends StatelessWidget {
 
 class _AccountDetails extends StatelessWidget {
   const _AccountDetails({
-    Key key,
+    Object debugLocation, Key key,
     @required this.accountName,
     @required this.accountEmail,
     this.onTap,
     this.isOpen,
-  }) : super(key: key);
+  }) : super(debugLocation: debugLocation, key: key);
 
   final Widget accountName;
   final Widget accountEmail;
@@ -140,7 +140,7 @@ class UserAccountsDrawerHeader extends StatefulWidget {
   ///
   /// Requires one of its ancestors to be a [Material] widget.
   const UserAccountsDrawerHeader({
-    Key key,
+    Object debugLocation, Key key,
     this.decoration,
     this.margin: const EdgeInsets.only(bottom: 8.0),
     this.currentAccountPicture,
@@ -148,7 +148,7 @@ class UserAccountsDrawerHeader extends StatefulWidget {
     @required this.accountName,
     @required this.accountEmail,
     this.onDetailsPressed
-  }) : super(key: key);
+  }) : super(debugLocation: debugLocation, key: key);
 
   /// The header's background. If decoration is null then a [BoxDecoration]
   /// with its background color set to the current theme's primaryColor is used.

--- a/packages/flutter/lib/src/painting/image_provider.dart
+++ b/packages/flutter/lib/src/painting/image_provider.dart
@@ -180,7 +180,7 @@ class ImageConfiguration {
 ///     Key key,
 ///     @required this.imageProvider,
 ///   }) : assert(imageProvider != null),
-///        super(key: key);
+///        super(debugLocation: debugLocation, key: key);
 ///
 ///   final ImageProvider imageProvider;
 ///

--- a/packages/flutter/lib/src/widgets/animated_cross_fade.dart
+++ b/packages/flutter/lib/src/widgets/animated_cross_fade.dart
@@ -109,7 +109,7 @@ class AnimatedCrossFade extends StatefulWidget {
   ///
   /// All the arguments other than [key] must be non-null.
   const AnimatedCrossFade({
-    Key key,
+    Object debugLocation, Key key,
     @required this.firstChild,
     @required this.secondChild,
     this.firstCurve: Curves.linear,
@@ -128,7 +128,7 @@ class AnimatedCrossFade extends StatefulWidget {
        assert(crossFadeState != null),
        assert(duration != null),
        assert(layoutBuilder != null),
-       super(key: key);
+       super(debugLocation: debugLocation, key: key);
 
   /// The child that is visible when [crossFadeState] is
   /// [CrossFadeState.showFirst]. It fades out when transitioning

--- a/packages/flutter/lib/src/widgets/animated_list.dart
+++ b/packages/flutter/lib/src/widgets/animated_list.dart
@@ -47,7 +47,7 @@ class _ActiveItem implements Comparable<_ActiveItem> {
 class AnimatedList extends StatefulWidget {
   /// Creates a scrolling container that animates items when they are inserted or removed.
   const AnimatedList({
-    Key key,
+    Object debugLocation, Key key,
     @required this.itemBuilder,
     this.initialItemCount: 0,
     this.scrollDirection: Axis.vertical,
@@ -59,7 +59,7 @@ class AnimatedList extends StatefulWidget {
     this.padding,
   }) : assert(itemBuilder != null),
        assert(initialItemCount != null && initialItemCount >= 0),
-       super(key: key);
+       super(debugLocation: debugLocation, key: key);
 
   /// Called, as needed, to build list item widgets.
   ///

--- a/packages/flutter/lib/src/widgets/animated_size.dart
+++ b/packages/flutter/lib/src/widgets/animated_size.dart
@@ -16,13 +16,13 @@ class AnimatedSize extends SingleChildRenderObjectWidget {
   ///
   /// The [curve] and [duration] arguments must not be null.
   const AnimatedSize({
-    Key key,
+    Object debugLocation, Key key,
     Widget child,
     this.alignment: Alignment.center,
     this.curve: Curves.linear,
     @required this.duration,
     @required this.vsync,
-  }) : super(key: key, child: child);
+  }) : super(debugLocation: debugLocation, key: key, child: child);
 
   /// The alignment of the child within the parent when the parent is not yet
   /// the same size as the child.

--- a/packages/flutter/lib/src/widgets/app.dart
+++ b/packages/flutter/lib/src/widgets/app.dart
@@ -66,7 +66,7 @@ class WidgetsApp extends StatefulWidget {
   /// The `supportedLocales` argument must be a list of one or more elements.
   /// By default supportedLocales is `[const Locale('en', 'US')]`.
   WidgetsApp({ // can't be const because the asserts use methods on Iterable :-(
-    Key key,
+    Object debugLocation, Key key,
     @required this.onGenerateRoute,
     this.onUnknownRoute,
     this.title: '',
@@ -97,7 +97,7 @@ class WidgetsApp extends StatefulWidget {
        assert(showSemanticsDebugger != null),
        assert(debugShowCheckedModeBanner != null),
        assert(debugShowWidgetInspector != null),
-       super(key: key);
+       super(debugLocation: debugLocation, key: key);
 
   /// A one-line description used by the device to identify the app for the user.
   ///

--- a/packages/flutter/lib/src/widgets/async.dart
+++ b/packages/flutter/lib/src/widgets/async.dart
@@ -46,7 +46,7 @@ import 'framework.dart';
 ///  recent interaction is needed for widget building.
 abstract class StreamBuilderBase<T, S> extends StatefulWidget {
   /// Creates a [StreamBuilderBase] connected to the specified [stream].
-  const StreamBuilderBase({ Key key, this.stream }) : super(key: key);
+  const StreamBuilderBase({ Object debugLocation, Key key, this.stream }) : super(debugLocation: debugLocation, key: key);
 
   /// The asynchronous computation to which this builder is currently connected,
   /// possibly null. When changed, the current summary is updated using
@@ -335,11 +335,11 @@ class StreamBuilder<T> extends StreamBuilderBase<T, AsyncSnapshot<T>> {
   /// snapshot of interaction with the specified [stream] and whose build
   /// strategy is given by [builder].
   const StreamBuilder({
-    Key key,
+    Object debugLocation, Key key,
     Stream<T> stream,
     @required this.builder
   }) : assert(builder != null),
-       super(key: key, stream: stream);
+       super(debugLocation: debugLocation, key: key, stream: stream);
 
   /// The build strategy currently used by this builder. Cannot be null.
   final AsyncWidgetBuilder<T> builder;
@@ -435,11 +435,11 @@ class FutureBuilder<T> extends StatefulWidget {
   ///
   /// The [builder] must not be null.
   const FutureBuilder({
-    Key key,
+    Object debugLocation, Key key,
     this.future,
     @required this.builder
   }) : assert(builder != null),
-       super(key: key);
+       super(debugLocation: debugLocation, key: key);
 
   /// The asynchronous computation to which this builder is currently connected,
   /// possibly null.

--- a/packages/flutter/lib/src/widgets/automatic_keep_alive.dart
+++ b/packages/flutter/lib/src/widgets/automatic_keep_alive.dart
@@ -26,9 +26,9 @@ class AutomaticKeepAlive extends StatefulWidget {
   /// Creates a widget that listens to [KeepAliveNotification]s and maintains a
   /// [KeepAlive] widget appropriately.
   const AutomaticKeepAlive({
-    Key key,
+    Object debugLocation, Key key,
     this.child,
-  }) : super(key: key);
+  }) : super(debugLocation: debugLocation, key: key);
 
   /// The widget below this widget in the tree.
   final Widget child;

--- a/packages/flutter/lib/src/widgets/banner.dart
+++ b/packages/flutter/lib/src/widgets/banner.dart
@@ -239,7 +239,7 @@ class Banner extends StatelessWidget {
   ///
   /// The [message] and [location] arguments must not be null.
   const Banner({
-    Key key,
+    Object debugLocation, Key key,
     this.child,
     @required this.message,
     this.textDirection,
@@ -251,7 +251,7 @@ class Banner extends StatelessWidget {
        assert(location != null),
        assert(color != null),
        assert(textStyle != null),
-       super(key: key);
+       super(debugLocation: debugLocation, key: key);
 
   /// The widget to show behind the banner.
   final Widget child;
@@ -327,9 +327,9 @@ class Banner extends StatelessWidget {
 class CheckedModeBanner extends StatelessWidget {
   /// Creates a checked mode banner.
   const CheckedModeBanner({
-    Key key,
+    Object debugLocation, Key key,
     @required this.child
-  }) : super(key: key);
+  }) : super(debugLocation: debugLocation, key: key);
 
   /// The widget to show behind the banner.
   final Widget child;

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -72,12 +72,12 @@ class Directionality extends InheritedWidget {
   ///
   /// The [textDirection] and [child] arguments must not be null.
   const Directionality({
-    Key key,
+    Object debugLocation, Key key,
     @required this.textDirection,
     @required Widget child
   }) : assert(textDirection != null),
        assert(child != null),
-       super(key: key, child: child);
+       super(debugLocation: debugLocation, key: key, child: child);
 
   /// The text direction for this subtree.
   final TextDirection textDirection;
@@ -147,11 +147,11 @@ class Opacity extends SingleChildRenderObjectWidget {
   /// The [opacity] argument must not be null and must be between 0.0 and 1.0
   /// (inclusive).
   const Opacity({
-    Key key,
+    Object debugLocation, Key key,
     @required this.opacity,
     Widget child,
   }) : assert(opacity != null && opacity >= 0.0 && opacity <= 1.0),
-       super(key: key, child: child);
+       super(debugLocation: debugLocation, key: key, child: child);
 
   /// The fraction to scale the child's alpha value.
   ///
@@ -214,13 +214,13 @@ class ShaderMask extends SingleChildRenderObjectWidget {
   ///
   /// The [shaderCallback] and [blendMode] arguments must not be null.
   const ShaderMask({
-    Key key,
+    Object debugLocation, Key key,
     @required this.shaderCallback,
     this.blendMode: BlendMode.modulate,
     Widget child
   }) : assert(shaderCallback != null),
        assert(blendMode != null),
-       super(key: key, child: child);
+       super(debugLocation: debugLocation, key: key, child: child);
 
   /// Called to create the [dart:ui.Shader] that generates the mask.
   ///
@@ -268,11 +268,11 @@ class BackdropFilter extends SingleChildRenderObjectWidget {
   ///
   /// The [filter] argument must not be null.
   const BackdropFilter({
-    Key key,
+    Object debugLocation, Key key,
     @required this.filter,
     Widget child
   }) : assert(filter != null),
-       super(key: key, child: child);
+       super(debugLocation: debugLocation, key: key, child: child);
 
   /// The image filter to apply to the existing painted content before painting the child.
   ///
@@ -344,7 +344,7 @@ class BackdropFilter extends SingleChildRenderObjectWidget {
 class CustomPaint extends SingleChildRenderObjectWidget {
   /// Creates a widget that delegates its painting.
   const CustomPaint({
-    Key key,
+    Object debugLocation, Key key,
     this.painter,
     this.foregroundPainter,
     this.size: Size.zero,
@@ -354,7 +354,7 @@ class CustomPaint extends SingleChildRenderObjectWidget {
   }) : assert(size != null),
        assert(isComplex != null),
        assert(willChange != null),
-       super(key: key, child: child);
+       super(debugLocation: debugLocation, key: key, child: child);
 
   /// The painter that paints before the children.
   final CustomPainter painter;
@@ -456,7 +456,7 @@ class ClipRect extends SingleChildRenderObjectWidget {
   ///
   /// If [clipper] is null, the clip will match the layout size and position of
   /// the child.
-  const ClipRect({ Key key, this.clipper, Widget child }) : super(key: key, child: child);
+  const ClipRect({ Object debugLocation, Key key, this.clipper, Widget child }) : super(debugLocation: debugLocation, key: key, child: child);
 
   /// If non-null, determines which clip to use.
   final CustomClipper<Rect> clipper;
@@ -501,12 +501,12 @@ class ClipRRect extends SingleChildRenderObjectWidget {
   ///
   /// If [clipper] is non-null, then [borderRadius] is ignored.
   const ClipRRect({
-    Key key,
+    Object debugLocation, Key key,
     this.borderRadius,
     this.clipper,
     Widget child,
   }) : assert(borderRadius != null || clipper != null),
-       super(key: key, child: child);
+       super(debugLocation: debugLocation, key: key, child: child);
 
   /// The border radius of the rounded corners.
   ///
@@ -555,7 +555,7 @@ class ClipOval extends SingleChildRenderObjectWidget {
   ///
   /// If [clipper] is null, the oval will be inscribed into the layout size and
   /// position of the child.
-  const ClipOval({ Key key, this.clipper, Widget child }) : super(key: key, child: child);
+  const ClipOval({ Object debugLocation, Key key, this.clipper, Widget child }) : super(debugLocation: debugLocation, key: key, child: child);
 
   /// If non-null, determines which clip to use.
   ///
@@ -607,7 +607,7 @@ class ClipPath extends SingleChildRenderObjectWidget {
   /// size and location of the child. However, rather than use this default,
   /// consider using a [ClipRect], which can achieve the same effect more
   /// efficiently.
-  const ClipPath({ Key key, this.clipper, Widget child }) : super(key: key, child: child);
+  const ClipPath({ Object debugLocation, Key key, this.clipper, Widget child }) : super(debugLocation: debugLocation, key: key, child: child);
 
   /// If non-null, determines which clip to use.
   ///
@@ -652,7 +652,7 @@ class PhysicalModel extends SingleChildRenderObjectWidget {
   ///
   /// The [shape], [elevation], [color], and [shadowColor] must not be null.
   const PhysicalModel({
-    Key key,
+    Object debugLocation, Key key,
     this.shape: BoxShape.rectangle,
     this.borderRadius,
     this.elevation: 0.0,
@@ -663,7 +663,7 @@ class PhysicalModel extends SingleChildRenderObjectWidget {
        assert(elevation != null),
        assert(color != null),
        assert(shadowColor != null),
-       super(key: key, child: child);
+       super(debugLocation: debugLocation, key: key, child: child);
 
   /// The type of shape.
   final BoxShape shape;
@@ -751,14 +751,14 @@ class Transform extends SingleChildRenderObjectWidget {
   ///
   /// The [transform] argument must not be null.
   const Transform({
-    Key key,
+    Object debugLocation, Key key,
     @required this.transform,
     this.origin,
     this.alignment,
     this.transformHitTests: true,
     Widget child,
   }) : assert(transform != null),
-       super(key: key, child: child);
+       super(debugLocation: debugLocation, key: key, child: child);
 
   /// Creates a widget that transforms its child using a rotation around the
   /// center.
@@ -782,14 +782,14 @@ class Transform extends SingleChildRenderObjectWidget {
   /// )
   /// ```
   Transform.rotate({
-    Key key,
+    Object debugLocation, Key key,
     @required double angle,
     this.origin,
     this.alignment: Alignment.center,
     this.transformHitTests: true,
     Widget child,
   }) : transform = new Matrix4.rotationZ(angle),
-       super(key: key, child: child);
+       super(debugLocation: debugLocation, key: key, child: child);
 
   /// The matrix to transform the child by during painting.
   final Matrix4 transform;
@@ -863,11 +863,11 @@ class CompositedTransformTarget extends SingleChildRenderObjectWidget {
   /// The [link] property must not be null, and must not be currently being used
   /// by any other [CompositedTransformTarget] object that is in the tree.
   const CompositedTransformTarget({
-    Key key,
+    Object debugLocation, Key key,
     @required this.link,
     Widget child,
   }) : assert(link != null),
-       super(key: key, child: child);
+       super(debugLocation: debugLocation, key: key, child: child);
 
   /// The link object that connects this [CompositedTransformTarget] with one or
   /// more [CompositedTransformFollower]s.
@@ -924,7 +924,7 @@ class CompositedTransformFollower extends SingleChildRenderObjectWidget {
   ///
   /// The [showWhenUnlinked] and [offset] properties must also not be null.
   const CompositedTransformFollower({
-    Key key,
+    Object debugLocation, Key key,
     @required this.link,
     this.showWhenUnlinked: true,
     this.offset: Offset.zero,
@@ -932,7 +932,7 @@ class CompositedTransformFollower extends SingleChildRenderObjectWidget {
   }) : assert(link != null),
        assert(showWhenUnlinked != null),
        assert(offset != null),
-       super(key: key, child: child);
+       super(debugLocation: debugLocation, key: key, child: child);
 
   /// The link object that connects this [CompositedTransformFollower] with a
   /// [CompositedTransformTarget].
@@ -985,13 +985,13 @@ class FittedBox extends SingleChildRenderObjectWidget {
   ///
   /// The [fit] and [alignment] arguments must not be null.
   const FittedBox({
-    Key key,
+    Object debugLocation, Key key,
     this.fit: BoxFit.contain,
     this.alignment: Alignment.center,
     Widget child,
   }) : assert(fit != null),
        assert(alignment != null),
-       super(key: key, child: child);
+       super(debugLocation: debugLocation, key: key, child: child);
 
   /// How to inscribe the child into the space allocated during layout.
   final BoxFit fit;
@@ -1046,12 +1046,12 @@ class FractionalTranslation extends SingleChildRenderObjectWidget {
   ///
   /// The [translation] argument must not be null.
   const FractionalTranslation({
-    Key key,
+    Object debugLocation, Key key,
     @required this.translation,
     this.transformHitTests: true,
     Widget child
   }) : assert(translation != null),
-       super(key: key, child: child);
+       super(debugLocation: debugLocation, key: key, child: child);
 
   /// The translation to apply to the child, scaled to the child's size.
   ///
@@ -1106,11 +1106,11 @@ class RotatedBox extends SingleChildRenderObjectWidget {
   ///
   /// The [quarterTurns] argument must not be null.
   const RotatedBox({
-    Key key,
+    Object debugLocation, Key key,
     @required this.quarterTurns,
     Widget child,
   }) : assert(quarterTurns != null),
-       super(key: key, child: child);
+       super(debugLocation: debugLocation, key: key, child: child);
 
   /// The number of clockwise quarter turns the child should be rotated.
   final int quarterTurns;
@@ -1172,11 +1172,11 @@ class Padding extends SingleChildRenderObjectWidget {
   ///
   /// The [padding] argument must not be null.
   const Padding({
-    Key key,
+    Object debugLocation, Key key,
     @required this.padding,
     Widget child,
   }) : assert(padding != null),
-       super(key: key, child: child);
+       super(debugLocation: debugLocation, key: key, child: child);
 
   /// The amount of space by which to inset the child.
   final EdgeInsetsGeometry padding;
@@ -1232,7 +1232,7 @@ class Align extends SingleChildRenderObjectWidget {
   ///
   /// The alignment defaults to [Alignment.center].
   const Align({
-    Key key,
+    Object debugLocation, Key key,
     this.alignment: Alignment.center,
     this.widthFactor,
     this.heightFactor,
@@ -1240,7 +1240,7 @@ class Align extends SingleChildRenderObjectWidget {
   }) : assert(alignment != null),
        assert(widthFactor == null || widthFactor >= 0.0),
        assert(heightFactor == null || heightFactor >= 0.0),
-       super(key: key, child: child);
+       super(debugLocation: debugLocation, key: key, child: child);
 
   /// How to align the child.
   ///
@@ -1319,8 +1319,8 @@ class Align extends SingleChildRenderObjectWidget {
 ///  * The [catalog of layout widgets](https://flutter.io/widgets/layout/).
 class Center extends Align {
   /// Creates a widget that centers its child.
-  const Center({ Key key, double widthFactor, double heightFactor, Widget child })
-    : super(key: key, widthFactor: widthFactor, heightFactor: heightFactor, child: child);
+  const Center({ Object debugLocation, Key key,double widthFactor, double heightFactor, Widget child })
+    : super(debugLocation: debugLocation, key: key, widthFactor: widthFactor, heightFactor: heightFactor, child: child);
 }
 
 /// A widget that defers the layout of its single child to a delegate.
@@ -1344,11 +1344,11 @@ class CustomSingleChildLayout extends SingleChildRenderObjectWidget {
   ///
   /// The [delegate] argument must not be null.
   const CustomSingleChildLayout({
-    Key key,
+    Object debugLocation, Key key,
     @required this.delegate,
     Widget child
   }) : assert(delegate != null),
-       super(key: key, child: child);
+       super(debugLocation: debugLocation, key: key, child: child);
 
   /// The delegate that controls the layout of the child.
   final SingleChildLayoutDelegate delegate;
@@ -1374,7 +1374,7 @@ class LayoutId extends ParentDataWidget<CustomMultiChildLayout> {
   ///
   /// Both the child and the id arguments must not be null.
   LayoutId({
-    Key key,
+    Object debugLocation, Key key,
     @required this.id,
     @required Widget child
   }) : assert(child != null),
@@ -1433,11 +1433,11 @@ class CustomMultiChildLayout extends MultiChildRenderObjectWidget {
   ///
   /// The [delegate] argument must not be null.
   CustomMultiChildLayout({
-    Key key,
+    Object debugLocation, Key key,
     @required this.delegate,
     List<Widget> children: const <Widget>[],
   }) : assert(delegate != null),
-       super(key: key, children: children);
+       super(debugLocation: debugLocation, key: key, children: children);
 
   /// The delegate that controls the layout of the children.
   final MultiChildLayoutDelegate delegate;
@@ -1497,20 +1497,20 @@ class SizedBox extends SingleChildRenderObjectWidget {
   /// Creates a fixed size box. The [width] and [height] parameters can be null
   /// to indicate that the size of the box should not be constrained in
   /// the corresponding dimension.
-  const SizedBox({ Key key, this.width, this.height, Widget child })
-    : super(key: key, child: child);
+  const SizedBox({ Object debugLocation, Key key,this.width, this.height, Widget child })
+    : super(debugLocation: debugLocation, key: key, child: child);
 
   /// Creates a box that will become as large as its parent allows.
-  const SizedBox.expand({ Key key, Widget child })
+  const SizedBox.expand({ Object debugLocation, Key key,Widget child })
     : width = double.INFINITY,
       height = double.INFINITY,
-      super(key: key, child: child);
+      super(debugLocation: debugLocation, key: key, child: child);
 
   /// Creates a box with the specified size.
-  SizedBox.fromSize({ Key key, Widget child, Size size })
+  SizedBox.fromSize({ Object debugLocation, Key key,Widget child, Size size })
     : width = size?.width,
       height = size?.height,
-      super(key: key, child: child);
+      super(debugLocation: debugLocation, key: key, child: child);
 
   /// If non-null, requires the child to have exactly this width.
   final double width;
@@ -1589,12 +1589,12 @@ class ConstrainedBox extends SingleChildRenderObjectWidget {
   ///
   /// The [constraints] argument must not be null.
   ConstrainedBox({
-    Key key,
+    Object debugLocation, Key key,
     @required this.constraints,
     Widget child
   }) : assert(constraints != null),
        assert(constraints.debugAssertIsValid()),
-       super(key: key, child: child);
+       super(debugLocation: debugLocation, key: key, child: child);
 
   /// The additional constraints to impose on the child.
   final BoxConstraints constraints;
@@ -1642,13 +1642,13 @@ class UnconstrainedBox extends SingleChildRenderObjectWidget {
   /// render at its "natural" size. If the child overflows the parents
   /// constraints, a warning will be given in debug mode.
   const UnconstrainedBox({
-    Key key,
+    Object debugLocation, Key key,
     Widget child,
     this.textDirection,
     this.alignment: Alignment.center,
     this.constrainedAxis,
   }) : assert(alignment != null),
-       super(key: key, child: child);
+       super(debugLocation: debugLocation, key: key, child: child);
 
   /// The text direction to use when interpreting the [alignment] if it is an
   /// [AlignmentDirectional].
@@ -1715,7 +1715,7 @@ class FractionallySizedBox extends SingleChildRenderObjectWidget {
   /// If non-null, the [widthFactor] and [heightFactor] arguments must be
   /// non-negative.
   const FractionallySizedBox({
-    Key key,
+    Object debugLocation, Key key,
     this.alignment: Alignment.center,
     this.widthFactor,
     this.heightFactor,
@@ -1723,7 +1723,7 @@ class FractionallySizedBox extends SingleChildRenderObjectWidget {
   }) : assert(alignment != null),
        assert(widthFactor == null || widthFactor >= 0.0),
        assert(heightFactor == null || heightFactor >= 0.0),
-       super(key: key, child: child);
+       super(debugLocation: debugLocation, key: key, child: child);
 
   /// If non-null, the fraction of the incoming width given to the child.
   ///
@@ -1811,13 +1811,13 @@ class LimitedBox extends SingleChildRenderObjectWidget {
   /// The [maxWidth] and [maxHeight] arguments must not be null and must not be
   /// negative.
   const LimitedBox({
-    Key key,
+    Object debugLocation, Key key,
     this.maxWidth: double.INFINITY,
     this.maxHeight: double.INFINITY,
     Widget child,
   }) : assert(maxWidth != null && maxWidth >= 0.0),
        assert(maxHeight != null && maxHeight >= 0.0),
-       super(key: key, child: child);
+       super(debugLocation: debugLocation, key: key, child: child);
 
   /// The maximum width limit to apply in the absence of a
   /// [BoxConstraints.maxWidth] constraint.
@@ -1868,14 +1868,14 @@ class LimitedBox extends SingleChildRenderObjectWidget {
 class OverflowBox extends SingleChildRenderObjectWidget {
   /// Creates a widget that lets its child overflow itself.
   const OverflowBox({
-    Key key,
+    Object debugLocation, Key key,
     this.alignment: Alignment.center,
     this.minWidth,
     this.maxWidth,
     this.minHeight,
     this.maxHeight,
     Widget child,
-  }) : super(key: key, child: child);
+  }) : super(debugLocation: debugLocation, key: key, child: child);
 
   /// How to align the child.
   ///
@@ -1956,13 +1956,13 @@ class SizedOverflowBox extends SingleChildRenderObjectWidget {
   ///
   /// The [size] argument must not be null.
   const SizedOverflowBox({
-    Key key,
+    Object debugLocation, Key key,
     @required this.size,
     this.alignment: Alignment.center,
     Widget child,
   }) : assert(size != null),
        assert(alignment != null),
-       super(key: key, child: child);
+       super(debugLocation: debugLocation, key: key, child: child);
 
   /// How to align the child.
   ///
@@ -2012,9 +2012,9 @@ class SizedOverflowBox extends SingleChildRenderObjectWidget {
 ///  * The [catalog of layout widgets](https://flutter.io/widgets/layout/).
 class Offstage extends SingleChildRenderObjectWidget {
   /// Creates a widget that visually hides its child.
-  const Offstage({ Key key, this.offstage: true, Widget child })
+  const Offstage({ Object debugLocation, Key key,this.offstage: true, Widget child })
     : assert(offstage != null),
-      super(key: key, child: child);
+      super(debugLocation: debugLocation, key: key, child: child);
 
   /// Whether the child is hidden from the rest of the tree.
   ///
@@ -2097,11 +2097,11 @@ class AspectRatio extends SingleChildRenderObjectWidget {
   ///
   /// The [aspectRatio] argument must not be null.
   const AspectRatio({
-    Key key,
+    Object debugLocation, Key key,
     @required this.aspectRatio,
     Widget child
   }) : assert(aspectRatio != null),
-       super(key: key, child: child);
+       super(debugLocation: debugLocation, key: key, child: child);
 
   /// The aspect ratio to attempt to use.
   ///
@@ -2147,8 +2147,8 @@ class IntrinsicWidth extends SingleChildRenderObjectWidget {
   /// Creates a widget that sizes its child to the child's intrinsic width.
   ///
   /// This class is relatively expensive. Avoid using it where possible.
-  const IntrinsicWidth({ Key key, this.stepWidth, this.stepHeight, Widget child })
-    : super(key: key, child: child);
+  const IntrinsicWidth({ Object debugLocation, Key key,this.stepWidth, this.stepHeight, Widget child })
+    : super(debugLocation: debugLocation, key: key, child: child);
 
   /// If non-null, force the child's width to be a multiple of this value.
   final double stepWidth;
@@ -2187,7 +2187,7 @@ class IntrinsicHeight extends SingleChildRenderObjectWidget {
   /// Creates a widget that sizes its child to the child's intrinsic height.
   ///
   /// This class is relatively expensive. Avoid using it where possible.
-  const IntrinsicHeight({ Key key, Widget child }) : super(key: key, child: child);
+  const IntrinsicHeight({ Object debugLocation, Key key, Widget child }) : super(debugLocation: debugLocation, key: key, child: child);
 
   @override
   RenderIntrinsicHeight createRenderObject(BuildContext context) => new RenderIntrinsicHeight();
@@ -2213,13 +2213,13 @@ class Baseline extends SingleChildRenderObjectWidget {
   ///
   /// The [baseline] and [baselineType] arguments must not be null.
   const Baseline({
-    Key key,
+    Object debugLocation, Key key,
     @required this.baseline,
     @required this.baselineType,
     Widget child
   }) : assert(baseline != null),
        assert(baselineType != null),
-       super(key: key, child: child);
+       super(debugLocation: debugLocation, key: key, child: child);
 
   /// The number of logical pixels from the top of this box at which to position
   /// the child's baseline.
@@ -2269,9 +2269,9 @@ class Baseline extends SingleChildRenderObjectWidget {
 class SliverToBoxAdapter extends SingleChildRenderObjectWidget {
   /// Creates a sliver that contains a single box widget.
   const SliverToBoxAdapter({
-    Key key,
+    Object debugLocation, Key key,
     Widget child,
-  }) : super(key: key, child: child);
+  }) : super(debugLocation: debugLocation, key: key, child: child);
 
   @override
   RenderSliverToBoxAdapter createRenderObject(BuildContext context) => new RenderSliverToBoxAdapter();
@@ -2298,11 +2298,11 @@ class SliverPadding extends SingleChildRenderObjectWidget {
   ///
   /// The [padding] argument must not be null.
   const SliverPadding({
-    Key key,
+    Object debugLocation, Key key,
     @required this.padding,
     Widget sliver,
   }) : assert(padding != null),
-       super(key: key, child: sliver);
+       super(debugLocation: debugLocation, key: key, child: sliver);
 
   /// The amount of space by which to inset the child sliver.
   final EdgeInsetsGeometry padding;
@@ -2392,12 +2392,12 @@ class ListBody extends MultiChildRenderObjectWidget {
   ///
   /// By default, the [mainAxis] is [Axis.vertical].
   ListBody({
-    Key key,
+    Object debugLocation, Key key,
     this.mainAxis: Axis.vertical,
     this.reverse: false,
     List<Widget> children: const <Widget>[],
   }) : assert(mainAxis != null),
-       super(key: key, children: children);
+       super(debugLocation: debugLocation, key: key, children: children);
 
   /// The direction to use as the main axis.
   final Axis mainAxis;
@@ -2478,13 +2478,13 @@ class Stack extends MultiChildRenderObjectWidget {
   /// By default, the non-positioned children of the stack are aligned by their
   /// top left corners.
   Stack({
-    Key key,
+    Object debugLocation, Key key,
     this.alignment: AlignmentDirectional.topStart,
     this.textDirection,
     this.fit: StackFit.loose,
     this.overflow: Overflow.clip,
     List<Widget> children: const <Widget>[],
-  }) : super(key: key, children: children);
+  }) : super(debugLocation: debugLocation, key: key, children: children);
 
   /// How to align the non-positioned and partially-positioned children in the
   /// stack.
@@ -2563,13 +2563,13 @@ class IndexedStack extends Stack {
   ///
   /// The [index] argument must not be null.
   IndexedStack({
-    Key key,
+    Object debugLocation, Key key,
     AlignmentGeometry alignment: AlignmentDirectional.topStart,
     TextDirection textDirection,
     StackFit sizing: StackFit.loose,
     this.index: 0,
     List<Widget> children: const <Widget>[],
-  }) : super(key: key, alignment: alignment, textDirection: textDirection, fit: sizing, children: children);
+  }) : super(debugLocation: debugLocation, key: key, alignment: alignment, textDirection: textDirection, fit: sizing, children: children);
 
   /// The index of the child to show.
   final int index;
@@ -2635,7 +2635,7 @@ class Positioned extends ParentDataWidget<Stack> {
   ///  * [PositionedDirectional], which is similar to [Positioned.directional]
   ///    but adapts to the ambient [Directionality].
   const Positioned({
-    Key key,
+    Object debugLocation, Key key,
     this.left,
     this.top,
     this.right,
@@ -2645,7 +2645,7 @@ class Positioned extends ParentDataWidget<Stack> {
     @required Widget child,
   }) : assert(left == null || right == null || width == null),
        assert(top == null || bottom == null || height == null),
-       super(key: key, child: child);
+       super(debugLocation: debugLocation, key: key, child: child);
 
   /// Creates a Positioned object with the values from the given [Rect].
   ///
@@ -2653,7 +2653,7 @@ class Positioned extends ParentDataWidget<Stack> {
   /// from the given [Rect]. The [right] and [bottom] properties are
   /// set to null.
   Positioned.fromRect({
-    Key key,
+    Object debugLocation, Key key,
     Rect rect,
     @required Widget child,
   }) : left = rect.left,
@@ -2662,14 +2662,14 @@ class Positioned extends ParentDataWidget<Stack> {
        height = rect.height,
        right = null,
        bottom = null,
-       super(key: key, child: child);
+       super(debugLocation: debugLocation, key: key, child: child);
 
   /// Creates a Positioned object with the values from the given [RelativeRect].
   ///
   /// This sets the [left], [top], [right], and [bottom] properties from the
   /// given [RelativeRect]. The [height] and [width] properties are set to null.
   Positioned.fromRelativeRect({
-    Key key,
+    Object debugLocation, Key key,
     RelativeRect rect,
     @required Widget child,
   }) : left = rect.left,
@@ -2678,12 +2678,12 @@ class Positioned extends ParentDataWidget<Stack> {
        bottom = rect.bottom,
        width = null,
        height = null,
-       super(key: key, child: child);
+       super(debugLocation: debugLocation, key: key, child: child);
 
   /// Creates a Positioned object with [left], [top], [right], and [bottom] set
   /// to 0.0 unless a value for them is passed.
   const Positioned.fill({
-    Key key,
+    Object debugLocation, Key key,
     this.left: 0.0,
     this.top: 0.0,
     this.right: 0.0,
@@ -2691,7 +2691,7 @@ class Positioned extends ParentDataWidget<Stack> {
     @required Widget child,
   }) : width = null,
        height = null,
-       super(key: key, child: child);
+       super(debugLocation: debugLocation, key: key, child: child);
 
   /// Creates a widget that controls where a child of a [Stack] is positioned.
   ///
@@ -2712,7 +2712,7 @@ class Positioned extends ParentDataWidget<Stack> {
   ///
   ///  * [PositionedDirectional], which adapts to the ambient [Directionality].
   factory Positioned.directional({
-    Key key,
+    Object debugLocation, Key key,
     @required TextDirection textDirection,
     double start,
     double top,
@@ -2898,7 +2898,7 @@ class PositionedDirectional extends StatelessWidget {
   ///  * [Positioned.directional], which also specifies the widget's horizontal
   ///    position using [start] and [end] but has an explicit [TextDirection].
   const PositionedDirectional({
-    Key key,
+    Object debugLocation, Key key,
     this.start,
     this.top,
     this.end,
@@ -2906,7 +2906,7 @@ class PositionedDirectional extends StatelessWidget {
     this.width,
     this.height,
     @required this.child,
-  }) : super(key: key);
+  }) : super(debugLocation: debugLocation, key: key);
 
   /// The distance that the child's leading edge is inset from the leading edge
   /// of the stack.
@@ -3044,7 +3044,7 @@ class Flex extends MultiChildRenderObjectWidget {
   /// disambiguate `start` or `end` values for the main or cross axis
   /// directions, the [textDirection] must not be null.
   Flex({
-    Key key,
+    Object debugLocation, Key key,
     @required this.direction,
     this.mainAxisAlignment: MainAxisAlignment.start,
     this.mainAxisSize: MainAxisSize.max,
@@ -3059,7 +3059,7 @@ class Flex extends MultiChildRenderObjectWidget {
        assert(crossAxisAlignment != null),
        assert(verticalDirection != null),
        assert(crossAxisAlignment != CrossAxisAlignment.baseline || textBaseline != null),
-       super(key: key, children: children);
+       super(debugLocation: debugLocation, key: key, children: children);
 
   /// The direction to use as the main axis.
   ///
@@ -3375,7 +3375,7 @@ class Row extends Flex {
   /// `start` or `end` values for the [mainAxisAlignment], the [textDirection]
   /// must not be null.
   Row({
-    Key key,
+    Object debugLocation, Key key,
     MainAxisAlignment mainAxisAlignment: MainAxisAlignment.start,
     MainAxisSize mainAxisSize: MainAxisSize.max,
     CrossAxisAlignment crossAxisAlignment: CrossAxisAlignment.center,
@@ -3565,7 +3565,7 @@ class Column extends Flex {
   /// to be necessary to disambiguate `start` or `end` values for the
   /// [crossAxisAlignment], the [textDirection] must not be null.
   Column({
-    Key key,
+    Object debugLocation, Key key,
     MainAxisAlignment mainAxisAlignment: MainAxisAlignment.start,
     MainAxisSize mainAxisSize: MainAxisSize.max,
     CrossAxisAlignment crossAxisAlignment: CrossAxisAlignment.center,
@@ -3607,11 +3607,11 @@ class Flexible extends ParentDataWidget<Flex> {
   /// Creates a widget that controls how a child of a [Row], [Column], or [Flex]
   /// flexes.
   const Flexible({
-    Key key,
+    Object debugLocation, Key key,
     this.flex: 1,
     this.fit: FlexFit.loose,
     @required Widget child,
-  }) : super(key: key, child: child);
+  }) : super(debugLocation: debugLocation, key: key, child: child);
 
   /// The flex factor to use for this child
   ///
@@ -3680,10 +3680,10 @@ class Expanded extends Flexible {
   /// Creates a widget that expands a child of a [Row], [Column], or [Flex]
   /// expand to fill the available space in the main axis.
   const Expanded({
-    Key key,
+    Object debugLocation, Key key,
     int flex: 1,
     @required Widget child,
-  }) : super(key: key, flex: flex, fit: FlexFit.tight, child: child);
+  }) : super(debugLocation: debugLocation, key: key, flex: flex, fit: FlexFit.tight, child: child);
 }
 
 /// A widget that displays its children in multiple horizontal or vertical runs.
@@ -3747,7 +3747,7 @@ class Wrap extends MultiChildRenderObjectWidget {
   /// disambiguate `start` or `end` values for the main or cross axis
   /// directions, the [textDirection] must not be null.
   Wrap({
-    Key key,
+    Object debugLocation, Key key,
     this.direction: Axis.horizontal,
     this.alignment: WrapAlignment.start,
     this.spacing: 0.0,
@@ -3757,7 +3757,7 @@ class Wrap extends MultiChildRenderObjectWidget {
     this.textDirection,
     this.verticalDirection: VerticalDirection.down,
     List<Widget> children: const <Widget>[],
-  }) : super(key: key, children: children);
+  }) : super(debugLocation: debugLocation, key: key, children: children);
 
   /// The direction to use as the main axis.
   ///
@@ -3974,11 +3974,11 @@ class Flow extends MultiChildRenderObjectWidget {
   ///
   /// The [delegate] argument must not be null.
   Flow({
-    Key key,
+    Object debugLocation, Key key,
     @required this.delegate,
     List<Widget> children: const <Widget>[],
   }) : assert(delegate != null),
-       super(key: key, children: RepaintBoundary.wrapAll(children));
+       super(debugLocation: debugLocation, key: key, children: RepaintBoundary.wrapAll(children));
        // https://github.com/dart-lang/sdk/issues/29277
 
   /// Creates a flow layout.
@@ -3989,11 +3989,11 @@ class Flow extends MultiChildRenderObjectWidget {
   ///
   /// The [delegate] argument must not be null.
   Flow.unwrapped({
-    Key key,
+    Object debugLocation, Key key,
     @required this.delegate,
     List<Widget> children: const <Widget>[],
   }) : assert(delegate != null),
-       super(key: key, children: children);
+       super(debugLocation: debugLocation, key: key, children: children);
 
   /// The delegate that controls the transformation matrices of the children.
   final FlowDelegate delegate;
@@ -4058,7 +4058,7 @@ class RichText extends LeafRenderObjectWidget {
   /// The [textDirection], if null, defaults to the ambient [Directionality],
   /// which in that case must not be null.
   const RichText({
-    Key key,
+    Object debugLocation, Key key,
     @required this.text,
     this.textAlign: TextAlign.start,
     this.textDirection,
@@ -4072,7 +4072,7 @@ class RichText extends LeafRenderObjectWidget {
        assert(overflow != null),
        assert(textScaleFactor != null),
        assert(maxLines == null || maxLines > 0),
-       super(key: key);
+       super(debugLocation: debugLocation, key: key);
 
   /// The text to display in this widget.
   final TextSpan text;
@@ -4169,7 +4169,7 @@ class RawImage extends LeafRenderObjectWidget {
   /// The [scale], [alignment], [repeat], and [matchTextDirection] arguments must
   /// not be null.
   const RawImage({
-    Key key,
+    Object debugLocation, Key key,
     this.image,
     this.width,
     this.height,
@@ -4185,7 +4185,7 @@ class RawImage extends LeafRenderObjectWidget {
        assert(alignment != null),
        assert(repeat != null),
        assert(matchTextDirection != null),
-       super(key: key);
+       super(debugLocation: debugLocation, key: key);
 
   /// The image to display.
   final ui.Image image;
@@ -4337,12 +4337,12 @@ class DefaultAssetBundle extends InheritedWidget {
   ///
   /// The [bundle] and [child] arguments must not be null.
   const DefaultAssetBundle({
-    Key key,
+    Object debugLocation, Key key,
     @required this.bundle,
     @required Widget child
   }) : assert(bundle != null),
        assert(child != null),
-       super(key: key, child: child);
+       super(debugLocation: debugLocation, key: key, child: child);
 
   /// The bundle to use as a default.
   final AssetBundle bundle;
@@ -4424,7 +4424,7 @@ class Listener extends SingleChildRenderObjectWidget {
   ///
   /// The [behavior] argument defaults to [HitTestBehavior.deferToChild].
   const Listener({
-    Key key,
+    Object debugLocation, Key key,
     this.onPointerDown,
     this.onPointerMove,
     this.onPointerUp,
@@ -4432,7 +4432,7 @@ class Listener extends SingleChildRenderObjectWidget {
     this.behavior: HitTestBehavior.deferToChild,
     Widget child
   }) : assert(behavior != null),
-       super(key: key, child: child);
+       super(debugLocation: debugLocation, key: key, child: child);
 
   /// Called when a pointer comes into contact with the screen at this object.
   final PointerDownEventListener onPointerDown;
@@ -4498,7 +4498,7 @@ class Listener extends SingleChildRenderObjectWidget {
 /// for the surround tree.
 class RepaintBoundary extends SingleChildRenderObjectWidget {
   /// Creates a widget that isolates repaints.
-  const RepaintBoundary({ Key key, Widget child }) : super(key: key, child: child);
+  const RepaintBoundary({ Object debugLocation, Key key, Widget child }) : super(debugLocation: debugLocation, key: key, child: child);
 
   /// Wraps the given child in a [RepaintBoundary].
   ///
@@ -4547,12 +4547,12 @@ class IgnorePointer extends SingleChildRenderObjectWidget {
   /// The [ignoring] argument must not be null. If [ignoringSemantics], this
   /// render object will be ignored for semantics if [ignoring] is true.
   const IgnorePointer({
-    Key key,
+    Object debugLocation, Key key,
     this.ignoring: true,
     this.ignoringSemantics,
     Widget child
   }) : assert(ignoring != null),
-       super(key: key, child: child);
+       super(debugLocation: debugLocation, key: key, child: child);
 
   /// Whether this widget is ignored during hit testing.
   ///
@@ -4607,11 +4607,11 @@ class AbsorbPointer extends SingleChildRenderObjectWidget {
   ///
   /// The [absorbing] argument must not be null
   const AbsorbPointer({
-    Key key,
+    Object debugLocation, Key key,
     this.absorbing: true,
     Widget child
   }) : assert(absorbing != null),
-       super(key: key, child: child);
+       super(debugLocation: debugLocation, key: key, child: child);
 
   /// Whether this widget absorbs pointers during hit testing.
   ///
@@ -4640,11 +4640,11 @@ class MetaData extends SingleChildRenderObjectWidget {
   ///
   /// The [behavior] argument defaults to [HitTestBehavior.deferToChild].
   const MetaData({
-    Key key,
+    Object debugLocation, Key key,
     this.metaData,
     this.behavior: HitTestBehavior.deferToChild,
     Widget child
-  }) : super(key: key, child: child);
+  }) : super(debugLocation: debugLocation, key: key, child: child);
 
   /// Opaque meta data ignored by the render tree
   final dynamic metaData;
@@ -4705,7 +4705,7 @@ class Semantics extends SingleChildRenderObjectWidget {
   /// The [container] argument must not be null. To create a `const` instance
   /// of [Semantics], use the [new Semantics.fromProperties] constructor.
   Semantics({
-    Key key,
+    Object debugLocation, Key key,
     Widget child,
     bool container: false,
     bool explicitChildNodes: false,
@@ -4760,14 +4760,14 @@ class Semantics extends SingleChildRenderObjectWidget {
   ///
   /// The [container] and [properties] arguments must not be null.
   const Semantics.fromProperties({
-    Key key,
+    Object debugLocation, Key key,
     Widget child,
     this.container: false,
     this.explicitChildNodes: false,
     @required this.properties,
   }) : assert(container != null),
        assert(properties != null),
-       super(key: key, child: child);
+       super(debugLocation: debugLocation, key: key, child: child);
 
   /// Contains properties used by assistive technologies to make the application
   /// more accessible.
@@ -4890,7 +4890,7 @@ class Semantics extends SingleChildRenderObjectWidget {
 /// callbacks.
 class MergeSemantics extends SingleChildRenderObjectWidget {
   /// Creates a widget that merges the semantics of its descendants.
-  const MergeSemantics({ Key key, Widget child }) : super(key: key, child: child);
+  const MergeSemantics({ Object debugLocation, Key key, Widget child }) : super(debugLocation: debugLocation, key: key, child: child);
 
   @override
   RenderMergeSemantics createRenderObject(BuildContext context) => new RenderMergeSemantics();
@@ -4911,7 +4911,7 @@ class MergeSemantics extends SingleChildRenderObjectWidget {
 class BlockSemantics extends SingleChildRenderObjectWidget {
   /// Creates a widget that excludes the semantics of all widgets painted before
   /// it in the same semantic container.
-  const BlockSemantics({ Key key, Widget child }) : super(key: key, child: child);
+  const BlockSemantics({ Object debugLocation, Key key, Widget child }) : super(debugLocation: debugLocation, key: key, child: child);
 
   @override
   RenderBlockSemantics createRenderObject(BuildContext context) => new RenderBlockSemantics();
@@ -4933,11 +4933,11 @@ class BlockSemantics extends SingleChildRenderObjectWidget {
 class ExcludeSemantics extends SingleChildRenderObjectWidget {
   /// Creates a widget that drops all the semantics of its descendants.
   const ExcludeSemantics({
-    Key key,
+    Object debugLocation, Key key,
     this.excluding: true,
     Widget child,
   }) : assert(excluding != null),
-        super(key: key, child: child);
+        super(debugLocation: debugLocation, key: key, child: child);
 
   /// Whether this widget is excluded in the semantics tree.
   final bool excluding;
@@ -4963,10 +4963,10 @@ class ExcludeSemantics extends SingleChildRenderObjectWidget {
 class KeyedSubtree extends StatelessWidget {
   /// Creates a widget that builds its child.
   const KeyedSubtree({
-    Key key,
+    Object debugLocation, Key key,
     @required this.child
   }) : assert(child != null),
-       super(key: key);
+       super(debugLocation: debugLocation, key: key);
 
   /// The widget below this widget in the tree.
   final Widget child;
@@ -5008,10 +5008,10 @@ class Builder extends StatelessWidget {
   ///
   /// The [builder] argument must not be null.
   const Builder({
-    Key key,
+    Object debugLocation, Key key,
     @required this.builder
   }) : assert(builder != null),
-       super(key: key);
+       super(debugLocation: debugLocation, key: key);
 
   /// Called to obtain the child widget.
   ///
@@ -5041,10 +5041,10 @@ class StatefulBuilder extends StatefulWidget {
   ///
   /// The [builder] argument must not be null.
   const StatefulBuilder({
-    Key key,
+    Object debugLocation, Key key,
     @required this.builder
   }) : assert(builder != null),
-       super(key: key);
+       super(debugLocation: debugLocation, key: key);
 
   /// Called to obtain the child widget.
   ///

--- a/packages/flutter/lib/src/widgets/binding.dart
+++ b/packages/flutter/lib/src/widgets/binding.dart
@@ -36,7 +36,7 @@ export 'dart:ui' show AppLifecycleState, Locale;
 ///
 /// ```dart
 /// class AppLifecycleReactor extends StatefulWidget {
-///   const AppLifecycleReactor({ Key key }) : super(key: key);
+///   const AppLifecycleReactor({ Object debugLocation, Key key }) : super(debugLocation: debugLocation, key: key);
 ///
 ///   @override
 ///   _AppLifecycleReactorState createState() => new _AppLifecycleReactorState();
@@ -113,7 +113,7 @@ abstract class WidgetsBindingObserver {
   ///
   /// ```dart
   /// class MetricsReactor extends StatefulWidget {
-  ///   const MetricsReactor({ Key key }) : super(key: key);
+  ///   const MetricsReactor({ Object debugLocation, Key key }) : super(debugLocation: debugLocation, key: key);
   ///
   ///   @override
   ///   _MetricsReactorState createState() => new _MetricsReactorState();
@@ -168,7 +168,7 @@ abstract class WidgetsBindingObserver {
   ///
   /// ```dart
   /// class TextScaleFactorReactor extends StatefulWidget {
-  ///   const TextScaleFactorReactor({ Key key }) : super(key: key);
+  ///   const TextScaleFactorReactor({ Object debugLocation, Key key }) : super(debugLocation: debugLocation, key: key);
   ///
   ///   @override
   ///   _TextScaleFactorReactorState createState() => new _TextScaleFactorReactorState();

--- a/packages/flutter/lib/src/widgets/container.dart
+++ b/packages/flutter/lib/src/widgets/container.dart
@@ -50,13 +50,13 @@ class DecoratedBox extends SingleChildRenderObjectWidget {
   /// The [decoration] and [position] arguments must not be null. By default the
   /// decoration paints behind the child.
   const DecoratedBox({
-    Key key,
+    Object debugLocation, Key key,
     @required this.decoration,
     this.position: DecorationPosition.background,
     Widget child
   }) : assert(decoration != null),
        assert(position != null),
-       super(key: key, child: child);
+       super(debugLocation: debugLocation, key: key, child: child);
 
   /// What decoration to paint.
   ///
@@ -236,7 +236,7 @@ class Container extends StatelessWidget {
   /// `decoration`, you can pass the color as the `color` argument to the
   /// `BoxDecoration`.
   Container({
-    Key key,
+    Object debugLocation, Key key,
     this.alignment,
     this.padding,
     Color color,
@@ -262,7 +262,7 @@ class Container extends StatelessWidget {
           ? constraints?.tighten(width: width, height: height)
             ?? new BoxConstraints.tightFor(width: width, height: height)
           : constraints,
-       super(key: key);
+       super(debugLocation: debugLocation, key: key);
 
   /// The [child] contained by the container.
   ///

--- a/packages/flutter/lib/src/widgets/dismissible.dart
+++ b/packages/flutter/lib/src/widgets/dismissible.dart
@@ -74,7 +74,7 @@ class Dismissible extends StatefulWidget {
   /// state of the dismissed item. Using keys causes the widgets to sync
   /// according to their keys and avoids this pitfall.
   const Dismissible({
-    @required Key key,
+    Object debugLocation, @required Key key,
     @required this.child,
     this.background,
     this.secondaryBackground,
@@ -85,7 +85,7 @@ class Dismissible extends StatefulWidget {
     this.dismissThresholds: const <DismissDirection, double>{},
   }) : assert(key != null),
        assert(secondaryBackground != null ? background != null : true),
-       super(key: key);
+       super(debugLocation: debugLocation, key: key);
 
   /// The widget below this widget in the tree.
   final Widget child;

--- a/packages/flutter/lib/src/widgets/drag_target.dart
+++ b/packages/flutter/lib/src/widgets/drag_target.dart
@@ -84,7 +84,7 @@ class Draggable<T> extends StatefulWidget {
   /// The [child] and [feedback] arguments must not be null. If
   /// [maxSimultaneousDrags] is non-null, it must be non-negative.
   const Draggable({
-    Key key,
+    Object debugLocation, Key key,
     @required this.child,
     @required this.feedback,
     this.data,
@@ -99,7 +99,7 @@ class Draggable<T> extends StatefulWidget {
   }) : assert(child != null),
        assert(feedback != null),
        assert(maxSimultaneousDrags == null || maxSimultaneousDrags >= 0),
-       super(key: key);
+       super(debugLocation: debugLocation, key: key);
 
 
   /// The data that will be dropped by this draggable.
@@ -219,7 +219,7 @@ class LongPressDraggable<T> extends Draggable<T> {
   /// The [child] and [feedback] arguments must not be null. If
   /// [maxSimultaneousDrags] is non-null, it must be non-negative.
   const LongPressDraggable({
-    Key key,
+    Object debugLocation, Key key,
     @required Widget child,
     @required Widget feedback,
     T data,
@@ -367,11 +367,11 @@ class DragTarget<T> extends StatefulWidget {
   ///
   /// The [builder] argument must not be null.
   const DragTarget({
-    Key key,
+    Object debugLocation, Key key,
     @required this.builder,
     this.onWillAccept,
     this.onAccept
-  }) : super(key: key);
+  }) : super(debugLocation: debugLocation, key: key);
 
   /// Called to build the contents of this widget.
   ///

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -152,7 +152,7 @@ class EditableText extends StatefulWidget {
   /// The [controller], [focusNode], [style], [cursorColor], and [textAlign]
   /// arguments must not be null.
   EditableText({
-    Key key,
+    Object debugLocation, Key key,
     @required this.controller,
     @required this.focusNode,
     this.obscureText: false,
@@ -187,7 +187,7 @@ class EditableText extends StatefulWidget {
                  ..addAll(inputFormatters ?? const Iterable<TextInputFormatter>.empty())
              )
            : inputFormatters,
-       super(key: key);
+       super(debugLocation: debugLocation, key: key);
 
   /// Controls the text being edited.
   final TextEditingController controller;
@@ -665,7 +665,7 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
 
 class _Editable extends LeafRenderObjectWidget {
   const _Editable({
-    Key key,
+    Object debugLocation, Key key,
     this.value,
     this.style,
     this.cursorColor,
@@ -683,7 +683,7 @@ class _Editable extends LeafRenderObjectWidget {
     this.onSelectionChanged,
     this.onCaretChanged,
   }) : assert(textDirection != null),
-       super(key: key);
+       super(debugLocation: debugLocation, key: key);
 
   final TextEditingValue value;
   final TextStyle style;

--- a/packages/flutter/lib/src/widgets/fade_in_image.dart
+++ b/packages/flutter/lib/src/widgets/fade_in_image.dart
@@ -63,7 +63,7 @@ class FadeInImage extends StatefulWidget {
   /// [fadeInDuration], [fadeInCurve], [alignment], [repeat], and
   /// [matchTextDirection] arguments must not be null.
   const FadeInImage({
-    Key key,
+    Object debugLocation, Key key,
     @required this.placeholder,
     @required this.image,
     this.fadeOutDuration: const Duration(milliseconds: 300),
@@ -85,7 +85,7 @@ class FadeInImage extends StatefulWidget {
        assert(alignment != null),
        assert(repeat != null),
        assert(matchTextDirection != null),
-       super(key: key);
+       super(debugLocation: debugLocation, key: key);
 
   /// Creates a widget that uses a placeholder image stored in memory while
   /// loading the final image from the network.
@@ -109,7 +109,7 @@ class FadeInImage extends StatefulWidget {
   ///  * [new Image.network], which has more details about loading images from
   ///    the network.
   FadeInImage.memoryNetwork({
-    Key key,
+    Object debugLocation, Key key,
     @required Uint8List placeholder,
     @required String image,
     double placeholderScale: 1.0,
@@ -137,7 +137,7 @@ class FadeInImage extends StatefulWidget {
        assert(matchTextDirection != null),
        placeholder = new MemoryImage(placeholder, scale: placeholderScale),
        image = new NetworkImage(image, scale: imageScale),
-       super(key: key);
+       super(debugLocation: debugLocation, key: key);
 
   /// Creates a widget that uses a placeholder image stored in an asset bundle
   /// while loading the final image from the network.
@@ -164,7 +164,7 @@ class FadeInImage extends StatefulWidget {
   ///  * [new Image.network], which has more details about loading images from
   ///    the network.
   FadeInImage.assetNetwork({
-    Key key,
+    Object debugLocation, Key key,
     @required String placeholder,
     @required String image,
     AssetBundle bundle,
@@ -194,7 +194,7 @@ class FadeInImage extends StatefulWidget {
        assert(repeat != null),
        assert(matchTextDirection != null),
        image = new NetworkImage(image, scale: imageScale),
-       super(key: key);
+       super(debugLocation: debugLocation, key: key);
 
   /// Image displayed while the target [image] is loading.
   final ImageProvider placeholder;

--- a/packages/flutter/lib/src/widgets/focus_scope.dart
+++ b/packages/flutter/lib/src/widgets/focus_scope.dart
@@ -10,11 +10,11 @@ import 'framework.dart';
 
 class _FocusScopeMarker extends InheritedWidget {
   const _FocusScopeMarker({
-    Key key,
+    Object debugLocation, Key key,
     @required this.node,
     Widget child,
   }) : assert(node != null),
-       super(key: key, child: child);
+       super(debugLocation: debugLocation, key: key, child: child);
 
   final FocusScopeNode node;
 
@@ -52,13 +52,13 @@ class FocusScope extends StatefulWidget {
   ///
   /// The [node] argument must not be null.
   const FocusScope({
-    Key key,
+    Object debugLocation, Key key,
     @required this.node,
     this.autofocus: false,
     this.child,
   }) : assert(node != null),
        assert(autofocus != null),
-       super(key: key);
+       super(debugLocation: debugLocation, key: key);
 
   /// Controls whether this scope is currently active.
   final FocusScopeNode node;

--- a/packages/flutter/lib/src/widgets/form.dart
+++ b/packages/flutter/lib/src/widgets/form.dart
@@ -22,12 +22,12 @@ class Form extends StatefulWidget {
   ///
   /// The [child] argument must not be null.
   const Form({
-    Key key,
+    Object debugLocation, Key key,
     @required this.child,
     this.autovalidate: false,
     this.onWillPop,
   }) : assert(child != null),
-       super(key: key);
+       super(debugLocation: debugLocation, key: key);
 
   /// Returns the closest [FormState] which encloses the given context.
   ///
@@ -137,13 +137,13 @@ class FormState extends State<Form> {
 
 class _FormScope extends InheritedWidget {
   const _FormScope({
-    Key key,
+    Object debugLocation, Key key,
     Widget child,
     FormState formState,
     int generation
   }) : _formState = formState,
        _generation = generation,
-       super(key: key, child: child);
+       super(debugLocation: debugLocation, key: key, child: child);
 
   final FormState _formState;
 
@@ -199,14 +199,14 @@ class FormField<T> extends StatefulWidget {
   ///
   /// The [builder] argument must not be null.
   const FormField({
-    Key key,
+    Object debugLocation, Key key,
     @required this.builder,
     this.onSaved,
     this.validator,
     this.initialValue,
     this.autovalidate: false,
   }) : assert(builder != null),
-       super(key: key);
+       super(debugLocation: debugLocation, key: key);
 
   /// An optional method to call with the final value when the form is saved via
   /// Form.save().

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -353,8 +353,11 @@ class TypeMatcher<T> {
 ///    particular configuration and ambient state.
 @immutable
 abstract class Widget extends DiagnosticableTree {
+  /// A kernel transformer will specificy this.
+  final Object debugLocation;
+
   /// Initializes [key] for subclasses.
-  const Widget({ this.key });
+  const Widget({ @required this.debugLocation, this.key });
 
   /// Controls how one widget replaces another widget in the tree.
   ///
@@ -478,7 +481,7 @@ abstract class Widget extends DiagnosticableTree {
 ///
 /// ```dart
 /// class GreenFrog extends StatelessWidget {
-///   const GreenFrog({ Key key }) : super(key: key);
+///   const GreenFrog({ Object debugLocation, Key key }) : super(debugLocation: debugLocation, key: key);
 ///
 ///   @override
 ///   Widget build(BuildContext context) {
@@ -497,7 +500,7 @@ abstract class Widget extends DiagnosticableTree {
 ///     Key key,
 ///     this.color: const Color(0xFF2DBD3A),
 ///     this.child,
-///   }) : super(key: key);
+///   }) : super(debugLocation: debugLocation, key: key);
 ///
 ///   final Color color;
 ///
@@ -523,7 +526,7 @@ abstract class Widget extends DiagnosticableTree {
 ///    be read by descendant widgets.
 abstract class StatelessWidget extends Widget {
   /// Initializes [key] for subclasses.
-  const StatelessWidget({ Key key }) : super(key: key);
+  const StatelessWidget({ @required Object debugLocation, Key key }) : super(debugLocation: debugLocation, key: key);
 
   /// Creates a [StatelessElement] to manage this widget's location in the tree.
   ///
@@ -685,7 +688,7 @@ abstract class StatelessWidget extends Widget {
 ///
 /// ```dart
 /// class YellowBird extends StatefulWidget {
-///   const YellowBird({ Key key }) : super(key: key);
+///   const YellowBird({ Object debugLocation, Key key }) : super(debugLocation: debugLocation, key: key);
 ///
 ///   @override
 ///   _YellowBirdState createState() => new _YellowBirdState();
@@ -713,7 +716,7 @@ abstract class StatelessWidget extends Widget {
 ///     Key key,
 ///     this.color: const Color(0xFFFFE306),
 ///     this.child,
-///   }) : super(key: key);
+///   }) : super(debugLocation: debugLocation, key: key);
 ///
 ///   final Color color;
 ///
@@ -754,7 +757,7 @@ abstract class StatelessWidget extends Widget {
 ///    be read by descendant widgets.
 abstract class StatefulWidget extends Widget {
   /// Initializes [key] for subclasses.
-  const StatefulWidget({ Key key }) : super(key: key);
+  const StatefulWidget({ @required Object debugLocation, Key key }) : super(debugLocation: debugLocation, key: key);
 
   /// Creates a [StatefulElement] to manage this widget's location in the tree.
   ///
@@ -1308,7 +1311,7 @@ abstract class State<T extends StatefulWidget> extends Diagnosticable {
 ///  * [Widget], for an overview of widgets in general.
 abstract class ProxyWidget extends Widget {
   /// Creates a widget that has exactly one child widget.
-  const ProxyWidget({ Key key, @required this.child }) : super(key: key);
+  const ProxyWidget({ Object debugLocation, Key key, @required this.child }) : super(debugLocation: debugLocation, key: key);
 
   /// The widget below this widget in the tree.
   final Widget child;
@@ -1338,7 +1341,7 @@ abstract class ProxyWidget extends Widget {
 ///     @required Widget child,
 ///   }) : assert(child != null),
 ///        assert(size != null),
-///        super(key: key, child: child);
+///        super(debugLocation: debugLocation, key: key, child: child);
 ///
 ///   final Size size;
 ///
@@ -1367,8 +1370,8 @@ abstract class ProxyWidget extends Widget {
 abstract class ParentDataWidget<T extends RenderObjectWidget> extends ProxyWidget {
   /// Abstract const constructor. This constructor enables subclasses to provide
   /// const constructors so that they can be used in const expressions.
-  const ParentDataWidget({ Key key, Widget child })
-    : super(key: key, child: child);
+  const ParentDataWidget({ Object debugLocation, Key key,Widget child })
+    : super(debugLocation: debugLocation, key: key, child: child);
 
   @override
   ParentDataElement<T> createElement() => new ParentDataElement<T>(this);
@@ -1467,7 +1470,7 @@ abstract class ParentDataWidget<T extends RenderObjectWidget> extends ProxyWidge
 ///     @required Widget child,
 ///   }) : assert(color != null),
 ///        assert(child != null),
-///        super(key: key, child: child);
+///        super(debugLocation: debugLocation, key: key, child: child);
 ///
 ///   final Color color;
 ///
@@ -1507,8 +1510,8 @@ abstract class ParentDataWidget<T extends RenderObjectWidget> extends ProxyWidge
 abstract class InheritedWidget extends ProxyWidget {
   /// Abstract const constructor. This constructor enables subclasses to provide
   /// const constructors so that they can be used in const expressions.
-  const InheritedWidget({ Key key, Widget child })
-    : super(key: key, child: child);
+  const InheritedWidget({ @required Object debugLocation, Key key,Widget child })
+    : super(debugLocation: debugLocation, key: key, child: child);
 
   @override
   InheritedElement createElement() => new InheritedElement(this);
@@ -1535,7 +1538,7 @@ abstract class InheritedWidget extends ProxyWidget {
 abstract class RenderObjectWidget extends Widget {
   /// Abstract const constructor. This constructor enables subclasses to provide
   /// const constructors so that they can be used in const expressions.
-  const RenderObjectWidget({ Key key }) : super(key: key);
+  const RenderObjectWidget({ Object debugLocation, Key key }) : super(debugLocation: debugLocation, key: key);
 
   /// RenderObjectWidgets always inflate to a [RenderObjectElement] subclass.
   @override
@@ -1577,7 +1580,7 @@ abstract class RenderObjectWidget extends Widget {
 abstract class LeafRenderObjectWidget extends RenderObjectWidget {
   /// Abstract const constructor. This constructor enables subclasses to provide
   /// const constructors so that they can be used in const expressions.
-  const LeafRenderObjectWidget({ Key key }) : super(key: key);
+  const LeafRenderObjectWidget({ Object debugLocation, Key key }) : super(debugLocation: debugLocation, key: key);
 
   @override
   LeafRenderObjectElement createElement() => new LeafRenderObjectElement(this);
@@ -1589,7 +1592,7 @@ abstract class LeafRenderObjectWidget extends RenderObjectWidget {
 abstract class SingleChildRenderObjectWidget extends RenderObjectWidget {
   /// Abstract const constructor. This constructor enables subclasses to provide
   /// const constructors so that they can be used in const expressions.
-  const SingleChildRenderObjectWidget({ Key key, this.child }) : super(key: key);
+  const SingleChildRenderObjectWidget({ Object debugLocation, Key key, this.child }) : super(debugLocation: debugLocation, key: key);
 
   /// The widget below this widget in the tree.
   final Widget child;
@@ -1607,10 +1610,10 @@ abstract class MultiChildRenderObjectWidget extends RenderObjectWidget {
   ///
   /// The [children] argument must not be null and must not contain any null
   /// objects.
-  MultiChildRenderObjectWidget({ Key key, this.children: const <Widget>[] })
+  MultiChildRenderObjectWidget({ Object debugLocation, Key key,this.children: const <Widget>[] })
     : assert(children != null),
       assert(!children.any((Widget child) => child == null)), // https://github.com/dart-lang/sdk/issues/29276
-      super(key: key);
+      super(debugLocation: debugLocation, key: key);
 
   /// The widgets below this widget in the tree.
   ///

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -317,6 +317,20 @@ class TypeMatcher<T> {
   bool check(dynamic object) => object is T;
 }
 
+/// Describes a location in a source file.
+///
+/// A Dart Kernel Transf
+class DebugLocation {
+  const DebugLocation({this.file, this.line, this.column});
+
+  final String file;
+  final int line;
+  final int column;
+
+  @override
+  String toString() => '$file:$line:$column';
+}
+
 /// Describes the configuration for an [Element].
 ///
 /// Widgets are the central class hierarchy in the Flutter framework. A widget

--- a/packages/flutter/lib/src/widgets/gesture_detector.dart
+++ b/packages/flutter/lib/src/widgets/gesture_detector.dart
@@ -137,7 +137,7 @@ class GestureDetector extends StatelessWidget {
   /// By default, gesture detectors contribute semantic information to the tree
   /// that is used by assistive technology.
   GestureDetector({
-    Key key,
+    Object debugLocation, Key key,
     this.child,
     this.onTapDown,
     this.onTapUp,
@@ -189,7 +189,7 @@ class GestureDetector extends StatelessWidget {
          }
          return true;
        }()),
-       super(key: key);
+       super(debugLocation: debugLocation, key: key);
 
   /// The widget below this widget in the tree.
   final Widget child;
@@ -451,14 +451,14 @@ class RawGestureDetector extends StatefulWidget {
   /// that is used by assistive technology. This can be controlled using
   /// [excludeFromSemantics].
   const RawGestureDetector({
-    Key key,
+    Object debugLocation, Key key,
     this.child,
     this.gestures: const <Type, GestureRecognizerFactory>{},
     this.behavior,
     this.excludeFromSemantics: false
   }) : assert(gestures != null),
        assert(excludeFromSemantics != null),
-       super(key: key);
+       super(debugLocation: debugLocation, key: key);
 
   /// The widget below this widget in the tree.
   final Widget child;
@@ -725,10 +725,10 @@ class RawGestureDetectorState extends State<RawGestureDetector> {
 
 class _GestureSemantics extends SingleChildRenderObjectWidget {
   const _GestureSemantics({
-    Key key,
+    Object debugLocation, Key key,
     Widget child,
     this.owner
-  }) : super(key: key, child: child);
+  }) : super(debugLocation: debugLocation, key: key, child: child);
 
   final RawGestureDetectorState owner;
 

--- a/packages/flutter/lib/src/widgets/grid_paper.dart
+++ b/packages/flutter/lib/src/widgets/grid_paper.dart
@@ -58,7 +58,7 @@ class _GridPaperPainter extends CustomPainter {
 class GridPaper extends StatelessWidget {
   /// Creates a widget that draws a rectilinear grid of 1-pixel-wide lines.
   const GridPaper({
-    Key key,
+    Object debugLocation, Key key,
     this.color: const Color(0x7FC3E8F3),
     this.interval: 100.0,
     this.divisions: 2,
@@ -66,7 +66,7 @@ class GridPaper extends StatelessWidget {
     this.child,
   }) : assert(divisions > 0, 'The "divisions" property must be greater than zero. If there were no divisions, the grid paper would not paint anything.'),
        assert(subdivisions > 0, 'The "subdivisions" property must be greater than zero. If there were no subdivisions, the grid paper would not paint anything.'),
-       super(key: key);
+       super(debugLocation: debugLocation, key: key);
 
   /// The color to draw the lines in the grid.
   ///

--- a/packages/flutter/lib/src/widgets/heroes.dart
+++ b/packages/flutter/lib/src/widgets/heroes.dart
@@ -78,13 +78,13 @@ class Hero extends StatefulWidget {
   ///
   /// The [tag] and [child] parameters must not be null.
   const Hero({
-    Key key,
+    Object debugLocation, Key key,
     @required this.tag,
     this.createRectTween,
     @required this.child,
   }) : assert(tag != null),
        assert(child != null),
-       super(key: key);
+       super(debugLocation: debugLocation, key: key);
 
   /// The identifier for this particular hero. If the tag of this hero matches
   /// the tag of a hero on a [PageRoute] that we're navigating to or from, then

--- a/packages/flutter/lib/src/widgets/icon.dart
+++ b/packages/flutter/lib/src/widgets/icon.dart
@@ -32,12 +32,12 @@ class Icon extends StatelessWidget {
   ///
   /// The [size] and [color] default to the value given by the current [IconTheme].
   const Icon(this.icon, {
-    Key key,
+    Object debugLocation, Key key,
     this.size,
     this.color,
     this.semanticLabel,
     this.textDirection,
-  }) : super(key: key);
+  }) : super(debugLocation: debugLocation, key: key);
 
   /// The icon to display. The available icons are described in [Icons].
   ///

--- a/packages/flutter/lib/src/widgets/icon_theme.dart
+++ b/packages/flutter/lib/src/widgets/icon_theme.dart
@@ -17,19 +17,19 @@ class IconTheme extends InheritedWidget {
   ///
   /// Both [data] and [child] arguments must not be null.
   const IconTheme({
-    Key key,
+    Object debugLocation, Key key,
     @required this.data,
     @required Widget child,
   }) : assert(data != null),
        assert(child != null),
-       super(key: key, child: child);
+       super(debugLocation: debugLocation, key: key, child: child);
 
   /// Creates an icon theme that controls the color, opacity, and size of
   /// descendant widgets, and merges in the current icon theme, if any.
   ///
   /// The [data] and [child] arguments must not be null.
   static Widget merge({
-    Key key,
+    Object debugLocation, Key key,
     @required IconThemeData data,
     @required Widget child,
   }) {

--- a/packages/flutter/lib/src/widgets/image.dart
+++ b/packages/flutter/lib/src/widgets/image.dart
@@ -111,7 +111,7 @@ class Image extends StatefulWidget {
   /// The [image], [alignment], [repeat], and [matchTextDirection] arguments
   /// must not be null.
   const Image({
-    Key key,
+    Object debugLocation, Key key,
     @required this.image,
     this.width,
     this.height,
@@ -128,7 +128,7 @@ class Image extends StatefulWidget {
        assert(alignment != null),
        assert(repeat != null),
        assert(matchTextDirection != null),
-       super(key: key);
+       super(debugLocation: debugLocation, key: key);
 
   /// Creates a widget that displays an [ImageStream] obtained from the network.
   ///
@@ -137,7 +137,7 @@ class Image extends StatefulWidget {
   ///
   /// All network images are cached regardless of HTTP headers.
   Image.network(String src, {
-    Key key,
+    Object debugLocation, Key key,
     double scale: 1.0,
     this.width,
     this.height,
@@ -155,7 +155,7 @@ class Image extends StatefulWidget {
        assert(alignment != null),
        assert(repeat != null),
        assert(matchTextDirection != null),
-       super(key: key);
+       super(debugLocation: debugLocation, key: key);
 
   /// Creates a widget that displays an [ImageStream] obtained from a [File].
   ///
@@ -164,7 +164,7 @@ class Image extends StatefulWidget {
   /// On Android, this may require the
   /// `android.permission.READ_EXTERNAL_STORAGE` permission.
   Image.file(File file, {
-    Key key,
+    Object debugLocation, Key key,
     double scale: 1.0,
     this.width,
     this.height,
@@ -181,7 +181,7 @@ class Image extends StatefulWidget {
        assert(alignment != null),
        assert(repeat != null),
        assert(matchTextDirection != null),
-       super(key: key);
+       super(debugLocation: debugLocation, key: key);
 
   /// Creates a widget that displays an [ImageStream] obtained from an asset
   /// bundle. The key for the image is given by the `name` argument.
@@ -294,7 +294,7 @@ class Image extends StatefulWidget {
   ///  * <https://flutter.io/assets-and-images/>, an introduction to assets in
   ///    Flutter.
   Image.asset(String name, {
-    Key key,
+    Object debugLocation, Key key,
     AssetBundle bundle,
     double scale,
     this.width,
@@ -314,13 +314,13 @@ class Image extends StatefulWidget {
        assert(alignment != null),
        assert(repeat != null),
        assert(matchTextDirection != null),
-       super(key: key);
+       super(debugLocation: debugLocation, key: key);
 
   /// Creates a widget that displays an [ImageStream] obtained from a [Uint8List].
   ///
   /// The [bytes], [scale], and [repeat] arguments must not be null.
   Image.memory(Uint8List bytes, {
-    Key key,
+    Object debugLocation, Key key,
     double scale: 1.0,
     this.width,
     this.height,
@@ -337,7 +337,7 @@ class Image extends StatefulWidget {
        assert(alignment != null),
        assert(repeat != null),
        assert(matchTextDirection != null),
-       super(key: key);
+       super(debugLocation: debugLocation, key: key);
 
   /// The image to display.
   final ImageProvider image;

--- a/packages/flutter/lib/src/widgets/image_icon.dart
+++ b/packages/flutter/lib/src/widgets/image_icon.dart
@@ -24,10 +24,10 @@ class ImageIcon extends StatelessWidget {
   ///
   /// The [size] and [color] default to the value given by the current [IconTheme].
   const ImageIcon(this.image, {
-    Key key,
+    Object debugLocation, Key key,
     this.size,
     this.color
-  }) : super(key: key);
+  }) : super(debugLocation: debugLocation, key: key);
 
   /// The image to display as the icon.
   ///

--- a/packages/flutter/lib/src/widgets/implicit_animations.dart
+++ b/packages/flutter/lib/src/widgets/implicit_animations.dart
@@ -196,12 +196,12 @@ abstract class ImplicitlyAnimatedWidget extends StatefulWidget {
   ///
   /// The [curve] and [duration] arguments must not be null.
   const ImplicitlyAnimatedWidget({
-    Key key,
+    Object debugLocation, Key key,
     this.curve: Curves.linear,
     @required this.duration
   }) : assert(curve != null),
        assert(duration != null),
-       super(key: key);
+       super(debugLocation: debugLocation, key: key);
 
   /// The curve to apply when animating the parameters of this container.
   final Curve curve;
@@ -353,7 +353,7 @@ class AnimatedContainer extends ImplicitlyAnimatedWidget {
   ///
   /// The [curve] and [duration] arguments must not be null.
   AnimatedContainer({
-    Key key,
+    Object debugLocation, Key key,
     this.alignment,
     this.padding,
     Color color,
@@ -381,7 +381,7 @@ class AnimatedContainer extends ImplicitlyAnimatedWidget {
           ? constraints?.tighten(width: width, height: height)
             ?? new BoxConstraints.tightFor(width: width, height: height)
           : constraints,
-       super(key: key, curve: curve, duration: duration);
+       super(debugLocation: debugLocation, key: key, curve: curve, duration: duration);
 
   /// The [child] contained by the container.
   ///
@@ -503,14 +503,14 @@ class AnimatedPadding extends ImplicitlyAnimatedWidget {
   ///
   /// The [padding], [curve], and [duration] arguments must not be null.
   AnimatedPadding({
-    Key key,
+    Object debugLocation, Key key,
     @required this.padding,
     this.child,
     Curve curve: Curves.linear,
     @required Duration duration,
   }) : assert(padding != null),
        assert(padding.isNonNegative),
-       super(key: key, curve: curve, duration: duration);
+       super(debugLocation: debugLocation, key: key, curve: curve, duration: duration);
 
   /// The amount of space by which to inset the child.
   final EdgeInsetsGeometry padding;
@@ -563,13 +563,13 @@ class AnimatedAlign extends ImplicitlyAnimatedWidget {
   ///
   /// The [alignment], [curve], and [duration] arguments must not be null.
   const AnimatedAlign({
-    Key key,
+    Object debugLocation, Key key,
     @required this.alignment,
     this.child,
     Curve curve: Curves.linear,
     @required Duration duration,
   }) : assert(alignment != null),
-       super(key: key, curve: curve, duration: duration);
+       super(debugLocation: debugLocation, key: key, curve: curve, duration: duration);
 
   /// How to align the child.
   ///
@@ -645,7 +645,7 @@ class AnimatedPositioned extends ImplicitlyAnimatedWidget {
   ///
   /// The [curve] and [duration] arguments must not be null.
   const AnimatedPositioned({
-    Key key,
+    Object debugLocation, Key key,
     @required this.child,
     this.left,
     this.top,
@@ -657,13 +657,13 @@ class AnimatedPositioned extends ImplicitlyAnimatedWidget {
     @required Duration duration,
   }) : assert(left == null || right == null || width == null),
        assert(top == null || bottom == null || height == null),
-      super(key: key, curve: curve, duration: duration);
+      super(debugLocation: debugLocation, key: key, curve: curve, duration: duration);
 
   /// Creates a widget that animates the rectangle it occupies implicitly.
   ///
   /// The [curve] and [duration] arguments must not be null.
   AnimatedPositioned.fromRect({
-    Key key,
+    Object debugLocation, Key key,
     this.child,
     Rect rect,
     Curve curve: Curves.linear,
@@ -674,7 +674,7 @@ class AnimatedPositioned extends ImplicitlyAnimatedWidget {
        height = rect.height,
        right = null,
        bottom = null,
-       super(key: key, curve: curve, duration: duration);
+       super(debugLocation: debugLocation, key: key, curve: curve, duration: duration);
 
   /// The widget below this widget in the tree.
   final Widget child;
@@ -783,7 +783,7 @@ class AnimatedPositionedDirectional extends ImplicitlyAnimatedWidget {
   ///
   /// The [curve] and [duration] arguments must not be null.
   const AnimatedPositionedDirectional({
-    Key key,
+    Object debugLocation, Key key,
     @required this.child,
     this.start,
     this.top,
@@ -795,7 +795,7 @@ class AnimatedPositionedDirectional extends ImplicitlyAnimatedWidget {
     @required Duration duration,
   }) : assert(start == null || end == null || width == null),
        assert(top == null || bottom == null || height == null),
-      super(key: key, curve: curve, duration: duration);
+      super(debugLocation: debugLocation, key: key, curve: curve, duration: duration);
 
   /// The widget below this widget in the tree.
   final Widget child;
@@ -895,13 +895,13 @@ class AnimatedOpacity extends ImplicitlyAnimatedWidget {
   /// The [opacity] argument must not be null and must be between 0.0 and 1.0,
   /// inclusive. The [curve] and [duration] arguments must not be null.
   const AnimatedOpacity({
-    Key key,
+    Object debugLocation, Key key,
     this.child,
     @required this.opacity,
     Curve curve: Curves.linear,
     @required Duration duration,
   }) : assert(opacity != null && opacity >= 0.0 && opacity <= 1.0),
-       super(key: key, curve: curve, duration: duration);
+       super(debugLocation: debugLocation, key: key, curve: curve, duration: duration);
 
   /// The widget below this widget in the tree.
   final Widget child;
@@ -954,7 +954,7 @@ class AnimatedDefaultTextStyle extends ImplicitlyAnimatedWidget {
   /// The [child], [style], [softWrap], [overflow], [curve], and [duration]
   /// arguments must not be null.
   const AnimatedDefaultTextStyle({
-    Key key,
+    Object debugLocation, Key key,
     @required this.child,
     @required this.style,
     this.textAlign,
@@ -968,7 +968,7 @@ class AnimatedDefaultTextStyle extends ImplicitlyAnimatedWidget {
        assert(softWrap != null),
        assert(overflow != null),
        assert(maxLines == null || maxLines > 0),
-       super(key: key, curve: curve, duration: duration);
+       super(debugLocation: debugLocation, key: key, curve: curve, duration: duration);
 
   /// The widget below this widget in the tree.
   final Widget child;
@@ -1059,7 +1059,7 @@ class AnimatedPhysicalModel extends ImplicitlyAnimatedWidget {
   ///
   /// Animating [shadowColor] is optional and is controlled by the [animateShadowColor] flag.
   const AnimatedPhysicalModel({
-    Key key,
+    Object debugLocation, Key key,
     @required this.child,
     @required this.shape,
     this.borderRadius: BorderRadius.zero,
@@ -1078,7 +1078,7 @@ class AnimatedPhysicalModel extends ImplicitlyAnimatedWidget {
        assert(shadowColor != null),
        assert(animateColor != null),
        assert(animateShadowColor != null),
-       super(key: key, curve: curve, duration: duration);
+       super(debugLocation: debugLocation, key: key, curve: curve, duration: duration);
 
   /// The widget below this widget in the tree.
   final Widget child;

--- a/packages/flutter/lib/src/widgets/layout_builder.dart
+++ b/packages/flutter/lib/src/widgets/layout_builder.dart
@@ -33,10 +33,10 @@ class LayoutBuilder extends RenderObjectWidget {
   ///
   /// The [builder] argument must not be null.
   const LayoutBuilder({
-    Key key,
+    Object debugLocation, Key key,
     @required this.builder
   }) : assert(builder != null),
-       super(key: key);
+       super(debugLocation: debugLocation, key: key);
 
   /// Called at layout time to construct the widget tree. The builder must not
   /// return null.

--- a/packages/flutter/lib/src/widgets/localizations.dart
+++ b/packages/flutter/lib/src/widgets/localizations.dart
@@ -221,14 +221,14 @@ class DefaultWidgetsLocalizations implements WidgetsLocalizations {
 
 class _LocalizationsScope extends InheritedWidget {
   const _LocalizationsScope ({
-    Key key,
+    Object debugLocation, Key key,
     @required this.locale,
     @required this.localizationsState,
     @required this.typeToResources,
     Widget child,
   }) : assert(localizationsState != null),
        assert(typeToResources != null),
-       super(key: key, child: child);
+       super(debugLocation: debugLocation, key: key, child: child);
 
   final Locale locale;
   final _LocalizationsState localizationsState;
@@ -332,14 +332,14 @@ class _LocalizationsScope extends InheritedWidget {
 class Localizations extends StatefulWidget {
   /// Create a widget from which localizations (like translated strings) can be obtained.
   Localizations({
-    Key key,
+    Object debugLocation, Key key,
     @required this.locale,
     @required this.delegates,
     this.child,
   }) : assert(locale != null),
        assert(delegates != null),
        assert(delegates.any((LocalizationsDelegate<dynamic> delegate) => delegate is LocalizationsDelegate<WidgetsLocalizations>)),
-       super(key: key);
+       super(debugLocation: debugLocation, key: key);
 
   /// Overrides the inherited [Locale] or [LocalizationsDelegate]s for `child`.
   ///
@@ -369,7 +369,7 @@ class Localizations extends StatefulWidget {
   /// entire app, specify [WidgetsApp.locale] or [WidgetsApp.localizationsDelegates]
   /// (or specify the same parameters for [MaterialApp]).
   factory Localizations.override({
-    Key key,
+    Object debugLocation, Key key,
     @required BuildContext context,
     Locale locale,
     List<LocalizationsDelegate<dynamic>> delegates,

--- a/packages/flutter/lib/src/widgets/media_query.dart
+++ b/packages/flutter/lib/src/widgets/media_query.dart
@@ -225,12 +225,12 @@ class MediaQuery extends InheritedWidget {
   ///
   /// The [data] and [child] arguments must not be null.
   const MediaQuery({
-    Key key,
+    Object debugLocation, Key key,
     @required this.data,
     @required Widget child,
   }) : assert(child != null),
        assert(data != null),
-       super(key: key, child: child);
+       super(debugLocation: debugLocation, key: key, child: child);
 
   /// Creates a new [MediaQuery] that inherits from the ambient [MediaQuery] from
   /// the given context, but removes the specified paddings.
@@ -254,7 +254,7 @@ class MediaQuery extends InheritedWidget {
   ///  * [SafeArea], which both removes the padding from the [MediaQuery] and
   ///    adds a [Padding] widget.
   factory MediaQuery.removePadding({
-    Key key,
+    Object debugLocation, Key key,
     @required BuildContext context,
     bool removeLeft: false,
     bool removeTop: false,

--- a/packages/flutter/lib/src/widgets/modal_barrier.dart
+++ b/packages/flutter/lib/src/widgets/modal_barrier.dart
@@ -28,10 +28,10 @@ import 'transitions.dart';
 class ModalBarrier extends StatelessWidget {
   /// Creates a widget that blocks user interaction.
   const ModalBarrier({
-    Key key,
+    Object debugLocation, Key key,
     this.color,
     this.dismissible: true
-  }) : super(key: key);
+  }) : super(debugLocation: debugLocation, key: key);
 
   /// If non-null, fill the barrier with this color.
   ///
@@ -97,10 +97,10 @@ class ModalBarrier extends StatelessWidget {
 class AnimatedModalBarrier extends AnimatedWidget {
   /// Creates a widget that blocks user interaction.
   const AnimatedModalBarrier({
-    Key key,
+    Object debugLocation, Key key,
     Animation<Color> color,
     this.dismissible: true
-  }) : super(key: key, listenable: color);
+  }) : super(debugLocation: debugLocation, key: key, listenable: color);
 
   /// If non-null, fill the barrier with this color.
   ///

--- a/packages/flutter/lib/src/widgets/navigation_toolbar.dart
+++ b/packages/flutter/lib/src/widgets/navigation_toolbar.dart
@@ -27,7 +27,7 @@ class NavigationToolbar extends StatelessWidget {
   /// Creates a widget that lays out its children in a manner suitable for a
   /// toolbar.
   const NavigationToolbar({
-    Key key,
+    Object debugLocation, Key key,
     this.leading,
     this.middle,
     this.trailing,
@@ -35,7 +35,7 @@ class NavigationToolbar extends StatelessWidget {
     this.middleSpacing: kMiddleSpacing,
   }) : assert(centerMiddle != null),
        assert(middleSpacing != null),
-       super(key: key);
+       super(debugLocation: debugLocation, key: key);
 
   /// The default spacing around the [middle] widget in dp.
   static const double kMiddleSpacing = 16.0;

--- a/packages/flutter/lib/src/widgets/navigator.dart
+++ b/packages/flutter/lib/src/widgets/navigator.dart
@@ -476,13 +476,13 @@ class Navigator extends StatefulWidget {
   ///
   /// The [onGenerateRoute] argument must not be null.
   const Navigator({
-    Key key,
+    Object debugLocation, Key key,
     this.initialRoute,
     @required this.onGenerateRoute,
     this.onUnknownRoute,
     this.observers: const <NavigatorObserver>[]
   }) : assert(onGenerateRoute != null),
-       super(key: key);
+       super(debugLocation: debugLocation, key: key);
 
   /// The name of the first route to show.
   ///

--- a/packages/flutter/lib/src/widgets/nested_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/nested_scroll_view.dart
@@ -37,7 +37,7 @@ class NestedScrollView extends StatefulWidget {
   ///
   /// The [reverse], [headerSliverBuilder], and [body] arguments must not be null.
   const NestedScrollView({
-    Key key,
+    Object debugLocation, Key key,
     this.controller,
     this.scrollDirection: Axis.vertical,
     this.reverse: false,
@@ -48,7 +48,7 @@ class NestedScrollView extends StatefulWidget {
        assert(reverse != null),
        assert(headerSliverBuilder != null),
        assert(body != null),
-       super(key: key);
+       super(debugLocation: debugLocation, key: key);
 
   /// An object that can be used to control the position to which the outer
   /// scroll view is scrolled.

--- a/packages/flutter/lib/src/widgets/notification_listener.dart
+++ b/packages/flutter/lib/src/widgets/notification_listener.dart
@@ -91,10 +91,10 @@ abstract class Notification {
 class NotificationListener<T extends Notification> extends StatelessWidget {
   /// Creates a widget that listens for notifications.
   const NotificationListener({
-    Key key,
+    Object debugLocation, Key key,
     @required this.child,
     this.onNotification,
-  }) : super(key: key);
+  }) : super(debugLocation: debugLocation, key: key);
 
   /// The widget directly below this widget in the tree.
   ///

--- a/packages/flutter/lib/src/widgets/orientation_builder.dart
+++ b/packages/flutter/lib/src/widgets/orientation_builder.dart
@@ -29,10 +29,10 @@ class OrientationBuilder extends StatelessWidget {
   ///
   /// The [builder] argument must not be null.
   const OrientationBuilder({
-    Key key,
+    Object debugLocation, Key key,
     @required this.builder,
   }) : assert(builder != null),
-       super(key: key);
+       super(debugLocation: debugLocation, key: key);
 
   /// Builds the widgets below this widget given this widget's orientation.
   ///

--- a/packages/flutter/lib/src/widgets/overlay.dart
+++ b/packages/flutter/lib/src/widgets/overlay.dart
@@ -154,9 +154,9 @@ class OverlayEntry {
 }
 
 class _OverlayEntry extends StatefulWidget {
-  _OverlayEntry(this.entry)
+  _OverlayEntry(this.entry, {Object debugLocation})
     : assert(entry != null),
-      super(key: entry._key);
+      super(key: entry._key, debugLocation: debugLocation);
 
   final OverlayEntry entry;
 
@@ -201,10 +201,10 @@ class Overlay extends StatefulWidget {
   /// Rather than creating an overlay, consider using the overlay that is
   /// created by the [WidgetsApp] or the [MaterialApp] for the application.
   const Overlay({
-    Key key,
+    Object debugLocation, Key key,
     this.initialEntries: const <OverlayEntry>[]
   }) : assert(initialEntries != null),
-       super(key: key);
+       super(debugLocation: debugLocation, key: key);
 
   /// The entries to include in the overlay initially.
   ///

--- a/packages/flutter/lib/src/widgets/overscroll_indicator.dart
+++ b/packages/flutter/lib/src/widgets/overscroll_indicator.dart
@@ -40,7 +40,7 @@ class GlowingOverscrollIndicator extends StatefulWidget {
   /// The [showLeading], [showTrailing], [axisDirection], [color], and
   /// [notificationPredicate] arguments must not be null.
   const GlowingOverscrollIndicator({
-    Key key,
+    Object debugLocation, Key key,
     this.showLeading: true,
     this.showTrailing: true,
     @required this.axisDirection,
@@ -52,7 +52,7 @@ class GlowingOverscrollIndicator extends StatefulWidget {
        assert(axisDirection != null),
        assert(color != null),
        assert(notificationPredicate != null),
-       super(key: key);
+       super(debugLocation: debugLocation, key: key);
 
   /// Whether to show the overscroll glow on the side with negative scroll
   /// offsets.

--- a/packages/flutter/lib/src/widgets/page_storage.dart
+++ b/packages/flutter/lib/src/widgets/page_storage.dart
@@ -139,11 +139,11 @@ class PageStorage extends StatelessWidget {
   ///
   /// The [bucket] argument must not be null.
   const PageStorage({
-    Key key,
+    Object debugLocation, Key key,
     @required this.bucket,
     @required this.child
   }) : assert(bucket != null),
-       super(key: key);
+       super(debugLocation: debugLocation, key: key);
 
   /// The widget below this widget in the tree.
   final Widget child;

--- a/packages/flutter/lib/src/widgets/page_view.dart
+++ b/packages/flutter/lib/src/widgets/page_view.dart
@@ -363,7 +363,7 @@ class PageView extends StatefulWidget {
   /// child that could possibly be displayed in the page view, instead of just
   /// those children that are actually visible.
   PageView({
-    Key key,
+    Object debugLocation, Key key,
     this.scrollDirection: Axis.horizontal,
     this.reverse: false,
     PageController controller,
@@ -373,7 +373,7 @@ class PageView extends StatefulWidget {
     List<Widget> children: const <Widget>[],
   }) : controller = controller ?? _defaultPageController,
        childrenDelegate = new SliverChildListDelegate(children),
-       super(key: key);
+       super(debugLocation: debugLocation, key: key);
 
   /// Creates a scrollable list that works page by page using widgets that are
   /// created on demand.
@@ -388,7 +388,7 @@ class PageView extends StatefulWidget {
   /// [itemBuilder] will be called only with indices greater than or equal to
   /// zero and less than [itemCount].
   PageView.builder({
-    Key key,
+    Object debugLocation, Key key,
     this.scrollDirection: Axis.horizontal,
     this.reverse: false,
     PageController controller,
@@ -399,12 +399,12 @@ class PageView extends StatefulWidget {
     int itemCount,
   }) : controller = controller ?? _defaultPageController,
        childrenDelegate = new SliverChildBuilderDelegate(itemBuilder, childCount: itemCount),
-       super(key: key);
+       super(debugLocation: debugLocation, key: key);
 
   /// Creates a scrollable list that works page by page with a custom child
   /// model.
   PageView.custom({
-    Key key,
+    Object debugLocation, Key key,
     this.scrollDirection: Axis.horizontal,
     this.reverse: false,
     PageController controller,
@@ -414,7 +414,7 @@ class PageView extends StatefulWidget {
     @required this.childrenDelegate,
   }) : assert(childrenDelegate != null),
        controller = controller ?? _defaultPageController,
-       super(key: key);
+       super(debugLocation: debugLocation, key: key);
 
   /// The axis along which the page view scrolls.
   ///

--- a/packages/flutter/lib/src/widgets/performance_overlay.dart
+++ b/packages/flutter/lib/src/widgets/performance_overlay.dart
@@ -28,15 +28,15 @@ class PerformanceOverlay extends LeafRenderObjectWidget {
   /// mask is created by shifting 1 by the index of the specific
   /// [PerformanceOverlayOption] to enable.
   const PerformanceOverlay({
-    Key key,
+    Object debugLocation, Key key,
     this.optionsMask: 0,
     this.rasterizerThreshold: 0,
     this.checkerboardRasterCacheImages: false,
     this.checkerboardOffscreenLayers: false,
-  }) : super(key: key);
+  }) : super(debugLocation: debugLocation, key: key);
 
   /// Create a performance overlay that displays all available statistics
-  PerformanceOverlay.allEnabled({ Key key,
+  PerformanceOverlay.allEnabled({ Object debugLocation, Key key,
                                   this.rasterizerThreshold: 0,
                                   this.checkerboardRasterCacheImages: false,
                                   this.checkerboardOffscreenLayers: false })
@@ -46,7 +46,7 @@ class PerformanceOverlay extends LeafRenderObjectWidget {
         1 << PerformanceOverlayOption.displayEngineStatistics.index |
         1 << PerformanceOverlayOption.visualizeEngineStatistics.index
       ),
-      super(key: key);
+      super(debugLocation: debugLocation, key: key);
 
   /// The mask is created by shifting 1 by the index of the specific
   /// [PerformanceOverlayOption] to enable.

--- a/packages/flutter/lib/src/widgets/placeholder.dart
+++ b/packages/flutter/lib/src/widgets/placeholder.dart
@@ -52,12 +52,12 @@ class _PlaceholderPainter extends CustomPainter {
 class Placeholder extends StatelessWidget {
   /// Creates a widget which draws a box.
   const Placeholder({
-    Key key,
+    Object debugLocation, Key key,
     this.color: const Color(0xFF455A64), // Blue Grey 700
     this.strokeWidth: 2.0,
     this.fallbackWidth: 400.0,
     this.fallbackHeight: 400.0,
-  }) : super(key: key);
+  }) : super(debugLocation: debugLocation, key: key);
 
   /// The color to draw the placeholder box.
   final Color color;

--- a/packages/flutter/lib/src/widgets/preferred_size.dart
+++ b/packages/flutter/lib/src/widgets/preferred_size.dart
@@ -44,10 +44,10 @@ abstract class PreferredSizeWidget implements Widget {
 class PreferredSize extends StatelessWidget implements PreferredSizeWidget {
   /// Creates a widget that has a preferred size.
   const PreferredSize({
-    Key key,
+    Object debugLocation, Key key,
     @required this.child,
     @required this.preferredSize,
-  }) : super(key: key);
+  }) : super(debugLocation: debugLocation, key: key);
 
   /// The widget below this widget in the tree.
   final Widget child;

--- a/packages/flutter/lib/src/widgets/primary_scroll_controller.dart
+++ b/packages/flutter/lib/src/widgets/primary_scroll_controller.dart
@@ -19,18 +19,18 @@ import 'scroll_controller.dart';
 class PrimaryScrollController extends InheritedWidget {
   /// Creates a widget that associates a [ScrollController] with a subtree.
   const PrimaryScrollController({
-    Key key,
+    Object debugLocation, Key key,
     @required this.controller,
     @required Widget child
   }) : assert(controller != null),
-       super(key: key, child: child);
+       super(debugLocation: debugLocation, key: key, child: child);
 
   /// Creates a subtree without an associated [ScrollController].
   const PrimaryScrollController.none({
-    Key key,
+    Object debugLocation, Key key,
     @required Widget child
   }) : controller = null,
-       super(key: key, child: child);
+       super(debugLocation: debugLocation, key: key, child: child);
 
   /// The [ScrollController] associated with the subtree.
   ///

--- a/packages/flutter/lib/src/widgets/raw_keyboard_listener.dart
+++ b/packages/flutter/lib/src/widgets/raw_keyboard_listener.dart
@@ -29,13 +29,13 @@ class RawKeyboardListener extends StatefulWidget {
   /// For text entry, consider using a [EditableText], which integrates with
   /// on-screen keyboards and input method editors (IMEs).
   const RawKeyboardListener({
-    Key key,
+    Object debugLocation, Key key,
     @required this.focusNode,
     @required this.onKey,
     @required this.child,
   }) : assert(focusNode != null),
        assert(child != null),
-       super(key: key);
+       super(debugLocation: debugLocation, key: key);
 
   /// Controls whether this widget has keyboard focus.
   final FocusNode focusNode;

--- a/packages/flutter/lib/src/widgets/routes.dart
+++ b/packages/flutter/lib/src/widgets/routes.dart
@@ -370,7 +370,7 @@ abstract class LocalHistoryRoute<T> extends Route<T> {
 
 class _ModalScopeStatus extends InheritedWidget {
   const _ModalScopeStatus({
-    Key key,
+    Object debugLocation, Key key,
     @required this.isCurrent,
     @required this.canPop,
     @required this.route,
@@ -379,7 +379,7 @@ class _ModalScopeStatus extends InheritedWidget {
        assert(canPop != null),
        assert(route != null),
        assert(child != null),
-       super(key: key, child: child);
+       super(debugLocation: debugLocation, key: key, child: child);
 
   final bool isCurrent;
   final bool canPop;
@@ -402,10 +402,10 @@ class _ModalScopeStatus extends InheritedWidget {
 
 class _ModalScope extends StatefulWidget {
   const _ModalScope({
-    Key key,
+    Object debugLocation, Key key,
     this.route,
     @required this.page,
-  }) : super(key: key);
+  }) : super(debugLocation: debugLocation, key: key);
 
   final ModalRoute<dynamic> route;
   final Widget page;

--- a/packages/flutter/lib/src/widgets/safe_area.dart
+++ b/packages/flutter/lib/src/widgets/safe_area.dart
@@ -29,7 +29,7 @@ class SafeArea extends StatelessWidget {
   ///
   /// The [left], [top], [right], and [bottom] arguments must not be null.
   const SafeArea({
-    Key key,
+    Object debugLocation, Key key,
     this.left: true,
     this.top: true,
     this.right: true,
@@ -39,7 +39,7 @@ class SafeArea extends StatelessWidget {
        assert(top != null),
        assert(right != null),
        assert(bottom != null),
-       super(key: key);
+       super(debugLocation: debugLocation, key: key);
 
   /// Whether to avoid system intrusions on the left.
   final bool left;

--- a/packages/flutter/lib/src/widgets/scroll_configuration.dart
+++ b/packages/flutter/lib/src/widgets/scroll_configuration.dart
@@ -87,10 +87,10 @@ class ScrollConfiguration extends InheritedWidget {
   ///
   /// The [behavior] and [child] arguments must not be null.
   const ScrollConfiguration({
-    Key key,
+    Object debugLocation, Key key,
     @required this.behavior,
     @required Widget child,
-  }) : super(key: key, child: child);
+  }) : super(debugLocation: debugLocation, key: key, child: child);
 
   /// How [Scrollable] widgets that are descendants of [child] should behave.
   final ScrollBehavior behavior;

--- a/packages/flutter/lib/src/widgets/scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/scroll_view.dart
@@ -50,7 +50,7 @@ abstract class ScrollView extends StatelessWidget {
   ///
   /// If the [primary] argument is true, the [controller] must be null.
   ScrollView({
-    Key key,
+    Object debugLocation, Key key,
     this.scrollDirection: Axis.vertical,
     this.reverse: false,
     this.controller,
@@ -65,7 +65,7 @@ abstract class ScrollView extends StatelessWidget {
        ),
        primary = primary ?? controller == null && scrollDirection == Axis.vertical,
        physics = physics ?? (primary == true || (primary == null && controller == null && scrollDirection == Axis.vertical) ? const AlwaysScrollableScrollPhysics() : null),
-       super(key: key);
+       super(debugLocation: debugLocation, key: key);
 
   /// The axis along which the scroll view scrolls.
   ///
@@ -311,7 +311,7 @@ class CustomScrollView extends ScrollView {
   ///
   /// If the [primary] argument is true, the [controller] must be null.
   CustomScrollView({
-    Key key,
+    Object debugLocation, Key key,
     Axis scrollDirection: Axis.vertical,
     bool reverse: false,
     ScrollController controller,
@@ -349,7 +349,7 @@ abstract class BoxScrollView extends ScrollView {
   ///
   /// If the [primary] argument is true, the [controller] must be null.
   BoxScrollView({
-    Key key,
+    Object debugLocation, Key key,
     Axis scrollDirection: Axis.vertical,
     bool reverse: false,
     ScrollController controller,
@@ -568,7 +568,7 @@ class ListView extends BoxScrollView {
   /// [SliverChildListDelegate.addRepaintBoundaries] property. Both must not be
   /// null.
   ListView({
-    Key key,
+    Object debugLocation, Key key,
     Axis scrollDirection: Axis.vertical,
     bool reverse: false,
     ScrollController controller,
@@ -620,7 +620,7 @@ class ListView extends BoxScrollView {
   /// [SliverChildBuilderDelegate.addRepaintBoundaries] property. Both must not
   /// be null.
   ListView.builder({
-    Key key,
+    Object debugLocation, Key key,
     Axis scrollDirection: Axis.vertical,
     bool reverse: false,
     ScrollController controller,
@@ -654,7 +654,7 @@ class ListView extends BoxScrollView {
   /// For example, a custom child model can control the algorithm used to
   /// estimate the size of children that are not actually visible.
   ListView.custom({
-    Key key,
+    Object debugLocation, Key key,
     Axis scrollDirection: Axis.vertical,
     bool reverse: false,
     ScrollController controller,
@@ -852,7 +852,7 @@ class GridView extends BoxScrollView {
   /// [SliverChildListDelegate.addRepaintBoundaries] property. Both must not be
   /// null.
   GridView({
-    Key key,
+    Object debugLocation, Key key,
     Axis scrollDirection: Axis.vertical,
     bool reverse: false,
     ScrollController controller,
@@ -901,7 +901,7 @@ class GridView extends BoxScrollView {
   /// [SliverChildBuilderDelegate.addRepaintBoundaries] property. Both must not
   /// be null.
   GridView.builder({
-    Key key,
+    Object debugLocation, Key key,
     Axis scrollDirection: Axis.vertical,
     bool reverse: false,
     ScrollController controller,
@@ -940,7 +940,7 @@ class GridView extends BoxScrollView {
   ///
   /// The [gridDelegate] and [childrenDelegate] arguments must not be null.
   GridView.custom({
-    Key key,
+    Object debugLocation, Key key,
     Axis scrollDirection: Axis.vertical,
     bool reverse: false,
     ScrollController controller,
@@ -978,7 +978,7 @@ class GridView extends BoxScrollView {
   ///
   ///  * [new SliverGrid.count], the equivalent constructor for [SliverGrid].
   GridView.count({
-    Key key,
+    Object debugLocation, Key key,
     Axis scrollDirection: Axis.vertical,
     bool reverse: false,
     ScrollController controller,
@@ -1029,7 +1029,7 @@ class GridView extends BoxScrollView {
   ///
   ///  * [new SliverGrid.extent], the equivalent constructor for [SliverGrid].
   GridView.extent({
-    Key key,
+    Object debugLocation, Key key,
     Axis scrollDirection: Axis.vertical,
     bool reverse: false,
     ScrollController controller,

--- a/packages/flutter/lib/src/widgets/scrollable.dart
+++ b/packages/flutter/lib/src/widgets/scrollable.dart
@@ -74,14 +74,14 @@ class Scrollable extends StatefulWidget {
   ///
   /// The [axisDirection] and [viewportBuilder] arguments must not be null.
   const Scrollable({
-    Key key,
+    Object debugLocation, Key key,
     this.axisDirection: AxisDirection.down,
     this.controller,
     this.physics,
     @required this.viewportBuilder,
   }) : assert(axisDirection != null),
        assert(viewportBuilder != null),
-       super (key: key);
+       super(debugLocation: debugLocation, key: key);
 
   /// The direction in which this widget scrolls.
   ///
@@ -207,13 +207,13 @@ class Scrollable extends StatefulWidget {
 // ScrollableState.build() always rebuilds its _ScrollableScope.
 class _ScrollableScope extends InheritedWidget {
   const _ScrollableScope({
-    Key key,
+    Object debugLocation, Key key,
     @required this.scrollable,
     @required this.position,
     @required Widget child
   }) : assert(scrollable != null),
        assert(child != null),
-       super(key: key, child: child);
+       super(debugLocation: debugLocation, key: key, child: child);
 
   final ScrollableState scrollable;
   final ScrollPosition position;

--- a/packages/flutter/lib/src/widgets/semantics_debugger.dart
+++ b/packages/flutter/lib/src/widgets/semantics_debugger.dart
@@ -23,7 +23,7 @@ class SemanticsDebugger extends StatefulWidget {
   /// Creates a widget that visualizes the semantics for the child.
   ///
   /// The [child] argument must not be null.
-  const SemanticsDebugger({ Key key, this.child }) : super(key: key);
+  const SemanticsDebugger({ Object debugLocation, Key key, this.child }) : super(debugLocation: debugLocation, key: key);
 
   /// The widget below this widget in the tree.
   final Widget child;

--- a/packages/flutter/lib/src/widgets/single_child_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/single_child_scroll_view.dart
@@ -41,7 +41,7 @@ import 'scrollable.dart';
 class SingleChildScrollView extends StatelessWidget {
   /// Creates a box in which a single widget can be scrolled.
   SingleChildScrollView({
-    Key key,
+    Object debugLocation, Key key,
     this.scrollDirection: Axis.vertical,
     this.reverse: false,
     this.padding,
@@ -55,7 +55,7 @@ class SingleChildScrollView extends StatelessWidget {
           'You cannot both set primary to true and pass an explicit controller.'
        ),
        primary = primary ?? controller == null && scrollDirection == Axis.vertical,
-       super(key: key);
+       super(debugLocation: debugLocation, key: key);
 
   /// The axis along which the scroll view scrolls.
   ///
@@ -147,12 +147,12 @@ class SingleChildScrollView extends StatelessWidget {
 
 class _SingleChildViewport extends SingleChildRenderObjectWidget {
   const _SingleChildViewport({
-    Key key,
+    Object debugLocation, Key key,
     this.axisDirection: AxisDirection.down,
     this.offset,
     Widget child,
   }) : assert(axisDirection != null),
-       super(key: key, child: child);
+       super(debugLocation: debugLocation, key: key, child: child);
 
   final AxisDirection axisDirection;
   final ViewportOffset offset;

--- a/packages/flutter/lib/src/widgets/size_changed_layout_notifier.dart
+++ b/packages/flutter/lib/src/widgets/size_changed_layout_notifier.dart
@@ -54,9 +54,9 @@ class SizeChangedLayoutNotifier extends SingleChildRenderObjectWidget {
   /// Creates a [SizeChangedLayoutNotifier] that dispatches layout changed
   /// notifications when [child] changes layout size.
   const SizeChangedLayoutNotifier({
-    Key key,
+    Object debugLocation, Key key,
     Widget child
-  }) : super(key: key, child: child);
+  }) : super(debugLocation: debugLocation, key: key, child: child);
 
   @override
   _RenderSizeChangedWithCallback createRenderObject(BuildContext context) {

--- a/packages/flutter/lib/src/widgets/sliver.dart
+++ b/packages/flutter/lib/src/widgets/sliver.dart
@@ -308,10 +308,10 @@ class SliverChildListDelegate extends SliverChildDelegate {
 abstract class SliverMultiBoxAdaptorWidget extends RenderObjectWidget {
   /// Initializes fields for subclasses.
   const SliverMultiBoxAdaptorWidget({
-    Key key,
+    Object debugLocation, Key key,
     @required this.delegate,
   }) : assert(delegate != null),
-       super(key: key);
+       super(debugLocation: debugLocation, key: key);
 
   /// The delegate that provides the children for this widget.
   ///
@@ -388,9 +388,9 @@ abstract class SliverMultiBoxAdaptorWidget extends RenderObjectWidget {
 class SliverList extends SliverMultiBoxAdaptorWidget {
   /// Creates a sliver that places box children in a linear array.
   const SliverList({
-    Key key,
+    Object debugLocation, Key key,
     @required SliverChildDelegate delegate,
-  }) : super(key: key, delegate: delegate);
+  }) : super(debugLocation: debugLocation, key: key, delegate: delegate);
 
   @override
   RenderSliverList createRenderObject(BuildContext context) {
@@ -444,10 +444,10 @@ class SliverFixedExtentList extends SliverMultiBoxAdaptorWidget {
   /// Creates a sliver that places box children with the same main axis extent
   /// in a linear array.
   const SliverFixedExtentList({
-    Key key,
+    Object debugLocation, Key key,
     @required SliverChildDelegate delegate,
     @required this.itemExtent,
-  }) : super(key: key, delegate: delegate);
+  }) : super(debugLocation: debugLocation, key: key, delegate: delegate);
 
   /// The extent the children are forced to have in the main axis.
   final double itemExtent;
@@ -511,10 +511,10 @@ class SliverGrid extends SliverMultiBoxAdaptorWidget {
   /// Creates a sliver that places multiple box children in a two dimensional
   /// arrangement.
   const SliverGrid({
-    Key key,
+    Object debugLocation, Key key,
     @required SliverChildDelegate delegate,
     @required this.gridDelegate,
-  }) : super(key: key, delegate: delegate);
+  }) : super(debugLocation: debugLocation, key: key, delegate: delegate);
 
   /// Creates a sliver that places multiple box children in a two dimensional
   /// arrangement with a fixed number of tiles in the cross axis.
@@ -526,7 +526,7 @@ class SliverGrid extends SliverMultiBoxAdaptorWidget {
   ///
   ///  * [new GridView.count], the equivalent constructor for [GridView] widgets.
   SliverGrid.count({
-    Key key,
+    Object debugLocation, Key key,
     @required int crossAxisCount,
     double mainAxisSpacing: 0.0,
     double crossAxisSpacing: 0.0,
@@ -538,7 +538,7 @@ class SliverGrid extends SliverMultiBoxAdaptorWidget {
          crossAxisSpacing: crossAxisSpacing,
          childAspectRatio: childAspectRatio,
        ),
-       super(key: key, delegate: new SliverChildListDelegate(children));
+       super(debugLocation: debugLocation, key: key, delegate: new SliverChildListDelegate(children));
 
   /// Creates a sliver that places multiple box children in a two dimensional
   /// arrangement with tiles that each have a maximum cross-axis extent.
@@ -550,7 +550,7 @@ class SliverGrid extends SliverMultiBoxAdaptorWidget {
   ///
   ///  * [new GridView.extent], the equivalent constructor for [GridView] widgets.
   SliverGrid.extent({
-    Key key,
+    Object debugLocation, Key key,
     @required double maxCrossAxisExtent,
     double mainAxisSpacing: 0.0,
     double crossAxisSpacing: 0.0,
@@ -562,7 +562,7 @@ class SliverGrid extends SliverMultiBoxAdaptorWidget {
          crossAxisSpacing: crossAxisSpacing,
          childAspectRatio: childAspectRatio,
        ),
-       super(key: key, delegate: new SliverChildListDelegate(children));
+       super(debugLocation: debugLocation, key: key, delegate: new SliverChildListDelegate(children));
 
   /// The delegate that controls the size and position of the children.
   final SliverGridDelegate gridDelegate;
@@ -614,12 +614,12 @@ class SliverGrid extends SliverMultiBoxAdaptorWidget {
 class SliverFillViewport extends SliverMultiBoxAdaptorWidget {
   /// Creates a sliver whose box children that each fill the viewport.
   const SliverFillViewport({
-    Key key,
+    Object debugLocation, Key key,
     @required SliverChildDelegate delegate,
     this.viewportFraction: 1.0,
   }) : assert(viewportFraction != null),
        assert(viewportFraction > 0.0),
-       super(key: key, delegate: delegate);
+       super(debugLocation: debugLocation, key: key, delegate: delegate);
 
   /// The fraction of the viewport that each child should fill in the main axis.
   ///
@@ -885,9 +885,9 @@ class SliverMultiBoxAdaptorElement extends RenderObjectElement implements Render
 class SliverFillRemaining extends SingleChildRenderObjectWidget {
   /// Creates a sliver that fills the remaining space in the viewport.
   const SliverFillRemaining({
-    Key key,
+    Object debugLocation, Key key,
     Widget child,
-  }) : super(key: key, child: child);
+  }) : super(debugLocation: debugLocation, key: key, child: child);
 
   @override
   RenderSliverFillRemaining createRenderObject(BuildContext context) => new RenderSliverFillRemaining();
@@ -903,12 +903,12 @@ class KeepAlive extends ParentDataWidget<SliverMultiBoxAdaptorWidget> {
   ///
   /// The [child] and [keepAlive] arguments must not be null.
   const KeepAlive({
-    Key key,
+    Object debugLocation, Key key,
     @required this.keepAlive,
     @required Widget child,
   }) : assert(child != null),
        assert(keepAlive != null),
-       super(key: key, child: child);
+       super(debugLocation: debugLocation, key: key, child: child);
 
   /// Whether to keep the child alive.
   ///

--- a/packages/flutter/lib/src/widgets/sliver_persistent_header.dart
+++ b/packages/flutter/lib/src/widgets/sliver_persistent_header.dart
@@ -91,14 +91,14 @@ class SliverPersistentHeader extends StatelessWidget {
   ///
   /// The [delegate], [pinned], and [floating] arguments must not be null.
   const SliverPersistentHeader({
-    Key key,
+    Object debugLocation, Key key,
     @required this.delegate,
     this.pinned: false,
     this.floating: false,
   }) : assert(delegate != null),
        assert(pinned != null),
        assert(floating != null),
-       super(key: key);
+       super(debugLocation: debugLocation, key: key);
 
   /// Configuration for the sliver's layout.
   ///
@@ -230,10 +230,10 @@ class _SliverPersistentHeaderElement extends RenderObjectElement {
 
 abstract class _SliverPersistentHeaderRenderObjectWidget extends RenderObjectWidget {
   const _SliverPersistentHeaderRenderObjectWidget({
-    Key key,
+    Object debugLocation, Key key,
     @required this.delegate,
   }) : assert(delegate != null),
-       super(key: key);
+       super(debugLocation: debugLocation, key: key);
 
   final SliverPersistentHeaderDelegate delegate;
 
@@ -277,9 +277,9 @@ abstract class _RenderSliverPersistentHeaderForWidgetsMixin extends RenderSliver
 
 class _SliverScrollingPersistentHeader extends _SliverPersistentHeaderRenderObjectWidget {
   const _SliverScrollingPersistentHeader({
-    Key key,
+    Object debugLocation, Key key,
     @required SliverPersistentHeaderDelegate delegate,
-  }) : super(key: key, delegate: delegate);
+  }) : super(debugLocation: debugLocation, key: key, delegate: delegate);
 
   @override
   _RenderSliverPersistentHeaderForWidgetsMixin createRenderObject(BuildContext context) {
@@ -295,9 +295,9 @@ class _RenderSliverScrollingPersistentHeaderForWidgets extends _RenderSliverScro
 
 class _SliverPinnedPersistentHeader extends _SliverPersistentHeaderRenderObjectWidget {
   const _SliverPinnedPersistentHeader({
-    Key key,
+    Object debugLocation, Key key,
     @required SliverPersistentHeaderDelegate delegate,
-  }) : super(key: key, delegate: delegate);
+  }) : super(debugLocation: debugLocation, key: key, delegate: delegate);
 
   @override
   _RenderSliverPersistentHeaderForWidgetsMixin createRenderObject(BuildContext context) {
@@ -312,9 +312,9 @@ class _RenderSliverPinnedPersistentHeaderForWidgets extends _RenderSliverPinnedP
 
 class _SliverFloatingPersistentHeader extends _SliverPersistentHeaderRenderObjectWidget {
   const _SliverFloatingPersistentHeader({
-    Key key,
+    Object debugLocation, Key key,
     @required SliverPersistentHeaderDelegate delegate,
-  }) : super(key: key, delegate: delegate);
+  }) : super(debugLocation: debugLocation, key: key, delegate: delegate);
 
   @override
   _RenderSliverPersistentHeaderForWidgetsMixin createRenderObject(BuildContext context) {
@@ -337,9 +337,9 @@ class _RenderSliverFloatingPinnedPersistentHeaderForWidgets extends _RenderSlive
 
 class _SliverFloatingPinnedPersistentHeader extends _SliverPersistentHeaderRenderObjectWidget {
   const _SliverFloatingPinnedPersistentHeader({
-    Key key,
+    Object debugLocation, Key key,
     @required SliverPersistentHeaderDelegate delegate,
-  }) : super(key: key, delegate: delegate);
+  }) : super(debugLocation: debugLocation, key: key, delegate: delegate);
 
   @override
   _RenderSliverPersistentHeaderForWidgetsMixin createRenderObject(BuildContext context) {

--- a/packages/flutter/lib/src/widgets/sliver_prototype_extent_list.dart
+++ b/packages/flutter/lib/src/widgets/sliver_prototype_extent_list.dart
@@ -37,10 +37,10 @@ class SliverPrototypeExtentList extends SliverMultiBoxAdaptorWidget {
   /// constrains them to have the same extent as a prototype item along
   /// the main axis.
   const SliverPrototypeExtentList({
-    Key key,
+    Object debugLocation, Key key,
     @required SliverChildDelegate delegate,
     @required this.prototypeItem,
-  }) : assert(prototypeItem != null), super(key: key, delegate: delegate);
+  }) : assert(prototypeItem != null), super(debugLocation: debugLocation, key: key, delegate: delegate);
 
   /// Defines the main axis extent of all of this sliver's children.
   ///

--- a/packages/flutter/lib/src/widgets/status_transitions.dart
+++ b/packages/flutter/lib/src/widgets/status_transitions.dart
@@ -13,10 +13,10 @@ abstract class StatusTransitionWidget extends StatefulWidget {
   ///
   /// The [animation] argument must not be null.
   const StatusTransitionWidget({
-    Key key,
+    Object debugLocation, Key key,
     @required this.animation
   }) : assert(animation != null),
-       super(key: key);
+       super(debugLocation: debugLocation, key: key);
 
   /// The animation to which this widget is listening.
   final Animation<double> animation;

--- a/packages/flutter/lib/src/widgets/table.dart
+++ b/packages/flutter/lib/src/widgets/table.dart
@@ -94,7 +94,7 @@ class Table extends RenderObjectWidget {
   /// The [children], [defaultColumnWidth], and [defaultVerticalAlignment]
   /// arguments must not be null.
   Table({
-    Key key,
+    Object debugLocation, Key key,
     this.children: const <TableRow>[],
     this.columnWidths,
     this.defaultColumnWidth: const FlexColumnWidth(1.0),
@@ -139,7 +139,7 @@ class Table extends RenderObjectWidget {
        _rowDecorations = children.any((TableRow row) => row.decoration != null)
                               ? children.map<Decoration>((TableRow row) => row.decoration).toList(growable: false)
                               : null,
-       super(key: key) {
+       super(debugLocation: debugLocation, key: key) {
     assert(() {
       final List<Widget> flatChildren = children.expand((TableRow row) => row.children).toList(growable: false);
       if (debugChildrenHaveDuplicateKeys(this, flatChildren)) {
@@ -367,10 +367,10 @@ class _TableElement extends RenderObjectElement {
 class TableCell extends ParentDataWidget<Table> {
   /// Creates a widget that controls how a child of a [Table] is aligned.
   const TableCell({
-    Key key,
+    Object debugLocation, Key key,
     this.verticalAlignment,
     @required Widget child
-  }) : super(key: key, child: child);
+  }) : super(debugLocation: debugLocation, key: key, child: child);
 
   /// How this cell is aligned vertically.
   final TableCellVerticalAlignment verticalAlignment;

--- a/packages/flutter/lib/src/widgets/text.dart
+++ b/packages/flutter/lib/src/widgets/text.dart
@@ -23,7 +23,7 @@ class DefaultTextStyle extends InheritedWidget {
   /// The [maxLines] property may be null (and indeed defaults to null), but if
   /// it is not null, it must be greater than zero.
   const DefaultTextStyle({
-    Key key,
+    Object debugLocation, Key key,
     @required this.style,
     this.textAlign,
     this.softWrap: true,
@@ -35,7 +35,7 @@ class DefaultTextStyle extends InheritedWidget {
        assert(overflow != null),
        assert(maxLines == null || maxLines > 0),
        assert(child != null),
-       super(key: key, child: child);
+       super(debugLocation: debugLocation, key: key, child: child);
 
   /// A const-constructible default text style that provides fallback values.
   ///
@@ -67,7 +67,7 @@ class DefaultTextStyle extends InheritedWidget {
   /// See the source below for an example of how to do this (since that's
   /// essentially what this constructor does).
   static Widget merge({
-    Key key,
+    Object debugLocation, Key key,
     TextStyle style,
     TextAlign textAlign,
     bool softWrap,
@@ -197,7 +197,7 @@ class Text extends StatelessWidget {
   /// If the [style] argument is null, the text will use the style from the
   /// closest enclosing [DefaultTextStyle].
   const Text(this.data, {
-    Key key,
+    Object debugLocation, Key key,
     this.style,
     this.textAlign,
     this.textDirection,
@@ -206,7 +206,7 @@ class Text extends StatelessWidget {
     this.textScaleFactor,
     this.maxLines,
   }) : assert(data != null),
-       super(key: key);
+       super(debugLocation: debugLocation, key: key);
 
   /// The text to display.
   final String data;

--- a/packages/flutter/lib/src/widgets/text.dart
+++ b/packages/flutter/lib/src/widgets/text.dart
@@ -43,12 +43,13 @@ class DefaultTextStyle extends InheritedWidget {
   ///
   /// This constructor creates a [DefaultTextStyle] that lacks a [child], which
   /// means the constructed value cannot be incorporated into the tree.
-  const DefaultTextStyle.fallback()
+  const DefaultTextStyle.fallback({Object debugLocation})
     : style = const TextStyle(),
       textAlign = null,
       softWrap = true,
       maxLines = null,
-      overflow = TextOverflow.clip;
+      overflow = TextOverflow.clip,
+      super(debugLocation: debugLocation);
 
   /// Creates a default text style that overrides the text styles in scope at
   /// this point in the widget tree.
@@ -80,6 +81,7 @@ class DefaultTextStyle extends InheritedWidget {
       builder: (BuildContext context) {
         final DefaultTextStyle parent = DefaultTextStyle.of(context);
         return new DefaultTextStyle(
+          debugLocation: debugLocation ?? parent.debugLocation,
           key: key,
           style: parent.style.merge(style),
           textAlign: textAlign ?? parent.textAlign,

--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -416,7 +416,7 @@ class TextSelectionOverlay implements TextSelectionDelegate {
 /// This widget represents a single draggable text selection handle.
 class _TextSelectionHandleOverlay extends StatefulWidget {
   const _TextSelectionHandleOverlay({
-    Key key,
+    Object debugLocation, Key key,
     @required this.selection,
     @required this.position,
     @required this.layerLink,
@@ -424,7 +424,7 @@ class _TextSelectionHandleOverlay extends StatefulWidget {
     @required this.onSelectionHandleChanged,
     @required this.onSelectionHandleTapped,
     @required this.selectionControls
-  }) : super(key: key);
+  }) : super(debugLocation: debugLocation, key: key);
 
   final TextSelection selection;
   final _TextSelectionHandlePosition position;

--- a/packages/flutter/lib/src/widgets/texture.dart
+++ b/packages/flutter/lib/src/widgets/texture.dart
@@ -35,7 +35,7 @@ import 'framework.dart';
 ///   for how to create and manage backend textures on iOS.
 class Texture extends LeafRenderObjectWidget {
   /// Creates a widget backed by the texture identified by [textureId].
-  const Texture({ Key key, @required this.textureId }): assert(textureId != null), super(key: key);
+  const Texture({ Object debugLocation, Key key, @required this.textureId }): assert(textureId != null), super(debugLocation: debugLocation, key: key);
 
   /// The identity of the backend texture.
   final int textureId;

--- a/packages/flutter/lib/src/widgets/ticker_provider.dart
+++ b/packages/flutter/lib/src/widgets/ticker_provider.dart
@@ -20,11 +20,11 @@ class TickerMode extends InheritedWidget {
   ///
   /// The [enabled] argument must not be null.
   const TickerMode({
-    Key key,
+    Object debugLocation, Key key,
     @required this.enabled,
     Widget child
   }) : assert(enabled != null),
-       super(key: key, child: child);
+       super(debugLocation: debugLocation, key: key, child: child);
 
   /// The current ticker mode of this subtree.
   ///

--- a/packages/flutter/lib/src/widgets/title.dart
+++ b/packages/flutter/lib/src/widgets/title.dart
@@ -16,13 +16,13 @@ class Title extends StatelessWidget {
   /// [color] must be an opaque color (i.e. color.alpha must be 255 (0xFF)).
   /// [color] and [child] are required arguments.
   Title({
-    Key key,
+    Object debugLocation, Key key,
     this.title: '',
     @required this.color,
     @required this.child,
   }) : assert(title != null),
        assert(color != null && color.alpha == 0xFF),
-       super(key: key);
+       super(debugLocation: debugLocation, key: key);
 
   /// A one-line description of this app for use in the window manager.
   /// Must not be null.

--- a/packages/flutter/lib/src/widgets/transitions.dart
+++ b/packages/flutter/lib/src/widgets/transitions.dart
@@ -38,10 +38,10 @@ abstract class AnimatedWidget extends StatefulWidget {
   ///
   /// The [listenable] argument is required.
   const AnimatedWidget({
-    Key key,
+    Object debugLocation, Key key,
     @required this.listenable
   }) : assert(listenable != null),
-       super(key: key);
+       super(debugLocation: debugLocation, key: key);
 
   /// The [Listenable] to which this widget is listening.
   ///
@@ -112,13 +112,13 @@ class SlideTransition extends AnimatedWidget {
   ///
   /// The [position] argument must not be null.
   const SlideTransition({
-    Key key,
+    Object debugLocation, Key key,
     @required Animation<Offset> position,
     this.transformHitTests: true,
     this.textDirection,
     this.child,
   }) : assert(position != null),
-       super(key: key, listenable: position);
+       super(debugLocation: debugLocation, key: key, listenable: position);
 
   /// The animation that controls the position of the child.
   ///
@@ -171,11 +171,11 @@ class ScaleTransition extends AnimatedWidget {
   /// The [scale] argument must not be null. The [alignment] argument defaults
   /// to [Alignment.center].
   const ScaleTransition({
-    Key key,
+    Object debugLocation, Key key,
     @required Animation<double> scale,
     this.alignment: Alignment.center,
     this.child,
-  }) : super(key: key, listenable: scale);
+  }) : super(debugLocation: debugLocation, key: key, listenable: scale);
 
   /// The animation that controls the scale of the child.
   ///
@@ -212,10 +212,10 @@ class RotationTransition extends AnimatedWidget {
   ///
   /// The [turns] argument must not be null.
   const RotationTransition({
-    Key key,
+    Object debugLocation, Key key,
     @required Animation<double> turns,
     this.child,
-  }) : super(key: key, listenable: turns);
+  }) : super(debugLocation: debugLocation, key: key, listenable: turns);
 
   /// The animation that controls the rotation of the child.
   ///
@@ -249,13 +249,13 @@ class SizeTransition extends AnimatedWidget {
   /// to [Axis.vertical]. The [axisAlignment] defaults to 0.0, which centers the
   /// child along the main axis during the transition.
   const SizeTransition({
-    Key key,
+    Object debugLocation, Key key,
     this.axis: Axis.vertical,
     @required Animation<double> sizeFactor,
     this.axisAlignment: 0.0,
     this.child,
   }) : assert(axis != null),
-       super(key: key, listenable: sizeFactor);
+       super(debugLocation: debugLocation, key: key, listenable: sizeFactor);
 
   /// [Axis.horizontal] if [sizeFactor] modifies the width, otherwise [Axis.vertical].
   final Axis axis;
@@ -298,10 +298,10 @@ class FadeTransition extends AnimatedWidget {
   ///
   /// The [opacity] argument must not be null.
   const FadeTransition({
-    Key key,
+    Object debugLocation, Key key,
     @required Animation<double> opacity,
     this.child,
-  }) : super(key: key, listenable: opacity);
+  }) : super(debugLocation: debugLocation, key: key, listenable: opacity);
 
   /// The animation that controls the opacity of the child.
   ///
@@ -353,10 +353,10 @@ class PositionedTransition extends AnimatedWidget {
   ///
   /// The [rect] argument must not be null.
   const PositionedTransition({
-    Key key,
+    Object debugLocation, Key key,
     @required Animation<RelativeRect> rect,
     @required this.child,
-  }) : super(key: key, listenable: rect);
+  }) : super(debugLocation: debugLocation, key: key, listenable: rect);
 
   /// The animation that controls the child's size and position.
   Animation<RelativeRect> get rect => listenable;
@@ -389,11 +389,11 @@ class RelativePositionedTransition extends AnimatedWidget {
   /// current value of the [rect] argument assuming that the stack has the given
   /// [size]. Both [rect] and [size] must not be null.
   const RelativePositionedTransition({
-    Key key,
+    Object debugLocation, Key key,
     @required Animation<Rect> rect,
     @required this.size,
     @required this.child,
-  }) : super(key: key, listenable: rect);
+  }) : super(debugLocation: debugLocation, key: key, listenable: rect);
 
   /// The animation that controls the child's size and position.
   ///
@@ -438,11 +438,11 @@ class DecoratedBoxTransition extends AnimatedWidget {
   ///
   /// * [new DecoratedBox].
   const DecoratedBoxTransition({
-    Key key,
+    Object debugLocation, Key key,
     @required this.decoration,
     this.position: DecorationPosition.background,
     @required this.child,
-  }) : super(key: key, listenable: decoration);
+  }) : super(debugLocation: debugLocation, key: key, listenable: decoration);
 
   /// Animation of the decoration to paint.
   ///
@@ -475,12 +475,12 @@ class AlignTransition extends AnimatedWidget {
   ///
   /// * [new Align].
   const AlignTransition({
-    Key key,
+    Object debugLocation, Key key,
     @required Animation<AlignmentGeometry> alignment,
     @required this.child,
     this.widthFactor,
     this.heightFactor,
-  }) : super(key: key, listenable: alignment);
+  }) : super(debugLocation: debugLocation, key: key, listenable: alignment);
 
   /// The animation that controls the child's alignment.
   Animation<AlignmentGeometry> get alignment => listenable;
@@ -584,12 +584,12 @@ class AnimatedBuilder extends AnimatedWidget {
   ///
   /// The [animation] and [builder] arguments must not be null.
   const AnimatedBuilder({
-    Key key,
+    Object debugLocation, Key key,
     @required Listenable animation,
     @required this.builder,
     this.child,
   }) : assert(builder != null),
-       super(key: key, listenable: animation);
+       super(debugLocation: debugLocation, key: key, listenable: animation);
 
   /// Called every time the animation changes value.
   final TransitionBuilder builder;

--- a/packages/flutter/lib/src/widgets/unique_widget.dart
+++ b/packages/flutter/lib/src/widgets/unique_widget.dart
@@ -25,9 +25,9 @@ abstract class UniqueWidget<T extends State<StatefulWidget>> extends StatefulWid
   /// The [key] argument must not be null because it identifies the unique
   /// inflated instance of this widget.
   const UniqueWidget({
-    @required GlobalKey<T> key,
+    Object debugLocation, @required GlobalKey<T> key,
   }) : assert(key != null),
-       super(key: key);
+       super(debugLocation: debugLocation, key: key);
 
   @override
   T createState();

--- a/packages/flutter/lib/src/widgets/viewport.dart
+++ b/packages/flutter/lib/src/widgets/viewport.dart
@@ -66,7 +66,7 @@ class Viewport extends MultiChildRenderObjectWidget {
   ///
   /// The [offset] argument must not be null.
   Viewport({
-    Key key,
+    Object debugLocation, Key key,
     this.axisDirection: AxisDirection.down,
     this.crossAxisDirection,
     this.anchor: 0.0,
@@ -76,7 +76,7 @@ class Viewport extends MultiChildRenderObjectWidget {
   }) : assert(offset != null),
        assert(slivers != null),
        assert(center == null || slivers.where((Widget child) => child.key == center).length == 1),
-       super(key: key, children: slivers);
+       super(debugLocation: debugLocation, key: key, children: slivers);
 
   /// The direction in which the [offset]'s [ViewportOffset.pixels] increases.
   ///
@@ -231,13 +231,13 @@ class ShrinkWrappingViewport extends MultiChildRenderObjectWidget {
   ///
   /// The [offset] argument must not be null.
   ShrinkWrappingViewport({
-    Key key,
+    Object debugLocation, Key key,
     this.axisDirection: AxisDirection.down,
     this.crossAxisDirection,
     @required this.offset,
     List<Widget> slivers: const <Widget>[],
   }) : assert(offset != null),
-       super(key: key, children: slivers);
+       super(debugLocation: debugLocation, key: key, children: slivers);
 
   /// The direction in which the [offset]'s [ViewportOffset.pixels] increases.
   ///

--- a/packages/flutter/lib/src/widgets/widget_inspector.dart
+++ b/packages/flutter/lib/src/widgets/widget_inspector.dart
@@ -426,11 +426,11 @@ class WidgetInspector extends StatefulWidget {
   ///
   /// The [child] argument must not be null.
   const WidgetInspector({
-    Key key,
+    Object debugLocation, Key key,
     @required this.child,
     @required this.selectButtonBuilder,
   }) : assert(child != null),
-       super(key: key);
+       super(debugLocation: debugLocation, key: key);
 
   /// The widget that is being inspected.
   final Widget child;
@@ -707,9 +707,9 @@ class InspectorSelection {
 
 class _InspectorOverlay extends LeafRenderObjectWidget {
   const _InspectorOverlay({
-    Key key,
+    Object debugLocation, Key key,
     @required this.selection,
-  }) : super(key: key);
+  }) : super(debugLocation: debugLocation, key: key);
 
   final InspectorSelection selection;
 

--- a/packages/flutter/lib/src/widgets/will_pop_scope.dart
+++ b/packages/flutter/lib/src/widgets/will_pop_scope.dart
@@ -21,11 +21,11 @@ class WillPopScope extends StatefulWidget {
   ///
   /// The [child] argument must not be null.
   const WillPopScope({
-    Key key,
+    Object debugLocation, Key key,
     @required this.child,
     @required this.onWillPop,
   }) : assert(child != null),
-       super(key: key);
+       super(debugLocation: debugLocation, key: key);
 
   /// The widget below this widget in the tree.
   final Widget child;

--- a/packages/flutter/test/material/app_test.dart
+++ b/packages/flutter/test/material/app_test.dart
@@ -6,7 +6,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/material.dart';
 
 class StateMarker extends StatefulWidget {
-  const StateMarker({ Key key, this.child }) : super(key: key);
+  const StateMarker({ Object debugLocation, Key key, this.child }) : super(debugLocation: debugLocation, key: key);
 
   final Widget child;
 

--- a/packages/flutter/test/material/list_tile_test.dart
+++ b/packages/flutter/test/material/list_tile_test.dart
@@ -6,7 +6,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 class TestIcon extends StatefulWidget {
-  const TestIcon({ Key key }) : super(key: key);
+  const TestIcon({ Object debugLocation, Key key }) : super(debugLocation: debugLocation, key: key);
 
   @override
   TestIconState createState() => new TestIconState();
@@ -23,7 +23,7 @@ class TestIconState extends State<TestIcon> {
 }
 
 class TestText extends StatefulWidget {
-  const TestText(this.text, { Key key }) : super(key: key);
+  const TestText(this.text, { Object debugLocation, Key key }) : super(debugLocation: debugLocation, key: key);
 
   final String text;
 

--- a/packages/flutter/test/material/tabs_test.dart
+++ b/packages/flutter/test/material/tabs_test.dart
@@ -24,7 +24,7 @@ Widget boilerplate({ Widget child, TextDirection textDirection: TextDirection.lt
 }
 
 class StateMarker extends StatefulWidget {
-  const StateMarker({ Key key, this.child }) : super(key: key);
+  const StateMarker({ Object debugLocation, Key key, this.child }) : super(debugLocation: debugLocation, key: key);
 
   final Widget child;
 

--- a/packages/flutter/test/material/time_picker_test.dart
+++ b/packages/flutter/test/material/time_picker_test.dart
@@ -17,7 +17,7 @@ import '../widgets/semantics_tester.dart';
 import 'feedback_tester.dart';
 
 class _TimePickerLauncher extends StatelessWidget {
-  const _TimePickerLauncher({ Key key, this.onChanged, this.locale }) : super(key: key);
+  const _TimePickerLauncher({ Object debugLocation, Key key, this.onChanged, this.locale }) : super(debugLocation: debugLocation, key: key);
 
   final ValueChanged<TimeOfDay> onChanged;
   final Locale locale;

--- a/packages/flutter/test/material/will_pop_test.dart
+++ b/packages/flutter/test/material/will_pop_test.dart
@@ -42,7 +42,7 @@ class SamplePageState extends State<SamplePage> {
 int willPopCount = 0;
 
 class SampleForm extends StatelessWidget {
-  const SampleForm({ Key key, this.callback }) : super(key: key);
+  const SampleForm({ Object debugLocation, Key key, this.callback }) : super(debugLocation: debugLocation, key: key);
 
   final WillPopCallback callback;
 

--- a/packages/flutter/test/widgets/async_test.dart
+++ b/packages/flutter/test/widgets/async_test.dart
@@ -259,7 +259,7 @@ Future<Null> eventFiring(WidgetTester tester) async {
 }
 
 class StringCollector extends StreamBuilderBase<String, List<String>> {
-  const StringCollector({ Key key, Stream<String> stream }) : super(key: key, stream: stream);
+  const StringCollector({ Object debugLocation, Key key, Stream<String> stream }) : super(debugLocation: debugLocation, key: key, stream: stream);
 
   @override
   List<String> initial() => <String>[];

--- a/packages/flutter/test/widgets/automatic_keep_alive_test.dart
+++ b/packages/flutter/test/widgets/automatic_keep_alive_test.dart
@@ -7,7 +7,7 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 class Leaf extends StatefulWidget {
-  const Leaf({ Key key, this.child }) : super(key: key);
+  const Leaf({ Object debugLocation, Key key, this.child }) : super(debugLocation: debugLocation, key: key);
   final Widget child;
   @override
   _LeafState createState() => new _LeafState();

--- a/packages/flutter/test/widgets/build_scope_test.dart
+++ b/packages/flutter/test/widgets/build_scope_test.dart
@@ -86,9 +86,9 @@ class BadDisposeWidgetState extends State<BadDisposeWidget> {
 
 class StatefulWrapper extends StatefulWidget {
   const StatefulWrapper({
-    Key key,
+    Object debugLocation, Key key,
     this.child,
-  }) : super(key: key);
+  }) : super(debugLocation: debugLocation, key: key);
 
   final Widget child;
 
@@ -117,9 +117,9 @@ class StatefulWrapperState extends State<StatefulWrapper> {
 
 class Wrapper extends StatelessWidget {
   const Wrapper({
-    Key key,
+    Object debugLocation, Key key,
     this.child,
-  }) : super(key: key);
+  }) : super(debugLocation: debugLocation, key: key);
 
   final Widget child;
 

--- a/packages/flutter/test/widgets/focus_test.dart
+++ b/packages/flutter/test/widgets/focus_test.dart
@@ -7,11 +7,11 @@ import 'package:flutter/widgets.dart';
 
 class TestFocusable extends StatefulWidget {
   const TestFocusable({
-    Key key,
+    Object debugLocation, Key key,
     this.no,
     this.yes,
     this.autofocus: true,
-  }) : super(key: key);
+  }) : super(debugLocation: debugLocation, key: key);
 
   final String no;
   final String yes;

--- a/packages/flutter/test/widgets/global_keys_moving_test.dart
+++ b/packages/flutter/test/widgets/global_keys_moving_test.dart
@@ -15,7 +15,7 @@ class Item {
 List<Item> items = <Item>[new Item(), new Item()];
 
 class StatefulLeaf extends StatefulWidget {
-  const StatefulLeaf({ GlobalKey key }) : super(key: key);
+  const StatefulLeaf({ Object debugLocation, GlobalKey key }) : super(debugLocation: debugLocation, key: key);
 
   @override
   StatefulLeafState createState() => new StatefulLeafState();

--- a/packages/flutter/test/widgets/heroes_test.dart
+++ b/packages/flutter/test/widgets/heroes_test.dart
@@ -109,7 +109,7 @@ class MutatingRoute extends MaterialPageRoute<Null> {
 }
 
 class MyStatefulWidget extends StatefulWidget {
-  const MyStatefulWidget({ Key key, this.value: '123' }) : super(key: key);
+  const MyStatefulWidget({ Object debugLocation, Key key, this.value: '123' }) : super(debugLocation: debugLocation, key: key);
   final String value;
   @override
   MyStatefulWidgetState createState() => new MyStatefulWidgetState();

--- a/packages/flutter/test/widgets/independent_widget_layout_test.dart
+++ b/packages/flutter/test/widgets/independent_widget_layout_test.dart
@@ -98,10 +98,10 @@ class TriggerableState extends State<TriggerableWidget> {
 
 class TestFocusable extends StatefulWidget {
   const TestFocusable({
-    Key key,
+    Object debugLocation, Key key,
     this.focusNode,
     this.autofocus: true,
-  }) : super(key: key);
+  }) : super(debugLocation: debugLocation, key: key);
 
   final bool autofocus;
   final FocusNode focusNode;

--- a/packages/flutter/test/widgets/inherited_test.dart
+++ b/packages/flutter/test/widgets/inherited_test.dart
@@ -8,8 +8,8 @@ import 'package:flutter/material.dart';
 import 'test_widgets.dart';
 
 class TestInherited extends InheritedWidget {
-  const TestInherited({ Key key, Widget child, this.shouldNotify: true })
-    : super(key: key, child: child);
+  const TestInherited({ Object debugLocation, Key key,Widget child, this.shouldNotify: true })
+    : super(debugLocation: debugLocation, key: key, child: child);
 
   final bool shouldNotify;
 
@@ -20,8 +20,8 @@ class TestInherited extends InheritedWidget {
 }
 
 class ValueInherited extends InheritedWidget {
-  const ValueInherited({ Key key, Widget child, this.value })
-    : super(key: key, child: child);
+  const ValueInherited({ Object debugLocation, Key key,Widget child, this.value })
+    : super(debugLocation: debugLocation, key: key, child: child);
 
   final int value;
 

--- a/packages/flutter/test/widgets/keep_alive_test.dart
+++ b/packages/flutter/test/widgets/keep_alive_test.dart
@@ -8,7 +8,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/widgets.dart';
 
 class Leaf extends StatefulWidget {
-  const Leaf({ Key key, this.child }) : super(key: key);
+  const Leaf({ Object debugLocation, Key key, this.child }) : super(debugLocation: debugLocation, key: key);
   final Widget child;
   @override
   _LeafState createState() => new _LeafState();

--- a/packages/flutter/test/widgets/layout_builder_and_global_keys_test.dart
+++ b/packages/flutter/test/widgets/layout_builder_and_global_keys_test.dart
@@ -7,9 +7,9 @@ import 'package:flutter/widgets.dart';
 
 class Wrapper extends StatelessWidget {
   const Wrapper({
-    Key key,
+    Object debugLocation, Key key,
     this.child,
-  }) : super(key: key);
+  }) : super(debugLocation: debugLocation, key: key);
 
   final Widget child;
 
@@ -19,9 +19,9 @@ class Wrapper extends StatelessWidget {
 
 class StatefulWrapper extends StatefulWidget {
   const StatefulWrapper({
-    Key key,
+    Object debugLocation, Key key,
     this.child,
-  }) : super(key: key);
+  }) : super(debugLocation: debugLocation, key: key);
 
   final Widget child;
 

--- a/packages/flutter/test/widgets/layout_builder_and_parent_data_test.dart
+++ b/packages/flutter/test/widgets/layout_builder_and_parent_data_test.dart
@@ -7,9 +7,9 @@ import 'package:flutter/widgets.dart';
 
 class SizeChanger extends StatefulWidget {
   const SizeChanger({
-    Key key,
+    Object debugLocation, Key key,
     this.child,
-  }) : super(key: key);
+  }) : super(debugLocation: debugLocation, key: key);
 
   final Widget child;
 
@@ -43,9 +43,9 @@ class SizeChangerState extends State<SizeChanger> {
 
 class Wrapper extends StatelessWidget {
   const Wrapper({
-    Key key,
+    Object debugLocation, Key key,
     this.child,
-  }) : super(key: key);
+  }) : super(debugLocation: debugLocation, key: key);
 
   final Widget child;
 

--- a/packages/flutter/test/widgets/layout_builder_and_state_test.dart
+++ b/packages/flutter/test/widgets/layout_builder_and_state_test.dart
@@ -8,9 +8,9 @@ import 'test_widgets.dart';
 
 class StatefulWrapper extends StatefulWidget {
   const StatefulWrapper({
-    Key key,
+    Object debugLocation, Key key,
     this.child,
-  }) : super(key: key);
+  }) : super(debugLocation: debugLocation, key: key);
 
   final Widget child;
 
@@ -35,9 +35,9 @@ class StatefulWrapperState extends State<StatefulWrapper> {
 
 class Wrapper extends StatelessWidget {
   const Wrapper({
-    Key key,
+    Object debugLocation, Key key,
     this.child,
-  }) : super(key: key);
+  }) : super(debugLocation: debugLocation, key: key);
 
   final Widget child;
 

--- a/packages/flutter/test/widgets/layout_builder_mutations_test.dart
+++ b/packages/flutter/test/widgets/layout_builder_mutations_test.dart
@@ -10,10 +10,10 @@ import 'package:flutter_test/flutter_test.dart' hide TypeMatcher;
 
 class Wrapper extends StatelessWidget {
   const Wrapper({
-    Key key,
+    Object debugLocation, Key key,
     @required this.child
   }) : assert(child != null),
-       super(key: key);
+       super(debugLocation: debugLocation, key: key);
 
   final Widget child;
 

--- a/packages/flutter/test/widgets/navigator_test.dart
+++ b/packages/flutter/test/widgets/navigator_test.dart
@@ -63,7 +63,7 @@ class ThirdWidget extends StatelessWidget {
 }
 
 class OnTapPage extends StatelessWidget {
-  const OnTapPage({ Key key, this.id, this.onTap }) : super(key: key);
+  const OnTapPage({ Object debugLocation, Key key, this.id, this.onTap }) : super(debugLocation: debugLocation, key: key);
 
   final String id;
   final VoidCallback onTap;

--- a/packages/flutter/test/widgets/page_forward_transitions_test.dart
+++ b/packages/flutter/test/widgets/page_forward_transitions_test.dart
@@ -8,11 +8,11 @@ import 'package:flutter/rendering.dart';
 
 class TestTransition extends AnimatedWidget {
   const TestTransition({
-    Key key,
+    Object debugLocation, Key key,
     this.childFirstHalf,
     this.childSecondHalf,
     Animation<double> animation
-  }) : super(key: key, listenable: animation);
+  }) : super(debugLocation: debugLocation, key: key, listenable: animation);
 
   final Widget childFirstHalf;
   final Widget childSecondHalf;

--- a/packages/flutter/test/widgets/page_transitions_test.dart
+++ b/packages/flutter/test/widgets/page_transitions_test.dart
@@ -14,7 +14,7 @@ class TestOverlayRoute extends OverlayRoute<Null> {
 }
 
 class PersistentBottomSheetTest extends StatefulWidget {
-  const PersistentBottomSheetTest({ Key key }) : super(key: key);
+  const PersistentBottomSheetTest({ Object debugLocation, Key key }) : super(debugLocation: debugLocation, key: key);
 
   @override
   PersistentBottomSheetTestState createState() => new PersistentBottomSheetTestState();

--- a/packages/flutter/test/widgets/render_object_widget_test.dart
+++ b/packages/flutter/test/widgets/render_object_widget_test.dart
@@ -21,7 +21,7 @@ class TestWidget extends StatelessWidget {
 }
 
 class TestOrientedBox extends SingleChildRenderObjectWidget {
-  const TestOrientedBox({ Key key, Widget child }) : super(key: key, child: child);
+  const TestOrientedBox({ Object debugLocation, Key key, Widget child }) : super(debugLocation: debugLocation, key: key, child: child);
 
   Decoration _getDecoration(BuildContext context) {
     final Orientation orientation = MediaQuery.of(context).orientation;

--- a/packages/flutter/test/widgets/reparent_state_harder_test.dart
+++ b/packages/flutter/test/widgets/reparent_state_harder_test.dart
@@ -8,7 +8,7 @@ import 'package:flutter_test/flutter_test.dart' hide TypeMatcher;
 // This is a regression test for https://github.com/flutter/flutter/issues/5588.
 
 class OrderSwitcher extends StatefulWidget {
-  const OrderSwitcher({ Key key, this.a, this.b }) : super(key: key);
+  const OrderSwitcher({ Object debugLocation, Key key, this.a, this.b }) : super(debugLocation: debugLocation, key: key);
 
   final Widget a;
   final Widget b;
@@ -45,7 +45,7 @@ class OrderSwitcherState extends State<OrderSwitcher> {
 }
 
 class DummyStatefulWidget extends StatefulWidget {
-  const DummyStatefulWidget(Key key) : super(key: key);
+  const DummyStatefulWidget(Key key, {Object debugLocation}) : super(debugLocation: debugLocation, key: key);
 
   @override
   DummyStatefulWidgetState createState() => new DummyStatefulWidgetState();

--- a/packages/flutter/test/widgets/reparent_state_test.dart
+++ b/packages/flutter/test/widgets/reparent_state_test.dart
@@ -6,7 +6,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/widgets.dart';
 
 class StateMarker extends StatefulWidget {
-  const StateMarker({ Key key, this.child }) : super(key: key);
+  const StateMarker({ Object debugLocation, Key key, this.child }) : super(debugLocation: debugLocation, key: key);
 
   final Widget child;
 
@@ -26,7 +26,7 @@ class StateMarkerState extends State<StateMarker> {
 }
 
 class DeactivateLogger extends StatefulWidget {
-  const DeactivateLogger({ Key key, this.log }) : super(key: key);
+  const DeactivateLogger({ Object debugLocation, Key key, this.log }) : super(debugLocation: debugLocation, key: key);
 
   final List<String> log;
 

--- a/packages/flutter/test/widgets/reparent_state_with_layout_builder_test.dart
+++ b/packages/flutter/test/widgets/reparent_state_with_layout_builder_test.dart
@@ -46,7 +46,7 @@ class BarState extends State<Bar> {
 }
 
 class StatefulCreationCounter extends StatefulWidget {
-  const StatefulCreationCounter({ Key key }) : super(key: key);
+  const StatefulCreationCounter({ Object debugLocation, Key key }) : super(debugLocation: debugLocation, key: key);
 
   @override
   StatefulCreationCounterState createState() => new StatefulCreationCounterState();

--- a/packages/flutter/test/widgets/scrollable_of_test.dart
+++ b/packages/flutter/test/widgets/scrollable_of_test.dart
@@ -6,7 +6,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/widgets.dart';
 
 class ScrollPositionListener extends StatefulWidget {
-  const ScrollPositionListener({ Key key, this.child, this.log}) : super(key: key);
+  const ScrollPositionListener({ Object debugLocation, Key key, this.child, this.log}) : super(debugLocation: debugLocation, key: key);
 
   final Widget child;
   final ValueChanged<String> log;

--- a/packages/flutter/test/widgets/semantics_10_test.dart
+++ b/packages/flutter/test/widgets/semantics_10_test.dart
@@ -63,11 +63,11 @@ Widget buildTestWidgets({bool excludeSemantics, String label, bool isSemanticsBo
 
 class TestWidget extends SingleChildRenderObjectWidget {
   const TestWidget({
-    Key key,
+    Object debugLocation, Key key,
     Widget child,
     this.label,
     this.isSemanticBoundary,
-  }) : super(key: key, child: child);
+  }) : super(debugLocation: debugLocation, key: key, child: child);
 
   final String label;
   final bool isSemanticBoundary;

--- a/packages/flutter/test/widgets/semantics_9_test.dart
+++ b/packages/flutter/test/widgets/semantics_9_test.dart
@@ -137,7 +137,7 @@ void main() {
 }
 
 class BoundaryBlockSemantics extends SingleChildRenderObjectWidget {
-  const BoundaryBlockSemantics({ Key key, Widget child }) : super(key: key, child: child);
+  const BoundaryBlockSemantics({ Object debugLocation, Key key, Widget child }) : super(debugLocation: debugLocation, key: key, child: child);
 
   @override
   RenderBoundaryBlockSemantics createRenderObject(BuildContext context) => new RenderBoundaryBlockSemantics();

--- a/packages/flutter/test/widgets/sliver_prototype_item_extent_test.dart
+++ b/packages/flutter/test/widgets/sliver_prototype_item_extent_test.dart
@@ -6,7 +6,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/widgets.dart';
 
 class TestItem extends StatelessWidget {
-  const TestItem({ Key key, this.item, this.width, this.height }) : super(key: key);
+  const TestItem({ Object debugLocation, Key key, this.item, this.width, this.height }) : super(debugLocation: debugLocation, key: key);
   final int item;
   final double width;
   final double height;

--- a/packages/flutter/test/widgets/slivers_appbar_floating_test.dart
+++ b/packages/flutter/test/widgets/slivers_appbar_floating_test.dart
@@ -270,7 +270,7 @@ class RenderBigSliver extends RenderSliver {
 }
 
 class BigSliver extends LeafRenderObjectWidget {
-  const BigSliver({ Key key, this.height }) : super(key: key);
+  const BigSliver({ Object debugLocation, Key key, this.height }) : super(debugLocation: debugLocation, key: key);
 
   final double height;
 

--- a/packages/flutter/test/widgets/slivers_appbar_pinned_test.dart
+++ b/packages/flutter/test/widgets/slivers_appbar_pinned_test.dart
@@ -357,7 +357,7 @@ class RenderBigSliver extends RenderSliver {
 }
 
 class BigSliver extends LeafRenderObjectWidget {
-  const BigSliver({ Key key, this.height }) : super(key: key);
+  const BigSliver({ Object debugLocation, Key key, this.height }) : super(debugLocation: debugLocation, key: key);
 
   final double height;
 

--- a/packages/flutter/test/widgets/slivers_appbar_scrolling_test.dart
+++ b/packages/flutter/test/widgets/slivers_appbar_scrolling_test.dart
@@ -139,7 +139,7 @@ class RenderBigSliver extends RenderSliver {
 }
 
 class BigSliver extends LeafRenderObjectWidget {
-  const BigSliver({ Key key }) : super(key: key);
+  const BigSliver({ Object debugLocation, Key key }) : super(debugLocation: debugLocation, key: key);
   @override
   RenderBigSliver createRenderObject(BuildContext context) {
     return new RenderBigSliver();

--- a/packages/flutter/test/widgets/slivers_protocol_test.dart
+++ b/packages/flutter/test/widgets/slivers_protocol_test.dart
@@ -68,7 +68,7 @@ class RenderBigSliver extends RenderSliver {
 }
 
 class BigSliver extends LeafRenderObjectWidget {
-  const BigSliver({ Key key }) : super(key: key);
+  const BigSliver({ Object debugLocation, Key key }) : super(debugLocation: debugLocation, key: key);
   @override
   RenderBigSliver createRenderObject(BuildContext context) {
     return new RenderBigSliver();
@@ -105,7 +105,7 @@ class RenderOverlappingSliver extends RenderSliver {
 }
 
 class OverlappingSliver extends LeafRenderObjectWidget {
-  const OverlappingSliver({ Key key }) : super(key: key);
+  const OverlappingSliver({ Object debugLocation, Key key }) : super(debugLocation: debugLocation, key: key);
   @override
   RenderOverlappingSliver createRenderObject(BuildContext context) {
     return new RenderOverlappingSliver();

--- a/packages/flutter/test/widgets/stateful_components_test.dart
+++ b/packages/flutter/test/widgets/stateful_components_test.dart
@@ -6,7 +6,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/widgets.dart';
 
 class InnerWidget extends StatefulWidget {
-  const InnerWidget({ Key key }) : super(key: key);
+  const InnerWidget({ Object debugLocation, Key key }) : super(debugLocation: debugLocation, key: key);
 
   @override
   InnerWidgetState createState() => new InnerWidgetState();
@@ -28,7 +28,7 @@ class InnerWidgetState extends State<InnerWidget> {
 }
 
 class OuterContainer extends StatefulWidget {
-  const OuterContainer({ Key key, this.child }) : super(key: key);
+  const OuterContainer({ Object debugLocation, Key key, this.child }) : super(debugLocation: debugLocation, key: key);
 
   final InnerWidget child;
 

--- a/packages/flutter/test/widgets/status_transitions_test.dart
+++ b/packages/flutter/test/widgets/status_transitions_test.dart
@@ -7,10 +7,10 @@ import 'package:flutter/widgets.dart';
 
 class TestStatusTransitionWidget extends StatusTransitionWidget {
   const TestStatusTransitionWidget({
-    Key key,
+    Object debugLocation, Key key,
     this.builder,
     Animation<double> animation,
-  }) : super(key: key, animation: animation);
+  }) : super(debugLocation: debugLocation, key: key, animation: animation);
 
   final WidgetBuilder builder;
 

--- a/packages/flutter/test/widgets/table_test.dart
+++ b/packages/flutter/test/widgets/table_test.dart
@@ -7,7 +7,7 @@ import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 
 class TestStatefulWidget extends StatefulWidget {
-  const TestStatefulWidget({ Key key }) : super(key: key);
+  const TestStatefulWidget({ Object debugLocation, Key key }) : super(debugLocation: debugLocation, key: key);
 
   @override
   TestStatefulWidgetState createState() => new TestStatefulWidgetState();

--- a/packages/flutter/test/widgets/test_widgets.dart
+++ b/packages/flutter/test/widgets/test_widgets.dart
@@ -30,7 +30,7 @@ class TestBuildCounter extends StatelessWidget {
 
 
 class FlipWidget extends StatefulWidget {
-  const FlipWidget({ Key key, this.left, this.right }) : super(key: key);
+  const FlipWidget({ Object debugLocation, Key key, this.left, this.right }) : super(debugLocation: debugLocation, key: key);
 
   final Widget left;
   final Widget right;

--- a/packages/flutter/test/widgets/unique_widget_test.dart
+++ b/packages/flutter/test/widgets/unique_widget_test.dart
@@ -6,7 +6,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/widgets.dart';
 
 class TestUniqueWidget extends UniqueWidget<TestUniqueWidgetState> {
-  const TestUniqueWidget({ GlobalKey key }) : super(key: key);
+  const TestUniqueWidget({ Object debugLocation, GlobalKey key }) : super(debugLocation: debugLocation, key: key);
 
   @override
   TestUniqueWidgetState createState() => new TestUniqueWidgetState();


### PR DESCRIPTION
For discussion: add debugLocation named parameter to all widget constructors.
This allows tracking of exactly where in user code a widget was creating which is a huge win for the widget inspector as you can filter to just widgets you created directly and you can jump to just the right source location in your file. The kernel transformer that uses these named parameters is smart enough to just leave a constructor alone if it does not have debugLocation so the functionality is purely opt-in.  There are still a few widgets missing from this CL (on the order of 20) where the constructors didn't match the patterns by regex expected.

Note that this has a small cost in performance as now some identical widgets will not be identical. E.g.

```dart
var x = const Text("foo")
var y = const Text("foo");
!(identical(x, y)

// Because the kernel transformer generates:
var x = const Text("foo", const DebugLocation(file: "foo.dart", line: 3));
var y = const Text("foo", const DebugLocation(file: "foo.dart", line: 4));
```

Note that in practice you still get most of the benefit from const as the following common pattern still works. Sample applications still seem to run with generally the same performance with this change plus the kernel transformer to make it real but I haven't benchmarked.

```dart
buildText() {
  return const Text("foo")
}
indentical(buildText(), buildText())
```

An even more magical alternative is we can add the debugLocation parameter to all the constructors with the same kernel transformer that fills in these named parameters. With this more magical approach you wouldn't be able to from user code in the flutter library control when you want to manually inject a debugLocation as in the case of text.dart line 70 where the static Widget merge method might want to propagate the debugLocation of the parent. I haven't thought deeply about whether that is a good or a bad thing. The big advantage of the magical approach is users wouldn't have to update their Widget classes to benefit from the tracking. The big disadvantage is the behavior with this debug transformer on is even more surprising. What? my const objects that I would think are identical aren't identical and I have no idea why?? By contrast with the approach of an explicit field on Widget, you can at least understand why the objects aren't identical.

Note that debugLocation does not have to be a named parameter particularly if we go the more magical approach, the kernel transformer can trivially be smart about handling optional positional parameters for this field.
For historic reasons, in this CL I did not force debugLocation to have type DebugLocation but that is a trivial fix if we decide the type of debugLocation should be fixed.

This CL was generated by running the following regexes along with a little manual cleanup for edge cases they missed.
```
perl -p -i -e "s/([(][{] )(Key key)/\1Object debugLocation, \2/g" `find ./ -name *.dart`
perl -p -i -e "s/( super\\()(key: key)/\1debugLocation: debugLocation, \2/g" `find ./ -name *.dart`
perl -p -i -e "s/^(    )(Key key,)/\1Object debugLocation, \2/g" `find ./ -name *.dart`
perl -p -i -e "s/([(] ?[{] ?)(Key key ?[}] ?[)])/\1Object debugLocation, \2/g" `find ./ -name *.dart`
perl -p -i -e "s/([(] ?[{] ?)(Key key,)/\1Object debugLocation, \2/g" `find ./ -name *.dart`
perl -p -i -e "s/^(    )(Key key[}])/\1Object debugLocation, \2/g" `find ./ -name *.dart`
````
