### PR TITLE
Move plugin injection to just after pub get

### DIFF
--- a/dev/devicelab/bin/tasks/plugin_test.dart
+++ b/dev/devicelab/bin/tasks/plugin_test.dart
@@ -1,0 +1,12 @@
+// Copyright (c) 2018 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:flutter_devicelab/tasks/plugin_tests.dart';
+import 'package:flutter_devicelab/framework/framework.dart';
+
+Future<Null> main() async {
+  await task(new PluginTest('apk'));
+}

--- a/dev/devicelab/bin/tasks/plugin_test_ios.dart
+++ b/dev/devicelab/bin/tasks/plugin_test_ios.dart
@@ -1,0 +1,12 @@
+// Copyright (c) 2018 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:flutter_devicelab/tasks/plugin_tests.dart';
+import 'package:flutter_devicelab/framework/framework.dart';
+
+Future<Null> main() async {
+  await task(new PluginTest('ios'));
+}

--- a/dev/devicelab/bin/tasks/plugin_test_win.dart
+++ b/dev/devicelab/bin/tasks/plugin_test_win.dart
@@ -1,0 +1,12 @@
+// Copyright (c) 2018 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:flutter_devicelab/tasks/plugin_tests.dart';
+import 'package:flutter_devicelab/framework/framework.dart';
+
+Future<Null> main() async {
+  await task(new PluginTest('apk'));
+}

--- a/dev/devicelab/lib/tasks/plugin_tests.dart
+++ b/dev/devicelab/lib/tasks/plugin_tests.dart
@@ -1,0 +1,69 @@
+// Copyright (c) 2018 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:io';
+
+import 'package:path/path.dart' as path;
+import 'package:flutter_devicelab/framework/framework.dart';
+import 'package:flutter_devicelab/framework/utils.dart';
+
+/// Defines task that creates new Flutter project, adds a plugin, and then
+/// builds the specified [buildTarget].
+class PluginTest {
+  final String buildTarget;
+
+  PluginTest(this.buildTarget);
+
+  Future<TaskResult> call() async {
+    section('Create Flutter project');
+    final Directory tmp = await Directory.systemTemp.createTemp('plugin');
+    final FlutterProject project = await FlutterProject.create(tmp, 'hello');
+    try {
+      section('Add plugin');
+      await project.addPlugin('path_provider');
+
+      section('Build');
+      await project.build(buildTarget);
+
+      return new TaskResult.success(null);
+    } catch (e) {
+      return new TaskResult.failure(e.toString());
+    } finally {
+      project.parent.deleteSync(recursive: true);
+    }
+  }
+}
+
+class FlutterProject {
+  FlutterProject(this.parent, this.name);
+
+  final Directory parent;
+  final String name;
+
+  static Future<FlutterProject> create(Directory directory, String name) async {
+    await inDirectory(directory, () async {
+      await flutter('create', options: <String>[name]);
+    });
+    return new FlutterProject(directory, name);
+  }
+
+  String get rootPath => path.join(parent.path, name);
+
+  Future<Null> addPlugin(String plugin) async {
+    final File pubspec = new File(path.join(rootPath, 'pubspec.yaml'));
+    String content = await pubspec.readAsString();
+    content = content.replaceFirst(
+      '\ndependencies:\n',
+      '\ndependencies:\n  $plugin:\n',
+    );
+    await pubspec.writeAsString(content, flush: true);
+  }
+
+  Future<Null> build(String target) async {
+    await inDirectory(new Directory(rootPath), () async {
+      await flutter('build', options: <String>[target]);
+    });
+  }
+}

--- a/dev/devicelab/lib/tasks/plugin_tests.dart
+++ b/dev/devicelab/lib/tasks/plugin_tests.dart
@@ -31,7 +31,7 @@ class PluginTest {
     } catch (e) {
       return new TaskResult.failure(e.toString());
     } finally {
-      project.parent.deleteSync(recursive: true);
+      await project.delete();
     }
   }
 }
@@ -65,5 +65,9 @@ class FlutterProject {
     await inDirectory(new Directory(rootPath), () async {
       await flutter('build', options: <String>[target]);
     });
+  }
+
+  Future<Null> delete() async {
+    await parent.delete(recursive: true);
   }
 }

--- a/dev/devicelab/manifest.yaml
+++ b/dev/devicelab/manifest.yaml
@@ -237,6 +237,13 @@ tasks:
     stage: devicelab
     required_agent_capabilities: ["linux/android"]
 
+  plugin_test:
+    description: >
+      Checks that the project template works and supports plugins.
+    stage: devicelab
+    required_agent_capabilities: ["linux/android"]
+    flaky: true
+
   flutter_gallery_instrumentation_test:
     description: >
       Same as flutter_gallery__transition_perf but uses Android instrumentation
@@ -252,6 +259,13 @@ tasks:
       Checks that flavored builds work on iOS.
     stage: devicelab_ios
     required_agent_capabilities: ["mac/ios"]
+
+  plugin_test_ios:
+    description: >
+      Checks that the project template works and supports plugins on iOS.
+    stage: devicelab_ios
+    required_agent_capabilities: ["mac/ios"]
+    flaky: true
 
   external_ui_integration_test_ios:
     description: >
@@ -346,6 +360,13 @@ tasks:
       Checks that platform channels work when app is launched from Windows.
     stage: devicelab_win
     required_agent_capabilities: ["windows/android"]
+
+  plugin_test_win:
+    description: >
+      Checks that the project template works and supports plugins on Windows.
+    stage: devicelab_win
+    required_agent_capabilities: ["windows/android"]
+    flaky: true
 
   hot_mode_dev_cycle_win__benchmark:
     description: >

--- a/packages/flutter_tools/lib/src/android/gradle.dart
+++ b/packages/flutter_tools/lib/src/android/gradle.dart
@@ -16,7 +16,6 @@ import '../base/utils.dart';
 import '../build_info.dart';
 import '../cache.dart';
 import '../globals.dart';
-import '../plugins.dart';
 import 'android_sdk.dart';
 import 'android_studio.dart';
 

--- a/packages/flutter_tools/lib/src/android/gradle.dart
+++ b/packages/flutter_tools/lib/src/android/gradle.dart
@@ -94,7 +94,6 @@ Future<GradleProject> _gradleProject() async {
 Future<GradleProject> _readGradleProject() async {
   final String gradle = await _ensureGradle();
   updateLocalProperties();
-  injectPlugins();
   try {
     final Status status = logger.startProgress('Resolving dependencies...', expectSlowOperation: true);
     final RunResult runResult = await runCheckedAsync(

--- a/packages/flutter_tools/lib/src/application_package.dart
+++ b/packages/flutter_tools/lib/src/application_package.dart
@@ -181,7 +181,7 @@ abstract class IOSApp extends ApplicationPackage {
     if (id == null)
       return null;
     final String projectPath = fs.path.join('ios', 'Runner.xcodeproj');
-    final Map<String, String> buildSettings = getXcodeBuildSettings(projectPath, 'Runner');
+    final Map<String, String> buildSettings = const XcodeProjectInterpreter().getBuildSettings(projectPath, 'Runner');
     id = substituteXcodeVariables(id, buildSettings);
 
     return new BuildableIOSApp(

--- a/packages/flutter_tools/lib/src/application_package.dart
+++ b/packages/flutter_tools/lib/src/application_package.dart
@@ -181,7 +181,7 @@ abstract class IOSApp extends ApplicationPackage {
     if (id == null)
       return null;
     final String projectPath = fs.path.join('ios', 'Runner.xcodeproj');
-    final Map<String, String> buildSettings = const XcodeProjectInterpreter().getBuildSettings(projectPath, 'Runner');
+    final Map<String, String> buildSettings = xcodeProjectInterpreter.getBuildSettings(projectPath, 'Runner');
     id = substituteXcodeVariables(id, buildSettings);
 
     return new BuildableIOSApp(

--- a/packages/flutter_tools/lib/src/application_package.dart
+++ b/packages/flutter_tools/lib/src/application_package.dart
@@ -185,7 +185,7 @@ abstract class IOSApp extends ApplicationPackage {
     id = substituteXcodeVariables(id, buildSettings);
 
     return new BuildableIOSApp(
-      appDirectory: fs.path.join('ios'),
+      appDirectory: 'ios',
       projectBundleId: id,
       buildSettings: buildSettings,
     );

--- a/packages/flutter_tools/lib/src/commands/create.dart
+++ b/packages/flutter_tools/lib/src/commands/create.dart
@@ -14,14 +14,10 @@ import '../base/common.dart';
 import '../base/file_system.dart';
 import '../base/os.dart';
 import '../base/utils.dart';
-import '../build_info.dart';
 import '../cache.dart';
 import '../dart/pub.dart';
 import '../doctor.dart';
-import '../flx.dart' as flx;
 import '../globals.dart';
-import '../ios/xcodeproj.dart';
-import '../plugins.dart';
 import '../project.dart';
 import '../runner/flutter_command.dart';
 import '../template.dart';
@@ -232,16 +228,9 @@ class CreateCommand extends FlutterCommand {
     printStatus('Wrote $generatedCount files.');
     printStatus('');
 
-    updateXcodeGeneratedProperties(
-      projectPath: appPath,
-      buildInfo: BuildInfo.debug,
-      target: flx.defaultMainPath,
-      previewDart2: false,
-    );
-
     if (argResults['pub']) {
       await pubGet(context: PubContext.create, directory: appPath, offline: argResults['offline']);
-      injectPlugins(directory: appPath);
+      new FlutterProject(fs.directory(appPath)).ensureReadyForPlatformSpecificTooling();
     }
 
     if (android_sdk.androidSdk != null)

--- a/packages/flutter_tools/lib/src/commands/create.dart
+++ b/packages/flutter_tools/lib/src/commands/create.dart
@@ -236,7 +236,6 @@ class CreateCommand extends FlutterCommand {
       projectPath: appPath,
       buildInfo: BuildInfo.debug,
       target: flx.defaultMainPath,
-      hasPlugins: generatePlugin,
       previewDart2: false,
     );
 

--- a/packages/flutter_tools/lib/src/commands/inject_plugins.dart
+++ b/packages/flutter_tools/lib/src/commands/inject_plugins.dart
@@ -24,7 +24,8 @@ class InjectPluginsCommand extends FlutterCommand {
 
   @override
   Future<Null> runCommand() async {
-    final bool result = injectPlugins().hasPlugin;
+    injectPlugins();
+    final bool result = hasPlugins();
     if (result) {
       printStatus('GeneratedPluginRegistrants successfully written.');
     } else {

--- a/packages/flutter_tools/lib/src/commands/packages.dart
+++ b/packages/flutter_tools/lib/src/commands/packages.dart
@@ -4,11 +4,10 @@
 
 import 'dart:async';
 
-import 'package:flutter_tools/src/plugins.dart';
-
 import '../base/common.dart';
 import '../base/os.dart';
 import '../dart/pub.dart';
+import '../plugins.dart';
 import '../runner/flutter_command.dart';
 
 class PackagesCommand extends FlutterCommand {

--- a/packages/flutter_tools/lib/src/commands/packages.dart
+++ b/packages/flutter_tools/lib/src/commands/packages.dart
@@ -5,9 +5,10 @@
 import 'dart:async';
 
 import '../base/common.dart';
+import '../base/file_system.dart';
 import '../base/os.dart';
 import '../dart/pub.dart';
-import '../plugins.dart';
+import '../project.dart';
 import '../runner/flutter_command.dart';
 
 class PackagesCommand extends FlutterCommand {
@@ -76,7 +77,7 @@ class PackagesGetCommand extends FlutterCommand {
       offline: argResults['offline'],
       checkLastModified: false,
     );
-    injectPlugins(directory: target);
+    new FlutterProject(fs.directory(target)).ensureReadyForPlatformSpecificTooling();
   }
 }
 

--- a/packages/flutter_tools/lib/src/commands/packages.dart
+++ b/packages/flutter_tools/lib/src/commands/packages.dart
@@ -4,6 +4,8 @@
 
 import 'dart:async';
 
+import 'package:flutter_tools/src/plugins.dart';
+
 import '../base/common.dart';
 import '../base/os.dart';
 import '../dart/pub.dart';
@@ -75,6 +77,7 @@ class PackagesGetCommand extends FlutterCommand {
       offline: argResults['offline'],
       checkLastModified: false,
     );
+    injectPlugins(directory: target);
   }
 }
 

--- a/packages/flutter_tools/lib/src/ios/cocoapods.dart
+++ b/packages/flutter_tools/lib/src/ios/cocoapods.dart
@@ -129,7 +129,7 @@ class CocoaPods {
       final String include = '#include "Pods/Target Support Files/Pods-Runner/Pods-Runner.${mode
           .toLowerCase()}.xcconfig"';
       if (!content.contains(include))
-        file.writeAsStringSync('$include\n$content');
+        file.writeAsStringSync('$include\n$content', flush: true);
     }
   }
 

--- a/packages/flutter_tools/lib/src/ios/cocoapods.dart
+++ b/packages/flutter_tools/lib/src/ios/cocoapods.dart
@@ -63,6 +63,9 @@ class CocoaPods {
     bool isSwift: false,
     bool flutterPodChanged: true,
   }) async {
+    if (!(await appIosDir.childFile('Podfile').exists())) {
+      throwToolExit('Podfile missing');
+    }
     if (await _checkPodCondition()) {
       if (_shouldRunPodInstall(appIosDir.path, flutterPodChanged))
         await _runPodInstall(appIosDir, iosEngineDir);
@@ -134,6 +137,15 @@ class CocoaPods {
       if (!content.contains(include))
         file.writeAsStringSync('$include\n$content', flush: true);
     }
+  }
+
+  /// Ensures that pod install is deemed needed on next check.
+  void invalidatePodInstallOutput(String directory) {
+    final File manifest = fs.file(
+      fs.path.join(directory, 'ios', 'Pods', 'Manifest.lock'),
+    );
+    if (manifest.existsSync())
+      manifest.deleteSync();
   }
 
   // Check if you need to run pod install.

--- a/packages/flutter_tools/lib/src/ios/cocoapods.dart
+++ b/packages/flutter_tools/lib/src/ios/cocoapods.dart
@@ -100,10 +100,11 @@ class CocoaPods {
   /// Ensures the `ios` sub-project of the Flutter project at [directory]
   /// contains a suitable `Podfile` and that its `Flutter/Xxx.xcconfig` files
   /// include pods configuration.
-  void setupPodfile(String directory) {
+  void setupPodfile(String directory, {XcodeProjectInterpreter interpreter}) {
+    interpreter ??= const XcodeProjectInterpreter();
     final String podfilePath = fs.path.join(directory, 'ios', 'Podfile');
-    if (!fs.file(podfilePath).existsSync()) {
-      final bool isSwift = getXcodeBuildSettings(
+    if (!fs.file(podfilePath).existsSync() && interpreter.canInterpretXcodeProjects) {
+      final bool isSwift = interpreter.getBuildSettings(
         fs.path.join(directory, 'ios', 'Runner.xcodeproj'),
         'Runner',
       ).containsKey('SWIFT_VERSION');

--- a/packages/flutter_tools/lib/src/ios/cocoapods.dart
+++ b/packages/flutter_tools/lib/src/ios/cocoapods.dart
@@ -102,8 +102,12 @@ class CocoaPods {
   /// include pods configuration.
   void setupPodfile(String directory, {XcodeProjectInterpreter interpreter}) {
     interpreter ??= const XcodeProjectInterpreter();
+    if (!interpreter.canInterpretXcodeProjects) {
+      // Don't do anything for iOS when host platform doesn't support it anyway.
+      return;
+    }
     final String podfilePath = fs.path.join(directory, 'ios', 'Podfile');
-    if (!fs.file(podfilePath).existsSync() && interpreter.canInterpretXcodeProjects) {
+    if (!fs.file(podfilePath).existsSync()) {
       final bool isSwift = interpreter.getBuildSettings(
         fs.path.join(directory, 'ios', 'Runner.xcodeproj'),
         'Runner',

--- a/packages/flutter_tools/lib/src/ios/cocoapods.dart
+++ b/packages/flutter_tools/lib/src/ios/cocoapods.dart
@@ -105,7 +105,10 @@ class CocoaPods {
     if (fs.file(podfilePath).existsSync()) {
       return;
     }
-    final bool isSwift = getXcodeBuildSettings(iosPath, 'Runner').containsKey('SWIFT_VERSION');
+    final bool isSwift = getXcodeBuildSettings(
+      fs.path.join(iosPath, 'Runner.xcodeproj'),
+      'Runner',
+    ).containsKey('SWIFT_VERSION');
     final File podfileTemplate = fs.file(fs.path.join(
       Cache.flutterRoot,
       'packages',

--- a/packages/flutter_tools/lib/src/ios/cocoapods.dart
+++ b/packages/flutter_tools/lib/src/ios/cocoapods.dart
@@ -99,7 +99,7 @@ class CocoaPods {
 
   /// Creates a default `Podfile` in the Flutter project at [directory],
   /// unless one already exists at `ios/Podfile`.
-  Future<Null> createPodfileIfMissing(String directory) async {
+  void createPodfileIfMissing(String directory) {
     final String iosPath = fs.path.join(directory, 'ios');
     final String podfilePath = fs.path.join(iosPath, 'Podfile');
     if (fs.file(podfilePath).existsSync()) {
@@ -118,19 +118,18 @@ class CocoaPods {
       isSwift ? 'Podfile-swift' : 'Podfile-objc',
     ));
     podfileTemplate.copySync(podfilePath);
-    await _addPodsDependencyToFlutterXcconfig(directory, 'Debug');
-    await _addPodsDependencyToFlutterXcconfig(directory, 'Release');
+    _addPodsDependencyToFlutterXcconfig(directory, 'Debug');
+    _addPodsDependencyToFlutterXcconfig(directory, 'Release');
   }
 
-  Future<Null> _addPodsDependencyToFlutterXcconfig(String directory, String mode) async {
+  void _addPodsDependencyToFlutterXcconfig(String directory, String mode) {
     final File file = fs.file(fs.path.join(directory, 'ios', 'Flutter', '$mode.xcconfig'));
-    if (await file.exists()) {
-      final String content = await file.readAsString();
+    if (file.existsSync()) {
+      final String content = file.readAsStringSync();
       final String include = '#include "Pods/Target Support Files/Pods-Runner/Pods-Runner.${mode
           .toLowerCase()}.xcconfig"';
-      if (!content.contains(include)) {
-        await file.writeAsString('$include\n$content');
-      }
+      if (!content.contains(include))
+        file.writeAsStringSync('$include\n$content');
     }
   }
 

--- a/packages/flutter_tools/lib/src/ios/cocoapods.dart
+++ b/packages/flutter_tools/lib/src/ios/cocoapods.dart
@@ -100,15 +100,14 @@ class CocoaPods {
   /// Ensures the `ios` sub-project of the Flutter project at [directory]
   /// contains a suitable `Podfile` and that its `Flutter/Xxx.xcconfig` files
   /// include pods configuration.
-  void setupPodfile(String directory, {XcodeProjectInterpreter interpreter}) {
-    interpreter ??= const XcodeProjectInterpreter();
-    if (!interpreter.canInterpretXcodeProjects) {
-      // Don't do anything for iOS when host platform doesn't support it anyway.
+  void setupPodfile(String directory) {
+    if (!xcodeProjectInterpreter.canInterpretXcodeProjects) {
+      // Don't do anything for iOS when host platform doesn't support it.
       return;
     }
     final String podfilePath = fs.path.join(directory, 'ios', 'Podfile');
     if (!fs.file(podfilePath).existsSync()) {
-      final bool isSwift = interpreter.getBuildSettings(
+      final bool isSwift = xcodeProjectInterpreter.getBuildSettings(
         fs.path.join(directory, 'ios', 'Runner.xcodeproj'),
         'Runner',
       ).containsKey('SWIFT_VERSION');

--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -217,7 +217,7 @@ Future<XcodeBuildResult> buildXcodeProject({
     return new XcodeBuildResult(success: false);
   }
 
-  final XcodeProjectInfo projectInfo = const XcodeProjectInterpreter().getInfo(app.appDirectory);
+  final XcodeProjectInfo projectInfo = xcodeProjectInterpreter.getInfo(app.appDirectory);
   if (!projectInfo.targets.contains('Runner')) {
     printError('The Xcode project does not define target "Runner" which is needed by Flutter tooling.');
     printError('Open Xcode to fix the problem:');

--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -217,7 +217,7 @@ Future<XcodeBuildResult> buildXcodeProject({
     return new XcodeBuildResult(success: false);
   }
 
-  final XcodeProjectInfo projectInfo = new XcodeProjectInfo.fromProjectSync(app.appDirectory);
+  final XcodeProjectInfo projectInfo = const XcodeProjectInterpreter().getInfo(app.appDirectory);
   if (!projectInfo.targets.contains('Runner')) {
     printError('The Xcode project does not define target "Runner" which is needed by Flutter tooling.');
     printError('Open Xcode to fix the problem:');

--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -261,7 +261,6 @@ Future<XcodeBuildResult> buildXcodeProject({
     projectPath: fs.currentDirectory.path,
     buildInfo: buildInfo,
     target: target,
-    hasPlugins: hasFlutterPlugins,
     previewDart2: buildInfo.previewDart2,
   );
 
@@ -417,7 +416,7 @@ Future<XcodeBuildResult> buildXcodeProject({
 
 String readGeneratedXcconfig(String appPath) {
   final String generatedXcconfigPath =
-      fs.path.join(fs.currentDirectory.path, appPath, 'Flutter','Generated.xcconfig');
+      fs.path.join(fs.currentDirectory.path, appPath, 'Flutter', 'Generated.xcconfig');
   final File generatedXcconfigFile = fs.file(generatedXcconfigPath);
   if (!generatedXcconfigFile.existsSync())
     return null;

--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -254,8 +254,7 @@ Future<XcodeBuildResult> buildXcodeProject({
   // copied over to a location that is suitable for Xcodebuild to find them.
   final Directory appDirectory = fs.directory(app.appDirectory);
   await _addServicesToBundle(appDirectory);
-  final InjectPluginsResult injectPluginsResult = injectPlugins();
-  final bool hasFlutterPlugins = injectPluginsResult.hasPlugin;
+  final bool hasFlutterPlugins = hasPlugins();
   final String previousGeneratedXcconfig = readGeneratedXcconfig(app.appDirectory);
 
   updateXcodeGeneratedProperties(
@@ -272,8 +271,7 @@ Future<XcodeBuildResult> buildXcodeProject({
         appIosDir: appDirectory,
         iosEngineDir: flutterFrameworkDir(buildInfo.mode),
         isSwift: app.isSwift,
-        pluginOrFlutterPodChanged: (injectPluginsResult.hasChanged
-            || previousGeneratedXcconfig != currentGeneratedXcconfig),
+        flutterPodChanged: (previousGeneratedXcconfig != currentGeneratedXcconfig),
     );
   }
 

--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -256,7 +256,7 @@ Future<XcodeBuildResult> buildXcodeProject({
   await _addServicesToBundle(appDirectory);
   final String previousGeneratedXcconfig = readGeneratedXcconfig(app.appDirectory);
 
-  updateXcodeGeneratedProperties(
+  updateGeneratedXcodeProperties(
     projectPath: fs.currentDirectory.path,
     buildInfo: buildInfo,
     target: target,
@@ -266,10 +266,10 @@ Future<XcodeBuildResult> buildXcodeProject({
   if (hasPlugins()) {
     final String currentGeneratedXcconfig = readGeneratedXcconfig(app.appDirectory);
     await cocoaPods.processPods(
-        appIosDir: appDirectory,
-        iosEngineDir: flutterFrameworkDir(buildInfo.mode),
-        isSwift: app.isSwift,
-        flutterPodChanged: (previousGeneratedXcconfig != currentGeneratedXcconfig),
+      appIosDir: appDirectory,
+      iosEngineDir: flutterFrameworkDir(buildInfo.mode),
+      isSwift: app.isSwift,
+      flutterPodChanged: (previousGeneratedXcconfig != currentGeneratedXcconfig),
     );
   }
 

--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -254,7 +254,6 @@ Future<XcodeBuildResult> buildXcodeProject({
   // copied over to a location that is suitable for Xcodebuild to find them.
   final Directory appDirectory = fs.directory(app.appDirectory);
   await _addServicesToBundle(appDirectory);
-  final bool hasFlutterPlugins = hasPlugins();
   final String previousGeneratedXcconfig = readGeneratedXcconfig(app.appDirectory);
 
   updateXcodeGeneratedProperties(
@@ -264,7 +263,7 @@ Future<XcodeBuildResult> buildXcodeProject({
     previewDart2: buildInfo.previewDart2,
   );
 
-  if (hasFlutterPlugins) {
+  if (hasPlugins()) {
     final String currentGeneratedXcconfig = readGeneratedXcconfig(app.appDirectory);
     await cocoaPods.processPods(
         appIosDir: appDirectory,

--- a/packages/flutter_tools/lib/src/ios/simulators.dart
+++ b/packages/flutter_tools/lib/src/ios/simulators.dart
@@ -291,7 +291,7 @@ class IOSSimulator extends Device {
   }
 
   @override
-  Future<LaunchResult> pstartAp(
+  Future<LaunchResult> startApp(
     ApplicationPackage app, {
     String mainPath,
     String route,

--- a/packages/flutter_tools/lib/src/ios/simulators.dart
+++ b/packages/flutter_tools/lib/src/ios/simulators.dart
@@ -291,7 +291,7 @@ class IOSSimulator extends Device {
   }
 
   @override
-  Future<LaunchResult> startApp(
+  Future<LaunchResult> pstartAp(
     ApplicationPackage app, {
     String mainPath,
     String route,

--- a/packages/flutter_tools/lib/src/ios/xcodeproj.dart
+++ b/packages/flutter_tools/lib/src/ios/xcodeproj.dart
@@ -62,9 +62,7 @@ void updateXcodeGeneratedProperties({
   localsFile.writeAsStringSync(localsBuffer.toString());
 }
 
-/// Interpreter of Xcode projects.
-///
-/// Encapsulates the system tool needed to facilitate unit testing of clients.
+/// Interpreter of Xcode projects settings.
 class XcodeProjectInterpreter {
   static const String _executable = '/usr/bin/xcodebuild';
 

--- a/packages/flutter_tools/lib/src/ios/xcodeproj.dart
+++ b/packages/flutter_tools/lib/src/ios/xcodeproj.dart
@@ -23,7 +23,6 @@ void updateXcodeGeneratedProperties({
   @required String projectPath,
   @required BuildInfo buildInfo,
   @required String target,
-  @required bool hasPlugins,
   @required bool previewDart2,
 }) {
   final StringBuffer localsBuffer = new StringBuffer();
@@ -57,10 +56,6 @@ void updateXcodeGeneratedProperties({
   if (previewDart2) {
     localsBuffer.writeln('PREVIEW_DART_2=true');
   }
-
-  // Add dependency to CocoaPods' generated project only if plugins are used.
-  if (hasPlugins)
-    localsBuffer.writeln('#include "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"');
 
   final File localsFile = fs.file(fs.path.join(projectPath, 'ios', 'Flutter', 'Generated.xcconfig'));
   localsFile.createSync(recursive: true);

--- a/packages/flutter_tools/lib/src/ios/xcodeproj.dart
+++ b/packages/flutter_tools/lib/src/ios/xcodeproj.dart
@@ -5,6 +5,7 @@
 import 'package:meta/meta.dart';
 
 import '../artifacts.dart';
+import '../base/context.dart';
 import '../base/file_system.dart';
 import '../base/process.dart';
 import '../base/utils.dart';
@@ -61,6 +62,11 @@ void updateXcodeGeneratedProperties({
   localsFile.createSync(recursive: true);
   localsFile.writeAsStringSync(localsBuffer.toString());
 }
+
+XcodeProjectInterpreter get xcodeProjectInterpreter => context.putIfAbsent(
+  XcodeProjectInterpreter,
+  () => const XcodeProjectInterpreter(),
+);
 
 /// Interpreter of Xcode projects settings.
 class XcodeProjectInterpreter {

--- a/packages/flutter_tools/lib/src/plugins.dart
+++ b/packages/flutter_tools/lib/src/plugins.dart
@@ -241,19 +241,12 @@ void injectPlugins({String directory}) {
     _writeAndroidPluginRegistrant(directory, plugins);
   if (fs.isDirectorySync(fs.path.join(directory, 'ios'))) {
     _writeIOSPluginRegistrant(directory, plugins);
+    final CocoaPods cocoaPods = const CocoaPods();
     if (plugins.isNotEmpty)
-      const CocoaPods().setupPodfile(directory);
+      cocoaPods.setupPodfile(directory);
     if (changed)
-      _ensurePodInstallIsExecutedOnNextIOSBuild(directory);
+      cocoaPods.invalidatePodInstallOutput(directory);
   }
-}
-
-void _ensurePodInstallIsExecutedOnNextIOSBuild(String directory) {
-  final File manifest = fs.file(
-    fs.path.join(directory, 'ios', 'Pods', 'Manifest.lock'),
-  );
-  if (manifest.existsSync())
-    manifest.deleteSync();
 }
 
 /// Returns whether the Flutter project at the specified [directory]

--- a/packages/flutter_tools/lib/src/plugins.dart
+++ b/packages/flutter_tools/lib/src/plugins.dart
@@ -9,6 +9,7 @@ import 'package:yaml/yaml.dart';
 import 'base/file_system.dart';
 import 'dart/package_map.dart';
 import 'globals.dart';
+import 'ios/cocoapods.dart';
 
 class Plugin {
   final String name;
@@ -140,7 +141,6 @@ void _writeAndroidPluginRegistrant(String directory, List<Plugin> plugins) {
   final Map<String, dynamic> context = <String, dynamic>{
     'plugins': androidPlugins,
   };
-  print('Here BB plugins');
 
   final String pluginRegistry =
       new mustache.Template(_androidPluginRegistryTemplate).renderString(context);
@@ -233,6 +233,9 @@ void injectPlugins({String directory}) {
     _writeAndroidPluginRegistrant(directory, plugins);
   if (fs.isDirectorySync(fs.path.join(directory, 'ios'))) {
     _writeIOSPluginRegistrant(directory, plugins);
+    if (plugins.isNotEmpty) {
+      const CocoaPods().createPodfileIfMissing(directory);
+    }
     if (changed)
       _ensurePodInstallIsExecutedOnNextIosBuild(directory);
   }

--- a/packages/flutter_tools/lib/src/plugins.dart
+++ b/packages/flutter_tools/lib/src/plugins.dart
@@ -231,6 +231,10 @@ class InjectPluginsResult{
 /// Injects plugins found in `pubspec.yaml` into the platform-specific projects.
 void injectPlugins({String directory}) {
   directory ??= fs.currentDirectory.path;
+  if (fs.file(fs.path.join(directory, 'example', 'pubspec.yaml')).existsSync()) {
+    // Switch to example app if in plugin project template.
+    directory = fs.path.join(directory, 'example');
+  }
   final List<Plugin> plugins = _findPlugins(directory);
   final bool changed = _writeFlutterPluginsList(directory, plugins);
   if (fs.isDirectorySync(fs.path.join(directory, 'android')))
@@ -238,7 +242,7 @@ void injectPlugins({String directory}) {
   if (fs.isDirectorySync(fs.path.join(directory, 'ios'))) {
     _writeIOSPluginRegistrant(directory, plugins);
     if (plugins.isNotEmpty)
-      const CocoaPods().createPodfileIfMissing(directory);
+      const CocoaPods().setupPodfile(directory);
     if (changed)
       _ensurePodInstallIsExecutedOnNextIOSBuild(directory);
   }

--- a/packages/flutter_tools/lib/src/plugins.dart
+++ b/packages/flutter_tools/lib/src/plugins.dart
@@ -233,15 +233,14 @@ void injectPlugins({String directory}) {
     _writeAndroidPluginRegistrant(directory, plugins);
   if (fs.isDirectorySync(fs.path.join(directory, 'ios'))) {
     _writeIOSPluginRegistrant(directory, plugins);
-    if (plugins.isNotEmpty) {
+    if (plugins.isNotEmpty)
       const CocoaPods().createPodfileIfMissing(directory);
-    }
     if (changed)
-      _ensurePodInstallIsExecutedOnNextIosBuild(directory);
+      _ensurePodInstallIsExecutedOnNextIOSBuild(directory);
   }
 }
 
-void _ensurePodInstallIsExecutedOnNextIosBuild(String directory) {
+void _ensurePodInstallIsExecutedOnNextIOSBuild(String directory) {
   final File manifest = fs.file(
     fs.path.join(directory, 'ios', 'Pods', 'Manifest.lock'),
   );

--- a/packages/flutter_tools/lib/src/project.dart
+++ b/packages/flutter_tools/lib/src/project.dart
@@ -4,7 +4,11 @@
 
 import 'dart:async';
 import 'dart:convert';
+
 import 'base/file_system.dart';
+import 'ios/xcodeproj.dart';
+import 'plugins.dart';
+
 
 /// Represents the contents of a Flutter project at the specified [directory].
 class FlutterProject {
@@ -43,8 +47,25 @@ class FlutterProject {
   /// The Android sub project of this project.
   AndroidProject get android => new AndroidProject(directory.childDirectory('android'));
 
+  /// Returns true if this project is a plugin project.
+  bool get isPluginProject => directory.childDirectory('example').childFile('pubspec.yaml').existsSync();
+
   /// The example sub project of this (plugin) project.
   FlutterProject get example => new FlutterProject(directory.childDirectory('example'));
+
+  /// Generates project files necessary to make Gradle builds work on Android
+  /// and CocoaPods+Xcode work on iOS.
+  void ensureReadyForPlatformSpecificTooling() {
+    if (!directory.existsSync()) {
+      return;
+    }
+    if (isPluginProject) {
+      example.ensureReadyForPlatformSpecificTooling();
+    } else {
+      injectPlugins(directory: directory.path);
+      generateXcodeProperties(directory.path);
+    }
+  }
 }
 
 /// Represents the contents of the ios/ folder of a Flutter project.

--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -6,7 +6,6 @@ import 'dart:async';
 
 import 'package:args/args.dart';
 import 'package:args/command_runner.dart';
-import 'package:flutter_tools/src/plugins.dart';
 import 'package:meta/meta.dart';
 import 'package:quiver/strings.dart';
 
@@ -22,6 +21,7 @@ import '../device.dart';
 import '../doctor.dart';
 import '../flx.dart' as flx;
 import '../globals.dart';
+import '../plugins.dart';
 import '../usage.dart';
 import 'flutter_command_runner.dart';
 

--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 
 import 'package:args/args.dart';
 import 'package:args/command_runner.dart';
+import 'package:flutter_tools/src/project.dart';
 import 'package:meta/meta.dart';
 import 'package:quiver/strings.dart';
 
@@ -275,7 +276,7 @@ abstract class FlutterCommand extends Command<Null> {
 
     if (shouldRunPub) {
       await pubGet(context: PubContext.getVerifyContext(name));
-      injectPlugins();
+      new FlutterProject(fs.currentDirectory).ensureReadyForPlatformSpecificTooling();
     }
 
     setupApplicationPackages();

--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 
 import 'package:args/args.dart';
 import 'package:args/command_runner.dart';
+import 'package:flutter_tools/src/plugins.dart';
 import 'package:meta/meta.dart';
 import 'package:quiver/strings.dart';
 
@@ -272,8 +273,10 @@ abstract class FlutterCommand extends Command<Null> {
     if (shouldUpdateCache)
       await cache.updateAll();
 
-    if (shouldRunPub)
+    if (shouldRunPub) {
       await pubGet(context: PubContext.getVerifyContext(name));
+      injectPlugins();
+    }
 
     setupApplicationPackages();
 

--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -6,7 +6,6 @@ import 'dart:async';
 
 import 'package:args/args.dart';
 import 'package:args/command_runner.dart';
-import 'package:flutter_tools/src/project.dart';
 import 'package:meta/meta.dart';
 import 'package:quiver/strings.dart';
 
@@ -22,7 +21,7 @@ import '../device.dart';
 import '../doctor.dart';
 import '../flx.dart' as flx;
 import '../globals.dart';
-import '../plugins.dart';
+import '../project.dart';
 import '../usage.dart';
 import 'flutter_command_runner.dart';
 

--- a/packages/flutter_tools/test/commands/packages_test.dart
+++ b/packages/flutter_tools/test/commands/packages_test.dart
@@ -90,15 +90,15 @@ void main() {
       'android/app/src/main/java/io/flutter/plugins/GeneratedPluginRegistrant.java',
     ];
 
-    final List<String> pluginWitnesses = <String>['.flutter-plugins'];
-    final Map<String, String> pluginContentWitnesses = <String, String>{};
-    if (const XcodeProjectInterpreter().canInterpretXcodeProjects) {
-      pluginWitnesses.add('ios/Podfile');
-      pluginContentWitnesses['ios/Flutter/Debug.xcconfig']
-        = '#include "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"';
-      pluginContentWitnesses['ios/Flutter/Release.xcconfig']
-        = '#include "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"';
-    }
+    const List<String> pluginWitnesses = const <String>[
+      '.flutter-plugins',
+      'ios/Podfile',
+    ];
+
+    const Map<String, String> pluginContentWitnesses = const <String, String>{
+      'ios/Flutter/Debug.xcconfig': '#include "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"',
+      'ios/Flutter/Release.xcconfig': '#include "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"',
+    };
 
     void expectDependenciesResolved(String projectPath) {
       for (String output in pubOutput) {

--- a/packages/flutter_tools/test/commands/packages_test.dart
+++ b/packages/flutter_tools/test/commands/packages_test.dart
@@ -77,41 +77,59 @@ void main() {
       );
     }
 
+    const List<String> pubOutput = const <String>[
+      '.packages',
+      'pubspec.lock',
+    ];
+
+    const List<String> pluginRegistrants = const <String>[
+      'ios/Runner/GeneratedPluginRegistrant.h',
+      'ios/Runner/GeneratedPluginRegistrant.m',
+      'android/app/src/main/java/io/flutter/plugins/GeneratedPluginRegistrant.java',
+    ];
+
+    const List<String> pluginWitnesses = const <String>[
+      '.flutter-plugins',
+      'ios/Podfile',
+    ];
+
+    const Map<String, String> pluginContentWitnesses = const <String, String>{
+      'ios/Flutter/Debug.xcconfig': '#include "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"',
+      'ios/Flutter/Release.xcconfig': '#include "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"',
+    };
+
     void expectDependenciesResolved(String projectPath) {
-      expectExists(projectPath, '.packages');
-      expectExists(projectPath, 'pubspec.lock');
+      for (String output in pubOutput) {
+        expectExists(projectPath, output);
+      }
     }
 
     void expectZeroPluginsInjected(String projectPath) {
-      expectNotExists(projectPath, '.flutter-plugins');
-      expectNotExists(projectPath, 'ios/Podfile');
-      expectExists(projectPath, 'ios/Runner/GeneratedPluginRegistrant.h');
-      expectExists(projectPath, 'ios/Runner/GeneratedPluginRegistrant.m');
-      expectExists(projectPath, 'android/app/src/main/java/io/flutter/plugins/GeneratedPluginRegistrant.java');
-      expectNotContains(projectPath, 'ios/Flutter/Debug.xcconfig', '#include "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"');
-      expectNotContains(projectPath, 'ios/Flutter/Release.xcconfig', '#include "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"');
+      for (final String registrant in pluginRegistrants) {
+        expectExists(projectPath, registrant);
+      }
+      for (final String witness in pluginWitnesses) {
+        expectNotExists(projectPath, witness);
+      }
+      pluginContentWitnesses.forEach((String witness, String content) {
+        expectNotContains(projectPath, witness, content);
+      });
     }
 
     void expectPluginInjected(String projectPath) {
-      expectExists(projectPath, '.flutter-plugins');
-      expectExists(projectPath, 'ios/Podfile');
-      expectExists(projectPath, 'ios/Runner/GeneratedPluginRegistrant.h');
-      expectExists(projectPath, 'ios/Runner/GeneratedPluginRegistrant.m');
-      expectExists(projectPath, 'android/app/src/main/java/io/flutter/plugins/GeneratedPluginRegistrant.java');
-      expectContains(projectPath, 'ios/Flutter/Debug.xcconfig', '#include "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"');
-      expectContains(projectPath, 'ios/Flutter/Release.xcconfig', '#include "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"');
+      for (final String registrant in pluginRegistrants) {
+        expectExists(projectPath, registrant);
+      }
+      for (final String witness in pluginWitnesses) {
+        expectExists(projectPath, witness);
+      }
+      pluginContentWitnesses.forEach((String witness, String content) {
+        expectContains(projectPath, witness, content);
+      });
     }
 
     void removeGeneratedFiles(String projectPath) {
-      for (String path in <String>[
-        '.packages',
-        'pubspec.lock',
-        '.flutter-plugins',
-        'ios/Podfile',
-        'ios/Runner/GeneratedPluginRegistrant.h',
-        'ios/Runner/GeneratedPluginRegistrant.m',
-        'android/app/src/main/java/io/flutter/plugins/GeneratedPluginRegistrant.java',
-      ]) {
+      for (String path in <String>[]..addAll(pubOutput)..addAll(pluginWitnesses)..addAll(pluginRegistrants)) {
         final File file = fs.file(fs.path.join(projectPath, path));
         if (file.existsSync())
           file.deleteSync();

--- a/packages/flutter_tools/test/commands/packages_test.dart
+++ b/packages/flutter_tools/test/commands/packages_test.dart
@@ -7,10 +7,8 @@ import 'dart:async';
 import 'package:args/command_runner.dart';
 import 'package:flutter_tools/src/base/file_system.dart' hide IOSink;
 import 'package:flutter_tools/src/base/io.dart';
-import 'package:flutter_tools/src/base/utils.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/commands/packages.dart';
-import 'package:flutter_tools/src/ios/xcodeproj.dart';
 import 'package:process/process.dart';
 import 'package:test/test.dart';
 

--- a/packages/flutter_tools/test/ios/cocoapods_test.dart
+++ b/packages/flutter_tools/test/ios/cocoapods_test.dart
@@ -194,7 +194,7 @@ Note: as of CocoaPods 1.0, `pod repo update` does not happen on `pod install` by
       await cocoaPodsUnderTest.processPods(
           appIosDir: projectUnderTest,
           iosEngineDir: 'engine/path',
-          pluginOrFlutterPodChanged: true
+          flutterPodChanged: true
       );
       verify(mockProcessManager.run(
         <String>['pod', 'install', '--verbose'],
@@ -223,7 +223,7 @@ Note: as of CocoaPods 1.0, `pod repo update` does not happen on `pod install` by
       await cocoaPodsUnderTest.processPods(
           appIosDir: projectUnderTest,
           iosEngineDir: 'engine/path',
-          pluginOrFlutterPodChanged: false
+          flutterPodChanged: false
       );
       verifyNever(mockProcessManager.run(
         <String>['pod', 'install', '--verbose'],

--- a/packages/flutter_tools/test/ios/cocoapods_test.dart
+++ b/packages/flutter_tools/test/ios/cocoapods_test.dart
@@ -107,6 +107,7 @@ void main() {
 
     testUsingContext(
         'include Pod config in xcconfig files, if not present', () {
+      when(mockXcodeProjectInterpreter.canInterpretXcodeProjects).thenReturn(true);
       podfile..createSync()..writeAsStringSync('Existing Podfile');
       debugConfigFile..createSync(recursive: true)..writeAsStringSync('Existing debug config');
       releaseConfigFile..createSync(recursive: true)..writeAsStringSync('Existing release config');

--- a/packages/flutter_tools/test/project_test.dart
+++ b/packages/flutter_tools/test/project_test.dart
@@ -17,6 +17,29 @@ void main() {
       final Directory directory = fs.directory('myproject');
       expect(new FlutterProject(directory).directory, directory);
     });
+    group('ensure ready for platform-specific tooling', () {
+      testInMemory('does nothing, if project is not created', () async {
+        final FlutterProject project = someProject();
+        project.ensureReadyForPlatformSpecificTooling();
+        expect(project.directory.existsSync(), isFalse);
+      });
+      testInMemory('injects plugins', () async {
+        final FlutterProject project = aProjectWithIos();
+        project.ensureReadyForPlatformSpecificTooling();
+        expect(project.ios.directory.childFile('Runner/GeneratedPluginRegistrant.h').existsSync(), isTrue);
+      });
+      testInMemory('generates Xcode configuration', () async {
+        final FlutterProject project = aProjectWithIos();
+        project.ensureReadyForPlatformSpecificTooling();
+        expect(project.ios.directory.childFile('Flutter/Generated.xcconfig').existsSync(), isTrue);
+      });
+      testInMemory('generates files in plugin example project', () async {
+        final FlutterProject project = aPluginProject();
+        project.ensureReadyForPlatformSpecificTooling();
+        expect(project.example.ios.directory.childFile('Runner/GeneratedPluginRegistrant.h').existsSync(), isTrue);
+        expect(project.example.ios.directory.childFile('Flutter/Generated.xcconfig').existsSync(), isTrue);
+      });
+    });
     group('organization names set', () {
       testInMemory('is empty, if project not created', () async {
         final FlutterProject project = someProject();
@@ -71,8 +94,23 @@ void main() {
   });
 }
 
-FlutterProject someProject() =>
-    new FlutterProject(fs.directory('some_project'));
+FlutterProject someProject() => new FlutterProject(fs.directory('some_project'));
+
+FlutterProject aProjectWithIos() {
+  final Directory directory = fs.directory('ios_project');
+  directory.childFile('pubspec.yaml').createSync(recursive: true);
+  directory.childFile('.packages').createSync(recursive: true);
+  directory.childDirectory('ios').createSync(recursive: true);
+  return new FlutterProject(directory);
+}
+
+FlutterProject aPluginProject() {
+  final Directory directory = fs.directory('plugin_project/example');
+  directory.childFile('pubspec.yaml').createSync(recursive: true);
+  directory.childFile('.packages').createSync(recursive: true);
+  directory.childDirectory('ios').createSync(recursive: true);
+  return new FlutterProject(directory.parent);
+}
 
 void testInMemory(String description, Future<Null> testMethod()) {
   testUsingContext(
@@ -82,6 +120,13 @@ void testInMemory(String description, Future<Null> testMethod()) {
       FileSystem: () => new MemoryFileSystem(),
     },
   );
+}
+
+void addPubPackages(Directory directory) {
+  directory.childFile('pubspec.yaml')
+    ..createSync(recursive: true);
+  directory.childFile('.packages')
+    ..createSync(recursive: true);
 }
 
 void addIosWithBundleId(Directory directory, String id) {

--- a/packages/flutter_tools/test/src/context.dart
+++ b/packages/flutter_tools/test/src/context.dart
@@ -19,6 +19,7 @@ import 'package:flutter_tools/src/device.dart';
 import 'package:flutter_tools/src/doctor.dart';
 import 'package:flutter_tools/src/ios/mac.dart';
 import 'package:flutter_tools/src/ios/simulators.dart';
+import 'package:flutter_tools/src/ios/xcodeproj.dart';
 import 'package:flutter_tools/src/run_hot.dart';
 import 'package:flutter_tools/src/usage.dart';
 import 'package:flutter_tools/src/version.dart';
@@ -50,6 +51,7 @@ void _defaultInitializeContext(AppContext testContext) {
     ..putIfAbsent(OperatingSystemUtils, () => new MockOperatingSystemUtils())
     ..putIfAbsent(PortScanner, () => new MockPortScanner())
     ..putIfAbsent(Xcode, () => new Xcode())
+    ..putIfAbsent(XcodeProjectInterpreter, () => new MockXcodeProjectInterpreter())
     ..putIfAbsent(IOSSimulatorUtils, () {
       final MockIOSSimulatorUtils mock = new MockIOSSimulatorUtils();
       when(mock.getAttachedDevices()).thenReturn(<IOSSimulator>[]);
@@ -260,6 +262,25 @@ class MockUsage implements Usage {
 
   @override
   void printWelcome() { }
+}
+
+class MockXcodeProjectInterpreter implements XcodeProjectInterpreter {
+  @override
+  bool get canInterpretXcodeProjects => true;
+
+  @override
+  Map<String, String> getBuildSettings(String projectPath, String target) {
+    return <String, String>{};
+  }
+
+  @override
+  XcodeProjectInfo getInfo(String projectPath) {
+    return new XcodeProjectInfo(
+      <String>['Runner'],
+      <String>['Debug', 'Release'],
+      <String>['Runner'],
+    );
+  }
 }
 
 class MockFlutterVersion extends Mock implements FlutterVersion {}


### PR DESCRIPTION
Move injection of Flutter plugins from just before build to just after getting/updating pub packages.

Plugin injection here means
* writing the `.flutter-plugins` file
* writing the `GeneratedPluginRegistrant.(java|h|m)` files
* writing the iOS `Podfile`, if it doesn't exit
* adding `#include "Pods/Target Support Files/Pods-Runner/Pods-Runner.xxx.xcconfig"` to `ios/Flutter/Xxx.xcconfig` files (cf. https://github.com/flutter/flutter/issues/12752).

**The intention** is to get us to a situation where upon initial project checkout or change to `pubspec.yaml`, the only step needed to get to a project buildable by platform-specific tooling is `flutter packages get`.

Discrepancies between `pubspec.yaml` and injected plugin files have caused usability problems (https://github.com/flutter/flutter/issues/11797). And we have been forced to check in the injected files as if they were source code (https://github.com/flutter/flutter/issues/13554) to make our project examples work out of the box.

Fixes #12752
Fixes #11797
Fixes #13554