### PR TITLE
Move geometric sort for semantics to the framework side.

### DIFF
--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -1895,7 +1895,7 @@ class RenderTransform extends RenderProxyBox {
     this.origin = origin;
   }
 
-  /// The origin of the coordinate system (relative to the upper left corder of
+  /// The origin of the coordinate system (relative to the upper left corner of
   /// this render object) in which to apply the matrix.
   ///
   /// Setting an origin is equivalent to conjugating the transform matrix by a
@@ -1907,6 +1907,7 @@ class RenderTransform extends RenderProxyBox {
       return;
     _origin = value;
     markNeedsPaint();
+    markNeedsSemanticsUpdate();
   }
 
   /// The alignment of the origin, relative to the size of the box.
@@ -1927,6 +1928,7 @@ class RenderTransform extends RenderProxyBox {
       return;
     _alignment = value;
     markNeedsPaint();
+    markNeedsSemanticsUpdate();
   }
 
   /// The text direction with which to resolve [alignment].
@@ -1940,6 +1942,7 @@ class RenderTransform extends RenderProxyBox {
       return;
     _textDirection = value;
     markNeedsPaint();
+    markNeedsSemanticsUpdate();
   }
 
   /// When set to true, hit tests are performed based on the position of the
@@ -1960,42 +1963,49 @@ class RenderTransform extends RenderProxyBox {
       return;
     _transform = new Matrix4.copy(value);
     markNeedsPaint();
+    markNeedsSemanticsUpdate();
   }
 
   /// Sets the transform to the identity matrix.
   void setIdentity() {
     _transform.setIdentity();
     markNeedsPaint();
+    markNeedsSemanticsUpdate();
   }
 
   /// Concatenates a rotation about the x axis into the transform.
   void rotateX(double radians) {
     _transform.rotateX(radians);
     markNeedsPaint();
+    markNeedsSemanticsUpdate();
   }
 
   /// Concatenates a rotation about the y axis into the transform.
   void rotateY(double radians) {
     _transform.rotateY(radians);
     markNeedsPaint();
+    markNeedsSemanticsUpdate();
   }
 
   /// Concatenates a rotation about the z axis into the transform.
   void rotateZ(double radians) {
     _transform.rotateZ(radians);
     markNeedsPaint();
+    markNeedsSemanticsUpdate();
   }
 
   /// Concatenates a translation by (x, y, z) into the transform.
   void translate(double x, [double y = 0.0, double z = 0.0]) {
     _transform.translate(x, y, z);
     markNeedsPaint();
+    markNeedsSemanticsUpdate();
   }
 
   /// Concatenates a scale into the transform.
   void scale(double x, [double y, double z]) {
     _transform.scale(x, y, z);
     markNeedsPaint();
+    markNeedsSemanticsUpdate();
   }
 
   Matrix4 get _effectiveTransform {


### PR DESCRIPTION
This adds geometric sort ordering back in for semantics nodes that don't have a sort order defined.

With this change, widgets that either have no sort order, or have an equivalent sort order, will be compared geometrically. The comparison is between the two starting corners, so it is TextDirection-aware: parent nodes that are set to have LTR text will compare upper left corners of their children, and upper right when set to RTL.

Also fixed a bug in the Transform widget that didn't mark modified nodes as needing a semantics update.