### PR TITLE
On simulators, don't pass file paths to the engine that don't exist.

### DIFF
--- a/packages/flutter_tools/lib/src/ios/simulators.dart
+++ b/packages/flutter_tools/lib/src/ios/simulators.dart
@@ -319,14 +319,6 @@ class IOSSimulator extends Device {
     // Prepare launch arguments.
     final List<String> args = <String>['--enable-dart-profiling'];
 
-    if (!prebuiltApplication) {
-      args.addAll(<String>[
-        '--flutter-assets-dir=${fs.path.absolute(getAssetBuildDirectory())}',
-        '--dart-main=${fs.path.absolute(mainPath)}${debuggingOptions.buildInfo.previewDart2?".dill":""}',
-        '--packages=${fs.path.absolute('.packages')}',
-      ]);
-    }
-
     if (debuggingOptions.debuggingEnabled) {
       if (debuggingOptions.buildInfo.isDebug)
         args.add('--enable-checked-mode');


### PR DESCRIPTION
The old engine used to ignore these arguments and look inside the inside its application bundle for launch assets. However, since the assets directory was also being specific, the new engine used that directory as its assets directory. This directory does not contain the requisite launch assets.

The application would run just fine within Xcode or just launching the application in the simulator director. Only tooling assisted launches were affected. This patch fixes such launches.