### PR TITLE
Change kRadialReactionRadius from 24 to 20

### DIFF
--- a/packages/flutter/lib/src/material/constants.dart
+++ b/packages/flutter/lib/src/material/constants.dart
@@ -17,7 +17,7 @@ const double kTextTabBarHeight = 48.0;
 const Duration kThemeChangeDuration = const Duration(milliseconds: 200);
 
 /// The radius of a circular material ink response in logical pixels.
-const double kRadialReactionRadius = 24.0;
+const double kRadialReactionRadius = 20.0;
 
 /// The amount of time a circular material ink response should take to expand to its full size.
 const Duration kRadialReactionDuration = const Duration(milliseconds: 100);

--- a/packages/flutter/test/material/checkbox_test.dart
+++ b/packages/flutter/test/material/checkbox_test.dart
@@ -15,6 +15,21 @@ void main() {
     debugResetSemanticsIdCounter();
   });
 
+  testWidgets('Checkbox size is 40x40', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      new Material(
+        child: new Center(
+          child: new Checkbox(
+            value: false,
+            onChanged: (bool newValue) { },
+          ),
+        ),
+      ),
+    );
+
+    expect(tester.getSize(find.byType(Checkbox)), const Size(40.0, 40.0));
+  });
+
   testWidgets('CheckBox semantics', (WidgetTester tester) async {
     final SemanticsTester semantics = new SemanticsTester(tester);
 

--- a/packages/flutter/test/material/radio_test.dart
+++ b/packages/flutter/test/material/radio_test.dart
@@ -63,6 +63,26 @@ void main() {
     expect(log, isEmpty);
   });
 
+  testWidgets('Radio size is 40x40', (WidgetTester tester) async {
+    final Key key = new UniqueKey();
+
+    await tester.pumpWidget(
+      new Material(
+        child: new Center(
+          child: new Radio<int>(
+            key: key,
+            value: 1,
+            groupValue: 2,
+            onChanged: (int newValue) { },
+          ),
+        ),
+      ),
+    );
+
+    expect(tester.getSize(find.byKey(key)), const Size(40.0, 40.0));
+  });
+
+
   testWidgets('Radio semantics', (WidgetTester tester) async {
     final SemanticsTester semantics = new SemanticsTester(tester);
 


### PR DESCRIPTION
In addition to reducing the radial ink splash size for `Radio`, `Checkbox` and `Switch`, this change effectively reduces the sizes of `Checkbox` and `Radio` to 40x40 per the most recent Material spec. It will also unblock two recently reverted `ListTile` PRs:

https://github.com/flutter/flutter/pull/17496
https://github.com/flutter/flutter/pull/17580

This change was originally part of https://github.com/flutter/flutter/pull/14483. It _will_ affect some layouts.

The current appearance of the radio buttons and the radial splash for checkbox and switch:

![image](https://user-images.githubusercontent.com/1377460/40078721-519ccd0e-583a-11e8-8383-d08c4e6772cb.png)

The new appearance:

![image](https://user-images.githubusercontent.com/1377460/40078779-7f96db3c-583a-11e8-9b7c-bcb6a64cd9dc.png)


