### PR TITLE
Turn off unused changes report during hot reload

### DIFF
--- a/packages/flutter_tools/lib/src/run_hot.dart
+++ b/packages/flutter_tools/lib/src/run_hot.dart
@@ -500,6 +500,7 @@ class HotRunner extends ResidentRunner {
     // change from host path to a device path). Subsequent reloads will
     // not be affected, so we resume reporting reload times on the second
     // reload.
+    final bool previewDart2 = debuggingOptions.buildInfo.previewDart2;
     final bool shouldReportReloadTime = !_runningFromSnapshot;
     final Stopwatch reloadTimer = new Stopwatch()..start();
 
@@ -514,7 +515,7 @@ class HotRunner extends ResidentRunner {
     final Stopwatch vmReloadTimer = new Stopwatch()..start();
     try {
       final String entryPath = fs.path.relative(
-        debuggingOptions.buildInfo.previewDart2 ? mainPath + '.dill' : mainPath,
+         previewDart2 ? mainPath + '.dill' : mainPath,
         from: projectRootPath,
       );
       final Completer<Map<String, dynamic>> retrieveFirstReloadReport = new Completer<Map<String, dynamic>>();
@@ -660,7 +661,7 @@ class HotRunner extends ResidentRunner {
       flutterUsage.sendTiming('hot', 'reload', reloadTimer.elapsed);
 
     String unusedElementMessage;
-    if (!reassembleAndScheduleErrors && !reassembleTimedOut) {
+    if (!reassembleAndScheduleErrors && !reassembleTimedOut && !previewDart2) {
       final List<Future<List<ProgramElement>>> unusedReports =
         <Future<List<ProgramElement>>>[];
       for (FlutterDevice device in flutterDevices)

--- a/packages/flutter_tools/lib/src/run_hot.dart
+++ b/packages/flutter_tools/lib/src/run_hot.dart
@@ -500,7 +500,7 @@ class HotRunner extends ResidentRunner {
     // change from host path to a device path). Subsequent reloads will
     // not be affected, so we resume reporting reload times on the second
     // reload.
-    final bool getUnusedReport = false;
+    final bool reportUnused = !debuggingOptions.buildInfo.previewDart2;
     final bool shouldReportReloadTime = !_runningFromSnapshot;
     final Stopwatch reloadTimer = new Stopwatch()..start();
 
@@ -661,7 +661,7 @@ class HotRunner extends ResidentRunner {
       flutterUsage.sendTiming('hot', 'reload', reloadTimer.elapsed);
 
     String unusedElementMessage;
-    if (getUnusedReport && !reassembleAndScheduleErrors && !reassembleTimedOut) {
+    if (reportUnused && !reassembleAndScheduleErrors && !reassembleTimedOut) {
       final List<Future<List<ProgramElement>>> unusedReports =
         <Future<List<ProgramElement>>>[];
       for (FlutterDevice device in flutterDevices)

--- a/packages/flutter_tools/lib/src/run_hot.dart
+++ b/packages/flutter_tools/lib/src/run_hot.dart
@@ -500,7 +500,7 @@ class HotRunner extends ResidentRunner {
     // change from host path to a device path). Subsequent reloads will
     // not be affected, so we resume reporting reload times on the second
     // reload.
-    final bool previewDart2 = debuggingOptions.buildInfo.previewDart2;
+    final bool getUnusedReport = false;
     final bool shouldReportReloadTime = !_runningFromSnapshot;
     final Stopwatch reloadTimer = new Stopwatch()..start();
 
@@ -515,7 +515,7 @@ class HotRunner extends ResidentRunner {
     final Stopwatch vmReloadTimer = new Stopwatch()..start();
     try {
       final String entryPath = fs.path.relative(
-         previewDart2 ? mainPath + '.dill' : mainPath,
+        debuggingOptions.buildInfo.previewDart2 ? mainPath + '.dill' : mainPath,
         from: projectRootPath,
       );
       final Completer<Map<String, dynamic>> retrieveFirstReloadReport = new Completer<Map<String, dynamic>>();
@@ -661,7 +661,7 @@ class HotRunner extends ResidentRunner {
       flutterUsage.sendTiming('hot', 'reload', reloadTimer.elapsed);
 
     String unusedElementMessage;
-    if (!reassembleAndScheduleErrors && !reassembleTimedOut && !previewDart2) {
+    if (getUnusedReport && !reassembleAndScheduleErrors && !reassembleTimedOut) {
       final List<Future<List<ProgramElement>>> unusedReports =
         <Future<List<ProgramElement>>>[];
       for (FlutterDevice device in flutterDevices)


### PR DESCRIPTION
A new UI is being designed to make the unused reload messaging clearer, the UI will use the coverage data to hightlight lines in the UI that were not executed during a reload.

In lieu of that we are turning off the unused reload messages experiment.

There were also some issues in Dart2 with this functionality
- source fingerprinting is not implemented in Dart2
- some additional synthetic functions are generated for invocation argument checking that are not appropriately filtered out.