### PR TITLE
Eliminate build aot --interpreter flag

### DIFF
--- a/packages/flutter_tools/lib/src/base/build.dart
+++ b/packages/flutter_tools/lib/src/base/build.dart
@@ -20,7 +20,6 @@ import '../version.dart';
 import 'context.dart';
 import 'file_system.dart';
 import 'process.dart';
-import 'utils.dart' show toTitleCase;
 
 GenSnapshot get genSnapshot => context[GenSnapshot];
 
@@ -215,17 +214,11 @@ class Snapshotter {
     @required String depfilePath,
     @required String packagesPath,
     @required String outputPath,
-    @required bool interpreter,
     @required bool previewDart2,
     @required bool preferSharedLibrary,
     List<String> extraFrontEndOptions: const <String>[],
     List<String> extraGenSnapshotOptions: const <String>[],
   }) async {
-    if (!isAotBuildMode(buildMode) && !interpreter) {
-      printError('${toTitleCase(getModeName(buildMode))} mode does not support AOT compilation.');
-      return -1;
-    }
-
     if (!(platform == TargetPlatform.android_arm ||
           platform == TargetPlatform.android_arm64 ||
           platform == TargetPlatform.ios)) {
@@ -257,6 +250,7 @@ class Snapshotter {
     final String ioEntryPoints = artifacts.getArtifactPath(Artifact.dartIoEntriesTxt, platform, buildMode);
     assert(ioEntryPoints != null);
 
+    final bool interpreter = platform == TargetPlatform.ios && buildMode == BuildMode.debug;
     final List<String> entryPointsJsonFiles = <String>[];
     if (previewDart2 && !interpreter) {
       entryPointsJsonFiles.addAll(<String>[

--- a/packages/flutter_tools/lib/src/commands/build_aot.dart
+++ b/packages/flutter_tools/lib/src/commands/build_aot.dart
@@ -26,7 +26,6 @@ class BuildAotCommand extends BuildSubCommand {
         defaultsTo: 'android-arm',
         allowed: <String>['android-arm', 'android-arm64', 'ios']
       )
-      ..addFlag('interpreter')
       ..addFlag('quiet', defaultsTo: false)
       ..addFlag('preview-dart-2',
         defaultsTo: true,
@@ -71,7 +70,6 @@ class BuildAotCommand extends BuildSubCommand {
       platform,
       getBuildMode(),
       outputPath: argResults['output-dir'],
-      interpreter: argResults['interpreter'],
       previewDart2: argResults['preview-dart-2'],
       extraFrontEndOptions: argResults[FlutterOptions.kExtraFrontEndOptions],
       extraGenSnapshotOptions: argResults[FlutterOptions.kExtraGenSnapshotOptions],
@@ -98,7 +96,6 @@ Future<String> buildAotSnapshot(
   TargetPlatform platform,
   BuildMode buildMode, {
   String outputPath,
-  bool interpreter: false,
   bool previewDart2: false,
   List<String> extraFrontEndOptions,
   List<String> extraGenSnapshotOptions,
@@ -114,7 +111,6 @@ Future<String> buildAotSnapshot(
       depfilePath: 'depFilePathGoesHere',
       packagesPath: PackageMap.globalPackagesPath,
       outputPath: outputPath,
-      interpreter: interpreter,
       previewDart2: previewDart2,
       preferSharedLibrary: preferSharedLibrary,
       extraFrontEndOptions: extraFrontEndOptions,

--- a/packages/flutter_tools/test/base/build_test.dart
+++ b/packages/flutter_tools/test/base/build_test.dart
@@ -676,7 +676,6 @@ void main() {
         depfilePath: fs.path.join(outputPath, 'snapshot.d'),
         packagesPath: '.packages',
         outputPath: outputPath,
-        interpreter: true,
         preferSharedLibrary: false,
         previewDart2: true,
       );
@@ -722,7 +721,6 @@ void main() {
         depfilePath: fs.path.join(outputPath, 'snapshot.d'),
         packagesPath: '.packages',
         outputPath: outputPath,
-        interpreter: false,
         preferSharedLibrary: false,
         previewDart2: true,
       );
@@ -770,7 +768,6 @@ void main() {
         depfilePath: fs.path.join(outputPath, 'snapshot.d'),
         packagesPath: '.packages',
         outputPath: outputPath,
-        interpreter: false,
         preferSharedLibrary: false,
         previewDart2: true,
       );


### PR DESCRIPTION
This is required for iOS debug builds, but unused otherwise. In theory,
Android debug builds could be run in this mode, but this is historically
untested and adds unnecessary complexity to the code. If ad-hoc testing
is required, it can be patched in when necessary.