### PR TITLE
Add flutter version to non-verbose doctor output

### DIFF
--- a/packages/flutter_tools/lib/src/doctor.dart
+++ b/packages/flutter_tools/lib/src/doctor.dart
@@ -250,7 +250,7 @@ class _FlutterValidator extends DoctorValidator {
     }
 
     return new ValidationResult(valid, messages,
-      statusInfo: 'on ${os.name}, locale ${platform.localeName}, channel ${version.channel}'
+      statusInfo: 'on ${os.name}, locale ${platform.localeName}, channel ${version.channel}, v${version.frameworkVersion}'
     );
   }
 }

--- a/packages/flutter_tools/lib/src/doctor.dart
+++ b/packages/flutter_tools/lib/src/doctor.dart
@@ -250,7 +250,7 @@ class _FlutterValidator extends DoctorValidator {
     }
 
     return new ValidationResult(valid, messages,
-      statusInfo: 'on ${os.name}, locale ${platform.localeName}, channel ${version.channel}, v${version.frameworkVersion}'
+      statusInfo: 'Channel ${version.channel}, v${version.frameworkVersion}, on ${os.name}, locale ${platform.localeName}'
     );
   }
 }


### PR DESCRIPTION
Currently flutter doctor gives us:
`[✓] Flutter (on Linux, locale en_US.UTF-8, channel master)`

This PR adds the version number to produce:
`[✓] Flutter (on Linux, locale en_US.UTF-8, channel master, v0.1.3-pre.46)`