### PR TITLE
Use File.rename instead of mv to move AOT outputs

### DIFF
--- a/packages/flutter_tools/lib/src/commands/build_aot.dart
+++ b/packages/flutter_tools/lib/src/commands/build_aot.dart
@@ -418,8 +418,8 @@ Future<String> _buildAotSnapshot(
     final List<String> commonBuildOptions = <String>['-arch', 'arm64', '-miphoneos-version-min=8.0'];
 
     if (interpreter) {
-      await runCheckedAsync(<String>['mv', vmSnapshotData, fs.path.join(outputDir.path, kVmSnapshotData)]);
-      await runCheckedAsync(<String>['mv', isolateSnapshotData, fs.path.join(outputDir.path, kIsolateSnapshotData)]);
+      await fs.file(vmSnapshotData).rename(fs.path.join(outputDir.path, kVmSnapshotData));
+      await fs.file(isolateSnapshotData).rename(fs.path.join(outputDir.path, kIsolateSnapshotData));
 
       await runCheckedAsync(<String>[
         'xxd', '--include', kVmSnapshotData, fs.path.basename(kVmSnapshotDataC)


### PR DESCRIPTION
This allows for testing with MemoryFileSystem, when tests are added.