### PR TITLE
Make automated_tests mostly ignore extraneous error messages

### DIFF
--- a/dev/automated_tests/flutter_test/exception_handling_expectation.txt
+++ b/dev/automated_tests/flutter_test/exception_handling_expectation.txt
@@ -1,4 +1,4 @@
-[^═]*(this line contains the test framework's output with the clock and so forth)?
+<<skip until matching line>>
 ══╡ EXCEPTION CAUGHT BY FLUTTER TEST FRAMEWORK ╞════════════════════════════════════════════════════
 The following message was thrown running a test:
 Who lives, who dies, who tells your story\?

--- a/dev/automated_tests/flutter_test/test_async_utils_guarded_expectation.txt
+++ b/dev/automated_tests/flutter_test/test_async_utils_guarded_expectation.txt
@@ -1,4 +1,4 @@
-[^═]*(this line contains the test framework's output with the clock and so forth)?
+<<skip until matching line>>
 ══╡ EXCEPTION CAUGHT BY FLUTTER TEST FRAMEWORK ╞════════════════════════════════════════════════════
 The following assertion was thrown running a test:
 Guarded function conflict\. You must use "await" with all Future-returning test APIs\.

--- a/dev/automated_tests/flutter_test/test_async_utils_unguarded_expectation.txt
+++ b/dev/automated_tests/flutter_test/test_async_utils_unguarded_expectation.txt
@@ -1,4 +1,5 @@
 [^═]*(this line contains the test framework's output with the clock and so forth)?
+<<skip until matching line>>
 ══╡ EXCEPTION CAUGHT BY FLUTTER TEST FRAMEWORK ╞════════════════════════════════════════════════════
 The following assertion was thrown running a test:
 Guarded function conflict\. You must use "await" with all Future-returning test APIs\.

--- a/dev/automated_tests/flutter_test/ticker_expectation.txt
+++ b/dev/automated_tests/flutter_test/ticker_expectation.txt
@@ -1,4 +1,4 @@
-[^═]*(this line contains the test framework's output with the clock and so forth)?
+<<skip until matching line>>
 ══╡ EXCEPTION CAUGHT BY SCHEDULER LIBRARY ╞═════════════════════════════════════════════════════════
 The following message was thrown:
 An animation is still running even after the widget tree was disposed.

--- a/dev/automated_tests/flutter_test/trivial_widget_expectation.txt
+++ b/dev/automated_tests/flutter_test/trivial_widget_expectation.txt
@@ -1,0 +1,2 @@
+[0-9]+:[0-9]+ [+]0: - A trivial widget test
+[0-9]+:[0-9]+ [+]1: All tests passed!

--- a/dev/automated_tests/flutter_test/trivial_widget_test.dart
+++ b/dev/automated_tests/flutter_test/trivial_widget_test.dart
@@ -1,0 +1,11 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('A trivial widget test', (WidgetTester tester) async {
+  });
+}

--- a/dev/automated_tests/flutter_test/trivial_widget_test.dart
+++ b/dev/automated_tests/flutter_test/trivial_widget_test.dart
@@ -2,10 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  testWidgets('A trivial widget test', (WidgetTester tester) async {
-  });
+  testWidgets('A trivial widget test', (WidgetTester tester) async {});
 }


### PR DESCRIPTION
A better workaround for #7224 than #14164, this implements @Hixie's suggestion of skipping over the extraneous error message in the test expectation.  However, since we don't want to lose track of the check for unusual error messages entirely, add a new test that specifically checks for that.