### PR TITLE
AppBar shows CloseButton even on custom PageRoute

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -20,3 +20,4 @@ Stefano Rodriguez <hlsroddy@gmail.com>
 Yusuke Konishi <yahpeycoy0403@gmail.com>
 Fredrik Simón <fredrik@fsimon.net>
 Ali Bitek <alibitek@protonmail.ch>
+Tetsuhiro Ueda <najeira@gmail.com>

--- a/packages/flutter/lib/src/material/app_bar.dart
+++ b/packages/flutter/lib/src/material/app_bar.dart
@@ -16,7 +16,6 @@ import 'icon_button.dart';
 import 'icons.dart';
 import 'material.dart';
 import 'material_localizations.dart';
-import 'page.dart';
 import 'scaffold.dart';
 import 'tabs.dart';
 import 'theme.dart';

--- a/packages/flutter/lib/src/material/app_bar.dart
+++ b/packages/flutter/lib/src/material/app_bar.dart
@@ -339,7 +339,7 @@ class _AppBarState extends State<AppBar> {
     final bool hasDrawer = scaffold?.hasDrawer ?? false;
     final bool hasEndDrawer = scaffold?.hasEndDrawer ?? false;
     final bool canPop = parentRoute?.canPop ?? false;
-    final bool useCloseButton = parentRoute is MaterialPageRoute<dynamic> && parentRoute.fullscreenDialog;
+    final bool useCloseButton = parentRoute is PageRoute<dynamic> && parentRoute.fullscreenDialog;
 
     IconThemeData appBarIconTheme = widget.iconTheme ?? themeData.primaryIconTheme;
     TextStyle centerStyle = widget.textTheme?.title ?? themeData.primaryTextTheme.title;


### PR DESCRIPTION
Fixes an issue that `leading` of `AppBar` is not `CloseButton` when custom `PageRoute` with `fullscreenDialog: true`.