### PR TITLE
Simplify iOS debug build

### DIFF
--- a/packages/flutter_tools/bin/xcode_backend.sh
+++ b/packages/flutter_tools/bin/xcode_backend.sh
@@ -109,7 +109,7 @@ BuildApp() {
     preview_dart_2_flag="--no-preview-dart-2"
   fi
 
-  if [[ "$CURRENT_ARCH" != "x86_64" ]]; then
+  if [[ "${build_mode}" != "debug" ]]; then
     StreamOutput " ├─Building Dart code..."
     RunCommand "${FLUTTER_ROOT}/bin/flutter" --suppress-analytics           \
       ${verbose_flag}                                                       \
@@ -131,6 +131,7 @@ BuildApp() {
   else
     RunCommand mkdir -p -- "${derived_dir}/App.framework"
     RunCommand eval "$(echo "static const int Moo = 88;" | xcrun clang -x c \
+        -arch "$CURRENT_ARCH" \
         -dynamiclib \
         -Xlinker -rpath -Xlinker '@executable_path/Frameworks' \
         -Xlinker -rpath -Xlinker '@loader_path/Frameworks' \

--- a/packages/flutter_tools/lib/src/context_runner.dart
+++ b/packages/flutter_tools/lib/src/context_runner.dart
@@ -74,7 +74,6 @@ Future<T> runInContext<T>(
       Usage: () => new Usage(),
       Xcode: () => new Xcode(),
       XcodeProjectInterpreter: () => new XcodeProjectInterpreter(),
-      Xxd: () => new Xxd(),
     },
   );
 }

--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -39,8 +39,6 @@ IMobileDevice get iMobileDevice => context[IMobileDevice];
 
 Xcode get xcode => context[Xcode];
 
-Xxd get xxd => context[Xxd];
-
 class PythonModule {
   const PythonModule(this.name);
 
@@ -102,12 +100,6 @@ class IMobileDevice {
   /// Captures a screenshot to the specified outputFile.
   Future<Null> takeScreenshot(File outputFile) {
     return runCheckedAsync(<String>['idevicescreenshot', outputFile.path]);
-  }
-}
-
-class Xxd {
-  Future<RunResult> run(List<String> args, {String workingDirectory}) {
-    return runCheckedAsync(<String>['xxd']..addAll(args), workingDirectory: workingDirectory);
   }
 }
 


### PR DESCRIPTION
iOS debug builds always run in interpreted mode whether on device or on
simulator. In both cases, we can skip snapshotting and link against an
empty App.framework. Previously, we did this for iOS simulator builds.
This does the same for device builds.

Previously, debug iOS builds used gen_snapshot to generate a core
snapshot, then used 'xxd' to generate C files containing the snapshot
data in buffers named kDartVmSnapshotData and kDartIsolateSnapshotData,
which are then compiled/linked into App.framework. This is unnecessary
since the VM compiled into Flutter.framework already contains this data.