### PR TITLE
Fix InkRipple.cancel animation race

### DIFF
--- a/packages/flutter/lib/src/material/ink_ripple.dart
+++ b/packages/flutter/lib/src/material/ink_ripple.dart
@@ -199,9 +199,14 @@ class InkRipple extends InteractiveInkFeature {
   @override
   void cancel() {
     _fadeInController.stop();
-    _fadeOutController
-      ..value = 1.0 - _fadeInController.value
-      ..animateTo(1.0, duration: _kCancelDuration);
+    // Watch out: setting _fadeOutController's value to 1.0 would
+    // trigger a call to _handleAlphaStatusChanged() which would
+    // dispose _fadeOutController.
+    if (_fadeInController.value > 0.0) {
+      _fadeOutController
+        ..value = 1.0 - _fadeInController.value
+        ..animateTo(1.0, duration: _kCancelDuration);
+    }
   }
 
   void _handleAlphaStatusChanged(AnimationStatus status) {

--- a/packages/flutter/lib/src/material/ink_splash.dart
+++ b/packages/flutter/lib/src/material/ink_splash.dart
@@ -170,7 +170,7 @@ class InkSplash extends InteractiveInkFeature {
 
   @override
   void cancel() {
-    _alphaController.forward();
+    _alphaController?.forward();
   }
 
   void _handleAlphaStatusChanged(AnimationStatus status) {
@@ -182,6 +182,7 @@ class InkSplash extends InteractiveInkFeature {
   void dispose() {
     _radiusController.dispose();
     _alphaController.dispose();
+    _alphaController = null;
     super.dispose();
   }
 

--- a/packages/flutter/test/material/ink_paint_test.dart
+++ b/packages/flutter/test/material/ink_paint_test.dart
@@ -250,6 +250,7 @@ void main() {
   });
 
   testWidgets('Cancel an InkRipple that was disposed when its animation ended', (WidgetTester tester) async {
+    // Regression test for https://github.com/flutter/flutter/issues/14391
     await tester.pumpWidget(
       new Material(
         child: new Center(
@@ -269,13 +270,13 @@ void main() {
     final Offset tapDownOffset = tester.getTopLeft(find.byType(InkWell));
     final Offset inkWellCenter = tester.getCenter(find.byType(InkWell));
     await tester.tapAt(tapDownOffset);
-    await tester.pump(); // start gesture
+    await tester.pump(); // start splash
     await tester.pump(const Duration(milliseconds: 375)); // _kFadeOutDuration, in_ripple.dart
 
     final TestGesture gesture = await tester.startGesture(tapDownOffset);
     await tester.pump(); // start gesture
     await gesture.moveTo(const Offset(0.0, 0.0));
-    await gesture.up();
+    await gesture.up(); // generates a tap cancel
     await tester.pumpAndSettle();
   });
 }

--- a/packages/flutter/test/material/ink_paint_test.dart
+++ b/packages/flutter/test/material/ink_paint_test.dart
@@ -248,4 +248,34 @@ void main() {
 
     await gesture.up();
   });
+
+  testWidgets('Cancel an InkRipple that was disposed when its animation ended', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      new Material(
+        child: new Center(
+          child: new Container(
+            width: 100.0,
+            height: 100.0,
+            child: new InkWell(
+              onTap: () { },
+              radius: 100.0,
+              splashFactory: InkRipple.splashFactory,
+            ),
+          ),
+        ),
+      ),
+    );
+
+    final Offset tapDownOffset = tester.getTopLeft(find.byType(InkWell));
+    final Offset inkWellCenter = tester.getCenter(find.byType(InkWell));
+    await tester.tapAt(tapDownOffset);
+    await tester.pump(); // start gesture
+    await tester.pump(const Duration(milliseconds: 375)); // _kFadeOutDuration, in_ripple.dart
+
+    final TestGesture gesture = await tester.startGesture(tapDownOffset);
+    await tester.pump(); // start gesture
+    await gesture.moveTo(const Offset(0.0, 0.0));
+    await gesture.up();
+    await tester.pumpAndSettle();
+  });
 }

--- a/packages/flutter/test/material/ink_paint_test.dart
+++ b/packages/flutter/test/material/ink_paint_test.dart
@@ -268,7 +268,6 @@ void main() {
     );
 
     final Offset tapDownOffset = tester.getTopLeft(find.byType(InkWell));
-    final Offset inkWellCenter = tester.getCenter(find.byType(InkWell));
     await tester.tapAt(tapDownOffset);
     await tester.pump(); // start splash
     await tester.pump(const Duration(milliseconds: 375)); // _kFadeOutDuration, in_ripple.dart


### PR DESCRIPTION
Although difficult to reproduce interactively, it was possible for the `..value` part of this innocuous statement to cause _fadeOutController to be disposed before the `..animateTo` was reached.
```
      _fadeOutController
       ..value = 1.0 - _fadeInController.value // DISPOSE
       ..animateTo(1.0, duration: _kCancelDuration);
```

Fixes https://github.com/flutter/flutter/issues/14391