### PR TITLE
Provide isolate id for rpc request to ensure they are run on correct (UI) thread.

### DIFF
--- a/packages/flutter_tools/lib/src/vmservice.dart
+++ b/packages/flutter_tools/lib/src/vmservice.dart
@@ -905,7 +905,11 @@ class VM extends ServiceObjectOwner {
     if (!isFlutterEngine)
       return;
     _viewCache.clear();
-    await vmService.vm.invokeRpc('_flutter.listViews', timeout: kLongRequestTimeout);
+    for (Isolate isolate in isolates) {
+      await vmService.vm.invokeRpc('_flutter.listViews',
+          timeout: kLongRequestTimeout,
+          params: <String, dynamic> {'isolateId': isolate.id});
+    }
   }
 
   Iterable<FlutterView> get views => _viewCache.values;
@@ -1393,6 +1397,7 @@ class FlutterView extends ServiceObject {
     assert(assetsDirectory != null);
     await owner.vmService.vm.invokeRpc('_flutter.setAssetBundlePath',
         params: <String, dynamic>{
+          'isolateId': _uiIsolate.id,
           'viewId': id,
           'assetDirectory': assetsDirectory.toFilePath(windows: false)
         });
@@ -1401,7 +1406,8 @@ class FlutterView extends ServiceObject {
   bool get hasIsolate => _uiIsolate != null;
 
   Future<Null> flushUIThreadTasks() async {
-    await owner.vm.invokeRpcRaw('_flutter.flushUIThreadTasks');
+    await owner.vm.invokeRpcRaw('_flutter.flushUIThreadTasks',
+      params: <String, dynamic>{'isolateId': _uiIsolate.id});
   }
 
   @override


### PR DESCRIPTION

This works together with https://github.com/flutter/engine/pull/5263 and goes towards fixing flutter/flutter#17434