### PR TITLE
Fix consolidate HTTP response and add test

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -21,3 +21,4 @@ Yusuke Konishi <yahpeycoy0403@gmail.com>
 Fredrik Simón <fredrik@fsimon.net>
 Ali Bitek <alibitek@protonmail.ch>
 Tetsuhiro Ueda <najeira@gmail.com>
+Dan Field <dfield@gmail.com>

--- a/packages/flutter/lib/src/foundation/consolidate_response.dart
+++ b/packages/flutter/lib/src/foundation/consolidate_response.dart
@@ -10,10 +10,9 @@ import 'dart:typed_data';
 /// 
 /// The future returned will forward all errors emitted by [response].
 Future<Uint8List> consolidateHttpClientResponseBytes(HttpClientResponse response) {
-  // dart:io guarantees that [contentLength] is -1 if the the header is missing or
-  // invalid.  This could still happen if a mocked response object does not fully
-  // implement the interface.
-  assert(response.contentLength != null);
+  // response.contentLength is not trustworthy when GZIP is involved
+  // or other cases where an intermediate transformer has been applied
+  // to the stream.
   final Completer<Uint8List> completer = new Completer<Uint8List>.sync();
 
   final List<List<int>> chunks = <List<int>>[];

--- a/packages/flutter/lib/src/foundation/consolidate_response.dart
+++ b/packages/flutter/lib/src/foundation/consolidate_response.dart
@@ -14,7 +14,6 @@ Future<Uint8List> consolidateHttpClientResponseBytes(HttpClientResponse response
   // or other cases where an intermediate transformer has been applied
   // to the stream.
   final Completer<Uint8List> completer = new Completer<Uint8List>.sync();
-
   final List<List<int>> chunks = <List<int>>[];
   int contentLength = 0;
   response.listen((List<int> chunk) {

--- a/packages/flutter/lib/src/foundation/consolidate_response.dart
+++ b/packages/flutter/lib/src/foundation/consolidate_response.dart
@@ -15,7 +15,7 @@ Future<Uint8List> consolidateHttpClientResponseBytes(HttpClientResponse response
   // implement the interface.
   assert(response.contentLength != null);
   final Completer<Uint8List> completer = new Completer<Uint8List>.sync();
-  if (response.contentLength == -1) {
+  if (response.contentLength == -1 || response.headers.value(HttpHeaders.CONTENT_ENCODING) == 'GZIP') {
     final List<List<int>> chunks = <List<int>>[];
     int contentLength = 0;
     response.listen((List<int> chunk) {

--- a/packages/flutter/lib/src/foundation/consolidate_response.dart
+++ b/packages/flutter/lib/src/foundation/consolidate_response.dart
@@ -15,34 +15,21 @@ Future<Uint8List> consolidateHttpClientResponseBytes(HttpClientResponse response
   // implement the interface.
   assert(response.contentLength != null);
   final Completer<Uint8List> completer = new Completer<Uint8List>.sync();
-  if (response.contentLength == -1 || response.headers.value(HttpHeaders.CONTENT_ENCODING) == 'GZIP') {
-    final List<List<int>> chunks = <List<int>>[];
-    int contentLength = 0;
-    response.listen((List<int> chunk) {
-      chunks.add(chunk);
-      contentLength += chunk.length;
-    }, onDone: () {
-      final Uint8List bytes = new Uint8List(contentLength);
-      int offset = 0;
-      for (List<int> chunk in chunks) {
-        bytes.setRange(offset, offset + chunk.length, chunk);
-        offset += chunk.length;
-      }
-      completer.complete(bytes);
-    }, onError: completer.completeError, cancelOnError: true);
-  } else {
-    // If the response has a content length, then allocate a buffer of the correct size.
-    final Uint8List bytes = new Uint8List(response.contentLength);
+
+  final List<List<int>> chunks = <List<int>>[];
+  int contentLength = 0;
+  response.listen((List<int> chunk) {
+    chunks.add(chunk);
+    contentLength += chunk.length;
+  }, onDone: () {
+    final Uint8List bytes = new Uint8List(contentLength);
     int offset = 0;
-    response.listen((List<int> chunk) {
+    for (List<int> chunk in chunks) {
       bytes.setRange(offset, offset + chunk.length, chunk);
       offset += chunk.length;
-    },
-    onError: completer.completeError,
-    onDone: () {
-      completer.complete(bytes);
-    },
-    cancelOnError: true);
-  }
+    }
+    completer.complete(bytes);
+  }, onError: completer.completeError, cancelOnError: true);
+  
   return completer.future;
 }

--- a/packages/flutter/test/foundation/consolidate_response_test.dart
+++ b/packages/flutter/test/foundation/consolidate_response_test.dart
@@ -13,11 +13,14 @@ void main() {
 
     setUp(() {
       response = new MockHttpClientResponse();
-      when(response.listen(typed(any),
-              onDone: typed(any, named: 'onDone'),
-              onError: typed(any, named: 'onError'),
-              cancelOnError: typed(any, named: 'cancelOnError')))
-          .thenAnswer((Invocation invocation) {
+      when(
+        response.listen(
+          typed(any),
+          onDone: typed(any, named: 'onDone'),
+          onError: typed(any, named: 'onError'),
+          cancelOnError: typed(any, named: 'cancelOnError'),
+        ),
+      ).thenAnswer((Invocation invocation) {
         final void Function(List<int>) onData =
             invocation.positionalArguments[0];
         final void Function(Object) onError =
@@ -64,11 +67,14 @@ void main() {
     });
 
     test('forwards errors from HttpClientResponse', () async {
-      when(response.listen(typed(any),
-              onDone: typed(any, named: 'onDone'),
-              onError: typed(any, named: 'onError'),
-              cancelOnError: typed(any, named: 'cancelOnError')))
-          .thenAnswer((Invocation invocation) {
+      when(
+        response.listen(
+          typed(any),
+          onDone: typed(any, named: 'onDone'),
+          onError: typed(any, named: 'onError'),
+          cancelOnError: typed(any, named: 'cancelOnError'),
+        ),
+      ).thenAnswer((Invocation invocation) {
         final void Function(List<int>) onData =
             invocation.positionalArguments[0];
         final void Function(Object) onError =

--- a/packages/flutter/test/foundation/consolidate_response_test.dart
+++ b/packages/flutter/test/foundation/consolidate_response_test.dart
@@ -10,12 +10,9 @@ void main() {
     final List<int> chunkOne = <int>[0, 1, 2, 3, 4, 5];
     final List<int> chunkTwo = <int>[6, 7, 8, 9, 10];
     MockHttpClientResponse response;
-    MockHttpHeaders headers;
-
+    
     setUp(() {
       response = new MockHttpClientResponse();
-      headers = new MockHttpHeaders();
-      when(response.headers).thenReturn(headers);
       when(response.listen(typed(any),
               onDone: typed(any, named: 'onDone'),
               onError: typed(any, named: 'onError'),
@@ -39,7 +36,6 @@ void main() {
         () async {
       when(response.contentLength)
           .thenReturn(chunkOne.length + chunkTwo.length);
-      headers._headers[HttpHeaders.CONTENT_ENCODING] = 'TEXT';
       final List<int> bytes =
           await consolidateHttpClientResponseBytes(response);
 
@@ -50,7 +46,6 @@ void main() {
         'Converts an compressed HttpClientResponse with contentLength to bytes',
         () async {
       when(response.contentLength).thenReturn(chunkOne.length);
-      headers._headers[HttpHeaders.CONTENT_ENCODING] = 'GZIP';
       final List<int> bytes =
           await consolidateHttpClientResponseBytes(response);
 
@@ -93,20 +88,3 @@ void main() {
 }
 
 class MockHttpClientResponse extends Mock implements HttpClientResponse {}
-
-class MockHttpHeaders extends Mock implements HttpHeaders {
-  Map<String, String> _headers;
-  MockHttpHeaders([Map<String, String> headers])
-      : _headers = headers ?? <String, String>{};
-
-  @override
-  List<String> operator [](String name) {
-    return _headers.containsKey(name) ? <String>[_headers[name]] : null;
-  }
-
-  @override
-  String value(String name) {
-    // TODO: for multi-value headers (when supported) this should throw an exception
-    return _headers.containsKey(name) ? _headers[name] : null;
-  }
-}

--- a/packages/flutter/test/foundation/consolidate_response_test.dart
+++ b/packages/flutter/test/foundation/consolidate_response_test.dart
@@ -10,7 +10,7 @@ void main() {
     final List<int> chunkOne = <int>[0, 1, 2, 3, 4, 5];
     final List<int> chunkTwo = <int>[6, 7, 8, 9, 10];
     MockHttpClientResponse response;
-    
+
     setUp(() {
       response = new MockHttpClientResponse();
       when(response.listen(typed(any),
@@ -26,9 +26,12 @@ void main() {
         final bool cancelOnError = invocation.namedArguments[#cancelOnError];
 
         return new Stream<List<int>>.fromIterable(
-                <List<int>>[chunkOne, chunkTwo])
-            .listen(onData,
-                onDone: onDone, onError: onError, cancelOnError: cancelOnError);
+            <List<int>>[chunkOne, chunkTwo]).listen(
+          onData,
+          onDone: onDone,
+          onError: onError,
+          cancelOnError: cancelOnError,
+        );
       });
     });
 
@@ -42,8 +45,7 @@ void main() {
       expect(bytes, <int>[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
     });
 
-    test(
-        'Converts an compressed HttpClientResponse with contentLength to bytes',
+    test('Converts a compressed HttpClientResponse with contentLength to bytes',
         () async {
       when(response.contentLength).thenReturn(chunkOne.length);
       final List<int> bytes =
@@ -51,7 +53,7 @@ void main() {
 
       expect(bytes, <int>[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
     });
-    
+
     test('Converts an HttpClientResponse without contentLength to bytes',
         () async {
       when(response.contentLength).thenReturn(-1);
@@ -76,8 +78,12 @@ void main() {
 
         return new Stream<List<int>>.fromFuture(
                 new Future<List<int>>.error(new Exception('Test Error')))
-            .listen(onData,
-                onDone: onDone, onError: onError, cancelOnError: cancelOnError);
+            .listen(
+          onData,
+          onDone: onDone,
+          onError: onError,
+          cancelOnError: cancelOnError,
+        );
       });
       when(response.contentLength).thenReturn(-1);
 

--- a/packages/flutter/test/foundation/consolidate_response_test.dart
+++ b/packages/flutter/test/foundation/consolidate_response_test.dart
@@ -10,59 +10,103 @@ void main() {
     final List<int> chunkOne = <int>[0, 1, 2, 3, 4, 5];
     final List<int> chunkTwo = <int>[6, 7, 8, 9, 10];
     MockHttpClientResponse response;
+    MockHttpHeaders headers;
 
     setUp(() {
       response = new MockHttpClientResponse();
-       when(response.listen(
-         typed(any),
-         onDone: typed(any, named: 'onDone'),
-         onError: typed(any, named: 'onError'),
-         cancelOnError: typed(any, named: 'cancelOnError')
-      )).thenAnswer((Invocation invocation) {
-        final void Function(List<int>) onData = invocation.positionalArguments[0];
-        final void Function(Object) onError = invocation.namedArguments[#onError];
+      headers = new MockHttpHeaders();
+      when(response.headers).thenReturn(headers);
+      when(response.listen(typed(any),
+              onDone: typed(any, named: 'onDone'),
+              onError: typed(any, named: 'onError'),
+              cancelOnError: typed(any, named: 'cancelOnError')))
+          .thenAnswer((Invocation invocation) {
+        final void Function(List<int>) onData =
+            invocation.positionalArguments[0];
+        final void Function(Object) onError =
+            invocation.namedArguments[#onError];
         final void Function() onDone = invocation.namedArguments[#onDone];
         final bool cancelOnError = invocation.namedArguments[#cancelOnError];
 
-        return new Stream<List<int>>.fromIterable(<List<int>>[chunkOne, chunkTwo])
-          .listen(onData, onDone: onDone, onError: onError, cancelOnError: cancelOnError);
+        return new Stream<List<int>>.fromIterable(
+                <List<int>>[chunkOne, chunkTwo])
+            .listen(onData,
+                onDone: onDone, onError: onError, cancelOnError: cancelOnError);
       });
     });
 
-    test('Converts an HttpClientResponse with contentLength to bytes', () async {
-      when(response.contentLength).thenReturn(chunkOne.length + chunkTwo.length);
-      final List<int> bytes = await consolidateHttpClientResponseBytes(response);
+    test('Converts an HttpClientResponse with contentLength to bytes',
+        () async {
+      when(response.contentLength)
+          .thenReturn(chunkOne.length + chunkTwo.length);
+      headers._headers[HttpHeaders.CONTENT_ENCODING] = 'TEXT';
+      final List<int> bytes =
+          await consolidateHttpClientResponseBytes(response);
 
       expect(bytes, <int>[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
     });
 
-    test('Converts an HttpClientResponse without contentLength to bytes', () async {
+    test(
+        'Converts an compressed HttpClientResponse with contentLength to bytes',
+        () async {
+      when(response.contentLength).thenReturn(chunkOne.length);
+      headers._headers[HttpHeaders.CONTENT_ENCODING] = 'GZIP';
+      final List<int> bytes =
+          await consolidateHttpClientResponseBytes(response);
+
+      expect(bytes, <int>[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+    });
+    
+    test('Converts an HttpClientResponse without contentLength to bytes',
+        () async {
       when(response.contentLength).thenReturn(-1);
-      final List<int> bytes = await consolidateHttpClientResponseBytes(response);
+      final List<int> bytes =
+          await consolidateHttpClientResponseBytes(response);
 
       expect(bytes, <int>[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
     });
 
     test('forwards errors from HttpClientResponse', () async {
-      when(response.listen(
-        typed(any),
-        onDone: typed(any, named: 'onDone'),
-        onError: typed(any, named: 'onError'),
-        cancelOnError: typed(any, named: 'cancelOnError')
-      )).thenAnswer((Invocation invocation) {
-        final void Function(List<int>) onData = invocation.positionalArguments[0];
-        final void Function(Object) onError = invocation.namedArguments[#onError];
+      when(response.listen(typed(any),
+              onDone: typed(any, named: 'onDone'),
+              onError: typed(any, named: 'onError'),
+              cancelOnError: typed(any, named: 'cancelOnError')))
+          .thenAnswer((Invocation invocation) {
+        final void Function(List<int>) onData =
+            invocation.positionalArguments[0];
+        final void Function(Object) onError =
+            invocation.namedArguments[#onError];
         final void Function() onDone = invocation.namedArguments[#onDone];
         final bool cancelOnError = invocation.namedArguments[#cancelOnError];
 
-        return new Stream<List<int>>.fromFuture(new Future<List<int>>.error(new Exception('Test Error')))
-          .listen(onData, onDone: onDone, onError: onError, cancelOnError: cancelOnError);
+        return new Stream<List<int>>.fromFuture(
+                new Future<List<int>>.error(new Exception('Test Error')))
+            .listen(onData,
+                onDone: onDone, onError: onError, cancelOnError: cancelOnError);
       });
       when(response.contentLength).thenReturn(-1);
 
-      expect(consolidateHttpClientResponseBytes(response), throwsA(const isInstanceOf<Exception>()));
+      expect(consolidateHttpClientResponseBytes(response),
+          throwsA(const isInstanceOf<Exception>()));
     });
   });
 }
 
 class MockHttpClientResponse extends Mock implements HttpClientResponse {}
+
+class MockHttpHeaders extends Mock implements HttpHeaders {
+  Map<String, String> _headers;
+  MockHttpHeaders([Map<String, String> headers])
+      : _headers = headers ?? <String, String>{};
+
+  @override
+  List<String> operator [](String name) {
+    return _headers.containsKey(name) ? <String>[_headers[name]] : null;
+  }
+
+  @override
+  String value(String name) {
+    // TODO: for multi-value headers (when supported) this should throw an exception
+    return _headers.containsKey(name) ? _headers[name] : null;
+  }
+}


### PR DESCRIPTION
Fixes #17034 

One thing I wonder about - in the case where we're trusting Content-Length, should we still be checking to see if we're overrunning the buffer and expand it if so?  That would also prevent this error without needing to worry about whether the data was compressed.