### PR TITLE
Fix #16247: SizeTransition clamps negative size factors

### DIFF
--- a/packages/flutter/lib/src/widgets/transitions.dart
+++ b/packages/flutter/lib/src/widgets/transitions.dart
@@ -290,8 +290,8 @@ class SizeTransition extends AnimatedWidget {
     return new ClipRect(
       child: new Align(
         alignment: alignment,
-        heightFactor: axis == Axis.vertical ? sizeFactor.value : null,
-        widthFactor: axis == Axis.horizontal ? sizeFactor.value : null,
+        heightFactor: axis == Axis.vertical ? math.max(sizeFactor.value, 0.0) : null,
+        widthFactor: axis == Axis.horizontal ? math.max(sizeFactor.value, 0.0) : null,
         child: child,
       )
     );

--- a/packages/flutter/test/widgets/transitions_test.dart
+++ b/packages/flutter/test/widgets/transitions_test.dart
@@ -191,4 +191,66 @@ void main() {
     expect(actualAlign.widthFactor, 0.3);
     expect(actualAlign.heightFactor, 0.4);
   });
+
+  testWidgets('SizeTransition clamps negative size factors - vertical axis', (WidgetTester tester) async {
+    final AnimationController controller = new AnimationController(vsync: const TestVSync());
+    final Animation<double> animation = new Tween(begin: -1.0, end: 1.0).animate(controller);
+
+    final Widget widget =  new Directionality(
+        textDirection: TextDirection.ltr,
+        child: new SizeTransition(
+          axis: Axis.vertical,
+          sizeFactor: animation,
+          child: const Text('Ready'),
+        ),
+      );
+
+    await tester.pumpWidget(widget);
+
+    final RenderPositionedBox actualPositionedBox = tester.renderObject(find.byType(Align));
+    expect(actualPositionedBox.heightFactor, 0.0);
+
+    controller.value = 0.0;
+    await tester.pump();
+    expect(actualPositionedBox.heightFactor, 0.0);
+
+    controller.value = 0.75;
+    await tester.pump();
+    expect(actualPositionedBox.heightFactor, 0.5);
+
+    controller.value = 1.0;
+    await tester.pump();
+    expect(actualPositionedBox.heightFactor, 1.0);
+  });
+
+  testWidgets('SizeTransition clamps negative size factors - horizontal axis', (WidgetTester tester) async {
+    final AnimationController controller = new AnimationController(vsync: const TestVSync());
+    final Animation<double> animation = new Tween(begin: -1.0, end: 1.0).animate(controller);
+
+    final Widget widget =  new Directionality(
+        textDirection: TextDirection.ltr,
+        child: new SizeTransition(
+          axis: Axis.horizontal,
+          sizeFactor: animation,
+          child: const Text('Ready'),
+        ),
+      );
+
+    await tester.pumpWidget(widget);
+
+    final RenderPositionedBox actualPositionedBox = tester.renderObject(find.byType(Align));
+    expect(actualPositionedBox.widthFactor, 0.0);
+
+    controller.value = 0.0;
+    await tester.pump();
+    expect(actualPositionedBox.widthFactor, 0.0);
+
+    controller.value = 0.75;
+    await tester.pump();
+    expect(actualPositionedBox.widthFactor, 0.5);
+
+    controller.value = 1.0;
+    await tester.pump();
+    expect(actualPositionedBox.widthFactor, 1.0);
+  });
 }

--- a/packages/flutter/test/widgets/transitions_test.dart
+++ b/packages/flutter/test/widgets/transitions_test.dart
@@ -194,7 +194,7 @@ void main() {
 
   testWidgets('SizeTransition clamps negative size factors - vertical axis', (WidgetTester tester) async {
     final AnimationController controller = new AnimationController(vsync: const TestVSync());
-    final Animation<double> animation = new Tween(begin: -1.0, end: 1.0).animate(controller);
+    final Animation<double> animation = new Tween<double>(begin: -1.0, end: 1.0).animate(controller);
 
     final Widget widget =  new Directionality(
         textDirection: TextDirection.ltr,
@@ -225,7 +225,7 @@ void main() {
 
   testWidgets('SizeTransition clamps negative size factors - horizontal axis', (WidgetTester tester) async {
     final AnimationController controller = new AnimationController(vsync: const TestVSync());
-    final Animation<double> animation = new Tween(begin: -1.0, end: 1.0).animate(controller);
+    final Animation<double> animation = new Tween<double>(begin: -1.0, end: 1.0).animate(controller);
 
     final Widget widget =  new Directionality(
         textDirection: TextDirection.ltr,


### PR DESCRIPTION
As pointed out in the bug, the issue is fixed by just clamping `sizeFactor.value`. 