### PR TITLE
adds properties to dismissible widget

### DIFF
--- a/packages/flutter/lib/src/widgets/dismissible.dart
+++ b/packages/flutter/lib/src/widgets/dismissible.dart
@@ -82,7 +82,7 @@ class Dismissible extends StatefulWidget {
     this.direction: DismissDirection.horizontal,
     this.resizeDuration: const Duration(milliseconds: 300),
     this.dismissThresholds: const <DismissDirection, double>{},
-    this.rollbackDuration: const Duration(milliseconds: 300),
+    this.movementDuration: const Duration(milliseconds: 200),
     this.crossAxisEndOffset: 0.0,
   }) : assert(key != null),
        assert(secondaryBackground != null ? background != null : true),
@@ -135,12 +135,13 @@ class Dismissible extends StatefulWidget {
   /// [direction] property.
   final Map<DismissDirection, double> dismissThresholds;
 
-  /// Defines the duration for card to come back to original position if not dismissed.
-  final Duration rollbackDuration;
+  /// Defines the duration for card to dismiss or to come back to original position if not dismissed.
+  final Duration movementDuration;
 
   /// Defines the end offset across the main axis after the card is dismissed.
   ///
-  /// If non-zero value is given then widget moves in cross direction depending on whether it is positive or negative.
+  /// If non-zero value is given then widget moves in cross direction depending on whether
+  /// it is positive or negative.
   final double crossAxisEndOffset;
 
   @override
@@ -192,7 +193,7 @@ class _DismissibleState extends State<Dismissible> with TickerProviderStateMixin
   @override
   void initState() {
     super.initState();
-    _moveController = new AnimationController(duration: widget.rollbackDuration, vsync: this)
+    _moveController = new AnimationController(duration: widget.movementDuration, vsync: this)
       ..addStatusListener(_handleDismissStatusChanged);
     _updateMoveAnimation();
   }

--- a/packages/flutter/lib/src/widgets/dismissible.dart
+++ b/packages/flutter/lib/src/widgets/dismissible.dart
@@ -1,7 +1,7 @@
--// Copyright 2015 The Chromium Authors. All rights reserved.		
--// Use of this source code is governed by a BSD-style license that can be		
--// found in the LICENSE file.		
--
+// Copyright 2015 The Chromium Authors. All rights reserved.		
+// Use of this source code is governed by a BSD-style license that can be		
+// found in the LICENSE file.		
+
  
 import 'package:flutter/foundation.dart';
 

--- a/packages/flutter/lib/src/widgets/dismissible.dart
+++ b/packages/flutter/lib/src/widgets/dismissible.dart
@@ -1,7 +1,3 @@
-// Copyright 2015 The Chromium Authors. All rights reserved.
-// Use of this source code is governed by a BSD-style license that can be
-// found in the LICENSE file.
-
 import 'package:flutter/foundation.dart';
 
 import 'automatic_keep_alive.dart';
@@ -12,7 +8,6 @@ import 'gesture_detector.dart';
 import 'ticker_provider.dart';
 import 'transitions.dart';
 
-const Duration _kDismissDuration = const Duration(milliseconds: 200);
 const Curve _kResizeTimeCurve = const Interval(0.4, 1.0, curve: Curves.ease);
 const double _kMinFlingVelocity = 700.0;
 const double _kMinFlingVelocityDelta = 400.0;
@@ -83,6 +78,8 @@ class Dismissible extends StatefulWidget {
     this.direction: DismissDirection.horizontal,
     this.resizeDuration: const Duration(milliseconds: 300),
     this.dismissThresholds: const <DismissDirection, double>{},
+    this.rollbackDuration: const Duration(milliseconds: 300),
+    this.crossAxisEndOffset: 0.0,
   }) : assert(key != null),
        assert(secondaryBackground != null ? background != null : true),
        super(key: key);
@@ -134,6 +131,13 @@ class Dismissible extends StatefulWidget {
   /// [direction] property.
   final Map<DismissDirection, double> dismissThresholds;
 
+  /// Defines the duration for card to come back to original position if not dismissed.
+  final Duration rollbackDuration;
+
+  /// Defines the end offset across the main axis after the card is dismissed.
+  /// If non-zero value is given then widget moves in cross direction depending on whether it is positive or negative.
+  final double crossAxisEndOffset;
+
   @override
   _DismissibleState createState() => new _DismissibleState();
 }
@@ -183,7 +187,7 @@ class _DismissibleState extends State<Dismissible> with TickerProviderStateMixin
   @override
   void initState() {
     super.initState();
-    _moveController = new AnimationController(duration: _kDismissDuration, vsync: this)
+    _moveController = new AnimationController(duration: widget.rollbackDuration, vsync: this)
       ..addStatusListener(_handleDismissStatusChanged);
     _updateMoveAnimation();
   }
@@ -317,7 +321,9 @@ class _DismissibleState extends State<Dismissible> with TickerProviderStateMixin
     final double end = _dragExtent.sign;
     _moveAnimation = new Tween<Offset>(
       begin: Offset.zero,
-      end: _directionIsXAxis ? new Offset(end, 0.0) : new Offset(0.0, end),
+      end: _directionIsXAxis
+          ? new Offset(end, widget.crossAxisEndOffset)
+          : new Offset(widget.crossAxisEndOffset, end),
     ).animate(_moveController);
   }
 
@@ -513,3 +519,4 @@ class _DismissibleState extends State<Dismissible> with TickerProviderStateMixin
     );
   }
 }
+

--- a/packages/flutter/lib/src/widgets/dismissible.dart
+++ b/packages/flutter/lib/src/widgets/dismissible.dart
@@ -1,8 +1,7 @@
-// Copyright 2015 The Chromium Authors. All rights reserved.		
-// Use of this source code is governed by a BSD-style license that can be		
-// found in the LICENSE file.		
+// Copyright 2015 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
- 
 import 'package:flutter/foundation.dart';
 
 import 'automatic_keep_alive.dart';
@@ -140,6 +139,7 @@ class Dismissible extends StatefulWidget {
   final Duration rollbackDuration;
 
   /// Defines the end offset across the main axis after the card is dismissed.
+  ///
   /// If non-zero value is given then widget moves in cross direction depending on whether it is positive or negative.
   final double crossAxisEndOffset;
 

--- a/packages/flutter/lib/src/widgets/dismissible.dart
+++ b/packages/flutter/lib/src/widgets/dismissible.dart
@@ -1,3 +1,8 @@
+-// Copyright 2015 The Chromium Authors. All rights reserved.		
+-// Use of this source code is governed by a BSD-style license that can be		
+-// found in the LICENSE file.		
+-
+ 
 import 'package:flutter/foundation.dart';
 
 import 'automatic_keep_alive.dart';

--- a/packages/flutter/test/widgets/dismissible_test.dart
+++ b/packages/flutter/test/widgets/dismissible_test.dart
@@ -153,7 +153,8 @@ Future<Null> rollbackElement(WidgetTester tester, Finder finder, { @required Axi
   switch (gestureDirection) {
     case AxisDirection.left:
       // getTopRight() returns a point that's just beyond itemWidget's right
-      // edge and outside the Dismissible event listener's bounds.
+      // edge and outside the Dismissible event listener's bounds. Just nudge
+      // the itemWidget before it's threshold.
       downLocation = tester.getTopRight(finder) + const Offset(-0.1, 0.0);
       upLocation = tester.getTopRight(finder) + const Offset(-0.2, 0.0);
       break;
@@ -193,8 +194,8 @@ Future<Null> rollbackItem(WidgetTester tester, int item, {
 
   await mechanism(tester, itemFinder, gestureDirection: gestureDirection);
 
-  await tester.pump(); // start the slide
-  await tester.pump(rollbackDuration); // finish the slide and start shrinking...
+  await tester.pump(); // start the nudge
+  await tester.pump(rollbackDuration); // to finish the nudge, it takes 'rollbackDuration' time.
   expect(itemFinder, findsWidgets);
 }
 
@@ -614,7 +615,7 @@ void main() {
     expect(backgroundBox.size.height, equals(100.0));
   });
 
-  testWidgets('Abort horizontal fling', (WidgetTester tester) async {
+  testWidgets('Horizontal nudge less than threshold', (WidgetTester tester) async {
     await tester.pumpWidget(buildTest());
     expect(dismissedItems, isEmpty);
 
@@ -626,7 +627,7 @@ void main() {
     expect(find.text('1'), findsOneWidget);
     expect(dismissedItems, isEmpty);
   });
-  testWidgets('Abort vertical fling', (WidgetTester tester) async {
+  testWidgets('Vertical nudge less than threshold', (WidgetTester tester) async {
     await tester.pumpWidget(buildTest());
     expect(dismissedItems, isEmpty);
 


### PR DESCRIPTION
Adds 2 properties.
`crossAxisEndOffset` which defines the end offset across the main axis after the card is dismissed.
`rollbackDuration` which defines the duration for card to come back to original position if not dismissed.