### PR TITLE
Let the gallery bundle Id ephemerally change to io.flutter.demo.gallery before deploying

### DIFF
--- a/examples/flutter_gallery/ios/Runner.xcodeproj/project.pbxproj
+++ b/examples/flutter_gallery/ios/Runner.xcodeproj/project.pbxproj
@@ -455,7 +455,7 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/Flutter",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = io.flutter.demo.gallery;
+				PRODUCT_BUNDLE_IDENTIFIER = io.flutter.examples.gallery;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Debug;
@@ -477,7 +477,7 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/Flutter",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = io.flutter.demo.gallery;
+				PRODUCT_BUNDLE_IDENTIFIER = io.flutter.examples.gallery;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Release;

--- a/examples/flutter_gallery/ios/fastlane/Fastfile
+++ b/examples/flutter_gallery/ios/fastlane/Fastfile
@@ -31,6 +31,8 @@ platform :ios do
 
     update_app_identifier(
       plist_path: 'Runner/Info.plist',
+      # Let the checked-in bundle ID be different so users don't collide on
+      # provisioning profile creation when building locally.
       app_identifier: 'io.flutter.demo.gallery'
     )
 

--- a/examples/flutter_gallery/ios/fastlane/Fastfile
+++ b/examples/flutter_gallery/ios/fastlane/Fastfile
@@ -29,6 +29,11 @@ platform :ios do
     raw_version = File.read('../../../../version')
     puts "Building and deploying version #{raw_version}..."
 
+    update_app_identifier(
+      plist_path: 'Runner/Info.plist',
+      app_identifier: 'io.flutter.demo.gallery'
+    )
+
     increment_version_number(
       # Only major, minor, patch digits and dots.
       version_number: /\d+\.\d+\.\d+/.match(raw_version)[0]


### PR DESCRIPTION
Fixes #14685 
Prevent provisioning profile creation collision when users manually builds. 