### PR TITLE
Remove the initial xcodebuild clean step which seems unnecessary

### DIFF
--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -299,28 +299,10 @@ Future<XcodeBuildResult> buildXcodeProject({
     }
   }
 
-  final Status cleanStatus =
-      logger.startProgress('Running Xcode clean...', expectSlowOperation: true);
-  final RunResult cleanResult = await runAsync(
-    <String>[
-      '/usr/bin/env',
-      'xcrun',
-      'xcodebuild',
-      'clean',
-      '-configuration', configuration,
-    ],
-    workingDirectory: app.appDirectory,
-  );
-  cleanStatus.stop();
-  if (cleanResult.exitCode != 0) {
-    throwToolExit('Xcode failed to clean\n${cleanResult.stderr}');
-  }
-
   final List<String> buildCommands = <String>[
     '/usr/bin/env',
     'xcrun',
     'xcodebuild',
-    'build',
     '-configuration', configuration,
     'ONLY_ACTIVE_ARCH=YES',
   ];


### PR DESCRIPTION
Was originally added in #3140 but testing both directions seems to work ok without this extra step which takes ~2s. 

Fixes #16095