### PR TITLE
Adds Java EE module to SDK manager calls

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_sdk.dart
+++ b/packages/flutter_tools/lib/src/android/android_sdk.dart
@@ -332,6 +332,7 @@ class AndroidSdk {
     if (_sdkManagerEnv == null) {
       // If we can locate Java, then add it to the path used to run the Android SDK manager.
       _sdkManagerEnv = <String, String>{};
+      _sdkManagerEnv['SDKMANAGER_OPTS'] = '--add-modules java.se.ee';
       final String javaBinary = findJavaBinary();
       if (javaBinary != null) {
         _sdkManagerEnv['PATH'] =


### PR DESCRIPTION
This PR adds an environment variable to the Android SDK Manager calls that re-enables the deprecated java EE module to allow SDK manager to run. **This is a workaround** and the fix should be done in the Android tools. However, without that fix, Flutter will be broken.

Fixes: flutter/flutter#16025

See:
https://bugs.openjdk.java.net/browse/JDK-8189188
https://stackoverflow.com/questions/47150410/failed-to-run-sdkmanager-list-android-sdk-with-java-9