### PR TITLE
Add version collition error handling for Android publish

### DIFF
--- a/examples/flutter_gallery/android/fastlane/Fastfile
+++ b/examples/flutter_gallery/android/fastlane/Fastfile
@@ -9,12 +9,17 @@ default_platform(:android)
 platform :android do
   desc 'Push the built release APK to alpha or beta depending on current branch'
   lane :deploy_play_store do
-    upload_to_play_store(
-      track: ENV['TRAVIS_BRANCH'] == 'beta' ? 'beta' : 'alpha',
-      apk: '../build/app/outputs/apk/release/app-release.apk',
-      json_key_data: ENV['GOOGLE_DEVELOPER_SERVICE_ACCOUNT_ACTOR_FASTLANE'],
-      skip_upload_screenshots: true,
-      skip_upload_images: true
-    )
+    begin
+      upload_to_play_store(
+        track: ENV['TRAVIS_BRANCH'] == 'beta' ? 'beta' : 'alpha',
+        apk: '../build/app/outputs/apk/release/app-release.apk',
+        json_key_data: ENV['GOOGLE_DEVELOPER_SERVICE_ACCOUNT_ACTOR_FASTLANE'],
+        skip_upload_screenshots: true,
+        skip_upload_images: true
+      )
+    rescue => exception
+      raise exception unless exception.message.include?('apkUpgradeVersionConflict')
+      puts 'Current version already present on the Play Store. Omitting this upload.'
+    end
   end
 end


### PR DESCRIPTION
Unfortunately it's impossible to capture status output from fastlane pilot for iOS