### PR TITLE
Apply media padding to Gallery animation demo

### DIFF
--- a/examples/flutter_gallery/lib/demo/animation/home.dart
+++ b/examples/flutter_gallery/lib/demo/animation/home.dart
@@ -610,12 +610,16 @@ class _AnimationDemoHomeState extends State<AnimationDemoHome> {
             left: 0.0,
             child: new IconTheme(
               data: const IconThemeData(color: Colors.white),
-              child: new IconButton(
-                icon: const BackButtonIcon(),
-                tooltip: 'Back',
-                onPressed: () {
-                  _handleBackButton(appBarMidScrollOffset);
-                }
+              child: new SafeArea(
+                top: false,
+                bottom: false,
+                child: new IconButton(
+                  icon: const BackButtonIcon(),
+                  tooltip: 'Back',
+                  onPressed: () {
+                    _handleBackButton(appBarMidScrollOffset);
+                  }
+                ),
               ),
             ),
           ),

--- a/examples/flutter_gallery/lib/demo/animation/widgets.dart
+++ b/examples/flutter_gallery/lib/demo/animation/widgets.dart
@@ -142,7 +142,7 @@ class SectionDetailView extends StatelessWidget {
       item = new Container(
         height: 240.0,
         padding: const EdgeInsets.all(16.0),
-        child: image,
+        child: new SafeArea(top: false, bottom:false, child: image),
       );
     } else {
       item = new ListTile(


### PR DESCRIPTION
Applies horizontal safe area insets to the animation demo in the
Gallery. Specifically, this ensures the back button is positioned
consistently with iOS expectations and that that main image card in the
detail view respects safe area insets.

This is to support the iPhone X sensor housing notch and other similarly
creative display features when in landscape orientation.