### PR TITLE
Improve padding around persistent footer buttons

### DIFF
--- a/packages/flutter/lib/src/material/scaffold.dart
+++ b/packages/flutter/lib/src/material/scaffold.dart
@@ -904,6 +904,30 @@ class ScaffoldState extends State<Scaffold> with TickerProviderStateMixin {
     }
 
     if (widget.persistentFooterButtons != null) {
+      final ButtonTheme buttonBarTheme = new ButtonTheme.bar(
+        child: new SafeArea(
+          top: false,
+          child: new ButtonBar(
+            children: widget.persistentFooterButtons,
+          ),
+        ),
+      );
+
+      // When adding a SafeArea around ButtonBar, reduce the SafeArea padding
+      // by the additional padding that ButtonBar applies.
+      //
+      // Normally, the SafeArea would be applied within ButtonBar, but we do
+      // it here due to the likelihood of ButtonBars being used in places where
+      // developers have inadvertently failed to remove media padding.
+      final double buttonPadding = buttonBarTheme.data.padding.horizontal / 2.0;
+      final MediaQueryData mediaQuery = MediaQuery.of(context);
+      final EdgeInsets reducedPadding = new EdgeInsets.fromLTRB(
+          math.max(0.0, mediaQuery.padding.left - buttonPadding / 2.0),
+          mediaQuery.padding.top,
+          math.max(0.0, mediaQuery.padding.right - buttonPadding / 2.0),
+          math.max(0.0, mediaQuery.padding.bottom - buttonPadding),
+      );
+
       _addIfNonNull(
         children,
         new Container(
@@ -914,15 +938,9 @@ class ScaffoldState extends State<Scaffold> with TickerProviderStateMixin {
               ),
             ),
           ),
-          child: new SafeArea(
-            child: new ButtonTheme.bar(
-              child: new SafeArea(
-                top: false,
-                child: new ButtonBar(
-                  children: widget.persistentFooterButtons
-                ),
-              ),
-            ),
+          child: new MediaQuery(
+            data: mediaQuery.copyWith(padding: reducedPadding),
+            child: buttonBarTheme,
           ),
         ),
         _ScaffoldSlot.persistentFooter,

--- a/packages/flutter/test/material/scaffold_test.dart
+++ b/packages/flutter/test/material/scaffold_test.dart
@@ -367,8 +367,8 @@ void main() {
         ),
       ),
     );
-    expect(tester.getBottomLeft(find.byType(ButtonBar)), const Offset(10.0, 560.0));
-    expect(tester.getBottomRight(find.byType(ButtonBar)), const Offset(770.0, 560.0));
+    expect(tester.getBottomLeft(find.byType(ButtonBar)), const Offset(6.0, 568.0));
+    expect(tester.getBottomRight(find.byType(ButtonBar)), const Offset(774.0, 568.0));
   });
 
   group('back arrow', () {
@@ -637,15 +637,15 @@ void main() {
     await tester.pump(const Duration(seconds: 1));
 
     expect(tester.getRect(find.byKey(appBar)), new Rect.fromLTRB(0.0, 0.0, 800.0, 43.0));
-    expect(tester.getRect(find.byKey(body)), new Rect.fromLTRB(0.0, 43.0, 800.0, 348.0));
-    expect(tester.getRect(find.byKey(floatingActionButton)), new Rect.fromLTRB(36.0, 255.0, 113.0, 332.0));
-    expect(tester.getRect(find.byKey(persistentFooterButton)), new Rect.fromLTRB(28.0, 357.0, 128.0, 447.0)); // Note: has 8px each top/bottom padding.
+    expect(tester.getRect(find.byKey(body)), new Rect.fromLTRB(0.0, 43.0, 800.0, 356.0));
+    expect(tester.getRect(find.byKey(floatingActionButton)), new Rect.fromLTRB(36.0, 263.0, 113.0, 340.0));
+    expect(tester.getRect(find.byKey(persistentFooterButton)), new Rect.fromLTRB(24.0, 365.0, 124.0, 455.0)); // Note: has 8px each top/bottom padding.
     expect(tester.getRect(find.byKey(drawer)), new Rect.fromLTRB(596.0, 0.0, 800.0, 600.0));
     expect(tester.getRect(find.byKey(bottomNavigationBar)), new Rect.fromLTRB(0.0, 515.0, 800.0, 600.0));
     expect(tester.getRect(find.byKey(insideAppBar)), new Rect.fromLTRB(20.0, 30.0, 750.0, 43.0));
-    expect(tester.getRect(find.byKey(insideBody)), new Rect.fromLTRB(20.0, 43.0, 750.0, 348.0));
-    expect(tester.getRect(find.byKey(insideFloatingActionButton)), new Rect.fromLTRB(36.0, 255.0, 113.0, 332.0));
-    expect(tester.getRect(find.byKey(insidePersistentFooterButton)), new Rect.fromLTRB(28.0, 357.0, 128.0, 447.0));
+    expect(tester.getRect(find.byKey(insideBody)), new Rect.fromLTRB(20.0, 43.0, 750.0, 356.0));
+    expect(tester.getRect(find.byKey(insideFloatingActionButton)), new Rect.fromLTRB(36.0, 263.0, 113.0, 340.0));
+    expect(tester.getRect(find.byKey(insidePersistentFooterButton)), new Rect.fromLTRB(24.0, 395.0, 124.0, 455.0));
     expect(tester.getRect(find.byKey(insideDrawer)), new Rect.fromLTRB(596.0, 30.0, 750.0, 540.0));
     expect(tester.getRect(find.byKey(insideBottomNavigationBar)), new Rect.fromLTRB(20.0, 515.0, 750.0, 540.0));
   });
@@ -727,12 +727,12 @@ void main() {
     expect(tester.getRect(find.byKey(appBar)), new Rect.fromLTRB(0.0, 0.0, 800.0, 43.0));
     expect(tester.getRect(find.byKey(body)), new Rect.fromLTRB(0.0, 43.0, 800.0, 400.0));
     expect(tester.getRect(find.byKey(floatingActionButton)), new Rect.fromLTRB(36.0, 307.0, 113.0, 384.0));
-    expect(tester.getRect(find.byKey(persistentFooterButton)), new Rect.fromLTRB(28.0, 442.0, 128.0, 532.0)); // Note: has 8px each top/bottom padding.
+    expect(tester.getRect(find.byKey(persistentFooterButton)), new Rect.fromLTRB(24.0, 450.0, 124.0, 540.0)); // Note: has 8px each top/bottom padding.
     expect(tester.getRect(find.byKey(drawer)), new Rect.fromLTRB(596.0, 0.0, 800.0, 600.0));
     expect(tester.getRect(find.byKey(insideAppBar)), new Rect.fromLTRB(20.0, 30.0, 750.0, 43.0));
     expect(tester.getRect(find.byKey(insideBody)), new Rect.fromLTRB(20.0, 43.0, 750.0, 400.0));
     expect(tester.getRect(find.byKey(insideFloatingActionButton)), new Rect.fromLTRB(36.0, 307.0, 113.0, 384.0));
-    expect(tester.getRect(find.byKey(insidePersistentFooterButton)), new Rect.fromLTRB(28.0, 442.0, 128.0, 532.0));
+    expect(tester.getRect(find.byKey(insidePersistentFooterButton)), new Rect.fromLTRB(24.0, 480.0, 124.0, 540.0));
     expect(tester.getRect(find.byKey(insideDrawer)), new Rect.fromLTRB(596.0, 30.0, 750.0, 540.0));
   });
 


### PR DESCRIPTION
In flutter/flutter#14512, a SafeArea was added around the ButtonBar
in the Scaffold's persistentFooterButtons. ButtonBar itself adds
horizontal and vertical padding around its button children. We work
around this here by removing equivalent padding from the media padding
(if present).

An alternative would be to remove the media padding from the ButtonTheme
padding, but that reduction would apply to any widgets in the ButtonBar
subtree as well, whereas media padding is immediately stripped by the
SafeArea.

Another alternative would be to move the SafeArea inside the ButtonBar,
and deal with the padding all in one place, but we worry that button
bars are likely to be used in a lot of places, and that developers won't
have stripped unnecessary media padding in those places.