### PR TITLE
retry iproxy command when unable to connect

### DIFF
--- a/packages/flutter_tools/lib/src/base/io.dart
+++ b/packages/flutter_tools/lib/src/base/io.dart
@@ -74,6 +74,7 @@ export 'dart:io'
         SYSTEM_ENCODING,
         WebSocket,
         WebSocketException,
+        WebSocketStatus,
         WebSocketTransformer;
 
 /// Exits the process with the given [exitCode].

--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 import 'dart:convert';
 
 import '../application_package.dart';
+import '../base/common.dart';
 import '../base/file_system.dart';
 import '../base/io.dart';
 import '../base/logger.dart';
@@ -486,16 +487,67 @@ class _IOSDevicePortForwarder extends DevicePortForwarder {
       hostPort = await portScanner.findAvailablePort();
     }
 
-    // Usage: iproxy LOCAL_TCP_PORT DEVICE_TCP_PORT UDID
-    final Process process = await runCommand(<String>[
-      device._iproxyPath,
-      hostPort.toString(),
-      devicePort.toString(),
-      device.id,
-    ]);
+    const int _kMaxAttempts = 5;
+    Duration delayBetweenIproxyAndConnection = const Duration(milliseconds: 100);
+    int attempts = 0;
+    ForwardedPort forwardedPort;
+    dynamic lastError;
+    while (attempts < _kMaxAttempts && forwardedPort == null) {
+      attempts += 1;
+      Process process;
+      try {
+        // Usage: iproxy LOCAL_TCP_PORT DEVICE_TCP_PORT UDID
+        process = await runCommand(<String>[
+          device._iproxyPath,
+          hostPort.toString(),
+          devicePort.toString(),
+          device.id,
+        ]);
 
-    final ForwardedPort forwardedPort = new ForwardedPort.withContext(hostPort,
-        devicePort, process);
+        // iproxy may not have established the connection yet, but also it does
+        // not produce a reliable machine-readable signal when it's established.
+        // This delay reduces the change that we will be attempting to connect
+        // prematurely.
+        await new Future<Null>.delayed(delayBetweenIproxyAndConnection);
+
+        // If at this point we are still unable to connect, we will try
+        // forwarding again, but this time we will give iproxy twice as much
+        // time as on the previous attempt.
+        delayBetweenIproxyAndConnection *= 2;
+
+        // Smoke-test the connection.
+        await (await WebSocket.connect('http://localhost:$hostPort')).close(
+          WebSocketStatus.NORMAL_CLOSURE,
+          'Connection smoke test successful'
+        );
+
+        // Connection is good.
+        forwardedPort = new ForwardedPort.withContext(hostPort,
+            devicePort, process);
+      } catch (e) {
+        lastError = e;
+        if (!processManager.killPid(process.pid)) {
+          printTrace(
+            'Process kill signal was not delivered to iproxy. Perhaps the '
+            'process was gone by the time we attempted to kill it.'
+          );
+        }
+        printTrace(
+          'Exception attempting to forward local port $hostPort to device-side '
+          'observatory port $devicePort: $e'
+        );
+        printTrace('This was attempt #$attempts.');
+      }
+    }
+
+    if (forwardedPort == null) {
+      throw new ToolExit(
+        'Failed to forward local port $hostPort to device-side Dart '
+        'observatory port $devicePort. Attempted to use '
+        '"${device._iproxyPath}" $_kMaxAttempts times, but all attempts '
+        'failed. Giving up. The latest error was: $lastError'
+      );
+    }
 
     printTrace('Forwarded port $forwardedPort');
 


### PR DESCRIPTION
Retry by restarting the `iproxy` command itself when unable to connect through the forwarded port. This also adds a smoke-test of the connection immediately after launching `iproxy`.

This is yet another attempt to fix the elusive https://github.com/flutter/flutter/issues/13655.

I didn't want to invest in unit-tests until we're sure that this works. If it does, I'll write tests in a follow-up PR. If it doesn't, I'll just roll it back.