### PR TITLE
Comment out empty flutter block in pubspec template

### DIFF
--- a/packages/flutter_tools/templates/package/pubspec.yaml.tmpl
+++ b/packages/flutter_tools/templates/package/pubspec.yaml.tmpl
@@ -16,7 +16,7 @@ dev_dependencies:
 # following page: https://www.dartlang.org/tools/pub/pubspec
 
 # The following section is specific to Flutter.
-flutter:
+# flutter:
 
   # To add assets to your package, add an assets section, like this:
   # assets:


### PR DESCRIPTION
The template for package projects includes a `flutter:` block with all its contents commented out, this PR comments out the `flutter:` directive too, fixing https://github.com/flutter/flutter/issues/14008.