### PR TITLE
Use isDirectory instead of existsSync to avoid crash

### DIFF
--- a/packages/flutter_tools/lib/src/vscode/vscode.dart
+++ b/packages/flutter_tools/lib/src/vscode/vscode.dart
@@ -163,7 +163,7 @@ class VsCode {
     final List<VsCode> results = <VsCode>[];
 
     for (_VsCodeInstallLocation searchLocation in searchLocations) {
-      if (fs.directory(searchLocation.installPath).existsSync()) {
+      if (fs.isDirectorySync(searchLocation.installPath)) {
         final String extensionDirectory =
             fs.path.join(homeDirPath, searchLocation.extensionsFolder, 'extensions');
         results.add(new VsCode.fromDirectory(searchLocation.installPath, extensionDirectory, edition: searchLocation.edition));


### PR DESCRIPTION
Fixes #15198.

This does assume if there is a permissions error that we want to just pretend we didn't know about the installation - I don't think this is perfect, but I also don't think the odds of a user not having read access to their own folders is common.