### PR TITLE
Changes the Linear Gradient on the CupertinoPicker from fixed white t…

### DIFF
--- a/packages/flutter/lib/src/cupertino/picker.dart
+++ b/packages/flutter/lib/src/cupertino/picker.dart
@@ -32,12 +32,10 @@ const double _kForegroundScreenOpacityFraction = 0.7;
 class CupertinoPicker extends StatefulWidget {
   /// Creates a control used for selecting values.
   ///
-  /// The [diameterRatio] and [itemExtent] arguments must not be null. The
+  /// The [backgroundColor], [diameterRatio] and [itemExtent] arguments must not be null. The
   /// [itemExtent] must be greater than zero.
   ///
-  /// The [backgroundColor] defaults to light gray. It can be set to null to
-  /// disable the background painting entirely; this is mildly more efficient
-  /// than using [Colors.transparent].
+  /// The [backgroundColor] defaults to light gray.
   const CupertinoPicker({
     Key key,
     this.diameterRatio: _kDefaultDiameterRatio,
@@ -46,7 +44,8 @@ class CupertinoPicker extends StatefulWidget {
     @required this.itemExtent,
     @required this.onSelectedItemChanged,
     @required this.children,
-  }) : assert(diameterRatio != null),
+  }) : assert(backgroundColor != null),
+       assert(diameterRatio != null),
        assert(diameterRatio > 0.0, RenderListWheelViewport.diameterRatioZeroMessage),
        assert(itemExtent != null),
        assert(itemExtent > 0),
@@ -64,9 +63,6 @@ class CupertinoPicker extends StatefulWidget {
   /// Background color behind the children.
   ///
   /// Defaults to a gray color in the iOS color palette.
-  ///
-  /// This can be set to null to disable the background painting entirely; this
-  /// is mildly more efficient than using [Colors.transparent].
   final Color backgroundColor;
 
   /// A [FixedExtentScrollController] to read and control the current item.
@@ -113,22 +109,22 @@ class _CupertinoPickerState extends State<CupertinoPicker> {
     }
   }
 
-  /// Makes the fade to white edge gradients.
+  /// Makes the fade to edge gradients according to the background color.
   Widget _buildGradientScreen() {
     return new Positioned.fill(
       child: new IgnorePointer(
         child: new Container(
-          decoration: const BoxDecoration(
-            gradient: const LinearGradient(
-              colors: const <Color>[
-                const Color(0xFFFFFFFF),
-                const Color(0xF2FFFFFF),
-                const Color(0xDDFFFFFF),
-                const Color(0x00FFFFFF),
-                const Color(0x00FFFFFF),
-                const Color(0xDDFFFFFF),
-                const Color(0xF2FFFFFF),
-                const Color(0xFFFFFFFF),
+          decoration: new BoxDecoration(
+            gradient: new LinearGradient(
+              colors: <Color>[
+                widget.backgroundColor,
+                widget.backgroundColor.withAlpha(0xF2),
+                widget.backgroundColor.withAlpha(0xDD),
+                widget.backgroundColor.withAlpha(0x00),
+                widget.backgroundColor.withAlpha(0x00),
+                widget.backgroundColor.withAlpha(0xDD),
+                widget.backgroundColor.withAlpha(0xF2),
+                widget.backgroundColor,
               ],
               stops: const <double>[
                 0.0, 0.05, 0.09, 0.22, 0.78, 0.91, 0.95, 1.0,


### PR DESCRIPTION
…o the background color property

## The Problem
While using the CupertinoPicker widget, I noticed it adds a white Linear Gradient to make the fade effect. The problem is that for any background color, the gradient is always white. It also causes perceptible visual changes, even when using light colors.

e.g.
This picture is from the [iOS Human Interface Guidelines](https://developer.apple.com/ios/human-interface-guidelines/controls/pickers/)

![screen shot 2018-04-07 at 00 07 44](https://user-images.githubusercontent.com/5948318/38451101-e53a5760-39ff-11e8-90e5-b0cd33ee66ac.png)

This other picture is from the current implementation on Flutter

![screen shot 2018-04-07 at 00 09 14](https://user-images.githubusercontent.com/5948318/38451114-35d6df9a-3a00-11e8-8c19-df0507224d81.png)

There isn't a white shade on the first picture, but it is very present on the second one.
The biggest problem happens when we set a darker background color

![screen shot 2018-04-07 at 00 37 58](https://user-images.githubusercontent.com/5948318/38451126-7fbbf0fa-3a00-11e8-860f-8fe62634d162.png)

## The Fix
I have changed the Linear Gradient to use the widget's background color instead of white. That way, the gradient is correct for any background color

e.g.
This is the same picker after the fix

![screen shot 2018-04-07 at 00 09 38](https://user-images.githubusercontent.com/5948318/38451134-de8a1436-3a00-11e8-85da-4619a5f3d7e3.png)

It will work for darker colors as well

![screen shot 2018-04-07 at 00 10 07](https://user-images.githubusercontent.com/5948318/38451160-6b7c0ec6-3a01-11e8-9d5a-25a9d3137b6f.png)

## Drawbacks
- Before the change, one could pass null to the backgroundColor. Now, it is not possible, since the Linear Gradient effect is mandatory and there is no way to apply it without a color
- A transparent background color will render a black gradient, since Colors.transparent is defined as const Color(0x00000000) 
