### PR TITLE
Make template Podfiles work with Cocoapods 1.5.0

### DIFF
--- a/packages/flutter_tools/templates/cocoapods/Podfile-objc
+++ b/packages/flutter_tools/templates/cocoapods/Podfile-objc
@@ -30,7 +30,6 @@ target 'Runner' do
   # Prepare symlinks folder. We use symlinks to avoid having Podfile.lock
   # referring to absolute paths on developers' machines.
   system('rm -rf Pods/.symlinks')
-  system('mkdir -p Pods/.symlinks/flutter')
   system('mkdir -p Pods/.symlinks/plugins')
 
   # Flutter Pods
@@ -40,16 +39,16 @@ target 'Runner' do
   end
   generated_xcode_build_settings.map { |p|
     if p[:name] == 'FLUTTER_FRAMEWORK_DIR'
-      symlink = File.join('Pods', '.symlinks', 'flutter', File.basename(p[:path]))
-      File.symlink(p[:path], symlink)
-      pod 'Flutter', :path => symlink
+      symlink = File.join('Pods', '.symlinks', 'flutter')
+      File.symlink(File.dirname(p[:path]), symlink)
+      pod 'Flutter', :path => File.join(symlink, File.basename(p[:path]))
     end
   }
 
   # Plugin Pods
   plugin_pods = parse_KV_file('../.flutter-plugins')
   plugin_pods.map { |p|
-    symlink = File.join('Pods', '.symlinks', 'plugins', File.basename(p[:path]))
+    symlink = File.join('Pods', '.symlinks', 'plugins', p[:name])
     File.symlink(p[:path], symlink)
     pod p[:name], :path => File.join(symlink, 'ios')
   }

--- a/packages/flutter_tools/templates/cocoapods/Podfile-swift
+++ b/packages/flutter_tools/templates/cocoapods/Podfile-swift
@@ -32,7 +32,6 @@ target 'Runner' do
   # Prepare symlinks folder. We use symlinks to avoid having Podfile.lock
   # referring to absolute paths on developers' machines.
   system('rm -rf Pods/.symlinks')
-  system('mkdir -p Pods/.symlinks/flutter')
   system('mkdir -p Pods/.symlinks/plugins')
 
   # Flutter Pods
@@ -42,16 +41,16 @@ target 'Runner' do
   end
   generated_xcode_build_settings.map { |p|
     if p[:name] == 'FLUTTER_FRAMEWORK_DIR'
-      symlink = File.join('Pods', '.symlinks', 'flutter', File.basename(p[:path]))
-      File.symlink(p[:path], symlink)
-      pod 'Flutter', :path => symlink
+      symlink = File.join('Pods', '.symlinks', 'flutter')
+      File.symlink(File.dirname(p[:path]), symlink)
+      pod 'Flutter', :path => File.join(symlink, File.basename(p[:path]))
     end
   }
 
   # Plugin Pods
   plugin_pods = parse_KV_file('../.flutter-plugins')
   plugin_pods.map { |p|
-    symlink = File.join('Pods', '.symlinks', 'plugins', File.basename(p[:path]))
+    symlink = File.join('Pods', '.symlinks', 'plugins', p[:name])
     File.symlink(p[:path], symlink)
     pod p[:name], :path => File.join(symlink, 'ios')
   }


### PR DESCRIPTION
Cocoapods 1.5.0 handles symlinked pods differently than previous releases.

Fixes https://github.com/flutter/flutter/issues/16036