### PR TITLE
Tweak theme_test so it passes when --track-widget-creation is used.

### DIFF
--- a/packages/flutter/test/material/theme_test.dart
+++ b/packages/flutter/test/material/theme_test.dart
@@ -299,43 +299,30 @@ void main() {
       testBuildCalled = 0;
       ThemeData themeData = new ThemeData(primaryColor: const Color(0xFF000000));
 
-      await tester.pumpWidget(
-        new Theme(
+      Widget buildTheme() {
+        return new Theme(
           data: themeData,
           child: const Test(),
-        ),
-      );
+        );
+      }
+
+      await tester.pumpWidget(buildTheme());
       expect(testBuildCalled, 1);
 
       // Pump the same widgets again.
-      await tester.pumpWidget(
-        new Theme(
-          data: themeData,
-          child: const Test(),
-        ),
-      );
+      await tester.pumpWidget(buildTheme());
       // No repeated build calls to the child since it's the same theme data.
       expect(testBuildCalled, 1);
 
       // New instance of theme data but still the same content.
       themeData = new ThemeData(primaryColor: const Color(0xFF000000));
-      await tester.pumpWidget(
-        new Theme(
-          data: themeData,
-          child: const Test(),
-        ),
-      );
+      await tester.pumpWidget(buildTheme());
       // Still no repeated calls.
       expect(testBuildCalled, 1);
 
       // Different now.
       themeData = new ThemeData(primaryColor: const Color(0xFF222222));
-      await tester.pumpWidget(
-        new Theme(
-          data: themeData,
-          child: const Test(),
-        ),
-      );
+      await tester.pumpWidget(buildTheme());
       // Should call build again.
       expect(testBuildCalled, 2);
     },


### PR DESCRIPTION
A bit more idiomatic way to tweak the theme test so it
still passes with --track-widget-creation.
This makes the test match the layout of a typical user build method where the same const
widget is created on the same line each time.