### PR TITLE
[LAND] Add dropdownbutton form field convenience class

### DIFF
--- a/packages/flutter/lib/src/material/dropdown.dart
+++ b/packages/flutter/lib/src/material/dropdown.dart
@@ -13,6 +13,7 @@ import 'constants.dart';
 import 'debug.dart';
 import 'icons.dart';
 import 'ink_well.dart';
+import 'input_decorator.dart';
 import 'material.dart';
 import 'material_localizations.dart';
 import 'scrollbar.dart';
@@ -687,5 +688,70 @@ class _DropdownButtonState<T> extends State<DropdownButton<T>> with WidgetsBindi
       behavior: HitTestBehavior.opaque,
       child: result
     );
+  }
+}
+
+/// A convenience class that wraps a [DropdownButton] in a [FormField] so as to
+/// act as a part of a [Form].
+///
+/// The [DropdownButton] widget is displayed without the underline, because it
+/// is provided by the [InputDecorator].
+///
+/// See also:
+///  * [DropdownButton], which is the underlying Widget providing the functionality
+///  * [InputDecorator], which shows the visual elements and styles the form
+///    field
+class DropdownButtonFormField<T> extends FormField<T> {
+  /// Creates a [DropdownButton] widget wrapped in an [InputDecorator] and
+  /// [FormField].
+  ///
+  /// As per [DropdownButton] items and onChanged must be supplied.
+  DropdownButtonFormField({
+    Key key,
+    T value,
+    @required List<DropdownMenuItem<T>> items,
+    @required this.onChanged,
+    InputDecoration decoration,
+    FormFieldSetter<T> onSaved,
+    FormFieldValidator<T> validator,
+    Widget hint,
+  }) : super(
+    key: key,
+    onSaved: onSaved,
+    validator: validator,
+    builder: (FormFieldState<T> field) {
+      final InputDecoration effectiveDecoration = (decoration ?? const InputDecoration())
+        .applyDefaults(Theme.of(field.context).inputDecorationTheme);
+      return new InputDecorator(
+        decoration: effectiveDecoration.copyWith(errorText: field.errorText),
+        child: new DropdownButtonHideUnderline(
+          child: new DropdownButton<T>(
+              isDense: true,
+              value: value,
+              items: items,
+              hint: hint,
+              onChanged: field.didChange,
+          ),
+        ),
+      );
+    }
+  );
+
+  /// Called when the user selects an item.
+  final ValueChanged<T> onChanged;
+
+  @override
+  FormFieldState<T> createState() => new _DropdownButtonFormFieldState<T>();
+}
+
+class _DropdownButtonFormFieldState<T> extends FormFieldState<T> {
+  @override
+  DropdownButtonFormField<T> get widget => super.widget;
+
+  @override
+  void didChange(T value) {
+    super.didChange(value);
+    if (widget.onChanged != null)
+      widget.onChanged(value);
   }
 }

--- a/packages/flutter/test/material/dropdown_test.dart
+++ b/packages/flutter/test/material/dropdown_test.dart
@@ -203,6 +203,48 @@ void main() {
     expect(value, equals('two'));
   });
 
+  testWidgets('Dropdown form field', (WidgetTester tester) async {
+    String value = 'one';
+
+    await tester.pumpWidget(
+      new StatefulBuilder(
+        builder: (BuildContext context, StateSetter setState) {
+          return new MaterialApp(
+            home: new Material(
+              child: new DropdownButtonFormField<String>(
+                value: value,
+                hint: const Text('Select Value'),
+                decoration: const InputDecoration(
+                  prefixIcon: const Icon(Icons.fastfood)
+                ),
+                items: menuItems.map((String val) {
+                  return new DropdownMenuItem<String>(
+                    value: val,
+                    child: new Text(val)
+                  );
+                }).toList(),
+                onChanged: (String v) {
+                  setState(() {
+                    value = v;
+                  });
+                },
+                validator: (String v) => v == null ? 'Must select value' : null,
+              ),
+            ),
+          );
+        }
+      )
+    );
+
+    expect(value, equals('one'));
+    await tester.tap(find.text('one'));
+    await tester.pump(const Duration(seconds: 1));
+    await tester.tap(find.text('three').last);
+    await tester.pump();
+    await tester.pump(const Duration(seconds: 1));
+    expect(value, equals('three'));
+  });
+
   testWidgets('Dropdown in ListView', (WidgetTester tester) async {
     // Regression test for https://github.com/flutter/flutter/issues/12053
     // Positions a DropdownButton at the left and right edges of the screen,


### PR DESCRIPTION
This is a basic wrapper for the DropdownButton Widget to use it as a part of a form. I didn't see anything similar that was already extant, though if I missed something, please let me know.  

![dropdownbuttonformfield](https://user-images.githubusercontent.com/100075/38657066-e459efd0-3de3-11e8-9508-6904447beace.png)

```dart
  @override
  Widget build(BuildContext context) {
    return new Scaffold(
      appBar: new AppBar(
        title: new Text("DropdownButtonFormFieldDemo"),
      ),
      body: new Builder(
        builder: (BuildContext context) {
          return new Container(
            padding: const EdgeInsets.all(12.0),
            child: new DropdownButtonFormField(
                value: _value,
                hint: new Text("Select value"),
                decoration: new InputDecoration(
                  prefixIcon: const Icon(Icons.fastfood),
                ),
                items:
                  ["First", "Second", "Third"].map((v) {
                    return new DropdownMenuItem(
                        value: v,
                        child: new Text(v));
                  }).toList(),
                onChanged: (v) {
                  setState(() {
                    _value = v;
                  });
                },
                validator: (v) => v == null ? "Must select value" : null
          ));
        },
      )
    );
```