### PR TITLE
Fix issue #17801, crash on double-tap under TalkBack on Android

### DIFF
--- a/packages/flutter/lib/src/material/text_field.dart
+++ b/packages/flutter/lib/src/material/text_field.dart
@@ -506,8 +506,8 @@ class _TextFieldState extends State<TextField> with AutomaticKeepAliveClientMixi
 
     return new Semantics(
       onTap: () {
-        if (!_controller.selection.isValid)
-          _controller.selection = new TextSelection.collapsed(offset: _controller.text.length);
+        if (!_effectiveController.selection.isValid)
+          _effectiveController.selection = new TextSelection.collapsed(offset: _effectiveController.text.length);
         _requestKeyboard();
       },
       child: new IgnorePointer(


### PR DESCRIPTION
The _controller field of TextField is null, if the app creates its own controller, resulting in a crash in return new Sematics() onTap() callack. It should use instead _effectiveController value. The crash prevents users under TalkBack on Android from showing soft keyboard after double-tap, as instructed by TalkBack.