### PR TITLE
Block debug AOT snapshot builds

### DIFF
--- a/packages/flutter_tools/lib/src/base/build.dart
+++ b/packages/flutter_tools/lib/src/base/build.dart
@@ -378,7 +378,7 @@ class AOTSnapshotter {
   }
 
   bool _isValidAotPlatform(TargetPlatform platform, BuildMode buildMode) {
-    if (platform == TargetPlatform.ios && buildMode == BuildMode.debug)
+    if (buildMode == BuildMode.debug)
       return false;
     return const <TargetPlatform>[
       TargetPlatform.android_arm,

--- a/packages/flutter_tools/test/base/build_test.dart
+++ b/packages/flutter_tools/test/base/build_test.dart
@@ -339,6 +339,19 @@ void main() {
       ), isNot(equals(0)));
     }, overrides: contextOverrides);
 
+    testUsingContext('Android ARM debug AOT snapshot is invalid', () async {
+      final String outputPath = fs.path.join('build', 'foo');
+      expect(await snapshotter.build(
+        platform: TargetPlatform.android_arm,
+        buildMode: BuildMode.debug,
+        mainPath: 'main.dill',
+        packagesPath: '.packages',
+        outputPath: outputPath,
+        preferSharedLibrary: false,
+        previewDart2: true,
+      ), isNot(0));
+    }, overrides: contextOverrides);
+
     testUsingContext('builds iOS profile AOT snapshot', () async {
       fs.file('main.dill').writeAsStringSync('binary magic');
 


### PR DESCRIPTION
We previously blocked iOS AOT builds, but Android debug builds are
always JIT builds.