### PR TITLE
Add `expectLater` to flutter_test

### DIFF
--- a/packages/flutter_test/lib/src/widget_tester.dart
+++ b/packages/flutter_test/lib/src/widget_tester.dart
@@ -158,6 +158,19 @@ void expectSync(dynamic actual, dynamic matcher, {
   test_package.expect(actual, matcher, reason: reason);
 }
 
+/// Just like [expect], but returns a [Future] that completes when the matcher
+/// has finished matching.
+///
+/// If the matcher fails asynchronously, that failure is piped to the returned
+/// future where it can be handled by user code.
+Future<void> expectLater(dynamic actual, dynamic matcher, {
+  String reason,
+  dynamic skip, // true or a String
+}) {
+  TestAsyncUtils.guardSync();
+  return test_package.expectLater(actual, matcher, reason: reason, skip: skip);
+}
+
 /// Class that programmatically interacts with widgets and the test environment.
 ///
 /// For convenience, instances of this class (such as the one provided by

--- a/packages/flutter_test/lib/src/widget_tester.dart
+++ b/packages/flutter_test/lib/src/widget_tester.dart
@@ -135,6 +135,10 @@ Future<Null> benchmarkWidgets(WidgetTesterCallback callback) {
 /// See [test_package.expect] for details. This is a variant of that function
 /// that additionally verifies that there are no asynchronous APIs
 /// that have not yet resolved.
+///
+/// See also:
+///
+///  * [expectLater] for use with asynchronous matchers.
 void expect(dynamic actual, dynamic matcher, {
   String reason,
   dynamic skip, // true or a String
@@ -161,14 +165,18 @@ void expectSync(dynamic actual, dynamic matcher, {
 /// Just like [expect], but returns a [Future] that completes when the matcher
 /// has finished matching.
 ///
+/// See [test_package.expectLater] for details.
+///
 /// If the matcher fails asynchronously, that failure is piped to the returned
-/// future where it can be handled by user code.
+/// future where it can be handled by user code. If it is not handled by user
+/// code, the test will fail.
 Future<void> expectLater(dynamic actual, dynamic matcher, {
   String reason,
   dynamic skip, // true or a String
 }) {
-  TestAsyncUtils.guardSync();
-  return test_package.expectLater(actual, matcher, reason: reason, skip: skip);
+  return TestAsyncUtils.guard(() async {
+    await test_package.expectLater(actual, matcher, reason: reason, skip: skip);
+  });
 }
 
 /// Class that programmatically interacts with widgets and the test environment.


### PR DESCRIPTION
* Wrap `expectLater()` in flutter_tester so that callers can
  wait for the matcher to complete in their tests

https://github.com/flutter/flutter/issues/16859