### PR TITLE
Make no-op buttons more accessible by showing a SnackBar when they're pressed

### DIFF
--- a/examples/flutter_gallery/lib/demo/material/bottom_app_bar_demo.dart
+++ b/examples/flutter_gallery/lib/demo/material/bottom_app_bar_demo.dart
@@ -312,11 +312,19 @@ class _DemoBottomAppBar extends StatelessWidget {
     rowContents.addAll(<Widget> [
       new IconButton(
         icon: const Icon(Icons.search),
-        onPressed: () {},
+        onPressed: () {
+          Scaffold.of(context).showSnackBar(
+            const SnackBar(content: const Text('This is a dummy search action.')),
+          );
+        },
       ),
       new IconButton(
         icon: const Icon(Icons.more_vert),
-        onPressed: () {},
+        onPressed: () {
+          Scaffold.of(context).showSnackBar(
+            const SnackBar(content: const Text('This is a dummy menu action.')),
+          );
+        },
       ),
     ]);
     return new Row(

--- a/examples/flutter_gallery/lib/demo/material/bottom_app_bar_demo.dart
+++ b/examples/flutter_gallery/lib/demo/material/bottom_app_bar_demo.dart
@@ -181,7 +181,6 @@ class _BottomAppBarDemoState extends State<BottomAppBarDemo> {
         new Semantics(
           label: 'Set Bottom App Bar color to ${colorToName[color]}',
           container: true,
-          explicitChildNodes: false,
           child: new Row(children: <Widget> [
             new Radio<Color>(
               value: color,
@@ -323,7 +322,6 @@ class _DemoBottomAppBar extends StatelessWidget {
       new Semantics(
         label: 'Search',
         container: true,
-        explicitChildNodes: false,
         enabled: false,
         child: new IconButton(
           icon: const Icon(Icons.search),
@@ -333,7 +331,6 @@ class _DemoBottomAppBar extends StatelessWidget {
       new Semantics(
         label: 'Show more',
         container: true,
-        explicitChildNodes: false,
         enabled: false,
         child: new IconButton(
           icon: const Icon(Icons.more_vert),

--- a/examples/flutter_gallery/lib/demo/material/bottom_app_bar_demo.dart
+++ b/examples/flutter_gallery/lib/demo/material/bottom_app_bar_demo.dart
@@ -310,32 +310,13 @@ class _DemoBottomAppBar extends StatelessWidget {
       );
     }
     rowContents.addAll(<Widget> [
-      // Generally, an icon button does not need to be wrapped in a Semantics object.
-      // When the button has a null onPressed callback, it will be disabled by default.
-      //
-      // However, for the purposes of this demo, we don't want the button to appear disabled.
-      // To achieve this we use a no-op callback instead of a null callback. This allows
-      // the buttons to appear active, but perform no actions.
-      //
-      // To tell the accessibility service that the callback is a no-op, the Semantics widget
-      // wraps these buttons with `enabled: false`.
-      new Semantics(
-        label: 'Search',
-        container: true,
-        enabled: false,
-        child: new IconButton(
-          icon: const Icon(Icons.search),
-          onPressed: () {},
-        ),
+      new IconButton(
+        icon: const Icon(Icons.search),
+        onPressed: () {},
       ),
-      new Semantics(
-        label: 'Show more',
-        container: true,
-        enabled: false,
-        child: new IconButton(
-          icon: const Icon(Icons.more_vert),
-          onPressed: () {},
-        ),
+      new IconButton(
+        icon: const Icon(Icons.more_vert),
+        onPressed: () {},
       ),
     ]);
     return new Row(


### PR DESCRIPTION
Also removing a use of `explicitChildNodes = false` which is the default behavior.