### PR TITLE
Change sky_engine to use a sdk dependency

### DIFF
--- a/packages/flutter/pubspec.yaml
+++ b/packages/flutter/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   vector_math: 2.0.5
 
   sky_engine:
-    path: ../../bin/cache/pkg/sky_engine
+    sdk: flutter
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/13559

pub from dart sdk dev.19 now known how to use a SDK dependency to locate sky_engine inside `bin/cache/pkg/`, so we can avoid a hardcoded path in pubspec.