### PR TITLE
Allow null flutter schema in pubspec

### DIFF
--- a/packages/flutter_tools/schema/pubspec_yaml.json
+++ b/packages/flutter_tools/schema/pubspec_yaml.json
@@ -6,7 +6,10 @@
     "properties": {
         "name": { "type": "string" },
         "flutter": {
-            "type": "object",
+            "oneOf": [
+                { "type": "object" },
+                { "type": "null" }
+            ],
             "additionalProperties": false,
             "properties": {
                 "uses-material-design": { "type": "boolean" },

--- a/packages/flutter_tools/test/flutter_manifest_test.dart
+++ b/packages/flutter_tools/test/flutter_manifest_test.dart
@@ -345,5 +345,17 @@ flutter:
       final List<Font> fonts = flutterManifest.fonts;
       expect(fonts.length, 0);
     });
+
+    test('allows a blank flutter section', () async {
+      const String manifest = '''
+name: test
+dependencies:
+  flutter:
+    sdk: flutter
+flutter:
+''';
+      final FlutterManifest flutterManifest = await FlutterManifest.createFromString(manifest);
+      expect(flutterManifest.isEmpty, false);
+    });
   });
 }


### PR DESCRIPTION
Fixes #14008 by allowing  the `flutter:` section of the pubspec schema to be null.