### PR TITLE
Assert that required dialog context args are non-null

### DIFF
--- a/packages/flutter/lib/src/material/about.dart
+++ b/packages/flutter/lib/src/material/about.dart
@@ -151,6 +151,7 @@ void showAboutDialog({
   String applicationLegalese,
   List<Widget> children,
 }) {
+  assert(context != null);
   showDialog<void>(
     context: context,
     builder: (BuildContext context) {
@@ -185,6 +186,7 @@ void showLicensePage({
   Widget applicationIcon,
   String applicationLegalese
 }) {
+  assert(context != null);
   Navigator.push(context, new MaterialPageRoute<void>(
     builder: (BuildContext context) => new LicensePage(
       applicationName: applicationName,


### PR DESCRIPTION
Otherwise, if you pass `context: null`, you'll get an inscrutable error like:
```
I/flutter (17260): The following NoSuchMethodError was thrown while handling a gesture:
I/flutter (17260): The method 'rootAncestorStateOfType' was called on null.
I/flutter (17260): Receiver: null
```
