### PR TITLE
Fix ScrollOffset calculation when childCount is null

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -22,3 +22,4 @@ Fredrik Simón <fredrik@fsimon.net>
 Ali Bitek <alibitek@protonmail.ch>
 Tetsuhiro Ueda <najeira@gmail.com>
 Dan Field <dfield@gmail.com>
+Noah Groß <gross@ngsger.de>

--- a/packages/flutter/lib/src/widgets/sliver.dart
+++ b/packages/flutter/lib/src/widgets/sliver.dart
@@ -779,15 +779,13 @@ class SliverMultiBoxAdaptorElement extends RenderObjectElement implements Render
     });
   }
 
-  double _extrapolateMaxScrollOffset(
+  static double _extrapolateMaxScrollOffset(
     int firstIndex,
     int lastIndex,
     double leadingScrollOffset,
     double trailingScrollOffset,
+    int childCount,
   ) {
-    final int childCount = this.childCount;
-    if (childCount == null)
-      return double.infinity;
     if (lastIndex == childCount - 1)
       return trailingScrollOffset;
     final int reifiedCount = lastIndex - firstIndex + 1;
@@ -803,6 +801,9 @@ class SliverMultiBoxAdaptorElement extends RenderObjectElement implements Render
     double leadingScrollOffset,
     double trailingScrollOffset,
   }) {
+    final int childCount = this.childCount;
+    if (childCount == null)
+      return double.infinity;
     return widget.estimateMaxScrollOffset(
       constraints,
       firstIndex,
@@ -814,6 +815,7 @@ class SliverMultiBoxAdaptorElement extends RenderObjectElement implements Render
       lastIndex,
       leadingScrollOffset,
       trailingScrollOffset,
+      childCount,
     );
   }
 

--- a/packages/flutter/test/widgets/grid_view_test.dart
+++ b/packages/flutter/test/widgets/grid_view_test.dart
@@ -481,6 +481,30 @@ void main() {
     expect(find.text('12'), findsNothing);
   });
 
+  testWidgets('GridView.builder with undefined itemCount', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      new Directionality(
+        textDirection: TextDirection.ltr,
+        child: new GridView.builder(
+          gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+            crossAxisCount: 4,
+          ),
+          shrinkWrap: true,
+          itemBuilder: (BuildContext context, int index) {
+            return new Container(
+              child: new Text('$index'),
+            );
+          },
+        ),
+      ),
+    );
+    expect(find.text('0'), findsOneWidget);
+    expect(find.text('11'), findsOneWidget);
+    await tester.drag(find.byType(GridView), const Offset(0.0, -300.0));
+    await tester.pump(const Duration(milliseconds: 200));
+    expect(find.text('13'), findsOneWidget);
+  });
+
   testWidgets('GridView cross axis layout', (WidgetTester tester) async {
     final Key target = new UniqueKey();
 


### PR DESCRIPTION
Fixes #16688 by checking for ``childCount == null`` and returning ``double.infinity`` as ScrollOffset for ``SliverMultiBoxAdaptorElement``.

**Note**: The patch was tested with ``GridView.builder``, scrolling past the 3000 items mark (without defining ``itemCount`` value)