### PR TITLE
Add a flutter run option that can override the default target platform

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_device.dart
+++ b/packages/flutter_tools/lib/src/android/android_device.dart
@@ -367,7 +367,7 @@ class AndroidDevice extends Device {
     }
 
     BuildInfo buildInfo = debuggingOptions.buildInfo;
-    if (devicePlatform == TargetPlatform.android_arm64)
+    if (buildInfo.targetPlatform == null && devicePlatform == TargetPlatform.android_arm64)
       buildInfo = buildInfo.withTargetPlatform(TargetPlatform.android_arm64);
 
     if (!prebuiltApplication) {

--- a/packages/flutter_tools/lib/src/commands/run.dart
+++ b/packages/flutter_tools/lib/src/commands/run.dart
@@ -34,6 +34,11 @@ abstract class RunCommandBase extends FlutterCommand {
               'forwards the host port to a device port.');
     argParser.addOption('route',
         help: 'Which route to load when running the app.');
+    argParser.addOption('target-platform',
+        defaultsTo: 'default',
+        allowed: <String>['default', 'android-arm', 'android-arm64'],
+        help: 'Specify the target platform when building the app for an '
+              'Android device.\nIgnored on iOS.');
     usesTargetOption();
     usesPortOptions();
     usesPubOption();

--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -164,6 +164,12 @@ abstract class FlutterCommand extends Command<Null> {
         ? argResults['preview-dart-2']
         : false;
 
+    TargetPlatform targetPlatform;
+    if (argParser.options.containsKey('target-platform') &&
+        argResults['target-platform'] != 'default') {
+      targetPlatform = getTargetPlatformForName(argResults['target-platform']);
+    }
+
     return new BuildInfo(getBuildMode(),
       argParser.options.containsKey('flavor')
         ? argResults['flavor']
@@ -178,9 +184,7 @@ abstract class FlutterCommand extends Command<Null> {
       preferSharedLibrary: argParser.options.containsKey('prefer-shared-library')
         ? argResults['prefer-shared-library']
         : false,
-      targetPlatform: argParser.options.containsKey('target-platform')
-        ? getTargetPlatformForName(argResults['target-platform'])
-        : null);
+      targetPlatform: targetPlatform);
   }
 
   void setupApplicationPackages() {


### PR DESCRIPTION
By default flutter run will build a 64-bit APK if the attached Android device
is 64-bit.  Specifying --target-platform=android-arm will deploy a 32-bit APK
to a 64-bit device.

Fixes https://github.com/flutter/flutter/issues/14526