### PR TITLE
Provide an initial rotation of the ExpansionIcon if isExpanded = true on initState

### DIFF
--- a/packages/flutter/lib/src/material/expand_icon.dart
+++ b/packages/flutter/lib/src/material/expand_icon.dart
@@ -1,6 +1,7 @@
 // Copyright 2015 The Chromium Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+import 'dart:math';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
@@ -72,6 +73,10 @@ class _ExpandIconState extends State<ExpandIcon> with SingleTickerProviderStateM
         curve: Curves.fastOutSlowIn
       )
     );
+    // If the widget is initially expanded, rotate the icon without animating it.
+    if (widget.isExpanded) {
+      _controller.value = pi;
+    }
   }
 
   @override

--- a/packages/flutter/lib/src/material/expand_icon.dart
+++ b/packages/flutter/lib/src/material/expand_icon.dart
@@ -1,7 +1,7 @@
 // Copyright 2015 The Chromium Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
-import 'dart:math';
+import 'dart:math' as math;
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
@@ -75,7 +75,7 @@ class _ExpandIconState extends State<ExpandIcon> with SingleTickerProviderStateM
     );
     // If the widget is initially expanded, rotate the icon without animating it.
     if (widget.isExpanded) {
-      _controller.value = pi;
+      _controller.value = math.pi;
     }
   }
 

--- a/packages/flutter/test/material/expand_icon_test.dart
+++ b/packages/flutter/test/material/expand_icon_test.dart
@@ -1,6 +1,7 @@
 // Copyright 2016 The Chromium Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 

--- a/packages/flutter/test/material/expand_icon_test.dart
+++ b/packages/flutter/test/material/expand_icon_test.dart
@@ -1,8 +1,6 @@
 // Copyright 2016 The Chromium Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
-import 'dart:math';
-
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 

--- a/packages/flutter/test/material/expand_icon_test.dart
+++ b/packages/flutter/test/material/expand_icon_test.dart
@@ -1,6 +1,7 @@
 // Copyright 2016 The Chromium Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+import 'dart:math';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -66,6 +67,23 @@ void main() {
     );
 
     expect(expanded, isFalse);
+  });
+
+  testWidgets('ExpandIcon is rotated initially if isExpanded is true on first build', (WidgetTester tester) async {
+    bool expanded = true;
+
+    await tester.pumpWidget(
+        wrap(
+            child: new ExpandIcon(
+              isExpanded: expanded,
+              onPressed: (bool isExpanded) {
+                expanded = !isExpanded;
+              },
+            )
+        )
+    );
+    final RotationTransition rotation = tester.firstWidget(find.byType(RotationTransition));
+    expect(rotation.turns.value, 0.5);
   });
 }
 


### PR DESCRIPTION
Fixes #15650

If an ExpansionIcon state is initially created with `isExpanded = true` it will not rotate the icon correctly.  Sets the initial value of the animation controller to `pi` radians if `isExpanded` is true in `initState()`, to rotate the icon without animating it.


### With fix
Top expansion icon is correctly pointed up when isExpanded is initially set to true.
<img width="200" src="https://user-images.githubusercontent.com/8975114/37560569-46608aea-29f8-11e8-8b33-babe25b18be7.png">

