### PR TITLE
Fix broken link to AnimatedListState documentation

### DIFF
--- a/packages/flutter/lib/src/widgets/animated_list.dart
+++ b/packages/flutter/lib/src/widgets/animated_list.dart
@@ -172,7 +172,7 @@ class AnimatedList extends StatefulWidget {
       'This can happen when the context provided is from the same StatefulWidget that '
       'built the AnimatedList. Please see the AnimatedList documentation for examples '
       'of how to refer to an AnimatedListState object: '
-      '  https://docs.flutter.io/flutter/widgets/AnimatedState-class.html\n'
+      '  https://docs.flutter.io/flutter/widgets/AnimatedListState-class.html \n'
       'The context used was:\n'
       '  $context'
     );


### PR DESCRIPTION
Fixes a broken link in `AnimatedList.of()`'s error message.