### PR TITLE
Allow customization of TextSpan in EditableText

### DIFF
--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -675,8 +675,8 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
             onPaste: _hasFocus && controls?.canPaste(this) == true ? () => controls.handlePaste(this) : null,
             child: new _Editable(
               key: _editableKey,
+              textSpan: buildTextSpan(),
               value: _value,
-              style: widget.style,
               cursorColor: widget.cursorColor,
               showCursor: _showCursor,
               hasFocus: _hasFocus,
@@ -686,7 +686,6 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
               textAlign: widget.textAlign,
               textDirection: _textDirection,
               obscureText: widget.obscureText,
-              obscureShowCharacterAtIndex: _obscureShowCharTicksPending > 0 ? _obscureLatestCharIndex : null,
               autocorrect: widget.autocorrect,
               offset: offset,
               onSelectionChanged: _handleSelectionChanged,
@@ -698,13 +697,44 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
       },
     );
   }
+
+  /// Builds [TextSpan] from current editing value.
+  ///
+  /// By default makes text in composing range appear as underlined.
+  /// Descendants can override this method to customize appearance of text.
+  TextSpan buildTextSpan() {
+    final int obscureShowCharacterAtIndex =
+        _obscureShowCharTicksPending > 0 ? _obscureLatestCharIndex : null;
+
+    if (!widget.obscureText && _value.composing.isValid) {
+      final TextStyle composingStyle = widget.style
+          .merge(const TextStyle(decoration: TextDecoration.underline));
+
+      return new TextSpan(style: widget.style, children: <TextSpan>[
+        new TextSpan(text: _value.composing.textBefore(_value.text)),
+        new TextSpan(
+            style: composingStyle,
+            text: _value.composing.textInside(_value.text)),
+        new TextSpan(text: _value.composing.textAfter(_value.text))
+      ]);
+    }
+
+    String text = _value.text;
+    if (widget.obscureText) {
+      text = RenderEditable.obscuringCharacter * text.length;
+      final int o = obscureShowCharacterAtIndex;
+      if (o != null && o >= 0 && o < text.length)
+        text = text.replaceRange(o, o + 1, _value.text.substring(o, o + 1));
+    }
+    return new TextSpan(style: widget.style, text: text);
+  }
 }
 
 class _Editable extends LeafRenderObjectWidget {
   const _Editable({
     Key key,
+    this.textSpan,
     this.value,
-    this.style,
     this.cursorColor,
     this.showCursor,
     this.hasFocus,
@@ -714,7 +744,6 @@ class _Editable extends LeafRenderObjectWidget {
     this.textAlign,
     @required this.textDirection,
     this.obscureText,
-    this.obscureShowCharacterAtIndex,
     this.autocorrect,
     this.offset,
     this.onSelectionChanged,
@@ -724,8 +753,8 @@ class _Editable extends LeafRenderObjectWidget {
        assert(rendererIgnoresPointer != null),
        super(key: key);
 
+  final TextSpan textSpan;
   final TextEditingValue value;
-  final TextStyle style;
   final Color cursorColor;
   final ValueNotifier<bool> showCursor;
   final bool hasFocus;
@@ -735,7 +764,6 @@ class _Editable extends LeafRenderObjectWidget {
   final TextAlign textAlign;
   final TextDirection textDirection;
   final bool obscureText;
-  final int obscureShowCharacterAtIndex;
   final bool autocorrect;
   final ViewportOffset offset;
   final SelectionChangedHandler onSelectionChanged;
@@ -745,7 +773,7 @@ class _Editable extends LeafRenderObjectWidget {
   @override
   RenderEditable createRenderObject(BuildContext context) {
     return new RenderEditable(
-      text: _styledTextSpan,
+      text: textSpan,
       cursorColor: cursorColor,
       showCursor: showCursor,
       hasFocus: hasFocus,
@@ -766,7 +794,7 @@ class _Editable extends LeafRenderObjectWidget {
   @override
   void updateRenderObject(BuildContext context, RenderEditable renderObject) {
     renderObject
-      ..text = _styledTextSpan
+      ..text = textSpan
       ..cursorColor = cursorColor
       ..showCursor = showCursor
       ..hasFocus = hasFocus
@@ -781,33 +809,5 @@ class _Editable extends LeafRenderObjectWidget {
       ..onCaretChanged = onCaretChanged
       ..ignorePointer = rendererIgnoresPointer
       ..obscureText = obscureText;
-  }
-
-  TextSpan get _styledTextSpan {
-    if (!obscureText && value.composing.isValid) {
-      final TextStyle composingStyle = style.merge(
-        const TextStyle(decoration: TextDecoration.underline)
-      );
-
-      return new TextSpan(
-        style: style,
-        children: <TextSpan>[
-          new TextSpan(text: value.composing.textBefore(value.text)),
-          new TextSpan(
-            style: composingStyle,
-            text: value.composing.textInside(value.text)
-          ),
-          new TextSpan(text: value.composing.textAfter(value.text))
-      ]);
-    }
-
-    String text = value.text;
-    if (obscureText) {
-      text = RenderEditable.obscuringCharacter * text.length;
-      final int o = obscureShowCharacterAtIndex;
-      if (o != null && o >= 0 && o < text.length)
-        text = text.replaceRange(o, o + 1, value.text.substring(o, o + 1));
-    }
-    return new TextSpan(style: style, text: text);
   }
 }

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -703,12 +703,10 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
   /// By default makes text in composing range appear as underlined.
   /// Descendants can override this method to customize appearance of text.
   TextSpan buildTextSpan() {
-    final int obscureShowCharacterAtIndex =
-        _obscureShowCharTicksPending > 0 ? _obscureLatestCharIndex : null;
-
     if (!widget.obscureText && _value.composing.isValid) {
-      final TextStyle composingStyle = widget.style
-          .merge(const TextStyle(decoration: TextDecoration.underline));
+      final TextStyle composingStyle = widget.style.merge(
+        const TextStyle(decoration: TextDecoration.underline),
+      );
 
       return new TextSpan(style: widget.style, children: <TextSpan>[
         new TextSpan(text: _value.composing.textBefore(_value.text)),
@@ -722,7 +720,8 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
     String text = _value.text;
     if (widget.obscureText) {
       text = RenderEditable.obscuringCharacter * text.length;
-      final int o = obscureShowCharacterAtIndex;
+      final int o =
+        _obscureShowCharTicksPending > 0 ? _obscureLatestCharIndex : null;
       if (o != null && o >= 0 && o < text.length)
         text = text.replaceRange(o, o + 1, _value.text.substring(o, o + 1));
     }

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -708,12 +708,15 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
         const TextStyle(decoration: TextDecoration.underline),
       );
 
-      return new TextSpan(style: widget.style, children: <TextSpan>[
-        new TextSpan(text: _value.composing.textBefore(_value.text)),
-        new TextSpan(
+      return new TextSpan(
+        style: widget.style,
+        children: <TextSpan>[
+          new TextSpan(text: _value.composing.textBefore(_value.text)),
+          new TextSpan(
             style: composingStyle,
-            text: _value.composing.textInside(_value.text)),
-        new TextSpan(text: _value.composing.textAfter(_value.text))
+            text: _value.composing.textInside(_value.text),
+          ),
+          new TextSpan(text: _value.composing.textAfter(_value.text)),
       ]);
     }
 

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -757,6 +757,50 @@ void main() {
     });
   });
 
+  testWidgets('allows customizing text style in subclasses', (WidgetTester tester) async {
+    controller.text = 'Hello World';
+
+    await tester.pumpWidget(new MaterialApp(
+      home: new CustomStyleEditableText(
+        controller: controller,
+        focusNode: focusNode,
+        style: textStyle,
+        cursorColor: cursorColor,
+      ),
+    ));
+
+    // Simulate selection change via tap to show handles.
+    final RenderEditable render = tester.allRenderObjects.firstWhere((RenderObject o) => o.runtimeType == RenderEditable);
+    expect(render.text.style.fontStyle, FontStyle.italic);
+  });
+
 }
 
 class MockTextSelectionControls extends Mock implements TextSelectionControls {}
+
+class CustomStyleEditableText extends EditableText {
+  CustomStyleEditableText({
+    TextEditingController controller,
+    Color cursorColor,
+    FocusNode focusNode,
+    TextStyle style,
+  }): super(
+      controller:controller,
+      cursorColor: cursorColor,
+      focusNode: focusNode,
+      style: style,
+  );
+  @override
+  CustomStyleEditableTextState createState() =>
+      new CustomStyleEditableTextState();
+}
+
+class CustomStyleEditableTextState extends EditableTextState {
+  @override
+  TextSpan buildTextSpan() {
+    return new TextSpan(
+        style: const TextStyle(fontStyle: FontStyle.italic),
+        text: widget.controller.value.text,
+    );
+  }
+}


### PR DESCRIPTION
This would allow to create a descendant with customized appearance.

Example use case: detecting dates in input text, like in recording below. Currently I have a very dirty workaround which tries to paint differently styled text underneath text input. This is not working very well obviously (see below recording).

![kapture 2018-04-23 at 17 02 24](https://user-images.githubusercontent.com/441756/39159021-2c9b3fdc-4718-11e8-85fa-d05447a6aa0d.gif)
