### PR TITLE
use the --dart-sdk parameter to flutter analyze if passed in

### DIFF
--- a/packages/flutter_tools/lib/src/commands/analyze_continuously.dart
+++ b/packages/flutter_tools/lib/src/commands/analyze_continuously.dart
@@ -15,7 +15,7 @@ import '../base/process_manager.dart';
 import '../base/terminal.dart';
 import '../base/utils.dart';
 import '../cache.dart';
-import '../dart/sdk.dart';
+import '../dart/sdk.dart' as sdk;
 import '../globals.dart';
 import 'analyze_base.dart';
 
@@ -53,7 +53,9 @@ class AnalyzeContinuously extends AnalyzeBase {
       analysisTarget = fs.currentDirectory.path;
     }
 
-    final AnalysisServer server = new AnalysisServer(dartSdkPath, directories, previewDart2: previewDart2);
+    final String sdkPath = argResults['dart-sdk'] ?? sdk.dartSdkPath;
+
+    final AnalysisServer server = new AnalysisServer(sdkPath, directories, previewDart2: previewDart2);
     server.onAnalyzing.listen((bool isAnalyzing) => _handleAnalysisStatus(server, isAnalyzing));
     server.onErrors.listen(_handleAnalysisErrors);
 
@@ -151,9 +153,9 @@ class AnalyzeContinuously extends AnalyzeBase {
 }
 
 class AnalysisServer {
-  AnalysisServer(this.sdk, this.directories, { this.previewDart2: false });
+  AnalysisServer(this.sdkPath, this.directories, { this.previewDart2: false });
 
-  final String sdk;
+  final String sdkPath;
   final List<String> directories;
   final bool previewDart2;
 
@@ -164,12 +166,12 @@ class AnalysisServer {
   int _id = 0;
 
   Future<Null> start() async {
-    final String snapshot = fs.path.join(sdk, 'bin/snapshots/analysis_server.dart.snapshot');
+    final String snapshot = fs.path.join(sdkPath, 'bin/snapshots/analysis_server.dart.snapshot');
     final List<String> command = <String>[
-      fs.path.join(dartSdkPath, 'bin', 'dart'),
+      fs.path.join(sdkPath, 'bin', 'dart'),
       snapshot,
       '--sdk',
-      sdk,
+      sdkPath,
     ];
 
     if (previewDart2) {

--- a/packages/flutter_tools/lib/src/commands/analyze_once.dart
+++ b/packages/flutter_tools/lib/src/commands/analyze_once.dart
@@ -13,6 +13,7 @@ import '../base/process.dart';
 import '../base/utils.dart';
 import '../cache.dart';
 import '../dart/analysis.dart';
+import '../dart/sdk.dart' as sdk;
 import '../globals.dart';
 import 'analyze.dart';
 import 'analyze_base.dart';
@@ -93,7 +94,9 @@ class AnalyzeOnce extends AnalyzeBase {
         arguments.add('--no-preview-dart-2');
       }
 
-      final String dartanalyzer = fs.path.join(Cache.flutterRoot, 'bin', 'cache', 'dart-sdk', 'bin', 'dartanalyzer');
+      final String sdkPath = argResults['dart-sdk'] ?? sdk.dartSdkPath;
+
+      final String dartanalyzer = fs.path.join(sdkPath, 'bin', 'dartanalyzer');
       arguments.insert(0, dartanalyzer);
       bool noErrors = false;
       final Set<String> issues = new Set<String>();


### PR DESCRIPTION
We have an existing `--dart-sdk` cli param to `flutter analyze`; this PR ensure that we use it (for both `flutter analyze` and `flutter analyze --watch`. Among other things, this will let us better benchmark `flutter analyze --flutter-repo` on every dart sdk commit (let us swap out the dart sdk that's used to power flutter analyze).

(I'll need to port this change to my PR to refactor flutter analyze as well)

/cc @sortie