### PR TITLE
Fix restart in presence of --output-dill option.

### DIFF
--- a/packages/flutter_tools/lib/src/run_hot.dart
+++ b/packages/flutter_tools/lib/src/run_hot.dart
@@ -392,7 +392,7 @@ class HotRunner extends ResidentRunner {
     // We are now running from source.
     _runningFromSnapshot = false;
     final String launchPath = debuggingOptions.buildInfo.previewDart2
-        ? dillOutputPath ?? mainPath + '.dill'
+        ? mainPath + '.dill'
         : mainPath;
     await _launchFromDevFS(launchPath);
     restartTimer.stop();


### PR DESCRIPTION
Extract fix from https://github.com/flutter/flutter/pull/15592 for hot restart when `flutter` runs in `--preview-dart-2` mode with `--output-dill` option f