### PR TITLE
chore: add Node.js 8 and 10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,8 @@ addons:
 language: node_js
 node_js:
   - "6"
+  - "8"
+  - "10"
 git:
   # We rely on git tags for determining the version.
   depth: false


### PR DESCRIPTION
Adding Node.js 8 and 10 to test the current testsuite / builds against the current LTS and stable Node.js releases.