### PR TITLE
Add --no-preview-dart-2 when in dart1 mode.

### DIFF
--- a/packages/flutter_tools/lib/src/android/gradle.dart
+++ b/packages/flutter_tools/lib/src/android/gradle.dart
@@ -381,6 +381,8 @@ Future<Null> _buildGradleProjectV2(String gradle, BuildInfo buildInfo, String ta
       command.add('-Pfilesystem-roots=${buildInfo.fileSystemRoots.join('|')}');
     if (buildInfo.fileSystemScheme != null)
       command.add('-Pfilesystem-scheme=${buildInfo.fileSystemScheme}');
+  } else {
+    command.add('-Ppreview-dart-2=false');
   }
   if (buildInfo.preferSharedLibrary && androidSdk.ndk != null) {
     command.add('-Pprefer-shared-library=true');


### PR DESCRIPTION
This is follow-up to https://github.com/flutter/flutter/pull/17682 to fix dart1 tests.