### PR TITLE
Trivial cleanup of layer debugging flags

### DIFF
--- a/packages/flutter/lib/src/rendering/debug.dart
+++ b/packages/flutter/lib/src/rendering/debug.dart
@@ -111,25 +111,41 @@ bool debugCheckIntrinsicSizes = false;
 ///  * The discussion at [RendererBinding.drawFrame].
 bool debugProfilePaintsEnabled = false;
 
-/// Setting to true will cause all clipping effects from the layer tree to be ignored.
+/// Setting to true will cause all clipping effects from the layer tree to be
+/// ignored.
 ///
 /// Can be used to debug whether objects being clipped are painting excessively
-/// in clipped areas. Can also be used to check whether excessive use of clipping
-/// is affecting performance.
+/// in clipped areas. Can also be used to check whether excessive use of
+/// clipping is affecting performance.
+///
+/// This will not reduce the number of [Layer] objects created; the compositing
+/// strategy is unaffected. It merely causes the clipping layers to be skipped
+/// when building the scene.
 bool debugDisableClipLayers = false;
 
-/// Setting to true will cause all physical modeling effects, such as shadows
-/// from elevations, from the layer tree to be ignored.
+/// Setting to true will cause all physical modeling effects from the layer
+/// tree, such as shadows from elevations, to be ignored.
 ///
 /// Can be used to check whether excessive use of physical models is affecting
 /// performance.
+///
+/// This will not reduce the number of [Layer] objects created; the compositing
+/// strategy is unaffected. It merely causes the physical shape layers to be
+/// skipped when building the scene.
 bool debugDisablePhysicalShapeLayers = false;
 
-/// Setting to true will cause all opacity effects to be ignored.
+/// Setting to true will cause all opacity effects from the layer tree to be
+/// ignored.
 ///
 /// An optimization to not paint the child at all when opacity is 0 will still
-/// remain. Can be used to check whether excessive use of opacity effects is
-/// affecting performance.
+/// remain.
+///
+/// Can be used to check whether excessive use of opacity effects is affecting
+/// performance.
+///
+/// This will not reduce the number of [Layer] objects created; the compositing
+/// strategy is unaffected. It merely causes the opacity layers to be skipped
+/// when building the scene.
 bool debugDisableOpacityLayers = false;
 
 void _debugDrawDoubleRect(Canvas canvas, Rect outerRect, Rect innerRect, Color color) {

--- a/packages/flutter/lib/src/rendering/layer.dart
+++ b/packages/flutter/lib/src/rendering/layer.dart
@@ -556,6 +556,10 @@ class OffsetLayer extends ContainerLayer {
 }
 
 /// A composite layer that clips its children using a rectangle.
+///
+/// When debugging, setting [debugDisableClipLayers] to true will cause this
+/// layer to be skipped (directly replaced by its children). This can be helpful
+/// to track down the cause of performance problems.
 class ClipRectLayer extends ContainerLayer {
   /// Creates a layer with a rectangular clip.
   ///
@@ -571,10 +575,15 @@ class ClipRectLayer extends ContainerLayer {
 
   @override
   void addToScene(ui.SceneBuilder builder, Offset layerOffset) {
-    if (!debugDisableClipLayers)
+    bool enabled = true;
+    assert(() {
+      enabled = !debugDisableClipLayers;
+      return true;
+    }());
+    if (enabled)
       builder.pushClipRect(clipRect.shift(layerOffset));
     addChildrenToScene(builder, layerOffset);
-    if (!debugDisableClipLayers)
+    if (enabled)
       builder.pop();
   }
 
@@ -586,6 +595,10 @@ class ClipRectLayer extends ContainerLayer {
 }
 
 /// A composite layer that clips its children using a rounded rectangle.
+///
+/// When debugging, setting [debugDisableClipLayers] to true will cause this
+/// layer to be skipped (directly replaced by its children). This can be helpful
+/// to track down the cause of performance problems.
 class ClipRRectLayer extends ContainerLayer {
   /// Creates a layer with a rounded-rectangular clip.
   ///
@@ -601,10 +614,15 @@ class ClipRRectLayer extends ContainerLayer {
 
   @override
   void addToScene(ui.SceneBuilder builder, Offset layerOffset) {
-    if (!debugDisableClipLayers)
+    bool enabled = true;
+    assert(() {
+      enabled = !debugDisableClipLayers;
+      return true;
+    }());
+    if (enabled)
       builder.pushClipRRect(clipRRect.shift(layerOffset));
     addChildrenToScene(builder, layerOffset);
-    if (!debugDisableClipLayers)
+    if (enabled)
       builder.pop();
   }
 
@@ -616,6 +634,10 @@ class ClipRRectLayer extends ContainerLayer {
 }
 
 /// A composite layer that clips its children using a path.
+///
+/// When debugging, setting [debugDisableClipLayers] to true will cause this
+/// layer to be skipped (directly replaced by its children). This can be helpful
+/// to track down the cause of performance problems.
 class ClipPathLayer extends ContainerLayer {
   /// Creates a layer with a path-based clip.
   ///
@@ -631,10 +653,15 @@ class ClipPathLayer extends ContainerLayer {
 
   @override
   void addToScene(ui.SceneBuilder builder, Offset layerOffset) {
-    if (!debugDisableClipLayers)
+    bool enabled = true;
+    assert(() {
+      enabled = !debugDisableClipLayers;
+      return true;
+    }());
+    if (enabled)
       builder.pushClipPath(clipPath.shift(layerOffset));
     addChildrenToScene(builder, layerOffset);
-    if (!debugDisableClipLayers)
+    if (enabled)
       builder.pop();
   }
 }
@@ -692,6 +719,10 @@ class TransformLayer extends OffsetLayer {
 }
 
 /// A composited layer that makes its children partially transparent.
+///
+/// When debugging, setting [debugDisableOpacityLayers] to true will cause this
+/// layer to be skipped (directly replaced by its children). This can be helpful
+/// to track down the cause of performance problems.
 class OpacityLayer extends ContainerLayer {
   /// Creates an opacity layer.
   ///
@@ -710,10 +741,15 @@ class OpacityLayer extends ContainerLayer {
 
   @override
   void addToScene(ui.SceneBuilder builder, Offset layerOffset) {
-    if (!debugDisableOpacityLayers)
+    bool enabled = true;
+    assert(() {
+      enabled = !debugDisableOpacityLayers;
+      return true;
+    }());
+    if (enabled)
       builder.pushOpacity(alpha);
     addChildrenToScene(builder, layerOffset);
-    if (!debugDisableOpacityLayers)
+    if (enabled)
       builder.pop();
   }
 
@@ -793,6 +829,10 @@ class BackdropFilterLayer extends ContainerLayer {
 /// For example, the layer casts a shadow according to its geometry and the
 /// relative position of lights and other physically modelled objects in the
 /// scene.
+///
+/// When debugging, setting [debugDisablePhysicalShapeLayers] to true will cause this
+/// layer to be skipped (directly replaced by its children). This can be helpful
+/// to track down the cause of performance problems.
 class PhysicalModelLayer extends ContainerLayer {
   /// Creates a composited layer that uses a physical model to producing
   /// lighting effects.
@@ -831,15 +871,21 @@ class PhysicalModelLayer extends ContainerLayer {
 
   @override
   void addToScene(ui.SceneBuilder builder, Offset layerOffset) {
-    if (!debugDisablePhysicalShapeLayers)
+    bool enabled = true;
+    assert(() {
+      enabled = !debugDisablePhysicalShapeLayers;
+      return true;
+    }());
+    if (enabled) {
       builder.pushPhysicalShape(
         path: clipPath.shift(layerOffset),
         elevation: elevation,
         color: color,
         shadowColor: shadowColor,
       );
+    }
     addChildrenToScene(builder, layerOffset);
-    if (!debugDisablePhysicalShapeLayers)
+    if (enabled)
       builder.pop();
   }
 


### PR DESCRIPTION
In theory, this should aid with tree shaking and minutely optimize the code in release builds.

cc @xster 