### PR TITLE
Update for dropdown icon to be @ right most side

### DIFF
--- a/packages/flutter/lib/src/material/dropdown.dart
+++ b/packages/flutter/lib/src/material/dropdown.dart
@@ -643,7 +643,7 @@ class _DropdownButtonState<T> extends State<DropdownButton<T>> with WidgetsBindi
         height: widget.isDense ? _denseButtonHeight : null,
         child: new Row(
           mainAxisAlignment: MainAxisAlignment.spaceBetween,
-          mainAxisSize: MainAxisSize.min,
+          mainAxisSize: MainAxisSize.max,
           children: <Widget>[
             // If value is null (then _selectedIndex is null) then we display
             // the hint or nothing at all.


### PR DESCRIPTION
Dropdown icon hangs with just next to text of dropdown button which is fine for default-sized dropdown button. But for bigger customized width dropdown icon should be at rightmost side of dropdown button.