### PR TITLE
Add IntelliJ path to doctor output

### DIFF
--- a/packages/flutter_tools/lib/src/doctor.dart
+++ b/packages/flutter_tools/lib/src/doctor.dart
@@ -276,7 +276,9 @@ class NoIdeValidator extends DoctorValidator {
 }
 
 abstract class IntelliJValidator extends DoctorValidator {
-  IntelliJValidator(String title) : super(title);
+  final String installPath;
+
+  IntelliJValidator(String title, this.installPath) : super(title);
 
   String get version;
   String get pluginsPath;
@@ -300,6 +302,8 @@ abstract class IntelliJValidator extends DoctorValidator {
   @override
   Future<ValidationResult> validate() async {
     final List<ValidationMessage> messages = <ValidationMessage>[];
+
+    messages.add(new ValidationMessage('IntelliJ at $installPath'));
 
     _validatePackage(messages, <String>['flutter-intellij', 'flutter-intellij.jar'],
         'Flutter', minVersion: kMinFlutterPluginVersion);
@@ -397,12 +401,10 @@ abstract class IntelliJValidator extends DoctorValidator {
 }
 
 class IntelliJValidatorOnLinuxAndWindows extends IntelliJValidator {
-  IntelliJValidatorOnLinuxAndWindows(String title, this.version, this.installPath, this.pluginsPath) : super(title);
+  IntelliJValidatorOnLinuxAndWindows(String title, this.version, String installPath, this.pluginsPath) : super(title, installPath);
 
   @override
   String version;
-
-  final String installPath;
 
   @override
   String pluginsPath;
@@ -451,10 +453,9 @@ class IntelliJValidatorOnLinuxAndWindows extends IntelliJValidator {
 }
 
 class IntelliJValidatorOnMac extends IntelliJValidator {
-  IntelliJValidatorOnMac(String title, this.id, this.installPath) : super(title);
+  IntelliJValidatorOnMac(String title, this.id, String installPath) : super(title, installPath);
 
   final String id;
-  final String installPath;
 
   static final Map<String, String> _dirNameToId = <String, String>{
     'IntelliJ IDEA.app' : 'IntelliJIdea',

--- a/packages/flutter_tools/test/commands/doctor_test.dart
+++ b/packages/flutter_tools/test/commands/doctor_test.dart
@@ -15,12 +15,17 @@ import '../src/context.dart';
 void main() {
   group('doctor', () {
     testUsingContext('intellij validator', () async {
-      final ValidationResult result = await new IntelliJValidatorTestTarget('Test').validate();
+      final String installPath = '/path/to/intelliJ';
+      final ValidationResult result = await new IntelliJValidatorTestTarget('Test', installPath).validate();
       expect(result.type, ValidationType.partial);
       expect(result.statusInfo, 'version test.test.test');
-      expect(result.messages, hasLength(3));
+      expect(result.messages, hasLength(4));
 
       ValidationMessage message = result.messages
+          .firstWhere((ValidationMessage m) => m.message.startsWith('IntelliJ '));
+      expect(message.message, 'IntelliJ at $installPath');
+
+      message = result.messages
           .firstWhere((ValidationMessage m) => m.message.startsWith('Dart '));
       expect(message.message, 'Dart plugin version 162.2485');
 
@@ -148,7 +153,7 @@ void main() {
 }
 
 class IntelliJValidatorTestTarget extends IntelliJValidator {
-  IntelliJValidatorTestTarget(String title) : super(title);
+  IntelliJValidatorTestTarget(String title, String installPath) : super(title, installPath);
 
   @override
   String get pluginsPath => fs.path.join('test', 'data', 'intellij', 'plugins');


### PR DESCRIPTION
Outputs:
```
[✓] IntelliJ IDEA Community Edition (version 2017.2)
    • IntelliJ at /path/to/idea-IC-172.3757.52
    • Flutter plugin version 19.1
    • Dart plugin version 172.4343.25
```

Closes https://github.com/flutter/flutter/issues/14575