### PR TITLE
Fix scrolling of multiple SliverLists and SliverGrids

### DIFF
--- a/examples/flutter_gallery/lib/demo/shrine/shrine_home.dart
+++ b/examples/flutter_gallery/lib/demo/shrine/shrine_home.dart
@@ -84,9 +84,7 @@ class _ShrineGridLayout extends SliverGridLayout {
   }
 
   @override
-  double estimateMaxScrollOffset(int childCount) {
-    if (childCount == null)
-      return null;
+  double computeMaxScrollOffset(int childCount) {
     if (childCount == 0)
       return 0.0;
     final int rowCount = _rowAtIndex(childCount - 1) + 1;

--- a/packages/flutter/lib/src/rendering/sliver_fixed_extent_list.dart
+++ b/packages/flutter/lib/src/rendering/sliver_fixed_extent_list.dart
@@ -171,7 +171,6 @@ abstract class RenderSliverFixedExtentBoxAdaptor extends RenderSliverMultiBoxAda
         final double max = computeMaxScrollOffset(constraints, itemExtent);
         geometry = new SliverGeometry(
           scrollExtent: max,
-          paintExtent: 0.0,
           maxPaintExtent: max,
         );
         childManager.didFinishLayout();

--- a/packages/flutter/lib/src/rendering/sliver_fixed_extent_list.dart
+++ b/packages/flutter/lib/src/rendering/sliver_fixed_extent_list.dart
@@ -87,6 +87,11 @@ abstract class RenderSliverFixedExtentBoxAdaptor extends RenderSliverMultiBoxAda
   /// index.
   ///
   /// By default, defers to [RenderSliverBoxChildManager.estimateMaxScrollOffset].
+  ///
+  /// See also:
+  ///
+  ///  * [computeMaxScrollOffset], which is similar but must provide a precise
+  ///    value.
   @protected
   double estimateMaxScrollOffset(SliverConstraints constraints, {
     int firstIndex,
@@ -101,6 +106,31 @@ abstract class RenderSliverFixedExtentBoxAdaptor extends RenderSliverMultiBoxAda
       leadingScrollOffset: leadingScrollOffset,
       trailingScrollOffset: trailingScrollOffset,
     );
+  }
+
+  /// Called to obtain a precise measure of the total scrollable extents of this
+  /// object.
+  ///
+  /// Must return the precise total distance from the start of the child with
+  /// the earliest possible index to the end of the child with the last possible
+  /// index.
+  ///
+  /// This is used when no child is available for the index corresponding to the
+  /// current scroll offset, to determine the precise dimensions of the sliver.
+  /// It must return a precise value. It will not be called if the
+  /// [childManager] returns an infinite number of children for positive
+  /// indices.
+  ///
+  /// By default, multiplies the [itemExtent] by the number of children reported
+  /// by [RenderSliverBoxChildManager.childCount].
+  ///
+  /// See also:
+  ///
+  ///  * [estimateMaxScrollOffset], which is similar but may provide inaccurate
+  ///    values.
+  @protected
+  double computeMaxScrollOffset(SliverConstraints constraints, double itemExtent) {
+    return childManager.childCount * itemExtent;
   }
 
   @override
@@ -137,8 +167,13 @@ abstract class RenderSliverFixedExtentBoxAdaptor extends RenderSliverMultiBoxAda
 
     if (firstChild == null) {
       if (!addInitialChild(index: firstIndex, layoutOffset: indexToLayoutOffset(itemExtent, firstIndex))) {
-        // There are no children.
-        geometry = SliverGeometry.zero;
+        // There are either no children, or we are past the end of all our children.
+        final double max = computeMaxScrollOffset(constraints, itemExtent);
+        geometry = new SliverGeometry(
+          scrollExtent: max,
+          paintExtent: 0.0,
+          maxPaintExtent: max,
+        );
         childManager.didFinishLayout();
         return;
       }

--- a/packages/flutter/lib/src/rendering/sliver_grid.dart
+++ b/packages/flutter/lib/src/rendering/sliver_grid.dart
@@ -545,7 +545,6 @@ class RenderSliverGrid extends RenderSliverMultiBoxAdaptor {
         final double max = layout.computeMaxScrollOffset(childManager.childCount);
         geometry = new SliverGeometry(
           scrollExtent: max,
-          paintExtent: 0.0,
           maxPaintExtent: max,
         );
         childManager.didFinishLayout();

--- a/packages/flutter/lib/src/rendering/sliver_grid.dart
+++ b/packages/flutter/lib/src/rendering/sliver_grid.dart
@@ -115,9 +115,11 @@ abstract class SliverGridLayout {
   /// The size and position of the child with the given index.
   SliverGridGeometry getGeometryForChildIndex(int index);
 
-  /// An estimate of the scroll extent needed to fully display all the tiles if
-  /// there are `childCount` children in total.
-  double estimateMaxScrollOffset(int childCount);
+  /// The scroll extent needed to fully display all the tiles if there are
+  /// `childCount` children in total.
+  ///
+  /// The child count will never be null.
+  double computeMaxScrollOffset(int childCount);
 }
 
 /// A [SliverGridLayout] that uses equally sized and spaced tiles.
@@ -221,9 +223,8 @@ class SliverGridRegularTileLayout extends SliverGridLayout {
   }
 
   @override
-  double estimateMaxScrollOffset(int childCount) {
-    if (childCount == null)
-      return null;
+  double computeMaxScrollOffset(int childCount) {
+    assert(childCount != null);
     final int mainAxisCount = ((childCount - 1) ~/ crossAxisCount) + 1;
     final double mainAxisSpacing = mainAxisStride - childMainAxisExtent;
     return mainAxisStride * mainAxisCount - mainAxisSpacing;
@@ -539,10 +540,14 @@ class RenderSliverGrid extends RenderSliverMultiBoxAdaptor {
     double trailingScrollOffset = firstChildGridGeometry.trailingScrollOffset;
 
     if (firstChild == null) {
-      if (!addInitialChild(index: firstIndex,
-          layoutOffset: firstChildGridGeometry.scrollOffset)) {
-        // There are no children.
-        geometry = SliverGeometry.zero;
+      if (!addInitialChild(index: firstIndex, layoutOffset: firstChildGridGeometry.scrollOffset)) {
+        // There are either no children, or we are past the end of all our children.
+        final double max = layout.computeMaxScrollOffset(childManager.childCount);
+        geometry = new SliverGeometry(
+          scrollExtent: max,
+          paintExtent: 0.0,
+          maxPaintExtent: max,
+        );
         childManager.didFinishLayout();
         return;
       }

--- a/packages/flutter/lib/src/rendering/sliver_multi_box_adaptor.dart
+++ b/packages/flutter/lib/src/rendering/sliver_multi_box_adaptor.dart
@@ -43,6 +43,10 @@ abstract class RenderSliverBoxChildManager {
   /// the [RenderSliverMultiBoxAdaptor] object if they were not created during
   /// this frame and have not yet been updated during this frame. It is not
   /// valid to add any other children to this render object.
+  ///
+  /// If this method does not create a child for a given `index` greater than or
+  /// equal to zero, then [computeMaxScrollOffset] must be able to return a
+  /// precise value.
   void createChild(int index, { @required RenderBox after });
 
   /// Remove the given child from the child list.
@@ -67,6 +71,18 @@ abstract class RenderSliverBoxChildManager {
     double leadingScrollOffset,
     double trailingScrollOffset,
   });
+
+  /// Called to obtain a precise measure of the total number of children.
+  ///
+  /// Must return the number that is one greater than the greatest `index` for
+  /// which `createChild` will actually create a child.
+  ///
+  /// This is used when [createChild] cannot add a child for a positive `index`,
+  /// to determine the precise dimensions of the sliver. It must return an
+  /// accurate and precise non-null value. It will not be called if
+  /// [createChild] is always able to create a child (e.g. for an infinite
+  /// list).
+  int get childCount;
 
   /// Called during [RenderSliverMultiBoxAdaptor.adoptChild].
   ///

--- a/packages/flutter/test/rendering/slivers_block_test.dart
+++ b/packages/flutter/test/rendering/slivers_block_test.dart
@@ -53,6 +53,9 @@ class TestRenderSliverBoxChildManager extends RenderSliverBoxChildManager {
   }
 
   @override
+  int get childCount => children.length;
+
+  @override
   void didAdoptChild(RenderBox child) {
     assert(_currentlyUpdatingChildIndex != null);
     final SliverMultiBoxAdaptorParentData childParentData = child.parentData;

--- a/packages/flutter/test/widgets/grid_view_test.dart
+++ b/packages/flutter/test/widgets/grid_view_test.dart
@@ -453,7 +453,4 @@ void main() {
     expect(tester.getTopLeft(find.byKey(target)), const Offset(600.0, 0.0));
     expect(tester.getBottomRight(find.byKey(target)), const Offset(800.0, 200.0));
   });
-
-  // TODO(ianh): can you tap a grid cell that is slightly off the bottom of the screen?
-  // (try it with the flutter_gallery Grid demo)
 }

--- a/packages/flutter/test/widgets/slivers_test.dart
+++ b/packages/flutter/test/widgets/slivers_test.dart
@@ -114,4 +114,85 @@ void main() {
       const Offset(0.0, 600.0),
     ], <bool>[false, false, true, true, false]);
   });
+
+  testWidgets('Multiple grids and lists', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      new Center(
+        child: new SizedBox(
+          width: 44.4,
+          height: 60.0,
+          child: new Directionality(
+            textDirection: TextDirection.ltr,
+            child: new CustomScrollView(
+              slivers: <Widget>[
+                new SliverList(
+                  delegate: new SliverChildListDelegate(
+                    <Widget>[
+                      new Container(height: 22.2, child: const Text('TOP')),
+                      new Container(height: 22.2),
+                      new Container(height: 22.2),
+                    ],
+                  ),
+                ),
+                new SliverFixedExtentList(
+                  itemExtent: 22.2,
+                  delegate: new SliverChildListDelegate(
+                    <Widget>[
+                      new Container(),
+                      new Container(child: const Text('A')),
+                      new Container(),
+                    ],
+                  ),
+                ),
+                new SliverGrid(
+                  gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+                    crossAxisCount: 2,
+                  ),
+                  delegate: new SliverChildListDelegate(
+                    <Widget>[
+                      new Container(),
+                      new Container(child: const Text('B')),
+                      new Container(),
+                    ],
+                  ),
+                ),
+                new SliverList(
+                  delegate: new SliverChildListDelegate(
+                    <Widget>[
+                      new Container(height: 22.2),
+                      new Container(height: 22.2),
+                      new Container(height: 22.2, child: const Text('BOTTOM')),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+    final TestGesture gesture = await tester.startGesture(const Offset(400.0, 300.0));
+    expect(find.text('TOP'), findsOneWidget);
+    expect(find.text('A'), findsNothing);
+    expect(find.text('B'), findsNothing);
+    expect(find.text('BOTTOM'), findsNothing);
+    await gesture.moveBy(const Offset(0.0, -70.0));
+    await tester.pump();
+    expect(find.text('TOP'), findsNothing);
+    expect(find.text('A'), findsOneWidget);
+    expect(find.text('B'), findsNothing);
+    expect(find.text('BOTTOM'), findsNothing);
+    await gesture.moveBy(const Offset(0.0, -70.0));
+    await tester.pump();
+    expect(find.text('TOP'), findsNothing);
+    expect(find.text('A'), findsNothing);
+    expect(find.text('B'), findsOneWidget);
+    expect(find.text('BOTTOM'), findsNothing);
+    await gesture.moveBy(const Offset(0.0, -70.0));
+    await tester.pump();
+    expect(find.text('TOP'), findsNothing);
+    expect(find.text('A'), findsNothing);
+    expect(find.text('B'), findsNothing);
+    expect(find.text('BOTTOM'), findsOneWidget);
+  });
 }


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/11548

Has a backward incompatible change:

> The `SliverGridLayout.estimateMaxScrollOffset` method has been replaced by the `SliverGridLayout.computeMaxScrollOffset` method. This new method must report an accurate value, not just an estimate. This was necessary to fix a bug where a finite `SliverGrid` could not handle being scrolled off the top of the screen (because we had no way to determine how much content it had).
>
> For similar reasons, the `RenderSliverBoxChildManager` interface has a new getter, `childCount`, which must return a non-null value if `createChild` can return null. In practice, it is unusual to implement this interface, so this should have no effect. It is more common to implement the widgets-layer equivalent, `SliverChildDelegate`. This interface already had an `estimatedChildCount` getter. The getter continues to exist, though its semantics have been adjusted a little to require that the returned value be accurate if the `build` method on the delegate ever returns null.

