### PR TITLE
Use a safe codec to read Skia SKP screenshot files when checking for errors

### DIFF
--- a/packages/flutter_tools/lib/src/commands/screenshot.dart
+++ b/packages/flutter_tools/lib/src/commands/screenshot.dart
@@ -89,7 +89,9 @@ class ScreenshotCommand extends FlutterCommand {
     await sink.close();
     await showOutputFileInfo(outputFile);
     if (await outputFile.length() < 1000) {
-      final String content = await outputFile.readAsString();
+      final String content = await outputFile.readAsString(
+        encoding: const AsciiCodec(allowInvalid: true),
+      );
       if (content.startsWith('{"jsonrpc":"2.0", "error"'))
         throwToolExit('\nIt appears the output file contains an error message, not valid skia output.');
     }


### PR DESCRIPTION
If the downloaded file is an actual SKP and not an error report, then the
default UTF-8 codec will fail to decode the SKP content