### PR TITLE
Fix call to `git checkout`

### DIFF
--- a/packages/flutter_tools/lib/src/commands/channel.dart
+++ b/packages/flutter_tools/lib/src/commands/channel.dart
@@ -108,7 +108,7 @@ class ChannelCommand extends FlutterCommand {
       if (result == 0) {
         // branch already exists, try just switching to it
         result = await runCommandAndStreamOutput(
-          <String>['git', 'checkout', branchName],
+          <String>['git', 'checkout', branchName, '--'],
           workingDirectory: Cache.flutterRoot,
           prefix: 'git: ',
         );


### PR DESCRIPTION
In the case of "dev", `git checkout dev` could be miconstrued
as checking out the dev _directory_ rather than the branch...

https://github.com/flutter/flutter/issues/14865