### PR TITLE
Self-execute closure passed to assert

### DIFF
--- a/packages/flutter/lib/src/material/refresh_indicator.dart
+++ b/packages/flutter/lib/src/material/refresh_indicator.dart
@@ -342,7 +342,7 @@ class RefreshIndicatorState extends State<RefreshIndicator> with TickerProviderS
                 library: 'material library',
               ));
             return true;
-          });
+          }());
           if (refreshResult == null)
             return;
           refreshResult.whenComplete(() {


### PR DESCRIPTION
In Dart 2.0, `assert()` will only accept bool values. https://github.com/dart-lang/sdk/issues/30326