### PR TITLE
Run test coverage in dart2 again

### DIFF
--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -225,7 +225,7 @@ Future<Null> _runCoverage() async {
   }
   coverageFile.deleteSync();
   await _runFlutterTest(path.join(flutterRoot, 'packages', 'flutter'),
-    options: const <String>['--coverage', '--no-preview-dart-2'],
+    options: const <String>['--coverage'],
   );
   if (!coverageFile.existsSync()) {
     print('${red}Coverage file not found.$reset');


### PR DESCRIPTION
My change in https://github.com/dart-lang/sdk/commit/521846c832e2788da6750f0e84946303c47b4009 should've fixed most of the performance regression when generating coverage reports in dart-2.

So we should try switching to dart-2 again.