### PR TITLE
Fixes crash caused by invisible semantics children

### DIFF
--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -2228,7 +2228,13 @@ abstract class RenderObject extends AbstractNode with DiagnosticableTreeMixin im
 
       node = node.parent;
       node._cachedSemanticsConfiguration = null;
-      isEffectiveSemanticsBoundary = node._semantics != null && node._semanticsConfiguration.isSemanticBoundary;
+      isEffectiveSemanticsBoundary = node._semanticsConfiguration.isSemanticBoundary;
+      if (isEffectiveSemanticsBoundary && node._semantics == null) {
+        // We have reached a semantics boundary that doesn't own a semantics node.
+        // That means the semantics of this branch are currently blocked and will
+        // not appear in the semantics tree. We can abort the walk here.
+        return;
+      }
     }
     if (node != this && _semantics != null && _needsSemanticsUpdate) {
       // If `this` node has already been added to [owner._nodesNeedingSemantics]

--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -2228,7 +2228,7 @@ abstract class RenderObject extends AbstractNode with DiagnosticableTreeMixin im
 
       node = node.parent;
       node._cachedSemanticsConfiguration = null;
-      isEffectiveSemanticsBoundary = node._semanticsConfiguration.isSemanticBoundary;
+      isEffectiveSemanticsBoundary = node._semantics != null && node._semanticsConfiguration.isSemanticBoundary;
     }
     if (node != this && _semantics != null && _needsSemanticsUpdate) {
       // If `this` node has already been added to [owner._nodesNeedingSemantics]

--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -3315,12 +3315,29 @@ class RenderSemanticsAnnotations extends RenderProxyBox {
 class RenderBlockSemantics extends RenderProxyBox {
   /// Create a render object that blocks semantics for nodes below it in paint
   /// order.
-  RenderBlockSemantics({ RenderBox child }) : super(child);
+  RenderBlockSemantics({ RenderBox child, bool blocking: true, }) : _blocking = blocking, super(child);
+
+  /// Whether this render object is blocking semantics from the semantic tree.
+  bool get blocking => _blocking;
+  bool _blocking;
+  set blocking(bool value) {
+    assert(value != null);
+    if (value == _blocking)
+      return;
+    _blocking = value;
+    markNeedsSemanticsUpdate();
+  }
 
   @override
   void describeSemanticsConfiguration(SemanticsConfiguration config) {
     super.describeSemanticsConfiguration(config);
-    config.isBlockingSemanticsOfPreviouslyPaintedNodes = true;
+    config.isBlockingSemanticsOfPreviouslyPaintedNodes = blocking;
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder description) {
+    super.debugFillProperties(description);
+    description.add(new DiagnosticsProperty<bool>('blocking', blocking));
   }
 }
 

--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -3317,7 +3317,8 @@ class RenderBlockSemantics extends RenderProxyBox {
   /// order.
   RenderBlockSemantics({ RenderBox child, bool blocking: true, }) : _blocking = blocking, super(child);
 
-  /// Whether this render object is blocking semantics from the semantic tree.
+  /// Whether this render object is blocking semantics of previously painted
+  /// [RenderObject]s below a common semantics boundary from the semantic tree.
   bool get blocking => _blocking;
   bool _blocking;
   set blocking(bool value) {

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -4964,10 +4964,24 @@ class MergeSemantics extends SingleChildRenderObjectWidget {
 class BlockSemantics extends SingleChildRenderObjectWidget {
   /// Creates a widget that excludes the semantics of all widgets painted before
   /// it in the same semantic container.
-  const BlockSemantics({ Key key, Widget child }) : super(key: key, child: child);
+  const BlockSemantics({ Key key, this.blocking: true, Widget child }) : super(key: key, child: child);
+
+  /// Whether this widget is blocking semantics in the semantics tree.
+  final bool blocking;
 
   @override
-  RenderBlockSemantics createRenderObject(BuildContext context) => new RenderBlockSemantics();
+  RenderBlockSemantics createRenderObject(BuildContext context) => new RenderBlockSemantics(blocking: blocking);
+
+  @override
+  void updateRenderObject(BuildContext context, RenderBlockSemantics renderObject) {
+    renderObject.blocking = blocking;
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder description) {
+    super.debugFillProperties(description);
+    description.add(new DiagnosticsProperty<bool>('blocking', blocking));
+  }
 }
 
 /// A widget that drops all the semantics of its descendants.

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -4966,7 +4966,8 @@ class BlockSemantics extends SingleChildRenderObjectWidget {
   /// it in the same semantic container.
   const BlockSemantics({ Key key, this.blocking: true, Widget child }) : super(key: key, child: child);
 
-  /// Whether this widget is blocking semantics in the semantics tree.
+  /// Whether this widget is blocking semantics of all widget that were painted
+  /// before it in the same semantic container.
   final bool blocking;
 
   @override

--- a/packages/flutter/test/widgets/semantics_6_test.dart
+++ b/packages/flutter/test/widgets/semantics_6_test.dart
@@ -26,34 +26,46 @@ void main() {
     );
 
     await tester.pumpWidget(buildWidget(
-      invisibleText: 'one',
+      blockedText: 'one',
     ));
 
     expect(semantics, hasSemantics(expectedSemantics));
 
     // The purpose of the test is to ensure that this change does not throw.
     await tester.pumpWidget(buildWidget(
-        invisibleText: 'two',
+        blockedText: 'two',
     ));
 
     expect(semantics, hasSemantics(expectedSemantics));
+
+    // Ensure that the previously blocked semantics end up in the tree correctly when unblocked.
+    await tester.pumpWidget(buildWidget(
+      blockedText: 'two',
+      blocking: false,
+    ));
+    expect(semantics, includesNodeWith(label: 'two', textDirection: TextDirection.ltr));
+
     semantics.dispose();
   });
 }
 
-Widget buildWidget({ @required String invisibleText }) {
-  assert(invisibleText != null);
+Widget buildWidget({ @required String blockedText, bool blocking: true }) {
+  assert(blockedText != null);
   return new Directionality(
     textDirection: TextDirection.ltr,
     child: new Stack(
         fit: StackFit.expand,
         children: <Widget>[
-          new ListView(
-            children: <Widget>[
-              new Text(invisibleText),
-            ],
+          new Semantics(
+            container: true,
+            child: new ListView(
+              children: <Widget>[
+                new Text(blockedText),
+              ],
+            ),
           ),
           new BlockSemantics(
+            blocking: blocking,
             child: new Semantics(
               label: 'hello',
               container: true,

--- a/packages/flutter/test/widgets/semantics_6_test.dart
+++ b/packages/flutter/test/widgets/semantics_6_test.dart
@@ -1,0 +1,65 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:meta/meta.dart';
+
+import 'semantics_tester.dart';
+
+void main() {
+  testWidgets('can change semantics in a branch blocked by BlockSemantics', (WidgetTester tester) async {
+    final SemanticsTester semantics = new SemanticsTester(tester);
+
+    final TestSemantics expectedSemantics = new TestSemantics.root(
+      children: <TestSemantics>[
+        new TestSemantics.rootChild(
+          id: 1,
+          label: 'hello',
+          textDirection: TextDirection.ltr,
+          rect: TestSemantics.fullScreen,
+        )
+      ],
+    );
+
+    await tester.pumpWidget(buildWidget(
+      invisibleText: 'one',
+    ));
+
+    expect(semantics, hasSemantics(expectedSemantics));
+
+    // The purpose of the test is to ensure that this change does not throw.
+    await tester.pumpWidget(buildWidget(
+        invisibleText: 'two',
+    ));
+
+    expect(semantics, hasSemantics(expectedSemantics));
+    semantics.dispose();
+  });
+}
+
+Widget buildWidget({ @required String invisibleText }) {
+  assert(invisibleText != null);
+  return new Directionality(
+    textDirection: TextDirection.ltr,
+    child: new Stack(
+        fit: StackFit.expand,
+        children: <Widget>[
+          new ListView(
+            children: <Widget>[
+              new Text(invisibleText),
+            ],
+          ),
+          new BlockSemantics(
+            child: new Semantics(
+              label: 'hello',
+              container: true,
+            ),
+          ),
+        ]
+    ),
+  );
+}


### PR DESCRIPTION
**tl;dr:** A `RenderObject` can only be an effective semantics boundary if it actually owned a `SemanticsNode` in the previous tree generation.

When using the `BlockSemantics` widget it is possible to introduce `RenderObject`s that are configured to be a semantics boundary, but because their semantics are blocked by `BlockSemantics` they will not (immediately) end up owning a `SemanticsNode`. When now a descendant of such a node-less semantics boundary marks itself as needing a semantics update we walk up the tree until we find the closest semantics boundary (which is our node-less `RenderObject`). We now incorrectly assume that this semantics boundary has a valid `SemanticsNode` and only regenerate the semantics subtree below this node. However, because the identified semantics boundary doesn't actually own a valid `SemanticsNode` asserts are throwing (e.g. `Child with id xx is invisible and should not be added to tree.`).

To fix this problem, we can just abort the walk if we reach a semantics boundary without a semantics node because (for now) we know that the semantics information of this branch will not make it into the final semantics tree.
If the semantics block is ever removed, the current algorithm re-generates the semantics for the entire branch and the semantics will be up-to-date then despite the abort. I've added a test to verify this to make sure it continues to work even when we change the algorithm.

Fixes https://github.com/flutter/flutter/issues/13326.
/cc @gavindoughtie FYI