### PR TITLE
RouteObserver supports multiple RouteAware per Route.

### DIFF
--- a/packages/flutter/test/widgets/routes_test.dart
+++ b/packages/flutter/test/widgets/routes_test.dart
@@ -453,6 +453,31 @@ void main() {
       observer.didPop(route, pageRoute);
       verifyNoMoreInteractions(pageRouteAware);
     });
+
+    test('does not call listeners when already subscribed', () {
+      final RouteObserver<PageRoute<dynamic>> observer = new RouteObserver<PageRoute<dynamic>>();
+      final RouteAware pageRouteAware = new MockRouteAware();
+      final MockPageRoute pageRoute = new MockPageRoute();
+      observer.subscribe(pageRouteAware, pageRoute);
+      observer.subscribe(pageRouteAware, pageRoute);
+      verify(pageRouteAware.didPush()).called(1);
+    });
+
+    test('does not call listeners when unsubscribed', () {
+      final RouteObserver<PageRoute<dynamic>> observer = new RouteObserver<PageRoute<dynamic>>();
+      final RouteAware pageRouteAware = new MockRouteAware();
+      final MockPageRoute pageRoute = new MockPageRoute();
+      final MockPageRoute nextPageRoute = new MockPageRoute();
+      observer.subscribe(pageRouteAware, pageRoute);
+      observer.subscribe(pageRouteAware, nextPageRoute);
+      verify(pageRouteAware.didPush()).called(2);
+
+      observer.unsubscribe(pageRouteAware);
+
+      observer.didPush(nextPageRoute, pageRoute);
+      observer.didPop(nextPageRoute, pageRoute);
+      verifyNoMoreInteractions(pageRouteAware);
+    });
   });
 }
 


### PR DESCRIPTION
Hi there,

### Problem
RouteObserver does not unsubscribe. If widget gets recreated, it may subscribe to the same route 2nd time before 1st widget unsubscribes. This would not subscribe 2nd widget.

### Proposed Solution
1. RouteObserver supports multiple RouteAware per Route
2. Unsubscribe should remove RouteAware for all routes

### Code Styling
`didPop` could look nicer with `subscribers?.forEach`, but I got lint warning not to use it.

### Tests
1. Does nothing if subscribe is called more than once
2. Should not call any listeners once unsubscribed

Thank you!