### PR TITLE
Update Card shape and elevation

### DIFF
--- a/examples/flutter_gallery/lib/demo/material/cards_demo.dart
+++ b/examples/flutter_gallery/lib/demo/material/cards_demo.dart
@@ -47,12 +47,13 @@ final List<TravelDestination> destinations = <TravelDestination>[
 ];
 
 class TravelDestinationItem extends StatelessWidget {
-  TravelDestinationItem({ Key key, @required this.destination })
+  TravelDestinationItem({ Key key, @required this.destination, this.shape })
     : assert(destination != null && destination.isValid),
       super(key: key);
 
   static const double height = 366.0;
   final TravelDestination destination;
+  final ShapeBorder shape;
 
   @override
   Widget build(BuildContext context) {
@@ -67,6 +68,7 @@ class TravelDestinationItem extends StatelessWidget {
         padding: const EdgeInsets.all(8.0),
         height: height,
         child: new Card(
+          shape: shape,
           child: new Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: <Widget>[
@@ -149,14 +151,39 @@ class TravelDestinationItem extends StatelessWidget {
   }
 }
 
-class CardsDemo extends StatelessWidget {
+
+class CardsDemo extends StatefulWidget {
   static const String routeName = '/material/cards';
+
+  @override
+  _CardsDemoState createState() => new _CardsDemoState();
+}
+
+class _CardsDemoState extends State<CardsDemo> {
+  ShapeBorder _shape;
 
   @override
   Widget build(BuildContext context) {
     return new Scaffold(
       appBar: new AppBar(
-        title: const Text('Travel stream')
+        title: const Text('Travel stream'),
+        actions: <Widget>[
+          new IconButton(
+            icon: const Icon(Icons.sentiment_very_satisfied),
+            onPressed: () {
+              setState(() {
+                _shape = _shape != null ? null : const RoundedRectangleBorder(
+                  borderRadius: const BorderRadius.only(
+                    topLeft: const Radius.circular(16.0),
+                    topRight: const Radius.circular(16.0),
+                    bottomLeft: const Radius.circular(2.0),
+                    bottomRight: const Radius.circular(2.0),
+                  ),
+                );
+              });
+            },
+          ),
+        ],
       ),
       body: new ListView(
         itemExtent: TravelDestinationItem.height,
@@ -164,7 +191,10 @@ class CardsDemo extends StatelessWidget {
         children: destinations.map((TravelDestination destination) {
           return new Container(
             margin: const EdgeInsets.only(bottom: 8.0),
-            child: new TravelDestinationItem(destination: destination)
+            child: new TravelDestinationItem(
+              destination: destination,
+              shape: _shape,
+            ),
           );
         }).toList()
       )

--- a/packages/flutter/lib/src/material/card.dart
+++ b/packages/flutter/lib/src/material/card.dart
@@ -5,6 +5,7 @@
 import 'package:flutter/widgets.dart';
 
 import 'material.dart';
+import 'theme.dart';
 
 /// A material design card. A card has slightly rounded corners and a shadow.
 ///
@@ -62,23 +63,38 @@ class Card extends StatelessWidget {
   const Card({
     Key key,
     this.color,
-    this.elevation: 2.0,
+    this.elevation,
+    this.shape,
     this.child,
   }) : super(key: key);
 
-  /// The widget below this widget in the tree.
+  /// The card's background color.
   ///
-  /// {@macro flutter.widgets.child}
-  final Widget child;
-
-  /// The color of material used for this card.
+  /// Defines the card's [Material.color].
+  ///
+  /// The default color is defined by the ambient [Theme]: [ThemeData.cardColor].
   final Color color;
 
   /// The z-coordinate at which to place this card. This controls the size of
   /// the shadow below the card.
   ///
-  /// Defaults to 2, the appropriate elevation for cards.
+  /// Defines the card's [Material.elevation].
+  ///
+  /// The default elevation is 1.0.
   final double elevation;
+
+  /// The shape of the card's [Material].
+  ///
+  /// Defines the card's [Material.shape].
+  ///
+  /// The default shape is a [RoundedRectangleBorder] with a circular corner
+  /// radius of 4.0.
+  final ShapeBorder shape;
+
+  /// The widget below this widget in the tree.
+  ///
+  /// {@macro flutter.widgets.child}
+  final Widget child;
 
   @override
   Widget build(BuildContext context) {
@@ -87,11 +103,14 @@ class Card extends StatelessWidget {
       child: new Container(
         margin: const EdgeInsets.all(4.0),
         child: new Material(
-          color: color,
           type: MaterialType.card,
-          elevation: elevation,
-          child: child
-        )
+          color: color ?? Theme.of(context).cardColor,
+          elevation: elevation ?? 1.0,
+          shape: shape ?? const RoundedRectangleBorder(
+            borderRadius: const BorderRadius.all(const Radius.circular(4.0)),
+          ),
+          child: child,
+        ),
       ),
     );
   }


### PR DESCRIPTION
The default elevation of the `Card` widget is now 1.0 (it was 2.0) and its circular corner radius is now 4.0 (was 2.0).

Card now has a shape parameter that's just passed along to its `Material` widget.

Updated card appearance:

![updated_card](https://user-images.githubusercontent.com/1377460/38263258-7ed7956a-3724-11e8-8462-a3d03f66ca0e.png)

Original card appearance:

![card](https://user-images.githubusercontent.com/1377460/38263265-83c1e0c6-3724-11e8-9a26-98d9c5272830.png)


