### PR TITLE
Exclude flutter doctor IDE validators in CI environments

### DIFF
--- a/packages/flutter_tools/lib/src/doctor.dart
+++ b/packages/flutter_tools/lib/src/doctor.dart
@@ -16,6 +16,7 @@ import 'base/file_system.dart';
 import 'base/os.dart';
 import 'base/platform.dart';
 import 'base/process_manager.dart';
+import 'base/utils.dart' show isRunningOnBot;
 import 'base/version.dart';
 import 'cache.dart';
 import 'device.dart';
@@ -40,13 +41,15 @@ class Doctor {
       if (iosWorkflow.appliesToHostPlatform)
         _validators.add(iosWorkflow);
 
-      final List<DoctorValidator> ideValidators = <DoctorValidator>[];
-      ideValidators.addAll(AndroidStudioValidator.allValidators);
-      ideValidators.addAll(IntelliJValidator.installedValidators);
-      if (ideValidators.isNotEmpty)
-        _validators.addAll(ideValidators);
-      else
-        _validators.add(new NoIdeValidator());
+      if (!isRunningOnBot) {
+        final List<DoctorValidator> ideValidators = <DoctorValidator>[];
+        ideValidators.addAll(AndroidStudioValidator.allValidators);
+        ideValidators.addAll(IntelliJValidator.installedValidators);
+        if (ideValidators.isNotEmpty)
+          _validators.addAll(ideValidators);
+        else
+          _validators.add(new NoIdeValidator());
+      }
 
       if (deviceManager.canListAnything)
         _validators.add(new DeviceValidator());


### PR DESCRIPTION
`flutter doctor` exits with a non-zero status code when one of the defined [IDE validators](https://github.com/flutter/flutter/blob/master/packages/flutter_tools/lib/src/doctor.dart#L43) returns `ValidationType.missing`:

- https://github.com/flutter/flutter/blob/master/packages/flutter_tools/lib/src/commands/doctor.dart#L28
- https://github.com/flutter/flutter/blob/master/packages/flutter_tools/lib/src/doctor.dart#L108

Due to this, one cannot use the exit status of `flutter doctor` command in a CI environment to determine whether flutter system requirements are met.

For example, in GitLab CI, the GitLab Runner stops executing when it encounters a command within a job that exits with a non zero code.
I had to use `RUN flutter doctor || exit 0` instead of `RUN flutter doctor` to prevent the build job from failing after running `flutter doctor` in a Docker container image based on Debian Stretch where no IDE is installed.
- https://gitlab.com/alibitek-flutter/flutter-docker-images/blob/master/Dockerfile_Flutter_Android#L75