### PR TITLE
fix rare flutter_tools logging crash in daemon mode

### DIFF
--- a/packages/flutter_tools/bin/fuchsia_builder.dart
+++ b/packages/flutter_tools/bin/fuchsia_builder.dart
@@ -15,7 +15,6 @@ import '../lib/src/base/io.dart';
 import '../lib/src/base/logger.dart';
 import '../lib/src/base/os.dart';
 import '../lib/src/base/platform.dart';
-import '../lib/src/base/terminal.dart';
 import '../lib/src/cache.dart';
 import '../lib/src/disabled_usage.dart';
 import '../lib/src/flx.dart';
@@ -50,7 +49,6 @@ Future<Null> main(List<String> args) async {
     context.putIfAbsent(Platform, () => const LocalPlatform());
     context.putIfAbsent(FileSystem, () => const LocalFileSystem());
     context.putIfAbsent(ProcessManager, () => const LocalProcessManager());
-    context.putIfAbsent(AnsiTerminal, () => new AnsiTerminal());
     context.putIfAbsent(Logger, () => new StdoutLogger());
     context.putIfAbsent(Cache, () => new Cache());
     context.putIfAbsent(Config, () => new Config());

--- a/packages/flutter_tools/bin/fuchsia_tester.dart
+++ b/packages/flutter_tools/bin/fuchsia_tester.dart
@@ -17,7 +17,6 @@ import '../lib/src/base/io.dart';
 import '../lib/src/base/logger.dart';
 import '../lib/src/base/os.dart';
 import '../lib/src/base/platform.dart';
-import '../lib/src/base/terminal.dart';
 import '../lib/src/cache.dart';
 import '../lib/src/dart/package_map.dart';
 import '../lib/src/disabled_usage.dart';
@@ -46,7 +45,6 @@ Future<Null> main(List<String> args) async {
     context.putIfAbsent(Platform, () => const LocalPlatform());
     context.putIfAbsent(FileSystem, () => const LocalFileSystem());
     context.putIfAbsent(ProcessManager, () => const LocalProcessManager());
-    context.putIfAbsent(AnsiTerminal, () => new AnsiTerminal());
     context.putIfAbsent(Logger, () => new StdoutLogger());
     context.putIfAbsent(Cache, () => new Cache());
     context.putIfAbsent(Config, () => new Config());

--- a/packages/flutter_tools/lib/runner.dart
+++ b/packages/flutter_tools/lib/runner.dart
@@ -18,7 +18,6 @@ import 'src/base/io.dart';
 import 'src/base/logger.dart';
 import 'src/base/platform.dart';
 import 'src/base/process.dart';
-import 'src/base/terminal.dart';
 import 'src/base/utils.dart';
 import 'src/cache.dart';
 import 'src/crash_reporting.dart';
@@ -68,7 +67,6 @@ Future<int> run(
     context.putIfAbsent(Platform, () => const LocalPlatform());
     context.putIfAbsent(FileSystem, () => const LocalFileSystem());
     context.putIfAbsent(ProcessManager, () => const LocalProcessManager());
-    context.putIfAbsent(AnsiTerminal, () => new AnsiTerminal());
     context.putIfAbsent(Logger, () => platform.isWindows ? new WindowsStdoutLogger() : new StdoutLogger());
     context.putIfAbsent(Config, () => new Config());
 

--- a/packages/flutter_tools/lib/src/base/terminal.dart
+++ b/packages/flutter_tools/lib/src/base/terminal.dart
@@ -15,7 +15,7 @@ import 'platform.dart';
 final AnsiTerminal _kAnsiTerminal = new AnsiTerminal();
 
 AnsiTerminal get terminal {
-  return context == null
+  return (context == null || context[AnsiTerminal] == null)
       ? _kAnsiTerminal
       : context[AnsiTerminal];
 }

--- a/packages/flutter_tools/lib/src/commands/daemon.dart
+++ b/packages/flutter_tools/lib/src/commands/daemon.dart
@@ -5,8 +5,6 @@
 import 'dart:async';
 import 'dart:convert';
 
-import 'package:flutter_tools/src/base/terminal.dart';
-
 import '../android/android_device.dart';
 import '../base/common.dart';
 import '../base/context.dart';
@@ -793,7 +791,6 @@ class AppInstance {
     _logger ??= new _AppRunLogger(domain, this, parent: logToStdout ? logger : null);
 
     final AppContext appContext = new AppContext();
-    appContext.setVariable(AnsiTerminal, new AnsiTerminal());
     appContext.setVariable(Logger, _logger);
     return appContext.runInZone(method);
   }

--- a/packages/flutter_tools/lib/src/commands/daemon.dart
+++ b/packages/flutter_tools/lib/src/commands/daemon.dart
@@ -5,6 +5,8 @@
 import 'dart:async';
 import 'dart:convert';
 
+import 'package:flutter_tools/src/base/terminal.dart';
+
 import '../android/android_device.dart';
 import '../base/common.dart';
 import '../base/context.dart';
@@ -791,6 +793,7 @@ class AppInstance {
     _logger ??= new _AppRunLogger(domain, this, parent: logToStdout ? logger : null);
 
     final AppContext appContext = new AppContext();
+    appContext.setVariable(AnsiTerminal, new AnsiTerminal());
     appContext.setVariable(Logger, _logger);
     return appContext.runInZone(method);
   }

--- a/packages/flutter_tools/test/src/context.dart
+++ b/packages/flutter_tools/test/src/context.dart
@@ -13,7 +13,6 @@ import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/os.dart';
 import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/base/port_scanner.dart';
-import 'package:flutter_tools/src/base/terminal.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/devfs.dart';
 import 'package:flutter_tools/src/device.dart';
@@ -42,7 +41,6 @@ typedef void ContextInitializer(AppContext testContext);
 
 void _defaultInitializeContext(AppContext testContext) {
   testContext
-    ..putIfAbsent(AnsiTerminal, () => new AnsiTerminal())
     ..putIfAbsent(DeviceManager, () => new MockDeviceManager())
     ..putIfAbsent(DevFSConfig, () => new DevFSConfig())
     ..putIfAbsent(Doctor, () => new MockDoctor())


### PR DESCRIPTION
Fixes #13993.  Implements the simpler solution described in [this comment](https://github.com/flutter/flutter/issues/13993#issuecomment-362087150), forcing `terminal` to return an AnsiTerminal in the case where context doesn't populate it. To be sure that this works, I removed manual population of AnsiTerminal from all the relevant places to make sure it would be obvious if the fallback didn't function.

I'm open to doing the larger refactor described, but it might take some time -- also open to other suggestions on how to accomplish this in a bulletproof manner.


