### PR TITLE
Revert "Disable selection of the Android ARM64 target platform based on the attached device"

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_device.dart
+++ b/packages/flutter_tools/lib/src/android/android_device.dart
@@ -366,11 +366,15 @@ class AndroidDevice extends Device {
       return new LaunchResult.failed();
     }
 
+    BuildInfo buildInfo = debuggingOptions.buildInfo;
+    if (buildInfo.targetPlatform == null && devicePlatform == TargetPlatform.android_arm64)
+      buildInfo = buildInfo.withTargetPlatform(TargetPlatform.android_arm64);
+
     if (!prebuiltApplication) {
       printTrace('Building APK');
       await buildApk(
           target: mainPath,
-          buildInfo: debuggingOptions.buildInfo,
+          buildInfo: buildInfo,
       );
       // Package has been built, so we can get the updated application ID and
       // activity name from the .apk.


### PR DESCRIPTION
This reverts commit cdb581807cc11030b63d00c04bb2d55fcb3d7ef4.

Dart has been updated in the engine, and this workaround should no longer be necessary.

Fixes https://github.com/flutter/flutter/issues/14646