### PR TITLE
Fix message channel usage in few tests.

### DIFF
--- a/packages/flutter/test/semantics/semantics_service_test.dart
+++ b/packages/flutter/test/semantics/semantics_service_test.dart
@@ -10,10 +10,10 @@ import 'package:test/test.dart';
 
 void main() {
   test('Semantic announcement', () async {
-    final List<Map<String, dynamic>> log = <Map<String, dynamic>>[];
+    final List<Map<dynamic, dynamic>> log = <Map<dynamic, dynamic>>[];
 
     SystemChannels.accessibility.setMockMessageHandler((Object mockMessage) async {
-      final Map<String, dynamic> message = mockMessage;
+      final Map<dynamic, dynamic> message = mockMessage;
       log.add(message);
     });
 

--- a/packages/flutter/test/widgets/scrollable_semantics_test.dart
+++ b/packages/flutter/test/widgets/scrollable_semantics_test.dart
@@ -225,7 +225,7 @@ void main() {
     expect(messages, isNot(hasLength(0)));
     expect(messages.every((dynamic message) => message['type'] == 'scroll'), isTrue);
 
-    Map<String, Object> message = messages.last['data'];
+    Map<Object, Object> message = messages.last['data'];
     expect(message['axis'], 'v');
     expect(message['pixels'], isPositive);
     expect(message['minScrollExtent'], 0.0);
@@ -271,7 +271,7 @@ void main() {
     expect(messages, isNot(hasLength(0)));
     expect(messages.every((dynamic message) => message['type'] == 'scroll'), isTrue);
 
-    Map<String, Object> message = messages.last['data'];
+    Map<Object, Object> message = messages.last['data'];
     expect(message['axis'], 'h');
     expect(message['pixels'], isPositive);
     expect(message['minScrollExtent'], 0.0);


### PR DESCRIPTION
Channels don't preserve Map and List type arguments: Map<String, Object>
arrives as Map<dynamic, dynamic> to the receiver.

In Dart 2 type system dynamic no longer serves as bottom type so
Map<dynamic, dynamic> can't be assign to a variable of type
Map<String, dynamic>.

Issue #14556