### PR TITLE
Fix RenderView.paintBounds

### DIFF
--- a/packages/flutter/lib/src/rendering/view.dart
+++ b/packages/flutter/lib/src/rendering/view.dart
@@ -185,7 +185,7 @@ class RenderView extends RenderObject with RenderObjectWithChildMixin<RenderBox>
   }
 
   @override
-  Rect get paintBounds => Offset.zero & size;
+  Rect get paintBounds => Offset.zero & (size * configuration.devicePixelRatio);
 
   @override
   Rect get semanticBounds {


### PR DESCRIPTION
It should account for the device pixel ratio

https://github.com/flutter/flutter/issues/16859