### PR TITLE
Don't push again on beta branch commit

### DIFF
--- a/dev/bots/travis_script.sh
+++ b/dev/bots/travis_script.sh
@@ -11,7 +11,7 @@ if [ "$SHARD" = "build_and_deploy_gallery" ]; then
     export ANDROID_HOME=`pwd`/android-sdk
     (cd examples/flutter_gallery; flutter build apk --release)
     echo "Android Flutter Gallery built"
-    if [[ "$TRAVIS_PULL_REQUEST" == "false" && ("$TRAVIS_BRANCH" == "dev" || "$TRAVIS_BRANCH" == "beta") ]]; then
+    if [[ "$TRAVIS_PULL_REQUEST" == "false" && "$TRAVIS_BRANCH" == "dev" ]]; then
       echo "Deploying to Play Store..."
       (cd examples/flutter_gallery/android; bundle install && bundle exec fastlane deploy_play_store)
     else
@@ -21,7 +21,7 @@ if [ "$SHARD" = "build_and_deploy_gallery" ]; then
     echo "Building Flutter Gallery for iOS..."
     (cd examples/flutter_gallery; flutter build ios --release --no-codesign)
     echo "iOS Flutter Gallery built"
-    if [[ "$TRAVIS_PULL_REQUEST" == "false" && ("$TRAVIS_BRANCH" == "dev" || "$TRAVIS_BRANCH" == "beta") ]]; then
+    if [[ "$TRAVIS_PULL_REQUEST" == "false" && "$TRAVIS_BRANCH" == "dev" ]]; then
       echo "Re-building with distribution profile and deploying to TestFlight..."
       (cd examples/flutter_gallery/ios; bundle install && bundle exec fastlane build_and_deploy_testflight)
     else

--- a/examples/flutter_gallery/android/fastlane/Fastfile
+++ b/examples/flutter_gallery/android/fastlane/Fastfile
@@ -11,7 +11,7 @@ platform :android do
   lane :deploy_play_store do
     begin
       upload_to_play_store(
-        track: ENV['TRAVIS_BRANCH'] == 'beta' ? 'beta' : 'alpha',
+        track: 'alpha',
         apk: '../build/app/outputs/apk/release/app-release.apk',
         json_key_data: ENV['GOOGLE_DEVELOPER_SERVICE_ACCOUNT_ACTOR_FASTLANE'],
         skip_upload_screenshots: true,


### PR DESCRIPTION
The build and deploy on beta is redundant since the binaries for that release is already in the Play Store / iTunes. The release needs a promotion rather than a re-deploy. 

Will also prevent failures on iOS where I can't detect version collisions with Fastlane