### PR TITLE
Only call notifyListeners once when switching tabs in TabController

### DIFF
--- a/packages/flutter/lib/src/material/tab_controller.dart
+++ b/packages/flutter/lib/src/material/tab_controller.dart
@@ -122,7 +122,6 @@ class TabController extends ChangeNotifier {
         .animateTo(_index.toDouble(), duration: duration, curve: curve)
         .whenCompleteOrCancel(() {
           _indexIsChangingCount -= 1;
-          notifyListeners();
         });
     } else {
       _indexIsChangingCount += 1;


### PR DESCRIPTION
Fixes #13848 