### PR TITLE
Revert "Add missing awaits in driver integration test"

### DIFF
--- a/dev/integration_tests/ui/test_driver/driver_test.dart
+++ b/dev/integration_tests/ui/test_driver/driver_test.dart
@@ -36,7 +36,7 @@ void main() {
     test('waitForAbsent should resolve when text "present" disappears', () async {
       // Begin waiting for it to disappear
       final Completer<Null> whenWaitForAbsentResolves = new Completer<Null>();
-      await driver.waitForAbsent(presentText).then(
+      driver.waitForAbsent(presentText).then(
         whenWaitForAbsentResolves.complete,
         onError: whenWaitForAbsentResolves.completeError,
       );
@@ -61,7 +61,7 @@ void main() {
     test('waitFor should resolve when text "present" reappears', () async {
       // Begin waiting for it to reappear
       final Completer<Null> whenWaitForResolves = new Completer<Null>();
-      await driver.waitFor(presentText).then(
+      driver.waitFor(presentText).then(
         whenWaitForResolves.complete,
         onError: whenWaitForResolves.completeError,
       );


### PR DESCRIPTION
Didn't fix the issue (which started at feb16d8d0156a475538e817b649e06d1f8d0cdc3), which affects only built iOS IPAs, but the failing test is an Android driver test. It definitely looks like some strange interleaving is going on with the driver tests in question.

Reverts flutter/flutter#17314