### PR TITLE
flutter_view_ios__start_up: move all test logic into TaskFunction

### DIFF
--- a/dev/devicelab/bin/tasks/flutter_view_ios__start_up.dart
+++ b/dev/devicelab/bin/tasks/flutter_view_ios__start_up.dart
@@ -12,11 +12,15 @@ import 'package:flutter_devicelab/framework/framework.dart';
 
 Future<Null> main() async {
   deviceOperatingSystem = DeviceOperatingSystem.ios;
-  final Directory iosDirectory = dir(
-    '${flutterDirectory.path}/examples/flutter_view/ios',
-  );
-  await inDirectory(iosDirectory, () async {
-    await exec('pod', <String>['install']);
+  await task(() async {
+    final Directory iosDirectory = dir(
+      '${flutterDirectory.path}/examples/flutter_view/ios',
+    );
+    await inDirectory(iosDirectory, () async {
+      await exec('pod', <String>['install']);
+    });
+
+    final TaskFunction taskFunction = createFlutterViewStartupTest();
+    return await taskFunction();
   });
-  await task(createFlutterViewStartupTest());
 }


### PR DESCRIPTION
This task attempted to run `pod install` outside the test function, causing the task runner to time out trying to connect to the task process. This may fix the test. If not, it should at least provide much better logging.