### PR TITLE
remove an unused flutter run flag

### DIFF
--- a/packages/flutter_tools/lib/src/commands/run.dart
+++ b/packages/flutter_tools/lib/src/commands/run.dart
@@ -83,10 +83,6 @@ class RunCommand extends RunCommandBase {
     requiresPubspecYaml();
 
     argParser
-      ..addFlag('full-restart',
-        defaultsTo: true,
-        help: 'Stop any currently running application process before running the app.',
-      )
       ..addFlag('start-paused',
         negatable: false,
         help: 'Start in a paused mode and wait for a debugger to connect.',


### PR DESCRIPTION
- remove the flutter run `--full-restart` flag - it had been orphaned, and was no longer being querying by flutter run code

context: https://github.com/flutter/flutter/issues/17568#issuecomment-389243625
