### PR TITLE
Make standard codecs extensible

### DIFF
--- a/dev/integration_tests/channels/android/app/src/main/java/com/yourcompany/channels/MainActivity.java
+++ b/dev/integration_tests/channels/android/app/src/main/java/com/yourcompany/channels/MainActivity.java
@@ -10,7 +10,6 @@ import android.os.Bundle;
 
 import java.io.ByteArrayOutputStream;
 import java.util.Date;
-import java.util.Objects;
 import io.flutter.app.FlutterActivity;
 import io.flutter.plugin.common.*;
 import io.flutter.plugins.GeneratedPluginRegistrant;

--- a/dev/integration_tests/channels/android/app/src/main/java/com/yourcompany/channels/MainActivity.java
+++ b/dev/integration_tests/channels/android/app/src/main/java/com/yourcompany/channels/MainActivity.java
@@ -4,12 +4,12 @@
 
 package com.yourcompany.channels;
 
+import java.io.ByteArrayOutputStream;
 import java.nio.ByteBuffer;
+import java.util.Date;
 
 import android.os.Bundle;
 
-import java.io.ByteArrayOutputStream;
-import java.util.Date;
 import io.flutter.app.FlutterActivity;
 import io.flutter.plugin.common.*;
 import io.flutter.plugins.GeneratedPluginRegistrant;
@@ -163,17 +163,17 @@ final class ExtendedStandardMessageCodec extends StandardMessageCodec {
       case DATE:
         return new Date(buffer.getLong());
       case PAIR:
-        return new Pair<Object, Object>(readValue(buffer), readValue(buffer));
+        return new Pair(readValue(buffer), readValue(buffer));
       default: return super.readUnknown(buffer);
     }
   }
 }
 
-final class Pair<L, R> {
-  public final L left;
-  public final R right;
+final class Pair {
+  public final Object left;
+  public final Object right;
 
-  public Pair(L left, R right) {
+  public Pair(Object left, Object right) {
     this.left = left;
     this.right = right;
   }

--- a/dev/integration_tests/channels/android/app/src/main/java/com/yourcompany/channels/MainActivity.java
+++ b/dev/integration_tests/channels/android/app/src/main/java/com/yourcompany/channels/MainActivity.java
@@ -140,11 +140,11 @@ public class MainActivity extends FlutterActivity {
 
 final class ExtendedStandardMessageCodec extends StandardMessageCodec {
   public static final ExtendedStandardMessageCodec INSTANCE = new ExtendedStandardMessageCodec();
-  private static final byte DATE = 0;
-  private static final byte PAIR = 1;
+  private static final byte DATE = (byte) 128;
+  private static final byte PAIR = (byte) 129;
 
   @Override
-  protected void writeUnknown(ByteArrayOutputStream stream, Object value) {
+  protected void writeValue(ByteArrayOutputStream stream, Object value) {
     if (value instanceof Date) {
       stream.write(DATE);
       writeLong(stream, ((Date) value).getTime());
@@ -153,18 +153,18 @@ final class ExtendedStandardMessageCodec extends StandardMessageCodec {
       writeValue(stream, ((Pair) value).left);
       writeValue(stream, ((Pair) value).right);
     } else {
-      super.writeUnknown(stream, value);
+      super.writeValue(stream, value);
     }
   }
 
   @Override
-  protected Object readUnknown(ByteBuffer buffer) {
-    switch (buffer.get()) {
+  protected Object readValueOfType(byte type, ByteBuffer buffer) {
+    switch (type) {
       case DATE:
         return new Date(buffer.getLong());
       case PAIR:
         return new Pair(readValue(buffer), readValue(buffer));
-      default: return super.readUnknown(buffer);
+      default: return super.readValueOfType(type, buffer);
     }
   }
 }

--- a/dev/integration_tests/channels/ios/Runner.xcodeproj/project.pbxproj
+++ b/dev/integration_tests/channels/ios/Runner.xcodeproj/project.pbxproj
@@ -8,8 +8,8 @@
 
 /* Begin PBXBuildFile section */
 		1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */ = {isa = PBXBuildFile; fileRef = 1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */; };
-		2D5378261FAA1A9400D5DBA9 /* flutter_assets in Resources */ = {isa = PBXBuildFile; fileRef = 2D5378251FAA1A9400D5DBA9 /* flutter_assets */; };
 		3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */; };
+		2D5378261FAA1A9400D5DBA9 /* flutter_assets in Resources */ = {isa = PBXBuildFile; fileRef = 2D5378251FAA1A9400D5DBA9 /* flutter_assets */; };
 		3B80C3941E831B6300D905FE /* App.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3B80C3931E831B6300D905FE /* App.framework */; };
 		3B80C3951E831B6300D905FE /* App.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 3B80C3931E831B6300D905FE /* App.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		9705A1C61CF904A100538489 /* Flutter.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9740EEBA1CF902C7004384FC /* Flutter.framework */; };
@@ -41,8 +41,8 @@
 /* Begin PBXFileReference section */
 		1498D2321E8E86230040F4C2 /* GeneratedPluginRegistrant.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GeneratedPluginRegistrant.h; sourceTree = "<group>"; };
 		1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GeneratedPluginRegistrant.m; sourceTree = "<group>"; };
-		2D5378251FAA1A9400D5DBA9 /* flutter_assets */ = {isa = PBXFileReference; lastKnownFileType = folder; name = flutter_assets; path = Flutter/flutter_assets; sourceTree = SOURCE_ROOT; };
 		3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = AppFrameworkInfo.plist; path = Flutter/AppFrameworkInfo.plist; sourceTree = "<group>"; };
+		2D5378251FAA1A9400D5DBA9 /* flutter_assets */ = {isa = PBXFileReference; lastKnownFileType = folder; name = flutter_assets; path = Flutter/flutter_assets; sourceTree = SOURCE_ROOT; };
 		3B80C3931E831B6300D905FE /* App.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = App.framework; path = Flutter/App.framework; sourceTree = "<group>"; };
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Release.xcconfig; path = Flutter/Release.xcconfig; sourceTree = "<group>"; };
 		7AFFD8ED1D35381100E5BB4D /* AppDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
@@ -160,7 +160,6 @@
 				TargetAttributes = {
 					97C146ED1CF9000F007C117D = {
 						CreatedOnToolsVersion = 7.3.1;
-						DevelopmentTeam = AQ7UHDBEXJ;
 					};
 				};
 			};
@@ -359,7 +358,6 @@
 			buildSettings = {
 				ARCHS = arm64;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				DEVELOPMENT_TEAM = AQ7UHDBEXJ;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -382,7 +380,6 @@
 			buildSettings = {
 				ARCHS = arm64;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				DEVELOPMENT_TEAM = AQ7UHDBEXJ;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",

--- a/dev/integration_tests/channels/ios/Runner.xcodeproj/project.pbxproj
+++ b/dev/integration_tests/channels/ios/Runner.xcodeproj/project.pbxproj
@@ -8,8 +8,8 @@
 
 /* Begin PBXBuildFile section */
 		1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */ = {isa = PBXBuildFile; fileRef = 1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */; };
-		3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */; };
 		2D5378261FAA1A9400D5DBA9 /* flutter_assets in Resources */ = {isa = PBXBuildFile; fileRef = 2D5378251FAA1A9400D5DBA9 /* flutter_assets */; };
+		3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */; };
 		3B80C3941E831B6300D905FE /* App.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3B80C3931E831B6300D905FE /* App.framework */; };
 		3B80C3951E831B6300D905FE /* App.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 3B80C3931E831B6300D905FE /* App.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		9705A1C61CF904A100538489 /* Flutter.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9740EEBA1CF902C7004384FC /* Flutter.framework */; };
@@ -41,8 +41,8 @@
 /* Begin PBXFileReference section */
 		1498D2321E8E86230040F4C2 /* GeneratedPluginRegistrant.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GeneratedPluginRegistrant.h; sourceTree = "<group>"; };
 		1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GeneratedPluginRegistrant.m; sourceTree = "<group>"; };
-		3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = AppFrameworkInfo.plist; path = Flutter/AppFrameworkInfo.plist; sourceTree = "<group>"; };
 		2D5378251FAA1A9400D5DBA9 /* flutter_assets */ = {isa = PBXFileReference; lastKnownFileType = folder; name = flutter_assets; path = Flutter/flutter_assets; sourceTree = SOURCE_ROOT; };
+		3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = AppFrameworkInfo.plist; path = Flutter/AppFrameworkInfo.plist; sourceTree = "<group>"; };
 		3B80C3931E831B6300D905FE /* App.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = App.framework; path = Flutter/App.framework; sourceTree = "<group>"; };
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Release.xcconfig; path = Flutter/Release.xcconfig; sourceTree = "<group>"; };
 		7AFFD8ED1D35381100E5BB4D /* AppDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
@@ -160,6 +160,7 @@
 				TargetAttributes = {
 					97C146ED1CF9000F007C117D = {
 						CreatedOnToolsVersion = 7.3.1;
+						DevelopmentTeam = AQ7UHDBEXJ;
 					};
 				};
 			};
@@ -358,6 +359,7 @@
 			buildSettings = {
 				ARCHS = arm64;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				DEVELOPMENT_TEAM = AQ7UHDBEXJ;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -380,6 +382,7 @@
 			buildSettings = {
 				ARCHS = arm64;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				DEVELOPMENT_TEAM = AQ7UHDBEXJ;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",

--- a/dev/integration_tests/channels/ios/Runner/AppDelegate.m
+++ b/dev/integration_tests/channels/ios/Runner/AppDelegate.m
@@ -5,6 +5,83 @@
 #include "AppDelegate.h"
 #include "GeneratedPluginRegistrant.h"
 
+@interface Pair : NSObject
+@property(atomic, readonly, strong, nullable) NSObject* left;
+@property(atomic, readonly, strong, nullable) NSObject* right;
+- (instancetype)initWithLeft:(NSObject*)first right:(NSObject*)right;
+@end
+
+@implementation Pair
+- (instancetype)initWithLeft:(NSObject*)left right:(NSObject*)right {
+  self = [super init];
+  _left = left;
+  _right = right;
+  return self;
+}
+@end
+
+const uint8_t DATE = 0;
+const uint8_t PAIR = 1;
+
+@interface ExtendedWriter : FlutterStandardWriter
+- (void)writeUnknownValue:(id)value;
+@end
+
+@implementation ExtendedWriter
+- (void)writeUnknownValue:(id)value {
+  if ([value isKindOfClass:[NSDate class]]) {
+    [self writeByte:DATE];
+    NSDate* date = value;
+    NSTimeInterval time = date.timeIntervalSince1970;
+    SInt64 ms = (SInt64) (time * 1000.0);
+    [self writeBytes:&ms length:8];
+  } else if ([value isKindOfClass:[Pair class]]) {
+    Pair* pair = value;
+    [self writeByte:PAIR];
+    [self writeValue:pair.left];
+    [self writeValue:pair.right];
+  } else {
+    [super writeUnknownValue:value];
+  }
+}
+@end
+
+@interface ExtendedReader : FlutterStandardReader
+- (id)readUnknownValue;
+@end
+
+@implementation ExtendedReader
+- (id)readUnknownValue {
+  uint8_t field = [self readByte];
+  switch (field) {
+    case DATE: {
+      SInt64 value;
+      [self readBytes:&value length:8];
+      NSTimeInterval time = [NSNumber numberWithLong:value].doubleValue / 1000.0;
+      return [NSDate dateWithTimeIntervalSince1970:time];
+    }
+    case PAIR: {
+      return [[Pair alloc] initWithLeft:[self readValue] right:[self readValue]];
+    }
+    default: return [super readUnknownValue];
+  }
+}
+@end
+
+@interface ExtendedReaderWriter : FlutterStandardReaderWriter
+- (FlutterStandardWriter*)writerWithData:(NSMutableData*)data;
+- (FlutterStandardReader*)readerWithData:(NSData*)data;
+@end
+
+@implementation ExtendedReaderWriter
+- (FlutterStandardWriter*)writerWithData:(NSMutableData*)data {
+  return [[ExtendedWriter alloc] initWithData:data];
+}
+- (FlutterStandardReader*)readerWithData:(NSData*)data {
+  return [[ExtendedReader alloc] initWithData:data];
+}
+@end
+
 @implementation AppDelegate
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
@@ -28,7 +105,7 @@
   [self setupMessagingHandshakeOnChannel:
     [FlutterBasicMessageChannel messageChannelWithName:@"std-msg"
                                        binaryMessenger:flutterController
-                                                 codec:[FlutterStandardMessageCodec sharedInstance]]];
+                                                 codec:[FlutterStandardMessageCodec withReaderWriter:[ExtendedReaderWriter new]]]];
   [self setupMethodCallSuccessHandshakeOnChannel:
     [FlutterMethodChannel methodChannelWithName:@"json-method"
                                 binaryMessenger:flutterController
@@ -36,7 +113,7 @@
   [self setupMethodCallSuccessHandshakeOnChannel:
     [FlutterMethodChannel methodChannelWithName:@"std-method"
                                 binaryMessenger:flutterController
-                                          codec:[FlutterStandardMethodCodec sharedInstance]]];
+                                          codec:[FlutterStandardMethodCodec withReaderWriter:[ExtendedReaderWriter new]]]];
   return [super application:application didFinishLaunchingWithOptions:launchOptions];
 }
 

--- a/dev/integration_tests/channels/ios/Runner/AppDelegate.m
+++ b/dev/integration_tests/channels/ios/Runner/AppDelegate.m
@@ -90,6 +90,7 @@ const uint8_t PAIR = 1;
   FlutterViewController *flutterController =
       (FlutterViewController *)self.window.rootViewController;
 
+  ExtendedReaderWriter* extendedReaderWriter = [ExtendedReaderWriter new];
   [self setupMessagingHandshakeOnChannel:
     [FlutterBasicMessageChannel messageChannelWithName:@"binary-msg"
                                        binaryMessenger:flutterController
@@ -105,7 +106,7 @@ const uint8_t PAIR = 1;
   [self setupMessagingHandshakeOnChannel:
     [FlutterBasicMessageChannel messageChannelWithName:@"std-msg"
                                        binaryMessenger:flutterController
-                                                 codec:[FlutterStandardMessageCodec withReaderWriter:[ExtendedReaderWriter new]]]];
+                                                 codec:[FlutterStandardMessageCodec withReaderWriter:extendedReaderWriter]]];
   [self setupMethodCallSuccessHandshakeOnChannel:
     [FlutterMethodChannel methodChannelWithName:@"json-method"
                                 binaryMessenger:flutterController
@@ -113,7 +114,7 @@ const uint8_t PAIR = 1;
   [self setupMethodCallSuccessHandshakeOnChannel:
     [FlutterMethodChannel methodChannelWithName:@"std-method"
                                 binaryMessenger:flutterController
-                                          codec:[FlutterStandardMethodCodec withReaderWriter:[ExtendedReaderWriter new]]]];
+                                          codec:[FlutterStandardMethodCodec withReaderWriter:extendedReaderWriter]]];
   return [super application:application didFinishLaunchingWithOptions:launchOptions];
 }
 

--- a/dev/integration_tests/channels/ios/Runner/AppDelegate.m
+++ b/dev/integration_tests/channels/ios/Runner/AppDelegate.m
@@ -105,7 +105,7 @@ const UInt8 PAIR = 129;
   [self setupMessagingHandshakeOnChannel:
     [FlutterBasicMessageChannel messageChannelWithName:@"std-msg"
                                        binaryMessenger:flutterController
-                                                 codec:[FlutterStandardMessageCodec withReaderWriter:extendedReaderWriter]]];
+                                                 codec:[FlutterStandardMessageCodec codecWithReaderWriter:extendedReaderWriter]]];
   [self setupMethodCallSuccessHandshakeOnChannel:
     [FlutterMethodChannel methodChannelWithName:@"json-method"
                                 binaryMessenger:flutterController
@@ -113,7 +113,7 @@ const UInt8 PAIR = 129;
   [self setupMethodCallSuccessHandshakeOnChannel:
     [FlutterMethodChannel methodChannelWithName:@"std-method"
                                 binaryMessenger:flutterController
-                                          codec:[FlutterStandardMethodCodec withReaderWriter:extendedReaderWriter]]];
+                                          codec:[FlutterStandardMethodCodec codecWithReaderWriter:extendedReaderWriter]]];
   return [super application:application didFinishLaunchingWithOptions:launchOptions];
 }
 

--- a/dev/integration_tests/channels/ios/Runner/AppDelegate.m
+++ b/dev/integration_tests/channels/ios/Runner/AppDelegate.m
@@ -20,15 +20,15 @@
 }
 @end
 
-const uint8_t DATE = 0;
-const uint8_t PAIR = 1;
+const UInt8 DATE = 128;
+const UInt8 PAIR = 129;
 
 @interface ExtendedWriter : FlutterStandardWriter
-- (void)writeUnknownValue:(id)value;
+- (void)writeValue:(id)value;
 @end
 
 @implementation ExtendedWriter
-- (void)writeUnknownValue:(id)value {
+- (void)writeValue:(id)value {
   if ([value isKindOfClass:[NSDate class]]) {
     [self writeByte:DATE];
     NSDate* date = value;
@@ -41,19 +41,18 @@ const uint8_t PAIR = 1;
     [self writeValue:pair.left];
     [self writeValue:pair.right];
   } else {
-    [super writeUnknownValue:value];
+    [super writeValue:value];
   }
 }
 @end
 
 @interface ExtendedReader : FlutterStandardReader
-- (id)readUnknownValue;
+- (id)readValueOfType:(UInt8)type;
 @end
 
 @implementation ExtendedReader
-- (id)readUnknownValue {
-  uint8_t field = [self readByte];
-  switch (field) {
+- (id)readValueOfType:(UInt8)type {
+  switch (type) {
     case DATE: {
       SInt64 value;
       [self readBytes:&value length:8];
@@ -63,7 +62,7 @@ const uint8_t PAIR = 1;
     case PAIR: {
       return [[Pair alloc] initWithLeft:[self readValue] right:[self readValue]];
     }
-    default: return [super readUnknownValue];
+    default: return [super readValueOfType:type];
   }
 }
 @end

--- a/dev/integration_tests/channels/lib/main.dart
+++ b/dev/integration_tests/channels/lib/main.dart
@@ -73,7 +73,7 @@ class _TestAppState extends State<TestApp> {
   ]);
   static final dynamic aCompoundUnknownValue = <dynamic>[
     anUnknownValue,
-    new Pair<dynamic, dynamic>(anUnknownValue, aList),
+    new Pair(anUnknownValue, aList),
   ];
   static final List<TestStep> steps = <TestStep>[
     () => methodCallJsonSuccessHandshake(null),

--- a/dev/integration_tests/channels/lib/main.dart
+++ b/dev/integration_tests/channels/lib/main.dart
@@ -10,6 +10,7 @@ import 'package:flutter_driver/driver_extension.dart';
 
 import 'src/basic_messaging.dart';
 import 'src/method_calls.dart';
+import 'src/pair.dart';
 import 'src/test_step.dart';
 
 void main() {
@@ -23,6 +24,7 @@ class TestApp extends StatefulWidget {
 }
 
 class _TestAppState extends State<TestApp> {
+  static final dynamic anUnknownValue = new DateTime.fromMillisecondsSinceEpoch(1520777802314);
   static final List<dynamic> aList = <dynamic>[
     false,
     0,
@@ -39,7 +41,7 @@ class _TestAppState extends State<TestApp> {
     'd': 'hello',
     'e': <dynamic>[
       <String, dynamic>{'key': 42}
-    ]
+    ],
   };
   static final Uint8List someUint8s = new Uint8List.fromList(<int>[
     0xBA,
@@ -69,6 +71,10 @@ class _TestAppState extends State<TestApp> {
     double.maxFinite,
     double.infinity,
   ]);
+  static final dynamic aCompoundUnknownValue = <dynamic>[
+    anUnknownValue,
+    new Pair<dynamic, dynamic>(anUnknownValue, aList),
+  ];
   static final List<TestStep> steps = <TestStep>[
     () => methodCallJsonSuccessHandshake(null),
     () => methodCallJsonSuccessHandshake(true),
@@ -83,6 +89,8 @@ class _TestAppState extends State<TestApp> {
     () => methodCallStandardSuccessHandshake('world'),
     () => methodCallStandardSuccessHandshake(aList),
     () => methodCallStandardSuccessHandshake(aMap),
+    () => methodCallStandardSuccessHandshake(anUnknownValue),
+    () => methodCallStandardSuccessHandshake(aCompoundUnknownValue),
     () => methodCallJsonErrorHandshake(null),
     () => methodCallJsonErrorHandshake('world'),
     () => methodCallStandardErrorHandshake(null),
@@ -138,6 +146,8 @@ class _TestAppState extends State<TestApp> {
     () => basicStandardHandshake(<String, dynamic>{}),
     () => basicStandardHandshake(<dynamic, dynamic>{7: true, false: -7}),
     () => basicStandardHandshake(aMap),
+    () => basicStandardHandshake(anUnknownValue),
+    () => basicStandardHandshake(aCompoundUnknownValue),
     () => basicBinaryMessageToUnknownChannel(),
     () => basicStringMessageToUnknownChannel(),
     () => basicJsonMessageToUnknownChannel(),

--- a/dev/integration_tests/channels/lib/src/basic_messaging.dart
+++ b/dev/integration_tests/channels/lib/src/basic_messaging.dart
@@ -12,8 +12,8 @@ import 'test_step.dart';
 class ExtendedStandardMessageCodec extends StandardMessageCodec {
   const ExtendedStandardMessageCodec();
 
-  static const _kDateTime = 0;
-  static const _kPair = 1;
+  static const int _kDateTime = 0;
+  static const int _kPair = 1;
 
   @override
   void writeUnknown(WriteBuffer buffer, dynamic value) {

--- a/dev/integration_tests/channels/lib/src/basic_messaging.dart
+++ b/dev/integration_tests/channels/lib/src/basic_messaging.dart
@@ -4,11 +4,10 @@
 
 import 'dart:async';
 import 'dart:typed_data';
-import 'dart:ui';
 import 'package:flutter/services.dart';
 import 'package:flutter/foundation.dart' show ReadBuffer, WriteBuffer;
-import 'test_step.dart';
 import 'pair.dart';
+import 'test_step.dart';
 
 class ExtendedStandardMessageCodec extends StandardMessageCodec {
   const ExtendedStandardMessageCodec();

--- a/dev/integration_tests/channels/lib/src/basic_messaging.dart
+++ b/dev/integration_tests/channels/lib/src/basic_messaging.dart
@@ -12,11 +12,11 @@ import 'test_step.dart';
 class ExtendedStandardMessageCodec extends StandardMessageCodec {
   const ExtendedStandardMessageCodec();
 
-  static const int _kDateTime = 0;
-  static const int _kPair = 1;
+  static const int _kDateTime = 128;
+  static const int _kPair = 129;
 
   @override
-  void writeUnknown(WriteBuffer buffer, dynamic value) {
+  void writeValue(WriteBuffer buffer, dynamic value) {
     if (value is DateTime) {
       buffer.putUint8(_kDateTime);
       buffer.putInt64(value.millisecondsSinceEpoch);
@@ -25,18 +25,18 @@ class ExtendedStandardMessageCodec extends StandardMessageCodec {
       writeValue(buffer, value.left);
       writeValue(buffer, value.right);
     } else {
-      super.writeUnknown(buffer, value);
+      super.writeValue(buffer, value);
     }
   }
 
   @override
-  dynamic readUnknown(ReadBuffer buffer) {
-    switch (buffer.getUint8()) {
+  dynamic readValueOfType(int type, ReadBuffer buffer) {
+    switch (type) {
     case _kDateTime:
       return new DateTime.fromMillisecondsSinceEpoch(buffer.getInt64());
     case _kPair:
       return new Pair(readValue(buffer), readValue(buffer));
-    default: return super.readUnknown(buffer);
+    default: return super.readValueOfType(type, buffer);
     }
   }
 }

--- a/dev/integration_tests/channels/lib/src/method_calls.dart
+++ b/dev/integration_tests/channels/lib/src/method_calls.dart
@@ -5,6 +5,7 @@
 import 'dart:async';
 import 'package:flutter/services.dart';
 import 'test_step.dart';
+import 'basic_messaging.dart';
 
 Future<TestStepResult> methodCallJsonSuccessHandshake(dynamic payload) async {
   const MethodChannel channel =
@@ -27,22 +28,28 @@ Future<TestStepResult> methodCallJsonNotImplementedHandshake() async {
 
 Future<TestStepResult> methodCallStandardSuccessHandshake(
     dynamic payload) async {
-  const MethodChannel channel =
-      const MethodChannel('std-method', const StandardMethodCodec());
+  const MethodChannel channel = const MethodChannel(
+    'std-method',
+    const StandardMethodCodec(const ExtendedStandardMessageCodec()),
+  );
   return _methodCallSuccessHandshake(
       'Standard success($payload)', channel, payload);
 }
 
 Future<TestStepResult> methodCallStandardErrorHandshake(dynamic payload) async {
-  const MethodChannel channel =
-      const MethodChannel('std-method', const StandardMethodCodec());
+  const MethodChannel channel = const MethodChannel(
+    'std-method',
+    const StandardMethodCodec(const ExtendedStandardMessageCodec()),
+  );
   return _methodCallErrorHandshake(
       'Standard error($payload)', channel, payload);
 }
 
 Future<TestStepResult> methodCallStandardNotImplementedHandshake() async {
-  const MethodChannel channel =
-      const MethodChannel('std-method', const StandardMethodCodec());
+  const MethodChannel channel = const MethodChannel(
+    'std-method',
+    const StandardMethodCodec(const ExtendedStandardMessageCodec()),
+  );
   return _methodCallNotImplementedHandshake(
       'Standard notImplemented()', channel);
 }

--- a/dev/integration_tests/channels/lib/src/method_calls.dart
+++ b/dev/integration_tests/channels/lib/src/method_calls.dart
@@ -4,8 +4,8 @@
 
 import 'dart:async';
 import 'package:flutter/services.dart';
-import 'test_step.dart';
 import 'basic_messaging.dart';
+import 'test_step.dart';
 
 Future<TestStepResult> methodCallJsonSuccessHandshake(dynamic payload) async {
   const MethodChannel channel =

--- a/dev/integration_tests/channels/lib/src/pair.dart
+++ b/dev/integration_tests/channels/lib/src/pair.dart
@@ -1,0 +1,14 @@
+// Copyright 2018 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+/// A pair of values. Used for testing custom codecs.
+class Pair<L, R> {
+  final L left;
+  final R right;
+
+  Pair(this.left, this.right);
+
+  @override
+  String toString() => 'Pair[$left, $right]';
+}

--- a/dev/integration_tests/channels/lib/src/pair.dart
+++ b/dev/integration_tests/channels/lib/src/pair.dart
@@ -3,9 +3,9 @@
 // found in the LICENSE file.
 
 /// A pair of values. Used for testing custom codecs.
-class Pair<L, R> {
-  final L left;
-  final R right;
+class Pair {
+  final dynamic left;
+  final dynamic right;
 
   Pair(this.left, this.right);
 

--- a/dev/integration_tests/channels/lib/src/test_step.dart
+++ b/dev/integration_tests/channels/lib/src/test_step.dart
@@ -53,7 +53,6 @@ class TestStepResult {
         if (snapshot.hasData) {
           return snapshot.data;
         } else {
-          print(snapshot.error);
           final TestStepResult result = snapshot.error;
           return result;
         }
@@ -182,6 +181,6 @@ bool _deepEqualsMap(Map<dynamic, dynamic> a, Map<dynamic, dynamic> b) {
   return true;
 }
 
-bool _deepEqualsPair(Pair<dynamic, dynamic> a, Pair<dynamic, dynamic> b) {
+bool _deepEqualsPair(Pair a, Pair b) {
   return _deepEquals(a.left, b.left) && _deepEquals(a.right, b.right);
 }

--- a/dev/integration_tests/channels/lib/src/test_step.dart
+++ b/dev/integration_tests/channels/lib/src/test_step.dart
@@ -7,6 +7,8 @@ import 'dart:typed_data';
 
 import 'package:flutter/material.dart';
 
+import 'pair.dart';
+
 enum TestStatus { ok, pending, failed, complete }
 
 typedef Future<TestStepResult> TestStep();
@@ -51,6 +53,7 @@ class TestStepResult {
         if (snapshot.hasData) {
           return snapshot.data;
         } else {
+          print(snapshot.error);
           final TestStepResult result = snapshot.error;
           return result;
         }
@@ -147,6 +150,8 @@ bool _deepEquals(dynamic a, dynamic b) {
     return b is List && _deepEqualsList(a, b);
   if (a is Map)
     return b is Map && _deepEqualsMap(a, b);
+  if (a is Pair)
+    return b is Pair && _deepEqualsPair(a, b);
   return false;
 }
 
@@ -175,4 +180,8 @@ bool _deepEqualsMap(Map<dynamic, dynamic> a, Map<dynamic, dynamic> b) {
       return false;
   }
   return true;
+}
+
+bool _deepEqualsPair(Pair<dynamic, dynamic> a, Pair<dynamic, dynamic> b) {
+  return _deepEquals(a.left, b.left) && _deepEquals(a.right, b.right);
 }

--- a/packages/flutter/lib/src/services/message_codecs.dart
+++ b/packages/flutter/lib/src/services/message_codecs.dart
@@ -201,6 +201,9 @@ class JSONMethodCodec implements MethodCodec {
 ///    `FlutterStandardTypedData`
 ///  * [List]\: `NSArray`
 ///  * [Map]\: `NSDictionary`
+///
+/// The codec is extensible by subclasses overriding [writeUnknown] and
+/// [readUnknown].
 class StandardMessageCodec implements MessageCodec<dynamic> {
   // The codec serializes messages as outlined below. This format must
   // match the Android and iOS counterparts.
@@ -253,6 +256,7 @@ class StandardMessageCodec implements MessageCodec<dynamic> {
   static const int _kFloat64List = 11;
   static const int _kList = 12;
   static const int _kMap = 13;
+  static const int _kUnknown = 255;
 
   /// Creates a [MessageCodec] using the Flutter standard binary encoding.
   const StandardMessageCodec();
@@ -262,7 +266,7 @@ class StandardMessageCodec implements MessageCodec<dynamic> {
     if (message == null)
       return null;
     final WriteBuffer buffer = new WriteBuffer();
-    _writeValue(buffer, message);
+    writeValue(buffer, message);
     return buffer.done();
   }
 
@@ -271,26 +275,34 @@ class StandardMessageCodec implements MessageCodec<dynamic> {
     if (message == null)
       return null;
     final ReadBuffer buffer = new ReadBuffer(message);
-    final dynamic result = _readValue(buffer);
+    final dynamic result = readValue(buffer);
     if (buffer.hasRemaining)
       throw const FormatException('Message corrupted');
     return result;
   }
 
-  static void _writeSize(WriteBuffer buffer, int value) {
-    assert(0 <= value && value <= 0xffffffff);
-    if (value < 254) {
-      buffer.putUint8(value);
-    } else if (value <= 0xffff) {
-      buffer.putUint8(254);
-      buffer.putUint16(value);
-    } else {
-      buffer.putUint8(255);
-      buffer.putUint32(value);
-    }
+  /// Writes an unknown [value] to [buffer].
+  ///
+  /// Hook point for subclasses to extend the codec. The default
+  /// implementation throws.
+  void writeUnknown(WriteBuffer buffer, dynamic value) {
+    throw new ArgumentError.value(value);
   }
 
-  static void _writeValue(WriteBuffer buffer, dynamic value) {
+  /// Reads an unknown value from [buffer] as written by [writeUnknown].
+  ///
+  /// Hook point for subclasses to extend the codec. The default implementation
+  /// throws.
+  dynamic readUnknown(ReadBuffer buffer) {
+    throw const FormatException('Message corrupted');
+  }
+
+  /// Writes [value] to [buffer] by first writing a type discriminator
+  /// byte, then the value itself.
+  ///
+  /// This method is intended for use by subclasses overriding
+  /// [writeUnknown].
+  void writeValue(WriteBuffer buffer, dynamic value) {
     if (value == null) {
       buffer.putUint8(_kNull);
     } else if (value is bool) {
@@ -309,53 +321,48 @@ class StandardMessageCodec implements MessageCodec<dynamic> {
     } else if (value is String) {
       buffer.putUint8(_kString);
       final List<int> bytes = utf8.encoder.convert(value);
-      _writeSize(buffer, bytes.length);
+      writeSize(buffer, bytes.length);
       buffer.putUint8List(bytes);
     } else if (value is Uint8List) {
       buffer.putUint8(_kUint8List);
-      _writeSize(buffer, value.length);
+      writeSize(buffer, value.length);
       buffer.putUint8List(value);
     } else if (value is Int32List) {
       buffer.putUint8(_kInt32List);
-      _writeSize(buffer, value.length);
+      writeSize(buffer, value.length);
       buffer.putInt32List(value);
     } else if (value is Int64List) {
       buffer.putUint8(_kInt64List);
-      _writeSize(buffer, value.length);
+      writeSize(buffer, value.length);
       buffer.putInt64List(value);
     } else if (value is Float64List) {
       buffer.putUint8(_kFloat64List);
-      _writeSize(buffer, value.length);
+      writeSize(buffer, value.length);
       buffer.putFloat64List(value);
     } else if (value is List) {
       buffer.putUint8(_kList);
-      _writeSize(buffer, value.length);
+      writeSize(buffer, value.length);
       for (final dynamic item in value) {
-        _writeValue(buffer, item);
+        writeValue(buffer, item);
       }
     } else if (value is Map) {
       buffer.putUint8(_kMap);
-      _writeSize(buffer, value.length);
+      writeSize(buffer, value.length);
       value.forEach((dynamic key, dynamic value) {
-        _writeValue(buffer, key);
-        _writeValue(buffer, value);
+        writeValue(buffer, key);
+        writeValue(buffer, value);
       });
     } else {
-      throw new ArgumentError.value(value);
+      buffer.putUint8(_kUnknown);
+      writeUnknown(buffer, value);
     }
   }
 
-  static int _readSize(ReadBuffer buffer) {
-    final int value = buffer.getUint8();
-    if (value < 254)
-      return value;
-    else if (value == 254)
-      return buffer.getUint16();
-    else
-      return buffer.getUint32();
-  }
-
-  static dynamic _readValue(ReadBuffer buffer) {
+  /// Reads a value from [buffer] as written by [writeValue].
+  ///
+  /// This method is intended for use by subclasses overriding
+  /// [readUnknown].
+  dynamic readValue(ReadBuffer buffer) {
     if (!buffer.hasRemaining)
       throw const FormatException('Message corrupted');
     dynamic result;
@@ -379,7 +386,7 @@ class StandardMessageCodec implements MessageCodec<dynamic> {
         // Flutter Engine APIs to use large ints have been deprecated on
         // 2018-01-09 and will be made unavailable.
         // TODO(mravn): remove this case once the APIs are unavailable.
-        final int length = _readSize(buffer);
+        final int length = readSize(buffer);
         final String hex = utf8.decoder.convert(buffer.getUint8List(length));
         result = int.parse(hex, radix: 16);
         break;
@@ -387,42 +394,77 @@ class StandardMessageCodec implements MessageCodec<dynamic> {
         result = buffer.getFloat64();
         break;
       case _kString:
-        final int length = _readSize(buffer);
+        final int length = readSize(buffer);
         result = utf8.decoder.convert(buffer.getUint8List(length));
         break;
       case _kUint8List:
-        final int length = _readSize(buffer);
+        final int length = readSize(buffer);
         result = buffer.getUint8List(length);
         break;
       case _kInt32List:
-        final int length = _readSize(buffer);
+        final int length = readSize(buffer);
         result = buffer.getInt32List(length);
         break;
       case _kInt64List:
-        final int length = _readSize(buffer);
+        final int length = readSize(buffer);
         result = buffer.getInt64List(length);
         break;
       case _kFloat64List:
-        final int length = _readSize(buffer);
+        final int length = readSize(buffer);
         result = buffer.getFloat64List(length);
         break;
       case _kList:
-        final int length = _readSize(buffer);
+        final int length = readSize(buffer);
         result = new List<dynamic>(length);
         for (int i = 0; i < length; i++) {
-          result[i] = _readValue(buffer);
+          result[i] = readValue(buffer);
         }
         break;
       case _kMap:
-        final int length = _readSize(buffer);
+        final int length = readSize(buffer);
         result = <dynamic, dynamic>{};
         for (int i = 0; i < length; i++) {
-          result[_readValue(buffer)] = _readValue(buffer);
+          result[readValue(buffer)] = readValue(buffer);
         }
+        break;
+      case _kUnknown:
+        result = readUnknown(buffer);
         break;
       default: throw const FormatException('Message corrupted');
     }
     return result;
+  }
+
+  /// Writes a non-negative 32-bit integer [value] to [buffer]
+  /// using an expanding 1-5 byte encoding that optimizes for small values.
+  ///
+  /// This method is intended for use by subclasses overriding
+  /// [writeUnknown].
+  void writeSize(WriteBuffer buffer, int value) {
+    assert(0 <= value && value <= 0xffffffff);
+    if (value < 254) {
+      buffer.putUint8(value);
+    } else if (value <= 0xffff) {
+      buffer.putUint8(254);
+      buffer.putUint16(value);
+    } else {
+      buffer.putUint8(255);
+      buffer.putUint32(value);
+    }
+  }
+
+  /// Reads a non-negative int from [buffer] as written by [writeSize].
+  ///
+  /// This method is intended for use by subclasses overriding
+  /// [readUnknown].
+  int readSize(ReadBuffer buffer) {
+    final int value = buffer.getUint8();
+    if (value < 254)
+      return value;
+    else if (value == 254)
+      return buffer.getUint16();
+    else
+      return buffer.getUint32();
   }
 }
 
@@ -448,21 +490,24 @@ class StandardMethodCodec implements MethodCodec {
   //     string, the error message string, and the error details value.
 
   /// Creates a [MethodCodec] using the Flutter standard binary encoding.
-  const StandardMethodCodec();
+  const StandardMethodCodec([this.messageCodec = const StandardMessageCodec()]);
+
+  /// The message codec that this method codec uses for encoding values.
+  final StandardMessageCodec messageCodec;
 
   @override
   ByteData encodeMethodCall(MethodCall call) {
     final WriteBuffer buffer = new WriteBuffer();
-    StandardMessageCodec._writeValue(buffer, call.method);
-    StandardMessageCodec._writeValue(buffer, call.arguments);
+    messageCodec.writeValue(buffer, call.method);
+    messageCodec.writeValue(buffer, call.arguments);
     return buffer.done();
   }
 
   @override
   MethodCall decodeMethodCall(ByteData methodCall) {
     final ReadBuffer buffer = new ReadBuffer(methodCall);
-    final dynamic method = StandardMessageCodec._readValue(buffer);
-    final dynamic arguments = StandardMessageCodec._readValue(buffer);
+    final dynamic method = messageCodec.readValue(buffer);
+    final dynamic arguments = messageCodec.readValue(buffer);
     if (method is String && !buffer.hasRemaining)
       return new MethodCall(method, arguments);
     else
@@ -473,7 +518,7 @@ class StandardMethodCodec implements MethodCodec {
   ByteData encodeSuccessEnvelope(dynamic result) {
     final WriteBuffer buffer = new WriteBuffer();
     buffer.putUint8(0);
-    StandardMessageCodec._writeValue(buffer, result);
+    messageCodec.writeValue(buffer, result);
     return buffer.done();
   }
 
@@ -481,9 +526,9 @@ class StandardMethodCodec implements MethodCodec {
   ByteData encodeErrorEnvelope({@required String code, String message, dynamic details}) {
     final WriteBuffer buffer = new WriteBuffer();
     buffer.putUint8(1);
-    StandardMessageCodec._writeValue(buffer, code);
-    StandardMessageCodec._writeValue(buffer, message);
-    StandardMessageCodec._writeValue(buffer, details);
+    messageCodec.writeValue(buffer, code);
+    messageCodec.writeValue(buffer, message);
+    messageCodec.writeValue(buffer, details);
     return buffer.done();
   }
 
@@ -494,10 +539,10 @@ class StandardMethodCodec implements MethodCodec {
       throw const FormatException('Expected envelope, got nothing');
     final ReadBuffer buffer = new ReadBuffer(envelope);
     if (buffer.getUint8() == 0)
-      return StandardMessageCodec._readValue(buffer);
-    final dynamic errorCode = StandardMessageCodec._readValue(buffer);
-    final dynamic errorMessage = StandardMessageCodec._readValue(buffer);
-    final dynamic errorDetails = StandardMessageCodec._readValue(buffer);
+      return messageCodec.readValue(buffer);
+    final dynamic errorCode = messageCodec.readValue(buffer);
+    final dynamic errorMessage = messageCodec.readValue(buffer);
+    final dynamic errorDetails = messageCodec.readValue(buffer);
     if (errorCode is String && (errorMessage == null || errorMessage is String) && !buffer.hasRemaining)
       throw new PlatformException(code: errorCode, message: errorMessage, details: errorDetails);
     else

--- a/packages/flutter/lib/src/services/message_codecs.dart
+++ b/packages/flutter/lib/src/services/message_codecs.dart
@@ -203,7 +203,7 @@ class JSONMethodCodec implements MethodCodec {
 ///  * [Map]\: `NSDictionary`
 ///
 /// The codec is extensible by subclasses overriding [writeValue] and
-/// [readValue].
+/// [readValueOfType].
 class StandardMessageCodec implements MessageCodec<dynamic> {
   // The codec serializes messages as outlined below. This format must
   // match the Android and iOS counterparts.
@@ -282,6 +282,8 @@ class StandardMessageCodec implements MessageCodec<dynamic> {
 
   /// Writes [value] to [buffer] by first writing a type discriminator
   /// byte, then the value itself.
+  ///
+  /// This method may be called recursively to serialize container values.
   ///
   /// Type discriminators 0 through 127 inclusive are reserved for use by the
   /// base class.
@@ -452,12 +454,14 @@ class StandardMessageCodec implements MessageCodec<dynamic> {
   /// [readValueOfType].
   int readSize(ReadBuffer buffer) {
     final int value = buffer.getUint8();
-    if (value < 254)
-      return value;
-    else if (value == 254)
-      return buffer.getUint16();
-    else
-      return buffer.getUint32();
+    switch (value) {
+      case 254:
+        return buffer.getUint16();
+      case 255:
+        return buffer.getUint32();
+      default:
+        return value;
+    }
   }
 }
 


### PR DESCRIPTION
Make standard message/method codecs extensible. Awaits companion flutter/engine PR (https://github.com/flutter/engine/pull/4770).

Fixes #15389 