### PR TITLE
Fix several Dart 2 issues in the flutter_driver.

### DIFF
--- a/packages/flutter_driver/lib/src/driver/timeline.dart
+++ b/packages/flutter_driver/lib/src/driver/timeline.dart
@@ -122,12 +122,13 @@ class TimelineEvent {
 }
 
 List<TimelineEvent> _parseEvents(Map<String, dynamic> json) {
-  final List<Map<String, dynamic>> jsonEvents = json['traceEvents'];
+  final List<dynamic> jsonEvents = json['traceEvents'];
 
   if (jsonEvents == null)
     return null;
 
-  return jsonEvents
+  // TODO(vegorov) use instance method version of castFrom when it is available.
+  return Iterable.castFrom<dynamic, Map<String, dynamic>>(jsonEvents)
     .map((Map<String, dynamic> eventJson) => new TimelineEvent(eventJson))
     .toList();
 }

--- a/packages/flutter_driver/lib/src/extension/extension.dart
+++ b/packages/flutter_driver/lib/src/extension/extension.dart
@@ -125,10 +125,10 @@ class FlutterDriverExtension {
     });
 
     _finders.addAll(<String, FinderConstructor>{
-      'ByText': _createByTextFinder,
-      'ByTooltipMessage': _createByTooltipMessageFinder,
-      'ByValueKey': _createByValueKeyFinder,
-      'ByType': _createByTypeFinder,
+      'ByText': (SerializableFinder finder) => _createByTextFinder(finder),
+      'ByTooltipMessage': (SerializableFinder finder) => _createByTooltipMessageFinder(finder),
+      'ByValueKey': (SerializableFinder finder) => _createByValueKeyFinder(finder),
+      'ByType': (SerializableFinder finder) => _createByTypeFinder(finder),
     });
   }
 

--- a/packages/flutter_driver/test/flutter_driver_test.dart
+++ b/packages/flutter_driver/test/flutter_driver_test.dart
@@ -56,7 +56,7 @@ void main() {
 
     test('connects to isolate paused at start', () async {
       final List<String> connectionLog = <String>[];
-      when(mockPeer.sendRequest('streamListen', typed(any))).thenAnswer((Invocation invocation) {
+      when(mockPeer.sendRequest('streamListen', any)).thenAnswer((Invocation invocation) {
         connectionLog.add('streamListen');
         return null;
       });

--- a/packages/flutter_driver/test/flutter_driver_test.dart
+++ b/packages/flutter_driver/test/flutter_driver_test.dart
@@ -40,7 +40,7 @@ void main() {
       when(mockClient.getVM()).thenReturn(mockVM);
       when(mockVM.isolates).thenReturn(<VMRunnableIsolate>[mockIsolate]);
       when(mockIsolate.loadRunnable()).thenReturn(mockIsolate);
-      when(mockIsolate.invokeExtension(any, any)).thenAnswer(
+      when(mockIsolate.invokeExtension(typed(any), typed(any))).thenAnswer(
           (Invocation invocation) => makeMockResponse(<String, dynamic>{'status': 'ok'}));
       vmServiceConnectFunction = (String url) {
         return new Future<VMServiceClientConnection>.value(
@@ -56,7 +56,7 @@ void main() {
 
     test('connects to isolate paused at start', () async {
       final List<String> connectionLog = <String>[];
-      when(mockPeer.sendRequest('streamListen', any)).thenAnswer((Invocation invocation) {
+      when(mockPeer.sendRequest('streamListen', typed(any))).thenAnswer((Invocation invocation) {
         connectionLog.add('streamListen');
         return null;
       });
@@ -124,7 +124,7 @@ void main() {
     });
 
     test('checks the health of the driver extension', () async {
-      when(mockIsolate.invokeExtension(any, any)).thenAnswer(
+      when(mockIsolate.invokeExtension(typed(any), typed(any))).thenAnswer(
           (Invocation invocation) => makeMockResponse(<String, dynamic>{'status': 'ok'}));
       final Health result = await driver.checkHealth();
       expect(result.status, HealthStatus.ok);
@@ -142,7 +142,7 @@ void main() {
       });
 
       test('finds by ValueKey', () async {
-        when(mockIsolate.invokeExtension(any, any)).thenAnswer((Invocation i) {
+        when(mockIsolate.invokeExtension(typed(any), typed(any))).thenAnswer((Invocation i) {
           expect(i.positionalArguments[1], <String, String>{
             'command': 'tap',
             'timeout': _kSerializedTestTimeout,
@@ -162,7 +162,7 @@ void main() {
       });
 
       test('sends the tap command', () async {
-        when(mockIsolate.invokeExtension(any, any)).thenAnswer((Invocation i) {
+        when(mockIsolate.invokeExtension(typed(any), typed(any))).thenAnswer((Invocation i) {
           expect(i.positionalArguments[1], <String, dynamic>{
             'command': 'tap',
             'timeout': _kSerializedTestTimeout,
@@ -181,7 +181,7 @@ void main() {
       });
 
       test('sends the getText command', () async {
-        when(mockIsolate.invokeExtension(any, any)).thenAnswer((Invocation i) {
+        when(mockIsolate.invokeExtension(typed(any), typed(any))).thenAnswer((Invocation i) {
           expect(i.positionalArguments[1], <String, dynamic>{
             'command': 'get_text',
             'timeout': _kSerializedTestTimeout,
@@ -204,7 +204,7 @@ void main() {
       });
 
       test('sends the waitFor command', () async {
-        when(mockIsolate.invokeExtension(any, any)).thenAnswer((Invocation i) {
+        when(mockIsolate.invokeExtension(typed(any), typed(any))).thenAnswer((Invocation i) {
           expect(i.positionalArguments[1], <String, dynamic>{
             'command': 'waitFor',
             'finderType': 'ByTooltipMessage',
@@ -219,7 +219,7 @@ void main() {
 
     group('waitUntilNoTransientCallbacks', () {
       test('sends the waitUntilNoTransientCallbacks command', () async {
-        when(mockIsolate.invokeExtension(any, any)).thenAnswer((Invocation i) {
+        when(mockIsolate.invokeExtension(typed(any), typed(any))).thenAnswer((Invocation i) {
           expect(i.positionalArguments[1], <String, dynamic>{
             'command': 'waitUntilNoTransientCallbacks',
             'timeout': _kSerializedTestTimeout,
@@ -356,7 +356,7 @@ void main() {
 
     group('sendCommand error conditions', () {
       test('local timeout', () async {
-        when(mockIsolate.invokeExtension(any, any)).thenAnswer((Invocation i) {
+        when(mockIsolate.invokeExtension(typed(any), typed(any))).thenAnswer((Invocation i) {
           // completer never competed to trigger timeout
           return new Completer<Map<String, dynamic>>().future;
         });
@@ -370,7 +370,7 @@ void main() {
       });
 
       test('remote error', () async {
-        when(mockIsolate.invokeExtension(any, any)).thenAnswer((Invocation i) {
+        when(mockIsolate.invokeExtension(typed(any), typed(any))).thenAnswer((Invocation i) {
           return makeMockResponse(<String, dynamic>{
             'message': 'This is a failure'
           }, isError: true);


### PR DESCRIPTION
* All lists produced by JSON parsing are List<dynamic>. If more
speficic type is required then they need to be explicitly cast, e.g.
using castFrom helper;
* Function of type (ByText) -> Finder is not a subtype of
(SerializableFinder) -> Finder because ByText is in the contravariant
position;
* In Dart 2 typed(any) should be used instead of any in mockito based
tests.