### PR TITLE
Add flutter doctor support for VS Code

### DIFF
--- a/packages/flutter_tools/lib/src/doctor.dart
+++ b/packages/flutter_tools/lib/src/doctor.dart
@@ -23,6 +23,7 @@ import 'globals.dart';
 import 'ios/ios_workflow.dart';
 import 'ios/plist_utils.dart';
 import 'version.dart';
+import 'vscode/vscode_validator.dart';
 
 Doctor get doctor => context[Doctor];
 
@@ -43,6 +44,7 @@ class Doctor {
       final List<DoctorValidator> ideValidators = <DoctorValidator>[];
       ideValidators.addAll(AndroidStudioValidator.allValidators);
       ideValidators.addAll(IntelliJValidator.installedValidators);
+      ideValidators.addAll(VsCodeValidator.installedValidators);
       if (ideValidators.isNotEmpty)
         _validators.addAll(ideValidators);
       else

--- a/packages/flutter_tools/lib/src/vscode/vscode.dart
+++ b/packages/flutter_tools/lib/src/vscode/vscode.dart
@@ -9,34 +9,6 @@ import '../base/file_system.dart';
 import '../base/platform.dart';
 import '../base/version.dart';
 
-// VS Code layout:
-
-// macOS:
-//   /Applications/Visual Studio Code.app/Contents/
-//   /Applications/Visual Studio Code - Insiders.app/Contents/
-//   $HOME/Applications/Visual Studio Code.app/Contents/
-//   $HOME/Applications/Visual Studio Code - Insiders.app/Contents/
-// macOS Extensions:
-//   $HOME/.vscode/extensions
-//   $HOME/.vscode-insiders/extensions
-
-// Windows:
-//   $programfiles(x86)\Microsoft VS Code
-//   $programfiles(x86)\Microsoft VS Code Insiders
-// TODO: Confirm these are correct for 64bit
-//   $programfiles\Microsoft VS Code
-//   $programfiles\Microsoft VS Code Insiders
-// Windows Extensions:
-//   $HOME/.vscode/extensions
-//   $HOME/.vscode-insiders/extensions
-
-// Linux:
-//   /usr/share/code/bin/code
-//   /usr/share/code-insiders/bin/code-insiders
-// Linux Extensions:
-//   $HOME/.vscode/extensions
-//   $HOME/.vscode-insiders/extensions
-
 const String extensionIdentifier = 'Dart-Code.dart-code';
 
 // Include VS Code insiders (useful for debugging).
@@ -82,6 +54,14 @@ class VsCode {
       return <VsCode>[];
   }
 
+  // macOS:
+  //   /Applications/Visual Studio Code.app/Contents/
+  //   /Applications/Visual Studio Code - Insiders.app/Contents/
+  //   $HOME/Applications/Visual Studio Code.app/Contents/
+  //   $HOME/Applications/Visual Studio Code - Insiders.app/Contents/
+  // macOS Extensions:
+  //   $HOME/.vscode/extensions
+  //   $HOME/.vscode-insiders/extensions
   static List<VsCode> _installedMacOS() {
     final Map<String, String> stable = <String, String>{
       fs.path.join('/Applications', 'Visual Studio Code.app', 'Contents'):
@@ -100,6 +80,15 @@ class VsCode {
     return _findInstalled(stable, insiders);
   }
 
+  // Windows:
+  //   $programfiles(x86)\Microsoft VS Code
+  //   $programfiles(x86)\Microsoft VS Code Insiders
+  // TODO: Confirm these are correct for 64bit
+  //   $programfiles\Microsoft VS Code
+  //   $programfiles\Microsoft VS Code Insiders
+  // Windows Extensions:
+  //   $HOME/.vscode/extensions
+  //   $HOME/.vscode-insiders/extensions
   static List<VsCode> _installedWindows() {
     final String progFiles86 = platform.environment['programfiles(x86)'];
     final String progFiles = platform.environment['programfiles'];
@@ -117,6 +106,12 @@ class VsCode {
     return _findInstalled(stable, insiders);
   }
 
+  // Linux:
+  //   /usr/share/code/bin/code
+  //   /usr/share/code-insiders/bin/code-insiders
+  // Linux Extensions:
+  //   $HOME/.vscode/extensions
+  //   $HOME/.vscode-insiders/extensions
   static List<VsCode> _installedLinux() {
     return _findInstalled(
       <String, String>{'/usr/share/code': '.vscode'},

--- a/packages/flutter_tools/lib/src/vscode/vscode.dart
+++ b/packages/flutter_tools/lib/src/vscode/vscode.dart
@@ -153,6 +153,12 @@ class VsCode {
       return;
     }
 
+    // If the extensions directory doesn't exist at all, the listSync()
+    // below will fail, so just bail out early.
+    if (!fs.isDirectorySync(extensionDirectory)) {
+      return;
+    }
+
     // Check for presence of extension.
     final Iterable<FileSystemEntity> extensionDirs = fs
         .directory(extensionDirectory)

--- a/packages/flutter_tools/lib/src/vscode/vscode.dart
+++ b/packages/flutter_tools/lib/src/vscode/vscode.dart
@@ -9,12 +9,12 @@ import '../base/file_system.dart';
 import '../base/platform.dart';
 import '../base/version.dart';
 
-const String extensionIdentifier = 'Dart-Code.dart-code';
-
 // Include VS Code insiders (useful for debugging).
 const bool _includeInsiders = false;
 
 class VsCode {
+  static const String extensionIdentifier = 'Dart-Code.dart-code';
+
   VsCode._(this.directory, this.extensionDirectory, { Version version })
       : this.version = version ?? Version.unknown {
     _init();
@@ -167,7 +167,7 @@ class VsCode {
 
       _isValid = true;
       extensionVersion = new Version.parse(
-          extensionDir.basename.substring('Dart-Code.dart-code-'.length));
+          extensionDir.basename.substring('$extensionIdentifier-'.length));
       validationMessages.add('Dart Code extension version $extensionVersion');
     }
   }

--- a/packages/flutter_tools/lib/src/vscode/vscode.dart
+++ b/packages/flutter_tools/lib/src/vscode/vscode.dart
@@ -1,0 +1,177 @@
+// Copyright 2018 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:convert';
+
+import '../base/common.dart';
+import '../base/file_system.dart';
+import '../base/platform.dart';
+import '../base/version.dart';
+import '../ios/plist_utils.dart';
+
+// VS Code layout:
+
+// macOS:
+//   /Applications/Visual Studio Code.app/Contents/
+//   /Applications/Visual Studio Code - Insiders.app/Contents/
+//   $HOME/Applications/Visual Studio Code.app/Contents/
+//   $HOME/Applications/Visual Studio Code - Insiders.app/Contents/
+// macOS Extensions:
+//   $HOME/.vscode/extensions
+//   $HOME/.vscode-insiders/extensions
+
+// Windows:
+//   $programfiles(x86)\Microsoft VS Code
+//   $programfiles(x86)\Microsoft VS Code Insiders
+// TODO: Confirm these are correct for 64bit
+//   $programfiles\Microsoft VS Code
+//   $programfiles\Microsoft VS Code Insiders
+// Windows Extensions:
+//   $HOME/.vscode/extensions
+//   $HOME/.vscode-insiders/extensions
+
+// Linux:
+//   /usr/share/code/bin/code
+//   /usr/share/code-insiders/bin/code-insiders
+// Linux Extensions:
+//   $HOME/.vscode/extensions
+//   $HOME/.vscode-insiders/extensions
+
+const String extensionIdentifier = 'Dart-Code.dart-code';
+
+const bool _includeInsiders =
+    false; // Include VS Code insiders (useful for debugging).
+
+class VsCode {
+  VsCode(this.directory, this.dataFolderName, {Version version})
+      : this.version = version ?? Version.unknown {
+    _init();
+  }
+
+  final String directory;
+  final String dataFolderName;
+  final Version version;
+
+  bool _isValid = false;
+  Version extensionVersion;
+  final List<String> _validationMessages = <String>[];
+
+  factory VsCode.fromFolder(String installPath, String dataFolderName) {
+    final String packageJsonPath =
+        fs.path.join(installPath, 'resources', 'app', 'package.json');
+    final String versionString = _getVersionFromPackageJson(packageJsonPath);
+    Version version;
+    if (versionString != null) version = new Version.parse(versionString);
+    return new VsCode(installPath, dataFolderName, version: version);
+  }
+
+  bool get isValid => _isValid;
+
+  List<String> get validationMessages => _validationMessages;
+
+  static List<VsCode> allInstalled() {
+    if (platform.isMacOS)
+      return _installedMacOS();
+    else if (platform.isWindows)
+      return _installedWindows();
+    else if (platform.isLinux)
+      return _installedLinux();
+    else
+      // VS Code isn't supported on the other platforms.
+      return [];
+  }
+
+  static List<VsCode> _installedMacOS() {
+    final stable = {
+      fs.path.join('/Applications', 'Visual Studio Code.app', 'Contents'):
+          '.vscode',
+      fs.path.join(homeDirPath, 'Applications', 'Visual Studio Code.app',
+          'Contents'): '.vscode'
+    };
+    final insiders = {
+      fs.path.join(
+              '/Applications', 'Visual Studio Code - Insiders.app', 'Contents'):
+          '.vscode-insiders',
+      fs.path.join(homeDirPath, 'Applications',
+          'Visual Studio Code - Insiders.app', 'Contents'): '.vscode-insiders'
+    };
+
+    return _findInstalled(stable, insiders);
+  }
+
+  static List<VsCode> _installedWindows() {
+    final progFiles86 = platform.environment['programfiles(x86)'];
+    final progFiles = platform.environment['programfiles'];
+
+    final stable = {
+      fs.path.join(progFiles86, 'Microsoft VS Code'): '.vscode',
+      fs.path.join(progFiles, 'Microsoft VS Code'): '.vscode'
+    };
+    final insiders = {
+      fs.path.join(progFiles86, 'Microsoft VS Code Insiders'):
+          '.vscode-insiders',
+      fs.path.join(progFiles, 'Microsoft VS Code Insiders'): '.vscode-insiders'
+    };
+
+    return _findInstalled(stable, insiders);
+  }
+
+  static List<VsCode> _installedLinux() {
+    return _findInstalled({'/usr/share/code': '.vscode'},
+        {'/usr/share/code-insiders': '.vscode-insiders'});
+  }
+
+  static List<VsCode> _findInstalled(
+      Map<String, String> stable, Map<String, String> insiders) {
+    final allPaths = new Map<String, String>();
+    allPaths.addAll(stable);
+    if (_includeInsiders) allPaths.addAll(insiders);
+
+    final List<VsCode> results = <VsCode>[];
+
+    for (var directory in allPaths.keys) {
+      if (fs.directory(directory).existsSync())
+        results.add(new VsCode.fromFolder(directory, allPaths[directory]));
+    }
+
+    return results;
+  }
+
+  void _init() {
+    _isValid = false;
+    _validationMessages.clear();
+
+    if (!fs.isDirectorySync(directory)) {
+      _validationMessages.add('VS Code not found at $directory');
+      return;
+    }
+
+    // Check for presence of extension.
+    final extensionFolders = fs
+        .directory(fs.path.join(homeDirPath, dataFolderName, 'extensions'))
+        .listSync()
+        .where((d) => fs.isDirectorySync(d.path))
+        .where((d) => d.basename.startsWith(extensionIdentifier));
+
+    if (extensionFolders.isNotEmpty) {
+      final extensionFolder = extensionFolders.first;
+
+      _isValid = true;
+      extensionVersion = new Version.parse(
+          extensionFolder.basename.substring('Dart-Code.dart-code-'.length));
+      validationMessages.add('Dart Code extension version $extensionVersion');
+    }
+  }
+
+  @override
+  String toString() =>
+      'VS Code ($version)${(extensionVersion != Version.unknown ? ', Dart Code ($extensionVersion)' : '')}';
+
+  static String _getVersionFromPackageJson(String packageJsonPath) {
+    if (!fs.isFileSync(packageJsonPath)) return null;
+    final jsonString = fs.file(packageJsonPath).readAsStringSync();
+    Map json = JSON.decode(jsonString);
+    return json['version'];
+  }
+}

--- a/packages/flutter_tools/lib/src/vscode/vscode.dart
+++ b/packages/flutter_tools/lib/src/vscode/vscode.dart
@@ -39,11 +39,11 @@ import '../base/version.dart';
 
 const String extensionIdentifier = 'Dart-Code.dart-code';
 
-const bool _includeInsiders =
-    false; // Include VS Code insiders (useful for debugging).
+// Include VS Code insiders (useful for debugging).
+const bool _includeInsiders = false;
 
 class VsCode {
-  VsCode._(this.directory, this.extensionDirectory, {Version version})
+  VsCode._(this.directory, this.extensionDirectory, { Version version })
       : this.version = version ?? Version.unknown {
     _init();
   }

--- a/packages/flutter_tools/lib/src/vscode/vscode.dart
+++ b/packages/flutter_tools/lib/src/vscode/vscode.dart
@@ -17,8 +17,6 @@ class VsCode {
 
   VsCode._(this.directory, this.extensionDirectory, { Version version })
       : this.version = version ?? Version.unknown {
-    _isValid = false;
-    _validationMessages.clear();
 
     if (!fs.isDirectorySync(directory)) {
       _validationMessages.add('VS Code not found at $directory');
@@ -35,7 +33,7 @@ class VsCode {
     final Iterable<FileSystemEntity> extensionDirs = fs
         .directory(extensionDirectory)
         .listSync()
-        .where((FileSystemEntity d) => fs.isDirectorySync(d.path))
+        .where((FileSystemEntity d) => d is Directory)
         .where(
             (FileSystemEntity d) => d.basename.startsWith(extensionIdentifier));
 
@@ -43,9 +41,9 @@ class VsCode {
       final FileSystemEntity extensionDir = extensionDirs.first;
 
       _isValid = true;
-      extensionVersion = new Version.parse(
+      _extensionVersion = new Version.parse(
           extensionDir.basename.substring('$extensionIdentifier-'.length));
-      validationMessages.add('Dart Code extension version $extensionVersion');
+      _validationMessages.add('Dart Code extension version $_extensionVersion');
     }
   }
 
@@ -54,7 +52,7 @@ class VsCode {
   final Version version;
 
   bool _isValid = false;
-  Version extensionVersion;
+  Version _extensionVersion;
   final List<String> _validationMessages = <String>[];
 
   factory VsCode.fromDirectory(String installPath, String extensionDirectory) {
@@ -69,7 +67,7 @@ class VsCode {
 
   bool get isValid => _isValid;
 
-  List<String> get validationMessages => _validationMessages;
+  Iterable<String> get validationMessages => _validationMessages;
 
   static List<VsCode> allInstalled() {
     if (platform.isMacOS)
@@ -170,7 +168,7 @@ class VsCode {
 
   @override
   String toString() =>
-      'VS Code ($version)${(extensionVersion != Version.unknown ? ', Dart Code ($extensionVersion)' : '')}';
+      'VS Code ($version)${(_extensionVersion != Version.unknown ? ', Dart Code ($_extensionVersion)' : '')}';
 
   static String _getVersionFromPackageJson(String packageJsonPath) {
     if (!fs.isFileSync(packageJsonPath))

--- a/packages/flutter_tools/lib/src/vscode/vscode.dart
+++ b/packages/flutter_tools/lib/src/vscode/vscode.dart
@@ -43,27 +43,27 @@ const bool _includeInsiders =
     false; // Include VS Code insiders (useful for debugging).
 
 class VsCode {
-  VsCode._(this.directory, this.extensionFolder, {Version version})
+  VsCode._(this.directory, this.extensionDirectory, {Version version})
       : this.version = version ?? Version.unknown {
     _init();
   }
 
   final String directory;
-  final String extensionFolder;
+  final String extensionDirectory;
   final Version version;
 
   bool _isValid = false;
   Version extensionVersion;
   final List<String> _validationMessages = <String>[];
 
-  factory VsCode.fromFolder(String installPath, String extensionFolder) {
+  factory VsCode.fromDirectory(String installPath, String extensionDirectory) {
     final String packageJsonPath =
         fs.path.join(installPath, 'resources', 'app', 'package.json');
     final String versionString = _getVersionFromPackageJson(packageJsonPath);
     Version version;
     if (versionString != null)
       version = new Version.parse(versionString);
-    return new VsCode._(installPath, extensionFolder, version: version);
+    return new VsCode._(installPath, extensionDirectory, version: version);
   }
 
   bool get isValid => _isValid;
@@ -135,9 +135,9 @@ class VsCode {
 
     for (String directory in allPaths.keys) {
       if (fs.directory(directory).existsSync()) {
-        final String extensionFolder =
+        final String extensionDirectory =
             fs.path.join(homeDirPath, allPaths[directory], 'extensions');
-        results.add(new VsCode.fromFolder(directory, extensionFolder));
+        results.add(new VsCode.fromDirectory(directory, extensionDirectory));
       }
     }
 
@@ -154,19 +154,19 @@ class VsCode {
     }
 
     // Check for presence of extension.
-    final Iterable<FileSystemEntity> extensionFolders = fs
-        .directory(extensionFolder)
+    final Iterable<FileSystemEntity> extensionDirs = fs
+        .directory(extensionDirectory)
         .listSync()
         .where((FileSystemEntity d) => fs.isDirectorySync(d.path))
         .where(
             (FileSystemEntity d) => d.basename.startsWith(extensionIdentifier));
 
-    if (extensionFolders.isNotEmpty) {
-      final FileSystemEntity extensionFolder = extensionFolders.first;
+    if (extensionDirs.isNotEmpty) {
+      final FileSystemEntity extensionDir = extensionDirs.first;
 
       _isValid = true;
       extensionVersion = new Version.parse(
-          extensionFolder.basename.substring('Dart-Code.dart-code-'.length));
+          extensionDir.basename.substring('Dart-Code.dart-code-'.length));
       validationMessages.add('Dart Code extension version $extensionVersion');
     }
   }

--- a/packages/flutter_tools/lib/src/vscode/vscode.dart
+++ b/packages/flutter_tools/lib/src/vscode/vscode.dart
@@ -8,7 +8,6 @@ import '../base/common.dart';
 import '../base/file_system.dart';
 import '../base/platform.dart';
 import '../base/version.dart';
-import '../ios/plist_utils.dart';
 
 // VS Code layout:
 
@@ -62,7 +61,8 @@ class VsCode {
         fs.path.join(installPath, 'resources', 'app', 'package.json');
     final String versionString = _getVersionFromPackageJson(packageJsonPath);
     Version version;
-    if (versionString != null) version = new Version.parse(versionString);
+    if (versionString != null)
+      version = new Version.parse(versionString);
     return new VsCode(installPath, dataFolderName, version: version);
   }
 
@@ -79,17 +79,17 @@ class VsCode {
       return _installedLinux();
     else
       // VS Code isn't supported on the other platforms.
-      return [];
+      return <VsCode>[];
   }
 
   static List<VsCode> _installedMacOS() {
-    final stable = {
+    final Map<String, String> stable = <String, String>{
       fs.path.join('/Applications', 'Visual Studio Code.app', 'Contents'):
           '.vscode',
       fs.path.join(homeDirPath, 'Applications', 'Visual Studio Code.app',
           'Contents'): '.vscode'
     };
-    final insiders = {
+    final Map<String, String> insiders = <String, String>{
       fs.path.join(
               '/Applications', 'Visual Studio Code - Insiders.app', 'Contents'):
           '.vscode-insiders',
@@ -101,14 +101,14 @@ class VsCode {
   }
 
   static List<VsCode> _installedWindows() {
-    final progFiles86 = platform.environment['programfiles(x86)'];
-    final progFiles = platform.environment['programfiles'];
+    final String progFiles86 = platform.environment['programfiles(x86)'];
+    final String progFiles = platform.environment['programfiles'];
 
-    final stable = {
+    final Map<String, String> stable = <String, String>{
       fs.path.join(progFiles86, 'Microsoft VS Code'): '.vscode',
       fs.path.join(progFiles, 'Microsoft VS Code'): '.vscode'
     };
-    final insiders = {
+    final Map<String, String> insiders = <String, String>{
       fs.path.join(progFiles86, 'Microsoft VS Code Insiders'):
           '.vscode-insiders',
       fs.path.join(progFiles, 'Microsoft VS Code Insiders'): '.vscode-insiders'
@@ -118,19 +118,22 @@ class VsCode {
   }
 
   static List<VsCode> _installedLinux() {
-    return _findInstalled({'/usr/share/code': '.vscode'},
-        {'/usr/share/code-insiders': '.vscode-insiders'});
+    return _findInstalled(
+      <String, String>{'/usr/share/code': '.vscode'},
+      <String, String>{'/usr/share/code-insiders': '.vscode-insiders'}
+    );
   }
 
   static List<VsCode> _findInstalled(
       Map<String, String> stable, Map<String, String> insiders) {
-    final allPaths = new Map<String, String>();
+    final Map<String, String> allPaths = <String, String>{};
     allPaths.addAll(stable);
-    if (_includeInsiders) allPaths.addAll(insiders);
+    if (_includeInsiders)
+      allPaths.addAll(insiders);
 
     final List<VsCode> results = <VsCode>[];
 
-    for (var directory in allPaths.keys) {
+    for (String directory in allPaths.keys) {
       if (fs.directory(directory).existsSync())
         results.add(new VsCode.fromFolder(directory, allPaths[directory]));
     }
@@ -148,14 +151,14 @@ class VsCode {
     }
 
     // Check for presence of extension.
-    final extensionFolders = fs
+    final Iterable<FileSystemEntity> extensionFolders = fs
         .directory(fs.path.join(homeDirPath, dataFolderName, 'extensions'))
         .listSync()
-        .where((d) => fs.isDirectorySync(d.path))
-        .where((d) => d.basename.startsWith(extensionIdentifier));
+        .where((FileSystemEntity d) => fs.isDirectorySync(d.path))
+        .where((FileSystemEntity d) => d.basename.startsWith(extensionIdentifier));
 
     if (extensionFolders.isNotEmpty) {
-      final extensionFolder = extensionFolders.first;
+      final FileSystemEntity extensionFolder = extensionFolders.first;
 
       _isValid = true;
       extensionVersion = new Version.parse(
@@ -169,9 +172,10 @@ class VsCode {
       'VS Code ($version)${(extensionVersion != Version.unknown ? ', Dart Code ($extensionVersion)' : '')}';
 
   static String _getVersionFromPackageJson(String packageJsonPath) {
-    if (!fs.isFileSync(packageJsonPath)) return null;
-    final jsonString = fs.file(packageJsonPath).readAsStringSync();
-    Map json = JSON.decode(jsonString);
+    if (!fs.isFileSync(packageJsonPath))
+      return null;
+    final String jsonString = fs.file(packageJsonPath).readAsStringSync();
+    final Map<String, String> json = JSON.decode(jsonString);
     return json['version'];
   }
 }

--- a/packages/flutter_tools/lib/src/vscode/vscode_validator.dart
+++ b/packages/flutter_tools/lib/src/vscode/vscode_validator.dart
@@ -9,6 +9,8 @@ import '../doctor.dart';
 import 'vscode.dart';
 
 class VsCodeValidator extends DoctorValidator {
+  static const String extensionMarketplaceUrl =
+    'https://marketplace.visualstudio.com/items?itemName=Dart-Code.dart-code';
   final VsCode _vsCode;
 
   VsCodeValidator(this._vsCode) : super('VS Code');
@@ -36,7 +38,7 @@ class VsCodeValidator extends DoctorValidator {
       messages.addAll(_vsCode.validationMessages
           .map((String m) => new ValidationMessage.error(m)));
       messages.add(new ValidationMessage(
-          'Dart Code extension not installed; install from\nhttps://marketplace.visualstudio.com/items?itemName=Dart-Code.dart-code'));
+          'Dart Code extension not installed; install from\n$extensionMarketplaceUrl'));
     }
 
     return new ValidationResult(type, messages, statusInfo: vsCodeVersionText);

--- a/packages/flutter_tools/lib/src/vscode/vscode_validator.dart
+++ b/packages/flutter_tools/lib/src/vscode/vscode_validator.dart
@@ -1,0 +1,44 @@
+// Copyright 2018 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+
+import '../base/version.dart';
+import '../doctor.dart';
+import 'vscode.dart';
+
+class VsCodeValidator extends DoctorValidator {
+  final VsCode _vsCode;
+
+  VsCodeValidator(this._vsCode) : super('VS Code');
+
+  static Iterable<DoctorValidator> get installedValidators {
+    return VsCode
+        .allInstalled()
+        .map((VsCode vsCode) => new VsCodeValidator(vsCode));
+  }
+
+  @override
+  Future<ValidationResult> validate() async {
+    final List<ValidationMessage> messages = <ValidationMessage>[];
+    ValidationType type = ValidationType.missing;
+    final String vsCodeVersionText = _vsCode.version == Version.unknown
+        ? null
+        : 'version ${_vsCode.version}';
+    messages.add(new ValidationMessage('VS Code at ${_vsCode.directory}'));
+    if (_vsCode.isValid) {
+      type = ValidationType.installed;
+      messages.addAll(_vsCode.validationMessages
+          .map((String m) => new ValidationMessage(m)));
+    } else {
+      type = ValidationType.partial;
+      messages.addAll(_vsCode.validationMessages
+          .map((String m) => new ValidationMessage.error(m)));
+      messages.add(new ValidationMessage(
+          'Dart Code extension not installed; install from\nhttps://marketplace.visualstudio.com/items?itemName=Dart-Code.dart-code'));
+    }
+
+    return new ValidationResult(type, messages, statusInfo: vsCodeVersionText);
+  }
+}

--- a/packages/flutter_tools/test/commands/doctor_test.dart
+++ b/packages/flutter_tools/test/commands/doctor_test.dart
@@ -6,6 +6,8 @@ import 'dart:async';
 
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/doctor.dart';
+import 'package:flutter_tools/src/vscode/vscode.dart';
+import 'package:flutter_tools/src/vscode/vscode_validator.dart';
 import 'package:test/test.dart';
 
 import '../src/context.dart';
@@ -26,6 +28,36 @@ void main() {
           .firstWhere((ValidationMessage m) => m.message.startsWith('Flutter '));
       expect(message.message, contains('Flutter plugin version 0.1.3'));
       expect(message.message, contains('recommended minimum version'));
+    });
+
+    testUsingContext('vs code validator when both installed', () async {
+      final ValidationResult result = await VsCodeValidatorTestTargets.installedWithExtension.validate();
+      expect(result.type, ValidationType.installed);
+      expect(result.statusInfo, 'version 1.2.3');
+      expect(result.messages, hasLength(2));
+
+      ValidationMessage message = result.messages
+          .firstWhere((ValidationMessage m) => m.message.startsWith('VS Code '));
+      expect(message.message, 'VS Code at test/data/vscode/application');
+
+      message = result.messages
+          .firstWhere((ValidationMessage m) => m.message.startsWith('Dart Code '));
+      expect(message.message, 'Dart Code extension version 4.5.6');
+    });
+
+    testUsingContext('vs code validator when extension missing', () async {
+      final ValidationResult result = await VsCodeValidatorTestTargets.installedWithoutExtension.validate();
+      expect(result.type, ValidationType.partial);
+      expect(result.statusInfo, 'version 1.2.3');
+      expect(result.messages, hasLength(2));
+
+      ValidationMessage message = result.messages
+          .firstWhere((ValidationMessage m) => m.message.startsWith('VS Code '));
+      expect(message.message, 'VS Code at test/data/vscode/application');
+
+      message = result.messages
+          .firstWhere((ValidationMessage m) => m.message.startsWith('Dart Code '));
+      expect(message.message, startsWith('Dart Code extension not installed'));
     });
   });
 
@@ -236,4 +268,18 @@ class FakeQuietDoctor extends Doctor {
     }
     return _validators;
   }
+}
+
+class VsCodeValidatorTestTargets extends VsCodeValidator {
+  static final String validInstall = fs.path.join('test', 'data', 'vscode', 'application');
+  static final String validExtensions = fs.path.join('test', 'data', 'vscode', 'extensions');
+  static final String missingExtensions = fs.path.join('test', 'data', 'vscode', 'notExtensions');
+  VsCodeValidatorTestTargets._(String installDirectory, String extensionDirectory) 
+    : super(new VsCode.fromDirectory(installDirectory, extensionDirectory));
+
+  static VsCodeValidatorTestTargets get installedWithExtension =>
+    new VsCodeValidatorTestTargets._(validInstall, validExtensions);
+
+  static VsCodeValidatorTestTargets get installedWithoutExtension =>
+    new VsCodeValidatorTestTargets._(validInstall, missingExtensions);
 }

--- a/packages/flutter_tools/test/commands/doctor_test.dart
+++ b/packages/flutter_tools/test/commands/doctor_test.dart
@@ -38,7 +38,7 @@ void main() {
 
       ValidationMessage message = result.messages
           .firstWhere((ValidationMessage m) => m.message.startsWith('VS Code '));
-      expect(message.message, 'VS Code at test/data/vscode/application');
+      expect(message.message, 'VS Code at ${VsCodeValidatorTestTargets.validInstall}');
 
       message = result.messages
           .firstWhere((ValidationMessage m) => m.message.startsWith('Dart Code '));
@@ -53,7 +53,7 @@ void main() {
 
       ValidationMessage message = result.messages
           .firstWhere((ValidationMessage m) => m.message.startsWith('VS Code '));
-      expect(message.message, 'VS Code at test/data/vscode/application');
+      expect(message.message, 'VS Code at ${VsCodeValidatorTestTargets.validInstall}');
 
       message = result.messages
           .firstWhere((ValidationMessage m) => m.message.startsWith('Dart Code '));

--- a/packages/flutter_tools/test/data/vscode/application/resources/app/package.json
+++ b/packages/flutter_tools/test/data/vscode/application/resources/app/package.json
@@ -1,0 +1,4 @@
+{
+	"name": "fake-vs-code-install-for-tests",
+	"version": "1.2.3"
+}

--- a/packages/flutter_tools/test/data/vscode/extensions/Dart-Code.dart-code-4.5.6/fake-extension.txt
+++ b/packages/flutter_tools/test/data/vscode/extensions/Dart-Code.dart-code-4.5.6/fake-extension.txt
@@ -1,0 +1,1 @@
+This file is here only to ensure the parent folder is stored in Git to act as a fake extension folder for tests.


### PR DESCRIPTION
Fixes #14314.

Looks in default install locations on Mac, Linux and Windows for VS Code. If found, looks in default extension location to see if Dart Code is installed.

If VS Code is not installed, nothing is reported. If VS Code is installed without Dart Code, a warning is shown.

No VS Code (no change in output):

<img width="726" alt="screen shot 2018-02-05 at 15 08 38" src="https://user-images.githubusercontent.com/1078012/35811486-8423b9d8-0a86-11e8-94ea-aab7dbf51b03.png">

VS Code, no Dart Code:

<img width="741" alt="screen shot 2018-02-05 at 15 08 15" src="https://user-images.githubusercontent.com/1078012/35811508-8cd0fc44-0a86-11e8-8c9f-bee9bf8aa228.png">

VS Code, with Dart Code:

<img width="739" alt="screen shot 2018-02-05 at 15 07 59" src="https://user-images.githubusercontent.com/1078012/35811522-96481d16-0a86-11e8-9360-6eb5cb5e41f8.png">

I've tested this on Windows 10, Mac OS High Sierra, Ubuntu LTS but I'm rather nervous about the possibility of breaking `flutter doctor` so this may need additional testing before merging! I'm also unsure if/how we could add automated tests for this?

Feel free to nitpick; this is a learning exercise!

(cc @devoncarew @mit-mit)