### PR TITLE
Stop Gradle daemon before attempting to delete Flutter project

### DIFF
--- a/dev/devicelab/lib/tasks/plugin_tests.dart
+++ b/dev/devicelab/lib/tasks/plugin_tests.dart
@@ -89,6 +89,11 @@ class FlutterProject {
   }
 
   Future<Null> delete() async {
+    // A running Gradle daemon might prevent us from deleting the project folder
+    // on Windows.
+    await inDirectory(new Directory(path.join(rootPath, 'android')), () async {
+      exec('gradle', <String>['--stop'], canFail: true);
+    });
     await parent.delete(recursive: true);
   }
 }

--- a/dev/devicelab/lib/tasks/plugin_tests.dart
+++ b/dev/devicelab/lib/tasks/plugin_tests.dart
@@ -89,11 +89,16 @@ class FlutterProject {
   }
 
   Future<Null> delete() async {
-    // A running Gradle daemon might prevent us from deleting the project folder
-    // on Windows.
-    await inDirectory(new Directory(path.join(rootPath, 'android')), () async {
-      exec('gradle', <String>['--stop'], canFail: true);
-    });
+    if (Platform.isWindows) {
+      // A running Gradle daemon might prevent us from deleting the project
+      // folder on Windows.
+      await inDirectory(
+        new Directory(path.join(rootPath, 'android')),
+        () async {
+          exec('gradle', <String>['--stop'], canFail: true);
+        },
+      );
+    }
     await parent.delete(recursive: true);
   }
 }

--- a/dev/devicelab/lib/tasks/plugin_tests.dart
+++ b/dev/devicelab/lib/tasks/plugin_tests.dart
@@ -95,7 +95,7 @@ class FlutterProject {
       await inDirectory(
         new Directory(path.join(rootPath, 'android')),
         () async {
-          exec('gradle', <String>['--stop'], canFail: true);
+          exec('gradlew.bat', <String>['--stop'], canFail: true);
         },
       );
     }


### PR DESCRIPTION
Speculating this may remove flakiness of `plugin_test_win`.