### PR TITLE
Revert "Adjust scroll increment in transition perf test (#17593)"

### DIFF
--- a/examples/flutter_gallery/test_driver/transitions_perf.dart
+++ b/examples/flutter_gallery/test_driver/transitions_perf.dart
@@ -4,30 +4,16 @@
 
 import 'dart:async';
 import 'dart:convert' show JsonEncoder;
-import 'dart:ui' show window, Size;
 
 import 'package:flutter_driver/driver_extension.dart';
 import 'package:flutter_gallery/gallery/demos.dart';
 import 'package:flutter_gallery/main.dart' as app;
 
-
 Future<String> _handleMessages(String message) async {
-  assert(message == 'demoNames' || message == 'mediaSize');
-  const JsonEncoder jsonEncoder = const JsonEncoder.withIndent('  ');
-  switch(message) {
-    case 'demoNames':
-      return jsonEncoder.convert(
-        kAllGalleryDemos.map((GalleryDemo demo) => '${demo.title}@${demo.category.name}').toList(),
-      );
-    case 'mediaSize':
-      final Size size = window.physicalSize / window.devicePixelRatio;
-      return jsonEncoder.convert(<String, double>{
-        'width': size.width,
-        'height': size.height,
-      });
-  }
-  assert(false, 'Not reachable');
-  return '';
+  assert(message == 'demoNames');
+  return const JsonEncoder.withIndent('  ').convert(
+    kAllGalleryDemos.map((GalleryDemo demo) => '${demo.title}@${demo.category.name}').toList(),
+  );
 }
 
 void main() {

--- a/examples/flutter_gallery/test_driver/transitions_perf_test.dart
+++ b/examples/flutter_gallery/test_driver/transitions_perf_test.dart
@@ -51,15 +51,9 @@ const List<String> kSkippedDemos = const <String>[
 
 // All of the gallery demos, identified as "title@category".
 //
-// These names are reported by the test app. See _handleMessages() in
-// transitions_perf.dart.
+// These names are reported by the test app, see _handleMessages()
+// in transitions_perf.dart.
 List<String> _allDemos = <String>[];
-
-// The height of the screen, in logical pixels.
-//
-// This is reported by the test app. See _handleMessages() in
-// transition_perf.dart.
-double _mediaHeight = 0.0;
 
 /// Extracts event data from [events] recorded by timeline, validates it, turns
 /// it into a histogram, and saves to a JSON file.
@@ -152,8 +146,7 @@ Future<Null> runDemos(List<String> demos, FlutterDriver driver) async {
     currentDemoCategory = demoCategory;
 
     final SerializableFinder demoItem = find.text(demoName);
-    final double scrollDistance = _mediaHeight / 4.0;
-    await driver.scrollUntilVisible(demoList, demoItem, dyScroll: -scrollDistance,  alignment: 0.5);
+    await driver.scrollUntilVisible(demoList, demoItem, dyScroll: -48.0,  alignment: 0.5);
 
     for (int i = 0; i < 2; i += 1) {
       await driver.tap(demoItem); // Launch the demo
@@ -189,10 +182,6 @@ void main([List<String> args = const <String>[]]) {
       _allDemos = const JsonDecoder().convert(await driver.requestData('demoNames'));
       if (_allDemos.isEmpty)
         throw 'no demo names found';
-
-      _mediaHeight = const JsonDecoder().convert(await driver.requestData('mediaSize'))['height'];
-      if (_mediaHeight <= 0.0)
-        throw 'unable to determine media height';
     });
 
     tearDownAll(() async {


### PR DESCRIPTION
Caused breakage wherein we're unable to find the Backdrop material demo.

This reverts commit 1095eafed497ab8785109b7b737112acc754cf93.