### PR TITLE
Silence broken test

### DIFF
--- a/dev/devicelab/bin/tasks/plugin_test_ios.dart
+++ b/dev/devicelab/bin/tasks/plugin_test_ios.dart
@@ -10,7 +10,6 @@ import 'package:flutter_devicelab/framework/framework.dart';
 Future<Null> main() async {
   await task(combine(<TaskFunction>[
     new PluginTest('ios', <String>['-i', 'objc']),
-    // TODO(mravn): Re-enable this once CocoaPods is upgraded on device lab.
-    // new PluginTest('ios', <String>['-i', 'swift']),
+    new PluginTest('ios', <String>['-i', 'swift']),
   ]));
 }

--- a/dev/devicelab/bin/tasks/plugin_test_ios.dart
+++ b/dev/devicelab/bin/tasks/plugin_test_ios.dart
@@ -10,6 +10,7 @@ import 'package:flutter_devicelab/framework/framework.dart';
 Future<Null> main() async {
   await task(combine(<TaskFunction>[
     new PluginTest('ios', <String>['-i', 'objc']),
-    new PluginTest('ios', <String>['-i', 'swift']),
+    // TODO(mravn): Re-enable this once CocoaPods is upgraded on device lab.
+    // new PluginTest('ios', <String>['-i', 'swift']),
   ]));
 }

--- a/dev/devicelab/manifest.yaml
+++ b/dev/devicelab/manifest.yaml
@@ -263,6 +263,7 @@ tasks:
       Checks that the project template works and supports plugins on iOS.
     stage: devicelab_ios
     required_agent_capabilities: ["mac/ios"]
+    flaky: true
 
   external_ui_integration_test_ios:
     description: >


### PR DESCRIPTION
CocoaPods needs upgrading on the device lab before the Swift plugin test can run.