### PR TITLE
Tri-state Checkbox

### DIFF
--- a/packages/flutter/lib/src/material/checkbox.dart
+++ b/packages/flutter/lib/src/material/checkbox.dart
@@ -22,8 +22,8 @@ import 'toggleable.dart';
 /// the checkbox.
 ///
 /// The checkbox can optionally display three values - true, false, and null -
-/// if [triState] is true. When [value] is null a dash is displayed. By default
-/// triState is false and the checkbox's value must be true or false.
+/// if [tristate] is true. When [value] is null a dash is displayed. By default
+/// [tristate] is false and the checkbox's [value] must be true or false.
 ///
 /// Requires one of its ancestors to be a [Material] widget.
 ///
@@ -47,20 +47,20 @@ class Checkbox extends StatefulWidget {
   ///
   /// The following arguments are required:
   ///
-  /// * [value], which determines whether the checkbox is checked. The value can
-  ///   only be be null if triState is true.
+  /// * [value], which determines whether the checkbox is checked. The [value]
+  ///   can only be be null if [tristate] is true.
   /// * [onChanged], which is called when the value of the checkbox should
   ///   change. It can be set to null to disable the checkbox.
   ///
-  /// The value of [triState] must not be null.
+  /// The value of [tristate] must not be null.
   const Checkbox({
     Key key,
     @required this.value,
-    this.triState: false,
+    this.tristate: false,
     @required this.onChanged,
     this.activeColor,
-  }) : assert(triState != null),
-       assert(triState || value != null),
+  }) : assert(tristate != null),
+       assert(tristate || value != null),
        super(key: key);
 
   /// Whether this checkbox is checked.
@@ -77,10 +77,10 @@ class Checkbox extends StatefulWidget {
   /// If this callback is null, the checkbox will be displayed as disabled
   /// and will not respond to input gestures.
   ///
-  /// When the checkbox is tapped, if [triState] is false (the default) then
-  /// the onChanged callback will be applied to `!value`. If [triState] is
-  /// true this callback will be applied to false if the current value is true,
-  /// false otherwise.
+  /// When the checkbox is tapped, if [tristate] is false (the default) then
+  /// the [onChanged] callback will be applied to `!value`. If [tristate] is
+  /// true this callback will be applied to false if the current [value]
+  /// is true, false otherwise.
   ///
   /// The callback provided to [onChanged] should update the state of the parent
   /// [StatefulWidget] using the [State.setState] method, so that the parent
@@ -112,8 +112,8 @@ class Checkbox extends StatefulWidget {
   /// Typically tri-state checkboxes are disabled (the onChanged callback is
   /// null) so they don't respond to taps.
   ///
-  /// If triState is false (the default), [value] must not be null.
-  final bool triState;
+  /// If tristate is false (the default), [value] must not be null.
+  final bool tristate;
 
   /// The width of a checkbox widget.
   static const double width = 18.0;
@@ -129,7 +129,7 @@ class _CheckboxState extends State<Checkbox> with TickerProviderStateMixin {
     final ThemeData themeData = Theme.of(context);
     return new _CheckboxRenderObjectWidget(
       value: widget.value,
-      triState: widget.triState,
+      tristate: widget.tristate,
       activeColor: widget.activeColor ?? themeData.accentColor,
       inactiveColor: widget.onChanged != null ? themeData.unselectedWidgetColor : themeData.disabledColor,
       onChanged: widget.onChanged,
@@ -142,20 +142,20 @@ class _CheckboxRenderObjectWidget extends LeafRenderObjectWidget {
   const _CheckboxRenderObjectWidget({
     Key key,
     @required this.value,
-    @required this.triState,
+    @required this.tristate,
     @required this.activeColor,
     @required this.inactiveColor,
     @required this.onChanged,
     @required this.vsync,
-  }) : assert(triState != null),
-       assert(triState || value != null),
+  }) : assert(tristate != null),
+       assert(tristate || value != null),
        assert(activeColor != null),
        assert(inactiveColor != null),
        assert(vsync != null),
        super(key: key);
 
   final bool value;
-  final bool triState;
+  final bool tristate;
   final Color activeColor;
   final Color inactiveColor;
   final ValueChanged<bool> onChanged;
@@ -164,7 +164,7 @@ class _CheckboxRenderObjectWidget extends LeafRenderObjectWidget {
   @override
   _RenderCheckbox createRenderObject(BuildContext context) => new _RenderCheckbox(
     value: value,
-    triState: triState,
+    tristate: tristate,
     activeColor: activeColor,
     inactiveColor: inactiveColor,
     onChanged: onChanged,
@@ -175,7 +175,7 @@ class _CheckboxRenderObjectWidget extends LeafRenderObjectWidget {
   void updateRenderObject(BuildContext context, _RenderCheckbox renderObject) {
     renderObject
       ..value = value
-      ..triState = triState
+      ..tristate = tristate
       ..activeColor = activeColor
       ..inactiveColor = inactiveColor
       ..onChanged = onChanged
@@ -190,7 +190,7 @@ const double _kStrokeWidth = 2.0;
 class _RenderCheckbox extends RenderToggleable {
   _RenderCheckbox({
     bool value,
-    bool triState,
+    bool tristate,
     Color activeColor,
     Color inactiveColor,
     ValueChanged<bool> onChanged,
@@ -198,12 +198,13 @@ class _RenderCheckbox extends RenderToggleable {
   }): _showDash = value == null,
       super(
         value: value,
-        triState: triState,
+        tristate: tristate,
         activeColor: activeColor,
         inactiveColor: inactiveColor,
         onChanged: onChanged,
         size: const Size(2 * kRadialReactionRadius, 2 * kRadialReactionRadius),
-        vsync: vsync);
+        vsync: vsync,
+      );
 
   bool _showDash;
 

--- a/packages/flutter/lib/src/material/checkbox.dart
+++ b/packages/flutter/lib/src/material/checkbox.dart
@@ -333,4 +333,7 @@ class _RenderCheckbox extends RenderToggleable {
   // TODO(hmuller): smooth segues for cases where the value changes
   // in the middle of position's animation cycle.
   // https://github.com/flutter/flutter/issues/14674
+
+  // TODO(hmuller): accessibility support for tristate checkboxes.
+  // https://github.com/flutter/flutter/issues/14677
 }

--- a/packages/flutter/lib/src/material/checkbox.dart
+++ b/packages/flutter/lib/src/material/checkbox.dart
@@ -247,7 +247,7 @@ class _RenderCheckbox extends RenderToggleable {
     final Canvas canvas = context.canvas;
     paintRadialReaction(canvas, offset, size.center(Offset.zero));
 
-    final Offset origin = offset + (size - const Size.square(_kEdgeSize)) / 2.0;
+    final Offset origin = offset + (size / 2.0 - const Size.square(_kEdgeSize) / 2.0);
     final double t = position.value;
     final Color borderColor = (onChanged == null)
       ? inactiveColor

--- a/packages/flutter/lib/src/material/checkbox.dart
+++ b/packages/flutter/lib/src/material/checkbox.dart
@@ -23,7 +23,7 @@ import 'toggleable.dart';
 ///
 /// The checkbox can optionally display three values - true, false, and null -
 /// if [triState] is true. When [value] is null a dash is displayed. By default
-/// triState is false and the checkbox's value may only be true or false.
+/// triState is false and the checkbox's value must be true or false.
 ///
 /// Requires one of its ancestors to be a [Material] widget.
 ///
@@ -74,12 +74,13 @@ class Checkbox extends StatefulWidget {
   /// change state until the parent widget rebuilds the checkbox with the new
   /// value.
   ///
-  /// If this callback is null, the checkbox will be displayed as disabled.
+  /// If this callback is null, the checkbox will be displayed as disabled
+  /// and will not respond to input gestures.
   ///
   /// When the checkbox is tapped, if [triState] is false (the default) then
   /// the onChanged callback will be applied to `!value`. If [triState] is
-  /// true this callback will be applied to true if the current value is
-  /// null or false, false otherwise.
+  /// true this callback will be applied to false if the current value is true,
+  /// false otherwise.
   ///
   /// The callback provided to [onChanged] should update the state of the parent
   /// [StatefulWidget] using the [State.setState] method, so that the parent
@@ -172,7 +173,7 @@ class _CheckboxRenderObjectWidget extends LeafRenderObjectWidget {
 
   @override
   void updateRenderObject(BuildContext context, _RenderCheckbox renderObject) {
-     renderObject
+    renderObject
       ..value = value
       ..triState = triState
       ..activeColor = activeColor

--- a/packages/flutter/lib/src/material/radio.dart
+++ b/packages/flutter/lib/src/material/radio.dart
@@ -176,6 +176,7 @@ class _RenderRadio extends RenderToggleable {
     @required TickerProvider vsync,
   }): super(
     value: value,
+    triState: false,
     activeColor: activeColor,
     inactiveColor: inactiveColor,
     onChanged: onChanged,

--- a/packages/flutter/lib/src/material/radio.dart
+++ b/packages/flutter/lib/src/material/radio.dart
@@ -176,7 +176,7 @@ class _RenderRadio extends RenderToggleable {
     @required TickerProvider vsync,
   }): super(
     value: value,
-    triState: false,
+    tristate: false,
     activeColor: activeColor,
     inactiveColor: inactiveColor,
     onChanged: onChanged,

--- a/packages/flutter/lib/src/material/switch.dart
+++ b/packages/flutter/lib/src/material/switch.dart
@@ -247,6 +247,7 @@ class _RenderSwitch extends RenderToggleable {
        _textDirection = textDirection,
        super(
          value: value,
+         triState: false,
          activeColor: activeColor,
          inactiveColor: inactiveColor,
          onChanged: onChanged,

--- a/packages/flutter/lib/src/material/switch.dart
+++ b/packages/flutter/lib/src/material/switch.dart
@@ -247,7 +247,7 @@ class _RenderSwitch extends RenderToggleable {
        _textDirection = textDirection,
        super(
          value: value,
-         triState: false,
+         tristate: false,
          activeColor: activeColor,
          inactiveColor: inactiveColor,
          onChanged: onChanged,

--- a/packages/flutter/lib/src/material/toggleable.dart
+++ b/packages/flutter/lib/src/material/toggleable.dart
@@ -22,22 +22,22 @@ abstract class RenderToggleable extends RenderConstrainedBox {
   /// Creates a toggleable render object.
   ///
   /// The [activeColor], and [inactiveColor] arguments must not be
-  /// null. The [value] can only be null if triState is true.
+  /// null. The [value] can only be null if tristate is true.
   RenderToggleable({
     @required bool value,
-    bool triState: false,
+    bool tristate: false,
     Size size,
     @required Color activeColor,
     @required Color inactiveColor,
     ValueChanged<bool> onChanged,
     @required TickerProvider vsync,
-  }) : assert(triState != null),
-       assert(triState || value != null),
+  }) : assert(tristate != null),
+       assert(tristate || value != null),
        assert(activeColor != null),
        assert(inactiveColor != null),
        assert(vsync != null),
        _value = value,
-       _triState = triState,
+       _tristate = tristate,
        _activeColor = activeColor,
        _inactiveColor = inactiveColor,
        _onChanged = onChanged,
@@ -82,7 +82,7 @@ abstract class RenderToggleable extends RenderConstrainedBox {
   /// The visual value of the control.
   ///
   /// When the control is inactive, the [value] is false and this animation has
-  /// the value 0.0. When the control is active, the value either true or triState
+  /// the value 0.0. When the control is active, the value either true or tristate
   /// is true and the value is null. When the control is active the animation
   /// has a value of 1.0. When the control is changing from inactive
   /// to active (or vice versa), [value] is the target value and this animation
@@ -117,7 +117,7 @@ abstract class RenderToggleable extends RenderConstrainedBox {
   /// False if this control is "inactive" (not checked, off, or unselected).
   ///
   /// If value is true then the control "active" (checked, on, or selected). If
-  /// triState is true and value is null, then the control is considered to be
+  /// tristate is true and value is null, then the control is considered to be
   /// in its third or "indeterminate" state.
   ///
   /// When the value changes, this object starts the [positionController] and
@@ -126,7 +126,7 @@ abstract class RenderToggleable extends RenderConstrainedBox {
   bool get value => _value;
   bool _value;
   set value(bool value) {
-    assert(triState || value != null);
+    assert(tristate || value != null);
     if (value == _value)
       return;
     _value = value;
@@ -143,15 +143,15 @@ abstract class RenderToggleable extends RenderConstrainedBox {
   /// If true, [value] can be true, false, or null, otherwise [value] must
   /// be true or false.
   ///
-  /// When [triState] is true and [value] is null, then the control is
+  /// When [tristate] is true and [value] is null, then the control is
   /// considered to be in its third or "indeterminate" state.
-  bool get triState => _triState;
-  bool _triState;
-  set triState(bool value) {
-    assert(triState != null);
-    if (value == _triState)
+  bool get tristate => _tristate;
+  bool _tristate;
+  set tristate(bool value) {
+    assert(tristate != null);
+    if (value == _tristate)
       return;
-    _triState = value;
+    _tristate = value;
     markNeedsSemanticsUpdate();
   }
 

--- a/packages/flutter/lib/src/material/toggleable.dart
+++ b/packages/flutter/lib/src/material/toggleable.dart
@@ -50,7 +50,7 @@ abstract class RenderToggleable extends RenderConstrainedBox {
       ..onTapCancel = _handleTapCancel;
     _positionController = new AnimationController(
       duration: _kToggleDuration,
-      value: (value == false ? 0.0 : 1.0),
+      value: value == false ? 0.0 : 1.0,
       vsync: vsync,
     );
     _position = new CurvedAnimation(

--- a/packages/flutter/lib/src/material/toggleable.dart
+++ b/packages/flutter/lib/src/material/toggleable.dart
@@ -134,10 +134,14 @@ abstract class RenderToggleable extends RenderConstrainedBox {
     _position
       ..curve = Curves.easeIn
       ..reverseCurve = Curves.easeOut;
-    if (value == false)
-      _positionController.reverse();
-    else
-      _positionController.forward();
+    switch (_positionController.status) {
+      case AnimationStatus.forward:
+      case AnimationStatus.completed:
+        _positionController.reverse();
+        break;
+      default:
+        _positionController.forward();
+    }
   }
 
   /// If true, [value] can be true, false, or null, otherwise [value] must
@@ -250,7 +254,7 @@ abstract class RenderToggleable extends RenderConstrainedBox {
   // the user dragged the toggleable: we may reach 0.0 or 1.0 without
   // seeing a tap. The Switch does this.
   void _handlePositionStateChanged(AnimationStatus status) {
-    if (isInteractive) {
+    if (isInteractive && !tristate) {
       if (status == AnimationStatus.completed && _value == false) {
         onChanged(true);
       }
@@ -268,8 +272,19 @@ abstract class RenderToggleable extends RenderConstrainedBox {
   }
 
   void _handleTap() {
-    if (isInteractive)
-      onChanged(value == false);
+    if (!isInteractive)
+      return;
+    switch (value) {
+      case false:
+        onChanged(true);
+        break;
+      case true:
+        onChanged(tristate ? null : false);
+        break;
+      default: // case null:
+        onChanged(false);
+        break;
+    }
   }
 
   void _handleTapUp(TapUpDetails details) {

--- a/packages/flutter/lib/src/material/toggleable.dart
+++ b/packages/flutter/lib/src/material/toggleable.dart
@@ -21,20 +21,23 @@ final Tween<double> _kRadialReactionRadiusTween = new Tween<double>(begin: 0.0, 
 abstract class RenderToggleable extends RenderConstrainedBox {
   /// Creates a toggleable render object.
   ///
-  /// The [value], [activeColor], and [inactiveColor] arguments must not be
-  /// null.
+  /// The [activeColor], and [inactiveColor] arguments must not be
+  /// null. The [value] can only be null if triState is true.
   RenderToggleable({
     @required bool value,
+    bool triState: false,
     Size size,
     @required Color activeColor,
     @required Color inactiveColor,
     ValueChanged<bool> onChanged,
     @required TickerProvider vsync,
-  }) : assert(value != null),
+  }) : assert(triState != null),
+       assert(triState || value != null),
        assert(activeColor != null),
        assert(inactiveColor != null),
        assert(vsync != null),
        _value = value,
+       _triState = triState,
        _activeColor = activeColor,
        _inactiveColor = inactiveColor,
        _onChanged = onChanged,
@@ -47,7 +50,7 @@ abstract class RenderToggleable extends RenderConstrainedBox {
       ..onTapCancel = _handleTapCancel;
     _positionController = new AnimationController(
       duration: _kToggleDuration,
-      value: value ? 1.0 : 0.0,
+      value: (value == false ? 0.0 : 1.0),
       vsync: vsync,
     );
     _position = new CurvedAnimation(
@@ -79,8 +82,9 @@ abstract class RenderToggleable extends RenderConstrainedBox {
   /// The visual value of the control.
   ///
   /// When the control is inactive, the [value] is false and this animation has
-  /// the value 0.0. When the control is active, the value is true and this
-  /// animation has the value 1.0. When the control is changing from inactive
+  /// the value 0.0. When the control is active, the value either true or triState
+  /// is true and the value is null. When the control is active the animation
+  /// has a value of 1.0. When the control is changing from inactive
   /// to active (or vice versa), [value] is the target value and this animation
   /// gradually updates from 0.0 to 1.0 (or vice versa).
   CurvedAnimation get position => _position;
@@ -110,7 +114,11 @@ abstract class RenderToggleable extends RenderConstrainedBox {
     reactionController.resync(vsync);
   }
 
-  /// Whether this control is current "active" (checked, on, selected) or "inactive" (unchecked, off, not selected).
+  /// False if this control is "inactive" (not checked, off, or unselected).
+  ///
+  /// If value is true then the control "active" (checked, on, or selected). If
+  /// triState is true and value is null, then the control is considered to be
+  /// in its third or "indeterminate" state.
   ///
   /// When the value changes, this object starts the [positionController] and
   /// [position] animations to animate the visual appearance of the control to
@@ -118,7 +126,7 @@ abstract class RenderToggleable extends RenderConstrainedBox {
   bool get value => _value;
   bool _value;
   set value(bool value) {
-    assert(value != null);
+    assert(triState || value != null);
     if (value == _value)
       return;
     _value = value;
@@ -126,10 +134,25 @@ abstract class RenderToggleable extends RenderConstrainedBox {
     _position
       ..curve = Curves.easeIn
       ..reverseCurve = Curves.easeOut;
-    if (value)
-      _positionController.forward();
-    else
+    if (value == false)
       _positionController.reverse();
+    else
+      _positionController.forward();
+  }
+
+  /// If true, [value] can be true, false, or null, otherwise [value] must
+  /// be true or false.
+  ///
+  /// When [triState] is true and [value] is null, then the control is
+  /// considered to be in its third or "indeterminate" state.
+  bool get triState => _triState;
+  bool _triState;
+  set triState(bool value) {
+    assert(triState != null);
+    if (value == _triState)
+      return;
+    _triState = value;
+    markNeedsSemanticsUpdate();
   }
 
   /// The color that should be used in the active state (i.e., when [value] is true).
@@ -196,10 +219,10 @@ abstract class RenderToggleable extends RenderConstrainedBox {
   @override
   void attach(PipelineOwner owner) {
     super.attach(owner);
-    if (value)
-      _positionController.forward();
-    else
+    if (value == false)
       _positionController.reverse();
+    else
+      _positionController.forward();
     if (isInteractive) {
       switch (_reactionController.status) {
         case AnimationStatus.forward:
@@ -223,12 +246,17 @@ abstract class RenderToggleable extends RenderConstrainedBox {
     super.detach();
   }
 
+  // Handle the case where the _positionController's value changes because
+  // the user dragged the toggleable: we may reach 0.0 or 1.0 without
+  // seeing a tap. The Switch does this.
   void _handlePositionStateChanged(AnimationStatus status) {
     if (isInteractive) {
-      if (status == AnimationStatus.completed && !_value)
+      if (status == AnimationStatus.completed && _value == false) {
         onChanged(true);
-      else if (status == AnimationStatus.dismissed && _value)
+      }
+      else if (status == AnimationStatus.dismissed && _value != false) {
         onChanged(false);
+      }
     }
   }
 
@@ -241,7 +269,7 @@ abstract class RenderToggleable extends RenderConstrainedBox {
 
   void _handleTap() {
     if (isInteractive)
-      onChanged(!_value);
+      onChanged(value == false);
   }
 
   void _handleTapUp(TapUpDetails details) {
@@ -290,7 +318,7 @@ abstract class RenderToggleable extends RenderConstrainedBox {
     config.isEnabled = isInteractive;
     if (isInteractive)
       config.onTap = _handleTap;
-    config.isChecked = _value;
+    config.isChecked = _value != false;
   }
 
   @override

--- a/packages/flutter/test/material/checkbox_test.dart
+++ b/packages/flutter/test/material/checkbox_test.dart
@@ -104,7 +104,7 @@ void main() {
   });
 
   testWidgets('CheckBox triState:true', (WidgetTester tester) async {
-    bool checkBoxValue = null;
+    bool checkBoxValue;
 
     await tester.pumpWidget(
       new Material(

--- a/packages/flutter/test/material/checkbox_test.dart
+++ b/packages/flutter/test/material/checkbox_test.dart
@@ -103,7 +103,7 @@ void main() {
     semantics.dispose();
   });
 
-  testWidgets('CheckBox tristate:true', (WidgetTester tester) async {
+  testWidgets('CheckBox tristate: true', (WidgetTester tester) async {
     bool checkBoxValue;
 
     await tester.pumpWidget(
@@ -133,5 +133,17 @@ void main() {
     await tester.tap(find.byType(Checkbox));
     await tester.pumpAndSettle();
     expect(checkBoxValue, true);
+
+    await tester.tap(find.byType(Checkbox));
+    await tester.pumpAndSettle();
+    expect(checkBoxValue, null);
+
+    checkBoxValue = true;
+    await tester.pumpAndSettle();
+    expect(checkBoxValue, true);
+
+    checkBoxValue = null;
+    await tester.pumpAndSettle();
+    expect(checkBoxValue, null);
   });
 }

--- a/packages/flutter/test/material/checkbox_test.dart
+++ b/packages/flutter/test/material/checkbox_test.dart
@@ -102,4 +102,36 @@ void main() {
 
     semantics.dispose();
   });
+
+  testWidgets('CheckBox triState:true', (WidgetTester tester) async {
+    bool checkBoxValue = null;
+
+    await tester.pumpWidget(
+      new Material(
+        child: new StatefulBuilder(
+          builder: (BuildContext context, StateSetter setState) {
+            return new Checkbox(
+              triState: true,
+              value: checkBoxValue,
+              onChanged: (bool value) {
+                setState(() {
+                  checkBoxValue = value;
+                });
+              },
+            );
+          },
+        ),
+      ),
+    );
+
+    expect(tester.widget<Checkbox>(find.byType(Checkbox)).value, null);
+
+    await tester.tap(find.byType(Checkbox));
+    await tester.pumpAndSettle();
+    expect(checkBoxValue, false);
+
+    await tester.tap(find.byType(Checkbox));
+    await tester.pumpAndSettle();
+    expect(checkBoxValue, true);
+  });
 }

--- a/packages/flutter/test/material/checkbox_test.dart
+++ b/packages/flutter/test/material/checkbox_test.dart
@@ -103,7 +103,7 @@ void main() {
     semantics.dispose();
   });
 
-  testWidgets('CheckBox triState:true', (WidgetTester tester) async {
+  testWidgets('CheckBox tristate:true', (WidgetTester tester) async {
     bool checkBoxValue;
 
     await tester.pumpWidget(
@@ -111,7 +111,7 @@ void main() {
         child: new StatefulBuilder(
           builder: (BuildContext context, StateSetter setState) {
             return new Checkbox(
-              triState: true,
+              tristate: true,
               value: checkBoxValue,
               onChanged: (bool value) {
                 setState(() {


### PR DESCRIPTION
Added optional support for tri-state checkboxes, i.e. a checkbox whose value can be true, false, or null.

The checkboxes on the right were created with `triState: true`, `value: null`.

![checkbox](https://user-images.githubusercontent.com/1377460/36057643-83886432-0dc5-11e8-8fb4-dc7f0b164bf6.png)


