### PR TITLE
Remove package:http from flutter

### DIFF
--- a/dev/bots/test/prepare_package_test.dart
+++ b/dev/bots/test/prepare_package_test.dart
@@ -17,6 +17,24 @@ import 'fake_process_manager.dart';
 
 void main() {
   final String testRef = 'deadbeefdeadbeefdeadbeefdeadbeefdeadbeef';
+  test('Throws on missing executable', () async {
+    // Uses a *real* process manager, since we want to know what happens if
+    // it can't find an executable.
+    final ProcessRunner processRunner = new ProcessRunner(subprocessOutput: false);
+    expect(
+        expectAsync1((List<String> commandLine) async {
+          return processRunner.runProcess(commandLine);
+        })(<String>['this_executable_better_not_exist_2857632534321']),
+        throwsA(const isInstanceOf<ProcessRunnerException>()));
+    try {
+      await processRunner.runProcess(<String>['this_executable_better_not_exist_2857632534321']);
+    } on ProcessRunnerException catch (e) {
+      expect(
+        e.message,
+        contains('Invalid argument(s): Cannot find executable for this_executable_better_not_exist_2857632534321.'),
+      );
+    }
+  });
   for (String platformName in <String>['macos', 'linux', 'windows']) {
     final FakePlatform platform = new FakePlatform(
       operatingSystem: platformName,

--- a/dev/manual_tests/test/card_collection_test.dart
+++ b/dev/manual_tests/test/card_collection_test.dart
@@ -2,8 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:io';
+
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart' show createHttpClient;
 import 'package:flutter_test/flutter_test.dart';
 
 import '../lib/card_collection.dart' as card_collection;
@@ -11,31 +12,32 @@ import 'mock_image_http.dart';
 
 void main() {
   testWidgets('Card Collection smoke test', (WidgetTester tester) async {
-    createHttpClient = createMockImageHttpClient;
-    card_collection.main(); // builds the app and schedules a frame but doesn't trigger one
-    await tester.pump(); // see https://github.com/flutter/flutter/issues/1865
-    await tester.pump(); // triggers a frame
+    HttpOverrides.runZoned(() async {
+      card_collection.main(); // builds the app and schedules a frame but doesn't trigger one
+      await tester.pump(); // see https://github.com/flutter/flutter/issues/1865
+      await tester.pump(); // triggers a frame
 
-    final Finder navigationMenu = find.byWidgetPredicate((Widget widget) {
-      if (widget is Tooltip)
-        return widget.message == 'Open navigation menu';
-      return false;
-    });
+      final Finder navigationMenu = find.byWidgetPredicate((Widget widget) {
+        if (widget is Tooltip)
+          return widget.message == 'Open navigation menu';
+        return false;
+      });
 
-    expect(navigationMenu, findsOneWidget);
+      expect(navigationMenu, findsOneWidget);
 
-    await tester.tap(navigationMenu);
-    await tester.pump(); // start opening menu
-    await tester.pump(const Duration(seconds: 1)); // wait til it's really opened
+      await tester.tap(navigationMenu);
+      await tester.pump(); // start opening menu
+      await tester.pump(const Duration(seconds: 1)); // wait til it's really opened
 
-    // smoke test for various checkboxes
-    await tester.tap(find.text('Make card labels editable'));
-    await tester.pump();
-    await tester.tap(find.text('Let the sun shine'));
-    await tester.pump();
-    await tester.tap(find.text('Make card labels editable'));
-    await tester.pump();
-    await tester.tap(find.text('Vary font sizes'));
-    await tester.pump();
+      // smoke test for various checkboxes
+      await tester.tap(find.text('Make card labels editable'));
+      await tester.pump();
+      await tester.tap(find.text('Let the sun shine'));
+      await tester.pump();
+      await tester.tap(find.text('Make card labels editable'));
+      await tester.pump();
+      await tester.tap(find.text('Vary font sizes'));
+      await tester.pump();
+    }, createHttpClient: createMockImageHttpClient);
   });
 }

--- a/dev/manual_tests/test/color_testing_demo_test.dart
+++ b/dev/manual_tests/test/color_testing_demo_test.dart
@@ -2,25 +2,27 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:io';
+
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart' show createHttpClient;
 import 'package:flutter_test/flutter_test.dart';
 
 import '../lib/color_testing_demo.dart' as color_testing_demo;
 import 'mock_image_http.dart';
 
 void main() {
-
   testWidgets('Color testing demo smoke test', (WidgetTester tester) async {
-    createHttpClient = createMockImageHttpClient;
-    color_testing_demo.main(); // builds the app and schedules a frame but doesn't trigger one
-    await tester.pump(); // see https://github.com/flutter/flutter/issues/1865
-    await tester.pump(); // triggers a frame
+    HttpOverrides.runZoned(() async {
+      color_testing_demo.main(); // builds the app and schedules a frame but doesn't trigger one
 
-    await tester.dragFrom(const Offset(0.0, 500.0), const Offset(0.0, 0.0)); // scrolls down
-    await tester.pump();
+      await tester.pump(); // see https://github.com/flutter/flutter/issues/1865
+      await tester.pump(); // triggers a frame
 
-    await tester.dragFrom(const Offset(0.0, 500.0), const Offset(0.0, 0.0)); // scrolls down
-    await tester.pump();
+      await tester.dragFrom(const Offset(0.0, 500.0), const Offset(0.0, 0.0)); // scrolls down
+      await tester.pump();
+
+      await tester.dragFrom(const Offset(0.0, 500.0), const Offset(0.0, 0.0)); // scrolls down
+      await tester.pump();
+    }, createHttpClient: createMockImageHttpClient);
   });
 }

--- a/dev/manual_tests/test/mock_image_http.dart
+++ b/dev/manual_tests/test/mock_image_http.dart
@@ -1,15 +1,39 @@
 import 'dart:async';
-import 'package:flutter/foundation.dart' show ValueGetter;
-import 'package:http/http.dart' as http;
-import 'package:http/testing.dart' as http;
+import 'dart:io';
+import 'package:mockito/mockito.dart';
 
 import '../../../packages/flutter/test/painting/image_data.dart';
 
 // Returns a mock HTTP client that responds with an image to all requests.
-ValueGetter<http.Client> createMockImageHttpClient = () {
-  return new http.MockClient((http.BaseRequest request) {
-    return new Future<http.Response>.value(
-      new http.Response.bytes(kTransparentImage, 200, request: request)
-    );
-  });
-};
+HttpClient createMockImageHttpClient(SecurityContext context) {
+  final MockHttpClient client = new MockHttpClient();
+  final MockHttpClientRequest request = new MockHttpClientRequest();
+  final MockHttpClientResponse response = new MockHttpClientResponse(kTransparentImage);
+  final MockHttpHeaders headers = new MockHttpHeaders();
+
+  when(request.headers).thenReturn(headers);
+  when(request.close()).thenReturn(new Future<HttpClientResponse>.value(response));
+  when(response.statusCode).thenReturn(200);
+  when(response.contentLength).thenReturn(kTransparentImage.length);
+  when(client.getUrl(typed(any))).thenReturn(request);
+
+  return client;
+}
+
+class MockHttpClient extends Mock implements HttpClient {}
+
+class MockHttpClientRequest extends Mock implements HttpClientRequest {}
+
+class MockHttpHeaders extends Mock implements HttpHeaders {}
+
+class MockHttpClientResponse extends Mock implements HttpClientResponse {
+  MockHttpClientResponse(this.bytes);
+
+  final List<int> bytes;
+
+  @override
+  StreamSubscription<List<int>> listen(void onData(List<int> event),
+      {Function onError, void onDone(), bool cancelOnError}) {
+    return new Stream<List<int>>.fromIterable(<List<int>>[bytes]).listen(onData, onError: onError, onDone: onDone, cancelOnError: cancelOnError);
+  }
+}

--- a/examples/layers/test/smoketests/widgets/spinning_mixed_test.dart
+++ b/examples/layers/test/smoketests/widgets/spinning_mixed_test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:io';
+
 import 'package:flutter/foundation.dart';
 import 'package:test/test.dart';
 
@@ -9,7 +11,9 @@ import '../../../widgets/spinning_mixed.dart' as demo;
 
 void main() {
   test('layers smoketest for widgets/spinning_mixed.dart', () {
-    FlutterError.onError = (FlutterErrorDetails details) { throw details.exception; };
-    demo.main();
+    HttpOverrides.runZoned(() {
+      FlutterError.onError = (FlutterErrorDetails details) { throw details.exception; };
+      demo.main();
+    }, createHttpClient: (_) => null());
   });
 }

--- a/examples/layers/test/smoketests/widgets/spinning_mixed_test.dart
+++ b/examples/layers/test/smoketests/widgets/spinning_mixed_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:io';
-
 import 'package:flutter/foundation.dart';
 import 'package:test/test.dart';
 
@@ -11,9 +9,7 @@ import '../../../widgets/spinning_mixed.dart' as demo;
 
 void main() {
   test('layers smoketest for widgets/spinning_mixed.dart', () {
-    HttpOverrides.runZoned(() {
-      FlutterError.onError = (FlutterErrorDetails details) { throw details.exception; };
-      demo.main();
-    }, createHttpClient: (_) => null());
+    FlutterError.onError = (FlutterErrorDetails details) { throw details.exception; };
+    demo.main();
   });
 }

--- a/examples/stocks/lib/stock_data.dart
+++ b/examples/stocks/lib/stock_data.dart
@@ -11,7 +11,6 @@ import 'dart:convert';
 import 'dart:math' as math;
 
 import 'package:flutter/foundation.dart';
-import 'package:flutter/services.dart';
 import 'package:http/http.dart' as http;
 
 final math.Random _rng = new math.Random();
@@ -42,7 +41,7 @@ class Stock {
 class StockData extends ChangeNotifier {
   StockData() {
     if (actuallyFetchData) {
-      _httpClient = createHttpClient();
+      _httpClient = new http.Client();
       _fetchNextChunk();
     }
   }

--- a/packages/flutter/BUILD.gn
+++ b/packages/flutter/BUILD.gn
@@ -28,8 +28,6 @@ dart_library("flutter") {
     "//third_party/dart/third_party/pkg/intl",
     "//third_party/dart-pkg/pub/async",
     "//third_party/dart-pkg/pub/collection",
-    "//third_party/dart-pkg/pub/http",
-    "//third_party/dart-pkg/pub/http_parser",
     "//third_party/dart-pkg/pub/meta",
     "//third_party/dart-pkg/pub/vector_math",
   ]

--- a/packages/flutter/lib/services.dart
+++ b/packages/flutter/lib/services.dart
@@ -14,7 +14,6 @@ export 'src/services/asset_bundle.dart';
 export 'src/services/binding.dart';
 export 'src/services/clipboard.dart';
 export 'src/services/haptic_feedback.dart';
-export 'src/services/http_client.dart';
 export 'src/services/message_codec.dart';
 export 'src/services/message_codecs.dart';
 export 'src/services/platform_channel.dart';

--- a/packages/flutter/lib/src/painting/image_provider.dart
+++ b/packages/flutter/lib/src/painting/image_provider.dart
@@ -432,7 +432,7 @@ class NetworkImage extends ImageProvider<NetworkImage> {
     );
   }
 
-  static final HttpClient _httpClient = HttpOverrides.current.createHttpClient(SecurityContext.defaultContext);
+  static final HttpClient _httpClient = new HttpClient();
 
   Future<ui.Codec> _loadAsync(NetworkImage key) async {
     assert(key == this);

--- a/packages/flutter/lib/src/painting/image_provider.dart
+++ b/packages/flutter/lib/src/painting/image_provider.dart
@@ -441,7 +441,7 @@ class NetworkImage extends ImageProvider<NetworkImage> {
     headers?.forEach((String name, String value) {
       request.headers.add(name, value);
     });
-    final HttpClientResponse  response = await request.close();
+    final HttpClientResponse response = await request.close();
     if (response == null || response.statusCode != 200)
       throw new Exception('HTTP request failed, statusCode: ${response?.statusCode}, $resolved');
 

--- a/packages/flutter/lib/src/painting/image_provider.dart
+++ b/packages/flutter/lib/src/painting/image_provider.dart
@@ -3,14 +3,14 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:io' show File;
+import 'dart:convert';
+import 'dart:io';
 import 'dart:typed_data';
 import 'dart:ui' as ui show instantiateImageCodec, Codec;
 import 'dart:ui' show Size, Locale, TextDirection, hashValues;
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
-import 'package:http/http.dart' as http;
 
 import 'binding.dart';
 import 'image_stream.dart';
@@ -432,20 +432,44 @@ class NetworkImage extends ImageProvider<NetworkImage> {
     );
   }
 
-  static final http.Client _httpClient = createHttpClient();
+  static final HttpClient _httpClient = HttpOverrides.current.createHttpClient(SecurityContext.defaultContext);
 
   Future<ui.Codec> _loadAsync(NetworkImage key) async {
     assert(key == this);
-
     final Uri resolved = Uri.base.resolve(key.url);
-    final http.Response response = await _httpClient.get(resolved, headers: headers);
+    final HttpClientRequest request = await _httpClient.getUrl(resolved);
+    headers?.forEach((String name, String value) {
+      request.headers.add(name, value);
+    });
+    final HttpClientResponse  response = await request.close();
     if (response == null || response.statusCode != 200)
       throw new Exception('HTTP request failed, statusCode: ${response?.statusCode}, $resolved');
 
-    final Uint8List bytes = response.bodyBytes;
-    if (bytes.lengthInBytes == 0)
-      throw new Exception('NetworkImage is an empty file: $resolved');
+    final Completer<Uint8List> completer = new Completer<Uint8List>.sync();
+    // We don't know the size of the response
+    if (response.contentLength == -1) {
+      final ByteConversionSink sink = new ByteConversionSink.withCallback((List<int> bytes) {
+        completer.complete(new Uint8List.fromList(bytes));
+      });
+      response.listen(sink.add, onError: completer.completeError, onDone: sink.close,
+          cancelOnError: true);
+      final Uint8List bytes = await completer.future;
+      if (bytes.lengthInBytes == 0)
+        throw new Exception('NetworkImage is an empty file: $resolved');
 
+      return await ui.instantiateImageCodec(bytes);
+    }
+
+    final Uint8List bytes = new Uint8List(response.contentLength);
+    int offset = 0;
+    response.listen((List<int> chunk) {
+      for (int i = 0; i < chunk.length; i++, offset++) {
+        bytes[offset] = chunk[i];
+      }
+    }, onError: completer.completeError, onDone: () {
+      completer.complete(bytes);
+    });
+    await completer.future;
     return await ui.instantiateImageCodec(bytes);
   }
 

--- a/packages/flutter/lib/src/services/asset_bundle.dart
+++ b/packages/flutter/lib/src/services/asset_bundle.dart
@@ -116,14 +116,14 @@ class NetworkAssetBundle extends AssetBundle {
           cancelOnError: true);
       return completer.future;
     }
-    final ByteData byteData = new ByteData(response.contentLength);
+    final Uint8List bytes = new Uint8List(response.contentLength);
     int offset = 0;
     response.listen((List<int> chunk) {
       for (int i = 0; i < chunk.length; i++, offset++) {
-        byteData.setUint8(offset, chunk[i]);
+        bytes[offset] = chunk[i];
       }
     }, onError: completer.completeError, onDone: () {
-      completer.complete(byteData);
+      completer.complete(bytes.buffer.asByteData());
     });
     return completer.future;
   }

--- a/packages/flutter/lib/src/services/asset_bundle.dart
+++ b/packages/flutter/lib/src/services/asset_bundle.dart
@@ -90,7 +90,7 @@ class NetworkAssetBundle extends AssetBundle {
   /// to the given base URL.
   NetworkAssetBundle(Uri baseUrl)
     : _baseUrl = baseUrl,
-      _httpClient = HttpOverrides.current.createHttpClient(SecurityContext.defaultContext);
+      _httpClient = new HttpClient();
 
   final Uri _baseUrl;
   final HttpClient _httpClient;

--- a/packages/flutter/lib/src/services/http_client.dart
+++ b/packages/flutter/lib/src/services/http_client.dart
@@ -1,4 +1,0 @@
-import 'dart:async';
-import 'dart:io';
-
-import 'package:flutter/foundation.dart';

--- a/packages/flutter/lib/src/services/http_client.dart
+++ b/packages/flutter/lib/src/services/http_client.dart
@@ -1,20 +1,4 @@
-// Copyright 2017 The Chromium Authors. All rights reserved.
-// Use of this source code is governed by a BSD-style license that can be
-// found in the LICENSE file.
+import 'dart:async';
+import 'dart:io';
 
 import 'package:flutter/foundation.dart';
-import 'package:http/http.dart' as http;
-
-/// (Deprecated, use [dart:io.HttpClientOverrides]) Create a new [http.Client] object.
-///
-/// We recommend [dart:io.HttpClientOverrides] instead of this function. Flutter
-/// will soon use [dart:io.HttpClient].
-///
-/// This can be set to a new function to override the default logic for creating
-/// HTTP clients, for example so that all logic in the framework that triggers
-/// HTTP requests will use the same `UserAgent` header, or so that tests can
-/// provide an [http.testing.MockClient].
-// TODO(ianh): Fix the link to MockClient once dartdoc has a solution.
-ValueGetter<http.Client> createHttpClient = () {
-  return new http.Client();
-};

--- a/packages/flutter/lib/src/widgets/animated_cross_fade.dart
+++ b/packages/flutter/lib/src/widgets/animated_cross_fade.dart
@@ -247,13 +247,13 @@ class _AnimatedCrossFadeState extends State<AnimatedCrossFade> with TickerProvid
   Animation<double> _initAnimation(Curve curve, bool inverted) {
     Animation<double> animation = new CurvedAnimation(
       parent: _controller,
-      curve: curve
+      curve: curve,
     );
 
     if (inverted) {
       animation = new Tween<double>(
-          begin: 1.0,
-          end: 0.0
+        begin: 1.0,
+        end: 0.0,
       ).animate(animation);
     }
 

--- a/packages/flutter/lib/src/widgets/transitions.dart
+++ b/packages/flutter/lib/src/widgets/transitions.dart
@@ -332,6 +332,12 @@ class FadeTransition extends SingleChildRenderObjectWidget {
     renderObject
       ..opacity = opacity;
   }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder description) {
+    super.debugFillProperties(description);
+    description.add(new DiagnosticsProperty<Animation<double>>('opacity', opacity));
+  }
 }
 
 /// An interpolation between two relative rects.

--- a/packages/flutter/pubspec.yaml
+++ b/packages/flutter/pubspec.yaml
@@ -6,7 +6,6 @@ homepage: http://flutter.io
 dependencies:
   # To update these, use "flutter update-packages --force-upgrade".
   collection: 1.14.6
-  http: 0.11.3+16
   meta: 1.1.2
   typed_data: 1.1.5
   vector_math: 2.0.5
@@ -31,7 +30,6 @@ dev_dependencies:
   glob: 1.1.5 # TRANSITIVE DEPENDENCY
   html: 0.13.2+2 # TRANSITIVE DEPENDENCY
   http_multi_server: 2.0.4 # TRANSITIVE DEPENDENCY
-  http_parser: 3.1.1 # TRANSITIVE DEPENDENCY
   io: 0.3.2+1 # TRANSITIVE DEPENDENCY
   isolate: 1.1.0 # TRANSITIVE DEPENDENCY
   js: 0.6.1 # TRANSITIVE DEPENDENCY

--- a/packages/flutter/test/material/bottom_navigation_bar_test.dart
+++ b/packages/flutter/test/material/bottom_navigation_bar_test.dart
@@ -553,7 +553,7 @@ Widget boilerplate({ Widget bottomNavigationBar, @required TextDirection textDir
   assert(textDirection != null);
   return new Localizations(
     locale: const Locale('en', 'US'),
-    delegates: <LocalizationsDelegate<dynamic>>[
+    delegates: const <LocalizationsDelegate<dynamic>>[
       DefaultMaterialLocalizations.delegate,
       DefaultWidgetsLocalizations.delegate,
     ],

--- a/packages/flutter/test/widgets/wrap_test.dart
+++ b/packages/flutter/test/widgets/wrap_test.dart
@@ -835,7 +835,7 @@ void main() {
       textDirection: TextDirection.ltr,
       spacing: 10.0,
       runSpacing: 10.0,
-      children: <Widget>[
+      children: const <Widget>[
         const SizedBox(width: 200.0, height: 10.0),
         const SizedBox(width: 200.0, height: 10.0),
         const SizedBox(width: 200.0, height: 10.0),
@@ -858,7 +858,7 @@ void main() {
       textDirection: TextDirection.ltr,
       spacing: 10.0,
       runSpacing: 10.0,
-      children: <Widget>[
+      children: const <Widget>[
         const SizedBox(width: 800.0, height: 0.0),
       ],
     ));

--- a/packages/flutter_test/lib/src/binding.dart
+++ b/packages/flutter_test/lib/src/binding.dart
@@ -1170,6 +1170,8 @@ class _MockHttpOverrides extends HttpOverrides {
     return new _MockHttpClient();
   }
 }
+
+/// A mocked [HttpClient] which always returns a [_MockHttpRequest].
 class _MockHttpClient implements HttpClient {
   @override
   bool autoUncompress;
@@ -1275,14 +1277,12 @@ class _MockHttpClient implements HttpClient {
   }
 }
 
+/// A mocked [HttpClientRequest] which always returns a [_MockHttpClientResponse].
 class _MockHttpRequest extends HttpClientRequest {
   @override
-<<<<<<< HEAD
-=======
   Encoding encoding;
 
   @override
->>>>>>> 8cd02e8495b655b112e9007793208233c20a2fb7
   void add(List<int> data) {}
 
   @override
@@ -1325,23 +1325,16 @@ class _MockHttpRequest extends HttpClientRequest {
   void write(Object obj) {}
 
   @override
-<<<<<<< HEAD
-  void writeAll(Iterable<Object> objects, [String separator = '']) {}
-=======
   void writeAll(Iterable objects, [String separator = '']) {}
->>>>>>> 8cd02e8495b655b112e9007793208233c20a2fb7
 
   @override
   void writeCharCode(int charCode) {}
 
   @override
   void writeln([Object obj = '']) {}
-<<<<<<< HEAD
-
-  @override
-  Encoding encoding;
 }
 
+/// A mocked [HttpClientResponse] which is empty and has a [statusCode] of 400.
 class _MockHttpResponse extends Stream<List<int>> implements HttpClientResponse {
   @override
   X509Certificate get certificate => null;

--- a/packages/flutter_test/lib/src/binding.dart
+++ b/packages/flutter_test/lib/src/binding.dart
@@ -12,8 +12,6 @@ import 'package:flutter/rendering.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
-import 'package:http/http.dart' as http;
-import 'package:http/testing.dart' as http;
 import 'package:quiver/testing/async.dart';
 import 'package:quiver/time.dart';
 import 'package:test/test.dart' as test_package;
@@ -140,13 +138,6 @@ abstract class TestWidgetsFlutterBinding extends BindingBase
   @override
   void initInstances() {
     timeDilation = 1.0; // just in case the developer has artificially changed it for development
-    createHttpClient = () {
-      return new http.MockClient((http.BaseRequest request) {
-        return new Future<http.Response>.value(
-          new http.Response('Mocked: Unavailable.', 404, request: request)
-        );
-      });
-    };
     _testTextInput = new TestTextInput()..register();
     super.initInstances();
   }

--- a/packages/flutter_test/lib/src/binding.dart
+++ b/packages/flutter_test/lib/src/binding.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:convert';
 import 'dart:io';
 import 'dart:ui' as ui;
 
@@ -1276,9 +1277,6 @@ class _MockHttpClient implements HttpClient {
 
 class _MockHttpRequest extends HttpClientRequest {
   @override
-  Encoding encoding;
-
-  @override
   void add(List<int> data) {}
 
   @override
@@ -1321,13 +1319,61 @@ class _MockHttpRequest extends HttpClientRequest {
   void write(Object obj) {}
 
   @override
-  void writeAll(Iterable objects, [String separator = '']) {}
+  void writeAll(Iterable<Object> objects, [String separator = '']) {}
 
   @override
   void writeCharCode(int charCode) {}
 
   @override
   void writeln([Object obj = '']) {}
+
+  @override
+  Encoding encoding;
 }
 
-class _MockHtt
+class _MockHttpResponse extends Stream<List<int>> implements HttpClientResponse {
+  @override
+  X509Certificate get certificate => null;
+
+  @override
+  HttpConnectionInfo get connectionInfo => null;
+
+  @override
+  int get contentLength => -1;
+
+  @override
+  List<Cookie> get cookies => null;
+
+  @override
+  Future<Socket> detachSocket() {
+    return new Future<Socket>.error(new UnsupportedError('Mocked response'));
+  }
+
+  @override
+  HttpHeaders get headers => null;
+
+  @override
+  bool get isRedirect => false;
+
+  @override
+  StreamSubscription<List<int>> listen(void Function(List<int> event) onData, {Function onError, void Function() onDone, bool cancelOnError}) {
+    return const Stream<List<int>>.empty().listen(onData, onError: onError, onDone: onDone, cancelOnError: cancelOnError);
+  }
+
+  @override
+  bool get persistentConnection => null;
+
+  @override
+  String get reasonPhrase => null;
+
+  @override
+  Future<HttpClientResponse> redirect([String method, Uri url, bool followLoops]) {
+    return new Future<HttpClientResponse>.error(new UnsupportedError('Mocked response'));
+  }
+
+  @override
+  List<RedirectInfo> get redirects => <RedirectInfo>[];
+
+  @override
+  int get statusCode => 400;
+}

--- a/packages/flutter_test/lib/src/binding.dart
+++ b/packages/flutter_test/lib/src/binding.dart
@@ -138,6 +138,7 @@ abstract class TestWidgetsFlutterBinding extends BindingBase
   @override
   void initInstances() {
     timeDilation = 1.0; // just in case the developer has artificially changed it for development
+    HttpOverrides.global = new _MockHttpOverrides();
     _testTextInput = new TestTextInput()..register();
     super.initInstances();
   }
@@ -1157,3 +1158,176 @@ StackTrace _unmangle(StackTrace stack) {
     return stack.toTrace().vmTrace;
   return stack;
 }
+
+/// Provides a default [HttpClient] which always returns empty 400 responses.
+///
+/// If another [HttpClient] is provided using [HttpOverrides.runZoned], that will
+/// take precedence over this provider.
+class _MockHttpOverrides extends HttpOverrides {
+  @override
+  HttpClient createHttpClient(SecurityContext _) {
+    return new _MockHttpClient();
+  }
+}
+class _MockHttpClient implements HttpClient {
+  @override
+  bool autoUncompress;
+
+  @override
+  Duration idleTimeout;
+
+  @override
+  int maxConnectionsPerHost;
+
+  @override
+  String userAgent;
+
+  @override
+  void addCredentials(Uri url, String realm, HttpClientCredentials credentials) {}
+
+  @override
+  void addProxyCredentials(String host, int port, String realm, HttpClientCredentials credentials) {}
+
+  @override
+  set authenticate(Future<bool> Function(Uri url, String scheme, String realm) f) {}
+
+  @override
+  set authenticateProxy(Future<bool> Function(String host, int port, String scheme, String realm) f) {}
+
+  @override
+  set badCertificateCallback(bool Function(X509Certificate cert, String host, int port) callback) {}
+
+  @override
+  void close({bool force: false}) {}
+
+  @override
+  Future<HttpClientRequest> delete(String host, int port, String path) {
+    return new Future<HttpClientRequest>.value(new _MockHttpRequest());
+  }
+
+  @override
+  Future<HttpClientRequest> deleteUrl(Uri url) {
+    return new Future<HttpClientRequest>.value(new _MockHttpRequest());
+  }
+
+  @override
+  set findProxy(String Function(Uri url) f) {}
+
+  @override
+  Future<HttpClientRequest> get(String host, int port, String path) {
+    return new Future<HttpClientRequest>.value(new _MockHttpRequest());
+  }
+
+  @override
+  Future<HttpClientRequest> getUrl(Uri url) {
+    return new Future<HttpClientRequest>.value(new _MockHttpRequest());
+  }
+
+  @override
+  Future<HttpClientRequest> head(String host, int port, String path) {
+    return new Future<HttpClientRequest>.value(new _MockHttpRequest());
+  }
+
+  @override
+  Future<HttpClientRequest> headUrl(Uri url) {
+    return new Future<HttpClientRequest>.value(new _MockHttpRequest());
+  }
+
+  @override
+  Future<HttpClientRequest> open(String method, String host, int port, String path) {
+    return new Future<HttpClientRequest>.value(new _MockHttpRequest());
+  }
+
+  @override
+  Future<HttpClientRequest> openUrl(String method, Uri url) {
+    return new Future<HttpClientRequest>.value(new _MockHttpRequest());
+  }
+
+  @override
+  Future<HttpClientRequest> patch(String host, int port, String path) {
+    return new Future<HttpClientRequest>.value(new _MockHttpRequest());
+  }
+
+  @override
+  Future<HttpClientRequest> patchUrl(Uri url) {
+    return new Future<HttpClientRequest>.value(new _MockHttpRequest());
+  }
+
+  @override
+  Future<HttpClientRequest> post(String host, int port, String path) {
+    return new Future<HttpClientRequest>.value(new _MockHttpRequest());
+  }
+
+  @override
+  Future<HttpClientRequest> postUrl(Uri url) {
+    return new Future<HttpClientRequest>.value(new _MockHttpRequest());
+  }
+
+  @override
+  Future<HttpClientRequest> put(String host, int port, String path) {
+    return new Future<HttpClientRequest>.value(new _MockHttpRequest());
+  }
+
+  @override
+  Future<HttpClientRequest> putUrl(Uri url) {
+    return new Future<HttpClientRequest>.value(new _MockHttpRequest());
+  }
+}
+
+class _MockHttpRequest extends HttpClientRequest {
+  @override
+  Encoding encoding;
+
+  @override
+  void add(List<int> data) {}
+
+  @override
+  void addError(Object error, [StackTrace stackTrace]) {}
+
+  @override
+  Future<Null> addStream(Stream<List<int>> stream) {
+    return new Future<Null>.value(null);
+  }
+
+  @override
+  Future<HttpClientResponse> close() {
+    return new Future<HttpClientResponse>.value(new _MockHttpResponse());
+  }
+
+  @override
+  HttpConnectionInfo get connectionInfo => null;
+
+  @override
+  List<Cookie> get cookies => null;
+
+  @override
+  Future<HttpClientResponse> get done => null;
+
+  @override
+  Future<Null> flush() {
+    return new Future<Null>.value(null);
+  }
+
+  @override
+  HttpHeaders get headers => null;
+
+  @override
+  String get method => null;
+
+  @override
+  Uri get uri => null;
+
+  @override
+  void write(Object obj) {}
+
+  @override
+  void writeAll(Iterable objects, [String separator = '']) {}
+
+  @override
+  void writeCharCode(int charCode) {}
+
+  @override
+  void writeln([Object obj = '']) {}
+}
+
+class _MockHtt

--- a/packages/flutter_test/lib/src/binding.dart
+++ b/packages/flutter_test/lib/src/binding.dart
@@ -1325,7 +1325,7 @@ class _MockHttpRequest extends HttpClientRequest {
   void write(Object obj) {}
 
   @override
-  void writeAll(Iterable objects, [String separator = '']) {}
+  void writeAll(Iterable<Object> objects, [String separator = '']) {}
 
   @override
   void writeCharCode(int charCode) {}


### PR DESCRIPTION
Flutter will no longer automatically include package:http, nor will it support setting `createHttpClient` to override the default client.

* `NetworkAssetBundle` and `ImageProvided` now use dart:io HttpClient directly.
* `NetworkAssetBundle` and `ImageProvided` use the content-length header if provided to allocate directly into a `Uint8List`.
* Moved some tests which used `package:http` MockClient to a Mockito based test.

Tests that need mock http requests should use `HttpOverrides.runZoned` to provide a mock `HttpClient` instance.  For an example, see [dev/manual_tests/test/card_collection_test.dart](https://github.com/flutter/flutter/pull/15364/files)

flutter_test now uses `HttpOverrides.global` to set a default mocked client which always returns empty 400 responses.  This is completely private, clients should author their own overrides if they want specific behavior.

This is a breaking change.

Fixes #13456

This saves a _solid_ 1.4 Kb from the Gallery app on Android.