### PR TITLE
Add height member to LinearProgressIndicator

### DIFF
--- a/examples/flutter_gallery/lib/demo/material/progress_indicator_demo.dart
+++ b/examples/flutter_gallery/lib/demo/material/progress_indicator_demo.dart
@@ -68,7 +68,7 @@ class _ProgressIndicatorDemoState extends State<ProgressIndicatorDemo> with Sing
         child: const LinearProgressIndicator()
       ),
       const LinearProgressIndicator(),
-      const LinearProgressIndicator(),
+      const LinearProgressIndicator(height: 12.0),
       new LinearProgressIndicator(value: _animation.value),
       new Row(
         mainAxisAlignment: MainAxisAlignment.spaceEvenly,

--- a/packages/flutter/lib/src/material/progress_indicator.dart
+++ b/packages/flutter/lib/src/material/progress_indicator.dart
@@ -10,7 +10,6 @@ import 'package:flutter/widgets.dart';
 import 'material.dart';
 import 'theme.dart';
 
-const double _kLinearProgressIndicatorHeight = 6.0;
 const double _kMinCircularProgressIndicatorSize = 36.0;
 
 // TODO(hansmuller): implement the support for buffer indicator
@@ -158,12 +157,19 @@ class LinearProgressIndicator extends ProgressIndicator {
   /// The [value] argument can be either null (corresponding to an indeterminate
   /// progress indicator) or non-null (corresponding to a determinate progress
   /// indicator). See [value] for details.
+  ///
+  /// The [height] argument defaults to `6.0` and must not be `null`.
   const LinearProgressIndicator({
     Key key,
     double value,
     Color backgroundColor,
     Animation<Color> valueColor,
-  }) : super(key: key, value: value, backgroundColor: backgroundColor, valueColor: valueColor);
+    this.height: 6.0,
+  }) : assert(height != null),
+       super(key: key, value: value, backgroundColor: backgroundColor, valueColor: valueColor);
+
+  /// The height of the progress indicator measured in pixels.
+  final double height;
 
   @override
   _LinearProgressIndicatorState createState() => new _LinearProgressIndicatorState();
@@ -203,9 +209,9 @@ class _LinearProgressIndicatorState extends State<LinearProgressIndicator> with 
 
   Widget _buildIndicator(BuildContext context, double animationValue, TextDirection textDirection) {
     return new Container(
-      constraints: const BoxConstraints.tightFor(
+      constraints: new BoxConstraints.tightFor(
         width: double.INFINITY,
-        height: _kLinearProgressIndicatorHeight,
+        height: widget.height,
       ),
       child: new CustomPaint(
         painter: new _LinearProgressIndicatorPainter(

--- a/packages/flutter/test/material/progress_indicator_test.dart
+++ b/packages/flutter/test/material/progress_indicator_test.dart
@@ -208,4 +208,49 @@ void main() {
     expect(find.byType(CircularProgressIndicator), paints..arc(strokeWidth: 16.0));
   });
 
+  testWidgets('LinearProgressIndicator with height 12.0', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const Directionality(
+        textDirection: TextDirection.ltr,
+        child: const Center(
+          child: const SizedBox(
+            width: 100.0,
+            child: const LinearProgressIndicator(value: 0.25, height: 12.0),
+          ),
+        ),
+      ),
+    );
+
+    expect(
+      find.byType(LinearProgressIndicator),
+      paints
+        ..rect(rect: new Rect.fromLTRB(0.0, 0.0, 100.0, 12.0))
+        ..rect(rect: new Rect.fromLTRB(0.0, 0.0, 25.0, 12.0))
+    );
+
+    expect(tester.binding.transientCallbackCount, 0);
+  });
+
+  testWidgets('LinearProgressIndicator with default height', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const Directionality(
+        textDirection: TextDirection.ltr,
+        child: const Center(
+          child: const SizedBox(
+            width: 100.0,
+            child: const LinearProgressIndicator(value: 0.25),
+          ),
+        ),
+      ),
+    );
+
+    expect(
+      find.byType(LinearProgressIndicator),
+      paints
+        ..rect(rect: new Rect.fromLTRB(0.0, 0.0, 100.0, 6.0))
+        ..rect(rect: new Rect.fromLTRB(0.0, 0.0, 25.0, 6.0))
+    );
+
+    expect(tester.binding.transientCallbackCount, 0);
+  });
 }


### PR DESCRIPTION
If merged this will close #15281.

---

This adds a `height` member of type `double` to Material's `LinearProgressIndicator` widget.

The purpose of this is to allow users to specify a custom height.

My personal reason for wanting to do this is to attempt to recreate the indicator used in Google's Project Fi app.

---

**Edit**: Adding an example & screenshot.

```dart
class TabB extends StatelessWidget {
  const TabB();

  @override
  Widget build(BuildContext context) {
    return new Center(
      child: new Container(
        color: Colors.white,
        child: new Center(
          child: new Column(
            children: [
              new Padding(
                padding: const EdgeInsets.all(8.0),
                child: new LinearProgressIndicator(value: 0.2), // `height` is null so use `6.0`
              ),
              new Padding(
                padding: const EdgeInsets.all(8.0),
                child: new LinearProgressIndicator(value: 0.4, height: 0.0), // `height` is less than `1.0` so use `1.0`
              ),
              new Padding(
                padding: const EdgeInsets.all(8.0),
                child: new LinearProgressIndicator(value: 0.6, height: 18.0),
              ),
            ],
          ),
        ),
      ),
    );
  }
}
```
![custom_heights](https://user-images.githubusercontent.com/4861023/37135916-40106e72-2254-11e8-9155-a0d5dc9cfdee.png)