### PR TITLE
Use the toString function of FlutterErrorDetails to pass information to test error handler

### DIFF
--- a/dev/automated_tests/flutter_test/exception_handling_expectation.txt
+++ b/dev/automated_tests/flutter_test/exception_handling_expectation.txt
@@ -1,58 +1,35 @@
 <<skip until matching line>>
-══╡ EXCEPTION CAUGHT BY FLUTTER TEST FRAMEWORK ╞════════════════════════════════════════════════════
-The following message was thrown running a test:
+Exception handling in test harness - string \[E\]
+Error caught by Flutter test framework, thrown running a test.
 Who lives, who dies, who tells your story\?
-
-When the exception was thrown, this was the stack:
+The test description was:
+Exception handling in test harness - string
 #0      main.<anonymous closure> \(.+[/\\]dev[/\\]automated_tests[/\\]flutter_test[/\\]exception_handling_test\.dart:10:5\)
 <asynchronous suspension>
 #1      .+ \(package:flutter_test[/\\]src[/\\]widget_tester\.dart:[0-9]+:[0-9]+\)
 <<skip until matching line>>
-^\(elided [0-9]+ .+\)$
-
-The test description was:
-Exception handling in test harness - string
-════════════════════════════════════════════════════════════════════════════════════════════════════
-.*(this line has more of the test framework's output)?
-  Test failed\. See exception logs above\.
-  The test description was: Exception handling in test harness - string
- *
-[^═]*(this line contains the test framework's output with the clock and so forth)?
-══╡ EXCEPTION CAUGHT BY FLUTTER TEST FRAMEWORK ╞════════════════════════════════════════════════════
-The following assertion was thrown running a test:
+\(elided [0-9]+ .+\)
+<<skip until matching line>>
+Exception handling in test harness - FlutterError \[E\]
+Error caught by Flutter test framework, thrown running a test.
 Who lives, who dies, who tells your story\?
-
-When the exception was thrown, this was the stack:
+The test description was:
+Exception handling in test harness - FlutterError
 #0      main.<anonymous closure> \(.+[/\\]dev[/\\]automated_tests[/\\]flutter_test[/\\]exception_handling_test\.dart:13:5\)
 <asynchronous suspension>
 #1      .+ \(package:flutter_test[/\\]src[/\\]widget_tester\.dart:[0-9]+:[0-9]+\)
 <<skip until matching line>>
-^\(elided [0-9]+ .+\)$
-
-The test description was:
-Exception handling in test harness - FlutterError
-════════════════════════════════════════════════════════════════════════════════════════════════════
-.*(this line has more of the test framework's output)?
-  Test failed\. See exception logs above\.
-  The test description was: Exception handling in test harness - FlutterError
- *
-[^═]*(this line contains the test framework's output with the clock and so forth)?
-══╡ EXCEPTION CAUGHT BY FLUTTER TEST FRAMEWORK ╞════════════════════════════════════════════════════
-The following message was thrown running a test:
+\(elided [0-9]+ .+\)
+<<skip until matching line>>
+Exception handling in test harness - uncaught Future error \[E\]
+Error caught by Flutter test framework, thrown running a test.
 Who lives, who dies, who tells your story\?
-
-When the exception was thrown, this was the stack:
+The test description was:
+Exception handling in test harness - uncaught Future error
 #[0-9]+ +main.<anonymous closure> \(.+[/\\]dev[/\\]automated_tests[/\\]flutter_test[/\\]exception_handling_test\.dart:16:9\)
 #[0-9]+ +main.<anonymous closure> \(.+[/\\]dev[/\\]automated_tests[/\\]flutter_test[/\\]exception_handling_test\.dart:15:77\)
 #[0-9]+ +.+ \(package:flutter_test[/\\]src[/\\]widget_tester\.dart:[0-9]+:[0-9]+\)
 <<skip until matching line>>
-^\(elided [0-9]+ .+\)$
+\(elided [0-9]+ .+\)
 
-The test description was:
-Exception handling in test harness - uncaught Future error
-════════════════════════════════════════════════════════════════════════════════════════════════════
-.*(this line has more of the test framework's output)?
-  Test failed\. See exception logs above\.
-  The test description was: Exception handling in test harness - uncaught Future error
- *
 .*..:.. \+0 -3: Some tests failed\. *

--- a/dev/automated_tests/flutter_test/test_async_utils_guarded_expectation.txt
+++ b/dev/automated_tests/flutter_test/test_async_utils_guarded_expectation.txt
@@ -1,6 +1,6 @@
 <<skip until matching line>>
-══╡ EXCEPTION CAUGHT BY FLUTTER TEST FRAMEWORK ╞════════════════════════════════════════════════════
-The following assertion was thrown running a test:
+TestAsyncUtils - custom guarded sections \[E\]
+Error caught by Flutter test framework, thrown running a test.
 Guarded function conflict\. You must use "await" with all Future-returning test APIs\.
 The guarded "guardedHelper" function was called from .*dev/automated_tests/flutter_test/test_async_utils_guarded_test\.dart on line [0-9]+\.
 Then, the "expect" function was called from .*dev/automated_tests/flutter_test/test_async_utils_guarded_test\.dart on line [0-9]+\.
@@ -10,16 +10,8 @@ If you are confident that all test APIs are being called using "await", and this
 When the first function \(guardedHelper\) was called, this was the stack:
 <<skip until matching line>>
 \(elided .+\)
-
-When the exception was thrown, this was the stack:
-<<skip until matching line>>
-\(elided .+\)
-
 The test description was:
 TestAsyncUtils - custom guarded sections
-════════════════════════════════════════════════════════════════════════════════════════════════════
-.*(this line has more of the test framework's output)?
-  Test failed\. See exception logs above\.
-  The test description was: TestAsyncUtils - custom guarded sections
- *
+TestAsyncUtils.guardSync
+<<skip until matching line>>
 .*..:.. \+0 -1: Some tests failed\. *

--- a/dev/automated_tests/flutter_test/test_async_utils_unguarded_expectation.txt
+++ b/dev/automated_tests/flutter_test/test_async_utils_unguarded_expectation.txt
@@ -1,7 +1,6 @@
-[^═]*(this line contains the test framework's output with the clock and so forth)?
 <<skip until matching line>>
-══╡ EXCEPTION CAUGHT BY FLUTTER TEST FRAMEWORK ╞════════════════════════════════════════════════════
-The following assertion was thrown running a test:
+TestAsyncUtils - handling unguarded async helper functions \[E\]
+Error caught by Flutter test framework, thrown running a test.
 Guarded function conflict\. You must use "await" with all Future-returning test APIs\.
 The guarded method "pump" from class WidgetTester was called from .*dev/automated_tests/flutter_test/test_async_utils_unguarded_test.dart on line [0-9]+\.
 Then, it was called again from .*dev/automated_tests/flutter_test/test_async_utils_unguarded_test.dart on line [0-9]+\.
@@ -10,16 +9,9 @@ The first method had not yet finished executing at the time that the second meth
 When the first method was called, this was the stack:
 <<skip until matching line>>
 (elided [0-9]+ frames from .+)
-
-When the exception was thrown, this was the stack:
-<<skip until matching line>>
-(elided [0-9]+ frames from .+)
-
 The test description was:
 TestAsyncUtils - handling unguarded async helper functions
-════════════════════════════════════════════════════════════════════════════════════════════════════
-.*..:.. \+0 -1: - TestAsyncUtils - handling unguarded async helper functions *
-  Test failed\. See exception logs above\.
-  The test description was: TestAsyncUtils - handling unguarded async helper functions
+<<skip until matching line>>
+(elided [0-9]+ frames from .+)
  *
 .*..:.. \+0 -1: Some tests failed\. *

--- a/dev/automated_tests/flutter_test/ticker_expectation.txt
+++ b/dev/automated_tests/flutter_test/ticker_expectation.txt
@@ -1,16 +1,12 @@
 <<skip until matching line>>
-══╡ EXCEPTION CAUGHT BY SCHEDULER LIBRARY ╞═════════════════════════════════════════════════════════
-The following message was thrown:
+Does flutter_test catch leaking tickers\? \[E\]
+Error caught by scheduler library.
 An animation is still running even after the widget tree was disposed.
-
 There was one transient callback left. The stack trace for when it was registered is as follows:
 ── callback 2 ──
 <<skip until matching line>>
 #[0-9]+      main.+ \(.+/dev/automated_tests/flutter_test/ticker_test\.dart:[0-9]+:[0-9]+\)
 <<skip until matching line>>
-════════════════════════════════════════════════════════════════════════════════════════════════════
-.*..:.. \+0 -1: - Does flutter_test catch leaking tickers\? \[E\]
-  Test failed\. See exception logs above\.
-  The test description was: Does flutter_test catch leaking tickers\?
+(elided [0-9]+ frames from .+)
  *
 .*..:.. \+0 -1: Some tests failed\. *

--- a/packages/flutter_test/lib/src/binding.dart
+++ b/packages/flutter_test/lib/src/binding.dart
@@ -363,8 +363,8 @@ abstract class TestWidgetsFlutterBinding extends BindingBase
       // get the same effect here by calling that error handler directly or indeed just throwing.
       // However, we call registerException because that's the semantically correct thing...
       test_package.registerException(
-        _pendingExceptionDetails.exception,
-        _pendingExceptionDetails.stack,
+        _pendingExceptionDetails.toString(),
+        _emptyStackTrace,
       );
       _pendingExceptionDetails = null;
     }
@@ -1298,6 +1298,8 @@ class _LiveTestRenderView extends RenderView {
     _label?.paint(context.canvas, offset - const Offset(0.0, 10.0));
   }
 }
+
+final StackTrace _emptyStackTrace = new stack_trace.Chain(const <stack_trace.Trace>[]);
 
 StackTrace _unmangle(StackTrace stack) {
   if (stack is stack_trace.Trace)

--- a/packages/flutter_test/lib/src/binding.dart
+++ b/packages/flutter_test/lib/src/binding.dart
@@ -357,17 +357,15 @@ abstract class TestWidgetsFlutterBinding extends BindingBase
     assert(Zone.current == _parentZone);
     assert(_currentTestCompleter != null);
     if (_pendingExceptionDetails != null) {
-      debugPrint = debugPrintOverride; // just in case the test overrides it -- otherwise we won't see the error!
-      FlutterError.dumpErrorToConsole(_pendingExceptionDetails, forceReport: true);
       // test_package.registerException actually just calls the current zone's error handler (that
       // is to say, _parentZone's handleUncaughtError function). FakeAsync doesn't add one of those,
       // but the test package does, that's how the test package tracks errors. So really we could
       // get the same effect here by calling that error handler directly or indeed just throwing.
       // However, we call registerException because that's the semantically correct thing...
-      String additional = '';
-      if (_currentTestDescription != '')
-        additional = '\nThe test description was: $_currentTestDescription';
-      test_package.registerException('Test failed. See exception logs above.$additional', _emptyStackTrace);
+      test_package.registerException(
+        _pendingExceptionDetails.exception,
+        _pendingExceptionDetails.stack,
+      );
       _pendingExceptionDetails = null;
     }
     _currentTestDescription = null;
@@ -1300,8 +1298,6 @@ class _LiveTestRenderView extends RenderView {
     _label?.paint(context.canvas, offset - const Offset(0.0, 10.0));
   }
 }
-
-final StackTrace _emptyStackTrace = new stack_trace.Chain(const <stack_trace.Trace>[]);
 
 StackTrace _unmangle(StackTrace stack) {
   if (stack is stack_trace.Trace)


### PR DESCRIPTION
It seems a bit odd to me that we are logging the exception ourselves then creating a fake one for the test framework. I would like to understand the rationale for doing this.

This is causing problems in Google's test infra where only the "Test Failed" is reported on the main page and users are forced to dig through test logs.