### PR TITLE
Adds the semantic node traversal order API.

### DIFF
--- a/examples/stocks/lib/stock_home.dart
+++ b/examples/stocks/lib/stock_home.dart
@@ -130,7 +130,7 @@ class StockHomeState extends State<StockHome> {
                 debugDumpApp();
                 debugDumpRenderTree();
                 debugDumpLayerTree();
-                debugDumpSemanticsTree(DebugSemanticsDumpOrder.traversal);
+                debugDumpSemanticsTree(DebugSemanticsDumpOrder.geometricOrder);
               } catch (e, stack) {
                 debugPrint('Exception while dumping app:\n$e\n$stack');
               }

--- a/packages/flutter/lib/src/rendering/binding.dart
+++ b/packages/flutter/lib/src/rendering/binding.dart
@@ -101,8 +101,8 @@ abstract class RendererBinding extends BindingBase with ServicesBinding, Schedul
     );
 
     registerSignalServiceExtension(
-      name: 'debugDumpSemanticsTreeInTraversalOrder',
-      callback: () { debugDumpSemanticsTree(DebugSemanticsDumpOrder.traversal); return debugPrintDone; }
+      name: 'debugDumpSemanticsTreeInGeometricOrder',
+      callback: () { debugDumpSemanticsTree(DebugSemanticsDumpOrder.geometricOrder); return debugPrintDone; }
     );
 
     registerSignalServiceExtension(

--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -2228,7 +2228,7 @@ abstract class RenderObject extends AbstractNode with DiagnosticableTreeMixin im
     // Dirty the semantics tree starting at `this` until we have reached a
     // RenderObject that is a semantics boundary. All semantics past this
     // RenderObject are still up-to date. Therefore, we will later only rebuild
-    // the semantics subtree starting at th identified semantics boundary.
+    // the semantics subtree starting at the identified semantics boundary.
 
     final bool wasSemanticsBoundary = _semantics != null && _cachedSemanticsConfiguration?.isSemanticBoundary == true;
     _cachedSemanticsConfiguration = null;
@@ -2254,7 +2254,7 @@ abstract class RenderObject extends AbstractNode with DiagnosticableTreeMixin im
       // remove it as it is no longer guaranteed that its semantics
       // node will continue to be in the tree. If it still is in the tree, the
       // ancestor `node` added to [owner._nodesNeedingSemantics] at the end of
-      // this block will ensure that the semantics of `this` node actually get
+      // this block will ensure that the semantics of `this` node actually gets
       // updated.
       // (See semantics_10_test.dart for an example why this is required).
       owner._nodesNeedingSemantics.remove(this);
@@ -3005,8 +3005,8 @@ class _ContainerSemanticsFragment extends _SemanticsFragment {
 /// A [_SemanticsFragment] that describes which concrete semantic information
 /// a [RenderObject] wants to add to the [SemanticsNode] of its parent.
 ///
-/// Specifically, it describes what children (as returned by [compileChildren])
-/// should be added to the parent's [SemanticsNode] and what [config] should be
+/// Specifically, it describes which children (as returned by [compileChildren])
+/// should be added to the parent's [SemanticsNode] and which [config] should be
 /// merged into the parent's [SemanticsNode].
 abstract class _InterestingSemanticsFragment extends _SemanticsFragment {
   _InterestingSemanticsFragment({
@@ -3082,7 +3082,7 @@ abstract class _InterestingSemanticsFragment extends _SemanticsFragment {
 /// An [_InterestingSemanticsFragment] that produces the root [SemanticsNode] of
 /// the semantics tree.
 ///
-/// The root node is available as only element in the Iterable returned by
+/// The root node is available as the only element in the Iterable returned by
 /// [children].
 class _RootSemanticsFragment extends _InterestingSemanticsFragment {
   _RootSemanticsFragment({
@@ -3144,7 +3144,7 @@ class _RootSemanticsFragment extends _InterestingSemanticsFragment {
 /// fragment it will create a new [SemanticsNode]. The newly created node will
 /// be annotated with the [SemanticsConfiguration] that - without the call to
 /// [markAsExplicit] - would have been merged into the parent's [SemanticsNode].
-/// Similarity, the new node will also take over the children that otherwise
+/// Similarly, the new node will also take over the children that otherwise
 /// would have been added to the parent's [SemanticsNode].
 ///
 /// After a call to [markAsExplicit] the only element returned by [children]

--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -3008,6 +3008,7 @@ class RenderSemanticsAnnotations extends RenderProxyBox {
     String decreasedValue,
     String hint,
     TextDirection textDirection,
+    SemanticsSortOrder sortOrder,
     VoidCallback onTap,
     VoidCallback onLongPress,
     VoidCallback onScrollLeft,
@@ -3035,6 +3036,7 @@ class RenderSemanticsAnnotations extends RenderProxyBox {
        _decreasedValue = decreasedValue,
        _hint = hint,
        _textDirection = textDirection,
+       _sortOrder = sortOrder,
        _onTap = onTap,
        _onLongPress = onLongPress,
        _onScrollLeft = onScrollLeft,
@@ -3205,6 +3207,20 @@ class RenderSemanticsAnnotations extends RenderProxyBox {
     if (textDirection == value)
       return;
     _textDirection = value;
+    markNeedsSemanticsUpdate();
+  }
+
+  /// Sets the [SemanticsNode.sortOrder] to the given value.
+  ///
+  /// This defines how this node will be sorted with the other semantics nodes
+  /// to determine the order in which they are traversed by the accessibility
+  /// services on the platform (e.g. VoiceOver on iOS and TalkBack on Android).
+  SemanticsSortOrder get sortOrder => _sortOrder;
+  SemanticsSortOrder _sortOrder;
+  set sortOrder(SemanticsSortOrder value) {
+    if (sortOrder == value)
+      return;
+    _sortOrder = value;
     markNeedsSemanticsUpdate();
   }
 
@@ -3504,6 +3520,8 @@ class RenderSemanticsAnnotations extends RenderProxyBox {
       config.hint = hint;
     if (textDirection != null)
       config.textDirection = textDirection;
+    if (sortOrder != null)
+      config.sortOrder = sortOrder;
     // Registering _perform* as action handlers instead of the user provided
     // ones to ensure that changing a user provided handler from a non-null to
     // another non-null value doesn't require a semantics update.

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -4828,7 +4828,16 @@ class Semantics extends SingleChildRenderObjectWidget {
   /// Creates a semantic annotation.
   ///
   /// The [container] argument must not be null. To create a `const` instance
-  /// of [Semantics], use the [new Semantics.fromProperties] constructor.
+  /// of [Semantics], use the [Semantics.fromProperties] constructor.
+  ///
+  /// Only one of [sortKey] or [sortOrder] may be specified. Specifying [sortKey]
+  /// is just a shorthand for specifying `new SemanticsSortOrder(key: sortKey)`
+  /// for the [sortOrder].
+  ///
+  /// See also:
+  ///
+  ///  * [SemanticsSortOrder] for a class that determines accessibility traversal
+  ///    order.
   Semantics({
     Key key,
     Widget child,
@@ -4844,6 +4853,8 @@ class Semantics extends SingleChildRenderObjectWidget {
     String decreasedValue,
     String hint,
     TextDirection textDirection,
+    SemanticsSortOrder sortOrder,
+    SemanticsSortKey sortKey,
     VoidCallback onTap,
     VoidCallback onLongPress,
     VoidCallback onScrollLeft,
@@ -4874,6 +4885,7 @@ class Semantics extends SingleChildRenderObjectWidget {
       decreasedValue: decreasedValue,
       hint: hint,
       textDirection: textDirection,
+      sortOrder: _effectiveSortOrder(sortKey, sortOrder),
       onTap: onTap,
       onLongPress: onLongPress,
       onScrollLeft: onScrollLeft,
@@ -4887,8 +4899,7 @@ class Semantics extends SingleChildRenderObjectWidget {
       onPaste: onPaste,
       onMoveCursorForwardByCharacter: onMoveCursorForwardByCharacter,
       onMoveCursorBackwardByCharacter: onMoveCursorBackwardByCharacter,
-      onSetSelection: onSetSelection,
-    ),
+    onSetSelection: onSetSelection,),
   );
 
   /// Creates a semantic annotation using [SemanticsProperties].
@@ -4903,6 +4914,11 @@ class Semantics extends SingleChildRenderObjectWidget {
   }) : assert(container != null),
        assert(properties != null),
        super(key: key, child: child);
+
+  static SemanticsSortOrder _effectiveSortOrder(SemanticsSortKey sortKey, SemanticsSortOrder sortOrder) {
+    assert(sortOrder == null || sortKey == null, 'Only one of sortOrder or sortKey may be specified.');
+    return sortOrder ?? (sortKey != null ? new SemanticsSortOrder(key: sortKey) : null);
+  }
 
   /// Contains properties used by assistive technologies to make the application
   /// more accessible.
@@ -4927,8 +4943,8 @@ class Semantics extends SingleChildRenderObjectWidget {
   /// information to the semantic tree is to introduce new explicit
   /// [SemanticNode]s to the tree.
   ///
-  /// This setting is often used in combination with [isSemanticBoundary] to
-  /// create semantic boundaries that are either writable or not for children.
+  /// This setting is often used in combination with [SemanticsConfiguration.isSemanticBoundary]
+  /// to create semantic boundaries that are either writable or not for children.
   final bool explicitChildNodes;
 
   @override
@@ -4946,6 +4962,7 @@ class Semantics extends SingleChildRenderObjectWidget {
       decreasedValue: properties.decreasedValue,
       hint: properties.hint,
       textDirection: _getTextDirection(context),
+      sortOrder: properties.sortOrder,
       onTap: properties.onTap,
       onLongPress: properties.onLongPress,
       onScrollLeft: properties.onScrollLeft,
@@ -4989,6 +5006,7 @@ class Semantics extends SingleChildRenderObjectWidget {
       ..decreasedValue = properties.decreasedValue
       ..hint = properties.hint
       ..textDirection = _getTextDirection(context)
+      ..sortOrder = properties.sortOrder
       ..onTap = properties.onTap
       ..onLongPress = properties.onLongPress
       ..onScrollLeft = properties.onScrollLeft

--- a/packages/flutter/test/foundation/service_extensions_test.dart
+++ b/packages/flutter/test/foundation/service_extensions_test.dart
@@ -193,11 +193,11 @@ void main() {
     console.clear();
   });
 
-  test('Service extensions - debugDumpSemanticsTreeInTraversalOrder', () async {
+  test('Service extensions - debugDumpSemanticsTreeInGeometricOrder', () async {
     Map<String, String> result;
 
     await binding.doFrame();
-    result = await binding.testExtension('debugDumpSemanticsTreeInTraversalOrder', <String, String>{});
+    result = await binding.testExtension('debugDumpSemanticsTreeInGeometricOrder', <String, String>{});
     expect(result, <String, String>{});
     expect(console, <String>['Semantics not collected.']);
     console.clear();

--- a/packages/flutter/test/semantics/semantics_test.dart
+++ b/packages/flutter/test/semantics/semantics_test.dart
@@ -4,8 +4,8 @@
 
 import 'package:flutter/rendering.dart';
 import 'package:flutter/semantics.dart';
-import 'package:test/test.dart';
 import 'package:vector_math/vector_math_64.dart';
+import 'package:flutter_test/flutter_test.dart';
 
 import '../rendering/rendering_tester.dart';
 
@@ -125,11 +125,153 @@ void main() {
     expect(child2.transform, isNull);
 
     expect(
-      root.toStringDeep(childOrder: DebugSemanticsDumpOrder.traversal),
+      root.toStringDeep(childOrder: DebugSemanticsDumpOrder.geometricOrder),
       'SemanticsNode#3(STALE, owner: null, Rect.fromLTRB(0.0, 0.0, 10.0, 5.0))\n'
       '├SemanticsNode#1(STALE, owner: null, Rect.fromLTRB(0.0, 0.0, 5.0, 5.0))\n'
       '└SemanticsNode#2(STALE, owner: null, Rect.fromLTRB(5.0, 0.0, 10.0, 5.0))\n',
     );
+  });
+
+  test('OrdinalSortKey compares correctly', () {
+    final List<List<SemanticsSortKey>> tests = <List<SemanticsSortKey>>[
+      <SemanticsSortKey>[const OrdinalSortKey(0.0), const OrdinalSortKey(0.0)],
+      <SemanticsSortKey>[const OrdinalSortKey(0.0), const OrdinalSortKey(1.0)],
+      <SemanticsSortKey>[const OrdinalSortKey(1.0), const OrdinalSortKey(0.0)],
+      <SemanticsSortKey>[const OrdinalSortKey(1.0), const OrdinalSortKey(1.0)],
+      <SemanticsSortKey>[const OrdinalSortKey(0.0), const CustomSortKey(1.0)],
+      <SemanticsSortKey>[const OrdinalSortKey(0.0), const CustomSortKey(0.0)],
+      <SemanticsSortKey>[const CustomSortKey(0.0), const OrdinalSortKey(0.0)],
+      <SemanticsSortKey>[const CustomSortKey(1.0), const OrdinalSortKey(0.0)],
+    ];
+    final List<int> expectedResults = <int>[0, -1, 1, 0, 0, 0, 0, 0];
+    assert(tests.length == expectedResults.length);
+    final List<int> results = <int>[];
+    for (List<SemanticsSortKey> tuple in tests) {
+      results.add(tuple[0].compareTo(tuple[1]));
+    }
+    expect(results, orderedEquals(expectedResults));
+  });
+
+  test('SemanticsSortOrder sorts correctly', () {
+    final SemanticsSortOrder order1 = new SemanticsSortOrder(key: const CustomSortKey(0.0));
+    final SemanticsSortOrder order2 = new SemanticsSortOrder(key: const CustomSortKey(0.0));
+    // Equal single keys compare equal.
+    expect(order1.compareTo(order2), equals(0));
+    // Key lists that are longer compare as after the shorter ones.
+    order1.keys.add(const OrdinalSortKey(1.0));
+    expect(order1.compareTo(order2), equals(1));
+    // Equal multiple key lists compare equal.
+    order2.keys.add(const OrdinalSortKey(1.0));
+    expect(order1.compareTo(order2), equals(0));
+    // Different types compare equal.
+    order1.keys.add(const OrdinalSortKey(1.0));
+    order2.keys.add(const CustomSortKey(1.0));
+    expect(order1.compareTo(order2), equals(0));
+    // Unequal multiple-key lists sort the shorter list first.
+    order1.keys.add(const CustomSortKey(2.0));
+    expect(order1.compareTo(order2), equals(1));
+  });
+
+  test('SemanticsSortOrder sorts correctly when assigned names', () {
+    final SemanticsSortOrder order1g1 = new SemanticsSortOrder(key: const CustomSortKey(0.0, name: 'group 1'));
+    final SemanticsSortOrder order2g1 = new SemanticsSortOrder(key: const CustomSortKey(1.0, name: 'group 1'));
+    final SemanticsSortOrder order2g2 = new SemanticsSortOrder(key: const CustomSortKey(1.0, name: 'group 2'));
+    final SemanticsSortOrder order3g2 = new SemanticsSortOrder(key: const OrdinalSortKey(1.0, name: 'group 1'));
+    // Keys in the same group compare.
+    expect(order1g1.compareTo(order2g1), equals(-1));
+    // Keys with different names compare equal.
+    expect(order1g1.compareTo(order2g2), equals(0));
+    // Keys with same names but different types compare equal.
+    expect(order1g1.compareTo(order3g2), equals(0));
+  });
+
+  test('SemanticsSortOrder replaces correctly in merge', () {
+    final SemanticsSortOrder order1 = new SemanticsSortOrder(keys: <SemanticsSortKey>[const CustomSortKey(0.0), const OrdinalSortKey(0.0)]);
+    final SemanticsSortOrder order2 = new SemanticsSortOrder(keys: <SemanticsSortKey>[const CustomSortKey(0.0), const OrdinalSortKey(0.0)]);
+    final SemanticsSortOrder order3 = new SemanticsSortOrder(keys: <SemanticsSortKey>[const CustomSortKey(1.0), const OrdinalSortKey(1.0)], discardParentOrder: true);
+    // Equal single keys compare equal.
+    expect(order1.compareTo(order2), equals(0));
+    // Merged orders with one that replaces merge correctly.
+    final SemanticsSortOrder merged = order1.merge(order3);
+    expect(merged.keys.length, 2);
+    expect(merged.keys, orderedEquals(order3.keys));
+    expect(merged.compareTo(order2), 1);
+    // Merged orders with one that doesn't replace merge correctly.
+    final SemanticsSortOrder merged2 = order1.merge(order2);
+    expect(merged2.keys.length, 4);
+    expect(merged2.keys, orderedEquals(<SemanticsSortKey>[]..addAll(order1.keys)..addAll(order2.keys)));
+    expect(merged2.compareTo(order2), 1); // (merged2 is longer, so greater than).
+  });
+
+  test('OrdinalSortKey compares correctly', () {
+    final List<List<SemanticsSortKey>> tests = <List<SemanticsSortKey>>[
+      <SemanticsSortKey>[const OrdinalSortKey(0.0), const OrdinalSortKey(0.0)],
+      <SemanticsSortKey>[const OrdinalSortKey(0.0), const OrdinalSortKey(1.0)],
+      <SemanticsSortKey>[const OrdinalSortKey(1.0), const OrdinalSortKey(0.0)],
+      <SemanticsSortKey>[const OrdinalSortKey(1.0), const OrdinalSortKey(1.0)],
+      <SemanticsSortKey>[const OrdinalSortKey(0.0), const CustomSortKey(1.0)],
+      <SemanticsSortKey>[const OrdinalSortKey(0.0), const CustomSortKey(0.0)],
+      <SemanticsSortKey>[const CustomSortKey(0.0), const OrdinalSortKey(0.0)],
+      <SemanticsSortKey>[const CustomSortKey(1.0), const OrdinalSortKey(0.0)],
+    ];
+    final List<int> expectedResults = <int>[0, -1, 1, 0, 0, 0, 0, 0];
+    assert(tests.length == expectedResults.length);
+    final List<int> results = <int>[];
+    for (List<SemanticsSortKey> tuple in tests) {
+      results.add(tuple[0].compareTo(tuple[1]));
+    }
+    expect(results, orderedEquals(expectedResults));
+  });
+
+  test('SemanticsSortOrder sorts correctly', () {
+    final SemanticsSortOrder order1 = new SemanticsSortOrder(key: const CustomSortKey(0.0));
+    final SemanticsSortOrder order2 = new SemanticsSortOrder(key: const CustomSortKey(0.0));
+    // Equal single keys compare equal.
+    expect(order1.compareTo(order2), equals(0));
+    // Key lists that are longer compare as after the shorter ones.
+    order1.keys.add(const OrdinalSortKey(1.0));
+    expect(order1.compareTo(order2), equals(1));
+    // Equal multiple key lists compare equal.
+    order2.keys.add(const OrdinalSortKey(1.0));
+    expect(order1.compareTo(order2), equals(0));
+    // Different types compare equal.
+    order1.keys.add(const OrdinalSortKey(1.0));
+    order2.keys.add(const CustomSortKey(1.0));
+    expect(order1.compareTo(order2), equals(0));
+    // Unequal multiple-key lists sort the shorter list first.
+    order1.keys.add(const CustomSortKey(2.0));
+    expect(order1.compareTo(order2), equals(1));
+  });
+
+  test('SemanticsSortOrder sorts correctly when assigned names', () {
+    final SemanticsSortOrder order1g1 = new SemanticsSortOrder(key: const CustomSortKey(0.0, name: 'group 1'));
+    final SemanticsSortOrder order2g1 = new SemanticsSortOrder(key: const CustomSortKey(1.0, name: 'group 1'));
+    final SemanticsSortOrder order2g2 = new SemanticsSortOrder(key: const CustomSortKey(1.0, name: 'group 2'));
+    final SemanticsSortOrder order3g2 = new SemanticsSortOrder(key: const OrdinalSortKey(1.0, name: 'group 1'));
+    // Keys in the same group compare.
+    expect(order1g1.compareTo(order2g1), equals(-1));
+    // Keys with different names compare equal.
+    expect(order1g1.compareTo(order2g2), equals(0));
+    // Keys with same names but different types compare equal.
+    expect(order1g1.compareTo(order3g2), equals(0));
+  });
+
+  test('SemanticsSortOrder replaces correctly in merge', () {
+    final SemanticsSortOrder order1 = new SemanticsSortOrder(keys: <SemanticsSortKey>[const CustomSortKey(0.0), const OrdinalSortKey(0.0)]);
+    final SemanticsSortOrder order2 = new SemanticsSortOrder(keys: <SemanticsSortKey>[const CustomSortKey(0.0), const OrdinalSortKey(0.0)]);
+    final SemanticsSortOrder order3 = new SemanticsSortOrder(keys: <SemanticsSortKey>[const CustomSortKey(1.0), const OrdinalSortKey(1.0)], discardParentOrder: true);
+    // Equal single keys compare equal.
+    expect(order1.compareTo(order2), equals(0));
+    // Merged orders with one that replaces merge correctly.
+    final SemanticsSortOrder merged = order1.merge(order3);
+    expect(merged.keys.length, 2);
+    expect(merged.keys, orderedEquals(order3.keys));
+    expect(merged.compareTo(order2), 1);
+    // Merged orders with one that doesn't replace merge correctly.
+    final SemanticsSortOrder merged2 = order1.merge(order2);
+    expect(merged2.keys.length, 4);
+    expect(merged2.keys, orderedEquals(<SemanticsSortKey>[]..addAll(order1.keys)..addAll(order2.keys)));
+    expect(merged2.compareTo(order2), 1); // (merged2 is longer, so greater than).
   });
 
   test('toStringDeep respects childOrder parameter', () {
@@ -144,7 +286,7 @@ void main() {
       childrenInInversePaintOrder: <SemanticsNode>[child1, child2],
     );
     expect(
-      root.toStringDeep(childOrder: DebugSemanticsDumpOrder.traversal),
+      root.toStringDeep(childOrder: DebugSemanticsDumpOrder.geometricOrder),
       'SemanticsNode#3(STALE, owner: null, Rect.fromLTRB(0.0, 0.0, 20.0, 5.0))\n'
       '├SemanticsNode#2(STALE, owner: null, Rect.fromLTRB(10.0, 0.0, 15.0, 5.0))\n'
       '└SemanticsNode#1(STALE, owner: null, Rect.fromLTRB(15.0, 0.0, 20.0, 5.0))\n',
@@ -177,7 +319,7 @@ void main() {
     );
 
     expect(
-      rootComplex.toStringDeep(childOrder: DebugSemanticsDumpOrder.traversal),
+      rootComplex.toStringDeep(childOrder: DebugSemanticsDumpOrder.geometricOrder),
       'SemanticsNode#7(STALE, owner: null, Rect.fromLTRB(0.0, 0.0, 25.0, 5.0))\n'
       '├SemanticsNode#4(STALE, owner: null, Rect.fromLTRB(0.0, 0.0, 10.0, 5.0))\n'
       '│├SemanticsNode#6(STALE, owner: null, Rect.fromLTRB(0.0, 0.0, 5.0, 5.0))\n'
@@ -201,12 +343,12 @@ void main() {
     final SemanticsNode minimalProperties = new SemanticsNode();
     expect(
       minimalProperties.toStringDeep(),
-      'SemanticsNode#1(Rect.fromLTRB(0.0, 0.0, 0.0, 0.0))\n',
+      'SemanticsNode#1(Rect.fromLTRB(0.0, 0.0, 0.0, 0.0), invisible)\n',
     );
 
     expect(
       minimalProperties.toStringDeep(minLevel: DiagnosticLevel.hidden),
-      'SemanticsNode#1(owner: null, isMergedIntoParent: false, mergeAllDescendantsIntoThisNode: false, Rect.fromLTRB(0.0, 0.0, 0.0, 0.0), actions: [], isInMutuallyExcusiveGroup: false, isSelected: false, isFocused: false, isButton: false, isTextField: false, label: "", value: "", increasedValue: "", decreasedValue: "", hint: "", textDirection: null)\n'
+      'SemanticsNode#1(owner: null, isMergedIntoParent: false, mergeAllDescendantsIntoThisNode: false, Rect.fromLTRB(0.0, 0.0, 0.0, 0.0), actions: [], isInMutuallyExcusiveGroup: false, isSelected: false, isFocused: false, isButton: false, isTextField: false, invisible, label: "", value: "", increasedValue: "", decreasedValue: "", hint: "", textDirection: null, nextNodeId: null, sortOrder: null)\n'
     );
 
     final SemanticsConfiguration config = new SemanticsConfiguration()
@@ -219,14 +361,15 @@ void main() {
       ..isSelected = true
       ..isButton = true
       ..label = 'Use all the properties'
-      ..textDirection = TextDirection.rtl;
+      ..textDirection = TextDirection.rtl
+      ..sortOrder = new SemanticsSortOrder(keys: <SemanticsSortKey>[const OrdinalSortKey(1.0)]);
     final SemanticsNode allProperties = new SemanticsNode()
       ..rect = new Rect.fromLTWH(50.0, 10.0, 20.0, 30.0)
       ..transform = new Matrix4.translation(new Vector3(10.0, 10.0, 0.0))
       ..updateWith(config: config, childrenInInversePaintOrder: null);
     expect(
       allProperties.toStringDeep(),
-      'SemanticsNode#2(STALE, owner: null, merge boundary ⛔️, Rect.fromLTRB(60.0, 20.0, 80.0, 50.0), actions: [longPress, scrollUp, showOnScreen], unchecked, selected, button, label: "Use all the properties", textDirection: rtl)\n',
+      equalsIgnoringHashCodes('SemanticsNode#2(STALE, owner: null, merge boundary ⛔️, Rect.fromLTRB(60.0, 20.0, 80.0, 50.0), actions: [longPress, scrollUp, showOnScreen], unchecked, selected, button, label: "Use all the properties", textDirection: rtl, sortOrder: SemanticsSortOrder#8e690(keys: [OrdinalSortKey#ca2b8(order: 1.0)]))\n'),
     );
     expect(
       allProperties.getSemanticsData().toString(),
@@ -369,4 +512,8 @@ class TestRender extends RenderProxyBox {
     if (hasScrollDownAction)
       config.onScrollDown = () { };
   }
+}
+
+class CustomSortKey extends OrdinalSortKey {
+  const CustomSortKey(double order, {String name}) : super(order, name: name);
 }

--- a/packages/flutter/test/widgets/semantics_tester.dart
+++ b/packages/flutter/test/widgets/semantics_tester.dart
@@ -42,6 +42,7 @@ class TestSemantics {
     this.decreasedValue: '',
     this.hint: '',
     this.textDirection,
+    this.nextNodeId,
     this.rect,
     this.transform,
     this.textSelection,
@@ -68,6 +69,7 @@ class TestSemantics {
     this.decreasedValue: '',
     this.hint: '',
     this.textDirection,
+    this.nextNodeId,
     this.transform,
     this.textSelection,
     this.children: const <TestSemantics>[],
@@ -103,6 +105,7 @@ class TestSemantics {
     this.increasedValue: '',
     this.decreasedValue: '',
     this.textDirection,
+    this.nextNodeId,
     this.rect,
     Matrix4 transform,
     this.textSelection,
@@ -168,6 +171,10 @@ class TestSemantics {
   /// label is present on the [SemanticsNode], a [SemanticsNode.textDirection]
   /// is also set.
   final TextDirection textDirection;
+
+  /// The ID of the node that is next in the semantics traversal order after
+  /// this node.
+  final int nextNodeId;
 
   /// The bounding box for this node in its coordinate system.
   ///
@@ -250,6 +257,8 @@ class TestSemantics {
       return fail('expected node id $id to have hint "$hint" but found hint "${nodeData.hint}".');
     if (textDirection != null && textDirection != nodeData.textDirection)
       return fail('expected node id $id to have textDirection "$textDirection" but found "${nodeData.textDirection}".');
+    if (nextNodeId != null && nextNodeId != nodeData.nextNodeId)
+      return fail('expected node id $id to have nextNodeId "$nextNodeId" but found "${nodeData.nextNodeId}".');
     if ((nodeData.label != '' || nodeData.value != '' || nodeData.hint != '' || node.increasedValue != '' || node.decreasedValue != '') && nodeData.textDirection == null)
       return fail('expected node id $id, which has a label, value, or hint, to have a textDirection, but it did not.');
     if (!ignoreRect && rect != nodeData.rect)
@@ -301,6 +310,8 @@ class TestSemantics {
       buf.writeln('$indent  hint: \'$hint\',');
     if (textDirection != null)
       buf.writeln('$indent  textDirection: $textDirection,');
+    if (nextNodeId != null)
+      buf.writeln('$indent  nextNodeId: $nextNodeId,');
     if (textSelection?.isValid == true)
       buf.writeln('$indent  textSelection:\n[${textSelection.start}, ${textSelection.end}],');
     if (rect != null)
@@ -483,8 +494,14 @@ class SemanticsTester {
       buf.writeln('  flags: ${_flagsToSemanticsFlagExpression(nodeData.flags)},');
     if (nodeData.actions != 0)
       buf.writeln('  actions: ${_actionsToSemanticsActionExpression(nodeData.actions)},');
-    if (node.label != null && node.label.isNotEmpty)
-      buf.writeln('  label: r\'${node.label}\',');
+    if (node.label != null && node.label.isNotEmpty) {
+      final String escapedLabel = node.label.replaceAll('\n', r'\n');
+      if (escapedLabel == node.label) {
+        buf.writeln('  label: r\'$escapedLabel\',');
+      } else {
+        buf.writeln('  label: \'$escapedLabel\',');
+      }
+    }
     if (node.value != null && node.value.isNotEmpty)
       buf.writeln('  value: r\'${node.value}\',');
     if (node.increasedValue != null && node.increasedValue.isNotEmpty)
@@ -495,6 +512,8 @@ class SemanticsTester {
       buf.writeln('  hint: r\'${node.hint}\',');
     if (node.textDirection != null)
       buf.writeln('  textDirection: ${node.textDirection},');
+    if (node.nextNodeId != null)
+      buf.writeln('  nextNodeId: ${node.nextNodeId},');
 
     if (node.hasChildren) {
       buf.writeln('  children: <TestSemantics>[');

--- a/packages/flutter/test/widgets/semantics_tester_generateTestSemanticsExpressionForCurrentSemanticsTree_test.dart
+++ b/packages/flutter/test/widgets/semantics_tester_generateTestSemanticsExpressionForCurrentSemanticsTree_test.dart
@@ -105,12 +105,15 @@ void _tests() {
         new TestSemantics(
           children: <TestSemantics>[
             new TestSemantics(
+              nextNodeId: 4,
               children: <TestSemantics>[
                 new TestSemantics(
+                  nextNodeId: 2,
                   children: <TestSemantics>[
                     new TestSemantics(
                       label: r'Plain text',
                       textDirection: TextDirection.ltr,
+                      nextNodeId: 3,
                     ),
                     new TestSemantics(
                       flags: <SemanticsFlag>[SemanticsFlag.hasCheckedState, SemanticsFlag.isChecked, SemanticsFlag.isSelected],
@@ -121,6 +124,7 @@ void _tests() {
                       decreasedValue: r'test-decreasedValue',
                       hint: r'test-hint',
                       textDirection: TextDirection.rtl,
+                      nextNodeId: -1,
                     ),
                   ],
                 ),

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -184,9 +184,9 @@ class FlutterDevice {
       await view.uiIsolate.flutterDebugDumpLayerTree();
   }
 
-  Future<Null> debugDumpSemanticsTreeInTraversalOrder() async {
+  Future<Null> debugDumpSemanticsTreeInGeometricOrder() async {
     for (FlutterView view in views)
-      await view.uiIsolate.flutterDebugDumpSemanticsTreeInTraversalOrder();
+      await view.uiIsolate.flutterDebugDumpSemanticsTreeInGeometricOrder();
   }
 
   Future<Null> debugDumpSemanticsTreeInInverseHitTestOrder() async {
@@ -499,10 +499,10 @@ abstract class ResidentRunner {
       await device.debugDumpLayerTree();
   }
 
-  Future<Null> _debugDumpSemanticsTreeInTraversalOrder() async {
+  Future<Null> _debugDumpSemanticsTreeInGeometricOrder() async {
     await refreshViews();
     for (FlutterDevice device in flutterDevices)
-      await device.debugDumpSemanticsTreeInTraversalOrder();
+      await device.debugDumpSemanticsTreeInGeometricOrder();
   }
 
   Future<Null> _debugDumpSemanticsTreeInInverseHitTestOrder() async {
@@ -685,7 +685,7 @@ abstract class ResidentRunner {
       }
     } else if (character == 'S') {
       if (supportsServiceProtocol) {
-        await _debugDumpSemanticsTreeInTraversalOrder();
+        await _debugDumpSemanticsTreeInGeometricOrder();
         return true;
       }
     } else if (character == 'U') {
@@ -826,12 +826,12 @@ abstract class ResidentRunner {
       printStatus('You can dump the widget hierarchy of the app (debugDumpApp) by pressing "w".');
       printStatus('To dump the rendering tree of the app (debugDumpRenderTree), press "t".');
       if (isRunningDebug) {
-        printStatus('For layers (debugDumpLayerTree), use "L"; accessibility (debugDumpSemantics), "S" (traversal order) or "U" (inverse hit test order).');
+        printStatus('For layers (debugDumpLayerTree), use "L"; for accessibility (debugDumpSemantics), use "S" (for geometric order) or "U" (for inverse hit test order).');
         printStatus('To toggle the widget inspector (WidgetsApp.showWidgetInspectorOverride), press "i".');
         printStatus('To toggle the display of construction lines (debugPaintSizeEnabled), press "p".');
         printStatus('To simulate different operating systems, (defaultTargetPlatform), press "o".');
       } else {
-        printStatus('To dump the accessibility tree (debugDumpSemantics), press "S" (for traversal order) or "U" (for inverse hit test order).');
+        printStatus('To dump the accessibility tree (debugDumpSemantics), press "S" (for geometric order) or "U" (for inverse hit test order).');
       }
       printStatus('To display the performance overlay (WidgetsApp.showPerformanceOverlay), press "P".');
     }

--- a/packages/flutter_tools/lib/src/vmservice.dart
+++ b/packages/flutter_tools/lib/src/vmservice.dart
@@ -1146,8 +1146,8 @@ class Isolate extends ServiceObjectOwner {
     return invokeFlutterExtensionRpcRaw('ext.flutter.debugDumpLayerTree', timeout: kLongRequestTimeout);
   }
 
-  Future<Map<String, dynamic>> flutterDebugDumpSemanticsTreeInTraversalOrder() {
-    return invokeFlutterExtensionRpcRaw('ext.flutter.debugDumpSemanticsTreeInTraversalOrder', timeout: kLongRequestTimeout);
+  Future<Map<String, dynamic>> flutterDebugDumpSemanticsTreeInGeometricOrder() {
+    return invokeFlutterExtensionRpcRaw('ext.flutter.debugDumpSemanticsTreeInGeometricOrder', timeout: kLongRequestTimeout);
   }
 
   Future<Map<String, dynamic>> flutterDebugDumpSemanticsTreeInInverseHitTestOrder() {


### PR DESCRIPTION
This adds an API for defining the semantic node traversal order.

It adds a `sortOrder` argument to the `Semantics` widget, which is a class that can define a list of sort keys to sort on.  The keys are sorted globally so that an order that doesn't have to do with the current widget hierarchy may be defined.

It also adds a shortcut `sortKey` argument to the `Semantics` widget that simply sets the `sortOrder` to just contain that key.

The platform side ([flutter/engine#4540](https://github.com/flutter/engine/pull/4540)) gets an additional member in the `SemanticsData` object that is an integer describing where in the overall order each semantics node belongs.  There is an associated engine-side change that takes this integer and uses it to order widgets for the platform's accessibility services.