### PR TITLE
Fix cases where previewDart2 and trackWidgetCreation were accidentally missed due to named parameters being omitted.

### DIFF
--- a/packages/flutter_tools/lib/src/commands/daemon.dart
+++ b/packages/flutter_tools/lib/src/commands/daemon.dart
@@ -5,6 +5,8 @@
 import 'dart:async';
 import 'dart:convert';
 
+import 'package:meta/meta.dart';
+
 import '../android/android_device.dart';
 import '../base/common.dart';
 import '../base/context.dart';
@@ -333,6 +335,8 @@ class AppDomain extends Domain {
       route,
       options,
       enableHotReload,
+      previewDart2: _getBoolArg(args, 'preview-dart-2'),
+      trackWidgetCreation: _getBoolArg(args, 'track-widget-creation'),
     );
 
     return <String, dynamic>{
@@ -347,7 +351,8 @@ class AppDomain extends Domain {
     Device device, String projectDirectory, String target, String route,
     DebuggingOptions options, bool enableHotReload, {
     String applicationBinary,
-    bool previewDart2: false,
+    @required bool previewDart2,
+    @required bool trackWidgetCreation,
     String projectRootPath,
     String packagesFilePath,
     bool ipv6: false,
@@ -360,7 +365,11 @@ class AppDomain extends Domain {
     final Directory cwd = fs.currentDirectory;
     fs.currentDirectory = fs.directory(projectDirectory);
 
-    final FlutterDevice flutterDevice = new FlutterDevice(device, previewDart2: previewDart2);
+    final FlutterDevice flutterDevice = new FlutterDevice(
+      device,
+      previewDart2: previewDart2,
+      trackWidgetCreation: trackWidgetCreation,
+    );
 
     ResidentRunner runner;
 

--- a/packages/flutter_tools/lib/src/commands/fuchsia_reload.dart
+++ b/packages/flutter_tools/lib/src/commands/fuchsia_reload.dart
@@ -129,7 +129,11 @@ class FuchsiaReloadCommand extends FlutterCommand {
       ).toList();
       final FuchsiaDevice device = new FuchsiaDevice(
           fullAddresses[0], name: _address);
-      final FlutterDevice flutterDevice = new FlutterDevice(device);
+      final FlutterDevice flutterDevice = new FlutterDevice(
+        device,
+        trackWidgetCreation: false,
+        previewDart2: false,
+      );
       flutterDevice.observatoryUris = observatoryUris;
       final HotRunner hotRunner = new HotRunner(
         <FlutterDevice>[flutterDevice],

--- a/packages/flutter_tools/lib/src/commands/run.dart
+++ b/packages/flutter_tools/lib/src/commands/run.dart
@@ -260,6 +260,7 @@ class RunCommand extends RunCommandBase {
           _createDebuggingOptions(), hotMode,
           applicationBinary: argResults['use-application-binary'],
           previewDart2: argResults['preview-dart-2'],
+          trackWidgetCreation: argResults['track-widget-creation'],
           projectRootPath: argResults['project-root'],
           packagesFilePath: globalResults['packages'],
           ipv6: ipv6,

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -39,8 +39,8 @@ class FlutterDevice {
   StreamSubscription<String> _loggingSubscription;
 
   FlutterDevice(this.device, {
-    bool previewDart2: false,
-    bool trackWidgetCreation: false,
+    @required bool previewDart2,
+    @required bool trackWidgetCreation,
   }) {
     if (previewDart2) {
       generator = new ResidentCompiler(

--- a/packages/flutter_tools/test/resident_runner_test.dart
+++ b/packages/flutter_tools/test/resident_runner_test.dart
@@ -51,7 +51,11 @@ void main() {
     // Currently the TestRunner is not properly configured to be able to run
     // with `previewDart2: true` due to missing resources.
     testRunner = new TestRunner(
-        <FlutterDevice>[new FlutterDevice(new MockDevice())]
+      <FlutterDevice>[new FlutterDevice(
+        new MockDevice(),
+        previewDart2: false,
+        trackWidgetCreation: false,
+      )],
     );
   });
 


### PR DESCRIPTION
This issue has cropped up a couple times now in flutter_tool so I think it is reasonable to force the
parameters to be required.
Omitting these parameters means someone forgot to flow the parameters through the system from
arguments to classes doing the actual work.