### PR TITLE
Flutter tools support for kernel transformer tracking Widget creation locations.

### DIFF
--- a/packages/flutter_tools/gradle/flutter.gradle
+++ b/packages/flutter_tools/gradle/flutter.gradle
@@ -260,7 +260,10 @@ class FlutterPlugin implements Plugin<Project> {
         if (project.hasProperty('preview-dart-2')) {
             previewDart2Value = project.property('preview-dart-2')
         }
-
+        Boolean trackWidgetCreationValue = false
+        if (project.hasProperty('track-widget-creation')) {
+            trackWidgetCreationValue = project.property('track-widget-creation')
+        }
         String extraFrontEndOptionsValue = null
         if (project.hasProperty('extra-front-end-options')) {
             extraFrontEndOptionsValue = project.property('extra-front-end-options')
@@ -299,6 +302,7 @@ class FlutterPlugin implements Plugin<Project> {
                 localEngineSrcPath this.localEngineSrcPath
                 targetPath target
                 previewDart2 previewDart2Value
+                trackWidgetCreation trackWidgetCreationValue
                 preferSharedLibrary preferSharedLibraryValue
                 targetPlatform targetPlatformValue
                 sourceDir project.file(project.flutter.source)
@@ -314,6 +318,7 @@ class FlutterPlugin implements Plugin<Project> {
                 localEngineSrcPath this.localEngineSrcPath
                 targetPath target
                 previewDart2 previewDart2Value
+                trackWidgetCreation trackWidgetCreationValue
                 preferSharedLibrary preferSharedLibraryValue
                 targetPlatform targetPlatformValue
                 sourceDir project.file(project.flutter.source)
@@ -349,6 +354,8 @@ abstract class BaseFlutterTask extends DefaultTask {
     String targetPath
     @Optional @Input
     Boolean previewDart2
+    @Optional @Input
+    Boolean trackWidgetCreation
     @Optional @Input
     Boolean preferSharedLibrary
     @Optional @Input
@@ -392,6 +399,9 @@ abstract class BaseFlutterTask extends DefaultTask {
                 if (previewDart2) {
                     args "--preview-dart-2"
                 }
+                if (trackWidgetCreation) {
+                    args "--track-widget-creation"
+                }
                 if (extraFrontEndOptions != null) {
                     args "--extra-front-end-options", "${extraFrontEndOptions}"
                 }
@@ -421,7 +431,9 @@ abstract class BaseFlutterTask extends DefaultTask {
             if (previewDart2) {
                 args "--preview-dart-2"
             }
-
+            if (trackWidgetCreation) {
+                args "--track-widget-creation"
+            }
             args "--output-file", "${intermediateDir}/app.flx"
             if (buildMode != "debug") {
                 args "--precompiled"

--- a/packages/flutter_tools/lib/src/android/gradle.dart
+++ b/packages/flutter_tools/lib/src/android/gradle.dart
@@ -300,6 +300,8 @@ Future<Null> _buildGradleProjectV2(String gradle, BuildInfo buildInfo, String ta
   if (buildInfo.previewDart2) {
     command.add('-Ppreview-dart-2=true');
     command.add('-Pstrong=true');
+    if (buildInfo.trackWidgetCreation)
+      command.add('-Ptrack-widget-creation=true');
     if (buildInfo.extraFrontEndOptions != null)
       command.add('-Pextra-front-end-options=${buildInfo.extraFrontEndOptions}');
     if (buildInfo.extraGenSnapshotOptions != null)

--- a/packages/flutter_tools/lib/src/build_info.dart
+++ b/packages/flutter_tools/lib/src/build_info.dart
@@ -12,6 +12,7 @@ import 'globals.dart';
 class BuildInfo {
   const BuildInfo(this.mode, this.flavor,
       {this.previewDart2,
+      this.trackWidgetCreation,
       this.extraFrontEndOptions,
       this.extraGenSnapshotOptions,
       this.preferSharedLibrary,
@@ -28,6 +29,9 @@ class BuildInfo {
 
   // Whether build should be done using Dart2 Frontend parser.
   final bool previewDart2;
+
+  /// Whether the build should track widget creation locations.
+  final bool trackWidgetCreation;
 
   /// Extra command-line options for front-end.
   final String extraFrontEndOptions;
@@ -68,6 +72,7 @@ class BuildInfo {
   BuildInfo withTargetPlatform(TargetPlatform targetPlatform) =>
       new BuildInfo(mode, flavor,
           previewDart2: previewDart2,
+          trackWidgetCreation: trackWidgetCreation,
           extraFrontEndOptions: extraFrontEndOptions,
           extraGenSnapshotOptions: extraGenSnapshotOptions,
           preferSharedLibrary: preferSharedLibrary,

--- a/packages/flutter_tools/lib/src/commands/build_aot.dart
+++ b/packages/flutter_tools/lib/src/commands/build_aot.dart
@@ -341,6 +341,7 @@ Future<String> _buildAotSnapshot(
       extraFrontEndOptions: extraFrontEndOptions,
       linkPlatformKernelIn : true,
       aot : true,
+      trackWidgetCreation: false,
     );
     if (mainPath == null) {
       printError('Compiler terminated unexpectedly.');

--- a/packages/flutter_tools/lib/src/commands/build_apk.dart
+++ b/packages/flutter_tools/lib/src/commands/build_apk.dart
@@ -16,6 +16,7 @@ class BuildApkCommand extends BuildSubCommand {
 
     argParser
       ..addFlag('preview-dart-2', negatable: false,  hide: !verboseHelp)
+      ..addFlag('track-widget-creation', negatable: false, hide: !verboseHelp)
       ..addFlag('prefer-shared-library', negatable: false,
           help: 'Whether to prefer compiling to a *.so file (android only).')
       ..addOption('target-platform',

--- a/packages/flutter_tools/lib/src/commands/build_flx.dart
+++ b/packages/flutter_tools/lib/src/commands/build_flx.dart
@@ -21,6 +21,11 @@ class BuildFlxCommand extends BuildSubCommand {
     argParser.addOption('snapshot', defaultsTo: defaultSnapshotPath);
     argParser.addOption('depfile', defaultsTo: defaultDepfilePath);
     argParser.addFlag('preview-dart-2', negatable: false, hide: !verboseHelp);
+    argParser.addFlag(
+      'track-widget-creation',
+      hide: !verboseHelp,
+      help: 'Track widget creation locations. Requires Dart 2.0 functionality.',
+    );
     argParser.addOption('working-dir', defaultsTo: getAssetBuildDirectory());
     argParser.addFlag('report-licensed-packages', help: 'Whether to report the names of all the packages that are included in the application\'s LICENSE file.', defaultsTo: false);
     usesPubOption();
@@ -51,7 +56,8 @@ class BuildFlxCommand extends BuildSubCommand {
       workingDirPath: argResults['working-dir'],
       previewDart2: argResults['preview-dart-2'],
       precompiledSnapshot: argResults['precompiled'],
-      reportLicensedPackages: argResults['report-licensed-packages']
+      reportLicensedPackages: argResults['report-licensed-packages'],
+      trackWidgetCreation: argResults['track-widget-creation'],
     );
   }
 }

--- a/packages/flutter_tools/lib/src/commands/run.dart
+++ b/packages/flutter_tools/lib/src/commands/run.dart
@@ -114,6 +114,9 @@ class RunCommand extends RunCommandBase {
         hide: !verboseHelp,
         help: 'Turn on strong mode semantics.\n'
               'Valid only when --preview-dart-2 is also specified');
+    argParser.addFlag('track-widget-creation',
+        hide: !verboseHelp,
+        help: 'Track widget creation locations. Requires Dart 2.0 functionality.');
     argParser.addOption('project-root',
         hide: !verboseHelp,
         help: 'Specify the project root directory.');
@@ -297,7 +300,11 @@ class RunCommand extends RunCommandBase {
     }
 
     final List<FlutterDevice> flutterDevices = devices.map((Device device) {
-      return new FlutterDevice(device, previewDart2: argResults['preview-dart-2']);
+      return new FlutterDevice(
+        device,
+        previewDart2: argResults['preview-dart-2'],
+        trackWidgetCreation: argResults['track-widget-creation'],
+      );
     }).toList();
 
     ResidentRunner runner;

--- a/packages/flutter_tools/lib/src/flx.dart
+++ b/packages/flutter_tools/lib/src/flx.dart
@@ -40,7 +40,8 @@ Future<Null> build({
   String packagesPath,
   bool previewDart2 : false,
   bool precompiledSnapshot: false,
-  bool reportLicensedPackages: false
+  bool reportLicensedPackages: false,
+  bool trackWidgetCreation: false,
 }) async {
   outputPath ??= defaultFlxOutputPath;
   snapshotPath ??= defaultSnapshotPath;
@@ -73,6 +74,7 @@ Future<Null> build({
       sdkRoot: artifacts.getArtifactPath(Artifact.flutterPatchedSdkPath),
       incrementalCompilerByteStorePath: fs.path.absolute(getIncrementalCompilerByteStoreDirectory()),
       mainPath: fs.file(mainPath).absolute.path,
+      trackWidgetCreation: trackWidgetCreation,
     );
     if (kernelBinaryFilename == null) {
       throwToolExit('Compiler terminated unexpectedly on $mainPath');

--- a/packages/flutter_tools/lib/src/ios/simulators.dart
+++ b/packages/flutter_tools/lib/src/ios/simulators.dart
@@ -411,11 +411,15 @@ class IOSSimulator extends Device {
     await SimControl.instance.install(id, fs.path.absolute(bundle.path));
   }
 
-  Future<Null> _sideloadUpdatedAssetsForInstalledApplicationBundle(ApplicationPackage app, BuildInfo buildInfo) =>
-      // When running in previewDart2 mode, we still need to run compiler to
-      // produce kernel file for the application.
-      flx.build(precompiledSnapshot: !buildInfo.previewDart2,
-          previewDart2: buildInfo.previewDart2);
+  Future<Null> _sideloadUpdatedAssetsForInstalledApplicationBundle(ApplicationPackage app, BuildInfo buildInfo) {
+    // When running in previewDart2 mode, we still need to run compiler to
+    // produce kernel file for the application.
+    return flx.build(
+      precompiledSnapshot: !buildInfo.previewDart2,
+      previewDart2: buildInfo.previewDart2,
+      trackWidgetCreation: buildInfo.trackWidgetCreation,
+    );
+  }
 
   @override
   Future<bool> stopApp(ApplicationPackage app) async {

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -38,9 +38,16 @@ class FlutterDevice {
 
   StreamSubscription<String> _loggingSubscription;
 
-  FlutterDevice(this.device, { bool previewDart2 : false }) {
-    if (previewDart2)
-      generator = new ResidentCompiler(artifacts.getArtifactPath(Artifact.flutterPatchedSdkPath));
+  FlutterDevice(this.device, {
+    bool previewDart2: false,
+    bool trackWidgetCreation: false,
+  }) {
+    if (previewDart2) {
+      generator = new ResidentCompiler(
+        artifacts.getArtifactPath(Artifact.flutterPatchedSdkPath),
+        trackWidgetCreation: trackWidgetCreation,
+      );
+    }
   }
 
   String viewFilter;

--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -170,11 +170,20 @@ abstract class FlutterCommand extends Command<Null> {
       targetPlatform = getTargetPlatformForName(argResults['target-platform']);
     }
 
+    final bool trackWidgetCreation = argParser.options.containsKey('track-widget-creation')
+        ? argResults['track-widget-creation']
+        : false;
+    if (trackWidgetCreation == true && previewDart2 == false) {
+      throw new UsageException(
+          '--track-widget-creation is valid only when --preview-dart-2 is specified.', null);
+    }
+
     return new BuildInfo(getBuildMode(),
       argParser.options.containsKey('flavor')
         ? argResults['flavor']
         : null,
       previewDart2: previewDart2,
+      trackWidgetCreation: trackWidgetCreation,
       extraFrontEndOptions: argParser.options.containsKey(FlutterOptions.kExtraFrontEndOptions)
           ? argResults[FlutterOptions.kExtraFrontEndOptions]
           : null,

--- a/packages/flutter_tools/test/resident_runner_test.dart
+++ b/packages/flutter_tools/test/resident_runner_test.dart
@@ -46,6 +46,10 @@ void main() {
   TestRunner testRunner;
 
   setUp(() {
+    // TODO(jacobr): make these tests run with `previewDart2: true` and
+    // `trackWidgetCreation: true` as well as the default flags.
+    // Currently the TestRunner is not properly configured to be able to run
+    // with `previewDart2: true` due to missing resources.
     testRunner = new TestRunner(
         <FlutterDevice>[new FlutterDevice(new MockDevice())]
     );


### PR DESCRIPTION
Additionally, I have not tested IOS end-to-end. If this seems reasonable I'll make sure the IOS emulator build is also respecting this flag.

See 
https://github.com/flutter/engine/pull/4529
for the corresponding flutter_engine cl.

This CL is part of implementing https://github.com/flutter/flutter-intellij/issues/1597
