### PR TITLE
Ignore 'No analyzer warnings!' stdout line from analyzer

### DIFF
--- a/dev/devicelab/bin/tasks/dartdocs.dart
+++ b/dev/devicelab/bin/tasks/dartdocs.dart
@@ -39,6 +39,8 @@ Future<Null> main() async {
         // ignore this line
       } else if (entry.startsWith('Analyzing ')) {
         // ignore this line
+      } else if (entry.startsWith('No analyzer warnings!')) {
+        // ignore this line
       } else {
         otherLines += 1;
       }


### PR DESCRIPTION
I guess we never had analyzer finding nothing wrong with dartdocs before.