### PR TITLE
Do not add spacing to the first child's width in RenderWrap line wrapping

### DIFF
--- a/packages/flutter/lib/src/rendering/wrap.dart
+++ b/packages/flutter/lib/src/rendering/wrap.dart
@@ -608,8 +608,7 @@ class RenderWrap extends RenderBox with ContainerRenderObjectMixin<RenderBox, Wr
       child.layout(childConstraints, parentUsesSize: true);
       final double childMainAxisExtent = _getMainAxisExtent(child);
       final double childCrossAxisExtent = _getCrossAxisExtent(child);
-      if (runMainAxisExtent + childMainAxisExtent + spacing > mainAxisLimit) {
-        assert(childCount > 0);
+      if (childCount > 0 && runMainAxisExtent + spacing + childMainAxisExtent > mainAxisLimit) {
         mainAxisExtent = math.max(mainAxisExtent, runMainAxisExtent);
         crossAxisExtent += runCrossAxisExtent;
         if (runMetrics.isNotEmpty)

--- a/packages/flutter/test/widgets/wrap_test.dart
+++ b/packages/flutter/test/widgets/wrap_test.dart
@@ -851,4 +851,19 @@ void main() {
       const Offset(0.0, 20.0)
     ]);
   });
+
+  testWidgets('Object exactly matches container width', (WidgetTester tester) async {
+    await tester.pumpWidget(new Wrap(
+      direction: Axis.horizontal,
+      textDirection: TextDirection.ltr,
+      spacing: 10.0,
+      runSpacing: 10.0,
+      children: <Widget>[
+        const SizedBox(width: 800.0, height: 0.0),
+      ],
+    ));
+
+    expect(tester.renderObject<RenderBox>(find.byType(Wrap)).size, equals(const Size(800.0, 600.0)));
+    verify(tester, <Offset>[const Offset(0.0, 0.0)]);
+  });
 }


### PR DESCRIPTION
The first child fits on the line if the line can accomodate its width.
After the first child the line needs room for the child's width plus spacing.