### PR TITLE
Let goldens push via ssh by default

### DIFF
--- a/packages/flutter_goldens/lib/flutter_goldens.dart
+++ b/packages/flutter_goldens/lib/flutter_goldens.dart
@@ -174,6 +174,7 @@ class GoldensClient {
       <String>[
         'git init',
         'git remote add upstream https://github.com/flutter/goldens.git',
+        'git remote set-url --push upstream git@github.com:flutter/goldens.git',
       ],
       workingDirectory: repositoryRoot,
     );


### PR DESCRIPTION
Let the golden repo's upstream push use SSH so the public can fetch and run the test but also avoids having to type in a username and password via HTTPS when pushing. 