### PR TITLE
Use correct branch for version checks on beta/dev

### DIFF
--- a/packages/flutter_tools/lib/src/version.dart
+++ b/packages/flutter_tools/lib/src/version.dart
@@ -296,7 +296,8 @@ class FlutterVersion {
 
     // Cache is empty or it's been a while since the last server ping. Ping the server.
     try {
-      final String branch = _channel == 'alpha' ? 'alpha' : 'master';
+      const List<String> knownChannels = const <String>['alpha', 'beta', 'dev'];
+      final String branch = knownChannels.contains(_channel) ? _channel : 'master';
       final DateTime remoteFrameworkCommitDate = DateTime.parse(await FlutterVersion.fetchRemoteFrameworkCommitDate(branch));
       await versionCheckStamp.store(
         newTimeVersionWasChecked: _clock.now(),

--- a/packages/flutter_tools/lib/src/version.dart
+++ b/packages/flutter_tools/lib/src/version.dart
@@ -296,8 +296,7 @@ class FlutterVersion {
 
     // Cache is empty or it's been a while since the last server ping. Ping the server.
     try {
-      const List<String> knownChannels = const <String>['alpha', 'beta', 'dev'];
-      final String branch = knownChannels.contains(_channel) ? _channel : 'master';
+      final String branch = officialChannels.contains(_channel) ? _channel : 'master';
       final DateTime remoteFrameworkCommitDate = DateTime.parse(await FlutterVersion.fetchRemoteFrameworkCommitDate(branch));
       await versionCheckStamp.store(
         newTimeVersionWasChecked: _clock.now(),


### PR DESCRIPTION
I've seen a number of complaints about Flutter telling people they're out of date when they're on latest beta (because the commit date is old) so I was going to look at putting a "real" update check in and discovered that there was already code to check the dates on the remote commits! Unfortunately it always used `master` branch unless you were on `alpha` so when you were more than x days out of date, it would always then warn you.

This PR adds `dev` and `beta` to the list of safe branches for checking (I'm not sure entirely why we need a safe list though, maybe it's to support checking against master when you're working on flutter on a branch?).

With this, when your beta is "too old" it should check the remote commit date and only warn if that's newer (eg., if there's actually a version you could update to on this branch).

This doesn't totally implement #14920 because it won't alert you until after 4 weeks(?), however simply reducing that duration to a lower number (or removing it entirely) may completely implement it.

Kinda Related:
- #15862
- #17748
- #14920