### PR TITLE
When targeting iOS sim in preview-dart-2, always compile.

### DIFF
--- a/packages/flutter_tools/lib/src/flx.dart
+++ b/packages/flutter_tools/lib/src/flx.dart
@@ -69,7 +69,7 @@ Future<Null> build({
   }
 
   DevFSContent kernelContent;
-  if (previewDart2) {
+  if (!precompiledSnapshot && previewDart2) {
     final String kernelBinaryFilename = await compile(
       sdkRoot: artifacts.getArtifactPath(Artifact.flutterPatchedSdkPath),
       incrementalCompilerByteStorePath: fs.path.absolute(getIncrementalCompilerByteStoreDirectory()),

--- a/packages/flutter_tools/lib/src/ios/simulators.dart
+++ b/packages/flutter_tools/lib/src/ios/simulators.dart
@@ -413,7 +413,11 @@ class IOSSimulator extends Device {
   }
 
   Future<Null> _sideloadUpdatedAssetsForInstalledApplicationBundle(ApplicationPackage app, BuildInfo buildInfo) =>
-      flx.build(precompiledSnapshot: true, previewDart2: buildInfo.previewDart2, strongMode: buildInfo.strongMode);
+      // When running in previewDart2 mode, we still need to run compiler to
+      // produce kernel file for the application.
+      flx.build(precompiledSnapshot: !buildInfo.previewDart2,
+          previewDart2: buildInfo.previewDart2,
+          strongMode: buildInfo.strongMode);
 
   @override
   Future<bool> stopApp(ApplicationPackage app) async {


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/14058, which erroneously ignored `precompiledSnapshot` flag completely, when it has to be ignored only when targeting iOS simulator. Before `--preview-dart-2` iOS simulator runs without snapshot, directly from the sources. This changes in `--preview-dart-2`, where we still have to run compiler even when targeting iOS simulator.