### PR TITLE
don't fail a test when there are issues deleting a temp dir

### DIFF
--- a/dev/bots/analyze-sample-code.dart
+++ b/dev/bots/analyze-sample-code.dart
@@ -294,7 +294,12 @@ dependencies:
       }
       print('-------8<-------');
     } else {
-      temp.deleteSync(recursive: true);
+      try {
+        temp.deleteSync(recursive: true);
+      } on FileSystemException catch (e) {
+        // ignore errors deleting the temporary directory
+        print('Ignored exception during tearDown: $e');
+      }
     }
   }
   exit(exitCode);


### PR DESCRIPTION
- don't fail a test when there are issues deleting a temp dir (we've seen this on the windows bot a few times)
- fix https://github.com/flutter/flutter/issues/17484
