### PR TITLE
Renamed CI tasks

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -23,13 +23,18 @@ task:
       docs_script: ./dev/bots/docs.sh
     - name: analyze
       test_script: dart ./dev/bots/test.dart
-    - name: tests
+    - name: tests-linux
+      env:
+        SHARD: tests
       test_script: dart ./dev/bots/test.dart
       container:
         cpu: 4
         memory: 8G
 
-windows_task:
+task:
+  name: tests-windows
+  env:
+    SHARD: tests
   windows_container:
     dockerfile: dev/bots/docker/Dockerfile.windows
   env:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -5,7 +5,6 @@ task:
   env:
     CIRRUS_WORKING_DIR: "/tmp/flutter sdk"
     PATH: "$CIRRUS_WORKING_DIR/bin:$CIRRUS_WORKING_DIR/bin/cache/dart-sdk/bin:$PATH"
-    SHARD: "$CIRRUS_TASK_NAME"
 
   git_fetch_script: git fetch origin
   setup_script: |
@@ -20,8 +19,12 @@ task:
 
   matrix:
     - name: docs
+      env:
+        SHARD: docs
       docs_script: ./dev/bots/docs.sh
     - name: analyze
+      env:
+        SHARD: analyze
       test_script: dart ./dev/bots/test.dart
     - name: tests-linux
       env:


### PR DESCRIPTION
`tests` to `tests-linux`
`windows` to `tests-windows`

as suggested in https://github.com/flutter/flutter/pull/16224#issuecomment-386132454