### PR TITLE
Run test coverage in dart1 mode.

### DIFF
--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -218,7 +218,7 @@ Future<Null> _runCoverage() async {
   }
   coverageFile.deleteSync();
   await _runFlutterTest(path.join(flutterRoot, 'packages', 'flutter'),
-    options: const <String>['--coverage'],
+    options: const <String>['--coverage', '--no-preview-dart-2'],
   );
   if (!coverageFile.existsSync()) {
     print('${red}Coverage file not found.$reset');


### PR DESCRIPTION
Running test coverage in dart2 mode runs over allocated timeslot on bots.