### PR TITLE
Allow 32-bit iOS device simulators

### DIFF
--- a/packages/flutter_tools/lib/src/ios/simulators.dart
+++ b/packages/flutter_tools/lib/src/ios/simulators.dart
@@ -247,36 +247,13 @@ class IOSSimulator extends Device {
       return false;
     }
 
-    // Step 1: Check if the device is part of a blacklisted category.
-    //         We do not support WatchOS or tvOS devices.
-
+    // Check if the device is part of a blacklisted category.
+    // We do not yet support WatchOS or tvOS devices.
     final RegExp blacklist = new RegExp(r'Apple (TV|Watch)', caseSensitive: false);
     if (blacklist.hasMatch(name)) {
-      _supportMessage = 'Flutter does not support Apple TV or Apple Watch. Select an iPhone 5s or above.';
+      _supportMessage = 'Flutter does not support Apple TV or Apple Watch.';
       return false;
     }
-
-    // Step 2: Check if the device must be rejected because of its version.
-    //         There is an artificial check on older simulators where arm64
-    //         targeted applications cannot be run (even though the Flutter
-    //         runner on the simulator is completely different).
-
-    // Check for unsupported iPads.
-    final Match iPadMatch = new RegExp(r'iPad (2|Retina)', caseSensitive: false).firstMatch(name);
-    if (iPadMatch != null) {
-      _supportMessage = 'Flutter does not yet support iPad 2 or iPad Retina. Select an iPad Air or above.';
-      return false;
-    }
-
-    // Check for unsupported iPhones.
-    final Match iPhoneMatch = new RegExp(r'iPhone [0-5]').firstMatch(name);
-    if (iPhoneMatch != null) {
-      if (name == 'iPhone 5s')
-        return true;
-      _supportMessage = 'Flutter does not yet support iPhone 5 or earlier. Select an iPhone 5s or above.';
-      return false;
-    }
-
     return true;
   }
 

--- a/packages/flutter_tools/test/ios/simulators_test.dart
+++ b/packages/flutter_tools/test/ios/simulators_test.dart
@@ -122,20 +122,20 @@ void main() {
       Platform: () => osx,
     });
 
-    testUsingContext('iPad 2 is unsupported', () {
-      expect(new IOSSimulator('x', name: 'iPad 2').isSupported(), false);
+    testUsingContext('iPad 2 is supported', () {
+      expect(new IOSSimulator('x', name: 'iPad 2').isSupported(), true);
     }, overrides: <Type, Generator>{
       Platform: () => osx,
     });
 
-    testUsingContext('iPad Retina is unsupported', () {
-      expect(new IOSSimulator('x', name: 'iPad Retina').isSupported(), false);
+    testUsingContext('iPad Retina is supported', () {
+      expect(new IOSSimulator('x', name: 'iPad Retina').isSupported(), true);
     }, overrides: <Type, Generator>{
       Platform: () => osx,
     });
 
-    testUsingContext('iPhone 5 is unsupported', () {
-      expect(new IOSSimulator('x', name: 'iPhone 5').isSupported(), false);
+    testUsingContext('iPhone 5 is supported', () {
+      expect(new IOSSimulator('x', name: 'iPhone 5').isSupported(), true);
     }, overrides: <Type, Generator>{
       Platform: () => osx,
     });
@@ -154,6 +154,12 @@ void main() {
 
     testUsingContext('iPhone 7 Plus is supported', () {
       expect(new IOSSimulator('x', name: 'iPhone 7 Plus').isSupported(), true);
+    }, overrides: <Type, Generator>{
+      Platform: () => osx,
+    });
+
+    testUsingContext('iPhone X is supported', () {
+      expect(new IOSSimulator('x', name: 'iPhone X').isSupported(), true);
     }, overrides: <Type, Generator>{
       Platform: () => osx,
     });


### PR DESCRIPTION
Previously, Flutter did not support iOS devices with armv7 or armv7s
CPUs. We now support these devices. This eliminates the previous
hardcoded checks that prevented running on simulators of older devices.

We maintain the existing restriction on running on watchOS or tvOS
simulators.