### PR TITLE
Fix misspelling in tab description

### DIFF
--- a/packages/flutter_localizations/lib/src/material_localizations.dart
+++ b/packages/flutter_localizations/lib/src/material_localizations.dart
@@ -284,7 +284,7 @@ class GlobalMaterialLocalizations implements MaterialLocalizations {
     final String template = _translationBundle.tabLabel;
     return template
       .replaceFirst(r'$tabIndex', formatDecimal(tabIndex))
-      .replaceFirst(r'tabCount', formatDecimal(tabCount));
+      .replaceFirst(r'$tabCount', formatDecimal(tabCount));
   }
 
   @override

--- a/packages/flutter_localizations/test/translations_test.dart
+++ b/packages/flutter_localizations/test/translations_test.dart
@@ -82,8 +82,8 @@ void main() {
       expect(localizations.pageRowsInfoTitle(1, 10, 100, false), isNot(contains(r'$rowCount')));
 
       expect(localizations.tabLabel(tabIndex: 2, tabCount: 5), isNotNull);
-      expect(localizations.tabLabel(tabIndex: 2, tabCount: 5), isNot(contains('tabIndex')));
-      expect(localizations.tabLabel(tabIndex: 2, tabCount: 5), isNot(contains('tabCount')));
+      expect(localizations.tabLabel(tabIndex: 2, tabCount: 5), isNot(contains(r'$tabIndex')));
+      expect(localizations.tabLabel(tabIndex: 2, tabCount: 5), isNot(contains(r'$tabCount')));
       expect(() => localizations.tabLabel(tabIndex: 0, tabCount: 5), throwsAssertionError);
       expect(() => localizations.tabLabel(tabIndex: 2, tabCount: 0), throwsAssertionError);
     });


### PR DESCRIPTION
Actual text: "Tab 2 of $3"
Expected text: "Tab 2 of 3"

Screenshot presenting issue:

<img width="258" alt="screen shot 2018-03-12 at 19 56 39" src="https://user-images.githubusercontent.com/3593905/37304254-5888329c-2631-11e8-96f0-bc2634bf6dc2.png">