### PR TITLE
Remove the rest of the uses of Number.tryParse()

### DIFF
--- a/dev/bots/analyze-sample-code.dart
+++ b/dev/bots/analyze-sample-code.dart
@@ -238,11 +238,13 @@ dependencies:
           throw 'failed to parse error message: $error';
         }
         final String column = error.substring(colon2 + kColon.length, bullet2);
-        final int lineNumber = int.tryParse(line, radix: 10);
+        // ignore: deprecated_member_use
+        final int lineNumber = int.parse(line, radix: 10, onError: (String source) => throw 'failed to parse error message: $error');
+        // ignore: deprecated_member_use
+        final int columnNumber = int.parse(column, radix: 10, onError: (String source) => throw 'failed to parse error message: $error');
         if (lineNumber == null) {
           throw 'failed to parse error message: $error';
         }
-        final int columnNumber = int.tryParse(column, radix: 10);
         if (columnNumber == null) {
           throw 'failed to parse error message: $error';
         }

--- a/packages/flutter_tools/lib/src/commands/fuchsia_reload.dart
+++ b/packages/flutter_tools/lib/src/commands/fuchsia_reload.dart
@@ -384,7 +384,8 @@ class FuchsiaReloadCommand extends FlutterCommand {
         final int lastSpace = trimmed.lastIndexOf(' ');
         final String lastWord = trimmed.substring(lastSpace + 1);
         if ((lastWord != '.') && (lastWord != '..')) {
-          final int value = int.tryParse(lastWord);
+          // ignore: deprecated_member_use
+          final int value = int.parse(lastWord, onError: (_) => null);
           if (value != null)
             ports.add(value);
         }

--- a/packages/fuchsia_remote_debug_protocol/lib/src/fuchsia_remote_connection.dart
+++ b/packages/fuchsia_remote_debug_protocol/lib/src/fuchsia_remote_connection.dart
@@ -197,7 +197,8 @@ class FuchsiaRemoteConnection {
       final int lastSpace = trimmed.lastIndexOf(' ');
       final String lastWord = trimmed.substring(lastSpace + 1);
       if ((lastWord != '.') && (lastWord != '..')) {
-        final int value = int.tryParse(lastWord);
+        // ignore: deprecated_member_use
+        final int value = int.parse(lastWord, onError: (_) => null);
         if (value != null) {
           ports.add(value);
         }


### PR DESCRIPTION
Theses occurrences of tryParse() the G3 Flutter roll (but strangely, not the G3 tests).

As with https://github.com/flutter/flutter/pull/16546, replaced all occurrences of `Number.tryParse()` with

```
// ignore: deprecated_member_use
.. original use of int.parse()
```
