### PR TITLE
Prepare docs scripts for beta

### DIFF
--- a/dev/bots/docs.sh
+++ b/dev/bots/docs.sh
@@ -48,8 +48,8 @@ if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
       done
     fi
 
-    if [ "$TRAVIS_BRANCH" == "dev" ]; then
-      echo "Updating dev docs: https://docs.flutter.io/"
+    if [ "$TRAVIS_BRANCH" == "beta" ]; then
+      echo "Updating beta docs: https://docs.flutter.io/"
       while : ; do
         firebase deploy --project docs-flutter-io && break
         echo Error: Unable to deploy documentation to firebase. Retrying in five seconds...


### PR DESCRIPTION
This sets things up so that when we next roll a dev build to beta, it updates the docs.
This means that for a while (until we publish a beta) the dev docs will not be updating.