### PR TITLE
Fix a couple of strong mode issues.

### DIFF
--- a/packages/flutter/lib/src/painting/image_resolution.dart
+++ b/packages/flutter/lib/src/painting/image_resolution.dart
@@ -214,7 +214,11 @@ class AssetImage extends AssetBundleImageProvider {
     if (json == null)
       return null;
     // TODO(ianh): JSON decoding really shouldn't be on the main thread.
-    final Map<String, List<String>> parsedManifest = JSON.decode(json);
+    final Map<String, dynamic> parsedJson = JSON.decode(json);
+    final Iterable<String> keys = parsedJson.keys;
+    final Map<String, List<String>> parsedManifest =
+        new Map<String, List<String>>.fromIterables(keys,
+          keys.map((String key) => new List<String>.from(parsedJson[key])));
     // TODO(ianh): convert that data structure to the right types.
     return new SynchronousFuture<Map<String, List<String>>>(parsedManifest);
   }

--- a/packages/flutter/lib/src/services/asset_bundle.dart
+++ b/packages/flutter/lib/src/services/asset_bundle.dart
@@ -179,10 +179,10 @@ abstract class CachingAssetBundle extends AssetBundle {
     assert(parser != null);
     if (_structuredDataCache.containsKey(key))
       return _structuredDataCache[key];
-    Completer<dynamic> completer;
-    Future<dynamic> result;
+    Completer<T> completer;
+    Future<T> result;
     loadString(key, cache: false).then<T>(parser).then<Null>((T value) {
-      result = new SynchronousFuture<dynamic>(value);
+      result = new SynchronousFuture<T>(value);
       _structuredDataCache[key] = result;
       if (completer != null) {
         // We already returned from the loadStructuredData function, which means
@@ -198,7 +198,7 @@ abstract class CachingAssetBundle extends AssetBundle {
     }
     // The code above hasn't yet run its "then" handler yet. Let's prepare a
     // completer for it to use when it does run.
-    completer = new Completer<dynamic>();
+    completer = new Completer<T>();
     _structuredDataCache[key] = completer.future;
     return completer.future;
   }


### PR DESCRIPTION
* JSON.decode produces Map<String, dynamic> and List<dynamic>
objects. If a more tight type is required then object needs to
be converted explicitly (see dart-lang/sdk#31876);
* Completer<dynamic> produces Future<dynamic>. In Dart 2 it is
runtime error to assign Future<dynamic> to variable of type Future<T>;