### PR TITLE
Initial implementation of BottomAppBar

### DIFF
--- a/packages/flutter/lib/material.dart
+++ b/packages/flutter/lib/material.dart
@@ -20,6 +20,7 @@ export 'src/material/app.dart';
 export 'src/material/app_bar.dart';
 export 'src/material/arc.dart';
 export 'src/material/back_button.dart';
+export 'src/material/bottom_app_bar.dart';
 export 'src/material/bottom_navigation_bar.dart';
 export 'src/material/bottom_sheet.dart';
 export 'src/material/button.dart';

--- a/packages/flutter/lib/src/material/bottom_app_bar.dart
+++ b/packages/flutter/lib/src/material/bottom_app_bar.dart
@@ -35,7 +35,7 @@ import 'scaffold.dart';
 ///
 ///  * [ComputeNotch] a function used for creating a notch in a shape.
 ///  * [ScaffoldGeometry.floatingActionBarComputeNotch] the [ComputeNotch] used to
-///  make a notch for the [FloatingActionButton]
+///    make a notch for the [FloatingActionButton]
 ///  * [FloatingActionButton] which the [BottomAppBar] makes a notch for.
 ///  * [AppBar] for a toolbar that is shown at the top of the screen.
 class BottomAppBar extends StatefulWidget {
@@ -48,6 +48,7 @@ class BottomAppBar extends StatefulWidget {
     this.elevation: 8.0,
     this.child,
   }) : assert(elevation != null),
+       assert(elevation >= 0.0),
        super(key: key);
 
   /// The widget below this widget in the tree.

--- a/packages/flutter/lib/src/material/bottom_app_bar.dart
+++ b/packages/flutter/lib/src/material/bottom_app_bar.dart
@@ -6,6 +6,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 
+import 'colors.dart';
 import 'material.dart';
 import 'scaffold.dart';
 
@@ -44,11 +45,9 @@ class BottomAppBar extends StatefulWidget {
   const BottomAppBar({
     Key key,
     this.child,
-    // TODO(amirh): use a default color from the theme.
-    @required this.color,
+    this.color,
     this.elevation: 8.0,
-  }) : assert(color != null),
-       assert(elevation != null),
+  }) : assert(elevation != null),
        super(key: key);
 
   /// The widget below this widget in the tree.
@@ -56,7 +55,7 @@ class BottomAppBar extends StatefulWidget {
   /// {@macro flutter.widgets.child}
   final Widget child;
 
-  /// The color to paint the material.
+  /// The bottom app bar's background color.
   final Color color;
 
   /// The z-coordinate at which to place this bottom app bar. This controls the
@@ -87,7 +86,8 @@ class _BottomAppBarState extends State<BottomAppBar> {
       ),
       clipper: new _BottomAppBarClipper(geometry: geometryListenable),
       elevation: widget.elevation,
-      color: widget.color,
+      // TODO(amirh): use a default color from the theme.
+      color: widget.color ?? Colors.white,
     );
   }
 }
@@ -109,7 +109,7 @@ class _BottomAppBarClipper extends CustomClipper<Path> {
     }
 
     final Rect button = geometry.value.floatingActionButtonArea
-      .translate(0.0, geometry.value.bottomNavigationBarTop * -1);
+      .translate(0.0, geometry.value.bottomNavigationBarTop * -1.0);
 
     final Rect intersect = appBar.intersect(button);
     if (intersect.width < 0.0 || intersect.height < 0.0) {

--- a/packages/flutter/lib/src/material/bottom_app_bar.dart
+++ b/packages/flutter/lib/src/material/bottom_app_bar.dart
@@ -33,7 +33,7 @@ import 'scaffold.dart';
 ///
 /// See also:
 ///
-///  * [ComputeNotch] a closure used for creating a notch in a shape.
+///  * [ComputeNotch] a function used for creating a notch in a shape.
 ///  * [ScaffoldGeometry.floatingActionBarComputeNotch] the [ComputeNotch] used to
 ///  make a notch for the [FloatingActionButton]
 ///  * [FloatingActionButton] which the [BottomAppBar] makes a notch for.
@@ -44,15 +44,18 @@ class BottomAppBar extends StatefulWidget {
   /// The [color] and [elevation] arguments must not be null.
   const BottomAppBar({
     Key key,
-    this.child,
     this.color,
     this.elevation: 8.0,
+    this.child,
   }) : assert(elevation != null),
        super(key: key);
 
   /// The widget below this widget in the tree.
   ///
   /// {@macro flutter.widgets.child}
+  ///
+  /// Typically this the child will be a [Row], with the first child
+  /// being an [IconButton] with the [Icons.menu] icon.
   final Widget child;
 
   /// The bottom app bar's background color.
@@ -80,14 +83,14 @@ class _BottomAppBarState extends State<BottomAppBar> {
   @override
   Widget build(BuildContext context) {
     return new PhysicalShape(
-      child: new Material(
-        type: MaterialType.transparency,
-        child: widget.child,
-      ),
       clipper: new _BottomAppBarClipper(geometry: geometryListenable),
       elevation: widget.elevation,
       // TODO(amirh): use a default color from the theme.
       color: widget.color ?? Colors.white,
+      child: new Material(
+        type: MaterialType.transparency,
+        child: widget.child,
+      ),
     );
   }
 }
@@ -108,11 +111,12 @@ class _BottomAppBarClipper extends CustomClipper<Path> {
       return new Path()..addRect(appBar);
     }
 
+    // button is the floating action button's bounding rectangle in the
+    // coordinate system that origins at the appBar's top left corner.
     final Rect button = geometry.value.floatingActionButtonArea
       .translate(0.0, geometry.value.bottomNavigationBarTop * -1.0);
 
-    final Rect intersect = appBar.intersect(button);
-    if (intersect.width < 0.0 || intersect.height < 0.0) {
+    if (appBar.overlaps(button)) {
       return new Path()..addRect(appBar);
     }
 

--- a/packages/flutter/lib/src/material/bottom_app_bar.dart
+++ b/packages/flutter/lib/src/material/bottom_app_bar.dart
@@ -32,8 +32,8 @@ import 'scaffold.dart';
 ///
 /// See also:
 ///
-///  * [NotchMaker] a closure used for creating a notch in a shape.
-///  * [ScaffoldGeometry.floatingActionBarNotchMaker] the [NotchMaker] used to
+///  * [ComputeNotch] a closure used for creating a notch in a shape.
+///  * [ScaffoldGeometry.floatingActionBarComputeNotch] the [ComputeNotch] used to
 ///  make a notch for the [FloatingActionButton]
 ///  * [FloatingActionButton] which the [BottomAppBar] makes a notch for.
 ///  * [AppBar] for a toolbar that is shown at the top of the screen.
@@ -104,7 +104,7 @@ class _BottomAppBarClipper extends CustomClipper<Path> {
   Path getClip(Size size) {
     final Rect appBar = Offset.zero & size;
     if (geometry.value.floatingActionButtonArea == null ||
-        geometry.value.floatingActionButtonNotchMaker == null) {
+        geometry.value.floatingActionButtonNotch == null) {
       return new Path()..addRect(appBar);
     }
 
@@ -116,11 +116,11 @@ class _BottomAppBarClipper extends CustomClipper<Path> {
       return new Path()..addRect(appBar);
     }
 
-    final NotchMaker notchMaker = geometry.value.floatingActionButtonNotchMaker;
+    final ComputeNotch computeNotch = geometry.value.floatingActionButtonNotch;
     return new Path()
       ..moveTo(appBar.left, appBar.top)
       ..addPath(
-        notchMaker(
+        computeNotch(
           appBar,
           button,
           new Offset(appBar.left, appBar.top),

--- a/packages/flutter/lib/src/material/floating_action_button.dart
+++ b/packages/flutter/lib/src/material/floating_action_button.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:math';
+import 'dart:math' as math;
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
@@ -39,9 +39,11 @@ class _DefaultHeroTag {
 /// If the [onPressed] callback is null, then the button will be disabled and
 /// will not react to touch.
 ///
-/// If the floating action bar is a descendant of a [Scaffold] that also has a
+/// If the floating action button is a descendant of a [Scaffold] that also has a
 /// [BottomAppBar], the [BottomAppBar] will show a notch to accomodate the
-/// [FloatingActionButton] when it overlaps the [BottomAppBar].
+/// [FloatingActionButton] when it overlaps the [BottomAppBar]. The notch's
+/// shape is an arc for a circle whose radius is the floating action button's
+/// radius plus [FloatingActionButton.notchMargin].
 ///
 /// See also:
 ///
@@ -129,10 +131,14 @@ class FloatingActionButton extends StatefulWidget {
   /// The margin to keep around the floating action button when creating a
   /// notch for it.
   ///
+  /// The notch is an arc of a circle with radius r+[notchMargin] where r is the
+  /// radius of the floating action button. This expanded radius leaves a margin
+  /// around the floating action button.
+  ///
   /// See also:
   ///
-  ///   * [BottomAppBar], a material design elements that shows a notch for the
-  ///   floating action button.
+  ///  * [BottomAppBar], a material design elements that shows a notch for the
+  ///    floating action button.
   final double notchMargin;
 
   @override
@@ -224,25 +230,24 @@ class _FloatingActionButtonState extends State<FloatingActionButton> {
     assert(() {
       if (end.dy != host.top)
         throw new FlutterError(
-          'The floating action button\'s notch maker must only be used for a notch in the top edge.\n'
+          'The floating action button\'s notch maker must only be used for a notch in the top edge of the host.\n'
           'The notch\'s path end point: $end is not in the top edge of $host'
         );
       if (start.dy != host.top)
         throw new FlutterError(
-          'The floating action button\'s notch maker must only be used for a notch in the top edge.\n'
+          'The floating action button\'s notch maker must only be used for a notch in the top edge the host.\n'
           'The notch\'s path start point: $start is not in the top edge of $host'
         );
       return true;
     }());
 
-    final Rect intersection = host.intersect(guest);
     assert(() {
-      if (intersection.width < 0.0 || intersection.height < 0.0)
+      if (!host.overlaps(guest))
         throw new FlutterError('Notch host must intersect with its guest');
       return true;
     }());
 
-    // The FAB's shape is a circle bound by the guest rectangle.
+    // The FAB's shape is a circle bounded by the guest rectangle.
     // So the FAB's radius is half the guest width.
     final double fabRadius = guest.width / 2.0;
 
@@ -272,7 +277,7 @@ class _FloatingActionButtonState extends State<FloatingActionButton> {
     // The other side (b) would be the distance on the horizontal axis between the
     // notch's center and the intersection points with it's top edge.
     final double a = host.top - guest.center.dy;
-    final double b = sqrt(notchRadius * notchRadius - a * a);
+    final double b = math.sqrt(notchRadius * notchRadius - a * a);
 
     return new Path()
       ..lineTo(guest.center.dx - b, host.top)

--- a/packages/flutter/lib/src/material/floating_action_button.dart
+++ b/packages/flutter/lib/src/material/floating_action_button.dart
@@ -237,14 +237,14 @@ class _FloatingActionButtonState extends State<FloatingActionButton> {
 
     final Rect intersection = host.intersect(guest);
     assert(() {
-      if (intersection.width < 0 || intersection.height < 0)
+      if (intersection.width < 0.0 || intersection.height < 0.0)
         throw new FlutterError('Notch host must intersect with its guest');
       return true;
     }());
 
     // The FAB's shape is a circle bound by the guest rectangle.
     // So the FAB's radius is half the guest width.
-    final double fabRadius = guest.width / 2;
+    final double fabRadius = guest.width / 2.0;
 
     final double notchRadius = fabRadius + widget.notchMargin;
     assert(() {
@@ -266,7 +266,7 @@ class _FloatingActionButtonState extends State<FloatingActionButton> {
     // center of the notch and the intersection of the notch's circle and the host's
     // top edge.
     //
-    // The hypotenuse of this triangle equals to the notch's radius, and one side
+    // The hypotenuse of this triangle equals the notch's radius, and one side
     // (a) is the distance from the notch's center to the top edge.
     //
     // The other side (b) would be the distance on the horizontal axis between the

--- a/packages/flutter/lib/src/material/floating_action_button.dart
+++ b/packages/flutter/lib/src/material/floating_action_button.dart
@@ -142,7 +142,7 @@ class FloatingActionButton extends StatefulWidget {
 class _FloatingActionButtonState extends State<FloatingActionButton> {
   bool _highlight = false;
 
-  VoidCallback _clearNotchMaker;
+  VoidCallback _clearComputeNotch;
 
   void _handleHighlightChanged(bool value) {
     setState(() {
@@ -210,17 +210,17 @@ class _FloatingActionButtonState extends State<FloatingActionButton> {
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
-    _clearNotchMaker = Scaffold.setFloatingActionButtonNotchMakerFor(context, _notchMaker);
+    _clearComputeNotch = Scaffold.setFloatingActionButtonNotchFor(context, _computeNotch);
   }
 
   @override
   void deactivate() {
-    if (_clearNotchMaker != null)
-      _clearNotchMaker();
+    if (_clearComputeNotch != null)
+      _clearComputeNotch();
     super.deactivate();
   }
 
-  Path _notchMaker(Rect host, Rect guest, Offset start, Offset end) {
+  Path _computeNotch(Rect host, Rect guest, Offset start, Offset end) {
     assert(() {
       if (end.dy != host.top)
         throw new FlutterError(

--- a/packages/flutter/lib/src/material/floating_action_button.dart
+++ b/packages/flutter/lib/src/material/floating_action_button.dart
@@ -142,6 +142,8 @@ class FloatingActionButton extends StatefulWidget {
 class _FloatingActionButtonState extends State<FloatingActionButton> {
   bool _highlight = false;
 
+  VoidCallback _clearNotchMaker;
+
   void _handleHighlightChanged(bool value) {
     setState(() {
       _highlight = value;
@@ -208,12 +210,13 @@ class _FloatingActionButtonState extends State<FloatingActionButton> {
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
-    Scaffold.setFloatingActionButtonNotchMakerFor(context, _notchMaker);
+    _clearNotchMaker = Scaffold.setFloatingActionButtonNotchMakerFor(context, _notchMaker);
   }
 
   @override
   void deactivate() {
-    Scaffold.setFloatingActionButtonNotchMakerFor(context, null);
+    if (_clearNotchMaker != null)
+      _clearNotchMaker();
     super.deactivate();
   }
 

--- a/packages/flutter/lib/src/material/scaffold.dart
+++ b/packages/flutter/lib/src/material/scaffold.dart
@@ -468,6 +468,8 @@ class _FloatingActionButtonTransitionState extends State<_FloatingActionButtonTr
 ///
 ///  * [AppBar], which is a horizontal bar typically shown at the top of an app
 ///    using the [appBar] property.
+///  * [BottomAppBar], which is a horizontal bar typically shown at the bottom
+///    of an app using the [bottomNavigationBar] property.
 ///  * [FloatingActionButton], which is a circular button typically shown in the
 ///    bottom right corner of the app using the [floatingActionButton] property.
 ///  * [Drawer], which is a vertical panel that is typically displayed to the

--- a/packages/flutter/lib/src/material/scaffold.dart
+++ b/packages/flutter/lib/src/material/scaffold.dart
@@ -24,6 +24,24 @@ const double _kFloatingActionButtonMargin = 16.0; // TODO(hmuller): should be de
 const Duration _kFloatingActionButtonSegue = const Duration(milliseconds: 200);
 final Tween<double> _kFloatingActionButtonTurnTween = new Tween<double>(begin: -0.125, end: 0.0);
 
+/// Returns a path for a notch in the outline of a shape.
+///
+/// The path makes a notch in the host shape that can contain the guest shape.
+///
+/// The `host` is the bounding rectangle for the shape into which the notch will
+/// be applied. The `guest` is the bounding rectangle of the shape for which we
+/// are creating a notch in the host.
+///
+/// The `start` and `end` arguments are points on the outline of the host shape
+/// that will be connected by the returned path.
+///
+/// The returned path may pass anywhere, including inside the guest bounds area,
+/// and may contain multiple subpaths. The returned path ends at `end` and does
+/// not end with a [Path.close]. The returned [Path] is built under the
+/// assumption it will be added to an existing path that is at the `start`
+/// coordinates using [Path.addPath].
+typedef Path NotchMaker(Rect host, Rect guest, Offset start, Offset end);
+
 enum _ScaffoldSlot {
   body,
   appBar,
@@ -46,6 +64,7 @@ class ScaffoldGeometry {
   const ScaffoldGeometry({
     this.bottomNavigationBarTop,
     this.floatingActionButtonArea,
+    this.floatingActionButtonNotchMaker,
   });
 
   /// The distance from the scaffold's top edge to the top edge of the
@@ -61,21 +80,42 @@ class ScaffoldGeometry {
   /// This is null when there is no floating action button showing.
   final Rect floatingActionButtonArea;
 
-  ScaffoldGeometry _scaleFab(double scaleFactor) {
+  /// A [NotchMaker] for the floating action button.
+  /// 
+  /// The contract for this [NotchMaker] is described in [NotchMaker] and
+  /// [Scaffold.setFloatingActionButtonNotchMakerFor].
+  final NotchMaker floatingActionButtonNotchMaker;
+
+  ScaffoldGeometry _scaleFloatingActionButton(double scaleFactor) {
     if (scaleFactor == 1.0)
       return this;
 
-    if (scaleFactor == 0.0)
-      return new ScaffoldGeometry(bottomNavigationBarTop: bottomNavigationBarTop);
+    if (scaleFactor == 0.0) {
+      return new ScaffoldGeometry(
+        bottomNavigationBarTop: bottomNavigationBarTop,
+        floatingActionButtonNotchMaker: floatingActionButtonNotchMaker,
+      );
+    }
 
-    final Rect scaledFab = Rect.lerp(
+    final Rect scaledButton = Rect.lerp(
       floatingActionButtonArea.center & Size.zero,
       floatingActionButtonArea,
       scaleFactor
     );
+    return copyWith(floatingActionButtonArea: scaledButton);
+  }
+
+  /// Creates a copy of this [ScaffoldGeometry] but with the given fields replaced with
+  /// the new values.
+  ScaffoldGeometry copyWith({
+    double bottomNavigationBarTop,
+    Rect floatingActionButtonArea,
+    NotchMaker floatingActionButtonNotchMaker,
+  }) {
     return new ScaffoldGeometry(
-      bottomNavigationBarTop: bottomNavigationBarTop,
-      floatingActionButtonArea: scaledFab,
+      bottomNavigationBarTop: bottomNavigationBarTop ?? this.bottomNavigationBarTop,
+      floatingActionButtonArea: floatingActionButtonArea ?? this.floatingActionButtonArea,
+      floatingActionButtonNotchMaker: floatingActionButtonNotchMaker ?? this.floatingActionButtonNotchMaker,
     );
   }
 }
@@ -100,18 +140,29 @@ class _ScaffoldGeometryNotifier extends ChangeNotifier implements ValueListenabl
         );
       return true;
     }());
-    return geometry._scaleFab(fabScale);
+    return geometry._scaleFloatingActionButton(fabScale);
   }
 
   void _updateWith({
     double bottomNavigationBarTop,
     Rect floatingActionButtonArea,
     double floatingActionButtonScale,
+    NotchMaker floatingActionButtonNotchMaker,
   }) {
     fabScale = floatingActionButtonScale ?? fabScale;
+    geometry = geometry.copyWith(
+      bottomNavigationBarTop: bottomNavigationBarTop,
+      floatingActionButtonArea: floatingActionButtonArea,
+      floatingActionButtonNotchMaker: floatingActionButtonNotchMaker,
+    );
+    notifyListeners();
+  }
+
+  void _updateFloatingActionButtonNotchMaker(NotchMaker fabNotchMaker) {
     geometry = new ScaffoldGeometry(
-      bottomNavigationBarTop: bottomNavigationBarTop ?? geometry?.bottomNavigationBarTop,
-      floatingActionButtonArea: floatingActionButtonArea ?? geometry?.floatingActionButtonArea,
+      bottomNavigationBarTop: geometry.bottomNavigationBarTop,
+      floatingActionButtonArea: geometry.floatingActionButtonArea,
+      floatingActionButtonNotchMaker: fabNotchMaker,
     );
     notifyListeners();
   }
@@ -675,6 +726,26 @@ class Scaffold extends StatefulWidget {
     return scaffoldScope.geometryNotifier;
   }
 
+  /// Sets the [ScaffoldGeometry.floatingActionButtonNotchMaker] for the closest
+  /// [Scaffold] ancestor of the given context if one exist.
+  ///
+  /// It is guaranteed that `notchMaker` will only be used for making notches
+  /// in the top edge of the [bottomNavigationBar], the start and end offsets given to
+  /// it will always be on the top edge of the [bottomNavigationBar], the start offset
+  /// will be to the left of the floating action button's bounds, and the end
+  /// offset will be to the right of the floating action button's bounds.
+  ///
+  /// Returns true if the [ScaffoldGeometry.floatingActionButtonNotchMaker] was
+  /// set.
+  /// Returns false if there as no [Scaffold] ancestor.
+  static bool setFloatingActionButtonNotchMakerFor(BuildContext context, NotchMaker notchMaker) {
+    final _ScaffoldScope scaffoldScope = context.inheritFromWidgetOfExactType(_ScaffoldScope);
+    if (scaffoldScope == null)
+      return false;
+    scaffoldScope.geometryNotifier._updateFloatingActionButtonNotchMaker(notchMaker);
+    return true;
+  }
+
   /// Whether the Scaffold that most tightly encloses the given context has a
   /// drawer.
   ///
@@ -964,7 +1035,7 @@ class ScaffoldState extends State<Scaffold> with TickerProviderStateMixin {
   @override
   void initState() {
     super.initState();
-    _geometryNotifier = new _ScaffoldGeometryNotifier(null, context);
+    _geometryNotifier = new _ScaffoldGeometryNotifier(const ScaffoldGeometry(), context);
   }
 
   @override

--- a/packages/flutter/lib/src/material/scaffold.dart
+++ b/packages/flutter/lib/src/material/scaffold.dart
@@ -751,7 +751,7 @@ class Scaffold extends StatefulWidget {
   }
 
   /// Sets the [ScaffoldGeometry.floatingActionButtonNotch] for the closest
-  /// [Scaffold] ancestor of the given context if one exist.
+  /// [Scaffold] ancestor of the given context, if one exist.
   ///
   /// It is guaranteed that `computeNotch` will only be used for making notches
   /// in the top edge of the [bottomNavigationBar], the start and end offsets given to

--- a/packages/flutter/lib/src/material/scaffold.dart
+++ b/packages/flutter/lib/src/material/scaffold.dart
@@ -751,7 +751,7 @@ class Scaffold extends StatefulWidget {
   }
 
   /// Sets the [ScaffoldGeometry.floatingActionButtonNotch] for the closest
-  /// [Scaffold] ancestor of the given context, if one exist.
+  /// [Scaffold] ancestor of the given context, if one exists.
   ///
   /// It is guaranteed that `computeNotch` will only be used for making notches
   /// in the top edge of the [bottomNavigationBar], the start and end offsets given to

--- a/packages/flutter/test/material/floating_action_button_test.dart
+++ b/packages/flutter/test/material/floating_action_button_test.dart
@@ -4,6 +4,7 @@
 
 import 'dart:ui';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -201,4 +202,194 @@ void main() {
 
     semantics.dispose();
   });
+
+  group('NotchMaker', () {
+    testWidgets('host and guest must intersect', (WidgetTester tester) async {
+      final NotchMaker notchMaker = await fetchNotchMaker(tester, const FloatingActionButton(onPressed: null));
+      final Rect host = new Rect.fromLTRB(0.0, 100.0, 300.0, 300.0);
+      final Rect guest = new Rect.fromLTWH(50.0, 50.0, 10.0, 10.0);
+      final Offset start = const Offset(10.0, 100.0);
+      final Offset end = const Offset(60.0, 100.0);
+      expect(() {notchMaker(host, guest, start, end);}, throwsFlutterError);
+    });
+
+    testWidgets('start/end must be on top edge', (WidgetTester tester) async {
+      final NotchMaker notchMaker = await fetchNotchMaker(tester, const FloatingActionButton(onPressed: null));
+      final Rect host = new Rect.fromLTRB(0.0, 100.0, 300.0, 300.0);
+      final Rect guest = new Rect.fromLTRB(190.0, 90.0, 210.0, 110.0);
+
+      Offset start = const Offset(180.0, 100.0);
+      Offset end = const Offset(220.0, 110.0);
+      expect(() {notchMaker(host, guest, start, end);}, throwsFlutterError);
+
+      start = const Offset(180.0, 110.0);
+      end = const Offset(220.0, 100.0);
+      expect(() {notchMaker(host, guest, start, end);}, throwsFlutterError);
+    });
+
+    testWidgets('start must be to the left of the notch', (WidgetTester tester) async {
+      final NotchMaker notchMaker = await fetchNotchMaker(tester, const FloatingActionButton(onPressed: null));
+      final Rect host = new Rect.fromLTRB(0.0, 100.0, 300.0, 300.0);
+      final Rect guest = new Rect.fromLTRB(190.0, 90.0, 210.0, 110.0);
+
+      final Offset start = const Offset(191.0, 100.0);
+      final Offset end = const Offset(220.0, 100.0);
+      expect(() {notchMaker(host, guest, start, end);}, throwsFlutterError);
+    });
+
+    testWidgets('end must be to the right of the notch', (WidgetTester tester) async {
+      final NotchMaker notchMaker = await fetchNotchMaker(tester, const FloatingActionButton(onPressed: null));
+      final Rect host = new Rect.fromLTRB(0.0, 100.0, 300.0, 300.0);
+      final Rect guest = new Rect.fromLTRB(190.0, 90.0, 210.0, 110.0);
+
+      final Offset start = const Offset(180.0, 100.0);
+      final Offset end = const Offset(209.0, 100.0);
+      expect(() {notchMaker(host, guest, start, end);}, throwsFlutterError);
+    });
+
+    testWidgets('notch no margin', (WidgetTester tester) async {
+      final NotchMaker notchMaker = await fetchNotchMaker(tester, const FloatingActionButton(onPressed: null, notchMargin: 0.0));
+      final Rect host = new Rect.fromLTRB(0.0, 100.0, 300.0, 300.0);
+      final Rect guest = new Rect.fromLTRB(190.0, 90.0, 210.0, 110.0);
+      final Offset start = const Offset(180.0, 100.0);
+      final Offset end = const Offset(220.0, 100.0);
+
+      final Path actualNotch = notchMaker(host, guest, start, end);
+      final Path expectedNotch = new Path()
+        ..lineTo(190.0, 100.0)
+        ..arcToPoint(
+          const Offset(210.0, 100.0),
+          radius: const Radius.circular(10.0),
+          clockwise: false
+        )
+        ..lineTo(220.0, 100.0);
+
+      expect(
+        createNotchedRectangle(host, start.dx, end.dx, actualNotch),
+        coversSameAreaAs(
+          createNotchedRectangle(host, start.dx, end.dx, expectedNotch),
+          areaToCompare: host.inflate(10.0)
+        )
+      );
+
+      expect(
+        createNotchedRectangle(host, start.dx, end.dx, actualNotch),
+        coversSameAreaAs(
+          createNotchedRectangle(host, start.dx, end.dx, expectedNotch),
+          areaToCompare: guest.inflate(10.0),
+          sampleSize: 50,
+        )
+      );
+    });
+
+    testWidgets('notch with margin', (WidgetTester tester) async {
+      final NotchMaker notchMaker = await fetchNotchMaker(tester,
+        const FloatingActionButton(onPressed: null, notchMargin: 4.0)
+      );
+      final Rect host = new Rect.fromLTRB(0.0, 100.0, 300.0, 300.0);
+      final Rect guest = new Rect.fromLTRB(190.0, 90.0, 210.0, 110.0);
+      final Offset start = const Offset(180.0, 100.0);
+      final Offset end = const Offset(220.0, 100.0);
+
+      final Path actualNotch = notchMaker(host, guest, start, end);
+      final Path expectedNotch = new Path()
+        ..lineTo(186.0, 100.0)
+        ..arcToPoint(
+          const Offset(214.0, 100.0),
+          radius: const Radius.circular(14.0),
+          clockwise: false
+        )
+        ..lineTo(220.0, 100.0);
+
+      expect(
+        createNotchedRectangle(host, start.dx, end.dx, actualNotch),
+        coversSameAreaAs(
+          createNotchedRectangle(host, start.dx, end.dx, expectedNotch),
+          areaToCompare: host.inflate(10.0)
+        )
+      );
+
+      expect(
+        createNotchedRectangle(host, start.dx, end.dx, actualNotch),
+        coversSameAreaAs(
+          createNotchedRectangle(host, start.dx, end.dx, expectedNotch),
+          areaToCompare: guest.inflate(10.0),
+          sampleSize: 50,
+        )
+      );
+    });
+  });
+}
+
+Path createNotchedRectangle(Rect container, double startX, double endX, Path notch) {
+  return new Path()
+    ..moveTo(container.left, container.top)
+    ..lineTo(startX, container.top)
+    ..addPath(notch, Offset.zero)
+    ..lineTo(container.right, container.top)
+    ..lineTo(container.right, container.bottom)
+    ..lineTo(container.left, container.bottom)
+    ..close();
+}
+Future<NotchMaker> fetchNotchMaker(WidgetTester tester, FloatingActionButton fab) async {
+      await tester.pumpWidget(new MaterialApp(
+          home: new Scaffold(
+            body: new ConstrainedBox(
+              constraints: const BoxConstraints.expand(height: 80.0),
+              child: new GeometryListener(),
+            ),
+            floatingActionButton: fab,
+          )
+      ));
+      final GeometryListenerState listenerState = tester.state(find.byType(GeometryListener));
+      return listenerState.cache.value.floatingActionButtonNotchMaker;
+}
+
+class GeometryListener extends StatefulWidget {
+  @override
+  State createState() => new GeometryListenerState();
+}
+
+class GeometryListenerState extends State<GeometryListener> {
+  @override
+  Widget build(BuildContext context) {
+    return new CustomPaint(
+      painter: cache
+    );
+  }
+
+  ValueListenable<ScaffoldGeometry> geometryListenable;
+  GeometryCachePainter cache;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    final ValueListenable<ScaffoldGeometry> newListenable = Scaffold.geometryOf(context);
+    if (geometryListenable == newListenable)
+      return;
+    
+    geometryListenable = newListenable;
+    cache = new GeometryCachePainter(geometryListenable);
+  }
+
+}
+
+// The Scaffold.geometryOf() value is only available at paint time.
+// To fetch it for the tests we implement this CustomPainter that just
+// caches the ScaffoldGeometry value in its paint method.
+class GeometryCachePainter extends CustomPainter {
+  GeometryCachePainter(this.geometryListenable) : super(repaint: geometryListenable);
+
+  final ValueListenable<ScaffoldGeometry> geometryListenable;
+
+  ScaffoldGeometry value;
+  @override
+  void paint(Canvas canvas, Size size) {
+    value = geometryListenable.value;
+  }
+
+  @override
+  bool shouldRepaint(GeometryCachePainter oldDelegate) {
+    return true;
+  }
 }

--- a/packages/flutter/test/material/floating_action_button_test.dart
+++ b/packages/flutter/test/material/floating_action_button_test.dart
@@ -203,58 +203,58 @@ void main() {
     semantics.dispose();
   });
 
-  group('NotchMaker', () {
+  group('ComputeNotch', () {
     testWidgets('host and guest must intersect', (WidgetTester tester) async {
-      final NotchMaker notchMaker = await fetchNotchMaker(tester, const FloatingActionButton(onPressed: null));
+      final ComputeNotch computeNotch = await fetchComputeNotch(tester, const FloatingActionButton(onPressed: null));
       final Rect host = new Rect.fromLTRB(0.0, 100.0, 300.0, 300.0);
       final Rect guest = new Rect.fromLTWH(50.0, 50.0, 10.0, 10.0);
       final Offset start = const Offset(10.0, 100.0);
       final Offset end = const Offset(60.0, 100.0);
-      expect(() {notchMaker(host, guest, start, end);}, throwsFlutterError);
+      expect(() {computeNotch(host, guest, start, end);}, throwsFlutterError);
     });
 
     testWidgets('start/end must be on top edge', (WidgetTester tester) async {
-      final NotchMaker notchMaker = await fetchNotchMaker(tester, const FloatingActionButton(onPressed: null));
+      final ComputeNotch computeNotch = await fetchComputeNotch(tester, const FloatingActionButton(onPressed: null));
       final Rect host = new Rect.fromLTRB(0.0, 100.0, 300.0, 300.0);
       final Rect guest = new Rect.fromLTRB(190.0, 90.0, 210.0, 110.0);
 
       Offset start = const Offset(180.0, 100.0);
       Offset end = const Offset(220.0, 110.0);
-      expect(() {notchMaker(host, guest, start, end);}, throwsFlutterError);
+      expect(() {computeNotch(host, guest, start, end);}, throwsFlutterError);
 
       start = const Offset(180.0, 110.0);
       end = const Offset(220.0, 100.0);
-      expect(() {notchMaker(host, guest, start, end);}, throwsFlutterError);
+      expect(() {computeNotch(host, guest, start, end);}, throwsFlutterError);
     });
 
     testWidgets('start must be to the left of the notch', (WidgetTester tester) async {
-      final NotchMaker notchMaker = await fetchNotchMaker(tester, const FloatingActionButton(onPressed: null));
+      final ComputeNotch computeNotch = await fetchComputeNotch(tester, const FloatingActionButton(onPressed: null));
       final Rect host = new Rect.fromLTRB(0.0, 100.0, 300.0, 300.0);
       final Rect guest = new Rect.fromLTRB(190.0, 90.0, 210.0, 110.0);
 
       final Offset start = const Offset(191.0, 100.0);
       final Offset end = const Offset(220.0, 100.0);
-      expect(() {notchMaker(host, guest, start, end);}, throwsFlutterError);
+      expect(() {computeNotch(host, guest, start, end);}, throwsFlutterError);
     });
 
     testWidgets('end must be to the right of the notch', (WidgetTester tester) async {
-      final NotchMaker notchMaker = await fetchNotchMaker(tester, const FloatingActionButton(onPressed: null));
+      final ComputeNotch computeNotch = await fetchComputeNotch(tester, const FloatingActionButton(onPressed: null));
       final Rect host = new Rect.fromLTRB(0.0, 100.0, 300.0, 300.0);
       final Rect guest = new Rect.fromLTRB(190.0, 90.0, 210.0, 110.0);
 
       final Offset start = const Offset(180.0, 100.0);
       final Offset end = const Offset(209.0, 100.0);
-      expect(() {notchMaker(host, guest, start, end);}, throwsFlutterError);
+      expect(() {computeNotch(host, guest, start, end);}, throwsFlutterError);
     });
 
     testWidgets('notch no margin', (WidgetTester tester) async {
-      final NotchMaker notchMaker = await fetchNotchMaker(tester, const FloatingActionButton(onPressed: null, notchMargin: 0.0));
+      final ComputeNotch computeNotch = await fetchComputeNotch(tester, const FloatingActionButton(onPressed: null, notchMargin: 0.0));
       final Rect host = new Rect.fromLTRB(0.0, 100.0, 300.0, 300.0);
       final Rect guest = new Rect.fromLTRB(190.0, 90.0, 210.0, 110.0);
       final Offset start = const Offset(180.0, 100.0);
       final Offset end = const Offset(220.0, 100.0);
 
-      final Path actualNotch = notchMaker(host, guest, start, end);
+      final Path actualNotch = computeNotch(host, guest, start, end);
       final Path expectedNotch = new Path()
         ..lineTo(190.0, 100.0)
         ..arcToPoint(
@@ -283,7 +283,7 @@ void main() {
     });
 
     testWidgets('notch with margin', (WidgetTester tester) async {
-      final NotchMaker notchMaker = await fetchNotchMaker(tester,
+      final ComputeNotch computeNotch = await fetchComputeNotch(tester,
         const FloatingActionButton(onPressed: null, notchMargin: 4.0)
       );
       final Rect host = new Rect.fromLTRB(0.0, 100.0, 300.0, 300.0);
@@ -291,7 +291,7 @@ void main() {
       final Offset start = const Offset(180.0, 100.0);
       final Offset end = const Offset(220.0, 100.0);
 
-      final Path actualNotch = notchMaker(host, guest, start, end);
+      final Path actualNotch = computeNotch(host, guest, start, end);
       final Path expectedNotch = new Path()
         ..lineTo(186.0, 100.0)
         ..arcToPoint(
@@ -331,7 +331,7 @@ Path createNotchedRectangle(Rect container, double startX, double endX, Path not
     ..lineTo(container.left, container.bottom)
     ..close();
 }
-Future<NotchMaker> fetchNotchMaker(WidgetTester tester, FloatingActionButton fab) async {
+Future<ComputeNotch> fetchComputeNotch(WidgetTester tester, FloatingActionButton fab) async {
       await tester.pumpWidget(new MaterialApp(
           home: new Scaffold(
             body: new ConstrainedBox(
@@ -342,7 +342,7 @@ Future<NotchMaker> fetchNotchMaker(WidgetTester tester, FloatingActionButton fab
           )
       ));
       final GeometryListenerState listenerState = tester.state(find.byType(GeometryListener));
-      return listenerState.cache.value.floatingActionButtonNotchMaker;
+      return listenerState.cache.value.floatingActionButtonNotch;
 }
 
 class GeometryListener extends StatefulWidget {

--- a/packages/flutter/test/material/scaffold_test.dart
+++ b/packages/flutter/test/material/scaffold_test.dart
@@ -940,15 +940,15 @@ void main() {
       numNotificationsAtLastFrame = listenerState.numNotifications;
     });
 
-    testWidgets('set floatingActionButtonNotchMaker', (WidgetTester tester) async {
-      final NotchMaker notchMaker = (Rect container, Rect notch, Offset start, Offset end) => null;
+    testWidgets('set floatingActionButtonNotch', (WidgetTester tester) async {
+      final ComputeNotch computeNotch = (Rect container, Rect notch, Offset start, Offset end) => null;
       await tester.pumpWidget(new MaterialApp(
           home: new Scaffold(
             body: new ConstrainedBox(
               constraints: const BoxConstraints.expand(height: 80.0),
               child: new GeometryListener(),
             ),
-            floatingActionButton: new NotchMakerSetter(notchMaker),
+            floatingActionButton: new ComputeNotchSetter(computeNotch),
           )
       ));
 
@@ -956,8 +956,8 @@ void main() {
       ScaffoldGeometry geometry = listenerState.cache.value;
 
       expect(
-        geometry.floatingActionButtonNotchMaker,
-        notchMaker,
+        geometry.floatingActionButtonNotch,
+        computeNotch,
       );
 
       await tester.pumpWidget(new MaterialApp(
@@ -974,37 +974,37 @@ void main() {
       geometry = listenerState.cache.value;
 
       expect(
-        geometry.floatingActionButtonNotchMaker,
+        geometry.floatingActionButtonNotch,
         null,
       );
     });
 
-    testWidgets('closing an inactive floatingActionButtonNotchMaker is a no-op', (WidgetTester tester) async {
-      final NotchMaker notchMaker = (Rect container, Rect notch, Offset start, Offset end) => null;
+    testWidgets('closing an inactive floatingActionButtonNotch is a no-op', (WidgetTester tester) async {
+      final ComputeNotch computeNotch = (Rect container, Rect notch, Offset start, Offset end) => null;
       await tester.pumpWidget(new MaterialApp(
           home: new Scaffold(
             body: new ConstrainedBox(
               constraints: const BoxConstraints.expand(height: 80.0),
               child: new GeometryListener(),
             ),
-            floatingActionButton: new NotchMakerSetter(notchMaker),
+            floatingActionButton: new ComputeNotchSetter(computeNotch),
           )
       ));
 
-      final NotchMakerSetterState notchMakerSetterState = tester.state(find.byType(NotchMakerSetter));
+      final ComputeNotchSetterState computeNotchSetterState = tester.state(find.byType(ComputeNotchSetter));
 
-      final VoidCallback clearFirstNotchMaker = notchMakerSetterState.clearNotchMaker;
+      final VoidCallback clearFirstComputeNotch = computeNotchSetterState.clearComputeNotch;
 
-      final NotchMaker notchMaker2 = (Rect container, Rect notch, Offset start, Offset end) => null;
+      final ComputeNotch computeNotch2 = (Rect container, Rect notch, Offset start, Offset end) => null;
       await tester.pumpWidget(new MaterialApp(
           home: new Scaffold(
             body: new ConstrainedBox(
               constraints: const BoxConstraints.expand(height: 80.0),
               child: new GeometryListener(),
             ),
-            floatingActionButton: new NotchMakerSetter(
-              notchMaker2,
-              // We're setting a key to make sure a new NotchMakerSetterState is
+            floatingActionButton: new ComputeNotchSetter(
+              computeNotch2,
+              // We're setting a key to make sure a new ComputeNotchSetterState is
               // created.
               key: new GlobalKey(),
             ),
@@ -1017,14 +1017,14 @@ void main() {
       // We call the clear callback for the first notch maker and verify that
       // the second notch maker is still set.
 
-      clearFirstNotchMaker();
+      clearFirstComputeNotch();
 
       final GeometryListenerState listenerState = tester.state(find.byType(GeometryListener));
       final ScaffoldGeometry geometry = listenerState.cache.value;
 
       expect(
-        geometry.floatingActionButtonNotchMaker,
-        notchMaker2,
+        geometry.floatingActionButtonNotch,
+        computeNotch2,
       );
     });
   });
@@ -1087,27 +1087,27 @@ class GeometryCachePainter extends CustomPainter {
   }
 }
 
-class NotchMakerSetter extends StatefulWidget {
-  const NotchMakerSetter(this.notchMaker, {Key key}): super(key: key);
+class ComputeNotchSetter extends StatefulWidget {
+  const ComputeNotchSetter(this.computeNotch, {Key key}): super(key: key);
 
-  final NotchMaker notchMaker;
+  final ComputeNotch computeNotch;
 
   @override
-  State createState() => new NotchMakerSetterState();
+  State createState() => new ComputeNotchSetterState();
 }
 
-class NotchMakerSetterState extends State<NotchMakerSetter> {
+class ComputeNotchSetterState extends State<ComputeNotchSetter> {
 
-  VoidCallback clearNotchMaker;
+  VoidCallback clearComputeNotch;
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
-    clearNotchMaker = Scaffold.setFloatingActionButtonNotchMakerFor(context, widget.notchMaker);
+    clearComputeNotch = Scaffold.setFloatingActionButtonNotchFor(context, widget.computeNotch);
   }
 
   @override
   void deactivate() {
-    clearNotchMaker();
+    clearComputeNotch();
     super.deactivate();
   }
 

--- a/packages/flutter/test/material/scaffold_test.dart
+++ b/packages/flutter/test/material/scaffold_test.dart
@@ -939,6 +939,44 @@ void main() {
       expect(listenerState.numNotifications, greaterThan(numNotificationsAtLastFrame));
       numNotificationsAtLastFrame = listenerState.numNotifications;
     });
+
+    testWidgets('set floatingActionButtonNotchMaker', (WidgetTester tester) async {
+      final NotchMaker notchMaker = (Rect container, Rect notch, Offset start, Offset end) => null;
+      await tester.pumpWidget(new MaterialApp(
+          home: new Scaffold(
+            body: new ConstrainedBox(
+              constraints: const BoxConstraints.expand(height: 80.0),
+              child: new GeometryListener(),
+            ),
+            floatingActionButton: new NotchMakerSetter(notchMaker),
+          )
+      ));
+
+      final GeometryListenerState listenerState = tester.state(find.byType(GeometryListener));
+      ScaffoldGeometry geometry = listenerState.cache.value;
+
+      expect(
+        geometry.floatingActionButtonNotchMaker,
+        notchMaker,
+      );
+
+      await tester.pumpWidget(new MaterialApp(
+          home: new Scaffold(
+            body: new ConstrainedBox(
+              constraints: const BoxConstraints.expand(height: 80.0),
+              child: new GeometryListener(),
+            ),
+            floatingActionButton: const NotchMakerSetter(null),
+          )
+      ));
+
+      geometry = listenerState.cache.value;
+
+      expect(
+        geometry.floatingActionButtonNotchMaker,
+        null,
+      );
+    });
   });
 }
 
@@ -983,7 +1021,7 @@ class GeometryListenerState extends State<GeometryListener> {
 // To fetch it for the tests we implement this CustomPainter that just
 // caches the ScaffoldGeometry value in its paint method.
 class GeometryCachePainter extends CustomPainter {
-  GeometryCachePainter(this.geometryListenable);
+  GeometryCachePainter(this.geometryListenable) : super(repaint: geometryListenable);
 
   final ValueListenable<ScaffoldGeometry> geometryListenable;
 
@@ -996,5 +1034,17 @@ class GeometryCachePainter extends CustomPainter {
   @override
   bool shouldRepaint(GeometryCachePainter oldDelegate) {
     return true;
+  }
+}
+
+class NotchMakerSetter extends StatelessWidget {
+  const NotchMakerSetter(this.notchMaker);
+
+  final NotchMaker notchMaker;
+
+  @override
+  Widget build(BuildContext context) {
+    Scaffold.setFloatingActionButtonNotchMakerFor(context, notchMaker);
+    return new Container();
   }
 }


### PR DESCRIPTION
Per reviewers request, I'm sending a single big e2e CL and not sending the induvidual PRs for the scaffold, floating action button, and bottom app bar changes separately.

Currently there is no unit test for BottomAppBar, as I there is no easy way to make the bottom app bar and the floating action button overlap before #14368 lands. Will write tests once that CL lands.

TBD in following CLs:
- Unit test BottomAppBar.
- Add a flag to BottomAppBar to enable/disable the notch.
- Use default color for the BottomAppBar from the theme.
- Implicitly animate the BAB's color and elevation.