### PR TITLE
Remove cupertino pull to refresh from transitions test

### DIFF
--- a/examples/flutter_gallery/test_driver/transitions_perf_test.dart
+++ b/examples/flutter_gallery/test_driver/transitions_perf_test.dart
@@ -72,7 +72,6 @@ const List<Demo> demos = const <Demo>[
   const Demo('Dialogs'),
   const Demo('Navigation'),
   const Demo('Pickers'),
-  const Demo('Pull to refresh'),
   const Demo('Sliders'),
   const Demo('Switches'),
 


### PR DESCRIPTION
Needs a version of #15602 for the test driver like we have for widget tester