### PR TITLE
Revert some uses of Number.tryParse()

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_device.dart
+++ b/packages/flutter_tools/lib/src/android/android_device.dart
@@ -210,6 +210,7 @@ class AndroidDevice extends Device {
       // Sample output: '22'
       final String sdkVersion = await _getProperty('ro.build.version.sdk');
 
+      // ignore: deprecated_member_use
       final int sdkVersionParsed = int.parse(sdkVersion, onError: (String source) => null);
       if (sdkVersionParsed == null) {
         printError('Unexpected response from getprop: "$sdkVersion"');
@@ -817,6 +818,7 @@ class _AndroidDevicePortForwarder extends DevicePortForwarder {
   final AndroidDevice device;
 
   static int _extractPort(String portString) {
+    // ignore: deprecated_member_use
     return int.parse(portString.trim(), onError: (_) => null);
   }
 

--- a/packages/flutter_tools/lib/src/android/android_device.dart
+++ b/packages/flutter_tools/lib/src/android/android_device.dart
@@ -210,7 +210,7 @@ class AndroidDevice extends Device {
       // Sample output: '22'
       final String sdkVersion = await _getProperty('ro.build.version.sdk');
 
-      final int sdkVersionParsed = int.tryParse(sdkVersion);
+      final int sdkVersionParsed = int.parse(sdkVersion, onError: (String source) => null);
       if (sdkVersionParsed == null) {
         printError('Unexpected response from getprop: "$sdkVersion"');
         return false;
@@ -817,7 +817,7 @@ class _AndroidDevicePortForwarder extends DevicePortForwarder {
   final AndroidDevice device;
 
   static int _extractPort(String portString) {
-    return int.tryParse(portString.trim());
+    return int.parse(portString.trim(), onError: (_) => null);
   }
 
   @override

--- a/packages/flutter_tools/lib/src/version.dart
+++ b/packages/flutter_tools/lib/src/version.dart
@@ -499,6 +499,7 @@ class GitTagVersion {
       return const GitTagVersion.unknown();
     }
     final List<int> parsedParts = parts.take(4).map<int>(
+      // ignore: deprecated_member_use
       (String value) => int.parse(value, onError: (String value) => null),
     ).toList();
     return new GitTagVersion(parsedParts[0], parsedParts[1], parsedParts[2], parsedParts[3], parts[4]);

--- a/packages/flutter_tools/lib/src/version.dart
+++ b/packages/flutter_tools/lib/src/version.dart
@@ -499,7 +499,7 @@ class GitTagVersion {
       return const GitTagVersion.unknown();
     }
     final List<int> parsedParts = parts.take(4).map<int>(
-      (String value) => int.tryParse(value),
+      (String value) => int.parse(value, onError: (String value) => null),
     ).toList();
     return new GitTagVersion(parsedParts[0], parsedParts[1], parsedParts[2], parsedParts[3], parts[4]);
   }


### PR DESCRIPTION
Engine roll https://github.com/flutter/flutter/pull/16518 included changes that depended on a version of the Dart SDK that's not available in G3 yet.