### PR TITLE
[Discuss] Scaffolding for a platform adaptive widget mechanism

### DIFF
--- a/packages/flutter/lib/src/cupertino/switch.dart
+++ b/packages/flutter/lib/src/cupertino/switch.dart
@@ -51,7 +51,7 @@ class CupertinoSwitch extends StatefulWidget {
     Key key,
     @required this.value,
     @required this.onChanged,
-    this.activeColor: CupertinoColors.activeGreen,
+    this.activeColor,
   }) : super(key: key);
 
   /// Whether this switch is on or off.
@@ -82,6 +82,8 @@ class CupertinoSwitch extends StatefulWidget {
   final ValueChanged<bool> onChanged;
 
   /// The color to use when this switch is on.
+  ///
+  /// Defaults to [CupertinoColors.activeGreen].
   final Color activeColor;
 
   @override
@@ -100,7 +102,7 @@ class _CupertinoSwitchState extends State<CupertinoSwitch> with TickerProviderSt
   Widget build(BuildContext context) {
     return new _CupertinoSwitchRenderObjectWidget(
       value: widget.value,
-      activeColor: widget.activeColor,
+      activeColor: widget.activeColor ?? CupertinoColors.activeGreen,
       onChanged: widget.onChanged,
       vsync: this,
     );

--- a/packages/flutter/lib/src/material/adaptive.dart
+++ b/packages/flutter/lib/src/material/adaptive.dart
@@ -1,0 +1,58 @@
+// Copyright 2018 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/widgets.dart';
+
+import 'theme.dart';
+
+/// Options for the adaptive behavior of [AdaptiveWidget].
+enum AdaptiveMode {
+  /// Always adapt the widget to the current [TargetPlatform].
+  adaptive,
+  /// Never adapt the widget to the current [TargetPlatform]. Always return
+  /// the Material Design widget.
+  static,
+  /// Adapt the widget to the current [TargetPlatform] if the widget type is
+  /// enabled in [ThemeData.adaptiveWidgetTheme].
+  theme,
+}
+
+/// A [StatelessWidget] that can build different widgets according to the
+/// current platform environment depending on the [adaptiveMode].
+abstract class AdaptiveWidget extends StatelessWidget {
+  const AdaptiveWidget({
+    Key key,
+    this.adaptiveMode: AdaptiveMode.theme,
+  }) : super(key: key);
+
+  final AdaptiveMode adaptiveMode;
+
+  Widget buildMaterialWidget(BuildContext context);
+
+  Widget buildCupertinoWidget(BuildContext context);
+
+  @override
+  Widget build(BuildContext context) {
+    if (adaptiveMode == AdaptiveMode.static) {
+      return buildMaterialWidget(context);
+    }
+
+    final ThemeData theme = Theme.of(context);
+
+    if (!theme.adaptiveWidgetTheme.isWidgetAdaptive(runtimeType)) {
+      return buildMaterialWidget(context);
+    }
+
+    switch (theme.platform) {
+      case TargetPlatform.android:
+        return buildMaterialWidget(context);
+      case TargetPlatform.iOS:
+        return buildCupertinoWidget(context);
+      case TargetPlatform.fuchsia:
+        return buildMaterialWidget(context);
+    }
+    assert(false);
+    return null;
+  }
+}

--- a/packages/flutter/lib/src/material/switch.dart
+++ b/packages/flutter/lib/src/material/switch.dart
@@ -2,11 +2,13 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 
+import 'adaptive.dart';
 import 'colors.dart';
 import 'constants.dart';
 import 'debug.dart';
@@ -33,7 +35,7 @@ import 'toggleable.dart';
 ///  * [Radio], for selecting among a set of explicit values.
 ///  * [Slider], for selecting a value in a range.
 ///  * <https://material.google.com/components/selection-controls.html#selection-controls-switch>
-class Switch extends StatefulWidget {
+class Switch extends AdaptiveWidget {
   /// Creates a material design switch.
   ///
   /// The switch itself does not maintain any state. Instead, when the state of
@@ -54,8 +56,9 @@ class Switch extends StatefulWidget {
     this.inactiveThumbColor,
     this.inactiveTrackColor,
     this.activeThumbImage,
-    this.inactiveThumbImage
-  }) : super(key: key);
+    this.inactiveThumbImage,
+    AdaptiveMode adaptiveMode,
+  }) : super(key: key, adaptiveMode: adaptiveMode);
 
   /// Whether this switch is on or off.
   ///
@@ -113,7 +116,53 @@ class Switch extends StatefulWidget {
   final ImageProvider inactiveThumbImage;
 
   @override
-  _SwitchState createState() => new _SwitchState();
+  Widget buildCupertinoWidget(BuildContext context) {
+    return new CupertinoSwitch(
+      value: value,
+      onChanged: onChanged,
+      activeColor: activeColor,
+    );
+  }
+
+  @override
+  Widget buildMaterialWidget(BuildContext context) {
+    return new _MountainViewSwitch(
+      value: value,
+      onChanged: onChanged,
+      activeColor: activeColor,
+      activeTrackColor: activeTrackColor,
+      inactiveThumbColor: inactiveThumbColor,
+      inactiveTrackColor: inactiveTrackColor,
+      activeThumbImage: activeThumbImage,
+      inactiveThumbImage: inactiveThumbImage,
+    );
+  }
+}
+
+class _MountainViewSwitch extends StatefulWidget{
+  const _MountainViewSwitch({
+    Key key,
+    @required this.value,
+    @required this.onChanged,
+    this.activeColor,
+    this.activeTrackColor,
+    this.inactiveThumbColor,
+    this.inactiveTrackColor,
+    this.activeThumbImage,
+    this.inactiveThumbImage
+  }) : super(key: key);
+
+  final bool value;
+  final ValueChanged<bool> onChanged;
+  final Color activeColor;
+  final Color activeTrackColor;
+  final Color inactiveThumbColor;
+  final Color inactiveTrackColor;
+  final ImageProvider activeThumbImage;
+  final ImageProvider inactiveThumbImage;
+
+  @override
+  _MountainViewSwitchState createState() => new _MountainViewSwitchState();
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
@@ -123,7 +172,7 @@ class Switch extends StatefulWidget {
   }
 }
 
-class _SwitchState extends State<Switch> with TickerProviderStateMixin {
+class _MountainViewSwitchState extends State<_MountainViewSwitch> with TickerProviderStateMixin {
   @override
   Widget build(BuildContext context) {
     assert(debugCheckHasMaterial(context));

--- a/packages/flutter/lib/src/material/theme_data.dart
+++ b/packages/flutter/lib/src/material/theme_data.dart
@@ -15,6 +15,7 @@ import 'ink_splash.dart';
 import 'ink_well.dart' show InteractiveInkFeatureFactory;
 import 'input_decorator.dart';
 import 'slider_theme.dart';
+import 'switch.dart';
 import 'typography.dart';
 
 export 'package:flutter/services.dart' show Brightness;
@@ -105,6 +106,7 @@ class ThemeData extends Diagnosticable {
     SliderThemeData sliderTheme,
     ChipThemeData chipTheme,
     TargetPlatform platform,
+    AdaptiveWidgetThemeData adaptiveWidgetTheme,
   }) {
     brightness ??= Brightness.light;
     final bool isDark = brightness == Brightness.dark;
@@ -168,6 +170,8 @@ class ThemeData extends Diagnosticable {
       brightness: brightness,
       labelStyle: textTheme.body2,
     );
+    adaptiveWidgetTheme ??= AdaptiveWidgetThemeData.none;
+
     return new ThemeData.raw(
       brightness: brightness,
       primaryColor: primaryColor,
@@ -208,6 +212,7 @@ class ThemeData extends Diagnosticable {
       sliderTheme: sliderTheme,
       chipTheme: chipTheme,
       platform: platform,
+      adaptiveWidgetTheme: adaptiveWidgetTheme,
     );
   }
 
@@ -257,6 +262,7 @@ class ThemeData extends Diagnosticable {
     @required this.sliderTheme,
     @required this.chipTheme,
     @required this.platform,
+    @required this.adaptiveWidgetTheme,
   }) : assert(brightness != null),
        assert(primaryColor != null),
        assert(primaryColorBrightness != null),
@@ -294,7 +300,8 @@ class ThemeData extends Diagnosticable {
        assert(accentIconTheme != null),
        assert(sliderTheme != null),
        assert(chipTheme != null),
-       assert(platform != null);
+       assert(platform != null),
+       assert(adaptiveWidgetTheme != null);
 
   /// A default light blue theme.
   ///
@@ -483,6 +490,8 @@ class ThemeData extends Diagnosticable {
   /// Defaults to the current platform.
   final TargetPlatform platform;
 
+  final AdaptiveWidgetThemeData adaptiveWidgetTheme;
+
   /// Creates a copy of this theme but with the given fields replaced with the new values.
   ThemeData copyWith({
     Brightness brightness,
@@ -524,6 +533,7 @@ class ThemeData extends Diagnosticable {
     SliderThemeData sliderTheme,
     ChipThemeData chipTheme,
     TargetPlatform platform,
+    AdaptiveWidgetThemeData adaptiveWidgetTheme,
   }) {
     return new ThemeData.raw(
       brightness: brightness ?? this.brightness,
@@ -565,6 +575,7 @@ class ThemeData extends Diagnosticable {
       sliderTheme: sliderTheme ?? this.sliderTheme,
       chipTheme: chipTheme ?? this.chipTheme,
       platform: platform ?? this.platform,
+      adaptiveWidgetTheme: adaptiveWidgetTheme ?? this.adaptiveWidgetTheme,
     );
   }
 
@@ -692,6 +703,7 @@ class ThemeData extends Diagnosticable {
       sliderTheme: SliderThemeData.lerp(a.sliderTheme, b.sliderTheme, t),
       chipTheme: ChipThemeData.lerp(a.chipTheme, b.chipTheme, t),
       platform: t < 0.5 ? a.platform : b.platform,
+      adaptiveWidgetTheme: t < 0.5 ? a.adaptiveWidgetTheme : b.adaptiveWidgetTheme,
     );
   }
 
@@ -736,7 +748,8 @@ class ThemeData extends Diagnosticable {
            (otherData.accentIconTheme == accentIconTheme) &&
            (otherData.sliderTheme == sliderTheme) &&
            (otherData.chipTheme == chipTheme) &&
-           (otherData.platform == platform);
+           (otherData.platform == platform) &&
+           (otherData.adaptiveWidgetTheme == adaptiveWidgetTheme);
   }
 
   @override
@@ -780,6 +793,7 @@ class ThemeData extends Diagnosticable {
         sliderTheme,
         chipTheme,
         platform,
+        adaptiveWidgetTheme,
       ),
     );
   }
@@ -825,6 +839,27 @@ class ThemeData extends Diagnosticable {
     properties.add(new DiagnosticsProperty<SliderThemeData>('sliderTheme', sliderTheme));
     properties.add(new DiagnosticsProperty<ChipThemeData>('chipTheme', chipTheme));
   }
+}
+
+/// Describes whether descendent Material Design widgets of various types
+/// should automatically adapt to use Cupertino widgets when running on iOS.
+@immutable
+class AdaptiveWidgetThemeData {
+  const AdaptiveWidgetThemeData(this._adaptivenessOptions);
+
+  static const AdaptiveWidgetThemeData none =
+      const AdaptiveWidgetThemeData(const <Type, bool>{
+        Switch: false,
+      });
+
+  static const AdaptiveWidgetThemeData all =
+      const AdaptiveWidgetThemeData(const <Type, bool>{
+        Switch: true,
+      });
+
+  final Map<Type, bool> _adaptivenessOptions;
+
+  bool isWidgetAdaptive(Type widgetType) => _adaptivenessOptions[widgetType] == true;
 }
 
 class _IdentityThemeDataCacheKey {


### PR DESCRIPTION
#8410

A barebone prototype to automatically switch between Material and Cupertino widgets for discussion. It only demonstrates it on one widget and there's no tests or documentations. 

Key assumption: 

- From previous offline chats, we've decided that Material and Cupertino are not siblings in the architecture hierarchy and Material wraps Cupertino in the way we established for page transitions. This just formalizes it and makes it simpler. 
- We're not going to implement animations between 2 different platforms' widgets because it's going to be complex and no one is going to use it :)

I went back and forth between inserting the switching logic in-place or wrapping another widget around both the Material and the Cupertino widgets but ultimately decided on replacing in-place:

- Reduce ongoing maintenance cost by keeping the number of public APIs to 2 instead of 3 where one can update the Material functionality and forget to update the plumbing or documentation in the wrapper widget
- This acts as a forcing function that makes us check that APIs between Material and Cupertino widgets are as consistent as possible in the ways how it deals with argument names, defaults, nulls etc (see the Cupertino switch edits)

Example usage of this mechanism at https://github.com/xster/flutter-test/blob/master/t92_dynamic_widget_switch/lib/main.dart

Will add other widgets and docs and test after a first round of discussions. 