### PR TITLE
Apply media padding to Shrine demo

### DIFF
--- a/examples/flutter_gallery/lib/demo/shrine/shrine_home.dart
+++ b/examples/flutter_gallery/lib/demo/shrine/shrine_home.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:math' as math;
 
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
@@ -382,30 +383,43 @@ class _ShrineHomeState extends State<ShrineHome> {
   @override
   Widget build(BuildContext context) {
     final Product featured = _products.firstWhere((Product product) => product.featureDescription != null);
+    final EdgeInsets mediaPadding = MediaQuery.of(context).padding;
+    final EdgeInsets sliverPadding = new EdgeInsets.fromLTRB(
+        math.max(16.0, mediaPadding.left),
+        16.0,
+        math.max(16.0, mediaPadding.right),
+        math.max(16.0, mediaPadding.bottom),
+    );
     return new ShrinePage(
       scaffoldKey: _scaffoldKey,
       products: _products,
       shoppingCart: _shoppingCart,
-      body: new CustomScrollView(
-        slivers: <Widget>[
-          new SliverToBoxAdapter(
-            child: new _Heading(product: featured),
-          ),
-          new SliverPadding(
-            padding: const EdgeInsets.all(16.0),
-            sliver: new SliverGrid(
-              gridDelegate: gridDelegate,
-              delegate: new SliverChildListDelegate(
-                _products.map((Product product) {
-                  return new _ProductItem(
-                    product: product,
-                    onPressed: () { _showOrderPage(product); },
-                  );
-                }).toList(),
+      body: new MediaQuery.removePadding(
+        context: context,
+        removeLeft: true,
+        removeRight: true,
+        removeBottom: true,
+        child: new CustomScrollView(
+          slivers: <Widget>[
+            new SliverToBoxAdapter(
+              child: new _Heading(product: featured),
+            ),
+            new SliverPadding(
+              padding: sliverPadding,
+              sliver: new SliverGrid(
+                gridDelegate: gridDelegate,
+                delegate: new SliverChildListDelegate(
+                  _products.map((Product product) {
+                    return new _ProductItem(
+                      product: product,
+                      onPressed: () { _showOrderPage(product); },
+                    );
+                  }).toList(),
+                ),
               ),
             ),
-          ),
-        ],
+          ],
+        ),
       ),
     );
   }

--- a/examples/flutter_gallery/lib/demo/shrine/shrine_order.dart
+++ b/examples/flutter_gallery/lib/demo/shrine/shrine_order.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:math' as math;
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
@@ -259,6 +261,13 @@ class _OrderPageState extends State<OrderPage> {
 
   @override
   Widget build(BuildContext context) {
+    final EdgeInsets mediaPadding = MediaQuery.of(context).padding;
+    final EdgeInsets sliverPadding = new EdgeInsets.fromLTRB(
+      math.max(8.0, mediaPadding.left),
+      32.0,
+      math.max(8.0, mediaPadding.right),
+      math.max(8.0, mediaPadding.bottom),
+    );
     return new ShrinePage(
       scaffoldKey: scaffoldKey,
       products: widget.products,
@@ -278,40 +287,46 @@ class _OrderPageState extends State<OrderPage> {
           color: Colors.black,
         ),
       ),
-      body: new CustomScrollView(
-        slivers: <Widget>[
-          new SliverToBoxAdapter(
-            child: new _Heading(
-              product: widget.order.product,
-              quantity: currentOrder.quantity,
-              quantityChanged: (int value) { updateOrder(quantity: value); },
-            ),
-          ),
-          new SliverPadding(
-            padding: const EdgeInsets.fromLTRB(8.0, 32.0, 8.0, 8.0),
-            sliver: new SliverGrid(
-              gridDelegate: const SliverGridDelegateWithMaxCrossAxisExtent(
-                maxCrossAxisExtent: 248.0,
-                mainAxisSpacing: 8.0,
-                crossAxisSpacing: 8.0,
-              ),
-              delegate: new SliverChildListDelegate(
-                widget.products
-                  .where((Product product) => product != widget.order.product)
-                  .map((Product product) {
-                    return new Card(
-                      elevation: 1.0,
-                      child: new Image.asset(
-                        product.imageAsset,
-                        package: product.imageAssetPackage,
-                        fit: BoxFit.contain,
-                      ),
-                    );
-                  }).toList(),
+      body: new MediaQuery.removePadding(
+        context: context,
+        removeLeft: true,
+        removeRight: true,
+        removeBottom: true,
+        child: new CustomScrollView(
+          slivers: <Widget>[
+            new SliverToBoxAdapter(
+              child: new _Heading(
+                product: widget.order.product,
+                quantity: currentOrder.quantity,
+                quantityChanged: (int value) { updateOrder(quantity: value); },
               ),
             ),
-          ),
-        ],
+            new SliverPadding(
+              padding: sliverPadding,
+              sliver: new SliverGrid(
+                gridDelegate: const SliverGridDelegateWithMaxCrossAxisExtent(
+                  maxCrossAxisExtent: 248.0,
+                  mainAxisSpacing: 8.0,
+                  crossAxisSpacing: 8.0,
+                ),
+                delegate: new SliverChildListDelegate(
+                  widget.products
+                    .where((Product product) => product != widget.order.product)
+                    .map((Product product) {
+                      return new Card(
+                        elevation: 1.0,
+                        child: new Image.asset(
+                          product.imageAsset,
+                          package: product.imageAssetPackage,
+                          fit: BoxFit.contain,
+                        ),
+                      );
+                    }).toList(),
+                ),
+              ),
+            ),
+          ],
+        ),
       ),
     );
   }


### PR DESCRIPTION
Applies horizontal and bottom safe area insets to the Shrine demo in the
Gallery. Top insets are not applied due to the presence of the
omnipresent sliver app bar. Specifically, this ensures that the grid
cards are inset inside the iPhone X notch in horizontal mode, and that
the bottom of the grid is positioned above the iOS home indicator.