### PR TITLE
Skip version checks when running `flutter upgrade`

### DIFF
--- a/packages/flutter_tools/lib/src/commands/upgrade.dart
+++ b/packages/flutter_tools/lib/src/commands/upgrade.dart
@@ -80,7 +80,7 @@ class UpgradeCommand extends FlutterCommand {
     printStatus('Running flutter doctor...');
     code = await runCommandAndStreamOutput(
       <String>[
-        fs.path.join('bin', 'flutter'), 'doctor', '--no-version-check',
+        fs.path.join('bin', 'flutter'), '--no-version-check', 'doctor',
       ],
       workingDirectory: Cache.flutterRoot,
       allowReentrantFlutter: true,

--- a/packages/flutter_tools/lib/src/commands/upgrade.dart
+++ b/packages/flutter_tools/lib/src/commands/upgrade.dart
@@ -60,7 +60,7 @@ class UpgradeCommand extends FlutterCommand {
     printStatus('Upgrading engine...');
     code = await runCommandAndStreamOutput(
       <String>[
-        fs.path.join('bin', 'flutter'), '--no-color', 'precache',
+        fs.path.join('bin', 'flutter'), '--no-color', '--skip-version-check', 'precache',
       ],
       workingDirectory: Cache.flutterRoot,
       allowReentrantFlutter: true
@@ -80,7 +80,7 @@ class UpgradeCommand extends FlutterCommand {
     printStatus('Running flutter doctor...');
     code = await runCommandAndStreamOutput(
       <String>[
-        fs.path.join('bin', 'flutter'), 'doctor',
+        fs.path.join('bin', 'flutter'), 'doctor', '--skip-version-check',
       ],
       workingDirectory: Cache.flutterRoot,
       allowReentrantFlutter: true,

--- a/packages/flutter_tools/lib/src/commands/upgrade.dart
+++ b/packages/flutter_tools/lib/src/commands/upgrade.dart
@@ -60,7 +60,7 @@ class UpgradeCommand extends FlutterCommand {
     printStatus('Upgrading engine...');
     code = await runCommandAndStreamOutput(
       <String>[
-        fs.path.join('bin', 'flutter'), '--no-color', '--skip-version-check', 'precache',
+        fs.path.join('bin', 'flutter'), '--no-color', '--no-version-check', 'precache',
       ],
       workingDirectory: Cache.flutterRoot,
       allowReentrantFlutter: true
@@ -80,7 +80,7 @@ class UpgradeCommand extends FlutterCommand {
     printStatus('Running flutter doctor...');
     code = await runCommandAndStreamOutput(
       <String>[
-        fs.path.join('bin', 'flutter'), 'doctor', '--skip-version-check',
+        fs.path.join('bin', 'flutter'), 'doctor', '--no-version-check',
       ],
       workingDirectory: Cache.flutterRoot,
       allowReentrantFlutter: true,

--- a/packages/flutter_tools/lib/src/runner/flutter_command_runner.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command_runner.dart
@@ -71,6 +71,10 @@ class FlutterCommandRunner extends CommandRunner<Null> {
         negatable: true,
         hide: !verboseHelp,
         help: 'Whether to use terminal colors.');
+    argParser.addFlag('skip-version-check',
+        negatable: false,
+        hide: !verboseHelp,
+        help: 'Suppress version check when this command runs.');
     argParser.addFlag('suppress-analytics',
         negatable: false,
         hide: !verboseHelp,
@@ -280,7 +284,7 @@ class FlutterCommandRunner extends CommandRunner<Null> {
 
         _checkFlutterCopy();
         await FlutterVersion.instance.ensureVersionFile();
-        if (topLevelResults.command?.name != 'upgrade') {
+        if (topLevelResults.command?.name != 'upgrade' && !topLevelResults['skip-version-check']) {
           await FlutterVersion.instance.checkFlutterVersionFreshness();
         }
 

--- a/packages/flutter_tools/lib/src/runner/flutter_command_runner.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command_runner.dart
@@ -71,10 +71,11 @@ class FlutterCommandRunner extends CommandRunner<Null> {
         negatable: true,
         hide: !verboseHelp,
         help: 'Whether to use terminal colors.');
-    argParser.addFlag('skip-version-check',
-        negatable: false,
+    argParser.addFlag('version-check',
+        negatable: true,
+        defaultsTo: true,
         hide: !verboseHelp,
-        help: 'Suppress version check when this command runs.');
+        help: 'Allow Flutter to check for updates when this command runs.');
     argParser.addFlag('suppress-analytics',
         negatable: false,
         hide: !verboseHelp,
@@ -284,7 +285,7 @@ class FlutterCommandRunner extends CommandRunner<Null> {
 
         _checkFlutterCopy();
         await FlutterVersion.instance.ensureVersionFile();
-        if (topLevelResults.command?.name != 'upgrade' && !topLevelResults['skip-version-check']) {
+        if (topLevelResults.command?.name != 'upgrade' && topLevelResults['version-check']) {
           await FlutterVersion.instance.checkFlutterVersionFreshness();
         }
 


### PR DESCRIPTION
We were already skipping the check in `flutter upgrade` but this also spawns `flutter precache` and `flutter doctor` which would still check and potentially output the message.

It's possible we could remove the flag from `doctor`, since I presume after `precache` the stamps will have updated such that we wouldn't warn (and maybe doing the check and warning the user if it still looks bad wouldn't be bad). LMK what you think.

We do have some automated tests around the version check, but they all directly call `checkFlutterVersionFreshness` so I'm not sure if there's a convenient way to put a test around this (since it would need to fake the timestamps etc.).

Fixes #11598.