### PR TITLE
Fix overlap check in bottom app bar's custom clipper

### DIFF
--- a/packages/flutter/lib/src/material/bottom_app_bar.dart
+++ b/packages/flutter/lib/src/material/bottom_app_bar.dart
@@ -117,7 +117,7 @@ class _BottomAppBarClipper extends CustomClipper<Path> {
     final Rect button = geometry.value.floatingActionButtonArea
       .translate(0.0, geometry.value.bottomNavigationBarTop * -1.0);
 
-    if (appBar.overlaps(button)) {
+    if (!appBar.overlaps(button)) {
       return new Path()..addRect(appBar);
     }
 

--- a/packages/flutter/test/material/bottom_app_bar_test.dart
+++ b/packages/flutter/test/material/bottom_app_bar_test.dart
@@ -17,8 +17,6 @@ void main() {
           bottomNavigationBar: const ShapeListener(const BottomAppBar()),
         ),
       ),
-      Duration.zero,
-      EnginePhase.paint
     );
 
     final ShapeListenerState shapeListenerState = tester.state(find.byType(ShapeListener));
@@ -39,7 +37,7 @@ void main() {
 
 // The bottom app bar clip path computation is only available at paint time.
 // In order to examine the notch path we implement this caching painter which
-// looks for at paint time for a descendant PhysicalShape and caches the
+// at paint time looks for for a descendant PhysicalShape and caches the
 // clip path it is using.
 class ClipCachePainter extends CustomPainter {
   ClipCachePainter(this.context);

--- a/packages/flutter/test/material/bottom_app_bar_test.dart
+++ b/packages/flutter/test/material/bottom_app_bar_test.dart
@@ -1,0 +1,103 @@
+// Copyright 2018 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+
+void main() {
+  testWidgets('no overlap with floating action button', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      new MaterialApp(
+        home: const Scaffold(
+          floatingActionButton: const FloatingActionButton(
+            onPressed: null,
+          ),
+          bottomNavigationBar: const ShapeListener(const BottomAppBar()),
+        ),
+      ),
+      Duration.zero,
+      EnginePhase.paint
+    );
+
+    final ShapeListenerState shapeListenerState = tester.state(find.byType(ShapeListener));
+    final RenderBox renderBox = tester.renderObject(find.byType(BottomAppBar));
+    final Path expectedPath = new Path()
+      ..addRect(Offset.zero & renderBox.size);
+
+    final Path actualPath = shapeListenerState.cache.value;
+    expect(
+      actualPath,
+      coversSameAreaAs(
+        expectedPath,
+        areaToCompare: (Offset.zero & renderBox.size).inflate(5.0),
+      )
+    );
+  });
+}
+
+// The bottom app bar clip path computation is only available at paint time.
+// In order to examine the notch path we implement this caching painter which
+// looks for at paint time for a descendant PhysicalShape and caches the
+// clip path it is using.
+class ClipCachePainter extends CustomPainter {
+  ClipCachePainter(this.context);
+
+  Path value;
+  BuildContext context;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final RenderPhysicalShape physicalShape = findPhysicalShapeChild(context);
+    value = physicalShape.clipper.getClip(size);
+  }
+
+  RenderPhysicalShape findPhysicalShapeChild(BuildContext context) {
+    RenderPhysicalShape result;
+    context.visitChildElements((Element e) {
+      final RenderObject renderObject = e.findRenderObject();
+      if (renderObject.runtimeType == RenderPhysicalShape) {
+        assert(result == null);
+        result = renderObject;
+      } else {
+        result = findPhysicalShapeChild(e);
+      }
+    });
+    return result;
+  }
+
+  @override
+  bool shouldRepaint(ClipCachePainter oldDelegate) {
+    return true;
+  }
+}
+
+class ShapeListener extends StatefulWidget {
+  const ShapeListener(this.child);
+
+  final Widget child;
+
+  @override
+  State createState() => new ShapeListenerState();
+
+}
+
+class ShapeListenerState extends State<ShapeListener> {
+  @override
+  Widget build(BuildContext context) {
+    return new CustomPaint(
+      child: widget.child,
+      painter: cache
+    );
+  }
+
+  ClipCachePainter cache;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    cache = new ClipCachePainter(context);
+  }
+
+}


### PR DESCRIPTION
Also adds a test harness that does some gymnastics in order to fetch the actual path the bottom app bar clips to (gymnastics are required as the clip is only available at paint time)