### PR TITLE
InputDecorator input and hint widgets should have the same width

### DIFF
--- a/packages/flutter/lib/src/material/input_decorator.dart
+++ b/packages/flutter/lib/src/material/input_decorator.dart
@@ -771,11 +771,11 @@ class _RenderDecoration extends RenderBox {
       + contentPadding.right);
 
     boxConstraints = boxConstraints.copyWith(maxWidth: inputWidth);
-    layoutLineBox(hint);
     if (label != null) // The label is not baseline aligned.
       label.layout(boxConstraints, parentUsesSize: true);
 
     boxConstraints = boxConstraints.copyWith(minWidth: inputWidth);
+    layoutLineBox(hint);
     layoutLineBox(input);
 
     double inputBaseline = contentPadding.top + aboveBaseline;

--- a/packages/flutter/test/material/input_decorator_test.dart
+++ b/packages/flutter/test/material/input_decorator_test.dart
@@ -259,6 +259,8 @@ void main() {
     expect(tester.getBottomLeft(find.text('hint')).dy, 28.0);
     expect(getBorderBottom(tester), 40.0);
     expect(getBorderWeight(tester), 1.0);
+
+    expect(tester.getSize(find.text('hint')).width, tester.getSize(find.text('text')).width);
   });
 
   testWidgets('InputDecorator input/label/hint layout', (WidgetTester tester) async {


### PR DESCRIPTION
InputDecorator now gives the hint and input fields the same width so that they will react the same way to the `textAlign` parameter.

Fixes https://github.com/flutter/flutter/issues/16784
Fixes https://github.com/flutter/flutter/issues/16769
Fixes https://github.com/flutter/flutter/issues/16366
Fixes https://github.com/flutter/flutter/issues/15079
