### PR TITLE
Update a TODO with issue number

### DIFF
--- a/packages/flutter_tools/lib/src/base/build.dart
+++ b/packages/flutter_tools/lib/src/base/build.dart
@@ -224,7 +224,7 @@ class AOTSnapshotter {
     if (platform == TargetPlatform.android_arm || iosArch == IOSArch.armv7) {
       // Use softfp for Android armv7 devices.
       // Note that this is the default for armv7 iOS builds, but harmless to set.
-      // TODO(cbracken) use TargetPlatform-specific gen_snapshot for Android so that this is defaulted.
+      // TODO(cbracken) eliminate this when we fix https://github.com/flutter/flutter/issues/17489
       genSnapshotArgs.add('--no-sim-use-hardfp');
 
       // Not supported by the Pixel in 32-bit mode.


### PR DESCRIPTION
Further digging revealed that the reason --no-sim-use-hardfp was
required to be specified explicitly was that Android engine gen_snapshot
binaries are built on Windows with target_os=win.