### PR TITLE
Require Cocoapods 1.5.0

### DIFF
--- a/packages/flutter_tools/lib/src/ios/cocoapods.dart
+++ b/packages/flutter_tools/lib/src/ios/cocoapods.dart
@@ -38,7 +38,9 @@ class CocoaPods {
 
   Future<bool> get hasCocoaPods => exitsHappyAsync(<String>['pod', '--version']);
 
-  String get cocoaPodsMinimumVersion => '1.5.0';
+  // TODO(mravn): Insist on 1.5.0 once build bots have that installed.
+  // Earlier versions do not work with Swift and static libraries.
+  String get cocoaPodsMinimumVersion => '1.0.0';
 
   Future<String> get cocoaPodsVersionText async => (await runAsync(<String>['pod', '--version'])).processResult.stdout.trim();
 

--- a/packages/flutter_tools/lib/src/ios/cocoapods.dart
+++ b/packages/flutter_tools/lib/src/ios/cocoapods.dart
@@ -38,7 +38,7 @@ class CocoaPods {
 
   Future<bool> get hasCocoaPods => exitsHappyAsync(<String>['pod', '--version']);
 
-  String get cocoaPodsMinimumVersion => '1.0.0';
+  String get cocoaPodsMinimumVersion => '1.5.0';
 
   Future<String> get cocoaPodsVersionText async => (await runAsync(<String>['pod', '--version'])).processResult.stdout.trim();
 

--- a/packages/flutter_tools/templates/cocoapods/Podfile-swift
+++ b/packages/flutter_tools/templates/cocoapods/Podfile-swift
@@ -56,19 +56,10 @@ target 'Runner' do
   }
 end
 
-pre_install do |installer|
-  # workaround for https://github.com/CocoaPods/CocoaPods/issues/3289
-  Pod::Installer::Xcode::TargetValidator.send(:define_method, :verify_no_static_framework_transitive_dependencies) {}
-end
-
 post_install do |installer|
   installer.pods_project.targets.each do |target|
     target.build_configurations.each do |config|
       config.build_settings['ENABLE_BITCODE'] = 'NO'
-    end
-    # workaround for https://github.com/CocoaPods/CocoaPods/issues/7463
-    target.headers_build_phase.files.each do |file|
-      file.settings = { 'ATTRIBUTES' => ['Public'] }
     end
   end
 end


### PR DESCRIPTION
Partial fix of https://github.com/flutter/flutter/issues/15031

Cocoapods 1.4.0 is barely able to build Swift-based Flutter projects that depends on static frameworks. The workarounds required result in errors after archival and submission to the app store.

Cocoapods 1.5.0 appears able to handle this situation without workarounds of any kind. But it does require `s.static_framework = true` to be added to the `.podspec` file of each plugin that uses static libs like `GoogleSignIn`. This is done in a [companion PR](https://github.com/flutter/plugins/pull/483) on the `flutter/plugins` repo.