### PR TITLE
Fix gen_snapshot name, path for Windows.

### DIFF
--- a/packages/flutter_tools/lib/src/artifacts.dart
+++ b/packages/flutter_tools/lib/src/artifacts.dart
@@ -7,6 +7,7 @@ import 'package:meta/meta.dart';
 import 'base/context.dart';
 import 'base/file_system.dart';
 import 'base/platform.dart';
+import 'base/process_manager.dart';
 import 'build_info.dart';
 import 'globals.dart';
 
@@ -33,7 +34,7 @@ String _artifactToFileName(Artifact artifact) {
     case Artifact.dartVmEntryPointsTxt:
       return 'dart_vm_entry_points.txt';
     case Artifact.genSnapshot:
-      return platform.isWindows ? 'gen_snapshot.exe' : 'gen_snapshot';
+      return 'gen_snapshot';
     case Artifact.flutterTester:
       return 'flutter_tester';
     case Artifact.snapshotDart:
@@ -266,7 +267,7 @@ class LocalEngineArtifacts extends Artifacts {
     final String genSnapshotName = _artifactToFileName(Artifact.genSnapshot);
     for (String clangDir in clangDirs) {
       final String genSnapshotPath = fs.path.join(engineOutPath, clangDir, genSnapshotName);
-      if (fs.file(genSnapshotPath).existsSync())
+      if (processManager.canRun(genSnapshotPath))
         return genSnapshotPath;
     }
     throw new Exception('Unable to find $genSnapshotName');

--- a/packages/flutter_tools/lib/src/artifacts.dart
+++ b/packages/flutter_tools/lib/src/artifacts.dart
@@ -33,7 +33,7 @@ String _artifactToFileName(Artifact artifact) {
     case Artifact.dartVmEntryPointsTxt:
       return 'dart_vm_entry_points.txt';
     case Artifact.genSnapshot:
-      return 'gen_snapshot';
+      return platform.isWindows ? 'gen_snapshot.exe' : 'gen_snapshot';
     case Artifact.flutterTester:
       return 'flutter_tester';
     case Artifact.snapshotDart:
@@ -262,7 +262,7 @@ class LocalEngineArtifacts extends Artifacts {
   }
 
   String _genSnapshotPath() {
-    const List<String> clangDirs = const <String>['clang_x86', 'clang_x64', 'clang_i386'];
+    const List<String> clangDirs = const <String>['.', 'clang_x86', 'clang_x64', 'clang_i386'];
     final String genSnapshotName = _artifactToFileName(Artifact.genSnapshot);
     for (String clangDir in clangDirs) {
       final String genSnapshotPath = fs.path.join(engineOutPath, clangDir, genSnapshotName);


### PR DESCRIPTION
Use `canRun` instead of check for file existence because it is guaranteed to work on Windows(where executable file have '.exe' extension) on Windows. 

Also, gen_snapshot on Windows is in build folder, rather than in `clang_*` subfolder.