### PR TITLE
Let the FAB compute the notch even when it doesn't overlap the BAB.

### DIFF
--- a/packages/flutter/lib/src/material/bottom_app_bar.dart
+++ b/packages/flutter/lib/src/material/bottom_app_bar.dart
@@ -117,10 +117,6 @@ class _BottomAppBarClipper extends CustomClipper<Path> {
     final Rect button = geometry.value.floatingActionButtonArea
       .translate(0.0, geometry.value.bottomNavigationBarTop * -1.0);
 
-    if (!appBar.overlaps(button)) {
-      return new Path()..addRect(appBar);
-    }
-
     final ComputeNotch computeNotch = geometry.value.floatingActionButtonNotch;
     return new Path()
       ..moveTo(appBar.left, appBar.top)


### PR DESCRIPTION
The Floating Action Button adds some margin around it for the notch.
So we need to compute a notch even when the FAB and the Bottom App Bar
doe not overlap.