### PR TITLE
Fix mismatched bracket in Xcode failure diagnostic

### DIFF
--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -386,13 +386,13 @@ Future<Null> diagnoseXcodeBuildFailure(
     printError(noProvisioningProfileInstruction, emphasis: true);
     return;
   }
+  // Make sure the user has specified one of:
+  // * DEVELOPMENT_TEAM (automatic signing)
+  // * PROVISIONING_PROFILE (manual signing)
   if (result.xcodeBuildExecution != null &&
       result.xcodeBuildExecution.buildForPhysicalDevice &&
-      // Make sure the user has specified one of:
-      // DEVELOPMENT_TEAM (automatic signing)
-      // PROVISIONING_PROFILE (manual signing)
-      !(app.buildSettings?.containsKey('DEVELOPMENT_TEAM')) == true
-          || app.buildSettings?.containsKey('PROVISIONING_PROFILE') == true) {
+      app.buildSettings != null &&
+      !<String>['DEVELOPMENT_TEAM', 'PROVISIONING_PROFILE'].any(app.buildSettings.containsKey)) {
     printError(noDevelopmentTeamInstruction, emphasis: true);
     return;
   }


### PR DESCRIPTION
When diagnosing a failed Xcode build, if neither the development team
(for automatic provisioning) nor the provisioning profile (for manual
provisioning) is set, display the appropriate error message. Previously,
this method would not output the appropriate error message if a
only a development team was set.