### PR TITLE
[flutter_test] more docs, tests for `within`; simpler _sizeDistance

### DIFF
--- a/packages/flutter_test/lib/src/matchers.dart
+++ b/packages/flutter_test/lib/src/matchers.dart
@@ -645,7 +645,7 @@ double _rectDistance(Rect a, Rect b) {
 
 double _sizeDistance(Size a, Size b) {
   final Offset delta = b - a;
-  return math.sqrt(delta.dx * delta.dx + delta.dy * delta.dy);
+  return delta.distance;
 }
 
 /// Asserts that two values are within a certain distance from each other.
@@ -659,6 +659,9 @@ double _sizeDistance(Size a, Size b) {
 ///  * [Color], whose distance is the maximum component-wise delta.
 ///  * [Offset], whose distance is the Euclidean distance computed using the
 ///    method [Offset.distance].
+///  * [Rect], whose distance is the maximum component-wise delta.
+///  * [Size], whose distance is the [Offset.distance] of the offset computed as
+///    the difference between two sizes.
 ///  * [int], whose distance is the absolute difference between two integers.
 ///  * [double], whose distance is the absolute difference between two doubles.
 ///

--- a/packages/flutter_test/test/matchers_test.dart
+++ b/packages/flutter_test/test/matchers_test.dart
@@ -199,6 +199,12 @@ void main() {
     expect(const Offset(1.0, 0.0), within(distance: 1.0, from: const Offset(0.0, 0.0)));
     expect(const Offset(1.0, 0.0), isNot(within(distance: 1.0, from: const Offset(-1.0, 0.0))));
 
+    expect(new Rect.fromLTRB(0.0, 1.0, 2.0, 3.0), within<Rect>(distance: 4.0, from: new Rect.fromLTRB(1.0, 3.0, 5.0, 7.0)));
+    expect(new Rect.fromLTRB(0.0, 1.0, 2.0, 3.0), isNot(within<Rect>(distance: 3.9, from: new Rect.fromLTRB(1.0, 3.0, 5.0, 7.0))));
+
+    expect(const Size(1.0, 1.0), within<Size>(distance: 1.415, from: const Size(2.0, 2.0)));
+    expect(const Size(1.0, 1.0), isNot(within<Size>(distance: 1.414, from: const Size(2.0, 2.0))));
+
     expect(
       () => within<bool>(distance: 1, from: false),
       throwsArgumentError,


### PR DESCRIPTION
Document missing value types supported by `within`. Add missing tests. Simplify _sizeDistance implementation.