### PR TITLE
Await completion of writing local.properties

### DIFF
--- a/packages/flutter_tools/lib/src/commands/create.dart
+++ b/packages/flutter_tools/lib/src/commands/create.dart
@@ -260,7 +260,7 @@ To edit platform code in an IDE see https://flutter.io/platform-plugins/#edit-co
       );
     }
     if (android_sdk.androidSdk != null)
-      gradle.updateLocalProperties(projectPath: dirPath);
+      await gradle.updateLocalProperties(projectPath: dirPath);
 
     final String projectName = templateContext['projectName'];
     final String organization = templateContext['organization'];


### PR DESCRIPTION
https://github.com/flutter/flutter/pull/16857 made the method to write `local.properties` async, updating all current call sites with `await`. Meanwhile, https://github.com/flutter/flutter/pull/17992 had added another call site. That one needs an `await` too, otherwise tests become flaky.

Fixes #18109  