### PR TITLE
Adjust scroll increment in transition perf test

### DIFF
--- a/examples/flutter_gallery/test_driver/transitions_perf.dart
+++ b/examples/flutter_gallery/test_driver/transitions_perf.dart
@@ -4,16 +4,30 @@
 
 import 'dart:async';
 import 'dart:convert' show JsonEncoder;
+import 'dart:ui' show window, Size;
 
 import 'package:flutter_driver/driver_extension.dart';
 import 'package:flutter_gallery/gallery/demos.dart';
 import 'package:flutter_gallery/main.dart' as app;
 
+
 Future<String> _handleMessages(String message) async {
-  assert(message == 'demoNames');
-  return const JsonEncoder.withIndent('  ').convert(
-    kAllGalleryDemos.map((GalleryDemo demo) => '${demo.title}@${demo.category.name}').toList(),
-  );
+  assert(message == 'demoNames' || message == 'mediaSize');
+  const JsonEncoder jsonEncoder = const JsonEncoder.withIndent('  ');
+  switch(message) {
+    case 'demoNames':
+      return jsonEncoder.convert(
+        kAllGalleryDemos.map((GalleryDemo demo) => '${demo.title}@${demo.category.name}').toList(),
+      );
+    case 'mediaSize':
+      final Size size = window.physicalSize / window.devicePixelRatio;
+      return jsonEncoder.convert(<String, double>{
+        'width': size.width,
+        'height': size.height,
+      });
+  }
+  assert(false, 'Not reachable');
+  return '';
 }
 
 void main() {

--- a/examples/flutter_gallery/test_driver/transitions_perf_test.dart
+++ b/examples/flutter_gallery/test_driver/transitions_perf_test.dart
@@ -51,9 +51,15 @@ const List<String> kSkippedDemos = const <String>[
 
 // All of the gallery demos, identified as "title@category".
 //
-// These names are reported by the test app, see _handleMessages()
-// in transitions_perf.dart.
+// These names are reported by the test app. See _handleMessages() in
+// transitions_perf.dart.
 List<String> _allDemos = <String>[];
+
+// The height of the screen, in logical pixels.
+//
+// This is reported by the test app. See _handleMessages() in
+// transition_perf.dart.
+double _mediaHeight = 0.0;
 
 /// Extracts event data from [events] recorded by timeline, validates it, turns
 /// it into a histogram, and saves to a JSON file.
@@ -146,7 +152,8 @@ Future<Null> runDemos(List<String> demos, FlutterDriver driver) async {
     currentDemoCategory = demoCategory;
 
     final SerializableFinder demoItem = find.text(demoName);
-    await driver.scrollUntilVisible(demoList, demoItem, dyScroll: -48.0,  alignment: 0.5);
+    final double scrollDistance = _mediaHeight / 4.0;
+    await driver.scrollUntilVisible(demoList, demoItem, dyScroll: -scrollDistance,  alignment: 0.5);
 
     for (int i = 0; i < 2; i += 1) {
       await driver.tap(demoItem); // Launch the demo
@@ -182,6 +189,10 @@ void main([List<String> args = const <String>[]]) {
       _allDemos = const JsonDecoder().convert(await driver.requestData('demoNames'));
       if (_allDemos.isEmpty)
         throw 'no demo names found';
+
+      _mediaHeight = const JsonDecoder().convert(await driver.requestData('mediaSize'))['height'];
+      if (_mediaHeight <= 0.0)
+        throw 'unable to determine media height';
     });
 
     tearDownAll(() async {


### PR DESCRIPTION
When attempting to locate an element in the Flutter Gallery transition
performance driver test, attempt to scroll downward in increments of 25%
of the screen rather than by an absolute pixel amount.

This helps get the test passing on devices with relatively small screen
heights.