### PR TITLE
Fix dartdoc errors in generated localization code and RenderEditable

### DIFF
--- a/dev/tools/gen_date_localizations.dart
+++ b/dev/tools/gen_date_localizations.dart
@@ -77,8 +77,9 @@ Future<Null> main(List<String> rawArgs) async {
 
 // This file has been automatically generated.  Please do not edit it manually.
 // To regenerate run (omit -w to print to console instead of the file):
-// dart --enable-asserts dev/tools/gen_date_localizations.dart -w
+// dart --enable-asserts dev/tools/gen_date_localizations.dart --overwrite
 
+// ignore_for_file: public_member_api_docs
 '''
 );
   buffer.writeln('const Map<String, dynamic> dateSymbols = const <String, dynamic> {');

--- a/dev/tools/gen_localizations.dart
+++ b/dev/tools/gen_localizations.dart
@@ -121,6 +121,8 @@ String generateTranslationBundles() {
 // translationBundleForLocale() function to look up a const TranslationBundle
 // instance for a locale.
 
+// ignore_for_file: public_member_api_docs
+
 import \'dart:ui\' show Locale;
 
 class TranslationBundle {

--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -570,6 +570,13 @@ class RenderEditable extends RenderBox {
 
   Offset _lastTapDownPosition;
   Offset _longPressPosition;
+
+  /// If [ignorePointer] is false (the default) then this method is called by
+  /// the internal gesture recognizer's [TapGestureRecognizer.onTapDown]
+  /// callback.
+  ///
+  /// When [ignorePointer] is true, an ancestor widget must respond to tap
+  /// down events by calling this method.
   void handleTapDown(TapDownDetails details) {
     _lastTapDownPosition = details.globalPosition + -_paintOffset;
   }
@@ -578,6 +585,12 @@ class RenderEditable extends RenderBox {
     handleTapDown(details);
   }
 
+  /// If [ignorePointer] is false (the default) then this method is called by
+  /// the internal gesture recognizer's [TapGestureRecognizer.onTap]
+  /// callback.
+  ///
+  /// When [ignorePointer] is true, an ancestor widget must respond to tap
+  /// events by calling this method.
   void handleTap() {
     _layoutText(constraints.maxWidth);
     assert(_lastTapDownPosition != null);
@@ -593,6 +606,12 @@ class RenderEditable extends RenderBox {
     handleTap();
   }
 
+  /// If [ignorePointer] is false (the default) then this method is called by
+  /// the internal gesture recognizer's [TapGestureRecognizer.onTapCancel]
+  /// callback.
+  ///
+  /// When [ignorePointer] is true, an ancestor widget must respond to tap
+  /// cancel events by calling this method.
   void handleTapCancel() {
     // longPress arrives after tapCancel, so remember the tap position.
     _longPressPosition = _lastTapDownPosition;
@@ -603,6 +622,12 @@ class RenderEditable extends RenderBox {
     handleTapCancel();
   }
 
+  /// If [ignorePointer] is false (the default) then this method is called by
+  /// the internal gesture recognizer's [LongPressRecognizer.onLongPress]
+  /// callback.
+  ///
+  /// When [ignorePointer] is true, an ancestor widget must respond to long
+  /// press events by calling this method.
   void handleLongPress() {
     _layoutText(constraints.maxWidth);
     final Offset globalPosition = _longPressPosition;

--- a/packages/flutter_localizations/lib/src/l10n/date_localizations.dart
+++ b/packages/flutter_localizations/lib/src/l10n/date_localizations.dart
@@ -4,7 +4,9 @@
 
 // This file has been automatically generated.  Please do not edit it manually.
 // To regenerate run (omit -w to print to console instead of the file):
-// dart --enable-asserts dev/tools/gen_date_localizations.dart -w
+// dart --enable-asserts dev/tools/gen_date_localizations.dart --overwrite
+
+// ignore_for_file: public_member_api_docs
 
 const Map<String, dynamic> dateSymbols = const <String, dynamic>{
   'ar': const <String, dynamic>{

--- a/packages/flutter_localizations/lib/src/l10n/localizations.dart
+++ b/packages/flutter_localizations/lib/src/l10n/localizations.dart
@@ -13,6 +13,8 @@
 // translationBundleForLocale() function to look up a const TranslationBundle
 // instance for a locale.
 
+// ignore_for_file: public_member_api_docs
+
 import 'dart:ui' show Locale;
 
 class TranslationBundle {


### PR DESCRIPTION
Added missing method docs to `RenderEditable`.

Added `ignore_for_file: public_member_api_docs` to the generated material localization files.
