### PR TITLE
Add caching for kernel compiles during AOT builds

### DIFF
--- a/packages/flutter_tools/lib/src/bundle.dart
+++ b/packages/flutter_tools/lib/src/bundle.dart
@@ -9,7 +9,6 @@ import 'asset.dart';
 import 'base/build.dart';
 import 'base/common.dart';
 import 'base/file_system.dart';
-import 'base/fingerprint.dart';
 import 'build_info.dart';
 import 'compile.dart';
 import 'dart/package_map.dart';
@@ -71,46 +70,22 @@ Future<void> build({
 
   DevFSContent kernelContent;
   if (!precompiledSnapshot && previewDart2) {
-    bool needBuild = true;
-    final Fingerprinter fingerprinter = new Fingerprinter(
-      fingerprintPath: '$depfilePath.fingerprint',
-      paths: <String>[mainPath],
-      properties: <String, String>{
-        'entryPoint': mainPath,
-        'trackWidgetCreation': trackWidgetCreation.toString(),
-      },
-      depfilePaths: <String>[depfilePath],
+    ensureDirectoryExists(applicationKernelFilePath);
+    final CompilerOutput compilerOutput = await kernelCompiler.compile(
+      sdkRoot: artifacts.getArtifactPath(Artifact.flutterPatchedSdkPath),
+      incrementalCompilerByteStorePath: fs.path.absolute(getIncrementalCompilerByteStoreDirectory()),
+      mainPath: fs.file(mainPath).absolute.path,
+      outputFilePath: applicationKernelFilePath,
+      depFilePath: depfilePath,
+      trackWidgetCreation: trackWidgetCreation,
+      fileSystemRoots: fileSystemRoots,
+      fileSystemScheme: fileSystemScheme,
+      packagesPath: packagesPath,
     );
-
-    if (await fingerprinter.doesFingerprintMatch()) {
-      needBuild = false;
-      printTrace('Skipping kernel compilation. Fingerprint match.');
+    if (compilerOutput?.outputFilename == null) {
+      throwToolExit('Compiler failed on $mainPath');
     }
-
-    String kernelBinaryFilename;
-    if (needBuild) {
-      ensureDirectoryExists(applicationKernelFilePath);
-      final CompilerOutput compilerOutput = await kernelCompiler.compile(
-        sdkRoot: artifacts.getArtifactPath(Artifact.flutterPatchedSdkPath),
-        incrementalCompilerByteStorePath: fs.path.absolute(getIncrementalCompilerByteStoreDirectory()),
-        mainPath: fs.file(mainPath).absolute.path,
-        outputFilePath: applicationKernelFilePath,
-        depFilePath: depfilePath,
-        trackWidgetCreation: trackWidgetCreation,
-        fileSystemRoots: fileSystemRoots,
-        fileSystemScheme: fileSystemScheme,
-        packagesPath: packagesPath,
-      );
-      kernelBinaryFilename = compilerOutput?.outputFilename;
-      if (kernelBinaryFilename == null) {
-        throwToolExit('Compiler failed on $mainPath');
-      }
-      // Compute and record build fingerprint.
-      await fingerprinter.writeFingerprint();
-    } else {
-      kernelBinaryFilename = applicationKernelFilePath;
-    }
-    kernelContent = new DevFSFileContent(fs.file(kernelBinaryFilename));
+    kernelContent = new DevFSFileContent(fs.file(compilerOutput.outputFilename));
 
     await fs.directory(getBuildDirectory()).childFile('frontend_server.d')
         .writeAsString('frontend_server.d: ${artifacts.getArtifactPath(Artifact.frontendServerSnapshotForEngineDartSdk)}\n');

--- a/packages/flutter_tools/lib/src/compile.dart
+++ b/packages/flutter_tools/lib/src/compile.dart
@@ -10,6 +10,7 @@ import 'package:usage/uuid/uuid.dart';
 import 'artifacts.dart';
 import 'base/common.dart';
 import 'base/context.dart';
+import 'base/fingerprint.dart';
 import 'base/io.dart';
 import 'base/process_manager.dart';
 import 'globals.dart';
@@ -84,6 +85,28 @@ class KernelCompiler {
       Artifact.frontendServerSnapshotForEngineDartSdk
     );
 
+    // TODO(cbracken) eliminate pathFilter.
+    // Currently the compiler emits buildbot paths for the core libs in the
+    // depfile. None of these are available on the local host.
+    Fingerprinter fingerprinter;
+    if (depFilePath != null) {
+      fingerprinter = new Fingerprinter(
+        fingerprintPath: '$depFilePath.fingerprint',
+        paths: <String>[mainPath],
+        properties: <String, String>{
+          'entryPoint': mainPath,
+          'trackWidgetCreation': trackWidgetCreation.toString(),
+        },
+        depfilePaths: <String>[depFilePath],
+        pathFilter: (String path) => !path.startsWith('/b/build/slave/'),
+      );
+
+      if (await fingerprinter.doesFingerprintMatch()) {
+        printTrace('Skipping kernel compilation. Fingerprint match.');
+        return new CompilerOutput(outputFilePath, 0);
+      }
+    }
+
     // This is a URI, not a file path, so the forward slash is correct even on Windows.
     if (!sdkRoot.endsWith('/'))
       sdkRoot = '$sdkRoot/';
@@ -153,7 +176,13 @@ class KernelCompiler {
       .transform(const LineSplitter())
       .listen(stdoutHandler.handler);
     final int exitCode = await server.exitCode;
-    return exitCode == 0 ? stdoutHandler.compilerOutput.future : null;
+    if (exitCode == 0) {
+      if (fingerprinter != null) {
+        await fingerprinter.writeFingerprint();
+      }
+      return stdoutHandler.compilerOutput.future;
+    }
+    return null;
   }
 }
 


### PR DESCRIPTION
We've always cached kernel compiles during bundle builds. This adds
caching for kernel compiles during AOT builds by moving caching into the
KernelCompiler.compile() method rather than around each invocation of it.

This also filters buildbot paths included by the kernel compile that are
not present on the local machine at paths /b/build/slave/Linux_Engine/...
The kernel compiler should probably include an option to not emit these
paths in the depfile, since these are used both by Gradle and the
Fingerprinter class.