### PR TITLE
Build App.framework for all requested architectures

### DIFF
--- a/packages/flutter_tools/bin/xcode_backend.sh
+++ b/packages/flutter_tools/bin/xcode_backend.sh
@@ -130,8 +130,16 @@ BuildApp() {
     RunCommand cp -r -- "${build_dir}/aot/App.framework" "${derived_dir}"
   else
     RunCommand mkdir -p -- "${derived_dir}/App.framework"
+
+    # Build stub for all requested architectures.
+    local arch_flags=""
+    read -r -a archs <<< "$ARCHS"
+    for arch in "${archs[@]}"; do
+      arch_flags="${arch_flags}-arch $arch "
+    done
+
     RunCommand eval "$(echo "static const int Moo = 88;" | xcrun clang -x c \
-        -arch "$CURRENT_ARCH" \
+        ${arch_flags} \
         -dynamiclib \
         -Xlinker -rpath -Xlinker '@executable_path/Frameworks' \
         -Xlinker -rpath -Xlinker '@loader_path/Frameworks' \


### PR DESCRIPTION
In debug mode iOS builds, we build a stub App.framework with no
functionality, since the engine itself loads the code from the included
bundle and subsequently via hot reload. This is simply done for
consistency with profile/release AOT app structure.

To satisfy the linker, ensure that we're building this code for all
build architectures, not just CURRENT_ARCH.

This is pre-work for supporting arbitrary iOS architectures (armv7,
arm64, universal) in Flutter.