### PR TITLE
Decode syslog-encoded iOS logs

### DIFF
--- a/packages/flutter_tools/test/ios/devices_test.dart
+++ b/packages/flutter_tools/test/ios/devices_test.dart
@@ -74,6 +74,17 @@ f577a7903cc54959be2e34bc4f7f80b7009efcf4
     });
   });
 
+  group('decodeSyslog', () {
+    test('decodes a syslog-encoded line', () {
+      final String decoded = decodeSyslog(r'I \M-b\M^]\M-$\M-o\M-8\M^O syslog \M-B\M-/\134_(\M-c\M^C\M^D)_/\M-B\M-/ \M-l\M^F\240!');
+      expect(decoded, r'I ❤️ syslog ¯\_(ツ)_/¯ 솠!');
+    });
+
+    test('passes through un-decodeable lines as-is', () {
+      final String decoded = decodeSyslog(r'I \M-b\M^O syslog!');
+      expect(decoded, r'I \M-b\M^O syslog!');
+    });
+  });
   group('logging', () {
     MockIMobileDevice mockIMobileDevice;
 


### PR DESCRIPTION
Apple encodes syslog entries using a 7-bit encoding where input UTF-8 bytes
are encoded as follows:
1. 0x00 to 0x19: non-printing range. Some ignored, some encoded as <...>.
2. 0x20 to 0x7f: as-is, with the exception of 0x5c (backslash).
3. 0x5c (backslash): octal representation \134.
4. 0x80 to 0x9f: \M^x (using control-character notation for range 0x00 to 0x40).
5. 0xa0: octal representation \240.
6. 0xa1 to 0xf7: \M-x (where x is the input byte stripped of its high-order bit).
7. 0xf8 to 0xff: unused in 4-byte UTF-8.

As there doesn't appear to be a system tool to decode these strings, we
implement here in Dart. If we're unable to decode a string (e.g.
decoding results in an invalid UTF-8 string), we fall back to emitting
the log line as-is.