### PR TITLE
Programmatically check / control drawer state

### DIFF
--- a/packages/flutter/lib/src/material/drawer.dart
+++ b/packages/flutter/lib/src/material/drawer.dart
@@ -287,6 +287,8 @@ class DrawerControllerState extends State<DrawerController> with SingleTickerPro
     }
   }
 
+  bool get isOpen => !_controller.isDismissed;
+
   /// Starts an animation to open the drawer.
   ///
   /// Typically called by [ScaffoldState.openDrawer].

--- a/packages/flutter/lib/src/material/scaffold.dart
+++ b/packages/flutter/lib/src/material/scaffold.dart
@@ -592,6 +592,10 @@ class ScaffoldState extends State<Scaffold> with TickerProviderStateMixin {
     _endDrawerKey.currentState?.open();
   }
 
+  void closeEndDrawer() {
+    _endDrawerKey.currentState?.close();
+  }
+
   // SNACKBAR API
 
   final Queue<ScaffoldFeatureController<SnackBar, SnackBarClosedReason>> _snackBars = new Queue<ScaffoldFeatureController<SnackBar, SnackBarClosedReason>>();

--- a/packages/flutter/lib/src/material/scaffold.dart
+++ b/packages/flutter/lib/src/material/scaffold.dart
@@ -560,6 +560,8 @@ class ScaffoldState extends State<Scaffold> with TickerProviderStateMixin {
 
   bool get isDrawerOpen => _drawerKey.currentState?.isOpen ?? false;
 
+  bool get isEndDrawerOpen => _endDrawerKey.currentState?.isOpen ?? false;
+
   /// Opens the [Drawer] (if any).
   ///
   /// If the scaffold has a non-null [Scaffold.drawer], this function will cause
@@ -590,6 +592,10 @@ class ScaffoldState extends State<Scaffold> with TickerProviderStateMixin {
   /// See [Scaffold.of] for information about how to obtain the [ScaffoldState].
   void openEndDrawer() {
     _endDrawerKey.currentState?.open();
+  }
+
+  void closeDrawer() {
+    _drawerKey.currentState?.close();
   }
 
   void closeEndDrawer() {

--- a/packages/flutter/lib/src/material/scaffold.dart
+++ b/packages/flutter/lib/src/material/scaffold.dart
@@ -558,6 +558,8 @@ class ScaffoldState extends State<Scaffold> with TickerProviderStateMixin {
   /// Whether this scaffold has a non-null [Scaffold.endDrawer].
   bool get hasEndDrawer => widget.endDrawer != null;
 
+  bool get isDrawerOpen => _drawerKey.currentState?.isOpen ?? false;
+
   /// Opens the [Drawer] (if any).
   ///
   /// If the scaffold has a non-null [Scaffold.drawer], this function will cause


### PR DESCRIPTION
We want to be able to programmatically check and control the state of the drawer and end drawer.

We use this to change the behavior of the back button in the main screen of our app:
If the drawer is closed, the back button opens it. If it's already open, the back button exits the app.

```
    return new WillPopScope(
      child: new Scaffold(
        key: _globalKey,
        body: _mainScreen(),
      ),
      onWillPop: () {
        ScaffoldState scaffold = _globalKey.currentState;
        if (Platform.isAndroid && scaffold != null) {
          if (scaffold.isDrawerOpen) {
            SystemNavigator.pop();
          } else {
            scaffold.openDrawer();
          }
        }
        return new Future<bool>.value(false);
      },
    );
```

We ended up doing this because we found that our users tend to think of the drawer as another screen that's below the current screen on the back stack.

We don't anticipate having any widgets that depend on this value and should redraw if it changes.

Credit for this change goes to @cforkish