### PR TITLE
Implement LinearTranslation widget

### DIFF
--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -2250,24 +2250,23 @@ class RenderFittedBox extends RenderProxyBox {
 
 /// Applies a translation transformation before painting its child.
 ///
-/// The translation is expressed as an [Offset] scaled to the child's size. For
-/// example, an [Offset] with a `dx` of 0.25 will result in a horizontal
-/// translation of one quarter the width of the child.
+/// The translation is expressed as an [Offset] which goes through a
+/// special transform function: [transformTranslation].
 ///
 /// Hit tests will only be detected inside the bounds of the
 /// [RenderFractionalTranslation], even if the contents are offset such that
 /// they overflow.
-class RenderFractionalTranslation extends RenderProxyBox {
+abstract class _RenderTranslation extends RenderProxyBox {
   /// Creates a render object that translates its child's painting.
   ///
   /// The [translation] argument must not be null.
-  RenderFractionalTranslation({
+  _RenderTranslation({
     @required Offset translation,
     this.transformHitTests: true,
     RenderBox child
   }) : assert(translation != null),
-       _translation = translation,
-       super(child);
+        _translation = translation,
+        super(child);
 
   /// The translation to apply to the child, scaled to the child's size.
   ///
@@ -2296,8 +2295,8 @@ class RenderFractionalTranslation extends RenderProxyBox {
     assert(!debugNeedsLayout);
     if (transformHitTests) {
       position = new Offset(
-        position.dx - translation.dx * size.width,
-        position.dy - translation.dy * size.height,
+        position.dx - transformedTranslation.dx,
+        position.dy - transformedTranslation.dy,
       );
     }
     return super.hitTest(result, position: position);
@@ -2308,8 +2307,8 @@ class RenderFractionalTranslation extends RenderProxyBox {
     assert(!debugNeedsLayout);
     if (child != null) {
       super.paint(context, new Offset(
-        offset.dx + translation.dx * size.width,
-        offset.dy + translation.dy * size.height,
+        offset.dx + transformedTranslation.dx,
+        offset.dy + transformedTranslation.dy,
       ));
     }
   }
@@ -2317,8 +2316,8 @@ class RenderFractionalTranslation extends RenderProxyBox {
   @override
   void applyPaintTransform(RenderBox child, Matrix4 transform) {
     transform.translate(
-      translation.dx * size.width,
-      translation.dy * size.height,
+      transformedTranslation.dx,
+      transformedTranslation.dy,
     );
   }
 
@@ -2328,6 +2327,74 @@ class RenderFractionalTranslation extends RenderProxyBox {
     description.add(new DiagnosticsProperty<Offset>('translation', translation));
     description.add(new DiagnosticsProperty<bool>('transformHitTests', transformHitTests));
   }
+
+  Offset get transformedTranslation => transformTranslation(translation);
+
+  Offset transformTranslation(Offset translation);
+}
+
+/// Applies a translation transformation before painting its child.
+///
+/// The translation is expressed as an [Offset] scaled to the child's size. For
+/// example, an [Offset] with a `dx` of 0.25 will result in a horizontal
+/// translation of one quarter the width of the child.
+///
+/// Hit tests will only be detected inside the bounds of the
+/// [RenderFractionalTranslation], even if the contents are offset such that
+/// they overflow.
+class RenderFractionalTranslation extends _RenderTranslation {
+
+  /// Creates a render object that translates its child's painting.
+  ///
+  /// The [translation] argument must not be null.
+  RenderFractionalTranslation({@required Offset translation,
+    bool transformHitTests: true,
+    RenderBox child})
+      : assert(translation != null),
+        super(
+          translation: translation,
+          transformHitTests: transformHitTests,
+          child: child);
+
+  @override
+  Offset transformTranslation(Offset translation) {
+    return new Offset(
+      translation.dx * size.width,
+      translation.dy * size.height,
+    );
+  }
+}
+
+
+/// Applies a translation transformation before painting its child.
+///
+/// The translation is expressed as an [Offset] of logical pixels. For
+/// example, an [Offset] with a `dx` of 25 will result in a horizontal
+/// translation of 25 logical pixel.
+///
+/// Hit tests will only be detected inside the bounds of the
+/// [RenderFractionalTranslation], even if the contents are offset such that
+/// they overflow.
+class RenderLinearTranslation extends _RenderTranslation {
+
+  /// Creates a render object that translates its child's painting.
+  ///
+  /// The [translation] argument must not be null.
+  RenderLinearTranslation({@required Offset translation,
+    bool transformHitTests: true,
+    RenderBox child})
+      : assert(translation != null),
+        super(
+          translation: translation,
+          transformHitTests: transformHitTests,
+          child: child);
+
+
+  @override
+  Offset transformTranslation(Offset translation) {
+    return translation;
+  }
+
 }
 
 /// Signature for listening to [PointerDownEvent] events.

--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -2373,7 +2373,7 @@ class RenderFractionalTranslation extends _RenderTranslation {
 /// translation of 25 logical pixel.
 ///
 /// Hit tests will only be detected inside the bounds of the
-/// [RenderFractionalTranslation], even if the contents are offset such that
+/// [RenderLinearTranslation], even if the contents are offset such that
 /// they overflow.
 class RenderLinearTranslation extends _RenderTranslation {
 

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -1165,7 +1165,7 @@ class FractionalTranslation extends SingleChildRenderObjectWidget {
 /// translation of 25 logical pixels of the child.
 ///
 /// Hit tests will only be detected inside the bounds of the
-/// [FractionalTranslation], even if the contents are offset such that
+/// [LinearTranslation], even if the contents are offset such that
 /// they overflow.
 ///
 /// See also:

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -1131,7 +1131,7 @@ class FractionalTranslation extends SingleChildRenderObjectWidget {
     this.transformHitTests: true,
     Widget child
   }) : assert(translation != null),
-       super(key: key, child: child);
+        super(key: key, child: child);
 
   /// The translation to apply to the child, scaled to the child's size.
   ///
@@ -1152,6 +1152,56 @@ class FractionalTranslation extends SingleChildRenderObjectWidget {
 
   @override
   void updateRenderObject(BuildContext context, RenderFractionalTranslation renderObject) {
+    renderObject
+      ..translation = translation
+      ..transformHitTests = transformHitTests;
+  }
+}
+
+/// Applies a translation transformation before painting its child.
+///
+/// The translation is expressed as a [Offset] of logical pixels. For
+/// example, an [Offset] with a `dx` of 25 will result in a horizontal
+/// translation of 25 logical pixels of the child.
+///
+/// Hit tests will only be detected inside the bounds of the
+/// [FractionalTranslation], even if the contents are offset such that
+/// they overflow.
+///
+/// See also:
+///
+///  * The [catalog of layout widgets](https://flutter.io/widgets/layout/).
+class LinearTranslation extends SingleChildRenderObjectWidget {
+  /// Creates a widget that translates its child's painting.
+  ///
+  /// The [translation] argument must not be null.
+  const LinearTranslation({
+    Key key,
+    @required this.translation,
+    this.transformHitTests: true,
+    Widget child
+  }) : assert(translation != null),
+        super(key: key, child: child);
+
+  /// The translation to apply to the child, scaled to the child's size.
+  ///
+  /// For example, an [Offset] with a `dx` of 25 will result in a horizontal
+  /// translation of 25 logical pixels of the child.
+  final Offset translation;
+
+  /// Whether to apply the translation when performing hit tests.
+  final bool transformHitTests;
+
+  @override
+  RenderLinearTranslation createRenderObject(BuildContext context) {
+    return new RenderLinearTranslation(
+      translation: translation,
+      transformHitTests: transformHitTests,
+    );
+  }
+
+  @override
+  void updateRenderObject(BuildContext context, RenderLinearTranslation renderObject) {
     renderObject
       ..translation = translation
       ..transformHitTests = transformHitTests;


### PR DESCRIPTION
One of my projects required to translate certain widgets by logical pixels. I think a simple 'LinearTranslation' widget should be provided by Flutter, since there is a 'more complicated' FractionalTranslation widget. 

I think the formatting is a little off, so I wanted to ask if I can find an IntelliJ code-style file somewhere? 🤔 