### PR TITLE
Adding edge avoidance, painting tests, general cleanup

### DIFF
--- a/packages/flutter/lib/src/material/slider.dart
+++ b/packages/flutter/lib/src/material/slider.dart
@@ -51,7 +51,10 @@ import 'theme.dart';
 /// given unbounded constraints, it will attempt to make the rail 144 pixels
 /// wide (with margins on each side) and will shrink-wrap vertically.
 ///
-/// Requires one of its ancestors to be a [Material] widget.
+/// Both [Material] and [MediaQuery] widgets are required to be present as
+/// ancestors for this widget. Typically, these are introduced by the
+/// [MaterialApp] or [WidgetsApp] widget at the top of your application widget
+/// tree.
 ///
 /// To determine how it should be displayed (e.g. colors, thumb shape, etc.),
 /// a slider uses the [SliderThemeData] available from either a [SliderTheme]
@@ -67,13 +70,16 @@ import 'theme.dart';
 ///  * [Radio], for selecting among a set of explicit values.
 ///  * [Checkbox] and [Switch], for toggling a particular value on or off.
 ///  * <https://material.google.com/components/sliders.html>
+///  * [MediaQuery], from which the text scale factor is obtained.
+
 class Slider extends StatefulWidget {
   /// Creates a material design slider.
   ///
   /// The slider itself does not maintain any state. Instead, when the state of
-  /// the slider changes, the widget calls the [onChanged] callback. Most widgets
-  /// that use a slider will listen for the [onChanged] callback and rebuild the
-  /// slider with a new [value] to update the visual appearance of the slider.
+  /// the slider changes, the widget calls the [onChanged] callback. Most
+  /// widgets that use a slider will listen for the [onChanged] callback and
+  /// rebuild the slider with a new [value] to update the visual appearance of
+  /// the slider.
   ///
   /// * [value] determines currently selected value for this slider.
   /// * [onChanged] is called when the user selects a new value for the slider.
@@ -268,6 +274,7 @@ class _SliderState extends State<Slider> with TickerProviderStateMixin {
   @override
   Widget build(BuildContext context) {
     assert(debugCheckHasMaterial(context));
+    assert(debugCheckHasMediaQuery(context));
 
     SliderThemeData sliderTheme = SliderTheme.of(context);
 
@@ -291,7 +298,7 @@ class _SliderState extends State<Slider> with TickerProviderStateMixin {
       divisions: widget.divisions,
       label: widget.label,
       sliderTheme: sliderTheme,
-      mediaQueryData: MediaQuery.of(context, nullOk: true),
+      mediaQueryData: MediaQuery.of(context),
       onChanged: (widget.onChanged != null) && (widget.max > widget.min) ? _handleChanged : null,
       state: this,
     );
@@ -395,9 +402,10 @@ class _RenderSlider extends RenderBox {
       ..onTapUp = _handleTapUp
       ..onTapCancel = _endInteraction;
 
-    // Don't need to call removeListener on these because this object and the
-    // state have a 1:1 relationship, and state has a more finite lifetime, so
-    // the animation controllers will be disposed of before these are.
+    // We don't need to call removeListener on these because this render object
+    // and the state have a 1:1 relationship, the state has a more finite
+    // lifetime, and so this render object is never used again after the state
+    // is disposed.
     _reaction = new CurvedAnimation(
       parent: state.reactionController,
       curve: Curves.fastOutSlowIn,

--- a/packages/flutter/lib/src/material/slider.dart
+++ b/packages/flutter/lib/src/material/slider.dart
@@ -401,22 +401,6 @@ class _RenderSlider extends RenderBox {
       ..onTapDown = _handleTapDown
       ..onTapUp = _handleTapUp
       ..onTapCancel = _endInteraction;
-
-    // We don't need to call removeListener on these because this render object
-    // and the state have a 1:1 relationship, the state has a more finite
-    // lifetime, and so this render object is never used again after the state
-    // is disposed.
-    _reaction = new CurvedAnimation(
-      parent: state.reactionController,
-      curve: Curves.fastOutSlowIn,
-    )..addListener(markNeedsPaint);
-    state.enableController.value = isInteractive ? 1.0 : 0.0;
-    _enableAnimation = new CurvedAnimation(
-      parent: state.enableController,
-      curve: Curves.easeInOut,
-    )..addListener(markNeedsPaint);
-    state.positionController.value = _value;
-    state.positionController.addListener(markNeedsPaint);
   }
 
   double get value => _value;
@@ -556,6 +540,30 @@ class _RenderSlider extends RenderBox {
   bool get isInteractive => onChanged != null;
 
   bool get isDiscrete => divisions != null && divisions > 0;
+
+  @override
+  void attach(PipelineOwner owner) {
+    super.attach(owner);
+    _reaction = new CurvedAnimation(
+      parent: _state.reactionController,
+      curve: Curves.fastOutSlowIn,
+    )..addListener(markNeedsPaint);
+    _state.enableController.value = isInteractive ? 1.0 : 0.0;
+    _enableAnimation = new CurvedAnimation(
+      parent: _state.enableController,
+      curve: Curves.easeInOut,
+    )..addListener(markNeedsPaint);
+    _state.positionController.value = _value;
+    _state.positionController.addListener(markNeedsPaint);
+  }
+
+  @override
+  void detach() {
+    super.detach();
+    _reaction.removeListener(markNeedsPaint);
+    _enableAnimation.removeListener(markNeedsPaint);
+    _state.positionController.removeListener(markNeedsPaint);
+  }
 
   double _getValueFromVisualPosition(double visualPosition) {
     switch (textDirection) {

--- a/packages/flutter/lib/src/material/slider_theme.dart
+++ b/packages/flutter/lib/src/material/slider_theme.dart
@@ -51,25 +51,25 @@ class SliderTheme extends InheritedWidget {
   /// ## Sample code
   ///
   /// ```dart
-  /// class Catatonic extends StatefulWidget {
+  /// class Launch extends StatefulWidget {
   ///   @override
-  ///   State createState() => new CatatonicState();
+  ///   State createState() => new LaunchState();
   /// }
   /// 
-  /// class CatatonicState extends State<Catatonic> {
-  ///   double _howLong;
+  /// class LaunchState extends State<Launch> {
+  ///   double _rocketThrust;
   /// 
   ///   @override
   ///   Widget build(BuildContext context) {
   ///     return new SliderTheme(
   ///       data: SliderTheme.of(context).copyWith(activeRailColor: const Color(0xff804040)),
   ///       child: new Slider(
-  ///         onChanged: (double value) => setState(() => _howLong = value),
-  ///         value: _howLong,
+  ///         onChanged: (double value) { setState(() { _rocketThrust = value; }); },
+  ///         value: _rocketThrust,
   ///       ),
   ///     );
   ///   }
-  /// }  
+  /// }
   /// ```
   ///
   /// See also:
@@ -171,7 +171,7 @@ class SliderThemeData extends Diagnosticable {
   ///     return new SliderTheme(
   ///       data: SliderTheme.of(context).copyWith(activeRailColor: const Color(0xff404080)),
   ///       child: new Slider(
-  ///         onChanged: (double value) => setState(() => _bliss = value),
+  ///         onChanged: (double value) { setState(() { _bliss = value; }); },
   ///         value: _bliss,
   ///       ),
   ///     );

--- a/packages/flutter/lib/src/material/slider_theme.dart
+++ b/packages/flutter/lib/src/material/slider_theme.dart
@@ -9,7 +9,6 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 
-import 'colors.dart';
 import 'theme.dart';
 import 'theme_data.dart';
 
@@ -49,21 +48,28 @@ class SliderTheme extends InheritedWidget {
   /// Defaults to the ambient [ThemeData.sliderTheme] if there is no
   /// [SliderTheme] in the given build context.
   ///
-  /// Typical usage is as follows:
+  /// ## Sample code
   ///
   /// ```dart
-  /// double _rocketThrust;
-  ///
-  /// @override
-  /// Widget build(BuildContext context) {
-  ///   return new SliderTheme(
-  ///     data: SliderTheme.of(context).copyWith(activeRail: Colors.orange),
-  ///     child: new Slider(
-  ///       onChanged: (double value) => setState(() => _rocketThrust = value),
-  ///       value: _rocketThrust;
-  ///     ),
-  ///   );
+  /// class Catatonic extends StatefulWidget {
+  ///   @override
+  ///   State createState() => new CatatonicState();
   /// }
+  /// 
+  /// class CatatonicState extends State<Catatonic> {
+  ///   double _howLong;
+  /// 
+  ///   @override
+  ///   Widget build(BuildContext context) {
+  ///     return new SliderTheme(
+  ///       data: SliderTheme.of(context).copyWith(activeRailColor: const Color(0xff804040)),
+  ///       child: new Slider(
+  ///         onChanged: (double value) => setState(() => _howLong = value),
+  ///         value: _howLong,
+  ///       ),
+  ///     );
+  ///   }
+  /// }  
   /// ```
   ///
   /// See also:
@@ -147,7 +153,31 @@ class SliderThemeData extends Diagnosticable {
   ///
   /// The simplest way to create a SliderThemeData is to use
   /// [copyWith] on the one you get from [SliderTheme.of], or create an
-  /// entirely new one with [SliderThemeData.materialDefaults].
+  /// entirely new one with [SliderThemeData.fromPrimaryColors].
+  ///
+  /// ## Sample code
+  ///
+  /// ```dart
+  /// class Blissful extends StatefulWidget {
+  ///   @override
+  ///   State createState() => new BlissfulState();
+  /// }
+  ///
+  /// class BlissfulState extends State<Blissful> {
+  ///   double _bliss;
+  ///
+  ///   @override
+  ///   Widget build(BuildContext context) {
+  ///     return new SliderTheme(
+  ///       data: SliderTheme.of(context).copyWith(activeRailColor: const Color(0xff404080)),
+  ///       child: new Slider(
+  ///         onChanged: (double value) => setState(() => _bliss = value),
+  ///         value: _bliss,
+  ///       ),
+  ///     );
+  ///   }
+  /// }
+  /// ```
   const SliderThemeData({
     @required this.activeRailColor,
     @required this.inactiveRailColor,
@@ -189,7 +219,7 @@ class SliderThemeData extends Diagnosticable {
   /// defaults when assigning them to the slider theme component colors.
   ///
   /// This is used to generate the default slider theme for a [ThemeData].
-  factory SliderThemeData.materialDefaults({
+  factory SliderThemeData.fromPrimaryColors({
     @required Color primaryColor,
     @required Color primaryColorDark,
     @required Color primaryColorLight,
@@ -238,22 +268,69 @@ class SliderThemeData extends Diagnosticable {
     );
   }
 
+  /// The color of the [Slider] rail between the [Slider.min] position and the
+  /// current thumb position.
   final Color activeRailColor;
+
+  /// The color of the [Slider] rail between the current thumb position and the
+  /// [Slider.max] position.
   final Color inactiveRailColor;
+
+  /// The color of the [Slider] rail between the [Slider.min] position and the
+  /// current thumb position when the [Slider] is disabled.
   final Color disabledActiveRailColor;
+
+  /// The color of the [Slider] rail between the current thumb position and the
+  /// [Slider.max] position when the [Slider] is disabled.
   final Color disabledInactiveRailColor;
+
+  /// The color of the rail's tick marks that are drawn between the [Slider.min]
+  /// position and the current thumb position.
   final Color activeTickMarkColor;
+
+  /// The color of the rail's tick marks that are drawn between the current
+  /// thumb position and the [Slider.max] position.
   final Color inactiveTickMarkColor;
+
+  /// The color of the rail's tick marks that are drawn between the [Slider.min]
+  /// position and the current thumb position when the [Slider] is disabled.
   final Color disabledActiveTickMarkColor;
+
+  /// The color of the rail's tick marks that are drawn between the current
+  /// thumb position and the [Slider.max] position when the [Slider] is
+  /// disabled.
   final Color disabledInactiveTickMarkColor;
+
+  /// The color given to the [thumbShape] to draw itself with.
   final Color thumbColor;
+
+  /// The color given to the [thumbShape] to draw itself with when the
+  /// [Slider] is disabled.
   final Color disabledThumbColor;
+
+  /// The color of the overlay drawn around the slider thumb when it is pressed.
+  ///
+  /// This is typically a semi-transparent color.
   final Color overlayColor;
+
+  /// The color given to the [valueIndicatorShape] to draw itself with.
   final Color valueIndicatorColor;
+
+  /// The shape and behavior that will be used to draw the [Slider]'s thumb.
+  ///
+  /// This can be customized by implementing a subclass of
+  /// [SliderComponentShape].
   final SliderComponentShape thumbShape;
+
+  /// The shape and behavior that will be used to draw the [Slider]'s value
+  /// indicator.
+  ///
+  /// This can be customized by implementing a subclass of
+  /// [SliderComponentShape].
   final SliderComponentShape valueIndicatorShape;
 
-  /// Whether the value indicator should be shown for different types of sliders.
+  /// Whether the value indicator should be shown for different types of
+  /// sliders.
   ///
   /// By default, [showValueIndicator] is set to
   /// [ShowValueIndicator.onlyForDiscrete]. The value indicator is only shown
@@ -285,8 +362,7 @@ class SliderThemeData extends Diagnosticable {
       activeTickMarkColor: activeTickMarkColor ?? this.activeTickMarkColor,
       inactiveTickMarkColor: inactiveTickMarkColor ?? this.inactiveTickMarkColor,
       disabledActiveTickMarkColor: disabledActiveTickMarkColor ?? this.disabledActiveTickMarkColor,
-      disabledInactiveTickMarkColor:
-          disabledInactiveTickMarkColor ?? this.disabledInactiveTickMarkColor,
+      disabledInactiveTickMarkColor: disabledInactiveTickMarkColor ?? this.disabledInactiveTickMarkColor,
       thumbColor: thumbColor ?? this.thumbColor,
       disabledThumbColor: disabledThumbColor ?? this.disabledThumbColor,
       overlayColor: overlayColor ?? this.overlayColor,
@@ -320,14 +396,11 @@ class SliderThemeData extends Diagnosticable {
       activeRailColor: Color.lerp(a.activeRailColor, b.activeRailColor, t),
       inactiveRailColor: Color.lerp(a.inactiveRailColor, b.inactiveRailColor, t),
       disabledActiveRailColor: Color.lerp(a.disabledActiveRailColor, b.disabledActiveRailColor, t),
-      disabledInactiveRailColor:
-          Color.lerp(a.disabledInactiveRailColor, b.disabledInactiveRailColor, t),
+      disabledInactiveRailColor: Color.lerp(a.disabledInactiveRailColor, b.disabledInactiveRailColor, t),
       activeTickMarkColor: Color.lerp(a.activeTickMarkColor, b.activeTickMarkColor, t),
       inactiveTickMarkColor: Color.lerp(a.inactiveTickMarkColor, b.inactiveTickMarkColor, t),
-      disabledActiveTickMarkColor:
-          Color.lerp(a.disabledActiveTickMarkColor, b.disabledActiveTickMarkColor, t),
-      disabledInactiveTickMarkColor:
-          Color.lerp(a.disabledInactiveTickMarkColor, b.disabledInactiveTickMarkColor, t),
+      disabledActiveTickMarkColor: Color.lerp(a.disabledActiveTickMarkColor, b.disabledActiveTickMarkColor, t),
+      disabledInactiveTickMarkColor: Color.lerp(a.disabledInactiveTickMarkColor, b.disabledInactiveTickMarkColor, t),
       thumbColor: Color.lerp(a.thumbColor, b.thumbColor, t),
       disabledThumbColor: Color.lerp(a.disabledThumbColor, b.disabledThumbColor, t),
       overlayColor: Color.lerp(a.overlayColor, b.overlayColor, t),
@@ -361,6 +434,9 @@ class SliderThemeData extends Diagnosticable {
 
   @override
   bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
     if (other.runtimeType != runtimeType) {
       return false;
     }
@@ -386,47 +462,26 @@ class SliderThemeData extends Diagnosticable {
   void debugFillProperties(DiagnosticPropertiesBuilder description) {
     super.debugFillProperties(description);
     final ThemeData defaultTheme = new ThemeData.fallback();
-    final SliderThemeData defaultData = new SliderThemeData.materialDefaults(
+    final SliderThemeData defaultData = new SliderThemeData.fromPrimaryColors(
       primaryColor: defaultTheme.primaryColor,
       primaryColorDark: defaultTheme.primaryColorDark,
       primaryColorLight: defaultTheme.primaryColorLight,
     );
-    description.add(new DiagnosticsProperty<Color>('activeRailColor', activeRailColor,
-        defaultValue: defaultData.activeRailColor));
-    description.add(new DiagnosticsProperty<Color>('inactiveRailColor', inactiveRailColor,
-        defaultValue: defaultData.inactiveRailColor));
-    description.add(new DiagnosticsProperty<Color>(
-        'disabledActiveRailColor', disabledActiveRailColor,
-        defaultValue: defaultData.disabledActiveRailColor));
-    description.add(new DiagnosticsProperty<Color>(
-        'disabledInactiveRailColor', disabledInactiveRailColor,
-        defaultValue: defaultData.disabledInactiveRailColor));
-    description.add(new DiagnosticsProperty<Color>('activeTickMarkColor', activeTickMarkColor,
-        defaultValue: defaultData.activeTickMarkColor));
-    description.add(new DiagnosticsProperty<Color>('inactiveTickMarkColor', inactiveTickMarkColor,
-        defaultValue: defaultData.inactiveTickMarkColor));
-    description.add(new DiagnosticsProperty<Color>(
-        'disabledActiveTickMarkColor', disabledActiveTickMarkColor,
-        defaultValue: defaultData.disabledActiveTickMarkColor));
-    description.add(new DiagnosticsProperty<Color>(
-        'disabledInactiveTickMarkColor', disabledInactiveTickMarkColor,
-        defaultValue: defaultData.disabledInactiveTickMarkColor));
-    description.add(new DiagnosticsProperty<Color>('thumbColor', thumbColor,
-        defaultValue: defaultData.thumbColor));
-    description.add(new DiagnosticsProperty<Color>('disabledThumbColor', disabledThumbColor,
-        defaultValue: defaultData.disabledThumbColor));
-    description.add(new DiagnosticsProperty<Color>('overlayColor', overlayColor,
-        defaultValue: defaultData.overlayColor));
-    description.add(new DiagnosticsProperty<Color>('valueIndicatorColor', valueIndicatorColor,
-        defaultValue: defaultData.valueIndicatorColor));
-    description.add(new DiagnosticsProperty<SliderComponentShape>('thumbShape', thumbShape,
-        defaultValue: defaultData.thumbShape));
-    description.add(new DiagnosticsProperty<SliderComponentShape>(
-        'valueIndicatorShape', valueIndicatorShape,
-        defaultValue: defaultData.valueIndicatorShape));
-    description.add(new DiagnosticsProperty<ShowValueIndicator>(
-        'showValueIndicator', showValueIndicator,
-        defaultValue: defaultData.showValueIndicator));
+    description.add(new DiagnosticsProperty<Color>('activeRailColor', activeRailColor, defaultValue: defaultData.activeRailColor));
+    description.add(new DiagnosticsProperty<Color>('inactiveRailColor', inactiveRailColor, defaultValue: defaultData.inactiveRailColor));
+    description.add(new DiagnosticsProperty<Color>('disabledActiveRailColor', disabledActiveRailColor, defaultValue: defaultData.disabledActiveRailColor));
+    description.add(new DiagnosticsProperty<Color>('disabledInactiveRailColor', disabledInactiveRailColor, defaultValue: defaultData.disabledInactiveRailColor));
+    description.add(new DiagnosticsProperty<Color>('activeTickMarkColor', activeTickMarkColor, defaultValue: defaultData.activeTickMarkColor));
+    description.add(new DiagnosticsProperty<Color>('inactiveTickMarkColor', inactiveTickMarkColor, defaultValue: defaultData.inactiveTickMarkColor));
+    description.add(new DiagnosticsProperty<Color>('disabledActiveTickMarkColor', disabledActiveTickMarkColor, defaultValue: defaultData.disabledActiveTickMarkColor));
+    description.add(new DiagnosticsProperty<Color>('disabledInactiveTickMarkColor', disabledInactiveTickMarkColor, defaultValue: defaultData.disabledInactiveTickMarkColor));
+    description.add(new DiagnosticsProperty<Color>('thumbColor', thumbColor, defaultValue: defaultData.thumbColor));
+    description.add(new DiagnosticsProperty<Color>('disabledThumbColor', disabledThumbColor, defaultValue: defaultData.disabledThumbColor));
+    description.add(new DiagnosticsProperty<Color>('overlayColor', overlayColor, defaultValue: defaultData.overlayColor));
+    description.add(new DiagnosticsProperty<Color>('valueIndicatorColor', valueIndicatorColor, defaultValue: defaultData.valueIndicatorColor));
+    description.add(new DiagnosticsProperty<SliderComponentShape>('thumbShape', thumbShape, defaultValue: defaultData.thumbShape));
+    description.add(new DiagnosticsProperty<SliderComponentShape>('valueIndicatorShape', valueIndicatorShape, defaultValue: defaultData.valueIndicatorShape));
+    description.add(new DiagnosticsProperty<ShowValueIndicator>('showValueIndicator', showValueIndicator, defaultValue: defaultData.showValueIndicator));
   }
 }
 
@@ -460,6 +515,7 @@ abstract class SliderComponentShape {
   /// passed is null, then no label was supplied to the [Slider].
   /// [value] is the current parametric value (from 0.0 to 1.0) of the slider.
   void paint(
+    RenderBox parentBox,
     PaintingContext context,
     bool isDiscrete,
     Offset thumbCenter,
@@ -468,7 +524,6 @@ abstract class SliderComponentShape {
     TextPainter labelPainter,
     SliderThemeData sliderTheme,
     TextDirection textDirection,
-    double textScaleFactor,
     double value,
   );
 }
@@ -493,6 +548,7 @@ class RoundSliderThumbShape extends SliderComponentShape {
 
   @override
   void paint(
+    RenderBox parentBox,
     PaintingContext context,
     bool isDiscrete,
     Offset thumbCenter,
@@ -501,14 +557,17 @@ class RoundSliderThumbShape extends SliderComponentShape {
     TextPainter labelPainter,
     SliderThemeData sliderTheme,
     TextDirection textDirection,
-    double textScaleFactor,
     double value,
   ) {
     final Canvas canvas = context.canvas;
-    final Tween<double> radiusTween =
-        new Tween<double>(begin: _disabledThumbRadius, end: _thumbRadius);
-    final ColorTween colorTween =
-        new ColorTween(begin: sliderTheme.disabledThumbColor, end: sliderTheme.thumbColor);
+    final Tween<double> radiusTween = new Tween<double>(
+      begin: _disabledThumbRadius,
+      end: _thumbRadius,
+    );
+    final ColorTween colorTween = new ColorTween(
+      begin: sliderTheme.disabledThumbColor,
+      end: sliderTheme.thumbColor,
+    );
     canvas.drawCircle(
       thumbCenter,
       radiusTween.evaluate(enableAnimation),
@@ -536,6 +595,9 @@ class PaddleSliderValueIndicatorShape extends SliderComponentShape {
 
   // Radius of the top lobe of the value indicator.
   static const double _topLobeRadius = 16.0;
+  // Baseline size of the label text. This is the size that the value indicator
+  // was designed to contain. We scale if from here to fit other sizes.
+  static const double _labelTextDesignSize = 14.0;
   // Radius of the bottom lobe of the value indicator.
   static const double _bottomLobeRadius = 6.0;
   // The starting angle for the bottom lobe. Picked to get the desired
@@ -557,15 +619,14 @@ class PaddleSliderValueIndicatorShape extends SliderComponentShape {
   static const double _twoSeventyDegrees = 3.0 * math.pi / 2.0;
   static const double _ninetyDegrees = math.pi / 2.0;
   static const double _thirtyDegrees = math.pi / 6.0;
-  static const Size preferredSize =
+  static const Size _preferredSize =
       const Size.fromHeight(_distanceBetweenTopBottomCenters + _topLobeRadius + _bottomLobeRadius);
 
-  static final Tween<double> _slideUpTween = new Tween<double>(begin: 0.0, end: 1.0);
   static Path _bottomLobePath; // Initialized by _generateBottomLobe
   static Offset _bottomLobeEnd; // Initialized by _generateBottomLobe
 
   @override
-  Size getPreferredSize(bool isEnabled, bool isDiscrete) => preferredSize;
+  Size getPreferredSize(bool isEnabled, bool isDiscrete) => _preferredSize;
 
   // Adds an arc to the path that has the attributes passed in. This is
   // a convenience to make adding arcs have less boilerplate.
@@ -638,20 +699,71 @@ class PaddleSliderValueIndicatorShape extends SliderComponentShape {
     return _bottomLobeEnd;
   }
 
-  void _drawValueIndicator(Canvas canvas, Offset center, Paint paint, double scale,
-      TextPainter labelPainter, double textScaleFactor) {
+  // Determines the "best" offset to keep the bubble on the screen. The calling
+  // code will bound that with the available movement in the paddle shape.
+  double _getIdealOffset(
+    RenderBox parentBox,
+    double halfWidthNeeded,
+    double scale,
+    Offset center,
+  ) {
+    const double edgeMargin = 4.0;
+    final Rect topLobeRect = new Rect.fromLTWH(
+      -_topLobeRadius - halfWidthNeeded,
+      -_topLobeRadius - _distanceBetweenTopBottomCenters,
+      2.0 * (_topLobeRadius + halfWidthNeeded),
+      2.0 * _topLobeRadius,
+    );
+    // We can just multiply by scale instead of a transform, since we're scaling
+    // around (0, 0).
+    final Offset topLeft = (topLobeRect.topLeft * scale) + center;
+    final Offset bottomRight = (topLobeRect.bottomRight * scale) + center;
+    double shift = 0.0;
+    if (topLeft.dx < edgeMargin) {
+      shift = edgeMargin - topLeft.dx;
+    }
+    if (bottomRight.dx > parentBox.size.width - edgeMargin) {
+      shift = parentBox.size.width - bottomRight.dx - edgeMargin;
+    }
+    shift = (scale == 0.0 ? 0.0 : shift / scale);
+    return shift;
+  }
+
+  void _drawValueIndicator(
+    RenderBox parentBox,
+    Canvas canvas,
+    Offset center,
+    Paint paint,
+    double scale,
+    TextPainter labelPainter,
+  ) {
     canvas.save();
     canvas.translate(center.dx, center.dy);
-    // The entire value indicator should scale with the text scale factor,
+    // The entire value indicator should scale with the size of the label,
     // to keep it large enough to encompass the label text.
-    canvas.scale(scale * textScaleFactor, scale * textScaleFactor);
-    final double inverseTextScale = 1.0 / textScaleFactor;
+    final double textScaleFactor = labelPainter.height / _labelTextDesignSize;
+    final double overallScale = scale * textScaleFactor;
+    canvas.scale(overallScale, overallScale);
+    final double inverseTextScale = textScaleFactor != 0 ? 1.0 / textScaleFactor : 0.0;
     final double labelHalfWidth = labelPainter.width / 2.0;
 
     // This is the needed extra width for the label.  It is only positive when
     // the label exceeds the minimum size contained by the round top lobe.
-    final double halfWidthNeeded =
-        math.max(0.0, inverseTextScale * labelHalfWidth - (_topLobeRadius - _labelPadding));
+    final double halfWidthNeeded = math.max(
+      0.0,
+      inverseTextScale * labelHalfWidth - (_topLobeRadius - _labelPadding),
+    );
+
+    double shift = _getIdealOffset(parentBox, halfWidthNeeded, overallScale, center);
+    double leftWidthNeeded;
+    double rightWidthNeeded;
+    if (shift < 0.0) {  // shifting to the left
+      shift = math.max(shift, -halfWidthNeeded);
+    } else {  // shifting to the right
+      shift = math.min(shift, halfWidthNeeded);
+    }
+    rightWidthNeeded = halfWidthNeeded + shift;
+    leftWidthNeeded = halfWidthNeeded - shift;
 
     final Path path = new Path();
     final Offset bottomLobeEnd = _addBottomLobe(path);
@@ -660,39 +772,57 @@ class PaddleSliderValueIndicatorShape extends SliderComponentShape {
     final double neckTriangleBase = _topNeckRadius - bottomLobeEnd.dx;
     // The parameter that describes how far along the transition from round to
     // stretched we are.
-    final double t = math.max(0.0, math.min(1.0, halfWidthNeeded / neckTriangleBase));
+    final double leftAmount = math.max(0.0, math.min(1.0, leftWidthNeeded / neckTriangleBase));
+    final double rightAmount = math.max(0.0, math.min(1.0, rightWidthNeeded / neckTriangleBase));
     // The angle between the top neck arc's center and the top lobe's center
     // and vertical.
-    final double theta = (1.0 - t) * _thirtyDegrees;
+    final double leftTheta = (1.0 - leftAmount) * _thirtyDegrees;
+    final double rightTheta = (1.0 - rightAmount) * _thirtyDegrees;
     // The center of the top left neck arc.
     final Offset neckLeftCenter = new Offset(
-        -neckTriangleBase, _topLobeCenter.dy + math.cos(theta) * _neckTriangleHypotenuse);
-    final Offset topLobeShift = new Offset(halfWidthNeeded, 0.0);
-    final double neckArcAngle = _ninetyDegrees - theta;
+      -neckTriangleBase,
+      _topLobeCenter.dy + math.cos(leftTheta) * _neckTriangleHypotenuse,
+    );
+    final Offset neckRightCenter = new Offset(
+      neckTriangleBase,
+      _topLobeCenter.dy + math.cos(rightTheta) * _neckTriangleHypotenuse,
+    );
+    final double leftNeckArcAngle = _ninetyDegrees - leftTheta;
+    final double rightNeckArcAngle = math.pi + _ninetyDegrees - rightTheta;
+
     _addArc(
       path,
       neckLeftCenter,
       _topNeckRadius,
       0.0,
-      -neckArcAngle,
+      -leftNeckArcAngle,
     );
-    _addArc(path, _topLobeCenter - topLobeShift, _topLobeRadius, _ninetyDegrees + theta,
-        _twoSeventyDegrees);
-    _addArc(path, _topLobeCenter + topLobeShift, _topLobeRadius, _twoSeventyDegrees,
-        _twoSeventyDegrees + math.pi - theta);
-    final Offset neckRightCenter = new Offset(-neckLeftCenter.dx, neckLeftCenter.dy);
+    _addArc(
+      path,
+      _topLobeCenter - new Offset(leftWidthNeeded, 0.0),
+      _topLobeRadius,
+      _ninetyDegrees + leftTheta,
+      _twoSeventyDegrees,
+    );
+    _addArc(
+      path,
+      _topLobeCenter + new Offset(rightWidthNeeded, 0.0),
+      _topLobeRadius,
+      _twoSeventyDegrees,
+      _twoSeventyDegrees + math.pi - rightTheta,
+    );
     _addArc(
       path,
       neckRightCenter,
       _topNeckRadius,
-      math.pi + neckArcAngle,
+      rightNeckArcAngle,
       math.pi,
     );
     canvas.drawPath(path, paint);
 
     // Draw the label.
     canvas.save();
-    canvas.translate(0.0, -_distanceBetweenTopBottomCenters);
+    canvas.translate(shift, -_distanceBetweenTopBottomCenters);
     canvas.scale(inverseTextScale, inverseTextScale);
     labelPainter.paint(canvas, Offset.zero - new Offset(labelHalfWidth, labelPainter.height / 2.0));
     canvas.restore();
@@ -701,6 +831,7 @@ class PaddleSliderValueIndicatorShape extends SliderComponentShape {
 
   @override
   void paint(
+    RenderBox parentBox,
     PaintingContext context,
     bool isDiscrete,
     Offset thumbCenter,
@@ -709,21 +840,20 @@ class PaddleSliderValueIndicatorShape extends SliderComponentShape {
     TextPainter labelPainter,
     SliderThemeData sliderTheme,
     TextDirection textDirection,
-    double textScaleFactor,
     double value,
   ) {
     assert(labelPainter != null);
-    final ColorTween colorTween =
-        new ColorTween(begin: Colors.transparent, end: sliderTheme.valueIndicatorColor);
     final ColorTween enableColor = new ColorTween(
-        begin: sliderTheme.disabledThumbColor, end: colorTween.evaluate(activationAnimation));
+      begin: sliderTheme.disabledThumbColor,
+      end: sliderTheme.valueIndicatorColor,
+    );
     _drawValueIndicator(
+      parentBox,
       context.canvas,
       thumbCenter,
       new Paint()..color = enableColor.evaluate(enableAnimation),
-      _slideUpTween.evaluate(activationAnimation),
+      activationAnimation.value,
       labelPainter,
-      textScaleFactor,
     );
   }
 }

--- a/packages/flutter/lib/src/material/theme_data.dart
+++ b/packages/flutter/lib/src/material/theme_data.dart
@@ -149,15 +149,9 @@ class ThemeData extends Diagnosticable {
     hintColor ??= isDark ? const Color(0x42FFFFFF) : const Color(0x4C000000);
     errorColor ??= Colors.red[700];
     inputDecorationTheme ??= const InputDecorationTheme();
-    iconTheme ??= isDark
-        ? const IconThemeData(color: Colors.white)
-        : const IconThemeData(color: Colors.black);
-    primaryIconTheme ??= primaryIsDark
-        ? const IconThemeData(color: Colors.white)
-        : const IconThemeData(color: Colors.black);
-    accentIconTheme ??= accentIsDark
-        ? const IconThemeData(color: Colors.white)
-        : const IconThemeData(color: Colors.black);
+    iconTheme ??= isDark ? const IconThemeData(color: Colors.white) : const IconThemeData(color: Colors.black);
+    primaryIconTheme ??= primaryIsDark ? const IconThemeData(color: Colors.white) : const IconThemeData(color: Colors.black);
+    accentIconTheme ??= accentIsDark ? const IconThemeData(color: Colors.white) : const IconThemeData(color: Colors.black);
     platform ??= defaultTargetPlatform;
     final Typography typography = new Typography(platform: platform);
     textTheme ??= isDark ? typography.white : typography.black;
@@ -168,7 +162,7 @@ class ThemeData extends Diagnosticable {
       primaryTextTheme = primaryTextTheme.apply(fontFamily: fontFamily);
       accentTextTheme = accentTextTheme.apply(fontFamily: fontFamily);
     }
-    sliderTheme ??= new SliderThemeData.materialDefaults(
+    sliderTheme ??= new SliderThemeData.fromPrimaryColors(
       primaryColor: primaryColor,
       primaryColorLight: primaryColorLight,
       primaryColorDark: primaryColorDark,
@@ -721,43 +715,43 @@ class ThemeData extends Diagnosticable {
   @override
   int get hashCode {
     return hashValues(
-        brightness,
-        primaryColor,
-        primaryColorBrightness,
-        canvasColor,
-        scaffoldBackgroundColor,
-        bottomAppBarColor,
-        cardColor,
-        dividerColor,
-        highlightColor,
-        splashColor,
-        splashFactory,
-        selectedRowColor,
-        unselectedWidgetColor,
-        disabledColor,
-        buttonColor,
-        buttonTheme,
-        secondaryHeaderColor,
-        textSelectionColor,
-        textSelectionHandleColor,
-        hashValues( // Too many values.
-          backgroundColor,
-          accentColor,
-          accentColorBrightness,
-          indicatorColor,
-          dialogBackgroundColor,
-          hintColor,
-          errorColor,
-          textTheme,
-          primaryTextTheme,
-          accentTextTheme,
-          iconTheme,
-          inputDecorationTheme,
-          primaryIconTheme,
-          accentIconTheme,
-          sliderTheme,
-          platform,
-        ),
+      brightness,
+      primaryColor,
+      primaryColorBrightness,
+      canvasColor,
+      scaffoldBackgroundColor,
+      bottomAppBarColor,
+      cardColor,
+      dividerColor,
+      highlightColor,
+      splashColor,
+      splashFactory,
+      selectedRowColor,
+      unselectedWidgetColor,
+      disabledColor,
+      buttonColor,
+      buttonTheme,
+      secondaryHeaderColor,
+      textSelectionColor,
+      textSelectionHandleColor,
+      hashValues(  // Too many values.
+        backgroundColor,
+        accentColor,
+        accentColorBrightness,
+        indicatorColor,
+        dialogBackgroundColor,
+        hintColor,
+        errorColor,
+        textTheme,
+        primaryTextTheme,
+        accentTextTheme,
+        iconTheme,
+        inputDecorationTheme,
+        primaryIconTheme,
+        accentIconTheme,
+        sliderTheme,
+        platform,
+      ),
     );
   }
 
@@ -765,64 +759,36 @@ class ThemeData extends Diagnosticable {
   void debugFillProperties(DiagnosticPropertiesBuilder description) {
     super.debugFillProperties(description);
     final ThemeData defaultData = new ThemeData.fallback();
-    description.add(new EnumProperty<TargetPlatform>('platform', platform,
-        defaultValue: defaultTargetPlatform));
-    description.add(new EnumProperty<Brightness>('brightness', brightness,
-        defaultValue: defaultData.brightness));
-    description.add(new DiagnosticsProperty<Color>('primaryColor', primaryColor,
-        defaultValue: defaultData.primaryColor));
-    description.add(new EnumProperty<Brightness>('primaryColorBrightness', primaryColorBrightness,
-        defaultValue: defaultData.primaryColorBrightness));
-    description.add(new DiagnosticsProperty<Color>('accentColor', accentColor,
-        defaultValue: defaultData.accentColor));
-    description.add(new EnumProperty<Brightness>('accentColorBrightness', accentColorBrightness,
-        defaultValue: defaultData.accentColorBrightness));
-    description.add(new DiagnosticsProperty<Color>('canvasColor', canvasColor,
-        defaultValue: defaultData.canvasColor));
-    description.add(new DiagnosticsProperty<Color>(
-        'scaffoldBackgroundColor', scaffoldBackgroundColor,
-        defaultValue: defaultData.scaffoldBackgroundColor));
-    description.add(new DiagnosticsProperty<Color>('bottomAppBarColor', bottomAppBarColor,
-        defaultValue: defaultData.bottomAppBarColor));
-    description.add(new DiagnosticsProperty<Color>('cardColor', cardColor,
-        defaultValue: defaultData.cardColor));
-    description.add(new DiagnosticsProperty<Color>('dividerColor', dividerColor,
-        defaultValue: defaultData.dividerColor));
-    description.add(new DiagnosticsProperty<Color>('highlightColor', highlightColor,
-        defaultValue: defaultData.highlightColor));
-    description.add(new DiagnosticsProperty<Color>('splashColor', splashColor,
-        defaultValue: defaultData.splashColor));
-    description.add(new DiagnosticsProperty<Color>('selectedRowColor', selectedRowColor,
-        defaultValue: defaultData.selectedRowColor));
-    description.add(new DiagnosticsProperty<Color>('unselectedWidgetColor', unselectedWidgetColor,
-        defaultValue: defaultData.unselectedWidgetColor));
-    description.add(new DiagnosticsProperty<Color>('disabledColor', disabledColor,
-        defaultValue: defaultData.disabledColor));
-    description.add(new DiagnosticsProperty<Color>('buttonColor', buttonColor,
-        defaultValue: defaultData.buttonColor));
-    description.add(new DiagnosticsProperty<Color>('secondaryHeaderColor', secondaryHeaderColor,
-        defaultValue: defaultData.secondaryHeaderColor));
-    description.add(new DiagnosticsProperty<Color>('textSelectionColor', textSelectionColor,
-        defaultValue: defaultData.textSelectionColor));
-    description.add(new DiagnosticsProperty<Color>(
-        'textSelectionHandleColor', textSelectionHandleColor,
-        defaultValue: defaultData.textSelectionHandleColor));
-    description.add(new DiagnosticsProperty<Color>('backgroundColor', backgroundColor,
-        defaultValue: defaultData.backgroundColor));
-    description.add(new DiagnosticsProperty<Color>('dialogBackgroundColor', dialogBackgroundColor,
-        defaultValue: defaultData.dialogBackgroundColor));
-    description.add(new DiagnosticsProperty<Color>('indicatorColor', indicatorColor,
-        defaultValue: defaultData.indicatorColor));
-    description.add(new DiagnosticsProperty<Color>('hintColor', hintColor,
-        defaultValue: defaultData.hintColor));
-    description.add(new DiagnosticsProperty<Color>('errorColor', errorColor,
-        defaultValue: defaultData.errorColor));
+    description.add(new EnumProperty<TargetPlatform>('platform', platform, defaultValue: defaultTargetPlatform));
+    description.add(new EnumProperty<Brightness>('brightness', brightness, defaultValue: defaultData.brightness));
+    description.add(new DiagnosticsProperty<Color>('primaryColor', primaryColor, defaultValue: defaultData.primaryColor));
+    description.add(new EnumProperty<Brightness>('primaryColorBrightness', primaryColorBrightness, defaultValue: defaultData.primaryColorBrightness));
+    description.add(new DiagnosticsProperty<Color>('accentColor', accentColor, defaultValue: defaultData.accentColor));
+    description.add(new EnumProperty<Brightness>('accentColorBrightness', accentColorBrightness, defaultValue: defaultData.accentColorBrightness));
+    description.add(new DiagnosticsProperty<Color>('canvasColor', canvasColor, defaultValue: defaultData.canvasColor));
+    description.add(new DiagnosticsProperty<Color>('scaffoldBackgroundColor', scaffoldBackgroundColor, defaultValue: defaultData.scaffoldBackgroundColor));
+    description.add(new DiagnosticsProperty<Color>('bottomAppBarColor', bottomAppBarColor, defaultValue: defaultData.bottomAppBarColor));
+    description.add(new DiagnosticsProperty<Color>('cardColor', cardColor, defaultValue: defaultData.cardColor));
+    description.add(new DiagnosticsProperty<Color>('dividerColor', dividerColor, defaultValue: defaultData.dividerColor));
+    description.add(new DiagnosticsProperty<Color>('highlightColor', highlightColor, defaultValue: defaultData.highlightColor));
+    description.add(new DiagnosticsProperty<Color>('splashColor', splashColor, defaultValue: defaultData.splashColor));
+    description.add(new DiagnosticsProperty<Color>('selectedRowColor', selectedRowColor, defaultValue: defaultData.selectedRowColor));
+    description.add(new DiagnosticsProperty<Color>('unselectedWidgetColor', unselectedWidgetColor, defaultValue: defaultData.unselectedWidgetColor));
+    description.add(new DiagnosticsProperty<Color>('disabledColor', disabledColor, defaultValue: defaultData.disabledColor));
+    description.add(new DiagnosticsProperty<Color>('buttonColor', buttonColor, defaultValue: defaultData.buttonColor));
+    description.add(new DiagnosticsProperty<Color>('secondaryHeaderColor', secondaryHeaderColor, defaultValue: defaultData.secondaryHeaderColor));
+    description.add(new DiagnosticsProperty<Color>('textSelectionColor', textSelectionColor, defaultValue: defaultData.textSelectionColor));
+    description.add(new DiagnosticsProperty<Color>('textSelectionHandleColor', textSelectionHandleColor, defaultValue: defaultData.textSelectionHandleColor));
+    description.add(new DiagnosticsProperty<Color>('backgroundColor', backgroundColor, defaultValue: defaultData.backgroundColor));
+    description.add(new DiagnosticsProperty<Color>('dialogBackgroundColor', dialogBackgroundColor, defaultValue: defaultData.dialogBackgroundColor));
+    description.add(new DiagnosticsProperty<Color>('indicatorColor', indicatorColor, defaultValue: defaultData.indicatorColor));
+    description.add(new DiagnosticsProperty<Color>('hintColor', hintColor, defaultValue: defaultData.hintColor));
+    description.add(new DiagnosticsProperty<Color>('errorColor', errorColor, defaultValue: defaultData.errorColor));
     description.add(new DiagnosticsProperty<ButtonThemeData>('buttonTheme', buttonTheme));
     description.add(new DiagnosticsProperty<TextTheme>('textTheme', textTheme));
     description.add(new DiagnosticsProperty<TextTheme>('primaryTextTheme', primaryTextTheme));
     description.add(new DiagnosticsProperty<TextTheme>('accentTextTheme', accentTextTheme));
-    description.add(new DiagnosticsProperty<InputDecorationTheme>(
-        'inputDecorationTheme', inputDecorationTheme));
+    description.add(new DiagnosticsProperty<InputDecorationTheme>('inputDecorationTheme', inputDecorationTheme));
     description.add(new DiagnosticsProperty<IconThemeData>('iconTheme', iconTheme));
     description.add(new DiagnosticsProperty<IconThemeData>('primaryIconTheme', primaryIconTheme));
     description.add(new DiagnosticsProperty<IconThemeData>('accentIconTheme', accentIconTheme));
@@ -846,8 +812,7 @@ class _IdentityThemeDataCacheKey {
     // We are explicitly ignoring the possibility that the types might not
     // match in the interests of speed.
     final _IdentityThemeDataCacheKey otherKey = other;
-    return identical(baseTheme, otherKey.baseTheme) &&
-        identical(localTextGeometry, otherKey.localTextGeometry);
+    return identical(baseTheme, otherKey.baseTheme) && identical(localTextGeometry, otherKey.localTextGeometry);
   }
 }
 

--- a/packages/flutter/lib/src/widgets/icon_theme_data.dart
+++ b/packages/flutter/lib/src/widgets/icon_theme_data.dart
@@ -34,7 +34,10 @@ class IconThemeData extends Diagnosticable {
   /// the new values.
   IconThemeData copyWith({Color color, double opacity, double size}) {
     return new IconThemeData(
-        color: color ?? this.color, opacity: opacity ?? this.opacity, size: size ?? this.size);
+      color: color ?? this.color,
+      opacity: opacity ?? this.opacity,
+      size: size ?? this.size,
+    );
   }
 
   /// Returns a new icon theme that matches this icon theme but with some values
@@ -43,7 +46,11 @@ class IconThemeData extends Diagnosticable {
   IconThemeData merge(IconThemeData other) {
     if (other == null)
       return this;
-    return copyWith(color: other.color, opacity: other.opacity, size: other.size);
+    return copyWith(
+      color: other.color,
+      opacity: other.opacity,
+      size: other.size,
+    );
   }
 
   /// Whether all the properties of this object are non-null.
@@ -97,11 +104,8 @@ class IconThemeData extends Diagnosticable {
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder description) {
     super.debugFillProperties(description);
-    if (color == null && _opacity == null && size == null) {
-      return;
-    }
-    description.add(new DiagnosticsProperty<Color>('color', color));
-    description.add(new DoubleProperty('opacity', _opacity));
-    description.add(new DoubleProperty('size', size));
+    description.add(new DiagnosticsProperty<Color>('color', color, defaultValue: null));
+    description.add(new DoubleProperty('opacity', opacity, defaultValue: null));
+    description.add(new DoubleProperty('size', size, defaultValue: null));
   }
 }

--- a/packages/flutter/test/material/slider_test.dart
+++ b/packages/flutter/test/material/slider_test.dart
@@ -52,16 +52,19 @@ void main() {
         textDirection: TextDirection.ltr,
         child: new StatefulBuilder(
           builder: (BuildContext context, StateSetter setState) {
-            return new Material(
-              child: new Center(
-                child: new Slider(
-                  key: sliderKey,
-                  value: value,
-                  onChanged: (double newValue) {
-                    setState(() {
-                      value = newValue;
-                    });
-                  },
+            return new MediaQuery(
+              data: new MediaQueryData.fromWindow(window),
+              child: new Material(
+                child: new Center(
+                  child: new Slider(
+                    key: sliderKey,
+                    value: value,
+                    onChanged: (double newValue) {
+                      setState(() {
+                        value = newValue;
+                      });
+                    },
+                  ),
                 ),
               ),
             );
@@ -95,16 +98,19 @@ void main() {
         textDirection: TextDirection.rtl,
         child: new StatefulBuilder(
           builder: (BuildContext context, StateSetter setState) {
-            return new Material(
-              child: new Center(
-                child: new Slider(
-                  key: sliderKey,
-                  value: value,
-                  onChanged: (double newValue) {
-                    setState(() {
-                      value = newValue;
-                    });
-                  },
+            return new MediaQuery(
+              data: new MediaQueryData.fromWindow(window),
+              child: new Material(
+                child: new Center(
+                  child: new Slider(
+                    key: sliderKey,
+                    value: value,
+                    onChanged: (double newValue) {
+                      setState(() {
+                        value = newValue;
+                      });
+                    },
+                  ),
                 ),
               ),
             );
@@ -139,17 +145,20 @@ void main() {
         textDirection: TextDirection.ltr,
         child: new StatefulBuilder(
           builder: (BuildContext context, StateSetter setState) {
-            return new Material(
-              child: new Center(
-                child: new Slider(
-                  key: sliderKey,
-                  value: value,
-                  onChanged: (double newValue) {
-                    setState(() {
-                      updates++;
-                      value = newValue;
-                    });
-                  },
+            return new MediaQuery(
+              data: new MediaQueryData.fromWindow(window),
+              child: new Material(
+                child: new Center(
+                  child: new Slider(
+                    key: sliderKey,
+                    value: value,
+                    onChanged: (double newValue) {
+                      setState(() {
+                        updates++;
+                        value = newValue;
+                      });
+                    },
+                  ),
                 ),
               ),
             );
@@ -179,19 +188,22 @@ void main() {
         child: new StatefulBuilder(
           builder: (BuildContext context, StateSetter setState) {
             final SliderThemeData sliderTheme = SliderTheme.of(context).copyWith(thumbShape: loggingThumb);
-            return new Material(
-              child: new Center(
-                child: new SliderTheme(
-                  data: sliderTheme,
-                  child: new Slider(
-                    key: sliderKey,
-                    value: value,
-                    divisions: 4,
-                    onChanged: (double newValue) {
-                      setState(() {
-                        value = newValue;
-                      });
-                    },
+            return new MediaQuery(
+              data: new MediaQueryData.fromWindow(window),
+              child: new Material(
+                child: new Center(
+                  child: new SliderTheme(
+                    data: sliderTheme,
+                    child: new Slider(
+                      key: sliderKey,
+                      value: value,
+                      divisions: 4,
+                      onChanged: (double newValue) {
+                        setState(() {
+                          value = newValue;
+                        });
+                      },
+                    ),
                   ),
                 ),
               ),
@@ -243,21 +255,24 @@ void main() {
         textDirection: TextDirection.ltr,
         child: new StatefulBuilder(
           builder: (BuildContext context, StateSetter setState) {
-            return new Material(
-              child: new Center(
-                child: new SizedBox(
-                  width: 144.0 + 2 * 16.0, // _kPreferredTotalWidth
-                  child: new Slider(
-                    key: sliderKey,
-                    min: 0.0,
-                    max: 100.0,
-                    divisions: 10,
-                    value: value,
-                    onChanged: (double newValue) {
-                      setState(() {
-                        value = newValue;
-                      });
-                    },
+            return new MediaQuery(
+              data: new MediaQueryData.fromWindow(window),
+              child: new Material(
+                child: new Center(
+                  child: new SizedBox(
+                    width: 144.0 + 2 * 16.0, // _kPreferredTotalWidth
+                    child: new Slider(
+                      key: sliderKey,
+                      min: 0.0,
+                      max: 100.0,
+                      divisions: 10,
+                      value: value,
+                      onChanged: (double newValue) {
+                        setState(() {
+                          value = newValue;
+                        });
+                      },
+                    ),
                   ),
                 ),
               ),
@@ -289,14 +304,17 @@ void main() {
     final List<double> log = <double>[];
     await tester.pumpWidget(new Directionality(
       textDirection: TextDirection.ltr,
-      child: new Material(
-        child: new Slider(
-          value: 0.0,
-          min: 0.0,
-          max: 1.0,
-          onChanged: (double newValue) {
-            log.add(newValue);
-          },
+      child: new MediaQuery(
+        data: new MediaQueryData.fromWindow(window),
+        child: new Material(
+          child: new Slider(
+            value: 0.0,
+            min: 0.0,
+            max: 1.0,
+            onChanged: (double newValue) {
+              log.add(newValue);
+            },
+          ),
         ),
       ),
     ));
@@ -307,14 +325,17 @@ void main() {
 
     await tester.pumpWidget(new Directionality(
       textDirection: TextDirection.ltr,
-      child: new Material(
-        child: new Slider(
-          value: 0.0,
-          min: 0.0,
-          max: 0.0,
-          onChanged: (double newValue) {
-            log.add(newValue);
-          },
+      child: new MediaQuery(
+        data: new MediaQueryData.fromWindow(window),
+        child: new Material(
+          child: new Slider(
+            value: 0.0,
+            min: 0.0,
+            max: 0.0,
+            onChanged: (double newValue) {
+              log.add(newValue);
+            },
+          ),
         ),
       ),
     ));
@@ -346,17 +367,20 @@ void main() {
             };
       return new Directionality(
         textDirection: TextDirection.ltr,
-        child: new Material(
-          child: new Center(
-            child: new Theme(
-              data: theme,
-              child: new Slider(
-                value: value,
-                label: '$value',
-                divisions: divisions,
-                activeColor: activeColor,
-                inactiveColor: inactiveColor,
-                onChanged: onChanged,
+        child: new MediaQuery(
+          data: new MediaQueryData.fromWindow(window),
+          child: new Material(
+            child: new Center(
+              child: new Theme(
+                data: theme,
+                child: new Slider(
+                  value: value,
+                  label: '$value',
+                  divisions: divisions,
+                  activeColor: activeColor,
+                  inactiveColor: inactiveColor,
+                  onChanged: onChanged,
+                ),
               ),
             ),
           ),
@@ -518,19 +542,22 @@ void main() {
     double value = 0.0;
     await tester.pumpWidget(new Directionality(
       textDirection: TextDirection.ltr,
-      child: new Material(
-        child: new ListView(
-          children: <Widget>[
-            new Slider(
-              value: value,
-              onChanged: (double newValue) {
-                value = newValue;
-              },
-            ),
-            new Container(
-              height: 2000.0,
-            ),
-          ],
+      child: new MediaQuery(
+        data: new MediaQueryData.fromWindow(window),
+        child: new Material(
+          child: new ListView(
+            children: <Widget>[
+              new Slider(
+                value: value,
+                onChanged: (double newValue) {
+                  value = newValue;
+                },
+              ),
+              new Container(
+                height: 2000.0,
+              ),
+            ],
+          ),
         ),
       ),
     ));
@@ -543,13 +570,16 @@ void main() {
     double value = 0.0;
     await tester.pumpWidget(new Directionality(
       textDirection: TextDirection.ltr,
-      child: new Material(
-        child: new Center(
-          child: new Slider(
-            value: value,
-            onChanged: (double newValue) {
-              value = newValue;
-            },
+      child: new MediaQuery(
+        data: new MediaQueryData.fromWindow(window),
+        child: new Material(
+          child: new Center(
+            child: new Slider(
+              value: value,
+              onChanged: (double newValue) {
+                value = newValue;
+              },
+            ),
           ),
         ),
       ),
@@ -571,13 +601,16 @@ void main() {
     double value = 0.0;
     await tester.pumpWidget(new Directionality(
       textDirection: TextDirection.rtl,
-      child: new Material(
-        child: new Center(
-          child: new Slider(
-            value: value,
-            onChanged: (double newValue) {
-              value = newValue;
-            },
+      child: new MediaQuery(
+        data: new MediaQueryData.fromWindow(window),
+        child: new Material(
+          child: new Center(
+            child: new Slider(
+              value: value,
+              onChanged: (double newValue) {
+                value = newValue;
+              },
+            ),
           ),
         ),
       ),
@@ -596,24 +629,12 @@ void main() {
   });
 
   testWidgets('Slider sizing', (WidgetTester tester) async {
-    await tester.pumpWidget(const Directionality(
+    await tester.pumpWidget(new Directionality(
       textDirection: TextDirection.ltr,
-      child: const Material(
-        child: const Center(
-          child: const Slider(
-            value: 0.5,
-            onChanged: null,
-          ),
-        ),
-      ),
-    ));
-    expect(tester.renderObject<RenderBox>(find.byType(Slider)).size, const Size(800.0, 600.0));
-
-    await tester.pumpWidget(const Directionality(
-      textDirection: TextDirection.ltr,
-      child: const Material(
-        child: const Center(
-          child: const IntrinsicWidth(
+      child: new MediaQuery(
+        data: new MediaQueryData.fromWindow(window),
+        child: const Material(
+          child: const Center(
             child: const Slider(
               value: 0.5,
               onChanged: null,
@@ -622,18 +643,39 @@ void main() {
         ),
       ),
     ));
+    expect(tester.renderObject<RenderBox>(find.byType(Slider)).size, const Size(800.0, 600.0));
+
+    await tester.pumpWidget(new Directionality(
+      textDirection: TextDirection.ltr,
+      child: new MediaQuery(
+        data: new MediaQueryData.fromWindow(window),
+        child: const Material(
+          child: const Center(
+            child: const IntrinsicWidth(
+              child: const Slider(
+                value: 0.5,
+                onChanged: null,
+              ),
+            ),
+          ),
+        ),
+      ),
+    ));
     expect(tester.renderObject<RenderBox>(find.byType(Slider)).size, const Size(144.0 + 2.0 * 16.0, 600.0));
 
-    await tester.pumpWidget(const Directionality(
+    await tester.pumpWidget(new Directionality(
       textDirection: TextDirection.ltr,
-      child: const Material(
-        child: const Center(
-          child: const OverflowBox(
-            maxWidth: double.INFINITY,
-            maxHeight: double.INFINITY,
-            child: const Slider(
-              value: 0.5,
-              onChanged: null,
+      child: new MediaQuery(
+        data: new MediaQueryData.fromWindow(window),
+        child: const Material(
+          child: const Center(
+            child: const OverflowBox(
+              maxWidth: double.INFINITY,
+              maxHeight: double.INFINITY,
+              child: const Slider(
+                value: 0.5,
+                onChanged: null,
+              ),
             ),
           ),
         ),
@@ -748,10 +790,13 @@ void main() {
 
     await tester.pumpWidget(new Directionality(
       textDirection: TextDirection.ltr,
-      child: new Material(
-        child: new Slider(
-          value: 0.5,
-          onChanged: (double v) {},
+      child: new MediaQuery(
+        data: new MediaQueryData.fromWindow(window),
+        child: new Material(
+          child: new Slider(
+            value: 0.5,
+            onChanged: (double v) {},
+          ),
         ),
       ),
     ));
@@ -770,12 +815,15 @@ void main() {
         ));
 
     // Disable slider
-    await tester.pumpWidget(const Directionality(
+    await tester.pumpWidget(new Directionality(
       textDirection: TextDirection.ltr,
-      child: const Material(
-        child: const Slider(
-          value: 0.5,
-          onChanged: null,
+      child: new MediaQuery(
+        data: new MediaQueryData.fromWindow(window),
+        child: const Material(
+          child: const Slider(
+            value: 0.5,
+            onChanged: null,
+          ),
         ),
       ),
     ));
@@ -802,17 +850,20 @@ void main() {
       final ValueChanged<double> onChanged = enabled ? (double d) => value = d : null;
       return new Directionality(
         textDirection: TextDirection.ltr,
-        child: new Material(
-          child: new Center(
-            child: new Theme(
-              data: baseTheme,
-              child: new SliderTheme(
-                data: sliderTheme,
-                child: new Slider(
-                  value: value,
-                  label: '$value',
-                  divisions: divisions,
-                  onChanged: onChanged,
+        child: new MediaQuery(
+          data: new MediaQueryData.fromWindow(window),
+          child: new Material(
+            child: new Center(
+              child: new Theme(
+                data: baseTheme,
+                child: new SliderTheme(
+                  data: sliderTheme,
+                  child: new Slider(
+                    value: value,
+                    label: '$value',
+                    divisions: divisions,
+                    onChanged: onChanged,
+                  ),
                 ),
               ),
             ),

--- a/packages/flutter/test/material/slider_theme_test.dart
+++ b/packages/flutter/test/material/slider_theme_test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:ui' show window;
+
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -31,14 +33,17 @@ void main() {
     Widget buildSlider(SliderThemeData data) {
       return new Directionality(
         textDirection: TextDirection.ltr,
-        child: new Material(
-          child: new Center(
-            child: new Theme(
-              data: theme,
-              child: const Slider(
-                value: 0.5,
-                label: '0.5',
-                onChanged: null,
+        child: new MediaQuery(
+          data: new MediaQueryData.fromWindow(window),
+          child: new Material(
+            child: new Center(
+              child: new Theme(
+                data: theme,
+                child: const Slider(
+                  value: 0.5,
+                  label: '0.5',
+                  onChanged: null,
+                ),
               ),
             ),
           ),
@@ -67,16 +72,19 @@ void main() {
     Widget buildSlider(SliderThemeData data) {
       return new Directionality(
         textDirection: TextDirection.ltr,
-        child: new Material(
-          child: new Center(
-            child: new Theme(
-              data: theme,
-              child: new SliderTheme(
-                data: customTheme,
-                child: const Slider(
-                  value: 0.5,
-                  label: '0.5',
-                  onChanged: null,
+        child: new MediaQuery(
+          data: new MediaQueryData.fromWindow(window),
+          child: new Material(
+            child: new Center(
+              child: new Theme(
+                data: theme,
+                child: new SliderTheme(
+                  data: customTheme,
+                  child: const Slider(
+                    value: 0.5,
+                    label: '0.5',
+                    onChanged: null,
+                  ),
                 ),
               ),
             ),
@@ -161,15 +169,18 @@ void main() {
       final ValueChanged<double> onChanged = enabled ? (double d) => value = d : null;
       return new Directionality(
         textDirection: TextDirection.ltr,
-        child: new Material(
-          child: new Center(
-            child: new SliderTheme(
-              data: sliderTheme,
-              child: new Slider(
-                value: value,
-                label: '$value',
-                divisions: divisions,
-                onChanged: onChanged,
+        child: new MediaQuery(
+          data: new MediaQueryData.fromWindow(window),
+          child: new Material(
+            child: new Center(
+              child: new SliderTheme(
+                data: sliderTheme,
+                child: new Slider(
+                  value: value,
+                  label: '$value',
+                  divisions: divisions,
+                  onChanged: onChanged,
+                ),
               ),
             ),
           ),
@@ -218,21 +229,24 @@ void main() {
     Widget buildApp(String value, {double sliderValue = 0.5}) {
       return new Directionality(
         textDirection: TextDirection.ltr,
-        child: new Material(
-          child: new Row(
-            children: <Widget>[
-              new Expanded(
-                child: new SliderTheme(
-                  data: sliderTheme,
-                  child: new Slider(
-                    value: sliderValue,
-                    label: '$value',
-                    divisions: 3,
-                    onChanged: (double d) {},
+        child: new MediaQuery(
+          data: new MediaQueryData.fromWindow(window),
+          child: new Material(
+            child: new Row(
+              children: <Widget>[
+                new Expanded(
+                  child: new SliderTheme(
+                    data: sliderTheme,
+                    child: new Slider(
+                      value: sliderValue,
+                      label: '$value',
+                      divisions: 3,
+                      onChanged: (double d) {},
+                    ),
                   ),
                 ),
-              ),
-            ],
+              ],
+            ),
           ),
         ),
       );

--- a/packages/flutter/test/widgets/semantics_debugger_test.dart
+++ b/packages/flutter/test/widgets/semantics_debugger_test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:ui' show window;
+
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter/rendering.dart';
@@ -292,13 +294,16 @@ void main() {
         child: new SemanticsDebugger(
           child: new Directionality(
             textDirection: TextDirection.ltr,
-            child: new Material(
-              child: new Center(
-                child: new Slider(
-                  value: value,
-                  onChanged: (double newValue) {
-                    value = newValue;
-                  },
+            child: new MediaQuery(
+              data: new MediaQueryData.fromWindow(window),
+              child: new Material(
+                child: new Center(
+                  child: new Slider(
+                    value: value,
+                    onChanged: (double newValue) {
+                      value = newValue;
+                    },
+                  ),
                 ),
               ),
             ),


### PR DESCRIPTION
Fixed the real repaint problem the Slider had (missing addListener), and added tests for it.

Added the ability for the value indicator to slide left and right to avoid falling off the edge of the screen.
It only shifts as much as it can without deforming, but even at large text scales, that is enough to keep the text on the screen.

Updated the formatting on theme_data.dart and others to use longer line length.

Also, removed a color tween that faded the value indicator in as it scaled, since that wasn't to spec.