### PR TITLE
Make non-global constants have consistent naming (with just _ instead of _k)

### DIFF
--- a/dev/integration_tests/channels/lib/src/basic_messaging.dart
+++ b/dev/integration_tests/channels/lib/src/basic_messaging.dart
@@ -12,16 +12,16 @@ import 'test_step.dart';
 class ExtendedStandardMessageCodec extends StandardMessageCodec {
   const ExtendedStandardMessageCodec();
 
-  static const int _kDateTime = 128;
-  static const int _kPair = 129;
+  static const int _dateTime = 128;
+  static const int _pair = 129;
 
   @override
   void writeValue(WriteBuffer buffer, dynamic value) {
     if (value is DateTime) {
-      buffer.putUint8(_kDateTime);
+      buffer.putUint8(_dateTime);
       buffer.putInt64(value.millisecondsSinceEpoch);
     } else if (value is Pair) {
-      buffer.putUint8(_kPair);
+      buffer.putUint8(_pair);
       writeValue(buffer, value.left);
       writeValue(buffer, value.right);
     } else {
@@ -32,9 +32,9 @@ class ExtendedStandardMessageCodec extends StandardMessageCodec {
   @override
   dynamic readValueOfType(int type, ReadBuffer buffer) {
     switch (type) {
-    case _kDateTime:
+    case _dateTime:
       return new DateTime.fromMillisecondsSinceEpoch(buffer.getInt64());
-    case _kPair:
+    case _pair:
       return new Pair(readValue(buffer), readValue(buffer));
     default: return super.readValueOfType(type, buffer);
     }

--- a/examples/flutter_gallery/lib/demo/shrine/shrine_home.dart
+++ b/examples/flutter_gallery/lib/demo/shrine/shrine_home.dart
@@ -94,17 +94,17 @@ class _ShrineGridLayout extends SliverGridLayout {
 }
 
 class _ShrineGridDelegate extends SliverGridDelegate {
-  static const double _kSpacing = 8.0;
+  static const double _spacing = 8.0;
 
   @override
   SliverGridLayout getLayout(SliverConstraints constraints) {
-    final double tileWidth = (constraints.crossAxisExtent - _kSpacing) / 2.0;
+    final double tileWidth = (constraints.crossAxisExtent - _spacing) / 2.0;
     const double tileHeight = 40.0 + 144.0 + 40.0;
     return new _ShrineGridLayout(
       tileWidth: tileWidth,
       tileHeight: tileHeight,
-      rowStride: tileHeight + _kSpacing,
-      columnStride: tileWidth + _kSpacing,
+      rowStride: tileHeight + _spacing,
+      columnStride: tileWidth + _spacing,
     );
   }
 

--- a/examples/flutter_gallery/lib/gallery/syntax_highlighter.dart
+++ b/examples/flutter_gallery/lib/gallery/syntax_highlighter.dart
@@ -65,7 +65,7 @@ class DartSyntaxHighlighter extends SyntaxHighlighter {
 
   SyntaxHighlighterStyle _style;
 
-  static const List<String> _kKeywords = const <String>[
+  static const List<String> _keywords = const <String>[
     'abstract', 'as', 'assert', 'async', 'await', 'break', 'case', 'catch',
     'class', 'const', 'continue', 'default', 'deferred', 'do', 'dynamic', 'else',
     'enum', 'export', 'external', 'extends', 'factory', 'false', 'final',
@@ -75,7 +75,7 @@ class DartSyntaxHighlighter extends SyntaxHighlighter {
     'void', 'while', 'with', 'yield'
   ];
 
-  static const List<String> _kBuiltInTypes = const <String>[
+  static const List<String> _builtInTypes = const <String>[
     'int', 'double', 'num', 'bool'
   ];
 
@@ -263,9 +263,9 @@ class DartSyntaxHighlighter extends SyntaxHighlighter {
         if (word.startsWith('_'))
           word = word.substring(1);
 
-        if (_kKeywords.contains(word))
+        if (_keywords.contains(word))
           type = _HighlightType.keyword;
-        else if (_kBuiltInTypes.contains(word))
+        else if (_builtInTypes.contains(word))
           type = _HighlightType.keyword;
         else if (_firstLetterIsUpperCase(word))
           type = _HighlightType.klass;

--- a/examples/stocks/lib/stock_data.dart
+++ b/examples/stocks/lib/stock_data.dart
@@ -65,7 +65,7 @@ class StockData extends ChangeNotifier {
     notifyListeners();
   }
 
-  static const int _kChunkCount = 30;
+  static const int _chunkCount = 30;
   int _nextChunk = 0;
 
   String _urlToFetch(int chunk) {
@@ -86,7 +86,7 @@ class StockData extends ChangeNotifier {
       }
       const JsonDecoder decoder = const JsonDecoder();
       add(decoder.convert(json));
-      if (_nextChunk < _kChunkCount) {
+      if (_nextChunk < _chunkCount) {
         _fetchNextChunk();
       } else {
         _end();

--- a/packages/flutter/lib/src/animation/curves.dart
+++ b/packages/flutter/lib/src/animation/curves.dart
@@ -214,7 +214,7 @@ class Cubic extends Curve {
   /// to the curve at the point (1, 1).
   final double d;
 
-  static const double _kCubicErrorBound = 0.001;
+  static const double _cubicErrorBound = 0.001;
 
   double _evaluateCubic(double a, double b, double m) {
     return 3 * a * (1 - m) * (1 - m) * m +
@@ -230,7 +230,7 @@ class Cubic extends Curve {
     while (true) {
       final double midpoint = (start + end) / 2;
       final double estimate = _evaluateCubic(a, c, midpoint);
-      if ((t - estimate).abs() < _kCubicErrorBound)
+      if ((t - estimate).abs() < _cubicErrorBound)
         return _evaluateCubic(b, d, midpoint);
       if (estimate < t)
         start = midpoint;

--- a/packages/flutter/lib/src/cupertino/refresh.dart
+++ b/packages/flutter/lib/src/cupertino/refresh.dart
@@ -266,8 +266,8 @@ class CupertinoRefreshControl extends StatefulWidget {
   ///
   /// [onRefresh] will be called when pulled far enough to trigger a refresh.
   const CupertinoRefreshControl({
-    this.refreshTriggerPullDistance: _kDefaultRefreshTriggerPullDistance,
-    this.refreshIndicatorExtent: _kDefaultRefreshIndicatorExtent,
+    this.refreshTriggerPullDistance: _defaultRefreshTriggerPullDistance,
+    this.refreshIndicatorExtent: _defaultRefreshIndicatorExtent,
     this.builder: buildSimpleRefreshIndicator,
     this.onRefresh,
   }) : assert(refreshTriggerPullDistance != null),
@@ -321,8 +321,8 @@ class CupertinoRefreshControl extends StatefulWidget {
   /// where the sliver will start retracting.
   final RefreshCallback onRefresh;
 
-  static const double _kDefaultRefreshTriggerPullDistance = 100.0;
-  static const double _kDefaultRefreshIndicatorExtent = 60.0;
+  static const double _defaultRefreshTriggerPullDistance = 100.0;
+  static const double _defaultRefreshIndicatorExtent = 60.0;
 
   /// Retrieve the current state of the CupertinoRefreshControl. The same as the
   /// state that gets passed into the [builder] function. Used for testing.
@@ -376,7 +376,7 @@ class CupertinoRefreshControl extends StatefulWidget {
 class _CupertinoRefreshControlState extends State<CupertinoRefreshControl> {
   /// Reset the state from done to inactive when only this fraction of the
   /// original `refreshTriggerPullDistance` is left.
-  static const double _kInactiveResetOverscrollFraction = 0.1;
+  static const double _inactiveResetOverscrollFraction = 0.1;
 
   RefreshIndicatorMode refreshState;
   // [Future] returned by the widget's `onRefresh`.
@@ -482,7 +482,7 @@ class _CupertinoRefreshControlState extends State<CupertinoRefreshControl> {
         // can feel sluggish if not going all the way back to 0.0 prevented
         // a subsequent pull-to-refresh from starting.
         if (lastIndicatorExtent >
-            widget.refreshTriggerPullDistance * _kInactiveResetOverscrollFraction) {
+            widget.refreshTriggerPullDistance * _inactiveResetOverscrollFraction) {
           return RefreshIndicatorMode.done;
         } else {
           nextState = RefreshIndicatorMode.inactive;

--- a/packages/flutter/lib/src/foundation/basic_types.dart
+++ b/packages/flutter/lib/src/foundation/basic_types.dart
@@ -77,16 +77,16 @@ const int kMaxUnsignedSMI = 0x3FFFFFFFFFFFFFFF;
 /// A BitField over an enum (or other class whose values implement "index").
 /// Only the first 62 values of the enum can be used as indices.
 class BitField<T extends dynamic> {
-  static const int _kSMIBits = 62; // see https://www.dartlang.org/articles/numeric-computation/#smis-and-mints
-  static const int _kAllZeros = 0;
-  static const int _kAllOnes = kMaxUnsignedSMI; // 2^(_kSMIBits+1)-1
+  static const int _smiBits = 62; // see https://www.dartlang.org/articles/numeric-computation/#smis-and-mints
+  static const int _allZeros = 0;
+  static const int _allOnes = kMaxUnsignedSMI; // 2^(_kSMIBits+1)-1
 
   /// Creates a bit field of all zeros.
   ///
   /// The given length must be at most 62.
   BitField(this._length)
-    : assert(_length <= _kSMIBits),
-      _bits = _kAllZeros;
+    : assert(_length <= _smiBits),
+      _bits = _allZeros;
 
   /// Creates a bit field filled with a particular value.
   ///
@@ -95,8 +95,8 @@ class BitField<T extends dynamic> {
   ///
   /// The given length must be at most 62.
   BitField.filled(this._length, bool value)
-    : assert(_length <= _kSMIBits),
-      _bits = value ? _kAllOnes : _kAllZeros;
+    : assert(_length <= _smiBits),
+      _bits = value ? _allOnes : _allZeros;
 
   final int _length;
   int _bits;
@@ -124,7 +124,7 @@ class BitField<T extends dynamic> {
   /// If the value is true, the bits are all set to one. Otherwise, the bits are
   /// all set to zero. Defaults to setting all the bits to zero.
   void reset([ bool value = false ]) {
-    _bits = value ? _kAllOnes : _kAllZeros;
+    _bits = value ? _allOnes : _allZeros;
   }
 }
 

--- a/packages/flutter/lib/src/gestures/velocity_tracker.dart
+++ b/packages/flutter/lib/src/gestures/velocity_tracker.dart
@@ -147,19 +147,19 @@ class _PointAtTime {
 /// The quality of the velocity estimation will be better if more data points
 /// have been received.
 class VelocityTracker {
-  static const int _kAssumePointerMoveStoppedMilliseconds = 40;
-  static const int _kHistorySize = 20;
-  static const int _kHorizonMilliseconds = 100;
-  static const int _kMinSampleSize = 3;
+  static const int _assumePointerMoveStoppedMilliseconds = 40;
+  static const int _historySize = 20;
+  static const int _horizonMilliseconds = 100;
+  static const int _minSampleSize = 3;
 
   // Circular buffer; current sample at _index.
-  final List<_PointAtTime> _samples = new List<_PointAtTime>(_kHistorySize);
+  final List<_PointAtTime> _samples = new List<_PointAtTime>(_historySize);
   int _index = 0;
 
   /// Adds a position as the given time to the tracker.
   void addPosition(Duration time, Offset position) {
     _index += 1;
-    if (_index == _kHistorySize)
+    if (_index == _historySize)
       _index = 0;
     _samples[_index] = new _PointAtTime(position, time);
   }
@@ -195,7 +195,7 @@ class VelocityTracker {
       final double age = (newestSample.time - sample.time).inMilliseconds.toDouble();
       final double delta = (sample.time - previousSample.time).inMilliseconds.abs().toDouble();
       previousSample = sample;
-      if (age > _kHorizonMilliseconds || delta > _kAssumePointerMoveStoppedMilliseconds)
+      if (age > _horizonMilliseconds || delta > _assumePointerMoveStoppedMilliseconds)
         break;
 
       oldestSample = sample;
@@ -204,12 +204,12 @@ class VelocityTracker {
       y.add(position.dy);
       w.add(1.0);
       time.add(-age);
-      index = (index == 0 ? _kHistorySize : index) - 1;
+      index = (index == 0 ? _historySize : index) - 1;
 
       sampleCount += 1;
-    } while (sampleCount < _kHistorySize);
+    } while (sampleCount < _historySize);
 
-    if (sampleCount >= _kMinSampleSize) {
+    if (sampleCount >= _minSampleSize) {
       final LeastSquaresSolver xSolver = new LeastSquaresSolver(time, x, w);
       final PolynomialFit xFit = xSolver.solve(2);
       if (xFit != null) {

--- a/packages/flutter/lib/src/material/data_table.dart
+++ b/packages/flutter/lib/src/material/data_table.dart
@@ -348,15 +348,15 @@ class DataTable extends StatelessWidget {
     }
   }
 
-  static const double _kHeadingRowHeight = 56.0;
-  static const double _kDataRowHeight = 48.0;
-  static const double _kTablePadding = 24.0;
-  static const double _kColumnSpacing = 56.0;
-  static const double _kSortArrowPadding = 2.0;
-  static const double _kHeadingFontSize = 12.0;
-  static const Duration _kSortArrowAnimationDuration = const Duration(milliseconds: 150);
-  static const Color _kGrey100Opacity = const Color(0x0A000000); // Grey 100 as opacity instead of solid color
-  static const Color _kGrey300Opacity = const Color(0x1E000000); // Dark theme variant is just a guess.
+  static const double _headingRowHeight = 56.0;
+  static const double _dataRowHeight = 48.0;
+  static const double _tablePadding = 24.0;
+  static const double _columnSpacing = 56.0;
+  static const double _sortArrowPadding = 2.0;
+  static const double _headingFontSize = 12.0;
+  static const Duration _sortArrowAnimationDuration = const Duration(milliseconds: 150);
+  static const Color _grey100Opacity = const Color(0x0A000000); // Grey 100 as opacity instead of solid color
+  static const Color _grey300Opacity = const Color(0x1E000000); // Dark theme variant is just a guess.
 
   Widget _buildCheckbox({
     Color color,
@@ -365,7 +365,7 @@ class DataTable extends StatelessWidget {
     ValueChanged<bool> onCheckboxChanged
   }) {
     Widget contents = new Padding(
-      padding: const EdgeInsetsDirectional.only(start: _kTablePadding, end: _kTablePadding / 2.0),
+      padding: const EdgeInsetsDirectional.only(start: _tablePadding, end: _tablePadding / 2.0),
       child: new Center(
         child: new Checkbox(
           activeColor: color,
@@ -400,9 +400,9 @@ class DataTable extends StatelessWidget {
       final Widget arrow = new _SortArrow(
         visible: sorted,
         down: sorted ? ascending : null,
-        duration: _kSortArrowAnimationDuration,
+        duration: _sortArrowAnimationDuration,
       );
-      const Widget arrowPadding = const SizedBox(width: _kSortArrowPadding);
+      const Widget arrowPadding = const SizedBox(width: _sortArrowPadding);
       label = new Row(
         textDirection: numeric ? TextDirection.rtl : null,
         children: <Widget>[ label, arrowPadding, arrow ],
@@ -410,20 +410,20 @@ class DataTable extends StatelessWidget {
     }
     label = new Container(
       padding: padding,
-      height: _kHeadingRowHeight,
+      height: _headingRowHeight,
       alignment: numeric ? Alignment.centerRight : AlignmentDirectional.centerStart,
       child: new AnimatedDefaultTextStyle(
         style: new TextStyle(
           // TODO(ianh): font family should match Theme; see https://github.com/flutter/flutter/issues/3116
           fontWeight: FontWeight.w500,
-          fontSize: _kHeadingFontSize,
-          height: math.min(1.0, _kHeadingRowHeight / _kHeadingFontSize),
+          fontSize: _headingFontSize,
+          height: math.min(1.0, _headingRowHeight / _headingFontSize),
           color: (Theme.of(context).brightness == Brightness.light)
             ? ((onSort != null && sorted) ? Colors.black87 : Colors.black54)
             : ((onSort != null && sorted) ? Colors.white : Colors.white70),
         ),
         softWrap: false,
-        duration: _kSortArrowAnimationDuration,
+        duration: _sortArrowAnimationDuration,
         child: label,
       ),
     );
@@ -463,7 +463,7 @@ class DataTable extends StatelessWidget {
     }
     label = new Container(
       padding: padding,
-      height: _kDataRowHeight,
+      height: _dataRowHeight,
       alignment: numeric ? Alignment.centerRight : AlignmentDirectional.centerStart,
       child: new DefaultTextStyle(
         style: new TextStyle(
@@ -503,7 +503,7 @@ class DataTable extends StatelessWidget {
     final BoxDecoration _kSelectedDecoration = new BoxDecoration(
       border: new Border(bottom: Divider.createBorderSide(context, width: 1.0)),
       // The backgroundColor has to be transparent so you can see the ink on the material
-      color: (Theme.of(context).brightness == Brightness.light) ? _kGrey100Opacity : _kGrey300Opacity,
+      color: (Theme.of(context).brightness == Brightness.light) ? _grey100Opacity : _grey300Opacity,
     );
     final BoxDecoration _kUnselectedDecoration = new BoxDecoration(
       border: new Border(bottom: Divider.createBorderSide(context, width: 1.0)),
@@ -529,7 +529,7 @@ class DataTable extends StatelessWidget {
 
     int displayColumnIndex = 0;
     if (showCheckboxColumn) {
-      tableColumns[0] = const FixedColumnWidth(_kTablePadding + Checkbox.width + _kTablePadding / 2.0);
+      tableColumns[0] = const FixedColumnWidth(_tablePadding + Checkbox.width + _tablePadding / 2.0);
       tableRows[0].children[0] = _buildCheckbox(
         color: theme.accentColor,
         checked: allChecked,
@@ -551,8 +551,8 @@ class DataTable extends StatelessWidget {
     for (int dataColumnIndex = 0; dataColumnIndex < columns.length; dataColumnIndex += 1) {
       final DataColumn column = columns[dataColumnIndex];
       final EdgeInsetsDirectional padding = new EdgeInsetsDirectional.only(
-        start: dataColumnIndex == 0 ? showCheckboxColumn ? _kTablePadding / 2.0 : _kTablePadding : _kColumnSpacing / 2.0,
-        end: dataColumnIndex == columns.length - 1 ? _kTablePadding : _kColumnSpacing / 2.0,
+        start: dataColumnIndex == 0 ? showCheckboxColumn ? _tablePadding / 2.0 : _tablePadding : _columnSpacing / 2.0,
+        end: dataColumnIndex == columns.length - 1 ? _tablePadding : _columnSpacing / 2.0,
       );
       if (dataColumnIndex == _onlyTextColumn) {
         tableColumns[displayColumnIndex] = const IntrinsicColumnWidth(flex: 1.0);
@@ -768,8 +768,8 @@ class _SortArrowState extends State<_SortArrow> with TickerProviderStateMixin {
     super.dispose();
   }
 
-  static const double _kArrowIconBaselineOffset = -1.5;
-  static const double _kArrowIconSize = 16.0;
+  static const double _arrowIconBaselineOffset = -1.5;
+  static const double _arrowIconSize = 16.0;
 
   @override
   Widget build(BuildContext context) {
@@ -777,11 +777,11 @@ class _SortArrowState extends State<_SortArrow> with TickerProviderStateMixin {
       opacity: _opacityAnimation.value,
       child: new Transform(
         transform: new Matrix4.rotationZ(_orientationOffset + _orientationAnimation.value)
-                             ..setTranslationRaw(0.0, _kArrowIconBaselineOffset, 0.0),
+                             ..setTranslationRaw(0.0, _arrowIconBaselineOffset, 0.0),
         alignment: Alignment.center,
         child: new Icon(
           Icons.arrow_downward,
-          size: _kArrowIconSize,
+          size: _arrowIconSize,
           color: (Theme.of(context).brightness == Brightness.light) ? Colors.black87 : Colors.white70,
         ),
       ),

--- a/packages/flutter/lib/src/material/date_picker.dart
+++ b/packages/flutter/lib/src/material/date_picker.dart
@@ -310,7 +310,7 @@ class DayPicker extends StatelessWidget {
   }
 
   // Do not use this directly - call getDaysInMonth instead.
-  static const List<int> _kDaysInMonth = const <int>[31, -1, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+  static const List<int> _daysInMonth = const <int>[31, -1, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
 
   /// Returns the number of days in a month, according to the proleptic
   /// Gregorian calendar.
@@ -324,7 +324,7 @@ class DayPicker extends StatelessWidget {
         return 29;
       return 28;
     }
-    return _kDaysInMonth[month - 1];
+    return _daysInMonth[month - 1];
   }
 
   /// Computes the offset from the first day of week that the first day of the

--- a/packages/flutter/lib/src/material/popup_menu.dart
+++ b/packages/flutter/lib/src/material/popup_menu.dart
@@ -377,14 +377,14 @@ class CheckedPopupMenuItem<T> extends PopupMenuItem<T> {
 }
 
 class _CheckedPopupMenuItemState<T> extends PopupMenuItemState<T, CheckedPopupMenuItem<T>> with SingleTickerProviderStateMixin {
-  static const Duration _kFadeDuration = const Duration(milliseconds: 150);
+  static const Duration _fadeDuration = const Duration(milliseconds: 150);
   AnimationController _controller;
   Animation<double> get _opacity => _controller.view;
 
   @override
   void initState() {
     super.initState();
-    _controller = new AnimationController(duration: _kFadeDuration, vsync: this)
+    _controller = new AnimationController(duration: _fadeDuration, vsync: this)
       ..value = widget.checked ? 1.0 : 0.0
       ..addListener(() => setState(() { /* animation changed */ }));
   }

--- a/packages/flutter/lib/src/material/progress_indicator.dart
+++ b/packages/flutter/lib/src/material/progress_indicator.dart
@@ -254,11 +254,11 @@ class _LinearProgressIndicatorState extends State<LinearProgressIndicator> with 
 }
 
 class _CircularProgressIndicatorPainter extends CustomPainter {
-  static const double _kTwoPI = math.pi * 2.0;
-  static const double _kEpsilon = .001;
+  static const double _twoPi = math.pi * 2.0;
+  static const double _epsilon = .001;
   // Canvas.drawArc(r, 0, 2*PI) doesn't draw anything, so just get close.
-  static const double _kSweep = _kTwoPI - _kEpsilon;
-  static const double _kStartAngle = -math.pi / 2.0;
+  static const double _sweep = _twoPi - _epsilon;
+  static const double _startAngle = -math.pi / 2.0;
 
   _CircularProgressIndicatorPainter({
     this.valueColor,
@@ -269,11 +269,11 @@ class _CircularProgressIndicatorPainter extends CustomPainter {
     this.rotationValue,
     this.strokeWidth,
   }) : arcStart = value != null
-         ? _kStartAngle
-         : _kStartAngle + tailValue * 3 / 2 * math.pi + rotationValue * math.pi * 1.7 - stepValue * 0.8 * math.pi,
+         ? _startAngle
+         : _startAngle + tailValue * 3 / 2 * math.pi + rotationValue * math.pi * 1.7 - stepValue * 0.8 * math.pi,
        arcSweep = value != null
-         ? value.clamp(0.0, 1.0) * _kSweep
-         : math.max(headValue * 3 / 2 * math.pi - tailValue * 3 / 2 * math.pi, _kEpsilon);
+         ? value.clamp(0.0, 1.0) * _sweep
+         : math.max(headValue * 3 / 2 * math.pi - tailValue * 3 / 2 * math.pi, _epsilon);
 
   final Color valueColor;
   final double value;
@@ -518,7 +518,7 @@ class RefreshProgressIndicator extends CircularProgressIndicator {
 }
 
 class _RefreshProgressIndicatorState extends _CircularProgressIndicatorState {
-  static const double _kIndicatorSize = 40.0;
+  static const double _indicatorSize = 40.0;
 
   // Always show the indeterminate version of the circular progress indicator.
   // When value is non-null the sweep of the progress indicator arrow's arc
@@ -537,8 +537,8 @@ class _RefreshProgressIndicatorState extends _CircularProgressIndicatorState {
   Widget _buildIndicator(BuildContext context, double headValue, double tailValue, int stepValue, double rotationValue) {
     final double arrowheadScale = widget.value == null ? 0.0 : (widget.value * 2.0).clamp(0.0, 1.0);
     return new Container(
-      width: _kIndicatorSize,
-      height: _kIndicatorSize,
+      width: _indicatorSize,
+      height: _indicatorSize,
       margin: const EdgeInsets.all(4.0), // accommodate the shadow
       child: new Material(
         type: MaterialType.circle,

--- a/packages/flutter/lib/src/material/time_picker.dart
+++ b/packages/flutter/lib/src/material/time_picker.dart
@@ -893,7 +893,7 @@ class _DialPainter extends CustomPainter {
     canvas.restore();
   }
 
-  static const double _kSemanticNodeSizeScale = 1.5;
+  static const double _semanticNodeSizeScale = 1.5;
 
   @override
   SemanticsBuilderCallback get semanticsBuilder => _buildSemantics;
@@ -901,7 +901,7 @@ class _DialPainter extends CustomPainter {
   /// Creates semantics nodes for the hour/minute labels painted on the dial.
   ///
   /// The nodes are positioned on top of the text and their size is
-  /// [_kSemanticNodeSizeScale] bigger than those of the text boxes to provide
+  /// [_semanticNodeSizeScale] bigger than those of the text boxes to provide
   /// bigger tap area.
   List<CustomPainterSemantics> _buildSemantics(Size size) {
     final double radius = size.shortestSide / 2.0;
@@ -934,8 +934,8 @@ class _DialPainter extends CustomPainter {
 
       for (_TappableLabel label in labels) {
         final TextPainter labelPainter = label.painter;
-        final double width = labelPainter.width * _kSemanticNodeSizeScale;
-        final double height = labelPainter.height * _kSemanticNodeSizeScale;
+        final double width = labelPainter.width * _semanticNodeSizeScale;
+        final double height = labelPainter.height * _semanticNodeSizeScale;
         final Offset nodeOffset = getOffsetForTheta(labelTheta, ring) + new Offset(-width / 2.0, -height / 2.0);
         final CustomPainterSemantics node = new CustomPainterSemantics(
           rect: new Rect.fromLTRB(

--- a/packages/flutter/lib/src/physics/tolerance.dart
+++ b/packages/flutter/lib/src/physics/tolerance.dart
@@ -10,12 +10,12 @@ class Tolerance {
   ///
   /// The arguments should all be positive values.
   const Tolerance({
-    this.distance: _kEpsilonDefault,
-    this.time: _kEpsilonDefault,
-    this.velocity: _kEpsilonDefault
+    this.distance: _epsilonDefault,
+    this.time: _epsilonDefault,
+    this.velocity: _epsilonDefault
   });
 
-  static const double _kEpsilonDefault = 1e-3;
+  static const double _epsilonDefault = 1e-3;
 
   /// A default tolerance of 0.001 for all three values.
   static const Tolerance defaultTolerance = const Tolerance();

--- a/packages/flutter/lib/src/rendering/viewport.dart
+++ b/packages/flutter/lib/src/rendering/viewport.dart
@@ -1008,7 +1008,7 @@ class RenderViewport extends RenderViewportBase<SliverPhysicalContainerParentDat
     }
   }
 
-  static const int _kMaxLayoutCycles = 10;
+  static const int _maxLayoutCycles = 10;
 
   // Out-of-band data computed during layout.
   double _minScrollExtent;
@@ -1057,9 +1057,9 @@ class RenderViewport extends RenderViewportBase<SliverPhysicalContainerParentDat
           break;
       }
       count += 1;
-    } while (count < _kMaxLayoutCycles);
+    } while (count < _maxLayoutCycles);
     assert(() {
-      if (count >= _kMaxLayoutCycles) {
+      if (count >= _maxLayoutCycles) {
         assert(count != 1);
         throw new FlutterError(
           'A RenderViewport exceeded its maximum number of layout cycles.\n'

--- a/packages/flutter/lib/src/services/message_codecs.dart
+++ b/packages/flutter/lib/src/services/message_codecs.dart
@@ -245,20 +245,20 @@ class StandardMessageCodec implements MessageCodec<dynamic> {
   // * Maps are encoded by first encoding their length in the expanding format,
   //   then follows the recursive encoding of each key/value pair, including the
   //   type byte for both (Maps are assumed to be heterogeneous).
-  static const int _kNull = 0;
-  static const int _kTrue = 1;
-  static const int _kFalse = 2;
-  static const int _kInt32 = 3;
-  static const int _kInt64 = 4;
-  static const int _kLargeInt = 5;
-  static const int _kFloat64 = 6;
-  static const int _kString = 7;
-  static const int _kUint8List = 8;
-  static const int _kInt32List = 9;
-  static const int _kInt64List = 10;
-  static const int _kFloat64List = 11;
-  static const int _kList = 12;
-  static const int _kMap = 13;
+  static const int _valueNull = 0;
+  static const int _valueTrue = 1;
+  static const int _valueFalse = 2;
+  static const int _valueInt32 = 3;
+  static const int _valueInt64 = 4;
+  static const int _valueLargeInt = 5;
+  static const int _valueFloat64 = 6;
+  static const int _valueString = 7;
+  static const int _valueUint8List = 8;
+  static const int _valueInt32List = 9;
+  static const int _valueInt64List = 10;
+  static const int _valueFloat64List = 11;
+  static const int _valueList = 12;
+  static const int _valueMap = 13;
 
   /// Creates a [MessageCodec] using the Flutter standard binary encoding.
   const StandardMessageCodec();
@@ -297,49 +297,49 @@ class StandardMessageCodec implements MessageCodec<dynamic> {
   /// clashes with any later extensions to the base class.
   void writeValue(WriteBuffer buffer, dynamic value) {
     if (value == null) {
-      buffer.putUint8(_kNull);
+      buffer.putUint8(_valueNull);
     } else if (value is bool) {
-      buffer.putUint8(value ? _kTrue : _kFalse);
+      buffer.putUint8(value ? _valueTrue : _valueFalse);
     } else if (value is int) {
       if (-0x7fffffff - 1 <= value && value <= 0x7fffffff) {
-        buffer.putUint8(_kInt32);
+        buffer.putUint8(_valueInt32);
         buffer.putInt32(value);
       } else {
-        buffer.putUint8(_kInt64);
+        buffer.putUint8(_valueInt64);
         buffer.putInt64(value);
       }
     } else if (value is double) {
-      buffer.putUint8(_kFloat64);
+      buffer.putUint8(_valueFloat64);
       buffer.putFloat64(value);
     } else if (value is String) {
-      buffer.putUint8(_kString);
+      buffer.putUint8(_valueString);
       final List<int> bytes = utf8.encoder.convert(value);
       writeSize(buffer, bytes.length);
       buffer.putUint8List(bytes);
     } else if (value is Uint8List) {
-      buffer.putUint8(_kUint8List);
+      buffer.putUint8(_valueUint8List);
       writeSize(buffer, value.length);
       buffer.putUint8List(value);
     } else if (value is Int32List) {
-      buffer.putUint8(_kInt32List);
+      buffer.putUint8(_valueInt32List);
       writeSize(buffer, value.length);
       buffer.putInt32List(value);
     } else if (value is Int64List) {
-      buffer.putUint8(_kInt64List);
+      buffer.putUint8(_valueInt64List);
       writeSize(buffer, value.length);
       buffer.putInt64List(value);
     } else if (value is Float64List) {
-      buffer.putUint8(_kFloat64List);
+      buffer.putUint8(_valueFloat64List);
       writeSize(buffer, value.length);
       buffer.putFloat64List(value);
     } else if (value is List) {
-      buffer.putUint8(_kList);
+      buffer.putUint8(_valueList);
       writeSize(buffer, value.length);
       for (final dynamic item in value) {
         writeValue(buffer, item);
       }
     } else if (value is Map) {
-      buffer.putUint8(_kMap);
+      buffer.putUint8(_valueMap);
       writeSize(buffer, value.length);
       value.forEach((dynamic key, dynamic value) {
         writeValue(buffer, key);
@@ -368,22 +368,22 @@ class StandardMessageCodec implements MessageCodec<dynamic> {
   dynamic readValueOfType(int type, ReadBuffer buffer) {
     dynamic result;
     switch (type) {
-      case _kNull:
+      case _valueNull:
         result = null;
         break;
-      case _kTrue:
+      case _valueTrue:
         result = true;
         break;
-      case _kFalse:
+      case _valueFalse:
         result = false;
         break;
-      case _kInt32:
+      case _valueInt32:
         result = buffer.getInt32();
         break;
-      case _kInt64:
+      case _valueInt64:
         result = buffer.getInt64();
         break;
-      case _kLargeInt:
+      case _valueLargeInt:
         // Flutter Engine APIs to use large ints have been deprecated on
         // 2018-01-09 and will be made unavailable.
         // TODO(mravn): remove this case once the APIs are unavailable.
@@ -391,37 +391,37 @@ class StandardMessageCodec implements MessageCodec<dynamic> {
         final String hex = utf8.decoder.convert(buffer.getUint8List(length));
         result = int.parse(hex, radix: 16);
         break;
-      case _kFloat64:
+      case _valueFloat64:
         result = buffer.getFloat64();
         break;
-      case _kString:
+      case _valueString:
         final int length = readSize(buffer);
         result = utf8.decoder.convert(buffer.getUint8List(length));
         break;
-      case _kUint8List:
+      case _valueUint8List:
         final int length = readSize(buffer);
         result = buffer.getUint8List(length);
         break;
-      case _kInt32List:
+      case _valueInt32List:
         final int length = readSize(buffer);
         result = buffer.getInt32List(length);
         break;
-      case _kInt64List:
+      case _valueInt64List:
         final int length = readSize(buffer);
         result = buffer.getInt64List(length);
         break;
-      case _kFloat64List:
+      case _valueFloat64List:
         final int length = readSize(buffer);
         result = buffer.getFloat64List(length);
         break;
-      case _kList:
+      case _valueList:
         final int length = readSize(buffer);
         result = new List<dynamic>(length);
         for (int i = 0; i < length; i++) {
           result[i] = readValue(buffer);
         }
         break;
-      case _kMap:
+      case _valueMap:
         final int length = readSize(buffer);
         result = <dynamic, dynamic>{};
         for (int i = 0; i < length; i++) {

--- a/packages/flutter/lib/src/widgets/overscroll_indicator.dart
+++ b/packages/flutter/lib/src/widgets/overscroll_indicator.dart
@@ -313,8 +313,8 @@ class _GlowController extends ChangeNotifier {
   static const double _maxOpacity = 0.5;
   static const double _pullOpacityGlowFactor = 0.8;
   static const double _velocityGlowFactor = 0.00006;
-  static const double _SQRT3 = 1.73205080757; // const math.sqrt(3)
-  static const double _kWidthToHeightFactor = (3.0 / 4.0) * (2.0 - _SQRT3);
+  static const double _sqrt3 = 1.73205080757; // const math.sqrt(3)
+  static const double _widthToHeightFactor = (3.0 / 4.0) * (2.0 - _sqrt3);
 
   // absorbed velocities are clamped to the range _minVelocity.._maxVelocity
   static const double _minVelocity = 100.0; // logical pixels per second
@@ -362,7 +362,7 @@ class _GlowController extends ChangeNotifier {
     _pullDistance += overscroll / 200.0; // This factor is magic. Not clear why we need it to match Android.
     _glowOpacityTween.begin = _glowOpacity.value;
     _glowOpacityTween.end = math.min(_glowOpacity.value + overscroll / extent * _pullOpacityGlowFactor, _maxOpacity);
-    final double height = math.min(extent, crossExtent * _kWidthToHeightFactor);
+    final double height = math.min(extent, crossExtent * _widthToHeightFactor);
     _glowSizeTween.begin = _glowSize.value;
     _glowSizeTween.end = math.max(1.0 - 1.0 / (0.7 * math.sqrt(_pullDistance * height)), _glowSize.value);
     _displacementTarget = crossAxisOffset / crossExtent;
@@ -443,7 +443,7 @@ class _GlowController extends ChangeNotifier {
       return;
     final double baseGlowScale = size.width > size.height ? size.height / size.width : 1.0;
     final double radius = size.width * 3.0 / 2.0;
-    final double height = math.min(size.height, size.width * _kWidthToHeightFactor);
+    final double height = math.min(size.height, size.width * _widthToHeightFactor);
     final double scaleY = _glowSize.value * baseGlowScale;
     final Rect rect = new Rect.fromLTWH(0.0, 0.0, size.width, height);
     final Offset center = new Offset((size.width / 2.0) * (0.5 + _displacement), height - radius);

--- a/packages/flutter/lib/src/widgets/scroll_activity.dart
+++ b/packages/flutter/lib/src/widgets/scroll_activity.dart
@@ -275,7 +275,7 @@ class ScrollDragController implements Drag {
 
   /// The drag distance past which, a [motionStartDistanceThreshold] breaking
   /// drag is considered a deliberate fling.
-  static const double _kBigThresholdBreakDistance = 24.0;
+  static const double _bigThresholdBreakDistance = 24.0;
 
   bool get _reversed => axisDirectionIsReversed(delegate.axisDirection);
 
@@ -332,7 +332,7 @@ class ScrollDragController implements Drag {
         if (_offsetSinceLastStop.abs() > motionStartDistanceThreshold) {
           // Threshold broken.
           _offsetSinceLastStop = null;
-          if (offset.abs() > _kBigThresholdBreakDistance) {
+          if (offset.abs() > _bigThresholdBreakDistance) {
             // This is heuristically a very deliberate fling. Leave the motion
             // unaffected.
             return offset;

--- a/packages/flutter/lib/src/widgets/scroll_simulation.dart
+++ b/packages/flutter/lib/src/widgets/scroll_simulation.dart
@@ -145,10 +145,10 @@ class ClampingScrollSimulation extends Simulation {
     @required this.velocity,
     this.friction: 0.015,
     Tolerance tolerance: Tolerance.defaultTolerance,
-  }) : assert(_flingVelocityPenetration(0.0) == _kInitialVelocityPenetration),
+  }) : assert(_flingVelocityPenetration(0.0) == _initialVelocityPenetration),
        super(tolerance: tolerance) {
     _duration = _flingDuration(velocity);
-    _distance = (velocity * _duration / _kInitialVelocityPenetration).abs();
+    _distance = (velocity * _duration / _initialVelocityPenetration).abs();
   }
 
   /// The position of the particle at the beginning of the simulation.
@@ -200,14 +200,14 @@ class ClampingScrollSimulation extends Simulation {
   // Scale f(t) so that 0.0 <= f(t) <= 1.0
   // f(t) = (1165.03 t^3 - 3143.62 t^2 + 2945.87 t) / 961.0
   //      = 1.2 t^3 - 3.27 t^2 + 3.065 t
-  static const double _kInitialVelocityPenetration = 3.065;
+  static const double _initialVelocityPenetration = 3.065;
   static double _flingDistancePenetration(double t) {
-    return (1.2 * t * t * t) - (3.27 * t * t) + (_kInitialVelocityPenetration * t);
+    return (1.2 * t * t * t) - (3.27 * t * t) + (_initialVelocityPenetration * t);
   }
 
   // The derivative of the _flingDistancePenetration() function.
   static double _flingVelocityPenetration(double t) {
-    return (3.6 * t * t) - (6.54 * t) + _kInitialVelocityPenetration;
+    return (3.6 * t * t) - (6.54 * t) + _initialVelocityPenetration;
   }
 
   @override

--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -248,8 +248,8 @@ class TextSelectionOverlay {
       _value = value {
     final OverlayState overlay = Overlay.of(context);
     assert(overlay != null);
-    _handleController = new AnimationController(duration: _kFadeDuration, vsync: overlay);
-    _toolbarController = new AnimationController(duration: _kFadeDuration, vsync: overlay);
+    _handleController = new AnimationController(duration: _fadeDuration, vsync: overlay);
+    _toolbarController = new AnimationController(duration: _fadeDuration, vsync: overlay);
   }
 
   /// The context in which the selection handles should appear.
@@ -278,7 +278,7 @@ class TextSelectionOverlay {
   final TextSelectionDelegate selectionDelegate;
 
   /// Controls the fade-in animations.
-  static const Duration _kFadeDuration = const Duration(milliseconds: 150);
+  static const Duration _fadeDuration = const Duration(milliseconds: 150);
   AnimationController _handleController;
   AnimationController _toolbarController;
   Animation<double> get _handleOpacity => _handleController.view;

--- a/packages/flutter/lib/src/widgets/widget_inspector.dart
+++ b/packages/flutter/lib/src/widgets/widget_inspector.dart
@@ -1159,7 +1159,7 @@ class _WidgetInspectorState extends State<WidgetInspector>
 
   /// Distance from the edge of of the bounding box for an element to consider
   /// as selecting the edge of the bounding box.
-  static const double _kEdgeHitMargin = 2.0;
+  static const double _edgeHitMargin = 2.0;
 
   InspectorSelectionChangedCallback _selectionChangedCallback;
   @override
@@ -1224,7 +1224,7 @@ class _WidgetInspectorState extends State<WidgetInspector>
       // Hits that occur on the edge of the bounding box of an object are
       // given priority to provide a way to select objects that would
       // otherwise be hard to select.
-      if (!bounds.deflate(_kEdgeHitMargin).contains(localPosition))
+      if (!bounds.deflate(_edgeHitMargin).contains(localPosition))
         edgeHits.add(object);
     }
     if (hit)

--- a/packages/flutter_driver/lib/src/driver/driver.dart
+++ b/packages/flutter_driver/lib/src/driver/driver.dart
@@ -128,10 +128,10 @@ class FlutterDriver {
        _logCommunicationToFile = logCommunicationToFile,
        _driverId = _nextDriverId++;
 
-  static const String _kFlutterExtensionMethod = 'ext.flutter.driver';
-  static const String _kSetVMTimelineFlagsMethod = '_setVMTimelineFlags';
-  static const String _kGetVMTimelineMethod = '_getVMTimeline';
-  static const String _kClearVMTimelineMethod = '_clearVMTimeline';
+  static const String _flutterExtensionMethodName = 'ext.flutter.driver';
+  static const String _setVMTimelineFlagsMethodName = '_setVMTimelineFlags';
+  static const String _getVMTimelineMethodName = '_getVMTimeline';
+  static const String _clearVMTimelineMethodName = '_clearVMTimeline';
 
   static int _nextDriverId = 0;
 
@@ -235,10 +235,10 @@ class FlutterDriver {
     }
 
     /// Waits for a signal from the VM service that the extension is registered.
-    /// Returns [_kFlutterExtensionMethod]
+    /// Returns [_flutterExtensionMethodName]
     Future<String> waitForServiceExtension() {
       return isolate.onExtensionAdded.firstWhere((String extension) {
-        return extension == _kFlutterExtensionMethod;
+        return extension == _flutterExtensionMethodName;
       });
     }
 
@@ -346,7 +346,7 @@ class FlutterDriver {
       final Map<String, String> serialized = command.serialize();
       _logCommunication('>>> $serialized');
       response = await _appIsolate
-          .invokeExtension(_kFlutterExtensionMethod, serialized)
+          .invokeExtension(_flutterExtensionMethodName, serialized)
           .timeout(command.timeout + _kRpcGraceTime);
       _logCommunication('<<< $response');
     } on TimeoutException catch (error, stackTrace) {
@@ -649,7 +649,7 @@ class FlutterDriver {
   }) async {
     assert(streams != null && streams.isNotEmpty);
     try {
-      await _peer.sendRequest(_kSetVMTimelineFlagsMethod, <String, String>{
+      await _peer.sendRequest(_setVMTimelineFlagsMethodName, <String, String>{
         'recordedStreams': _timelineStreamsToString(streams)
       }).timeout(timeout);
       return null;
@@ -666,9 +666,9 @@ class FlutterDriver {
   Future<Timeline> stopTracingAndDownloadTimeline({ Duration timeout: _kShortTimeout }) async {
     try {
       await _peer
-          .sendRequest(_kSetVMTimelineFlagsMethod, <String, String>{'recordedStreams': '[]'})
+          .sendRequest(_setVMTimelineFlagsMethodName, <String, String>{'recordedStreams': '[]'})
           .timeout(timeout);
-      return new Timeline.fromJson(await _peer.sendRequest(_kGetVMTimelineMethod));
+      return new Timeline.fromJson(await _peer.sendRequest(_getVMTimelineMethodName));
     } catch (error, stackTrace) {
       throw new DriverError(
         'Failed to stop tracing due to remote error',
@@ -709,7 +709,7 @@ class FlutterDriver {
   Future<Null> clearTimeline({ Duration timeout: _kShortTimeout }) async {
     try {
       await _peer
-          .sendRequest(_kClearVMTimelineMethod, <String, String>{})
+          .sendRequest(_clearVMTimelineMethodName, <String, String>{})
           .timeout(timeout);
     } catch (error, stackTrace) {
       throw new DriverError(

--- a/packages/flutter_test/lib/src/binding.dart
+++ b/packages/flutter_test/lib/src/binding.dart
@@ -297,23 +297,23 @@ abstract class TestWidgetsFlutterBinding extends BindingBase
   FlutterExceptionHandler _oldExceptionHandler;
   FlutterErrorDetails _pendingExceptionDetails;
 
-  static const TextStyle _kMessageStyle = const TextStyle(
+  static const TextStyle _messageStyle = const TextStyle(
     color: const Color(0xFF917FFF),
     fontSize: 40.0,
   );
 
-  static const Widget _kPreTestMessage = const Center(
+  static const Widget _preTestMessage = const Center(
     child: const Text(
       'Test starting...',
-      style: _kMessageStyle,
+      style: _messageStyle,
       textDirection: TextDirection.ltr,
     )
   );
 
-  static const Widget _kPostTestMessage = const Center(
+  static const Widget _postTestMessage = const Center(
     child: const Text(
       'Test finished.',
-      style: _kMessageStyle,
+      style: _messageStyle,
       textDirection: TextDirection.ltr,
     )
   );
@@ -500,7 +500,7 @@ abstract class TestWidgetsFlutterBinding extends BindingBase
   Future<Null> _runTestBody(Future<Null> testBody(), VoidCallback invariantTester) async {
     assert(inTest);
 
-    runApp(new Container(key: new UniqueKey(), child: _kPreTestMessage)); // Reset the tree to a known state.
+    runApp(new Container(key: new UniqueKey(), child: _preTestMessage)); // Reset the tree to a known state.
     await pump();
 
     final bool autoUpdateGoldensBeforeTest = autoUpdateGoldenFiles;
@@ -513,7 +513,7 @@ abstract class TestWidgetsFlutterBinding extends BindingBase
       // We only try to clean up and verify invariants if we didn't already
       // fail. If we got an exception already, then we instead leave everything
       // alone so that we don't cause more spurious errors.
-      runApp(new Container(key: new UniqueKey(), child: _kPostTestMessage)); // Unmount any remaining widgets.
+      runApp(new Container(key: new UniqueKey(), child: _postTestMessage)); // Unmount any remaining widgets.
       await pump();
       invariantTester();
       _verifyAutoUpdateGoldensUnset(autoUpdateGoldensBeforeTest);

--- a/packages/flutter_tools/lib/src/android/android_sdk.dart
+++ b/packages/flutter_tools/lib/src/android/android_sdk.dart
@@ -223,8 +223,8 @@ class AndroidSdk {
     _init();
   }
 
-  static const String _kJavaHomeEnvironmentVariable = 'JAVA_HOME';
-  static const String _kJavaExecutable = 'java';
+  static const String _javaHomeEnvironmentVariable = 'JAVA_HOME';
+  static const String _javaExecutable = 'java';
 
   /// The path to the Android SDK.
   final String directory;
@@ -429,7 +429,7 @@ class AndroidSdk {
     if (android_studio.javaPath != null)
       return fs.path.join(android_studio.javaPath, 'bin', 'java');
 
-    final String javaHomeEnv = platform.environment[_kJavaHomeEnvironmentVariable];
+    final String javaHomeEnv = platform.environment[_javaHomeEnvironmentVariable];
     if (javaHomeEnv != null) {
       // Trust JAVA_HOME.
       return fs.path.join(javaHomeEnv, 'bin', 'java');
@@ -451,7 +451,7 @@ class AndroidSdk {
     }
 
     // Fallback to PATH based lookup.
-    return os.which(_kJavaExecutable)?.path;
+    return os.which(_javaExecutable)?.path;
   }
 
   Map<String, String> _sdkManagerEnv;

--- a/packages/flutter_tools/lib/src/android/android_workflow.dart
+++ b/packages/flutter_tools/lib/src/android/android_workflow.dart
@@ -45,7 +45,7 @@ class AndroidWorkflow extends DoctorValidator implements Workflow {
   @override
   bool get canListEmulators => getEmulatorPath(androidSdk) != null && getAvdPath() != null;
 
-  static const String _kJdkDownload = 'https://www.oracle.com/technetwork/java/javase/downloads/';
+  static const String _jdkDownload = 'https://www.oracle.com/technetwork/java/javase/downloads/';
 
   /// Returns false if we cannot determine the Java version or if the version
   /// is not compatible.
@@ -138,7 +138,7 @@ class AndroidWorkflow extends DoctorValidator implements Workflow {
       messages.add(new ValidationMessage.error(
           'No Java Development Kit (JDK) found; You must have the environment '
           'variable JAVA_HOME set and the java binary in your PATH. '
-          'You can download the JDK from $_kJdkDownload.'));
+          'You can download the JDK from $_jdkDownload.'));
       return new ValidationResult(ValidationType.partial, messages, statusInfo: sdkVersionText);
     }
     messages.add(new ValidationMessage('Java binary at: $javaBinary'));

--- a/packages/flutter_tools/lib/src/asset.dart
+++ b/packages/flutter_tools/lib/src/asset.dart
@@ -58,10 +58,10 @@ class _ManifestAssetBundle implements AssetBundle {
   final Map<String, DevFSContent> entries = <String, DevFSContent>{};
 
   static const String defaultManifestPath = 'pubspec.yaml';
-  static const String _kAssetManifestJson = 'AssetManifest.json';
-  static const String _kFontManifestJson = 'FontManifest.json';
-  static const String _kFontSetMaterial = 'material';
-  static const String _kLICENSE = 'LICENSE';
+  static const String _assetManifestJson = 'AssetManifest.json';
+  static const String _fontManifestJson = 'FontManifest.json';
+  static const String _fontSetMaterial = 'material';
+  static const String _license = 'LICENSE';
 
   DateTime _lastBuildTimestamp;
 
@@ -106,7 +106,7 @@ class _ManifestAssetBundle implements AssetBundle {
       return 1;
 
     if (flutterManifest.isEmpty) {
-      entries[_kAssetManifestJson] = new DevFSStringContent('{}');
+      entries[_assetManifestJson] = new DevFSStringContent('{}');
       return 0;
     }
 
@@ -195,19 +195,19 @@ class _ManifestAssetBundle implements AssetBundle {
 
     final List<_Asset> materialAssets = <_Asset>[];
     if (flutterManifest.usesMaterialDesign && includeDefaultFonts) {
-      materialAssets.addAll(_getMaterialAssets(_kFontSetMaterial));
+      materialAssets.addAll(_getMaterialAssets(_fontSetMaterial));
     }
     for (_Asset asset in materialAssets) {
       assert(asset.assetFileExists);
       entries[asset.entryUri.path] = new DevFSFileContent(asset.assetFile);
     }
 
-    entries[_kAssetManifestJson] = _createAssetManifest(assetVariants);
+    entries[_assetManifestJson] = _createAssetManifest(assetVariants);
 
-    entries[_kFontManifestJson] = new DevFSStringContent(json.encode(fonts));
+    entries[_fontManifestJson] = new DevFSStringContent(json.encode(fonts));
 
     // TODO(ianh): Only do the following line if we've changed packages or if our LICENSE file changed
-    entries[_kLICENSE] = await _obtainLicenses(packageMap, assetBasePath, reportPackages: reportLicensedPackages);
+    entries[_license] = await _obtainLicenses(packageMap, assetBasePath, reportPackages: reportLicensedPackages);
 
     return 0;
   }
@@ -384,7 +384,7 @@ List<Map<String, dynamic>> _parseFonts(
 }) {
   final List<Map<String, dynamic>> fonts = <Map<String, dynamic>>[];
   if (manifest.usesMaterialDesign && includeDefaultFonts) {
-    fonts.addAll(_getMaterialFonts(_ManifestAssetBundle._kFontSetMaterial));
+    fonts.addAll(_getMaterialFonts(_ManifestAssetBundle._fontSetMaterial));
   }
   if (packageName == null) {
     fonts.addAll(manifest.fontsDescriptor);

--- a/packages/flutter_tools/lib/src/commands/update_packages.dart
+++ b/packages/flutter_tools/lib/src/commands/update_packages.dart
@@ -943,9 +943,9 @@ class PubspecDependency extends PubspecLine {
   bool get lockIsOverride => _lockIsOverride;
   bool _lockIsOverride;
 
-  static const String _kPathPrefix = '    path: ';
-  static const String _kSdkPrefix = '    sdk: ';
-  static const String _kGitPrefix = '    git:';
+  static const String _pathPrefix = '    path: ';
+  static const String _sdkPrefix = '    sdk: ';
+  static const String _gitPrefix = '    git:';
 
   /// Whether the dependency points to a package in the Flutter SDK.
   ///
@@ -973,15 +973,15 @@ class PubspecDependency extends PubspecLine {
   bool parseLock(String line, String pubspecPath, { @required bool lockIsOverride }) {
     assert(lockIsOverride != null);
     assert(kind == DependencyKind.unknown);
-    if (line.startsWith(_kPathPrefix)) {
+    if (line.startsWith(_pathPrefix)) {
       // We're a path dependency; remember the (absolute) path.
-      _lockTarget = fs.path.absolute(fs.path.dirname(pubspecPath), line.substring(_kPathPrefix.length, line.length));
+      _lockTarget = fs.path.absolute(fs.path.dirname(pubspecPath), line.substring(_pathPrefix.length, line.length));
       _kind = DependencyKind.path;
-    } else if (line.startsWith(_kSdkPrefix)) {
+    } else if (line.startsWith(_sdkPrefix)) {
       // We're an SDK dependency.
-      _lockTarget = line.substring(_kSdkPrefix.length, line.length);
+      _lockTarget = line.substring(_sdkPrefix.length, line.length);
       _kind = DependencyKind.sdk;
-    } else if (line.startsWith(_kGitPrefix)) {
+    } else if (line.startsWith(_gitPrefix)) {
       // We're a git: dependency. Return false so we'll be forgotten.
       return false;
     } else {

--- a/packages/flutter_tools/lib/src/version.dart
+++ b/packages/flutter_tools/lib/src/version.dart
@@ -135,7 +135,7 @@ class FlutterVersion {
   /// In the absence of bugs and crashes a Flutter developer should never see
   /// this remote appear in their `git remote` list, but also if it happens to
   /// persist we do the proper clean-up for extra robustness.
-  static const String _kVersionCheckRemote = '__flutter_version_check__';
+  static const String _versionCheckRemote = '__flutter_version_check__';
 
   /// The date of the latest framework commit in the remote repository.
   ///
@@ -148,11 +148,11 @@ class FlutterVersion {
         'git',
         'remote',
         'add',
-        _kVersionCheckRemote,
+        _versionCheckRemote,
         'https://github.com/flutter/flutter.git',
       ]);
-      await _run(<String>['git', 'fetch', _kVersionCheckRemote, branch]);
-      return _latestGitCommitDate('$_kVersionCheckRemote/$branch');
+      await _run(<String>['git', 'fetch', _versionCheckRemote, branch]);
+      return _latestGitCommitDate('$_versionCheckRemote/$branch');
     } finally {
       await _removeVersionCheckRemoteIfExists();
     }
@@ -163,8 +163,8 @@ class FlutterVersion {
         .split('\n')
         .map((String name) => name.trim()) // to account for OS-specific line-breaks
         .toList();
-    if (remotes.contains(_kVersionCheckRemote))
-      await _run(<String>['git', 'remote', 'remove', _kVersionCheckRemote]);
+    if (remotes.contains(_versionCheckRemote))
+      await _run(<String>['git', 'remote', 'remove', _versionCheckRemote]);
   }
 
   static FlutterVersion get instance => context[FlutterVersion];


### PR DESCRIPTION
Our style guide says the k's are not necessary, and it seems like a good idea to make all the code be consistent on this.

Only naming changes to private vars: no logic changes.