### PR TITLE
Fix for docmentation bug on RenderObject.parentData

### DIFF
--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -1051,7 +1051,7 @@ abstract class RenderObject extends AbstractNode with DiagnosticableTreeMixin im
   ///    calling [setupParentData] on the future parent node.
   ///  * The conventions for using the parent data depend on the layout protocol
   ///    used between the parent and child. For example, in box layout, the
-  ///    parent data is completely opaque but in sector layout the child is
+  ///    parent data is completely opaque but in sliver layout the child is
   ///    permitted to read some fields of the parent data.
   ParentData parentData;
 


### PR DESCRIPTION
I don't think a description is required.. such a minor change.  
Changed "sector layout" for "sliver layout".