### PR TITLE
Add .dart_tool to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ version
 
 # Flutter/Dart/Pub related
 **/doc/api/
+.dart_tool/
 .flutter-plugins
 .packages
 .pub-cache/

--- a/dev/tools/vitool/.gitignore
+++ b/dev/tools/vitool/.gitignore
@@ -1,4 +1,5 @@
 # Files and directories created by pub
+.dart_tool/
 .packages
 .pub/
 build/

--- a/packages/flutter_tools/templates/create/.gitignore.tmpl
+++ b/packages/flutter_tools/templates/create/.gitignore.tmpl
@@ -1,5 +1,6 @@
 .DS_Store
 .atom/
+.dart_tool/
 .idea
 .vscode/
 .packages

--- a/packages/flutter_tools/templates/package/.gitignore.tmpl
+++ b/packages/flutter_tools/templates/package/.gitignore.tmpl
@@ -1,5 +1,6 @@
 .DS_Store
 .atom/
+.dart_tool/
 .idea
 .packages
 .pub/

--- a/packages/flutter_tools/templates/plugin/.gitignore.tmpl
+++ b/packages/flutter_tools/templates/plugin/.gitignore.tmpl
@@ -1,5 +1,6 @@
 .DS_Store
 .atom/
+.dart_tool/
 .idea
 .packages
 .pub/


### PR DESCRIPTION
Dart is migrating to .dart_tool/ as the location for cached artifacts
and other temporary files generated by tooling in the SDK. As part of
this, pub will be migrating from .pub to .dart_tool/pub.

In future, this path will also be used for other tooling, such as package:build.