### PR TITLE
Attempt a less invasive way to disable fading.

### DIFF
--- a/packages/flutter/lib/src/material/page.dart
+++ b/packages/flutter/lib/src/material/page.dart
@@ -18,16 +18,17 @@ final Tween<Offset> _kBottomUpTween = new Tween<Offset>(
 class _MountainViewPageTransition extends StatelessWidget {
   _MountainViewPageTransition({
     Key key,
+    @required bool fade,
     @required Animation<double> routeAnimation,
     @required this.child,
   }) : _positionAnimation = _kBottomUpTween.animate(new CurvedAnimation(
          parent: routeAnimation, // The route's linear 0.0 - 1.0 animation.
          curve: Curves.fastOutSlowIn,
        )),
-       _opacityAnimation = new CurvedAnimation(
+       _opacityAnimation = fade ? new CurvedAnimation(
          parent: routeAnimation,
          curve: Curves.easeIn, // Eyeballed from other Material apps.
-       ),
+       ) : const AlwaysStoppedAnimation<double>(1.0),
        super(key: key);
 
   final Animation<Offset> _positionAnimation;
@@ -82,6 +83,14 @@ class MaterialPageRoute<T> extends PageRoute<T> {
     // ignore: prefer_asserts_in_initializer_lists , https://github.com/dart-lang/sdk/issues/31223
     assert(opaque);
   }
+
+  /// Turns on the fading of routes during page transitions.
+  ///
+  /// This is currently disabled by default because of performance issues on
+  /// low-end phones. Eventually these issues will be resolved and this flag
+  /// will be removed.
+  @Deprecated('This flag will eventually be removed once the performance issues are resolved. See: https://github.com/flutter/flutter/issues/13736')
+  static bool debugEnableFadingRoutes = false;
 
   /// Builds the primary contents of the route.
   final WidgetBuilder builder;
@@ -159,6 +168,7 @@ class MaterialPageRoute<T> extends PageRoute<T> {
       return new _MountainViewPageTransition(
         routeAnimation: animation,
         child: child,
+        fade: debugEnableFadingRoutes, // ignore: deprecated_member_use
       );
     }
   }

--- a/packages/flutter/test/material/page_test.dart
+++ b/packages/flutter/test/material/page_test.dart
@@ -40,7 +40,7 @@ void main() {
     // Animation begins 3/4 of the way up the page.
     expect(widget2TopLeft.dy < widget2Size.height / 4.0, true);
     // Animation starts with page 2 being near transparent.
-    expect(widget2Opacity.opacity < 0.01, true);
+    expect(widget2Opacity.opacity < 0.01, MaterialPageRoute.debugEnableFadingRoutes); // ignore: deprecated_member_use
 
     await tester.pump(const Duration(milliseconds: 300));
 
@@ -59,7 +59,7 @@ void main() {
     // Page 2 starts to move down.
     expect(widget1TopLeft.dy < widget2TopLeft.dy, true);
     // Page 2 starts to lose opacity.
-    expect(widget2Opacity.opacity < 1.0, true);
+    expect(widget2Opacity.opacity < 1.0, MaterialPageRoute.debugEnableFadingRoutes); // ignore: deprecated_member_use
 
     await tester.pump(const Duration(milliseconds: 300));
 


### PR DESCRIPTION
Hopefully this will fix the performance regression in https://github.com/flutter/flutter/pull/13680 but with an easier way to flip the switch.