### PR TITLE
[await sync-async flag] Add test of sync async execution

### DIFF
--- a/packages/flutter/test/engine/dart_test.dart
+++ b/packages/flutter/test/engine/dart_test.dart
@@ -1,0 +1,26 @@
+// Copyright 2018 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:test/test.dart';
+
+/// Verifies Dart semantics governed by flags set by Flutter tooling.
+void main() {
+  group('Async', () {
+    String greeting = 'hello';
+    Future<void> changeGreeting() async {
+      greeting += ' 1';
+      await new Future<void>.value(null);
+      greeting += ' 2';
+    }
+    test('execution of async method starts synchronously', () async {
+      expect(greeting, 'hello');
+      final Future<void> future = changeGreeting();
+      expect(greeting, 'hello 1');
+      await future;
+      expect(greeting, 'hello 1 2');
+    });
+  });
+}

--- a/packages/flutter/test/widgets/async_test.dart
+++ b/packages/flutter/test/widgets/async_test.dart
@@ -17,7 +17,7 @@ void main() {
       greeting += ' 1';
       await new Future<void>.value(null);
       greeting += ' 2';
-    };
+    }
     test('execution of async method starts synchronously', () async {
       expect(greeting, 'hello');
       final Future<void> future = changeGreeting();

--- a/packages/flutter/test/widgets/async_test.dart
+++ b/packages/flutter/test/widgets/async_test.dart
@@ -11,6 +11,21 @@ void main() {
   Widget snapshotText(BuildContext context, AsyncSnapshot<String> snapshot) {
     return new Text(snapshot.toString(), textDirection: TextDirection.ltr);
   }
+  group('Dart semantics', () {
+    String greeting = 'hello';
+    Future<void> changeGreeting() async {
+      greeting += ' 1';
+      await null;
+      greeting += ' 2';
+    };
+    test('execution of async method starts synchronously', () async {
+      expect(greeting, 'hello');
+      Future<void> future = changeGreeting();
+      expect(greeting, 'hello 1');
+      await future;
+      expect(greeting, 'hello 1 2');
+    });
+  });
   group('AsyncSnapshot', () {
     test('requiring data succeeds if data is present', () {
       expect(

--- a/packages/flutter/test/widgets/async_test.dart
+++ b/packages/flutter/test/widgets/async_test.dart
@@ -11,21 +11,6 @@ void main() {
   Widget snapshotText(BuildContext context, AsyncSnapshot<String> snapshot) {
     return new Text(snapshot.toString(), textDirection: TextDirection.ltr);
   }
-  group('Dart semantics', () {
-    String greeting = 'hello';
-    Future<void> changeGreeting() async {
-      greeting += ' 1';
-      await new Future<void>.value(null);
-      greeting += ' 2';
-    }
-    test('execution of async method starts synchronously', () async {
-      expect(greeting, 'hello');
-      final Future<void> future = changeGreeting();
-      expect(greeting, 'hello 1');
-      await future;
-      expect(greeting, 'hello 1 2');
-    });
-  });
   group('AsyncSnapshot', () {
     test('requiring data succeeds if data is present', () {
       expect(

--- a/packages/flutter/test/widgets/async_test.dart
+++ b/packages/flutter/test/widgets/async_test.dart
@@ -15,12 +15,12 @@ void main() {
     String greeting = 'hello';
     Future<void> changeGreeting() async {
       greeting += ' 1';
-      await null;
+      await new Future<void>.value(null);
       greeting += ' 2';
     };
     test('execution of async method starts synchronously', () async {
       expect(greeting, 'hello');
-      Future<void> future = changeGreeting();
+      final Future<void> future = changeGreeting();
       expect(greeting, 'hello 1');
       await future;
       expect(greeting, 'hello 1 2');


### PR DESCRIPTION
Add a test of sync-async Dart semantics to the async widgets test suite. This may not be the ideal place for it, and I'd appreciate suggestions for a better place to put it.