### PR TITLE
Add missing docs to public function.

### DIFF
--- a/packages/flutter/lib/src/widgets/widget_inspector.dart
+++ b/packages/flutter/lib/src/widgets/widget_inspector.dart
@@ -290,6 +290,11 @@ class WidgetInspectorService {
     );
   }
 
+  /// Cause the entire tree to be rebuilt. This is used by development tools
+  /// when the application code has changed and is being hot-reloaded, to cause
+  /// the widget tree to pick up any changed implementations.
+  ///
+  /// This is expensive and should not be called except during development.
   @protected
   Future<Null> forceRebuild() {
     final WidgetsBinding binding = WidgetsBinding.instance;


### PR DESCRIPTION
Adding missing docs to the `forceRebuild` function in the widget inspector.

Just noticed that the missing docs benchmark regressed from zero, and I thought I'd fix it. :-)