### PR TITLE
Parameterize several mixins to avoid override errors when compiling with CFE

### DIFF
--- a/dev/integration_tests/external_ui/lib/main.dart
+++ b/dev/integration_tests/external_ui/lib/main.dart
@@ -23,7 +23,7 @@ const MethodChannel channel = const MethodChannel('texture');
 
 enum FrameState { initial, slow, afterSlow, fast, afterFast }
 
-class MyAppState extends State<MyApp> with SingleTickerProviderStateMixin {
+class MyAppState extends State<MyApp> with SingleTickerProviderStateMixin<MyApp> {
   int _widgetBuilds = 0;
   FrameState _state;
   String _summary = '';

--- a/dev/manual_tests/lib/material_arc.dart
+++ b/dev/manual_tests/lib/material_arc.dart
@@ -416,7 +416,7 @@ class AnimationDemo extends StatefulWidget {
   _AnimationDemoState createState() => new _AnimationDemoState();
 }
 
-class _AnimationDemoState extends State<AnimationDemo> with TickerProviderStateMixin {
+class _AnimationDemoState extends State<AnimationDemo> with TickerProviderStateMixin<AnimationDemo> {
   List<_ArcDemo> _allDemos;
 
   @override

--- a/dev/manual_tests/lib/text.dart
+++ b/dev/manual_tests/lib/text.dart
@@ -116,7 +116,7 @@ class Fuzzer extends StatefulWidget {
   _FuzzerState createState() => new _FuzzerState();
 }
 
-class _FuzzerState extends State<Fuzzer> with SingleTickerProviderStateMixin {
+class _FuzzerState extends State<Fuzzer> with SingleTickerProviderStateMixin<Fuzzer> {
   TextSpan _textSpan = const TextSpan(text: 'Welcome to the Flutter text fuzzer.');
   Ticker _ticker;
   math.Random _random;
@@ -790,7 +790,7 @@ class Zalgo extends StatefulWidget {
   _ZalgoState createState() => new _ZalgoState();
 }
 
-class _ZalgoState extends State<Zalgo> with SingleTickerProviderStateMixin {
+class _ZalgoState extends State<Zalgo> with SingleTickerProviderStateMixin<Zalgo> {
   String _text;
   Ticker _ticker;
   math.Random _random;
@@ -897,7 +897,7 @@ class Painting extends StatefulWidget {
   _PaintingState createState() => new _PaintingState();
 }
 
-class _PaintingState extends State<Painting> with SingleTickerProviderStateMixin {
+class _PaintingState extends State<Painting> with SingleTickerProviderStateMixin<Painting> {
   String _text;
   Ticker _ticker;
   math.Random _random;

--- a/examples/catalog/lib/app_bar_bottom.dart
+++ b/examples/catalog/lib/app_bar_bottom.dart
@@ -9,7 +9,7 @@ class AppBarBottomSample extends StatefulWidget {
   _AppBarBottomSampleState createState() => new _AppBarBottomSampleState();
 }
 
-class _AppBarBottomSampleState extends State<AppBarBottomSample> with SingleTickerProviderStateMixin {
+class _AppBarBottomSampleState extends State<AppBarBottomSample> with SingleTickerProviderStateMixin<AppBarBottomSample> {
   TabController _tabController;
 
   @override

--- a/examples/flutter_gallery/lib/demo/material/bottom_navigation_demo.dart
+++ b/examples/flutter_gallery/lib/demo/material/bottom_navigation_demo.dart
@@ -84,7 +84,7 @@ class BottomNavigationDemo extends StatefulWidget {
 }
 
 class _BottomNavigationDemoState extends State<BottomNavigationDemo>
-    with TickerProviderStateMixin {
+    with TickerProviderStateMixin<BottomNavigationDemo> {
   int _currentIndex = 0;
   BottomNavigationBarType _type = BottomNavigationBarType.shifting;
   List<NavigationIconView> _navigationViews;

--- a/examples/flutter_gallery/lib/demo/material/drawer_demo.dart
+++ b/examples/flutter_gallery/lib/demo/material/drawer_demo.dart
@@ -16,7 +16,7 @@ class DrawerDemo extends StatefulWidget {
   _DrawerDemoState createState() => new _DrawerDemoState();
 }
 
-class _DrawerDemoState extends State<DrawerDemo> with TickerProviderStateMixin {
+class _DrawerDemoState extends State<DrawerDemo> with TickerProviderStateMixin<DrawerDemo> {
   final GlobalKey<ScaffoldState> _scaffoldKey = new GlobalKey<ScaffoldState>();
 
   static const List<String> _drawerContents = const <String>[

--- a/examples/flutter_gallery/lib/demo/material/grid_list_demo.dart
+++ b/examples/flutter_gallery/lib/demo/material/grid_list_demo.dart
@@ -60,7 +60,7 @@ class _GridTitleText extends StatelessWidget {
   }
 }
 
-class _GridPhotoViewerState extends State<GridPhotoViewer> with SingleTickerProviderStateMixin {
+class _GridPhotoViewerState extends State<GridPhotoViewer> with SingleTickerProviderStateMixin<GridPhotoViewer> {
   AnimationController _controller;
   Animation<Offset> _flingAnimation;
   Offset _offset = Offset.zero;

--- a/examples/flutter_gallery/lib/demo/material/progress_indicator_demo.dart
+++ b/examples/flutter_gallery/lib/demo/material/progress_indicator_demo.dart
@@ -11,7 +11,7 @@ class ProgressIndicatorDemo extends StatefulWidget {
   _ProgressIndicatorDemoState createState() => new _ProgressIndicatorDemoState();
 }
 
-class _ProgressIndicatorDemoState extends State<ProgressIndicatorDemo> with SingleTickerProviderStateMixin {
+class _ProgressIndicatorDemoState extends State<ProgressIndicatorDemo> with SingleTickerProviderStateMixin<ProgressIndicatorDemo> {
   AnimationController _controller;
   Animation<double> _animation;
 

--- a/examples/flutter_gallery/lib/demo/material/scrollable_tabs_demo.dart
+++ b/examples/flutter_gallery/lib/demo/material/scrollable_tabs_demo.dart
@@ -40,7 +40,7 @@ class ScrollableTabsDemo extends StatefulWidget {
   ScrollableTabsDemoState createState() => new ScrollableTabsDemoState();
 }
 
-class ScrollableTabsDemoState extends State<ScrollableTabsDemo> with SingleTickerProviderStateMixin {
+class ScrollableTabsDemoState extends State<ScrollableTabsDemo> with SingleTickerProviderStateMixin<ScrollableTabsDemo> {
   TabController _controller;
   TabsDemoStyle _demoStyle = TabsDemoStyle.iconsAndText;
 

--- a/examples/flutter_gallery/lib/demo/material/tabs_fab_demo.dart
+++ b/examples/flutter_gallery/lib/demo/material/tabs_fab_demo.dart
@@ -39,7 +39,7 @@ class TabsFabDemo extends StatefulWidget {
   _TabsFabDemoState createState() => new _TabsFabDemoState();
 }
 
-class _TabsFabDemoState extends State<TabsFabDemo> with SingleTickerProviderStateMixin {
+class _TabsFabDemoState extends State<TabsFabDemo> with SingleTickerProviderStateMixin<TabsFabDemo> {
   final GlobalKey<ScaffoldState> _scaffoldKey = new GlobalKey<ScaffoldState>();
 
   TabController _controller;

--- a/examples/flutter_gallery/lib/demo/video_demo.dart
+++ b/examples/flutter_gallery/lib/demo/video_demo.dart
@@ -225,7 +225,7 @@ class FadeAnimation extends StatefulWidget {
 }
 
 class _FadeAnimationState extends State<FadeAnimation>
-    with SingleTickerProviderStateMixin {
+    with SingleTickerProviderStateMixin<FadeAnimation> {
   AnimationController animationController;
 
   @override
@@ -361,7 +361,7 @@ Future<bool> isIOSSimulator() async {
 }
 
 class _VideoDemoState extends State<VideoDemo>
-    with SingleTickerProviderStateMixin {
+    with SingleTickerProviderStateMixin<VideoDemo> {
   final VideoPlayerController butterflyController = new VideoPlayerController(
     butterflyUri,
   );

--- a/examples/flutter_gallery/lib/gallery/home.dart
+++ b/examples/flutter_gallery/lib/gallery/home.dart
@@ -108,7 +108,7 @@ class GalleryHome extends StatefulWidget {
   GalleryHomeState createState() => new GalleryHomeState();
 }
 
-class GalleryHomeState extends State<GalleryHome> with SingleTickerProviderStateMixin {
+class GalleryHomeState extends State<GalleryHome> with SingleTickerProviderStateMixin<GalleryHome> {
   static final GlobalKey<ScaffoldState> _scaffoldKey = new GlobalKey<ScaffoldState>();
 
   AnimationController _controller;

--- a/examples/layers/services/isolate.dart
+++ b/examples/layers/services/isolate.dart
@@ -204,7 +204,7 @@ class IsolateExampleWidget extends StatefulWidget {
 }
 
 // Main application state.
-class IsolateExampleState extends State<StatefulWidget> with SingleTickerProviderStateMixin {
+class IsolateExampleState extends State<StatefulWidget> with SingleTickerProviderStateMixin<StatefulWidget> {
 
   String _status = 'Idle';
   String _label = 'Start';

--- a/examples/layers/widgets/spinning_square.dart
+++ b/examples/layers/widgets/spinning_square.dart
@@ -9,7 +9,7 @@ class SpinningSquare extends StatefulWidget {
   _SpinningSquareState createState() => new _SpinningSquareState();
 }
 
-class _SpinningSquareState extends State<SpinningSquare> with SingleTickerProviderStateMixin {
+class _SpinningSquareState extends State<SpinningSquare> with SingleTickerProviderStateMixin<SpinningSquare> {
   AnimationController _animation;
 
   @override

--- a/packages/flutter/lib/src/cupertino/activity_indicator.dart
+++ b/packages/flutter/lib/src/cupertino/activity_indicator.dart
@@ -33,7 +33,7 @@ class CupertinoActivityIndicator extends StatefulWidget {
 const double _kIndicatorWidth = 20.0;
 const double _kIndicatorHeight = 20.0;
 
-class _CupertinoActivityIndicatorState extends State<CupertinoActivityIndicator> with SingleTickerProviderStateMixin {
+class _CupertinoActivityIndicatorState extends State<CupertinoActivityIndicator> with SingleTickerProviderStateMixin<CupertinoActivityIndicator> {
   AnimationController _controller;
 
   @override

--- a/packages/flutter/lib/src/cupertino/button.dart
+++ b/packages/flutter/lib/src/cupertino/button.dart
@@ -111,7 +111,7 @@ class CupertinoButton extends StatefulWidget {
   }
 }
 
-class _CupertinoButtonState extends State<CupertinoButton> with SingleTickerProviderStateMixin {
+class _CupertinoButtonState extends State<CupertinoButton> with SingleTickerProviderStateMixin<CupertinoButton> {
   // Eyeballed values. Feel free to tweak.
   static const Duration kFadeOutDuration = const Duration(milliseconds: 10);
   static const Duration kFadeInDuration = const Duration(milliseconds: 100);

--- a/packages/flutter/lib/src/cupertino/scrollbar.dart
+++ b/packages/flutter/lib/src/cupertino/scrollbar.dart
@@ -51,7 +51,7 @@ class CupertinoScrollbar extends StatefulWidget {
   _CupertinoScrollbarState createState() => new _CupertinoScrollbarState();
 }
 
-class _CupertinoScrollbarState extends State<CupertinoScrollbar> with TickerProviderStateMixin {
+class _CupertinoScrollbarState extends State<CupertinoScrollbar> with TickerProviderStateMixin<CupertinoScrollbar> {
   ScrollbarPainter _painter;
   TextDirection _textDirection;
 

--- a/packages/flutter/lib/src/cupertino/slider.dart
+++ b/packages/flutter/lib/src/cupertino/slider.dart
@@ -119,7 +119,7 @@ class CupertinoSlider extends StatefulWidget {
   }
 }
 
-class _CupertinoSliderState extends State<CupertinoSlider> with TickerProviderStateMixin {
+class _CupertinoSliderState extends State<CupertinoSlider> with TickerProviderStateMixin<CupertinoSlider> {
   void _handleChanged(double value) {
     assert(widget.onChanged != null);
     widget.onChanged(value * (widget.max - widget.min) + widget.min);

--- a/packages/flutter/lib/src/cupertino/switch.dart
+++ b/packages/flutter/lib/src/cupertino/switch.dart
@@ -95,7 +95,7 @@ class CupertinoSwitch extends StatefulWidget {
   }
 }
 
-class _CupertinoSwitchState extends State<CupertinoSwitch> with TickerProviderStateMixin {
+class _CupertinoSwitchState extends State<CupertinoSwitch> with TickerProviderStateMixin<CupertinoSwitch> {
   @override
   Widget build(BuildContext context) {
     return new _CupertinoSwitchRenderObjectWidget(

--- a/packages/flutter/lib/src/material/app_bar.dart
+++ b/packages/flutter/lib/src/material/app_bar.dart
@@ -403,7 +403,7 @@ class _AppBarState extends State<AppBar> {
         icon: const Icon(Icons.menu),
         onPressed: _handleDrawerButtonEnd,
         tooltip: MaterialLocalizations.of(context).openAppDrawerTooltip,
-      );      
+      );
     }
 
     final Widget toolbar = new Padding(
@@ -919,7 +919,7 @@ class SliverAppBar extends StatefulWidget {
 
 // This class is only Stateful because it owns the TickerProvider used
 // by the floating appbar snap animation (via FloatingHeaderSnapConfiguration).
-class _SliverAppBarState extends State<SliverAppBar> with TickerProviderStateMixin {
+class _SliverAppBarState extends State<SliverAppBar> with TickerProviderStateMixin<SliverAppBar> {
   FloatingHeaderSnapConfiguration _snapConfiguration;
 
   void _updateSnapConfiguration() {

--- a/packages/flutter/lib/src/material/bottom_navigation_bar.dart
+++ b/packages/flutter/lib/src/material/bottom_navigation_bar.dart
@@ -271,7 +271,7 @@ class _BottomNavigationTile extends StatelessWidget {
   }
 }
 
-class _BottomNavigationBarState extends State<BottomNavigationBar> with TickerProviderStateMixin {
+class _BottomNavigationBarState extends State<BottomNavigationBar> with TickerProviderStateMixin<BottomNavigationBar> {
   List<AnimationController> _controllers;
   List<CurvedAnimation> _animations;
 

--- a/packages/flutter/lib/src/material/checkbox.dart
+++ b/packages/flutter/lib/src/material/checkbox.dart
@@ -96,7 +96,7 @@ class Checkbox extends StatefulWidget {
   _CheckboxState createState() => new _CheckboxState();
 }
 
-class _CheckboxState extends State<Checkbox> with TickerProviderStateMixin {
+class _CheckboxState extends State<Checkbox> with TickerProviderStateMixin<Checkbox> {
   @override
   Widget build(BuildContext context) {
     assert(debugCheckHasMaterial(context));

--- a/packages/flutter/lib/src/material/data_table.dart
+++ b/packages/flutter/lib/src/material/data_table.dart
@@ -679,7 +679,7 @@ class _SortArrow extends StatefulWidget {
   _SortArrowState createState() => new _SortArrowState();
 }
 
-class _SortArrowState extends State<_SortArrow> with TickerProviderStateMixin {
+class _SortArrowState extends State<_SortArrow> with TickerProviderStateMixin<_SortArrow> {
 
   AnimationController _opacityController;
   Animation<double> _opacityAnimation;

--- a/packages/flutter/lib/src/material/drawer.dart
+++ b/packages/flutter/lib/src/material/drawer.dart
@@ -158,7 +158,7 @@ class DrawerController extends StatefulWidget {
 /// State for a [DrawerController].
 ///
 /// Typically used by a [Scaffold] to [open] and [close] the drawer.
-class DrawerControllerState extends State<DrawerController> with SingleTickerProviderStateMixin {
+class DrawerControllerState extends State<DrawerController> with SingleTickerProviderStateMixin<DrawerController> {
   @override
   void initState() {
     super.initState();

--- a/packages/flutter/lib/src/material/expand_icon.dart
+++ b/packages/flutter/lib/src/material/expand_icon.dart
@@ -58,7 +58,7 @@ class ExpandIcon extends StatefulWidget {
   _ExpandIconState createState() => new _ExpandIconState();
 }
 
-class _ExpandIconState extends State<ExpandIcon> with SingleTickerProviderStateMixin {
+class _ExpandIconState extends State<ExpandIcon> with SingleTickerProviderStateMixin<ExpandIcon> {
   AnimationController _controller;
   Animation<double> _iconTurns;
 

--- a/packages/flutter/lib/src/material/expansion_tile.dart
+++ b/packages/flutter/lib/src/material/expansion_tile.dart
@@ -79,7 +79,7 @@ class ExpansionTile extends StatefulWidget {
   _ExpansionTileState createState() => new _ExpansionTileState();
 }
 
-class _ExpansionTileState extends State<ExpansionTile> with SingleTickerProviderStateMixin {
+class _ExpansionTileState extends State<ExpansionTile> with SingleTickerProviderStateMixin<ExpansionTile> {
   AnimationController _controller;
   CurvedAnimation _easeOutAnimation;
   CurvedAnimation _easeInAnimation;

--- a/packages/flutter/lib/src/material/ink_well.dart
+++ b/packages/flutter/lib/src/material/ink_well.dart
@@ -374,7 +374,7 @@ class InkResponse extends StatefulWidget {
   }
 }
 
-class _InkResponseState<T extends InkResponse> extends State<T> with AutomaticKeepAliveClientMixin {
+class _InkResponseState<T extends InkResponse> extends State<T> with AutomaticKeepAliveClientMixin<T> {
   Set<InteractiveInkFeature> _splashes;
   InteractiveInkFeature _currentSplash;
   InkHighlight _lastHighlight;

--- a/packages/flutter/lib/src/material/input_decorator.dart
+++ b/packages/flutter/lib/src/material/input_decorator.dart
@@ -122,7 +122,7 @@ class _BorderContainer extends StatefulWidget {
   _BorderContainerState createState() => new _BorderContainerState();
 }
 
-class _BorderContainerState extends State<_BorderContainer> with SingleTickerProviderStateMixin {
+class _BorderContainerState extends State<_BorderContainer> with SingleTickerProviderStateMixin<_BorderContainer> {
   AnimationController _controller;
   Animation<double> _borderAnimation;
   _InputBorderTween _border;
@@ -236,7 +236,7 @@ class _HelperError extends StatefulWidget {
   _HelperErrorState createState() => new _HelperErrorState();
 }
 
-class _HelperErrorState extends State<_HelperError> with SingleTickerProviderStateMixin {
+class _HelperErrorState extends State<_HelperError> with SingleTickerProviderStateMixin<_HelperError> {
   // If the height of this widget and the counter are zero ("empty") at
   // layout time, no space is allocated for the subtext.
   static const Widget empty = const SizedBox();
@@ -1328,7 +1328,7 @@ class InputDecorator extends StatefulWidget {
   }
 }
 
-class _InputDecoratorState extends State<InputDecorator> with TickerProviderStateMixin {
+class _InputDecoratorState extends State<InputDecorator> with TickerProviderStateMixin<InputDecorator> {
   AnimationController _floatingLabelController;
   AnimationController _shakingLabelController;
   final _InputBorderGap _borderGap = new _InputBorderGap();

--- a/packages/flutter/lib/src/material/material.dart
+++ b/packages/flutter/lib/src/material/material.dart
@@ -234,7 +234,7 @@ class Material extends StatefulWidget {
   static const double defaultSplashRadius = 35.0;
 }
 
-class _MaterialState extends State<Material> with TickerProviderStateMixin {
+class _MaterialState extends State<Material> with TickerProviderStateMixin<Material> {
   final GlobalKey _inkFeatureRenderer = new GlobalKey(debugLabel: 'ink renderer');
 
   Color _getBackgroundColor(BuildContext context) {

--- a/packages/flutter/lib/src/material/mergeable_material.dart
+++ b/packages/flutter/lib/src/material/mergeable_material.dart
@@ -150,7 +150,7 @@ class _AnimationTuple {
   double gapStart;
 }
 
-class _MergeableMaterialState extends State<MergeableMaterial> with TickerProviderStateMixin {
+class _MergeableMaterialState extends State<MergeableMaterial> with TickerProviderStateMixin<MergeableMaterial> {
   List<MergeableMaterialItem> _children;
   final Map<LocalKey, _AnimationTuple> _animationTuples =
       <LocalKey, _AnimationTuple>{};

--- a/packages/flutter/lib/src/material/popup_menu.dart
+++ b/packages/flutter/lib/src/material/popup_menu.dart
@@ -349,7 +349,7 @@ class CheckedPopupMenuItem<T> extends PopupMenuItem<T> {
   _CheckedPopupMenuItemState<T> createState() => new _CheckedPopupMenuItemState<T>();
 }
 
-class _CheckedPopupMenuItemState<T> extends _PopupMenuItemState<CheckedPopupMenuItem<T>> with SingleTickerProviderStateMixin {
+class _CheckedPopupMenuItemState<T> extends _PopupMenuItemState<CheckedPopupMenuItem<T>> with SingleTickerProviderStateMixin<CheckedPopupMenuItem<T>> {
   static const Duration _kFadeDuration = const Duration(milliseconds: 150);
   AnimationController _controller;
   Animation<double> get _opacity => _controller.view;

--- a/packages/flutter/lib/src/material/progress_indicator.dart
+++ b/packages/flutter/lib/src/material/progress_indicator.dart
@@ -169,7 +169,7 @@ class LinearProgressIndicator extends ProgressIndicator {
   _LinearProgressIndicatorState createState() => new _LinearProgressIndicatorState();
 }
 
-class _LinearProgressIndicatorState extends State<LinearProgressIndicator> with SingleTickerProviderStateMixin {
+class _LinearProgressIndicatorState extends State<LinearProgressIndicator> with SingleTickerProviderStateMixin<LinearProgressIndicator> {
   Animation<double> _animation;
   AnimationController _controller;
 
@@ -349,7 +349,7 @@ final Animatable<int> _kStepTween = new StepTween(begin: 0, end: 5);
 
 final Animatable<double> _kRotationTween = new CurveTween(curve: const SawTooth(5));
 
-class _CircularProgressIndicatorState extends State<CircularProgressIndicator> with SingleTickerProviderStateMixin {
+class _CircularProgressIndicatorState extends State<CircularProgressIndicator> with SingleTickerProviderStateMixin<CircularProgressIndicator> {
   AnimationController _controller;
 
   @override

--- a/packages/flutter/lib/src/material/radio.dart
+++ b/packages/flutter/lib/src/material/radio.dart
@@ -102,7 +102,7 @@ class Radio<T> extends StatefulWidget {
   _RadioState<T> createState() => new _RadioState<T>();
 }
 
-class _RadioState<T> extends State<Radio<T>> with TickerProviderStateMixin {
+class _RadioState<T> extends State<Radio<T>> with TickerProviderStateMixin<Radio<T>> {
   bool get _enabled => widget.onChanged != null;
 
   Color _getInactiveColor(ThemeData themeData) {

--- a/packages/flutter/lib/src/material/refresh_indicator.dart
+++ b/packages/flutter/lib/src/material/refresh_indicator.dart
@@ -133,7 +133,7 @@ class RefreshIndicator extends StatefulWidget {
 
 /// Contains the state for a [RefreshIndicator]. This class can be used to
 /// programmatically show the refresh indicator, see the [show] method.
-class RefreshIndicatorState extends State<RefreshIndicator> with TickerProviderStateMixin {
+class RefreshIndicatorState extends State<RefreshIndicator> with TickerProviderStateMixin<RefreshIndicator> {
   AnimationController _positionController;
   AnimationController _scaleController;
   Animation<double> _positionFactor;

--- a/packages/flutter/lib/src/material/scaffold.dart
+++ b/packages/flutter/lib/src/material/scaffold.dart
@@ -179,7 +179,7 @@ class _FloatingActionButtonTransition extends StatefulWidget {
   _FloatingActionButtonTransitionState createState() => new _FloatingActionButtonTransitionState();
 }
 
-class _FloatingActionButtonTransitionState extends State<_FloatingActionButtonTransition> with TickerProviderStateMixin {
+class _FloatingActionButtonTransitionState extends State<_FloatingActionButtonTransition> with TickerProviderStateMixin<_FloatingActionButtonTransition> {
   AnimationController _previousController;
   AnimationController _currentController;
   CurvedAnimation _previousAnimation;
@@ -541,7 +541,7 @@ class Scaffold extends StatefulWidget {
 ///
 /// Can display [SnackBar]s and [BottomSheet]s. Retrieve a [ScaffoldState] from
 /// the current [BuildContext] using [Scaffold.of].
-class ScaffoldState extends State<Scaffold> with TickerProviderStateMixin {
+class ScaffoldState extends State<Scaffold> with TickerProviderStateMixin<Scaffold> {
 
   // DRAWER API
 

--- a/packages/flutter/lib/src/material/scrollbar.dart
+++ b/packages/flutter/lib/src/material/scrollbar.dart
@@ -52,7 +52,7 @@ class Scrollbar extends StatefulWidget {
 }
 
 
-class _ScrollbarState extends State<Scrollbar> with TickerProviderStateMixin {
+class _ScrollbarState extends State<Scrollbar> with TickerProviderStateMixin<Scrollbar> {
   ScrollbarPainter _materialPainter;
   TargetPlatform _currentPlatform;
   TextDirection _textDirection;

--- a/packages/flutter/lib/src/material/slider.dart
+++ b/packages/flutter/lib/src/material/slider.dart
@@ -169,7 +169,7 @@ class Slider extends StatefulWidget {
   }
 }
 
-class _SliderState extends State<Slider> with TickerProviderStateMixin {
+class _SliderState extends State<Slider> with TickerProviderStateMixin<Slider> {
   _SliderState() {
     _reactionController = new AnimationController(
       duration: kRadialReactionDuration,

--- a/packages/flutter/lib/src/material/stepper.dart
+++ b/packages/flutter/lib/src/material/stepper.dart
@@ -179,7 +179,7 @@ class Stepper extends StatefulWidget {
   _StepperState createState() => new _StepperState();
 }
 
-class _StepperState extends State<Stepper> with TickerProviderStateMixin {
+class _StepperState extends State<Stepper> with TickerProviderStateMixin<Stepper> {
   List<GlobalKey> _keys;
   final Map<int, StepState> _oldStates = <int, StepState>{};
 

--- a/packages/flutter/lib/src/material/switch.dart
+++ b/packages/flutter/lib/src/material/switch.dart
@@ -123,7 +123,7 @@ class Switch extends StatefulWidget {
   }
 }
 
-class _SwitchState extends State<Switch> with TickerProviderStateMixin {
+class _SwitchState extends State<Switch> with TickerProviderStateMixin<Switch> {
   @override
   Widget build(BuildContext context) {
     assert(debugCheckHasMaterial(context));

--- a/packages/flutter/lib/src/material/tab_controller.dart
+++ b/packages/flutter/lib/src/material/tab_controller.dart
@@ -31,7 +31,7 @@ import 'constants.dart';
 ///   _MyTabbedPageState createState() => new _MyTabbedPageState();
 /// }
 ///
-/// class _MyTabbedPageState extends State<MyTabbedPage> with SingleTickerProviderStateMixin {
+/// class _MyTabbedPageState extends State<MyTabbedPage> with SingleTickerProviderStateMixin<MyTabbedPage> {
 ///   final List<Tab> myTabs = <Tab>[
 ///     new Tab(text: 'LEFT'),
 ///     new Tab(text: 'RIGHT'),
@@ -285,7 +285,7 @@ class DefaultTabController extends StatefulWidget {
   _DefaultTabControllerState createState() => new _DefaultTabControllerState();
 }
 
-class _DefaultTabControllerState extends State<DefaultTabController> with SingleTickerProviderStateMixin {
+class _DefaultTabControllerState extends State<DefaultTabController> with SingleTickerProviderStateMixin<DefaultTabController> {
   TabController _controller;
 
   @override

--- a/packages/flutter/lib/src/material/text_field.dart
+++ b/packages/flutter/lib/src/material/text_field.dart
@@ -279,7 +279,7 @@ class TextField extends StatefulWidget {
   }
 }
 
-class _TextFieldState extends State<TextField> with AutomaticKeepAliveClientMixin {
+class _TextFieldState extends State<TextField> with AutomaticKeepAliveClientMixin<TextField> {
   final GlobalKey<EditableTextState> _editableTextKey = new GlobalKey<EditableTextState>();
 
   Set<InteractiveInkFeature> _splashes;

--- a/packages/flutter/lib/src/material/time_picker.dart
+++ b/packages/flutter/lib/src/material/time_picker.dart
@@ -998,7 +998,7 @@ class _Dial extends StatefulWidget {
   _DialState createState() => new _DialState();
 }
 
-class _DialState extends State<_Dial> with SingleTickerProviderStateMixin {
+class _DialState extends State<_Dial> with SingleTickerProviderStateMixin<_Dial> {
   @override
   void initState() {
     super.initState();

--- a/packages/flutter/lib/src/material/tooltip.dart
+++ b/packages/flutter/lib/src/material/tooltip.dart
@@ -94,7 +94,7 @@ class Tooltip extends StatefulWidget {
   }
 }
 
-class _TooltipState extends State<Tooltip> with SingleTickerProviderStateMixin {
+class _TooltipState extends State<Tooltip> with SingleTickerProviderStateMixin<Tooltip> {
   AnimationController _controller;
   OverlayEntry _entry;
   Timer _timer;

--- a/packages/flutter/lib/src/material/two_level_list.dart
+++ b/packages/flutter/lib/src/material/two_level_list.dart
@@ -147,7 +147,7 @@ class TwoLevelSublist extends StatefulWidget {
 }
 
 @deprecated
-class _TwoLevelSublistState extends State<TwoLevelSublist> with SingleTickerProviderStateMixin {
+class _TwoLevelSublistState extends State<TwoLevelSublist> with SingleTickerProviderStateMixin<TwoLevelSublist> {
   AnimationController _controller;
   CurvedAnimation _easeOutAnimation;
   CurvedAnimation _easeInAnimation;

--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -34,7 +34,7 @@ export 'package:flutter/gestures.dart' show
 /// the proxy box with its child. However, RenderProxyBox is a useful base class
 /// for render objects that wish to mimic most, but not all, of the properties
 /// of their child.
-class RenderProxyBox extends RenderBox with RenderObjectWithChildMixin<RenderBox>, RenderProxyBoxMixin {
+class RenderProxyBox extends RenderBox with RenderObjectWithChildMixin<RenderBox>, RenderProxyBoxMixin<RenderBox> {
   /// Creates a proxy render box.
   ///
   /// Proxy render boxes are rarely created directly because they simply proxy
@@ -52,7 +52,7 @@ class RenderProxyBox extends RenderBox with RenderObjectWithChildMixin<RenderBox
 /// of [RenderProxyBox] is desired but inheriting from [RenderProxyBox] is
 /// impractical (e.g. because you want to mix in other classes as well).
 // TODO(ianh): Remove this class once https://github.com/dart-lang/sdk/issues/15101 is fixed
-abstract class RenderProxyBoxMixin extends RenderBox with RenderObjectWithChildMixin<RenderBox> {
+abstract class RenderProxyBoxMixin<T extends RenderBox> extends RenderBox with RenderObjectWithChildMixin<T> {
   // This class is intended to be used as a mixin, and should not be
   // extended directly.
   factory RenderProxyBoxMixin._() => null;

--- a/packages/flutter/lib/src/widgets/animated_cross_fade.dart
+++ b/packages/flutter/lib/src/widgets/animated_cross_fade.dart
@@ -229,7 +229,7 @@ class AnimatedCrossFade extends StatefulWidget {
   }
 }
 
-class _AnimatedCrossFadeState extends State<AnimatedCrossFade> with TickerProviderStateMixin {
+class _AnimatedCrossFadeState extends State<AnimatedCrossFade> with TickerProviderStateMixin<AnimatedCrossFade> {
   AnimationController _controller;
   Animation<double> _firstAnimation;
   Animation<double> _secondAnimation;

--- a/packages/flutter/lib/src/widgets/animated_list.dart
+++ b/packages/flutter/lib/src/widgets/animated_list.dart
@@ -206,7 +206,7 @@ class AnimatedList extends StatefulWidget {
 ///
 /// [AnimatedList] item input handlers can also refer to their [AnimatedListState]
 /// with the static [AnimatedList.of] method.
-class AnimatedListState extends State<AnimatedList> with TickerProviderStateMixin {
+class AnimatedListState extends State<AnimatedList> with TickerProviderStateMixin<AnimatedList> {
   final List<_ActiveItem> _incomingItems = <_ActiveItem>[];
   final List<_ActiveItem> _outgoingItems = <_ActiveItem>[];
   int _itemsCount = 0;

--- a/packages/flutter/lib/src/widgets/automatic_keep_alive.dart
+++ b/packages/flutter/lib/src/widgets/automatic_keep_alive.dart
@@ -299,7 +299,7 @@ class KeepAliveHandle extends ChangeNotifier {
 ///
 ///  * [AutomaticKeepAlive], which listens to messages from this mixin.
 ///  * [KeepAliveNotification], the notifications sent by this mixin.
-abstract class AutomaticKeepAliveClientMixin extends State<StatefulWidget> {
+abstract class AutomaticKeepAliveClientMixin<T extends StatefulWidget> extends State<T> {
   // This class is intended to be used as a mixin, and should not be
   // extended directly.
   factory AutomaticKeepAliveClientMixin._() => null;

--- a/packages/flutter/lib/src/widgets/dismissible.dart
+++ b/packages/flutter/lib/src/widgets/dismissible.dart
@@ -179,7 +179,7 @@ class _DismissibleClipper extends CustomClipper<Rect> {
 
 enum _FlingGestureKind { none, forward, reverse }
 
-class _DismissibleState extends State<Dismissible> with TickerProviderStateMixin, AutomaticKeepAliveClientMixin {
+class _DismissibleState extends State<Dismissible> with TickerProviderStateMixin<Dismissible>, AutomaticKeepAliveClientMixin<Dismissible> {
   @override
   void initState() {
     super.initState();

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -308,7 +308,7 @@ class EditableText extends StatefulWidget {
 }
 
 /// State for a [EditableText].
-class EditableTextState extends State<EditableText> with AutomaticKeepAliveClientMixin implements TextInputClient {
+class EditableTextState extends State<EditableText> with AutomaticKeepAliveClientMixin<EditableText> implements TextInputClient {
   Timer _cursorTimer;
   final ValueNotifier<bool> _showCursor = new ValueNotifier<bool>(false);
   final GlobalKey _editableKey = new GlobalKey();

--- a/packages/flutter/lib/src/widgets/fade_in_image.dart
+++ b/packages/flutter/lib/src/widgets/fade_in_image.dart
@@ -348,7 +348,7 @@ class _ImageProviderResolver {
   }
 }
 
-class _FadeInImageState extends State<FadeInImage> with TickerProviderStateMixin {
+class _FadeInImageState extends State<FadeInImage> with TickerProviderStateMixin<FadeInImage> {
   _ImageProviderResolver _imageResolver;
   _ImageProviderResolver _placeholderResolver;
 

--- a/packages/flutter/lib/src/widgets/implicit_animations.dart
+++ b/packages/flutter/lib/src/widgets/implicit_animations.dart
@@ -233,7 +233,7 @@ typedef Tween<T> TweenVisitor<T>(Tween<T> tween, T targetValue, TweenConstructor
 /// Subclasses must implement the [forEachTween] method to help
 /// [AnimatedWidgetBaseState] iterate through the subclasses' widget's fields
 /// and animate them.
-abstract class AnimatedWidgetBaseState<T extends ImplicitlyAnimatedWidget> extends State<T> with SingleTickerProviderStateMixin {
+abstract class AnimatedWidgetBaseState<T extends ImplicitlyAnimatedWidget> extends State<T> with SingleTickerProviderStateMixin<T> {
   AnimationController _controller;
 
   /// The animation driving this widget's implicit animations.

--- a/packages/flutter/lib/src/widgets/navigator.dart
+++ b/packages/flutter/lib/src/widgets/navigator.dart
@@ -737,7 +737,7 @@ class Navigator extends StatefulWidget {
 }
 
 /// The state for a [Navigator] widget.
-class NavigatorState extends State<Navigator> with TickerProviderStateMixin {
+class NavigatorState extends State<Navigator> with TickerProviderStateMixin<Navigator> {
   final GlobalKey<OverlayState> _overlayKey = new GlobalKey<OverlayState>();
   final List<Route<dynamic>> _history = <Route<dynamic>>[];
   final Set<Route<dynamic>> _poppedRoutes = new Set<Route<dynamic>>();

--- a/packages/flutter/lib/src/widgets/overlay.dart
+++ b/packages/flutter/lib/src/widgets/overlay.dart
@@ -263,7 +263,7 @@ class Overlay extends StatefulWidget {
 ///
 /// Used to insert [OverlayEntry]s into the overlay using the [insert] and
 /// [insertAll] functions.
-class OverlayState extends State<Overlay> with TickerProviderStateMixin {
+class OverlayState extends State<Overlay> with TickerProviderStateMixin<Overlay> {
   final List<OverlayEntry> _entries = <OverlayEntry>[];
 
   @override
@@ -519,7 +519,7 @@ class _TheatreElement extends RenderObjectElement {
 // children of its primary subtree's stack can be moved to this object's list
 // of zombie children without changing their parent data objects.
 class _RenderTheatre extends RenderBox
-  with RenderObjectWithChildMixin<RenderStack>, RenderProxyBoxMixin,
+  with RenderObjectWithChildMixin<RenderStack>, RenderProxyBoxMixin<RenderStack>,
        ContainerRenderObjectMixin<RenderBox, StackParentData> {
 
   @override

--- a/packages/flutter/lib/src/widgets/overscroll_indicator.dart
+++ b/packages/flutter/lib/src/widgets/overscroll_indicator.dart
@@ -126,7 +126,7 @@ class GlowingOverscrollIndicator extends StatefulWidget {
   }
 }
 
-class _GlowingOverscrollIndicatorState extends State<GlowingOverscrollIndicator> with TickerProviderStateMixin {
+class _GlowingOverscrollIndicatorState extends State<GlowingOverscrollIndicator> with TickerProviderStateMixin<GlowingOverscrollIndicator> {
   _GlowController _leadingController;
   _GlowController _trailingController;
   Listenable _leadingAndTrailingListener;

--- a/packages/flutter/lib/src/widgets/scrollable.dart
+++ b/packages/flutter/lib/src/widgets/scrollable.dart
@@ -249,7 +249,7 @@ class _ScrollableScope extends InheritedWidget {
 ///
 /// This class is not intended to be subclassed. To specialize the behavior of a
 /// [Scrollable], provide it with a [ScrollPhysics].
-class ScrollableState extends State<Scrollable> with TickerProviderStateMixin
+class ScrollableState extends State<Scrollable> with TickerProviderStateMixin<Scrollable>
     implements ScrollContext {
   /// The manager for this [Scrollable] widget's viewport position.
   ///

--- a/packages/flutter/lib/src/widgets/ticker_provider.dart
+++ b/packages/flutter/lib/src/widgets/ticker_provider.dart
@@ -73,7 +73,7 @@ class TickerMode extends InheritedWidget {
 /// This mixin only supports vending a single ticker. If you might have multiple
 /// [AnimationController] objects over the lifetime of the [State], use a full
 /// [TickerProviderStateMixin] instead.
-abstract class SingleTickerProviderStateMixin extends State<dynamic> implements TickerProvider { // ignore: TYPE_ARGUMENT_NOT_MATCHING_BOUNDS, https://github.com/dart-lang/sdk/issues/25232
+abstract class SingleTickerProviderStateMixin<T extends StatefulWidget> extends State<T> implements TickerProvider { // ignore: TYPE_ARGUMENT_NOT_MATCHING_BOUNDS, https://github.com/dart-lang/sdk/issues/25232
   // This class is intended to be used as a mixin, and should not be
   // extended directly.
   factory SingleTickerProviderStateMixin._() => null;
@@ -155,7 +155,7 @@ abstract class SingleTickerProviderStateMixin extends State<dynamic> implements 
 /// If you only have a single [Ticker] (for example only a single
 /// [AnimationController]) for the lifetime of your [State], then using a
 /// [SingleTickerProviderStateMixin] is more efficient. This is the common case.
-abstract class TickerProviderStateMixin extends State<dynamic> implements TickerProvider { // ignore: TYPE_ARGUMENT_NOT_MATCHING_BOUNDS, https://github.com/dart-lang/sdk/issues/25232
+abstract class TickerProviderStateMixin<T extends StatefulWidget> extends State<T> implements TickerProvider { // ignore: TYPE_ARGUMENT_NOT_MATCHING_BOUNDS, https://github.com/dart-lang/sdk/issues/25232
   // This class is intended to be used as a mixin, and should not be
   // extended directly.
   factory TickerProviderStateMixin._() => null;
@@ -228,10 +228,10 @@ abstract class TickerProviderStateMixin extends State<dynamic> implements Ticker
 // class name leaks into stack traces and error messages and that name would be
 // confusing. Instead we use the less precise but more anodyne "_WidgetTicker",
 // which attracts less attention.
-class _WidgetTicker extends Ticker {
+class _WidgetTicker  extends Ticker {
   _WidgetTicker(TickerCallback onTick, this._creator, { String debugLabel }) : super(onTick, debugLabel: debugLabel);
 
-  final TickerProviderStateMixin _creator;
+  final TickerProviderStateMixin<StatefulWidget> _creator;
 
   @override
   void dispose() {

--- a/packages/flutter/lib/src/widgets/transitions.dart
+++ b/packages/flutter/lib/src/widgets/transitions.dart
@@ -568,7 +568,7 @@ typedef Widget TransitionBuilder(BuildContext context, Widget child);
 ///   _SpinnerState createState() => new _SpinnerState();
 /// }
 ///
-/// class _SpinnerState extends State<Spinner> with SingleTickerProviderStateMixin {
+/// class _SpinnerState extends State<Spinner> with SingleTickerProviderStateMixin<Spinner> {
 ///   AnimationController _controller;
 ///
 ///   @override

--- a/packages/flutter/test/material/tabbed_scrollview_warp_test.dart
+++ b/packages/flutter/test/material/tabbed_scrollview_warp_test.dart
@@ -28,7 +28,7 @@ class MyHomePage extends StatefulWidget {
   _MyHomePageState createState() => new _MyHomePageState();
 }
 
-class _MyHomePageState extends State<MyHomePage> with TickerProviderStateMixin {
+class _MyHomePageState extends State<MyHomePage> with TickerProviderStateMixin<MyHomePage> {
   static const int tabCount = 3;
   TabController tabController;
 

--- a/packages/flutter/test/material/tabs_test.dart
+++ b/packages/flutter/test/material/tabs_test.dart
@@ -84,7 +84,7 @@ class TabControllerFrame extends StatefulWidget {
   TabControllerFrameState createState() => new TabControllerFrameState();
 }
 
-class TabControllerFrameState extends State<TabControllerFrame> with SingleTickerProviderStateMixin {
+class TabControllerFrameState extends State<TabControllerFrame> with SingleTickerProviderStateMixin<TabControllerFrame> {
   TabController _controller;
 
   @override

--- a/packages/flutter/test/widgets/animated_cross_fade_test.dart
+++ b/packages/flutter/test/widgets/animated_cross_fade_test.dart
@@ -370,7 +370,7 @@ class _TickerWatchingWidget extends StatefulWidget {
   State<StatefulWidget> createState() => new _TickerWatchingWidgetState();
 }
 
-class _TickerWatchingWidgetState extends State<_TickerWatchingWidget> with SingleTickerProviderStateMixin {
+class _TickerWatchingWidgetState extends State<_TickerWatchingWidget> with SingleTickerProviderStateMixin<_TickerWatchingWidget> {
   Ticker ticker;
 
   @override

--- a/packages/flutter/test/widgets/ticker_provider_test.dart
+++ b/packages/flutter/test/widgets/ticker_provider_test.dart
@@ -69,7 +69,7 @@ class BoringTickerTest extends StatefulWidget {
   _BoringTickerTestState createState() => new _BoringTickerTestState();
 }
 
-class _BoringTickerTestState extends State<BoringTickerTest> with SingleTickerProviderStateMixin {
+class _BoringTickerTestState extends State<BoringTickerTest> with SingleTickerProviderStateMixin<BoringTickerTest> {
   @override
   Widget build(BuildContext context) => new Container();
 }


### PR DESCRIPTION
# This PR is not yet for commit - but rather for informative purposes (see dart-lang/sdk#31984)

This PR adds type parameters to `TickerProviderStateMixin`, `SingleTickerProviderStateMixin`, `AutomaticKeepAliveClientMixin` and `RenderProxyBoxMixin`. 

Having type parameters ensures that we don't have instantiations of the same class with different type arguments appearing in superinterfaces of mixin application. 

/cc @Hixie @leafpetersen 