### PR TITLE
flutter_tools: URI-decode data: URI content

### DIFF
--- a/packages/flutter_tools/test/src/common.dart
+++ b/packages/flutter_tools/test/src/common.dart
@@ -32,8 +32,8 @@ String getFlutterRoot() {
       scriptUri = platform.script;
       break;
     case 'data':
-      final RegExp flutterTools = new RegExp(r'(file://[^ ;]*[/\\]flutter_tools[^%]+\.dart)%');
-      final Match match = flutterTools.firstMatch(platform.script.path);
+      final RegExp flutterTools = new RegExp(r'(file://[^"]*[/\\]flutter_tools[/\\][^"]+\.dart)', multiLine: true);
+      final Match match = flutterTools.firstMatch(Uri.decodeFull(platform.script.path));
       if (match == null)
         throw invalidScript();
       scriptUri = Uri.parse(match.group(1));


### PR DESCRIPTION
In getFlutterRoot(), scripts loaded via data: URIs are URI encoded.
getFlutterRoot() scans the contents of the data for the file:// URI path
of the Flutter SDK, which itself is URI-encoded. The end result is that
if the SDK path contains a space, the embedded file:// URI will contain
a %20. When this is encoded in a data: URI, the contents are
URI-encoded, resulting in %2520, since the % is encoded to %25.

This patch decodes the data: URI before extracting the SDK file:// URI.