### PR TITLE
Enable universal iOS binaries for examples

### DIFF
--- a/examples/catalog/ios/Flutter/AppFrameworkInfo.plist
+++ b/examples/catalog/ios/Flutter/AppFrameworkInfo.plist
@@ -20,10 +20,6 @@
   <string>????</string>
   <key>CFBundleVersion</key>
   <string>1.0</string>
-  <key>UIRequiredDeviceCapabilities</key>
-  <array>
-    <string>arm64</string>
-  </array>
   <key>MinimumOSVersion</key>
   <string>8.0</string>
 </dict>

--- a/examples/catalog/ios/Runner.xcodeproj/project.pbxproj
+++ b/examples/catalog/ios/Runner.xcodeproj/project.pbxproj
@@ -372,7 +372,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 9740EEB21CF90195004384FC /* Debug.xcconfig */;
 			buildSettings = {
-				ARCHS = arm64;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -394,7 +393,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 7AFA3C8E1D35360C0083082E /* Release.xcconfig */;
 			buildSettings = {
-				ARCHS = arm64;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (

--- a/examples/catalog/ios/Runner/Info.plist
+++ b/examples/catalog/ios/Runner/Info.plist
@@ -26,10 +26,6 @@
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>
 	<string>Main</string>
-	<key>UIRequiredDeviceCapabilities</key>
-	<array>
-		<string>arm64</string>
-	</array>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>

--- a/examples/flutter_view/ios/Flutter/AppFrameworkInfo.plist
+++ b/examples/flutter_view/ios/Flutter/AppFrameworkInfo.plist
@@ -20,10 +20,6 @@
   <string>????</string>
   <key>CFBundleVersion</key>
   <string>1.0</string>
-  <key>UIRequiredDeviceCapabilities</key>
-  <array>
-    <string>arm64</string>
-  </array>
   <key>MinimumOSVersion</key>
   <string>8.0</string>
 </dict>

--- a/examples/flutter_view/ios/Runner.xcodeproj/project.pbxproj
+++ b/examples/flutter_view/ios/Runner.xcodeproj/project.pbxproj
@@ -435,7 +435,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 9740EEB21CF90195004384FC /* Debug.xcconfig */;
 			buildSettings = {
-				ARCHS = arm64;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -458,7 +457,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 7AFA3C8E1D35360C0083082E /* Release.xcconfig */;
 			buildSettings = {
-				ARCHS = arm64;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (

--- a/examples/flutter_view/ios/Runner/Info.plist
+++ b/examples/flutter_view/ios/Runner/Info.plist
@@ -26,10 +26,6 @@
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>
 	<string>Main</string>
-	<key>UIRequiredDeviceCapabilities</key>
-	<array>
-		<string>arm64</string>
-	</array>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>

--- a/examples/hello_world/ios/Flutter/AppFrameworkInfo.plist
+++ b/examples/hello_world/ios/Flutter/AppFrameworkInfo.plist
@@ -20,10 +20,6 @@
   <string>????</string>
   <key>CFBundleVersion</key>
   <string>1.0</string>
-  <key>UIRequiredDeviceCapabilities</key>
-  <array>
-    <string>arm64</string>
-  </array>
   <key>MinimumOSVersion</key>
   <string>8.0</string>
 </dict>

--- a/examples/hello_world/ios/Runner.xcodeproj/project.pbxproj
+++ b/examples/hello_world/ios/Runner.xcodeproj/project.pbxproj
@@ -376,7 +376,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 9740EEB21CF90195004384FC /* Debug.xcconfig */;
 			buildSettings = {
-				ARCHS = arm64;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -398,7 +397,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 7AFA3C8E1D35360C0083082E /* Release.xcconfig */;
 			buildSettings = {
-				ARCHS = arm64;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (

--- a/examples/hello_world/ios/Runner/Info.plist
+++ b/examples/hello_world/ios/Runner/Info.plist
@@ -26,10 +26,6 @@
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>
 	<string>Main</string>
-	<key>UIRequiredDeviceCapabilities</key>
-	<array>
-		<string>arm64</string>
-	</array>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>

--- a/examples/layers/ios/Flutter/AppFrameworkInfo.plist
+++ b/examples/layers/ios/Flutter/AppFrameworkInfo.plist
@@ -20,10 +20,6 @@
   <string>????</string>
   <key>CFBundleVersion</key>
   <string>1.0</string>
-  <key>UIRequiredDeviceCapabilities</key>
-  <array>
-    <string>arm64</string>
-  </array>
   <key>MinimumOSVersion</key>
   <string>8.0</string>
 </dict>

--- a/examples/layers/ios/Runner.xcodeproj/project.pbxproj
+++ b/examples/layers/ios/Runner.xcodeproj/project.pbxproj
@@ -356,7 +356,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 9740EEB21CF90195004384FC /* Debug.xcconfig */;
 			buildSettings = {
-				ARCHS = arm64;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -378,7 +377,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 7AFA3C8E1D35360C0083082E /* Release.xcconfig */;
 			buildSettings = {
-				ARCHS = arm64;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (

--- a/examples/layers/ios/Runner/Info.plist
+++ b/examples/layers/ios/Runner/Info.plist
@@ -26,10 +26,6 @@
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>
 	<string>Main</string>
-	<key>UIRequiredDeviceCapabilities</key>
-	<array>
-		<string>arm64</string>
-	</array>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>

--- a/examples/platform_channel/ios/Flutter/AppFrameworkInfo.plist
+++ b/examples/platform_channel/ios/Flutter/AppFrameworkInfo.plist
@@ -20,10 +20,6 @@
   <string>????</string>
   <key>CFBundleVersion</key>
   <string>1.0</string>
-  <key>UIRequiredDeviceCapabilities</key>
-  <array>
-    <string>arm64</string>
-  </array>
   <key>MinimumOSVersion</key>
   <string>8.0</string>
 </dict>

--- a/examples/platform_channel/ios/Runner.xcodeproj/project.pbxproj
+++ b/examples/platform_channel/ios/Runner.xcodeproj/project.pbxproj
@@ -364,7 +364,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 9740EEB21CF90195004384FC /* Debug.xcconfig */;
 			buildSettings = {
-				ARCHS = arm64;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -386,7 +385,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 7AFA3C8E1D35360C0083082E /* Release.xcconfig */;
 			buildSettings = {
-				ARCHS = arm64;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (

--- a/examples/platform_channel/ios/Runner/Info.plist
+++ b/examples/platform_channel/ios/Runner/Info.plist
@@ -26,10 +26,6 @@
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>
 	<string>Main</string>
-	<key>UIRequiredDeviceCapabilities</key>
-	<array>
-		<string>arm64</string>
-	</array>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>

--- a/examples/platform_channel_swift/ios/Flutter/AppFrameworkInfo.plist
+++ b/examples/platform_channel_swift/ios/Flutter/AppFrameworkInfo.plist
@@ -20,10 +20,6 @@
   <string>????</string>
   <key>CFBundleVersion</key>
   <string>1.0</string>
-  <key>UIRequiredDeviceCapabilities</key>
-  <array>
-    <string>arm64</string>
-  </array>
   <key>MinimumOSVersion</key>
   <string>8.0</string>
 </dict>

--- a/examples/platform_channel_swift/ios/Runner.xcodeproj/project.pbxproj
+++ b/examples/platform_channel_swift/ios/Runner.xcodeproj/project.pbxproj
@@ -361,7 +361,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 9740EEB21CF90195004384FC /* Debug.xcconfig */;
 			buildSettings = {
-				ARCHS = arm64;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				ENABLE_BITCODE = NO;
@@ -387,7 +386,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 7AFA3C8E1D35360C0083082E /* Release.xcconfig */;
 			buildSettings = {
-				ARCHS = arm64;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				ENABLE_BITCODE = NO;

--- a/examples/platform_channel_swift/ios/Runner/Info.plist
+++ b/examples/platform_channel_swift/ios/Runner/Info.plist
@@ -26,10 +26,6 @@
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>
 	<string>Main</string>
-	<key>UIRequiredDeviceCapabilities</key>
-	<array>
-		<string>arm64</string>
-	</array>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>

--- a/examples/platform_view/ios/Flutter/AppFrameworkInfo.plist
+++ b/examples/platform_view/ios/Flutter/AppFrameworkInfo.plist
@@ -20,10 +20,6 @@
   <string>????</string>
   <key>CFBundleVersion</key>
   <string>1.0</string>
-  <key>UIRequiredDeviceCapabilities</key>
-  <array>
-    <string>arm64</string>
-  </array>
   <key>MinimumOSVersion</key>
   <string>8.0</string>
 </dict>

--- a/examples/platform_view/ios/Runner.xcodeproj/project.pbxproj
+++ b/examples/platform_view/ios/Runner.xcodeproj/project.pbxproj
@@ -434,7 +434,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 9740EEB21CF90195004384FC /* Debug.xcconfig */;
 			buildSettings = {
-				ARCHS = arm64;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -457,7 +456,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 7AFA3C8E1D35360C0083082E /* Release.xcconfig */;
 			buildSettings = {
-				ARCHS = arm64;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (

--- a/examples/platform_view/ios/Runner/Info.plist
+++ b/examples/platform_view/ios/Runner/Info.plist
@@ -26,10 +26,6 @@
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>
 	<string>Main</string>
-	<key>UIRequiredDeviceCapabilities</key>
-	<array>
-		<string>arm64</string>
-	</array>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>

--- a/examples/stocks/ios/Flutter/AppFrameworkInfo.plist
+++ b/examples/stocks/ios/Flutter/AppFrameworkInfo.plist
@@ -20,10 +20,6 @@
   <string>????</string>
   <key>CFBundleVersion</key>
   <string>1.0</string>
-  <key>UIRequiredDeviceCapabilities</key>
-  <array>
-    <string>arm64</string>
-  </array>
   <key>MinimumOSVersion</key>
   <string>8.0</string>
 </dict>

--- a/examples/stocks/ios/Runner.xcodeproj/project.pbxproj
+++ b/examples/stocks/ios/Runner.xcodeproj/project.pbxproj
@@ -364,7 +364,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 9740EEB21CF90195004384FC /* Debug.xcconfig */;
 			buildSettings = {
-				ARCHS = arm64;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -386,7 +385,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 7AFA3C8E1D35360C0083082E /* Release.xcconfig */;
 			buildSettings = {
-				ARCHS = arm64;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (

--- a/examples/stocks/ios/Runner/Info.plist
+++ b/examples/stocks/ios/Runner/Info.plist
@@ -26,10 +26,6 @@
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>
 	<string>Main</string>
-	<key>UIRequiredDeviceCapabilities</key>
-	<array>
-		<string>arm64</string>
-	</array>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>


### PR DESCRIPTION
Updates all example projects to build as universal binaries that run on
both armv7 and arm64 now that we support both platforms on iOS.