### PR TITLE
Display a message if hardware rendering is supported

### DIFF
--- a/packages/flutter_tools/lib/src/commands/run.dart
+++ b/packages/flutter_tools/lib/src/commands/run.dart
@@ -284,19 +284,25 @@ class RunCommand extends RunCommandBase {
     }
 
     for (Device device in devices) {
-      if (await device.supportsHardwareRendering) {
-        final bool enableSoftwareRendering = argResults['enable-software-rendering'] == true;
-        if (enableSoftwareRendering) {
-          printStatus('Using software rendering with device ${device.name}. you may get better performance');
-          printStatus('with hardware mode by configuring hardware rendering for your device.');
-        } else {
-          printStatus('Using hardware rendering with device ${device.name}. If you get graphics artifacts,');
-          printStatus('consider enabling software rendering with "--enable-software-rendering".');
+      if (await device.isLocalEmulator) {
+        if (await device.supportsHardwareRendering) {
+          final bool enableSoftwareRendering = argResults['enable-software-rendering'] == true;
+          if (enableSoftwareRendering) {
+            printStatus(
+              'Using software rendering with device ${device.name}. You may get better performance'
+              'with hardware mode by configuring hardware rendering for your device.'
+            );
+          } else {
+            printStatus(
+              'Using hardware rendering with device ${device.name}. If you get graphics artifacts,'
+              'consider enabling software rendering with "--enable-software-rendering".'
+            );
+          }
         }
-      }
 
-      if (await device.isLocalEmulator && !isEmulatorBuildMode(getBuildMode())) {
-        throwToolExit('${toTitleCase(getModeName(getBuildMode()))} mode is not supported for emulators.');
+        if (!isEmulatorBuildMode(getBuildMode())) {
+          throwToolExit('${toTitleCase(getModeName(getBuildMode()))} mode is not supported for emulators.');
+        }
       }
     }
 

--- a/packages/flutter_tools/lib/src/commands/run.dart
+++ b/packages/flutter_tools/lib/src/commands/run.dart
@@ -284,8 +284,20 @@ class RunCommand extends RunCommandBase {
     }
 
     for (Device device in devices) {
-      if (await device.isLocalEmulator && !isEmulatorBuildMode(getBuildMode()))
+      if (await device.supportsHardwareRendering) {
+        final bool enableSoftwareRendering = argResults['enable-software-rendering'] == true;
+        if (enableSoftwareRendering) {
+          printStatus('Using software rendering with device ${device.name}. you may get better performance');
+          printStatus('with hardware mode by configuring hardware rendering for your device.');
+        } else {
+          printStatus('Using hardware rendering with device ${device.name}. If you get graphics artifacts,');
+          printStatus('consider enabling software rendering with "--enable-software-rendering".');
+        }
+      }
+
+      if (await device.isLocalEmulator && !isEmulatorBuildMode(getBuildMode())) {
         throwToolExit('${toTitleCase(getModeName(getBuildMode()))} mode is not supported for emulators.');
+      }
     }
 
     if (hotMode) {

--- a/packages/flutter_tools/lib/src/device.dart
+++ b/packages/flutter_tools/lib/src/device.dart
@@ -192,6 +192,28 @@ abstract class Device {
   /// Whether it is an emulated device running on localhost.
   Future<bool> get isLocalEmulator;
 
+  /// Whether the device is a simulator on a platform which supports hardware rendering.
+  Future<bool> get supportsHardwareRendering async {
+    if (!await isLocalEmulator) {
+      return false;
+    }
+    final TargetPlatform targetPlatform = await this.targetPlatform;
+    switch (targetPlatform) {
+      case TargetPlatform.android_arm:
+      case TargetPlatform.android_arm64:
+      case TargetPlatform.android_x64:
+      case TargetPlatform.android_x86:
+        return true;
+      case TargetPlatform.ios:
+      case TargetPlatform.darwin_x64:
+      case TargetPlatform.linux_x64:
+      case TargetPlatform.windows_x64:
+      case TargetPlatform.fuchsia:
+      default:
+        return false;
+    }
+  }
+
   /// Check if a version of the given app is already installed
   Future<bool> isAppInstalled(ApplicationPackage app);
 

--- a/packages/flutter_tools/lib/src/device.dart
+++ b/packages/flutter_tools/lib/src/device.dart
@@ -194,11 +194,8 @@ abstract class Device {
 
   /// Whether the device is a simulator on a platform which supports hardware rendering.
   Future<bool> get supportsHardwareRendering async {
-    if (!await isLocalEmulator) {
-      return false;
-    }
-    final TargetPlatform targetPlatform = await this.targetPlatform;
-    switch (targetPlatform) {
+    assert(await isLocalEmulator);
+    switch (await targetPlatform) {
       case TargetPlatform.android_arm:
       case TargetPlatform.android_arm64:
       case TargetPlatform.android_x64:


### PR DESCRIPTION
If the device is an android emulator, display a message depending on whether software/hardware rendering is enabled.


Fixes #13336