### PR TITLE
Idea: Provide initial data to the StreamBuilder

### DIFF
--- a/packages/flutter/lib/src/widgets/async.dart
+++ b/packages/flutter/lib/src/widgets/async.dart
@@ -267,13 +267,13 @@ typedef Widget AsyncWidgetBuilder<T>(BuildContext context, AsyncSnapshot<T> snap
 /// a [Stream].
 ///
 /// Widget rebuilding is scheduled by each interaction, using [State.setState],
-/// but is otherwise decoupled from the timing of the stream. The [build] method
+/// but is otherwise decoupled from the timing of the stream. The [builder]
 /// is called at the discretion of the Flutter pipeline, and will thus receive a
 /// timing-dependent sub-sequence of the snapshots that represent the
 /// interaction with the stream.
 ///
 /// As an example, when interacting with a stream producing the integers
-/// 0 through 9, the [build] method may be called with any ordered sub-sequence
+/// 0 through 9, the [builder] may be called with any ordered sub-sequence
 /// of the following snapshots that includes the last one (the one with
 /// ConnectionState.done):
 ///
@@ -284,8 +284,9 @@ typedef Widget AsyncWidgetBuilder<T>(BuildContext context, AsyncSnapshot<T> snap
 /// * `new AsyncSnapshot<int>.withData(ConnectionState.active, 9)`
 /// * `new AsyncSnapshot<int>.withData(ConnectionState.done, 9)`
 ///
-/// The actual sequence of invocations of [build] depends on the relative timing
-/// of events produced by the stream and the build rate of the Flutter pipeline.
+/// The actual sequence of invocations of the [builder] depends on the relative
+/// timing of events produced by the stream and the build rate of the Flutter
+/// pipeline.
 ///
 /// Changing the [StreamBuilder] configuration to another stream during event
 /// generation introduces snapshot pairs of the form
@@ -303,15 +304,10 @@ typedef Widget AsyncWidgetBuilder<T>(BuildContext context, AsyncSnapshot<T> snap
 /// The data and error fields of snapshots produced are only changed when the
 /// state is `ConnectionState.active`.
 ///
-/// By default, the initial snapshot will not contain data, resulting in a
-/// snapshot of the form
-///
-/// * `new AsyncSnapshot<String>.withData(ConnectionState.none, null)`
-///
-/// You can override this by providing [initialData], which results in a
-/// snapshot of the form
-///
-/// * `new AsyncSnapshot<String>.withData(ConnectionState.none, 'initial data')`
+/// The initial snapshot data can be controlled by specifying [initialData].
+/// You would use this facility to ensure that if the [builder] is invoked
+/// before the first event arrives on the stream, the snapshot carries data of
+/// your choice rather than the default null value.
 ///
 /// See also:
 ///
@@ -344,7 +340,7 @@ class StreamBuilder<T> extends StreamBuilderBase<T, AsyncSnapshot<T>> {
   /// Creates a new [StreamBuilder] that builds itself based on the latest
   /// snapshot of interaction with the specified [stream] and whose build
   /// strategy is given by [builder]. The [initialData] is used to create the
-  /// first snapshot delivered to the [builder].
+  /// initial snapshot. It is null by default.
   const StreamBuilder({
     Key key,
     this.initialData,
@@ -407,15 +403,10 @@ class StreamBuilder<T> extends StreamBuilderBase<T, AsyncSnapshot<T>> {
 /// * `new AsyncSnapshot<String>.withData(ConnectionState.waiting, null)`
 /// * `new AsyncSnapshot<String>.withError(ConnectionState.done, 'some error')`
 ///
-/// By default, the initial snapshot delivered to the [builder] will not contain
-/// data, resulting in a snapshot of the form:
-///
-/// * `new AsyncSnapshot<String>.withData(ConnectionState.waiting, null)`
-///
-/// You can override this by providing [initialData], which results in a
-/// snapshot of the form:
-///
-/// * `new AsyncSnapshot<String>.withData(ConnectionState.waiting, 'initial data')`
+/// The initial snapshot data can be controlled by specifying [initialData]. You
+/// would use this facility to ensure that if the [builder] is invoked before
+/// the future completes, the snapshot carries data of your choice rather than
+/// the default null value.
 ///
 /// The data and error fields of the snapshot change only as the connection
 /// state field transitions from `waiting` to `done`, and they will be retained
@@ -493,7 +484,7 @@ class _FutureBuilderState<T> extends State<FutureBuilder<T>> {
   @override
   void initState() {
     super.initState();
-    _snapshot = new AsyncSnapshot<T>.withData(ConnectionState.none, widget.initialData); // ignore: prefer_const_constructors
+    _snapshot = new AsyncSnapshot<T>.withData(ConnectionState.none, widget.initialData);
     _subscribe();
   }
 

--- a/packages/flutter/lib/src/widgets/async.dart
+++ b/packages/flutter/lib/src/widgets/async.dart
@@ -303,6 +303,16 @@ typedef Widget AsyncWidgetBuilder<T>(BuildContext context, AsyncSnapshot<T> snap
 /// The data and error fields of snapshots produced are only changed when the
 /// state is `ConnectionState.active`.
 ///
+/// By default, the initial snapshot will not contain data, resulting in a
+/// snapshot of the form
+///
+/// * `new AsyncSnapshot<String>.withData(ConnectionState.none, null)`
+///
+/// You can override this by providing [initialData], which results in a
+/// snapshot of the form
+///
+/// * `new AsyncSnapshot<String>.withData(ConnectionState.none, 'initial data')`
+///
 /// See also:
 ///
 /// * [StreamBuilderBase], which supports widget building based on a computation
@@ -333,9 +343,8 @@ typedef Widget AsyncWidgetBuilder<T>(BuildContext context, AsyncSnapshot<T> snap
 class StreamBuilder<T> extends StreamBuilderBase<T, AsyncSnapshot<T>> {
   /// Creates a new [StreamBuilder] that builds itself based on the latest
   /// snapshot of interaction with the specified [stream] and whose build
-  /// strategy is given by [builder]. You can also specify the [initialData],
-  /// which will be contained within the first AsyncSnapshot delivered to
-  /// your [builder].
+  /// strategy is given by [builder]. The [initialData] is used to create the
+  /// first snapshot delivered to the [builder].
   const StreamBuilder({
     Key key,
     this.initialData,
@@ -348,8 +357,7 @@ class StreamBuilder<T> extends StreamBuilderBase<T, AsyncSnapshot<T>> {
   /// The build strategy currently used by this builder. Cannot be null.
   final AsyncWidgetBuilder<T> builder;
 
-  /// Allows you to provide data for the first AsyncSnapshot sent to the
-  /// [builder]. By default, no data will be provided.
+  /// The data that will be used to create the initial snapshot. Null by default.
   final T initialData;
 
   @override
@@ -399,6 +407,16 @@ class StreamBuilder<T> extends StreamBuilderBase<T, AsyncSnapshot<T>> {
 /// * `new AsyncSnapshot<String>.withData(ConnectionState.waiting, null)`
 /// * `new AsyncSnapshot<String>.withError(ConnectionState.done, 'some error')`
 ///
+/// By default, the initial snapshot delivered to the [builder] will not contain
+/// data, resulting in a snapshot of the form:
+///
+/// * `new AsyncSnapshot<String>.withData(ConnectionState.waiting, null)`
+///
+/// You can override this by providing [initialData], which results in a
+/// snapshot of the form:
+///
+/// * `new AsyncSnapshot<String>.withData(ConnectionState.waiting, 'initial data')`
+///
 /// The data and error fields of the snapshot change only as the connection
 /// state field transitions from `waiting` to `done`, and they will be retained
 /// when changing the [FutureBuilder] configuration to another future. If the
@@ -445,6 +463,7 @@ class FutureBuilder<T> extends StatefulWidget {
   const FutureBuilder({
     Key key,
     this.future,
+    this.initialData,
     @required this.builder
   }) : assert(builder != null),
        super(key: key);
@@ -456,6 +475,9 @@ class FutureBuilder<T> extends StatefulWidget {
   /// The build strategy currently used by this builder. Cannot be null.
   final AsyncWidgetBuilder<T> builder;
 
+  /// The data that will be used to create the initial snapshot. Null by default.
+  final T initialData;
+
   @override
   State<FutureBuilder<T>> createState() => new _FutureBuilderState<T>();
 }
@@ -466,11 +488,12 @@ class _FutureBuilderState<T> extends State<FutureBuilder<T>> {
   /// calling setState from stale callbacks, e.g. after disposal of this state,
   /// or after widget reconfiguration to a new Future.
   Object _activeCallbackIdentity;
-  AsyncSnapshot<T> _snapshot = new AsyncSnapshot<T>.nothing(); // ignore: prefer_const_constructors
+  AsyncSnapshot<T> _snapshot;
 
   @override
   void initState() {
     super.initState();
+    _snapshot = new AsyncSnapshot<T>.withData(ConnectionState.none, widget.initialData); // ignore: prefer_const_constructors
     _subscribe();
   }
 

--- a/packages/flutter/lib/src/widgets/async.dart
+++ b/packages/flutter/lib/src/widgets/async.dart
@@ -333,19 +333,27 @@ typedef Widget AsyncWidgetBuilder<T>(BuildContext context, AsyncSnapshot<T> snap
 class StreamBuilder<T> extends StreamBuilderBase<T, AsyncSnapshot<T>> {
   /// Creates a new [StreamBuilder] that builds itself based on the latest
   /// snapshot of interaction with the specified [stream] and whose build
-  /// strategy is given by [builder].
+  /// strategy is given by [builder]. You can also specify the [initialData],
+  /// which will be contained within the first AsyncSnapshot delivered to
+  /// your [builder].
   const StreamBuilder({
     Key key,
+    this.initialData,
     Stream<T> stream,
     @required this.builder
-  }) : assert(builder != null),
-       super(key: key, stream: stream);
+  })
+      : assert(builder != null),
+        super(key: key, stream: stream);
 
   /// The build strategy currently used by this builder. Cannot be null.
   final AsyncWidgetBuilder<T> builder;
 
+  /// Allows you to provide data for the first AsyncSnapshot sent to the
+  /// [builder]. By default, no data will be provided.
+  final T initialData;
+
   @override
-  AsyncSnapshot<T> initial() => new AsyncSnapshot<T>.nothing(); // ignore: prefer_const_constructors
+  AsyncSnapshot<T> initial() => new AsyncSnapshot<T>.withData(ConnectionState.none, initialData);
 
   @override
   AsyncSnapshot<T> afterConnected(AsyncSnapshot<T> current) => current.inState(ConnectionState.waiting);

--- a/packages/flutter/test/widgets/async_test.dart
+++ b/packages/flutter/test/widgets/async_test.dart
@@ -180,6 +180,19 @@ void main() {
       await eventFiring(tester);
       expect(find.text('AsyncSnapshot(ConnectionState.done, 4, null)'), findsOneWidget);
     });
+    testWidgets('runs the builder using given initial data', (WidgetTester tester) async {
+      final String initial = 'A';
+      final StreamController<String> controller = new StreamController<String>();
+      await tester.pumpWidget(new StreamBuilder<String>(
+        stream: controller.stream,
+        builder: snapshotText,
+        initialData: initial,
+      ));
+      expect(
+        find.text('AsyncSnapshot(ConnectionState.waiting, $initial, null)'),
+        findsOneWidget,
+      );
+    });
   });
   group('FutureBuilder and StreamBuilder behave identically on Stream from Future', () {
     testWidgets('when completing with data', (WidgetTester tester) async {

--- a/packages/flutter/test/widgets/async_test.dart
+++ b/packages/flutter/test/widgets/async_test.dart
@@ -121,19 +121,28 @@ void main() {
     testWidgets('runs the builder using given initial data', (WidgetTester tester) async {
       final GlobalKey key = new GlobalKey();
       await tester.pumpWidget(new FutureBuilder<String>(
-        key: key, future: null, builder: snapshotText, initialData: 'I'
+        key: key,
+        future: null,
+        builder: snapshotText,
+        initialData: 'I',
       ));
       expect(find.text('AsyncSnapshot(ConnectionState.none, I, null)'), findsOneWidget);
     });
     testWidgets('ignores initialData when reconfiguring', (WidgetTester tester) async {
       final GlobalKey key = new GlobalKey();
       await tester.pumpWidget(new FutureBuilder<String>(
-        key: key, future: null, builder: snapshotText, initialData: 'I'
+        key: key,
+        future: null,
+        builder: snapshotText,
+        initialData: 'I',
       ));
       expect(find.text('AsyncSnapshot(ConnectionState.none, I, null)'), findsOneWidget);
       final Completer<String> completer = new Completer<String>();
       await tester.pumpWidget(new FutureBuilder<String>(
-        key: key, future: completer.future, builder: snapshotText, initialData: 'Ignored'
+        key: key,
+        future: completer.future,
+        builder: snapshotText,
+        initialData: 'Ignored',
       ));
       expect(find.text('AsyncSnapshot(ConnectionState.waiting, I, null)'), findsOneWidget);
     });
@@ -201,18 +210,28 @@ void main() {
     });
     testWidgets('runs the builder using given initial data', (WidgetTester tester) async {
       final StreamController<String> controller = new StreamController<String>();
-      await tester.pumpWidget(new StreamBuilder<String>(stream: controller.stream, builder: snapshotText, initialData: 'I'));
+      await tester.pumpWidget(new StreamBuilder<String>(
+        stream: controller.stream,
+        builder: snapshotText,
+        initialData: 'I',
+      ));
       expect(find.text('AsyncSnapshot(ConnectionState.waiting, I, null)'), findsOneWidget);
     });
     testWidgets('ignores initialData when reconfiguring', (WidgetTester tester) async {
       final GlobalKey key = new GlobalKey();
       await tester.pumpWidget(new StreamBuilder<String>(
-        key: key, stream: null, builder: snapshotText, initialData: 'I'
+        key: key,
+        stream: null,
+        builder: snapshotText,
+        initialData: 'I',
       ));
       expect(find.text('AsyncSnapshot(ConnectionState.none, I, null)'), findsOneWidget);
       final StreamController<String> controller = new StreamController<String>();
       await tester.pumpWidget(new StreamBuilder<String>(
-        key: key, stream: controller.stream, builder: snapshotText, initialData: 'Ignored'
+        key: key,
+        stream: controller.stream,
+        builder: snapshotText,
+        initialData: 'Ignored',
       ));
       expect(find.text('AsyncSnapshot(ConnectionState.waiting, I, null)'), findsOneWidget);
     });

--- a/packages/flutter/test/widgets/async_test.dart
+++ b/packages/flutter/test/widgets/async_test.dart
@@ -66,19 +66,6 @@ void main() {
       ));
       expect(find.text('AsyncSnapshot(ConnectionState.waiting, null, null)'), findsOneWidget);
     });
-    testWidgets('gracefully handles transition from null future with initial data without introducing new states', (WidgetTester tester) async {
-      final String initial = 'initial';
-      final GlobalKey key = new GlobalKey();
-      await tester.pumpWidget(new FutureBuilder<String>(
-        key: key, future: null, builder: snapshotText, initialData: initial,
-      ));
-      expect(find.text('AsyncSnapshot(ConnectionState.none, $initial, null)'), findsOneWidget);
-      final Completer<String> completer = new Completer<String>();
-      await tester.pumpWidget(new FutureBuilder<String>(
-        key: key, future: completer.future, builder: snapshotText, initialData: 'No change',
-      ));
-      expect(find.text('AsyncSnapshot(ConnectionState.waiting, $initial, null)'), findsOneWidget);
-    });
     testWidgets('gracefully handles transition to null future', (WidgetTester tester) async {
       final GlobalKey key = new GlobalKey();
       final Completer<String> completer = new Completer<String>();
@@ -94,22 +81,6 @@ void main() {
       await eventFiring(tester);
       expect(find.text('AsyncSnapshot(ConnectionState.none, null, null)'), findsOneWidget);
     });
-    testWidgets('gracefully handles transition to null future with initial data without introducing new states', (WidgetTester tester) async {
-      final String initial = 'initial';
-      final GlobalKey key = new GlobalKey();
-      final Completer<String> completer = new Completer<String>();
-      await tester.pumpWidget(new FutureBuilder<String>(
-        key: key, future: completer.future, builder: snapshotText, initialData: initial,
-      ));
-      expect(find.text('AsyncSnapshot(ConnectionState.waiting, $initial, null)'), findsOneWidget);
-      await tester.pumpWidget(new FutureBuilder<String>(
-        key: key, future: null, builder: snapshotText, initialData: 'No change',
-      ));
-      expect(find.text('AsyncSnapshot(ConnectionState.none, $initial, null)'), findsOneWidget);
-      completer.complete('hello');
-      await eventFiring(tester);
-      expect(find.text('AsyncSnapshot(ConnectionState.none, $initial, null)'), findsOneWidget);
-    });
     testWidgets('gracefully handles transition to other future', (WidgetTester tester) async {
       final GlobalKey key = new GlobalKey();
       final Completer<String> completerA = new Completer<String>();
@@ -122,24 +93,6 @@ void main() {
         key: key, future: completerB.future, builder: snapshotText
       ));
       expect(find.text('AsyncSnapshot(ConnectionState.waiting, null, null)'), findsOneWidget);
-      completerB.complete('B');
-      completerA.complete('A');
-      await eventFiring(tester);
-      expect(find.text('AsyncSnapshot(ConnectionState.done, B, null)'), findsOneWidget);
-    });
-    testWidgets('gracefully handles transition to other future with initial data without introducing new states', (WidgetTester tester) async {
-      final String initial = 'initial';
-      final GlobalKey key = new GlobalKey();
-      final Completer<String> completerA = new Completer<String>();
-      final Completer<String> completerB = new Completer<String>();
-      await tester.pumpWidget(new FutureBuilder<String>(
-        key: key, future: completerA.future, builder: snapshotText, initialData: initial,
-      ));
-      expect(find.text('AsyncSnapshot(ConnectionState.waiting, $initial, null)'), findsOneWidget);
-      await tester.pumpWidget(new FutureBuilder<String>(
-        key: key, future: completerB.future, builder: snapshotText, initialData: 'No change',
-      ));
-      expect(find.text('AsyncSnapshot(ConnectionState.waiting, $initial, null)'), findsOneWidget);
       completerB.complete('B');
       completerA.complete('A');
       await eventFiring(tester);
@@ -165,6 +118,25 @@ void main() {
       await eventFiring(tester);
       expect(find.text('AsyncSnapshot(ConnectionState.done, null, bad)'), findsOneWidget);
     });
+    testWidgets('runs the builder using given initial data', (WidgetTester tester) async {
+      final GlobalKey key = new GlobalKey();
+      await tester.pumpWidget(new FutureBuilder<String>(
+        key: key, future: null, builder: snapshotText, initialData: 'I',
+      ));
+      expect(find.text('AsyncSnapshot(ConnectionState.none, I, null)'), findsOneWidget);
+    });
+    testWidgets('ignores initialData when reconfiguring', (WidgetTester tester) async {
+      final GlobalKey key = new GlobalKey();
+      await tester.pumpWidget(new FutureBuilder<String>(
+        key: key, future: null, builder: snapshotText, initialData: 'I',
+      ));
+      expect(find.text('AsyncSnapshot(ConnectionState.none, I, null)'), findsOneWidget);
+      final Completer<String> completer = new Completer<String>();
+      await tester.pumpWidget(new FutureBuilder<String>(
+        key: key, future: completer.future, builder: snapshotText, initialData: 'Ignored',
+      ));
+      expect(find.text('AsyncSnapshot(ConnectionState.waiting, I, null)'), findsOneWidget);
+    });
   });
   group('StreamBuilder', () {
     testWidgets('gracefully handles transition from null stream', (WidgetTester tester) async {
@@ -179,19 +151,6 @@ void main() {
       ));
       expect(find.text('AsyncSnapshot(ConnectionState.waiting, null, null)'), findsOneWidget);
     });
-    testWidgets('gracefully handles transition from null stream with initial data without introducing new states', (WidgetTester tester) async {
-      final String initial = 'initial';
-      final GlobalKey key = new GlobalKey();
-      await tester.pumpWidget(new StreamBuilder<String>(
-        key: key, stream: null, builder: snapshotText, initialData: initial,
-      ));
-      expect(find.text('AsyncSnapshot(ConnectionState.none, $initial, null)'), findsOneWidget);
-      final StreamController<String> controller = new StreamController<String>();
-      await tester.pumpWidget(new StreamBuilder<String>(
-        key: key, stream: controller.stream, builder: snapshotText, initialData: 'No change',
-      ));
-      expect(find.text('AsyncSnapshot(ConnectionState.waiting, $initial, null)'), findsOneWidget);
-    });
     testWidgets('gracefully handles transition to null stream', (WidgetTester tester) async {
       final GlobalKey key = new GlobalKey();
       final StreamController<String> controller = new StreamController<String>();
@@ -204,22 +163,6 @@ void main() {
       ));
       expect(find.text('AsyncSnapshot(ConnectionState.none, null, null)'), findsOneWidget);
     });
-    testWidgets('gracefully handles transition to null stream with initial data without introducing new states', (WidgetTester tester) async {
-      final String initial = 'initial';
-      final GlobalKey key = new GlobalKey();
-      final StreamController<String> controller = new StreamController<String>();
-      await tester.pumpWidget(new StreamBuilder<String>(
-        key: key, stream: controller.stream, builder: snapshotText, initialData: initial,
-      ));
-      expect(find.text('AsyncSnapshot(ConnectionState.waiting, $initial, null)'), findsOneWidget);
-      controller.add('A');
-      await eventFiring(tester);
-      expect(find.text('AsyncSnapshot(ConnectionState.active, A, null)'), findsOneWidget);
-      await tester.pumpWidget(new StreamBuilder<String>(
-        key: key, stream: null, builder: snapshotText, initialData: 'No change',
-      ));
-      expect(find.text('AsyncSnapshot(ConnectionState.none, A, null)'), findsOneWidget);
-    });
     testWidgets('gracefully handles transition to other stream', (WidgetTester tester) async {
       final GlobalKey key = new GlobalKey();
       final StreamController<String> controllerA = new StreamController<String>();
@@ -230,23 +173,6 @@ void main() {
       expect(find.text('AsyncSnapshot(ConnectionState.waiting, null, null)'), findsOneWidget);
       await tester.pumpWidget(new StreamBuilder<String>(
         key: key, stream: controllerB.stream, builder: snapshotText
-      ));
-      controllerB.add('B');
-      controllerA.add('A');
-      await eventFiring(tester);
-      expect(find.text('AsyncSnapshot(ConnectionState.active, B, null)'), findsOneWidget);
-    });
-    testWidgets('gracefully handles transition to other stream with initial data without introducing new states', (WidgetTester tester) async {
-      final String initial = 'initial';
-      final GlobalKey key = new GlobalKey();
-      final StreamController<String> controllerA = new StreamController<String>();
-      final StreamController<String> controllerB = new StreamController<String>();
-      await tester.pumpWidget(new StreamBuilder<String>(
-        key: key, stream: controllerA.stream, builder: snapshotText, initialData: initial,
-      ));
-      expect(find.text('AsyncSnapshot(ConnectionState.waiting, $initial, null)'), findsOneWidget);
-      await tester.pumpWidget(new StreamBuilder<String>(
-        key: key, stream: controllerB.stream, builder: snapshotText, initialData: 'No change',
       ));
       controllerB.add('B');
       controllerA.add('A');
@@ -274,17 +200,25 @@ void main() {
       expect(find.text('AsyncSnapshot(ConnectionState.done, 4, null)'), findsOneWidget);
     });
     testWidgets('runs the builder using given initial data', (WidgetTester tester) async {
-      final String initial = 'A';
       final StreamController<String> controller = new StreamController<String>();
       await tester.pumpWidget(new StreamBuilder<String>(
         stream: controller.stream,
         builder: snapshotText,
-        initialData: initial,
+        initialData: 'I',
       ));
-      expect(
-        find.text('AsyncSnapshot(ConnectionState.waiting, $initial, null)'),
-        findsOneWidget,
-      );
+      expect(find.text('AsyncSnapshot(ConnectionState.waiting, I, null)'), findsOneWidget);
+    });
+    testWidgets('ignores initialData when reconfiguring', (WidgetTester tester) async {
+      final GlobalKey key = new GlobalKey();
+      await tester.pumpWidget(new StreamBuilder<String>(
+        key: key, stream: null, builder: snapshotText, initialData: 'I',
+      ));
+      expect(find.text('AsyncSnapshot(ConnectionState.none, I, null)'), findsOneWidget);
+      final StreamController<String> controller = new StreamController<String>();
+      await tester.pumpWidget(new StreamBuilder<String>(
+        key: key, stream: controller.stream, builder: snapshotText, initialData: 'Ignored',
+      ));
+      expect(find.text('AsyncSnapshot(ConnectionState.waiting, I, null)'), findsOneWidget);
     });
   });
   group('FutureBuilder and StreamBuilder behave identically on Stream from Future', () {
@@ -319,19 +253,18 @@ void main() {
     });
     testWidgets('when initialData is used with null Future and Stream', (WidgetTester tester) async {
       await tester.pumpWidget(new Column(children: <Widget>[
-        new FutureBuilder<String>(future: null, builder: snapshotText, initialData: 'A',),
-        new StreamBuilder<String>(stream: null, builder: snapshotText, initialData: 'A',),
+        new FutureBuilder<String>(future: null, builder: snapshotText, initialData: 'I',),
+        new StreamBuilder<String>(stream: null, builder: snapshotText, initialData: 'I',),
       ]));
-      expect(find.text('AsyncSnapshot(ConnectionState.none, A, null)'), findsNWidgets(2));
+      expect(find.text('AsyncSnapshot(ConnectionState.none, I, null)'), findsNWidgets(2));
     });
-    testWidgets('when using initialData and completes with data', (WidgetTester tester) async {
-      final String initial = 'initial';
+    testWidgets('when using initialData and completing with data', (WidgetTester tester) async {
       final Completer<String> completer = new Completer<String>();
       await tester.pumpWidget(new Column(children: <Widget>[
-        new FutureBuilder<String>(future: completer.future, builder: snapshotText, initialData: initial),
-        new StreamBuilder<String>(stream: completer.future.asStream(), builder: snapshotText, initialData: initial),
+        new FutureBuilder<String>(future: completer.future, builder: snapshotText, initialData: 'I'),
+        new StreamBuilder<String>(stream: completer.future.asStream(), builder: snapshotText, initialData: 'I'),
       ]));
-      expect(find.text('AsyncSnapshot(ConnectionState.waiting, $initial, null)'), findsNWidgets(2));
+      expect(find.text('AsyncSnapshot(ConnectionState.waiting, I, null)'), findsNWidgets(2));
       completer.complete('hello');
       await eventFiring(tester);
       expect(find.text('AsyncSnapshot(ConnectionState.done, hello, null)'), findsNWidgets(2));

--- a/packages/flutter/test/widgets/async_test.dart
+++ b/packages/flutter/test/widgets/async_test.dart
@@ -121,19 +121,19 @@ void main() {
     testWidgets('runs the builder using given initial data', (WidgetTester tester) async {
       final GlobalKey key = new GlobalKey();
       await tester.pumpWidget(new FutureBuilder<String>(
-        key: key, future: null, builder: snapshotText, initialData: 'I',
+        key: key, future: null, builder: snapshotText, initialData: 'I'
       ));
       expect(find.text('AsyncSnapshot(ConnectionState.none, I, null)'), findsOneWidget);
     });
     testWidgets('ignores initialData when reconfiguring', (WidgetTester tester) async {
       final GlobalKey key = new GlobalKey();
       await tester.pumpWidget(new FutureBuilder<String>(
-        key: key, future: null, builder: snapshotText, initialData: 'I',
+        key: key, future: null, builder: snapshotText, initialData: 'I'
       ));
       expect(find.text('AsyncSnapshot(ConnectionState.none, I, null)'), findsOneWidget);
       final Completer<String> completer = new Completer<String>();
       await tester.pumpWidget(new FutureBuilder<String>(
-        key: key, future: completer.future, builder: snapshotText, initialData: 'Ignored',
+        key: key, future: completer.future, builder: snapshotText, initialData: 'Ignored'
       ));
       expect(find.text('AsyncSnapshot(ConnectionState.waiting, I, null)'), findsOneWidget);
     });
@@ -201,22 +201,18 @@ void main() {
     });
     testWidgets('runs the builder using given initial data', (WidgetTester tester) async {
       final StreamController<String> controller = new StreamController<String>();
-      await tester.pumpWidget(new StreamBuilder<String>(
-        stream: controller.stream,
-        builder: snapshotText,
-        initialData: 'I',
-      ));
+      await tester.pumpWidget(new StreamBuilder<String>(stream: controller.stream, builder: snapshotText, initialData: 'I'));
       expect(find.text('AsyncSnapshot(ConnectionState.waiting, I, null)'), findsOneWidget);
     });
     testWidgets('ignores initialData when reconfiguring', (WidgetTester tester) async {
       final GlobalKey key = new GlobalKey();
       await tester.pumpWidget(new StreamBuilder<String>(
-        key: key, stream: null, builder: snapshotText, initialData: 'I',
+        key: key, stream: null, builder: snapshotText, initialData: 'I'
       ));
       expect(find.text('AsyncSnapshot(ConnectionState.none, I, null)'), findsOneWidget);
       final StreamController<String> controller = new StreamController<String>();
       await tester.pumpWidget(new StreamBuilder<String>(
-        key: key, stream: controller.stream, builder: snapshotText, initialData: 'Ignored',
+        key: key, stream: controller.stream, builder: snapshotText, initialData: 'Ignored'
       ));
       expect(find.text('AsyncSnapshot(ConnectionState.waiting, I, null)'), findsOneWidget);
     });
@@ -253,8 +249,8 @@ void main() {
     });
     testWidgets('when initialData is used with null Future and Stream', (WidgetTester tester) async {
       await tester.pumpWidget(new Column(children: <Widget>[
-        new FutureBuilder<String>(future: null, builder: snapshotText, initialData: 'I',),
-        new StreamBuilder<String>(stream: null, builder: snapshotText, initialData: 'I',),
+        new FutureBuilder<String>(future: null, builder: snapshotText, initialData: 'I'),
+        new StreamBuilder<String>(stream: null, builder: snapshotText, initialData: 'I'),
       ]));
       expect(find.text('AsyncSnapshot(ConnectionState.none, I, null)'), findsNWidgets(2));
     });

--- a/packages/flutter/test/widgets/async_test.dart
+++ b/packages/flutter/test/widgets/async_test.dart
@@ -66,6 +66,19 @@ void main() {
       ));
       expect(find.text('AsyncSnapshot(ConnectionState.waiting, null, null)'), findsOneWidget);
     });
+    testWidgets('gracefully handles transition from null future with initial data without introducing new states', (WidgetTester tester) async {
+      final String initial = 'initial';
+      final GlobalKey key = new GlobalKey();
+      await tester.pumpWidget(new FutureBuilder<String>(
+        key: key, future: null, builder: snapshotText, initialData: initial,
+      ));
+      expect(find.text('AsyncSnapshot(ConnectionState.none, $initial, null)'), findsOneWidget);
+      final Completer<String> completer = new Completer<String>();
+      await tester.pumpWidget(new FutureBuilder<String>(
+        key: key, future: completer.future, builder: snapshotText, initialData: 'No change',
+      ));
+      expect(find.text('AsyncSnapshot(ConnectionState.waiting, $initial, null)'), findsOneWidget);
+    });
     testWidgets('gracefully handles transition to null future', (WidgetTester tester) async {
       final GlobalKey key = new GlobalKey();
       final Completer<String> completer = new Completer<String>();
@@ -81,6 +94,22 @@ void main() {
       await eventFiring(tester);
       expect(find.text('AsyncSnapshot(ConnectionState.none, null, null)'), findsOneWidget);
     });
+    testWidgets('gracefully handles transition to null future with initial data without introducing new states', (WidgetTester tester) async {
+      final String initial = 'initial';
+      final GlobalKey key = new GlobalKey();
+      final Completer<String> completer = new Completer<String>();
+      await tester.pumpWidget(new FutureBuilder<String>(
+        key: key, future: completer.future, builder: snapshotText, initialData: initial,
+      ));
+      expect(find.text('AsyncSnapshot(ConnectionState.waiting, $initial, null)'), findsOneWidget);
+      await tester.pumpWidget(new FutureBuilder<String>(
+        key: key, future: null, builder: snapshotText, initialData: 'No change',
+      ));
+      expect(find.text('AsyncSnapshot(ConnectionState.none, $initial, null)'), findsOneWidget);
+      completer.complete('hello');
+      await eventFiring(tester);
+      expect(find.text('AsyncSnapshot(ConnectionState.none, $initial, null)'), findsOneWidget);
+    });
     testWidgets('gracefully handles transition to other future', (WidgetTester tester) async {
       final GlobalKey key = new GlobalKey();
       final Completer<String> completerA = new Completer<String>();
@@ -93,6 +122,24 @@ void main() {
         key: key, future: completerB.future, builder: snapshotText
       ));
       expect(find.text('AsyncSnapshot(ConnectionState.waiting, null, null)'), findsOneWidget);
+      completerB.complete('B');
+      completerA.complete('A');
+      await eventFiring(tester);
+      expect(find.text('AsyncSnapshot(ConnectionState.done, B, null)'), findsOneWidget);
+    });
+    testWidgets('gracefully handles transition to other future with initial data without introducing new states', (WidgetTester tester) async {
+      final String initial = 'initial';
+      final GlobalKey key = new GlobalKey();
+      final Completer<String> completerA = new Completer<String>();
+      final Completer<String> completerB = new Completer<String>();
+      await tester.pumpWidget(new FutureBuilder<String>(
+        key: key, future: completerA.future, builder: snapshotText, initialData: initial,
+      ));
+      expect(find.text('AsyncSnapshot(ConnectionState.waiting, $initial, null)'), findsOneWidget);
+      await tester.pumpWidget(new FutureBuilder<String>(
+        key: key, future: completerB.future, builder: snapshotText, initialData: 'No change',
+      ));
+      expect(find.text('AsyncSnapshot(ConnectionState.waiting, $initial, null)'), findsOneWidget);
       completerB.complete('B');
       completerA.complete('A');
       await eventFiring(tester);
@@ -132,6 +179,19 @@ void main() {
       ));
       expect(find.text('AsyncSnapshot(ConnectionState.waiting, null, null)'), findsOneWidget);
     });
+    testWidgets('gracefully handles transition from null stream with initial data without introducing new states', (WidgetTester tester) async {
+      final String initial = 'initial';
+      final GlobalKey key = new GlobalKey();
+      await tester.pumpWidget(new StreamBuilder<String>(
+        key: key, stream: null, builder: snapshotText, initialData: initial,
+      ));
+      expect(find.text('AsyncSnapshot(ConnectionState.none, $initial, null)'), findsOneWidget);
+      final StreamController<String> controller = new StreamController<String>();
+      await tester.pumpWidget(new StreamBuilder<String>(
+        key: key, stream: controller.stream, builder: snapshotText, initialData: 'No change',
+      ));
+      expect(find.text('AsyncSnapshot(ConnectionState.waiting, $initial, null)'), findsOneWidget);
+    });
     testWidgets('gracefully handles transition to null stream', (WidgetTester tester) async {
       final GlobalKey key = new GlobalKey();
       final StreamController<String> controller = new StreamController<String>();
@@ -144,6 +204,22 @@ void main() {
       ));
       expect(find.text('AsyncSnapshot(ConnectionState.none, null, null)'), findsOneWidget);
     });
+    testWidgets('gracefully handles transition to null stream with initial data without introducing new states', (WidgetTester tester) async {
+      final String initial = 'initial';
+      final GlobalKey key = new GlobalKey();
+      final StreamController<String> controller = new StreamController<String>();
+      await tester.pumpWidget(new StreamBuilder<String>(
+        key: key, stream: controller.stream, builder: snapshotText, initialData: initial,
+      ));
+      expect(find.text('AsyncSnapshot(ConnectionState.waiting, $initial, null)'), findsOneWidget);
+      controller.add('A');
+      await eventFiring(tester);
+      expect(find.text('AsyncSnapshot(ConnectionState.active, A, null)'), findsOneWidget);
+      await tester.pumpWidget(new StreamBuilder<String>(
+        key: key, stream: null, builder: snapshotText, initialData: 'No change',
+      ));
+      expect(find.text('AsyncSnapshot(ConnectionState.none, A, null)'), findsOneWidget);
+    });
     testWidgets('gracefully handles transition to other stream', (WidgetTester tester) async {
       final GlobalKey key = new GlobalKey();
       final StreamController<String> controllerA = new StreamController<String>();
@@ -154,6 +230,23 @@ void main() {
       expect(find.text('AsyncSnapshot(ConnectionState.waiting, null, null)'), findsOneWidget);
       await tester.pumpWidget(new StreamBuilder<String>(
         key: key, stream: controllerB.stream, builder: snapshotText
+      ));
+      controllerB.add('B');
+      controllerA.add('A');
+      await eventFiring(tester);
+      expect(find.text('AsyncSnapshot(ConnectionState.active, B, null)'), findsOneWidget);
+    });
+    testWidgets('gracefully handles transition to other stream with initial data without introducing new states', (WidgetTester tester) async {
+      final String initial = 'initial';
+      final GlobalKey key = new GlobalKey();
+      final StreamController<String> controllerA = new StreamController<String>();
+      final StreamController<String> controllerB = new StreamController<String>();
+      await tester.pumpWidget(new StreamBuilder<String>(
+        key: key, stream: controllerA.stream, builder: snapshotText, initialData: initial,
+      ));
+      expect(find.text('AsyncSnapshot(ConnectionState.waiting, $initial, null)'), findsOneWidget);
+      await tester.pumpWidget(new StreamBuilder<String>(
+        key: key, stream: controllerB.stream, builder: snapshotText, initialData: 'No change',
       ));
       controllerB.add('B');
       controllerA.add('A');
@@ -223,6 +316,25 @@ void main() {
         new StreamBuilder<String>(stream: null, builder: snapshotText),
       ]));
       expect(find.text('AsyncSnapshot(ConnectionState.none, null, null)'), findsNWidgets(2));
+    });
+    testWidgets('when initialData is used with null Future and Stream', (WidgetTester tester) async {
+      await tester.pumpWidget(new Column(children: <Widget>[
+        new FutureBuilder<String>(future: null, builder: snapshotText, initialData: 'A',),
+        new StreamBuilder<String>(stream: null, builder: snapshotText, initialData: 'A',),
+      ]));
+      expect(find.text('AsyncSnapshot(ConnectionState.none, A, null)'), findsNWidgets(2));
+    });
+    testWidgets('when using initialData and completes with data', (WidgetTester tester) async {
+      final String initial = 'initial';
+      final Completer<String> completer = new Completer<String>();
+      await tester.pumpWidget(new Column(children: <Widget>[
+        new FutureBuilder<String>(future: completer.future, builder: snapshotText, initialData: initial),
+        new StreamBuilder<String>(stream: completer.future.asStream(), builder: snapshotText, initialData: initial),
+      ]));
+      expect(find.text('AsyncSnapshot(ConnectionState.waiting, $initial, null)'), findsNWidgets(2));
+      completer.complete('hello');
+      await eventFiring(tester);
+      expect(find.text('AsyncSnapshot(ConnectionState.done, hello, null)'), findsNWidgets(2));
     });
   });
   group('StreamBuilderBase', () {


### PR DESCRIPTION
This allows one to run the builder function the first time with an `AsyncSnapshot` that contains the given `initialData`, rather than with an `AsyncSnapshot` that has no data.

This can be helpful when the Data your Stream provides is itself a State Machine with it's own "has data" / "missing data" semantics.

As it currently works, you need to deal with not only the `AsyncSnapshot` State, but also your own Data's State, which leads to additional / clunky branching logic. 