### PR TITLE
Fix error with 'flutter packages get' in package projects

### DIFF
--- a/packages/flutter_tools/lib/src/ios/xcodeproj.dart
+++ b/packages/flutter_tools/lib/src/ios/xcodeproj.dart
@@ -28,17 +28,19 @@ String _generatedXcodePropertiesPath(String projectPath) {
   return fs.path.join(projectPath, 'ios', 'Flutter', 'Generated.xcconfig');
 }
 
-/// Writes default Xcode properties files in the Flutter project at
-/// [projectPath], if such files do not already exist.
+/// Writes default Xcode properties files in the Flutter project at [projectPath],
+/// if project is an iOS project and such files do not already exist.
 void generateXcodeProperties(String projectPath) {
-  if (fs.file(_generatedXcodePropertiesPath(projectPath)).existsSync())
-    return;
-  updateGeneratedXcodeProperties(
+  if (fs.isDirectorySync(fs.path.join(projectPath, 'ios'))) {
+    if (fs.file(_generatedXcodePropertiesPath(projectPath)).existsSync())
+      return;
+    updateGeneratedXcodeProperties(
       projectPath: projectPath,
       buildInfo: BuildInfo.debug,
       target: bundle.defaultMainPath,
       previewDart2: false,
-  );
+    );
+  }
 }
 
 /// Writes or rewrites Xcode property files with the specified information.

--- a/packages/flutter_tools/lib/src/plugins.dart
+++ b/packages/flutter_tools/lib/src/plugins.dart
@@ -231,12 +231,9 @@ class InjectPluginsResult{
 /// Injects plugins found in `pubspec.yaml` into the platform-specific projects.
 void injectPlugins({String directory}) {
   directory ??= fs.currentDirectory.path;
-  if (fs.file(fs.path.join(directory, 'example', 'pubspec.yaml')).existsSync()) {
-    // Switch to example app if in plugin project template.
-    directory = fs.path.join(directory, 'example');
-  }
   final List<Plugin> plugins = _findPlugins(directory);
   final bool changed = _writeFlutterPluginsList(directory, plugins);
+
   if (fs.isDirectorySync(fs.path.join(directory, 'android')))
     _writeAndroidPluginRegistrant(directory, plugins);
   if (fs.isDirectorySync(fs.path.join(directory, 'ios'))) {

--- a/packages/flutter_tools/lib/src/project.dart
+++ b/packages/flutter_tools/lib/src/project.dart
@@ -47,16 +47,16 @@ class FlutterProject {
   /// The Android sub project of this project.
   AndroidProject get android => new AndroidProject(directory.childDirectory('android'));
 
-  /// Returns true if this project is a plugin project.
-  bool get isPluginProject => directory.childDirectory('example').childFile('pubspec.yaml').existsSync();
+  /// Returns true if this project has an example application
+  bool get hasExampleApp => directory.childDirectory('example').childFile('pubspec.yaml').existsSync();
 
-  /// The example sub project of this (plugin) project.
+  /// The example sub project of this (package or plugin) project.
   FlutterProject get example => new FlutterProject(directory.childDirectory('example'));
 
   /// Generates project files necessary to make Gradle builds work on Android
-  /// and CocoaPods+Xcode work on iOS.
+  /// and CocoaPods+Xcode work on iOS, for app projects only
   void ensureReadyForPlatformSpecificTooling() {
-    if (!directory.existsSync() || isPluginProject) {
+    if (!directory.existsSync() || hasExampleApp) {
       return;
     }
     injectPlugins(directory: directory.path);

--- a/packages/flutter_tools/test/project_test.dart
+++ b/packages/flutter_tools/test/project_test.dart
@@ -23,11 +23,11 @@ void main() {
         project.ensureReadyForPlatformSpecificTooling();
         expect(project.directory.existsSync(), isFalse);
       });
-      testInMemory('does nothing in plugin root project', () async {
+      testInMemory('does nothing in plugin or package root project', () async {
         final FlutterProject project = aPluginProject();
         project.ensureReadyForPlatformSpecificTooling();
-        expect(project.example.ios.directory.childFile('Runner/GeneratedPluginRegistrant.h').existsSync(), isFalse);
-        expect(project.example.ios.directory.childFile('Flutter/Generated.xcconfig').existsSync(), isFalse);
+        expect(project.ios.directory.childFile('Runner/GeneratedPluginRegistrant.h').existsSync(), isFalse);
+        expect(project.ios.directory.childFile('Flutter/Generated.xcconfig').existsSync(), isFalse);
       });
       testInMemory('injects plugins', () async {
         final FlutterProject project = aProjectWithIos();


### PR DESCRIPTION
Package projects are erroneously being treated as (iOS) apps due to previous changes to the `flutter packages` command.

Due to a combination of factors [explained here](https://github.com/flutter/flutter/issues/16362#issuecomment-383377657), packages with plugin dependencies are the only affected projects - which is probably why it has flown a bit under the radar.

Fixes #16362