### PR TITLE
Fix of flutter packages get in plugin projects

### DIFF
--- a/packages/flutter_tools/lib/src/project.dart
+++ b/packages/flutter_tools/lib/src/project.dart
@@ -56,15 +56,11 @@ class FlutterProject {
   /// Generates project files necessary to make Gradle builds work on Android
   /// and CocoaPods+Xcode work on iOS.
   void ensureReadyForPlatformSpecificTooling() {
-    if (!directory.existsSync()) {
+    if (!directory.existsSync() || isPluginProject) {
       return;
     }
-    if (isPluginProject) {
-      example.ensureReadyForPlatformSpecificTooling();
-    } else {
-      injectPlugins(directory: directory.path);
-      generateXcodeProperties(directory.path);
-    }
+    injectPlugins(directory: directory.path);
+    generateXcodeProperties(directory.path);
   }
 }
 

--- a/packages/flutter_tools/test/commands/packages_test.dart
+++ b/packages/flutter_tools/test/commands/packages_test.dart
@@ -192,6 +192,24 @@ void main() {
       // TODO(mravn): This test fails on the Chrome windows bot only.
       // Skipping until resolved.
     }, timeout: allowForRemotePubInvocation, skip: true);
+    testUsingContext('get fetches packages and injects plugin in plugin project', () async {
+      final String projectPath = await createProject(
+        temp,
+        arguments: <String>['-t', 'plugin', '--no-pub'],
+      );
+      final String exampleProjectPath = fs.path.join(projectPath, 'example');
+      removeGeneratedFiles(projectPath);
+      removeGeneratedFiles(exampleProjectPath);
+
+      await runCommandIn(projectPath, 'get');
+
+      expectDependenciesResolved(projectPath);
+
+      await runCommandIn(exampleProjectPath, 'get');
+
+      expectDependenciesResolved(exampleProjectPath);
+      expectPluginInjected(exampleProjectPath);
+    }, timeout: allowForRemotePubInvocation);
   });
 
   group('packages test/pub', () {

--- a/packages/flutter_tools/test/project_test.dart
+++ b/packages/flutter_tools/test/project_test.dart
@@ -23,6 +23,12 @@ void main() {
         project.ensureReadyForPlatformSpecificTooling();
         expect(project.directory.existsSync(), isFalse);
       });
+      testInMemory('does nothing in plugin root project', () async {
+        final FlutterProject project = aPluginProject();
+        project.ensureReadyForPlatformSpecificTooling();
+        expect(project.example.ios.directory.childFile('Runner/GeneratedPluginRegistrant.h').existsSync(), isFalse);
+        expect(project.example.ios.directory.childFile('Flutter/Generated.xcconfig').existsSync(), isFalse);
+      });
       testInMemory('injects plugins', () async {
         final FlutterProject project = aProjectWithIos();
         project.ensureReadyForPlatformSpecificTooling();
@@ -32,12 +38,6 @@ void main() {
         final FlutterProject project = aProjectWithIos();
         project.ensureReadyForPlatformSpecificTooling();
         expect(project.ios.directory.childFile('Flutter/Generated.xcconfig').existsSync(), isTrue);
-      });
-      testInMemory('generates files in plugin example project', () async {
-        final FlutterProject project = aPluginProject();
-        project.ensureReadyForPlatformSpecificTooling();
-        expect(project.example.ios.directory.childFile('Runner/GeneratedPluginRegistrant.h').existsSync(), isTrue);
-        expect(project.example.ios.directory.childFile('Flutter/Generated.xcconfig').existsSync(), isTrue);
       });
     });
     group('organization names set', () {

--- a/packages/flutter_tools/test/src/common.dart
+++ b/packages/flutter_tools/test/src/common.dart
@@ -88,13 +88,15 @@ Matcher throwsProcessExit([dynamic exitCode]) {
 /// Matcher for [ProcessExit]s.
 const Matcher isProcessExit = const isInstanceOf<ProcessExit>();
 
-/// Creates a flutter project in the [temp] directory.
+/// Creates a flutter project in the [temp] directory using the
+/// [arguments] list if specified, or `--no-pub` if not.
 /// Returns the path to the flutter project.
-Future<String> createProject(Directory temp) async {
+Future<String> createProject(Directory temp, {List<String> arguments}) async {
+  arguments ??= <String>['--no-pub'];
   final String projectPath = fs.path.join(temp.path, 'flutter_project');
   final CreateCommand command = new CreateCommand();
   final CommandRunner<Null> runner = createTestCommandRunner(command);
-  await runner.run(<String>['create', '--no-pub', projectPath]);
+  await runner.run(<String>['create']..addAll(arguments)..add(projectPath));
   return projectPath;
 }
 


### PR DESCRIPTION
`flutter packages get` fails when run on a plugin project in which no `.packages` file exists in the `example` sub-project.

Regressed in https://github.com/flutter/flutter/pull/14743

Causes build failure on `flutter/plugins`: https://travis-ci.org/flutter/plugins/jobs/342369445