### PR TITLE
Run test harness finalizers in reverse order.

### DIFF
--- a/packages/flutter_tools/lib/src/test/flutter_platform.dart
+++ b/packages/flutter_tools/lib/src/test/flutter_platform.dart
@@ -275,7 +275,7 @@ class _FlutterPlatform extends PlatformPlugin {
 
     dynamic outOfBandError; // error that we couldn't send to the harness that we need to send via our future
 
-    final List<_Finalizer> finalizers = <_Finalizer>[];
+    final List<_Finalizer> finalizers = <_Finalizer>[]; // Will be run in reverse order.
     bool subprocessActive = false;
     bool controllerSinkClosed = false;
     try {
@@ -511,7 +511,8 @@ class _FlutterPlatform extends PlatformPlugin {
       }
     } finally {
       printTrace('test $ourTestCount: cleaning up...');
-      for (_Finalizer finalizer in finalizers) {
+      // Finalizers are treated like a stack; run them in reverse order.
+      for (_Finalizer finalizer in finalizers.reversed) {
         try {
           await finalizer();
         } catch (error, stack) {


### PR DESCRIPTION
Finalizers handle the restoration of state. In order to restore
the state correctly, they shouyld be run in LIFO order.

Fixes #16657