### PR TITLE
Create frontend compiler in `flutter test` lazily.

### DIFF
--- a/packages/flutter_tools/lib/src/test/flutter_platform.dart
+++ b/packages/flutter_tools/lib/src/test/flutter_platform.dart
@@ -262,7 +262,7 @@ class _FlutterPlatform extends PlatformPlugin {
       printTrace('test $ourTestCount: starting shell process${previewDart2? " in preview-dart-2 mode":""}');
 
       // [dillFilePath] can be set only if [previewDart2] is [true].
-      assert(dillFilePath == null || !previewDart2);
+      assert(dillFilePath == null || previewDart2);
       // If a kernel file is given, then use that to launch the test.
       // Otherwise create a "listener" dart that invokes actual test.
       String mainDart = dillFilePath != null

--- a/packages/flutter_tools/lib/src/test/flutter_platform.dart
+++ b/packages/flutter_tools/lib/src/test/flutter_platform.dart
@@ -271,9 +271,7 @@ class _FlutterPlatform extends PlatformPlugin {
 
       if (previewDart2 && dillFilePath == null) {
         // Lazily instantiate compiler so it is built only if it is actually used.
-        if (compiler == null) {
-          compiler = new _Compiler();
-        }
+        compiler ??= new _Compiler();
         mainDart = await compiler.compile(mainDart);
 
         if (mainDart == null) {
@@ -505,7 +503,7 @@ class _FlutterPlatform extends PlatformPlugin {
     });
 
     // Prepare the Dart file that will talk to us and start the test.
-    File listenerFile = fs.file('${temporaryDirectory.path}/listener.dart');
+    final File listenerFile = fs.file('${temporaryDirectory.path}/listener.dart');
     listenerFile.createSync();
     listenerFile.writeAsStringSync(_generateTestMain(
       testUrl: fs.path.toUri(fs.path.absolute(testPath)).toString(),


### PR DESCRIPTION
This is needed to avoid unwarranted runtime dependencies on Artifacts, for example when in non-preview-dart-2 mode. 
Refactor the compilation-related code into _Compiler class.