### PR TITLE
Reject requests for hot reload if a hot reload is already in progress.

### DIFF
--- a/dev/devicelab/bin/tasks/run_machine_concurrent_hot_reload.dart
+++ b/dev/devicelab/bin/tasks/run_machine_concurrent_hot_reload.dart
@@ -119,7 +119,9 @@ void main() {
       if (successResponses.length != 1)
         throw 'Did not receive the expected (exactly one) successful hot reload response.';
 
-      // TODO: Send another hot reload to ensure it works correctly
+      final dynamic hotReload3 = await sendRequest('app.restart', { 'appId': appId, 'fullRestart': false });
+      if (hotReload3['error'] != null)
+        throw 'Received an error response from a hot reload after all other hot reloads had completed.';
       
       sendRequest('app.stop', { 'appId': appId });
       final int result = await run.exitCode;

--- a/dev/devicelab/bin/tasks/run_machine_concurrent_hot_reload.dart
+++ b/dev/devicelab/bin/tasks/run_machine_concurrent_hot_reload.dart
@@ -90,7 +90,7 @@ void main() {
           'method': method,
           'params': params
         };
-        final String json = JSON.encode([req]);
+        final String json = JSON.encode(<Map<String, dynamic>>[req]);
         print('run:stdin: $json');
         run.stdin.writeln(json);
         final Map<String, dynamic> result = await response.future;
@@ -99,8 +99,8 @@ void main() {
       }
 
       print('test: sending two hot reloads...');
-      final Future<dynamic> hotReload1 = sendRequest('app.restart', { 'appId': appId, 'fullRestart': false });
-      final Future<dynamic> hotReload2 = sendRequest('app.restart', { 'appId': appId, 'fullRestart': false });
+      final Future<dynamic> hotReload1 = sendRequest('app.restart', <String, dynamic>{ 'appId': appId, 'fullRestart': false });
+      final Future<dynamic> hotReload2 = sendRequest('app.restart', <String, dynamic>{ 'appId': appId, 'fullRestart': false });
       final Future<List<dynamic>> reloadRequests = Future.wait<dynamic>(<Future<dynamic>>[hotReload1, hotReload2]);
       final dynamic results = await Future.any<dynamic>(<Future<dynamic>>[run.exitCode, reloadRequests]);
 
@@ -108,8 +108,8 @@ void main() {
         throw 'App crashed during hot reloads.';
       
       final List<dynamic> responses = results;
-      final List errorResponses = responses.where((dynamic r) => r['error'] != null).toList();
-      final List successResponses = responses.where((dynamic r) => r['error'] == null && r['result'] != null && r['result']['code'] == 0).toList();
+      final List<dynamic> errorResponses = responses.where((dynamic r) => r['error'] != null).toList();
+      final List<dynamic> successResponses = responses.where((dynamic r) => r['error'] == null && r['result'] != null && r['result']['code'] == 0).toList();
 
       if (errorResponses.length != 1)
         throw 'Did not receive the expected (exactly one) hot reload error response.';
@@ -119,11 +119,11 @@ void main() {
       if (successResponses.length != 1)
         throw 'Did not receive the expected (exactly one) successful hot reload response.';
 
-      final dynamic hotReload3 = await sendRequest('app.restart', { 'appId': appId, 'fullRestart': false });
+      final dynamic hotReload3 = await sendRequest('app.restart', <String, dynamic>{ 'appId': appId, 'fullRestart': false });
       if (hotReload3['error'] != null)
         throw 'Received an error response from a hot reload after all other hot reloads had completed.';
       
-      sendRequest('app.stop', { 'appId': appId });
+      sendRequest('app.stop', <String, dynamic>{ 'appId': appId });
       final int result = await run.exitCode;
       if (result != 0)
         throw 'Received unexpected exit code $result from run process.';

--- a/dev/devicelab/bin/tasks/run_machine_concurrent_hot_reload.dart
+++ b/dev/devicelab/bin/tasks/run_machine_concurrent_hot_reload.dart
@@ -1,0 +1,133 @@
+// Copyright (c) 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:path/path.dart' as path;
+import 'package:vm_service_client/vm_service_client.dart';
+
+import 'package:flutter_devicelab/framework/adb.dart';
+import 'package:flutter_devicelab/framework/framework.dart';
+import 'package:flutter_devicelab/framework/utils.dart';
+
+void main() {
+  Map<String, dynamic> parseFlutterResponse(String line) {
+    if (line.startsWith('[') && line.endsWith(']')) {
+      try {
+        return JSON.decode(line)[0];
+      } catch (e) {
+      // Not valid JSON, so likely some other output that was surrounded by [brackets]
+        return null;
+      }
+    }
+    return null;
+  }
+  
+  task(() async {
+    int vmServicePort;
+    String appId;
+
+    final Device device = await devices.workingDevice;
+    await device.unlock();
+    final Directory appDir = dir(path.join(flutterDirectory.path, 'dev/integration_tests/ui'));
+    await inDirectory(appDir, () async {
+      final Completer<Null> ready = new Completer<Null>();
+      bool ok;
+      print('run: starting...');
+      final Process run = await startProcess(
+        path.join(flutterDirectory.path, 'bin', 'flutter'),
+        <String>['run', '--machine', '--verbose', '-d', device.deviceId, 'lib/commands.dart'],
+      );
+      final StreamController<String> stdout = new StreamController<String>.broadcast();
+      run.stdout
+          .transform(UTF8.decoder)
+          .transform(const LineSplitter())
+          .listen((String line) {
+            print('run:stdout: $line');
+            stdout.add(line);
+            final dynamic json = parseFlutterResponse(line);
+            if (json != null && json['event'] == 'app.debugPort') {
+              vmServicePort = Uri.parse(json['params']['wsUri']).port;
+              print('service protocol connection available at port $vmServicePort');
+            }
+            else if (json != null && json['event'] == 'app.started') {
+              appId = json['params']['appId'];
+              print('run: ready!');
+              ready.complete();
+              ok ??= true;
+            }
+          });
+      run.stderr
+          .transform(UTF8.decoder)
+          .transform(const LineSplitter())
+          .listen((String line) {
+            stderr.writeln('run:stderr: $line');
+          });
+      run.exitCode.then((int exitCode) {
+        ok = false;
+      });
+      await Future.any<dynamic>(<Future<dynamic>>[ready.future, run.exitCode]);
+      if (!ok)
+        throw 'Failed to run test app.';
+
+      final VMServiceClient client = new VMServiceClient.connect('ws://localhost:$vmServicePort/ws');
+
+      int id = 1;
+      Future<Map<String, dynamic>> sendRequest(String method, dynamic params) async {
+        final int requestId = id++;
+        final Completer<Map<String, dynamic>> response = new Completer<Map<String, dynamic>>();
+        final StreamSubscription<String> responseSubscription = stdout.stream
+            .listen((String line) {
+              final Map<String, dynamic> json = parseFlutterResponse(line);
+              if (json != null && json['id'] == requestId)
+                response.complete(json);
+            });
+        final Map<String, dynamic> req = <String, dynamic>{
+          'id': requestId,
+          'method': method,
+          'params': params
+        };
+        final String json = JSON.encode([req]);
+        print('run:stdin: $json');
+        run.stdin.writeln(json);
+        final Map<String, dynamic> result = await response.future;
+        responseSubscription.cancel();
+        return result;
+      }
+
+      print('test: sending two hot reloads...');
+      final Future<dynamic> hotReload1 = sendRequest('app.restart', { 'appId': appId, 'fullRestart': false });
+      final Future<dynamic> hotReload2 = sendRequest('app.restart', { 'appId': appId, 'fullRestart': false });
+      final Future<List<dynamic>> reloadRequests = Future.wait<dynamic>(<Future<dynamic>>[hotReload1, hotReload2]);
+      final dynamic results = await Future.any<dynamic>(<Future<dynamic>>[run.exitCode, reloadRequests]);
+
+      if (!ok)
+        throw 'App crashed during hot reloads.';
+      
+      final List<dynamic> responses = results;
+      final List errorResponses = responses.where((dynamic r) => r['error'] != null).toList();
+      final List successResponses = responses.where((dynamic r) => r['error'] == null && r['result'] != null && r['result']['code'] == 0).toList();
+
+      if (errorResponses.length != 1)
+        throw 'Did not receive the expected (exactly one) hot reload error response.';
+      final String errorMessage = errorResponses.first['error'];
+      if (!errorMessage.contains('in progress'))
+        throw 'Error response was not that hot reload was in progress.';
+      if (successResponses.length != 1)
+        throw 'Did not receive the expected (exactly one) successful hot reload response.';
+
+      // TODO: Send another hot reload to ensure it works correctly
+      
+      sendRequest('app.stop', { 'appId': appId });
+      final int result = await run.exitCode;
+      if (result != 0)
+        throw 'Received unexpected exit code $result from run process.';
+      print('test: validating that the app has in fact closed...');
+      await client.done.timeout(const Duration(seconds: 5));
+    });
+    return new TaskResult.success(null);
+  });
+}

--- a/dev/devicelab/bin/tasks/run_machine_concurrent_hot_reload.dart
+++ b/dev/devicelab/bin/tasks/run_machine_concurrent_hot_reload.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 The Chromium Authors. All rights reserved.
+// Copyright (c) 2018 The Chromium Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/dev/devicelab/bin/tasks/run_machine_concurrent_hot_reload.dart
+++ b/dev/devicelab/bin/tasks/run_machine_concurrent_hot_reload.dart
@@ -26,6 +26,10 @@ void main() {
     return null;
   }
 
+  Stream<String> transformToLines(Stream<List<int>> byteStream) {
+    return byteStream.transform(UTF8.decoder).transform(const LineSplitter());
+  }
+
   task(() async {
     int vmServicePort;
     String appId;
@@ -51,10 +55,7 @@ void main() {
       );
       final StreamController<String> stdout =
           new StreamController<String>.broadcast();
-      run.stdout
-          .transform(UTF8.decoder)
-          .transform(const LineSplitter())
-          .listen((String line) {
+      transformToLines(run.stdout).listen((String line) {
         print('run:stdout: $line');
         stdout.add(line);
         final dynamic json = parseFlutterResponse(line);
@@ -68,10 +69,7 @@ void main() {
           ok ??= true;
         }
       });
-      run.stderr
-          .transform(UTF8.decoder)
-          .transform(const LineSplitter())
-          .listen((String line) {
+      transformToLines(run.stderr).listen((String line) {
         stderr.writeln('run:stderr: $line');
       });
       run.exitCode.then((int exitCode) {

--- a/dev/devicelab/manifest.yaml
+++ b/dev/devicelab/manifest.yaml
@@ -200,6 +200,12 @@ tasks:
     stage: devicelab
     required_agent_capabilities: ["mac/android"]
 
+  run_machine_concurrent_hot_reload:
+    description: >
+      Runs tests of concurrent hot reload commands via flutter run --machine.
+    stage: devicelab
+    required_agent_capabilities: ["mac/android"]
+
   service_extensions_test:
     description: >
       Validates our service protocol extensions.

--- a/packages/flutter_tools/lib/src/commands/daemon.dart
+++ b/packages/flutter_tools/lib/src/commands/daemon.dart
@@ -447,7 +447,8 @@ class AppDomain extends Domain {
   bool isRestartSupported(bool enableHotReload, Device device) =>
       enableHotReload && device.supportsHotMode;
 
-  Future<Null> inProgressHotReload;
+  Future<Null> _inProgressHotReload;
+
   Future<OperationResult> restart(Map<String, dynamic> args) async {
     final String appId = _getStringArg(args, 'appId', required: true);
     final bool fullRestart = _getBoolArg(args, 'fullRestart') ?? false;
@@ -457,14 +458,14 @@ class AppDomain extends Domain {
     if (app == null)
       throw "app '$appId' not found";
 
-    if (!fullRestart && inProgressHotReload != null)
+    if (!fullRestart && _inProgressHotReload != null)
       throw 'hot restart already in progress';
 
     final Future<OperationResult> action = app._runInZone(this, () {
       return app.restart(fullRestart: fullRestart, pauseAfterRestart: pauseAfterRestart);
     });
     if (!fullRestart)
-      inProgressHotReload = action.then((_) => inProgressHotReload = null);
+      _inProgressHotReload = action.then((_) => _inProgressHotReload = null);
     return action;
   }
 

--- a/packages/flutter_tools/lib/src/commands/daemon.dart
+++ b/packages/flutter_tools/lib/src/commands/daemon.dart
@@ -447,7 +447,7 @@ class AppDomain extends Domain {
   bool isRestartSupported(bool enableHotReload, Device device) =>
       enableHotReload && device.supportsHotMode;
 
-  Future<Null> _inProgressHotReload;
+  Future<OperationResult> _inProgressHotReload;
 
   Future<OperationResult> restart(Map<String, dynamic> args) async {
     final String appId = _getStringArg(args, 'appId', required: true);
@@ -461,12 +461,12 @@ class AppDomain extends Domain {
     if (_inProgressHotReload != null)
       throw 'hot restart already in progress';
 
-    final Future<OperationResult> action = app._runInZone(this, () {
+    _inProgressHotReload = app._runInZone(this, () {
       return app.restart(fullRestart: fullRestart, pauseAfterRestart: pauseAfterRestart);
     });
-    if (!fullRestart)
-      _inProgressHotReload = action.then((_) => _inProgressHotReload = null);
-    return action;
+    return _inProgressHotReload.whenComplete(() {
+      _inProgressHotReload = null;
+    });
   }
 
   /// Returns an error, or the service extension result (a map with two fixed

--- a/packages/flutter_tools/lib/src/commands/daemon.dart
+++ b/packages/flutter_tools/lib/src/commands/daemon.dart
@@ -458,7 +458,7 @@ class AppDomain extends Domain {
     if (app == null)
       throw "app '$appId' not found";
 
-    if (!fullRestart && _inProgressHotReload != null)
+    if (_inProgressHotReload != null)
       throw 'hot restart already in progress';
 
     final Future<OperationResult> action = app._runInZone(this, () {


### PR DESCRIPTION
Fixes #14184 

I created a copy of the `command_tests.dart` devicelab test and changed it to talk `--machine` (including extracting the debug port from `app.debugPort` since there's no banner like `flutter run --hot` which is what the other test used). Without the change in `daemon.dart` this test will fail because of a crash. With the code change the test passes (the second reload is rejected).

I'm somewhat nervous about this change because breaking hot reload would be a big deal, so please review carefully. Is the change in `daemon.dart` reliable enough that it can't end up with a hungover future that stops future hot reloads working?

Also; should I be adding run_machine_concurrent_hot_reload to the manifest file? The doc says "The `manifest.yaml` file describes a subset of tests we run in the CI" but I'm not certain what that subset is and whether this test should be part of it.

As always, nitpick away; this is a learning exercise!

cc @devoncarew @yjbanov 