### PR TITLE
Add AndroidSdk.sdkManagerPath, sdkManagerVersion

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_sdk.dart
+++ b/packages/flutter_tools/lib/src/android/android_sdk.dart
@@ -9,6 +9,7 @@ import 'package:meta/meta.dart';
 import '../base/common.dart';
 import '../base/context.dart';
 import '../base/file_system.dart';
+import '../base/io.dart' show ProcessResult;
 import '../base/os.dart';
 import '../base/platform.dart';
 import '../base/process_manager.dart';
@@ -283,6 +284,22 @@ class AndroidSdk {
     _sdkVersions.sort();
 
     _latestVersion = _sdkVersions.isEmpty ? null : _sdkVersions.last;
+  }
+
+  /// Returns the filesystem path of the Android SDK manager tool or null if not found.
+  String get sdkManagerPath {
+    return fs.path.join(directory, 'tools', 'bin', 'sdkmanager');
+  }
+
+  /// Returns the version of the Android SDK manager tool or null if not found.
+  String get sdkManagerVersion {
+    if (!processManager.canRun(sdkManagerPath))
+      throwToolExit('Android sdkmanager not found. Update to the latest Android SDK to resolve this.');
+    final ProcessResult result = processManager.runSync(<String>[sdkManagerPath, '--version']);
+    if (result.exitCode != 0) {
+      throwToolExit('sdkmanager --version failed: ${result.exitCode}', exitCode: result.exitCode);
+    }
+    return result.stdout.trim();
   }
 
   @override

--- a/packages/flutter_tools/lib/src/android/android_workflow.dart
+++ b/packages/flutter_tools/lib/src/android/android_workflow.dart
@@ -186,13 +186,9 @@ class AndroidWorkflow extends DoctorValidator implements Workflow {
           fs.path.dirname(javaBinary) + os.pathVarSeparator + platform.environment['PATH'];
     }
 
-    final String sdkManagerPath = fs.path.join(
-        androidSdk.directory, 'tools', 'bin',
-        platform.isWindows ? 'sdkmanager.bat' : 'sdkmanager',
-    );
     final Process process = await runCommand(
-        <String>[sdkManagerPath, '--licenses'],
-        environment: sdkManagerEnv,
+      <String>[androidSdk.sdkManagerPath, '--licenses'],
+      environment: sdkManagerEnv,
     );
 
     waitGroup<Null>(<Future<Null>>[


### PR DESCRIPTION
Convenience getters for the the path to the Android SDK manager and the
currently installed version of the tool.

Pre-factoring to support better checks around the --android-licenses
command, which uses a feature of the SDK manager that is unsupported in
older versions of the tool.