### PR TITLE
Moving API doc asset URLs to point to the new location.

### DIFF
--- a/dev/manual_tests/lib/color_testing_demo.dart
+++ b/dev/manual_tests/lib/color_testing_demo.dart
@@ -22,9 +22,9 @@ class ColorDemoHome extends StatelessWidget {
       body: new ListView(
         padding: const EdgeInsets.all(5.0),
         children: <Widget>[
-          new Image.network('https://flutter.github.io/assets-for-api-docs/tests/colors/gbr.png'),
-          new Image.network('https://flutter.github.io/assets-for-api-docs/tests/colors/tf.png'),
-          new Image.network('https://flutter.github.io/assets-for-api-docs/tests/colors/wide-gamut.png'),
+          new Image.network('https://flutter.github.io/assets-for-api-docs/assets/tests/colors/gbr.png'),
+          new Image.network('https://flutter.github.io/assets-for-api-docs/assets/tests/colors/tf.png'),
+          new Image.network('https://flutter.github.io/assets-for-api-docs/assets/tests/colors/wide-gamut.png'),
           const GradientRow(leftColor: const Color(0xFFFF0000), rightColor: const Color(0xFF00FF00)),
           const GradientRow(leftColor: const Color(0xFF0000FF), rightColor: const Color(0xFFFFFF00)),
           const GradientRow(leftColor: const Color(0xFFFF0000), rightColor: const Color(0xFF0000FF)),

--- a/examples/flutter_gallery/lib/demo/video_demo.dart
+++ b/examples/flutter_gallery/lib/demo/video_demo.dart
@@ -11,7 +11,7 @@ import 'package:device_info/device_info.dart';
 
 // TODO(sigurdm): This should not be stored here.
 const String beeUri =
-    'https://flutter.github.io/assets-for-api-docs/videos/bee.mp4';
+    'https://flutter.github.io/assets-for-api-docs/assets/videos/bee.mp4';
 
 class VideoCard extends StatelessWidget {
   final VideoPlayerController controller;

--- a/packages/flutter/lib/src/animation/curves.dart
+++ b/packages/flutter/lib/src/animation/curves.dart
@@ -28,8 +28,8 @@ abstract class Curve {
   /// Returns a new curve that is the reversed inversion of this one.
   /// This is often useful as the reverseCurve of an [Animation].
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/animation/curve_bounce_in.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/animation/curve_flipped.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/animation/curve_bounce_in.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/animation/curve_flipped.png)
   ///
   /// See also:
   ///
@@ -57,7 +57,7 @@ class _Linear extends Curve {
 /// The curve rises linearly from 0.0 to 1.0 and then falls discontinuously back
 /// to 0.0 each iteration.
 ///
-/// ![](https://flutter.github.io/assets-for-api-docs/animation/curve_sawtooth.png)
+/// ![](https://flutter.github.io/assets-for-api-docs/assets/animation/curve_sawtooth.png)
 class SawTooth extends Curve {
   /// Creates a sawtooth curve.
   ///
@@ -90,7 +90,7 @@ class SawTooth extends Curve {
 /// set to 1.0 will essentially become a three-second animation that starts
 /// three seconds later.
 ///
-/// ![](https://flutter.github.io/assets-for-api-docs/animation/curve_interval.png)
+/// ![](https://flutter.github.io/assets-for-api-docs/assets/animation/curve_interval.png)
 class Interval extends Curve {
   /// Creates an interval curve.
   ///
@@ -139,7 +139,7 @@ class Interval extends Curve {
 
 /// A curve that is 0.0 until it hits the threshold, then it jumps to 1.0.
 ///
-/// ![](https://flutter.github.io/assets-for-api-docs/animation/curve_threshold.png)
+/// ![](https://flutter.github.io/assets-for-api-docs/assets/animation/curve_threshold.png)
 class Threshold extends Curve {
   /// Creates a threshold curve.
   ///
@@ -171,10 +171,10 @@ class Threshold extends Curve {
 ///  * [Curves.easeOut]
 ///  * [Curves.easeInOut]
 ///
-/// ![](https://flutter.github.io/assets-for-api-docs/animation/curve_ease.png)
-/// ![](https://flutter.github.io/assets-for-api-docs/animation/curve_ease_in.png)
-/// ![](https://flutter.github.io/assets-for-api-docs/animation/curve_ease_out.png)
-/// ![](https://flutter.github.io/assets-for-api-docs/animation/curve_ease_in_out.png)
+/// ![](https://flutter.github.io/assets-for-api-docs/assets/animation/curve_ease.png)
+/// ![](https://flutter.github.io/assets-for-api-docs/assets/animation/curve_ease_in.png)
+/// ![](https://flutter.github.io/assets-for-api-docs/assets/animation/curve_ease_out.png)
+/// ![](https://flutter.github.io/assets-for-api-docs/assets/animation/curve_ease_in_out.png)
 ///
 /// The [Cubic] class implements third-order Bézier curves.
 class Cubic extends Curve {
@@ -253,8 +253,8 @@ class Cubic extends Curve {
 ///
 /// This is the class used to implement the [flipped] getter on curves.
 ///
-/// ![](https://flutter.github.io/assets-for-api-docs/animation/curve_bounce_in.png)
-/// ![](https://flutter.github.io/assets-for-api-docs/animation/curve_flipped_curve.png)
+/// ![](https://flutter.github.io/assets-for-api-docs/assets/animation/curve_bounce_in.png)
+/// ![](https://flutter.github.io/assets-for-api-docs/assets/animation/curve_flipped_curve.png)
 class FlippedCurve extends Curve {
   /// Creates a flipped curve.
   ///
@@ -361,7 +361,7 @@ class _BounceInOutCurve extends Curve {
 /// An instance of this class using the default period of 0.4 is available as
 /// [Curves.elasticIn].
 ///
-/// ![](https://flutter.github.io/assets-for-api-docs/animation/curve_elastic_in.png)
+/// ![](https://flutter.github.io/assets-for-api-docs/assets/animation/curve_elastic_in.png)
 class ElasticInCurve extends Curve {
   /// Creates an elastic-in curve.
   ///
@@ -390,7 +390,7 @@ class ElasticInCurve extends Curve {
 /// An instance of this class using the default period of 0.4 is available as
 /// [Curves.elasticOut].
 ///
-/// ![](https://flutter.github.io/assets-for-api-docs/animation/curve_elastic_out.png)
+/// ![](https://flutter.github.io/assets-for-api-docs/assets/animation/curve_elastic_out.png)
 class ElasticOutCurve extends Curve {
   /// Creates an elastic-out curve.
   ///
@@ -419,7 +419,7 @@ class ElasticOutCurve extends Curve {
 /// An instance of this class using the default period of 0.4 is available as
 /// [Curves.elasticInOut].
 ///
-/// ![](https://flutter.github.io/assets-for-api-docs/animation/curve_elastic_in_out.png)
+/// ![](https://flutter.github.io/assets-for-api-docs/assets/animation/curve_elastic_in_out.png)
 class ElasticInOutCurve extends Curve {
   /// Creates an elastic-in-out curve.
   ///
@@ -451,19 +451,19 @@ class ElasticInOutCurve extends Curve {
 
 /// A collection of common animation curves.
 ///
-/// ![](https://flutter.github.io/assets-for-api-docs/animation/curve_bounce_in.png)
-/// ![](https://flutter.github.io/assets-for-api-docs/animation/curve_bounce_in_out.png)
-/// ![](https://flutter.github.io/assets-for-api-docs/animation/curve_bounce_out.png)
-/// ![](https://flutter.github.io/assets-for-api-docs/animation/curve_decelerate.png)
-/// ![](https://flutter.github.io/assets-for-api-docs/animation/curve_ease.png)
-/// ![](https://flutter.github.io/assets-for-api-docs/animation/curve_ease_in.png)
-/// ![](https://flutter.github.io/assets-for-api-docs/animation/curve_ease_in_out.png)
-/// ![](https://flutter.github.io/assets-for-api-docs/animation/curve_ease_out.png)
-/// ![](https://flutter.github.io/assets-for-api-docs/animation/curve_elastic_in.png)
-/// ![](https://flutter.github.io/assets-for-api-docs/animation/curve_elastic_in_out.png)
-/// ![](https://flutter.github.io/assets-for-api-docs/animation/curve_elastic_out.png)
-/// ![](https://flutter.github.io/assets-for-api-docs/animation/curve_fast_out_slow_in.png)
-/// ![](https://flutter.github.io/assets-for-api-docs/animation/curve_linear.png)
+/// ![](https://flutter.github.io/assets-for-api-docs/assets/animation/curve_bounce_in.png)
+/// ![](https://flutter.github.io/assets-for-api-docs/assets/animation/curve_bounce_in_out.png)
+/// ![](https://flutter.github.io/assets-for-api-docs/assets/animation/curve_bounce_out.png)
+/// ![](https://flutter.github.io/assets-for-api-docs/assets/animation/curve_decelerate.png)
+/// ![](https://flutter.github.io/assets-for-api-docs/assets/animation/curve_ease.png)
+/// ![](https://flutter.github.io/assets-for-api-docs/assets/animation/curve_ease_in.png)
+/// ![](https://flutter.github.io/assets-for-api-docs/assets/animation/curve_ease_in_out.png)
+/// ![](https://flutter.github.io/assets-for-api-docs/assets/animation/curve_ease_out.png)
+/// ![](https://flutter.github.io/assets-for-api-docs/assets/animation/curve_elastic_in.png)
+/// ![](https://flutter.github.io/assets-for-api-docs/assets/animation/curve_elastic_in_out.png)
+/// ![](https://flutter.github.io/assets-for-api-docs/assets/animation/curve_elastic_out.png)
+/// ![](https://flutter.github.io/assets-for-api-docs/assets/animation/curve_fast_out_slow_in.png)
+/// ![](https://flutter.github.io/assets-for-api-docs/assets/animation/curve_linear.png)
 ///
 /// See also:
 ///
@@ -478,7 +478,7 @@ class Curves {
   /// method returns its input unmodified. This is useful as a default curve for
   /// cases where a [Curve] is required but no actual curve is desired.
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/animation/curve_linear.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/animation/curve_linear.png)
   static const Curve linear = const _Linear._();
 
   /// A curve where the rate of change starts out quickly and then decelerates; an
@@ -487,27 +487,27 @@ class Curves {
   /// This is equivalent to the Android `DecelerateInterpolator` class with a unit
   /// factor (the default factor).
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/animation/curve_decelerate.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/animation/curve_decelerate.png)
   static const Curve decelerate = const _DecelerateCurve._();
 
   /// A cubic animation curve that speeds up quickly and ends slowly.
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/animation/curve_ease.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/animation/curve_ease.png)
   static const Cubic ease = const Cubic(0.25, 0.1, 0.25, 1.0);
 
   /// A cubic animation curve that starts slowly and ends quickly.
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/animation/curve_ease_in.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/animation/curve_ease_in.png)
   static const Cubic easeIn = const Cubic(0.42, 0.0, 1.0, 1.0);
 
   /// A cubic animation curve that starts quickly and ends slowly.
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/animation/curve_ease_out.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/animation/curve_ease_out.png)
   static const Cubic easeOut = const Cubic(0.0, 0.0, 0.58, 1.0);
 
   /// A cubic animation curve that starts slowly, speeds up, and then and ends slowly.
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/animation/curve_ease_in_out.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/animation/curve_ease_in_out.png)
   static const Cubic easeInOut = const Cubic(0.42, 0.0, 0.58, 1.0);
 
   /// A curve that starts quickly and eases into its final position.
@@ -516,36 +516,36 @@ class Curves {
   /// final destination. As a result, the user isn’t left waiting for the
   /// animation to finish, and the negative effects of motion are minimized.
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/animation/curve_fast_out_slow_in.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/animation/curve_fast_out_slow_in.png)
   static const Cubic fastOutSlowIn = const Cubic(0.4, 0.0, 0.2, 1.0);
 
   /// An oscillating curve that grows in magnitude.
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/animation/curve_bounce_in.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/animation/curve_bounce_in.png)
   static const Curve bounceIn = const _BounceInCurve._();
 
   /// An oscillating curve that first grows and then shrink in magnitude.
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/animation/curve_bounce_out.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/animation/curve_bounce_out.png)
   static const Curve bounceOut = const _BounceOutCurve._();
 
   /// An oscillating curve that first grows and then shrink in magnitude.
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/animation/curve_bounce_in_out.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/animation/curve_bounce_in_out.png)
   static const Curve bounceInOut = const _BounceInOutCurve._();
 
   /// An oscillating curve that grows in magnitude while overshooting its bounds.
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/animation/curve_elastic_in.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/animation/curve_elastic_in.png)
   static const ElasticInCurve elasticIn = const ElasticInCurve();
 
   /// An oscillating curve that shrinks in magnitude while overshooting its bounds.
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/animation/curve_elastic_out.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/animation/curve_elastic_out.png)
   static const ElasticOutCurve elasticOut = const ElasticOutCurve();
 
   /// An oscillating curve that grows and then shrinks in magnitude while overshooting its bounds.
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/animation/curve_elastic_in_out.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/animation/curve_elastic_in_out.png)
   static const ElasticInOutCurve elasticInOut = const ElasticInOutCurve();
 }

--- a/packages/flutter/lib/src/material/app_bar.dart
+++ b/packages/flutter/lib/src/material/app_bar.dart
@@ -79,7 +79,7 @@ class _ToolbarContainerLayout extends SingleChildLayoutDelegate {
 ///
 /// ![The leading widget is in the top left, the actions are in the top right,
 /// the title is between them. The bottom is, naturally, at the bottom, and the
-/// flexibleSpace is behind all of them.](https://flutter.github.io/assets-for-api-docs/material/app_bar.png)
+/// flexibleSpace is behind all of them.](https://flutter.github.io/assets-for-api-docs/assets/material/app_bar.png)
 ///
 /// If the [leading] widget is omitted, but the [AppBar] is in a [Scaffold] with
 /// a [Drawer], then a button will be inserted to open the drawer. Otherwise, if

--- a/packages/flutter/lib/src/material/card.dart
+++ b/packages/flutter/lib/src/material/card.dart
@@ -49,7 +49,7 @@ import 'theme.dart';
 ///
 /// ![A card with a slight shadow, consisting of two rows, one with an icon and
 /// some text describing a musical, and the other with buttons for buying
-/// tickets or listening to the show.](https://flutter.github.io/assets-for-api-docs/material/card.png)
+/// tickets or listening to the show.](https://flutter.github.io/assets-for-api-docs/assets/material/card.png)
 ///
 /// See also:
 ///

--- a/packages/flutter/lib/src/material/colors.dart
+++ b/packages/flutter/lib/src/material/colors.dart
@@ -123,59 +123,59 @@ class MaterialAccentColor extends ColorSwatch<int> {
 ///
 /// ## Color palettes
 ///
-/// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.pink.png)
-/// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.pinkAccent.png)
+/// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.pink.png)
+/// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.pinkAccent.png)
 ///
-/// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.red.png)
-/// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.redAccent.png)
+/// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.red.png)
+/// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.redAccent.png)
 ///
-/// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.deepOrange.png)
-/// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.deepOrangeAccent.png)
+/// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.deepOrange.png)
+/// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.deepOrangeAccent.png)
 ///
-/// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.orange.png)
-/// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.orangeAccent.png)
+/// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.orange.png)
+/// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.orangeAccent.png)
 ///
-/// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.amber.png)
-/// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.amberAccent.png)
+/// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.amber.png)
+/// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.amberAccent.png)
 ///
-/// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.yellow.png)
-/// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.yellowAccent.png)
+/// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.yellow.png)
+/// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.yellowAccent.png)
 ///
-/// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.lime.png)
-/// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.limeAccent.png)
+/// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.lime.png)
+/// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.limeAccent.png)
 ///
-/// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.lightGreen.png)
-/// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.lightGreenAccent.png)
+/// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.lightGreen.png)
+/// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.lightGreenAccent.png)
 ///
-/// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.green.png)
-/// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.greenAccent.png)
+/// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.green.png)
+/// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.greenAccent.png)
 ///
-/// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.teal.png)
-/// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.tealAccent.png)
+/// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.teal.png)
+/// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.tealAccent.png)
 ///
-/// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.cyan.png)
-/// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.cyanAccent.png)
+/// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.cyan.png)
+/// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.cyanAccent.png)
 ///
-/// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.lightBlue.png)
-/// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.lightBlueAccent.png)
+/// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.lightBlue.png)
+/// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.lightBlueAccent.png)
 ///
-/// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.blue.png)
-/// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.blueAccent.png)
+/// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.blue.png)
+/// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.blueAccent.png)
 ///
-/// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.indigo.png)
-/// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.indigoAccent.png)
+/// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.indigo.png)
+/// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.indigoAccent.png)
 ///
-/// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.purple.png)
-/// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.purpleAccent.png)
+/// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.purple.png)
+/// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.purpleAccent.png)
 ///
-/// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.deepPurple.png)
-/// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.deepPurpleAccent.png)
+/// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.deepPurple.png)
+/// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.deepPurpleAccent.png)
 ///
-/// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.blueGrey.png)
+/// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.blueGrey.png)
 ///
-/// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.brown.png)
+/// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.brown.png)
 ///
-/// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.grey.png)
+/// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.grey.png)
 ///
 /// ## Blacks and whites
 ///
@@ -183,8 +183,8 @@ class MaterialAccentColor extends ColorSwatch<int> {
 /// levels (e.g. [Colors.white12] and [Colors.white10]) are very hard to see and
 /// should be avoided in general. They are intended for very subtle effects.
 ///
-/// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.blacks.png)
-/// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.whites.png)
+/// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.blacks.png)
+/// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.whites.png)
 ///
 /// The [Colors.transparent] color isn't shown here because it is entirely
 /// invisible!
@@ -196,7 +196,7 @@ class Colors {
 
   /// Completely opaque black.
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.blacks.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.blacks.png)
   ///
   /// See also:
   ///
@@ -210,7 +210,7 @@ class Colors {
   ///
   /// This is a good contrasting color for text in light themes.
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.blacks.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.blacks.png)
   ///
   /// See also:
   ///
@@ -226,7 +226,7 @@ class Colors {
   /// This is a color commonly used for headings in light themes. It's also used
   /// as the mask color behind dialogs.
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.blacks.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.blacks.png)
   ///
   /// See also:
   ///
@@ -241,7 +241,7 @@ class Colors {
   ///
   /// Used for disabled icons.
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.blacks.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.blacks.png)
   ///
   /// See also:
   ///
@@ -253,7 +253,7 @@ class Colors {
   ///
   /// Used for the placeholder text in data tables in light themes.
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.blacks.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.blacks.png)
   ///
   /// See also:
   ///
@@ -265,7 +265,7 @@ class Colors {
   ///
   /// Used for disabled radio buttons and the text of disabled flat buttons in light themes.
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.blacks.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.blacks.png)
   ///
   /// See also:
   ///
@@ -278,7 +278,7 @@ class Colors {
 
   /// Black with 12% opacity.
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.blacks.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.blacks.png)
   ///
   /// Used for the background of disabled raised buttons in light themes.
   ///
@@ -293,7 +293,7 @@ class Colors {
   /// This is a good contrasting color for the [ThemeData.primaryColor] in the
   /// dark theme. See [ThemeData.brightness].
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.whites.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.whites.png)
   ///
   /// See also:
   ///
@@ -310,7 +310,7 @@ class Colors {
   ///
   /// This is a color commonly used for headings in dark themes.
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.whites.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.whites.png)
   ///
   /// See also:
   ///
@@ -325,7 +325,7 @@ class Colors {
   ///
   /// Used for disabled radio buttons and the text of disabled flat buttons in dark themes.
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.whites.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.whites.png)
   ///
   /// See also:
   ///
@@ -338,7 +338,7 @@ class Colors {
 
   /// White with 24% opacity.
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.whites.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.whites.png)
   ///
   /// Used for the splash color for filled buttons.
   ///
@@ -350,7 +350,7 @@ class Colors {
 
   /// White with 12% opacity.
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.whites.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.whites.png)
   ///
   /// Used for the background of disabled raised buttons in dark themes.
   ///
@@ -362,7 +362,7 @@ class Colors {
 
   /// White with 10% opacity.
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.whites.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.whites.png)
   ///
   /// See also:
   ///
@@ -373,14 +373,14 @@ class Colors {
 
   /// The red primary color and swatch.
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.red.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.redAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.red.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.redAccent.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.deepOrange.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.deepOrangeAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.deepOrange.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.deepOrangeAccent.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.pink.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.pinkAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.pink.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.pinkAccent.png)
   ///
   /// ## Sample code
   ///
@@ -416,14 +416,14 @@ class Colors {
 
   /// The red accent swatch.
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.red.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.redAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.red.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.redAccent.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.deepOrange.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.deepOrangeAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.deepOrange.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.deepOrangeAccent.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.pink.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.pinkAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.pink.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.pinkAccent.png)
   ///
   /// ## Sample code
   ///
@@ -453,14 +453,14 @@ class Colors {
 
   /// The pink primary color and swatch.
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.pink.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.pinkAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.pink.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.pinkAccent.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.red.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.redAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.red.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.redAccent.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.purple.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.purpleAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.purple.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.purpleAccent.png)
   ///
   /// ## Sample code
   ///
@@ -496,14 +496,14 @@ class Colors {
 
   /// The pink accent color swatch.
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.pink.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.pinkAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.pink.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.pinkAccent.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.red.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.redAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.red.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.redAccent.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.purple.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.purpleAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.purple.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.purpleAccent.png)
   ///
   /// ## Sample code
   ///
@@ -533,14 +533,14 @@ class Colors {
 
   /// The purple primary color and swatch.
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.purple.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.purpleAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.purple.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.purpleAccent.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.deepPurple.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.deepPurpleAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.deepPurple.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.deepPurpleAccent.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.pink.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.pinkAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.pink.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.pinkAccent.png)
   ///
   /// ## Sample code
   ///
@@ -576,14 +576,14 @@ class Colors {
 
   /// The purple accent color and swatch.
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.purple.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.purpleAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.purple.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.purpleAccent.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.deepPurple.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.deepPurpleAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.deepPurple.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.deepPurpleAccent.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.pink.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.pinkAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.pink.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.pinkAccent.png)
   ///
   /// ## Sample code
   ///
@@ -613,14 +613,14 @@ class Colors {
 
   /// The deep purple primary color and swatch.
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.deepPurple.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.deepPurpleAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.deepPurple.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.deepPurpleAccent.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.purple.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.purpleAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.purple.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.purpleAccent.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.indigo.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.indigoAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.indigo.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.indigoAccent.png)
   ///
   /// ## Sample code
   ///
@@ -656,14 +656,14 @@ class Colors {
 
   /// The deep purple accent color and swatch.
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.deepPurple.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.deepPurpleAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.deepPurple.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.deepPurpleAccent.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.purple.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.purpleAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.purple.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.purpleAccent.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.indigo.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.indigoAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.indigo.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.indigoAccent.png)
   ///
   /// ## Sample code
   ///
@@ -693,14 +693,14 @@ class Colors {
 
   /// The indigo primary color and swatch.
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.indigo.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.indigoAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.indigo.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.indigoAccent.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.blue.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.blueAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.blue.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.blueAccent.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.deepPurple.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.deepPurpleAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.deepPurple.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.deepPurpleAccent.png)
   ///
   /// ## Sample code
   ///
@@ -736,14 +736,14 @@ class Colors {
 
   /// The indigo accent color and swatch.
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.indigo.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.indigoAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.indigo.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.indigoAccent.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.blue.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.blueAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.blue.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.blueAccent.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.deepPurple.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.deepPurpleAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.deepPurple.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.deepPurpleAccent.png)
   ///
   /// ## Sample code
   ///
@@ -773,16 +773,16 @@ class Colors {
 
   /// The blue primary color and swatch.
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.blue.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.blueAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.blue.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.blueAccent.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.indigo.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.indigoAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.indigo.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.indigoAccent.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.lightBlue.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.lightBlueAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.lightBlue.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.lightBlueAccent.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.blueGrey.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.blueGrey.png)
   ///
   /// ## Sample code
   ///
@@ -818,14 +818,14 @@ class Colors {
 
   /// The blue accent color and swatch.
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.blue.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.blueAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.blue.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.blueAccent.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.indigo.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.indigoAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.indigo.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.indigoAccent.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.lightBlue.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.lightBlueAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.lightBlue.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.lightBlueAccent.png)
   ///
   /// ## Sample code
   ///
@@ -855,14 +855,14 @@ class Colors {
 
   /// The light blue primary color and swatch.
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.lightBlue.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.lightBlueAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.lightBlue.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.lightBlueAccent.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.blue.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.blueAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.blue.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.blueAccent.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.cyan.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.cyanAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.cyan.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.cyanAccent.png)
   ///
   /// ## Sample code
   ///
@@ -898,14 +898,14 @@ class Colors {
 
   /// The light blue accent swatch.
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.lightBlue.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.lightBlueAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.lightBlue.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.lightBlueAccent.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.blue.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.blueAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.blue.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.blueAccent.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.cyan.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.cyanAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.cyan.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.cyanAccent.png)
   ///
   /// ## Sample code
   ///
@@ -935,16 +935,16 @@ class Colors {
 
   /// The cyan primary color and swatch.
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.cyan.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.cyanAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.cyan.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.cyanAccent.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.lightBlue.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.lightBlueAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.lightBlue.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.lightBlueAccent.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.teal.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.tealAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.teal.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.tealAccent.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.blueGrey.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.blueGrey.png)
   ///
   /// ## Sample code
   ///
@@ -980,14 +980,14 @@ class Colors {
 
   /// The cyan accent color and swatch.
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.cyan.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.cyanAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.cyan.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.cyanAccent.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.lightBlue.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.lightBlueAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.lightBlue.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.lightBlueAccent.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.teal.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.tealAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.teal.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.tealAccent.png)
   ///
   /// ## Sample code
   ///
@@ -1017,14 +1017,14 @@ class Colors {
 
   /// The teal primary color and swatch.
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.teal.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.tealAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.teal.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.tealAccent.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.green.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.greenAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.green.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.greenAccent.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.cyan.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.cyanAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.cyan.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.cyanAccent.png)
   ///
   /// ## Sample code
   ///
@@ -1060,14 +1060,14 @@ class Colors {
 
   /// The teal accent color and swatch.
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.teal.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.tealAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.teal.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.tealAccent.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.green.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.greenAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.green.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.greenAccent.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.cyan.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.cyanAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.cyan.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.cyanAccent.png)
   ///
   /// ## Sample code
   ///
@@ -1097,17 +1097,17 @@ class Colors {
 
   /// The green primary color and swatch.
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.green.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.greenAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.green.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.greenAccent.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.teal.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.tealAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.teal.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.tealAccent.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.lightGreen.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.lightGreenAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.lightGreen.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.lightGreenAccent.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.lime.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.limeAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.lime.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.limeAccent.png)
   ///
   /// ## Sample code
   ///
@@ -1143,17 +1143,17 @@ class Colors {
 
   /// The green accent color and swatch.
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.green.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.greenAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.green.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.greenAccent.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.teal.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.tealAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.teal.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.tealAccent.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.lightGreen.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.lightGreenAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.lightGreen.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.lightGreenAccent.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.lime.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.limeAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.lime.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.limeAccent.png)
   ///
   /// ## Sample code
   ///
@@ -1183,14 +1183,14 @@ class Colors {
 
   /// The light green primary color and swatch.
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.lightGreen.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.lightGreenAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.lightGreen.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.lightGreenAccent.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.green.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.greenAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.green.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.greenAccent.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.lime.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.limeAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.lime.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.limeAccent.png)
   ///
   /// ## Sample code
   ///
@@ -1226,14 +1226,14 @@ class Colors {
 
   /// The light green accent color and swatch.
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.lightGreen.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.lightGreenAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.lightGreen.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.lightGreenAccent.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.green.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.greenAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.green.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.greenAccent.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.lime.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.limeAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.lime.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.limeAccent.png)
   ///
   /// ## Sample code
   ///
@@ -1263,14 +1263,14 @@ class Colors {
 
   /// The lime primary color and swatch.
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.lime.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.limeAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.lime.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.limeAccent.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.lightGreen.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.lightGreenAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.lightGreen.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.lightGreenAccent.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.yellow.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.yellowAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.yellow.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.yellowAccent.png)
   ///
   /// ## Sample code
   ///
@@ -1306,14 +1306,14 @@ class Colors {
 
   /// The lime accent primary color and swatch.
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.lime.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.limeAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.lime.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.limeAccent.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.lightGreen.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.lightGreenAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.lightGreen.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.lightGreenAccent.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.yellow.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.yellowAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.yellow.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.yellowAccent.png)
   ///
   /// ## Sample code
   ///
@@ -1343,14 +1343,14 @@ class Colors {
 
   /// The yellow primary color and swatch.
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.yellow.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.yellowAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.yellow.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.yellowAccent.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.lime.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.limeAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.lime.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.limeAccent.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.amber.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.amberAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.amber.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.amberAccent.png)
   ///
   /// ## Sample code
   ///
@@ -1386,14 +1386,14 @@ class Colors {
 
   /// The yellow accent color and swatch.
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.yellow.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.yellowAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.yellow.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.yellowAccent.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.lime.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.limeAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.lime.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.limeAccent.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.amber.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.amberAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.amber.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.amberAccent.png)
   ///
   /// ## Sample code
   ///
@@ -1423,14 +1423,14 @@ class Colors {
 
   /// The amber primary color and swatch.
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.amber.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.amberAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.amber.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.amberAccent.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.yellow.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.yellowAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.yellow.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.yellowAccent.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.orange.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.orangeAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.orange.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.orangeAccent.png)
   ///
   /// ## Sample code
   ///
@@ -1466,14 +1466,14 @@ class Colors {
 
   /// The amber accent color and swatch.
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.amber.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.amberAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.amber.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.amberAccent.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.yellow.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.yellowAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.yellow.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.yellowAccent.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.orange.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.orangeAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.orange.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.orangeAccent.png)
   ///
   /// ## Sample code
   ///
@@ -1503,16 +1503,16 @@ class Colors {
 
   /// The orange primary color and swatch.
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.orange.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.orangeAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.orange.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.orangeAccent.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.amber.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.amberAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.amber.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.amberAccent.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.deepOrange.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.deepOrangeAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.deepOrange.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.deepOrangeAccent.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.brown.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.brown.png)
   ///
   /// ## Sample code
   ///
@@ -1548,14 +1548,14 @@ class Colors {
 
   /// The orange accent color and swatch.
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.orange.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.orangeAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.orange.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.orangeAccent.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.amber.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.amberAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.amber.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.amberAccent.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.deepOrange.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.deepOrangeAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.deepOrange.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.deepOrangeAccent.png)
   ///
   /// ## Sample code
   ///
@@ -1585,16 +1585,16 @@ class Colors {
 
   /// The deep orange primary color and swatch.
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.deepOrange.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.deepOrangeAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.deepOrange.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.deepOrangeAccent.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.orange.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.orangeAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.orange.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.orangeAccent.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.red.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.redAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.red.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.redAccent.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.brown.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.brown.png)
   ///
   /// ## Sample code
   ///
@@ -1630,14 +1630,14 @@ class Colors {
 
   /// The deep orange accent color and swatch.
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.deepOrange.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.deepOrangeAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.deepOrange.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.deepOrangeAccent.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.orange.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.orangeAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.orange.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.orangeAccent.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.red.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.redAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.red.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.redAccent.png)
   ///
   /// ## Sample code
   ///
@@ -1667,11 +1667,11 @@ class Colors {
 
   /// The brown primary color and swatch.
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.brown.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.brown.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.orange.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.orange.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.blueGrey.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.blueGrey.png)
   ///
   /// This swatch has no corresponding accent color and swatch.
   ///
@@ -1708,11 +1708,11 @@ class Colors {
 
   /// The grey primary color and swatch.
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.grey.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.grey.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.blueGrey.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.blueGrey.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.brown.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.brown.png)
   ///
   /// This swatch has no corresponding accent swatch.
   ///
@@ -1758,13 +1758,13 @@ class Colors {
 
   /// The blue-grey primary color and swatch.
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.blueGrey.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.blueGrey.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.grey.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.grey.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.cyan.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.cyan.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.blue.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.blue.png)
   ///
   /// This swatch has no corresponding accent swatch.
   ///

--- a/packages/flutter/lib/src/material/ink_well.dart
+++ b/packages/flutter/lib/src/material/ink_well.dart
@@ -129,11 +129,11 @@ abstract class InteractiveInkFeatureFactory {
 /// The first diagram shows how it looks if the [InkResponse] is relatively
 /// large:
 ///
-/// ![The highlight is a disc centered in the box, smaller than the child widget.](https://flutter.github.io/assets-for-api-docs/material/ink_response_large.png)
+/// ![The highlight is a disc centered in the box, smaller than the child widget.](https://flutter.github.io/assets-for-api-docs/assets/material/ink_response_large.png)
 ///
 /// The second diagram shows how it looks if the [InkResponse] is small:
 ///
-/// ![The highlight is a disc overflowing the box, centered on the child.](https://flutter.github.io/assets-for-api-docs/material/ink_response_small.png)
+/// ![The highlight is a disc overflowing the box, centered on the child.](https://flutter.github.io/assets-for-api-docs/assets/material/ink_response_small.png)
 ///
 /// The main thing to notice from these diagrams is that the splashes happily
 /// exceed the bounds of the widget (because [containedInkWell] is false).
@@ -142,7 +142,7 @@ abstract class InteractiveInkFeatureFactory {
 /// [highlightShape] of [BoxShape.rectangle] with [containedInkWell] set to
 /// true. These are the values used by [InkWell].
 ///
-/// ![The highlight is a rectangle the size of the box.](https://flutter.github.io/assets-for-api-docs/material/ink_well.png)
+/// ![The highlight is a rectangle the size of the box.](https://flutter.github.io/assets-for-api-docs/assets/material/ink_well.png)
 ///
 /// The [InkResponse] widget must have a [Material] widget as an ancestor. The
 /// [Material] widget is where the ink reactions are actually painted. This
@@ -565,7 +565,7 @@ class _InkResponseState<T extends InkResponse> extends State<T> with AutomaticKe
 /// The following diagram shows how an [InkWell] looks when tapped, when using
 /// default values.
 ///
-/// ![The highlight is a rectangle the size of the box.](https://flutter.github.io/assets-for-api-docs/material/ink_well.png)
+/// ![The highlight is a rectangle the size of the box.](https://flutter.github.io/assets-for-api-docs/assets/material/ink_well.png)
 ///
 /// The [InkWell] widget must have a [Material] widget as an ancestor. The
 /// [Material] widget is where the ink reactions are actually painted. This

--- a/packages/flutter/lib/src/painting/box_fit.dart
+++ b/packages/flutter/lib/src/painting/box_fit.dart
@@ -15,30 +15,30 @@ import 'basic_types.dart';
 enum BoxFit {
   /// Fill the target box by distorting the source's aspect ratio.
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/painting/box_fit_fill.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/painting/box_fit_fill.png)
   fill,
 
   /// As large as possible while still containing the source entirely within the
   /// target box.
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/painting/box_fit_contain.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/painting/box_fit_contain.png)
   contain,
 
   /// As small as possible while still covering the entire target box.
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/painting/box_fit_cover.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/painting/box_fit_cover.png)
   cover,
 
   /// Make sure the full width of the source is shown, regardless of
   /// whether this means the source overflows the target box vertically.
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/painting/box_fit_fitWidth.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/painting/box_fit_fitWidth.png)
   fitWidth,
 
   /// Make sure the full height of the source is shown, regardless of
   /// whether this means the source overflows the target box horizontally.
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/painting/box_fit_fitHeight.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/painting/box_fit_fitHeight.png)
   fitHeight,
 
   /// Align the source within the target box (by default, centering) and discard
@@ -46,7 +46,7 @@ enum BoxFit {
   ///
   /// The source image is not resized.
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/painting/box_fit_none.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/painting/box_fit_none.png)
   none,
 
   /// Align the source within the target box (by default, centering) and, if
@@ -56,7 +56,7 @@ enum BoxFit {
   /// This is the same as `contain` if that would shrink the image, otherwise it
   /// is the same as `none`.
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/painting/box_fit_scaleDown.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/painting/box_fit_scaleDown.png)
   scaleDown,
 }
 

--- a/packages/flutter/lib/src/painting/gradient.dart
+++ b/packages/flutter/lib/src/painting/gradient.dart
@@ -311,9 +311,9 @@ class LinearGradient extends Gradient {
   ///
   /// For details, see [TileMode].
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/dart-ui/tile_mode_clamp_linear.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/dart-ui/tile_mode_mirror_linear.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/dart-ui/tile_mode_repeated_linear.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/dart-ui/tile_mode_clamp_linear.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/dart-ui/tile_mode_mirror_linear.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/dart-ui/tile_mode_repeated_linear.png)
   final TileMode tileMode;
 
   @override
@@ -532,9 +532,9 @@ class RadialGradient extends Gradient {
   ///
   /// For details, see [TileMode].
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/dart-ui/tile_mode_clamp_radial.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/dart-ui/tile_mode_mirror_radial.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/dart-ui/tile_mode_repeated_radial.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/dart-ui/tile_mode_clamp_radial.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/dart-ui/tile_mode_mirror_radial.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/dart-ui/tile_mode_repeated_radial.png)
   final TileMode tileMode;
 
   @override


### PR DESCRIPTION
I'm moving the assets in the assets-for-api-docs repo to a slightly different location to help with organization in that repo, so this PR points the doc URLs to the new location. The old assets won't be removed until this PR makes its way to the API docs website.

No documentation or code changes here, other than changing doc image URLs.