### PR TITLE
Add a space to the Flutter SDK path on Appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,7 @@
 install:
+- cmd: cd ..
+- cmd: move flutter "flutter sdk"
+- cmd: cd "flutter sdk"
 - cmd: bin\flutter.bat config --no-analytics
 - cmd: bin\flutter.bat update-packages
 


### PR DESCRIPTION
Ensures we don't regress #6577 on Windows.