### PR TITLE
Don't use flutter_test in animated_icons_private_test.

### DIFF
--- a/packages/flutter/test/material/animated_icons_private_test.dart
+++ b/packages/flutter/test/material/animated_icons_private_test.dart
@@ -15,9 +15,9 @@ import 'dart:ui' as ui show Paint, Path, Canvas;
 
 import 'package:flutter/animation.dart';
 import 'package:flutter/widgets.dart';
-import 'package:flutter_test/flutter_test.dart';
 import 'package:meta/meta.dart';
 import 'package:mockito/mockito.dart';
+import 'package:test/test.dart';
 
 part 'package:flutter/src/material/animated_icons/animated_icons.dart';
 part 'package:flutter/src/material/animated_icons/animated_icons_data.dart';


### PR DESCRIPTION
This broke the coverage tool, as material/animated_icons/animated_icons.dart
was loaded twice as a part, once directly animated_icons_private_test, and one
through animated_icons_private_test->flutter_tester->...->material

The coverage package assumes a 1:1 mapping between VM scripts and URIs due to a
limitation in the underlying vm_service_client package, which currently doesn't
provide a unique identifier for VM scripts.

The underlying issue is tracked by dart-lang/tools#437.
  