### PR TITLE
Always add a DevFS asset entry for the font manifest

### DIFF
--- a/packages/flutter_tools/lib/src/asset.dart
+++ b/packages/flutter_tools/lib/src/asset.dart
@@ -204,9 +204,7 @@ class _ManifestAssetBundle implements AssetBundle {
 
     entries[_kAssetManifestJson] = _createAssetManifest(assetVariants);
 
-
-    if (fonts.isNotEmpty)
-      entries[_kFontManifestJson] = new DevFSStringContent(json.encode(fonts));
+    entries[_kFontManifestJson] = new DevFSStringContent(json.encode(fonts));
 
     // TODO(ianh): Only do the following line if we've changed packages or if our LICENSE file changed
     entries[_kLICENSE] = await _obtainLicenses(packageMap, assetBasePath, reportPackages: reportLicensedPackages);

--- a/packages/flutter_tools/test/asset_bundle_package_fonts_test.dart
+++ b/packages/flutter_tools/test/asset_bundle_package_fonts_test.dart
@@ -123,8 +123,8 @@ $fontsSection
 
       final AssetBundle bundle = AssetBundleFactory.instance.createBundle();
       await bundle.build(manifestPath: 'pubspec.yaml');
-      expect(bundle.entries.length, 2); // LICENSE, AssetManifest
-      expect(bundle.entries.containsKey('FontManifest.json'), false);
+      expect(bundle.entries.length, 3); // LICENSE, AssetManifest, FontManifest
+      expect(bundle.entries.containsKey('FontManifest.json'), isTrue);
     });
 
     testUsingContext('App font uses font file from package', () async {

--- a/packages/flutter_tools/test/asset_bundle_package_test.dart
+++ b/packages/flutter_tools/test/asset_bundle_package_test.dart
@@ -124,11 +124,15 @@ $assetsSection
 
       final AssetBundle bundle = AssetBundleFactory.instance.createBundle();
       await bundle.build(manifestPath: 'pubspec.yaml');
-      expect(bundle.entries.length, 2); // LICENSE, AssetManifest
+      expect(bundle.entries.length, 3); // LICENSE, AssetManifest, FontManifest
       const String expectedAssetManifest = '{}';
       expect(
         utf8.decode(await bundle.entries['AssetManifest.json'].contentsAsBytes()),
         expectedAssetManifest,
+      );
+      expect(
+        utf8.decode(await bundle.entries['FontManifest.json'].contentsAsBytes()),
+        '[]',
       );
     });
 
@@ -144,13 +148,16 @@ $assetsSection
 
       final AssetBundle bundle = AssetBundleFactory.instance.createBundle();
       await bundle.build(manifestPath: 'pubspec.yaml');
-      expect(bundle.entries.length, 2); // LICENSE, AssetManifest
+      expect(bundle.entries.length, 3); // LICENSE, AssetManifest, FontManifest
       const String expectedAssetManifest = '{}';
       expect(
         utf8.decode(await bundle.entries['AssetManifest.json'].contentsAsBytes()),
         expectedAssetManifest,
       );
-
+      expect(
+        utf8.decode(await bundle.entries['FontManifest.json'].contentsAsBytes()),
+        '[]',
+      );
     });
 
     testUsingContext('One asset is bundled when the package has and lists one asset its pubspec', () async {


### PR DESCRIPTION
The engine expects it to always be there.