### PR TITLE
Check for null isolate name during fuchsia hot reload

### DIFF
--- a/packages/flutter_tools/lib/src/commands/fuchsia_reload.dart
+++ b/packages/flutter_tools/lib/src/commands/fuchsia_reload.dart
@@ -186,6 +186,8 @@ class FuchsiaReloadCommand extends FlutterCommand {
       if (v.uiIsolate == null)
         continue;
       final Uri addr = v.owner.vmService.httpAddress;
+      if (v.uiIsolate == null)
+        continue;
       printTrace('At $addr, found view: ${v.uiIsolate.name}');
       if (v.uiIsolate.name.contains(viewFilter))
         result.add(addr.port);


### PR DESCRIPTION
Apparently isolate names on Fuchsia can be null (I got a crash). This change allows hot reload on Fuchsia to skip isolates with null names when searching for a particular isolate to hot reload.