### PR TITLE
Fix boolean flag parsing in gradle. Track 'trackWidgetCreation' as build property.

### DIFF
--- a/packages/flutter_tools/gradle/flutter.gradle
+++ b/packages/flutter_tools/gradle/flutter.gradle
@@ -258,7 +258,7 @@ class FlutterPlugin implements Plugin<Project> {
 
         Boolean previewDart2Value = false
         if (project.hasProperty('preview-dart-2')) {
-            previewDart2Value = project.property('preview-dart-2')
+            previewDart2Value = project.property('preview-dart-2').toBoolean()
         }
         String[] fileSystemRootsValue = null
         if (project.hasProperty('filesystem-roots')) {
@@ -270,8 +270,9 @@ class FlutterPlugin implements Plugin<Project> {
         }
         Boolean trackWidgetCreationValue = false
         if (project.hasProperty('track-widget-creation')) {
-            trackWidgetCreationValue = project.property('track-widget-creation')
+            trackWidgetCreationValue = project.property('track-widget-creation').toBoolean()
         }
+
         String extraFrontEndOptionsValue = null
         if (project.hasProperty('extra-front-end-options')) {
             extraFrontEndOptionsValue = project.property('extra-front-end-options')
@@ -282,7 +283,7 @@ class FlutterPlugin implements Plugin<Project> {
         }
         Boolean preferSharedLibraryValue = false
         if (project.hasProperty('prefer-shared-library')) {
-            preferSharedLibraryValue = project.property('prefer-shared-library')
+            preferSharedLibraryValue = project.property('prefer-shared-library').toBoolean()
         }
         String targetPlatformValue = null
         if (project.hasProperty('target-platform')) {

--- a/packages/flutter_tools/lib/src/bundle.dart
+++ b/packages/flutter_tools/lib/src/bundle.dart
@@ -85,6 +85,7 @@ Future<void> build({
         ..add(mainPath);
       final Map<String, String> properties = <String, String>{
         'entryPoint': mainPath,
+        'trackWidgetCreation': trackWidgetCreation.toString(),
       };
       return new Fingerprint.fromBuildInputs(properties, compilerInputPaths);
     }


### PR DESCRIPTION
This allows passing `-Ptrack-widget-creation=false` to gradle which until this fix was interpreted as `track-widget-creation` set to `true`.
Tracking `trackWidgetCreation` as property ensures that its value is taken into account when calculating build fingerprint, changing it will force rebuild.

This goes towards fixing https://github.com/flutter/flutter/issues/16766.