### PR TITLE
Make the `isRunningOnBot` getter more robust.

### DIFF
--- a/packages/flutter_tools/lib/src/base/utils.dart
+++ b/packages/flutter_tools/lib/src/base/utils.dart
@@ -45,7 +45,7 @@ class BotDetector {
 }
 
 bool get isRunningOnBot {
-  BotDetector botDetector = context?.getVariable(BotDetector) ?? _kBotDetector;
+  final BotDetector botDetector = context?.getVariable(BotDetector) ?? _kBotDetector;
   return botDetector.isRunningOnBot;
 }
 

--- a/packages/flutter_tools/lib/src/base/utils.dart
+++ b/packages/flutter_tools/lib/src/base/utils.dart
@@ -45,10 +45,8 @@ class BotDetector {
 }
 
 bool get isRunningOnBot {
-  if (context == null) {
-    return _kBotDetector.isRunningOnBot;
-  }
-  return context[BotDetector].isRunningOnBot;
+  BotDetector botDetector = context?.getVariable(BotDetector) ?? _kBotDetector;
+  return botDetector.isRunningOnBot;
 }
 
 String hex(List<int> bytes) {


### PR DESCRIPTION
It was failing in the case of an AppContext being in scope
but not having a `BotDetector` seeded in it.