### PR TITLE
Rename --prefer-shared-library to --build-shared library consistently

### DIFF
--- a/packages/flutter_tools/gradle/flutter.gradle
+++ b/packages/flutter_tools/gradle/flutter.gradle
@@ -282,8 +282,8 @@ class FlutterPlugin implements Plugin<Project> {
             extraGenSnapshotOptionsValue = project.property('extra-gen-snapshot-options')
         }
         Boolean preferSharedLibraryValue = false
-        if (project.hasProperty('prefer-shared-library')) {
-            preferSharedLibraryValue = project.property('prefer-shared-library').toBoolean()
+        if (project.hasProperty('build-shared-library')) {
+            preferSharedLibraryValue = project.property('build-shared-library').toBoolean()
         }
         String targetPlatformValue = null
         if (project.hasProperty('target-platform')) {
@@ -423,7 +423,7 @@ abstract class BaseFlutterTask extends DefaultTask {
                     args "--extra-gen-snapshot-options", "${extraGenSnapshotOptions}"
                 }
                 if (preferSharedLibrary) {
-                    args "--prefer-shared-library"
+                    args "--build-shared-library"
                 }
                 if (targetPlatform != null) {
                     args "--target-platform", "${targetPlatform}"

--- a/packages/flutter_tools/gradle/flutter.gradle
+++ b/packages/flutter_tools/gradle/flutter.gradle
@@ -281,9 +281,9 @@ class FlutterPlugin implements Plugin<Project> {
         if (project.hasProperty('extra-gen-snapshot-options')) {
             extraGenSnapshotOptionsValue = project.property('extra-gen-snapshot-options')
         }
-        Boolean preferSharedLibraryValue = false
+        Boolean buildSharedLibraryValue = false
         if (project.hasProperty('build-shared-library')) {
-            preferSharedLibraryValue = project.property('build-shared-library').toBoolean()
+            buildSharedLibraryValue = project.property('build-shared-library').toBoolean()
         }
         String targetPlatformValue = null
         if (project.hasProperty('target-platform')) {
@@ -314,7 +314,7 @@ class FlutterPlugin implements Plugin<Project> {
                 fileSystemRoots fileSystemRootsValue
                 fileSystemScheme fileSystemSchemeValue
                 trackWidgetCreation trackWidgetCreationValue
-                preferSharedLibrary preferSharedLibraryValue
+                buildSharedLibrary buildSharedLibraryValue
                 targetPlatform targetPlatformValue
                 sourceDir project.file(project.flutter.source)
                 intermediateDir project.file("${project.buildDir}/${AndroidProject.FD_INTERMEDIATES}/flutter/${variant.name}")
@@ -361,7 +361,7 @@ abstract class BaseFlutterTask extends DefaultTask {
     @Optional @Input
     Boolean trackWidgetCreation
     @Optional @Input
-    Boolean preferSharedLibrary
+    Boolean buildSharedLibrary
     @Optional @Input
     String targetPlatform
     File sourceDir
@@ -422,7 +422,7 @@ abstract class BaseFlutterTask extends DefaultTask {
                 if (extraGenSnapshotOptions != null) {
                     args "--extra-gen-snapshot-options", "${extraGenSnapshotOptions}"
                 }
-                if (preferSharedLibrary) {
+                if (buildSharedLibrary) {
                     args "--build-shared-library"
                 }
                 if (targetPlatform != null) {
@@ -487,7 +487,7 @@ class FlutterTask extends BaseFlutterTask {
             include "flutter_assets/**" // the working dir and its files
 
             if (buildMode != 'debug') {
-                if (preferSharedLibrary) {
+                if (buildSharedLibrary) {
                     include "app.so"
                 } else {
                     include "vm_snapshot_data"

--- a/packages/flutter_tools/lib/src/android/gradle.dart
+++ b/packages/flutter_tools/lib/src/android/gradle.dart
@@ -341,7 +341,7 @@ Future<Null> _buildGradleProjectV2(String gradle, BuildInfo buildInfo, String ta
     command.add('-Ppreview-dart-2=false');
   }
   if (buildInfo.preferSharedLibrary && androidSdk.ndk != null) {
-    command.add('-Pprefer-shared-library=true');
+    command.add('-Pbuild-shared-library=true');
   }
   if (buildInfo.targetPlatform == TargetPlatform.android_arm64)
     command.add('-Ptarget-platform=android-arm64');

--- a/packages/flutter_tools/lib/src/android/gradle.dart
+++ b/packages/flutter_tools/lib/src/android/gradle.dart
@@ -340,7 +340,7 @@ Future<Null> _buildGradleProjectV2(String gradle, BuildInfo buildInfo, String ta
   } else {
     command.add('-Ppreview-dart-2=false');
   }
-  if (buildInfo.preferSharedLibrary && androidSdk.ndk != null) {
+  if (buildInfo.buildSharedLibrary && androidSdk.ndk != null) {
     command.add('-Pbuild-shared-library=true');
   }
   if (buildInfo.targetPlatform == TargetPlatform.android_arm64)

--- a/packages/flutter_tools/lib/src/build_info.dart
+++ b/packages/flutter_tools/lib/src/build_info.dart
@@ -15,7 +15,7 @@ class BuildInfo {
     this.trackWidgetCreation: false,
     this.extraFrontEndOptions,
     this.extraGenSnapshotOptions,
-    this.preferSharedLibrary,
+    this.buildSharedLibrary,
     this.targetPlatform,
     this.fileSystemRoots,
     this.fileSystemScheme,
@@ -49,7 +49,7 @@ class BuildInfo {
   final String extraGenSnapshotOptions;
 
   /// Whether to prefer AOT compiling to a *so file.
-  final bool preferSharedLibrary;
+  final bool buildSharedLibrary;
 
   /// Target platform for the build (e.g. android_arm versus android_arm64).
   final TargetPlatform targetPlatform;
@@ -97,7 +97,7 @@ class BuildInfo {
           trackWidgetCreation: trackWidgetCreation,
           extraFrontEndOptions: extraFrontEndOptions,
           extraGenSnapshotOptions: extraGenSnapshotOptions,
-          preferSharedLibrary: preferSharedLibrary,
+          buildSharedLibrary: buildSharedLibrary,
           targetPlatform: targetPlatform);
 }
 

--- a/packages/flutter_tools/lib/src/commands/build_apk.dart
+++ b/packages/flutter_tools/lib/src/commands/build_apk.dart
@@ -23,7 +23,7 @@ class BuildApkCommand extends BuildSubCommand {
         help: 'Preview Dart 2.0 functionality.',
       )
       ..addFlag('track-widget-creation', negatable: false, hide: !verboseHelp)
-      ..addFlag('prefer-shared-library',
+      ..addFlag('build-shared-library',
         negatable: false,
         help: 'Whether to prefer compiling to a *.so file (android only).',
       )

--- a/packages/flutter_tools/lib/src/ios/simulators.dart
+++ b/packages/flutter_tools/lib/src/ios/simulators.dart
@@ -366,7 +366,7 @@ class IOSSimulator extends Device {
         trackWidgetCreation: buildInfo.trackWidgetCreation,
         extraFrontEndOptions: buildInfo.extraFrontEndOptions,
         extraGenSnapshotOptions: buildInfo.extraGenSnapshotOptions,
-        preferSharedLibrary: buildInfo.preferSharedLibrary);
+        buildSharedLibrary: buildInfo.buildSharedLibrary);
 
     final XcodeBuildResult buildResult = await buildXcodeProject(
       app: app,

--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -222,7 +222,7 @@ abstract class FlutterCommand extends Command<Null> {
       extraGenSnapshotOptions: argParser.options.containsKey(FlutterOptions.kExtraGenSnapshotOptions)
           ? argResults[FlutterOptions.kExtraGenSnapshotOptions]
           : null,
-      preferSharedLibrary: argParser.options.containsKey('build-shared-library')
+      buildSharedLibrary: argParser.options.containsKey('build-shared-library')
         ? argResults['build-shared-library']
         : false,
       targetPlatform: targetPlatform,

--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -222,8 +222,8 @@ abstract class FlutterCommand extends Command<Null> {
       extraGenSnapshotOptions: argParser.options.containsKey(FlutterOptions.kExtraGenSnapshotOptions)
           ? argResults[FlutterOptions.kExtraGenSnapshotOptions]
           : null,
-      preferSharedLibrary: argParser.options.containsKey('prefer-shared-library')
-        ? argResults['prefer-shared-library']
+      preferSharedLibrary: argParser.options.containsKey('build-shared-library')
+        ? argResults['build-shared-library']
         : false,
       targetPlatform: targetPlatform,
       fileSystemRoots: argParser.options.containsKey(FlutterOptions.kFileSystemRoot)


### PR DESCRIPTION
The change in 8b8d368 has only renamed the flag in a subset of the
places.