### PR TITLE
Allow changing a clipper's type (ShapeBorderClipper,_BottomAppBarClipper).

### DIFF
--- a/packages/flutter/lib/src/material/bottom_app_bar.dart
+++ b/packages/flutter/lib/src/material/bottom_app_bar.dart
@@ -152,7 +152,11 @@ class _BottomAppBarClipper extends CustomClipper<Path> {
   }
 
   @override
-  bool shouldReclip(covariant _BottomAppBarClipper oldClipper) {
-    return oldClipper.geometry != geometry;
+  bool shouldReclip(CustomClipper<Path> oldClipper) {
+    if (oldClipper.runtimeType != _BottomAppBarClipper)
+      return true;
+
+    final _BottomAppBarClipper typedOldClipper = oldClipper;
+    return typedOldClipper.geometry != geometry;
   }
 }

--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -1080,8 +1080,11 @@ class ShapeBorderClipper extends CustomClipper<Path> {
   }
 
   @override
-  bool shouldReclip(covariant ShapeBorderClipper oldClipper) {
-    return oldClipper.shape != shape;
+  bool shouldReclip(CustomClipper<Path> oldClipper) {
+    if (oldClipper.runtimeType != ShapeBorderClipper)
+      return true;
+    final ShapeBorderClipper typedOldClipper = oldClipper;
+    return typedOldClipper.shape != shape;
   }
 }
 

--- a/packages/flutter/test/material/bottom_app_bar_test.dart
+++ b/packages/flutter/test/material/bottom_app_bar_test.dart
@@ -86,6 +86,9 @@ void main() {
     expect(physicalShape.color, const Color(0xff0000ff));
   });
 
+  // This is a regression test for a bug we had where toggling hasNotch
+  // will crash, as the shouldReclip method of ShapeBorderClipper or
+  // _BottomAppBarClipper will try an illegal downcast.
   testWidgets('toggle hasNotch', (WidgetTester tester) async {
     await tester.pumpWidget(
       new MaterialApp(

--- a/packages/flutter/test/material/bottom_app_bar_test.dart
+++ b/packages/flutter/test/material/bottom_app_bar_test.dart
@@ -86,6 +86,37 @@ void main() {
     expect(physicalShape.color, const Color(0xff0000ff));
   });
 
+  testWidgets('toggle hasNotch', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      new MaterialApp(
+        home: const Scaffold(
+          bottomNavigationBar: const BottomAppBar(
+            hasNotch: true,
+          ),
+        ),
+      ),
+    );
+
+    await tester.pumpWidget(
+      new MaterialApp(
+        home: const Scaffold(
+          bottomNavigationBar: const BottomAppBar(
+            hasNotch: false,
+          ),
+        ),
+      ),
+    );
+
+    await tester.pumpWidget(
+      new MaterialApp(
+        home: const Scaffold(
+          bottomNavigationBar: const BottomAppBar(
+            hasNotch: true,
+          ),
+        ),
+      ),
+    );
+  });
   // TODO(amirh): test a BottomAppBar with hasNotch=false and an overlapping
   // FAB.
   //


### PR DESCRIPTION
The downcast was crashing when toggling hasNotch for BottomAppBar.