### PR TITLE
Add _PointerState#toString

### DIFF
--- a/packages/flutter/lib/src/gestures/converter.dart
+++ b/packages/flutter/lib/src/gestures/converter.dart
@@ -29,6 +29,11 @@ class _PointerState {
   }
 
   Offset lastPosition;
+
+  @override
+  String toString() {
+    return '_PointerState(pointer: $pointer, down: $down, lastPosition: $lastPosition)';
+  }
 }
 
 /// Converts from engine pointer data to framework pointer events.


### PR DESCRIPTION
This method makes it easier to debug issues involving broken pointer
states.