### PR TITLE
Adjust test/material/popup_menu_test.dart for Dart 2 semantics.

### DIFF
--- a/packages/flutter/test/material/popup_menu_test.dart
+++ b/packages/flutter/test/material/popup_menu_test.dart
@@ -215,7 +215,12 @@ void main() {
         child: const Text('XXX'),
       ),
     );
-    final WidgetPredicate popupMenu = (Widget widget) => widget.runtimeType.toString() == '_PopupMenu';
+    final WidgetPredicate popupMenu = (Widget widget) {
+      final String widgetType = widget.runtimeType.toString();
+      // Dart 2 implements reified generic methods which means showMenu<int>(...)
+      // creates _PopupMenu<int> and not _PopupMenu<dynamic>.
+      return widgetType == '_PopupMenu' || widgetType == '_PopupMenu<int>';
+    };
 
     Future<Null> openMenu(TextDirection textDirection, Alignment alignment) async {
       return TestAsyncUtils.guard(() async {

--- a/packages/flutter/test/material/popup_menu_test.dart
+++ b/packages/flutter/test/material/popup_menu_test.dart
@@ -219,7 +219,7 @@ void main() {
       final String widgetType = widget.runtimeType.toString();
       // TODO(mraleph): Remove the old case below.
       return widgetType == '_PopupMenu<int>' // normal case
-            || widgetType == '_PopupMenu'; // for old versions of Dart that don't reify method type arguments
+          || widgetType == '_PopupMenu'; // for old versions of Dart that don't reify method type arguments
     };
 
     Future<Null> openMenu(TextDirection textDirection, Alignment alignment) async {

--- a/packages/flutter/test/material/popup_menu_test.dart
+++ b/packages/flutter/test/material/popup_menu_test.dart
@@ -217,9 +217,9 @@ void main() {
     );
     final WidgetPredicate popupMenu = (Widget widget) {
       final String widgetType = widget.runtimeType.toString();
-      // Dart 2 implements reified generic methods which means showMenu<int>(...)
-      // creates _PopupMenu<int> and not _PopupMenu<dynamic>.
-      return widgetType == '_PopupMenu' || widgetType == '_PopupMenu<int>';
+      // TODO(mraleph): Remove the old case below.
+      return widgetType == '_PopupMenu<int>' // normal case
+            || widgetType == '_PopupMenu'; // for old versions of Dart that don't reify method type arguments
     };
 
     Future<Null> openMenu(TextDirection textDirection, Alignment alignment) async {


### PR DESCRIPTION
Dart 2 implements reified generics which means `showMenu<int>` creates
`_PopupMenu<int>` not `_PopupMenu<dynamic>`.