### PR TITLE
Remove pinning that became obsolete once we moved up to gradle 4.1

### DIFF
--- a/examples/flutter_gallery/pubspec.yaml
+++ b/examples/flutter_gallery/pubspec.yaml
@@ -3,11 +3,11 @@ dependencies:
   flutter:
     sdk: flutter
   collection: 1.14.3
-  device_info: 0.0.5
+  device_info: 0.1.0
   intl: 0.15.2
-  connectivity: 0.1.1
+  connectivity: 0.2.0
   string_scanner: 1.0.2
-  url_launcher: 1.0.3
+  url_launcher: 2.0.0
   cupertino_icons: 0.1.1
   video_player: 0.0.7
 

--- a/packages/flutter_tools/lib/src/commands/update_packages.dart
+++ b/packages/flutter_tools/lib/src/commands/update_packages.dart
@@ -30,18 +30,6 @@ const Map<String, String> _kManuallyPinnedDependencies = const <String, String>{
   // https://github.com/dart-lang/sdk/issues/31442
   // TODO(amirh): unpin this.
   'test': '0.12.26',
-  // Major version upgrade to next version(2.0.0) breaks flutter build:
-  // https://github.com/flutter/flutter/issues/13953
-  // TODO(aam): unpin this.
-  'url_launcher': '1.0.3',
-  // Version upgrade to next version(0.2.0) breaks flutter build:
-  // https://github.com/flutter/flutter/issues/13958
-  // TODO(aam): unpin this.
-  'connectivity' : '0.1.1',
-  // Version upgrade to next version(0.1.0) breaks flutter build:
-  // https://github.com/flutter/flutter/issues/13956
-  // TODO(aam): unpin this.
-  'device_info': '0.0.5',
   // Add pinned packages here.
 };
 


### PR DESCRIPTION
Upgrade to gradle 4.1 landed in https://github.com/flutter/flutter/pull/13928.

This fixes  #13953, #13956, #13958.