### PR TITLE
Apply media padding to Gallery video demo

### DIFF
--- a/examples/flutter_gallery/lib/demo/video_demo.dart
+++ b/examples/flutter_gallery/lib/demo/video_demo.dart
@@ -85,15 +85,19 @@ class VideoCard extends StatelessWidget {
       Navigator.of(context).push(route);
     }
 
-    return new Card(
-      child: new Column(
-        children: <Widget>[
-          new ListTile(title: new Text(title), subtitle: new Text(subtitle)),
-          new GestureDetector(
-            onTap: pushFullScreenWidget,
-            child: _buildInlineVideo(),
-          ),
-        ],
+    return new SafeArea(
+      top: false,
+      bottom: false,
+      child: new Card(
+        child: new Column(
+          children: <Widget>[
+            new ListTile(title: new Text(title), subtitle: new Text(subtitle)),
+            new GestureDetector(
+              onTap: pushFullScreenWidget,
+              child: _buildInlineVideo(),
+            ),
+          ],
+        ),
       ),
     );
   }


### PR DESCRIPTION
Applies horizontal safe area insets to the video demo in the Gallery.
This is to support the iPhone X sensor housing notch and other similarly
creative display features when in landscape orientation.