### PR TITLE
Fix an incorrect variable name in Dart 2 flutter test code

### DIFF
--- a/packages/flutter_tools/lib/src/test/flutter_platform.dart
+++ b/packages/flutter_tools/lib/src/test/flutter_platform.dart
@@ -217,7 +217,7 @@ class _FlutterPlatform extends PlatformPlugin {
             .createTempSync('flutter_bundle_directory');
         finalizers.add(() async {
           printTrace('test $ourTestCount: deleting temporary bundle directory');
-          temporaryDirectory.deleteSync(recursive: true);
+          tempBundleDirectory.deleteSync(recursive: true);
         });
 
         // copy 'vm_platform_strong.dill' into 'platform.dill'


### PR DESCRIPTION
The code was attempting to delete `temporaryDirectory` while it should have been deleting `tempBundleDirectory`