### PR TITLE
Add border to CircleAvatar (#13566)

### DIFF
--- a/packages/flutter/lib/src/material/circle_avatar.dart
+++ b/packages/flutter/lib/src/material/circle_avatar.dart
@@ -4,6 +4,7 @@
 
 import 'package:flutter/widgets.dart';
 
+import 'colors.dart';
 import 'constants.dart';
 import 'theme.dart';
 import 'theme_data.dart';
@@ -57,6 +58,8 @@ class CircleAvatar extends StatelessWidget {
     this.radius,
     this.minRadius,
     this.maxRadius,
+    this.borderColor = Colors.transparent,
+    this.borderWidth = 0.0,
   })  : assert(radius == null || (minRadius == null && maxRadius == null)),
         super(key: key);
 
@@ -119,6 +122,16 @@ class CircleAvatar extends StatelessWidget {
   /// Defaults to [double.infinity].
   final double maxRadius;
 
+  /// The color of an optional border around the avatar.
+  ///
+  /// Defaults to [Colors.transparent].
+  final Color borderColor;
+
+  /// The border width of an optional border around the avatar.
+  ///
+  /// Defaults to 0.0.
+  final double borderWidth;
+
   // The default radius if nothing is specified.
   static const double _defaultRadius = 20.0;
 
@@ -140,6 +153,17 @@ class CircleAvatar extends StatelessWidget {
       return _defaultRadius * 2.0;
     }
     return 2.0 * (radius ?? maxRadius ?? _defaultMaxRadius);
+  }
+
+  BoxBorder get _border {
+    if (borderColor == Colors.transparent || borderWidth == 0.0) {
+      return null;
+    }
+    return new Border.all(
+      color: borderColor,
+      width: borderWidth,
+      style: BorderStyle.solid,
+    );
   }
 
   @override
@@ -183,6 +207,7 @@ class CircleAvatar extends StatelessWidget {
           ? new DecorationImage(image: backgroundImage, fit: BoxFit.cover)
           : null,
         shape: BoxShape.circle,
+        border: _border,
       ),
       child: child == null
           ? null

--- a/packages/flutter/lib/src/material/circle_avatar.dart
+++ b/packages/flutter/lib/src/material/circle_avatar.dart
@@ -58,8 +58,8 @@ class CircleAvatar extends StatelessWidget {
     this.radius,
     this.minRadius,
     this.maxRadius,
-    this.borderColor = Colors.transparent,
-    this.borderWidth = 0.0,
+    this.borderColor: Colors.transparent,
+    this.borderWidth,
   })  : assert(radius == null || (minRadius == null && maxRadius == null)),
         super(key: key);
 
@@ -129,7 +129,7 @@ class CircleAvatar extends StatelessWidget {
 
   /// The border width of an optional border around the avatar.
   ///
-  /// Defaults to 0.0.
+  /// Defaults to null.
   final double borderWidth;
 
   // The default radius if nothing is specified.
@@ -156,7 +156,7 @@ class CircleAvatar extends StatelessWidget {
   }
 
   BoxBorder get _border {
-    if (borderColor == Colors.transparent || borderWidth == 0.0) {
+    if (borderWidth == null) {
       return null;
     }
     return new Border.all(

--- a/packages/flutter/test/material/circle_avatar_test.dart
+++ b/packages/flutter/test/material/circle_avatar_test.dart
@@ -256,6 +256,85 @@ void main() {
     final RenderParagraph paragraph = tester.renderObject(find.text('Z'));
     expect(paragraph.text.style.color, equals(new ThemeData.fallback().primaryColorLight));
   });
+
+  testWidgets('CircleAvatar renders border when border color and border width supplied', (WidgetTester tester) async {
+    const Color backgroundColor = Colors.black;
+    const Color borderColor = Colors.white;
+    const double borderWidth = 2.0;
+    await tester.pumpWidget(
+      wrap(
+        child: const CircleAvatar(
+          backgroundColor: backgroundColor,
+          maxRadius: 50.0,
+          minRadius: 50.0,
+          child: const Text('Z'),
+          borderColor: borderColor,
+          borderWidth: borderWidth,
+        ),
+      ),
+    );
+
+    final RenderConstrainedBox box = tester.renderObject(find.byType(CircleAvatar));
+    expect(box.size, equals(const Size(100.0, 100.0)));
+    final RenderDecoratedBox child = box.child;
+    final BoxDecoration decoration = child.decoration;
+
+    // Border check
+    expect(decoration.border is Border, isTrue);
+    final Border border = decoration.border;
+    expect(border.isUniform, isTrue);
+    // All sides are uniform so checking a single side is sufficient for all 4.
+    expect(border.left.color, equals(borderColor));
+    expect(border.left.width, equals(borderWidth));
+  });
+
+  testWidgets('CircleAvatar has no border when border color supplied but border width is not', (WidgetTester tester) async {
+    const Color backgroundColor = Colors.black;
+    const Color borderColor = Colors.white;
+    await tester.pumpWidget(
+      wrap(
+        child: const CircleAvatar(
+          backgroundColor: backgroundColor,
+          maxRadius: 50.0,
+          minRadius: 50.0,
+          child: const Text('Z'),
+          borderColor: borderColor,
+        ),
+      ),
+    );
+
+    final RenderConstrainedBox box = tester.renderObject(find.byType(CircleAvatar));
+    expect(box.size, equals(const Size(100.0, 100.0)));
+    final RenderDecoratedBox child = box.child;
+    final BoxDecoration decoration = child.decoration;
+
+    // Border check
+    expect(decoration.border, isNull);
+  });
+
+  testWidgets('CircleAvatar has no border when border width supplied but border color is not', (WidgetTester tester) async {
+    const Color backgroundColor = Colors.black;
+    const double borderWidth = 2.0;
+    await tester.pumpWidget(
+      wrap(
+        child: const CircleAvatar(
+          backgroundColor: backgroundColor,
+          maxRadius: 50.0,
+          minRadius: 50.0,
+          child: const Text('Z'),
+          borderWidth: borderWidth,
+        ),
+      ),
+    );
+
+    final RenderConstrainedBox box = tester.renderObject(find.byType(CircleAvatar));
+    expect(box.size, equals(const Size(100.0, 100.0)));
+    final RenderDecoratedBox child = box.child;
+    final BoxDecoration decoration = child.decoration;
+
+    // Border check
+    expect(decoration.border, isNull);
+  });
 }
 
 Widget wrap({ Widget child }) {

--- a/packages/flutter/test/material/circle_avatar_test.dart
+++ b/packages/flutter/test/material/circle_avatar_test.dart
@@ -288,6 +288,65 @@ void main() {
     expect(border.left.width, equals(borderWidth));
   });
 
+  testWidgets('CircleAvatar renders border when hairline width is requested', (WidgetTester tester) async {
+    const Color backgroundColor = Colors.black;
+    const Color borderColor = Colors.white;
+    const double hairlineBorderWidth = 0.0; // hairline width
+    await tester.pumpWidget(
+      wrap(
+        child: const CircleAvatar(
+          backgroundColor: backgroundColor,
+          maxRadius: 50.0,
+          minRadius: 50.0,
+          child: const Text('Z'),
+          borderColor: borderColor,
+          borderWidth: hairlineBorderWidth,
+        ),
+      ),
+    );
+
+    final RenderConstrainedBox box = tester.renderObject(find.byType(CircleAvatar));
+    expect(box.size, equals(const Size(100.0, 100.0)));
+    final RenderDecoratedBox child = box.child;
+    final BoxDecoration decoration = child.decoration;
+
+    // Border check
+    expect(decoration.border is Border, isTrue);
+    final Border border = decoration.border;
+    expect(border.left.width, equals(hairlineBorderWidth));
+  });
+
+  testWidgets('CircleAvatar renders border when border width supplied and color is transparent', (WidgetTester tester) async {
+    const Color backgroundColor = Colors.black;
+    const Color borderColor = Colors.transparent;
+    const double borderWidth = 2.0;
+    await tester.pumpWidget(
+      wrap(
+        child: const CircleAvatar(
+          backgroundColor: backgroundColor,
+          maxRadius: 50.0,
+          minRadius: 50.0,
+          child: const Text('Z'),
+          borderColor: borderColor,
+          borderWidth: borderWidth,
+        ),
+      ),
+    );
+
+    final RenderConstrainedBox box = tester.renderObject(find.byType(CircleAvatar));
+    expect(box.size, equals(const Size(100.0, 100.0)));
+    final RenderDecoratedBox child = box.child;
+    final BoxDecoration decoration = child.decoration;
+
+    // Border check
+    expect(decoration.border is Border, isTrue);
+    final Border border = decoration.border;
+    expect(border.isUniform, isTrue);
+    // All sides are uniform so checking a single side is sufficient for all 4.
+    expect(border.left.color, equals(borderColor));
+    expect(border.left.width, equals(borderWidth));
+  });
+
   testWidgets('CircleAvatar has no border when border color supplied but border width is not', (WidgetTester tester) async {
     const Color backgroundColor = Colors.black;
     const Color borderColor = Colors.white;
@@ -299,30 +358,6 @@ void main() {
           minRadius: 50.0,
           child: const Text('Z'),
           borderColor: borderColor,
-        ),
-      ),
-    );
-
-    final RenderConstrainedBox box = tester.renderObject(find.byType(CircleAvatar));
-    expect(box.size, equals(const Size(100.0, 100.0)));
-    final RenderDecoratedBox child = box.child;
-    final BoxDecoration decoration = child.decoration;
-
-    // Border check
-    expect(decoration.border, isNull);
-  });
-
-  testWidgets('CircleAvatar has no border when border width supplied but border color is not', (WidgetTester tester) async {
-    const Color backgroundColor = Colors.black;
-    const double borderWidth = 2.0;
-    await tester.pumpWidget(
-      wrap(
-        child: const CircleAvatar(
-          backgroundColor: backgroundColor,
-          maxRadius: 50.0,
-          minRadius: 50.0,
-          child: const Text('Z'),
-          borderWidth: borderWidth,
         ),
       ),
     );


### PR DESCRIPTION
Issue:
https://github.com/flutter/flutter/issues/13566

CircleAvatar looks for non-transparent color and non-zero border width and adds a Border as desired.