### PR TITLE
Avoid NPE in InkDecoration dispose

### DIFF
--- a/packages/flutter/lib/src/material/ink_decoration.dart
+++ b/packages/flutter/lib/src/material/ink_decoration.dart
@@ -233,7 +233,7 @@ class _InkState extends State<Ink> {
 
   @override
   void deactivate() {
-    _ink.dispose();
+    _ink?.dispose();
     assert(_ink == null);
     super.deactivate();
   }


### PR DESCRIPTION
Avoids a null pointer exception if dispose() is called on an
already-disposed InkDecoration.