### PR TITLE
Example implementation of Image changes

### DIFF
--- a/packages/flutter/lib/src/painting/image_stream.dart
+++ b/packages/flutter/lib/src/painting/image_stream.dart
@@ -183,6 +183,7 @@ class ImageStream extends Diagnosticable {
 /// configure it with the right [ImageStreamCompleter] when possible.
 abstract class ImageStreamCompleter extends Diagnosticable {
   final List<ImageListener> _listeners = <ImageListener>[];
+
   ImageInfo _current;
 
   /// Adds a listener callback that is called whenever a new concrete [ImageInfo]

--- a/packages/flutter/lib/src/widgets/image.dart
+++ b/packages/flutter/lib/src/widgets/image.dart
@@ -9,6 +9,7 @@ import 'dart:typed_data';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/painting.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
 
 import 'basic.dart';
 import 'framework.dart';
@@ -47,6 +48,7 @@ ImageConfiguration createLocalImageConfiguration(BuildContext context, { Size si
     devicePixelRatio: MediaQuery.of(context, nullOk: true)?.devicePixelRatio ?? 1.0,
     locale: Localizations.localeOf(context, nullOk: true),
     textDirection: Directionality.of(context),
+    behaviorDelegate: ImageBehavior.of(context),
     size: size,
     platform: defaultTargetPlatform,
   );
@@ -522,11 +524,11 @@ class _ImageState extends State<Image> {
   }
 
   void _resolveImage() {
-    final ImageStream newStream =
-      widget.image.resolve(createLocalImageConfiguration(
-          context,
-          size: widget.width != null && widget.height != null ? new Size(widget.width, widget.height) : null
-      ));
+    final ImageConfiguration configuration = createLocalImageConfiguration(
+      context,
+       size: widget.width != null && widget.height != null ? new Size(widget.width, widget.height) : null
+    );
+    final ImageStream newStream = widget.image.resolve(configuration);
     assert(newStream != null);
     _updateSourceStream(newStream);
   }

--- a/packages/flutter/lib/src/widgets/image_behavior.dart
+++ b/packages/flutter/lib/src/widgets/image_behavior.dart
@@ -1,0 +1,92 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/src/painting/image_provider.dart';
+import 'package:flutter/src/widgets/framework.dart';
+import 'package:flutter/src/widgets/image.dart';
+
+
+///
+class ImageBehavior extends StatefulWidget {
+    
+  ///
+  const ImageBehavior({
+    Key key,
+    this.delegate = const ImageBehaviorDelegate(),
+    this.precache = const <ImageProvider<Object>>[],
+    @required this.child,
+  }) : assert(delegate != null),
+       super(key: key);
+
+  ///
+  final ImageBehaviorDelegate delegate;
+
+  ///
+  final Widget child;
+
+  ///
+  final List<ImageProvider> precache;
+
+  ///
+  static ImageBehaviorDelegate of(BuildContext context) {
+    final _InheritedImageBehavior behavior = context.inheritFromWidgetOfExactType(_InheritedImageBehavior);
+    return behavior?.delegate ?? const ImageBehaviorDelegate();
+  }
+
+  @override
+  State<ImageBehavior> createState() => new _ImageBehaviorState();
+}
+
+class _ImageBehaviorState extends State<ImageBehavior> {
+  @override
+  void initState() {
+    _precacheImages();
+    super.initState();
+  }
+
+  @override
+  void didUpdateWidget(ImageBehavior oldWidget) {
+    if (!identical(oldWidget.precache, widget.precache)) {
+      _precacheImages();
+    }
+    super.didUpdateWidget(oldWidget);
+  }
+
+  @override
+  void dispose() {
+    widget.delegate.dispose();
+    super.dispose();
+  }
+
+  void _precacheImages() {
+    final ImageConfiguration configuration = createLocalImageConfiguration(context)
+      .copyWith(behaviorDelegate: widget.delegate);
+    for (ImageProvider<Object> provider in widget.precache)
+      provider.resolve(configuration);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return new _InheritedImageBehavior(
+      child: widget.child,
+      delegate: widget.delegate
+    );
+  }
+}
+
+/// 
+class _InheritedImageBehavior extends InheritedWidget {
+  
+  ///
+  const _InheritedImageBehavior({
+    Key key,
+    @required this.delegate,
+    @required Widget child,
+  }) : super(key: key, child: child);
+
+  ///
+  final ImageBehaviorDelegate delegate;
+
+  @override
+  bool updateShouldNotify(covariant _InheritedImageBehavior oldWidget) {
+    return oldWidget.delegate.runtimeType != delegate.runtimeType;
+  }
+}

--- a/packages/flutter/lib/widgets.dart
+++ b/packages/flutter/lib/widgets.dart
@@ -43,6 +43,7 @@ export 'src/widgets/icon_data.dart';
 export 'src/widgets/icon_theme.dart';
 export 'src/widgets/icon_theme_data.dart';
 export 'src/widgets/image.dart';
+export 'src/widgets/image_behavior.dart';
 export 'src/widgets/image_icon.dart';
 export 'src/widgets/implicit_animations.dart';
 export 'src/widgets/layout_builder.dart';

--- a/packages/flutter/test/painting/decoration_test.dart
+++ b/packages/flutter/test/painting/decoration_test.dart
@@ -32,7 +32,7 @@ class SynchronousTestImageProvider extends ImageProvider<int> {
   }
 
   @override
-  ImageStreamCompleter load(int key) {
+  ImageStreamCompleter load(int key, _) {
     return new OneFrameImageStreamCompleter(
       new SynchronousFuture<ImageInfo>(new TestImageInfo(key, image: new TestImage(), scale: 1.0))
     );
@@ -46,7 +46,7 @@ class AsyncTestImageProvider extends ImageProvider<int> {
   }
 
   @override
-  ImageStreamCompleter load(int key) {
+  ImageStreamCompleter load(int key, _) {
     return new OneFrameImageStreamCompleter(
       new Future<ImageInfo>.value(new TestImageInfo(key))
     );
@@ -67,7 +67,7 @@ class DelayedImageProvider extends ImageProvider<DelayedImageProvider> {
   }
 
   @override
-  ImageStreamCompleter load(DelayedImageProvider key) {
+  ImageStreamCompleter load(DelayedImageProvider key, _) {
     return new OneFrameImageStreamCompleter(_completer.future);
   }
 

--- a/packages/flutter/test/painting/fake_image_provider.dart
+++ b/packages/flutter/test/painting/fake_image_provider.dart
@@ -26,7 +26,7 @@ class FakeImageProvider extends ImageProvider<FakeImageProvider> {
   }
 
   @override
-  ImageStreamCompleter load(FakeImageProvider key) {
+  ImageStreamCompleter load(FakeImageProvider key, _) {
     assert(key == this);
     return new MultiFrameImageStreamCompleter(
       codec: new SynchronousFuture<ui.Codec>(_codec),

--- a/packages/flutter/test/painting/image_test_utils.dart
+++ b/packages/flutter/test/painting/image_test_utils.dart
@@ -31,7 +31,7 @@ class TestImageProvider extends ImageProvider<TestImageProvider> {
   }
 
   @override
-  ImageStreamCompleter load(TestImageProvider key) =>
+  ImageStreamCompleter load(TestImageProvider key, _) =>
       new OneFrameImageStreamCompleter(_completer.future);
 
   ImageInfo complete() {

--- a/packages/flutter/test/painting/mocks_for_image_cache.dart
+++ b/packages/flutter/test/painting/mocks_for_image_cache.dart
@@ -35,7 +35,7 @@ class TestImageProvider extends ImageProvider<int> {
   }
 
   @override
-  ImageStreamCompleter load(int key) {
+  ImageStreamCompleter load(int key, _) {
     return new OneFrameImageStreamCompleter(
       new SynchronousFuture<ImageInfo>(new TestImageInfo(imageValue, image: image))
     );

--- a/packages/flutter/test/painting/shape_decoration_test.dart
+++ b/packages/flutter/test/painting/shape_decoration_test.dart
@@ -107,7 +107,7 @@ class TestImageProvider extends ImageProvider<TestImageProvider> {
   }
 
   @override
-  ImageStreamCompleter load(TestImageProvider key) {
+  ImageStreamCompleter load(TestImageProvider key, _) {
     return new OneFrameImageStreamCompleter(
       new SynchronousFuture<ImageInfo>(new ImageInfo(image: new TestImage(), scale: 1.0)),
     );

--- a/packages/flutter/test/widgets/box_decoration_test.dart
+++ b/packages/flutter/test/widgets/box_decoration_test.dart
@@ -28,7 +28,7 @@ class TestImageProvider extends ImageProvider<TestImageProvider> {
   }
 
   @override
-  ImageStreamCompleter load(TestImageProvider key) {
+  ImageStreamCompleter load(TestImageProvider key, _) {
     return new OneFrameImageStreamCompleter(
       future.then<ImageInfo>((Null value) => new ImageInfo(image: image))
     );

--- a/packages/flutter/test/widgets/image_resolution_test.dart
+++ b/packages/flutter/test/widgets/image_resolution_test.dart
@@ -103,7 +103,7 @@ class TestAssetImage extends AssetImage {
   TestAssetImage(String name) : super(name);
 
   @override
-  ImageStreamCompleter load(AssetBundleImageKey key) {
+  ImageStreamCompleter load(AssetBundleImageKey key, _) {
     ImageInfo imageInfo;
     key.bundle.load(key.name).then<void>((ByteData data) {
       final TestByteData testData = data;

--- a/packages/flutter/test/widgets/image_rtl_test.dart
+++ b/packages/flutter/test/widgets/image_rtl_test.dart
@@ -19,7 +19,7 @@ class TestImageProvider extends ImageProvider<TestImageProvider> {
   }
 
   @override
-  ImageStreamCompleter load(TestImageProvider key) {
+  ImageStreamCompleter load(TestImageProvider key, _) {
     return new OneFrameImageStreamCompleter(
       new SynchronousFuture<ImageInfo>(new ImageInfo(image: new TestImage()))
     );


### PR DESCRIPTION
# Improvements to Image Caching and Loading

## Background
The high level goals of this design are an improvement to the image caching system:
- Intuitive and reasonable default behavior for the ImageCache
  - Image cache limit based on image size instead of image count
  - More aggressive cache flushing on low memory events.
  - Diagnostics and logging support of the current state of the image cache for tooling.
- Support for better customization of image caching and loading behavior.
    - Changing how images load without updating ImageProviders.
    - Better APIs for pre-caching and evicting of imaages.
    - Addition of the missing common image providers Placeholder and Fallback.

This will involve some breaking changes to the ImageCache and ImageProvider APIs, and introduce several new classes for customizing image behavior. 

## Proposed Changes
An example of these changes is implemented in [flutter/flutter#17614](https://github.com/flutter/flutter/pull/17614).  This PR is not complete and currently exists only as a reference for this proposal - much of the described behavior has not been fully implemented.  There are two breaking changes in this proposal:
  - A second parameter has been added to `ImageProvider.load`.
  - `ImageCache.maximumSize` has been deprecated and no longer has any effect on cache size.

### ImageCache
A new setter/getter named `maximumSizeBytes` will be added to adjust the maximum cache size based on size of the image in memory. This will default to 10MB and can be updated by developers.

The `ImageCache` will add a second listener to each newly created `ImageStreamCompleter` which adds the image size information to the cache when it completes.  This may break tests which expect a certain number of listeners. Image size will be estimated from ImageInfo objects using `width * height * 4`.  Only images which have completed contribute to cache size and when the cache limit is reached only images which have contributed some size will be removed.  The `putIfAbsent` method used to interact with the cache is unchanged otherwise.

Additionally, to support more caching customization I've added a method which removes a single entry from the cache.  Examples of this API are given further down.

**Deprecated:**
```dart
set maximumSize(int value) { … }
```

**Added:**
```dart
/// The maximum size that the image cache will grow to before evicting images.
set maximumSizeBytes(int value) {..}

int get maximumSizeBytes => ...

/// Removes the image associated with [key] from the cache and decreases the cache
/// size.
void remove(Object key) {...}
```

### ImageProvider
The ImageProvider has two responsibilities:
- Identifying an image; for `NetworkImage` this is the scale and url, for `FileImage` this is the file handle and scale.
- Creating an `ImageStream` from the information above and providing this information to an `ImageWidget`.

To support the changes below in ImageService, a second parameter has been added to the `load` method.  A custom `ImageProvder` that doesn't use the `ImageService` is free to ignore this parameter.

**Modified:**
```dart
ImageStreamCompleter load(T key, ImageConfiguration configuration);
```

### ImageBehavior & ImageService
The logic for producing an Image from a key will be moved to a new class named `ImageService`.  An instance of this service is provided via the ImageConfiguration object from an `InheritedWidget` named `ImageBehavior`.

The ImageService base class will contain the logic for loading images from the `NetworkImage`, `AssetImage`, `MemoryImage`, and `FileImage`. However, usage of the new `ImageBehavior` widget is entirely optional, since a provider is still free to provide its own load implementation.

The design of the `ImageService` is based on the assumption that new or custom ImageProviders are uncommon, and instead it is preferable to allow extending the loading logic of the existing ImageProviders.

**Added:**
```dart
class ImageBehavior extends StatefulWidget {
  const ImageBehavior({
    @required this.child,
    @required this.service,
    /// Immediately begins precaching images when this widget is constructed.
    this.precachedImages = const <ImageProvider<Object>>[],
  });
  
  /// The subtree which the delegate applies to.
  final Widget child;

  /// Images which Flutter will start to load and cache when this widget is built.
  final List<ImageProvider<Object>> precachedImages;
  
  /// See below for API
  final ImageService service;
 
  /// Look up the nearest `ImageService` from the build context.
  static ImageService of(BuildContext context);
  
  ...
}
```

```dart
/// Customizes the behavior of images in a subtree.
class ImageService {
  const ImageService();
  
  /// Called once when the subtree containing this widget is torn down.
  void dispose() {}

  /// Proxies call to ImageCache.evict.
  void evict(Object key) {}

  /// Proxies call to ImageCache.putIfAbsent.
  ImageStreamCompleter putIfAbsent(Object key, ImageStreamCompleter loader());

  /// Loads a network image.
  ImageStreamCompleter loadUrl(NetworkImage key);

  /// Loads a file image.
  ImageStreamCompleter loadFile(FileImage key);

  /// Loads an asset image.
  ImageStreamCompleter loadAsset(AssetImageKey key);

  /// Loads a memory image.
  ImageStreamCompleter loadMemory(MemoryImage key);
}
```

## Examples
To demonstrate the usefulness of the above changes, I've prepared some example implementations below.

### Example: Early Eviction 
An `ImageService` which automatically evicts any images which were cached by the subtree below it when it is destroyed.  This is implemented by saving the keys which are cached and then evicting them when `dispose` is called.  The `ImageService` can be stateful since the `ImageBehavior` widget will only replace it if the `runtimeType` changes.

Consider a "search page" in an application which displays a grid of network images.  If it is unlikely that exactly the same search will be made again, we could preemptively evict all cached images when the subtree is destroyed.

```dart
class EarlyEvictionImageService extends ImageService {
  final Set<Object> _imageKeys = new Set();
  
  @override
  void putIfAbsent(Object key, ImageStreamCompleter loader()) {
    _imageKeys.add(key);
    super.putIfAbsent(key, loader);
  } 

  @override
  void dispose() {
    _imageKeys.forEach(imageCache.evict);
  }
}
```

**Example Use**
In the example below, all the images loaded in the `ListView` will be evicted when this widget is destroyed.
```dart
Widget build(BuildContext context) {
  return new ImageBehavior(
    service: new EarlyEvictionImageService(),
    child: new ListView(
      children: imageQuery.map((String url) {
        return new Image.network(url, ...);
      });
    ),
  )
}
```

### Example: Mocking ImageProviders in Tests
The following delegate will cause all ImageProviders to return the test image in the subtree below it.  This can be used to provide images to `Image.network` without mocking the `HttpClient`.  This can be useful for testing a large custom widget which includes network images that must be loaded, for hit-testing or layour purposes.  The bits themselves can be loaded by the test harness.

```dart
class TestImageService extends ImageService {
  const TestImageService(this.testImage);

  final List<int> testImage;

  @override
  ImageStreamCompleter loadUrl(NetworkImage key) => _load(key.scale);

  @override
  ImageStreamCompleter loadFile(FileImage key) => _load(key.scale);

  @override
  ImageStreamCompleter loadAsset(AssetImageKey key) => _load(key.scale);

  @override
  ImageStreamCompleter loadMemory(MemoryImage key) => _load(key.scale);

  ImageStreamCompleter _load(double scale) {
   return new MultiFrameImageStreamCompleter(
      codec: ui.instantiateImageCodec(testImage),
      scale: key.scale,
    );
  }
}
```

**Example use**
In the example below, the image loaded by `Image.network` will be created from the bits passed to `TestImageService`.

```dart
void main() {
  testWidgets('widget that contains a network image', (WidgetTester tester) async {
    await tester.pumpWidget(
      ImageBehavior(
        delegate: const TestImageService(testImage: testImage),
        child: MyWidget(
         child: Image.network('...'),
        ),
      ),
    );
    
    ...
  });
}
```

### Example: Adding automatic retry with backoff to `Image.network`
Using the `ImageBehavior` widget with a custom `ImageService` it is now possible to change how images load over the network while still using the `Image.network` constructor.  The `AutomagicBackoffImageService` overrides the default behavior of `loadUrl` to autmatically retry failed HTTP requests up to five times.  This is a fairly naive implementation for demonstration purposes only!

```dart
class AutomagicBackoffImageService extends ImageService {
  static final _httpClient = new HttpClient();
  bool _isDisposed = false;

  @override
  void dispose() {
    _isDisposed = true;
  }

  @override
  ImageStreamCompleter loadUrl(NetworkImage key) {
   final Uri uri = Uri.base.resolve(key.url);
   return new MultiFrameImageStreamCompleter(
     codec: _load(uri, key.headers),
     scale: scale,
   );
  }

  /// Not a complete implementation, doesn't handle certain errors.
  Future<ui.Codec> _load(Uri uri, Map<String, String> headers) async {
    for (int i = 0; i < 5; i++) {
      if (_isDisposed)
        break;
      final HttpClientRequest request = await _httpClient.getUrl(uri);
      headers?.forEach(request.headers.add);
      final HttpClientResponse response = await request.close();
      if (response.statusCode == HttpStatus.OK) {
        final Uint8List bytes = await consolidateHttpClientResponseBytes(response);
        return ui.instantiateImageCodec(bytes);
      }
      await new Future.delayed(new Duration(seconds: i + 1));
    }
    return null;
  }
}
```


### Example: Placeholder and Fallback image
A common feature for Android image libraries like Picasso or Glide is the ability to specify placeholder or fallback images.
 - A placeholder is an image which displays before another resource loads.
 - A fallback image displays in case a resource fails to load..

Using the new APIs we can still easily implement these as an `ImageProvider` without requiring a new widget.  This is done by creating a custom `ImageStream` and exposing an error callback for the `ImageStreamCompleter`.

```dart
class CombinedImageStream extends ImageStream {
  void add(ImageInfo info);
  ...
}
```

```dart
///  Shows [placeholder] until [image] loads.
class PlaceholderImage extends ImageProvider<PlaceholderImage> {
  const PlaceholderImage({this.placeholder, this.image});  

  final ImageProvider<Object> placeholder;
  final ImageProvider<Object> image;

  @override
  ImageStream resolve(ImageConfiguration configuration) {
    final CombinedImageStream stream = new CombinedImageStream();
    bool imageLoaded = false;
    image.resolve(configuration).addListener((ImageInfo info, bool syncCall) {
      imageLoaded = true;
      stream.add(info);
    });
    placeholder.resolve(configuration).addListener(
     (ImageInfo info, bool syncCall) {
      if (imageLoaded)
        return;
      stream.add(info);
    });
    return stream;
  }

  ...
}
```

```dart
class FallbackImage extends ImageProvider<FallbackImage> {
  const FallbackImage({this.fallback, this.image});  

  final ImageProvider<Object> fallback;
  final ImageProvider<Object> image;

  @override
  ImageStream resolve(ImageConfiguration configuration) {
    final CombinedImageStream stream = new CombinedImageStream();
    image.resolve(configuration)
      ..addListener((ImageInfo info, bool syncCall) {
        stream.add(image);
      })
      ..addErrorListener((Object error, StackTrace stackTrace) {
        fallback.resolve(configuration).addListener(
          (ImageInfo image, bool syncCall) {
            stream.add(image);
          });
      });
     return image;
  }
  
  ...
}
```

## Github Issues
- https://github.com/flutter/flutter/issues/16241
- https://github.com/flutter/flutter/issues/16375
