### PR TITLE
SliverList works with changing children that are keyed

### DIFF
--- a/packages/flutter/lib/src/widgets/sliver.dart
+++ b/packages/flutter/lib/src/widgets/sliver.dart
@@ -739,6 +739,20 @@ class SliverMultiBoxAdaptorElement extends RenderObjectElement implements Render
   }
 
   @override
+  Element updateChild(Element child, Widget newWidget, dynamic newSlot) {
+    final SliverMultiBoxAdaptorParentData oldParentData = child?.renderObject?.parentData;
+    final Element newChild = super.updateChild(child, newWidget, newSlot);
+    final SliverMultiBoxAdaptorParentData newParentData = newChild?.renderObject?.parentData;
+
+    // Preserve the old layoutOffset if the renderObject was swapped out.
+    if (oldParentData != newParentData && oldParentData != null && newParentData != null) {
+      newParentData.layoutOffset = oldParentData.layoutOffset;
+    }
+
+    return newChild;
+  }
+
+  @override
   void forgetChild(Element child) {
     assert(child != null);
     assert(child.slot != null);

--- a/packages/flutter/test/widgets/sliver_list_test.dart
+++ b/packages/flutter/test/widgets/sliver_list_test.dart
@@ -1,0 +1,73 @@
+import 'package:flutter/foundation.dart';
+// Copyright 2018 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter/widgets.dart';
+
+void main() {
+  testWidgets('SliverList changes children (with keys)', (WidgetTester tester) async {
+    final List<int> items = new List<int>.generate(20, (int i) => i);
+    const double itemHeight = 300.0;
+    const double viewportHeight = 500.0;
+
+    final double scrollPosition = 18 * itemHeight;
+    final ScrollController controller = new ScrollController(initialScrollOffset: scrollPosition);
+
+    Widget _buildSliverList(List<int> items) {
+      return new Directionality(
+        textDirection: TextDirection.ltr,
+        child: new Center(
+          child: new Container(
+            height: viewportHeight,
+            child: new CustomScrollView(
+              controller: controller,
+              slivers: <Widget>[
+                new SliverList(
+                  delegate: new SliverChildBuilderDelegate(
+                    (BuildContext context, int i) {
+                      return new Container(
+                        key: new ValueKey<int>(items[i]),
+                        height: itemHeight,
+                        child: new Text('Tile ${items[i]}'),
+                      );
+                    },
+                    childCount: items.length,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      );
+    }
+
+    await tester.pumpWidget(_buildSliverList(items));
+    await tester.pumpAndSettle();
+
+    expect(controller.offset, scrollPosition);
+    expect(find.text('Tile 0'), findsNothing);
+    expect(find.text('Tile 1'), findsNothing);
+    expect(find.text('Tile 18'), findsOneWidget);
+    expect(find.text('Tile 19'), findsOneWidget);
+
+    await tester.pumpWidget(_buildSliverList(items.reversed.toList()));
+    await tester.pumpAndSettle();
+
+    expect(controller.offset, scrollPosition);
+    expect(find.text('Tile 19'), findsNothing);
+    expect(find.text('Tile 18'), findsNothing);
+    expect(find.text('Tile 1'), findsOneWidget);
+    expect(find.text('Tile 0'), findsOneWidget);
+
+    controller.jumpTo(0.0);
+    await tester.pumpAndSettle();
+
+    expect(controller.offset, 0.0);
+    expect(find.text('Tile 19'), findsOneWidget);
+    expect(find.text('Tile 18'), findsOneWidget);
+    expect(find.text('Tile 1'), findsNothing);
+    expect(find.text('Tile 0'), findsNothing);
+  });
+}

--- a/packages/flutter/test/widgets/sliver_list_test.dart
+++ b/packages/flutter/test/widgets/sliver_list_test.dart
@@ -1,9 +1,9 @@
-import 'package:flutter/foundation.dart';
 // Copyright 2018 The Chromium Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 
 void main() {
@@ -12,7 +12,7 @@ void main() {
     const double itemHeight = 300.0;
     const double viewportHeight = 500.0;
 
-    final double scrollPosition = 18 * itemHeight;
+    const double scrollPosition = 18 * itemHeight;
     final ScrollController controller = new ScrollController(initialScrollOffset: scrollPosition);
 
     Widget _buildSliverList(List<int> items) {

--- a/packages/flutter/test/widgets/sliver_list_test.dart
+++ b/packages/flutter/test/widgets/sliver_list_test.dart
@@ -7,7 +7,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 
 void main() {
-  testWidgets('SliverList changes children (with keys)', (WidgetTester tester) async {
+  testWidgets('SliverList reverse children (with keys)', (WidgetTester tester) async {
     final List<int> items = new List<int>.generate(20, (int i) => i);
     const double itemHeight = 300.0;
     const double viewportHeight = 500.0;
@@ -15,35 +15,12 @@ void main() {
     const double scrollPosition = 18 * itemHeight;
     final ScrollController controller = new ScrollController(initialScrollOffset: scrollPosition);
 
-    Widget _buildSliverList(List<int> items) {
-      return new Directionality(
-        textDirection: TextDirection.ltr,
-        child: new Center(
-          child: new Container(
-            height: viewportHeight,
-            child: new CustomScrollView(
-              controller: controller,
-              slivers: <Widget>[
-                new SliverList(
-                  delegate: new SliverChildBuilderDelegate(
-                    (BuildContext context, int i) {
-                      return new Container(
-                        key: new ValueKey<int>(items[i]),
-                        height: itemHeight,
-                        child: new Text('Tile ${items[i]}'),
-                      );
-                    },
-                    childCount: items.length,
-                  ),
-                ),
-              ],
-            ),
-          ),
-        ),
-      );
-    }
-
-    await tester.pumpWidget(_buildSliverList(items));
+    await tester.pumpWidget(_buildSliverList(
+      items: items,
+      controller: controller,
+      itemHeight: itemHeight,
+      viewportHeight: viewportHeight,
+    ));
     await tester.pumpAndSettle();
 
     expect(controller.offset, scrollPosition);
@@ -52,8 +29,14 @@ void main() {
     expect(find.text('Tile 18'), findsOneWidget);
     expect(find.text('Tile 19'), findsOneWidget);
 
-    await tester.pumpWidget(_buildSliverList(items.reversed.toList()));
-    await tester.pumpAndSettle();
+    await tester.pumpWidget(_buildSliverList(
+      items: items.reversed.toList(),
+      controller: controller,
+      itemHeight: itemHeight,
+      viewportHeight: viewportHeight,
+    ));
+    final int frames = await tester.pumpAndSettle();
+    expect(frames, 1); // ensures that there is no (animated) bouncing of the scrollable
 
     expect(controller.offset, scrollPosition);
     expect(find.text('Tile 19'), findsNothing);
@@ -70,4 +53,129 @@ void main() {
     expect(find.text('Tile 1'), findsNothing);
     expect(find.text('Tile 0'), findsNothing);
   });
+
+  testWidgets('SliverList replace children (with keys)', (WidgetTester tester) async {
+    final List<int> items = new List<int>.generate(20, (int i) => i);
+    const double itemHeight = 300.0;
+    const double viewportHeight = 500.0;
+
+    const double scrollPosition = 18 * itemHeight;
+    final ScrollController controller = new ScrollController(initialScrollOffset: scrollPosition);
+
+    await tester.pumpWidget(_buildSliverList(
+      items: items,
+      controller: controller,
+      itemHeight: itemHeight,
+      viewportHeight: viewportHeight,
+    ));
+    await tester.pumpAndSettle();
+
+    expect(controller.offset, scrollPosition);
+    expect(find.text('Tile 0'), findsNothing);
+    expect(find.text('Tile 1'), findsNothing);
+    expect(find.text('Tile 18'), findsOneWidget);
+    expect(find.text('Tile 19'), findsOneWidget);
+
+    await tester.pumpWidget(_buildSliverList(
+      items: items.map((int i) => i + 100).toList(),
+      controller: controller,
+      itemHeight: itemHeight,
+      viewportHeight: viewportHeight,
+    ));
+    final int frames = await tester.pumpAndSettle();
+    expect(frames, 1); // ensures that there is no (animated) bouncing of the scrollable
+
+    expect(controller.offset, scrollPosition);
+    expect(find.text('Tile 0'), findsNothing);
+    expect(find.text('Tile 1'), findsNothing);
+    expect(find.text('Tile 18'), findsNothing);
+    expect(find.text('Tile 19'), findsNothing);
+
+    expect(find.text('Tile 100'), findsNothing);
+    expect(find.text('Tile 101'), findsNothing);
+    expect(find.text('Tile 118'), findsOneWidget);
+    expect(find.text('Tile 119'), findsOneWidget);
+
+    controller.jumpTo(0.0);
+    await tester.pumpAndSettle();
+
+    expect(controller.offset, 0.0);
+    expect(find.text('Tile 100'), findsOneWidget);
+    expect(find.text('Tile 101'), findsOneWidget);
+    expect(find.text('Tile 118'), findsNothing);
+    expect(find.text('Tile 119'), findsNothing);
+  });
+
+  testWidgets('SliverList replace with shorter children list (with keys)', (WidgetTester tester) async {
+    final List<int> items = new List<int>.generate(20, (int i) => i);
+    const double itemHeight = 300.0;
+    const double viewportHeight = 500.0;
+
+    final double scrollPosition = items.length * itemHeight - viewportHeight;
+    final ScrollController controller = new ScrollController(initialScrollOffset: scrollPosition);
+
+    await tester.pumpWidget(_buildSliverList(
+      items: items,
+      controller: controller,
+      itemHeight: itemHeight,
+      viewportHeight: viewportHeight,
+    ));
+    await tester.pumpAndSettle();
+
+    expect(controller.offset, scrollPosition);
+    expect(find.text('Tile 0'), findsNothing);
+    expect(find.text('Tile 1'), findsNothing);
+    expect(find.text('Tile 17'), findsNothing);
+    expect(find.text('Tile 18'), findsOneWidget);
+    expect(find.text('Tile 19'), findsOneWidget);
+
+    await tester.pumpWidget(_buildSliverList(
+      items: items.sublist(0, items.length - 1),
+      controller: controller,
+      itemHeight: itemHeight,
+      viewportHeight: viewportHeight,
+    ));
+    final int frames = await tester.pumpAndSettle();
+    expect(frames, greaterThan(1)); // ensure animation to bring tile17 into view
+
+    expect(controller.offset, scrollPosition - itemHeight);
+    expect(find.text('Tile 0'), findsNothing);
+    expect(find.text('Tile 1'), findsNothing);
+    expect(find.text('Tile 17'), findsOneWidget);
+    expect(find.text('Tile 18'), findsOneWidget);
+    expect(find.text('Tile 19'), findsNothing);
+  });
+}
+
+Widget _buildSliverList({
+  List<int> items: const <int>[],
+  ScrollController controller,
+  double itemHeight: 500.0,
+  double viewportHeight: 300.0,
+}) {
+  return new Directionality(
+    textDirection: TextDirection.ltr,
+    child: new Center(
+      child: new Container(
+        height: viewportHeight,
+        child: new CustomScrollView(
+          controller: controller,
+          slivers: <Widget>[
+            new SliverList(
+              delegate: new SliverChildBuilderDelegate(
+                    (BuildContext context, int i) {
+                  return new Container(
+                    key: new ValueKey<int>(items[i]),
+                    height: itemHeight,
+                    child: new Text('Tile ${items[i]}'),
+                  );
+                },
+                childCount: items.length,
+              ),
+            ),
+          ],
+        ),
+      ),
+    ),
+  );
 }


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/14590.

Here is what went wrong:

Imagine a SliverList with many children (all with a unique key) scrolled all the way to the end. Only a subset of those children will be shown on screen (let's say the last two), therefore only those two will have RenderObjects. We now replace the list of children with a list of same length where all children have different keys. Because the keys do not match, the framework will remove the existing two RenderObjects and will instantiate two new RenderObject for the last two children in the new list. Unfortunately, due to this swap we lose the `parentData` attached to the old RenderObjects, namely the `layoutOffset` indicating where this particular RenderObject is located in the SliverList. When the RenderSliverList now is asked to layout its RenderObject children it gets confused: It looks at its first RenderObject child [1] and sees in its `parentData` that the child is supposed to be located at offset 0.0 (WRONG, it should show something close to the current scroll offset here, but that information was lost). Since the scroll offset is very large (we are after all scrolled to the end), the RenderSliver list requests to layout more children after this one but pretty quickly runs out of children (because we are at the end) before being able to fill the viewport. Since there are no other slivers to fill the Viewport, the Viewport adjusts the scrollPosition to bring these RenderObjects back into view. That's why we see the strange scrolling animation observed in the bug, after which the scrollable is totally broken because of the incorrect `layoutOffset`s.

This PR attempts to save the `layoutOffset` before a RenderObject is being replaced and re-assigns it to the newly created RenderObject.

[1] https://github.com/flutter/flutter/blob/0a8713efe04b94cbedfd3e71a1c88552adb9fb54/packages/flutter/lib/src/rendering/sliver_list.dart#L94