### PR TITLE
Fix flutter shell script to handle properly shells that have CDPATH set

### DIFF
--- a/bin/flutter
+++ b/bin/flutter
@@ -14,6 +14,8 @@
 
 set -e
 
+unset CDPATH
+
 function follow_links() {
   cd -P "${1%/*}"
   local file="$PWD/${1##*/}"


### PR DESCRIPTION
Before this change, if CDPATH was set, and you type (from the flutter root): `bin/flutter --version`

You would get an error like this:
```
% bin/flutter -version
bin/flutter: line 118: cd: $'./bin\n/path/to/flutter/bin': No such file or directory
Error: The Flutter directory is not a clone of the GitHub project.
       The flutter tool requires Git in order to operate properly;
       to set up Flutter, run the following command:
       git clone -b beta https://github.com/flutter/flutter.git
```

This is because the `cd` command in `follow_links` was printing the directory Bash chose from the CDPATH to stdout, causing the path to have a newline in it, which understandably confuses the rest of the script.