### PR TITLE
Expandable Search

### DIFF
--- a/examples/flutter_gallery/lib/demo/material/material.dart
+++ b/examples/flutter_gallery/lib/demo/material/material.dart
@@ -24,6 +24,7 @@ export 'page_selector_demo.dart';
 export 'persistent_bottom_sheet_demo.dart';
 export 'progress_indicator_demo.dart';
 export 'scrollable_tabs_demo.dart';
+export 'search_demo.dart';
 export 'selection_controls_demo.dart';
 export 'slider_demo.dart';
 export 'snack_bar_demo.dart';

--- a/examples/flutter_gallery/lib/demo/material/search_demo.dart
+++ b/examples/flutter_gallery/lib/demo/material/search_demo.dart
@@ -156,7 +156,7 @@ class _SearchDemoSearchDelegate extends SearchDelegate<int> {
       suggestions: suggestions.map((int i) => '$i'),
       onSelected: (String suggestion) {
         query = suggestion;
-        showResultsPage(context);
+        showResults(context);
       },
     );
   }
@@ -210,8 +210,8 @@ class _SearchDemoSearchDelegate extends SearchDelegate<int> {
               icon: const Icon(Icons.clear),
               onPressed: () {
                 query = '';
-                if (isShowingResultsPage(context)) {
-                  showSearchPage(context);
+                if (isShowingResults(context)) {
+                  showSuggestions(context);
                 }
               },
             )

--- a/examples/flutter_gallery/lib/demo/material/search_demo.dart
+++ b/examples/flutter_gallery/lib/demo/material/search_demo.dart
@@ -153,7 +153,7 @@ class _SearchDemoSearchDelegate extends SearchDelegate<int> {
 
     return new _SuggestionList(
       query: query,
-      suggestions: suggestions.map((int i) => '$i'),
+      suggestions: suggestions.map((int i) => '$i').toList(),
       onSelected: (String suggestion) {
         query = suggestion;
         showResults(context);
@@ -210,9 +210,7 @@ class _SearchDemoSearchDelegate extends SearchDelegate<int> {
               icon: const Icon(Icons.clear),
               onPressed: () {
                 query = '';
-                if (isShowingResults(context)) {
-                  showSuggestions(context);
-                }
+                showSuggestions(context);
               },
             )
     ];
@@ -254,15 +252,17 @@ class _ResultCard extends StatelessWidget {
 class _SuggestionList extends StatelessWidget {
   const _SuggestionList({this.suggestions, this.query, this.onSelected});
 
-  final Iterable<String> suggestions;
+  final List<String> suggestions;
   final String query;
   final ValueChanged<String> onSelected;
 
   @override
   Widget build(BuildContext context) {
     final ThemeData theme = Theme.of(context);
-    return new ListView(
-      children: suggestions.map((String suggestion) {
+    return new ListView.builder(
+      itemCount: suggestions.length,
+      itemBuilder: (BuildContext context, int i) {
+        final String suggestion = suggestions[i];
         return new ListTile(
           leading: query.isEmpty ? const Icon(Icons.history) : new Container(),
           title: new RichText(
@@ -281,7 +281,7 @@ class _SuggestionList extends StatelessWidget {
             onSelected(suggestion);
           },
         );
-      }).toList(),
+      },
     );
   }
 }

--- a/examples/flutter_gallery/lib/demo/material/search_demo.dart
+++ b/examples/flutter_gallery/lib/demo/material/search_demo.dart
@@ -8,11 +8,11 @@ class SearchDemo extends StatefulWidget {
   static const String routeName = '/material/search';
 
   @override
-  SearchDemoState createState() => new SearchDemoState();
+  _SearchDemoState createState() => new _SearchDemoState();
 }
 
-class SearchDemoState extends State<SearchDemo> {
-  final SearchDemoSearchDelegate _delegate = new SearchDemoSearchDelegate();
+class _SearchDemoState extends State<SearchDemo> {
+  final _SearchDemoSearchDelegate _delegate = new _SearchDemoSearchDelegate();
   final GlobalKey<ScaffoldState> _scaffoldKey = new GlobalKey<ScaffoldState>();
 
   int _lastIntegerSelected;
@@ -39,7 +39,7 @@ class SearchDemoState extends State<SearchDemo> {
             tooltip: 'Search',
             icon: const Icon(Icons.search),
             onPressed: () async {
-              final int selected = await showSearchOverlay<int>(
+              final int selected = await showSearch<int>(
                 context: context,
                 delegate: _delegate,
               );
@@ -91,7 +91,7 @@ class SearchDemoState extends State<SearchDemo> {
         ),
       ),
       floatingActionButton: new FloatingActionButton.extended(
-        tooltip: 'Back',
+        tooltip: 'Back', // Tests depend on this label to exit the demo.
         onPressed: () {
           Navigator.of(context).pop();
         },
@@ -128,7 +128,7 @@ class SearchDemoState extends State<SearchDemo> {
   }
 }
 
-class SearchDemoSearchDelegate extends SearchDelegate<int> {
+class _SearchDemoSearchDelegate extends SearchDelegate<int> {
   final List<int> _data = new List<int>.generate(100001, (int i) => i).reversed.toList();
   final List<int> _history = <int>[42607, 85604, 66374, 44, 174];
 
@@ -162,8 +162,7 @@ class SearchDemoSearchDelegate extends SearchDelegate<int> {
           title: new RichText(
             text: new TextSpan(
               text: suggestion.substring(0, query.length),
-              style:
-                  theme.textTheme.subhead.copyWith(fontWeight: FontWeight.bold),
+              style: theme.textTheme.subhead.copyWith(fontWeight: FontWeight.bold),
               children: <TextSpan>[
                 new TextSpan(
                   text: suggestion.substring(query.length),
@@ -193,40 +192,24 @@ class SearchDemoSearchDelegate extends SearchDelegate<int> {
       );
     }
 
-    final ThemeData theme = Theme.of(context);
     return new ListView(
       children: <Widget>[
-        _buildCard('This integer', searched, theme, context),
-        _buildCard('Next integer', searched + 1, theme, context),
-        _buildCard('Previous integer', searched - 1, theme, context),
-      ],
-    );
-  }
-
-  Widget _buildCard(
-    String title,
-    int i,
-    ThemeData theme,
-    BuildContext context,
-  ) {
-    return new GestureDetector(
-      onTap: () {
-        close(context, i);
-      },
-      child: new Card(
-        child: new Padding(
-          padding: const EdgeInsets.all(8.0),
-          child: new Column(
-            children: <Widget>[
-              new Text(title),
-              new Text(
-                '$i',
-                style: theme.textTheme.headline.copyWith(fontSize: 72.0),
-              ),
-            ],
-          ),
+        new _ResultCard(
+          title: 'This integer',
+          integer: searched,
+          searchDelegate: this,
         ),
-      ),
+        new _ResultCard(
+          title: 'Next integer',
+          integer: searched + 1,
+          searchDelegate: this,
+        ),
+        new _ResultCard(
+          title: 'Previous integer',
+          integer: searched - 1,
+          searchDelegate: this,
+        ),
+      ],
     );
   }
 
@@ -253,4 +236,39 @@ class SearchDemoSearchDelegate extends SearchDelegate<int> {
             )
     ];
   }
+}
+
+class _ResultCard extends StatelessWidget {
+
+  _ResultCard({this.integer, this.title, this.searchDelegate});
+
+  final int integer;
+  final String title;
+  final SearchDelegate searchDelegate;
+
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    return new GestureDetector(
+      onTap: () {
+        searchDelegate.close(context, integer);
+      },
+      child: new Card(
+        child: new Padding(
+          padding: const EdgeInsets.all(8.0),
+          child: new Column(
+            children: <Widget>[
+              new Text(title),
+              new Text(
+                '$integer',
+                style: theme.textTheme.headline.copyWith(fontSize: 72.0),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
 }

--- a/examples/flutter_gallery/lib/demo/material/search_demo.dart
+++ b/examples/flutter_gallery/lib/demo/material/search_demo.dart
@@ -264,7 +264,7 @@ class _SuggestionList extends StatelessWidget {
       itemBuilder: (BuildContext context, int i) {
         final String suggestion = suggestions[i];
         return new ListTile(
-          leading: query.isEmpty ? const Icon(Icons.history) : new Container(),
+          leading: query.isEmpty ? const Icon(Icons.history) : const Icon(null),
           title: new RichText(
             text: new TextSpan(
               text: suggestion.substring(0, query.length),

--- a/examples/flutter_gallery/lib/demo/material/search_demo.dart
+++ b/examples/flutter_gallery/lib/demo/material/search_demo.dart
@@ -254,7 +254,7 @@ class _ResultCard extends StatelessWidget {
 class _SuggestionList extends StatelessWidget {
   const _SuggestionList({this.suggestions, this.query, this.onSelected});
 
-  final List<String> suggestions;
+  final Iterable<String> suggestions;
   final String query;
   final ValueChanged<String> onSelected;
 

--- a/examples/flutter_gallery/lib/demo/material/search_demo.dart
+++ b/examples/flutter_gallery/lib/demo/material/search_demo.dart
@@ -240,11 +240,11 @@ class _SearchDemoSearchDelegate extends SearchDelegate<int> {
 
 class _ResultCard extends StatelessWidget {
 
-  _ResultCard({this.integer, this.title, this.searchDelegate});
+  const _ResultCard({this.integer, this.title, this.searchDelegate});
 
   final int integer;
   final String title;
-  final SearchDelegate searchDelegate;
+  final SearchDelegate<int> searchDelegate;
 
 
   @override

--- a/examples/flutter_gallery/lib/demo/material/search_demo.dart
+++ b/examples/flutter_gallery/lib/demo/material/search_demo.dart
@@ -83,9 +83,7 @@ class _SearchDemoState extends State<SearchDemo> {
                 ],
               ),
             ),
-            const Padding(
-              padding: const EdgeInsets.symmetric(vertical: 64.0),
-            ),
+            const SizedBox(height: 64.0),
             new Text('Last selected integer: ${_lastIntegerSelected ?? 'NONE' }.')
           ],
         ),
@@ -148,35 +146,18 @@ class _SearchDemoSearchDelegate extends SearchDelegate<int> {
 
   @override
   Widget buildSuggestions(BuildContext context) {
-    final ThemeData theme = Theme.of(context);
 
     final Iterable<int> suggestions = query.isEmpty
         ? _history
         : _data.where((int i) => '$i'.startsWith(query));
 
-    return new ListView(
-      children: suggestions.map((int i) {
-        final String suggestion = '$i';
-        return new ListTile(
-          leading: query.isEmpty ? const Icon(Icons.history) : new Container(),
-          title: new RichText(
-            text: new TextSpan(
-              text: suggestion.substring(0, query.length),
-              style: theme.textTheme.subhead.copyWith(fontWeight: FontWeight.bold),
-              children: <TextSpan>[
-                new TextSpan(
-                  text: suggestion.substring(query.length),
-                  style: theme.textTheme.subhead,
-                ),
-              ],
-            ),
-          ),
-          onTap: () {
-            query = '$i';
-            showResultsPage(context);
-          },
-        );
-      }).toList(),
+    return new _SuggestionList(
+      query: query,
+      suggestions: suggestions.map((int i) => '$i'),
+      onSelected: (String suggestion) {
+        query = suggestion;
+        showResultsPage(context);
+      },
     );
   }
 
@@ -239,13 +220,11 @@ class _SearchDemoSearchDelegate extends SearchDelegate<int> {
 }
 
 class _ResultCard extends StatelessWidget {
-
   const _ResultCard({this.integer, this.title, this.searchDelegate});
 
   final int integer;
   final String title;
   final SearchDelegate<int> searchDelegate;
-
 
   @override
   Widget build(BuildContext context) {
@@ -270,5 +249,39 @@ class _ResultCard extends StatelessWidget {
       ),
     );
   }
+}
 
+class _SuggestionList extends StatelessWidget {
+  const _SuggestionList({this.suggestions, this.query, this.onSelected});
+
+  final List<String> suggestions;
+  final String query;
+  final ValueChanged<String> onSelected;
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    return new ListView(
+      children: suggestions.map((String suggestion) {
+        return new ListTile(
+          leading: query.isEmpty ? const Icon(Icons.history) : new Container(),
+          title: new RichText(
+            text: new TextSpan(
+              text: suggestion.substring(0, query.length),
+              style: theme.textTheme.subhead.copyWith(fontWeight: FontWeight.bold),
+              children: <TextSpan>[
+                new TextSpan(
+                  text: suggestion.substring(query.length),
+                  style: theme.textTheme.subhead,
+                ),
+              ],
+            ),
+          ),
+          onTap: () {
+            onSelected(suggestion);
+          },
+        );
+      }).toList(),
+    );
+  }
 }

--- a/examples/flutter_gallery/lib/demo/material/search_demo.dart
+++ b/examples/flutter_gallery/lib/demo/material/search_demo.dart
@@ -15,6 +15,8 @@ class SearchDemoState extends State<SearchDemo> {
   final SearchDemoSearchDelegate _delegate = new SearchDemoSearchDelegate();
   final GlobalKey<ScaffoldState> _scaffoldKey = new GlobalKey<ScaffoldState>();
 
+  int _lastIntegerSelected;
+
   @override
   Widget build(BuildContext context) {
     return new Scaffold(
@@ -37,10 +39,15 @@ class SearchDemoState extends State<SearchDemo> {
             tooltip: 'Search',
             icon: const Icon(Icons.search),
             onPressed: () async {
-              showSearchOverlay(
+              final int selected = await showSearchOverlay<int>(
                 context: context,
                 delegate: _delegate,
               );
+              if (selected != null && selected != _lastIntegerSelected) {
+                setState(() {
+                  _lastIntegerSelected = selected;
+                });
+              }
             },
           ),
           new IconButton(
@@ -51,27 +58,36 @@ class SearchDemoState extends State<SearchDemo> {
         ],
       ),
       body: new Center(
-        child: new MergeSemantics(
-          child: new Column(
-            mainAxisAlignment: MainAxisAlignment.center,
-            children: <Widget>[
-              new Row(
+        child: new Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: <Widget>[
+            new MergeSemantics(
+              child: new Column(
                 mainAxisAlignment: MainAxisAlignment.center,
-                children: const <Widget>[
-                  const Text('Press the '),
-                  const Tooltip(
-                    message: 'search',
-                    child: const Icon(
-                      Icons.search,
-                      size: 18.0,
-                    ),
+                children: <Widget>[
+                  new Row(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: const <Widget>[
+                      const Text('Press the '),
+                      const Tooltip(
+                        message: 'search',
+                        child: const Icon(
+                          Icons.search,
+                          size: 18.0,
+                        ),
+                      ),
+                      const Text(' icon in the AppBar'),
+                    ],
                   ),
-                  const Text(' icon in the AppBar'),
+                  const Text('and search for an integer between 0 and 100,000.'),
                 ],
               ),
-              const Text('and search for an integer between 0 and 100,000.'),
-            ],
-          ),
+            ),
+            const Padding(
+              padding: const EdgeInsets.symmetric(vertical: 64.0),
+            ),
+            new Text('Last selected integer: ${_lastIntegerSelected ?? 'NONE' }.')
+          ],
         ),
       ),
       floatingActionButton: new FloatingActionButton.extended(
@@ -112,7 +128,7 @@ class SearchDemoState extends State<SearchDemo> {
   }
 }
 
-class SearchDemoSearchDelegate extends SearchDelegate<void> {
+class SearchDemoSearchDelegate extends SearchDelegate<int> {
   final List<int> _data = new List<int>.generate(100001, (int i) => i).reversed.toList();
   final List<int> _history = <int>[42607, 85604, 66374, 44, 174];
 
@@ -180,9 +196,9 @@ class SearchDemoSearchDelegate extends SearchDelegate<void> {
     final ThemeData theme = Theme.of(context);
     return new ListView(
       children: <Widget>[
-        _buildCard('This integer', searched, theme),
-        _buildCard('Next integer', searched + 1, theme),
-        _buildCard('Previous integer', searched - 1, theme),
+        _buildCard('This integer', searched, theme, context),
+        _buildCard('Next integer', searched + 1, theme, context),
+        _buildCard('Previous integer', searched - 1, theme, context),
       ],
     );
   }
@@ -191,8 +207,12 @@ class SearchDemoSearchDelegate extends SearchDelegate<void> {
     String title,
     int i,
     ThemeData theme,
+    BuildContext context,
   ) {
     return new GestureDetector(
+      onTap: () {
+        close(context, i);
+      },
       child: new Card(
         child: new Padding(
           padding: const EdgeInsets.all(8.0),

--- a/examples/flutter_gallery/lib/gallery/demos.dart
+++ b/examples/flutter_gallery/lib/gallery/demos.dart
@@ -314,6 +314,14 @@ List<GalleryDemo> _buildGalleryDemos() {
       buildRoute: (BuildContext context) => const OverscrollDemo(),
     ),
     new GalleryDemo(
+      title: 'Search',
+      subtitle: 'Expandable search',
+      icon: Icons.search,
+      category: _kMaterialComponents,
+      routeName: SearchDemo.routeName,
+      buildRoute: (BuildContext context) => new SearchDemo(),
+    ),
+    new GalleryDemo(
       title: 'Selection controls',
       subtitle: 'Checkboxes, radio buttons, and switches',
       icon: GalleryIcons.check_box,

--- a/packages/flutter/lib/material.dart
+++ b/packages/flutter/lib/material.dart
@@ -78,6 +78,7 @@ export 'src/material/raised_button.dart';
 export 'src/material/refresh_indicator.dart';
 export 'src/material/scaffold.dart';
 export 'src/material/scrollbar.dart';
+export 'src/material/search.dart';
 export 'src/material/shadows.dart';
 export 'src/material/slider.dart';
 export 'src/material/slider_theme.dart';

--- a/packages/flutter/lib/src/material/material_localizations.dart
+++ b/packages/flutter/lib/src/material/material_localizations.dart
@@ -160,6 +160,10 @@ abstract class MaterialLocalizations {
   /// alert dialog widget is opened.
   String get alertDialogLabel;
 
+  /// Label indicating that a text field is a search field. This will be used
+  /// as a hint text in the text field.
+  String get searchFieldLabel;
+
   /// The format used to lay out the time picker.
   ///
   /// The documentation for [TimeOfDayFormat] enum values provides details on
@@ -536,6 +540,9 @@ class DefaultMaterialLocalizations implements MaterialLocalizations {
 
   @override
   String get alertDialogLabel => 'Alert';
+
+  @override
+  String get searchFieldLabel => 'Search';
 
   @override
   String aboutListTileTitle(String applicationName) => 'About $applicationName';

--- a/packages/flutter/lib/src/material/search.dart
+++ b/packages/flutter/lib/src/material/search.dart
@@ -1,0 +1,475 @@
+// Copyright 2018 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:flutter/widgets.dart';
+
+import 'app_bar.dart';
+import 'colors.dart';
+import 'input_border.dart';
+import 'input_decorator.dart';
+import 'scaffold.dart';
+import 'text_field.dart';
+import 'theme.dart';
+
+/// Shows a full screen search overlay.
+///
+/// The overlay consists of an app bar with a search field and a body which can
+/// either show suggested search queries (the search page) or the search
+/// results (the results page).
+///
+/// The appearance of the search overlay is determined by the provided
+/// `delegate`. The initial query string is given by `query`, which defaults
+/// to the empty string. When `query` is set to null, `delegate.query` will
+/// be used as the initial query.
+///
+/// The transition to the search overlay triggered by this method looks best
+/// if the screen triggering the transition contains an [AppBar] at the top
+/// and the transition is triggered from an [IconButton.onPressed] within
+/// [AppBar.actions]. The animation provided by [SearchDelegate.animation] can
+/// be used to trigger additional animations in the underlying screen while
+/// the search overlay fades in or out. This is commonly used to animate
+/// an [AnimatedIcon] in the [AppBar.leading] position e.g. from the hamburger
+/// menu to the back arrow used to exit the search overlay.
+///
+/// See also:
+///
+///  * [SearchDelegate] for ways to customize the search overlay.
+Future<T> showSearchOverlay<T>({
+  @required BuildContext context,
+  @required SearchDelegate<T> delegate,
+  String query: '',
+}) {
+  assert(delegate != null);
+  assert(context != null);
+  delegate.query = query ?? delegate.query;
+  return Navigator.of(context).push(new _SearchPageRoute<T>(
+    delegate: delegate,
+  ));
+}
+
+/// Delegate for [showSearchOverlay] to customize the search experience.
+///
+/// The search experience consists of two pages:
+///
+/// 1) A search page showing a search field in an [AppBar] and suggestions
+///    shown below in the body of the page. Which suggestions are shown is
+///    determined by [SearchDelegate.buildSuggestions].
+/// 2) A results page with an [AppBar] showing the current search string and
+///    the search results in the body. The search results are provided by
+///    [SearchDelegate.buildResults].
+///
+/// Additionally, the [SearchDelegate] also allows customizing the buttons
+/// shown alongside the [AppBar] on both screens via [leading] and [actions].
+abstract class SearchDelegate<T> {
+
+  /// Suggestions shown in the body of the search overlay while the user types a
+  /// query into the search field.
+  ///
+  /// The delegate method is called whenever the content of [query] changes and
+  /// the value of [query] can be used to determine which suggestions should
+  /// be shown.
+  ///
+  /// Usually, this method will return a [ListView] with one [ListTile] per
+  /// suggestion. When [ListTile.onTap] is called, [query] should be updated
+  /// with the corresponding [suggestion] and the results page should be shown
+  /// by calling [showResultsPage].
+  Widget buildSuggestions(BuildContext context);
+
+  /// The results shown after the user submits a search from the search page.
+  ///
+  /// The content of [query] can be used to determine what the users searched
+  /// for.
+  Widget buildResults(BuildContext context);
+
+  /// A widget to display before the current query in the [AppBar] of the search
+  /// overlay.
+  ///
+  /// Typically an [IconButton] as a back button to exit the search overlay. It
+  /// is suggested to show an [AnimatedIcon] driven by [transitionAnimation],
+  /// which animated from e.g. a hamburger menu to the back button as the search
+  /// overlay fades in.
+  ///
+  /// See also:
+  ///
+  ///  * [AppBar.leading], the intended use for the return value of this method.
+  Widget buildLeading(BuildContext context);
+
+  /// Widgets to display after the search query in the [AppBar] of the search
+  /// overlay.
+  ///
+  /// If the [query] is not empty, this should typically contain a button to
+  /// clear the query and go back to the search page if the results page is
+  /// currently shown.
+  ///
+  /// See also:
+  ///
+  ///  * [AppBar.actions], the intended use for the return value of this method.
+  List<Widget> buildActions(BuildContext context);
+
+  /// The theme used to style the [AppBar] of the search overlay.
+  ///
+  /// By default, a white theme is used.
+  ///
+  /// See also:
+  ///
+  ///  * [AppBar.backgroundColor], which is set to [ThemeData.primaryColor].
+  ///  * [Appbar.iconTheme], which is set to [ThemeData.primaryIconTheme].
+  ///  * [AppBar.textTheme], which is set to [ThemeData.primaryTextTheme].
+  ///  * [AppBar.brightness], which is set to [ThemeData.primaryColorBrightness].
+  ThemeData appBarTheme(BuildContext context) {
+    assert(context != null);
+    final ThemeData theme = Theme.of(context);
+    assert(theme != null);
+    return theme.copyWith(
+      primaryColor: Colors.white,
+      primaryIconTheme: theme.primaryIconTheme.copyWith(color: Colors.grey),
+      primaryColorBrightness: Brightness.light,
+      primaryTextTheme: theme.textTheme,
+    );
+  }
+
+  /// The current query string shown in the app bar.
+  ///
+  /// The user manipulates this string via the keyboard.
+  ///
+  /// If the user taps on a suggestion provided by [buildSuggestions] this
+  /// string should be updated to that suggestion via the setter.
+  String get query => _textEditingController.text;
+  set query(String value) {
+    assert(query != null);
+    _textEditingController.text = value;
+  }
+
+
+  /// Transition to the results page.
+  ///
+  /// If the user taps on a suggestion provided by [buildSuggestions] the
+  /// search overlay should typically transition to the page showing the search
+  /// results for the suggested query. This transition can be triggered
+  /// by calling this method.
+  ///
+  /// See also:
+  ///
+  ///  * [isShowingResultsPage] to check if the search overlay is currently
+  ///    showing the results page.
+  ///  * [isShowingSearchPage] to check if the search overlay is currently
+  ///     showing the search page.
+  ///  * [showSearchPage] to transition to the search page.
+  @protected
+  Future<T> showResultsPage(BuildContext context) {
+    assert(isShowingSearchPage(context));
+    focusNode.unfocus();
+    return Navigator.of(context).pushReplacement(new _ResultsPageRoute<T>(
+      delegate: this,
+    ));
+  }
+
+  /// Transition to the search page.
+  ///
+  /// If the search overlay is currently showing the results page this method
+  /// can be used to trigger a transition back to the search page.
+  ///
+  /// This can only be called if the search overlay is currently showing the
+  /// results page. To show the search overlay on top of another route call
+  /// [showSearchOverlay] instead of this method.
+  ///
+  /// See also:
+  ///
+  ///  * [isShowingResultsPage] to check if the search overlay is currently
+  ///    showing the results page.
+  ///  * [isShowingSearchPage] to check if the search overlay is currently
+  ///     showing the search page.
+  ///  * [showResultsPage] to transition to the results page.
+  @protected
+  Future<T> showSearchPage(BuildContext context) {
+    assert(isShowingResultsPage(context));
+    return Navigator.of(context).pushReplacement(new _SearchPageRoute<T>(
+      delegate: this,
+      useProxyAnimationOnEntry: false,
+    ));
+  }
+
+  /// Close the search overlay and return to the underlying route.
+  ///
+  /// This method returns to the side that called [showSearchOverlay] initially.
+  @protected
+  void close(BuildContext context, T result) {
+    assert(isShowingResultsPage(context) || isShowingSearchPage(context));
+    focusNode.unfocus();
+    Navigator.of(context).pop(result);
+  }
+
+  /// Whether the search overlay is currently showing the search page.
+  ///
+  /// On the search page the user can enter a search query in the app bar
+  /// and sees suggested queries (from [buildSuggestions]) in the body.
+  ///
+  /// See also:
+  ///
+  ///  * [isShowingResultsPage] to check if the search overlay is currently
+  ///    showing the results page.
+  ///  * [showSearchPage] to transition to the search page.
+  ///  * [showResultsPage] to transition to the results page.
+  bool isShowingSearchPage(BuildContext context) => ModalRoute.of(context) is _SearchPageRoute;
+
+  /// Whether the search overlay is currently showing the results page.
+  ///
+  /// On the results page the user should see hits for the provided [query],
+  /// which are obtained from [buildResults].
+  ///
+  /// See also:
+  ///
+  ///  * [isShowingResultsPage] to check if the search overlay is currently
+  ///    showing the results page.
+  ///  * [showSearchPage] to transition to the search page.
+  ///  * [showResultsPage] to transition to the results page.
+  bool isShowingResultsPage(BuildContext context) => ModalRoute.of(context) is _ResultsPageRoute;
+
+  /// [Animation] triggered while the search overlay fades in or out.
+  ///
+  /// This animation is commonly used to animate [AnimatedIcon]s of
+  /// [IconButton]s return by [buildLeading] or contained within the route
+  /// below the search overlay.
+  Animation<double> get transitionAnimation => _proxyAnimation;
+
+  /// [FocusNode] used by the text field showing the current search query.
+  ///
+  /// It can be used to unfocus the text field before transitioning to the
+  /// results page.
+  final FocusNode focusNode = new FocusNode();
+
+  final TextEditingController _textEditingController = new TextEditingController();
+
+  final ProxyAnimation _proxyAnimation = new ProxyAnimation(kAlwaysDismissedAnimation);
+}
+
+/// Base class for routes within the search overlay.
+///
+/// [_SearchOverlayPageRoute] are cross-faded in and can trigger animations
+/// during the route transition in the new and old route by setting
+/// [SearchDelegate.transitionAnimation]. The latter is for example used to
+/// animate the hamburger menu icon of an [AppBar] into a back arrow while the
+/// search overlay fades in.
+abstract class _SearchOverlayPageRoute<T> extends PageRoute<T> {
+  _SearchOverlayPageRoute({
+    @required this.delegate,
+    this.triggerAnimationsInRoutesOnEntry: true,
+  }) : assert(delegate != null), assert(triggerAnimationsInRoutesOnEntry != null);
+
+  /// The [SearchDelegate] determining the appearance of the search overlay
+  /// owning this route.
+  final SearchDelegate<T> delegate;
+
+  /// Whether [delegate.animation] should be triggered while this route fades
+  /// in.
+  final bool triggerAnimationsInRoutesOnEntry;
+
+  @override
+  Color get barrierColor => null;
+
+  @override
+  String get barrierLabel => null;
+
+  @override
+  Duration get transitionDuration => const Duration(milliseconds: 300);
+
+  @override
+  bool get maintainState => false;
+
+  @override
+  Widget buildTransitions(
+    BuildContext context,
+    Animation<double> animation,
+    Animation<double> secondaryAnimation,
+    Widget child,
+  ) {
+    return new FadeTransition(
+      opacity: animation,
+      child: child,
+    );
+  }
+
+  @override
+  Animation<double> createAnimation() {
+    final Animation<double> animation = super.createAnimation();
+    if (triggerAnimationsInRoutesOnEntry) {
+      delegate._proxyAnimation.parent = animation;
+    } else {
+      Function listener;
+      listener = (AnimationStatus status) {
+        switch (status) {
+          case AnimationStatus.dismissed:
+          case AnimationStatus.forward:
+            break;
+          case AnimationStatus.reverse:
+          case AnimationStatus.completed:
+            animation.removeStatusListener(listener);
+            delegate._proxyAnimation.parent = animation;
+            break;
+        }
+      };
+      animation.addStatusListener(listener);
+    }
+    return animation;
+  }
+}
+
+// SEARCH PAGE
+
+/// Route to switch to the search page of the search overlay.
+class _SearchPageRoute<T> extends _SearchOverlayPageRoute<T> {
+  _SearchPageRoute({
+    bool useProxyAnimationOnEntry: true,
+    SearchDelegate<T> delegate,
+  }) : super(
+          triggerAnimationsInRoutesOnEntry: useProxyAnimationOnEntry,
+          delegate: delegate,
+        );
+
+  @override
+  Widget buildPage(
+    BuildContext context,
+    Animation<double> animation,
+    Animation<double> secondaryAnimation,
+  ) {
+    return new _SearchPage<T>(
+      delegate: delegate,
+      animation: animation,
+    );
+  }
+}
+
+class _SearchPage<T> extends StatefulWidget {
+  const _SearchPage({
+    this.delegate,
+    this.animation,
+  });
+
+  final SearchDelegate<T> delegate;
+  final Animation<double> animation;
+
+  @override
+  State<StatefulWidget> createState() => new _SearchPageState<T>();
+}
+
+class _SearchPageState<T> extends State<_SearchPage<T>> {
+  @override
+  void initState() {
+    super.initState();
+    _controller.addListener(_onQueryChanged);
+    widget.animation.addStatusListener(_onAnimationStatusChanged);
+  }
+
+  @override
+  void dispose() {
+    super.dispose();
+    _controller.removeListener(_onQueryChanged);
+    widget.animation.removeStatusListener(_onAnimationStatusChanged);
+  }
+
+  void _onAnimationStatusChanged(AnimationStatus status) {
+    if (status != AnimationStatus.completed) {
+      return;
+    }
+    widget.animation.removeStatusListener(_onAnimationStatusChanged);
+    FocusScope.of(context).requestFocus(widget.delegate.focusNode);
+  }
+
+  void _onQueryChanged() {
+    setState(() {
+      // rebuild ourselves because query changed.
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = widget.delegate.appBarTheme(context);
+    return new Scaffold(
+      appBar: new AppBar(
+        backgroundColor: theme.primaryColor,
+        iconTheme: theme.primaryIconTheme,
+        textTheme: theme.primaryTextTheme,
+        brightness: theme.primaryColorBrightness,
+        leading: widget.delegate.buildLeading(context),
+        // TODO(goderbauer): Show the search key (instead of enter) on keyboard.
+        title: new TextField(
+          controller: _controller,
+          focusNode: widget.delegate.focusNode,
+          style: theme.textTheme.title,
+          onSubmitted: (String _) {
+            widget.delegate.showResultsPage(context);
+          },
+          decoration: const InputDecoration(
+            border: InputBorder.none,
+            hintText: 'Search', // TODO(goderbauer): I18N
+          ),
+        ),
+        actions: widget.delegate.buildActions(context),
+      ),
+      body: widget.delegate.buildSuggestions(context),
+    );
+  }
+
+  TextEditingController get _controller => widget.delegate._textEditingController;
+}
+
+// RESULTS PAGE
+
+/// Route to switch to the results page of the search overlay.
+class _ResultsPageRoute<T> extends _SearchOverlayPageRoute<T> {
+  _ResultsPageRoute({
+    SearchDelegate<T> delegate,
+  }) : super(delegate: delegate, triggerAnimationsInRoutesOnEntry: false);
+
+  @override
+  Widget buildPage(
+    BuildContext context,
+    Animation<double> animation,
+    Animation<double> secondaryAnimation,
+  ) {
+    return new _ResultsPage<T>(
+      delegate: delegate,
+    );
+  }
+}
+
+class _ResultsPage<T> extends StatelessWidget {
+  const _ResultsPage({
+    this.delegate,
+  });
+
+  final SearchDelegate<T> delegate;
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = delegate.appBarTheme(context);
+    return new Scaffold(
+      appBar: new AppBar(
+        backgroundColor: theme.primaryColor,
+        iconTheme: theme.primaryIconTheme,
+        textTheme: theme.primaryTextTheme,
+        brightness: theme.primaryColorBrightness,
+        leading: delegate.buildLeading(context),
+        centerTitle: false,
+        title: new GestureDetector(
+          // TODO(goderbauer): find a better way then Row-Expanded to make the GestureDetector as wide as the appbar allows.
+          child: new Row(
+            children: <Widget>[
+              new Expanded(
+                child: new Text(delegate.query),
+              ),
+            ],
+          ),
+          onTap: () {
+            delegate.showSearchPage(context);
+          },
+        ),
+        actions: delegate.buildActions(context),
+      ),
+      body: delegate.buildResults(context),
+    );
+  }
+}

--- a/packages/flutter/lib/src/material/search.dart
+++ b/packages/flutter/lib/src/material/search.dart
@@ -29,6 +29,10 @@ import 'theme.dart';
 /// The method returns the selected search result, which can be set in the
 /// [SearchDelegate.close] call.
 ///
+/// A given [SearchDelegate] can only be associated with one active [showSearch]
+/// call. Call [SearchDelegate.close] before re-using the same delegate instance
+/// for another [showSearch] call.
+///
 /// The transition to the search page triggered by this method looks best if the
 /// screen triggering the transition contains an [AppBar] at the top and the
 /// transition is called from an [IconButton] that's part of [AppBar.actions].
@@ -79,6 +83,10 @@ Future<T> showSearch<T>({
 /// Once the user has selected a search result, [SearchDelegate.close] should be
 /// called to remove the search page from the top of the navigation stack and
 /// to notify the caller of [showSearch] about the selected search result.
+///
+/// A given [SearchDelegate] can only be associated with one active [showSearch]
+/// call. Call [SearchDelegate.close] before re-using the same delegate instance
+/// for another [showSearch] call.
 abstract class SearchDelegate<T> {
 
   /// Suggestions shown in the body of the search page while the user types a

--- a/packages/flutter/lib/src/material/search.dart
+++ b/packages/flutter/lib/src/material/search.dart
@@ -26,15 +26,17 @@ import 'theme.dart';
 /// to the empty string. When `query` is set to null, `delegate.query` will
 /// be used as the initial query.
 ///
-/// The transition to the search triggered by this method looks best if the
+/// The method returns the selected search result, which can be set in the
+/// [SearchDelegate.close] call.
+///
+/// The transition to the search page triggered by this method looks best if the
 /// screen triggering the transition contains an [AppBar] at the top and the
-/// transition is triggered from an [IconButton.onPressed] within
-/// [AppBar.actions]. The animation provided by
-/// [SearchDelegate.transitionAnimation] can be used to trigger additional
-/// animations in the underlying screen while the search fades in or out. This
-/// is commonly used to animate an [AnimatedIcon] in the [AppBar.leading]
-/// position e.g. from the hamburger menu to the back arrow used to exit the
-/// search overlay.
+/// transition is called from an [IconButton] that's part of [AppBar.actions].
+/// The animation provided by [SearchDelegate.transitionAnimation] can be used
+/// to trigger additional in the underlying page while the search page fades in
+/// or out. This is commonly used to animate an [AnimatedIcon] in the
+/// [AppBar.leading] position e.g. from the hamburger menu to the back arrow
+/// used to exit the search overlay.
 ///
 /// See also:
 ///

--- a/packages/flutter/lib/src/material/search.dart
+++ b/packages/flutter/lib/src/material/search.dart
@@ -401,7 +401,7 @@ class _SearchPageState<T> extends State<_SearchPage<T>> {
         textTheme: theme.primaryTextTheme,
         brightness: theme.primaryColorBrightness,
         leading: widget.delegate.buildLeading(context),
-        // TODO(goderbauer): Show the search key (instead of enter) on keyboard.
+        // TODO(goderbauer): Show the search key (instead of enter) on keyboard, https://github.com/flutter/flutter/issues/17525
         title: new TextField(
           controller: _controller,
           focusNode: widget.delegate.focusNode,

--- a/packages/flutter/lib/src/material/search.dart
+++ b/packages/flutter/lib/src/material/search.dart
@@ -10,6 +10,7 @@ import 'app_bar.dart';
 import 'colors.dart';
 import 'input_border.dart';
 import 'input_decorator.dart';
+import 'material_localizations.dart';
 import 'scaffold.dart';
 import 'text_field.dart';
 import 'theme.dart';
@@ -402,9 +403,9 @@ class _SearchPageState<T> extends State<_SearchPage<T>> {
           onSubmitted: (String _) {
             widget.delegate.showResultsPage(context);
           },
-          decoration: const InputDecoration(
+          decoration: new InputDecoration(
             border: InputBorder.none,
-            hintText: 'Search', // TODO(goderbauer): I18N
+            hintText: MaterialLocalizations.of(context).searchFieldLabel
           ),
         ),
         actions: widget.delegate.buildActions(context),

--- a/packages/flutter/lib/src/material/search.dart
+++ b/packages/flutter/lib/src/material/search.dart
@@ -196,9 +196,10 @@ abstract class SearchDelegate<T> {
     ));
   }
 
-  /// Close the search overlay and return to the underlying route.
+  /// Closes the search overlay and return to the underlying route.
   ///
-  /// This method returns to the side that called [showSearchOverlay] initially.
+  /// The value provided for `result` is used as the return value of the call
+  /// to [showSearchOverlay] that launched the search initially.
   @protected
   void close(BuildContext context, T result) {
     assert(isShowingResultsPage(context) || isShowingSearchPage(context));

--- a/packages/flutter/test/material/localizations_test.dart
+++ b/packages/flutter/test/material/localizations_test.dart
@@ -34,6 +34,7 @@ void main() {
     expect(localizations.popupMenuLabel, isNotNull);
     expect(localizations.dialogLabel, isNotNull);
     expect(localizations.alertDialogLabel, isNotNull);
+    expect(localizations.searchFieldLabel, isNotNull);
 
     expect(localizations.aboutListTileTitle('FOO'), isNotNull);
     expect(localizations.aboutListTileTitle('FOO'), contains('FOO'));

--- a/packages/flutter/test/material/search_test.dart
+++ b/packages/flutter/test/material/search_test.dart
@@ -127,7 +127,7 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(delegate.query, 'Wow');
-    expect(delegate.querysForSuggestions, ['Wow']);
+    expect(delegate.querysForSuggestions, <String>['Wow']);
     expect(delegate.querysForResults, hasLength(0));
 
     await tester.tap(find.text('Suggestions'));
@@ -138,8 +138,8 @@ void main() {
     expect(find.text('Results'), findsOneWidget);
 
     expect(delegate.query, 'Wow');
-    expect(delegate.querysForSuggestions, ['Wow']);
-    expect(delegate.querysForResults, ['Wow']);
+    expect(delegate.querysForSuggestions, <String>['Wow']);
+    expect(delegate.querysForResults, <String>['Wow']);
 
     TextField textField = tester.widget(find.byType(TextField));
     expect(textField.focusNode.hasFocus, isFalse);
@@ -153,15 +153,15 @@ void main() {
 
     expect(find.text('Suggestions'), findsOneWidget);
     expect(find.text('Results'), findsNothing);
-    expect(delegate.querysForSuggestions, ['Wow', 'Wow']);
-    expect(delegate.querysForResults, ['Wow']);
+    expect(delegate.querysForSuggestions, <String>['Wow', 'Wow']);
+    expect(delegate.querysForResults, <String>['Wow']);
 
     await tester.enterText(find.byType(TextField), 'Foo');
     await tester.pumpAndSettle();
 
     expect(delegate.query, 'Foo');
-    expect(delegate.querysForSuggestions, ['Wow', 'Wow', 'Foo']);
-    expect(delegate.querysForResults, ['Wow']);
+    expect(delegate.querysForSuggestions, <String>['Wow', 'Wow', 'Foo']);
+    expect(delegate.querysForResults, <String>['Wow']);
 
     // Go to results again
     await tester.tap(find.text('Suggestions'));
@@ -171,8 +171,8 @@ void main() {
     expect(find.text('Results'), findsOneWidget);
 
     expect(delegate.query, 'Foo');
-    expect(delegate.querysForSuggestions, ['Wow', 'Wow', 'Foo']);
-    expect(delegate.querysForResults, ['Wow', 'Foo']);
+    expect(delegate.querysForSuggestions, <String>['Wow', 'Wow', 'Foo']);
+    expect(delegate.querysForResults, <String>['Wow', 'Foo']);
 
     textField = tester.widget(find.byType(TextField));
     expect(textField.focusNode.hasFocus, isFalse);
@@ -251,6 +251,35 @@ void main() {
 
     expect(find.text('Foo'), findsNothing);
     expect(find.text('Bar'), findsOneWidget);
+  });
+
+  testWidgets('transitionAnimation runs while search fades in/out', (WidgetTester tester) async {
+    final _TestSearchDelegate delegate = new _TestSearchDelegate();
+
+    await tester.pumpWidget(new TestHomePage(
+      delegate: delegate,
+      passInInitialQuery: true,
+      initialQuery: null,
+    ));
+
+    // runs while search fades in
+    expect(delegate.transitionAnimation.status, AnimationStatus.dismissed);
+    await tester.tap(find.byTooltip('Search'));
+    expect(delegate.transitionAnimation.status, AnimationStatus.forward);
+    await tester.pumpAndSettle();
+    expect(delegate.transitionAnimation.status, AnimationStatus.completed);
+
+    // does not run while switching to results
+    await tester.tap(find.text('Suggestions'));
+    expect(delegate.transitionAnimation.status, AnimationStatus.completed);
+    await tester.pumpAndSettle();
+    expect(delegate.transitionAnimation.status, AnimationStatus.completed);
+
+    // runs while search fades out
+    await tester.tap(find.byTooltip('Back'));
+    expect(delegate.transitionAnimation.status, AnimationStatus.reverse);
+    await tester.pumpAndSettle();
+    expect(delegate.transitionAnimation.status, AnimationStatus.dismissed);
   });
 }
 

--- a/packages/flutter/test/material/search_test.dart
+++ b/packages/flutter/test/material/search_test.dart
@@ -1,0 +1,348 @@
+// Copyright 2018 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('Can open and close search', (WidgetTester tester) async {
+    final _TestSearchDelegate delegate = new _TestSearchDelegate();
+    final List<String> selectedResults = <String>[];
+
+    await tester.pumpWidget(new TestHomePage(
+      delegate: delegate,
+      results: selectedResults,
+    ));
+
+    // We are on the homepage
+    expect(find.text('HomeBody'), findsOneWidget);
+    expect(find.text('HomeTitle'), findsOneWidget);
+    expect(find.text('Suggestions'), findsNothing);
+
+    // Open search
+    await tester.tap(find.byTooltip('Search'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('HomeBody'), findsNothing);
+    expect(find.text('HomeTitle'), findsNothing);
+    expect(find.text('Suggestions'), findsOneWidget);
+    expect(selectedResults, hasLength(0));
+
+    final TextField textField = tester.widget(find.byType(TextField));
+    expect(textField.focusNode.hasFocus, isTrue);
+
+    // Close search
+    await tester.tap(find.byTooltip('Back'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('HomeBody'), findsOneWidget);
+    expect(find.text('HomeTitle'), findsOneWidget);
+    expect(find.text('Suggestions'), findsNothing);
+    expect(selectedResults, <String>['Result']);
+  });
+
+  testWidgets('Requests suggestions', (WidgetTester tester) async {
+    final _TestSearchDelegate delegate = new _TestSearchDelegate();
+
+    await tester.pumpWidget(new TestHomePage(
+      delegate: delegate,
+    ));
+    await tester.tap(find.byTooltip('Search'));
+    await tester.pumpAndSettle();
+
+    expect(delegate.query, '');
+    expect(delegate.querysForSuggestions.last, '');
+    expect(delegate.querysForResults, hasLength(0));
+
+    // Type W o w into search field
+    delegate.querysForSuggestions.clear();
+    await tester.enterText(find.byType(TextField), 'W');
+    await tester.pumpAndSettle();
+    expect(delegate.query, 'W');
+    await tester.enterText(find.byType(TextField), 'Wo');
+    await tester.pumpAndSettle();
+    expect(delegate.query, 'Wo');
+    await tester.enterText(find.byType(TextField), 'Wow');
+    await tester.pumpAndSettle();
+    expect(delegate.query, 'Wow');
+
+    expect(delegate.querysForSuggestions, <String>['W', 'Wo', 'Wow']);
+    expect(delegate.querysForResults, hasLength(0));
+  });
+
+  testWidgets('Shows Results and closes search', (WidgetTester tester) async {
+    final _TestSearchDelegate delegate = new _TestSearchDelegate();
+    final List<String> selectedResults = <String>[];
+
+    await tester.pumpWidget(new TestHomePage(
+      delegate: delegate,
+      results: selectedResults,
+    ));
+    await tester.tap(find.byTooltip('Search'));
+    await tester.pumpAndSettle();
+    await tester.enterText(find.byType(TextField), 'Wow');
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Suggestions'));
+    await tester.pumpAndSettle();
+
+    // We are on the results page for Wow
+    expect(find.text('HomeBody'), findsNothing);
+    expect(find.text('HomeTitle'), findsNothing);
+    expect(find.text('Suggestions'), findsNothing);
+    expect(find.text('Results'), findsOneWidget);
+
+    final TextField textField = tester.widget(find.byType(TextField));
+    expect(textField.focusNode.hasFocus, isFalse);
+    expect(delegate.querysForResults, <String>['Wow']);
+
+    // Close search
+    await tester.tap(find.byTooltip('Back'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('HomeBody'), findsOneWidget);
+    expect(find.text('HomeTitle'), findsOneWidget);
+    expect(find.text('Suggestions'), findsNothing);
+    expect(find.text('Results'), findsNothing);
+    expect(selectedResults, <String>['Result']);
+  });
+
+  testWidgets('Can switch between results and suggestions',
+      (WidgetTester tester) async {
+    final _TestSearchDelegate delegate = new _TestSearchDelegate();
+
+    await tester.pumpWidget(new TestHomePage(
+      delegate: delegate,
+    ));
+    await tester.tap(find.byTooltip('Search'));
+    await tester.pumpAndSettle();
+
+    // Showing suggestions
+    expect(find.text('Suggestions'), findsOneWidget);
+    expect(find.text('Results'), findsNothing);
+
+    // Typing query Wow
+    delegate.querysForSuggestions.clear();
+    await tester.enterText(find.byType(TextField), 'Wow');
+    await tester.pumpAndSettle();
+
+    expect(delegate.query, 'Wow');
+    expect(delegate.querysForSuggestions, ['Wow']);
+    expect(delegate.querysForResults, hasLength(0));
+
+    await tester.tap(find.text('Suggestions'));
+    await tester.pumpAndSettle();
+
+    // Showing Results
+    expect(find.text('Suggestions'), findsNothing);
+    expect(find.text('Results'), findsOneWidget);
+
+    expect(delegate.query, 'Wow');
+    expect(delegate.querysForSuggestions, ['Wow']);
+    expect(delegate.querysForResults, ['Wow']);
+
+    TextField textField = tester.widget(find.byType(TextField));
+    expect(textField.focusNode.hasFocus, isFalse);
+
+    // Taping search field to go back to suggestions
+    await tester.tap(find.byType(TextField));
+    await tester.pumpAndSettle();
+
+    textField = tester.widget(find.byType(TextField));
+    expect(textField.focusNode.hasFocus, isTrue);
+
+    expect(find.text('Suggestions'), findsOneWidget);
+    expect(find.text('Results'), findsNothing);
+    expect(delegate.querysForSuggestions, ['Wow', 'Wow']);
+    expect(delegate.querysForResults, ['Wow']);
+
+    await tester.enterText(find.byType(TextField), 'Foo');
+    await tester.pumpAndSettle();
+
+    expect(delegate.query, 'Foo');
+    expect(delegate.querysForSuggestions, ['Wow', 'Wow', 'Foo']);
+    expect(delegate.querysForResults, ['Wow']);
+
+    // Go to results again
+    await tester.tap(find.text('Suggestions'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Suggestions'), findsNothing);
+    expect(find.text('Results'), findsOneWidget);
+
+    expect(delegate.query, 'Foo');
+    expect(delegate.querysForSuggestions, ['Wow', 'Wow', 'Foo']);
+    expect(delegate.querysForResults, ['Wow', 'Foo']);
+
+    textField = tester.widget(find.byType(TextField));
+    expect(textField.focusNode.hasFocus, isFalse);
+  });
+
+  testWidgets('Fresh search allways starts with empty query',
+      (WidgetTester tester) async {
+    final _TestSearchDelegate delegate = new _TestSearchDelegate();
+
+    await tester.pumpWidget(new TestHomePage(
+      delegate: delegate,
+    ));
+    await tester.tap(find.byTooltip('Search'));
+    await tester.pumpAndSettle();
+
+    expect(delegate.query, '');
+
+    delegate.query = 'Foo';
+    await tester.tap(find.byTooltip('Back'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byTooltip('Search'));
+    await tester.pumpAndSettle();
+
+    expect(delegate.query, '');
+  });
+
+  testWidgets('Initial queries are honored', (WidgetTester tester) async {
+    final _TestSearchDelegate delegate = new _TestSearchDelegate();
+
+    expect(delegate.query, '');
+
+    await tester.pumpWidget(new TestHomePage(
+      delegate: delegate,
+      passInInitialQuery: true,
+      initialQuery: 'Foo',
+    ));
+    await tester.tap(find.byTooltip('Search'));
+    await tester.pumpAndSettle();
+
+    expect(delegate.query, 'Foo');
+  });
+
+  testWidgets('Initial query null re-used previous query', (WidgetTester tester) async {
+    final _TestSearchDelegate delegate = new _TestSearchDelegate();
+
+    delegate.query = 'Foo';
+
+    await tester.pumpWidget(new TestHomePage(
+      delegate: delegate,
+      passInInitialQuery: true,
+      initialQuery: null,
+    ));
+    await tester.tap(find.byTooltip('Search'));
+    await tester.pumpAndSettle();
+
+    expect(delegate.query, 'Foo');
+  });
+
+  testWidgets('Changing query shows up in search field', (WidgetTester tester) async {
+    final _TestSearchDelegate delegate = new _TestSearchDelegate();
+
+    await tester.pumpWidget(new TestHomePage(
+      delegate: delegate,
+      passInInitialQuery: true,
+      initialQuery: null,
+    ));
+    await tester.tap(find.byTooltip('Search'));
+    await tester.pumpAndSettle();
+
+    delegate.query = 'Foo';
+
+    expect(find.text('Foo'), findsOneWidget);
+    expect(find.text('Bar'), findsNothing);
+
+    delegate.query = 'Bar';
+
+    expect(find.text('Foo'), findsNothing);
+    expect(find.text('Bar'), findsOneWidget);
+  });
+}
+
+class TestHomePage extends StatelessWidget {
+  const TestHomePage(
+      {this.results,
+      this.delegate,
+      this.passInInitialQuery: false,
+      this.initialQuery});
+
+  final List<String> results;
+  final SearchDelegate<String> delegate;
+  final bool passInInitialQuery;
+  final String initialQuery;
+
+  @override
+  Widget build(BuildContext context) {
+    return new MaterialApp(
+      home: Builder(builder: (BuildContext context) {
+        return new Scaffold(
+          appBar: new AppBar(
+            title: const Text('HomeTitle'),
+            actions: <Widget>[
+              new IconButton(
+                tooltip: 'Search',
+                icon: const Icon(Icons.search),
+                onPressed: () async {
+                  String selectedResult;
+                  if (passInInitialQuery) {
+                    selectedResult = await showSearch<String>(
+                      context: context,
+                      delegate: delegate,
+                      query: initialQuery,
+                    );
+                  } else {
+                    selectedResult = await showSearch<String>(
+                      context: context,
+                      delegate: delegate,
+                    );
+                  }
+                  results?.add(selectedResult);
+                },
+              ),
+            ],
+          ),
+          body: const Text('HomeBody'),
+        );
+      }),
+    );
+  }
+}
+
+class _TestSearchDelegate extends SearchDelegate<String> {
+  @override
+  Widget buildLeading(BuildContext context) {
+    return new IconButton(
+      tooltip: 'Back',
+      icon: const Icon(Icons.arrow_back),
+      onPressed: () {
+        close(context, 'Result');
+      },
+    );
+  }
+
+  final List<String> querysForSuggestions = <String>[];
+  final List<String> querysForResults = <String>[];
+
+  @override
+  Widget buildSuggestions(BuildContext context) {
+    querysForSuggestions.add(query);
+    return new MaterialButton(
+      onPressed: () {
+        showResults(context);
+      },
+      child: const Text('Suggestions'),
+    );
+  }
+
+  @override
+  Widget buildResults(BuildContext context) {
+    querysForResults.add(query);
+    return const Text('Results');
+  }
+
+  @override
+  List<Widget> buildActions(BuildContext context) {
+    return <Widget>[
+      new IconButton(
+        tooltip: 'Clear',
+        icon: const Icon(Icons.clear),
+        onPressed: () {},
+      )
+    ];
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/localizations.dart
+++ b/packages/flutter_localizations/lib/src/l10n/localizations.dart
@@ -64,6 +64,7 @@ class TranslationBundle {
   String get popupMenuLabel => parent?.popupMenuLabel;
   String get dialogLabel => parent?.dialogLabel;
   String get alertDialogLabel => parent?.alertDialogLabel;
+  String get searchFieldLabel => parent?.searchFieldLabel;
 }
 
 // ignore: camel_case_types
@@ -113,6 +114,7 @@ class _Bundle_ar extends TranslationBundle {
   @override String get popupMenuLabel => r'قائمة منبثقة';
   @override String get dialogLabel => r'مربع حوار';
   @override String get alertDialogLabel => r'مربع حوار التنبيه';
+  @override String get searchFieldLabel => r'بحث';
 }
 
 // ignore: camel_case_types
@@ -159,6 +161,7 @@ class _Bundle_de extends TranslationBundle {
   @override String get popupMenuLabel => r'Pop-up-Menü';
   @override String get dialogLabel => r'Dialogfeld';
   @override String get alertDialogLabel => r'Aufmerksam';
+  @override String get searchFieldLabel => r'Suchen';
 }
 
 // ignore: camel_case_types
@@ -205,6 +208,7 @@ class _Bundle_en extends TranslationBundle {
   @override String get popupMenuLabel => r'Popup menu';
   @override String get dialogLabel => r'Dialog';
   @override String get alertDialogLabel => r'Alert';
+  @override String get searchFieldLabel => r'Search';
 }
 
 // ignore: camel_case_types
@@ -251,6 +255,7 @@ class _Bundle_es extends TranslationBundle {
   @override String get popupMenuLabel => r'Menú emergente';
   @override String get dialogLabel => r'Cuadro de diálogo';
   @override String get alertDialogLabel => r'Alerta';
+  @override String get searchFieldLabel => r'Buscar';
 }
 
 // ignore: camel_case_types
@@ -296,6 +301,7 @@ class _Bundle_fa extends TranslationBundle {
   @override String get popupMenuLabel => r'منوی بازشو';
   @override String get dialogLabel => r'کادر گفتگو';
   @override String get alertDialogLabel => r'هشدار';
+  @override String get searchFieldLabel => r'جستجو کردن';
 }
 
 // ignore: camel_case_types
@@ -342,6 +348,7 @@ class _Bundle_fr extends TranslationBundle {
   @override String get popupMenuLabel => r'Menu contextuel';
   @override String get dialogLabel => r'Boîte de dialogue';
   @override String get alertDialogLabel => r'Alerte';
+  @override String get searchFieldLabel => r'Chercher';
 }
 
 // ignore: camel_case_types
@@ -387,6 +394,7 @@ class _Bundle_gsw extends TranslationBundle {
   @override String get popupMenuLabel => r'Pop-up-Menü';
   @override String get dialogLabel => r'Dialogfeld';
   @override String get alertDialogLabel => r'Aufmerksam';
+  @override String get searchFieldLabel => r'Suchen';
 }
 
 // ignore: camel_case_types
@@ -434,6 +442,7 @@ class _Bundle_he extends TranslationBundle {
   @override String get popupMenuLabel => r'תפריט קופץ';
   @override String get dialogLabel => r'תיבת דו-שיח';
   @override String get alertDialogLabel => r'עֵרָנִי';
+  @override String get searchFieldLabel => r'לחפש';
 }
 
 // ignore: camel_case_types
@@ -479,6 +488,7 @@ class _Bundle_id extends TranslationBundle {
   @override String get popupMenuLabel => r'Menu pop-up';
   @override String get dialogLabel => r'Dialog';
   @override String get alertDialogLabel => r'Waspada';
+  @override String get searchFieldLabel => r'Pencarian';
 }
 
 // ignore: camel_case_types
@@ -524,6 +534,7 @@ class _Bundle_it extends TranslationBundle {
   @override String get popupMenuLabel => r'Menu popup';
   @override String get dialogLabel => r'Finestra di dialogo';
   @override String get alertDialogLabel => r'Mettere in guardia';
+  @override String get searchFieldLabel => r'Ricerca';
 }
 
 // ignore: camel_case_types
@@ -569,6 +580,7 @@ class _Bundle_ja extends TranslationBundle {
   @override String get popupMenuLabel => r'ポップアップ メニュー';
   @override String get dialogLabel => r'ダイアログ';
   @override String get alertDialogLabel => r'アラート';
+  @override String get searchFieldLabel => r'サーチ';
 }
 
 // ignore: camel_case_types
@@ -614,6 +626,7 @@ class _Bundle_ko extends TranslationBundle {
   @override String get popupMenuLabel => r'팝업 메뉴';
   @override String get dialogLabel => r'대화상자';
   @override String get alertDialogLabel => r'경보';
+  @override String get searchFieldLabel => r'수색';
 }
 
 // ignore: camel_case_types
@@ -660,6 +673,7 @@ class _Bundle_ms extends TranslationBundle {
   @override String get popupMenuLabel => r'Menu pop timbul';
   @override String get dialogLabel => r'Dialog';
   @override String get alertDialogLabel => r'Amaran';
+  @override String get searchFieldLabel => r'Carian';
 }
 
 // ignore: camel_case_types
@@ -750,6 +764,53 @@ class _Bundle_nl extends TranslationBundle {
   @override String get popupMenuLabel => r'Pop-upmenu';
   @override String get dialogLabel => r'Dialoogvenster';
   @override String get alertDialogLabel => r'Alarm';
+  @override String get searchFieldLabel => r'Zoeken';
+}
+
+// ignore: camel_case_types
+class _Bundle_no extends TranslationBundle {
+  const _Bundle_no() : super(null);
+  @override String get scriptCategory => r'English-like';
+  @override String get timeOfDayFormat => r'HH:mm';
+  @override String get openAppDrawerTooltip => r'Åpne navigasjonsmenyen';
+  @override String get backButtonTooltip => r'Tilbake';
+  @override String get closeButtonTooltip => r'Lukk';
+  @override String get deleteButtonTooltip => r'Slett';
+  @override String get nextMonthTooltip => r'Neste måned';
+  @override String get previousMonthTooltip => r'Forrige måned';
+  @override String get nextPageTooltip => r'Neste side';
+  @override String get previousPageTooltip => r'Forrige side';
+  @override String get showMenuTooltip => r'Vis meny';
+  @override String get aboutListTileTitle => r'Om $applicationName';
+  @override String get licensesPageTitle => r'Lisenser';
+  @override String get pageRowsInfoTitle => r'$firstRow–$lastRow av $rowCount';
+  @override String get pageRowsInfoTitleApproximate => r'$firstRow–$lastRow av omtrent $rowCount';
+  @override String get rowsPerPageTitle => r'Rader per side:';
+  @override String get tabLabel => r'Fane $tabIndex av $tabCount';
+  @override String get selectedRowCountTitleOne => r'1 element er valgt';
+  @override String get selectedRowCountTitleOther => r'$selectedRowCount elementer er valgt';
+  @override String get cancelButtonLabel => r'AVBRYT';
+  @override String get closeButtonLabel => r'LUKK';
+  @override String get continueButtonLabel => r'FORTSETT';
+  @override String get copyButtonLabel => r'KOPIÉR';
+  @override String get cutButtonLabel => r'KLIPP UT';
+  @override String get okButtonLabel => r'OK';
+  @override String get pasteButtonLabel => r'LIM INN';
+  @override String get selectAllButtonLabel => r'VELG ALLE';
+  @override String get viewLicensesButtonLabel => r'SE LISENSER';
+  @override String get anteMeridiemAbbreviation => r'AM';
+  @override String get postMeridiemAbbreviation => r'PM';
+  @override String get timePickerHourModeAnnouncement => r'Angi timer';
+  @override String get timePickerMinuteModeAnnouncement => r'Angi minutter';
+  @override String get modalBarrierDismissLabel => r'Avvis';
+  @override String get signedInLabel => r'Pålogget';
+  @override String get hideAccountsLabel => r'Skjul kontoer';
+  @override String get showAccountsLabel => r'Vis kontoer';
+  @override String get drawerLabel => r'Navigasjonsmeny';
+  @override String get popupMenuLabel => r'Forgrunnsmeny';
+  @override String get dialogLabel => r'Dialogboks';
+  @override String get alertDialogLabel => r'Varsling';
+  @override String get searchFieldLabel => r'Søke';
 }
 
 // ignore: camel_case_types
@@ -797,6 +858,7 @@ class _Bundle_pl extends TranslationBundle {
   @override String get popupMenuLabel => r'Wyskakujące menu';
   @override String get dialogLabel => r'Okno dialogowe';
   @override String get alertDialogLabel => r'Alarm';
+  @override String get searchFieldLabel => r'Szukaj';
 }
 
 // ignore: camel_case_types
@@ -839,6 +901,7 @@ class _Bundle_ps extends TranslationBundle {
   @override String get popupMenuLabel => r'د پاپ اپ مینو';
   @override String get dialogLabel => r'خبرې اترې';
   @override String get alertDialogLabel => r'خبرتیا';
+  @override String get searchFieldLabel => r'لټون';
 }
 
 // ignore: camel_case_types
@@ -884,6 +947,7 @@ class _Bundle_pt extends TranslationBundle {
   @override String get popupMenuLabel => r'Menu pop-up';
   @override String get dialogLabel => r'Caixa de diálogo';
   @override String get alertDialogLabel => r'Alerta';
+  @override String get searchFieldLabel => r'Pesquisa';
 }
 
 // ignore: camel_case_types
@@ -931,6 +995,7 @@ class _Bundle_ro extends TranslationBundle {
   @override String get popupMenuLabel => r'Meniu pop-up';
   @override String get dialogLabel => r'Casetă de dialog';
   @override String get alertDialogLabel => r'Alerta';
+  @override String get searchFieldLabel => r'Căutare';
 }
 
 // ignore: camel_case_types
@@ -979,6 +1044,7 @@ class _Bundle_ru extends TranslationBundle {
   @override String get popupMenuLabel => r'Всплывающее меню';
   @override String get dialogLabel => r'Диалоговое окно';
   @override String get alertDialogLabel => r'бдительный';
+  @override String get searchFieldLabel => r'Поиск';
 }
 
 // ignore: camel_case_types
@@ -1024,6 +1090,7 @@ class _Bundle_th extends TranslationBundle {
   @override String get popupMenuLabel => r'เมนูป๊อปอัป';
   @override String get dialogLabel => r'กล่องโต้ตอบ';
   @override String get alertDialogLabel => r'เตือนภัย';
+  @override String get searchFieldLabel => r'ค้นหา';
 }
 
 // ignore: camel_case_types
@@ -1069,6 +1136,7 @@ class _Bundle_tr extends TranslationBundle {
   @override String get popupMenuLabel => r'Popup menü';
   @override String get dialogLabel => r'İletişim kutusu';
   @override String get alertDialogLabel => r'Alarm';
+  @override String get searchFieldLabel => r'Arama';
 }
 
 // ignore: camel_case_types
@@ -1114,6 +1182,7 @@ class _Bundle_ur extends TranslationBundle {
   @override String get popupMenuLabel => r'پاپ اپ مینو';
   @override String get dialogLabel => r'ڈائیلاگ';
   @override String get alertDialogLabel => r'انتباہ';
+  @override String get searchFieldLabel => r'تلاش کریں';
 }
 
 // ignore: camel_case_types
@@ -1159,6 +1228,7 @@ class _Bundle_vi extends TranslationBundle {
   @override String get popupMenuLabel => r'Menu bật lên';
   @override String get dialogLabel => r'Hộp thoại';
   @override String get alertDialogLabel => r'Hộp thoại';
+  @override String get searchFieldLabel => r'Tìm kiếm';
 }
 
 // ignore: camel_case_types
@@ -1204,6 +1274,7 @@ class _Bundle_zh extends TranslationBundle {
   @override String get popupMenuLabel => r'弹出菜单';
   @override String get dialogLabel => r'对话框';
   @override String get alertDialogLabel => r'警报';
+  @override String get searchFieldLabel => r'搜索';
 }
 
 // ignore: camel_case_types

--- a/packages/flutter_localizations/lib/src/l10n/localizations.dart
+++ b/packages/flutter_localizations/lib/src/l10n/localizations.dart
@@ -719,6 +719,7 @@ class _Bundle_nb extends TranslationBundle {
   @override String get popupMenuLabel => r'Forgrunnsmeny';
   @override String get dialogLabel => r'Dialogboks';
   @override String get alertDialogLabel => r'Varsling';
+  @override String get searchFieldLabel => r'Søke';
 }
 
 // ignore: camel_case_types
@@ -765,52 +766,6 @@ class _Bundle_nl extends TranslationBundle {
   @override String get dialogLabel => r'Dialoogvenster';
   @override String get alertDialogLabel => r'Alarm';
   @override String get searchFieldLabel => r'Zoeken';
-}
-
-// ignore: camel_case_types
-class _Bundle_no extends TranslationBundle {
-  const _Bundle_no() : super(null);
-  @override String get scriptCategory => r'English-like';
-  @override String get timeOfDayFormat => r'HH:mm';
-  @override String get openAppDrawerTooltip => r'Åpne navigasjonsmenyen';
-  @override String get backButtonTooltip => r'Tilbake';
-  @override String get closeButtonTooltip => r'Lukk';
-  @override String get deleteButtonTooltip => r'Slett';
-  @override String get nextMonthTooltip => r'Neste måned';
-  @override String get previousMonthTooltip => r'Forrige måned';
-  @override String get nextPageTooltip => r'Neste side';
-  @override String get previousPageTooltip => r'Forrige side';
-  @override String get showMenuTooltip => r'Vis meny';
-  @override String get aboutListTileTitle => r'Om $applicationName';
-  @override String get licensesPageTitle => r'Lisenser';
-  @override String get pageRowsInfoTitle => r'$firstRow–$lastRow av $rowCount';
-  @override String get pageRowsInfoTitleApproximate => r'$firstRow–$lastRow av omtrent $rowCount';
-  @override String get rowsPerPageTitle => r'Rader per side:';
-  @override String get tabLabel => r'Fane $tabIndex av $tabCount';
-  @override String get selectedRowCountTitleOne => r'1 element er valgt';
-  @override String get selectedRowCountTitleOther => r'$selectedRowCount elementer er valgt';
-  @override String get cancelButtonLabel => r'AVBRYT';
-  @override String get closeButtonLabel => r'LUKK';
-  @override String get continueButtonLabel => r'FORTSETT';
-  @override String get copyButtonLabel => r'KOPIÉR';
-  @override String get cutButtonLabel => r'KLIPP UT';
-  @override String get okButtonLabel => r'OK';
-  @override String get pasteButtonLabel => r'LIM INN';
-  @override String get selectAllButtonLabel => r'VELG ALLE';
-  @override String get viewLicensesButtonLabel => r'SE LISENSER';
-  @override String get anteMeridiemAbbreviation => r'AM';
-  @override String get postMeridiemAbbreviation => r'PM';
-  @override String get timePickerHourModeAnnouncement => r'Angi timer';
-  @override String get timePickerMinuteModeAnnouncement => r'Angi minutter';
-  @override String get modalBarrierDismissLabel => r'Avvis';
-  @override String get signedInLabel => r'Pålogget';
-  @override String get hideAccountsLabel => r'Skjul kontoer';
-  @override String get showAccountsLabel => r'Vis kontoer';
-  @override String get drawerLabel => r'Navigasjonsmeny';
-  @override String get popupMenuLabel => r'Forgrunnsmeny';
-  @override String get dialogLabel => r'Dialogboks';
-  @override String get alertDialogLabel => r'Varsling';
-  @override String get searchFieldLabel => r'Søke';
 }
 
 // ignore: camel_case_types

--- a/packages/flutter_localizations/lib/src/l10n/material_ar.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_ar.arb
@@ -42,5 +42,6 @@
   "drawerLabel": "قائمة تنقل",
   "popupMenuLabel": "قائمة منبثقة",
   "dialogLabel": "مربع حوار",
-  "alertDialogLabel": "مربع حوار التنبيه"
+  "alertDialogLabel": "مربع حوار التنبيه",
+  "searchFieldLabel": "بحث"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_de.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_de.arb
@@ -39,5 +39,6 @@
   "drawerLabel": "Navigationsmenü",
   "popupMenuLabel": "Pop-up-Menü",
   "dialogLabel": "Dialogfeld",
-  "alertDialogLabel": "Aufmerksam"
+  "alertDialogLabel": "Aufmerksam",
+  "searchFieldLabel": "Suchen"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_de_CH.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_de_CH.arb
@@ -38,5 +38,6 @@
   "drawerLabel": "Navigationsmenü",
   "popupMenuLabel": "Pop-up-Menü",
   "dialogLabel": "Dialogfeld",
-  "alertDialogLabel": "Aufmerksam"
+  "alertDialogLabel": "Aufmerksam",
+  "searchFieldLabel": "Suchen"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_en.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_en.arb
@@ -199,5 +199,10 @@
   "alertDialogLabel": "Alert",
   "@dialogLabel": {
     "description": "The audio announcement made when an AlertDialog is opened."
-  }
+  },
+
+  "searchFieldLabel": "Search",
+    "@dialogLabel": {
+      "description": "Label indicating that a text field is a search field. This will be used as a hint text in the text field."
+    }
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_en_AU.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_en_AU.arb
@@ -38,5 +38,6 @@
   "drawerLabel": "Navigation menu",
   "popupMenuLabel": "Pop-up menu",
   "dialogLabel": "Dialogue",
-  "alertDialogLabel": "Alert"
+  "alertDialogLabel": "Alert",
+  "searchFieldLabel": "Search"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_en_CA.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_en_CA.arb
@@ -38,5 +38,6 @@
   "drawerLabel": "Navigation menu",
   "popupMenuLabel": "Pop-up menu",
   "dialogLabel": "Dialogue",
-  "alertDialogLabel": "Alert"
+  "alertDialogLabel": "Alert",
+  "searchFieldLabel": "Search"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_en_GB.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_en_GB.arb
@@ -38,5 +38,6 @@
   "drawerLabel": "Navigation menu",
   "popupMenuLabel": "Pop-up menu",
   "dialogLabel": "Dialogue",
-  "alertDialogLabel": "Alert"
+  "alertDialogLabel": "Alert",
+  "searchFieldLabel": "Search"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_en_IE.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_en_IE.arb
@@ -38,5 +38,6 @@
   "drawerLabel": "Navigation menu",
   "popupMenuLabel": "Pop-up menu",
   "dialogLabel": "Dialogue",
-  "alertDialogLabel": "Alert"
+  "alertDialogLabel": "Alert",
+  "searchFieldLabel": "Search"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_en_IN.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_en_IN.arb
@@ -38,5 +38,6 @@
   "drawerLabel": "Navigation menu",
   "popupMenuLabel": "Pop-up menu",
   "dialogLabel": "Dialogue",
-  "alertDialogLabel": "Alert"
+  "alertDialogLabel": "Alert",
+  "searchFieldLabel": "Search"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_en_SG.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_en_SG.arb
@@ -38,5 +38,6 @@
   "drawerLabel": "Navigation menu",
   "popupMenuLabel": "Pop-up menu",
   "dialogLabel": "Dialogue",
-  "alertDialogLabel": "Alert"
+  "alertDialogLabel": "Alert",
+  "searchFieldLabel": "Search"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_en_ZA.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_en_ZA.arb
@@ -38,5 +38,6 @@
   "drawerLabel": "Navigation menu",
   "popupMenuLabel": "Pop-up menu",
   "dialogLabel": "Dialogue",
-  "alertDialogLabel": "Alert"
+  "alertDialogLabel": "Alert",
+  "searchFieldLabel": "Search"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_es.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_es.arb
@@ -39,5 +39,6 @@
   "drawerLabel": "Menú de navegación",
   "popupMenuLabel": "Menú emergente",
   "dialogLabel": "Cuadro de diálogo",
-  "alertDialogLabel": "Alerta"
+  "alertDialogLabel": "Alerta",
+  "searchFieldLabel": "Buscar"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_es_419.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_es_419.arb
@@ -38,5 +38,6 @@
   "drawerLabel": "Menú de navegación",
   "popupMenuLabel": "Menú emergente",
   "dialogLabel": "Diálogo",
-  "alertDialogLabel": "Alerta"
+  "alertDialogLabel": "Alerta",
+  "searchFieldLabel": "Buscar"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_es_AR.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_es_AR.arb
@@ -38,5 +38,6 @@
   "drawerLabel": "Menú de navegación",
   "popupMenuLabel": "Menú emergente",
   "dialogLabel": "Diálogo",
-  "alertDialogLabel": "Alerta"
+  "alertDialogLabel": "Alerta",
+  "searchFieldLabel": "Buscar"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_es_BO.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_es_BO.arb
@@ -38,5 +38,6 @@
   "drawerLabel": "Menú de navegación",
   "popupMenuLabel": "Menú emergente",
   "dialogLabel": "Diálogo",
-  "alertDialogLabel": "Alerta"
+  "alertDialogLabel": "Alerta",
+  "searchFieldLabel": "Buscar"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_es_CL.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_es_CL.arb
@@ -38,5 +38,6 @@
   "drawerLabel": "Menú de navegación",
   "popupMenuLabel": "Menú emergente",
   "dialogLabel": "Diálogo",
-  "alertDialogLabel": "Alerta"
+  "alertDialogLabel": "Alerta",
+  "searchFieldLabel": "Buscar"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_es_CO.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_es_CO.arb
@@ -38,5 +38,6 @@
   "drawerLabel": "Menú de navegación",
   "popupMenuLabel": "Menú emergente",
   "dialogLabel": "Diálogo",
-  "alertDialogLabel": "Alerta"
+  "alertDialogLabel": "Alerta",
+  "searchFieldLabel": "Buscar"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_es_CR.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_es_CR.arb
@@ -38,5 +38,6 @@
   "drawerLabel": "Menú de navegación",
   "popupMenuLabel": "Menú emergente",
   "dialogLabel": "Diálogo",
-  "alertDialogLabel": "Alerta"
+  "alertDialogLabel": "Alerta",
+  "searchFieldLabel": "Buscar"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_es_DO.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_es_DO.arb
@@ -38,5 +38,6 @@
   "drawerLabel": "Menú de navegación",
   "popupMenuLabel": "Menú emergente",
   "dialogLabel": "Diálogo",
-  "alertDialogLabel": "Alerta"
+  "alertDialogLabel": "Alerta",
+  "searchFieldLabel": "Buscar"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_es_EC.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_es_EC.arb
@@ -38,5 +38,6 @@
   "drawerLabel": "Menú de navegación",
   "popupMenuLabel": "Menú emergente",
   "dialogLabel": "Diálogo",
-  "alertDialogLabel": "Alerta"
+  "alertDialogLabel": "Alerta",
+  "searchFieldLabel": "Buscar"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_es_GT.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_es_GT.arb
@@ -38,5 +38,6 @@
   "drawerLabel": "Menú de navegación",
   "popupMenuLabel": "Menú emergente",
   "dialogLabel": "Diálogo",
-  "alertDialogLabel": "Alerta"
+  "alertDialogLabel": "Alerta",
+  "searchFieldLabel": "Buscar"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_es_HN.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_es_HN.arb
@@ -38,5 +38,6 @@
   "drawerLabel": "Menú de navegación",
   "popupMenuLabel": "Menú emergente",
   "dialogLabel": "Diálogo",
-  "alertDialogLabel": "Alerta"
+  "alertDialogLabel": "Alerta",
+  "searchFieldLabel": "Buscar"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_es_MX.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_es_MX.arb
@@ -38,5 +38,6 @@
   "drawerLabel": "Menú de navegación",
   "popupMenuLabel": "Menú emergente",
   "dialogLabel": "Diálogo",
-  "alertDialogLabel": "Alerta"
+  "alertDialogLabel": "Alerta",
+  "searchFieldLabel": "Buscar"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_es_NI.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_es_NI.arb
@@ -38,5 +38,6 @@
   "drawerLabel": "Menú de navegación",
   "popupMenuLabel": "Menú emergente",
   "dialogLabel": "Diálogo",
-  "alertDialogLabel": "Alerta"
+  "alertDialogLabel": "Alerta",
+  "searchFieldLabel": "Buscar"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_es_PA.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_es_PA.arb
@@ -38,5 +38,6 @@
   "drawerLabel": "Menú de navegación",
   "popupMenuLabel": "Menú emergente",
   "dialogLabel": "Diálogo",
-  "alertDialogLabel": "Alerta"
+  "alertDialogLabel": "Alerta",
+  "searchFieldLabel": "Buscar"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_es_PE.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_es_PE.arb
@@ -38,5 +38,6 @@
   "drawerLabel": "Menú de navegación",
   "popupMenuLabel": "Menú emergente",
   "dialogLabel": "Diálogo",
-  "alertDialogLabel": "Alerta"
+  "alertDialogLabel": "Alerta",
+  "searchFieldLabel": "Buscar"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_es_PR.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_es_PR.arb
@@ -38,5 +38,6 @@
   "drawerLabel": "Menú de navegación",
   "popupMenuLabel": "Menú emergente",
   "dialogLabel": "Diálogo",
-  "alertDialogLabel": "Alerta"
+  "alertDialogLabel": "Alerta",
+  "searchFieldLabel": "Buscar"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_es_PY.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_es_PY.arb
@@ -38,5 +38,6 @@
   "drawerLabel": "Menú de navegación",
   "popupMenuLabel": "Menú emergente",
   "dialogLabel": "Diálogo",
-  "alertDialogLabel": "Alerta"
+  "alertDialogLabel": "Alerta",
+  "searchFieldLabel": "Buscar"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_es_SV.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_es_SV.arb
@@ -38,5 +38,6 @@
   "drawerLabel": "Menú de navegación",
   "popupMenuLabel": "Menú emergente",
   "dialogLabel": "Diálogo",
-  "alertDialogLabel": "Alerta"
+  "alertDialogLabel": "Alerta",
+  "searchFieldLabel": "Buscar"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_es_US.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_es_US.arb
@@ -38,5 +38,6 @@
   "drawerLabel": "Menú de navegación",
   "popupMenuLabel": "Menú emergente",
   "dialogLabel": "Diálogo",
-  "alertDialogLabel": "Alerta"
+  "alertDialogLabel": "Alerta",
+  "searchFieldLabel": "Buscar"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_es_UY.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_es_UY.arb
@@ -38,5 +38,6 @@
   "drawerLabel": "Menú de navegación",
   "popupMenuLabel": "Menú emergente",
   "dialogLabel": "Diálogo",
-  "alertDialogLabel": "Alerta"
+  "alertDialogLabel": "Alerta",
+  "searchFieldLabel": "Buscar"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_es_VE.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_es_VE.arb
@@ -38,5 +38,6 @@
   "drawerLabel": "Menú de navegación",
   "popupMenuLabel": "Menú emergente",
   "dialogLabel": "Diálogo",
-  "alertDialogLabel": "Alerta"
+  "alertDialogLabel": "Alerta",
+  "searchFieldLabel": "Buscar"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_fa.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_fa.arb
@@ -38,5 +38,6 @@
   "drawerLabel": "منوی پیمایش",
   "popupMenuLabel": "منوی بازشو",
   "dialogLabel": "کادر گفتگو",
-  "alertDialogLabel": "هشدار"
+  "alertDialogLabel": "هشدار",
+  "searchFieldLabel": "جستجو کردن"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_fr.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_fr.arb
@@ -39,5 +39,6 @@
   "drawerLabel": "Menu de navigation",
   "popupMenuLabel": "Menu contextuel",
   "dialogLabel": "Boîte de dialogue",
-  "alertDialogLabel": "Alerte"
+  "alertDialogLabel": "Alerte",
+  "searchFieldLabel": "Chercher"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_gsw.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_gsw.arb
@@ -38,5 +38,6 @@
   "drawerLabel": "Navigationsmenü",
   "popupMenuLabel": "Pop-up-Menü",
   "dialogLabel": "Dialogfeld",
-  "alertDialogLabel": "Aufmerksam"
+  "alertDialogLabel": "Aufmerksam",
+  "searchFieldLabel": "Suchen"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_he.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_he.arb
@@ -40,5 +40,6 @@
   "drawerLabel": "תפריט ניווט",
   "popupMenuLabel": "תפריט קופץ",
   "dialogLabel": "תיבת דו-שיח",
-  "alertDialogLabel": "עֵרָנִי"
+  "alertDialogLabel": "עֵרָנִי",
+  "searchFieldLabel": "לחפש"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_id.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_id.arb
@@ -38,5 +38,6 @@
   "drawerLabel": "Menu navigasi",
   "popupMenuLabel": "Menu pop-up",
   "dialogLabel": "Dialog",
-  "alertDialogLabel": "Waspada"
+  "alertDialogLabel": "Waspada",
+  "searchFieldLabel": "Pencarian"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_it.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_it.arb
@@ -38,5 +38,6 @@
   "drawerLabel": "Menu di navigazione",
   "popupMenuLabel": "Menu popup",
   "dialogLabel": "Finestra di dialogo",
-  "alertDialogLabel": "Mettere in guardia"
+  "alertDialogLabel": "Mettere in guardia",
+  "searchFieldLabel": "Ricerca"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_ja.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_ja.arb
@@ -38,5 +38,6 @@
   "drawerLabel": "ナビゲーション メニュー",
   "popupMenuLabel": "ポップアップ メニュー",
   "dialogLabel": "ダイアログ",
-  "alertDialogLabel": "アラート"
+  "alertDialogLabel": "アラート",
+  "searchFieldLabel": "サーチ"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_ko.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_ko.arb
@@ -38,5 +38,6 @@
   "drawerLabel": "탐색 메뉴",
   "popupMenuLabel": "팝업 메뉴",
   "dialogLabel": "대화상자",
-  "alertDialogLabel": "경보"
+  "alertDialogLabel": "경보",
+  "searchFieldLabel": "수색"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_ms.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_ms.arb
@@ -39,5 +39,6 @@
   "drawerLabel": "Menu navigasi",
   "popupMenuLabel": "Menu pop timbul",
   "dialogLabel": "Dialog",
-  "alertDialogLabel": "Amaran"
+  "alertDialogLabel": "Amaran",
+  "searchFieldLabel": "Carian"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_nb.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_nb.arb
@@ -38,5 +38,6 @@
   "drawerLabel": "Navigasjonsmeny",
   "popupMenuLabel": "Forgrunnsmeny",
   "dialogLabel": "Dialogboks",
-  "alertDialogLabel": "Varsling"
+  "alertDialogLabel": "Varsling",
+  "searchFieldLabel": "Søke"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_nl.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_nl.arb
@@ -38,5 +38,6 @@
   "drawerLabel": "Navigatiemenu",
   "popupMenuLabel": "Pop-upmenu",
   "dialogLabel": "Dialoogvenster",
-  "alertDialogLabel": "Alarm"
+  "alertDialogLabel": "Alarm",
+  "searchFieldLabel": "Zoeken"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_pl.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_pl.arb
@@ -40,5 +40,6 @@
   "drawerLabel": "Menu nawigacyjne",
   "popupMenuLabel": "Wyskakujące menu",
   "dialogLabel": "Okno dialogowe",
-  "alertDialogLabel": "Alarm"
+  "alertDialogLabel": "Alarm",
+  "searchFieldLabel": "Szukaj"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_ps.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_ps.arb
@@ -37,5 +37,6 @@
   "drawerLabel": "د نیویگیشن مینو",
   "popupMenuLabel": "د پاپ اپ مینو",
   "dialogLabel": "خبرې اترې",
-  "alertDialogLabel": "خبرتیا"
+  "alertDialogLabel": "خبرتیا",
+  "searchFieldLabel": "لټون"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_pt.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_pt.arb
@@ -40,5 +40,6 @@
   "drawerLabel": "Menu de navegação",
   "popupMenuLabel": "Menu pop-up",
   "dialogLabel": "Caixa de diálogo",
-  "alertDialogLabel": "Alerta"
+  "alertDialogLabel": "Alerta",
+  "searchFieldLabel": "Pesquisa"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_pt_PT.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_pt_PT.arb
@@ -38,5 +38,6 @@
   "drawerLabel": "Menu de navegação",
   "popupMenuLabel": "Menu pop-up",
   "dialogLabel": "Caixa de diálogo",
-  "alertDialogLabel": "Alerta"
+  "alertDialogLabel": "Alerta",
+  "searchFieldLabel": "Pesquisa"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_ro.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_ro.arb
@@ -40,5 +40,6 @@
   "drawerLabel": "Meniu de navigare",
   "popupMenuLabel": "Meniu pop-up",
   "dialogLabel": "Casetă de dialog",
-  "alertDialogLabel": "Alerta"
+  "alertDialogLabel": "Alerta",
+  "searchFieldLabel": "Căutare"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_ru.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_ru.arb
@@ -41,5 +41,6 @@
   "drawerLabel": "Меню навигации",
   "popupMenuLabel": "Всплывающее меню",
   "dialogLabel": "Диалоговое окно",
-  "alertDialogLabel": "бдительный"
+  "alertDialogLabel": "бдительный",
+  "searchFieldLabel": "Поиск"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_th.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_th.arb
@@ -38,5 +38,6 @@
   "drawerLabel": "เมนูการนำทาง",
   "popupMenuLabel": "เมนูป๊อปอัป",
   "dialogLabel": "กล่องโต้ตอบ",
-  "alertDialogLabel": "เตือนภัย"
+  "alertDialogLabel": "เตือนภัย",
+  "searchFieldLabel": "ค้นหา"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_tr.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_tr.arb
@@ -38,5 +38,6 @@
   "drawerLabel": "Gezinme menüsü",
   "popupMenuLabel": "Popup menü",
   "dialogLabel": "İletişim kutusu",
-  "alertDialogLabel": "Alarm"
+  "alertDialogLabel": "Alarm",
+  "searchFieldLabel": "Arama"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_ur.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_ur.arb
@@ -38,5 +38,6 @@
   "drawerLabel": "نیویگیشن مینو",
   "popupMenuLabel": "پاپ اپ مینو",
   "dialogLabel": "ڈائیلاگ",
-  "alertDialogLabel": "انتباہ"
+  "alertDialogLabel": "انتباہ",
+  "searchFieldLabel": "تلاش کریں"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_vi.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_vi.arb
@@ -38,5 +38,6 @@
   "drawerLabel": "Menu di chuyển",
   "popupMenuLabel": "Menu bật lên",
   "dialogLabel": "Hộp thoại",
-  "alertDialogLabel": "Hộp thoại"
+  "alertDialogLabel": "Hộp thoại",
+  "searchFieldLabel": "Tìm kiếm"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_zh.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_zh.arb
@@ -38,5 +38,6 @@
   "drawerLabel": "导航菜单",
   "popupMenuLabel": "弹出菜单",
   "dialogLabel": "对话框",
-  "alertDialogLabel": "警报"
+  "alertDialogLabel": "警报",
+  "searchFieldLabel": "搜索"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_zh_HK.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_zh_HK.arb
@@ -38,5 +38,6 @@
   "drawerLabel": "導覽選單",
   "popupMenuLabel": "彈出式選單",
   "dialogLabel": "對話方塊",
-  "alertDialogLabel": "警报"
+  "alertDialogLabel": "警报",
+  "searchFieldLabel": "搜索"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_zh_TW.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_zh_TW.arb
@@ -38,5 +38,6 @@
   "drawerLabel": "導覽選單",
   "popupMenuLabel": "彈出式選單",
   "dialogLabel": "對話方塊",
-  "alertDialogLabel": "警报"
+  "alertDialogLabel": "警报",
+  "searchFieldLabel": "搜索"
 }

--- a/packages/flutter_localizations/lib/src/material_localizations.dart
+++ b/packages/flutter_localizations/lib/src/material_localizations.dart
@@ -16,7 +16,7 @@ import 'widgets_localizations.dart';
 
 // Watch out: the supported locales list in the doc comment below must be kept
 // in sync with the list we test, see test/translations_test.dart, and of course
-// the acutal list of supported locales in _MaterialLocalizationsDelegate.
+// the actual list of supported locales in _MaterialLocalizationsDelegate.
 
 /// Localized strings for the material widgets.
 ///

--- a/packages/flutter_localizations/lib/src/material_localizations.dart
+++ b/packages/flutter_localizations/lib/src/material_localizations.dart
@@ -269,6 +269,9 @@ class GlobalMaterialLocalizations implements MaterialLocalizations {
   String get alertDialogLabel => _translationBundle.alertDialogLabel;
 
   @override
+  String get searchFieldLabel => _translationBundle.searchFieldLabel;
+
+  @override
   String aboutListTileTitle(String applicationName) {
     final String text = _translationBundle.aboutListTileTitle;
     return text.replaceFirst(r'$applicationName', applicationName);


### PR DESCRIPTION
https://github.com/flutter/flutter/issues/17119#issuecomment-391186746

As spec'ed out in https://material.io/design/navigation/search.html#expandable-search.

The search can be triggered by tapping the search icon in the AppBar:

![img_0005](https://user-images.githubusercontent.com/1227763/40082713-a62db782-5846-11e8-97d5-3c8feaa28fab.PNG)

Doing so will bring up the search page where the user can type in a search query and see suggested queries:

![img_0006](https://user-images.githubusercontent.com/1227763/40082719-a97c5fd8-5846-11e8-9870-297dcb9b1a27.PNG)

Once the query is submitted, a results page is shown:

![img_0007](https://user-images.githubusercontent.com/1227763/40082720-abba0462-5846-11e8-9c77-692773f628d7.PNG)

TODO:
- [x] i18n for the hint text (will update this PR)
- [x] tests (will update this PR)
- [ ] change the enter key on the keyboard to the search key (requires https://github.com/flutter/flutter/issues/17525, will happen in a follow-up PR)

Requires fix from https://github.com/flutter/flutter/pull/17624.