### PR TITLE
Partially fix Dart 2 issues in animated_icons.test.

### DIFF
--- a/packages/flutter/test/material/animated_icons_test.dart
+++ b/packages/flutter/test/material/animated_icons_test.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import 'dart:math' as math show pi;
-import 'dart:ui' as ui;
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -32,7 +31,7 @@ void main() {
     final CustomPaint customPaint = tester.widget(find.byType(CustomPaint));
     final MockCanvas canvas = new MockCanvas();
     customPaint.painter.paint(canvas, const Size(48.0, 48.0));
-    verify(canvas.drawPath(typed(any), paintColorMatcher(0xFF666666)));
+    verify(canvas.drawPath(typed(any), typed(argThat(hasColor(0xFF666666)))));
   });
 
   testWidgets('IconTheme opacity', (WidgetTester tester) async {
@@ -54,7 +53,7 @@ void main() {
     final CustomPaint customPaint = tester.widget(find.byType(CustomPaint));
     final MockCanvas canvas = new MockCanvas();
     customPaint.painter.paint(canvas, const Size(48.0, 48.0));
-    verify(canvas.drawPath(typed(any), paintColorMatcher(0x80666666)));
+    verify(canvas.drawPath(typed(any), typed(argThat(hasColor(0x80666666)))));
   });
 
   testWidgets('color overrides IconTheme color', (WidgetTester tester) async {
@@ -76,7 +75,7 @@ void main() {
     final CustomPaint customPaint = tester.widget(find.byType(CustomPaint));
     final MockCanvas canvas = new MockCanvas();
     customPaint.painter.paint(canvas, const Size(48.0, 48.0));
-    verify(canvas.drawPath(typed(any), paintColorMatcher(0xFF0000FF)));
+    verify(canvas.drawPath(typed(any), typed(argThat(hasColor(0xFF0000FF)))));
   });
 
   testWidgets('IconTheme size', (WidgetTester tester) async {
@@ -216,11 +215,11 @@ void main() {
   });
 }
 
-dynamic paintColorMatcher(int color) {
+PaintColorMatcher hasColor(int color) {
   return new PaintColorMatcher(color);
 }
 
-class PaintColorMatcher extends Matcher implements ui.Paint {
+class PaintColorMatcher extends Matcher {
   const PaintColorMatcher(this.expectedColor);
 
   final int expectedColor;

--- a/packages/flutter/test/material/animated_icons_test.dart
+++ b/packages/flutter/test/material/animated_icons_test.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'dart:math' as math show pi;
+import 'dart:ui' as ui;
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -31,7 +32,7 @@ void main() {
     final CustomPaint customPaint = tester.widget(find.byType(CustomPaint));
     final MockCanvas canvas = new MockCanvas();
     customPaint.painter.paint(canvas, const Size(48.0, 48.0));
-    verify(canvas.drawPath(any, paintColorMatcher(0xFF666666)));
+    verify(canvas.drawPath(typed(any), paintColorMatcher(0xFF666666)));
   });
 
   testWidgets('IconTheme opacity', (WidgetTester tester) async {
@@ -53,7 +54,7 @@ void main() {
     final CustomPaint customPaint = tester.widget(find.byType(CustomPaint));
     final MockCanvas canvas = new MockCanvas();
     customPaint.painter.paint(canvas, const Size(48.0, 48.0));
-    verify(canvas.drawPath(any, paintColorMatcher(0x80666666)));
+    verify(canvas.drawPath(typed(any), paintColorMatcher(0x80666666)));
   });
 
   testWidgets('color overrides IconTheme color', (WidgetTester tester) async {
@@ -75,7 +76,7 @@ void main() {
     final CustomPaint customPaint = tester.widget(find.byType(CustomPaint));
     final MockCanvas canvas = new MockCanvas();
     customPaint.painter.paint(canvas, const Size(48.0, 48.0));
-    verify(canvas.drawPath(any, paintColorMatcher(0xFF0000FF)));
+    verify(canvas.drawPath(typed(any), paintColorMatcher(0xFF0000FF)));
   });
 
   testWidgets('IconTheme size', (WidgetTester tester) async {
@@ -185,8 +186,8 @@ void main() {
     final CustomPaint customPaint = tester.widget(find.byType(CustomPaint));
     final MockCanvas canvas = new MockCanvas();
     customPaint.painter.paint(canvas, const Size(48.0, 48.0));
-    verifyNever(canvas.rotate(any));
-    verifyNever(canvas.translate(any, any));
+    verifyNever(canvas.rotate(typed(any)));
+    verifyNever(canvas.translate(typed(any), typed(any)));
   });
 
   testWidgets('Inherited text direction overridden', (WidgetTester tester) async {
@@ -219,7 +220,7 @@ dynamic paintColorMatcher(int color) {
   return new PaintColorMatcher(color);
 }
 
-class PaintColorMatcher extends Matcher {
+class PaintColorMatcher extends Matcher implements ui.Paint {
   const PaintColorMatcher(this.expectedColor);
 
   final int expectedColor;


### PR DESCRIPTION
It should be using `typed(any)` instead of `any` and
`PaintColorMatcher` should implement `ui.Paint`.