### PR TITLE
Added custom selection indicators to the gallery scrollable tabs demo

### DIFF
--- a/examples/flutter_gallery/lib/demo/material/scrollable_tabs_demo.dart
+++ b/examples/flutter_gallery/lib/demo/material/scrollable_tabs_demo.dart
@@ -43,6 +43,7 @@ class ScrollableTabsDemo extends StatefulWidget {
 class ScrollableTabsDemoState extends State<ScrollableTabsDemo> with SingleTickerProviderStateMixin {
   TabController _controller;
   TabsDemoStyle _demoStyle = TabsDemoStyle.iconsAndText;
+  bool _customIndicator = false;
 
   @override
   void initState() {
@@ -62,6 +63,61 @@ class ScrollableTabsDemoState extends State<ScrollableTabsDemo> with SingleTicke
     });
   }
 
+  ShapeDecoration getIndicator() {
+    if (!_customIndicator)
+      return null;
+
+    switch(_demoStyle) {
+      case TabsDemoStyle.iconsAndText:
+        return new ShapeDecoration(
+          shape: const RoundedRectangleBorder(
+            borderRadius: const BorderRadius.all(const Radius.circular(4.0)),
+            side: const BorderSide(
+              color: Colors.white24,
+              width: 2.0,
+            ),
+          ) + const RoundedRectangleBorder(
+            borderRadius: const BorderRadius.all(const Radius.circular(4.0)),
+            side: const BorderSide(
+              color: Colors.transparent,
+              width: 4.0,
+            ),
+          ),
+        );
+
+      case TabsDemoStyle.iconsOnly:
+        return new ShapeDecoration(
+          shape: const CircleBorder(
+            side: const BorderSide(
+              color: Colors.white24,
+              width: 4.0,
+            ),
+          ) + const CircleBorder(
+            side: const BorderSide(
+              color: Colors.transparent,
+              width: 4.0,
+            ),
+          ),
+        );
+
+      case TabsDemoStyle.textOnly:
+        return new ShapeDecoration(
+          shape: const StadiumBorder(
+            side: const BorderSide(
+              color: Colors.white24,
+              width: 2.0,
+            ),
+          ) + const StadiumBorder(
+            side: const BorderSide(
+              color: Colors.transparent,
+              width: 4.0,
+            ),
+          ),
+        );
+    }
+    return null;
+  }
+
   @override
   Widget build(BuildContext context) {
     final Color iconColor = Theme.of(context).accentColor;
@@ -69,6 +125,14 @@ class ScrollableTabsDemoState extends State<ScrollableTabsDemo> with SingleTicke
       appBar: new AppBar(
         title: const Text('Scrollable tabs'),
         actions: <Widget>[
+          new IconButton(
+            icon: const Icon(Icons.sentiment_very_satisfied),
+            onPressed: () {
+              setState(() {
+                _customIndicator = !_customIndicator;
+              });
+            },
+          ),
           new PopupMenuButton<TabsDemoStyle>(
             onSelected: changeDemoStyle,
             itemBuilder: (BuildContext context) => <PopupMenuItem<TabsDemoStyle>>[
@@ -90,6 +154,7 @@ class ScrollableTabsDemoState extends State<ScrollableTabsDemo> with SingleTicke
         bottom: new TabBar(
           controller: _controller,
           isScrollable: true,
+          indicator: getIndicator(),
           tabs: _allPages.map((_Page page) {
             switch (_demoStyle) {
               case TabsDemoStyle.iconsAndText:


### PR DESCRIPTION
Pressing the smiley face turns on the custom tab selection indicators. There's a different indicator for each kind of tab label.

![both](https://user-images.githubusercontent.com/1377460/37186976-f46c577a-22fc-11e8-8a89-4d9bdde6bca4.png)

![text_only](https://user-images.githubusercontent.com/1377460/37186981-f8f6567e-22fc-11e8-8380-7cb4f1e541f3.png)

![icons_only](https://user-images.githubusercontent.com/1377460/37186984-fbea6fc8-22fc-11e8-8e75-e3f64981547e.png)

As a second step (another PR), I will add an insets parameter to the ShapeBorder subclasses (like CircleBorder) and then simplify the code that constructs the custom indicators. For example:

```dart
new ShapeDecoration(
  shape: const CircleBorder(
    insets: const EdgeInsets.all(4.0),
    side: const BorderSide(
      color: Colors.white24,
      width: 4.0,
    ),
  ),

  // insets instead of adding:
  const CircleBorder(
    side: const BorderSide(
      color: Colors.transparent,
      width: 4.0,
    ),
  )
```
