### PR TITLE
Pass entry points JSON files to front-end server

### DIFF
--- a/packages/flutter_tools/lib/src/artifacts.dart
+++ b/packages/flutter_tools/lib/src/artifacts.dart
@@ -15,6 +15,8 @@ import 'globals.dart';
 enum Artifact {
   dartIoEntriesTxt,
   dartVmEntryPointsTxt,
+  entryPointsJson,
+  entryPointsExtraJson,
   genSnapshot,
   flutterTester,
   snapshotDart,
@@ -34,6 +36,10 @@ String _artifactToFileName(Artifact artifact) {
       return 'dart_io_entries.txt';
     case Artifact.dartVmEntryPointsTxt:
       return 'dart_vm_entry_points.txt';
+    case Artifact.entryPointsJson:
+      return 'entry_points.json';
+    case Artifact.entryPointsExtraJson:
+      return 'entry_points_extra.json';
     case Artifact.genSnapshot:
       return 'gen_snapshot';
     case Artifact.flutterTester:
@@ -121,6 +127,8 @@ class CachedArtifacts extends Artifacts {
     switch (artifact) {
       case Artifact.dartIoEntriesTxt:
       case Artifact.dartVmEntryPointsTxt:
+      case Artifact.entryPointsJson:
+      case Artifact.entryPointsExtraJson:
       case Artifact.frontendServerSnapshotForEngineDartSdk:
         assert(mode != BuildMode.debug, 'Artifact $artifact only available in non-debug mode.');
         return fs.path.join(engineDir, _artifactToFileName(artifact));
@@ -139,6 +147,8 @@ class CachedArtifacts extends Artifacts {
     switch (artifact) {
       case Artifact.dartIoEntriesTxt:
       case Artifact.dartVmEntryPointsTxt:
+      case Artifact.entryPointsJson:
+      case Artifact.entryPointsExtraJson:
       case Artifact.genSnapshot:
       case Artifact.snapshotDart:
       case Artifact.flutterFramework:
@@ -231,6 +241,9 @@ class LocalEngineArtifacts extends Artifacts {
         return fs.path.join(_engineSrcPath, 'third_party', 'dart', 'runtime', 'bin', _artifactToFileName(artifact));
       case Artifact.dartVmEntryPointsTxt:
         return fs.path.join(_engineSrcPath, 'flutter', 'runtime', _artifactToFileName(artifact));
+      case Artifact.entryPointsJson:
+      case Artifact.entryPointsExtraJson:
+        return fs.path.join(engineOutPath, 'dart_entry_points', _artifactToFileName(artifact));
       case Artifact.snapshotDart:
         return fs.path.join(_engineSrcPath, 'flutter', 'lib', 'snapshot', _artifactToFileName(artifact));
       case Artifact.genSnapshot:

--- a/packages/flutter_tools/lib/src/commands/build_aot.dart
+++ b/packages/flutter_tools/lib/src/commands/build_aot.dart
@@ -187,6 +187,8 @@ Future<String> _buildAotSnapshot(
     buildMode,
   );
   final String ioEntryPoints = artifacts.getArtifactPath(Artifact.dartIoEntriesTxt, platform, buildMode);
+  final String entryPointsJson = artifacts.getArtifactPath(Artifact.entryPointsJson, platform, buildMode);
+  final String entryPointsExtraJson = artifacts.getArtifactPath(Artifact.entryPointsExtraJson, platform, buildMode);
 
   final PackageMap packageMap = new PackageMap(PackageMap.globalPackagesPath);
   final String packageMapError = packageMap.checkValid();
@@ -206,6 +208,13 @@ Future<String> _buildAotSnapshot(
     vmServicePath,
     mainPath,
   ];
+
+  if (previewDart2) {
+    inputPaths.addAll(<String>[
+      entryPointsJson,
+      entryPointsExtraJson,
+    ]);
+  }
 
   final Set<String> outputPaths = new Set<String>();
 
@@ -371,6 +380,7 @@ Future<String> _buildAotSnapshot(
       extraFrontEndOptions: extraFrontEndOptions,
       linkPlatformKernelIn : true,
       aot : true,
+      entryPointsJsonFiles: <String>[entryPointsJson, entryPointsExtraJson],
       trackWidgetCreation: false,
     );
     if (mainPath == null) {

--- a/packages/flutter_tools/lib/src/compile.dart
+++ b/packages/flutter_tools/lib/src/compile.dart
@@ -62,6 +62,7 @@ Future<String> compile(
     String depFilePath,
     bool linkPlatformKernelIn: false,
     bool aot: false,
+    List<String> entryPointsJsonFiles,
     bool trackWidgetCreation: false,
     List<String> extraFrontEndOptions,
     String incrementalCompilerByteStorePath,
@@ -87,6 +88,11 @@ Future<String> compile(
     command.add('--no-link-platform');
   if (aot) {
     command.add('--aot');
+  }
+  if (entryPointsJsonFiles != null) {
+    for (String entryPointsJson in entryPointsJsonFiles) {
+      command.addAll(<String>['--entry-points', entryPointsJson]);
+    }
   }
   if (incrementalCompilerByteStorePath != null) {
     command.add('--incremental');

--- a/packages/flutter_tools/test/artifacts_test.dart
+++ b/packages/flutter_tools/test/artifacts_test.dart
@@ -32,6 +32,10 @@ void main() {
           fs.path.join(tempDir.path, 'bin', 'cache', 'artifacts', 'engine', 'ios-release', 'Flutter.framework')
       );
       expect(
+          artifacts.getArtifactPath(Artifact.entryPointsExtraJson, TargetPlatform.android_arm64, BuildMode.release),
+          fs.path.join(tempDir.path, 'bin', 'cache', 'artifacts', 'engine', 'android-arm64-release', 'entry_points_extra.json')
+      );
+      expect(
           artifacts.getArtifactPath(Artifact.flutterTester),
           fs.path.join(tempDir.path, 'bin', 'cache', 'artifacts', 'engine', 'linux-x64', 'flutter_tester')
       );
@@ -80,6 +84,10 @@ void main() {
       expect(
           artifacts.getArtifactPath(Artifact.dartIoEntriesTxt, TargetPlatform.android_arm, BuildMode.debug),
           fs.path.join(tempDir.path, 'third_party', 'dart', 'runtime', 'bin', 'dart_io_entries.txt')
+      );
+      expect(
+          artifacts.getArtifactPath(Artifact.entryPointsJson, TargetPlatform.android_arm, BuildMode.profile),
+          fs.path.join(tempDir.path, 'out', 'android_debug_unopt', 'dart_entry_points', 'entry_points.json')
       );
       expect(
           artifacts.getArtifactPath(Artifact.flutterFramework, TargetPlatform.ios, BuildMode.release),


### PR DESCRIPTION
This is a preparation to enable new global type flow analysis in Dart 2 AOT. Global analysis needs entry points JSON files in order to enumerate Dart entry points.

These entry points JSON files are generated while building Flutter engine (https://github.com/flutter/engine/pull/4725, https://github.com/flutter/engine/pull/4734) and uploaded into the cloud as a part of platform/mode-specific artifacts (https://chromium-review.googlesource.com/c/chromium/tools/build/+/944519).

This change adds artifact declarations for entry points JSON files into Flutter tools and passes them to Dart 2 front-end server (which passes them to the global type flow analysis).