### PR TITLE
Send an event at startup with the protocol version and pid

### DIFF
--- a/packages/flutter_tools/lib/src/commands/daemon.dart
+++ b/packages/flutter_tools/lib/src/commands/daemon.dart
@@ -28,7 +28,7 @@ import '../runner/flutter_command.dart';
 import '../tester/flutter_tester.dart';
 import '../vmservice.dart';
 
-const String protocolVersion = '0.2.0';
+const String protocolVersion = '0.3.0';
 
 /// A server process command. This command will start up a long-lived server.
 /// It reads JSON-RPC based commands from stdin, executes them, and returns
@@ -241,6 +241,14 @@ class DaemonDomain extends Domain {
   DaemonDomain(Daemon daemon) : super(daemon, 'daemon') {
     registerHandler('version', version);
     registerHandler('shutdown', shutdown);
+
+    sendEvent(
+      'daemon.connected',
+      <String, dynamic>{
+        'version': protocolVersion,
+        'pid': pid,
+      },
+    );
 
     _subscription = daemon.notifyingLogger.onMessage.listen((LogMessage message) {
       if (daemon.logToStdout) {

--- a/packages/flutter_tools/test/commands/daemon_test.dart
+++ b/packages/flutter_tools/test/commands/daemon_test.dart
@@ -209,7 +209,8 @@ void main() {
           notifyingLogger: notifyingLogger,
       );
 
-      final Map<String, dynamic> response = await responses.stream.first;
+      final Map<String, dynamic> response =
+        await responses.stream.skipWhile(_isConnectedEvent).first;
       expect(response['event'], 'daemon.showMessage');
       expect(response['params'], isMap);
       expect(response['params'], containsPair('level', 'warning'));
@@ -249,7 +250,7 @@ void main() {
       daemon.deviceDomain.addDeviceDiscoverer(discoverer);
       discoverer.addDevice(new MockAndroidDevice());
 
-      return responses.stream.first.then((Map<String, dynamic> response) {
+      return responses.stream.skipWhile(_isConnectedEvent).first.then((Map<String, dynamic> response) {
         expect(response['event'], 'device.added');
         expect(response['params'], isMap);
 
@@ -321,6 +322,8 @@ void main() {
 }
 
 bool _notEvent(Map<String, dynamic> map) => map['event'] == null;
+
+bool _isConnectedEvent(Map<String, dynamic> map) => map['event'] == 'daemon.connected';
 
 class MockAndroidWorkflow extends AndroidWorkflow {
   MockAndroidWorkflow({ this.canListDevices: true });


### PR DESCRIPTION
The pid will help with some of the issues of terminate the process when launched through a shell script and the version will allow clients to make decisions about supported features.

I've also bumped the protocol version number for two reasons:

1. This change
2. We didn't increase it when we added the previous emulator commands

This event appears both when running `flutter daemon` and `flutter run --machine`.

@devoncarew I called it `daemon.connected` because the analysis server already used the name `connected` for a similar event and it seemed consistent, but shout if you want me to change it.

(I'll update the wiki page once this is agreed/approved too - I presume those changes are instant and can't go in a PR?).