### PR TITLE
Fix Scaffold.endDrawer dartDoc to mention openEndDrawer

### DIFF
--- a/packages/flutter/lib/src/material/scaffold.dart
+++ b/packages/flutter/lib/src/material/scaffold.dart
@@ -834,7 +834,7 @@ class Scaffold extends StatefulWidget {
   /// left-to-right ([TextDirection.rtl])
   ///
   /// In the uncommon case that you wish to open the drawer manually, use the
-  /// [ScaffoldState.openDrawer] function.
+  /// [ScaffoldState.openEndDrawer] function.
   ///
   /// Typically a [Drawer].
   final Widget endDrawer;


### PR DESCRIPTION
This PR introduces a minor fix to the `Scaffold.endDrawer` dartDoc - it should be referencing `openEndDrawer` to manually open the drawer, and not `openDrawer`.