### PR TITLE
Notify test timeouts differently than test completions.

### DIFF
--- a/packages/flutter_tools/lib/src/test/coverage_collector.dart
+++ b/packages/flutter_tools/lib/src/test/coverage_collector.dart
@@ -18,7 +18,7 @@ class CoverageCollector extends TestWatcher {
   Map<String, dynamic> _globalHitmap;
 
   @override
-  Future<Null> onFinishedTests(ProcessEvent event) async {
+  Future<void> onFinishedTest(ProcessEvent event) async {
     printTrace('test ${event.childIndex}: collecting coverage');
     await collectCoverage(event.process, event.observatoryUri);
   }

--- a/packages/flutter_tools/lib/src/test/flutter_platform.dart
+++ b/packages/flutter_tools/lib/src/test/flutter_platform.dart
@@ -506,8 +506,10 @@ class _FlutterPlatform extends PlatformPlugin {
             await watcher.onTestTimedOut(new ProcessEvent(ourTestCount, process));
             break;
           case _InitialResult.connected:
-            await watcher.onFinishedTest(
-                new ProcessEvent(ourTestCount, process, processObservatoryUri));
+            if (subprocessActive) {
+              await watcher.onFinishedTest(
+                  new ProcessEvent(ourTestCount, process, processObservatoryUri));
+            }
             break;
         }
       }

--- a/packages/flutter_tools/lib/src/test/flutter_platform.dart
+++ b/packages/flutter_tools/lib/src/test/flutter_platform.dart
@@ -497,9 +497,19 @@ class _FlutterPlatform extends PlatformPlugin {
           break;
       }
 
-      if (subprocessActive && watcher != null) {
-        await watcher.onFinishedTests(
-            new ProcessEvent(ourTestCount, process, processObservatoryUri));
+      if (watcher != null) {
+        switch (initialResult) {
+          case _InitialResult.crashed:
+            await watcher.onTestCrashed(new ProcessEvent(ourTestCount, process));
+            break;
+          case _InitialResult.timedOut:
+            await watcher.onTestTimedOut(new ProcessEvent(ourTestCount, process));
+            break;
+          case _InitialResult.connected:
+            await watcher.onFinishedTest(
+                new ProcessEvent(ourTestCount, process, processObservatoryUri));
+            break;
+        }
       }
     } catch (error, stack) {
       printTrace('test $ourTestCount: error caught during test; ${controllerSinkClosed ? "reporting to console" : "sending to test framework"}');

--- a/packages/flutter_tools/lib/src/test/watcher.dart
+++ b/packages/flutter_tools/lib/src/test/watcher.dart
@@ -6,7 +6,7 @@ import 'dart:async';
 import '../base/io.dart' show Process;
 
 /// Callbacks for reporting progress while running tests.
-class TestWatcher {
+abstract class TestWatcher {
   /// Called after a child process starts.
   ///
   /// If startPaused was true, the caller needs to resume in Observatory to
@@ -17,12 +17,19 @@ class TestWatcher {
   ///
   /// The child process won't exit until this method completes.
   /// Not called if the process died.
-  Future<Null> onFinishedTests(ProcessEvent event) async {}
+  Future<void> onFinishedTest(ProcessEvent event) async {}
+
+  /// Called when the test process crashed before connecting to test harness.
+  Future<void> onTestCrashed(ProcessEvent event) async {}
+
+  /// Called if we timed out waiting for the test process to connect to test
+  /// harness.
+  Future<void> onTestTimedOut(ProcessEvent event) async {}
 }
 
 /// Describes a child process started during testing.
 class ProcessEvent {
-  ProcessEvent(this.childIndex, this.process, this.observatoryUri);
+  ProcessEvent(this.childIndex, this.process, [this.observatoryUri]);
 
   /// The index assigned when the child process was launched.
   ///


### PR DESCRIPTION
This avoids notifying the coverage collector that we
completed the test when in fact we timed out, which in
turn avoids a downstream exception caused by the fact
that coverage collector assumes it has a valid observatory
port by which it can gather coverage data.

Fixes https://github.com/flutter/flutter/issues/16839