### PR TITLE
Add support for a new kind of InkSplash: the "ripple"

### DIFF
--- a/packages/flutter/lib/material.dart
+++ b/packages/flutter/lib/material.dart
@@ -53,6 +53,7 @@ export 'src/material/grid_tile_bar.dart';
 export 'src/material/icon_button.dart';
 export 'src/material/icons.dart';
 export 'src/material/ink_highlight.dart';
+export 'src/material/ink_ripple.dart';
 export 'src/material/ink_splash.dart';
 export 'src/material/ink_well.dart';
 export 'src/material/input_border.dart';

--- a/packages/flutter/lib/src/material/ink_highlight.dart
+++ b/packages/flutter/lib/src/material/ink_highlight.dart
@@ -45,11 +45,10 @@ class InkHighlight extends InkFeature {
     VoidCallback onRemoved,
   }) : assert(color != null),
        assert(shape != null),
-       _color = color,
        _shape = shape,
        _borderRadius = borderRadius ?? BorderRadius.zero,
        _rectCallback = rectCallback,
-       super(controller: controller, referenceBox: referenceBox, onRemoved: onRemoved) {
+       super(controller: controller, referenceBox: referenceBox, color: color, onRemoved: onRemoved) {
     _alphaController = new AnimationController(duration: _kHighlightFadeDuration, vsync: controller.vsync)
       ..addListener(controller.markNeedsPaint)
       ..addStatusListener(_handleAlphaStatusChanged)
@@ -68,16 +67,6 @@ class InkHighlight extends InkFeature {
 
   Animation<int> _alpha;
   AnimationController _alphaController;
-
-  /// The color of the ink used to emphasize part of the material.
-  Color get color => _color;
-  Color _color;
-  set color(Color value) {
-    if (value == _color)
-      return;
-    _color = value;
-    controller.markNeedsPaint();
-  }
 
   /// Whether this part of the material is being visually emphasized.
   bool get active => _active;

--- a/packages/flutter/lib/src/material/ink_highlight.dart
+++ b/packages/flutter/lib/src/material/ink_highlight.dart
@@ -6,6 +6,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 
+import 'ink_well.dart' show InteractiveInkFeature;
 import 'material.dart';
 
 const Duration _kHighlightFadeDuration = const Duration(milliseconds: 200);
@@ -25,7 +26,7 @@ const Duration _kHighlightFadeDuration = const Duration(milliseconds: 200);
 ///  * [Material], which is the widget on which the ink highlight is painted.
 ///  * [InkSplash], which is an ink feature that shows a reaction to user input
 ///    on a [Material].
-class InkHighlight extends InkFeature {
+class InkHighlight extends InteractiveInkFeature {
   /// Begin a highlight animation.
   ///
   /// The [controller] argument is typically obtained via

--- a/packages/flutter/lib/src/material/ink_ripple.dart
+++ b/packages/flutter/lib/src/material/ink_ripple.dart
@@ -8,6 +8,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 
+import 'ink_well.dart' show InteractiveInkFeature;
 import 'material.dart';
 
 const Duration _kUnconfirmedRippleDuration = const Duration(seconds: 1);
@@ -69,7 +70,7 @@ double _getRippleRadiusForPositionInSize(Size bounds, Offset position) {
 ///  * [Material], which is the widget on which the ink splash is painted.
 ///  * [InkHighlight], which is an ink feature that emphasizes a part of a
 ///    [Material].
- class InkRipple extends InkFeature {
+class InkRipple extends InteractiveInkFeature {
   /// Begin a ripple, centered at [position] relative to [referenceBox].
   ///
   /// The [controller] argument is typically obtained via
@@ -88,15 +89,17 @@ double _getRippleRadiusForPositionInSize(Size bounds, Offset position) {
   InkRipple({
     @required MaterialInkController controller,
     @required RenderBox referenceBox,
-    Offset position,
-    Color color,
+    @required Offset position,
+    @required Color color,
     bool containedInkWell: false,
     RectCallback rectCallback,
-    BorderRadius borderRadius: BorderRadius.zero,
+    BorderRadius borderRadius,
     double radius,
     VoidCallback onRemoved,
-  }) : _position = position,
-       _borderRadius = borderRadius,
+  }) : assert(color != null),
+       assert(position != null),
+       _position = position,
+       _borderRadius = borderRadius ?? BorderRadius.zero,
        _targetRadius = radius ?? _getTargetRadius(referenceBox, containedInkWell, rectCallback, position),
        _clipCallback = _getClipCallback(referenceBox, containedInkWell, rectCallback),
        super(controller: controller, referenceBox: referenceBox, color: color, onRemoved: onRemoved)

--- a/packages/flutter/lib/src/material/ink_ripple.dart
+++ b/packages/flutter/lib/src/material/ink_ripple.dart
@@ -8,7 +8,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 
-import 'ink_well.dart' show InteractiveInkFeature;
+import 'ink_well.dart';
 import 'material.dart';
 
 const Duration _kUnconfirmedRippleDuration = const Duration(seconds: 1);
@@ -48,6 +48,35 @@ double _getRippleRadiusForPositionInSize(Size bounds, Offset position) {
   return math.max(math.max(d1, d2), math.max(d3, d4)).ceilToDouble();
 }
 
+class _InkRippleFactory extends InteractiveInkFeatureFactory {
+  const _InkRippleFactory();
+
+  @override
+  InteractiveInkFeature create({
+    @required MaterialInkController controller,
+    @required RenderBox referenceBox,
+    @required Offset position,
+    @required Color color,
+    bool containedInkWell: false,
+    RectCallback rectCallback,
+    BorderRadius borderRadius,
+    double radius,
+    VoidCallback onRemoved,
+  }) {
+    return new InkRipple(
+      controller: controller,
+      referenceBox: referenceBox,
+      position: position,
+      color: color,
+      containedInkWell: containedInkWell,
+      rectCallback: rectCallback,
+      borderRadius: borderRadius,
+      radius: radius,
+      onRemoved: onRemoved,
+    );
+  }
+}
+
 /// A visual reaction on a piece of [Material] to user input.
 ///
 /// A circular ink feature whose origin starts at the input touch point and
@@ -71,6 +100,10 @@ double _getRippleRadiusForPositionInSize(Size bounds, Offset position) {
 ///  * [InkHighlight], which is an ink feature that emphasizes a part of a
 ///    [Material].
 class InkRipple extends InteractiveInkFeature {
+  /// Used to specify this type of ink splash for an [InkWell], [InkResponse]
+  /// or material [Theme].
+  static const InteractiveInkFeatureFactory splashFactory = const _InkRippleFactory();
+
   /// Begin a ripple, centered at [position] relative to [referenceBox].
   ///
   /// The [controller] argument is typically obtained via

--- a/packages/flutter/lib/src/material/ink_ripple.dart
+++ b/packages/flutter/lib/src/material/ink_ripple.dart
@@ -49,14 +49,16 @@ double _getRippleRadiusForPositionInSize(Size bounds, Offset position) {
 
 /// A visual reaction on a piece of [Material] to user input.
 ///
-/// A circular in feature whose origin starts at the input touch point and
-/// whose radius expands from 60% of the final radius. The splash's origin
-/// animates to the center.
+/// A circular ink feature whose origin starts at the input touch point and
+/// whose radius expands from 60% of the final radius. The splash origin
+/// animates to the center of its [referenceBox].
 ///
-/// This object is rarely created directly. Instead of creating an ink ripple
-/// directly, consider using an [InkResponse] or [InkWell] widget, which uses
+/// This object is rarely created directly. Instead of creating an ink ripple,
+/// consider using an [InkResponse] or [InkWell] widget, which uses
 /// gestures (such as tap and long-press) to trigger ink splashes. This class
 /// is used when the [Theme]'s [ThemeData.splashType] is [InkSplashType.ripple].
+///
+/// See also:
 ///
 ///  * [InkSplash], which is an ink splash feature that expands less
 ///    aggressively than the ripple.
@@ -68,24 +70,23 @@ double _getRippleRadiusForPositionInSize(Size bounds, Offset position) {
 ///  * [InkHighlight], which is an ink feature that emphasizes a part of a
 ///    [Material].
  class InkRipple extends InkFeature {
-  /// Begin a ripple, centered at position relative to [referenceBox].
+  /// Begin a ripple, centered at [position] relative to [referenceBox].
   ///
   /// The [controller] argument is typically obtained via
   /// `Material.of(context)`.
   ///
-  /// If `containedInkWell` is true, then the ripple will be sized to fit
+  /// If [containedInkWell] is true, then the ripple will be sized to fit
   /// the well rectangle, then clipped to it when drawn. The well
-  /// rectangle is the box returned by `rectCallback`, if provided, or
+  /// rectangle is the box returned by [rectCallback], if provided, or
   /// otherwise is the bounds of the [referenceBox].
   ///
-  /// If `containedInkWell` is false, then `rectCallback` should be null.
+  /// If [containedInkWell] is false, then [rectCallback] should be null.
   /// The ink ripple is clipped only to the edges of the [Material].
   /// This is the default.
   ///
-  /// When the ripple is removed, `onRemoved` will be called.
+  /// When the ripple is removed, [onRemoved] will be called.
   InkRipple({
     @required MaterialInkController controller,
-
     @required RenderBox referenceBox,
     Offset position,
     Color color,
@@ -159,9 +160,6 @@ double _getRippleRadiusForPositionInSize(Size bounds, Offset position) {
   Animation<int> _fadeOut;
   AnimationController _fadeOutController;
 
-  /// The user input is confirmed.
-  ///
-  /// Causes the reaction to propagate faster across the material.
   @override
   void confirm() {
     _radiusController

--- a/packages/flutter/lib/src/material/ink_splash.dart
+++ b/packages/flutter/lib/src/material/ink_splash.dart
@@ -46,10 +46,14 @@ double _getSplashRadiusForPositionInSize(Size bounds, Offset position) {
 ///
 /// This object is rarely created directly. Instead of creating an ink splash
 /// directly, consider using an [InkResponse] or [InkWell] widget, which uses
-/// gestures (such as tap and long-press) to trigger ink splashes.
+/// gestures (such as tap and long-press) to trigger ink splashes. This class
+/// is used when the [Theme]'s [ThemeData.splashType] is [InkSplashType.drop]
+/// (which is the theme's default splash type).
 ///
 /// See also:
 ///
+///  * [InkRipple], which is an ink splash feature that expands more
+///    aggressively than this class does.
 ///  * [InkResponse], which uses gestures to trigger ink highlights and ink
 ///    splashes in the parent [Material].
 ///  * [InkWell], which is a rectangular [InkResponse] (the most common type of

--- a/packages/flutter/lib/src/material/ink_splash.dart
+++ b/packages/flutter/lib/src/material/ink_splash.dart
@@ -8,6 +8,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 
+import 'ink_well.dart' show InteractiveInkFeature;
 import 'material.dart';
 
 const Duration _kUnconfirmedSplashDuration = const Duration(seconds: 1);
@@ -61,7 +62,7 @@ double _getSplashRadiusForPositionInSize(Size bounds, Offset position) {
 ///  * [Material], which is the widget on which the ink splash is painted.
 ///  * [InkHighlight], which is an ink feature that emphasizes a part of a
 ///    [Material].
-class InkSplash extends InkFeature {
+class InkSplash extends InteractiveInkFeature {
   /// Begin a splash, centered at position relative to [referenceBox].
   ///
   /// The [controller] argument is typically obtained via

--- a/packages/flutter/lib/src/material/ink_splash.dart
+++ b/packages/flutter/lib/src/material/ink_splash.dart
@@ -79,9 +79,7 @@ class _InkSplashFactory extends InteractiveInkFeatureFactory {
 ///
 /// This object is rarely created directly. Instead of creating an ink splash
 /// directly, consider using an [InkResponse] or [InkWell] widget, which uses
-/// gestures (such as tap and long-press) to trigger ink splashes. This class
-/// is used when the [Theme]'s [ThemeData.splashType] is [InkSplashType.drop]
-/// (which is the theme's default splash type).
+/// gestures (such as tap and long-press) to trigger ink splashes.
 ///
 /// See also:
 ///

--- a/packages/flutter/lib/src/material/ink_splash.dart
+++ b/packages/flutter/lib/src/material/ink_splash.dart
@@ -8,7 +8,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 
-import 'ink_well.dart' show InteractiveInkFeature;
+import 'ink_well.dart';
 import 'material.dart';
 
 const Duration _kUnconfirmedSplashDuration = const Duration(seconds: 1);
@@ -43,7 +43,39 @@ double _getSplashRadiusForPositionInSize(Size bounds, Offset position) {
   return math.max(math.max(d1, d2), math.max(d3, d4)).ceilToDouble();
 }
 
+class _InkSplashFactory extends InteractiveInkFeatureFactory {
+  const _InkSplashFactory();
+
+  @override
+  InteractiveInkFeature create({
+    @required MaterialInkController controller,
+    @required RenderBox referenceBox,
+    @required Offset position,
+    @required Color color,
+    bool containedInkWell: false,
+    RectCallback rectCallback,
+    BorderRadius borderRadius,
+    double radius,
+    VoidCallback onRemoved,
+  }) {
+    return new InkSplash(
+      controller: controller,
+      referenceBox: referenceBox,
+      position: position,
+      color: color,
+      containedInkWell: containedInkWell,
+      rectCallback: rectCallback,
+      borderRadius: borderRadius,
+      radius: radius,
+      onRemoved: onRemoved,
+    );
+  }
+}
+
 /// A visual reaction on a piece of [Material] to user input.
+///
+/// A circular ink feature whose origin starts at the input touch point
+/// and whose radius expands from zero.
 ///
 /// This object is rarely created directly. Instead of creating an ink splash
 /// directly, consider using an [InkResponse] or [InkWell] widget, which uses
@@ -63,6 +95,10 @@ double _getSplashRadiusForPositionInSize(Size bounds, Offset position) {
 ///  * [InkHighlight], which is an ink feature that emphasizes a part of a
 ///    [Material].
 class InkSplash extends InteractiveInkFeature {
+  /// Used to specify this type of ink splash for an [InkWell], [InkResponse]
+  /// or material [Theme].
+  static const InteractiveInkFeatureFactory splashFactory = const _InkSplashFactory();
+
   /// Begin a splash, centered at position relative to [referenceBox].
   ///
   /// The [controller] argument is typically obtained via

--- a/packages/flutter/lib/src/material/ink_well.dart
+++ b/packages/flutter/lib/src/material/ink_well.dart
@@ -164,6 +164,7 @@ class InkResponse extends StatefulWidget {
   /// See also:
   ///
   ///  * [splashColor], the color of the splash.
+  ///  * [splashType], which defines the appearance of the splash.
   final double radius;
 
   /// The clipping radius of the containing rect.
@@ -176,6 +177,7 @@ class InkResponse extends StatefulWidget {
   ///
   ///  * [highlightShape], the shape of the highlight.
   ///  * [splashColor], the color of the splash.
+  ///  * [splashType], which defines the appearance of the splash.
   final Color highlightColor;
 
   /// The splash color of the ink response. If this property is null then the
@@ -183,10 +185,20 @@ class InkResponse extends StatefulWidget {
   ///
   /// See also:
   ///
+  ///  * [splashType], which defines the appearance of the splash.
   ///  * [radius], the (maximum) size of the ink splash.
   ///  * [highlightColor], the color of the highlight.
   final Color splashColor;
 
+  /// Defines the appearance of the splash.
+  ///
+  /// Defaults to the value of the theme's splash type: [ThemeData.splashType].
+  ///
+  /// See also:
+  ///
+  ///  * [radius], the (maximum) size of the ink splash.
+  ///  * [splashColor], the color of the splash.
+  ///  * [highlightColor], the color of the highlight.
   final InkSplashType splashType;
 
   /// Whether detected gestures should provide acoustic and/or haptic feedback.
@@ -471,6 +483,7 @@ class InkWell extends InkResponse {
     Color highlightColor,
     Color splashColor,
     InkSplashType splashType,
+    double radius,
     BorderRadius borderRadius,
     bool enableFeedback: true,
     bool excludeFromSemantics: false,
@@ -486,6 +499,7 @@ class InkWell extends InkResponse {
     highlightColor: highlightColor,
     splashColor: splashColor,
     splashType: splashType,
+    radius: radius,
     borderRadius: borderRadius,
     enableFeedback: enableFeedback,
     excludeFromSemantics: excludeFromSemantics,

--- a/packages/flutter/lib/src/material/ink_well.dart
+++ b/packages/flutter/lib/src/material/ink_well.dart
@@ -31,6 +31,8 @@ import 'theme.dart';
 /// class.
 abstract class InteractiveInkFeature extends InkFeature {
   /// Creates an InteractiveInkFeature.
+  ///
+  /// The [controller] and [referenceBox] arguments must not be null.
   InteractiveInkFeature({
     @required MaterialInkController controller,
     @required RenderBox referenceBox,

--- a/packages/flutter/lib/src/material/ink_well.dart
+++ b/packages/flutter/lib/src/material/ink_well.dart
@@ -404,7 +404,7 @@ class _InkResponseState<T extends InkResponse> extends State<T> with AutomaticKe
     final BorderRadius borderRadius = widget.borderRadius ?? BorderRadius.zero;
 
     InteractiveInkFeature splash;
-    void onRemoved () {
+    void onRemoved() {
       if (_splashes != null) {
         assert(_splashes.contains(splash));
         _splashes.remove(splash);

--- a/packages/flutter/lib/src/material/material.dart
+++ b/packages/flutter/lib/src/material/material.dart
@@ -401,11 +401,9 @@ abstract class InkFeature {
   InkFeature({
     @required MaterialInkController controller,
     @required this.referenceBox,
-    Color color,
     this.onRemoved,
   }) : assert(controller != null),
        assert(referenceBox != null),
-       _color = color,
        _controller = controller;
 
   /// The [MaterialInkController] associated with this [InkFeature].
@@ -431,30 +429,6 @@ abstract class InkFeature {
     _controller._removeFeature(this);
     if (onRemoved != null)
       onRemoved();
-  }
-
-  /// Called when the user input that triggered this feature's appearance was confirmed.
-  ///
-  /// Typically causes the ink to propagate faster across the material. By default this
-  /// method does nothing.
-  void confirm() {
-  }
-
-  /// Called when the user input that triggered this feature's appearance was canceled.
-  ///
-  /// Typically causes the ink to gradually disappear. By default this method does
-  /// nothing.
-  void cancel() {
-  }
-
-  /// The ink's color.
-  Color get color => _color;
-  Color _color;
-  set color(Color value) {
-    if (value == _color)
-      return;
-    _color = value;
-    controller.markNeedsPaint();
   }
 
   void _paint(Canvas canvas) {

--- a/packages/flutter/lib/src/material/material.dart
+++ b/packages/flutter/lib/src/material/material.dart
@@ -38,27 +38,6 @@ enum MaterialType {
   transparency
 }
 
-/// Defines the appearance of an ink splash displayed by [InkResponse] or
-/// [InkWell].
-///
-/// See also:
-///
-///   * [ThemeData.splashType], which defines the splash type for a Material
-///     [Theme].
-enum InkSplashType {
-  /// The kind of InkSplash displayed by [InkSplash].
-  ///
-  /// A circular splash whose origin is the input touch point and whose radius
-  /// expands from zero.
-  drop,
-
-  /// The kind of InkSplash displayed by [InkRipple].
-  ///
-  /// A circular splash whose origin starts at the input touch point and whose radius
-  /// expands from 60% of the final radius. The splash's origin animates to the center.
-  ripple,
-}
-
 /// The border radii used by the various kinds of material in material design.
 ///
 /// See also:

--- a/packages/flutter/lib/src/material/material.dart
+++ b/packages/flutter/lib/src/material/material.dart
@@ -38,6 +38,26 @@ enum MaterialType {
   transparency
 }
 
+/// Defines the kind of ink splash displayed by [InkResponse] or [InkWell].
+///
+/// See also:
+///
+///   * [ThemeData.splashType], which defines the splash type for a Material
+///     [Theme].
+enum InkSplashType {
+  /// The kind of InkSplash displayed by [InkSplash].
+  ///
+  /// A circular splash whose origin is the input touch point and whose radius
+  /// expands from zero.
+  drop,
+
+  /// The kind of InkSplash displayed by [InkRipple].
+  ///
+  /// A circular splash whose origin starts at the input touch point and whose radius
+  /// expands from 60% of the final radius. The splash's origin animates to the center.
+  ripple,
+}
+
 /// The border radii used by the various kinds of material in material design.
 ///
 /// See also:
@@ -380,9 +400,11 @@ abstract class InkFeature {
   InkFeature({
     @required MaterialInkController controller,
     @required this.referenceBox,
+    Color color,
     this.onRemoved,
   }) : assert(controller != null),
        assert(referenceBox != null),
+       _color = color,
        _controller = controller;
 
   /// The [MaterialInkController] associated with this [InkFeature].
@@ -408,6 +430,28 @@ abstract class InkFeature {
     _controller._removeFeature(this);
     if (onRemoved != null)
       onRemoved();
+  }
+
+  /// Called when the user input that triggered this feature's appearance was confirmed.
+  ///
+  /// Typically causes the ink to propagate faster across the material.
+  void confirm() {
+  }
+
+  /// Called when the user input that triggered this feature's appearance was canceled.
+  ///
+  /// Typically causes the ink to gradually disappear.
+  void cancel() {
+  }
+
+  /// The ink's color.
+  Color get color => _color;
+  Color _color;
+  set color(Color value) {
+    if (value == _color)
+      return;
+    _color = value;
+    controller.markNeedsPaint();
   }
 
   void _paint(Canvas canvas) {

--- a/packages/flutter/lib/src/material/material.dart
+++ b/packages/flutter/lib/src/material/material.dart
@@ -38,7 +38,8 @@ enum MaterialType {
   transparency
 }
 
-/// Defines the kind of ink splash displayed by [InkResponse] or [InkWell].
+/// Defines the appearance of an ink splash displayed by [InkResponse] or
+/// [InkWell].
 ///
 /// See also:
 ///
@@ -434,13 +435,15 @@ abstract class InkFeature {
 
   /// Called when the user input that triggered this feature's appearance was confirmed.
   ///
-  /// Typically causes the ink to propagate faster across the material.
+  /// Typically causes the ink to propagate faster across the material. By default this
+  /// method does nothing.
   void confirm() {
   }
 
   /// Called when the user input that triggered this feature's appearance was canceled.
   ///
-  /// Typically causes the ink to gradually disappear.
+  /// Typically causes the ink to gradually disappear. By default this method does
+  /// nothing.
   void cancel() {
   }
 

--- a/packages/flutter/lib/src/material/theme_data.dart
+++ b/packages/flutter/lib/src/material/theme_data.dart
@@ -8,6 +8,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 
 import 'colors.dart';
+import 'material.dart' show InkSplashType;
 import 'typography.dart';
 
 /// Describes the contrast needs of a color.
@@ -82,6 +83,7 @@ class ThemeData {
     Color dividerColor,
     Color highlightColor,
     Color splashColor,
+    InkSplashType splashType,
     Color selectedRowColor,
     Color unselectedWidgetColor,
     Color disabledColor,
@@ -118,6 +120,7 @@ class ThemeData {
     dividerColor ??= isDark ? const Color(0x1FFFFFFF) : const Color(0x1F000000);
     highlightColor ??= isDark ? _kDarkThemeHighlightColor : _kLightThemeHighlightColor;
     splashColor ??= isDark ? _kDarkThemeSplashColor : _kLightThemeSplashColor;
+    splashType ??= InkSplashType.drop;
     selectedRowColor ??= Colors.grey[100];
     unselectedWidgetColor ??= isDark ? Colors.white70 : Colors.black54;
     disabledColor ??= isDark ? Colors.white30 : Colors.black26;
@@ -156,6 +159,7 @@ class ThemeData {
       dividerColor: dividerColor,
       highlightColor: highlightColor,
       splashColor: splashColor,
+      splashType: splashType,
       selectedRowColor: selectedRowColor,
       unselectedWidgetColor: unselectedWidgetColor,
       disabledColor: disabledColor,
@@ -196,6 +200,7 @@ class ThemeData {
     @required this.dividerColor,
     @required this.highlightColor,
     @required this.splashColor,
+    @required this.splashType,
     @required this.selectedRowColor,
     @required this.unselectedWidgetColor,
     @required this.disabledColor,
@@ -226,6 +231,7 @@ class ThemeData {
        assert(dividerColor != null),
        assert(highlightColor != null),
        assert(splashColor != null),
+       assert(splashType != null),
        assert(selectedRowColor != null),
        assert(unselectedWidgetColor != null),
        assert(disabledColor != null),
@@ -317,6 +323,8 @@ class ThemeData {
   /// The color of ink splashes. See [InkWell].
   final Color splashColor;
 
+  final InkSplashType splashType;
+
   /// The color used to highlight selected rows.
   final Color selectedRowColor;
 
@@ -398,6 +406,7 @@ class ThemeData {
     Color dividerColor,
     Color highlightColor,
     Color splashColor,
+    InkSplashType splashType,
     Color selectedRowColor,
     Color unselectedWidgetColor,
     Color disabledColor,
@@ -430,6 +439,7 @@ class ThemeData {
       dividerColor: dividerColor ?? this.dividerColor,
       highlightColor: highlightColor ?? this.highlightColor,
       splashColor: splashColor ?? this.splashColor,
+      splashType: splashType ?? this.splashType,
       selectedRowColor: selectedRowColor ?? this.selectedRowColor,
       unselectedWidgetColor: unselectedWidgetColor ?? this.unselectedWidgetColor,
       disabledColor: disabledColor ?? this.disabledColor,
@@ -545,6 +555,7 @@ class ThemeData {
       dividerColor: Color.lerp(a.dividerColor, b.dividerColor, t),
       highlightColor: Color.lerp(a.highlightColor, b.highlightColor, t),
       splashColor: Color.lerp(a.splashColor, b.splashColor, t),
+      splashType: t < 0.5 ? a.splashType : b.splashType,
       selectedRowColor: Color.lerp(a.selectedRowColor, b.selectedRowColor, t),
       unselectedWidgetColor: Color.lerp(a.unselectedWidgetColor, b.unselectedWidgetColor, t),
       disabledColor: Color.lerp(a.disabledColor, b.disabledColor, t),
@@ -583,6 +594,7 @@ class ThemeData {
            (otherData.dividerColor == dividerColor) &&
            (otherData.highlightColor == highlightColor) &&
            (otherData.splashColor == splashColor) &&
+           (otherData.splashType == splashType) &&
            (otherData.selectedRowColor == selectedRowColor) &&
            (otherData.unselectedWidgetColor == unselectedWidgetColor) &&
            (otherData.disabledColor == disabledColor) &&
@@ -618,6 +630,7 @@ class ThemeData {
       dividerColor,
       highlightColor,
       splashColor,
+      splashType,
       selectedRowColor,
       unselectedWidgetColor,
       disabledColor,
@@ -627,8 +640,8 @@ class ThemeData {
       textSelectionHandleColor,
       backgroundColor,
       accentColor,
-      accentColorBrightness,
       hashValues( // Too many values.
+        accentColorBrightness,
         indicatorColor,
         dialogBackgroundColor,
         hintColor,

--- a/packages/flutter/lib/src/material/theme_data.dart
+++ b/packages/flutter/lib/src/material/theme_data.dart
@@ -323,6 +323,7 @@ class ThemeData {
   /// The color of ink splashes. See [InkWell].
   final Color splashColor;
 
+  /// Defines the appearance of ink splashes. See [InkWell].
   final InkSplashType splashType;
 
   /// The color used to highlight selected rows.

--- a/packages/flutter/lib/src/material/theme_data.dart
+++ b/packages/flutter/lib/src/material/theme_data.dart
@@ -327,7 +327,7 @@ class ThemeData {
   /// Defines the appearance of ink splashes produces by [InkWell]
   /// and [InkResponse].
   ///
-  /// See Also
+  /// See also:
   ///
   ///  * [InkSplash.splashFactory], which defines the default splash.
   ///  * [InkRipple.splashFactory], which defines a splash that spreads out

--- a/packages/flutter/lib/src/material/theme_data.dart
+++ b/packages/flutter/lib/src/material/theme_data.dart
@@ -8,7 +8,8 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 
 import 'colors.dart';
-import 'material.dart' show InkSplashType;
+import 'ink_splash.dart';
+import 'ink_well.dart' show InteractiveInkFeatureFactory;
 import 'typography.dart';
 
 /// Describes the contrast needs of a color.
@@ -83,7 +84,7 @@ class ThemeData {
     Color dividerColor,
     Color highlightColor,
     Color splashColor,
-    InkSplashType splashType,
+    InteractiveInkFeatureFactory splashFactory,
     Color selectedRowColor,
     Color unselectedWidgetColor,
     Color disabledColor,
@@ -120,7 +121,7 @@ class ThemeData {
     dividerColor ??= isDark ? const Color(0x1FFFFFFF) : const Color(0x1F000000);
     highlightColor ??= isDark ? _kDarkThemeHighlightColor : _kLightThemeHighlightColor;
     splashColor ??= isDark ? _kDarkThemeSplashColor : _kLightThemeSplashColor;
-    splashType ??= InkSplashType.drop;
+    splashFactory ??= InkSplash.splashFactory;
     selectedRowColor ??= Colors.grey[100];
     unselectedWidgetColor ??= isDark ? Colors.white70 : Colors.black54;
     disabledColor ??= isDark ? Colors.white30 : Colors.black26;
@@ -159,7 +160,7 @@ class ThemeData {
       dividerColor: dividerColor,
       highlightColor: highlightColor,
       splashColor: splashColor,
-      splashType: splashType,
+      splashFactory: splashFactory,
       selectedRowColor: selectedRowColor,
       unselectedWidgetColor: unselectedWidgetColor,
       disabledColor: disabledColor,
@@ -200,7 +201,7 @@ class ThemeData {
     @required this.dividerColor,
     @required this.highlightColor,
     @required this.splashColor,
-    @required this.splashType,
+    @required this.splashFactory,
     @required this.selectedRowColor,
     @required this.unselectedWidgetColor,
     @required this.disabledColor,
@@ -231,7 +232,7 @@ class ThemeData {
        assert(dividerColor != null),
        assert(highlightColor != null),
        assert(splashColor != null),
-       assert(splashType != null),
+       assert(splashFactory != null),
        assert(selectedRowColor != null),
        assert(unselectedWidgetColor != null),
        assert(disabledColor != null),
@@ -323,8 +324,15 @@ class ThemeData {
   /// The color of ink splashes. See [InkWell].
   final Color splashColor;
 
-  /// Defines the appearance of ink splashes. See [InkWell].
-  final InkSplashType splashType;
+  /// Defines the appearance of ink splashes produces by [InkWell]
+  /// and [InkResponse].
+  ///
+  /// See Also
+  ///
+  ///  * [InkSplash.splashFactory], which defines the default splash.
+  ///  * [InkRipple.splashFactory], which defines a splash that spreads out
+  ///    more aggresively than the default.
+  final InteractiveInkFeatureFactory splashFactory;
 
   /// The color used to highlight selected rows.
   final Color selectedRowColor;
@@ -407,7 +415,7 @@ class ThemeData {
     Color dividerColor,
     Color highlightColor,
     Color splashColor,
-    InkSplashType splashType,
+    InteractiveInkFeatureFactory splashFactory,
     Color selectedRowColor,
     Color unselectedWidgetColor,
     Color disabledColor,
@@ -440,7 +448,7 @@ class ThemeData {
       dividerColor: dividerColor ?? this.dividerColor,
       highlightColor: highlightColor ?? this.highlightColor,
       splashColor: splashColor ?? this.splashColor,
-      splashType: splashType ?? this.splashType,
+      splashFactory: splashFactory ?? this.splashFactory,
       selectedRowColor: selectedRowColor ?? this.selectedRowColor,
       unselectedWidgetColor: unselectedWidgetColor ?? this.unselectedWidgetColor,
       disabledColor: disabledColor ?? this.disabledColor,
@@ -556,7 +564,7 @@ class ThemeData {
       dividerColor: Color.lerp(a.dividerColor, b.dividerColor, t),
       highlightColor: Color.lerp(a.highlightColor, b.highlightColor, t),
       splashColor: Color.lerp(a.splashColor, b.splashColor, t),
-      splashType: t < 0.5 ? a.splashType : b.splashType,
+      splashFactory: t < 0.5 ? a.splashFactory : b.splashFactory,
       selectedRowColor: Color.lerp(a.selectedRowColor, b.selectedRowColor, t),
       unselectedWidgetColor: Color.lerp(a.unselectedWidgetColor, b.unselectedWidgetColor, t),
       disabledColor: Color.lerp(a.disabledColor, b.disabledColor, t),
@@ -595,7 +603,7 @@ class ThemeData {
            (otherData.dividerColor == dividerColor) &&
            (otherData.highlightColor == highlightColor) &&
            (otherData.splashColor == splashColor) &&
-           (otherData.splashType == splashType) &&
+           (otherData.splashFactory == splashFactory) &&
            (otherData.selectedRowColor == selectedRowColor) &&
            (otherData.unselectedWidgetColor == unselectedWidgetColor) &&
            (otherData.disabledColor == disabledColor) &&
@@ -631,7 +639,7 @@ class ThemeData {
       dividerColor,
       highlightColor,
       splashColor,
-      splashType,
+      splashFactory,
       selectedRowColor,
       unselectedWidgetColor,
       disabledColor,

--- a/packages/flutter/test/material/ink_paint_test.dart
+++ b/packages/flutter/test/material/ink_paint_test.dart
@@ -68,7 +68,7 @@ void main() {
               splashColor: splashColor,
               onTap: () { },
               radius: 100.0,
-              splashType: InkSplashType.ripple,
+              splashFactory: InkRipple.splashFactory,
             ),
           ),
         ),

--- a/packages/flutter/test/material/ink_paint_test.dart
+++ b/packages/flutter/test/material/ink_paint_test.dart
@@ -9,7 +9,7 @@ import 'package:flutter_test/flutter_test.dart';
 import '../rendering/mock_canvas.dart';
 
 void main() {
-  testWidgets('Does the ink widget render a border radius', (WidgetTester tester) async {
+  testWidgets('The inkwell widget renders an ink splash', (WidgetTester tester) async {
     final Color highlightColor = const Color(0xAAFF0000);
     final Color splashColor = const Color(0xAA0000FF);
     final BorderRadius borderRadius = new BorderRadius.circular(6.0);
@@ -49,5 +49,131 @@ void main() {
     );
 
     await gesture.up();
+  });
+
+  testWidgets('The inkwell widget renders an ink ripple', (WidgetTester tester) async {
+    final Color highlightColor = const Color(0xAAFF0000);
+    final Color splashColor = const Color(0xB40000FF);
+    final BorderRadius borderRadius = new BorderRadius.circular(6.0);
+
+    await tester.pumpWidget(
+      new Material(
+        child: new Center(
+          child: new Container(
+            width: 100.0,
+            height: 100.0,
+            child: new InkWell(
+              borderRadius: borderRadius,
+              highlightColor: highlightColor,
+              splashColor: splashColor,
+              onTap: () { },
+              radius: 100.0,
+              splashType: InkSplashType.ripple,
+            ),
+          ),
+        ),
+      ),
+    );
+
+    final Offset tapDownOffset = tester.getTopLeft(find.byType(InkWell));
+    final Offset inkWellCenter = tester.getCenter(find.byType(InkWell));
+    //final TestGesture gesture = await tester.startGesture(tapDownOffset);
+    await tester.tapAt(tapDownOffset);
+    await tester.pump(); // start gesture
+
+    final RenderBox box = Material.of(tester.element(find.byType(InkWell))) as dynamic;
+
+    bool offsetsAreClose(Offset a, Offset b) => (a - b).distance < 1.0;
+    bool radiiAreClose(double a, double b) => (a - b).abs() < 1.0;
+
+    // Initially the ripple's center is where the tap occurred,
+    expect(box, paints..something((Symbol method, List<dynamic> arguments) {
+      if (method != #drawCircle)
+        return false;
+      final Offset center = arguments[0];
+      final double radius = arguments[1];
+      final Paint paint = arguments[2];
+      if (offsetsAreClose(center, tapDownOffset) && radius == 30.0 && paint.color.alpha == 0)
+        return true;
+      throw '''
+        Expected: center == $tapDownOffset, radius == 30.0, alpha == 0
+        Found: center == $center radius == $radius alpha == ${paint.color.alpha}''';
+    }));
+
+    // The ripple fades in for 75ms. During that time its alpha is eased from
+    // 0 to  the splashColor's alpha value and its center moves towards the
+    // center of the ink well.
+    await tester.pump(const Duration(milliseconds: 50));
+    expect(box, paints..something((Symbol method, List<dynamic> arguments) {
+      if (method != #drawCircle)
+        return false;
+      final Offset center = arguments[0];
+      final double radius = arguments[1];
+      final Paint paint = arguments[2];
+      final Offset expectedCenter = tapDownOffset + const Offset(17.0, 17.0);
+      final double expectedRadius = 56.0;
+      if (offsetsAreClose(center, expectedCenter) && radiiAreClose(radius, expectedRadius) && paint.color.alpha == 120)
+        return true;
+      throw '''
+        Expected: center == $expectedCenter, radius == $expectedRadius, alpha == 120
+        Found: center == $center radius == $radius alpha == ${paint.color.alpha}''';
+    }));
+
+    // At 75ms the ripple has fade in: it's alpha matches the splashColor's
+    // alpha and its center has moved closer to the ink well's center.
+    await tester.pump(const Duration(milliseconds: 25));
+    expect(box, paints..something((Symbol method, List<dynamic> arguments) {
+      if (method != #drawCircle)
+        return false;
+      final Offset center = arguments[0];
+      final double radius = arguments[1];
+      final Paint paint = arguments[2];
+      final Offset expectedCenter = tapDownOffset + const Offset(29.0, 29.0);
+      final double expectedRadius = 73.0;
+      if (offsetsAreClose(center, expectedCenter) && radiiAreClose(radius, expectedRadius) && paint.color.alpha == 180)
+        return true;
+      throw '''
+        Expected: center == $expectedCenter, radius == $expectedRadius, alpha == 180
+        Found: center == $center radius == $radius alpha == ${paint.color.alpha}''';
+    }));
+
+    // At this point the splash radius has expanded to its limit: 5 passed the
+    // ink well's radius parameter. The splash center has moved to its final
+    // location at the inkwell's center and the fade-out is about to start.
+    await tester.pump(const Duration(milliseconds: 225));
+    expect(box, paints..something((Symbol method, List<dynamic> arguments) {
+      if (method != #drawCircle)
+        return false;
+      final Offset center = arguments[0];
+      final double radius = arguments[1];
+      final Paint paint = arguments[2];
+      final Offset expectedCenter = inkWellCenter;
+      final double expectedRadius = 105.0;
+      if (offsetsAreClose(center, expectedCenter) && radiiAreClose(radius, expectedRadius) && paint.color.alpha == 180)
+        return true;
+      throw '''
+        Expected: center == $expectedCenter, radius == $expectedRadius, alpha == 180
+        Found: center == $center radius == $radius alpha == ${paint.color.alpha}''';
+      return true;
+      throw 'FAILED';
+    }));
+
+    // After another 150ms the fade-out is complete.
+    await tester.pump(const Duration(milliseconds: 150));
+    expect(box, paints..something((Symbol method, List<dynamic> arguments) {
+      if (method != #drawCircle)
+        return false;
+      final Offset center = arguments[0];
+      final double radius = arguments[1];
+      final Paint paint = arguments[2];
+      final Offset expectedCenter = inkWellCenter;
+      final double expectedRadius = 105.0;
+      if (offsetsAreClose(center, expectedCenter) && radiiAreClose(radius, expectedRadius) && paint.color.alpha == 0)
+        return true;
+      throw '''
+        Expected: center == $expectedCenter, radius == $expectedRadius, alpha == 0
+        Found: center == $center radius == $radius alpha == ${paint.color.alpha}''';
+    }));
+
   });
 }

--- a/packages/flutter/test/material/ink_paint_test.dart
+++ b/packages/flutter/test/material/ink_paint_test.dart
@@ -154,8 +154,6 @@ void main() {
       throw '''
         Expected: center == $expectedCenter, radius == $expectedRadius, alpha == 180
         Found: center == $center radius == $radius alpha == ${paint.color.alpha}''';
-      return true;
-      throw 'FAILED';
     }));
 
     // After another 150ms the fade-out is complete.

--- a/packages/flutter/test/material/ink_paint_test.dart
+++ b/packages/flutter/test/material/ink_paint_test.dart
@@ -137,7 +137,7 @@ void main() {
         Found: center == $center radius == $radius alpha == ${paint.color.alpha}''';
     }));
 
-    // At this point the splash radius has expanded to its limit: 5 passed the
+    // At this point the splash radius has expanded to its limit: 5 past the
     // ink well's radius parameter. The splash center has moved to its final
     // location at the inkwell's center and the fade-out is about to start.
     await tester.pump(const Duration(milliseconds: 225));


### PR DESCRIPTION
Added the `InkRipple` InkFeature and an InkSplashType enum to the material library.

Added `InkSplashType splashType` to material's theme data.

InkWell and InkResponse now have a `InkSplashType splashType` parameter that determines what kind of ink feature is displayed in reponse to user input. This parameter defaults to `Theme.of(..).splashType`.

Hoisted `color` `confirm()` and `cancel()` from the `InkFeature` subclasses to `InkFeature`.

