### PR TITLE
update doc styles for 'implementation' sections

### DIFF
--- a/dev/docs/styles.html
+++ b/dev/docs/styles.html
@@ -133,12 +133,9 @@
     font-weight: 100;
   }
 
-  /* Attempt to de-emphasise the source code section */
-  section.summary.source-code {
-    opacity: 0.3;
-  }
-  section.summary.source-code:hover {
-    opacity: 0.8;
+  /* address a style issue with the background of code sections */
+  code.hljs {
+    background: inherit;
   }
 
   footer {


### PR DESCRIPTION
- remove the use of partial transparency for the source code section; renaming from `Source` to `Implementation` hopefully makes it clear enough that this is the impl. of a method and not sample source (see https://github.com/flutter/flutter/pull/10215, https://github.com/flutter/flutter/issues/9377)
- fix an issue with having two nested background colors in code sections

For the 2nd issue, before:

<img width="377" alt="screen shot 2018-02-02 at 11 36 48 am" src="https://user-images.githubusercontent.com/1269969/35751612-08e96cce-080e-11e8-97c9-fe314f90e14c.png">

and after:

<img width="524" alt="screen shot 2018-02-02 at 11 36 41 am" src="https://user-images.githubusercontent.com/1269969/35751618-0efa188e-080e-11e8-84b2-d3014b212569.png">

@jcollins-g 