### PR TITLE
Instrument vm service extensions in the gallery

### DIFF
--- a/examples/flutter_gallery/lib/main.dart
+++ b/examples/flutter_gallery/lib/main.dart
@@ -5,11 +5,15 @@
 // Thanks for checking out Flutter!
 // Like what you see? Tweet us @flutterio
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 import 'gallery/app.dart';
 
 void main() {
+  // Temporary debugging hook for https://github.com/flutter/flutter/issues/17956
+  debugInstrumentationEnabled = true;
+
   // Overriding https://github.com/flutter/flutter/issues/13736 for better
   // visual effect at the cost of performance.
   MaterialPageRoute.debugEnableFadingRoutes = true; // ignore: deprecated_member_use

--- a/packages/flutter/test/foundation/debug_test.dart
+++ b/packages/flutter/test/foundation/debug_test.dart
@@ -1,0 +1,74 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('debugInstrumentAction', () {
+    DebugPrintCallback originalDebugPrintCallback;
+    StringBuffer printBuffer;
+
+    setUp(() {
+      debugInstrumentationEnabled = true;
+      printBuffer = new StringBuffer();
+      originalDebugPrintCallback = debugPrint;
+      debugPrint = (String message, {int wrapWidth}) {
+        printBuffer.writeln(message);
+      };
+    });
+
+    tearDown(() {
+      debugInstrumentationEnabled = false;
+      debugPrint = originalDebugPrintCallback;
+    });
+
+    test('works with sync actions', () async {
+      final int result = await debugInstrumentAction<int>('no-op', () {
+        debugPrint('action()');
+        return 1;
+      });
+      expect(result, 1);
+      expect(
+        printBuffer.toString(),
+        matches(new RegExp('^action\\(\\)\nAction "no-op" took .+\$', multiLine: true)),
+      );
+    });
+
+    test('works with async actions', () async {
+      final int result = await debugInstrumentAction<int>('no-op', () async {
+        debugPrint('action()');
+        return 1;
+      });
+      expect(result, 1);
+      expect(
+        printBuffer.toString(),
+        matches(new RegExp('^action\\(\\)\nAction "no-op" took .+\$', multiLine: true)),
+      );
+    });
+
+    test('throws if sync action throws', () {
+      try {
+        debugInstrumentAction<void>('throws', () => throw 'Error');
+        fail('Error expected but not thrown');
+      } on String catch (error) {
+        expect(error, 'Error');
+        expect(printBuffer.toString(), matches(r'^Action "throws" took .+'));
+      }
+    });
+
+    test('returns failing future if async action throws', () async {
+      try {
+        await debugInstrumentAction<void>('throws', () async {
+          await new Future<void>.delayed(Duration.zero);
+          throw 'Error';
+        });
+        fail('Error expected but not thrown');
+      } on String catch (error) {
+        expect(error, 'Error');
+        expect(printBuffer.toString(), matches(r'^Action "throws" took .+'));
+      }
+    });
+  });
+}


### PR DESCRIPTION
https://github.com/flutter/flutter/issues/17956

* Add a `debugInstrumentAction()` method that will wrap an action
  in a stopwatch and print the time it took to run the action.
* Add a global `debugInstrumentationEnabled` that will control
  whether `debugInstrumentAction()` does anything (even in debug
  builds).
* Add some basic instrumentation to `registerServiceExtension()`
* Temporarily enable the `debugInstrumentationEnabled` flag in the
  Gallery to give us better visibility into what's happening in
  https://github.com/flutter/flutter/issues/17956