### PR TITLE
Add to Artifacts, and add optional arguments to entry points for flut…

### DIFF
--- a/packages/flutter_tools/lib/src/artifacts.dart
+++ b/packages/flutter_tools/lib/src/artifacts.dart
@@ -258,7 +258,7 @@ class LocalEngineArtifacts extends Artifacts {
       case Artifact.engineDartSdkPath:
         return fs.path.join(_hostEngineOutPath, 'dart-sdk');
       case Artifact.engineDartBinary:
-        return fs.path.join(_hostEngineOutPath, 'dart-sdk','bin', _artifactToFileName(artifact));
+        return fs.path.join(_hostEngineOutPath,'dart-sdk','bin', _artifactToFileName(artifact));
     }
     assert(false, 'Invalid artifact $artifact.');
     return null;

--- a/packages/flutter_tools/lib/src/artifacts.dart
+++ b/packages/flutter_tools/lib/src/artifacts.dart
@@ -258,7 +258,7 @@ class LocalEngineArtifacts extends Artifacts {
       case Artifact.engineDartSdkPath:
         return fs.path.join(_hostEngineOutPath, 'dart-sdk');
       case Artifact.engineDartBinary:
-        return fs.path.join(_hostEngineOutPath,'dart-sdk','bin', _artifactToFileName(artifact));
+        return fs.path.join(_hostEngineOutPath, 'dart-sdk', 'bin', _artifactToFileName(artifact));
     }
     assert(false, 'Invalid artifact $artifact.');
     return null;

--- a/packages/flutter_tools/lib/src/artifacts.dart
+++ b/packages/flutter_tools/lib/src/artifacts.dart
@@ -26,6 +26,7 @@ enum Artifact {
   flutterPatchedSdkPath,
   frontendServerSnapshotForEngineDartSdk,
   engineDartSdkPath,
+  engineDartBinary,
 }
 
 String _artifactToFileName(Artifact artifact) {
@@ -57,6 +58,8 @@ String _artifactToFileName(Artifact artifact) {
       return 'dart-sdk';
     case Artifact.frontendServerSnapshotForEngineDartSdk:
       return 'frontend_server.dart.snapshot';
+    case Artifact.engineDartBinary:
+      return 'dart';
   }
   assert(false, 'Invalid artifact $artifact.');
   return null;
@@ -170,6 +173,8 @@ class CachedArtifacts extends Artifacts {
         return fs.path.join(engineArtifactsPath, platformDirName, _artifactToFileName(artifact));
       case Artifact.engineDartSdkPath:
         return dartSdkPath;
+      case Artifact.engineDartBinary:
+        return fs.path.join(dartSdkPath,'bin', _artifactToFileName(artifact));
       case Artifact.platformKernelDill:
         return fs.path.join(_getFlutterPatchedSdkPath(), _artifactToFileName(artifact));
       case Artifact.platformLibrariesJson:
@@ -252,6 +257,8 @@ class LocalEngineArtifacts extends Artifacts {
         return fs.path.join(_hostEngineOutPath, 'gen', _artifactToFileName(artifact));
       case Artifact.engineDartSdkPath:
         return fs.path.join(_hostEngineOutPath, 'dart-sdk');
+      case Artifact.engineDartBinary:
+        return fs.path.join(_hostEngineOutPath, 'dart-sdk','bin', _artifactToFileName(artifact));
     }
     assert(false, 'Invalid artifact $artifact.');
     return null;

--- a/packages/flutter_tools/lib/src/commands/daemon.dart
+++ b/packages/flutter_tools/lib/src/commands/daemon.dart
@@ -357,6 +357,7 @@ class AppDomain extends Domain {
     @required bool trackWidgetCreation,
     String projectRootPath,
     String packagesFilePath,
+    String dillOutputPath,
     bool ipv6: false,
   }) async {
     if (await device.isLocalEmulator && !options.buildInfo.supportsEmulator) {
@@ -371,6 +372,7 @@ class AppDomain extends Domain {
       device,
       previewDart2: options.buildInfo.previewDart2,
       trackWidgetCreation: trackWidgetCreation,
+      dillOutputPath: dillOutputPath,
     );
 
     ResidentRunner runner;
@@ -384,6 +386,7 @@ class AppDomain extends Domain {
         applicationBinary: applicationBinary,
         projectRootPath: projectRootPath,
         packagesFilePath: packagesFilePath,
+        dillOutputPath: dillOutputPath,
         ipv6: ipv6,
         hostIsIde: true,
       );

--- a/packages/flutter_tools/lib/src/commands/run.dart
+++ b/packages/flutter_tools/lib/src/commands/run.dart
@@ -147,6 +147,10 @@ class RunCommand extends RunCommandBase {
             'results out to "refresh_benchmark.json", and exit. This flag is\n'
             'intended for use in generating automated flutter benchmarks.');
 
+    argParser.addOption('output-dill',
+        hide: !verboseHelp,
+        help: 'Specify the path to frontend server output kernel file.');
+
     argParser.addOption(FlutterOptions.kExtraFrontEndOptions, hide: true);
     argParser.addOption(FlutterOptions.kExtraGenSnapshotOptions, hide: true);
   }
@@ -262,6 +266,7 @@ class RunCommand extends RunCommandBase {
           trackWidgetCreation: argResults['track-widget-creation'],
           projectRootPath: argResults['project-root'],
           packagesFilePath: globalResults['packages'],
+          dillOutputPath: argResults['output-dill'],
           ipv6: ipv6,
         );
       } catch (error) {
@@ -301,6 +306,7 @@ class RunCommand extends RunCommandBase {
         device,
         previewDart2: argResults['preview-dart-2'],
         trackWidgetCreation: argResults['track-widget-creation'],
+        dillOutputPath: argResults['output-dill'],
       );
     }).toList();
 
@@ -314,6 +320,7 @@ class RunCommand extends RunCommandBase {
         applicationBinary: argResults['use-application-binary'],
         projectRootPath: argResults['project-root'],
         packagesFilePath: globalResults['packages'],
+        dillOutputPath: argResults['output-dill'],
         stayResident: stayResident,
         ipv6: ipv6,
       );

--- a/packages/flutter_tools/lib/src/compile.dart
+++ b/packages/flutter_tools/lib/src/compile.dart
@@ -8,8 +8,6 @@ import 'dart:convert';
 import 'package:usage/uuid/uuid.dart';
 
 import 'artifacts.dart';
-import 'base/common.dart';
-import 'base/file_system.dart';
 import 'base/io.dart';
 import 'base/process_manager.dart';
 import 'globals.dart';

--- a/packages/flutter_tools/lib/src/compile.dart
+++ b/packages/flutter_tools/lib/src/compile.dart
@@ -14,18 +14,6 @@ import 'base/io.dart';
 import 'base/process_manager.dart';
 import 'globals.dart';
 
-String _dartExecutable() {
-  final String engineDartSdkPath = artifacts.getArtifactPath(
-    Artifact.engineDartSdkPath
-  );
-  if (!fs.isDirectorySync(engineDartSdkPath)) {
-    throwToolExit('No dart sdk Flutter host engine build found at $engineDartSdkPath.\n'
-      'Note that corresponding host engine build is required even when targeting particular device platforms.',
-      exitCode: 2);
-  }
-  return fs.path.join(engineDartSdkPath, 'bin', 'dart');
-}
-
 class _StdoutHandler {
   _StdoutHandler() {
     reset();
@@ -74,7 +62,7 @@ Future<String> compile(
   if (!sdkRoot.endsWith('/'))
     sdkRoot = '$sdkRoot/';
   final List<String> command = <String>[
-    _dartExecutable(),
+    artifacts.getArtifactPath(Artifact.engineDartBinary),
     frontendServer,
     '--sdk-root',
     sdkRoot,
@@ -154,13 +142,13 @@ class ResidentCompiler {
   /// Binary file name is returned if compilation was successful, otherwise
   /// null is returned.
   Future<String> recompile(String mainPath, List<String> invalidatedFiles,
-      {String outputPath}) async {
+      {String outputPath, String packagesFilePath}) async {
     stdoutHandler.reset();
 
     // First time recompile is called we actually have to compile the app from
     // scratch ignoring list of invalidated files.
     if (_server == null)
-      return _compile(mainPath, outputPath);
+      return _compile(mainPath, outputPath, packagesFilePath);
 
     final String inputKey = new Uuid().generateV4();
     _server.stdin.writeln('recompile ${mainPath != null ? mainPath + " ": ""}$inputKey');
@@ -170,12 +158,12 @@ class ResidentCompiler {
     return stdoutHandler.outputFilename.future;
   }
 
-  Future<String> _compile(String scriptFilename, String outputPath) async {
+  Future<String> _compile(String scriptFilename, String outputPath, String packagesFilePath) async {
     final String frontendServer = artifacts.getArtifactPath(
       Artifact.frontendServerSnapshotForEngineDartSdk
     );
     final List<String> args = <String>[
-      _dartExecutable(),
+      artifacts.getArtifactPath(Artifact.engineDartBinary),
       frontendServer,
       '--sdk-root',
       _sdkRoot,
@@ -185,6 +173,9 @@ class ResidentCompiler {
     ];
     if (outputPath != null) {
       args.addAll(<String>['--output-dill', outputPath]);
+    }
+    if (packagesFilePath != null) {
+      args.addAll(<String>['--packages', packagesFilePath]);
     }
     if (_trackWidgetCreation) {
       args.add('--track-widget-creation');

--- a/packages/flutter_tools/lib/src/devfs.dart
+++ b/packages/flutter_tools/lib/src/devfs.dart
@@ -407,6 +407,7 @@ class DevFS {
     bool bundleDirty: false,
     Set<String> fileFilter,
     ResidentCompiler generator,
+    String dillOutputPath,
     bool fullRestart: false,
   }) async {
     // Mark all entries as possibly deleted.
@@ -500,7 +501,8 @@ class DevFS {
       }
       final String compiledBinary =
           await generator.recompile(mainPath, invalidatedFiles,
-              outputPath: fs.path.join(getBuildDirectory(), 'app.dill'));
+              outputPath:  dillOutputPath ?? fs.path.join(getBuildDirectory(), 'app.dill'),
+              packagesFilePath : _packagesFilePath);
       if (compiledBinary != null && compiledBinary.isNotEmpty)
         dirtyEntries.putIfAbsent(
           Uri.parse(target + '.dill'),

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -35,12 +35,14 @@ class FlutterDevice {
   DevFS devFS;
   ApplicationPackage package;
   ResidentCompiler generator;
+  String dillOutputPath;
 
   StreamSubscription<String> _loggingSubscription;
 
   FlutterDevice(this.device, {
     @required bool previewDart2,
     @required bool trackWidgetCreation,
+    this.dillOutputPath,
   }) {
     if (previewDart2) {
       generator = new ResidentCompiler(
@@ -386,7 +388,8 @@ class FlutterDevice {
         bundleDirty: bundleDirty,
         fileFilter: fileFilter,
         generator: generator,
-        fullRestart: fullRestart
+        fullRestart: fullRestart,
+        dillOutputPath: dillOutputPath,
       );
     } on DevFSException {
       devFSStatus.cancel();


### PR DESCRIPTION
…ter run and test to allow for wiring up the same with preview-dart-2 internally

- add path to Dart VM for the engine, used to launch the frontend_server in dart 2
- add optional arguments for  passing in the path of the output dill file for dart 2 compilation
- pass in the packages file explicitly when it is specified
- for flutter test with dart 2 do not generate and compile the test wrapper file if a kernel file is specified