### PR TITLE
Remove tear-off mocking in refresh_test

### DIFF
--- a/packages/flutter/test/cupertino/refresh_test.dart
+++ b/packages/flutter/test/cupertino/refresh_test.dart
@@ -27,7 +27,6 @@ void main() {
     when(mockHelper.builder(
             typed(any), typed(any), typed(any), typed(any), typed(any)))
         .thenAnswer((Invocation i) {
-      BuildContext context = i.positionalArguments[0];
       RefreshIndicatorMode refreshState = i.positionalArguments[1];
       double pulledExtent = i.positionalArguments[2];
       double refreshTriggerPullDistance = i.positionalArguments[3];

--- a/packages/flutter/test/cupertino/refresh_test.dart
+++ b/packages/flutter/test/cupertino/refresh_test.dart
@@ -24,43 +24,32 @@ void main() {
     refreshCompleter = new Completer<void>.sync();
     refreshIndicator = new Container();
 
-    when(mockHelper.builder).thenReturn(
-      (
-        BuildContext context,
-        RefreshIndicatorMode refreshState,
-        double pulledExtent,
-        double refreshTriggerPullDistance,
-        double refreshIndicatorExtent,
-      ) {
-        if (refreshState == RefreshIndicatorMode.inactive) {
-          throw new TestFailure(
-            'RefreshControlIndicatorBuilder should never be called with the '
-            "inactive state because there's nothing to build in that case"
-          );
-        }
-        if (pulledExtent < 0.0) {
-          throw new TestFailure('The pulledExtent should never be less than 0.0');
-        }
-        if (refreshTriggerPullDistance < 0.0) {
-          throw new TestFailure('The refreshTriggerPullDistance should never be less than 0.0');
-        }
-        if (refreshIndicatorExtent < 0.0) {
-          throw new TestFailure('The refreshIndicatorExtent should never be less than 0.0');
-        }
-        // This closure is now shadowing the mock implementation which logs.
-        // Pass the call to the mock to log.
-        mockHelper.builder(
-          context,
-          refreshState,
-          pulledExtent,
-          refreshTriggerPullDistance,
-          refreshIndicatorExtent,
+    when(mockHelper.builder(
+            typed(any), typed(any), typed(any), typed(any), typed(any)))
+        .thenAnswer((Invocation i) {
+      BuildContext context = i.positionalArguments[0];
+      RefreshIndicatorMode refreshState = i.positionalArguments[1];
+      double pulledExtent = i.positionalArguments[2];
+      double refreshTriggerPullDistance = i.positionalArguments[3];
+      double refreshIndicatorExtent = i.positionalArguments[4];
+      if (refreshState == RefreshIndicatorMode.inactive) {
+        throw new TestFailure(
+          'RefreshControlIndicatorBuilder should never be called with the '
+          "inactive state because there's nothing to build in that case"
         );
-        return refreshIndicator;
-      },
-    );
+      }
+      if (pulledExtent < 0.0) {
+        throw new TestFailure('The pulledExtent should never be less than 0.0');
+      }
+      if (refreshTriggerPullDistance < 0.0) {
+        throw new TestFailure('The refreshTriggerPullDistance should never be less than 0.0');
+      }
+      if (refreshIndicatorExtent < 0.0) {
+        throw new TestFailure('The refreshIndicatorExtent should never be less than 0.0');
+      }
+      return refreshIndicator;
+    });
     // Make the function reference itself concrete.
-    when(mockHelper.refreshTask).thenReturn(() => mockHelper.refreshTask());
     when(mockHelper.refreshTask()).thenReturn(refreshCompleter.future);
   });
 
@@ -98,7 +87,6 @@ void main() {
 
       // The function is referenced once while passing into CupertinoRefreshControl
       // but never called.
-      verify(mockHelper.builder);
       verifyNoMoreInteractions(mockHelper);
 
       expect(
@@ -132,7 +120,6 @@ void main() {
 
       // The function is referenced once while passing into CupertinoRefreshControl
       // but never called.
-      verify(mockHelper.builder);
       verify(mockHelper.builder(
         typed(any),
         RefreshIndicatorMode.drag,
@@ -175,7 +162,6 @@ void main() {
 
         // The function is referenced once while passing into CupertinoRefreshControl
         // but never called.
-        verify(mockHelper.builder);
         verifyNoMoreInteractions(mockHelper);
 
         expect(
@@ -807,8 +793,6 @@ void main() {
 
         await tester.fling(find.byType(Container).first, const Offset(0.0, -200.0), 3000.0);
 
-        verify(mockHelper.builder);
-        verify(mockHelper.refreshTask);
         verifyNoMoreInteractions(mockHelper);
 
         debugDefaultTargetPlatformOverride = null;

--- a/packages/flutter/test/cupertino/refresh_test.dart
+++ b/packages/flutter/test/cupertino/refresh_test.dart
@@ -21,14 +21,14 @@ void main() {
 
   /// These two Functions are required to avoid tearing off of the MockHelper object,
   /// which is not supported when using Dart 2 runtime semantics.
-  Function builder = (BuildContext context, RefreshIndicatorMode refreshState,
+  final Function builder = (BuildContext context, RefreshIndicatorMode refreshState,
           double pulledExtent,
           double refreshTriggerPullDistance,
           double refreshIndicatorExtent) =>
       mockHelper.builder(context, refreshState, pulledExtent, refreshTriggerPullDistance,
           refreshIndicatorExtent);
 
-  Function onRefresh = () => mockHelper.refreshTask();
+  final Function onRefresh = () => mockHelper.refreshTask();
 
   setUp(() {
     mockHelper = new MockHelper();

--- a/packages/flutter/test/cupertino/refresh_test.dart
+++ b/packages/flutter/test/cupertino/refresh_test.dart
@@ -27,10 +27,10 @@ void main() {
     when(mockHelper.builder(
             typed(any), typed(any), typed(any), typed(any), typed(any)))
         .thenAnswer((Invocation i) {
-      RefreshIndicatorMode refreshState = i.positionalArguments[1];
-      double pulledExtent = i.positionalArguments[2];
-      double refreshTriggerPullDistance = i.positionalArguments[3];
-      double refreshIndicatorExtent = i.positionalArguments[4];
+      final RefreshIndicatorMode refreshState = i.positionalArguments[1];
+      final double pulledExtent = i.positionalArguments[2];
+      final double refreshTriggerPullDistance = i.positionalArguments[3];
+      final double refreshIndicatorExtent = i.positionalArguments[4];
       if (refreshState == RefreshIndicatorMode.inactive) {
         throw new TestFailure(
           'RefreshControlIndicatorBuilder should never be called with the '

--- a/packages/flutter/test/cupertino/refresh_test.dart
+++ b/packages/flutter/test/cupertino/refresh_test.dart
@@ -49,7 +49,6 @@ void main() {
       }
       return refreshIndicator;
     });
-    // Make the function reference itself concrete.
     when(mockHelper.refreshTask()).thenReturn(refreshCompleter.future);
   });
 
@@ -85,8 +84,6 @@ void main() {
         ),
       );
 
-      // The function is referenced once while passing into CupertinoRefreshControl
-      // but never called.
       verifyNoMoreInteractions(mockHelper);
 
       expect(
@@ -119,7 +116,7 @@ void main() {
       await tester.pump();
 
       // The function is referenced once while passing into CupertinoRefreshControl
-      // but never called.
+      // and is called.
       verify(mockHelper.builder(
         typed(any),
         RefreshIndicatorMode.drag,
@@ -160,8 +157,6 @@ void main() {
         await tester.drag(find.text('0'), const Offset(0.0, 50.0));
         await tester.pump();
 
-        // The function is referenced once while passing into CupertinoRefreshControl
-        // but never called.
         verifyNoMoreInteractions(mockHelper);
 
         expect(

--- a/packages/flutter/test/cupertino/refresh_test.dart
+++ b/packages/flutter/test/cupertino/refresh_test.dart
@@ -19,6 +19,17 @@ void main() {
   /// returns.
   Widget refreshIndicator;
 
+  /// These two Functions are required to avoid tearing off of the MockHelper object,
+  /// which is not supported when using Dart 2 runtime semantics.
+  Function builder = (BuildContext context, RefreshIndicatorMode refreshState,
+          double pulledExtent,
+          double refreshTriggerPullDistance,
+          double refreshIndicatorExtent) =>
+      mockHelper.builder(context, refreshState, pulledExtent, refreshTriggerPullDistance,
+          refreshIndicatorExtent);
+
+  Function onRefresh = () => mockHelper.refreshTask();
+
   setUp(() {
     mockHelper = new MockHelper();
     refreshCompleter = new Completer<void>.sync();
@@ -75,7 +86,7 @@ void main() {
           child: new CustomScrollView(
             slivers: <Widget>[
               new CupertinoRefreshControl(
-                builder: mockHelper.builder,
+                builder: builder,
               ),
               buildAListOfStuff(),
             ],
@@ -102,7 +113,7 @@ void main() {
           child: new CustomScrollView(
             slivers: <Widget>[
               new CupertinoRefreshControl(
-                builder: mockHelper.builder,
+                builder: builder,
               ),
               buildAListOfStuff(),
             ],
@@ -144,7 +155,7 @@ void main() {
             child: new CustomScrollView(
               slivers: <Widget>[
                 new CupertinoRefreshControl(
-                  builder: mockHelper.builder,
+                  builder: builder,
                 ),
                 buildAListOfStuff(),
               ],
@@ -176,7 +187,7 @@ void main() {
           child: new CustomScrollView(
             slivers: <Widget>[
               new CupertinoRefreshControl(
-                builder: mockHelper.builder,
+                builder: builder,
               ),
               buildAListOfStuff(),
             ],
@@ -192,7 +203,6 @@ void main() {
       await tester.pump(const Duration(seconds: 3));
 
       verifyInOrder(<void>[
-        mockHelper.builder,
         mockHelper.builder(
           typed(any),
           RefreshIndicatorMode.drag,
@@ -241,8 +251,8 @@ void main() {
           child: new CustomScrollView(
             slivers: <Widget>[
               new CupertinoRefreshControl(
-                builder: mockHelper.builder,
-                onRefresh: mockHelper.refreshTask,
+                builder: builder,
+                onRefresh: onRefresh,
               ),
               buildAListOfStuff(),
             ],
@@ -259,8 +269,6 @@ void main() {
       await tester.pump();
 
       verifyInOrder(<void>[
-        mockHelper.builder,
-        mockHelper.refreshTask,
         mockHelper.builder(
           typed(any),
           RefreshIndicatorMode.drag,
@@ -305,8 +313,8 @@ void main() {
             child: new CustomScrollView(
               slivers: <Widget>[
                 new CupertinoRefreshControl(
-                  builder: mockHelper.builder,
-                  onRefresh: mockHelper.refreshTask,
+                  builder: builder,
+                  onRefresh: onRefresh,
                 ),
                 buildAListOfStuff(),
               ],
@@ -320,8 +328,6 @@ void main() {
         await tester.pump(const Duration(milliseconds: 50));
 
         verifyInOrder(<void>[
-          mockHelper.builder,
-          mockHelper.refreshTask,
           mockHelper.builder(
             typed(any),
             RefreshIndicatorMode.armed,
@@ -384,8 +390,8 @@ void main() {
           child: new CustomScrollView(
             slivers: <Widget>[
               new CupertinoRefreshControl(
-                builder: mockHelper.builder,
-                onRefresh: mockHelper.refreshTask,
+                builder: builder,
+                onRefresh: onRefresh,
               ),
               buildAListOfStuff(),
             ],
@@ -464,8 +470,8 @@ void main() {
           child: new CustomScrollView(
             slivers: <Widget>[
               new CupertinoRefreshControl(
-                builder: mockHelper.builder,
-                onRefresh: mockHelper.refreshTask,
+                builder: builder,
+                onRefresh: onRefresh,
               ),
               buildAListOfStuff(),
             ],
@@ -541,8 +547,8 @@ void main() {
             child: new CustomScrollView(
               slivers: <Widget>[
                 new CupertinoRefreshControl(
-                  builder: mockHelper.builder,
-                  onRefresh: mockHelper.refreshTask,
+                  builder: builder,
+                  onRefresh: onRefresh,
                 ),
                 buildAListOfStuff(),
               ],
@@ -630,8 +636,8 @@ void main() {
             child: new CustomScrollView(
               slivers: <Widget>[
                 new CupertinoRefreshControl(
-                  builder: mockHelper.builder,
-                  onRefresh: mockHelper.refreshTask,
+                  builder: builder,
+                  onRefresh: onRefresh,
                 ),
                 buildAListOfStuff(),
               ],
@@ -686,8 +692,8 @@ void main() {
             child: new CustomScrollView(
               slivers: <Widget>[
                 new CupertinoRefreshControl(
-                  builder: mockHelper.builder,
-                  onRefresh: mockHelper.refreshTask,
+                  builder: builder,
+                  onRefresh: onRefresh,
                 ),
                 buildAListOfStuff(),
               ],
@@ -774,8 +780,8 @@ void main() {
               slivers: <Widget>[
                 buildAListOfStuff(),
                 new CupertinoRefreshControl( // it's in the middle now.
-                  builder: mockHelper.builder,
-                  onRefresh: mockHelper.refreshTask,
+                  builder: builder,
+                  onRefresh: onRefresh,
                 ),
                 buildAListOfStuff(),
               ],
@@ -806,7 +812,7 @@ void main() {
             child: new CustomScrollView(
               slivers: <Widget>[
                 new CupertinoRefreshControl(
-                  builder: mockHelper.builder,
+                  builder: builder,
                 ),
                 buildAListOfStuff(),
               ],
@@ -857,7 +863,7 @@ void main() {
           child: new CustomScrollView(
             slivers: <Widget>[
               new CupertinoRefreshControl(
-                builder: mockHelper.builder,
+                builder: builder,
               ),
               buildAListOfStuff(),
             ],
@@ -882,7 +888,7 @@ void main() {
           child: new CustomScrollView(
             slivers: <Widget>[
               new CupertinoRefreshControl(
-                builder: mockHelper.builder,
+                builder: builder,
               ),
               buildAListOfStuff(),
             ],
@@ -917,7 +923,7 @@ void main() {
           child: new CustomScrollView(
             slivers: <Widget>[
               new CupertinoRefreshControl(
-                builder: mockHelper.builder,
+                builder: builder,
                 refreshTriggerPullDistance: 80.0,
               ),
               buildAListOfStuff(),
@@ -955,8 +961,8 @@ void main() {
             child: new CustomScrollView(
               slivers: <Widget>[
                 new CupertinoRefreshControl(
-                  builder: mockHelper.builder,
-                  onRefresh: mockHelper.refreshTask,
+                  builder: builder,
+                  onRefresh: onRefresh,
                   refreshTriggerPullDistance: 90.0,
                   refreshIndicatorExtent: 50.0,
                 ),
@@ -1000,8 +1006,8 @@ void main() {
             child: new CustomScrollView(
               slivers: <Widget>[
                 new CupertinoRefreshControl(
-                  builder: mockHelper.builder,
-                  onRefresh: mockHelper.refreshTask,
+                  builder: builder,
+                  onRefresh: onRefresh,
                 ),
                 buildAListOfStuff(),
               ],
@@ -1052,8 +1058,8 @@ void main() {
             child: new CustomScrollView(
               slivers: <Widget>[
                 new CupertinoRefreshControl(
-                  builder: mockHelper.builder,
-                  onRefresh: mockHelper.refreshTask,
+                  builder: builder,
+                  onRefresh: onRefresh,
                 ),
                 buildAListOfStuff(),
               ],
@@ -1115,8 +1121,8 @@ void main() {
             child: new CustomScrollView(
               slivers: <Widget>[
                 new CupertinoRefreshControl(
-                  builder: mockHelper.builder,
-                  onRefresh: mockHelper.refreshTask,
+                  builder: builder,
+                  onRefresh: onRefresh,
                 ),
                 buildAListOfStuff(),
               ],
@@ -1182,7 +1188,7 @@ void main() {
               slivers: <Widget>[
                 new CupertinoRefreshControl(
                   builder: null,
-                  onRefresh: mockHelper.refreshTask,
+                  onRefresh: onRefresh,
                   refreshIndicatorExtent: 0.0,
                 ),
                 buildAListOfStuff(),


### PR DESCRIPTION
Fixes #15849.

In Dart 2 semantics (so far...) Mock objects cannot have their methods torn off as a part of mocking.

Related to https://github.com/dart-lang/build/issues/4842.