### PR TITLE
Fix: InputDecorator fails with null border, non-null labelText

### DIFF
--- a/packages/flutter/lib/src/material/input_decorator.dart
+++ b/packages/flutter/lib/src/material/input_decorator.dart
@@ -998,7 +998,8 @@ class _RenderDecoration extends RenderBox {
       final double t = decoration.floatingLabelProgress;
       // The center of the outline border label ends up a little below the
       // center of the top border line.
-      final double floatingY = decoration.border.isOutline ? -labelHeight * 0.25 : contentPadding.top;
+      final bool isOutlineBorder = decoration.border != null && decoration.border.isOutline;
+      final double floatingY = isOutlineBorder ? -labelHeight * 0.25 : contentPadding.top;
       final double scale = lerpDouble(1.0, 0.75, t);
       final double dx = textDirection == TextDirection.rtl
         ? labelOffset.dx + label.size.width * (1.0 - scale) // origin is on the right

--- a/packages/flutter/test/material/input_decorator_test.dart
+++ b/packages/flutter/test/material/input_decorator_test.dart
@@ -913,4 +913,22 @@ void main() {
       "InputDecorator-[<'key'>](decoration: InputDecoration(border: UnderlineInputBorder()), baseStyle: TextStyle(<all styles inherited>), isFocused: false, isEmpty: false)",
     );
   });
+
+  testWidgets('InputDecorator with null border and label', (WidgetTester tester) async {
+    // Regression test for https://github.com/flutter/flutter/issues/14165
+    await tester.pumpWidget(
+      buildInputDecorator(
+        // isEmpty: false (default)
+        // isFocused: false (default)
+        decoration: const InputDecoration(
+          labelText: 'label',
+          border: null,
+        ),
+      ),
+    );
+
+    expect(tester.getSize(find.byType(InputDecorator)), const Size(800.0, 56.0));
+    expect(tester.getTopLeft(find.text('label')).dy, 12.0);
+    expect(tester.getBottomLeft(find.text('label')).dy, 24.0);
+  });
 }

--- a/packages/flutter/test/material/input_decorator_test.dart
+++ b/packages/flutter/test/material/input_decorator_test.dart
@@ -928,6 +928,7 @@ void main() {
     );
 
     expect(tester.getSize(find.byType(InputDecorator)), const Size(800.0, 56.0));
+    expect(getBorderWeight(tester), 0.0);
     expect(tester.getTopLeft(find.text('label')).dy, 12.0);
     expect(tester.getBottomLeft(find.text('label')).dy, 24.0);
   });


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/14165
