### PR TITLE
Temporarily revert use of Iterable.castFrom().

### DIFF
--- a/packages/flutter/lib/src/widgets/nested_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/nested_scroll_view.dart
@@ -891,8 +891,6 @@ class _NestedScrollController extends ScrollController {
 
   Iterable<_NestedScrollPosition> get nestedPositions sync* {
     yield* positions;
-    // TODO(vegorov) use instance method version of castFrom when it is available.
-    //yield* Iterable.castFrom<ScrollPosition, _NestedScrollPosition>(positions);
   }
 }
 

--- a/packages/flutter/lib/src/widgets/nested_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/nested_scroll_view.dart
@@ -890,8 +890,9 @@ class _NestedScrollController extends ScrollController {
   }
 
   Iterable<_NestedScrollPosition> get nestedPositions sync* {
+    yield* positions;
     // TODO(vegorov) use instance method version of castFrom when it is available.
-    yield* Iterable.castFrom<ScrollPosition, _NestedScrollPosition>(positions);
+    //yield* Iterable.castFrom<ScrollPosition, _NestedScrollPosition>(positions);
   }
 }
 


### PR DESCRIPTION
Internal repo has not been rolled to latest Dart SDK yet.