### PR TITLE
Add emulator.getEmulators and emulator.launch to daemon

### DIFF
--- a/packages/flutter_tools/lib/src/commands/daemon.dart
+++ b/packages/flutter_tools/lib/src/commands/daemon.dart
@@ -848,7 +848,6 @@ class EmulatorDomain extends Domain {
     return list.map(_emulatorToMap).toList();
   }
 
-  /// Enable device events.
   Future<Null> launch(Map<String, dynamic> args) async {
     final String emulatorId = _getStringArg(args, 'emulatorId', required: true);
     final List<Emulator> matches =

--- a/packages/flutter_tools/test/commands/daemon_test.dart
+++ b/packages/flutter_tools/test/commands/daemon_test.dart
@@ -263,6 +263,43 @@ void main() {
       AndroidWorkflow: () => new MockAndroidWorkflow(),
       IOSWorkflow: () => new MockIOSWorkflow(),
     });
+
+    testUsingContext('emulator.launch without an emulatorId should report an error', () async {
+      final DaemonCommand command = new DaemonCommand();
+      applyMocksToCommand(command);
+
+      final StreamController<Map<String, dynamic>> commands = new StreamController<Map<String, dynamic>>();
+      final StreamController<Map<String, dynamic>> responses = new StreamController<Map<String, dynamic>>();
+      daemon = new Daemon(
+        commands.stream,
+        responses.add,
+        daemonCommand: command,
+        notifyingLogger: notifyingLogger
+      );
+
+      commands.add(<String, dynamic>{ 'id': 0, 'method': 'emulator.launch' });
+      final Map<String, dynamic> response = await responses.stream.firstWhere(_notEvent);
+      expect(response['id'], 0);
+      expect(response['error'], contains('emulatorId is required'));
+      responses.close();
+      commands.close();
+    });
+
+    testUsingContext('emulator.getEmulators should respond with list', () async {
+      final StreamController<Map<String, dynamic>> commands = new StreamController<Map<String, dynamic>>();
+      final StreamController<Map<String, dynamic>> responses = new StreamController<Map<String, dynamic>>();
+      daemon = new Daemon(
+        commands.stream,
+        responses.add,
+        notifyingLogger: notifyingLogger
+      );
+      commands.add(<String, dynamic>{'id': 0, 'method': 'emulator.getEmulators'});
+      final Map<String, dynamic> response = await responses.stream.firstWhere(_notEvent);
+      expect(response['id'], 0);
+      expect(response['result'], isList);
+      responses.close();
+      commands.close();
+    });
   });
 
   group('daemon serialization', () {

--- a/packages/flutter_tools/tool/daemon_client.dart
+++ b/packages/flutter_tools/tool/daemon_client.dart
@@ -15,6 +15,8 @@ Process daemon;
 //   start: start an app
 //   stop: stop a running app
 //   devices: list devices
+//   emulators: list emulators
+//   launch: launch an emulator
 
 Future<Null> main() async {
   daemon = await Process.start('dart', <String>['bin/flutter_tools.dart', 'daemon']);
@@ -62,6 +64,15 @@ Future<Null> main() async {
       }
     } else if (line == 'devices') {
       _send(<String, dynamic>{'method': 'device.getDevices'});
+    } else if (line == 'emulators') {
+      _send(<String, dynamic>{'method': 'emulator.getEmulators'});
+    } else if (words.first == 'launch') {
+      _send(<String, dynamic>{
+        'method': 'emulator.launch',
+        'params': <String, dynamic>{
+          'emulatorId': words[1]
+        }
+      });
     } else if (line == 'enable') {
       _send(<String, dynamic>{'method': 'device.enable'});
     } else {

--- a/packages/flutter_tools/tool/daemon_client.dart
+++ b/packages/flutter_tools/tool/daemon_client.dart
@@ -66,7 +66,7 @@ Future<Null> main() async {
       _send(<String, dynamic>{'method': 'device.getDevices'});
     } else if (line == 'emulators') {
       _send(<String, dynamic>{'method': 'emulator.getEmulators'});
-    } else if (words.first == 'launch') {
+    } else if (words.first == 'emulator-launch') {
       _send(<String, dynamic>{
         'method': 'emulator.launch',
         'params': <String, dynamic>{

--- a/packages/flutter_tools/tool/daemon_client.dart
+++ b/packages/flutter_tools/tool/daemon_client.dart
@@ -5,7 +5,7 @@
 import 'dart:async';
 import 'dart:convert';
 
-import 'package:flutter_tools/src/base/io.dart';
+import 'dart:io';
 
 Process daemon;
 


### PR DESCRIPTION
@devoncarew This adds support to the daemon for listing and launching emulators. It was based on the devices code in there. I couldn't find many tests for getDevices but I copied what I did see and amended for emulators.

Something we might not have considered with daemon is versioning - should a client be able to tell whether a daemon will support listing emulators, for example? (in this case we can just send it and see if it errors, but if we ever want to make more breaking changes that might not be possible).

Note: for some reason to make `daemon_client.dart` work, I had to change this:

```
- import 'package:flutter_tools/src/base/io.dart';
+ import 'dart:io';
```

Otherwise `stdout` is null and it crashes. I did not commit that change as I don't understand the cause; but it may be a bug that should be fixed.

Related to:
- #14822
- Dart-Code/Dart-Code#490
- #13379