### PR TITLE
Fix #16464: Pass hit test when a big child is inside RenderFittedBox

### DIFF
--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -2073,7 +2073,7 @@ class RenderTransform extends RenderProxyBox {
   }
 
   @override
-  bool hitTest(HitTestResult result, { Offset position }) {
+  bool hitTestChildren(HitTestResult result, { Offset position }) {
     if (transformHitTests) {
       final Matrix4 inverse = Matrix4.tryInvert(_effectiveTransform);
       if (inverse == null) {
@@ -2083,7 +2083,7 @@ class RenderTransform extends RenderProxyBox {
       }
       position = MatrixUtils.transformPoint(inverse, position);
     }
-    return hitTestChildren(result, position: position) ||super.hitTest(result, position: position);
+    return super.hitTestChildren(result, position: position);
   }
 
   @override
@@ -2254,7 +2254,7 @@ class RenderFittedBox extends RenderProxyBox {
   }
 
   @override
-  bool hitTest(HitTestResult result, { Offset position }) {
+  bool hitTestChildren(HitTestResult result, { Offset position }) {
     if (size.isEmpty)
       return false;
     _updatePaintData();
@@ -2265,7 +2265,7 @@ class RenderFittedBox extends RenderProxyBox {
       return false;
     }
     position = MatrixUtils.transformPoint(inverse, position);
-    return hitTestChildren(result, position: position) || super.hitTest(result, position: position);
+    return super.hitTestChildren(result, position: position);
   }
 
   @override
@@ -2331,7 +2331,7 @@ class RenderFractionalTranslation extends RenderProxyBox {
   bool transformHitTests;
 
   @override
-  bool hitTest(HitTestResult result, { Offset position }) {
+  bool hitTestChildren(HitTestResult result, { Offset position }) {
     assert(!debugNeedsLayout);
     if (transformHitTests) {
       position = new Offset(
@@ -2339,7 +2339,7 @@ class RenderFractionalTranslation extends RenderProxyBox {
         position.dy - translation.dy * size.height,
       );
     }
-    return hitTestChildren(result, position: position) || super.hitTest(result, position: position);
+    return super.hitTestChildren(result, position: position);
   }
 
   @override
@@ -4173,7 +4173,7 @@ class RenderFollowerLayer extends RenderProxyBox {
   }
 
   @override
-  bool hitTest(HitTestResult result, { Offset position }) {
+  bool hitTestChildren(HitTestResult result, { Offset position }) {
     final Matrix4 inverse = Matrix4.tryInvert(getCurrentTransform());
     if (inverse == null) {
       // We cannot invert the effective transform. That means the child
@@ -4181,7 +4181,7 @@ class RenderFollowerLayer extends RenderProxyBox {
       return false;
     }
     position = MatrixUtils.transformPoint(inverse, position);
-    return hitTestChildren(result, position: position) || super.hitTest(result, position: position);
+    return super.hitTestChildren(result, position: position);
   }
 
   @override

--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -2083,7 +2083,7 @@ class RenderTransform extends RenderProxyBox {
       }
       position = MatrixUtils.transformPoint(inverse, position);
     }
-    return super.hitTest(result, position: position);
+    return hitTestChildren(result, position: position) ||super.hitTest(result, position: position);
   }
 
   @override
@@ -2265,7 +2265,7 @@ class RenderFittedBox extends RenderProxyBox {
       return false;
     }
     position = MatrixUtils.transformPoint(inverse, position);
-    return super.hitTest(result, position: position);
+    return hitTestChildren(result, position: position) || super.hitTest(result, position: position);
   }
 
   @override
@@ -2339,7 +2339,7 @@ class RenderFractionalTranslation extends RenderProxyBox {
         position.dy - translation.dy * size.height,
       );
     }
-    return super.hitTest(result, position: position);
+    return hitTestChildren(result, position: position) || super.hitTest(result, position: position);
   }
 
   @override
@@ -4181,7 +4181,7 @@ class RenderFollowerLayer extends RenderProxyBox {
       return false;
     }
     position = MatrixUtils.transformPoint(inverse, position);
-    return super.hitTest(result, position: position);
+    return hitTestChildren(result, position: position) || super.hitTest(result, position: position);
   }
 
   @override

--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -2331,6 +2331,15 @@ class RenderFractionalTranslation extends RenderProxyBox {
     markNeedsPaint();
   }
 
+  @override
+  bool hitTest(HitTestResult result, { Offset position }) {
+    // RenderFractionalTranslation objects don't check if they are
+    // themselves hit, because it's confusing to think about
+    // how the untransformed size and the child's transformed
+    // position interact.
+    return hitTestChildren(result, position: position);
+  }
+
   /// When set to true, hit tests are performed based on the position of the
   /// child as it is painted. When set to false, hit tests are performed
   /// ignoring the transformation.

--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -2073,6 +2073,15 @@ class RenderTransform extends RenderProxyBox {
   }
 
   @override
+  bool hitTest(HitTestResult result, { Offset position }) {
+    // RenderTransform objects don't check if they are
+    // themselves hit, because it's confusing to think about
+    // how the untransformed size and the child's transformed
+    // position interact.
+    return hitTestChildren(result, position: position);
+  }
+
+  @override
   bool hitTestChildren(HitTestResult result, { Offset position }) {
     if (transformHitTests) {
       final Matrix4 inverse = Matrix4.tryInvert(_effectiveTransform);
@@ -4170,6 +4179,15 @@ class RenderFollowerLayer extends RenderProxyBox {
   /// [new Matrix4.identity].
   Matrix4 getCurrentTransform() {
     return _layer?.getLastTransform() ?? new Matrix4.identity();
+  }
+
+  @override
+  bool hitTest(HitTestResult result, { Offset position }) {
+    // RenderFollowerLayer objects don't check if they are
+    // themselves hit, because it's confusing to think about
+    // how the untransformed size and the child's transformed
+    // position interact.
+    return hitTestChildren(result, position: position);
   }
 
   @override

--- a/packages/flutter/test/widgets/basic_test.dart
+++ b/packages/flutter/test/widgets/basic_test.dart
@@ -54,6 +54,37 @@ void main() {
 
   });
 
+  group('FractionalTranslation', () {
+    testWidgets('hit test', (WidgetTester tester) async {
+      final GlobalKey key1 = new GlobalKey();
+      bool _pointerDown = false;
+
+      await tester.pumpWidget(
+        new Center(
+          child: new FractionalTranslation(
+            translation: const Offset(1.0, 1.0),
+            transformHitTests: true,
+            child: new Listener(
+              onPointerDown: (PointerDownEvent event) {
+                _pointerDown = true;
+              },
+              child: new SizedBox(
+                key: key1,
+                width: 100.0,
+                height: 100.0,
+                child: new Container(
+                  color: const Color(0xFF0000FF)
+                ),
+              ),
+            )
+          )
+        )
+      );
+      expect(_pointerDown, isFalse);
+      await tester.tap(find.byKey(key1));
+      expect(_pointerDown, isTrue);
+    });
+  });
 }
 
 HitsRenderBox hits(RenderBox renderBox) => new HitsRenderBox(renderBox);

--- a/packages/flutter/test/widgets/basic_test.dart
+++ b/packages/flutter/test/widgets/basic_test.dart
@@ -55,7 +55,7 @@ void main() {
   });
 
   group('FractionalTranslation', () {
-    testWidgets('hit test - inside bounding box', (WidgetTester tester) async {
+    testWidgets('hit test - entirely inside the bounding box', (WidgetTester tester) async {
       final GlobalKey key1 = new GlobalKey();
       bool _pointerDown = false;
 
@@ -85,7 +85,37 @@ void main() {
       expect(_pointerDown, isTrue);
     });
 
-    testWidgets('hit test - outside bounding box', (WidgetTester tester) async {
+    testWidgets('hit test - partially inside the bounding box', (WidgetTester tester) async {
+      final GlobalKey key1 = new GlobalKey();
+      bool _pointerDown = false;
+
+      await tester.pumpWidget(
+        new Center(
+          child: new FractionalTranslation(
+            translation: const Offset(0.5, 0.5),
+            transformHitTests: true,
+            child: new Listener(
+              onPointerDown: (PointerDownEvent event) {
+                _pointerDown = true;
+              },
+              child: new SizedBox(
+                key: key1,
+                width: 100.0,
+                height: 100.0,
+                child: new Container(
+                  color: const Color(0xFF0000FF)
+                ),
+              ),
+            )
+          )
+        )
+      );
+      expect(_pointerDown, isFalse);
+      await tester.tap(find.byKey(key1));
+      expect(_pointerDown, isTrue);
+    });
+
+    testWidgets('hit test - completely outside the bounding box', (WidgetTester tester) async {
       final GlobalKey key1 = new GlobalKey();
       bool _pointerDown = false;
 

--- a/packages/flutter/test/widgets/basic_test.dart
+++ b/packages/flutter/test/widgets/basic_test.dart
@@ -55,7 +55,37 @@ void main() {
   });
 
   group('FractionalTranslation', () {
-    testWidgets('hit test', (WidgetTester tester) async {
+    testWidgets('hit test - inside bounding box', (WidgetTester tester) async {
+      final GlobalKey key1 = new GlobalKey();
+      bool _pointerDown = false;
+
+      await tester.pumpWidget(
+        new Center(
+          child: new FractionalTranslation(
+            translation: Offset.zero,
+            transformHitTests: true,
+            child: new Listener(
+              onPointerDown: (PointerDownEvent event) {
+                _pointerDown = true;
+              },
+              child: new SizedBox(
+                key: key1,
+                width: 100.0,
+                height: 100.0,
+                child: new Container(
+                  color: const Color(0xFF0000FF)
+                ),
+              ),
+            )
+          )
+        )
+      );
+      expect(_pointerDown, isFalse);
+      await tester.tap(find.byKey(key1));
+      expect(_pointerDown, isTrue);
+    });
+
+    testWidgets('hit test - outside bounding box', (WidgetTester tester) async {
       final GlobalKey key1 = new GlobalKey();
       bool _pointerDown = false;
 

--- a/packages/flutter/test/widgets/fitted_box_test.dart
+++ b/packages/flutter/test/widgets/fitted_box_test.dart
@@ -439,6 +439,39 @@ void main() {
       }
     }
   });
+
+  testWidgets('Big child into small fitted box - hit testing', (WidgetTester tester) async {
+    final GlobalKey key1 = new GlobalKey();
+    bool _pointerDown = false;
+    await tester.pumpWidget(
+      new Center(
+        child: new SizedBox(
+          width: 100.0,
+          height: 100.0,
+          child: new FittedBox(
+            fit: BoxFit.contain,
+            alignment: FractionalOffset.center,
+            child: new SizedBox(
+              width: 1000.0,
+              height: 1000.0,
+              child: new Listener(
+                onPointerDown: (PointerDownEvent event) {
+                  _pointerDown = true;
+                },
+                child: new Container(
+                  key: key1,
+                  color: const Color(0xFF000000),
+                )
+              )
+            )
+          )
+        )
+      )
+    );
+    expect(_pointerDown, isFalse);
+    await tester.tap(find.byKey(key1));
+    expect(_pointerDown, isTrue);
+  });
 }
 
 List<Type> getLayers() {

--- a/packages/flutter/test/widgets/transform_test.dart
+++ b/packages/flutter/test/widgets/transform_test.dart
@@ -333,4 +333,29 @@ void main() {
       -400.0, -300.0, 0.0, 1.0, // it's 1600x1200, centered in an 800x600 square
     ]);
   });
+
+  testWidgets('Translated child into translated box - hit test', (WidgetTester tester) async {
+    final GlobalKey key1 = new GlobalKey();
+    bool _pointerDown = false;
+    await tester.pumpWidget(
+      new Transform.translate(
+        offset: const Offset(100.0, 50.0),
+        child: new Transform.translate(
+          offset: const Offset(1000.0, 1000.0),
+          child: new Listener(
+            onPointerDown: (PointerDownEvent event) {
+              _pointerDown = true;
+            },
+            child: new Container(
+              key: key1,
+              color: const Color(0xFF000000),
+            )
+          )
+        )
+      ),
+    );
+    expect(_pointerDown, isFalse);
+    await tester.tap(find.byKey(key1));
+    expect(_pointerDown, isTrue);
+  });
 }


### PR DESCRIPTION
I took a look at issue #16464 and found that `RenderProxyBoxMixin` already overrides `hitTestChildren`. However, when `RenderBox.hitTest` is called, the `_size.contains(position)` seems to be false. Thus, causing the entire test to return false. 
