### PR TITLE
Simplify script snapshotting code

### DIFF
--- a/packages/flutter_tools/lib/src/base/build.dart
+++ b/packages/flutter_tools/lib/src/base/build.dart
@@ -171,7 +171,7 @@ class Snapshotter {
     @required String depfilePath,
     @required String packagesPath
   }) async {
-    final SnapshotType type = new SnapshotType(null, BuildMode.debug);
+    final SnapshotType snapshotType = new SnapshotType(null, BuildMode.debug);
     final List<String> args = <String>[
       '--snapshot_kind=script',
       '--script_snapshot=$snapshotPath',
@@ -180,36 +180,7 @@ class Snapshotter {
     ];
 
     final String fingerprintPath = '$depfilePath.fingerprint';
-    final int exitCode = await _build(
-      snapshotType: type,
-      outputSnapshotPath: snapshotPath,
-      packagesPath: packagesPath,
-      snapshotArgs: args,
-      depfilePath: depfilePath,
-      mainPath: mainPath,
-      fingerprintPath: fingerprintPath,
-    );
-    if (exitCode != 0)
-      return exitCode;
-    await _writeFingerprint(type, snapshotPath, depfilePath, mainPath, fingerprintPath);
-    return exitCode;
-  }
-
-  /// Builds an architecture-specific ahead-of-time compiled snapshot of the specified script.
-  Future<Null> buildAotSnapshot() async {
-    throw new UnimplementedError('AOT snapshotting not yet implemented');
-  }
-
-  Future<int> _build({
-    @required SnapshotType snapshotType,
-    @required List<String> snapshotArgs,
-    @required String outputSnapshotPath,
-    @required String packagesPath,
-    @required String depfilePath,
-    @required String mainPath,
-    @required String fingerprintPath,
-  }) async {
-    if (!await _isBuildRequired(snapshotType, outputSnapshotPath, depfilePath, mainPath, fingerprintPath)) {
+    if (!await _isBuildRequired(snapshotType, snapshotPath, depfilePath, mainPath, fingerprintPath)) {
       printTrace('Skipping snapshot build. Fingerprints match.');
       return 0;
     }
@@ -219,13 +190,18 @@ class Snapshotter {
         snapshotType: snapshotType,
         packagesPath: packagesPath,
         depfilePath: depfilePath,
-        additionalArgs: snapshotArgs,
+        additionalArgs: args,
     );
+
     if (exitCode != 0)
       return exitCode;
+    await _writeFingerprint(snapshotType, snapshotPath, depfilePath, mainPath, fingerprintPath);
+    return exitCode;
+  }
 
-    _writeFingerprint(snapshotType, outputSnapshotPath, depfilePath, mainPath, fingerprintPath);
-    return 0;
+  /// Builds an architecture-specific ahead-of-time compiled snapshot of the specified script.
+  Future<Null> buildAotSnapshot() async {
+    throw new UnimplementedError('AOT snapshotting not yet implemented');
   }
 
   Future<bool> _isBuildRequired(SnapshotType type, String outputSnapshotPath, String depfilePath, String mainPath, String fingerprintPath) async {


### PR DESCRIPTION
Inlines the very small amount of work being done in _build() into
buildScriptSnapshot(). Eliminates a duplicate (and un-awaited) call to
_writeFingerprint.