### PR TITLE
Extracted an ImplicitlyAnimatedWidgetState from AnimatedWidgetBaseState

### DIFF
--- a/packages/flutter/lib/src/widgets/implicit_animations.dart
+++ b/packages/flutter/lib/src/widgets/implicit_animations.dart
@@ -234,9 +234,9 @@ typedef Tween<T> TweenVisitor<T>(Tween<T> tween, T targetValue, TweenConstructor
 /// animation, themselves. If you would like `setState()` to be called
 /// automatically as the animation changes, use [AnimatedWidgetBaseState].
 ///
-/// Subclasses must implement the [forEachTween] method to help
-/// [ImplicitlyAnimatedWidgetState] iterate through the subclasses' widget's fields
-/// and animate them.
+/// Subclasses must implement the [forEachTween] method to allow
+/// [ImplicitlyAnimatedWidgetState] to iterate through the subclasses' widget's
+/// fields and animate them.
 abstract class ImplicitlyAnimatedWidgetState<T extends ImplicitlyAnimatedWidget> extends State<T> with SingleTickerProviderStateMixin {
   /// The animation controller driving this widget's implicit animations.
   @protected
@@ -335,13 +335,14 @@ abstract class ImplicitlyAnimatedWidgetState<T extends ImplicitlyAnimatedWidget>
 }
 
 /// A base class for widgets with implicit animations that need to rebuild their
-/// Widget tree as the animation runs.
+/// widget tree as the animation runs.
 ///
-/// If you would rather respond to a running animation directly, use
-/// [ImplicitlyAnimatedWidgetState].
+/// This class calls [build] each frame that the animation tickets. For a
+/// variant that does not rebuild each frame, consider subclassing
+/// [ImplicitlyAnimatedWidgetState] directly.
 ///
-/// Subclasses must implement the [forEachTween] method to help
-/// [AnimatedWidgetBaseState] iterate through the subclasses' widget's fields
+/// Subclasses must implement the [forEachTween] method to allow
+/// [AnimatedWidgetBaseState] to iterate through the subclasses' widget's fields
 /// and animate them.
 abstract class AnimatedWidgetBaseState<T extends ImplicitlyAnimatedWidget> extends ImplicitlyAnimatedWidgetState<T> {
   @override
@@ -351,7 +352,7 @@ abstract class AnimatedWidgetBaseState<T extends ImplicitlyAnimatedWidget> exten
   }
 
   void _handleAnimationChanged() {
-    setState(() { });
+    setState(() { /* The animation ticked. Rebuild with new animation value */ });
   }
 }
 

--- a/packages/flutter/lib/src/widgets/implicit_animations.dart
+++ b/packages/flutter/lib/src/widgets/implicit_animations.dart
@@ -210,7 +210,7 @@ abstract class ImplicitlyAnimatedWidget extends StatefulWidget {
   final Duration duration;
 
   @override
-  AnimatedWidgetBaseState<ImplicitlyAnimatedWidget> createState();
+  ImplicitlyAnimatedWidgetState<ImplicitlyAnimatedWidget> createState();
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
@@ -230,10 +230,17 @@ typedef Tween<T> TweenVisitor<T>(Tween<T> tween, T targetValue, TweenConstructor
 
 /// A base class for widgets with implicit animations.
 ///
+/// [ImplicitlyAnimatedWidgetState] requires that subclasses respond to the
+/// animation, themselves. If you would like `setState()` to be called
+/// automatically as the animation changes, use [AnimatedWidgetBaseState].
+///
 /// Subclasses must implement the [forEachTween] method to help
-/// [AnimatedWidgetBaseState] iterate through the subclasses' widget's fields
+/// [ImplicitlyAnimatedWidgetState] iterate through the subclasses' widget's fields
 /// and animate them.
-abstract class AnimatedWidgetBaseState<T extends ImplicitlyAnimatedWidget> extends State<T> with SingleTickerProviderStateMixin {
+abstract class ImplicitlyAnimatedWidgetState<T extends ImplicitlyAnimatedWidget> extends State<T> with SingleTickerProviderStateMixin {
+  /// The animation controller driving this widget's implicit animations.
+  @protected
+  AnimationController get controller => _controller;
   AnimationController _controller;
 
   /// The animation driving this widget's implicit animations.
@@ -247,7 +254,7 @@ abstract class AnimatedWidgetBaseState<T extends ImplicitlyAnimatedWidget> exten
       duration: widget.duration,
       debugLabel: '${widget.toStringShort()}',
       vsync: this,
-    )..addListener(_handleAnimationChanged);
+    );
     _updateCurve();
     _constructTweens();
   }
@@ -280,10 +287,6 @@ abstract class AnimatedWidgetBaseState<T extends ImplicitlyAnimatedWidget> exten
   void dispose() {
     _controller.dispose();
     super.dispose();
-  }
-
-  void _handleAnimationChanged() {
-    setState(() { });
   }
 
   bool _shouldAnimateTween(Tween<dynamic> tween, dynamic targetValue) {
@@ -329,6 +332,27 @@ abstract class AnimatedWidgetBaseState<T extends ImplicitlyAnimatedWidget> exten
   /// value to use as the current value the next time that the forEachTween()
   /// method is called.
   void forEachTween(TweenVisitor<dynamic> visitor);
+}
+
+/// A base class for widgets with implicit animations that need to rebuild their
+/// Widget tree as the animation runs.
+///
+/// If you would rather respond to a running animation directly, use
+/// [ImplicitlyAnimatedWidgetState].
+///
+/// Subclasses must implement the [forEachTween] method to help
+/// [AnimatedWidgetBaseState] iterate through the subclasses' widget's fields
+/// and animate them.
+abstract class AnimatedWidgetBaseState<T extends ImplicitlyAnimatedWidget> extends ImplicitlyAnimatedWidgetState<T> {
+  @override
+  void initState() {
+    super.initState();
+    controller.addListener(_handleAnimationChanged);
+  }
+
+  void _handleAnimationChanged() {
+    setState(() { });
+  }
 }
 
 /// A container that gradually changes its values over a period of time.


### PR DESCRIPTION
Extracted a superclass from AnimatedWidgetBaseState that is called ImplicitlyAnimatedWidgetState. ImplicitlyAnimatedWidgetState implicitly animates, but it does not call setState() automatically. Subclasses must respond to animation changes themselves. This is a useful optimization for Widgets whose render objects listen to animations directly. (#18173)