### PR TITLE
libtxt: update paragraph_text for current libtxt behavior

### DIFF
--- a/packages/flutter/test/rendering/paragraph_test.dart
+++ b/packages/flutter/test/rendering/paragraph_test.dart
@@ -271,17 +271,14 @@ void main() {
     // rendering widths in tests.
     // TODO(#12357): Figure out why this is, and fix it (if needed) once Blink
     // text rendering is replaced.
-    // anyOf for heights is needed because libtxt and Blink calculate selection
-    // rectangles differently.
-    // TODO: remove this when Blink is replaced.
     expect(boxes[0].toRect().width, anyOf(14.0, 13.0));
-    expect(boxes[0].toRect().height, anyOf(13.0, 26.0));
+    expect(boxes[0].toRect().height, closeTo(13.0, 0.0001));
     expect(boxes[1].toRect().width, anyOf(27.0, 26.0));
-    expect(boxes[1].toRect().height, 26.0);
+    expect(boxes[1].toRect().height, closeTo(26.0, 0.0001));
     expect(boxes[2].toRect().width, anyOf(27.0, 26.0));
-    expect(boxes[2].toRect().height, 26.0);
+    expect(boxes[2].toRect().height, closeTo(26.0, 0.0001));
     expect(boxes[3].toRect().width, anyOf(14.0, 13.0));
-    expect(boxes[3].toRect().height, anyOf(13.0, 26.0));
+    expect(boxes[3].toRect().height, closeTo(13.0, 0.0001));
   });
 
   test('toStringDeep', () {


### PR DESCRIPTION
* libtxt now calculates selection rectangles reflecting the heights of
differently styled text spans within a line (matching Blink)
* libtxt does not round the coordinates of selection rectangles (unlike Blink)