### PR TITLE
Increase gallery perf scrollUntilVisible timeout

### DIFF
--- a/examples/flutter_gallery/test_driver/transitions_perf_test.dart
+++ b/examples/flutter_gallery/test_driver/transitions_perf_test.dart
@@ -146,7 +146,11 @@ Future<Null> runDemos(List<String> demos, FlutterDriver driver) async {
     currentDemoCategory = demoCategory;
 
     final SerializableFinder demoItem = find.text(demoName);
-    await driver.scrollUntilVisible(demoList, demoItem, dyScroll: -48.0,  alignment: 0.5);
+    await driver.scrollUntilVisible(demoList, demoItem,
+      dyScroll: -48.0,
+      alignment: 0.5,
+      timeout: const Duration(seconds: 30),
+    );
 
     for (int i = 0; i < 2; i += 1) {
       await driver.tap(demoItem); // Launch the demo


### PR DESCRIPTION
On smaller-screen devices such as the iPhone 4s, more scrolling is
required between the Material dialog demo and the Material pickers demo
than will happen within the default timeout.