### PR TITLE
TextField with null decoration

### DIFF
--- a/packages/flutter/lib/src/material/text_field.dart
+++ b/packages/flutter/lib/src/material/text_field.dart
@@ -364,7 +364,8 @@ class _TextFieldState extends State<TextField> with AutomaticKeepAliveClientMixi
 
   InteractiveInkFeature _createInkFeature(TapDownDetails details) {
     final MaterialInkController inkController = Material.of(context);
-    final RenderBox referenceBox = InputDecorator.containerOf(_editableTextKey.currentContext);
+    final BuildContext editableContext = _editableTextKey.currentContext;
+    final RenderBox referenceBox = InputDecorator.containerOf(editableContext) ?? editableContext.findRenderObject();
     final Offset position = referenceBox.globalToLocal(details.globalPosition);
     final Color color = Theme.of(context).splashColor;
 

--- a/packages/flutter/test/material/text_field_focus_test.dart
+++ b/packages/flutter/test/material/text_field_focus_test.dart
@@ -206,4 +206,25 @@ void main() {
     await tester.pump(); // in case the AutomaticKeepAlive widget thinks it needs a cleanup frame
     expect(find.byType(TextField), findsOneWidget);
   });
+
+  testWidgets('TextField with decoration:null', (WidgetTester tester) async {
+    // Regression test for https://github.com/flutter/flutter/issues/16880
+
+    await tester.pumpWidget(
+      new MaterialApp(
+        home: const Material(
+          child: const Center(
+            child: const TextField(
+              decoration: null
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(tester.testTextInput.isVisible, isFalse);
+    await tester.tap(find.byType(TextField));
+    await tester.idle();
+    expect(tester.testTextInput.isVisible, isTrue);
+  });
 }


### PR DESCRIPTION
InputDecorator.containerOf() returns null in this case (as it should), so use the Editable's RenderBox instead.

Fixes https://github.com/flutter/flutter/issues/16880