### PR TITLE
Improve error message for missing 32-bit libstc++

### DIFF
--- a/packages/flutter_tools/lib/src/doctor.dart
+++ b/packages/flutter_tools/lib/src/doctor.dart
@@ -242,10 +242,15 @@ class _FlutterValidator extends DoctorValidator {
 
     // Check that the binaries we downloaded for this platform actually run on it.
     if (!_genSnapshotRuns(genSnapshotPath)) {
-      messages.add(new ValidationMessage.error(
-        'Downloaded executables cannot execute '
-        'on host (see https://github.com/flutter/flutter/issues/6207 for more information)'
-      ));
+      final StringBuffer buf = new StringBuffer();
+      buf.writeln('Downloaded executables cannot execute on host.');
+      buf.writeln('See https://github.com/flutter/flutter/issues/6207 for more information');
+      if (platform.isLinux) {
+        buf.writeln('On Debian/Ubuntu/Mint: sudo apt-get install lib32stdc++6');
+        buf.writeln('On Fedora: dnf install libstdc++.i686');
+        buf.writeln('On Arch: pacman -S lib32-libstdc++5');
+      }
+      messages.add(new ValidationMessage.error(buf.toString()));
       valid = ValidationType.partial;
     }
 


### PR DESCRIPTION
Adds more actionable error messages for users of the most common Linux
distributions. We could improve this by checking the current
distribution and emitting only the appropriate error message. We could
further improve that by only emitting the install instructions if we
determine the appropriate package is not installed.

See: https://github.com/flutter/flutter/issues/6207