### PR TITLE
Eliminate unnecessary params in assembly AOT

### DIFF
--- a/packages/flutter_tools/lib/src/base/build.dart
+++ b/packages/flutter_tools/lib/src/base/build.dart
@@ -249,12 +249,8 @@ class AOTSnapshotter {
     final List<String> inputPaths = <String>[uiPath, vmServicePath, vmEntryPoints, ioEntryPoints, mainPath];
     final Set<String> outputPaths = new Set<String>();
 
-    final String vmSnapshotData = fs.path.join(outputDir.path, 'vm_snapshot_data');
-    final String isolateSnapshotData = fs.path.join(outputDir.path, 'isolate_snapshot_data');
     final String depfilePath = fs.path.join(outputDir.path, 'snapshot.d');
     final List<String> genSnapshotArgs = <String>[
-      '--vm_snapshot_data=$vmSnapshotData',
-      '--isolate_snapshot_data=$isolateSnapshotData',
       '--url_mapping=dart:ui,$uiPath',
       '--url_mapping=dart:vmservice_io,$vmServicePath',
       '--embedder_entry_points_manifest=$vmEntryPoints',
@@ -286,11 +282,15 @@ class AOTSnapshotter {
       genSnapshotArgs.add('--assembly=$assembly');
     } else {
       // Blob AOT snapshot.
+      final String vmSnapshotData = fs.path.join(outputDir.path, 'vm_snapshot_data');
+      final String isolateSnapshotData = fs.path.join(outputDir.path, 'isolate_snapshot_data');
       final String vmSnapshotInstructions = fs.path.join(outputDir.path, 'vm_snapshot_instr');
       final String isolateSnapshotInstructions = fs.path.join(outputDir.path, 'isolate_snapshot_instr');
-      outputPaths.addAll(<String>[vmSnapshotData, isolateSnapshotData]);
+      outputPaths.addAll(<String>[vmSnapshotData, isolateSnapshotData, vmSnapshotInstructions, isolateSnapshotInstructions]);
       genSnapshotArgs.addAll(<String>[
         '--snapshot_kind=app-aot-blobs',
+        '--vm_snapshot_data=$vmSnapshotData',
+        '--isolate_snapshot_data=$isolateSnapshotData',
         '--vm_snapshot_instructions=$vmSnapshotInstructions',
         '--isolate_snapshot_instructions=$isolateSnapshotInstructions',
       ]);

--- a/packages/flutter_tools/test/base/build_test.dart
+++ b/packages/flutter_tools/test/base/build_test.dart
@@ -662,8 +662,6 @@ void main() {
       expect(genSnapshot.snapshotType.mode, BuildMode.profile);
       expect(genSnapshot.packagesPath, '.packages');
       expect(genSnapshot.additionalArgs, <String>[
-        '--vm_snapshot_data=${fs.path.join(outputPath, 'vm_snapshot_data')}',
-        '--isolate_snapshot_data=${fs.path.join(outputPath, 'isolate_snapshot_data')}',
         '--url_mapping=dart:ui,${fs.path.join(skyEnginePath, 'lib', 'ui', 'ui.dart')}',
         '--url_mapping=dart:vmservice_io,${fs.path.join(skyEnginePath, 'sdk_ext', 'vmservice_io.dart')}',
         '--embedder_entry_points_manifest=$kVmEntrypoints',
@@ -706,8 +704,6 @@ void main() {
       expect(genSnapshot.snapshotType.mode, BuildMode.release);
       expect(genSnapshot.packagesPath, '.packages');
       expect(genSnapshot.additionalArgs, <String>[
-        '--vm_snapshot_data=${fs.path.join(outputPath, 'vm_snapshot_data')}',
-        '--isolate_snapshot_data=${fs.path.join(outputPath, 'isolate_snapshot_data')}',
         '--url_mapping=dart:ui,${fs.path.join(skyEnginePath, 'lib', 'ui', 'ui.dart')}',
         '--url_mapping=dart:vmservice_io,${fs.path.join(skyEnginePath, 'sdk_ext', 'vmservice_io.dart')}',
         '--embedder_entry_points_manifest=$kVmEntrypoints',


### PR DESCRIPTION
Previously, we were incorrectly passing --vm_snapshot_data and
--isolate_snapshot_data options to gen_snapshot in assembly AOT builds.
These only make sense in AOT blob snapshot mode (alongside
--vm_snapshot_instructions and --isolate_snapshot_instructions).