### PR TITLE
[tools] consolidate "preview Dart 2" option in BuildInfo

### DIFF
--- a/packages/flutter_tools/lib/src/build_info.dart
+++ b/packages/flutter_tools/lib/src/build_info.dart
@@ -11,7 +11,7 @@ import 'globals.dart';
 /// Information about a build to be performed or used.
 class BuildInfo {
   const BuildInfo(this.mode, this.flavor,
-      {this.previewDart2,
+      {this.previewDart2: false,
       this.trackWidgetCreation,
       this.extraFrontEndOptions,
       this.extraGenSnapshotOptions,
@@ -19,6 +19,7 @@ class BuildInfo {
       this.targetPlatform});
 
   final BuildMode mode;
+
   /// Represents a custom Android product flavor or an Xcode scheme, null for
   /// using the default.
   ///
@@ -27,7 +28,7 @@ class BuildInfo {
   /// Mode-Flavor (e.g. Release-Paid).
   final String flavor;
 
-  // Whether build should be done using Dart2 Frontend parser.
+  /// Whether build should be done using Dart2 Frontend parser.
   final bool previewDart2;
 
   /// Whether the build should track widget creation locations.
@@ -39,7 +40,7 @@ class BuildInfo {
   /// Extra command-line options for gen_snapshot.
   final String extraGenSnapshotOptions;
 
-  // Whether to prefer AOT compiling to a *so file.
+  /// Whether to prefer AOT compiling to a *so file.
   final bool preferSharedLibrary;
 
   /// Target platform for the build (e.g. android_arm versus android_arm64).

--- a/packages/flutter_tools/lib/src/build_info.dart
+++ b/packages/flutter_tools/lib/src/build_info.dart
@@ -10,13 +10,14 @@ import 'globals.dart';
 
 /// Information about a build to be performed or used.
 class BuildInfo {
-  const BuildInfo(this.mode, this.flavor,
-      {this.previewDart2: false,
-      this.trackWidgetCreation,
-      this.extraFrontEndOptions,
-      this.extraGenSnapshotOptions,
-      this.preferSharedLibrary,
-      this.targetPlatform});
+  const BuildInfo(this.mode, this.flavor, {
+    this.previewDart2: false,
+    this.trackWidgetCreation,
+    this.extraFrontEndOptions,
+    this.extraGenSnapshotOptions,
+    this.preferSharedLibrary,
+    this.targetPlatform,
+  });
 
   final BuildMode mode;
 

--- a/packages/flutter_tools/lib/src/commands/daemon.dart
+++ b/packages/flutter_tools/lib/src/commands/daemon.dart
@@ -316,7 +316,11 @@ class AppDomain extends Domain {
     if (!fs.isDirectorySync(projectDirectory))
       throw "'$projectDirectory' does not exist";
 
-    final BuildInfo buildInfo = new BuildInfo(getBuildModeForName(mode) ?? BuildMode.debug, flavor);
+    final BuildInfo buildInfo = new BuildInfo(
+      getBuildModeForName(mode) ?? BuildMode.debug,
+      flavor,
+      previewDart2: _getBoolArg(args, 'preview-dart-2'),
+    );
     DebuggingOptions options;
     if (buildInfo.isRelease) {
       options = new DebuggingOptions.disabled(buildInfo);
@@ -335,7 +339,6 @@ class AppDomain extends Domain {
       route,
       options,
       enableHotReload,
-      previewDart2: _getBoolArg(args, 'preview-dart-2'),
       trackWidgetCreation: _getBoolArg(args, 'track-widget-creation'),
     );
 
@@ -351,7 +354,6 @@ class AppDomain extends Domain {
     Device device, String projectDirectory, String target, String route,
     DebuggingOptions options, bool enableHotReload, {
     String applicationBinary,
-    @required bool previewDart2,
     @required bool trackWidgetCreation,
     String projectRootPath,
     String packagesFilePath,
@@ -367,7 +369,7 @@ class AppDomain extends Domain {
 
     final FlutterDevice flutterDevice = new FlutterDevice(
       device,
-      previewDart2: previewDart2,
+      previewDart2: options.buildInfo.previewDart2,
       trackWidgetCreation: trackWidgetCreation,
     );
 
@@ -380,7 +382,6 @@ class AppDomain extends Domain {
         debuggingOptions: options,
         usesTerminalUI: false,
         applicationBinary: applicationBinary,
-        previewDart2: previewDart2,
         projectRootPath: projectRootPath,
         packagesFilePath: packagesFilePath,
         ipv6: ipv6,
@@ -393,7 +394,6 @@ class AppDomain extends Domain {
         debuggingOptions: options,
         usesTerminalUI: false,
         applicationBinary: applicationBinary,
-        previewDart2: previewDart2,
         ipv6: ipv6,
       );
     }

--- a/packages/flutter_tools/lib/src/commands/run.dart
+++ b/packages/flutter_tools/lib/src/commands/run.dart
@@ -259,7 +259,6 @@ class RunCommand extends RunCommandBase {
           devices.first, fs.currentDirectory.path, targetFile, route,
           _createDebuggingOptions(), hotMode,
           applicationBinary: argResults['use-application-binary'],
-          previewDart2: argResults['preview-dart-2'],
           trackWidgetCreation: argResults['track-widget-creation'],
           projectRootPath: argResults['project-root'],
           packagesFilePath: globalResults['packages'],
@@ -313,7 +312,6 @@ class RunCommand extends RunCommandBase {
         debuggingOptions: _createDebuggingOptions(),
         benchmarkMode: argResults['benchmark'],
         applicationBinary: argResults['use-application-binary'],
-        previewDart2: argResults['preview-dart-2'],
         projectRootPath: argResults['project-root'],
         packagesFilePath: globalResults['packages'],
         stayResident: stayResident,
@@ -326,7 +324,6 @@ class RunCommand extends RunCommandBase {
         debuggingOptions: _createDebuggingOptions(),
         traceStartup: traceStartup,
         applicationBinary: argResults['use-application-binary'],
-        previewDart2: argResults['preview-dart-2'],
         stayResident: stayResident,
         ipv6: ipv6,
       );

--- a/packages/flutter_tools/lib/src/run_cold.dart
+++ b/packages/flutter_tools/lib/src/run_cold.dart
@@ -20,7 +20,6 @@ class ColdRunner extends ResidentRunner {
     bool usesTerminalUI: true,
     this.traceStartup: false,
     this.applicationBinary,
-    this.previewDart2 : false,
     bool stayResident: true,
     bool ipv6: false,
   }) : super(devices,
@@ -32,7 +31,6 @@ class ColdRunner extends ResidentRunner {
 
   final bool traceStartup;
   final String applicationBinary;
-  final bool previewDart2;
 
   @override
   Future<int> run({

--- a/packages/flutter_tools/lib/src/run_hot.dart
+++ b/packages/flutter_tools/lib/src/run_hot.dart
@@ -39,7 +39,6 @@ class HotRunner extends ResidentRunner {
     bool usesTerminalUI: true,
     this.benchmarkMode: false,
     this.applicationBinary,
-    this.previewDart2: false,
     this.hostIsIde: false,
     String projectRootPath,
     String packagesFilePath,
@@ -54,15 +53,14 @@ class HotRunner extends ResidentRunner {
              stayResident: stayResident,
              ipv6: ipv6);
 
+  final bool benchmarkMode;
   final String applicationBinary;
   final bool hostIsIde;
   Set<String> _dartDependencies;
 
-  final bool benchmarkMode;
   final Map<String, List<int>> benchmarkData = <String, List<int>>{};
   // The initial launch is from a snapshot.
   bool _runningFromSnapshot = true;
-  bool previewDart2 = false;
   DateTime firstBuildTime;
 
   void _addBenchmarkData(String name, int value) {
@@ -391,7 +389,7 @@ class HotRunner extends ResidentRunner {
     }
     // We are now running from source.
     _runningFromSnapshot = false;
-    await _launchFromDevFS(previewDart2 ? mainPath + '.dill' : mainPath);
+    await _launchFromDevFS(debuggingOptions.buildInfo.previewDart2 ? mainPath + '.dill' : mainPath);
     restartTimer.stop();
     printTrace('Restart performed in '
         '${getElapsedAsMilliseconds(restartTimer.elapsed)}.');
@@ -510,8 +508,8 @@ class HotRunner extends ResidentRunner {
     final Stopwatch vmReloadTimer = new Stopwatch()..start();
     try {
       final String entryPath = fs.path.relative(
-        previewDart2 ? mainPath + '.dill' : mainPath,
-        from: projectRootPath
+        debuggingOptions.buildInfo.previewDart2 ? mainPath + '.dill' : mainPath,
+        from: projectRootPath,
       );
       final Completer<Map<String, dynamic>> retrieveFirstReloadReport = new Completer<Map<String, dynamic>>();
 


### PR DESCRIPTION
This is not fixing any bugs, but should reduce the possibility of future bugs. We used to redundantly pass the value of `--preview-dart-2` option as standalone variable _in addition_ to passing it as a field of `BuildInfo`. This PR removes all standalone variables and fields. Only `BuildInfo` is used as the source of this option.
