### PR TITLE
Enable aligning a dropdown button's width with its menu's width 

### DIFF
--- a/packages/flutter/lib/src/material/button_theme.dart
+++ b/packages/flutter/lib/src/material/button_theme.dart
@@ -64,16 +64,19 @@ class ButtonTheme extends InheritedWidget {
     double height: 36.0,
     EdgeInsetsGeometry padding,
     ShapeBorder shape,
+    bool alignedDropdown: false,
     Widget child,
   }) : assert(textTheme != null),
        assert(minWidth != null && minWidth >= 0.0),
        assert(height != null && height >= 0.0),
+       assert(alignedDropdown != null),
        data = new ButtonThemeData(
          textTheme: textTheme,
          minWidth: minWidth,
          height: height,
          padding: padding,
          shape: shape,
+         alignedDropdown: alignedDropdown
        ),
        super(key: key, child: child);
 
@@ -98,16 +101,19 @@ class ButtonTheme extends InheritedWidget {
     double height: 36.0,
     EdgeInsetsGeometry padding: const EdgeInsets.symmetric(horizontal: 8.0),
     ShapeBorder shape,
+    bool alignedDropdown: false,
     Widget child,
   }) : assert(textTheme != null),
        assert(minWidth != null && minWidth >= 0.0),
        assert(height != null && height >= 0.0),
+       assert(alignedDropdown != null),
        data = new ButtonThemeData(
          textTheme: textTheme,
          minWidth: minWidth,
          height: height,
          padding: padding,
          shape: shape,
+         alignedDropdown: alignedDropdown,
        ),
        super(key: key, child: child);
 
@@ -146,9 +152,11 @@ class ButtonThemeData extends Diagnosticable {
     this.height: 36.0,
     EdgeInsetsGeometry padding,
     ShapeBorder shape,
+    this.alignedDropdown: false,
   }) : assert(textTheme != null),
        assert(minWidth != null && minWidth >= 0.0),
        assert(height != null && height >= 0.0),
+       assert(alignedDropdown != null),
        _padding = padding,
        _shape = shape;
 
@@ -229,6 +237,15 @@ class ButtonThemeData extends Diagnosticable {
   }
   final ShapeBorder _shape;
 
+  /// If true, then a [DropdownButton] menu's width will match the button's
+  /// width.
+  ///
+  /// If false (the default), then the dropdown's menu will be wider than
+  /// its button. In either case dropdown button will line up the leading
+  /// edge of the menu's value with the leading edge of the values
+  /// displayed by the menu items.
+  final bool alignedDropdown;
+
   @override
   bool operator ==(dynamic other) {
     if (other.runtimeType != runtimeType)
@@ -238,7 +255,8 @@ class ButtonThemeData extends Diagnosticable {
         && minWidth == typedOther.minWidth
         && height == typedOther.height
         && padding == typedOther.padding
-        && shape == typedOther.shape;
+        && shape == typedOther.shape
+        && alignedDropdown == typedOther.alignedDropdown;
   }
 
   @override
@@ -249,6 +267,7 @@ class ButtonThemeData extends Diagnosticable {
       height,
       padding,
       shape,
+      alignedDropdown,
     );
   }
 
@@ -256,13 +275,15 @@ class ButtonThemeData extends Diagnosticable {
   void debugFillProperties(DiagnosticPropertiesBuilder description) {
     super.debugFillProperties(description);
     final ButtonThemeData defaultTheme = const ButtonThemeData();
-    description.add(new EnumProperty<ButtonTextTheme>('textTheme', textTheme,
-        defaultValue: defaultTheme.textTheme));
+    description.add(new EnumProperty<ButtonTextTheme>('textTheme', textTheme, defaultValue: defaultTheme.textTheme));
     description.add(new DoubleProperty('minWidth', minWidth, defaultValue: defaultTheme.minWidth));
     description.add(new DoubleProperty('height', height, defaultValue: defaultTheme.height));
-    description.add(new DiagnosticsProperty<EdgeInsetsGeometry>('padding', padding,
-        defaultValue: defaultTheme.padding));
-    description.add(
-        new DiagnosticsProperty<ShapeBorder>('shape', shape, defaultValue: defaultTheme.shape));
+    description.add(new DiagnosticsProperty<EdgeInsetsGeometry>('padding', padding, defaultValue: defaultTheme.padding));
+    description.add(new DiagnosticsProperty<ShapeBorder>('shape', shape, defaultValue: defaultTheme.shape));
+    description.add(new FlagProperty('alignedDropdown',
+      value: alignedDropdown,
+      defaultValue: defaultTheme.alignedDropdown,
+      ifTrue: 'dropdown width matches button',
+    ));
   }
 }

--- a/packages/flutter/lib/src/material/button_theme.dart
+++ b/packages/flutter/lib/src/material/button_theme.dart
@@ -241,7 +241,7 @@ class ButtonThemeData extends Diagnosticable {
   /// width.
   ///
   /// If false (the default), then the dropdown's menu will be wider than
-  /// its button. In either case dropdown button will line up the leading
+  /// its button. In either case the dropdown button will line up the leading
   /// edge of the menu's value with the leading edge of the values
   /// displayed by the menu items.
   final bool alignedDropdown;

--- a/packages/flutter/lib/src/material/button_theme.dart
+++ b/packages/flutter/lib/src/material/button_theme.dart
@@ -244,6 +244,8 @@ class ButtonThemeData extends Diagnosticable {
   /// its button. In either case the dropdown button will line up the leading
   /// edge of the menu's value with the leading edge of the values
   /// displayed by the menu items.
+  ///
+  /// This property only affects [DropdownButton] and its menu.
   final bool alignedDropdown;
 
   @override

--- a/packages/flutter/lib/src/material/dropdown.dart
+++ b/packages/flutter/lib/src/material/dropdown.dart
@@ -151,7 +151,7 @@ class _DropdownMenuState<T> extends State<_DropdownMenu<T>> {
         opacity: opacity,
         child: new InkWell(
           child: new Container(
-            padding: widget.padding,//_kMenuHorizontalPadding,
+            padding: widget.padding,
             child: route.items[itemIndex],
           ),
           onTap: () => Navigator.pop(
@@ -635,7 +635,7 @@ class _DropdownButtonState<T> extends State<DropdownButton<T>> with WidgetsBindi
 
     Widget result = new DefaultTextStyle(
       style: _textStyle,
-      child: new Container(//new SizedBox(
+      child: new Container(
         padding: widget.padding,
         height: widget.isDense ? _denseButtonHeight : null,
         child: new Row(

--- a/packages/flutter/lib/src/material/dropdown.dart
+++ b/packages/flutter/lib/src/material/dropdown.dart
@@ -581,7 +581,7 @@ class _DropdownButtonState<T> extends State<DropdownButton<T>> with WidgetsBindi
   void _handleTap() {
     final RenderBox itemBox = context.findRenderObject();
     final Rect itemRect = itemBox.localToGlobal(Offset.zero) & itemBox.size;
-    final TextDirection textDirection = Direcionality.of(context);
+    final TextDirection textDirection = Directionality.of(context);
     final Rect buttonRect = widget.menuMargin.resolve(textDirection).inflateRect(itemRect);
 
     assert(_dropdownRoute == null);

--- a/packages/flutter/lib/src/material/dropdown.dart
+++ b/packages/flutter/lib/src/material/dropdown.dart
@@ -245,7 +245,7 @@ class _DropdownMenuRouteLayout<T> extends SingleChildLayoutDelegate {
     double left;
     switch (textDirection) {
       case TextDirection.rtl:
-        left = buttonRect.right.clamp(0.0, size.width - childSize.width) - childSize.width;
+      left = buttonRect.right.clamp(0.0, size.width) - childSize.width;
         break;
       case TextDirection.ltr:
         left = buttonRect.left.clamp(0.0, size.width - childSize.width);

--- a/packages/flutter/lib/src/material/theme_data.dart
+++ b/packages/flutter/lib/src/material/theme_data.dart
@@ -491,7 +491,7 @@ class ThemeData extends Diagnosticable {
     Color unselectedWidgetColor,
     Color disabledColor,
     Color buttonColor,
-    Color buttonTheme,
+    ButtonThemeData buttonTheme,
     Color secondaryHeaderColor,
     Color textSelectionColor,
     Color textSelectionHandleColor,

--- a/packages/flutter/test/material/button_theme_test.dart
+++ b/packages/flutter/test/material/button_theme_test.dart
@@ -253,7 +253,7 @@ void main() {
     await tester.tap(button);
     await tester.pumpAndSettle();
 
-    // alignedDropdown: true means the button and menu widths match
+    // Aligneddropdown: true means the button and menu widths match
     expect(tester.getSize(button).width, 200.0);
     expect(tester.getSize(menu).width, 200.0);
 
@@ -262,7 +262,6 @@ void main() {
     final Finder fooText = find.text('foo');
     expect(fooText, findsNWidgets(2));
     expect(tester.getRect(fooText.at(0)), tester.getRect(fooText.at(1)));
-
 
     // Dismiss the menu.
     await tester.tapAt(Offset.zero);

--- a/packages/flutter/test/material/button_theme_test.dart
+++ b/packages/flutter/test/material/button_theme_test.dart
@@ -178,48 +178,53 @@ void main() {
   });
 
   testWidgets('ButtonTheme alignedDropdown', (WidgetTester tester) async {
+    final Key dropdownKey = new UniqueKey();
 
     Widget buildFrame({ bool alignedDropdown, TextDirection textDirection }) {
       return new MaterialApp(
-        home: new Directionality(
-          textDirection: textDirection,
-          child: new ButtonTheme(
-            alignedDropdown: alignedDropdown,
-            child: new Material(
-              child: new Builder(
-                builder: (BuildContext context) {
-                  return new Container(
-                    alignment: Alignment.center,
-                    child: new DropdownButtonHideUnderline(
-                      child: new Container(
-                        width: 200.0,
-                        child: new DropdownButton(
-                          onChanged: (String value) { },
-                          value: 'foo',
-                          items: const <DropdownMenuItem<String>>[
-                            const DropdownMenuItem<String>(
-                              value: 'foo',
-                              child: const Text('foo'),
-                            ),
-                            const DropdownMenuItem<String>(
-                              value: 'bar',
-                              child: const Text('bar'),
-                            ),
-                          ],
-                        ),
+        builder: (BuildContext context, Widget child) {
+          return new Directionality(
+            textDirection: textDirection,
+            child: child,
+          );
+        },
+        home: new ButtonTheme(
+          alignedDropdown: alignedDropdown,
+          child: new Material(
+            child: new Builder(
+              builder: (BuildContext context) {
+                return new Container(
+                  alignment: Alignment.center,
+                  child: new DropdownButtonHideUnderline(
+                    child: new Container(
+                      width: 200.0,
+                      child: new DropdownButton<String>(
+                        key: dropdownKey,
+                        onChanged: (String value) { },
+                        value: 'foo',
+                        items: const <DropdownMenuItem<String>>[
+                          const DropdownMenuItem<String>(
+                            value: 'foo',
+                            child: const Text('foo'),
+                          ),
+                          const DropdownMenuItem<String>(
+                            value: 'bar',
+                            child: const Text('bar'),
+                          ),
+                        ],
                       ),
                     ),
-                  );
-                },
-              ),
+                  ),
+                );
+              },
             ),
           ),
         ),
       );
     }
 
-    final Finder button = find.byType(DropdownButton);
-    final Finder menu = find.byWidgetPredicate((Widget w) => '${w.runtimeType}' == '_DropdownMenu');
+    final Finder button = find.byKey(dropdownKey);
+    final Finder menu = find.byWidgetPredicate((Widget w) => '${w.runtimeType}' == '_DropdownMenu<String>');
 
     await tester.pumpWidget(
       buildFrame(
@@ -256,7 +261,7 @@ void main() {
     // down button's label. The should both appear at the same location.
     final Finder fooText = find.text('foo');
     expect(fooText, findsNWidgets(2));
-    expect(tester.getTopLeft(fooText.at(0)), tester.getTopLeft(fooText.at(1)));
+    expect(tester.getRect(fooText.at(0)), tester.getRect(fooText.at(1)));
 
 
     // Dismiss the menu.
@@ -275,6 +280,6 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(fooText, findsNWidgets(2));
-    expect(tester.getTopRight(fooText.at(0)), tester.getTopRight(fooText.at(1)));
+    expect(tester.getRect(fooText.at(0)), tester.getRect(fooText.at(1)));
   });
 }

--- a/packages/flutter/test/material/button_theme_test.dart
+++ b/packages/flutter/test/material/button_theme_test.dart
@@ -14,6 +14,7 @@ void main() {
     expect(theme.shape, const RoundedRectangleBorder(
       borderRadius: const BorderRadius.all(const Radius.circular(2.0)),
     ));
+    expect(theme.alignedDropdown, false);
   });
 
   test('ButtonThemeData default overrides', () {
@@ -23,11 +24,13 @@ void main() {
       height: 200.0,
       padding: EdgeInsets.zero,
       shape: const RoundedRectangleBorder(),
+      alignedDropdown: true,
     );
     expect(theme.textTheme, ButtonTextTheme.primary);
     expect(theme.constraints, const BoxConstraints(minWidth: 100.0, minHeight: 200.0));
     expect(theme.padding, EdgeInsets.zero);
     expect(theme.shape, const RoundedRectangleBorder());
+    expect(theme.alignedDropdown, true);
   });
 
   testWidgets('ButtonTheme defaults', (WidgetTester tester) async {
@@ -172,5 +175,106 @@ void main() {
     expect(tester.widget<Material>(find.byType(Material)).shape, shape);
     expect(tester.widget<Material>(find.byType(Material)).color, const Color(0xFF00FF00));
     expect(tester.getSize(find.byType(Material)), const Size(100.0, 200.0));
+  });
+
+  testWidgets('ButtonTheme alignedDropdown', (WidgetTester tester) async {
+
+    Widget buildFrame({ bool alignedDropdown, TextDirection textDirection }) {
+      return new MaterialApp(
+        home: new Directionality(
+          textDirection: textDirection,
+          child: new ButtonTheme(
+            alignedDropdown: alignedDropdown,
+            child: new Material(
+              child: new Builder(
+                builder: (BuildContext context) {
+                  return new Container(
+                    alignment: Alignment.center,
+                    child: new DropdownButtonHideUnderline(
+                      child: new Container(
+                        width: 200.0,
+                        child: new DropdownButton(
+                          onChanged: (String value) { },
+                          value: 'foo',
+                          items: const <DropdownMenuItem<String>>[
+                            const DropdownMenuItem<String>(
+                              value: 'foo',
+                              child: const Text('foo'),
+                            ),
+                            const DropdownMenuItem<String>(
+                              value: 'bar',
+                              child: const Text('bar'),
+                            ),
+                          ],
+                        ),
+                      ),
+                    ),
+                  );
+                },
+              ),
+            ),
+          ),
+        ),
+      );
+    }
+
+    final Finder button = find.byType(DropdownButton);
+    final Finder menu = find.byWidgetPredicate((Widget w) => '${w.runtimeType}' == '_DropdownMenu');
+
+    await tester.pumpWidget(
+      buildFrame(
+        alignedDropdown: false,
+        textDirection: TextDirection.ltr,
+      ),
+    );
+    await tester.tap(button);
+    await tester.pumpAndSettle();
+
+    // 240 = 200.0 (button width) + _kUnalignedMenuMargin (20.0 left and right)
+    expect(tester.getSize(button).width, 200.0);
+    expect(tester.getSize(menu).width, 240.0);
+
+    // Dismiss the menu.
+    await tester.tapAt(Offset.zero);
+    await tester.pumpAndSettle();
+    expect(menu, findsNothing);
+
+    await tester.pumpWidget(
+      buildFrame(
+        alignedDropdown: true,
+        textDirection: TextDirection.ltr,
+      ),
+    );
+    await tester.tap(button);
+    await tester.pumpAndSettle();
+
+    // alignedDropdown: true means the button and menu widths match
+    expect(tester.getSize(button).width, 200.0);
+    expect(tester.getSize(menu).width, 200.0);
+
+    // There are two 'foo' widgets: the selected menu item's label and the drop
+    // down button's label. The should both appear at the same location.
+    final Finder fooText = find.text('foo');
+    expect(fooText, findsNWidgets(2));
+    expect(tester.getTopLeft(fooText.at(0)), tester.getTopLeft(fooText.at(1)));
+
+
+    // Dismiss the menu.
+    await tester.tapAt(Offset.zero);
+    await tester.pumpAndSettle();
+    expect(menu, findsNothing);
+
+    // Same test as above execpt RTL
+    await tester.pumpWidget(
+      buildFrame(
+        alignedDropdown: true,
+        textDirection: TextDirection.rtl,
+      ),
+    );
+    await tester.tap(button);
+    await tester.pumpAndSettle();
+
+    expect(fooText, findsNWidgets(2));
+    expect(tester.getTopRight(fooText.at(0)), tester.getTopRight(fooText.at(1)));
   });
 }


### PR DESCRIPTION
By default dropdown menus are wider than their dropdown button: 16.0 pixels wider on the left, and 24.0 pixels wider on the right.

Setting `ButtonThemeData.alignedDropdown` to true makes dropdown menus the same width as their button. The button's label is padded 16.0 on the left so that the button and menu item labels line up.

```dart
new ButtonTheme(
  alignedDropdown: true,
  child: new DropdownButton( ... ),
)
```

Fixes https://github.com/flutter/flutter/issues/14785