### PR TITLE
Adding some tests for onTapDown and onTapCancel to InkWell.

### DIFF
--- a/packages/flutter/lib/src/material/ink_well.dart
+++ b/packages/flutter/lib/src/material/ink_well.dart
@@ -382,6 +382,10 @@ class InkResponse extends StatefulWidget {
       gestures.add('double tap');
     if (onLongPress != null)
       gestures.add('long press');
+    if (onTapDown != null)
+      gestures.add('tap down');
+    if (onTapCancel != null)
+      gestures.add('tap cancel');
     properties.add(new IterableProperty<String>('gestures', gestures, ifEmpty: '<none>'));
     properties.add(new DiagnosticsProperty<bool>('containedInkWell', containedInkWell, level: DiagnosticLevel.fine));
     properties.add(new DiagnosticsProperty<BoxShape>(

--- a/packages/flutter/test/material/ink_well_test.dart
+++ b/packages/flutter/test/material/ink_well_test.dart
@@ -26,6 +26,12 @@ void main() {
           onLongPress: () {
             log.add('long-press');
           },
+          onTapDown: (TapDownDetails details) {
+            log.add('tap-down');
+          },
+          onTapCancel: () {
+            log.add('tap-cancel');
+          },
         ),
       ),
     ));
@@ -36,18 +42,32 @@ void main() {
 
     await tester.pump(const Duration(seconds: 1));
 
-    expect(log, equals(<String>['tap']));
+    expect(log, equals(<String>['tap-down', 'tap']));
     log.clear();
 
     await tester.tap(find.byType(InkWell), pointer: 2);
     await tester.tap(find.byType(InkWell), pointer: 3);
 
-    expect(log, equals(<String>['double-tap']));
+    expect(log, equals(<String>['tap-cancel', 'double-tap']));
     log.clear();
 
     await tester.longPress(find.byType(InkWell), pointer: 4);
 
-    expect(log, equals(<String>['long-press']));
+    expect(log, equals(<String>['tap-down', 'tap-cancel', 'long-press']));
+
+    log.clear();
+    TestGesture gesture = await tester.startGesture(tester.getRect(find.byType(InkWell)).center);
+    await tester.pump(const Duration(milliseconds: 100));
+    expect(log, equals(<String>['tap-down']));
+    await gesture.up();
+    await tester.pump(const Duration(seconds: 1));
+
+    log.clear();
+    gesture = await tester.startGesture(tester.getRect(find.byType(InkWell)).center);
+    await tester.pump(const Duration(milliseconds: 100));
+    await gesture.moveBy(const Offset(0.0, 200.0));
+    await gesture.cancel();
+    expect(log, equals(<String>['tap-down', 'tap-cancel']));
   });
 
   testWidgets('long-press and tap on disabled should not throw', (WidgetTester tester) async {


### PR DESCRIPTION
Adding some tests for onTapDown and onTapCancel for the InkWell, as suggested in post-submission comments by @Hixie  in https://github.com/flutter/flutter/pull/16190.

Also, added those to the diagnostic output.