### PR TITLE
Mark 32-bit iOS gallery transitions test unflaky

### DIFF
--- a/dev/devicelab/manifest.yaml
+++ b/dev/devicelab/manifest.yaml
@@ -452,4 +452,3 @@ tasks:
       32-bit iOS.
     stage: devicelab_ios
     required_agent_capabilities: ["mac/ios32"]
-    flaky: true


### PR DESCRIPTION
Remaining issue was fixed in 580c844c2fe37b680c0355b6b035e56b27da18df.