### PR TITLE
Use a set to remove duplicate channel names

### DIFF
--- a/packages/flutter_tools/lib/src/commands/channel.dart
+++ b/packages/flutter_tools/lib/src/commands/channel.dart
@@ -47,6 +47,7 @@ class ChannelCommand extends FlutterCommand {
     // Beware: currentBranch could contain PII. See getBranchName().
     final String currentChannel = FlutterVersion.instance.channel;
     final String currentBranch = FlutterVersion.instance.getBranchName();
+    final Set<String> seenChannels = new Set<String>();
 
     showAll = showAll || currentChannel != currentBranch;
 
@@ -59,6 +60,10 @@ class ChannelCommand extends FlutterCommand {
         if (split.length < 2)
           return null;
         final String branchName = split[1];
+        if (seenChannels.contains(branchName)) {
+          return null;
+        }
+        seenChannels.add(branchName);
         if (branchName == currentBranch)
           return '* $branchName';
         if (!branchName.startsWith('HEAD ') &&

--- a/packages/flutter_tools/test/channel_test.dart
+++ b/packages/flutter_tools/test/channel_test.dart
@@ -2,16 +2,24 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
 import 'package:args/command_runner.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/commands/channel.dart';
+import 'package:mockito/mockito.dart';
 import 'package:test/test.dart';
+import 'package:process/process.dart';
 
 import 'src/common.dart';
 import 'src/context.dart';
 
 void main() {
   group('channel', () {
+    final MockProcessManager mockProcessManager = new MockProcessManager();
+
     setUpAll(() {
       Cache.disableLocking();
     });
@@ -26,5 +34,51 @@ void main() {
       // so we check for the header text rather than any specific channel name.
       expect(testLogger.statusText, contains('Flutter channels:'));
     });
+
+    testUsingContext('removes duplicates', () async {
+      final Stream<List<int>> stdout = new Stream<List<int>>.fromIterable(<List<int>>[
+        utf8.encode(
+          'origin/dev\n'
+          'origin/beta\n'
+          'upstream/dev\n'
+          'upstream/beta\n'
+        ),
+      ]);
+      final Process process = new MockProcess();
+
+      when(process.stdout).thenReturn(stdout);
+      when(process.stderr).thenReturn(const Stream<List<int>>.empty());
+      when(process.exitCode).thenReturn(new Future<int>.value(0));
+      when(mockProcessManager.start(
+        <String>['git', 'branch', '-r'],
+        workingDirectory: typed(any, named: 'workingDirectory'),
+        environment: typed(any, named: 'environment')))
+      .thenReturn(new Future<Process>.value(process));
+
+      final ChannelCommand command = new ChannelCommand();
+      final CommandRunner<Null> runner = createTestCommandRunner(command);
+      await runner.run(<String>['channel']);
+
+      verify(mockProcessManager.start(<String>['git', 'branch', '-r'],
+          workingDirectory: typed(any, named: 'workingDirectory'),
+          environment: typed(any, named: 'environment'))).called(1);
+
+      expect(testLogger.errorText, hasLength(0));
+
+      // format the status text for a simpler assertion.
+      final Iterable<String> rows = testLogger.statusText
+        .split('\n')
+        .map((String line) => line.trim())
+        .where((String line) => line?.isNotEmpty == true)
+        .skip(1); // remove `Flutter channels:` line
+
+      expect(rows, <String>['dev', 'beta']);
+    }, overrides: <Type, Generator>{
+      ProcessManager: () =>  mockProcessManager,
+    });
   });
 }
+
+class MockProcessManager extends Mock implements ProcessManager {}
+
+class MockProcess extends Mock implements Process {}


### PR DESCRIPTION
Fixes #14898

This prevents the flutter tool from displaying the same branch multiple times.  For example, upstream/master and origin/master will cause master to be displayed twice before this change.

Since this command delegates to Git, I'm unsure about the testing strategy.

Before change:
```
flutter channels:
  Hixie-patch-1
  add_text_span_ctr_to_text
  alpha
  beta
  break_show_dialog
  check_lifecycle_no_future
  default_primary_color
  dev
  dialog_updates_for_real
  hackathon
  master
  remove_package_http
  revert-14660-description-update
  revert-14832-roll_engine_0222
  Hixie-patch-1
  alpha
  beta
  cloudFirestoreTest
  dev
  hackathon
  kevmoo.license
  master
  revert-14660-description-update
  revert-14832-roll_engine_0222
```
After change:

```
flutter channels:
  Hixie-patch-1
  add_text_span_ctr_to_text
  alpha
  beta
  break_show_dialog
  check_lifecycle_no_future
  default_primary_color
  dev
  dialog_updates_for_real
  hackathon
  master
  remove_package_http
  revert-14660-description-update
  revert-14832-roll_engine_0222
  cloudFirestoreTest
  kevmoo.license
```