### PR TITLE
add the full path to a flutter command

### DIFF
--- a/packages/flutter_tools/lib/src/commands/run.dart
+++ b/packages/flutter_tools/lib/src/commands/run.dart
@@ -190,13 +190,11 @@ class RunCommand extends RunCommandBase {
 
   @override
   Future<String> get usagePath async {
-    final String command = shouldUseHotMode() ? 'hotrun' : name;
+    final String command = await super.usagePath;
 
     if (devices == null)
       return command;
-
-    // Return 'run/ios'.
-    if (devices.length > 1)
+    else if (devices.length > 1)
       return '$command/all';
     else
       return '$command/${getNameForTargetPlatform(await devices[0].targetPlatform)}';

--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -243,7 +243,15 @@ abstract class FlutterCommand extends Command<Null> {
 
   /// The path to send to Google Analytics. Return null here to disable
   /// tracking of the command.
-  Future<String> get usagePath async => name;
+  Future<String> get usagePath async {
+    if (parent is FlutterCommand) {
+      final FlutterCommand commandParent = parent;
+      final String path = await commandParent.usagePath;
+      return '$path/$name';
+    } else {
+      return name;
+    }
+  }
 
   /// Additional usage values to be sent with the usage ping.
   Future<Map<String, String>> get usageValues async => const <String, String>{};
@@ -274,7 +282,8 @@ abstract class FlutterCommand extends Command<Null> {
         } finally {
           final DateTime endTime = clock.now();
           printTrace('"flutter $name" took ${getElapsedAsMilliseconds(endTime.difference(startTime))}.');
-          if (usagePath != null) {
+          final Future<String> usagePathResult = usagePath;
+          if (usagePathResult != null) {
             final List<String> labels = <String>[];
             if (commandResult?.exitStatus != null)
               labels.add(getEnumName(commandResult.exitStatus));

--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -247,7 +247,8 @@ abstract class FlutterCommand extends Command<Null> {
     if (parent is FlutterCommand) {
       final FlutterCommand commandParent = parent;
       final String path = await commandParent.usagePath;
-      return '$path/$name';
+      // Don't report for parents that return null for usagePath.
+      return path == null ? null : '$path/$name';
     } else {
       return name;
     }
@@ -282,8 +283,9 @@ abstract class FlutterCommand extends Command<Null> {
         } finally {
           final DateTime endTime = clock.now();
           printTrace('"flutter $name" took ${getElapsedAsMilliseconds(endTime.difference(startTime))}.');
-          final Future<String> usagePathResult = usagePath;
-          if (usagePathResult != null) {
+          // Note that this is checking the result of the call to 'usagePath'
+          // (a Future<String>), and not the result of evaluating the Future.
+          if (usagePath != null) {
             final List<String> labels = <String>[];
             if (commandResult?.exitStatus != null)
               labels.add(getEnumName(commandResult.exitStatus));

--- a/packages/flutter_tools/test/analytics_test.dart
+++ b/packages/flutter_tools/test/analytics_test.dart
@@ -5,9 +5,12 @@
 import 'package:args/command_runner.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/cache.dart';
+import 'package:flutter_tools/src/commands/build.dart';
+import 'package:flutter_tools/src/commands/build_apk.dart';
 import 'package:flutter_tools/src/commands/config.dart';
 import 'package:flutter_tools/src/commands/doctor.dart';
 import 'package:flutter_tools/src/doctor.dart';
+import 'package:flutter_tools/src/runner/flutter_command.dart';
 import 'package:flutter_tools/src/usage.dart';
 import 'package:flutter_tools/src/version.dart';
 import 'package:mockito/mockito.dart';
@@ -129,6 +132,21 @@ void main() {
     }, overrides: <Type, Generator>{
       Clock: () => mockClock,
       Doctor: () => mockDoctor,
+      Usage: () => mockUsage,
+    });
+
+    testUsingContext('single command usage path', () async {
+      final FlutterCommand doctorCommand = new DoctorCommand();
+      expect(await doctorCommand.usagePath, 'doctor');
+    }, overrides: <Type, Generator>{
+      Usage: () => mockUsage,
+    });
+
+    testUsingContext('compound command usage path', () async {
+      final BuildCommand buildCommand = new BuildCommand();
+      final FlutterCommand buildApkCommand = buildCommand.subcommands['apk'];
+      expect(await buildApkCommand.usagePath, 'build/apk');
+    }, overrides: <Type, Generator>{
       Usage: () => mockUsage,
     });
   });

--- a/packages/flutter_tools/test/analytics_test.dart
+++ b/packages/flutter_tools/test/analytics_test.dart
@@ -6,7 +6,6 @@ import 'package:args/command_runner.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/commands/build.dart';
-import 'package:flutter_tools/src/commands/build_apk.dart';
 import 'package:flutter_tools/src/commands/config.dart';
 import 'package:flutter_tools/src/commands/doctor.dart';
 import 'package:flutter_tools/src/doctor.dart';


### PR DESCRIPTION
- change the `usagePath` for flutter_tools commands to include the full path to the command (so, track `build/apk` instead of `apk`)
- clarify in one place that we're using the null result value of a call to a Future method, instead of a null value through the future (I was tripped up by this when reading the code)
- change `hotrun/<device>` to just use `run/<device>`, for consistency with the rest of the command tracking

@jcollins-g 
