### PR TITLE
Update dart-petitparser and dart-xml packages

### DIFF
--- a/dev/benchmarks/microbenchmarks/pubspec.yaml
+++ b/dev/benchmarks/microbenchmarks/pubspec.yaml
@@ -39,7 +39,7 @@ dependencies:
   package_config: 1.0.3 # TRANSITIVE DEPENDENCY
   package_resolver: 1.0.2 # TRANSITIVE DEPENDENCY
   path: 1.5.1 # TRANSITIVE DEPENDENCY
-  petitparser: 1.7.4 # TRANSITIVE DEPENDENCY
+  petitparser: 1.7.5 # TRANSITIVE DEPENDENCY
   plugin: 0.2.0+2 # TRANSITIVE DEPENDENCY
   pool: 1.3.4 # TRANSITIVE DEPENDENCY
   pub_semver: 1.3.2 # TRANSITIVE DEPENDENCY

--- a/dev/devicelab/pubspec.yaml
+++ b/dev/devicelab/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 dependencies:
   args: 1.4.1
   file: 2.3.7
-  image: 1.1.29
+  image: 1.1.30
   meta: 1.1.2
   path: 1.5.1
   platform: 2.1.2

--- a/dev/devicelab/pubspec.yaml
+++ b/dev/devicelab/pubspec.yaml
@@ -49,7 +49,7 @@ dev_dependencies:
   node_preamble: 1.4.0 # TRANSITIVE DEPENDENCY
   package_config: 1.0.3 # TRANSITIVE DEPENDENCY
   package_resolver: 1.0.2 # TRANSITIVE DEPENDENCY
-  petitparser: 1.7.4 # TRANSITIVE DEPENDENCY
+  petitparser: 1.7.5 # TRANSITIVE DEPENDENCY
   plugin: 0.2.0+2 # TRANSITIVE DEPENDENCY
   pool: 1.3.4 # TRANSITIVE DEPENDENCY
   pub_semver: 1.3.2 # TRANSITIVE DEPENDENCY
@@ -67,5 +67,5 @@ dev_dependencies:
   utf: 0.9.0+4 # TRANSITIVE DEPENDENCY
   watcher: 0.9.7+7 # TRANSITIVE DEPENDENCY
   web_socket_channel: 1.0.7 # TRANSITIVE DEPENDENCY
-  xml: 2.6.0 # TRANSITIVE DEPENDENCY
+  xml: 3.0.0 # TRANSITIVE DEPENDENCY
   yaml: 2.1.13 # TRANSITIVE DEPENDENCY

--- a/dev/integration_tests/ui/pubspec.yaml
+++ b/dev/integration_tests/ui/pubspec.yaml
@@ -2,7 +2,7 @@ name: integration_ui
 description: Flutter non-plugin UI integration tests.
 
 dependencies:
-  image: 1.1.29
+  image: 1.1.30
   flutter:
     sdk: flutter
   flutter_driver:

--- a/dev/integration_tests/ui/pubspec.yaml
+++ b/dev/integration_tests/ui/pubspec.yaml
@@ -46,7 +46,7 @@ dev_dependencies:
   package_config: 1.0.3 # TRANSITIVE DEPENDENCY
   package_resolver: 1.0.2 # TRANSITIVE DEPENDENCY
   path: 1.5.1 # TRANSITIVE DEPENDENCY
-  petitparser: 1.7.4 # TRANSITIVE DEPENDENCY
+  petitparser: 1.7.5 # TRANSITIVE DEPENDENCY
   plugin: 0.2.0+2 # TRANSITIVE DEPENDENCY
   pool: 1.3.4 # TRANSITIVE DEPENDENCY
   pub_semver: 1.3.2 # TRANSITIVE DEPENDENCY
@@ -68,7 +68,7 @@ dev_dependencies:
   vm_service_client: 0.2.4+1 # TRANSITIVE DEPENDENCY
   watcher: 0.9.7+7 # TRANSITIVE DEPENDENCY
   web_socket_channel: 1.0.7 # TRANSITIVE DEPENDENCY
-  xml: 2.6.0 # TRANSITIVE DEPENDENCY
+  xml: 3.0.0 # TRANSITIVE DEPENDENCY
   yaml: 2.1.13 # TRANSITIVE DEPENDENCY
 
 flutter:

--- a/dev/tools/vitool/pubspec.yaml
+++ b/dev/tools/vitool/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   args: 1.4.1
   vector_math: 2.0.5
-  xml: 2.6.0
+  xml: 3.0.0
 
 dev_dependencies:
   test: 0.12.32+1
@@ -41,7 +41,7 @@ dev_dependencies:
   package_config: 1.0.3 # TRANSITIVE DEPENDENCY
   package_resolver: 1.0.2 # TRANSITIVE DEPENDENCY
   path: 1.5.1 # TRANSITIVE DEPENDENCY
-  petitparser: 1.7.4 # TRANSITIVE DEPENDENCY
+  petitparser: 1.7.5 # TRANSITIVE DEPENDENCY
   plugin: 0.2.0+2 # TRANSITIVE DEPENDENCY
   pool: 1.3.4 # TRANSITIVE DEPENDENCY
   pub_semver: 1.3.2 # TRANSITIVE DEPENDENCY

--- a/examples/stocks/pubspec.yaml
+++ b/examples/stocks/pubspec.yaml
@@ -44,7 +44,7 @@ dev_dependencies:
   package_config: 1.0.3 # TRANSITIVE DEPENDENCY
   package_resolver: 1.0.2 # TRANSITIVE DEPENDENCY
   path: 1.5.1 # TRANSITIVE DEPENDENCY
-  petitparser: 1.7.4 # TRANSITIVE DEPENDENCY
+  petitparser: 1.7.5 # TRANSITIVE DEPENDENCY
   plugin: 0.2.0+2 # TRANSITIVE DEPENDENCY
   pool: 1.3.4 # TRANSITIVE DEPENDENCY
   pub_semver: 1.3.2 # TRANSITIVE DEPENDENCY

--- a/packages/flutter_tools/pubspec.yaml
+++ b/packages/flutter_tools/pubspec.yaml
@@ -31,7 +31,7 @@ dependencies:
   usage: 3.3.0
   vm_service_client: 0.2.4+1
   web_socket_channel: 1.0.7
-  xml: 2.6.0
+  xml: 3.0.0
   yaml: 2.1.13
 
   # We depend on very specific internal implementation details of the
@@ -67,7 +67,7 @@ dev_dependencies:
   node_preamble: 1.4.0 # TRANSITIVE DEPENDENCY
   package_resolver: 1.0.2 # TRANSITIVE DEPENDENCY
   path: 1.5.1 # TRANSITIVE DEPENDENCY
-  petitparser: 1.7.4 # TRANSITIVE DEPENDENCY
+  petitparser: 1.7.5 # TRANSITIVE DEPENDENCY
   pool: 1.3.4 # TRANSITIVE DEPENDENCY
   pub_semver: 1.3.2 # TRANSITIVE DEPENDENCY
   shelf: 0.7.2 # TRANSITIVE DEPENDENCY


### PR DESCRIPTION
Update the following pacakes
- dart-petitparser to 1.7.5
- dart-xml to 3.0.0
These updates fix some of the strong mode errors we were encountering while running flutter tests under --preview-dart-2 mode.