### PR TITLE
Add a method to NavigationState for adding routes below

### DIFF
--- a/packages/flutter/lib/src/widgets/navigator.dart
+++ b/packages/flutter/lib/src/widgets/navigator.dart
@@ -1075,6 +1075,40 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin {
     assert(() { _debugLocked = false; return true; }());
   }
 
+  /// Inserts the `newRoute` below the given `anchorRoute`.
+  ///
+  /// The route prior to the added route, if any, is notified (see
+  /// [Route.didChangeNext]). The route above the added route is also notified
+  /// (see [Route.didChangePrevious]). The navigator observer is not notified.
+  /// Returns a [Future] that completes to the `result` value passed to [pop]
+  /// when the inserted route is popped off the navigator.
+  Future<Object> insertBelow(Route<dynamic> anchorRoute, Route<dynamic> newRoute) {
+    assert(!_debugLocked);
+    assert(() { _debugLocked = true; return true; }());
+    assert(anchorRoute._navigator == this);
+    final int index = _history.indexOf(anchorRoute);
+    assert(index >= 0);
+    assert(newRoute != null);
+    assert(newRoute._navigator == null);
+    assert(newRoute.overlayEntries.isEmpty);
+    setState(() {
+      final Route<dynamic> previousRoute = index > 0 ? _history[index - 1] : null;
+      newRoute._navigator = this;
+      final OverlayEntry entryPoint = previousRoute != null
+        ? previousRoute.overlayEntries.last
+        : null;
+      newRoute.install(entryPoint);
+      _history.insert(index, newRoute);
+      newRoute.didChangePrevious(previousRoute);
+      newRoute.didChangeNext(anchorRoute);
+      if (previousRoute != null)
+        previousRoute.didChangeNext(newRoute);
+      anchorRoute.didChangePrevious(newRoute);
+    });
+    assert(() { _debugLocked = false; return true; }());
+    return newRoute.popped;
+  }
+
   /// Push the given route and then remove all the previous routes until the
   /// `predicate` returns true.
   ///

--- a/packages/flutter/lib/src/widgets/navigator.dart
+++ b/packages/flutter/lib/src/widgets/navigator.dart
@@ -1099,6 +1099,7 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin {
         : null;
       newRoute.install(entryPoint);
       _history.insert(index, newRoute);
+      newRoute.didReplace(null);
       newRoute.didChangePrevious(previousRoute);
       newRoute.didChangeNext(anchorRoute);
       if (previousRoute != null)

--- a/packages/flutter/lib/src/widgets/overlay.dart
+++ b/packages/flutter/lib/src/widgets/overlay.dart
@@ -275,13 +275,15 @@ class OverlayState extends State<Overlay> with TickerProviderStateMixin {
   /// Insert the given entry into the overlay.
   ///
   /// If [above] is non-null, the entry is inserted just above [above].
-  /// Otherwise, the entry is inserted on top.
-  void insert(OverlayEntry entry, { OverlayEntry above }) {
+  /// Otherwise, the entry is inserted on the top, unless [atBottom] is `true`.
+  void insert(OverlayEntry entry, { OverlayEntry above, bool atBottom: false }) {
     assert(entry._overlay == null);
     assert(above == null || (above._overlay == this && _entries.contains(above)));
     entry._overlay = this;
     setState(() {
-      final int index = above == null ? _entries.length : _entries.indexOf(above) + 1;
+      final int index = above == null
+        ? (atBottom ? 0 : _entries.length)
+        : _entries.indexOf(above) + 1;
       _entries.insert(index, entry);
     });
   }
@@ -289,8 +291,8 @@ class OverlayState extends State<Overlay> with TickerProviderStateMixin {
   /// Insert all the entries in the given iterable.
   ///
   /// If [above] is non-null, the entries are inserted just above [above].
-  /// Otherwise, the entries are inserted on top.
-  void insertAll(Iterable<OverlayEntry> entries, { OverlayEntry above }) {
+  /// Otherwise, the entry is inserted on the top, unless [atBottom] is `true`.
+  void insertAll(Iterable<OverlayEntry> entries, { OverlayEntry above, bool atBottom: false }) {
     assert(above == null || (above._overlay == this && _entries.contains(above)));
     if (entries.isEmpty)
       return;
@@ -299,7 +301,9 @@ class OverlayState extends State<Overlay> with TickerProviderStateMixin {
       entry._overlay = this;
     }
     setState(() {
-      final int index = above == null ? _entries.length : _entries.indexOf(above) + 1;
+      final int index = above == null
+        ? (atBottom ? 0 : _entries.length)
+        : _entries.indexOf(above) + 1;
       _entries.insertAll(index, entries);
     });
   }

--- a/packages/flutter/lib/src/widgets/overlay.dart
+++ b/packages/flutter/lib/src/widgets/overlay.dart
@@ -291,7 +291,7 @@ class OverlayState extends State<Overlay> with TickerProviderStateMixin {
   /// Insert all the entries in the given iterable.
   ///
   /// If [above] is non-null, the entries are inserted just above [above].
-  /// Otherwise, the entry is inserted on the top, unless [atBottom] is `true`.
+  /// Otherwise, the entries are inserted on the top, unless [atBottom] is `true`.
   void insertAll(Iterable<OverlayEntry> entries, { OverlayEntry above, bool atBottom: false }) {
     assert(above == null || (above._overlay == this && _entries.contains(above)));
     if (entries.isEmpty)

--- a/packages/flutter/lib/src/widgets/overlay.dart
+++ b/packages/flutter/lib/src/widgets/overlay.dart
@@ -275,7 +275,7 @@ class OverlayState extends State<Overlay> with TickerProviderStateMixin {
   /// Insert the given entry into the overlay.
   ///
   /// If [above] is non-null, the entry is inserted just above [above].
-  /// Otherwise, the entry is inserted on the top, unless [atBottom] is `true`.
+  /// Otherwise, the entry is inserted on top, unless [atBottom] is `true`.
   void insert(OverlayEntry entry, { OverlayEntry above, bool atBottom: false }) {
     assert(entry._overlay == null);
     assert(above == null || (above._overlay == this && _entries.contains(above)));
@@ -291,7 +291,7 @@ class OverlayState extends State<Overlay> with TickerProviderStateMixin {
   /// Insert all the entries in the given iterable.
   ///
   /// If [above] is non-null, the entries are inserted just above [above].
-  /// Otherwise, the entries are inserted on the top, unless [atBottom] is `true`.
+  /// Otherwise, the entries are inserted on top, unless [atBottom] is `true`.
   void insertAll(Iterable<OverlayEntry> entries, { OverlayEntry above, bool atBottom: false }) {
     assert(above == null || (above._overlay == this && _entries.contains(above)));
     if (entries.isEmpty)

--- a/packages/flutter/lib/src/widgets/routes.dart
+++ b/packages/flutter/lib/src/widgets/routes.dart
@@ -32,7 +32,7 @@ abstract class OverlayRoute<T> extends Route<T> {
   void install(OverlayEntry insertionPoint) {
     assert(_overlayEntries.isEmpty);
     _overlayEntries.addAll(createOverlayEntries());
-    navigator.overlay?.insertAll(_overlayEntries, above: insertionPoint);
+    navigator.overlay?.insertAll(_overlayEntries, above: insertionPoint, atBottom: true);
     super.install(insertionPoint);
   }
 

--- a/packages/flutter/test/widgets/navigator_test.dart
+++ b/packages/flutter/test/widgets/navigator_test.dart
@@ -605,6 +605,80 @@ void main() {
     expect(previousRoute, routes['/']);
   });
 
+  testWidgets('insertBelow', (WidgetTester tester) async {
+    await tester.pumpWidget(new MaterialApp(
+      home: const Material(child: const Text('home')),
+    ));
+    final Map<String, PageRouteBuilder<dynamic>> routes = <String, PageRouteBuilder<dynamic>> {
+      '/a': new PageRouteBuilder<Null>(pageBuilder: (_, __, ___) => const Material(child: const Text('a'))),
+      '/b': new PageRouteBuilder<Null>(pageBuilder: (_, __, ___) => const Material(child: const Text('b'))),
+      '/c': new PageRouteBuilder<Null>(pageBuilder: (_, __, ___) => const Material(child: const Text('c'))),
+      '/d': new PageRouteBuilder<Null>(pageBuilder: (_, __, ___) => const Material(child: const Text('d'))),
+    };
+
+    final NavigatorState navigator = tester.state(find.byType(Navigator));
+    navigator.pushReplacement(routes['/c']);
+    await tester.pumpAndSettle();
+
+    expect(find.text('a'), findsNothing);
+    expect(find.text('b'), findsNothing);
+    expect(find.text('c'), findsOneWidget);
+    expect(find.text('d'), findsNothing);
+
+    expect(routes['/a'].isActive, false);
+    expect(routes['/b'].isActive, false);
+    expect(routes['/c'].isActive, true);
+    expect(routes['/d'].isActive, false);
+    expect(routes['/c'].isFirst, true);
+    expect(routes['/c'].isCurrent, true);
+
+    navigator.insertBelow(routes['/c'], routes['/b']);
+    await tester.pumpAndSettle();
+
+    expect(find.text('a'), findsNothing);
+    expect(find.text('b'), findsNothing);
+    expect(find.text('c'), findsOneWidget);
+    expect(find.text('d'), findsNothing);
+
+    expect(routes['/a'].isActive, false);
+    expect(routes['/b'].isActive, true);
+    expect(routes['/c'].isActive, true);
+    expect(routes['/d'].isActive, false);
+    expect(routes['/b'].isFirst, true);
+    expect(routes['/c'].isFirst, false);
+    expect(routes['/c'].isCurrent, true);
+
+    navigator.insertBelow(routes['/b'], routes['/a']);
+    await tester.pumpAndSettle();
+
+    expect(find.text('a'), findsNothing);
+    expect(find.text('b'), findsNothing);
+    expect(find.text('c'), findsOneWidget);
+    expect(find.text('d'), findsNothing);
+
+    expect(routes['/a'].isActive, true);
+    expect(routes['/b'].isActive, true);
+    expect(routes['/c'].isActive, true);
+    expect(routes['/d'].isActive, false);
+    expect(routes['/a'].isFirst, true);
+    expect(routes['/c'].isCurrent, true);
+
+    navigator.push(routes['/d']);
+    await tester.pumpAndSettle();
+
+    expect(find.text('a'), findsNothing);
+    expect(find.text('b'), findsNothing);
+    expect(find.text('c'), findsNothing);
+    expect(find.text('d'), findsOneWidget);
+
+    expect(routes['/a'].isActive, true);
+    expect(routes['/b'].isActive, true);
+    expect(routes['/c'].isActive, true);
+    expect(routes['/d'].isActive, true);
+    expect(routes['/a'].isFirst, true);
+    expect(routes['/d'].isCurrent, true);
+  });
+
   testWidgets('remove a route whose value is awaited', (WidgetTester tester) async {
     Future<String> pageValue;
     final Map<String, WidgetBuilder> pageBuilders = <String, WidgetBuilder>{


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/12146

I also needed to modify `insert` and `insertAll` inside `OverlayState` adding an `atBottom` parameter, because it was not possible to use it as it was when you need to insert new overlays at index 0 once the first is inserted.