### PR TITLE
Add Text.rich constructor to Text widget

### DIFF
--- a/packages/flutter/lib/src/widgets/text.dart
+++ b/packages/flutter/lib/src/widgets/text.dart
@@ -164,13 +164,8 @@ class DefaultTextStyle extends InheritedWidget {
 /// for example, to make the text bold while using the default font family and
 /// size.
 ///
-/// The [Text] widget can also be created directly from a [TextSpan]. Default text
-/// styles will not be provided to the span in this case, but they are used as default
-/// values for the other named parameters.
-///
-///
-/// To display text that uses multiple styles (e.g., a paragraph with some bold
-/// words), use [RichText].
+/// The [Text] widget can also be created directly from a [TextSpan] to display
+/// text that uses multiple styles (e.g., a paragraph with some bold words).
 ///
 /// ## Sample code
 ///
@@ -218,8 +213,8 @@ class Text extends StatelessWidget {
        span = null,
        super(key: key);
 
-  /// Creates a text widget from a [TextSpan].
-  const Text.fromSpan(this.span, {
+  /// Creates a text widget with a [TextSpan].
+  const Text.rich(this.span, {
     Key key,
     this.textAlign,
     this.textDirection,
@@ -239,7 +234,7 @@ class Text extends StatelessWidget {
 
   /// The text to display as a span.
   ///
-  /// If constructed from a [TextSpan], `data` will be null.
+  /// If constructed with a [TextSpan], `data` will be null.
   final TextSpan span;
 
   /// If non-null, the style to use for this text.
@@ -248,7 +243,7 @@ class Text extends StatelessWidget {
   /// the closest enclosing [DefaultTextStyle]. Otherwise, the style will
   /// replace the closest enclosing [DefaultTextStyle].
   ///
-  /// If constructed from a [TextSpan], the style will be null.
+  /// If constructed with a [TextSpan], the style will be null.
   final TextStyle style;
 
   /// How the text should be aligned horizontally.

--- a/packages/flutter/lib/src/widgets/text.dart
+++ b/packages/flutter/lib/src/widgets/text.dart
@@ -164,8 +164,9 @@ class DefaultTextStyle extends InheritedWidget {
 /// for example, to make the text bold while using the default font family and
 /// size.
 ///
-/// The [Text] widget can also be created with a [TextSpan] to display text that
-/// uses multiple styles (e.g., a paragraph with some bold words).
+/// Using the [new TextSpan.rich] constructor, the [Text] widget can also be
+/// created with a [TextSpan] to display text that use multiple styles
+/// (e.g., a paragraph with some bold words).
 ///
 /// ## Sample code
 ///
@@ -210,11 +211,11 @@ class Text extends StatelessWidget {
     this.textScaleFactor,
     this.maxLines,
   }) : assert(data != null),
-       span = null,
+       textSpan = null,
        super(key: key);
 
   /// Creates a text widget with a [TextSpan].
-  const Text.rich(this.span, {
+  const Text.rich(this.textSpan, {
     Key key,
     this.style,
     this.textAlign,
@@ -223,19 +224,19 @@ class Text extends StatelessWidget {
     this.overflow,
     this.textScaleFactor,
     this.maxLines,
-  }): assert(span != null),
+  }): assert(textSpan != null),
       data = null,
       super(key: key);
 
   /// The text to display.
   ///
-  /// This will be null if a [TextSpan] is provided instead.
+  /// This will be null if a [textSpan] is provided instead.
   final String data;
 
-  /// The text to display as a span.
+  /// The text to display as a [TextSpan].
   ///
-  /// This will be null if a String is provided instead.
-  final TextSpan span;
+  /// This will be null if [data] is provided instead.
+  final TextSpan textSpan;
 
   /// If non-null, the style to use for this text.
   ///
@@ -309,7 +310,7 @@ class Text extends StatelessWidget {
       text: new TextSpan(
         style: effectiveTextStyle,
         text: data,
-        children: span != null ? <TextSpan>[span] : null,
+        children: textSpan != null ? <TextSpan>[textSpan] : null,
       ),
     );
   }
@@ -318,7 +319,9 @@ class Text extends StatelessWidget {
   void debugFillProperties(DiagnosticPropertiesBuilder description) {
     super.debugFillProperties(description);
     description.add(new StringProperty('data', data, showName: false));
-    span?.debugFillProperties(description);
+    if (textSpan != null) {
+      description.add(textSpan.toDiagnosticsNode(name: 'textSpan', style: DiagnosticsTreeStyle.transition));
+    }
     style?.debugFillProperties(description);
     description.add(new EnumProperty<TextAlign>('textAlign', textAlign, defaultValue: null));
     description.add(new EnumProperty<TextDirection>('textDirection', textDirection, defaultValue: null));

--- a/packages/flutter/lib/src/widgets/text.dart
+++ b/packages/flutter/lib/src/widgets/text.dart
@@ -216,6 +216,7 @@ class Text extends StatelessWidget {
   /// Creates a text widget with a [TextSpan].
   const Text.rich(this.span, {
     Key key,
+    this.style,
     this.textAlign,
     this.textDirection,
     this.softWrap,
@@ -224,17 +225,16 @@ class Text extends StatelessWidget {
     this.maxLines,
   }): assert(span != null),
       data = null,
-      style = null,
       super(key: key);
 
   /// The text to display.
   ///
-  /// If constructed with the default constructor, `span` will be null.
+  /// This will be null if a [TextSpan] is provided instead.
   final String data;
 
   /// The text to display as a span.
   ///
-  /// If constructed with a [TextSpan], `data` will be null.
+  /// This will be null if a String is provided instead.
   final TextSpan span;
 
   /// If non-null, the style to use for this text.
@@ -242,8 +242,6 @@ class Text extends StatelessWidget {
   /// If the style's "inherit" property is true, the style will be merged with
   /// the closest enclosing [DefaultTextStyle]. Otherwise, the style will
   /// replace the closest enclosing [DefaultTextStyle].
-  ///
-  /// If constructed with a [TextSpan], the style will be null.
   final TextStyle style;
 
   /// How the text should be aligned horizontally.
@@ -299,7 +297,7 @@ class Text extends StatelessWidget {
   Widget build(BuildContext context) {
     final DefaultTextStyle defaultTextStyle = DefaultTextStyle.of(context);
     TextStyle effectiveTextStyle = style;
-    if (span == null && (style == null || style.inherit))
+    if (style == null || style.inherit)
       effectiveTextStyle = defaultTextStyle.style.merge(style);
     return new RichText(
       textAlign: textAlign ?? defaultTextStyle.textAlign ?? TextAlign.start,
@@ -308,17 +306,19 @@ class Text extends StatelessWidget {
       overflow: overflow ?? defaultTextStyle.overflow,
       textScaleFactor: textScaleFactor ?? MediaQuery.of(context, nullOk: true)?.textScaleFactor ?? 1.0,
       maxLines: maxLines ?? defaultTextStyle.maxLines,
-      text: span ?? new TextSpan(
+      text: new TextSpan(
         style: effectiveTextStyle,
         text: data,
-      )
+        children: span != null ? <TextSpan>[span] : null,
+      ),
     );
   }
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder description) {
     super.debugFillProperties(description);
-    description.add(new StringProperty('data', data ?? span.toPlainText(), showName: false));
+    description.add(new StringProperty('data', data, showName: false));
+    span?.debugFillProperties(description);
     style?.debugFillProperties(description);
     description.add(new EnumProperty<TextAlign>('textAlign', textAlign, defaultValue: null));
     description.add(new EnumProperty<TextDirection>('textDirection', textDirection, defaultValue: null));

--- a/packages/flutter/lib/src/widgets/text.dart
+++ b/packages/flutter/lib/src/widgets/text.dart
@@ -164,8 +164,8 @@ class DefaultTextStyle extends InheritedWidget {
 /// for example, to make the text bold while using the default font family and
 /// size.
 ///
-/// The [Text] widget can also be created directly from a [TextSpan] to display
-/// text that uses multiple styles (e.g., a paragraph with some bold words).
+/// The [Text] widget can also be created with a [TextSpan] to display text that
+/// uses multiple styles (e.g., a paragraph with some bold words).
 ///
 /// ## Sample code
 ///

--- a/packages/flutter/lib/src/widgets/text.dart
+++ b/packages/flutter/lib/src/widgets/text.dart
@@ -164,6 +164,11 @@ class DefaultTextStyle extends InheritedWidget {
 /// for example, to make the text bold while using the default font family and
 /// size.
 ///
+/// The [Text] widget can also be created directly from a [TextSpan]. Default text
+/// styles will not be provided to the span in this case, but they are used as default
+/// values for the other named parameters.
+///
+///
 /// To display text that uses multiple styles (e.g., a paragraph with some bold
 /// words), use [RichText].
 ///
@@ -210,16 +215,40 @@ class Text extends StatelessWidget {
     this.textScaleFactor,
     this.maxLines,
   }) : assert(data != null),
+       span = null,
        super(key: key);
 
+  /// Creates a text widget from a [TextSpan].
+  const Text.fromSpan(this.span, {
+    Key key,
+    this.textAlign,
+    this.textDirection,
+    this.softWrap,
+    this.overflow,
+    this.textScaleFactor,
+    this.maxLines,
+  }): assert(span != null),
+      data = null,
+      style = null,
+      super(key: key);
+
   /// The text to display.
+  ///
+  /// If constructed with the default constructor, `span` will be null.
   final String data;
+
+  /// The text to display as a span.
+  ///
+  /// If constructed from a [TextSpan], `data` will be null.
+  final TextSpan span;
 
   /// If non-null, the style to use for this text.
   ///
   /// If the style's "inherit" property is true, the style will be merged with
   /// the closest enclosing [DefaultTextStyle]. Otherwise, the style will
   /// replace the closest enclosing [DefaultTextStyle].
+  ///
+  /// If constructed from a [TextSpan], the style will be null.
   final TextStyle style;
 
   /// How the text should be aligned horizontally.
@@ -275,7 +304,7 @@ class Text extends StatelessWidget {
   Widget build(BuildContext context) {
     final DefaultTextStyle defaultTextStyle = DefaultTextStyle.of(context);
     TextStyle effectiveTextStyle = style;
-    if (style == null || style.inherit)
+    if (span == null && (style == null || style.inherit))
       effectiveTextStyle = defaultTextStyle.style.merge(style);
     return new RichText(
       textAlign: textAlign ?? defaultTextStyle.textAlign ?? TextAlign.start,
@@ -284,7 +313,7 @@ class Text extends StatelessWidget {
       overflow: overflow ?? defaultTextStyle.overflow,
       textScaleFactor: textScaleFactor ?? MediaQuery.of(context, nullOk: true)?.textScaleFactor ?? 1.0,
       maxLines: maxLines ?? defaultTextStyle.maxLines,
-      text: new TextSpan(
+      text: span ?? new TextSpan(
         style: effectiveTextStyle,
         text: data,
       )
@@ -294,7 +323,7 @@ class Text extends StatelessWidget {
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder description) {
     super.debugFillProperties(description);
-    description.add(new StringProperty('data', data, showName: false));
+    description.add(new StringProperty('data', data ?? span.toPlainText(), showName: false));
     style?.debugFillProperties(description);
     description.add(new EnumProperty<TextAlign>('textAlign', textAlign, defaultValue: null));
     description.add(new EnumProperty<TextDirection>('textDirection', textDirection, defaultValue: null));

--- a/packages/flutter/test/widgets/text_test.dart
+++ b/packages/flutter/test/widgets/text_test.dart
@@ -85,4 +85,22 @@ void main() {
     expect(message, contains('Directionality'));
     expect(message, contains(' Text '));
   });
+
+  testWidgets('Text can be created from TextSpans', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const Text.fromSpan(
+        const TextSpan(
+          text: 'Hello',
+          children: const <TextSpan>[
+            const TextSpan(text: ' beautiful ', style: const TextStyle(fontStyle: FontStyle.italic)),
+            const TextSpan(text: 'world', style: const TextStyle(fontWeight: FontWeight.bold)),
+          ],
+        ),
+        textDirection: TextDirection.ltr,
+      ),
+    );
+
+    final RichText text = tester.firstWidget(find.byType(RichText));
+    expect(text, isNotNull);
+  });
 }

--- a/packages/flutter/test/widgets/text_test.dart
+++ b/packages/flutter/test/widgets/text_test.dart
@@ -86,21 +86,27 @@ void main() {
     expect(message, contains(' Text '));
   });
 
-  testWidgets('Text can be created from TextSpans', (WidgetTester tester) async {
+  testWidgets('Text can be created from TextSpans and uses defaultTextStyle', (WidgetTester tester) async {
     await tester.pumpWidget(
-      const Text.rich(
-        const TextSpan(
-          text: 'Hello',
-          children: const <TextSpan>[
-            const TextSpan(text: ' beautiful ', style: const TextStyle(fontStyle: FontStyle.italic)),
-            const TextSpan(text: 'world', style: const TextStyle(fontWeight: FontWeight.bold)),
-          ],
+      const DefaultTextStyle(
+        style: const TextStyle(
+          fontSize: 20.0,
         ),
-        textDirection: TextDirection.ltr,
+        child: const Text.rich(
+          const TextSpan(
+            text: 'Hello',
+            children: const <TextSpan>[
+              const TextSpan(text: ' beautiful ', style: const TextStyle(fontStyle: FontStyle.italic)),
+              const TextSpan(text: 'world', style: const TextStyle(fontWeight: FontWeight.bold)),
+            ],
+          ),
+          textDirection: TextDirection.ltr,
+        ),
       ),
     );
 
     final RichText text = tester.firstWidget(find.byType(RichText));
     expect(text, isNotNull);
+    expect(text.text.style.fontSize, 20.0);
   });
 }

--- a/packages/flutter/test/widgets/text_test.dart
+++ b/packages/flutter/test/widgets/text_test.dart
@@ -88,7 +88,7 @@ void main() {
 
   testWidgets('Text can be created from TextSpans', (WidgetTester tester) async {
     await tester.pumpWidget(
-      const Text.fromSpan(
+      const Text.rich(
         const TextSpan(
           text: 'Hello',
           children: const <TextSpan>[


### PR DESCRIPTION
This allows a text widget to be constructed directly from a TextSpan.  The Tree of spans can each have their own styles while still inheriting from the default text styles (though these are not applied directly - I assume there is some magic here I am missing).  

Adds named constructor fromSpan to TextWidget
Adds member TextSpan span to TextWidget
Adds simple smoke test (any insight into testing these changes would be appreciated).

Fixes #13791