### PR TITLE
Reorder the asyncBarrier call to account for the new sync-async semantics

### DIFF
--- a/packages/flutter_test/lib/src/binding.dart
+++ b/packages/flutter_test/lib/src/binding.dart
@@ -461,9 +461,9 @@ abstract class TestWidgetsFlutterBinding extends BindingBase
     );
     _parentZone = Zone.current;
     final Zone testZone = _parentZone.fork(specification: errorHandlingZoneSpecification);
+    asyncBarrier(); // When using AutomatedTestWidgetsFlutterBinding, this flushes the microtasks.
     testZone.runBinary(_runTestBody, testBody, invariantTester)
       .whenComplete(_testCompletionHandler);
-    asyncBarrier(); // When using AutomatedTestWidgetsFlutterBinding, this flushes the microtasks.
     return _currentTestCompleter.future;
   }
 


### PR DESCRIPTION
Reorder the asyncBarrier call to account for the new sync-async semantics,
Should fix the assertion - 
[  +21 ms] I/FlutterActivityDelegate(26029): onResume setting current activity to this
stdout: [  +82 ms] E/flutter (26029): [ERROR:topaz/lib/tonic/logging/dart_error.cc(16)] Unhandled exception:
stdout: [        ] E/flutter (26029): Asynchronous call to guarded function leaked. You must use "await" with all Future-returning test APIs.
stdout: [        ] E/flutter (26029): The guarded method "pump" from class LiveTestWidgetsFlutterBinding was called from package:flutter_test/src/binding.dart on line 474, but never completed before its parent scope closed.
stdout: [        ] E/flutter (26029): #0      TestAsyncUtils.verifyAllScopesClosed (package:flutter_test/src/test_async_utils.dart:281)
stdout: [        ] E/flutter (26029): #1      TestWidgetsFlutterBinding.asyncBarrier (package:flutter_test/src/binding.dart:317)
stdout: [        ] E/flutter (26029): #2      TestWidgetsFlutterBinding._runTest (package:flutter_test/src/binding.dart:466)
stdout: [        ] E/flutter (26029): #3      LiveTestWidgetsFlutterBinding.runTest (package:flutter_test/src/binding.dart:958)
stdout: [        ] E/flutter (26029): #4      _AsyncAwaitCompleter.start (dart:async/runtime/libasync_patch.dart:49)
stdout: [        ] E/flutter (26029): #5      LiveTestWidgetsFlutterBinding.runTest (package:flutter_test/src/binding.dart:953)
stdout: [        ] E/flutter (26029): #6      benchmarkWidgets (package:flutter_test/src/widget_tester.dart:127)
stdout: [        ] E/flutter (26029): #7      main (file:///Users/fortuna/.cocoon/flutter/dev/benchmarks/microbenchmarks/lib/stocks/layout_bench.dart:28)
stdout: [        ] E/flutter (26029): #8      _AsyncAwaitCompleter.start (dart:async/runtime/libasync_patch.dart:49)
stdout: [        ] E/flutter (26029): #9      main (file:///Users/fortuna/.cocoon/flutter/dev/benchmarks/microbenchmarks/lib/stocks/layout_bench.dart:18)
stdout: [        ] E/flutter (26029): #10     _startIsolate. (dart:isolate/runtime/libisolate_patch.dart:279)
stdout: [        ] E/flutter (26029): #11     _RawReceivePortImpl._handleMessage (dart:isolate/runtime/libisolate_pat