### PR TITLE
Fix path-to-uri conversion that broke hot reload on Windows.

### DIFF
--- a/packages/flutter_tools/lib/src/devfs.dart
+++ b/packages/flutter_tools/lib/src/devfs.dart
@@ -505,7 +505,7 @@ class DevFS {
               packagesFilePath : _packagesFilePath);
       if (compiledBinary != null && compiledBinary.isNotEmpty)
         dirtyEntries.putIfAbsent(
-          Uri.parse(target + '.dill'),
+          fs.path.toUri(target + '.dill'),
           () => new DevFSFileContent(fs.file(compiledBinary))
         );
     }


### PR DESCRIPTION
This fixes #14945