### PR TITLE
change ThemeData.primaryColor to PrimarySwatch instead of PrimarySwatch[500]

### DIFF
--- a/examples/stocks/test/icon_color_test.dart
+++ b/examples/stocks/test/icon_color_test.dart
@@ -73,7 +73,7 @@ void main() {
     expect(find.text('Account Balance'), findsOneWidget);
 
     // check the colour of the icon - light mode
-    checkIconColor(tester, 'Stock List', Colors.purple.shade500); // theme primary color
+    checkIconColor(tester, 'Stock List', Colors.purple); // theme primary color
     checkIconColor(tester, 'Account Balance', Colors.black26); // disabled
     checkIconColor(tester, 'About', Colors.black45); // enabled
 

--- a/packages/flutter/lib/src/material/theme_data.dart
+++ b/packages/flutter/lib/src/material/theme_data.dart
@@ -118,7 +118,7 @@ class ThemeData extends Diagnosticable {
     brightness ??= Brightness.light;
     final bool isDark = brightness == Brightness.dark;
     primarySwatch ??= Colors.blue;
-    primaryColor ??= isDark ? Colors.grey[900] : primarySwatch[500];
+    primaryColor ??= isDark ? Colors.grey[900] : primarySwatch;
     primaryColorBrightness ??= estimateBrightnessForColor(primaryColor);
     primaryColorLight ??= isDark ? Colors.grey[500] : primarySwatch[100];
     primaryColorDark ??= isDark ? Colors.black : primarySwatch[700];

--- a/packages/flutter/test/material/app_builder_test.dart
+++ b/packages/flutter/test/material/app_builder_test.dart
@@ -15,7 +15,7 @@ void main() {
       home: const Placeholder(),
       builder: (BuildContext context, Widget child) {
         log.add('build');
-        expect(Theme.of(context).primaryColor, Colors.green.shade500);
+        expect(Theme.of(context).primaryColor, Colors.green);
         expect(Directionality.of(context), TextDirection.ltr);
         expect(child, const isInstanceOf<Navigator>());
         return const Placeholder();
@@ -47,7 +47,7 @@ void main() {
         home: new Builder(
           builder: (BuildContext context) {
             log.add('build');
-            expect(Theme.of(context).primaryColor, Colors.yellow.shade500);
+            expect(Theme.of(context).primaryColor, Colors.yellow);
             expect(Directionality.of(context), TextDirection.rtl);
             return const Placeholder();
           },

--- a/packages/flutter/test/widgets/list_view_viewporting_test.dart
+++ b/packages/flutter/test/widgets/list_view_viewporting_test.dart
@@ -236,7 +236,7 @@ void main() {
 
     DecoratedBox widget = tester.firstWidget(find.byType(DecoratedBox));
     BoxDecoration decoration = widget.decoration;
-    expect(decoration.color, equals(Colors.blue[500]));
+    expect(decoration.color, equals(Colors.blue));
 
     setState(() {
       themeData = new ThemeData(primarySwatch: Colors.green);
@@ -246,7 +246,7 @@ void main() {
 
     widget = tester.firstWidget(find.byType(DecoratedBox));
     decoration = widget.decoration;
-    expect(decoration.color, equals(Colors.green[500]));
+    expect(decoration.color, equals(Colors.green));
   });
 
   testWidgets('ListView padding', (WidgetTester tester) async {


### PR DESCRIPTION
Currently, ThemeData always chooses PrimarySwatch[500] as the primary color for light themes, since this is the case for all included MaterialColors.  MaterialColor and ColorSwatch also implement Color, specifically the primary color.  This color can be used directly in place of the 500 shade.

Even for the same color value a MaterialColor != Color, so this change might cause breakages in any tests which assert a primary color is equal to a Color.shade500.

Fixes #14498