### PR TITLE
Include kernel_compile.d in Gradle depfiles

### DIFF
--- a/packages/flutter_tools/gradle/flutter.gradle
+++ b/packages/flutter_tools/gradle/flutter.gradle
@@ -371,12 +371,20 @@ abstract class BaseFlutterTask extends DefaultTask {
     @Optional @Input
     String extraGenSnapshotOptions
 
-    @OutputFile
-    File getDependenciesFile() {
+    @OutputFiles
+    FileCollection getDependenciesFiles() {
         if (buildMode != 'debug') {
-            return project.file("${intermediateDir}/snapshot.d")
+            // For AOT builds, include the gen_snapshot depfile.
+            FileCollection depfiles = project.files("${intermediateDir}/snapshot.d")
+            if (previewDart2) {
+                // For Dart 2, also include the kernel compiler depfile, since
+                // kernel compile is the first stage of AOT build in this mode,
+                // and it includes all the Dart sources.
+                depfiles += project.files("${intermediateDir}/kernel_compile.d")
+            }
+            return depfiles
         }
-        return project.file("${intermediateDir}/snapshot_blob.bin.d")
+        return project.files("${intermediateDir}/snapshot_blob.bin.d")
     }
 
     void buildBundle() {
@@ -499,31 +507,27 @@ class FlutterTask extends BaseFlutterTask {
                 logger.error("Error reading dependency file ${dependenciesFile}: ${e}")
             }
         }
-        return null
+        return project.files()
     }
 
     @InputFiles
     FileCollection getSourceFiles() {
-        File dependenciesFile = getDependenciesFile()
-        FileCollection sources = readDependencies(dependenciesFile)
-        if (sources != null) {
+        FileCollection sources = project.files()
+        for (File depfile in getDependenciesFiles()) {
+          sources += readDependencies(depfile)
+        }
+        if (!sources.isEmpty()) {
             // We have a dependencies file. Add a dependency on gen_snapshot as well, since the
             // snapshots have to be rebuilt if it changes.
-            FileCollection snapshotter = readDependencies(project.file("${intermediateDir}/gen_snapshot.d"))
-            if (snapshotter != null) {
-                sources = sources.plus(snapshotter)
-            }
+            sources += readDependencies(project.file("${intermediateDir}/gen_snapshot.d"))
             if (previewDart2) {
-                FileCollection frontendServer = readDependencies(project.file("${intermediateDir}/frontend_server.d"))
-                if (frontendServer != null) {
-                    sources = sources.plus(frontendServer)
-                }
+                sources += readDependencies(project.file("${intermediateDir}/frontend_server.d"))
             }
             if (localEngineSrcPath != null) {
-                sources = sources.plus(project.files("$localEngineSrcPath/$localEngine"))
+                sources += project.files("$localEngineSrcPath/$localEngine")
             }
             // Finally, add a dependency on pubspec.yaml as well.
-            return sources.plus(project.files('pubspec.yaml'))
+            return sources + project.files('pubspec.yaml')
         }
         // No dependencies file (or problems parsing it). Fall back to source files.
         return project.fileTree(


### PR DESCRIPTION
This updates the Android build to declare the kernel compile depfile as
an output and its contents as inputs when running with --preview-dart-2
(the default mode).

The 'flutter build aot' command behaves differently depending on whether
it's running in Dart 1 or Dart 2 mode:

* Dart 1: the entrypoint Dart file (typically main.dart) is passed
  directly to gen_snapshot, which then emits snapshot.d, whose contents
  list the transitive closure of Dart dependencies (input files) for the
  snapshot. snapshot.d is a declared output, its contents (plus
  gen_snapshot itself) constitute the set of input files to the Gradle
  build action.

* Dart 2: then entrypoint Dart file (typically main.dart) is first
  compiled with the Dart kernel frontend. This emits kernel_compile.d,
  whose contents list the transitive closure of Dart dependencies (input
  files) for the kernel 'dill' output file. This 'dill' file is then
  passed to gen_snapshot, which emits snapshot.d, whose contents are
  empty. As of this change, both snapshot.d and kernel_compile.d are
  declared outputs, and their contents (plus gen_snapshot and the
  frontend compiler themselves) constitute the set of input files to the
  Gradle build action.

This fixes a bug wherein profile/release AOT outputs were not
invalidated due to snapshot.d being empty, and kernel_compile.d being
ignored. This was introduced during recent refactoring of the AOT build
code, wherein the kernel compile and gen_snapshot actions were changed
to emit independent depfiles (previously one stomped -- or failed to --
on the other's output).