### PR TITLE
use gem to install cocoapods, instead of brew

### DIFF
--- a/packages/flutter_tools/lib/src/ios/cocoapods.dart
+++ b/packages/flutter_tools/lib/src/ios/cocoapods.dart
@@ -24,11 +24,11 @@ const String noCocoaPodsConsequence = '''
   For more info, see https://flutter.io/platform-plugins''';
 
 const String cocoaPodsInstallInstructions = '''
-  brew install cocoapods
+  gem install cocoapods
   pod setup''';
 
 const String cocoaPodsUpgradeInstructions = '''
-  brew upgrade cocoapods
+  gem install cocoapods
   pod setup''';
 
 CocoaPods get cocoaPods => context[CocoaPods];


### PR DESCRIPTION
1. official docs of cocoapods use gem
2. gem is preinstalled on mac, brew isn't
3. people could be using ports, not brew

partially resolves #16458 