### PR TITLE
ScaffoldGeometry plumbing.

### DIFF
--- a/packages/flutter/lib/src/material/scaffold.dart
+++ b/packages/flutter/lib/src/material/scaffold.dart
@@ -101,9 +101,9 @@ class _ScaffoldGeometryNotifier extends ValueNotifier<ScaffoldGeometry> {
       final RenderObject renderObject = context.findRenderObject();
       if (renderObject == null || !renderObject.owner.debugDoingPaint)
         throw new FlutterError(
-            'Scaffold.geometryOf() must only be accessed during the paint phase.\n\n'
-                'The ScaffoldGeometry is only available during the paint phase, because\n'
-                'its value is computed during the animation and layout phases prior to painting.'
+            'Scaffold.geometryOf() must only be accessed during the paint phase.\n'
+            'The ScaffoldGeometry is only available during the paint phase, because\n'
+            'its value is computed during the animation and layout phases prior to painting.'
         );
       return true;
     }());
@@ -115,14 +115,13 @@ class _ScaffoldGeometryNotifier extends ValueNotifier<ScaffoldGeometry> {
     Rect floatingActionButtonArea,
     double floatingActionButtonScale,
   }) {
-
     final double newFloatingActionButtonScale = floatingActionButtonScale ??  super.value?.floatingActionButtonScale;
     Rect newFloatingActionButtonArea;
     if (newFloatingActionButtonScale != 0.0)
-      newFloatingActionButtonArea = floatingActionButtonArea ??  super.value?.floatingActionButtonArea;
+      newFloatingActionButtonArea = floatingActionButtonArea ?? super.value?.floatingActionButtonArea;
 
     value = new ScaffoldGeometry(
-      bottomNavigationBarTop: bottomNavigationBarTop ??  super.value?.bottomNavigationBarTop,
+      bottomNavigationBarTop: bottomNavigationBarTop ?? super.value?.bottomNavigationBarTop,
       floatingActionButtonArea: newFloatingActionButtonArea,
       floatingActionButtonScale: newFloatingActionButtonScale,
     );

--- a/packages/flutter/lib/src/material/scaffold.dart
+++ b/packages/flutter/lib/src/material/scaffold.dart
@@ -39,6 +39,7 @@ enum _ScaffoldSlot {
 
 // Examples can assume:
 // ScaffoldGeometry scaffoldGeometry;
+
 /// Geometry information for scaffold components.
 ///
 /// To get a [ValueNotifier] for the scaffold geometry call

--- a/packages/flutter/lib/src/material/scaffold.dart
+++ b/packages/flutter/lib/src/material/scaffold.dart
@@ -86,19 +86,6 @@ class ScaffoldGeometry {
   ///
   /// This will be 0 when there is no [Scaffold.floatingActionButton] set.
   final double floatingActionButtonScale;
-
-  static ScaffoldGeometry _copyWith({
-    ScaffoldGeometry previousGeometry,
-    double bottomNavigationBarTop,
-    Rect floatingActionButtonPosition,
-    double floatingActionButtonScale,
-  }) {
-    return new ScaffoldGeometry(
-      bottomNavigationBarTop: bottomNavigationBarTop ??  previousGeometry?.bottomNavigationBarTop,
-      floatingActionButtonPosition: floatingActionButtonPosition ??  previousGeometry?.floatingActionButtonPosition,
-      floatingActionButtonScale: floatingActionButtonScale ??  previousGeometry?.floatingActionButtonScale,
-    );
-  }
 }
 
 class _ScaffoldGeometryNotifier extends ValueNotifier<ScaffoldGeometry> {
@@ -120,7 +107,17 @@ class _ScaffoldGeometryNotifier extends ValueNotifier<ScaffoldGeometry> {
     return super.value;
   }
 
-  ScaffoldGeometry get _partialValue => super.value;
+  void _updateWith({
+    double bottomNavigationBarTop,
+    Rect floatingActionButtonPosition,
+    double floatingActionButtonScale,
+  }) {
+    value = new ScaffoldGeometry(
+      bottomNavigationBarTop: bottomNavigationBarTop ??  super.value?.bottomNavigationBarTop,
+      floatingActionButtonPosition: floatingActionButtonPosition ??  super.value?.floatingActionButtonPosition,
+      floatingActionButtonScale: floatingActionButtonScale ??  super.value?.floatingActionButtonScale,
+    );
+  }
 }
 
 class _ScaffoldLayout extends MultiChildLayoutDelegate {
@@ -255,8 +252,7 @@ class _ScaffoldLayout extends MultiChildLayoutDelegate {
       positionChild(_ScaffoldSlot.endDrawer, Offset.zero);
     }
 
-    geometryNotifier.value = ScaffoldGeometry._copyWith(
-      previousGeometry: geometryNotifier._partialValue,
+    geometryNotifier._updateWith(
       bottomNavigationBarTop: bottomNavigationBarTop,
       floatingActionButtonPosition: floatingActionButtonRect,
     );
@@ -406,8 +402,7 @@ class _FloatingActionButtonTransitionState extends State<_FloatingActionButtonTr
   }
 
   void _updateGeometryScale(double scale) {
-    widget.geometryNotifier.value = ScaffoldGeometry._copyWith(
-      previousGeometry: widget.geometryNotifier._partialValue,
+    widget.geometryNotifier._updateWith(
       floatingActionButtonScale: scale,
     );
   }

--- a/packages/flutter/lib/src/material/scaffold.dart
+++ b/packages/flutter/lib/src/material/scaffold.dart
@@ -91,7 +91,6 @@ class _ScaffoldGeometryNotifier extends ValueNotifier<ScaffoldGeometry> {
   _ScaffoldGeometryNotifier(ScaffoldGeometry geometry)
     : super(geometry);
 
-
   @override
   ScaffoldGeometry get value{
     if (!RendererBinding.instance.pipelineOwner.debugDoingPaint)

--- a/packages/flutter/test/material/scaffold_test.dart
+++ b/packages/flutter/test/material/scaffold_test.dart
@@ -829,7 +829,7 @@ void main() {
       final Rect fabRect = floatingActionButtonBox.localToGlobal(Offset.zero) & floatingActionButtonBox.size;
 
       expect(
-        geometry.floatingActionButtonPosition,
+        geometry.floatingActionButtonArea,
         fabRect
       );
       expect(
@@ -852,6 +852,11 @@ void main() {
       expect(
         geometry.floatingActionButtonScale,
         0.0
+      );
+
+      expect(
+          geometry.floatingActionButtonArea,
+          null
       );
     });
 


### PR DESCRIPTION
Adds a ScaffoldGeometry class and ValueNotifier for it.
A scaffold's ScaffoldGeometry notifier is held in the _ScaffoldState,
and is passed to _ScaffoldScope.
New ScaffoldGemometry objects are built and published to the notifier
during the layout pass after computing the scaffold's layout.