### PR TITLE
Clean up output directory before copying over new files

### DIFF
--- a/packages/flutter_tools/gradle/flutter.gradle
+++ b/packages/flutter_tools/gradle/flutter.gradle
@@ -255,7 +255,7 @@ class FlutterPlugin implements Plugin<Project> {
         if (project.hasProperty('preview-dart-2')) {
             previewDart2Value = project.property('preview-dart-2')
         }
-	
+
         Boolean strongModeValue = false
         if (project.hasProperty('strong')) {
             strongModeValue = project.property('strong')
@@ -295,7 +295,7 @@ class FlutterPlugin implements Plugin<Project> {
                 localEngineSrcPath this.localEngineSrcPath
                 targetPath target
                 previewDart2 previewDart2Value
-                strongMode strongModeValue	
+                strongMode strongModeValue
                 preferSharedLibrary preferSharedLibraryValue
                 sourceDir project.file(project.flutter.source)
                 intermediateDir project.file("${project.buildDir}/${AndroidProject.FD_INTERMEDIATES}/flutter/${variant.name}")
@@ -310,7 +310,7 @@ class FlutterPlugin implements Plugin<Project> {
                 localEngineSrcPath this.localEngineSrcPath
                 targetPath target
                 previewDart2 previewDart2Value
-                strongMode strongModeValue	
+                strongMode strongModeValue
                 preferSharedLibrary preferSharedLibraryValue
                 sourceDir project.file(project.flutter.source)
                 intermediateDir project.file("${project.buildDir}/${AndroidProject.FD_INTERMEDIATES}/flutter/${variant.name}")
@@ -318,9 +318,14 @@ class FlutterPlugin implements Plugin<Project> {
                 extraGenSnapshotOptions extraGenSnapshotOptionsValue
             }
 
+            Task deleteOutputDir = project.tasks.create(name: "deleteOutputDirectory${variant.name.capitalize()}", type:Delete) {
+                delete variant.mergeAssets.outputDir
+            }
+
             Task copyFlxTask = project.tasks.create(name: "copyFlutterAssets${variant.name.capitalize()}", type: Copy) {
                 dependsOn flutterTask
                 dependsOn variant.mergeAssets
+                dependsOn deleteOutputDir
                 into variant.mergeAssets.outputDir
                 with flutterTask.assets
             }
@@ -453,18 +458,20 @@ class FlutterTask extends BaseFlutterTask {
     CopySpec getAssets() {
         return project.copySpec {
             from "${intermediateDir}"
+
             include "flutter_assets/**" // the working dir and its files
+
             if (buildMode != 'debug') {
-	       if (preferSharedLibrary) {
-                  include "${intermediateDir}/app.so"
-	       } else {
-                  include "vm_snapshot_data"
-                  include "vm_snapshot_instr"
-                  include "isolate_snapshot_data"
-                  include "isolate_snapshot_instr"
-	       }
+                if (preferSharedLibrary) {
+                    include "${intermediateDir}/app.so"
+                } else {
+                    include "vm_snapshot_data"
+                    include "vm_snapshot_instr"
+                    include "isolate_snapshot_data"
+                    include "isolate_snapshot_instr"
+                }
             }
-      }
+        }
     }
 
     FileCollection readDependencies(File dependenciesFile) {

--- a/packages/flutter_tools/gradle/flutter.gradle
+++ b/packages/flutter_tools/gradle/flutter.gradle
@@ -318,14 +318,10 @@ class FlutterPlugin implements Plugin<Project> {
                 extraGenSnapshotOptions extraGenSnapshotOptionsValue
             }
 
-            Task deleteOutputDir = project.tasks.create(name: "deleteOutputDirectory${variant.name.capitalize()}", type:Delete) {
-                delete variant.mergeAssets.outputDir
-            }
-
             Task copyFlxTask = project.tasks.create(name: "copyFlutterAssets${variant.name.capitalize()}", type: Copy) {
                 dependsOn flutterTask
                 dependsOn variant.mergeAssets
-                dependsOn deleteOutputDir
+                dependsOn "clean${variant.mergeAssets.name.capitalize()}"
                 into variant.mergeAssets.outputDir
                 with flutterTask.assets
             }


### PR DESCRIPTION
Clean up of whitespaces aside, this deletes output directory before copying new build artifacts over.

This complements https://github.com/flutter/flutter/pull/14081 that does the same thing on ios, which is needed to prevent incompatible(`--preview-dart-2` vs non-`preview-dart-2`) build artifacts being included into the built app.

This fixes https://github.com/flutter/flutter/issues/13878.