### PR TITLE
Add support for listing and launching emulators

### DIFF
--- a/packages/flutter_tools/lib/executable.dart
+++ b/packages/flutter_tools/lib/executable.dart
@@ -15,6 +15,7 @@ import 'src/commands/daemon.dart';
 import 'src/commands/devices.dart';
 import 'src/commands/doctor.dart';
 import 'src/commands/drive.dart';
+import 'src/commands/emulators.dart';
 import 'src/commands/format.dart';
 import 'src/commands/fuchsia_reload.dart';
 import 'src/commands/ide_config.dart';
@@ -57,6 +58,7 @@ Future<Null> main(List<String> args) async {
     new DevicesCommand(),
     new DoctorCommand(verbose: verbose),
     new DriveCommand(),
+    new EmulatorsCommand(),
     new FormatCommand(),
     new FuchsiaReloadCommand(),
     new IdeConfigCommand(hidden: !verboseHelp),

--- a/packages/flutter_tools/lib/src/android/android_emulator.dart
+++ b/packages/flutter_tools/lib/src/android/android_emulator.dart
@@ -28,7 +28,7 @@ class AndroidEmulators extends EmulatorDiscovery {
 
 class AndroidEmulator extends Emulator {
   AndroidEmulator(String id, [this._properties])
-  : super(id, _properties != null && _properties.isNotEmpty);
+      : super(id, _properties != null && _properties.isNotEmpty);
 
   Map<String, String> _properties;
 
@@ -44,10 +44,12 @@ class AndroidEmulator extends Emulator {
   @override
   Future<bool> launch() async {
     final Status status = logger.startProgress('Launching $id...');
-    final RunResult launchResult = await runAsync(<String>[getEmulatorPath(), '-avd', id]);
+    final RunResult launchResult =
+        await runAsync(<String>[getEmulatorPath(), '-avd', id]);
     status.stop();
     if (launchResult.exitCode != 0) {
-      printError('Error: emulator exited with exit code ${launchResult.exitCode}');
+      printError(
+          'Error: emulator exited with exit code ${launchResult.exitCode}');
       printError('$launchResult');
       return false;
     }
@@ -62,7 +64,7 @@ List<AndroidEmulator> getEmulatorAvds() {
   if (emulatorPath == null) {
     return <AndroidEmulator>[];
   }
-  
+
   final String listAvdsOutput = runSync(<String>[emulatorPath, '-list-avds']);
 
   final List<AndroidEmulator> emulators = <AndroidEmulator>[];
@@ -86,7 +88,8 @@ AndroidEmulator _createEmulator(String id) {
   if (ini['path'] != null) {
     final File configFile = fs.file(fs.path.join(ini['path'], 'config.ini'));
     if (configFile.existsSync()) {
-      final Map<String, String> properties = parseIniLines(configFile.readAsLinesSync());
+      final Map<String, String> properties =
+          parseIniLines(configFile.readAsLinesSync());
       return new AndroidEmulator(id, properties);
     }
   }
@@ -100,11 +103,12 @@ Map<String, String> parseIniLines(List<String> contents) {
 
   final Iterable<List<String>> properties = contents
       .map((String l) => l.trim())
-      .where((String l) =>
-          l != '' && !l.startsWith('#')) // Strip blank lines/comments
-      .where((String l) =>
-          l.contains('=')) // Discard anything that isn't simple name=value
-      .map((String l) => l.split('=')); // Split into name/value
+      // Strip blank lines/comments
+      .where((String l) => l != '' && !l.startsWith('#'))
+      // Discard anything that isn't simple name=value
+      .where((String l) => l.contains('='))
+      // Split into name/value
+      .map((String l) => l.split('='));
 
   for (List<String> property in properties) {
     results[property[0].trim()] = property[1].trim();

--- a/packages/flutter_tools/lib/src/android/android_emulator.dart
+++ b/packages/flutter_tools/lib/src/android/android_emulator.dart
@@ -1,0 +1,60 @@
+// Copyright 2018 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:meta/meta.dart';
+
+import '../android/android_sdk.dart';
+import '../android/android_workflow.dart';
+import '../base/process.dart';
+import '../emulator.dart';
+import 'android_sdk.dart';
+
+class AndroidEmulators extends EmulatorDiscovery {
+  @override
+  bool get supportsPlatform => true;
+
+  @override
+  bool get canListAnything => androidWorkflow.canListDevices;
+
+  @override
+  Future<List<Emulator>> get emulators async => getEmulatorAvds();
+}
+
+class AndroidEmulator extends Emulator {
+  AndroidEmulator(
+    String id
+  ) : super(id);
+
+  @override
+  String get name => id;
+
+  // @override
+  // Future<bool> launch() async {
+  //   // TODO: ...
+  //   return null;Í
+  // }
+}
+
+/// Return the list of available emulator AVDs.
+List<AndroidEmulator> getEmulatorAvds() {
+  final String emulatorPath = getEmulatorPath(androidSdk);
+  if (emulatorPath == null)
+    return <AndroidEmulator>[];
+  final String text = runSync(<String>[emulatorPath, '-list-avds']);
+  final List<AndroidEmulator> devices = <AndroidEmulator>[];
+  parseEmulatorAvdOutput(text, devices);
+  return devices;
+}
+
+/// Parse the given `emulator -list-avds` output in [text], and fill out the given list
+/// of emulators.
+@visibleForTesting
+void parseEmulatorAvdOutput(String text,
+  List<AndroidEmulator> emulators) {
+  for (String line in text.trim().split('\n')) {
+    emulators.add(new AndroidEmulator(line));
+  }
+}

--- a/packages/flutter_tools/lib/src/android/android_emulator.dart
+++ b/packages/flutter_tools/lib/src/android/android_emulator.dart
@@ -72,7 +72,7 @@ List<AndroidEmulator> getEmulatorAvds() {
 /// Parse the given `emulator -list-avds` output in [text], and fill out the given list
 /// of emulators by reading information from the relevant ini files.
 void extractEmulatorAvdInfo(String text, List<AndroidEmulator> emulators) {
-  for (String id in text.trim().split('\n')) {
+  for (String id in text.trim().split('\n').where((String l) => l != '')) {
     emulators.add(_createEmulator(id));
   }
 }

--- a/packages/flutter_tools/lib/src/android/android_emulator.dart
+++ b/packages/flutter_tools/lib/src/android/android_emulator.dart
@@ -17,7 +17,7 @@ class AndroidEmulators extends EmulatorDiscovery {
   bool get supportsPlatform => true;
 
   @override
-  bool get canListAnything => androidWorkflow.canListDevices;
+  bool get canListAnything => androidWorkflow.canListEmulators;
 
   @override
   Future<List<Emulator>> get emulators async => getEmulatorAvds();
@@ -44,9 +44,9 @@ List<AndroidEmulator> getEmulatorAvds() {
   if (emulatorPath == null)
     return <AndroidEmulator>[];
   final String text = runSync(<String>[emulatorPath, '-list-avds']);
-  final List<AndroidEmulator> devices = <AndroidEmulator>[];
-  parseEmulatorAvdOutput(text, devices);
-  return devices;
+  final List<AndroidEmulator> emulators = <AndroidEmulator>[];
+  parseEmulatorAvdOutput(text, emulators);
+  return emulators;
 }
 
 /// Parse the given `emulator -list-avds` output in [text], and fill out the given list

--- a/packages/flutter_tools/lib/src/android/android_emulator.dart
+++ b/packages/flutter_tools/lib/src/android/android_emulator.dart
@@ -45,8 +45,6 @@ class AndroidEmulator extends Emulator {
     final RunResult launchResult =
         await runAsync(<String>[getEmulatorPath(), '-avd', id]);
     if (launchResult.exitCode != 0) {
-      printError(
-          'Error: emulator exited with exit code ${launchResult.exitCode}');
       printError('$launchResult');
       return false;
     }

--- a/packages/flutter_tools/lib/src/android/android_emulator.dart
+++ b/packages/flutter_tools/lib/src/android/android_emulator.dart
@@ -9,7 +9,6 @@ import 'package:meta/meta.dart';
 import '../android/android_sdk.dart';
 import '../android/android_workflow.dart';
 import '../base/file_system.dart';
-import '../base/logger.dart';
 import '../base/process.dart';
 import '../emulator.dart';
 import '../globals.dart';

--- a/packages/flutter_tools/lib/src/android/android_emulator.dart
+++ b/packages/flutter_tools/lib/src/android/android_emulator.dart
@@ -43,10 +43,8 @@ class AndroidEmulator extends Emulator {
 
   @override
   Future<bool> launch() async {
-    final Status status = logger.startProgress('Launching $id...');
     final RunResult launchResult =
         await runAsync(<String>[getEmulatorPath(), '-avd', id]);
-    status.stop();
     if (launchResult.exitCode != 0) {
       printError(
           'Error: emulator exited with exit code ${launchResult.exitCode}');

--- a/packages/flutter_tools/lib/src/android/android_emulator.dart
+++ b/packages/flutter_tools/lib/src/android/android_emulator.dart
@@ -9,8 +9,10 @@ import 'package:meta/meta.dart';
 import '../android/android_sdk.dart';
 import '../android/android_workflow.dart';
 import '../base/file_system.dart';
+import '../base/logger.dart';
 import '../base/process.dart';
 import '../emulator.dart';
+import '../globals.dart';
 import 'android_sdk.dart';
 
 class AndroidEmulators extends EmulatorDiscovery {
@@ -39,11 +41,19 @@ class AndroidEmulator extends Emulator {
   @override
   String get label => _properties['avd.ini.displayname'];
 
-  // @override
-  // Future<bool> launch() async {
-  //   // TODO: ...
-  //   return null;Í
-  // }
+  @override
+  Future<bool> launch() async {
+    final Status status = logger.startProgress('Launching $id...');
+    final RunResult launchResult = await runAsync(<String>[getEmulatorPath(), '-avd', id]);
+    status.stop();
+    if (launchResult.exitCode != 0) {
+      printError('Error: emulator exited with exit code ${launchResult.exitCode}');
+      printError('$launchResult');
+      return false;
+    }
+
+    return true;
+  }
 }
 
 /// Return the list of available emulator AVDs.

--- a/packages/flutter_tools/lib/src/android/android_emulator.dart
+++ b/packages/flutter_tools/lib/src/android/android_emulator.dart
@@ -81,12 +81,12 @@ void extractEmulatorAvdInfo(String text, List<AndroidEmulator> emulators) {
 AndroidEmulator _createEmulator(String id) {
   id = id.trim();
   final File iniFile = fs.file(fs.path.join(getAvdPath(), '$id.ini'));
-  final Map<String, String> ini = _parseIniLines(iniFile.readAsLinesSync());
+  final Map<String, String> ini = parseIniLines(iniFile.readAsLinesSync());
 
   if (ini['path'] != null) {
     final File configFile = fs.file(fs.path.join(ini['path'], 'config.ini'));
     if (configFile.existsSync()) {
-      final Map<String, String> properties = _parseIniLines(configFile.readAsLinesSync());
+      final Map<String, String> properties = parseIniLines(configFile.readAsLinesSync());
       return new AndroidEmulator(id, properties);
     }
   }
@@ -94,9 +94,8 @@ AndroidEmulator _createEmulator(String id) {
   return new AndroidEmulator(id);
 }
 
-// TODO: Tests
 @visibleForTesting
-Map<String, String> _parseIniLines(List<String> contents) {
+Map<String, String> parseIniLines(List<String> contents) {
   final Map<String, String> results = <String, String>{};
 
   final Iterable<List<String>> properties = contents

--- a/packages/flutter_tools/lib/src/android/android_emulator.dart
+++ b/packages/flutter_tools/lib/src/android/android_emulator.dart
@@ -41,15 +41,13 @@ class AndroidEmulator extends Emulator {
   String get label => _properties['avd.ini.displayname'];
 
   @override
-  Future<bool> launch() async {
+  Future<void> launch() async {
     final RunResult launchResult =
         await runAsync(<String>[getEmulatorPath(), '-avd', id]);
+
     if (launchResult.exitCode != 0) {
       printError('$launchResult');
-      return false;
     }
-
-    return true;
   }
 }
 

--- a/packages/flutter_tools/lib/src/android/android_emulator.dart
+++ b/packages/flutter_tools/lib/src/android/android_emulator.dart
@@ -42,12 +42,20 @@ class AndroidEmulator extends Emulator {
 
   @override
   Future<void> launch() async {
-    final RunResult launchResult =
-        await runAsync(<String>[getEmulatorPath(), '-avd', id]);
-
-    if (launchResult.exitCode != 0) {
-      printError('$launchResult');
-    }
+    final Future<void> launchResult =
+        runAsync(<String>[getEmulatorPath(), '-avd', id])
+            .then((RunResult runResult) {
+              if (runResult.exitCode != 0) {
+                printError('$runResult');
+              }
+            });
+    // emulator continues running on a successful launch so if we
+    // haven't quit within 3 seconds we assume that's a success and just
+    // return.
+    await Future.any<void>(<Future<void>>[
+      launchResult,
+      new Future<void>.delayed(const Duration(seconds: 3))
+    ]);
   }
 }
 

--- a/packages/flutter_tools/lib/src/android/android_sdk.dart
+++ b/packages/flutter_tools/lib/src/android/android_sdk.dart
@@ -78,10 +78,28 @@ String getEmulatorPath([AndroidSdk existingSdk]) {
 
 /// Locate the path for storing AVD emulator images. Returns null if none found.
 String getAvdPath() {
+  
   final List<String> searchPaths = <String>[
-    platform.environment['ANDROID_AVD_HOME'],
-    fs.path.join(platform.environment['HOME'], '.android', 'avd'),
+    platform.environment['ANDROID_AVD_HOME']
   ];
+
+  if (platform.environment['HOME'] != null)
+    searchPaths.add(fs.path.join(platform.environment['HOME'], '.android', 'avd'));
+
+  if (platform.isWindows) {
+    final String homeDrive = platform.environment['HOMEDRIVE'];
+    final String homePath = platform.environment['HOMEPATH'];
+
+    if (homeDrive != null && homePath != null) {
+      // Can't use path.join for HOMEDRIVE/HOMEPATH
+      // https://github.com/dart-lang/path/issues/37
+      final String home = homeDrive + homePath;
+      searchPaths.add(fs.path.join(home, '.android', 'avd'));
+    }
+  }
+
+  print(searchPaths);
+
   return searchPaths.where((String p) => p != null).firstWhere(
     (String p) => fs.directory(p).existsSync(),
     orElse: () => null,

--- a/packages/flutter_tools/lib/src/android/android_sdk.dart
+++ b/packages/flutter_tools/lib/src/android/android_sdk.dart
@@ -245,7 +245,7 @@ class AndroidSdk {
 
   String get adbPath => getPlatformToolsPath('adb');
 
-  String get emulatorPath => getToolsPath('emulator');
+  String get emulatorPath => getEmulatorPath();
 
   /// Validate the Android SDK. This returns an empty list if there are no
   /// issues; otherwise, it returns a list of issues found.
@@ -263,8 +263,17 @@ class AndroidSdk {
     return fs.path.join(directory, 'platform-tools', binaryName);
   }
 
-  String getToolsPath(String binaryName) {
-    return fs.path.join(directory, 'tools', binaryName);
+  String getEmulatorPath() {
+    final String binaryName = platform.isWindows ? 'emulator.exe' : 'emulator';
+    // Emulator now lives inside "emulator" but used to live inside "tools" so
+    // try both.
+    final List<String> searchFolders = <String>['emulator', 'tools'];
+    for (final String folder in searchFolders) {
+      final String path = fs.path.join(directory, folder, binaryName);
+      if (fs.file(path).existsSync())
+        return path;
+    }
+    return null;
   }
 
   void _init() {

--- a/packages/flutter_tools/lib/src/android/android_sdk.dart
+++ b/packages/flutter_tools/lib/src/android/android_sdk.dart
@@ -59,6 +59,23 @@ String getAdbPath([AndroidSdk existingSdk]) {
   }
 }
 
+/// Locate ADB. Prefer to use one from an Android SDK, if we can locate that.
+/// This should be used over accessing androidSdk.adbPath directly because it
+/// will work for those users who have Android Platform Tools installed but
+/// not the full SDK.
+String getEmulatorPath([AndroidSdk existingSdk]) {
+  if (existingSdk?.emulatorPath != null)
+    return existingSdk.emulatorPath;
+
+  final AndroidSdk sdk = AndroidSdk.locateAndroidSdk();
+
+  if (sdk?.latestVersion == null) {
+    return os.which('emulator')?.path;
+  } else {
+    return sdk.emulatorPath;
+  }
+}
+
 class AndroidSdk {
   AndroidSdk(this.directory, [this.ndkDirectory, this.ndkCompiler,
       this.ndkCompilerArgs]) {
@@ -200,6 +217,8 @@ class AndroidSdk {
 
   String get adbPath => getPlatformToolsPath('adb');
 
+  String get emulatorPath => getToolsPath('emulator');
+
   /// Validate the Android SDK. This returns an empty list if there are no
   /// issues; otherwise, it returns a list of issues found.
   List<String> validateSdkWellFormed() {
@@ -214,6 +233,10 @@ class AndroidSdk {
 
   String getPlatformToolsPath(String binaryName) {
     return fs.path.join(directory, 'platform-tools', binaryName);
+  }
+
+  String getToolsPath(String binaryName) {
+    return fs.path.join(directory, 'tools', binaryName);
   }
 
   void _init() {

--- a/packages/flutter_tools/lib/src/android/android_sdk.dart
+++ b/packages/flutter_tools/lib/src/android/android_sdk.dart
@@ -98,8 +98,6 @@ String getAvdPath() {
     }
   }
 
-  print(searchPaths);
-
   return searchPaths.where((String p) => p != null).firstWhere(
     (String p) => fs.directory(p).existsSync(),
     orElse: () => null,

--- a/packages/flutter_tools/lib/src/android/android_sdk.dart
+++ b/packages/flutter_tools/lib/src/android/android_sdk.dart
@@ -59,9 +59,9 @@ String getAdbPath([AndroidSdk existingSdk]) {
   }
 }
 
-/// Locate ADB. Prefer to use one from an Android SDK, if we can locate that.
-/// This should be used over accessing androidSdk.adbPath directly because it
-/// will work for those users who have Android Platform Tools installed but
+/// Locate 'emulator'. Prefer to use one from an Android SDK, if we can locate that.
+/// This should be used over accessing androidSdk.emulatorPath directly because it
+/// will work for those users who have Android Tools installed but
 /// not the full SDK.
 String getEmulatorPath([AndroidSdk existingSdk]) {
   if (existingSdk?.emulatorPath != null)
@@ -74,6 +74,18 @@ String getEmulatorPath([AndroidSdk existingSdk]) {
   } else {
     return sdk.emulatorPath;
   }
+}
+
+/// Locate the path for storing AVD emulator images. Returns null if none found.
+String getAvdPath() {
+  final List<String> searchPaths = <String>[
+    platform.environment['ANDROID_AVD_HOME'],
+    fs.path.join(platform.environment['HOME'], '.android', 'avd'),
+  ];
+  return searchPaths.where((String p) => p != null).firstWhere(
+    (String p) => fs.directory(p).existsSync(),
+    orElse: () => null,
+  );
 }
 
 class AndroidSdk {

--- a/packages/flutter_tools/lib/src/android/android_workflow.dart
+++ b/packages/flutter_tools/lib/src/android/android_workflow.dart
@@ -45,9 +45,6 @@ class AndroidWorkflow extends DoctorValidator implements Workflow {
   @override
   bool get canListEmulators => getEmulatorPath(androidSdk) != null;
 
-  @override
-  bool get canLaunchEmulators => androidSdk != null && androidSdk.validateSdkWellFormed().isEmpty;
-
   static const String _kJdkDownload = 'https://www.oracle.com/technetwork/java/javase/downloads/';
 
   /// Returns false if we cannot determine the Java version or if the version

--- a/packages/flutter_tools/lib/src/android/android_workflow.dart
+++ b/packages/flutter_tools/lib/src/android/android_workflow.dart
@@ -42,6 +42,12 @@ class AndroidWorkflow extends DoctorValidator implements Workflow {
   @override
   bool get canLaunchDevices => androidSdk != null && androidSdk.validateSdkWellFormed().isEmpty;
 
+  @override
+  bool get canListEmulators => getEmulatorPath(androidSdk) != null;
+
+  @override
+  bool get canLaunchEmulators => androidSdk != null && androidSdk.validateSdkWellFormed().isEmpty;
+
   static const String _kJdkDownload = 'https://www.oracle.com/technetwork/java/javase/downloads/';
 
   /// Returns false if we cannot determine the Java version or if the version

--- a/packages/flutter_tools/lib/src/android/android_workflow.dart
+++ b/packages/flutter_tools/lib/src/android/android_workflow.dart
@@ -43,7 +43,7 @@ class AndroidWorkflow extends DoctorValidator implements Workflow {
   bool get canLaunchDevices => androidSdk != null && androidSdk.validateSdkWellFormed().isEmpty;
 
   @override
-  bool get canListEmulators => getEmulatorPath(androidSdk) != null;
+  bool get canListEmulators => getEmulatorPath(androidSdk) != null && getAvdPath() != null;
 
   static const String _kJdkDownload = 'https://www.oracle.com/technetwork/java/javase/downloads/';
 

--- a/packages/flutter_tools/lib/src/commands/devices.dart
+++ b/packages/flutter_tools/lib/src/commands/devices.dart
@@ -32,7 +32,8 @@ class DevicesCommand extends FlutterCommand {
     if (devices.isEmpty) {
       printStatus(
         'No devices detected.\n\n'
-        'If you expected your device to be detected, please run "flutter doctor" to diagnose\n'
+        "Run 'flutter emulators' to list and start any available device emulators.\n\n"
+        'Or, if you expected your device to be detected, please run "flutter doctor" to diagnose\n'
         'potential issues, or visit https://flutter.io/setup/ for troubleshooting tips.');
       final List<String> diagnostics = await deviceManager.getDeviceDiagnostics();
       if (diagnostics.isNotEmpty) {

--- a/packages/flutter_tools/lib/src/commands/emulators.dart
+++ b/packages/flutter_tools/lib/src/commands/emulators.dart
@@ -37,13 +37,17 @@ class EmulatorsCommand extends FlutterCommand {
     if (argResults.wasParsed('start')) {
       await _startEmulator(argResults['start']);
     } else {
-      await _listEmulators();
+      final String searchText =
+          argResults.rest != null && argResults.rest.isNotEmpty
+              ? argResults.rest.first
+              : null;
+      await _listEmulators(searchText);
     }
   }
 
   Future<Null> _startEmulator(String id) async {
     final List<Emulator> emulators =
-        await emulatorManager.getEmulatorsById(id).toList();
+        await emulatorManager.getEmulatorsMatching(id).toList();
 
     if (emulators.isEmpty) {
       printStatus("No emulator found that matches '$id'.");
@@ -55,9 +59,11 @@ class EmulatorsCommand extends FlutterCommand {
     }
   }
 
-  Future<Null> _listEmulators() async {
+  Future<Null> _listEmulators(String searchText) async {
     final List<Emulator> emulators =
-        await emulatorManager.getAllAvailableEmulators().toList();
+        searchText == null
+        ? await emulatorManager.getAllAvailableEmulators().toList()
+        : await emulatorManager.getEmulatorsMatching(searchText).toList();
 
     if (emulators.isEmpty) {
       printStatus('No emulators available.\n\n'

--- a/packages/flutter_tools/lib/src/commands/emulators.dart
+++ b/packages/flutter_tools/lib/src/commands/emulators.dart
@@ -65,14 +65,6 @@ class EmulatorsCommand extends FlutterCommand {
           // 'You may need to create images using "flutter emulators --create"\n'
           'You may need to create one using Android Studio '
           'or visit https://flutter.io/setup/ for troubleshooting tips.');
-      final List<String> diagnostics =
-          await emulatorManager.getEmulatorDiagnostics();
-      if (diagnostics.isNotEmpty) {
-        printStatus('');
-        for (String diagnostic in diagnostics) {
-          printStatus('• ${diagnostic.replaceAll('\n', '\n  ')}');
-        }
-      }
     } else {
       printStatus(
           '${emulators.length} available ${pluralize('emulator', emulators.length)}:\n');

--- a/packages/flutter_tools/lib/src/commands/emulators.dart
+++ b/packages/flutter_tools/lib/src/commands/emulators.dart
@@ -12,6 +12,11 @@ import '../globals.dart';
 import '../runner/flutter_command.dart';
 
 class EmulatorsCommand extends FlutterCommand {
+  EmulatorsCommand() {
+    argParser.addOption('start',
+        help: 'The full or partial ID of the emulator to start.');
+  }
+
   @override
   final String name = 'emulators';
 
@@ -20,23 +25,46 @@ class EmulatorsCommand extends FlutterCommand {
 
   @override
   Future<Null> runCommand() async {
-    if (!doctor.canListAnything) {
+    if (doctor.workflows.every((Workflow w) => !w.canListEmulators)) {
       throwToolExit(
-        "Unable to locate emulators; please run 'flutter doctor' for "
-        'information about installing additional components.',
-        exitCode: 1);
+          "Unable to query emulators; please run 'flutter doctor' for "
+          'information about installing additional components.',
+          exitCode: 1);
     }
 
-    final List<Emulator> emulators = await emulatorManager.getAllAvailableEmulators().toList();
+    if (argResults.wasParsed('start')) {
+      await _startEmulator(argResults['start']);
+    } else {
+      await _listEmulators();
+    }
+  }
+
+  Future<Null> _startEmulator(String id) async {
+    final List<Emulator> emulators =
+        await emulatorManager.getEmulatorsById(id).toList();
 
     if (emulators.isEmpty) {
-      printStatus(
-        'No emulators available.\n\n'
-        // TODO: Change these when we support creation
-        // 'You may need to create images using "flutter emulators --create"\n'
-        'You may need to create one using Android Studio\n'
-        'or visit https://flutter.io/setup/ for troubleshooting tips.');
-      final List<String> diagnostics = await emulatorManager.getEmulatorDiagnostics();
+      printStatus("No emulator found that matches the ID '$id'.");
+    } else if (emulators.length > 1) {
+      printStatus("More than one emulator matches the ID '$id':\n");
+      Emulator.printEmulators(emulators);
+    } else {
+      emulators.first.launch();
+    }
+  }
+
+  Future<Null> _listEmulators() async {
+    final List<Emulator> emulators =
+        await emulatorManager.getAllAvailableEmulators().toList();
+
+    if (emulators.isEmpty) {
+      printStatus('No emulators available.\n\n'
+          // TODO: Change these when we support creation
+          // 'You may need to create images using "flutter emulators --create"\n'
+          'You may need to create one using Android Studio\n'
+          'or visit https://flutter.io/setup/ for troubleshooting tips.');
+      final List<String> diagnostics =
+          await emulatorManager.getEmulatorDiagnostics();
       if (diagnostics.isNotEmpty) {
         printStatus('');
         for (String diagnostic in diagnostics) {
@@ -44,7 +72,8 @@ class EmulatorsCommand extends FlutterCommand {
         }
       }
     } else {
-      printStatus('${emulators.length} available ${pluralize('emulators', emulators.length)}:\n');
+      printStatus(
+          '${emulators.length} available ${pluralize('emulators', emulators.length)}:\n');
       await Emulator.printEmulators(emulators);
     }
   }

--- a/packages/flutter_tools/lib/src/commands/emulators.dart
+++ b/packages/flutter_tools/lib/src/commands/emulators.dart
@@ -74,7 +74,7 @@ class EmulatorsCommand extends FlutterCommand {
     } else {
       printStatus(
           '${emulators.length} available ${pluralize('emulator', emulators.length)}:\n');
-      await Emulator.printEmulators(emulators);
+      Emulator.printEmulators(emulators);
     }
   }
 }

--- a/packages/flutter_tools/lib/src/commands/emulators.dart
+++ b/packages/flutter_tools/lib/src/commands/emulators.dart
@@ -46,9 +46,9 @@ class EmulatorsCommand extends FlutterCommand {
         await emulatorManager.getEmulatorsById(id).toList();
 
     if (emulators.isEmpty) {
-      printStatus("No emulator found that matches the ID '$id'.");
+      printStatus("No emulator found that matches '$id'.");
     } else if (emulators.length > 1) {
-      printStatus("More than one emulator matches the ID '$id':\n");
+      printStatus("More than one emulator matches '$id':\n");
       Emulator.printEmulators(emulators);
     } else {
       emulators.first.launch();

--- a/packages/flutter_tools/lib/src/commands/emulators.dart
+++ b/packages/flutter_tools/lib/src/commands/emulators.dart
@@ -61,7 +61,7 @@ class EmulatorsCommand extends FlutterCommand {
 
     if (emulators.isEmpty) {
       printStatus('No emulators available.\n\n'
-          // TODO: Change these when we support creation
+          // TODO(dantup): Change these when we support creation
           // 'You may need to create images using "flutter emulators --create"\n'
           'You may need to create one using Android Studio '
           'or visit https://flutter.io/setup/ for troubleshooting tips.');

--- a/packages/flutter_tools/lib/src/commands/emulators.dart
+++ b/packages/flutter_tools/lib/src/commands/emulators.dart
@@ -73,7 +73,7 @@ class EmulatorsCommand extends FlutterCommand {
       }
     } else {
       printStatus(
-          '${emulators.length} available ${pluralize('emulators', emulators.length)}:\n');
+          '${emulators.length} available ${pluralize('emulator', emulators.length)}:\n');
       await Emulator.printEmulators(emulators);
     }
   }

--- a/packages/flutter_tools/lib/src/commands/emulators.dart
+++ b/packages/flutter_tools/lib/src/commands/emulators.dart
@@ -5,6 +5,7 @@
 import 'dart:async';
 
 import '../base/common.dart';
+import '../base/platform.dart';
 import '../base/utils.dart';
 import '../doctor.dart';
 import '../emulator.dart';
@@ -27,8 +28,9 @@ class EmulatorsCommand extends FlutterCommand {
   Future<Null> runCommand() async {
     if (doctor.workflows.every((Workflow w) => !w.canListEmulators)) {
       throwToolExit(
-          "Unable to query emulators; please run 'flutter doctor' for "
-          'information about installing additional components.',
+          'Unable to find any emulator sources. Please ensure you have some\n'
+          'Android AVD images ' + (platform.isMacOS ? 'or an iOS Simulator ' : '')
+          + 'available.',
           exitCode: 1);
     }
 

--- a/packages/flutter_tools/lib/src/commands/emulators.dart
+++ b/packages/flutter_tools/lib/src/commands/emulators.dart
@@ -1,0 +1,51 @@
+// Copyright 2018 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+
+import '../base/common.dart';
+import '../base/utils.dart';
+import '../doctor.dart';
+import '../emulator.dart';
+import '../globals.dart';
+import '../runner/flutter_command.dart';
+
+class EmulatorsCommand extends FlutterCommand {
+  @override
+  final String name = 'emulators';
+
+  @override
+  final String description = 'List all available emulators.';
+
+  @override
+  Future<Null> runCommand() async {
+    if (!doctor.canListAnything) {
+      throwToolExit(
+        "Unable to locate emulators; please run 'flutter doctor' for "
+        'information about installing additional components.',
+        exitCode: 1);
+    }
+
+    final List<Emulator> emulators = await emulatorManager.getAllAvailableEmulators().toList();
+
+    if (emulators.isEmpty) {
+      printStatus(
+        'No emulators available.\n\n'
+        // TODO: Change these when we support creation
+        // 'You may need to create images using "flutter emulators --create"\n'
+        'You may need to create one using Android Studio\n'
+        'or visit https://flutter.io/setup/ for troubleshooting tips.');
+      final List<String> diagnostics = await emulatorManager.getEmulatorDiagnostics();
+      if (diagnostics.isNotEmpty) {
+        printStatus('');
+        for (String diagnostic in diagnostics) {
+          printStatus('• ${diagnostic.replaceAll('\n', '\n  ')}');
+        }
+      }
+    } else {
+      printStatus('${emulators.length} available ${pluralize('emulators', emulators.length)}:\n');
+      await Emulator.printEmulators(emulators);
+    }
+  }
+}

--- a/packages/flutter_tools/lib/src/commands/emulators.dart
+++ b/packages/flutter_tools/lib/src/commands/emulators.dart
@@ -63,7 +63,7 @@ class EmulatorsCommand extends FlutterCommand {
       printStatus('No emulators available.\n\n'
           // TODO: Change these when we support creation
           // 'You may need to create images using "flutter emulators --create"\n'
-          'You may need to create one using Android Studio\n'
+          'You may need to create one using Android Studio '
           'or visit https://flutter.io/setup/ for troubleshooting tips.');
       final List<String> diagnostics =
           await emulatorManager.getEmulatorDiagnostics();

--- a/packages/flutter_tools/lib/src/commands/emulators.dart
+++ b/packages/flutter_tools/lib/src/commands/emulators.dart
@@ -22,7 +22,7 @@ class EmulatorsCommand extends FlutterCommand {
   final String name = 'emulators';
 
   @override
-  final String description = 'List all available emulators.';
+  final String description = 'List and start available emulators.';
 
   @override
   Future<Null> runCommand() async {

--- a/packages/flutter_tools/lib/src/commands/emulators.dart
+++ b/packages/flutter_tools/lib/src/commands/emulators.dart
@@ -25,6 +25,9 @@ class EmulatorsCommand extends FlutterCommand {
   final String description = 'List and launch available emulators.';
 
   @override
+  final List<String> aliases = <String>['emulator'];
+
+  @override
   Future<Null> runCommand() async {
     if (doctor.workflows.every((Workflow w) => !w.canListEmulators)) {
       throwToolExit(

--- a/packages/flutter_tools/lib/src/commands/emulators.dart
+++ b/packages/flutter_tools/lib/src/commands/emulators.dart
@@ -55,7 +55,7 @@ class EmulatorsCommand extends FlutterCommand {
       printStatus("More than one emulator matches '$id':\n");
       Emulator.printEmulators(emulators);
     } else {
-      emulators.first.launch();
+      await emulators.first.launch();
     }
   }
 

--- a/packages/flutter_tools/lib/src/commands/emulators.dart
+++ b/packages/flutter_tools/lib/src/commands/emulators.dart
@@ -55,8 +55,10 @@ class EmulatorsCommand extends FlutterCommand {
     if (emulators.isEmpty) {
       printStatus("No emulator found that matches '$id'.");
     } else if (emulators.length > 1) {
-      printStatus("More than one emulator matches '$id':\n");
-      Emulator.printEmulators(emulators);
+      _printEmulatorList(
+        emulators,
+        "More than one emulator matches '$id':",
+      );
     } else {
       await emulators.first.launch();
     }
@@ -75,9 +77,17 @@ class EmulatorsCommand extends FlutterCommand {
           'You may need to create one using Android Studio '
           'or visit https://flutter.io/setup/ for troubleshooting tips.');
     } else {
-      printStatus(
-          '${emulators.length} available ${pluralize('emulator', emulators.length)}:\n');
-      Emulator.printEmulators(emulators);
+      _printEmulatorList(
+        emulators,
+        '${emulators.length} available ${pluralize('emulator', emulators.length)}:',
+      );
     }
+  }
+
+  void _printEmulatorList(List<Emulator> emulators, String message) {
+    printStatus('$message\n');
+    Emulator.printEmulators(emulators);
+    printStatus(
+        "\nTo run an emulator, run 'flutter emulators --launch <emulator id>'.");
   }
 }

--- a/packages/flutter_tools/lib/src/commands/emulators.dart
+++ b/packages/flutter_tools/lib/src/commands/emulators.dart
@@ -14,15 +14,15 @@ import '../runner/flutter_command.dart';
 
 class EmulatorsCommand extends FlutterCommand {
   EmulatorsCommand() {
-    argParser.addOption('start',
-        help: 'The full or partial ID of the emulator to start.');
+    argParser.addOption('launch',
+        help: 'The full or partial ID of the emulator to launch.');
   }
 
   @override
   final String name = 'emulators';
 
   @override
-  final String description = 'List and start available emulators.';
+  final String description = 'List and launch available emulators.';
 
   @override
   Future<Null> runCommand() async {
@@ -34,8 +34,8 @@ class EmulatorsCommand extends FlutterCommand {
           exitCode: 1);
     }
 
-    if (argResults.wasParsed('start')) {
-      await _startEmulator(argResults['start']);
+    if (argResults.wasParsed('launch')) {
+      await _launchEmulator(argResults['launch']);
     } else {
       final String searchText =
           argResults.rest != null && argResults.rest.isNotEmpty
@@ -45,7 +45,7 @@ class EmulatorsCommand extends FlutterCommand {
     }
   }
 
-  Future<Null> _startEmulator(String id) async {
+  Future<Null> _launchEmulator(String id) async {
     final List<Emulator> emulators =
         await emulatorManager.getEmulatorsMatching(id).toList();
 

--- a/packages/flutter_tools/lib/src/commands/emulators.dart
+++ b/packages/flutter_tools/lib/src/commands/emulators.dart
@@ -32,8 +32,9 @@ class EmulatorsCommand extends FlutterCommand {
     if (doctor.workflows.every((Workflow w) => !w.canListEmulators)) {
       throwToolExit(
           'Unable to find any emulator sources. Please ensure you have some\n'
-          'Android AVD images ' + (platform.isMacOS ? 'or an iOS Simulator ' : '')
-          + 'available.',
+              'Android AVD images ' +
+              (platform.isMacOS ? 'or an iOS Simulator ' : '') +
+              'available.',
           exitCode: 1);
     }
 
@@ -65,8 +66,7 @@ class EmulatorsCommand extends FlutterCommand {
   }
 
   Future<Null> _listEmulators(String searchText) async {
-    final List<Emulator> emulators =
-        searchText == null
+    final List<Emulator> emulators = searchText == null
         ? await emulatorManager.getAllAvailableEmulators()
         : await emulatorManager.getEmulatorsMatching(searchText);
 

--- a/packages/flutter_tools/lib/src/commands/emulators.dart
+++ b/packages/flutter_tools/lib/src/commands/emulators.dart
@@ -47,7 +47,7 @@ class EmulatorsCommand extends FlutterCommand {
 
   Future<Null> _launchEmulator(String id) async {
     final List<Emulator> emulators =
-        await emulatorManager.getEmulatorsMatching(id).toList();
+        await emulatorManager.getEmulatorsMatching(id);
 
     if (emulators.isEmpty) {
       printStatus("No emulator found that matches '$id'.");
@@ -62,8 +62,8 @@ class EmulatorsCommand extends FlutterCommand {
   Future<Null> _listEmulators(String searchText) async {
     final List<Emulator> emulators =
         searchText == null
-        ? await emulatorManager.getAllAvailableEmulators().toList()
-        : await emulatorManager.getEmulatorsMatching(searchText).toList();
+        ? await emulatorManager.getAllAvailableEmulators()
+        : await emulatorManager.getEmulatorsMatching(searchText);
 
     if (emulators.isEmpty) {
       printStatus('No emulators available.\n\n'

--- a/packages/flutter_tools/lib/src/commands/run.dart
+++ b/packages/flutter_tools/lib/src/commands/run.dart
@@ -216,7 +216,7 @@ class RunCommand extends RunCommandBase {
     if (getCurrentHostPlatform() == HostPlatform.darwin_x64 &&
         xcode.isInstalledAndMeetsVersionCheck) {
       printStatus('');
-      printStatus('To run on a simulator, launch it first: open -a Simulator.app');
+      printStatus("Run 'flutter emulators' to list and start any available device emulators.");
       printStatus('');
       printStatus('If you expected your device to be detected, please run "flutter doctor" to diagnose');
       printStatus('potential issues, or visit https://flutter.io/setup/ for troubleshooting tips.');

--- a/packages/flutter_tools/lib/src/context_runner.dart
+++ b/packages/flutter_tools/lib/src/context_runner.dart
@@ -26,6 +26,7 @@ import 'compile.dart';
 import 'devfs.dart';
 import 'device.dart';
 import 'doctor.dart';
+import 'emulator.dart';
 import 'ios/cocoapods.dart';
 import 'ios/ios_workflow.dart';
 import 'ios/mac.dart';
@@ -58,6 +59,7 @@ Future<T> runInContext<T>(
       DeviceManager: () => new DeviceManager(),
       Doctor: () => const Doctor(),
       DoctorValidatorsProvider: () => DoctorValidatorsProvider.defaultInstance,
+      EmulatorManager: () => new EmulatorManager(),
       Flags: () => const EmptyFlags(),
       FlutterVersion: () => new FlutterVersion(const Clock()),
       GenSnapshot: () => const GenSnapshot(),

--- a/packages/flutter_tools/lib/src/doctor.dart
+++ b/packages/flutter_tools/lib/src/doctor.dart
@@ -209,6 +209,12 @@ abstract class Workflow {
 
   /// Could this thing launch *something*? It may still have minor issues.
   bool get canLaunchDevices;
+
+  /// Are we functional enough to list emulators?
+  bool get canListEmulators;
+
+  /// Could this thing launch *something*? It may still have minor issues.
+  bool get canLaunchEmulators;
 }
 
 enum ValidationType {

--- a/packages/flutter_tools/lib/src/doctor.dart
+++ b/packages/flutter_tools/lib/src/doctor.dart
@@ -212,9 +212,6 @@ abstract class Workflow {
 
   /// Are we functional enough to list emulators?
   bool get canListEmulators;
-
-  /// Could this thing launch *something*? It may still have minor issues.
-  bool get canLaunchEmulators;
 }
 
 enum ValidationType {

--- a/packages/flutter_tools/lib/src/emulator.dart
+++ b/packages/flutter_tools/lib/src/emulator.dart
@@ -119,7 +119,7 @@ abstract class Emulator {
 
   final String id;
 
-  String get name;
+  String get name => id;
 
   @override
   int get hashCode => id.hashCode;

--- a/packages/flutter_tools/lib/src/emulator.dart
+++ b/packages/flutter_tools/lib/src/emulator.dart
@@ -115,11 +115,13 @@ abstract class EmulatorDiscovery {
 }
 
 abstract class Emulator {
-  Emulator(this.id);
+  Emulator(this.id, this.hasConfig);
 
   final String id;
-
-  String get name => id;
+  final bool hasConfig;
+  String get name;
+  String get manufacturer;
+  String get label;
 
   @override
   int get hashCode => id.hashCode;
@@ -145,6 +147,8 @@ abstract class Emulator {
     for (Emulator emulator in emulators) {
       table.add(<String>[
         emulator.name,
+        emulator.manufacturer,
+        emulator.label,
         emulator.id,
       ]);
     }

--- a/packages/flutter_tools/lib/src/emulator.dart
+++ b/packages/flutter_tools/lib/src/emulator.dart
@@ -102,9 +102,9 @@ abstract class Emulator {
   @override
   String toString() => name;
 
-  static Stream<String> descriptions(List<Emulator> emulators) async* {
+  static List<String> descriptions(List<Emulator> emulators) {
     if (emulators.isEmpty)
-      return;
+      return <String>[];
 
     // Extract emulators information
     final List<List<String>> table = <List<String>>[];
@@ -125,12 +125,14 @@ abstract class Emulator {
     }
 
     // Join columns into lines of text
-    for (List<String> row in table) {
-      yield indices.map((int i) => row[i].padRight(widths[i])).join(' • ') + ' • ${row.last}';
-    }
+    return table.map((List<String> row) {
+      return indices
+        .map((int i) => row[i].padRight(widths[i]))
+        .join(' • ') + ' • ${row.last}';
+    }).toList();
   }
 
-  static Future<Null> printEmulators(List<Emulator> emulators) async {
-    await descriptions(emulators).forEach(printStatus);
+  static void printEmulators(List<Emulator> emulators) {
+    descriptions(emulators).forEach(printStatus);
   }
 }

--- a/packages/flutter_tools/lib/src/emulator.dart
+++ b/packages/flutter_tools/lib/src/emulator.dart
@@ -8,6 +8,7 @@ import 'dart:math' as math;
 import 'android/android_emulator.dart';
 import 'base/context.dart';
 import 'globals.dart';
+import 'ios/ios_emulators.dart';
 
 EmulatorManager get emulatorManager => context[EmulatorManager];
 
@@ -18,6 +19,7 @@ class EmulatorManager {
   EmulatorManager() {
     // Register the known discoverers.
     _emulatorDiscoverers.add(new AndroidEmulators());
+    _emulatorDiscoverers.add(new IOSEmulators());
   }
 
   final List<EmulatorDiscovery> _emulatorDiscoverers = <EmulatorDiscovery>[];

--- a/packages/flutter_tools/lib/src/emulator.dart
+++ b/packages/flutter_tools/lib/src/emulator.dart
@@ -50,7 +50,7 @@ class EmulatorManager {
     return _emulatorDiscoverers.where((EmulatorDiscovery discoverer) => discoverer.supportsPlatform);
   }
 
-  /// Return the list of all connected emulators.
+  /// Return the list of all available emulators.
   Stream<Emulator> getAllAvailableEmulators() async* {
     for (EmulatorDiscovery discoverer in _platformDiscoverers) {
       for (Emulator emulator in await discoverer.emulators) {

--- a/packages/flutter_tools/lib/src/emulator.dart
+++ b/packages/flutter_tools/lib/src/emulator.dart
@@ -1,0 +1,168 @@
+// Copyright 2018 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:math' as math;
+
+import 'android/android_emulator.dart';
+import 'base/context.dart';
+import 'globals.dart';
+
+EmulatorManager get emulatorManager => context[EmulatorManager];
+
+/// A class to get all available emulators.
+class EmulatorManager {
+  /// Constructing EmulatorManager is cheap; they only do expensive work if some
+  /// of their methods are called.
+  EmulatorManager() {
+    // Register the known discoverers.
+    _emulatorDiscoverers.add(new AndroidEmulators());
+  }
+
+  final List<EmulatorDiscovery> _emulatorDiscoverers = <EmulatorDiscovery>[];
+
+  String _specifiedEmulatorId;
+
+  /// A user-specified emulator ID.
+  String get specifiedEmulatorId {
+    if (_specifiedEmulatorId == null || _specifiedEmulatorId == 'all')
+      return null;
+    return _specifiedEmulatorId;
+  }
+
+  set specifiedEmulatorId(String id) {
+    _specifiedEmulatorId = id;
+  }
+
+  /// True when the user has specified a single specific emulator.
+  bool get hasSpecifiedEmulatorId => specifiedEmulatorId != null;
+
+  /// True when the user has specified all emulators by setting
+  /// specifiedEmulatorId = 'all'.
+  bool get hasSpecifiedAllEmulators => _specifiedEmulatorId == 'all';
+
+  Stream<Emulator> getEmulatorsById(String emulatorId) async* {
+    final List<Emulator> emulators = await getAllAvailableEmulators().toList();
+    emulatorId = emulatorId.toLowerCase();
+    bool exactlyMatchesEmulatorId(Emulator emulator) =>
+        emulator.id.toLowerCase() == emulatorId ||
+        emulator.name.toLowerCase() == emulatorId;
+    bool startsWithEmulatorId(Emulator emulator) =>
+        emulator.id.toLowerCase().startsWith(emulatorId) ||
+        emulator.name.toLowerCase().startsWith(emulatorId);
+
+    final Emulator exactMatch = emulators.firstWhere(
+        exactlyMatchesEmulatorId, orElse: () => null);
+    if (exactMatch != null) {
+      yield exactMatch;
+      return;
+    }
+
+    // Match on a id or name starting with [emulatorId].
+    for (Emulator emulator in emulators.where(startsWithEmulatorId))
+      yield emulator;
+  }
+
+  /// Return the list of available emulators, filtered by any user-specified emulator id.
+  Stream<Emulator> getEmulators() {
+    return hasSpecifiedEmulatorId
+        ? getEmulatorsById(specifiedEmulatorId)
+        : getAllAvailableEmulators();
+  }
+
+  Iterable<EmulatorDiscovery> get _platformDiscoverers {
+    return _emulatorDiscoverers.where((EmulatorDiscovery discoverer) => discoverer.supportsPlatform);
+  }
+
+  /// Return the list of all connected emulators.
+  Stream<Emulator> getAllAvailableEmulators() async* {
+    for (EmulatorDiscovery discoverer in _platformDiscoverers) {
+      for (Emulator emulator in await discoverer.emulators) {
+        yield emulator;
+      }
+    }
+  }
+
+  /// Whether we're capable of listing any emulators given the current environment configuration.
+  bool get canListAnything {
+    return _platformDiscoverers.any((EmulatorDiscovery discoverer) => discoverer.canListAnything);
+  }
+
+  /// Get diagnostics about issues with any emulators.
+  Future<List<String>> getEmulatorDiagnostics() async {
+    final List<String> diagnostics = <String>[];
+    for (EmulatorDiscovery discoverer in _platformDiscoverers) {
+      diagnostics.addAll(await discoverer.getDiagnostics());
+    }
+    return diagnostics;
+  }
+}
+
+/// An abstract class to discover and enumerate a specific type of emulators.
+abstract class EmulatorDiscovery {
+  bool get supportsPlatform;
+
+  /// Whether this emulator discovery is capable of listing any emulators given the
+  /// current environment configuration.
+  bool get canListAnything;
+
+  Future<List<Emulator>> get emulators;
+
+  /// Gets a list of diagnostic messages pertaining to issues with any available
+  /// emulators (will be an empty list if there are no issues).
+  Future<List<String>> getDiagnostics() => new Future<List<String>>.value(<String>[]);
+}
+
+abstract class Emulator {
+  Emulator(this.id);
+
+  final String id;
+
+  String get name;
+
+  @override
+  int get hashCode => id.hashCode;
+
+  @override
+  bool operator ==(dynamic other) {
+    if (identical(this, other))
+      return true;
+    if (other is! Emulator)
+      return false;
+    return id == other.id;
+  }
+
+  @override
+  String toString() => name;
+
+  static Stream<String> descriptions(List<Emulator> emulators) async* {
+    if (emulators.isEmpty)
+      return;
+
+    // Extract emulators information
+    final List<List<String>> table = <List<String>>[];
+    for (Emulator emulator in emulators) {
+      table.add(<String>[
+        emulator.name,
+        emulator.id,
+      ]);
+    }
+
+    // Calculate column widths
+    final List<int> indices = new List<int>.generate(table[0].length - 1, (int i) => i);
+    List<int> widths = indices.map((int i) => 0).toList();
+    for (List<String> row in table) {
+      widths = indices.map((int i) => math.max(widths[i], row[i].length)).toList();
+    }
+
+    // Join columns into lines of text
+    for (List<String> row in table) {
+      yield indices.map((int i) => row[i].padRight(widths[i])).join(' • ') + ' • ${row.last}';
+    }
+  }
+
+  static Future<Null> printEmulators(List<Emulator> emulators) async {
+    await descriptions(emulators).forEach(printStatus);
+  }
+}

--- a/packages/flutter_tools/lib/src/emulator.dart
+++ b/packages/flutter_tools/lib/src/emulator.dart
@@ -24,15 +24,15 @@ class EmulatorManager {
 
   final List<EmulatorDiscovery> _emulatorDiscoverers = <EmulatorDiscovery>[];
 
-  Stream<Emulator> getEmulatorsById(String emulatorId) async* {
+  Stream<Emulator> getEmulatorsMatching(String searchText) async* {
     final List<Emulator> emulators = await getAllAvailableEmulators().toList();
-    emulatorId = emulatorId.toLowerCase();
+    searchText = searchText.toLowerCase();
     bool exactlyMatchesEmulatorId(Emulator emulator) =>
-        emulator.id?.toLowerCase() == emulatorId ||
-        emulator.name?.toLowerCase() == emulatorId;
+        emulator.id?.toLowerCase() == searchText ||
+        emulator.name?.toLowerCase() == searchText;
     bool startsWithEmulatorId(Emulator emulator) =>
-        emulator.id?.toLowerCase()?.startsWith(emulatorId) == true ||
-        emulator.name?.toLowerCase()?.startsWith(emulatorId) == true;
+        emulator.id?.toLowerCase()?.startsWith(searchText) == true ||
+        emulator.name?.toLowerCase()?.startsWith(searchText) == true;
 
     final Emulator exactMatch = emulators.firstWhere(
         exactlyMatchesEmulatorId, orElse: () => null);

--- a/packages/flutter_tools/lib/src/emulator.dart
+++ b/packages/flutter_tools/lib/src/emulator.dart
@@ -24,26 +24,6 @@ class EmulatorManager {
 
   final List<EmulatorDiscovery> _emulatorDiscoverers = <EmulatorDiscovery>[];
 
-  String _specifiedEmulatorId;
-
-  /// A user-specified emulator ID.
-  String get specifiedEmulatorId {
-    if (_specifiedEmulatorId == null || _specifiedEmulatorId == 'all')
-      return null;
-    return _specifiedEmulatorId;
-  }
-
-  set specifiedEmulatorId(String id) {
-    _specifiedEmulatorId = id;
-  }
-
-  /// True when the user has specified a single specific emulator.
-  bool get hasSpecifiedEmulatorId => specifiedEmulatorId != null;
-
-  /// True when the user has specified all emulators by setting
-  /// specifiedEmulatorId = 'all'.
-  bool get hasSpecifiedAllEmulators => _specifiedEmulatorId == 'all';
-
   Stream<Emulator> getEmulatorsById(String emulatorId) async* {
     final List<Emulator> emulators = await getAllAvailableEmulators().toList();
     emulatorId = emulatorId.toLowerCase();
@@ -64,13 +44,6 @@ class EmulatorManager {
     // Match on a id or name starting with [emulatorId].
     for (Emulator emulator in emulators.where(startsWithEmulatorId))
       yield emulator;
-  }
-
-  /// Return the list of available emulators, filtered by any user-specified emulator id.
-  Stream<Emulator> getEmulators() {
-    return hasSpecifiedEmulatorId
-        ? getEmulatorsById(specifiedEmulatorId)
-        : getAllAvailableEmulators();
   }
 
   Iterable<EmulatorDiscovery> get _platformDiscoverers {

--- a/packages/flutter_tools/lib/src/emulator.dart
+++ b/packages/flutter_tools/lib/src/emulator.dart
@@ -135,6 +135,8 @@ abstract class Emulator {
     return id == other.id;
   }
 
+  void launch();
+
   @override
   String toString() => name;
 

--- a/packages/flutter_tools/lib/src/emulator.dart
+++ b/packages/flutter_tools/lib/src/emulator.dart
@@ -90,15 +90,6 @@ class EmulatorManager {
   bool get canListAnything {
     return _platformDiscoverers.any((EmulatorDiscovery discoverer) => discoverer.canListAnything);
   }
-
-  /// Get diagnostics about issues with any emulators.
-  Future<List<String>> getEmulatorDiagnostics() async {
-    final List<String> diagnostics = <String>[];
-    for (EmulatorDiscovery discoverer in _platformDiscoverers) {
-      diagnostics.addAll(await discoverer.getDiagnostics());
-    }
-    return diagnostics;
-  }
 }
 
 /// An abstract class to discover and enumerate a specific type of emulators.
@@ -110,10 +101,6 @@ abstract class EmulatorDiscovery {
   bool get canListAnything;
 
   Future<List<Emulator>> get emulators;
-
-  /// Gets a list of diagnostic messages pertaining to issues with any available
-  /// emulators (will be an empty list if there are no issues).
-  Future<List<String>> getDiagnostics() => new Future<List<String>>.value(<String>[]);
 }
 
 abstract class Emulator {

--- a/packages/flutter_tools/lib/src/emulator.dart
+++ b/packages/flutter_tools/lib/src/emulator.dart
@@ -48,11 +48,11 @@ class EmulatorManager {
     final List<Emulator> emulators = await getAllAvailableEmulators().toList();
     emulatorId = emulatorId.toLowerCase();
     bool exactlyMatchesEmulatorId(Emulator emulator) =>
-        emulator.id.toLowerCase() == emulatorId ||
-        emulator.name.toLowerCase() == emulatorId;
+        emulator.id?.toLowerCase() == emulatorId ||
+        emulator.name?.toLowerCase() == emulatorId;
     bool startsWithEmulatorId(Emulator emulator) =>
-        emulator.id.toLowerCase().startsWith(emulatorId) ||
-        emulator.name.toLowerCase().startsWith(emulatorId);
+        emulator.id?.toLowerCase()?.startsWith(emulatorId) == true ||
+        emulator.name?.toLowerCase()?.startsWith(emulatorId) == true;
 
     final Emulator exactMatch = emulators.firstWhere(
         exactlyMatchesEmulatorId, orElse: () => null);
@@ -150,10 +150,10 @@ abstract class Emulator {
     final List<List<String>> table = <List<String>>[];
     for (Emulator emulator in emulators) {
       table.add(<String>[
-        emulator.name,
-        emulator.manufacturer,
-        emulator.label,
-        emulator.id,
+        emulator.name ?? emulator.id ?? '',
+        emulator.manufacturer ?? '',
+        emulator.label ?? '',
+        emulator.id ?? '',
       ]);
     }
 

--- a/packages/flutter_tools/lib/src/emulator.dart
+++ b/packages/flutter_tools/lib/src/emulator.dart
@@ -123,11 +123,14 @@ abstract class Emulator {
     }
 
     // Join columns into lines of text
+    final RegExp whiteSpaceAndDots = new RegExp(r'[•\s]+$');
     return table.map((List<String> row) {
       return indices
         .map((int i) => row[i].padRight(widths[i]))
-        .join(' • ') + (row.last != '' ? ' • ${row.last}' : '');
-    }).toList();
+        .join(' • ') + ' • ${row.last}';
+    })
+        .map((String line) => line.replaceAll(whiteSpaceAndDots, ''))
+        .toList();
   }
 
   static void printEmulators(List<Emulator> emulators) {

--- a/packages/flutter_tools/lib/src/emulator.dart
+++ b/packages/flutter_tools/lib/src/emulator.dart
@@ -95,7 +95,7 @@ abstract class Emulator {
     return id == other.id;
   }
 
-  void launch();
+  Future<void> launch();
 
   @override
   String toString() => name;

--- a/packages/flutter_tools/lib/src/emulator.dart
+++ b/packages/flutter_tools/lib/src/emulator.dart
@@ -110,10 +110,10 @@ abstract class Emulator {
     final List<List<String>> table = <List<String>>[];
     for (Emulator emulator in emulators) {
       table.add(<String>[
-        emulator.name ?? emulator.id ?? '',
+        emulator.id ?? '',
+        emulator.name ?? '',
         emulator.manufacturer ?? '',
         emulator.label ?? '',
-        emulator.id ?? '',
       ]);
     }
 

--- a/packages/flutter_tools/lib/src/emulator.dart
+++ b/packages/flutter_tools/lib/src/emulator.dart
@@ -51,7 +51,7 @@ class EmulatorManager {
   /// Return the list of all available emulators.
   Future<List<Emulator>> getAllAvailableEmulators() async {
     final List<Emulator> emulators = <Emulator>[];
-    Future.forEach(_platformDiscoverers, (EmulatorDiscovery discoverer) async {
+    await Future.forEach(_platformDiscoverers, (EmulatorDiscovery discoverer) async {
       emulators.addAll(await discoverer.emulators);
     });
     return emulators;

--- a/packages/flutter_tools/lib/src/emulator.dart
+++ b/packages/flutter_tools/lib/src/emulator.dart
@@ -126,7 +126,7 @@ abstract class Emulator {
     return table.map((List<String> row) {
       return indices
         .map((int i) => row[i].padRight(widths[i]))
-        .join(' • ') + ' • ${row.last}';
+        .join(' • ') + (row.last != '' ? ' • ${row.last}' : '');
     }).toList();
   }
 

--- a/packages/flutter_tools/lib/src/ios/ios_emulators.dart
+++ b/packages/flutter_tools/lib/src/ios/ios_emulators.dart
@@ -5,7 +5,6 @@
 import 'dart:async';
 
 import '../base/file_system.dart';
-import '../base/logger.dart';
 import '../base/platform.dart';
 import '../base/process.dart';
 import '../emulator.dart';
@@ -68,7 +67,7 @@ String getSimulatorPath() {
     '/Applications/Xcode.app/Contents/Developer/Applications/Simulator.app',
   ];
   return searchPaths.where((String p) => p != null).firstWhere(
-    (String p) => fs.directory(p).existsSync(),
-    orElse: () => null,
-  );
+        (String p) => fs.directory(p).existsSync(),
+        orElse: () => null,
+      );
 }

--- a/packages/flutter_tools/lib/src/ios/ios_emulators.dart
+++ b/packages/flutter_tools/lib/src/ios/ios_emulators.dart
@@ -1,0 +1,76 @@
+// Copyright 2018 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+
+import '../base/file_system.dart';
+import '../base/logger.dart';
+import '../base/platform.dart';
+import '../base/process.dart';
+import '../emulator.dart';
+import '../globals.dart';
+import 'ios_workflow.dart';
+
+// TODO: Is there a better name for this? We already have IOSSimulator classes
+// that represent *running* simulators, but this is about "unlaunched images"...
+class IOSEmulators extends EmulatorDiscovery {
+  @override
+  bool get supportsPlatform => platform.isMacOS;
+
+  @override
+  bool get canListAnything => iosWorkflow.canListEmulators;
+
+  @override
+  Future<List<Emulator>> get emulators async => getEmulators();
+}
+
+class IOSEmulator extends Emulator {
+  IOSEmulator(String id) : super(id, true);
+
+  @override
+  String get name => 'iOS Simulator';
+
+  @override
+  String get manufacturer => 'Apple';
+
+  @override
+  String get label => '';
+
+  @override
+  Future<bool> launch() async {
+    final Status status = logger.startProgress('Launching $id...');
+    final RunResult launchResult =
+        await runAsync(<String>['open', '-a', getSimulatorPath()]);
+    status.stop();
+    if (launchResult.exitCode != 0) {
+      printError(
+          'Error: iOS simulator failed to launch with exit code ${launchResult.exitCode}');
+      printError('$launchResult');
+      return false;
+    }
+
+    return true;
+  }
+}
+
+/// Return the list of iOS Simulators (there can only be zero or one).
+List<IOSEmulator> getEmulators() {
+  final String simulatorPath = getSimulatorPath();
+  if (simulatorPath == null) {
+    return <IOSEmulator>[];
+  }
+
+  return <IOSEmulator>[new IOSEmulator('apple_ios_simulator')];
+}
+
+String getSimulatorPath() {
+  final List<String> searchPaths = <String>[
+    // TODO: Could this be anywhere else?
+    '/Applications/Xcode.app/Contents/Developer/Applications/Simulator.app',
+  ];
+  return searchPaths.where((String p) => p != null).firstWhere(
+    (String p) => fs.directory(p).existsSync(),
+    orElse: () => null,
+  );
+}

--- a/packages/flutter_tools/lib/src/ios/ios_emulators.dart
+++ b/packages/flutter_tools/lib/src/ios/ios_emulators.dart
@@ -34,7 +34,7 @@ class IOSEmulator extends Emulator {
   String get manufacturer => 'Apple';
 
   @override
-  String get label => '';
+  String get label => null;
 
   @override
   Future<bool> launch() async {

--- a/packages/flutter_tools/lib/src/ios/ios_emulators.dart
+++ b/packages/flutter_tools/lib/src/ios/ios_emulators.dart
@@ -41,8 +41,6 @@ class IOSEmulator extends Emulator {
     final RunResult launchResult =
         await runAsync(<String>['open', '-a', getSimulatorPath()]);
     if (launchResult.exitCode != 0) {
-      printError(
-          'Error: iOS simulator failed to launch with exit code ${launchResult.exitCode}');
       printError('$launchResult');
       return false;
     }

--- a/packages/flutter_tools/lib/src/ios/ios_emulators.dart
+++ b/packages/flutter_tools/lib/src/ios/ios_emulators.dart
@@ -39,10 +39,8 @@ class IOSEmulator extends Emulator {
 
   @override
   Future<bool> launch() async {
-    final Status status = logger.startProgress('Launching $id...');
     final RunResult launchResult =
         await runAsync(<String>['open', '-a', getSimulatorPath()]);
-    status.stop();
     if (launchResult.exitCode != 0) {
       printError(
           'Error: iOS simulator failed to launch with exit code ${launchResult.exitCode}');

--- a/packages/flutter_tools/lib/src/ios/ios_emulators.dart
+++ b/packages/flutter_tools/lib/src/ios/ios_emulators.dart
@@ -11,7 +11,7 @@ import '../emulator.dart';
 import '../globals.dart';
 import 'ios_workflow.dart';
 
-// TODO: Is there a better name for this? We already have IOSSimulator classes
+// TODO(dantup): Is there a better name for this? We already have IOSSimulator classes
 // that represent *running* simulators, but this is about "unlaunched images"...
 class IOSEmulators extends EmulatorDiscovery {
   @override
@@ -61,7 +61,7 @@ List<IOSEmulator> getEmulators() {
 
 String getSimulatorPath() {
   final List<String> searchPaths = <String>[
-    // TODO: Could this be anywhere else?
+    // TODO(dantup): Could this be anywhere else?
     '/Applications/Xcode.app/Contents/Developer/Applications/Simulator.app',
   ];
   return searchPaths.where((String p) => p != null).firstWhere(

--- a/packages/flutter_tools/lib/src/ios/ios_emulators.dart
+++ b/packages/flutter_tools/lib/src/ios/ios_emulators.dart
@@ -35,15 +35,12 @@ class IOSEmulator extends Emulator {
   String get label => null;
 
   @override
-  Future<bool> launch() async {
+  Future<void> launch() async {
     final RunResult launchResult =
         await runAsync(<String>['open', '-a', getSimulatorPath()]);
     if (launchResult.exitCode != 0) {
       printError('$launchResult');
-      return false;
     }
-
-    return true;
   }
 }
 

--- a/packages/flutter_tools/lib/src/ios/ios_emulators.dart
+++ b/packages/flutter_tools/lib/src/ios/ios_emulators.dart
@@ -11,8 +11,6 @@ import '../emulator.dart';
 import '../globals.dart';
 import 'ios_workflow.dart';
 
-// TODO(dantup): Is there a better name for this? We already have IOSSimulator classes
-// that represent *running* simulators, but this is about "unlaunched images"...
 class IOSEmulators extends EmulatorDiscovery {
   @override
   bool get supportsPlatform => platform.isMacOS;

--- a/packages/flutter_tools/lib/src/ios/ios_emulators.dart
+++ b/packages/flutter_tools/lib/src/ios/ios_emulators.dart
@@ -9,6 +9,7 @@ import '../base/platform.dart';
 import '../base/process.dart';
 import '../emulator.dart';
 import '../globals.dart';
+import '../ios/mac.dart';
 import 'ios_workflow.dart';
 
 class IOSEmulators extends EmulatorDiscovery {
@@ -56,8 +57,7 @@ List<IOSEmulator> getEmulators() {
 
 String getSimulatorPath() {
   final List<String> searchPaths = <String>[
-    // TODO(dantup): Could this be anywhere else?
-    '/Applications/Xcode.app/Contents/Developer/Applications/Simulator.app',
+    fs.path.join(xcode.xcodeSelectPath, 'Applications', 'Simulator.app'),
   ];
   return searchPaths.where((String p) => p != null).firstWhere(
         (String p) => fs.directory(p).existsSync(),

--- a/packages/flutter_tools/lib/src/ios/ios_workflow.dart
+++ b/packages/flutter_tools/lib/src/ios/ios_workflow.dart
@@ -33,9 +33,6 @@ class IOSWorkflow extends DoctorValidator implements Workflow {
   @override
   bool get canListEmulators => false;
 
-  @override
-  bool get canLaunchEmulators => false;
-
   Future<bool> get hasIDeviceInstaller => exitsHappyAsync(<String>['ideviceinstaller', '-h']);
 
   Future<bool> get hasIosDeploy => exitsHappyAsync(<String>['ios-deploy', '--version']);

--- a/packages/flutter_tools/lib/src/ios/ios_workflow.dart
+++ b/packages/flutter_tools/lib/src/ios/ios_workflow.dart
@@ -30,6 +30,12 @@ class IOSWorkflow extends DoctorValidator implements Workflow {
   @override
   bool get canLaunchDevices => xcode.isInstalledAndMeetsVersionCheck;
 
+  @override
+  bool get canListEmulators => false;
+
+  @override
+  bool get canLaunchEmulators => false;
+
   Future<bool> get hasIDeviceInstaller => exitsHappyAsync(<String>['ideviceinstaller', '-h']);
 
   Future<bool> get hasIosDeploy => exitsHappyAsync(<String>['ios-deploy', '--version']);

--- a/packages/flutter_tools/test/android/android_emulator_test.dart
+++ b/packages/flutter_tools/test/android/android_emulator_test.dart
@@ -1,0 +1,56 @@
+// Copyright 2018 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_tools/src/android/android_emulator.dart';
+import 'package:test/test.dart';
+
+import '../src/context.dart';
+
+void main() {
+  group('android_emulator', () {
+    testUsingContext('flags emulators without config', () {
+      const String emulatorID = '1234';
+      final AndroidEmulator emulator = new AndroidEmulator(emulatorID);
+      expect(emulator.id, emulatorID);
+      expect(emulator.hasConfig, false);
+    });
+    testUsingContext('flags emulators with config', () {
+      const String emulatorID = '1234';
+      final AndroidEmulator emulator =
+          new AndroidEmulator(emulatorID, <String, String>{'name': 'test'});
+      expect(emulator.id, emulatorID);
+      expect(emulator.hasConfig, true);
+    });
+    testUsingContext('stores expected metadata', () {
+      const String emulatorID = '1234';
+      const String name = 'My Test Name';
+      const String manufacturer = 'Me';
+      const String label = 'The best one';
+      final Map<String, String> properties = <String, String>{
+        'hw.device.name': name,
+        'hw.device.manufacturer': manufacturer,
+        'avd.ini.displayname': label
+      };
+      final AndroidEmulator emulator =
+          new AndroidEmulator(emulatorID, properties);
+      expect(emulator.id, emulatorID);
+      expect(emulator.name, name);
+      expect(emulator.manufacturer, manufacturer);
+      expect(emulator.label, label);
+    });
+    testUsingContext('parses ini files', () {
+      const String iniFile = '''
+        hw.device.name=My Test Name
+        #hw.device.name=Bad Name
+
+        hw.device.manufacturer=Me
+        avd.ini.displayname = dispName
+      ''';
+      final Map<String, String> results = parseIniLines(iniFile.split('\n'));
+      expect(results['hw.device.name'], 'My Test Name');
+      expect(results['hw.device.manufacturer'], 'Me');
+      expect(results['avd.ini.displayname'], 'dispName');
+    });
+  });
+}

--- a/packages/flutter_tools/test/emulator_test.dart
+++ b/packages/flutter_tools/test/emulator_test.dart
@@ -61,4 +61,10 @@ class _MockEmulator extends Emulator {
   @override
   final String label;
 
+  @override
+  void launch() {
+    throw new UnimplementedError('Not implemented in Mock');
+  }
+
+  
 }

--- a/packages/flutter_tools/test/emulator_test.dart
+++ b/packages/flutter_tools/test/emulator_test.dart
@@ -19,9 +19,9 @@ void main() {
     });
 
     testUsingContext('getEmulatorsById', () async {
-      final _MockEmulator emulator1 = new _MockEmulator('Nexus_5');
-      final _MockEmulator emulator2 = new _MockEmulator('Nexus_5X_API_27_x86');
-      final _MockEmulator emulator3 = new _MockEmulator('iOS Simulator');
+      final _MockEmulator emulator1 = new _MockEmulator('Nexus_5', 'Nexus 5', 'Google', '');
+      final _MockEmulator emulator2 = new _MockEmulator('Nexus_5X_API_27_x86', 'Nexus 5X', 'Google', '');
+      final _MockEmulator emulator3 = new _MockEmulator('iOS Simulator', 'iOS Simulator', 'Apple', '');
       final List<Emulator> emulators = <Emulator>[emulator1, emulator2, emulator3];
       final EmulatorManager emulatorManager = new TestEmulatorManager(emulators);
 
@@ -50,8 +50,15 @@ class TestEmulatorManager extends EmulatorManager {
 }
 
 class _MockEmulator extends Emulator {
-  _MockEmulator(String id) : super(id);
+  _MockEmulator(String id, this.name, this.manufacturer, this.label) : super(id, true);
 
   @override
-  void noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+  final String name;
+ 
+  @override
+  final String manufacturer;
+ 
+  @override
+  final String label;
+
 }

--- a/packages/flutter_tools/test/emulator_test.dart
+++ b/packages/flutter_tools/test/emulator_test.dart
@@ -1,0 +1,57 @@
+// Copyright 2018 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:flutter_tools/src/emulator.dart';
+import 'package:test/test.dart';
+
+import 'src/context.dart';
+
+void main() {
+  group('EmulatorManager', () {
+    testUsingContext('getEmulators', () async {
+      // Test that EmulatorManager.getEmulators() doesn't throw.
+      final EmulatorManager emulatorManager = new EmulatorManager();
+      final List<Emulator> emulators = await emulatorManager.getAllAvailableEmulators().toList();
+      expect(emulators, isList);
+    });
+
+    testUsingContext('getEmulatorsById', () async {
+      final _MockEmulator emulator1 = new _MockEmulator('Nexus_5');
+      final _MockEmulator emulator2 = new _MockEmulator('Nexus_5X_API_27_x86');
+      final _MockEmulator emulator3 = new _MockEmulator('iOS Simulator');
+      final List<Emulator> emulators = <Emulator>[emulator1, emulator2, emulator3];
+      final EmulatorManager emulatorManager = new TestEmulatorManager(emulators);
+
+      Future<Null> expectEmulator(String id, List<Emulator> expected) async {
+        expect(await emulatorManager.getEmulatorsById(id).toList(), expected);
+      }
+      expectEmulator('Nexus_5', <Emulator>[emulator1]);
+      expectEmulator('Nexus_5X', <Emulator>[emulator2]);
+      expectEmulator('Nexus_5X_API_27_x86', <Emulator>[emulator2]);
+      expectEmulator('Nexus', <Emulator>[emulator1, emulator2]);
+      expectEmulator('iOS Simulator', <Emulator>[emulator3]);
+      expectEmulator('ios', <Emulator>[emulator3]);
+    });
+  });
+}
+
+class TestEmulatorManager extends EmulatorManager {
+  final List<Emulator> allEmulators;
+
+  TestEmulatorManager(this.allEmulators);
+
+  @override
+  Stream<Emulator> getAllAvailableEmulators() {
+    return new Stream<Emulator>.fromIterable(allEmulators);
+  }
+}
+
+class _MockEmulator extends Emulator {
+  _MockEmulator(String id) : super(id);
+
+  @override
+  void noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}

--- a/packages/flutter_tools/test/emulator_test.dart
+++ b/packages/flutter_tools/test/emulator_test.dart
@@ -26,7 +26,7 @@ void main() {
       final EmulatorManager emulatorManager = new TestEmulatorManager(emulators);
 
       Future<Null> expectEmulator(String id, List<Emulator> expected) async {
-        expect(await emulatorManager.getEmulatorsById(id).toList(), expected);
+        expect(await emulatorManager.getEmulatorsMatching(id).toList(), expected);
       }
       expectEmulator('Nexus_5', <Emulator>[emulator1]);
       expectEmulator('Nexus_5X', <Emulator>[emulator2]);

--- a/packages/flutter_tools/test/emulator_test.dart
+++ b/packages/flutter_tools/test/emulator_test.dart
@@ -14,7 +14,7 @@ void main() {
     testUsingContext('getEmulators', () async {
       // Test that EmulatorManager.getEmulators() doesn't throw.
       final EmulatorManager emulatorManager = new EmulatorManager();
-      final List<Emulator> emulators = await emulatorManager.getAllAvailableEmulators().toList();
+      final List<Emulator> emulators = await emulatorManager.getAllAvailableEmulators();
       expect(emulators, isList);
     });
 
@@ -26,7 +26,7 @@ void main() {
       final EmulatorManager emulatorManager = new TestEmulatorManager(emulators);
 
       Future<Null> expectEmulator(String id, List<Emulator> expected) async {
-        expect(await emulatorManager.getEmulatorsMatching(id).toList(), expected);
+        expect(await emulatorManager.getEmulatorsMatching(id), expected);
       }
       expectEmulator('Nexus_5', <Emulator>[emulator1]);
       expectEmulator('Nexus_5X', <Emulator>[emulator2]);
@@ -44,8 +44,8 @@ class TestEmulatorManager extends EmulatorManager {
   TestEmulatorManager(this.allEmulators);
 
   @override
-  Stream<Emulator> getAllAvailableEmulators() {
-    return new Stream<Emulator>.fromIterable(allEmulators);
+  Future<List<Emulator>> getAllAvailableEmulators() {
+    return new Future<List<Emulator>>.value(allEmulators);
   }
 }
 

--- a/packages/flutter_tools/test/emulator_test.dart
+++ b/packages/flutter_tools/test/emulator_test.dart
@@ -62,7 +62,7 @@ class _MockEmulator extends Emulator {
   final String label;
 
   @override
-  void launch() {
+  Future<void> launch() {
     throw new UnimplementedError('Not implemented in Mock');
   }
 }

--- a/packages/flutter_tools/test/emulator_test.dart
+++ b/packages/flutter_tools/test/emulator_test.dart
@@ -65,6 +65,4 @@ class _MockEmulator extends Emulator {
   void launch() {
     throw new UnimplementedError('Not implemented in Mock');
   }
-
-  
 }


### PR DESCRIPTION
This is work-in-progress, just opening this to allow feedback.

For now, I'm using the term `emulators` to refer to these (these being AVDs in the case of Android and "the simulator" for iOS), but this can easily be changed.

Commands are being implemented as:

- `flutter emulators` - lists emulators
- `flutter emulators --launch xxx` - launch an emulator

Creation will be handled in a separate PR once listing/launching is done. The code is mostly a copy of the `devices` code but much simplified (since there's a lot less to do with an AVD). Right now, this just supports `flutter emulators` which spits out the list (same as `emulator -list-avds`).

## TODO:

- [x] Display more information about an emulator (currently only shows IDs)
- [x] Support launching an emulator
- [x] [Are there other places the simulator could be](https://github.com/flutter/flutter/pull/16705#discussion_r185809497)?
- [x] [Fix missing await](https://github.com/flutter/flutter/pull/16705#issuecomment-386339354) (in a way that doesn't stall the process until emulator closes, or lose error output)
- [ ] Add tests
- [x] Agree on name (currently "emulators")
- [x] Agree command interface (currently `flutter emulators` w/ `--launch`/`--create`)
- [x] Ensure missing `emulators` command reports a useful error
- [x] Ensure error output from `emulators` command is displayed correctly
- [x] Add in "the simulator" for iOS when running on Mac
- [x] Ensure iOS simulator doesn't appear on non-Mac
- [x] ~~Investigate if ID/names can be matched up with `flutter devices` output~~ Yes they can, but only be connected to the device. Need to decide whether to do anything with this (considering it out of scope for this PR)

Relates to:

https://github.com/flutter/flutter/issues/14822
https://github.com/Dart-Code/Dart-Code/issues/490
https://github.com/flutter/flutter/issues/13379