### PR TITLE
Make runAsync() run in child zone, not root zone

### DIFF
--- a/packages/flutter_test/test/widget_tester_test.dart
+++ b/packages/flutter_test/test/widget_tester_test.dart
@@ -481,6 +481,18 @@ void main() {
       expect(() => tester.runAsync(() async {}), throwsA(const isInstanceOf<TestFailure>()));
       completer.complete();
     });
+
+    testWidgets('maintains existing zone values', (WidgetTester tester) async {
+      final Object key = new Object();
+      await runZoned(() {
+        expect(Zone.current[key], 'abczed');
+        return tester.runAsync<String>(() async {
+          expect(Zone.current[key], 'abczed');
+        });
+      }, zoneValues: <dynamic, dynamic>{
+        key: 'abczed',
+      });
+    });
   });
 }
 


### PR DESCRIPTION
Some APIs (such as the ones in package:test) assume you're running
in a child zone of the test zone by attempting to extract information
from the zone values. When we run runAsync() in the root zone, those
zone values are lost, and such API methods don't work.

The solution is to run in a child zone, but with a specification that
says to use the Root zone for task scheduling (both timers and
microtakss).