### PR TITLE
Strong mode fix in Table._updateRenderObjectChildren

### DIFF
--- a/packages/flutter/lib/src/widgets/table.dart
+++ b/packages/flutter/lib/src/widgets/table.dart
@@ -340,11 +340,12 @@ class _TableElement extends RenderObjectElement {
     assert(renderObject != null);
     renderObject.setFlatChildren(
       _children.isNotEmpty ? _children[0].children.length : 0,
-      _children.expand<RenderBox>((_TableElementRow row) =>
-          row.children.map<RenderBox>((Element child) {
-            final RenderBox box = child.renderObject;
-            return box;
-          })).toList()
+      _children.expand<RenderBox>((_TableElementRow row) {
+        return row.children.map<RenderBox>((Element child) {
+          final RenderBox box = child.renderObject;
+          return box;
+        });
+      }).toList()
     );
   }
 

--- a/packages/flutter/lib/src/widgets/table.dart
+++ b/packages/flutter/lib/src/widgets/table.dart
@@ -340,7 +340,11 @@ class _TableElement extends RenderObjectElement {
     assert(renderObject != null);
     renderObject.setFlatChildren(
       _children.isNotEmpty ? _children[0].children.length : 0,
-      _children.expand((_TableElementRow row) => row.children.map<RenderBox>((Element child) => child.renderObject)).toList()
+      _children.expand<RenderBox>((_TableElementRow row) =>
+          row.children.map<RenderBox>((Element child) {
+            final RenderBox box = child.renderObject;
+            return box;
+          })).toList()
     );
   }
 

--- a/packages/flutter/lib/src/widgets/table.dart
+++ b/packages/flutter/lib/src/widgets/table.dart
@@ -340,7 +340,7 @@ class _TableElement extends RenderObjectElement {
     assert(renderObject != null);
     renderObject.setFlatChildren(
       _children.isNotEmpty ? _children[0].children.length : 0,
-      _children.expand((_TableElementRow row) => row.children.map((Element child) => child.renderObject)).toList()
+      _children.expand((_TableElementRow row) => row.children.map<RenderBox>((Element child) => child.renderObject)).toList()
     );
   }
 


### PR DESCRIPTION
`renderObject.setFlatChildren` expects `List<RenderBox>`, not `List<RenderObject>`.