### PR TITLE
Increased the channels test timeout

### DIFF
--- a/dev/integration_tests/channels/test_driver/main_test.dart
+++ b/dev/integration_tests/channels/test_driver/main_test.dart
@@ -25,7 +25,7 @@ void main() {
       if (status != 'complete') {
         fail('Failed at step $step with status $status');
       }
-    }, timeout: new Timeout(const Duration(minutes: 1)));
+    }, timeout: const Timeout(const Duration(minutes: 1)));
 
     tearDownAll(() async {
       driver?.close();

--- a/dev/integration_tests/channels/test_driver/main_test.dart
+++ b/dev/integration_tests/channels/test_driver/main_test.dart
@@ -25,7 +25,7 @@ void main() {
       if (status != 'complete') {
         fail('Failed at step $step with status $status');
       }
-    }, timeout: new Timeout(new Duration(minutes: 1)));
+    }, timeout: new Timeout(const Duration(minutes: 1)));
 
     tearDownAll(() async {
       driver?.close();

--- a/dev/integration_tests/channels/test_driver/main_test.dart
+++ b/dev/integration_tests/channels/test_driver/main_test.dart
@@ -25,7 +25,7 @@ void main() {
       if (status != 'complete') {
         fail('Failed at step $step with status $status');
       }
-    });
+    }, timeout: new Timeout(new Duration(minutes: 1)));
 
     tearDownAll(() async {
       driver?.close();


### PR DESCRIPTION
The channel test (dev/integration_tests/channels/lib)  doesn't use TextField so this timeout is unlikely to related to https://github.com/flutter/flutter/pull/16369.

However the test does reliably fail (locally) due to the 30s timeout on Linux with a Moto G4. It succeeds with a Nexus5.

