### PR TITLE
Rely on the engine's reply to the _runInView service protocol method to decide if hot-restart succeeded.

### DIFF
--- a/packages/flutter_tools/lib/src/vmservice.dart
+++ b/packages/flutter_tools/lib/src/vmservice.dart
@@ -1320,30 +1320,17 @@ class FlutterView extends ServiceObject {
     _uiIsolate = map['isolate'];
   }
 
-  // TODO(johnmccutchan): Report errors when running failed.
   Future<Null> runFromSource(Uri entryUri,
                              Uri packagesUri,
                              Uri assetsDirectoryUri) async {
-    final String viewId = id;
-    // When this completer completes the isolate is running.
-    final Completer<Null> completer = new Completer<Null>();
-    final StreamSubscription<ServiceEvent> subscription =
-      owner.vm.vmService.onIsolateEvent.listen((ServiceEvent event) {
-      // TODO(johnmccutchan): Listen to the debug stream and catch initial
-      // launch errors.
-      if (event.kind == ServiceEvent.kIsolateRunnable) {
-        printTrace('Isolate is runnable.');
-        if (!completer.isCompleted)
-          completer.complete(null);
-      }
-    });
-    await owner.vm.runInView(viewId,
-                             entryUri,
-                             packagesUri,
-                             assetsDirectoryUri);
-    await completer.future;
-    await owner.vm.refreshViews();
-    await subscription.cancel();
+    ServiceMap result = await owner.vm.runInView(id, entryUri, packagesUri, assetsDirectoryUri);
+    if (result['type'] == 'Success') {
+      await owner.vm.refreshViews();
+    } else {
+      // TODO(chinmaygarde): Modify this method to handle error conditions
+      // from the engine.
+      print('ERROR: Could not re-run application from source');
+    }
   }
 
   Future<Null> setAssetDirectory(Uri assetsDirectory) async {


### PR DESCRIPTION
Before the refactor, the engine did not return a reliable result to the [`_flutter.runInView`](https://github.com/flutter/engine/wiki/Engine-Specific-Service-Protocol-Extensions#run-in-view-aka-cold-reload-cold-restart-restart-capital-r-reload-not-hot-reload) engine service protocol extension. To work around this, isolate events were subscribed to so that the detection of a new runnable isolate could indicate that the hot-restart had correctly propagated. The issue with this approach was subscribing to the isolate events from the newly launched isolate and the call to launch the new isolate itself was racy. If the engine managed to launch the new isolate before the tool had a chance to subscribe to the new isolates events, it would hang forever since the VM would never send an event (since no one was listening to any events).

The Flutter engine now reliably is able to tell the service protocol (synchronously) that the new isolate has been launched. This allows us to check the result of the service protocol method. If the method succeeded, the engine guarantees that the new isolate has been launched.
