### PR TITLE
Fix the remote setup to only change the URL.

### DIFF
--- a/dev/bots/prepare_package.dart
+++ b/dev/bots/prepare_package.dart
@@ -298,8 +298,7 @@ class ArchiveCreator {
     await _runGit(<String>['reset', '--hard', revision]);
 
     // Make the origin point to github instead of the chromium mirror.
-    await _runGit(<String>['remote', 'remove', 'origin']);
-    await _runGit(<String>['remote', 'add', 'origin', githubRepo]);
+    await _runGit(<String>['remote', 'set-url', 'origin', githubRepo]);
   }
 
   /// Retrieve the MinGit executable from storage and unpack it.
@@ -362,18 +361,25 @@ class ArchiveCreator {
 
   /// Unpacks the given zip file into the currentDirectory (if set), or the
   /// same directory as the archive.
-  ///
-  /// May only be run on Windows (since 7Zip is not available on other platforms).
   Future<String> _unzipArchive(File archive, {Directory workingDirectory}) {
-    assert(platform.isWindows); // 7Zip is only available on Windows.
     workingDirectory ??= new Directory(path.dirname(archive.absolute.path));
-    final List<String> commandLine = <String>['7za', 'x', archive.absolute.path];
+    List<String> commandLine;
+    if (platform.isWindows) {
+      commandLine = <String>[
+        '7za',
+        'x',
+        archive.absolute.path,
+      ];
+    } else {
+      commandLine = <String>[
+        'unzip',
+        archive.absolute.path,
+      ];
+    }
     return _processRunner.runProcess(commandLine, workingDirectory: workingDirectory);
   }
 
   /// Create a zip archive from the directory source.
-  ///
-  /// May only be run on Windows (since 7Zip is not available on other platforms).
   Future<String> _createZipArchive(File output, Directory source) {
     List<String> commandLine;
     if (platform.isWindows) {

--- a/dev/bots/test/prepare_package_test.dart
+++ b/dev/bots/test/prepare_package_test.dart
@@ -113,8 +113,7 @@ void main() {
           'git clone -b dev https://chromium.googlesource.com/external/github.com/flutter/flutter':
               null,
           'git reset --hard $testRef': null,
-          'git remote remove origin': null,
-          'git remote add origin https://github.com/flutter/flutter.git': null,
+          'git remote set-url origin https://github.com/flutter/flutter.git': null,
           'git describe --tags --abbrev=0': <ProcessResult>[new ProcessResult(0, 0, 'v1.2.3', '')],
         };
         if (platform.isWindows) {
@@ -158,8 +157,7 @@ void main() {
           'git clone -b dev https://chromium.googlesource.com/external/github.com/flutter/flutter':
               null,
           'git reset --hard $testRef': null,
-          'git remote remove origin': null,
-          'git remote add origin https://github.com/flutter/flutter.git': null,
+          'git remote set-url origin https://github.com/flutter/flutter.git': null,
           'git describe --tags --abbrev=0': <ProcessResult>[new ProcessResult(0, 0, 'v1.2.3', '')],
         };
         if (platform.isWindows) {


### PR DESCRIPTION
This changes the packaging tool to only set the remote URL instead of recreating the remote.

Recreating it was removing some metadata that identified the repo as having been cloned from the "real" repo, so flutter --version would report an unknown channel and source.  This just sets the URL so that it looks like it came from GitHub.

I also fixed some incorrect comments, and made unzip work on platforms other than Windows (even though we don't really need it there yet).

Fixes #15518