### PR TITLE
We can launch if the flutter-tester device is enabled.

### DIFF
--- a/packages/flutter_tools/lib/src/doctor.dart
+++ b/packages/flutter_tools/lib/src/doctor.dart
@@ -21,6 +21,7 @@ import 'globals.dart';
 import 'intellij/intellij.dart';
 import 'ios/ios_workflow.dart';
 import 'ios/plist_utils.dart';
+import 'tester/flutter_tester.dart';
 import 'version.dart';
 import 'vscode/vscode_validator.dart';
 
@@ -191,7 +192,11 @@ class Doctor {
 
   bool get canListAnything => workflows.any((Workflow workflow) => workflow.canListDevices);
 
-  bool get canLaunchAnything => workflows.any((Workflow workflow) => workflow.canLaunchDevices);
+  bool get canLaunchAnything {
+    if (FlutterTesterDevices.showFlutterTesterDevice)
+      return true;
+    return workflows.any((Workflow workflow) => workflow.canLaunchDevices);
+  }
 }
 
 /// A series of tools and required install steps for a target platform (iOS or Android).


### PR DESCRIPTION
Or we could create actual `Workflow` / `Validator` for tester device.