### PR TITLE
Correct DefaultMaterialLocalizations.delegate supported locales list

### DIFF
--- a/packages/flutter_localizations/lib/src/material_localizations.dart
+++ b/packages/flutter_localizations/lib/src/material_localizations.dart
@@ -14,6 +14,10 @@ import 'l10n/date_localizations.dart' as date_localizations;
 import 'l10n/localizations.dart' show TranslationBundle, translationBundleForLocale;
 import 'widgets_localizations.dart';
 
+// Watch out: the supported locales list in the doc comment below must be kept
+// in sync with the list we test, see test/translations_test.dart, and of course
+// the acutal list of supported locales in _MaterialLocalizationsDelegate.
+
 /// Localized strings for the material widgets.
 ///
 /// To include the localizations provided by this class in a [MaterialApp],
@@ -493,22 +497,29 @@ void _loadDateIntlDataIfNotLoaded() {
 class _MaterialLocalizationsDelegate extends LocalizationsDelegate<MaterialLocalizations> {
   const _MaterialLocalizationsDelegate();
 
+  // Watch out: this list must match the one in the GlobalMaterialLocalizations
+  // class doc and the list we test, see test/translations_test.dart.
   static const List<String> _supportedLanguages = const <String>[
     'ar', // Arabic
     'de', // German
     'en', // English
     'es', // Spanish
-    'fa', // Farsi
+    'fa', // Farsi (Persian)
     'fr', // French
     'he', // Hebrew
     'it', // Italian
     'ja', // Japanese
+    'ko', // Korean
+    'nl', // Dutch
+    'pl', // Polish
     'ps', // Pashto
     'pt', // Portugese
     'ro', // Romanian
     'ru', // Russian
+    'th', // Thai
+    'tr', // Turkish
     'ur', // Urdu
-    'zh', // Simplified Chinese
+    'zh', // Chinese (simplified)
   ];
 
   @override

--- a/packages/flutter_localizations/test/translations_test.dart
+++ b/packages/flutter_localizations/test/translations_test.dart
@@ -7,6 +7,8 @@ import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
+  // Watch out: this list must be kept in sync with the comment at the top of
+  // GlobalMaterialLocalizations.
   final List<String> languages = <String>[
     'ar', // Arabic
     'de', // German
@@ -33,6 +35,9 @@ void main() {
   for (String language in languages) {
     testWidgets('translations exist for $language', (WidgetTester tester) async {
       final Locale locale = new Locale(language, '');
+
+      expect(GlobalMaterialLocalizations.delegate.isSupported(locale), isTrue);
+
       final MaterialLocalizations localizations = new GlobalMaterialLocalizations(locale);
 
       expect(localizations.openAppDrawerTooltip, isNotNull);


### PR DESCRIPTION
Added the five locales introduced by https://github.com/flutter/flutter/pull/13621 to the list of locales supported by GlobalMaterialLocalizations:

```
ko - Korean
nl - Dutch
pl - Polish
th - Thai
tr - Turkish
```

Fixes https://github.com/flutter/flutter/issues/14451
