### PR TITLE
Fix AOT snapshotting depfile path

### DIFF
--- a/packages/flutter_tools/lib/src/commands/build_aot.dart
+++ b/packages/flutter_tools/lib/src/commands/build_aot.dart
@@ -72,7 +72,7 @@ class BuildAotCommand extends BuildSubCommand {
         platform: platform,
         buildMode: getBuildMode(),
         mainPath: findMainDartFile(targetFile),
-        depfilePath: 'depFilePathGoesHere',
+        depfilePath: fs.path.join(outputPath, 'snapshot.d'),
         packagesPath: PackageMap.globalPackagesPath,
         outputPath: outputPath,
         previewDart2: argResults['preview-dart-2'],


### PR DESCRIPTION
Fixes a bug introduced in 82f969ff0593e1da270bcc18cb0a495877f617df where
the depfile used for AOT snapshotting, useful in particular for skipping
gen_snapshot when inputs/outputs haven't changed since the last build.