### PR TITLE
Small simplification in RenderEditable

### DIFF
--- a/packages/flutter/lib/src/material/text_field.dart
+++ b/packages/flutter/lib/src/material/text_field.dart
@@ -389,7 +389,6 @@ class _TextFieldState extends State<TextField> with AutomaticKeepAliveClientMixi
   }
 
   void _handleTapCancel() {
-    _renderEditable.handleTapCancel();
     _cancelCurrentSplash();
   }
 

--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -155,8 +155,7 @@ class RenderEditable extends RenderBox {
     assert(!_showCursor.value || cursorColor != null);
     _tap = new TapGestureRecognizer(debugOwner: this)
       ..onTapDown = _handleTapDown
-      ..onTap = _handleTap
-      ..onTapCancel = _handleTapCancel;
+      ..onTap = _handleTap;
     _longPress = new LongPressGestureRecognizer(debugOwner: this)
       ..onLongPress = _handleLongPress;
   }
@@ -171,7 +170,7 @@ class RenderEditable extends RenderBox {
 
   /// If true [handleEvent] does nothing and it's assumed that this
   /// renderer will be notified of input gestures via [handleTapDown],
-  /// [handleTap], [handleTapCancel], and [handleLongPress].
+  /// [handleTap], and [handleLongPress].
   ///
   /// The default value of this property is false.
   bool ignorePointer;
@@ -569,7 +568,6 @@ class RenderEditable extends RenderBox {
   }
 
   Offset _lastTapDownPosition;
-  Offset _longPressPosition;
 
   /// If [ignorePointer] is false (the default) then this method is called by
   /// the internal gesture recognizer's [TapGestureRecognizer.onTapDown]
@@ -594,32 +592,14 @@ class RenderEditable extends RenderBox {
   void handleTap() {
     _layoutText(constraints.maxWidth);
     assert(_lastTapDownPosition != null);
-    final Offset globalPosition = _lastTapDownPosition;
-    _lastTapDownPosition = null;
     if (onSelectionChanged != null) {
-      final TextPosition position = _textPainter.getPositionForOffset(globalToLocal(globalPosition));
+      final TextPosition position = _textPainter.getPositionForOffset(globalToLocal(_lastTapDownPosition));
       onSelectionChanged(new TextSelection.fromPosition(position), this, SelectionChangedCause.tap);
     }
   }
   void _handleTap() {
     assert(!ignorePointer);
     handleTap();
-  }
-
-  /// If [ignorePointer] is false (the default) then this method is called by
-  /// the internal gesture recognizer's [TapGestureRecognizer.onTapCancel]
-  /// callback.
-  ///
-  /// When [ignorePointer] is true, an ancestor widget must respond to tap
-  /// cancel events by calling this method.
-  void handleTapCancel() {
-    // longPress arrives after tapCancel, so remember the tap position.
-    _longPressPosition = _lastTapDownPosition;
-    _lastTapDownPosition = null;
-  }
-  void _handleTapCancel() {
-    assert(!ignorePointer);
-    handleTapCancel();
   }
 
   /// If [ignorePointer] is false (the default) then this method is called by
@@ -630,10 +610,9 @@ class RenderEditable extends RenderBox {
   /// press events by calling this method.
   void handleLongPress() {
     _layoutText(constraints.maxWidth);
-    final Offset globalPosition = _longPressPosition;
-    _longPressPosition = null;
+    assert(_lastTapDownPosition != null);
     if (onSelectionChanged != null) {
-      final TextPosition position = _textPainter.getPositionForOffset(globalToLocal(globalPosition));
+      final TextPosition position = _textPainter.getPositionForOffset(globalToLocal(_lastTapDownPosition));
       onSelectionChanged(_selectWordAtOffset(position), this, SelectionChangedCause.longPress);
     }
   }


### PR DESCRIPTION
A small simplification per some feedback from @Hixie:
https://github.com/flutter/flutter/pull/14055/files/a1cf5fb5c10478db32f912af9594bdd99ede0995#diff-d43c8b73cc68fc6b958630bf15fbf022

This is a backwards incompatible change: the `RenderEditable.handleTapCancel()` method was removed. The method has only existed for about 4 days, since https://github.com/flutter/flutter/pull/14055.
