### PR TITLE
Support arbitrary shaped Material.

### DIFF
--- a/packages/flutter/lib/src/material/material.dart
+++ b/packages/flutter/lib/src/material/material.dart
@@ -107,8 +107,11 @@ abstract class MaterialInkController {
 /// material, use a [MaterialInkController] obtained via [Material.of].
 ///
 /// In general, the features of a [Material] should not change over time (e.g. a
-/// [Material] should not change its [color], [shadowColor] or [type]). The one
-/// exception is the [elevation], changes to which will be animated.
+/// [Material] should not change its [color], [shadowColor] or [type]).
+/// Changes to [elevation] and [shadowColor] are animated. Changes to [shape] are
+/// animated if [type] is not [MaterialType.transparency] and [ShapeBorder.lerp]
+/// between the previous and next [shape] values is supported.
+///
 ///
 /// ## Shape
 ///

--- a/packages/flutter/lib/src/material/material.dart
+++ b/packages/flutter/lib/src/material/material.dart
@@ -332,7 +332,7 @@ class _MaterialState extends State<Material> with TickerProviderStateMixin {
         );
 
       case MaterialType.circle:
-        return new CircleBorder();
+        return const CircleBorder();
     }
     return new RoundedRectangleBorder();
   }

--- a/packages/flutter/lib/src/material/material.dart
+++ b/packages/flutter/lib/src/material/material.dart
@@ -147,6 +147,10 @@ class Material extends StatefulWidget {
   /// Creates a piece of material.
   ///
   /// The [type], [elevation] and [shadowColor] arguments must not be null.
+  ///
+  /// [shape] and [borderRadius] must not be both non-null.
+  /// If [type] is [MaterialType.circle] then [borderRadius] and [shape] must be
+  /// null.
   const Material({
     Key key,
     this.type: MaterialType.canvas,
@@ -160,7 +164,8 @@ class Material extends StatefulWidget {
   }) : assert(type != null),
        assert(elevation != null),
        assert(shadowColor != null),
-       assert(!(identical(type, MaterialType.circle) && borderRadius != null)),
+       assert(!(shape != null && borderRadius != null)),
+       assert(!(identical(type, MaterialType.circle) && (borderRadius != null || shape != null))),
        super(key: key);
 
   /// The widget below this widget in the tree.

--- a/packages/flutter/lib/src/material/material.dart
+++ b/packages/flutter/lib/src/material/material.dart
@@ -310,10 +310,10 @@ class _MaterialState extends State<Material> with TickerProviderStateMixin {
 
   // Determines the shape for this Material.
   //
-  // If a shapeBorder was specified it will determine the shape,
-  // Otherwise if a borderRadius was specified, the shape is a rounded
+  // If a shapeBorder was specified, it will determine the shape.
+  // If a borderRadius was specified, the shape is a rounded
   // rectangle.
-  // Otherwise the shape is determined by the widget type as described in the
+  // Otherwise, the shape is determined by the widget type as described in the
   // Material class documentation.
   ShapeBorder _getShape() {
     if (widget.shapeBorder != null)
@@ -499,23 +499,21 @@ abstract class InkFeature {
   String toString() => describeIdentity(this);
 }
 
-/// An interpolation between to [ShapeBorder]s.
+/// An interpolation between two [ShapeBorder]s.
 ///
-/// This class specialises the interpolation of [Tween] to use [ShapeBorder.lerp].
+/// This class specializes the interpolation of [Tween] to use [ShapeBorder.lerp].
 class ShapeBorderTween extends Tween<ShapeBorder> {
-
   /// Creates a [ShapeBorder] tween.
   ///
   /// the [begin] and [end] properties may be null; see [ShapeBorder.lerp] for
   /// the null handling semantics.
   ShapeBorderTween({ShapeBorder begin, ShapeBorder end}): super(begin: begin, end: end);
 
-  /// Returns the value this variable has at the given animation clock value.
+  /// Returns the value this tween has at the given animation clock value.
   @override
   ShapeBorder lerp(double t) {
     return ShapeBorder.lerp(begin, end, t);
   }
-
 }
 
 /// Animated version of [PhysicalShape].

--- a/packages/flutter/lib/src/material/material.dart
+++ b/packages/flutter/lib/src/material/material.dart
@@ -148,9 +148,11 @@ class Material extends StatefulWidget {
   ///
   /// The [type], [elevation] and [shadowColor] arguments must not be null.
   ///
-  /// [shape] and [borderRadius] must not be both non-null.
-  /// If [type] is [MaterialType.circle] then [borderRadius] and [shape] must be
-  /// null.
+  /// If a [shape] is specified, then the [borderRadius] property must not be
+  /// null and the [type] property must not be [MaterialType.circle]. If the
+  /// [borderRadius] is specified, then the [type] property must not be
+  /// [MaterialType.circle]. In both cases, these restrictions are intended to
+  /// catch likely errors.
   const Material({
     Key key,
     this.type: MaterialType.canvas,

--- a/packages/flutter/lib/src/rendering/layer.dart
+++ b/packages/flutter/lib/src/rendering/layer.dart
@@ -591,12 +591,6 @@ class ClipPathLayer extends ContainerLayer {
     addChildrenToScene(builder, layerOffset);
     builder.pop();
   }
-
-  @override
-  void debugFillProperties(DiagnosticPropertiesBuilder description) {
-    super.debugFillProperties(description);
-    description.add(new DiagnosticsProperty<Path>('clipPath', clipPath));
-  }
 }
 
 /// A composited layer that applies a given transformation matrix to its

--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -1052,35 +1052,35 @@ abstract class CustomClipper<T> {
 class ShapeBorderClipper extends CustomClipper<Path> {
   /// Creates a [ShapeBorder] clipper.
   ///
-  /// The [shapeBorder] argument must not be null.
+  /// The [shape] argument must not be null.
   ///
-  /// The [textDirection] argument must be provided non-null if [shapeBorder]
+  /// The [textDirection] argument must be provided non-null if [shape]
   /// has a text direction dependency (for example if it is expressed in terms
   /// of "start" and "end" instead of "left" and "right"). It may be null if
   /// the border will not need the text direction to paint itself.
   const ShapeBorderClipper({
-    @required this.shapeBorder,
+    @required this.shape,
     this.textDirection,
-  }) : assert(shapeBorder != null);
+  }) : assert(shape != null);
 
   /// The shape border whose outer path this clipper clips to.
-  final ShapeBorder shapeBorder;
+  final ShapeBorder shape;
 
-  /// The text direction to use for getting the outer path for [shapeBorder].
+  /// The text direction to use for getting the outer path for [shape].
   ///
   /// [ShapeBorder]s can depend on the text direction (e.g having a "dent"
   /// towards the start of the shape).
   final TextDirection textDirection;
 
-  /// Returns the outer path of [shapeBorder] as the clip.
+  /// Returns the outer path of [shape] as the clip.
   @override
   Path getClip(Size size) {
-    return shapeBorder.getOuterPath(Offset.zero & size, textDirection: textDirection);
+    return shape.getOuterPath(Offset.zero & size, textDirection: textDirection);
   }
 
   @override
   bool shouldReclip(covariant ShapeBorderClipper oldClipper) {
-    return oldClipper.shapeBorder != shapeBorder;
+    return oldClipper.shape != shape;
   }
 }
 

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -780,7 +780,7 @@ class PhysicalShape extends SingleChildRenderObjectWidget {
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder description) {
     super.debugFillProperties(description);
-    description.add(new EnumProperty<CustomClipper<Path>>('clipper', clipper));
+    description.add(new DiagnosticsProperty<CustomClipper<Path>>('clipper', clipper));
     description.add(new DoubleProperty('elevation', elevation));
     description.add(new DiagnosticsProperty<Color>('color', color));
     description.add(new DiagnosticsProperty<Color>('shadowColor', shadowColor));

--- a/packages/flutter/test/material/ink_well_test.dart
+++ b/packages/flutter/test/material/ink_well_test.dart
@@ -140,17 +140,17 @@ void main() {
           ),
         ),
       );
-      expect(tester.renderObject<RenderProxyBox>(find.byType(PhysicalModel)).child, paintsNothing);
+      expect(tester.renderObject<RenderProxyBox>(find.byType(PhysicalShape)).child, paintsNothing);
       await tester.tap(find.byType(InkWell));
       await tester.pump();
       await tester.pump(const Duration(milliseconds: 10));
-      expect(tester.renderObject<RenderProxyBox>(find.byType(PhysicalModel)).child, paints..circle());
+      expect(tester.renderObject<RenderProxyBox>(find.byType(PhysicalShape)).child, paints..circle());
       await tester.drag(find.byType(ListView), const Offset(0.0, -1000.0));
       await tester.pump(const Duration(milliseconds: 10));
       await tester.drag(find.byType(ListView), const Offset(0.0, 1000.0));
       await tester.pump(const Duration(milliseconds: 10));
       expect(
-        tester.renderObject<RenderProxyBox>(find.byType(PhysicalModel)).child,
+        tester.renderObject<RenderProxyBox>(find.byType(PhysicalShape)).child,
         keepAlive ? (paints..circle()) : paintsNothing,
       );
     }

--- a/packages/flutter/test/material/material_test.dart
+++ b/packages/flutter/test/material/material_test.dart
@@ -200,14 +200,14 @@ void main() {
       );
     });
 
-    testWidgets('clips to shapeBorder when provided', (WidgetTester tester) async {
+    testWidgets('clips to shape when provided', (WidgetTester tester) async {
       final GlobalKey materialKey = new GlobalKey();
       await tester.pumpWidget(
         new Material(
           key: materialKey,
           type: MaterialType.transparency,
           borderRadius: const BorderRadius.all(const Radius.circular(10.0)),
-          shapeBorder: const StadiumBorder(),
+          shape: const StadiumBorder(),
           child: const SizedBox(width: 100.0, height: 100.0)
         )
       );
@@ -215,7 +215,7 @@ void main() {
       expect(
         find.byKey(materialKey),
         clipsWithShapeBorder(
-          shapeBorder: const StadiumBorder(),
+          shape: const StadiumBorder(),
         ),
       );
     });
@@ -258,21 +258,21 @@ void main() {
       ));
     });
 
-    testWidgets('canvas with shapeBorder and elevation', (WidgetTester tester) async {
+    testWidgets('canvas with shape and elevation', (WidgetTester tester) async {
       final GlobalKey materialKey = new GlobalKey();
       await tester.pumpWidget(
         new Material(
           key: materialKey,
           type: MaterialType.canvas,
           borderRadius: const BorderRadius.all(const Radius.circular(5.0)),
-          shapeBorder: const StadiumBorder(),
+          shape: const StadiumBorder(),
           child: const SizedBox(width: 100.0, height: 100.0),
           elevation: 1.0,
         )
       );
 
       expect(find.byKey(materialKey), rendersOnPhysicalShape(
-          shapeBorder: const StadiumBorder(),
+          shape: const StadiumBorder(),
           elevation: 1.0,
       ));
     });
@@ -313,21 +313,21 @@ void main() {
       ));
     });
 
-    testWidgets('card with shapeBorder and elevation', (WidgetTester tester) async {
+    testWidgets('card with shape and elevation', (WidgetTester tester) async {
       final GlobalKey materialKey = new GlobalKey();
       await tester.pumpWidget(
         new Material(
           key: materialKey,
           type: MaterialType.card,
           borderRadius: const BorderRadius.all(const Radius.circular(5.0)),
-          shapeBorder: const StadiumBorder(),
+          shape: const StadiumBorder(),
           elevation: 5.0,
           child: const SizedBox(width: 100.0, height: 100.0),
         )
       );
 
       expect(find.byKey(materialKey), rendersOnPhysicalShape(
-          shapeBorder: const StadiumBorder(),
+          shape: const StadiumBorder(),
           elevation: 5.0,
       ));
     });
@@ -349,20 +349,20 @@ void main() {
       ));
     });
 
-    testWidgets('circle overridden by shapeBorder', (WidgetTester tester) async {
+    testWidgets('circle overridden by shape', (WidgetTester tester) async {
       final GlobalKey materialKey = new GlobalKey();
       await tester.pumpWidget(
         new Material(
           key: materialKey,
           type: MaterialType.circle,
-          shapeBorder: const StadiumBorder(),
+          shape: const StadiumBorder(),
           child: const SizedBox(width: 100.0, height: 100.0),
           color: const Color(0xFF0000FF),
         )
       );
 
       expect(find.byKey(materialKey), rendersOnPhysicalShape(
-          shapeBorder: const StadiumBorder(),
+          shape: const StadiumBorder(),
           elevation: 0.0,
       ));
     });
@@ -405,7 +405,7 @@ void main() {
       ));
     });
 
-    testWidgets('button with elevation and shapeBorder', (WidgetTester tester) async {
+    testWidgets('button with elevation and shape', (WidgetTester tester) async {
       final GlobalKey materialKey = new GlobalKey();
       await tester.pumpWidget(
         new Material(
@@ -414,13 +414,13 @@ void main() {
           child: const SizedBox(width: 100.0, height: 100.0),
           color: const Color(0xFF0000FF),
           borderRadius: const BorderRadius.all(const Radius.circular(6.0)),
-          shapeBorder: const StadiumBorder(),
+          shape: const StadiumBorder(),
           elevation: 4.0,
         )
       );
 
       expect(find.byKey(materialKey), rendersOnPhysicalShape(
-          shapeBorder: const StadiumBorder(),
+          shape: const StadiumBorder(),
           elevation: 4.0,
       ));
     });

--- a/packages/flutter/test/material/material_test.dart
+++ b/packages/flutter/test/material/material_test.dart
@@ -206,7 +206,6 @@ void main() {
         new Material(
           key: materialKey,
           type: MaterialType.transparency,
-          borderRadius: const BorderRadius.all(const Radius.circular(10.0)),
           shape: const StadiumBorder(),
           child: const SizedBox(width: 100.0, height: 100.0)
         )
@@ -264,7 +263,6 @@ void main() {
         new Material(
           key: materialKey,
           type: MaterialType.canvas,
-          borderRadius: const BorderRadius.all(const Radius.circular(5.0)),
           shape: const StadiumBorder(),
           child: const SizedBox(width: 100.0, height: 100.0),
           elevation: 1.0,
@@ -319,7 +317,6 @@ void main() {
         new Material(
           key: materialKey,
           type: MaterialType.card,
-          borderRadius: const BorderRadius.all(const Radius.circular(5.0)),
           shape: const StadiumBorder(),
           elevation: 5.0,
           child: const SizedBox(width: 100.0, height: 100.0),
@@ -345,24 +342,6 @@ void main() {
 
       expect(find.byKey(materialKey), rendersOnPhysicalModel(
           shape: BoxShape.circle,
-          elevation: 0.0,
-      ));
-    });
-
-    testWidgets('circle overridden by shape', (WidgetTester tester) async {
-      final GlobalKey materialKey = new GlobalKey();
-      await tester.pumpWidget(
-        new Material(
-          key: materialKey,
-          type: MaterialType.circle,
-          shape: const StadiumBorder(),
-          child: const SizedBox(width: 100.0, height: 100.0),
-          color: const Color(0xFF0000FF),
-        )
-      );
-
-      expect(find.byKey(materialKey), rendersOnPhysicalShape(
-          shape: const StadiumBorder(),
           elevation: 0.0,
       ));
     });
@@ -413,7 +392,6 @@ void main() {
           type: MaterialType.button,
           child: const SizedBox(width: 100.0, height: 100.0),
           color: const Color(0xFF0000FF),
-          borderRadius: const BorderRadius.all(const Radius.circular(6.0)),
           shape: const StadiumBorder(),
           elevation: 4.0,
         )

--- a/packages/flutter/test/material/material_test.dart
+++ b/packages/flutter/test/material/material_test.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:flutter/material.dart';
+import 'package:flutter/painting.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -28,8 +29,8 @@ Widget buildMaterial(
   );
 }
 
-RenderPhysicalModel getShadow(WidgetTester tester) {
-  return tester.renderObject(find.byType(PhysicalModel));
+RenderPhysicalShape getShadow(WidgetTester tester) {
+  return tester.renderObject(find.byType(PhysicalShape));
 }
 
 class PaintRecorder extends CustomPainter {
@@ -121,23 +122,23 @@ void main() {
     // a kThemeChangeDuration time interval.
 
     await tester.pumpWidget(buildMaterial(elevation: 0.0));
-    final RenderPhysicalModel modelA = getShadow(tester);
+    final RenderPhysicalShape modelA = getShadow(tester);
     expect(modelA.elevation, equals(0.0));
 
     await tester.pumpWidget(buildMaterial(elevation: 9.0));
-    final RenderPhysicalModel modelB = getShadow(tester);
+    final RenderPhysicalShape modelB = getShadow(tester);
     expect(modelB.elevation, equals(0.0));
 
     await tester.pump(const Duration(milliseconds: 1));
-    final RenderPhysicalModel modelC = getShadow(tester);
+    final RenderPhysicalShape modelC = getShadow(tester);
     expect(modelC.elevation, closeTo(0.0, 0.001));
 
     await tester.pump(kThemeChangeDuration ~/ 2);
-    final RenderPhysicalModel modelD = getShadow(tester);
+    final RenderPhysicalShape modelD = getShadow(tester);
     expect(modelD.elevation, isNot(closeTo(0.0, 0.001)));
 
     await tester.pump(kThemeChangeDuration);
-    final RenderPhysicalModel modelE = getShadow(tester);
+    final RenderPhysicalShape modelE = getShadow(tester);
     expect(modelE.elevation, equals(9.0));
   });
 
@@ -146,23 +147,23 @@ void main() {
     // a kThemeChangeDuration time interval.
 
     await tester.pumpWidget(buildMaterial(shadowColor: const Color(0xFF00FF00)));
-    final RenderPhysicalModel modelA = getShadow(tester);
+    final RenderPhysicalShape modelA = getShadow(tester);
     expect(modelA.shadowColor, equals(const Color(0xFF00FF00)));
 
     await tester.pumpWidget(buildMaterial(shadowColor: const Color(0xFFFF0000)));
-    final RenderPhysicalModel modelB = getShadow(tester);
+    final RenderPhysicalShape modelB = getShadow(tester);
     expect(modelB.shadowColor, equals(const Color(0xFF00FF00)));
 
     await tester.pump(const Duration(milliseconds: 1));
-    final RenderPhysicalModel modelC = getShadow(tester);
+    final RenderPhysicalShape modelC = getShadow(tester);
     expect(modelC.shadowColor, within<Color>(distance: 1, from: const Color(0xFF00FF00)));
 
     await tester.pump(kThemeChangeDuration ~/ 2);
-    final RenderPhysicalModel modelD = getShadow(tester);
+    final RenderPhysicalShape modelD = getShadow(tester);
     expect(modelD.shadowColor, isNot(within<Color>(distance: 1, from: const Color(0xFF00FF00))));
 
     await tester.pump(kThemeChangeDuration);
-    final RenderPhysicalModel modelE = getShadow(tester);
+    final RenderPhysicalShape modelE = getShadow(tester);
     expect(modelE.shadowColor, equals(const Color(0xFFFF0000)));
   });
 
@@ -195,6 +196,26 @@ void main() {
         find.byKey(materialKey),
         clipsWithBoundingRRect(
           borderRadius: const BorderRadius.all(const Radius.circular(10.0))
+        ),
+      );
+    });
+
+    testWidgets('clips to shapeBorder when provided', (WidgetTester tester) async {
+      final GlobalKey materialKey = new GlobalKey();
+      await tester.pumpWidget(
+        new Material(
+          key: materialKey,
+          type: MaterialType.transparency,
+          borderRadius: const BorderRadius.all(const Radius.circular(10.0)),
+          shapeBorder: const StadiumBorder(),
+          child: const SizedBox(width: 100.0, height: 100.0)
+        )
+      );
+
+      expect(
+        find.byKey(materialKey),
+        clipsWithShapeBorder(
+          shapeBorder: const StadiumBorder(),
         ),
       );
     });
@@ -237,6 +258,25 @@ void main() {
       ));
     });
 
+    testWidgets('canvas with shapeBorder and elevation', (WidgetTester tester) async {
+      final GlobalKey materialKey = new GlobalKey();
+      await tester.pumpWidget(
+        new Material(
+          key: materialKey,
+          type: MaterialType.canvas,
+          borderRadius: const BorderRadius.all(const Radius.circular(5.0)),
+          shapeBorder: const StadiumBorder(),
+          child: const SizedBox(width: 100.0, height: 100.0),
+          elevation: 1.0,
+        )
+      );
+
+      expect(find.byKey(materialKey), rendersOnPhysicalShape(
+          shapeBorder: const StadiumBorder(),
+          elevation: 1.0,
+      ));
+    });
+
     testWidgets('card', (WidgetTester tester) async {
       final GlobalKey materialKey = new GlobalKey();
       await tester.pumpWidget(
@@ -273,6 +313,25 @@ void main() {
       ));
     });
 
+    testWidgets('card with shapeBorder and elevation', (WidgetTester tester) async {
+      final GlobalKey materialKey = new GlobalKey();
+      await tester.pumpWidget(
+        new Material(
+          key: materialKey,
+          type: MaterialType.card,
+          borderRadius: const BorderRadius.all(const Radius.circular(5.0)),
+          shapeBorder: const StadiumBorder(),
+          elevation: 5.0,
+          child: const SizedBox(width: 100.0, height: 100.0),
+        )
+      );
+
+      expect(find.byKey(materialKey), rendersOnPhysicalShape(
+          shapeBorder: const StadiumBorder(),
+          elevation: 5.0,
+      ));
+    });
+
     testWidgets('circle', (WidgetTester tester) async {
       final GlobalKey materialKey = new GlobalKey();
       await tester.pumpWidget(
@@ -286,6 +345,24 @@ void main() {
 
       expect(find.byKey(materialKey), rendersOnPhysicalModel(
           shape: BoxShape.circle,
+          elevation: 0.0,
+      ));
+    });
+
+    testWidgets('circle overridden by shapeBorder', (WidgetTester tester) async {
+      final GlobalKey materialKey = new GlobalKey();
+      await tester.pumpWidget(
+        new Material(
+          key: materialKey,
+          type: MaterialType.circle,
+          shapeBorder: const StadiumBorder(),
+          child: const SizedBox(width: 100.0, height: 100.0),
+          color: const Color(0xFF0000FF),
+        )
+      );
+
+      expect(find.byKey(materialKey), rendersOnPhysicalShape(
+          shapeBorder: const StadiumBorder(),
           elevation: 0.0,
       ));
     });
@@ -324,6 +401,26 @@ void main() {
       expect(find.byKey(materialKey), rendersOnPhysicalModel(
           shape: BoxShape.rectangle,
           borderRadius: const BorderRadius.all(const Radius.circular(6.0)),
+          elevation: 4.0,
+      ));
+    });
+
+    testWidgets('button with elevation and shapeBorder', (WidgetTester tester) async {
+      final GlobalKey materialKey = new GlobalKey();
+      await tester.pumpWidget(
+        new Material(
+          key: materialKey,
+          type: MaterialType.button,
+          child: const SizedBox(width: 100.0, height: 100.0),
+          color: const Color(0xFF0000FF),
+          borderRadius: const BorderRadius.all(const Radius.circular(6.0)),
+          shapeBorder: const StadiumBorder(),
+          elevation: 4.0,
+        )
+      );
+
+      expect(find.byKey(materialKey), rendersOnPhysicalShape(
+          shapeBorder: const StadiumBorder(),
           elevation: 4.0,
       ));
     });

--- a/packages/flutter/test/rendering/proxy_box_test.dart
+++ b/packages/flutter/test/rendering/proxy_box_test.dart
@@ -100,24 +100,24 @@ void main() {
     test('shape change triggers repaint', () {
       final RenderPhysicalShape root = new RenderPhysicalShape(
         color: const Color(0xffff00ff),
-        clipper: const ShapeBorderClipper(shapeBorder: const CircleBorder()),
+        clipper: const ShapeBorderClipper(shape: const CircleBorder()),
       );
       layout(root, phase: EnginePhase.composite);
       expect(root.debugNeedsPaint, isFalse);
 
       // Same shape, no repaint.
-      root.clipper = const ShapeBorderClipper(shapeBorder: const CircleBorder());
+      root.clipper = const ShapeBorderClipper(shape: const CircleBorder());
       expect(root.debugNeedsPaint, isFalse);
 
       // Different shape triggers repaint.
-      root.clipper = const ShapeBorderClipper(shapeBorder: const StadiumBorder());
+      root.clipper = const ShapeBorderClipper(shape: const StadiumBorder());
       expect(root.debugNeedsPaint, isTrue);
     });
 
     test('compositing on non-Fuchsia', () {
       final RenderPhysicalShape root = new RenderPhysicalShape(
         color: const Color(0xffff00ff),
-        clipper: const ShapeBorderClipper(shapeBorder: const CircleBorder()),
+        clipper: const ShapeBorderClipper(shape: const CircleBorder()),
       );
       layout(root, phase: EnginePhase.composite);
       expect(root.needsCompositing, isFalse);

--- a/packages/flutter/test/rendering/recording_canvas.dart
+++ b/packages/flutter/test/rendering/recording_canvas.dart
@@ -111,6 +111,15 @@ class TestRecordingPaintingContext implements PaintingContext {
   }
 
   @override
+  void pushClipPath(bool needsCompositing, Offset offset, Rect bounds, Path clipPath, PaintingContextCallback painter) {
+    canvas
+      ..save()
+      ..clipPath(clipPath.shift(offset));
+    painter(this, offset);
+    canvas.restore();
+  }
+
+  @override
   void pushTransform(bool needsCompositing, Offset offset, Matrix4 transform, PaintingContextCallback painter) {
     canvas.save();
     canvas.transform(transform.storage);

--- a/packages/flutter/test/widgets/basic_test.dart
+++ b/packages/flutter/test/widgets/basic_test.dart
@@ -12,14 +12,14 @@ void main() {
     testWidgets('properties', (WidgetTester tester) async {
       await tester.pumpWidget(
         const PhysicalShape(
-          clipper: const ShapeBorderClipper(shapeBorder: const CircleBorder()),
+          clipper: const ShapeBorderClipper(shape: const CircleBorder()),
           elevation: 2.0,
           color: const Color(0xFF0000FF),
           shadowColor: const Color(0xFF00FF00),
         )
       );
       final RenderPhysicalShape renderObject = tester.renderObject(find.byType(PhysicalShape));
-      expect(renderObject.clipper, const ShapeBorderClipper(shapeBorder: const CircleBorder()));
+      expect(renderObject.clipper, const ShapeBorderClipper(shape: const CircleBorder()));
       expect(renderObject.color, const Color(0xFF0000FF));
       expect(renderObject.shadowColor, const Color(0xFF00FF00));
       expect(renderObject.elevation, 2.0);
@@ -28,7 +28,7 @@ void main() {
     testWidgets('hit test', (WidgetTester tester) async {
       await tester.pumpWidget(
         new PhysicalShape(
-          clipper: const ShapeBorderClipper(shapeBorder: const CircleBorder()),
+          clipper: const ShapeBorderClipper(shape: const CircleBorder()),
           elevation: 2.0,
           color: const Color(0xFF0000FF),
           shadowColor: const Color(0xFF00FF00),

--- a/packages/flutter_test/lib/src/matchers.dart
+++ b/packages/flutter_test/lib/src/matchers.dart
@@ -795,9 +795,9 @@ Matcher clipsWithBoundingRRect({@required BorderRadius borderRadius}) {
 
 /// Asserts that a [Finder] locates a single object whose root RenderObject
 /// is a [RenderClipPath] with a [ShapeBorderClipper] that clips to
-/// [shapeBorder].
-Matcher clipsWithShapeBorder({@required ShapeBorder shapeBorder}) {
-  return new _ClipsWithShapeBorder(shapeBorder: shapeBorder);
+/// [shape].
+Matcher clipsWithShapeBorder({@required ShapeBorder shape}) {
+  return new _ClipsWithShapeBorder(shape: shape);
 }
 
 /// Asserts that a [Finder] locates a single object whose root RenderObject
@@ -831,15 +831,15 @@ Matcher rendersOnPhysicalModel({
 
 /// Asserts that a [Finder] locates a single object whose root RenderObject
 /// is [RenderPhysicalShape] that uses a [ShapeBorderClipper] that clips to
-/// [shapeBorder] as its clipper.
+/// [shape] as its clipper.
 /// If [elevation] is non null asserts that [RenderPhysicalShape.elevation] is
 /// equal to [elevation].
 Matcher rendersOnPhysicalShape({
-  ShapeBorder shapeBorder,
+  ShapeBorder shape,
   double elevation,
 }) {
   return new _RendersOnPhysicalShape(
-    shapeBorder: shapeBorder,
+    shape: shape,
     elevation: elevation,
   );
 }
@@ -937,17 +937,17 @@ class _RendersOnPhysicalModel extends _MatchRenderObject<RenderPhysicalShape, Re
   }
 
   bool assertRoundedRectangle(ShapeBorderClipper shapeClipper, BorderRadius borderRadius, Map<dynamic, dynamic> matchState) {
-      if (shapeClipper.shapeBorder.runtimeType != RoundedRectangleBorder)
-        return failWithDescription(matchState, 'had shape border: ${shapeClipper.shapeBorder}');
-      final RoundedRectangleBorder border = shapeClipper.shapeBorder;
+      if (shapeClipper.shape.runtimeType != RoundedRectangleBorder)
+        return failWithDescription(matchState, 'had shape border: ${shapeClipper.shape}');
+      final RoundedRectangleBorder border = shapeClipper.shape;
       if (border.borderRadius != borderRadius)
         return failWithDescription(matchState, 'had borderRadius: ${border.borderRadius}');
       return true;
   }
 
   bool assertCircle(ShapeBorderClipper shapeClipper, Map<dynamic, dynamic> matchState) {
-      if (shapeClipper.shapeBorder.runtimeType != CircleBorder)
-        return failWithDescription(matchState, 'had shape border: ${shapeClipper.shapeBorder}');
+      if (shapeClipper.shape.runtimeType != CircleBorder)
+        return failWithDescription(matchState, 'had shape border: ${shapeClipper.shape}');
       return true;
   }
 
@@ -966,11 +966,11 @@ class _RendersOnPhysicalModel extends _MatchRenderObject<RenderPhysicalShape, Re
 
 class _RendersOnPhysicalShape extends _MatchRenderObject<RenderPhysicalShape, Null> {
   const _RendersOnPhysicalShape({
-    this.shapeBorder,
+    this.shape,
     this.elevation,
   });
 
-  final ShapeBorder shapeBorder;
+  final ShapeBorder shape;
   final double elevation;
 
   @override
@@ -979,8 +979,8 @@ class _RendersOnPhysicalShape extends _MatchRenderObject<RenderPhysicalShape, Nu
       return failWithDescription(matchState, 'clipper was: ${renderObject.clipper}');
     final ShapeBorderClipper shapeClipper = renderObject.clipper;
 
-    if (shapeClipper.shapeBorder != shapeBorder)
-      return failWithDescription(matchState, 'shapeBorder was: ${shapeClipper.shapeBorder}');
+    if (shapeClipper.shape != shape)
+      return failWithDescription(matchState, 'shape was: ${shapeClipper.shape}');
 
     if (elevation != null && renderObject.elevation != elevation)
       return failWithDescription(matchState, 'had elevation: ${renderObject.elevation}');
@@ -995,7 +995,7 @@ class _RendersOnPhysicalShape extends _MatchRenderObject<RenderPhysicalShape, Nu
 
   @override
   Description describe(Description description) {
-    description.add('renders on a physical model with shapeBorder $shapeBorder');
+    description.add('renders on a physical model with shape $shape');
     if (elevation != null)
       description.add(' with elevation $elevation');
     return description;
@@ -1017,9 +1017,9 @@ class _ClipsWithBoundingRect extends _MatchRenderObject<RenderClipPath, RenderCl
     if (renderObject.clipper.runtimeType != ShapeBorderClipper)
       return failWithDescription(matchState, 'clipper was: ${renderObject.clipper}');
     final ShapeBorderClipper shapeClipper = renderObject.clipper;
-    if (shapeClipper.shapeBorder.runtimeType != RoundedRectangleBorder)
-      return failWithDescription(matchState, 'shapeBorder was: ${shapeClipper.shapeBorder}');
-    final RoundedRectangleBorder border = shapeClipper.shapeBorder;
+    if (shapeClipper.shape.runtimeType != RoundedRectangleBorder)
+      return failWithDescription(matchState, 'shape was: ${shapeClipper.shape}');
+    final RoundedRectangleBorder border = shapeClipper.shape;
     if (border.borderRadius != BorderRadius.zero)
       return failWithDescription(matchState, 'borderRadius was: ${border.borderRadius}');
     return true;
@@ -1052,9 +1052,9 @@ class _ClipsWithBoundingRRect extends _MatchRenderObject<RenderClipPath, RenderC
     if (renderObject.clipper.runtimeType != ShapeBorderClipper)
       return failWithDescription(matchState, 'clipper was: ${renderObject.clipper}');
     final ShapeBorderClipper shapeClipper = renderObject.clipper;
-    if (shapeClipper.shapeBorder.runtimeType != RoundedRectangleBorder)
-      return failWithDescription(matchState, 'shapeBorder was: ${shapeClipper.shapeBorder}');
-    final RoundedRectangleBorder border = shapeClipper.shapeBorder;
+    if (shapeClipper.shape.runtimeType != RoundedRectangleBorder)
+      return failWithDescription(matchState, 'shape was: ${shapeClipper.shape}');
+    final RoundedRectangleBorder border = shapeClipper.shape;
     if (border.borderRadius != borderRadius)
       return failWithDescription(matchState, 'had borderRadius: ${border.borderRadius}');
     return true;
@@ -1066,17 +1066,17 @@ class _ClipsWithBoundingRRect extends _MatchRenderObject<RenderClipPath, RenderC
 }
 
 class _ClipsWithShapeBorder extends _MatchRenderObject<RenderClipPath, Null> {
-  const _ClipsWithShapeBorder({@required this.shapeBorder});
+  const _ClipsWithShapeBorder({@required this.shape});
 
-  final ShapeBorder shapeBorder;
+  final ShapeBorder shape;
 
   @override
   bool renderObjectMatchesM(Map<dynamic, dynamic> matchState, RenderClipPath renderObject) {
     if (renderObject.clipper.runtimeType != ShapeBorderClipper)
       return failWithDescription(matchState, 'clipper was: ${renderObject.clipper}');
     final ShapeBorderClipper shapeClipper = renderObject.clipper;
-    if (shapeClipper.shapeBorder != shapeBorder)
-      return failWithDescription(matchState, 'shapeBorder was: ${shapeClipper.shapeBorder}');
+    if (shapeClipper.shape != shape)
+      return failWithDescription(matchState, 'shape was: ${shapeClipper.shape}');
     return true;
   }
 
@@ -1088,5 +1088,5 @@ class _ClipsWithShapeBorder extends _MatchRenderObject<RenderClipPath, Null> {
 
   @override
   Description describe(Description description) =>
-    description.add('clips with shapeBorder: $shapeBorder');
+    description.add('clips with shape: $shape');
 }


### PR DESCRIPTION
For backward compatibility we keep supporting specifying the shape as a
combination of MaterialType and borderRadius, and we just use that as a
default when shapeBorder is null.

To cleanup the implementation if shapeBorder was not specified we just
translate the specified shape to a shapeBorder internally.
I benchmarked paint, layout and hit testing, with the specialized shape
clippers vs. the equivalent path clippers and did not see any
significant performance difference.

For testing, I extended the clippers/physicalShape matchers to match either the
specialized shape or the equivalent shape specified with a path.