### PR TITLE
Pass verbose flag to Xcode subcommands

### DIFF
--- a/packages/flutter_tools/bin/xcode_backend.sh
+++ b/packages/flutter_tools/bin/xcode_backend.sh
@@ -91,6 +91,11 @@ BuildApp() {
 
   AssertExists "${target_path}"
 
+  local verbose_flag=""
+  if [[ -n "$VERBOSE_SCRIPT_LOGGING" ]]; then
+    verbose_flag="--verbose"
+  fi
+
   local build_dir="${FLUTTER_BUILD_DIR:-build}"
   local local_engine_flag=""
   if [[ -n "$LOCAL_ENGINE" ]]; then
@@ -113,7 +118,9 @@ BuildApp() {
     fi
 
     StreamOutput " ├─Building Dart code..."
-    RunCommand "${FLUTTER_ROOT}/bin/flutter" --suppress-analytics build aot \
+    RunCommand "${FLUTTER_ROOT}/bin/flutter" --suppress-analytics           \
+      ${verbose_flag}                                                       \
+      build aot                                                             \
       --output-dir="${build_dir}/aot"                                       \
       --target-platform=ios                                                 \
       --target="${target_path}"                                             \
@@ -145,13 +152,15 @@ BuildApp() {
   fi
 
   StreamOutput " ├─Assembling Flutter resources..."
-  RunCommand "${FLUTTER_ROOT}/bin/flutter" --suppress-analytics build bundle \
-    --target="${target_path}"                                                \
-    --snapshot="${build_dir}/snapshot_blob.bin"                              \
-    --depfile="${build_dir}/snapshot_blob.bin.d"                             \
-    --asset-dir="${derived_dir}/flutter_assets"                              \
-    ${precompilation_flag}                                                   \
-    ${local_engine_flag}                                                     \
+  RunCommand "${FLUTTER_ROOT}/bin/flutter" --suppress-analytics             \
+    ${verbose_flag}                                                         \
+    build bundle                                                            \
+    --target="${target_path}"                                               \
+    --snapshot="${build_dir}/snapshot_blob.bin"                             \
+    --depfile="${build_dir}/snapshot_blob.bin.d"                            \
+    --asset-dir="${derived_dir}/flutter_assets"                             \
+    ${precompilation_flag}                                                  \
+    ${local_engine_flag}                                                    \
     ${preview_dart_2_flag}
 
   if [[ $? -ne 0 ]]; then


### PR DESCRIPTION
When flutter builds are run with --verbose, pass the flag through to
flutter sub-commands run via xcode_backend.sh.