### PR TITLE
Run iOS gen_snapshot as x86_64 arch

### DIFF
--- a/packages/flutter_tools/lib/src/base/build.dart
+++ b/packages/flutter_tools/lib/src/base/build.dart
@@ -50,6 +50,15 @@ class GenSnapshot {
       '--print_snapshot_sizes',
     ]..addAll(additionalArgs);
     final String snapshotterPath = artifacts.getArtifactPath(Artifact.genSnapshot, snapshotType.platform, snapshotType.mode);
+
+    // iOS gen_snapshot is a multi-arch binary. Running as an i386 binary will
+    // generate armv7 code. Running as an x86_64 binary will generate arm64
+    // code. /usr/bin/arch can be used to run binaries with the specified
+    // architecture.
+    if (snapshotType.platform == TargetPlatform.ios) {
+      // TODO(cbracken): for the moment, always generate only arm64 code.
+      return runCommandAndStreamOutput(<String>['/usr/bin/arch', '-x86_64', snapshotterPath]..addAll(args));
+    }
     return runCommandAndStreamOutput(<String>[snapshotterPath]..addAll(args));
   }
 }

--- a/packages/flutter_tools/lib/src/commands/build_aot.dart
+++ b/packages/flutter_tools/lib/src/commands/build_aot.dart
@@ -260,7 +260,16 @@ Future<String> _buildAotSnapshot(
     return null;
   }
 
-  final List<String> genSnapshotCmd = <String>[
+  final List<String> genSnapshotCmd = <String>[];
+  // iOS gen_snapshot is a multi-arch binary. Running as an i386 binary will
+  // generate armv7 code. Running as an x86_64 binary will generate arm64
+  // code. /usr/bin/arch can be used to run binaries with the specified
+  // architecture.
+  //
+  // TODO(cbracken): update the GenSnapshot class to handle AOT builds.
+  if (platform == TargetPlatform.ios)
+    genSnapshotCmd.addAll(<String>['arch', '-x86_64']);
+  genSnapshotCmd.addAll(<String>[
     genSnapshot,
     '--await_is_keyword',
     '--vm_snapshot_data=$vmSnapshotData',
@@ -271,7 +280,7 @@ Future<String> _buildAotSnapshot(
     '--print_snapshot_sizes',
     '--dependencies=$dependencies',
     '--causal_async_stacks',
-  ];
+  ]);
 
   if ((extraFrontEndOptions != null) && extraFrontEndOptions.isNotEmpty)
     printTrace('Extra front-end options: $extraFrontEndOptions');


### PR DESCRIPTION
We are about to begin building gen_snapshot as a multi-arch binary,
which when run as x86_64 will generate arm64 AOT output, and when run as
i386 will generate armv7 AOT output.

Currently, gen_snapshot is an x86_64 binary, so this change is
effectively preventative in nature, and is a no-op with the current
snapshotter.