### PR TITLE
Use bundled mingit on Windows if available

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@
 
 # Flutter repo-specific
 /bin/cache/
+/bin/mingit/
 /dev/benchmarks/mega_gallery/
 /dev/bots/.recipe_deps
 /dev/bots/android_tools/

--- a/bin/flutter.bat
+++ b/bin/flutter.bat
@@ -29,6 +29,10 @@ SET pub_cache_path=%FLUTTER_ROOT%\.pub-cache
 SET dart=%dart_sdk_path%\bin\dart.exe
 SET pub=%dart_sdk_path%\bin\pub.bat
 
+REM If available, add location of bundled mingit to PATH
+SET mingit_path=%FLUTTER_ROOT%\bin\mingit\cmd
+IF EXIST "%mingit_path%" SET PATH=%PATH%;%mingit_path%
+
 REM Test if Git is available on the Host
 where /q git || ECHO Error: Unable to find git in your PATH. && EXIT /B 1
 REM  Test if the flutter directory is a git clone, otherwise git rev-parse HEAD would fail

--- a/bin/internal/update_dart_sdk.ps1
+++ b/bin/internal/update_dart_sdk.ps1
@@ -51,6 +51,9 @@ Write-Host "Unzipping Dart SDK..."
 If (Get-Command 7z -errorAction SilentlyContinue) {
     # The built-in unzippers are painfully slow. Use 7-Zip, if available.
     & 7z x $dartSdkZip -o"$cachePath" -bd | Out-Null
+} ElseIf (Get-Command 7za -errorAction SilentlyContinue) {
+    # Use 7-Zip's standalone version 7za.exe, if available.
+    & 7za x $dartSdkZip -o"$cachePath" -bd | Out-Null
 } ElseIf (Get-Command Expand-Archive -errorAction SilentlyContinue) {
     # Use PowerShell's built-in unzipper, if available (requires PowerShell 5+).
     Expand-Archive $dartSdkZip -DestinationPath $cachePath


### PR DESCRIPTION
In the packaged ZIP files for Flutter we bundle mingit on Windows to make setup for our users easier (they don't have to download and install git anymore). This change makes Flutter use the bundled mingit if it is available and if git is not installed on the system.

This change will still require that users add `flutter\bin` to their path or they'll have to execute `flutter\bin\flutter.bat` directly. A follow-up PR will add a pre-configured Flutter Console that people can start with a double-click to minimize setup even further.

Also in this PR:
* If 7Zip (`7z.exe`) is not available to unpack the Dart SDK try 7Zip's standalone version (`7za.exe`).

/cc @mit-mit @gspencergoog 