### PR TITLE
Send relative uri when target physical file path is specified.

### DIFF
--- a/packages/flutter_tools/lib/src/devfs.dart
+++ b/packages/flutter_tools/lib/src/devfs.dart
@@ -409,6 +409,7 @@ class DevFS {
     ResidentCompiler generator,
     String dillOutputPath,
     bool fullRestart: false,
+    String projectRootPath,
   }) async {
     // Mark all entries as possibly deleted.
     for (DevFSContent content in _entries.values) {
@@ -503,11 +504,16 @@ class DevFS {
           await generator.recompile(mainPath, invalidatedFiles,
               outputPath:  dillOutputPath ?? fs.path.join(getBuildDirectory(), 'app.dill'),
               packagesFilePath : _packagesFilePath);
-      if (compiledBinary != null && compiledBinary.isNotEmpty)
+      if (compiledBinary != null && compiledBinary.isNotEmpty) {
+        final String entryUri = projectRootPath != null ?
+            fs.path.relative(mainPath, from: projectRootPath):
+            mainPath;
         dirtyEntries.putIfAbsent(
-          fs.path.toUri(target + '.dill'),
+          fs.path.toUri(entryUri + '.dill'),
           () => new DevFSFileContent(fs.file(compiledBinary))
         );
+      }
+
     }
     if (dirtyEntries.isNotEmpty) {
       printTrace('Updating files');

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -376,7 +376,8 @@ class FlutterDevice {
     bool bundleFirstUpload: false,
     bool bundleDirty: false,
     Set<String> fileFilter,
-    bool fullRestart: false
+    bool fullRestart: false,
+    String projectRootPath,
   }) async {
     final Status devFSStatus = logger.startProgress(
       'Syncing files to device ${device.name}...',
@@ -395,6 +396,7 @@ class FlutterDevice {
         generator: generator,
         fullRestart: fullRestart,
         dillOutputPath: dillOutputPath,
+        projectRootPath: projectRootPath,
       );
     } on DevFSException {
       devFSStatus.cancel();

--- a/packages/flutter_tools/lib/src/run_hot.dart
+++ b/packages/flutter_tools/lib/src/run_hot.dart
@@ -279,7 +279,8 @@ class HotRunner extends ResidentRunner {
         bundleFirstUpload: isFirstUpload,
         bundleDirty: isFirstUpload == false && rebuildBundle,
         fileFilter: _dartDependencies,
-        fullRestart: fullRestart
+        fullRestart: fullRestart,
+        projectRootPath: projectRootPath,
       );
       if (!result)
         return false;


### PR DESCRIPTION
This fixes issue when `--target` option is specified and points to physical file.
If this happens main app entry point that requires updating during hot reload needs to be identified by relative uri.