### PR TITLE
bump benchmark timeouts

### DIFF
--- a/dev/devicelab/lib/tasks/microbenchmarks.dart
+++ b/dev/devicelab/lib/tasks/microbenchmarks.dart
@@ -14,7 +14,7 @@ import 'package:flutter_devicelab/framework/ios.dart';
 import 'package:flutter_devicelab/framework/utils.dart';
 
 /// The maximum amount of time a single microbenchmark is allowed to take.
-const Duration _kBenchmarkTimeout = const Duration(minutes: 6);
+const Duration _kBenchmarkTimeout = const Duration(minutes: 10);
 
 /// Creates a device lab task that runs benchmarks in
 /// `dev/benchmarks/microbenchmarks` reports results to the dashboard.

--- a/dev/devicelab/manifest.yaml
+++ b/dev/devicelab/manifest.yaml
@@ -332,6 +332,7 @@ tasks:
       Runs end-to-end Flutter tests on iOS.
     stage: devicelab_ios
     required_agent_capabilities: ["mac/ios"]
+    timeout_in_minutes: 20
 
   ios_sample_catalog_generator:
     description: >


### PR DESCRIPTION
After the recent engine and Dart updates the benchmarks started to time out. This speculatively attempts to fix the issue by bumping the timeouts.

If this fixes the issue we might want to look into why our build times regressed. If it doesn't perhaps the issue is that the processes are stuck rather than take longer.