### PR TITLE
Speed up AnimatedSwitcher.

### DIFF
--- a/examples/flutter_gallery/lib/gallery/home.dart
+++ b/examples/flutter_gallery/lib/gallery/home.dart
@@ -302,13 +302,6 @@ class _GalleryHomeState extends State<GalleryHome> with SingleTickerProviderStat
     super.dispose();
   }
 
-  static Widget _animatedSwitcherLayoutBuilder(List<Widget> children) {
-    return new Stack(
-      children: children,
-      alignment: Alignment.center,
-    );
-  }
-
   @override
   Widget build(BuildContext context) {
     final ThemeData theme = Theme.of(context);
@@ -338,7 +331,6 @@ class _GalleryHomeState extends State<GalleryHome> with SingleTickerProviderStat
               duration: _kFrontLayerSwitchDuration,
               switchOutCurve: switchOutCurve,
               switchInCurve: switchInCurve,
-              layoutBuilder: _animatedSwitcherLayoutBuilder,
               child: _category == null
                 ? const _FlutterLogo()
                 : new IconButton(
@@ -358,7 +350,6 @@ class _GalleryHomeState extends State<GalleryHome> with SingleTickerProviderStat
               duration: _kFrontLayerSwitchDuration,
               switchOutCurve: switchOutCurve,
               switchInCurve: switchInCurve,
-              layoutBuilder: _animatedSwitcherLayoutBuilder,
               child: _category != null
                 ? new _DemosPage(_category)
                 : new _CategoriesPage(

--- a/packages/flutter/lib/src/material/chip.dart
+++ b/packages/flutter/lib/src/material/chip.dart
@@ -514,13 +514,7 @@ class Chip extends StatelessWidget implements ChipAttributes, DeletableChipAttri
 ///  * [Wrap], A widget that displays its children in multiple horizontal or
 ///    vertical runs.
 ///  * <https://material.google.com/components/chips.html>
-class InputChip extends StatelessWidget
-    implements
-        ChipAttributes,
-        DeletableChipAttributes,
-        SelectableChipAttributes,
-        DisabledChipAttributes,
-        TappableChipAttributes {
+class InputChip extends StatelessWidget implements ChipAttributes, DeletableChipAttributes, SelectableChipAttributes, DisabledChipAttributes, TappableChipAttributes {
   /// Creates an [InputChip].
   ///
   /// The [onPressed] and [onSelected] callbacks must not both be specified at
@@ -667,11 +661,7 @@ class InputChip extends StatelessWidget
 ///  * [Wrap], A widget that displays its children in multiple horizontal or
 ///    vertical runs.
 ///  * <https://material.google.com/components/chips.html>
-class ChoiceChip extends StatelessWidget
-    implements
-        ChipAttributes,
-        SelectableChipAttributes,
-        DisabledChipAttributes {
+class ChoiceChip extends StatelessWidget implements ChipAttributes, SelectableChipAttributes, DisabledChipAttributes {
   /// Create a chip that acts like a radio button.
   ///
   /// The [label] and [selected] attributes must not be null.
@@ -830,11 +820,7 @@ class ChoiceChip extends StatelessWidget
 ///  * [Wrap], A widget that displays its children in multiple horizontal or
 ///    vertical runs.
 ///  * <https://material.google.com/components/chips.html>
-class FilterChip extends StatelessWidget
-    implements
-        ChipAttributes,
-        SelectableChipAttributes,
-        DisabledChipAttributes {
+class FilterChip extends StatelessWidget implements ChipAttributes, SelectableChipAttributes, DisabledChipAttributes {
   /// Create a chip that acts like a checkbox.
   ///
   /// The [selected] and [label] attributes must not be null.
@@ -968,10 +954,9 @@ class ActionChip extends StatelessWidget implements ChipAttributes, TappableChip
     this.padding,
   })  : assert(label != null),
         assert(
-          onPressed != null,
-          'Rather than disabling an ActionChip by setting onPressed to null, '
-          'remove it from the interface entirely.',
-        ),
+            onPressed != null,
+            'Rather than disabling an ActionChip by setting onPressed to null, '
+            'remove it from the interface entirely.',),
         super(key: key);
 
   @override
@@ -1041,13 +1026,7 @@ class ActionChip extends StatelessWidget implements ChipAttributes, TappableChip
 ///  * [Wrap], A widget that displays its children in multiple horizontal or
 ///    vertical runs.
 ///  * <https://material.google.com/components/chips.html>
-class RawChip extends StatefulWidget
-    implements
-        ChipAttributes,
-        DeletableChipAttributes,
-        SelectableChipAttributes,
-        DisabledChipAttributes,
-        TappableChipAttributes {
+class RawChip extends StatefulWidget implements ChipAttributes, DeletableChipAttributes, SelectableChipAttributes, DisabledChipAttributes, TappableChipAttributes {
   /// Creates a RawChip
   ///
   /// The [onPressed] and [onSelected] callbacks must not both be specified at
@@ -1161,9 +1140,7 @@ class _RawChipState extends State<RawChip> with TickerProviderStateMixin<RawChip
   bool get hasAvatar => widget.avatar != null;
 
   bool get canTap {
-    return widget.isEnabled
-        && widget.tapEnabled
-        && (widget.onPressed != null || widget.onSelected != null);
+    return widget.isEnabled && widget.tapEnabled && (widget.onPressed != null || widget.onSelected != null);
   }
 
   bool _isTapping = false;
@@ -1200,12 +1177,9 @@ class _RawChipState extends State<RawChip> with TickerProviderStateMixin<RawChip
 
     // These will delay the start of some animations, and/or reduce their
     // length compared to the overall select animation, using Intervals.
-    final double checkmarkPercentage = _kCheckmarkDuration.inMilliseconds /
-        _kSelectDuration.inMilliseconds;
-    final double checkmarkReversePercentage = _kCheckmarkReverseDuration.inMilliseconds /
-        _kSelectDuration.inMilliseconds;
-    final double avatarDrawerReversePercentage = _kReverseDrawerDuration.inMilliseconds /
-        _kSelectDuration.inMilliseconds;
+    final double checkmarkPercentage = _kCheckmarkDuration.inMilliseconds / _kSelectDuration.inMilliseconds;
+    final double checkmarkReversePercentage = _kCheckmarkReverseDuration.inMilliseconds / _kSelectDuration.inMilliseconds;
+    final double avatarDrawerReversePercentage = _kReverseDrawerDuration.inMilliseconds / _kSelectDuration.inMilliseconds;
     checkmarkAnimation = new CurvedAnimation(
       parent: selectController,
       curve: new Interval(1.0 - checkmarkPercentage, 1.0, curve: Curves.fastOutSlowIn),
@@ -1345,19 +1319,16 @@ class _RawChipState extends State<RawChip> with TickerProviderStateMixin<RawChip
     final IconThemeData iconThemeData = theme.iconTheme.copyWith(
       color: widget.deleteIconColor ?? chipTheme.deleteIconColor,
     );
-    return KeyedSubtree.wrap(
-      _wrapWithTooltip(
-        new InkResponse(
-          onTap: widget.isEnabled ? widget.onDeleted : null,
-          child: new IconTheme(
-            data: iconThemeData,
-            child: widget.deleteIcon,
-          ),
+    return _wrapWithTooltip(
+      new InkResponse(
+        onTap: widget.isEnabled ? widget.onDeleted : null,
+        child: new IconTheme(
+          data: iconThemeData,
+          child: widget.deleteIcon,
         ),
-        widget.deleteButtonTooltipMessage ?? MaterialLocalizations.of(context)?.deleteButtonTooltip,
-        widget.onDeleted,
       ),
-      hashValues(iconThemeData, widget.deleteIcon),
+      widget.deleteButtonTooltipMessage ?? MaterialLocalizations.of(context)?.deleteButtonTooltip,
+      widget.onDeleted,
     );
   }
 
@@ -1632,15 +1603,15 @@ class _ChipRenderTheme {
       return false;
     }
     final _ChipRenderTheme typedOther = other;
-    return typedOther.avatar == avatar
-        && typedOther.label == label
-        && typedOther.deleteIcon == deleteIcon
-        && typedOther.brightness == brightness
-        && typedOther.padding == padding
-        && typedOther.labelPadding == labelPadding
-        && typedOther.showAvatar == showAvatar
-        && typedOther.showCheckmark == showCheckmark
-        && typedOther.canTapBody == canTapBody;
+    return typedOther.avatar == avatar &&
+        typedOther.label == label &&
+        typedOther.deleteIcon == deleteIcon &&
+        typedOther.brightness == brightness &&
+        typedOther.padding == padding &&
+        typedOther.labelPadding == labelPadding &&
+        typedOther.showAvatar == showAvatar &&
+        typedOther.showCheckmark == showCheckmark &&
+        typedOther.canTapBody == canTapBody;
   }
 
   @override
@@ -1826,22 +1797,14 @@ class _RenderChip extends RenderBox {
     // The overall padding isn't affected by missing avatar or delete icon
     // because we add the padding regardless to give extra padding for the label
     // when they're missing.
-    final double overallPadding = theme.padding.horizontal +
-        theme.labelPadding.horizontal;
-    return overallPadding +
-        _minWidth(avatar, height) +
-        _minWidth(label, height) +
-        _minWidth(deleteIcon, height);
+    final double overallPadding = theme.padding.horizontal + theme.labelPadding.horizontal;
+    return overallPadding + _minWidth(avatar, height) + _minWidth(label, height) + _minWidth(deleteIcon, height);
   }
 
   @override
   double computeMaxIntrinsicWidth(double height) {
-    final double overallPadding = theme.padding.vertical +
-        theme.labelPadding.horizontal;
-    return overallPadding +
-        _maxWidth(avatar, height) +
-        _maxWidth(label, height) +
-        _maxWidth(deleteIcon, height);
+    final double overallPadding = theme.padding.vertical + theme.labelPadding.horizontal;
+    return overallPadding + _maxWidth(avatar, height) + _maxWidth(label, height) + _maxWidth(deleteIcon, height);
   }
 
   @override
@@ -2025,9 +1988,7 @@ class _RenderChip extends RenderBox {
           pressRect = new Rect.fromLTWH(
             0.0,
             0.0,
-            deleteIconShowing
-                ? start + theme.padding.left
-                : overallSize.width + theme.padding.horizontal,
+            deleteIconShowing ? start + theme.padding.left : overallSize.width + theme.padding.horizontal,
             overallSize.height + theme.padding.vertical,
           );
         } else {
@@ -2111,17 +2072,13 @@ class _RenderChip extends RenderBox {
 
     final ColorTween fadeTween = new ColorTween(begin: Colors.transparent, end: paintColor);
 
-    paintColor = checkmarkAnimation.status == AnimationStatus.reverse
-        ? fadeTween.evaluate(checkmarkAnimation)
-        : paintColor;
+    paintColor = checkmarkAnimation.status == AnimationStatus.reverse ? fadeTween.evaluate(checkmarkAnimation) : paintColor;
 
     final Paint paint = new Paint()
       ..color = paintColor
       ..style = PaintingStyle.stroke
       ..strokeWidth = _kCheckmarkStrokeWidth * (avatar != null ? avatar.size.height / 24.0 : 1.0);
-    final double t = checkmarkAnimation.status == AnimationStatus.reverse
-        ? 1.0
-        : checkmarkAnimation.value;
+    final double t = checkmarkAnimation.status == AnimationStatus.reverse ? 1.0 : checkmarkAnimation.value;
     if (t == 0.0) {
       // Nothing to draw.
       return;
@@ -2159,8 +2116,7 @@ class _RenderChip extends RenderBox {
       }
       // Need to make the check mark be a little smaller than the avatar.
       final double checkSize = avatar.size.height * 0.75;
-      final Offset checkOffset = _boxParentData(avatar).offset +
-          new Offset(avatar.size.height * 0.125, avatar.size.height * 0.125);
+      final Offset checkOffset = _boxParentData(avatar).offset + new Offset(avatar.size.height * 0.125, avatar.size.height * 0.125);
       _paintCheck(context.canvas, offset + checkOffset, checkSize);
     }
   }

--- a/packages/flutter/lib/src/material/chip.dart
+++ b/packages/flutter/lib/src/material/chip.dart
@@ -1342,18 +1342,22 @@ class _RawChipState extends State<RawChip> with TickerProviderStateMixin<RawChip
     if (!hasDeleteButton) {
       return null;
     }
-    return _wrapWithTooltip(
-      new InkResponse(
-        onTap: widget.isEnabled ? widget.onDeleted : null,
-        child: new IconTheme(
-          data: theme.iconTheme.copyWith(
-            color: (widget.deleteIconColor ?? chipTheme.deleteIconColor) ?? theme.iconTheme.color,
+    final IconThemeData iconThemeData = theme.iconTheme.copyWith(
+      color: widget.deleteIconColor ?? chipTheme.deleteIconColor,
+    );
+    return KeyedSubtree.wrap(
+      _wrapWithTooltip(
+        new InkResponse(
+          onTap: widget.isEnabled ? widget.onDeleted : null,
+          child: new IconTheme(
+            data: iconThemeData,
+            child: widget.deleteIcon,
           ),
-          child: widget.deleteIcon,
         ),
+        widget.deleteButtonTooltipMessage ?? MaterialLocalizations.of(context)?.deleteButtonTooltip,
+        widget.onDeleted,
       ),
-      widget.deleteButtonTooltipMessage ?? MaterialLocalizations.of(context)?.deleteButtonTooltip,
-      widget.onDeleted,
+      hashValues(iconThemeData, widget.deleteIcon),
     );
   }
 

--- a/packages/flutter/lib/src/material/chip.dart
+++ b/packages/flutter/lib/src/material/chip.dart
@@ -514,7 +514,13 @@ class Chip extends StatelessWidget implements ChipAttributes, DeletableChipAttri
 ///  * [Wrap], A widget that displays its children in multiple horizontal or
 ///    vertical runs.
 ///  * <https://material.google.com/components/chips.html>
-class InputChip extends StatelessWidget implements ChipAttributes, DeletableChipAttributes, SelectableChipAttributes, DisabledChipAttributes, TappableChipAttributes {
+class InputChip extends StatelessWidget
+    implements
+        ChipAttributes,
+        DeletableChipAttributes,
+        SelectableChipAttributes,
+        DisabledChipAttributes,
+        TappableChipAttributes {
   /// Creates an [InputChip].
   ///
   /// The [onPressed] and [onSelected] callbacks must not both be specified at
@@ -661,7 +667,11 @@ class InputChip extends StatelessWidget implements ChipAttributes, DeletableChip
 ///  * [Wrap], A widget that displays its children in multiple horizontal or
 ///    vertical runs.
 ///  * <https://material.google.com/components/chips.html>
-class ChoiceChip extends StatelessWidget implements ChipAttributes, SelectableChipAttributes, DisabledChipAttributes {
+class ChoiceChip extends StatelessWidget
+    implements
+        ChipAttributes,
+        SelectableChipAttributes,
+        DisabledChipAttributes {
   /// Create a chip that acts like a radio button.
   ///
   /// The [label] and [selected] attributes must not be null.
@@ -820,7 +830,11 @@ class ChoiceChip extends StatelessWidget implements ChipAttributes, SelectableCh
 ///  * [Wrap], A widget that displays its children in multiple horizontal or
 ///    vertical runs.
 ///  * <https://material.google.com/components/chips.html>
-class FilterChip extends StatelessWidget implements ChipAttributes, SelectableChipAttributes, DisabledChipAttributes {
+class FilterChip extends StatelessWidget
+    implements
+        ChipAttributes,
+        SelectableChipAttributes,
+        DisabledChipAttributes {
   /// Create a chip that acts like a checkbox.
   ///
   /// The [selected] and [label] attributes must not be null.
@@ -954,9 +968,10 @@ class ActionChip extends StatelessWidget implements ChipAttributes, TappableChip
     this.padding,
   })  : assert(label != null),
         assert(
-            onPressed != null,
-            'Rather than disabling an ActionChip by setting onPressed to null, '
-            'remove it from the interface entirely.',),
+          onPressed != null,
+          'Rather than disabling an ActionChip by setting onPressed to null, '
+          'remove it from the interface entirely.',
+        ),
         super(key: key);
 
   @override
@@ -1026,7 +1041,13 @@ class ActionChip extends StatelessWidget implements ChipAttributes, TappableChip
 ///  * [Wrap], A widget that displays its children in multiple horizontal or
 ///    vertical runs.
 ///  * <https://material.google.com/components/chips.html>
-class RawChip extends StatefulWidget implements ChipAttributes, DeletableChipAttributes, SelectableChipAttributes, DisabledChipAttributes, TappableChipAttributes {
+class RawChip extends StatefulWidget
+    implements
+        ChipAttributes,
+        DeletableChipAttributes,
+        SelectableChipAttributes,
+        DisabledChipAttributes,
+        TappableChipAttributes {
   /// Creates a RawChip
   ///
   /// The [onPressed] and [onSelected] callbacks must not both be specified at
@@ -1140,7 +1161,9 @@ class _RawChipState extends State<RawChip> with TickerProviderStateMixin<RawChip
   bool get hasAvatar => widget.avatar != null;
 
   bool get canTap {
-    return widget.isEnabled && widget.tapEnabled && (widget.onPressed != null || widget.onSelected != null);
+    return widget.isEnabled
+        && widget.tapEnabled
+        && (widget.onPressed != null || widget.onSelected != null);
   }
 
   bool _isTapping = false;
@@ -1177,9 +1200,12 @@ class _RawChipState extends State<RawChip> with TickerProviderStateMixin<RawChip
 
     // These will delay the start of some animations, and/or reduce their
     // length compared to the overall select animation, using Intervals.
-    final double checkmarkPercentage = _kCheckmarkDuration.inMilliseconds / _kSelectDuration.inMilliseconds;
-    final double checkmarkReversePercentage = _kCheckmarkReverseDuration.inMilliseconds / _kSelectDuration.inMilliseconds;
-    final double avatarDrawerReversePercentage = _kReverseDrawerDuration.inMilliseconds / _kSelectDuration.inMilliseconds;
+    final double checkmarkPercentage = _kCheckmarkDuration.inMilliseconds /
+        _kSelectDuration.inMilliseconds;
+    final double checkmarkReversePercentage = _kCheckmarkReverseDuration.inMilliseconds /
+        _kSelectDuration.inMilliseconds;
+    final double avatarDrawerReversePercentage = _kReverseDrawerDuration.inMilliseconds /
+        _kSelectDuration.inMilliseconds;
     checkmarkAnimation = new CurvedAnimation(
       parent: selectController,
       curve: new Interval(1.0 - checkmarkPercentage, 1.0, curve: Curves.fastOutSlowIn),
@@ -1302,7 +1328,7 @@ class _RawChipState extends State<RawChip> with TickerProviderStateMixin<RawChip
     }
   }
 
-  Widget _wrapWithTooltip(Widget child, String tooltip, VoidCallback callback) {
+  Widget _wrapWithTooltip(String tooltip, VoidCallback callback, Widget child) {
     if (child == null || callback == null || tooltip == null) {
       return child;
     }
@@ -1316,19 +1342,18 @@ class _RawChipState extends State<RawChip> with TickerProviderStateMixin<RawChip
     if (!hasDeleteButton) {
       return null;
     }
-    final IconThemeData iconThemeData = theme.iconTheme.copyWith(
-      color: widget.deleteIconColor ?? chipTheme.deleteIconColor,
-    );
     return _wrapWithTooltip(
+      widget.deleteButtonTooltipMessage ?? MaterialLocalizations.of(context)?.deleteButtonTooltip,
+      widget.onDeleted,
       new InkResponse(
         onTap: widget.isEnabled ? widget.onDeleted : null,
         child: new IconTheme(
-          data: iconThemeData,
+          data: theme.iconTheme.copyWith(
+            color: widget.deleteIconColor ?? chipTheme.deleteIconColor,
+          ),
           child: widget.deleteIcon,
         ),
       ),
-      widget.deleteButtonTooltipMessage ?? MaterialLocalizations.of(context)?.deleteButtonTooltip,
-      widget.onDeleted,
     );
   }
 
@@ -1363,42 +1388,43 @@ class _RawChipState extends State<RawChip> with TickerProviderStateMixin<RawChip
             );
           },
           child: _wrapWithTooltip(
-              new _ChipRenderWidget(
-                theme: new _ChipRenderTheme(
-                  label: new DefaultTextStyle(
-                    overflow: TextOverflow.fade,
-                    textAlign: TextAlign.start,
-                    maxLines: 1,
-                    softWrap: false,
-                    style: widget.labelStyle ?? chipTheme.labelStyle,
-                    child: widget.label,
-                  ),
-                  avatar: new AnimatedSwitcher(
-                    child: widget.avatar,
-                    duration: _kDrawerDuration,
-                    switchInCurve: Curves.fastOutSlowIn,
-                  ),
-                  deleteIcon: new AnimatedSwitcher(
-                    child: _buildDeleteIcon(context, theme, chipTheme),
-                    duration: _kDrawerDuration,
-                    switchInCurve: Curves.fastOutSlowIn,
-                  ),
-                  brightness: chipTheme.brightness,
-                  padding: (widget.padding ?? chipTheme.padding).resolve(textDirection),
-                  labelPadding: (widget.labelPadding ?? chipTheme.labelPadding).resolve(textDirection),
-                  showAvatar: hasAvatar,
-                  showCheckmark: widget.showCheckmark,
-                  canTapBody: canTap,
+            widget.tooltip,
+            widget.onPressed,
+            new _ChipRenderWidget(
+              theme: new _ChipRenderTheme(
+                label: new DefaultTextStyle(
+                  overflow: TextOverflow.fade,
+                  textAlign: TextAlign.start,
+                  maxLines: 1,
+                  softWrap: false,
+                  style: widget.labelStyle ?? chipTheme.labelStyle,
+                  child: widget.label,
                 ),
-                value: widget.selected,
-                checkmarkAnimation: checkmarkAnimation,
-                enableAnimation: enableAnimation,
-                avatarDrawerAnimation: avatarDrawerAnimation,
-                deleteDrawerAnimation: deleteDrawerAnimation,
-                isEnabled: widget.isEnabled,
+                avatar: new AnimatedSwitcher(
+                  child: widget.avatar,
+                  duration: _kDrawerDuration,
+                  switchInCurve: Curves.fastOutSlowIn,
+                ),
+                deleteIcon: new AnimatedSwitcher(
+                  child: _buildDeleteIcon(context, theme, chipTheme),
+                  duration: _kDrawerDuration,
+                  switchInCurve: Curves.fastOutSlowIn,
+                ),
+                brightness: chipTheme.brightness,
+                padding: (widget.padding ?? chipTheme.padding).resolve(textDirection),
+                labelPadding: (widget.labelPadding ?? chipTheme.labelPadding).resolve(textDirection),
+                showAvatar: hasAvatar,
+                showCheckmark: widget.showCheckmark,
+                canTapBody: canTap,
               ),
-              widget.tooltip,
-              widget.onPressed),
+              value: widget.selected,
+              checkmarkAnimation: checkmarkAnimation,
+              enableAnimation: enableAnimation,
+              avatarDrawerAnimation: avatarDrawerAnimation,
+              deleteDrawerAnimation: deleteDrawerAnimation,
+              isEnabled: widget.isEnabled,
+            ),
+          ),
         ),
       ),
     );
@@ -1603,15 +1629,15 @@ class _ChipRenderTheme {
       return false;
     }
     final _ChipRenderTheme typedOther = other;
-    return typedOther.avatar == avatar &&
-        typedOther.label == label &&
-        typedOther.deleteIcon == deleteIcon &&
-        typedOther.brightness == brightness &&
-        typedOther.padding == padding &&
-        typedOther.labelPadding == labelPadding &&
-        typedOther.showAvatar == showAvatar &&
-        typedOther.showCheckmark == showCheckmark &&
-        typedOther.canTapBody == canTapBody;
+    return typedOther.avatar == avatar
+        && typedOther.label == label
+        && typedOther.deleteIcon == deleteIcon
+        && typedOther.brightness == brightness
+        && typedOther.padding == padding
+        && typedOther.labelPadding == labelPadding
+        && typedOther.showAvatar == showAvatar
+        && typedOther.showCheckmark == showCheckmark
+        && typedOther.canTapBody == canTapBody;
   }
 
   @override
@@ -1797,14 +1823,22 @@ class _RenderChip extends RenderBox {
     // The overall padding isn't affected by missing avatar or delete icon
     // because we add the padding regardless to give extra padding for the label
     // when they're missing.
-    final double overallPadding = theme.padding.horizontal + theme.labelPadding.horizontal;
-    return overallPadding + _minWidth(avatar, height) + _minWidth(label, height) + _minWidth(deleteIcon, height);
+    final double overallPadding = theme.padding.horizontal +
+        theme.labelPadding.horizontal;
+    return overallPadding +
+        _minWidth(avatar, height) +
+        _minWidth(label, height) +
+        _minWidth(deleteIcon, height);
   }
 
   @override
   double computeMaxIntrinsicWidth(double height) {
-    final double overallPadding = theme.padding.vertical + theme.labelPadding.horizontal;
-    return overallPadding + _maxWidth(avatar, height) + _maxWidth(label, height) + _maxWidth(deleteIcon, height);
+    final double overallPadding = theme.padding.vertical +
+        theme.labelPadding.horizontal;
+    return overallPadding +
+        _maxWidth(avatar, height) +
+        _maxWidth(label, height) +
+        _maxWidth(deleteIcon, height);
   }
 
   @override
@@ -1988,7 +2022,9 @@ class _RenderChip extends RenderBox {
           pressRect = new Rect.fromLTWH(
             0.0,
             0.0,
-            deleteIconShowing ? start + theme.padding.left : overallSize.width + theme.padding.horizontal,
+            deleteIconShowing
+                ? start + theme.padding.left
+                : overallSize.width + theme.padding.horizontal,
             overallSize.height + theme.padding.vertical,
           );
         } else {
@@ -2072,13 +2108,17 @@ class _RenderChip extends RenderBox {
 
     final ColorTween fadeTween = new ColorTween(begin: Colors.transparent, end: paintColor);
 
-    paintColor = checkmarkAnimation.status == AnimationStatus.reverse ? fadeTween.evaluate(checkmarkAnimation) : paintColor;
+    paintColor = checkmarkAnimation.status == AnimationStatus.reverse
+        ? fadeTween.evaluate(checkmarkAnimation)
+        : paintColor;
 
     final Paint paint = new Paint()
       ..color = paintColor
       ..style = PaintingStyle.stroke
       ..strokeWidth = _kCheckmarkStrokeWidth * (avatar != null ? avatar.size.height / 24.0 : 1.0);
-    final double t = checkmarkAnimation.status == AnimationStatus.reverse ? 1.0 : checkmarkAnimation.value;
+    final double t = checkmarkAnimation.status == AnimationStatus.reverse
+        ? 1.0
+        : checkmarkAnimation.value;
     if (t == 0.0) {
       // Nothing to draw.
       return;
@@ -2116,7 +2156,8 @@ class _RenderChip extends RenderBox {
       }
       // Need to make the check mark be a little smaller than the avatar.
       final double checkSize = avatar.size.height * 0.75;
-      final Offset checkOffset = _boxParentData(avatar).offset + new Offset(avatar.size.height * 0.125, avatar.size.height * 0.125);
+      final Offset checkOffset = _boxParentData(avatar).offset +
+          new Offset(avatar.size.height * 0.125, avatar.size.height * 0.125);
       _paintCheck(context.canvas, offset + checkOffset, checkSize);
     }
   }

--- a/packages/flutter/lib/src/widgets/animated_switcher.dart
+++ b/packages/flutter/lib/src/widgets/animated_switcher.dart
@@ -217,8 +217,11 @@ class AnimatedSwitcher extends StatefulWidget {
   ///
   /// This is an [AnimatedSwitcherLayoutBuilder] function.
   static Widget defaultLayoutBuilder(Widget currentChild, List<Widget> previousChildren) {
+    List<Widget> children = previousChildren;
+    if (currentChild != null)
+      children = children.toList()..add(currentChild);
     return new Stack(
-      children: currentChild == null ? previousChildren : previousChildren + <Widget>[currentChild],
+      children: children,
       alignment: Alignment.center,
     );
   }
@@ -227,7 +230,7 @@ class AnimatedSwitcher extends StatefulWidget {
 class _AnimatedSwitcherState extends State<AnimatedSwitcher> with TickerProviderStateMixin {
   final Set<_AnimatedSwitcherChildEntry> _previousChildren = new Set<_AnimatedSwitcherChildEntry>();
   _AnimatedSwitcherChildEntry _currentChild;
-  List<Widget> _previousChildWidgetCache = new List<Widget>.unmodifiable(<Widget>[]);
+  List<Widget> _previousChildWidgetCache = const <Widget>[];
   int serialNumber = 0;
 
   @override
@@ -340,9 +343,10 @@ class _AnimatedSwitcherState extends State<AnimatedSwitcher> with TickerProvider
         hasNewChild && !Widget.canUpdate(widget.child, _currentChild.widgetChild)) {
       _addEntry(animate: true);
     } else {
-      // Make sure we update the child widget in _currentChild even if we're not
-      // going to start a new animation, but keep the key from the previous
-      // transition, since otherwise there is a huge performance penalty.
+      // Make sure we update the child widget and transition in _currentChild
+      // even if we're not going to start a new animation, but keep the key from
+      // the previous transition so that we update the transition instead of
+      // replacing it.
       if (_currentChild != null) {
         _currentChild.widgetChild = widget.child;
         _currentChild.transition = new KeyedSubtree(

--- a/packages/flutter/test/material/chip_test.dart
+++ b/packages/flutter/test/material/chip_test.dart
@@ -1029,10 +1029,10 @@ void main() {
       platform: TargetPlatform.android,
       primarySwatch: Colors.blue,
     );
-    final ChipThemeData chipTheme = themeData.chipTheme;
+    final ChipThemeData defaultChipTheme = themeData.chipTheme;
     bool value = false;
     Widget buildApp({
-      ChipThemeData theme,
+      ChipThemeData chipTheme,
       Widget avatar,
       Widget deleteIcon,
       bool isSelectable: true,
@@ -1040,12 +1040,12 @@ void main() {
       bool isDeletable: true,
       bool showCheckmark: true,
     }) {
-      theme ??= chipTheme;
+      chipTheme ??= defaultChipTheme;
       return _wrapForChip(
         child: new Theme(
           data: themeData,
           child: new ChipTheme(
-            data: theme,
+            data: chipTheme,
             child: new StatefulBuilder(builder: (BuildContext context, StateSetter setState) {
               return new RawChip(
                 showCheckmark: showCheckmark,
@@ -1054,7 +1054,7 @@ void main() {
                 avatar: avatar,
                 deleteIcon: deleteIcon,
                 isEnabled: isSelectable || isPressable,
-                shape: theme.shape,
+                shape: chipTheme.shape,
                 selected: isSelectable ? value : null,
                 label: new Text('$value'),
                 onSelected: isSelectable
@@ -1085,13 +1085,13 @@ void main() {
     DefaultTextStyle labelStyle = getLabelStyle(tester);
 
     // Check default theme for enabled widget.
-    expect(materialBox, paints..path(color: chipTheme.backgroundColor));
+    expect(materialBox, paints..path(color: defaultChipTheme.backgroundColor));
     expect(iconData.color, equals(const Color(0xde000000)));
     expect(labelStyle.style.color, equals(Colors.black.withAlpha(0xde)));
     await tester.tap(find.byType(RawChip));
     await tester.pumpAndSettle();
     materialBox = getMaterialBox(tester);
-    expect(materialBox, paints..path(color: chipTheme.selectedColor));
+    expect(materialBox, paints..path(color: defaultChipTheme.selectedColor));
     await tester.tap(find.byType(RawChip));
     await tester.pumpAndSettle();
 
@@ -1100,7 +1100,7 @@ void main() {
     await tester.pumpAndSettle();
     materialBox = getMaterialBox(tester);
     labelStyle = getLabelStyle(tester);
-    expect(materialBox, paints..path(color: chipTheme.disabledColor));
+    expect(materialBox, paints..path(color: defaultChipTheme.disabledColor));
     expect(labelStyle.style.color, equals(Colors.black.withAlpha(0xde)));
 
     // Apply a custom theme.
@@ -1108,14 +1108,14 @@ void main() {
     const Color customColor2 = const Color(0xdeadbeef);
     const Color customColor3 = const Color(0xbeefcafe);
     const Color customColor4 = const Color(0xaddedabe);
-    final ChipThemeData customTheme = chipTheme.copyWith(
+    final ChipThemeData customTheme = defaultChipTheme.copyWith(
       brightness: Brightness.dark,
       backgroundColor: customColor1,
       disabledColor: customColor2,
       selectedColor: customColor3,
       deleteIconColor: customColor4,
     );
-    await tester.pumpWidget(buildApp(theme: customTheme));
+    await tester.pumpWidget(buildApp(chipTheme: customTheme));
     await tester.pumpAndSettle();
     materialBox = getMaterialBox(tester);
     iconData = getIconData(tester);
@@ -1134,7 +1134,7 @@ void main() {
 
     // Check custom theme with disabled widget.
     await tester.pumpWidget(buildApp(
-      theme: customTheme,
+      chipTheme: customTheme,
       isSelectable: false,
       isPressable: false,
       isDeletable: true,

--- a/packages/flutter/test/widgets/animated_switcher_test.dart
+++ b/packages/flutter/test/widgets/animated_switcher_test.dart
@@ -190,8 +190,7 @@ void main() {
     final List<Widget> foundChildren = <Widget>[];
     Widget newLayoutBuilder(Widget currentChild, List<Widget> previousChildren) {
       foundChildren.clear();
-      if (currentChild != null)
-        foundChildren.add(currentChild);
+      if (currentChild != null) foundChildren.add(currentChild);
       foundChildren.addAll(previousChildren);
       return new Column(
         children: previousChildren,
@@ -301,6 +300,35 @@ void main() {
     expect(transition.opacity.value, closeTo(0.1, 0.01));
     await tester.pumpAndSettle();
     expect(StatefulTestState.generation, equals(3));
+  });
+
+  testWidgets('AnimatedSwitcher updates widgets without animating if they are isomorphic.', (WidgetTester tester) async {
+    Future<Null> pumpChild(Widget child) async {
+      return tester.pumpWidget(
+        new Directionality(
+          textDirection: TextDirection.rtl,
+          child: new AnimatedSwitcher(
+            duration: const Duration(milliseconds: 100),
+            child: child,
+            switchInCurve: Curves.linear,
+            switchOutCurve: Curves.linear,
+          ),
+        ),
+      );
+    }
+
+    await pumpChild(const Text('1'));
+    await tester.pump(const Duration(milliseconds: 10));
+    FadeTransition transition = tester.widget(find.byType(FadeTransition).first);
+    expect(transition.opacity.value, equals(1.0));
+    expect(find.text('1'), findsOneWidget);
+    expect(find.text('2'), findsNothing);
+    await pumpChild(const Text('2'));
+    transition = tester.widget(find.byType(FadeTransition).first);
+    await tester.pump(const Duration(milliseconds: 20));
+    expect(transition.opacity.value, equals(1.0));
+    expect(find.text('1'), findsNothing);
+    expect(find.text('2'), findsOneWidget);
   });
 }
 

--- a/packages/flutter/test/widgets/animated_switcher_test.dart
+++ b/packages/flutter/test/widgets/animated_switcher_test.dart
@@ -19,6 +19,7 @@ void main() {
       ),
     );
 
+    expect(find.byType(FadeTransition), findsOneWidget);
     FadeTransition transition = tester.firstWidget(find.byType(FadeTransition));
     expect(transition.opacity.value, equals(1.0));
 
@@ -32,6 +33,7 @@ void main() {
     );
 
     await tester.pump(const Duration(milliseconds: 50));
+    expect(find.byType(FadeTransition), findsNWidgets(2));
     transition = tester.firstWidget(find.byType(FadeTransition));
     expect(transition.opacity.value, equals(0.5));
 
@@ -64,6 +66,7 @@ void main() {
       ),
     );
 
+    expect(find.byType(FadeTransition), findsOneWidget);
     FadeTransition transition = tester.firstWidget(find.byType(FadeTransition));
     expect(transition.opacity.value, equals(1.0));
 
@@ -77,7 +80,8 @@ void main() {
     );
 
     await tester.pump(const Duration(milliseconds: 50));
-    transition = tester.widget(find.byType(FadeTransition));
+    expect(find.byType(FadeTransition), findsOneWidget);
+    transition = tester.firstWidget(find.byType(FadeTransition));
     expect(transition.opacity.value, equals(1.0));
     await tester.pumpAndSettle();
   });
@@ -117,6 +121,7 @@ void main() {
       ),
     );
 
+    expect(find.byType(FadeTransition), findsOneWidget);
     transition = tester.firstWidget(find.byType(FadeTransition));
     expect(transition.opacity.value, equals(1.0));
 
@@ -163,9 +168,9 @@ void main() {
   });
 
   testWidgets('AnimatedSwitcher uses custom layout.', (WidgetTester tester) async {
-    Widget newLayoutBuilder(List<Widget> children) {
+    Widget newLayoutBuilder(Widget currentChild, List<Widget> previousChildren) {
       return new Column(
-        children: children,
+        children: previousChildren + <Widget>[currentChild],
       );
     }
 
@@ -182,12 +187,14 @@ void main() {
   });
 
   testWidgets('AnimatedSwitcher uses custom transitions.', (WidgetTester tester) async {
-    final List<Widget> transitions = <Widget>[];
-    Widget newLayoutBuilder(List<Widget> children) {
-      transitions.clear();
-      transitions.addAll(children);
+    final List<Widget> foundChildren = <Widget>[];
+    Widget newLayoutBuilder(Widget currentChild, List<Widget> previousChildren) {
+      foundChildren.clear();
+      if (currentChild != null)
+        foundChildren.add(currentChild);
+      foundChildren.addAll(previousChildren);
       return new Column(
-        children: children,
+        children: previousChildren,
       );
     }
 
@@ -212,12 +219,108 @@ void main() {
     );
 
     expect(find.byType(Column), findsOneWidget);
-    for (Widget transition in transitions) {
-      expect(transition, const isInstanceOf<KeyedSubtree>());
+    for (Widget child in foundChildren) {
+      expect(child, const isInstanceOf<KeyedSubtree>());
+    }
+
+    await tester.pumpWidget(
+      new Directionality(
+        textDirection: TextDirection.rtl,
+        child: new AnimatedSwitcher(
+          duration: const Duration(milliseconds: 100),
+          child: null,
+          switchInCurve: Curves.linear,
+          layoutBuilder: newLayoutBuilder,
+          transitionBuilder: newTransitionBuilder,
+        ),
+      ),
+    );
+    await tester.pump(const Duration(milliseconds: 50));
+
+    for (Widget child in foundChildren) {
+      expect(child, const isInstanceOf<KeyedSubtree>());
       expect(
-        find.descendant(of: find.byWidget(transition), matching: find.byType(SizeTransition)),
+        find.descendant(of: find.byWidget(child), matching: find.byType(SizeTransition)),
         findsOneWidget,
       );
     }
   });
+
+  testWidgets("AnimatedSwitcher doesn't reset state of the children in transitions.", (WidgetTester tester) async {
+    final UniqueKey statefulOne = new UniqueKey();
+    final UniqueKey statefulTwo = new UniqueKey();
+    final UniqueKey statefulThree = new UniqueKey();
+
+    StatefulTestState.generation = 0;
+
+    await tester.pumpWidget(
+      new AnimatedSwitcher(
+        duration: const Duration(milliseconds: 100),
+        child: new StatefulTest(key: statefulOne),
+        switchInCurve: Curves.linear,
+        switchOutCurve: Curves.linear,
+      ),
+    );
+
+    expect(find.byType(FadeTransition), findsOneWidget);
+    FadeTransition transition = tester.firstWidget(find.byType(FadeTransition));
+    expect(transition.opacity.value, equals(1.0));
+    expect(StatefulTestState.generation, equals(1));
+
+    await tester.pumpWidget(
+      new AnimatedSwitcher(
+        duration: const Duration(milliseconds: 100),
+        child: new StatefulTest(key: statefulTwo),
+        switchInCurve: Curves.linear,
+        switchOutCurve: Curves.linear,
+      ),
+    );
+
+    await tester.pump(const Duration(milliseconds: 50));
+    expect(find.byType(FadeTransition), findsNWidgets(2));
+    transition = tester.firstWidget(find.byType(FadeTransition));
+    expect(transition.opacity.value, equals(0.5));
+    expect(StatefulTestState.generation, equals(2));
+
+    await tester.pumpWidget(
+      new AnimatedSwitcher(
+        duration: const Duration(milliseconds: 100),
+        child: new StatefulTest(key: statefulThree),
+        switchInCurve: Curves.linear,
+        switchOutCurve: Curves.linear,
+      ),
+    );
+
+    await tester.pump(const Duration(milliseconds: 10));
+    expect(StatefulTestState.generation, equals(3));
+    transition = tester.widget(find.byType(FadeTransition).at(0));
+    expect(transition.opacity.value, closeTo(0.4, 0.01));
+    transition = tester.widget(find.byType(FadeTransition).at(1));
+    expect(transition.opacity.value, closeTo(0.4, 0.01));
+    transition = tester.widget(find.byType(FadeTransition).at(2));
+    expect(transition.opacity.value, closeTo(0.1, 0.01));
+    await tester.pumpAndSettle();
+    expect(StatefulTestState.generation, equals(3));
+  });
+}
+
+class StatefulTest extends StatefulWidget {
+  const StatefulTest({Key key}) : super(key: key);
+
+  @override
+  StatefulTestState createState() => new StatefulTestState();
+}
+
+class StatefulTestState extends State<StatefulTest> {
+  StatefulTestState();
+  static int generation = 0;
+
+  @override
+  void initState() {
+    super.initState();
+    generation++;
+  }
+
+  @override
+  Widget build(BuildContext context) => new Container();
 }

--- a/packages/flutter/test/widgets/animated_switcher_test.dart
+++ b/packages/flutter/test/widgets/animated_switcher_test.dart
@@ -190,7 +190,9 @@ void main() {
     final List<Widget> foundChildren = <Widget>[];
     Widget newLayoutBuilder(Widget currentChild, List<Widget> previousChildren) {
       foundChildren.clear();
-      if (currentChild != null) foundChildren.add(currentChild);
+      if (currentChild != null) {
+        foundChildren.add(currentChild);
+      }
       foundChildren.addAll(previousChildren);
       return new Column(
         children: previousChildren,


### PR DESCRIPTION
This optimizes the AnimatedSwitcher so that it tags the right widget with its keyed subtree, and avoids rebuilding the transition unnecessarily.

This significantly improves the performance of Chips (which uses AnimatedSwitcher to swap out it's avatar and delete icon children).

Here's a graph of "before" and "after" this change for Chips (averaged over 10 seconds of frames for each number of chips: each chip has two animated switchers in it):
![chart 3](https://user-images.githubusercontent.com/8867023/39950441-f40df552-5535-11e8-80a0-ef88829d34f1.png)

