### PR TITLE
Generalized TabBar selected tab indicator

### DIFF
--- a/packages/flutter/lib/material.dart
+++ b/packages/flutter/lib/material.dart
@@ -81,6 +81,7 @@ export 'src/material/stepper.dart';
 export 'src/material/switch.dart';
 export 'src/material/switch_list_tile.dart';
 export 'src/material/tab_controller.dart';
+export 'src/material/tab_indicator.dart';
 export 'src/material/tabs.dart';
 export 'src/material/text_field.dart';
 export 'src/material/text_form_field.dart';

--- a/packages/flutter/lib/src/material/tab_indicator.dart
+++ b/packages/flutter/lib/src/material/tab_indicator.dart
@@ -1,0 +1,115 @@
+// Copyright 2018 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/widgets.dart';
+
+import 'colors.dart';
+
+/// Used with [TabBar.indicatorShape] to draw a horizontal line below the
+/// selected tab
+///
+/// The line is inset from the tab's boundary by [padding]. The [borderSide]
+/// defines the line's color and weight.
+///
+/// The [TabBar.indicatorSize] property can be used to define the
+/// tab's boundary in terms of its (centered) widget, [TabIndicatorSize.label],
+/// or the the entire tab, [TabIndicatorSize.tab].
+class DefaultTabIndicator extends ShapeBorder {
+  /// Create a underline style tab indicator.
+  ///
+  /// The [borderSide] and [padding] arguments must not be null.
+  const DefaultTabIndicator({
+    this.borderSide: const BorderSide(width: 2.0, color: Colors.white),
+    this.padding: EdgeInsets.zero,
+  }) : assert(borderSide != null), assert(padding != null);
+
+  /// The color and weight of the line drawn below the selected tab.
+  final BorderSide borderSide;
+
+  /// Locates the [borderSide] style selected tab underline relative to the
+  /// tab's boundary.
+  ///
+  /// The [TabBar.indicatorSize] property can be used to define the
+  /// tab's boundary in terms of its (centered) widget, [TabIndicatorSize.label],
+  /// or the the entire tab,  [TabIndicatorSize.tab].
+  final EdgeInsetsGeometry padding;
+
+  @override
+  EdgeInsetsGeometry get dimensions {
+    return padding.subtract(new EdgeInsets.only(bottom: borderSide.width));
+  }
+
+  @override
+  DefaultTabIndicator scale(double t) {
+    return new DefaultTabIndicator(
+      borderSide: borderSide.scale(t),
+      padding: padding * t,
+    );
+  }
+
+  Rect _indicatorRectFor(Rect rect, TextDirection textDirection) {
+    assert(rect != null);
+    assert(textDirection != null);
+    final Rect indicator = padding.resolve(textDirection).deflateRect(rect);
+    return new Rect.fromLTWH(
+        indicator.left,
+        indicator.bottom - borderSide.width,
+        indicator.width,
+        borderSide.width,
+    );
+  }
+
+  @override
+  Path getInnerPath(Rect rect, { TextDirection textDirection }) {
+    return new Path()
+      ..addRect(_indicatorRectFor(rect, textDirection).deflate(borderSide.width));
+  }
+
+  @override
+  Path getOuterPath(Rect rect, { TextDirection textDirection }) {
+    return new Path()
+      ..addRect(_indicatorRectFor(rect, textDirection));
+  }
+
+  @override
+  ShapeBorder lerpFrom(ShapeBorder a, double t) {
+    if (a is DefaultTabIndicator) {
+      return new DefaultTabIndicator(
+        borderSide: BorderSide.lerp(a.borderSide, borderSide, t),
+        padding: EdgeInsetsGeometry.lerp(a.padding, padding, t),
+      );
+    }
+    return super.lerpFrom(a, t);
+  }
+
+  @override
+  ShapeBorder lerpTo(ShapeBorder b, double t) {
+    if (b is DefaultTabIndicator) {
+      return new DefaultTabIndicator(
+        borderSide: BorderSide.lerp(borderSide, b.borderSide, t),
+        padding: EdgeInsetsGeometry.lerp(padding, b.padding, t),
+      );
+    }
+    return super.lerpTo(b, t);
+  }
+
+  @override
+  void paint(Canvas canvas, Rect rect, { TextDirection textDirection }) {
+    final Rect indicator = _indicatorRectFor(rect, textDirection).deflate(borderSide.width / 2.0);
+    canvas.drawLine(indicator.bottomLeft, indicator.bottomRight, borderSide.toPaint());
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    if (identical(this, other))
+      return true;
+    if (runtimeType != other.runtimeType)
+      return false;
+    final DefaultTabIndicator typedOther = other;
+    return typedOther.borderSide == borderSide && typedOther.padding == padding;
+  }
+
+  @override
+  int get hashCode => hashValues(borderSide, padding);
+}

--- a/packages/flutter/lib/src/material/tab_indicator.dart
+++ b/packages/flutter/lib/src/material/tab_indicator.dart
@@ -14,7 +14,7 @@ import 'colors.dart';
 ///
 /// The [TabBar.indicatorSize] property can be used to define the indicator's
 /// bounds in terms of its (centered) widget with [TabIndicatorSize.label],
-/// or the the entire tab with [TabIndicatorSize.tab].
+/// or the entire tab with [TabIndicatorSize.tab].
 class UnderlineTabIndicator extends Decoration {
   /// Create an underline style selected tab indicator.
   ///

--- a/packages/flutter/lib/src/material/tab_indicator.dart
+++ b/packages/flutter/lib/src/material/tab_indicator.dart
@@ -7,7 +7,7 @@ import 'package:flutter/widgets.dart';
 import 'colors.dart';
 
 /// Used with [TabBar.indicator] to draw a horizontal line below the
-/// selected tab
+/// selected tab.
 ///
 /// The line is inset from the tab's boundary by [padding]. The [borderSide]
 /// defines the line's color and weight.
@@ -27,12 +27,11 @@ class UnderlineTabIndicator extends Decoration {
   /// The color and weight of the line drawn below the selected tab.
   final BorderSide borderSide;
 
-  /// Locates the [borderSide] style selected tab underline relative to the
-  /// tab's boundary.
+  /// Locates the selected tab's underline relative to the tab's boundary.
   ///
   /// The [TabBar.indicatorSize] property can be used to define the
-  /// tab's boundary in terms of its (centered) widget, [TabIndicatorSize.label],
-  /// or the the entire tab, [TabIndicatorSize.tab].
+  /// tab indicator's bounds in terms of its (centered) tab widget,
+  /// [TabIndicatorSize.label], or the entire tab, [TabIndicatorSize.tab].
   final EdgeInsetsGeometry insets;
 
   @override

--- a/packages/flutter/lib/src/material/tab_indicator.dart
+++ b/packages/flutter/lib/src/material/tab_indicator.dart
@@ -9,14 +9,14 @@ import 'colors.dart';
 /// Used with [TabBar.indicator] to draw a horizontal line below the
 /// selected tab.
 ///
-/// The line is inset from the tab's boundary by [padding]. The [borderSide]
-/// defines the line's color and weight.
+/// The selected tab underline is inset from the tab's boundary by [insets].
+/// The [borderSide] defines the line's color and weight.
 ///
-/// The [TabBar.indicatorSize] property can be used to define the
-/// tab's boundary in terms of its (centered) widget, [TabIndicatorSize.label],
-/// or the the entire tab, [TabIndicatorSize.tab].
+/// The [TabBar.indicatorSize] property can be used to define the indicator's
+/// bounds in terms of its (centered) widget with [TabIndicatorSize.label],
+/// or the the entire tab with [TabIndicatorSize.tab].
 class UnderlineTabIndicator extends Decoration {
-  /// Create an underline style tab indicator.
+  /// Create an underline style selected tab indicator.
   ///
   /// The [borderSide] and [insets] arguments must not be null.
   const UnderlineTabIndicator({
@@ -24,14 +24,14 @@ class UnderlineTabIndicator extends Decoration {
     this.insets: EdgeInsets.zero,
   }) : assert(borderSide != null), assert(insets != null);
 
-  /// The color and weight of the line drawn below the selected tab.
+  /// The color and weight of the horizontal line drawn below the selected tab.
   final BorderSide borderSide;
 
   /// Locates the selected tab's underline relative to the tab's boundary.
   ///
   /// The [TabBar.indicatorSize] property can be used to define the
-  /// tab indicator's bounds in terms of its (centered) tab widget,
-  /// [TabIndicatorSize.label], or the entire tab, [TabIndicatorSize.tab].
+  /// tab indicator's bounds in terms of its (centered) tab widget with
+  /// [TabIndicatorSize.label], or the entire tab with [TabIndicatorSize.tab].
   final EdgeInsetsGeometry insets;
 
   @override

--- a/packages/flutter/lib/src/material/tab_indicator.dart
+++ b/packages/flutter/lib/src/material/tab_indicator.dart
@@ -15,11 +15,11 @@ import 'colors.dart';
 /// The [TabBar.indicatorSize] property can be used to define the
 /// tab's boundary in terms of its (centered) widget, [TabIndicatorSize.label],
 /// or the the entire tab, [TabIndicatorSize.tab].
-class DefaultTabIndicator extends ShapeBorder {
-  /// Create a underline style tab indicator.
+class UnderlineTabIndicator extends ShapeBorder {
+  /// Create an underline style tab indicator.
   ///
   /// The [borderSide] and [padding] arguments must not be null.
-  const DefaultTabIndicator({
+  const UnderlineTabIndicator({
     this.borderSide: const BorderSide(width: 2.0, color: Colors.white),
     this.padding: EdgeInsets.zero,
   }) : assert(borderSide != null), assert(padding != null);
@@ -32,7 +32,7 @@ class DefaultTabIndicator extends ShapeBorder {
   ///
   /// The [TabBar.indicatorSize] property can be used to define the
   /// tab's boundary in terms of its (centered) widget, [TabIndicatorSize.label],
-  /// or the the entire tab,  [TabIndicatorSize.tab].
+  /// or the the entire tab, [TabIndicatorSize.tab].
   final EdgeInsetsGeometry padding;
 
   @override
@@ -41,8 +41,8 @@ class DefaultTabIndicator extends ShapeBorder {
   }
 
   @override
-  DefaultTabIndicator scale(double t) {
-    return new DefaultTabIndicator(
+  UnderlineTabIndicator scale(double t) {
+    return new UnderlineTabIndicator(
       borderSide: borderSide.scale(t),
       padding: padding * t,
     );
@@ -53,10 +53,10 @@ class DefaultTabIndicator extends ShapeBorder {
     assert(textDirection != null);
     final Rect indicator = padding.resolve(textDirection).deflateRect(rect);
     return new Rect.fromLTWH(
-        indicator.left,
-        indicator.bottom - borderSide.width,
-        indicator.width,
-        borderSide.width,
+      indicator.left,
+      indicator.bottom - borderSide.width,
+      indicator.width,
+      borderSide.width,
     );
   }
 
@@ -74,8 +74,8 @@ class DefaultTabIndicator extends ShapeBorder {
 
   @override
   ShapeBorder lerpFrom(ShapeBorder a, double t) {
-    if (a is DefaultTabIndicator) {
-      return new DefaultTabIndicator(
+    if (a is UnderlineTabIndicator) {
+      return new UnderlineTabIndicator(
         borderSide: BorderSide.lerp(a.borderSide, borderSide, t),
         padding: EdgeInsetsGeometry.lerp(a.padding, padding, t),
       );
@@ -85,8 +85,8 @@ class DefaultTabIndicator extends ShapeBorder {
 
   @override
   ShapeBorder lerpTo(ShapeBorder b, double t) {
-    if (b is DefaultTabIndicator) {
-      return new DefaultTabIndicator(
+    if (b is UnderlineTabIndicator) {
+      return new UnderlineTabIndicator(
         borderSide: BorderSide.lerp(borderSide, b.borderSide, t),
         padding: EdgeInsetsGeometry.lerp(padding, b.padding, t),
       );
@@ -102,11 +102,9 @@ class DefaultTabIndicator extends ShapeBorder {
 
   @override
   bool operator ==(dynamic other) {
-    if (identical(this, other))
-      return true;
     if (runtimeType != other.runtimeType)
       return false;
-    final DefaultTabIndicator typedOther = other;
+    final UnderlineTabIndicator typedOther = other;
     return typedOther.borderSide == borderSide && typedOther.padding == padding;
   }
 

--- a/packages/flutter/lib/src/material/tabs.dart
+++ b/packages/flutter/lib/src/material/tabs.dart
@@ -22,7 +22,6 @@ import 'theme.dart';
 
 const double _kTabHeight = 46.0;
 const double _kTextAndIconTabHeight = 72.0;
-const double _kMinTabWidth = 72.0;
 
 /// Defines the bounds of a [TabBar] tab for the sake of its selected tab
 /// indicator.
@@ -118,7 +117,6 @@ class Tab extends StatelessWidget {
       child: new Center(
         child: label,
         widthFactor: 1.0,
-        heightFactor: 1.0
       ),
     );
   }
@@ -858,15 +856,17 @@ class _TabBarState extends State<TabBar> {
 
     final List<Widget> wrappedTabs = new List<Widget>(widget.tabs.length);
     for (int i = 0; i < widget.tabs.length; i += 1) {
-      wrappedTabs[i] = new Container(
-        alignment: Alignment.center,
-        padding: kTabLabelPadding,
-        constraints: const BoxConstraints(minWidth: _kMinTabWidth),
-        child: new KeyedSubtree(
-          key: _tabKeys[i],
-          child: widget.tabs[i],
+      wrappedTabs[i] = new Center(
+        heightFactor: 1.0,
+        child: new Padding(
+          padding: kTabLabelPadding,
+          child: new KeyedSubtree(
+            key: _tabKeys[i],
+            child: widget.tabs[i],
+          ),
         ),
       );
+
     }
 
     // If the controller was provided by DefaultTabController and we're part
@@ -899,9 +899,9 @@ class _TabBarState extends State<TabBar> {
       }
     }
 
-    // Add the tap handler to each tab. If the tab bar is scrollable
-    // then give all of the tabs equal flexibility so that their widths
-    // reflect the intrinsic width of their labels.
+    // Add the tap handler to each tab. If the tab bar is not scrollable
+    // then give all of the tabs equal flexibility so that they each occupy
+    // the same share of the tab bar's overall width.
     final int tabCount = widget.tabs.length;
     for (int index = 0; index < tabCount; index += 1) {
       wrappedTabs[index] = new InkWell(

--- a/packages/flutter/lib/src/material/tabs.dart
+++ b/packages/flutter/lib/src/material/tabs.dart
@@ -574,7 +574,7 @@ class TabBar extends StatefulWidget implements PreferredSizeWidget {
   /// and [indicatorPadding] properties are ignored.
   ///
   /// The default, underline-style, selected tab indicator can be defined with
-  /// [DefaultTabIndicator].
+  /// [UnderlineTabIndicator].
   ///
   /// The indicator is painted relative to the tab's bounds. If [indicatorSize]
   /// is [TabBarIndicatorSize.tab] the tab's bounds are as wide as the space
@@ -670,7 +670,7 @@ class _TabBarState extends State<TabBar> {
     if (color == Material.of(context).color)
       color = Colors.white;
 
-    return new DefaultTabIndicator(
+    return new UnderlineTabIndicator(
       padding: widget.indicatorPadding,
       borderSide: new BorderSide(
         width: widget.indicatorWeight,

--- a/packages/flutter/lib/src/painting/decoration.dart
+++ b/packages/flutter/lib/src/painting/decoration.dart
@@ -188,7 +188,7 @@ abstract class Decoration extends Diagnosticable {
 abstract class BoxPainter {
   /// Abstract const constructor. This constructor enables subclasses to provide
   /// const constructors so that they can be used in const expressions.
-  BoxPainter([this.onChanged]);
+  const BoxPainter([this.onChanged]);
 
   /// Paints the [Decoration] for which this object was created on the
   /// given canvas using the given configuration.

--- a/packages/flutter/test/material/tabs_test.dart
+++ b/packages/flutter/test/material/tabs_test.dart
@@ -1056,6 +1056,73 @@ void main() {
     ));
   });
 
+  testWidgets('TabBar changes indicator attributes', (WidgetTester tester) async {
+    final List<Widget> tabs = new List<Widget>.generate(4, (int index) {
+      return new Tab(text: 'Tab $index');
+    });
+
+    final TabController controller = new TabController(
+      vsync: const TestVSync(),
+      length: tabs.length,
+    );
+
+    Color indicatorColor = const Color(0xFF00FF00);
+    double indicatorWeight = 8.0;
+    double padLeft = 8.0;
+    double padRight = 4.0;
+
+    Widget buildFrame() {
+      return boilerplate(
+        child: new Container(
+          alignment: Alignment.topLeft,
+          child: new TabBar(
+            indicatorWeight: indicatorWeight,
+            indicatorColor: indicatorColor,
+            indicatorPadding: new EdgeInsets.only(left: padLeft, right: padRight),
+            controller: controller,
+            tabs: tabs,
+          ),
+        ),
+      );
+    }
+
+    await tester.pumpWidget(buildFrame());
+
+    final RenderBox tabBarBox = tester.firstRenderObject<RenderBox>(find.byType(TabBar));
+    expect(tabBarBox.size.height, 54.0); // 54 = _kTabHeight(46) + indicatorWeight(8.0)
+
+    double indicatorY = 54.0 - indicatorWeight / 2.0;
+    double indicatorLeft = padLeft + indicatorWeight / 2.0;
+    double indicatorRight = 200.0 - (padRight + indicatorWeight / 2.0);
+
+    expect(tabBarBox, paints..line(
+      color: indicatorColor,
+      strokeWidth: indicatorWeight,
+      p1: new Offset(indicatorLeft, indicatorY),
+      p2: new Offset(indicatorRight, indicatorY),
+    ));
+
+    indicatorColor = const Color(0xFF0000FF);
+    indicatorWeight = 4.0;
+    padLeft = 4.0;
+    padRight = 8.0;
+
+    await tester.pumpWidget(buildFrame());
+
+    expect(tabBarBox.size.height, 50.0); // 54 = _kTabHeight(46) + indicatorWeight(4.0)
+
+    indicatorY = 50.0 - indicatorWeight / 2.0;
+    indicatorLeft = padLeft + indicatorWeight / 2.0;
+    indicatorRight = 200.0 - (padRight + indicatorWeight / 2.0);
+
+    expect(tabBarBox, paints..line(
+      color: indicatorColor,
+      strokeWidth: indicatorWeight,
+      p1: new Offset(indicatorLeft, indicatorY),
+      p2: new Offset(indicatorRight, indicatorY),
+    ));
+  });
+
   testWidgets('TabBar with directional indicatorPadding (LTR)', (WidgetTester tester) async {
     final List<Widget> tabs = <Widget>[
       new SizedBox(key: new UniqueKey(), width: 130.0, height: 30.0),

--- a/packages/flutter/test/material/tabs_test.dart
+++ b/packages/flutter/test/material/tabs_test.dart
@@ -140,9 +140,11 @@ class TabIndicatorRecordingCanvas extends TestRecordingCanvas {
   Rect indicatorRect;
 
   @override
-  void drawRect(Rect rect, Paint paint) {
+  void drawLine(Offset p1, Offset p2, Paint paint) {
+    // Assuming that the indicatorWeight is 2.0, the default.
+    const double indicatorWeight = 2.0;
     if (paint.color == indicatorColor)
-      indicatorRect = rect;
+      indicatorRect = new Rect.fromPoints(p1, p2).inflate(indicatorWeight / 2.0);
   }
 }
 
@@ -926,21 +928,22 @@ void main() {
 
     // The initialIndex tab should be visible and right justified
     expect(find.text('TAB #19'), findsOneWidget);
-    expect(tester.getTopRight(find.widgetWithText(Tab, 'TAB #19')).dx, 800.0);
+
+    // Tabs have a minimum width of 72.0 and 'TAB #19' is wider than
+    // that. Tabs are padded horizontally with kTabLabelPadding.
+    final double tabRight = 800.0 - kTabLabelPadding.right;
+
+    expect(tester.getTopRight(find.widgetWithText(Tab, 'TAB #19')).dx, tabRight);
   });
 
   testWidgets('TabBar with indicatorWeight, indicatorPadding (LTR)', (WidgetTester tester) async {
-    const Color color = const Color(0xFF00FF00);
-    const double height = 100.0;
-    const double weight = 8.0;
+    const Color indicatorColor = const Color(0xFF00FF00);
+    const double indicatorWeight = 8.0;
     const double padLeft = 8.0;
     const double padRight = 4.0;
 
     final List<Widget> tabs = new List<Widget>.generate(4, (int index) {
-      return new Container(
-        key: new ValueKey<int>(index),
-        height: height,
-      );
+      return new Tab(text: 'Tab $index');
     });
 
     final TabController controller = new TabController(
@@ -950,61 +953,56 @@ void main() {
 
     await tester.pumpWidget(
       boilerplate(
-        child: new Column(
-          children: <Widget>[
-            new TabBar(
-              indicatorWeight: 8.0,
-              indicatorColor: color,
-              indicatorPadding: const EdgeInsets.only(left: padLeft, right: padRight),
-              controller: controller,
-              tabs: tabs,
-            ),
-            new Flexible(child: new Container()),
-          ],
+        child: new Container(
+          alignment: Alignment.topLeft,
+          child: new TabBar(
+            indicatorWeight: indicatorWeight,
+            indicatorColor: indicatorColor,
+            indicatorPadding: const EdgeInsets.only(left: padLeft, right: padRight),
+            controller: controller,
+            tabs: tabs,
+          ),
         ),
       ),
     );
 
     final RenderBox tabBarBox = tester.firstRenderObject<RenderBox>(find.byType(TabBar));
+    expect(tabBarBox.size.height, 54.0); // 54 = _kTabHeight(46) + indicatorWeight(8.0)
 
-    // Selected tab dimensions
-    double tabWidth = tester.getSize(find.byKey(const ValueKey<int>(0))).width;
-    double tabLeft = tester.getTopLeft(find.byKey(const ValueKey<int>(0))).dx;
-    double tabRight = tabLeft + tabWidth;
+    final double indicatorY = 54.0 - indicatorWeight / 2.0;
+    double indicatorLeft = padLeft + indicatorWeight / 2.0;
+    double indicatorRight = 200.0 - (padRight + indicatorWeight / 2.0);
 
-    expect(tabBarBox, paints..rect(
-      style: PaintingStyle.fill,
-      color: color,
-      rect: new Rect.fromLTRB(tabLeft + padLeft, height, tabRight - padRight, height + weight)
+    expect(tabBarBox, paints..line(
+      color: indicatorColor,
+      strokeWidth: indicatorWeight,
+      p1: new Offset(indicatorLeft, indicatorY),
+      p2: new Offset(indicatorRight, indicatorY),
     ));
 
     // Select tab 3
     controller.index = 3;
     await tester.pumpAndSettle();
 
-    tabWidth = tester.getSize(find.byKey(const ValueKey<int>(3))).width;
-    tabLeft = tester.getTopLeft(find.byKey(const ValueKey<int>(3))).dx;
-    tabRight = tabLeft + tabWidth;
+    indicatorLeft = 600.0 + padLeft + indicatorWeight / 2.0;
+    indicatorRight = 800.0 - (padRight + indicatorWeight / 2.0);
 
-    expect(tabBarBox, paints..rect(
-      style: PaintingStyle.fill,
-      color: color,
-      rect: new Rect.fromLTRB(tabLeft + padLeft, height, tabRight - padRight, height + weight)
+    expect(tabBarBox, paints..line(
+      color: indicatorColor,
+      strokeWidth: indicatorWeight,
+      p1: new Offset(indicatorLeft, indicatorY),
+      p2: new Offset(indicatorRight, indicatorY),
     ));
   });
 
   testWidgets('TabBar with indicatorWeight, indicatorPadding (RTL)', (WidgetTester tester) async {
-    const Color color = const Color(0xFF00FF00);
-    const double height = 100.0;
-    const double weight = 8.0;
+    const Color indicatorColor = const Color(0xFF00FF00);
+    const double indicatorWeight = 8.0;
     const double padLeft = 8.0;
     const double padRight = 4.0;
 
     final List<Widget> tabs = new List<Widget>.generate(4, (int index) {
-      return new Container(
-        key: new ValueKey<int>(index),
-        height: height,
-      );
+      return new Tab(text: 'Tab $index');
     });
 
     final TabController controller = new TabController(
@@ -1015,46 +1013,46 @@ void main() {
     await tester.pumpWidget(
       boilerplate(
         textDirection: TextDirection.rtl,
-        child: new Column(
-          children: <Widget>[
-            new TabBar(
-              indicatorWeight: 8.0,
-              indicatorColor: color,
-              indicatorPadding: const EdgeInsets.only(left: padLeft, right: padRight),
-              controller: controller,
-              tabs: tabs,
-            ),
-            new Flexible(child: new Container()),
-          ],
+        child: new Container(
+          alignment: Alignment.topLeft,
+          child: new TabBar(
+            indicatorWeight: indicatorWeight,
+            indicatorColor: indicatorColor,
+            indicatorPadding: const EdgeInsets.only(left: padLeft, right: padRight),
+            controller: controller,
+            tabs: tabs,
+          ),
         ),
       ),
     );
 
     final RenderBox tabBarBox = tester.firstRenderObject<RenderBox>(find.byType(TabBar));
+    expect(tabBarBox.size.height, 54.0); // 54 = _kTabHeight(46) + indicatorWeight(8.0)
+    expect(tabBarBox.size.width, 800.0);
 
-    // Selected tab dimensions
-    double tabWidth = tester.getSize(find.byKey(const ValueKey<int>(0))).width;
-    double tabLeft = tester.getTopLeft(find.byKey(const ValueKey<int>(0))).dx;
-    double tabRight = tabLeft + tabWidth;
+    final double indicatorY = 54.0 - indicatorWeight / 2.0;
+    double indicatorLeft = 600.0 + padLeft + indicatorWeight / 2.0;
+    double indicatorRight = 800.0 - padRight - indicatorWeight / 2.0;
 
-    expect(tabBarBox, paints..rect(
-      style: PaintingStyle.fill,
-      color: color,
-      rect: new Rect.fromLTRB(tabLeft + padLeft, height, tabRight - padRight, height + weight)
+    expect(tabBarBox, paints..line(
+      color: indicatorColor,
+      strokeWidth: indicatorWeight,
+      p1: new Offset(indicatorLeft, indicatorY),
+      p2: new Offset(indicatorRight, indicatorY),
     ));
 
     // Select tab 3
     controller.index = 3;
     await tester.pumpAndSettle();
 
-    tabWidth = tester.getSize(find.byKey(const ValueKey<int>(3))).width;
-    tabLeft = tester.getTopLeft(find.byKey(const ValueKey<int>(3))).dx;
-    tabRight = tabLeft + tabWidth;
+    indicatorLeft = padLeft + indicatorWeight / 2.0;
+    indicatorRight = 200.0 - padRight -  indicatorWeight / 2.0;
 
-    expect(tabBarBox, paints..rect(
-      style: PaintingStyle.fill,
-      color: color,
-      rect: new Rect.fromLTRB(tabLeft + padLeft, height, tabRight - padRight, height + weight)
+    expect(tabBarBox, paints..line(
+      color: indicatorColor,
+      strokeWidth: indicatorWeight,
+      p1: new Offset(indicatorLeft, indicatorY),
+      p2: new Offset(indicatorRight, indicatorY),
     ));
   });
 
@@ -1065,6 +1063,8 @@ void main() {
       new SizedBox(key: new UniqueKey(), width: 150.0, height: 50.0),
     ];
 
+    const double indicatorWeight = 2.0; // the default
+
     final TabController controller = new TabController(
       vsync: const TestVSync(),
       length: tabs.length,
@@ -1072,27 +1072,56 @@ void main() {
 
     await tester.pumpWidget(
       boilerplate(
-        child: new Center(
-          child: new SizedBox(
-            width: 800.0,
-            child: new TabBar(
-              indicatorPadding: const EdgeInsetsDirectional.only(start: 100.0),
-              isScrollable: true,
-              controller: controller,
-              tabs: tabs,
-            ),
+        child: new Container(
+          alignment: Alignment.topLeft,
+          child: new TabBar(
+            indicatorPadding: const EdgeInsetsDirectional.only(start: 100.0),
+            isScrollable: true,
+            controller: controller,
+            tabs: tabs,
           ),
         ),
       ),
     );
 
-    expect(tester.getRect(find.byKey(tabs[0].key)), new Rect.fromLTRB(0.0, 284.0, 130.0, 314.0));
-    expect(tester.getRect(find.byKey(tabs[1].key)), new Rect.fromLTRB(130.0, 279.0, 270.0, 319.0));
-    expect(tester.getRect(find.byKey(tabs[2].key)), new Rect.fromLTRB(270.0, 274.0, 420.0, 324.0));
+    final RenderBox tabBarBox = tester.firstRenderObject<RenderBox>(find.byType(TabBar));
+    const double tabBarHeight = 50.0 + indicatorWeight;  // 50 = max tab height
+    expect(tabBarBox.size.height, tabBarHeight);
 
-    expect(tester.firstRenderObject<RenderBox>(find.byType(TabBar)), paints..rect(
-      style: PaintingStyle.fill,
-      rect: new Rect.fromLTRB(100.0, 50.0, 130.0, 52.0),
+    // Tab0 width = 130, height = 30
+    double tabLeft = kTabLabelPadding.left;
+    double tabRight = tabLeft + 130.0;
+    double tabTop = (tabBarHeight - indicatorWeight - 30.0) / 2.0;
+    double tabBottom = tabTop + 30.0;
+    Rect tabRect = new Rect.fromLTRB(tabLeft, tabTop, tabRight, tabBottom);
+    expect(tester.getRect(find.byKey(tabs[0].key)), tabRect);
+
+
+    // Tab1 width = 140, height = 40
+    tabLeft = tabRight + kTabLabelPadding.right + kTabLabelPadding.left;
+    tabRight = tabLeft + 140.0;
+    tabTop = (tabBarHeight - indicatorWeight - 40.0) / 2.0;
+    tabBottom = tabTop + 40.0;
+    tabRect = new Rect.fromLTRB(tabLeft, tabTop, tabRight, tabBottom);
+    expect(tester.getRect(find.byKey(tabs[1].key)), tabRect);
+
+
+    // Tab2 width = 150, height = 50
+    tabLeft = tabRight + kTabLabelPadding.right + kTabLabelPadding.left;
+    tabRight = tabLeft + 150.0;
+    tabTop = (tabBarHeight - indicatorWeight - 50.0) / 2.0;
+    tabBottom = tabTop + 50.0;
+    tabRect = new Rect.fromLTRB(tabLeft, tabTop, tabRight, tabBottom);
+    expect(tester.getRect(find.byKey(tabs[2].key)), tabRect);
+
+    // Tab 0 selected, indicator padding resolves to left: 100.0
+    final double indicatorLeft = 100.0 + indicatorWeight / 2.0;
+    final double indicatorRight = 130.0 + kTabLabelPadding.horizontal - indicatorWeight / 2.0;
+    final double indicatorY = tabBottom + indicatorWeight / 2.0;
+    expect(tabBarBox, paints..line(
+      strokeWidth: indicatorWeight,
+      p1: new Offset(indicatorLeft, indicatorY),
+      p2: new Offset(indicatorRight, indicatorY),
     ));
   });
 
@@ -1103,6 +1132,8 @@ void main() {
       new SizedBox(key: new UniqueKey(), width: 150.0, height: 50.0),
     ];
 
+    const double indicatorWeight = 2.0; // the default
+
     final TabController controller = new TabController(
       vsync: const TestVSync(),
       length: tabs.length,
@@ -1111,36 +1142,62 @@ void main() {
     await tester.pumpWidget(
       boilerplate(
         textDirection: TextDirection.rtl,
-        child: new Center(
-          child: new SizedBox(
-            width: 800.0,
-            child: new TabBar(
-              indicatorPadding: const EdgeInsetsDirectional.only(start: 100.0),
-              isScrollable: true,
-              controller: controller,
-              tabs: tabs,
-            ),
+        child: new Container(
+          alignment: Alignment.topLeft,
+          child: new TabBar(
+            indicatorPadding: const EdgeInsetsDirectional.only(start: 100.0),
+            isScrollable: true,
+            controller: controller,
+            tabs: tabs,
           ),
         ),
       ),
     );
 
-    expect(tester.getRect(find.byKey(tabs[0].key)), new Rect.fromLTRB(670.0, 284.0, 800.0, 314.0));
-    expect(tester.getRect(find.byKey(tabs[1].key)), new Rect.fromLTRB(530.0, 279.0, 670.0, 319.0));
-    expect(tester.getRect(find.byKey(tabs[2].key)), new Rect.fromLTRB(380.0, 274.0, 530.0, 324.0));
+    final RenderBox tabBarBox = tester.firstRenderObject<RenderBox>(find.byType(TabBar));
+    const double tabBarHeight = 50.0 + indicatorWeight;  // 50 = max tab height
+    expect(tabBarBox.size.height, tabBarHeight);
 
-    final RenderBox tabBar = tester.renderObject<RenderBox>(find.byType(CustomPaint).at(1));
+    // Tab2 width = 150, height = 50
+    double tabLeft = kTabLabelPadding.left;
+    double tabRight = tabLeft + 150.0;
+    double tabTop = (tabBarHeight - indicatorWeight - 50.0) / 2.0;
+    double tabBottom = tabTop + 50.0;
+    Rect tabRect = new Rect.fromLTRB(tabLeft, tabTop, tabRight, tabBottom);
+    expect(tester.getRect(find.byKey(tabs[2].key)), tabRect);
 
-    expect(tabBar.size, const Size(420.0, 52.0));
-    expect(tabBar, paints..rect(
-      style: PaintingStyle.fill,
-      rect: new Rect.fromLTRB(tabBar.size.width - 130.0, 50.0, tabBar.size.width - 100.0, 52.0),
+    // Tab1 width = 140, height = 40
+    tabLeft = tabRight + kTabLabelPadding.right + kTabLabelPadding.left;
+    tabRight = tabLeft + 140.0;
+    tabTop = (tabBarHeight - indicatorWeight - 40.0) / 2.0;
+    tabBottom = tabTop + 40.0;
+    tabRect = new Rect.fromLTRB(tabLeft, tabTop, tabRight, tabBottom);
+    expect(tester.getRect(find.byKey(tabs[1].key)), tabRect);
+
+    // Tab0 width = 130, height = 30
+    tabLeft = tabRight + kTabLabelPadding.right + kTabLabelPadding.left;
+    tabRight = tabLeft + 130.0;
+    tabTop = (tabBarHeight - indicatorWeight - 30.0) / 2.0;
+    tabBottom = tabTop + 30.0;
+    tabRect = new Rect.fromLTRB(tabLeft, tabTop, tabRight, tabBottom);
+    expect(tester.getRect(find.byKey(tabs[0].key)), tabRect);
+
+    // Tab 0 selected, indicator padding resolves to right: 100.0
+    final double indicatorLeft = tabLeft - kTabLabelPadding.left + indicatorWeight / 2.0;
+    final double indicatorRight = tabRight + kTabLabelPadding.left - indicatorWeight / 2.0 - 100.0;
+    final double indicatorY = 50.0 + indicatorWeight / 2.0;
+    expect(tabBarBox, paints..line(
+      strokeWidth: indicatorWeight,
+      p1: new Offset(indicatorLeft, indicatorY),
+      p2: new Offset(indicatorRight, indicatorY),
     ));
   });
 
   testWidgets('Overflowing RTL tab bar', (WidgetTester tester) async {
     final List<Widget> tabs = new List<Widget>.filled(100,
-      new SizedBox(key: new UniqueKey(), width: 30.0, height: 20.0),
+      // For convenience padded width of each tab will equal 100:
+      // 76 + kTabLabelPadding.horizontal(24)
+      new SizedBox(key: new UniqueKey(), width: 76.0, height: 40.0),
     );
 
     final TabController controller = new TabController(
@@ -1148,10 +1205,13 @@ void main() {
       length: tabs.length,
     );
 
+    const double indicatorWeight = 2.0; // the default
+
     await tester.pumpWidget(
       boilerplate(
         textDirection: TextDirection.rtl,
-        child: new Center(
+        child: new Container(
+          alignment: Alignment.topLeft,
           child: new TabBar(
             isScrollable: true,
             controller: controller,
@@ -1161,25 +1221,40 @@ void main() {
       ),
     );
 
-    expect(tester.firstRenderObject<RenderBox>(find.byType(TabBar)), paints..rect(
-      style: PaintingStyle.fill,
-      rect: new Rect.fromLTRB(2970.0, 20.0, 3000.0, 22.0),
+    final RenderBox tabBarBox = tester.firstRenderObject<RenderBox>(find.byType(TabBar));
+    const double tabBarHeight = 40.0 + indicatorWeight;  // 40 = tab height
+    expect(tabBarBox.size.height, tabBarHeight);
+
+    // Tab 0 out of 100 selected
+    double indicatorLeft = 99.0 * 100.0 + indicatorWeight / 2.0;
+    double indicatorRight = 100.0 * 100.0 - indicatorWeight / 2.0;
+    final double indicatorY = 40.0 + indicatorWeight / 2.0;
+    expect(tabBarBox, paints..line(
+      strokeWidth: indicatorWeight,
+      p1: new Offset(indicatorLeft, indicatorY),
+      p2: new Offset(indicatorRight, indicatorY),
     ));
 
     controller.animateTo(tabs.length - 1, duration: const Duration(seconds: 1), curve: Curves.linear);
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 500));
 
-    expect(tester.firstRenderObject<RenderBox>(find.byType(TabBar)), paints..rect(
-      style: PaintingStyle.fill,
-      rect: new Rect.fromLTRB(742.5, 20.0, 772.5, 22.0), // (these values were derived empirically, not analytically)
+    // The x coordinates of p1 and p2 were derived empirically, not analytically.
+    expect(tabBarBox, paints..line(
+      strokeWidth: indicatorWeight,
+      p1: new Offset(2476.0, indicatorY),
+      p2: new Offset(2574.0, indicatorY),
     ));
 
     await tester.pump(const Duration(milliseconds: 501));
 
-    expect(tester.firstRenderObject<RenderBox>(find.byType(TabBar)), paints..rect(
-      style: PaintingStyle.fill,
-      rect: new Rect.fromLTRB(0.0, 20.0, 30.0, 22.0),
+    // Tab 99 out of 100 selected, appears on the far left because RTL
+    indicatorLeft = indicatorWeight / 2.0;
+    indicatorRight = 100.0 - indicatorWeight / 2.0;
+    expect(tabBarBox, paints..line(
+      strokeWidth: indicatorWeight,
+      p1: new Offset(indicatorLeft, indicatorY),
+      p2: new Offset(indicatorRight, indicatorY),
     ));
   });
 
@@ -1372,22 +1447,23 @@ void main() {
     expect(tester.getSize(find.byType(TabBar)), const Size(800.0, 48.0));
     expect(tester.getSize(find.byType(TabBarView)), const Size(800.0, 600.0 - 48.0));
 
-    // The one tab spans the app's width
-    expect(tester.getTopLeft(find.widgetWithText(Tab, 'TAB')).dx, 0);
-    expect(tester.getTopRight(find.widgetWithText(Tab, 'TAB')).dx, 800);
+    // The one tab should be center vis the app's width (800).
+    final double tabLeft = tester.getTopLeft(find.widgetWithText(Tab, 'TAB')).dx;
+    final double tabRight = tester.getTopRight(find.widgetWithText(Tab, 'TAB')).dx;
+    expect(tabLeft + (tabRight - tabLeft) / 2.0, 400.0);
 
     // A fling in the TabBar or TabBarView, shouldn't move the tab.
 
     await tester.fling(find.byType(TabBar), const Offset(-100.0, 0.0), 5000.0);
     await tester.pump(const Duration(milliseconds: 50));
-    expect(tester.getTopLeft(find.widgetWithText(Tab, 'TAB')).dx, 0);
-    expect(tester.getTopRight(find.widgetWithText(Tab, 'TAB')).dx, 800);
+    expect(tester.getTopLeft(find.widgetWithText(Tab, 'TAB')).dx, tabLeft);
+    expect(tester.getTopRight(find.widgetWithText(Tab, 'TAB')).dx, tabRight);
     await tester.pumpAndSettle();
 
     await tester.fling(find.byType(TabBarView), const Offset(100.0, 0.0), 5000.0);
     await tester.pump(const Duration(milliseconds: 50));
-    expect(tester.getTopLeft(find.widgetWithText(Tab, 'TAB')).dx, 0);
-    expect(tester.getTopRight(find.widgetWithText(Tab, 'TAB')).dx, 800);
+    expect(tester.getTopLeft(find.widgetWithText(Tab, 'TAB')).dx, tabLeft);
+    expect(tester.getTopRight(find.widgetWithText(Tab, 'TAB')).dx, tabRight);
     await tester.pumpAndSettle();
 
     expect(controller.index, 0);


### PR DESCRIPTION
A `TabBar`'s selected tab indicator can now be defined with a Decoration, using `indicator`. The new `UnderlineTabIndicator` (a Decoration) defines the default underline-style selected tab indicator.

The selected tab indicator's width can be defined by the overall width of the tab, with `indicatorSize: TabBarIndicatorSize.tab`, or just the width of the tab's label with `indicatorSize: TabBarIndicatorSize.label`.

Here are some examples that use `indicator` and `indicatorSize`.

```dart
indicator: new ShapeDecoration(
  shape: new RoundedRectangleBorder(
    borderRadius: new BorderRadius.circular(8.0),
    side: new BorderSide(
      color: Colors.white,
      width: 2.0,
    ),
  ) + // Inset the white border by 6.0
  new RoundedRectangleBorder(
    side: new BorderSide(
      color: Colors.transparent,
      width: 6.0,
    ),
  ),
),
```
![custom_indicator1](https://user-images.githubusercontent.com/1377460/36442281-16a81264-162a-11e8-956a-fca92a1f130d.png)

This example sets `indicatorSize` and configures `UnderlineIndicatorShape`'s insets:

```dart
indicatorSize: TabBarIndicatorSize.label,
indicator: const UnderlineTabIndicator(
  insets: const EdgeInsets.only(bottom: 12.0),
),
```

![custom_indicator2](https://user-images.githubusercontent.com/1377460/36288504-c79cb37c-126f-11e8-9201-1fb6dfc7b42e.png)

This PR includes an incompatible change: the Tab Widget's width is no longer padded horizontally. It's height is still fixed depending on what it contains (text or icon or both) and it's still centered vertically. TabBar still horizontally centers tab widgets within the space they're allocated. 

Tests that assume that Tab's widgets will expand to fill the available width, for example tests that check TabBar Tab bounds, will have to be updated.

This change was made to enable computing a tab's intrinsic width for TabIndicatorSize.label. It should only affect apps that used Tab widgets outside of the TabBar or tests that check Tab bounds.



