### PR TITLE
Add missing imports to animated_icons_private_test

### DIFF
--- a/packages/flutter/test/material_animated_icons/animated_icons_private_test.dart
+++ b/packages/flutter/test/material_animated_icons/animated_icons_private_test.dart
@@ -16,10 +16,12 @@ import 'dart:ui' as ui show Paint, Path, Canvas;
 import 'package:flutter/animation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:meta/meta.dart';
 import 'package:mockito/mockito.dart';
 
 part 'package:flutter/src/material_animated_icons/animated_icons.dart';
 part 'package:flutter/src/material_animated_icons/animated_icons_data.dart';
+part 'package:flutter/src/material_animated_icons/data/arrow_menu.g.dart';
 part 'package:flutter/src/material_animated_icons/data/menu_arrow.g.dart';
 
 class MockCanvas extends Mock implements ui.Canvas {}


### PR DESCRIPTION
This started breaking the analyzer following https://github.com/flutter/flutter/pull/13889
The test version of the material_animated_icons library did not include the meta
package (needed for the `@required` tag) and was also not including all
the generated icons files.

Ideally we should find a way to fix this without enumerating all the
icons in the test file.
But for now just adding the missing file to fix the build breakage.
  