### PR TITLE
[tools] add Stdio to AppContext created by daemon AppInstance

### DIFF
--- a/packages/flutter_tools/lib/src/commands/daemon.dart
+++ b/packages/flutter_tools/lib/src/commands/daemon.dart
@@ -812,6 +812,7 @@ class AppInstance {
 
     final AppContext appContext = new AppContext();
     appContext.setVariable(Logger, _logger);
+    appContext.setVariable(Stdio, const Stdio());
     return appContext.runInZone(method);
   }
 }


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/14636 ... hopefully. My understanding after some debugging is that `ResidentRunner` attempts to print "Service protocol connection closed." when the device-side VM service closes the connection. Simultaneously, the resident process itself is attempting to shutdown. Hence the race: if the resident process shuts down first, it never gets the notification about the severed connection and makes no attempt to print the aforementioned string. However, if it loses the race it attempts to use `Stdio` from the `AppContext` in the current `Zone`. Unfortunately, the daemon never adds `Stdio` to the `AppContext` and so it crashes with `NoSuchMethodError`.

The fix seems to be to simply add `Stdio` to the `AppContext` 🤞

/cc @DanTup @tvolkert 