### PR TITLE
Fixed a typo in translations_test.dart: Norwegian LC is "no"

### DIFF
--- a/packages/flutter_localizations/test/translations_test.dart
+++ b/packages/flutter_localizations/test/translations_test.dart
@@ -22,7 +22,7 @@ void main() {
     'ja', // Japanese
     'ko', // Korean
     'nl', // Dutch
-    'nl', // Norwegian
+    'no', // Norwegian
     'pl', // Polish
     'ps', // Pashto
     'pt', // Portugese


### PR DESCRIPTION
Reported here: https://github.com/flutter/flutter/pull/15708#issuecomment-374594029