### PR TITLE
Revert "Eliminate build aot --interpreter flag (#17025)"

### DIFF
--- a/packages/flutter_tools/lib/src/base/build.dart
+++ b/packages/flutter_tools/lib/src/base/build.dart
@@ -20,6 +20,7 @@ import '../version.dart';
 import 'context.dart';
 import 'file_system.dart';
 import 'process.dart';
+import 'utils.dart' show toTitleCase;
 
 GenSnapshot get genSnapshot => context[GenSnapshot];
 
@@ -214,11 +215,17 @@ class Snapshotter {
     @required String depfilePath,
     @required String packagesPath,
     @required String outputPath,
+    @required bool interpreter,
     @required bool previewDart2,
     @required bool preferSharedLibrary,
     List<String> extraFrontEndOptions: const <String>[],
     List<String> extraGenSnapshotOptions: const <String>[],
   }) async {
+    if (!isAotBuildMode(buildMode) && !interpreter) {
+      printError('${toTitleCase(getModeName(buildMode))} mode does not support AOT compilation.');
+      return -1;
+    }
+
     if (!(platform == TargetPlatform.android_arm ||
           platform == TargetPlatform.android_arm64 ||
           platform == TargetPlatform.ios)) {
@@ -250,7 +257,6 @@ class Snapshotter {
     final String ioEntryPoints = artifacts.getArtifactPath(Artifact.dartIoEntriesTxt, platform, buildMode);
     assert(ioEntryPoints != null);
 
-    final bool interpreter = platform == TargetPlatform.ios && buildMode == BuildMode.debug;
     final List<String> entryPointsJsonFiles = <String>[];
     if (previewDart2 && !interpreter) {
       entryPointsJsonFiles.addAll(<String>[

--- a/packages/flutter_tools/lib/src/commands/build_aot.dart
+++ b/packages/flutter_tools/lib/src/commands/build_aot.dart
@@ -26,6 +26,7 @@ class BuildAotCommand extends BuildSubCommand {
         defaultsTo: 'android-arm',
         allowed: <String>['android-arm', 'android-arm64', 'ios']
       )
+      ..addFlag('interpreter')
       ..addFlag('quiet', defaultsTo: false)
       ..addFlag('preview-dart-2',
         defaultsTo: true,
@@ -70,6 +71,7 @@ class BuildAotCommand extends BuildSubCommand {
       platform,
       getBuildMode(),
       outputPath: argResults['output-dir'],
+      interpreter: argResults['interpreter'],
       previewDart2: argResults['preview-dart-2'],
       extraFrontEndOptions: argResults[FlutterOptions.kExtraFrontEndOptions],
       extraGenSnapshotOptions: argResults[FlutterOptions.kExtraGenSnapshotOptions],
@@ -96,6 +98,7 @@ Future<String> buildAotSnapshot(
   TargetPlatform platform,
   BuildMode buildMode, {
   String outputPath,
+  bool interpreter: false,
   bool previewDart2: false,
   List<String> extraFrontEndOptions,
   List<String> extraGenSnapshotOptions,
@@ -111,6 +114,7 @@ Future<String> buildAotSnapshot(
       depfilePath: 'depFilePathGoesHere',
       packagesPath: PackageMap.globalPackagesPath,
       outputPath: outputPath,
+      interpreter: interpreter,
       previewDart2: previewDart2,
       preferSharedLibrary: preferSharedLibrary,
       extraFrontEndOptions: extraFrontEndOptions,

--- a/packages/flutter_tools/test/base/build_test.dart
+++ b/packages/flutter_tools/test/base/build_test.dart
@@ -676,6 +676,7 @@ void main() {
         depfilePath: fs.path.join(outputPath, 'snapshot.d'),
         packagesPath: '.packages',
         outputPath: outputPath,
+        interpreter: true,
         preferSharedLibrary: false,
         previewDart2: true,
       );
@@ -721,6 +722,7 @@ void main() {
         depfilePath: fs.path.join(outputPath, 'snapshot.d'),
         packagesPath: '.packages',
         outputPath: outputPath,
+        interpreter: false,
         preferSharedLibrary: false,
         previewDart2: true,
       );
@@ -768,6 +770,7 @@ void main() {
         depfilePath: fs.path.join(outputPath, 'snapshot.d'),
         packagesPath: '.packages',
         outputPath: outputPath,
+        interpreter: false,
         preferSharedLibrary: false,
         previewDart2: true,
       );


### PR DESCRIPTION
Requires a fix to xcode_backend.sh. Will followup momentarily with that
fix.

This reverts commit 8c4f0c0d215ca3219923c60fce2cd7c7528acf9b.