### PR TITLE
Update dartdoc version to 0.19.0.

### DIFF
--- a/dev/bots/docs.sh
+++ b/dev/bots/docs.sh
@@ -22,7 +22,7 @@ if [ -d "$FLUTTER_PUB_CACHE" ]; then
 fi
 
 # Install dartdoc.
-bin/cache/dart-sdk/bin/pub global activate dartdoc 0.18.1
+bin/cache/dart-sdk/bin/pub global activate dartdoc 0.19.0
 
 # This script generates a unified doc set, and creates
 # a custom index.html, placing everything into dev/docs/doc.


### PR DESCRIPTION
This has virtually no impact to generated docs for flutter, it is just catching Flutter up to the latest release. All the big changes have to do with the new cross-package linking support.

Release notes:  https://github.com/dart-lang/dartdoc/releases/tag/v0.19.0

```
/tmp
$ diff -urN dartdoc-comparison-flutterEWEHMR/dev/docs/doc flutterJUTJRQ/dev/docs/doc
diff -urN dartdoc-comparison-flutterEWEHMR/dev/docs/doc/index.html flutterJUTJRQ/dev/docs/doc/index.html
--- dartdoc-comparison-flutterEWEHMR/dev/docs/doc/index.html	2018-05-02 08:49:41.285813170 -0700
+++ flutterJUTJRQ/dev/docs/doc/index.html	2018-05-02 08:46:06.267598556 -0700
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="generator" content="made with love by dartdoc 0.18.1">
+  <meta name="generator" content="made with love by dartdoc 0.19.0">
   <meta name="description" content="Flutter API docs, for the Dart programming language.">
   <title>Flutter - Dart API docs</title>
   <base href="./flutter/">
/tmp
$
```