### PR TITLE
Enable --sync-async in Flutter.

### DIFF
--- a/dev/automated_tests/flutter_test/exception_handling_expectation.txt
+++ b/dev/automated_tests/flutter_test/exception_handling_expectation.txt
@@ -43,7 +43,10 @@ Who lives, who dies, who tells your story\?
 
 When the exception was thrown, this was the stack:
 #[0-9]+ +main.<anonymous closure> \(.+[/\\]dev[/\\]automated_tests[/\\]flutter_test[/\\]exception_handling_test\.dart:16:9\)
-#[0-9]+ +main.<anonymous closure> \(.+[/\\]dev[/\\]automated_tests[/\\]flutter_test[/\\]exception_handling_test\.dart:15:77\)
+#[0-9]+ +.+ \(package:flutter_test[/\\]src[/\\]binding.dart:[0-9]+:[0-9]+\)
+#[0-9]+ +.+ \(package:flutter_test[/\\]src[/\\]binding.dart:[0-9]+:[0-9]+\)
+#[0-9]+ +.+ \(package:flutter_test[/\\]src[/\\]binding.dart:[0-9]+:[0-9]+\)
+#[0-9]+ +.+ \(package:flutter_test[/\\]src[/\\]binding.dart:[0-9]+:[0-9]+\)
 #[0-9]+ +.+ \(package:flutter_test[/\\]src[/\\]widget_tester\.dart:[0-9]+:[0-9]+\)
 <<skip until matching line>>
 ^\(elided [0-9]+ .+\)$

--- a/dev/automated_tests/flutter_test/test_async_utils_guarded_test.dart
+++ b/dev/automated_tests/flutter_test/test_async_utils_guarded_test.dart
@@ -14,7 +14,10 @@ class TestTestBinding extends AutomatedTestWidgetsFlutterBinding {
 
 Future<Null> guardedHelper(WidgetTester tester) {
   return TestAsyncUtils.guard(() async {
-    await tester.pumpWidget(const Text('Hello'));
+    await tester.pumpWidget(const Directionality(
+      textDirection: TextDirection.ltr,
+      child: const Text('Hello'),
+    ));
   });
 }
 

--- a/packages/flutter_test/lib/src/binding.dart
+++ b/packages/flutter_test/lib/src/binding.dart
@@ -768,10 +768,11 @@ class AutomatedTestWidgetsFlutterBinding extends TestWidgetsFlutterBinding {
 
     return new Future<Null>.microtask(() async {
       // Run all queued microtasks.
-      await new Future.microtask(() {});
+      await new Future<Null>.microtask(() {});
       // When the test had an exception, the test-framework already
       // ran the teardown functions, removing the _fakeAsync function.
-      if (_fakeAsync == null) return null;
+      if (_fakeAsync == null)
+        return null;
       // Resolve interplay between fake async and real async calls.
       _fakeAsync.flushMicrotasks();
       while (_pendingAsyncTasks != null) {

--- a/packages/flutter_test/lib/src/binding.dart
+++ b/packages/flutter_test/lib/src/binding.dart
@@ -771,7 +771,7 @@ class AutomatedTestWidgetsFlutterBinding extends TestWidgetsFlutterBinding {
       await new Future.microtask(() {});
       // When the test had an exception, the test-framework already
       // ran the teardown functions, removing the _fakeAsync function.
-      if (_fakeAsync == null) return;
+      if (_fakeAsync == null) return null;
       // Resolve interplay between fake async and real async calls.
       _fakeAsync.flushMicrotasks();
       while (_pendingAsyncTasks != null) {

--- a/packages/flutter_test/lib/src/binding.dart
+++ b/packages/flutter_test/lib/src/binding.dart
@@ -767,6 +767,11 @@ class AutomatedTestWidgetsFlutterBinding extends TestWidgetsFlutterBinding {
     });
 
     return new Future<Null>.microtask(() async {
+      // Run all queued microtasks.
+      await new Future.microtask(() {});
+      // When the test had an exception, the test-framework already
+      // ran the teardown functions, removing the _fakeAsync function.
+      if (_fakeAsync == null) return;
       // Resolve interplay between fake async and real async calls.
       _fakeAsync.flushMicrotasks();
       while (_pendingAsyncTasks != null) {

--- a/packages/flutter_tools/lib/src/compile.dart
+++ b/packages/flutter_tools/lib/src/compile.dart
@@ -120,6 +120,7 @@ class KernelCompiler {
       '--sdk-root',
       sdkRoot,
       '--strong',
+      '--sync-async',
       '--target=flutter',
     ];
     if (trackWidgetCreation)
@@ -252,6 +253,7 @@ class ResidentCompiler {
       _sdkRoot,
       '--incremental',
       '--strong',
+      '--sync-async',
       '--target=flutter',
     ];
     if (outputPath != null) {


### PR DESCRIPTION
Enables the --sync-async flag for Flutter.
Also fixes the flutter-test package, updates a test (which has a different stacktrace now), and completes one test (where one line wasn't hit before).