### PR TITLE
disable/enable locking should be official APIs

### DIFF
--- a/packages/flutter_tools/lib/src/cache.dart
+++ b/packages/flutter_tools/lib/src/cache.dart
@@ -45,17 +45,13 @@ class Cache {
 
   /// Turn off the [lock]/[releaseLockEarly] mechanism.
   ///
-  /// This is used by the tests since they run simultaneously and all in one
+  /// This is useful in tests since they run simultaneously and all in one
   /// process and so it would be a mess if they had to use the lock.
-  @visibleForTesting
   static void disableLocking() {
     _lockEnabled = false;
   }
 
   /// Turn on the [lock]/[releaseLockEarly] mechanism.
-  ///
-  /// This is used by the tests.
-  @visibleForTesting
   static void enableLocking() {
     _lockEnabled = true;
   }


### PR DESCRIPTION
Google dev environment uses these because our staging area is not writable. Since they are marked @visibleForTesting, analyzer throws warnings. Since there's a legitimate use case for these APIs, let's open them up.