### PR TITLE
Eliminate hardcoding of no-sim-use-hardfp

### DIFF
--- a/packages/flutter_tools/lib/src/base/build.dart
+++ b/packages/flutter_tools/lib/src/base/build.dart
@@ -344,7 +344,6 @@ class Snapshotter {
         }
         if (platform == TargetPlatform.android_arm) {
           genSnapshotArgs.addAll(<String>[
-            '--no-sim-use-hardfp', // Android uses the softfloat ABI.
             '--no-use-integer-division', // Not supported by the Pixel in 32-bit mode.
           ]);
         }


### PR DESCRIPTION
This is now derived automatically from the target platform by
gen_snapshot.