### PR TITLE
Fix xcode build settings parsing

### DIFF
--- a/packages/flutter_tools/lib/src/ios/xcodeproj.dart
+++ b/packages/flutter_tools/lib/src/ios/xcodeproj.dart
@@ -12,7 +12,7 @@ import '../build_info.dart';
 import '../cache.dart';
 import '../globals.dart';
 
-final RegExp _settingExpr = new RegExp(r'(\w+)\s*=\s*(\S+)');
+final RegExp _settingExpr = new RegExp(r'(\w+)\s*=\s*(.*)$');
 final RegExp _varExpr = new RegExp(r'\$\((.*)\)');
 
 String flutterFrameworkDir(BuildMode mode) {
@@ -77,9 +77,10 @@ Map<String, String> getXcodeBuildSettings(String xcodeProjPath, String target) {
 
 Map<String, String> parseXcodeBuildSettings(String showBuildSettingsOutput) {
   final Map<String, String> settings = <String, String>{};
-  for (String line in showBuildSettingsOutput.split('\n').where(_settingExpr.hasMatch)) {
-    final Match match = _settingExpr.firstMatch(line);
-    settings[match[1]] = match[2];
+  for (Match match in showBuildSettingsOutput.split('\n').map(_settingExpr.firstMatch)) {
+    if (match != null) {
+      settings[match[1]] = match[2];
+    }
   }
   return settings;
 }


### PR DESCRIPTION
Regexp chopped off setting values at first space. Flavors test broken as a result, I believe.