### PR TITLE
Hide the NDK warning that should never happen with a regexp

### DIFF
--- a/packages/flutter_tools/lib/src/android/gradle.dart
+++ b/packages/flutter_tools/lib/src/android/gradle.dart
@@ -36,6 +36,14 @@ enum FlutterPluginVersion {
   managed,
 }
 
+// Investigation documented in #13975 suggests the filter should be a subset
+// of the impact of -q, but users insist they see the error message sometimes
+// anyway.  If we can prove it really is impossible, delete the filter.
+final RegExp ndkMessageFilter = new RegExp(r'^(?!NDK is missing a ".*" directory'
+  r'|If you are not using NDK, unset the NDK variable from ANDROID_NDK_HOME or local.properties to remove this warning'
+  r'|If you are using NDK, verify the ndk.dir is set to a valid NDK directory.  It is currently set to .*)');
+
+
 bool isProjectUsingGradle() {
   return fs.isFileSync('android/build.gradle');
 }
@@ -310,6 +318,7 @@ Future<Null> _buildGradleProjectV2(String gradle, BuildInfo buildInfo, String ta
       workingDirectory: 'android',
       allowReentrantFlutter: true,
       environment: _gradleEnv,
+      filter: logger.isVerbose ? null : ndkMessageFilter,
   );
   status.stop();
 

--- a/packages/flutter_tools/test/android/gradle_test.dart
+++ b/packages/flutter_tools/test/android/gradle_test.dart
@@ -8,6 +8,28 @@ import 'package:flutter_tools/src/build_info.dart';
 import 'package:test/test.dart';
 
 void main() {
+  group('gradle build', () {
+    test('regexp should only match lines without the error message', () {
+      final List<String> nonMatchingLines = <String>[
+        'NDK is missing a "platforms" directory.',
+        'If you are using NDK, verify the ndk.dir is set to a valid NDK directory.  It is currently set to /usr/local/company/home/username/Android/Sdk/ndk-bundle.',
+        'If you are not using NDK, unset the NDK variable from ANDROID_NDK_HOME or local.properties to remove this warning.',
+      ];
+      final List<String> matchingLines = <String>[
+        ':app:preBuild UP-TO-DATE',
+        'BUILD SUCCESSFUL in 0s',
+        '',
+        'Something NDK related mentioning ANDROID_NDK_HOME',
+      ];
+      for (String m in nonMatchingLines) {
+        expect(ndkMessageFilter.hasMatch(m), isFalse);
+      }
+      for (String m in matchingLines) {
+        expect(ndkMessageFilter.hasMatch(m), isTrue);
+      }
+    });
+  });
+
   group('gradle project', () {
     GradleProject projectFrom(String properties) => new GradleProject.fromAppProperties(properties);
 


### PR DESCRIPTION
Fixes #13975, even though it shouldn't happen anyway.  Besides the unit test, end-to-end tested by commenting out the addtion of `-q` and verifying the error appears when the SDK installation and/or NDK settings are broken.