### PR TITLE
Solving the problem of popUntil

### DIFF
--- a/packages/flutter/lib/src/widgets/navigator.dart
+++ b/packages/flutter/lib/src/widgets/navigator.dart
@@ -1717,8 +1717,12 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin {
   /// }
   /// ```
   void popUntil(RoutePredicate predicate) {
-    while (!predicate(_history.last))
+    if (!predicate(_history.last)) {
       pop();
+      new Timer(new Duration(milliseconds: 0), () {
+        popUntil(predicate);
+      });
+    }
   }
 
   /// Immediately remove `route` from the navigator, and [Route.dispose] it.


### PR DESCRIPTION
Solve popUntil shutdown page, no callback dispose method and GlobalKey state will not be destroyed.