### PR TITLE
Build single-architecture for local iOS engines

### DIFF
--- a/packages/flutter_tools/lib/src/ios/xcodeproj.dart
+++ b/packages/flutter_tools/lib/src/ios/xcodeproj.dart
@@ -80,6 +80,15 @@ void updateGeneratedXcodeProperties({
   if (artifacts is LocalEngineArtifacts) {
     final LocalEngineArtifacts localEngineArtifacts = artifacts;
     localsBuffer.writeln('LOCAL_ENGINE=${localEngineArtifacts.engineOutPath}');
+
+    // Tell Xcode not to build universal binaries for local engines, which are
+    // single-architecture.
+    //
+    // NOTE: this assumes that local engine binary paths are consistent with
+    // the conventions uses in the engine: 32-bit iOS engines are built to
+    // paths ending in _arm, 64-bit builds are not.
+    final String arch = localEngineArtifacts.engineOutPath.endsWith('_arm') ? 'armv7' : 'arm64';
+    localsBuffer.writeln('ARCHS=$arch');
   }
 
   if (previewDart2) {


### PR DESCRIPTION
When running with --local-engine, build single-architecture apps, rather
than what's declared in the Xcode project.

By default, Flutter creates Xcode projects that generate universal
binaries supporting both armv7 and arm64 processors. Since local engine builds
are all single-architecture, override the Xcode project's ARCHS setting
with the appropriate value for the specific engine.

NOTE: this assumes engine paths consistent with those used in the engine
repo: 32-bit iOS engine builds end in _arm, 64-bit builds do not.