### PR TITLE
Recommend upgrading to Cocoapods 1.5.0

### DIFF
--- a/packages/flutter_tools/lib/src/context_runner.dart
+++ b/packages/flutter_tools/lib/src/context_runner.dart
@@ -52,7 +52,7 @@ Future<T> runInContext<T>(
       BotDetector: () => const BotDetector(),
       Cache: () => new Cache(),
       Clock: () => const Clock(),
-      CocoaPods: () => const CocoaPods(),
+      CocoaPods: () => new CocoaPods(),
       Config: () => new Config(),
       DevFSConfig: () => new DevFSConfig(),
       DeviceManager: () => new DeviceManager(),

--- a/packages/flutter_tools/lib/src/ios/cocoapods.dart
+++ b/packages/flutter_tools/lib/src/ios/cocoapods.dart
@@ -143,6 +143,7 @@ class CocoaPods {
       );
       return false;
     }
+    
     return true;
   }
 

--- a/packages/flutter_tools/lib/src/ios/cocoapods.dart
+++ b/packages/flutter_tools/lib/src/ios/cocoapods.dart
@@ -143,7 +143,7 @@ class CocoaPods {
       );
       return false;
     }
-    
+
     return true;
   }
 

--- a/packages/flutter_tools/lib/src/ios/cocoapods.dart
+++ b/packages/flutter_tools/lib/src/ios/cocoapods.dart
@@ -33,25 +33,46 @@ const String cocoaPodsUpgradeInstructions = '''
 
 CocoaPods get cocoaPods => context[CocoaPods];
 
+/// Result of evaluating the CocoaPods installation.
+enum CocoaPodsStatus {
+  /// iOS plugins will not work, installation required.
+  notInstalled,
+  /// iOS plugins will not work, upgrade required.
+  belowMinimumVersion,
+  /// iOS plugins may not work in certain situations (Swift, static libraries),
+  /// upgrade recommended.
+  belowRecommendedVersion,
+  /// Everything should be fine.
+  recommended,
+}
+
 class CocoaPods {
-  const CocoaPods();
+  Future<String> _versionText;
 
-  Future<bool> get hasCocoaPods => exitsHappyAsync(<String>['pod', '--version']);
-
-  // TODO(mravn): Insist on 1.5.0 once build bots have that installed.
-  // Earlier versions do not work with Swift and static libraries.
   String get cocoaPodsMinimumVersion => '1.0.0';
+  String get cocoaPodsRecommendedVersion => '1.5.0';
 
-  Future<String> get cocoaPodsVersionText async => (await runAsync(<String>['pod', '--version'])).processResult.stdout.trim();
+  Future<String> get cocoaPodsVersionText {
+    _versionText ??= runAsync(<String>['pod', '--version']).then<String>((RunResult result) {
+      return result.exitCode == 0 ? result.stdout.trim() : null;
+    });
+    return _versionText;
+  }
 
-  Future<bool> get isCocoaPodsInstalledAndMeetsVersionCheck async {
-    if (!await hasCocoaPods)
-      return false;
+  Future<CocoaPodsStatus> get evaluateCocoaPodsInstallation async {
+    final String versionText = await cocoaPodsVersionText;
+    if (versionText == null)
+      return CocoaPodsStatus.notInstalled;
     try {
-      final Version installedVersion = new Version.parse(await cocoaPodsVersionText);
-      return installedVersion >= new Version.parse(cocoaPodsMinimumVersion);
+      final Version installedVersion = new Version.parse(versionText);
+      if (installedVersion < new Version.parse(cocoaPodsMinimumVersion))
+        return CocoaPodsStatus.belowMinimumVersion;
+      else if (installedVersion < new Version.parse(cocoaPodsRecommendedVersion))
+        return CocoaPodsStatus.belowRecommendedVersion;
+      else
+        return CocoaPodsStatus.recommended;
     } on FormatException {
-      return false;
+      return CocoaPodsStatus.notInstalled;
     }
   }
 
@@ -79,16 +100,37 @@ class CocoaPods {
 
   /// Make sure the CocoaPods tools are in the right states.
   Future<bool> _checkPodCondition() async {
-    if (!await isCocoaPodsInstalledAndMeetsVersionCheck) {
-      final String minimumVersion = cocoaPodsMinimumVersion;
-      printError(
-        'Warning: CocoaPods version $minimumVersion or greater not installed. Skipping pod install.\n'
-        '$noCocoaPodsConsequence\n'
-        'To install:\n'
-        '$cocoaPodsInstallInstructions\n',
-        emphasis: true,
-      );
-      return false;
+    final CocoaPodsStatus installation = await evaluateCocoaPodsInstallation;
+    switch (installation) {
+      case CocoaPodsStatus.notInstalled:
+        printError(
+          'Warning: CocoaPods not installed. Skipping pod install.\n'
+          '$noCocoaPodsConsequence\n'
+          'To install:\n'
+          '$cocoaPodsInstallInstructions\n',
+          emphasis: true,
+        );
+        return false;
+      case CocoaPodsStatus.belowMinimumVersion:
+        printError(
+          'Warning: CocoaPods minimum required version $cocoaPodsMinimumVersion or greater not installed. Skipping pod install.\n'
+          '$noCocoaPodsConsequence\n'
+          'To upgrade:\n'
+          '$cocoaPodsUpgradeInstructions\n',
+          emphasis: true,
+        );
+        return false;
+      case CocoaPodsStatus.belowRecommendedVersion:
+        printError(
+          'Warning: CocoaPods recommended version $cocoaPodsRecommendedVersion or greater not installed.\n'
+          'Pods handling may fail on some projects involving plugins.\n'
+          'To upgrade:\n'
+          '$cocoaPodsUpgradeInstructions\n',
+          emphasis: true,
+        );
+        break;
+      default:
+        break;
     }
     if (!await isCocoaPodsInitialized) {
       printError(
@@ -101,7 +143,6 @@ class CocoaPods {
       );
       return false;
     }
-
     return true;
   }
 
@@ -155,19 +196,20 @@ class CocoaPods {
 
   // Check if you need to run pod install.
   // The pod install will run if any of below is true.
-  // 1. The flutter.framework has changed (debug/release/profile)
-  // 2. The podfile.lock doesn't exist
-  // 3. The Pods/Manifest.lock doesn't exist (It is deleted when plugins change)
-  // 4. The podfile.lock doesn't match Pods/Manifest.lock.
+  // 1. Flutter dependencies have changed
+  // 2. Podfile.lock doesn't exist or is older than Podfile
+  // 3. Pods/Manifest.lock doesn't exist (It is deleted when plugins change)
+  // 4. Podfile.lock doesn't match Pods/Manifest.lock.
   bool _shouldRunPodInstall(Directory appIosDirectory, bool dependenciesChanged) {
     if (dependenciesChanged)
       return true;
-    // Check if podfile.lock and Pods/Manifest.lock exist and match.
+    final File podfileFile = appIosDirectory.childFile('Podfile');
     final File podfileLockFile = appIosDirectory.childFile('Podfile.lock');
     final File manifestLockFile =
         appIosDirectory.childFile(fs.path.join('Pods', 'Manifest.lock'));
     return !podfileLockFile.existsSync()
         || !manifestLockFile.existsSync()
+        || podfileLockFile.statSync().modified.isBefore(podfileFile.statSync().modified)
         || podfileLockFile.readAsStringSync() != manifestLockFile.readAsStringSync();
   }
 

--- a/packages/flutter_tools/lib/src/ios/ios_workflow.dart
+++ b/packages/flutter_tools/lib/src/ios/ios_workflow.dart
@@ -171,7 +171,9 @@ class IOSWorkflow extends DoctorValidator implements Workflow {
         }
       }
 
-      if (await cocoaPods.isCocoaPodsInstalledAndMeetsVersionCheck) {
+      final CocoaPodsStatus cocoaPodsStatus = await cocoaPods.evaluateCocoaPodsInstallation;
+
+      if (cocoaPodsStatus == CocoaPodsStatus.recommended) {
         if (await cocoaPods.isCocoaPodsInitialized) {
           messages.add(new ValidationMessage('CocoaPods version ${await cocoaPods.cocoaPodsVersionText}'));
         } else {
@@ -186,7 +188,7 @@ class IOSWorkflow extends DoctorValidator implements Workflow {
         }
       } else {
         brewStatus = ValidationType.partial;
-        if (!await cocoaPods.hasCocoaPods) {
+        if (cocoaPodsStatus == CocoaPodsStatus.notInstalled) {
           messages.add(new ValidationMessage.error(
             'CocoaPods not installed.\n'
             '$noCocoaPodsConsequence\n'
@@ -195,7 +197,7 @@ class IOSWorkflow extends DoctorValidator implements Workflow {
           ));
         } else {
           messages.add(new ValidationMessage.error(
-            'CocoaPods out of date ($cocoaPods.cocoaPodsMinimumVersion is required).\n'
+            'CocoaPods out of date (${cocoaPods.cocoaPodsRecommendedVersion} is recommended).\n'
             '$noCocoaPodsConsequence\n'
             'To upgrade:\n'
             '$cocoaPodsUpgradeInstructions'

--- a/packages/flutter_tools/lib/src/ios/ios_workflow.dart
+++ b/packages/flutter_tools/lib/src/ios/ios_workflow.dart
@@ -196,7 +196,7 @@ class IOSWorkflow extends DoctorValidator implements Workflow {
             '$cocoaPodsInstallInstructions'
           ));
         } else {
-          messages.add(new ValidationMessage.error(
+          messages.add(new ValidationMessage.hint(
             'CocoaPods out of date (${cocoaPods.cocoaPodsRecommendedVersion} is recommended).\n'
             '$noCocoaPodsConsequence\n'
             'To upgrade:\n'

--- a/packages/flutter_tools/lib/src/plugins.dart
+++ b/packages/flutter_tools/lib/src/plugins.dart
@@ -238,7 +238,7 @@ void injectPlugins({String directory}) {
     _writeAndroidPluginRegistrant(directory, plugins);
   if (fs.isDirectorySync(fs.path.join(directory, 'ios'))) {
     _writeIOSPluginRegistrant(directory, plugins);
-    const CocoaPods cocoaPods = const CocoaPods();
+    final CocoaPods cocoaPods = new CocoaPods();
     if (plugins.isNotEmpty)
       cocoaPods.setupPodfile(directory);
     if (changed)

--- a/packages/flutter_tools/templates/cocoapods/Podfile-objc
+++ b/packages/flutter_tools/templates/cocoapods/Podfile-objc
@@ -29,8 +29,8 @@ end
 target 'Runner' do
   # Prepare symlinks folder. We use symlinks to avoid having Podfile.lock
   # referring to absolute paths on developers' machines.
-  system('rm -rf Pods/.symlinks')
-  system('mkdir -p Pods/.symlinks/plugins')
+  system('rm -rf .symlinks')
+  system('mkdir -p .symlinks/plugins')
 
   # Flutter Pods
   generated_xcode_build_settings = parse_KV_file('./Flutter/Generated.xcconfig')
@@ -39,7 +39,7 @@ target 'Runner' do
   end
   generated_xcode_build_settings.map { |p|
     if p[:name] == 'FLUTTER_FRAMEWORK_DIR'
-      symlink = File.join('Pods', '.symlinks', 'flutter')
+      symlink = File.join('.symlinks', 'flutter')
       File.symlink(File.dirname(p[:path]), symlink)
       pod 'Flutter', :path => File.join(symlink, File.basename(p[:path]))
     end
@@ -48,7 +48,7 @@ target 'Runner' do
   # Plugin Pods
   plugin_pods = parse_KV_file('../.flutter-plugins')
   plugin_pods.map { |p|
-    symlink = File.join('Pods', '.symlinks', 'plugins', p[:name])
+    symlink = File.join('.symlinks', 'plugins', p[:name])
     File.symlink(p[:path], symlink)
     pod p[:name], :path => File.join(symlink, 'ios')
   }

--- a/packages/flutter_tools/templates/cocoapods/Podfile-swift
+++ b/packages/flutter_tools/templates/cocoapods/Podfile-swift
@@ -31,8 +31,8 @@ target 'Runner' do
 
   # Prepare symlinks folder. We use symlinks to avoid having Podfile.lock
   # referring to absolute paths on developers' machines.
-  system('rm -rf Pods/.symlinks')
-  system('mkdir -p Pods/.symlinks/plugins')
+  system('rm -rf .symlinks')
+  system('mkdir -p .symlinks/plugins')
 
   # Flutter Pods
   generated_xcode_build_settings = parse_KV_file('./Flutter/Generated.xcconfig')
@@ -41,7 +41,7 @@ target 'Runner' do
   end
   generated_xcode_build_settings.map { |p|
     if p[:name] == 'FLUTTER_FRAMEWORK_DIR'
-      symlink = File.join('Pods', '.symlinks', 'flutter')
+      symlink = File.join('.symlinks', 'flutter')
       File.symlink(File.dirname(p[:path]), symlink)
       pod 'Flutter', :path => File.join(symlink, File.basename(p[:path]))
     end
@@ -50,7 +50,7 @@ target 'Runner' do
   # Plugin Pods
   plugin_pods = parse_KV_file('../.flutter-plugins')
   plugin_pods.map { |p|
-    symlink = File.join('Pods', '.symlinks', 'plugins', p[:name])
+    symlink = File.join('.symlinks', 'plugins', p[:name])
     File.symlink(p[:path], symlink)
     pod p[:name], :path => File.join(symlink, 'ios')
   }

--- a/packages/flutter_tools/templates/create/ios.tmpl/.gitignore
+++ b/packages/flutter_tools/templates/create/ios.tmpl/.gitignore
@@ -42,3 +42,4 @@ Icon?
 /ServiceDefinitions.json
 
 Pods/
+.symlinks/

--- a/packages/flutter_tools/test/ios/cocoapods_test.dart
+++ b/packages/flutter_tools/test/ios/cocoapods_test.dart
@@ -386,7 +386,7 @@ Note: as of CocoaPods 1.0, `pod repo update` does not happen on `pod install` by
       projectUnderTest.childFile('Pods/Manifest.lock')
         ..createSync(recursive: true)
         ..writeAsString('Existing lock file.');
-      await new Future<void>.delayed(const Duration(milliseconds: 1));
+      await new Future<void>.delayed(const Duration(milliseconds: 10));
       projectUnderTest.childFile('Podfile')
         ..writeAsString('Updated Podfile');
       await cocoaPodsUnderTest.processPods(

--- a/packages/flutter_tools/test/ios/cocoapods_test.dart
+++ b/packages/flutter_tools/test/ios/cocoapods_test.dart
@@ -226,7 +226,7 @@ void main() {
     testUsingContext('throws, if specs repo is outdated.', () async {
       fs.file(fs.path.join('project', 'ios', 'Podfile'))
         ..createSync()
-        ..writeAsString('Existing Podfile');
+        ..writeAsStringSync('Existing Podfile');
 
       when(mockProcessManager.run(
         <String>['pod', 'install', '--verbose'],
@@ -272,10 +272,10 @@ Note: as of CocoaPods 1.0, `pod repo update` does not happen on `pod install` by
     testUsingContext('run pod install, if Podfile.lock is missing', () async {
       projectUnderTest.childFile('Podfile')
         ..createSync()
-        ..writeAsString('Existing Podfile');
+        ..writeAsStringSync('Existing Podfile');
       projectUnderTest.childFile('Pods/Manifest.lock')
         ..createSync(recursive: true)
-        ..writeAsString('Existing lock file.');
+        ..writeAsStringSync('Existing lock file.');
       final bool didInstall = await cocoaPodsUnderTest.processPods(
         appIosDirectory: projectUnderTest,
         iosEngineDir: 'engine/path',
@@ -295,10 +295,10 @@ Note: as of CocoaPods 1.0, `pod repo update` does not happen on `pod install` by
     testUsingContext('runs pod install, if Manifest.lock is missing', () async {
       projectUnderTest.childFile('Podfile')
         ..createSync()
-        ..writeAsString('Existing Podfile');
+        ..writeAsStringSync('Existing Podfile');
       projectUnderTest.childFile('Podfile.lock')
         ..createSync()
-        ..writeAsString('Existing lock file.');
+        ..writeAsStringSync('Existing lock file.');
       final bool didInstall = await cocoaPodsUnderTest.processPods(
         appIosDirectory: projectUnderTest,
         iosEngineDir: 'engine/path',
@@ -321,13 +321,13 @@ Note: as of CocoaPods 1.0, `pod repo update` does not happen on `pod install` by
     testUsingContext('runs pod install, if Manifest.lock different from Podspec.lock', () async {
       projectUnderTest.childFile('Podfile')
         ..createSync()
-        ..writeAsString('Existing Podfile');
+        ..writeAsStringSync('Existing Podfile');
       projectUnderTest.childFile('Podfile.lock')
         ..createSync()
-        ..writeAsString('Existing lock file.');
+        ..writeAsStringSync('Existing lock file.');
       projectUnderTest.childFile('Pods/Manifest.lock')
         ..createSync(recursive: true)
-        ..writeAsString('Different lock file.');
+        ..writeAsStringSync('Different lock file.');
       final bool didInstall = await cocoaPodsUnderTest.processPods(
         appIosDirectory: projectUnderTest,
         iosEngineDir: 'engine/path',
@@ -350,13 +350,13 @@ Note: as of CocoaPods 1.0, `pod repo update` does not happen on `pod install` by
     testUsingContext('runs pod install, if flutter framework changed', () async {
       projectUnderTest.childFile('Podfile')
         ..createSync()
-        ..writeAsString('Existing Podfile');
+        ..writeAsStringSync('Existing Podfile');
       projectUnderTest.childFile('Podfile.lock')
         ..createSync()
-        ..writeAsString('Existing lock file.');
+        ..writeAsStringSync('Existing lock file.');
       projectUnderTest.childFile('Pods/Manifest.lock')
         ..createSync(recursive: true)
-        ..writeAsString('Existing lock file.');
+        ..writeAsStringSync('Existing lock file.');
       final bool didInstall = await cocoaPodsUnderTest.processPods(
         appIosDirectory: projectUnderTest,
         iosEngineDir: 'engine/path',
@@ -379,16 +379,16 @@ Note: as of CocoaPods 1.0, `pod repo update` does not happen on `pod install` by
     testUsingContext('runs pod install, if Podfile.lock is older than Podfile', () async {
       projectUnderTest.childFile('Podfile')
         ..createSync()
-        ..writeAsString('Existing Podfile');
+        ..writeAsStringSync('Existing Podfile');
       projectUnderTest.childFile('Podfile.lock')
         ..createSync()
-        ..writeAsString('Existing lock file.');
+        ..writeAsStringSync('Existing lock file.');
       projectUnderTest.childFile('Pods/Manifest.lock')
         ..createSync(recursive: true)
-        ..writeAsString('Existing lock file.');
+        ..writeAsStringSync('Existing lock file.');
       await new Future<void>.delayed(const Duration(milliseconds: 10));
       projectUnderTest.childFile('Podfile')
-        ..writeAsString('Updated Podfile');
+        ..writeAsStringSync('Updated Podfile');
       await cocoaPodsUnderTest.processPods(
         appIosDirectory: projectUnderTest,
         iosEngineDir: 'engine/path',
@@ -410,13 +410,13 @@ Note: as of CocoaPods 1.0, `pod repo update` does not happen on `pod install` by
     testUsingContext('skips pod install, if nothing changed', () async {
       projectUnderTest.childFile('Podfile')
         ..createSync()
-        ..writeAsString('Existing Podfile');
+        ..writeAsStringSync('Existing Podfile');
       projectUnderTest.childFile('Podfile.lock')
         ..createSync()
-        ..writeAsString('Existing lock file.');
+        ..writeAsStringSync('Existing lock file.');
       projectUnderTest.childFile('Pods/Manifest.lock')
         ..createSync(recursive: true)
-        ..writeAsString('Existing lock file.');
+        ..writeAsStringSync('Existing lock file.');
       final bool didInstall = await cocoaPodsUnderTest.processPods(
         appIosDirectory: projectUnderTest,
         iosEngineDir: 'engine/path',
@@ -436,13 +436,13 @@ Note: as of CocoaPods 1.0, `pod repo update` does not happen on `pod install` by
     testUsingContext('a failed pod install deletes Pods/Manifest.lock', () async {
       projectUnderTest.childFile('Podfile')
         ..createSync()
-        ..writeAsString('Existing Podfile');
+        ..writeAsStringSync('Existing Podfile');
       projectUnderTest.childFile('Podfile.lock')
         ..createSync()
-        ..writeAsString('Existing lock file.');
+        ..writeAsStringSync('Existing lock file.');
       projectUnderTest.childFile('Pods/Manifest.lock')
         ..createSync(recursive: true)
-        ..writeAsString('Existing lock file.');
+        ..writeAsStringSync('Existing lock file.');
 
       when(mockProcessManager.run(
         <String>['pod', 'install', '--verbose'],

--- a/packages/flutter_tools/test/ios/cocoapods_test.dart
+++ b/packages/flutter_tools/test/ios/cocoapods_test.dart
@@ -23,6 +23,7 @@ void main() {
   MockXcodeProjectInterpreter mockXcodeProjectInterpreter;
   Directory projectUnderTest;
   CocoaPods cocoaPodsUnderTest;
+  ProcessResult resultOfPodVersion;
 
   setUp(() {
     Cache.flutterRoot = 'flutter';
@@ -30,7 +31,8 @@ void main() {
     mockProcessManager = new MockProcessManager();
     mockXcodeProjectInterpreter = new MockXcodeProjectInterpreter();
     projectUnderTest = fs.directory(fs.path.join('project', 'ios'))..createSync(recursive: true);
-
+    cocoaPodsUnderTest = new CocoaPods();
+    resultOfPodVersion = exitsHappy('1.5.0');
     fs.file(fs.path.join(
       Cache.flutterRoot, 'packages', 'flutter_tools', 'templates', 'cocoapods', 'Podfile-objc'
     ))
@@ -41,30 +43,86 @@ void main() {
     ))
         ..createSync(recursive: true)
         ..writeAsStringSync('Swift podfile template');
-    cocoaPodsUnderTest = const TestCocoaPods();
-
+    fs.directory(fs.path.join(homeDirPath, '.cocoapods', 'repos', 'master')).createSync(recursive: true);
+    when(mockProcessManager.run(
+      <String>['pod', '--version'],
+      workingDirectory: any,
+      environment: any,
+    )).thenAnswer((_) async => resultOfPodVersion);
     when(mockProcessManager.run(
       <String>['pod', 'install', '--verbose'],
       workingDirectory: 'project/ios',
       environment: <String, String>{'FLUTTER_FRAMEWORK_DIR': 'engine/path', 'COCOAPODS_DISABLE_STATS': 'true'},
-    )).thenAnswer((_) => new Future<ProcessResult>.value(exitsHappy));
+    )).thenAnswer((_) async => exitsHappy());
+  });
+
+  void pretendPodIsNotInstalled() {
+    resultOfPodVersion = exitsWithError();
+  }
+
+  void pretendPodVersionIs(String versionText) {
+    resultOfPodVersion = exitsHappy(versionText);
+  }
+
+  group('Evaluate installation', () {
+    testUsingContext('detects not installed', () async {
+      pretendPodIsNotInstalled();
+      expect(await cocoaPodsUnderTest.evaluateCocoaPodsInstallation, CocoaPodsStatus.notInstalled);
+    }, overrides: <Type, Generator>{
+      ProcessManager: () => mockProcessManager,
+    });
+
+    testUsingContext('detects installed', () async {
+      pretendPodVersionIs('0.0.1');
+      expect(await cocoaPodsUnderTest.evaluateCocoaPodsInstallation, isNot(CocoaPodsStatus.notInstalled));
+    }, overrides: <Type, Generator>{
+      ProcessManager: () => mockProcessManager,
+    });
+
+    testUsingContext('detects below minimum version', () async {
+      pretendPodVersionIs('0.39.8');
+      expect(await cocoaPodsUnderTest.evaluateCocoaPodsInstallation, CocoaPodsStatus.belowMinimumVersion);
+    }, overrides: <Type, Generator>{
+      ProcessManager: () => mockProcessManager,
+    });
+
+    testUsingContext('detects below recommended version', () async {
+      pretendPodVersionIs('1.4.99');
+      expect(await cocoaPodsUnderTest.evaluateCocoaPodsInstallation, CocoaPodsStatus.belowRecommendedVersion);
+    }, overrides: <Type, Generator>{
+      ProcessManager: () => mockProcessManager,
+    });
+
+    testUsingContext('detects at recommended version', () async {
+      pretendPodVersionIs('1.5.0');
+      expect(await cocoaPodsUnderTest.evaluateCocoaPodsInstallation, CocoaPodsStatus.recommended);
+    }, overrides: <Type, Generator>{
+      ProcessManager: () => mockProcessManager,
+    });
+
+    testUsingContext('detects above recommended version', () async {
+      pretendPodVersionIs('1.5.1');
+      expect(await cocoaPodsUnderTest.evaluateCocoaPodsInstallation, CocoaPodsStatus.recommended);
+    }, overrides: <Type, Generator>{
+      ProcessManager: () => mockProcessManager,
+    });
   });
 
   group('Setup Podfile', () {
-    File podfile;
+    File podFile;
     File debugConfigFile;
     File releaseConfigFile;
 
     setUp(() {
       debugConfigFile = fs.file(fs.path.join('project', 'ios', 'Flutter', 'Debug.xcconfig'));
       releaseConfigFile = fs.file(fs.path.join('project', 'ios', 'Flutter', 'Release.xcconfig'));
-      podfile = fs.file(fs.path.join('project', 'ios', 'Podfile'));
+      podFile = fs.file(fs.path.join('project', 'ios', 'Podfile'));
     });
 
     testUsingContext('creates objective-c Podfile when not present', () {
       cocoaPodsUnderTest.setupPodfile('project');
 
-      expect(podfile.readAsStringSync(), 'Objective-C podfile template');
+      expect(podFile.readAsStringSync(), 'Objective-C podfile template');
     }, overrides: <Type, Generator>{
       FileSystem: () => fs,
     });
@@ -77,18 +135,18 @@ void main() {
 
       cocoaPodsUnderTest.setupPodfile('project');
 
-      expect(podfile.readAsStringSync(), 'Swift podfile template');
+      expect(podFile.readAsStringSync(), 'Swift podfile template');
     }, overrides: <Type, Generator>{
       FileSystem: () => fs,
       XcodeProjectInterpreter: () => mockXcodeProjectInterpreter,
     });
 
     testUsingContext('does not recreate Podfile when already present', () {
-      podfile..createSync()..writeAsStringSync('Existing Podfile');
+      podFile..createSync()..writeAsStringSync('Existing Podfile');
 
       cocoaPodsUnderTest.setupPodfile('project');
 
-      expect(podfile.readAsStringSync(), 'Existing Podfile');
+      expect(podFile.readAsStringSync(), 'Existing Podfile');
     }, overrides: <Type, Generator>{
       FileSystem: () => fs,
     });
@@ -98,14 +156,14 @@ void main() {
 
       cocoaPodsUnderTest.setupPodfile('project');
 
-      expect(podfile.existsSync(), false);
+      expect(podFile.existsSync(), false);
     }, overrides: <Type, Generator>{
       FileSystem: () => fs,
       XcodeProjectInterpreter: () => mockXcodeProjectInterpreter,
     });
 
     testUsingContext('includes Pod config in xcconfig files, if not present', () {
-      podfile..createSync()..writeAsStringSync('Existing Podfile');
+      podFile..createSync()..writeAsStringSync('Existing Podfile');
       debugConfigFile..createSync(recursive: true)..writeAsStringSync('Existing debug config');
       releaseConfigFile..createSync(recursive: true)..writeAsStringSync('Existing release config');
 
@@ -126,14 +184,14 @@ void main() {
 
   group('Process pods', () {
     testUsingContext('prints error, if CocoaPods is not installed', () async {
+      pretendPodIsNotInstalled();
       projectUnderTest.childFile('Podfile').createSync();
-      cocoaPodsUnderTest = const TestCocoaPods(false);
       final bool didInstall = await cocoaPodsUnderTest.processPods(
         appIosDirectory: projectUnderTest,
         iosEngineDir: 'engine/path',
       );
       verifyNever(mockProcessManager.run(
-        typed<List<String>>(any),
+        argThat(containsAllInOrder(<String>['pod', 'install'])),
         workingDirectory: any,
         environment: typed<Map<String, String>>(any, named: 'environment'),
       ));
@@ -146,7 +204,6 @@ void main() {
     });
 
     testUsingContext('throws, if Podfile is missing.', () async {
-      cocoaPodsUnderTest = const TestCocoaPods(true);
       try {
         await cocoaPodsUnderTest.processPods(
           appIosDirectory: projectUnderTest,
@@ -156,7 +213,7 @@ void main() {
       } catch(e) {
         expect(e, const isInstanceOf<ToolExit>());
         verifyNever(mockProcessManager.run(
-          typed<List<String>>(any),
+          argThat(containsAllInOrder(<String>['pod', 'install'])),
           workingDirectory: any,
           environment: typed<Map<String, String>>(any, named: 'environment'),
         ));
@@ -178,9 +235,7 @@ void main() {
           'FLUTTER_FRAMEWORK_DIR': 'engine/path',
           'COCOAPODS_DISABLE_STATS': 'true',
         },
-      )).thenAnswer((_) => new Future<ProcessResult>.value(new ProcessResult(
-        1,
-        1,
+      )).thenAnswer((_) async => exitsWithError(
         '''
 [!] Unable to satisfy the following requirements:
 
@@ -195,8 +250,7 @@ You have either:
  * not added the source repo that hosts the Podspec to your Podfile.
 
 Note: as of CocoaPods 1.0, `pod repo update` does not happen on `pod install` by default.''',
-        '',
-      )));
+      ));
       try {
         await cocoaPodsUnderTest.processPods(
           appIosDirectory: projectUnderTest,
@@ -322,6 +376,37 @@ Note: as of CocoaPods 1.0, `pod repo update` does not happen on `pod install` by
       ProcessManager: () => mockProcessManager,
     });
 
+    testUsingContext('runs pod install, if Podfile.lock is older than Podfile', () async {
+      projectUnderTest.childFile('Podfile')
+        ..createSync()
+        ..writeAsString('Existing Podfile');
+      projectUnderTest.childFile('Podfile.lock')
+        ..createSync()
+        ..writeAsString('Existing lock file.');
+      projectUnderTest.childFile('Pods/Manifest.lock')
+        ..createSync(recursive: true)
+        ..writeAsString('Existing lock file.');
+      await new Future<void>.delayed(const Duration(milliseconds: 1));
+      projectUnderTest.childFile('Podfile')
+        ..writeAsString('Updated Podfile');
+      await cocoaPodsUnderTest.processPods(
+        appIosDirectory: projectUnderTest,
+        iosEngineDir: 'engine/path',
+        dependenciesChanged: false,
+      );
+      verify(mockProcessManager.run(
+        <String>['pod', 'install', '--verbose'],
+        workingDirectory: 'project/ios',
+        environment: <String, String>{
+          'FLUTTER_FRAMEWORK_DIR': 'engine/path',
+          'COCOAPODS_DISABLE_STATS': 'true',
+        },
+      ));
+    }, overrides: <Type, Generator>{
+      FileSystem: () => fs,
+      ProcessManager: () => mockProcessManager,
+    });
+
     testUsingContext('skips pod install, if nothing changed', () async {
       projectUnderTest.childFile('Podfile')
         ..createSync()
@@ -339,7 +424,7 @@ Note: as of CocoaPods 1.0, `pod repo update` does not happen on `pod install` by
       );
       expect(didInstall, isFalse);
       verifyNever(mockProcessManager.run(
-        typed<List<String>>(any),
+        argThat(containsAllInOrder(<String>['pod', 'install'])),
         workingDirectory: any,
         environment: typed<Map<String, String>>(any, named: 'environment'),
       ));
@@ -367,9 +452,7 @@ Note: as of CocoaPods 1.0, `pod repo update` does not happen on `pod install` by
           'COCOAPODS_DISABLE_STATS': 'true',
         },
       )).thenAnswer(
-        (_) => new Future<ProcessResult>.value(
-          new ProcessResult(1, 1, 'fails for some reason', '')
-        )
+        (_) async => exitsWithError()
       );
 
       try {
@@ -392,24 +475,5 @@ Note: as of CocoaPods 1.0, `pod repo update` does not happen on `pod install` by
 class MockProcessManager extends Mock implements ProcessManager {}
 class MockXcodeProjectInterpreter extends Mock implements XcodeProjectInterpreter {}
 
-class TestCocoaPods extends CocoaPods {
-  const TestCocoaPods([this._hasCocoaPods = true]);
-
-  final bool _hasCocoaPods;
-
-  @override
-  Future<bool> get hasCocoaPods => new Future<bool>.value(_hasCocoaPods);
-
-  @override
-  Future<String> get cocoaPodsVersionText async => new Future<String>.value('1.5.0');
-
-  @override
-  Future<bool> get isCocoaPodsInitialized => new Future<bool>.value(true);
-}
-
-final ProcessResult exitsHappy = new ProcessResult(
-  1, // pid
-  0, // exitCode
-  '', // stdout
-  '', // stderr
-);
+ProcessResult exitsWithError([String stdout = '']) => new ProcessResult(1, 1, stdout, '');
+ProcessResult exitsHappy([String stdout = '']) => new ProcessResult(1, 0, stdout, '');

--- a/packages/flutter_tools/test/ios/ios_workflow_test.dart
+++ b/packages/flutter_tools/test/ios/ios_workflow_test.dart
@@ -33,10 +33,10 @@ void main() {
       cocoaPods = new MockCocoaPods();
       fs = new MemoryFileSystem();
 
-      when(cocoaPods.isCocoaPodsInstalledAndMeetsVersionCheck)
-          .thenAnswer((_) => new Future<bool>.value(true));
-      when(cocoaPods.isCocoaPodsInitialized)
-          .thenAnswer((_) => new Future<bool>.value(true));
+      when(cocoaPods.evaluateCocoaPodsInstallation)
+          .thenAnswer((_) async => CocoaPodsStatus.recommended);
+      when(cocoaPods.isCocoaPodsInitialized).thenAnswer((_) async => true);
+      when(cocoaPods.cocoaPodsVersionText).thenAnswer((_) async => '1.8.0');
     });
 
     testUsingContext('Emit missing status when nothing is installed', () async {
@@ -213,9 +213,8 @@ void main() {
           .thenReturn('Xcode 8.2.1\nBuild version 8C1002\n');
       when(xcode.isInstalledAndMeetsVersionCheck).thenReturn(true);
       when(xcode.eulaSigned).thenReturn(true);
-      when(cocoaPods.isCocoaPodsInstalledAndMeetsVersionCheck)
-          .thenAnswer((_) => new Future<bool>.value(false));
-      when(cocoaPods.hasCocoaPods).thenAnswer((_) => new Future<bool>.value(false));
+      when(cocoaPods.evaluateCocoaPodsInstallation)
+          .thenAnswer((_) async => CocoaPodsStatus.notInstalled);
       when(xcode.isSimctlInstalled).thenReturn(true);
       final IOSWorkflowTestTarget workflow = new IOSWorkflowTestTarget();
       final ValidationResult result = await workflow.validate();
@@ -232,11 +231,8 @@ void main() {
           .thenReturn('Xcode 8.2.1\nBuild version 8C1002\n');
       when(xcode.isInstalledAndMeetsVersionCheck).thenReturn(true);
       when(xcode.eulaSigned).thenReturn(true);
-      when(cocoaPods.isCocoaPodsInstalledAndMeetsVersionCheck)
-          .thenAnswer((_) => new Future<bool>.value(false));
-      when(cocoaPods.hasCocoaPods).thenAnswer((_) => new Future<bool>.value(true));
-      when(cocoaPods.cocoaPodsVersionText)
-          .thenAnswer((_) => new Future<String>.value('0.39.0'));
+      when(cocoaPods.evaluateCocoaPodsInstallation)
+          .thenAnswer((_) async => CocoaPodsStatus.belowRecommendedVersion);
       when(xcode.isSimctlInstalled).thenReturn(true);
       final IOSWorkflowTestTarget workflow = new IOSWorkflowTestTarget();
       final ValidationResult result = await workflow.validate();
@@ -253,8 +249,6 @@ void main() {
           .thenReturn('Xcode 8.2.1\nBuild version 8C1002\n');
       when(xcode.isInstalledAndMeetsVersionCheck).thenReturn(true);
       when(xcode.eulaSigned).thenReturn(true);
-      when(cocoaPods.isCocoaPodsInstalledAndMeetsVersionCheck).thenAnswer((_) async => false);
-      when(cocoaPods.hasCocoaPods).thenAnswer((_) async => true);
       when(cocoaPods.isCocoaPodsInitialized).thenAnswer((_) async => false);
       when(xcode.isSimctlInstalled).thenReturn(true);
 


### PR DESCRIPTION
Retake of #16971, with the following changes:
* Report upgrade hint rather than error from `flutter doctor` when earlier version of Cocoapods is installed.
* Move plugin `.symlinks/` out of `Pods/` folder as it appears to cause build issues for some users (cf. #16036; possibly related to Ruby package version differences that cause Cocoapods 1.5.0 to have different behavior when faced with symbolic links.)