### PR TITLE
Marked flutter_gallery_instrumentation_test flaky

### DIFF
--- a/dev/devicelab/manifest.yaml
+++ b/dev/devicelab/manifest.yaml
@@ -249,6 +249,7 @@ tasks:
       test can run on off-the-shelf infrastructures, such as Firebase Test Lab.
     stage: devicelab
     required_agent_capabilities: ["linux/android"]
+    flaky: true
 
   # iOS on-device tests
 


### PR DESCRIPTION
This is a temporary hack to unblock the repo.

There are several problems with all of the tests that try and drive the gallery:
- The code that attempts to scroll through the gallery home page and tap on each demo in turn tends to only work by coincidence.  The lists of demo titles are out of sync with the gallery app itself and the scrolling code doesn't scroll until each demo title is actually in view.
- The Backdrop demo, which doesn't have a 'Back' button that's initially visible, needs special treatment.

I'm working on a real fix now.