### PR TITLE
Inline buildScriptSnapshot calls

### DIFF
--- a/packages/flutter_tools/test/base/build_test.dart
+++ b/packages/flutter_tools/test/base/build_test.dart
@@ -374,15 +374,6 @@ void main() {
       }));
     }
 
-    Future<Null> buildScriptSnapshot({ String mainPath = 'main.dart' }) {
-      return snapshotter.buildScriptSnapshot(
-        mainPath: mainPath,
-        snapshotPath: 'output.snapshot',
-        depfilePath: 'output.snapshot.d',
-        packagesPath: '.packages',
-      );
-    }
-
     void expectFingerprintHas({
       String entryPoint: 'main.dart',
       Map<String, String> checksums = const <String, String>{},
@@ -401,7 +392,12 @@ void main() {
       await fs.file('main.dart').writeAsString('void main() {}');
       await fs.file('output.snapshot').create();
       await fs.file('output.snapshot.d').writeAsString('snapshot : main.dart');
-      await buildScriptSnapshot();
+      await snapshotter.buildScriptSnapshot(
+        mainPath: 'main.dart',
+        snapshotPath: 'output.snapshot',
+        depfilePath: 'output.snapshot.d',
+        packagesPath: '.packages',
+      );
 
       expect(genSnapshot.callCount, 1);
       expect(genSnapshot.snapshotType.platform, isNull);
@@ -430,7 +426,12 @@ void main() {
         'main.dart': '27f5ebf0f8c559b2af9419d190299a5e',
         'output.snapshot': 'deadbeef000b204e9800998ecaaaaa',
       });
-      await buildScriptSnapshot();
+      await snapshotter.buildScriptSnapshot(
+        mainPath: 'main.dart',
+        snapshotPath: 'output.snapshot',
+        depfilePath: 'output.snapshot.d',
+        packagesPath: '.packages',
+      );
 
       expect(genSnapshot.callCount, 1);
       expectFingerprintHas(checksums: <String, String>{
@@ -446,7 +447,12 @@ void main() {
         'main.dart': '27f5ebf0f8c559b2af9419d190299a5e',
         'output.snapshot': 'd41d8cd98f00b204e9800998ecf8427e',
       });
-      await buildScriptSnapshot();
+      await snapshotter.buildScriptSnapshot(
+        mainPath: 'main.dart',
+        snapshotPath: 'output.snapshot',
+        depfilePath: 'output.snapshot.d',
+        packagesPath: '.packages',
+      );
 
       expect(genSnapshot.callCount, 1);
       expectFingerprintHas(checksums: <String, String>{
@@ -473,7 +479,12 @@ void main() {
             'other.dart': 'e0c35f083f0ad76b2d87100ec678b516',
             'output.snapshot': 'd41d8cd98f00b204e9800998ecf8427e',
           });
-          await buildScriptSnapshot(mainPath: 'other.dart');
+          await snapshotter.buildScriptSnapshot(
+            mainPath: 'other.dart',
+            snapshotPath: 'output.snapshot',
+            depfilePath: 'output.snapshot.d',
+            packagesPath: '.packages',
+          );
 
           expect(genSnapshot.callCount, 1);
           expectFingerprintHas(
@@ -496,7 +507,12 @@ void main() {
         'main.dart': '27f5ebf0f8c559b2af9419d190299a5e',
         'output.snapshot': 'd41d8cd98f00b204e9800998ecf8427e',
       });
-      await buildScriptSnapshot();
+      await snapshotter.buildScriptSnapshot(
+        mainPath: 'main.dart',
+        snapshotPath: 'output.snapshot',
+        depfilePath: 'output.snapshot.d',
+        packagesPath: '.packages',
+      );
 
       expect(genSnapshot.callCount, 0);
       expectFingerprintHas(checksums: <String, String>{


### PR DESCRIPTION
Minor simplification for clarity, so all the fake files/outputs are declared together.