### PR TITLE
Make sure broken pod install runs triggers pod install on next flutter build

### DIFF
--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -268,7 +268,7 @@ Future<XcodeBuildResult> buildXcodeProject({
   if (hasPlugins()) {
     final String currentGeneratedXcconfig = readGeneratedXcconfig(app.appDirectory);
     await cocoaPods.processPods(
-      appIosDir: appDirectory,
+      appIosDirectory: appDirectory,
       iosEngineDir: flutterFrameworkDir(buildInfo.mode),
       isSwift: app.isSwift,
       flutterPodChanged: (previousGeneratedXcconfig != currentGeneratedXcconfig),


### PR DESCRIPTION
Fixes #14131 

Also disambiguated various *directory variable names in cocoapods.dart since they refer to different directories.