### PR TITLE
Text form field initial value

### DIFF
--- a/packages/flutter/lib/src/material/text_form_field.dart
+++ b/packages/flutter/lib/src/material/text_form_field.dart
@@ -121,7 +121,7 @@ class _TextFormFieldState extends FormFieldState<String> {
   void initState() {
     super.initState();
     if (widget.controller == null) {
-      _controller = new TextEditingController(text: widget.initialValue ?? '');
+      _controller = new TextEditingController(text: widget.initialValue);
     } else {
       widget.controller.addListener(_handleControllerChanged);
     }
@@ -154,7 +154,7 @@ class _TextFormFieldState extends FormFieldState<String> {
   void reset() {
     super.reset();
     setState(() {
-      _effectiveController.text = widget.initialValue ?? '';
+      _effectiveController.text = widget.initialValue;
     });
   }
 

--- a/packages/flutter/lib/src/material/text_form_field.dart
+++ b/packages/flutter/lib/src/material/text_form_field.dart
@@ -19,9 +19,15 @@ import 'theme.dart';
 /// pass a [GlobalKey] to the constructor and use [GlobalKey.currentState] to
 /// save or reset the form field.
 ///
-/// When a [controller] is specified, it can be used to control the text being
-/// edited. Its content will be overwritten by [initialValue] (which defaults
-/// to the empty string) on creation and when [reset] is called.
+/// When a [controller] is specified, its [TextEditingController.text]
+/// defines the [initialValue]. If this [FormField] is part of a scrolling
+/// container that lazily constructs its children, like a [ListView] or a
+/// [CustomScrollView], then a [controller] should be specified.
+/// The controller's lifetime should be managed by a stateful widget ancestor
+/// of the scrolling container.
+///
+/// If a [controller] is not specified, [initialValue] can be used to give
+/// the automatically generated controller an initial value.
 ///
 /// For a documentation about the various parameters, see [TextField].
 ///
@@ -35,16 +41,17 @@ import 'theme.dart';
 class TextFormField extends FormField<String> {
   /// Creates a [FormField] that contains a [TextField].
   ///
-  /// When a [controller] is specified, it can be used to control the text
-  /// being edited. Its content will be overwritten by [initialValue] (which
-  /// defaults to the empty string) on creation and when [reset] is called.
+  /// When a [controller] is specified, [initialValue] must be null (the
+  /// default). If [controller] is null, then a [TextEditingController]
+  /// will be constructed automatically and its `text` will be initialized
+  /// to [initalValue] or the empty string.
   ///
   /// For documentation about the various parameters, see the [TextField] class
   /// and [new TextField], the constructor.
   TextFormField({
     Key key,
     this.controller,
-    String initialValue: '',
+    String initialValue,
     FocusNode focusNode,
     InputDecoration decoration: const InputDecoration(),
     TextInputType keyboardType: TextInputType.text,
@@ -58,7 +65,7 @@ class TextFormField extends FormField<String> {
     FormFieldSetter<String> onSaved,
     FormFieldValidator<String> validator,
     List<TextInputFormatter> inputFormatters,
-  }) : assert(initialValue != null),
+  }) : assert(initialValue == null || controller == null),
        assert(keyboardType != null),
        assert(textAlign != null),
        assert(autofocus != null),
@@ -67,7 +74,7 @@ class TextFormField extends FormField<String> {
        assert(maxLines == null || maxLines > 0),
        super(
     key: key,
-    initialValue: initialValue,
+    initialValue: controller != null ? controller.text : (initialValue ?? ''),
     onSaved: onSaved,
     validator: validator,
     builder: (FormFieldState<String> field) {
@@ -94,7 +101,8 @@ class TextFormField extends FormField<String> {
 
   /// Controls the text being edited.
   ///
-  /// If null, this widget will create its own [TextEditingController].
+  /// If null, this widget will create its own [TextEditingController] and
+  /// initialize its [TextEditingController.text] with [initialValue].
   final TextEditingController controller;
 
   @override
@@ -113,9 +121,8 @@ class _TextFormFieldState extends FormFieldState<String> {
   void initState() {
     super.initState();
     if (widget.controller == null) {
-      _controller = new TextEditingController(text: widget.initialValue);
+      _controller = new TextEditingController(text: widget.initialValue ?? '');
     } else {
-      widget.controller.text = widget.initialValue;
       widget.controller.addListener(_handleControllerChanged);
     }
   }
@@ -147,7 +154,7 @@ class _TextFormFieldState extends FormFieldState<String> {
   void reset() {
     super.reset();
     setState(() {
-      _effectiveController.text = widget.initialValue;
+      _effectiveController.text = widget.initialValue ?? '';
     });
   }
 

--- a/packages/flutter/test/widgets/form_test.dart
+++ b/packages/flutter/test/widgets/form_test.dart
@@ -204,8 +204,8 @@ void main() {
     expect(editableText.widget.controller.text, equals('world'));
   });
 
-  testWidgets('Provide initial value to input when controller is specified', (WidgetTester tester) async {
-    final TextEditingController controller = new TextEditingController();
+  testWidgets('Controller defines initial value', (WidgetTester tester) async {
+    final TextEditingController controller = new TextEditingController(text: 'hello');
     const String initialValue = 'hello';
     final GlobalKey<FormFieldState<String>> inputKey = new GlobalKey<FormFieldState<String>>();
 
@@ -217,7 +217,6 @@ void main() {
             child: new Form(
               child: new TextFormField(
                 key: inputKey,
-                initialValue: 'hello',
                 controller: controller,
               ),
             ),
@@ -251,7 +250,6 @@ void main() {
     final GlobalKey<FormState> formKey = new GlobalKey<FormState>();
     final GlobalKey<FormFieldState<String>> inputKey = new GlobalKey<FormFieldState<String>>();
     final TextEditingController controller = new TextEditingController(text: 'Plover');
-    const String initialValue = 'Plugh';
 
     Widget builder() {
       return new Directionality(
@@ -263,7 +261,7 @@ void main() {
               child: new TextFormField(
                 key: inputKey,
                 controller: controller,
-                initialValue: initialValue,
+                // initialValue is 'Plover'
               ),
             ),
           ),
@@ -284,9 +282,9 @@ void main() {
     // verify value resets to initialValue on reset.
     formKey.currentState.reset();
     await tester.idle();
-    expect(inputKey.currentState.value, equals(initialValue));
-    expect(editableText.widget.controller.text, equals(initialValue));
-    expect(controller.text, equals(initialValue));
+    expect(inputKey.currentState.value, equals('Plover'));
+    expect(editableText.widget.controller.text, equals('Plover'));
+    expect(controller.text, equals('Plover'));
   });
 
   testWidgets('TextEditingController updates to/from form field value', (WidgetTester tester) async {


### PR DESCRIPTION
Currently `TextFormField.initialValue` defaults to an empty string and is used to initialize the TextFormField controller's `TextEditingController.text`. If an explicit TextEditingController parameter is provided, it is counter-productive to unconditionally initialize it since doing so clears its state.

This PR changes the default value of `TextFormField.initialValue` to null and only uses it if the TextFormField's controller is internally generated. If a controller is specified, the `initialValue` is defined by the controller's text and the `initialValue` parameter must be null.

This is an incompatible change.

Without this change, it is difficult to build a lazily constructed list - like a `ListView` - of TextFormFields because each time a TextFormField is recreated its TextEditingController is effectively reset. Given this change the following app works as expected. The state of all 25 TextFormField's is preserved upon scrolling because their TextEditingControllers are persistent.

```dart
class FormFieldLifetime extends StatefulWidget {
  @override
  _FormFieldLifetimeState createState() => new _FormFieldLifetimeState();
}

class _FormFieldLifetimeState extends State<FormFieldLifetime> {
  final List<TextEditingController> _controllers = new List.generate(25, (int n) {
    return new TextEditingController();
  }).toList();

  @override
  Widget build(BuildContext context) {
    return new Scaffold(
      appBar: new AppBar(title: new Text("FormFieldLifetime")),
      body: new Form(
        child: new ListView(
          children: new List<Widget>.generate(_controllers.length, (int n) {
            return new TextFormField(
              controller: _controllers[n],
            );
          }).toList(),
        ),
      ),
    );
  }
}
```
