### PR TITLE
Extensibility improvements to flutter_tools

### DIFF
--- a/packages/flutter_tools/lib/src/asset.dart
+++ b/packages/flutter_tools/lib/src/asset.dart
@@ -16,11 +16,14 @@ import 'devfs.dart';
 import 'flutter_manifest.dart';
 import 'globals.dart';
 
+const AssetBundleFactory _kManifestFactory = const _ManifestAssetBundleFactory();
+
 /// Injected factory class for spawning [AssetBundle] instances.
 abstract class AssetBundleFactory {
   /// The singleton instance, pulled from the [AppContext].
-  static AssetBundleFactory get instance => context.putIfAbsent(
-      AssetBundleFactory, () => new _ManifestAssetBundleFactory());
+  static AssetBundleFactory get instance => context == null
+      ? _kManifestFactory
+      : context.putIfAbsent(AssetBundleFactory, () => _kManifestFactory);
 
   /// Creates a new [AssetBundle].
   AssetBundle createBundle();
@@ -45,6 +48,8 @@ abstract class AssetBundle {
 }
 
 class _ManifestAssetBundleFactory implements AssetBundleFactory {
+  const _ManifestAssetBundleFactory();
+
   @override
   AssetBundle createBundle() => new _ManifestAssetBundle();
 }

--- a/packages/flutter_tools/lib/src/asset.dart
+++ b/packages/flutter_tools/lib/src/asset.dart
@@ -54,8 +54,6 @@ class _ManifestAssetBundleFactory implements AssetBundleFactory {
   AssetBundle createBundle() => new _ManifestAssetBundle();
 }
 
-
-/// A bundle of assets.
 class _ManifestAssetBundle implements AssetBundle {
   @override
   final Map<String, DevFSContent> entries = <String, DevFSContent>{};

--- a/packages/flutter_tools/lib/src/asset.dart
+++ b/packages/flutter_tools/lib/src/asset.dart
@@ -7,6 +7,7 @@ import 'dart:convert';
 
 import 'package:yaml/yaml.dart';
 
+import 'base/context.dart';
 import 'base/file_system.dart';
 import 'build_info.dart';
 import 'cache.dart';
@@ -15,8 +16,43 @@ import 'devfs.dart';
 import 'flutter_manifest.dart';
 import 'globals.dart';
 
+/// Injected factory class for spawning [AssetBundle] instances.
+abstract class AssetBundleFactory {
+  /// The singleton instance, pulled from the [AppContext].
+  static FlutterVersion get instance => context.putIfAbsent(
+      AssetBundleFactory, () => new _ManifestAssetBundleFactory());
+
+  /// Creates a new [AssetBundle].
+  AssetBundle createBundle();
+}
+
+abstract class AssetBundle {
+  factory AssetBundle.fixed(String projectRoot, String projectAssets) =>
+      new _ManifestAssetBundle.fixed(projectRoot, projectAssets);
+
+  Map<String, DevFSContent> get entries;
+
+  bool needsBuild({String manifestPath: FlutterManifest.defaultPath});
+
+  /// Returns 0 for success; non-zero for failure.
+  Future<int> build({
+    String manifestPath: FlutterManifest.defaultPath,
+    String workingDirPath,
+    String packagesPath,
+    bool includeDefaultFonts: true,
+    bool reportLicensedPackages: false
+  });
+}
+
+class _ManifestAssetBundleFactory implements AssetBundleFactory {
+  @override
+  AssetBundle createBundle() => new _ManifestAssetBundle();
+}
+
+
 /// A bundle of assets.
-class AssetBundle {
+class _ManifestAssetBundle {
+  @override
   final Map<String, DevFSContent> entries = <String, DevFSContent>{};
 
   static const String defaultManifestPath = 'pubspec.yaml';
@@ -28,14 +64,14 @@ class AssetBundle {
   bool _fixed = false;
   DateTime _lastBuildTimestamp;
 
-  /// Constructs an [AssetBundle] that gathers the set of assets from the
+  /// Constructs an [_ManifestAssetBundle] that gathers the set of assets from the
   /// pubspec.yaml manifest.
-  AssetBundle();
+  _ManifestAssetBundle();
 
-  /// Constructs an [AssetBundle] with a fixed set of assets.
+  /// Constructs an [_ManifestAssetBundle] with a fixed set of assets.
   /// [projectRoot] The absolute path to the project root.
   /// [projectAssets] comma separated list of assets.
-  AssetBundle.fixed(String projectRoot, String projectAssets) {
+  _ManifestAssetBundle.fixed(String projectRoot, String projectAssets) {
     _fixed = true;
     if ((projectRoot == null) || (projectAssets == null))
       return;
@@ -50,6 +86,7 @@ class AssetBundle {
     }
   }
 
+  @override
   bool needsBuild({String manifestPath: defaultManifestPath}) {
     if (_fixed)
       return false;
@@ -63,6 +100,7 @@ class AssetBundle {
     return stat.modified.isAfter(_lastBuildTimestamp);
   }
 
+  @override
   Future<int> build({
     String manifestPath: defaultManifestPath,
     String workingDirPath,
@@ -190,11 +228,6 @@ class AssetBundle {
     entries[_kLICENSE] = await _obtainLicenses(packageMap, assetBasePath, reportPackages: reportLicensedPackages);
 
     return 0;
-  }
-
-  void dump() {
-    printTrace('Dumping AssetBundle:');
-    (entries.keys.toList()..sort()).forEach(printTrace);
   }
 }
 
@@ -369,7 +402,7 @@ List<Map<String, dynamic>> _parseFonts(
 }) {
   final List<Map<String, dynamic>> fonts = <Map<String, dynamic>>[];
   if (manifest.usesMaterialDesign && includeDefaultFonts) {
-    fonts.addAll(_getMaterialFonts(AssetBundle._kFontSetMaterial));
+    fonts.addAll(_getMaterialFonts(_ManifestAssetBundle._kFontSetMaterial));
   }
   if (packageName == null) {
     fonts.addAll(manifest.fontsDescriptor);

--- a/packages/flutter_tools/lib/src/asset.dart
+++ b/packages/flutter_tools/lib/src/asset.dart
@@ -19,7 +19,7 @@ import 'globals.dart';
 /// Injected factory class for spawning [AssetBundle] instances.
 abstract class AssetBundleFactory {
   /// The singleton instance, pulled from the [AppContext].
-  static FlutterVersion get instance => context.putIfAbsent(
+  static AssetBundleFactory get instance => context.putIfAbsent(
       AssetBundleFactory, () => new _ManifestAssetBundleFactory());
 
   /// Creates a new [AssetBundle].
@@ -32,11 +32,11 @@ abstract class AssetBundle {
 
   Map<String, DevFSContent> get entries;
 
-  bool needsBuild({String manifestPath: FlutterManifest.defaultPath});
+  bool needsBuild({String manifestPath: _ManifestAssetBundle.defaultManifestPath});
 
   /// Returns 0 for success; non-zero for failure.
   Future<int> build({
-    String manifestPath: FlutterManifest.defaultPath,
+    String manifestPath: _ManifestAssetBundle.defaultManifestPath,
     String workingDirPath,
     String packagesPath,
     bool includeDefaultFonts: true,
@@ -51,7 +51,7 @@ class _ManifestAssetBundleFactory implements AssetBundleFactory {
 
 
 /// A bundle of assets.
-class _ManifestAssetBundle {
+class _ManifestAssetBundle implements AssetBundle {
   @override
   final Map<String, DevFSContent> entries = <String, DevFSContent>{};
 

--- a/packages/flutter_tools/lib/src/commands/run.dart
+++ b/packages/flutter_tools/lib/src/commands/run.dart
@@ -109,10 +109,6 @@ class RunCommand extends RunCommandBase {
         hide: !verboseHelp,
         help: 'Turn on strong mode semantics.\n'
               'Valid only when --preview-dart-2 is also specified');
-    argParser.addOption('packages',
-        hide: !verboseHelp,
-        valueHelp: 'path',
-        help: 'Specify the path to the .packages file.');
     argParser.addOption('project-root',
         hide: !verboseHelp,
         help: 'Specify the project root directory.');
@@ -260,7 +256,7 @@ class RunCommand extends RunCommandBase {
           previewDart2: argResults['preview-dart-2'],
           strongMode: argResults['strong'],
           projectRootPath: argResults['project-root'],
-          packagesFilePath: argResults['packages'],
+          packagesFilePath: globalResults['packages'],
           projectAssets: argResults['project-assets'],
           ipv6: ipv6,
         );
@@ -313,7 +309,7 @@ class RunCommand extends RunCommandBase {
         previewDart2: argResults['preview-dart-2'],
         strongMode: argResults['strong'],
         projectRootPath: argResults['project-root'],
-        packagesFilePath: argResults['packages'],
+        packagesFilePath: globalResults['packages'],
         projectAssets: argResults['project-assets'],
         stayResident: stayResident,
         ipv6: ipv6,

--- a/packages/flutter_tools/lib/src/flx.dart
+++ b/packages/flutter_tools/lib/src/flx.dart
@@ -114,7 +114,7 @@ Future<List<String>> assemble({
   printTrace('Building $outputPath');
 
   // Build the asset bundle.
-  final AssetBundle assetBundle = new AssetBundle();
+  final AssetBundle assetBundle = AssetBundleFactory.instance.createBundle();
   final int result = await assetBundle.build(
     manifestPath: manifestPath,
     workingDirPath: workingDirPath,

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -420,7 +420,7 @@ abstract class ResidentRunner {
     if (projectAssets != null)
       _assetBundle = new AssetBundle.fixed(_projectRootPath, projectAssets);
     else
-      _assetBundle = new AssetBundle();
+      _assetBundle = AssetBundleFactory.instance.createBundle();
   }
 
   final List<FlutterDevice> flutterDevices;

--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -11,6 +11,7 @@ import 'package:quiver/strings.dart';
 
 import '../application_package.dart';
 import '../base/common.dart';
+import '../base/context.dart';
 import '../base/file_system.dart';
 import '../base/utils.dart';
 import '../build_info.dart';
@@ -62,6 +63,11 @@ class FlutterOptions {
 }
 
 abstract class FlutterCommand extends Command<Null> {
+  /// The currently executing command (or sub-command).
+  ///
+  /// Will be `null` until the top-most command has begun execution.
+  static FlutterCommand get current => context[FlutterCommand];
+
   @override
   ArgParser get argParser => _argParser;
   final ArgParser _argParser = new ArgParser(allowTrailingOptions: false);
@@ -202,6 +208,8 @@ abstract class FlutterCommand extends Command<Null> {
   @override
   Future<Null> run() async {
     final DateTime startTime = clock.now();
+
+    context.setVariable(FlutterCommand, this);
 
     if (flutterUsage.isFirstRun)
       flutterUsage.printWelcome();

--- a/packages/flutter_tools/test/asset_bundle_package_fonts_test.dart
+++ b/packages/flutter_tools/test/asset_bundle_package_fonts_test.dart
@@ -57,7 +57,7 @@ $fontsSection
     List<String> packages,
     String expectedAssetManifest,
   ) async {
-    final AssetBundle bundle = new AssetBundle();
+    final AssetBundle bundle = AssetBundleFactory.instance.createBundle();
     await bundle.build(manifestPath: 'pubspec.yaml');
 
     for (String packageName in packages) {
@@ -121,7 +121,7 @@ $fontsSection
       writePackagesFile('test_package:p/p/lib/');
       writePubspecFile('p/p/pubspec.yaml', 'test_package');
 
-      final AssetBundle bundle = new AssetBundle();
+      final AssetBundle bundle = AssetBundleFactory.instance.createBundle();
       await bundle.build(manifestPath: 'pubspec.yaml');
       expect(bundle.entries.length, 2); // LICENSE, AssetManifest
       expect(bundle.entries.containsKey('FontManifest.json'), false);

--- a/packages/flutter_tools/test/asset_bundle_package_test.dart
+++ b/packages/flutter_tools/test/asset_bundle_package_test.dart
@@ -64,7 +64,7 @@ $assetsSection
     List<String> packages,
     String expectedAssetManifest,
   ) async {
-    final AssetBundle bundle = new AssetBundle();
+    final AssetBundle bundle = AssetBundleFactory.instance.createBundle();
     await bundle.build(manifestPath: 'pubspec.yaml');
 
     for (String packageName in packages) {
@@ -122,7 +122,7 @@ $assetsSection
       writePackagesFile('test_package:p/p/lib/');
       writePubspecFile('p/p/pubspec.yaml', 'test_package');
 
-      final AssetBundle bundle = new AssetBundle();
+      final AssetBundle bundle = AssetBundleFactory.instance.createBundle();
       await bundle.build(manifestPath: 'pubspec.yaml');
       expect(bundle.entries.length, 2); // LICENSE, AssetManifest
       final String expectedAssetManifest = '{}';
@@ -142,7 +142,7 @@ $assetsSection
       final List<String> assets = <String>['a/foo'];
       writeAssets('p/p/', assets);
 
-      final AssetBundle bundle = new AssetBundle();
+      final AssetBundle bundle = AssetBundleFactory.instance.createBundle();
       await bundle.build(manifestPath: 'pubspec.yaml');
       expect(bundle.entries.length, 2); // LICENSE, AssetManifest
       final String expectedAssetManifest = '{}';

--- a/packages/flutter_tools/test/asset_bundle_test.dart
+++ b/packages/flutter_tools/test/asset_bundle_test.dart
@@ -97,8 +97,8 @@ void main()  {
       }
     });
 
-    test('nonempty', () async {
-      final AssetBundle ab = new AssetBundle();
+    testUsingContext('nonempty', () async {
+      final AssetBundle ab = AssetBundleFactory.instance.createBundle();
       expect(await ab.build(), 0);
       expect(ab.entries.length, greaterThan(0));
     });
@@ -108,7 +108,7 @@ void main()  {
         ..createSync()
         ..writeAsStringSync('');
 
-      final AssetBundle bundle = new AssetBundle();
+      final AssetBundle bundle = AssetBundleFactory.instance.createBundle();
       await bundle.build(manifestPath: 'pubspec.yaml');
       expect(bundle.entries.length, 1);
       final String expectedAssetManifest = '{}';

--- a/packages/flutter_tools/test/asset_bundle_variant_test.dart
+++ b/packages/flutter_tools/test/asset_bundle_variant_test.dart
@@ -71,7 +71,7 @@ flutter:
           ..writeAsStringSync(asset);
       }
 
-      AssetBundle bundle = new AssetBundle();
+      AssetBundle bundle = AssetBundleFactory.instance.createBundle();
       await bundle.build(manifestPath: 'pubspec.yaml');
 
       // The main asset file, /a/b/c/foo, and its variants exist.
@@ -81,7 +81,7 @@ flutter:
       }
 
       fs.file('a/b/c/foo').deleteSync();
-      bundle = new AssetBundle();
+      bundle = AssetBundleFactory.instance.createBundle();
       await bundle.build(manifestPath: 'pubspec.yaml');
 
       // Now the main asset file, /a/b/c/foo, does not exist. This is OK because

--- a/packages/flutter_tools/test/asset_test.dart
+++ b/packages/flutter_tools/test/asset_test.dart
@@ -29,7 +29,7 @@ void main()  {
     // This test intentionally does not use a memory file system to ensure
     // that AssetBundle with fonts also works on Windows.
     testUsingContext('app font uses local font file', () async {
-      final AssetBundle asset = new AssetBundle();
+      final AssetBundle asset = AssetBundleFactory.instance.createBundle();
       await asset.build(
         manifestPath : fs.path.join(dataPath, 'main', 'pubspec.yaml'),
         packagesPath: fs.path.join(dataPath, 'main', '.packages'),

--- a/packages/flutter_tools/test/devfs_test.dart
+++ b/packages/flutter_tools/test/devfs_test.dart
@@ -27,6 +27,7 @@ void main() {
   Directory tempDir;
   String basePath;
   DevFS devFS;
+  final AssetBundle assetBundle = AssetBundleFactory.instance.createBundle();
 
   setUpAll(() {
     fs = new MemoryFileSystem();
@@ -212,7 +213,6 @@ void main() {
     });
 
     testUsingContext('add an asset bundle', () async {
-      final AssetBundle assetBundle = AssetBundleFactory.instance.createBundle();
       assetBundle.entries['a.txt'] = new DevFSStringContent('abc');
       final int bytes = await devFS.update(bundle: assetBundle, bundleDirty: true);
       devFSOperations.expectMessages(<String>[
@@ -226,7 +226,6 @@ void main() {
     });
 
     testUsingContext('add a file to the asset bundle - bundleDirty', () async {
-      final AssetBundle assetBundle = AssetBundleFactory.instance.createBundle();
       assetBundle.entries['b.txt'] = new DevFSStringContent('abcd');
       final int bytes = await devFS.update(bundle: assetBundle, bundleDirty: true);
       // Expect entire asset bundle written because bundleDirty is true
@@ -243,7 +242,6 @@ void main() {
     });
 
     testUsingContext('add a file to the asset bundle', () async {
-      final AssetBundle assetBundle = AssetBundleFactory.instance.createBundle();
       assetBundle.entries['c.txt'] = new DevFSStringContent('12');
       final int bytes = await devFS.update(bundle: assetBundle);
       devFSOperations.expectMessages(<String>[
@@ -258,7 +256,6 @@ void main() {
     });
 
     testUsingContext('delete a file from the asset bundle', () async {
-      final AssetBundle assetBundle = AssetBundleFactory.instance.createBundle();
       assetBundle.entries.remove('c.txt');
       final int bytes = await devFS.update(bundle: assetBundle);
       devFSOperations.expectMessages(<String>[
@@ -272,7 +269,6 @@ void main() {
     });
 
     testUsingContext('delete all files from the asset bundle', () async {
-      final AssetBundle assetBundle = AssetBundleFactory.instance.createBundle();
       assetBundle.entries.clear();
       final int bytes = await devFS.update(bundle: assetBundle, bundleDirty: true);
       devFSOperations.expectMessages(<String>[

--- a/packages/flutter_tools/test/devfs_test.dart
+++ b/packages/flutter_tools/test/devfs_test.dart
@@ -27,7 +27,6 @@ void main() {
   Directory tempDir;
   String basePath;
   DevFS devFS;
-  final AssetBundle assetBundle = new AssetBundle();
 
   setUpAll(() {
     fs = new MemoryFileSystem();
@@ -213,6 +212,7 @@ void main() {
     });
 
     testUsingContext('add an asset bundle', () async {
+      final AssetBundle assetBundle = AssetBundleFactory.instance.createBundle();
       assetBundle.entries['a.txt'] = new DevFSStringContent('abc');
       final int bytes = await devFS.update(bundle: assetBundle, bundleDirty: true);
       devFSOperations.expectMessages(<String>[
@@ -226,6 +226,7 @@ void main() {
     });
 
     testUsingContext('add a file to the asset bundle - bundleDirty', () async {
+      final AssetBundle assetBundle = AssetBundleFactory.instance.createBundle();
       assetBundle.entries['b.txt'] = new DevFSStringContent('abcd');
       final int bytes = await devFS.update(bundle: assetBundle, bundleDirty: true);
       // Expect entire asset bundle written because bundleDirty is true
@@ -242,6 +243,7 @@ void main() {
     });
 
     testUsingContext('add a file to the asset bundle', () async {
+      final AssetBundle assetBundle = AssetBundleFactory.instance.createBundle();
       assetBundle.entries['c.txt'] = new DevFSStringContent('12');
       final int bytes = await devFS.update(bundle: assetBundle);
       devFSOperations.expectMessages(<String>[
@@ -256,6 +258,7 @@ void main() {
     });
 
     testUsingContext('delete a file from the asset bundle', () async {
+      final AssetBundle assetBundle = AssetBundleFactory.instance.createBundle();
       assetBundle.entries.remove('c.txt');
       final int bytes = await devFS.update(bundle: assetBundle);
       devFSOperations.expectMessages(<String>[
@@ -269,6 +272,7 @@ void main() {
     });
 
     testUsingContext('delete all files from the asset bundle', () async {
+      final AssetBundle assetBundle = AssetBundleFactory.instance.createBundle();
       assetBundle.entries.clear();
       final int bytes = await devFS.update(bundle: assetBundle, bundleDirty: true);
       devFSOperations.expectMessages(<String>[


### PR DESCRIPTION
* Make the current command injected into the AppContext, allowing
  other classes to inject the current command.
* Introduce `AssetBundleFactory`, an injected factory class for
  spawning instances of `AssetBundle`. This allows other run contexts
  to use custom asset bundling logic.
* Clean up RunCommand by removing a 'packages' argument that duplicated
  a global argument by the same name (and for the same purpose).
  Duplicate arguments are confusing and error-prone.