### PR TITLE
Reintroduce engineDartSdkPath artifact.

### DIFF
--- a/packages/flutter_tools/lib/src/artifacts.dart
+++ b/packages/flutter_tools/lib/src/artifacts.dart
@@ -9,6 +9,7 @@ import 'base/file_system.dart';
 import 'base/platform.dart';
 import 'base/process_manager.dart';
 import 'build_info.dart';
+import 'dart/sdk.dart';
 import 'globals.dart';
 
 enum Artifact {
@@ -24,6 +25,7 @@ enum Artifact {
   platformLibrariesJson,
   flutterPatchedSdkPath,
   frontendServerSnapshotForEngineDartSdk,
+  engineDartSdkPath,
 }
 
 String _artifactToFileName(Artifact artifact) {
@@ -51,6 +53,8 @@ String _artifactToFileName(Artifact artifact) {
     case Artifact.flutterPatchedSdkPath:
       assert(false, 'No filename for sdk path, should not be invoked');
       return null;
+    case Artifact.engineDartSdkPath:
+      return 'dart-sdk';
     case Artifact.frontendServerSnapshotForEngineDartSdk:
       return 'frontend_server.dart.snapshot';
   }
@@ -164,6 +168,8 @@ class CachedArtifacts extends Artifacts {
         final String engineArtifactsPath = cache.getArtifactDirectory('engine').path;
         final String platformDirName = getNameForTargetPlatform(platform);
         return fs.path.join(engineArtifactsPath, platformDirName, _artifactToFileName(artifact));
+      case Artifact.engineDartSdkPath:
+        return dartSdkPath;
       case Artifact.platformKernelDill:
         return fs.path.join(_getFlutterPatchedSdkPath(), _artifactToFileName(artifact));
       case Artifact.platformLibrariesJson:
@@ -244,6 +250,8 @@ class LocalEngineArtifacts extends Artifacts {
         return _getFlutterPatchedSdkPath();
       case Artifact.frontendServerSnapshotForEngineDartSdk:
         return fs.path.join(_hostEngineOutPath, 'gen', _artifactToFileName(artifact));
+      case Artifact.engineDartSdkPath:
+        return fs.path.join(_hostEngineOutPath, 'dart-sdk');
     }
     assert(false, 'Invalid artifact $artifact.');
     return null;

--- a/packages/flutter_tools/lib/src/compile.dart
+++ b/packages/flutter_tools/lib/src/compile.dart
@@ -8,14 +8,22 @@ import 'dart:convert';
 import 'package:usage/uuid/uuid.dart';
 
 import 'artifacts.dart';
+import 'base/common.dart';
 import 'base/file_system.dart';
 import 'base/io.dart';
 import 'base/process_manager.dart';
-import 'dart/sdk.dart';
 import 'globals.dart';
 
 String _dartExecutable() {
-  return fs.path.join(dartSdkPath, 'bin', 'dart');
+  final String engineDartSdkPath = artifacts.getArtifactPath(
+    Artifact.engineDartSdkPath
+  );
+  if (!fs.isDirectorySync(engineDartSdkPath)) {
+    throwToolExit('No dart sdk Flutter host engine build found at $engineDartSdkPath.\n'
+      'Note that corresponding host engine build is required even when targeting particular device platforms.',
+      exitCode: 2);
+  }
+  return fs.path.join(engineDartSdkPath, 'bin', 'dart');
 }
 
 class _StdoutHandler {

--- a/packages/flutter_tools/test/artifacts_test.dart
+++ b/packages/flutter_tools/test/artifacts_test.dart
@@ -89,6 +89,10 @@ void main() {
           artifacts.getArtifactPath(Artifact.flutterTester),
           fs.path.join(tempDir.path, 'out', 'android_debug_unopt', 'flutter_tester')
       );
+      expect(
+        artifacts.getArtifactPath(Artifact.engineDartSdkPath),
+        fs.path.join(tempDir.path, 'out', 'host_debug_unopt', 'dart-sdk')
+      );
     }, overrides: <Type, Generator> {
       Platform: () => new FakePlatform(operatingSystem: 'linux')
     });


### PR DESCRIPTION
This is needed to support running with local engine's dart sdk.

This is follow-up to https://github.com/flutter/flutter/pull/14702.