### PR TITLE
Reduce Xcode noise #3

### DIFF
--- a/packages/flutter_tools/bin/xcode_backend.sh
+++ b/packages/flutter_tools/bin/xcode_backend.sh
@@ -4,7 +4,9 @@
 # found in the LICENSE file.
 
 RunCommand() {
-  echo "♦ $*"
+  if [[ -n "$VERBOSE_SCRIPT_LOGGING" ]]; then
+    echo "♦ $*"
+  fi
   "$@"
   return $?
 }

--- a/packages/flutter_tools/lib/src/application_package.dart
+++ b/packages/flutter_tools/lib/src/application_package.dart
@@ -210,7 +210,11 @@ class BuildableIOSApp extends IOSApp {
 
   final String appDirectory;
 
-  /// Build settings of the app's XCode project.
+  /// Build settings of the app's Xcode project.
+  ///
+  /// These are the build settings as specified in the Xcode project files.
+  ///
+  /// Build settings may change depending on the parameters passed while building.
   final Map<String, String> buildSettings;
 
   @override

--- a/packages/flutter_tools/lib/src/commands/build_ios.dart
+++ b/packages/flutter_tools/lib/src/commands/build_ios.dart
@@ -76,7 +76,7 @@ class BuildIOSCommand extends BuildSubCommand {
     );
 
     if (!result.success) {
-      await diagnoseXcodeBuildFailure(result, app);
+      await diagnoseXcodeBuildFailure(result);
       throwToolExit('Encountered error while building for $logTarget.');
     }
 

--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -172,7 +172,7 @@ class IOSDevice extends Device {
       );
       if (!buildResult.success) {
         printError('Could not build the precompiled application for the device.');
-        await diagnoseXcodeBuildFailure(buildResult, app);
+        await diagnoseXcodeBuildFailure(buildResult);
         printError('');
         return new LaunchResult.failed();
       }

--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -357,7 +357,7 @@ Future<XcodeBuildResult> buildXcodeProject({
 
   // Run -showBuildSettings again but with the exact same parameters as the build.
   final Map<String, String> buildSettings = parseXcodeBuildSettings(runCheckedSync(
-    buildCommands..add('-showBuildSettings'),
+    new List<String>.from(buildCommands)..add('-showBuildSettings'),
     workingDirectory: app.appDirectory,
   ));
 

--- a/packages/flutter_tools/lib/src/ios/xcodeproj.dart
+++ b/packages/flutter_tools/lib/src/ios/xcodeproj.dart
@@ -72,8 +72,12 @@ Map<String, String> getXcodeBuildSettings(String xcodeProjPath, String target) {
   final String out = runCheckedSync(<String>[
     '/usr/bin/xcodebuild', '-project', absProjPath, '-target', target, '-showBuildSettings'
   ]);
+  return parseXcodeBuildSettings(out);
+}
+
+Map<String, String> parseXcodeBuildSettings(String showBuildSettingsOutput) {
   final Map<String, String> settings = <String, String>{};
-  for (String line in out.split('\n').where(_settingExpr.hasMatch)) {
+  for (String line in showBuildSettingsOutput.split('\n').where(_settingExpr.hasMatch)) {
     final Match match = _settingExpr.firstMatch(line);
     settings[match[1]] = match[2];
   }

--- a/packages/flutter_tools/test/ios/mac_test.dart
+++ b/packages/flutter_tools/test/ios/mac_test.dart
@@ -5,7 +5,6 @@
 import 'dart:async';
 
 import 'package:file/file.dart';
-import 'package:flutter_tools/src/application_package.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/io.dart' show ProcessException, ProcessResult;
 import 'package:flutter_tools/src/ios/mac.dart';
@@ -243,15 +242,12 @@ void main() {
   });
 
   group('Diagnose Xcode build failure', () {
-    BuildableIOSApp app;
+    Map<String, String> buildSettings;
 
     setUp(() {
-      app = new BuildableIOSApp(
-        projectBundleId: 'test.app',
-        buildSettings: <String, String>{
-          'For our purposes': 'a non-empty build settings map is valid',
-        },
-      );
+      buildSettings = <String, String>{
+        'PRODUCT_BUNDLE_IDENTIFIER': 'test.app',
+      };
     });
 
     testUsingContext('No provisioning profile shows message', () async {
@@ -313,13 +309,14 @@ Could not build the precompiled application for the device.
 
 Error launching application on iPhone.''',
         xcodeBuildExecution: new XcodeBuildExecution(
-          <String>['xcrun', 'xcodebuild', 'blah'],
-          '/blah/blah',
-          buildForPhysicalDevice: true
+          buildCommands: <String>['xcrun', 'xcodebuild', 'blah'],
+          appDirectory: '/blah/blah',
+          buildForPhysicalDevice: true,
+          buildSettings: buildSettings,
         ),
       );
 
-      await diagnoseXcodeBuildFailure(buildResult, app);
+      await diagnoseXcodeBuildFailure(buildResult);
       expect(
         testLogger.errorText,
         contains('No Provisioning Profile was found for your project\'s Bundle Identifier or your device.'),
@@ -393,13 +390,14 @@ Xcode's output:
 
 Could not build the precompiled application for the device.''',
         xcodeBuildExecution: new XcodeBuildExecution(
-          <String>['xcrun', 'xcodebuild', 'blah'],
-          '/blah/blah',
-          buildForPhysicalDevice: true
+          buildCommands: <String>['xcrun', 'xcodebuild', 'blah'],
+          appDirectory: '/blah/blah',
+          buildForPhysicalDevice: true,
+          buildSettings: buildSettings,
         ),
       );
 
-      await diagnoseXcodeBuildFailure(buildResult, app);
+      await diagnoseXcodeBuildFailure(buildResult);
       expect(
         testLogger.errorText,
         contains('Building a deployable iOS app requires a selected Development Team with a Provisioning Profile'),


### PR DESCRIPTION
Third time's a charm

Unreverts #14641

Fixes #13104

Reduces xcodebuild fluff. 

Also stops scrapping xcodebuild output as a critical path to building successfully. Fixes #14657

Fixes an issue where the build settings used to diagnose xcode build failures may not be the same settings used to build. Fixes #14661