### PR TITLE
Detect permissions issues running flutter on Windows

### DIFF
--- a/bin/flutter.bat
+++ b/bin/flutter.bat
@@ -47,6 +47,18 @@ IF NOT EXIST "%flutter_root%\.git" (
 REM Ensure that bin/cache exists.
 IF NOT EXIST "%cache_dir%" MKDIR "%cache_dir%"
 
+REM If the cache still doesn't exist, fail with an error that we probably don't have permissions.
+IF NOT EXIST "%cache_dir%" (
+  ECHO Error: Unable to create cache directory at
+  ECHO            %cache_dir%
+  ECHO.
+  ECHO        This may because you do not have sufficient permissions to write to
+  ECHO        this folder and is often caused by installing Flutter into a
+  ECHO        folder like C:\Program Files and then running as a non-Admin.
+  EXIT /B 1
+)
+
+
 REM To debug the tool, you can uncomment the following lines to enable checked mode and set an observatory port:
 REM SET FLUTTER_TOOL_ARGS="--checked %FLUTTER_TOOL_ARGS%"
 REM SET FLUTTER_TOOL_ARGS="%FLUTTER_TOOL_ARGS% --observe=65432"

--- a/bin/flutter.bat
+++ b/bin/flutter.bat
@@ -53,8 +53,8 @@ IF NOT EXIST "%cache_dir%" (
   ECHO            %cache_dir%
   ECHO.
   ECHO        This may be because flutter doesn't have write permissions for
-  ECHO        this path. Try moving flutter to a writable folder, such as
-  ECHO        within your home directory.
+  ECHO        this path. Try moving the flutter directory to a writable location,
+  ECHO        such as within your home directory.
   EXIT /B 1
 )
 

--- a/bin/flutter.bat
+++ b/bin/flutter.bat
@@ -52,9 +52,9 @@ IF NOT EXIST "%cache_dir%" (
   ECHO Error: Unable to create cache directory at
   ECHO            %cache_dir%
   ECHO.
-  ECHO        This may because you do not have sufficient permissions to write to
-  ECHO        this folder and is often caused by installing Flutter into a
-  ECHO        folder like C:\Program Files and then running as a non-Admin.
+  ECHO        This may be because flutter doesn't have write permissions for
+  ECHO        this path. Try moving flutter to a writable folder, such as
+  ECHO        within your home directory.
   EXIT /B 1
 )
 


### PR DESCRIPTION
I think this is a reasonable fix for #17972 (/ #17967 / #17742). Currently Windows users just get stuck in an infinite loop if they put Flutter in a folder they don't have write access to (such as `Program Files` and then run as non-Admin).
