### PR TITLE
Fix overflow behavior for RTL strings.

### DIFF
--- a/packages/flutter/lib/src/rendering/paragraph.dart
+++ b/packages/flutter/lib/src/rendering/paragraph.dart
@@ -344,7 +344,20 @@ class RenderParagraph extends RenderBox {
       }
       canvas.clipRect(bounds);
     }
-    _textPainter.paint(canvas, offset);
+    Offset overflowOffset;
+    switch (textDirection) {
+      case TextDirection.rtl:
+        overflowOffset = new Offset(size.width - _textPainter.width, 0.0);
+        break;
+      case TextDirection.ltr:
+        overflowOffset = Offset.zero;
+        break;
+    }
+    assert(() {
+      debugOverflowOffset = overflowOffset;
+      return true;
+    }());
+    _textPainter.paint(canvas, offset + overflowOffset);
     if (_hasVisualOverflow) {
       if (_overflowShader != null) {
         canvas.translate(offset.dx, offset.dy);
@@ -356,6 +369,17 @@ class RenderParagraph extends RenderBox {
       canvas.restore();
     }
   }
+
+
+  /// We may have to move the string over when we have overflow so that the
+  /// correct part of the string is truncated.  This is the amount that the
+  /// paragraph is shifted when that occurs.
+  ///
+  /// This member is visible only because it is useful in testing this object:
+  /// it's not in production use, and is only set in debug builds. Only
+  /// set after a paint has occurred.
+  @visibleForTesting
+  Offset debugOverflowOffset;
 
   /// Returns the offset at which to paint the caret.
   ///

--- a/packages/flutter/test/rendering/paragraph_test.dart
+++ b/packages/flutter/test/rendering/paragraph_test.dart
@@ -91,17 +91,20 @@ void main() {
   });
 
   test('overflow test', () {
-    final RenderParagraph paragraph = new RenderParagraph(
-      const TextSpan(
-        text: 'This\n' // 4 characters * 10px font size = 40px width on the first line
-              'is a wrapping test. It should wrap at manual newlines, and if softWrap is true, also at spaces.',
-        style: const TextStyle(fontFamily: 'Ahem', fontSize: 10.0),
-      ),
-      textDirection: TextDirection.ltr,
-      maxLines: 1,
-      softWrap: true,
-    );
-
+    const String testText = 'This\n' // 4 characters * 10px font size = 40px width on the first line
+        'is a wrapping test. It should wrap at manual newlines, and if softWrap is true, also at spaces.';
+    RenderParagraph createParagraph({TextDirection textDirection: TextDirection.ltr}) {
+      return new RenderParagraph(
+        const TextSpan(
+          text: testText,
+          style: const TextStyle(fontFamily: 'Ahem', fontSize: 10.0),
+        ),
+        textDirection: textDirection,
+        maxLines: 1,
+        softWrap: true,
+      );
+    }
+    RenderParagraph paragraph = createParagraph();
     void relayoutWith({ int maxLines, bool softWrap, TextOverflow overflow }) {
       paragraph
         ..maxLines = maxLines
@@ -164,6 +167,16 @@ void main() {
 
     relayoutWith(maxLines: 100, softWrap: true, overflow: TextOverflow.fade);
     expect(paragraph.debugHasOverflowShader, isFalse);
+
+    relayoutWith(maxLines: 1, softWrap:false, overflow: TextOverflow.clip);
+    pumpFrame(phase: EnginePhase.paint);
+    expect(paragraph.debugOverflowOffset, equals(Offset.zero));
+
+    paragraph = createParagraph(textDirection: TextDirection.rtl);
+    layout(paragraph, constraints: const BoxConstraints(maxWidth: 50.0));
+    relayoutWith(maxLines: 1, softWrap:false, overflow: TextOverflow.clip);
+    pumpFrame(phase: EnginePhase.paint);
+    expect(paragraph.debugOverflowOffset, equals(const Offset(-900.0, 0.0)));
   });
 
   test('maxLines', () {


### PR DESCRIPTION
Changes the text rendering so that for RTL strings that have visual overflow, the correct end of the string is truncated.

Fixes #15500