### PR TITLE
Fix devicelab tests broken by #14173

### DIFF
--- a/dev/devicelab/bin/tasks/flutter_gallery_instrumentation_test.dart
+++ b/dev/devicelab/bin/tasks/flutter_gallery_instrumentation_test.dart
@@ -21,7 +21,7 @@ Future<Null> main() async {
       await flutter('packages', options: <String>['get']);
       await flutter('clean');
       await flutter('build', options: <String>['apk', '--target', 'test/live_smoketest.dart']);
-      final String androidStudioPath = grep('Android Studio at', from: await evalFlutter('doctor')).first.split(' ').last;
+      final String androidStudioPath = grep('Android Studio at', from: await evalFlutter('doctor', options: <String>['-v'])).first.split(' ').last;
       await exec('./tool/run_instrumentation_test.sh', <String>[], environment: <String, String>{
         'JAVA_HOME': '$androidStudioPath/jre',
       });

--- a/dev/devicelab/bin/tasks/gradle_plugin_test.dart
+++ b/dev/devicelab/bin/tasks/gradle_plugin_test.dart
@@ -14,7 +14,7 @@ String javaHome;
 void main() {
   task(() async {
     section('Running flutter doctor to get JAVA_HOME');
-    final String flutterDoctor = await evalFlutter('doctor');
+    final String flutterDoctor = await evalFlutter('doctor', options: <String>['-v']);
     final RegExp javaHomeExtractor = new RegExp(r'Android Studio at (.*)');
     javaHome = javaHomeExtractor.firstMatch(flutterDoctor).group(1) + '/jre';
 


### PR DESCRIPTION
#14173 greatly condenses doctor output without -v, as intended.  This breaks parsers of that output.

https://flutter-dashboard.appspot.com/api/get-log?ownerKey=ahNzfmZsdXR0ZXItZGFzaGJvYXJkclgLEglDaGVja2xpc3QiOGZsdXR0ZXIvZmx1dHRlci8yNjEwMmM5MTIwZWJjMDFiNWM1ZTQ4YzQyYTAxZGE5ZjNlODQ5ZGFmDAsSBFRhc2sYgICAgICAqAoM

and

https://flutter-dashboard.appspot.com/api/get-log?ownerKey=ahNzfmZsdXR0ZXItZGFzaGJvYXJkclgLEglDaGVja2xpc3QiOGZsdXR0ZXIvZmx1dHRlci8yNjEwMmM5MTIwZWJjMDFiNWM1ZTQ4YzQyYTAxZGE5ZjNlODQ5ZGFmDAsSBFRhc2sYgICAgICAqAkM

should be fixed with this change.