### PR TITLE
Pass Text/RichText locale along to RenderParagraph

### DIFF
--- a/packages/flutter/lib/src/rendering/paragraph.dart
+++ b/packages/flutter/lib/src/rendering/paragraph.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:ui' as ui show Gradient, Shader, TextBox;
+import 'dart:ui' as ui show Gradient, Shader, TextBox, Locale;
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
@@ -44,6 +44,7 @@ class RenderParagraph extends RenderBox {
     TextOverflow overflow: TextOverflow.clip,
     double textScaleFactor: 1.0,
     int maxLines,
+    ui.Locale locale,
   }) : assert(text != null),
        assert(text.debugAssertIsValid()),
        assert(textAlign != null),
@@ -61,6 +62,7 @@ class RenderParagraph extends RenderBox {
          textScaleFactor: textScaleFactor,
          maxLines: maxLines,
          ellipsis: overflow == TextOverflow.ellipsis ? _kEllipsis : null,
+         locale: locale,
        );
 
   final TextPainter _textPainter;
@@ -170,6 +172,15 @@ class RenderParagraph extends RenderBox {
     if (_textPainter.maxLines == value)
       return;
     _textPainter.maxLines = value;
+    _overflowShader = null;
+    markNeedsLayout();
+  }
+
+  ui.Locale get locale => _textPainter.locale;
+  set locale(ui.Locale value) {
+    if (_textPainter.locale == value)
+      return;
+    _textPainter.locale = locale;
     _overflowShader = null;
     markNeedsLayout();
   }

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -10,6 +10,7 @@ import 'package:flutter/services.dart';
 
 import 'debug.dart';
 import 'framework.dart';
+import 'localizations.dart';
 
 export 'package:flutter/animation.dart';
 export 'package:flutter/foundation.dart' show
@@ -4341,6 +4342,7 @@ class RichText extends LeafRenderObjectWidget {
       overflow: overflow,
       textScaleFactor: textScaleFactor,
       maxLines: maxLines,
+      locale: Localizations.localeOf(context, nullOk: true),
     );
   }
 
@@ -4354,7 +4356,8 @@ class RichText extends LeafRenderObjectWidget {
       ..softWrap = softWrap
       ..overflow = overflow
       ..textScaleFactor = textScaleFactor
-      ..maxLines = maxLines;
+      ..maxLines = maxLines
+      ..locale = Localizations.localeOf(context, nullOk: true);
   }
 
   @override


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/16408

With this change, the same unicode character may render differently depending on the locale.

The screenshot below is based on [the following code](https://gist.github.com/HansMuller/101ab5a797c5121f1e16d5eb0ddf1282), where `character` is `骨` and the text style specifies the [NotoSerifCJKjp font](https://www.google.com/get/noto/).

```
new Localizations.override(
  context: context,
  locale: const Locale('ja'),
  child: new Text(character, style: style),
),
new Localizations.override(
  context: context,
  locale: const Locale('zh'),
  child: new Text(character, style: style),
),

```

If you look closely, the Japanese version of the character on the left, differs from the Chinese version on the right. I have it on good authority - @cbracken  - that this example is correct.

![l10n_font](https://user-images.githubusercontent.com/1377460/40503473-faad6f34-5f42-11e8-972b-d83b727c9d0e.png)

Here's another example, using 線, which also appears to be correct per the local Chinese and Japanese speakers (Japanese on the left, Chinese on the right):

![l10n_font2](https://user-images.githubusercontent.com/1377460/40510574-fd195c42-5f51-11e8-8921-2014d8d4325d.png)

On the other hand, the 次 character discussed in Tetsuhiro Ueda's [medium.com article](https://medium.com/@najeira/flutter-and-cjk-font-selection-5dbc6a6164ba) doesn't appear to be exactly what's expected (Japanese on the left, Chinese on the right):

![l10_font](https://user-images.githubusercontent.com/1377460/40503953-945e7992-5f44-11e8-961a-02faacee5f1e.png)

I don't think the unexpected results in this case have to do with this PR. 
