### PR TITLE
More Travis deploy script fixes

### DIFF
--- a/dev/bots/travis_setup.sh
+++ b/dev/bots/travis_setup.sh
@@ -25,9 +25,11 @@ if [ -n "$TRAVIS" ]; then
     export ANDROID_HOME=`pwd`/android-sdk
     export PATH=`pwd`/android-sdk/tools/bin:$PATH
     mkdir -p /home/travis/.android # silence sdkmanager warning
+    set +x # Travis's env variable hiding is a bit wonky. Don't echo back this line.
     if [ -n "$ANDROID_GALLERY_UPLOAD_KEY" ]; then
-      echo $ANDROID_GALLERY_UPLOAD_KEY | base64 --decode > /home/travis/.android/debug.keystore
+      echo "$ANDROID_GALLERY_UPLOAD_KEY" | base64 --decode > /home/travis/.android/debug.keystore
     fi
+    set -x
     echo 'count=0' > /home/travis/.android/repositories.cfg # silence sdkmanager warning
     # suppressing output of sdkmanager to keep log under 4MB (travis limit)
     echo y | sdkmanager "tools" >/dev/null

--- a/examples/flutter_gallery/ios/fastlane/Fastfile
+++ b/examples/flutter_gallery/ios/fastlane/Fastfile
@@ -15,9 +15,13 @@ platform :ios do
     # Doesn't do anything when not on Travis.
     setup_travis
 
+    # Relative to this file.
+    raw_version = File.read('../../../../version')
+    puts "Building and deploying version #{raw_version}..."
+
     increment_version_number(
-      # Relative to this file. Accept only digits and dots.
-      version_number: File.read('../../../../version').gsub(/[^0-9\.]/, '')
+      # Only major, minor, patch digits and dots.
+      version_number: /\d+\.\d+\.\d+/.match(raw_version)[0]
     )
 
     # Retrieves all the necessary certs and provisioning profiles.

--- a/examples/flutter_gallery/ios/fastlane/Fastfile
+++ b/examples/flutter_gallery/ios/fastlane/Fastfile
@@ -28,7 +28,8 @@ platform :ios do
     sync_code_signing(
       git_url: ENV['PUBLISHING_MATCH_CERTIFICATE_REPO'],
       type: 'appstore',
-      readonly: true
+      readonly: true,
+      verbose: false
     )
 
     # Modify the Xcode project to use the new team and profile.


### PR DESCRIPTION
#14306
- Escape characters in the base64
- Don't echo back the keystore
- Limit the iOS version to 2 dots only
- Don't print back the cert repo url