### PR TITLE
Re-enable usage of TransformLayers with text in RenderListWheelViewport

### DIFF
--- a/packages/flutter/lib/src/rendering/list_wheel_viewport.dart
+++ b/packages/flutter/lib/src/rendering/list_wheel_viewport.dart
@@ -562,9 +562,7 @@ class RenderListWheelViewport
     );
 
     context.pushTransform(
-      // Text with TransformLayers and no cullRects currently have an issue rendering
-      // https://github.com/flutter/flutter/issues/14224.
-      false,
+      needsCompositing,
       offset,
       _centerOriginTransform(transform),
       // Pre-transform painting function.

--- a/packages/flutter/test/widgets/list_wheel_scroll_view_test.dart
+++ b/packages/flutter/test/widgets/list_wheel_scroll_view_test.dart
@@ -405,7 +405,7 @@ void main() {
       );
 
       expect(
-        List.from<TransformLayer>(
+        new List<TransformLayer>.from(
           tester.layers.where((Layer layer) => layer is TransformLayer)
         )
           .map((TransformLayer layer) => layer.transform.storage)

--- a/packages/flutter/test/widgets/list_wheel_scroll_view_test.dart
+++ b/packages/flutter/test/widgets/list_wheel_scroll_view_test.dart
@@ -385,6 +385,39 @@ void main() {
         ]),
       ));
     });
+
+    testWidgets('Painting creates layers', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        new Directionality(
+          textDirection: TextDirection.ltr,
+          child: new ListWheelScrollView(
+            itemExtent: 100.0,
+            children: <Widget>[
+              new Container(
+                width: 200.0,
+                child: const Center(
+                  child: const Text('blah'),
+                ),
+              ),
+            ],
+          ),
+        ),
+      );
+
+      expect(
+        List.from<TransformLayer>(
+          tester.layers.where((Layer layer) => layer is TransformLayer)
+        )
+          .map((TransformLayer layer) => layer.transform.storage)
+          .toList(),
+        contains(equals(<dynamic>[
+          1.0, 0.0, 0.0, 0.0,
+          0.0, 1.0, 0.0, 0.0,
+          -1.2, -0.9, 1.0, -0.003,
+          moreOrLessEquals(0.0), moreOrLessEquals(0.0), 0.0, moreOrLessEquals(1.0),
+        ])),
+      );
+    });
   });
 
   group('scroll notifications', () {


### PR DESCRIPTION
Issue #14224 is no longer reproducible on head. Removing workaround. 