### PR TITLE
Fix strong mode issue in _PosixUtils._which.

### DIFF
--- a/packages/flutter_tools/lib/src/base/os.dart
+++ b/packages/flutter_tools/lib/src/base/os.dart
@@ -91,7 +91,8 @@ class _PosixUtils extends OperatingSystemUtils {
     final ProcessResult result = processManager.runSync(command);
     if (result.exitCode != 0)
       return const <File>[];
-    return result.stdout.trim().split('\n').map((String path) => fs.file(path.trim())).toList();
+    final String stdout = result.stdout;
+    return stdout.trim().split('\n').map((String path) => fs.file(path.trim())).toList();
   }
 
   @override


### PR DESCRIPTION
ProcessResult.stdout has static type dynamic so for
inference to infer proper type argument for the map
invocation we need to cast stdout to String explicitly.

Fixes #17163