### PR TITLE
RenderWrap.performLayout should take spacing into consideration

### DIFF
--- a/packages/flutter/lib/src/rendering/wrap.dart
+++ b/packages/flutter/lib/src/rendering/wrap.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:developer';
 import 'dart:math' as math;
 
 import 'box.dart';

--- a/packages/flutter/lib/src/rendering/wrap.dart
+++ b/packages/flutter/lib/src/rendering/wrap.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:developer';
 import 'dart:math' as math;
 
 import 'box.dart';
@@ -608,7 +609,7 @@ class RenderWrap extends RenderBox with ContainerRenderObjectMixin<RenderBox, Wr
       child.layout(childConstraints, parentUsesSize: true);
       final double childMainAxisExtent = _getMainAxisExtent(child);
       final double childCrossAxisExtent = _getCrossAxisExtent(child);
-      if (runMainAxisExtent + childMainAxisExtent > mainAxisLimit) {
+      if (runMainAxisExtent + childMainAxisExtent + spacing > mainAxisLimit) {
         assert(childCount > 0);
         mainAxisExtent = math.max(mainAxisExtent, runMainAxisExtent);
         crossAxisExtent += runCrossAxisExtent;

--- a/packages/flutter/test/widgets/wrap_test.dart
+++ b/packages/flutter/test/widgets/wrap_test.dart
@@ -842,8 +842,7 @@ void main() {
         const SizedBox(width: 200.0, height: 10.0),
         const SizedBox(width: 171.0, height: 10.0),
       ],
-      )
-    );
+    ));
 
     expect(tester.renderObject<RenderBox>(find.byType(Wrap)).size, equals(const Size(800.0, 600.0)));
     verify(tester, <Offset>[

--- a/packages/flutter/test/widgets/wrap_test.dart
+++ b/packages/flutter/test/widgets/wrap_test.dart
@@ -828,4 +828,29 @@ void main() {
     expect(tester.renderObject<RenderBox>(find.byType(Baseline)).size,
            within<Size>(from: const Size(100.0, 200.0), distance: 0.001));
   });
+
+  testWidgets('Spacing with slight overflow', (WidgetTester tester) async {
+
+    await tester.pumpWidget(new Wrap(
+      direction: Axis.horizontal,
+      textDirection: TextDirection.ltr,
+      spacing: 10.0,
+      runSpacing: 10.0,
+      children: <Widget>[
+        const SizedBox(width: 200.0, height: 10.0),
+        const SizedBox(width: 200.0, height: 10.0),
+        const SizedBox(width: 200.0, height: 10.0),
+        const SizedBox(width: 171.0, height: 10.0),
+      ],
+      )
+    );
+
+    expect(tester.renderObject<RenderBox>(find.byType(Wrap)).size, equals(const Size(800.0, 600.0)));
+    verify(tester, <Offset>[
+      const Offset(0.0, 0.0),
+      const Offset(210.0, 0.0),
+      const Offset(420.0, 0.0),
+      const Offset(0.0, 20.0)
+    ]);
+  });
 }

--- a/packages/flutter/test/widgets/wrap_test.dart
+++ b/packages/flutter/test/widgets/wrap_test.dart
@@ -830,7 +830,6 @@ void main() {
   });
 
   testWidgets('Spacing with slight overflow', (WidgetTester tester) async {
-
     await tester.pumpWidget(new Wrap(
       direction: Axis.horizontal,
       textDirection: TextDirection.ltr,


### PR DESCRIPTION
RenderWrap.performLayout  should take spacing into consideration when deciding to move to next row/axis.

Background from #11488:

`renderWrap.performLayout()` checks if the size of the child plus the main axis extend exceeds the main axis limit: `runMainAxisExtent + childMainAxisExtent > maxAxisLimit`. This calculation doesn't involve the spacing, however, so the child could overflow from 0 to spacing.


This should be illustrated by the added test case. For example, the four sized boxes are place in an 800 x 600 container, with widths of 200, 200, 200, 171 and a spacing of 10.  If we go through the numbers, the offsets end up as:

```
0.0  + 200 (width) + 10 (spacing)
210 + 200 (width) + 10 (spacing)
420 + 200 (width) + 10 (spacing)
630 + 171 (width)
801
```
Since this exceeds the containers width of 800, we would expect this box to be moved to the next row.  However, as long as the overflow amount is <= `spacing`, then it will still be placed on the same row. The test case shows with the change added the correct offset is indeed on the next row.

