### PR TITLE
Make the inspector handle widgets with non-invertible transforms gracefully.

### DIFF
--- a/packages/flutter/lib/src/widgets/widget_inspector.dart
+++ b/packages/flutter/lib/src/widgets/widget_inspector.dart
@@ -564,7 +564,14 @@ class _WidgetInspectorState extends State<WidgetInspector>
     Matrix4 transform,
   ) {
     bool hit = false;
-    final Matrix4 inverse = new Matrix4.inverted(transform);
+    Matrix4 inverse;
+    try {
+      inverse = new Matrix4.inverted(transform);
+    } on ArgumentError {
+      // We cannot invert the transform. That means the object doesn't appear on
+      // screen and cannot be hit.
+      return false;
+    }
     final Offset localPosition = MatrixUtils.transformPoint(inverse, position);
 
     final List<DiagnosticsNode> children = object.debugDescribeChildren();

--- a/packages/flutter/test/widgets/widget_inspector_test.dart
+++ b/packages/flutter/test/widgets/widget_inspector_test.dart
@@ -117,6 +117,31 @@ void main() {
     expect(paragraphText(getInspectorState().selection.current), equals('BOTTOM'));
   });
 
+  testWidgets('WidgetInspector non-invertible transform regression test', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      new Directionality(
+        textDirection: TextDirection.ltr,
+        child: new WidgetInspector(
+          selectButtonBuilder: null,
+          child: new Transform(
+            transform: new Matrix4.identity()..scale(0.0),
+            child: new Stack(
+              children: const <Widget>[
+                const Text('a', textDirection: TextDirection.ltr),
+                const Text('b', textDirection: TextDirection.ltr),
+                const Text('c', textDirection: TextDirection.ltr),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.byType(Transform));
+
+    expect(true, isTrue); // Expect that we reach here without crashing.
+  });
+
   testWidgets('WidgetInspector scroll test', (WidgetTester tester) async {
     final Key childKey = new UniqueKey();
     final GlobalKey selectButtonKey = new GlobalKey();


### PR DESCRIPTION
proxy_box.dart also has to use a `try` block to avoid throwing when hit testing non-invertible matrices.
It could be a good idea to add a Matrix4 method that returns null instead of throwing when inverting a matrix so that users who are pausing on all thrown exceptions don't pause on these breakpoints.

This fixes  https://github.com/flutter/flutter-intellij/issues/1948