### PR TITLE
Add hot_mode preview_dart_2 tests for ios.

### DIFF
--- a/dev/devicelab/bin/tasks/hot_mode_dev_cycle_ios__preview_dart_2_benchmark.dart
+++ b/dev/devicelab/bin/tasks/hot_mode_dev_cycle_ios__preview_dart_2_benchmark.dart
@@ -1,0 +1,12 @@
+// Copyright (c) 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:flutter_devicelab/tasks/hot_mode_tests.dart';
+import 'package:flutter_devicelab/framework/framework.dart';
+
+Future<Null> main() async {
+  await task(createHotModeTest(isPreviewDart2: true));
+}

--- a/dev/devicelab/bin/tasks/hot_mode_dev_cycle_ios__preview_dart_2_benchmark.dart
+++ b/dev/devicelab/bin/tasks/hot_mode_dev_cycle_ios__preview_dart_2_benchmark.dart
@@ -6,7 +6,9 @@ import 'dart:async';
 
 import 'package:flutter_devicelab/tasks/hot_mode_tests.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
+import 'package:flutter_devicelab/framework/adb.dart';
 
 Future<Null> main() async {
+  deviceOperatingSystem = DeviceOperatingSystem.ios;
   await task(createHotModeTest(isPreviewDart2: true));
 }

--- a/dev/devicelab/bin/tasks/hot_mode_dev_cycle_ios__preview_dart_2_benchmark.dart
+++ b/dev/devicelab/bin/tasks/hot_mode_dev_cycle_ios__preview_dart_2_benchmark.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 The Chromium Authors. All rights reserved.
+// Copyright (c) 2018 The Chromium Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/dev/devicelab/manifest.yaml
+++ b/dev/devicelab/manifest.yaml
@@ -155,6 +155,14 @@ tasks:
     stage: devicelab
     required_agent_capabilities: ["mac/android"]
 
+  hot_mode_dev_cycle_ios__preview_dart_2_benchmark:
+    description: >
+      Measures the performance of Dart VM hot patching feature under
+      --preview-dart-2 option, that enables Dart 2.0 frontend.
+    stage: devicelab
+    required_agent_capabilities: ["mac/ios"]
+    flaky: true
+
   complex_layout_scroll_perf__memory:
     description: >
       Measures memory usage of the scroll performance test.


### PR DESCRIPTION
Until this there were no hot restart/reload benchmarks running on iOS devices. This adds one that exercises `--preview-dart-2` flag.