### PR TITLE
Turn support for sync-async on in Flutter.

### DIFF
--- a/dev/automated_tests/flutter_test/exception_handling_expectation.txt
+++ b/dev/automated_tests/flutter_test/exception_handling_expectation.txt
@@ -43,7 +43,7 @@ Who lives, who dies, who tells your story\?
 
 When the exception was thrown, this was the stack:
 #[0-9]+ +main.<anonymous closure> \(.+[/\\]dev[/\\]automated_tests[/\\]flutter_test[/\\]exception_handling_test\.dart:16:9\)
-#[0-9]+ +main.<anonymous closure> \(.+[/\\]dev[/\\]automated_tests[/\\]flutter_test[/\\]exception_handling_test\.dart:15:77\)
+<<skip until matching line>>
 #[0-9]+ +.+ \(package:flutter_test[/\\]src[/\\]widget_tester\.dart:[0-9]+:[0-9]+\)
 <<skip until matching line>>
 ^\(elided [0-9]+ .+\)$

--- a/dev/automated_tests/flutter_test/test_async_utils_guarded_expectation.txt
+++ b/dev/automated_tests/flutter_test/test_async_utils_guarded_expectation.txt
@@ -18,6 +18,10 @@ When the exception was thrown, this was the stack:
 The test description was:
 TestAsyncUtils - custom guarded sections
 ════════════════════════════════════════════════════════════════════════════════════════════════════
+══╡ EXCEPTION CAUGHT BY FLUTTER TEST FRAMEWORK ╞════════════════════════════════════════════════════
+The following message was thrown:
+Multiple exceptions \(2\) were detected during the running of the current test, and at least one was unexpected.
+════════════════════════════════════════════════════════════════════════════════════════════════════
 .*(this line has more of the test framework's output)?
   Test failed\. See exception logs above\.
   The test description was: TestAsyncUtils - custom guarded sections

--- a/packages/flutter_tools/lib/src/compile.dart
+++ b/packages/flutter_tools/lib/src/compile.dart
@@ -216,6 +216,7 @@ class ResidentCompiler {
       _sdkRoot,
       '--incremental',
       '--strong',
+      '--sync-async',
       '--target=flutter',
     ];
     if (outputPath != null) {

--- a/packages/flutter_tools/lib/src/compile.dart
+++ b/packages/flutter_tools/lib/src/compile.dart
@@ -90,6 +90,7 @@ Future<CompilerOutput> compile(
     '--sdk-root',
     sdkRoot,
     '--strong',
+    '--sync-async',
     '--target=flutter',
   ];
   if (trackWidgetCreation)


### PR DESCRIPTION
With this feature execution of async functions starts immediately instead of it being delayed by one microtask tick.