### PR TITLE
Remove _checkPort() when getting flutter views

### DIFF
--- a/packages/flutter_tools/lib/src/commands/fuchsia_reload.dart
+++ b/packages/flutter_tools/lib/src/commands/fuchsia_reload.dart
@@ -162,24 +162,9 @@ class FuchsiaReloadCommand extends FlutterCommand {
     return _vmServiceCache[port];
   }
 
-  Future<bool> _checkPort(int port) async {
-    bool connected = true;
-    Socket s;
-    try {
-      s = await Socket.connect(ipv4Loopback, port);
-    } catch (_) {
-      connected = false;
-    }
-    if (s != null)
-      await s.close();
-    return connected;
-  }
-
   Future<List<FlutterView>> _getViews(List<int> ports) async {
     final List<FlutterView> views = <FlutterView>[];
     for (int port in ports) {
-      if (!await _checkPort(port))
-        continue;
       final VMService vmService = await _getVMService(port);
       await vmService.getVM();
       await vmService.waitForViews();


### PR DESCRIPTION
This change removes port checking code that failed most of the time and isn't necessarily helpful when it succeeds, per discussion with zra@.