### PR TITLE
Allow spaces in SDK path in flutter_tools tests

### DIFF
--- a/packages/flutter_tools/test/src/common.dart
+++ b/packages/flutter_tools/test/src/common.dart
@@ -32,7 +32,7 @@ String getFlutterRoot() {
       scriptUri = platform.script;
       break;
     case 'data':
-      final RegExp flutterTools = new RegExp(r'(file://[^%]*[/\\]flutter_tools[^%]+\.dart)%');
+      final RegExp flutterTools = new RegExp(r'(file://[^ ;]*[/\\]flutter_tools[^%]+\.dart)%');
       final Match match = flutterTools.firstMatch(platform.script.path);
       if (match == null)
         throw invalidScript();


### PR DESCRIPTION
The Flutter engine now supports package: and file: imports that resolve
to paths on disk that include spaces and other URI-escaped characters.
This patch eliminates the restriction that Dart source paths not include
%20 (or other URI-escaped characters) in their paths in flutter_tool
tests.