### PR TITLE
Follow-on work to goldens

### DIFF
--- a/dev/tools/dartdoc.dart
+++ b/dev/tools/dartdoc.dart
@@ -121,13 +121,15 @@ Future<Null> main(List<String> arguments) async {
     dartdocBaseArgs.add('--no-validate-links');
   }
   // Generate the documentation.
+  // We don't need to exclude flutter_tools in this list because it's not in the
+  // recursive dependencies of the package defined at dev/docs/pubspec.yaml
   final List<String> dartdocArgs = <String>[]..addAll(dartdocBaseArgs)..addAll(<String>[
     '--header', 'styles.html',
     '--header', 'analytics.html',
     '--header', 'survey.html',
     '--footer-text', 'lib/footer.html',
     '--exclude-packages',
-'analyzer,args,barback,cli_util,csslib,front_end,glob,html,http_multi_server,io,isolate,js,kernel,logging,mime,mockito,node_preamble,plugin,shelf,shelf_packages_handler,shelf_static,shelf_web_socket,utf,watcher,yaml',
+'analyzer,args,barback,cli_util,csslib,flutter_goldens,front_end,glob,html,http_multi_server,io,isolate,js,kernel,logging,mime,mockito,node_preamble,plugin,shelf,shelf_packages_handler,shelf_static,shelf_web_socket,utf,watcher,yaml',
     '--exclude',
   'package:Flutter/temp_doc.dart,package:http/browser_client.dart,package:intl/intl_browser.dart,package:matcher/mirror_matchers.dart,package:quiver/mirrors.dart,package:quiver/io.dart,package:vm_service_client/vm_service_client.dart,package:web_socket_channel/html.dart',
     '--favicon=favicon.ico',

--- a/packages/flutter_goldens/lib/flutter_goldens.dart
+++ b/packages/flutter_goldens/lib/flutter_goldens.dart
@@ -35,15 +35,21 @@ Future<void> main(FutureOr<void> testMain()) async {
 /// the `$FLUTTER_ROOT/bin/cache/pkg/goldens` folder, then perform the comparison against
 /// the files therein.
 class FlutterGoldenFileComparator implements GoldenFileComparator {
+  /// Creates a [FlutterGoldenFileComparator] that will resolve golden file
+  /// URIs relative to the specified [basedir].
+  ///
+  /// The [fs] parameter exists for testing purposes only.
   @visibleForTesting
   FlutterGoldenFileComparator(
-    this.goldens,
     this.basedir, {
     this.fs: const LocalFileSystem(),
   });
 
-  final GoldensClient goldens;
+  /// The directory to which golden file URIs will be resolved in [compare] and [update].
   final Uri basedir;
+
+  /// The file system used to perform file access.
+  @visibleForTesting
   final FileSystem fs;
 
   /// Creates a new [FlutterGoldenFileComparator] that mirrors the relative
@@ -51,11 +57,24 @@ class FlutterGoldenFileComparator implements GoldenFileComparator {
   ///
   /// By the time the future completes, the clone of the `flutter/goldens`
   /// repository is guaranteed to be ready use.
-  static Future<FlutterGoldenFileComparator> fromDefaultComparator() async {
-    final LocalFileComparator defaultComparator = goldenFileComparator;
-    final GoldensClient goldens = new GoldensClient();
+  ///
+  /// The [goldens] and [defaultComparator] parameters are visible for testing
+  /// purposes only.
+  static Future<FlutterGoldenFileComparator> fromDefaultComparator({
+    GoldensClient goldens,
+    LocalFileComparator defaultComparator,
+  }) async {
+    defaultComparator ??= goldenFileComparator;
+
+    // Prepare the goldens repo.
+    goldens ??= new GoldensClient();
     await goldens.prepare();
-    return new FlutterGoldenFileComparator(goldens, defaultComparator.basedir);
+
+    // Calculate the appropriate basedir for the current test context.
+    final FileSystem fs = goldens.fs;
+    final Directory testDirectory = fs.directory(defaultComparator.basedir);
+    final String testDirectoryRelativePath = fs.path.relative(testDirectory.path, from: goldens.flutterRoot.path);
+    return new FlutterGoldenFileComparator(goldens.repositoryRoot.childDirectory(testDirectoryRelativePath).uri);
   }
 
   @override
@@ -77,10 +96,7 @@ class FlutterGoldenFileComparator implements GoldenFileComparator {
   }
 
   File _getGoldenFile(Uri uri) {
-    final File relativeFile = fs.file(uri);
-    final Directory testDirectory = fs.directory(basedir);
-    final String relativeBase = fs.path.relative(testDirectory.path, from: goldens.flutterRoot.path);
-    return goldens.repositoryRoot.childDirectory(relativeBase).childFile(relativeFile.path);
+    return fs.directory(basedir).childFile(fs.file(uri).path);
   }
 }
 

--- a/packages/flutter_test/lib/src/goldens.dart
+++ b/packages/flutter_test/lib/src/goldens.dart
@@ -66,8 +66,8 @@ abstract class GoldenFileComparator {
 ///
 ///  * [flutter_test] for more information about how to configure tests at the
 ///    directory-level.
-GoldenFileComparator _goldenFileComparator = const _UninitializedComparator();
 GoldenFileComparator get goldenFileComparator => _goldenFileComparator;
+GoldenFileComparator _goldenFileComparator = const _UninitializedComparator();
 set goldenFileComparator(GoldenFileComparator comparator) {
   _goldenFileComparator = comparator ?? const _UninitializedComparator();
 }

--- a/packages/flutter_tools/lib/src/commands/analyze_once.dart
+++ b/packages/flutter_tools/lib/src/commands/analyze_once.dart
@@ -273,6 +273,8 @@ class AnalyzeOnce extends AnalyzeBase {
       return false;
     if (filenameComponents[flutterRootComponents.length + 1] == 'flutter_tools')
       return false;
+    if (filenameComponents[flutterRootComponents.length + 1] == 'flutter_goldens')
+      return false;
     if (filenameComponents[flutterRootComponents.length + 2] != 'lib')
       return false;
     return true;

--- a/packages/flutter_tools/lib/src/commands/analyze_once.dart
+++ b/packages/flutter_tools/lib/src/commands/analyze_once.dart
@@ -273,8 +273,6 @@ class AnalyzeOnce extends AnalyzeBase {
       return false;
     if (filenameComponents[flutterRootComponents.length + 1] == 'flutter_tools')
       return false;
-    if (filenameComponents[flutterRootComponents.length + 1] == 'flutter_goldens')
-      return false;
     if (filenameComponents[flutterRootComponents.length + 2] != 'lib')
       return false;
     return true;


### PR DESCRIPTION
* Exclude flutter_goldens package from dartdoc because it's for internal
  use only
* Document why flutter_tools doesn' tneed to be excluded from the list of
  packages to document
* Make `flutter analyze --dartdocs` ignore undocumented members in flutter_goldens
* Performance optimization in the flutter comparator, and associated
  test updates.

Fixes the undocumented public members benchmark