### PR TITLE
Pass --run-forever to flutter-tester to ensure it doesn't quit after executing main

### DIFF
--- a/packages/flutter_tools/lib/src/tester/flutter_tester.dart
+++ b/packages/flutter_tools/lib/src/tester/flutter_tester.dart
@@ -84,6 +84,9 @@ class FlutterTesterDevice extends Device {
   @override
   bool isSupported() => true;
 
+  bool _isRunning = false;
+  bool get isRunning => _isRunning;
+
   @override
   Future<LaunchResult> startApp(
     ApplicationPackage package, {
@@ -109,6 +112,7 @@ class FlutterTesterDevice extends Device {
 
     final List<String> command = <String>[
       shellPath,
+      '--run-forever',
       '--non-interactive',
       '--enable-dart-profiling',
       '--packages=${PackageMap.globalPackagesPath}',
@@ -147,7 +151,9 @@ class FlutterTesterDevice extends Device {
     try {
       printTrace(command.join(' '));
 
+      _isRunning = true;
       _process = await processManager.start(command);
+      _process.exitCode.then((_) => _isRunning = false);
       _process.stdout
           .transform(utf8.decoder)
           .transform(const LineSplitter())

--- a/packages/flutter_tools/test/integration/flutter_tester_test.dart
+++ b/packages/flutter_tools/test/integration/flutter_tester_test.dart
@@ -3,14 +3,18 @@
 // found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:convert';
 
 import 'package:file/file.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
+import 'package:flutter_tools/src/base/io.dart';
+import 'package:flutter_tools/src/base/process_manager.dart';
 import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/device.dart';
 import 'package:flutter_tools/src/tester/flutter_tester.dart';
 import 'package:test/test.dart';
 
+import '../src/common.dart';
 import '../src/context.dart';
 
 void main() {
@@ -70,6 +74,39 @@ void main() {
 
       expect(await device.stopApp(null), isTrue);
     });
+
+    testUsingContext('keeps running', () async {
+      _writePubspec();
+      _writePackages();
+      await _getPackages();
+
+      final String mainPath = fs.path.join('lib', 'main.dart');
+      _writeFile(mainPath, r'''
+import 'package:flutter/material.dart';
+
+void main() => runApp(new MyApp());
+
+class MyApp extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return new MaterialApp(
+      title: 'Flutter Demo',
+      home: new Container(),
+    );
+  }
+}
+''');
+
+      final LaunchResult result = await start(mainPath);
+
+      expect(result.started, isTrue);
+      expect(result.observatoryUri, isNotNull);
+
+      await new Future<void>.delayed(const Duration(seconds: 3));
+      expect(device.isRunning, true);
+
+      expect(await device.stopApp(null), isTrue);
+    });
   });
 }
 
@@ -92,4 +129,17 @@ dependencies:
   flutter:
     sdk: flutter
 ''');
+}
+
+Future<void> _getPackages() async {
+  final List<String> command = <String>[
+    fs.path.join(getFlutterRoot(), 'bin', 'flutter'),
+    'packages',
+    'get'
+  ];
+  final Process process = await processManager.start(command);
+  process.stderr.transform(utf8.decoder).listen(print);
+  final int exitCode = await process.exitCode;
+  if (exitCode != 0)
+    throw new Exception('flutter packages get failed');
 }

--- a/packages/flutter_tools/test/integration/flutter_tester_test.dart
+++ b/packages/flutter_tools/test/integration/flutter_tester_test.dart
@@ -138,8 +138,9 @@ Future<void> _getPackages() async {
     'get'
   ];
   final Process process = await processManager.start(command);
-  process.stderr.transform(utf8.decoder).listen(print);
+  final StringBuffer errorOutput = new StringBuffer();
+  process.stderr.transform(utf8.decoder).listen(errorOutput.write);
   final int exitCode = await process.exitCode;
   if (exitCode != 0)
-    throw new Exception('flutter packages get failed');
+    throw new Exception('flutter packages get failed: ${errorOutput.toString()}');
 }


### PR DESCRIPTION
This additional test uses an empty flutter app and waits for 3 seconds then checks the device process has not quit. Without the `--run-forever` flag the test will fail (note: it may be slow if you don't have the packages cached) on the expectation that `isRunning=true`. With `--run-forever` it will pass.

I don't know if these tests currently run on any servers anywhere, I'm just running manually.