### PR TITLE
Plumb strong mode through startApp() to the engine on iOS.

### DIFF
--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -189,8 +189,13 @@ class IOSDevice extends Device {
       return new LaunchResult.failed();
     }
 
+    final bool strongMode = platformArgs['strong'] ?? false;
+
     // Step 3: Attempt to install the application on the device.
     final List<String> launchArguments = <String>['--enable-dart-profiling'];
+
+    if (strongMode)
+      launchArguments.add('--strong');
 
     if (debuggingOptions.startPaused)
       launchArguments.add('--start-paused');

--- a/packages/flutter_tools/lib/src/ios/simulators.dart
+++ b/packages/flutter_tools/lib/src/ios/simulators.dart
@@ -316,8 +316,13 @@ class IOSSimulator extends Device {
         return new LaunchResult.failed();
     }
 
+    final bool strongMode = platformArgs['strong'] ?? false;
+
     // Prepare launch arguments.
     final List<String> args = <String>['--enable-dart-profiling'];
+
+    if (strongMode)
+      args.add('--strong');
 
     if (!prebuiltApplication) {
       args.addAll(<String>[


### PR DESCRIPTION
This is a temporary solution to make things work with --preview-dart-2 until
issue #14594 is resolved.