### PR TITLE
a11y traversal: sort locally; use new sorting algorithm

### DIFF
--- a/examples/flutter_gallery/lib/gallery/app.dart
+++ b/examples/flutter_gallery/lib/gallery/app.dart
@@ -157,7 +157,7 @@ class GalleryAppState extends State<GalleryApp> {
       };
     }
 
-    return Semantics(
+    return new Semantics(
       textDirection: _overrideDirection,
       child: new MaterialApp(
         title: 'Flutter Gallery',
@@ -169,7 +169,7 @@ class GalleryAppState extends State<GalleryApp> {
         routes: _kRoutes,
         home: home,
         builder: (BuildContext context, Widget child) {
-          return Semantics(
+          return new Semantics(
             textDirection: _overrideDirection,
             child: new Directionality(
               textDirection: _overrideDirection,

--- a/examples/flutter_gallery/lib/gallery/app.dart
+++ b/examples/flutter_gallery/lib/gallery/app.dart
@@ -42,7 +42,7 @@ class GalleryAppState extends State<GalleryApp> {
   bool _showPerformanceOverlay = false;
   bool _checkerboardRasterCacheImages = false;
   bool _checkerboardOffscreenLayers = false;
-  TextDirection _overrideDirection = TextDirection.rtl;
+  TextDirection _overrideDirection = TextDirection.ltr;
   double _timeDilation = 1.0;
   TargetPlatform _platform;
 
@@ -157,27 +157,21 @@ class GalleryAppState extends State<GalleryApp> {
       };
     }
 
-    return new Semantics(
-      textDirection: _overrideDirection,
-      child: new MaterialApp(
-        title: 'Flutter Gallery',
-        color: Colors.grey,
-        theme: _galleryTheme.theme.copyWith(platform: _platform ?? defaultTargetPlatform),
-        showPerformanceOverlay: _showPerformanceOverlay,
-        checkerboardRasterCacheImages: _checkerboardRasterCacheImages,
-        checkerboardOffscreenLayers: _checkerboardOffscreenLayers,
-        routes: _kRoutes,
-        home: home,
-        builder: (BuildContext context, Widget child) {
-          return new Semantics(
-            textDirection: _overrideDirection,
-            child: new Directionality(
-              textDirection: _overrideDirection,
-              child: _applyScaleFactor(child),
-            ),
-          );
-        },
-      ),
+    return new MaterialApp(
+      title: 'Flutter Gallery',
+      color: Colors.grey,
+      theme: _galleryTheme.theme.copyWith(platform: _platform ?? defaultTargetPlatform),
+      showPerformanceOverlay: _showPerformanceOverlay,
+      checkerboardRasterCacheImages: _checkerboardRasterCacheImages,
+      checkerboardOffscreenLayers: _checkerboardOffscreenLayers,
+      routes: _kRoutes,
+      home: home,
+      builder: (BuildContext context, Widget child) {
+        return new Directionality(
+          textDirection: _overrideDirection,
+          child: _applyScaleFactor(child),
+        );
+      },
     );
   }
 }

--- a/examples/flutter_gallery/lib/gallery/app.dart
+++ b/examples/flutter_gallery/lib/gallery/app.dart
@@ -42,7 +42,7 @@ class GalleryAppState extends State<GalleryApp> {
   bool _showPerformanceOverlay = false;
   bool _checkerboardRasterCacheImages = false;
   bool _checkerboardOffscreenLayers = false;
-  TextDirection _overrideDirection = TextDirection.ltr;
+  TextDirection _overrideDirection = TextDirection.rtl;
   double _timeDilation = 1.0;
   TargetPlatform _platform;
 
@@ -157,21 +157,27 @@ class GalleryAppState extends State<GalleryApp> {
       };
     }
 
-    return new MaterialApp(
-      title: 'Flutter Gallery',
-      color: Colors.grey,
-      theme: _galleryTheme.theme.copyWith(platform: _platform ?? defaultTargetPlatform),
-      showPerformanceOverlay: _showPerformanceOverlay,
-      checkerboardRasterCacheImages: _checkerboardRasterCacheImages,
-      checkerboardOffscreenLayers: _checkerboardOffscreenLayers,
-      routes: _kRoutes,
-      home: home,
-      builder: (BuildContext context, Widget child) {
-        return new Directionality(
-          textDirection: _overrideDirection,
-          child: _applyScaleFactor(child),
-        );
-      },
+    return Semantics(
+      textDirection: _overrideDirection,
+      child: new MaterialApp(
+        title: 'Flutter Gallery',
+        color: Colors.grey,
+        theme: _galleryTheme.theme.copyWith(platform: _platform ?? defaultTargetPlatform),
+        showPerformanceOverlay: _showPerformanceOverlay,
+        checkerboardRasterCacheImages: _checkerboardRasterCacheImages,
+        checkerboardOffscreenLayers: _checkerboardOffscreenLayers,
+        routes: _kRoutes,
+        home: home,
+        builder: (BuildContext context, Widget child) {
+          return Semantics(
+            textDirection: _overrideDirection,
+            child: new Directionality(
+              textDirection: _overrideDirection,
+              child: _applyScaleFactor(child),
+            ),
+          );
+        },
+      ),
     );
   }
 }

--- a/examples/flutter_gallery/lib/main.dart
+++ b/examples/flutter_gallery/lib/main.dart
@@ -6,7 +6,6 @@
 // Like what you see? Tweet us @flutterio
 
 import 'package:flutter/material.dart';
-import 'package:flutter_gallery/demo/material/date_and_time_picker_demo.dart';
 
 import 'gallery/app.dart';
 
@@ -15,10 +14,4 @@ void main() {
   // visual effect at the cost of performance.
   MaterialPageRoute.debugEnableFadingRoutes = true; // ignore: deprecated_member_use
   runApp(const GalleryApp());
-//  runApp(new MaterialApp(
-//    home: new Directionality(
-//      textDirection: TextDirection.rtl,
-//      child: new DateAndTimePickerDemo(),
-//    ),
-//  ));
 }

--- a/examples/flutter_gallery/lib/main.dart
+++ b/examples/flutter_gallery/lib/main.dart
@@ -6,6 +6,7 @@
 // Like what you see? Tweet us @flutterio
 
 import 'package:flutter/material.dart';
+import 'package:flutter_gallery/demo/material/date_and_time_picker_demo.dart';
 
 import 'gallery/app.dart';
 
@@ -14,4 +15,10 @@ void main() {
   // visual effect at the cost of performance.
   MaterialPageRoute.debugEnableFadingRoutes = true; // ignore: deprecated_member_use
   runApp(const GalleryApp());
+//  runApp(new MaterialApp(
+//    home: new Directionality(
+//      textDirection: TextDirection.rtl,
+//      child: new DateAndTimePickerDemo(),
+//    ),
+//  ));
 }

--- a/examples/stocks/lib/stock_home.dart
+++ b/examples/stocks/lib/stock_home.dart
@@ -130,7 +130,7 @@ class StockHomeState extends State<StockHome> {
                 debugDumpApp();
                 debugDumpRenderTree();
                 debugDumpLayerTree();
-                debugDumpSemanticsTree(DebugSemanticsDumpOrder.geometricOrder);
+                debugDumpSemanticsTree(DebugSemanticsDumpOrder.traversalOrder);
               } catch (e, stack) {
                 debugPrint('Exception while dumping app:\n$e\n$stack');
               }

--- a/packages/flutter/lib/src/material/app_bar.dart
+++ b/packages/flutter/lib/src/material/app_bar.dart
@@ -482,10 +482,14 @@ class _AppBarState extends State<AppBar> {
       );
     }
 
-    return new Material(
-      color: widget.backgroundColor ?? themeData.primaryColor,
-      elevation: widget.elevation,
-      child: appBar,
+    return new Semantics(
+      container: true,
+      explicitChildNodes: true,
+      child: new Material(
+        color: widget.backgroundColor ?? themeData.primaryColor,
+        elevation: widget.elevation,
+        child: appBar,
+      ),
     );
   }
 }

--- a/packages/flutter/lib/src/material/bottom_navigation_bar.dart
+++ b/packages/flutter/lib/src/material/bottom_navigation_bar.dart
@@ -485,41 +485,45 @@ class _BottomNavigationBarState extends State<BottomNavigationBar> with TickerPr
         backgroundColor = _backgroundColor;
         break;
     }
-    return new Stack(
-      children: <Widget>[
-        new Positioned.fill(
-          child: new Material( // Casts shadow.
-            elevation: 8.0,
-            color: backgroundColor,
+    return new Semantics(
+      container: true,
+      explicitChildNodes: true,
+      child: new Stack(
+        children: <Widget>[
+          new Positioned.fill(
+            child: new Material( // Casts shadow.
+              elevation: 8.0,
+              color: backgroundColor,
+            ),
           ),
-        ),
-        new ConstrainedBox(
-          constraints: new BoxConstraints(minHeight: kBottomNavigationBarHeight + additionalBottomPadding),
-          child: new Stack(
-            children: <Widget>[
-              new Positioned.fill(
-                child: new CustomPaint(
-                  painter: new _RadialPainter(
-                    circles: _circles.toList(),
-                    textDirection: Directionality.of(context),
+          new ConstrainedBox(
+            constraints: new BoxConstraints(minHeight: kBottomNavigationBarHeight + additionalBottomPadding),
+            child: new Stack(
+              children: <Widget>[
+                new Positioned.fill(
+                  child: new CustomPaint(
+                    painter: new _RadialPainter(
+                      circles: _circles.toList(),
+                      textDirection: Directionality.of(context),
+                    ),
                   ),
                 ),
-              ),
-              new Material( // Splashes.
-                type: MaterialType.transparency,
-                child: new Padding(
-                  padding: new EdgeInsets.only(bottom: additionalBottomPadding),
-                  child: new MediaQuery.removePadding(
-                    context: context,
-                    removeBottom: true,
-                    child: _createContainer(_createTiles()),
+                new Material( // Splashes.
+                  type: MaterialType.transparency,
+                  child: new Padding(
+                    padding: new EdgeInsets.only(bottom: additionalBottomPadding),
+                    child: new MediaQuery.removePadding(
+                      context: context,
+                      removeBottom: true,
+                      child: _createContainer(_createTiles()),
+                    ),
                   ),
                 ),
-              ),
-            ],
+              ],
+            ),
           ),
-        ),
-      ],
+        ],
+      ),
     );
   }
 }

--- a/packages/flutter/lib/src/material/date_picker.dart
+++ b/packages/flutter/lib/src/material/date_picker.dart
@@ -641,30 +641,39 @@ class _MonthPickerState extends State<MonthPicker> {
       height: _kMaxDayPickerHeight,
       child: new Stack(
         children: <Widget>[
-          new PageView.builder(
-            key: new ValueKey<DateTime>(widget.selectedDate),
-            controller: _dayPickerController,
-            scrollDirection: Axis.horizontal,
-            itemCount: _monthDelta(widget.firstDate, widget.lastDate) + 1,
-            itemBuilder: _buildItems,
-            onPageChanged: _handleMonthPageChanged,
+          new Semantics(
+            sortKey: _MonthPickerSortKey.calendar,
+            child: new PageView.builder(
+              key: new ValueKey<DateTime>(widget.selectedDate),
+              controller: _dayPickerController,
+              scrollDirection: Axis.horizontal,
+              itemCount: _monthDelta(widget.firstDate, widget.lastDate) + 1,
+              itemBuilder: _buildItems,
+              onPageChanged: _handleMonthPageChanged,
+            ),
           ),
           new PositionedDirectional(
             top: 0.0,
             start: 8.0,
-            child: new IconButton(
-              icon: const Icon(Icons.chevron_left),
-              tooltip: _isDisplayingFirstMonth ? null : '${localizations.previousMonthTooltip} ${localizations.formatMonthYear(_previousMonthDate)}',
-              onPressed: _isDisplayingFirstMonth ? null : _handlePreviousMonth,
+            child: new Semantics(
+              sortKey: _MonthPickerSortKey.previousMonth,
+              child: new IconButton(
+                icon: const Icon(Icons.chevron_left),
+                tooltip: _isDisplayingFirstMonth ? null : '${localizations.previousMonthTooltip} ${localizations.formatMonthYear(_previousMonthDate)}',
+                onPressed: _isDisplayingFirstMonth ? null : _handlePreviousMonth,
+              ),
             ),
           ),
           new PositionedDirectional(
             top: 0.0,
             end: 8.0,
-            child: new IconButton(
-              icon: const Icon(Icons.chevron_right),
-              tooltip: _isDisplayingLastMonth ? null : '${localizations.nextMonthTooltip} ${localizations.formatMonthYear(_nextMonthDate)}',
-              onPressed: _isDisplayingLastMonth ? null : _handleNextMonth,
+            child: new Semantics(
+              sortKey: _MonthPickerSortKey.nextMonth,
+              child: new IconButton(
+                icon: const Icon(Icons.chevron_right),
+                tooltip: _isDisplayingLastMonth ? null : '${localizations.nextMonthTooltip} ${localizations.formatMonthYear(_nextMonthDate)}',
+                onPressed: _isDisplayingLastMonth ? null : _handleNextMonth,
+              ),
             ),
           ),
         ],
@@ -678,6 +687,16 @@ class _MonthPickerState extends State<MonthPicker> {
     _dayPickerController?.dispose();
     super.dispose();
   }
+}
+
+// Defines semantic traversal order of the top-level widgets inside the month
+// picker.
+class _MonthPickerSortKey extends OrdinalSortKey {
+  static const _MonthPickerSortKey previousMonth = const _MonthPickerSortKey(1.0);
+  static const _MonthPickerSortKey nextMonth = const _MonthPickerSortKey(2.0);
+  static const _MonthPickerSortKey calendar = const _MonthPickerSortKey(3.0);
+
+  const _MonthPickerSortKey(double order) : super(order);
 }
 
 /// A scrollable list of years to allow picking a year.

--- a/packages/flutter/lib/src/rendering/binding.dart
+++ b/packages/flutter/lib/src/rendering/binding.dart
@@ -101,8 +101,8 @@ abstract class RendererBinding extends BindingBase with ServicesBinding, Schedul
     );
 
     registerSignalServiceExtension(
-      name: 'debugDumpSemanticsTreeInGeometricOrder',
-      callback: () { debugDumpSemanticsTree(DebugSemanticsDumpOrder.geometricOrder); return debugPrintDone; }
+      name: 'debugDumpSemanticsTreeInTraversalOrder',
+      callback: () { debugDumpSemanticsTree(DebugSemanticsDumpOrder.traversalOrder); return debugPrintDone; }
     );
 
     registerSignalServiceExtension(

--- a/packages/flutter/lib/src/semantics/semantics.dart
+++ b/packages/flutter/lib/src/semantics/semantics.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:math' as math;
 import 'dart:typed_data';
 import 'dart:ui' as ui;
 import 'dart:ui' show Offset, Rect, SemanticsAction, SemanticsFlag,
@@ -92,6 +93,7 @@ class SemanticsData extends Diagnosticable {
     @required this.decreasedValue,
     @required this.hint,
     @required this.textDirection,
+    // TODO(yjbanov): remove nextNodeId and previousNodeId
     @required this.nextNodeId,
     @required this.previousNodeId,
     @required this.rect,
@@ -154,10 +156,12 @@ class SemanticsData extends Diagnosticable {
 
   /// The index indicating the ID of the next node in the traversal order after
   /// this node for the platform's accessibility services.
+  // TODO(yjbanov): remove nextNodeId and previousNodeId
   final int nextNodeId;
 
   /// The index indicating the ID of the previous node in the traversal order before
   /// this node for the platform's accessibility services.
+  // TODO(yjbanov): remove nextNodeId and previousNodeId
   final int previousNodeId;
 
   /// The currently selected text (or the position of the cursor) within [value]
@@ -242,7 +246,9 @@ class SemanticsData extends Diagnosticable {
     properties.add(new StringProperty('decreasedValue', decreasedValue, defaultValue: ''));
     properties.add(new StringProperty('hint', hint, defaultValue: ''));
     properties.add(new EnumProperty<TextDirection>('textDirection', textDirection, defaultValue: null));
+    // TODO(yjbanov): remove nextNodeId and previousNodeId
     properties.add(new IntProperty('nextNodeId', nextNodeId, defaultValue: null));
+    // TODO(yjbanov): remove nextNodeId and previousNodeId
     properties.add(new IntProperty('previousNodeId', previousNodeId, defaultValue: null));
     if (textSelection?.isValid == true)
       properties.add(new MessageProperty('textSelection', '[${textSelection.start}, ${textSelection.end}]'));
@@ -264,6 +270,7 @@ class SemanticsData extends Diagnosticable {
         && typedOther.decreasedValue == decreasedValue
         && typedOther.hint == hint
         && typedOther.textDirection == textDirection
+        // TODO(yjbanov): remove nextNodeId and previousNodeId
         && typedOther.nextNodeId == nextNodeId
         && typedOther.previousNodeId == previousNodeId
         && typedOther.rect == rect
@@ -1150,14 +1157,9 @@ class SemanticsNode extends AbstractNode with DiagnosticableTreeMixin {
   /// If this is set to -1, it will indicate that there is no next node to
   /// the engine (i.e. this is the last node in the sort order). When it is
   /// null, it means that no semantics update has been built yet.
+  // TODO(yjbanov): remove nextNodeId and previousNodeId
   int get nextNodeId => _nextNodeId;
   int _nextNodeId;
-  void _updateNextNodeId(int value) {
-    if (value == _nextNodeId)
-      return;
-    _nextNodeId = value;
-    _markDirty();
-  }
 
   /// The ID of the previous node in the traversal order before this node.
   ///
@@ -1169,14 +1171,9 @@ class SemanticsNode extends AbstractNode with DiagnosticableTreeMixin {
   /// If this is set to -1, it will indicate that there is no previous node to
   /// the engine (i.e. this is the first node in the sort order). When it is
   /// null, it means that no semantics update has been built yet.
+  // TODO(yjbanov): remove nextNodeId and previousNodeId
   int get previousNodeId => _previousNodeId;
   int _previousNodeId;
-  void _updatePreviousNodeId(int value) {
-    if (value == _previousNodeId)
-      return;
-    _previousNodeId = value;
-    _markDirty();
-  }
 
   /// The currently selected text (or the position of the cursor) within [value]
   /// if this node represents a text field.
@@ -1363,10 +1360,11 @@ class SemanticsNode extends AbstractNode with DiagnosticableTreeMixin {
     if (!hasChildren || mergeAllDescendantsIntoThisNode) {
       children = _kEmptyChildList;
     } else {
-      final int childCount = _children.length;
+      final List<SemanticsNode> sortedChildren = _childrenInTraversalOrder();
+      final int childCount = sortedChildren.length;
       children = new Int32List(childCount);
       for (int i = 0; i < childCount; ++i) {
-        children[i] = _children[i].id;
+        children[i] = sortedChildren[i].id;
       }
     }
     builder.updateNode(
@@ -1391,6 +1389,55 @@ class SemanticsNode extends AbstractNode with DiagnosticableTreeMixin {
       children: children,
     );
     _dirty = false;
+  }
+
+  /// Builds a new list made of [_children] sorted in semantic traversal order.
+  List<SemanticsNode> _childrenInTraversalOrder() {
+    final List<SemanticsNode> childrenInDefaultOrder = _childrenInDefaultOrder(_children);
+
+    // List.sort does not guarantee stable sort order. Therefore, children are
+    // first partitioned into groups that have compatible sort keys, i.e. keys
+    // in the same group can be compared to each other. These groups stay in
+    // the same place. Only children within the same group are sorted.
+    final List<_TraversalSortNode> everythingSorted = <_TraversalSortNode>[];
+    final List<_TraversalSortNode> sortNodes = <_TraversalSortNode>[];
+    SemanticsSortKey lastSortKey;
+    for (int position = 0; position < childrenInDefaultOrder.length; position += 1) {
+      final SemanticsNode child = childrenInDefaultOrder[position];
+      final SemanticsSortKey sortKey = child.sortKey;
+      lastSortKey = position > 0
+          ? childrenInDefaultOrder[position - 1].sortKey
+          : null;
+      final bool isCompatibleWithPreviousSortKey = position == 0 ||
+          sortKey.runtimeType == lastSortKey.runtimeType &&
+          (sortKey == null || sortKey.name == lastSortKey.name);
+      if (!isCompatibleWithPreviousSortKey && sortNodes.isNotEmpty) {
+        // Do not sort groups with null sort keys. List.sort does not guarantee
+        // a stable sort order.
+        if (lastSortKey != null) {
+          sortNodes.sort();
+        }
+        everythingSorted.addAll(sortNodes);
+        sortNodes.clear();
+      }
+
+      sortNodes.add(new _TraversalSortNode(
+        node: child,
+        sortKey: sortKey,
+        position: position,
+      ));
+    }
+
+    // Do not sort groups with null sort keys. List.sort does not guarantee
+    // a stable sort order.
+    if (lastSortKey != null) {
+      sortNodes.sort();
+    }
+    everythingSorted.addAll(sortNodes);
+
+    return everythingSorted
+      .map<SemanticsNode>((_TraversalSortNode sortNode) => sortNode.node)
+      .toList();
   }
 
   /// Sends a [SemanticsEvent] associated with this [SemanticsNode].
@@ -1517,92 +1564,271 @@ class SemanticsNode extends AbstractNode with DiagnosticableTreeMixin {
   }
 }
 
+/// An edge of a box, such as top, bottom, left or right, used to compute
+/// [SemanticsNode]s that overlap vertically or horizontally.
+class _BoxEdge implements Comparable<_BoxEdge> {
+  _BoxEdge({
+    @required this.isStart,
+    @required this.offset,
+    @required this.node,
+  }) : assert(isStart != null),
+       assert(offset != null),
+       assert(node != null);
+
+  /// True if the edge comes before the seconds edge along the traversal
+  /// direction, and false otherwise.
+  ///
+  /// This field is never null.
+  ///
+  /// For example, in LTR traversal the left edge's [isStart] is set to true,
+  /// the right edge's [isStart] is set to false. When considering vertical
+  /// ordering of boxes, the top edge is the start edge, and the bottom edge is
+  /// the end edge.
+  final bool isStart;
+
+  /// The offset from the start edge of the parent [SemanticsNode] in the
+  /// direction of the traversal.
+  final double offset;
+
+  /// The node whom this edge belongs.
+  final SemanticsNode node;
+
+  @override
+  int compareTo(_BoxEdge other) {
+    return (offset - other.offset).sign.toInt();
+  }
+}
+
+/// A group of [nodes] that are disjoint vertically or horizontally from other
+/// nodes that share the same [SemanticsNode] parent.
+///
+/// The [nodes] are sorted among each other separately from other nodes.
+class _SemanticsSortGroup extends Comparable<_SemanticsSortGroup> {
+  _SemanticsSortGroup({
+    @required this.startOffset,
+  }) : assert(startOffset != null);
+
+  /// The offset from the start edge of the parent [SemanticsNode] in the
+  /// direction of the traversal.
+  ///
+  /// This value is equal to the [_BoxEdge.offset] of the first node in the
+  /// [nodes] list being considered.
+  final double startOffset;
+
+  /// The nodes that are sorted among each other.
+  final List<SemanticsNode> nodes = <SemanticsNode>[];
+
+  @override
+  int compareTo(_SemanticsSortGroup other) {
+    return (startOffset - other.startOffset).sign.toInt();
+  }
+
+  /// Sorts this group assuming that [nodes] belong to the same vertical group.
+  ///
+  /// This method breaks up this group into horizontal [_SemanticsSortGroup]s
+  /// then sorts them using [sortedWithinKnot].
+  List<SemanticsNode> sortedWithinVerticalGroup() {
+    final List<_BoxEdge> edges = <_BoxEdge>[];
+    for (SemanticsNode child in nodes) {
+      edges.add(new _BoxEdge(
+        isStart: true,
+        offset: _pointInParentCoordinates(child, child.rect.topLeft).dx,
+        node: child,
+      ));
+      edges.add(new _BoxEdge(
+        isStart: false,
+        offset: _pointInParentCoordinates(child, child.rect.bottomRight).dx,
+        node: child,
+      ));
+    }
+    edges.sort();
+
+    final List<_SemanticsSortGroup> horizontalGroups = <_SemanticsSortGroup>[];
+    _SemanticsSortGroup group;
+    int depth = 0;
+    for (_BoxEdge edge in edges) {
+      if (edge.isStart) {
+        depth += 1;
+        group ??= new _SemanticsSortGroup(
+          startOffset: edge.offset,
+        );
+        group.nodes.add(edge.node);
+      } else {
+        depth -= 1;
+      }
+      if (depth == 0) {
+        horizontalGroups.add(group);
+        group = null;
+      }
+    }
+    horizontalGroups.sort();
+
+    final List<SemanticsNode> result = <SemanticsNode>[];
+    for (_SemanticsSortGroup group in horizontalGroups) {
+      final List<SemanticsNode> sortedKnotNodes = group.sortedWithinKnot();
+      result.addAll(sortedKnotNodes);
+    }
+    return result;
+  }
+
+  /// Sorts [nodes] where nodes intersect both vertically and horizontally.
+  ///
+  /// This method constructs a graph, where vertices are [SemanticsNode]s and
+  /// edges are "traversed before" relation between pairs of nodes. The sort
+  /// order is the topological sorting of the graph, with the original order of
+  /// [nodes] used as the tie breaker.
+  ///
+  /// Whether a node is traversed before another node is determined by the
+  /// vector that connects the two nodes' centers. If the vector "points to the
+  /// right or down", defined as the [Offset.direction] being between `-pi/4`
+  /// and `3*pi/4`), then the semantics node whose center is at the end of the
+  /// vector is said to be traversed after.
+  List<SemanticsNode> sortedWithinKnot() {
+    if (nodes.length <= 1) {
+      return nodes;
+    }
+    final Map<int, SemanticsNode> nodeMap = <int, SemanticsNode>{};
+    final Map<int, int> edges = <int, int>{};
+    for (SemanticsNode node in nodes) {
+      nodeMap[node.id] = node;
+      final Offset center = _pointInParentCoordinates(node, node.rect.center);
+      for (SemanticsNode nextNode in nodes) {
+        if (identical(node, nextNode)) {
+          // Skip self.
+          continue;
+        }
+        final Offset nextCenter = _pointInParentCoordinates(nextNode, nextNode.rect.center);
+        final Offset centerDelta = nextCenter - center;
+        final double direction = centerDelta.direction;
+        if (-math.pi / 4 < direction && direction < 3 * math.pi / 4 &&
+            edges[nextNode.id] != node.id) {
+          edges[node.id] = nextNode.id;
+        }
+      }
+    }
+
+    final List<int> sortedIds = <int>[];
+    final Set<int> visitedIds = new Set<int>();
+    final List<SemanticsNode> startNodes = nodes.toList()..sort((SemanticsNode a, SemanticsNode b) {
+      final Offset aTopLeft = _pointInParentCoordinates(a, a.rect.topLeft);
+      final Offset bTopLeft = _pointInParentCoordinates(b, b.rect.topLeft);
+      final int verticalDiff = aTopLeft.dy.compareTo(bTopLeft.dy);
+      if (verticalDiff != 0) {
+        return -verticalDiff;
+      }
+      return -aTopLeft.dx.compareTo(bTopLeft.dx);
+    });
+
+    void search(int id) {
+      if (visitedIds.contains(id)) {
+        return;
+      }
+      visitedIds.add(id);
+      if (edges.containsKey(id)) {
+        search(edges[id]);
+      }
+      sortedIds.add(id);
+    }
+
+    startNodes.map((SemanticsNode node) => node.id).forEach(search);
+    final List<SemanticsNode> result = sortedIds.map<SemanticsNode>((int id) => nodeMap[id]).toList().reversed.toList();
+    return result;
+  }
+}
+
+/// Converts `point` to the `node`'s parent's coordinate system.
+Offset _pointInParentCoordinates(SemanticsNode node, Offset point) {
+  if (node.transform == null) {
+    return point;
+  }
+  final Vector3 vector = new Vector3(point.dx, point.dy, 0.0);
+  node.transform.transform3(vector);
+  return new Offset(vector.x, vector.y);
+}
+
+/// Sorts `children` using the default sorting algorithm, and returns them as a
+/// new list.
+///
+/// The algorithm first breaks up children into groups such that no two nodes
+/// from different groups overlap vertically. These groups are sorted vertically
+/// according to their [_SemanticsSortGroup.startOffset].
+///
+/// Within each group, the nodes are sorted using
+/// [_SemanticsSortGroup.sortedWithinVerticalGroup].
+List<SemanticsNode> _childrenInDefaultOrder(List<SemanticsNode> children) {
+  final List<_BoxEdge> edges = <_BoxEdge>[];
+  for (SemanticsNode child in children) {
+    edges.add(new _BoxEdge(
+      isStart: true,
+      offset: _pointInParentCoordinates(child, child.rect.topLeft).dy,
+      node: child,
+    ));
+    edges.add(new _BoxEdge(
+      isStart: false,
+      offset: _pointInParentCoordinates(child, child.rect.bottomRight).dy,
+      node: child,
+    ));
+  }
+  edges.sort();
+
+  final List<_SemanticsSortGroup> verticalGroups = <_SemanticsSortGroup>[];
+  _SemanticsSortGroup group;
+  int depth = 0;
+  for (_BoxEdge edge in edges) {
+    if (edge.isStart) {
+      depth += 1;
+      group ??= new _SemanticsSortGroup(
+        startOffset: edge.offset,
+      );
+      group.nodes.add(edge.node);
+    } else {
+      depth -= 1;
+    }
+    if (depth == 0) {
+      verticalGroups.add(group);
+      group = null;
+    }
+  }
+  verticalGroups.sort();
+
+  final List<SemanticsNode> result = <SemanticsNode>[];
+  for (_SemanticsSortGroup group in verticalGroups) {
+    final List<SemanticsNode> sortedGroupNodes = group.sortedWithinVerticalGroup();
+    result.addAll(sortedGroupNodes);
+  }
+  return result;
+}
+
 /// The implementation of [Comparable] that implements the ordering of
 /// [SemanticsNode]s in the accessibility traversal.
 ///
 /// [SemanticsNode]s are sorted prior to sending them to the engine side.
 ///
-/// This implementation considers a [node]'s [sortKey], it's parent's text
-/// direction ([containerTextDirection]), and its geometric position relative to
-/// its siblings ([globalStartCorner]).
-///
-/// A null value is allowed for [containerTextDirection], because in that case
-/// we want to fall back to ordering by child insertion order for nodes that are
-/// equal after sorting from top to bottom.
+/// This implementation considers a [node]'s [sortKey] and its position within
+/// the list of its siblings. [sortKey] takes precedence over position.
 class _TraversalSortNode implements Comparable<_TraversalSortNode> {
-  _TraversalSortNode({@required this.node, this.containerTextDirection, this.sortKey, Matrix4 transform})
+  _TraversalSortNode({@required this.node, this.sortKey, @required this.position})
     : assert(node != null),
-      // When containerTextDirection is null, this is set to topLeft, but the x
-      // coordinate is also ignored when doing the comparison in that case, so
-      // this isn't actually expressing a directionality opinion.
-      globalStartCorner = _transformPoint(
-        containerTextDirection == TextDirection.rtl ? node.rect.topRight : node.rect.topLeft,
-        transform,
-      );
+      assert(position != null);
 
   /// The node whose position this sort node determines.
   final SemanticsNode node;
 
-  /// The effective text direction for this node is the directionality that
-  /// its container has.
-  final TextDirection containerTextDirection;
-
   /// Determines the position of this node among its siblings.
   ///
   /// Sort keys take precedence over other attributes, such as
-  /// [globalStartCorner].
+  /// [position].
   final SemanticsSortKey sortKey;
 
-  /// The starting corner for the rectangle on this semantics node in
-  /// global coordinates.
-  ///
-  /// When the container has the directionality [TextDirection.ltr], this is the
-  /// upper left corner.  When the container has the directionality
-  /// [TextDirection.rtl], this is the upper right corner. When the container
-  /// has no directionality, this is set, but the x coordinate is ignored.
-  final Offset globalStartCorner;
-
-  static Offset _transformPoint(Offset point, Matrix4 matrix) {
-    final Vector3 result = matrix.transform3(new Vector3(point.dx, point.dy, 0.0));
-    return new Offset(result.x, result.y);
-  }
-
-  /// Compares the node's start corner with that of `other`.
-  ///
-  /// Sorts top to bottom, and then start to end.
-  ///
-  /// This takes into account the container text direction, since the
-  /// coordinate system has zero on the left, and we need to compare
-  /// differently for different text directions.
-  ///
-  /// If no text direction is available (i.e. [containerTextDirection] is
-  /// null), then we sort by vertical position first, and then by child
-  /// insertion order.
-  int _compareGeometry(_TraversalSortNode other) {
-    final int verticalDiff = globalStartCorner.dy.compareTo(other.globalStartCorner.dy);
-    if (verticalDiff != 0) {
-      return verticalDiff;
-    }
-    switch (containerTextDirection) {
-      case TextDirection.rtl:
-        return other.globalStartCorner.dx.compareTo(globalStartCorner.dx);
-      case TextDirection.ltr:
-        return globalStartCorner.dx.compareTo(other.globalStartCorner.dx);
-    }
-    // In case containerTextDirection is null we fall back to child insertion order.
-    return 0;
-  }
+  /// Position within the list of siblings.
+  final int position;
 
   @override
   int compareTo(_TraversalSortNode other) {
     if (sortKey == null || other?.sortKey == null) {
-      return _compareGeometry(other);
+      return position - other.position;
     }
-    final int comparison = sortKey.compareTo(other.sortKey);
-    if (comparison != 0) {
-      return comparison;
-    }
-    return _compareGeometry(other);
+    return sortKey.compareTo(other.sortKey);
   }
 }
 
@@ -1630,58 +1856,10 @@ class SemanticsOwner extends ChangeNotifier {
     super.dispose();
   }
 
-  // Updates the nextNodeId and previousNodeId IDs on the semantics nodes. These
-  // IDs are used on the platform side to order the nodes for traversal by the
-  // accessibility services. If the nextNodeId or previousNodeId for a node
-  // changes, the node will be marked as dirty.
-  void _updateTraversalOrder() {
-    void updateRecursively(SemanticsNode parent, Matrix4 parentGlobalTransform) {
-      assert(parentGlobalTransform != null);
-
-      final List<_TraversalSortNode> children = <_TraversalSortNode>[];
-
-      parent.visitChildren((SemanticsNode child) {
-        final Matrix4 childGlobalTransform = child.transform != null
-            ? parentGlobalTransform.multiplied(child.transform)
-            : parentGlobalTransform;
-
-        children.add(new _TraversalSortNode(
-          node: child,
-          containerTextDirection: parent.textDirection,
-          sortKey: child.sortKey,
-          transform: childGlobalTransform,
-        ));
-
-        updateRecursively(child, childGlobalTransform);
-        return true;
-      });
-
-      if (children.isEmpty) {
-        // We need at least one node for the following code to work.
-        return;
-      }
-
-      children.sort();
-      _TraversalSortNode node = children.removeLast();
-      node.node._updateNextNodeId(-1);
-      while (children.isNotEmpty) {
-        final _TraversalSortNode previousNode = children.removeLast();
-        node.node._updatePreviousNodeId(previousNode.node.id);
-        previousNode.node._updateNextNodeId(node.node.id);
-        node = previousNode;
-      }
-      node.node._updatePreviousNodeId(-1);
-    }
-
-    updateRecursively(rootSemanticsNode, new Matrix4.identity());
-  }
-
   /// Update the semantics using [Window.updateSemantics].
   void sendSemanticsUpdate() {
     if (_dirtyNodes.isEmpty)
       return;
-    // Nodes that change their previousNodeId will be marked as dirty.
-    _updateTraversalOrder();
     final List<SemanticsNode> visitedNodes = <SemanticsNode>[];
     while (_dirtyNodes.isNotEmpty) {
       final List<SemanticsNode> localDirtyNodes = _dirtyNodes.where((SemanticsNode node) => !_detachedNodes.contains(node)).toList();
@@ -2735,8 +2913,8 @@ abstract class SemanticsSortKey extends Diagnosticable implements Comparable<Sem
 
   @override
   int compareTo(SemanticsSortKey other) {
-    if (other.runtimeType != runtimeType || other.name != name)
-      return 0;
+    assert(runtimeType == other.runtimeType);
+    assert(name == other.name);
     return doCompare(other);
   }
 

--- a/packages/flutter/lib/src/semantics/semantics.dart
+++ b/packages/flutter/lib/src/semantics/semantics.dart
@@ -1334,83 +1334,64 @@ class SemanticsNode extends AbstractNode with DiagnosticableTreeMixin {
 
   /// Builds a new list made of [_children] sorted in semantic traversal order.
   List<SemanticsNode> _childrenInTraversalOrder() {
-    final Stopwatch sw = new Stopwatch()..start();
-    try {
-      TextDirection inheritedTextDirection = textDirection;
-      SemanticsNode ancestor = parent;
-      while (inheritedTextDirection == null && ancestor != null) {
-        inheritedTextDirection = ancestor.textDirection;
-        ancestor = ancestor.parent;
-      }
-
-      List<SemanticsNode> childrenInDefaultOrder = _childrenInDefaultOrder(_children, inheritedTextDirection);
-      if (inheritedTextDirection != null) {
-        childrenInDefaultOrder = _childrenInDefaultOrder(_children, inheritedTextDirection);
-      } else {
-        // In the absence of text direction default to paint order.
-        childrenInDefaultOrder = _children;
-      }
-
-      // List.sort does not guarantee stable sort order. Therefore, children are
-      // first partitioned into groups that have compatible sort keys, i.e. keys
-      // in the same group can be compared to each other. These groups stay in
-      // the same place. Only children within the same group are sorted.
-      final List<_TraversalSortNode> everythingSorted = <_TraversalSortNode>[];
-      final List<_TraversalSortNode> sortNodes = <_TraversalSortNode>[];
-      SemanticsSortKey lastSortKey;
-      for (int position = 0; position < childrenInDefaultOrder.length; position += 1) {
-        final SemanticsNode child = childrenInDefaultOrder[position];
-        final SemanticsSortKey sortKey = child.sortKey;
-        lastSortKey = position > 0
-            ? childrenInDefaultOrder[position - 1].sortKey
-            : null;
-        final bool isCompatibleWithPreviousSortKey = position == 0 ||
-            sortKey.runtimeType == lastSortKey.runtimeType &&
-            (sortKey == null || sortKey.name == lastSortKey.name);
-        if (!isCompatibleWithPreviousSortKey && sortNodes.isNotEmpty) {
-          // Do not sort groups with null sort keys. List.sort does not guarantee
-          // a stable sort order.
-          if (lastSortKey != null) {
-            sortNodes.sort();
-          }
-          everythingSorted.addAll(sortNodes);
-          sortNodes.clear();
-        }
-
-        sortNodes.add(new _TraversalSortNode(
-          node: child,
-          sortKey: sortKey,
-          position: position,
-        ));
-      }
-
-      // Do not sort groups with null sort keys. List.sort does not guarantee
-      // a stable sort order.
-      if (lastSortKey != null) {
-        sortNodes.sort();
-      }
-      everythingSorted.addAll(sortNodes);
-
-      return everythingSorted
-        .map<SemanticsNode>((_TraversalSortNode sortNode) => sortNode.node)
-        .toList();
-    } finally {
-      if (sw.elapsedMilliseconds > 100) {
-        print(
-          '<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>\n'
-          '<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>\n'
-          '<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>\n'
-          '<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>\n'
-          '<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>\n'
-          '<<<<<<<<<<<<<<<<<<<<<<<<<<<< !!!ALERT!!! >>>>>>>>>>>>>>>>>>>>>>>>>>>\n'
-          '<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>\n'
-          '<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>\n'
-          '<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>\n'
-          '<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>\n'
-          '<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>\n'
-        );
-      }
+    TextDirection inheritedTextDirection = textDirection;
+    SemanticsNode ancestor = parent;
+    while (inheritedTextDirection == null && ancestor != null) {
+      inheritedTextDirection = ancestor.textDirection;
+      ancestor = ancestor.parent;
     }
+
+    List<SemanticsNode> childrenInDefaultOrder = _childrenInDefaultOrder(_children, inheritedTextDirection);
+    if (inheritedTextDirection != null) {
+      childrenInDefaultOrder = _childrenInDefaultOrder(_children, inheritedTextDirection);
+    } else {
+      // In the absence of text direction default to paint order.
+      childrenInDefaultOrder = _children;
+    }
+
+    // List.sort does not guarantee stable sort order. Therefore, children are
+    // first partitioned into groups that have compatible sort keys, i.e. keys
+    // in the same group can be compared to each other. These groups stay in
+    // the same place. Only children within the same group are sorted.
+    final List<_TraversalSortNode> everythingSorted = <_TraversalSortNode>[];
+    final List<_TraversalSortNode> sortNodes = <_TraversalSortNode>[];
+    SemanticsSortKey lastSortKey;
+    for (int position = 0; position < childrenInDefaultOrder.length; position += 1) {
+      final SemanticsNode child = childrenInDefaultOrder[position];
+      final SemanticsSortKey sortKey = child.sortKey;
+      lastSortKey = position > 0
+          ? childrenInDefaultOrder[position - 1].sortKey
+          : null;
+      final bool isCompatibleWithPreviousSortKey = position == 0 ||
+          sortKey.runtimeType == lastSortKey.runtimeType &&
+          (sortKey == null || sortKey.name == lastSortKey.name);
+      if (!isCompatibleWithPreviousSortKey && sortNodes.isNotEmpty) {
+        // Do not sort groups with null sort keys. List.sort does not guarantee
+        // a stable sort order.
+        if (lastSortKey != null) {
+          sortNodes.sort();
+        }
+        everythingSorted.addAll(sortNodes);
+        sortNodes.clear();
+      }
+
+      sortNodes.add(new _TraversalSortNode(
+        node: child,
+        sortKey: sortKey,
+        position: position,
+      ));
+    }
+
+    // Do not sort groups with null sort keys. List.sort does not guarantee
+    // a stable sort order.
+    if (lastSortKey != null) {
+      sortNodes.sort();
+    }
+    everythingSorted.addAll(sortNodes);
+
+    return everythingSorted
+      .map<SemanticsNode>((_TraversalSortNode sortNode) => sortNode.node)
+      .toList();
   }
 
   /// Sends a [SemanticsEvent] associated with this [SemanticsNode].
@@ -1540,12 +1521,18 @@ class SemanticsNode extends AbstractNode with DiagnosticableTreeMixin {
 
 /// An edge of a box, such as top, bottom, left or right, used to compute
 /// [SemanticsNode]s that overlap vertically or horizontally.
+///
+/// For computing horizontal overlap in an LTR setting we create two [_BoxEdge]
+/// objects for each [SemanticsNode]: one representing the left edge (marked
+/// with [isLeadingEdge] equal to true) and one for the right edge (with [isLeadingEdge]
+/// equal to false). Similarly, for vertical overlap we also create two objects
+/// for each [SemanticsNode], one for the top and one for the bottom edge.
 class _BoxEdge implements Comparable<_BoxEdge> {
   _BoxEdge({
-    @required this.isStart,
+    @required this.isLeadingEdge,
     @required this.offset,
     @required this.node,
-  }) : assert(isStart != null),
+  }) : assert(isLeadingEdge != null),
        assert(offset != null),
        assert(node != null);
 
@@ -1554,11 +1541,11 @@ class _BoxEdge implements Comparable<_BoxEdge> {
   ///
   /// This field is never null.
   ///
-  /// For example, in LTR traversal the left edge's [isStart] is set to true,
-  /// the right edge's [isStart] is set to false. When considering vertical
+  /// For example, in LTR traversal the left edge's [isLeadingEdge] is set to true,
+  /// the right edge's [isLeadingEdge] is set to false. When considering vertical
   /// ordering of boxes, the top edge is the start edge, and the bottom edge is
   /// the end edge.
-  final bool isStart;
+  final bool isLeadingEdge;
 
   /// The offset from the start edge of the parent [SemanticsNode] in the
   /// direction of the traversal.
@@ -1608,12 +1595,12 @@ class _SemanticsSortGroup extends Comparable<_SemanticsSortGroup> {
     final List<_BoxEdge> edges = <_BoxEdge>[];
     for (SemanticsNode child in nodes) {
       edges.add(new _BoxEdge(
-        isStart: true,
+        isLeadingEdge: true,
         offset: _pointInParentCoordinates(child, child.rect.topLeft).dx,
         node: child,
       ));
       edges.add(new _BoxEdge(
-        isStart: false,
+        isLeadingEdge: false,
         offset: _pointInParentCoordinates(child, child.rect.bottomRight).dx,
         node: child,
       ));
@@ -1624,7 +1611,7 @@ class _SemanticsSortGroup extends Comparable<_SemanticsSortGroup> {
     _SemanticsSortGroup group;
     int depth = 0;
     for (_BoxEdge edge in edges) {
-      if (edge.isStart) {
+      if (edge.isLeadingEdge) {
         depth += 1;
         group ??= new _SemanticsSortGroup(
           startOffset: edge.offset,
@@ -1655,6 +1642,9 @@ class _SemanticsSortGroup extends Comparable<_SemanticsSortGroup> {
 
   /// Sorts [nodes] where nodes intersect both vertically and horizontally.
   ///
+  /// In the special case when [nodes] contains one or less nodes, this method
+  /// returns [nodes] unchanged.
+  ///
   /// This method constructs a graph, where vertices are [SemanticsNode]s and
   /// edges are "traversed before" relation between pairs of nodes. The sort
   /// order is the topological sorting of the graph, with the original order of
@@ -1667,7 +1657,7 @@ class _SemanticsSortGroup extends Comparable<_SemanticsSortGroup> {
   /// vector is said to be traversed after.
   List<SemanticsNode> sortedWithinKnot() {
     if (nodes.length <= 1) {
-      // Trivial node. Nothing to do.
+      // Trivial knot. Nothing to do.
       return nodes;
     }
     final Map<int, SemanticsNode> nodeMap = <int, SemanticsNode>{};
@@ -1743,16 +1733,18 @@ Offset _pointInParentCoordinates(SemanticsNode node, Offset point) {
 ///
 /// Within each group, the nodes are sorted using
 /// [_SemanticsSortGroup.sortedWithinVerticalGroup].
+///
+/// For an illustration of the algorithm see http://bit.ly/flutter-default-traversal.
 List<SemanticsNode> _childrenInDefaultOrder(List<SemanticsNode> children, TextDirection textDirection) {
   final List<_BoxEdge> edges = <_BoxEdge>[];
   for (SemanticsNode child in children) {
     edges.add(new _BoxEdge(
-      isStart: true,
+      isLeadingEdge: true,
       offset: _pointInParentCoordinates(child, child.rect.topLeft).dy,
       node: child,
     ));
     edges.add(new _BoxEdge(
-      isStart: false,
+      isLeadingEdge: false,
       offset: _pointInParentCoordinates(child, child.rect.bottomRight).dy,
       node: child,
     ));
@@ -1763,7 +1755,7 @@ List<SemanticsNode> _childrenInDefaultOrder(List<SemanticsNode> children, TextDi
   _SemanticsSortGroup group;
   int depth = 0;
   for (_BoxEdge edge in edges) {
-    if (edge.isStart) {
+    if (edge.isLeadingEdge) {
       depth += 1;
       group ??= new _SemanticsSortGroup(
         startOffset: edge.offset,
@@ -1813,7 +1805,8 @@ class _TraversalSortNode implements Comparable<_TraversalSortNode> {
   /// [position].
   final SemanticsSortKey sortKey;
 
-  /// Position within the list of siblings.
+  /// Position within the list of siblings as determined by the default sort
+  /// order.
   final int position;
 
   @override

--- a/packages/flutter/lib/src/semantics/semantics.dart
+++ b/packages/flutter/lib/src/semantics/semantics.dart
@@ -1466,7 +1466,7 @@ class SemanticsNode extends AbstractNode with DiagnosticableTreeMixin {
     String prefixLineOne: '',
     String prefixOtherLines,
     DiagnosticLevel minLevel: DiagnosticLevel.debug,
-    DebugSemanticsDumpOrder childOrder: DebugSemanticsDumpOrder.geometricOrder,
+    DebugSemanticsDumpOrder childOrder: DebugSemanticsDumpOrder.traversalOrder,
   }) {
     assert(childOrder != null);
     return toDiagnosticsNode(childOrder: childOrder).toStringDeep(prefixLineOne: prefixLineOne, prefixOtherLines: prefixOtherLines, minLevel: minLevel);
@@ -1476,7 +1476,7 @@ class SemanticsNode extends AbstractNode with DiagnosticableTreeMixin {
   DiagnosticsNode toDiagnosticsNode({
     String name,
     DiagnosticsTreeStyle style: DiagnosticsTreeStyle.sparse,
-    DebugSemanticsDumpOrder childOrder: DebugSemanticsDumpOrder.geometricOrder,
+    DebugSemanticsDumpOrder childOrder: DebugSemanticsDumpOrder.traversalOrder,
   }) {
     return new _SemanticsDiagnosticableNode(
       name: name,
@@ -1500,8 +1500,6 @@ class SemanticsNode extends AbstractNode with DiagnosticableTreeMixin {
       return const <SemanticsNode>[];
 
     switch (childOrder) {
-      case DebugSemanticsDumpOrder.geometricOrder:
-        return new List<SemanticsNode>.from(_children)..sort(_geometryComparator);
       case DebugSemanticsDumpOrder.inverseHitTest:
         return _children;
       case DebugSemanticsDumpOrder.traversalOrder:
@@ -1509,13 +1507,6 @@ class SemanticsNode extends AbstractNode with DiagnosticableTreeMixin {
     }
     assert(false);
     return null;
-  }
-
-  static int _geometryComparator(SemanticsNode a, SemanticsNode b) {
-    final Rect rectA = a.transform == null ? a.rect : MatrixUtils.transformRect(a.transform, a.rect);
-    final Rect rectB = b.transform == null ? b.rect : MatrixUtils.transformRect(b.transform, b.rect);
-    final int top = rectA.top.compareTo(rectB.top);
-    return top == 0 ? rectA.left.compareTo(rectB.left) : top;
   }
 }
 
@@ -2836,14 +2827,6 @@ enum DebugSemanticsDumpOrder {
   /// asked first if it wants to respond to a user's interaction, followed by
   /// the second last, etc. until a taker is found.
   inverseHitTest,
-
-  /// Print nodes in geometric traversal order.
-  ///
-  /// Geometric traversal order is the default traversal order for semantics nodes which
-  /// don't have [SemanticsNode.sortOrder] set.  This traversal order ignores the node
-  /// sort order, since the diagnostics system follows the widget tree and can only sort
-  /// a node's children, and the semantics system sorts nodes globally.
-  geometricOrder,
 
   /// Print nodes in semantic traversal order.
   ///

--- a/packages/flutter/lib/src/semantics/semantics.dart
+++ b/packages/flutter/lib/src/semantics/semantics.dart
@@ -93,9 +93,6 @@ class SemanticsData extends Diagnosticable {
     @required this.decreasedValue,
     @required this.hint,
     @required this.textDirection,
-    // TODO(yjbanov): remove nextNodeId and previousNodeId
-    @required this.nextNodeId,
-    @required this.previousNodeId,
     @required this.rect,
     @required this.textSelection,
     @required this.scrollPosition,
@@ -153,16 +150,6 @@ class SemanticsData extends Diagnosticable {
   /// The reading direction for the text in [label], [value], [hint],
   /// [increasedValue], and [decreasedValue].
   final TextDirection textDirection;
-
-  /// The index indicating the ID of the next node in the traversal order after
-  /// this node for the platform's accessibility services.
-  // TODO(yjbanov): remove nextNodeId and previousNodeId
-  final int nextNodeId;
-
-  /// The index indicating the ID of the previous node in the traversal order before
-  /// this node for the platform's accessibility services.
-  // TODO(yjbanov): remove nextNodeId and previousNodeId
-  final int previousNodeId;
 
   /// The currently selected text (or the position of the cursor) within [value]
   /// if this node represents a text field.
@@ -246,10 +233,6 @@ class SemanticsData extends Diagnosticable {
     properties.add(new StringProperty('decreasedValue', decreasedValue, defaultValue: ''));
     properties.add(new StringProperty('hint', hint, defaultValue: ''));
     properties.add(new EnumProperty<TextDirection>('textDirection', textDirection, defaultValue: null));
-    // TODO(yjbanov): remove nextNodeId and previousNodeId
-    properties.add(new IntProperty('nextNodeId', nextNodeId, defaultValue: null));
-    // TODO(yjbanov): remove nextNodeId and previousNodeId
-    properties.add(new IntProperty('previousNodeId', previousNodeId, defaultValue: null));
     if (textSelection?.isValid == true)
       properties.add(new MessageProperty('textSelection', '[${textSelection.start}, ${textSelection.end}]'));
     properties.add(new DoubleProperty('scrollExtentMin', scrollExtentMin, defaultValue: null));
@@ -270,9 +253,6 @@ class SemanticsData extends Diagnosticable {
         && typedOther.decreasedValue == decreasedValue
         && typedOther.hint == hint
         && typedOther.textDirection == textDirection
-        // TODO(yjbanov): remove nextNodeId and previousNodeId
-        && typedOther.nextNodeId == nextNodeId
-        && typedOther.previousNodeId == previousNodeId
         && typedOther.rect == rect
         && setEquals(typedOther.tags, tags)
         && typedOther.textSelection == textSelection
@@ -283,7 +263,7 @@ class SemanticsData extends Diagnosticable {
   }
 
   @override
-  int get hashCode => ui.hashValues(flags, actions, label, value, increasedValue, decreasedValue, hint, textDirection, nextNodeId, previousNodeId, rect, tags, textSelection, scrollPosition, scrollExtentMax, scrollExtentMin, transform);
+  int get hashCode => ui.hashValues(flags, actions, label, value, increasedValue, decreasedValue, hint, textDirection, rect, tags, textSelection, scrollPosition, scrollExtentMax, scrollExtentMin, transform);
 }
 
 class _SemanticsDiagnosticableNode extends DiagnosticableNode<SemanticsNode> {
@@ -1141,39 +1121,8 @@ class SemanticsNode extends AbstractNode with DiagnosticableTreeMixin {
   /// This is used to describe the order in which the semantic node should be
   /// traversed by the accessibility services on the platform (e.g. VoiceOver
   /// on iOS and TalkBack on Android).
-  ///
-  /// This is used to determine the [nextNodeId] and [previousNodeId] during a
-  /// semantics update.
   SemanticsSortKey get sortKey => _sortKey;
   SemanticsSortKey _sortKey;
-
-  /// The ID of the next node in the traversal order after this node.
-  ///
-  /// Only valid after at least one semantics update has been built.
-  ///
-  /// This is the value passed to the engine to tell it what the order
-  /// should be for traversing semantics nodes.
-  ///
-  /// If this is set to -1, it will indicate that there is no next node to
-  /// the engine (i.e. this is the last node in the sort order). When it is
-  /// null, it means that no semantics update has been built yet.
-  // TODO(yjbanov): remove nextNodeId and previousNodeId
-  int get nextNodeId => _nextNodeId;
-  int _nextNodeId;
-
-  /// The ID of the previous node in the traversal order before this node.
-  ///
-  /// Only valid after at least one semantics update has been built.
-  ///
-  /// This is the value passed to the engine to tell it what the order
-  /// should be for traversing semantics nodes.
-  ///
-  /// If this is set to -1, it will indicate that there is no previous node to
-  /// the engine (i.e. this is the first node in the sort order). When it is
-  /// null, it means that no semantics update has been built yet.
-  // TODO(yjbanov): remove nextNodeId and previousNodeId
-  int get previousNodeId => _previousNodeId;
-  int _previousNodeId;
 
   /// The currently selected text (or the position of the cursor) within [value]
   /// if this node represents a text field.
@@ -1279,8 +1228,6 @@ class SemanticsNode extends AbstractNode with DiagnosticableTreeMixin {
     String increasedValue = _increasedValue;
     String decreasedValue = _decreasedValue;
     TextDirection textDirection = _textDirection;
-    int nextNodeId = _nextNodeId;
-    int previousNodeId = _previousNodeId;
     Set<SemanticsTag> mergedTags = tags == null ? null : new Set<SemanticsTag>.from(tags);
     TextSelection textSelection = _textSelection;
     double scrollPosition = _scrollPosition;
@@ -1293,8 +1240,6 @@ class SemanticsNode extends AbstractNode with DiagnosticableTreeMixin {
         flags |= node._flags;
         actions |= node._actionsAsBits;
         textDirection ??= node._textDirection;
-        nextNodeId ??= node._nextNodeId;
-        previousNodeId ??= node._previousNodeId;
         textSelection ??= node._textSelection;
         scrollPosition ??= node._scrollPosition;
         scrollExtentMax ??= node._scrollExtentMax;
@@ -1334,8 +1279,6 @@ class SemanticsNode extends AbstractNode with DiagnosticableTreeMixin {
       decreasedValue: decreasedValue,
       hint: hint,
       textDirection: textDirection,
-      nextNodeId: nextNodeId,
-      previousNodeId: previousNodeId,
       rect: rect,
       transform: transform,
       tags: mergedTags,
@@ -1378,8 +1321,6 @@ class SemanticsNode extends AbstractNode with DiagnosticableTreeMixin {
       increasedValue: data.increasedValue,
       hint: data.hint,
       textDirection: data.textDirection,
-      nextNodeId: data.nextNodeId,
-      previousNodeId: data.previousNodeId,
       textSelectionBase: data.textSelection != null ? data.textSelection.baseOffset : -1,
       textSelectionExtent: data.textSelection != null ? data.textSelection.extentOffset : -1,
       scrollPosition: data.scrollPosition != null ? data.scrollPosition : double.nan,
@@ -1393,64 +1334,83 @@ class SemanticsNode extends AbstractNode with DiagnosticableTreeMixin {
 
   /// Builds a new list made of [_children] sorted in semantic traversal order.
   List<SemanticsNode> _childrenInTraversalOrder() {
-    TextDirection inheritedTextDirection = textDirection;
-    SemanticsNode ancestor = parent;
-    while (inheritedTextDirection == null && ancestor != null) {
-      inheritedTextDirection = ancestor.textDirection;
-      ancestor = ancestor.parent;
-    }
-
-    List<SemanticsNode> childrenInDefaultOrder = _childrenInDefaultOrder(_children, inheritedTextDirection);
-    if (inheritedTextDirection != null) {
-      childrenInDefaultOrder = _childrenInDefaultOrder(_children, inheritedTextDirection);
-    } else {
-      // In the absence of text direction default to paint order.
-      childrenInDefaultOrder = _children;
-    }
-
-    // List.sort does not guarantee stable sort order. Therefore, children are
-    // first partitioned into groups that have compatible sort keys, i.e. keys
-    // in the same group can be compared to each other. These groups stay in
-    // the same place. Only children within the same group are sorted.
-    final List<_TraversalSortNode> everythingSorted = <_TraversalSortNode>[];
-    final List<_TraversalSortNode> sortNodes = <_TraversalSortNode>[];
-    SemanticsSortKey lastSortKey;
-    for (int position = 0; position < childrenInDefaultOrder.length; position += 1) {
-      final SemanticsNode child = childrenInDefaultOrder[position];
-      final SemanticsSortKey sortKey = child.sortKey;
-      lastSortKey = position > 0
-          ? childrenInDefaultOrder[position - 1].sortKey
-          : null;
-      final bool isCompatibleWithPreviousSortKey = position == 0 ||
-          sortKey.runtimeType == lastSortKey.runtimeType &&
-          (sortKey == null || sortKey.name == lastSortKey.name);
-      if (!isCompatibleWithPreviousSortKey && sortNodes.isNotEmpty) {
-        // Do not sort groups with null sort keys. List.sort does not guarantee
-        // a stable sort order.
-        if (lastSortKey != null) {
-          sortNodes.sort();
-        }
-        everythingSorted.addAll(sortNodes);
-        sortNodes.clear();
+    final Stopwatch sw = new Stopwatch()..start();
+    try {
+      TextDirection inheritedTextDirection = textDirection;
+      SemanticsNode ancestor = parent;
+      while (inheritedTextDirection == null && ancestor != null) {
+        inheritedTextDirection = ancestor.textDirection;
+        ancestor = ancestor.parent;
       }
 
-      sortNodes.add(new _TraversalSortNode(
-        node: child,
-        sortKey: sortKey,
-        position: position,
-      ));
-    }
+      List<SemanticsNode> childrenInDefaultOrder = _childrenInDefaultOrder(_children, inheritedTextDirection);
+      if (inheritedTextDirection != null) {
+        childrenInDefaultOrder = _childrenInDefaultOrder(_children, inheritedTextDirection);
+      } else {
+        // In the absence of text direction default to paint order.
+        childrenInDefaultOrder = _children;
+      }
 
-    // Do not sort groups with null sort keys. List.sort does not guarantee
-    // a stable sort order.
-    if (lastSortKey != null) {
-      sortNodes.sort();
-    }
-    everythingSorted.addAll(sortNodes);
+      // List.sort does not guarantee stable sort order. Therefore, children are
+      // first partitioned into groups that have compatible sort keys, i.e. keys
+      // in the same group can be compared to each other. These groups stay in
+      // the same place. Only children within the same group are sorted.
+      final List<_TraversalSortNode> everythingSorted = <_TraversalSortNode>[];
+      final List<_TraversalSortNode> sortNodes = <_TraversalSortNode>[];
+      SemanticsSortKey lastSortKey;
+      for (int position = 0; position < childrenInDefaultOrder.length; position += 1) {
+        final SemanticsNode child = childrenInDefaultOrder[position];
+        final SemanticsSortKey sortKey = child.sortKey;
+        lastSortKey = position > 0
+            ? childrenInDefaultOrder[position - 1].sortKey
+            : null;
+        final bool isCompatibleWithPreviousSortKey = position == 0 ||
+            sortKey.runtimeType == lastSortKey.runtimeType &&
+            (sortKey == null || sortKey.name == lastSortKey.name);
+        if (!isCompatibleWithPreviousSortKey && sortNodes.isNotEmpty) {
+          // Do not sort groups with null sort keys. List.sort does not guarantee
+          // a stable sort order.
+          if (lastSortKey != null) {
+            sortNodes.sort();
+          }
+          everythingSorted.addAll(sortNodes);
+          sortNodes.clear();
+        }
 
-    return everythingSorted
-      .map<SemanticsNode>((_TraversalSortNode sortNode) => sortNode.node)
-      .toList();
+        sortNodes.add(new _TraversalSortNode(
+          node: child,
+          sortKey: sortKey,
+          position: position,
+        ));
+      }
+
+      // Do not sort groups with null sort keys. List.sort does not guarantee
+      // a stable sort order.
+      if (lastSortKey != null) {
+        sortNodes.sort();
+      }
+      everythingSorted.addAll(sortNodes);
+
+      return everythingSorted
+        .map<SemanticsNode>((_TraversalSortNode sortNode) => sortNode.node)
+        .toList();
+    } finally {
+      if (sw.elapsedMilliseconds > 100) {
+        print(
+          '<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>\n'
+          '<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>\n'
+          '<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>\n'
+          '<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>\n'
+          '<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>\n'
+          '<<<<<<<<<<<<<<<<<<<<<<<<<<<< !!!ALERT!!! >>>>>>>>>>>>>>>>>>>>>>>>>>>\n'
+          '<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>\n'
+          '<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>\n'
+          '<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>\n'
+          '<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>\n'
+          '<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>\n'
+        );
+      }
+    }
   }
 
   /// Sends a [SemanticsEvent] associated with this [SemanticsNode].
@@ -1508,8 +1468,6 @@ class SemanticsNode extends AbstractNode with DiagnosticableTreeMixin {
     properties.add(new StringProperty('decreasedValue', _decreasedValue, defaultValue: ''));
     properties.add(new StringProperty('hint', _hint, defaultValue: ''));
     properties.add(new EnumProperty<TextDirection>('textDirection', _textDirection, defaultValue: null));
-    properties.add(new IntProperty('nextNodeId', _nextNodeId, defaultValue: null));
-    properties.add(new IntProperty('previousNodeId', _previousNodeId, defaultValue: null));
     properties.add(new DiagnosticsProperty<SemanticsSortKey>('sortKey', sortKey, defaultValue: null));
     if (_textSelection?.isValid == true)
       properties.add(new MessageProperty('text selection', '[${_textSelection.start}, ${_textSelection.end}]'));

--- a/packages/flutter/lib/src/semantics/semantics.dart
+++ b/packages/flutter/lib/src/semantics/semantics.dart
@@ -1549,12 +1549,13 @@ class SemanticsNode extends AbstractNode with DiagnosticableTreeMixin {
 
   @override
   List<DiagnosticsNode> debugDescribeChildren({ DebugSemanticsDumpOrder childOrder: DebugSemanticsDumpOrder.inverseHitTest }) {
-    return _getChildrenInOrder(childOrder)
+    return debugListChildrenInOrder(childOrder)
       .map<DiagnosticsNode>((SemanticsNode node) => node.toDiagnosticsNode(childOrder: childOrder))
       .toList();
   }
 
-  Iterable<SemanticsNode> _getChildrenInOrder(DebugSemanticsDumpOrder childOrder) {
+  /// Returns the list of direct children of this node in the specified order.
+  List<SemanticsNode> debugListChildrenInOrder(DebugSemanticsDumpOrder childOrder) {
     assert(childOrder != null);
     if (_children == null)
       return const <SemanticsNode>[];

--- a/packages/flutter/lib/src/semantics/semantics.dart
+++ b/packages/flutter/lib/src/semantics/semantics.dart
@@ -1341,7 +1341,7 @@ class SemanticsNode extends AbstractNode with DiagnosticableTreeMixin {
       ancestor = ancestor.parent;
     }
 
-    List<SemanticsNode> childrenInDefaultOrder = _childrenInDefaultOrder(_children, inheritedTextDirection);
+    List<SemanticsNode> childrenInDefaultOrder;
     if (inheritedTextDirection != null) {
       childrenInDefaultOrder = _childrenInDefaultOrder(_children, inheritedTextDirection);
     } else {
@@ -2879,9 +2879,27 @@ String _concatStrings({
 /// Base class for all sort keys for [Semantics] accessibility traversal order
 /// sorting.
 ///
-/// If subclasses of this class compare themselves to another subclass of
-/// [SemanticsSortKey], they will compare as "equal" so that keys of the same
-/// type are ordered only with respect to one another.
+/// Only keys of the same type and having matching [name]s are compared. If a
+/// list of sibling [SemanticsNode]s contains keys that are not comparable with
+/// each other the list is first sorted using the default sorting algorithm.
+/// Then the nodes are broken down into groups by moving comparable nodes
+/// towards the _earliest_ node in the group. Finally each group is sorted by
+/// sort key and the resulting list is made by concatenating the sorted groups
+/// back.
+///
+/// For example, let's take nodes (C, D, B, E, A, F). Let's assign node A key 1,
+/// node B key 2, node C key 3. Let's also assume that the default sort order
+/// leaves the original list intact. Because nodes A, B, and C, have comparable
+/// sort key, they will form a group by pulling all nodes towards the earliest
+/// node, which is C. The result is group (C, B, A). The remaining nodes D, E,
+/// F, form a second group with sort key being `null`. The first group is sorted
+/// using their sort keys becoming (A, B, C). The second group is left as is
+/// because it does not specify sort keys. Then we concatenate the two groups -
+/// (A, B, C) and (D, E, F) - into the final (A, B, C, D, E, F).
+///
+/// Because of the complexity introduced by incomparable sort keys among sibling
+/// nodes, it is recommended to either use comparable keys for all nodes, or
+/// use null for all of them, leaving the sort order to the default algorithm.
 ///
 /// See Also:
 ///
@@ -2894,13 +2912,12 @@ abstract class SemanticsSortKey extends Diagnosticable implements Comparable<Sem
 
   /// An optional name that will make this sort key only order itself
   /// with respect to other sort keys of the same [name], as long as
-  /// they are of the same [runtimeType]. If compared with a
-  /// [SemanticsSortKey] with a different name or type, they will
-  /// compare as "equal".
+  /// they are of the same [runtimeType].
   final String name;
 
   @override
   int compareTo(SemanticsSortKey other) {
+    // The sorting algorithm must not compare incomparable keys.
     assert(runtimeType == other.runtimeType);
     assert(name == other.name);
     return doCompare(other);
@@ -2908,12 +2925,13 @@ abstract class SemanticsSortKey extends Diagnosticable implements Comparable<Sem
 
   /// The implementation of [compareTo].
   ///
-  /// The argument is guaranteed to be of the same type as this object.
+  /// The argument is guaranteed to be of the same type as this object and have
+  /// the same [name].
   ///
   /// The method should return a negative number if this object comes earlier in
   /// the sort order than the argument; and a positive number if it comes later
-  /// in the sort order. Returning zero causes the system to default to
-  /// comparing the geometry of the nodes.
+  /// in the sort order. Returning zero causes the system to use default sort
+  /// order.
   @protected
   int doCompare(covariant SemanticsSortKey other);
 

--- a/packages/flutter/lib/src/widgets/app.dart
+++ b/packages/flutter/lib/src/widgets/app.dart
@@ -602,7 +602,7 @@ class _WidgetsAppState extends State<WidgetsApp> implements WidgetsBindingObserv
     if (widget.onGenerateTitle != null) {
       title = new Builder(
         // This Builder exists to provide a context below the Localizations widget.
-        // The onGenerateCallback() can refer to Localizations via its context
+        // The onGenerateTitle callback can refer to Localizations via its context
         // parameter.
         builder: (BuildContext context) {
           final String title = widget.onGenerateTitle(context);

--- a/packages/flutter/lib/src/widgets/modal_barrier.dart
+++ b/packages/flutter/lib/src/widgets/modal_barrier.dart
@@ -65,11 +65,11 @@ class ModalBarrier extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     assert(!dismissible || semanticsLabel == null || debugCheckHasDirectionality(context));
-    final bool semanticsDismissable = dismissible && defaultTargetPlatform != TargetPlatform.android;
+    final bool semanticsDismissible = dismissible && defaultTargetPlatform != TargetPlatform.android;
     return new BlockSemantics(
       child: new ExcludeSemantics(
         // On Android, the back button is used to dismiss a modal.
-        excluding: !semanticsDismissable,
+        excluding: !semanticsDismissible,
         child: new GestureDetector(
           onTapDown: (TapDownDetails details) {
             if (dismissible)
@@ -77,8 +77,8 @@ class ModalBarrier extends StatelessWidget {
           },
           behavior: HitTestBehavior.opaque,
           child: new Semantics(
-            label: semanticsDismissable ? semanticsLabel : null,
-            textDirection: semanticsDismissable && semanticsLabel != null ? Directionality.of(context) : null,
+            label: semanticsDismissible ? semanticsLabel : null,
+            textDirection: semanticsDismissible && semanticsLabel != null ? Directionality.of(context) : null,
             child: new ConstrainedBox(
               constraints: const BoxConstraints.expand(),
               child: color == null ? null : new DecoratedBox(

--- a/packages/flutter/lib/src/widgets/scroll_position.dart
+++ b/packages/flutter/lib/src/widgets/scroll_position.dart
@@ -102,8 +102,10 @@ abstract class ScrollPosition extends ViewportOffset with ScrollMetrics {
   ///    create scroll positions and initialize this property.
   final bool keepScrollOffset;
 
-  /// A label that is used in the [toString] output. Intended to aid with
-  /// identifying animation controller instances in debug output.
+  /// A label that is used in the [toString] output.
+  ///
+  /// Intended to aid with identifying animation controller instances in debug
+  /// output.
   final String debugLabel;
 
   @override
@@ -123,10 +125,9 @@ abstract class ScrollPosition extends ViewportOffset with ScrollMetrics {
   double _viewportDimension;
 
   /// Whether [viewportDimension], [minScrollExtent], [maxScrollExtent],
-  /// [outOfRange], and [atEdge] are available yet.
+  /// [outOfRange], and [atEdge] are available.
   ///
-  /// Set to true just before the first time that [applyNewDimensions] is
-  /// called.
+  /// Set to true just before the first time [applyNewDimensions] is called.
   bool get haveDimensions => _haveDimensions;
   bool _haveDimensions = false;
 

--- a/packages/flutter/test/cupertino/button_test.dart
+++ b/packages/flutter/test/cupertino/button_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:ui' show SemanticsFlag;
-
 import 'package:flutter/rendering.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/scheduler.dart';

--- a/packages/flutter/test/foundation/service_extensions_test.dart
+++ b/packages/flutter/test/foundation/service_extensions_test.dart
@@ -193,11 +193,11 @@ void main() {
     console.clear();
   });
 
-  test('Service extensions - debugDumpSemanticsTreeInGeometricOrder', () async {
+  test('Service extensions - debugDumpSemanticsTreeInTraversalOrder', () async {
     Map<String, dynamic> result;
 
     await binding.doFrame();
-    result = await binding.testExtension('debugDumpSemanticsTreeInGeometricOrder', <String, String>{});
+    result = await binding.testExtension('debugDumpSemanticsTreeInTraversalOrder', <String, String>{});
     expect(result, <String, String>{});
     expect(console, <String>['Semantics not collected.']);
     console.clear();

--- a/packages/flutter/test/material/app_bar_test.dart
+++ b/packages/flutter/test/material/app_bar_test.dart
@@ -7,6 +7,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import '../widgets/semantics_tester.dart';
+
 Widget buildSliverAppBarApp({ bool floating, bool pinned, double expandedHeight, bool snap: false }) {
   return new Localizations(
     locale: const Locale('en', 'US'),
@@ -65,6 +67,10 @@ double appBarBottom(WidgetTester tester) => tester.getBottomLeft(find.byType(App
 double tabBarHeight(WidgetTester tester) => tester.getSize(find.byType(TabBar)).height;
 
 void main() {
+  setUp(() {
+    debugResetSemanticsIdCounter();
+  });
+
   testWidgets('AppBar centers title on iOS', (WidgetTester tester) async {
     await tester.pumpWidget(
       new MaterialApp(
@@ -1181,5 +1187,156 @@ void main() {
     expect(tester.getRect(find.byType(AppBar)), new Rect.fromLTRB(0.0, 0.0, 800.00, 100.0 + 56.0));
     expect(tester.getRect(find.byKey(leadingKey)), new Rect.fromLTRB(800.0 - 56.0, 100.0, 800.0, 100.0 + 56.0));
     expect(tester.getRect(find.byKey(trailingKey)), new Rect.fromLTRB(4.0, 100.0, 400.0 + 4.0, 100.0 + 56.0));
+  });
+
+  testWidgets('SliverAppBar provides correct semantics in LTR', (WidgetTester tester) async {
+    final SemanticsTester semantics = new SemanticsTester(tester);
+
+    await tester.pumpWidget(
+      new MaterialApp(
+        home: new Center(
+          child: new AppBar(
+            leading: const Text('Leading'),
+            title: const Text('Title'),
+            actions: const <Widget>[
+              const Text('Action 1'),
+              const Text('Action 2'),
+              const Text('Action 3'),
+            ],
+            bottom: const PreferredSize(
+              preferredSize: const Size(0.0, kToolbarHeight),
+              child: const Text('Bottom'),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(semantics, hasSemantics(
+      new TestSemantics.root(
+        children: <TestSemantics>[
+          new TestSemantics(
+            flags: <SemanticsFlag>[SemanticsFlag.scopesRoute],
+            children: <TestSemantics>[
+              new TestSemantics(
+                children: <TestSemantics>[
+                  new TestSemantics(
+                    label: 'Leading',
+                    textDirection: TextDirection.ltr,
+                  ),
+                  new TestSemantics(
+                    flags: <SemanticsFlag>[SemanticsFlag.namesRoute],
+                    label: 'Title',
+                    textDirection: TextDirection.ltr,
+                  ),
+                  new TestSemantics(
+                    label: 'Action 1',
+                    textDirection: TextDirection.ltr,
+                  ),
+                  new TestSemantics(
+                    label: 'Action 2',
+                    textDirection: TextDirection.ltr,
+                  ),
+                  new TestSemantics(
+                    label: 'Action 3',
+                    textDirection: TextDirection.ltr,
+                  ),
+                  new TestSemantics(
+                    label: 'Bottom',
+                    textDirection: TextDirection.ltr,
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ],
+      ),
+      ignoreRect: true,
+      ignoreTransform: true,
+      ignoreId: true,
+    ));
+
+    semantics.dispose();
+  });
+
+  testWidgets('SliverAppBar provides correct semantics in RTL', (WidgetTester tester) async {
+    final SemanticsTester semantics = new SemanticsTester(tester);
+
+    await tester.pumpWidget(
+      new MaterialApp(
+        home: new Semantics(
+          textDirection: TextDirection.rtl,
+          child: new Directionality(
+            textDirection: TextDirection.rtl,
+            child: new Center(
+              child: new AppBar(
+                leading: const Text('Leading'),
+                title: const Text('Title'),
+                actions: const <Widget>[
+                  const Text('Action 1'),
+                  const Text('Action 2'),
+                  const Text('Action 3'),
+                ],
+                bottom: const PreferredSize(
+                  preferredSize: const Size(0.0, kToolbarHeight),
+                  child: const Text('Bottom'),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(semantics, hasSemantics(
+      new TestSemantics.root(
+        children: <TestSemantics>[
+          new TestSemantics(
+            flags: <SemanticsFlag>[SemanticsFlag.scopesRoute],
+            children: <TestSemantics>[
+              new TestSemantics(
+                textDirection: TextDirection.rtl,
+                children: <TestSemantics>[
+                  new TestSemantics(
+                    children: <TestSemantics>[
+                      new TestSemantics(
+                        label: 'Leading',
+                        textDirection: TextDirection.rtl,
+                      ),
+                      new TestSemantics(
+                        flags: <SemanticsFlag>[SemanticsFlag.namesRoute],
+                        label: 'Title',
+                        textDirection: TextDirection.rtl,
+                      ),
+                      new TestSemantics(
+                        label: 'Action 1',
+                        textDirection: TextDirection.rtl,
+                      ),
+                      new TestSemantics(
+                        label: 'Action 2',
+                        textDirection: TextDirection.rtl,
+                      ),
+                      new TestSemantics(
+                        label: 'Action 3',
+                        textDirection: TextDirection.rtl,
+                      ),
+                      new TestSemantics(
+                        label: 'Bottom',
+                        textDirection: TextDirection.rtl,
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ],
+      ),
+      ignoreRect: true,
+      ignoreTransform: true,
+      ignoreId: true,
+    ));
+
+    semantics.dispose();
   });
 }

--- a/packages/flutter/test/material/bottom_navigation_bar_test.dart
+++ b/packages/flutter/test/material/bottom_navigation_bar_test.dart
@@ -512,32 +512,36 @@ void main() {
       ),
     );
 
-    // TODO(goderbauer): traversal order is incorrect, https://github.com/flutter/flutter/issues/14375
     final TestSemantics expected = new TestSemantics.root(
       children: <TestSemantics>[
         new TestSemantics(
           id: 1,
-          flags: <SemanticsFlag>[SemanticsFlag.isSelected],
-          actions: <SemanticsAction>[SemanticsAction.tap],
-          label: 'AC\nTab 1 of 3',
-          textDirection: TextDirection.ltr,
-          previousNodeId: 3, // Should be 2
-        ),
-        new TestSemantics(
-          id: 2,
-          actions: <SemanticsAction>[SemanticsAction.tap],
-          label: 'Alarm\nTab 2 of 3',
-          textDirection: TextDirection.ltr,
-          nextNodeId: 3,
-          previousNodeId: -1, // Should be 1
-        ),
-        new TestSemantics(
-          id: 3,
-          actions: <SemanticsAction>[SemanticsAction.tap],
-          label: 'Hot Tub\nTab 3 of 3',
-          textDirection: TextDirection.ltr,
-          nextNodeId: 1, // Should be -1
-          previousNodeId: 2,
+          children: <TestSemantics>[
+            new TestSemantics(
+              id: 2,
+              flags: <SemanticsFlag>[SemanticsFlag.isSelected],
+              actions: <SemanticsAction>[SemanticsAction.tap],
+              label: 'AC\nTab 1 of 3',
+              textDirection: TextDirection.ltr,
+              previousNodeId: 3, // Should be 2
+            ),
+            new TestSemantics(
+              id: 3,
+              actions: <SemanticsAction>[SemanticsAction.tap],
+              label: 'Alarm\nTab 2 of 3',
+              textDirection: TextDirection.ltr,
+              nextNodeId: 3,
+              previousNodeId: -1, // Should be 1
+            ),
+            new TestSemantics(
+              id: 4,
+              actions: <SemanticsAction>[SemanticsAction.tap],
+              label: 'Hot Tub\nTab 3 of 3',
+              textDirection: TextDirection.ltr,
+              nextNodeId: 1, // Should be -1
+              previousNodeId: 2,
+            ),
+          ],
         ),
       ],
     );

--- a/packages/flutter/test/material/bottom_navigation_bar_test.dart
+++ b/packages/flutter/test/material/bottom_navigation_bar_test.dart
@@ -523,23 +523,18 @@ void main() {
               actions: <SemanticsAction>[SemanticsAction.tap],
               label: 'AC\nTab 1 of 3',
               textDirection: TextDirection.ltr,
-              previousNodeId: 3, // Should be 2
             ),
             new TestSemantics(
               id: 3,
               actions: <SemanticsAction>[SemanticsAction.tap],
               label: 'Alarm\nTab 2 of 3',
               textDirection: TextDirection.ltr,
-              nextNodeId: 3,
-              previousNodeId: -1, // Should be 1
             ),
             new TestSemantics(
               id: 4,
               actions: <SemanticsAction>[SemanticsAction.tap],
               label: 'Hot Tub\nTab 3 of 3',
               textDirection: TextDirection.ltr,
-              nextNodeId: 1, // Should be -1
-              previousNodeId: 2,
             ),
           ],
         ),

--- a/packages/flutter/test/material/buttons_test.dart
+++ b/packages/flutter/test/material/buttons_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:ui' show SemanticsFlag;
-
 import 'package:flutter/rendering.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';

--- a/packages/flutter/test/material/card_test.dart
+++ b/packages/flutter/test/material/card_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:ui' show SemanticsFlag;
-
 import 'package:flutter/rendering.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';

--- a/packages/flutter/test/material/control_list_tile_test.dart
+++ b/packages/flutter/test/material/control_list_tile_test.dart
@@ -100,7 +100,6 @@ void main() {
       children: <TestSemantics>[
         new TestSemantics.rootChild(
           id: 1,
-          nextNodeId: 3,
           rect: new Rect.fromLTWH(0.0, 0.0, 800.0, 56.0),
           transform: null,
           flags: <SemanticsFlag>[
@@ -114,8 +113,6 @@ void main() {
         ),
         new TestSemantics.rootChild(
           id: 3,
-          previousNodeId: 1,
-          nextNodeId: 5,
           rect: new Rect.fromLTWH(0.0, 0.0, 800.0, 56.0),
           transform: new Matrix4.translationValues(0.0, 56.0, 0.0),
           flags: <SemanticsFlag>[
@@ -129,7 +126,6 @@ void main() {
         ),
         new TestSemantics.rootChild(
           id: 5,
-          previousNodeId: 3,
           rect: new Rect.fromLTWH(0.0, 0.0, 800.0, 56.0),
           transform: new Matrix4.translationValues(0.0, 112.0, 0.0),
           flags: <SemanticsFlag>[

--- a/packages/flutter/test/material/control_list_tile_test.dart
+++ b/packages/flutter/test/material/control_list_tile_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:ui' show SemanticsFlag;
-
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';

--- a/packages/flutter/test/material/date_picker_test.dart
+++ b/packages/flutter/test/material/date_picker_test.dart
@@ -4,7 +4,9 @@
 
 import 'dart:ui';
 
+import 'package:flutter/rendering.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import '../widgets/semantics_tester.dart';
@@ -393,179 +395,183 @@ void _tests() {
         children: <TestSemantics>[
           new TestSemantics(
             actions: <SemanticsAction>[SemanticsAction.tap],
-            label: r'2016',
+            label: '2016',
             textDirection: TextDirection.ltr,
           ),
           new TestSemantics(
             flags: <SemanticsFlag>[SemanticsFlag.isSelected],
             actions: <SemanticsAction>[SemanticsAction.tap],
-            label: r'Fri, Jan 15',
+            label: 'Fri, Jan 15',
             textDirection: TextDirection.ltr,
           ),
           new TestSemantics(
             children: <TestSemantics>[
               new TestSemantics(
-                actions: <SemanticsAction>[SemanticsAction.scrollLeft, SemanticsAction.scrollRight],
                 children: <TestSemantics>[
                   new TestSemantics(
+                    actions: <SemanticsAction>[SemanticsAction.scrollLeft, SemanticsAction.scrollRight],
                     children: <TestSemantics>[
                       new TestSemantics(
                         children: <TestSemantics>[
                           new TestSemantics(
-                            actions: <SemanticsAction>[SemanticsAction.tap],
-                            label: r'1, Friday, January 1, 2016',
-                            textDirection: TextDirection.ltr,
-                          ),
-                          new TestSemantics(
-                            actions: <SemanticsAction>[SemanticsAction.tap],
-                            label: r'2, Saturday, January 2, 2016',
-                            textDirection: TextDirection.ltr,
-                          ),
-                          new TestSemantics(
-                            actions: <SemanticsAction>[SemanticsAction.tap],
-                            label: r'3, Sunday, January 3, 2016',
-                            textDirection: TextDirection.ltr,
-                          ),
-                          new TestSemantics(
-                            actions: <SemanticsAction>[SemanticsAction.tap],
-                            label: r'4, Monday, January 4, 2016',
-                            textDirection: TextDirection.ltr,
-                          ),
-                          new TestSemantics(
-                            actions: <SemanticsAction>[SemanticsAction.tap],
-                            label: r'5, Tuesday, January 5, 2016',
-                            textDirection: TextDirection.ltr,
-                          ),
-                          new TestSemantics(
-                            actions: <SemanticsAction>[SemanticsAction.tap],
-                            label: r'6, Wednesday, January 6, 2016',
-                            textDirection: TextDirection.ltr,
-                          ),
-                          new TestSemantics(
-                            actions: <SemanticsAction>[SemanticsAction.tap],
-                            label: r'7, Thursday, January 7, 2016',
-                            textDirection: TextDirection.ltr,
-                          ),
-                          new TestSemantics(
-                            actions: <SemanticsAction>[SemanticsAction.tap],
-                            label: r'8, Friday, January 8, 2016',
-                            textDirection: TextDirection.ltr,
-                          ),
-                          new TestSemantics(
-                            actions: <SemanticsAction>[SemanticsAction.tap],
-                            label: r'9, Saturday, January 9, 2016',
-                            textDirection: TextDirection.ltr,
-                          ),
-                          new TestSemantics(
-                            actions: <SemanticsAction>[SemanticsAction.tap],
-                            label: r'10, Sunday, January 10, 2016',
-                            textDirection: TextDirection.ltr,
-                          ),
-                          new TestSemantics(
-                            actions: <SemanticsAction>[SemanticsAction.tap],
-                            label: r'11, Monday, January 11, 2016',
-                            textDirection: TextDirection.ltr,
-                          ),
-                          new TestSemantics(
-                            actions: <SemanticsAction>[SemanticsAction.tap],
-                            label: r'12, Tuesday, January 12, 2016',
-                            textDirection: TextDirection.ltr,
-                          ),
-                          new TestSemantics(
-                            actions: <SemanticsAction>[SemanticsAction.tap],
-                            label: r'13, Wednesday, January 13, 2016',
-                            textDirection: TextDirection.ltr,
-                          ),
-                          new TestSemantics(
-                            actions: <SemanticsAction>[SemanticsAction.tap],
-                            label: r'14, Thursday, January 14, 2016',
-                            textDirection: TextDirection.ltr,
-                          ),
-                          new TestSemantics(
-                            flags: <SemanticsFlag>[SemanticsFlag.isSelected],
-                            actions: <SemanticsAction>[SemanticsAction.tap],
-                            label: r'15, Friday, January 15, 2016',
-                            textDirection: TextDirection.ltr,
-                          ),
-                          new TestSemantics(
-                            actions: <SemanticsAction>[SemanticsAction.tap],
-                            label: r'16, Saturday, January 16, 2016',
-                            textDirection: TextDirection.ltr,
-                          ),
-                          new TestSemantics(
-                            actions: <SemanticsAction>[SemanticsAction.tap],
-                            label: r'17, Sunday, January 17, 2016',
-                            textDirection: TextDirection.ltr,
-                          ),
-                          new TestSemantics(
-                            actions: <SemanticsAction>[SemanticsAction.tap],
-                            label: r'18, Monday, January 18, 2016',
-                            textDirection: TextDirection.ltr,
-                          ),
-                          new TestSemantics(
-                            actions: <SemanticsAction>[SemanticsAction.tap],
-                            label: r'19, Tuesday, January 19, 2016',
-                            textDirection: TextDirection.ltr,
-                          ),
-                          new TestSemantics(
-                            actions: <SemanticsAction>[SemanticsAction.tap],
-                            label: r'20, Wednesday, January 20, 2016',
-                            textDirection: TextDirection.ltr,
-                          ),
-                          new TestSemantics(
-                            actions: <SemanticsAction>[SemanticsAction.tap],
-                            label: r'21, Thursday, January 21, 2016',
-                            textDirection: TextDirection.ltr,
-                          ),
-                          new TestSemantics(
-                            actions: <SemanticsAction>[SemanticsAction.tap],
-                            label: r'22, Friday, January 22, 2016',
-                            textDirection: TextDirection.ltr,
-                          ),
-                          new TestSemantics(
-                            actions: <SemanticsAction>[SemanticsAction.tap],
-                            label: r'23, Saturday, January 23, 2016',
-                            textDirection: TextDirection.ltr,
-                          ),
-                          new TestSemantics(
-                            actions: <SemanticsAction>[SemanticsAction.tap],
-                            label: r'24, Sunday, January 24, 2016',
-                            textDirection: TextDirection.ltr,
-                          ),
-                          new TestSemantics(
-                            actions: <SemanticsAction>[SemanticsAction.tap],
-                            label: r'25, Monday, January 25, 2016',
-                            textDirection: TextDirection.ltr,
-                          ),
-                          new TestSemantics(
-                            actions: <SemanticsAction>[SemanticsAction.tap],
-                            label: r'26, Tuesday, January 26, 2016',
-                            textDirection: TextDirection.ltr,
-                          ),
-                          new TestSemantics(
-                            actions: <SemanticsAction>[SemanticsAction.tap],
-                            label: r'27, Wednesday, January 27, 2016',
-                            textDirection: TextDirection.ltr,
-                          ),
-                          new TestSemantics(
-                            actions: <SemanticsAction>[SemanticsAction.tap],
-                            label: r'28, Thursday, January 28, 2016',
-                            textDirection: TextDirection.ltr,
-                          ),
-                          new TestSemantics(
-                            actions: <SemanticsAction>[SemanticsAction.tap],
-                            label: r'29, Friday, January 29, 2016',
-                            textDirection: TextDirection.ltr,
-                          ),
-                          new TestSemantics(
-                            actions: <SemanticsAction>[SemanticsAction.tap],
-                            label: r'30, Saturday, January 30, 2016',
-                            textDirection: TextDirection.ltr,
-                          ),
-                          new TestSemantics(
-                            actions: <SemanticsAction>[SemanticsAction.tap],
-                            label: r'31, Sunday, January 31, 2016',
-                            textDirection: TextDirection.ltr,
+                            children: <TestSemantics>[
+                              new TestSemantics(
+                                actions: <SemanticsAction>[SemanticsAction.tap],
+                                label: '1, Friday, January 1, 2016',
+                                textDirection: TextDirection.ltr,
+                              ),
+                              new TestSemantics(
+                                actions: <SemanticsAction>[SemanticsAction.tap],
+                                label: '2, Saturday, January 2, 2016',
+                                textDirection: TextDirection.ltr,
+                              ),
+                              new TestSemantics(
+                                actions: <SemanticsAction>[SemanticsAction.tap],
+                                label: '3, Sunday, January 3, 2016',
+                                textDirection: TextDirection.ltr,
+                              ),
+                              new TestSemantics(
+                                actions: <SemanticsAction>[SemanticsAction.tap],
+                                label: '4, Monday, January 4, 2016',
+                                textDirection: TextDirection.ltr,
+                              ),
+                              new TestSemantics(
+                                actions: <SemanticsAction>[SemanticsAction.tap],
+                                label: '5, Tuesday, January 5, 2016',
+                                textDirection: TextDirection.ltr,
+                              ),
+                              new TestSemantics(
+                                actions: <SemanticsAction>[SemanticsAction.tap],
+                                label: '6, Wednesday, January 6, 2016',
+                                textDirection: TextDirection.ltr,
+                              ),
+                              new TestSemantics(
+                                actions: <SemanticsAction>[SemanticsAction.tap],
+                                label: '7, Thursday, January 7, 2016',
+                                textDirection: TextDirection.ltr,
+                              ),
+                              new TestSemantics(
+                                actions: <SemanticsAction>[SemanticsAction.tap],
+                                label: '8, Friday, January 8, 2016',
+                                textDirection: TextDirection.ltr,
+                              ),
+                              new TestSemantics(
+                                actions: <SemanticsAction>[SemanticsAction.tap],
+                                label: '9, Saturday, January 9, 2016',
+                                textDirection: TextDirection.ltr,
+                              ),
+                              new TestSemantics(
+                                actions: <SemanticsAction>[SemanticsAction.tap],
+                                label: '10, Sunday, January 10, 2016',
+                                textDirection: TextDirection.ltr,
+                              ),
+                              new TestSemantics(
+                                actions: <SemanticsAction>[SemanticsAction.tap],
+                                label: '11, Monday, January 11, 2016',
+                                textDirection: TextDirection.ltr,
+                              ),
+                              new TestSemantics(
+                                actions: <SemanticsAction>[SemanticsAction.tap],
+                                label: '12, Tuesday, January 12, 2016',
+                                textDirection: TextDirection.ltr,
+                              ),
+                              new TestSemantics(
+                                actions: <SemanticsAction>[SemanticsAction.tap],
+                                label: '13, Wednesday, January 13, 2016',
+                                textDirection: TextDirection.ltr,
+                              ),
+                              new TestSemantics(
+                                actions: <SemanticsAction>[SemanticsAction.tap],
+                                label: '14, Thursday, January 14, 2016',
+                                textDirection: TextDirection.ltr,
+                              ),
+                              new TestSemantics(
+                                flags: <SemanticsFlag>[SemanticsFlag.isSelected],
+                                actions: <SemanticsAction>[SemanticsAction.tap],
+                                label: '15, Friday, January 15, 2016',
+                                textDirection: TextDirection.ltr,
+                              ),
+                              new TestSemantics(
+                                actions: <SemanticsAction>[SemanticsAction.tap],
+                                label: '16, Saturday, January 16, 2016',
+                                textDirection: TextDirection.ltr,
+                              ),
+                              new TestSemantics(
+                                actions: <SemanticsAction>[SemanticsAction.tap],
+                                label: '17, Sunday, January 17, 2016',
+                                textDirection: TextDirection.ltr,
+                              ),
+                              new TestSemantics(
+                                actions: <SemanticsAction>[SemanticsAction.tap],
+                                label: '18, Monday, January 18, 2016',
+                                textDirection: TextDirection.ltr,
+                              ),
+                              new TestSemantics(
+                                actions: <SemanticsAction>[SemanticsAction.tap],
+                                label: '19, Tuesday, January 19, 2016',
+                                textDirection: TextDirection.ltr,
+                              ),
+                              new TestSemantics(
+                                actions: <SemanticsAction>[SemanticsAction.tap],
+                                label: '20, Wednesday, January 20, 2016',
+                                textDirection: TextDirection.ltr,
+                              ),
+                              new TestSemantics(
+                                actions: <SemanticsAction>[SemanticsAction.tap],
+                                label: '21, Thursday, January 21, 2016',
+                                textDirection: TextDirection.ltr,
+                              ),
+                              new TestSemantics(
+                                actions: <SemanticsAction>[SemanticsAction.tap],
+                                label: '22, Friday, January 22, 2016',
+                                textDirection: TextDirection.ltr,
+                              ),
+                              new TestSemantics(
+                                actions: <SemanticsAction>[SemanticsAction.tap],
+                                label: '23, Saturday, January 23, 2016',
+                                textDirection: TextDirection.ltr,
+                              ),
+                              new TestSemantics(
+                                actions: <SemanticsAction>[SemanticsAction.tap],
+                                label: '24, Sunday, January 24, 2016',
+                                textDirection: TextDirection.ltr,
+                              ),
+                              new TestSemantics(
+                                actions: <SemanticsAction>[SemanticsAction.tap],
+                                label: '25, Monday, January 25, 2016',
+                                textDirection: TextDirection.ltr,
+                              ),
+                              new TestSemantics(
+                                actions: <SemanticsAction>[SemanticsAction.tap],
+                                label: '26, Tuesday, January 26, 2016',
+                                textDirection: TextDirection.ltr,
+                              ),
+                              new TestSemantics(
+                                actions: <SemanticsAction>[SemanticsAction.tap],
+                                label: '27, Wednesday, January 27, 2016',
+                                textDirection: TextDirection.ltr,
+                              ),
+                              new TestSemantics(
+                                actions: <SemanticsAction>[SemanticsAction.tap],
+                                label: '28, Thursday, January 28, 2016',
+                                textDirection: TextDirection.ltr,
+                              ),
+                              new TestSemantics(
+                                actions: <SemanticsAction>[SemanticsAction.tap],
+                                label: '29, Friday, January 29, 2016',
+                                textDirection: TextDirection.ltr,
+                              ),
+                              new TestSemantics(
+                                actions: <SemanticsAction>[SemanticsAction.tap],
+                                label: '30, Saturday, January 30, 2016',
+                                textDirection: TextDirection.ltr,
+                              ),
+                              new TestSemantics(
+                                actions: <SemanticsAction>[SemanticsAction.tap],
+                                label: '31, Sunday, January 31, 2016',
+                                textDirection: TextDirection.ltr,
+                              ),
+                            ],
                           ),
                         ],
                       ),
@@ -576,43 +582,27 @@ void _tests() {
             ],
           ),
           new TestSemantics(
-            flags: <SemanticsFlag>[
-              SemanticsFlag.isButton,
-              SemanticsFlag.hasEnabledState,
-              SemanticsFlag.isEnabled,
-            ],
+            flags: <SemanticsFlag>[SemanticsFlag.isButton, SemanticsFlag.hasEnabledState, SemanticsFlag.isEnabled],
             actions: <SemanticsAction>[SemanticsAction.tap],
-            label: r'Previous month December 2015',
+            label: 'Previous month December 2015',
             textDirection: TextDirection.ltr,
           ),
           new TestSemantics(
-            flags: <SemanticsFlag>[
-              SemanticsFlag.isButton,
-              SemanticsFlag.hasEnabledState,
-              SemanticsFlag.isEnabled,
-            ],
+            flags: <SemanticsFlag>[SemanticsFlag.isButton, SemanticsFlag.hasEnabledState, SemanticsFlag.isEnabled],
             actions: <SemanticsAction>[SemanticsAction.tap],
-            label: r'Next month February 2016',
+            label: 'Next month February 2016',
             textDirection: TextDirection.ltr,
           ),
           new TestSemantics(
-            flags: <SemanticsFlag>[
-              SemanticsFlag.isButton,
-              SemanticsFlag.hasEnabledState,
-              SemanticsFlag.isEnabled,
-            ],
+            flags: <SemanticsFlag>[SemanticsFlag.isButton, SemanticsFlag.hasEnabledState, SemanticsFlag.isEnabled],
             actions: <SemanticsAction>[SemanticsAction.tap],
-            label: r'CANCEL',
+            label: 'CANCEL',
             textDirection: TextDirection.ltr,
           ),
           new TestSemantics(
-            flags: <SemanticsFlag>[
-              SemanticsFlag.isButton,
-              SemanticsFlag.hasEnabledState,
-              SemanticsFlag.isEnabled,
-            ],
+            flags: <SemanticsFlag>[SemanticsFlag.isButton, SemanticsFlag.hasEnabledState, SemanticsFlag.isEnabled],
             actions: <SemanticsAction>[SemanticsAction.tap],
-            label: r'OK',
+            label: 'OK',
             textDirection: TextDirection.ltr,
           ),
         ],

--- a/packages/flutter/test/material/list_tile_test.dart
+++ b/packages/flutter/test/material/list_tile_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:ui' show SemanticsFlag;
-
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';

--- a/packages/flutter/test/material/outline_button_test.dart
+++ b/packages/flutter/test/material/outline_button_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:ui' show SemanticsFlag;
-
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/rendering.dart';

--- a/packages/flutter/test/material/tabs_test.dart
+++ b/packages/flutter/test/material/tabs_test.dart
@@ -1363,7 +1363,6 @@ void main() {
               children: <TestSemantics>[
                 new TestSemantics(
                   id: 3,
-                  nextNodeId: 4,
                   actions: SemanticsAction.tap.index,
                   flags: SemanticsFlag.isSelected.index,
                   label: 'TAB #0\nTab 1 of 2',
@@ -1372,7 +1371,6 @@ void main() {
                 ),
                 new TestSemantics(
                   id: 4,
-                  previousNodeId: 3,
                   actions: SemanticsAction.tap.index,
                   label: 'TAB #1\nTab 2 of 2',
                   rect: new Rect.fromLTRB(0.0, 0.0, 108.0, kTextTabBarHeight),
@@ -1622,7 +1620,6 @@ void main() {
               children: <TestSemantics>[
                 new TestSemantics(
                   id: 3,
-                  nextNodeId: 4,
                   actions: SemanticsAction.tap.index,
                   flags: SemanticsFlag.isSelected.index,
                   label: 'Semantics override 0\nTab 1 of 2',
@@ -1631,7 +1628,6 @@ void main() {
                 ),
                 new TestSemantics(
                   id: 4,
-                  previousNodeId: 3,
                   actions: SemanticsAction.tap.index,
                   label: 'Semantics override 1\nTab 2 of 2',
                   rect: new Rect.fromLTRB(0.0, 0.0, 108.0, kTextTabBarHeight),

--- a/packages/flutter/test/material/tabs_test.dart
+++ b/packages/flutter/test/material/tabs_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:ui' show SemanticsFlag, SemanticsAction;
-
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -4,7 +4,6 @@
 
 import 'dart:async';
 import 'dart:io' show Platform;
-import 'dart:ui' show SemanticsFlag;
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';

--- a/packages/flutter/test/material/user_accounts_drawer_header_test.dart
+++ b/packages/flutter/test/material/user_accounts_drawer_header_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:ui' show SemanticsFlag;
-
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';

--- a/packages/flutter/test/semantics/semantics_test.dart
+++ b/packages/flutter/test/semantics/semantics_test.dart
@@ -143,37 +143,16 @@ void main() {
     );
   });
 
-  test('OrdinalSortKey compares correctly', () {
-    const List<List<SemanticsSortKey>> tests = const <List<SemanticsSortKey>>[
-      const <SemanticsSortKey>[const OrdinalSortKey(0.0), const OrdinalSortKey(0.0)],
-      const <SemanticsSortKey>[const OrdinalSortKey(0.0), const OrdinalSortKey(1.0)],
-      const <SemanticsSortKey>[const OrdinalSortKey(1.0), const OrdinalSortKey(0.0)],
-      const <SemanticsSortKey>[const OrdinalSortKey(1.0), const OrdinalSortKey(1.0)],
-      const <SemanticsSortKey>[const OrdinalSortKey(0.0), const CustomSortKey(1.0)],
-      const <SemanticsSortKey>[const OrdinalSortKey(0.0), const CustomSortKey(0.0)],
-      const <SemanticsSortKey>[const CustomSortKey(0.0), const OrdinalSortKey(0.0)],
-      const <SemanticsSortKey>[const CustomSortKey(1.0), const OrdinalSortKey(0.0)],
-    ];
-    final List<int> expectedResults = <int>[0, -1, 1, 0, 0, 0, 0, 0];
-    assert(tests.length == expectedResults.length);
-    final List<int> results = <int>[];
-    for (List<SemanticsSortKey> tuple in tests) {
-      results.add(tuple[0].compareTo(tuple[1]));
-    }
-    expect(results, orderedEquals(expectedResults));
-  });
+  test('Incompatible OrdinalSortKey throw AssertionError when compared', () {
+    // Different types.
+    expect(() {
+      const OrdinalSortKey(0.0).compareTo(const CustomSortKey(0.0));
+    }, throwsAssertionError);
 
-  test('SemanticsSortKey sorts correctly when assigned names', () {
-    const SemanticsSortKey order1g1 = const CustomSortKey(0.0, name: 'group 1');
-    const SemanticsSortKey order2g1 = const CustomSortKey(1.0, name: 'group 1');
-    const SemanticsSortKey order2g2 = const CustomSortKey(1.0, name: 'group 2');
-    const SemanticsSortKey order3g2 = const OrdinalSortKey(1.0, name: 'group 1');
-    // Keys in the same group compare.
-    expect(order1g1.compareTo(order2g1), equals(-1));
-    // Keys with different names compare equal.
-    expect(order1g1.compareTo(order2g2), equals(0));
-    // Keys with same names but different types compare equal.
-    expect(order1g1.compareTo(order3g2), equals(0));
+    // Different names.
+    expect(() {
+      const OrdinalSortKey(0.0, name: 'a').compareTo(const OrdinalSortKey(0.0, name: 'b'));
+    }, throwsAssertionError);
   });
 
   test('OrdinalSortKey compares correctly', () {
@@ -182,12 +161,8 @@ void main() {
       const <SemanticsSortKey>[const OrdinalSortKey(0.0), const OrdinalSortKey(1.0)],
       const <SemanticsSortKey>[const OrdinalSortKey(1.0), const OrdinalSortKey(0.0)],
       const <SemanticsSortKey>[const OrdinalSortKey(1.0), const OrdinalSortKey(1.0)],
-      const <SemanticsSortKey>[const OrdinalSortKey(0.0), const CustomSortKey(1.0)],
-      const <SemanticsSortKey>[const OrdinalSortKey(0.0), const CustomSortKey(0.0)],
-      const <SemanticsSortKey>[const CustomSortKey(0.0), const OrdinalSortKey(0.0)],
-      const <SemanticsSortKey>[const CustomSortKey(1.0), const OrdinalSortKey(0.0)],
     ];
-    final List<int> expectedResults = <int>[0, -1, 1, 0, 0, 0, 0, 0];
+    final List<int> expectedResults = <int>[0, -1, 1, 0];
     assert(tests.length == expectedResults.length);
     final List<int> results = <int>[];
     for (List<SemanticsSortKey> tuple in tests) {
@@ -196,17 +171,20 @@ void main() {
     expect(results, orderedEquals(expectedResults));
   });
 
-  test('SemanticsSortKey sorts correctly when assigned names', () {
-    const SemanticsSortKey order1g1 = const CustomSortKey(0.0, name: 'group 1');
-    const SemanticsSortKey order2g1 = const CustomSortKey(1.0, name: 'group 1');
-    const SemanticsSortKey order2g2 = const CustomSortKey(1.0, name: 'group 2');
-    const SemanticsSortKey order3g2 = const OrdinalSortKey(1.0, name: 'group 1');
-    // Keys in the same group compare.
-    expect(order1g1.compareTo(order2g1), equals(-1));
-    // Keys with different names compare equal.
-    expect(order1g1.compareTo(order2g2), equals(0));
-    // Keys with same names but different types compare equal.
-    expect(order1g1.compareTo(order3g2), equals(0));
+  test('OrdinalSortKey compares correctly', () {
+    const List<List<SemanticsSortKey>> tests = const <List<SemanticsSortKey>>[
+      const <SemanticsSortKey>[const OrdinalSortKey(0.0), const OrdinalSortKey(0.0)],
+      const <SemanticsSortKey>[const OrdinalSortKey(0.0), const OrdinalSortKey(1.0)],
+      const <SemanticsSortKey>[const OrdinalSortKey(1.0), const OrdinalSortKey(0.0)],
+      const <SemanticsSortKey>[const OrdinalSortKey(1.0), const OrdinalSortKey(1.0)],
+    ];
+    final List<int> expectedResults = <int>[0, -1, 1, 0];
+    assert(tests.length == expectedResults.length);
+    final List<int> results = <int>[];
+    for (List<SemanticsSortKey> tuple in tests) {
+      results.add(tuple[0].compareTo(tuple[1]));
+    }
+    expect(results, orderedEquals(expectedResults));
   });
 
   test('toStringDeep respects childOrder parameter', () {

--- a/packages/flutter/test/semantics/semantics_test.dart
+++ b/packages/flutter/test/semantics/semantics_test.dart
@@ -125,7 +125,7 @@ void main() {
     expect(child2.transform, isNull);
 
     expect(
-      root.toStringDeep(childOrder: DebugSemanticsDumpOrder.geometricOrder),
+      root.toStringDeep(childOrder: DebugSemanticsDumpOrder.traversalOrder),
       'SemanticsNode#3\n'
       ' │ STALE\n'
       ' │ owner: null\n'
@@ -199,21 +199,21 @@ void main() {
       childrenInInversePaintOrder: <SemanticsNode>[child1, child2],
     );
     expect(
-      root.toStringDeep(childOrder: DebugSemanticsDumpOrder.geometricOrder),
+      root.toStringDeep(childOrder: DebugSemanticsDumpOrder.traversalOrder),
       'SemanticsNode#3\n'
       ' │ STALE\n'
       ' │ owner: null\n'
       ' │ Rect.fromLTRB(0.0, 0.0, 20.0, 5.0)\n'
       ' │\n'
-      ' ├─SemanticsNode#2\n'
+      ' ├─SemanticsNode#1\n'
       ' │   STALE\n'
       ' │   owner: null\n'
-      ' │   Rect.fromLTRB(10.0, 0.0, 15.0, 5.0)\n'
+      ' │   Rect.fromLTRB(15.0, 0.0, 20.0, 5.0)\n'
       ' │\n'
-      ' └─SemanticsNode#1\n'
+      ' └─SemanticsNode#2\n'
       '     STALE\n'
       '     owner: null\n'
-      '     Rect.fromLTRB(15.0, 0.0, 20.0, 5.0)\n'
+      '     Rect.fromLTRB(10.0, 0.0, 15.0, 5.0)\n'
     );
 
     expect(
@@ -254,36 +254,36 @@ void main() {
     );
 
     expect(
-      rootComplex.toStringDeep(childOrder: DebugSemanticsDumpOrder.geometricOrder),
+      rootComplex.toStringDeep(childOrder: DebugSemanticsDumpOrder.traversalOrder),
       'SemanticsNode#7\n'
       ' │ STALE\n'
       ' │ owner: null\n'
       ' │ Rect.fromLTRB(0.0, 0.0, 25.0, 5.0)\n'
       ' │\n'
-      ' ├─SemanticsNode#4\n'
-      ' │ │ STALE\n'
-      ' │ │ owner: null\n'
-      ' │ │ Rect.fromLTRB(0.0, 0.0, 10.0, 5.0)\n'
-      ' │ │\n'
-      ' │ ├─SemanticsNode#6\n'
-      ' │ │   STALE\n'
-      ' │ │   owner: null\n'
-      ' │ │   Rect.fromLTRB(0.0, 0.0, 5.0, 5.0)\n'
-      ' │ │\n'
-      ' │ └─SemanticsNode#5\n'
-      ' │     STALE\n'
-      ' │     owner: null\n'
-      ' │     Rect.fromLTRB(5.0, 0.0, 10.0, 5.0)\n'
+      ' ├─SemanticsNode#1\n'
+      ' │   STALE\n'
+      ' │   owner: null\n'
+      ' │   Rect.fromLTRB(15.0, 0.0, 20.0, 5.0)\n'
       ' │\n'
       ' ├─SemanticsNode#2\n'
       ' │   STALE\n'
       ' │   owner: null\n'
       ' │   Rect.fromLTRB(10.0, 0.0, 15.0, 5.0)\n'
       ' │\n'
-      ' └─SemanticsNode#1\n'
-      '     STALE\n'
-      '     owner: null\n'
-      '     Rect.fromLTRB(15.0, 0.0, 20.0, 5.0)\n'
+      ' └─SemanticsNode#4\n'
+      '   │ STALE\n'
+      '   │ owner: null\n'
+      '   │ Rect.fromLTRB(0.0, 0.0, 10.0, 5.0)\n'
+      '   │\n'
+      '   ├─SemanticsNode#5\n'
+      '   │   STALE\n'
+      '   │   owner: null\n'
+      '   │   Rect.fromLTRB(5.0, 0.0, 10.0, 5.0)\n'
+      '   │\n'
+      '   └─SemanticsNode#6\n'
+      '       STALE\n'
+      '       owner: null\n'
+      '       Rect.fromLTRB(0.0, 0.0, 5.0, 5.0)\n'
     );
 
     expect(

--- a/packages/flutter/test/semantics/semantics_test.dart
+++ b/packages/flutter/test/semantics/semantics_test.dart
@@ -345,8 +345,6 @@ void main() {
       '   decreasedValue: ""\n'
       '   hint: ""\n'
       '   textDirection: null\n'
-      '   nextNodeId: null\n'
-      '   previousNodeId: null\n'
       '   sortKey: null\n'
       '   scrollExtentMin: null\n'
       '   scrollPosition: null\n'

--- a/packages/flutter/test/widgets/custom_painter_test.dart
+++ b/packages/flutter/test/widgets/custom_painter_test.dart
@@ -150,20 +150,16 @@ void _defineTests() {
             children: <TestSemantics>[
               new TestSemantics(
                 id: 3,
-                nextNodeId: 4,
-                previousNodeId: 2,
                 label: 'background',
                 rect: new Rect.fromLTRB(1.0, 1.0, 2.0, 2.0),
               ),
               new TestSemantics(
                 id: 2,
-                nextNodeId: 3,
                 label: 'Hello',
                 rect: new Rect.fromLTRB(0.0, 0.0, 800.0, 600.0),
               ),
               new TestSemantics(
                 id: 4,
-                previousNodeId: 3,
                 label: 'foreground',
                 rect: new Rect.fromLTRB(1.0, 1.0, 2.0, 2.0),
               ),

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:ui' show SemanticsFlag;
-
 import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/material.dart';

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -600,8 +600,6 @@ void main() {
               flags: <SemanticsFlag>[SemanticsFlag.isTextField, SemanticsFlag.isObscured],
               value: expectedValue,
               textDirection: TextDirection.ltr,
-              nextNodeId: -1,
-              previousNodeId: -1,
             ),
           ],
         ),

--- a/packages/flutter/test/widgets/implicit_semantics_test.dart
+++ b/packages/flutter/test/widgets/implicit_semantics_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:ui' show SemanticsFlag;
-
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter/rendering.dart';

--- a/packages/flutter/test/widgets/implicit_semantics_test.dart
+++ b/packages/flutter/test/widgets/implicit_semantics_test.dart
@@ -79,12 +79,10 @@ void main() {
               children: <TestSemantics>[
                 new TestSemantics(
                   id: 2,
-                  nextNodeId: 3,
                   label: 'Michael Goderbauer',
                 ),
                 new TestSemantics(
                   id: 3,
-                  previousNodeId: 2,
                   label: 'goderbauer@google.com',
                 ),
               ],
@@ -235,20 +233,16 @@ void main() {
               children: <TestSemantics>[
                 new TestSemantics(
                   id: 6,
-                  nextNodeId: 7,
                   flags: SemanticsFlag.isSelected.index,
                   label: 'node 1',
                 ),
                 new TestSemantics(
                   id: 7,
-                  previousNodeId: 6,
-                  nextNodeId: 8,
                   flags: SemanticsFlag.isSelected.index,
                   label: 'node 2',
                 ),
                 new TestSemantics(
                   id: 8,
-                  previousNodeId: 7,
                   flags: SemanticsFlag.isSelected.index,
                   label: 'node 3',
                 ),

--- a/packages/flutter/test/widgets/semantics_1_test.dart
+++ b/packages/flutter/test/widgets/semantics_1_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:ui' show SemanticsFlag;
-
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';

--- a/packages/flutter/test/widgets/semantics_1_test.dart
+++ b/packages/flutter/test/widgets/semantics_1_test.dart
@@ -122,14 +122,12 @@ void main() {
           children: <TestSemantics>[
             new TestSemantics(
               id: 2,
-              nextNodeId: 3,
               label: 'child1',
               rect: new Rect.fromLTRB(0.0, 0.0, 800.0, 10.0),
               flags: SemanticsFlag.isSelected.index,
             ),
             new TestSemantics(
               id: 3,
-              previousNodeId: 2,
               label: 'child2',
               rect: new Rect.fromLTRB(0.0, 0.0, 800.0, 10.0),
               flags: SemanticsFlag.isSelected.index,
@@ -220,14 +218,12 @@ void main() {
           children: <TestSemantics>[
             new TestSemantics(
               id: 4,
-              nextNodeId: 3,
               label: 'child1',
               rect: new Rect.fromLTRB(0.0, 0.0, 800.0, 10.0),
               flags: SemanticsFlag.isSelected.index,
             ),
             new TestSemantics(
               id: 3,
-              previousNodeId: 4,
               label: 'child2',
               rect: new Rect.fromLTRB(0.0, 0.0, 800.0, 10.0),
               flags: SemanticsFlag.isSelected.index,

--- a/packages/flutter/test/widgets/semantics_2_test.dart
+++ b/packages/flutter/test/widgets/semantics_2_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:ui' show SemanticsFlag;
-
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';

--- a/packages/flutter/test/widgets/semantics_2_test.dart
+++ b/packages/flutter/test/widgets/semantics_2_test.dart
@@ -58,14 +58,12 @@ void main() {
           children: <TestSemantics>[
             new TestSemantics(
               id: 2,
-              nextNodeId: 3,
               label: 'child1',
               rect: new Rect.fromLTRB(0.0, 0.0, 800.0, 10.0),
               flags: SemanticsFlag.isSelected.index,
             ),
             new TestSemantics(
               id: 3,
-              previousNodeId: 2,
               label: 'child2',
               rect: new Rect.fromLTRB(0.0, 0.0, 800.0, 10.0),
               flags: SemanticsFlag.isSelected.index,
@@ -156,14 +154,12 @@ void main() {
           children: <TestSemantics>[
             new TestSemantics(
               id: 4,
-              nextNodeId: 3,
               label: 'child1',
               rect: new Rect.fromLTRB(0.0, 0.0, 800.0, 10.0),
               flags: SemanticsFlag.isSelected.index,
             ),
             new TestSemantics(
               id: 3,
-              previousNodeId: 4,
               label: 'child2',
               rect: new Rect.fromLTRB(0.0, 0.0, 800.0, 10.0),
               flags: SemanticsFlag.isSelected.index,

--- a/packages/flutter/test/widgets/semantics_3_test.dart
+++ b/packages/flutter/test/widgets/semantics_3_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:ui' show SemanticsFlag;
-
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';

--- a/packages/flutter/test/widgets/semantics_4_test.dart
+++ b/packages/flutter/test/widgets/semantics_4_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:ui' show SemanticsFlag;
-
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter/rendering.dart';

--- a/packages/flutter/test/widgets/semantics_4_test.dart
+++ b/packages/flutter/test/widgets/semantics_4_test.dart
@@ -54,25 +54,21 @@ void main() {
         children: <TestSemantics>[
           new TestSemantics.rootChild(
             id: 1,
-            nextNodeId: 2,
             label: 'L1',
             rect: TestSemantics.fullScreen,
           ),
           new TestSemantics.rootChild(
             id: 2,
-            previousNodeId: 1,
             label: 'L2',
             rect: TestSemantics.fullScreen,
             children: <TestSemantics>[
               new TestSemantics(
                 id: 3,
-                nextNodeId: 4,
                 flags: SemanticsFlag.hasCheckedState.index | SemanticsFlag.isChecked.index,
                 rect: TestSemantics.fullScreen,
               ),
               new TestSemantics(
                 id: 4,
-                previousNodeId: 3,
                 flags: SemanticsFlag.hasCheckedState.index,
                 rect: TestSemantics.fullScreen,
               ),
@@ -118,13 +114,11 @@ void main() {
         children: <TestSemantics>[
           new TestSemantics.rootChild(
             id: 1,
-            nextNodeId: 2,
             label: 'L1',
             rect: TestSemantics.fullScreen,
           ),
           new TestSemantics.rootChild(
             id: 2,
-            previousNodeId: 1,
             label: 'L2',
             flags: SemanticsFlag.hasCheckedState.index | SemanticsFlag.isChecked.index,
             rect: TestSemantics.fullScreen,

--- a/packages/flutter/test/widgets/semantics_5_test.dart
+++ b/packages/flutter/test/widgets/semantics_5_test.dart
@@ -37,12 +37,10 @@ void main() {
         children: <TestSemantics>[
           new TestSemantics.rootChild(
             id: 1,
-            nextNodeId: 2,
             rect: TestSemantics.fullScreen,
           ),
           new TestSemantics.rootChild(
             id: 2,
-            previousNodeId: 1,
             label: 'label',
             rect: TestSemantics.fullScreen,
           ),

--- a/packages/flutter/test/widgets/semantics_7_test.dart
+++ b/packages/flutter/test/widgets/semantics_7_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:ui' show SemanticsFlag;
-
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';

--- a/packages/flutter/test/widgets/semantics_7_test.dart
+++ b/packages/flutter/test/widgets/semantics_7_test.dart
@@ -56,7 +56,6 @@ void main() {
         children: <TestSemantics>[
           new TestSemantics.rootChild(
             id: 1,
-            nextNodeId: 4,
             flags: SemanticsFlag.hasCheckedState.index | SemanticsFlag.isChecked.index,
             label: label,
             rect: TestSemantics.fullScreen,
@@ -64,7 +63,6 @@ void main() {
           // IDs 2 and 3 are used up by the nodes that get merged in
           new TestSemantics.rootChild(
             id: 4,
-            previousNodeId: 1,
             flags: SemanticsFlag.hasCheckedState.index | SemanticsFlag.isChecked.index,
             label: label,
             rect: TestSemantics.fullScreen,
@@ -114,7 +112,6 @@ void main() {
         children: <TestSemantics>[
           new TestSemantics.rootChild(
             id: 1,
-            nextNodeId: 4,
             flags: SemanticsFlag.hasCheckedState.index | SemanticsFlag.isChecked.index,
             label: label,
             rect: TestSemantics.fullScreen,
@@ -122,7 +119,6 @@ void main() {
           // IDs 2 and 3 are used up by the nodes that get merged in
           new TestSemantics.rootChild(
             id: 4,
-            previousNodeId: 1,
             flags: SemanticsFlag.hasCheckedState.index | SemanticsFlag.isChecked.index,
             label: label,
             rect: TestSemantics.fullScreen,

--- a/packages/flutter/test/widgets/semantics_8_test.dart
+++ b/packages/flutter/test/widgets/semantics_8_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:ui' show SemanticsFlag;
-
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';

--- a/packages/flutter/test/widgets/semantics_merge_test.dart
+++ b/packages/flutter/test/widgets/semantics_merge_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:ui' show SemanticsFlag;
-
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';

--- a/packages/flutter/test/widgets/semantics_merge_test.dart
+++ b/packages/flutter/test/widgets/semantics_merge_test.dart
@@ -44,12 +44,10 @@ void main() {
           new TestSemantics.rootChild(
             id: 1,
             label: 'test1',
-            nextNodeId: 2,
           ),
           new TestSemantics.rootChild(
             id: 2,
             label: 'test2',
-            previousNodeId: 1,
           ),
         ],
       ),
@@ -113,8 +111,8 @@ void main() {
     expect(semantics, hasSemantics(
       new TestSemantics.root(
         children: <TestSemantics>[
-          new TestSemantics.rootChild(id: 6, label: 'test1', nextNodeId: 7),
-          new TestSemantics.rootChild(id: 7, label: 'test2', previousNodeId: 6),
+          new TestSemantics.rootChild(id: 6, label: 'test1'),
+          new TestSemantics.rootChild(id: 7, label: 'test2'),
         ],
       ),
       ignoreRect: true,

--- a/packages/flutter/test/widgets/semantics_test.dart
+++ b/packages/flutter/test/widgets/semantics_test.dart
@@ -661,21 +661,11 @@ void main() {
             id: 1,
             children: <TestSemantics>[
               new TestSemantics(
-                id: 2,
-                label: r'Label 1',
-                textDirection: TextDirection.ltr,
-              ),
-              new TestSemantics(
-                id: 3,
-                label: r'Label 2',
-                textDirection: TextDirection.ltr,
-              ),
-              new TestSemantics(
                 id: 4,
                 children: <TestSemantics>[
                   new TestSemantics(
-                    id: 5,
-                    label: r'Label 3',
+                    id: 7,
+                    label: r'Label 5',
                     textDirection: TextDirection.ltr,
                   ),
                   new TestSemantics(
@@ -684,11 +674,21 @@ void main() {
                     textDirection: TextDirection.ltr,
                   ),
                   new TestSemantics(
-                    id: 7,
-                    label: r'Label 5',
+                    id: 5,
+                    label: r'Label 3',
                     textDirection: TextDirection.ltr,
                   ),
                 ],
+              ),
+              new TestSemantics(
+                id: 3,
+                label: r'Label 2',
+                textDirection: TextDirection.ltr,
+              ),
+              new TestSemantics(
+                id: 2,
+                label: r'Label 1',
+                textDirection: TextDirection.ltr,
               ),
             ],
           ),
@@ -734,11 +734,6 @@ void main() {
       new TestSemantics.root(
         children: <TestSemantics>[
           new TestSemantics(
-            id: 1,
-            label: r'Label 1',
-            textDirection: TextDirection.ltr,
-          ),
-          new TestSemantics(
             id: 2,
             label: r'Label 2',
             textDirection: TextDirection.ltr,
@@ -746,6 +741,11 @@ void main() {
           new TestSemantics(
             id: 3,
             label: r'Label 3',
+            textDirection: TextDirection.ltr,
+          ),
+          new TestSemantics(
+            id: 1,
+            label: r'Label 1',
             textDirection: TextDirection.ltr,
           ),
         ],

--- a/packages/flutter/test/widgets/semantics_test.dart
+++ b/packages/flutter/test/widgets/semantics_test.dart
@@ -664,37 +664,29 @@ void main() {
                 id: 2,
                 label: r'Label 1',
                 textDirection: TextDirection.ltr,
-                previousNodeId: 3,
               ),
               new TestSemantics(
                 id: 3,
                 label: r'Label 2',
                 textDirection: TextDirection.ltr,
-                nextNodeId: 2,
-                previousNodeId: 4,
               ),
               new TestSemantics(
                 id: 4,
-                nextNodeId: 3,
                 children: <TestSemantics>[
                   new TestSemantics(
                     id: 5,
                     label: r'Label 3',
                     textDirection: TextDirection.ltr,
-                    previousNodeId: 6,
                   ),
                   new TestSemantics(
                     id: 6,
                     label: r'Label 4',
                     textDirection: TextDirection.ltr,
-                    nextNodeId: 5,
-                    previousNodeId: 7,
                   ),
                   new TestSemantics(
                     id: 7,
                     label: r'Label 5',
                     textDirection: TextDirection.ltr,
-                    nextNodeId: 6,
                   ),
                 ],
               ),
@@ -745,20 +737,16 @@ void main() {
             id: 1,
             label: r'Label 1',
             textDirection: TextDirection.ltr,
-            previousNodeId: 3,
           ),
           new TestSemantics(
             id: 2,
             label: r'Label 2',
             textDirection: TextDirection.ltr,
-            nextNodeId: 3,
           ),
           new TestSemantics(
             id: 3,
             label: r'Label 3',
             textDirection: TextDirection.ltr,
-            nextNodeId: 1,
-            previousNodeId: 2,
           ),
         ],
       ), ignoreTransform: true, ignoreRect: true));
@@ -804,22 +792,18 @@ void main() {
           new TestSemantics(
             label: r'Label 2',
             textDirection: TextDirection.ltr,
-            previousNodeId: 1,
           ),
           new TestSemantics(
             label: r'Label 3',
             textDirection: TextDirection.ltr,
-            previousNodeId: 2,
           ),
           new TestSemantics(
             label: r'Label 4',
             textDirection: TextDirection.ltr,
-            previousNodeId: 3,
           ),
           new TestSemantics(
             label: r'Label 5',
             textDirection: TextDirection.ltr,
-            previousNodeId: 4,
           ),
         ],
       ), ignoreTransform: true, ignoreRect: true, ignoreId: true),
@@ -865,12 +849,10 @@ void main() {
           new TestSemantics(
             label: r'Label 1',
             textDirection: TextDirection.ltr,
-            previousNodeId: 5,
           ),
           new TestSemantics(
             label: r'Label 2',
             textDirection: TextDirection.ltr,
-            previousNodeId: 1,
           ),
           new TestSemantics(
             label: r'Label 3',
@@ -879,12 +861,10 @@ void main() {
           new TestSemantics(
             label: r'Label 4',
             textDirection: TextDirection.ltr,
-            previousNodeId: 3,
           ),
           new TestSemantics(
             label: r'Label 5',
             textDirection: TextDirection.ltr,
-            previousNodeId: 4,
           ),
         ],
       ), ignoreTransform: true, ignoreRect: true, ignoreId: true),
@@ -972,23 +952,18 @@ void main() {
             ),
             new TestSemantics(
               flags: <SemanticsFlag>[SemanticsFlag.isButton],
-              previousNodeId: 5,
             ),
             new TestSemantics(
               flags: <SemanticsFlag>[SemanticsFlag.isButton],
-              previousNodeId: 6,
             ),
             new TestSemantics(
               flags: <SemanticsFlag>[SemanticsFlag.isButton],
-              previousNodeId: 3,
             ),
             new TestSemantics(
               flags: <SemanticsFlag>[SemanticsFlag.isButton],
-              previousNodeId: 4,
             ),
             new TestSemantics(
               flags: <SemanticsFlag>[SemanticsFlag.isButton],
-              previousNodeId: 1,
             ),
           ],
         ),

--- a/packages/flutter/test/widgets/semantics_tester.dart
+++ b/packages/flutter/test/widgets/semantics_tester.dart
@@ -43,9 +43,6 @@ class TestSemantics {
     this.decreasedValue: '',
     this.hint: '',
     this.textDirection,
-    // TODO(yjbanov): remove nextNodeId and previousNodeId.
-    int nextNodeId: -1,
-    int previousNodeId: -1,
     this.rect,
     this.transform,
     this.textSelection,
@@ -59,8 +56,6 @@ class TestSemantics {
        assert(decreasedValue != null),
        assert(hint != null),
        assert(children != null),
-       assert(nextNodeId != null),
-       assert(previousNodeId != null),
        tags = tags?.toSet() ?? new Set<SemanticsTag>();
 
   /// Creates an object with some test semantics data, with the [id] and [rect]
@@ -109,9 +104,6 @@ class TestSemantics {
     this.increasedValue: '',
     this.decreasedValue: '',
     this.textDirection,
-    // TODO(yjbanov): remove nextNodeId and previousNodeId.
-    int nextNodeId: -1,
-    int previousNodeId: -1,
     this.rect,
     Matrix4 transform,
     this.textSelection,
@@ -126,8 +118,6 @@ class TestSemantics {
        assert(hint != null),
        transform = _applyRootChildScale(transform),
        assert(children != null),
-       assert(nextNodeId != null),
-       assert(previousNodeId != null),
        tags = tags?.toSet() ?? new Set<SemanticsTag>();
 
   /// The unique identifier for this node.
@@ -557,10 +547,6 @@ class SemanticsTester {
       buf.writeln('  hint: \'${node.hint}\',');
     if (node.textDirection != null)
       buf.writeln('  textDirection: ${node.textDirection},');
-    if (node.nextNodeId != null && node.nextNodeId != -1)
-      buf.writeln('  nextNodeId: ${node.nextNodeId},');
-    if (node.previousNodeId != null && node.previousNodeId != -1)
-      buf.writeln('  previousNodeId: ${node.previousNodeId},');
 
     if (node.hasChildren) {
       buf.writeln('  children: <TestSemantics>[');

--- a/packages/flutter/test/widgets/semantics_tester.dart
+++ b/packages/flutter/test/widgets/semantics_tester.dart
@@ -620,7 +620,7 @@ Matcher hasSemantics(TestSemantics semantics, {
   bool ignoreRect: false,
   bool ignoreTransform: false,
   bool ignoreId: false,
-  DebugSemanticsDumpOrder childOrder: DebugSemanticsDumpOrder.inverseHitTest,
+  DebugSemanticsDumpOrder childOrder: DebugSemanticsDumpOrder.traversalOrder,
 }) {
   return new _HasSemantics(
     semantics,

--- a/packages/flutter/test/widgets/semantics_tester.dart
+++ b/packages/flutter/test/widgets/semantics_tester.dart
@@ -43,8 +43,9 @@ class TestSemantics {
     this.decreasedValue: '',
     this.hint: '',
     this.textDirection,
-    this.nextNodeId: -1,
-    this.previousNodeId: -1,
+    // TODO(yjbanov): remove nextNodeId and previousNodeId.
+    int nextNodeId: -1,
+    int previousNodeId: -1,
     this.rect,
     this.transform,
     this.textSelection,
@@ -87,8 +88,6 @@ class TestSemantics {
        assert(hint != null),
        rect = TestSemantics.rootRect,
        assert(children != null),
-       nextNodeId = null,
-       previousNodeId = null,
        tags = tags?.toSet() ?? new Set<SemanticsTag>();
 
   /// Creates an object with some test semantics data, with the [id] and [rect]
@@ -110,8 +109,9 @@ class TestSemantics {
     this.increasedValue: '',
     this.decreasedValue: '',
     this.textDirection,
-    this.nextNodeId: -1,
-    this.previousNodeId: -1,
+    // TODO(yjbanov): remove nextNodeId and previousNodeId.
+    int nextNodeId: -1,
+    int previousNodeId: -1,
     this.rect,
     Matrix4 transform,
     this.textSelection,
@@ -179,14 +179,6 @@ class TestSemantics {
   /// label is present on the [SemanticsNode], a [SemanticsNode.textDirection]
   /// is also set.
   final TextDirection textDirection;
-
-  /// The ID of the node that is next in the semantics traversal order after
-  /// this node.
-  final int nextNodeId;
-
-  /// The ID of the node that is previous in the semantics traversal order before
-  /// this node.
-  final int previousNodeId;
 
   /// The bounding box for this node in its coordinate system.
   ///
@@ -269,10 +261,6 @@ class TestSemantics {
       return fail('expected node id $id to have hint "$hint" but found hint "${nodeData.hint}".');
     if (textDirection != null && textDirection != nodeData.textDirection)
       return fail('expected node id $id to have textDirection "$textDirection" but found "${nodeData.textDirection}".');
-    if (!ignoreId && nextNodeId != nodeData.nextNodeId)
-      return fail('expected node id $id to have nextNodeId "$nextNodeId" but found "${nodeData.nextNodeId}".');
-    if (!ignoreId && previousNodeId != nodeData.previousNodeId)
-      return fail('expected node id $id to have previousNodeId "$previousNodeId" but found "${nodeData.previousNodeId}".');
     if ((nodeData.label != '' || nodeData.value != '' || nodeData.hint != '' || node.increasedValue != '' || node.decreasedValue != '') && nodeData.textDirection == null)
       return fail('expected node id $id, which has a label, value, or hint, to have a textDirection, but it did not.');
     if (!ignoreRect && rect != nodeData.rect)
@@ -324,10 +312,6 @@ class TestSemantics {
       buf.writeln('$indent  hint: \'$hint\',');
     if (textDirection != null)
       buf.writeln('$indent  textDirection: $textDirection,');
-    if (nextNodeId != null)
-      buf.writeln('$indent  nextNodeId: $nextNodeId,');
-    if (previousNodeId != null)
-      buf.writeln('$indent  previousNodeId: $previousNodeId,');
     if (textSelection?.isValid == true)
       buf.writeln('$indent  textSelection:\n[${textSelection.start}, ${textSelection.end}],');
     if (rect != null)

--- a/packages/flutter/test/widgets/semantics_tester.dart
+++ b/packages/flutter/test/widgets/semantics_tester.dart
@@ -10,6 +10,7 @@ import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:meta/meta.dart';
 
+export 'dart:ui' show SemanticsFlag, SemanticsAction;
 export 'package:flutter/rendering.dart' show SemanticsData;
 
 const String _matcherHelp = 'Try dumping the semantics with debugDumpSemanticsTree(DebugSemanticsDumpOrder.inverseHitTest) from the package:flutter/rendering.dart library to see what the semantics tree looks like.';

--- a/packages/flutter/test/widgets/semantics_tester_generateTestSemanticsExpressionForCurrentSemanticsTree_test.dart
+++ b/packages/flutter/test/widgets/semantics_tester_generateTestSemanticsExpressionForCurrentSemanticsTree_test.dart
@@ -55,7 +55,7 @@ void _tests() {
     final SemanticsTester semantics = new SemanticsTester(tester);
     await pumpTestWidget(tester);
     final String code = semantics
-      .generateTestSemanticsExpressionForCurrentSemanticsTree()
+      .generateTestSemanticsExpressionForCurrentSemanticsTree(DebugSemanticsDumpOrder.inverseHitTest)
       .split('\n')
       .map((String line) => line.trim())
       .join('\n')

--- a/packages/flutter/test/widgets/semantics_tester_generateTestSemanticsExpressionForCurrentSemanticsTree_test.dart
+++ b/packages/flutter/test/widgets/semantics_tester_generateTestSemanticsExpressionForCurrentSemanticsTree_test.dart
@@ -119,7 +119,6 @@ void _tests() {
                           tags: <SemanticsTag>[const SemanticsTag('RenderViewport.twoPane')],
                           label: 'Plain text',
                           textDirection: TextDirection.ltr,
-                          nextNodeId: 4,
                         ),
                         new TestSemantics(
                           id: 4,
@@ -132,7 +131,6 @@ void _tests() {
                           decreasedValue: 'test-decreasedValue',
                           hint: 'test-hint',
                           textDirection: TextDirection.rtl,
-                          previousNodeId: 3,
                         ),
                       ],
                     ),

--- a/packages/flutter/test/widgets/semantics_tester_generateTestSemanticsExpressionForCurrentSemanticsTree_test.dart
+++ b/packages/flutter/test/widgets/semantics_tester_generateTestSemanticsExpressionForCurrentSemanticsTree_test.dart
@@ -4,7 +4,6 @@
 
 import 'dart:async';
 import 'dart:io';
-import 'dart:ui' show SemanticsFlag;
 
 import 'package:flutter/material.dart';
 import 'package:flutter/semantics.dart';

--- a/packages/flutter/test/widgets/semantics_traversal_test.dart
+++ b/packages/flutter/test/widgets/semantics_traversal_test.dart
@@ -295,7 +295,7 @@ class TraversalTester {
     assert(children is LinkedHashMap);
     await tester.pumpWidget(
         new Container(
-            child: Directionality(
+            child: new Directionality(
               textDirection: textDirection,
               child: new Semantics(
                 textDirection: textDirection,

--- a/packages/flutter/test/widgets/semantics_traversal_test.dart
+++ b/packages/flutter/test/widgets/semantics_traversal_test.dart
@@ -1,0 +1,365 @@
+// Copyright 2018 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:collection';
+import 'dart:math' as math;
+import 'dart:ui';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter/semantics.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'semantics_tester.dart';
+
+typedef Future<Null> TraversalTestFunction(TraversalTester tester);
+const Size tenByTen = const Size(10.0, 10.0);
+
+void main() {
+  setUp(() {
+    debugResetSemanticsIdCounter();
+  });
+
+  void testTraversal(String description, TraversalTestFunction testFunction) {
+    testWidgets(description, (WidgetTester tester) async {
+      final TraversalTester traversalTester = new TraversalTester(tester);
+      await testFunction(traversalTester);
+      traversalTester.dispose();
+    });
+  }
+
+  // ┌───┐ ┌───┐
+  // │ A │>│ B │
+  // └───┘ └───┘
+  testTraversal('Semantics traverses horizontally left-to-right', (TraversalTester tester) async {
+    await tester.test(
+      textDirection: TextDirection.ltr,
+      children: <String, Rect>{
+        'A': const Offset(0.0, 0.0) & tenByTen,
+        'B': const Offset(20.0, 0.0) & tenByTen,
+      },
+      expectedTraversal: 'A B',
+    );
+  });
+
+  // ┌───┐ ┌───┐
+  // │ A │<│ B │
+  // └───┘ └───┘
+  testTraversal('Semantics traverses horizontally right-to-left', (TraversalTester tester) async {
+    await tester.test(
+      textDirection: TextDirection.rtl,
+      children: <String, Rect>{
+        'A': const Offset(0.0, 0.0) & tenByTen,
+        'B': const Offset(20.0, 0.0) & tenByTen,
+      },
+      expectedTraversal: 'B A',
+    );
+  });
+
+  // ┌───┐
+  // │ A │
+  // └───┘
+  //   V
+  // ┌───┐
+  // │ B │
+  // └───┘
+  testTraversal('Semantics traverses vertically top-to-bottom', (TraversalTester tester) async {
+    for (TextDirection textDirection in TextDirection.values) {
+      await tester.test(
+        textDirection: textDirection,
+        children: <String, Rect>{
+          'A': const Offset(0.0, 0.0) & tenByTen,
+          'B': const Offset(0.0, 20.0) & tenByTen,
+        },
+        expectedTraversal: 'A B',
+      );
+    }
+  });
+
+  // ┌───┐ ┌───┐
+  // │ A │>│ B │
+  // └───┘ └───┘
+  //   ┌─────┘
+  //   V
+  // ┌───┐ ┌───┐
+  // │ C │>│ D │
+  // └───┘ └───┘
+  testTraversal('Semantics traverses a grid left-to-right', (TraversalTester tester) async {
+    await tester.test(
+      textDirection: TextDirection.ltr,
+      children: <String, Rect>{
+        'A': const Offset(0.0, 0.0) & tenByTen,
+        'B': const Offset(20.0, 0.0) & tenByTen,
+        'C': const Offset(0.0, 20.0) & tenByTen,
+        'D': const Offset(20.0, 20.0) & tenByTen,
+      },
+      expectedTraversal: 'A B C D',
+    );
+  });
+
+  // ┌───┐ ┌───┐
+  // │ A │<│ B │
+  // └───┘ └───┘
+  //   └─────┐
+  //         V
+  // ┌───┐ ┌───┐
+  // │ C │<│ D │
+  // └───┘ └───┘
+  testTraversal('Semantics traverses a grid right-to-left', (TraversalTester tester) async {
+    await tester.test(
+      textDirection: TextDirection.rtl,
+      children: <String, Rect>{
+        'A': const Offset(0.0, 0.0) & tenByTen,
+        'B': const Offset(20.0, 0.0) & tenByTen,
+        'C': const Offset(0.0, 20.0) & tenByTen,
+        'D': const Offset(20.0, 20.0) & tenByTen,
+      },
+      expectedTraversal: 'B A D C',
+    );
+  });
+
+  // ┌───┐           ┌───┐
+  // │ A │           │ C │
+  // └───┘<->┌───┐<->└───┘
+  //         │ B │
+  //         └───┘
+  testTraversal('Semantics traverses vertically overlapping nodes horizontally', (TraversalTester tester) async {
+    final Map<String, Rect> children = <String, Rect>{
+      'A': const Offset(0.0, 0.0) & tenByTen,
+      'B': const Offset(20.0, 5.0) & tenByTen,
+      'C': const Offset(40.0, 0.0) & tenByTen,
+    };
+
+    await tester.test(
+      textDirection: TextDirection.ltr,
+      children: children,
+      expectedTraversal: 'A B C',
+    );
+
+    await tester.test(
+      textDirection: TextDirection.rtl,
+      children: children,
+      expectedTraversal: 'C B A',
+    );
+  });
+
+  // LTR:
+  // ┌───┐ ┌───┐ ┌───┐ ┌───┐
+  // │ A │>│ B │>│ C │>│ D │
+  // └───┘ └───┘ └───┘ └───┘
+  //   ┌─────────────────┘
+  //   V
+  // ┌───┐ ┌─────────┐ ┌───┐
+  // │ E │ │         │>│ H │
+  // └───┘ │    G    │ └───┘
+  //   V   │         │   V
+  // ┌───┐ │         │ ┌───┐
+  // │ F │>│         │ │ I │
+  // └───┘ └─────────┘ └───┘
+  //   ┌─────────────────┘
+  //   V
+  // ┌───┐ ┌───┐ ┌───┐ ┌───┐
+  // │ J │>│ K │>│ L │>│ M │
+  // └───┘ └───┘ └───┘ └───┘
+  //
+  // RTL:
+  // ┌───┐ ┌───┐ ┌───┐ ┌───┐
+  // │ A │<│ B │<│ C │<│ D │
+  // └───┘ └───┘ └───┘ └───┘
+  //   └─────────────────┐
+  //                     V
+  // ┌───┐ ┌─────────┐ ┌───┐
+  // │ E │<│         │ │ H │
+  // └───┘ │    G    │ └───┘
+  //   V   │         │   V
+  // ┌───┐ │         │ ┌───┐
+  // │ F │ │         │<│ I │
+  // └───┘ └─────────┘ └───┘
+  //   └─────────────────┐
+  //                     V
+  // ┌───┐ ┌───┐ ┌───┐ ┌───┐
+  // │ J │<│ K │<│ L │<│ M │
+  // └───┘ └───┘ └───┘ └───┘
+  testTraversal('Semantics traverses vertical groups, then horizontal groups, then knots', (TraversalTester tester) async {
+    final Map<String, Rect> children = <String, Rect>{
+      'A': const Offset(0.0, 0.0) & tenByTen,
+      'B': const Offset(20.0, 0.0) & tenByTen,
+      'C': const Offset(40.0, 0.0) & tenByTen,
+      'D': const Offset(60.0, 0.0) & tenByTen,
+      'E': const Offset(0.0, 20.0) & tenByTen,
+      'F': const Offset(0.0, 40.0) & tenByTen,
+      'G': const Offset(20.0, 20.0) & (tenByTen * 2.0),
+      'H': const Offset(60.0, 20.0) & tenByTen,
+      'I': const Offset(60.0, 40.0) & tenByTen,
+      'J': const Offset(0.0, 60.0) & tenByTen,
+      'K': const Offset(20.0, 60.0) & tenByTen,
+      'L': const Offset(40.0, 60.0) & tenByTen,
+      'M': const Offset(60.0, 60.0) & tenByTen,
+    };
+
+    await tester.test(
+      textDirection: TextDirection.ltr,
+      children: children,
+      expectedTraversal: 'A B C D E F G H I J K L M',
+    );
+
+    await tester.test(
+      textDirection: TextDirection.rtl,
+      children: children,
+      expectedTraversal: 'D C B A H I G E F M L K J',
+    );
+  });
+
+  // The following test tests traversal of the simplest "knot", which is two
+  // nodes overlapping both vertically and horizontally. For example:
+  //
+  // ┌─────────┐
+  // │         │
+  // │   A     │
+  // │     ┌───┼─────┐
+  // │     │   │     │
+  // └─────┼───┘     │
+  //       │     B   │
+  //       │         │
+  //       └─────────┘
+  //
+  // The outcome depends on the relative positions of the centers of `Rect`s of
+  // their respective boxes, specifically the direction (i.e. angle) of the
+  // vector pointing from A to B. We test different angles, one for each octant:
+  //
+  //  -3π/4 -π/2  -π/4
+  //      ╲   │   ╱
+  //       ╲ 1│2 ╱
+  //        ╲ │ ╱
+  //     i=0 ╲│╱ 3
+  //  π ──────┼────── 0
+  //       7 ╱│╲ 4
+  //        ╱ │ ╲
+  //       ╱ 6│5 ╲
+  //      ╱   │   ╲
+  //   3π/4  π/2   π/4
+  //
+  // For LTR, angles falling into octants 3, 4, 5, and 6, produce A -> B, all
+  // others produce B -> A.
+  //
+  // For RTL, angles falling into octants 5, 6, 7, and 0, produce A -> B, all
+  // others produce B -> A.
+  testTraversal('Semantics sorts knots', (TraversalTester tester) async {
+    const double start = -math.pi + math.pi / 8.0;
+
+    for (int i = 0; i < 8; i += 1) {
+      final double angle = start + i.toDouble() * math.pi / 4.0;
+      final double dx = math.cos(angle) * 5.0;
+      final double dy = math.sin(angle) * 5.0;
+
+      final Map<String, Rect> children = <String, Rect>{
+        'A': const Offset(10.0, 10.0) & tenByTen,
+        'B': new Offset(10.0 + dx, 10.0 + dy) & tenByTen,
+      };
+
+      try {
+        await tester.test(
+          textDirection: TextDirection.ltr,
+          children: children,
+          expectedTraversal: 3 <= i && i <= 6 ? 'A B' : 'B A',
+        );
+
+        await tester.test(
+          textDirection: TextDirection.rtl,
+          children: children,
+          expectedTraversal: 1 <= i && i <= 4 ? 'B A' : 'A B',
+        );
+      } catch (error) {
+        fail(
+          'Test failed with i == $i, angle == ${angle / math.pi}π\n'
+          '$error'
+        );
+      }
+    }
+  });
+}
+
+class TraversalTester {
+  TraversalTester(this.tester) : semantics = new SemanticsTester(tester);
+
+  final WidgetTester tester;
+  final SemanticsTester semantics;
+
+  Future<Null> test({
+    TextDirection textDirection,
+    Map<String, Rect> children,
+    String expectedTraversal,
+  }) async {
+    assert(children is LinkedHashMap);
+    await tester.pumpWidget(
+        new Container(
+            child: Directionality(
+              textDirection: textDirection,
+              child: new Semantics(
+                textDirection: textDirection,
+                child: new CustomMultiChildLayout(
+                  delegate: new TestLayoutDelegate(children),
+                  children: children.keys.map<Widget>((String label) {
+                    return new LayoutId(
+                      id: label,
+                      child: new Semantics(
+                        container: true,
+                        explicitChildNodes: true,
+                        label: label,
+                        child: new SizedBox(
+                          width: children[label].width,
+                          height: children[label].height,
+                        ),
+                      ),
+                    );
+                  }).toList(),
+                ),
+              ),
+            )
+        )
+    );
+
+    expect(semantics, hasSemantics(
+      new TestSemantics.root(
+        children: <TestSemantics>[
+          new TestSemantics.rootChild(
+            textDirection: textDirection,
+            children: expectedTraversal.split(' ').map<TestSemantics>((String label) {
+              return new TestSemantics(
+                label: label,
+              );
+            }).toList(),
+          )
+        ],
+      ),
+      ignoreTransform: true,
+      ignoreRect: true,
+      ignoreId: true,
+      childOrder: DebugSemanticsDumpOrder.traversalOrder,
+    ));
+  }
+
+  void dispose() {
+    semantics.dispose();
+  }
+}
+
+class TestLayoutDelegate extends MultiChildLayoutDelegate {
+
+  TestLayoutDelegate(this.children);
+
+  final Map<String, Rect> children;
+
+  @override
+  void performLayout(Size size) {
+    children.forEach((String label, Rect rect) {
+      layoutChild(label, new BoxConstraints.loose(size));
+      positionChild(label, rect.topLeft);
+    });
+  }
+
+  @override
+  bool shouldRelayout(MultiChildLayoutDelegate oldDelegate) => oldDelegate == this;
+}

--- a/packages/flutter/test/widgets/sliver_semantics_test.dart
+++ b/packages/flutter/test/widgets/sliver_semantics_test.dart
@@ -13,6 +13,16 @@ import 'package:vector_math/vector_math_64.dart';
 import 'semantics_tester.dart';
 
 void main() {
+  group('Sliver Semantics', () {
+    setUp(() {
+      debugResetSemanticsIdCounter();
+    });
+
+    _tests();
+  });
+}
+
+void _tests() {
   testWidgets('excludeFromScrollable works correctly', (WidgetTester tester) async {
     final SemanticsTester semantics = new SemanticsTester(tester);
 
@@ -56,28 +66,24 @@ void main() {
             tags: <SemanticsTag>[RenderViewport.useTwoPaneSemantics],
             children: <TestSemantics>[
               new TestSemantics(
-                id: 5,
+                id: 6,
                 actions: <SemanticsAction>[SemanticsAction.scrollUp],
                 children: <TestSemantics>[
                   new TestSemantics(
                     id: 2,
                     label: r'Item 0',
                     textDirection: TextDirection.ltr,
-                    nextNodeId: 3,
-                    previousNodeId: 4,
                   ),
                   new TestSemantics(
                     id: 3,
                     label: r'Item 1',
                     textDirection: TextDirection.ltr,
-                    previousNodeId: 2,
                   ),
                   new TestSemantics(
                     id: 4,
                     flags: <SemanticsFlag>[SemanticsFlag.namesRoute],
                     label: r'Semantics Test with Slivers',
                     textDirection: TextDirection.ltr,
-                    nextNodeId: 2,
                   ),
                 ],
               ),
@@ -102,28 +108,23 @@ void main() {
             tags: <SemanticsTag>[RenderViewport.useTwoPaneSemantics],
             children: <TestSemantics>[
               new TestSemantics(
-                id: 5,
+                id: 6,
                 actions: <SemanticsAction>[SemanticsAction.scrollUp, SemanticsAction.scrollDown],
-                nextNodeId: 4,
                 children: <TestSemantics>[
                   new TestSemantics(
                     id: 2,
                     label: r'Item 0',
                     textDirection: TextDirection.ltr,
-                    nextNodeId: 3,
                   ),
                   new TestSemantics(
                     id: 3,
                     label: r'Item 1',
                     textDirection: TextDirection.ltr,
-                    nextNodeId: 6,
-                    previousNodeId: 2,
                   ),
                   new TestSemantics(
-                    id: 6,
+                    id: 7,
                     label: r'Item 2',
                     textDirection: TextDirection.ltr,
-                    previousNodeId: 3,
                   ),
                 ],
               ),
@@ -132,7 +133,6 @@ void main() {
                 flags: <SemanticsFlag>[SemanticsFlag.namesRoute],
                 label: r'Semantics Test with Slivers',
                 textDirection: TextDirection.ltr,
-                previousNodeId: 5,
               ),
             ],
           ),
@@ -155,35 +155,29 @@ void main() {
             tags: <SemanticsTag>[RenderViewport.useTwoPaneSemantics],
             children: <TestSemantics>[
               new TestSemantics(
-                id: 5,
+                id: 6,
                 actions: <SemanticsAction>[SemanticsAction.scrollUp, SemanticsAction.scrollDown],
                 children: <TestSemantics>[
                   new TestSemantics(
                     id: 2,
                     label: r'Item 0',
                     textDirection: TextDirection.ltr,
-                    nextNodeId: 3,
-                    previousNodeId: 4,
                   ),
                   new TestSemantics(
                     id: 3,
                     label: r'Item 1',
                     textDirection: TextDirection.ltr,
-                    nextNodeId: 6,
-                    previousNodeId: 2,
                   ),
                   new TestSemantics(
-                    id: 6,
+                    id: 7,
                     label: r'Item 2',
                     textDirection: TextDirection.ltr,
-                    previousNodeId: 3,
                   ),
                   new TestSemantics(
                     id: 4,
                     flags: <SemanticsFlag>[SemanticsFlag.namesRoute],
                     label: r'Semantics Test with Slivers',
                     textDirection: TextDirection.ltr,
-                    nextNodeId: 2,
                   ),
                 ],
               ),
@@ -233,24 +227,22 @@ void main() {
       new TestSemantics.root(
         children: <TestSemantics>[
           new TestSemantics.rootChild(
-            id: 7,
+            id: 1,
             tags: <SemanticsTag>[RenderViewport.useTwoPaneSemantics],
             children: <TestSemantics>[
               new TestSemantics(
-                id: 10,
+                id: 4,
                 actions: <SemanticsAction>[SemanticsAction.scrollUp, SemanticsAction.scrollDown],
                 children: <TestSemantics>[
                   new TestSemantics(
-                    id: 8,
+                    id: 2,
                     label: 'Item 2',
                     textDirection: TextDirection.ltr,
-                    previousNodeId: 9,
                   ),
                   new TestSemantics(
-                    id: 9,
+                    id: 3,
                     label: 'Item 1',
                     textDirection: TextDirection.ltr,
-                    nextNodeId: 8,
                   ),
                 ],
               ),
@@ -289,44 +281,36 @@ void main() {
       new TestSemantics.root(
         children: <TestSemantics>[
           new TestSemantics.rootChild(
-            id: 11,
+            id: 1,
             tags: <SemanticsTag>[RenderViewport.useTwoPaneSemantics],
             children: <TestSemantics>[
               new TestSemantics(
-                id: 17,
+                id: 7,
                 children: <TestSemantics>[
                   new TestSemantics(
-                    id: 12,
+                    id: 2,
                     label: 'Item 4',
                     textDirection: TextDirection.ltr,
-                    previousNodeId: 13,
                   ),
                   new TestSemantics(
-                    id: 13,
+                    id: 3,
                     label: 'Item 3',
                     textDirection: TextDirection.ltr,
-                    nextNodeId: 12,
-                    previousNodeId: 14,
                   ),
                   new TestSemantics(
-                    id: 14,
+                    id: 4,
                     label: 'Item 2',
                     textDirection: TextDirection.ltr,
-                    nextNodeId: 13,
-                    previousNodeId: 15,
                   ),
                   new TestSemantics(
-                    id: 15,
+                    id: 5,
                     label: 'Item 1',
                     textDirection: TextDirection.ltr,
-                    nextNodeId: 14,
-                    previousNodeId: 16,
                   ),
                   new TestSemantics(
-                    id: 16,
+                    id: 6,
                     label: 'Item 0',
                     textDirection: TextDirection.ltr,
-                    nextNodeId: 15,
                   ),
                 ],
               ),
@@ -378,49 +362,50 @@ void main() {
       new TestSemantics.root(
         children: <TestSemantics>[
           new TestSemantics.rootChild(
-            id: 18,
+            id: 1,
             rect: TestSemantics.fullScreen,
             tags: <SemanticsTag>[RenderViewport.useTwoPaneSemantics],
             children: <TestSemantics>[
               new TestSemantics(
-                id: 23,
-                nextNodeId: 22,
+                id: 7,
                 actions: SemanticsAction.scrollUp.index | SemanticsAction.scrollDown.index,
                 rect: TestSemantics.fullScreen,
                 children: <TestSemantics>[
                   // Item 0 is missing because its covered by the app bar.
                   new TestSemantics(
-                    id: 19,
-                    nextNodeId: 20,
+                    id: 2,
                     rect: new Rect.fromLTRB(0.0, 0.0, 800.0, 200.0),
                     // Item 1 starts 20.0dp below edge, so there would be room for Item 0.
                     transform: new Matrix4.translation(new Vector3(0.0, 20.0, 0.0)),
                     label: 'Item 1',
                   ),
                   new TestSemantics(
-                    id: 20,
-                    nextNodeId: 21,
-                    previousNodeId: 19,
+                    id: 3,
                     rect: new Rect.fromLTRB(0.0, 0.0, 800.0, 200.0),
                     transform: new Matrix4.translation(new Vector3(0.0, 220.0, 0.0)),
                     label: 'Item 2',
                   ),
                   new TestSemantics(
-                    id: 21,
+                    id: 4,
                     rect: new Rect.fromLTRB(0.0, 0.0, 800.0, 200.0),
                     transform: new Matrix4.translation(new Vector3(0.0, 420.0, 0.0)),
                     label: 'Item 3',
-                    previousNodeId: 20,
                   ),
                 ],
               ),
               new TestSemantics(
-                id: 22,
+                id: 5,
                 rect: new Rect.fromLTRB(0.0, 0.0, 120.0, 20.0),
                 flags: <SemanticsFlag>[SemanticsFlag.namesRoute],
                 tags: <SemanticsTag>[RenderViewport.excludeFromScrolling],
-                label: 'AppBar',
-                previousNodeId: 23,
+                children: <TestSemantics>[
+                  new TestSemantics(
+                    id: 6,
+                    label: 'AppBar',
+                    rect: new Rect.fromLTRB(0.0, 0.0, 120.0, 20.0),
+                    textDirection: TextDirection.ltr,
+                  ),
+                ],
               ),
             ],
           )
@@ -468,34 +453,29 @@ void main() {
       new TestSemantics.root(
         children: <TestSemantics>[
           new TestSemantics.rootChild(
-            id: 24,
+            id: 1,
             rect: TestSemantics.fullScreen,
             tags: <SemanticsTag>[RenderViewport.useTwoPaneSemantics],
             children: <TestSemantics>[
               new TestSemantics(
-                id: 29,
-                nextNodeId: 28,
+                id: 7,
                 actions: SemanticsAction.scrollUp.index | SemanticsAction.scrollDown.index,
                 rect: TestSemantics.fullScreen,
                 children: <TestSemantics>[
                   new TestSemantics(
-                    id: 25,
-                    previousNodeId: 26,
+                    id: 2,
                     rect: new Rect.fromLTRB(0.0, 0.0, 800.0, 200.0),
                     transform: new Matrix4.translation(new Vector3(0.0, 420.0, 0.0)),
                     label: 'Item 3',
                   ),
                   new TestSemantics(
-                    id: 26,
-                    nextNodeId: 25,
-                    previousNodeId: 27,
+                    id: 3,
                     rect: new Rect.fromLTRB(0.0, 0.0, 800.0, 200.0),
                     transform: new Matrix4.translation(new Vector3(0.0, 220.0, 0.0)),
                     label: 'Item 2',
                   ),
                   new TestSemantics(
-                    id: 27,
-                    nextNodeId: 26,
+                    id: 4,
                     rect: new Rect.fromLTRB(0.0, 0.0, 800.0, 200.0),
                     // Item 1 starts 20.0dp below edge, so there would be room for Item 0.
                     transform: new Matrix4.translation(new Vector3(0.0, 20.0, 0.0)),
@@ -505,12 +485,18 @@ void main() {
                 ],
               ),
               new TestSemantics(
-                id: 28,
+                id: 5,
                 previousNodeId: 29,
                 rect: new Rect.fromLTRB(0.0, 0.0, 120.0, 20.0),
                 flags: <SemanticsFlag>[SemanticsFlag.namesRoute],
                 tags: <SemanticsTag>[RenderViewport.excludeFromScrolling],
-                label: 'AppBar'
+                children: <TestSemantics>[
+                  new TestSemantics(
+                    id: 6,
+                    rect: new Rect.fromLTRB(0.0, 0.0, 120.0, 20.0),
+                    label: 'AppBar',
+                  ),
+                ],
               ),
             ],
           )
@@ -560,50 +546,48 @@ void main() {
       new TestSemantics.root(
         children: <TestSemantics>[
           new TestSemantics.rootChild(
-            id: 30,
+            id: 1,
             rect: TestSemantics.fullScreen,
             tags: <SemanticsTag>[RenderViewport.useTwoPaneSemantics],
             children: <TestSemantics>[
               new TestSemantics(
-                id: 35,
-                nextNodeId: 34,
+                id: 7,
                 actions: SemanticsAction.scrollUp.index | SemanticsAction.scrollDown.index,
                 rect: TestSemantics.fullScreen,
                 children: <TestSemantics>[
                   // Item 0 is missing because its covered by the app bar.
                   new TestSemantics(
-                    id: 31,
-                    previousNodeId: 32,
+                    id: 2,
                     // Item 1 ends at 580dp, so there would be 20dp space for Item 0.
                     rect: new Rect.fromLTRB(0.0, 0.0, 800.0, 200.0),
-                    transform: new Matrix4.translation(new Vector3(0.0, 380.0, 0.0)),
                     label: 'Item 1',
                   ),
                   new TestSemantics(
-                    id: 32,
-                    nextNodeId: 31,
-                    previousNodeId: 33,
+                    id: 3,
                     rect: new Rect.fromLTRB(0.0, 0.0, 800.0, 200.0),
-                    transform: new Matrix4.translation(new Vector3(0.0, 180.0, 0.0)),
                     label: 'Item 2',
                   ),
                   new TestSemantics(
-                    id: 33,
-                    nextNodeId: 32,
+                    id: 4,
                     rect: new Rect.fromLTRB(0.0, 0.0, 800.0, 200.0),
-                    transform: new Matrix4.translation(new Vector3(0.0, -20.0, 0.0)),
                     label: 'Item 3',
                   ),
                 ],
               ),
               new TestSemantics(
-                id: 34,
-                previousNodeId: 35,
+                id: 5,
                 rect: new Rect.fromLTRB(0.0, 0.0, 120.0, 20.0),
                 transform: new Matrix4.translation(new Vector3(0.0, 544.0, 0.0)),
                 flags: <SemanticsFlag>[SemanticsFlag.namesRoute],
                 tags: <SemanticsTag>[RenderViewport.excludeFromScrolling],
-                label: 'AppBar'
+                children: <TestSemantics>[
+                  new TestSemantics(
+                    id: 6,
+                    rect: new Rect.fromLTRB(0.0, 0.0, 120.0, 20.0),
+                    label: 'AppBar',
+                    textDirection: TextDirection.ltr,
+                  ),
+                ],
               ),
             ],
           )
@@ -652,34 +636,29 @@ void main() {
       new TestSemantics.root(
         children: <TestSemantics>[
           new TestSemantics.rootChild(
-            id: 36,
+            id: 1,
             rect: TestSemantics.fullScreen,
             tags: <SemanticsTag>[RenderViewport.useTwoPaneSemantics],
             children: <TestSemantics>[
               new TestSemantics(
-                id: 41,
-                nextNodeId: 40,
+                id: 7,
                 actions: SemanticsAction.scrollUp.index | SemanticsAction.scrollDown.index,
                 rect: TestSemantics.fullScreen,
                 children: <TestSemantics>[
                   new TestSemantics(
-                    id: 37,
-                    nextNodeId: 38,
+                    id: 2,
                     rect: new Rect.fromLTRB(0.0, 0.0, 800.0, 200.0),
                     transform: new Matrix4.translation(new Vector3(0.0, -20.0, 0.0)),
                     label: 'Item 3',
                   ),
                   new TestSemantics(
-                    id: 38,
-                    nextNodeId: 39,
-                    previousNodeId: 37,
+                    id: 3,
                     rect: new Rect.fromLTRB(0.0, 0.0, 800.0, 200.0),
                     transform: new Matrix4.translation(new Vector3(0.0, 180.0, 0.0)),
                     label: 'Item 2',
                   ),
                   new TestSemantics(
-                    id: 39,
-                    previousNodeId: 38,
+                    id: 4,
                     rect: new Rect.fromLTRB(0.0, 0.0, 800.0, 200.0),
                     // Item 1 ends at 580dp, so there would be 20dp space for Item 0.
                     transform: new Matrix4.translation(new Vector3(0.0, 380.0, 0.0)),
@@ -689,13 +668,21 @@ void main() {
                 ],
               ),
               new TestSemantics(
-                id: 40,
+                id: 5,
                 previousNodeId: 41,
                 rect: new Rect.fromLTRB(0.0, 0.0, 120.0, 20.0),
                 transform: new Matrix4.translation(new Vector3(0.0, 544.0, 0.0)),
                 flags: <SemanticsFlag>[SemanticsFlag.namesRoute],
                 tags: <SemanticsTag>[RenderViewport.excludeFromScrolling],
-                label: 'AppBar'
+                children: <TestSemantics>[
+                  new TestSemantics(
+                    id: 6,
+                    rect: new Rect.fromLTRB(0.0, 0.0, 120.0, 20.0),
+                    transform: new Matrix4.translation(new Vector3(0.0, 544.0, 0.0)),
+                    label: 'AppBar',
+                    textDirection: TextDirection.ltr,
+                  ),
+                ],
               ),
             ],
           )

--- a/packages/flutter/test/widgets/sliver_semantics_test.dart
+++ b/packages/flutter/test/widgets/sliver_semantics_test.dart
@@ -486,7 +486,6 @@ void _tests() {
               ),
               new TestSemantics(
                 id: 5,
-                previousNodeId: 29,
                 rect: new Rect.fromLTRB(0.0, 0.0, 120.0, 20.0),
                 flags: <SemanticsFlag>[SemanticsFlag.namesRoute],
                 tags: <SemanticsTag>[RenderViewport.excludeFromScrolling],
@@ -669,7 +668,6 @@ void _tests() {
               ),
               new TestSemantics(
                 id: 5,
-                previousNodeId: 41,
                 rect: new Rect.fromLTRB(0.0, 0.0, 120.0, 20.0),
                 transform: new Matrix4.translation(new Vector3(0.0, 544.0, 0.0)),
                 flags: <SemanticsFlag>[SemanticsFlag.namesRoute],

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -195,9 +195,9 @@ class FlutterDevice {
       await view.uiIsolate.flutterDebugDumpLayerTree();
   }
 
-  Future<Null> debugDumpSemanticsTreeInGeometricOrder() async {
+  Future<Null> debugDumpSemanticsTreeInTraversalOrder() async {
     for (FlutterView view in views)
-      await view.uiIsolate.flutterDebugDumpSemanticsTreeInGeometricOrder();
+      await view.uiIsolate.flutterDebugDumpSemanticsTreeInTraversalOrder();
   }
 
   Future<Null> debugDumpSemanticsTreeInInverseHitTestOrder() async {
@@ -505,10 +505,10 @@ abstract class ResidentRunner {
       await device.debugDumpLayerTree();
   }
 
-  Future<Null> _debugDumpSemanticsTreeInGeometricOrder() async {
+  Future<Null> _debugDumpSemanticsTreeInTraversalOrder() async {
     await refreshViews();
     for (FlutterDevice device in flutterDevices)
-      await device.debugDumpSemanticsTreeInGeometricOrder();
+      await device.debugDumpSemanticsTreeInTraversalOrder();
   }
 
   Future<Null> _debugDumpSemanticsTreeInInverseHitTestOrder() async {
@@ -691,7 +691,7 @@ abstract class ResidentRunner {
       }
     } else if (character == 'S') {
       if (supportsServiceProtocol) {
-        await _debugDumpSemanticsTreeInGeometricOrder();
+        await _debugDumpSemanticsTreeInTraversalOrder();
         return true;
       }
     } else if (character == 'U') {
@@ -832,12 +832,12 @@ abstract class ResidentRunner {
       printStatus('You can dump the widget hierarchy of the app (debugDumpApp) by pressing "w".');
       printStatus('To dump the rendering tree of the app (debugDumpRenderTree), press "t".');
       if (isRunningDebug) {
-        printStatus('For layers (debugDumpLayerTree), use "L"; for accessibility (debugDumpSemantics), use "S" (for geometric order) or "U" (for inverse hit test order).');
+        printStatus('For layers (debugDumpLayerTree), use "L"; for accessibility (debugDumpSemantics), use "S" (for traversal order) or "U" (for inverse hit test order).');
         printStatus('To toggle the widget inspector (WidgetsApp.showWidgetInspectorOverride), press "i".');
         printStatus('To toggle the display of construction lines (debugPaintSizeEnabled), press "p".');
         printStatus('To simulate different operating systems, (defaultTargetPlatform), press "o".');
       } else {
-        printStatus('To dump the accessibility tree (debugDumpSemantics), press "S" (for geometric order) or "U" (for inverse hit test order).');
+        printStatus('To dump the accessibility tree (debugDumpSemantics), press "S" (for traversal order) or "U" (for inverse hit test order).');
       }
       printStatus('To display the performance overlay (WidgetsApp.showPerformanceOverlay), press "P".');
     }

--- a/packages/flutter_tools/lib/src/vmservice.dart
+++ b/packages/flutter_tools/lib/src/vmservice.dart
@@ -1190,8 +1190,8 @@ class Isolate extends ServiceObjectOwner {
     return invokeFlutterExtensionRpcRaw('ext.flutter.debugDumpLayerTree', timeout: kLongRequestTimeout);
   }
 
-  Future<Map<String, dynamic>> flutterDebugDumpSemanticsTreeInGeometricOrder() {
-    return invokeFlutterExtensionRpcRaw('ext.flutter.debugDumpSemanticsTreeInGeometricOrder', timeout: kLongRequestTimeout);
+  Future<Map<String, dynamic>> flutterDebugDumpSemanticsTreeInTraversalOrder() {
+    return invokeFlutterExtensionRpcRaw('ext.flutter.debugDumpSemanticsTreeInTraversalOrder', timeout: kLongRequestTimeout);
   }
 
   Future<Map<String, dynamic>> flutterDebugDumpSemanticsTreeInInverseHitTestOrder() {


### PR DESCRIPTION
- Remove global sorting that's not supported by iOS. Instead it sorts locally using a new algorithm [illustrated here](https://docs.google.com/presentation/d/1z-sLVogRPA8R0PHf1R-aMylS1UVQP3KQi9vO6apV4g0).
- RTL
- Remove `nextNodeId`/`previousNodeId`

Fixes https://github.com/flutter/flutter/issues/12187
Fixes https://github.com/flutter/flutter/issues/14375
Fixes https://github.com/flutter/flutter/issues/14570 (together with https://github.com/flutter/engine/pull/4937)

TODO:

- [x] remove traces of geometric sort order (e.g. the enum option)
- [ ] pass hit test order so it can be applied on Android (iOS doesn't support it; this requires an engine-side change)

/cc @goderbauer @gspencergoog 