### PR TITLE
Experiment to understand test flakiness

### DIFF
--- a/dev/devicelab/lib/tasks/plugin_tests.dart
+++ b/dev/devicelab/lib/tasks/plugin_tests.dart
@@ -97,6 +97,8 @@ class FlutterProject {
         <String>['--stop'],
         canFail: true,
       );
+      // TODO(mravn): Investigating if flakiness is timing dependent.
+      await new Future<Null>.delayed(new Duration(seconds: 10));
     }
     await parent.delete(recursive: true);
   }

--- a/dev/devicelab/lib/tasks/plugin_tests.dart
+++ b/dev/devicelab/lib/tasks/plugin_tests.dart
@@ -98,7 +98,7 @@ class FlutterProject {
         canFail: true,
       );
       // TODO(mravn): Investigating if flakiness is timing dependent.
-      await new Future<Null>.delayed(new Duration(seconds: 10));
+      await new Future<Null>.delayed(const Duration(seconds: 10));
     }
     await parent.delete(recursive: true);
   }


### PR DESCRIPTION
Deleting temporary Flutter project folder fails on Windows
```
Task failed: FileSystemException: Deletion failed, path = 'C:\Users\win1\AppData\Local\Temp\plugin7521553f-2eb4-11e8-a1af-0016eb682332' (OS Error: The process cannot access the file because it is being used by another process.
, errno = 32)
```
Since we already seem to have stopped everything (Gradle daemon included), this PR experiments with timing.