### PR TITLE
Allow Flutter tool to be vendored as a submodule

### DIFF
--- a/bin/flutter
+++ b/bin/flutter
@@ -93,7 +93,7 @@ if ! hash git 2>/dev/null; then
   exit 1
 fi
 # Test if the flutter directory is a git clone (otherwise git rev-parse HEAD would fail)
-if [ ! -d "$FLUTTER_ROOT/.git" ]; then
+if [ ! -e "$FLUTTER_ROOT/.git" ]; then
   echo "Error: The Flutter directory is not a clone of the GitHub project."
   exit 1
 fi


### PR DESCRIPTION
When Flutter is vendored as a submodule, `.git` is a File whose contents are a pointer to the Git directory. This change allows you to pin your app to a certain version of Flutter via submodules.

Along with something like #12827, this allows application developers to always use their pinned version, similar to `gradlew` (though my `flutterw` is far simpler):

```sh
#!/bin/bash
set -euo pipefail

DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"

## Assuming you have run `git submodule add https://github.com/flutter/flutter ./vendor/flutter`
export PATH="$DIR/vendor/flutter/bin:$PATH"

exec flutter $@
```

Fixes #3770
