### PR TITLE
Fix hue to 0.0 when red == green == blue.

### DIFF
--- a/packages/flutter/lib/src/painting/colors.dart
+++ b/packages/flutter/lib/src/painting/colors.dart
@@ -49,7 +49,9 @@ class HSVColor {
     } else if (max == blue) {
       hue = 60.0 * (((red - green) / delta) + 4);
     }
-
+    
+    /// fix hue to 0.0 when red == green == blue.
+    hue = hue.isNaN ? 0.0 : hue;
     final double saturation = max == 0.0 ? 0.0 : delta / max;
 
     return new HSVColor.fromAHSV(alpha, hue, saturation, max);

--- a/packages/flutter/test/painting/colors_test.dart
+++ b/packages/flutter/test/painting/colors_test.dart
@@ -32,11 +32,13 @@ void main() {
     final HSVColor red = new HSVColor.fromColor(const Color.fromARGB(0xFF, 0xFF, 0x00, 0x00));
     final HSVColor green = new HSVColor.fromColor(const Color.fromARGB(0xFF, 0x00, 0xFF, 0x00));
     final HSVColor blue = new HSVColor.fromColor(const Color.fromARGB(0xFF, 0x00, 0x00, 0xFF));
+    final HSVColor grey = new HSVColor.fromColor(const Color.fromARGB(0xFF, 0x80, 0x80, 0x80));
 
     expect(black.toColor(), equals(const Color.fromARGB(0xFF, 0x00, 0x00, 0x00)));
     expect(red.toColor(), equals(const Color.fromARGB(0xFF, 0xFF, 0x00, 0x00)));
     expect(green.toColor(), equals(const Color.fromARGB(0xFF, 0x00, 0xFF, 0x00)));
     expect(blue.toColor(), equals(const Color.fromARGB(0xFF, 0x00, 0x00, 0xFF)));
+    expect(grey.toColor(), equals(const Color.fromARGB(0xFF, 0x80, 0x80, 0x80)));
   });
 
   test('ColorSwatch test', () {


### PR DESCRIPTION
When passing a Color object with same R/G/B code ( e.g. [new Color.fromRGBO(100, 100, 100, 1.0)] ) to HSVColor.fromColor(Color color) , the hue in return will be NaN .
![_ _20180423130957](https://user-images.githubusercontent.com/19624835/39108777-88eca1d4-46fc-11e8-8692-c7d57e92f109.png)
