### PR TITLE
[Waiting for Router] findRouteByName method in NavigatorState

### DIFF
--- a/packages/flutter/lib/src/widgets/navigator.dart
+++ b/packages/flutter/lib/src/widgets/navigator.dart
@@ -1239,6 +1239,17 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin {
     _cancelActivePointers();
   }
 
+  /// Retrieves the [Route] with this name if it is associated with this navigator
+  /// and null otherwise.
+  Route<dynamic> findRouteByName(String routeName) {
+    assert(routeName != null);
+    try {
+      return _history.firstWhere((dynamic route) => route.settings.name == routeName);
+    } catch (e) {
+      return null;
+    }
+  }
+
   /// Complete the lifecycle for a route that has been popped off the navigator.
   ///
   /// When the navigator pops a route, the navigator retains a reference to the


### PR DESCRIPTION
I find this kind of method very useful when I want to create complicated nonlinear navigation patterns. I mostly use it in conjunction with removeRoute and replaceRoute.