### PR TITLE
Fix snapshot fingerprinting in --preview-dart-2 mode.

### DIFF
--- a/packages/flutter_tools/lib/src/commands/build_aot.dart
+++ b/packages/flutter_tools/lib/src/commands/build_aot.dart
@@ -337,7 +337,7 @@ Future<String> _buildAotSnapshot(
 
   final String entryPoint = mainPath;
   final SnapshotType snapshotType = new SnapshotType(platform, buildMode);
-  Fingerprint makeFingerprint() async {
+  Future<Fingerprint> makeFingerprint() async {
     final Set<String> snapshotInputPaths = await readDepfile(dependencies)
       ..add(entryPoint)
       ..addAll(outputPaths);

--- a/packages/flutter_tools/lib/src/commands/build_aot.dart
+++ b/packages/flutter_tools/lib/src/commands/build_aot.dart
@@ -335,8 +335,15 @@ Future<String> _buildAotSnapshot(
     ]);
   }
 
-  final String genSnapshotInputFile = previewDart2 ? kApplicationKernelPath : mainPath;
+  final String entryPoint = mainPath;
   final SnapshotType snapshotType = new SnapshotType(platform, buildMode);
+  Fingerprint makeFingerprint() async {
+    final Set<String> snapshotInputPaths = await readDepfile(dependencies)
+      ..add(entryPoint)
+      ..addAll(outputPaths);
+    return Snapshotter.createFingerprint(snapshotType, entryPoint, snapshotInputPaths);
+  }
+
   final File fingerprintFile = fs.file('$dependencies.fingerprint');
   final List<File> fingerprintFiles = <File>[fingerprintFile, fs.file(dependencies)]
     ..addAll(inputPaths.map(fs.file))
@@ -345,11 +352,7 @@ Future<String> _buildAotSnapshot(
     try {
       final String json = await fingerprintFile.readAsString();
       final Fingerprint oldFingerprint = new Fingerprint.fromJson(json);
-      final Set<String> snapshotInputPaths = await readDepfile(dependencies)
-        ..add(genSnapshotInputFile)
-        ..addAll(outputPaths);
-      final Fingerprint newFingerprint = Snapshotter.createFingerprint(snapshotType, genSnapshotInputFile, snapshotInputPaths);
-      if (oldFingerprint == newFingerprint) {
+      if (oldFingerprint == await makeFingerprint()) {
         printStatus('Skipping AOT snapshot build. Fingerprint match.');
         return outputPath;
       }
@@ -459,10 +462,7 @@ Future<String> _buildAotSnapshot(
 
   // Compute and record build fingerprint.
   try {
-    final Set<String> snapshotInputPaths = await readDepfile(dependencies)
-      ..add(mainPath)
-      ..addAll(outputPaths);
-    final Fingerprint fingerprint = Snapshotter.createFingerprint(snapshotType, mainPath, snapshotInputPaths);
+    final Fingerprint fingerprint = await makeFingerprint();
     await fingerprintFile.writeAsString(fingerprint.toJson());
   } catch (e, s) {
     // Log exception and continue, this step is a performance improvement only.


### PR DESCRIPTION
This is a follow up to PR #14775 - instead of treating dill file
as an input treat as intermediate file and don't fingerprint it.

Make sure to always use original main Dart file as an entry
point for fingerprint calculation.

This fixes an issue that AOT snapshot would not be recompiled in
the preview-dart-2 mode if entry point changes, e.g.

$ flutter build aot -t t/x.dart --preview-dart-2
$ flutter build aot -t t/y.dart --preview-dart-2

The second invocation would not build AOT snapshot.

(This issue is visible on the microbencmarks bot)