### PR TITLE
Improve robustness of --version parsing for sdkmanager

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_sdk.dart
+++ b/packages/flutter_tools/lib/src/android/android_sdk.dart
@@ -347,7 +347,8 @@ class AndroidSdk {
       throwToolExit('Android sdkmanager not found. Update to the latest Android SDK to resolve this.');
     final ProcessResult result = processManager.runSync(<String>[sdkManagerPath, '--version'], environment: sdkManagerEnv);
     if (result.exitCode != 0) {
-      throwToolExit('sdkmanager --version failed: ${result.exitCode}', exitCode: result.exitCode);
+      printTrace('sdkmanager --version failed: exitCode: ${result.exitCode} stdout: ${result.stdout} stderr: ${result.stderr}');
+      return null;
     }
     return result.stdout.trim();
   }

--- a/packages/flutter_tools/lib/src/android/android_workflow.dart
+++ b/packages/flutter_tools/lib/src/android/android_workflow.dart
@@ -213,7 +213,7 @@ class AndroidWorkflow extends DoctorValidator implements Workflow {
       );
 
     final Version sdkManagerVersion = new Version.parse(androidSdk.sdkManagerVersion);
-    if (sdkManagerVersion.major < 26)
+    if (sdkManagerVersion == null || sdkManagerVersion.major < 26)
       // SDK manager is found, but needs to be updated.
       throwToolExit(
         'A newer version of the Android SDK is required. To update, run:\n'

--- a/packages/flutter_tools/test/android/android_sdk_test.dart
+++ b/packages/flutter_tools/test/android/android_sdk_test.dart
@@ -81,7 +81,7 @@ void main() {
       ProcessManager: () => processManager,
     });
 
-    testUsingContext('throws on sdkmanager version check failure', () {
+    testUsingContext('does not throw on sdkmanager version check failure', () {
       sdkDir = MockAndroidSdk.createSdkDirectory();
       Config.instance.setValue('android-sdk', sdkDir.path);
 
@@ -89,7 +89,7 @@ void main() {
       when(processManager.canRun(sdk.sdkManagerPath)).thenReturn(true);
       when(processManager.runSync(<String>[sdk.sdkManagerPath, '--version'], environment: argThat(isNotNull)))
           .thenReturn(new ProcessResult(1, 1, '26.1.1\n', 'Mystery error'));
-      expect(() => sdk.sdkManagerVersion, throwsToolExit(exitCode: 1));
+      expect(sdk.sdkManagerVersion, isNull);
     }, overrides: <Type, Generator>{
       FileSystem: () => fs,
       ProcessManager: () => processManager,

--- a/packages/flutter_tools/test/android/android_workflow_test.dart
+++ b/packages/flutter_tools/test/android/android_workflow_test.dart
@@ -132,7 +132,21 @@ void main() {
     when(sdk.sdkManagerPath).thenReturn('/foo/bar/sdkmanager');
     when(sdk.sdkManagerVersion).thenReturn('25.0.0');
 
-    expect(AndroidWorkflow.runLicenseManager(), throwsToolExit());
+    expect(AndroidWorkflow.runLicenseManager(), throwsToolExit(message: 'To update, run'));
+  }, overrides: <Type, Generator>{
+    AndroidSdk: () => sdk,
+    FileSystem: () => fs,
+    Platform: () => new FakePlatform()..environment = <String, String>{'HOME': '/home/me'},
+    ProcessManager: () => processManager,
+    Stdio: () => stdio,
+  });
+
+  testUsingContext('runLicenseManager errors correctly for null version', () async {
+    MockAndroidSdk.createSdkDirectory();
+    when(sdk.sdkManagerPath).thenReturn('/foo/bar/sdkmanager');
+    when(sdk.sdkManagerVersion).thenReturn(null);
+
+    expect(AndroidWorkflow.runLicenseManager(), throwsToolExit(message: 'To update, run'));
   }, overrides: <Type, Generator>{
     AndroidSdk: () => sdk,
     FileSystem: () => fs,


### PR DESCRIPTION
Fixes #9959.  #14249 helps flutter run the right command for accepting licenses, but it throws with an unhelpful error message if sdkmanager doesn't support --version.  Some extremely old sdkmanagers don't support this.

Fixes this by displaying the same message for old versions as for sdkmanagers that don't support --versions.  An alternative would be to display a "your sdkmanager is broken" message and also encourage updating, but I wonder if that would be too complicated?  Comments welcome.