### PR TITLE
Put the backdrop demo controls on the right

### DIFF
--- a/examples/flutter_gallery/lib/demo/material/backdrop_demo.dart
+++ b/examples/flutter_gallery/lib/demo/material/backdrop_demo.dart
@@ -386,11 +386,11 @@ class _BackdropDemoState extends State<BackdropDemo> with SingleTickerProviderSt
         ),
         actions: <Widget>[
           new IconButton(
-          onPressed: _toggleBackdropPanelVisibility,
-          icon: new AnimatedIcon(
-            icon: AnimatedIcons.close_menu,
-            progress: _controller.view,
-          ),
+            onPressed: _toggleBackdropPanelVisibility,
+            icon: new AnimatedIcon(
+              icon: AnimatedIcons.close_menu,
+              progress: _controller.view,
+            ),
           ),
         ],
       ),

--- a/examples/flutter_gallery/lib/demo/material/backdrop_demo.dart
+++ b/examples/flutter_gallery/lib/demo/material/backdrop_demo.dart
@@ -342,14 +342,7 @@ class _BackdropDemoState extends State<BackdropDemo> with SingleTickerProviderSt
           },
         ),
       );
-    }).toList()
-    ..add(const SizedBox(height: 8.0))
-    ..add(
-      new Align(
-        alignment: AlignmentDirectional.centerStart,
-        child: new BackButton(color: Colors.white.withOpacity(0.5))
-      ),
-    );
+    }).toList();
 
     return new Container(
       key: _backdropKey,
@@ -388,16 +381,18 @@ class _BackdropDemoState extends State<BackdropDemo> with SingleTickerProviderSt
     return new Scaffold(
       appBar: new AppBar(
         elevation: 0.0,
-        leading: new IconButton(
+        title: new BackdropTitle(
+          listenable: _controller.view,
+        ),
+        actions: <Widget>[
+          new IconButton(
           onPressed: _toggleBackdropPanelVisibility,
           icon: new AnimatedIcon(
             icon: AnimatedIcons.close_menu,
             progress: _controller.view,
           ),
-        ),
-        title: new BackdropTitle(
-          listenable: _controller.view,
-        ),
+          ),
+        ],
       ),
       body: new LayoutBuilder(
         builder: _buildStack,

--- a/examples/flutter_gallery/test/live_smoketest.dart
+++ b/examples/flutter_gallery/test/live_smoketest.dart
@@ -30,7 +30,6 @@ const List<String> _kUnsynchronizedDemos = const <String>[
 // These demos can't be backed out of by tapping a button whose
 // tooltip is 'Back'.
 const List<String> _kSkippedDemos = const <String>[
-  'Backdrop',
   'Pull to refresh',
 ];
 

--- a/examples/flutter_gallery/test/smoke_test.dart
+++ b/examples/flutter_gallery/test/smoke_test.dart
@@ -102,12 +102,6 @@ Future<Null> smokeDemo(WidgetTester tester, String routeName) async {
   await tester.pump();
   await tester.pump(const Duration(milliseconds: 400));
 
-  // This demo's back button isn't initially visible.
-  if (routeName == '/material/backdrop') {
-    await tester.tap(find.byTooltip('Tap to dismiss'));
-    await tester.pumpAndSettle();
-  }
-
   // Go back
   await tester.pageBack();
   await tester.pumpAndSettle();


### PR DESCRIPTION
By putting it on the right, the back button appears where everyone (include our tests) expect it.