### PR TITLE
First run simulator with -n to ensure it always opens a device

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_emulator.dart
+++ b/packages/flutter_tools/lib/src/android/android_emulator.dart
@@ -41,20 +41,22 @@ class AndroidEmulator extends Emulator {
   String get label => _properties['avd.ini.displayname'];
 
   @override
-  Future<void> launch() async {
-    final Future<void> launchResult =
+  Future<bool> launch() async {
+    final Future<bool> launchResult =
         runAsync(<String>[getEmulatorPath(), '-avd', id])
             .then((RunResult runResult) {
               if (runResult.exitCode != 0) {
                 printError('$runResult');
+                return false;
               }
+              return true;
             });
     // emulator continues running on a successful launch so if we
     // haven't quit within 3 seconds we assume that's a success and just
     // return.
-    await Future.any<void>(<Future<void>>[
+    return Future.any<bool>(<Future<bool>>[
       launchResult,
-      new Future<void>.delayed(const Duration(seconds: 3))
+      new Future<void>.delayed(const Duration(seconds: 3)).then((_) => true)
     ]);
   }
 }

--- a/packages/flutter_tools/lib/src/emulator.dart
+++ b/packages/flutter_tools/lib/src/emulator.dart
@@ -95,7 +95,7 @@ abstract class Emulator {
     return id == other.id;
   }
 
-  Future<void> launch();
+  Future<bool> launch();
 
   @override
   String toString() => name;

--- a/packages/flutter_tools/lib/src/ios/ios_emulators.dart
+++ b/packages/flutter_tools/lib/src/ios/ios_emulators.dart
@@ -36,8 +36,8 @@ class IOSEmulator extends Emulator {
   String get label => null;
 
   @override
-  Future<void> launch() async {
-    Future<void> launchSimulator(List<String> additionalArgs) async {
+  Future<bool> launch() async {
+    Future<bool> launchSimulator(List<String> additionalArgs) async {
       final List<String> args = <String>['open']
           .followedBy(additionalArgs)
           .followedBy(<String>['-a', getSimulatorPath()]);
@@ -45,15 +45,18 @@ class IOSEmulator extends Emulator {
       final RunResult launchResult = await runAsync(args);
       if (launchResult.exitCode != 0) {
         printError('$launchResult');
+        return false;
       }
+      return true;
     }
 
     // First run with `-n` to force a device to boot if there isn't already one
-    await launchSimulator(<String>['-n']);
+    if (!await launchSimulator(<String>['-n']))
+      return false;
     
     // Run again to force it to Foreground (using -n doesn't force existing
     // devices to the foreground)
-    await launchSimulator(<String>[]);
+    return launchSimulator(<String>[]);
   }
 }
 

--- a/packages/flutter_tools/lib/src/ios/ios_emulators.dart
+++ b/packages/flutter_tools/lib/src/ios/ios_emulators.dart
@@ -37,11 +37,23 @@ class IOSEmulator extends Emulator {
 
   @override
   Future<void> launch() async {
-    final RunResult launchResult =
-        await runAsync(<String>['open', '-a', getSimulatorPath()]);
-    if (launchResult.exitCode != 0) {
-      printError('$launchResult');
+    Future<void> launchSimulator(List<String> additionalArgs) async {
+      final List<String> args = <String>['open']
+          .followedBy(additionalArgs)
+          .followedBy(<String>['-a', getSimulatorPath()]);
+
+      final RunResult launchResult = await runAsync(args);
+      if (launchResult.exitCode != 0) {
+        printError('$launchResult');
+      }
     }
+
+    // First run with `-n` to force a device to boot if there isn't already one
+    await launchSimulator(<String>['-n']);
+    
+    // Run again to force it to Foreground (using -n doesn't force existing
+    // devices to the foreground)
+    await launchSimulator(<String>[]);
   }
 }
 

--- a/packages/flutter_tools/test/emulator_test.dart
+++ b/packages/flutter_tools/test/emulator_test.dart
@@ -62,7 +62,7 @@ class _MockEmulator extends Emulator {
   final String label;
 
   @override
-  Future<void> launch() {
+  Future<bool> launch() {
     throw new UnimplementedError('Not implemented in Mock');
   }
 }


### PR DESCRIPTION
@devoncarew This is a fix for the issue described in https://github.com/flutter/flutter-intellij/issues/2234. If you Cmd+W in Simulator to close the window but leave the app running, then `flutter emulator --launch ios` wouldn't seem to work. I found that passing `-n` which is supposed to force a new instance solves this (Simulator seems to not allow multiple running devices, so it doesn't actually create multiple instances).

However, a side-effect was that if it was already running, it bailed and didn't come to the foreground, so we just run it again without the `-n` immediately after (which brings it to the foreground).

It seems to work fine for me without having to show a message to the user. LMK what you think.

(cc @pq)