### PR TITLE
Un(less)conditionally schedule first callback frame when creating ticker

### DIFF
--- a/packages/flutter/lib/src/scheduler/ticker.dart
+++ b/packages/flutter/lib/src/scheduler/ticker.dart
@@ -155,8 +155,10 @@ class Ticker {
     }());
     assert(_startTime == null);
     _future = new TickerFuture._();
-    if (shouldScheduleTick)
-      scheduleTick();
+    if (!muted && !scheduled) {
+      assert(!scheduled);
+      _animationId = SchedulerBinding.instance.scheduleFrameCallback(_tick, rescheduling: false);
+    }
     if (SchedulerBinding.instance.schedulerPhase.index > SchedulerPhase.idle.index &&
         SchedulerBinding.instance.schedulerPhase.index < SchedulerPhase.postFrameCallbacks.index)
       _startTime = SchedulerBinding.instance.currentFrameTimeStamp;

--- a/packages/flutter/lib/src/scheduler/ticker.dart
+++ b/packages/flutter/lib/src/scheduler/ticker.dart
@@ -156,7 +156,6 @@ class Ticker {
     assert(_startTime == null);
     _future = new TickerFuture._();
     if (!muted && !scheduled) {
-      assert(!scheduled);
       _animationId = SchedulerBinding.instance.scheduleFrameCallback(_tick, rescheduling: false);
     }
     if (SchedulerBinding.instance.schedulerPhase.index > SchedulerPhase.idle.index &&

--- a/packages/flutter/lib/src/scheduler/ticker.dart
+++ b/packages/flutter/lib/src/scheduler/ticker.dart
@@ -155,8 +155,8 @@ class Ticker {
     }());
     assert(_startTime == null);
     _future = new TickerFuture._();
-    if (!muted && !scheduled) {
-      _animationId = SchedulerBinding.instance.scheduleFrameCallback(_tick, rescheduling: false);
+    if (shouldScheduleTick) {
+      scheduleTick();
     }
     if (SchedulerBinding.instance.schedulerPhase.index > SchedulerPhase.idle.index &&
         SchedulerBinding.instance.schedulerPhase.index < SchedulerPhase.postFrameCallbacks.index)
@@ -217,7 +217,7 @@ class Ticker {
   /// * The ticker is not active ([start] has not been called).
   /// * The ticker is not ticking, e.g. because it is [muted] (see [isTicking]).
   @protected
-  bool get shouldScheduleTick => isTicking && !scheduled;
+  bool get shouldScheduleTick => !muted && isActive && !scheduled;
 
   void _tick(Duration timeStamp) {
     assert(isTicking);
@@ -239,7 +239,6 @@ class Ticker {
   /// This should only be called if [shouldScheduleTick] is true.
   @protected
   void scheduleTick({ bool rescheduling: false }) {
-    assert(isTicking);
     assert(!scheduled);
     assert(shouldScheduleTick);
     _animationId = SchedulerBinding.instance.scheduleFrameCallback(_tick, rescheduling: rescheduling);


### PR DESCRIPTION
Currently creating a ticker while idle will prevent any future ticks from being scheduled.  This changes the logic in `start()` to almost always schedule first frame callback, so that when we leave the idle state ticking resumes correctly.  Added test case fails without change


Fixes #13818 for iOS.