### PR TITLE
Fix powershell cat invocation to ensure correct encoding and line ending.

### DIFF
--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -75,7 +75,7 @@ Future<Null> _verifyInternationalizations() async {
 
   final String localizationsFile = path.join('packages', 'flutter_localizations', 'lib', 'src', 'l10n', 'localizations.dart');
 
-  final String executable = Platform.isWindows ? "powershell" : "cat";
+  final String executable = Platform.isWindows ? 'powershell' : 'cat';
   final List<String> args = Platform.isWindows ?
       <String>['\$PSDefaultParameterValues["*:Encoding"]="utf8";(gc $localizationsFile) -join "`n"']:
       <String>[localizationsFile];

--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -75,11 +75,18 @@ Future<Null> _verifyInternationalizations() async {
 
   final String localizationsFile = path.join('packages', 'flutter_localizations', 'lib', 'src', 'l10n', 'localizations.dart');
 
-  final EvalResult sourceContents = await _evalCommand(
-    'powershell',
-    <String>['\$PSDefaultParameterValues["*:Encoding"]="utf8";(gc $localizationsFile) -join "`n"'],
-    workingDirectory: flutterRoot,
-  );
+  final EvalResult sourceContents =
+    Platform.isWindows ?
+      await _evalCommand(
+        'powershell',
+        <String>['\$PSDefaultParameterValues["*:Encoding"]="utf8";(gc $localizationsFile) -join "`n"'],
+        workingDirectory: flutterRoot,
+      ):
+      await _evalCommand(
+        'cat',
+        <String>[localizationsFile],
+        workingDirectory: flutterRoot,
+      );
 
   if (genResult.stdout.trim() != sourceContents.stdout.trim()) {
     stderr

--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -75,18 +75,12 @@ Future<Null> _verifyInternationalizations() async {
 
   final String localizationsFile = path.join('packages', 'flutter_localizations', 'lib', 'src', 'l10n', 'localizations.dart');
 
-  final EvalResult sourceContents =
-    Platform.isWindows ?
-      await _evalCommand(
-        'powershell',
-        <String>['\$PSDefaultParameterValues["*:Encoding"]="utf8";(gc $localizationsFile) -join "`n"'],
-        workingDirectory: flutterRoot,
-      ):
-      await _evalCommand(
-        'cat',
-        <String>[localizationsFile],
-        workingDirectory: flutterRoot,
-      );
+  final String executable = Platform.isWindows ? "powershell" : "cat";
+  final List<String> args = Platform.isWindows ?
+      <String>['\$PSDefaultParameterValues["*:Encoding"]="utf8";(gc $localizationsFile) -join "`n"']:
+      <String>[localizationsFile];
+
+  final EvalResult sourceContents = await _evalCommand(executable, args, workingDirectory: flutterRoot);
 
   if (genResult.stdout.trim() != sourceContents.stdout.trim()) {
     stderr

--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -76,8 +76,8 @@ Future<Null> _verifyInternationalizations() async {
   final String localizationsFile = path.join('packages', 'flutter_localizations', 'lib', 'src', 'l10n', 'localizations.dart');
 
   final EvalResult sourceContents = await _evalCommand(
-    'cat',
-    <String>[localizationsFile],
+    'powershell',
+    <String>['\$PSDefaultParameterValues["*:Encoding"]="utf8";(gc $localizationsFile) -join "`n"'],
     workingDirectory: flutterRoot,
   );
 


### PR DESCRIPTION
Without these changes I couldn't get `dev\bots\test.dart` running on my Windows box.

Not sure what configuration was applied to AppVeyor to make it work without these changes. It might be that there are some cygwin tools(cat) installed.