### PR TITLE
Increase hint text contrast ratio to 4.5

### DIFF
--- a/packages/flutter/lib/src/material/input_decorator.dart
+++ b/packages/flutter/lib/src/material/input_decorator.dart
@@ -2305,31 +2305,18 @@ class InputDecorationTheme extends Diagnosticable {
   void debugFillProperties(DiagnosticPropertiesBuilder description) {
     super.debugFillProperties(description);
     const InputDecorationTheme defaultTheme = const InputDecorationTheme();
-    description.add(new DiagnosticsProperty<TextStyle>('labelStyle', labelStyle,
-        defaultValue: defaultTheme.labelStyle));
-    description.add(new DiagnosticsProperty<TextStyle>('helperStyle', helperStyle,
-        defaultValue: defaultTheme.helperStyle));
-    description.add(new DiagnosticsProperty<TextStyle>('hintStyle', hintStyle,
-        defaultValue: defaultTheme.hintStyle));
-    description.add(new DiagnosticsProperty<TextStyle>('errorStyle', errorStyle,
-        defaultValue: defaultTheme.errorStyle));
-    description
-        .add(new DiagnosticsProperty<bool>('isDense', isDense, defaultValue: defaultTheme.isDense));
-    description.add(new DiagnosticsProperty<EdgeInsets>('contentPadding', contentPadding,
-        defaultValue: defaultTheme.contentPadding));
-    description.add(new DiagnosticsProperty<bool>('isCollapsed', isCollapsed,
-        defaultValue: defaultTheme.isCollapsed));
-    description.add(new DiagnosticsProperty<TextStyle>('prefixStyle', prefixStyle,
-        defaultValue: defaultTheme.prefixStyle));
-    description.add(new DiagnosticsProperty<TextStyle>('suffixStyle', suffixStyle,
-        defaultValue: defaultTheme.suffixStyle));
-    description.add(new DiagnosticsProperty<TextStyle>('counterStyle', counterStyle,
-        defaultValue: defaultTheme.counterStyle));
-    description
-        .add(new DiagnosticsProperty<bool>('filled', filled, defaultValue: defaultTheme.filled));
-    description.add(new DiagnosticsProperty<Color>('fillColor', fillColor,
-        defaultValue: defaultTheme.fillColor));
-    description.add(
-        new DiagnosticsProperty<InputBorder>('border', border, defaultValue: defaultTheme.border));
+    description.add(new DiagnosticsProperty<TextStyle>('labelStyle', labelStyle, defaultValue: defaultTheme.labelStyle));
+    description.add(new DiagnosticsProperty<TextStyle>('helperStyle', helperStyle, defaultValue: defaultTheme.helperStyle));
+    description.add(new DiagnosticsProperty<TextStyle>('hintStyle', hintStyle, defaultValue: defaultTheme.hintStyle));
+    description.add(new DiagnosticsProperty<TextStyle>('errorStyle', errorStyle, defaultValue: defaultTheme.errorStyle));
+    description.add(new DiagnosticsProperty<bool>('isDense', isDense, defaultValue: defaultTheme.isDense));
+    description.add(new DiagnosticsProperty<EdgeInsets>('contentPadding', contentPadding, defaultValue: defaultTheme.contentPadding));
+    description.add(new DiagnosticsProperty<bool>('isCollapsed', isCollapsed, defaultValue: defaultTheme.isCollapsed));
+    description.add(new DiagnosticsProperty<TextStyle>('prefixStyle', prefixStyle, defaultValue: defaultTheme.prefixStyle));
+    description.add(new DiagnosticsProperty<TextStyle>('suffixStyle', suffixStyle, defaultValue: defaultTheme.suffixStyle));
+    description.add(new DiagnosticsProperty<TextStyle>('counterStyle', counterStyle, defaultValue: defaultTheme.counterStyle));
+    description.add(new DiagnosticsProperty<bool>('filled', filled, defaultValue: defaultTheme.filled));
+    description.add(new DiagnosticsProperty<Color>('fillColor', fillColor, defaultValue: defaultTheme.fillColor));
+    description.add(new DiagnosticsProperty<InputBorder>('border', border, defaultValue: defaultTheme.border));
   }
 }

--- a/packages/flutter/lib/src/material/theme_data.dart
+++ b/packages/flutter/lib/src/material/theme_data.dart
@@ -146,7 +146,7 @@ class ThemeData extends Diagnosticable {
     backgroundColor ??= isDark ? Colors.grey[700] : primarySwatch[200];
     dialogBackgroundColor ??= isDark ? Colors.grey[800] : Colors.white;
     indicatorColor ??= accentColor == primaryColor ? Colors.white : accentColor;
-    hintColor ??= isDark ? const Color(0x42FFFFFF) : const Color(0x4C000000);
+    hintColor ??= isDark ?  const Color(0x80FFFFFF) : const Color(0x8A000000);
     errorColor ??= Colors.red[700];
     inputDecorationTheme ??= const InputDecorationTheme();
     iconTheme ??= isDark ? const IconThemeData(color: Colors.white) : const IconThemeData(color: Colors.black);


### PR DESCRIPTION
Also cleaned up one minor code formatting tragedy in input_decorator.dart.

Contrast ratio is now 4.5.

Fixes https://github.com/flutter/flutter/issues/15219

Old hintColor:

![current_hint_color](https://user-images.githubusercontent.com/1377460/37376304-d5018ddc-26e0-11e8-89af-ed8c4d8e7cf0.png)

New hintColor:

![new_hint_color](https://user-images.githubusercontent.com/1377460/37376315-db137942-26e0-11e8-9b06-17585e272861.png)


