### PR TITLE
Do exponential backoff for all exceptions in VMService::defaultOpenChannel.

### DIFF
--- a/packages/flutter_tools/lib/src/vmservice.dart
+++ b/packages/flutter_tools/lib/src/vmservice.dart
@@ -53,7 +53,7 @@ Future<StreamChannel<String>> _defaultOpenChannel(Uri uri) async {
     attempts += 1;
     try {
       socket = await io.WebSocket.connect(uri.toString());
-    } on io.WebSocketException catch(e) {
+    } catch (e) {
       printTrace('Exception attempting to connect to observatory: $e');
       printTrace('This was attempt #$attempts. Will retry in $delay.');
       await new Future<Null>.delayed(delay);

--- a/packages/flutter_tools/test/vmservice_test.dart
+++ b/packages/flutter_tools/test/vmservice_test.dart
@@ -8,13 +8,16 @@ import 'package:flutter_tools/src/base/io.dart';
 import 'package:flutter_tools/src/base/port_scanner.dart';
 import 'package:flutter_tools/src/vmservice.dart';
 
+import 'src/common.dart';
+import 'src/context.dart';
+
 void main() {
   group('VMService', () {
-    test('fails connection eagerly in the connect() method', () async {
+    testUsingContext('fails connection eagerly in the connect() method', () async {
       final int port = await const HostPortScanner().findAvailablePort();
       expect(
         VMService.connect(Uri.parse('http://localhost:$port')),
-        throwsA(const isInstanceOf<SocketException>()),
+        throwsToolExit(),
       );
     });
   });

--- a/packages/flutter_tools/test/vmservice_test.dart
+++ b/packages/flutter_tools/test/vmservice_test.dart
@@ -4,7 +4,6 @@
 
 import 'package:test/test.dart';
 
-import 'package:flutter_tools/src/base/io.dart';
 import 'package:flutter_tools/src/base/port_scanner.dart';
 import 'package:flutter_tools/src/vmservice.dart';
 


### PR DESCRIPTION
We were trying to only catch WebSocketException, but in fact
SocketException can be thrown as well.