### PR TITLE
Eliminate unnecessary buildAotSnapshot parameter

### DIFF
--- a/packages/flutter_tools/lib/src/base/build.dart
+++ b/packages/flutter_tools/lib/src/base/build.dart
@@ -212,7 +212,6 @@ class Snapshotter {
     @required TargetPlatform platform,
     @required BuildMode buildMode,
     @required String mainPath,
-    @required String depfilePath,
     @required String packagesPath,
     @required String outputPath,
     @required bool previewDart2,
@@ -233,7 +232,7 @@ class Snapshotter {
     final String vmSnapshotInstructions = fs.path.join(outputDir.path, 'vm_snapshot_instr');
     final String isolateSnapshotData = fs.path.join(outputDir.path, 'isolate_snapshot_data');
     final String isolateSnapshotInstructions = fs.path.join(outputDir.path, 'isolate_snapshot_instr');
-    final String dependencies = fs.path.join(outputDir.path, 'snapshot.d');
+    final String depfilePath = fs.path.join(outputDir.path, 'snapshot.d');
     final String assembly = fs.path.join(outputDir.path, 'snapshot_assembly.S');
     final String assemblyO = fs.path.join(outputDir.path, 'snapshot_assembly.o');
     final String assemblySo = fs.path.join(outputDir.path, 'app.so');
@@ -323,7 +322,7 @@ class Snapshotter {
       '--isolate_snapshot_data=$isolateSnapshotData',
       '--url_mapping=dart:ui,$uiPath',
       '--url_mapping=dart:vmservice_io,$vmServicePath',
-      '--dependencies=$dependencies',
+      '--dependencies=$depfilePath',
     ];
 
     if ((extraFrontEndOptions != null) && extraFrontEndOptions.isNotEmpty)
@@ -402,7 +401,7 @@ class Snapshotter {
       ]);
     }
 
-    final String fingerprintPath = '$dependencies.fingerprint';
+    final String fingerprintPath = '$depfilePath.fingerprint';
     final SnapshotType snapshotType = new SnapshotType(platform, buildMode);
     if (!await _isBuildRequired(snapshotType, outputPaths, depfilePath, mainPath, fingerprintPath)) {
       printTrace('Skipping AOT snapshot build. Fingerprint match.');
@@ -415,7 +414,7 @@ class Snapshotter {
         sdkRoot: artifacts.getArtifactPath(Artifact.flutterPatchedSdkPath),
         mainPath: mainPath,
         outputFilePath: kApplicationKernelPath,
-        depFilePath: dependencies,
+        depFilePath: depfilePath,
         extraFrontEndOptions: extraFrontEndOptions,
         linkPlatformKernelIn: true,
         aot: !interpreter,
@@ -443,7 +442,7 @@ class Snapshotter {
     final int genSnapshotExitCode = await genSnapshot.run(
       snapshotType: new SnapshotType(platform, buildMode),
       packagesPath: packageMap.packagesPath,
-      depfilePath: dependencies,
+      depfilePath: depfilePath,
       additionalArgs: genSnapshotArgs,
     );
     if (genSnapshotExitCode != 0) {

--- a/packages/flutter_tools/lib/src/commands/build_aot.dart
+++ b/packages/flutter_tools/lib/src/commands/build_aot.dart
@@ -72,7 +72,6 @@ class BuildAotCommand extends BuildSubCommand {
         platform: platform,
         buildMode: getBuildMode(),
         mainPath: findMainDartFile(targetFile),
-        depfilePath: fs.path.join(outputPath, 'snapshot.d'),
         packagesPath: PackageMap.globalPackagesPath,
         outputPath: outputPath,
         previewDart2: argResults['preview-dart-2'],

--- a/packages/flutter_tools/test/base/build_test.dart
+++ b/packages/flutter_tools/test/base/build_test.dart
@@ -673,7 +673,6 @@ void main() {
         platform: TargetPlatform.ios,
         buildMode: BuildMode.debug,
         mainPath: 'main.dart',
-        depfilePath: fs.path.join(outputPath, 'snapshot.d'),
         packagesPath: '.packages',
         outputPath: outputPath,
         preferSharedLibrary: false,
@@ -685,7 +684,6 @@ void main() {
       expect(genSnapshot.snapshotType.platform, TargetPlatform.ios);
       expect(genSnapshot.snapshotType.mode, BuildMode.debug);
       expect(genSnapshot.packagesPath, '.packages');
-      expect(genSnapshot.depfilePath, fs.path.join(outputPath, 'snapshot.d'));
       expect(genSnapshot.additionalArgs, <String>[
         '--vm_snapshot_data=${fs.path.join(outputPath, 'vm_snapshot_data')}',
         '--isolate_snapshot_data=${fs.path.join(outputPath, 'isolate_snapshot_data')}',
@@ -718,7 +716,6 @@ void main() {
         platform: TargetPlatform.ios,
         buildMode: BuildMode.profile,
         mainPath: 'main.dart',
-        depfilePath: fs.path.join(outputPath, 'snapshot.d'),
         packagesPath: '.packages',
         outputPath: outputPath,
         preferSharedLibrary: false,
@@ -730,7 +727,6 @@ void main() {
       expect(genSnapshot.snapshotType.platform, TargetPlatform.ios);
       expect(genSnapshot.snapshotType.mode, BuildMode.profile);
       expect(genSnapshot.packagesPath, '.packages');
-      expect(genSnapshot.depfilePath, fs.path.join(outputPath, 'snapshot.d'));
       expect(genSnapshot.additionalArgs, <String>[
         '--vm_snapshot_data=${fs.path.join(outputPath, 'vm_snapshot_data')}',
         '--isolate_snapshot_data=${fs.path.join(outputPath, 'isolate_snapshot_data')}',
@@ -765,7 +761,6 @@ void main() {
         platform: TargetPlatform.ios,
         buildMode: BuildMode.release,
         mainPath: 'main.dart',
-        depfilePath: fs.path.join(outputPath, 'snapshot.d'),
         packagesPath: '.packages',
         outputPath: outputPath,
         preferSharedLibrary: false,
@@ -777,7 +772,6 @@ void main() {
       expect(genSnapshot.snapshotType.platform, TargetPlatform.ios);
       expect(genSnapshot.snapshotType.mode, BuildMode.release);
       expect(genSnapshot.packagesPath, '.packages');
-      expect(genSnapshot.depfilePath, fs.path.join(outputPath, 'snapshot.d'));
       expect(genSnapshot.additionalArgs, <String>[
         '--vm_snapshot_data=${fs.path.join(outputPath, 'vm_snapshot_data')}',
         '--isolate_snapshot_data=${fs.path.join(outputPath, 'isolate_snapshot_data')}',


### PR DESCRIPTION
This isn't user-specifiable through a flag, so no need to pass it as a
parameter.