### PR TITLE
Eliminate hardcoded SDK path name from test

### DIFF
--- a/dev/automated_tests/flutter_test/ticker_expectation.txt
+++ b/dev/automated_tests/flutter_test/ticker_expectation.txt
@@ -6,7 +6,7 @@ An animation is still running even after the widget tree was disposed.
 There was one transient callback left. The stack trace for when it was registered is as follows:
 ── callback 2 ──
 <<skip until matching line>>
-#[0-9]+      main.+ \(.+/flutter/dev/automated_tests/flutter_test/ticker_test\.dart:[0-9]+:[0-9]+\)
+#[0-9]+      main.+ \(.+/dev/automated_tests/flutter_test/ticker_test\.dart:[0-9]+:[0-9]+\)
 <<skip until matching line>>
 ════════════════════════════════════════════════════════════════════════════════════════════════════
 .*..:.. \+0 -1: - Does flutter_test catch leaking tickers\? \[E\]


### PR DESCRIPTION
Eliminates the assumption that the flutter SDK is installed in a
directory named "flutter" from ticker_expectation.txt.