### PR TITLE
Mark iOS App ID param as required

### DIFF
--- a/packages/flutter_tools/lib/src/application_package.dart
+++ b/packages/flutter_tools/lib/src/application_package.dart
@@ -141,7 +141,7 @@ bool _isBundleDirectory(FileSystemEntity entity) =>
     entity is Directory && entity.path.endsWith('.app');
 
 abstract class IOSApp extends ApplicationPackage {
-  IOSApp({String projectBundleId}) : super(id: projectBundleId);
+  IOSApp({@required String projectBundleId}) : super(id: projectBundleId);
 
   /// Creates a new IOSApp from an existing IPA.
   factory IOSApp.fromIpa(String applicationBinary) {
@@ -239,7 +239,7 @@ class PrebuiltIOSApp extends IOSApp {
     this.ipaPath,
     this.bundleDir,
     this.bundleName,
-    String projectBundleId,
+    @required String projectBundleId,
   }) : super(projectBundleId: projectBundleId);
 
   @override

--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -398,7 +398,7 @@ Future<Null> diagnoseXcodeBuildFailure(
   }
   if (result.xcodeBuildExecution != null &&
       result.xcodeBuildExecution.buildForPhysicalDevice &&
-      app.id?.contains('com.example') ?? false) {
+      app.id.contains('com.example')) {
     printError('');
     printError('It appears that your application still contains the default signing identifier.');
     printError("Try replacing 'com.example' with your signing id in Xcode:");


### PR DESCRIPTION
Previously, the iOS ApplicationPackage subclasses did not mark the
bundleID constructor parameter as @required. This is passed up to the
ApplicationPackage constructor as the id parameter which is already
marked @required and is asserted to be non-null.