### PR TITLE
Rename AnimatedChildSwitcher to AnimatedSwitcher

### DIFF
--- a/packages/flutter/lib/src/material/chip.dart
+++ b/packages/flutter/lib/src/material/chip.dart
@@ -1399,12 +1399,12 @@ class _RawChipState extends State<RawChip> with TickerProviderStateMixin<RawChip
                     style: widget.labelStyle ?? chipTheme.labelStyle,
                     child: widget.label,
                   ),
-                  avatar: new AnimatedChildSwitcher(
+                  avatar: new AnimatedSwitcher(
                     child: widget.avatar,
                     duration: _kDrawerDuration,
                     switchInCurve: Curves.fastOutSlowIn,
                   ),
-                  deleteIcon: new AnimatedChildSwitcher(
+                  deleteIcon: new AnimatedSwitcher(
                     child: _buildDeleteIcon(context, theme, chipTheme),
                     duration: _kDrawerDuration,
                     switchInCurve: Curves.fastOutSlowIn,

--- a/packages/flutter/lib/src/widgets/animated_cross_fade.dart
+++ b/packages/flutter/lib/src/widgets/animated_cross_fade.dart
@@ -100,7 +100,7 @@ typedef Widget AnimatedCrossFadeBuilder(Widget topChild, Key topChildKey, Widget
 ///
 ///  * [AnimatedSize], the lower-level widget which [AnimatedCrossFade] uses to
 ///    automatically change size.
-///  * [AnimatedChildSwitcher], which switches out a child for a new one with a
+///  * [AnimatedSwitcher], which switches out a child for a new one with a
 ///    customizable transition.
 class AnimatedCrossFade extends StatefulWidget {
   /// Creates a cross-fade animation widget.

--- a/packages/flutter/lib/src/widgets/animated_switcher.dart
+++ b/packages/flutter/lib/src/widgets/animated_switcher.dart
@@ -11,11 +11,11 @@ import 'ticker_provider.dart';
 import 'transitions.dart';
 
 // Internal representation of a child that, now or in the past, was set on the
-// AnimatedChildSwitcher.child field, but is now in the process of
+// AnimatedSwitcher.child field, but is now in the process of
 // transitioning. The internal representation includes fields that we don't want
 // to expose to the public API (like the controller).
-class _AnimatedChildSwitcherChildEntry {
-  _AnimatedChildSwitcherChildEntry({
+class _AnimatedSwitcherChildEntry {
+  _AnimatedSwitcherChildEntry({
     @required this.animation,
     @required this.transition,
     @required this.controller,
@@ -37,31 +37,31 @@ class _AnimatedChildSwitcherChildEntry {
 }
 
 /// Signature for builders used to generate custom transitions for
-/// [AnimatedChildSwitcher].
+/// [AnimatedSwitcher].
 ///
 /// The [child] should be transitioning in when the [animation] is running in
 /// the forward direction.
 ///
 /// The function should return a widget which wraps the given [child]. It may
 /// also use the [animation] to inform its transition. It must not return null.
-typedef Widget AnimatedChildSwitcherTransitionBuilder(Widget child, Animation<double> animation);
+typedef Widget AnimatedSwitcherTransitionBuilder(Widget child, Animation<double> animation);
 
 /// Signature for builders used to generate custom layouts for
-/// [AnimatedChildSwitcher].
+/// [AnimatedSwitcher].
 ///
 /// The function should return a widget which contains the given children, laid
 /// out as desired. It must not return null.
-typedef Widget AnimatedChildSwitcherLayoutBuilder(List<Widget> children);
+typedef Widget AnimatedSwitcherLayoutBuilder(List<Widget> children);
 
 /// A widget that by default does a [FadeTransition] between a new widget and
-/// the widget previously set on the [AnimatedChildSwitcher] as a child.
+/// the widget previously set on the [AnimatedSwitcher] as a child.
 ///
 /// If they are swapped fast enough (i.e. before [duration] elapses), more than
 /// one previous child can exist and be transitioning out while the newest one
 /// is transitioning in.
 ///
 /// If the "new" child is the same widget type as the "old" child, but with
-/// different parameters, then [AnimatedChildSwitcher] will *not* do a
+/// different parameters, then [AnimatedSwitcher] will *not* do a
 /// transition between them, since as far as the framework is concerned, they
 /// are the same widget, and the existing widget can be updated with the new
 /// parameters. If you wish to force the transition to occur, set a [Key]
@@ -88,7 +88,7 @@ typedef Widget AnimatedChildSwitcherLayoutBuilder(List<Widget> children);
 ///       child: Column(
 ///         mainAxisAlignment: MainAxisAlignment.center,
 ///         children: <Widget>[
-///           new AnimatedChildSwitcher(
+///           new AnimatedSwitcher(
 ///             duration: const Duration(milliseconds: 200),
 ///             transitionBuilder: (Widget child, Animation<double> animation) {
 ///               return new ScaleTransition(child: child, scale: animation);
@@ -119,20 +119,20 @@ typedef Widget AnimatedChildSwitcherLayoutBuilder(List<Widget> children);
 ///
 ///  * [AnimatedCrossFade], which only fades between two children, but also
 ///    interpolates their sizes, and is reversible.
-///  * [FadeTransition] which [AnimatedChildSwitcher] uses to perform the transition.
-class AnimatedChildSwitcher extends StatefulWidget {
-  /// Creates an [AnimatedChildSwitcher].
+///  * [FadeTransition] which [AnimatedSwitcher] uses to perform the transition.
+class AnimatedSwitcher extends StatefulWidget {
+  /// Creates an [AnimatedSwitcher].
   ///
   /// The [duration], [transitionBuilder], [layoutBuilder], [switchInCurve], and
   /// [switchOutCurve] parameters must not be null.
-  const AnimatedChildSwitcher({
+  const AnimatedSwitcher({
     Key key,
     this.child,
     @required this.duration,
     this.switchInCurve: Curves.linear,
     this.switchOutCurve: Curves.linear,
-    this.transitionBuilder: AnimatedChildSwitcher.defaultTransitionBuilder,
-    this.layoutBuilder: AnimatedChildSwitcher.defaultLayoutBuilder,
+    this.transitionBuilder: AnimatedSwitcher.defaultTransitionBuilder,
+    this.layoutBuilder: AnimatedSwitcher.defaultLayoutBuilder,
   })  : assert(duration != null),
         assert(switchInCurve != null),
         assert(switchOutCurve != null),
@@ -161,37 +161,37 @@ class AnimatedChildSwitcher extends StatefulWidget {
   /// the [child] in when the animation runs in the forward direction and out
   /// when the animation runs in the reverse direction.
   ///
-  /// The default is [AnimatedChildSwitcher.defaultTransitionBuilder].
+  /// The default is [AnimatedSwitcher.defaultTransitionBuilder].
   ///
   /// See also:
   ///
-  ///  * [AnimatedChildSwitcherTransitionBuilder] for more information about
+  ///  * [AnimatedSwitcherTransitionBuilder] for more information about
   ///    how a transition builder should function.
-  final AnimatedChildSwitcherTransitionBuilder transitionBuilder;
+  final AnimatedSwitcherTransitionBuilder transitionBuilder;
 
   /// A function that wraps all of the children that are transitioning out, and
   /// the [child] that's transitioning in, with a widget that lays all of them
   /// out.
   ///
-  /// The default is [AnimatedChildSwitcher.defaultLayoutBuilder].
+  /// The default is [AnimatedSwitcher.defaultLayoutBuilder].
   ///
   /// See also:
   ///
-  ///  * [AnimatedChildSwitcherLayoutBuilder] for more information about
+  ///  * [AnimatedSwitcherLayoutBuilder] for more information about
   ///    how a layout builder should function.
-  final AnimatedChildSwitcherLayoutBuilder layoutBuilder;
+  final AnimatedSwitcherLayoutBuilder layoutBuilder;
 
   @override
-  _AnimatedChildSwitcherState createState() => new _AnimatedChildSwitcherState();
+  _AnimatedSwitcherState createState() => new _AnimatedSwitcherState();
 
-  /// The default transition algorithm used by [AnimatedChildSwitcher].
+  /// The default transition algorithm used by [AnimatedSwitcher].
   ///
   /// The new child is given a [FadeTransition] which increases opacity as
   /// the animation goes from 0.0 to 1.0, and decreases when the animation is
   /// reversed.
   ///
   /// The default value for the [transitionBuilder], an
-  /// [AnimatedChildSwitcherTransitionBuilder] function.
+  /// [AnimatedSwitcherTransitionBuilder] function.
   static Widget defaultTransitionBuilder(Widget child, Animation<double> animation) {
     return new FadeTransition(
       opacity: animation,
@@ -199,14 +199,14 @@ class AnimatedChildSwitcher extends StatefulWidget {
     );
   }
 
-  /// The default layout algorithm used by [AnimatedChildSwitcher].
+  /// The default layout algorithm used by [AnimatedSwitcher].
   ///
   /// The new child is placed in a [Stack] that sizes itself to match the
   /// largest of the child or a previous child. The children are centered on
   /// each other.
   ///
   /// This is the default value for [layoutBuilder]. It implements
-  /// [AnimatedChildSwitcherLayoutBuilder].
+  /// [AnimatedSwitcherLayoutBuilder].
   static Widget defaultLayoutBuilder(List<Widget> children) {
     return new Stack(
       children: children,
@@ -215,9 +215,9 @@ class AnimatedChildSwitcher extends StatefulWidget {
   }
 }
 
-class _AnimatedChildSwitcherState extends State<AnimatedChildSwitcher> with TickerProviderStateMixin {
-  final Set<_AnimatedChildSwitcherChildEntry> _children = new Set<_AnimatedChildSwitcherChildEntry>();
-  _AnimatedChildSwitcherChildEntry _currentChild;
+class _AnimatedSwitcherState extends State<AnimatedSwitcher> with TickerProviderStateMixin {
+  final Set<_AnimatedSwitcherChildEntry> _children = new Set<_AnimatedSwitcherChildEntry>();
+  _AnimatedSwitcherChildEntry _currentChild;
 
   @override
   void initState() {
@@ -232,11 +232,11 @@ class _AnimatedChildSwitcherState extends State<AnimatedChildSwitcher> with Tick
     );
   }
 
-  _AnimatedChildSwitcherChildEntry _newEntry({
+  _AnimatedSwitcherChildEntry _newEntry({
     @required AnimationController controller,
     @required Animation<double> animation,
   }) {
-    final _AnimatedChildSwitcherChildEntry entry = new _AnimatedChildSwitcherChildEntry(
+    final _AnimatedSwitcherChildEntry entry = new _AnimatedSwitcherChildEntry(
       widgetChild: widget.child,
       transition: _generateTransition(animation),
       animation: animation,
@@ -293,7 +293,7 @@ class _AnimatedChildSwitcherState extends State<AnimatedChildSwitcher> with Tick
     if (_currentChild != null) {
       _currentChild.controller.dispose();
     }
-    for (_AnimatedChildSwitcherChildEntry child in _children) {
+    for (_AnimatedSwitcherChildEntry child in _children) {
       child.controller.dispose();
     }
     super.dispose();
@@ -303,7 +303,7 @@ class _AnimatedChildSwitcherState extends State<AnimatedChildSwitcher> with Tick
   bool get hasOldChild => _currentChild != null;
 
   @override
-  void didUpdateWidget(AnimatedChildSwitcher oldWidget) {
+  void didUpdateWidget(AnimatedSwitcher oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (hasNewChild != hasOldChild || hasNewChild &&
         !Widget.canUpdate(widget.child, _currentChild.widgetChild)) {
@@ -319,7 +319,7 @@ class _AnimatedChildSwitcherState extends State<AnimatedChildSwitcher> with Tick
   @override
   Widget build(BuildContext context) {
     final List<Widget> children = _children.map<Widget>(
-      (_AnimatedChildSwitcherChildEntry entry) {
+      (_AnimatedSwitcherChildEntry entry) {
         return entry.transition;
       },
     ).toList();

--- a/packages/flutter/lib/widgets.dart
+++ b/packages/flutter/lib/widgets.dart
@@ -14,10 +14,10 @@ library widgets;
 
 export 'package:vector_math/vector_math_64.dart' show Matrix4;
 
-export 'src/widgets/animated_child_switcher.dart';
 export 'src/widgets/animated_cross_fade.dart';
 export 'src/widgets/animated_list.dart';
 export 'src/widgets/animated_size.dart';
+export 'src/widgets/animated_switcher.dart';
 export 'src/widgets/app.dart';
 export 'src/widgets/async.dart';
 export 'src/widgets/automatic_keep_alive.dart';

--- a/packages/flutter/test/widgets/animated_switcher_test.dart
+++ b/packages/flutter/test/widgets/animated_switcher_test.dart
@@ -6,12 +6,12 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  testWidgets('AnimatedChildSwitcher fades in a new child.', (WidgetTester tester) async {
+  testWidgets('AnimatedSwitcher fades in a new child.', (WidgetTester tester) async {
     final UniqueKey containerOne = new UniqueKey();
     final UniqueKey containerTwo = new UniqueKey();
     final UniqueKey containerThree = new UniqueKey();
     await tester.pumpWidget(
-      new AnimatedChildSwitcher(
+      new AnimatedSwitcher(
         duration: const Duration(milliseconds: 100),
         child: new Container(key: containerOne, color: const Color(0x00000000)),
         switchInCurve: Curves.linear,
@@ -23,7 +23,7 @@ void main() {
     expect(transition.opacity.value, equals(1.0));
 
     await tester.pumpWidget(
-      new AnimatedChildSwitcher(
+      new AnimatedSwitcher(
         duration: const Duration(milliseconds: 100),
         child: new Container(key: containerTwo, color: const Color(0xff000000)),
         switchInCurve: Curves.linear,
@@ -36,7 +36,7 @@ void main() {
     expect(transition.opacity.value, equals(0.5));
 
     await tester.pumpWidget(
-      new AnimatedChildSwitcher(
+      new AnimatedSwitcher(
         duration: const Duration(milliseconds: 100),
         child: new Container(key: containerThree, color: const Color(0xffff0000)),
         switchInCurve: Curves.linear,
@@ -54,9 +54,9 @@ void main() {
     await tester.pumpAndSettle();
   });
 
-  testWidgets("AnimatedChildSwitcher doesn't transition in a new child of the same type.", (WidgetTester tester) async {
+  testWidgets("AnimatedSwitcher doesn't transition in a new child of the same type.", (WidgetTester tester) async {
     await tester.pumpWidget(
-      new AnimatedChildSwitcher(
+      new AnimatedSwitcher(
         duration: const Duration(milliseconds: 100),
         child: new Container(color: const Color(0x00000000)),
         switchInCurve: Curves.linear,
@@ -68,7 +68,7 @@ void main() {
     expect(transition.opacity.value, equals(1.0));
 
     await tester.pumpWidget(
-      new AnimatedChildSwitcher(
+      new AnimatedSwitcher(
         duration: const Duration(milliseconds: 100),
         child: new Container(color: const Color(0xff000000)),
         switchInCurve: Curves.linear,
@@ -82,9 +82,9 @@ void main() {
     await tester.pumpAndSettle();
   });
 
-  testWidgets('AnimatedChildSwitcher handles null children.', (WidgetTester tester) async {
+  testWidgets('AnimatedSwitcher handles null children.', (WidgetTester tester) async {
     await tester.pumpWidget(
-      const AnimatedChildSwitcher(
+      const AnimatedSwitcher(
         duration: const Duration(milliseconds: 100),
         child: null,
         switchInCurve: Curves.linear,
@@ -95,7 +95,7 @@ void main() {
     expect(find.byType(FadeTransition), findsNothing);
 
     await tester.pumpWidget(
-      new AnimatedChildSwitcher(
+      new AnimatedSwitcher(
         duration: const Duration(milliseconds: 100),
         child: new Container(color: const Color(0xff000000)),
         switchInCurve: Curves.linear,
@@ -109,7 +109,7 @@ void main() {
     await tester.pumpAndSettle();
 
     await tester.pumpWidget(
-      new AnimatedChildSwitcher(
+      new AnimatedSwitcher(
         duration: const Duration(milliseconds: 100),
         child: new Container(color: const Color(0x00000000)),
         switchInCurve: Curves.linear,
@@ -121,7 +121,7 @@ void main() {
     expect(transition.opacity.value, equals(1.0));
 
     await tester.pumpWidget(
-      const AnimatedChildSwitcher(
+      const AnimatedSwitcher(
         duration: const Duration(milliseconds: 100),
         child: null,
         switchInCurve: Curves.linear,
@@ -134,7 +134,7 @@ void main() {
     expect(transition.opacity.value, equals(0.5));
 
     await tester.pumpWidget(
-      const AnimatedChildSwitcher(
+      const AnimatedSwitcher(
         duration: const Duration(milliseconds: 100),
         child: null,
         switchInCurve: Curves.linear,
@@ -149,8 +149,8 @@ void main() {
     await tester.pumpAndSettle();
   });
 
-  testWidgets("AnimatedChildSwitcher doesn't start any animations after dispose.", (WidgetTester tester) async {
-    await tester.pumpWidget(new AnimatedChildSwitcher(
+  testWidgets("AnimatedSwitcher doesn't start any animations after dispose.", (WidgetTester tester) async {
+    await tester.pumpWidget(new AnimatedSwitcher(
       duration: const Duration(milliseconds: 100),
       child: new Container(color: const Color(0xff000000)),
       switchInCurve: Curves.linear,
@@ -162,7 +162,7 @@ void main() {
     expect(await tester.pumpAndSettle(const Duration(milliseconds: 100)), equals(1));
   });
 
-  testWidgets('AnimatedChildSwitcher uses custom layout.', (WidgetTester tester) async {
+  testWidgets('AnimatedSwitcher uses custom layout.', (WidgetTester tester) async {
     Widget newLayoutBuilder(List<Widget> children) {
       return new Column(
         children: children,
@@ -170,7 +170,7 @@ void main() {
     }
 
     await tester.pumpWidget(
-      new AnimatedChildSwitcher(
+      new AnimatedSwitcher(
         duration: const Duration(milliseconds: 100),
         child: new Container(color: const Color(0x00000000)),
         switchInCurve: Curves.linear,
@@ -181,7 +181,7 @@ void main() {
     expect(find.byType(Column), findsOneWidget);
   });
 
-  testWidgets('AnimatedChildSwitcher uses custom transitions.', (WidgetTester tester) async {
+  testWidgets('AnimatedSwitcher uses custom transitions.', (WidgetTester tester) async {
     final List<Widget> transitions = <Widget>[];
     Widget newLayoutBuilder(List<Widget> children) {
       transitions.clear();
@@ -201,7 +201,7 @@ void main() {
     await tester.pumpWidget(
       new Directionality(
         textDirection: TextDirection.rtl,
-        child: new AnimatedChildSwitcher(
+        child: new AnimatedSwitcher(
           duration: const Duration(milliseconds: 100),
           child: new Container(color: const Color(0x00000000)),
           switchInCurve: Curves.linear,


### PR DESCRIPTION
We don't really like the name AnimatedChildSwitcher, and we think that AnimatedSwitcher might be better (since the Child part is redundant).

Nothing in here besides a rename.