### PR TITLE
expose scaled fab area in ScaffoldGeometry

### DIFF
--- a/packages/flutter/lib/src/material/scaffold.dart
+++ b/packages/flutter/lib/src/material/scaffold.dart
@@ -95,6 +95,12 @@ class _ScaffoldGeometryNotifier extends ValueNotifier<ScaffoldGeometry> {
 
   final BuildContext context;
 
+  // When the floating action button scale is 0 we override the
+  // [ScaffoldGeometry.floatingActionButtonArea] with null, and keep it's value
+  // here. This allows us to publish this area in case the next partial update
+  // makes the scale non zero.
+  Rect overridenFloatingActionBarArea;
+
   @override
   ScaffoldGeometry get value {
     assert(() {
@@ -115,10 +121,18 @@ class _ScaffoldGeometryNotifier extends ValueNotifier<ScaffoldGeometry> {
     Rect floatingActionButtonArea,
     double floatingActionButtonScale,
   }) {
-    final double newFloatingActionButtonScale = floatingActionButtonScale ??  super.value?.floatingActionButtonScale;
+    final double newFloatingActionButtonScale = floatingActionButtonScale ?? super.value?.floatingActionButtonScale;
     Rect newFloatingActionButtonArea;
+    // The layout code that is updating the FAB area does not know whether
+    // there is a non null FAB set, in that case we override the area with null
+    // to make sure we don't provide values that don't make sense.
+    // We are caching the area in [overridenFloatingActionBarArea] and restore
+    // it in case the next partial update changes the scale to non-zero without
+    // providing a new FAB area.
     if (newFloatingActionButtonScale != 0.0)
-      newFloatingActionButtonArea = floatingActionButtonArea ?? super.value?.floatingActionButtonArea;
+      newFloatingActionButtonArea = floatingActionButtonArea ?? super.value?.floatingActionButtonArea ?? overridenFloatingActionBarArea;
+    else
+      overridenFloatingActionBarArea = floatingActionButtonArea ?? overridenFloatingActionBarArea;
 
     value = new ScaffoldGeometry(
       bottomNavigationBarTop: bottomNavigationBarTop ?? super.value?.bottomNavigationBarTop,

--- a/packages/flutter/lib/src/material/scaffold.dart
+++ b/packages/flutter/lib/src/material/scaffold.dart
@@ -37,9 +37,6 @@ enum _ScaffoldSlot {
   statusBar,
 }
 
-// Examples can assume:
-// ScaffoldGeometry scaffoldGeometry;
-
 /// Geometry information for scaffold components.
 ///
 /// To get a [ValueNotifier] for the scaffold geometry call
@@ -49,7 +46,6 @@ class ScaffoldGeometry {
   const ScaffoldGeometry({
     this.bottomNavigationBarTop,
     this.floatingActionButtonArea,
-    this.floatingActionButtonScale: 1.0,
   });
 
   /// The distance from the scaffold's top edge to the top edge of the
@@ -62,44 +58,35 @@ class ScaffoldGeometry {
   /// The rectangle in which the scaffold is laying out
   /// [Scaffold.floatingActionButton].
   ///
-  /// The floating action button might be scaled inside this rectangle, to get
-  /// the bounding rectangle in which the floating action is painted scale this
-  /// value by [floatingActionButtonScale].
-  ///
-  /// ## Sample code
-  ///
-  /// ```dart
-  ///  final Rect scaledFab = Rect.lerp(
-  ///    scaffoldGeometry.floatingActionButtonArea.center & Size.zero,
-  ///    scaffoldGeometry.floatingActionButtonArea,
-  ///    scaffoldGeometry.floatingActionButtonScale
-  ///  );
-  /// ```
-  ///
   /// This is null when there is no floating action button showing.
   final Rect floatingActionButtonArea;
 
-  /// The amount by which the [Scaffold.floatingActionButton] is scaled.
-  ///
-  /// To get the bounding rectangle in which the floating action button is
-  /// painted scaled [floatingActionPosition] by this proportion. 
-  ///
-  /// This will be 0 when there is no [Scaffold.floatingActionButton] set.
-  final double floatingActionButtonScale;
+  ScaffoldGeometry _scaleFab(double scaleFactor) {
+    if (scaleFactor == 1.0)
+      return this;
+
+    if (scaleFactor == 0.0)
+      return new ScaffoldGeometry(bottomNavigationBarTop: bottomNavigationBarTop);
+
+    final Rect scaledFab = Rect.lerp(
+      floatingActionButtonArea.center & Size.zero,
+      floatingActionButtonArea,
+      scaleFactor
+    );
+    return new ScaffoldGeometry(
+      bottomNavigationBarTop: bottomNavigationBarTop,
+      floatingActionButtonArea: scaledFab,
+    );
+  }
 }
 
-class _ScaffoldGeometryNotifier extends ValueNotifier<ScaffoldGeometry> {
-  _ScaffoldGeometryNotifier(ScaffoldGeometry geometry, this.context)
-    : assert (context != null),
-      super(geometry);
+class _ScaffoldGeometryNotifier extends ChangeNotifier implements ValueListenable<ScaffoldGeometry> {
+  _ScaffoldGeometryNotifier(this.geometry, this.context)
+    : assert (context != null);
 
   final BuildContext context;
-
-  // When the floating action button scale is 0 we override the
-  // [ScaffoldGeometry.floatingActionButtonArea] with null, and keep it's value
-  // here. This allows us to publish this area in case the next partial update
-  // makes the scale non zero.
-  Rect overridenFloatingActionBarArea;
+  double fabScale;
+  ScaffoldGeometry geometry;
 
   @override
   ScaffoldGeometry get value {
@@ -113,7 +100,7 @@ class _ScaffoldGeometryNotifier extends ValueNotifier<ScaffoldGeometry> {
         );
       return true;
     }());
-    return super.value;
+    return geometry._scaleFab(fabScale);
   }
 
   void _updateWith({
@@ -121,24 +108,12 @@ class _ScaffoldGeometryNotifier extends ValueNotifier<ScaffoldGeometry> {
     Rect floatingActionButtonArea,
     double floatingActionButtonScale,
   }) {
-    final double newFloatingActionButtonScale = floatingActionButtonScale ?? super.value?.floatingActionButtonScale;
-    Rect newFloatingActionButtonArea;
-    // The layout code that is updating the FAB area does not know whether
-    // there is a non null FAB set, in that case we override the area with null
-    // to make sure we don't provide values that don't make sense.
-    // We are caching the area in [overridenFloatingActionBarArea] and restore
-    // it in case the next partial update changes the scale to non-zero without
-    // providing a new FAB area.
-    if (newFloatingActionButtonScale != 0.0)
-      newFloatingActionButtonArea = floatingActionButtonArea ?? super.value?.floatingActionButtonArea ?? overridenFloatingActionBarArea;
-    else
-      overridenFloatingActionBarArea = floatingActionButtonArea ?? overridenFloatingActionBarArea;
-
-    value = new ScaffoldGeometry(
-      bottomNavigationBarTop: bottomNavigationBarTop ?? super.value?.bottomNavigationBarTop,
-      floatingActionButtonArea: newFloatingActionButtonArea,
-      floatingActionButtonScale: newFloatingActionButtonScale,
+    fabScale = floatingActionButtonScale ?? fabScale;
+    geometry = new ScaffoldGeometry(
+      bottomNavigationBarTop: bottomNavigationBarTop ?? geometry?.bottomNavigationBarTop,
+      floatingActionButtonArea: floatingActionButtonArea ?? geometry?.floatingActionButtonArea,
     );
+    notifyListeners();
   }
 }
 

--- a/packages/flutter/test/material/scaffold_test.dart
+++ b/packages/flutter/test/material/scaffold_test.dart
@@ -832,10 +832,6 @@ void main() {
         geometry.floatingActionButtonArea,
         fabRect
       );
-      expect(
-        geometry.floatingActionButtonScale,
-        1.0
-      );
     });
 
     testWidgets('no floatingActionButton', (WidgetTester tester) async {
@@ -848,11 +844,6 @@ void main() {
 
       final GeometryListenerState listenerState = tester.state(find.byType(GeometryListener));
       final ScaffoldGeometry geometry = listenerState.cache.value;
-
-      expect(
-        geometry.floatingActionButtonScale,
-        0.0
-      );
 
       expect(
           geometry.floatingActionButtonArea,
@@ -878,17 +869,15 @@ void main() {
             ),
       )));
 
+      final GeometryListenerState listenerState = tester.state(find.byType(GeometryListener));
       await tester.pump(const Duration(milliseconds: 50));
 
-      final GeometryListenerState listenerState = tester.state(find.byType(GeometryListener));
-      final ScaffoldGeometry geometry = listenerState.cache.value;
+      ScaffoldGeometry geometry = listenerState.cache.value;
 
-      expect(
-        geometry.floatingActionButtonScale,
-        inExclusiveRange(0.0, 1.0),
-      );
+      final Rect transitioningFabRect = geometry.floatingActionButtonArea;
 
       await tester.pump(const Duration(seconds: 3));
+      geometry = listenerState.cache.value;
       final RenderBox floatingActionButtonBox = tester.renderObject(find.byKey(key));
       final Rect fabRect = floatingActionButtonBox.localToGlobal(Offset.zero) & floatingActionButtonBox.size;
 
@@ -896,9 +885,61 @@ void main() {
         geometry.floatingActionButtonArea,
         fabRect
       );
+
+      expect(
+        geometry.floatingActionButtonArea.center,
+        transitioningFabRect.center
+      );
+
+      expect(
+        geometry.floatingActionButtonArea.width,
+        greaterThan(transitioningFabRect.width)
+      );
+
+      expect(
+        geometry.floatingActionButtonArea.height,
+        greaterThan(transitioningFabRect.height)
+      );
+    });
+
+    testWidgets('change notifications', (WidgetTester tester) async {
+      final GlobalKey key = new GlobalKey();
+      int numNotificationsAtLastFrame = 0;
+      await tester.pumpWidget(new MaterialApp(home: new Scaffold(
+            body: new ConstrainedBox(
+              constraints: const BoxConstraints.expand(height: 80.0),
+              child: new GeometryListener(),
+            ),
+      )));
+
+      final GeometryListenerState listenerState = tester.state(find.byType(GeometryListener));
+
+      expect(listenerState.numNotifications, greaterThan(numNotificationsAtLastFrame));
+      numNotificationsAtLastFrame = listenerState.numNotifications;
+
+      await tester.pumpWidget(new MaterialApp(home: new Scaffold(
+            body: new Container(),
+            floatingActionButton: new FloatingActionButton(
+              key: key,
+              child: new GeometryListener(),
+              onPressed: () {},
+            ),
+      )));
+
+      expect(listenerState.numNotifications, greaterThan(numNotificationsAtLastFrame));
+      numNotificationsAtLastFrame = listenerState.numNotifications;
+
+      await tester.pump(const Duration(milliseconds: 50));
+
+      expect(listenerState.numNotifications, greaterThan(numNotificationsAtLastFrame));
+      numNotificationsAtLastFrame = listenerState.numNotifications;
+
+      await tester.pump(const Duration(seconds: 3));
+
+      expect(listenerState.numNotifications, greaterThan(numNotificationsAtLastFrame));
+      numNotificationsAtLastFrame = listenerState.numNotifications;
     });
   });
-
 }
 
 class GeometryListener extends StatefulWidget {

--- a/packages/flutter/test/material/scaffold_test.dart
+++ b/packages/flutter/test/material/scaffold_test.dart
@@ -887,6 +887,15 @@ void main() {
         geometry.floatingActionButtonScale,
         inExclusiveRange(0.0, 1.0),
       );
+
+      await tester.pump(const Duration(seconds: 3));
+      final RenderBox floatingActionButtonBox = tester.renderObject(find.byKey(key));
+      final Rect fabRect = floatingActionButtonBox.localToGlobal(Offset.zero) & floatingActionButtonBox.size;
+
+      expect(
+        geometry.floatingActionButtonArea,
+        fabRect
+      );
     });
   });
 


### PR DESCRIPTION
Scaling the FAB down to 0 and then up was losing the FAB area variable.
This workaround is pretty ugly, but I expect it to be gone with Dave's
refactoring of the fab scaling logic.