### PR TITLE
Fix Dart2 compatibility with flutter_tools' tests.

### DIFF
--- a/packages/flutter_tools/test/ios/cocoapods_test.dart
+++ b/packages/flutter_tools/test/ios/cocoapods_test.dart
@@ -47,7 +47,7 @@ void main() {
       <String>['pod', 'install', '--verbose'],
       workingDirectory: 'project/ios',
       environment: <String, String>{'FLUTTER_FRAMEWORK_DIR': 'engine/path', 'COCOAPODS_DISABLE_STATS': 'true'},
-    )).thenReturn(exitsHappy);
+    )).thenAnswer((_) => new Future<ProcessResult>.value(exitsHappy));
   });
 
   group('Setup Podfile', () {
@@ -177,7 +177,7 @@ void main() {
           'FLUTTER_FRAMEWORK_DIR': 'engine/path',
           'COCOAPODS_DISABLE_STATS': 'true',
         },
-      )).thenReturn(new ProcessResult(
+      )).thenAnswer((_) => new Future<ProcessResult>.value(new ProcessResult(
         1,
         1,
         '''
@@ -195,7 +195,7 @@ You have either:
 
 Note: as of CocoaPods 1.0, `pod repo update` does not happen on `pod install` by default.''',
         '',
-      ));
+      )));
       try {
         await cocoaPodsUnderTest.processPods(
           appIosDirectory: projectUnderTest,
@@ -360,7 +360,11 @@ Note: as of CocoaPods 1.0, `pod repo update` does not happen on `pod install` by
           'FLUTTER_FRAMEWORK_DIR': 'engine/path',
           'COCOAPODS_DISABLE_STATS': 'true',
         },
-      )).thenReturn(new ProcessResult(1, 1, 'fails for some reason', ''));
+      )).thenAnswer(
+        (_) => new Future<ProcessResult>.value(
+          new ProcessResult(1, 1, 'fails for some reason', '')
+        )
+      );
 
       try {
         await cocoaPodsUnderTest.processPods(

--- a/packages/flutter_tools/test/ios/code_signing_test.dart
+++ b/packages/flutter_tools/test/ios/code_signing_test.dart
@@ -189,7 +189,7 @@ void main() {
             ))
           ));
       when(mockOpenSslProcess.stderr).thenAnswer((Invocation invocation) => mockOpenSslStdErr);
-      when(mockOpenSslProcess.exitCode).thenReturn(0);
+      when(mockOpenSslProcess.exitCode).thenAnswer((_) => new Future<int>.value(0));
 
       final String developmentTeam = await getCodeSigningIdentityDevelopmentTeam(iosApp: app);
 
@@ -259,7 +259,7 @@ void main() {
             )),
           ));
       when(mockOpenSslProcess.stderr).thenAnswer((Invocation invocation) => mockOpenSslStdErr);
-      when(mockOpenSslProcess.exitCode).thenReturn(0);
+      when(mockOpenSslProcess.exitCode).thenAnswer((_) => new Future<int>.value(0));
 
       final String developmentTeam = await getCodeSigningIdentityDevelopmentTeam(iosApp: app, usesTerminalUi: false);
 
@@ -321,7 +321,7 @@ void main() {
             ))
           ));
       when(mockOpenSslProcess.stderr).thenAnswer((Invocation invocation) => mockOpenSslStdErr);
-      when(mockOpenSslProcess.exitCode).thenReturn(0);
+      when(mockOpenSslProcess.exitCode).thenAnswer((_) => new Future<int>.value(0));
       when<String>(mockConfig.getValue('ios-signing-cert')).thenReturn('iPhone Developer: Profile 3 (3333CCCC33)');
 
       final String developmentTeam = await getCodeSigningIdentityDevelopmentTeam(iosApp: app);
@@ -390,7 +390,7 @@ void main() {
             ))
           ));
       when(mockOpenSslProcess.stderr).thenAnswer((Invocation invocation) => mockOpenSslStdErr);
-      when(mockOpenSslProcess.exitCode).thenReturn(0);
+      when(mockOpenSslProcess.exitCode).thenAnswer((_) => new Future<int>.value(0));
       when<String>(mockConfig.getValue('ios-signing-cert')).thenReturn('iPhone Developer: Invalid Profile');
 
       final String developmentTeam = await getCodeSigningIdentityDevelopmentTeam(iosApp: app);

--- a/packages/flutter_tools/test/ios/devices_test.dart
+++ b/packages/flutter_tools/test/ios/devices_test.dart
@@ -59,10 +59,14 @@ void main() {
 98206e7a4afd4aedaff06e687594e089dede3c44
 f577a7903cc54959be2e34bc4f7f80b7009efcf4
 '''));
-      when(iMobileDevice.getInfoForDevice('98206e7a4afd4aedaff06e687594e089dede3c44', 'DeviceName')).thenReturn('La tele me regarde');
-      when(iMobileDevice.getInfoForDevice('98206e7a4afd4aedaff06e687594e089dede3c44', 'ProductVersion')).thenReturn('10.3.2');
-      when(iMobileDevice.getInfoForDevice('f577a7903cc54959be2e34bc4f7f80b7009efcf4', 'DeviceName')).thenReturn('Puits sans fond');
-      when(iMobileDevice.getInfoForDevice('f577a7903cc54959be2e34bc4f7f80b7009efcf4', 'ProductVersion')).thenReturn('11.0');
+      when(iMobileDevice.getInfoForDevice('98206e7a4afd4aedaff06e687594e089dede3c44', 'DeviceName'))
+          .thenAnswer((_) => new Future<String>.value('La tele me regarde'));
+      when(iMobileDevice.getInfoForDevice('98206e7a4afd4aedaff06e687594e089dede3c44', 'ProductVersion'))
+          .thenAnswer((_) => new Future<String>.value('10.3.2'));
+      when(iMobileDevice.getInfoForDevice('f577a7903cc54959be2e34bc4f7f80b7009efcf4', 'DeviceName'))
+          .thenAnswer((_) => new Future<String>.value('Puits sans fond'));
+      when(iMobileDevice.getInfoForDevice('f577a7903cc54959be2e34bc4f7f80b7009efcf4', 'ProductVersion'))
+          .thenAnswer((_) => new Future<String>.value('11.0'));
       final List<IOSDevice> devices = await IOSDevice.getAttachedDevices();
       expect(devices, hasLength(2));
       expect(devices[0].id, '98206e7a4afd4aedaff06e687594e089dede3c44');

--- a/packages/flutter_tools/test/ios/ios_workflow_test.dart
+++ b/packages/flutter_tools/test/ios/ios_workflow_test.dart
@@ -33,8 +33,10 @@ void main() {
       cocoaPods = new MockCocoaPods();
       fs = new MemoryFileSystem();
 
-      when(cocoaPods.isCocoaPodsInstalledAndMeetsVersionCheck).thenReturn(true);
-      when(cocoaPods.isCocoaPodsInitialized).thenReturn(true);
+      when(cocoaPods.isCocoaPodsInstalledAndMeetsVersionCheck)
+          .thenAnswer((_) => new Future<bool>.value(true));
+      when(cocoaPods.isCocoaPodsInitialized)
+          .thenAnswer((_) => new Future<bool>.value(true));
     });
 
     testUsingContext('Emit missing status when nothing is installed', () async {
@@ -227,8 +229,9 @@ void main() {
           .thenReturn('Xcode 8.2.1\nBuild version 8C1002\n');
       when(xcode.isInstalledAndMeetsVersionCheck).thenReturn(true);
       when(xcode.eulaSigned).thenReturn(true);
-      when(cocoaPods.isCocoaPodsInstalledAndMeetsVersionCheck).thenReturn(false);
-      when(cocoaPods.hasCocoaPods).thenReturn(false);
+      when(cocoaPods.isCocoaPodsInstalledAndMeetsVersionCheck)
+          .thenAnswer((_) => new Future<bool>.value(false));
+      when(cocoaPods.hasCocoaPods).thenAnswer((_) => new Future<bool>.value(false));
       when(xcode.isSimctlInstalled).thenReturn(true);
       final IOSWorkflowTestTarget workflow = new IOSWorkflowTestTarget();
       final ValidationResult result = await workflow.validate();
@@ -245,9 +248,11 @@ void main() {
           .thenReturn('Xcode 8.2.1\nBuild version 8C1002\n');
       when(xcode.isInstalledAndMeetsVersionCheck).thenReturn(true);
       when(xcode.eulaSigned).thenReturn(true);
-      when(cocoaPods.isCocoaPodsInstalledAndMeetsVersionCheck).thenReturn(false);
-      when(cocoaPods.hasCocoaPods).thenReturn(true);
-      when(cocoaPods.cocoaPodsVersionText).thenReturn('0.39.0');
+      when(cocoaPods.isCocoaPodsInstalledAndMeetsVersionCheck)
+          .thenAnswer((_) => new Future<bool>.value(false));
+      when(cocoaPods.hasCocoaPods).thenAnswer((_) => new Future<bool>.value(true));
+      when(cocoaPods.cocoaPodsVersionText)
+          .thenAnswer((_) => new Future<String>.value('0.39.0'));
       when(xcode.isSimctlInstalled).thenReturn(true);
       final IOSWorkflowTestTarget workflow = new IOSWorkflowTestTarget();
       final ValidationResult result = await workflow.validate();

--- a/packages/flutter_tools/test/ios/mac_test.dart
+++ b/packages/flutter_tools/test/ios/mac_test.dart
@@ -41,7 +41,7 @@ void main() {
 
     testUsingContext('getAvailableDeviceIDs throws ToolExit when idevice_id returns non-zero', () async {
       when(mockProcessManager.run(<String>['idevice_id', '-l']))
-          .thenReturn(new ProcessResult(1, 1, '', 'Sad today'));
+          .thenAnswer((_) => new Future<ProcessResult>.value(new ProcessResult(1, 1, '', 'Sad today')));
       expect(() async => await iMobileDevice.getAvailableDeviceIDs(), throwsToolExit());
     }, overrides: <Type, Generator>{
       ProcessManager: () => mockProcessManager,
@@ -49,7 +49,7 @@ void main() {
 
     testUsingContext('getAvailableDeviceIDs returns idevice_id output when installed', () async {
       when(mockProcessManager.run(<String>['idevice_id', '-l']))
-          .thenReturn(new ProcessResult(1, 0, 'foo', ''));
+          .thenAnswer((_) => new Future<ProcessResult>.value(new ProcessResult(1, 0, 'foo', '')));
       expect(await iMobileDevice.getAvailableDeviceIDs(), 'foo');
     }, overrides: <Type, Generator>{
       ProcessManager: () => mockProcessManager,
@@ -72,7 +72,7 @@ void main() {
         when(mockProcessManager.run(<String>['idevicescreenshot', outputPath],
             environment: null,
             workingDirectory: null
-        )).thenReturn(new ProcessResult(4, 1, '', ''));
+        )).thenAnswer((_) => new Future<ProcessResult>.value(new ProcessResult(4, 1, '', '')));
 
         expect(() async => await iMobileDevice.takeScreenshot(mockOutputFile), throwsA(anything));
       }, overrides: <Type, Generator>{


### PR DESCRIPTION
Closes https://github.com/flutter/flutter/issues/15696.*

tl;dr - this is not valid (and newer versions of Mockito correctly expose the error, see #15696).

```dart
import 'package:mockito/mockito.dart';

abstract class Service {
  Future<bool> get isOnline;
}

class MockService extends Mock implements Service {}

void main() {
  var mock = new MockService();

  // You are returning a type of `bool` instead of a type of `Future<bool>`.
  when(mock.isOnline).thenReturn(true);
}
```

This _"just works"_ right now, because of the heavy use of `dynamic` in Mockito, and as long as the return value is always `await`-ed (i.e. you never try to call `.then` on a type of `bool`), then it also "_just works_". 

Naively, the fix might be:

```dart
void main() {
  var mock = new MockService();
  when(mock.isOnline).thenReturn(new Future.value(true));
}
```

... but this is actually a (correct) error in Mockito. It's not safe to create a `Future` or `Stream` _before_ the invocation of `isOnline` - that would bind the Future's callbacks to the _current_ `Zone`, not the `Zone` of the code calling `.isOnline` - which is how _real_ code would work. So we use a slightly different pattern with `.thenAnswer`:

```dart
void main() {
  var mock = new MockService();

  // Create a new Future(true) when ".isOnline" is invoked (not before).
  when(mock.isOnline).thenAnswer((_) => new Future.value(true));
}
```

*_With the exception of the last failure case, which will be fixed elsewhere._