### PR TITLE
Fix incorrect generic type specification

### DIFF
--- a/packages/flutter/lib/src/widgets/overlay.dart
+++ b/packages/flutter/lib/src/widgets/overlay.dart
@@ -519,7 +519,7 @@ class _TheatreElement extends RenderObjectElement {
 // children of its primary subtree's stack can be moved to this object's list
 // of zombie children without changing their parent data objects.
 class _RenderTheatre extends RenderBox
-  with RenderObjectWithChildMixin<RenderStack>, RenderProxyBoxMixin<RenderBox>,
+  with RenderObjectWithChildMixin<RenderStack>, RenderProxyBoxMixin<RenderStack>,
        ContainerRenderObjectMixin<RenderBox, StackParentData> {
 
   @override


### PR DESCRIPTION
This incorrect specification produces the following error when a hot reload is done after modifying any file in flutter packages.
```
Initializing hot reload...                                       
compiler message: file:///usr/local/google/home/asiva/workspace/flutter-roll/flutter/packages/flutter/lib/src/widgets/overlay.dart: Error: The parameter 'value' of the method '_RenderTheatre::child' has type #lib1::RenderStack, which does not match the corresponding type in the overridden method (#lib2::RenderBox).
compiler message: Change to a supertype of #lib2::RenderBox (or, for a covariant parameter, a subtype).
compiler message: file:///usr/local/google/home/asiva/workspace/flutter-roll/flutter/packages/flutter/lib/src/rendering/object.dart: Context: This is the overriden method ('child').
Reloaded 237 of 561 libraries in 6,005ms.

```