### PR TITLE
Revert "Add slider minimum interaction time (#15358)"

### DIFF
--- a/packages/flutter/lib/src/material/slider.dart
+++ b/packages/flutter/lib/src/material/slider.dart
@@ -2,13 +2,11 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:async';
 import 'dart:math' as math;
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/rendering.dart';
-import 'package:flutter/scheduler.dart' show timeDilation;
 import 'package:flutter/widgets.dart';
 
 import 'constants.dart';
@@ -214,30 +212,22 @@ class Slider extends StatefulWidget {
 
 class _SliderState extends State<Slider> with TickerProviderStateMixin {
   static const Duration enableAnimationDuration = const Duration(milliseconds: 75);
-  static const Duration valueIndicatorAnimationDuration = const Duration(milliseconds: 100);
+  static const Duration positionAnimationDuration = const Duration(milliseconds: 75);
 
-  // Animation controller that is run when the overlay (a.k.a radial reaction)
-  // is shown in response to user interaction.
-  AnimationController overlayController;
-  // Animation controller that is run when the value indicator is being shown
-  // or hidden.
-  AnimationController valueIndicatorController;
+  // Animation controller that is run when interactions occur (taps, drags,
+  // etc.).
+  AnimationController reactionController;
   // Animation controller that is run when enabling/disabling the slider.
   AnimationController enableController;
   // Animation controller that is run when transitioning between one value
   // and the next on a discrete slider.
   AnimationController positionController;
-  Timer interactionTimer;
 
   @override
   void initState() {
     super.initState();
-    overlayController = new AnimationController(
+    reactionController = new AnimationController(
       duration: kRadialReactionDuration,
-      vsync: this,
-    );
-    valueIndicatorController = new AnimationController(
-      duration: valueIndicatorAnimationDuration,
       vsync: this,
     );
     enableController = new AnimationController(
@@ -245,24 +235,18 @@ class _SliderState extends State<Slider> with TickerProviderStateMixin {
       vsync: this,
     );
     positionController = new AnimationController(
-      duration: Duration.zero,
+      duration: positionAnimationDuration,
       vsync: this,
     );
-    // Create timer in a cancelled state, so that we don't have to
-    // check for null below.
-    interactionTimer = new Timer(Duration.zero, () {});
-    interactionTimer.cancel();
     enableController.value = widget.onChanged != null ? 1.0 : 0.0;
-    positionController.value = _unlerp(widget.value);
+    positionController.value = widget.value;
   }
 
   @override
   void dispose() {
-    overlayController.dispose();
-    valueIndicatorController.dispose();
+    reactionController.dispose();
     enableController.dispose();
     positionController.dispose();
-    interactionTimer?.cancel();
     super.dispose();
   }
 
@@ -374,6 +358,15 @@ class _SliderRenderObjectWidget extends LeafRenderObjectWidget {
   }
 }
 
+const double _overlayRadius = 16.0;
+const double _overlayDiameter = _overlayRadius * 2.0;
+const double _railHeight = 2.0;
+const double _preferredRailWidth = 144.0;
+const double _preferredTotalWidth = _preferredRailWidth + _overlayDiameter;
+
+const double _adjustmentUnit = 0.1; // Matches iOS implementation of material slider.
+final Tween<double> _overlayRadiusTween = new Tween<double>(begin: 0.0, end: _overlayRadius);
+
 class _RenderSlider extends RenderBox {
   _RenderSlider({
     @required double value,
@@ -410,12 +403,8 @@ class _RenderSlider extends RenderBox {
       ..onTapDown = _handleTapDown
       ..onTapUp = _handleTapUp
       ..onTapCancel = _endInteraction;
-    _overlayAnimation = new CurvedAnimation(
-      parent: _state.overlayController,
-      curve: Curves.fastOutSlowIn,
-    );
-    _valueIndicatorAnimation = new CurvedAnimation(
-      parent: _state.valueIndicatorController,
+    _reaction = new CurvedAnimation(
+      parent: _state.reactionController,
       curve: Curves.fastOutSlowIn,
     );
     _enableAnimation = new CurvedAnimation(
@@ -424,34 +413,11 @@ class _RenderSlider extends RenderBox {
     );
   }
 
-  static const Duration _positionAnimationDuration = const Duration(milliseconds: 75);
-  static const double _overlayRadius = 16.0;
-  static const double _overlayDiameter = _overlayRadius * 2.0;
-  static const double _railHeight = 2.0;
-  static const double _preferredRailWidth = 144.0;
-  static const double _preferredTotalWidth = _preferredRailWidth + _overlayDiameter;
-  static const Duration _minimumInteractionTime = const Duration(milliseconds: 500);
-  static const double _adjustmentUnit = 0.1; // Matches iOS implementation of material slider.
-  static final Tween<double> _overlayRadiusTween = new Tween<double>(begin: 0.0, end: _overlayRadius);
-
-  _SliderState _state;
-  Animation<double> _overlayAnimation;
-  Animation<double> _valueIndicatorAnimation;
-  Animation<double> _enableAnimation;
-  final TextPainter _labelPainter = new TextPainter();
-  HorizontalDragGestureRecognizer _drag;
-  TapGestureRecognizer _tap;
-  bool _active = false;
-  double _currentDragValue = 0.0;
-
-  double get _railLength => size.width - _overlayDiameter;
-
-  bool get isInteractive => onChanged != null;
-
-  bool get isDiscrete => divisions != null && divisions > 0;
-
   double get value => _value;
   double _value;
+
+  _SliderState _state;
+
   set value(double newValue) {
     assert(newValue != null && newValue >= 0.0 && newValue <= 1.0);
     final double convertedValue = isDiscrete ? _discretize(newValue) : newValue;
@@ -460,14 +426,6 @@ class _RenderSlider extends RenderBox {
     }
     _value = convertedValue;
     if (isDiscrete) {
-      // Reset the duration to match the distance that we're traveling, so that
-      // whatever the distance, we still do it in _positionAnimationDuration,
-      // and if we get re-targeted in the middle, it still takes that long to
-      // get to the new location.
-      final double distance = (_value - _state.positionController.value).abs();
-      _state.positionController.duration = distance != 0.0
-        ? _positionAnimationDuration * (1.0 / distance)
-        : 0.0;
       _state.positionController.animateTo(convertedValue, curve: Curves.easeInOut);
     } else {
       _state.positionController.value = convertedValue;
@@ -556,25 +514,6 @@ class _RenderSlider extends RenderBox {
     _updateLabelPainter();
   }
 
-  bool get showValueIndicator {
-    bool showValueIndicator;
-    switch (_sliderTheme.showValueIndicator) {
-      case ShowValueIndicator.onlyForDiscrete:
-        showValueIndicator = isDiscrete;
-        break;
-      case ShowValueIndicator.onlyForContinuous:
-        showValueIndicator = !isDiscrete;
-        break;
-      case ShowValueIndicator.always:
-        showValueIndicator = true;
-        break;
-      case ShowValueIndicator.never:
-        showValueIndicator = false;
-        break;
-    }
-    return showValueIndicator;
-  }
-
   void _updateLabelPainter() {
     if (label != null) {
       _labelPainter
@@ -591,19 +530,31 @@ class _RenderSlider extends RenderBox {
     markNeedsLayout();
   }
 
+  double get _railLength => size.width - _overlayDiameter;
+
+  Animation<double> _reaction;
+  Animation<double> _enableAnimation;
+  final TextPainter _labelPainter = new TextPainter();
+  HorizontalDragGestureRecognizer _drag;
+  TapGestureRecognizer _tap;
+  bool _active = false;
+  double _currentDragValue = 0.0;
+
+  bool get isInteractive => onChanged != null;
+
+  bool get isDiscrete => divisions != null && divisions > 0;
+
   @override
   void attach(PipelineOwner owner) {
     super.attach(owner);
-    _overlayAnimation.addListener(markNeedsPaint);
-    _valueIndicatorAnimation.addListener(markNeedsPaint);
+    _reaction.addListener(markNeedsPaint);
     _enableAnimation.addListener(markNeedsPaint);
     _state.positionController.addListener(markNeedsPaint);
   }
 
   @override
   void detach() {
-    _overlayAnimation.removeListener(markNeedsPaint);
-    _valueIndicatorAnimation.removeListener(markNeedsPaint);
+    _reaction.removeListener(markNeedsPaint);
     _enableAnimation.removeListener(markNeedsPaint);
     _state.positionController.removeListener(markNeedsPaint);
     super.detach();
@@ -637,19 +588,7 @@ class _RenderSlider extends RenderBox {
       _active = true;
       _currentDragValue = _getValueFromGlobalPosition(globalPosition);
       onChanged(_discretize(_currentDragValue));
-      _state.overlayController.forward();
-      if (showValueIndicator) {
-        _state.valueIndicatorController.forward();
-        if (_state.interactionTimer.isActive) {
-          _state.interactionTimer.cancel();
-        }
-        _state.interactionTimer = new Timer(_minimumInteractionTime * timeDilation, () {
-          if (!_active && _state.valueIndicatorController.status == AnimationStatus.completed) {
-            _state.valueIndicatorController.reverse();
-          }
-          _state.interactionTimer.cancel();
-        });
-      }
+      _state.reactionController.forward();
     }
   }
 
@@ -657,10 +596,7 @@ class _RenderSlider extends RenderBox {
     if (_active) {
       _active = false;
       _currentDragValue = 0.0;
-      _state.overlayController.reverse();
-      if (showValueIndicator && !_state.interactionTimer.isActive) {
-        _state.valueIndicatorController.reverse();
-      }
+      _state.reactionController.reverse();
     }
   }
 
@@ -760,15 +696,15 @@ class _RenderSlider extends RenderBox {
   }
 
   void _paintOverlay(Canvas canvas, Offset center) {
-    if (!_overlayAnimation.isDismissed) {
+    if (!_reaction.isDismissed) {
       // TODO(gspencer) : We don't really follow the spec here for overlays.
       // The spec says to use 16% opacity for drawing over light material,
       // and 32% for colored material, but we don't really have a way to
       // know what the underlying color is, so there's no easy way to
       // implement this. Choosing the "light" version for now.
-      final Paint overlayPaint = new Paint()..color = _sliderTheme.overlayColor;
-      final double radius = _overlayRadiusTween.evaluate(_overlayAnimation);
-      canvas.drawCircle(center, radius, overlayPaint);
+      final Paint reactionPaint = new Paint()..color = _sliderTheme.overlayColor;
+      final double radius = _overlayRadiusTween.evaluate(_reaction);
+      canvas.drawCircle(center, radius, reactionPaint);
     }
   }
 
@@ -845,15 +781,29 @@ class _RenderSlider extends RenderBox {
       rightTickMarkPaint,
     );
 
-    if (isInteractive && label != null &&
-        _valueIndicatorAnimation.status != AnimationStatus.dismissed) {
+    if (isInteractive && _reaction.status != AnimationStatus.dismissed && label != null) {
+      bool showValueIndicator;
+      switch (_sliderTheme.showValueIndicator) {
+        case ShowValueIndicator.onlyForDiscrete:
+          showValueIndicator = isDiscrete;
+          break;
+        case ShowValueIndicator.onlyForContinuous:
+          showValueIndicator = !isDiscrete;
+          break;
+        case ShowValueIndicator.always:
+          showValueIndicator = true;
+          break;
+        case ShowValueIndicator.never:
+          showValueIndicator = false;
+          break;
+      }
       if (showValueIndicator) {
         _sliderTheme.valueIndicatorShape.paint(
           this,
           context,
           isDiscrete,
           thumbCenter,
-          _valueIndicatorAnimation,
+          _reaction,
           _enableAnimation,
           _labelPainter,
           _sliderTheme,
@@ -868,7 +818,7 @@ class _RenderSlider extends RenderBox {
       context,
       isDiscrete,
       thumbCenter,
-      _overlayAnimation,
+      _reaction,
       _enableAnimation,
       label != null ? _labelPainter : null,
       _sliderTheme,

--- a/packages/flutter/lib/src/material/slider_theme.dart
+++ b/packages/flutter/lib/src/material/slider_theme.dart
@@ -469,19 +469,19 @@ class SliderThemeData extends Diagnosticable {
     );
     description.add(new DiagnosticsProperty<Color>('activeRailColor', activeRailColor, defaultValue: defaultData.activeRailColor));
     description.add(new DiagnosticsProperty<Color>('inactiveRailColor', inactiveRailColor, defaultValue: defaultData.inactiveRailColor));
-    description.add(new DiagnosticsProperty<Color>('disabledActiveRailColor', disabledActiveRailColor, defaultValue: defaultData.disabledActiveRailColor, level: DiagnosticLevel.debug));
-    description.add(new DiagnosticsProperty<Color>('disabledInactiveRailColor', disabledInactiveRailColor, defaultValue: defaultData.disabledInactiveRailColor, level: DiagnosticLevel.debug));
-    description.add(new DiagnosticsProperty<Color>('activeTickMarkColor', activeTickMarkColor, defaultValue: defaultData.activeTickMarkColor, level: DiagnosticLevel.debug));
-    description.add(new DiagnosticsProperty<Color>('inactiveTickMarkColor', inactiveTickMarkColor, defaultValue: defaultData.inactiveTickMarkColor, level: DiagnosticLevel.debug));
-    description.add(new DiagnosticsProperty<Color>('disabledActiveTickMarkColor', disabledActiveTickMarkColor, defaultValue: defaultData.disabledActiveTickMarkColor, level: DiagnosticLevel.debug));
-    description.add(new DiagnosticsProperty<Color>('disabledInactiveTickMarkColor', disabledInactiveTickMarkColor, defaultValue: defaultData.disabledInactiveTickMarkColor, level: DiagnosticLevel.debug));
+    description.add(new DiagnosticsProperty<Color>('disabledActiveRailColor', disabledActiveRailColor, defaultValue: defaultData.disabledActiveRailColor));
+    description.add(new DiagnosticsProperty<Color>('disabledInactiveRailColor', disabledInactiveRailColor, defaultValue: defaultData.disabledInactiveRailColor));
+    description.add(new DiagnosticsProperty<Color>('activeTickMarkColor', activeTickMarkColor, defaultValue: defaultData.activeTickMarkColor));
+    description.add(new DiagnosticsProperty<Color>('inactiveTickMarkColor', inactiveTickMarkColor, defaultValue: defaultData.inactiveTickMarkColor));
+    description.add(new DiagnosticsProperty<Color>('disabledActiveTickMarkColor', disabledActiveTickMarkColor, defaultValue: defaultData.disabledActiveTickMarkColor));
+    description.add(new DiagnosticsProperty<Color>('disabledInactiveTickMarkColor', disabledInactiveTickMarkColor, defaultValue: defaultData.disabledInactiveTickMarkColor));
     description.add(new DiagnosticsProperty<Color>('thumbColor', thumbColor, defaultValue: defaultData.thumbColor));
-    description.add(new DiagnosticsProperty<Color>('disabledThumbColor', disabledThumbColor, defaultValue: defaultData.disabledThumbColor, level: DiagnosticLevel.debug));
-    description.add(new DiagnosticsProperty<Color>('overlayColor', overlayColor, defaultValue: defaultData.overlayColor, level: DiagnosticLevel.debug));
+    description.add(new DiagnosticsProperty<Color>('disabledThumbColor', disabledThumbColor, defaultValue: defaultData.disabledThumbColor));
+    description.add(new DiagnosticsProperty<Color>('overlayColor', overlayColor, defaultValue: defaultData.overlayColor));
     description.add(new DiagnosticsProperty<Color>('valueIndicatorColor', valueIndicatorColor, defaultValue: defaultData.valueIndicatorColor));
-    description.add(new DiagnosticsProperty<SliderComponentShape>('thumbShape', thumbShape, defaultValue: defaultData.thumbShape, level: DiagnosticLevel.debug));
-    description.add(new DiagnosticsProperty<SliderComponentShape>('valueIndicatorShape', valueIndicatorShape, defaultValue: defaultData.valueIndicatorShape, level: DiagnosticLevel.debug));
-    description.add(new EnumProperty<ShowValueIndicator>('showValueIndicator', showValueIndicator, defaultValue: defaultData.showValueIndicator));
+    description.add(new DiagnosticsProperty<SliderComponentShape>('thumbShape', thumbShape, defaultValue: defaultData.thumbShape));
+    description.add(new DiagnosticsProperty<SliderComponentShape>('valueIndicatorShape', valueIndicatorShape, defaultValue: defaultData.valueIndicatorShape));
+    description.add(new DiagnosticsProperty<ShowValueIndicator>('showValueIndicator', showValueIndicator, defaultValue: defaultData.showValueIndicator));
   }
 }
 
@@ -595,8 +595,8 @@ class PaddleSliderValueIndicatorShape extends SliderComponentShape {
 
   // Radius of the top lobe of the value indicator.
   static const double _topLobeRadius = 16.0;
-  // Designed size of the label text. This is the size that the value indicator
-  // was designed to contain. We scale it from here to fit other sizes.
+  // Baseline size of the label text. This is the size that the value indicator
+  // was designed to contain. We scale if from here to fit other sizes.
   static const double _labelTextDesignSize = 14.0;
   // Radius of the bottom lobe of the value indicator.
   static const double _bottomLobeRadius = 6.0;

--- a/packages/flutter/test/material/slider_test.dart
+++ b/packages/flutter/test/material/slider_test.dart
@@ -177,168 +177,6 @@ void main() {
     expect(updates, equals(1));
   });
 
-  testWidgets('Value indicator shows for a bit after being tapped', (WidgetTester tester) async {
-    final Key sliderKey = new UniqueKey();
-    double value = 0.0;
-
-    await tester.pumpWidget(
-      new Directionality(
-        textDirection: TextDirection.ltr,
-        child: new StatefulBuilder(
-          builder: (BuildContext context, StateSetter setState) {
-            return new MediaQuery(
-              data: new MediaQueryData.fromWindow(window),
-              child: new Material(
-                child: new Center(
-                  child: new Slider(
-                    key: sliderKey,
-                    value: value,
-                    divisions: 4,
-                    onChanged: (double newValue) {
-                      setState(() {
-                        value = newValue;
-                      });
-                    },
-                  ),
-                ),
-              ),
-            );
-          },
-        ),
-      ),
-    );
-
-    expect(value, equals(0.0));
-    await tester.tap(find.byKey(sliderKey));
-    expect(value, equals(0.5));
-    await tester.pump(const Duration(milliseconds: 100));
-    // Starts with the position animation and value indicator
-    expect(SchedulerBinding.instance.transientCallbackCount, equals(2));
-    await tester.pump(const Duration(milliseconds: 100));
-    // Value indicator is longer than position.
-    expect(SchedulerBinding.instance.transientCallbackCount, equals(1));
-    await tester.pump(const Duration(milliseconds: 100));
-    expect(SchedulerBinding.instance.transientCallbackCount, equals(0));
-    await tester.pump(const Duration(milliseconds: 100));
-    expect(SchedulerBinding.instance.transientCallbackCount, equals(0));
-    await tester.pump(const Duration(milliseconds: 100));
-    // Shown for long enough, value indicator is animated closed.
-    expect(SchedulerBinding.instance.transientCallbackCount, equals(1));
-    await tester.pump(const Duration(milliseconds: 101));
-    expect(SchedulerBinding.instance.transientCallbackCount, equals(0));
-  });
-
-  testWidgets('Discrete Slider repaints and animates when dragged', (WidgetTester tester) async {
-    final Key sliderKey = new UniqueKey();
-    double value = 0.0;
-    final List<Offset> log = <Offset>[];
-    final LoggingThumbShape loggingThumb = new LoggingThumbShape(log);
-    await tester.pumpWidget(
-      new Directionality(
-        textDirection: TextDirection.ltr,
-        child: new StatefulBuilder(
-          builder: (BuildContext context, StateSetter setState) {
-            final SliderThemeData sliderTheme = SliderTheme.of(context).copyWith(thumbShape: loggingThumb);
-            return new MediaQuery(
-              data: new MediaQueryData.fromWindow(window),
-              child: new Material(
-                child: new Center(
-                  child: new SliderTheme(
-                    data: sliderTheme,
-                    child: new Slider(
-                      key: sliderKey,
-                      value: value,
-                      divisions: 4,
-                      onChanged: (double newValue) {
-                        setState(() {
-                          value = newValue;
-                        });
-                      },
-                    ),
-                  ),
-                ),
-              ),
-            );
-          },
-        ),
-      ),
-    );
-
-    final List<Offset> expectedLog = <Offset>[
-      const Offset(16.0, 300.0),
-      const Offset(16.0, 300.0),
-      const Offset(400.0, 300.0),
-    ];
-    final TestGesture gesture = await tester.startGesture(tester.getCenter(find.byKey(sliderKey)));
-    await tester.pump();
-    await tester.pump(const Duration(milliseconds: 100));
-    expect(value, equals(0.5));
-    expect(log.length, 3);
-    expect(log, orderedEquals(expectedLog));
-    await gesture.moveBy(const Offset(-500.0, 0.0));
-    await tester.pump();
-    await tester.pump(const Duration(milliseconds: 10));
-    expect(value, equals(0.0));
-    expect(log.length, 5);
-    expect(log.last.dx, closeTo(386.3, 0.1));
-    // With no more gesture or value changes, the thumb position should still
-    // be redrawn in the animated position.
-    await tester.pump();
-    await tester.pump(const Duration(milliseconds: 10));
-    expect(value, equals(0.0));
-    expect(log.length, 7);
-    expect(log.last.dx, closeTo(343.3, 0.1));
-    // Final position.
-    await tester.pump(const Duration(milliseconds: 80));
-    expectedLog.add(const Offset(16.0, 300.0));
-    expect(value, equals(0.0));
-    expect(log.length, 8);
-    expect(log.last.dx, closeTo(16.0, 0.1));
-    await gesture.up();
-  });
-
-  testWidgets("Slider doesn't send duplicate change events if tapped on the same value", (WidgetTester tester) async {
-    final Key sliderKey = new UniqueKey();
-    double value = 0.0;
-    int updates = 0;
-
-    await tester.pumpWidget(
-      new Directionality(
-        textDirection: TextDirection.ltr,
-        child: new StatefulBuilder(
-          builder: (BuildContext context, StateSetter setState) {
-            return new MediaQuery(
-              data: new MediaQueryData.fromWindow(window),
-              child: new Material(
-                child: new Center(
-                  child: new Slider(
-                    key: sliderKey,
-                    value: value,
-                    onChanged: (double newValue) {
-                      setState(() {
-                        updates++;
-                        value = newValue;
-                      });
-                    },
-                  ),
-                ),
-              ),
-            );
-          },
-        ),
-      ),
-    );
-
-    expect(value, equals(0.0));
-    await tester.tap(find.byKey(sliderKey));
-    expect(value, equals(0.5));
-    await tester.pump();
-    await tester.tap(find.byKey(sliderKey));
-    expect(value, equals(0.5));
-    await tester.pump();
-    expect(updates, equals(1));
-  });
-
   testWidgets('discrete Slider repaints when dragged', (WidgetTester tester) async {
     final Key sliderKey = new UniqueKey();
     double value = 0.0;
@@ -391,14 +229,14 @@ void main() {
     await tester.pump(const Duration(milliseconds: 10));
     expect(value, equals(0.0));
     expect(log.length, 5);
-    expect(log.last.dx, closeTo(386.3, 0.1));
+    expect(log.last.dx, closeTo(343.3, 0.1));
     // With no more gesture or value changes, the thumb position should still
     // be redrawn in the animated position.
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 10));
     expect(value, equals(0.0));
     expect(log.length, 7);
-    expect(log.last.dx, closeTo(343.3, 0.1));
+    expect(log.last.dx, closeTo(185.5, 0.1));
     // Final position.
     await tester.pump(const Duration(milliseconds: 80));
     expectedLog.add(const Offset(16.0, 300.0));
@@ -605,11 +443,7 @@ void main() {
     expect(sliderBox, isNot(paints..rect(color: sliderTheme.disabledInactiveRailColor)));
 
     // Test colors for discrete slider with inactiveColor and activeColor set.
-    await tester.pumpWidget(buildApp(
-      activeColor: customColor1,
-      inactiveColor: customColor2,
-      divisions: 3,
-    ));
+    await tester.pumpWidget(buildApp(activeColor: customColor1, inactiveColor: customColor2, divisions: 3));
     expect(sliderBox, paints..rect(color: customColor1)..rect(color: customColor2));
     expect(
         sliderBox,
@@ -628,7 +462,7 @@ void main() {
 
     // Test default theme for disabled widget.
     await tester.pumpWidget(buildApp(enabled: false));
-    await tester.pumpAndSettle();
+    await tester.pump(const Duration(seconds: 1)); // wait for disable animation to finish.
     expect(
         sliderBox,
         paints
@@ -655,8 +489,9 @@ void main() {
     await tester.pumpWidget(buildApp(divisions: 3));
     Offset center = tester.getCenter(find.byType(Slider));
     TestGesture gesture = await tester.startGesture(center);
+    await tester.pump();
     // Wait for value indicator animation to finish.
-    await tester.pumpAndSettle();
+    await tester.pump(const Duration(milliseconds: 500));
     expect(value, equals(2.0 / 3.0));
     expect(
       sliderBox,
@@ -672,8 +507,9 @@ void main() {
         ..circle(color: sliderTheme.thumbColor),
     );
     await gesture.up();
+    await tester.pump();
     // Wait for value indicator animation to finish.
-    await tester.pumpAndSettle();
+    await tester.pump(const Duration(milliseconds: 500));
 
     // Testing the custom colors are used for the indicator.
     await tester.pumpWidget(buildApp(
@@ -683,8 +519,9 @@ void main() {
     ));
     center = tester.getCenter(find.byType(Slider));
     gesture = await tester.startGesture(center);
+    await tester.pump();
     // Wait for value indicator animation to finish.
-    await tester.pumpAndSettle();
+    await tester.pump(const Duration(milliseconds: 500));
     expect(value, equals(2.0 / 3.0));
     expect(
       sliderBox,
@@ -897,22 +734,24 @@ void main() {
     await tester.pumpWidget(buildSlider(textScaleFactor: 1.0));
     Offset center = tester.getCenter(find.byType(Slider));
     TestGesture gesture = await tester.startGesture(center);
-    await tester.pumpAndSettle();
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 500));
 
     expect(tester.renderObject(find.byType(Slider)), paints..scale(x: 1.0, y: 1.0));
 
     await gesture.up();
-    await tester.pumpAndSettle();
+    await tester.pump(const Duration(seconds: 1));
 
     await tester.pumpWidget(buildSlider(textScaleFactor: 2.0));
     center = tester.getCenter(find.byType(Slider));
     gesture = await tester.startGesture(center);
-    await tester.pumpAndSettle();
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 500));
 
     expect(tester.renderObject(find.byType(Slider)), paints..scale(x: 2.0, y: 2.0));
 
     await gesture.up();
-    await tester.pumpAndSettle();
+    await tester.pump(const Duration(seconds: 1));
 
     // Check continuous
     await tester.pumpWidget(buildSlider(
@@ -922,12 +761,13 @@ void main() {
     ));
     center = tester.getCenter(find.byType(Slider));
     gesture = await tester.startGesture(center);
-    await tester.pumpAndSettle();
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 500));
 
     expect(tester.renderObject(find.byType(Slider)), paints..scale(x: 1.0, y: 1.0));
 
     await gesture.up();
-    await tester.pumpAndSettle();
+    await tester.pump(const Duration(seconds: 1));
 
     await tester.pumpWidget(buildSlider(
       textScaleFactor: 2.0,
@@ -936,12 +776,13 @@ void main() {
     ));
     center = tester.getCenter(find.byType(Slider));
     gesture = await tester.startGesture(center);
-    await tester.pumpAndSettle();
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 500));
 
     expect(tester.renderObject(find.byType(Slider)), paints..scale(x: 2.0, y: 2.0));
 
     await gesture.up();
-    await tester.pumpAndSettle();
+    await tester.pump(const Duration(seconds: 1));
   });
 
   testWidgets('Slider has correct animations when reparented', (WidgetTester tester) async {
@@ -989,7 +830,7 @@ void main() {
       TestGesture gesture = await tester.startGesture(Offset.zero);
       await tester.pump();
       await gesture.up();
-      await tester.pumpAndSettle();
+      await tester.pump(const Duration(seconds: 1));
       expect(SchedulerBinding.instance.transientCallbackCount, equals(0));
       expect(
         sliderBox,
@@ -1009,13 +850,13 @@ void main() {
       expect(
         sliderBox,
         paints
-          ..circle(x: 105.0625, y: 16.0, radius: 3.791776657104492)
+          ..circle(x: 310.9375, y: 16.0, radius: 3.791776657104492)
           ..circle(x: 17.0, y: 16.0, radius: 1.0)
           ..circle(x: 208.5, y: 16.0, radius: 1.0)
           ..circle(x: 400.0, y: 16.0, radius: 1.0)
           ..circle(x: 591.5, y: 16.0, radius: 1.0)
           ..circle(x: 783.0, y: 16.0, radius: 1.0)
-          ..circle(x: 105.0625, y: 16.0, radius: 6.0),
+          ..circle(x: 310.9375, y: 16.0, radius: 6.0),
       );
 
       // Reparenting in the middle of an animation should do nothing.
@@ -1029,16 +870,15 @@ void main() {
       expect(
         sliderBox,
         paints
-          ..circle(x: 185.5457763671875, y: 16.0, radius: 8.0)
+          ..circle(x: 396.6802978515625, y: 16.0, radius: 8.0)
           ..circle(x: 17.0, y: 16.0, radius: 1.0)
           ..circle(x: 208.5, y: 16.0, radius: 1.0)
-          ..circle(x: 400.0, y: 16.0, radius: 1.0)
           ..circle(x: 591.5, y: 16.0, radius: 1.0)
           ..circle(x: 783.0, y: 16.0, radius: 1.0)
-          ..circle(x: 185.5457763671875, y: 16.0, radius: 6.0),
+          ..circle(x: 396.6802978515625, y: 16.0, radius: 6.0),
       );
       // Wait for animations to finish.
-      await tester.pumpAndSettle();
+      await tester.pump(const Duration(milliseconds: 300));
       expect(SchedulerBinding.instance.transientCallbackCount, equals(0));
       expect(
         sliderBox,
@@ -1051,7 +891,8 @@ void main() {
           ..circle(x: 400.0, y: 16.0, radius: 6.0),
       );
       await gesture.up();
-      await tester.pumpAndSettle();
+      await tester.pump();
+      await tester.pump(const Duration(seconds: 1));
       expect(SchedulerBinding.instance.transientCallbackCount, equals(0));
       expect(
         sliderBox,
@@ -1062,6 +903,21 @@ void main() {
           ..circle(x: 783.0, y: 16.0, radius: 1.0)
           ..circle(x: 400.0, y: 16.0, radius: 6.0),
       );
+      // Move to 0.0 again.
+      gesture = await tester.startGesture(Offset.zero);
+      await tester.pump();
+      await gesture.up();
+      await tester.pump(const Duration(seconds: 1));
+      expect(SchedulerBinding.instance.transientCallbackCount, equals(0));
+      expect(
+        sliderBox,
+        paints
+          ..circle(x: 208.5, y: 16.0, radius: 1.0)
+          ..circle(x: 400.0, y: 16.0, radius: 1.0)
+          ..circle(x: 591.5, y: 16.0, radius: 1.0)
+          ..circle(x: 783.0, y: 16.0, radius: 1.0)
+          ..circle(x: 16.0, y: 16.0, radius: 6.0),
+      );
     }
 
     await tester.pumpWidget(buildSlider(1));
@@ -1069,6 +925,7 @@ void main() {
     await testReparenting(false);
     // Now do it again with reparenting in the middle of an animation.
     await testReparenting(true);
+
   });
 
   testWidgets('Slider Semantics', (WidgetTester tester) async {
@@ -1168,8 +1025,9 @@ void main() {
       await tester.pumpWidget(buildApp(sliderTheme: theme, divisions: divisions, enabled: enabled));
       final Offset center = tester.getCenter(find.byType(Slider));
       final TestGesture gesture = await tester.startGesture(center);
+      await tester.pump();
       // Wait for value indicator animation to finish.
-      await tester.pumpAndSettle();
+      await tester.pump(const Duration(milliseconds: 500));
 
       final RenderBox sliderBox = tester.firstRenderObject<RenderBox>(find.byType(Slider));
       expect(


### PR DESCRIPTION
This is purely a test revert to rule out the associated patch as the
source of the flutter_gallery_ios__transition_perf632 frames
missed_frame_rasterizer_budget_count benchmark.

I do not expect that this is the source of the regression; it seems far
more likely that this was a fluke regression on this commit and that the
true source of the regression is #15494.

This reverts commit d28e9aa5c94a85ae729650ad12147834d191ec9a.