### PR TITLE
Make plugins work in Swift projects

### DIFF
--- a/dev/devicelab/bin/tasks/plugin_test.dart
+++ b/dev/devicelab/bin/tasks/plugin_test.dart
@@ -8,5 +8,8 @@ import 'package:flutter_devicelab/tasks/plugin_tests.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 
 Future<Null> main() async {
-  await task(new PluginTest('apk'));
+  await task(combine(<TaskFunction>[
+    new PluginTest('apk', 'java'),
+    new PluginTest('apk', 'kotlin'),
+  ]));
 }

--- a/dev/devicelab/bin/tasks/plugin_test.dart
+++ b/dev/devicelab/bin/tasks/plugin_test.dart
@@ -9,7 +9,7 @@ import 'package:flutter_devicelab/framework/framework.dart';
 
 Future<Null> main() async {
   await task(combine(<TaskFunction>[
-    new PluginTest('apk', 'java'),
-    new PluginTest('apk', 'kotlin'),
+    new PluginTest('apk', <String>['-a', 'java']),
+    new PluginTest('apk', <String>['-a', 'kotlin']),
   ]));
 }

--- a/dev/devicelab/bin/tasks/plugin_test_ios.dart
+++ b/dev/devicelab/bin/tasks/plugin_test_ios.dart
@@ -8,5 +8,8 @@ import 'package:flutter_devicelab/tasks/plugin_tests.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 
 Future<Null> main() async {
-  await task(new PluginTest('ios'));
+  await task(combine(<TaskFunction>[
+    new PluginTest('ios', 'objc'),
+    new PluginTest('ios', 'swift'),
+  ]));
 }

--- a/dev/devicelab/bin/tasks/plugin_test_ios.dart
+++ b/dev/devicelab/bin/tasks/plugin_test_ios.dart
@@ -9,7 +9,7 @@ import 'package:flutter_devicelab/framework/framework.dart';
 
 Future<Null> main() async {
   await task(combine(<TaskFunction>[
-    new PluginTest('ios', 'objc'),
-    new PluginTest('ios', 'swift'),
+    new PluginTest('ios', <String>['-i', 'objc']),
+    new PluginTest('ios', <String>['-i', 'swift']),
   ]));
 }

--- a/dev/devicelab/bin/tasks/plugin_test_win.dart
+++ b/dev/devicelab/bin/tasks/plugin_test_win.dart
@@ -8,5 +8,8 @@ import 'package:flutter_devicelab/tasks/plugin_tests.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 
 Future<Null> main() async {
-  await task(new PluginTest('apk'));
+  await task(combine(<TaskFunction>[
+    new PluginTest('apk', 'java'),
+    new PluginTest('apk', 'kotlin'),
+  ]));
 }

--- a/dev/devicelab/bin/tasks/plugin_test_win.dart
+++ b/dev/devicelab/bin/tasks/plugin_test_win.dart
@@ -9,7 +9,7 @@ import 'package:flutter_devicelab/framework/framework.dart';
 
 Future<Null> main() async {
   await task(combine(<TaskFunction>[
-    new PluginTest('apk', 'java'),
-    new PluginTest('apk', 'kotlin'),
+    new PluginTest('apk', <String>['-a', 'java']),
+    new PluginTest('apk', <String>['-a', 'kotlin']),
   ]));
 }

--- a/dev/devicelab/lib/tasks/plugin_tests.dart
+++ b/dev/devicelab/lib/tasks/plugin_tests.dart
@@ -10,7 +10,7 @@ import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/framework/ios.dart';
 import 'package:flutter_devicelab/framework/utils.dart';
 
-/// Combines several TaskFunction with trivial success value into one.
+/// Combines several TaskFunctions with trivial success value into one.
 TaskFunction combine(List<TaskFunction> tasks) {
   return () async {
     for (TaskFunction task in tasks) {

--- a/packages/flutter_tools/templates/cocoapods/Podfile-swift
+++ b/packages/flutter_tools/templates/cocoapods/Podfile-swift
@@ -67,5 +67,9 @@ post_install do |installer|
     target.build_configurations.each do |config|
       config.build_settings['ENABLE_BITCODE'] = 'NO'
     end
+    # workaround for https://github.com/CocoaPods/CocoaPods/issues/7463
+    target.headers_build_phase.files.each do |file|
+      file.settings = { 'ATTRIBUTES' => ['Public'] }
+    end
   end
 end


### PR DESCRIPTION
Enabling plugins in Swift iOS projects (https://github.com/flutter/flutter/pull/14667) and making Podfiles use symlinks (https://github.com/flutter/flutter/pull/14748) collided due to https://github.com/CocoaPods/CocoaPods/issues/7463 which affects Swift projects with plugins only.

This PR adds a workaround for the CocoaPods issue to the project template's Swift Podfile.

Fixes #15099 