### PR TITLE
Fix text_style_text.dart to be Dart 2 compliant.

### DIFF
--- a/packages/flutter/test/painting/text_style_test.dart
+++ b/packages/flutter/test/painting/text_style_test.dart
@@ -23,7 +23,7 @@ void main() {
       fontWeight: FontWeight.w800,
       height: 123.0,
     );
-    expect(() { s1.fontFamily = 'test'; }, throws); // ignore: ASSIGNMENT_TO_FINAL
+    expect(() { s1.fontFamily = 'test'; }, throwsA(anything)); // ignore: ASSIGNMENT_TO_FINAL
     expect(s1.fontFamily, isNull);
     expect(s1.fontSize, 10.0);
     expect(s1.fontWeight, FontWeight.w800);

--- a/packages/flutter/test/painting/text_style_test.dart
+++ b/packages/flutter/test/painting/text_style_test.dart
@@ -23,7 +23,7 @@ void main() {
       fontWeight: FontWeight.w800,
       height: 123.0,
     );
-    expect(() { s1.fontFamily = 'test'; }, throwsA(isNoSuchMethodError)); // ignore: ASSIGNMENT_TO_FINAL
+    expect(() { s1.fontFamily = 'test'; }, throws); // ignore: ASSIGNMENT_TO_FINAL
     expect(s1.fontFamily, isNull);
     expect(s1.fontSize, 10.0);
     expect(s1.fontWeight, FontWeight.w800);

--- a/packages/flutter/test/painting/text_style_test.dart
+++ b/packages/flutter/test/painting/text_style_test.dart
@@ -23,7 +23,7 @@ void main() {
       fontWeight: FontWeight.w800,
       height: 123.0,
     );
-    expect(() { s1.fontFamily = 'test'; }, throwsA(anything)); // ignore: ASSIGNMENT_TO_FINAL
+    expect(() { s1.fontFamily = 'test'; }, throwsA(const isInstanceOf<Error>())); // ignore: ASSIGNMENT_TO_FINAL
     expect(s1.fontFamily, isNull);
     expect(s1.fontSize, 10.0);
     expect(s1.fontWeight, FontWeight.w800);


### PR DESCRIPTION
In Dart 2 mode we throw different exception: compiler generates
throw of a compilation error instead of runtime throwing
noSuchMethod.