### PR TITLE
Modified TextFormField to retain value when scrolled

### DIFF
--- a/packages/flutter/lib/src/material/text_form_field.dart
+++ b/packages/flutter/lib/src/material/text_form_field.dart
@@ -134,6 +134,7 @@ class _TextFormFieldState extends FormFieldState<String> {
     if (widget.controller == null) {
       _controller = new TextEditingController(text: widget.initialValue);
     } else {
+      setValue(widget.controller.text);
       widget.controller.addListener(_handleControllerChanged);
     }
   }

--- a/packages/flutter/test/material/text_form_field_test.dart
+++ b/packages/flutter/test/material/text_form_field_test.dart
@@ -49,7 +49,7 @@ void main() {
     await tester.pump();
     expect(_called, true);
   });
-  
+
   testWidgets('autovalidate is passed to super', (WidgetTester tester) async {
     int _validateCalled = 0;
 
@@ -71,5 +71,44 @@ void main() {
     await tester.enterText(find.byType(TextField), 'a');
     await tester.pump();
     expect(_validateCalled, 2);
+  });
+
+  testWidgets('InitialValue is set to controller value', (WidgetTester tester) async {
+    const String controllerValue = 'controllerValue';
+    final TextEditingController controller = new TextEditingController(text: controllerValue);
+
+    await tester.pumpWidget(
+      new MaterialApp(
+        home: new Material(
+          child: new Center(
+            child: new TextFormField(
+              controller: controller,
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text(controllerValue), findsOneWidget);
+    expect(find.text(''), findsNothing);
+  });
+
+  testWidgets('InitialValue is set to initialValue when controller is null', (WidgetTester tester) async {
+
+    await tester.pumpWidget(
+      new MaterialApp(
+        home: new Material(
+          child: new Center(
+            child: new TextFormField(
+              initialValue: 'initValue',
+            ),
+          ),
+        ),
+      ),
+    );
+
+
+    expect(find.text(''), findsNothing);
+    expect(find.text('initValue'), findsOneWidget);
   });
 }


### PR DESCRIPTION
Modified TextFormField to retain value if component is scrolled off the screen

Removed the first assert because it is taken care of when setting the initialValue field

Added if check to pull value from controller into widget if the controller has value

Fixes Issues: #11500, #15484, #14104, #16028 