### PR TITLE
Prepare for running tests on Windows

### DIFF
--- a/packages/flutter/lib/src/foundation/assertions.dart
+++ b/packages/flutter/lib/src/foundation/assertions.dart
@@ -361,7 +361,7 @@ class FlutterError extends AssertionError {
       '_FakeAsync',
       '_FrameCallbackEntry',
     ];
-    final RegExp stackParser = new RegExp(r'^#[0-9]+ +([^.]+).* \(([^/]*)/.+:[0-9]+(?::[0-9]+)?\)$');
+    final RegExp stackParser = new RegExp(r'^#[0-9]+ +([^.]+).* \(([^/\\]*)[/\\].+:[0-9]+(?::[0-9]+)?\)$');
     final RegExp packageParser = new RegExp(r'^([^:]+):(.+)$');
     final List<String> result = <String>[];
     final List<String> skipped = <String>[];

--- a/packages/flutter/test/foundation/error_reporting_test.dart
+++ b/packages/flutter/test/foundation/error_reporting_test.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:io' show Platform;
 
 import 'package:flutter/foundation.dart';
 import 'package:test/test.dart';
@@ -43,6 +44,8 @@ Future<Null> main() async {
 
   final StackTrace sampleStack = await getSampleStack();
 
+  final String divider = Platform.pathSeparator;
+
   test('Error reporting - pretest', () async {
     expect(debugPrint, equals(debugPrintThrottled));
     debugPrint = (String message, { int wrapWidth }) {
@@ -66,7 +69,7 @@ Future<Null> main() async {
       '^══╡ EXCEPTION CAUGHT BY ERROR HANDLING TEST ╞═══════════════════════════════════════════════════════\n'
       'The following assertion was thrown testing the error handling logic:\n'
       'Message goes here\\.\n'
-      '\'[^\']+flutter/test/foundation/error_reporting_test\\.dart\': Failed assertion: line [0-9]+ pos [0-9]+: \'false\'\n'
+      '\'[^\']+flutter${divider}test${divider}foundation${divider}error_reporting_test\\.dart\': Failed assertion: line [0-9]+ pos [0-9]+: \'false\'\n'
       '\n'
       'Either the assertion indicates an error in the framework itself, or we should provide substantially '
       'more information in this error message to help you determine and fix the underlying cause\\.\n'
@@ -74,10 +77,10 @@ Future<Null> main() async {
       '  https://github\\.com/flutter/flutter/issues/new\n'
       '\n'
       'When the exception was thrown, this was the stack:\n'
-      '#0      getSampleStack\\.<anonymous closure> \\([^)]+flutter/test/foundation/error_reporting_test\\.dart:[0-9]+:[0-9]+\\)\n'
-      '#2      getSampleStack \\([^)]+flutter/test/foundation/error_reporting_test\\.dart:[0-9]+:[0-9]+\\)\n'
+      '#0      getSampleStack\\.<anonymous closure> \\([^)]+flutter${divider}test${divider}foundation${divider}error_reporting_test\\.dart:[0-9]+:[0-9]+\\)\n'
+      '#2      getSampleStack \\([^)]+flutter${divider}test${divider}foundation${divider}error_reporting_test\\.dart:[0-9]+:[0-9]+\\)\n'
       '<asynchronous suspension>\n' // TODO(ianh): https://github.com/flutter/flutter/issues/4021
-      '#3      main \\([^)]+flutter/test/foundation/error_reporting_test\\.dart:[0-9]+:[0-9]+\\)\n'
+      '#3      main \\([^)]+flutter${divider}test${divider}foundation${divider}error_reporting_test\\.dart:[0-9]+:[0-9]+\\)\n'
       '(.+\n)+' // TODO(ianh): when fixing #4021, also filter out frames from the test infrastructure below the first call to our main()
       '\\(elided [0-9]+ frames from package dart:async\\)\n'
       '\n'
@@ -107,7 +110,7 @@ Future<Null> main() async {
       'word word word word word word word word word word word word word word word word word word word word '
       'word word word word word word word word word word word word word word word word word word word word '
       'word word word word word word word word word word word word word word word word word word word word\n'
-      '\'[^\']+flutter/test/foundation/error_reporting_test\\.dart\': Failed assertion: line [0-9]+ pos [0-9]+: \'false\'\n'
+      '\'[^\']+flutter${divider}test${divider}foundation${divider}error_reporting_test\\.dart\': Failed assertion: line [0-9]+ pos [0-9]+: \'false\'\n'
       '\n'
       'Either the assertion indicates an error in the framework itself, or we should provide substantially '
       'more information in this error message to help you determine and fix the underlying cause\\.\n'
@@ -147,7 +150,7 @@ Future<Null> main() async {
     expect(console.join('\n'), matches(new RegExp(
       '^══╡ EXCEPTION CAUGHT BY ERROR HANDLING TEST ╞═══════════════════════════════════════════════════════\n'
       'The following assertion was thrown testing the error handling logic:\n'
-      '\'[^\']+flutter/test/foundation/error_reporting_test\\.dart\': Failed assertion: line [0-9]+ pos [0-9]+: \'false\': is not true\\.\n'
+      '\'[^\']+flutter${divider}test${divider}foundation${divider}error_reporting_test\\.dart\': Failed assertion: line [0-9]+ pos [0-9]+: \'false\': is not true\\.\n'
       '\n'
       'Either the assertion indicates an error in the framework itself, or we should provide substantially '
       'more information in this error message to help you determine and fix the underlying cause\\.\n'
@@ -155,10 +158,10 @@ Future<Null> main() async {
       '  https://github\\.com/flutter/flutter/issues/new\n'
       '\n'
       'When the exception was thrown, this was the stack:\n'
-      '#0      getSampleStack\\.<anonymous closure> \\([^)]+flutter/test/foundation/error_reporting_test\\.dart:[0-9]+:[0-9]+\\)\n'
-      '#2      getSampleStack \\([^)]+flutter/test/foundation/error_reporting_test\\.dart:[0-9]+:[0-9]+\\)\n'
+      '#0      getSampleStack\\.<anonymous closure> \\([^)]+flutter${divider}test${divider}foundation${divider}error_reporting_test\\.dart:[0-9]+:[0-9]+\\)\n'
+      '#2      getSampleStack \\([^)]+flutter${divider}test${divider}foundation${divider}error_reporting_test\\.dart:[0-9]+:[0-9]+\\)\n'
       '<asynchronous suspension>\n' // TODO(ianh): https://github.com/flutter/flutter/issues/4021
-      '#3      main \\([^)]+flutter/test/foundation/error_reporting_test\\.dart:[0-9]+:[0-9]+\\)\n'
+      '#3      main \\([^)]+flutter${divider}test${divider}foundation${divider}error_reporting_test\\.dart:[0-9]+:[0-9]+\\)\n'
       '(.+\n)+' // TODO(ianh): when fixing #4021, also filter out frames from the test infrastructure below the first call to our main()
       '\\(elided [0-9]+ frames from package dart:async\\)\n'
       '\n'
@@ -170,7 +173,7 @@ Future<Null> main() async {
     FlutterError.dumpErrorToConsole(new FlutterErrorDetails(
       exception: getAssertionErrorWithoutMessage(),
     ));
-    expect(console.join('\n'), matches('Another exception was thrown: \'[^\']+flutter/test/foundation/error_reporting_test\\.dart\': Failed assertion: line [0-9]+ pos [0-9]+: \'false\': is not true\\.'));
+    expect(console.join('\n'), matches('Another exception was thrown: \'[^\']+flutter${divider}test${divider}foundation${divider}error_reporting_test\\.dart\': Failed assertion: line [0-9]+ pos [0-9]+: \'false\': is not true\\.'));
     console.clear();
     FlutterError.resetErrorCount();
   });

--- a/packages/flutter/test/foundation/stack_trace_test.dart
+++ b/packages/flutter/test/foundation/stack_trace_test.dart
@@ -2,17 +2,21 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:io';
+
 import 'package:flutter/foundation.dart';
 import 'package:test/test.dart';
 
 void main() {
   // TODO(8128): These tests and the filtering mechanism should be revisited to account for causal async stack traces.
 
+  final String divider = Platform.pathSeparator;
+  
   test('FlutterError.defaultStackFilter', () {
     final List<String> filtered = FlutterError.defaultStackFilter(StackTrace.current.toString().trimRight().split('\n')).toList();
     expect(filtered.length, greaterThanOrEqualTo(4));
     expect(filtered[0], matches(r'^#0 +main\.<anonymous closure> \(.*stack_trace_test\.dart:[0-9]+:[0-9]+\)$'));
-    expect(filtered[1], matches(r'^#1 +Declarer\.test\.<anonymous closure>.<anonymous closure> \(package:test/.+:[0-9]+:[0-9]+\)$'));
+    expect(filtered[1], matches(r'^#1 +Declarer\.test\.<anonymous closure>.<anonymous closure> \(package:test' + divider + r'.+:[0-9]+:[0-9]+\)$'));
     expect(filtered[2], equals('<asynchronous suspension>'));
     expect(filtered.last, matches(r'^\(elided [1-9][0-9]+ frames from package dart:async, package dart:async-patch, and package stack_trace\)$'));
   });

--- a/packages/flutter/test/painting/text_painter_rtl_test.dart
+++ b/packages/flutter/test/painting/text_painter_rtl_test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:io';
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter/painting.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -317,7 +319,7 @@ void main() {
         const TextBox.fromLTRBD(0.0, 10.0, 10.0, 20.0, TextDirection.rtl), // Alef
       ],
     );
-  });
+  }, skip: Platform.isWindows); // Ahem-based tests don't yet quite work on Windows
 
   test('TextPainter - line wrap mid-word', () {
     final TextPainter painter = new TextPainter()

--- a/packages/flutter/test/rendering/paragraph_test.dart
+++ b/packages/flutter/test/rendering/paragraph_test.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:io';
 import 'dart:ui' as ui show TextBox;
 
 import 'package:flutter/rendering.dart';
@@ -68,7 +69,7 @@ void main() {
 
     expect(boxes.any((ui.TextBox box) => box.left == 250 && box.top == 0), isTrue);
     expect(boxes.any((ui.TextBox box) => box.right == 100 && box.top == 10), isTrue);
-  });
+  }, skip: Platform.isWindows); // Ahem-based tests don't yet quite work on Windows
 
   test('getWordBoundary control test', () {
     final RenderParagraph paragraph = new RenderParagraph(
@@ -190,7 +191,7 @@ void main() {
 
     layoutAt(3);
     expect(paragraph.size.height, 30.0);
-  });
+  }, skip: Platform.isWindows); // Ahem-based tests don't yet quite work on Windows
 
   test('changing color does not do layout', () {
     final RenderParagraph paragraph = new RenderParagraph(


### PR DESCRIPTION
Seems like we don't yet run the flutter tests on Windows, but we're
close to being able to. This makes some minor changes to make that
more possible:

 - fix the stack parsing code to support Windows paths
 - fix the tests for the stack error handling code to handle Windows paths
 - skip some tests that rely on Ahem font metrics