### PR TITLE
Reland 9534082fc097dadf075c1eda7938af48df59ce3e with fix for incremen…

### DIFF
--- a/packages/flutter_tools/lib/src/commands/build_aot.dart
+++ b/packages/flutter_tools/lib/src/commands/build_aot.dart
@@ -342,6 +342,10 @@ Future<String> _buildAotSnapshot(
       aot : true,
       strongMode: strongMode,
     );
+    if (mainPath == null) {
+      printError('Compiler terminated unexpectedly.');
+      return null;
+    }
   }
 
   genSnapshotCmd.add(mainPath);

--- a/packages/flutter_tools/lib/src/compile.dart
+++ b/packages/flutter_tools/lib/src/compile.dart
@@ -110,8 +110,8 @@ Future<String> compile(
     .transform(UTF8.decoder)
     .transform(const LineSplitter())
     .listen(stdoutHandler.handler);
-  await server.exitCode;
-  return stdoutHandler.outputFilename.future;
+  final int exitCode = await server.exitCode;
+  return exitCode == 0 ? stdoutHandler.outputFilename.future : null;
 }
 
 /// Wrapper around incremental frontend server compiler, that communicates with
@@ -167,7 +167,16 @@ class ResidentCompiler {
     _server.stdout
       .transform(UTF8.decoder)
       .transform(const LineSplitter())
-      .listen(stdoutHandler.handler);
+      .listen(
+        stdoutHandler.handler,
+        onDone: () {
+          // when outputFilename future is not completed, but stdout is closed
+          // process has died unexpectedly.
+          if (!stdoutHandler.outputFilename.isCompleted) {
+            stdoutHandler.outputFilename.complete(null);
+          }
+        });
+
     _server.stderr
       .transform(UTF8.decoder)
       .transform(const LineSplitter())

--- a/packages/flutter_tools/lib/src/flx.dart
+++ b/packages/flutter_tools/lib/src/flx.dart
@@ -76,6 +76,9 @@ Future<Null> build({
       mainPath: fs.file(mainPath).absolute.path,
       strongMode: strongMode
     );
+    if (kernelBinaryFilename == null) {
+      throwToolExit('Compiler terminated unexpectedly on $mainPath');
+    }
     kernelContent = new DevFSFileContent(fs.file(kernelBinaryFilename));
   }
 

--- a/packages/flutter_tools/test/compile_test.dart
+++ b/packages/flutter_tools/test/compile_test.dart
@@ -74,6 +74,28 @@ void main() {
     }, overrides: <Type, Generator>{
       ProcessManager: () => mockProcessManager,
     });
+
+    testUsingContext('single dart abnormal compiler termination', () async {
+      when(mockFrontendServer.exitCode).thenReturn(255);
+
+      final BufferLogger logger = context[Logger];
+
+      when(mockFrontendServer.stdout)
+          .thenAnswer((Invocation invocation) => new Stream<List<int>>.fromFuture(
+          new Future<List<int>>.value(UTF8.encode(
+              'result abc\nline1\nline2\nabc'
+          ))
+      ));
+
+      final String output = await compile(sdkRoot: '/path/to/sdkroot',
+          mainPath: '/path/to/main.dart'
+      );
+      expect(mockFrontendServerStdIn.getAndClear(), isEmpty);
+      expect(logger.errorText, equals('compiler message: line1\ncompiler message: line2\n'));
+      expect(output, equals(null));
+    }, overrides: <Type, Generator>{
+      ProcessManager: () => mockProcessManager,
+    });
   });
 
   group('incremental compile', () {
@@ -101,7 +123,10 @@ void main() {
       when(mockProcessManager.start(any)).thenAnswer(
           (Invocation invocation) => new Future<Process>.value(mockFrontendServer)
       );
-      when(mockFrontendServer.exitCode).thenReturn(0);
+    });
+
+    tearDown(() {
+      verifyNever(mockFrontendServer.exitCode);
     });
 
     testUsingContext('single dart compile', () async {
@@ -121,6 +146,21 @@ void main() {
       verifyNoMoreInteractions(mockFrontendServerStdIn);
       expect(logger.errorText, equals('compiler message: line1\ncompiler message: line2\n'));
       expect(output, equals('/path/to/main.dart.dill'));
+    }, overrides: <Type, Generator>{
+      ProcessManager: () => mockProcessManager,
+    });
+
+    testUsingContext('single dart compile abnormally terminates', () async {
+      final BufferLogger logger = context[Logger];
+
+      when(mockFrontendServer.stdout)
+          .thenAnswer((Invocation invocation) => new Stream<List<int>>.empty()
+      );
+
+      final String output = await generator.recompile(
+          '/path/to/main.dart', null /* invalidatedFiles */
+      );
+      expect(output, equals(null));
     }, overrides: <Type, Generator>{
       ProcessManager: () => mockProcessManager,
     });

--- a/packages/flutter_tools/test/compile_test.dart
+++ b/packages/flutter_tools/test/compile_test.dart
@@ -151,10 +151,8 @@ void main() {
     });
 
     testUsingContext('single dart compile abnormally terminates', () async {
-      final BufferLogger logger = context[Logger];
-
       when(mockFrontendServer.stdout)
-          .thenAnswer((Invocation invocation) => new Stream<List<int>>.empty()
+          .thenAnswer((Invocation invocation) => const Stream<List<int>>.empty()
       );
 
       final String output = await generator.recompile(


### PR DESCRIPTION
…tal compilation.

This relands https://github.com/flutter/flutter/pull/13982 with fix for incremental mode compilation.

When in incremental mode, awaiting exitCode won't work because compiler is not expected to exit after compilation.
Instead listen for stdout stream closing and report error if outputFilename has not been received.