### PR TITLE
Disable selection of the Android ARM64 target platform based on the attached device

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_device.dart
+++ b/packages/flutter_tools/lib/src/android/android_device.dart
@@ -366,15 +366,11 @@ class AndroidDevice extends Device {
       return new LaunchResult.failed();
     }
 
-    BuildInfo buildInfo = debuggingOptions.buildInfo;
-    if (buildInfo.targetPlatform == null && devicePlatform == TargetPlatform.android_arm64)
-      buildInfo = buildInfo.withTargetPlatform(TargetPlatform.android_arm64);
-
     if (!prebuiltApplication) {
       printTrace('Building APK');
       await buildApk(
           target: mainPath,
-          buildInfo: buildInfo,
+          buildInfo: debuggingOptions.buildInfo,
       );
       // Package has been built, so we can get the updated application ID and
       // activity name from the .apk.


### PR DESCRIPTION
The current ARM64 back end generates code that crashes on some devices,
including Pixel phones.  With this change, the android-arm64 target will
not be used by "flutter run" unless explicitly requested.
This is intended as a workaround until we can roll out an engine with the
required Dart VM fix.

See https://github.com/flutter/flutter/issues/14454