### PR TITLE
Check that State.initState and State.didUpdateWidget don't return Futures

### DIFF
--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -3731,13 +3731,14 @@ class StatefulElement extends ComponentElement {
     assert(_state._debugLifecycleState == _StateLifecycle.created);
     try {
       _debugSetAllowIgnoredCallsToMarkNeedsBuild(true);
-      final dynamic _debugCheckForReturnedFuture = _state.initState() as dynamic;
+      final dynamic debugCheckForReturnedFuture = _state.initState() as dynamic;
       assert(() {
-        if (_debugCheckForReturnedFuture is Future) {
+        if (debugCheckForReturnedFuture is Future) {
           throw new FlutterError(
-            '${_state.runtimeType}.didUpdateWidget returned a Future.\n'
-            'State.didUpdateWidget must be a void method without an `async` keyword.\n'
-            'Async lifecycle methods violate the State contract.\n'
+            '${_state.runtimeType}.initState() returned a Future.\n'
+            'State.initState() must be a void method without an `async` keyword.\n'
+            'Rather than awaiting on asynchronous work directly inside of initState,\n'
+            'call a separate method to do this work without awaiting it.'
           );
         }
         return true;
@@ -3763,13 +3764,14 @@ class StatefulElement extends ComponentElement {
     _state._widget = widget;
     try {
       _debugSetAllowIgnoredCallsToMarkNeedsBuild(true);
-      final dynamic _debugCheckForReturnedFuture = _state.didUpdateWidget(oldWidget) as dynamic;
+      final dynamic debugCheckForReturnedFuture = _state.didUpdateWidget(oldWidget) as dynamic;
       assert(() {
-        if (_debugCheckForReturnedFuture is Future) {
+        if (debugCheckForReturnedFuture is Future) {
           throw new FlutterError(
-            '${_state.runtimeType}.didUpdateWidget returned a Future.\n'
-            'State.didUpdateWidget must be a void method without an `async` keyword.\n'
-            'Async lifecycle methods violate the State contract.\n'
+            '${_state.runtimeType}.didUpdateWidget() returned a Future.\n'
+            'State.didUpdateWidget() must be a void method without an `async` keyword.\n'
+            'Rather than awaiting on asynchronous work directly inside of didUpdateWidget,\n'
+            'call a separate method to do this work without awaiting it.'
           );
         }
         return true;

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -3731,7 +3731,17 @@ class StatefulElement extends ComponentElement {
     assert(_state._debugLifecycleState == _StateLifecycle.created);
     try {
       _debugSetAllowIgnoredCallsToMarkNeedsBuild(true);
-      _state.initState();
+      final void _debugCheckForReturnedFuture = _state.initState();
+      assert(() {
+        if ((_debugCheckForReturnedFuture  as dynamic) is Future) {
+          throw new FlutterError(
+              '${_state.runtimeType}.didUpdateWidget returned a Future.\n'
+              'State.didUpdateWidget must be a void method without an `async` keyword.\n'
+              'Async lifecycle methods violate the State contract.\n'
+          );
+        }
+        return true;
+      }());
     } finally {
       _debugSetAllowIgnoredCallsToMarkNeedsBuild(false);
     }
@@ -3753,7 +3763,17 @@ class StatefulElement extends ComponentElement {
     _state._widget = widget;
     try {
       _debugSetAllowIgnoredCallsToMarkNeedsBuild(true);
-      _state.didUpdateWidget(oldWidget);
+      final void _debugCheckForReturnedFuture = _state.didUpdateWidget(oldWidget);
+      assert(() {
+        if ((_debugCheckForReturnedFuture as dynamic) is Future) {
+          throw new FlutterError(
+              '${_state.runtimeType}.didUpdateWidget returned a Future.\n'
+              'State.didUpdateWidget must be a void method without an `async` keyword.\n'
+              'Async lifecycle methods violate the State contract.\n'
+          );
+        }
+        return true;
+      }());
     } finally {
       _debugSetAllowIgnoredCallsToMarkNeedsBuild(false);
     }

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -3731,13 +3731,13 @@ class StatefulElement extends ComponentElement {
     assert(_state._debugLifecycleState == _StateLifecycle.created);
     try {
       _debugSetAllowIgnoredCallsToMarkNeedsBuild(true);
-      final void _debugCheckForReturnedFuture = _state.initState();
+      final dynamic _debugCheckForReturnedFuture = _state.initState() as dynamic;
       assert(() {
-        if ((_debugCheckForReturnedFuture  as dynamic) is Future) {
+        if (_debugCheckForReturnedFuture is Future) {
           throw new FlutterError(
-              '${_state.runtimeType}.didUpdateWidget returned a Future.\n'
-              'State.didUpdateWidget must be a void method without an `async` keyword.\n'
-              'Async lifecycle methods violate the State contract.\n'
+            '${_state.runtimeType}.didUpdateWidget returned a Future.\n'
+            'State.didUpdateWidget must be a void method without an `async` keyword.\n'
+            'Async lifecycle methods violate the State contract.\n'
           );
         }
         return true;
@@ -3763,13 +3763,13 @@ class StatefulElement extends ComponentElement {
     _state._widget = widget;
     try {
       _debugSetAllowIgnoredCallsToMarkNeedsBuild(true);
-      final void _debugCheckForReturnedFuture = _state.didUpdateWidget(oldWidget);
+      final dynamic _debugCheckForReturnedFuture = _state.didUpdateWidget(oldWidget) as dynamic;
       assert(() {
-        if ((_debugCheckForReturnedFuture as dynamic) is Future) {
+        if (_debugCheckForReturnedFuture is Future) {
           throw new FlutterError(
-              '${_state.runtimeType}.didUpdateWidget returned a Future.\n'
-              'State.didUpdateWidget must be a void method without an `async` keyword.\n'
-              'Async lifecycle methods violate the State contract.\n'
+            '${_state.runtimeType}.didUpdateWidget returned a Future.\n'
+            'State.didUpdateWidget must be a void method without an `async` keyword.\n'
+            'Async lifecycle methods violate the State contract.\n'
           );
         }
         return true;

--- a/packages/flutter/test/widgets/async_lifecycle_test.dart
+++ b/packages/flutter/test/widgets/async_lifecycle_test.dart
@@ -43,21 +43,14 @@ class InvalidDidUpdateWidgetLifecycleWidgetState extends State<InvalidDidUpdateW
 
 void main() {
   testWidgets('async onInit throws FlutterError', (WidgetTester tester) async {
-    const InvalidOnInitLifecycleWidget invalidWidget = const InvalidOnInitLifecycleWidget();
-
-    await tester.pumpWidget(invalidWidget);
+    await tester.pumpWidget(const InvalidOnInitLifecycleWidget());
 
     expect(tester.takeException(), const isInstanceOf<FlutterError>());
   });
 
   testWidgets('async didUpdateWidget throws FlutterError', (WidgetTester tester) async {
-    const InvalidDidUpdateWidgetLifecycleWidget invalidWidget = const InvalidDidUpdateWidgetLifecycleWidget(id: 1);
-
-    await tester.pumpWidget(invalidWidget);
-
-    const InvalidDidUpdateWidgetLifecycleWidget invalidWidgetUpdate = const InvalidDidUpdateWidgetLifecycleWidget(id: 2);
-
-    await tester.pumpWidget(invalidWidgetUpdate);
+    await tester.pumpWidget(const InvalidDidUpdateWidgetLifecycleWidget(id: 1));
+    await tester.pumpWidget( const InvalidDidUpdateWidgetLifecycleWidget(id: 2));
 
     expect(tester.takeException(), const isInstanceOf<FlutterError>());
   });

--- a/packages/flutter/test/widgets/async_lifecycle_test.dart
+++ b/packages/flutter/test/widgets/async_lifecycle_test.dart
@@ -1,0 +1,64 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+class InvalidOnInitLifecycleWidget extends StatefulWidget {
+  const InvalidOnInitLifecycleWidget({Key key}) : super(key: key);
+
+  @override
+  InvalidOnInitLifecycleWidgetState createState() => new InvalidOnInitLifecycleWidgetState();
+}
+
+class InvalidOnInitLifecycleWidgetState extends State<InvalidOnInitLifecycleWidget> {
+  @override
+  void initState() async {
+    super.initState();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return new Container();
+  }
+}
+
+class InvalidDidUpdateWidgetLifecycleWidget extends StatefulWidget {
+  const InvalidDidUpdateWidgetLifecycleWidget({Key key, this.id}) : super(key: key);
+
+  final int id;
+
+  @override
+  InvalidDidUpdateWidgetLifecycleWidgetState createState() => new InvalidDidUpdateWidgetLifecycleWidgetState();
+}
+
+class InvalidDidUpdateWidgetLifecycleWidgetState extends State<InvalidDidUpdateWidgetLifecycleWidget> {
+  @override
+  void didUpdateWidget(InvalidDidUpdateWidgetLifecycleWidget oldWidget) async {
+    super.didUpdateWidget(oldWidget);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return new Container();
+  }
+}
+
+void main() {
+  testWidgets('async onInit throws FlutterError', (WidgetTester tester) async {
+    const InvalidOnInitLifecycleWidget invalidWidget = const InvalidOnInitLifecycleWidget();
+
+    await tester.pumpWidget(invalidWidget);
+
+    expect(tester.takeException(), const isInstanceOf<FlutterError>());
+  });
+
+  testWidgets('async didUpdateWidget throws FlutterError', (WidgetTester tester) async {
+    const InvalidDidUpdateWidgetLifecycleWidget invalidWidget = const InvalidDidUpdateWidgetLifecycleWidget(id: 1);
+
+    await tester.pumpWidget(invalidWidget);
+
+    const InvalidDidUpdateWidgetLifecycleWidget invalidWidgetUpdate = const InvalidDidUpdateWidgetLifecycleWidget(id: 2);
+
+    await tester.pumpWidget(invalidWidgetUpdate);
+
+    expect(tester.takeException(), const isInstanceOf<FlutterError>());
+  });
+}

--- a/packages/flutter/test/widgets/async_lifecycle_test.dart
+++ b/packages/flutter/test/widgets/async_lifecycle_test.dart
@@ -45,13 +45,13 @@ void main() {
   testWidgets('async onInit throws FlutterError', (WidgetTester tester) async {
     await tester.pumpWidget(const InvalidOnInitLifecycleWidget());
 
-    expect(tester.takeException(), const isInstanceOf<FlutterError>());
+    expect(tester.takeException(), isFlutterError);
   });
 
   testWidgets('async didUpdateWidget throws FlutterError', (WidgetTester tester) async {
     await tester.pumpWidget(const InvalidDidUpdateWidgetLifecycleWidget(id: 1));
     await tester.pumpWidget( const InvalidDidUpdateWidgetLifecycleWidget(id: 2));
 
-    expect(tester.takeException(), const isInstanceOf<FlutterError>());
+    expect(tester.takeException(), isFlutterError);
   });
 }

--- a/packages/flutter/test/widgets/async_lifecycle_test.dart
+++ b/packages/flutter/test/widgets/async_lifecycle_test.dart
@@ -50,7 +50,7 @@ void main() {
 
   testWidgets('async didUpdateWidget throws FlutterError', (WidgetTester tester) async {
     await tester.pumpWidget(const InvalidDidUpdateWidgetLifecycleWidget(id: 1));
-    await tester.pumpWidget( const InvalidDidUpdateWidgetLifecycleWidget(id: 2));
+    await tester.pumpWidget(const InvalidDidUpdateWidgetLifecycleWidget(id: 2));
 
     expect(tester.takeException(), isFlutterError);
   });


### PR DESCRIPTION
Marking Flutter lifecycle methods as `async` can cause subtle bugs in Dart 1, and may still be a issue in Dart 2 [1].  For example, the snippet below will throw an error in Dart 1 because the debug lifecycle is not updated synchronously.

```dart
@override
Future initState() async {
  super.initState();
  foo = await service.getFoo();
}
```
In Dart 2, there is no immediate error caused by failing to call `super.initState` since async functions will start immediately.  The element, however, will not be correctly marked as dirty.  This will be surprising to users, since It is not normally necessary to call `setState` in the `initState` or `didUpdateWidget` method.

To implement this check, I mirrored the [technique](https://github.com/flutter/flutter/blob/10393a12faf8d427ca01dd56f0a69936b2ff5161/packages/flutter/lib/src/widgets/framework.dart#L1108) used to verify that `setState` doesn't return a Future.

[1] _It seems like with the [synchronous async start ](https://github.com/dart-lang/sdk/commit/2170830a9e41fa5b4067fde7bd44b76f5128c502) changes, the value of this check might be diminished._

Fixes #12366