### PR TITLE
Radial splash and radio button update

### DIFF
--- a/packages/flutter/lib/src/material/constants.dart
+++ b/packages/flutter/lib/src/material/constants.dart
@@ -17,13 +17,13 @@ const double kTextTabBarHeight = 48.0;
 const Duration kThemeChangeDuration = const Duration(milliseconds: 200);
 
 /// The radius of a circular material ink response in logical pixels.
-const double kRadialReactionRadius = 24.0;
+const double kRadialReactionRadius = 20.0;
 
 /// The amount of time a circular material ink response should take to expand to its full size.
-const Duration kRadialReactionDuration = const Duration(milliseconds: 200);
+const Duration kRadialReactionDuration = const Duration(milliseconds: 100);
 
 /// The value of the alpha channel to use when drawing a circular material ink response.
-const int kRadialReactionAlpha = 0x33;
+const int kRadialReactionAlpha = 0x1F;
 
 /// The duration of the horizontal scroll animation that occurs when a tab is tapped.
 const Duration kTabScrollDuration = const Duration(milliseconds: 300);

--- a/packages/flutter/lib/src/material/radio.dart
+++ b/packages/flutter/lib/src/material/radio.dart
@@ -11,9 +11,8 @@ import 'debug.dart';
 import 'theme.dart';
 import 'toggleable.dart';
 
-const double _kDiameter = 16.0;
-const double _kOuterRadius = _kDiameter / 2.0;
-const double _kInnerRadius = 5.0;
+const double _kOuterRadius = 8.0;
+const double _kInnerRadius = 4.5;
 
 /// A material design radio button.
 ///


### PR DESCRIPTION
Small update to the appearance of the radio buttons and to the [radial splash](https://docs.flutter.io/flutter/material/RenderToggleable/paintRadialReaction.html).

The splash changes also affect checkbox, switch, and the slider thumb.

- Reduced splash radius from 24.0 to 20.0
- Reduced splash alpha from 0x33 to 1F (from 20% to 12%)
- Reduced splash duration from 200ms to 100ms
- Reduced radio button's inner filled circle radius from 5.0 to 4.5.

The current appearance of the radio buttons and the radial splash for checkbox and switch:
![old](https://user-images.githubusercontent.com/1377460/35838017-06d602e8-0a9e-11e8-9ffe-5555ce3dcfb8.png)

The new appearance:
![new](https://user-images.githubusercontent.com/1377460/35838021-0bd11a3a-0a9e-11e8-8dd7-40ca03518939.png)
