### PR TITLE
Explicitly specify softfp ABI for armv7 builds

### DIFF
--- a/packages/flutter_tools/lib/src/base/build.dart
+++ b/packages/flutter_tools/lib/src/base/build.dart
@@ -222,6 +222,11 @@ class AOTSnapshotter {
     }
 
     if (platform == TargetPlatform.android_arm || iosArch == IOSArch.armv7) {
+      // Use softfp for Android armv7 devices.
+      // Note that this is the default for armv7 iOS builds, but harmless to set.
+      // TODO(cbracken) use TargetPlatform-specific gen_snapshot for Android so that this is defaulted.
+      genSnapshotArgs.add('--no-sim-use-hardfp');
+
       // Not supported by the Pixel in 32-bit mode.
       genSnapshotArgs.add('--no-use-integer-division');
     }


### PR DESCRIPTION
This reverts #17147, which was safe under the assumption that
getArtifactPath() returns a platform-specific gen_snapshot instance
(which have the correct default set for this flag) -- it turns out that
though we pass the platform to getArtifactPath(), we always return the
host gen_snapshot for Android.

A followup patch will update getArtifactPath() and revert this patch.