### PR TITLE
Fix expectLater to not wrap the delegate in a guard

### DIFF
--- a/packages/flutter_test/lib/src/widget_tester.dart
+++ b/packages/flutter_test/lib/src/widget_tester.dart
@@ -174,9 +174,10 @@ Future<void> expectLater(dynamic actual, dynamic matcher, {
   String reason,
   dynamic skip, // true or a String
 }) {
-  return TestAsyncUtils.guard(() async {
-    await test_package.expectLater(actual, matcher, reason: reason, skip: skip);
-  });
+  // We can't wrap the delegate in a guard, or we'll hit async barriers in
+  // [TestWidgetsFlutterBinding] while we're waiting for the matcher to complete
+  TestAsyncUtils.guardSync();
+  return test_package.expectLater(actual, matcher, reason: reason, skip: skip);
 }
 
 /// Class that programmatically interacts with widgets and the test environment.

--- a/packages/flutter_test/test/widget_tester_test.dart
+++ b/packages/flutter_test/test/widget_tester_test.dart
@@ -20,7 +20,7 @@ void main() {
   group('expectLater', () {
     testWidgets('completes when matcher completes', (WidgetTester tester) async {
       final Completer<void> completer = new Completer<void>();
-      final Future<Null> future = expectLater(null, new FakeMatcher(completer));
+      final Future<void> future = expectLater(null, new FakeMatcher(completer));
       String value;
       future.then((void _) {
         value = '123';
@@ -31,19 +31,6 @@ void main() {
       await future;
       await tester.pump();
       test_package.expect(value, '123');
-    });
-
-    testWidgets('Prevents re-entrant calls', (WidgetTester tester) async {
-      final Completer<void> completer = new Completer<void>();
-      final Future<Null> future = expectLater(null, new FakeMatcher(completer));
-      try {
-        expectLater(null, new FakeMatcher(completer));
-        fail('FlutterError expected but not thrown');
-      } on FlutterError catch (error) {
-        completer.complete();
-        await future;
-        expect(error.message, contains('Guarded function conflict'));
-      }
     });
   });
 


### PR DESCRIPTION
Follow-up to https://github.com/flutter/flutter/pull/17063

https://github.com/flutter/flutter/issues/16859