### PR TITLE
Default ThemeData's toggleableActiveColor to accentColor if not set

### DIFF
--- a/packages/flutter/lib/src/material/theme_data.dart
+++ b/packages/flutter/lib/src/material/theme_data.dart
@@ -114,8 +114,8 @@ class ThemeData extends Diagnosticable {
     primaryColorLight ??= isDark ? Colors.grey[500] : primarySwatch[100];
     primaryColorDark ??= isDark ? Colors.black : primarySwatch[700];
     final bool primaryIsDark = primaryColorBrightness == Brightness.dark;
+    toggleableActiveColor ??= isDark ? Colors.tealAccent[200] : (accentColor ?? primarySwatch[600]);
     accentColor ??= isDark ? Colors.tealAccent[200] : primarySwatch[500];
-    toggleableActiveColor ??= isDark ? Colors.tealAccent[200] : primarySwatch[600];
     accentColorBrightness ??= estimateBrightnessForColor(accentColor);
     final bool accentIsDark = accentColorBrightness == Brightness.dark;
     canvasColor ??= isDark ? Colors.grey[850] : Colors.grey[50];


### PR DESCRIPTION
@jonahwilliams added a new `toggleableActiveColor` property to `ThemeData` in #17637. If it's not set, toggleable controls like `Switch`, `Checkbox`, and `Radio` use the primary swatch. Previously they used the `accentColor`.

To avoid breaking apps, I think we should first try falling back to the `accentColor` if the `toggleableActiveColor` is not set. The primary swatch should only be used if neither `accentColor` nor `toggleableActiveColor` are set.

In the future we might want to introduce the concept of an `accentSwatch`. That change could be done in a backwards-compatible manner.

Unfortunately we don't have a test for the `ThemeData` constructor; I'll file an issue for this.