### PR TITLE
Add onChangeStart and onChangeEnd to slider.

### DIFF
--- a/packages/flutter/test/material/slider_test.dart
+++ b/packages/flutter/test/material/slider_test.dart
@@ -46,6 +46,8 @@ void main() {
   testWidgets('Slider can move when tapped (LTR)', (WidgetTester tester) async {
     final Key sliderKey = new UniqueKey();
     double value = 0.0;
+    double startValue;
+    double endValue;
 
     await tester.pumpWidget(
       new Directionality(
@@ -64,6 +66,12 @@ void main() {
                         value = newValue;
                       });
                     },
+                    onChangeStart: (double value) {
+                      startValue = value;
+                    },
+                    onChangeEnd: (double value) {
+                      endValue = value;
+                    },
                   ),
                 ),
               ),
@@ -76,6 +84,10 @@ void main() {
     expect(value, equals(0.0));
     await tester.tap(find.byKey(sliderKey));
     expect(value, equals(0.5));
+    expect(startValue, equals(0.0));
+    expect(endValue, equals(0.5));
+    startValue = null;
+    endValue = null;
     await tester.pump(); // No animation should start.
     expect(SchedulerBinding.instance.transientCallbackCount, equals(0));
 
@@ -85,6 +97,8 @@ void main() {
     final Offset target = topLeft + (bottomRight - topLeft) / 4.0;
     await tester.tapAt(target);
     expect(value, closeTo(0.25, 0.05));
+    expect(startValue, equals(0.5));
+    expect(endValue, closeTo(0.25, 0.05));
     await tester.pump(); // No animation should start.
     expect(SchedulerBinding.instance.transientCallbackCount, equals(0));
   });
@@ -138,7 +152,11 @@ void main() {
   testWidgets("Slider doesn't send duplicate change events if tapped on the same value", (WidgetTester tester) async {
     final Key sliderKey = new UniqueKey();
     double value = 0.0;
+    double startValue;
+    double endValue;
     int updates = 0;
+    int startValueUpdates = 0;
+    int endValueUpdates = 0;
 
     await tester.pumpWidget(
       new Directionality(
@@ -158,6 +176,14 @@ void main() {
                         value = newValue;
                       });
                     },
+                    onChangeStart: (double value) {
+                      startValueUpdates++;
+                      startValue = value;
+                    },
+                    onChangeEnd: (double value) {
+                      endValueUpdates++;
+                      endValue = value;
+                    },
                   ),
                 ),
               ),
@@ -170,11 +196,15 @@ void main() {
     expect(value, equals(0.0));
     await tester.tap(find.byKey(sliderKey));
     expect(value, equals(0.5));
+    expect(startValue, equals(0.0));
+    expect(endValue, equals(0.5));
     await tester.pump();
     await tester.tap(find.byKey(sliderKey));
     expect(value, equals(0.5));
     await tester.pump();
     expect(updates, equals(1));
+    expect(startValueUpdates, equals(2));
+    expect(endValueUpdates, equals(2));
   });
 
   testWidgets('Value indicator shows for a bit after being tapped', (WidgetTester tester) async {


### PR DESCRIPTION
This fixes https://github.com/flutter/flutter/issues/17169 by adding onChangeStart and onChangeEnd to the slider.  These will be called when the user starts a change, and when they end a change, regardless of whether that change is a tap or a drag.

These differ from onChanged, in that they only report when the user starts and ends an interaction, not at every slight change.