### PR TITLE
Adding Flutter version check from Intellij API

### DIFF
--- a/packages/flutter_tools/lib/src/doctor.dart
+++ b/packages/flutter_tools/lib/src/doctor.dart
@@ -363,7 +363,7 @@ abstract class IntelliJValidator extends DoctorValidator {
         try {
           final String latestFlutter = await _getLatestVersionPossible();
           final Version flutterVersion = new Version.parse(latestFlutter);
-          final String serverMessage = localVersion < flutterVersion ? "[Consider upgrading your plugin version to $version]" : "";
+          final String serverMessage = localVersion < flutterVersion ? "[Consider upgrading your plugin version to $latestFlutter]" : "";
             messages.add(new ValidationMessage(
               '$title plugin ${localVersion != null ? "version $localVersion" : "installed"} $serverMessage'
             ));
@@ -382,15 +382,15 @@ abstract class IntelliJValidator extends DoctorValidator {
   }
 
   Future<String> _getLatestVersionPossible() async {
-      final String url = 'https://plugins.jetbrains.com/plugins/list?build=IU-$buildNumber&pluginId=io.flutter';
-      
+      final String url = 'https://plugins.jetbrains.com/plugins/list?build=$buildNumber&pluginId=io.flutter';
+
       try {
         final http.Response response = await http.get(url);
         final xml.XmlDocument xmlDocument = xml.parse(response.body);
         final String version = xmlDocument.findAllElements('version').map((xml.XmlElement node) => node.text).first;
         return version;
       } catch (e) {
-        return "Unable to obtain version from Intellij Server";
+        throw "Unable to obtain version from Intellij plugin server";
       }
     }
 
@@ -464,6 +464,7 @@ class IntelliJValidatorOnLinuxAndWindows extends IntelliJValidator {
             String installPath;
             try {
               installPath = fs.file(fs.path.join(dir.path, 'system', '.home')).readAsStringSync();
+              buildNumber = fs.file(fs.path.join(installPath, 'build.txt')).readAsStringSync();
             } catch (e) {
               // ignored
             }

--- a/packages/flutter_tools/lib/src/doctor.dart
+++ b/packages/flutter_tools/lib/src/doctor.dart
@@ -361,7 +361,7 @@ abstract class IntelliJValidator extends DoctorValidator {
         try {
           final String latestFlutter = await _getLatestVersionPossible();
           final Version flutterVersion = new Version.parse(latestFlutter);
-          final String serverMessage = localVersion < flutterVersion ? "[Consider upgrading your plugin version to $latestFlutter]" : "";
+          final String serverMessage = localVersion < flutterVersion ? '[Consider upgrading your plugin version to $latestFlutter]' : '';
             messages.add(new ValidationMessage(
               '$title plugin ${localVersion != null ? "version $localVersion" : "installed"} $serverMessage'
             ));
@@ -388,7 +388,7 @@ abstract class IntelliJValidator extends DoctorValidator {
         final String version = xmlDocument.findAllElements('version').map((xml.XmlElement node) => node.text).first;
         return version;
       } catch (e) {
-        throw "Unable to obtain version from Intellij plugin server";
+        throw 'Unable to check for the plugin updates in the plugin repository';
       }
     }
 

--- a/packages/flutter_tools/lib/src/doctor.dart
+++ b/packages/flutter_tools/lib/src/doctor.dart
@@ -4,10 +4,10 @@
 
 import 'dart:async';
 import 'dart:convert' show UTF8;
-import 'package:http/http.dart' as http;
-import 'package:xml/xml.dart' as xml;
 
 import 'package:archive/archive.dart';
+import 'package:http/http.dart' as http;
+import 'package:xml/xml.dart' as xml;
 
 import 'android/android_studio_validator.dart';
 import 'android/android_workflow.dart';
@@ -335,9 +335,6 @@ abstract class IntelliJValidator extends DoctorValidator {
 
       return;
     }
-
-    
-
     messages.add(new ValidationMessage.error(
       '$title plugin not installed; this adds $title specific functionality.'
     ));
@@ -367,9 +364,9 @@ abstract class IntelliJValidator extends DoctorValidator {
             messages.add(new ValidationMessage(
               '$title plugin ${localVersion != null ? "version $localVersion" : "installed"} $serverMessage'
             ));
-        } catch (e) {
+        } catch (e) {          
           messages.add(new ValidationMessage(
-            '$title plugin ${localVersion != null ? "version $localVersion" : "installed"}'
+            '$title plugin ${localVersion != null ? "version $localVersion" : "installed"} [$e]'
           ));
         }
       }
@@ -393,7 +390,7 @@ abstract class IntelliJValidator extends DoctorValidator {
         final String version = xmlDocument.findAllElements('version').map((xml.XmlElement node) => node.text).first;
         return version;
       } catch (e) {
-        return e;
+        return "Unable to obtain version from Intellij Server";
       }
     }
 

--- a/packages/flutter_tools/lib/src/doctor.dart
+++ b/packages/flutter_tools/lib/src/doctor.dart
@@ -4,8 +4,6 @@
 
 import 'dart:async';
 import 'dart:convert' show UTF8;
-import 'package:http/http.dart' as http;
-import 'package:xml/xml.dart' as xml;
 
 import 'package:archive/archive.dart';
 import 'package:http/http.dart' as http;

--- a/packages/flutter_tools/lib/src/ios/plist_utils.dart
+++ b/packages/flutter_tools/lib/src/ios/plist_utils.dart
@@ -7,6 +7,7 @@ import '../base/process.dart';
 
 const String kCFBundleIdentifierKey = 'CFBundleIdentifier';
 const String kCFBundleShortVersionStringKey = 'CFBundleShortVersionString';
+const String kCFBundleVersionKey = 'CFBundleVersion';
 
 String getValueFromFile(String plistFilePath, String key) {
   // TODO(chinmaygarde): For now, we only need to read from plist files on a mac

--- a/packages/flutter_tools/test/commands/doctor_test.dart
+++ b/packages/flutter_tools/test/commands/doctor_test.dart
@@ -36,4 +36,7 @@ class IntelliJValidatorTestTarget extends IntelliJValidator {
 
   @override
   String get version => 'test.test.test';
+
+  @override
+  String get buildNumber => 'IU-173.3942.27';
 }


### PR DESCRIPTION
This Pull request is to add the functionaly described in issse https://github.com/flutter/flutter/issues/8118
Things it does:
- It validates the packages are installed as always
- Checks minimum version as always
- Obtains latest available plugin version for the version of the IDE Installed. 
- If the server is unavailable or the user is offline it will respond with messages it used to. 

The new message is as follows. 

When the user is online and is at minimum version but not updated
 - Flutter plugin version 20.0.1 [Consider upgrading your plugin version to 20.0.3]

@pq, @mit-mit let me know if you have any comments.
