### PR TITLE
Pin connectivity and device_info to unbreak the build.

### DIFF
--- a/examples/flutter_gallery/pubspec.yaml
+++ b/examples/flutter_gallery/pubspec.yaml
@@ -3,9 +3,9 @@ dependencies:
   flutter:
     sdk: flutter
   collection: 1.14.3
-  device_info: 0.1.0
+  device_info: 0.0.5
   intl: 0.15.2
-  connectivity: 0.2.0
+  connectivity: 0.1.1
   string_scanner: 1.0.2
   url_launcher: 1.0.3
   cupertino_icons: 0.1.1

--- a/packages/flutter_tools/lib/src/commands/update_packages.dart
+++ b/packages/flutter_tools/lib/src/commands/update_packages.dart
@@ -34,6 +34,14 @@ const Map<String, String> _kManuallyPinnedDependencies = const <String, String>{
   // https://github.com/flutter/flutter/issues/13953
   // TODO(aam): unpin this.
   'url_launcher': '1.0.3',
+  // Version upgrade to next version(0.2.0) breaks flutter build:
+  // https://github.com/flutter/flutter/issues/13958
+  // TODO(aam): unpin this.
+  'connectivity' : '0.1.1',
+  // Version upgrade to next version(0.1.0) breaks flutter build:
+  // https://github.com/flutter/flutter/issues/13956
+  // TODO(aam): unpin this.
+  'device_info': '0.0.5',
   // Add pinned packages here.
 };
 


### PR DESCRIPTION
This is follow-up to https://github.com/flutter/flutter/pull/13952.