### PR TITLE
Fixed an uninitialized bool in the gallery FAB demo

### DIFF
--- a/examples/flutter_gallery/lib/demo/material/tabs_fab_demo.dart
+++ b/examples/flutter_gallery/lib/demo/material/tabs_fab_demo.dart
@@ -44,7 +44,7 @@ class _TabsFabDemoState extends State<TabsFabDemo> with SingleTickerProviderStat
 
   TabController _controller;
   _Page _selectedPage;
-  bool _extendedButtons;
+  bool _extendedButtons = false;
 
   @override
   void initState() {


### PR DESCRIPTION
This was causing the devicelab `flutter_gallery_instrumentation_test` to fail.
