### PR TITLE
Skip upgrade check on flutter upgrade

### DIFF
--- a/packages/flutter_tools/lib/src/runner/flutter_command_runner.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command_runner.dart
@@ -248,7 +248,9 @@ class FlutterCommandRunner extends CommandRunner<Null> {
 
     _checkFlutterCopy();
     await FlutterVersion.instance.ensureVersionFile();
-    await FlutterVersion.instance.checkFlutterVersionFreshness();
+    if (globalResults.command?.name != 'upgrade') {
+      await FlutterVersion.instance.checkFlutterVersionFreshness();
+    }
 
     if (globalResults.wasParsed('packages'))
       PackageMap.globalPackagesPath = fs.path.normalize(fs.path.absolute(globalResults['packages']));


### PR DESCRIPTION
Checks that we aren't already running the upgrade command before calling `checkFlutterVersionFreshness`.

Fixes https://github.com/flutter/flutter/issues/12991