### PR TITLE
When running tests with --preview-dart-2 check for compilation errors.

### DIFF
--- a/packages/flutter_tools/lib/src/test/flutter_platform.dart
+++ b/packages/flutter_tools/lib/src/test/flutter_platform.dart
@@ -211,6 +211,11 @@ class _FlutterPlatform extends PlatformPlugin {
           packagesPath: PackageMap.globalPackagesPath,
         );
 
+        if (mainDart == null) {
+          controller.sink.addError(_getErrorMessage('Compilation failed', testPath, shellPath))
+          return;
+        }
+
         // bundlePath needs to point to a folder with `platform.dill` file.
         final Directory tempBundleDirectory = fs.systemTempDirectory
             .createTempSync('flutter_bundle_directory');

--- a/packages/flutter_tools/lib/src/test/flutter_platform.dart
+++ b/packages/flutter_tools/lib/src/test/flutter_platform.dart
@@ -212,7 +212,7 @@ class _FlutterPlatform extends PlatformPlugin {
         );
 
         if (mainDart == null) {
-          controller.sink.addError(_getErrorMessage('Compilation failed', testPath, shellPath))
+          controller.sink.addError(_getErrorMessage('Compilation failed', testPath, shellPath));
           return;
         }
 

--- a/packages/flutter_tools/lib/src/test/flutter_platform.dart
+++ b/packages/flutter_tools/lib/src/test/flutter_platform.dart
@@ -213,7 +213,7 @@ class _FlutterPlatform extends PlatformPlugin {
 
         if (mainDart == null) {
           controller.sink.addError(_getErrorMessage('Compilation failed', testPath, shellPath));
-          return;
+          return null;
         }
 
         // bundlePath needs to point to a folder with `platform.dill` file.


### PR DESCRIPTION
If compiler failed to produce Kernel binary then compile(...) returns
null to the caller. If we don't check for null we end up trying to
run file called "null" which causes a very confusing crash of the
flutter_tester.