### PR TITLE
Move script snapshot argumtents to Snapshotter

### DIFF
--- a/packages/flutter_tools/lib/src/base/build.dart
+++ b/packages/flutter_tools/lib/src/base/build.dart
@@ -26,6 +26,9 @@ class SnapshotType {
 
   final TargetPlatform platform;
   final BuildMode mode;
+
+  @override
+  String toString() => '$platform $mode';
 }
 
 /// Interface to the gen_snapshot command-line tool.
@@ -38,13 +41,9 @@ class GenSnapshot {
     @required String depfilePath,
     Iterable<String> additionalArgs: const <String>[],
   }) {
-    final String vmSnapshotData = artifacts.getArtifactPath(Artifact.vmSnapshotData);
-    final String isolateSnapshotData = artifacts.getArtifactPath(Artifact.isolateSnapshotData);
     final List<String> args = <String>[
       '--await_is_keyword',
       '--causal_async_stacks',
-      '--vm_snapshot_data=$vmSnapshotData',
-      '--isolate_snapshot_data=$isolateSnapshotData',
       '--packages=$packagesPath',
       '--dependencies=$depfilePath',
       '--print_snapshot_sizes',
@@ -172,9 +171,13 @@ class Snapshotter {
     @required String packagesPath
   }) async {
     final SnapshotType snapshotType = new SnapshotType(null, BuildMode.debug);
+    final String vmSnapshotData = artifacts.getArtifactPath(Artifact.vmSnapshotData);
+    final String isolateSnapshotData = artifacts.getArtifactPath(Artifact.isolateSnapshotData);
     final List<String> args = <String>[
       '--snapshot_kind=script',
       '--script_snapshot=$snapshotPath',
+      '--vm_snapshot_data=$vmSnapshotData',
+      '--isolate_snapshot_data=$isolateSnapshotData',
       '--enable-mirrors=false',
       mainPath,
     ];

--- a/packages/flutter_tools/test/base/build_test.dart
+++ b/packages/flutter_tools/test/base/build_test.dart
@@ -34,8 +34,20 @@ class _FakeGenSnapshot implements GenSnapshot {
   final String snapshotContent;
   final String depfileContent;
   int _callCount = 0;
+  SnapshotType _snapshotType;
+  String _packagesPath;
+  String _depfilePath;
+  List<String> _additionalArgs;
 
   int get callCount => _callCount;
+
+  SnapshotType get snapshotType => _snapshotType;
+
+  String get packagesPath => _packagesPath;
+
+  String get depfilePath => _depfilePath;
+
+  List<String> get additionalArgs => _additionalArgs;
 
   @override
   Future<int> run({
@@ -45,6 +57,10 @@ class _FakeGenSnapshot implements GenSnapshot {
     Iterable<String> additionalArgs,
   }) async {
     _callCount += 1;
+    _snapshotType = snapshotType;
+    _packagesPath = packagesPath;
+    _depfilePath = depfilePath;
+    _additionalArgs = additionalArgs.toList();
 
     if (!succeed)
       return 1;
@@ -388,6 +404,18 @@ void main() {
       await buildSnapshot();
 
       expect(genSnapshot.callCount, 1);
+      expect(genSnapshot.snapshotType.platform, isNull);
+      expect(genSnapshot.snapshotType.mode, BuildMode.debug);
+      expect(genSnapshot.packagesPath, '.packages');
+      expect(genSnapshot.depfilePath, 'output.snapshot.d');
+      expect(genSnapshot.additionalArgs, <String>[
+        '--snapshot_kind=script',
+        '--script_snapshot=output.snapshot',
+        '--vm_snapshot_data=vm_isolate_snapshot.bin',
+        '--isolate_snapshot_data=isolate_snapshot.bin',
+        '--enable-mirrors=false',
+        'main.dart',
+      ]);
       expectFingerprintHas(checksums: <String, String>{
         'main.dart': '27f5ebf0f8c559b2af9419d190299a5e',
         'output.snapshot': 'd41d8cd98f00b204e9800998ecf8427e',


### PR DESCRIPTION
This moves --vm_snapshot_data and --isolate_snapshot_data argument
hardcoding from GenSnapshot (a minimal wrapper around gen_snapshot
invocations) to Snapshotter.buildScriptSnapshot(). These arguments are
present in both AOT and script snapshots, but differ semantically: for
script snapshots they're inputs from the host engine artifacts
directory, for AOT snapshots they're outputs to the build directory.