### PR TITLE
Remove test group in favour of addTearDown

### DIFF
--- a/dev/automated_tests/flutter_test/test_async_utils_unguarded_expectation.txt
+++ b/dev/automated_tests/flutter_test/test_async_utils_unguarded_expectation.txt
@@ -18,7 +18,7 @@ When the exception was thrown, this was the stack:
 The test description was:
 TestAsyncUtils - handling unguarded async helper functions
 ════════════════════════════════════════════════════════════════════════════════════════════════════
-.*..:.. \+0 -1: - TestAsyncUtils - handling unguarded async helper functions *
+.*..:.. \+0 -1: TestAsyncUtils - handling unguarded async helper functions *
   Test failed\. See exception logs above\.
   The test description was: TestAsyncUtils - handling unguarded async helper functions
  *

--- a/dev/automated_tests/flutter_test/ticker_expectation.txt
+++ b/dev/automated_tests/flutter_test/ticker_expectation.txt
@@ -9,7 +9,7 @@ There was one transient callback left. The stack trace for when it was registere
 #[0-9]+      main.+ \(.+/dev/automated_tests/flutter_test/ticker_test\.dart:[0-9]+:[0-9]+\)
 <<skip until matching line>>
 ════════════════════════════════════════════════════════════════════════════════════════════════════
-.*..:.. \+0 -1: - Does flutter_test catch leaking tickers\? \[E\]
+.*..:.. \+0 -1: Does flutter_test catch leaking tickers\? \[E\]
   Test failed\. See exception logs above\.
   The test description was: Does flutter_test catch leaking tickers\?
  *

--- a/dev/automated_tests/flutter_test/trivial_widget_expectation.txt
+++ b/dev/automated_tests/flutter_test/trivial_widget_expectation.txt
@@ -1,2 +1,2 @@
-[0-9]+:[0-9]+ [+]0: - A trivial widget test
+[0-9]+:[0-9]+ [+]0: A trivial widget test
 [0-9]+:[0-9]+ [+]1: All tests passed!

--- a/packages/flutter_test/lib/src/widget_tester.dart
+++ b/packages/flutter_test/lib/src/widget_tester.dart
@@ -57,20 +57,19 @@ void testWidgets(String description, WidgetTesterCallback callback, {
   final TestWidgetsFlutterBinding binding = TestWidgetsFlutterBinding.ensureInitialized();
   final WidgetTester tester = new WidgetTester._(binding);
   timeout ??= binding.defaultTestTimeout;
-  test_package.group('-', () {
     test_package.test(
-      description,
-      () {
-        return binding.runTest(
-          () => callback(tester),
-          tester._endOfTestVerifications,
-          description: description ?? '',
-        );
-      },
-      skip: skip,
-    );
-    test_package.tearDown(binding.postTest);
-  }, timeout: timeout);
+    description,
+    () {
+      test_package.addTearDown(binding.postTest);
+      return binding.runTest(
+        () => callback(tester),
+        tester._endOfTestVerifications,
+        description: description ?? '',
+      );
+    },
+    skip: skip,
+    timeout: timeout
+  );
 }
 
 /// Runs the [callback] inside the Flutter benchmark environment.


### PR DESCRIPTION
Fixes #17932.

This swaps the phantom group for `addTearDown`. The `widget_tester_test` tests pass after this change but fail if you just remove the teardown, so I believe that confirms it's working as expected.