### PR TITLE
Fix golden file matcher size calculation

### DIFF
--- a/packages/flutter_test/lib/src/matchers.dart
+++ b/packages/flutter_test/lib/src/matchers.dart
@@ -1235,7 +1235,7 @@ class _MatchesGoldenFile extends AsyncMatcher {
     }
     assert(!renderObject.debugNeedsPaint);
     final OffsetLayer layer = renderObject.layer;
-    final Future<ui.Image> imageFuture = layer.toImage(element.size);
+    final Future<ui.Image> imageFuture = layer.toImage(renderObject.paintBounds.size);
 
     final TestWidgetsFlutterBinding binding = TestWidgetsFlutterBinding.ensureInitialized();
     return binding.runAsync<String>(() async {


### PR DESCRIPTION
It was referring to `element`, while it was painting the render
object's layer (where render object no longer necessarily matched
element).

https://github.com/flutter/flutter/issues/16859