### PR TITLE
Do not encode the server port in the test file

### DIFF
--- a/packages/flutter_tools/lib/src/test/flutter_platform.dart
+++ b/packages/flutter_tools/lib/src/test/flutter_platform.dart
@@ -560,7 +560,6 @@ class _FlutterPlatform extends PlatformPlugin {
   String _generateTestMain({
     String testUrl,
     String encodedWebsocketUrl,
-    String serverPort: r'$serverPort' ,
   }) {
     return '''
 import 'dart:convert';
@@ -579,7 +578,7 @@ import '$testUrl' as test;
 void main() {
   print('$_kStartTimeoutTimerMessage');
   String serverPort = Platform.environment['SERVER_PORT'];
-  String server = Uri.decodeComponent('$encodedWebsocketUrl:$serverPort');
+  String server = Uri.decodeComponent('$encodedWebsocketUrl:\$serverPort');
   StreamChannel channel = serializeSuite(() {
     catchIsolateErrors();
     return test.main;

--- a/packages/flutter_tools/lib/src/test/flutter_platform.dart
+++ b/packages/flutter_tools/lib/src/test/flutter_platform.dart
@@ -745,7 +745,7 @@ class _FlutterPlatformStreamSinkWrapper<S> implements StreamSink<S> {
 
   @override
   Future<dynamic> close() {
-    Future.wait<dynamic>(<Future<dynamic>>[
+   Future.wait<dynamic>(<Future<dynamic>>[
       _parent.close(),
       _shellProcessClosed,
     ]).then<Null>(
@@ -760,8 +760,7 @@ class _FlutterPlatformStreamSinkWrapper<S> implements StreamSink<S> {
   @override
   void add(S event) => _parent.add(event);
   @override
-  void addError(dynamic errorEvent, [StackTrace stackTrace]) =>
-      _parent.addError(errorEvent, stackTrace);
+  void addError(dynamic errorEvent, [ StackTrace stackTrace ]) => _parent.addError(errorEvent, stackTrace);
   @override
   Future<dynamic> addStream(Stream<S> stream) => _parent.addStream(stream);
 }

--- a/packages/flutter_tools/lib/src/test/flutter_platform.dart
+++ b/packages/flutter_tools/lib/src/test/flutter_platform.dart
@@ -565,7 +565,7 @@ class _FlutterPlatform extends PlatformPlugin {
   }) {
     return '''
 import 'dart:convert';
-import 'dart:io';
+import 'dart:io';  // ignore: dart_io_import
 
 // We import this library first in order to trigger an import error for
 // package:test (rather than package:stream_channel) when the developer forgets

--- a/packages/flutter_tools/lib/src/test/flutter_platform.dart
+++ b/packages/flutter_tools/lib/src/test/flutter_platform.dart
@@ -513,7 +513,6 @@ class _FlutterPlatform extends PlatformPlugin {
     listenerFile.writeAsStringSync(_generateTestMain(
       testUrl: fs.path.toUri(fs.path.absolute(testPath)).toString(),
       encodedWebsocketUrl: Uri.encodeComponent(_getWebSocketUrl()),
-      serverPort: r'$serverPort',
     ));
     return listenerFile.path;
   }
@@ -561,7 +560,7 @@ class _FlutterPlatform extends PlatformPlugin {
   String _generateTestMain({
     String testUrl,
     String encodedWebsocketUrl,
-    String serverPort,
+    String serverPort: r'$serverPort' ,
   }) {
     return '''
 import 'dart:convert';


### PR DESCRIPTION
Remove the encoding the port information for the web socket connection at test file generation time,  instead set it as an environment variable. This allows for the test file to be created and kernel generated without any test harness specific information.