### PR TITLE
Make text shrink to fit its lines when multi line

### DIFF
--- a/packages/flutter/lib/src/painting/text_painter.dart
+++ b/packages/flutter/lib/src/painting/text_painter.dart
@@ -369,21 +369,28 @@ class TextPainter {
       final double newWidth = maxIntrinsicWidth.clamp(minWidth, maxWidth);
       if (newWidth != width)
         _paragraph.layout(new ui.ParagraphConstraints(width: newWidth));
-      if (!didExceedMaxLines) {
-        final List<TextBox> boxes = _paragraph.getBoxesForRange(0, text.toPlainText().length);
-        double startMost = double.maxFinite;
-        double endMost = 0.0;
-        for (final TextBox box in boxes) {
-          if (startMost > box.start)
-            startMost = box.start;
-          if (endMost < box.end)
-            endMost = box.end;
-        }
-        final double maxBoxWidth = endMost - startMost;
-        if (maxBoxWidth > 0.0 && maxBoxWidth >= minWidth && maxBoxWidth != width) {
-          _paragraph.layout(new ui.ParagraphConstraints(width: maxBoxWidth));
-        }
-      }
+      if (!didExceedMaxLines)
+        _shrinkToWidestRow(minWidth);
+    }
+  }
+
+  void _shrinkToWidestRow(double minWidth) {
+    final List<TextBox> boxes = _paragraph.getBoxesForRange(0, -1);
+    if (boxes.isEmpty)
+      return;
+
+    double startMost = double.maxFinite;
+    double endMost = 0.0;
+    for (final TextBox box in boxes) {
+      if (startMost > box.start)
+        startMost = box.start;
+      if (endMost < box.end)
+        endMost = box.end;
+    }
+
+    final double maxBoxWidth = endMost - startMost;
+    if (maxBoxWidth > 0.0 && maxBoxWidth >= minWidth && maxBoxWidth != width) {
+      _paragraph.layout(new ui.ParagraphConstraints(width: maxBoxWidth));
     }
   }
 

--- a/packages/flutter/lib/src/painting/text_painter.dart
+++ b/packages/flutter/lib/src/painting/text_painter.dart
@@ -369,18 +369,20 @@ class TextPainter {
       final double newWidth = maxIntrinsicWidth.clamp(minWidth, maxWidth);
       if (newWidth != width)
         _paragraph.layout(new ui.ParagraphConstraints(width: newWidth));
-      final List<TextBox> boxes = _paragraph.getBoxesForRange(0, text.toPlainText().length);
-      double startMost = double.maxFinite;
-      double endMost = 0.0;
-      for (final TextBox box in boxes) {
-        if (startMost > box.start)
-          startMost = box.start;
-        if (endMost < box.end)
-          endMost = box.end;
-      }
-      final double maxBoxWidth = endMost - startMost;
-      if (maxBoxWidth > 0.0 && maxBoxWidth >= minWidth && maxBoxWidth != width) {
-        _paragraph.layout(new ui.ParagraphConstraints(width: maxBoxWidth));
+      if (!didExceedMaxLines) {
+        final List<TextBox> boxes = _paragraph.getBoxesForRange(0, text.toPlainText().length);
+        double startMost = double.maxFinite;
+        double endMost = 0.0;
+        for (final TextBox box in boxes) {
+          if (startMost > box.start)
+            startMost = box.start;
+          if (endMost < box.end)
+            endMost = box.end;
+        }
+        final double maxBoxWidth = endMost - startMost;
+        if (maxBoxWidth > 0.0 && maxBoxWidth >= minWidth && maxBoxWidth != width) {
+          _paragraph.layout(new ui.ParagraphConstraints(width: maxBoxWidth));
+        }
       }
     }
   }

--- a/packages/flutter/lib/src/painting/text_painter.dart
+++ b/packages/flutter/lib/src/painting/text_painter.dart
@@ -375,7 +375,7 @@ class TextPainter {
   }
 
   void _shrinkToWidestRow(double minWidth) {
-    final List<TextBox> boxes = _paragraph.getBoxesForRange(0, -1);
+    final List<TextBox> boxes = _paragraph.getBoxesForRange(0, 0x7FFFFFFF);
     if (boxes.isEmpty)
       return;
 

--- a/packages/flutter/lib/src/painting/text_painter.dart
+++ b/packages/flutter/lib/src/painting/text_painter.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'dart:ui' as ui show Paragraph, ParagraphBuilder, ParagraphConstraints, ParagraphStyle;
+import 'dart:math' as math show max;
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
@@ -369,6 +370,21 @@ class TextPainter {
       final double newWidth = maxIntrinsicWidth.clamp(minWidth, maxWidth);
       if (newWidth != width)
         _paragraph.layout(new ui.ParagraphConstraints(width: newWidth));
+      final List<TextBox> boxes = _paragraph.getBoxesForRange(0, text.toPlainText().length);
+      final Map<double, double> lineWidths = <double, double>{};
+      for (final TextBox box in boxes) {
+        if (lineWidths[box.top] == null) {
+          lineWidths[box.top] = 0.0;
+        }
+        lineWidths[box.top] += box.end - box.start;
+      }
+      final double maxBoxWidth = lineWidths.values.fold(
+        0.0,
+        (prev, elem) => math.max(prev, elem),
+      );
+      if (maxBoxWidth > 0.0 && maxBoxWidth != width) {
+        _paragraph.layout(new ui.ParagraphConstraints(width: maxBoxWidth));
+      }
     }
   }
 

--- a/packages/flutter/lib/src/painting/text_painter.dart
+++ b/packages/flutter/lib/src/painting/text_painter.dart
@@ -382,7 +382,7 @@ class TextPainter {
         0.0,
         (double previous, double element) => math.max(previous, element),
       );
-      if (maxBoxWidth > 0.0 && maxBoxWidth != width) {
+      if (maxBoxWidth > 0.0 && maxBoxWidth >= minWidth && maxBoxWidth != width) {
         _paragraph.layout(new ui.ParagraphConstraints(width: maxBoxWidth));
       }
     }

--- a/packages/flutter/lib/src/painting/text_painter.dart
+++ b/packages/flutter/lib/src/painting/text_painter.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:math' as math show max;
 import 'dart:ui' as ui show Paragraph, ParagraphBuilder, ParagraphConstraints, ParagraphStyle;
 
 import 'package:flutter/foundation.dart';
@@ -371,17 +370,15 @@ class TextPainter {
       if (newWidth != width)
         _paragraph.layout(new ui.ParagraphConstraints(width: newWidth));
       final List<TextBox> boxes = _paragraph.getBoxesForRange(0, text.toPlainText().length);
-      final Map<double, double> lineWidths = <double, double>{};
+      double startMost = double.maxFinite;
+      double endMost = 0.0;
       for (final TextBox box in boxes) {
-        if (lineWidths[box.top] == null) {
-          lineWidths[box.top] = 0.0;
-        }
-        lineWidths[box.top] += box.end - box.start;
+        if (startMost > box.start)
+          startMost = box.start;
+        if (endMost < box.end)
+          endMost = box.end;
       }
-      final double maxBoxWidth = lineWidths.values.fold(
-        0.0,
-        (double previous, double element) => math.max(previous, element),
-      );
+      final double maxBoxWidth = endMost - startMost;
       if (maxBoxWidth > 0.0 && maxBoxWidth >= minWidth && maxBoxWidth != width) {
         _paragraph.layout(new ui.ParagraphConstraints(width: maxBoxWidth));
       }

--- a/packages/flutter/lib/src/painting/text_painter.dart
+++ b/packages/flutter/lib/src/painting/text_painter.dart
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:ui' as ui show Paragraph, ParagraphBuilder, ParagraphConstraints, ParagraphStyle;
 import 'dart:math' as math show max;
+import 'dart:ui' as ui show Paragraph, ParagraphBuilder, ParagraphConstraints, ParagraphStyle;
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
@@ -380,7 +380,7 @@ class TextPainter {
       }
       final double maxBoxWidth = lineWidths.values.fold(
         0.0,
-        (prev, elem) => math.max(prev, elem),
+        (double previous, double element) => math.max(previous, element),
       );
       if (maxBoxWidth > 0.0 && maxBoxWidth != width) {
         _paragraph.layout(new ui.ParagraphConstraints(width: maxBoxWidth));

--- a/packages/flutter/test/cupertino/dialog_test.dart
+++ b/packages/flutter/test/cupertino/dialog_test.dart
@@ -152,14 +152,14 @@ void main() {
 
     // Check sizes/locations of the text.
     expect(tester.getSize(find.text('The Title')), equals(const Size(230.0, 198.0)));
-    expect(tester.getSize(find.text('Cancel')), equals(const Size(75.0, 300.0)));
-    expect(tester.getSize(find.text('OK')), equals(const Size(75.0, 100.0)));
+    expect(tester.getSize(find.text('Cancel')), equals(const Size(51.0, 300.0)));
+    expect(tester.getSize(find.text('OK')), equals(const Size(51.0, 100.0)));
     expect(tester.getTopLeft(find.text('The Title')), equals(const Offset(285.0, 40.0)));
 
     // The Cancel and OK buttons have different Y values because "Cancel" is
     // wrapping (as it should with large text sizes like this).
-    expect(tester.getTopLeft(find.text('Cancel')), equals(const Offset(295.0, 250.0)));
-    expect(tester.getTopLeft(find.text('OK')), equals(const Offset(430.0, 350.0)));
+    expect(tester.getTopLeft(find.text('Cancel')), equals(const Offset(307.0, 250.0)));
+    expect(tester.getTopLeft(find.text('OK')), equals(const Offset(442.0, 350.0)));
   });
 }
 

--- a/packages/flutter/test/material/list_tile_test.dart
+++ b/packages/flutter/test/material/list_tile_test.dart
@@ -206,7 +206,7 @@ void main() {
     void testHorizontalGeometry() {
       expect(right('leading'), 800.0 - 16.0 - rightPadding);
       expect(right('title'), 800.0 - 72.0 - rightPadding);
-      expect(left('leading') - right('title'), 16.0);
+      expect(left('leading') - right('title'), 28.0);
       expect(left('trailing'), 16.0 + leftPadding);
     }
 


### PR DESCRIPTION
fixes #13211

When a multiline paragraph was layouted inside a constrained box, its resulting width was always the box max. This behaviour is probably not the one someone would expect. In fact it was breaking one of our designs (a view very similar to the native iMessage, Whatsapp and Facebook Messenger apps, where the messages are inside bubbles that are perfectly wrapped around the texts. This PR fixes the behaviour making sure that the paragraph is always layouted using a width that is computed from the widest row.

Some tests are still failing (my guess is that the hard-coded values inside the tests can be corrected with the new ones).

Our empirical tests prove that this should be the expected behaviour, however we can be missing the bigger picture, so please tell me what do you think about this.
 