### PR TITLE
Retry on SocketException in fetchUrl

### DIFF
--- a/packages/flutter_tools/lib/src/base/net.dart
+++ b/packages/flutter_tools/lib/src/base/net.dart
@@ -48,6 +48,9 @@ Future<List<int>> _attempt(Uri url) async {
       'URL: $url',
       exitCode: kNetworkProblemExitCode,
     );
+  } on SocketException catch (error) {
+    printTrace('Download error: $error');
+    return null;
   }
   final HttpClientResponse response = await request.close();
   if (response.statusCode != 200) {


### PR DESCRIPTION
Fixes #16545.  May also fix parts of #11546.

In addition to adding a test for SocketException, added a test for verifying the HandshakeException handling and renamed a variable to avoid accidentally storing the error message to the wrong place.