### PR TITLE
send 'reloadRecommended' info to IDEs

### DIFF
--- a/packages/flutter_tools/lib/src/commands/daemon.dart
+++ b/packages/flutter_tools/lib/src/commands/daemon.dart
@@ -705,8 +705,8 @@ Map<String, dynamic> _operationResultToMap(OperationResult result) {
     'message': result.message,
   };
 
-  if (result.hint != null)
-    map['hint'] = result.hint;
+  if (result.hintMessage != null)
+    map['hintMessage'] = result.hintMessage;
   if (result.hintId != null)
     map['hintId'] = result.hintId;
 

--- a/packages/flutter_tools/lib/src/commands/daemon.dart
+++ b/packages/flutter_tools/lib/src/commands/daemon.dart
@@ -677,11 +677,14 @@ Stream<Map<String, dynamic>> get stdinCommandStream => stdin
   });
 
 void stdoutCommandResponse(Map<String, dynamic> command) {
-  final String encoded = JSON.encode(command, toEncodable: _jsonEncodeObject);
-  stdout.writeln('[$encoded]');
+  stdout.writeln('[${jsonEncodeObject(command)}]');
 }
 
-dynamic _jsonEncodeObject(dynamic object) {
+String jsonEncodeObject(dynamic object) {
+  return JSON.encode(object, toEncodable: _toEncodable);
+}
+
+dynamic _toEncodable(dynamic object) {
   if (object is OperationResult)
     return _operationResultToMap(object);
   return object;
@@ -697,10 +700,17 @@ Future<Map<String, dynamic>> _deviceToMap(Device device) async {
 }
 
 Map<String, dynamic> _operationResultToMap(OperationResult result) {
-  return <String, dynamic>{
+  final Map<String, dynamic> map = <String, dynamic>{
     'code': result.code,
-    'message': result.message
+    'message': result.message,
   };
+
+  if (result.hint != null)
+    map['hint'] = result.hint;
+  if (result.hintId != null)
+    map['hintId'] = result.hintId;
+
+  return map;
 }
 
 dynamic _toJsonable(dynamic obj) {

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -843,7 +843,7 @@ abstract class ResidentRunner {
 }
 
 class OperationResult {
-  OperationResult(this.code, this.message, { this.hint, this.hintId });
+  OperationResult(this.code, this.message, { this.hintMessage, this.hintId });
 
   /// The result of the operation; a non-zero code indicates a failure.
   final int code;
@@ -855,7 +855,7 @@ class OperationResult {
   /// sidecar data about the operation results. For example, this is used when
   /// a reload is successful but some changed program elements where not run after a
   /// reassemble.
-  final String hint;
+  final String hintMessage;
 
   /// A key used by tools to discriminate between different kinds of operation results.
   /// For example, a successful reload might have a [code] of 0 and a [hintId] of

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -843,11 +843,24 @@ abstract class ResidentRunner {
 }
 
 class OperationResult {
-  OperationResult(this.code, this.message, { this.hint });
+  OperationResult(this.code, this.message, { this.hint, this.hintId });
 
+  /// The result of the operation; a non-zero code indicates a failure.
   final int code;
+
+  /// A user facing message about the results of the operation.
   final String message;
+
+  /// An optional hint about the results of the operation. This is used to provide
+  /// sidecar data about the operation results. For example, this is used when
+  /// a reload is successful but some changed program elements where not run after a
+  /// reassemble.
   final String hint;
+
+  /// A key used by tools to discriminate between different kinds of operation results.
+  /// For example, a successful reload might have a [code] of 0 and a [hintId] of
+  /// `'restartRecommended'`.
+  final String hintId;
 
   bool get isOk => code == 0;
 

--- a/packages/flutter_tools/lib/src/run_hot.dart
+++ b/packages/flutter_tools/lib/src/run_hot.dart
@@ -679,6 +679,7 @@ class HotRunner extends ResidentRunner {
       reassembleAndScheduleErrors ? 1 : OperationResult.ok.code,
       reloadMessage,
       hint: unusedElementMessage,
+      hintId: unusedElementMessage != null ? 'restartRecommended' : null,
     );
   }
 

--- a/packages/flutter_tools/lib/src/run_hot.dart
+++ b/packages/flutter_tools/lib/src/run_hot.dart
@@ -457,8 +457,8 @@ class HotRunner extends ResidentRunner {
         status.cancel();
         if (result.isOk)
           printStatus('${result.message} in ${getElapsedAsMilliseconds(timer.elapsed)}.');
-        if (result.hint != null)
-          printStatus('\n${result.hint}');
+        if (result.hintMessage != null)
+          printStatus('\n${result.hintMessage}');
         return result;
       } catch (error) {
         status.cancel();
@@ -678,7 +678,7 @@ class HotRunner extends ResidentRunner {
     return new OperationResult(
       reassembleAndScheduleErrors ? 1 : OperationResult.ok.code,
       reloadMessage,
-      hint: unusedElementMessage,
+      hintMessage: unusedElementMessage,
       hintId: unusedElementMessage != null ? 'restartRecommended' : null,
     );
   }

--- a/packages/flutter_tools/test/commands/daemon_test.dart
+++ b/packages/flutter_tools/test/commands/daemon_test.dart
@@ -10,6 +10,7 @@ import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/commands/daemon.dart';
 import 'package:flutter_tools/src/globals.dart';
 import 'package:flutter_tools/src/ios/ios_workflow.dart';
+import 'package:flutter_tools/src/resident_runner.dart';
 import 'package:test/test.dart';
 
 import '../src/context.dart';
@@ -265,6 +266,23 @@ void main() {
     }, overrides: <Type, Generator>{
       AndroidWorkflow: () => new MockAndroidWorkflow(),
       IOSWorkflow: () => new MockIOSWorkflow(),
+    });
+  });
+
+  group('daemon serialization', () {
+    test('OperationResult', () {
+      expect(
+        jsonEncodeObject(OperationResult.ok),
+        '{"code":0,"message":""}'
+      );
+      expect(
+        jsonEncodeObject(new OperationResult(1, 'foo')),
+        '{"code":1,"message":"foo"}'
+      );
+      expect(
+        jsonEncodeObject(new OperationResult(0, 'foo', hint: 'my hint', hintId: 'myId')),
+        '{"code":0,"message":"foo","hint":"my hint","hintId":"myId"}'
+      );
     });
   });
 }

--- a/packages/flutter_tools/test/commands/daemon_test.dart
+++ b/packages/flutter_tools/test/commands/daemon_test.dart
@@ -280,8 +280,8 @@ void main() {
         '{"code":1,"message":"foo"}'
       );
       expect(
-        jsonEncodeObject(new OperationResult(0, 'foo', hint: 'my hint', hintId: 'myId')),
-        '{"code":0,"message":"foo","hint":"my hint","hintId":"myId"}'
+        jsonEncodeObject(new OperationResult(0, 'foo', hintMessage: 'my hint', hintId: 'myId')),
+        '{"code":0,"message":"foo","hintMessage":"my hint","hintId":"myId"}'
       );
     });
   });


### PR DESCRIPTION
- send any reload hint message, and a reload hint ID, to IDEs after a reload
- use this to send a `reloadRecommended` hint to IDEs, in order to better support the `'Some program elements were changed during reload but did not run when the view was reassembled...`' message
- work towards https://github.com/flutter/flutter-intellij/issues/1398

@jcollins-g @tvolkert @rmacnak-google 