### PR TITLE
Fix dartdoc typo

### DIFF
--- a/packages/flutter/lib/semantics.dart
+++ b/packages/flutter/lib/semantics.dart
@@ -10,7 +10,7 @@
 /// to the platform.
 ///
 /// The [SemanticsNode] hierarchy represents the semantic structure of the UI
-/// and is used to by the platform-specific accessibility services.
+/// and is used by the platform-specific accessibility services.
 library semantics;
 
 export 'src/semantics/semantics.dart';


### PR DESCRIPTION
TBR. Trivial documentation change to determine if the red tree is caused by flake.