### PR TITLE
Fix example code just showing endless spinner when deployed from Windows

### DIFF
--- a/examples/flutter_gallery/lib/gallery/demo.dart
+++ b/examples/flutter_gallery/lib/gallery/demo.dart
@@ -117,7 +117,7 @@ class FullScreenCodeDialogState extends State<FullScreenCodeDialog> {
     getExampleCode(widget.exampleCodeTag, DefaultAssetBundle.of(context)).then<Null>((String code) {
       if (mounted) {
         setState(() {
-          _exampleCode = code;
+          _exampleCode = code ?? 'Example code not found';
         });
       }
     });

--- a/examples/flutter_gallery/lib/gallery/example_code_parser.dart
+++ b/examples/flutter_gallery/lib/gallery/example_code_parser.dart
@@ -46,7 +46,7 @@ Future<Null> _parseExampleCode(AssetBundle bundle) async {
         codeTag = null;
       } else {
         // Add to the current block
-        codeBlock.add(line);
+        codeBlock.add(line.trimRight());
       }
     }
   }

--- a/examples/flutter_gallery/lib/gallery/example_code_parser.dart
+++ b/examples/flutter_gallery/lib/gallery/example_code_parser.dart
@@ -46,6 +46,8 @@ Future<Null> _parseExampleCode(AssetBundle bundle) async {
         codeTag = null;
       } else {
         // Add to the current block
+        // trimRight() to remove any \r on Windows
+        // without removing any useful indentation
         codeBlock.add(line.trimRight());
       }
     }

--- a/examples/flutter_gallery/lib/gallery/example_code_parser.dart
+++ b/examples/flutter_gallery/lib/gallery/example_code_parser.dart
@@ -33,7 +33,7 @@ Future<Null> _parseExampleCode(AssetBundle bundle) async {
       if (line.startsWith(_kStartTag)) {
         // Starting a new code block.
         codeBlock = <String>[];
-        codeTag = line.substring(_kStartTag.length);
+        codeTag = line.substring(_kStartTag.length).trim();
       } else {
         // Just skipping the line.
       }

--- a/examples/flutter_gallery/test/example_code_parser_test.dart
+++ b/examples/flutter_gallery/test/example_code_parser_test.dart
@@ -18,6 +18,9 @@ void main() {
 
     final String codeSnippet1 = await getExampleCode('test_1', bundle);
     expect(codeSnippet1, 'test 1 0\ntest 1 1');
+
+    final String codeSnippet3 = await getExampleCode('test_2_windows_breaks', bundle);
+    expect(codeSnippet3, 'windows test 2 0\nwindows test 2 1');
   });
 }
 
@@ -32,6 +35,8 @@ test 0 1
 test 1 0
 test 1 1
 // END
+
+// START test_2_windows_breaks\r\nwindows test 2 0\r\nwindows test 2 1\r\n// END
 ''';
 
 class TestAssetBundle extends AssetBundle {


### PR DESCRIPTION
Fixes #14820. The issue is that the code is split be `\n` and then put into a map. On Windows the key has a trailing `\r` which means the lookups don't find any code.

I made two changes:

1. If the code is not found, display a message rather than leaving it as null (which keeps the spinner visible)
2. Trim the code label before putting into the map

Happy to tweak this if you don't think they're the best fixes.