### PR TITLE
Add a toString for CurveTween

### DIFF
--- a/packages/flutter/lib/src/animation/tween.dart
+++ b/packages/flutter/lib/src/animation/tween.dart
@@ -327,4 +327,7 @@ class CurveTween extends Animatable<double> {
     }
     return curve.transform(t);
   }
+
+  @override
+  String toString() => '$runtimeType(curve: $curve)';
 }


### PR DESCRIPTION
Fixes #14678

The Tweens already have a toString available.

@Hixie we discussed also putting a toString on the root Animatable, but there's nothing substantial to put there.  I believe it's better to leave it off so that smoke tests can detect when an Animatable child doesn't have toString.