### PR TITLE
Cross fade gallery UI front layer

### DIFF
--- a/examples/flutter_gallery/lib/demo/material/buttons_demo.dart
+++ b/examples/flutter_gallery/lib/demo/material/buttons_demo.dart
@@ -46,7 +46,7 @@ const String _actionText =
 const String _actionCode = 'buttons_action';
 
 class ButtonsDemo extends StatefulWidget {
-  static const String routeName = '/material//buttons';
+  static const String routeName = '/material/buttons';
 
   @override
   _ButtonsDemoState createState() => new _ButtonsDemoState();

--- a/examples/flutter_gallery/lib/gallery/app.dart
+++ b/examples/flutter_gallery/lib/gallery/app.dart
@@ -45,30 +45,10 @@ class _GalleryAppState extends State<GalleryApp> {
     // For a different example of how to set up an application routing table
     // using named routes, consider the example in the Navigator class documentation:
     // https://docs.flutter.io/flutter/widgets/Navigator-class.html
-
     return new Map<String, WidgetBuilder>.fromIterable(
       kAllGalleryDemos,
       key: (dynamic demo) => '${demo.routeName}',
       value: (dynamic demo) => demo.buildRoute,
-    )..addAll(
-      new Map<String, WidgetBuilder>.fromIterable(
-        kAllGalleryDemoCategories,
-        key: (dynamic category) => '/${category.name}',
-        value: (dynamic category) {
-          return (BuildContext context) {
-            return new DemosPage(
-              category: category,
-              optionsPage: new GalleryOptionsPage(
-                options: _options,
-                onOptionsChanged: _handleOptionsChanged,
-                onSendFeedback: widget.onSendFeedback ?? () {
-                  launch('https://github.com/flutter/flutter/issues/new', forceSafariVC: false);
-                },
-              ),
-            );
-          };
-        },
-      ),
     );
   }
 
@@ -131,7 +111,7 @@ class _GalleryAppState extends State<GalleryApp> {
         options: _options,
         onOptionsChanged: _handleOptionsChanged,
         onSendFeedback: widget.onSendFeedback ?? () {
-          launch('https://github.com/flutter/flutter/issues/new');
+          launch('https://github.com/flutter/flutter/issues/new', forceSafariVC: false);
         },
       ),
     );

--- a/examples/flutter_gallery/lib/gallery/backdrop.dart
+++ b/examples/flutter_gallery/lib/gallery/backdrop.dart
@@ -115,7 +115,7 @@ class _CrossFadeTransition extends AnimatedWidget {
           ),
         ),
         new IgnorePointer(
-          ignoring: opacity2 <1.0,
+          ignoring: opacity2 < 1.0,
           child: new Opacity(
             opacity: opacity2,
             child: new Semantics(

--- a/examples/flutter_gallery/lib/gallery/home.dart
+++ b/examples/flutter_gallery/lib/gallery/home.dart
@@ -105,7 +105,7 @@ class _CategoriesPage extends StatelessWidget {
     final int columnCount = (MediaQuery.of(context).orientation == Orientation.portrait) ? 2 : 3;
 
     return new SingleChildScrollView(
-      key: new PageStorageKey<String>('categories'),
+      key: const PageStorageKey<String>('categories'),
       child: new LayoutBuilder(
         builder: (BuildContext context, BoxConstraints constraints) {
           final double columnWidth = constraints.biggest.width / columnCount.toDouble();
@@ -223,7 +223,7 @@ class _DemosPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return new KeyedSubtree(
-      key: new ValueKey<String>('GalleryDemoList'), // So the tests can find this ListView
+      key: const ValueKey<String>('GalleryDemoList'), // So the tests can find this ListView
       child: new ListView(
         key: new PageStorageKey<String>(category.name),
         padding: const EdgeInsets.only(top: 8.0),

--- a/examples/flutter_gallery/test/example_code_display_test.dart
+++ b/examples/flutter_gallery/test/example_code_display_test.dart
@@ -18,7 +18,7 @@ void main() {
     await tester.pump(); // see https://github.com/flutter/flutter/issues/1865
     await tester.pump(); // triggers a frame
 
-    Scrollable.ensureVisible(tester.element(find.text('Material')), alignment: 0.5);
+    await Scrollable.ensureVisible(tester.element(find.text('Material')), alignment: 0.5);
     await tester.pumpAndSettle();
     await tester.tap(find.text('Material'));
     await tester.pumpAndSettle();

--- a/examples/flutter_gallery/test/smoke_test.dart
+++ b/examples/flutter_gallery/test/smoke_test.dart
@@ -150,10 +150,11 @@ Future<Null> smokeGallery(WidgetTester tester) async {
   expect(find.text(kGalleryTitle), findsOneWidget);
 
   for (GalleryDemoCategory category in kAllGalleryDemoCategories) {
+    await Scrollable.ensureVisible(tester.element(find.text(category.name)), alignment: 0.5);
     await tester.tap(find.text(category.name));
     await tester.pumpAndSettle();
     for (GalleryDemo demo in kGalleryCategoryToDemos[category]) {
-      Scrollable.ensureVisible(tester.element(find.text(demo.title)), alignment: 0.5);
+      await Scrollable.ensureVisible(tester.element(find.text(demo.title)), alignment: 0.0);
       await smokeDemo(tester, demo);
       tester.binding.debugAssertNoTransientCallbacks('A transient callback was still active after running $demo');
     }

--- a/examples/flutter_gallery/test_driver/transitions_perf_test.dart
+++ b/examples/flutter_gallery/test_driver/transitions_perf_test.dart
@@ -126,12 +126,15 @@ Future<Null> runDemos(List<String> demos, FlutterDriver driver) async {
   for (String demo in demos) {
     final String demoAtCategory = _allDemos.firstWhere((String s) => s.startsWith(demo));
     final String demoCategory = demoAtCategory.substring(demoAtCategory.indexOf('@') + 1);
+    print('> $demoAtCategory');
 
     if (currentDemoCategory == null) {
       await driver.tap(find.text(demoCategory));
     } else if (currentDemoCategory != demoCategory) {
       await driver.tap(find.byTooltip('Back'));
       await driver.tap(find.text(demoCategory));
+      // Scroll back to the top
+      await driver.scroll(demoList, 0.0, 10000, const Duration(milliseconds: 100));
     }
     currentDemoCategory = demoCategory;
 
@@ -150,7 +153,7 @@ Future<Null> runDemos(List<String> demos, FlutterDriver driver) async {
       }
     }
 
-    print('Success');
+    print('< Success');
   }
 
   // Return to the home screen

--- a/examples/flutter_gallery/test_driver/transitions_perf_test.dart
+++ b/examples/flutter_gallery/test_driver/transitions_perf_test.dart
@@ -134,7 +134,7 @@ Future<Null> runDemos(List<String> demos, FlutterDriver driver) async {
       await driver.tap(find.byTooltip('Back'));
       await driver.tap(find.text(demoCategory));
       // Scroll back to the top
-      await driver.scroll(demoList, 0.0, 10000, const Duration(milliseconds: 100));
+      await driver.scroll(demoList, 0.0, 10000.0, const Duration(milliseconds: 100));
     }
     currentDemoCategory = demoCategory;
 


### PR DESCRIPTION
Tapping a demo category on the home page causes the front-layer to cross-fade to the list of demos for that category. Previously a new route was pushed.
