### PR TITLE
Added GalleryApp testMode

### DIFF
--- a/examples/flutter_gallery/lib/gallery/app.dart
+++ b/examples/flutter_gallery/lib/gallery/app.dart
@@ -25,6 +25,7 @@ class GalleryApp extends StatefulWidget {
     this.enableRasterCacheImagesCheckerboard: true,
     this.enableOffscreenLayersCheckerboard: true,
     this.onSendFeedback,
+    this.testMode: false,
   }) : super(key: key);
 
   final UpdateUrlFetcher updateUrlFetcher;
@@ -32,6 +33,7 @@ class GalleryApp extends StatefulWidget {
   final bool enableRasterCacheImagesCheckerboard;
   final bool enableOffscreenLayersCheckerboard;
   final VoidCallback onSendFeedback;
+  final bool testMode;
 
   @override
   _GalleryAppState createState() => new _GalleryAppState();
@@ -107,6 +109,7 @@ class _GalleryAppState extends State<GalleryApp> {
   @override
   Widget build(BuildContext context) {
     Widget home = new GalleryHome(
+      testMode: widget.testMode,
       optionsPage: new GalleryOptionsPage(
         options: _options,
         onOptionsChanged: _handleOptionsChanged,

--- a/examples/flutter_gallery/lib/gallery/backdrop.dart
+++ b/examples/flutter_gallery/lib/gallery/backdrop.dart
@@ -263,66 +263,72 @@ class _BackdropState extends State<Backdrop> with SingleTickerProviderStateMixin
       end: const RelativeRect.fromLTRB(0.0, _kBackAppBarHeight, 0.0, 0.0),
     ).animate(_controller);
 
-    return new Stack(
-      key: _backdropKey,
-      children: <Widget>[
-        new Column(
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          children: <Widget>[
-            // Back layer
-            new _BackAppBar(
-              leading: widget.frontAction,
-              title: new _CrossFadeTransition(
+    final List<Widget> layers = <Widget>[
+      // Back layer
+      new Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: <Widget>[
+          new _BackAppBar(
+            leading: widget.frontAction,
+            title: new _CrossFadeTransition(
+              progress: _controller,
+              alignment: AlignmentDirectional.centerStart,
+              child0: new Semantics(namesRoute: true, child: widget.frontTitle),
+              child1: new Semantics(namesRoute: true, child: widget.backTitle),
+            ),
+            trailing: new IconButton(
+              onPressed: _toggleFrontLayer,
+              tooltip: 'Toggle options page',
+              icon: new AnimatedIcon(
+                icon: AnimatedIcons.close_menu,
                 progress: _controller,
-                alignment: AlignmentDirectional.centerStart,
-                child0: new Semantics(namesRoute: true, child: widget.frontTitle),
-                child1: new Semantics(namesRoute: true, child: widget.backTitle),
-              ),
-              trailing: new IconButton(
-                onPressed: _toggleFrontLayer,
-                tooltip: 'Toggle options page',
-                icon: new AnimatedIcon(
-                  icon: AnimatedIcons.close_menu,
-                  progress: _controller,
-                ),
-              ),
-            ),
-            new Expanded(
-              child: new _TappableWhileStatusIs(
-                AnimationStatus.dismissed,
-                controller: _controller,
-                child: widget.backLayer,
-              ),
-            ),
-          ],
-        ),
-        // Front layer
-        new PositionedTransition(
-          rect: frontRelativeRect,
-          child: new AnimatedBuilder(
-            animation: _controller,
-            builder: (BuildContext context, Widget child) {
-              return new PhysicalShape(
-                elevation: 12.0,
-                color: Theme.of(context).canvasColor,
-                clipper: new ShapeBorderClipper(
-                  shape: new BeveledRectangleBorder(
-                    borderRadius: _kFrontHeadingBevelRadius.lerp(_controller.value),
-                  ),
-                ),
-                child: child,
-              );
-            },
-            child: new _TappableWhileStatusIs(
-              AnimationStatus.completed,
-              controller: _controller,
-              child: new FadeTransition(
-                opacity: _frontOpacity,
-                child: widget.frontLayer,
               ),
             ),
           ),
+          new Expanded(
+            child: new _TappableWhileStatusIs(
+              AnimationStatus.dismissed,
+              controller: _controller,
+              child: widget.backLayer,
+            ),
+          ),
+        ],
+      ),
+      // Front layer
+      new PositionedTransition(
+        rect: frontRelativeRect,
+        child: new AnimatedBuilder(
+          animation: _controller,
+          builder: (BuildContext context, Widget child) {
+            return new PhysicalShape(
+              elevation: 12.0,
+              color: Theme.of(context).canvasColor,
+              clipper: new ShapeBorderClipper(
+                shape: new BeveledRectangleBorder(
+                  borderRadius: _kFrontHeadingBevelRadius.lerp(_controller.value),
+                ),
+              ),
+              child: child,
+            );
+          },
+          child: new _TappableWhileStatusIs(
+            AnimationStatus.completed,
+            controller: _controller,
+            child: new FadeTransition(
+              opacity: _frontOpacity,
+              child: widget.frontLayer,
+            ),
+          ),
         ),
+      ),
+    ];
+
+    // The front "heading" is a (typically transparent) widget that's stacked on
+    // top of, and at the top of, the front layer. It adds support for dragging
+    // the front layer up and down and for opening and closing the front layer
+    // with a tap. It may obscure part of the front layer's topmost child.
+    if (widget.frontHeading != null) {
+      layers.add(
         new PositionedTransition(
           rect: frontRelativeRect,
           child: new ExcludeSemantics(
@@ -338,7 +344,12 @@ class _BackdropState extends State<Backdrop> with SingleTickerProviderStateMixin
             ),
           ),
         ),
-      ],
+      );
+    }
+
+    return new Stack(
+      key: _backdropKey,
+      children: layers,
     );
   }
 

--- a/examples/flutter_gallery/lib/gallery/home.dart
+++ b/examples/flutter_gallery/lib/gallery/home.dart
@@ -270,10 +270,12 @@ class GalleryHome extends StatefulWidget {
 
   const GalleryHome({
     Key key,
+    this.testMode: false,
     this.optionsPage,
   }) : super(key: key);
 
   final Widget optionsPage;
+  final bool testMode;
 
   @override
   _GalleryHomeState createState() => new _GalleryHomeState();
@@ -345,13 +347,13 @@ class _GalleryHomeState extends State<GalleryHome> with SingleTickerProviderStat
                   onPressed: () => setState(() => _category = null),
                 ),
             ),
-            frontTitle:  new AnimatedSwitcher(
+            frontTitle: new AnimatedSwitcher(
               duration: _kFrontLayerSwitchDuration,
               child: _category == null
                 ? const Text('Flutter gallery')
                 : new Text(_category.name),
             ),
-            frontHeading: new Container(height: 24.0),
+            frontHeading: widget.testMode ? null: new Container(height: 24.0),
             frontLayer: new AnimatedSwitcher(
               duration: _kFrontLayerSwitchDuration,
               switchOutCurve: switchOutCurve,

--- a/examples/flutter_gallery/test/drawer_test.dart
+++ b/examples/flutter_gallery/test/drawer_test.dart
@@ -17,6 +17,7 @@ void main() {
 
     await tester.pumpWidget(
       new GalleryApp(
+        testMode: true,
         onSendFeedback: () {
           hasFeedback = true;
         },

--- a/examples/flutter_gallery/test/example_code_display_test.dart
+++ b/examples/flutter_gallery/test/example_code_display_test.dart
@@ -14,7 +14,7 @@ void main() {
   testWidgets('Flutter gallery button example code displays', (WidgetTester tester) async {
     // Regression test for https://github.com/flutter/flutter/issues/6147
 
-    await tester.pumpWidget(const GalleryApp());
+    await tester.pumpWidget(const GalleryApp(testMode: true));
     await tester.pump(); // see https://github.com/flutter/flutter/issues/1865
     await tester.pump(); // triggers a frame
 

--- a/examples/flutter_gallery/test/live_smoketest.dart
+++ b/examples/flutter_gallery/test/live_smoketest.dart
@@ -43,7 +43,7 @@ Future<Null> main() async {
     if (!new Set<String>.from(allDemoTitles).containsAll(_kSkippedDemoTitles))
       fail('Unrecognized demo names in _kSkippedDemoTitles: $_kSkippedDemoTitles');
 
-    runApp(const GalleryApp());
+    runApp(const GalleryApp(testMode: true));
     final _LiveWidgetController controller = new _LiveWidgetController();
     for (GalleryDemoCategory category in kAllGalleryDemoCategories) {
       await controller.tap(find.text(category.name));

--- a/examples/flutter_gallery/test/pesto_test.dart
+++ b/examples/flutter_gallery/test/pesto_test.dart
@@ -19,7 +19,7 @@ void main() {
         child: const SizedBox(
           width: 450.0,
           height: 800.0,
-          child: const GalleryApp()
+          child: const GalleryApp(testMode: true)
         )
       )
     );
@@ -43,7 +43,7 @@ void main() {
   });
 
   testWidgets('Pesto can be scrolled all the way down', (WidgetTester tester) async {
-    await tester.pumpWidget(const GalleryApp());
+    await tester.pumpWidget(const GalleryApp(testMode: true));
     await tester.pump(); // see https://github.com/flutter/flutter/issues/1865
     await tester.pump(); // triggers a frame
 

--- a/examples/flutter_gallery/test/simple_smoke_test.dart
+++ b/examples/flutter_gallery/test/simple_smoke_test.dart
@@ -4,7 +4,7 @@
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:flutter_gallery/main.dart' as flutter_gallery_main;
+import 'package:flutter_gallery/gallery/app.dart' show GalleryApp;
 
 void main() {
   final TestWidgetsFlutterBinding binding = TestWidgetsFlutterBinding.ensureInitialized();
@@ -12,7 +12,9 @@ void main() {
     binding.framePolicy = LiveTestWidgetsFlutterBindingFramePolicy.fullyLive;
 
   testWidgets('Flutter Gallery app simple smoke test', (WidgetTester tester) async {
-    flutter_gallery_main.main(); // builds the app and schedules a frame but doesn't trigger one
+    await tester.pumpWidget(
+      const GalleryApp(testMode: true) // builds the app and schedules a frame but doesn't trigger one
+    );
     await tester.pump(); // see https://github.com/flutter/flutter/issues/1865
     await tester.pump(); // triggers a frame
 

--- a/examples/flutter_gallery/test/smoke_test.dart
+++ b/examples/flutter_gallery/test/smoke_test.dart
@@ -139,6 +139,7 @@ Future<Null> smokeGallery(WidgetTester tester) async {
 
   await tester.pumpWidget(
     new GalleryApp(
+      testMode: true,
       onSendFeedback: () {
         sendFeedbackButtonPressed = true; // see smokeOptionsPage()
       },

--- a/examples/flutter_gallery/test/update_test.dart
+++ b/examples/flutter_gallery/test/update_test.dart
@@ -17,7 +17,12 @@ void main() {
 
   // Regression test for https://github.com/flutter/flutter/pull/5168
   testWidgets('update dialog', (WidgetTester tester) async {
-    await tester.pumpWidget(const GalleryApp(updateUrlFetcher: mockUpdateUrlFetcher));
+    await tester.pumpWidget(
+      const GalleryApp(
+        testMode: true,
+        updateUrlFetcher: mockUpdateUrlFetcher
+      )
+    );
     await tester.pump(); // see https://github.com/flutter/flutter/issues/1865
     await tester.pump(); // triggers a frame
 

--- a/examples/flutter_gallery/test_driver/memory_nav.dart
+++ b/examples/flutter_gallery/test_driver/memory_nav.dart
@@ -3,9 +3,13 @@
 // found in the LICENSE file.
 
 import 'package:flutter_driver/driver_extension.dart';
-import 'package:flutter_gallery/main.dart' as app;
+import 'package:flutter_gallery/gallery/app.dart' show GalleryApp;
+import 'package:flutter/material.dart';
 
 void main() {
   enableFlutterDriverExtension();
-  app.main();
+  // As in lib/main.dart: overriding https://github.com/flutter/flutter/issues/13736
+  // for better visual effect at the cost of performance.
+  MaterialPageRoute.debugEnableFadingRoutes = true; // ignore: deprecated_member_use
+  runApp(const GalleryApp(testMode: true));
 }

--- a/examples/flutter_gallery/test_driver/scroll_perf.dart
+++ b/examples/flutter_gallery/test_driver/scroll_perf.dart
@@ -3,9 +3,13 @@
 // found in the LICENSE file.
 
 import 'package:flutter_driver/driver_extension.dart';
-import 'package:flutter_gallery/main.dart' as app;
+import 'package:flutter_gallery/gallery/app.dart' show GalleryApp;
+import 'package:flutter/material.dart';
 
 void main() {
   enableFlutterDriverExtension();
-  app.main();
+  // As in lib/main.dart: overriding https://github.com/flutter/flutter/issues/13736
+  // for better visual effect at the cost of performance.
+  MaterialPageRoute.debugEnableFadingRoutes = true; // ignore: deprecated_member_use
+  runApp(const GalleryApp(testMode: true));
 }

--- a/examples/flutter_gallery/test_driver/transitions_perf.dart
+++ b/examples/flutter_gallery/test_driver/transitions_perf.dart
@@ -7,7 +7,8 @@ import 'dart:convert' show JsonEncoder;
 
 import 'package:flutter_driver/driver_extension.dart';
 import 'package:flutter_gallery/gallery/demos.dart';
-import 'package:flutter_gallery/main.dart' as app;
+import 'package:flutter_gallery/gallery/app.dart' show GalleryApp;
+import 'package:flutter/material.dart';
 
 Future<String> _handleMessages(String message) async {
   assert(message == 'demoNames');
@@ -18,5 +19,8 @@ Future<String> _handleMessages(String message) async {
 
 void main() {
   enableFlutterDriverExtension(handler: _handleMessages);
-  app.main();
+  // As in lib/main.dart: overriding https://github.com/flutter/flutter/issues/13736
+  // for better visual effect at the cost of performance.
+  MaterialPageRoute.debugEnableFadingRoutes = true; // ignore: deprecated_member_use
+  runApp(const GalleryApp(testMode: true));
 }


### PR DESCRIPTION
This additional GalleryApp flag is intended to make tests that launch all of the demos a little more robust by eliminating the possibility of missing the first item in a list-of-demos page and hitting the front layer's heading instead.
