### PR TITLE
Place the transform and its children within the RenderFlow's opacity layer

### DIFF
--- a/packages/flutter/lib/src/rendering/flow.dart
+++ b/packages/flutter/lib/src/rendering/flow.dart
@@ -342,7 +342,7 @@ class RenderFlow extends RenderBox
       _paintingContext.pushTransform(needsCompositing, _paintingOffset, transform, painter);
     } else {
       _paintingContext.pushOpacity(_paintingOffset, _getAlphaFromOpacity(opacity), (PaintingContext context, Offset offset) {
-        _paintingContext.pushTransform(needsCompositing, offset, transform, painter);
+        context.pushTransform(needsCompositing, offset, transform, painter);
       });
     }
   }


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/15037