### PR TITLE
[H] Move the splitting of licenses to an isolate

### DIFF
--- a/packages/flutter/lib/foundation.dart
+++ b/packages/flutter/lib/foundation.dart
@@ -39,6 +39,7 @@ export 'src/foundation/change_notifier.dart';
 export 'src/foundation/collections.dart';
 export 'src/foundation/debug.dart';
 export 'src/foundation/diagnostics.dart';
+export 'src/foundation/isolates.dart';
 export 'src/foundation/key.dart';
 export 'src/foundation/licenses.dart';
 export 'src/foundation/node.dart';

--- a/packages/flutter/lib/src/foundation/isolates.dart
+++ b/packages/flutter/lib/src/foundation/isolates.dart
@@ -1,0 +1,66 @@
+// Copyright 2018 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:isolate';
+
+import 'package:meta/meta.dart';
+
+/// Signature for the callback passed to [compute].
+///
+/// {@macro flutter.foundation.compute.types}
+///
+/// Instances of [ComputeCallback] must be top-level functions or static methods
+/// of classes, not closures or instance methods of objects.
+///
+/// {@macro flutter.foundation.compute.limitations}
+typedef R ComputeCallback<Q, R>(Q message);
+
+/// Spawn an isolate, run `callback` on that isolate, passing it `message`, and
+/// (eventually) return the value returned by `callback`.
+///
+/// This is useful for operations that take longer than a few milliseconds, and
+/// which would therefore risk skipping frames. For tasks that will only take a
+/// few milliseconds, consider [scheduleTask] instead.
+///
+/// {@template flutter.foundation.compute.types}
+/// `Q` is the type of the message that kicks off the computation.
+///
+/// `R` is the type of the value returned.
+/// {@endtemplate}
+///
+/// The `callback` argument must be a top-level function, not a closure or an
+/// instance or static method of a class.
+///
+/// {@template flutter.foundation.compute.limitations}
+/// There are limitations on the values that can be sent and received to and
+/// from isolates. These limitations constrain the values of `Q` and `R` that
+/// are possible. See the discussion at [SendPort.send].
+/// {@endtemplate}
+Future<R> compute<Q, R>(ComputeCallback<Q, R> callback, Q message) async {
+  final ReceivePort resultPort = new ReceivePort();
+  final Isolate isolate = await Isolate.spawn(
+    _spawn,
+    new _IsolateConfiguration<Q, R>(callback, message, resultPort.sendPort),
+    errorsAreFatal: true,
+    onExit: resultPort.sendPort,
+  );
+  final R result = await resultPort.first;
+  resultPort.close();
+  isolate.kill();
+  return result;
+}
+
+@immutable
+class _IsolateConfiguration<Q, R> {
+  const _IsolateConfiguration(this.callback, this.message, this.resultPort);
+  final ComputeCallback<Q, R> callback;
+  final Q message;
+  final SendPort resultPort;
+}
+
+void _spawn<Q, R>(_IsolateConfiguration<Q, R> configuration) {
+  final R result = configuration.callback(configuration.message);
+  configuration.resultPort.send(result);
+}

--- a/packages/flutter/lib/src/foundation/licenses.dart
+++ b/packages/flutter/lib/src/foundation/licenses.dart
@@ -54,7 +54,7 @@ abstract class LicenseEntry {
 }
 
 enum _LicenseEntryWithLineBreaksParserState {
-  beforeParagraph, inParagraph
+  beforeParagraph, inParagraph,
 }
 
 /// Variant of [LicenseEntry] for licenses that separate paragraphs with blank
@@ -104,6 +104,14 @@ enum _LicenseEntryWithLineBreaksParserState {
 ///
 /// This would result in a license with six [paragraphs], the third, fourth, and
 /// fifth being indented one level.
+///
+/// ## Performance considerations
+///
+/// Computing the paragraphs is relatively expensive. Doing the work for one
+/// license per frame is reasonable; doing more at the same time is ill-advised.
+/// Consider doing all the work at once using [compute] to move the work to
+/// another thread, or spreading the work across multiple frames using
+/// [scheduleTask].
 class LicenseEntryWithLineBreaks extends LicenseEntry {
   /// Create a license entry for a license whose text is hard-wrapped within
   /// paragraphs and has paragraph breaks denoted by blank lines or with
@@ -170,8 +178,9 @@ class LicenseEntryWithLineBreaks extends LicenseEntry {
               break;
             case '\n':
             case '\f':
-              if (lines.isNotEmpty)
+              if (lines.isNotEmpty) {
                 yield getParagraph();
+              }
               lastLineIndent = 0;
               currentLineIndent = 0;
               currentParagraphIndentation = null;
@@ -231,8 +240,9 @@ class LicenseEntryWithLineBreaks extends LicenseEntry {
     }
     switch (state) {
       case _LicenseEntryWithLineBreaksParserState.beforeParagraph:
-        if (lines.isNotEmpty)
+        if (lines.isNotEmpty) {
           yield getParagraph();
+        }
         break;
       case _LicenseEntryWithLineBreaksParserState.inParagraph:
         addLine();

--- a/packages/flutter/lib/src/foundation/licenses.dart
+++ b/packages/flutter/lib/src/foundation/licenses.dart
@@ -63,10 +63,13 @@ enum _LicenseEntryWithLineBreaksParserState {
 /// unless they start with the same number of spaces as the previous line, in
 /// which case it's assumed they are a continuation of an indented paragraph.
 ///
+/// ## Sample code
+///
 /// For example, the BSD license in this format could be encoded as follows:
 ///
 /// ```dart
-///   LicenseRegistry.addLicense(() {
+/// void initMyLibrary() {
+///   LicenseRegistry.addLicense(() async* {
 ///     yield new LicenseEntryWithLineBreaks(<String>['my_library'], '''
 /// Copyright 2016 The Sample Authors. All rights reserved.
 ///
@@ -95,7 +98,8 @@ enum _LicenseEntryWithLineBreaksParserState {
 /// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 /// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 /// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.''');
-///   }
+///   });
+/// }
 /// ```
 ///
 /// This would result in a license with six [paragraphs], the third, fourth, and
@@ -283,8 +287,7 @@ class LicenseRegistry {
 
   /// Returns the licenses that have been registered.
   ///
-  /// Because generating the list of licenses is expensive, this function should
-  /// only be called once.
+  /// Generating the list of licenses is expensive.
   static Stream<LicenseEntry> get licenses async* {
     if (_collectors == null)
       return;

--- a/packages/flutter/lib/src/material/about.dart
+++ b/packages/flutter/lib/src/material/about.dart
@@ -5,8 +5,8 @@
 import 'dart:async';
 import 'dart:io' show Platform;
 
-import 'package:flutter/widgets.dart';
 import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart';
 
 import 'app_bar.dart';
 import 'debug.dart';
@@ -364,7 +364,6 @@ class LicensePage extends StatefulWidget {
 }
 
 class _LicensePageState extends State<LicensePage> {
-
   @override
   void initState() {
     super.initState();
@@ -458,7 +457,6 @@ class _LicensePageState extends State<LicensePage> {
           child: new Scrollbar(
             child: new ListView(
               padding: const EdgeInsets.symmetric(horizontal: 8.0, vertical: 12.0),
-              shrinkWrap: true,
               children: contents,
             ),
           ),

--- a/packages/flutter/lib/src/material/about.dart
+++ b/packages/flutter/lib/src/material/about.dart
@@ -3,10 +3,12 @@
 // found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:developer' show Timeline, Flow;
 import 'dart:io' show Platform;
 
 import 'package:flutter/foundation.dart';
-import 'package:flutter/widgets.dart';
+import 'package:flutter/scheduler.dart';
+import 'package:flutter/widgets.dart' hide Flow;
 
 import 'app_bar.dart';
 import 'debug.dart';
@@ -374,9 +376,19 @@ class _LicensePageState extends State<LicensePage> {
   bool _loaded = false;
 
   Future<Null> _initLicenses() async {
+    final Flow flow = Flow.begin();
+    Timeline.timeSync('_initLicenses()', () { }, flow: flow);
     await for (LicenseEntry license in LicenseRegistry.licenses) {
       if (!mounted)
         return;
+      Timeline.timeSync('_initLicenses()', () { }, flow: Flow.step(flow.id));
+      final List<LicenseParagraph> paragraphs =
+        await SchedulerBinding.instance.scheduleTask<List<LicenseParagraph>>(
+          () => license.paragraphs.toList(),
+          Priority.animation,
+          debugLabel: 'License',
+          flow: flow,
+        );
       setState(() {
         _licenses.add(const Padding(
           padding: const EdgeInsets.symmetric(vertical: 18.0),
@@ -395,7 +407,7 @@ class _LicensePageState extends State<LicensePage> {
             textAlign: TextAlign.center
           )
         ));
-        for (LicenseParagraph paragraph in license.paragraphs) {
+        for (LicenseParagraph paragraph in paragraphs) {
           if (paragraph.indent == LicenseParagraph.centeredIndent) {
             _licenses.add(new Padding(
               padding: const EdgeInsets.only(top: 16.0),
@@ -418,6 +430,7 @@ class _LicensePageState extends State<LicensePage> {
     setState(() {
       _loaded = true;
     });
+    Timeline.timeSync('Build scheduled', () { }, flow: Flow.end(flow.id));
   }
 
   @override

--- a/packages/flutter/lib/src/services/binding.dart
+++ b/packages/flutter/lib/src/services/binding.dart
@@ -41,7 +41,7 @@ abstract class ServicesBinding extends BindingBase {
 
   Stream<LicenseEntry> _addLicenses() async* {
     final String rawLicenses = await rootBundle.loadString('LICENSE', cache: false);
-    final List<LicenseEntry> licenses = await compute(_parseLicenses, rawLicenses);
+    final List<LicenseEntry> licenses = await compute(_parseLicenses, rawLicenses, debugLabel: 'parseLicenses');
     yield* new Stream<LicenseEntry>.fromIterable(licenses);
   }
 

--- a/packages/flutter/lib/src/services/binding.dart
+++ b/packages/flutter/lib/src/services/binding.dart
@@ -39,22 +39,29 @@ abstract class ServicesBinding extends BindingBase {
     LicenseRegistry.addLicense(_addLicenses);
   }
 
-  static final String _licenseSeparator = '\n' + ('-' * 80) + '\n';
-
   Stream<LicenseEntry> _addLicenses() async* {
     final String rawLicenses = await rootBundle.loadString('LICENSE', cache: false);
+    final List<LicenseEntry> licenses = await compute(_parseLicenses, rawLicenses);
+    yield* new Stream<LicenseEntry>.fromIterable(licenses);
+  }
+
+  // This is run in another isolate created by _addLicenses above.
+  static List<LicenseEntry> _parseLicenses(String rawLicenses) {
+    final String _licenseSeparator = '\n' + ('-' * 80) + '\n';
+    final List<LicenseEntry> result = <LicenseEntry>[];
     final List<String> licenses = rawLicenses.split(_licenseSeparator);
     for (String license in licenses) {
       final int split = license.indexOf('\n\n');
       if (split >= 0) {
-        yield new LicenseEntryWithLineBreaks(
+        result.add(new LicenseEntryWithLineBreaks(
           license.substring(0, split).split('\n'),
           license.substring(split + 2)
-        );
+        ));
       } else {
-        yield new LicenseEntryWithLineBreaks(const <String>[], license);
+        result.add(new LicenseEntryWithLineBreaks(const <String>[], license));
       }
     }
+    return result;
   }
 
   @override

--- a/packages/flutter/test/material/about_test.dart
+++ b/packages/flutter/test/material/about_test.dart
@@ -76,36 +76,36 @@ void main() {
   });
 
   testWidgets('AboutListTile control test', (WidgetTester tester) async {
-    final List<String> log = <String>[];
-
-    Future<Null> licenseFuture;
     LicenseRegistry.addLicense(() {
-      log.add('license1');
-      licenseFuture = tester.pumpWidget(new Container());
-      return new Stream<LicenseEntry>.fromIterable(<LicenseEntry>[]);
+      return new Stream<LicenseEntry>.fromIterable(<LicenseEntry>[
+        new LicenseEntryWithLineBreaks(<String>['AAA'], 'BBB')
+      ]);
     });
 
     LicenseRegistry.addLicense(() {
-      log.add('license2');
       return new Stream<LicenseEntry>.fromIterable(<LicenseEntry>[
-        new LicenseEntryWithLineBreaks(<String>[ 'Another package '], 'Another license')
+        new LicenseEntryWithLineBreaks(<String>['Another package'], 'Another license')
       ]);
     });
 
     await tester.pumpWidget(
       new MaterialApp(
         home: const Center(
-          child: const LicensePage()
+          child: const LicensePage(),
         ),
       ),
     );
 
-    expect(licenseFuture, isNotNull);
-    await licenseFuture;
+    expect(find.text('AAA'), findsNothing);
+    expect(find.text('BBB'), findsNothing);
+    expect(find.text('Another package'), findsNothing);
+    expect(find.text('Another license'), findsNothing);
 
-    // We should not hit an exception here.
-    await tester.idle();
+    await tester.pumpAndSettle();
 
-    expect(log, equals(<String>['license1', 'license2']));
+    expect(find.text('AAA'), findsOneWidget);
+    expect(find.text('BBB'), findsOneWidget);
+    expect(find.text('Another package'), findsOneWidget);
+    expect(find.text('Another license'), findsOneWidget);
   });
 }


### PR DESCRIPTION
This improves (from horrific to terrible) the performance of the
license screen. It also introduces a feature in the foundation layer
to make using isolates for one-off computations easier.

The real problem that remains with this, though, is that transfering
data between isolates is a stop-the-world operation and can take an
absurd amount of time (far more than a few milliseconds), so we still
skip frames.

More work thus remains to be done.