### PR TITLE
Correct profile-mode AOT snapshot flags

### DIFF
--- a/packages/flutter_tools/lib/src/base/build.dart
+++ b/packages/flutter_tools/lib/src/base/build.dart
@@ -194,12 +194,6 @@ class AOTSnapshotter {
         '--strong',
       ]);
     }
-    if (buildMode != BuildMode.release) {
-      genSnapshotArgs.addAll(<String>[
-        '--no-checked',
-        '--conditional_directives',
-      ]);
-    }
     if (extraGenSnapshotOptions != null && extraGenSnapshotOptions.isNotEmpty) {
       printTrace('Extra gen_snapshot options: $extraGenSnapshotOptions');
       genSnapshotArgs.addAll(extraGenSnapshotOptions);

--- a/packages/flutter_tools/test/base/build_test.dart
+++ b/packages/flutter_tools/test/base/build_test.dart
@@ -396,8 +396,6 @@ void main() {
         '--dependencies=${fs.path.join(outputPath, 'snapshot.d')}',
         '--reify-generic-functions',
         '--strong',
-        '--no-checked',
-        '--conditional_directives',
         '--snapshot_kind=app-aot-assembly',
         '--assembly=${fs.path.join(outputPath, 'snapshot_assembly.S')}',
         'main.dill',


### PR DESCRIPTION
Previously, in non-release (i.e. profile) AOT builds, we were setting
--no-checked and --conditional_directives flags. --no-checked is the
default, and we don't make use of conditional directives in Flutter.