### PR TITLE
No longer gitignore pubspec.lock

### DIFF
--- a/packages/flutter_tools/templates/create/.gitignore.tmpl
+++ b/packages/flutter_tools/templates/create/.gitignore.tmpl
@@ -7,5 +7,4 @@
 build/
 ios/.generated/
 packages
-pubspec.lock
 .flutter-plugins

--- a/packages/flutter_tools/templates/package/.gitignore.tmpl
+++ b/packages/flutter_tools/templates/package/.gitignore.tmpl
@@ -4,4 +4,3 @@
 .packages
 .pub/
 packages
-pubspec.lock


### PR DESCRIPTION
As per discussion here: https://github.com/flutter/flutter/issues/13428#issuecomment-351370702

Enabled now that `pubspec.lock` no longer has relative paths: https://github.com/flutter/flutter/issues/13559