### PR TITLE
Show help info instead of crashing if Android SDK is not found

### DIFF
--- a/packages/flutter_tools/lib/src/android/gradle.dart
+++ b/packages/flutter_tools/lib/src/android/gradle.dart
@@ -209,6 +209,9 @@ void updateLocalProperties({String projectPath, BuildInfo buildInfo}) {
     settings = new SettingsFile.parseFromFile(localProperties);
   } else {
     settings = new SettingsFile();
+    if (androidSdk == null) {
+      throwToolExit('Unable to locate Android SDK. Please run `flutter doctor` for more details.');
+    }
     settings.values['sdk.dir'] = escapePath(androidSdk.directory);
     changed = true;
   }

--- a/packages/flutter_tools/lib/src/android/gradle.dart
+++ b/packages/flutter_tools/lib/src/android/gradle.dart
@@ -199,7 +199,6 @@ distributionUrl=https\\://services.gradle.org/distributions/gradle-$gradleVersio
 
 /// Create android/local.properties if needed, and update Flutter settings.
 void updateLocalProperties({String projectPath, BuildInfo buildInfo}) {
-  return; // TODO TEST
   final File localProperties = (projectPath == null)
       ? fs.file(fs.path.join('android', 'local.properties'))
       : fs.file(fs.path.join(projectPath, 'android', 'local.properties'));

--- a/packages/flutter_tools/lib/src/android/gradle.dart
+++ b/packages/flutter_tools/lib/src/android/gradle.dart
@@ -199,6 +199,7 @@ distributionUrl=https\\://services.gradle.org/distributions/gradle-$gradleVersio
 
 /// Create android/local.properties if needed, and update Flutter settings.
 void updateLocalProperties({String projectPath, BuildInfo buildInfo}) {
+  return; // TODO TEST
   final File localProperties = (projectPath == null)
       ? fs.file(fs.path.join('android', 'local.properties'))
       : fs.file(fs.path.join(projectPath, 'android', 'local.properties'));

--- a/packages/flutter_tools/test/android/gradle_test.dart
+++ b/packages/flutter_tools/test/android/gradle_test.dart
@@ -2,11 +2,12 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import '../src/common.dart';
 import 'package:flutter_tools/src/android/gradle.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/build_info.dart';
 import 'package:test/test.dart';
+
+import '../src/common.dart';
 
 void main() {
   group('gradle build', () {

--- a/packages/flutter_tools/test/android/gradle_test.dart
+++ b/packages/flutter_tools/test/android/gradle_test.dart
@@ -3,12 +3,31 @@
 // found in the LICENSE file.
 
 import 'package:flutter_tools/src/android/gradle.dart';
+import 'package:flutter_tools/src/base/common.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/build_info.dart';
 import 'package:test/test.dart';
 
 void main() {
   group('gradle build', () {
+    test('do not crash if there is no Android SDK', () async {
+      Exception shouldBeToolExit;
+      try {
+        // We'd like to always set androidSdk to null and test updateLocalProperties. But that's
+        // currently impossible as the test is not hermetic. Luckily, our bots don't have Android
+        // SDKs yet so androidSdk should be null by default.
+        //
+        // This test is written to fail if our bots get Android SDKs in the future: shouldBeToolExit
+        // will be null and our expectation would fail. That would remind us to make these tests
+        // hermetic before adding Android SDKs to the bots.
+        updateLocalProperties();
+      } on Exception catch (e) {
+        shouldBeToolExit = e;
+      }
+      // Ensure that we throw a meaningful ToolExit instead of a general crash.
+      expect(shouldBeToolExit is ToolExit, isTrue);
+    });
+
     test('regexp should only match lines without the error message', () {
       final List<String> nonMatchingLines = <String>[
         'NDK is missing a "platforms" directory.',

--- a/packages/flutter_tools/test/android/gradle_test.dart
+++ b/packages/flutter_tools/test/android/gradle_test.dart
@@ -10,7 +10,7 @@ import 'package:test/test.dart';
 
 void main() {
   group('gradle build', () {
-    test('do not crash if there is no Android SDK', () async {
+    test('do not crash if there is no Android SDK', () {
       Exception shouldBeToolExit;
       try {
         // We'd like to always set androidSdk to null and test updateLocalProperties. But that's

--- a/packages/flutter_tools/test/android/gradle_test.dart
+++ b/packages/flutter_tools/test/android/gradle_test.dart
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import '../src/common.dart';
 import 'package:flutter_tools/src/android/gradle.dart';
-import 'package:flutter_tools/src/base/common.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/build_info.dart';
 import 'package:test/test.dart';
@@ -25,7 +25,7 @@ void main() {
         shouldBeToolExit = e;
       }
       // Ensure that we throw a meaningful ToolExit instead of a general crash.
-      expect(shouldBeToolExit is ToolExit, isTrue);
+      expect(shouldBeToolExit, isToolExit);
     });
 
     test('regexp should only match lines without the error message', () {


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/16832