### PR TITLE
Set encryption compliance in Gallery Info.plist

### DIFF
--- a/examples/flutter_gallery/ios/Runner/Info.plist
+++ b/examples/flutter_gallery/ios/Runner/Info.plist
@@ -43,6 +43,8 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
 </dict>


### PR DESCRIPTION
Make it so we don't have to manually click through the export compliance form for every binary release on TestFlight