### PR TITLE
Improve SDK search error messages

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_sdk.dart
+++ b/packages/flutter_tools/lib/src/android/android_sdk.dart
@@ -212,9 +212,6 @@ class AndroidSdk {
     if(latestVersion == null)
       return <String>['No latest version of Android SDK found (check SDK for standard layout).'];
 
-    if (sdkVersions.isEmpty || latestVersion == null)
-      return <String>['Android SDK is missing command line tools; download from https://goo.gl/XxQghQ'];
-
     return latestVersion.validateSdkWellFormed();
   }
 

--- a/packages/flutter_tools/lib/src/android/android_sdk.dart
+++ b/packages/flutter_tools/lib/src/android/android_sdk.dart
@@ -207,10 +207,10 @@ class AndroidSdk {
       return <String>['Android SDK file not found: $adbPath.'];
 
     if (sdkVersions.isEmpty)
-      return <String>['No Android SDK version found.'];
+      return <String>['No Android SDK version found (check SDK for standard layout).'];
     
     if(latestVersion == null)
-      return <String>['No latest version of Android SDK found.'];
+      return <String>['No latest version of Android SDK found (check SDK for standard layout).'];
 
     if (sdkVersions.isEmpty || latestVersion == null)
       return <String>['Android SDK is missing command line tools; download from https://goo.gl/XxQghQ'];

--- a/packages/flutter_tools/lib/src/android/android_sdk.dart
+++ b/packages/flutter_tools/lib/src/android/android_sdk.dart
@@ -206,6 +206,12 @@ class AndroidSdk {
     if (!processManager.canRun(adbPath))
       return <String>['Android SDK file not found: $adbPath.'];
 
+    if (sdkVersions.isEmpty)
+      return <String>['No Android SDK version found.'];
+    
+    if(latestVersion == null)
+      return <String>['No latest version of Android SDK found.'];
+
     if (sdkVersions.isEmpty || latestVersion == null)
       return <String>['Android SDK is missing command line tools; download from https://goo.gl/XxQghQ'];
 


### PR DESCRIPTION
On many platforms with non-standard sdk packages current error messages do not give a clue.
This PR improves error messages slightly.