### PR TITLE
Migrate to Mockito 3's anyNamed

### DIFF
--- a/packages/flutter/test/foundation/consolidate_response_test.dart
+++ b/packages/flutter/test/foundation/consolidate_response_test.dart
@@ -15,9 +15,9 @@ void main() {
       response = new MockHttpClientResponse();
        when(response.listen(
          typed(any),
-         onDone: typed(any, named: 'onDone'),
-         onError: typed(any, named: 'onError'),
-         cancelOnError: typed(any, named: 'cancelOnError')
+         onDone: anyNamed('onDone'),
+         onError: anyNamed('onError'),
+         cancelOnError: anyNamed('cancelOnError')
       )).thenAnswer((Invocation invocation) {
         final void Function(List<int>) onData = invocation.positionalArguments[0];
         final void Function(Object) onError = invocation.namedArguments[#onError];
@@ -46,9 +46,9 @@ void main() {
     test('forwards errors from HttpClientResponse', () async {
       when(response.listen(
         typed(any),
-        onDone: typed(any, named: 'onDone'),
-        onError: typed(any, named: 'onError'),
-        cancelOnError: typed(any, named: 'cancelOnError')
+        onDone: anyNamed('onDone'),
+        onError: anyNamed('onError'),
+        cancelOnError: anyNamed('cancelOnError')
       )).thenAnswer((Invocation invocation) {
         final void Function(List<int>) onData = invocation.positionalArguments[0];
         final void Function(Object) onError = invocation.namedArguments[#onError];

--- a/packages/flutter_tools/test/channel_test.dart
+++ b/packages/flutter_tools/test/channel_test.dart
@@ -51,8 +51,8 @@ void main() {
       when(process.exitCode).thenAnswer((_) => new Future<int>.value(0));
       when(mockProcessManager.start(
         <String>['git', 'branch', '-r'],
-        workingDirectory: typed(any, named: 'workingDirectory'),
-        environment: typed(any, named: 'environment')))
+        workingDirectory: anyNamed('workingDirectory'),
+        environment: anyNamed('environment')))
       .thenAnswer((_) => new Future<Process>.value(process));
 
       final ChannelCommand command = new ChannelCommand();
@@ -60,8 +60,8 @@ void main() {
       await runner.run(<String>['channel']);
 
       verify(mockProcessManager.start(<String>['git', 'branch', '-r'],
-          workingDirectory: typed(any, named: 'workingDirectory'),
-          environment: typed(any, named: 'environment'))).called(1);
+          workingDirectory: anyNamed('workingDirectory'),
+          environment: anyNamed('environment'))).called(1);
 
       expect(testLogger.errorText, hasLength(0));
 

--- a/packages/flutter_tools/test/ios/cocoapods_test.dart
+++ b/packages/flutter_tools/test/ios/cocoapods_test.dart
@@ -206,7 +206,7 @@ void main() {
       verifyNever(mockProcessManager.run(
         argThat(containsAllInOrder(<String>['pod', 'install'])),
         workingDirectory: any,
-        environment: typed<Map<String, String>>(any, named: 'environment'),
+        environment: anyNamed('environment'),
       ));
       expect(testLogger.errorText, contains('not installed'));
       expect(testLogger.errorText, contains('Skipping pod install'));
@@ -228,7 +228,7 @@ void main() {
         verifyNever(mockProcessManager.run(
           argThat(containsAllInOrder(<String>['pod', 'install'])),
           workingDirectory: any,
-          environment: typed<Map<String, String>>(any, named: 'environment'),
+          environment: anyNamed('environment'),
         ));
       }
     }, overrides: <Type, Generator>{
@@ -439,7 +439,7 @@ Note: as of CocoaPods 1.0, `pod repo update` does not happen on `pod install` by
       verifyNever(mockProcessManager.run(
         argThat(containsAllInOrder(<String>['pod', 'install'])),
         workingDirectory: any,
-        environment: typed<Map<String, String>>(any, named: 'environment'),
+        environment: anyNamed('environment'),
       ));
     }, overrides: <Type, Generator>{
       FileSystem: () => fs,


### PR DESCRIPTION
Before Migrating to Mockito 3 (or like, 3 beta), tests need to migrate to the intermediate 2/3 compatible API. See the [upgrading-to-mockito-3 doc](https://github.com/dart-lang/mockito/blob/master/upgrading-to-mockito-3.md).