### PR TITLE
add a period after xcode build done

### DIFF
--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -418,8 +418,8 @@ Future<XcodeBuildResult> buildXcodeProject({
   // Free pipe file.
   scriptOutputPipeTempDirectory?.deleteSync(recursive: true);
   printStatus(
-    'Xcode build done',
-    ansiAlternative: 'Xcode build done'.padRight(kDefaultStatusPadding + 1)
+    'Xcode build done.',
+    ansiAlternative: 'Xcode build done.'.padRight(kDefaultStatusPadding + 1)
         + '${getElapsedAsSeconds(buildStopwatch.elapsed).padLeft(5)}',
   );
 


### PR DESCRIPTION
- add a period after 'xcode build done', to better match other `flutter run` output

@xster