### PR TITLE
[frdp] Ignore stale ports.

### DIFF
--- a/packages/fuchsia_remote_debug_protocol/examples/list_vms_and_flutter_views.dart
+++ b/packages/fuchsia_remote_debug_protocol/examples/list_vms_and_flutter_views.dart
@@ -31,7 +31,8 @@ Future<Null> main(List<String> args) async {
   final String interface = args.length > 1 ? args[1] : '';
   // Example ssh config path for the Fuchsia device after having made a local
   // build.
-  const String sshConfigPath = '../../out/release-x86-64/ssh-keys/ssh_config';
+  const String sshConfigPath =
+      '../../../fuchsia/out/x64rel/ssh-keys/ssh_config';
   final FuchsiaRemoteConnection connection =
       await FuchsiaRemoteConnection.connect(address, interface, sshConfigPath);
   print('On $address, the following Dart VM ports are running:');

--- a/packages/fuchsia_remote_debug_protocol/lib/src/fuchsia_remote_connection.dart
+++ b/packages/fuchsia_remote_debug_protocol/lib/src/fuchsia_remote_connection.dart
@@ -133,11 +133,11 @@ class FuchsiaRemoteConnection {
     if (_forwardedVmServicePorts.isEmpty) {
       return <FlutterView>[];
     }
-    List<List<FlutterView>> flutterViewLists =
-        await _invokeForAllVms<FlutterView>((DartVm vmService) async {
+    final List<List<FlutterView>> flutterViewLists =
+        await _invokeForAllVms<List<FlutterView>>((DartVm vmService) async {
       return await vmService.getAllFlutterViews();
     });
-    List<FlutterView> results = flutterViewLists.fold<List<FlutterView>>(
+    final List<FlutterView> results = flutterViewLists.fold<List<FlutterView>>(
         <FlutterView>[], (List<FlutterView> acc, List<FlutterView> element) {
       acc.addAll(element);
       return acc;
@@ -151,7 +151,7 @@ class FuchsiaRemoteConnection {
   // will be updated in the event that ports are found to be broken/stale: they
   // will be shut down and removed from tracking.
   Future<List<E>> _invokeForAllVms<E>(
-      Future<List<E>> vmFunction(DartVm vmService)) async {
+      Future<E> vmFunction(DartVm vmService)) async {
     final List<E> result = <E>[];
     final Set<int> stalePorts = new Set<int>();
     for (PortForwarder pf in _forwardedVmServicePorts) {
@@ -202,11 +202,14 @@ class FuchsiaRemoteConnection {
     })));
 
     // Filters out stale ports after connecting. Ignores results.
-    await _invokeForAllVms<Map<String, dynamic>>((DartVm vmService) async {
-      Map<String, dynamic> res = await vmService.invokeRpc('getVersion');
-      _log.fine('DartVM version check result: $res');
-      return res;
-    });
+    await _invokeForAllVms<Map<String, dynamic>>(
+      (DartVm vmService) async {
+        final Map<String, dynamic> res =
+            await vmService.invokeRpc('getVersion');
+        _log.fine('DartVM version check result: $res');
+        return res;
+      },
+    );
   }
 
   /// Gets the open Dart VM service ports on a remote Fuchsia device.

--- a/packages/fuchsia_remote_debug_protocol/lib/src/fuchsia_remote_connection.dart
+++ b/packages/fuchsia_remote_debug_protocol/lib/src/fuchsia_remote_connection.dart
@@ -140,10 +140,11 @@ class FuchsiaRemoteConnection {
     );
   }
 
-  // Runs a flattened list of results run against all Dart VMs.
+  // Calls all Dart VM's, returning a flattened list of results.
   //
   // A side effect of this function is that internally tracked port forwarding
-  // will be updated in the event that ports are found to be broken/stale.
+  // will be updated in the event that ports are found to be broken/stale: they
+  // will be shut down and removed from tracking.
   Future<List<E>> _invokeForAllVms<E>(
       Future<List<E>> vmFunction(DartVm vmService)) async {
     List<E> result = <E>[];

--- a/packages/fuchsia_remote_debug_protocol/lib/src/fuchsia_remote_connection.dart
+++ b/packages/fuchsia_remote_debug_protocol/lib/src/fuchsia_remote_connection.dart
@@ -147,8 +147,8 @@ class FuchsiaRemoteConnection {
   // will be shut down and removed from tracking.
   Future<List<E>> _invokeForAllVms<E>(
       Future<List<E>> vmFunction(DartVm vmService)) async {
-    List<E> result = <E>[];
-    Set<int> stalePorts = new Set<int>();
+    final List<E> result = <E>[];
+    final Set<int> stalePorts = new Set<int>();
     for (PortForwarder pf in _forwardedVmServicePorts) {
       try {
         final DartVm service = await _getDartVm(pf.port);

--- a/packages/fuchsia_remote_debug_protocol/test/fuchsia_remote_connection_test.dart
+++ b/packages/fuchsia_remote_debug_protocol/test/fuchsia_remote_connection_test.dart
@@ -30,9 +30,9 @@ void main() {
       const String address = 'fe80::8eae:4cff:fef4:9247';
       const String interface = 'eno1';
       // Adds some extra junk to make sure the strings will be cleaned up.
-      when(mockRunner.run(typed(any)))
-      .thenAnswer((_) => new Future<List<String>>.value(
-          <String>['123\n\n\n', '456  ', '789']));
+      when(mockRunner.run(typed(any))).thenAnswer((_) =>
+          new Future<List<String>>.value(
+              <String>['123\n\n\n', '456  ', '789']));
       when(mockRunner.address).thenReturn(address);
       when(mockRunner.interface).thenReturn(interface);
       int port = 0;
@@ -100,8 +100,10 @@ void main() {
           mockPeerConnections.add(mp);
           uriConnections.add(uri);
           when(mp.sendRequest(typed<String>(any), typed<String>(any)))
+              // The local ports max the desired indices for now, so get the
+              // canned response from the URI port.
               .thenAnswer((_) => new Future<Map<String, dynamic>>(
-                  () => flutterViewCannedResponses[flutterViewIndex++]));
+                  () => flutterViewCannedResponses[uri.port]));
           return mp;
         });
       }

--- a/packages/fuchsia_remote_debug_protocol/test/fuchsia_remote_connection_test.dart
+++ b/packages/fuchsia_remote_debug_protocol/test/fuchsia_remote_connection_test.dart
@@ -100,7 +100,7 @@ void main() {
           mockPeerConnections.add(mp);
           uriConnections.add(uri);
           when(mp.sendRequest(typed<String>(any), typed<String>(any)))
-              // The local ports max the desired indices for now, so get the
+              // The local ports match the desired indices for now, so get the
               // canned response from the URI port.
               .thenAnswer((_) => new Future<Map<String, dynamic>>(
                   () => flutterViewCannedResponses[uri.port]));


### PR DESCRIPTION
This also changes some minor code style.

In addition, `HttpException` is treated as a "known error" in that the assumption is a stale port from `/tmp/dart.services/`

For unknown connection errors, there are now three reconnect attempts made instead of ten.