### PR TITLE
Fail ios workflow when simctl does not work

### DIFF
--- a/packages/flutter_tools/lib/src/ios/ios_workflow.dart
+++ b/packages/flutter_tools/lib/src/ios/ios_workflow.dart
@@ -90,8 +90,8 @@ class IOSWorkflow extends DoctorValidator implements Workflow {
       if (!xcode.isSimctlInstalled) {
         xcodeStatus = ValidationType.partial;
         messages.add(new ValidationMessage.error(
-          'Xcode requires additional components to be installed in order to run.  Launch Xcode and install '
-          'additional required components when prompted.'
+          'Xcode requires additional components to be installed in order to run.\n'
+          'Launch Xcode and install additional required components when prompted.'
         ));
       }
       if ((await macDevMode).contains('disabled')) {

--- a/packages/flutter_tools/lib/src/ios/ios_workflow.dart
+++ b/packages/flutter_tools/lib/src/ios/ios_workflow.dart
@@ -23,7 +23,7 @@ class IOSWorkflow extends DoctorValidator implements Workflow {
 
   // We need xcode (+simctl) to list simulator devices, and libimobiledevice to list real devices.
   @override
-  bool get canListDevices => xcode.isInstalledAndMeetsVersionCheck;
+  bool get canListDevices => xcode.isInstalledAndMeetsVersionCheck && xcode.isSimctlInstalled;
 
   // We need xcode to launch simulator devices, and ideviceinstaller and ios-deploy
   // for real devices.
@@ -85,6 +85,13 @@ class IOSWorkflow extends DoctorValidator implements Workflow {
         xcodeStatus = ValidationType.partial;
         messages.add(new ValidationMessage.error(
           'Xcode end user license agreement not signed; open Xcode or run the command \'sudo xcodebuild -license\'.'
+        ));
+      }
+      if (!xcode.isSimctlInstalled) {
+        xcodeStatus = ValidationType.partial;
+        messages.add(new ValidationMessage.error(
+          'Xcode requires additional components to be installed in order to run.  Launch Xcode and install '
+          'additional required components when prompted.'
         ));
       }
       if ((await macDevMode).contains('disabled')) {

--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -158,11 +158,7 @@ class Xcode {
         // This command will error if additional components need to be installed in
         // xcode 9.2 and above.
         final ProcessResult result = processManager.runSync(<String>['/usr/bin/xcrun', 'simctl', 'list']);
-        if (result.stderr != null) {
-          _isSimctlInstalled = false;
-        } else {
-          _isSimctlInstalled = true;
-        }
+        _isSimctlInstalled = result.stderr == null;
       } on ProcessException {
         _isSimctlInstalled = false;
       }

--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -149,6 +149,27 @@ class Xcode {
     return _eulaSigned;
   }
 
+  bool _areAdditionalComponentsInstalled;
+
+  /// Verifies that simctl is installed by trying to run it.
+  bool get areAdditionalComponentsInstalled {
+    if (_areAdditionalComponentsInstalled == null) {
+      try {
+        // This command will error if additional components need to be installed in
+        // xcode 9.2 and above.
+        final ProcessResult result = processManager.runSync(<String>['/usr/bin/xcrun', 'simctl', 'list']);
+        if (result.stderr != null) {
+          _areAdditionalComponentsInstalled = false;
+        } else {
+          _areAdditionalComponentsInstalled = true;
+        }
+      } on ProcessException {
+        _areAdditionalComponentsInstalled = false;
+      }
+    }
+    return _areAdditionalComponentsInstalled;
+  }
+
   bool get isVersionSatisfactory {
     if (!xcodeProjectInterpreter.isInstalled)
       return false;

--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -149,25 +149,25 @@ class Xcode {
     return _eulaSigned;
   }
 
-  bool _areAdditionalComponentsInstalled;
+  bool _isSimctlInstalled;
 
   /// Verifies that simctl is installed by trying to run it.
-  bool get areAdditionalComponentsInstalled {
-    if (_areAdditionalComponentsInstalled == null) {
+  bool get isSimctlInstalled {
+    if (_isSimctlInstalled == null) {
       try {
         // This command will error if additional components need to be installed in
         // xcode 9.2 and above.
         final ProcessResult result = processManager.runSync(<String>['/usr/bin/xcrun', 'simctl', 'list']);
         if (result.stderr != null) {
-          _areAdditionalComponentsInstalled = false;
+          _isSimctlInstalled = false;
         } else {
-          _areAdditionalComponentsInstalled = true;
+          _isSimctlInstalled = true;
         }
       } on ProcessException {
-        _areAdditionalComponentsInstalled = false;
+        _isSimctlInstalled = false;
       }
     }
-    return _areAdditionalComponentsInstalled;
+    return _isSimctlInstalled;
   }
 
   bool get isVersionSatisfactory {

--- a/packages/flutter_tools/test/ios/ios_workflow_test.dart
+++ b/packages/flutter_tools/test/ios/ios_workflow_test.dart
@@ -83,6 +83,7 @@ void main() {
           .thenReturn('Xcode 7.0.1\nBuild version 7C1002\n');
       when(xcode.isInstalledAndMeetsVersionCheck).thenReturn(false);
       when(xcode.eulaSigned).thenReturn(true);
+      when(xcode.isSimctlInstalled).thenReturn(true);
       final IOSWorkflowTestTarget workflow = new IOSWorkflowTestTarget();
       final ValidationResult result = await workflow.validate();
       expect(result.type, ValidationType.partial);
@@ -98,6 +99,7 @@ void main() {
           .thenReturn('Xcode 8.2.1\nBuild version 8C1002\n');
       when(xcode.isInstalledAndMeetsVersionCheck).thenReturn(true);
       when(xcode.eulaSigned).thenReturn(false);
+      when(xcode.isSimctlInstalled).thenReturn(true);
       final IOSWorkflowTestTarget workflow = new IOSWorkflowTestTarget();
       final ValidationResult result = await workflow.validate();
       expect(result.type, ValidationType.partial);
@@ -113,6 +115,7 @@ void main() {
           .thenReturn('Xcode 8.2.1\nBuild version 8C1002\n');
       when(xcode.isInstalledAndMeetsVersionCheck).thenReturn(true);
       when(xcode.eulaSigned).thenReturn(true);
+      when(xcode.isSimctlInstalled).thenReturn(true);
       final IOSWorkflowTestTarget workflow = new IOSWorkflowTestTarget(macDevMode: 'Developer mode is currently disabled.');
       final ValidationResult result = await workflow.validate();
       expect(result.type, ValidationType.partial);
@@ -128,6 +131,7 @@ void main() {
           .thenReturn('Xcode 8.2.1\nBuild version 8C1002\n');
       when(xcode.isInstalledAndMeetsVersionCheck).thenReturn(true);
       when(xcode.eulaSigned).thenReturn(true);
+      when(xcode.isSimctlInstalled).thenReturn(true);
       final IOSWorkflowTestTarget workflow = new IOSWorkflowTestTarget(hasPythonSixModule: false);
       final ValidationResult result = await workflow.validate();
       expect(result.type, ValidationType.partial);
@@ -143,6 +147,7 @@ void main() {
           .thenReturn('Xcode 8.2.1\nBuild version 8C1002\n');
       when(xcode.isInstalledAndMeetsVersionCheck).thenReturn(true);
       when(xcode.eulaSigned).thenReturn(true);
+      when(xcode.isSimctlInstalled).thenReturn(true);
       final IOSWorkflowTestTarget workflow = new IOSWorkflowTestTarget(hasHomebrew: false);
       final ValidationResult result = await workflow.validate();
       expect(result.type, ValidationType.partial);
@@ -158,6 +163,7 @@ void main() {
           .thenReturn('Xcode 8.2.1\nBuild version 8C1002\n');
       when(xcode.isInstalledAndMeetsVersionCheck).thenReturn(true);
       when(xcode.eulaSigned).thenReturn(true);
+      when(xcode.isSimctlInstalled).thenReturn(true);
       final IOSWorkflowTestTarget workflow = new IOSWorkflowTestTarget();
       final ValidationResult result = await workflow.validate();
       expect(result.type, ValidationType.partial);
@@ -173,6 +179,7 @@ void main() {
           .thenReturn('Xcode 8.2.1\nBuild version 8C1002\n');
       when(xcode.isInstalledAndMeetsVersionCheck).thenReturn(true);
       when(xcode.eulaSigned).thenReturn(true);
+      when(xcode.isSimctlInstalled).thenReturn(true);
       final IOSWorkflowTestTarget workflow = new IOSWorkflowTestTarget();
       final ValidationResult result = await workflow.validate();
       expect(result.type, ValidationType.partial);
@@ -187,6 +194,7 @@ void main() {
       when(xcode.versionText)
           .thenReturn('Xcode 8.2.1\nBuild version 8C1002\n');
       when(xcode.isInstalledAndMeetsVersionCheck).thenReturn(true);
+      when(xcode.isSimctlInstalled).thenReturn(true);
       when(xcode.eulaSigned).thenReturn(true);
       final IOSWorkflowTestTarget workflow = new IOSWorkflowTestTarget(hasIosDeploy: false);
       final ValidationResult result = await workflow.validate();
@@ -203,6 +211,7 @@ void main() {
           .thenReturn('Xcode 8.2.1\nBuild version 8C1002\n');
       when(xcode.isInstalledAndMeetsVersionCheck).thenReturn(true);
       when(xcode.eulaSigned).thenReturn(true);
+      when(xcode.isSimctlInstalled).thenReturn(true);
       final IOSWorkflowTestTarget workflow = new IOSWorkflowTestTarget(iosDeployVersionText: '1.8.0');
       final ValidationResult result = await workflow.validate();
       expect(result.type, ValidationType.partial);
@@ -220,6 +229,7 @@ void main() {
       when(xcode.eulaSigned).thenReturn(true);
       when(cocoaPods.isCocoaPodsInstalledAndMeetsVersionCheck).thenReturn(false);
       when(cocoaPods.hasCocoaPods).thenReturn(false);
+      when(xcode.isSimctlInstalled).thenReturn(true);
       final IOSWorkflowTestTarget workflow = new IOSWorkflowTestTarget();
       final ValidationResult result = await workflow.validate();
       expect(result.type, ValidationType.partial);
@@ -238,6 +248,7 @@ void main() {
       when(cocoaPods.isCocoaPodsInstalledAndMeetsVersionCheck).thenReturn(false);
       when(cocoaPods.hasCocoaPods).thenReturn(true);
       when(cocoaPods.cocoaPodsVersionText).thenReturn('0.39.0');
+      when(xcode.isSimctlInstalled).thenReturn(true);
       final IOSWorkflowTestTarget workflow = new IOSWorkflowTestTarget();
       final ValidationResult result = await workflow.validate();
       expect(result.type, ValidationType.partial);
@@ -256,6 +267,7 @@ void main() {
       when(cocoaPods.isCocoaPodsInstalledAndMeetsVersionCheck).thenReturn(false);
       when(cocoaPods.hasCocoaPods).thenReturn(true);
       when(cocoaPods.isCocoaPodsInitialized).thenReturn(false);
+      when(xcode.isSimctlInstalled).thenReturn(true);
 
       final ValidationResult result = await new IOSWorkflowTestTarget().validate();
       expect(result.type, ValidationType.partial);
@@ -267,12 +279,30 @@ void main() {
       ProcessManager: () => processManager,
     });
 
+    testUsingContext('Emits partial status when simctl is not installed', () async {
+      when(xcode.isInstalled).thenReturn(true);
+      when(xcode.versionText)
+          .thenReturn('Xcode 8.2.1\nBuild version 8C1002\n');
+      when(xcode.isInstalledAndMeetsVersionCheck).thenReturn(true);
+      when(xcode.eulaSigned).thenReturn(true);
+      when(xcode.isSimctlInstalled).thenReturn(false);
+      final IOSWorkflowTestTarget workflow = new IOSWorkflowTestTarget();
+      final ValidationResult result = await workflow.validate();
+      expect(result.type, ValidationType.partial);
+    }, overrides: <Type, Generator>{
+      IMobileDevice: () => iMobileDevice,
+      Xcode: () => xcode,
+      CocoaPods: () => cocoaPods,
+    });
+
+
     testUsingContext('Succeeds when all checks pass', () async {
       when(xcode.isInstalled).thenReturn(true);
       when(xcode.versionText)
           .thenReturn('Xcode 8.2.1\nBuild version 8C1002\n');
       when(xcode.isInstalledAndMeetsVersionCheck).thenReturn(true);
       when(xcode.eulaSigned).thenReturn(true);
+      when(xcode.isSimctlInstalled).thenReturn(true);
 
       ensureDirectoryExists(fs.path.join(homeDirPath, '.cocoapods', 'repos', 'master', 'README.md'));
 


### PR DESCRIPTION
Fixes #13063 by
  * Partial failure of IOS workflow if `xcrun simctl list` does not exit successfully.  This prints a message that the user must open xcode and install required components.
  * Don't display connected devices if `simctl` is not enabled

