### PR TITLE
Handle the case where InputDecorator is constrained to 0x0

### DIFF
--- a/packages/flutter/lib/src/material/input_decorator.dart
+++ b/packages/flutter/lib/src/material/input_decorator.dart
@@ -764,14 +764,14 @@ class _RenderDecoration extends RenderBox {
     if (suffixIcon != null)
       suffixIcon.layout(boxConstraints, parentUsesSize: true);
 
-    final double inputWidth = constraints.maxWidth - (
+    final double inputWidth = math.max(0.0, constraints.maxWidth - (
       _boxSize(icon).width
       + contentPadding.left
       + _boxSize(prefixIcon).width
       + _boxSize(prefix).width
       + _boxSize(suffix).width
       + _boxSize(suffixIcon).width
-      + contentPadding.right);
+      + contentPadding.right));
 
     boxConstraints = boxConstraints.copyWith(maxWidth: inputWidth);
     if (label != null) // The label is not baseline aligned.
@@ -811,10 +811,11 @@ class _RenderDecoration extends RenderBox {
       // The helper or error text can occupy the full width less the space
       // occupied by the icon and counter.
       boxConstraints = boxConstraints.copyWith(
-        maxWidth: boxConstraints.maxWidth
+        maxWidth: math.max(0.0, boxConstraints.maxWidth
           - _boxSize(icon).width
           - _boxSize(counter).width
           - contentPadding.horizontal,
+        ),
       );
       layoutLineBox(helperError);
 

--- a/packages/flutter/test/material/input_decorator_test.dart
+++ b/packages/flutter/test/material/input_decorator_test.dart
@@ -1408,4 +1408,24 @@ void main() {
       ],
     ));
   });
+
+  testWidgets('InputDecorator constrained to 0x0', (WidgetTester tester) async {
+    // Regression test for https://github.com/flutter/flutter/issues/17710
+    await tester.pumpWidget(
+      new Material(
+        child: new Directionality(
+          textDirection: TextDirection.ltr,
+          child: new UnconstrainedBox(child: new ConstrainedBox(
+            constraints: new BoxConstraints.tight(Size.zero),
+            child: new InputDecorator(
+              decoration: const InputDecoration(
+                labelText: 'XP',
+                border: const OutlineInputBorder(),
+              ),
+            ),
+          )),
+        ),
+      ),
+    );
+  });
 }

--- a/packages/flutter/test/material/input_decorator_test.dart
+++ b/packages/flutter/test/material/input_decorator_test.dart
@@ -1417,7 +1417,7 @@ void main() {
           textDirection: TextDirection.ltr,
           child: new UnconstrainedBox(child: new ConstrainedBox(
             constraints: new BoxConstraints.tight(Size.zero),
-            child: new InputDecorator(
+            child: const InputDecorator(
               decoration: const InputDecoration(
                 labelText: 'XP',
                 border: const OutlineInputBorder(),


### PR DESCRIPTION
This can happen when the app starts up, if the framework manages to start layout before the actual window size is known.

Fixes https://github.com/flutter/flutter/issues/17710
