### PR TITLE
Revert "Handle abnormal termination of frontend compiler. (#13982)"

### DIFF
--- a/packages/flutter_tools/lib/src/commands/build_aot.dart
+++ b/packages/flutter_tools/lib/src/commands/build_aot.dart
@@ -342,10 +342,6 @@ Future<String> _buildAotSnapshot(
       aot : true,
       strongMode: strongMode,
     );
-    if (mainPath == null) {
-      printError('Compiler terminated unexpectedly.');
-      return null;
-    }
   }
 
   genSnapshotCmd.add(mainPath);

--- a/packages/flutter_tools/lib/src/compile.dart
+++ b/packages/flutter_tools/lib/src/compile.dart
@@ -110,8 +110,8 @@ Future<String> compile(
     .transform(UTF8.decoder)
     .transform(const LineSplitter())
     .listen(stdoutHandler.handler);
-  final int exitCode = await server.exitCode;
-  return exitCode == 0 ? stdoutHandler.outputFilename.future : null;
+  await server.exitCode;
+  return stdoutHandler.outputFilename.future;
 }
 
 /// Wrapper around incremental frontend server compiler, that communicates with
@@ -175,8 +175,7 @@ class ResidentCompiler {
 
     _server.stdin.writeln('compile $scriptFilename');
 
-    final int exitCode = await _server.exitCode;
-    return exitCode == 0 ? stdoutHandler.outputFilename.future : null;
+    return stdoutHandler.outputFilename.future;
   }
 
 

--- a/packages/flutter_tools/lib/src/flx.dart
+++ b/packages/flutter_tools/lib/src/flx.dart
@@ -76,9 +76,6 @@ Future<Null> build({
       mainPath: fs.file(mainPath).absolute.path,
       strongMode: strongMode
     );
-    if (kernelBinaryFilename == null) {
-      throwToolExit('Compiler terminated unexpectedly on $mainPath');
-    }
     kernelContent = new DevFSFileContent(fs.file(kernelBinaryFilename));
   }
 

--- a/packages/flutter_tools/test/compile_test.dart
+++ b/packages/flutter_tools/test/compile_test.dart
@@ -74,28 +74,6 @@ void main() {
     }, overrides: <Type, Generator>{
       ProcessManager: () => mockProcessManager,
     });
-
-    testUsingContext('single dart abnormal compiler termination', () async {
-      when(mockFrontendServer.exitCode).thenReturn(255);
-
-      final BufferLogger logger = context[Logger];
-
-      when(mockFrontendServer.stdout)
-          .thenAnswer((Invocation invocation) => new Stream<List<int>>.fromFuture(
-          new Future<List<int>>.value(UTF8.encode(
-              'result abc\nline1\nline2\nabc'
-          ))
-      ));
-
-      final String output = await compile(sdkRoot: '/path/to/sdkroot',
-          mainPath: '/path/to/main.dart'
-      );
-      expect(mockFrontendServerStdIn.getAndClear(), isEmpty);
-      expect(logger.errorText, equals('compiler message: line1\ncompiler message: line2\n'));
-      expect(output, equals(null));
-    }, overrides: <Type, Generator>{
-      ProcessManager: () => mockProcessManager,
-    });
   });
 
   group('incremental compile', () {
@@ -143,27 +121,6 @@ void main() {
       verifyNoMoreInteractions(mockFrontendServerStdIn);
       expect(logger.errorText, equals('compiler message: line1\ncompiler message: line2\n'));
       expect(output, equals('/path/to/main.dart.dill'));
-    }, overrides: <Type, Generator>{
-      ProcessManager: () => mockProcessManager,
-    });
-
-    testUsingContext('single dart compile abnormally terminates', () async {
-      when(mockFrontendServer.exitCode).thenReturn(255);
-
-      final BufferLogger logger = context[Logger];
-
-      when(mockFrontendServer.stdout)
-          .thenAnswer((Invocation invocation) => new Stream<List<int>>.fromFuture(
-          new Future<List<int>>.value(UTF8.encode(
-              'result abc\nline1\nline2\nabc /path/to/main.dart.dill'
-          ))
-      ));
-
-      final String output = await generator.recompile(
-          '/path/to/main.dart', null /* invalidatedFiles */
-      );
-      expect(logger.errorText, equals('compiler message: line1\ncompiler message: line2\n'));
-      expect(output, equals(null));
     }, overrides: <Type, Generator>{
       ProcessManager: () => mockProcessManager,
     });


### PR DESCRIPTION
This reverts commit 9534082fc097dadf075c1eda7938af48df59ce3e.

Causes hot_mode_dev_cycle__preview_dart_2_benchmark test timeout.