### PR TITLE
Rename "slow mode" to be "debug mode"

### DIFF
--- a/examples/catalog/bin/screenshot.dart.template
+++ b/examples/catalog/bin/screenshot.dart.template
@@ -36,6 +36,6 @@ class SampleScreenshotsState extends State<SampleScreenshots> {
 
 void main() {
   enableFlutterDriverExtension();
-  WidgetsApp.debugAllowBannerOverride = false; // No "slow mode" banner.
+  WidgetsApp.debugAllowBannerOverride = false; // No "debug mode" banner.
   runApp(new SampleScreenshots());
 }

--- a/examples/catalog/bin/screenshot.dart.template
+++ b/examples/catalog/bin/screenshot.dart.template
@@ -36,6 +36,6 @@ class SampleScreenshotsState extends State<SampleScreenshots> {
 
 void main() {
   enableFlutterDriverExtension();
-  WidgetsApp.debugAllowBannerOverride = false; // No "debug mode" banner.
+  WidgetsApp.debugAllowBannerOverride = false; // No "debug" banner.
   runApp(new SampleScreenshots());
 }

--- a/examples/flutter_gallery/lib/gallery/home.dart
+++ b/examples/flutter_gallery/lib/gallery/home.dart
@@ -202,7 +202,7 @@ class GalleryHomeState extends State<GalleryHome> with SingleTickerProviderState
       )
     );
 
-    // In checked mode our MaterialApp will show the default "slow mode" banner.
+    // In checked mode our MaterialApp will show the default "debug mode" banner.
     // Otherwise show the "preview" banner.
     bool showPreviewBanner = true;
     assert(() {

--- a/examples/flutter_gallery/lib/gallery/home.dart
+++ b/examples/flutter_gallery/lib/gallery/home.dart
@@ -202,7 +202,7 @@ class GalleryHomeState extends State<GalleryHome> with SingleTickerProviderState
       )
     );
 
-    // In checked mode our MaterialApp will show the default "debug mode" banner.
+    // In checked mode our MaterialApp will show the default "debug" banner.
     // Otherwise show the "preview" banner.
     bool showPreviewBanner = true;
     assert(() {

--- a/packages/flutter/lib/src/material/app.dart
+++ b/packages/flutter/lib/src/material/app.dart
@@ -511,7 +511,7 @@ class MaterialApp extends StatefulWidget {
   /// reported by the framework.
   final bool showSemanticsDebugger;
 
-  /// Turns on a little "DEBUG MODE" banner in checked mode to indicate
+  /// Turns on a little "DEBUG" banner in checked mode to indicate
   /// that the app is in checked mode. This is on by default (in
   /// checked mode), to turn it off, set the constructor argument to
   /// false. In release mode this has no effect.

--- a/packages/flutter/lib/src/material/app.dart
+++ b/packages/flutter/lib/src/material/app.dart
@@ -511,7 +511,7 @@ class MaterialApp extends StatefulWidget {
   /// reported by the framework.
   final bool showSemanticsDebugger;
 
-  /// Turns on a little "SLOW MODE" banner in checked mode to indicate
+  /// Turns on a little "DEBUG MODE" banner in checked mode to indicate
   /// that the app is in checked mode. This is on by default (in
   /// checked mode), to turn it off, set the constructor argument to
   /// false. In release mode this has no effect.

--- a/packages/flutter/lib/src/widgets/app.dart
+++ b/packages/flutter/lib/src/widgets/app.dart
@@ -348,7 +348,7 @@ class WidgetsApp extends StatefulWidget {
   /// material package.
   final InspectorSelectButtonBuilder inspectorSelectButtonBuilder;
 
-  /// Turns on a "SLOW MODE" little banner in checked mode to indicate
+  /// Turns on a "DEBUG MODE" little banner in checked mode to indicate
   /// that the app is in checked mode. This is on by default (in
   /// checked mode), to turn it off, set the constructor argument to
   /// false. In release mode this has no effect.

--- a/packages/flutter/lib/src/widgets/app.dart
+++ b/packages/flutter/lib/src/widgets/app.dart
@@ -348,7 +348,7 @@ class WidgetsApp extends StatefulWidget {
   /// material package.
   final InspectorSelectButtonBuilder inspectorSelectButtonBuilder;
 
-  /// Turns on a "DEBUG MODE" little banner in checked mode to indicate
+  /// Turns on a "DEBUG" little banner in checked mode to indicate
   /// that the app is in checked mode. This is on by default (in
   /// checked mode), to turn it off, set the constructor argument to
   /// false. In release mode this has no effect.

--- a/packages/flutter/lib/src/widgets/banner.dart
+++ b/packages/flutter/lib/src/widgets/banner.dart
@@ -233,7 +233,7 @@ class BannerPainter extends CustomPainter {
 /// See also:
 ///
 ///  * [CheckedModeBanner], which the [WidgetsApp] widget includes by default in
-///    debug mode, to show a banner that says "DEBUG MODE".
+///    debug mode, to show a banner that says "DEBUG".
 class Banner extends StatelessWidget {
   /// Creates a banner.
   ///
@@ -323,7 +323,7 @@ class Banner extends StatelessWidget {
   }
 }
 
-/// Displays a [Banner] saying "DEBUG MODE" when running in checked mode.
+/// Displays a [Banner] saying "DEBUG" when running in checked mode.
 /// [MaterialApp] builds one of these by default.
 /// Does nothing in release mode.
 class CheckedModeBanner extends StatelessWidget {
@@ -344,7 +344,7 @@ class CheckedModeBanner extends StatelessWidget {
     assert(() {
       result = new Banner(
         child: result,
-        message: 'DEBUG MODE',
+        message: 'DEBUG',
         textDirection: TextDirection.ltr,
         location: BannerLocation.topEnd,
       );
@@ -358,7 +358,7 @@ class CheckedModeBanner extends StatelessWidget {
     super.debugFillProperties(description);
     String message = 'disabled';
     assert(() {
-      message = '"DEBUG MODE"';
+      message = '"DEBUG"';
       return true;
     }());
     description.add(new DiagnosticsNode.message(message));

--- a/packages/flutter/lib/src/widgets/banner.dart
+++ b/packages/flutter/lib/src/widgets/banner.dart
@@ -233,7 +233,7 @@ class BannerPainter extends CustomPainter {
 /// See also:
 ///
 ///  * [CheckedModeBanner], which the [WidgetsApp] widget includes by default in
-///    debug mode, to show a banner that says "SLOW MODE".
+///    debug mode, to show a banner that says "DEBUG MODE".
 class Banner extends StatelessWidget {
   /// Creates a banner.
   ///
@@ -323,7 +323,7 @@ class Banner extends StatelessWidget {
   }
 }
 
-/// Displays a [Banner] saying "SLOW MODE" when running in checked mode.
+/// Displays a [Banner] saying "DEBUG MODE" when running in checked mode.
 /// [MaterialApp] builds one of these by default.
 /// Does nothing in release mode.
 class CheckedModeBanner extends StatelessWidget {
@@ -344,7 +344,7 @@ class CheckedModeBanner extends StatelessWidget {
     assert(() {
       result = new Banner(
         child: result,
-        message: 'SLOW MODE',
+        message: 'DEBUG MODE',
         textDirection: TextDirection.ltr,
         location: BannerLocation.topEnd,
       );
@@ -358,7 +358,7 @@ class CheckedModeBanner extends StatelessWidget {
     super.debugFillProperties(description);
     String message = 'disabled';
     assert(() {
-      message = '"SLOW MODE"';
+      message = '"DEBUG MODE"';
       return true;
     }());
     description.add(new DiagnosticsNode.message(message));

--- a/packages/flutter/lib/src/widgets/widget_inspector.dart
+++ b/packages/flutter/lib/src/widgets/widget_inspector.dart
@@ -424,7 +424,7 @@ class WidgetInspectorService {
 
   /// Returns whether [Widget] creation locations are available.
   ///
-  /// [Widget] creation locations are only available for slow mode builds when
+  /// [Widget] creation locations are only available for debug mode builds when
   /// the `--track-widget-creation` flag is passed to `flutter_tool`. Dart 2.0
   /// is required as injecting creation locations requires a
   /// [Dart Kernel Transformer](https://github.com/dart-lang/sdk/wiki/Kernel-Documentation).
@@ -1127,7 +1127,7 @@ class _Location {
 
 /// Returns the creation location of an object if one is available.
 ///
-/// Creation locations are only available for slow mode builds when
+/// Creation locations are only available for debug mode builds when
 /// the `--track-widget-creation` flag is passed to `flutter_tool`. Dart 2.0 is
 /// required as injecting creation locations requires a
 /// [Dart Kernel Transformer](https://github.com/dart-lang/sdk/wiki/Kernel-Documentation).

--- a/packages/flutter/test/widgets/banner_test.dart
+++ b/packages/flutter/test/widgets/banner_test.dart
@@ -273,7 +273,7 @@ void main() {
       ..rotate(angle: math.PI / 4.0)
       ..rect(rect: new Rect.fromLTRB(-40.0, 28.0, 40.0, 40.0), color: const Color(0x7f000000), hasMaskFilter: true)
       ..rect(rect: new Rect.fromLTRB(-40.0, 28.0, 40.0, 40.0), color: const Color(0xa0b71c1c), hasMaskFilter: false)
-      ..paragraph(offset: const Offset(-40.0, 24.0))
+      ..paragraph(offset: const Offset(-40.0, 29.0))
       ..restore
     );
   });


### PR DESCRIPTION
This moves toward more consistency in our messaging. Apps are
launched using --debug, so the banner will reflect the build
mode.