### PR TITLE
Make flutter_driver work with sync-async

### DIFF
--- a/packages/flutter_driver/lib/src/extension/extension.dart
+++ b/packages/flutter_driver/lib/src/extension/extension.dart
@@ -206,6 +206,7 @@ class FlutterDriverExtension {
 
   /// Runs `finder` repeatedly until it finds one or more [Element]s.
   Future<Finder> _waitForElement(Finder finder) async {
+    await null; // TODO(mravn): This method depends on async execution.
     if (_frameSync)
       await _waitUntilFrame(() => SchedulerBinding.instance.transientCallbackCount == 0);
 

--- a/packages/flutter_driver/lib/src/extension/extension.dart
+++ b/packages/flutter_driver/lib/src/extension/extension.dart
@@ -206,7 +206,9 @@ class FlutterDriverExtension {
 
   /// Runs `finder` repeatedly until it finds one or more [Element]s.
   Future<Finder> _waitForElement(Finder finder) async {
-    await null; // TODO(mravn): This method depends on async execution.
+    // TODO(mravn): This method depends on async execution. A refactoring
+    // for sync-async semantics is tracked in https://github.com/flutter/flutter/issues/16801.
+    await new Future<void>.value(null);
     if (_frameSync)
       await _waitUntilFrame(() => SchedulerBinding.instance.transientCallbackCount == 0);
 


### PR DESCRIPTION
Ensure we don't execute finders too early with sync-async semantics.