### PR TITLE
Add a slider demo, and a text theme for SliderThemeData

### DIFF
--- a/examples/flutter_gallery/lib/demo/material/slider_demo.dart
+++ b/examples/flutter_gallery/lib/demo/material/slider_demo.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:math' as math;
+
 import 'package:flutter/material.dart';
 
 class SliderDemo extends StatefulWidget {
@@ -11,12 +13,124 @@ class SliderDemo extends StatefulWidget {
   _SliderDemoState createState() => new _SliderDemoState();
 }
 
+Path _triangle(double size, Offset thumbCenter, {bool invert: false}) {
+  final Path thumbPath = new Path();
+  final double height = math.sqrt(3.0) / 2.0;
+  final double halfSide = size / 2.0;
+  final double centerHeight = size * height / 3.0;
+  final double sign = invert ? -1.0 : 1.0;
+  thumbPath.moveTo(thumbCenter.dx - halfSide, thumbCenter.dy + sign * centerHeight);
+  thumbPath.lineTo(thumbCenter.dx, thumbCenter.dy - 2.0 * sign * centerHeight);
+  thumbPath.lineTo(thumbCenter.dx + halfSide, thumbCenter.dy + sign * centerHeight);
+  thumbPath.lineTo(thumbCenter.dx - halfSide, thumbCenter.dy + sign * centerHeight);
+  return thumbPath;
+}
+
+class _CustomThumbShape extends SliderComponentShape {
+  const _CustomThumbShape();
+  static const double _thumbSize = 4.0;
+  static const double _disabledThumbSize = 4.0;
+
+  @override
+  Size getPreferredSize(bool isEnabled, bool isDiscrete) {
+    return new Size.fromRadius(isEnabled ? _thumbSize : _disabledThumbSize);
+  }
+
+  @override
+  void paint(
+    RenderBox parentBox,
+    PaintingContext context,
+    bool isDiscrete,
+    Offset thumbCenter,
+    Animation<double> activationAnimation,
+    Animation<double> enableAnimation,
+    TextPainter labelPainter,
+    SliderThemeData sliderTheme,
+    TextDirection textDirection,
+    double value,
+  ) {
+    final Canvas canvas = context.canvas;
+    final Tween<double> radiusTween = new Tween<double>(
+      begin: _disabledThumbSize,
+      end: _thumbSize,
+    );
+    final ColorTween colorTween = new ColorTween(
+      begin: sliderTheme.disabledThumbColor,
+      end: sliderTheme.thumbColor,
+    );
+    final double size = _thumbSize * radiusTween.evaluate(enableAnimation);
+    final Path thumbPath = _triangle(size, thumbCenter);
+    canvas.drawPath(thumbPath, new Paint()..color = colorTween.evaluate(enableAnimation));
+  }
+}
+
+class _CustomValueIndicatorShape extends SliderComponentShape {
+  const _CustomValueIndicatorShape();
+  static const double _indicatorSize = 4.0;
+  static const double _disabledIndicatorSize = 4.0;
+  static const double _slideUpHeight = 40.0;
+
+  @override
+  Size getPreferredSize(bool isEnabled, bool isDiscrete) {
+    return new Size.fromRadius(isEnabled ? _indicatorSize : _disabledIndicatorSize);
+  }
+
+  @override
+  void paint(
+    RenderBox parentBox,
+    PaintingContext context,
+    bool isDiscrete,
+    Offset thumbCenter,
+    Animation<double> activationAnimation,
+    Animation<double> enableAnimation,
+    TextPainter labelPainter,
+    SliderThemeData sliderTheme,
+    TextDirection textDirection,
+    double value,
+  ) {
+    final Canvas canvas = context.canvas;
+    final Tween<double> radiusTween = new Tween<double>(
+      begin: _disabledIndicatorSize,
+      end: _indicatorSize,
+    );
+    final ColorTween enableColor = new ColorTween(
+      begin: sliderTheme.disabledThumbColor,
+      end: sliderTheme.valueIndicatorColor,
+    );
+    final Tween<double> slideUpTween = new Tween<double>(
+      begin: 0.0,
+      end: _slideUpHeight,
+    );
+    final double size = _indicatorSize * radiusTween.evaluate(enableAnimation);
+    final Offset slideUpOffset = new Offset(0.0, -slideUpTween.evaluate(activationAnimation));
+    final Path thumbPath = _triangle(
+      size,
+      thumbCenter + slideUpOffset,
+      invert: true,
+    );
+    final Color paintColor = enableColor.evaluate(enableAnimation).withAlpha((255.0 * activationAnimation.value).round());
+    canvas.drawPath(
+      thumbPath,
+      new Paint()..color = paintColor,
+    );
+    canvas.drawLine(
+        thumbCenter,
+        thumbCenter + slideUpOffset,
+        new Paint()
+          ..color = paintColor
+          ..style = PaintingStyle.stroke
+          ..strokeWidth = 2.0);
+    labelPainter.paint(canvas, thumbCenter + slideUpOffset + new Offset(-labelPainter.width / 2.0, -labelPainter.height - 4.0));
+  }
+}
+
 class _SliderDemoState extends State<SliderDemo> {
   double _value = 25.0;
   double _discreteValue = 20.0;
 
   @override
   Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
     return new Scaffold(
       appBar: new AppBar(title: const Text('Sliders')),
       body: new Padding(
@@ -26,7 +140,7 @@ class _SliderDemoState extends State<SliderDemo> {
           children: <Widget>[
             new Column(
               mainAxisSize: MainAxisSize.min,
-              children: <Widget> [
+              children: <Widget>[
                 new Slider(
                   value: _value,
                   min: 0.0,
@@ -35,21 +149,21 @@ class _SliderDemoState extends State<SliderDemo> {
                     setState(() {
                       _value = value;
                     });
-                  }
+                  },
                 ),
                 const Text('Continuous'),
-              ]
+              ],
             ),
             new Column(
               mainAxisSize: MainAxisSize.min,
-              children: const <Widget> [
+              children: const <Widget>[
                 const Slider(value: 0.25, onChanged: null),
                 const Text('Disabled'),
-              ]
+              ],
             ),
             new Column(
               mainAxisSize: MainAxisSize.min,
-              children: <Widget> [
+              children: <Widget>[
                 new Slider(
                   value: _discreteValue,
                   min: 0.0,
@@ -60,9 +174,41 @@ class _SliderDemoState extends State<SliderDemo> {
                     setState(() {
                       _discreteValue = value;
                     });
-                  }
+                  },
                 ),
                 const Text('Discrete'),
+              ],
+            ),
+            new Column(
+              mainAxisSize: MainAxisSize.min,
+              children: <Widget>[
+                new SliderTheme(
+                  data: theme.sliderTheme.copyWith(
+                    activeRailColor: Colors.deepPurple,
+                    inactiveRailColor: Colors.black26,
+                    activeTickMarkColor: Colors.white70,
+                    inactiveTickMarkColor: Colors.black,
+                    overlayColor: Colors.black12,
+                    thumbColor: Colors.deepPurple,
+                    valueIndicatorColor: Colors.deepPurpleAccent,
+                    thumbShape: const _CustomThumbShape(),
+                    valueIndicatorShape: const _CustomValueIndicatorShape(),
+                    valueIndicatorTextStyle: theme.accentTextTheme.body2.copyWith(color: Colors.black87),
+                  ),
+                  child: new Slider(
+                    value: _discreteValue,
+                    min: 0.0,
+                    max: 100.0,
+                    divisions: 5,
+                    label: '${_discreteValue.round()}',
+                    onChanged: (double value) {
+                      setState(() {
+                        _discreteValue = value;
+                      });
+                    },
+                  ),
+                ),
+                const Text('Discrete with Custom Theme'),
               ],
             ),
           ],

--- a/examples/flutter_gallery/lib/demo/material/slider_demo.dart
+++ b/examples/flutter_gallery/lib/demo/material/slider_demo.dart
@@ -22,12 +22,11 @@ Path _triangle(double size, Offset thumbCenter, {bool invert: false}) {
   thumbPath.moveTo(thumbCenter.dx - halfSide, thumbCenter.dy + sign * centerHeight);
   thumbPath.lineTo(thumbCenter.dx, thumbCenter.dy - 2.0 * sign * centerHeight);
   thumbPath.lineTo(thumbCenter.dx + halfSide, thumbCenter.dy + sign * centerHeight);
-  thumbPath.lineTo(thumbCenter.dx - halfSide, thumbCenter.dy + sign * centerHeight);
+  thumbPath.close();
   return thumbPath;
 }
 
 class _CustomThumbShape extends SliderComponentShape {
-  const _CustomThumbShape();
   static const double _thumbSize = 4.0;
   static const double _disabledThumbSize = 4.0;
 
@@ -36,19 +35,14 @@ class _CustomThumbShape extends SliderComponentShape {
     return new Size.fromRadius(isEnabled ? _thumbSize : _disabledThumbSize);
   }
 
+  SliderThemeData sliderTheme;
+  Animation<double> enableAnimation;
+
   @override
   void paint(
-    RenderBox parentBox,
     PaintingContext context,
-    bool isDiscrete,
     Offset thumbCenter,
-    Animation<double> activationAnimation,
-    Animation<double> enableAnimation,
-    TextPainter labelPainter,
-    SliderThemeData sliderTheme,
-    TextDirection textDirection,
-    double value,
-  ) {
+    ) {
     final Canvas canvas = context.canvas;
     final Tween<double> radiusTween = new Tween<double>(
       begin: _disabledThumbSize,
@@ -65,7 +59,6 @@ class _CustomThumbShape extends SliderComponentShape {
 }
 
 class _CustomValueIndicatorShape extends SliderComponentShape {
-  const _CustomValueIndicatorShape();
   static const double _indicatorSize = 4.0;
   static const double _disabledIndicatorSize = 4.0;
   static const double _slideUpHeight = 40.0;
@@ -75,18 +68,15 @@ class _CustomValueIndicatorShape extends SliderComponentShape {
     return new Size.fromRadius(isEnabled ? _indicatorSize : _disabledIndicatorSize);
   }
 
+  SliderThemeData sliderTheme;
+  Animation<double> activationAnimation;
+  Animation<double> enableAnimation;
+  TextPainter labelPainter;
+
   @override
   void paint(
-    RenderBox parentBox,
     PaintingContext context,
-    bool isDiscrete,
     Offset thumbCenter,
-    Animation<double> activationAnimation,
-    Animation<double> enableAnimation,
-    TextPainter labelPainter,
-    SliderThemeData sliderTheme,
-    TextDirection textDirection,
-    double value,
   ) {
     final Canvas canvas = context.canvas;
     final Tween<double> radiusTween = new Tween<double>(
@@ -191,8 +181,8 @@ class _SliderDemoState extends State<SliderDemo> {
                     overlayColor: Colors.black12,
                     thumbColor: Colors.deepPurple,
                     valueIndicatorColor: Colors.deepPurpleAccent,
-                    thumbShape: const _CustomThumbShape(),
-                    valueIndicatorShape: const _CustomValueIndicatorShape(),
+                    thumbShape: new _CustomThumbShape(),
+                    valueIndicatorShape: new _CustomValueIndicatorShape(),
                     valueIndicatorTextStyle: theme.accentTextTheme.body2.copyWith(color: Colors.black87),
                   ),
                   child: new Slider(

--- a/examples/flutter_gallery/lib/demo/material/slider_demo.dart
+++ b/examples/flutter_gallery/lib/demo/material/slider_demo.dart
@@ -28,31 +28,37 @@ Path _triangle(double size, Offset thumbCenter, {bool invert: false}) {
 
 class _CustomThumbShape extends SliderComponentShape {
   static const double _thumbSize = 4.0;
-  static const double _disabledThumbSize = 4.0;
+  static const double _disabledThumbSize = 3.0;
 
   @override
   Size getPreferredSize(bool isEnabled, bool isDiscrete) {
-    return new Size.fromRadius(isEnabled ? _thumbSize : _disabledThumbSize);
+    return isEnabled ? const Size.fromRadius(_thumbSize) : const Size.fromRadius(_disabledThumbSize);
   }
 
-  SliderThemeData sliderTheme;
-  Animation<double> enableAnimation;
+  static final Tween<double> sizeTween = new Tween<double>(
+    begin: _disabledThumbSize,
+    end: _thumbSize,
+  );
 
   @override
   void paint(
     PaintingContext context,
-    Offset thumbCenter,
-    ) {
+    Offset thumbCenter, {
+    Animation<double> activationAnimation,
+    Animation<double> enableAnimation,
+    bool isDiscrete,
+    TextPainter labelPainter,
+    RenderBox parentBox,
+    SliderThemeData sliderTheme,
+    TextDirection textDirection,
+    double value,
+  }) {
     final Canvas canvas = context.canvas;
-    final Tween<double> radiusTween = new Tween<double>(
-      begin: _disabledThumbSize,
-      end: _thumbSize,
-    );
     final ColorTween colorTween = new ColorTween(
       begin: sliderTheme.disabledThumbColor,
       end: sliderTheme.thumbColor,
     );
-    final double size = _thumbSize * radiusTween.evaluate(enableAnimation);
+    final double size = _thumbSize * sizeTween.evaluate(enableAnimation);
     final Path thumbPath = _triangle(size, thumbCenter);
     canvas.drawPath(thumbPath, new Paint()..color = colorTween.evaluate(enableAnimation));
   }
@@ -60,7 +66,7 @@ class _CustomThumbShape extends SliderComponentShape {
 
 class _CustomValueIndicatorShape extends SliderComponentShape {
   static const double _indicatorSize = 4.0;
-  static const double _disabledIndicatorSize = 4.0;
+  static const double _disabledIndicatorSize = 3.0;
   static const double _slideUpHeight = 40.0;
 
   @override
@@ -68,21 +74,25 @@ class _CustomValueIndicatorShape extends SliderComponentShape {
     return new Size.fromRadius(isEnabled ? _indicatorSize : _disabledIndicatorSize);
   }
 
-  SliderThemeData sliderTheme;
-  Animation<double> activationAnimation;
-  Animation<double> enableAnimation;
-  TextPainter labelPainter;
+  static final Tween<double> sizeTween = new Tween<double>(
+    begin: _disabledIndicatorSize,
+    end: _indicatorSize,
+  );
 
   @override
   void paint(
     PaintingContext context,
-    Offset thumbCenter,
-  ) {
+    Offset thumbCenter, {
+    Animation<double> activationAnimation,
+    Animation<double> enableAnimation,
+    bool isDiscrete,
+    TextPainter labelPainter,
+    RenderBox parentBox,
+    SliderThemeData sliderTheme,
+    TextDirection textDirection,
+    double value,
+  }) {
     final Canvas canvas = context.canvas;
-    final Tween<double> radiusTween = new Tween<double>(
-      begin: _disabledIndicatorSize,
-      end: _indicatorSize,
-    );
     final ColorTween enableColor = new ColorTween(
       begin: sliderTheme.disabledThumbColor,
       end: sliderTheme.valueIndicatorColor,
@@ -91,7 +101,7 @@ class _CustomValueIndicatorShape extends SliderComponentShape {
       begin: 0.0,
       end: _slideUpHeight,
     );
-    final double size = _indicatorSize * radiusTween.evaluate(enableAnimation);
+    final double size = _indicatorSize * sizeTween.evaluate(enableAnimation);
     final Offset slideUpOffset = new Offset(0.0, -slideUpTween.evaluate(activationAnimation));
     final Path thumbPath = _triangle(
       size,

--- a/packages/flutter/lib/src/material/slider.dart
+++ b/packages/flutter/lib/src/material/slider.dart
@@ -775,28 +775,6 @@ class _RenderSlider extends RenderBox {
     }
   }
 
-  void _updateThumb() {
-    _sliderTheme.thumbShape.activationAnimation = _valueIndicatorAnimation;
-    _sliderTheme.thumbShape.enableAnimation = _enableAnimation;
-    _sliderTheme.thumbShape.isDiscrete = isDiscrete;
-    _sliderTheme.thumbShape.labelPainter = _labelPainter;
-    _sliderTheme.thumbShape.parentBox = this;
-    _sliderTheme.thumbShape.sliderTheme = _sliderTheme;
-    _sliderTheme.thumbShape.textDirection = _textDirection;
-    _sliderTheme.thumbShape.value = _value;
-  }
-
-  void _updateValueIndicator() {
-    _sliderTheme.valueIndicatorShape.activationAnimation = _valueIndicatorAnimation;
-    _sliderTheme.valueIndicatorShape.enableAnimation = _enableAnimation;
-    _sliderTheme.valueIndicatorShape.isDiscrete = isDiscrete;
-    _sliderTheme.valueIndicatorShape.labelPainter = _labelPainter;
-    _sliderTheme.valueIndicatorShape.parentBox = this;
-    _sliderTheme.valueIndicatorShape.sliderTheme = _sliderTheme;
-    _sliderTheme.valueIndicatorShape.textDirection = _textDirection;
-    _sliderTheme.valueIndicatorShape.value = _value;
-  }
-
   @override
   void paint(PaintingContext context, Offset offset) {
     final Canvas canvas = context.canvas;
@@ -873,18 +851,32 @@ class _RenderSlider extends RenderBox {
     if (isInteractive && label != null &&
         _valueIndicatorAnimation.status != AnimationStatus.dismissed) {
       if (showValueIndicator) {
-        _updateValueIndicator();
         _sliderTheme.valueIndicatorShape.paint(
           context,
           thumbCenter,
+          activationAnimation: _valueIndicatorAnimation,
+          enableAnimation: _enableAnimation,
+          isDiscrete: isDiscrete,
+          labelPainter: _labelPainter,
+          parentBox: this,
+          sliderTheme: _sliderTheme,
+          textDirection: _textDirection,
+          value: _value,
         );
       }
     }
 
-    _updateThumb();
     _sliderTheme.thumbShape.paint(
       context,
       thumbCenter,
+      activationAnimation: _valueIndicatorAnimation,
+      enableAnimation: _enableAnimation,
+      isDiscrete: isDiscrete,
+      labelPainter: _labelPainter,
+      parentBox: this,
+      sliderTheme: _sliderTheme,
+      textDirection: _textDirection,
+      value: _value,
     );
   }
 

--- a/packages/flutter/lib/src/material/slider.dart
+++ b/packages/flutter/lib/src/material/slider.dart
@@ -579,7 +579,7 @@ class _RenderSlider extends RenderBox {
     if (label != null) {
       _labelPainter
         ..text = new TextSpan(
-          style: _sliderTheme.valueIndicatorTextStyle ?? _theme.accentTextTheme.body2,
+          style: _sliderTheme.valueIndicatorTextStyle,
           text: label,
         )
         ..textDirection = textDirection
@@ -775,6 +775,28 @@ class _RenderSlider extends RenderBox {
     }
   }
 
+  void _updateThumb() {
+    _sliderTheme.thumbShape.activationAnimation = _valueIndicatorAnimation;
+    _sliderTheme.thumbShape.enableAnimation = _enableAnimation;
+    _sliderTheme.thumbShape.isDiscrete = isDiscrete;
+    _sliderTheme.thumbShape.labelPainter = _labelPainter;
+    _sliderTheme.thumbShape.parentBox = this;
+    _sliderTheme.thumbShape.sliderTheme = _sliderTheme;
+    _sliderTheme.thumbShape.textDirection = _textDirection;
+    _sliderTheme.thumbShape.value = _value;
+  }
+
+  void _updateValueIndicator() {
+    _sliderTheme.valueIndicatorShape.activationAnimation = _valueIndicatorAnimation;
+    _sliderTheme.valueIndicatorShape.enableAnimation = _enableAnimation;
+    _sliderTheme.valueIndicatorShape.isDiscrete = isDiscrete;
+    _sliderTheme.valueIndicatorShape.labelPainter = _labelPainter;
+    _sliderTheme.valueIndicatorShape.parentBox = this;
+    _sliderTheme.valueIndicatorShape.sliderTheme = _sliderTheme;
+    _sliderTheme.valueIndicatorShape.textDirection = _textDirection;
+    _sliderTheme.valueIndicatorShape.value = _value;
+  }
+
   @override
   void paint(PaintingContext context, Offset offset) {
     final Canvas canvas = context.canvas;
@@ -851,32 +873,18 @@ class _RenderSlider extends RenderBox {
     if (isInteractive && label != null &&
         _valueIndicatorAnimation.status != AnimationStatus.dismissed) {
       if (showValueIndicator) {
+        _updateValueIndicator();
         _sliderTheme.valueIndicatorShape.paint(
-          this,
           context,
-          isDiscrete,
           thumbCenter,
-          _valueIndicatorAnimation,
-          _enableAnimation,
-          _labelPainter,
-          _sliderTheme,
-          _textDirection,
-          value,
         );
       }
     }
 
+    _updateThumb();
     _sliderTheme.thumbShape.paint(
-      this,
       context,
-      isDiscrete,
       thumbCenter,
-      _overlayAnimation,
-      _enableAnimation,
-      label != null ? _labelPainter : null,
-      _sliderTheme,
-      _textDirection,
-      value,
     );
   }
 

--- a/packages/flutter/lib/src/material/slider.dart
+++ b/packages/flutter/lib/src/material/slider.dart
@@ -578,7 +578,10 @@ class _RenderSlider extends RenderBox {
   void _updateLabelPainter() {
     if (label != null) {
       _labelPainter
-        ..text = new TextSpan(style: _theme.accentTextTheme.body2, text: label)
+        ..text = new TextSpan(
+          style: _sliderTheme.valueIndicatorTextStyle ?? _theme.accentTextTheme.body2,
+          text: label,
+        )
         ..textDirection = textDirection
         ..textScaleFactor = _mediaQueryData.textScaleFactor
         ..layout();

--- a/packages/flutter/lib/src/material/slider_theme.dart
+++ b/packages/flutter/lib/src/material/slider_theme.dart
@@ -35,9 +35,9 @@ class SliderTheme extends InheritedWidget {
     Key key,
     @required this.data,
     @required Widget child,
-  }) : assert(child != null),
-       assert(data != null),
-       super(key: key, child: child);
+  })  : assert(child != null),
+        assert(data != null),
+        super(key: key, child: child);
 
   /// Specifies the color and shape values for descendant slider widgets.
   final SliderThemeData data;
@@ -194,22 +194,23 @@ class SliderThemeData extends Diagnosticable {
     @required this.thumbShape,
     @required this.valueIndicatorShape,
     @required this.showValueIndicator,
-    this.valueIndicatorTextStyle,
-  }) : assert(activeRailColor != null),
-       assert(inactiveRailColor != null),
-       assert(disabledActiveRailColor != null),
-       assert(disabledInactiveRailColor != null),
-       assert(activeTickMarkColor != null),
-       assert(inactiveTickMarkColor != null),
-       assert(disabledActiveTickMarkColor != null),
-       assert(disabledInactiveTickMarkColor != null),
-       assert(thumbColor != null),
-       assert(disabledThumbColor != null),
-       assert(overlayColor != null),
-       assert(valueIndicatorColor != null),
-       assert(thumbShape != null),
-       assert(valueIndicatorShape != null),
-       assert(showValueIndicator != null);
+    @required this.valueIndicatorTextStyle,
+  })  : assert(activeRailColor != null),
+        assert(inactiveRailColor != null),
+        assert(disabledActiveRailColor != null),
+        assert(disabledInactiveRailColor != null),
+        assert(activeTickMarkColor != null),
+        assert(inactiveTickMarkColor != null),
+        assert(disabledActiveTickMarkColor != null),
+        assert(disabledInactiveTickMarkColor != null),
+        assert(thumbColor != null),
+        assert(disabledThumbColor != null),
+        assert(overlayColor != null),
+        assert(valueIndicatorColor != null),
+        assert(thumbShape != null),
+        assert(valueIndicatorShape != null),
+        assert(valueIndicatorTextStyle != null),
+        assert(showValueIndicator != null);
 
   /// Generates a SliderThemeData from three main colors.
   ///
@@ -224,10 +225,12 @@ class SliderThemeData extends Diagnosticable {
     @required Color primaryColor,
     @required Color primaryColorDark,
     @required Color primaryColorLight,
+    @required TextStyle valueIndicatorTextStyle,
   }) {
     assert(primaryColor != null);
     assert(primaryColorDark != null);
     assert(primaryColorLight != null);
+    assert(valueIndicatorTextStyle != null);
 
     // These are Material Design defaults, and are used to derive
     // component Colors (with opacity) from base colors.
@@ -263,8 +266,9 @@ class SliderThemeData extends Diagnosticable {
       disabledThumbColor: primaryColorDark.withAlpha(disabledThumbAlpha),
       overlayColor: primaryColor.withAlpha(overlayLightAlpha),
       valueIndicatorColor: primaryColor.withAlpha(valueIndicatorAlpha),
-      thumbShape: const RoundSliderThumbShape(),
-      valueIndicatorShape: const PaddleSliderValueIndicatorShape(),
+      thumbShape: new RoundSliderThumbShape(),
+      valueIndicatorShape: new PaddleSliderValueIndicatorShape(),
+      valueIndicatorTextStyle: valueIndicatorTextStyle,
       showValueIndicator: ShowValueIndicator.onlyForDiscrete,
     );
   }
@@ -418,9 +422,7 @@ class SliderThemeData extends Diagnosticable {
       thumbShape: t < 0.5 ? a.thumbShape : b.thumbShape,
       valueIndicatorShape: t < 0.5 ? a.valueIndicatorShape : b.valueIndicatorShape,
       showValueIndicator: t < 0.5 ? a.showValueIndicator : b.showValueIndicator,
-      valueIndicatorTextStyle: (a.valueIndicatorTextStyle != null && b.valueIndicatorTextStyle != null)
-          ? TextStyle.lerp(a.valueIndicatorTextStyle, b.valueIndicatorTextStyle, t)
-          : t < 0.5 ? a.valueIndicatorTextStyle : b.valueIndicatorTextStyle,
+      valueIndicatorTextStyle: TextStyle.lerp(a.valueIndicatorTextStyle, b.valueIndicatorTextStyle, t),
     );
   }
 
@@ -481,6 +483,7 @@ class SliderThemeData extends Diagnosticable {
       primaryColor: defaultTheme.primaryColor,
       primaryColorDark: defaultTheme.primaryColorDark,
       primaryColorLight: defaultTheme.primaryColorLight,
+      valueIndicatorTextStyle: defaultTheme.accentTextTheme.body2,
     );
     description.add(new DiagnosticsProperty<Color>('activeRailColor', activeRailColor, defaultValue: defaultData.activeRailColor));
     description.add(new DiagnosticsProperty<Color>('inactiveRailColor', inactiveRailColor, defaultValue: defaultData.inactiveRailColor));
@@ -489,7 +492,8 @@ class SliderThemeData extends Diagnosticable {
     description.add(new DiagnosticsProperty<Color>('activeTickMarkColor', activeTickMarkColor, defaultValue: defaultData.activeTickMarkColor, level: DiagnosticLevel.debug));
     description.add(new DiagnosticsProperty<Color>('inactiveTickMarkColor', inactiveTickMarkColor, defaultValue: defaultData.inactiveTickMarkColor, level: DiagnosticLevel.debug));
     description.add(new DiagnosticsProperty<Color>('disabledActiveTickMarkColor', disabledActiveTickMarkColor, defaultValue: defaultData.disabledActiveTickMarkColor, level: DiagnosticLevel.debug));
-    description.add(new DiagnosticsProperty<Color>('disabledInactiveTickMarkColor', disabledInactiveTickMarkColor, defaultValue: defaultData.disabledInactiveTickMarkColor, level: DiagnosticLevel.debug));
+    description
+        .add(new DiagnosticsProperty<Color>('disabledInactiveTickMarkColor', disabledInactiveTickMarkColor, defaultValue: defaultData.disabledInactiveTickMarkColor, level: DiagnosticLevel.debug));
     description.add(new DiagnosticsProperty<Color>('thumbColor', thumbColor, defaultValue: defaultData.thumbColor));
     description.add(new DiagnosticsProperty<Color>('disabledThumbColor', disabledThumbColor, defaultValue: defaultData.disabledThumbColor, level: DiagnosticLevel.debug));
     description.add(new DiagnosticsProperty<Color>('overlayColor', overlayColor, defaultValue: defaultData.overlayColor, level: DiagnosticLevel.debug));
@@ -506,6 +510,9 @@ class SliderThemeData extends Diagnosticable {
 /// Create a subclass of this if you would like a custom slider thumb or
 /// value indicator shape.
 ///
+/// Override the setters that you need in order to implement your shape.
+/// By default, the setters ignore the values set on them.
+///
 /// See also:
 ///
 ///  * [RoundSliderThumbShape] for a simple example of a thumb shape.
@@ -519,28 +526,45 @@ abstract class SliderComponentShape {
   /// Returns the preferred size of the shape, based on the given conditions.
   Size getPreferredSize(bool isEnabled, bool isDiscrete);
 
+  /// The parent [RenderBox] for this shape.
+  set parentBox(RenderBox parentBox) {}
+
+  /// Whether this slider is a discrete slider or not.
+  set isDiscrete(bool isDiscrete) {}
+
+  /// The current animation for the activation of the value indicator. It
+  /// reverses when the user stops interacting with the slider.
+  set activationAnimation(Animation<double> activationAnimation) {}
+
+  /// An animation triggered when the [Slider] is enabled, and it reverses when
+  /// the slider is disabled.
+  set enableAnimation(Animation<double> enableAnimation) {}
+
+  /// The painter for the value indicator's label.
+  ///
+  /// If [labelPainter] is non-null, then [labelPainter.paint] should be
+  /// called with the location that the label should appear if you want to have
+  /// a label in your value indicator. If the labelPainter passed is null, then
+  /// no label was supplied to the [Slider].
+  set labelPainter(TextPainter labelPainter) {}
+
+  /// The current text direction.
+  set textDirection(TextDirection textDirection) {}
+
+  /// The slider theme that this shape is associated with at paint time.
+  set sliderTheme(SliderThemeData sliderTheme) {}
+
+  /// The current parametric value of the slider, from 0.0 to 1.0.
+  set value(double value) {}
+
   /// Paints the shape, taking into account the state passed to it.
   ///
-  /// [activationAnimation] is an animation triggered when the user beings
-  /// to interact with the slider. It reverses when the user stops interacting
-  /// with the slider.
-  /// [enableAnimation] is an animation triggered when the [Slider] is enabled,
-  /// and it reverses when the slider is disabled.
-  /// If [labelPainter] is non-null, then [labelPainter.paint] should be
-  /// called with the location that the label should appear. If the labelPainter
-  /// passed is null, then no label was supplied to the [Slider].
-  /// [value] is the current parametric value (from 0.0 to 1.0) of the slider.
+  /// context is the current painting context, containing the canvas to be drawn
+  /// on. The thumb center is the current location of the thumb in the local
+  /// coordinate system.
   void paint(
-    RenderBox parentBox,
     PaintingContext context,
-    bool isDiscrete,
     Offset thumbCenter,
-    Animation<double> activationAnimation,
-    Animation<double> enableAnimation,
-    TextPainter labelPainter,
-    SliderThemeData sliderTheme,
-    TextDirection textDirection,
-    double value,
   );
 }
 
@@ -553,9 +577,6 @@ abstract class SliderComponentShape {
 ///  * [SliderThemeData] where an instance of this class is set to inform the
 ///    slider of the shape of the its thumb.
 class RoundSliderThumbShape extends SliderComponentShape {
-  /// Create a slider thumb that draws a circle.
-  const RoundSliderThumbShape();
-
   static const double _thumbRadius = 6.0;
   static const double _disabledThumbRadius = 4.0;
 
@@ -564,32 +585,39 @@ class RoundSliderThumbShape extends SliderComponentShape {
     return new Size.fromRadius(isEnabled ? _thumbRadius : _disabledThumbRadius);
   }
 
+  Animation<double> enableAnimation;
+
+  SliderThemeData get sliderTheme => _sliderTheme;
+  SliderThemeData _sliderTheme;
   @override
-  void paint(
-    RenderBox parentBox,
-    PaintingContext context,
-    bool isDiscrete,
-    Offset thumbCenter,
-    Animation<double> activationAnimation,
-    Animation<double> enableAnimation,
-    TextPainter labelPainter,
-    SliderThemeData sliderTheme,
-    TextDirection textDirection,
-    double value,
-  ) {
-    final Canvas canvas = context.canvas;
-    final Tween<double> radiusTween = new Tween<double>(
-      begin: _disabledThumbRadius,
-      end: _thumbRadius,
-    );
-    final ColorTween colorTween = new ColorTween(
+  set sliderTheme(SliderThemeData sliderTheme) {
+    if (sliderTheme == _sliderTheme) {
+      return;
+    }
+    _sliderTheme = sliderTheme;
+    _enableColor = new ColorTween(
       begin: sliderTheme.disabledThumbColor,
       end: sliderTheme.thumbColor,
     );
+  }
+
+  final Tween<double> radiusTween = new Tween<double>(
+    begin: _disabledThumbRadius,
+    end: _thumbRadius,
+  );
+
+  ColorTween _enableColor;
+
+  @override
+  void paint(
+    PaintingContext context,
+    Offset thumbCenter,
+  ) {
+    final Canvas canvas = context.canvas;
     canvas.drawCircle(
       thumbCenter,
       radiusTween.evaluate(enableAnimation),
-      new Paint()..color = colorTween.evaluate(enableAnimation),
+      new Paint()..color = _enableColor.evaluate(enableAnimation),
     );
   }
 }
@@ -603,9 +631,6 @@ class RoundSliderThumbShape extends SliderComponentShape {
 ///  * [SliderThemeData] where an instance of this class is set to inform the
 ///    slider of the shape of the its value indicator.
 class PaddleSliderValueIndicatorShape extends SliderComponentShape {
-  /// Create a slider value indicator in the shape of an upside-down pear.
-  const PaddleSliderValueIndicatorShape();
-
   // These constants define the shape of the default value indicator.
   // The value indicator changes shape based on the size of
   // the label: The top lobe spreads horizontally, and the
@@ -638,8 +663,7 @@ class PaddleSliderValueIndicatorShape extends SliderComponentShape {
   static const double _twoSeventyDegrees = 3.0 * math.pi / 2.0;
   static const double _ninetyDegrees = math.pi / 2.0;
   static const double _thirtyDegrees = math.pi / 6.0;
-  static const Size _preferredSize =
-      const Size.fromHeight(_distanceBetweenTopBottomCenters + _topLobeRadius + _bottomLobeRadius);
+  static const Size _preferredSize = const Size.fromHeight(_distanceBetweenTopBottomCenters + _topLobeRadius + _bottomLobeRadius);
   // Set to true if you want a rectangle to be drawn around the label bubble.
   // This helps with building tests that check that the label draws in the right
   // place (because it prints the rect in the failed test output). It should not
@@ -651,6 +675,27 @@ class PaddleSliderValueIndicatorShape extends SliderComponentShape {
 
   @override
   Size getPreferredSize(bool isEnabled, bool isDiscrete) => _preferredSize;
+
+  RenderBox parentBox;
+  Animation<double> activationAnimation;
+  Animation<double> enableAnimation;
+  TextPainter labelPainter;
+
+  SliderThemeData get sliderTheme => _sliderTheme;
+  SliderThemeData _sliderTheme;
+  @override
+  set sliderTheme(SliderThemeData sliderTheme) {
+    if (sliderTheme == _sliderTheme) {
+      return;
+    }
+    _sliderTheme = sliderTheme;
+    _enableColor = new ColorTween(
+      begin: sliderTheme.disabledThumbColor,
+      end: sliderTheme.valueIndicatorColor,
+    );
+  }
+
+  ColorTween _enableColor;
 
   // Adds an arc to the path that has the attributes passed in. This is
   // a convenience to make adding arcs have less boilerplate.
@@ -781,9 +826,11 @@ class PaddleSliderValueIndicatorShape extends SliderComponentShape {
     double shift = _getIdealOffset(parentBox, halfWidthNeeded, overallScale, center);
     double leftWidthNeeded;
     double rightWidthNeeded;
-    if (shift < 0.0) {  // shifting to the left
+    if (shift < 0.0) {
+      // shifting to the left
       shift = math.max(shift, -halfWidthNeeded);
-    } else {  // shifting to the right
+    } else {
+      // shifting to the right
       shift = math.min(shift, halfWidthNeeded);
     }
     rightWidthNeeded = halfWidthNeeded + shift;
@@ -822,21 +869,23 @@ class PaddleSliderValueIndicatorShape extends SliderComponentShape {
     final double stretch = (neckStretchBaseline * t).clamp(0.0, 10.0 * neckStretchBaseline);
     final Offset neckStretch = new Offset(0.0, neckStretchBaseline - stretch);
 
-    assert(!_debuggingLabelLocation || () {
-      final Offset leftCenter = _topLobeCenter - new Offset(leftWidthNeeded, 0.0) + neckStretch;
-      final Offset rightCenter = _topLobeCenter + new Offset(rightWidthNeeded, 0.0) + neckStretch;
-      final Rect valueRect = new Rect.fromLTRB(
-        leftCenter.dx - _topLobeRadius,
-        leftCenter.dy - _topLobeRadius,
-        rightCenter.dx + _topLobeRadius,
-        rightCenter.dy + _topLobeRadius,
-      );
-      final Paint outlinePaint = new Paint()
-        ..color = const Color(0xffff0000)
-        ..style = PaintingStyle.stroke..strokeWidth = 1.0;
-      canvas.drawRect(valueRect, outlinePaint);
-      return true;
-    }());
+    assert(!_debuggingLabelLocation ||
+        () {
+          final Offset leftCenter = _topLobeCenter - new Offset(leftWidthNeeded, 0.0) + neckStretch;
+          final Offset rightCenter = _topLobeCenter + new Offset(rightWidthNeeded, 0.0) + neckStretch;
+          final Rect valueRect = new Rect.fromLTRB(
+            leftCenter.dx - _topLobeRadius,
+            leftCenter.dy - _topLobeRadius,
+            rightCenter.dx + _topLobeRadius,
+            rightCenter.dy + _topLobeRadius,
+          );
+          final Paint outlinePaint = new Paint()
+            ..color = const Color(0xffff0000)
+            ..style = PaintingStyle.stroke
+            ..strokeWidth = 1.0;
+          canvas.drawRect(valueRect, outlinePaint);
+          return true;
+        }());
 
     _addArc(
       path,
@@ -879,27 +928,15 @@ class PaddleSliderValueIndicatorShape extends SliderComponentShape {
 
   @override
   void paint(
-    RenderBox parentBox,
     PaintingContext context,
-    bool isDiscrete,
     Offset thumbCenter,
-    Animation<double> activationAnimation,
-    Animation<double> enableAnimation,
-    TextPainter labelPainter,
-    SliderThemeData sliderTheme,
-    TextDirection textDirection,
-    double value,
   ) {
     assert(labelPainter != null);
-    final ColorTween enableColor = new ColorTween(
-      begin: sliderTheme.disabledThumbColor,
-      end: sliderTheme.valueIndicatorColor,
-    );
     _drawValueIndicator(
       parentBox,
       context.canvas,
       thumbCenter,
-      new Paint()..color = enableColor.evaluate(enableAnimation),
+      new Paint()..color = _enableColor.evaluate(enableAnimation),
       activationAnimation.value,
       labelPainter,
     );

--- a/packages/flutter/lib/src/material/slider_theme.dart
+++ b/packages/flutter/lib/src/material/slider_theme.dart
@@ -194,6 +194,7 @@ class SliderThemeData extends Diagnosticable {
     @required this.thumbShape,
     @required this.valueIndicatorShape,
     @required this.showValueIndicator,
+    this.valueIndicatorTextStyle,
   }) : assert(activeRailColor != null),
        assert(inactiveRailColor != null),
        assert(disabledActiveRailColor != null),
@@ -337,6 +338,11 @@ class SliderThemeData extends Diagnosticable {
   /// when the thumb is being touched.
   final ShowValueIndicator showValueIndicator;
 
+  /// The text style for the text on the value indicator.
+  ///
+  /// By default this is the [ThemeData.accentTextTheme.body2] text theme.
+  final TextStyle valueIndicatorTextStyle;
+
   /// Creates a copy of this object but with the given fields replaced with the
   /// new values.
   SliderThemeData copyWith({
@@ -355,6 +361,7 @@ class SliderThemeData extends Diagnosticable {
     SliderComponentShape thumbShape,
     SliderComponentShape valueIndicatorShape,
     ShowValueIndicator showValueIndicator,
+    TextStyle valueIndicatorTextStyle,
   }) {
     return new SliderThemeData(
       activeRailColor: activeRailColor ?? this.activeRailColor,
@@ -372,6 +379,7 @@ class SliderThemeData extends Diagnosticable {
       thumbShape: thumbShape ?? this.thumbShape,
       valueIndicatorShape: valueIndicatorShape ?? this.valueIndicatorShape,
       showValueIndicator: showValueIndicator ?? this.showValueIndicator,
+      valueIndicatorTextStyle: valueIndicatorTextStyle ?? this.valueIndicatorTextStyle,
     );
   }
 
@@ -410,6 +418,9 @@ class SliderThemeData extends Diagnosticable {
       thumbShape: t < 0.5 ? a.thumbShape : b.thumbShape,
       valueIndicatorShape: t < 0.5 ? a.valueIndicatorShape : b.valueIndicatorShape,
       showValueIndicator: t < 0.5 ? a.showValueIndicator : b.showValueIndicator,
+      valueIndicatorTextStyle: (a.valueIndicatorTextStyle != null && b.valueIndicatorTextStyle != null)
+          ? TextStyle.lerp(a.valueIndicatorTextStyle, b.valueIndicatorTextStyle, t)
+          : t < 0.5 ? a.valueIndicatorTextStyle : b.valueIndicatorTextStyle,
     );
   }
 
@@ -431,6 +442,7 @@ class SliderThemeData extends Diagnosticable {
       thumbShape,
       valueIndicatorShape,
       showValueIndicator,
+      valueIndicatorTextStyle,
     );
   }
 
@@ -457,7 +469,8 @@ class SliderThemeData extends Diagnosticable {
         otherData.valueIndicatorColor == valueIndicatorColor &&
         otherData.thumbShape == thumbShape &&
         otherData.valueIndicatorShape == valueIndicatorShape &&
-        otherData.showValueIndicator == showValueIndicator;
+        otherData.showValueIndicator == showValueIndicator &&
+        otherData.valueIndicatorTextStyle == valueIndicatorTextStyle;
   }
 
   @override
@@ -484,6 +497,7 @@ class SliderThemeData extends Diagnosticable {
     description.add(new DiagnosticsProperty<SliderComponentShape>('thumbShape', thumbShape, defaultValue: defaultData.thumbShape, level: DiagnosticLevel.debug));
     description.add(new DiagnosticsProperty<SliderComponentShape>('valueIndicatorShape', valueIndicatorShape, defaultValue: defaultData.valueIndicatorShape, level: DiagnosticLevel.debug));
     description.add(new EnumProperty<ShowValueIndicator>('showValueIndicator', showValueIndicator, defaultValue: defaultData.showValueIndicator));
+    description.add(new DiagnosticsProperty<TextStyle>('valueIndicatorTextStyle', valueIndicatorTextStyle, defaultValue: defaultData.valueIndicatorTextStyle));
   }
 }
 

--- a/packages/flutter/lib/src/material/theme_data.dart
+++ b/packages/flutter/lib/src/material/theme_data.dart
@@ -166,6 +166,7 @@ class ThemeData extends Diagnosticable {
       primaryColor: primaryColor,
       primaryColorLight: primaryColorLight,
       primaryColorDark: primaryColorDark,
+      valueIndicatorTextStyle: accentTextTheme.body2,
     );
     return new ThemeData.raw(
       brightness: brightness,

--- a/packages/flutter/test/material/slider_test.dart
+++ b/packages/flutter/test/material/slider_test.dart
@@ -26,8 +26,16 @@ class LoggingThumbShape extends SliderComponentShape {
   @override
   void paint(
     PaintingContext context,
-    Offset thumbCenter,
-    ) {
+    Offset thumbCenter, {
+    Animation<double> activationAnimation,
+    Animation<double> enableAnimation,
+    bool isDiscrete,
+    TextPainter labelPainter,
+    RenderBox parentBox,
+    SliderThemeData sliderTheme,
+    TextDirection textDirection,
+    double value,
+  }) {
     log.add(thumbCenter);
     final Paint thumbPaint = new Paint()..color = Colors.red;
     context.canvas.drawCircle(thumbCenter, 5.0, thumbPaint);

--- a/packages/flutter/test/material/slider_test.dart
+++ b/packages/flutter/test/material/slider_test.dart
@@ -25,17 +25,9 @@ class LoggingThumbShape extends SliderComponentShape {
 
   @override
   void paint(
-    RenderBox parentBox,
     PaintingContext context,
-    bool isDiscrete,
     Offset thumbCenter,
-    Animation<double> activationAnimation,
-    Animation<double> enableAnimation,
-    TextPainter labelPainter,
-    SliderThemeData sliderTheme,
-    TextDirection textDirection,
-    double value,
-  ) {
+    ) {
     log.add(thumbCenter);
     final Paint thumbPaint = new Paint()..color = Colors.red;
     context.canvas.drawCircle(thumbCenter, 5.0, thumbPaint);

--- a/packages/flutter/test/material/slider_theme_test.dart
+++ b/packages/flutter/test/material/slider_theme_test.dart
@@ -104,11 +104,13 @@ void main() {
     const Color customColor1 = const Color(0xcafefeed);
     const Color customColor2 = const Color(0xdeadbeef);
     const Color customColor3 = const Color(0xdecaface);
+    const Color customColor4 = const Color(0xfeedcafe);
 
     final SliderThemeData sliderTheme = new SliderThemeData.fromPrimaryColors(
       primaryColor: customColor1,
       primaryColorDark: customColor2,
       primaryColorLight: customColor3,
+      valueIndicatorTextStyle: new ThemeData.fallback().accentTextTheme.body2.copyWith(color: customColor4),
     );
 
     expect(sliderTheme.activeRailColor, equals(customColor1.withAlpha(0xff)));
@@ -126,6 +128,7 @@ void main() {
     expect(sliderTheme.thumbShape, equals(const isInstanceOf<RoundSliderThumbShape>()));
     expect(sliderTheme.valueIndicatorShape, equals(const isInstanceOf<PaddleSliderValueIndicatorShape>()));
     expect(sliderTheme.showValueIndicator, equals(ShowValueIndicator.onlyForDiscrete));
+    expect(sliderTheme.valueIndicatorTextStyle.color, equals(customColor4));
   });
 
   testWidgets('SliderThemeData lerps correctly', (WidgetTester tester) async {
@@ -133,11 +136,13 @@ void main() {
       primaryColor: Colors.black,
       primaryColorDark: Colors.black,
       primaryColorLight: Colors.black,
+      valueIndicatorTextStyle: new ThemeData.fallback().accentTextTheme.body2.copyWith(color: Colors.black),
     );
     final SliderThemeData sliderThemeWhite = new SliderThemeData.fromPrimaryColors(
       primaryColor: Colors.white,
       primaryColorDark: Colors.white,
       primaryColorLight: Colors.white,
+      valueIndicatorTextStyle: new ThemeData.fallback().accentTextTheme.body2.copyWith(color: Colors.white),
     );
     final SliderThemeData lerp = SliderThemeData.lerp(sliderThemeBlack, sliderThemeWhite, 0.5);
     const Color middleGrey = const Color(0xff7f7f7f);
@@ -153,6 +158,7 @@ void main() {
     expect(lerp.disabledThumbColor, equals(middleGrey.withAlpha(0x52)));
     expect(lerp.overlayColor, equals(middleGrey.withAlpha(0x29)));
     expect(lerp.valueIndicatorColor, equals(middleGrey.withAlpha(0xff)));
+    expect(lerp.valueIndicatorTextStyle.color, equals(middleGrey.withAlpha(0xff)));
   });
 
   testWidgets('Default slider thumb shape draws correctly', (WidgetTester tester) async {


### PR DESCRIPTION
This adds a slider demo with a custom theme to the gallery.

In the process of adding this, I decided to add a text theme to the SliderThemeData, since it's a pain to change the text style on the value indicator otherwise.

![screenshot_20180316-120543](https://user-images.githubusercontent.com/8867023/37540320-b9c99746-2913-11e8-9add-275ca4e20fbb.png)