### PR TITLE
Update kernel compile log message

### DIFF
--- a/packages/flutter_tools/lib/src/bundle.dart
+++ b/packages/flutter_tools/lib/src/bundle.dart
@@ -84,7 +84,7 @@ Future<void> build({
 
     if (await fingerprinter.doesFingerprintMatch()) {
       needBuild = false;
-      printStatus('Skipping compilation. Fingerprint match.');
+      printTrace('Skipping kernel compilation. Fingerprint match.');
     }
 
     String kernelBinaryFilename;


### PR DESCRIPTION
Updates the message emitted when a kernel compile is skipped in the
build bundle action. Since we now use fingerprinting to enable
performance of script snapshots, AOT snapshots, and kernel compiles,
this helps a bit with debugging.