### PR TITLE
Update dartdoc to 0.20.0

### DIFF
--- a/dev/bots/docs.sh
+++ b/dev/bots/docs.sh
@@ -22,7 +22,7 @@ if [ -d "$FLUTTER_PUB_CACHE" ]; then
 fi
 
 # Install dartdoc.
-bin/cache/dart-sdk/bin/pub global activate dartdoc 0.19.1
+bin/cache/dart-sdk/bin/pub global activate dartdoc 0.20.0
 
 # This script generates a unified doc set, and creates
 # a custom index.html, placing everything into dev/docs/doc.


### PR DESCRIPTION
dartdoc 0.20.0 fully supports running under --preview-dart-2.  No significant changes to output, only a few added span classes associated with a templating refactor.

Of greatest interest to Flutter may be the support for animations introduced by @gspencergoog:  https://github.com/dart-lang/dartdoc/tree/v0.20.0#animations

Release notes:  https://github.com/dart-lang/dartdoc/releases/tag/v0.20.0