### PR TITLE
Work around integration_ui test flakiness

### DIFF
--- a/dev/integration_tests/ui/lib/driver.dart
+++ b/dev/integration_tests/ui/lib/driver.dart
@@ -7,10 +7,7 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_driver/driver_extension.dart';
 
 void main() {
-  enableFlutterDriverExtension(handler: (String message) async {
-    // TODO(cbernaschina) remove when test flakiness is resolved
-    return 'driver';
-  });
+  enableFlutterDriverExtension();
   runApp(new DriverTestApp());
 }
 

--- a/dev/integration_tests/ui/test_driver/driver_test.dart
+++ b/dev/integration_tests/ui/test_driver/driver_test.dart
@@ -14,6 +14,8 @@ void main() {
 
     setUpAll(() async {
       driver = await FlutterDriver.connect();
+      // TODO(cbracken): remove when source of test flakiness is resolved.
+      await new Future<Null>.delayed(const Duration(seconds: 1));
     });
 
     tearDownAll(() async {


### PR DESCRIPTION
This test fails consistently on mac2 and mac3 with the attached Moto G4
devices but passes consistently on other machines.

Adding a delay of 1s right after driver.connect() in setUpAll() causes
it to pass on the machines in question, which suggests a race condition.
Specifically it looks like connect returns the moment Flutter Driver
identifies that the isolate is up and running, but empirically it looks
like we start running the first test before the UI is actually up. This
triggers a failure wherein we start looking for elements before they're
onstage.

Link to viewport.dart:213 at HEAD:
https://github.com/flutter/flutter/blob/b2b46659262c66ff13abc2b8016a94a47646eaad/packages/flutter/lib/src/widgets/viewport.dart#L213

Stack trace:
FlutterDriver waitFor should find text "present"

```
  DriverError: Error in Flutter application: Uncaught extension error while executing waitFor: NoSuchMethodError: The getter 'visible' was called on null.
  Receiver: null
  Tried calling: visible
  #0      Object.noSuchMethod (dart:core/runtime/libobject_patch.dart:46:5)
  #1      _ViewportElement.debugVisitOnstageChildren. (package:flutter/src/widgets/viewport.dart:213:36)
  #2      WhereIterator.moveNext (dart:_internal/iterable.dart:439:11)
  #3      Iterable.forEach (dart:core/iterable.dart)
  #4      _ViewportElement.debugVisitOnstageChildren (package:flutter/src/widgets/viewport.dart:214:8)
  #5      _DepthFirstChildIterator._reverseChildrenOf (package:flutter_test/src/all_elements.dart:54:15)
  #6      _DepthFirstChildIterator.moveNext (package:flutter_test/src/all_elements.dart:45:19)
  #7      CachingIterable._fillNext (package:flutter/src/foundation/basic_types.dart:252:27)
  #8      _LazyListIterator.moveNext (package:flutter/src/foundation/basic_types.dart:279:21)
  #9      WhereIterator.moveNext (dart:_internal/iterable.dart:438:22)
  #10     CachingIterable._fillNext (package:flutter/src/foundation/basic_types.dart:252:27)
  #11     _LazyListIterator.moveNext (package:flutter/src/foundation/basic_types.dart:279:21)
  #12     Iterable.isEmpty (dart:core/iterable.dart:449:33)
  #13     Iterable.isNotEmpty (dart:core/iterable.dart:456:27)
  #14     FlutterDriverExtension._waitForElement. (package:flutter_driver/src/extension/extension.dart:215:51)
  #15     FlutterDriverExtension._waitUntilFrame (package:flutter_driver/src/extension/extension.dart:197:19)
  #16     FlutterDriverExtension._waitForElement (package:flutter_driver/src/extension/extension.dart:215:11)

  #17     FlutterDriverExtension._waitFor (package:flutter_driver/src/extension/extension.dart:286:11)

  #18     FlutterDriverExtension.call (package:flutter_driver/src/extension/extension.dart:168:51)

  #19     BindingBase.registerServiceExtension. (package:flutter/src/foundation/binding.dart:370:32)
```